### PR TITLE
feat(skills): add Claw v1 RCA outcome self-check to optimization skills

### DIFF
--- a/.cursor/skills/inference-optimization/actions/report.md
+++ b/.cursor/skills/inference-optimization/actions/report.md
@@ -99,3 +99,79 @@ How to compute:
 - `gain_pct` = `(optimized - baseline) / baseline * 100`
 
 The CI parser requires these exact six field names. Missing or renamed fields → N/A.
+
+## Claw Mode: Session Outcome Self-Check (RCA)
+
+Claw's v1 RCA pipeline consumes an optional outcome file written at end-of-turn.
+When this skill is running inside the Claw sandbox, treat this as the **very last
+step** — run it after the report is finalized **and** after RayJob cleanup
+(`workload_stop`) is done.
+
+### Rules
+
+- The skill is running inside the Claw sandbox iff `/workspace/.claw_message_id`
+  exists. If it does not, exit this step silently (LOCAL / CI modes do not use RCA).
+- Write an outcome file **only** when the primary deliverable
+  (`$WORK_DIR/optimization_report.md`) is missing or clearly broken.
+- On success, write **nothing** — backend treats absence-of-file as success.
+- Do **not** emit a `task_outcome` value other than the three allowed ones;
+  anything else is ignored by the backend.
+
+### Allowed outcome values
+
+| `task_outcome` | Meaning |
+|----------------|---------|
+| `completed_no_report` | `optimization_report.md` was not produced at all |
+| `completed_broken_report` | Report file exists but is truncated / missing structure |
+| `completed_invalid_report` | Report looks complete but key content is invalid |
+
+### Script
+
+Run this verbatim as the final step of `report`. It is a no-op on success and
+on LOCAL / CI modes.
+
+```bash
+REPORT="${WORK_DIR:?WORK_DIR not set}/optimization_report.md"
+
+MSG_ID_FILE="/workspace/.claw_message_id"
+if [ -r "$MSG_ID_FILE" ]; then
+  MID="$(tr -d '[:space:]' < "$MSG_ID_FILE")"
+  if [ -n "$MID" ]; then
+    OUT_DIR="/workspace/.claw_outcomes"
+    mkdir -p "$OUT_DIR"
+
+    outcome=""
+    reason=""
+    if [ ! -f "$REPORT" ]; then
+      outcome="completed_no_report"
+      reason="optimization_report.md was not produced"
+    elif [ "$(wc -c < "$REPORT")" -lt 800 ]; then
+      outcome="completed_broken_report"
+      reason="report too small (<800 bytes)"
+    elif [ "$(grep -c '^## ' "$REPORT")" -lt 2 ]; then
+      outcome="completed_broken_report"
+      reason="fewer than 2 H2 sections in report"
+    elif ! grep -q '^| ' "$REPORT"; then
+      outcome="completed_invalid_report"
+      reason="no result tables in report"
+    fi
+
+    if [ -n "$outcome" ]; then
+      python3 - "$OUT_DIR/$MID.json" "$outcome" "$reason" <<'PY'
+import json, sys
+path, outcome, reason = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(path, "w") as f:
+    json.dump({"task_outcome": outcome, "reason": reason}, f)
+PY
+    fi
+  fi
+fi
+```
+
+Outcome file schema (consumed by `executor-ts` and forwarded to backend as
+`task_outcome` / `outcome_reason` on the `executor-complete` callback):
+
+```json
+{"task_outcome": "completed_no_report",
+ "reason": "optimization_report.md was not produced"}
+```

--- a/.cursor/skills/marathon-inference-optimization/SKILL.md
+++ b/.cursor/skills/marathon-inference-optimization/SKILL.md
@@ -59,6 +59,10 @@ responsibility, defined here once so the prompt can stay short.
    (or, if absent, the `=== NO SESSION_REPORT.md — final state.json ===`
    block) to the user.
 
