### PR TITLE
patch integration for graph-capture profiling and roofline annotations

### DIFF
--- a/inference_optimization/InferenceX/AGENTS.md
+++ b/inference_optimization/InferenceX/AGENTS.md
@@ -17,6 +17,7 @@ InferenceX is an open-source, automated benchmarking system that continuously tr
 │   ├── launch_b200/h100/h200-*.sh     # NVIDIA launcher scripts
 │   └── launch_mi*.sh                  # AMD launcher scripts
 ├── utils/                   # Python utilities
+│   ├── apply_tracelens_patches.sh  # Applies TraceLens patches for graph-capture profiling
 │   ├── matrix_logic/        # Config generation and validation
 │   │   ├── generate_sweep_configs.py  # CLI for generating benchmark matrix
 │   │   ├── validation.py              # Pydantic validation models
@@ -161,7 +162,7 @@ When working with benchmark configurations, use these valid values:
 ### Bash
 
 - Source shared utilities: `source benchmark_lib.sh`
-- Functions: `check_env_vars()`, `wait_for_server_ready()`, `run_benchmark_serving()`, `run_eval()`, `append_lm_eval_summary()`
+- Functions: `check_env_vars()`, `wait_for_server_ready()`, `run_benchmark_serving()`, `run_eval()`, `append_lm_eval_summary()`, `apply_tracelens_patches()`
 - Parameters passed via environment variables
 
 ### Git
@@ -422,6 +423,72 @@ These patches are applied via `sitecustomize.py` in `PYTHONPATH`.
 - `benchmarks/benchmark_lib.sh` - Shared benchmark/eval utilities
 - `utils/evals/` - Eval task definitions (gsm8k.yaml, math500.yaml)
 - `utils/collect_eval_results.py` - Aggregates eval results into JSON/table
