### PR TITLE
Feature/generic gpu optimization

### DIFF
--- a/.cursor/skills/generic-gpu-optimization/README.md
+++ b/.cursor/skills/generic-gpu-optimization/README.md
@@ -1,0 +1,102 @@
+# Generic GPU Optimization Skill
+
+A point-and-shoot performance optimization skill for any GPU codebase on AMD ROCm.
+Unlike `inference-optimization` and `training-optimization`, this skill makes no
+assumption about the framework. It auto-detects what your repo is and runs the
+Hyperloom DFS optimization loop against it.
+
+## What it can handle
+
+| Project shape | Detected as | Build | Bench | Tests |
+|---|---|---|---|---|
+| C++/HIP library with CMake + Google Benchmark | `hip-cmake-bench` | `cmake --build` | `bench --benchmark_format=json` | `ctest` |
+| C++/HIP library with CMake + Catch2 | `hip-cmake-bench` | `cmake --build` | parsed from `[[bench]]` tag | `ctest` |
+| Standalone PyTorch script with `if __name__ == "__main__"` and timing | `pytorch-script` | `pip install -e .` (if pyproject) | direct `python` invocation | `pytest` (if `tests/`) |
+| Triton kernel collection with `bench.py` / `benchmark.py` | `triton-collection` | `pip install -e .` | `python bench.py` | `pytest tests/` |
+| HPC application with `--bench` mode | `hpc-app` | `make` or `cmake` | `./app --bench` | optional |
+
+If detection comes back `unknown` the agent will ask you for the build, bench,
+and (optional) test commands once, then proceed.
+
+## Quick Start
+
+### Bootstrap the skill into your target repo
+
+From the Hyperloom root:
+
+```bash
+./scripts/optimize_repo.sh /path/to/your/gpu/repo
+```
+
+This copies the skill, the `mcp.json`, and an `.env.template` into
+`<your-repo>/.cursor/`. Edit `<your-repo>/.env` to set `AK_YOUR_API_KEY`.
+
+### Run from Cursor
+
+Open `<your-repo>` in Cursor with the GEAK + OOB MCPs enabled, then:
+
+```
+@.cursor/skills/generic-gpu-optimization/SKILL.md
+Optimize this repo for MI355X.
+```
+
+The agent runs setup → detect → build → baseline → correctness → profile → loop.
+
+### Override what the agent picks up
+
+```
+@.cursor/skills/generic-gpu-optimization/SKILL.md
+Optimize this repo.
+BENCH_COMMAND: ./build/bench/MATRIX_BENCH --benchmark_filter=select_k --benchmark_format=json
+TEST_COMMAND: ctest -R MATRIX_TEST --output-on-failure
+GPU: MI300X
+TIME_BUDGET_MIN: 60
+Try at least env-vars and one kernel rewrite.
+```
+
+Anything you specify wins over auto-detection.
+
+## Worked Example: hipRAFT
+
+```
+@.cursor/skills/generic-gpu-optimization/SKILL.md
+Optimize hipRAFT select_k on MI300X.
+
+REPO_ROOT: /home/gpinkert/projects/rocm-ds/hipRaft
+BENCH_TARGET: select_k
+GPU: MI300X (gfx942)
+```
+
+Detect will find `cpp/CMakeLists.txt`, `cpp/bench/prims/matrix/select_k.cu`,
+`cpp/tests/`, and classify the project as `hip-cmake-bench`. It will build via
+`./build.sh bench-prims`, run
+`./cpp/build/release/bench/prims/MATRIX_BENCH --benchmark_filter=select_k
+--benchmark_format=json` for the metric, and gate every change with
+`ctest -R MATRIX_TEST`.
+
+## What the agent tries
+
+| Category | Examples |
+|---|---|
+| Env vars | `HSA_ENABLE_SDMA`, `GPU_MAX_HW_QUEUES`, `HIP_FORCE_DEV_KERNARG`, `HSA_FORCE_FINE_GRAIN_PCIE`, `HIP_LAUNCH_BLOCKING=0` |
+| Compile flags | `-O3` vs `-O2`, `-ffast-math`, `--offload-arch=gfx950`, `-mllvm -amdgpu-early-inline-all`, `-DNDEBUG`, `-DCMAKE_HIP_ARCHITECTURES=…` |
+| Kernel rewrites (GEAK) | Hot HIP `__global__` or Triton kernel sent to GEAK MCP, validated against tests |
+| Code patches | Targeted edits suggested by profile (e.g. fuse two passes, change launch config) |
+| torch.compile | If `pytorch-script` and the workload is amenable |
+
+## Output
+
+- `$RESULT_DIR/results.tsv` — every attempt with metric, status, description
+- `$RESULT_DIR/optimization_report.md` — final report with what worked and why
+- `$RESULT_DIR/patches/` — all kept code patches, applicable to clean checkout
+- `$RESULT_DIR/kept_env.sh` — sourceable file with all kept env vars
+- `$RESULT_DIR/kept_cmake.txt` — list of kept CMake/compile flag overrides
+
+## Limitations
+
+- TraceLens agentic analysis only runs if the project has a PyTorch trace. For
+  C++/HIP projects the agent uses `rocprofv3` and parses kernel times directly.
+- If your benchmark prints results in a non-standard format, you may need to
+  point the agent at the metric line (`BENCH_METRIC_REGEX`).
+- Multi-GPU correctness gating relies on the project's existing test suite; the
+  skill does not invent distributed correctness tests.

--- a/.cursor/skills/generic-gpu-optimization/SKILL.md
+++ b/.cursor/skills/generic-gpu-optimization/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: generic-gpu-optimization
+description: |
+  Autonomous DFS-guided performance optimization for arbitrary GPU codebases on AMD
+  ROCm hardware (MI300X / MI325X / MI355X). Works on any repo that has a buildable
+  GPU workload and a way to measure runtime — does NOT require an inference server,
+  Primus/Megatron, or any specific framework. Auto-detects build system, benchmark
+  harness, correctness tests, and kernel languages (HIP, Triton, CUDA->HIP, SYCL,
+  PyTorch). Submits hot kernels to the GEAK MCP for AI-driven kernel rewrites.
+globs:
+  - "**/CMakeLists.txt"
+  - "**/pyproject.toml"
+  - "**/setup.py"
+  - "**/build.sh"
+  - "**/*.hip"
+  - "**/*.cu"
+  - "**/*.cuh"
+  - "**/triton*"
+---
+
+# Generic GPU Optimization — DFS Orchestrator
+
+## When to Use This Skill
+
+Use this skill when the user points you at a repository containing GPU code and
+asks you to make it faster, but the project is **not** a known inference server
+(SGLang/vLLM) or training stack (Primus/Megatron). Examples:
+
+- A C++/HIP library with Google Benchmark or Catch2 micro-benchmarks (e.g. hipRAFT,
+  rocPRIM, rocSPARSE, custom kernel libraries)
+- A standalone PyTorch script that runs a forward/backward loop
+- A Triton kernel collection with a Python harness
+- An HPC application with a `--bench` mode
+- A research codebase with a `benchmarks/` or `bench/` directory
+
+If the repo IS a SGLang/vLLM server use `inference-optimization`. If it is
+Primus/Megatron training use `training-optimization`. Otherwise: this skill.
+
+## Hard Constraints
+
+1. **Correctness must not regress.** If the project ships tests (ctest, pytest,
+   gtest, Catch2, unittest), they MUST pass after every kept change. If no tests
+   exist, fall back to comparing benchmark numerical output (golden file) before
+   accepting a patch.
+2. **Build must remain reproducible.** Every change is recorded as either a
+   compile-flag override, an environment variable, or a code patch. Nothing is
+   accepted that cannot be re-applied to a clean checkout.
+3. **One change per attempt.** Even though the agent can think in groups, each
+   attempt isolates a single variable so attribution is clean.
+
+## Architecture
+
+```
+SKILL.md (this file)        — DFS orchestrator
+README.md                   — Usage guide and examples
+actions/
+  detect.md                 — Auto-discover build system, benchmarks, tests, kernels
+  setup.md                  — Environment validation, GPU detection
+  build.md                  — Build the project (CMake / pip / make / etc.)
+  baseline.md               — Run the benchmark, record metric
+  correctness.md            — Run the test suite, gate keep/revert
+  profile.md                — Profile with the right tool for the stack
+  compile-flags.md          — Try compiler / CMake flags
+  env-vars.md               — Try ROCm runtime env vars
+  kernel-opt.md             — Extract hot kernels and submit to GEAK
+  patch.md                  — Apply / revert a code patch with correctness gate
+  report.md                 — Produce final optimization report
+scripts/
+  common.sh                 — Shared helpers (metric extraction, kill, etc.)
+  detect_project.sh         — Writes $RESULT_DIR/detected.env
+  run_bench.sh              — Dispatches based on detected.env
+  run_correctness.sh        — Runs detected test suite
+  profile_rocm.sh           — rocprofv3 wrapper for native code
+  profile_torch.sh          — torch.profiler wrapper for PyTorch code
+kb/
+  entries.jsonl             — Persistent knowledge base (seeded empty)
+```
+
+## DFS Search Tree
+
+```
+                        ┌──────────┐
+                        │  SETUP   │   GPU type, ROCm version, Python env
+                        └────┬─────┘
+                             │
+                        ┌────▼─────┐
+                        │  DETECT  │   Build system, benchmarks, tests, kernel langs
+                        └────┬─────┘
+                             │
+                        ┌────▼─────┐
+                        │  BUILD   │   Initial clean build
+                        └────┬─────┘
+                             │
+                        ┌────▼─────┐
+                        │ BASELINE │   Run benchmark, record metric
+                        └────┬─────┘
+                             │
+                        ┌────▼─────┐
+                        │CORRECTNESS│  Confirm clean tests pass (sanity)
+                        └────┬─────┘
+                             │
+                        ┌────▼─────┐
+                        │ PROFILE  │   rocprofv3 OR torch.profiler
+                        └────┬─────┘
+                             │
+              ┌──────────────▼──────────────┐
+              │      HEURISTIC SCORING      │
+              └──────────────┬──────────────┘
+                             │
+              ┌──────────────▼──────────────────────┐
+              │    DFS over candidate actions       │
+              │                                      │
+              │ ┌──────────┐ ┌──────────┐ ┌───────┐ │
+              │ │ ENV-VARS │ │COMPILE-  │ │KERNEL │ │
+              │ │ (cheap)  │ │  FLAGS   │ │ -OPT  │ │
+              │ └──────────┘ └──────────┘ └───────┘ │
+              │                                      │
+              │ Each: build → bench → correctness    │
+              │       → keep or revert               │
+              └──────────────┬──────────────────────┘
+                             │
+                      ┌──────▼──────┐
+                      │   REPORT    │
+                      └─────────────┘
+```
+
+## Heuristic Scoring
+
+```
+score = (expected_pct_reduction / cost_minutes)
+        × (1 - correctness_risk)
+        × (1 - build_risk)
+        × target_gap_multiplier
+```
+
+### Initial Score Priors (set after DETECT)
+
+The detect step writes `project_class` into `$RESULT_DIR/detected.env`. Choose
+priors based on it:
+
+| Action          | hip-cmake-bench | pytorch-script | triton-collection | hpc-app |
+|-----------------|----------------:|---------------:|------------------:|--------:|
+| env-vars        |               4 |              4 |                 3 |       4 |
+| compile-flags   |               9 |              2 |                 3 |       8 |
+| kernel-opt      |               8 |              5 |                 9 |       6 |
+| torch.compile   |               0 |              7 |                 0 |       0 |
+| precision-cast  |               2 |              5 |                 4 |       2 |
+
+Re-score after every action using the same rules as `training-optimization/SKILL.md`
+(success boosts similar actions ×1.5, failure penalizes ×0.5).
+
+## State Schema
+
+```python
+state = {
+    "repo_root": "",
+    "project_class": "",          # hip-cmake-bench / pytorch-script / triton-collection / hpc-app / unknown
+    "build_system": "",           # cmake / setup.py / make / pyproject / none
+    "build_command": "",          # exact command resolved by detect
+    "bench_command": "",          # exact command (may include filters/args)
+    "bench_metric": "ms_per_iter",# or items_per_sec / GB_per_sec, etc.
+    "test_command": "",           # ctest / pytest / etc., empty if no tests
+    "correctness_mode": "tests",  # tests / golden-output / none
+    "kernel_langs": [],           # subset of {hip, triton, cuda, sycl}
+    "gpu_type": "",               # MI300X / MI325X / MI355X
+    "gpu_arch": "",               # gfx942 / gfx950
+    "rocm_version": "",
+
+    "baseline_metric": 0.0,
+    "current_metric": 0.0,
+    "metric_lower_is_better": True,
+    "cumulative_gain_pct": 0.0,
+
+    "kept_env_vars": {},          # name -> value
+    "kept_compile_flags": [],
+    "kept_patches": [],           # list of git patches saved to $RESULT_DIR/patches/
+    "kernel_candidates": [],      # populated by profile
+
+    "action_stack": [],
+    "completed_actions": [],
+    "consecutive_discards": 0,
+}
+```
+
+## Orchestrator Loop
+
+```
+PROCEDURE optimize(repo_root, [target_metric]):
+
+  1. SETUP                → actions/setup.md
+  2. DETECT               → actions/detect.md   (writes detected.env)
+  3. BUILD (clean)        → actions/build.md
+  4. BASELINE             → actions/baseline.md (runs detected bench, records metric)
+  5. CORRECTNESS (sanity) → actions/correctness.md (must pass on clean build)
+  6. PROFILE              → actions/profile.md (rocprof or torch.profiler)
+  7. KB WARM-UP           → query kb/entries.jsonl for prior runs on this repo
+  8. BUILD ACTION STACK   → score candidates per detected project_class
+
+  9. DFS LOOP:
+     WHILE action_stack not empty AND NOT stopping_criteria_met():
+       a. Pop highest-scored action
+       b. Execute it (env-var, compile-flag, kernel-opt, etc.)
+       c. REBUILD if needed → actions/build.md
+       d. CORRECTNESS GATE → actions/correctness.md
+          - If tests fail: REVERT, mark INVALID, do not record metric
+       e. MEASURE          → actions/baseline.md (re-run benchmark)
+       f. KEEP/REVERT decision based on metric delta
+       g. RE-SCORE remaining actions
+       h. Push any new sub-actions discovered (e.g. profile reveals new hot kernel)
+
+ 10. REPORT               → actions/report.md
+ 11. KB INGEST            → write learnings to kb/entries.jsonl
+```
+
+## Stopping Criteria
+
+Stop the DFS loop when ANY of these is true:
+
+- Action stack is empty AND no new candidates exist
+- 3 consecutive discards (likely plateaued)
+- Wall-clock budget exceeded (`$TIME_BUDGET_MIN`, default 90)
+- Cumulative gain >= 25% (good enough, write report)
+- All remaining action scores < 1.0
+
+## Correctness Gate Protocol (CRITICAL)
+
+After EVERY change, before recording metric improvement:
+
+1. Trigger `actions/correctness.md` with the detected `test_command`.
+2. If `correctness_mode == "tests"`: tests must pass (exit 0, all pass).
+3. If `correctness_mode == "golden-output"`: bench output must match the golden
+   file within tolerance saved in `$RESULT_DIR/golden.json`.
+4. If `correctness_mode == "none"`: WARN the user once, then proceed using only
+   benchmark "did it run cleanly" as the gate. Annotate the report.
+
+A change that improves the metric but fails correctness is ALWAYS reverted and
+recorded as INVALID, regardless of speedup magnitude.
+
+## Kernel Optimization Eligibility
+
+Trigger `actions/kernel-opt.md` for a kernel when:
+
+- It accounts for ≥ 3% of total GPU time in the profile
+- Its source is locatable in the repo (not vendor BLAS / hipBLASLt / hipFFT)
+- It is one of: HIP `__global__`, Triton `@triton.jit`, or torch.compile-generated
+  Inductor Triton
+
+Do NOT submit:
+- hipBLASLt / hipBLAS / rocBLAS GEMMs (vendor-tuned)
+- RCCL / NCCL communication kernels
+- aiter / Composable Kernel attention (vendor-tuned)
+
+## Notes for the Agent
+
+- **Never rewrite the user's code path silently.** Every code patch must be saved
+  to `$RESULT_DIR/patches/<NN>-<short-name>.patch` so it can be applied to a
+  clean checkout.
+- **Always rebuild from scratch when changing compile flags.** Set
+  `CMAKE_BUILD_DIR=$RESULT_DIR/build-<attempt>` to avoid cache contamination.
+- **Prefer env-vars first** — they are zero-cost to revert and often produce
+  the largest single gains on AMD (e.g. `HSA_ENABLE_SDMA`,
+  `GPU_MAX_HW_QUEUES`, `HIP_FORCE_DEV_KERNARG`).
+- **If detect.md cannot find a benchmark or test command**, ask the user once.
+  Do not invent commands.

