### PR TITLE
feat: harden marathon protocol — deep analysis, KM feed pipeline, micro-benchmarking, GPU time-share

### DIFF
--- a/.cursor/skills/inference-optimization/actions/vendor-kernel-config.md
+++ b/.cursor/skills/inference-optimization/actions/vendor-kernel-config.md
@@ -1,0 +1,196 @@
+# Action: Vendor Kernel Configuration
+
+**DFS role:** Scores 5 for MoE+MLA models. This fills the gap when torch.compile is
+incompatible and GEAK has no targets. Vendor kernel dtype/fused/sort changes target
+aiter kernels that dominate 40%+ of compute on these models. Apply sub-actions
+sequentially; each is independently scored and can be pruned.
+
+Configure and toggle vendor-provided kernel variants (aiter, CK, hipBLASLt) without
+rewriting kernel source. This is distinct from `kernel-opt.md` (GEAK/Codex/Claude
+rewrite Triton kernels) — this action selects among **existing** vendor kernel paths
+and configuration options.
+
+## When to Use
+
+This action is relevant when:
+- kernel profile shows significant time in `aiter::*`, `ck::*`, `hipBLASLt::*`, or
+  `hipModuleLaunchKernel::*` kernels
+- Model uses vendor MoE kernels (`fmoe_fp8_blockscale_g1u1`, `moe_sorting_fwd`)
+- Model uses FP8 weights or KV cache (dtype variant selection applies)
+- `kernel-opt` (GEAK) scored low because torch.compile is unavailable
+
+**Key insight:** For MoE+MLA models where GEAK scores 2 (no torch.compile targets),
+vendor kernel config can still yield 2–5% from dtype/fused/sort changes that GEAK
+cannot perform (vendor kernels are off-limits to GEAK per Lesson #6).
+
+## Inputs
+
+- kernel profile (category breakdown with kernel names and efficiency metrics)
+- Current server config and environment variables
+- KB entries for this model's vendor kernel compatibility
+
+## KB Query
+
+```bash
+python3 $SKILL_ROOT/kb/kb_query.py "$MODEL_NAME vendor kernel dtype MoE fused sort aiter" --top-k 10 --compact
+python3 $SKILL_ROOT/kb/kb_query.py --category vendor_kernel_config --compact
+```
+
+## Sub-Actions
+
+### VKC-1: FP8 Dtype Selection (fnuz vs OCP)
+
+AMD GPUs support two FP8 formats:
+- **fnuz** (`e4m3fnuz`): AMD-native, default on ROCm
+- **OCP** (`e4m3`, "non-AI optimized"): industry-standard, used by NVIDIA
+
+The aiter library may use different kernel paths depending on which format is active.
+Switching can yield **~1.7% uplift** (validated on DSR1-class models).
+
+**How to test:**
+```bash
+# Check current dtype
+python3 -c "import torch; print(torch.float8_e4m3fn, torch.float8_e4m3fnuz)"
+
+# Environment variable to force OCP format (framework-dependent)
+export AMDGCN_USE_OCP_FP8=1  # or framework-specific flag
+# Restart server, re-benchmark
+```
+
+**Interactions with MTP/speculative decoding:** Low risk — dtype change applies uniformly
+to both base and draft forward passes. But SGLANG_USE_ROCM700A may select kernel paths
+that assume a specific dtype. Test with MTP config, not baseline.
+
+**accuracy_risk:** 0.15 (precision change — gate required)
+
+### VKC-2: MoE Fused Kernel Toggle
+
+The aiter library provides fused MoE kernels that combine sort + quantize + GEMM into
+fewer dispatches. These may not be enabled by default or may have newer variants.
+
+Known variants:
+- `aiter::fmoe_fp8_blockscale_g1u1` — current default (sort + 2-phase GEMM)
+- `aiter::fmoe_bf16_blockscaleFp8_g1u1_novs_silu` — BF16 input variant
+- Newer fused variants may combine sort phases with GEMM dispatch
+
+**Expected uplift:** ~1.5% (validated micro-benchmark, needs E2E verification)
+
+**How to test:**
+```bash
+# Check available fused MoE implementations
+python3 -c "import aiter; print([x for x in dir(aiter) if 'fmoe' in x or 'fused_moe' in x])"
+
+# Environment variable or config to select variant
+export AITER_FUSED_MOE_VERSION=2  # framework-dependent
+# Restart server, re-benchmark
+```
+
+**Interactions with MTP:** Medium risk — MTP changes effective batch sizes during
+draft/verify phases. Fused kernels may be tuned for specific batch size ranges. Test
+with MTP config at multiple concurrency levels (CONC=4, 32, 64 minimum).
+
+**accuracy_risk:** 0.10 (compute path change — gate required)
+
+### VKC-3: GEMM Tuning CSV Selection
+
+aiter and hipBLASLt use pre-tuned GEMM configurations stored in CSV files. Different
+CSV files are tuned for different model shapes and batch sizes.
+
+**How to check:**
+```bash
+# Find loaded tuning CSVs in server log
+grep -i "tuned\|tuning\|csv" $RESULT_DIR/server.log | head -20
+
+# Available tuning files
+find /sgl-workspace/aiter -name "*tuned*.csv" -o -name "*tuning*.csv" 2>/dev/null
+ls /opt/rocm/lib/hipblaslt/data/ 2>/dev/null
+```
+
+**Expected uplift:** 1–3% if current CSV is for a different model shape.
+
+**accuracy_risk:** 0.05 (only affects GEMM tile selection, not computation)
+
+### VKC-4: aiter Environment Flags
+
+Environment variables that select kernel code paths within aiter:
+
+| Flag | Effect | When to Use |
+|------|--------|-------------|
+| `SGLANG_USE_AITER=1` | Enable aiter kernels | Always (already default) |
+| `SGLANG_USE_ROCM700A=1` | MI355X-specific optimizations | MTP config, MI355X only |
+| `AMDGCN_USE_BUFFER_OPS=0` | Disable buffer ops (vLLM) | When buffer ops cause issues |
+| `VLLM_ROCM_USE_AITER=1` | Enable aiter in vLLM | vLLM framework |
+| `VLLM_ROCM_USE_AITER_TRITON_ROPE=1` | Use aiter Triton RoPE | vLLM with aiter |
+
+**accuracy_risk:** 0.05 (code path selection)
+
+## Procedure
+
+### Step 1: Profile-Informed Triage
+
+Read kernel profile output to identify vendor kernel categories and time distribution:
+
+```
+If MoE kernels (fmoe_*, moe_sorting_*) > 20% of compute:
+    → VKC-1 (dtype), VKC-2 (fused) are relevant
+If GEMM kernels (Cijk_*, a8w8_blockscale) > 15% of compute:
+    → VKC-3 (GEMM tuning) is relevant
+If aiter kernels are in use:
+    → VKC-4 (env flags) — check for untested flags
+```
+
+### Step 2: Check KB for Known Regressions
+
+```bash
+python3 $SKILL_ROOT/kb/kb_query.py "$MODEL_NAME vendor kernel regression" --top-k 5 --compact
+```
+
+**CRITICAL:** If KB shows a known regression for a sub-action (e.g., MoE sort 3x
+slower), **skip that sub-action** unless KB shows the regression was resolved after
+a specific date/version.
+
+### Step 3: Apply Sub-Actions Sequentially
+
+Apply one sub-action at a time. After each:
+1. Restart server (kill + wait + relaunch)
+2. Benchmark at CONC=64 (quick single-point)
+3. If gain > 0%: keep, move to next sub-action
+4. If gain ≤ 0%: revert, log, move to next sub-action
+
+**Order:** VKC-1 → VKC-2 → VKC-3 → VKC-4
+
+### Step 4: Combined Verification
+
+After all kept sub-actions are applied together:
+1. Full concurrency sweep (CONC=4,8,16,32,64)
+2. Accuracy gate (GSM8K) — required since accuracy_risk > 0
+
+### Step 5: MTP Compatibility Check
+
+If the model uses MTP/speculative decoding:
+1. Re-run the full test with MTP config (not just baseline)
+2. Compare MTP + vendor config vs MTP alone
+3. Variable batch sizes from speculation can interact with kernel tuning
+
+**If MTP config regresses but baseline improves:** Log as MTP-incompatible in KB.
+The sub-action may still be useful for non-MTP deployments.
+
+## Outputs
+
+- Per sub-action results: (sub_action, gain_pct, status, config_change)
+- Combined gain after all kept sub-actions
+- MTP compatibility flag per sub-action
+- KB entries for model-specific vendor kernel behavior
+
+## Heuristic Update
+
+- Kept sub-action: boost similar sub-actions for same model class by 1.3×
+- Reverted sub-action: reduce score for that sub-action by 0.5× for this model class
+- MTP-incompatible result: add `mtp_incompatible` tag to KB entry, reduce score to 0
+  when MTP is active
+
+## Failure Handling
+
+- Server crash after config change: revert all env vars, restart with known-good config
+- Import error (aiter version too old): log version requirement, skip sub-action
+- Kernel not found (variant doesn't exist in this aiter version): skip, log

--- a/.cursor/skills/marathon-inference-optimization/scripts/launcher/pane_kernel_mgr.md
+++ b/.cursor/skills/marathon-inference-optimization/scripts/launcher/pane_kernel_mgr.md
@@ -19,6 +19,12 @@ Hard constraints (what you MUST NEVER do):
 
 Your job: poll `$SESSION_DIR/kernel_manager/work_queue.jsonl`, dispatch to OOB backends (deep guided loop up to 5 rounds), write merge-ready patches to `merge_ready/<id>/`, append results to `results.jsonl`, and log failures to `event_log.jsonl`.
 
+Timing expectation: The orchestrator runs Steps 0-2 (warm-start, re-profile, deep analysis)
+before dispatching work. Expect the work queue to be empty for the first ~15-30 min. After
+that, the orchestrator bulk-dispatches kernel targets from deep analysis (Step 2). If the
+queue is still empty after 30 min, check state.json to see if the orchestrator is stuck
+and log a finding to findings.jsonl alerting it.
+
 Tooling rules:
 - All polling MUST be plain bash (`while sleep N; do ... done`, `tail -f`, `inotifywait`).
 - Do NOT call CronCreate / CronDelete / Schedule / TodoWrite-as-scheduler / any background task scheduler. The outer monitor tails your log every 60s — keep your output legible and in-process.

--- a/.cursor/skills/marathon-inference-optimization/scripts/launcher/pane_orchestrator.md
+++ b/.cursor/skills/marathon-inference-optimization/scripts/launcher/pane_orchestrator.md
@@ -34,6 +34,63 @@ Tooling rules:
 - Do NOT call CronCreate / CronDelete / Schedule / TodoWrite-as-scheduler / any background task scheduler. The outer monitor tails your log every 60s — keep your output legible and in-process.
 - Do NOT spawn detached `&` background daemons. The pane is restarted by the launcher's `--continue` loop; rogue background jobs survive restarts and corrupt state.
 
+Stage Gate Enforcement (CRITICAL — IR-20):
+- The protocol has 8 stages (0-7). You MUST execute them IN ORDER.
+- After completing each stage, call complete_stage() to record it in state.json.
+- Before starting any stage N, verify ALL stages 0..N-1 are in protocol_stages_completed.
+- DO NOT pre-populate the action stack from prior session knowledge during warm-start.
+  The action stack comes from PROFILING (Step 1) + DEEP ANALYSIS (Step 2), not memory.
+- DO NOT enter the DFS loop (Step 4) until Steps 0, 1, 2, 3 are ALL completed.
+- The Kernel Manager work queue MUST have entries before Step 3 completes (from Step 2 bulk dispatch).
+
+Action Tracking (CRITICAL — IR-21):
+- EVERY optimization MUST be recorded in state.json completed_actions[] with:
+  {id, action, name, status, description, tput_before, tput_after, gain_pct, timestamp}
+- tput_before = MEASURED throughput BEFORE the change.
+- tput_after = MEASURED throughput AFTER the change.
+- This builds the throughput-vs-time plot. Untracked gains are invisible.
+- Update state.json baseline_tput_per_gpu, current_tput_per_gpu, best_tput_per_gpu after EVERY bench.
+
+Warm-Start Rule (CRITICAL — IR-22):
+- Warm-start (Step 0) does ONE thing: launch the server AS-IS (no patches, no hotfixes),
+  run a baseline benchmark, and record the measured throughput. That's it.
+- DO NOT apply any hotfixes, patches, or optimizations during warm-start.
+- Known hotfixes from prior sessions (block_m fix, TRITON_ROPE toggle, CK alignment,
+  BF16 GEMM tuning, etc.) go into the ACTION STACK during Step 3 (Build Stack).
+- The DFS loop (Step 4) then applies them one-by-one with proper before/after benchmarks.
+- This ensures every single gain shows up on the timeline plot.
+
+Read-Only Analysis Rule (CRITICAL — IR-23):
+- Steps 1 (Profile) and 2 (Deep Analysis) are READ-ONLY. No code changes, no patches,
+  no file writes to system packages, no env var changes, no server restarts.
+- These steps ONLY produce: findings, kernel breakdowns, and candidate actions.
+- All candidate actions go into the action_stack (Step 3) for DFS execution (Step 4).
+- The ONLY place code changes happen is the DFS loop (Step 4).
+
+Stack Empty Rule (CRITICAL — IR-24):
+- If the action_stack is empty during DFS, do NOT exit the loop or wait for dream.
+- IMMEDIATELY re-profile + re-run deep analysis (with env var scan + top 10 kernels).
+- The deep analysis MUST produce at least 5-10 candidates. If fewer, go deeper.
+- The marathon has 24h — empty stack after 1h means analysis was incomplete.
+
+Deep Analysis Scope (CRITICAL):
+- Step 2 MUST analyze AT LEAST the top 10 kernels by GPU% (threshold: 2.0%).
+- Step 2 MUST start with an env var scan (check serve script for missing flags like
+  FP4_ASM_GEMM, FP8_MFMA_PAGE_ATTN, AMDGCN_USE_BUFFER_OPS, AITER_CONFIG_FMOE, etc.)
+- Each unset high-impact env var becomes a candidate action (score = gpu_pct * 10).
+- The action stack after deep analysis should have AT LEAST 5-10 items.
+
+Stage checklist — execute in this exact order, no exceptions:
+  Step 0: WARM-START → launch server AS-IS with NO patches, run baseline benchmark, record tput
+  Step 1: RE-PROFILE → READ-ONLY profiling on running server, get kernel GPU% breakdown
+  Step 2: DEEP ANALYSIS → READ-ONLY env var scan + top-10 kernel analysis, min 5-10 candidates
+  Step 3: BUILD STACK → score actions from profile+analysis, verify KM queue has work
+  Step 4: DFS LOOP → pop/execute/measure/re-score. If stack empty → re-profile + re-analyze (IR-24)
+  Step 5+: SWEEP, REPORT, DREAM
+
+On --continue restart: Read state.json, check protocol_stages_completed, resume from
+the NEXT incomplete stage. Do NOT restart from Step 0 if it's already completed.
+
 Autonomy:
 - Work autonomously; never ask for human confirmation between DFS actions.
-- Begin the Marathon protocol from Step 0 WARM-START now.
+- Begin the Marathon protocol now. Read state.json first to determine which stage to start from.

--- a/marathon_optimization/marathon_harness/skills/SKILL.md
+++ b/marathon_optimization/marathon_harness/skills/SKILL.md
@@ -60,17 +60,57 @@ a re-profile to understand the baseline before going deep.
 
 ## The Protocol
 
-**Execute these steps in order.**
+**Execute these steps in STRICT ORDER. No skipping. No reordering.**
+
+Each step has a GATE — you MUST record completion in `state.json` before
+proceeding to the next step. Check `state.json["protocol_stages_completed"]`
+at the start of each step; if the previous stage is missing, you are out
+of order — STOP and go back.
 
 ```
-0. WARM-START     → actions/setup.md       — ingest Sprint handoff or pre-optimized baseline
-1. RE-PROFILE     → actions/profile.md     — fresh trace on the optimized baseline
-2. DEEP ANALYSIS  → actions/deep-kernel-analysis.md — per-kernel dispatch tracing + variant discovery
-3. BUILD STACK    → score Marathon-specific actions, push highest-first
+0. WARM-START     → actions/setup.md       — ingest baseline + BENCHMARK to measure actual tput
+1. RE-PROFILE     → actions/profile.md     — fresh trace on the baseline server
+2. DEEP ANALYSIS  → actions/deep-kernel-analysis.md + BULK KM DISPATCH
+3. BUILD STACK    → score Marathon-specific actions from profile + analysis results
 4. DFS LOOP       → pop → execute → measure → re-score → dream every 3-4h → repeat
 5. SWEEP          → actions/sweep.md       — extended sweep on deeply-optimized config
 6. REPORT         → actions/report.md      — final report + KB contribution
 7. DREAM          → final consolidation, cross-run KB contribution
+```
+
+### Stage Gate Protocol (MANDATORY — IR-20)
+
+After completing each stage, record it in state.json:
+
+```python
+import json, datetime
+def complete_stage(state_path, stage_num, stage_name, result_summary):
+    with open(state_path) as f:
+        state = json.load(f)
+    entry = {
+        "stage": stage_num,
+        "name": stage_name,
+        "completed_at": datetime.datetime.now(datetime.UTC).isoformat(),
+        "result": result_summary
+    }
+    if "protocol_stages_completed" not in state:
+        state["protocol_stages_completed"] = []
+    state["protocol_stages_completed"].append(entry)
+    state["protocol_stage"] = stage_num + 1
+    state["phase"] = stage_name
+    with open(state_path, "w") as f:
+        json.dump(state, f, indent=2)
+```
+
+**GATE CHECK** — run this before starting any stage N:
+```python
+def gate_check(state, required_stage):
+    completed = [s["stage"] for s in state.get("protocol_stages_completed", [])]
+    for s in range(required_stage):
+        if s not in completed:
+            raise RuntimeError(f"STAGE GATE VIOLATION: stage {s} not completed, "
+                               f"cannot start stage {required_stage}. "
+                               f"Completed: {completed}")
 ```
 
 ### Step 0: Warm-Start
@@ -81,52 +121,183 @@ Two modes (see `actions/setup.md`):
   load `handoff/opportunities.json` as pre-scored Marathon action candidates.
 - **Mode B: Pre-optimized directory** — parse launch script, extract config, set as baseline.
 
-Both modes skip basic setup and go directly to re-profile.
+**Step 0 MUST end with a MEASURED baseline benchmark.** The `baseline_tput_per_gpu`
+in state.json MUST be an actual benchmark result, never an assumed or inherited
+value. Run the benchmark, record the result, then call `complete_stage(0, "warmstart", ...)`.
 
-### Step 2: Deep Analysis
+Both modes then proceed to Step 1 RE-PROFILE (no skipping).
 
-For every kernel consuming >MIN_GPU_PCT of GPU time, run `actions/deep-kernel-analysis.md`:
+### Step 1: Re-Profile (MANDATORY — do NOT skip)
 
+**GATE:** Step 0 must be in `protocol_stages_completed` before starting Step 1.
+
+After measuring the baseline in Step 0, profile the RUNNING server to get
+a kernel-level GPU% breakdown. This drives everything that follows.
+
+1. Run `actions/profile.md` on the baseline server (already running from Step 0)
+2. Record the top-N kernels by GPU% in `state.json["kernel_dispatch_map"]`
+3. Identify which kernels are >1% GPU time — these are your optimization targets
+4. Record the profile result path in state.json
+5. Call `complete_stage(1, "re-profile", {"top_kernels": [...], "profile_path": "..."})`
+
+**DO NOT build the action stack or start DFS without a fresh profile.**
+Prior session knowledge is useful context but NOT a substitute for profiling
+the current running server — library versions change, optimizations get
+reverted, dispatch paths shift.
+
+### Step 2: Deep Analysis + BULK KM DISPATCH
+
+**GATE:** Step 1 must be in `protocol_stages_completed` before starting Step 2.
+
+Run `actions/deep-kernel-analysis.md` on AT LEAST the **top 10 kernels** by GPU%
+(minimum threshold: 2.0% GPU time). Do NOT stop after finding one opportunity.
+
+**MANDATORY analysis steps for EACH of the top 10 kernels:**
+
+0. **Env var scan** — FIRST, scan ALL framework env vars that control dispatch
+   (FP4_ASM, MFMA_PAGE_ATTN, BUFFER_OPS, CONFIG_FMOE, CONFIG_GEMM_BF16, etc.)
+   Check which are set vs unset in the serve script. Each unset high-impact flag
+   is a candidate action.
 1. **Dispatch path trace** — Python call chain → compiled extension → GPU kernel
 2. **Variant discovery** — search for alternative implementations, check platform branching
 3. **Config verification** — check shape-specific tuning configs vs generic defaults
 4. **Build system trace** — how is the kernel compiled? Patch vs rebuild required?
 5. **Opportunity report** — classifies each kernel as `self-fix` or `oob-rewrite`:
-   - **Self-fix** (dispatch bugs, one-line routing changes): orchestrator applies directly
-   - **OOB-rewrite** (kernel rewrites, multi-file changes): written to the Kernel Manager's
-     work queue at `$RESULT_DIR/kernel_manager/work_queue.jsonl`
+   - **Self-fix** (dispatch bugs, env var flags, config changes): → action_stack
+   - **OOB-rewrite** (kernel rewrites, multi-file changes): → KM work queue
+
+The action_stack after Step 2 should have AT LEAST 5-10 candidate actions.
+If you have fewer than 5, you haven't analyzed deeply enough — go back and
+check more kernels and env var flags.
+
+**BULK KM DISPATCH (MANDATORY after deep analysis):**
+
+After completing deep analysis, IMMEDIATELY write work_queue entries for ALL
+OOB-rewrite targets in bulk. Do NOT trickle them one-at-a-time as you pop DFS
+actions. The KM runs asynchronously — feeding it all targets up front maximizes
+parallelism and ensures kernel optimizations are in-flight while you do other DFS work.
+
+For EACH kernel with GPU% >= 1 that needs OOB optimization:
+```python
+entry = {
+    "id": f"km-{kernel_name_slug}",
+    "kernel_name": kernel_name,
+    "source_file": source_file,
+    "source_type": source_type,  # "triton" | "cpp_hip" | "python"
+    "strategy": strategy,        # "oob-rewrite" | "triton-rewrite" | "hip-kernel" | etc.
+    "priority": int(gpu_pct * 10),
+    "gpu_pct": gpu_pct,
+    "dispatch_analysis": {
+        "active_path": current_dispatch_path,
+        "optimal_path": best_known_path,
+        "dispatch_bug": bool,
+    },
+    "trace_shapes": [...],       # actual GEMM/op shapes from profiler
+    "constraints": {
+        "head_dim": 64,          # from model config
+        "hidden_size": 2880,
+        "target_vgprs": 64,     # for 4-wave occupancy on gfx950
+        "fp8_type": "e4m3fnuz", # MI355X native type
+    },
+    "status": "pending",
+    "timestamp": now_utc_iso,
+}
+# Append to $RESULT_DIR/kernel_manager/work_queue.jsonl
+```
+
+Target: up to 25 entries per analysis cycle (`KERNEL_OPT_MAX_SUBMISSIONS = 25`).
+The KM will process them in priority order (highest gpu_pct first).
+
+### Step 3: Build Stack
+
+**GATE:** Step 2 must be in `protocol_stages_completed` before starting Step 3.
+
+Score Marathon-specific actions based on the profile and deep analysis results.
+The action stack MUST be derived from actual profiling data — not from prior
+session knowledge alone. Prior sessions provide context for scoring, but the
+actions themselves come from the current profile + deep analysis.
+
+1. For each kernel from the profile: score based on GPU%, dispatch analysis,
+   and prior session outcomes (what worked/failed before)
+2. Push all scored actions onto `action_stack`, highest score first
+3. Verify the KM work queue has entries (from Step 2 bulk dispatch)
+4. Call `complete_stage(3, "build-stack", {"stack_size": N, "km_queue_size": M})`
 
 ### Step 4: The DFS Loop (Marathon Core)
 
-```
-WHILE action_stack is not empty AND NOT stopping_criteria_met():
+**GATE:** Step 3 must be in `protocol_stages_completed` before entering the DFS loop.
 
-  a. Pop highest-scored action from action_stack
-  b. IF action is a self-fix dispatch bug:
+```
+WHILE NOT stopping_criteria_met():
+
+  ** STACK EMPTY → IMMEDIATE RE-ANALYSIS (IR-24): **
+     If action_stack is empty, do NOT exit the DFS loop. Instead:
+       1. Re-profile the server (actions/profile.md)
+       2. Run FULL deep analysis (actions/deep-kernel-analysis.md) with
+          the updated rules: top 10 kernels, env var scan, min 5 candidates
+       3. Bulk-dispatch new KM targets
+       4. Build fresh action stack from analysis results
+       5. If the new stack is STILL empty after thorough analysis, THEN
+          enter dream.md and try re-exploration strategies
+       6. Only exit the DFS loop if stopping_criteria_met() (time budget
+          exhausted or shutdown signal)
+     The marathon has 24h — an empty stack after 1h means analysis was
+     incomplete, NOT that optimization is done.
+
+  a. Check shutdown signal: [ -f "$SESSION_DIR/STOP_PANE_orchestrator" ]
+
+  ★★★ STEP b: MERGE-OP POLL — ALWAYS FIRST, BEFORE POPPING ANY ACTION ★★★
+     KM merges ALWAYS take priority over DFS exploration. The Kernel Manager
+     runs validated 4-step tests (IR-17: compile → correctness → multi-shape
+     micro-benchmark → adversarial). Its merge-ready patches represent
+     already-proven kernel improvements — they must be integrated immediately and test e2e.
+
+     BEFORE popping any action, call poll_kernel_results(). For each
+     merge-ready result with micro_benchmark data:
+     → Push a `merge-op` action with score 10 (HIGHEST PRIORITY)
+     → merge-ops auto-sort to the top of the stack
+     → Next pop (step c) will pick them up
+
+     ALSO poll every 10 minutes WITHIN long-running actions (benchmark
+     waits, server startup, compilation) and after every server restart.
+
+     DO NOT SKIP. DO NOT DEFER. If merge-ready patches exist, they are
+     your next action — period. No DFS exploration until all merge-ops
+     are processed.
+
+  c. Pop highest-scored action from action_stack (merge-ops will be on top)
+  d. IF action is a self-fix dispatch bug:
        → Apply fix directly (git archaeology + patch + test)
        → No Kernel Manager involvement needed
-  c. IF action is a deep-kernel-opt target:
+  e. IF action is a deep-kernel-opt target:
        → Write to $RESULT_DIR/kernel_manager/work_queue.jsonl
        → The Kernel Manager (tmux pane 2) processes it asynchronously
        → Continue DFS loop with other actions
-  d. Execute the action (dispatch to actions/*.md)
-  e. ACCURACY GATE: if accuracy_risk > 0 → run eval, revert if drop > threshold
-  f. Measure: new_tput_per_gpu
-  g. Update state: current_tput_per_gpu, cumulative_gain_pct
-  h. RE-SCORE all remaining actions on the stack
-  i. Push new sub-actions discovered during execution
-  j. Log to completed_actions
-  k. KB ingest
+  f. Execute the action (dispatch to actions/*.md)
+  g. ACCURACY GATE: if accuracy_risk > 0 → run eval, revert if drop > threshold
+  h. Measure: new_tput_per_gpu (MANDATORY — this is the bench result)
+  i. Update state: current_tput_per_gpu, cumulative_gain_pct, best_tput_per_gpu
+  j. RE-SCORE all remaining actions on the stack
+  k. Push new sub-actions discovered during execution
+  l. Log to completed_actions with FULL schema (IR-18: tput_before, tput_after,
+     gain_pct, timestamp — never omit)
+  m. If KEEP: sync $BASE_DIR/state.json (IR-19)
+  n. KB ingest
 
-  ** MERGE-OP POLL: ** Between DFS actions, check results.jsonl for completed
-     kernel optimizations from the Kernel Manager. For each merge-ready result:
-     → Push a `merge-op` action onto the stack with score 9 (high priority)
-     → merge-op: kill server → apply patch → rebuild if needed → restart →
-       E2E benchmark → KEEP/REVERT
-     → On REVERT or crash during merge-op:
-       write event to event_log.jsonl (Watchdog will investigate)
+  ** GPU REQUEST POLL (IR-25): ** Check for pending KM GPU requests.
+     When TP == GPU_COUNT, the KM cannot micro-benchmark without borrowing GPUs.
+     Check $SESSION_DIR/kernel_manager/gpu_request.json for status: "pending".
+     If found:
+     → Kill inference server + release_gpu_lock()
+     → Set gpu_request.json status to "granted" (grant_gpu_request())
+     → Wait for KM to finish: poll for status "released" (15s intervals, 30min max)
+     → Once released: restart server + write_gpu_lock()
+     → Delete gpu_request.json (cleanup_gpu_request())
+     The KM micro-benchmark is critical — it feeds merge-ops (score 10 priority).
+     Wait up to 30min for KM to finish. One server restart cycle is a small cost
+     compared to losing validated benchmark data.
 
-  ** FINDINGS POLL: ** Between DFS actions, check findings.jsonl for Watchdog
+  ** FINDINGS POLL: ** After merge-op poll and between DFS actions, check findings.jsonl for Watchdog
      guidance. Findings may influence scoring:
      - If Watchdog says "hw-blocked" for a kernel: remove its actions from stack
      - If Watchdog provides constraints: update pending kernel targets
@@ -148,6 +319,37 @@ WHILE action_stack is not empty AND NOT stopping_criteria_met():
 
   ** CHECKPOINT: ** After every KEEP decision and every 30 min:
      → actions/checkpoint.md (persist state for recovery)
+
+  ** RE-PROFILE CADENCE (every 3 hours): **
+     Every 3 hours of wall clock, re-profile the running server to discover
+     NEW kernel bottlenecks that emerged after prior optimizations. Prior
+     KEEPs may have shifted the bottleneck from one kernel to another.
+       1. Run actions/profile.md to get fresh kernel breakdown
+       2. Compare with previous profile — find kernels whose GPU% increased
+       3. Run deep analysis on the top 10 NEW or CHANGED candidates
+       4. Bulk-dispatch new targets to KM work queue (up to 25 total)
+       5. Push new DFS actions from the analysis onto the stack
+     This ensures the KM always has fresh work and the orch doesn't run
+     out of ideas mid-marathon.
+
+  ** ESCALATION (failed DFS action → KM): **
+     When a DFS action fails and the failure is kernel-level (not config/infra):
+       → Write a work_queue entry to KM with the failure context:
+         {id, kernel_name, source_file, strategy: "escalated-from-orch",
+          failure_reason, prior_attempts: [...], constraints_discovered}
+       → The KM may find a different approach (different backend, different
+         optimization strategy) that the orch couldn't execute directly
+       → Do NOT just discard kernel failures — always escalate to KM first
+
+  ** CIRCUIT BREAKER (5 consecutive failures → re-analyze): **
+     After 5 consecutive DFS action failures (DISCARD or error):
+       1. STOP popping actions — the current stack is stale
+       2. Re-profile the server (even if <3h since last profile)
+       3. Run fresh deep analysis on the new profile
+       4. Bulk-dispatch new KM targets from the analysis
+       5. Replace the stale action stack with fresh actions
+       6. Reset consecutive failure counter
+     This prevents the orch from grinding through a stale stack of bad ideas.
 ```
 
 **Dream is mandatory every 3-4 hours.** Not just at tier boundaries. Every dream
@@ -187,8 +389,20 @@ def push_kernel_target(target, result_dir):
 **Polling results** (orchestrator reads manager output):
 
 ```python
+MERGE_READY_STATUSES = {"merge-ready", "patch_generated_locally"}
+
 def poll_kernel_results(result_dir, last_seen_id=None):
-    """Check for new merge-ready results from the Kernel Manager."""
+    """Check for new merge-ready results from the Kernel Manager.
+
+    Matches both 'merge-ready' (OOB-tested) and 'patch_generated_locally'
+    (locally written when OOB was unavailable). Both indicate a complete
+    patch directory exists under merge_ready/<task_id>/.
+
+    QUALITY GATE: Reject results that lack micro_benchmark data or
+    correctness evidence. A merge-ready result without benchmark data
+    means the KM skipped the 4-step test pipeline — these are unreliable
+    and should be discarded with a log message, not merged.
+    """
     results_path = os.path.join(result_dir, "kernel_manager", "results.jsonl")
     if not os.path.exists(results_path):
         return []
@@ -199,8 +413,16 @@ def poll_kernel_results(result_dir, last_seen_id=None):
             if not line:
                 continue
             result = json.loads(line)
-            if result["status"] == "merge-ready":
-                if last_seen_id is None or result["id"] > last_seen_id:
+            if result.get("status") in MERGE_READY_STATUSES:
+                rid = result.get("id") or result.get("task_id")
+                if last_seen_id is None or (rid and rid > last_seen_id):
+                    # Quality gate: require micro_benchmark data or explicit "deferred"
+                    mb = result.get("micro_benchmark") or result.get("micro_speedup")
+                    corr = result.get("correctness") or result.get("correctness_status")
+                    if mb is None and corr not in ("passed", "gpu_smoke_pass"):
+                        print(f"[MERGE-OP POLL] SKIPPING {rid}: no micro_benchmark "
+                              f"and no correctness evidence — KM must run 4-step test")
+                        continue
                     new_results.append(result)
     return new_results
 ```
@@ -437,6 +659,7 @@ read event_log.jsonl  write events ←──────────────
 - `$RESULT_DIR/kernel_manager/event_log.jsonl` — orchestrator + manager write, watchdog reads
 - `$RESULT_DIR/kernel_manager/findings.jsonl` — watchdog writes, orchestrator + manager read
 - `$RESULT_DIR/kernel_manager/rca_reports/<id>/` — watchdog writes detailed reports
+- `$RESULT_DIR/kernel_manager/gpu_request.json` — KM writes request, orchestrator grants/cleans up
 
 ## Time Tiers
 
@@ -523,7 +746,7 @@ state = {
 
     # DFS state
     "action_stack": [],
-    "completed_actions": [],
+    "completed_actions": [],       # REQUIRED per-entry schema — see below
     "kernel_candidates": [],
 
     # Async kernel optimization (legacy — direct OOB dispatch)
@@ -560,6 +783,88 @@ state = {
     "backend_wins": {},
     "frameworks_rebuilt": [],       # list of libraries rebuilt during this run
 }
+```
+
+## `completed_actions` Entry Schema (MANDATORY — IR-18)
+
+Every entry appended to `completed_actions` MUST include ALL of these fields.
+Sessions that omit `tput_before` / `tput_after` make gains invisible in
+timeline plots and break session-to-session handoff (the 5119→10551 gap bug).
+
+```python
+{
+    "id": "action_xxx",                     # unique action id
+    "action": "operator-tuning",            # action type from actions/*.md
+    "name": "Human-readable action name",   # short description
+    "status": "KEEP",                       # KEEP | DISCARD | REVERT | INFO | DONE
+    "description": "What was done",         # 1-2 sentences
+
+    # --- THESE FOUR FIELDS ARE MANDATORY (never omit, never null) ---
+    "tput_before": 10551.33,               # tok/s/GPU BEFORE this action
+    "tput_after": 10551.33,                # tok/s/GPU AFTER this action (= bench result)
+    "gain_pct": 0.0,                       # (tput_after - tput_before) / tput_before * 100
+    "timestamp": "2026-04-21T22:01:54Z",   # ISO 8601
+
+    # Optional but encouraged
+    "bench_id": "bench_marathon_xxx",       # benchmark result directory name
+    "accuracy_before": None,                # if accuracy gate was run
+    "accuracy_after": None,
+}
+```
+
+**IR-21 (action tracking):** Every optimization MUST be recorded in
+`completed_actions` with `tput_before`, `tput_after`, `gain_pct`, and
+`timestamp`. This builds the throughput-vs-time timeline.
+
+**IR-22 (no warm-start hotfixes):** Warm-start (Step 0) MUST NOT apply any
+patches, hotfixes, or optimizations. It launches the server AS-IS, runs a
+baseline benchmark, and records the measured throughput. That's it.
+Known hotfixes from prior sessions (block_m fix, TRITON_ROPE toggle, CK
+alignment fix, BF16 GEMM tuning, etc.) are added to the action_stack during
+Step 3 (Build Stack) and executed one-by-one in the DFS loop (Step 4) with
+proper before/after benchmarks. This ensures every gain appears on the
+throughput-vs-time plot.
+
+**IR-23 (read-only analysis):** Steps 1 (Re-Profile) and 2 (Deep Analysis)
+are strictly READ-ONLY. No code changes, no patches, no file writes to
+system packages, no env var changes, no server restarts. These steps ONLY
+produce findings, kernel breakdowns, and candidate actions. All candidates
+go into the action_stack (Step 3). Code changes ONLY happen in the DFS
+loop (Step 4), one action at a time with before/after benchmarks.
+
+## `BASE_DIR/state.json` Sync (MANDATORY — IR-19)
+
+After every KEEP decision and at session shutdown, the orchestrator MUST
+update `$BASE_DIR/state.json` with the session's best results:
+
+```python
+import json
+def sync_base_dir_state(base_dir, session_state):
+    base_state_path = f"{base_dir}/state.json"
+    base_state = {}
+    try:
+        with open(base_state_path) as f:
+            base_state = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        pass
+    best = session_state.get("best_tput_per_gpu", 0)
+    prev_best = base_state.get("current_tput_per_gpu", 0)
+    if best > prev_best:
+        base_state.update({
+            "current_tput_per_gpu": best,
+            "sprint_baseline_tput_per_gpu": base_state.get(
+                "sprint_baseline_tput_per_gpu",
+                session_state.get("sprint_tput_per_gpu", 0)),
+            "tp": session_state.get("tp"),
+            "framework": session_state.get("framework"),
+            "model": session_state.get("model_name"),
+            "last_session_id": session_state.get("session_id"),
+            "last_session_best_tput": best,
+            "last_updated": session_state.get("last_updated",
+                __import__("datetime").datetime.utcnow().isoformat()),
+        })
+        with open(base_state_path, "w") as f:
+            json.dump(base_state, f, indent=2)
 ```
 
 ## Accuracy Gate
@@ -603,6 +908,137 @@ via the fast path — do NOT send them to the Kernel Manager (wastes round-trip 
 
 **IR-11:** Always check `git log -S` before writing new code. The correct code may have
 existed and been removed by a later commit (the RoPE lesson).
+
+**IR-12 (KM merges always first):** At the TOP of every DFS iteration,
+BEFORE popping any action, poll `results.jsonl` for merge-ready KM patches.
+If any exist, push them as `merge-op` with score 10 (highest). KM merges
+always take priority over DFS exploration — no exceptions. The Kernel
+Manager has already validated these patches through the 4-step IR-17
+pipeline (compile → correctness → multi-shape benchmark → adversarial).
+Deferring them wastes the KM's work and delays throughput gains.
+
+**IR-18 (completed_actions tracking):** Every entry in `completed_actions`
+MUST include `tput_before`, `tput_after`, `gain_pct`, and `timestamp`.
+Never omit these — timeline plots and session handoff depend on them.
+See "completed_actions Entry Schema" above.
+
+**IR-19 (BASE_DIR state sync):** After every KEEP decision and at session
+shutdown, sync `best_tput_per_gpu` to `$BASE_DIR/state.json`. This is the
+cross-session handoff contract. Without it, the next session starts from a
+stale sprint baseline and the throughput timeline has invisible gaps.
+
+**IR-13 (GPU lock):** Before starting the inference server, write
+`/tmp/.marathon_gpu_lock.json` with the GPUs being used. Remove it when the
+server is killed. The Kernel Manager reads this lock to find free GPUs for
+micro-benchmarks without contention. Schema:
+```json
+{
+  "holder": "orchestrator",
+  "gpus": [0],
+  "pid": 12345,
+  "since": "2026-04-21T18:00:00Z",
+  "purpose": "inference-server"
+}
+```
+Write helper (call after every server launch):
+```python
+import json, os, datetime
+def write_gpu_lock(gpus, server_pid):
+    lock = {"holder": "orchestrator", "gpus": list(gpus), "pid": server_pid,
+            "since": datetime.datetime.utcnow().isoformat() + "Z",
+            "purpose": "inference-server"}
+    with open("/tmp/.marathon_gpu_lock.json", "w") as f:
+        json.dump(lock, f)
+
+def release_gpu_lock():
+    try: os.remove("/tmp/.marathon_gpu_lock.json")
+    except FileNotFoundError: pass
+```
+Call `write_gpu_lock(list(range(TP)), pid)` after server start.
+Call `release_gpu_lock()` after `kill_server()`.
+
+**IR-25 (GPU time-share):** When `TP == GPU_COUNT` (all GPUs run the server),
+the Kernel Manager has no free GPUs for micro-benchmarks. The KM can request
+temporary exclusive GPU access by writing a `gpu_request.json` file. The
+orchestrator checks for this request during its DFS poll loop and, if found,
+temporarily kills the server to grant GPU access.
+
+**Protocol:**
+1. KM writes `$SESSION_DIR/kernel_manager/gpu_request.json` with `status: "pending"`
+2. Orchestrator sees it during GPU REQUEST POLL (DFS loop), kills the server,
+   calls `release_gpu_lock()`, sets request `status: "granted"`
+3. KM reads "granted", acquires lock (`holder: "kernel-manager"`), runs micro-benchmarks
+4. KM releases lock, sets request `status: "released"`
+5. Orchestrator reads "released", restarts the server, calls `write_gpu_lock()`,
+   deletes the request file
+
+**GPU request helpers (orchestrator side):**
+```python
+import json, os, time
+
+GPU_REQUEST_PATH = os.path.join(os.environ.get("SESSION_DIR", ""),
+                                "kernel_manager/gpu_request.json")
+
+def check_gpu_request():
+    """Check if KM has a pending GPU request. Returns the request dict or None."""
+    try:
+        with open(GPU_REQUEST_PATH) as f:
+            req = json.load(f)
+        if req.get("status") == "pending":
+            return req
+    except (FileNotFoundError, json.JSONDecodeError):
+        pass
+    return None
+
+def grant_gpu_request():
+    """Grant the pending GPU request (call after killing server + releasing lock)."""
+    try:
+        with open(GPU_REQUEST_PATH) as f:
+            req = json.load(f)
+        req["status"] = "granted"
+        req["granted_at"] = datetime.datetime.utcnow().isoformat() + "Z"
+        with open(GPU_REQUEST_PATH, "w") as f:
+            json.dump(req, f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        pass
+
+def wait_for_gpu_release(timeout_s=1800, poll_interval_s=15):
+    """Wait for KM to finish and set status to 'released'. Returns True if released.
+    Default timeout is 30min — the micro-benchmark MUST run, so we wait."""
+    elapsed = 0
+    while elapsed < timeout_s:
+        try:
+            with open(GPU_REQUEST_PATH) as f:
+                req = json.load(f)
+            if req.get("status") == "released":
+                return True
+        except (FileNotFoundError, json.JSONDecodeError):
+            return True  # file gone = KM done
+        time.sleep(poll_interval_s)
+        elapsed += poll_interval_s
+    return False  # timeout
+
+def cleanup_gpu_request():
+    """Remove the request file after server restart."""
+    try: os.remove(GPU_REQUEST_PATH)
+    except FileNotFoundError: pass
+```
+
+**GPU REQUEST POLL sequence (in DFS loop):**
+```
+req = check_gpu_request()
+if req:
+    log("GPU REQUEST: KM needs GPUs for kernel: " + req.get("kernel", "?"))
+    kill_server()
+    release_gpu_lock()
+    grant_gpu_request()
+    released = wait_for_gpu_release()  # 30min default — micro-benchmark must run
+    if not released:
+        log("WARNING: GPU request timed out after 30min, restarting server anyway")
+    cleanup_gpu_request()
+    start_server()  # normal server launch (calls write_gpu_lock internally)
+    # Next DFS iteration will re-benchmark if needed
+```
 
 ## Agent Creativity
 

--- a/marathon_optimization/marathon_harness/skills/actions/deep-kernel-analysis.md
+++ b/marathon_optimization/marathon_harness/skills/actions/deep-kernel-analysis.md
@@ -9,12 +9,65 @@ transforms opaque kernel names from profiler output into actionable optimization
 - List of top-N kernels by GPU time % (from `state.kernel_candidates`)
 - `state.kernel_dispatch_map` (initially empty — this action populates it)
 
+## Mandatory Scope (CRITICAL)
+
+You MUST analyze at least the **top 10 kernels by GPU%** from the profile.
+MIN_GPU_PCT = 2.0% — every kernel above this threshold gets full Steps 1-5.
+Do NOT stop after finding the first opportunity. The goal is a COMPREHENSIVE
+action stack, not a single fix.
+
+After analyzing individual kernels, you MUST also run Step 0 (Env Var Scan)
+to find framework-level dispatch flags that control entire kernel families.
+
 ## Procedure
 
-For **each** kernel consuming >MIN_GPU_PCT of GPU time, run Steps 1-5 below.
+### Step 0: Environment Variable Dispatch Scan (MANDATORY)
+
+Before individual kernel analysis, scan for framework env vars that control
+major kernel dispatch paths. These are the highest-impact, lowest-effort
+optimizations and are often missed by per-kernel analysis.
+
+```bash
+# a) Find ALL env vars that control kernel dispatch in the framework
+grep -rn "os.environ.get\|os.getenv\|envs\." \
+    $FRAMEWORK_ROOT/model_executor/layers/ \
+    $FRAMEWORK_ROOT/worker/ \
+    $FRAMEWORK_ROOT/compilation/ \
+    2>/dev/null | grep -i "rocm\|aiter\|triton\|gemm\|attn\|mfma\|fp4\|fp8\|buffer\|rope"
+
+# b) For EACH env var found, check:
+#    - Is it currently SET in the serve script?
+#    - What is its DEFAULT value?
+#    - What kernel path does it enable/disable?
+#    - What is the expected performance impact?
+
+# c) Common high-impact ROCm/vLLM env vars to check:
+#    VLLM_ROCM_USE_AITER_FP4_ASM_GEMM   — enables ASM FP4 GEMM (replaces Triton)
+#    VLLM_ROCM_FP8_MFMA_PAGE_ATTN       — enables MFMA page attention
+#    AMDGCN_USE_BUFFER_OPS              — enables buffer load/store ops
+#    AITER_CONFIG_FMOE                  — path to tuned MoE GEMM CSV
+#    AITER_CONFIG_GEMM_BF16             — path to tuned BF16 GEMM CSV
+#    VLLM_ROCM_USE_AITER_TRITON_ROPE    — Triton vs CK rope kernel
+#    CU_NUM                             — forces CU count for config lookup
+```
+
+For each unset or suboptimal env var, create a candidate action:
+```python
+{
+    "name": f"Enable {env_var}={recommended_value}",
+    "type": "env-var-dispatch",
+    "classification": "self-fix",
+    "score": gpu_pct_affected * 10,  # high score — low effort, high impact
+    "description": f"Set {env_var} in serve script to activate {path_description}",
+}
+```
+
+### Steps 1-5: Per-Kernel Analysis
+
+For **each** kernel consuming >MIN_GPU_PCT (2.0%) of GPU time, run Steps 1-5 below.
 This is the most detailed analysis in the Marathon — invest time here.
 
-### Step 1: Dispatch Path Trace
+### Step 1: Dispatch Path Trace (per kernel)
 
 Trace the full call chain from Python API to GPU kernel launch:
 
@@ -356,15 +409,23 @@ def _select_backends(analysis):
 ```
 
 ## Outputs
-- `state.kernel_dispatch_map` — fully populated for all top-N kernels
-- `state.action_stack` — enriched with:
+- `state.kernel_dispatch_map` — fully populated for all top-N kernels (at least 10)
+- `state.action_stack` — enriched with AT LEAST 5-10 candidates:
+  - **Env-var-dispatch** actions from Step 0 (highest priority — low effort, high impact)
   - **Self-fix** dispatch-fix actions (high priority, orchestrator handles directly)
+  - **Config-only** actions (tuned CSV loading, shape-specific configs)
   - **Kernel-manager-poll** placeholders (low priority, remind orchestrator to check results)
 - `state.dispatch_bugs_found` — list of dispatch routing issues found
 - `state.untuned_shapes` — list of kernel shapes using generic configs
 - `$RESULT_DIR/kernel_manager/work_queue.jsonl` — kernel targets for the Kernel Manager
 - `state.kernel_manager_targets_pushed` — count of targets pushed to work queue
 - Per-kernel analysis logged to `$RESULT_DIR/kernel_analysis/`
+
+## Validation Gate
+If action_stack has fewer than 5 candidates after deep analysis, the analysis
+is INCOMPLETE. Go back and analyze more kernels, check more env vars, look at
+the serve script for missing optimization flags. The profiler data should
+yield at least 5-10 actionable items for any non-trivially-optimized model.
 
 ## Heuristic Update
 

--- a/marathon_optimization/marathon_harness/skills/kernel-manager/SKILL.md
+++ b/marathon_optimization/marathon_harness/skills/kernel-manager/SKILL.md
@@ -43,16 +43,82 @@ LOOP forever:
      c. If oob-rewrite:
         i.   GIT ARCHAEOLOGY — check history before writing new code
         ii.  CHECK findings for prior guidance on this kernel
-        iii. DEEP OOB LOOP (up to 5 rounds):
-             - BUILD prompt with accumulated session_history
-             - DISPATCH to backends with engineered prompts
-             - COLLECT results (poll + download)
-             - LOCAL TEST — compile, correctness, micro-benchmark
-             - DEEP ANALYZE — not just pass/fail, but WHY it failed
-             - If crash/segfault: WRITE event to event_log.jsonl
-             - CHECK findings.jsonl for new Watchdog guidance
-             - BUILD next round with accumulated context
-        iv.  If all rounds exhausted: WRITE "exhausted" event
+        iii. ★ MANDATORY MULTI-ROUND PROTOCOL (up to 5 rounds) ★
+             You MUST follow this rigid step-by-step protocol for EVERY
+             oob-rewrite target. Do NOT freelance or shortcut.
+
+             FOR round_num = 1 to MAX_OOB_ROUNDS (5):
+
+               STEP A — SELECT backends for this round:
+                 - Round 1: dispatch to ALL available backends in parallel
+                 - Round 2+: prefer backends that produced the best result
+                   in prior rounds; also try any backend not yet tried
+                 - If OOB backends unavailable: write locally (you have
+                   full source access and a GPU)
+
+               STEP B — BUILD prompt with:
+                 - Full source file content (read from disk, not cached)
+                 - Model architecture: head_dim=64, hidden_size=2880,
+                   intermediate_size=2880, sliding_window=128, mxfp4 quant,
+                   128 experts top-4 MoE
+                 - Hardware constraints: gfx950 (MI355X), 304 CUs,
+                   VGPR limit=64 for 4-wave occupancy, fp8=e4m3fnuz
+                 - Trace shapes from the work queue entry
+                 - Watchdog findings for this kernel (from findings.jsonl)
+                 - ★ ALL session_history from prior rounds (MANDATORY from
+                   round 2+, see IR-18) — what was tried, what failed, WHY,
+                   and what constraints were discovered
+
+               STEP C — DISPATCH to selected backends:
+                 - If multiple OOB backends available: dispatch to ALL in
+                   parallel (do not sequential-try one at a time)
+                 - If writing locally: produce the kernel code yourself
+                 - Poll for results (OOB_POLL_INTERVAL_S=15, timeout=30min)
+
+               STEP D — COLLECT the best result:
+                 - Compare all backend responses
+                 - Prefer the one with actual compilable code (longest)
+                 - If multiple pass compile: keep all for testing
+
+               STEP E — RUN 4-step local test (IR-17):
+                 compile → correctness → micro-bench → adversarial
+                 Use find_free_gpu() / get_test_device() for GPU access
+
+               STEP F — IF ALL TESTS PASS:
+                 → Generate merge-ready patch
+                 → Write to results.jsonl with full micro_benchmark data
+                 → STOP (success — no need for more rounds)
+
+               STEP G — IF ANY TEST FAILS: DEEP ANALYZE the failure:
+                 DO NOT just record "failed". Analyze the failure mode:
+                 - COMPILE_FAIL: extract exact compiler error line, identify
+                   the constraint violated (e.g., unsupported intrinsic,
+                   max_vgprs exceeded, type mismatch)
+                 - CORRECTNESS_FAIL: identify WHICH output elements diverge,
+                   at what tolerance, for which shapes. Is it a precision
+                   issue or a logic bug?
+                 - REGRESSION: identify which shapes regressed and by how
+                   much. Is it occupancy-dependent? Does it regress only at
+                   large batch sizes?
+                 - SEGFAULT: capture crash log (first 2000 chars), write
+                   event to event_log.jsonl for Watchdog
+
+               STEP H — RECORD in session_history:
+                 {round_num, backend, outcome, error_analysis,
+                  constraints_used, micro_speedup (if any)}
+
+               STEP I — CHECK findings.jsonl for new Watchdog guidance
+                 that may have arrived during this round
+
+               STEP J — Feed failure analysis + discovered constraints
+                 into the NEXT round's prompt (Step B)
+
+             END FOR
+
+        iv.  If all 5 rounds exhausted without a PASS:
+             → WRITE "exhausted" event to event_log.jsonl with FULL
+               session_history so Watchdog + orch can see all attempts
+             → Write result with status: "failed" and session_history
      d. GENERATE merge-ready patch directory
      e. WRITE result to results.jsonl
   4. SLEEP 30s if no new work
@@ -482,6 +548,76 @@ Append to `results.jsonl` with status `merge-ready`, `failed`, or `no-improvemen
 
 ---
 
+## Backend-Specific Prompt Guidance
+
+Each OOB backend has different strengths. Tailor your prompt content
+and emphasis to the backend you're dispatching to.
+
+### GEAK (GPU Execution Agent — has a GPU)
+
+GEAK can compile, run, and benchmark kernels. Emphasize:
+- Provide the FULL source file to modify
+- Include exact `hipcc` / Triton compile commands
+- Include a benchmark harness snippet that GEAK can run directly
+- Include expected input/output shapes and dtypes
+- Ask GEAK to return both the kernel code AND benchmark numbers
+- Constraint emphasis: occupancy (VGPR budget), wavefront scheduling,
+  LDS usage, memory coalescing for gfx950
+
+### Codex (Code generation — no GPU)
+
+Codex excels at register-pressure-aware rewrites. Emphasize:
+- Focus prompt on register pressure and VGPR budget constraints
+- Specify exact target: `max_vgprs=64` for 4-wave occupancy on gfx950
+- Include ISA-level hints: `v_mfma_f32_*` instructions, `ds_read_b128`
+- Ask for LDS usage optimization and bank conflict avoidance
+- Codex CANNOT run the kernel — you MUST test locally after collecting
+
+### Claude OOB (Deep reasoning — no GPU)
+
+Claude is best for multi-file changes and deep algorithmic reasoning:
+- Use multi-turn conversation style (provide full context up front)
+- Include architectural reasoning: why this kernel matters, what the
+  dispatch chain looks like, what other components are affected
+- For framework-scheduling changes: include ALL affected files
+- For kernel fusion: describe the full dataflow graph
+- Claude will reason about trade-offs but CANNOT test — test locally
+
+### LLM Proxy (Generic model dispatch)
+
+Fallback for when other backends are unavailable:
+- Provide the most complete prompt possible (full source + constraints)
+- Simpler optimization targets work better (config changes, Triton)
+- Complex HIP kernels may need post-processing of the output
+
+---
+
+## Parallel Backend Dispatch
+
+When multiple OOB backends are available, dispatch to ALL of them in
+parallel for the same target. Do NOT sequential-try one backend at a time.
+
+```
+Round 1 dispatch strategy:
+  1. DISPATCH the same optimized prompt to GEAK, Codex, Claude, LLM in parallel
+  2. POLL all backends concurrently (OOB_POLL_INTERVAL_S=15)
+  3. COLLECT results as they arrive
+  4. Pick the BEST result (criteria: compiles > doesn't, passes correctness
+     > doesn't, highest micro-benchmark speedup)
+  5. If multiple candidates pass: test all locally, keep the fastest
+
+Round 2+ dispatch strategy:
+  1. Prefer backends that produced the closest-to-passing result in prior round
+  2. Also try any backend that hasn't been tried yet
+  3. Include session_history showing what other backends tried and failed
+  4. Feed the BEST prior result (even if failed) as a starting point
+```
+
+This maximizes the probability of finding a working optimization per round
+and minimizes wall-clock time (parallel vs sequential).
+
+---
+
 ## Constants
 
 | Constant | Value | Description |
@@ -520,9 +656,111 @@ orchestrator runs E2E after applying the merge-op.
 **IR-7:** Write results atomically. Always append full JSON lines; never leave
 partial writes in results.jsonl.
 
-**IR-8:** If the GPU is busy (server is running), skip micro-benchmark and mark
-result as `micro_benchmark: "deferred"`. The orchestrator will verify during
-integration after stopping the server.
+**IR-8:** If **all** GPUs are busy, try requesting temporary access before
+deferring (see IR-25 below). When `TP < GPU_COUNT`, use a free GPU directly
+(see `actions/local-test.md` `find_free_gpu()`). The server uses GPUs
+`0..TP-1`; remaining GPUs are available for micro-benchmarks. Read
+`/tmp/.marathon_gpu_lock.json` (if present) for the authoritative list of
+locked GPUs. Never default to device 0 without checking.
+
+**IR-25 (GPU time-share request):** When `find_free_gpu()` returns None (all
+GPUs locked by the inference server), request temporary exclusive GPU access
+from the orchestrator instead of immediately deferring. The orchestrator will
+kill the server during its next DFS poll to grant access.
+
+**Protocol:**
+1. Write `$SESSION_DIR/kernel_manager/gpu_request.json` with `status: "pending"`
+2. Poll every 30s for up to 30 minutes waiting for `status: "granted"`
+3. If granted: acquire the GPU lock (`holder: "kernel-manager"`), run
+   micro-benchmarks, then release the lock and set `status: "released"`
+4. The micro-benchmark MUST run — do NOT defer on timeout. If the
+   orchestrator has not granted after 30min, log a warning and retry
+   the request once. Only defer as a last resort after 60min total.
+
+**GPU request helpers (KM side):**
+```python
+import json, os, time, datetime
+
+GPU_LOCK_PATH = "/tmp/.marathon_gpu_lock.json"
+GPU_REQUEST_PATH = os.path.join(os.environ.get("SESSION_DIR", ""),
+                                "kernel_manager/gpu_request.json")
+
+def request_gpu_access(kernel_name, estimated_duration_s=300):
+    """Request exclusive GPU access from the orchestrator.
+    Writes a pending request, polls for grant, returns (device, reason)."""
+    req = {"status": "pending", "requester": "kernel-manager",
+           "kernel": kernel_name,
+           "since": datetime.datetime.utcnow().isoformat() + "Z",
+           "estimated_duration_s": estimated_duration_s}
+    os.makedirs(os.path.dirname(GPU_REQUEST_PATH), exist_ok=True)
+    with open(GPU_REQUEST_PATH, "w") as f:
+        json.dump(req, f)
+
+    # Try twice: 30min initial + 30min retry = 60min max
+    for attempt in range(2):
+        if attempt > 0:
+            # Re-write pending request for retry
+            req["since"] = datetime.datetime.utcnow().isoformat() + "Z"
+            req["attempt"] = attempt + 1
+            with open(GPU_REQUEST_PATH, "w") as f:
+                json.dump(req, f)
+        for _ in range(60):  # 60 * 30s = 30min per attempt
+            time.sleep(30)
+            try:
+                with open(GPU_REQUEST_PATH) as f:
+                    r = json.load(f)
+                if r.get("status") == "granted":
+                    write_gpu_lock([0], os.getpid())
+                    os.environ["HIP_VISIBLE_DEVICES"] = "0"
+                    os.environ["CUDA_VISIBLE_DEVICES"] = "0"
+                    return "cuda:0", "GPU_GRANTED by orchestrator"
+            except (FileNotFoundError, json.JSONDecodeError):
+                pass
+    # 60min total with no grant — last resort defer
+    try: os.remove(GPU_REQUEST_PATH)
+    except FileNotFoundError: pass
+    return None, "GPU_REQUEST_TIMEOUT — orchestrator did not grant in 60min"
+
+def write_gpu_lock(gpus, pid):
+    lock = {"holder": "kernel-manager", "gpus": list(gpus), "pid": pid,
+            "since": datetime.datetime.utcnow().isoformat() + "Z",
+            "purpose": "micro-benchmark"}
+    with open(GPU_LOCK_PATH, "w") as f:
+        json.dump(lock, f)
+
+def release_gpu_lock():
+    try: os.remove(GPU_LOCK_PATH)
+    except FileNotFoundError: pass
+
+def release_gpu_after_benchmark():
+    """Release GPU lock and signal orchestrator to restart server."""
+    release_gpu_lock()
+    try:
+        with open(GPU_REQUEST_PATH) as f:
+            r = json.load(f)
+        r["status"] = "released"
+        r["released_at"] = datetime.datetime.utcnow().isoformat() + "Z"
+        with open(GPU_REQUEST_PATH, "w") as f:
+            json.dump(r, f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        pass
+```
+
+**Usage in the local-test flow:**
+```
+dev, reason = find_free_gpu()
+if dev is None:
+    # No free GPU — request temporary access
+    dev, reason = request_gpu_access(kernel_name)
+    if dev is None:
+        # Timeout — defer
+        result["micro_benchmark"] = "deferred"
+        result["micro_benchmark_reason"] = reason
+    else:
+        # Got access — run benchmarks, then release
+        run_micro_benchmarks(dev, ...)
+        release_gpu_after_benchmark()
+```
 
 **IR-9:** Write an event to `event_log.jsonl` for every crash, segfault, and
 exhausted target. Include the full session_history so the Watchdog has context.
@@ -534,6 +772,94 @@ exhausted target. Include the full session_history so the Watchdog has context.
 The accumulated context of what was tried and why it failed is the most
 valuable input to the next attempt.
 
+**IR-15 (GPU lock):** Before running micro-benchmarks, read the GPU lock file
+at `/tmp/.marathon_gpu_lock.json`. The orchestrator writes this file before
+starting the inference server. Schema:
+```json
+{
+  "holder": "orchestrator",
+  "gpus": [0, 1],
+  "pid": 12345,
+  "since": "2026-04-21T18:00:00Z",
+  "purpose": "inference-server"
+}
+```
+Use `find_free_gpu()` from `actions/local-test.md` which reads this lock.
+When running a micro-benchmark, set `HIP_VISIBLE_DEVICES` /
+`CUDA_VISIBLE_DEVICES` to the free device so torch targets the correct GPU.
+
+**IR-16 (merge-ready status):** When writing to `results.jsonl`, use
+`status: "merge-ready"` for any patch that has a complete
+`merge_ready/<id>/` directory with `metadata.json` — regardless of whether
+the kernel was generated by OOB backends or locally. The `generation_method`
+field (`oob-rewrite` vs `local_kernel_write`) distinguishes provenance.
+Use `status: "failed"` only when no usable patch was produced. The
+orchestrator's MERGE-OP POLL filters on `status == "merge-ready"` — any
+other status (e.g. `patch_generated_locally`) will be silently ignored.
+
+**IR-18 (session_history mandatory in every prompt from round 2+):**
+From round 2 onward, EVERY prompt to an OOB backend or local write MUST
+include the accumulated session_history showing:
+  - What was tried in prior rounds
+  - Which backend was used
+  - The exact outcome (COMPILE_FAIL, CORRECTNESS_FAIL, REGRESSION, etc.)
+  - The error analysis (WHY it failed, not just THAT it failed)
+  - What constraints were discovered (e.g., max_vgprs=64 violated)
+  - What micro-benchmark speedup was achieved (if any)
+Use `format_session_history(task_id)` to generate the history block.
+This is the SINGLE MOST VALUABLE input to the next attempt — without it,
+the model repeats the same mistakes. Omitting session_history in round 2+
+is a protocol violation. If you have nothing to include (round 1), say
+"This is the first optimization attempt for this kernel."
+
+**IR-17 (MANDATORY 4-step local test gate — NO EXCEPTIONS):**
+A kernel may ONLY be written to results.jsonl with `status: "merge-ready"`
+if it has passed ALL 4 steps of the local test pipeline from
+`actions/local-test.md`. A "gpu_smoke_pass" or "compiles OK" is NOT
+sufficient. The 4 steps are:
+
+  **Step 1 — COMPILE:** The kernel must compile without errors.
+    - Triton: `exec(compile(source, filename, "exec"), ns)` in isolated ns
+    - HIP/C++: `hipcc -O3 --amdgpu-target=gfx950` exits 0
+    - Fail → `status: "failed"`, feed error to next OOB round
+
+  **Step 2 — CORRECTNESS:** Run the kernel on a FREE GPU (use
+  `get_test_device()` from `actions/local-test.md`) and compare output
+  against the ORIGINAL kernel or a PyTorch reference.
+    - Use `torch.allclose(out, ref, atol=1e-2, rtol=1e-2)`
+    - Test with at least 3 different input shapes/sizes
+    - If GPU busy and ALL GPUs locked: defer (PASS-DEFERRED), do NOT skip
+    - Fail → `status: "failed"`, feed error to next OOB round
+
+  **Step 3 — MICRO-BENCHMARK:** Time the optimized kernel vs the original
+  or a baseline on the same free GPU. Test at MULTIPLE batch sizes
+  (e.g. B=1,4,16,64) to catch occupancy-dependent regressions.
+    - Use `torch.cuda.Event(enable_timing=True)` with warmup (20 iters)
+      and measurement (200 iters)
+    - Compute per-shape speedup; require avg_speedup > 1.05x AND no
+      single shape regresses below 0.95x
+    - Record `micro_benchmark: {avg_speedup, per_shape: [...], latency_us}`
+      in the result
+    - If GPU busy: defer (PASS-DEFERRED), but the result MUST say
+      `micro_benchmark: "deferred"` — never omit the field
+    - Fail (< 1.05x or regression) → `status: "failed"`, include perf data
+
+  **Step 4 — ADVERSARIAL (optional but recommended):** Test edge cases:
+  zero-length inputs, maximum shapes, NaN/Inf inputs. Skip only if the
+  kernel type doesn't support it (e.g. config-only patches).
+
+  **Only when ALL required steps PASS** may you write `status: "merge-ready"`.
+  The result entry MUST include:
+    - `micro_benchmark: {avg_speedup: X.XX, per_shape: [...]}` (real data)
+    - `correctness: "passed"` (not "gpu_smoke_pass")
+    - `patch_type`, `target_file`, `rollback_command`, `apply_instructions`
+
+  A result with `status: "merge-ready"` but missing `micro_benchmark` data
+  will be DISCARDED by the orchestrator. This wastes everyone's time.
+  If you cannot run the benchmark (GPU busy), use `status: "merge-ready"`
+  with `micro_benchmark: "deferred"` — this is acceptable. But NEVER
+  write `merge-ready` with no micro_benchmark field at all.
+
 ## Autonomy
 
 Execute autonomously. No human confirmation needed for:
@@ -541,7 +867,7 @@ Execute autonomously. No human confirmation needed for:
 - Dispatching to OOB backends (GEAK, Codex, Claude, LLM Proxy)
 - Running git commands (read-only: log, show, diff)
 - Local compilation testing (Triton, hipcc)
-- Micro-benchmarking (when GPU is available)
+- Micro-benchmarking on free GPUs (check lock, set HIP_VISIBLE_DEVICES)
 - Editing source files to prepare patches
 - Writing events to event_log.jsonl (for Watchdog consumption)
 - Reading findings from findings.jsonl (from Watchdog)

--- a/marathon_optimization/marathon_harness/skills/kernel-manager/actions/local-test.md
+++ b/marathon_optimization/marathon_harness/skills/kernel-manager/actions/local-test.md
@@ -131,24 +131,182 @@ def clear_aiter_jit_cache(kernel_name):
 
 ## Step 2: Correctness Check
 
-**Requires GPU access.** If the inference server is running on the GPU, skip this step
-and mark as `correctness: "deferred"`.
+**Requires GPU access.** If the inference server is running on **all** GPUs, skip
+this step and mark as `correctness: "deferred"`. When `TP < GPU_COUNT`, use a free
+GPU via `get_test_device()` — do NOT default to device 0 (the server's GPU).
 
 ### GPU Availability Check
 
+The inference server uses GPUs `0..TP-1`. When `TP < GPU_COUNT`, the remaining
+GPUs are free for micro-benchmarks. Always check **all** devices — not just
+device 0 — and use the GPU lock file if present.
+
 ```python
-import torch
+import torch, os, json
+
+GPU_LOCK_PATH = "/tmp/.marathon_gpu_lock.json"
+
+def _read_gpu_lock():
+    """Read the GPU lock file to find which GPUs the orchestrator is using."""
+    try:
+        with open(GPU_LOCK_PATH) as f:
+            lock = json.load(f)
+        if lock.get("holder") and lock.get("gpus"):
+            return set(lock["gpus"])
+    except (FileNotFoundError, json.JSONDecodeError, KeyError):
+        pass
+    return None
+
+def find_free_gpu():
+    """Find a GPU not used by the inference server.
+
+    Returns (device_id, reason) — device_id is an int if a free GPU exists,
+    or None if all GPUs are busy.
+
+    Resolution order:
+      1. Read /tmp/.marathon_gpu_lock.json (authoritative, written by orch)
+      2. Fall back to TP env var (server uses devices 0..TP-1)
+      3. Fall back to per-device memory probe
+    """
+    total_gpus = torch.cuda.device_count()
+    if total_gpus == 0:
+        return None, "NO_GPU — torch sees 0 devices"
+
+    locked = _read_gpu_lock()
+    if locked is not None:
+        for dev in range(total_gpus):
+            if dev in locked:
+                continue
+            mem_free, mem_total = torch.cuda.mem_get_info(dev)
+            if (mem_total - mem_free) / mem_total < 0.20:
+                return dev, f"OK — GPU {dev} free (lock says {sorted(locked)} busy)"
+        return None, f"ALL_LOCKED — lock={sorted(locked)}, all others >20% used"
+
+    server_tp = int(os.environ.get("TP", str(total_gpus)))
+    server_gpus = set(range(min(server_tp, total_gpus)))
+
+    for dev in range(total_gpus):
+        if dev in server_gpus:
+            continue
+        mem_free, mem_total = torch.cuda.mem_get_info(dev)
+        if (mem_total - mem_free) / mem_total < 0.20:
+            return dev, f"OK — GPU {dev} free (TP={server_tp}, devices {sorted(server_gpus)} assumed busy)"
+
+    for dev in range(total_gpus):
+        mem_free, mem_total = torch.cuda.mem_get_info(dev)
+        if (mem_total - mem_free) / mem_total < 0.20:
+            return dev, f"OK — GPU {dev} free (all-scan, server may be down)"
+
+    return None, f"GPU_BUSY — all {total_gpus} devices >20% VRAM used"
 
 def gpu_available():
-    """Check if the GPU is free for testing."""
+    """Legacy compat wrapper. Returns True if any GPU is free."""
+    dev, _ = find_free_gpu()
+    return dev is not None
+
+def get_test_device(kernel_name=None):
+    """Return the device string for torch tensors during testing.
+
+    Sets HIP_VISIBLE_DEVICES / CUDA_VISIBLE_DEVICES so torch operations
+    target the free GPU, not the server's GPU.
+
+    Resolution order:
+      1. Try find_free_gpu() for an immediately available GPU
+      2. If none free, request temporary access from orchestrator (IR-25)
+      3. If request times out after 60min total (2 attempts), return None
+    """
+    dev, reason = find_free_gpu()
+    if dev is not None:
+        os.environ["HIP_VISIBLE_DEVICES"] = str(dev)
+        os.environ["CUDA_VISIBLE_DEVICES"] = str(dev)
+        return "cuda:0", reason
+
+    # No free GPU — request temporary access from orchestrator
+    dev, reason = request_gpu_access(kernel_name or "unknown")
+    if dev is not None:
+        return dev, reason  # request_gpu_access already set env vars
+    return None, reason
+
+import time, datetime
+
+GPU_REQUEST_PATH = os.path.join(os.environ.get("SESSION_DIR", ""),
+                                "kernel_manager/gpu_request.json")
+
+def request_gpu_access(kernel_name, estimated_duration_s=300):
+    """Request exclusive GPU access from the orchestrator (IR-25).
+
+    Writes a pending request, polls for the orchestrator to grant it
+    (by killing the inference server), then returns a device.
+
+    Returns (device_str, reason) — device_str is "cuda:0" if granted,
+    or None if the request timed out.
+    """
+    if not GPU_REQUEST_PATH or GPU_REQUEST_PATH.startswith("/kernel_manager"):
+        return None, "GPU_REQUEST_SKIP — SESSION_DIR not set"
+
+    req = {"status": "pending", "requester": "kernel-manager",
+           "kernel": kernel_name,
+           "since": datetime.datetime.utcnow().isoformat() + "Z",
+           "estimated_duration_s": estimated_duration_s}
+    os.makedirs(os.path.dirname(GPU_REQUEST_PATH), exist_ok=True)
+    with open(GPU_REQUEST_PATH, "w") as f:
+        json.dump(req, f)
+
+    # Try twice: 30min initial + 30min retry = 60min max.
+    # The micro-benchmark MUST run — do not give up easily.
+    for attempt in range(2):
+        if attempt > 0:
+            req["since"] = datetime.datetime.utcnow().isoformat() + "Z"
+            req["attempt"] = attempt + 1
+            with open(GPU_REQUEST_PATH, "w") as f:
+                json.dump(req, f)
+        for _ in range(60):  # 60 * 30s = 30min per attempt
+            time.sleep(30)
+            try:
+                with open(GPU_REQUEST_PATH) as f:
+                    r = json.load(f)
+                if r.get("status") == "granted":
+                    _write_gpu_lock_km([0], os.getpid())
+                    os.environ["HIP_VISIBLE_DEVICES"] = "0"
+                    os.environ["CUDA_VISIBLE_DEVICES"] = "0"
+                    return "cuda:0", "GPU_GRANTED by orchestrator"
+            except (FileNotFoundError, json.JSONDecodeError):
+                pass
+    # 60min total — last resort
+    try: os.remove(GPU_REQUEST_PATH)
+    except FileNotFoundError: pass
+    return None, "GPU_REQUEST_TIMEOUT — orchestrator did not grant in 60min"
+
+def _write_gpu_lock_km(gpus, pid):
+    """Write GPU lock as kernel-manager (temporary holder during benchmarks)."""
+    lock = {"holder": "kernel-manager", "gpus": list(gpus), "pid": pid,
+            "since": datetime.datetime.utcnow().isoformat() + "Z",
+            "purpose": "micro-benchmark"}
+    with open(GPU_LOCK_PATH, "w") as f:
+        json.dump(lock, f)
+
+def _release_gpu_lock_km():
+    """Release GPU lock held by kernel-manager."""
+    try: os.remove(GPU_LOCK_PATH)
+    except FileNotFoundError: pass
+
+def release_gpu_after_benchmark():
+    """Release GPU lock and signal orchestrator to restart its server.
+
+    Call this after ALL micro-benchmarks are done for the current kernel.
+    The orchestrator polls gpu_request.json and will restart the inference
+    server when it sees status: 'released'.
+    """
+    _release_gpu_lock_km()
     try:
-        mem_free, mem_total = torch.cuda.mem_get_info()
-        usage_pct = (mem_total - mem_free) / mem_total * 100
-        if usage_pct > 20:
-            return False  # server likely running
-        return True
-    except RuntimeError:
-        return False
+        with open(GPU_REQUEST_PATH) as f:
+            r = json.load(f)
+        r["status"] = "released"
+        r["released_at"] = datetime.datetime.utcnow().isoformat() + "Z"
+        with open(GPU_REQUEST_PATH, "w") as f:
+            json.dump(r, f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        pass
 ```
 
 ### Correctness Verification
@@ -224,7 +382,10 @@ def verify_correctness(original_source, optimized_source, test_shapes, dtype=tor
 
 ## Step 3: Micro-Benchmark
 
-**Requires GPU access.** If GPU is busy, mark as `micro_benchmark: "deferred"`.
+**Requires GPU access.** The micro-benchmark MUST run.
+When `TP < GPU_COUNT`, use a free GPU via `get_test_device()`.
+When `TP == GPU_COUNT`, request temporary GPU access from the orchestrator (IR-25),
+which will wait up to 60min total (2 × 30min attempts). Only defer as a last resort.
 
 ### Multi-Shape Benchmark
 
@@ -443,7 +604,17 @@ Putting it all together — the complete test pipeline for a single kernel resul
 
 ```python
 def run_full_test(original_source, optimized_source, test_shapes, kernel_type, kernel_name=None):
-    """Run the complete test pipeline. Returns a test report dict."""
+    """Run the complete test pipeline. Returns a test report dict.
+
+    GPU access strategy (IR-25):
+      1. Try find_free_gpu() for an immediately available GPU
+      2. If none free, request_gpu_access() asks the orchestrator to
+         temporarily kill the server and grant GPU time
+      3. Waits up to 60min (2 × 30min attempts) — micro-benchmark must run
+      4. If GPUs were borrowed, release_gpu_after_benchmark() signals
+         the orchestrator to restart its server
+      5. Only defer as absolute last resort (60min timeout with no grant)
+    """
     report = {
         "compilation": None,
         "correctness": None,
@@ -451,13 +622,14 @@ def run_full_test(original_source, optimized_source, test_shapes, kernel_type, k
         "verdict": None,
         "feedback": None,
         "caches_cleared": [],
+        "gpu_borrowed": False,
     }
     
-    # Step 1: Compilation
+    # Step 1: Compilation (no GPU needed)
     if kernel_type in ("triton", "inductor-triton", "triton-source"):
         comp_ok, comp_msg = check_triton_compilation(optimized_source)
     elif kernel_type in ("cpp-hip", "hip-kernel"):
-        comp_ok, comp_msg = check_hip_compilation(optimized_source)  # source is a file path
+        comp_ok, comp_msg = check_hip_compilation(optimized_source)
     else:
         comp_ok, comp_msg = True, "OK — Python source (no compilation needed)"
     
@@ -467,19 +639,27 @@ def run_full_test(original_source, optimized_source, test_shapes, kernel_type, k
         report["feedback"] = build_feedback(report["compilation"], None, None)
         return report
     
-    # Step 2: Correctness (if GPU available)
-    if gpu_available():
+    # Acquire GPU for steps 2-3 (uses IR-25 request if no free GPU)
+    device, gpu_reason = get_test_device(kernel_name)
+    gpu_ok = device is not None
+    borrowed = "GPU_GRANTED" in gpu_reason if gpu_ok else False
+    report["gpu_borrowed"] = borrowed
+    
+    # Step 2: Correctness (requires GPU)
+    if gpu_ok:
         corr_ok, corr_msg = verify_correctness(original_source, optimized_source, test_shapes)
         report["correctness"] = (corr_ok, corr_msg)
         if not corr_ok:
             report["verdict"] = "FAIL-CORRECTNESS"
             report["feedback"] = build_feedback(report["compilation"], report["correctness"], None)
+            if borrowed:
+                release_gpu_after_benchmark()
             return report
     else:
-        report["correctness"] = (None, "DEFERRED — GPU busy")
+        report["correctness"] = (None, f"DEFERRED — {gpu_reason}")
     
-    # Step 3: Micro-benchmark (if GPU available)
-    if gpu_available():
+    # Step 3: Micro-benchmark (requires GPU)
+    if gpu_ok:
         speedup, details = micro_benchmark(original_source, optimized_source, test_shapes)
         report["micro_benchmark"] = (speedup, details)
         if speedup is None:
@@ -490,18 +670,26 @@ def run_full_test(original_source, optimized_source, test_shapes, kernel_type, k
                 report["feedback"] = build_feedback(
                     report["compilation"], report["correctness"], report["micro_benchmark"]
                 )
+                if borrowed:
+                    release_gpu_after_benchmark()
                 return report
         elif speedup < 1.05:
             report["verdict"] = "FAIL-PERF"
             report["feedback"] = build_feedback(
                 report["compilation"], report["correctness"], report["micro_benchmark"]
             )
+            if borrowed:
+                release_gpu_after_benchmark()
             return report
         else:
             report["verdict"] = "PASS"
     else:
-        report["micro_benchmark"] = (None, "DEFERRED — GPU busy")
+        report["micro_benchmark"] = (None, f"DEFERRED — {gpu_reason}")
         report["verdict"] = "PASS-DEFERRED"
+    
+    # Release borrowed GPU back to orchestrator (triggers server restart)
+    if borrowed:
+        release_gpu_after_benchmark()
     
     # Step 4: Clear caches for the patch type
     patch_type_map = {

--- a/marathon_optimization/marathon_harness/skills/scripts/common.sh
+++ b/marathon_optimization/marathon_harness/skills/scripts/common.sh
@@ -119,21 +119,31 @@ print("Trace integrity: OK")
 ' 2>&1 || return 1
 }
 
-# Require sufficient free GPU memory on device 0, retrying with kill_server between attempts.
-# Uses globals: FRAMEWORK, GPU_FREE_THRESHOLD (default 0.85), GPU_CHECK_RETRIES (default 2).
+# Require sufficient free GPU memory on devices 0..TP-1 (the server's GPUs),
+# retrying with kill_server between attempts.
+# Uses globals: FRAMEWORK, TP, GPU_FREE_THRESHOLD (default 0.85), GPU_CHECK_RETRIES (default 2).
 check_gpu_memory() {
     local thresh="${GPU_FREE_THRESHOLD:-0.85}"
     local retries="${GPU_CHECK_RETRIES:-2}"
+    local tp="${TP:-1}"
     local try
     for try in $(seq 1 "$retries"); do
-        if GPU_FREE_THRESHOLD="$thresh" python3 -c "
-import torch
-import os
+        if GPU_FREE_THRESHOLD="$thresh" TP_CHECK="$tp" python3 -c "
+import torch, os
 thresh = float(os.environ.get('GPU_FREE_THRESHOLD', '0.85'))
-f, t = torch.cuda.mem_get_info(0)
-ratio = f / t
-print(f'GPU memory: {f/1024**3:.1f}GB free / {t/1024**3:.1f}GB total ({ratio*100:.1f}% free)')
-assert ratio > thresh, f'GPU not free enough: {ratio*100:.1f}% <= {thresh*100:.1f}% required'
+tp = int(os.environ.get('TP_CHECK', '1'))
+total_gpus = torch.cuda.device_count()
+check_devs = list(range(min(tp, total_gpus)))
+all_ok = True
+for dev in check_devs:
+    f, t = torch.cuda.mem_get_info(dev)
+    ratio = f / t
+    status = 'OK' if ratio > thresh else 'BUSY'
+    print(f'GPU {dev}: {f/1024**3:.1f}GB free / {t/1024**3:.1f}GB total ({ratio*100:.1f}% free) [{status}]')
+    if ratio <= thresh:
+        all_ok = False
+assert all_ok, f'Not all server GPUs (0..{tp-1}) are free (threshold {thresh*100:.0f}%)'
+print(f'All {len(check_devs)} server GPUs free.')
 " 2>&1; then
             return 0
         fi


### PR DESCRIPTION
Key changes:
- **Stage-gated protocol (IR-20)**: Enforces strict ordering (warm-start → profile → deep analysis → build stack → DFS). Each stage must be recorded in `state.json` before the next can begin. Prevents the orchestrator from jumping into DFS without profiling.
- **Deep analysis overhaul**: Mandatory env-var dispatch scan + top-10 kernel analysis (min 2% GPU time). Must produce at least 5-10 candidate actions. Added Step 0 (env var scan) to catch high-impact, low-effort flags (FP4_ASM, MFMA_PAGE_ATTN, CONFIG_FMOE, etc.) that were previously missed.
- **Bulk KM dispatch**: After deep analysis, ALL OOB-rewrite targets are dispatched to the KM work queue in bulk — not trickled one-at-a-time during DFS. Maximizes KM parallelism.
- **Merge-op priority (score 10)**: KM results with validated micro-benchmarks are always popped first in the DFS loop. No DFS exploration until all merge-ops are processed.
- **GPU time-sharing (IR-25)**: When TP == GPU_COUNT (all GPUs used by the server), the KM can request temporary exclusive GPU access via `gpu_request.json`. The orchestrator kills the server, grants access, waits up to 30min for the KM to finish, then restarts. KM retries once if not granted (60min total). Micro-benchmarks must run — defer only as a last resort.
- **GPU lock protocol (IR-15)**: File-based lock at `/tmp/.marathon_gpu_lock.json` lets KM discover which GPUs are free without guessing. `find_free_gpu()` reads the lock, falls back to TP-based inference, then to memory probing.
- **Multi-shape micro-benchmarking**: Full 4-step local test (compile → correctness → micro-bench → adversarial) with `get_test_device()` handling GPU acquisition. `run_full_test()` properly releases borrowed GPUs on all exit paths.
- **Re-profile cadence + stack-empty rule (IR-24)**: Re-profiles every 3 hours and when the action stack empties. Empty stack triggers immediate re-analysis instead of exiting the loop.
- **Backend-specific prompt guidance**: Tailored dispatch strategies for GEAK, Codex, Claude, and LLM proxy backends, with parallel dispatch in round 1.
- **Vendor kernel config skill**: New skill for managing framework-level kernel dispatch configurations (aiter, CK, Triton routing).