+
+## TraceLens Patch Integration
+
+InferenceX can automatically apply [TraceLens](https://github.com/AMD-AGI/TraceLens) patches to vLLM/SGLang at container startup. These patches add CUDA graph capture profiling and roofline annotations to profiler traces, enabling deeper performance analysis.
+
+### How It Works
+
+1. `benchmark_lib.sh` auto-calls `apply_tracelens_patches()` when sourced
+2. If `TRACELENS_PATCHES=1`, the script clones `AMD-AGI/TraceLens` (public) into the container at `/tmp/TraceLens`
+3. It auto-detects the installed vLLM version and selects the matching patch (e.g., `config_vllm_v0.18.0.patch` for vLLM 0.18.x)
+4. Applies the patch via `git apply` to the container's system Python
+5. Optionally installs the TraceLens Python package for post-collection analysis
+
+If `TRACELENS_PATCHES` is unset or `0`, the function is a no-op — existing benchmarks are unaffected.
+
+### What the Patches Add
+
+| File | Change |
+|------|--------|
+| `vllm/config/profiler.py` | Adds `capture_torch_profiler_dir` and `detailed_trace_annotation` config fields |
+| `vllm/v1/worker/gpu_model_runner.py` | Profiles CUDA graph capture with per-batch-size `record_function` annotations |
+| `vllm/v1/worker/gpu_worker.py` | Adds roofline annotations (sq, sk, sqsq, sqsk per context/generation group) |
+
+### Usage
+
+Set the env var before launching the runner:
+
+```bash
+export TRACELENS_PATCHES=1
+export PROFILE=1
+bash ./runners/launch_mi300x-amd.sh
+```
+
+To mount a local TraceLens clone instead of cloning inside the container:
+
+```bash
+export TRACELENS_PATCHES=1
+export TRACELENS_REPO=/path/to/TraceLens
+bash ./runners/launch_mi300x-amd.sh
+```
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TRACELENS_PATCHES` | `0` | Set to `1` to enable patching |
+| `TRACELENS_REPO` | *(empty)* | Path to local TraceLens clone (skips cloning) |
+| `TRACELENS_GIT_URL` | `https://github.com/AMD-AGI/TraceLens.git` | Clone URL override |
+| `TRACELENS_GIT_REF` | `main` | Branch/tag to clone |
+| `TRACELENS_VLLM_VERSION` | *(auto-detected)* | Override vLLM version for patch selection (e.g., `v0.18`, `v0.19`) |
+
+### Supported Patches
+
+Available patches depend on the TraceLens repo. The public repo currently has:
+- `config_vllm_v0.18.0.patch` — for vLLM 0.18.x
+- `config_vllm_v0.19.0.patch` — for vLLM 0.19.x
+- `sglang_roofline_patches/*.patch` — for SGLang v0.5.9
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `utils/apply_tracelens_patches.sh` | Standalone script: clones TraceLens, detects version, applies patches |
+| `benchmarks/benchmark_lib.sh` | Wrapper function `apply_tracelens_patches()` — auto-called when sourced |
+| `runners/launch_mi300x-amd.sh` | Passes `TRACELENS_*` env vars and mounts into Docker |
+| `runners/launch_mi355x-amds.sh` | Same for Slurm/Enroot containers |
 
 ## Testing
 

--- a/inference_optimization/InferenceX/benchmarks/benchmark_lib.sh
+++ b/inference_optimization/InferenceX/benchmarks/benchmark_lib.sh
@@ -90,15 +90,15 @@ check_env_vars() {
 # Activation: set TRACELENS_PATCHES=1 to enable (no-op otherwise).
 #
 # The script will use TRACELENS_REPO if set, otherwise it clones
-# TraceLens-internal automatically into /tmp/TraceLens-internal.
+# AMD-AGI/TraceLens (public) automatically into /tmp/TraceLens.
 #
 # Env vars:
 #   TRACELENS_PATCHES=1        enable patching (required)
 #   TRACELENS_REPO             path to existing local clone (optional)
-#   TRACELENS_GIT_URL           clone URL override (default: AMD-AGI/TraceLens-internal)
+#   TRACELENS_GIT_URL           clone URL (default: https://github.com/AMD-AGI/TraceLens.git)
 #   TRACELENS_GIT_REF           branch/tag (default: main)
 #   FRAMEWORK                  "vllm" or "sglang" (auto-detected if unset)
-#   TRACELENS_VLLM_VERSION     override vLLM version for patch selection
+#   TRACELENS_VLLM_VERSION     override vLLM version for patch selection (e.g. v0.18, v0.19)
 #
 # Idempotent — a marker file prevents double-patching in the same container.
 TRACELENS_APPLIED_MARKER="/tmp/.tracelens_patches_applied"
@@ -143,6 +143,9 @@ apply_tracelens_patches() {
     bash "$patch_script" "${args[@]}"
     touch "$TRACELENS_APPLIED_MARKER"
 }
+
+# Auto-apply when this file is sourced (no-op unless TRACELENS_PATCHES=1)
+apply_tracelens_patches
 
 # Wait for server to be ready by polling the health endpoint
 # All parameters are required

--- a/inference_optimization/InferenceX/benchmarks/benchmark_lib.sh
+++ b/inference_optimization/InferenceX/benchmarks/benchmark_lib.sh
@@ -80,6 +80,70 @@ check_env_vars() {
     fi
 }
 
+# --------------------------------
+# TraceLens patching
+# --------------------------------
+
+# Apply TraceLens patches to the running inference framework for graph-capture
+# profiling and roofline annotations.
+#
+# Activation: set TRACELENS_PATCHES=1 to enable (no-op otherwise).
+#
+# The script will use TRACELENS_REPO if set, otherwise it clones
+# TraceLens-internal automatically into /tmp/TraceLens-internal.
+#
+# Env vars:
+#   TRACELENS_PATCHES=1        enable patching (required)
+#   TRACELENS_REPO             path to existing local clone (optional)
+#   TRACELENS_GIT_URL           clone URL override (default: AMD-AGI/TraceLens-internal)
+#   TRACELENS_GIT_REF           branch/tag (default: main)
+#   FRAMEWORK                  "vllm" or "sglang" (auto-detected if unset)
+#   TRACELENS_VLLM_VERSION     override vLLM version for patch selection
+#
+# Idempotent — a marker file prevents double-patching in the same container.
+TRACELENS_APPLIED_MARKER="/tmp/.tracelens_patches_applied"
+
+apply_tracelens_patches() {
+    if [[ "${TRACELENS_PATCHES:-0}" != "1" ]]; then
+        return 0
+    fi
+    if [[ -f "$TRACELENS_APPLIED_MARKER" ]]; then
+        echo "[TraceLens] Patches already applied in this environment, skipping."
+        return 0
+    fi
+
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../utils" && pwd)"
+    local patch_script="$script_dir/apply_tracelens_patches.sh"
+
+    if [[ ! -x "$patch_script" ]]; then
+        echo "WARNING: TraceLens patch script not found: $patch_script" >&2
+        return 1
+    fi
+
+    local args=()
+
+    # If TRACELENS_REPO is set, pass it through; otherwise the script
+    # will clone TraceLens-internal on its own.
+    if [[ -n "${TRACELENS_REPO:-}" ]]; then
+        args+=(--tracelens "$TRACELENS_REPO")
+    fi
+    if [[ -n "${FRAMEWORK:-}" ]]; then
+        local fw_arg
+        case "$FRAMEWORK" in
+            *sglang*) fw_arg="sglang" ;;
+            *)        fw_arg="vllm" ;;
+        esac
+        args+=(--framework "$fw_arg")
+    fi
+    if [[ -n "${TRACELENS_VLLM_VERSION:-}" ]]; then
+        args+=(--version "$TRACELENS_VLLM_VERSION")
+    fi
+
+    bash "$patch_script" "${args[@]}"
+    touch "$TRACELENS_APPLIED_MARKER"
+}
+
 # Wait for server to be ready by polling the health endpoint
 # All parameters are required
 # Parameters:

--- a/inference_optimization/InferenceX/runners/launch_mi300x-amd.sh
+++ b/inference_optimization/InferenceX/runners/launch_mi300x-amd.sh
@@ -9,10 +9,9 @@ server_name="bmk-server"
 
 TRACELENS_ARGS=()
 if [[ -n "${TRACELENS_REPO:-}" && -d "${TRACELENS_REPO}" ]]; then
-    TRACELENS_ARGS+=(-v "${TRACELENS_REPO}:/workspace/TraceLens-internal:ro")
-    TRACELENS_ARGS+=(-e TRACELENS_REPO=/workspace/TraceLens-internal)
+    TRACELENS_ARGS+=(-v "${TRACELENS_REPO}:/workspace/TraceLens:ro")
+    TRACELENS_ARGS+=(-e TRACELENS_REPO=/workspace/TraceLens)
 fi
-# When TRACELENS_PATCHES=1 but no local repo, the container will clone it
 TRACELENS_ARGS+=(-e TRACELENS_PATCHES -e TRACELENS_GIT_URL -e TRACELENS_GIT_REF -e TRACELENS_VLLM_VERSION)
 
 set -x