--- a/.cursor/skills/generic-gpu-optimization/actions/baseline.md
+++ b/.cursor/skills/generic-gpu-optimization/actions/baseline.md
@@ -1,0 +1,115 @@
+# Action: Run Benchmark and Record Metric
+
+## Inputs
+- `$BENCH_COMMAND`, `$BENCH_METRIC_REGEX`, `$BENCH_METRIC` (from detected.env)
+- `$BUILD_DIR` (from build.md)
+- `$ATTEMPT_ID` (e.g. "0" for baseline, "3" for attempt 3)
+- `$KEPT_ENV_FILE` (sourceable, contains kept env vars from prior attempts)
+
+## Procedure
+
+### Step 1: Apply kept environment variables
+```bash
+[ -f "${KEPT_ENV_FILE:-$RESULT_DIR/kept_env.sh}" ] && \
+    source "${KEPT_ENV_FILE:-$RESULT_DIR/kept_env.sh}"
+```
+
+### Step 2: Run benchmark with timing
+```bash
+ATTEMPT_LOG="$RESULT_DIR/bench-${ATTEMPT_ID:-0}.log"
+ATTEMPT_JSON="$RESULT_DIR/bench-${ATTEMPT_ID:-0}.json"
+
+cd "$REPO_ROOT"
+START=$(date +%s)
+"$SKILL_ROOT/scripts/run_bench.sh" 2>&1 | tee "$ATTEMPT_LOG"
+RUN_EXIT=${PIPESTATUS[0]}
+DURATION=$(( $(date +%s) - START ))
+echo "Run took ${DURATION}s"
+
+if [ $RUN_EXIT -ne 0 ]; then
+    echo "BENCH_FAILED" > "$RESULT_DIR/bench_status.txt"
+    exit $RUN_EXIT
+fi
+```
+
+### Step 3: Extract the metric
+```bash
+METRIC=$("$SKILL_ROOT/scripts/common.sh" extract_metric "$ATTEMPT_LOG" "$BENCH_METRIC_REGEX")
+
+if [ -z "$METRIC" ]; then
+    echo "ERROR: could not extract metric from $ATTEMPT_LOG using regex: $BENCH_METRIC_REGEX"
+    echo "First 50 lines of log:"
+    head -50 "$ATTEMPT_LOG"
+    exit 1
+fi
+echo "$BENCH_METRIC: $METRIC"
+```
+
+### Step 4: Append to results.tsv
+```bash
+RESULTS="$RESULT_DIR/results.tsv"
+[ -f "$RESULTS" ] || echo -e "attempt\tmetric\tdelta_pct\tstatus\tdescription" > "$RESULTS"
+
+if [ "$ATTEMPT_ID" = "0" ]; then
+    DELTA="0.00"
+    STATUS="baseline"
+    BASELINE_METRIC="$METRIC"
+    echo "BASELINE_METRIC=$METRIC" >> "$RESULT_DIR/state.env"
+else
+    BASELINE_METRIC=$(grep -oP '(?<=^BASELINE_METRIC=)[\d.]+' "$RESULT_DIR/state.env")
+    if [ "${METRIC_LOWER_IS_BETTER:-true}" = "true" ]; then
+        DELTA=$(python3 -c "print(f'{($BASELINE_METRIC - $METRIC) / $BASELINE_METRIC * 100:+.2f}')")
+    else
+        DELTA=$(python3 -c "print(f'{($METRIC - $BASELINE_METRIC) / $BASELINE_METRIC * 100:+.2f}')")
+    fi
+    STATUS="pending"  # decided after correctness gate + keep/revert logic
+fi
+
+echo -e "$ATTEMPT_ID\t$METRIC\t$DELTA\t$STATUS\t${ATTEMPT_DESCRIPTION:-}" >> "$RESULTS"
+```
+
+### Step 5: Multi-run noise check (baseline only)
+On `ATTEMPT_ID=0`, run the benchmark 3 times and confirm the metric varies by
+< 2%. If noise is high, set `BENCH_REPETITIONS=5` for all subsequent attempts
+(via `run_bench.sh`).
+
+```bash
+if [ "$ATTEMPT_ID" = "0" ]; then
+    METRICS=()
+    for i in 1 2 3; do
+        "$SKILL_ROOT/scripts/run_bench.sh" > "$RESULT_DIR/noise-$i.log" 2>&1
+        m=$("$SKILL_ROOT/scripts/common.sh" extract_metric "$RESULT_DIR/noise-$i.log" "$BENCH_METRIC_REGEX")
+        METRICS+=("$m")
+    done
+    NOISE=$(python3 -c "
+import statistics
+xs = [${METRICS[@]/#/}]
+xs = [float(x) for x in '${METRICS[*]}'.split()]
+print(f'{statistics.stdev(xs)/statistics.mean(xs)*100:.2f}')
+")
+    echo "Baseline noise: ${NOISE}%"
+    echo "BENCH_NOISE_PCT=$NOISE" >> "$RESULT_DIR/state.env"
+fi
+```
+
+## Outputs
+- `$RESULT_DIR/results.tsv` updated
+- `$RESULT_DIR/state.env` updated with `BASELINE_METRIC` (only on attempt 0)
+- `$RESULT_DIR/bench-N.{log,json}` per attempt
+
+## Keep/Revert Decision (applied AFTER correctness.md passes)
+Pseudocode:
+```
+if correctness == FAIL:
+    revert; status=INVALID; consecutive_discards++
+elif delta_pct < 0:               # regressed
+    revert; status=DISCARD; consecutive_discards++
+elif abs(delta_pct) < bench_noise_pct:
+    revert; status=NOISE; consecutive_discards++  # not enough signal
+else:
+    keep; status=KEEP; consecutive_discards=0
+```
+
+## Failure Handling
+- Bench command exits non-zero: revert the change, do NOT record metric.
+- Metric extraction fails: print log head, ask user to set `BENCH_METRIC_REGEX`.

--- a/.cursor/skills/generic-gpu-optimization/actions/build.md
+++ b/.cursor/skills/generic-gpu-optimization/actions/build.md
@@ -1,0 +1,68 @@
+# Action: Build the Project
+
+## Inputs
+- `$REPO_ROOT`, `$RESULT_DIR`
+- `$BUILD_COMMAND` (from detected.env)
+- `$EXTRA_CMAKE_FLAGS` / `$EXTRA_CXX_FLAGS` / `$EXTRA_HIP_FLAGS` (optional, from compile-flags action)
+- `$BUILD_DIR_SUFFIX` (optional, e.g. "attempt-3" — isolates builds when changing flags)
+
+## Procedure
+
+### Step 1: Decide build directory
+For CMake projects, isolate builds when compile flags change:
+```bash
+if [ -n "${EXTRA_CMAKE_FLAGS:-}${EXTRA_CXX_FLAGS:-}${EXTRA_HIP_FLAGS:-}" ]; then
+    BUILD_DIR="$REPO_ROOT/build-${BUILD_DIR_SUFFIX:-baseline}"
+else
+    BUILD_DIR="${BUILD_DIR:-$REPO_ROOT/build}"
+fi
+mkdir -p "$BUILD_DIR"
+```
+
+### Step 2: Run the build
+```bash
+cd "$REPO_ROOT"
+
+case "$PROJECT_CLASS" in
+  hip-cmake-bench|hpc-app)
+      # Allow detect.md to override the default cmake invocation
+      if [ -n "${EXTRA_CMAKE_FLAGS:-}" ]; then
+          cmake -S . -B "$BUILD_DIR" $EXTRA_CMAKE_FLAGS \
+              -DCMAKE_CXX_FLAGS="${EXTRA_CXX_FLAGS:-}" \
+              -DCMAKE_HIP_FLAGS="${EXTRA_HIP_FLAGS:-}"
+          cmake --build "$BUILD_DIR" -j"$(nproc)" 2>&1 | tee "$RESULT_DIR/build.log"
+      else
+          eval "$BUILD_COMMAND" 2>&1 | tee "$RESULT_DIR/build.log"
+      fi
+      ;;
+  pytorch-script|triton-collection)
+      eval "$BUILD_COMMAND" 2>&1 | tee "$RESULT_DIR/build.log"
+      ;;
+  *)
+      eval "$BUILD_COMMAND" 2>&1 | tee "$RESULT_DIR/build.log"
+      ;;
+esac
+```
+
+### Step 3: Capture build success
+```bash
+BUILD_EXIT=${PIPESTATUS[0]}
+if [ $BUILD_EXIT -ne 0 ]; then
+    echo "BUILD_FAILED" > "$RESULT_DIR/build_status.txt"
+    echo "ERROR: build failed with exit $BUILD_EXIT — see $RESULT_DIR/build.log"
+    exit $BUILD_EXIT
+fi
+echo "BUILD_OK" > "$RESULT_DIR/build_status.txt"
+echo "BUILD_DIR=$BUILD_DIR" >> "$RESULT_DIR/state.env"
+```
+
+## Outputs
+- `$BUILD_DIR/` populated
+- `$RESULT_DIR/build.log` for diagnosis
+- `BUILD_DIR` exported for downstream actions
+
+## Failure Handling
+- Build failure: REVERT the most recent change, mark attempt as INVALID,
+  decrement consecutive_discards (don't penalize the agent for a transient build
+  flake — but record it).
+- For 3 build failures in a row: stop and surface to the user.

--- a/.cursor/skills/generic-gpu-optimization/actions/compile-flags.md
+++ b/.cursor/skills/generic-gpu-optimization/actions/compile-flags.md
@@ -1,0 +1,66 @@
+# Action: Try Compiler / CMake Flag Overrides
+
+## When to use
+After env-vars have been exhausted (or in parallel for `hip-cmake-bench` /
+`hpc-app` projects where flags often dominate).
+
+## Catalog
+
+### CMake / build-type
+| Flag | Try | Notes |
+|---|---|---|
+| `-DCMAKE_BUILD_TYPE` | `Release`, `RelWithDebInfo` | Confirm Release |
+| `-DCMAKE_HIP_ARCHITECTURES` | matches detected `$GPU_ARCH` | Critical — wrong arch silently runs slowly |
+| `-DCMAKE_INTERPROCEDURAL_OPTIMIZATION` | `ON` | LTO; ~2-5% on dense workloads |
+| `-DBUILD_SHARED_LIBS` | `OFF` | Static linking, faster dispatch |
+
+### HIP / Clang flags (via `-DCMAKE_HIP_FLAGS=...`)
+| Flag | Notes |
+|---|---|
+| `-O3` | Confirm |
+| `-ffast-math` | Reorders FP; correctness gate catches breakage |
+| `-mllvm -amdgpu-early-inline-all=true` | Aggressive inlining for kernel-heavy code |
+| `-mllvm -amdgpu-function-calls=false` | Force-inline all device functions |
+| `-mllvm -amdgpu-unroll-threshold=...` | Tune unroll factor (try 100, 200, 400) |
+| `-fgpu-rdc` / `-fno-gpu-rdc` | RDC on/off; off is faster if no cross-TU device calls |
+| `-Xclang -mllvm -Xclang -amdgpu-internalize-symbols` | Better IPO |
+
+### CXX flags
+| Flag | Notes |
+|---|---|
+| `-O3 -DNDEBUG` | Confirm |
+| `-march=native` | Host-side — doesn't affect kernels but helps launch overhead |
+
+## Procedure
+
+### Step 1: Pick a single flag to add (or change)
+```bash
+EXTRA_HIP_FLAGS="-mllvm -amdgpu-early-inline-all=true"
+ATTEMPT_DESCRIPTION="hip-flag: $EXTRA_HIP_FLAGS"
+BUILD_DIR_SUFFIX="attempt-${ATTEMPT_ID}-inline-all"
+```
+
+### Step 2: Trigger build.md (clean build into isolated dir)
+A clean build is mandatory — CMake caches old flags otherwise.
+
+### Step 3: Trigger baseline.md (using the new $BUILD_DIR)
+The bench command stays the same; only the binary changed.
+
+### Step 4: Trigger correctness.md
+Compile flags can break correctness (especially `-ffast-math`). Never skip.
+
+### Step 5: Keep or revert
+If KEEP, append to `$RESULT_DIR/kept_cmake.txt`:
+```
+CMAKE: -DCMAKE_BUILD_TYPE=Release
+HIP:   -mllvm -amdgpu-early-inline-all=true
+```
+The next build action concatenates everything in this file.
+
+## Combination Rule
+Try flags one at a time. After all candidates tested, attempt the union of
+winners as a final consolidation pass.
+
+## Outputs
+- `$RESULT_DIR/kept_cmake.txt` (sourced by `build.md` for subsequent builds)
+- Entry in `results.tsv`

