### PR TITLE
fix(auto-label): use built-in github.token for label operations

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Apply labels
         env:
-          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           RULE_LABELS: ${{ steps.rules.outputs.rule_labels }}
           LLM_LABELS: ${{ steps.llm.outputs.llm_labels }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}


### PR DESCRIPTION
## Summary

The `Apply labels` step in auto-label.yml was using `secrets.PROJECT_TOKEN` which is not populated in this repo's secrets (it may have been removed or was only at org level). This caused `gh issue edit` to fail silently with:

> gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.

## Fix

Use the built-in `github.token` instead. The workflow already declares `permissions: issues: write`, which gives the built-in token sufficient access to add labels.

## Verification

Tested on issue #94: LLM returned correct classification (`type:feature`, `domain:ui`, `domain:inference`) but labels failed to apply due to empty GH_TOKEN. This fix should resolve it.

## Test plan

- [ ] Merge this PR
- [ ] Create a blank test issue -> verify labels are applied automatically