### PR TITLE
feat(critic-agent): add deterministic runtime + decision-memory pipeline

### DIFF
--- a/critic-agent/.gitignore
+++ b/critic-agent/.gitignore
@@ -1,3 +1,7 @@
 __pycache__/
 *.py[cod]
 .pytest_cache/
+.venv/
+.coverage
+htmlcov/
+session-memory/

--- a/critic-agent/AGENTS.md
+++ b/critic-agent/AGENTS.md
@@ -38,6 +38,33 @@ return `emit.json["critic_decision_review"]` instead.
 | `KB_READ_ENABLED` | Set to `false` to disable KB priors lookup. |
 | `KB_SERVICE_TOKEN` | Reserved for v2 auth. |
 | `CRITIC_PRIOR_CACHE_TTL_SECONDS` | Per-session KB prior cache TTL. |
+| `CRITIC_KB_BREAKER_THRESHOLD` | Consecutive transport errors before the circuit breaker opens (default `1` — first failure short-circuits the rest of the request). |
+| `CRITIC_KB_BREAKER_COOLDOWN_SECONDS` | How long the breaker stays open before allowing another KB attempt (default `60`). |
+
+## KB unreachable behaviour (default)
+
+The runtime treats KB unreachability as "skip KB, keep reviewing" by
+default — you do not need to flip a flag when the KB service is down:
+
+1. The first KB transport / network / 5xx-after-retries failure trips an
+   in-process circuit breaker per `KBWriter` instance.
+2. While the breaker is open (`CRITIC_KB_BREAKER_COOLDOWN_SECONDS`):
+   - `list_priors` returns `cache="kb_unreachable"` with empty priors and
+     never makes another transport call.
+   - `write_verdict`, `write_kb_drafts`, and `add_contradiction` return
+     `WriteResult(status="disabled", reason="kb_unreachable")` so the
+     review pipeline keeps emitting verdicts.
+   - `prepare-review` reports `judge_bundle.kb_read_skipped_reason =
+     "kb_unreachable"` and adds a note so the SKILL knows priors are
+     missing because of an outage rather than a clean miss.
+3. A successful KB call resets the breaker (`_record_kb_success`).
+4. 4xx errors (`KBValidationError`) do **not** open the breaker — they
+   indicate a client bug, not service unavailability, and are surfaced
+   as `error` on the response.
+
+`KB_READ_ENABLED=false` is still honoured for operator-driven kill
+switches; the breaker is the automatic equivalent for transient
+outages.
 
 ## Bash allowlist
 

--- a/critic-agent/AGENTS.md
+++ b/critic-agent/AGENTS.md
@@ -1,0 +1,89 @@
+# Hosting the Critic skill in an A2A / Codex chat server
+
+The Critic does not need a dedicated long-running service. The intended
+delivery is:
+
+- A Codex-based **A2A chat server** owns the agent identity (allowlists,
+  rate limits, auth).
+- The Critic SKILL is mounted into that server.
+- The server permits exactly two Bash commands for Critic turns:
+  `python -m runtime.cli prepare-review` and `python -m runtime.cli commit-review`.
+- For session lifecycle: `init-session` and `close-session`.
+
+## Per-turn flow
+
+1. The host receives a request payload (Coordinator-style or
+   dialogue-style) and writes it to `${CRITIC_WORKDIR}/request.json`.
+2. Codex runs `prepare-review`, reads `judge_bundle.json` and the
+   Critic SKILL prompts, then writes `review.json`.
+3. Codex runs `commit-review` and uses `emit.json` as the response back
+   to the host.
+
+The host should consider `emit.json["intent_envelope"]` (when present)
+the canonical response for a Coordinator caller; for dialogue callers
+return `emit.json["critic_decision_review"]` instead.
+
+## Required environment
+
+| Variable | Purpose |
+|---|---|
+| `WORKSPACE_PATH` | Root for the skill files (defaults to `/workspace`). |
+| `CRITIC_SESSION_MEMORY_DIR` | Persistent volume for per-session memory (default `/var/lib/critic-session-memory`). Mount as PVC. |
+| `CRITIC_KB_CLIENT_MODE` | `live` to talk to the KB service, `inmemory` for dry-run / local tests. |
+| `KB_BASE_URL` | KB service URL when `CRITIC_KB_CLIENT_MODE=live`. |
+| `KB_TIMEOUT_MS` | HTTP timeout for KB calls (default 10000). |
+| `KB_RETRY_MAX` | KB retry budget (default 3). |
+| `KB_DEAD_LETTER_DIR` | PVC mount for dead-letter JSONL files. |
+| `KB_WRITE_ENABLED` | Set to `false` to disable KB writes globally. |
+| `KB_READ_ENABLED` | Set to `false` to disable KB priors lookup. |
+| `KB_SERVICE_TOKEN` | Reserved for v2 auth. |
+| `CRITIC_PRIOR_CACHE_TTL_SECONDS` | Per-session KB prior cache TTL. |
+
+## Bash allowlist
+
+Configure the chat server's Bash gate to allow exactly:
+
+```text
+python3 -m runtime.cli init-session ...
+python3 -m runtime.cli prepare-review ...
+python3 -m runtime.cli commit-review ...
+python3 -m runtime.cli close-session ...
+python3 -m runtime.cli list-priors ...
+python3 -m runtime.cli replay-dead-letter ...
+```
+
+Reject `write-verdict`, `write-kb-drafts`, `add-contradiction` outside
+trusted operators — they are exposed for tooling, not for direct LLM use.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Logical success (including `dead_lettered` write outcomes). |
+| `2` | Adapter bug; surface to the host so the SKILL can produce `needs_review`. |
+
+The CLI emits a single JSON object on stdout (or to `--out`) for every
+command, so the host can parse the response without regex.
+
+## Recommended dead-letter cron
+
+```bash
+*/15 * * * *  python -m runtime.cli replay-dead-letter \
+                --dir "$KB_DEAD_LETTER_DIR" \
+                --keep-on-success
+```
+
+## Optional: local Cursor / IDE workflow
+
+When developing locally without the chat server, you can drive the same
+flow by hand:
+
+```bash
+echo '{"kind": "coordinator_inbox", ...}' > req.json
+python -m runtime.cli prepare-review --request req.json --out judge.json
+# craft review.json based on judge.json + skill prompts
+python -m runtime.cli commit-review --request req.json --review review.json --out emit.json
+```
+
+Tests for the runtime live under `runtime/tests/`; the SKILL fixtures
+under `tests/`.

--- a/critic-agent/SKILL.md
+++ b/critic-agent/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: critic-agent
 description: |
-  Critic layer for the v0.6 inference optimizer. Use when Conductor asks for a
-  Critic Review verdict on Orchestration or Kernel proposals, KB recall/ingest
-  guidance, cross-run synthesis, or Devil's advocate review signals.
+  Critic layer for the v0.6 inference optimizer. Use when Conductor asks
+  for a Critic Review verdict on Orchestration or Kernel proposals,
+  conversation-driven decision review, KB recall/ingest guidance,
+  cross-run synthesis, or Devil's advocate review signals.
 globs:
   - "**/critic*"
   - "**/review*"
@@ -15,86 +16,118 @@ globs:
 
 # Critic Optimization Reviewer
 
-> **You are the Critic.** Conductor calls you with a complete context packet.
-> Your job is to return validated JSON that gates or advises optimization
+> **You are the Critic.** A host (Coordinator inside Hyperloom, or a
+> Codex-based A2A chat server elsewhere) calls you with a context
+> packet, an inbox prompt, or a dialogue-style decision request. Your job
+> is to return validated JSON that gates or advises optimization
 > direction. You do not execute the optimization loop.
 >
-> This is a standalone resident agent skill. All files live under
-> `$WORKSPACE_PATH/critic-agent`; default `WORKSPACE_PATH` is `/workspace`.
-> Coordinator owns registration, routing, and integration.
+> This skill is paired with the deterministic runtime under
+> `runtime/`. The runtime owns all state and side effects: session
+> memory, KB read/write, intent envelope assembly. The skill prompts
+> own the *reasoning*.
+>
+> All files live under `$WORKSPACE_PATH/critic-agent`; default
+> `WORKSPACE_PATH` is `/workspace`.
 
 ## Mission
 
 Critic is the horizontal review and memory layer for the v0.6 optimizer:
 
-1. Review Orchestration and Kernel proposals with one verdict:
-   `approve`, `reject`, `redirect`, `advise`, or `needs_review`.
-2. Review benchmark, accuracy, rollback, dispatch, and cross-layer evidence.
-3. Own KB read/write/synthesis for cross-run memory.
-4. Emit Devil's advocate signals as advice, not as parliament votes.
-5. Attach `predicted_gain_pct` to `approve` and `redirect` verdicts for Brier
-   calibration.
+1. Review Orchestration and Kernel proposals with one verdict per
+   proposal: `approve`, `reject`, `redirect`, `advise`, or `needs_review`.
+2. For dialogue-style requests, return a `critic_decision_review` with
+   verdict ∈ {`adopt`, `reject`, `revise`, `needs_info`}.
+3. Review benchmark, accuracy, rollback, dispatch, and cross-layer
+   evidence.
+4. Own KB read/write/synthesis for cross-run memory (via the runtime).
+5. Emit Devil's advocate signals as `advice`, never as parliament votes.
+6. Attach `predicted_gain_pct` to `approve` and `redirect` verdicts for
+   Brier calibration.
 
-Critic does not own server lifecycle, resource locks, patch application, RCA, or
-benchmark execution. Those responsibilities stay with Conductor,
-Orchestration, Kernel, Robustness, and task-specific sub-agents.
+Critic does **not** own server lifecycle, resource locks, patch
+application, RCA, or benchmark execution. Those responsibilities stay
+with Conductor, Orchestration, Kernel, Robustness, and task-specific
+sub-agents.
+
+## Two-Phase Loop
+
+Every Critic turn runs two CLI calls around your reasoning:
+
+```bash
+# 1. Parse the request, merge with session memory, fetch KB priors.
+python -m runtime.cli prepare-review --request request.json --out judge_bundle.json
+
+# 2. Reason. Produce review.json per the relevant schema below.
+
+# 3. Validate, persist memory, optionally write KB, build the envelope.
+python -m runtime.cli commit-review --request request.json --review review.json --out emit.json
+```
+
+Use the contents of `emit.json` as your final reply (the host will
+forward `intent_envelope` to the Coordinator, or `critic_decision_review`
+to the dialogue caller).
+
+For session lifecycle:
+
+```bash
+python -m runtime.cli init-session  --request request.json
+python -m runtime.cli close-session --request request.json [--kb-draft draft.json]
+```
+
+For lower-level KB operations, see `actions/draft_kb.md` and
+`actions/review_patch.md`.
 
 ## Request Types
 
-Determine the request type from the packet:
+`request.json` always carries one `kind`. Pick the matching action:
 
-- `review_verdict`: packet includes a `target_proposal_msg_id`, proposal,
-  Kernel `response`, `integrate keep_proposed`, benchmark data, or a proposed
-  side-effecting action.
-- `kb_draft`: packet includes a completed action result, final report, or run
-  summary that should produce KB entries.
-- `kb_hint`: packet asks for KB recall guidance to inject into a future prompt.
-- `objection_signal`: packet asks for non-blocking Devil's advocate advice about
-  an already approved task or keep decision.
+| `kind` | Action |
+|---|---|
+| `coordinator_inbox` | [actions/review_coordinator_inbox.md](actions/review_coordinator_inbox.md) |
+| `critic_decision_request` | [actions/review_decision.md](actions/review_decision.md) |
+| `kb_draft_request` | [actions/draft_kb.md](actions/draft_kb.md) |
+| `kb_hint_request` | reuse [references/verdict_schema.md](references/verdict_schema.md) — read-only, no commit step needed |
+| `objection_signal` | [actions/objection_signal.md](actions/objection_signal.md) |
 
-If the packet includes both review and KB work, return a combined response using
-the schema in [references/verdict_schema.md](references/verdict_schema.md).
+When in doubt, treat the input as `coordinator_inbox` and parse it as
+described in
+[references/coordinator_protocol.md](references/coordinator_protocol.md).
 
-## Review Verdict Protocol
+## Review Constraints
 
-For proposal review, follow:
+The runtime fills `judge_bundle.review_constraints` with the current
+hard rules. These mirror the contract:
 
-- [actions/review_patch.md](actions/review_patch.md)
-- [references/risk_rules.md](references/risk_rules.md)
-- [references/verdict_schema.md](references/verdict_schema.md)
-
-Return only the review verdict JSON object unless the caller explicitly asks for
-explanation outside JSON.
-
-## KB Draft Protocol
-
-For KB drafts, follow:
-
-- [actions/draft_kb.md](actions/draft_kb.md)
-- [references/verdict_schema.md](references/verdict_schema.md)
-
-Return only the KB draft JSON object unless the caller explicitly asks for
-explanation outside JSON.
+- `approve` requires comparable before/after benchmark, accuracy gate
+  (or waiver), active-path proof when relevant, and a clear rollback.
+- Critic-written `importance` is capped at `0.84`.
+- Verdicts must be drawn from the bundle's `allowed_verdicts` list.
 
 ## Hard Rules
 
-- Do not return `approve` without comparable before/after benchmark evidence.
+- Do not return `approve` without comparable before/after benchmark
+  evidence.
 - Do not return `approve` without an accuracy gate result or an explicit
   Conductor-provided waiver.
-- Do not treat micro-benchmark speedup as an E2E win unless the packet connects
-  it to the active dispatch path and final throughput result.
-- Do not invent missing context. If evidence is absent, object and list the
-  required evidence.
+- Do not treat micro-benchmark speedup as an E2E win unless the packet
+  connects it to the active dispatch path and final throughput result.
+- Do not invent missing context. If `judge_bundle.required_context` is
+  non-empty, return `needs_review` (or `needs_info` for decision
+  requests) and list the missing keys.
 - Do not return `reject` or `redirect` from historical claims without
-  `kb_evidence`; use packet evidence for local benchmark/correctness failures.
-- Do not create KB entries from speculative ideas, failed attempts without a
-  reusable lesson, or results that were not validated by controlled evidence.
-- Do not mutate files, apply patches, kill servers, restart services, or write to
-  shared state.
-- Do not `delegate`, `request`, or `propose_action`.
-- Do not perform RCA. RCA, recovery, and handle behavior belong to Robustness.
-- Do not use tools except validated JSON output and the narrow KB read/write
-  path provided by Conductor.
+  `kb_evidence`; use `packet_evidence` for packet-local benchmark or
+  correctness failures.
+- Do not create KB entries from speculative ideas, failed attempts
+  without a reusable lesson, or results that were not validated by
+  controlled evidence.
+- Do not mutate files, apply patches, kill servers, restart services,
+  or write to shared state.
+- Do not `delegate`, `request`, or `propose_action` (PolicyGate will
+  reject those intents anyway).
+- Do not perform RCA. RCA, recovery, and handle behavior belong to
+  Robustness.
+- Do not call KB endpoints directly — always go through `runtime.cli`.
 
 ## Approve Standard
 
@@ -105,8 +138,10 @@ Return `approve` only when all blocker risks are cleared:
 - Accuracy gate passes or has a documented waiver.
 - Rollback path is clear.
 - Build, cache, dispatch, and runtime implications are addressed.
-- Robustness findings and known failure patterns do not contradict the decision.
+- Robustness findings and known failure patterns do not contradict the
+  decision.
 
-Return `advise` for non-blocking concerns. Return `needs_review` when a high-risk
-proposal cannot be safely approved and there is not enough evidence for a real
-`reject` or `redirect`.
+Return `advise` for non-blocking concerns. Return `needs_review` (or
+`needs_info` for decision requests) when a high-risk proposal cannot be
+safely approved and there is not enough evidence for a real `reject` or
+`redirect`.

--- a/critic-agent/SKILL.md
+++ b/critic-agent/SKILL.md
@@ -104,6 +104,12 @@ hard rules. These mirror the contract:
 - Critic-written `importance` is capped at `0.84`.
 - Verdicts must be drawn from the bundle's `allowed_verdicts` list.
 
+If `judge_bundle.kb_read_skipped_reason == "kb_unreachable"` (or
+`kb_read_disabled`), KB priors were not consulted for this turn. Treat
+the absence of priors as *unknown*, not as *no contradicting prior*:
+prefer `advise` / `needs_review` over `approve` based on packet
+evidence alone, and mention the missing KB recall in `notes`.
+
 ## Hard Rules
 
 - Do not return `approve` without comparable before/after benchmark

--- a/critic-agent/actions/objection_signal.md
+++ b/critic-agent/actions/objection_signal.md
@@ -1,0 +1,51 @@
+# Objection Signal (Devil's Advocate)
+
+Use this action when `request.kind == "objection_signal"`. The host
+wants non-blocking advice about a decision that is already underway —
+not a fresh verdict.
+
+## Step 1 — Prepare
+
+```bash
+python -m runtime.cli prepare-review \
+  --request "$CRITIC_WORKDIR/request.json" \
+  --out "$CRITIC_WORKDIR/judge_bundle.json"
+```
+
+The bundle is identical to the dialogue-style one. Use
+`kb_priors_for_decision` and `messages` to look for missed risks or
+historical contradictions.
+
+## Step 2 — Reason
+
+Compose a short markdown advice body. Keep it under ~600 tokens; the
+host injects this into the next prompt for Orchestration.
+
+Write `$CRITIC_WORKDIR/review.json`:
+
+```json
+{
+  "verdict": "advise",
+  "advice": [
+    {
+      "target_proposal_msg_id": "abc1",
+      "body_md": "Heads-up: kb_xxx records that this kernel rewrite needs an explicit cache clear; rerun the final benchmark after the patch."
+    }
+  ]
+}
+```
+
+When in doubt, return one `send_message{topic="advice"}` plus
+`verdict = "advise"`. The runtime will package it into the intent
+envelope without blocking dispatch.
+
+## Step 3 — Commit
+
+```bash
+python -m runtime.cli commit-review \
+  --request "$CRITIC_WORKDIR/request.json" \
+  --review "$CRITIC_WORKDIR/review.json" \
+  --out "$CRITIC_WORKDIR/emit.json"
+```
+
+The host should treat the resulting envelope as informational only.

--- a/critic-agent/actions/review_coordinator_inbox.md
+++ b/critic-agent/actions/review_coordinator_inbox.md
@@ -1,0 +1,98 @@
+# Review Coordinator Inbox
+
+Use this action when `request.kind == "coordinator_inbox"`. The host has
+forwarded the Coordinator's per-turn prompt verbatim (see
+[references/coordinator_protocol.md](../references/coordinator_protocol.md)).
+
+## Step 1 — Prepare
+
+```bash
+python -m runtime.cli prepare-review \
+  --request "$CRITIC_WORKDIR/request.json" \
+  --out "$CRITIC_WORKDIR/judge_bundle.json"
+```
+
+`judge_bundle.json` will contain:
+
+- `merged_context` — model / framework / precision / workload / etc.
+  combined with session memory.
+- `missing_context` — keys that fell back to `unknown` (informational).
+- `required_context` — non-empty when critical keys (`model`,
+  `framework`) are still missing; if so, see Step 2.
+- `proposals` — only proposals not yet reviewed in this session.
+- `kb_priors_by_proposal` — array per `msg_id` (cache-aware).
+- `review_constraints` — current allowed verdicts and approve checklist.
+
+## Step 2 — Reason
+
+For each proposal in `proposals`, decide a verdict using:
+
+- The Approve Standard from `SKILL.md`.
+- [references/risk_rules.md](../references/risk_rules.md) for blocker /
+  major / minor categorisation.
+- [references/verdict_schema.md](../references/verdict_schema.md) for
+  the per-verdict required fields.
+- Any `kb_priors_by_proposal[<msg_id>]` returned in Step 1.
+
+Special cases:
+
+- `judge_bundle.required_context` is non-empty → emit `needs_review`
+  for every proposal with `source = "critic_unavailable"` and list the
+  missing keys in `notes`.
+- `proposals` is empty → emit nothing; the runtime will fall back to a
+  heartbeat in Step 3.
+
+Write the result to `$CRITIC_WORKDIR/review.json`:
+
+```json
+{
+  "review_verdicts": [
+    {
+      "target_proposal_msg_id": "abc1",
+      "verdict": "approve",
+      "source": "critic",
+      "reasoning": "Active dispatch path proven; benchmark within tolerance; rollback documented.",
+      "confidence": "high",
+      "predicted_gain_pct": 4.2,
+      "kb_evidence": ["kb_xxx"],
+      "packet_evidence": ["benchmark.after.gain_pct", "accuracy_gate.status"],
+      "risks": [],
+      "required_evidence": [],
+      "notes": [],
+      "persist_to_kb": true,
+      "topic": "kernel-opt-active-dispatch"
+    }
+  ],
+  "advice": [
+    {
+      "target_proposal_msg_id": "abc1",
+      "body_md": "Re-run the sweep at higher concurrency before promotion."
+    }
+  ]
+}
+```
+
+`persist_to_kb` (optional) flags a verdict whose lesson is reusable and
+should be upserted into KB. `topic` should be the slug-friendly handle
+(the runtime calls `slugify_safe`).
+
+## Step 3 — Commit
+
+```bash
+python -m runtime.cli commit-review \
+  --request "$CRITIC_WORKDIR/request.json" \
+  --review "$CRITIC_WORKDIR/review.json" \
+  --out "$CRITIC_WORKDIR/emit.json"
+```
+
+`emit.json["intent_envelope"]` is the canonical reply for the host.
+
+## Failure modes
+
+- **Schema validation error** — runtime exits with code 2; the host
+  should treat it as a Critic outage and fall back to a heartbeat
+  envelope.
+- **KB write dead-lettered** — `kb_writes[*].result.status` is
+  `dead_lettered`. The verdict is still emitted; cron will replay later.
+- **Missing critical context** — produce `needs_review` verdicts and
+  set `source = "critic_unavailable"`.

--- a/critic-agent/actions/review_decision.md
+++ b/critic-agent/actions/review_decision.md
@@ -1,0 +1,85 @@
+# Review Dialogue-Style Decision
+
+Use this action when `request.kind == "critic_decision_request"`. The
+caller is typically a Codex-based A2A chat server, not the Hyperloom
+Coordinator.
+
+## Step 1 — Prepare
+
+```bash
+python -m runtime.cli prepare-review \
+  --request "$CRITIC_WORKDIR/request.json" \
+  --out "$CRITIC_WORKDIR/judge_bundle.json"
+```
+
+The bundle contains:
+
+- `messages` — the dialogue so far (oldest first).
+- `decision` — the proposed decision summary the host wants you to
+  judge.
+- `merged_context` — context with session memory filled in.
+- `required_context` — non-empty when critical keys are missing; the
+  bundle's `kb_read_skipped_reason` will be `missing_critical_context`.
+- `kb_priors_for_decision` — KB priors looked up by decision topic.
+
+## Step 2 — Reason
+
+Apply the rules in `SKILL.md`. Pick one verdict from
+`{adopt, reject, revise, needs_info}` and write
+`$CRITIC_WORKDIR/review.json`:
+
+```json
+{
+  "verdict": "adopt",
+  "confidence": "high",
+  "reason": "Session evidence shows the change keeps tput at +4% with no accuracy regression.",
+  "recommendation": "Proceed; clear compiled cache before final benchmark.",
+  "basis": "mixed",
+  "kb_evidence": [
+    {
+      "id": "kb_xxx",
+      "kind": "pitfall",
+      "slug": "cache-clear-required-after-dispatch-change"
+    }
+  ],
+  "session_evidence": ["benchmark.after.gain_pct", "accuracy_gate.status"],
+  "required_context": [],
+  "notes": [],
+  "topic": "adopt-patch-x"
+}
+```
+
+When `judge_bundle.required_context` is non-empty:
+
+- `verdict` = `needs_info`.
+- `required_context` = the same list copied from the bundle.
+- `basis` = `insufficient_context`.
+
+## Step 3 — Commit
+
+```bash
+python -m runtime.cli commit-review \
+  --request "$CRITIC_WORKDIR/request.json" \
+  --review "$CRITIC_WORKDIR/review.json" \
+  --out "$CRITIC_WORKDIR/emit.json"
+```
+
+The output is `emit.json["critic_decision_review"]`. The runtime also
+writes a KB row when:
+
+- the verdict is `adopt` / `reject` / `revise`,
+- `confidence` is at least `medium`, and
+- the topic is slugifiable.
+
+KB writes are best-effort: if they fail, `emit.json["kb_writes"]` will
+contain `status="dead_lettered"` and the decision review still goes
+out.
+
+## Common pitfalls
+
+- Skipping `confidence` — defaults to `medium` but you should pick
+  explicitly.
+- Returning `adopt` without `session_evidence` or `kb_evidence` —
+  refuses to write the supporting KB lesson.
+- Bypassing `commit-review` — the dialogue caller never sees a verdict
+  unless `commit-review` produced `emit.json`.

--- a/critic-agent/pytest.ini
+++ b/critic-agent/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths = runtime/tests tests
+pythonpath = .
+filterwarnings =
+    error::SyntaxWarning
+    ignore::DeprecationWarning

--- a/critic-agent/references/coordinator_protocol.md
+++ b/critic-agent/references/coordinator_protocol.md
@@ -1,0 +1,89 @@
+# Coordinator Inbox Protocol
+
+The Coordinator (`inference_optimizer.orchestrator.coordinator.Coordinator`)
+hands every reactor a prompt with the layout below. Critic must consume
+this format (or the equivalent payload that an A2A host preserves
+verbatim into `request.raw_prompt`).
+
+```text
+=== Shared session state ===
+session_id=<sess_id>   model=<model>   framework=<framework>   ...
+
+=== Knowledge base hints ===          <-- only for orchestration role
+<free text bullet list>
+
+=== Inbox for critic (newest last) ===
+  seq=<int> msg_id=<hex> from=<agent> topic=<topic> payload=<python repr dict>
+  ...
+```
+
+The runtime parser (`runtime.inbox_parser.parse_inbox_prompt`) returns:
+
+* `agent_name` — should be `critic` for our turns.
+* `shared_state` — `key=value` tokens from the header.
+* `inbox` — every parsed row.
+* `proposals` — `topic=proposal` rows whose payload parsed as a dict.
+* `kb_hints_text` — preserved (we do not read it for Critic turns).
+
+## Per-tick contract (matches `MockCriticBackend`)
+
+For every `topic=proposal` row in the inbox the Critic must emit one
+`review_verdict` intent. If no proposal is present, the runtime emits a
+`send_message{topic=heartbeat}` so the Coordinator never times out on an
+empty envelope.
+
+The intent envelope shape is:
+
+```json
+{
+  "intents": [
+    {
+      "intent_type": "review_verdict",
+      "payload": {
+        "target_proposal_msg_id": "<hex>",
+        "verdict": "approve|reject|redirect|advise|needs_review",
+        "source": "critic",
+        "reasoning": "...",
+        "kb_evidence": [],
+        "packet_evidence": [],
+        "risks": [],
+        "predicted_gain_pct": null,
+        "confidence": "medium"
+      }
+    }
+  ]
+}
+```
+
+## Allowed values
+
+| Field | Values | Source |
+|---|---|---|
+| `intent_type` (Critic) | `review_verdict`, `send_message`, `update_persona`, `ask_question`, `answer`, `alert` | `inference_optimizer.orchestrator.agent_role._CRITIC_INTENTS` |
+| `verdict` | `approve`, `reject`, `redirect`, `advise`, `needs_review` | `policy.REVIEW_VERDICTS` |
+| `source` | `critic`, `mock`, `timeout`, `critic_unavailable` | `references/verdict_schema.md` |
+
+## Source mapping
+
+| Critic situation | `source` |
+|---|---|
+| Normal LLM-driven verdict | `critic` |
+| Runtime returned heartbeat or `needs_review` due to missing context | `critic_unavailable` |
+| Forced timeout fallback | `timeout` |
+| Mock backend (tests / dry-run) | `mock` |
+
+## Idempotency
+
+The runtime keeps a per-session `reviewed_msg_ids.json` and filters
+already-decided proposals out of the prepare-review bundle. Do not
+re-emit a verdict for the same `target_proposal_msg_id`; use a
+`send_message{topic=advice}` instead if you need to amend a prior call.
+
+## Common pitfalls
+
+* Do not include `intent_envelope` outside the JSON object — Codex's
+  `validated_json_output` must be exactly the envelope shape.
+* Do not synthesise extra `intent_type` values; PolicyGate denies
+  anything outside the Critic intent set.
+* Do not rewrite `payload.target_proposal_msg_id` — the Coordinator
+  matches it against `pending_proposals` literally.

--- a/critic-agent/references/decision_review_schema.md
+++ b/critic-agent/references/decision_review_schema.md
@@ -1,0 +1,103 @@
+# Decision Review Schema (dialogue-driven hosts)
+
+For non-Coordinator hosts (e.g. an A2A chat server fronting Codex), the
+Critic accepts a richer dialogue-style request. The first call carries
+the full context; later calls may be incremental.
+
+## Request: `critic_decision_request`
+
+```json
+{
+  "kind": "critic_decision_request",
+  "session_id": "sess_123",
+  "decision_id": "dec_456",
+  "messages": [
+    {
+      "role": "coordinator",
+      "content": "We plan to adopt patch X because it improves throughput by 3%."
+    },
+    {
+      "role": "kernel-agent",
+      "content": "Patch X changes the dispatch path and requires cache clear."
+    }
+  ],
+  "context": {
+    "model": "deepseek-r1-0528-fp8",
+    "framework": "sglang",
+    "precision": "fp8",
+    "workload": "decode",
+    "scale": "8xMI300",
+    "objective": "throughput"
+  },
+  "decision": {
+    "summary": "Adopt patch X",
+    "owner": "kernel-agent",
+    "target": "dispatch path optimization"
+  }
+}
+```
+
+`context` is only required on the first call. Later calls may omit it;
+the runtime fills missing fields from session memory.
+
+## Response: `critic_decision_review`
+
+```json
+{
+  "kind": "critic_decision_review",
+  "session_id": "sess_123",
+  "decision_id": "dec_456",
+  "verdict": "adopt",
+  "confidence": "high",
+  "reason": "Session evidence supports the patch and no KB pitfall contradicts it.",
+  "recommendation": "Proceed, but rerun the final benchmark after clearing compiled cache.",
+  "basis": "mixed",
+  "kb_evidence": [
+    {
+      "id": "kb_xxx",
+      "kind": "pitfall",
+      "slug": "cache-clear-required-after-dispatch-change",
+      "summary": "Stale compiled cache hides regressions."
+    }
+  ],
+  "session_evidence": ["benchmark.after.gain_pct", "accuracy_gate.status"],
+  "required_context": [],
+  "notes": []
+}
+```
+
+### Allowed values
+
+| Field | Values |
+|---|---|
+| `verdict` | `adopt`, `reject`, `revise`, `needs_info` |
+| `confidence` | `high`, `medium`, `low` |
+| `basis` | `kb`, `llm`, `mixed`, `session`, `insufficient_context` |
+
+### Verdict semantics
+
+| Verdict | Meaning |
+|---|---|
+| `adopt` | Proceed with the decision. |
+| `reject` | Do not adopt. Provide a `reason` and either `kb_evidence` or `session_evidence`. |
+| `revise` | Direction is sound but needs adjustments before adoption. |
+| `needs_info` | Cannot decide because critical context is missing. Always populate `required_context`. |
+
+## When KB writes happen
+
+`commit-review` translates the dialogue verdict into a KB write trigger
+when the lesson is reusable:
+
+| Dialogue verdict | KB trigger | KB kind |
+|---|---|---|
+| `adopt` | `critic_verdict_approve` | `technique` |
+| `reject` | `critic_verdict_reject` | `pitfall` |
+| `revise` | `critic_verdict_redirect` | `pitfall` |
+| `needs_info` | `critic_verdict_needs_review` | `pitfall` (informational) |
+
+Writes are skipped silently when:
+
+- `KB_WRITE_ENABLED=false`,
+- `model` or `framework` is unknown,
+- the verdict has no slugifiable `topic`, or
+- `confidence == "low"` and there is no measurement evidence.

--- a/critic-agent/references/intent_envelope.md
+++ b/critic-agent/references/intent_envelope.md
@@ -1,0 +1,58 @@
+# Intent Envelope Schema (Critic side)
+
+The Coordinator (`inference_optimizer.orchestrator.intent_parser`)
+expects the following object — produced by the Critic for every turn:
+
+```json
+{
+  "intents": [
+    {
+      "intent_type": "review_verdict",
+      "payload": {
+        "target_proposal_msg_id": "abc123",
+        "verdict": "approve",
+        "source": "critic",
+        "reasoning": "...",
+        "kb_evidence": ["kb_xxx"],
+        "packet_evidence": ["benchmark.after.gain_pct"],
+        "risks": [],
+        "predicted_gain_pct": 4.2,
+        "confidence": "high",
+        "advice_text": "",
+        "alternative_action": null,
+        "required_evidence": [],
+        "notes": []
+      }
+    }
+  ]
+}
+```
+
+The Critic runtime never produces this JSON itself — it builds it via
+`runtime.intent_envelope.build_envelope(...)` after `commit-review`.
+
+## Allowed intent types (Critic role)
+
+| `intent_type` | Required payload fields |
+|---|---|
+| `review_verdict` | `target_proposal_msg_id`, `verdict` |
+| `send_message` | `topic` |
+| `ask_question` | `topic`, `question` |
+| `answer` | `in_reply_to`, `answer` |
+| `alert` | `severity`, `summary` |
+| `update_persona` | `body_md` |
+
+## Validation
+
+The runtime's `runtime.intent_envelope.validate_envelope(...)` mirrors
+the Coordinator's PolicyGate checks. If the SKILL produces a malformed
+review, `commit-review` raises `ReviewValidationError` and the host
+should fall back to a `needs_review` heartbeat (see
+[references/coordinator_protocol.md](coordinator_protocol.md)).
+
+## Heartbeat fallback
+
+When `commit-review` produces zero intents, the runtime appends a single
+`send_message{topic="heartbeat"}` so the Coordinator's reactor pass
+always observes signal of life — exactly the behaviour the v0.6 mock
+adapter ships with.

--- a/critic-agent/runtime/__init__.py
+++ b/critic-agent/runtime/__init__.py
@@ -1,0 +1,22 @@
+"""Critic runtime adapter package.
+
+This package provides the deterministic Python layer that backs the
+LLM-driven Critic SKILL. Responsibilities:
+
+* Parse Coordinator-style inbox prompts and dialogue-style decision
+  requests into a uniform :class:`CriticRequest` (``request_models``).
+* Maintain per-session memory across calls (``session_memory``).
+* Translate Critic JSON outputs into Coordinator-compatible intent
+  envelopes (``intent_envelope``).
+* Mediate KB read/write side effects with retries, dead-lettering and
+  metrics (``kb_client``, ``kb_writer``, ``dead_letter``, ``metrics``).
+* Compose the prepare-review / commit-review / init-session /
+  close-session flows expected by the Critic actions (``decision_reviewer``).
+
+The runtime is invoked from the Critic SKILL via the CLI in
+``runtime.cli``; the LLM never calls these modules directly.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/critic-agent/runtime/category_mapping.py
+++ b/critic-agent/runtime/category_mapping.py
@@ -1,0 +1,83 @@
+"""Translate Critic ``kb_drafts[].category`` into KB ``kind`` (contract §2.1).
+
+The KB contract enumerates exactly four ``kind`` values; the Critic
+SKILL operates on a richer category vocabulary (see
+``actions/draft_kb.md`` and ``references/verdict_schema.md``). This
+module provides a deterministic surjective mapping plus a list of
+categories that intentionally have no KB equivalent and should be
+``rejected`` rather than silently dropped.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from .errors import RuntimeAdapterError
+
+
+# KB-side ``kind`` enum (kb-critic-integration-contract §2.1).
+KB_KINDS: frozenset[str] = frozenset({
+    "pitfall",
+    "technique",
+    "params_catalog",
+    "model_profile",
+})
+
+
+# Critic categories → KB kinds. Categories without an entry are treated as
+# "no KB equivalent" — caller may surface them in ``rejected_candidates``.
+CATEGORY_TO_KIND: dict[str, str] = {
+    "pitfall": "pitfall",
+    "crash_recovery": "pitfall",
+    "benchmark_methodology": "pitfall",
+    "architecture_constraint": "pitfall",
+    "kernel_optimization": "technique",
+    "call_stack_optimization": "technique",
+    "backend_exploration": "technique",
+    "framework_comparison": "technique",
+    "target_comparison": "technique",
+    "lesson": "technique",
+    "dream_consolidation": "technique",
+    "server_params": "params_catalog",
+}
+
+
+def map_category_to_kind(category: str) -> str:
+    """Return the KB ``kind`` for a Critic ``category``.
+
+    Raises:
+        RuntimeAdapterError: If ``category`` is not in the catalogue.
+    """
+    if not isinstance(category, str):
+        raise RuntimeAdapterError(
+            f"category must be str, got {type(category).__name__}"
+        )
+    kind = CATEGORY_TO_KIND.get(category)
+    if not kind:
+        raise RuntimeAdapterError(
+            f"unsupported Critic category {category!r}; mapping table only "
+            f"covers {sorted(CATEGORY_TO_KIND.keys())!r}"
+        )
+    return kind
+
+
+def filter_supported_categories(
+    categories: Iterable[str],
+) -> tuple[list[str], list[str]]:
+    """Split an iterable into ``(supported, rejected)`` category lists."""
+    supported: list[str] = []
+    rejected: list[str] = []
+    for c in categories:
+        if c in CATEGORY_TO_KIND:
+            supported.append(c)
+        else:
+            rejected.append(c)
+    return supported, rejected
+
+
+__all__ = [
+    "CATEGORY_TO_KIND",
+    "KB_KINDS",
+    "filter_supported_categories",
+    "map_category_to_kind",
+]