--- a/.cursor/skills/generic-gpu-optimization/actions/correctness.md
+++ b/.cursor/skills/generic-gpu-optimization/actions/correctness.md
@@ -1,0 +1,85 @@
+# Action: Correctness Gate
+
+## Inputs
+- `$TEST_COMMAND`, `$CORRECTNESS_MODE` (from detected.env)
+- `$BUILD_DIR`
+- `$ATTEMPT_ID` — current attempt being gated
+
+## Procedure
+
+### Mode: tests
+Run the detected test command and require zero exit + zero failures.
+
+```bash
+cd "${BUILD_DIR:-$REPO_ROOT}"
+
+START=$(date +%s)
+"$SKILL_ROOT/scripts/run_correctness.sh" 2>&1 | tee "$RESULT_DIR/tests-${ATTEMPT_ID}.log"
+EXIT=${PIPESTATUS[0]}
+DURATION=$(( $(date +%s) - START ))
+echo "Tests took ${DURATION}s"
+
+if [ $EXIT -eq 0 ]; then
+    echo "CORRECTNESS_PASS" > "$RESULT_DIR/correctness-${ATTEMPT_ID}.txt"
+else
+    echo "CORRECTNESS_FAIL" > "$RESULT_DIR/correctness-${ATTEMPT_ID}.txt"
+    echo "Test failure summary:"
+    grep -E "FAIL|FAILED|Error" "$RESULT_DIR/tests-${ATTEMPT_ID}.log" | head -20
+fi
+```
+
+### Mode: golden-output
+Compare benchmark stdout against `$RESULT_DIR/golden.json` saved at attempt 0.
+
+```python
+import json, sys, math
+
+def almost_equal(a, b, rtol=1e-3, atol=1e-5):
+    if isinstance(a, (list, tuple)):
+        return all(almost_equal(x, y, rtol, atol) for x, y in zip(a, b))
+    if isinstance(a, dict):
+        return all(almost_equal(a[k], b[k], rtol, atol) for k in a if k in b)
+    if isinstance(a, (int, float)):
+        return math.isclose(a, b, rel_tol=rtol, abs_tol=atol)
+    return a == b
+
+golden = json.load(open(sys.argv[1]))
+current = json.load(open(sys.argv[2]))
+
+# Compare only numerical output, not timing
+fields = ["output", "result", "checksum", "value", "values"]
+for f in fields:
+    if f in golden and f in current:
+        if not almost_equal(golden[f], current[f]):
+            print(f"GOLDEN MISMATCH in field '{f}'")
+            sys.exit(1)
+print("GOLDEN OK")
+```
+
+### Mode: none
+Issue a one-time warning, then accept the change if the bench just exited cleanly.
+Annotate `optimization_report.md` that no correctness gate was active.
+
+```bash
+if [ "$CORRECTNESS_MODE" = "none" ]; then
+    [ -f "$RESULT_DIR/.no_correctness_warned" ] || {
+        echo "WARNING: no test suite or golden output detected. Optimizations will"
+        echo "be accepted based only on whether the benchmark exits cleanly."
+        echo "Add a TEST_COMMAND to override."
+        touch "$RESULT_DIR/.no_correctness_warned"
+    }
+    echo "CORRECTNESS_SKIP" > "$RESULT_DIR/correctness-${ATTEMPT_ID}.txt"
+fi
+```
+
+## Outputs
+- `$RESULT_DIR/correctness-${ATTEMPT_ID}.txt` — one of `CORRECTNESS_{PASS,FAIL,SKIP}`
+- `$RESULT_DIR/tests-${ATTEMPT_ID}.log` — full test output
+
+## Failure Handling
+- Test runner crashes (exit > 1, no test output): treat as build/env regression
+  → revert and mark INVALID.
+- Test timeout (no output for 5 min): kill, mark INVALID, increase timeout for
+  next attempt.
+- Flaky test (passes on retry): record as `CORRECTNESS_PASS_RETRY`, accept the
+  change, but add the test name to `$RESULT_DIR/flaky_tests.txt` for the report.

--- a/.cursor/skills/generic-gpu-optimization/actions/detect.md
+++ b/.cursor/skills/generic-gpu-optimization/actions/detect.md
@@ -32,9 +32,23 @@ The detector classifies into one of:
 ### Step 2: Locate kernel sources
 ```bash
 KERNEL_LANGS=""
-[ -n "$(find "$REPO_ROOT" -name '*.hip' -o -name '*.cuh' -o -name '*.cu' 2>/dev/null | head -1)" ] && KERNEL_LANGS="$KERNEL_LANGS hip"
-grep -r -l --include='*.py' '@triton.jit' "$REPO_ROOT" 2>/dev/null | head -1 >/dev/null && KERNEL_LANGS="$KERNEL_LANGS triton"
-grep -r -l --include='*.py' 'torch.compile\|torch.compile(' "$REPO_ROOT" 2>/dev/null | head -1 >/dev/null && KERNEL_LANGS="$KERNEL_LANGS torch-compile"
+# Exclude vendored / build / venv trees so we don't mis-classify.
+# Use a function rather than `eval` to avoid shell glob-expansion of -path patterns.
+_find_src() {
+    find "$REPO_ROOT" \
+        -path '*/thirdparty/*'    -prune -o \
+        -path '*/third_party/*'   -prune -o \
+        -path '*/build*/*'        -prune -o \
+        -path '*/cmake-build-*/*' -prune -o \
+        -path '*/_deps/*'         -prune -o \
+        -path '*/.venv/*'         -prune -o \
+        -path '*/site-packages/*' -prune -o \
+        "$@" -print 2>/dev/null
+}
+
+[ -n "$(_find_src \( -name '*.hip' -o -name '*.cuh' -o -name '*.cu' \) | head -1)" ] && KERNEL_LANGS="$KERNEL_LANGS hip"
+[ -n "$(_find_src -name '*.py' | xargs grep -l '@triton.jit' 2>/dev/null | head -1)" ] && KERNEL_LANGS="$KERNEL_LANGS triton"
+[ -n "$(_find_src -name '*.py' | xargs grep -l 'torch\.compile' 2>/dev/null | head -1)" ] && KERNEL_LANGS="$KERNEL_LANGS torch-compile"
 echo "KERNEL_LANGS=\"$(echo $KERNEL_LANGS | xargs)\"" >> "$RESULT_DIR/detected.env"
 ```
 

--- a/.cursor/skills/generic-gpu-optimization/actions/detect.md
+++ b/.cursor/skills/generic-gpu-optimization/actions/detect.md
@@ -1,0 +1,83 @@
+# Action: Auto-Detect Project
+
+## Goal
+Determine `project_class`, `build_command`, `bench_command`, `test_command`,
+`kernel_langs`, and `correctness_mode`. Write everything to
+`$RESULT_DIR/detected.env` so subsequent actions can dispatch.
+
+## Inputs
+- `$REPO_ROOT`, `$RESULT_DIR`
+- Optional user overrides: `$BUILD_COMMAND`, `$BENCH_COMMAND`, `$TEST_COMMAND`,
+  `$BENCH_METRIC_REGEX`
+
+## Procedure
+
+### Step 1: Run the heuristic detector
+```bash
+"$SKILL_ROOT/scripts/detect_project.sh" "$REPO_ROOT" > "$RESULT_DIR/detected.env"
+cat "$RESULT_DIR/detected.env"
+source "$RESULT_DIR/detected.env"
+```
+
+The detector classifies into one of:
+- `hip-cmake-bench` — `CMakeLists.txt` + a `bench/` or `benchmarks/` dir with
+  Google Benchmark (`benchmark::benchmark` link), Catch2, or NVBench
+- `pytorch-script` — `pyproject.toml` or `setup.py` + at least one `.py` that
+  imports `torch` AND has a `__main__` block with timing output
+- `triton-collection` — Python code that imports `triton` and has a `bench.py`,
+  `benchmark.py`, or `benchmarks/` directory
+- `hpc-app` — `Makefile` or `CMakeLists.txt` with `--bench` / `-b` flag in main
+- `unknown` — fallback
+
+### Step 2: Locate kernel sources
+```bash
+KERNEL_LANGS=""
+[ -n "$(find "$REPO_ROOT" -name '*.hip' -o -name '*.cuh' -o -name '*.cu' 2>/dev/null | head -1)" ] && KERNEL_LANGS="$KERNEL_LANGS hip"
+grep -r -l --include='*.py' '@triton.jit' "$REPO_ROOT" 2>/dev/null | head -1 >/dev/null && KERNEL_LANGS="$KERNEL_LANGS triton"
+grep -r -l --include='*.py' 'torch.compile\|torch.compile(' "$REPO_ROOT" 2>/dev/null | head -1 >/dev/null && KERNEL_LANGS="$KERNEL_LANGS torch-compile"
+echo "KERNEL_LANGS=\"$(echo $KERNEL_LANGS | xargs)\"" >> "$RESULT_DIR/detected.env"
+```
+
+### Step 3: Determine correctness mode
+Priority order:
+1. If `ctest` is configured (CMake build dir contains `CTestTestfile.cmake`) → `tests`, `TEST_COMMAND="ctest --output-on-failure"`
+2. If `pytest` config or `tests/` dir with `test_*.py` → `tests`, `TEST_COMMAND="pytest -x"`
+3. If a known benchmark binary exists, capture its FIRST baseline output as a golden file → `golden-output`
+4. Else → `none` (warn the user)
+
+Append to `detected.env`:
+```bash
+echo "CORRECTNESS_MODE=$CORRECTNESS_MODE"   >> "$RESULT_DIR/detected.env"
+echo "TEST_COMMAND=\"$TEST_COMMAND\""        >> "$RESULT_DIR/detected.env"
+```
+
+### Step 4: Apply user overrides
+Anything passed in via `$BUILD_COMMAND`, `$BENCH_COMMAND`, `$TEST_COMMAND`, or
+`$BENCH_METRIC_REGEX` REPLACES the detected value:
+
+```bash
+[ -n "${BUILD_COMMAND:-}" ] && sed -i "s|^BUILD_COMMAND=.*|BUILD_COMMAND=\"$BUILD_COMMAND\"|" "$RESULT_DIR/detected.env"
+[ -n "${BENCH_COMMAND:-}" ] && sed -i "s|^BENCH_COMMAND=.*|BENCH_COMMAND=\"$BENCH_COMMAND\"|" "$RESULT_DIR/detected.env"
+[ -n "${TEST_COMMAND:-}"  ] && sed -i "s|^TEST_COMMAND=.*|TEST_COMMAND=\"$TEST_COMMAND\"|"   "$RESULT_DIR/detected.env"
+```
+
+### Step 5: Sanity print
+```bash
+echo "=== Detection Summary ==="
+echo "  project_class:    $PROJECT_CLASS"
+echo "  build_command:    $BUILD_COMMAND"
+echo "  bench_command:    $BENCH_COMMAND"
+echo "  bench_metric:     $BENCH_METRIC ($BENCH_METRIC_REGEX)"
+echo "  test_command:     $TEST_COMMAND"
+echo "  correctness_mode: $CORRECTNESS_MODE"
+echo "  kernel_langs:     $KERNEL_LANGS"
+```
+
+## Outputs
+- `$RESULT_DIR/detected.env` — sourceable, contains everything subsequent actions
+  need to know about the project shape
+
+## Failure Handling
+- If detector returns `unknown` AND no overrides supplied: ASK the user for
+  `BUILD_COMMAND`, `BENCH_COMMAND`, `TEST_COMMAND` and re-run this action.
+- If `BENCH_COMMAND` is empty after detection + overrides: STOP with a clear error.

--- a/.cursor/skills/generic-gpu-optimization/actions/env-vars.md
+++ b/.cursor/skills/generic-gpu-optimization/actions/env-vars.md
@@ -1,0 +1,61 @@
+# Action: Try ROCm Runtime Environment Variables
+
+## Why this is the cheapest action
+Env vars don't require a rebuild — just re-run the benchmark with the variable
+set. Often produces single-digit-percent gains for free, especially on AMD.
+
+## Catalog (try in this order, scored highest first)
+
+| Env var | Default | Try | Why |
+|---|---|---|---|
+| `HSA_ENABLE_SDMA` | 1 | `0` | Disables SDMA, often faster for small transfers on MI3xx |
+| `GPU_MAX_HW_QUEUES` | 4 | `8`, `16` | More concurrent kernel streams |
+| `HIP_FORCE_DEV_KERNARG` | 0 | `1` | Allocates kernel args in device memory; lower launch overhead |
+| `HSA_FORCE_FINE_GRAIN_PCIE` | 0 | `1` | Fine-grain PCIe coherence; helps small-message workloads |
+| `HSA_ENABLE_PEER_SDMA` | 1 | `0` | Disable peer SDMA on single-GPU runs |
+| `AMD_DIRECT_DISPATCH` | 1 | `1` | Confirm enabled (huge win on launch-bound kernels) |
+| `HIPBLASLT_TUNING_FILE` | unset | `$RESULT_DIR/blaslt.tune` | Persists hipBLASLt autotune across runs |
+| `ROCBLAS_LAYER` | 0 | `0` | Make sure no logging overhead is on |
+| `MIOPEN_FIND_MODE` | 5 | `1` | Faster MIOpen heuristic mode |
+| `OMP_NUM_THREADS` | nproc | `1`, `nproc/2` | If launch-bound on host |
+
+For PyTorch projects also try:
+| `PYTORCH_TUNABLEOP_ENABLED` | 0 | `1` | GEMM autotune (skip on first run, slow) |
+| `TORCH_BLAS_PREFER_HIPBLASLT` | 1 | `1` | Confirm hipBLASLt is preferred |
+| `TORCHINDUCTOR_CACHE_DIR` | `/tmp/...` | `$RESULT_DIR/inductor` | Reproducible compile cache |
+
+## Procedure
+
+### Step 1: Pick one env var to test
+```bash
+ENV_NAME="$1"      # e.g. HSA_ENABLE_SDMA
+ENV_VAL="$2"       # e.g. 0
+ATTEMPT_DESCRIPTION="env: $ENV_NAME=$ENV_VAL"
+```
+
+### Step 2: Re-run benchmark with the var set (no rebuild)
+```bash
+export "$ENV_NAME=$ENV_VAL"
+ATTEMPT_ID=$((ATTEMPT_ID + 1))
+# Trigger baseline.md (which will source kept_env.sh and pick up the new export)
+```
+
+### Step 3: Apply correctness gate
+Trigger `correctness.md`. Env vars normally don't affect correctness, but they
+sometimes do (e.g. fine-grain PCIe) — never skip the gate.
+
+### Step 4: Keep or revert
+If KEEP, append to `$RESULT_DIR/kept_env.sh`:
+```bash
+echo "export $ENV_NAME=$ENV_VAL" >> "$RESULT_DIR/kept_env.sh"
+```
+If REVERT, just `unset $ENV_NAME`.
+
+## Combination Rule
+After 2+ wins, push a `combined-env-test` action with all winners simultaneously.
+Sometimes individual wins compose, sometimes they fight; only direct measurement
+tells you.
+
+## Outputs
+- `$RESULT_DIR/kept_env.sh` updated
+- Entry in `results.tsv`