--- a/inference_optimization/InferenceX/runners/launch_mi300x-amd.sh
+++ b/inference_optimization/InferenceX/runners/launch_mi300x-amd.sh
@@ -7,6 +7,14 @@ PORT=8888
 
 server_name="bmk-server"
 
+TRACELENS_ARGS=()
+if [[ -n "${TRACELENS_REPO:-}" && -d "${TRACELENS_REPO}" ]]; then
+    TRACELENS_ARGS+=(-v "${TRACELENS_REPO}:/workspace/TraceLens-internal:ro")
+    TRACELENS_ARGS+=(-e TRACELENS_REPO=/workspace/TraceLens-internal)
+fi
+# When TRACELENS_PATCHES=1 but no local repo, the container will clone it
+TRACELENS_ARGS+=(-e TRACELENS_PATCHES -e TRACELENS_GIT_URL -e TRACELENS_GIT_REF -e TRACELENS_VLLM_VERSION)
+
 set -x
 docker run --rm --ipc=host --shm-size=16g --network=host --name=$server_name \
 --privileged --cap-add=CAP_SYS_ADMIN --device=/dev/kfd --device=/dev/dri --device=/dev/mem \
@@ -16,6 +24,8 @@ docker run --rm --ipc=host --shm-size=16g --network=host --name=$server_name \
 -e HF_TOKEN -e HF_HUB_CACHE -e MODEL -e TP -e CONC -e MAX_MODEL_LEN -e PORT=$PORT \
 -e ISL -e OSL -e PYTHONPYCACHEPREFIX=/tmp/pycache/ -e RANDOM_RANGE_RATIO -e RESULT_FILENAME -e RUN_EVAL -e RUNNER_TYPE \
 -e PROFILE -e SGLANG_TORCH_PROFILER_DIR -e VLLM_TORCH_PROFILER_DIR -e VLLM_RPC_TIMEOUT \
+-e FRAMEWORK \
+"${TRACELENS_ARGS[@]}" \
 --entrypoint=/bin/bash \
 $IMAGE \
 benchmarks/single_node/"${EXP_NAME%%_*}_${PRECISION}_mi300x.sh"

--- a/inference_optimization/InferenceX/runners/launch_mi355x-amds.sh
+++ b/inference_optimization/InferenceX/runners/launch_mi355x-amds.sh
@@ -181,9 +181,17 @@ else
 
     export VLLM_CACHE_ROOT="/it-share/gharunners/.cache/vllm"
 
+    CONTAINER_MOUNTS="$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE"
+    if [[ -n "${TRACELENS_REPO:-}" && -d "${TRACELENS_REPO}" ]]; then
+        CONTAINER_MOUNTS="${CONTAINER_MOUNTS},${TRACELENS_REPO}:/workspace/TraceLens-internal"
+        export TRACELENS_REPO=/workspace/TraceLens-internal
+    fi
+    # TRACELENS_PATCHES, TRACELENS_GIT_URL, TRACELENS_GIT_REF are forwarded
+    # via --export=ALL on the srun line below
+
     srun --jobid=$JOB_ID \
         --container-image=$SQUASH_FILE \
-        --container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \
+        --container-mounts=$CONTAINER_MOUNTS \
         --container-mount-home \
         --container-writable \
         --container-workdir=/workspace/ \

--- a/inference_optimization/InferenceX/runners/launch_mi355x-amds.sh
+++ b/inference_optimization/InferenceX/runners/launch_mi355x-amds.sh
@@ -183,11 +183,9 @@ else
 
     CONTAINER_MOUNTS="$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE"
     if [[ -n "${TRACELENS_REPO:-}" && -d "${TRACELENS_REPO}" ]]; then
-        CONTAINER_MOUNTS="${CONTAINER_MOUNTS},${TRACELENS_REPO}:/workspace/TraceLens-internal"
-        export TRACELENS_REPO=/workspace/TraceLens-internal
+        CONTAINER_MOUNTS="${CONTAINER_MOUNTS},${TRACELENS_REPO}:/workspace/TraceLens"
+        export TRACELENS_REPO=/workspace/TraceLens
     fi
-    # TRACELENS_PATCHES, TRACELENS_GIT_URL, TRACELENS_GIT_REF are forwarded
-    # via --export=ALL on the srun line below
 
     srun --jobid=$JOB_ID \
         --container-image=$SQUASH_FILE \

--- a/inference_optimization/InferenceX/utils/apply_tracelens_patches.sh
+++ b/inference_optimization/InferenceX/utils/apply_tracelens_patches.sh
@@ -2,47 +2,46 @@
 #
 # Apply TraceLens inference-analysis patches to the current Python environment.
 #
-# This script patches vLLM or SGLang (in-place, inside a container or venv)
-# so that profiling traces include:
-#   - CUDA graph capture traces (per batch-size, per capture mode)
-#   - Roofline annotations (sq, sk, sqsq, sqsk per context/generation group)
+# Patches vLLM or SGLang in-place (inside a container) so profiling traces
+# include CUDA graph capture traces and roofline annotations.
 #
-# It also installs the TraceLens package (--no-deps) for post-collection
-# analysis (report generation, trace splitting, etc.).
+# The patch source is the public AMD-AGI/TraceLens repo by default.  The
+# script will clone it automatically if no local copy is available.
 #
 # Usage:
 #   bash apply_tracelens_patches.sh [OPTIONS]
 #
 # Options:
-#   --framework  vllm|sglang   (default: auto-detect from $FRAMEWORK or probe Python)
-#   --version    v0.13|v0.14|v0.15|v0.16|v0.17  (vLLM only; default: auto-detect)
-#   --tracelens  /path/to/TraceLens-internal     (overrides $TRACELENS_REPO)
-#   --clone-to   /path/to/dir   clone TraceLens-internal here if not already present
-#   --git-ref    branch/tag/sha to clone (default: main)
-#   --install    also pip-install TraceLens       (default: true)
-#   --no-install skip TraceLens pip install
+#   --framework  vllm|sglang          auto-detect from $FRAMEWORK or Python
+#   --version    v0.18|v0.19|...      vLLM only; auto-detect if omitted
+#   --tracelens  /path/to/TraceLens   use existing local clone
+#   --clone-to   /path/to/dir         clone destination (default: /tmp/TraceLens)
+#   --git-ref    branch/tag/sha       clone ref (default: main)
+#   --install    pip-install TraceLens (default)
+#   --no-install skip pip install
 #   --dry-run    show what would happen without applying
+#   --list       list available patches and exit
 #
 # Environment variables (all optional):
-#   TRACELENS_REPO      path to existing local TraceLens-internal clone
-#   TRACELENS_GIT_URL   git URL to clone from (default: AMD-AGI/TraceLens-internal on GitHub)
-#   TRACELENS_GIT_REF   branch/tag/sha (default: main)
-#   FRAMEWORK           "vllm" or "sglang" — skips auto-detection
+#   TRACELENS_REPO      path to existing local TraceLens clone
+#   TRACELENS_GIT_URL   clone URL (default: https://github.com/AMD-AGI/TraceLens.git)
+#   TRACELENS_GIT_REF   branch/tag (default: main)
+#   FRAMEWORK           "vllm" or "sglang"
 #
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-TRACELENS_GIT_URL="${TRACELENS_GIT_URL:-https://github.com/AMD-AGI/TraceLens-internal.git}"
+TRACELENS_GIT_URL="${TRACELENS_GIT_URL:-https://github.com/AMD-AGI/TraceLens.git}"
 TRACELENS_GIT_REF="${TRACELENS_GIT_REF:-main}"
 
-# Defaults
 FRAMEWORK_ARG=""
 VLLM_VERSION_ARG=""
 TRACELENS_REPO="${TRACELENS_REPO:-}"
 CLONE_TO=""
 DO_INSTALL=true
 DRY_RUN=false
+LIST_PATCHES=false
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -54,6 +53,7 @@ while [[ $# -gt 0 ]]; do
         --install)     DO_INSTALL=true; shift ;;
         --no-install)  DO_INSTALL=false; shift ;;
         --dry-run)     DRY_RUN=true; shift ;;
+        --list)        LIST_PATCHES=true; shift ;;
         -h|--help)
             sed -n '2,/^$/{ s/^# //; s/^#$//; p; }' "$0"
             exit 0