--- a/critic-agent/runtime/cli.py
+++ b/critic-agent/runtime/cli.py
@@ -1,0 +1,297 @@
+"""Critic runtime CLI.
+
+The Critic SKILL shells out to this module via:
+
+```
+python -m runtime.cli init-session     --request request.json
+python -m runtime.cli prepare-review   --request request.json [--out judge.json]
+python -m runtime.cli commit-review    --request request.json --review review.json [--out emit.json]
+python -m runtime.cli close-session    --request request.json [--kb-draft draft.json]
+
+# Low-level KB ops (kept for backward compat / tooling).
+python -m runtime.cli list-priors      --packet packet.json [--kind ...] [--topic ...]
+python -m runtime.cli write-verdict    --packet packet.json --verdict verdict.json --ctx ctx.json
+python -m runtime.cli write-kb-drafts  --packet packet.json --kb-draft kb_draft.json --ctx ctx.json
+python -m runtime.cli add-contradiction --new-id ID --old-ids id1,id2 --ctx ctx.json
+python -m runtime.cli replay-dead-letter [--dir DIR] [--keep-on-success]
+```
+
+Every command writes a single JSON object to stdout (or to ``--out``)
+and returns exit code 0 on logical success — including
+``dead_lettered`` outcomes per contract §6. Exit code 2 is reserved for
+adapter bugs that should propagate back to the SKILL caller.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from .dead_letter import DeadLetter
+from .decision_reviewer import DecisionReviewer
+from .errors import RuntimeAdapterError
+from .in_memory_kb_client import InMemoryKBClient
+from .kb_client import HTTPKBClient, KBClient
+from .kb_writer import KBWriter, WriteContext
+from .scope_builder import build_scope, scope_cache_key
+from .session_memory import SessionMemory
+
+
+# ---------------------------------------------------------------------------
+def _read_json(path: str | Path) -> Any:
+    text = Path(path).read_text(encoding="utf-8")
+    return json.loads(text) if text.strip() else None
+
+
+def _emit_json(obj: Any, out: str | None) -> None:
+    serialised = json.dumps(obj, ensure_ascii=False, indent=2)
+    if out and out != "-":
+        Path(out).write_text(serialised + "\n", encoding="utf-8")
+    sys.stdout.write(serialised + "\n")
+    sys.stdout.flush()
+
+
+def _resolve_kb_client() -> KBClient:
+    mode = os.environ.get("CRITIC_KB_CLIENT_MODE", "inmemory").lower()
+    if mode == "live":
+        base_url = os.environ.get("KB_BASE_URL")
+        if not base_url:
+            raise RuntimeAdapterError(
+                "CRITIC_KB_CLIENT_MODE=live but KB_BASE_URL is not set"
+            )
+        return HTTPKBClient(
+            base_url=base_url,
+            timeout_ms=int(os.environ.get("KB_TIMEOUT_MS", "10000")),
+            retry_max=int(os.environ.get("KB_RETRY_MAX", "3")),
+            token=os.environ.get("KB_SERVICE_TOKEN"),
+        )
+    return InMemoryKBClient()
+
+
+def _resolve_reviewer() -> DecisionReviewer:
+    sm = SessionMemory()
+    client = _resolve_kb_client()
+    writer = KBWriter(client, session_memory=sm)
+    return DecisionReviewer(session_memory=sm, kb_client=client, kb_writer=writer)
+
+
+# ---------------------------------------------------------------------------
+def _cmd_init_session(args: argparse.Namespace) -> None:
+    request = _read_json(args.request)
+    reviewer = _resolve_reviewer()
+    out = reviewer.init_session(request)
+    _emit_json(out, args.out)
+
+
+def _cmd_prepare_review(args: argparse.Namespace) -> None:
+    request = _read_json(args.request)
+    reviewer = _resolve_reviewer()
+    bundle = reviewer.prepare_review(request)
+    _emit_json(bundle.to_dict(), args.out)
+
+
+def _cmd_commit_review(args: argparse.Namespace) -> None:
+    request = _read_json(args.request)
+    review = _read_json(args.review)
+    if not isinstance(review, dict):
+        raise RuntimeAdapterError("--review must be a JSON object")
+    reviewer = _resolve_reviewer()
+    outcome = reviewer.commit_review(request, review)
+    _emit_json(outcome.to_dict(), args.out)
+
+
+def _cmd_close_session(args: argparse.Namespace) -> None:
+    request = _read_json(args.request)
+    kb_draft = _read_json(args.kb_draft) if args.kb_draft else None
+    reviewer = _resolve_reviewer()
+    outcome = reviewer.close_session(request, kb_draft)
+    _emit_json(outcome.to_dict(), args.out)
+
+
+# ---------------------------------------------------------------------------
+def _cmd_list_priors(args: argparse.Namespace) -> None:
+    packet = _read_json(args.packet) or {}
+    context = packet.get("context") or packet.get("environment") or {}
+    scope = build_scope(context, require_critical=False)
+    scope_filter = {k: v for k, v in scope.items() if v != "unknown"}
+    client = _resolve_kb_client()
+    writer = KBWriter(client)
+    priors = writer.list_priors(
+        scope=scope_filter,
+        kind=args.kind,
+        topic=args.topic,
+        limit=args.limit,
+        ctx=WriteContext(session_id=args.session or "cli", review_id="cli"),
+    )
+    priors["scope_cache_key"] = scope_cache_key(scope_filter, topic=args.topic)
+    _emit_json(priors, args.out)
+
+
+def _cmd_write_verdict(args: argparse.Namespace) -> None:
+    packet = _read_json(args.packet) or {}
+    verdict = _read_json(args.verdict) or {}
+    ctx_raw = _read_json(args.ctx) or {}
+    client = _resolve_kb_client()
+    writer = KBWriter(client)
+    ctx = WriteContext(
+        session_id=ctx_raw.get("session_id") or "cli",
+        review_id=ctx_raw.get("review_id"),
+        source_role=ctx_raw.get("source_role", "critic"),
+        source_type=ctx_raw.get("source_type", "critic_decision_review"),
+        topic=ctx_raw.get("topic"),
+        extra_metadata=ctx_raw.get("metadata") or {},
+    )
+    res = writer.write_verdict(
+        verdict=verdict,
+        packet_context=packet.get("context") or packet.get("environment") or {},
+        session_context=ctx_raw.get("session_context") or {},
+        ctx=ctx,
+    )
+    _emit_json(res.to_dict(), args.out)
+
+
+def _cmd_write_kb_drafts(args: argparse.Namespace) -> None:
+    packet = _read_json(args.packet) or {}
+    kb_draft = _read_json(args.kb_draft) or {}
+    ctx_raw = _read_json(args.ctx) or {}
+    client = _resolve_kb_client()
+    writer = KBWriter(client)
+    ctx = WriteContext(
+        session_id=ctx_raw.get("session_id") or "cli",
+        review_id=ctx_raw.get("review_id"),
+        source_role=ctx_raw.get("source_role", "critic"),
+        source_type=ctx_raw.get("source_type", "critic_kb_draft"),
+        extra_metadata=ctx_raw.get("metadata") or {},
+    )
+    res = writer.write_kb_drafts(
+        kb_drafts=kb_draft.get("kb_drafts") or [],
+        packet_context=packet.get("context") or packet.get("environment") or {},
+        session_context=ctx_raw.get("session_context") or {},
+        ctx=ctx,
+    )
+    _emit_json(res.to_dict(), args.out)
+
+
+def _cmd_add_contradiction(args: argparse.Namespace) -> None:
+    ctx_raw = _read_json(args.ctx) or {}
+    client = _resolve_kb_client()
+    writer = KBWriter(client)
+    ctx = WriteContext(
+        session_id=ctx_raw.get("session_id") or "cli",
+        review_id=ctx_raw.get("review_id"),
+        source_role=ctx_raw.get("source_role", "critic"),
+    )
+    old_ids = [oid.strip() for oid in args.old_ids.split(",") if oid.strip()]
+    res = writer.add_contradiction(new_id=args.new_id, old_ids=old_ids, ctx=ctx)
+    _emit_json(res.to_dict(), args.out)
+
+
+def _cmd_replay_dead_letter(args: argparse.Namespace) -> None:
+    dlq = DeadLetter(root=args.dir or os.environ.get("KB_DEAD_LETTER_DIR"))
+    client = _resolve_kb_client()
+    summary = dlq.replay(
+        lambda endpoint, payload: _replay_dispatch(client, endpoint, payload),
+        delete_on_success=not args.keep_on_success,
+    )
+    _emit_json(summary.to_dict(), args.out)
+
+
+def _replay_dispatch(client: KBClient, endpoint: str, payload: dict[str, Any]) -> None:
+    if endpoint == "upsert":
+        client.upsert(payload)
+    elif endpoint == "batch_insert":
+        client.batch_insert(payload.get("items") or [], on_conflict=payload.get("on_conflict") or "upsert")
+    elif endpoint == "edges/add":
+        client.add_edges(payload.get("edges") or [])
+    elif endpoint == "list":
+        client.list(**payload)
+    else:
+        raise RuntimeAdapterError(f"replay-dead-letter: unknown endpoint {endpoint!r}")
+
+
+# ---------------------------------------------------------------------------
+def _make_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="runtime.cli", description="Critic runtime CLI")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    # Phase 0
+    init = sub.add_parser("init-session")
+    init.add_argument("--request", required=True)
+    init.add_argument("--out", default="-")
+    init.set_defaults(func=_cmd_init_session)
+
+    close = sub.add_parser("close-session")
+    close.add_argument("--request", required=True)
+    close.add_argument("--kb-draft", default=None)
+    close.add_argument("--out", default="-")
+    close.set_defaults(func=_cmd_close_session)
+
+    # Phase 1 + 2
+    prep = sub.add_parser("prepare-review")
+    prep.add_argument("--request", required=True)
+    prep.add_argument("--out", default="-")
+    prep.set_defaults(func=_cmd_prepare_review)
+
+    commit = sub.add_parser("commit-review")
+    commit.add_argument("--request", required=True)
+    commit.add_argument("--review", required=True)
+    commit.add_argument("--out", default="-")
+    commit.set_defaults(func=_cmd_commit_review)
+
+    # Low-level
+    listp = sub.add_parser("list-priors")
+    listp.add_argument("--packet", required=True)
+    listp.add_argument("--kind", default=None)
+    listp.add_argument("--topic", default=None)
+    listp.add_argument("--limit", type=int, default=10)
+    listp.add_argument("--session", default=None)
+    listp.add_argument("--out", default="-")
+    listp.set_defaults(func=_cmd_list_priors)
+
+    wv = sub.add_parser("write-verdict")
+    wv.add_argument("--packet", required=True)
+    wv.add_argument("--verdict", required=True)
+    wv.add_argument("--ctx", required=True)
+    wv.add_argument("--out", default="-")
+    wv.set_defaults(func=_cmd_write_verdict)
+
+    wd = sub.add_parser("write-kb-drafts")
+    wd.add_argument("--packet", required=True)
+    wd.add_argument("--kb-draft", required=True)
+    wd.add_argument("--ctx", required=True)
+    wd.add_argument("--out", default="-")
+    wd.set_defaults(func=_cmd_write_kb_drafts)
+
+    ac = sub.add_parser("add-contradiction")
+    ac.add_argument("--new-id", required=True)
+    ac.add_argument("--old-ids", required=True, help="Comma-separated KB ids.")
+    ac.add_argument("--ctx", required=True)
+    ac.add_argument("--out", default="-")
+    ac.set_defaults(func=_cmd_add_contradiction)
+
+    rd = sub.add_parser("replay-dead-letter")
+    rd.add_argument("--dir", default=None)
+    rd.add_argument("--keep-on-success", action="store_true")
+    rd.add_argument("--out", default="-")
+    rd.set_defaults(func=_cmd_replay_dead_letter)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _make_parser()
+    args = parser.parse_args(argv)
+    try:
+        args.func(args)
+    except RuntimeAdapterError as exc:
+        sys.stderr.write(f"runtime.cli: {exc}\n")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/critic-agent/runtime/dead_letter.py
+++ b/critic-agent/runtime/dead_letter.py
@@ -1,0 +1,143 @@
+"""Append-only KB dead-letter queue (contract §6 / G-5).
+
+Failed KB writes go into ``KB_DEAD_LETTER_DIR/<endpoint>.jsonl`` so a cron
+or operator can replay them later. The format is one JSON record per
+line, with the *intent* fields necessary to retry the operation
+(``endpoint``, ``payload``, ``attempts``, ``last_error``, ``ts``).
+
+The replay helper is provided for tests / cron jobs; it walks every
+``*.jsonl`` file in the directory and feeds rows back into a callable
+that knows how to dispatch by ``endpoint``. Successful rows are dropped;
+failed rows are preserved.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from .errors import RuntimeAdapterError
+from .metrics import CRITIC_KB_DEAD_LETTER_COUNT, get_registry
+
+
+DEFAULT_DEAD_LETTER_DIR = "/var/lib/critic-kb-dlq"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds")
+
+
+@dataclass
+class ReplaySummary:
+    scanned: int = 0
+    succeeded: int = 0
+    failed: int = 0
+    failed_details: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "scanned": self.scanned,
+            "succeeded": self.succeeded,
+            "failed": self.failed,
+            "failed_details": list(self.failed_details),
+        }
+
+
+class DeadLetter:
+    """Filesystem-backed dead-letter queue."""
+
+    def __init__(self, root: str | Path | None = None):
+        if root is None:
+            root = os.environ.get("KB_DEAD_LETTER_DIR", DEFAULT_DEAD_LETTER_DIR)
+        self.root = Path(root)
+
+    def _path_for(self, endpoint: str) -> Path:
+        if not endpoint or "/" in endpoint:
+            raise RuntimeAdapterError(f"invalid endpoint name: {endpoint!r}")
+        return self.root / f"{endpoint}.jsonl"
+
+    def append(
+        self,
+        endpoint: str,
+        payload: dict[str, Any],
+        *,
+        attempts: int,
+        last_error: str,
+        context: dict[str, Any] | None = None,
+    ) -> Path:
+        self.root.mkdir(parents=True, exist_ok=True)
+        path = self._path_for(endpoint)
+        record = {
+            "ts": _now_iso(),
+            "endpoint": endpoint,
+            "payload": payload,
+            "attempts": attempts,
+            "last_error": last_error,
+            "context": context or {},
+        }
+        with path.open("a", encoding="utf-8") as fp:
+            fp.write(json.dumps(record, ensure_ascii=False) + "\n")
+        get_registry().counter(CRITIC_KB_DEAD_LETTER_COUNT).inc({"endpoint": endpoint})
+        return path
+
+    def files(self) -> list[Path]:
+        if not self.root.exists():
+            return []
+        return sorted(self.root.glob("*.jsonl"))
+
+    def replay(
+        self,
+        dispatcher: Callable[[str, dict[str, Any]], None],
+        *,
+        delete_on_success: bool = True,
+    ) -> ReplaySummary:
+        """Walk every ``*.jsonl`` and call ``dispatcher(endpoint, payload)``.
+
+        Successful rows are removed (file gets rewritten without them);
+        failing rows stay so they can be retried later. The dispatcher
+        should raise to signal failure.
+        """
+        summary = ReplaySummary()
+        for path in self.files():
+            failed_lines: list[str] = []
+            for lineno, line in enumerate(path.read_text("utf-8").splitlines(), start=1):
+                if not line.strip():
+                    continue
+                summary.scanned += 1
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    summary.failed += 1
+                    summary.failed_details.append({
+                        "file": str(path),
+                        "line": lineno,
+                        "reason": f"json: {exc}",
+                    })
+                    failed_lines.append(line)
+                    continue
+                endpoint = record.get("endpoint")
+                payload = record.get("payload") or {}
+                try:
+                    dispatcher(endpoint, payload)
+                    summary.succeeded += 1
+                except Exception as exc:  # noqa: BLE001
+                    summary.failed += 1
+                    summary.failed_details.append({
+                        "file": str(path),
+                        "line": lineno,
+                        "reason": str(exc),
+                    })
+                    failed_lines.append(line)
+            if delete_on_success:
+                if failed_lines:
+                    path.write_text("\n".join(failed_lines) + "\n", encoding="utf-8")
+                else:
+                    path.unlink()
+        return summary
+
+
+__all__ = ["DEFAULT_DEAD_LETTER_DIR", "DeadLetter", "ReplaySummary"]

--- a/critic-agent/runtime/decision_reviewer.py
+++ b/critic-agent/runtime/decision_reviewer.py
@@ -1,0 +1,615 @@
+"""Two-phase orchestration for the Critic decision pipeline.
+
+The Critic SKILL is hosted by an A2A chat server (Codex). Each turn looks
+roughly like:
+
+1. Codex receives a prompt from the Coordinator (or a dialogue-style
+   request). The SKILL extracts a request JSON and runs::
+
+       python -m runtime.cli prepare-review --request request.json --out judge.json
+
+   This produces a *judge bundle* with merged context, KB priors, and a
+   list of proposals to review (when applicable).
+
+2. The SKILL reasons over the judge bundle to produce a Critic-shaped
+   review JSON (one of the schemas in ``references/``).
+
+3. The SKILL runs::
+
+       python -m runtime.cli commit-review --request request.json --review review.json --out emit.json
+
+   to validate the review, persist it in session memory, optionally write
+   to KB, and emit the Coordinator-compatible intent envelope.
+
+This module hosts the deterministic logic for both phases.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from .errors import (
+    InboxParseError,
+    IntentEnvelopeValidationError,
+    RequestValidationError,
+    ReviewValidationError,
+    RuntimeAdapterError,
+    ScopeError,
+)
+from .inbox_parser import parse_inbox_prompt
+from .intent_envelope import (
+    ALLOWED_VERDICTS,
+    Intent,
+    build_advice_intent,
+    build_envelope,
+    build_heartbeat_intent,
+    build_review_verdict_intent,
+)
+from .kb_client import KBClient
+from .kb_writer import KBWriter, WriteContext
+from .metrics import CRITIC_REVIEW_VERDICT_TOTAL, get_registry
+from .request_models import (
+    COORDINATOR_INBOX,
+    CRITICAL_CONTEXT_KEYS,
+    CONTEXT_DIMENSIONS,
+    CriticRequest,
+    DECISION_REQUEST,
+    KB_DRAFT_REQUEST,
+    Proposal,
+    parse_request,
+)
+from .scope_builder import build_scope, scope_cache_key
+from .session_memory import SessionMemory
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds")
+
+
+# ---------------------------------------------------------------------------
+@dataclass
+class JudgeBundle:
+    """Phase-1 output. The SKILL prompts read this to produce review JSON."""
+
+    kind: str
+    session_id: str
+    decision_id: str | None
+    merged_context: dict[str, Any] = field(default_factory=dict)
+    missing_context: list[str] = field(default_factory=list)
+    required_context: list[str] = field(default_factory=list)
+    proposals: list[dict[str, Any]] = field(default_factory=list)
+    messages: list[dict[str, Any]] = field(default_factory=list)
+    decision: dict[str, Any] = field(default_factory=dict)
+    kb_priors_by_proposal: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+    kb_priors_for_decision: list[dict[str, Any]] = field(default_factory=list)
+    kb_read_skipped_reason: str | None = None
+    review_constraints: dict[str, Any] = field(default_factory=dict)
+    notes: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "session_id": self.session_id,
+            "decision_id": self.decision_id,
+            "merged_context": dict(self.merged_context),
+            "missing_context": list(self.missing_context),
+            "required_context": list(self.required_context),
+            "proposals": [dict(p) for p in self.proposals],
+            "messages": [dict(m) for m in self.messages],
+            "decision": dict(self.decision),
+            "kb_priors_by_proposal": {
+                k: [dict(p) for p in v] for k, v in self.kb_priors_by_proposal.items()
+            },
+            "kb_priors_for_decision": [dict(p) for p in self.kb_priors_for_decision],
+            "kb_read_skipped_reason": self.kb_read_skipped_reason,
+            "review_constraints": dict(self.review_constraints),
+            "notes": list(self.notes),
+        }
+
+
+@dataclass
+class CommitOutcome:
+    """Phase-2 output."""
+
+    kind: str
+    session_id: str
+    decision_id: str | None
+    intent_envelope: dict[str, Any] | None = None
+    decision_review: dict[str, Any] | None = None
+    kb_writes: list[dict[str, Any]] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        out = {
+            "kind": self.kind,
+            "session_id": self.session_id,
+            "decision_id": self.decision_id,
+            "kb_writes": [dict(w) for w in self.kb_writes],
+            "notes": list(self.notes),
+        }
+        if self.intent_envelope is not None:
+            out["intent_envelope"] = self.intent_envelope
+        if self.decision_review is not None:
+            out["critic_decision_review"] = self.decision_review
+        return out
+
+
+# ---------------------------------------------------------------------------
+class DecisionReviewer:
+    """Orchestrator for the Critic prepare/commit lifecycle."""
+
+    def __init__(
+        self,
+        *,
+        session_memory: SessionMemory | None = None,
+        kb_client: KBClient | None = None,
+        kb_writer: KBWriter | None = None,
+    ):
+        self.session_memory = session_memory or SessionMemory()
+        if kb_writer is None:
+            if kb_client is None:
+                # Lazily import to avoid creating a registry when not needed.
+                from .in_memory_kb_client import InMemoryKBClient
+
+                kb_client = InMemoryKBClient()
+            kb_writer = KBWriter(kb_client, session_memory=self.session_memory)
+        self.kb_writer = kb_writer
+
+    # ------------------------------------------------------------------
+    # Phase 0: init / close session
+    # ------------------------------------------------------------------
+    def init_session(self, raw_request: dict[str, Any]) -> dict[str, Any]:
+        req = parse_request(raw_request)
+        merge = self.session_memory.merge_context(req.session_id, req.context)
+        self.session_memory.append_event(req.session_id, {
+            "kind": "init_session",
+            "explicit_keys": merge.explicit_keys,
+            "from_memory_keys": merge.from_memory_keys,
+            "missing_keys": merge.missing_keys,
+        })
+        return {
+            "session_id": req.session_id,
+            "merged_context": merge.merged,
+            "missing_context": merge.missing_keys,
+        }
+
+    def close_session(
+        self,
+        raw_request: dict[str, Any],
+        kb_draft: dict[str, Any] | None = None,
+    ) -> CommitOutcome:
+        req = parse_request(raw_request)
+        outcome = CommitOutcome(
+            kind="session_close",
+            session_id=req.session_id,
+            decision_id=req.decision_id,
+        )
+        if kb_draft:
+            drafts = list(kb_draft.get("kb_drafts") or [])
+            ctx = WriteContext(
+                session_id=req.session_id,
+                review_id=req.decision_id,
+                source_type="critic_kb_draft",
+                topic=None,
+            )
+            session_ctx = self.session_memory.load_context(req.session_id)
+            res = self.kb_writer.write_kb_drafts(
+                kb_drafts=drafts,
+                packet_context=req.context,
+                session_context=session_ctx,
+                ctx=ctx,
+            )
+            outcome.kb_writes.append({
+                "trigger": "session_close",
+                "result": res.to_dict(),
+                "items": len(drafts),
+            })
+        self.session_memory.append_event(req.session_id, {
+            "kind": "close_session",
+            "kb_writes": [w["result"]["status"] for w in outcome.kb_writes],
+        })
+        return outcome
+
+    # ------------------------------------------------------------------
+    # Phase 1: prepare-review
+    # ------------------------------------------------------------------
+    def prepare_review(self, raw_request: dict[str, Any]) -> JudgeBundle:
+        req = parse_request(raw_request)
+        bundle = JudgeBundle(
+            kind=req.kind,
+            session_id=req.session_id,
+            decision_id=req.decision_id,
+        )
+        self._populate_inbox(req)
+        merge = self.session_memory.merge_context(req.session_id, req.context)
+        bundle.merged_context = merge.merged
+        bundle.missing_context = list(merge.missing_keys)
+        bundle.proposals = [p.to_dict() for p in req.proposals]
+        bundle.messages = list(req.messages)
+        bundle.decision = dict(req.decision)
+        bundle.review_constraints = self._review_constraints()
+
+        # Hard requirement: if model/framework still unknown, KB reads must be
+        # skipped and the Critic should fall back to needs_review.
+        critical_missing = [
+            k for k in CRITICAL_CONTEXT_KEYS if merge.merged.get(k) in (None, "", "unknown")
+        ]
+        if critical_missing:
+            bundle.required_context = critical_missing
+            bundle.kb_read_skipped_reason = "missing_critical_context"
+            bundle.notes.append(
+                "model and/or framework unknown — KB priors not fetched"
+            )
+            self.session_memory.append_event(req.session_id, {
+                "kind": "prepare_review",
+                "missing_critical": critical_missing,
+                "kb_skipped": True,
+            })
+            return bundle
+
+        # Skip KB reads only if explicitly disabled or inappropriate kind.
+        if req.kind in (KB_DRAFT_REQUEST,):
+            bundle.kb_read_skipped_reason = "kb_draft_does_not_need_priors"
+            return bundle
+
+        scope = build_scope(req.context, session_context=merge.merged, require_critical=False)
+        # Hide unknown values when listing priors so the service doesn't filter
+        # to literal "unknown" rows.
+        scope_filter = {k: v for k, v in scope.items() if v != "unknown"}
+
+        topic_hits: dict[str, list[dict[str, Any]]] = {}
+        ctx = WriteContext(session_id=req.session_id, review_id=req.decision_id)
+        if req.proposals:
+            for p in req.proposals:
+                topic = self._topic_for_proposal(p)
+                priors = self.kb_writer.list_priors(
+                    scope=scope_filter,
+                    kind=None,
+                    topic=topic,
+                    metadata_filter=None,
+                    limit=int(os.environ.get("CRITIC_KB_PRIOR_LIMIT", "5")),
+                    ctx=ctx,
+                )
+                topic_hits[p.msg_id] = priors.get("priors") or []
+                self.session_memory.append_event(req.session_id, {
+                    "kind": "kb_prior_lookup",
+                    "msg_id": p.msg_id,
+                    "topic": topic,
+                    "cache": priors.get("cache"),
+                    "count": len(topic_hits[p.msg_id]),
+                })
+            bundle.kb_priors_by_proposal = topic_hits
+        else:
+            topic = self._topic_for_decision(req)
+            priors = self.kb_writer.list_priors(
+                scope=scope_filter,
+                kind=None,
+                topic=topic,
+                metadata_filter=None,
+                limit=int(os.environ.get("CRITIC_KB_PRIOR_LIMIT", "5")),
+                ctx=ctx,
+            )
+            bundle.kb_priors_for_decision = priors.get("priors") or []
+            self.session_memory.append_event(req.session_id, {
+                "kind": "kb_prior_lookup_decision",
+                "topic": topic,
+                "cache": priors.get("cache"),
+                "count": len(bundle.kb_priors_for_decision),
+            })
+
+        if scope.get("model") == "unknown" or scope.get("framework") == "unknown":
+            bundle.notes.append("scope partially unknown — proceed with caution")
+        bundle.notes.append(f"scope_cache_key={scope_cache_key(scope_filter)}")
+        return bundle
+
+    # ------------------------------------------------------------------
+    # Phase 2: commit-review
+    # ------------------------------------------------------------------
+    def commit_review(
+        self,
+        raw_request: dict[str, Any],
+        review: dict[str, Any],
+    ) -> CommitOutcome:
+        req = parse_request(raw_request)
+        self._populate_inbox(req)
+        if not isinstance(review, dict):
+            raise ReviewValidationError(
+                f"review must be a dict, got {type(review).__name__}"
+            )
+
+        outcome = CommitOutcome(
+            kind=req.kind,
+            session_id=req.session_id,
+            decision_id=req.decision_id,
+        )
+        session_ctx = self.session_memory.load_context(req.session_id)
+
+        if req.kind == COORDINATOR_INBOX:
+            self._commit_coordinator_inbox(req, review, outcome, session_ctx)
+        elif req.kind == DECISION_REQUEST:
+            self._commit_decision_request(req, review, outcome, session_ctx)
+        elif req.kind == KB_DRAFT_REQUEST:
+            self._commit_kb_draft(req, review, outcome, session_ctx)
+        else:
+            raise ReviewValidationError(
+                f"commit_review does not support kind={req.kind!r}"
+            )
+        return outcome
+
+    # ------------------------------------------------------------------
+    # Implementation helpers
+    # ------------------------------------------------------------------
+    def _populate_inbox(self, req: CriticRequest) -> None:
+        if req.kind != COORDINATOR_INBOX:
+            return
+        if req.proposals:
+            return
+        if not req.raw_prompt:
+            return
+        try:
+            parsed = parse_inbox_prompt(req.raw_prompt)
+        except InboxParseError:
+            return
+        if not req.context:
+            req.context.update({k: parsed.shared_state[k] for k in parsed.shared_state})
+        # Filter out proposals already handled in this session (idempotency).
+        new_msg_ids = self.session_memory.filter_unreviewed(
+            req.session_id, [p.msg_id for p in parsed.proposals]
+        )
+        keep = {mid for mid in new_msg_ids}
+        req.proposals = [p for p in parsed.proposals if p.msg_id in keep]
+
+    def _review_constraints(self) -> dict[str, Any]:
+        return {
+            "allowed_verdicts": sorted(ALLOWED_VERDICTS),
+            "approve_requires": [
+                "comparable_before_after_benchmark",
+                "accuracy_gate_or_waiver",
+                "active_path_proof_when_relevant",
+                "rollback_plan",
+            ],
+            "ceiling_importance": 0.84,
+        }
+
+    def _topic_for_proposal(self, proposal: Proposal) -> str:
+        if proposal.action_name:
+            return proposal.action_name
+        body = proposal.payload.get("topic") or proposal.payload.get("summary")
+        if isinstance(body, str) and body.strip():
+            return body.strip()
+        return f"proposal-{proposal.msg_id}"
+
+    def _topic_for_decision(self, req: CriticRequest) -> str:
+        decision = req.decision
+        if isinstance(decision, dict):
+            for key in ("topic", "summary", "target"):
+                value = decision.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+        return f"decision-{req.decision_id or req.session_id}"
+
+    # ---- coordinator_inbox commit ------------------------------------
+    def _commit_coordinator_inbox(
+        self,
+        req: CriticRequest,
+        review: dict[str, Any],
+        outcome: CommitOutcome,
+        session_ctx: dict[str, Any],
+    ) -> None:
+        verdicts_raw = review.get("review_verdicts")
+        if verdicts_raw is None:
+            verdicts_raw = review.get("verdicts")
+        if not isinstance(verdicts_raw, list):
+            raise ReviewValidationError(
+                "coordinator_inbox commit expects review.review_verdicts to be a list"
+            )
+        intents: list[Intent] = []
+        for i, item in enumerate(verdicts_raw):
+            if not isinstance(item, dict):
+                raise ReviewValidationError(
+                    f"review.review_verdicts[{i}] must be an object"
+                )
+            target = item.get("target_proposal_msg_id")
+            verdict = item.get("verdict")
+            if verdict not in ALLOWED_VERDICTS:
+                raise ReviewValidationError(
+                    f"review.review_verdicts[{i}].verdict {verdict!r} is not valid"
+                )
+            if not isinstance(target, str) or not target:
+                raise ReviewValidationError(
+                    f"review.review_verdicts[{i}].target_proposal_msg_id missing"
+                )
+            try:
+                intent = build_review_verdict_intent(
+                    target_proposal_msg_id=target,
+                    verdict=verdict,
+                    reasoning=item.get("reasoning", ""),
+                    source=item.get("source", "critic"),
+                    confidence=item.get("confidence"),
+                    predicted_gain_pct=item.get("predicted_gain_pct"),
+                    kb_evidence=item.get("kb_evidence") or [],
+                    packet_evidence=item.get("packet_evidence") or [],
+                    risks=item.get("risks") or [],
+                    required_evidence=item.get("required_evidence") or [],
+                    alternative_action=item.get("alternative_action"),
+                    advice_text=item.get("advice_text", ""),
+                    notes=item.get("notes") or [],
+                )
+            except IntentEnvelopeValidationError as exc:
+                raise ReviewValidationError(str(exc)) from exc
+            intents.append(intent)
+            self.session_memory.mark_reviewed(
+                req.session_id, target, verdict, decision_id=req.decision_id
+            )
+            self.session_memory.append_decision(req.session_id, {
+                "ts": _now_iso(),
+                "target_proposal_msg_id": target,
+                "verdict": verdict,
+                "reasoning": item.get("reasoning"),
+                "source": item.get("source", "critic"),
+                "kb_evidence": item.get("kb_evidence") or [],
+            })
+            get_registry().counter(CRITIC_REVIEW_VERDICT_TOTAL).inc({"verdict": verdict})
+            self._maybe_write_kb_for_verdict(item, req, session_ctx, outcome)
+
+        # Optional advice for proposals approved with caveats.
+        for advisory in review.get("advice") or []:
+            if not isinstance(advisory, dict):
+                continue
+            body = advisory.get("body_md") or advisory.get("text")
+            if not body:
+                continue
+            intents.append(build_advice_intent(
+                body, target_proposal_msg_id=advisory.get("target_proposal_msg_id")
+            ))
+
+        # Heartbeat fallback if no proposals to review.
+        if not intents:
+            intents.append(build_heartbeat_intent())
+
+        outcome.intent_envelope = build_envelope(intents).to_dict()
+
+    # ---- decision_request commit -------------------------------------
+    def _commit_decision_request(
+        self,
+        req: CriticRequest,
+        review: dict[str, Any],
+        outcome: CommitOutcome,
+        session_ctx: dict[str, Any],
+    ) -> None:
+        for k in ("verdict", "reason"):
+            if k not in review:
+                raise ReviewValidationError(
+                    f"decision_request review missing required key {k!r}"
+                )
+        if review["verdict"] not in {"adopt", "reject", "revise", "needs_info"}:
+            raise ReviewValidationError(
+                f"decision_request review.verdict {review['verdict']!r} not in "
+                f"adopt|reject|revise|needs_info"
+            )
+        decision_review = {
+            "kind": "critic_decision_review",
+            "session_id": req.session_id,
+            "decision_id": req.decision_id,
+            "verdict": review["verdict"],
+            "confidence": review.get("confidence", "medium"),
+            "reason": review["reason"],
+            "recommendation": review.get("recommendation", ""),
+            "basis": review.get("basis", "mixed"),
+            "kb_evidence": review.get("kb_evidence") or [],
+            "session_evidence": review.get("session_evidence") or [],
+            "required_context": review.get("required_context") or [],
+            "notes": review.get("notes") or [],
+        }
+        self.session_memory.append_decision(req.session_id, {
+            "ts": _now_iso(),
+            "decision_review": decision_review,
+        })
+        # Translate adopt/reject into KB writes when there's reusable lesson.
+        verdict_for_kb = {
+            "adopt": "approve",
+            "reject": "reject",
+            "revise": "redirect",
+            "needs_info": "needs_review",
+        }[review["verdict"]]
+        kb_payload = {
+            "verdict": verdict_for_kb,
+            "reasoning": review.get("reason", ""),
+            "packet_evidence": review.get("session_evidence") or [],
+            "kb_evidence": review.get("kb_evidence") or [],
+            "risks": review.get("risks") or [],
+            "confidence": review.get("confidence", "medium"),
+            "predicted_gain_pct": review.get("predicted_gain_pct"),
+        }
+        ctx = WriteContext(
+            session_id=req.session_id,
+            review_id=req.decision_id,
+            source_type=f"critic_decision_{review['verdict']}",
+            topic=review.get("topic") or (req.decision.get("summary") if isinstance(req.decision, dict) else None),
+        )
+        write_res = self.kb_writer.write_verdict(
+            verdict=kb_payload,
+            packet_context=req.context,
+            session_context=session_ctx,
+            ctx=ctx,
+        )
+        outcome.kb_writes.append({
+            "trigger": "decision_request",
+            "result": write_res.to_dict(),
+        })
+        outcome.decision_review = decision_review
+
+    # ---- kb_draft commit ----------------------------------------------
+    def _commit_kb_draft(
+        self,
+        req: CriticRequest,
+        review: dict[str, Any],
+        outcome: CommitOutcome,
+        session_ctx: dict[str, Any],
+    ) -> None:
+        drafts = review.get("kb_drafts") or []
+        if not isinstance(drafts, list):
+            raise ReviewValidationError("kb_draft commit expects review.kb_drafts list")
+        ctx = WriteContext(
+            session_id=req.session_id,
+            review_id=req.decision_id,
+            source_type="critic_kb_draft",
+        )
+        res = self.kb_writer.write_kb_drafts(
+            kb_drafts=drafts,
+            packet_context=req.context,
+            session_context=session_ctx,
+            ctx=ctx,
+        )
+        outcome.kb_writes.append({"trigger": "kb_draft", "result": res.to_dict()})
+        outcome.decision_review = {
+            "kind": "critic_kb_draft",
+            "session_id": req.session_id,
+            "kb_drafts_attempted": len(drafts),
+            "kb_writes": [w["result"] for w in outcome.kb_writes],
+        }
+
+    def _maybe_write_kb_for_verdict(
+        self,
+        verdict_item: dict[str, Any],
+        req: CriticRequest,
+        session_ctx: dict[str, Any],
+        outcome: CommitOutcome,
+    ) -> None:
+        verdict = verdict_item.get("verdict")
+        if verdict not in {"reject", "redirect", "approve"}:
+            return
+        # Only write to KB when the SKILL flagged the verdict as
+        # producing a reusable lesson — surface as ``persist_to_kb=True``.
+        if not verdict_item.get("persist_to_kb"):
+            return
+        ctx = WriteContext(
+            session_id=req.session_id,
+            review_id=req.decision_id,
+            source_type=f"critic_verdict_{verdict}",
+            topic=verdict_item.get("topic"),
+        )
+        try:
+            res = self.kb_writer.write_verdict(
+                verdict=verdict_item,
+                packet_context=req.context,
+                session_context=session_ctx,
+                ctx=ctx,
+            )
+            outcome.kb_writes.append({
+                "trigger": "review_verdict",
+                "target_proposal_msg_id": verdict_item.get("target_proposal_msg_id"),
+                "result": res.to_dict(),
+            })
+        except RuntimeAdapterError as exc:
+            outcome.notes.append(f"kb_write_skipped: {exc}")
+
+
+__all__ = [
+    "CommitOutcome",
+    "DecisionReviewer",
+    "JudgeBundle",
+]

--- a/critic-agent/runtime/decision_reviewer.py
+++ b/critic-agent/runtime/decision_reviewer.py
@@ -255,6 +255,33 @@ class DecisionReviewer:
             bundle.kb_read_skipped_reason = "kb_draft_does_not_need_priors"
             return bundle
 
+        # KB reads disabled wholesale (operator switch) → reflect in bundle.
+        if not self.kb_writer.read_enabled:
+            bundle.kb_read_skipped_reason = "kb_read_disabled"
+            bundle.notes.append("KB_READ_ENABLED=false — proceeding without priors")
+            self.session_memory.append_event(req.session_id, {
+                "kind": "prepare_review",
+                "kb_skipped": True,
+                "reason": "kb_read_disabled",
+            })
+            return bundle
+
+        # Breaker already open from an earlier failure → short-circuit
+        # before paying another timeout for this request.
+        if self.kb_writer.is_kb_unreachable():
+            bundle.kb_read_skipped_reason = "kb_unreachable"
+            bundle.notes.append(
+                "KB service unreachable (circuit breaker open); proceeding without priors"
+            )
+            bundle.review_constraints["kb_breaker"] = self.kb_writer.kb_breaker_state()
+            self.session_memory.append_event(req.session_id, {
+                "kind": "prepare_review",
+                "kb_skipped": True,
+                "reason": "kb_unreachable",
+                "breaker": self.kb_writer.kb_breaker_state(),
+            })
+            return bundle
+
         scope = build_scope(req.context, session_context=merge.merged, require_critical=False)
         # Hide unknown values when listing priors so the service doesn't filter
         # to literal "unknown" rows.
@@ -262,6 +289,7 @@ class DecisionReviewer:
 
         topic_hits: dict[str, list[dict[str, Any]]] = {}
         ctx = WriteContext(session_id=req.session_id, review_id=req.decision_id)
+        any_kb_unreachable = False
         if req.proposals:
             for p in req.proposals:
                 topic = self._topic_for_proposal(p)
@@ -274,6 +302,8 @@ class DecisionReviewer:
                     ctx=ctx,
                 )
                 topic_hits[p.msg_id] = priors.get("priors") or []
+                if priors.get("cache") == "kb_unreachable":
+                    any_kb_unreachable = True
                 self.session_memory.append_event(req.session_id, {
                     "kind": "kb_prior_lookup",
                     "msg_id": p.msg_id,
@@ -293,12 +323,21 @@ class DecisionReviewer:
                 ctx=ctx,
             )
             bundle.kb_priors_for_decision = priors.get("priors") or []
+            if priors.get("cache") == "kb_unreachable":
+                any_kb_unreachable = True
             self.session_memory.append_event(req.session_id, {
                 "kind": "kb_prior_lookup_decision",
                 "topic": topic,
                 "cache": priors.get("cache"),
                 "count": len(bundle.kb_priors_for_decision),
             })
+
+        if any_kb_unreachable:
+            bundle.kb_read_skipped_reason = "kb_unreachable"
+            bundle.notes.append(
+                "KB service unreachable for at least one lookup — priors may be incomplete"
+            )
+            bundle.review_constraints["kb_breaker"] = self.kb_writer.kb_breaker_state()
 
         if scope.get("model") == "unknown" or scope.get("framework") == "unknown":
             bundle.notes.append("scope partially unknown — proceed with caution")

--- a/critic-agent/runtime/errors.py
+++ b/critic-agent/runtime/errors.py
@@ -1,0 +1,77 @@
+"""Typed errors raised by the Critic runtime adapter.
+
+The errors are deliberately granular so the CLI / SKILL can map them to
+deterministic recovery paths (e.g. dead-letter, fall back to
+``needs_review``, or surface ``required_context`` to the caller).
+"""
+
+from __future__ import annotations
+
+
+class RuntimeAdapterError(RuntimeError):
+    """Base class for all Critic runtime errors."""
+
+
+class RequestValidationError(RuntimeAdapterError):
+    """The incoming request JSON is structurally invalid."""
+
+
+class ReviewValidationError(RuntimeAdapterError):
+    """The Critic-produced review JSON does not match the expected schema."""
+
+
+class SessionMemoryError(RuntimeAdapterError):
+    """An I/O or schema error happened while accessing session memory."""
+
+
+class ScopeError(RuntimeAdapterError):
+    """The packet/context cannot be turned into a valid KB scope."""
+
+
+class SlugifyError(RuntimeAdapterError):
+    """The slugify input cannot be reduced to a non-empty deterministic slug."""
+
+
+class KBError(RuntimeAdapterError):
+    """Base class for KB transport errors."""
+
+
+class KBValidationError(KBError):
+    """The KB rejected the payload (HTTP 400 / 422)."""
+
+
+class KBNotFoundError(KBError):
+    """The KB returned 404 (e.g. edge target absent)."""
+
+
+class KBConflictError(KBError):
+    """The KB returned 409 — should not occur with upsert mode."""
+
+
+class KBTransportError(KBError):
+    """Network / 5xx / timeout errors after exhausting retries."""
+
+
+class IntentEnvelopeValidationError(RuntimeAdapterError):
+    """The intent envelope produced for the Coordinator is invalid."""
+
+
+class InboxParseError(RuntimeAdapterError):
+    """The Coordinator-style inbox prompt could not be parsed."""
+
+
+__all__ = [
+    "InboxParseError",
+    "IntentEnvelopeValidationError",
+    "KBConflictError",
+    "KBError",
+    "KBNotFoundError",
+    "KBTransportError",
+    "KBValidationError",
+    "RequestValidationError",
+    "ReviewValidationError",
+    "RuntimeAdapterError",
+    "ScopeError",
+    "SessionMemoryError",
+    "SlugifyError",
+]

--- a/critic-agent/runtime/importance_mapping.py
+++ b/critic-agent/runtime/importance_mapping.py
@@ -1,0 +1,84 @@
+"""Map Critic confidence / verdict signals to KB ``importance`` floats.
+
+Critic is forbidden from writing the top tier (``>= 0.85``) — that range is
+reserved for Alchemist promotion (contract §2.3). The service additionally
+guards against downgrades (G-2 ``max(existing, incoming)``), so we never
+have to special-case "do not downgrade" client-side; we just emit honest
+values within Critic's allowed range.
+
+The two helpers cover the two write triggers we care about today:
+
+* :func:`importance_for_verdict` — Trigger A (review_verdict 落地后).
+* :func:`importance_for_kb_draft` — Trigger B (session close kb_draft).
+"""
+
+from __future__ import annotations
+
+CRITIC_IMPORTANCE_CEILING = 0.84  # Anything above is alchemist-only.
+
+_HIGH_VERDICT_WITH_MEASUREMENT = 0.7
+_HIGH_VERDICT_WITHOUT_MEASUREMENT = 0.4
+_MEDIUM_VERDICT = 0.5
+_DEFAULT_VERDICT = 0.4
+_LOW_VERDICT = 0.4
+
+_DRAFT_DEFAULT = 0.5
+_DRAFT_HIGH_CONFIDENCE = 0.6
+
+
+def importance_for_verdict(
+    *,
+    verdict: str,
+    confidence: str | None = None,
+    has_measurement: bool = False,
+) -> float:
+    """Choose KB ``importance`` for a review_verdict-derived KB write.
+
+    Args:
+        verdict: One of the contract verdicts (``approve`` / ``reject`` / ...).
+        confidence: ``high`` / ``medium`` / ``low`` (Critic schema). ``None``
+            falls back to ``medium``.
+        has_measurement: True when the packet carries a comparable
+            before/after benchmark or reproducer evidence.
+    """
+    confidence_label = (confidence or "medium").lower()
+    # ``advise`` and ``needs_review`` are usually informational — keep them
+    # low so they don't crowd out higher-quality entries.
+    if verdict in ("advise", "needs_review"):
+        return _LOW_VERDICT
+    if confidence_label == "high":
+        return (
+            _HIGH_VERDICT_WITH_MEASUREMENT
+            if has_measurement
+            else _HIGH_VERDICT_WITHOUT_MEASUREMENT
+        )
+    if confidence_label == "low":
+        return _LOW_VERDICT
+    return _MEDIUM_VERDICT if has_measurement else _DEFAULT_VERDICT
+
+
+def importance_for_kb_draft(*, confidence: float | None) -> float:
+    """Choose KB ``importance`` for a Critic kb_draft entry.
+
+    The Critic SKILL emits ``confidence`` as a float in ``[0.0, 1.0]``; we
+    promote drafts that pass ``0.8`` to ``0.6`` and otherwise default to
+    ``0.5`` (contract §2.3 Critic default).
+    """
+    if confidence is None:
+        return _DRAFT_DEFAULT
+    if confidence >= 0.8:
+        return _DRAFT_HIGH_CONFIDENCE
+    return _DRAFT_DEFAULT
+
+
+def cap_importance(value: float) -> float:
+    """Clamp ``value`` to Critic's allowed write range."""
+    return min(max(0.0, float(value)), CRITIC_IMPORTANCE_CEILING)
+
+
+__all__ = [
+    "CRITIC_IMPORTANCE_CEILING",
+    "cap_importance",
+    "importance_for_kb_draft",
+    "importance_for_verdict",
+]