--- a/.cursor/skills/generic-gpu-optimization/actions/kernel-opt.md
+++ b/.cursor/skills/generic-gpu-optimization/actions/kernel-opt.md
@@ -1,0 +1,118 @@
+# Action: Kernel Optimization via GEAK MCP
+
+## Eligibility (mirrors training-optimization, framework-agnostic)
+A kernel from `$RESULT_DIR/kernel_candidates.json` is eligible if:
+- `gpu_pct >= 3.0`
+- `source_path` is inside `$REPO_ROOT` (rewriting vendor sources is forbidden)
+- `kernel_lang` ∈ `{hip, triton}`
+
+## Procedure
+
+### Step 1: Pick the highest-scoring candidate
+```python
+import json
+candidates = json.load(open(f"{RESULT_DIR}/kernel_candidates.json"))["candidates"]
+candidates = [c for c in candidates if c["gpu_pct"] >= 3.0
+                                    and c["source_path"]
+                                    and c["kernel_lang"] in ("hip", "triton")]
+candidates.sort(key=lambda c: c["gpu_pct"], reverse=True)
+target = candidates[0]
+```
+
+### Step 2: Extract a self-contained kernel file
+The submission to GEAK should be a single file containing:
+1. The kernel source (function + any device-side helpers it transitively calls)
+2. A comment block at the top with:
+   - Kernel name + current `gpu_pct`
+   - Sample input shapes/dtypes from the profile
+   - Hardware: `${GPU} (${GPU_ARCH})`
+   - Project context (one paragraph)
+
+For HIP, gather transitive `__device__` helpers via `rg`:
+```bash
+EXTRACT_OUT="$RESULT_DIR/geak-input-${ATTEMPT_ID}.${EXT}"
+python3 "$SKILL_ROOT/scripts/extract_kernel.py" \
+    --source "$target.source_path" \
+    --kernel "$target.name" \
+    --shapes "$target.sample_shapes" \
+    --gpu "$GPU" \
+    --out "$EXTRACT_OUT"
+```
+
+### Step 3: Submit to GEAK MCP
+Use the `geak-agent` MCP server (configured in `.cursor/mcp.json`):
+
+```
+1. geak_set_model_config(model="claude-opus-4-6", mode="kernel-rewrite")
+2. geak_create_task(
+       input_type="file",
+       input_path=EXTRACT_OUT,
+       hardware=GPU_ARCH,
+       prompt="Optimize this kernel for AMD ${GPU}. Preserve numerical
+               correctness. Target a 1.5-3x speedup. Return a drop-in
+               replacement."
+   )
+3. geak_submit_task(task_id=...)
+4. POLL geak_get_task(task_id=...) every 30s, max 30 min
+5. geak_get_outputs(task_id=...) → download_url
+6. geak_download_file(url=..., local=$RESULT_DIR/geak-output-${ATTEMPT_ID}.${EXT})
+```
+
+(See `.cursor/skills/training-optimization/GEAK-KERNEL-OPTIMIZATION.md` for the
+full reference of the MCP tool sequence — it is identical here.)
+
+### Step 4: Local validation
+Before patching the repo:
+
+```bash
+# 1. Compile check (HIP)
+hipcc -c "$RESULT_DIR/geak-output-${ATTEMPT_ID}.hip" \
+      --offload-arch=$GPU_ARCH -o /tmp/geak_check.o
+[ $? -eq 0 ] || { echo "GEAK output won't compile — discard"; exit 1; }
+
+# 2. Microbench (optional but recommended)
+python3 "$SKILL_ROOT/scripts/kernel_microbench.py" \
+    --orig "$target.source_path" \
+    --new  "$RESULT_DIR/geak-output-${ATTEMPT_ID}.${EXT}" \
+    --shapes "$target.sample_shapes"
+```
+
+### Step 5: Apply as a patch
+```bash
+cp "$target.source_path" "$target.source_path.geak.bak"
+# Splice the new kernel body into the original file
+python3 "$SKILL_ROOT/scripts/splice_kernel.py" \
+    --target "$target.source_path" \
+    --kernel "$target.name" \
+    --replacement "$RESULT_DIR/geak-output-${ATTEMPT_ID}.${EXT}"
+
+# Save patch
+git -C "$REPO_ROOT" diff -- "$target.source_path" > \
+    "$RESULT_DIR/patches/$(printf '%02d' $ATTEMPT_ID)-${target.name}.patch"
+```
+
+### Step 6: Trigger build.md → correctness.md → baseline.md
+Same protocol as any other action. KEEP only if:
+- Build succeeds
+- Correctness PASS
+- Metric improves > bench_noise_pct
+
+### Step 7: Revert protocol
+```bash
+mv "$target.source_path.geak.bak" "$target.source_path"
+git -C "$REPO_ROOT" checkout -- "$target.source_path"
+```
+
+## Outputs
+- `$RESULT_DIR/geak-input-N.{hip,py}`, `geak-output-N.{hip,py}`
+- `$RESULT_DIR/patches/NN-<kernel>.patch` (if kept)
+- Entry in `results.tsv`
+
+## Notes
+- Submit ONE kernel per task. Multi-kernel submissions degrade output quality.
+- For Inductor-generated Triton (torch.compile path), see
+  `.cursor/skills/inference-optimization/kernel-opt/geak.md` for the cache-patching
+  trick — it applies verbatim to any pytorch-script project.
+- Never blindly accept GEAK output that fails the microbench, even if
+  end-to-end metrics improve — it usually means the workload doesn't actually
+  exercise the kernel.

--- a/.cursor/skills/generic-gpu-optimization/actions/patch.md
+++ b/.cursor/skills/generic-gpu-optimization/actions/patch.md
@@ -1,0 +1,45 @@
+# Action: Apply / Revert a Generic Code Patch
+
+## When to use
+For any code change that isn't a compile flag, env var, or kernel rewrite. Most
+common case: profile suggests a small structural fix (e.g. cache a value, change
+launch-config heuristic, replace a `for`-loop with a fused pass).
+
+## Procedure
+
+### Step 1: Save baseline of every file you'll touch
+```bash
+for f in "${FILES_TO_PATCH[@]}"; do
+    cp "$f" "$f.${ATTEMPT_ID}.bak"
+done
+```
+
+### Step 2: Apply the change
+Make the edit. Keep the change SCOPED — one logical change per attempt. If
+you're tempted to "also fix" a nearby issue, push it as a separate action.
+
+### Step 3: Save the patch
+```bash
+git -C "$REPO_ROOT" diff -- "${FILES_TO_PATCH[@]}" > \
+    "$RESULT_DIR/patches/$(printf '%02d' $ATTEMPT_ID)-${PATCH_NAME}.patch"
+```
+
+### Step 4: Trigger build → correctness → baseline (standard pipeline)
+
+### Step 5: Keep or revert
+If KEEP: leave the change in place. The patch file in `$RESULT_DIR/patches/` is
+the durable artifact — it can be re-applied to a clean checkout via:
+```bash
+git -C $REPO_ROOT apply $RESULT_DIR/patches/*.patch
+```
+
+If REVERT:
+```bash
+for f in "${FILES_TO_PATCH[@]}"; do
+    mv "$f.${ATTEMPT_ID}.bak" "$f"
+done
+git -C "$REPO_ROOT" checkout -- "${FILES_TO_PATCH[@]}"
+```
+
+## Outputs
+- `$RESULT_DIR/patches/NN-<name>.patch` (always saved, even on revert, for the report)

--- a/.cursor/skills/generic-gpu-optimization/actions/profile.md
+++ b/.cursor/skills/generic-gpu-optimization/actions/profile.md
@@ -1,0 +1,111 @@
+# Action: Profile and Identify Hot Kernels
+
+## Inputs
+- `$BENCH_COMMAND`, `$KERNEL_LANGS`, `$PROJECT_CLASS`
+- `$BUILD_DIR`
+
+## Decision: which profiler
+
+| project_class      | kernel_langs contain | Use |
+|--------------------|----------------------|-----|
+| pytorch-script     | torch-compile/triton | torch.profiler (`profile_torch.sh`) |
+| triton-collection  | triton               | torch.profiler |
+| hip-cmake-bench    | hip                  | rocprofv3 (`profile_rocm.sh`) |
+| hpc-app            | hip                  | rocprofv3 |
+| any                | mixed                | rocprofv3 (catches everything) |
+
+## Procedure
+
+### Step 1: Run profiler
+```bash
+case "$PROJECT_CLASS" in
+  pytorch-script|triton-collection)
+      "$SKILL_ROOT/scripts/profile_torch.sh" > "$RESULT_DIR/profile.log" 2>&1
+      TRACE="$RESULT_DIR/profiles/torch_trace.json"
+      ;;
+  *)
+      "$SKILL_ROOT/scripts/profile_rocm.sh" > "$RESULT_DIR/profile.log" 2>&1
+      TRACE="$RESULT_DIR/profiles/rocprof.json"
+      ;;
+esac
+
+[ -f "$TRACE" ] || { echo "ERROR: no trace produced"; exit 1; }
+```
+
+### Step 2: Top-20 kernel breakdown
+```python
+import json, sys
+from collections import defaultdict
+
+trace_path = sys.argv[1]
+trace = json.load(open(trace_path))
+
+# rocprofv3 vs torch.profiler schema
+events = trace.get("traceEvents", trace.get("kernels", trace))
+
+kernel_time = defaultdict(float)
+kernel_count = defaultdict(int)
+for e in events:
+    if isinstance(e, dict):
+        # torch.profiler
+        if e.get("cat") == "kernel" and "dur" in e:
+            kernel_time[e["name"]] += e["dur"]
+            kernel_count[e["name"]] += 1
+        # rocprofv3 has KernelName + DurationNs
+        elif "KernelName" in e:
+            kernel_time[e["KernelName"]] += e.get("DurationNs", 0) / 1000.0  # to us
+            kernel_count[e["KernelName"]] += 1
+
+total = sum(kernel_time.values())
+print(f"\nTop-20 kernels ({total/1e6:.2f}s total):\n")
+for name, t in sorted(kernel_time.items(), key=lambda x: -x[1])[:20]:
+    print(f"  {name[:80]:80s}  {t/1000:>8.1f}ms  {t/total*100:>5.1f}%  {kernel_count[name]:>5d}x")
+```
+
+### Step 3: Extract GEAK candidates
+A kernel becomes a candidate if ALL hold:
+- ≥ 3% of total GPU time
+- Source can be located in `$REPO_ROOT` (NOT in `/opt/rocm/`, NOT in
+  `site-packages/`)
+- Name does NOT match the vendor exclusion list:
+  ```
+  Cijk_*           hipBLASLt
+  rocblas_*        rocBLAS
+  ck::*            Composable Kernel
+  aiter::*         AITER
+  rccl_*           RCCL
+  cufft_*/hipfft_* hipFFT
+  ```
+
+For each candidate, find source:
+```bash
+# HIP kernel
+KNAME="select_k_radix_kernel"
+SRC=$(rg -l "void ${KNAME}|__global__.*${KNAME}" "$REPO_ROOT" --glob '*.{hip,cu,cuh,h,cpp}' | head -1)
+
+# Triton kernel (Python)
+SRC=$(rg -l "@triton.jit" "$REPO_ROOT" --glob '*.py' | xargs rg -l "def ${KNAME}" 2>/dev/null | head -1)
+
+# Inductor-generated Triton (torch.compile)
+SRC=$(ls /tmp/torchinductor_*/*/triton/${KNAME}*.py 2>/dev/null | head -1)
+```
+
+### Step 4: Save candidates list
+```bash
+jq -n --argjson candidates "$CANDIDATES_JSON" \
+    '{candidates: $candidates}' > "$RESULT_DIR/kernel_candidates.json"
+```
+
+Each candidate has: `{name, gpu_pct, source_path, kernel_lang, sample_shapes}`.
+
+## Outputs
+- `$RESULT_DIR/profile.log`
+- `$RESULT_DIR/profiles/{torch_trace.json|rocprof.json}`
+- `$RESULT_DIR/kernel_candidates.json` — fed to `kernel-opt.md`
+- Top-20 breakdown printed to console for the user to read
+
+## Failure Handling
+- `rocprofv3` not installed: try `rocprof` (v2) or `omnitrace`. If none available,
+  skip profile and proceed with env-vars + compile-flags only (will still produce
+  gains, just blind).
+- Trace file empty: re-run with longer `--benchmark_min_time` (5s).

--- a/.cursor/skills/generic-gpu-optimization/actions/profile.md
+++ b/.cursor/skills/generic-gpu-optimization/actions/profile.md
@@ -33,34 +33,61 @@ esac
 ```
 
 ### Step 2: Top-20 kernel breakdown
+
+The exact JSON schema differs between profilers. Use the helper below — it
+recognizes torch.profiler Chrome traces, rocprofv3 (`rocprofiler-sdk-tool`),
+rocprof-v2 CSV-derived JSON (`{"kernels": [...]}`), and falls back to a
+generic `traceEvents` walker.
+
 ```python
 import json, sys
 from collections import defaultdict
 
+def kernel_breakdown(trace_path):
+    data = json.load(open(trace_path))
+    times, counts = defaultdict(float), defaultdict(int)
+
+    # ---- rocprofv3 schema ------------------------------------------------
+    if isinstance(data, dict) and "rocprofiler-sdk-tool" in data:
+        top = data["rocprofiler-sdk-tool"][0]
+        sym = {s["kernel_id"]: s["kernel_name"]
+               for s in top.get("kernel_symbols", [])
+               if s.get("kernel_name")}
+        for d in top.get("buffer_records", {}).get("kernel_dispatch", []):
+            kid = d.get("kernel_id") or d.get("dispatch_info", {}).get("kernel_id")
+            name = sym.get(kid, f"<id_{kid}>")
+            dur_ns = d["end_timestamp"] - d["start_timestamp"]
+            times[name] += dur_ns / 1000.0   # ns -> us
+            counts[name] += 1
+        return times, counts
+
+    # ---- rocprof v2 fallback (our wrapper writes {kernels: [{KernelName,DurationNs}]})
+    if isinstance(data, dict) and "kernels" in data:
+        for e in data["kernels"]:
+            times[e["KernelName"]] += e.get("DurationNs", 0) / 1000.0
+            counts[e["KernelName"]] += 1
+        return times, counts
+
+    # ---- torch.profiler Chrome trace -------------------------------------
+    events = data.get("traceEvents", []) if isinstance(data, dict) else data
+    for e in events:
+        if isinstance(e, dict) and e.get("cat") == "kernel" and "dur" in e:
+            times[e["name"]] += e["dur"]   # already us
+            counts[e["name"]] += 1
+    return times, counts
+
+
 trace_path = sys.argv[1]