@@ -62,42 +62,39 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# ── Resolve or clone TraceLens repo ──────────────────────────────────────────
+# ── Resolve or clone TraceLens repo ───────────────────────────────────────────
 
 PATCH_SUBDIR="examples/custom_workflows/inference_analysis"
 
 ensure_tracelens_repo() {
-    # Already have a valid local path — nothing to do
     if [[ -n "$TRACELENS_REPO" && -d "$TRACELENS_REPO/$PATCH_SUBDIR" ]]; then
         echo "[TraceLens] Using existing repo: $TRACELENS_REPO"
         return 0
     fi
 
-    # Determine clone destination
     local dest="${CLONE_TO:-}"
     if [[ -z "$dest" ]]; then
         if [[ -n "$TRACELENS_REPO" ]]; then
             dest="$TRACELENS_REPO"
         else
-            dest="/tmp/TraceLens-internal"
+            dest="/tmp/TraceLens"
         fi
     fi
 
-    # If already cloned at dest, reuse it
     if [[ -d "$dest/$PATCH_SUBDIR" ]]; then
         echo "[TraceLens] Found existing clone at $dest"
         TRACELENS_REPO="$dest"
         return 0
     fi
 
-    echo "[TraceLens] TraceLens-internal not found locally. Cloning..."
+    echo "[TraceLens] Cloning TraceLens..."
     echo "[TraceLens]   URL: $TRACELENS_GIT_URL"
     echo "[TraceLens]   Ref: $TRACELENS_GIT_REF"
-    echo "[TraceLens]   Destination: $dest"
+    echo "[TraceLens]   Dest: $dest"
 
     if ! command -v git &>/dev/null; then
-        echo "ERROR: git is not available — cannot clone TraceLens-internal." >&2
-        echo "       Either install git or mount/copy TraceLens-internal manually." >&2
+        echo "ERROR: git not available — cannot clone TraceLens." >&2
+        echo "       Mount or copy TraceLens manually, then pass --tracelens /path" >&2
         exit 1
     fi
 
@@ -105,14 +102,39 @@ ensure_tracelens_repo() {
     TRACELENS_REPO="$dest"
 
     if [[ ! -d "$TRACELENS_REPO/$PATCH_SUBDIR" ]]; then
-        echo "ERROR: Cloned repo is missing $PATCH_SUBDIR — wrong repo or branch?" >&2
+        echo "ERROR: Cloned repo missing $PATCH_SUBDIR — wrong repo or branch?" >&2
         exit 1
     fi
-
     echo "[TraceLens] Clone successful"
 }
 
 ensure_tracelens_repo
+
+# ── Discover available patches ────────────────────────────────────────────────
+
+PATCH_DIR="$TRACELENS_REPO/$PATCH_SUBDIR"
+
+discover_vllm_patches() {
+    local -a patches=()
+    for f in "$PATCH_DIR"/*vllm*.patch; do
+        [[ -f "$f" ]] || continue
+        patches+=("$(basename "$f")")
+    done
+    printf '%s\n' "${patches[@]}" | sort -V
+}
+
+if $LIST_PATCHES; then
+    echo "Available vLLM patches:"
+    discover_vllm_patches | while read -r p; do echo "  $p"; done
+    echo ""
+    if [[ -d "$PATCH_DIR/sglang_roofline_patches" ]]; then
+        echo "Available SGLang patches:"
+        for f in "$PATCH_DIR/sglang_roofline_patches/"*.patch; do
+            [[ -f "$f" ]] && echo "  $(basename "$f")"
+        done
+    fi
+    exit 0
+fi
 
 # ── Detect framework ─────────────────────────────────────────────────────────
 
@@ -132,7 +154,7 @@ detect_framework() {
     elif python3 -c "import sglang" 2>/dev/null; then
         echo "sglang"
     else
-        echo "ERROR: Cannot detect framework. Neither vllm nor sglang is importable." >&2
+        echo "ERROR: Cannot detect framework. Neither vllm nor sglang importable." >&2
         echo "       Pass --framework vllm|sglang explicitly." >&2
         exit 1
     fi
@@ -141,7 +163,7 @@ detect_framework() {
 FW="$(detect_framework)"
 echo "[TraceLens] Detected framework: $FW"
 
-# ── Framework-specific logic ──────────────────────────────────────────────────
+# ── vLLM patching ────────────────────────────────────────────────────────────
 
 apply_vllm_patches() {
     local pkg_dir
@@ -149,48 +171,66 @@ apply_vllm_patches() {
     pkg_dir="$(cd "$pkg_dir" && pwd)"
     echo "[TraceLens] vLLM package root: $pkg_dir"
 
-    # Auto-detect vLLM version if not specified
+    # ── Resolve version → patch file ──
     local ver="$VLLM_VERSION_ARG"
+    local raw_ver=""
+
     if [[ -z "$ver" ]]; then
-        local raw_ver
         raw_ver="$(python3 -c "import vllm; print(vllm.__version__)" 2>/dev/null || echo "unknown")"
         echo "[TraceLens] Detected vLLM version: $raw_ver"
+
+        # Extract minor version: 0.18.x → v0.18, 0.19.1 → v0.19, etc.
         case "$raw_ver" in
-            0.13.*) ver="v0.13" ;;
-            0.14.*) ver="v0.14" ;;
-            0.15.*) ver="v0.15" ;;
-            0.16.*) ver="v0.16" ;;
-            0.17.*) ver="v0.17" ;;
+            0.*.*)
+                local minor
+                minor="$(echo "$raw_ver" | cut -d. -f1-2)"
+                ver="v${minor}"
+                ;;
             *)
-                echo "ERROR: Cannot map vLLM version '$raw_ver' to a known patch." >&2
-                echo "       Available patches: v0.13, v0.14, v0.15, v0.16, v0.17" >&2
-                echo "       Pass --version v0.XX explicitly." >&2
-                exit 1
+                ver=""
                 ;;
         esac
     fi
 
-    # Map short version to patch filename
-    local patch_file
+    # Normalize user-supplied short forms: v18 → v0.18, v19 → v0.19
     case "$ver" in
-        v0.13|v13) patch_file="vllm_v0.13.0.patch" ;;
-        v0.14|v14) patch_file="vllm_v0.14.0.patch" ;;
-        v0.15|v15) patch_file="vllm_v0.15.0.patch" ;;
-        v0.16|v16) patch_file="vllm_v0.16.0.patch" ;;
-        v0.17|v17) patch_file="vllm_v0.17.0.patch" ;;
-        *)
-            echo "ERROR: Unknown vLLM version tag '$ver'." >&2
-            exit 1
-            ;;
+        v18) ver="v0.18" ;;
+        v19) ver="v0.19" ;;
     esac
 
-    local patch_path="$TRACELENS_REPO/$PATCH_SUBDIR/$patch_file"
-    if [[ ! -f "$patch_path" ]]; then
-        echo "ERROR: Patch file not found: $patch_path" >&2
+    # Search for a matching patch file.  Try two naming conventions:
+    #   config_vllm_v0.XX.0.patch  (public TraceLens)
+    #   vllm_v0.XX.0.patch         (TraceLens-internal)
+    local patch_file=""
+    if [[ -n "$ver" ]]; then
+        local minor_num="${ver#v0.}"  # e.g. "18", "19"
+        for candidate in \
+            "config_vllm_v0.${minor_num}.0.patch" \
+            "vllm_v0.${minor_num}.0.patch"; do
+            if [[ -f "$PATCH_DIR/$candidate" ]]; then
+                patch_file="$candidate"
+                break
+            fi
+        done
+    fi
+
+    if [[ -z "$patch_file" ]]; then
+        echo ""
+        echo "ERROR: No matching patch found for vLLM version '${raw_ver:-$ver}'." >&2
+        echo ""
+        echo "Available patches in $PATCH_DIR:" >&2
+        discover_vllm_patches | while read -r p; do echo "  $p" >&2; done
+        echo ""
+        echo "You can select one explicitly with --version, e.g.:" >&2
+        echo "  --version v0.18" >&2
+        echo "  --version v0.19" >&2
         exit 1
     fi
 
-    echo "[TraceLens] Applying $patch_file to $pkg_dir"
+    local patch_path="$PATCH_DIR/$patch_file"
+    echo "[TraceLens] Selected patch: $patch_file"
+    echo "[TraceLens] Applying to: $pkg_dir"
+
     if $DRY_RUN; then
         echo "[DRY RUN] cd $pkg_dir && git apply --check $patch_path"
         cd "$pkg_dir" && git apply --check "$patch_path" 2>&1 || true
@@ -199,15 +239,18 @@ apply_vllm_patches() {
 
     cd "$pkg_dir"
     if git apply "$patch_path" 2>/dev/null; then
-        echo "[TraceLens] Patch applied successfully via git apply"
+        echo "[TraceLens] Patch applied via git apply"
     elif patch -p1 --fuzz=10 < "$patch_path"; then
-        echo "[TraceLens] Patch applied successfully via patch -p1 (fallback)"
+        echo "[TraceLens] Patch applied via patch -p1 (fallback)"
     else
         echo "ERROR: Failed to apply $patch_file" >&2
-        echo "       The vLLM version may not match the patch exactly." >&2
+        echo "       The installed vLLM may not match the patch." >&2
+        echo "       Try --version to select a different patch." >&2
         exit 1
     fi
 }
+
+# ── SGLang patching ───────────────────────────────────────────────────────────
 
 apply_sglang_patches() {
     local pkg_dir
@@ -215,18 +258,18 @@ apply_sglang_patches() {
     pkg_dir="$(cd "$pkg_dir" && pwd)"
     echo "[TraceLens] SGLang package root: $pkg_dir"
 
-    local patch_dir="$TRACELENS_REPO/$PATCH_SUBDIR/sglang_roofline_patches"
-    if [[ ! -d "$patch_dir" ]]; then
-        echo "ERROR: SGLang patch directory not found: $patch_dir" >&2
+    local sglang_patch_dir="$PATCH_DIR/sglang_roofline_patches"
+    if [[ ! -d "$sglang_patch_dir" ]]; then
+        echo "ERROR: SGLang patch directory not found: $sglang_patch_dir" >&2
         exit 1
     fi
 
-    local patch_count=0
-    for patch_path in "$patch_dir"/*.patch; do
+    local count=0
+    for patch_path in "$sglang_patch_dir"/*.patch; do
         [[ -f "$patch_path" ]] || continue
-        patch_count=$((patch_count + 1))
-        local patch_name
-        patch_name="$(basename "$patch_path")"
+        count=$((count + 1))
+        local name
+        name="$(basename "$patch_path")"
 
         if $DRY_RUN; then
             echo "[DRY RUN] cd $pkg_dir && git apply --check $patch_path"
@@ -234,18 +277,17 @@ apply_sglang_patches() {
             continue
         fi
 
-        echo "[TraceLens] Applying $patch_name ..."
+        echo "[TraceLens] Applying $name ..."
         cd "$pkg_dir"
         if ! git apply "$patch_path"; then
-            echo "ERROR: Failed to apply $patch_name" >&2
+            echo "ERROR: Failed to apply $name" >&2
             exit 1
         fi
     done
-
-    echo "[TraceLens] Applied $patch_count SGLang patch(es)"
+    echo "[TraceLens] Applied $count SGLang patch(es)"
 }
 
-# ── Apply patches ─────────────────────────────────────────────────────────────
+# ── Dispatch ──────────────────────────────────────────────────────────────────
 
 case "$FW" in
     vllm)   apply_vllm_patches ;;
@@ -257,9 +299,18 @@ esac
 
 if $DO_INSTALL && ! $DRY_RUN; then
     echo "[TraceLens] Installing TraceLens package (--no-deps) ..."
-    pip install --no-deps --break-system-packages "$TRACELENS_REPO" 2>/dev/null \
-        || pip install --no-deps "$TRACELENS_REPO"
-    echo "[TraceLens] TraceLens installed successfully"
+    install_src="$TRACELENS_REPO"
+    if ! touch "$TRACELENS_REPO/.write_test" 2>/dev/null; then
+        install_src="/tmp/TraceLens-install"
+        echo "[TraceLens] Repo is read-only, copying to $install_src for pip install ..."
+        rm -rf "$install_src"
+        cp -r "$TRACELENS_REPO" "$install_src"
+    else
+        rm -f "$TRACELENS_REPO/.write_test"
+    fi
+    pip install --no-deps --break-system-packages "$install_src" 2>/dev/null \
+        || pip install --no-deps "$install_src"
+    echo "[TraceLens] TraceLens installed"
 fi
 
 echo "[TraceLens] Done."

--- a/inference_optimization/InferenceX/utils/apply_tracelens_patches.sh
+++ b/inference_optimization/InferenceX/utils/apply_tracelens_patches.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+#
+# Apply TraceLens inference-analysis patches to the current Python environment.
+#
+# This script patches vLLM or SGLang (in-place, inside a container or venv)
+# so that profiling traces include:
+#   - CUDA graph capture traces (per batch-size, per capture mode)
+#   - Roofline annotations (sq, sk, sqsq, sqsk per context/generation group)
+#
+# It also installs the TraceLens package (--no-deps) for post-collection
+# analysis (report generation, trace splitting, etc.).
+#
+# Usage:
+#   bash apply_tracelens_patches.sh [OPTIONS]
+#
+# Options:
+#   --framework  vllm|sglang   (default: auto-detect from $FRAMEWORK or probe Python)
+#   --version    v0.13|v0.14|v0.15|v0.16|v0.17  (vLLM only; default: auto-detect)
+#   --tracelens  /path/to/TraceLens-internal     (overrides $TRACELENS_REPO)
+#   --clone-to   /path/to/dir   clone TraceLens-internal here if not already present
+#   --git-ref    branch/tag/sha to clone (default: main)
+#   --install    also pip-install TraceLens       (default: true)
+#   --no-install skip TraceLens pip install
+#   --dry-run    show what would happen without applying
+#
+# Environment variables (all optional):
+#   TRACELENS_REPO      path to existing local TraceLens-internal clone
+#   TRACELENS_GIT_URL   git URL to clone from (default: AMD-AGI/TraceLens-internal on GitHub)
+#   TRACELENS_GIT_REF   branch/tag/sha (default: main)
+#   FRAMEWORK           "vllm" or "sglang" — skips auto-detection
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+TRACELENS_GIT_URL="${TRACELENS_GIT_URL:-https://github.com/AMD-AGI/TraceLens-internal.git}"
+TRACELENS_GIT_REF="${TRACELENS_GIT_REF:-main}"
+
+# Defaults
+FRAMEWORK_ARG=""
+VLLM_VERSION_ARG=""
+TRACELENS_REPO="${TRACELENS_REPO:-}"
+CLONE_TO=""
+DO_INSTALL=true
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --framework)   FRAMEWORK_ARG="$2"; shift 2 ;;
+        --version)     VLLM_VERSION_ARG="$2"; shift 2 ;;
+        --tracelens)   TRACELENS_REPO="$2"; shift 2 ;;
+        --clone-to)    CLONE_TO="$2"; shift 2 ;;
+        --git-ref)     TRACELENS_GIT_REF="$2"; shift 2 ;;
+        --install)     DO_INSTALL=true; shift ;;
+        --no-install)  DO_INSTALL=false; shift ;;
+        --dry-run)     DRY_RUN=true; shift ;;
+        -h|--help)
+            sed -n '2,/^$/{ s/^# //; s/^#$//; p; }' "$0"
+            exit 0
+            ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+# ── Resolve or clone TraceLens repo ──────────────────────────────────────────
+
+PATCH_SUBDIR="examples/custom_workflows/inference_analysis"
+
+ensure_tracelens_repo() {
+    # Already have a valid local path — nothing to do
+    if [[ -n "$TRACELENS_REPO" && -d "$TRACELENS_REPO/$PATCH_SUBDIR" ]]; then
+        echo "[TraceLens] Using existing repo: $TRACELENS_REPO"
+        return 0
+    fi
+
+    # Determine clone destination
+    local dest="${CLONE_TO:-}"
+    if [[ -z "$dest" ]]; then
+        if [[ -n "$TRACELENS_REPO" ]]; then
+            dest="$TRACELENS_REPO"
+        else
+            dest="/tmp/TraceLens-internal"
+        fi
+    fi
+
+    # If already cloned at dest, reuse it
+    if [[ -d "$dest/$PATCH_SUBDIR" ]]; then
+        echo "[TraceLens] Found existing clone at $dest"
+        TRACELENS_REPO="$dest"
+        return 0
+    fi
+
+    echo "[TraceLens] TraceLens-internal not found locally. Cloning..."
+    echo "[TraceLens]   URL: $TRACELENS_GIT_URL"
+    echo "[TraceLens]   Ref: $TRACELENS_GIT_REF"
+    echo "[TraceLens]   Destination: $dest"
+
+    if ! command -v git &>/dev/null; then
+        echo "ERROR: git is not available — cannot clone TraceLens-internal." >&2
+        echo "       Either install git or mount/copy TraceLens-internal manually." >&2
+        exit 1
+    fi
+
+    git clone --depth 1 --branch "$TRACELENS_GIT_REF" "$TRACELENS_GIT_URL" "$dest"
+    TRACELENS_REPO="$dest"
+
+    if [[ ! -d "$TRACELENS_REPO/$PATCH_SUBDIR" ]]; then
+        echo "ERROR: Cloned repo is missing $PATCH_SUBDIR — wrong repo or branch?" >&2
+        exit 1
+    fi
+
+    echo "[TraceLens] Clone successful"
+}
+
+ensure_tracelens_repo
+
+# ── Detect framework ─────────────────────────────────────────────────────────
+
+detect_framework() {
+    if [[ -n "$FRAMEWORK_ARG" ]]; then
+        echo "$FRAMEWORK_ARG"
+        return
+    fi
+    if [[ -n "${FRAMEWORK:-}" ]]; then
+        case "$FRAMEWORK" in
+            *sglang*) echo "sglang"; return ;;
+            *vllm*)   echo "vllm"; return ;;
+        esac
+    fi
+    if python3 -c "import vllm" 2>/dev/null; then
+        echo "vllm"
+    elif python3 -c "import sglang" 2>/dev/null; then
+        echo "sglang"
+    else
+        echo "ERROR: Cannot detect framework. Neither vllm nor sglang is importable." >&2
+        echo "       Pass --framework vllm|sglang explicitly." >&2
+        exit 1
+    fi
+}
+
+FW="$(detect_framework)"
+echo "[TraceLens] Detected framework: $FW"
+
+# ── Framework-specific logic ──────────────────────────────────────────────────
+
+apply_vllm_patches() {
+    local pkg_dir
+    pkg_dir="$(python3 -c "import vllm, os; print(os.path.join(os.path.dirname(vllm.__file__), '..'))")"
+    pkg_dir="$(cd "$pkg_dir" && pwd)"
+    echo "[TraceLens] vLLM package root: $pkg_dir"
+
+    # Auto-detect vLLM version if not specified
+    local ver="$VLLM_VERSION_ARG"
+    if [[ -z "$ver" ]]; then
+        local raw_ver
+        raw_ver="$(python3 -c "import vllm; print(vllm.__version__)" 2>/dev/null || echo "unknown")"
+        echo "[TraceLens] Detected vLLM version: $raw_ver"
+        case "$raw_ver" in
+            0.13.*) ver="v0.13" ;;
+            0.14.*) ver="v0.14" ;;
+            0.15.*) ver="v0.15" ;;
+            0.16.*) ver="v0.16" ;;
+            0.17.*) ver="v0.17" ;;
+            *)
+                echo "ERROR: Cannot map vLLM version '$raw_ver' to a known patch." >&2
+                echo "       Available patches: v0.13, v0.14, v0.15, v0.16, v0.17" >&2
+                echo "       Pass --version v0.XX explicitly." >&2
+                exit 1
+                ;;
+        esac
+    fi
+
+    # Map short version to patch filename
+    local patch_file
+    case "$ver" in
+        v0.13|v13) patch_file="vllm_v0.13.0.patch" ;;
+        v0.14|v14) patch_file="vllm_v0.14.0.patch" ;;
+        v0.15|v15) patch_file="vllm_v0.15.0.patch" ;;
+        v0.16|v16) patch_file="vllm_v0.16.0.patch" ;;
+        v0.17|v17) patch_file="vllm_v0.17.0.patch" ;;
+        *)
+            echo "ERROR: Unknown vLLM version tag '$ver'." >&2
+            exit 1
+            ;;
+    esac
+
+    local patch_path="$TRACELENS_REPO/$PATCH_SUBDIR/$patch_file"
+    if [[ ! -f "$patch_path" ]]; then
+        echo "ERROR: Patch file not found: $patch_path" >&2
+        exit 1
+    fi
+
+    echo "[TraceLens] Applying $patch_file to $pkg_dir"
+    if $DRY_RUN; then
+        echo "[DRY RUN] cd $pkg_dir && git apply --check $patch_path"
+        cd "$pkg_dir" && git apply --check "$patch_path" 2>&1 || true
+        return
+    fi
+
+    cd "$pkg_dir"
+    if git apply "$patch_path" 2>/dev/null; then
+        echo "[TraceLens] Patch applied successfully via git apply"
+    elif patch -p1 --fuzz=10 < "$patch_path"; then
+        echo "[TraceLens] Patch applied successfully via patch -p1 (fallback)"
+    else
+        echo "ERROR: Failed to apply $patch_file" >&2
+        echo "       The vLLM version may not match the patch exactly." >&2
+        exit 1
+    fi
+}
+
+apply_sglang_patches() {
+    local pkg_dir
+    pkg_dir="$(python3 -c "import sglang, os; print(os.path.dirname(os.path.dirname(sglang.__file__)))")"
+    pkg_dir="$(cd "$pkg_dir" && pwd)"
+    echo "[TraceLens] SGLang package root: $pkg_dir"
+
+    local patch_dir="$TRACELENS_REPO/$PATCH_SUBDIR/sglang_roofline_patches"
+    if [[ ! -d "$patch_dir" ]]; then
+        echo "ERROR: SGLang patch directory not found: $patch_dir" >&2
+        exit 1
+    fi
+
+    local patch_count=0
+    for patch_path in "$patch_dir"/*.patch; do
+        [[ -f "$patch_path" ]] || continue
+        patch_count=$((patch_count + 1))
+        local patch_name
+        patch_name="$(basename "$patch_path")"
+
+        if $DRY_RUN; then
+            echo "[DRY RUN] cd $pkg_dir && git apply --check $patch_path"
+            cd "$pkg_dir" && git apply --check "$patch_path" 2>&1 || true
+            continue
+        fi
+
+        echo "[TraceLens] Applying $patch_name ..."
+        cd "$pkg_dir"
+        if ! git apply "$patch_path"; then
+            echo "ERROR: Failed to apply $patch_name" >&2
+            exit 1
+        fi
+    done
+
+    echo "[TraceLens] Applied $patch_count SGLang patch(es)"
+}
+
+# ── Apply patches ─────────────────────────────────────────────────────────────
+
+case "$FW" in
+    vllm)   apply_vllm_patches ;;
+    sglang) apply_sglang_patches ;;
+    *)      echo "ERROR: Unsupported framework '$FW'" >&2; exit 1 ;;
+esac
+
+# ── Install TraceLens ─────────────────────────────────────────────────────────
+
+if $DO_INSTALL && ! $DRY_RUN; then
+    echo "[TraceLens] Installing TraceLens package (--no-deps) ..."
+    pip install --no-deps --break-system-packages "$TRACELENS_REPO" 2>/dev/null \
+        || pip install --no-deps "$TRACELENS_REPO"
+    echo "[TraceLens] TraceLens installed successfully"
+fi
+
+echo "[TraceLens] Done."


### PR DESCRIPTION
Add TraceLens patch integration for graph-capture profiling

- Add utils/apply_tracelens_patches.sh — applies TraceLens inference patches to vLLM/SGLang at runtime, auto-detecting framework and version
- Add apply_tracelens_patches() wrapper in benchmark_lib.sh
- Update MI300X and MI355X launchers to mount TraceLens repo and forward env vars into containers
- Gated behind TRACELENS_PATCHES=1 — zero impact on existing workflows