--- a/critic-agent/runtime/in_memory_kb_client.py
+++ b/critic-agent/runtime/in_memory_kb_client.py
@@ -1,0 +1,343 @@
+"""In-memory KBClient used by tests + dry-run mode.
+
+This implementation honours the four behaviours the contract (§7.3)
+requires from a faithful mock:
+
+1. ``(scope, kind, slug)`` UNIQUE with upsert idempotency, partial merge
+   (G-1) and importance protection (G-2).
+2. ``contradicts`` auto-mirroring with ``mirrored_to`` / ``mirror_skipped``
+   bookkeeping (G-8).
+3. ``scope_filter`` containment with ``trim().lowercase()`` value
+   normalisation (G-3).
+4. ``metadata_filter`` supports nested paths and array-contains (G-7).
+
+It also exposes :meth:`simulate_failure` for fault injection so the
+caller can exercise dead-letter paths deterministically.
+
+Time semantics: ``updated_at`` increments are delegated to a ``time_fn``
+parameter so tests can pin them; production uses :func:`time.time`.
+"""
+
+from __future__ import annotations
+
+import copy
+import time
+import uuid
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from .errors import KBValidationError
+
+
+# ---------------------------------------------------------------------------
+def _normalise_value(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip().lower()
+
+
+def _normalise_scope(scope: dict[str, Any]) -> dict[str, str]:
+    return {k: _normalise_value(v) for k, v in scope.items()}
+
+
+def _scope_contains(row_scope: dict[str, str], scope_filter: dict[str, Any]) -> bool:
+    """Return True if ``row_scope`` matches every key/value in the filter."""
+    for k, v in scope_filter.items():
+        wanted = _normalise_value(v)
+        if row_scope.get(k, "") != wanted:
+            return False
+    return True
+
+
+def _matches_metadata(metadata: dict[str, Any], filter_obj: dict[str, Any]) -> bool:
+    """Recursive nested + array-contains matcher (G-7)."""
+    for key, expected in filter_obj.items():
+        if isinstance(expected, dict):
+            sub = metadata.get(key)
+            if not isinstance(sub, dict):
+                return False
+            if not _matches_metadata(sub, expected):
+                return False
+            continue
+        if isinstance(expected, list):
+            haystack = metadata.get(key)
+            if isinstance(haystack, list):
+                # array contains: every item in expected must be in haystack
+                for item in expected:
+                    if item not in haystack:
+                        return False
+                continue
+            return False
+        if metadata.get(key) != expected:
+            return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+@dataclass
+class _Row:
+    id: str
+    scope: dict[str, str]
+    kind: str
+    slug: str
+    importance: float
+    summary: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+    edges: dict[str, list[str]] = field(default_factory=dict)
+    deleted: bool = False
+    created_at: float = 0.0
+    updated_at: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "scope": dict(self.scope),
+            "kind": self.kind,
+            "slug": self.slug,
+            "importance": self.importance,
+            "summary": self.summary,
+            "metadata": copy.deepcopy(self.metadata),
+            "edges": {k: list(v) for k, v in self.edges.items()},
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "deleted": self.deleted,
+        }
+
+
+_REQUIRED_UPSERT_FIELDS: tuple[str, ...] = ("scope", "kind", "slug", "importance")
+
+
+# ---------------------------------------------------------------------------
+class InMemoryKBClient:
+    """Faithful in-memory mock of the KB service surface."""
+
+    def __init__(self, *, time_fn: Callable[[], float] = time.time):
+        self._rows: dict[str, _Row] = {}
+        self._index: dict[tuple[str, str, str], str] = {}
+        self._time_fn = time_fn
+        self._failure_queue: deque[dict[str, Any]] = deque()
+
+    # ------------------------------------------------------------------
+    # Fault injection
+    # ------------------------------------------------------------------
+    def simulate_failure(
+        self,
+        *,
+        endpoint: str,
+        times: int,
+        error: dict[str, Any],
+    ) -> None:
+        """Schedule ``times`` consecutive failures for ``endpoint``.
+
+        ``error`` is propagated as a :class:`KBValidationError` so callers
+        can simulate 4xx-class failures; for 5xx-class behaviour (retry
+        loops) compose with :class:`runtime.kb_client.HTTPKBClient` in an
+        integration test instead.
+        """
+        for _ in range(times):
+            self._failure_queue.append({"endpoint": endpoint, "error": error})
+
+    def _maybe_fail(self, endpoint: str) -> None:
+        if not self._failure_queue:
+            return
+        head = self._failure_queue[0]
+        if head["endpoint"] == endpoint:
+            self._failure_queue.popleft()
+            err = head["error"]
+            raise KBValidationError(f"{endpoint}: simulated failure {err!r}")
+
+    # ------------------------------------------------------------------
+    # list
+    # ------------------------------------------------------------------
+    def list(
+        self,
+        *,
+        scope_filter: dict[str, Any],
+        kind: str | None = None,
+        metadata_filter: dict[str, Any] | None = None,
+        limit: int = 10,
+        sort_by: str = "updated_at_desc",
+        include_deleted: bool = False,
+    ) -> dict[str, Any]:
+        self._maybe_fail("list")
+        if not isinstance(scope_filter, dict):
+            raise KBValidationError("list: scope_filter must be an object")
+        out: list[_Row] = []
+        for row in self._rows.values():
+            if row.deleted and not include_deleted:
+                continue
+            if kind is not None and row.kind != kind:
+                continue
+            if not _scope_contains(row.scope, scope_filter):
+                continue
+            if metadata_filter and not _matches_metadata(row.metadata, metadata_filter):
+                continue
+            out.append(row)
+        out.sort(key=lambda r: r.updated_at, reverse=(sort_by == "updated_at_desc"))
+        if limit:
+            out = out[:limit]
+        return {"entries": [r.to_dict() for r in out], "count": len(out)}
+
+    # ------------------------------------------------------------------
+    # upsert
+    # ------------------------------------------------------------------
+    def upsert(self, payload: dict[str, Any]) -> dict[str, Any]:
+        self._maybe_fail("upsert")
+        for f in _REQUIRED_UPSERT_FIELDS:
+            if f not in payload:
+                raise KBValidationError(f"upsert: missing field {f!r}")
+        scope = _normalise_scope(payload["scope"])
+        kind = payload["kind"]
+        slug = payload["slug"]
+        importance_in = float(payload["importance"])
+        summary_in = payload.get("summary", "")
+        metadata_in = payload.get("metadata") or {}
+        edges_in = payload.get("edges") or {}
+
+        warnings: list[str] = []
+        # Scope value normalisation (G-3): if any incoming value differs
+        # from its normalised form, surface a warning.
+        for k, v in payload["scope"].items():
+            if str(v).strip().lower() != _normalise_value(v) or _normalise_value(v) != _normalise_value(payload["scope"][k]):
+                # Heuristic: emit warning whenever value had upper-case or surrounding spaces.
+                if str(v) != _normalise_value(v):
+                    warnings.append("scope_value_normalized")
+                    break
+
+        key = (json_scope_key(scope), kind, slug)
+        existing_id = self._index.get(key)
+        now = self._time_fn()
+        if existing_id is None:
+            row = _Row(
+                id=f"kb_{uuid.uuid4().hex[:10]}",
+                scope=scope,
+                kind=kind,
+                slug=slug,
+                importance=importance_in,
+                summary=summary_in,
+                metadata=copy.deepcopy(metadata_in),
+                edges={k: list(v) for k, v in edges_in.items()},
+                created_at=now,
+                updated_at=now,
+            )
+            self._rows[row.id] = row
+            self._index[key] = row.id
+            return {"row": row.to_dict(), "created": True, "warnings": warnings}
+
+        row = self._rows[existing_id]
+        # Partial field merge (G-1).
+        if "summary" in payload:
+            row.summary = summary_in
+        if metadata_in:
+            row.metadata = _deep_merge(row.metadata, metadata_in)
+        for kind_edge, ids in edges_in.items():
+            existing = row.edges.setdefault(kind_edge, [])
+            for eid in ids:
+                if eid not in existing:
+                    existing.append(eid)
+        # Importance protection (G-2).
+        if importance_in < row.importance:
+            warnings.append("importance_protected")
+        else:
+            row.importance = importance_in
+        row.updated_at = now
+        return {"row": row.to_dict(), "created": False, "warnings": warnings}
+
+    # ------------------------------------------------------------------
+    # batch_insert
+    # ------------------------------------------------------------------
+    def batch_insert(
+        self,
+        items: list[dict[str, Any]],
+        *,
+        on_conflict: str = "upsert",
+    ) -> dict[str, Any]:
+        self._maybe_fail("batch_insert")
+        if on_conflict not in ("upsert", "error"):
+            raise KBValidationError(
+                f"batch_insert: on_conflict must be upsert|error, got {on_conflict!r}"
+            )
+        results: list[dict[str, Any]] = []
+        for item in items:
+            if on_conflict == "upsert":
+                results.append(self.upsert(item))
+            else:
+                key = (
+                    json_scope_key(_normalise_scope(item["scope"])),
+                    item["kind"],
+                    item["slug"],
+                )
+                if key in self._index:
+                    raise KBValidationError(
+                        f"batch_insert: conflict on {key!r}; use on_conflict=upsert"
+                    )
+                results.append(self.upsert(item))
+        return {"results": results, "count": len(results)}
+
+    # ------------------------------------------------------------------
+    # add_edges
+    # ------------------------------------------------------------------
+    def add_edges(self, edges: list[dict[str, Any]]) -> dict[str, Any]:
+        self._maybe_fail("edges/add")
+        added: list[dict[str, Any]] = []
+        mirrored_to: list[dict[str, Any]] = []
+        mirror_skipped: list[dict[str, Any]] = []
+        for edge in edges:
+            kind = edge.get("kind")
+            src = edge.get("from_id")
+            dst = edge.get("to_id")
+            if not (kind and src and dst):
+                raise KBValidationError(
+                    f"edges/add: missing kind/from_id/to_id: {edge!r}"
+                )
+            row_src = self._rows.get(src)
+            if row_src is None:
+                # Source missing → standard 404 in real service.
+                mirror_skipped.append({"edge": edge, "reason": "src_missing"})
+                continue
+            bucket = row_src.edges.setdefault(kind, [])
+            if dst not in bucket:
+                bucket.append(dst)
+            added.append({"from_id": src, "to_id": dst, "kind": kind})
+            # Auto-mirror for ``contradicts``.
+            if kind == "contradicts":
+                row_dst = self._rows.get(dst)
+                if row_dst is None:
+                    mirror_skipped.append({"edge": edge, "reason": "dst_missing"})
+                    continue
+                back = row_dst.edges.setdefault(kind, [])
+                if src not in back:
+                    back.append(src)
+                mirrored_to.append({"from_id": dst, "to_id": src, "kind": kind})
+        return {"added": added, "mirrored_to": mirrored_to, "mirror_skipped": mirror_skipped}
+
+    # ------------------------------------------------------------------
+    # Test helpers
+    # ------------------------------------------------------------------
+    def all_rows(self) -> list[dict[str, Any]]:
+        return [r.to_dict() for r in self._rows.values()]
+
+    def reset(self) -> None:
+        self._rows.clear()
+        self._index.clear()
+        self._failure_queue.clear()
+
+
+# ---------------------------------------------------------------------------
+def json_scope_key(scope: dict[str, str]) -> str:
+    """Stable scope key used for `(scope, kind, slug)` UNIQUE."""
+    return "|".join(f"{k}={scope[k]}" for k in sorted(scope.keys()))
+
+
+def _deep_merge(base: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
+    out = copy.deepcopy(base)
+    for k, v in incoming.items():
+        if isinstance(v, dict) and isinstance(out.get(k), dict):
+            out[k] = _deep_merge(out[k], v)
+        else:
+            out[k] = copy.deepcopy(v)
+    return out
+
+
+__all__ = ["InMemoryKBClient", "json_scope_key"]

--- a/critic-agent/runtime/inbox_parser.py
+++ b/critic-agent/runtime/inbox_parser.py
@@ -1,0 +1,302 @@
+r"""Parse the Coordinator-style ``_compose_prompt`` text into structured fields.
+
+The Coordinator (DESIGN v0.6 §8.3 / §13.1) hands every reactor a prompt with
+the following layout:
+
+```
+=== Shared session state ===
+<key=value tokens, possibly across several lines>
+
+=== Knowledge base hints ===
+<free text, only for the orchestration role>
+
+=== Inbox for <agent> (newest last) ===
+  seq=<int> msg_id=<hex> from=<agent> topic=<topic> payload=<python-repr-dict>
+  ...
+```
+
+The Critic mock backend also uses the exact regex
+``r"^\s*seq=(\d+)\s+msg_id=([a-f0-9]+)\s+from=(\w+)\s+topic=proposal\s+payload=(.*)$"``
+to spot proposals; we keep behaviour identical so a real Critic agent
+remains drop-in compatible.
+
+This parser is intentionally tolerant:
+
+* Unknown sections are stored under ``extras`` instead of raising.
+* The shared-state line is parsed as best-effort ``key=value`` tokens; values
+  that themselves contain ``=`` or whitespace are accepted but kept as the
+  raw tail.
+* Payload parsing prefers :func:`ast.literal_eval` (matches the
+  ``str(dict)`` format produced by ``_compose_prompt``) and falls back to
+  :func:`json.loads`. If neither succeeds, the row is still kept with the
+  raw payload string for audit, but it does **not** appear in
+  ``proposals`` so the Critic never produces a verdict against an
+  unparseable proposal.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any, Iterable
+
+from .errors import InboxParseError
+from .request_models import Proposal
+
+
+# ``=== Section title ===`` marker. Title may include parentheses, spaces and
+# words. Capture group 1 is the trimmed title.
+_SECTION_RE = re.compile(r"^\s*===\s*(.+?)\s*===\s*$")
+
+# Inbox row layout (matches Coordinator._compose_prompt). Hex32 is the v0.6
+# canonical msg_id, but we accept any non-empty hex run.
+_INBOX_ROW_RE = re.compile(
+    r"^\s*seq=(?P<seq>\d+)\s+"
+    r"msg_id=(?P<msg_id>[A-Za-z0-9_\-]+)\s+"
+    r"from=(?P<from_agent>[A-Za-z0-9_\-]+)\s+"
+    r"topic=(?P<topic>[A-Za-z0-9_\-]+)\s+"
+    r"payload=(?P<payload>.*)$"
+)
+
+# Section titles we recognise.
+_SHARED_STATE_TITLE = "Shared session state"
+_KB_HINTS_TITLE = "Knowledge base hints"
+_INBOX_PREFIX = "Inbox for "
+
+
+# ---------------------------------------------------------------------------
+@dataclass
+class InboxRow:
+    """One parsed line from the inbox tail."""
+
+    seq: int
+    msg_id: str
+    from_agent: str
+    topic: str
+    payload: dict[str, Any] | None
+    raw_payload: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "seq": self.seq,
+            "msg_id": self.msg_id,
+            "from_agent": self.from_agent,
+            "topic": self.topic,
+            "payload": self.payload,
+            "raw_payload": self.raw_payload,
+        }
+
+
+@dataclass
+class ParsedPrompt:
+    """Structured view of a Coordinator-style prompt.
+
+    Attributes:
+        agent_name: Inferred from the inbox section title (e.g. ``critic``).
+        shared_state: ``key -> value`` tokens parsed from the shared state
+            section. Values are kept as strings; the caller may coerce.
+        inbox: All inbox rows, including non-proposal topics.
+        proposals: Subset of ``inbox`` whose ``topic == "proposal"`` and
+            whose payload parsed cleanly. Already converted to
+            :class:`Proposal` for downstream convenience.
+        kb_hints_text: Raw KB hints section (orchestration only); ``""`` if
+            absent.
+        extras: Any other ``=== Title ===`` section, mapped title -> raw text.
+    """
+
+    agent_name: str | None = None
+    shared_state: dict[str, str] = field(default_factory=dict)
+    inbox: list[InboxRow] = field(default_factory=list)
+    proposals: list[Proposal] = field(default_factory=list)
+    kb_hints_text: str = ""
+    extras: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "agent_name": self.agent_name,
+            "shared_state": dict(self.shared_state),
+            "inbox": [r.to_dict() for r in self.inbox],
+            "proposals": [p.to_dict() for p in self.proposals],
+            "kb_hints_text": self.kb_hints_text,
+            "extras": dict(self.extras),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Shared-state token parser
+# ---------------------------------------------------------------------------
+_TOKEN_RE = re.compile(r"(?P<key>[A-Za-z_][A-Za-z0-9_]*)=")
+
+
+def _parse_shared_state(text: str) -> dict[str, str]:
+    """Best-effort ``key=value`` token parser.
+
+    The Coordinator's ``shared_state.to_prompt_summary()`` emits whitespace-
+    separated tokens. We tolerate values that contain spaces or symbols by
+    consuming until the next ``key=`` token start. Quoted values and
+    multi-token values both round-trip back to a single string.
+    """
+    out: dict[str, str] = {}
+    cleaned = " ".join(line.strip() for line in text.splitlines() if line.strip())
+    if not cleaned:
+        return out
+    matches = list(_TOKEN_RE.finditer(cleaned))
+    for i, m in enumerate(matches):
+        key = m.group("key")
+        value_start = m.end()
+        value_end = matches[i + 1].start() if i + 1 < len(matches) else len(cleaned)
+        value = cleaned[value_start:value_end].strip()
+        # Trim trailing punctuation that is clearly a separator (comma, semicolon).
+        while value.endswith((",", ";")):
+            value = value[:-1].rstrip()
+        out[key] = value
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Payload parser
+# ---------------------------------------------------------------------------
+def _try_parse_payload(raw: str) -> dict[str, Any] | None:
+    """Return a dict if ``raw`` parses as either ``ast.literal_eval`` or JSON."""
+    raw = raw.strip()
+    if not raw:
+        return None
+    # ``str(dict)`` form (Python repr, single quotes) — most common.
+    try:
+        value = ast.literal_eval(raw)
+    except (ValueError, SyntaxError):
+        value = None
+    if isinstance(value, dict):
+        return value
+    # JSON fallback (allows callers that emit JSON directly).
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError:
+        value = None
+    if isinstance(value, dict):
+        return value
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Section iterator
+# ---------------------------------------------------------------------------
+def _iter_sections(text: str) -> Iterable[tuple[str | None, list[str]]]:
+    """Yield ``(title, lines)`` tuples in source order.
+
+    Lines before the first ``=== ===`` marker are emitted with title=``None``
+    so the caller can either ignore them or surface them as preamble.
+    """
+    current_title: str | None = None
+    current_lines: list[str] = []
+    for line in text.splitlines():
+        m = _SECTION_RE.match(line)
+        if m:
+            if current_title is not None or current_lines:
+                yield current_title, current_lines
+            current_title = m.group(1)
+            current_lines = []
+            continue
+        current_lines.append(line)
+    if current_title is not None or current_lines:
+        yield current_title, current_lines
+
+
+def _agent_from_inbox_title(title: str) -> str | None:
+    """Extract ``critic`` from titles like ``Inbox for critic (newest last)``."""
+    if not title.startswith(_INBOX_PREFIX):
+        return None
+    rest = title[len(_INBOX_PREFIX) :].strip()
+    # Strip a trailing parenthesised qualifier such as ``(newest last)``.
+    paren = rest.find("(")
+    if paren >= 0:
+        rest = rest[:paren].strip()
+    return rest or None
+
+
+# ---------------------------------------------------------------------------
+def parse_inbox_prompt(text: str) -> ParsedPrompt:
+    """Parse a Coordinator-style prompt into :class:`ParsedPrompt`.
+
+    Raises:
+        InboxParseError: If the input is not a string.
+    """
+    if not isinstance(text, str):
+        raise InboxParseError(f"prompt must be str, got {type(text).__name__}")
+    parsed = ParsedPrompt()
+    for title, lines in _iter_sections(text):
+        if title is None:
+            # Preamble before any section header — treat as ignorable.
+            continue
+        if title == _SHARED_STATE_TITLE:
+            parsed.shared_state = _parse_shared_state("\n".join(lines))
+            continue
+        if title == _KB_HINTS_TITLE:
+            parsed.kb_hints_text = "\n".join(lines).strip()
+            continue
+        if title.startswith(_INBOX_PREFIX):
+            parsed.agent_name = _agent_from_inbox_title(title)
+            for raw_line in lines:
+                if not raw_line.strip() or raw_line.strip().startswith("("):
+                    # Empty line or "(no new messages)" placeholder.
+                    continue
+                row = _parse_inbox_row(raw_line)
+                if row is None:
+                    # Keep going — a malformed line is a coordinator bug, not
+                    # a fatal error for the Critic. We surface it via
+                    # ``extras['malformed_inbox']`` for audit.
+                    bucket = parsed.extras.setdefault("malformed_inbox", "")
+                    parsed.extras["malformed_inbox"] = (
+                        bucket + ("\n" if bucket else "") + raw_line.strip()
+                    )
+                    continue
+                parsed.inbox.append(row)
+                if row.topic == "proposal" and isinstance(row.payload, dict):
+                    parsed.proposals.append(_proposal_from_row(row))
+            continue
+        # Unknown section — preserve verbatim for audit.
+        parsed.extras[title] = "\n".join(lines).strip()
+    return parsed
+
+
+def _parse_inbox_row(raw: str) -> InboxRow | None:
+    m = _INBOX_ROW_RE.match(raw)
+    if not m:
+        return None
+    payload_text = m.group("payload").strip()
+    payload = _try_parse_payload(payload_text)
+    return InboxRow(
+        seq=int(m.group("seq")),
+        msg_id=m.group("msg_id"),
+        from_agent=m.group("from_agent"),
+        topic=m.group("topic"),
+        payload=payload,
+        raw_payload=payload_text,
+    )
+
+
+def _proposal_from_row(row: InboxRow) -> Proposal:
+    payload = dict(row.payload or {})
+    action_name = payload.get("action_name") if isinstance(payload.get("action_name"), str) else None
+    gain_raw = payload.get("predicted_gain_pct")
+    if isinstance(gain_raw, (int, float)):
+        predicted_gain_pct: float | None = float(gain_raw)
+    else:
+        predicted_gain_pct = None
+    return Proposal(
+        msg_id=row.msg_id,
+        from_agent=row.from_agent,
+        payload=payload,
+        seq=row.seq,
+        action_name=action_name,
+        predicted_gain_pct=predicted_gain_pct,
+    )
+
+
+__all__ = [
+    "InboxRow",
+    "ParsedPrompt",
+    "parse_inbox_prompt",
+]

--- a/critic-agent/runtime/intent_envelope.py
+++ b/critic-agent/runtime/intent_envelope.py
@@ -1,0 +1,283 @@
+"""Build and validate Coordinator-compatible intent envelopes.
+
+The Coordinator (DESIGN v0.6 §14) accepts intent envelopes of the form
+
+```
+{"intents": [{"intent_type": "<type>", "payload": {...}}, ...]}
+```
+
+The Critic agent only ever produces three intent types in normal operation:
+
+* ``review_verdict`` — primary output for any ``proposal`` it sees.
+* ``send_message`` — heartbeat (no proposal in inbox) or devil's advocate
+  ``advice`` topic.
+* ``update_persona`` — append-only persona update (Critic role permission).
+
+We deliberately mirror the schema and verdict vocabulary from
+``inference_optimizer/orchestrator/intent_parser.py`` and
+``inference_optimizer/orchestrator/policy.py`` rather than importing them, so
+the Critic skill stays usable as a standalone package (no Hyperloom-wide
+runtime dependency at install time).
+
+If the Coordinator ever extends the envelope schema, update this file and
+the ``ENVELOPE_SCHEMA_VERSION`` constant.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable
+
+from .errors import IntentEnvelopeValidationError
+
+
+ENVELOPE_SCHEMA_VERSION = "v0.6"
+
+
+# Intent types the Critic role is allowed to emit (DESIGN v0.6 §7.6 +
+# ``_CRITIC_INTENTS`` in agent_role.py).
+ALLOWED_CRITIC_INTENTS: frozenset[str] = frozenset({
+    "review_verdict",
+    "send_message",
+    "ask_question",
+    "answer",
+    "alert",
+    "update_persona",
+})
+
+
+# Verdict vocabulary from policy.REVIEW_VERDICTS.
+ALLOWED_VERDICTS: frozenset[str] = frozenset({
+    "approve",
+    "reject",
+    "redirect",
+    "advise",
+    "needs_review",
+})
+
+
+# Verdict source vocabulary from references/verdict_schema.md.
+ALLOWED_VERDICT_SOURCES: frozenset[str] = frozenset({
+    "critic",
+    "mock",
+    "timeout",
+    "critic_unavailable",
+})
+
+
+# Required payload fields per intent type — same set the Coordinator's
+# PolicyGate enforces. See ``_PAYLOAD_REQUIRED`` in intent_parser.py.
+_PAYLOAD_REQUIRED: dict[str, tuple[str, ...]] = {
+    "send_message": ("topic",),
+    "ask_question": ("topic", "question"),
+    "answer": ("in_reply_to", "answer"),
+    "alert": ("severity", "summary"),
+    "update_persona": ("body_md",),
+    "review_verdict": ("target_proposal_msg_id", "verdict"),
+}
+
+
+# Default content for the heartbeat fallback. Matches MockCriticBackend
+# behaviour so callers can unit-test parity.
+DEFAULT_HEARTBEAT_TOPIC = "heartbeat"
+DEFAULT_HEARTBEAT_BODY = "ok (critic)"
+DEFAULT_ADVICE_TOPIC = "advice"
+
+
+# ---------------------------------------------------------------------------
+@dataclass
+class Intent:
+    """One envelope item — exactly what the Coordinator parses."""
+
+    intent_type: str
+    payload: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"intent_type": self.intent_type, "payload": dict(self.payload)}
+
+
+@dataclass
+class IntentEnvelope:
+    """A list of :class:`Intent` items + envelope metadata."""
+
+    intents: list[Intent] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"intents": [i.to_dict() for i in self.intents]}
+
+    def append(self, intent: Intent) -> None:
+        self.intents.append(intent)
+
+
+# ---------------------------------------------------------------------------
+def _validate_payload(intent_type: str, payload: dict[str, Any]) -> None:
+    if not isinstance(payload, dict):
+        raise IntentEnvelopeValidationError(
+            f"intent {intent_type!r}: payload must be an object, "
+            f"got {type(payload).__name__}"
+        )
+    required = _PAYLOAD_REQUIRED.get(intent_type, ())
+    for key in required:
+        if key not in payload:
+            raise IntentEnvelopeValidationError(
+                f"intent {intent_type!r}: missing required payload key {key!r}"
+            )
+    if intent_type == "review_verdict":
+        verdict = payload.get("verdict")
+        if verdict not in ALLOWED_VERDICTS:
+            raise IntentEnvelopeValidationError(
+                f"review_verdict.verdict {verdict!r} not in "
+                f"{sorted(ALLOWED_VERDICTS)!r}"
+            )
+        target = payload.get("target_proposal_msg_id")
+        if not isinstance(target, str) or not target:
+            raise IntentEnvelopeValidationError(
+                "review_verdict.target_proposal_msg_id must be a non-empty string"
+            )
+        source = payload.get("source")
+        if source is not None and source not in ALLOWED_VERDICT_SOURCES:
+            raise IntentEnvelopeValidationError(
+                f"review_verdict.source {source!r} not in "
+                f"{sorted(ALLOWED_VERDICT_SOURCES)!r}"
+            )
+
+
+def validate_envelope(envelope: dict[str, Any]) -> IntentEnvelope:
+    """Validate the dict form and return a typed :class:`IntentEnvelope`.
+
+    The function is the inverse of :meth:`IntentEnvelope.to_dict` — it's the
+    only place we accept envelopes constructed by hand (e.g. when reading
+    a Skill-produced ``review.json``).
+    """
+    if not isinstance(envelope, dict):
+        raise IntentEnvelopeValidationError(
+            f"envelope must be an object, got {type(envelope).__name__}"
+        )
+    if "intents" not in envelope:
+        raise IntentEnvelopeValidationError("envelope missing 'intents' key")
+    items = envelope["intents"]
+    if not isinstance(items, list) or not items:
+        raise IntentEnvelopeValidationError(
+            "envelope.intents must be a non-empty list"
+        )
+    out = IntentEnvelope()
+    for i, item in enumerate(items):
+        if not isinstance(item, dict):
+            raise IntentEnvelopeValidationError(
+                f"envelope.intents[{i}] must be an object"
+            )
+        if "intent_type" not in item or "payload" not in item:
+            raise IntentEnvelopeValidationError(
+                f"envelope.intents[{i}] missing intent_type or payload"
+            )
+        intent_type = item["intent_type"]
+        if intent_type not in ALLOWED_CRITIC_INTENTS:
+            raise IntentEnvelopeValidationError(
+                f"envelope.intents[{i}].intent_type {intent_type!r} is not "
+                f"a Critic-permitted intent (allowed: "
+                f"{sorted(ALLOWED_CRITIC_INTENTS)!r})"
+            )
+        payload = item["payload"]
+        _validate_payload(intent_type, payload)
+        out.append(Intent(intent_type=intent_type, payload=dict(payload)))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Builders — convenience constructors used by decision_reviewer.
+# ---------------------------------------------------------------------------
+def build_review_verdict_intent(
+    *,
+    target_proposal_msg_id: str,
+    verdict: str,
+    reasoning: str = "",
+    source: str = "critic",
+    confidence: str | None = None,
+    predicted_gain_pct: float | None = None,
+    kb_evidence: Iterable[str] | None = None,
+    packet_evidence: Iterable[str] | None = None,
+    risks: list[dict[str, Any]] | None = None,
+    required_evidence: Iterable[str] | None = None,
+    alternative_action: str | None = None,
+    advice_text: str = "",
+    notes: Iterable[str] | None = None,
+) -> Intent:
+    if verdict not in ALLOWED_VERDICTS:
+        raise IntentEnvelopeValidationError(
+            f"verdict {verdict!r} not in {sorted(ALLOWED_VERDICTS)!r}"
+        )
+    if source not in ALLOWED_VERDICT_SOURCES:
+        raise IntentEnvelopeValidationError(
+            f"source {source!r} not in {sorted(ALLOWED_VERDICT_SOURCES)!r}"
+        )
+    if not target_proposal_msg_id:
+        raise IntentEnvelopeValidationError(
+            "target_proposal_msg_id is required"
+        )
+    payload: dict[str, Any] = {
+        "target_proposal_msg_id": target_proposal_msg_id,
+        "verdict": verdict,
+        "source": source,
+        "reasoning": reasoning,
+        "predicted_gain_pct": predicted_gain_pct,
+        "kb_evidence": list(kb_evidence or []),
+        "packet_evidence": list(packet_evidence or []),
+        "risks": list(risks or []),
+        "required_evidence": list(required_evidence or []),
+        "alternative_action": alternative_action,
+        "advice_text": advice_text,
+        "notes": list(notes or []),
+    }
+    if confidence is not None:
+        payload["confidence"] = confidence
+    return Intent(intent_type="review_verdict", payload=payload)
+
+
+def build_heartbeat_intent(body_md: str = DEFAULT_HEARTBEAT_BODY) -> Intent:
+    return Intent(
+        intent_type="send_message",
+        payload={"topic": DEFAULT_HEARTBEAT_TOPIC, "body_md": body_md},
+    )
+
+
+def build_advice_intent(body_md: str, *, target_proposal_msg_id: str | None = None) -> Intent:
+    payload: dict[str, Any] = {"topic": DEFAULT_ADVICE_TOPIC, "body_md": body_md}
+    if target_proposal_msg_id:
+        payload["about_proposal_msg_id"] = target_proposal_msg_id
+    return Intent(intent_type="send_message", payload=payload)
+
+
+def build_envelope(intents: Iterable[Intent]) -> IntentEnvelope:
+    """Wrap a non-empty iterable of intents into an envelope.
+
+    Empty input falls back to a single heartbeat so the Coordinator never
+    times out on an empty envelope; this matches MockCriticBackend.
+    """
+    materialised = list(intents)
+    if not materialised:
+        materialised = [build_heartbeat_intent()]
+    env = IntentEnvelope()
+    for intent in materialised:
+        env.append(intent)
+    # Self-check by routing through validate_envelope so we surface bugs at
+    # build time rather than after the LLM has already produced a response.
+    validate_envelope(env.to_dict())
+    return env
+
+
+__all__ = [
+    "ALLOWED_CRITIC_INTENTS",
+    "ALLOWED_VERDICTS",
+    "ALLOWED_VERDICT_SOURCES",
+    "DEFAULT_ADVICE_TOPIC",
+    "DEFAULT_HEARTBEAT_BODY",
+    "DEFAULT_HEARTBEAT_TOPIC",
+    "ENVELOPE_SCHEMA_VERSION",
+    "Intent",
+    "IntentEnvelope",
+    "build_advice_intent",
+    "build_envelope",
+    "build_heartbeat_intent",
+    "build_review_verdict_intent",
+    "validate_envelope",
+]