-trace = json.load(open(trace_path))
-
-# rocprofv3 vs torch.profiler schema
-events = trace.get("traceEvents", trace.get("kernels", trace))
-
-kernel_time = defaultdict(float)
-kernel_count = defaultdict(int)
-for e in events:
-    if isinstance(e, dict):
-        # torch.profiler
-        if e.get("cat") == "kernel" and "dur" in e:
-            kernel_time[e["name"]] += e["dur"]
-            kernel_count[e["name"]] += 1
-        # rocprofv3 has KernelName + DurationNs
-        elif "KernelName" in e:
-            kernel_time[e["KernelName"]] += e.get("DurationNs", 0) / 1000.0  # to us
-            kernel_count[e["KernelName"]] += 1
-
-total = sum(kernel_time.values())
-print(f"\nTop-20 kernels ({total/1e6:.2f}s total):\n")
-for name, t in sorted(kernel_time.items(), key=lambda x: -x[1])[:20]:
-    print(f"  {name[:80]:80s}  {t/1000:>8.1f}ms  {t/total*100:>5.1f}%  {kernel_count[name]:>5d}x")
+times, counts = kernel_breakdown(trace_path)
+total = sum(times.values())
+print(f"\nTop-20 kernels ({total/1e3:.2f} ms total GPU time):\n")
+for name, t in sorted(times.items(), key=lambda x: -x[1])[:20]:
+    short = name if len(name) <= 80 else name[:77] + "..."
+    print(f"  {short:80s}  {t:>9.1f}us  {t/total*100:>5.1f}%  {counts[name]:>5d}x")
 ```
+
+The helper is also available as `$SKILL_ROOT/scripts/analyze_profile.py` so the
+agent doesn't have to inline this every run.
 
 ### Step 3: Extract GEAK candidates
 A kernel becomes a candidate if ALL hold:

--- a/.cursor/skills/generic-gpu-optimization/actions/report.md
+++ b/.cursor/skills/generic-gpu-optimization/actions/report.md
@@ -1,0 +1,94 @@
+# Action: Final Optimization Report
+
+## Inputs
+- `$RESULT_DIR/results.tsv`
+- `$RESULT_DIR/kept_env.sh`
+- `$RESULT_DIR/kept_cmake.txt`
+- `$RESULT_DIR/patches/`
+- `$RESULT_DIR/profile.log`
+- `$RESULT_DIR/state.env`
+
+## Output: `$RESULT_DIR/optimization_report.md`
+
+### Template
+
+```markdown
+# Hyperloom Generic-GPU Optimization Report
+
+**Repo:** `$REPO_ROOT`
+**Project class:** `$PROJECT_CLASS`
+**GPU:** `$GPU` (`$GPU_ARCH`), ROCm `$ROCM_VERSION`
+**Baseline SHA:** `$BASELINE_SHA`
+**Run started:** `$START_TIME`
+**Run duration:** `$DURATION_MIN` minutes
+
+## Headline
+
+| Metric | Baseline | Optimized | Delta |
+|---|---|---|---|
+| `$BENCH_METRIC` | `$BASELINE_METRIC` | `$BEST_METRIC` | **`$BEST_DELTA_PCT`%** |
+
+## What worked
+
+| Attempt | Action | Description | Delta |
+|---|---|---|---|
+… extracted from results.tsv, status=KEEP …
+
+## What didn't
+
+| Attempt | Action | Description | Why discarded |
+|---|---|---|---|
+… status in {DISCARD, INVALID, NOISE} …
+
+## Reproduction
+
+### 1. Apply environment
+```bash
+source $RESULT_DIR/kept_env.sh
+```
+
+### 2. Apply build flags
+```bash
+$(cat $RESULT_DIR/kept_cmake.txt)
+```
+
+### 3. Apply code patches
+```bash
+git apply $RESULT_DIR/patches/*.patch
+```
+
+### 4. Build & run
+```bash
+$BUILD_COMMAND
+$BENCH_COMMAND
+```
+
+## Profile diff
+
+Top-5 kernels (by GPU %):
+- Baseline: …
+- Optimized: …
+
+## Knowledge contribution
+
+Entries appended to `$SKILL_ROOT/kb/entries.jsonl`:
+- New optimizations validated for `$PROJECT_CLASS` on `$GPU_ARCH`
+- New pitfalls (e.g. flag X breaks correctness when Y)
+
+## Notes for the next run
+… any remaining hot kernels, env vars not yet tried, ideas the agent ran out of
+time for …
+```
+
+## Procedure
+1. Read all inputs.
+2. Render the markdown template.
+3. Append KB entries via `python3 $SKILL_ROOT/kb/kb_ingest.py < new_entries.jsonl`
+   (re-uses the `training-optimization` KB schema — see
+   `.cursor/skills/training-optimization/kb/kb_schema.py`).
+4. Print the report path to the user.
+
+## Failure Handling
+- Missing inputs (e.g. `kept_env.sh` doesn't exist): include "no winning env vars" in the report.
+- Empty `results.tsv` beyond baseline: report "no successful optimizations" but
+  still write the report so the user has the profile.

--- a/.cursor/skills/generic-gpu-optimization/actions/setup.md
+++ b/.cursor/skills/generic-gpu-optimization/actions/setup.md
@@ -1,0 +1,72 @@
+# Action: Environment Setup
+
+## Inputs
+- `$REPO_ROOT` (required) — path to the user's GPU repo
+- `$GPU` (optional) — GPU type override (e.g. MI300X / MI355X)
+- `$TIME_BUDGET_MIN` (optional, default 90)
+
+## Procedure
+
+### Step 1: Validate repo exists
+```bash
+: "${REPO_ROOT:?REPO_ROOT required}"
+[ -d "$REPO_ROOT" ] || { echo "ERROR: $REPO_ROOT does not exist"; exit 1; }
+```
+
+### Step 2: Detect GPU + ROCm
+```bash
+GPU_NAME=$(rocm-smi --showproductname 2>/dev/null | grep -oE "MI[0-9]+[A-Z]*" | head -1)
+GPU_ARCH=$(rocminfo 2>/dev/null | grep -m1 -oE "gfx[0-9]+[a-z]*")
+ROCM_VERSION=$(cat /opt/rocm/.info/version 2>/dev/null || hipconfig --version 2>/dev/null)
+GPU_COUNT=$(rocm-smi -i 2>/dev/null | grep -c "GPU\[")
+
+export GPU="${GPU:-$GPU_NAME}"
+export GPU_ARCH GPU_COUNT ROCM_VERSION
+
+[ -n "$GPU_ARCH" ] || { echo "ERROR: no AMD GPU detected (rocminfo failed)"; exit 1; }
+echo "GPU: $GPU ($GPU_ARCH), $GPU_COUNT devices, ROCm $ROCM_VERSION"
+```
+
+### Step 3: Create result directory
+```bash
+TIMESTAMP=$(date +%Y-%m-%d-%H-%M)
+export RESULT_DIR="${RESULT_DIR:-/tmp/hyperloom-results/$(basename "$REPO_ROOT")-$TIMESTAMP}"
+mkdir -p "$RESULT_DIR/patches" "$RESULT_DIR/profiles"
+echo "Results: $RESULT_DIR"
+```
+
+### Step 4: Snapshot baseline git state
+```bash
+cd "$REPO_ROOT"
+if git rev-parse --git-dir >/dev/null 2>&1; then
+    BASELINE_SHA=$(git rev-parse HEAD)
+    git status --porcelain > "$RESULT_DIR/git_status_baseline.txt"
+    [ -s "$RESULT_DIR/git_status_baseline.txt" ] && \
+        echo "WARNING: working tree not clean — patches may apply on top of local changes"
+    echo "Baseline SHA: $BASELINE_SHA"
+    export BASELINE_SHA
+fi
+```
+
+### Step 5: Initialize state file
+```bash
+cat > "$RESULT_DIR/state.env" <<STATE
+REPO_ROOT=$REPO_ROOT
+RESULT_DIR=$RESULT_DIR
+GPU=$GPU
+GPU_ARCH=$GPU_ARCH
+GPU_COUNT=$GPU_COUNT
+ROCM_VERSION=$ROCM_VERSION
+BASELINE_SHA=${BASELINE_SHA:-}
+TIME_BUDGET_MIN=${TIME_BUDGET_MIN:-90}
+STATE
+```
+
+## Outputs
+- `$RESULT_DIR` populated
+- `$RESULT_DIR/state.env` — sourceable across all subsequent actions
+- GPU info exported
+
+## Failure Handling
+- No AMD GPU: stop with clear error
+- No git: continue, but warn that patch tracking degrades

--- a/.cursor/skills/generic-gpu-optimization/actions/setup.md
+++ b/.cursor/skills/generic-gpu-optimization/actions/setup.md
@@ -18,7 +18,7 @@
 GPU_NAME=$(rocm-smi --showproductname 2>/dev/null | grep -oE "MI[0-9]+[A-Z]*" | head -1)
 GPU_ARCH=$(rocminfo 2>/dev/null | grep -m1 -oE "gfx[0-9]+[a-z]*")
 ROCM_VERSION=$(cat /opt/rocm/.info/version 2>/dev/null || hipconfig --version 2>/dev/null)
-GPU_COUNT=$(rocm-smi -i 2>/dev/null | grep -c "GPU\[")
+GPU_COUNT=$(rocm-smi --showid 2>/dev/null | grep -oE "GPU\[[0-9]+\]" | sort -u | wc -l)
 
 export GPU="${GPU:-$GPU_NAME}"
 export GPU_ARCH GPU_COUNT ROCM_VERSION

--- a/.cursor/skills/generic-gpu-optimization/scripts/analyze_profile.py
+++ b/.cursor/skills/generic-gpu-optimization/scripts/analyze_profile.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+analyze_profile.py — print a top-N kernel breakdown from a profiler trace.
+
+Supported schemas:
+  * rocprofv3       : { "rocprofiler-sdk-tool": [{ "kernel_symbols": [...],
+                                                   "buffer_records": {"kernel_dispatch": [...]}}] }
+  * rocprof v2 wrap : { "kernels": [{"KernelName", "DurationNs"}, ...] }
+  * torch.profiler  : { "traceEvents": [{"cat":"kernel","name","dur"}, ...] }
+
+Usage:
+  analyze_profile.py <trace.json> [--top N] [--json]
+
+Prints a ranked list to stdout; if --json is given, also emits a structured
+list to <trace>.kernels.json suitable for ingestion by kernel-opt.md.
+"""
+import argparse, json, sys
+from collections import defaultdict
+from pathlib import Path
+
+
+def kernel_breakdown(trace_path):
+    """Return (times_us, counts) dicts keyed by kernel name."""
+    data = json.load(open(trace_path))
+    times, counts = defaultdict(float), defaultdict(int)
+
+    if isinstance(data, dict) and "rocprofiler-sdk-tool" in data:
+        top = data["rocprofiler-sdk-tool"][0]
+        sym = {s["kernel_id"]: s["kernel_name"]
+               for s in top.get("kernel_symbols", [])
+               if s.get("kernel_name")}
+        for d in top.get("buffer_records", {}).get("kernel_dispatch", []):
+            kid = d.get("kernel_id") or d.get("dispatch_info", {}).get("kernel_id")
+            name = sym.get(kid, f"<id_{kid}>")
+            dur_ns = d["end_timestamp"] - d["start_timestamp"]
+            times[name] += dur_ns / 1000.0
+            counts[name] += 1
+        return times, counts
+
+    if isinstance(data, dict) and "kernels" in data:
+        for e in data["kernels"]:
+            times[e["KernelName"]] += e.get("DurationNs", 0) / 1000.0
+            counts[e["KernelName"]] += 1
+        return times, counts
+
+    events = data.get("traceEvents", []) if isinstance(data, dict) else data
+    for e in events:
+        if isinstance(e, dict) and e.get("cat") == "kernel" and "dur" in e:
+            times[e["name"]] += e["dur"]
+            counts[e["name"]] += 1
+    return times, counts
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("trace")
+    ap.add_argument("--top", type=int, default=20)
+    ap.add_argument("--json", action="store_true",
+                    help="also write <trace>.kernels.json with structured ranking")
+    args = ap.parse_args()
+
+    times, counts = kernel_breakdown(args.trace)
+    total = sum(times.values())
+    if not total:
+        print(f"WARN: no kernel time found in {args.trace}", file=sys.stderr)
+        sys.exit(2)
+
+    ranked = sorted(times.items(), key=lambda x: -x[1])
+    print(f"\nTop-{args.top} kernels ({total/1e3:.2f} ms total GPU time):\n")
+    for name, t in ranked[:args.top]:
+        short = name if len(name) <= 80 else name[:77] + "..."
+        print(f"  {short:80s}  {t:>9.1f}us  {t/total*100:>5.1f}%  {counts[name]:>5d}x")
+
+    if args.json:
+        out = Path(args.trace).with_suffix(".kernels.json")
+        json.dump(
+            [{"name": n, "time_us": t, "pct_total": t/total*100, "count": counts[n]}
+             for n, t in ranked],
+            open(out, "w"),
+            indent=2,
+        )
+        print(f"\nWrote ranked breakdown -> {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.cursor/skills/generic-gpu-optimization/scripts/common.sh
+++ b/.cursor/skills/generic-gpu-optimization/scripts/common.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# =============================================================================
+# generic-gpu-optimization/scripts/common.sh
+# Shared helpers. Source me, or invoke as: ./common.sh <function> <args>
+# =============================================================================
+
+set -euo pipefail
+
+# --- kill_workload --------------------------------------------------------
+# Kill any lingering benchmark / training processes from the target repo.
+kill_workload() {
+    local patterns="${1:-bench|benchmark|torchrun}"
+    pkill -9 -f "$patterns" 2>/dev/null || true
+    sleep 2
+}
+
+# --- extract_metric -------------------------------------------------------
+# Args: <log_file> <regex_with_one_capture_group>
+# Prints the matched value, or empty.
+extract_metric() {
+    local log="$1"
+    local regex="$2"
+    [ -f "$log" ] || { echo ""; return 1; }
+
+    python3 - "$log" "$regex" <<'PY'
+import re, sys
+log_path, regex = sys.argv[1], sys.argv[2]
+matches = []
+for line in open(log_path, errors="ignore"):
+    m = re.search(regex, line)
+    if m:
+        try:
+            matches.append(float(m.group(1)))
+        except (ValueError, IndexError):
+            pass
+if not matches:
+    sys.exit(0)
+# Use last match (final summary), or median if many
+if len(matches) > 5:
+    matches.sort()
+    print(f"{matches[len(matches)//2]:.4f}")
+else:
+    print(f"{matches[-1]:.4f}")
+PY
+}
+
+# --- copy_or_warn ---------------------------------------------------------
+copy_or_warn() {
+    local src="$1" dst="$2"
+    if [ -f "$src" ]; then cp "$src" "$dst"; else echo "WARN: missing $src"; fi
+}
+
+# --- next_attempt_id ------------------------------------------------------
+next_attempt_id() {
+    local results="${1:-$RESULT_DIR/results.tsv}"
+    if [ -f "$results" ]; then
+        awk -F'\t' 'NR>1 {print $1}' "$results" | sort -n | tail -1 | awk '{print $1+1}'
+    else
+        echo 0
+    fi
+}
+
+# --- gpu_idle_check -------------------------------------------------------
+gpu_idle_check() {
+    local pct
+    pct=$(rocm-smi --showuse 2>/dev/null | grep -oE '[0-9]+%' | head -1 | tr -d '%')
+    if [ -n "$pct" ] && [ "$pct" -gt 5 ]; then
+        echo "WARN: GPU $pct% busy — measurement noise will be high"
+    fi
+}
+
+# Allow invoking as a CLI
+if [ "${BASH_SOURCE[0]}" = "$0" ] && [ $# -gt 0 ]; then
+    "$@"
+fi

--- a/.cursor/skills/generic-gpu-optimization/scripts/detect_project.sh
+++ b/.cursor/skills/generic-gpu-optimization/scripts/detect_project.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# =============================================================================
+# detect_project.sh — heuristic project classifier
+#
+# Usage: detect_project.sh <repo_root>
+# Output (stdout): KEY=VALUE lines suitable for `source`.
+#
+# Sets:
+#   PROJECT_CLASS    - hip-cmake-bench / pytorch-script / triton-collection / hpc-app / unknown
+#   BUILD_SYSTEM     - cmake / setup.py / pyproject / make / none
+#   BUILD_COMMAND    - exact command to (re)build from scratch
+#   BENCH_COMMAND    - exact command to run the benchmark
+#   BENCH_METRIC     - name of the metric (ms_per_iter / items_per_sec / etc.)
+#   BENCH_METRIC_REGEX - regex with one capture group to grep the metric out of bench output
+#   METRIC_LOWER_IS_BETTER - true / false
+#   TEST_COMMAND     - command to run tests (may be empty)
+#   CORRECTNESS_MODE - tests / golden-output / none
+# =============================================================================
+
+# NOTE: pipefail is intentionally OFF — many `find ... | head -1` pipelines below
+# would otherwise SIGPIPE-fail and abort detection.
+set -eu
+REPO_ROOT="${1:?repo root required}"
+[ -d "$REPO_ROOT" ] || { echo "ERROR: $REPO_ROOT not found" >&2; exit 1; }
+
+cd "$REPO_ROOT"
+
+# --- 1. Build system detection -------------------------------------------
+HAS_CMAKE=$([ -f CMakeLists.txt ] || [ -f cpp/CMakeLists.txt ] && echo 1 || echo 0)
+HAS_PYPROJECT=$([ -f pyproject.toml ] && echo 1 || echo 0)
+HAS_SETUP_PY=$([ -f setup.py ] && echo 1 || echo 0)
+HAS_MAKEFILE=$([ -f Makefile ] && echo 1 || echo 0)
+HAS_BUILD_SH=$([ -f build.sh ] && echo 1 || echo 0)
+
+# --- 2. Kernel language signals ------------------------------------------
+HAS_HIP=$( find . -name '*.hip' -o -name '*.cuh' -o -name '*.cu' 2>/dev/null | head -1 | wc -l )
+HAS_TRITON=$( grep -r -l --include='*.py' '@triton.jit' . 2>/dev/null | head -1 | wc -l )
+
+# --- 3. Benchmark harness signals ----------------------------------------
+HAS_GBENCH=$( grep -r -l --include='CMakeLists.txt' 'benchmark::benchmark' . 2>/dev/null | head -1 | wc -l )
+HAS_CATCH2=$( grep -r -l --include='CMakeLists.txt' 'Catch2' . 2>/dev/null | head -1 | wc -l )
+HAS_BENCH_DIR=$( [ -d bench ] || [ -d benchmarks ] || [ -d cpp/bench ] && echo 1 || echo 0 )
+HAS_PY_BENCH=$( find . -maxdepth 3 -name 'bench*.py' -o -name 'benchmark*.py' 2>/dev/null | head -1 | wc -l )
+
+# --- 4. Test harness signals ---------------------------------------------
+HAS_CTEST=$( find . -name 'CTestTestfile.cmake' -o -name 'tests' -type d 2>/dev/null | head -1 | wc -l )
+HAS_PYTEST=$( ([ -d tests ] || [ -d test ] || grep -q '^pytest' pyproject.toml 2>/dev/null) && echo 1 || echo 0 )
+
+# --- 5. Classify ---------------------------------------------------------
+PROJECT_CLASS="unknown"
+BUILD_SYSTEM="none"
+BUILD_COMMAND=""
+BENCH_COMMAND=""
+BENCH_METRIC="ms_per_iter"
+BENCH_METRIC_REGEX="ms_per_iter[:\s=]+([0-9.]+)"
+METRIC_LOWER_IS_BETTER="true"
+TEST_COMMAND=""
+CORRECTNESS_MODE="none"
+
+if [ "$HAS_CMAKE" = 1 ] && [ "$HAS_HIP" -gt 0 ] && { [ "$HAS_GBENCH" -gt 0 ] || [ "$HAS_BENCH_DIR" = 1 ]; }; then
+    PROJECT_CLASS="hip-cmake-bench"
+    BUILD_SYSTEM="cmake"
+
+    # Prefer build.sh if it exists (often handles ROCm specifics)
+    if [ "$HAS_BUILD_SH" = 1 ]; then
+        BUILD_COMMAND="bash $REPO_ROOT/build.sh"
+    else
+        # Find the right CMakeLists root (some projects have it under cpp/)
+        if [ -f cpp/CMakeLists.txt ]; then
+            BUILD_COMMAND="cmake -S cpp -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j\$(nproc)"
+        else
+            BUILD_COMMAND="cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j\$(nproc)"
+        fi
+    fi
+
+    # Find the first bench binary; user can override via BENCH_COMMAND
+    BENCH_BIN=$(find build* cpp/build* -maxdepth 6 -type f -executable 2>/dev/null | grep -iE 'bench|benchmark' | head -1 || true)
+    if [ -n "$BENCH_BIN" ]; then
+        BENCH_COMMAND="$BENCH_BIN --benchmark_format=json --benchmark_min_time=2s --benchmark_repetitions=3"
+        # Google Benchmark prints "real_time" in JSON; the regex picks the mean
+        BENCH_METRIC="real_time_ns"
+        BENCH_METRIC_REGEX='"real_time"\s*:\s*([0-9.]+)'
+    else
+        # No built binary yet — emit a hint with a likely path and Google Benchmark args
+        BENCH_DIR=$(find . cpp -maxdepth 3 -type d \( -name bench -o -name benchmarks \) 2>/dev/null | head -1 || true)
+        if [ -n "$BENCH_DIR" ]; then
+            BENCH_COMMAND="<rerun detect after build; expected: \$BUILD_DIR/${BENCH_DIR#./}/<BIN> --benchmark_format=json --benchmark_min_time=2s>"
+            BENCH_METRIC="real_time_ns"
+            BENCH_METRIC_REGEX='"real_time"\s*:\s*([0-9.]+)'
+        fi
+    fi
+
+    if [ "$HAS_CTEST" = 1 ]; then
+        TEST_COMMAND="cd build && ctest --output-on-failure -j\$(nproc)"
+        CORRECTNESS_MODE="tests"
+    else
+        CORRECTNESS_MODE="golden-output"
+    fi
+
+elif [ "$HAS_TRITON" -gt 0 ] && { [ "$HAS_PY_BENCH" -gt 0 ] || [ -d benchmarks ]; }; then
+    PROJECT_CLASS="triton-collection"
+    BUILD_SYSTEM=$([ "$HAS_PYPROJECT" = 1 ] && echo pyproject || echo setup.py)
+    BUILD_COMMAND="pip install -e ."
+
+    BENCH_PY=$(find . -maxdepth 3 \( -name 'bench*.py' -o -name 'benchmark*.py' \) 2>/dev/null | head -1)
+    BENCH_COMMAND="python $BENCH_PY"
+    BENCH_METRIC_REGEX="(?:ms_per_iter|latency_ms|time_ms)[:\s=]+([0-9.]+)"
+
+    if [ "$HAS_PYTEST" = 1 ]; then
+        TEST_COMMAND="pytest -x"
+        CORRECTNESS_MODE="tests"
+    fi
+
+elif { [ "$HAS_PYPROJECT" = 1 ] || [ "$HAS_SETUP_PY" = 1 ]; } && grep -r -l --include='*.py' '^import torch\|^from torch' . 2>/dev/null | head -1 >/dev/null; then
+    PROJECT_CLASS="pytorch-script"
+    BUILD_SYSTEM=$([ "$HAS_PYPROJECT" = 1 ] && echo pyproject || echo setup.py)
+    BUILD_COMMAND="pip install -e ."
+
+    # Look for an obvious entrypoint
+    ENTRY=$(find . -maxdepth 3 \( -name 'bench*.py' -o -name 'benchmark*.py' -o -name 'run.py' -o -name 'main.py' \) 2>/dev/null | head -1)
+    if [ -n "$ENTRY" ]; then
+        BENCH_COMMAND="python $ENTRY"
+    fi
+    BENCH_METRIC_REGEX="(?:ms_per_iter|samples_per_sec|tokens_per_sec)[:\s=]+([0-9.]+)"
+
+    if [ "$HAS_PYTEST" = 1 ]; then
+        TEST_COMMAND="pytest -x"
+        CORRECTNESS_MODE="tests"
+    fi
+
+elif [ "$HAS_MAKEFILE" = 1 ] && [ "$HAS_HIP" -gt 0 ]; then
+    PROJECT_CLASS="hpc-app"
+    BUILD_SYSTEM="make"
+    BUILD_COMMAND="make -j\$(nproc)"
+    # User MUST provide BENCH_COMMAND override
+fi
+
+# --- 6. Emit -------------------------------------------------------------
+cat <<OUT
+PROJECT_CLASS=$PROJECT_CLASS
+BUILD_SYSTEM=$BUILD_SYSTEM
+BUILD_COMMAND="$BUILD_COMMAND"
+BENCH_COMMAND="$BENCH_COMMAND"
+BENCH_METRIC=$BENCH_METRIC
+BENCH_METRIC_REGEX='$BENCH_METRIC_REGEX'
+METRIC_LOWER_IS_BETTER=$METRIC_LOWER_IS_BETTER
+TEST_COMMAND="$TEST_COMMAND"
+CORRECTNESS_MODE=$CORRECTNESS_MODE
+HAS_HIP=$HAS_HIP
+HAS_TRITON=$HAS_TRITON
+OUT

--- a/.cursor/skills/generic-gpu-optimization/scripts/detect_project.sh
+++ b/.cursor/skills/generic-gpu-optimization/scripts/detect_project.sh
@@ -43,8 +43,20 @@ HAS_BENCH_DIR=$( [ -d bench ] || [ -d benchmarks ] || [ -d cpp/bench ] && echo 1
 HAS_PY_BENCH=$( find . -maxdepth 3 -name 'bench*.py' -o -name 'benchmark*.py' 2>/dev/null | head -1 | wc -l )
 
 # --- 4. Test harness signals ---------------------------------------------
-HAS_CTEST=$( find . -name 'CTestTestfile.cmake' -o -name 'tests' -type d 2>/dev/null | head -1 | wc -l )
+# Locate the actual CTestTestfile.cmake (its dir is where ctest must be invoked)
+CTEST_FILE=$(find build* cpp/build* -maxdepth 2 -name 'CTestTestfile.cmake' 2>/dev/null | head -1 || true)
+HAS_CTEST=$([ -n "$CTEST_FILE" ] && echo 1 || echo 0)
+CTEST_DIR=$([ -n "$CTEST_FILE" ] && dirname "$CTEST_FILE" || echo "")
 HAS_PYTEST=$( ([ -d tests ] || [ -d test ] || grep -q '^pytest' pyproject.toml 2>/dev/null) && echo 1 || echo 0 )
+
+# Determine the cmake source root (./ vs cpp/) so build/test commands point at the right place
+if [ -f cpp/CMakeLists.txt ]; then
+    CMAKE_SRC="cpp"
+    DEFAULT_BUILD_DIR="cpp/build"
+else
+    CMAKE_SRC="."
+    DEFAULT_BUILD_DIR="build"
+fi
 
 # --- 5. Classify ---------------------------------------------------------
 PROJECT_CLASS="unknown"
@@ -65,33 +77,30 @@ if [ "$HAS_CMAKE" = 1 ] && [ "$HAS_HIP" -gt 0 ] && { [ "$HAS_GBENCH" -gt 0 ] || 
     if [ "$HAS_BUILD_SH" = 1 ]; then
         BUILD_COMMAND="bash $REPO_ROOT/build.sh"
     else
-        # Find the right CMakeLists root (some projects have it under cpp/)
-        if [ -f cpp/CMakeLists.txt ]; then
-            BUILD_COMMAND="cmake -S cpp -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j\$(nproc)"
-        else
-            BUILD_COMMAND="cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j\$(nproc)"
-        fi
+        BUILD_COMMAND="cmake -S $CMAKE_SRC -B $DEFAULT_BUILD_DIR -DCMAKE_BUILD_TYPE=Release && cmake --build $DEFAULT_BUILD_DIR -j\$(nproc)"
     fi
 
     # Find the first bench binary; user can override via BENCH_COMMAND
-    BENCH_BIN=$(find build* cpp/build* -maxdepth 6 -type f -executable 2>/dev/null | grep -iE 'bench|benchmark' | head -1 || true)
+    BENCH_BIN=$(find $DEFAULT_BUILD_DIR -maxdepth 6 -type f -executable 2>/dev/null | grep -iE 'bench|benchmark' | head -1 || true)
     if [ -n "$BENCH_BIN" ]; then
         BENCH_COMMAND="$BENCH_BIN --benchmark_format=json --benchmark_min_time=2s --benchmark_repetitions=3"
         # Google Benchmark prints "real_time" in JSON; the regex picks the mean
         BENCH_METRIC="real_time_ns"
         BENCH_METRIC_REGEX='"real_time"\s*:\s*([0-9.]+)'
     else
-        # No built binary yet — emit a hint with a likely path and Google Benchmark args
+        # No built binary yet — leave BENCH_COMMAND empty; emit a separate hint
+        # variable so sourcing detected.env doesn't fail under `set -u`.
         BENCH_DIR=$(find . cpp -maxdepth 3 -type d \( -name bench -o -name benchmarks \) 2>/dev/null | head -1 || true)
         if [ -n "$BENCH_DIR" ]; then
-            BENCH_COMMAND="<rerun detect after build; expected: \$BUILD_DIR/${BENCH_DIR#./}/<BIN> --benchmark_format=json --benchmark_min_time=2s>"
+            BENCH_HINT="rerun detect after build; expected bench dir: ${BENCH_DIR#./}"
             BENCH_METRIC="real_time_ns"
             BENCH_METRIC_REGEX='"real_time"\s*:\s*([0-9.]+)'
         fi
     fi
 
     if [ "$HAS_CTEST" = 1 ]; then
-        TEST_COMMAND="cd build && ctest --output-on-failure -j\$(nproc)"
+        # ctest must run from the dir containing CTestTestfile.cmake
+        TEST_COMMAND="cd $CTEST_DIR && ctest --output-on-failure -j\$(nproc)"
         CORRECTNESS_MODE="tests"
     else
         CORRECTNESS_MODE="golden-output"
@@ -136,11 +145,15 @@ elif [ "$HAS_MAKEFILE" = 1 ] && [ "$HAS_HIP" -gt 0 ]; then
 fi
 
 # --- 6. Emit -------------------------------------------------------------
+# All values are quoted; the file must be sourceable under `set -euo pipefail`
+# (no unescaped $VAR references in the values).
+BENCH_HINT="${BENCH_HINT:-}"
 cat <<OUT
 PROJECT_CLASS=$PROJECT_CLASS
 BUILD_SYSTEM=$BUILD_SYSTEM
 BUILD_COMMAND="$BUILD_COMMAND"
 BENCH_COMMAND="$BENCH_COMMAND"
+BENCH_HINT="$BENCH_HINT"
 BENCH_METRIC=$BENCH_METRIC
 BENCH_METRIC_REGEX='$BENCH_METRIC_REGEX'
 METRIC_LOWER_IS_BETTER=$METRIC_LOWER_IS_BETTER

--- a/.cursor/skills/generic-gpu-optimization/scripts/profile_rocm.sh
+++ b/.cursor/skills/generic-gpu-optimization/scripts/profile_rocm.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# =============================================================================
+# profile_rocm.sh — wrap the BENCH_COMMAND with rocprofv3 (or rocprof v2 fallback)
+# Outputs: $RESULT_DIR/profiles/rocprof.json
+# =============================================================================
+set -euo pipefail
+[ -n "${RESULT_DIR:-}" ] || { echo "RESULT_DIR not set"; exit 1; }
+source "$RESULT_DIR/state.env"
+source "$RESULT_DIR/detected.env"
+[ -f "$RESULT_DIR/kept_env.sh" ] && source "$RESULT_DIR/kept_env.sh"
+
+mkdir -p "$RESULT_DIR/profiles"
+cd "$REPO_ROOT"
+
+if command -v rocprofv3 >/dev/null 2>&1; then
+    echo "[profile] using rocprofv3"
+    rocprofv3 \
+        --kernel-trace --hip-trace \
+        --output-format json \
+        -d "$RESULT_DIR/profiles/rocprof_run" \
+        -- bash -c "$BENCH_COMMAND"
+    # Coalesce to a single json
+    find "$RESULT_DIR/profiles/rocprof_run" -name '*.json' -exec cat {} \; > \
+        "$RESULT_DIR/profiles/rocprof.json"
+
+elif command -v rocprof >/dev/null 2>&1; then
+    echo "[profile] using rocprof v2 fallback"
+    rocprof --hip-trace --hsa-trace \
+        -o "$RESULT_DIR/profiles/rocprof.csv" \
+        bash -c "$BENCH_COMMAND"
+    # Convert CSV to a minimal json the analyzer understands
+    python3 - <<PY > "$RESULT_DIR/profiles/rocprof.json"
+import csv, json, sys
+rows = list(csv.DictReader(open("$RESULT_DIR/profiles/rocprof.csv")))
+events = [{"KernelName": r.get("KernelName") or r.get("Name"),
+           "DurationNs": float(r.get("DurationNs") or r.get("Duration") or 0)} for r in rows]
+print(json.dumps({"kernels": events}))
+PY
+
+else
+    echo "ERROR: neither rocprofv3 nor rocprof installed"
+    exit 1
+fi
+
+echo "[profile] wrote $RESULT_DIR/profiles/rocprof.json"

--- a/.cursor/skills/generic-gpu-optimization/scripts/profile_torch.sh
+++ b/.cursor/skills/generic-gpu-optimization/scripts/profile_torch.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# =============================================================================
+# profile_torch.sh — wrap the BENCH_COMMAND with torch.profiler via PYTHONSTARTUP
+# Outputs: $RESULT_DIR/profiles/torch_trace.json
+# =============================================================================
+set -euo pipefail
+[ -n "${RESULT_DIR:-}" ] || { echo "RESULT_DIR not set"; exit 1; }
+source "$RESULT_DIR/state.env"
+source "$RESULT_DIR/detected.env"
+[ -f "$RESULT_DIR/kept_env.sh" ] && source "$RESULT_DIR/kept_env.sh"
+
+mkdir -p "$RESULT_DIR/profiles"
+PROF_OUT="$RESULT_DIR/profiles/torch_trace.json"
+
+# Inject a torch.profiler context via a wrapper script.
+WRAPPER="$RESULT_DIR/profiles/torch_profile_wrapper.py"
+cat > "$WRAPPER" <<PY
+import os, runpy, sys
+import torch
+from torch.profiler import profile, schedule, ProfilerActivity, tensorboard_trace_handler
+
+argv = sys.argv[1:]
+if not argv:
+    print("usage: torch_profile_wrapper.py <script.py> [args...]"); sys.exit(2)
+script, *args = argv
+sys.argv = [script] + args
+
+acts = [ProfilerActivity.CPU, ProfilerActivity.CUDA]
+sched = schedule(wait=2, warmup=2, active=3, repeat=1)
+
+with profile(activities=acts, schedule=sched,
+             on_trace_ready=lambda p: p.export_chrome_trace("$PROF_OUT"),
+             record_shapes=False) as p:
+    runpy.run_path(script, run_name="__main__")
+    p.step()
+PY
+
+cd "$REPO_ROOT"
+# BENCH_COMMAND is "python <script> [args]". Replace "python" with our wrapper invocation.
+WRAPPED=$(echo "$BENCH_COMMAND" | sed -E "s|^python(3?) |python\1 $WRAPPER |")
+echo "[profile-torch] $WRAPPED"
+bash -c "$WRAPPED"
+
+[ -f "$PROF_OUT" ] || { echo "ERROR: torch.profiler did not produce $PROF_OUT"; exit 1; }
+echo "[profile-torch] wrote $PROF_OUT"

--- a/.cursor/skills/generic-gpu-optimization/scripts/run_bench.sh
+++ b/.cursor/skills/generic-gpu-optimization/scripts/run_bench.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# =============================================================================
+# run_bench.sh — dispatcher that runs the detected/overridden BENCH_COMMAND
+# Sources $RESULT_DIR/state.env, $RESULT_DIR/detected.env, $RESULT_DIR/kept_env.sh
+# =============================================================================
+set -euo pipefail
+
+[ -n "${RESULT_DIR:-}" ] || { echo "RESULT_DIR not set"; exit 1; }
+
+source "$RESULT_DIR/state.env"
+source "$RESULT_DIR/detected.env"
+[ -f "$RESULT_DIR/kept_env.sh" ] && source "$RESULT_DIR/kept_env.sh"
+
+[ -n "${BENCH_COMMAND:-}" ] || {
+    echo "ERROR: BENCH_COMMAND empty. Run detect again, or set BENCH_COMMAND before invoking."
+    exit 2
+}
+
+cd "$REPO_ROOT"
+echo "[bench] $BENCH_COMMAND"
+echo "[bench] kept env: $(env | grep -E '^(HSA_|GPU_MAX|HIP_|HSA_FORCE|MIOPEN|TORCH|PYTORCH)' | tr '\n' ' ')"
+exec bash -c "$BENCH_COMMAND"

--- a/.cursor/skills/generic-gpu-optimization/scripts/run_correctness.sh
+++ b/.cursor/skills/generic-gpu-optimization/scripts/run_correctness.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# =============================================================================
+# run_correctness.sh — runs the detected TEST_COMMAND
+# =============================================================================
+set -euo pipefail
+[ -n "${RESULT_DIR:-}" ] || { echo "RESULT_DIR not set"; exit 1; }
+source "$RESULT_DIR/state.env"
+source "$RESULT_DIR/detected.env"
+[ -f "$RESULT_DIR/kept_env.sh" ] && source "$RESULT_DIR/kept_env.sh"
+
+if [ -z "${TEST_COMMAND:-}" ] || [ "$CORRECTNESS_MODE" = "none" ]; then
+    echo "[correctness] no tests configured; skipping"
+    exit 0
+fi
+
+cd "$REPO_ROOT"
+echo "[correctness] $TEST_COMMAND"
+exec bash -c "$TEST_COMMAND"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Block 5-6 - Validated Delivery: The agent optimizes for throughput while maintai
 | | |
 |---|---|
 | **[How the Optimization Loop Works](docs/HOW_THE_OPTIMIZATION_LOOP_WORKS.md)** | Scoring heuristics, stack mechanics, dynamic branching, and the self-evolving knowledge base |
+| **[Generic GPU Optimization](docs/GENERIC_GPU_OPTIMIZATION.md)** | Point Hyperloom at any GPU repo (HIP / Triton / PyTorch); auto-detects build, bench, and tests |
 | **[GLM-5 — Discovering Optimizations Hard to Spot Manually](docs/CASE_STUDY_GLM5.md)** | Hidden GEMM configs, cross-repo kernel patches, +193% throughput |
 | **[DeepSeek-R1 — Fast Scale-Up on a New Workload](docs/CASE_STUDY_DEEPSEEK_R1.md)** | 7 configs to optimal in one session, MTP scheduling fix, +97% over B200 |
 
@@ -135,6 +136,35 @@ The agent takes it from there — baseline, profile, loop, report.
 
 ---
 
+## Quickstart — Any GPU Repo (Generic Mode)
+
+If your project isn't an SGLang/vLLM inference server or a Primus/Megatron training stack — for example a C++/HIP library with Google Benchmark, a standalone Triton kernel collection, or a research PyTorch script — use the **`generic-gpu-optimization`** skill. It auto-detects your build system, benchmark, and tests, then runs the same Hyperloom DFS loop against them.
+
+```bash
+# from the Hyperloom checkout
+./scripts/optimize_repo.sh /path/to/your/gpu/repo
+```
+
+This bootstraps the skill, `mcp.json`, and `.env.template` into your repo, then prints what was auto-detected. Then in Cursor (with the GEAK + OOB MCPs enabled):
+
+```
+@.cursor/skills/generic-gpu-optimization/SKILL.md
+Optimize this repo for MI355X.
+```
+
+The agent runs **setup → detect → build → baseline → correctness → profile → DFS loop (env-vars / compile-flags / GEAK kernel-opt) → report**. Every change is gated against the project's existing test suite (`ctest` / `pytest`); changes that pass tests and improve the metric are kept, everything else is reverted.
+
+Override anything the detector got wrong by passing it in the prompt:
+```
+BENCH_COMMAND: ./build/bench/MATRIX_BENCH --benchmark_filter=select_k --benchmark_format=json
+TEST_COMMAND:  ctest -R MATRIX_TEST --output-on-failure
+TIME_BUDGET_MIN: 60
+```
+
+Full design and the auto-detection rules: **[docs/GENERIC_GPU_OPTIMIZATION.md](docs/GENERIC_GPU_OPTIMIZATION.md)** | Skill README: **[.cursor/skills/generic-gpu-optimization/README.md](.cursor/skills/generic-gpu-optimization/README.md)**
+
+---
+
 ## Quickstart — Fully Local Mode (Docker / K8s)
 
 Run Hyperloom on your own GPU infrastructure — a single container bundles all MCP services (TraceLens, GEAK, OOB Agent), InferenceX, and Skills. No manual MCP or environment setup required.
@@ -194,6 +224,7 @@ Each domain has a comprehensive skill file with the full optimization protocol, 
 | **Training** | [SKILL.md](.cursor/skills/training-optimization/SKILL.md) | [README](.cursor/skills/training-optimization/README.md) |
 | **Inference** | [SKILL.md](.cursor/skills/inference-optimization/SKILL.md) | [README](.cursor/skills/inference-optimization/README.md) |
 | **MLPerf Training** | [SKILL.md](.cursor/skills/mlperf-optimization/SKILL.md) | [Readme](.cursor/skills/mlperf-optimization/Readme.MD) |
+| **Generic GPU Repo** | [SKILL.md](.cursor/skills/generic-gpu-optimization/SKILL.md) | [README](.cursor/skills/generic-gpu-optimization/README.md) |
 
 The skill files are the agent's instructions. They encode the full optimization methodology — setup, profiling protocol, what to try, how to measure, when to stop, and how to report. The knowledge base sections are updated live during runs with new pitfalls and validated results.
 
@@ -208,7 +239,8 @@ Hyperloom/
 │   └── skills/
 │       ├── training-optimization/        # Training optimization skill + knowledge base
 │       ├── inference-optimization/       # Inference optimization skill + scripts
-│       └── mlperf-optimization/          # MLPerf training optimization skill
+│       ├── mlperf-optimization/          # MLPerf training optimization skill
+│       └── generic-gpu-optimization/     # Auto-detect + optimize ANY GPU repo (HIP/Triton/PyTorch)
 ├── inference_optimization/
 │   └── InferenceX/                       # Inference benchmarking framework
 ├── training_optimization/

--- a/docs/GENERIC_GPU_OPTIMIZATION.md
+++ b/docs/GENERIC_GPU_OPTIMIZATION.md
@@ -1,0 +1,141 @@
+# Generic GPU Optimization
+
+Hyperloom's `generic-gpu-optimization` skill lets you point the agent at any
+GPU codebase — not just inference servers (SGLang/vLLM) and not just
+Primus/Megatron training. It auto-detects the project shape and runs the same
+DFS Think → Try → Measure → Decide loop that powers the other skills.
+
+## Design
+
+The skill is built around three observations:
+
+1. **The DFS orchestrator is framework-agnostic.** `SKILL.md` only needs three
+   abstract operations: *build*, *measure*, *test*. Whether "build" means
+   `cmake --build` or `pip install -e .` is just a string.
+2. **Almost any GPU repo provides those three operations**, even if the
+   commands vary. A heuristic detector is enough to find them in 90% of cases;
+   for the rest the user supplies them once.
+3. **GEAK and the OOB Agent MCPs don't care about the surrounding framework.**
+   Given a kernel source file, target arch, and sample shapes, they produce a
+   rewrite. The skill just needs to extract the kernel and splice the result back.
+
+## What the skill detects
+
+Run by `scripts/detect_project.sh`:
+
+| Signal | Implies |
+|---|---|
+| `CMakeLists.txt` + `*.hip`/`*.cu` + `benchmark::benchmark` link | `hip-cmake-bench` |
+| `pyproject.toml` + `import torch` + `bench*.py` | `pytorch-script` |
+| `@triton.jit` + `bench*.py` or `benchmarks/` | `triton-collection` |
+| `Makefile` + `*.hip` + `--bench`/`-b` flag in main | `hpc-app` |
+| `CTestTestfile.cmake` | `tests` correctness mode + `ctest` |
+| `tests/test_*.py` or pyproject pytest section | `tests` correctness mode + `pytest` |
+| neither of the above | `golden-output` (capture first bench output) or `none` |
+
+Detection writes everything to `$RESULT_DIR/detected.env`. Subsequent actions
+just `source` it.
+
+## Action repertoire
+
+Five action types are scored by the heuristic and explored DFS-style:
+
+| Action | Cost | Risk | Typical gain |
+|---|---|---|---|
+| `env-vars`      | seconds        | low (correctness can fail on fine-grain PCIe) | 1-8% |
+| `compile-flags` | minutes (rebuild) | medium (`-ffast-math` can break things) | 2-15% |
+| `kernel-opt` (GEAK) | 10-30 min/kernel | medium (output validated by tests) | 5-50% |
+| `patch` (manual code change) | minutes | medium-high | varies |
+| `torch.compile` (pytorch-script only) | minutes | low | 5-15% |
+
+Initial priors are set by `project_class`; gains/losses re-score after each
+attempt (success boosts similar actions ×1.5, failure penalizes ×0.5).
+
+## Correctness gating
+
+Every kept change must pass the project's own test suite. The skill never
+invents tests — it only runs what's already there:
+
+| Detected | Gate |
+|---|---|
+| `CTestTestfile.cmake` exists | `ctest --output-on-failure` |
+| `tests/test_*.py` exists | `pytest -x` |
+| neither | Capture baseline bench output as golden, compare numerical fields |
+| nothing parseable | Warn user; accept on bench exit-code only |
+
+The gate is mandatory. A 10x speedup that fails tests is reverted, recorded as
+INVALID, and the agent moves on.
+
+## Profiling
+
+| Stack | Tool | Output |
+|---|---|---|
+| `pytorch-script` / `triton-collection` | `torch.profiler` (Chrome trace) | `profiles/torch_trace.json` |
+| `hip-cmake-bench` / `hpc-app` | `rocprofv3` (preferred), `rocprof` v2 fallback | `profiles/rocprof.json` |
+
+Both schemas are normalized to `{KernelName, DurationNs}` for the kernel
+selector, so `kernel-opt.md` doesn't need to know which profiler ran.
+
+## Bootstrap flow
+
+```
+[user] ./scripts/optimize_repo.sh /path/to/repo
+       ├── copies skill to <repo>/.cursor/skills/generic-gpu-optimization/
+       ├── copies mcp.json
+       ├── copies .env.template
+       └── runs detect_project.sh, prints summary
+
+[user] cd /path/to/repo  &&  cp .env.template .env  &&  edit AK_YOUR_API_KEY
+
+[user] open repo in Cursor; in chat:
+       @.cursor/skills/generic-gpu-optimization/SKILL.md
+       Optimize this repo for MI300X.
+
+[agent] setup -> detect -> build -> baseline -> correctness -> profile
+        -> DFS loop (env-vars, compile-flags, kernel-opt) -> report
+```
+
+## Reproducing a run
+
+Every run produces:
+- `$RESULT_DIR/results.tsv`
+- `$RESULT_DIR/optimization_report.md`
+- `$RESULT_DIR/kept_env.sh`
+- `$RESULT_DIR/kept_cmake.txt`
+- `$RESULT_DIR/patches/*.patch`
+
+Reproduction on a clean checkout:
+```bash
+git checkout $BASELINE_SHA
+git apply $RESULT_DIR/patches/*.patch
+$(cat $RESULT_DIR/kept_cmake.txt | tr '\n' ' ')   # rebuild with kept flags
+source $RESULT_DIR/kept_env.sh
+$BENCH_COMMAND
+```
+
+## Limitations
+
+- **No TraceLens for native code.** TraceLens consumes torch.profiler traces;
+  it doesn't analyze rocprof JSON. For C++/HIP projects you get the kernel
+  breakdown but not the full agentic analysis pass.
+- **Multi-GPU correctness is project-defined.** The skill runs whatever the
+  project's tests run; it doesn't synthesize distributed correctness checks.
+- **Build isolation per attempt is per-CMake-cache.** If your project has
+  side-effecting build artifacts outside the build dir (e.g. generated headers
+  in `src/`), you'll need a manual `make clean` between attempts.
+- **Kernel splicing is heuristic.** GEAK output replaces the function body
+  textually. For complex multi-function kernels you may need to apply patches
+  manually.
+
+## Comparison with the other skills
+
+| Concern | inference-optimization | training-optimization | generic-gpu-optimization |
+|---|---|---|---|
+| Server lifecycle | Yes (SGLang/vLLM) | No | No |
+| YAML config parsing | No | Yes (Primus) | No |
+| GBS gate | No | Yes (immutable global batch) | No (uses test suite) |
+| Build system | n/a (pip) | n/a (pip) | Detected: cmake/pip/make |
+| Profiler | torch.profiler + TraceLens | torch.profiler + TraceLens | torch.profiler OR rocprofv3 |
+| GEAK kernel-opt | Yes | Yes | Yes |
+| Initial priors | model-class table | model-class table | project-class table |
+| Stopping criteria | identical | identical | identical |

--- a/scripts/optimize_repo.sh
+++ b/scripts/optimize_repo.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# =============================================================================
+# optimize_repo.sh — bootstrap any repo with the generic-gpu-optimization skill
+#
+# Usage:
+#   ./scripts/optimize_repo.sh <path-to-target-repo> [--force]
+#
+# What it does:
+#   - Copies .cursor/skills/generic-gpu-optimization/ into <target>/.cursor/skills/
+#   - Copies .cursor/mcp.json into <target>/.cursor/ (if not present)
+#   - Copies .env.template into <target>/ (if not present)
+#   - Runs the heuristic detector and prints what was found, so you can review
+#     before opening Cursor
+# =============================================================================
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HYPERLOOM_ROOT="$(dirname "$SCRIPT_DIR")"
+
+TARGET="${1:?usage: optimize_repo.sh <target-repo> [--force]}"
+FORCE="${2:-}"
+
+[ -d "$TARGET" ] || { echo "ERROR: target $TARGET does not exist"; exit 1; }
+TARGET=$(cd "$TARGET" && pwd)
+
+SRC_SKILL="$HYPERLOOM_ROOT/.cursor/skills/generic-gpu-optimization"
+DST_SKILL="$TARGET/.cursor/skills/generic-gpu-optimization"
+SRC_MCP="$HYPERLOOM_ROOT/.cursor/mcp.json"
+DST_MCP="$TARGET/.cursor/mcp.json"
+SRC_ENV="$HYPERLOOM_ROOT/.env.template"
+DST_ENV="$TARGET/.env.template"
+
+echo "Hyperloom root: $HYPERLOOM_ROOT"
+echo "Target repo:    $TARGET"
+echo
+
+# 1. Skill
+mkdir -p "$TARGET/.cursor/skills"
+if [ -d "$DST_SKILL" ] && [ "$FORCE" != "--force" ]; then
+    echo "[skip] $DST_SKILL already exists (use --force to overwrite)"
+else
+    cp -r "$SRC_SKILL" "$DST_SKILL"
+    echo "[ok]   copied skill to $DST_SKILL"
+fi
+
+# 2. MCP config
+if [ -f "$DST_MCP" ] && [ "$FORCE" != "--force" ]; then
+    echo "[skip] $DST_MCP already exists"
+else
+    cp "$SRC_MCP" "$DST_MCP"
+    echo "[ok]   copied $DST_MCP"
+fi
+
+# 3. .env template
+if [ -f "$DST_ENV" ] && [ "$FORCE" != "--force" ]; then
+    echo "[skip] $DST_ENV already exists"
+else
+    cp "$SRC_ENV" "$DST_ENV"
+    echo "[ok]   copied $DST_ENV — copy to .env and fill in AK_YOUR_API_KEY"
+fi
+
+# 4. Run the detector for a sanity preview
+echo
+echo "=== Project detection ==="
+"$SRC_SKILL/scripts/detect_project.sh" "$TARGET" || {
+    echo "WARN: detector failed; the agent will ask you for BUILD_COMMAND/BENCH_COMMAND on first run"
+}
+
+cat <<NEXT
+
+=== Next steps ===
+1. cd $TARGET
+2. cp .env.template .env  &&  edit .env to set AK_YOUR_API_KEY
+3. Open this folder in Cursor with the geak-agent + oci-oob-agent MCP toggles ENABLED
+4. In Cursor chat:
+
+   @.cursor/skills/generic-gpu-optimization/SKILL.md
+   Optimize this repo for ${TARGET##*/} on $(rocm-smi --showproductname 2>/dev/null | grep -oE 'MI[0-9]+[A-Z]*' | head -1 || echo 'MI300X').
+
+The agent will run setup -> detect -> build -> baseline -> profile -> DFS loop.
+Override anything by passing it in the prompt:
+   BENCH_COMMAND: ./build/bench/MY_BENCH --filter=foo
+   TEST_COMMAND:  ctest -R MY_TEST
+   TIME_BUDGET_MIN: 60
+NEXT