+5. **Claw-mode outcome self-check** (last thing you do — see "Claw Mode:
+   Session Outcome Self-Check (RCA)" near the bottom of this file). It is a
+   no-op on LOCAL hosts and adds negligible cost on Claw, so always include it.
+
 ### Hard rules
 
 - **No cron, no &-loops, no scheduled tasks.** Use multi-turn shell tool
@@ -267,3 +271,75 @@ pane IS on the GPU host natively.
 - `$SPEC_ROOT/actions/*.md` — per-action execution details (deep-kernel-analysis,
   operator-tuning, framework-rebuild, comm-optimization, compiler-tuning, dream,
   checkpoint, re-explore, recover, sweep, report)
+
+## Claw Mode: Session Outcome Self-Check (RCA)
+
+Claw's v1 RCA pipeline consumes an optional outcome file written at end-of-turn.
+Run this **after step 4** (after you've forwarded `SESSION_REPORT.md` back to
+the user). It is a no-op on LOCAL hosts.
+
+### Rules
+
+- The launcher is running inside the Claw sandbox iff `/workspace/.claw_message_id`
+  exists. If it does not, exit this step silently.
+- The marathon deliverable is `$SESSION_DIR/SESSION_REPORT.md` — emit a failure
+  outcome only when it is missing or clearly broken.
+- On success, write **nothing**; backend treats absence as success.
+- Never emit a `task_outcome` value other than the three allowed ones.
+
+### Allowed outcome values
+
+| `task_outcome` | Meaning |
+|----------------|---------|
+| `completed_no_report` | `SESSION_REPORT.md` was not produced (orchestrator never saw STOP) |
+| `completed_broken_report` | `SESSION_REPORT.md` exists but is truncated / missing structure |
+| `completed_invalid_report` | Report looks complete but key content is invalid |
+
+### Script
+
+```bash
+# $SESSION_DIR is the marathon run directory — same one you've been polling.
+REPORT="${SESSION_DIR:?SESSION_DIR not set}/SESSION_REPORT.md"
+
+MSG_ID_FILE="/workspace/.claw_message_id"
+if [ -r "$MSG_ID_FILE" ]; then
+  MID="$(tr -d '[:space:]' < "$MSG_ID_FILE")"
+  if [ -n "$MID" ]; then
+    OUT_DIR="/workspace/.claw_outcomes"
+    mkdir -p "$OUT_DIR"
+
+    outcome=""
+    reason=""
+    if [ ! -f "$REPORT" ]; then
+      outcome="completed_no_report"
+      reason="SESSION_REPORT.md was not produced"
+    elif [ "$(wc -c < "$REPORT")" -lt 800 ]; then
+      outcome="completed_broken_report"
+      reason="SESSION_REPORT too small (<800 bytes)"
+    elif [ "$(grep -c '^## ' "$REPORT")" -lt 2 ]; then
+      outcome="completed_broken_report"
+      reason="fewer than 2 H2 sections in SESSION_REPORT"
+    elif ! grep -q '^| ' "$REPORT"; then
+      outcome="completed_invalid_report"
+      reason="no result tables in SESSION_REPORT"
+    fi
+
+    if [ -n "$outcome" ]; then
+      python3 - "$OUT_DIR/$MID.json" "$outcome" "$reason" <<'PY'
+import json, sys
+path, outcome, reason = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(path, "w") as f:
+    json.dump({"task_outcome": outcome, "reason": reason}, f)
+PY
+    fi
+  fi
+fi
+```
+
+Outcome file schema (forwarded by `executor-ts` to backend as `task_outcome` /
+`outcome_reason` on the `executor-complete` callback):
+
+```json
+{"task_outcome": "completed_no_report",
+ "reason": "SESSION_REPORT.md was not produced"}
+```

--- a/.cursor/skills/mlperf-optimization/actions/report.md
+++ b/.cursor/skills/mlperf-optimization/actions/report.md
@@ -299,3 +299,78 @@ N/A — terminal action.
 - **Hang (>30 min no progress):** inspect GPU utilization; do not kill—wait for recovery or natural failure.
 - **Profiling (Step 4) fails:** ship report without trace comparison; state unavailable.
 - **TraceLens CLI not installed or fails:** omit TraceLens section; note unavailability in report.
+
+## Claw Mode: Session Outcome Self-Check (RCA)
+
+Claw's v1 RCA pipeline consumes an optional outcome file written at end-of-turn.
+When this skill is running inside the Claw sandbox, treat this as the **very last
+step** — run it after the report (`$RESULT_DIR/optimization_report.md`) has been
+finalized.
+
+### Rules
+
+- The skill is running inside the Claw sandbox iff `/workspace/.claw_message_id`
+  exists. If it does not, exit this step silently (LOCAL / CI modes do not use RCA).
+- Write an outcome file **only** when `$RESULT_DIR/optimization_report.md` is
+  missing or clearly broken. On success, write **nothing** — backend treats
+  absence-of-file as success.
+- Do **not** emit a `task_outcome` value other than the three allowed ones.
+
+### Allowed outcome values
+
+| `task_outcome` | Meaning |
+|----------------|---------|
+| `completed_no_report` | `optimization_report.md` was not produced at all |
+| `completed_broken_report` | Report file exists but is truncated / missing structure |
+| `completed_invalid_report` | Report looks complete but key content is invalid |
+
+### Script
+
+Run this verbatim as the last step of `report`. It is a no-op on success and
+on LOCAL / CI modes.
+
+```bash
+REPORT="${RESULT_DIR:?RESULT_DIR not set}/optimization_report.md"
+
+MSG_ID_FILE="/workspace/.claw_message_id"
+if [ -r "$MSG_ID_FILE" ]; then
+  MID="$(tr -d '[:space:]' < "$MSG_ID_FILE")"
+  if [ -n "$MID" ]; then
+    OUT_DIR="/workspace/.claw_outcomes"
+    mkdir -p "$OUT_DIR"
+
+    outcome=""
+    reason=""
+    if [ ! -f "$REPORT" ]; then
+      outcome="completed_no_report"
+      reason="optimization_report.md was not produced"
+    elif [ "$(wc -c < "$REPORT")" -lt 800 ]; then
+      outcome="completed_broken_report"
+      reason="report too small (<800 bytes)"
+    elif [ "$(grep -c '^## ' "$REPORT")" -lt 2 ]; then
+      outcome="completed_broken_report"
+      reason="fewer than 2 H2 sections in report"
+    elif ! grep -q '^| ' "$REPORT"; then
+      outcome="completed_invalid_report"
+      reason="no result tables in report"
+    fi
+
+    if [ -n "$outcome" ]; then
+      python3 - "$OUT_DIR/$MID.json" "$outcome" "$reason" <<'PY'
+import json, sys
+path, outcome, reason = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(path, "w") as f:
+    json.dump({"task_outcome": outcome, "reason": reason}, f)
+PY
+    fi
+  fi
+fi
+```
+
+Outcome file schema (forwarded by `executor-ts` to backend as `task_outcome` /
+`outcome_reason` on the `executor-complete` callback):
+
+```json
+{"task_outcome": "completed_no_report",
+ "reason": "optimization_report.md was not produced"}
+```

--- a/.cursor/skills/training-optimization/actions/report.md
+++ b/.cursor/skills/training-optimization/actions/report.md
@@ -157,3 +157,78 @@ python3 $SKILL_ROOT/kb/kb_ingest.py \
 ## Failure Handling
 - If final profiling fails: write report without trace comparison
 - If TraceLens unavailable: skip TraceLens section, note in report
+
+## Claw Mode: Session Outcome Self-Check (RCA)
+
+Claw's v1 RCA pipeline consumes an optional outcome file written at end-of-turn.
+When this skill is running inside the Claw sandbox, treat this as the **very last
+step** — run it after the report (`$RESULT_DIR/optimization_report.md`) has been
+finalized.
+
+### Rules
+
+- The skill is running inside the Claw sandbox iff `/workspace/.claw_message_id`
+  exists. If it does not, exit this step silently (LOCAL / CI modes do not use RCA).
+- Write an outcome file **only** when `$RESULT_DIR/optimization_report.md` is
+  missing or clearly broken. On success, write **nothing** — backend treats
+  absence-of-file as success.
+- Do **not** emit a `task_outcome` value other than the three allowed ones.
+
+### Allowed outcome values
+
+| `task_outcome` | Meaning |
+|----------------|---------|
+| `completed_no_report` | `optimization_report.md` was not produced at all |
+| `completed_broken_report` | Report file exists but is truncated / missing structure |
+| `completed_invalid_report` | Report looks complete but key content is invalid |
+
+### Script
+
+Run this verbatim as the last step of `report`. It is a no-op on success and
+on LOCAL / CI modes.
+
+```bash
+REPORT="${RESULT_DIR:?RESULT_DIR not set}/optimization_report.md"
+
+MSG_ID_FILE="/workspace/.claw_message_id"
+if [ -r "$MSG_ID_FILE" ]; then
+  MID="$(tr -d '[:space:]' < "$MSG_ID_FILE")"
+  if [ -n "$MID" ]; then
+    OUT_DIR="/workspace/.claw_outcomes"
+    mkdir -p "$OUT_DIR"
+
+    outcome=""
+    reason=""
+    if [ ! -f "$REPORT" ]; then
+      outcome="completed_no_report"
+      reason="optimization_report.md was not produced"
+    elif [ "$(wc -c < "$REPORT")" -lt 800 ]; then
+      outcome="completed_broken_report"
+      reason="report too small (<800 bytes)"
+    elif [ "$(grep -c '^## ' "$REPORT")" -lt 2 ]; then
+      outcome="completed_broken_report"
+      reason="fewer than 2 H2 sections in report"
+    elif ! grep -q '^| ' "$REPORT"; then
+      outcome="completed_invalid_report"
+      reason="no result tables in report"
+    fi
+
+    if [ -n "$outcome" ]; then
+      python3 - "$OUT_DIR/$MID.json" "$outcome" "$reason" <<'PY'
+import json, sys
+path, outcome, reason = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(path, "w") as f:
+    json.dump({"task_outcome": outcome, "reason": reason}, f)
+PY
+    fi
+  fi
+fi
+```
+
+Outcome file schema (forwarded by `executor-ts` to backend as `task_outcome` /
+`outcome_reason` on the `executor-complete` callback):
+
+```json
+{"task_outcome": "completed_no_report",
+ "reason": "optimization_report.md was not produced"}
+```


### PR DESCRIPTION
## Why

Claw v1 RCA needs a signal from the running skill whenever the deliverable
(`optimization_report.md` / `SESSION_REPORT.md`) is **missing or clearly
broken** — even though the skill itself did not crash. Before this change
there was no such signal, so the RCA scanner never picked up these "soft
failures" (`completed_no_report` / `completed_broken_report` /
`completed_invalid_report`).