--- a/critic-agent/runtime/kb_client.py
+++ b/critic-agent/runtime/kb_client.py
@@ -1,0 +1,212 @@
+"""KB client interface + minimal HTTP transport.
+
+The Critic uses only 4 KB endpoints (contract §4):
+
+* ``POST /api/kb/list``
+* ``POST /api/kb/upsert``
+* ``POST /api/kb/batch_insert``
+* ``POST /api/kb/edges/add``
+
+We expose them as plain methods on :class:`KBClient` (a protocol) and ship
+two implementations:
+
+* :class:`HTTPKBClient` — thin urllib-based transport with retry +
+  exponential backoff. We deliberately avoid pulling in ``httpx`` so the
+  runtime stays installable in minimal Codex containers.
+* :class:`InMemoryKBClient` (in ``in_memory_kb_client.py``) — same surface,
+  pure Python state, used by tests and dry-runs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Protocol
+
+from .errors import (
+    KBConflictError,
+    KBNotFoundError,
+    KBTransportError,
+    KBValidationError,
+)
+from .metrics import (
+    CRITIC_KB_WRITE_DURATION_SECONDS,
+    CRITIC_KB_WRITE_TOTAL,
+    get_registry,
+)
+
+
+DEFAULT_TIMEOUT_MS = 10_000
+DEFAULT_RETRY_MAX = 3
+DEFAULT_BACKOFF_BASE = 1.0  # seconds; 1, 2, 4 ...
+
+
+class KBClient(Protocol):
+    """Protocol shared between ``HTTPKBClient`` and ``InMemoryKBClient``."""
+
+    def list(
+        self,
+        *,
+        scope_filter: dict[str, Any],
+        kind: str | None = None,
+        metadata_filter: dict[str, Any] | None = None,
+        limit: int = 10,
+        sort_by: str = "updated_at_desc",
+        include_deleted: bool = False,
+    ) -> dict[str, Any]: ...
+
+    def upsert(self, payload: dict[str, Any]) -> dict[str, Any]: ...
+
+    def batch_insert(
+        self,
+        items: list[dict[str, Any]],
+        *,
+        on_conflict: str = "upsert",
+    ) -> dict[str, Any]: ...
+
+    def add_edges(self, edges: list[dict[str, Any]]) -> dict[str, Any]: ...
+
+
+# ---------------------------------------------------------------------------
+class HTTPKBClient:
+    """Minimal HTTP wrapper over ``/api/kb/*``.
+
+    Retry policy mirrors contract §6: exponential backoff on 429 / 5xx /
+    network errors up to ``retry_max`` times. 4xx errors raise
+    :class:`KBValidationError` immediately so the caller can dead-letter.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        token: str | None = None,
+        timeout_ms: int = DEFAULT_TIMEOUT_MS,
+        retry_max: int = DEFAULT_RETRY_MAX,
+        backoff_base: float = DEFAULT_BACKOFF_BASE,
+        sleep_fn=time.sleep,
+    ):
+        if not base_url:
+            raise ValueError("HTTPKBClient: base_url is required")
+        self.base_url = base_url.rstrip("/")
+        self.token = token or os.environ.get("KB_SERVICE_TOKEN") or ""
+        self.timeout_s = float(timeout_ms) / 1000.0
+        self.retry_max = retry_max
+        self.backoff_base = backoff_base
+        self._sleep = sleep_fn
+
+    # ------------------------------------------------------------------
+    # Public API — one method per endpoint.
+    # ------------------------------------------------------------------
+    def list(
+        self,
+        *,
+        scope_filter: dict[str, Any],
+        kind: str | None = None,
+        metadata_filter: dict[str, Any] | None = None,
+        limit: int = 10,
+        sort_by: str = "updated_at_desc",
+        include_deleted: bool = False,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "scope_filter": scope_filter,
+            "limit": limit,
+            "sort_by": sort_by,
+            "include_deleted": include_deleted,
+        }
+        if kind is not None:
+            body["kind"] = kind
+        if metadata_filter is not None:
+            body["metadata_filter"] = metadata_filter
+        return self._request("/api/kb/list", body)
+
+    def upsert(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return self._request("/api/kb/upsert", payload)
+
+    def batch_insert(
+        self,
+        items: list[dict[str, Any]],
+        *,
+        on_conflict: str = "upsert",
+    ) -> dict[str, Any]:
+        return self._request(
+            "/api/kb/batch_insert",
+            {"items": items, "on_conflict": on_conflict},
+        )
+
+    def add_edges(self, edges: list[dict[str, Any]]) -> dict[str, Any]:
+        return self._request("/api/kb/edges/add", {"edges": edges})
+
+    # ------------------------------------------------------------------
+    # Internal — request / retry
+    # ------------------------------------------------------------------
+    def _request(self, path: str, body: dict[str, Any]) -> dict[str, Any]:
+        url = f"{self.base_url}{path}"
+        data = json.dumps(body).encode("utf-8")
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+
+        registry = get_registry()
+        endpoint_label = path.split("/")[-1]
+        last_error: Exception | None = None
+        attempt = 0
+        start = time.time()
+        while attempt <= self.retry_max:
+            attempt += 1
+            req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+            try:
+                with urllib.request.urlopen(req, timeout=self.timeout_s) as resp:
+                    payload = resp.read().decode("utf-8") or "{}"
+                    body_obj = json.loads(payload) if payload else {}
+                    registry.counter(CRITIC_KB_WRITE_TOTAL).inc({
+                        "endpoint": endpoint_label,
+                        "status": str(resp.status),
+                    })
+                    registry.histogram(CRITIC_KB_WRITE_DURATION_SECONDS).observe(
+                        time.time() - start, {"endpoint": endpoint_label}
+                    )
+                    return body_obj
+            except urllib.error.HTTPError as exc:
+                # 4xx → don't retry; let caller dead-letter.
+                status = getattr(exc, "code", 0)
+                err_body = exc.read().decode("utf-8", errors="replace") if exc.fp else ""
+                registry.counter(CRITIC_KB_WRITE_TOTAL).inc({
+                    "endpoint": endpoint_label, "status": str(status),
+                })
+                if status == 404:
+                    raise KBNotFoundError(f"{path} 404: {err_body}") from exc
+                if status == 409:
+                    raise KBConflictError(f"{path} 409: {err_body}") from exc
+                if 400 <= status < 500 and status != 429:
+                    raise KBValidationError(f"{path} {status}: {err_body}") from exc
+                last_error = exc
+            except urllib.error.URLError as exc:
+                last_error = exc
+            if attempt > self.retry_max:
+                break
+            self._sleep(self._backoff_for(attempt))
+        raise KBTransportError(
+            f"{path}: failed after {self.retry_max} retries — last_error={last_error!r}"
+        )
+
+    def _backoff_for(self, attempt: int) -> float:
+        # Exponential with optional jitter to avoid thundering herd.
+        base = self.backoff_base * (2 ** (attempt - 1))
+        return base * (0.9 + 0.2 * random.random())
+
+
+__all__ = [
+    "DEFAULT_BACKOFF_BASE",
+    "DEFAULT_RETRY_MAX",
+    "DEFAULT_TIMEOUT_MS",
+    "HTTPKBClient",
+    "KBClient",
+]

--- a/critic-agent/runtime/kb_writer.py
+++ b/critic-agent/runtime/kb_writer.py
@@ -22,12 +22,19 @@ Plus the read helper :meth:`list_priors` with TTL'd cache backed by
 from __future__ import annotations
 
 import os
+import time
 from dataclasses import dataclass, field
 from typing import Any
 
 from .category_mapping import map_category_to_kind
 from .dead_letter import DeadLetter
-from .errors import KBError, KBValidationError, RuntimeAdapterError, ScopeError
+from .errors import (
+    KBError,
+    KBTransportError,
+    KBValidationError,
+    RuntimeAdapterError,
+    ScopeError,
+)
 from .importance_mapping import (
     cap_importance,
     importance_for_kb_draft,
@@ -35,8 +42,10 @@ from .importance_mapping import (
 )
 from .kb_client import KBClient
 from .metrics import (
+    CRITIC_KB_BREAKER_OPEN_TOTAL,
     CRITIC_KB_PRIOR_CACHE_HIT,
     CRITIC_KB_PRIOR_CACHE_MISS,
+    CRITIC_KB_UNREACHABLE_TOTAL,
     CRITIC_KB_WRITE_TOTAL,
     CRITIC_REVIEW_VERDICT_TOTAL,
     get_registry,
@@ -53,11 +62,40 @@ _KB_RELEVANT_VERDICTS: frozenset[str] = frozenset({
 })
 
 
+# Circuit-breaker defaults: when the KB transport fails ``threshold`` times
+# in a row, every read / write short-circuits for ``cooldown`` seconds. The
+# defaults intentionally err on the side of "skip KB rather than wait" — a
+# single connection failure is enough to open the breaker, with a short
+# cooldown so a transient outage doesn't block the whole session.
+_DEFAULT_BREAKER_THRESHOLD = 1
+_DEFAULT_BREAKER_COOLDOWN_SECONDS = 60.0
+
+
 def _read_bool_env(name: str, default: bool) -> bool:
     raw = os.environ.get(name)
     if raw is None:
         return default
     return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _read_int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def _read_float_env(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
 
 
 @dataclass
@@ -74,9 +112,19 @@ class WriteContext:
 
 @dataclass
 class WriteResult:
-    """Outcome of a KB write attempt."""
+    """Outcome of a KB write attempt.
 
-    status: str  # ok | dead_lettered | skipped | disabled
+    Statuses:
+        ok            — request returned 2xx.
+        dead_lettered — write failed (transport or 4xx) and is queued for
+                        cron replay; the review pipeline still proceeds.
+        skipped       — pre-condition prevented the write (verdict not
+                        relevant, missing scope, no topic, etc.).
+        disabled      — ``KB_WRITE_ENABLED=false`` or the breaker is open
+                        (``reason="kb_unreachable"``).
+    """
+
+    status: str
     detail: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -93,12 +141,71 @@ class KBWriter:
         *,
         session_memory: SessionMemory | None = None,
         dead_letter: DeadLetter | None = None,
+        time_fn=time.time,
     ):
         self.client = client
         self.session_memory = session_memory or SessionMemory()
         self.dead_letter = dead_letter or DeadLetter()
         self.write_enabled = _read_bool_env("KB_WRITE_ENABLED", True)
         self.read_enabled = _read_bool_env("KB_READ_ENABLED", True)
+        self._time_fn = time_fn
+
+        # Circuit-breaker state: when the KB transport fails ``threshold``
+        # times in a row, short-circuit reads + writes for ``cooldown``
+        # seconds so we don't block every proposal on a hung service.
+        self._breaker_threshold = max(
+            1, _read_int_env("CRITIC_KB_BREAKER_THRESHOLD", _DEFAULT_BREAKER_THRESHOLD)
+        )
+        self._breaker_cooldown = max(
+            0.0, _read_float_env("CRITIC_KB_BREAKER_COOLDOWN_SECONDS", _DEFAULT_BREAKER_COOLDOWN_SECONDS)
+        )
+        self._consecutive_failures = 0
+        self._unreachable_until = 0.0
+
+    # ------------------------------------------------------------------
+    # Circuit-breaker helpers
+    # ------------------------------------------------------------------
+    def is_kb_unreachable(self) -> bool:
+        """Return True iff the breaker is currently open."""
+        return self._time_fn() < self._unreachable_until
+
+    def kb_breaker_state(self) -> dict[str, Any]:
+        """Snapshot for ``judge_bundle.notes`` / metrics dashboards."""
+        now = self._time_fn()
+        return {
+            "open": now < self._unreachable_until,
+            "remaining_seconds": max(0.0, self._unreachable_until - now),
+            "consecutive_failures": self._consecutive_failures,
+            "threshold": self._breaker_threshold,
+            "cooldown_seconds": self._breaker_cooldown,
+        }
+
+    def force_kb_unreachable(self, *, cooldown: float | None = None) -> None:
+        """Open the breaker manually (used by tests + admin tooling)."""
+        self._consecutive_failures = self._breaker_threshold
+        self._unreachable_until = self._time_fn() + (
+            cooldown if cooldown is not None else self._breaker_cooldown
+        )
+        get_registry().counter(CRITIC_KB_BREAKER_OPEN_TOTAL).inc({"reason": "manual"})
+
+    def _record_kb_failure(self, endpoint: str, exc: Exception) -> None:
+        """Account a transport error and possibly open the breaker."""
+        self._consecutive_failures += 1
+        get_registry().counter(CRITIC_KB_UNREACHABLE_TOTAL).inc({
+            "endpoint": endpoint,
+        })
+        if self._consecutive_failures >= self._breaker_threshold:
+            already_open = self._unreachable_until > self._time_fn()
+            self._unreachable_until = self._time_fn() + self._breaker_cooldown
+            if not already_open:
+                get_registry().counter(CRITIC_KB_BREAKER_OPEN_TOTAL).inc({
+                    "endpoint": endpoint,
+                })
+
+    def _record_kb_success(self) -> None:
+        """Reset the breaker after any successful KB call."""
+        self._consecutive_failures = 0
+        self._unreachable_until = 0.0
 
     # ------------------------------------------------------------------
     # list_priors (Trigger D — read; not gated by KB_WRITE_ENABLED)
@@ -113,19 +220,36 @@ class KBWriter:
         limit: int = 10,
         ctx: WriteContext | None = None,
     ) -> dict[str, Any]:
-        """Look up KB priors with session-memory caching.
+        """Look up KB priors with caching + circuit-breaker short-circuit.
 
-        Returns ``{priors, cache: 'hit'|'miss'|'disabled', cache_key}``.
+        Returns ``{priors, cache, cache_key, [error]}``. ``cache`` is one of
+        ``hit`` / ``miss`` / ``disabled`` / ``kb_unreachable``. The function
+        never raises — KB transport / 4xx errors translate into an empty
+        ``priors`` list with the failure mode reflected in ``cache`` and an
+        ``error`` field.
         """
         if not self.read_enabled:
             return {"priors": [], "cache": "disabled", "cache_key": ""}
 
         cache_key = scope_cache_key(scope, topic=topic)
+
+        # Cache wins regardless of breaker state — we may still have valid
+        # priors from before the outage.
         if ctx is not None:
             cached = self.session_memory.get_cached_priors(ctx.session_id, cache_key)
             if cached is not None:
                 get_registry().counter(CRITIC_KB_PRIOR_CACHE_HIT).inc()
                 return {"priors": list(cached), "cache": "hit", "cache_key": cache_key}
+
+        # Breaker open → short-circuit before paying another timeout.
+        if self.is_kb_unreachable():
+            get_registry().counter(CRITIC_KB_UNREACHABLE_TOTAL).inc({"endpoint": "list"})
+            return {
+                "priors": [],
+                "cache": "kb_unreachable",
+                "cache_key": cache_key,
+                "breaker": self.kb_breaker_state(),
+            }
 
         get_registry().counter(CRITIC_KB_PRIOR_CACHE_MISS).inc()
         try:
@@ -135,13 +259,27 @@ class KBWriter:
                 metadata_filter=metadata_filter,
                 limit=limit,
             )
+        except KBTransportError as exc:
+            self._record_kb_failure("list", exc)
+            return {
+                "priors": [],
+                "cache": "kb_unreachable",
+                "cache_key": cache_key,
+                "error": str(exc),
+                "breaker": self.kb_breaker_state(),
+            }
         except KBError as exc:
+            # 4xx / validation errors — KB is up, the request was bad. Don't
+            # trip the breaker; surface the error for inspection but keep
+            # priors empty so the LLM doesn't act on garbage.
             return {
                 "priors": [],
                 "cache": "miss",
                 "cache_key": cache_key,
                 "error": str(exc),
             }
+
+        self._record_kb_success()
         priors = response.get("entries") or []
         if ctx is not None:
             self.session_memory.put_cached_priors(ctx.session_id, cache_key, priors)
@@ -160,6 +298,11 @@ class KBWriter:
     ) -> WriteResult:
         if not self.write_enabled:
             return WriteResult("disabled", {"reason": "KB_WRITE_ENABLED=false"})
+        if self.is_kb_unreachable():
+            return WriteResult("disabled", {
+                "reason": "kb_unreachable",
+                "breaker": self.kb_breaker_state(),
+            })
         verdict_label = verdict.get("verdict")
         get_registry().counter(CRITIC_REVIEW_VERDICT_TOTAL).inc({
             "verdict": str(verdict_label),
@@ -226,6 +369,11 @@ class KBWriter:
             return WriteResult("disabled", {"reason": "KB_WRITE_ENABLED=false"})
         if not kb_drafts:
             return WriteResult("skipped", {"reason": "no_drafts"})
+        if self.is_kb_unreachable():
+            return WriteResult("disabled", {
+                "reason": "kb_unreachable",
+                "breaker": self.kb_breaker_state(),
+            })
         try:
             scope = build_scope(packet_context, session_context=session_context)
         except ScopeError as exc:
@@ -275,9 +423,23 @@ class KBWriter:
                 "endpoint": "batch_insert",
                 "status": "200",
             })
+            self._record_kb_success()
             return WriteResult(
                 "ok",
                 {"response": response, "rejected": rejected},
+            )
+        except KBTransportError as exc:
+            self._record_kb_failure("batch_insert", exc)
+            self.dead_letter.append(
+                "batch_insert",
+                {"items": items, "on_conflict": "upsert"},
+                attempts=1,
+                last_error=str(exc),
+                context={"session_id": ctx.session_id, "review_id": ctx.review_id},
+            )
+            return WriteResult(
+                "dead_lettered",
+                {"reason": "transport_error", "error": str(exc), "rejected": rejected},
             )
         except KBValidationError as exc:
             self.dead_letter.append(
@@ -316,6 +478,11 @@ class KBWriter:
     ) -> WriteResult:
         if not self.write_enabled:
             return WriteResult("disabled", {"reason": "KB_WRITE_ENABLED=false"})
+        if self.is_kb_unreachable():
+            return WriteResult("disabled", {
+                "reason": "kb_unreachable",
+                "breaker": self.kb_breaker_state(),
+            })
         if not new_id or not old_ids:
             return WriteResult("skipped", {"reason": "missing_ids"})
         edges = [
@@ -324,7 +491,11 @@ class KBWriter:
         ]
         try:
             response = self.client.add_edges(edges)
+            self._record_kb_success()
             return WriteResult("ok", {"response": response})
+        except KBTransportError as exc:
+            self._record_kb_failure("edges/add", exc)
+            return WriteResult("skipped", {"reason": "edge_write_failed", "error": str(exc)})
         except KBError as exc:
             # Edge writes are supplemental — best-effort. Don't dead-letter.
             return WriteResult("skipped", {"reason": "edge_write_failed", "error": str(exc)})
@@ -343,7 +514,18 @@ class KBWriter:
                 "endpoint": "upsert",
                 "status": "200",
             })
+            self._record_kb_success()
             return WriteResult("ok", {"response": response})
+        except KBTransportError as exc:
+            self._record_kb_failure("upsert", exc)
+            self.dead_letter.append(
+                "upsert",
+                payload,
+                attempts=1,
+                last_error=str(exc),
+                context={"session_id": ctx.session_id, "review_id": ctx.review_id},
+            )
+            return WriteResult("dead_lettered", {"reason": "transport_error", "error": str(exc)})
         except KBValidationError as exc:
             self.dead_letter.append(
                 "upsert",

--- a/critic-agent/runtime/kb_writer.py
+++ b/critic-agent/runtime/kb_writer.py
@@ -1,0 +1,403 @@
+"""High-level KB write façade used by the decision reviewer.
+
+This module never raises to the caller for transport / 4xx errors — it
+catches them, dead-letters, and returns a typed :class:`WriteResult` so
+the Critic decision pipeline never blocks on KB issues
+(contract §6 — "writes must not block review_verdict").
+
+Three triggers map to three methods:
+
+* :meth:`write_verdict` (Trigger A)  — gate decisions that produced a
+  reusable lesson get an upsert; ``defer`` / ``inconclusive`` /
+  ``advise`` are skipped.
+* :meth:`write_kb_drafts` (Trigger B) — session-close kb_draft batch
+  insert with ``on_conflict=upsert``.
+* :meth:`add_contradiction` (Trigger C) — single-side contradicts edge
+  (KB service mirrors).
+
+Plus the read helper :meth:`list_priors` with TTL'd cache backed by
+:class:`runtime.session_memory.SessionMemory`.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+from .category_mapping import map_category_to_kind
+from .dead_letter import DeadLetter
+from .errors import KBError, KBValidationError, RuntimeAdapterError, ScopeError
+from .importance_mapping import (
+    cap_importance,
+    importance_for_kb_draft,
+    importance_for_verdict,
+)
+from .kb_client import KBClient
+from .metrics import (
+    CRITIC_KB_PRIOR_CACHE_HIT,
+    CRITIC_KB_PRIOR_CACHE_MISS,
+    CRITIC_KB_WRITE_TOTAL,
+    CRITIC_REVIEW_VERDICT_TOTAL,
+    get_registry,
+)
+from .scope_builder import build_scope, scope_cache_key
+from .session_memory import SessionMemory
+from .slugify import slugify, slugify_safe
+
+
+# Verdicts that should produce a KB write (per contract §5.1 — defer /
+# inconclusive / advise are pure dispatch decisions, no reusable lesson).
+_KB_RELEVANT_VERDICTS: frozenset[str] = frozenset({
+    "approve", "reject", "redirect", "needs_review",
+})
+
+
+def _read_bool_env(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass
+class WriteContext:
+    """Per-write metadata threaded through every call."""
+
+    session_id: str
+    review_id: str | None = None
+    source_role: str = "critic"
+    source_type: str = "critic_decision_review"
+    topic: str | None = None
+    extra_metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class WriteResult:
+    """Outcome of a KB write attempt."""
+
+    status: str  # ok | dead_lettered | skipped | disabled
+    detail: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"status": self.status, "detail": dict(self.detail)}
+
+
+# ---------------------------------------------------------------------------
+class KBWriter:
+    """Façade with side-effect orchestration around a :class:`KBClient`."""
+
+    def __init__(
+        self,
+        client: KBClient,
+        *,
+        session_memory: SessionMemory | None = None,
+        dead_letter: DeadLetter | None = None,
+    ):
+        self.client = client
+        self.session_memory = session_memory or SessionMemory()
+        self.dead_letter = dead_letter or DeadLetter()
+        self.write_enabled = _read_bool_env("KB_WRITE_ENABLED", True)
+        self.read_enabled = _read_bool_env("KB_READ_ENABLED", True)
+
+    # ------------------------------------------------------------------
+    # list_priors (Trigger D — read; not gated by KB_WRITE_ENABLED)
+    # ------------------------------------------------------------------
+    def list_priors(
+        self,
+        *,
+        scope: dict[str, Any],
+        kind: str | None = None,
+        topic: str | None = None,
+        metadata_filter: dict[str, Any] | None = None,
+        limit: int = 10,
+        ctx: WriteContext | None = None,
+    ) -> dict[str, Any]:
+        """Look up KB priors with session-memory caching.
+
+        Returns ``{priors, cache: 'hit'|'miss'|'disabled', cache_key}``.
+        """
+        if not self.read_enabled:
+            return {"priors": [], "cache": "disabled", "cache_key": ""}
+
+        cache_key = scope_cache_key(scope, topic=topic)
+        if ctx is not None:
+            cached = self.session_memory.get_cached_priors(ctx.session_id, cache_key)
+            if cached is not None:
+                get_registry().counter(CRITIC_KB_PRIOR_CACHE_HIT).inc()
+                return {"priors": list(cached), "cache": "hit", "cache_key": cache_key}
+
+        get_registry().counter(CRITIC_KB_PRIOR_CACHE_MISS).inc()
+        try:
+            response = self.client.list(
+                scope_filter=scope,
+                kind=kind,
+                metadata_filter=metadata_filter,
+                limit=limit,
+            )
+        except KBError as exc:
+            return {
+                "priors": [],
+                "cache": "miss",
+                "cache_key": cache_key,
+                "error": str(exc),
+            }
+        priors = response.get("entries") or []
+        if ctx is not None:
+            self.session_memory.put_cached_priors(ctx.session_id, cache_key, priors)
+        return {"priors": priors, "cache": "miss", "cache_key": cache_key}
+
+    # ------------------------------------------------------------------
+    # write_verdict (Trigger A)
+    # ------------------------------------------------------------------
+    def write_verdict(
+        self,
+        *,
+        verdict: dict[str, Any],
+        packet_context: dict[str, Any],
+        session_context: dict[str, Any] | None = None,
+        ctx: WriteContext,
+    ) -> WriteResult:
+        if not self.write_enabled:
+            return WriteResult("disabled", {"reason": "KB_WRITE_ENABLED=false"})
+        verdict_label = verdict.get("verdict")
+        get_registry().counter(CRITIC_REVIEW_VERDICT_TOTAL).inc({
+            "verdict": str(verdict_label),
+        })
+        if verdict_label not in _KB_RELEVANT_VERDICTS:
+            return WriteResult("skipped", {"reason": f"verdict={verdict_label}"})
+
+        try:
+            scope = build_scope(packet_context, session_context=session_context)
+        except ScopeError as exc:
+            return WriteResult("skipped", {"reason": "scope_construction_failed", "error": str(exc)})
+
+        topic = ctx.topic or verdict.get("topic") or _topic_from_reasoning(verdict)
+        try:
+            slug = slugify_safe(topic) if topic else None
+        except Exception as exc:  # noqa: BLE001
+            return WriteResult("skipped", {"reason": "slug_failed", "error": str(exc)})
+        if not slug:
+            return WriteResult("skipped", {"reason": "no_topic"})
+
+        kind = "pitfall" if verdict_label in ("reject", "redirect", "needs_review") else "technique"
+        has_measurement = bool(verdict.get("packet_evidence"))
+        importance = cap_importance(importance_for_verdict(
+            verdict=verdict_label,
+            confidence=verdict.get("confidence"),
+            has_measurement=has_measurement,
+        ))
+
+        payload = {
+            "scope": scope,
+            "kind": kind,
+            "slug": slug,
+            "importance": importance,
+            "summary": (verdict.get("reasoning") or "")[:2000],
+            "metadata": {
+                "source_session": ctx.session_id,
+                "source_review_id": ctx.review_id,
+                "source_type": "critic_verdict_" + verdict_label,
+                "source_role": ctx.source_role,
+                "topic": topic or "",
+                "evidence": {
+                    "packet_evidence": verdict.get("packet_evidence", []),
+                    "kb_evidence": verdict.get("kb_evidence", []),
+                    "risks": verdict.get("risks", []),
+                    "predicted_gain_pct": verdict.get("predicted_gain_pct"),
+                },
+                **ctx.extra_metadata,
+            },
+        }
+        return self._upsert_with_dead_letter(payload, ctx)
+
+    # ------------------------------------------------------------------
+    # write_kb_drafts (Trigger B)
+    # ------------------------------------------------------------------
+    def write_kb_drafts(
+        self,
+        *,
+        kb_drafts: list[dict[str, Any]],
+        packet_context: dict[str, Any],
+        session_context: dict[str, Any] | None = None,
+        ctx: WriteContext,
+    ) -> WriteResult:
+        if not self.write_enabled:
+            return WriteResult("disabled", {"reason": "KB_WRITE_ENABLED=false"})
+        if not kb_drafts:
+            return WriteResult("skipped", {"reason": "no_drafts"})
+        try:
+            scope = build_scope(packet_context, session_context=session_context)
+        except ScopeError as exc:
+            return WriteResult("skipped", {"reason": "scope_construction_failed", "error": str(exc)})
+
+        items: list[dict[str, Any]] = []
+        rejected: list[dict[str, Any]] = []
+        for d in kb_drafts:
+            category = d.get("category")
+            try:
+                kind = map_category_to_kind(category)
+            except RuntimeAdapterError as exc:
+                rejected.append({"draft": d, "reason": str(exc)})
+                continue
+            topic = d.get("action") or d.get("lesson") or category
+            try:
+                slug = slug_for_kind(kind, topic, d)
+            except Exception as exc:  # noqa: BLE001
+                rejected.append({"draft": d, "reason": f"slug_failed: {exc}"})
+                continue
+            importance = cap_importance(importance_for_kb_draft(confidence=d.get("confidence")))
+            items.append({
+                "scope": scope,
+                "kind": kind,
+                "slug": slug,
+                "importance": importance,
+                "summary": (d.get("lesson") or d.get("action") or "")[:2000],
+                "metadata": {
+                    "source_session": ctx.session_id,
+                    "source_review_id": ctx.review_id,
+                    "source_type": "critic_kb_draft",
+                    "source_role": ctx.source_role,
+                    "topic": topic,
+                    "tags": list(d.get("tags") or []),
+                    "result": d.get("result") or {},
+                    "context": d.get("context") or "",
+                    "strategy_tested": d.get("strategy_tested") or [],
+                    **ctx.extra_metadata,
+                },
+            })
+        if not items:
+            return WriteResult("skipped", {"reason": "all_rejected", "rejected": rejected})
+
+        try:
+            response = self.client.batch_insert(items, on_conflict="upsert")
+            get_registry().counter(CRITIC_KB_WRITE_TOTAL).inc({
+                "endpoint": "batch_insert",
+                "status": "200",
+            })
+            return WriteResult(
+                "ok",
+                {"response": response, "rejected": rejected},
+            )
+        except KBValidationError as exc:
+            self.dead_letter.append(
+                "batch_insert",
+                {"items": items, "on_conflict": "upsert"},
+                attempts=1,
+                last_error=str(exc),
+                context={"session_id": ctx.session_id, "review_id": ctx.review_id},
+            )
+            return WriteResult(
+                "dead_lettered",
+                {"reason": "validation_error", "error": str(exc), "rejected": rejected},
+            )
+        except KBError as exc:
+            self.dead_letter.append(
+                "batch_insert",
+                {"items": items, "on_conflict": "upsert"},
+                attempts=1,
+                last_error=str(exc),
+                context={"session_id": ctx.session_id, "review_id": ctx.review_id},
+            )
+            return WriteResult(
+                "dead_lettered",
+                {"reason": "transport_error", "error": str(exc), "rejected": rejected},
+            )
+
+    # ------------------------------------------------------------------
+    # add_contradiction (Trigger C)
+    # ------------------------------------------------------------------
+    def add_contradiction(
+        self,
+        *,
+        new_id: str,
+        old_ids: list[str],
+        ctx: WriteContext,
+    ) -> WriteResult:
+        if not self.write_enabled:
+            return WriteResult("disabled", {"reason": "KB_WRITE_ENABLED=false"})
+        if not new_id or not old_ids:
+            return WriteResult("skipped", {"reason": "missing_ids"})
+        edges = [
+            {"kind": "contradicts", "from_id": new_id, "to_id": old_id}
+            for old_id in old_ids
+        ]
+        try:
+            response = self.client.add_edges(edges)
+            return WriteResult("ok", {"response": response})
+        except KBError as exc:
+            # Edge writes are supplemental — best-effort. Don't dead-letter.
+            return WriteResult("skipped", {"reason": "edge_write_failed", "error": str(exc)})
+
+    # ------------------------------------------------------------------
+    # internals
+    # ------------------------------------------------------------------
+    def _upsert_with_dead_letter(
+        self,
+        payload: dict[str, Any],
+        ctx: WriteContext,
+    ) -> WriteResult:
+        try:
+            response = self.client.upsert(payload)
+            get_registry().counter(CRITIC_KB_WRITE_TOTAL).inc({
+                "endpoint": "upsert",
+                "status": "200",
+            })
+            return WriteResult("ok", {"response": response})
+        except KBValidationError as exc:
+            self.dead_letter.append(
+                "upsert",
+                payload,
+                attempts=1,
+                last_error=str(exc),
+                context={"session_id": ctx.session_id, "review_id": ctx.review_id},
+            )
+            return WriteResult("dead_lettered", {"reason": "validation_error", "error": str(exc)})
+        except KBError as exc:
+            self.dead_letter.append(
+                "upsert",
+                payload,
+                attempts=1,
+                last_error=str(exc),
+                context={"session_id": ctx.session_id, "review_id": ctx.review_id},
+            )
+            return WriteResult("dead_lettered", {"reason": "transport_error", "error": str(exc)})
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _topic_from_reasoning(verdict: dict[str, Any]) -> str | None:
+    """Derive a slug-safe topic from verdict.reasoning when not provided."""
+    reasoning = (verdict.get("reasoning") or "").strip()
+    if not reasoning:
+        return None
+    # Take the first 8 ASCII words to keep within slugify length bounds.
+    words = [w for w in reasoning.split() if w.isascii()][:8]
+    if not words:
+        return None
+    return " ".join(words)
+
+
+def slug_for_kind(kind: str, topic: str, draft: dict[str, Any] | None = None) -> str:
+    """Build a slug for ``(kind, topic, draft)`` per contract §2.2 templates."""
+    draft = draft or {}
+    if kind == "params_catalog":
+        # Param entries should slugify the param name itself.
+        param_name = draft.get("action") or topic
+        return slugify(param_name)
+    if kind == "model_profile":
+        model = draft.get("model") or draft.get("model_family") or topic
+        return slugify(f"{model}-profile")
+    if kind == "pitfall":
+        return slugify_safe(topic)
+    # technique
+    return slugify_safe(topic)
+
+
+__all__ = [
+    "KBWriter",
+    "WriteContext",
+    "WriteResult",
+    "slug_for_kind",
+]

--- a/critic-agent/runtime/metrics.py
+++ b/critic-agent/runtime/metrics.py
@@ -1,0 +1,106 @@
+"""In-process metrics shim.
+
+In production the Critic agent will export the metrics enumerated in
+``kb-critic-integration-contract`` Appendix E via Prometheus. The runtime
+here keeps a process-local registry so unit tests can assert that the
+right counters fire without requiring a Prometheus client dependency.
+
+If Prometheus support is later wired in, replace
+:func:`get_registry` with a real client and keep the API surface
+(``inc`` / ``observe``) identical.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from threading import Lock
+from typing import Any
+
+
+@dataclass
+class _Counter:
+    name: str
+    values: dict[tuple[tuple[str, str], ...], float] = field(default_factory=dict)
+
+    def inc(self, labels: dict[str, str] | None = None, by: float = 1.0) -> None:
+        key = tuple(sorted((labels or {}).items()))
+        self.values[key] = self.values.get(key, 0.0) + by
+
+
+@dataclass
+class _Histogram:
+    name: str
+    samples: dict[tuple[tuple[str, str], ...], list[float]] = field(default_factory=lambda: defaultdict(list))
+
+    def observe(self, value: float, labels: dict[str, str] | None = None) -> None:
+        key = tuple(sorted((labels or {}).items()))
+        self.samples[key].append(float(value))
+
+
+class MetricsRegistry:
+    """Tiny in-memory metrics registry."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._counters: dict[str, _Counter] = {}
+        self._histograms: dict[str, _Histogram] = {}
+
+    def counter(self, name: str) -> _Counter:
+        with self._lock:
+            counter = self._counters.get(name)
+            if counter is None:
+                counter = _Counter(name=name)
+                self._counters[name] = counter
+            return counter
+
+    def histogram(self, name: str) -> _Histogram:
+        with self._lock:
+            hist = self._histograms.get(name)
+            if hist is None:
+                hist = _Histogram(name=name)
+                self._histograms[name] = hist
+            return hist
+
+    def snapshot(self) -> dict[str, Any]:
+        return {
+            "counters": {n: dict(c.values) for n, c in self._counters.items()},
+            "histograms": {n: {k: list(v) for k, v in h.samples.items()} for n, h in self._histograms.items()},
+        }
+
+    def reset(self) -> None:
+        with self._lock:
+            self._counters.clear()
+            self._histograms.clear()
+
+
+_registry = MetricsRegistry()
+
+
+def get_registry() -> MetricsRegistry:
+    return _registry
+
+
+# Conventional metric names — keep stable so dashboards don't churn.
+CRITIC_KB_WRITE_TOTAL = "critic_kb_write_total"
+CRITIC_KB_WRITE_DURATION_SECONDS = "critic_kb_write_duration_seconds"
+CRITIC_KB_DEAD_LETTER_COUNT = "critic_kb_dead_letter_count"
+CRITIC_KB_DISTILL_TOKENS_TOTAL = "critic_kb_distill_tokens_total"
+CRITIC_KB_DISTILL_COST_TOTAL = "critic_kb_distill_cost_total"
+CRITIC_KB_PRIOR_CACHE_HIT = "critic_kb_prior_cache_hit"
+CRITIC_KB_PRIOR_CACHE_MISS = "critic_kb_prior_cache_miss"
+CRITIC_REVIEW_VERDICT_TOTAL = "critic_review_verdict_total"
+
+
+__all__ = [
+    "CRITIC_KB_DEAD_LETTER_COUNT",
+    "CRITIC_KB_DISTILL_COST_TOTAL",
+    "CRITIC_KB_DISTILL_TOKENS_TOTAL",
+    "CRITIC_KB_PRIOR_CACHE_HIT",
+    "CRITIC_KB_PRIOR_CACHE_MISS",
+    "CRITIC_KB_WRITE_DURATION_SECONDS",
+    "CRITIC_KB_WRITE_TOTAL",
+    "CRITIC_REVIEW_VERDICT_TOTAL",
+    "MetricsRegistry",
+    "get_registry",
+]

--- a/critic-agent/runtime/metrics.py
+++ b/critic-agent/runtime/metrics.py
@@ -89,15 +89,19 @@ CRITIC_KB_DISTILL_TOKENS_TOTAL = "critic_kb_distill_tokens_total"
 CRITIC_KB_DISTILL_COST_TOTAL = "critic_kb_distill_cost_total"
 CRITIC_KB_PRIOR_CACHE_HIT = "critic_kb_prior_cache_hit"
 CRITIC_KB_PRIOR_CACHE_MISS = "critic_kb_prior_cache_miss"
+CRITIC_KB_UNREACHABLE_TOTAL = "critic_kb_unreachable_total"
+CRITIC_KB_BREAKER_OPEN_TOTAL = "critic_kb_breaker_open_total"
 CRITIC_REVIEW_VERDICT_TOTAL = "critic_review_verdict_total"
 
 
 __all__ = [
+    "CRITIC_KB_BREAKER_OPEN_TOTAL",
     "CRITIC_KB_DEAD_LETTER_COUNT",
     "CRITIC_KB_DISTILL_COST_TOTAL",
     "CRITIC_KB_DISTILL_TOKENS_TOTAL",
     "CRITIC_KB_PRIOR_CACHE_HIT",
     "CRITIC_KB_PRIOR_CACHE_MISS",
+    "CRITIC_KB_UNREACHABLE_TOTAL",
     "CRITIC_KB_WRITE_DURATION_SECONDS",
     "CRITIC_KB_WRITE_TOTAL",
     "CRITIC_REVIEW_VERDICT_TOTAL",

--- a/critic-agent/runtime/request_models.py
+++ b/critic-agent/runtime/request_models.py
@@ -1,0 +1,277 @@
+"""Internal request / context models for the Critic runtime.
+
+The Critic agent has two main entry shapes today:
+
+1. ``coordinator_inbox`` — Coordinator (DESIGN v0.6 §13.1) feeds a textual
+   prompt with a shared-state header and an inbox tail. The Critic must
+   emit an intent envelope (``{"intents": [{"intent_type": ...}, ...]}``)
+   that the Coordinator can route via :func:`validate_envelope`.
+
+2. ``critic_decision_request`` — a higher-level decision review used by
+   non-Coordinator hosts (e.g. an A2A chat server). The first call carries
+   the full context; later calls may be incremental and must be merged
+   against the per-session memory.
+
+Both shapes converge on :class:`CriticRequest`, which carries the
+session id, optional explicit context, the parsed proposals (if any) and
+the original raw payload for audit.
+
+This module is import-light: it has no dependency on the KB client, the
+inbox parser, or the LLM. It only validates structure so other modules
+can rely on the shape.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from .errors import RequestValidationError
+
+
+# ---------------------------------------------------------------------------
+# Allowed request kinds
+# ---------------------------------------------------------------------------
+COORDINATOR_INBOX = "coordinator_inbox"
+DECISION_REQUEST = "critic_decision_request"
+KB_DRAFT_REQUEST = "kb_draft_request"
+KB_HINT_REQUEST = "kb_hint_request"
+OBJECTION_REQUEST = "objection_signal"
+
+REQUEST_KINDS: frozenset[str] = frozenset({
+    COORDINATOR_INBOX,
+    DECISION_REQUEST,
+    KB_DRAFT_REQUEST,
+    KB_HINT_REQUEST,
+    OBJECTION_REQUEST,
+})
+
+
+# Context dimensions that the KB scope is built from. ``model`` and
+# ``framework`` are treated as critical: when either is missing after
+# memory merge, KB reads are skipped and the verdict downgrades to
+# ``needs_review`` rather than guess.
+CONTEXT_DIMENSIONS: tuple[str, ...] = (
+    "model",
+    "framework",
+    "model_family",
+    "workload",
+    "precision",
+    "scale",
+    "objective",
+)
+CRITICAL_CONTEXT_KEYS: tuple[str, ...] = ("model", "framework")
+
+
+# ---------------------------------------------------------------------------
+# Proposal extracted from a Coordinator inbox row
+# ---------------------------------------------------------------------------
+@dataclass
+class Proposal:
+    """One ``topic=proposal`` row extracted from a Coordinator inbox.
+
+    Attributes:
+        msg_id: The Coordinator-issued ``msg_id`` (hex32 in v0.6).
+        from_agent: Originating agent name (e.g. ``orchestration``).
+        seq: Optional bus sequence number (kept for ordering / replay).
+        action_name: Convenience copy of ``payload.action_name``.
+        predicted_gain_pct: Convenience copy of
+            ``payload.predicted_gain_pct``; ``None`` when absent.
+        payload: The raw proposal payload as parsed.
+    """
+
+    msg_id: str
+    from_agent: str
+    payload: dict[str, Any] = field(default_factory=dict)
+    seq: int | None = None
+    action_name: str | None = None
+    predicted_gain_pct: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+# ---------------------------------------------------------------------------
+# CriticRequest
+# ---------------------------------------------------------------------------
+@dataclass
+class CriticRequest:
+    """Normalised Critic input.
+
+    Both Coordinator-driven and dialogue-driven entry points produce one
+    of these. Downstream modules (``decision_reviewer``,
+    ``intent_envelope``, ``session_memory``) only see this shape.
+    """
+
+    kind: str
+    session_id: str
+    decision_id: str | None = None
+    raw_prompt: str | None = None
+    messages: list[dict[str, Any]] = field(default_factory=list)
+    context: dict[str, Any] = field(default_factory=dict)
+    decision: dict[str, Any] = field(default_factory=dict)
+    proposals: list[Proposal] = field(default_factory=list)
+    options: dict[str, Any] = field(default_factory=dict)
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "kind": self.kind,
+            "session_id": self.session_id,
+            "decision_id": self.decision_id,
+            "raw_prompt": self.raw_prompt,
+            "messages": list(self.messages),
+            "context": dict(self.context),
+            "decision": dict(self.decision),
+            "proposals": [p.to_dict() for p in self.proposals],
+            "options": dict(self.options),
+        }
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+def _require_str(d: dict[str, Any], key: str, *, where: str) -> str:
+    if key not in d:
+        raise RequestValidationError(f"{where}: missing required field {key!r}")
+    value = d[key]
+    if not isinstance(value, str) or not value.strip():
+        raise RequestValidationError(
+            f"{where}: field {key!r} must be a non-empty string, got {type(value).__name__}"
+        )
+    return value
+
+
+def _optional_str(d: dict[str, Any], key: str, *, where: str) -> str | None:
+    if key not in d or d[key] is None:
+        return None
+    value = d[key]
+    if not isinstance(value, str):
+        raise RequestValidationError(
+            f"{where}: field {key!r} must be a string when present, got {type(value).__name__}"
+        )
+    return value
+
+
+def _optional_dict(d: dict[str, Any], key: str, *, where: str) -> dict[str, Any]:
+    if key not in d or d[key] is None:
+        return {}
+    value = d[key]
+    if not isinstance(value, dict):
+        raise RequestValidationError(
+            f"{where}: field {key!r} must be an object when present, got {type(value).__name__}"
+        )
+    return dict(value)
+
+
+def _optional_list(d: dict[str, Any], key: str, *, where: str) -> list[Any]:
+    if key not in d or d[key] is None:
+        return []
+    value = d[key]
+    if not isinstance(value, list):
+        raise RequestValidationError(
+            f"{where}: field {key!r} must be a list when present, got {type(value).__name__}"
+        )
+    return list(value)
+
+
+def parse_request(raw: dict[str, Any]) -> CriticRequest:
+    """Validate the input dict and return a :class:`CriticRequest`.
+
+    The function is permissive about extra keys (they go into ``raw``)
+    but strict about required ones, mirroring contract §14.4 — invalid
+    requests should fail fast so the SKILL never produces a bogus
+    verdict.
+    """
+    if not isinstance(raw, dict):
+        raise RequestValidationError(
+            f"top-level must be an object, got {type(raw).__name__}"
+        )
+
+    kind = _require_str(raw, "kind", where="request")
+    if kind not in REQUEST_KINDS:
+        raise RequestValidationError(
+            f"request: kind {kind!r} is not in {sorted(REQUEST_KINDS)!r}"
+        )
+    session_id = _require_str(raw, "session_id", where="request")
+
+    decision_id = _optional_str(raw, "decision_id", where="request")
+    if decision_id is None and kind in (DECISION_REQUEST, OBJECTION_REQUEST):
+        decision_id = f"dec_{uuid.uuid4().hex[:12]}"
+
+    raw_prompt = _optional_str(raw, "raw_prompt", where="request")
+    if kind == COORDINATOR_INBOX and not (raw_prompt and raw_prompt.strip()):
+        raise RequestValidationError(
+            "coordinator_inbox: raw_prompt must be a non-empty string"
+        )
+
+    messages = _optional_list(raw, "messages", where="request")
+    for i, msg in enumerate(messages):
+        if not isinstance(msg, dict):
+            raise RequestValidationError(
+                f"request.messages[{i}] must be an object, got {type(msg).__name__}"
+            )
+
+    context = _optional_dict(raw, "context", where="request")
+    decision = _optional_dict(raw, "decision", where="request")
+    options = _optional_dict(raw, "options", where="request")
+
+    proposals_raw = _optional_list(raw, "proposals", where="request")
+    proposals: list[Proposal] = []
+    for i, prop in enumerate(proposals_raw):
+        if not isinstance(prop, dict):
+            raise RequestValidationError(
+                f"request.proposals[{i}] must be an object, got {type(prop).__name__}"
+            )
+        msg_id = _require_str(prop, "msg_id", where=f"request.proposals[{i}]")
+        from_agent = _require_str(prop, "from_agent", where=f"request.proposals[{i}]")
+        payload = _optional_dict(prop, "payload", where=f"request.proposals[{i}]")
+        seq = prop.get("seq")
+        if seq is not None and not isinstance(seq, int):
+            raise RequestValidationError(
+                f"request.proposals[{i}].seq must be int when present"
+            )
+        action_name = payload.get("action_name") if isinstance(payload.get("action_name"), str) else None
+        gain_raw = payload.get("predicted_gain_pct")
+        if isinstance(gain_raw, (int, float)):
+            predicted_gain_pct: float | None = float(gain_raw)
+        else:
+            predicted_gain_pct = None
+        proposals.append(Proposal(
+            msg_id=msg_id,
+            from_agent=from_agent,
+            payload=payload,
+            seq=seq,
+            action_name=action_name,
+            predicted_gain_pct=predicted_gain_pct,
+        ))
+
+    return CriticRequest(
+        kind=kind,
+        session_id=session_id,
+        decision_id=decision_id,
+        raw_prompt=raw_prompt,
+        messages=messages,
+        context=context,
+        decision=decision,
+        proposals=proposals,
+        options=options,
+        raw=dict(raw),
+    )
+
+
+__all__ = [
+    "COORDINATOR_INBOX",
+    "CONTEXT_DIMENSIONS",
+    "CRITICAL_CONTEXT_KEYS",
+    "CriticRequest",
+    "DECISION_REQUEST",
+    "KB_DRAFT_REQUEST",
+    "KB_HINT_REQUEST",
+    "OBJECTION_REQUEST",
+    "Proposal",
+    "REQUEST_KINDS",
+    "parse_request",
+]

--- a/critic-agent/runtime/scope_builder.py
+++ b/critic-agent/runtime/scope_builder.py
@@ -1,0 +1,182 @@
+"""Build a KB scope dict from explicit context + session memory.
+
+The KB service requires the 6 mandatory scope dimensions
+``{org, framework, model, model_family, workload, precision}`` to be present
+on every write (contract §2.1). Two optional dimensions ``{scale, objective}``
+may be added when known. ``org`` is fixed at ``"hyperloom"`` in v1.
+
+Inputs to :func:`build_scope`:
+
+* ``packet_context``: explicit context coming from the current Coordinator
+  packet or decision request.
+* ``session_context``: context recovered from session memory (already
+  merged with previous turns).
+
+Order of precedence: ``packet_context > session_context > "unknown"``. The
+service normalises values via ``trim().lowercase()`` (G-3); we do the same
+client-side so list / metadata filters round-trip without surprises.
+
+If :data:`CRITICAL_SCOPE_KEYS` cannot be filled by either input we raise
+:class:`ScopeError`. The caller (typically ``decision_reviewer``) treats
+this as a hard signal to skip KB reads / writes and downgrade the verdict
+to ``needs_review``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+
+from .errors import ScopeError
+
+
+ORG_DEFAULT = "hyperloom"
+
+# 6 必填维度
+CRITICAL_SCOPE_KEYS: tuple[str, ...] = (
+    "org",
+    "framework",
+    "model",
+    "model_family",
+    "workload",
+    "precision",
+)
+
+# 可选维度 — 不写 "unknown"，要么填要么不填 key
+OPTIONAL_SCOPE_KEYS: tuple[str, ...] = ("scale", "objective")
+
+
+# Crude model-family heuristic (extend as new model families enter Hyperloom).
+_MODEL_FAMILY_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"^deepseek", re.IGNORECASE), "deepseek"),
+    (re.compile(r"^qwen", re.IGNORECASE), "qwen"),
+    (re.compile(r"^llama", re.IGNORECASE), "llama"),
+    (re.compile(r"^glm", re.IGNORECASE), "glm"),
+    (re.compile(r"^mistral", re.IGNORECASE), "mistral"),
+    (re.compile(r"^kimi", re.IGNORECASE), "kimi"),
+    (re.compile(r"^gemma", re.IGNORECASE), "gemma"),
+)
+
+
+_UNKNOWN_VALUES: frozenset[str] = frozenset({"", "unknown", "null", "none"})
+
+
+def _normalise(value: Any) -> str:
+    """Apply contract G-3 normalisation: trim + lowercase, stringified."""
+    if value is None:
+        return ""
+    text = str(value).strip().lower()
+    return text
+
+
+def _is_present(value: Any) -> bool:
+    text = _normalise(value)
+    return text not in _UNKNOWN_VALUES
+
+
+def _pick(
+    key: str,
+    *sources: Mapping[str, Any] | None,
+) -> str:
+    for src in sources:
+        if not src:
+            continue
+        if key in src and _is_present(src[key]):
+            return _normalise(src[key])
+    return ""
+
+
+def derive_model_family(model: str) -> str:
+    """Best-effort family extractor for ``model`` strings.
+
+    Returns ``""`` when the model is unknown/empty so callers can decide
+    whether to default to ``"unknown"`` (and emit a warning) or to refuse
+    the write entirely.
+    """
+    text = _normalise(model)
+    if not text:
+        return ""
+    for pat, family in _MODEL_FAMILY_RULES:
+        if pat.match(text):
+            return family
+    return ""
+
+
+def build_scope(
+    packet_context: Mapping[str, Any] | None = None,
+    *,
+    session_context: Mapping[str, Any] | None = None,
+    require_critical: bool = True,
+) -> dict[str, Any]:
+    """Construct a KB scope dict from explicit + session contexts.
+
+    Args:
+        packet_context: Context from the current request. Wins on conflict.
+        session_context: Context recovered from :mod:`session_memory`.
+        require_critical: If True (default), raise :class:`ScopeError` when
+            ``model`` or ``framework`` cannot be filled. Set to False for
+            dry-run / preview callers that want to surface missing keys
+            non-fatally.
+
+    Returns:
+        A dict with all 6 critical keys (``"unknown"`` filling otherwise),
+        and any optional keys present in either input. ``org`` defaults to
+        ``"hyperloom"``.
+    """
+    pc = dict(packet_context or {})
+    sc = dict(session_context or {})
+
+    scope: dict[str, Any] = {}
+
+    for key in CRITICAL_SCOPE_KEYS:
+        if key == "org":
+            value = _pick(key, pc, sc) or ORG_DEFAULT
+            scope[key] = value
+            continue
+        value = _pick(key, pc, sc)
+        if not value and key == "model_family":
+            # Derive from model when family is missing.
+            model_value = _pick("model", pc, sc)
+            value = derive_model_family(model_value) or ""
+        scope[key] = value or "unknown"
+
+    for key in OPTIONAL_SCOPE_KEYS:
+        if _is_present(pc.get(key)):
+            scope[key] = _normalise(pc[key])
+        elif _is_present(sc.get(key)):
+            scope[key] = _normalise(sc[key])
+
+    if require_critical:
+        missing_critical = [
+            k for k in ("model", "framework") if scope[k] == "unknown"
+        ]
+        if missing_critical:
+            raise ScopeError(
+                f"cannot build KB scope: missing critical keys "
+                f"{missing_critical!r}; explicit context keys="
+                f"{sorted(pc.keys())!r}; session context keys="
+                f"{sorted(sc.keys())!r}"
+            )
+
+    return scope
+
+
+def scope_cache_key(scope: Mapping[str, Any], *, topic: str | None = None) -> str:
+    """Stable, hashable representation of (scope + optional topic).
+
+    Used by ``session_memory.SessionMemory.get_cached_priors``.
+    """
+    parts = [f"{k}={scope[k]}" for k in sorted(scope.keys())]
+    if topic:
+        parts.append(f"topic={_normalise(topic)}")
+    return "|".join(parts)
+
+
+__all__ = [
+    "CRITICAL_SCOPE_KEYS",
+    "OPTIONAL_SCOPE_KEYS",
+    "ORG_DEFAULT",
+    "build_scope",
+    "derive_model_family",
+    "scope_cache_key",
+]

--- a/critic-agent/runtime/session_memory.py
+++ b/critic-agent/runtime/session_memory.py
@@ -1,0 +1,389 @@
+"""Per-session memory store for the Critic agent.
+
+The Critic must keep state inside a single session because the Coordinator
+(and other A2A hosts) only send the full context on the *first* call —
+subsequent turns may carry incremental messages plus a decision. Critic
+needs to merge those turns against the previously known context, recall
+already-reviewed proposals, and reuse cached KB priors instead of hammering
+the KB on every reactor tick.
+
+Design constraints (handoff doc §5):
+
+* MVP storage is local JSON / JSONL — no database dependency.
+* Stateful per-session, stateless across sessions: nothing in this file
+  is intended to outlive the session (long-term knowledge goes to remote
+  KB).
+* Files are append-only where it makes sense (decisions, events) and
+  small-and-rewritten where consolidation is cheaper (context, priors
+  cache, reviewed msg ids).
+* Merging an incoming context dict with the stored one is **explicit-wins**:
+  values present in the request override stored values, but stored values
+  fill in for keys the request omitted. Both ``""`` and ``"unknown"`` are
+  treated as missing.
+
+Layout under ``CRITIC_SESSION_MEMORY_DIR``::
+
+    <root>/<session_id>/
+      context.json
+      decisions.jsonl
+      events.jsonl
+      kb_priors_cache.json
+      reviewed_msg_ids.json
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+from .errors import SessionMemoryError
+
+
+DEFAULT_SESSION_MEMORY_DIR = "/var/lib/critic-session-memory"
+DEFAULT_PRIOR_CACHE_TTL_SECONDS = 3600
+
+# Keys whose stored value can be filled in for the next request.
+_MERGEABLE_CONTEXT_KEYS: tuple[str, ...] = (
+    "model",
+    "framework",
+    "model_family",
+    "workload",
+    "precision",
+    "scale",
+    "objective",
+    "baseline_tput",
+    "baseline_label",
+    "current_best",
+    "session_label",
+)
+
+_MISSING_VALUES: frozenset[str] = frozenset({"", "unknown", "null", "none"})
+
+
+def _is_missing(value: Any) -> bool:
+    """Return ``True`` if value should be treated as absent."""
+    if value is None:
+        return True
+    if isinstance(value, str) and value.strip().lower() in _MISSING_VALUES:
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+@dataclass
+class MergeResult:
+    """Result of merging an incoming context against stored memory."""
+
+    merged: dict[str, Any] = field(default_factory=dict)
+    explicit_keys: list[str] = field(default_factory=list)
+    from_memory_keys: list[str] = field(default_factory=list)
+    missing_keys: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "merged": dict(self.merged),
+            "explicit_keys": list(self.explicit_keys),
+            "from_memory_keys": list(self.from_memory_keys),
+            "missing_keys": list(self.missing_keys),
+        }
+
+
+# ---------------------------------------------------------------------------
+class SessionMemory:
+    """File-backed session memory.
+
+    Concurrency: the Critic agent is single-process per A2A session today.
+    We therefore do not implement file locking — the worst we'd do under
+    concurrent writers is overwrite the small JSON files. If multi-writer
+    becomes a concern later, swap the underlying store, not the API.
+    """
+
+    def __init__(self, root: str | Path | None = None):
+        if root is None:
+            root = os.environ.get(
+                "CRITIC_SESSION_MEMORY_DIR", DEFAULT_SESSION_MEMORY_DIR
+            )
+        self.root = Path(root)
+        self.prior_cache_ttl = float(
+            os.environ.get(
+                "CRITIC_PRIOR_CACHE_TTL_SECONDS",
+                str(DEFAULT_PRIOR_CACHE_TTL_SECONDS),
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # Path helpers
+    # ------------------------------------------------------------------
+    def session_dir(self, session_id: str) -> Path:
+        if not session_id or not isinstance(session_id, str):
+            raise SessionMemoryError(f"invalid session_id: {session_id!r}")
+        # Disallow path traversal — session_id is meant to be a short
+        # opaque token, not a path fragment.
+        if "/" in session_id or ".." in session_id:
+            raise SessionMemoryError(f"session_id must not contain slashes: {session_id!r}")
+        return self.root / session_id
+
+    def _ensure_session_dir(self, session_id: str) -> Path:
+        d = self.session_dir(session_id)
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def _context_path(self, session_id: str) -> Path:
+        return self.session_dir(session_id) / "context.json"
+
+    def _decisions_path(self, session_id: str) -> Path:
+        return self.session_dir(session_id) / "decisions.jsonl"
+
+    def _events_path(self, session_id: str) -> Path:
+        return self.session_dir(session_id) / "events.jsonl"
+
+    def _priors_cache_path(self, session_id: str) -> Path:
+        return self.session_dir(session_id) / "kb_priors_cache.json"
+
+    def _reviewed_path(self, session_id: str) -> Path:
+        return self.session_dir(session_id) / "reviewed_msg_ids.json"
+
+    # ------------------------------------------------------------------
+    # Context
+    # ------------------------------------------------------------------
+    def load_context(self, session_id: str) -> dict[str, Any]:
+        path = self._context_path(session_id)
+        if not path.exists():
+            return {}
+        return _read_json(path, default={})
+
+    def save_context(self, session_id: str, context: dict[str, Any]) -> None:
+        if not isinstance(context, dict):
+            raise SessionMemoryError(
+                f"context must be a dict, got {type(context).__name__}"
+            )
+        self._ensure_session_dir(session_id)
+        _write_json_atomic(self._context_path(session_id), context)
+
+    def merge_context(
+        self,
+        session_id: str,
+        incoming: dict[str, Any],
+        *,
+        persist: bool = True,
+    ) -> MergeResult:
+        """Merge ``incoming`` against stored context with explicit-wins semantics.
+
+        ``persist`` defaults to ``True`` so callers don't forget to write
+        back; pass ``persist=False`` for read-only merges (e.g. dry-run).
+        """
+        if not isinstance(incoming, dict):
+            raise SessionMemoryError(
+                f"incoming context must be a dict, got {type(incoming).__name__}"
+            )
+        stored = self.load_context(session_id)
+        merged: dict[str, Any] = dict(stored)
+        explicit: list[str] = []
+        from_memory: list[str] = []
+        for key, value in incoming.items():
+            if _is_missing(value):
+                continue
+            merged[key] = value
+            explicit.append(key)
+        for key in _MERGEABLE_CONTEXT_KEYS:
+            if key in explicit:
+                continue
+            if key in stored and not _is_missing(stored.get(key)):
+                merged[key] = stored[key]
+                from_memory.append(key)
+
+        missing: list[str] = []
+        for key in _MERGEABLE_CONTEXT_KEYS:
+            if _is_missing(merged.get(key)):
+                missing.append(key)
+
+        result = MergeResult(
+            merged=merged,
+            explicit_keys=explicit,
+            from_memory_keys=from_memory,
+            missing_keys=missing,
+        )
+        if persist:
+            self.save_context(session_id, merged)
+        return result
+
+    # ------------------------------------------------------------------
+    # Decisions
+    # ------------------------------------------------------------------
+    def append_decision(self, session_id: str, decision_review: dict[str, Any]) -> None:
+        if not isinstance(decision_review, dict):
+            raise SessionMemoryError(
+                "decision_review must be a dict"
+            )
+        self._ensure_session_dir(session_id)
+        record = {
+            "ts": _now_iso(),
+            "decision_review": decision_review,
+        }
+        _append_jsonl(self._decisions_path(session_id), record)
+
+    def list_decisions(self, session_id: str) -> list[dict[str, Any]]:
+        path = self._decisions_path(session_id)
+        if not path.exists():
+            return []
+        return list(_read_jsonl(path))
+
+    # ------------------------------------------------------------------
+    # Events (free-form audit trail)
+    # ------------------------------------------------------------------
+    def append_event(self, session_id: str, event: dict[str, Any]) -> None:
+        if not isinstance(event, dict):
+            raise SessionMemoryError("event must be a dict")
+        self._ensure_session_dir(session_id)
+        _append_jsonl(self._events_path(session_id), {"ts": _now_iso(), **event})
+
+    def list_events(self, session_id: str) -> list[dict[str, Any]]:
+        path = self._events_path(session_id)
+        if not path.exists():
+            return []
+        return list(_read_jsonl(path))
+
+    # ------------------------------------------------------------------
+    # KB priors cache (per-scope+topic)
+    # ------------------------------------------------------------------
+    def get_cached_priors(
+        self,
+        session_id: str,
+        cache_key: str,
+        *,
+        now: float | None = None,
+    ) -> list[dict[str, Any]] | None:
+        cache = _read_json(self._priors_cache_path(session_id), default={})
+        entry = cache.get(cache_key)
+        if not isinstance(entry, dict):
+            return None
+        ts = entry.get("ts")
+        priors = entry.get("priors")
+        if not isinstance(priors, list) or not isinstance(ts, (int, float)):
+            return None
+        if (now or time.time()) - float(ts) > self.prior_cache_ttl:
+            return None
+        return priors
+
+    def put_cached_priors(
+        self,
+        session_id: str,
+        cache_key: str,
+        priors: list[dict[str, Any]],
+    ) -> None:
+        if not isinstance(priors, list):
+            raise SessionMemoryError("priors must be a list")
+        self._ensure_session_dir(session_id)
+        path = self._priors_cache_path(session_id)
+        cache = _read_json(path, default={})
+        cache[cache_key] = {"ts": time.time(), "priors": list(priors)}
+        _write_json_atomic(path, cache)
+
+    # ------------------------------------------------------------------
+    # Already-reviewed proposals
+    # ------------------------------------------------------------------
+    def is_msg_already_reviewed(self, session_id: str, msg_id: str) -> bool:
+        data = _read_json(self._reviewed_path(session_id), default={})
+        if not isinstance(data, dict):
+            return False
+        return msg_id in data
+
+    def reviewed_verdict_for(self, session_id: str, msg_id: str) -> str | None:
+        data = _read_json(self._reviewed_path(session_id), default={})
+        if not isinstance(data, dict):
+            return None
+        entry = data.get(msg_id)
+        if isinstance(entry, dict):
+            verdict = entry.get("verdict")
+            if isinstance(verdict, str):
+                return verdict
+        return None
+
+    def mark_reviewed(
+        self,
+        session_id: str,
+        msg_id: str,
+        verdict: str,
+        *,
+        decision_id: str | None = None,
+    ) -> None:
+        if not msg_id or not verdict:
+            raise SessionMemoryError("msg_id and verdict are required")
+        self._ensure_session_dir(session_id)
+        path = self._reviewed_path(session_id)
+        data = _read_json(path, default={})
+        if not isinstance(data, dict):
+            data = {}
+        data[msg_id] = {
+            "verdict": verdict,
+            "ts": _now_iso(),
+            "decision_id": decision_id,
+        }
+        _write_json_atomic(path, data)
+
+    def filter_unreviewed(
+        self,
+        session_id: str,
+        msg_ids: Iterable[str],
+    ) -> list[str]:
+        data = _read_json(self._reviewed_path(session_id), default={})
+        if not isinstance(data, dict):
+            data = {}
+        return [m for m in msg_ids if m not in data]
+
+
+# ---------------------------------------------------------------------------
+# Tiny JSON helpers — kept private so we don't grow them into a real ORM.
+# ---------------------------------------------------------------------------
+def _now_iso() -> str:
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds")
+
+
+def _read_json(path: Path, *, default: Any) -> Any:
+    if not path.exists():
+        return default
+    try:
+        return json.loads(path.read_text(encoding="utf-8") or "null")
+    except json.JSONDecodeError as exc:
+        raise SessionMemoryError(f"corrupt json at {path}: {exc}") from exc
+
+
+def _write_json_atomic(path: Path, data: Any) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _append_jsonl(path: Path, record: dict[str, Any]) -> None:
+    with path.open("a", encoding="utf-8") as fp:
+        fp.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def _read_jsonl(path: Path) -> Iterable[dict[str, Any]]:
+    with path.open("r", encoding="utf-8") as fp:
+        for line in fp:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise SessionMemoryError(
+                    f"corrupt jsonl line at {path}: {exc}"
+                ) from exc
+            if isinstance(obj, dict):
+                yield obj
+
+
+__all__ = [
+    "DEFAULT_PRIOR_CACHE_TTL_SECONDS",
+    "DEFAULT_SESSION_MEMORY_DIR",
+    "MergeResult",
+    "SessionMemory",
+]

--- a/critic-agent/runtime/slugify.py
+++ b/critic-agent/runtime/slugify.py
@@ -1,0 +1,110 @@
+"""Deterministic slug generation per ``kb-critic-integration-contract`` Appendix D.
+
+Two writers — Critic and Alchemist — share this algorithm so the same fact
+collapses onto the same ``(scope, kind, slug)`` tuple. Any change here is a
+breaking SDK bump (contract D.5).
+
+Public API:
+
+* :func:`slugify(topic)` — ASCII-only deterministic slug, raises
+  :class:`SlugifyError` for ``empty`` / ``non_ascii`` / ``too_short``.
+* :func:`slugify_safe(topic, translate_fn=None, fallback_prefix='auto')` —
+  Non-ASCII safe wrapper. Pure-ASCII input falls through to ``slugify``;
+  otherwise the caller can inject a translation function (e.g. an LLM
+  call) and we slugify the result. If translation fails or is absent, we
+  fall back to ``<fallback_prefix>-<sha256(topic)[:8]>``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import unicodedata
+from typing import Callable
+
+from .errors import SlugifyError
+
+
+_NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
+_LEADING_TRAILING_DASH_RE = re.compile(r"^-+|-+$")
+_REPEATED_DASH_RE = re.compile(r"-+")
+
+_ASCII_RE = re.compile(r"^[\x00-\x7f]*$")
+
+_MIN_LEN = 8
+_MAX_LEN = 80
+_TRUNC_LEN = 72
+
+
+def _ascii_only(text: str) -> bool:
+    return bool(_ASCII_RE.match(text))
+
+
+def slugify(topic: str) -> str:
+    """ASCII-only deterministic slug.
+
+    See contract Appendix D.2 for the step-by-step spec.
+    """
+    if not isinstance(topic, str):
+        raise SlugifyError(f"topic must be str, got {type(topic).__name__}")
+    if not topic.strip():
+        raise SlugifyError("empty: topic is empty or whitespace-only")
+    normalised = unicodedata.normalize("NFKC", topic)
+    if not _ascii_only(normalised):
+        # First non-ASCII offset (rough, character-based).
+        offset = next(
+            (i for i, ch in enumerate(normalised) if ord(ch) > 127),
+            -1,
+        )
+        raise SlugifyError(
+            f"non_ascii: topic contains non-ASCII characters (offset={offset})"
+        )
+    lowered = normalised.lower()
+    replaced = _NON_ALNUM_RE.sub("-", lowered)
+    trimmed = _LEADING_TRAILING_DASH_RE.sub("", replaced)
+    folded = _REPEATED_DASH_RE.sub("-", trimmed)
+    if not folded:
+        raise SlugifyError("empty: slug collapsed to empty after normalisation")
+    if len(folded) > _MAX_LEN:
+        digest = hashlib.sha256(topic.encode("utf-8")).hexdigest()[:7]
+        return f"{folded[:_TRUNC_LEN]}-{digest}"
+    if len(folded) < _MIN_LEN:
+        raise SlugifyError(
+            f"too_short: slug={folded!r} length={len(folded)} < {_MIN_LEN}"
+        )
+    return folded
+
+
+def slugify_safe(
+    topic: str,
+    translate_fn: Callable[[str], str] | None = None,
+    *,
+    fallback_prefix: str = "auto",
+) -> str:
+    """Non-ASCII safe wrapper (contract §7.2 / G-6).
+
+    * Pure ASCII → :func:`slugify`.
+    * Non-ASCII + ``translate_fn`` provided → ``slugify(translate_fn(topic))``.
+    * Non-ASCII without translate_fn (or translate_fn raises) → the
+      deterministic fallback ``<prefix>-<sha8>`` so writes remain idempotent.
+    """
+    if not isinstance(topic, str) or not topic.strip():
+        raise SlugifyError("empty: topic is empty or whitespace-only")
+    normalised = unicodedata.normalize("NFKC", topic)
+    if _ascii_only(normalised):
+        return slugify(topic)
+    if translate_fn is not None:
+        try:
+            translated = translate_fn(topic)
+        except Exception:  # noqa: BLE001 — fall back per contract §7.2
+            translated = None
+        if translated:
+            try:
+                return slugify(translated)
+            except SlugifyError:
+                pass
+    digest = hashlib.sha256(topic.encode("utf-8")).hexdigest()[:8]
+    return f"{fallback_prefix}-{digest}"
+
+
+__all__ = ["slugify", "slugify_safe"]

--- a/critic-agent/runtime/tests/conftest.py
+++ b/critic-agent/runtime/tests/conftest.py
@@ -1,0 +1,34 @@
+"""Shared pytest fixtures for the Critic runtime tests.
+
+Keeping these tiny and orthogonal makes individual test files readable and
+prevents the runtime tests from depending on the wider Hyperloom test
+harness — the runtime is intended to be pip-installable on its own.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture()
+def tmp_session_root(tmp_path: Path) -> Path:
+    """Per-test session-memory root that's isolated from $HOME / /var."""
+    root = tmp_path / "critic-session-memory"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture()
+def write_json(tmp_path: Path):
+    """Helper to drop a JSON object on disk and return the path."""
+
+    def _write(name: str, body: dict[str, Any]) -> Path:
+        p = tmp_path / name
+        p.write_text(json.dumps(body), encoding="utf-8")
+        return p
+
+    return _write

--- a/critic-agent/runtime/tests/fixtures/slugify-golden.json
+++ b/critic-agent/runtime/tests/fixtures/slugify-golden.json
@@ -1,0 +1,13 @@
+[
+  { "input": "MLA FP8 torch.compile incompat", "output": "mla-fp8-torch-compile-incompat" },
+  { "input": "  FA3   H100  crash  ", "output": "fa3-h100-crash" },
+  { "input": "sglang 1.0 chunked prefill bug", "output": "sglang-1-0-chunked-prefill-bug" },
+  { "input": "--num-continuous-decode-steps", "output": "num-continuous-decode-steps" },
+  { "input": "CUDA Graph (decode replay)", "output": "cuda-graph-decode-replay" },
+  { "input": "DeepSeek-R1-0528-FP8 profile", "output": "deepseek-r1-0528-fp8-profile" },
+  { "input": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA-overflow-test", "output_pattern": "^a{72}-[0-9a-f]{7}$" },
+  { "input": "", "throws": "SlugifyError", "reason": "empty" },
+  { "input": "   ", "throws": "SlugifyError", "reason": "empty" },
+  { "input": "abc", "throws": "SlugifyError", "reason": "too_short" },
+  { "input": "FA3 H100 crash", "output": "fa3-h100-crash" }
+]

--- a/critic-agent/runtime/tests/test_category_mapping.py
+++ b/critic-agent/runtime/tests/test_category_mapping.py
@@ -1,0 +1,45 @@
+"""Tests for :mod:`runtime.category_mapping`."""
+
+from __future__ import annotations
+
+import pytest
+
+from runtime.category_mapping import (
+    CATEGORY_TO_KIND,
+    KB_KINDS,
+    filter_supported_categories,
+    map_category_to_kind,
+)
+from runtime.errors import RuntimeAdapterError
+
+
+def test_kb_kinds_set_matches_contract():
+    assert KB_KINDS == frozenset({"pitfall", "technique", "params_catalog", "model_profile"})
+
+
+def test_kernel_opt_maps_to_technique():
+    assert map_category_to_kind("kernel_optimization") == "technique"
+
+
+def test_pitfall_categories_collapse_correctly():
+    assert map_category_to_kind("crash_recovery") == "pitfall"
+    assert map_category_to_kind("benchmark_methodology") == "pitfall"
+    assert map_category_to_kind("architecture_constraint") == "pitfall"
+
+
+def test_unknown_category_raises():
+    with pytest.raises(RuntimeAdapterError):
+        map_category_to_kind("not_a_thing")
+
+
+def test_filter_supported_partitions_lists():
+    supported, rejected = filter_supported_categories(
+        ["kernel_optimization", "definitely_not_a_thing", "server_params"]
+    )
+    assert supported == ["kernel_optimization", "server_params"]
+    assert rejected == ["definitely_not_a_thing"]
+
+
+def test_full_table_targets_known_kinds():
+    for category, kind in CATEGORY_TO_KIND.items():
+        assert kind in KB_KINDS, (category, kind)

--- a/critic-agent/runtime/tests/test_cli.py
+++ b/critic-agent/runtime/tests/test_cli.py
@@ -1,0 +1,105 @@
+"""Smoke tests for the CLI front door.
+
+We run the parser/dispatch in-process via :func:`runtime.cli.main` so the
+behaviour exercised matches what ``python -m runtime.cli ...`` would do.
+The tests focus on the new commands; the legacy ones (``write-verdict``,
+``write-kb-drafts``, ...) are covered transitively by ``test_kb_writer``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from runtime.cli import main
+
+
+def _write(path: Path, body) -> Path:
+    path.write_text(json.dumps(body), encoding="utf-8")
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _isolate_session_memory(tmp_path, monkeypatch):
+    monkeypatch.setenv("CRITIC_SESSION_MEMORY_DIR", str(tmp_path / "sm"))
+    monkeypatch.setenv("CRITIC_KB_CLIENT_MODE", "inmemory")
+    monkeypatch.setenv("KB_DEAD_LETTER_DIR", str(tmp_path / "dlq"))
+    yield
+
+
+def test_init_session_writes_context(tmp_path, capsys):
+    request = _write(tmp_path / "req.json", {
+        "kind": "critic_decision_request",
+        "session_id": "sess_cli_init",
+        "context": {"model": "qwen3-14b", "framework": "sglang"},
+        "messages": [],
+    })
+    rc = main(["init-session", "--request", str(request)])
+    assert rc == 0
+    captured = capsys.readouterr().out
+    assert json.loads(captured)["session_id"] == "sess_cli_init"
+
+
+def test_prepare_and_commit_review_for_coordinator_inbox(tmp_path, capsys):
+    request = _write(tmp_path / "req.json", {
+        "kind": "coordinator_inbox",
+        "session_id": "sess_cli_e2e",
+        "raw_prompt": (
+            "=== Shared session state ===\n"
+            "model=qwen3-14b framework=sglang workload=decode precision=fp8\n"
+            "=== Inbox for critic ===\n"
+            "  seq=1 msg_id=cli01 from=orchestration topic=proposal payload={'action_name': 'baseline'}\n"
+        ),
+    })
+    rc = main(["prepare-review", "--request", str(request), "--out", str(tmp_path / "judge.json")])
+    assert rc == 0
+    judge = json.loads((tmp_path / "judge.json").read_text("utf-8"))
+    assert judge["proposals"][0]["msg_id"] == "cli01"
+
+    review = _write(tmp_path / "review.json", {
+        "review_verdicts": [
+            {
+                "target_proposal_msg_id": "cli01",
+                "verdict": "approve",
+                "reasoning": "ok",
+            }
+        ]
+    })
+    rc = main([
+        "commit-review",
+        "--request", str(request),
+        "--review", str(review),
+        "--out", str(tmp_path / "emit.json"),
+    ])
+    assert rc == 0
+    emit = json.loads((tmp_path / "emit.json").read_text("utf-8"))
+    assert emit["intent_envelope"]["intents"][0]["payload"]["verdict"] == "approve"
+
+
+def test_close_session_emits_summary(tmp_path):
+    request = _write(tmp_path / "req.json", {
+        "kind": "critic_decision_request",
+        "session_id": "sess_cli_close",
+        "context": {
+            "model": "qwen3-14b", "framework": "sglang",
+            "model_family": "qwen", "workload": "decode", "precision": "fp8",
+        },
+    })
+    main(["init-session", "--request", str(request)])
+    rc = main([
+        "close-session",
+        "--request", str(request),
+        "--out", str(tmp_path / "close.json"),
+    ])
+    assert rc == 0
+    out = json.loads((tmp_path / "close.json").read_text("utf-8"))
+    assert out["session_id"] == "sess_cli_close"
+
+
+def test_invalid_request_returns_exit_code_2(tmp_path):
+    bad = _write(tmp_path / "bad.json", {"kind": "wat"})
+    rc = main(["init-session", "--request", str(bad)])
+    assert rc == 2

--- a/critic-agent/runtime/tests/test_dead_letter.py
+++ b/critic-agent/runtime/tests/test_dead_letter.py
@@ -1,0 +1,95 @@
+"""Tests for :class:`runtime.dead_letter.DeadLetter`."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from runtime.dead_letter import DeadLetter
+from runtime.errors import RuntimeAdapterError
+
+
+def test_append_and_files_round_trip(tmp_path):
+    dlq = DeadLetter(root=tmp_path)
+    p = dlq.append(
+        "upsert",
+        {"scope": {}, "kind": "pitfall", "slug": "x"},
+        attempts=2,
+        last_error="503",
+    )
+    assert p.exists()
+    files = dlq.files()
+    assert files == [p]
+    record = json.loads(p.read_text("utf-8").splitlines()[0])
+    assert record["endpoint"] == "upsert"
+    assert record["attempts"] == 2
+
+
+def test_append_rejects_bad_endpoint(tmp_path):
+    dlq = DeadLetter(root=tmp_path)
+    with pytest.raises(RuntimeAdapterError):
+        dlq.append("up/sert", {}, attempts=1, last_error="x")
+
+
+def test_replay_succeeds_removes_lines(tmp_path):
+    dlq = DeadLetter(root=tmp_path)
+    dlq.append("upsert", {"k": 1}, attempts=1, last_error="x")
+    dlq.append("upsert", {"k": 2}, attempts=1, last_error="x")
+
+    seen = []
+
+    def dispatcher(endpoint, payload):
+        seen.append((endpoint, payload))
+
+    summary = dlq.replay(dispatcher)
+    assert summary.scanned == 2
+    assert summary.succeeded == 2
+    assert summary.failed == 0
+    assert dlq.files() == []
+    assert [s[0] for s in seen] == ["upsert", "upsert"]
+
+
+def test_replay_keeps_failed_rows(tmp_path):
+    dlq = DeadLetter(root=tmp_path)
+    dlq.append("upsert", {"k": 1}, attempts=1, last_error="x")
+    dlq.append("upsert", {"k": 2}, attempts=1, last_error="x")
+
+    def dispatcher(endpoint, payload):
+        if payload["k"] == 1:
+            raise RuntimeError("boom")
+
+    summary = dlq.replay(dispatcher)
+    assert summary.scanned == 2
+    assert summary.succeeded == 1
+    assert summary.failed == 1
+    files = dlq.files()
+    # Surviving file should still hold one record.
+    assert len(files) == 1
+    survivors = [json.loads(line) for line in files[0].read_text("utf-8").splitlines() if line.strip()]
+    assert len(survivors) == 1
+    assert survivors[0]["payload"]["k"] == 1
+
+
+def test_replay_empty_dir_returns_zero_summary(tmp_path):
+    dlq = DeadLetter(root=tmp_path / "empty")
+    summary = dlq.replay(lambda *a, **k: None)
+    assert summary.to_dict() == {
+        "scanned": 0,
+        "succeeded": 0,
+        "failed": 0,
+        "failed_details": [],
+    }
+
+
+def test_replay_handles_corrupt_lines_as_failures(tmp_path):
+    dlq = DeadLetter(root=tmp_path)
+    dlq.append("upsert", {"k": 1}, attempts=1, last_error="x")
+    # Append a bad line manually.
+    p = dlq.files()[0]
+    with p.open("a", encoding="utf-8") as fp:
+        fp.write("{not json\n")
+
+    summary = dlq.replay(lambda *a, **k: None)
+    assert summary.scanned == 2
+    assert summary.failed == 1

--- a/critic-agent/runtime/tests/test_decision_reviewer.py
+++ b/critic-agent/runtime/tests/test_decision_reviewer.py
@@ -1,0 +1,301 @@
+"""Integration tests for the prepare/commit lifecycle.
+
+These tests use :class:`InMemoryKBClient` and a temp session-memory root,
+so they cover the deterministic side of the Critic agent end-to-end (no
+LLM involvement needed).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from runtime.decision_reviewer import DecisionReviewer
+from runtime.errors import ReviewValidationError
+from runtime.in_memory_kb_client import InMemoryKBClient
+from runtime.kb_writer import KBWriter
+from runtime.session_memory import SessionMemory
+
+
+@pytest.fixture()
+def reviewer(tmp_path):
+    sm = SessionMemory(root=tmp_path / "sm")
+    kb = InMemoryKBClient()
+    writer = KBWriter(kb, session_memory=sm)
+    return DecisionReviewer(session_memory=sm, kb_writer=writer), kb, sm
+
+
+def _coordinator_request(prompt: str, session_id: str = "sess_a") -> dict:
+    return {
+        "kind": "coordinator_inbox",
+        "session_id": session_id,
+        "raw_prompt": prompt,
+    }
+
+
+_PROMPT_WITH_TWO_PROPOSALS = (
+    "=== Shared session state ===\n"
+    "session_id=sess_a model=Qwen3-14B framework=sglang baseline_tput=1200\n"
+    "=== Inbox for critic (newest last) ===\n"
+    "  seq=1 msg_id=aaa1 from=orchestration topic=proposal payload={'action_name': 'baseline'}\n"
+    "  seq=2 msg_id=bbb2 from=orchestration topic=proposal payload={'action_name': 'kernel_opt', 'predicted_gain_pct': 4.2}\n"
+)
+
+
+def test_prepare_review_for_coordinator_inbox_extracts_proposals(reviewer):
+    rev, kb, sm = reviewer
+    bundle = rev.prepare_review(_coordinator_request(_PROMPT_WITH_TWO_PROPOSALS))
+    assert bundle.kind == "coordinator_inbox"
+    assert sorted(p["msg_id"] for p in bundle.proposals) == ["aaa1", "bbb2"]
+    # Context merged from shared_state.
+    assert bundle.merged_context["model"] == "Qwen3-14B"
+    assert bundle.merged_context["framework"] == "sglang"
+    assert bundle.kb_read_skipped_reason is None
+    assert "active_path_proof_when_relevant" in bundle.review_constraints["approve_requires"]
+
+
+def test_prepare_review_skips_kb_when_critical_context_missing(reviewer):
+    rev, kb, sm = reviewer
+    bundle = rev.prepare_review({
+        "kind": "critic_decision_request",
+        "session_id": "sess_b",
+        "messages": [{"role": "coordinator", "content": "decide"}],
+        "decision": {"summary": "adopt patch x"},
+    })
+    assert bundle.required_context == ["model", "framework"]
+    assert bundle.kb_read_skipped_reason == "missing_critical_context"
+
+
+def test_prepare_review_returns_kb_priors_per_proposal(reviewer):
+    rev, kb, sm = reviewer
+    kb.upsert({
+        "scope": {
+            "org": "hyperloom",
+            "framework": "sglang",
+            "model": "qwen3-14b",
+            "model_family": "qwen",
+            "workload": "decode",
+            "precision": "fp8",
+        },
+        "kind": "pitfall",
+        "slug": "active-path-unproven-pitfall",
+        "importance": 0.5,
+        "metadata": {"topic": "active path"},
+    })
+    prompt = (
+        "=== Shared session state ===\n"
+        "model=qwen3-14b framework=sglang workload=decode precision=fp8\n"
+        "=== Inbox for critic ===\n"
+        "  seq=1 msg_id=aaa from=orchestration topic=proposal payload={'action_name': 'kernel_opt'}\n"
+    )
+    bundle = rev.prepare_review(_coordinator_request(prompt, "sess_priors"))
+    assert "aaa" in bundle.kb_priors_by_proposal
+
+
+def test_prepare_review_filters_already_reviewed_proposals(reviewer):
+    rev, kb, sm = reviewer
+    sm.mark_reviewed("sess_dedup", "aaa1", "approve")
+    bundle = rev.prepare_review(_coordinator_request(
+        _PROMPT_WITH_TWO_PROPOSALS, "sess_dedup",
+    ))
+    proposal_ids = sorted(p["msg_id"] for p in bundle.proposals)
+    assert proposal_ids == ["bbb2"]
+
+
+def test_commit_review_for_coordinator_inbox_emits_intent_envelope(reviewer):
+    rev, kb, sm = reviewer
+    rev.prepare_review(_coordinator_request(_PROMPT_WITH_TWO_PROPOSALS, "sess_c"))
+    review = {
+        "review_verdicts": [
+            {
+                "target_proposal_msg_id": "aaa1",
+                "verdict": "approve",
+                "reasoning": "matches kb-1",
+                "confidence": "medium",
+                "predicted_gain_pct": 0.0,
+            },
+            {
+                "target_proposal_msg_id": "bbb2",
+                "verdict": "reject",
+                "reasoning": "active dispatch path unproven",
+                "kb_evidence": ["kb_x"],
+            },
+        ]
+    }
+    outcome = rev.commit_review(
+        _coordinator_request(_PROMPT_WITH_TWO_PROPOSALS, "sess_c"),
+        review,
+    )
+    assert outcome.intent_envelope is not None
+    intents = outcome.intent_envelope["intents"]
+    assert len(intents) == 2
+    types = [i["intent_type"] for i in intents]
+    verdicts = [i["payload"]["verdict"] for i in intents]
+    assert types == ["review_verdict", "review_verdict"]
+    assert sorted(verdicts) == ["approve", "reject"]
+    # Reviewed msg_ids tracked
+    assert sm.is_msg_already_reviewed("sess_c", "aaa1")
+    assert sm.is_msg_already_reviewed("sess_c", "bbb2")
+
+
+def test_commit_review_invalid_verdict_raises(reviewer):
+    rev, kb, sm = reviewer
+    rev.prepare_review(_coordinator_request(_PROMPT_WITH_TWO_PROPOSALS, "sess_d"))
+    with pytest.raises(ReviewValidationError, match="not valid"):
+        rev.commit_review(
+            _coordinator_request(_PROMPT_WITH_TWO_PROPOSALS, "sess_d"),
+            {"review_verdicts": [{"target_proposal_msg_id": "aaa1", "verdict": "lgtm"}]},
+        )
+
+
+def test_commit_review_no_proposals_emits_heartbeat(reviewer):
+    rev, kb, sm = reviewer
+    prompt = (
+        "=== Shared session state ===\n"
+        "model=qwen3-14b framework=sglang\n"
+        "=== Inbox for critic ===\n"
+        "(no new messages)\n"
+    )
+    rev.prepare_review(_coordinator_request(prompt, "sess_e"))
+    outcome = rev.commit_review(
+        _coordinator_request(prompt, "sess_e"),
+        {"review_verdicts": []},
+    )
+    intents = outcome.intent_envelope["intents"]
+    assert len(intents) == 1
+    assert intents[0]["intent_type"] == "send_message"
+    assert intents[0]["payload"]["topic"] == "heartbeat"
+
+
+def test_commit_review_persists_to_kb_when_flagged(reviewer):
+    rev, kb, sm = reviewer
+    rev.prepare_review(_coordinator_request(_PROMPT_WITH_TWO_PROPOSALS, "sess_f"))
+    review = {
+        "review_verdicts": [
+            {
+                "target_proposal_msg_id": "aaa1",
+                "verdict": "reject",
+                "reasoning": "active dispatch path unproven for this kernel",
+                "packet_evidence": ["benchmark.after.gain_pct"],
+                "persist_to_kb": True,
+                "topic": "active dispatch path unproven",
+            },
+        ]
+    }
+    outcome = rev.commit_review(
+        _coordinator_request(_PROMPT_WITH_TWO_PROPOSALS, "sess_f"),
+        review,
+    )
+    assert any(w["trigger"] == "review_verdict" for w in outcome.kb_writes)
+    assert kb.all_rows()
+
+
+def test_decision_request_prepare_with_full_context(reviewer):
+    rev, kb, sm = reviewer
+    bundle = rev.prepare_review({
+        "kind": "critic_decision_request",
+        "session_id": "sess_g",
+        "messages": [{"role": "coordinator", "content": "adopt patch x?"}],
+        "context": {
+            "model": "deepseek-r1-0528-fp8", "framework": "sglang",
+            "model_family": "deepseek", "workload": "decode", "precision": "fp8",
+        },
+        "decision": {"summary": "adopt patch x"},
+    })
+    assert bundle.required_context == []
+    assert bundle.kb_read_skipped_reason is None
+
+
+def test_decision_request_commit_emits_decision_review(reviewer):
+    rev, kb, sm = reviewer
+    request = {
+        "kind": "critic_decision_request",
+        "session_id": "sess_h",
+        "messages": [{"role": "coordinator", "content": "adopt?"}],
+        "context": {
+            "model": "deepseek-r1-0528-fp8", "framework": "sglang",
+            "model_family": "deepseek", "workload": "decode", "precision": "fp8",
+        },
+        "decision": {"summary": "adopt patch x"},
+    }
+    rev.prepare_review(request)
+    review = {
+        "verdict": "adopt",
+        "reason": "no contradicting kb prior; benchmark within tolerance",
+        "recommendation": "rerun final benchmark after cache clear",
+        "basis": "session",
+        "session_evidence": ["benchmark.after.gain_pct"],
+    }
+    outcome = rev.commit_review(request, review)
+    assert outcome.decision_review is not None
+    assert outcome.decision_review["verdict"] == "adopt"
+    assert outcome.kb_writes  # review_verdict-equivalent triggered
+
+
+def test_init_session_records_event(reviewer):
+    rev, kb, sm = reviewer
+    out = rev.init_session({
+        "kind": "critic_decision_request",
+        "session_id": "sess_init",
+        "context": {"model": "qwen3-14b", "framework": "sglang"},
+        "messages": [],
+    })
+    assert out["session_id"] == "sess_init"
+    events = sm.list_events("sess_init")
+    assert events and events[0]["kind"] == "init_session"
+
+
+def test_close_session_writes_kb_drafts_when_provided(reviewer):
+    rev, kb, sm = reviewer
+    rev.init_session({
+        "kind": "critic_decision_request",
+        "session_id": "sess_close",
+        "context": {
+            "model": "qwen3-14b", "framework": "sglang",
+            "model_family": "qwen", "workload": "decode", "precision": "fp8",
+        },
+        "messages": [],
+    })
+    outcome = rev.close_session(
+        {"kind": "critic_decision_request", "session_id": "sess_close",
+         "context": {"model": "qwen3-14b", "framework": "sglang",
+                     "model_family": "qwen", "workload": "decode", "precision": "fp8"}},
+        kb_draft={
+            "kb_drafts": [
+                {
+                    "category": "kernel_optimization",
+                    "action": "Patched the active dispatch path for Qwen3-14B.",
+                    "lesson": "Active dispatch path must be kept in sync with kernel rewrite.",
+                    "tags": ["dispatch"],
+                    "result": {"status": "KEEP", "gain_pct": 4.2},
+                    "confidence": 0.9,
+                }
+            ]
+        },
+    )
+    assert outcome.kb_writes
+    assert outcome.kb_writes[0]["result"]["status"] in ("ok", "skipped", "dead_lettered")
+
+
+def test_kb_priors_cache_hit_avoids_second_kb_call(reviewer):
+    rev, kb, sm = reviewer
+    kb.upsert({
+        "scope": {
+            "org": "hyperloom", "framework": "sglang", "model": "qwen3-14b",
+            "model_family": "qwen", "workload": "decode", "precision": "fp8",
+        },
+        "kind": "pitfall", "slug": "active-path-unproven-pitfall", "importance": 0.5,
+        "metadata": {"topic": "active path"},
+    })
+    prompt = (
+        "=== Shared session state ===\n"
+        "model=qwen3-14b framework=sglang workload=decode precision=fp8\n"
+        "=== Inbox for critic ===\n"
+        "  seq=1 msg_id=aaa from=orchestration topic=proposal payload={'action_name': 'kernel_opt'}\n"
+    )
+    rev.prepare_review(_coordinator_request(prompt, "sess_cache_e2e"))
+    # Now flush KB to ensure the second call uses cache.
+    kb.reset()
+    bundle = rev.prepare_review(_coordinator_request(prompt, "sess_cache_e2e"))
+    # First call cached the result; KB is now empty but bundle still
+    # contains priors because of cache hit.
+    assert bundle.kb_priors_by_proposal["aaa"]

--- a/critic-agent/runtime/tests/test_importance_mapping.py
+++ b/critic-agent/runtime/tests/test_importance_mapping.py
@@ -1,0 +1,42 @@
+"""Tests for :mod:`runtime.importance_mapping`."""
+
+from __future__ import annotations
+
+from runtime.importance_mapping import (
+    CRITIC_IMPORTANCE_CEILING,
+    cap_importance,
+    importance_for_kb_draft,
+    importance_for_verdict,
+)
+
+
+def test_high_with_measurement_scores_above_default():
+    score = importance_for_verdict(
+        verdict="reject", confidence="high", has_measurement=True
+    )
+    assert score == 0.7
+
+
+def test_high_without_measurement_drops_back_to_low():
+    score = importance_for_verdict(
+        verdict="reject", confidence="high", has_measurement=False
+    )
+    assert score == 0.4
+
+
+def test_advise_clamped_low_regardless_of_confidence():
+    assert importance_for_verdict(verdict="advise", confidence="high") == 0.4
+
+
+def test_kb_draft_high_confidence_promoted():
+    assert importance_for_kb_draft(confidence=0.85) == 0.6
+
+
+def test_kb_draft_default_when_unknown():
+    assert importance_for_kb_draft(confidence=None) == 0.5
+
+
+def test_cap_importance_enforces_critic_ceiling():
+    assert cap_importance(0.99) == CRITIC_IMPORTANCE_CEILING
+    assert cap_importance(0.5) == 0.5
+    assert cap_importance(-1.0) == 0.0

--- a/critic-agent/runtime/tests/test_in_memory_kb_client.py
+++ b/critic-agent/runtime/tests/test_in_memory_kb_client.py
@@ -1,0 +1,172 @@
+"""Tests for :class:`runtime.in_memory_kb_client.InMemoryKBClient`.
+
+The contract (§7.3) lists 4 promises this mock must keep; one test per
+promise plus a couple of edge cases.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from runtime.errors import KBValidationError
+from runtime.in_memory_kb_client import InMemoryKBClient
+
+
+def _scope():
+    return {
+        "org": "hyperloom",
+        "framework": "sglang",
+        "model": "deepseek-r1",
+        "model_family": "deepseek",
+        "workload": "decode",
+        "precision": "fp8",
+    }
+
+
+def test_upsert_creates_then_returns_existing():
+    kb = InMemoryKBClient()
+    out1 = kb.upsert({
+        "scope": _scope(),
+        "kind": "pitfall",
+        "slug": "mla-fp8-torch-compile-incompat",
+        "importance": 0.5,
+        "summary": "first",
+        "metadata": {"topic": "t"},
+    })
+    assert out1["created"] is True
+    out2 = kb.upsert({
+        "scope": _scope(),
+        "kind": "pitfall",
+        "slug": "mla-fp8-torch-compile-incompat",
+        "importance": 0.4,
+        "summary": "second",
+        "metadata": {"topic": "t2"},
+    })
+    assert out2["created"] is False
+    # Importance protected (G-2): incoming < existing keeps existing.
+    assert out2["row"]["importance"] == 0.5
+    assert "importance_protected" in out2["warnings"]
+    # Summary partial-merged (G-1).
+    assert out2["row"]["summary"] == "second"
+    # Metadata deep-merged.
+    assert out2["row"]["metadata"]["topic"] == "t2"
+
+
+def test_upsert_missing_field_raises():
+    kb = InMemoryKBClient()
+    with pytest.raises(KBValidationError):
+        kb.upsert({"kind": "pitfall", "slug": "x", "importance": 0.5})
+
+
+def test_contradicts_edge_auto_mirrors():
+    kb = InMemoryKBClient()
+    a = kb.upsert({
+        "scope": _scope(), "kind": "pitfall", "slug": "a-aaaaaa", "importance": 0.5,
+    })["row"]["id"]
+    b = kb.upsert({
+        "scope": _scope(), "kind": "pitfall", "slug": "b-bbbbbb", "importance": 0.5,
+    })["row"]["id"]
+    out = kb.add_edges([{"kind": "contradicts", "from_id": a, "to_id": b}])
+    assert {"from_id": a, "to_id": b, "kind": "contradicts"} in out["added"]
+    assert any(m["from_id"] == b and m["to_id"] == a for m in out["mirrored_to"])
+    rows = kb.all_rows()
+    by_id = {r["id"]: r for r in rows}
+    assert b in by_id[a]["edges"]["contradicts"]
+    assert a in by_id[b]["edges"]["contradicts"]
+
+
+def test_contradicts_with_missing_target_records_skip():
+    kb = InMemoryKBClient()
+    a = kb.upsert({
+        "scope": _scope(), "kind": "pitfall", "slug": "a-aaaaaa", "importance": 0.5,
+    })["row"]["id"]
+    out = kb.add_edges([{"kind": "contradicts", "from_id": a, "to_id": "ghost"}])
+    assert out["mirror_skipped"]
+    assert out["mirror_skipped"][0]["reason"] == "dst_missing"
+
+
+def test_list_returns_only_matching_scope_after_normalisation():
+    kb = InMemoryKBClient()
+    kb.upsert({
+        "scope": _scope(), "kind": "pitfall", "slug": "a-pitfall1",
+        "importance": 0.5,
+    })
+    other = dict(_scope())
+    other["framework"] = "vllm"
+    kb.upsert({
+        "scope": other, "kind": "pitfall", "slug": "b-pitfall2",
+        "importance": 0.5,
+    })
+    out = kb.list(scope_filter={"framework": "  SGLang "})
+    assert all(r["scope"]["framework"] == "sglang" for r in out["entries"])
+    assert any(r["slug"] == "a-pitfall1" for r in out["entries"])
+
+
+def test_metadata_filter_supports_nested_paths():
+    kb = InMemoryKBClient()
+    kb.upsert({
+        "scope": _scope(), "kind": "pitfall", "slug": "deep-pitfall",
+        "importance": 0.5,
+        "metadata": {"evidence": {"packet_evidence": ["benchmark.after.gain_pct"]}},
+    })
+    out = kb.list(
+        scope_filter=_scope(),
+        metadata_filter={"evidence": {"packet_evidence": ["benchmark.after.gain_pct"]}},
+    )
+    assert len(out["entries"]) == 1
+
+
+def test_metadata_filter_array_contains_subset():
+    kb = InMemoryKBClient()
+    kb.upsert({
+        "scope": _scope(), "kind": "technique", "slug": "tag-test",
+        "importance": 0.5,
+        "metadata": {"tags": ["dispatch", "kernel", "active_path"]},
+    })
+    hit = kb.list(
+        scope_filter=_scope(),
+        metadata_filter={"tags": ["dispatch"]},
+    )
+    miss = kb.list(
+        scope_filter=_scope(),
+        metadata_filter={"tags": ["nonexistent"]},
+    )
+    assert len(hit["entries"]) == 1
+    assert miss["entries"] == []
+
+
+def test_simulate_failure_drains_one_failure_per_endpoint():
+    kb = InMemoryKBClient()
+    kb.simulate_failure(endpoint="upsert", times=2, error={"code": 503})
+    with pytest.raises(KBValidationError):
+        kb.upsert({"scope": _scope(), "kind": "pitfall", "slug": "abcdef-1", "importance": 0.5})
+    with pytest.raises(KBValidationError):
+        kb.upsert({"scope": _scope(), "kind": "pitfall", "slug": "abcdef-2", "importance": 0.5})
+    out = kb.upsert({"scope": _scope(), "kind": "pitfall", "slug": "abcdef-3", "importance": 0.5})
+    assert out["created"] is True
+
+
+def test_batch_insert_with_upsert_on_conflict():
+    kb = InMemoryKBClient()
+    items = [
+        {"scope": _scope(), "kind": "pitfall", "slug": "abcdef-1", "importance": 0.5},
+        {"scope": _scope(), "kind": "pitfall", "slug": "abcdef-2", "importance": 0.5},
+    ]
+    out = kb.batch_insert(items)
+    assert out["count"] == 2
+
+
+def test_list_default_excludes_deleted_rows():
+    kb = InMemoryKBClient()
+    out = kb.upsert({"scope": _scope(), "kind": "pitfall", "slug": "abcdef-1", "importance": 0.5})
+    rid = out["row"]["id"]
+    kb._rows[rid].deleted = True
+    assert kb.list(scope_filter=_scope())["entries"] == []
+    assert kb.list(scope_filter=_scope(), include_deleted=True)["entries"]
+
+
+def test_list_scope_value_normalisation_handles_uppercase_in_filter_too():
+    kb = InMemoryKBClient()
+    kb.upsert({"scope": _scope(), "kind": "pitfall", "slug": "abcdef-1", "importance": 0.5})
+    out = kb.list(scope_filter={"model": "DEEPSEEK-R1"})
+    assert out["entries"]

--- a/critic-agent/runtime/tests/test_inbox_parser.py
+++ b/critic-agent/runtime/tests/test_inbox_parser.py
@@ -1,0 +1,185 @@
+"""Tests for :mod:`runtime.inbox_parser`.
+
+The corpus mirrors what ``Coordinator._compose_prompt`` actually emits, plus a
+handful of degraded inputs that we want to handle without crashing.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+from runtime.inbox_parser import (
+    InboxRow,
+    ParsedPrompt,
+    parse_inbox_prompt,
+)
+
+
+def _build_prompt(*, shared: str, inbox_title: str, inbox_body: str) -> str:
+    return (
+        "=== Shared session state ===\n"
+        f"{shared.rstrip()}\n"
+        f"=== {inbox_title} ===\n"
+        f"{inbox_body.rstrip()}\n"
+    )
+
+
+def test_parse_minimal_proposal_inbox():
+    text = _build_prompt(
+        shared="session_id=sess_1 model=Qwen3-14B framework=sglang baseline_tput=1200",
+        inbox_title="Inbox for critic (newest last)",
+        inbox_body=(
+            "  seq=12 msg_id=abc1 from=orchestration topic=proposal "
+            "payload={'action_name': 'kernel_opt', 'predicted_gain_pct': 4.2}"
+        ),
+    )
+    parsed = parse_inbox_prompt(text)
+    assert isinstance(parsed, ParsedPrompt)
+    assert parsed.agent_name == "critic"
+    assert parsed.shared_state["model"] == "Qwen3-14B"
+    assert parsed.shared_state["framework"] == "sglang"
+    assert parsed.shared_state["baseline_tput"] == "1200"
+    assert len(parsed.inbox) == 1
+    row = parsed.inbox[0]
+    assert isinstance(row, InboxRow)
+    assert row.seq == 12
+    assert row.msg_id == "abc1"
+    assert row.topic == "proposal"
+    assert row.payload == {"action_name": "kernel_opt", "predicted_gain_pct": 4.2}
+    assert len(parsed.proposals) == 1
+    assert parsed.proposals[0].action_name == "kernel_opt"
+    assert parsed.proposals[0].predicted_gain_pct == 4.2
+
+
+def test_parse_multiple_topics_only_extracts_proposals():
+    text = _build_prompt(
+        shared="model=qwen framework=vllm",
+        inbox_title="Inbox for critic (newest last)",
+        inbox_body=(
+            "  seq=1 msg_id=aaa1 from=orchestration topic=proposal payload={'action_name':'baseline'}\n"
+            "  seq=2 msg_id=bbb2 from=orchestration topic=proposal payload={'action_name':'sweep'}\n"
+            "  seq=3 msg_id=ccc3 from=robustness topic=alert payload={'severity':'low'}\n"
+            "  seq=4 msg_id=ddd4 from=kernel topic=request payload={'kind':'kernel_opt'}"
+        ),
+    )
+    parsed = parse_inbox_prompt(text)
+    assert [r.topic for r in parsed.inbox] == ["proposal", "proposal", "alert", "request"]
+    assert sorted(p.msg_id for p in parsed.proposals) == ["aaa1", "bbb2"]
+
+
+def test_parse_inbox_with_no_messages_returns_empty():
+    text = (
+        "=== Shared session state ===\n"
+        "model=qwen\n"
+        "=== Inbox for critic ===\n"
+        "(no new messages)\n"
+    )
+    parsed = parse_inbox_prompt(text)
+    assert parsed.agent_name == "critic"
+    assert parsed.inbox == []
+    assert parsed.proposals == []
+
+
+def test_unparseable_payload_does_not_emit_proposal_but_keeps_row():
+    text = _build_prompt(
+        shared="model=qwen",
+        inbox_title="Inbox for critic",
+        inbox_body=(
+            "  seq=1 msg_id=zzz from=orchestration topic=proposal payload=NOT_A_DICT_AT_ALL"
+        ),
+    )
+    parsed = parse_inbox_prompt(text)
+    assert len(parsed.inbox) == 1
+    assert parsed.inbox[0].payload is None
+    assert parsed.inbox[0].raw_payload == "NOT_A_DICT_AT_ALL"
+    assert parsed.proposals == []
+
+
+def test_malformed_inbox_line_lands_in_extras():
+    text = _build_prompt(
+        shared="model=qwen",
+        inbox_title="Inbox for critic",
+        inbox_body=(
+            "  seq=1 msg_id=ok from=o topic=proposal payload={'action_name':'baseline'}\n"
+            "  totally bogus line"
+        ),
+    )
+    parsed = parse_inbox_prompt(text)
+    assert len(parsed.inbox) == 1
+    assert "malformed_inbox" in parsed.extras
+    assert "totally bogus line" in parsed.extras["malformed_inbox"]
+
+
+def test_unknown_section_preserved_in_extras():
+    text = (
+        "=== Shared session state ===\n"
+        "model=qwen\n"
+        "=== Some Future Section ===\n"
+        "anything goes here\n"
+        "=== Inbox for critic ===\n"
+        "(no new messages)\n"
+    )
+    parsed = parse_inbox_prompt(text)
+    assert parsed.extras["Some Future Section"] == "anything goes here"
+
+
+def test_kb_hints_section_preserved_for_orchestration_role():
+    text = textwrap.dedent(
+        """\
+        === Shared session state ===
+        model=qwen framework=sglang
+        === Knowledge base hints ===
+        - prefer dispatch fix before kernel rewrite
+        === Inbox for orchestration (newest last) ===
+        (no new messages)
+        """
+    )
+    parsed = parse_inbox_prompt(text)
+    assert parsed.agent_name == "orchestration"
+    assert "dispatch" in parsed.kb_hints_text
+
+
+def test_payload_with_nested_quotes_round_trips():
+    payload_repr = "{'reason': \"can't compare\"}"
+    text = _build_prompt(
+        shared="model=qwen",
+        inbox_title="Inbox for critic",
+        inbox_body=f"  seq=1 msg_id=h1 from=o topic=proposal payload={payload_repr}",
+    )
+    parsed = parse_inbox_prompt(text)
+    assert parsed.inbox[0].payload == {"reason": "can't compare"}
+
+
+def test_payload_json_form_also_supported():
+    text = _build_prompt(
+        shared="model=qwen",
+        inbox_title="Inbox for critic",
+        inbox_body=(
+            "  seq=1 msg_id=h1 from=o topic=proposal "
+            'payload={"action_name": "baseline", "predicted_gain_pct": 0}'
+        ),
+    )
+    parsed = parse_inbox_prompt(text)
+    assert parsed.proposals[0].action_name == "baseline"
+    assert parsed.proposals[0].predicted_gain_pct == 0.0
+
+
+def test_shared_state_preserves_value_with_spaces():
+    text = (
+        "=== Shared session state ===\n"
+        "model=Qwen3-14B objective=throughput baseline_label=Baseline before patch\n"
+        "=== Inbox for critic ===\n"
+        "(no new messages)\n"
+    )
+    parsed = parse_inbox_prompt(text)
+    assert parsed.shared_state["baseline_label"] == "Baseline before patch"
+
+
+def test_multiple_inbox_sections_are_treated_independently():
+    text = (
+        "=== Inbox for critic (newest last) ===\n"
+        "  seq=1 msg_id=a from=o topic=proposal payload={'action_name':'baseline'}\n"
+    )
+    parsed = parse_inbox_prompt(text)
+    assert parsed.agent_name == "critic"
+    assert len(parsed.proposals) == 1

--- a/critic-agent/runtime/tests/test_intent_envelope.py
+++ b/critic-agent/runtime/tests/test_intent_envelope.py
@@ -1,0 +1,185 @@
+"""Validation + parity tests for :mod:`runtime.intent_envelope`.
+
+The parity assertions mirror the Coordinator-side schema in
+``inference_optimizer/orchestrator/intent_parser.py`` (REVIEW_VERDICT
+required keys) and ``policy.REVIEW_VERDICTS`` so a future Coordinator
+upgrade fails loudly here first.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from runtime.errors import IntentEnvelopeValidationError
+from runtime.intent_envelope import (
+    ALLOWED_VERDICTS,
+    ALLOWED_VERDICT_SOURCES,
+    DEFAULT_HEARTBEAT_TOPIC,
+    Intent,
+    IntentEnvelope,
+    build_advice_intent,
+    build_envelope,
+    build_heartbeat_intent,
+    build_review_verdict_intent,
+    validate_envelope,
+)
+
+
+def test_allowed_verdicts_match_design_v06():
+    assert ALLOWED_VERDICTS == frozenset(
+        {"approve", "reject", "redirect", "advise", "needs_review"}
+    )
+
+
+def test_allowed_verdict_sources_match_schema():
+    assert ALLOWED_VERDICT_SOURCES == frozenset(
+        {"critic", "mock", "timeout", "critic_unavailable"}
+    )
+
+
+def test_build_review_verdict_intent_minimal():
+    intent = build_review_verdict_intent(
+        target_proposal_msg_id="abc1",
+        verdict="approve",
+    )
+    assert intent.intent_type == "review_verdict"
+    assert intent.payload["target_proposal_msg_id"] == "abc1"
+    assert intent.payload["verdict"] == "approve"
+    assert intent.payload["source"] == "critic"
+    assert intent.payload["risks"] == []
+
+
+def test_build_review_verdict_intent_full():
+    intent = build_review_verdict_intent(
+        target_proposal_msg_id="abc1",
+        verdict="redirect",
+        reasoning="prefer dispatch fix first",
+        confidence="high",
+        predicted_gain_pct=2.5,
+        kb_evidence=["kb_1"],
+        packet_evidence=["benchmark.after.gain_pct"],
+        risks=[{"type": "active_path_unproven", "severity": "blocker"}],
+        required_evidence=["dispatch_evidence"],
+        alternative_action="profile",
+        notes=["see kb_1"],
+    )
+    p = intent.payload
+    assert p["confidence"] == "high"
+    assert p["alternative_action"] == "profile"
+    assert p["risks"][0]["type"] == "active_path_unproven"
+
+
+def test_build_review_verdict_rejects_bad_verdict():
+    with pytest.raises(IntentEnvelopeValidationError, match="verdict"):
+        build_review_verdict_intent(
+            target_proposal_msg_id="abc1", verdict="lgtm"
+        )
+
+
+def test_build_review_verdict_rejects_bad_source():
+    with pytest.raises(IntentEnvelopeValidationError, match="source"):
+        build_review_verdict_intent(
+            target_proposal_msg_id="abc1", verdict="approve", source="someone"
+        )
+
+
+def test_build_review_verdict_rejects_empty_target():
+    with pytest.raises(IntentEnvelopeValidationError, match="target"):
+        build_review_verdict_intent(
+            target_proposal_msg_id="", verdict="approve"
+        )
+
+
+def test_build_heartbeat_intent_default():
+    h = build_heartbeat_intent()
+    assert h.intent_type == "send_message"
+    assert h.payload["topic"] == DEFAULT_HEARTBEAT_TOPIC
+
+
+def test_build_envelope_with_intents_validates():
+    env = build_envelope([
+        build_review_verdict_intent(target_proposal_msg_id="m1", verdict="approve"),
+        build_review_verdict_intent(target_proposal_msg_id="m2", verdict="reject"),
+    ])
+    d = env.to_dict()
+    assert len(d["intents"]) == 2
+    assert d["intents"][0]["payload"]["target_proposal_msg_id"] == "m1"
+
+
+def test_build_envelope_empty_falls_back_to_heartbeat():
+    env = build_envelope([])
+    d = env.to_dict()
+    assert len(d["intents"]) == 1
+    assert d["intents"][0]["intent_type"] == "send_message"
+    assert d["intents"][0]["payload"]["topic"] == DEFAULT_HEARTBEAT_TOPIC
+
+
+def test_validate_envelope_accepts_well_formed_dict():
+    env = validate_envelope({
+        "intents": [
+            {
+                "intent_type": "review_verdict",
+                "payload": {
+                    "target_proposal_msg_id": "abc",
+                    "verdict": "approve",
+                    "source": "critic",
+                    "reasoning": "ok",
+                },
+            }
+        ]
+    })
+    assert isinstance(env, IntentEnvelope)
+    assert env.intents[0].payload["verdict"] == "approve"
+
+
+def test_validate_envelope_rejects_disallowed_intent():
+    with pytest.raises(IntentEnvelopeValidationError, match="not.*Critic"):
+        validate_envelope({
+            "intents": [
+                {
+                    "intent_type": "delegate",
+                    "payload": {"action_name": "baseline"},
+                }
+            ]
+        })
+
+
+def test_validate_envelope_rejects_missing_payload_key():
+    with pytest.raises(IntentEnvelopeValidationError, match="target"):
+        validate_envelope({
+            "intents": [
+                {"intent_type": "review_verdict", "payload": {"verdict": "approve"}}
+            ]
+        })
+
+
+def test_validate_envelope_rejects_empty_list():
+    with pytest.raises(IntentEnvelopeValidationError, match="non-empty"):
+        validate_envelope({"intents": []})
+
+
+def test_validate_envelope_rejects_unknown_verdict():
+    with pytest.raises(IntentEnvelopeValidationError, match="verdict"):
+        validate_envelope({
+            "intents": [
+                {
+                    "intent_type": "review_verdict",
+                    "payload": {
+                        "target_proposal_msg_id": "x",
+                        "verdict": "yes",
+                    },
+                }
+            ]
+        })
+
+
+def test_advice_intent_carries_optional_target():
+    intent = build_advice_intent("watch dispatch", target_proposal_msg_id="m1")
+    assert intent.payload["topic"] == "advice"
+    assert intent.payload["about_proposal_msg_id"] == "m1"
+
+
+def test_intent_to_dict_round_trip():
+    a = Intent(intent_type="send_message", payload={"topic": "heartbeat"})
+    out = validate_envelope({"intents": [a.to_dict()]})
+    assert out.intents[0].intent_type == "send_message"

--- a/critic-agent/runtime/tests/test_kb_breaker.py
+++ b/critic-agent/runtime/tests/test_kb_breaker.py
@@ -1,0 +1,259 @@
+"""Circuit-breaker behaviour for KB unreachability.
+
+These tests cover the contract:
+
+* When the KB transport fails, ``KBWriter.list_priors`` short-circuits
+  on subsequent calls within the cooldown window, returning an empty
+  ``priors`` list with ``cache="kb_unreachable"`` and never raising.
+* Writes (``write_verdict`` / ``write_kb_drafts`` / ``add_contradiction``)
+  honour the open breaker and refuse to make remote calls.
+* A successful KB call resets the breaker.
+* ``DecisionReviewer.prepare_review`` reflects the breaker state in
+  ``judge_bundle.kb_read_skipped_reason`` so the SKILL knows priors are
+  missing because of an outage rather than a clean miss.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from runtime.dead_letter import DeadLetter
+from runtime.decision_reviewer import DecisionReviewer
+from runtime.errors import KBTransportError, KBValidationError
+from runtime.in_memory_kb_client import InMemoryKBClient
+from runtime.kb_writer import KBWriter, WriteContext
+from runtime.session_memory import SessionMemory
+
+
+class _FlakyKBClient(InMemoryKBClient):
+    """InMemoryKBClient with deterministic transport failure injection."""
+
+    def __init__(self):
+        super().__init__()
+        self._fail_count: dict[str, int] = {}
+
+    def fail_next(self, endpoint: str, times: int = 1) -> None:
+        self._fail_count[endpoint] = self._fail_count.get(endpoint, 0) + times
+
+    def _consume(self, endpoint: str) -> None:
+        remaining = self._fail_count.get(endpoint, 0)
+        if remaining > 0:
+            self._fail_count[endpoint] = remaining - 1
+            raise KBTransportError(f"{endpoint}: simulated transport error")
+
+    def list(self, **kwargs):
+        self._consume("list")
+        return super().list(**kwargs)
+
+    def upsert(self, payload):
+        self._consume("upsert")
+        return super().upsert(payload)
+
+    def batch_insert(self, items, *, on_conflict="upsert"):
+        self._consume("batch_insert")
+        return super().batch_insert(items, on_conflict=on_conflict)
+
+    def add_edges(self, edges):
+        self._consume("edges/add")
+        return super().add_edges(edges)
+
+
+@pytest.fixture()
+def writer(tmp_path):
+    sm = SessionMemory(root=tmp_path / "sm")
+    dlq = DeadLetter(root=tmp_path / "dlq")
+    kb = _FlakyKBClient()
+    w = KBWriter(kb, session_memory=sm, dead_letter=dlq)
+    return w, kb, sm, dlq
+
+
+def _scope():
+    return {
+        "org": "hyperloom",
+        "framework": "sglang",
+        "model": "deepseek-r1",
+        "model_family": "deepseek",
+        "workload": "decode",
+        "precision": "fp8",
+    }
+
+
+def test_list_priors_short_circuits_after_first_transport_error(writer):
+    w, kb, _, _ = writer
+    kb.fail_next("list", times=1)
+    out1 = w.list_priors(scope=_scope())
+    assert out1["cache"] == "kb_unreachable"
+    assert out1["priors"] == []
+    assert "error" in out1
+    assert w.is_kb_unreachable() is True
+
+    # Second call should not even hit the transport because the breaker is
+    # open. We assert this by clearing the failure queue: if the call
+    # actually went through, list() would succeed and cache would be 'miss'.
+    out2 = w.list_priors(scope=_scope())
+    assert out2["cache"] == "kb_unreachable"
+    assert "error" not in out2  # no transport call made
+    assert out2["breaker"]["open"] is True
+
+
+def test_list_priors_validation_error_does_not_open_breaker(writer):
+    w, kb, _, _ = writer
+
+    def boom(**kwargs):
+        raise KBValidationError("422 bad scope")
+
+    kb.list = boom  # type: ignore[method-assign]
+    out = w.list_priors(scope=_scope())
+    assert out["cache"] == "miss"
+    assert out["priors"] == []
+    assert "error" in out
+    assert w.is_kb_unreachable() is False
+
+
+def test_list_priors_resets_breaker_on_recovery(writer):
+    w, kb, _, _ = writer
+    kb.fail_next("list", times=1)
+    assert w.list_priors(scope=_scope())["cache"] == "kb_unreachable"
+    # Force the breaker closed manually so we can re-attempt within cooldown.
+    w._unreachable_until = 0.0
+    w._consecutive_failures = 0
+    out = w.list_priors(scope=_scope())
+    assert out["cache"] == "miss"
+    assert w._consecutive_failures == 0
+
+
+def test_breaker_threshold_higher_than_one(tmp_path, monkeypatch):
+    monkeypatch.setenv("CRITIC_KB_BREAKER_THRESHOLD", "3")
+    sm = SessionMemory(root=tmp_path / "sm")
+    kb = _FlakyKBClient()
+    w = KBWriter(kb, session_memory=sm, dead_letter=DeadLetter(root=tmp_path / "dlq"))
+    kb.fail_next("list", times=2)
+    assert w.list_priors(scope=_scope())["cache"] == "kb_unreachable"
+    assert w.is_kb_unreachable() is False  # only 1 failure recorded
+    assert w.list_priors(scope=_scope())["cache"] == "kb_unreachable"
+    assert w.is_kb_unreachable() is False  # 2 failures, still under threshold
+    kb.fail_next("list", times=1)
+    assert w.list_priors(scope=_scope())["cache"] == "kb_unreachable"
+    assert w.is_kb_unreachable() is True  # 3rd failure trips it
+
+
+def test_write_verdict_disabled_when_breaker_open(writer):
+    w, _, _, _ = writer
+    w.force_kb_unreachable()
+    res = w.write_verdict(
+        verdict={
+            "verdict": "reject",
+            "reasoning": "active dispatch path unproven for this kernel",
+            "packet_evidence": ["benchmark.after.gain_pct"],
+        },
+        packet_context={
+            "framework": "sglang", "model": "deepseek-r1",
+            "model_family": "deepseek", "workload": "decode", "precision": "fp8",
+        },
+        ctx=WriteContext(session_id="s1", review_id="rev"),
+    )
+    assert res.status == "disabled"
+    assert res.detail["reason"] == "kb_unreachable"
+    assert res.detail["breaker"]["open"] is True
+
+
+def test_write_kb_drafts_disabled_when_breaker_open(writer):
+    w, _, _, _ = writer
+    w.force_kb_unreachable()
+    res = w.write_kb_drafts(
+        kb_drafts=[{
+            "category": "kernel_optimization",
+            "action": "patch the active dispatch path",
+            "lesson": "active dispatch path must stay in sync",
+            "tags": [],
+        }],
+        packet_context={
+            "framework": "sglang", "model": "deepseek-r1",
+            "model_family": "deepseek", "workload": "decode", "precision": "fp8",
+        },
+        ctx=WriteContext(session_id="s2"),
+    )
+    assert res.status == "disabled"
+    assert res.detail["reason"] == "kb_unreachable"
+
+
+def test_write_verdict_dead_letters_then_opens_breaker(writer):
+    w, kb, _, dlq = writer
+    kb.fail_next("upsert", times=1)
+    res = w.write_verdict(
+        verdict={
+            "verdict": "reject",
+            "reasoning": "active dispatch path unproven for this kernel",
+            "packet_evidence": ["benchmark.after.gain_pct"],
+        },
+        packet_context={
+            "framework": "sglang", "model": "deepseek-r1",
+            "model_family": "deepseek", "workload": "decode", "precision": "fp8",
+        },
+        ctx=WriteContext(session_id="s_dlq", review_id="rev"),
+    )
+    assert res.status == "dead_lettered"
+    assert res.detail["reason"] == "transport_error"
+    assert dlq.files()
+    # Subsequent write would short-circuit on the breaker.
+    assert w.is_kb_unreachable() is True
+
+
+def test_decision_reviewer_marks_bundle_when_breaker_open(tmp_path):
+    sm = SessionMemory(root=tmp_path / "sm")
+    kb = _FlakyKBClient()
+    writer = KBWriter(kb, session_memory=sm)
+    rev = DecisionReviewer(session_memory=sm, kb_writer=writer)
+    writer.force_kb_unreachable()
+
+    bundle = rev.prepare_review({
+        "kind": "coordinator_inbox",
+        "session_id": "sess_breaker",
+        "raw_prompt": (
+            "=== Shared session state ===\n"
+            "model=qwen3-14b framework=sglang workload=decode precision=fp8\n"
+            "=== Inbox for critic ===\n"
+            "  seq=1 msg_id=mmm from=orchestration topic=proposal payload={'action_name': 'kernel_opt'}\n"
+        ),
+    })
+    assert bundle.kb_read_skipped_reason == "kb_unreachable"
+    assert any("KB service unreachable" in n for n in bundle.notes)
+    assert bundle.review_constraints["kb_breaker"]["open"] is True
+
+
+def test_decision_reviewer_marks_bundle_when_kb_read_disabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("KB_READ_ENABLED", "false")
+    sm = SessionMemory(root=tmp_path / "sm")
+    writer = KBWriter(InMemoryKBClient(), session_memory=sm)
+    rev = DecisionReviewer(session_memory=sm, kb_writer=writer)
+    bundle = rev.prepare_review({
+        "kind": "coordinator_inbox",
+        "session_id": "sess_disabled",
+        "raw_prompt": (
+            "=== Shared session state ===\n"
+            "model=qwen3-14b framework=sglang\n"
+            "=== Inbox for critic ===\n"
+            "  seq=1 msg_id=mmm from=orchestration topic=proposal payload={}\n"
+        ),
+    })
+    assert bundle.kb_read_skipped_reason == "kb_read_disabled"
+
+
+def test_breaker_reflects_per_request_failures_in_bundle(tmp_path):
+    sm = SessionMemory(root=tmp_path / "sm")
+    kb = _FlakyKBClient()
+    writer = KBWriter(kb, session_memory=sm)
+    rev = DecisionReviewer(session_memory=sm, kb_writer=writer)
+    kb.fail_next("list", times=1)
+    bundle = rev.prepare_review({
+        "kind": "coordinator_inbox",
+        "session_id": "sess_per_request",
+        "raw_prompt": (
+            "=== Shared session state ===\n"
+            "model=qwen3-14b framework=sglang workload=decode precision=fp8\n"
+            "=== Inbox for critic ===\n"
+            "  seq=1 msg_id=mmm from=orchestration topic=proposal payload={'action_name': 'baseline'}\n"
+        ),
+    })
+    assert bundle.kb_read_skipped_reason == "kb_unreachable"
+    assert bundle.kb_priors_by_proposal["mmm"] == []

--- a/critic-agent/runtime/tests/test_kb_writer.py
+++ b/critic-agent/runtime/tests/test_kb_writer.py
@@ -1,0 +1,195 @@
+"""End-to-end tests for :class:`runtime.kb_writer.KBWriter`.
+
+We use :class:`runtime.in_memory_kb_client.InMemoryKBClient` so the tests
+exercise the same surface a production HTTP client would, but without
+network IO. Dead-letter and session-memory paths use the temp fixtures.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from runtime.dead_letter import DeadLetter
+from runtime.in_memory_kb_client import InMemoryKBClient
+from runtime.kb_writer import KBWriter, WriteContext
+from runtime.session_memory import SessionMemory
+
+
+@pytest.fixture()
+def packet_context():
+    return {
+        "framework": "sglang",
+        "model": "deepseek-r1-0528-fp8",
+        "model_family": "deepseek",
+        "workload": "decode",
+        "precision": "fp8",
+    }
+
+
+@pytest.fixture()
+def writer(tmp_path):
+    kb = InMemoryKBClient()
+    sm = SessionMemory(root=tmp_path / "sm")
+    dlq = DeadLetter(root=tmp_path / "dlq")
+    return KBWriter(kb, session_memory=sm, dead_letter=dlq), kb, sm, dlq
+
+
+def test_write_verdict_skipped_for_advise(writer, packet_context):
+    w, kb, _, _ = writer
+    res = w.write_verdict(
+        verdict={
+            "verdict": "advise",
+            "reasoning": "small concurrency mismatch",
+            "packet_evidence": ["benchmark.after.gain_pct"],
+        },
+        packet_context=packet_context,
+        ctx=WriteContext(session_id="s1"),
+    )
+    assert res.status == "skipped"
+    assert kb.all_rows() == []
+
+
+def test_write_verdict_reject_creates_pitfall(writer, packet_context):
+    w, kb, _, _ = writer
+    res = w.write_verdict(
+        verdict={
+            "verdict": "reject",
+            "reasoning": "active dispatch path unproven for this kernel",
+            "packet_evidence": ["benchmark.after.gain_pct"],
+            "kb_evidence": [],
+            "confidence": "high",
+            "risks": [{"type": "active_path_unproven", "severity": "blocker"}],
+        },
+        packet_context=packet_context,
+        ctx=WriteContext(session_id="s1", review_id="rev_1", topic="active dispatch path unproven"),
+    )
+    assert res.status == "ok"
+    rows = kb.all_rows()
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "pitfall"
+    assert rows[0]["importance"] <= 0.84
+
+
+def test_write_verdict_skipped_when_disabled(monkeypatch, writer, packet_context):
+    w, kb, _, _ = writer
+    monkeypatch.setenv("KB_WRITE_ENABLED", "false")
+    w.write_enabled = False  # honour env at runtime
+    res = w.write_verdict(
+        verdict={"verdict": "reject", "reasoning": "x"},
+        packet_context=packet_context,
+        ctx=WriteContext(session_id="s1"),
+    )
+    assert res.status == "disabled"
+
+
+def test_write_verdict_dead_letters_on_validation_error(writer, packet_context):
+    w, kb, sm, dlq = writer
+    kb.simulate_failure(endpoint="upsert", times=1, error={"code": 422})
+    res = w.write_verdict(
+        verdict={
+            "verdict": "reject",
+            "reasoning": "active dispatch path unproven for this kernel",
+            "packet_evidence": ["benchmark.after.gain_pct"],
+        },
+        packet_context=packet_context,
+        ctx=WriteContext(session_id="s1", review_id="rev"),
+    )
+    assert res.status == "dead_lettered"
+    files = dlq.files()
+    assert len(files) == 1
+    line = files[0].read_text("utf-8").splitlines()[0]
+    record = json.loads(line)
+    assert record["endpoint"] == "upsert"
+    assert "session_id" in record["context"]
+
+
+def test_write_kb_drafts_batch_inserts_and_filters_unknown_categories(writer, packet_context):
+    w, kb, _, _ = writer
+    drafts = [
+        {
+            "category": "kernel_optimization",
+            "action": "Patch fused attention kernel for Qwen3-14B on MI355X.",
+            "lesson": "Active dispatch path must be updated jointly.",
+            "tags": ["attention"],
+            "result": {"status": "KEEP", "gain_pct": 4.2},
+            "confidence": 0.9,
+        },
+        {
+            "category": "definitely_not_a_real_category",
+            "action": "x",
+        },
+    ]
+    res = w.write_kb_drafts(
+        kb_drafts=drafts,
+        packet_context=packet_context,
+        ctx=WriteContext(session_id="s1", review_id="rev_2"),
+    )
+    assert res.status == "ok"
+    assert len(kb.all_rows()) == 1
+    assert kb.all_rows()[0]["kind"] == "technique"
+    rejected = res.detail["rejected"]
+    assert rejected and rejected[0]["draft"]["category"] == "definitely_not_a_real_category"
+
+
+def test_list_priors_uses_session_memory_cache(writer, packet_context):
+    w, kb, sm, _ = writer
+    kb.upsert({
+        "scope": {
+            "org": "hyperloom",
+            **{k: packet_context[k] for k in ("framework", "model", "model_family", "workload", "precision")},
+        },
+        "kind": "pitfall",
+        "slug": "active-path-unproven-pitfall",
+        "importance": 0.5,
+        "metadata": {"topic": "active path"},
+    })
+    scope = {
+        "org": "hyperloom",
+        **{k: packet_context[k] for k in ("framework", "model", "model_family", "workload", "precision")},
+    }
+    ctx = WriteContext(session_id="s_cache")
+    first = w.list_priors(scope=scope, kind="pitfall", topic="active path", ctx=ctx)
+    assert first["cache"] == "miss"
+    assert first["priors"]
+    second = w.list_priors(scope=scope, kind="pitfall", topic="active path", ctx=ctx)
+    assert second["cache"] == "hit"
+    assert second["priors"] == first["priors"]
+
+
+def test_add_contradiction_writes_edge(writer, packet_context):
+    w, kb, _, _ = writer
+    a = kb.upsert({
+        "scope": {
+            "org": "hyperloom",
+            **{k: packet_context[k] for k in ("framework", "model", "model_family", "workload", "precision")},
+        },
+        "kind": "pitfall", "slug": "abcdef-1", "importance": 0.5,
+    })["row"]["id"]
+    b = kb.upsert({
+        "scope": {
+            "org": "hyperloom",
+            **{k: packet_context[k] for k in ("framework", "model", "model_family", "workload", "precision")},
+        },
+        "kind": "pitfall", "slug": "abcdef-2", "importance": 0.5,
+    })["row"]["id"]
+    res = w.add_contradiction(
+        new_id=a, old_ids=[b], ctx=WriteContext(session_id="s1"),
+    )
+    assert res.status == "ok"
+    rows = {r["id"]: r for r in kb.all_rows()}
+    assert b in rows[a]["edges"]["contradicts"]
+    assert a in rows[b]["edges"]["contradicts"]
+
+
+def test_write_verdict_with_missing_critical_scope_skipped(writer):
+    w, kb, _, _ = writer
+    res = w.write_verdict(
+        verdict={"verdict": "reject", "reasoning": "x"},
+        packet_context={"framework": "sglang"},  # model missing
+        ctx=WriteContext(session_id="s1"),
+    )
+    assert res.status == "skipped"
+    assert "scope_construction_failed" in res.detail.get("reason", "")

--- a/critic-agent/runtime/tests/test_metrics.py
+++ b/critic-agent/runtime/tests/test_metrics.py
@@ -1,0 +1,39 @@
+"""Tests for the in-process metrics shim."""
+
+from __future__ import annotations
+
+from runtime.metrics import (
+    CRITIC_KB_WRITE_TOTAL,
+    MetricsRegistry,
+    get_registry,
+)
+
+
+def test_counter_increments_per_label_set():
+    reg = MetricsRegistry()
+    reg.counter("c").inc({"endpoint": "upsert", "status": "200"})
+    reg.counter("c").inc({"endpoint": "upsert", "status": "200"})
+    reg.counter("c").inc({"endpoint": "upsert", "status": "503"})
+    snap = reg.snapshot()
+    counter = snap["counters"]["c"]
+    assert counter[(("endpoint", "upsert"), ("status", "200"))] == 2
+    assert counter[(("endpoint", "upsert"), ("status", "503"))] == 1
+
+
+def test_histogram_collects_samples():
+    reg = MetricsRegistry()
+    reg.histogram("h").observe(0.1, {"endpoint": "upsert"})
+    reg.histogram("h").observe(0.2, {"endpoint": "upsert"})
+    snap = reg.snapshot()
+    h = snap["histograms"]["h"]
+    assert h[(("endpoint", "upsert"),)] == [0.1, 0.2]
+
+
+def test_singleton_registry_persists_across_calls():
+    a = get_registry()
+    a.reset()
+    a.counter(CRITIC_KB_WRITE_TOTAL).inc({"endpoint": "upsert", "status": "200"})
+    b = get_registry()
+    assert a is b
+    assert b.snapshot()["counters"][CRITIC_KB_WRITE_TOTAL]
+    a.reset()

--- a/critic-agent/runtime/tests/test_request_models.py
+++ b/critic-agent/runtime/tests/test_request_models.py
@@ -1,0 +1,159 @@
+"""Schema validation for :mod:`critic-agent.runtime.request_models`.
+
+The test set is intentionally exhaustive on edge cases because the rest
+of the runtime trusts these dataclasses.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from runtime.request_models import (
+    COORDINATOR_INBOX,
+    DECISION_REQUEST,
+    CriticRequest,
+    Proposal,
+    parse_request,
+)
+from runtime.errors import RequestValidationError
+
+
+def test_parse_coordinator_inbox_with_raw_prompt():
+    req = parse_request({
+        "kind": COORDINATOR_INBOX,
+        "session_id": "sess_1",
+        "raw_prompt": "=== Inbox for critic ===\n  seq=1 msg_id=abc topic=proposal payload={}",
+    })
+    assert isinstance(req, CriticRequest)
+    assert req.kind == COORDINATOR_INBOX
+    assert req.session_id == "sess_1"
+    assert req.raw_prompt is not None
+    assert req.proposals == []
+    assert req.context == {}
+    assert req.decision_id is None
+
+
+def test_parse_coordinator_inbox_requires_raw_prompt():
+    with pytest.raises(RequestValidationError, match="raw_prompt"):
+        parse_request({
+            "kind": COORDINATOR_INBOX,
+            "session_id": "sess_1",
+        })
+
+
+def test_parse_decision_request_assigns_decision_id_when_missing():
+    req = parse_request({
+        "kind": DECISION_REQUEST,
+        "session_id": "sess_1",
+        "messages": [{"role": "coordinator", "content": "hi"}],
+        "context": {"model": "Qwen3-14B", "framework": "sglang"},
+        "decision": {"summary": "adopt patch x"},
+    })
+    assert req.kind == DECISION_REQUEST
+    assert req.decision_id is not None
+    assert req.decision_id.startswith("dec_")
+    assert req.context == {"model": "Qwen3-14B", "framework": "sglang"}
+    assert req.messages and req.messages[0]["role"] == "coordinator"
+
+
+def test_parse_decision_request_keeps_explicit_decision_id():
+    req = parse_request({
+        "kind": DECISION_REQUEST,
+        "session_id": "sess_1",
+        "decision_id": "dec_known",
+    })
+    assert req.decision_id == "dec_known"
+
+
+def test_parse_unknown_kind_rejected():
+    with pytest.raises(RequestValidationError, match="kind"):
+        parse_request({"kind": "wat", "session_id": "sess_1"})
+
+
+def test_parse_missing_session_rejected():
+    with pytest.raises(RequestValidationError, match="session_id"):
+        parse_request({"kind": COORDINATOR_INBOX, "raw_prompt": "x"})
+
+
+def test_parse_proposal_normalises_action_and_gain():
+    req = parse_request({
+        "kind": COORDINATOR_INBOX,
+        "session_id": "s",
+        "raw_prompt": "x",
+        "proposals": [
+            {
+                "msg_id": "abc",
+                "from_agent": "orchestration",
+                "seq": 12,
+                "payload": {
+                    "action_name": "kernel_opt",
+                    "predicted_gain_pct": 4.2,
+                    "extra": "ok",
+                },
+            }
+        ],
+    })
+    assert len(req.proposals) == 1
+    p = req.proposals[0]
+    assert isinstance(p, Proposal)
+    assert p.msg_id == "abc"
+    assert p.from_agent == "orchestration"
+    assert p.action_name == "kernel_opt"
+    assert p.predicted_gain_pct == pytest.approx(4.2)
+    assert p.payload["extra"] == "ok"
+    assert p.seq == 12
+
+
+def test_parse_proposal_rejects_non_dict_payload():
+    with pytest.raises(RequestValidationError, match="payload"):
+        parse_request({
+            "kind": COORDINATOR_INBOX,
+            "session_id": "s",
+            "raw_prompt": "x",
+            "proposals": [{"msg_id": "abc", "from_agent": "o", "payload": "no"}],
+        })
+
+
+def test_parse_proposal_rejects_non_int_seq():
+    with pytest.raises(RequestValidationError, match="seq"):
+        parse_request({
+            "kind": COORDINATOR_INBOX,
+            "session_id": "s",
+            "raw_prompt": "x",
+            "proposals": [{"msg_id": "abc", "from_agent": "o", "seq": "12"}],
+        })
+
+
+def test_parse_proposal_missing_msg_id():
+    with pytest.raises(RequestValidationError, match="msg_id"):
+        parse_request({
+            "kind": COORDINATOR_INBOX,
+            "session_id": "s",
+            "raw_prompt": "x",
+            "proposals": [{"from_agent": "o"}],
+        })
+
+
+def test_parse_messages_must_be_dicts():
+    with pytest.raises(RequestValidationError, match="messages"):
+        parse_request({
+            "kind": DECISION_REQUEST,
+            "session_id": "s",
+            "messages": ["not-a-dict"],
+        })
+
+
+def test_to_dict_round_trip_preserves_proposal_fields():
+    req = parse_request({
+        "kind": COORDINATOR_INBOX,
+        "session_id": "s",
+        "raw_prompt": "x",
+        "proposals": [{
+            "msg_id": "m1", "from_agent": "o",
+            "payload": {"action_name": "baseline"},
+        }],
+    })
+    d = req.to_dict()
+    assert d["proposals"][0]["msg_id"] == "m1"
+    assert d["proposals"][0]["action_name"] == "baseline"
+    assert d["proposals"][0]["predicted_gain_pct"] is None

--- a/critic-agent/runtime/tests/test_scope_builder.py
+++ b/critic-agent/runtime/tests/test_scope_builder.py
@@ -1,0 +1,111 @@
+"""Scope construction tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from runtime.errors import ScopeError
+from runtime.scope_builder import (
+    CRITICAL_SCOPE_KEYS,
+    OPTIONAL_SCOPE_KEYS,
+    ORG_DEFAULT,
+    build_scope,
+    derive_model_family,
+    scope_cache_key,
+)
+
+
+def test_org_defaults_to_hyperloom():
+    s = build_scope(
+        {"framework": "sglang", "model": "deepseek-r1", "model_family": "deepseek",
+         "workload": "decode", "precision": "fp8"}
+    )
+    assert s["org"] == ORG_DEFAULT
+
+
+def test_explicit_context_wins_over_session():
+    s = build_scope(
+        {"framework": "sglang", "model": "deepseek-r1"},
+        session_context={"framework": "vllm", "model_family": "deepseek",
+                         "workload": "decode", "precision": "fp8"},
+    )
+    assert s["framework"] == "sglang"
+    assert s["model_family"] == "deepseek"
+
+
+def test_normalises_value_trim_and_lowercase():
+    s = build_scope(
+        {"framework": "  SGLang ", "model": "DeepSeek-R1",
+         "model_family": "DeepSeek", "workload": "Decode", "precision": "FP8"}
+    )
+    assert s["framework"] == "sglang"
+    assert s["model"] == "deepseek-r1"
+    assert s["precision"] == "fp8"
+
+
+def test_unknown_treated_as_missing_and_filled_from_session():
+    s = build_scope(
+        {"framework": "unknown", "model": "deepseek-r1"},
+        session_context={"framework": "sglang"},
+    )
+    assert s["framework"] == "sglang"
+
+
+def test_optional_keys_only_present_when_known():
+    s_no_opt = build_scope(
+        {"framework": "sglang", "model": "deepseek-r1", "model_family": "deepseek",
+         "workload": "decode", "precision": "fp8"}
+    )
+    assert "scale" not in s_no_opt
+    s_with_opt = build_scope(
+        {"framework": "sglang", "model": "deepseek-r1", "model_family": "deepseek",
+         "workload": "decode", "precision": "fp8", "scale": "8xMI300", "objective": "throughput"}
+    )
+    assert s_with_opt["scale"] == "8xmi300"
+    assert s_with_opt["objective"] == "throughput"
+
+
+def test_critical_keys_missing_raises_by_default():
+    with pytest.raises(ScopeError, match="model"):
+        build_scope({"framework": "sglang"})
+
+
+def test_require_critical_false_returns_unknown_placeholder():
+    s = build_scope({"framework": "sglang"}, require_critical=False)
+    assert s["model"] == "unknown"
+    assert s["framework"] == "sglang"
+
+
+def test_model_family_derived_from_model_when_missing():
+    s = build_scope(
+        {"framework": "sglang", "model": "deepseek-r1-0528-fp8",
+         "workload": "decode", "precision": "fp8"}
+    )
+    assert s["model_family"] == "deepseek"
+
+
+def test_model_family_unknown_when_no_rule_matches():
+    s = build_scope(
+        {"framework": "sglang", "model": "phantom-2b",
+         "workload": "decode", "precision": "fp8"},
+        require_critical=False,
+    )
+    assert s["model_family"] == "unknown"
+
+
+def test_scope_cache_key_is_stable_across_dict_order():
+    a = scope_cache_key({"model": "x", "framework": "y"}, topic="t")
+    b = scope_cache_key({"framework": "y", "model": "x"}, topic="t")
+    assert a == b
+
+
+def test_critical_keys_constants():
+    assert "model" in CRITICAL_SCOPE_KEYS
+    assert "framework" in CRITICAL_SCOPE_KEYS
+    assert OPTIONAL_SCOPE_KEYS == ("scale", "objective")
+
+
+def test_derive_model_family_known_and_unknown():
+    assert derive_model_family("Qwen3-14B") == "qwen"
+    assert derive_model_family("Llama-4-405B") == "llama"
+    assert derive_model_family("phantom-2b") == ""

--- a/critic-agent/runtime/tests/test_session_memory.py
+++ b/critic-agent/runtime/tests/test_session_memory.py
@@ -1,0 +1,160 @@
+"""Tests for :mod:`runtime.session_memory`.
+
+We test against a temp directory so we don't touch the real
+``CRITIC_SESSION_MEMORY_DIR``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+
+import pytest
+
+from runtime.errors import SessionMemoryError
+from runtime.session_memory import (
+    DEFAULT_PRIOR_CACHE_TTL_SECONDS,
+    MergeResult,
+    SessionMemory,
+)
+
+
+def test_session_dir_rejects_path_traversal(tmp_session_root):
+    sm = SessionMemory(root=tmp_session_root)
+    with pytest.raises(SessionMemoryError):
+        sm.session_dir("../escape")
+    with pytest.raises(SessionMemoryError):
+        sm.session_dir("a/b")
+
+
+def test_load_context_when_absent_returns_empty(tmp_session_root):
+    sm = SessionMemory(root=tmp_session_root)
+    assert sm.load_context("sess_1") == {}
+
+
+def test_save_and_load_context_round_trip(tmp_session_root):
+    sm = SessionMemory(root=tmp_session_root)
+    ctx = {"model": "Qwen3-14B", "framework": "sglang"}
+    sm.save_context("sess_1", ctx)
+    assert sm.load_context("sess_1") == ctx
+
+
+def test_merge_context_explicit_wins_and_persists(tmp_session_root):
+    sm = SessionMemory(root=tmp_session_root)
+    sm.save_context("sess_1", {"model": "Qwen3-14B", "framework": "vllm"})
+    res = sm.merge_context("sess_1", {"framework": "sglang"})
+    assert isinstance(res, MergeResult)
+    assert res.merged["framework"] == "sglang"
+    assert res.merged["model"] == "Qwen3-14B"
+    assert "framework" in res.explicit_keys
+    assert "model" in res.from_memory_keys
+    # Persisted
+    assert sm.load_context("sess_1")["framework"] == "sglang"
+
+
+def test_merge_context_unknown_treated_as_missing(tmp_session_root):
+    sm = SessionMemory(root=tmp_session_root)
+    sm.save_context("sess_1", {"model": "Qwen3-14B"})
+    res = sm.merge_context("sess_1", {"model": "unknown", "precision": ""})
+    assert res.merged["model"] == "Qwen3-14B"
+    assert "model" in res.from_memory_keys
+    assert "precision" in res.missing_keys
+
+
+def test_merge_context_lists_missing_critical_keys(tmp_session_root):
+    sm = SessionMemory(root=tmp_session_root)
+    res = sm.merge_context("sess_1", {})
+    assert "model" in res.missing_keys
+    assert "framework" in res.missing_keys
+
+
+def test_append_and_list_decisions(tmp_session_root):
+    sm = SessionMemory(root=tmp_session_root)
+    sm.append_decision("sess_1", {"verdict": "approve"})
+    sm.append_decision("sess_1", {"verdict": "reject"})
+    out = sm.list_decisions("sess_1")
+    assert len(out) == 2
+    assert out[0]["decision_review"]["verdict"] == "approve"
+    assert out[1]["decision_review"]["verdict"] == "reject"
+
+
+def test_append_decision_rejects_non_dict(tmp_session_root):
+    sm = SessionMemory(root=tmp_session_root)
+    with pytest.raises(SessionMemoryError):
+        sm.append_decision("sess_1", "not a dict")  # type: ignore[arg-type]
+
+
+def test_events_jsonl_roundtrip(tmp_session_root):
+    sm = SessionMemory(root=tmp_session_root)
+    sm.append_event("sess_1", {"kind": "kb_cache_miss"})
+    sm.append_event("sess_1", {"kind": "kb_write_ok", "id": "kb_xxx"})
+    events = sm.list_events("sess_1")
+    assert [e["kind"] for e in events] == ["kb_cache_miss", "kb_write_ok"]
+
+
+def test_priors_cache_hit_and_miss(tmp_session_root, monkeypatch):
+    sm = SessionMemory(root=tmp_session_root)
+    sm.put_cached_priors("sess_1", "scope-x|topic-y", [{"id": "kb_a"}])
+    assert sm.get_cached_priors("sess_1", "scope-x|topic-y") == [{"id": "kb_a"}]
+    assert sm.get_cached_priors("sess_1", "scope-x|topic-z") is None
+
+
+def test_priors_cache_expires_after_ttl(tmp_session_root):
+    os_environ_backup = dict(os.environ)
+    try:
+        os.environ["CRITIC_PRIOR_CACHE_TTL_SECONDS"] = "0.001"
+        sm = SessionMemory(root=tmp_session_root)
+        sm.put_cached_priors("sess_1", "k", [{"id": "kb_a"}])
+        time.sleep(0.01)
+        assert sm.get_cached_priors("sess_1", "k") is None
+    finally:
+        os.environ.clear()
+        os.environ.update(os_environ_backup)
+
+
+def test_default_ttl_constant_exposed():
+    assert DEFAULT_PRIOR_CACHE_TTL_SECONDS == 3600
+
+
+def test_mark_reviewed_dedup(tmp_session_root):
+    sm = SessionMemory(root=tmp_session_root)
+    sm.mark_reviewed("sess_1", "msg_a", "approve", decision_id="dec_1")
+    assert sm.is_msg_already_reviewed("sess_1", "msg_a") is True
+    assert sm.is_msg_already_reviewed("sess_1", "msg_b") is False
+    assert sm.reviewed_verdict_for("sess_1", "msg_a") == "approve"
+
+
+def test_filter_unreviewed_returns_only_new(tmp_session_root):
+    sm = SessionMemory(root=tmp_session_root)
+    sm.mark_reviewed("sess_1", "m1", "approve")
+    out = sm.filter_unreviewed("sess_1", ["m1", "m2", "m3"])
+    assert out == ["m2", "m3"]
+
+
+def test_corrupt_context_file_raises(tmp_session_root):
+    sm = SessionMemory(root=tmp_session_root)
+    sm._ensure_session_dir("sess_1")
+    sm._context_path("sess_1").write_text("{not json", encoding="utf-8")
+    with pytest.raises(SessionMemoryError):
+        sm.load_context("sess_1")
+
+
+def test_atomic_write_does_not_leave_tmp_files(tmp_session_root):
+    sm = SessionMemory(root=tmp_session_root)
+    sm.save_context("sess_1", {"a": 1})
+    sd = sm.session_dir("sess_1")
+    assert (sd / "context.json").exists()
+    assert not list(sd.glob("*.tmp"))
+
+
+def test_jsonl_records_are_well_formed_lines(tmp_session_root):
+    sm = SessionMemory(root=tmp_session_root)
+    sm.append_event("sess_1", {"kind": "x"})
+    sm.append_event("sess_1", {"kind": "y"})
+    raw = (sm.session_dir("sess_1") / "events.jsonl").read_text("utf-8")
+    lines = [ln for ln in raw.splitlines() if ln.strip()]
+    assert len(lines) == 2
+    for ln in lines:
+        obj = json.loads(ln)
+        assert "ts" in obj and "kind" in obj

--- a/critic-agent/runtime/tests/test_slugify.py
+++ b/critic-agent/runtime/tests/test_slugify.py
@@ -1,0 +1,96 @@
+"""Slugify spec tests against the contract Appendix D.4 golden fixture."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from runtime.errors import SlugifyError
+from runtime.slugify import slugify, slugify_safe
+
+
+_GOLDEN_PATH = Path(__file__).parent / "fixtures" / "slugify-golden.json"
+
+
+def _golden_cases():
+    return json.loads(_GOLDEN_PATH.read_text(encoding="utf-8"))
+
+
+def test_golden_cases_all_pass():
+    for case in _golden_cases():
+        if "throws" in case:
+            with pytest.raises(SlugifyError) as exc:
+                slugify(case["input"])
+            assert case["reason"] in str(exc.value)
+            continue
+        out = slugify(case["input"])
+        if "output_pattern" in case:
+            assert re.match(case["output_pattern"], out), (
+                f"input={case['input']!r} got={out!r} expected pattern "
+                f"{case['output_pattern']!r}"
+            )
+        else:
+            assert out == case["output"], (
+                f"input={case['input']!r} got={out!r} expected {case['output']!r}"
+            )
+
+
+def test_slugify_rejects_non_ascii():
+    with pytest.raises(SlugifyError, match="non_ascii"):
+        slugify("FA3 在 H100 上崩溃")
+
+
+def test_slugify_rejects_too_short_after_normalisation():
+    with pytest.raises(SlugifyError, match="too_short"):
+        slugify("a-b")
+
+
+def test_slugify_rejects_only_separators():
+    with pytest.raises(SlugifyError, match="empty"):
+        slugify("---   ___")
+
+
+def test_slugify_safe_pure_ascii_passes_through():
+    assert slugify_safe("MLA FP8 torch.compile incompat") == "mla-fp8-torch-compile-incompat"
+
+
+def test_slugify_safe_uses_translate_fn_for_non_ascii():
+    out = slugify_safe(
+        "FA3 在 H100 上崩溃",
+        translate_fn=lambda t: "fa3 h100 crash",
+    )
+    assert out == "fa3-h100-crash"
+
+
+def test_slugify_safe_fallback_prefix_when_no_translator():
+    out = slugify_safe("FA3 在 H100 上崩溃")
+    assert out.startswith("auto-")
+    assert len(out.split("-", 1)[1]) == 8
+
+
+def test_slugify_safe_fallback_when_translator_raises():
+    def bad_translate(_):
+        raise RuntimeError("translation service unavailable")
+
+    out = slugify_safe(
+        "FA3 在 H100 上崩溃",
+        translate_fn=bad_translate,
+        fallback_prefix="critic",
+    )
+    assert out.startswith("critic-")
+
+
+def test_slugify_safe_idempotent_for_same_non_ascii_input():
+    a = slugify_safe("FA3 在 H100 上崩溃")
+    b = slugify_safe("FA3 在 H100 上崩溃")
+    assert a == b
+
+
+def test_slugify_long_input_truncated_with_hash():
+    long = "a" * 200
+    out = slugify(long)
+    assert len(out) == 72 + 1 + 7
+    assert out.startswith("a" * 72 + "-")

--- a/critic-agent/tests/coordinator_inbox_cases.json
+++ b/critic-agent/tests/coordinator_inbox_cases.json
@@ -1,0 +1,51 @@
+[
+  {
+    "id": "inbox-001-two-proposals-mixed-verdicts",
+    "description": "Coordinator forwards two proposals: a baseline and a kernel rewrite. Critic should approve the baseline (if benchmark exists) and reject the kernel rewrite if active dispatch path is unproven.",
+    "input_packet": {
+      "request_type": "coordinator_inbox",
+      "session_id": "sess-inbox-001",
+      "raw_prompt": "=== Shared session state ===\nsession_id=sess-inbox-001 model=qwen3-14b framework=sglang workload=decode precision=fp8 baseline_tput=1200\n=== Inbox for critic (newest last) ===\n  seq=12 msg_id=aaa1 from=orchestration topic=proposal payload={'action_name': 'baseline', 'predicted_gain_pct': 0}\n  seq=13 msg_id=bbb2 from=orchestration topic=proposal payload={'action_name': 'kernel_opt', 'predicted_gain_pct': 4.2}\n"
+    },
+    "expected": {
+      "kind": "intent_envelope",
+      "intent_count": 2,
+      "intent_types_any_of": ["review_verdict"],
+      "verdicts_per_proposal": [
+        {"target_proposal_msg_id": "aaa1", "verdict": "approve"},
+        {"target_proposal_msg_id": "bbb2", "verdict": "reject"}
+      ]
+    }
+  },
+  {
+    "id": "inbox-002-empty-inbox-emits-heartbeat",
+    "description": "Coordinator inbox is empty. Critic must emit a single send_message heartbeat so the Coordinator never times out.",
+    "input_packet": {
+      "request_type": "coordinator_inbox",
+      "session_id": "sess-inbox-002",
+      "raw_prompt": "=== Shared session state ===\nmodel=qwen3-14b framework=sglang\n=== Inbox for critic ===\n(no new messages)\n"
+    },
+    "expected": {
+      "kind": "intent_envelope",
+      "intent_count": 1,
+      "intent_types_any_of": ["send_message"]
+    }
+  },
+  {
+    "id": "inbox-003-needs-review-when-context-missing",
+    "description": "Inbox carries a proposal but the shared session header is missing model/framework. Critic must emit needs_review and not invent context.",
+    "input_packet": {
+      "request_type": "coordinator_inbox",
+      "session_id": "sess-inbox-003",
+      "raw_prompt": "=== Shared session state ===\nsession_id=sess-inbox-003\n=== Inbox for critic ===\n  seq=1 msg_id=ccc3 from=orchestration topic=proposal payload={'action_name': 'mystery'}\n"
+    },
+    "expected": {
+      "kind": "intent_envelope",
+      "intent_count": 1,
+      "intent_types_any_of": ["review_verdict"],
+      "verdicts_per_proposal": [
+        {"target_proposal_msg_id": "ccc3", "verdict": "needs_review"}
+      ]
+    }
+  }
+]

--- a/critic-agent/tests/decision_review_cases.json
+++ b/critic-agent/tests/decision_review_cases.json
@@ -1,0 +1,84 @@
+[
+  {
+    "id": "decision-001-adopt-with-session-evidence",
+    "description": "Decision to adopt patch X is supported by full context, fresh benchmark and an existing KB technique. Critic should adopt with a clear session evidence trail.",
+    "input_packet": {
+      "request_type": "critic_decision_request",
+      "session_id": "sess-decision-001",
+      "decision_id": "dec-001",
+      "messages": [
+        {"role": "coordinator", "content": "Plan: adopt patch X (kernel rewrite for fused attention)."},
+        {"role": "kernel-agent", "content": "Patch X requires cache clear; reproducer benchmark shows +4.2% tput, accuracy gate ok."}
+      ],
+      "context": {
+        "model": "deepseek-r1-0528-fp8",
+        "framework": "sglang",
+        "model_family": "deepseek",
+        "workload": "decode",
+        "precision": "fp8",
+        "scale": "8xMI300",
+        "objective": "throughput"
+      },
+      "decision": {
+        "summary": "Adopt patch X (fused attention rewrite)",
+        "owner": "kernel-agent",
+        "topic": "fused-attention-rewrite-deepseek-r1"
+      }
+    },
+    "expected": {
+      "kind": "critic_decision_review",
+      "verdict": "adopt",
+      "basis": "session"
+    }
+  },
+  {
+    "id": "decision-002-needs-info-when-context-missing",
+    "description": "Coordinator forwards a decision request without the model + framework keys. Critic must respond with needs_info and list missing context, never invent it.",
+    "input_packet": {
+      "request_type": "critic_decision_request",
+      "session_id": "sess-decision-002",
+      "decision_id": "dec-002",
+      "messages": [
+        {"role": "coordinator", "content": "Adopt patch Y?"}
+      ],
+      "context": {},
+      "decision": {
+        "summary": "Adopt patch Y"
+      }
+    },
+    "expected": {
+      "kind": "critic_decision_review",
+      "verdict": "needs_info",
+      "basis": "insufficient_context"
+    }
+  },
+  {
+    "id": "decision-003-revise-when-kb-flags-side-effect",
+    "description": "Decision is plausible but a KB pitfall warns about a missing cache clear; Critic should revise rather than adopt or reject.",
+    "input_packet": {
+      "request_type": "critic_decision_request",
+      "session_id": "sess-decision-003",
+      "decision_id": "dec-003",
+      "messages": [
+        {"role": "coordinator", "content": "Adopt patch Z (dispatch path change)."},
+        {"role": "kernel-agent", "content": "Benchmark not yet rerun after the change."}
+      ],
+      "context": {
+        "model": "qwen3-14b",
+        "framework": "sglang",
+        "model_family": "qwen",
+        "workload": "decode",
+        "precision": "fp8"
+      },
+      "decision": {
+        "summary": "Adopt patch Z (dispatch path optimization)",
+        "topic": "dispatch-path-change-qwen3-14b"
+      }
+    },
+    "expected": {
+      "kind": "critic_decision_review",
+      "verdict": "revise",
+      "basis": "mixed"
+    }
+  }
+]

--- a/critic-agent/tests/expected_outputs.json
+++ b/critic-agent/tests/expected_outputs.json
@@ -268,5 +268,159 @@
       }
     ],
     "notes": []
+  },
+  "decision-001-adopt-with-session-evidence": {
+    "kind": "critic_decision_review",
+    "session_id": "sess-decision-001",
+    "decision_id": "dec-001",
+    "verdict": "adopt",
+    "confidence": "high",
+    "reason": "Patch X reproducer benchmark shows +4.2% tput at the active dispatch path, accuracy gate is green, and rollback is documented.",
+    "recommendation": "Proceed; clear compiled cache before final benchmark.",
+    "basis": "session",
+    "kb_evidence": [],
+    "session_evidence": [
+      "benchmark.after.gain_pct",
+      "accuracy_gate.status",
+      "dispatch_evidence.active_path_proven"
+    ],
+    "required_context": [],
+    "notes": []
+  },
+  "decision-002-needs-info-when-context-missing": {
+    "kind": "critic_decision_review",
+    "session_id": "sess-decision-002",
+    "decision_id": "dec-002",
+    "verdict": "needs_info",
+    "confidence": "low",
+    "reason": "Cannot decide: critical context (model, framework) is missing from the request and session memory.",
+    "recommendation": "Resend the decision with model and framework populated.",
+    "basis": "insufficient_context",
+    "kb_evidence": [],
+    "session_evidence": [],
+    "required_context": ["model", "framework"],
+    "notes": [
+      "needs_info follows the hard rule: do not invent missing context."
+    ]
+  },
+  "decision-003-revise-when-kb-flags-side-effect": {
+    "kind": "critic_decision_review",
+    "session_id": "sess-decision-003",
+    "decision_id": "dec-003",
+    "verdict": "revise",
+    "confidence": "medium",
+    "reason": "KB pitfall warns about cache clear after dispatch path changes, and the benchmark has not been rerun.",
+    "recommendation": "Rerun the benchmark after cache clear before adopting.",
+    "basis": "mixed",
+    "kb_evidence": [
+      {
+        "id": "kb_xxx",
+        "kind": "pitfall",
+        "slug": "cache-clear-required-after-dispatch-change"
+      }
+    ],
+    "session_evidence": [],
+    "required_context": [],
+    "notes": []
+  },
+  "inbox-001-two-proposals-mixed-verdicts": {
+    "kind": "intent_envelope",
+    "intents": [
+      {
+        "intent_type": "review_verdict",
+        "payload": {
+          "target_proposal_msg_id": "aaa1",
+          "verdict": "approve",
+          "source": "critic",
+          "reasoning": "Baseline carries comparable tput and rollback; approve.",
+          "predicted_gain_pct": 0,
+          "confidence": "high",
+          "kb_evidence": [],
+          "packet_evidence": [
+            "benchmark.after.gain_pct",
+            "accuracy_gate.status",
+            "rollback.available"
+          ],
+          "risks": [],
+          "required_evidence": [],
+          "alternative_action": null,
+          "advice_text": "",
+          "notes": []
+        }
+      },
+      {
+        "intent_type": "review_verdict",
+        "payload": {
+          "target_proposal_msg_id": "bbb2",
+          "verdict": "reject",
+          "source": "critic",
+          "reasoning": "Active dispatch path is unproven for the kernel rewrite; require dispatch evidence before retry.",
+          "predicted_gain_pct": null,
+          "confidence": "high",
+          "kb_evidence": [
+            "kb:qwen/qwen3-14b/active-path-unproven-pitfall"
+          ],
+          "packet_evidence": [],
+          "risks": [
+            {
+              "type": "active_path_unproven",
+              "severity": "blocker",
+              "reason": "No proof that the kernel rewrite is on the active dispatch path.",
+              "required_fix": "Provide dispatch_evidence.active_path_proven=true",
+              "evidence_ref": "dispatch_evidence"
+            }
+          ],
+          "required_evidence": [
+            "dispatch_evidence.active_path_proven"
+          ],
+          "alternative_action": null,
+          "advice_text": "",
+          "notes": []
+        }
+      }
+    ]
+  },
+  "inbox-002-empty-inbox-emits-heartbeat": {
+    "kind": "intent_envelope",
+    "intents": [
+      {
+        "intent_type": "send_message",
+        "payload": {
+          "topic": "heartbeat",
+          "body_md": "ok (critic)"
+        }
+      }
+    ]
+  },
+  "inbox-003-needs-review-when-context-missing": {
+    "kind": "intent_envelope",
+    "intents": [
+      {
+        "intent_type": "review_verdict",
+        "payload": {
+          "target_proposal_msg_id": "ccc3",
+          "verdict": "needs_review",
+          "source": "critic_unavailable",
+          "reasoning": "Model and framework missing from shared session state and session memory; cannot review.",
+          "predicted_gain_pct": null,
+          "confidence": "low",
+          "kb_evidence": [],
+          "packet_evidence": [],
+          "risks": [
+            {
+              "type": "insufficient_context",
+              "severity": "blocker",
+              "reason": "model and framework are required to evaluate the proposal.",
+              "required_fix": "Resend with shared session state populated.",
+              "evidence_ref": "shared_session_state"
+            }
+          ],
+          "required_evidence": ["shared_session_state.model", "shared_session_state.framework"],
+          "alternative_action": null,
+          "advice_text": "",
+          "notes": []
+        }
+      }
+    ]
   }
 }

--- a/critic-agent/tests/validate_cases.py
+++ b/critic-agent/tests/validate_cases.py
@@ -41,9 +41,19 @@ KB_CATEGORIES = {
 }
 
 VERDICTS = {"approve", "reject", "redirect", "advise", "needs_review"}
+DECISION_VERDICTS = {"adopt", "reject", "revise", "needs_info"}
+DECISION_BASIS = {"kb", "llm", "mixed", "session", "insufficient_context"}
 SOURCES = {"critic", "mock", "timeout", "critic_unavailable"}
 CONFIDENCE = {"high", "medium", "low"}
 SEVERITIES = {"blocker", "major", "minor"}
+COORDINATOR_INTENT_TYPES = {
+    "review_verdict",
+    "send_message",
+    "ask_question",
+    "answer",
+    "alert",
+    "update_persona",
+}
 
 
 def fail(message: str) -> None:
@@ -97,6 +107,14 @@ def validate_case_file(path: Path) -> list[dict[str, Any]]:
             if expected_kind != "kb_draft":
                 fail(f"{case_id}: expected.kind must be kb_draft")
             validate_kb_expected(case_id, case["expected"])
+        elif request_type == "critic_decision_request":
+            if expected_kind != "critic_decision_review":
+                fail(f"{case_id}: expected.kind must be critic_decision_review")
+            validate_decision_expected(case_id, case["expected"])
+        elif request_type == "coordinator_inbox":
+            if expected_kind != "intent_envelope":
+                fail(f"{case_id}: expected.kind must be intent_envelope")
+            validate_coordinator_expected(case_id, case["expected"])
         else:
             fail(f"{case_id}: unsupported request_type {request_type!r}")
 
@@ -111,6 +129,34 @@ def validate_review_expected(case_id: str, expected: dict[str, Any]) -> None:
         for risk_type in as_list(expected.get(key)):
             if risk_type not in RISK_TYPES:
                 fail(f"{case_id}: unknown risk type {risk_type}")
+
+
+def validate_decision_expected(case_id: str, expected: dict[str, Any]) -> None:
+    require_type(case_id, expected, "verdict", str)
+    if expected["verdict"] not in DECISION_VERDICTS:
+        fail(f"{case_id}: invalid decision verdict {expected['verdict']}")
+    basis = expected.get("basis")
+    if basis is not None and basis not in DECISION_BASIS:
+        fail(f"{case_id}: invalid basis {basis}")
+
+
+def validate_coordinator_expected(case_id: str, expected: dict[str, Any]) -> None:
+    intent_types_any_of = as_list(expected.get("intent_types_any_of"))
+    for intent_type in intent_types_any_of:
+        if intent_type not in COORDINATOR_INTENT_TYPES:
+            fail(f"{case_id}: unknown intent_type {intent_type}")
+    expected_count = expected.get("intent_count")
+    if expected_count is not None:
+        try:
+            int(expected_count)
+        except (TypeError, ValueError):
+            fail(f"{case_id}: intent_count must be int")
+    proposals = as_list(expected.get("verdicts_per_proposal"))
+    for entry in proposals:
+        if not isinstance(entry, dict):
+            fail(f"{case_id}: verdicts_per_proposal items must be dicts")
+        if entry.get("verdict") not in VERDICTS:
+            fail(f"{case_id}: bad verdict in verdicts_per_proposal")
 
 
 def validate_kb_expected(case_id: str, expected: dict[str, Any]) -> None:
@@ -138,10 +184,17 @@ def validate_outputs(cases: list[dict[str, Any]], outputs_path: Path) -> None:
         output = outputs[case_id]
         if not isinstance(output, dict):
             fail(f"{case_id}: output must be an object")
-        if case["expected"]["kind"] == "review_verdict":
+        kind = case["expected"]["kind"]
+        if kind == "review_verdict":
             assert_review_output(case_id, case["expected"], output)
-        else:
+        elif kind == "kb_draft":
             assert_kb_output(case_id, case["expected"], output)
+        elif kind == "critic_decision_review":
+            assert_decision_output(case_id, case["expected"], output)
+        elif kind == "intent_envelope":
+            assert_intent_envelope_output(case_id, case["expected"], output)
+        else:
+            fail(f"{case_id}: unexpected expected.kind {kind!r}")
 
 
 def assert_review_output(case_id: str, expected: dict[str, Any], output: dict[str, Any]) -> None:
@@ -325,6 +378,64 @@ def validate_kb_draft(case_id: str, draft: Any) -> None:
             fail(f"{case_id}: KB draft confidence must be in [0, 1]")
 
 
+def assert_decision_output(case_id: str, expected: dict[str, Any], output: dict[str, Any]) -> None:
+    if output.get("kind") != "critic_decision_review":
+        fail(f"{case_id}: output.kind must be critic_decision_review")
+    require_type(case_id, output, "verdict", str)
+    if output["verdict"] not in DECISION_VERDICTS:
+        fail(f"{case_id}: invalid decision verdict {output['verdict']}")
+    if output["verdict"] != expected["verdict"]:
+        fail(f"{case_id}: decision verdict mismatch")
+    basis = output.get("basis")
+    if basis and basis not in DECISION_BASIS:
+        fail(f"{case_id}: invalid basis {basis}")
+    if expected.get("basis") and basis != expected["basis"]:
+        fail(f"{case_id}: basis mismatch")
+    required_keys = ("reason",)
+    if output["verdict"] in ("adopt", "reject", "revise"):
+        required_keys += ("session_evidence",)
+    for key in required_keys:
+        if key not in output:
+            fail(f"{case_id}: missing required key {key}")
+    if output["verdict"] == "needs_info":
+        if not output.get("required_context"):
+            fail(f"{case_id}: needs_info requires non-empty required_context")
+
+
+def assert_intent_envelope_output(case_id: str, expected: dict[str, Any], output: dict[str, Any]) -> None:
+    if output.get("kind") != "intent_envelope":
+        fail(f"{case_id}: output.kind must be intent_envelope")
+    require_type(case_id, output, "intents", list)
+    intents = output["intents"]
+    if not intents:
+        fail(f"{case_id}: intent envelope must be non-empty")
+    types = [item.get("intent_type") for item in intents]
+    for intent_type in types:
+        if intent_type not in COORDINATOR_INTENT_TYPES:
+            fail(f"{case_id}: invalid intent_type {intent_type!r}")
+    expected_count = expected.get("intent_count")
+    if expected_count is not None and len(intents) != int(expected_count):
+        fail(f"{case_id}: intent count mismatch — got {len(intents)}, expected {expected_count}")
+    for entry in as_list(expected.get("verdicts_per_proposal")):
+        target = entry.get("target_proposal_msg_id")
+        verdict = entry.get("verdict")
+        match = next(
+            (
+                i for i in intents
+                if i.get("intent_type") == "review_verdict"
+                and i.get("payload", {}).get("target_proposal_msg_id") == target
+            ),
+            None,
+        )
+        if match is None:
+            fail(f"{case_id}: missing review_verdict for proposal {target}")
+        if match["payload"].get("verdict") != verdict:
+            fail(f"{case_id}: verdict for {target} expected {verdict}, got {match['payload'].get('verdict')}")
+    intent_any = set(as_list(expected.get("intent_types_any_of")))
+    if intent_any and not intent_any.intersection(types):
+        fail(f"{case_id}: expected at least one intent_type from {sorted(intent_any)}")
+
+
 def validate_rejected_candidate(case_id: str, rejected_candidate: Any) -> None:
     if not isinstance(rejected_candidate, dict):
         fail(f"{case_id}: rejected_candidates entries must be objects")
@@ -342,7 +453,12 @@ def main() -> None:
     parser.add_argument(
         "--cases",
         nargs="+",
-        default=["review_verdict_cases.json", "kb_draft_cases.json"],
+        default=[
+            "review_verdict_cases.json",
+            "kb_draft_cases.json",
+            "decision_review_cases.json",
+            "coordinator_inbox_cases.json",
+        ],
         help="Case files to validate.",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary

Reimplement the Critic agent for v0.6 by pairing the LLM SKILL with a deterministic Python runtime under `critic-agent/runtime/`. The runtime owns session memory, KB read/write side effects, intent envelope assembly, and Coordinator-style inbox parsing so the SKILL only has to produce validated review JSON.

This delivers the critic-context-kb-interaction-handoff design without breaking the existing v0.6 Coordinator protocol — the runtime emits exactly the `{intents:[...]}` envelopes that `inference_optimizer.orchestrator.intent_parser.validate_envelope` and `policy.PolicyGate` already accept, including the heartbeat fallback that `MockCriticBackend` ships with.

## What's in the box

### `critic-agent/runtime/` (deterministic Python adapter)

- **request_models / inbox_parser** — normalise 4 request kinds (`coordinator_inbox`, `critic_decision_request`, `kb_draft_request`, `objection_signal`) and parse Coordinator `_compose_prompt` text using the same regex shape as `MockCriticBackend._PROPOSAL_RE`.
- **session_memory** — local JSON/JSONL store with explicit-wins context merge, KB-prior cache (TTL'd, scope-keyed), and `reviewed_msg_ids` dedup so we never double-emit verdicts within a session.
- **intent_envelope** — mirrors the upstream `intent_parser` schema and `policy.REVIEW_VERDICTS` vocabulary; `validate_envelope` raises before any LLM-produced JSON leaves the runtime.
- **KB layer** — `kb_client` (urllib HTTP transport), `in_memory_kb_client` (faithful mock implementing the 4 §7.3 promises: unique constraint + idempotent upsert with G-1 partial merge / G-2 importance protection, contradicts auto-mirror with G-8 mirror_skipped, scope containment with G-3 normalisation, metadata_filter with G-7 nested + array-contains), `kb_writer` (high-level façade that never blocks the review pipeline on KB failures), `dead_letter` (JSONL DLQ + replay), `metrics` (in-process counter shim — Prometheus-ready), `slugify` (Appendix D byte-equal with Critic / Alchemist), `scope_builder` (6 mandatory + 2 optional dimensions, ScopeError on missing critical keys), `category_mapping` + `importance_mapping` (Critic ceiling 0.84).
- **decision_reviewer** — orchestrates `init-session` / `prepare-review` / `commit-review` / `close-session` and translates the SKILL's review JSON into intent envelopes, KB writes, and session memory updates.
- **cli.py** — `python -m runtime.cli ...` exposes everything the SKILL or a cron job needs, plus the legacy `list-priors` / `write-verdict` / `write-kb-drafts` / `add-contradiction` / `replay-dead-letter` commands.

### SKILL + docs

- `SKILL.md` rewritten around the two-phase CLI loop with per-kind action dispatch.
- New `actions/{review_coordinator_inbox,review_decision,objection_signal}.md` for the new request kinds.
- New `references/{coordinator_protocol,decision_review_schema,intent_envelope}.md` document the Coordinator parity contract.
- New `AGENTS.md` describing the Codex / A2A chat-server hosting model with required env vars and Bash allowlist.

### Tests

- **`runtime/tests/`** — 136 passing unit + integration tests (every module has its own file; `test_decision_reviewer.py` covers prepare/commit cycles end-to-end against `InMemoryKBClient`; `test_cli.py` is a smoke test that invokes `runtime.cli.main` directly).
- **`tests/`** — `validate_cases.py` extended with `critic_decision_request` and `coordinator_inbox` schemas; 6 new fixtures + reference outputs added under `decision_review_cases.json` and `coordinator_inbox_cases.json`. **16 cases validated** with no regression on the existing `review_verdict_cases.json` / `kb_draft_cases.json`.

## Coordinator parity check

I cross-validated the runtime's output against the upstream Coordinator:

```python
from runtime.decision_reviewer import DecisionReviewer
from inference_optimizer.orchestrator.intent_parser import validate_envelope
from inference_optimizer.orchestrator.policy import PolicyGate
from inference_optimizer.orchestrator.agent_role import default_role_registry

# heartbeat (empty inbox)        -> send_message{topic="heartbeat"}    -> PolicyGate accepts
# coordinator_inbox (1 proposal) -> review_verdict{verdict="approve"}  -> PolicyGate accepts
```

Both pass `validate_envelope` and `PolicyGate.validate_intent("critic", ...)` without further changes.

## Hosting model (no new long-running service)

Delivered as **SKILL + runtime scripts**, intended to be mounted into a Codex-based A2A chat server:

```
host turn -> request.json
         -> python -m runtime.cli prepare-review --request request.json --out judge_bundle.json
         -> SKILL reasons, writes review.json
         -> python -m runtime.cli commit-review --request request.json --review review.json --out emit.json
         -> host returns emit.json["intent_envelope"] (or critic_decision_review)
```

Required env (see `AGENTS.md`): `CRITIC_SESSION_MEMORY_DIR`, `CRITIC_KB_CLIENT_MODE` (`live`/`inmemory`), `KB_BASE_URL`, `KB_DEAD_LETTER_DIR`, `KB_WRITE_ENABLED`, `KB_READ_ENABLED`, `KB_SERVICE_TOKEN`, `CRITIC_PRIOR_CACHE_TTL_SECONDS`.

## Test plan

- [x] `cd critic-agent && python -m pytest runtime/tests -q` — **136 passed** (in-process, no external KB).
- [x] `cd critic-agent && python tests/validate_cases.py` — **16 cases validated** (existing 10 + 6 new).
- [x] Cross-validate produced envelopes against `inference_optimizer.orchestrator.intent_parser.validate_envelope` and `PolicyGate` for both the `approve` proposal and the empty-inbox heartbeat path.
- [ ] Replace `MockCriticBackend` in `inference_optimizer/orchestrator/backends/critic_mock.py` with a backend that shells out to `python -m runtime.cli prepare-review` + `commit-review` and re-run the existing P0_3 / P0_4 Coordinator tests. (Tracked as follow-up — left intentionally for downstream test owners as discussed.)
- [ ] Smoke against a real KB service in dev (`CRITIC_KB_CLIENT_MODE=live`, `KB_BASE_URL=...`).

## Notes for reviewers

- The runtime is import-light on purpose (no `httpx`, no `pydantic`) so it stays installable in a minimal Codex container.
- `KBWriter` never raises to the SKILL on KB failures — write outcomes flow back as `WriteResult(status="dead_lettered" | "skipped" | ...)` and a cron should call `python -m runtime.cli replay-dead-letter` periodically.
- `pytest.ini` is local to `critic-agent/` so we don't inherit the parent's `asyncio_mode = "auto"` (the runtime is sync).
- All files in `critic-agent/runtime/` and the new docs are intentionally self-contained — no cross-imports from `inference_optimizer.*` so the package can also be packaged separately if/when that is useful.


Made with [Cursor](https://cursor.com)