--- a/scripts/optimize_repo.sh
+++ b/scripts/optimize_repo.sh
@@ -39,6 +39,9 @@ mkdir -p "$TARGET/.cursor/skills"
 if [ -d "$DST_SKILL" ] && [ "$FORCE" != "--force" ]; then
     echo "[skip] $DST_SKILL already exists (use --force to overwrite)"
 else
+    # Must rm -rf first: `cp -r src dst` with dst existing produces dst/src/,
+    # which would silently leave stale files in the outer dir on re-bootstrap.
+    rm -rf "$DST_SKILL"
     cp -r "$SRC_SKILL" "$DST_SKILL"
     echo "[ok]   copied skill to $DST_SKILL"
 fi


### PR DESCRIPTION
## Summary

Adds a fourth Hyperloom skill, **`generic-gpu-optimization`**, that lets the agent optimize **arbitrary GPU codebases** — not just SGLang/vLLM inference servers (`inference-optimization`) or Primus/Megatron training (`training-optimization`). The skill auto-detects the project shape and runs the same DFS Think → Try → Measure → Decide loop against detected build / bench / test commands.

The existing four skills are untouched; this is purely additive.

## Motivation

Today, pointing Hyperloom at a project that isn't an inference server or a Primus/Megatron training stack means hand-writing a custom skill: rewriting `setup.md`, `classify.md`, `run_baseline.sh`, swapping `torch.profiler` for `rocprofv3`, etc. That's a lot of boilerplate for what is fundamentally the same DFS loop with three abstract operations: *build*, *measure*, *test*.