We discussed placing this check in a standalone skill and auto-injecting
it via `SYSTEM_TOOL_IDS` on the backend, but a simpler path is: the
optimization skills are already mandatory for every optimization turn,
so adding the self-check to their `report` step gets us the same
coverage with zero backend magic.

## What

The last step of each skill's report now does exactly one thing:

1. Read `/workspace/.claw_message_id` (written by `executor-ts`). If it's
   missing, the skill is running LOCAL / CI mode → exit silently.
2. Inspect the primary report file for: existence, size ≥ 800 bytes, ≥ 2
   H2 sections, and at least one markdown table row.
3. If any check fails, write
   `/workspace/.claw_outcomes/<message_id>.json` with one of the three
   allowed outcome values and a short reason.
4. On success, write **nothing** — the backend treats absence-of-file as
   success.

Files changed:

- `.cursor/skills/inference-optimization/actions/report.md`
  — checks `$WORK_DIR/optimization_report.md` after RayJob cleanup.
- `.cursor/skills/mlperf-optimization/actions/report.md`
  — checks `$RESULT_DIR/optimization_report.md`.
- `.cursor/skills/training-optimization/actions/report.md`
  — checks `$RESULT_DIR/optimization_report.md`.
- `.cursor/skills/marathon-inference-optimization/SKILL.md`
  — adds a new step 5 (Claw-mode outcome self-check) after the launcher
    forwards `SESSION_REPORT.md`, and a dedicated section at the bottom
    with the script; checks `$SESSION_DIR/SESSION_REPORT.md`.

