### PR TITLE
issue #136 fixing: add AITER stale baton pitfall

### DIFF
--- a/.cursor/skills/inference-optimization/SKILL.md
+++ b/.cursor/skills/inference-optimization/SKILL.md
@@ -212,6 +212,25 @@ These are recurring errors observed in production CI runs. **Read before executi
    those. If not, apply this rule as a fallback. Failure to trace does NOT block
    execution — skip if the script is unavailable.
 
+10. **AITER JIT crash / stale batons: clear orphaned lock files before restarting SGLang.**
+    AITER guards Triton/HIP JIT compilation with file locks ("batons") under
+    `/sgl-workspace/aiter/aiter/jit/build/lock_*`. If the previous SGLang process was
+    hard-killed (SIGKILL, watchdog timeout, OOM, segfault) **during** a JIT compile,
+    the lock file remains on disk with no live owner. The next IR-4 relaunch then
+    blocks forever with `waiting for baton release at .../jit/build/lock_*` and never
+    reaches the health endpoint. After kill + GPU-memory check, verify no live
+    sglang process is legitimately compiling and clear stale locks before relaunch:
+
+    ```bash
+    pgrep -f 'python.*-m sglang.launch_server' >/dev/null || \
+      find /sgl-workspace/aiter/aiter/jit/build -maxdepth 1 -name 'lock_*' -type f -delete
+    ```
+
+    Pair the restart with a longer `--watchdog-timeout` so the watchdog does not kill
+    the new process while it is mid-JIT and is itself the legitimate baton holder.
+    Failure mode: setup/baseline phase hangs, server.log shows repeated
+    `waiting for baton release`, and no benchmark output is ever produced.
+
 ## DFS Search Tree
 
 **Phases:** SETUP → CLASSIFY → TARGET ANALYSIS (optional) → BASELINE (+ GSM8K accuracy) → PROFILE → HEURISTIC SCORING → DFS LOOP (pick highest-scored action → execute → re-score → repeat) → SWEEP → REPORT


### PR DESCRIPTION
## Summary

Add a Common Pitfalls entry to `inference-optimization` SKILL.md covering AITER
JIT stale baton (lock file) cleanup, so the orchestrator no longer hangs at
`waiting for baton release` after an SGLang crash during JIT compile.

## Root cause

AITER guards Triton/HIP JIT compilation with file-based locks ("batons") under
`/sgl-workspace/aiter/aiter/jit/build/lock_*`. If the previous SGLang process is
hard-killed (SIGKILL, watchdog timeout, OOM, segfault) **during** a JIT compile,
the lock file remains on disk with no live owner. The next IR-4 relaunch then
blocks forever on `waiting for baton release at .../jit/build/lock_*` and never
reaches the health endpoint — surfacing as a setup/baseline hang.

The skill's existing `kill_server + check_gpu_memory` (IR-4) operates on
processes, not on filesystem locks, so stale batons survive every restart loop.

## Fix

Add pitfall #10 to `.cursor/skills/inference-optimization/SKILL.md` Common
Pitfalls section. The entry:

- Explains the failure mode and where it appears (setup/baseline hang).
- Documents a guarded cleanup that only removes locks when **no** live
  `sglang.launch_server` process is running, avoiding accidental deletion of an
  active compile's baton:

  ```bash
  pgrep -f 'python.*-m sglang.launch_server' >/dev/null || \
    find /sgl-workspace/aiter/aiter/jit/build -maxdepth 1 -name 'lock_*' -type f -delete
  ```

- Recommends a longer `--watchdog-timeout` so the watchdog does not kill the new
  process while it is the legitimate baton holder mid-JIT.

## Scope (intentionally minimal)

- 1 file changed, +19 lines (docs only).
- No changes to Iron Rules, `scripts/`, `actions/`, `KNOWLEDGE-BASE.md`, or
  `kb/`.
- No behavior change to running code; this is an authoring-time guidance update
  that the orchestrator agent reads at the start of every run.

## Related

Fixes the v0.2 inference-mode "Hang / no progress" issue: *AITER batons can
prevent SGLang inference engine reboots*. (#136 )