This skill encodes those three operations as a heuristic detector and a set of dispatchers, so that the agent can be invoked against e.g. a HIP/CMake library, a standalone PyTorch script, or a Triton kernel collection without skill-authoring overhead.

## Usage

### Bootstrap any repo in one command

```bash
# from the Hyperloom checkout
./scripts/optimize_repo.sh /path/to/your/gpu/repo
```

This:
- copies `.cursor/skills/generic-gpu-optimization/` into the target
- copies `.cursor/mcp.json` (GEAK + OOB MCPs)
- copies `.env.template`
- runs the heuristic detector and prints what was found

### Run from Cursor

After setting `AK_YOUR_API_KEY` in `<target>/.env` and enabling the GEAK + OOB MCP toggles:

```
@.cursor/skills/generic-gpu-optimization/SKILL.md
Optimize this repo for MI355X.
```

The agent runs **setup → detect → build → baseline → correctness → profile → DFS loop (env-vars / compile-flags / GEAK kernel-opt) → report**. Every kept change is gated against the project's own test suite (ctest / pytest); regressions and correctness failures auto-revert.

### Override anything

If the detector got something wrong, override in the prompt:

```
@.cursor/skills/generic-gpu-optimization/SKILL.md
Optimize this repo for MI300X.

BENCH_COMMAND: ./build/bench/MATRIX_BENCH --benchmark_filter=select_k --benchmark_format=json
TEST_COMMAND:  ctest -R MATRIX_TEST --output-on-failure
TIME_BUDGET_MIN: 60
```