## How it plugs into Claw v1

- `executor-ts` (prod Node.js executor) already writes
  `/workspace/.claw_message_id` at turn start and reads
  `/workspace/.claw_outcomes/<mid>.json` before posting
  `executor-complete`; the outcome is forwarded as `task_outcome` /
  `outcome_reason` to the backend (AMD-AGI/Primus-Claw#40).
- The backend RCA path treats
  `completed_no_report | completed_broken_report | completed_invalid_report`
  as a failure, sets `should_rca=true` on the final `status_update`, and
  the Conductor RCA scanner picks the message up.

Any value other than those three is ignored, so this change is safe if
the backend fields are ever renamed — the worst case is missed RCA
detection, not a false positive.

## Release plan

- Merge this PR.
- The marketplace-packaged copies of these four skills on Primus-Claw
  (`inference-optimization` id=16, `-claw` id=11, `-magpie` id=20,
  `-zhanglei` id=19, `-CI` id=23, `-cli-b` id=25;
  `mlperf-optimization`; `training-optimization`;
  `marathon-inference-optimization`) need to be re-packaged + re-uploaded
  by whoever normally publishes them. New sessions will pick up the new
  behavior automatically once the tools marketplace has the updated
  archives.
- No executor / backend / image rebuild required.

## Test plan

- [ ] Dry-run the self-check script locally with `/tmp/workspace` as
      `WORKSPACE_PATH`, both with and without `.claw_message_id`, and
      verify it's a no-op in the missing-file case.
- [ ] After re-publishing one of the inference-optimization skills, run
      a Claw session that produces a complete report → backend should
      log `should_rca=false` on the stop event.
- [ ] Re-run with the report intentionally deleted → backend should
      log `should_rca=true`, `task_outcome="completed_no_report"` on
      the stop event and the Conductor scanner should dispatch RCA.