### PR TITLE
feat: pin IntelliKit to SHA bcbfa02 in fully-local Dockerfiles for reproducible builds

### DIFF
--- a/deploy/fully-local/Dockerfile.sglang
+++ b/deploy/fully-local/Dockerfile.sglang
@@ -76,4 +76,5 @@ ENV MODE=local \
     NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 
 EXPOSE 22 8001 8002 8003
-CMD ["/opt/entrypoint.sh"]
+ENTRYPOINT ["/opt/entrypoint.sh"]
+CMD []

--- a/deploy/fully-local/Dockerfile.sglang
+++ b/deploy/fully-local/Dockerfile.sglang
@@ -26,10 +26,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && echo 'root:root' | chpasswd
 
 # --- Layer 2: GEAK + intellikit (pinned branches, single layer) ---
+# Pin IntelliKit to a known-good SHA for reproducible builds (issue #62).
+# Keep aligned with GEAK/pyproject.toml; bump both together.
+ARG INTELLIKIT_SHA=bcbfa0252df9d55f3aab68c95dd3ce45ccbe5b46
 RUN git clone --branch feature/xiaofei/claw --depth 1 \
         https://github.com/AMD-AGI/GEAK.git /opt/geak \
-    && git clone --depth 1 \
-        https://github.com/AMDResearch/intellikit.git /opt/intellikit \
+    && git clone https://github.com/AMDResearch/intellikit.git /opt/intellikit \
+    && git -C /opt/intellikit checkout ${INTELLIKIT_SHA} \
     && cd /opt/geak && pip install --no-cache-dir -e . \
     && pip install --no-cache-dir -r server/requirements.txt \
     && pip install --no-cache-dir -e /opt/intellikit/metrix/

--- a/deploy/fully-local/Dockerfile.vllm
+++ b/deploy/fully-local/Dockerfile.vllm
@@ -75,4 +75,5 @@ ENV MODE=local \
     NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 
 EXPOSE 22 8001 8002 8003
-CMD ["/opt/entrypoint.sh"]
+ENTRYPOINT ["/opt/entrypoint.sh"]
+CMD []

--- a/deploy/fully-local/Dockerfile.vllm
+++ b/deploy/fully-local/Dockerfile.vllm
@@ -26,10 +26,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && echo 'root:root' | chpasswd
 
 # --- Layer 2: GEAK + intellikit (pinned branches, single layer) ---
+# Pin IntelliKit to a known-good SHA for reproducible builds (issue #62).
+# Keep aligned with GEAK/pyproject.toml; bump both together.
+ARG INTELLIKIT_SHA=bcbfa0252df9d55f3aab68c95dd3ce45ccbe5b46
 RUN git clone --branch feature/xiaofei/claw --depth 1 \
         https://github.com/AMD-AGI/GEAK.git /opt/geak \
-    && git clone --depth 1 \
-        https://github.com/AMDResearch/intellikit.git /opt/intellikit \
+    && git clone https://github.com/AMDResearch/intellikit.git /opt/intellikit \
+    && git -C /opt/intellikit checkout ${INTELLIKIT_SHA} \
     && cd /opt/geak && pip install --no-cache-dir -e . \
     && pip install --no-cache-dir -r server/requirements.txt \
     && pip install --no-cache-dir -e /opt/intellikit/metrix/


### PR DESCRIPTION
Close https://github.com/AMD-AGI/Hyperloom/issues/62

Replace floating `main` clones with an `ARG INTELLIKIT_SHA` pinned to the SHA already used by GEAK/pyproject.toml, ensuring reproducible builds until an IntelliKit release train is established.