## What gets detected

| Project signal | Classified as | Default build | Default bench | Default tests |
|---|---|---|---|---|
| `CMakeLists.txt` + `*.hip` + `benchmark::benchmark` link | `hip-cmake-bench` | `cmake --build` (or `build.sh` if present) | first executable matching `*bench*` in build dir | `ctest` (located in actual `CTestTestfile.cmake` dir) |
| `pyproject.toml` + `import torch` + `bench*.py` | `pytorch-script` | `pip install -e .` | `python <entrypoint>` | `pytest -x` |
| `@triton.jit` + `bench*.py` or `benchmarks/` | `triton-collection` | `pip install -e .` | `python bench.py` | `pytest -x` |
| `Makefile` + `*.hip` | `hpc-app` | `make -j$(nproc)` | (user override required) | (user override) |
| (none of the above) | `unknown` | (user override required) | (user override) | (user override) |

The detector skips vendored trees (`thirdparty/`, `_deps/`, `.venv/`, `site-packages/`, `build*/`) so it doesn't mis-classify based on code you don't own.

## Action repertoire

| Action | Cost | Risk | Typical gain |
|---|---|---|---|
| `env-vars` | seconds (no rebuild) | low | 1–8 % |
| `compile-flags` | minutes (rebuild) | medium (`-ffast-math` can break things) | 2–15 % |
                                                                                            | `kernel-opt` (GEAK on hot HIP/Triton kernel) | 10–30 min/kernel | medium (output validated by tests) | 5–50 % |
| `patch` (manual code change) | minutes | medium-high | varies |
| `torch.compile` (`pytorch-script` only) | minutes | low | 5–15 % |

Initial priors are project-class specific. Re-scoring rules mirror `training-optimization` (success boosts similar actions ×1.5, failure penalizes ×0.5).

## Correctness gating

Every kept change must pass the project's own tests. The skill never invents tests:

- `CTestTestfile.cmake` present → `ctest --output-on-failure`
- `tests/test_*.py` present → `pytest -x`
- neither → capture baseline bench output as golden, compare numerical fields
- nothing parseable → warn user, accept on bench exit-code only

Mandatory gate. A 10× speedup that fails tests is reverted, recorded as INVALID, and the agent moves on.

## Profiling

| Stack | Profiler | Output schema |
|---|---|---|
| `pytorch-script` / `triton-collection` | `torch.profiler` (Chrome trace) | `traceEvents[].cat == "kernel"` |
| `hip-cmake-bench` / `hpc-app` | `rocprofv3` (preferred), `rocprof v2` fallback | `rocprofiler-sdk-tool[].buffer_records.kernel_dispatch[]` |

Both are normalized by `scripts/analyze_profile.py` into a top-N kernel breakdown, so `kernel-opt.md` is profiler-agnostic.

## Verified end-to-end on a real codebase

Smoke-tested against [hipRAFT](https://github.com/AMD-AIOSS/hipRaft) on MI210 (gfx90a) / ROCm 7.2.0:

| Stage | Result |
|---|---|
| bootstrap | Skill, mcp.json, .env.template copied; detector summary printed |
| setup | MI210 / gfx90a / 8 GPUs / ROCm 7.2.0 detected |
| detect | Classified `hip-cmake-bench`, found `build.sh` + `cpp/build/tests/CTestTestfile.cmake`, `KERNEL_LANGS="hip"` |
| correctness | `gtests/UTILS_TEST --gtest_filter='*Bitonic*'` → 45/45 passed in 373 ms |
| baseline | `run_bench.sh` + `extract_metric` → 367 ms |
| profile | `rocprofv3` → 55 MB trace; `analyze_profile.py` → top kernel `raft::util::bitonic_kernel<128, double>` at **21.1 %** of GPU time |
| attempt cycle | 3 env-var attempts ran cleanly through bench → correctness → keep/revert; `kept_env.sh` accumulated wins |

The trace surfaced a real, hardware-grounded finding the skill is designed to expose:

> Every Capacity ≥ 16 instantiation of `bitonic_kernel` is spilling up to **2700 bytes/thread to global scratch**, with **zero AGPRs being used** despite gfx90a having 128 of them per wave. Top three proposed actions:
> 1. compile-flag `-mllvm -amdgpu-spill-vgpr-to-agpr=true`
> 2. patch `local_arr` from registers to LDS at `cpp/tests/util/bitonic_sort.cu:75`
> 3. add `__launch_bounds__(kMaxBlockSize, 2)` to double occupancy

(Negative findings: `GPU_MAX_HW_QUEUES=16` regresses by 27.8 % on this workload — saved as a KB entry candidate so the agent doesn't re-test it.)

## Files added

```
.cursor/skills/generic-gpu-optimization/
├── SKILL.md                 # DFS orchestrator (project-class agnostic)
├── README.md                # Usage guide + worked example
├── actions/                 # 11 playbooks
│   ├── setup.md             # GPU/ROCm detection, RESULT_DIR
│   ├── detect.md            # Auto-discover build/bench/test/kernel-langs
│   ├── build.md             # Dispatches to detected build_command
│   ├── baseline.md          # Runs bench, extracts metric, noise check
│   ├── correctness.md       # Runs detected tests; tests / golden-output / none modes
│   ├── profile.md           # Picks rocprofv3 or torch.profiler
│   ├── env-vars.md          # 11 ROCm runtime env-var candidates
│   ├── compile-flags.md     # CMake / HIP / Clang flag candidates
│   ├── kernel-opt.md        # GEAK MCP submission; works on any HIP/Triton kernel
│   ├── patch.md             # Generic code-patch action with revert protocol
│   └── report.md            # Final report renderer
├── scripts/
│   ├── common.sh            # extract_metric, kill_workload, etc.
│   ├── detect_project.sh    # Heuristic project classifier
│   ├── run_bench.sh         # Dispatcher
│   ├── run_correctness.sh   # Dispatcher
│   ├── profile_rocm.sh      # rocprofv3 wrapper (with rocprof v2 fallback)
│   ├── profile_torch.sh     # torch.profiler wrapper
│   └── analyze_profile.py   # Normalizes 3 profiler schemas → top-N breakdown
└── kb/entries.jsonl         # Empty seed (re-uses training-optimization KB schema)

scripts/optimize_repo.sh     # One-shot bootstrap into a target repo

docs/GENERIC_GPU_OPTIMIZATION.md   # Design + auto-detection rules + skill comparison

README.md                    # New "Quickstart — Any GPU Repo" section, table entry, repo-tree, Learn More link
```
## Commits

The branch is two commits:

- **`0585b48`** `feat: add generic-gpu-optimization skill for arbitrary GPU repos` — initial implementation
- **`f297896`** `fix: bugs surfaced by end-to-end smoke test on hipRAFT` — six real bugs caught during the live smoke run:
  1. `GPU_COUNT` was always wrong (counted lines, not devices) → fixed to `sort -u` on `GPU[N]` indexes
  2. `KERNEL_LANGS="triton"` false-positive (`head | true` exits 0 on empty) → fixed to `[ -n "$(...)" ]`; also added vendored-tree exclusions
  3. `TEST_COMMAND="cd build && ctest"` ignored real `cpp/build/tests/` location → finds actual `CTestTestfile.cmake` dir
  4. `BENCH_COMMAND` placeholder embedded `$BUILD_DIR` → broke `set -u` sourcing; split into `BENCH_HINT`
  5. `optimize_repo.sh --force` silently nested files (`cp -r src dst` when `dst` is a dir) → added `rm -rf` first
  6. `profile.md` analyzer used a guessed schema → rewrote to handle real rocprofv3 (`rocprofiler-sdk-tool` with `kernel_symbols` lookup), promoted to standalone `analyze_profile.py`

## Comparison with the existing skills

| Concern | inference-opt | training-opt | generic-gpu-opt |
|---|---|---|---|
| Server lifecycle | Yes (SGLang/vLLM) | No | No |
| YAML config parsing | No | Yes (Primus) | No |
| GBS gate | No | Yes (immutable global batch) | No (uses test suite) |
| Build system | n/a (pip) | n/a (pip) | Detected: cmake/pip/make |
| Profiler | torch.profiler + TraceLens | torch.profiler + TraceLens | torch.profiler OR rocprofv3 |
| GEAK kernel-opt | Yes | Yes | Yes |
| Initial priors | model-class table | model-class table | project-class table |
| Stopping criteria | identical | identical | identical |

Full design + auto-detection rules: [`docs/GENERIC_GPU_OPTIMIZATION.md`](docs/GENERIC_GPU_OPTIMIZATION.md). Skill README: [`.cursor/skills/generic-gpu-optimization/README.md`](.cursor/skills/generic-gpu-optimization/README.md).

## Untested

- `pytorch-script` path — no suitable non-inference PyTorch project on the test box
- `kernel-opt` action against the live GEAK MCP — needs Cursor + a real `AK_YOUR_API_KEY`
- `compile-flags` action through a full hipRAFT rebuild — would take ~10+ min; the action calls `build.md` which is exercised by `hip-cmake-bench` patterns but not yet end-to-end with a flag swap