### PR TITLE
feat(robustness-agent): M1+M1.5 reactor with single-machine LocalProbe + LLM RCA

### DIFF
--- a/robustness-agent/SKILL.md
+++ b/robustness-agent/SKILL.md
@@ -1,75 +1,193 @@
 ---
 name: robustness-agent
-description: Independent guardian daemon for Hyperloom inference optimization. Provides continuous health monitoring (GPU/process/disk/server), event-driven anomaly detection, root cause analysis, and scheduling police capabilities (kill_task/force_dispatch/prune_branch/escalate_strategy_change).
+description: Independent guardian daemon for Hyperloom inference optimization. Implements the inference_optimizer "robustness" reactor (DESIGN v0.6) so the Coordinator can call it as a Backend, plus a standalone loop for dev. Owns continuous health monitoring, RCA, and scheduling-police capabilities (kill_task / force_dispatch / prune_branch / escalate_strategy_change).
 ---
 
 # Robustness Agent
 
-Independent Python daemon that monitors the health of an inference optimization
-session. Designed to run alongside Conductor + Orchestration + Kernel agents,
-providing L0-L2 observability and automated intervention.
+A Python package that ships the `robustness` agent for the
+`inference_optimizer` Coordinator and a CLI for standalone use.
 
-## Quick Start
+The agent observes shared state, the orchestration agent's inbox, and
+cluster telemetry; classifies symptoms; and emits Coordinator-validated
+intents (alert / escalate_strategy_change / prune_branch / etc.) plus
+on-disk findings.
+
+## Quick start
 
 ```bash
 cd robustness-agent
-pip install -e .
+python3 -m venv .venv && .venv/bin/pip install -e ".[test]"
 
-SESSION_DIR=/path/to/session \
-  robustness-agent
+# M1 reactor mode (default). Auto-discovers session_dir and probes
+# robustness-server before falling back to local probes.
+.venv/bin/robustness-agent
+
+# Legacy SQLite-IntentEmitter loop (kept for environments still on the
+# pre-M1 transport).
+.venv/bin/robustness-agent --mode legacy
 ```
 
-## Environment Variables
+## M1 module layout
+
+```
+robustness_agent/
+├── role/
+│   ├── envelope.py         # IntentType / Intent / build_* helpers (mirror upstream)
+│   ├── prompt_inputs.py    # Coordinator prompt -> ReactorContext
+│   ├── reactor.py          # Reactor.tick() pipeline driver
+│   └── backend_adapter.py  # SINGLE_PROC adapter implementing Backend
+├── decision/
+│   ├── policy_aware.py     # local PolicyGate-equivalent payload guard
+│   ├── action_ladder.py    # symptom -> intent (+ Finding) translation (async)
+│   └── rca_engine.py       # NoopRcaEngine | LlmRcaEngine + RcaThrottle (M1.5)
+├── signals/
+│   ├── stall.py / crash.py / event.py / health.py / local_health.py (M1.5)
+│   └── classifier.py       # composes the rules and de-duplicates
+├── sources/
+│   ├── base.py             # Source / SourceData / DegradeRouter
+│   ├── server_client.py    # robustness-server REST + Source adapter
+│   └── local_probe.py      # local fallback (conductor.db, ps, df, parsed rocm-smi, http probes, log error patterns)
+├── findings/sink.py        # JSONL append sink for Findings
+├── factory.py              # Config -> Reactor / Backend bundle
+├── config.py               # discovery + tunables
+├── main.py                 # CLI: --mode reactor (default) | legacy
+└── (legacy) agent.py / conductor.py / monitors / checks / providers
+```
+
+The legacy loop is preserved behind `--mode legacy` and emits a
+`DeprecationWarning` when constructed. Migration target is the
+SINGLE_PROC backend below.
+
+## Coordinator integration (SINGLE_PROC)
+
+```python
+from robustness_agent.config import Config
+from robustness_agent.factory import build_backend
+
+config = await Config.discover()
+backend, bundle = build_backend(config)
+# Register backend with the Coordinator's BackendRegistry under name
+# "robustness". The Coordinator then drives backend.run(prompt) per tick.
+
+try:
+    await coordinator.run_until_stop()
+finally:
+    await bundle.aclose()  # closes the httpx client + flushes the sink
+```
+
+The backend's wire shape is identical to
+`inference_optimizer.orchestrator.backends.base.Backend`. A contract
+test (`tests/test_role_contract.py`) and an end-to-end integration
+test (`tests/test_inference_optimizer_integration.py`) validate every
+emitted intent against the upstream `PolicyGate`.
+
+## Environment variables
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `SESSION_DIR` | yes | — | Path to the session directory containing `storage/conductor.db` |
-| `ROBUST_ANALYZER_URL` | no | — | Primus-Robust-Internal analyzer URL (e.g. `http://robust-analyzer:8085`). If unset, uses local shell commands for GPU metrics |
-| `OPENAI_BASE_URL` | no | — | LLM endpoint for RCA diagnosis |
-| `SAFE_API_KEY` | no | — | API key for LLM |
-| `LLM_MODEL` | no | `claude-opus-4-7` | Model to use for RCA |
+| `SESSION_DIR` | no | scan known paths | Path containing `storage/conductor.db`; the FindingSink writes under `{session_dir}/agents/robustness/findings/{session_id}.jsonl`. |
+| `ROBUSTNESS_SERVER_URL` | no | scan known DNS | M1 primary data source; empty disables the primary path and forces local-only mode. |
+| `ROBUST_ANALYZER_URL` | no | scan known DNS | Used by the legacy provider only. |
+| `OPENAI_BASE_URL` | no | — | LLM endpoint for RCA (used as `llm_base_url`). |
+| `SAFE_API_KEY` | no | — | API key for the LLM proxy (used as `llm_api_key`). |
+| `LLM_MODEL` | no | `claude-opus-4-7` | RCA model name. |
+| `ROBUSTNESS_LLM_RCA_DISABLED` | no | unset | Set to `1` to forcibly disable the LlmRcaEngine even when credentials are present. |
 
-## Architecture
+## Symptom -> intent mapping (M1 / M1.5)
+
+| Symptom | Severity | Intents emitted | Source |
+|---------|----------|-----------------|--------|
+| `agent_stall` (≥ stall_timeout_s) | medium | `alert(medium)` | M1 |
+| `agent_stall` (≥ severity_high_after_s) | high | `alert(high)` + `escalate_strategy_change` | M1 |
+| `crash_count_rising` (≥ 2) | medium | `alert(medium)` | M1 |
+| `crash_count_high` (≥ 5) | high | `alert(high)` + `escalate_strategy_change` | M1 |
+| `crash_count_emergency` (≥ 10) | high | `alert(high)` + `escalate_strategy_change` | M1 |
+| `repeated_policy_denied` (≥ 3) | medium | `alert(medium)` | M1 |
+| `repeated_failure` (≥ 2 same family) | medium | `alert(medium)` (high tier triggers `prune_branch`) | M1 |
+| `pod_not_running` (Failed) | high | `alert(high)` | M1 |
+| `pod_not_running` (other non-Running) | medium | `alert(medium)` | M1 |
+| `pod_no_metrics` (≥ no_metrics_warn_s) | low | `send_message(observation)` | M1 |
+| `local_server_unreachable` (any target down) | medium / high (all down) | `alert(medium)` / `alert(high)` | M1.5 |
+| `log_error_pattern` (CUDA OOM / NCCL / segfault) | high | `alert(high)` + `escalate_strategy_change` | M1.5 |
+| `log_error_pattern` (RuntimeError / generic) | medium | `alert(medium)` | M1.5 |
+| `gpu_thermal_high` (≥ warn_c) | medium | `alert(medium)` | M1.5 |
+| `gpu_thermal_high` (≥ crit_c) | high | `alert(high)` + `escalate_strategy_change` | M1.5 |
+| (no symptoms) | — | `send_message(heartbeat)` | M1 |
+
+Cooldown: identical `(symptom_name, subject)` keys are silenced for
+`config.cooldown_ticks` ticks (default 5) to avoid inbox flooding.
+
+## Data sources (M1 / M1.5)
+
+* **Primary:** `robustness-server`
+  * `/api/v1/sessions/{id}/pods`
+  * `/api/v1/sessions/{id}/events`
+  * `/api/v1/sessions/{id}/summary`
+* **Fallback:** local probes
+  * `conductor.db` (read-only) for Coordinator events
+  * `shutil.disk_usage`, `ps`, parsed `rocm-smi --csv` / `nvidia-smi`
+  * `Config.health_probe_targets[]` — local HTTP `/health` probes for
+    inference servers running on the same host (M1.5)
+  * tail of a configured log file + error-pattern extraction
+    (`CUDA out of memory`, `NCCL error`, `Segmentation fault`, etc.)
+
+LocalProbe stays small-scope by design: it only collects what the
+agent itself can see. GPU time-series, workload inference health, and
+node-level fault detection stay with primus-robust + robustness-server
+(see `docs/robustness-agent-implementation-plan.md` §6.1 for the
+ownership matrix).
+
+`DegradeRouter` switches to the fallback after
+`source_fail_threshold` (default 3) consecutive primary failures and
+re-probes the primary every `source_recheck_interval_s` (default 30s).
+State transitions emit one WARN log; no spam in steady state.
+
+## LLM RCA (M1.5)
+
+When `llm_base_url` and `llm_api_key` are both set (and
+`ROBUSTNESS_LLM_RCA_DISABLED` is not `1`), the factory wires
+`LlmRcaEngine` instead of `NoopRcaEngine`. The engine talks to an
+OpenAI-compatible chat-completions endpoint and writes the response
+to `Finding.rca_text`.
+
+Throttle defaults (override on `Config`):
+
+* `llm_rca_severity_min="high"` — only `high`-severity symptoms call
+  the LLM. Set to `"medium"` to include medium-severity findings.
+* `llm_rca_cooldown_s=60.0` — same `(symptom_name, subject)` is not
+  re-summarized within this window.
+* `llm_rca_max_calls_per_tick=1` — hard cap per reactor tick.
+
+If the LLM call times out, returns a non-2xx, or otherwise fails, the
+ActionLadder swallows the error and emits the intent without
+`rca_text`. RCA never blocks intent delivery.
+
+## Findings on disk
+
+Each tick that emits a non-heartbeat intent writes one
+`Finding` JSON line to:
 
 ```
-robustness-agent (independent daemon)
-├── Monitors (async tasks, different intervals)
-│   ├── ProcessMonitor    (10s) — sglang/vllm/benchmark process tracking
-│   ├── GpuMonitor        (15s) — VRAM/temp/ECC/utilization via Provider
-│   ├── ServerHealthMonitor(30s) — HTTP /health endpoint probing
-│   ├── LogTailer         (5s)  — server.log error pattern matching
-│   └── DiskCheck         (60s) — disk space monitoring
-│
-├── Checks (event-driven from Conductor SQLite)
-│   ├── EventCheck   — error patterns, KEEP/REVERT bouncing, family failures
-│   └── StallCheck   — agent heartbeat timeout detection
-│
-├── Providers (pluggable metrics backend)
-│   ├── LocalProvider   — rocm-smi / nvidia-smi / ps / df
-│   ├── RobustProvider  — Primus-Robust-Internal REST API
-│   └── HybridProvider  — auto-fallback: Robust when available, Local otherwise
-│
-├── RCA Engine (LLM, invoked only on critical alert accumulation)
-│   └── Structured evidence → LLM diagnosis → action recommendation
-│
-└── Conductor Integration
-    ├── ConductorReader — poll SQLite events table (read-only)
-    └── IntentEmitter   — write alerts and scheduling police intents
+{session_dir}/agents/robustness/findings/{session_id}.jsonl
 ```
 
-## Scheduling Police Intents (v0.6 §19)
+Fields: `tick_index`, `timestamp_unix`, `symptom_name`, `severity`,
+`summary`, `intents` (envelope dicts), `evidence`, `rca_text`.
 
-| Intent | When |
-|--------|------|
-| `kill_task` | Task stuck or repeatedly failing |
-| `force_dispatch` | High-value task blocked behind low-priority queue |
-| `prune_branch` | 3+ failures in same action family |
-| `escalate_strategy_change` | Systemic issue requiring Orchestration to change approach |
+These records are the M5 hand-off point: a future milestone POSTs them
+to the robustness-server for dashboards / alerting; in M1 they remain
+local-only.
 
-## Deployment Modes
+## Roadmap beyond M1.5
 
-- **Local mode** (`ROBUST_ANALYZER_URL` unset): All metrics collected via shell
-  commands. GPU history limited to in-memory ring buffer (default 1h).
-- **Cluster mode** (`ROBUST_ANALYZER_URL` set): GPU/RDMA/fault metrics from
-  Primus-Robust-Internal (5s granularity, 30-day history). Process/disk/server
-  health still collected locally.
+* **M2** — robustness-server `/api/v1/cluster/*` proxies (faults / GPU
+  time-series / node info). Agent's `signals/{gpu,disk,health}` start
+  preferring server data; LocalProbe stays as the disconnected fallback.
+* **M3** — multi-cli transport (`inbox.jsonl` / `outbox.jsonl`); same
+  reactor, different adapter.
+* **M4** — scheduling-police hard actions (`prune_branch`,
+  `force_dispatch`, `kill_task`, `delegate{recover|server_lifecycle|accuracy_gate}`),
+  gated behind `ROBUSTNESS_AGENT_ENABLE_HARD_ACTIONS`.
+* **M5** — findings publisher to robustness-server for cross-session
+  reporting and advisory pull-back.

--- a/robustness-agent/src/robustness_agent/agent.py
+++ b/robustness-agent/src/robustness_agent/agent.py
@@ -1,10 +1,14 @@
-"""Core Robustness Agent — event-driven guardian daemon.
+"""Core Robustness Agent — legacy event-driven daemon (pre-M1).
 
-Architecture:
-  - Multiple async monitoring tasks run at different intervals
-  - All alerts feed into a central alert bus
-  - Rule engine + RCA engine consume alerts and emit intents to Conductor
-  - LLM is only invoked when critical alerts accumulate (cost efficient)
+This loop wires monitors -> checks -> RCA -> ``IntentEmitter`` directly
+against the Coordinator's SQLite database.  M1 introduces a Backend-
+based pipeline (see :mod:`robustness_agent.role.reactor`) that emits
+intents to the Coordinator over the standard Backend protocol; this
+file is kept so the ``--mode legacy`` CLI flag still works while the
+MULTI_CLI transport (M3) is in flight.
+
+Prefer :class:`~robustness_agent.role.backend_adapter.RobustnessAgentBackend`
+for new deployments.
 """
 
 from __future__ import annotations

--- a/robustness-agent/src/robustness_agent/conductor.py
+++ b/robustness-agent/src/robustness_agent/conductor.py
@@ -119,13 +119,26 @@ class ConductorReader:
 
 
 class IntentEmitter:
-    """Write robustness intents back to Conductor.
+    """Write robustness intents back to Conductor (legacy MVP path).
 
-    In the MVP, intents are written as events to the same SQLite DB.
-    In production, this may use NATS or A2A protocol instead.
+    Deprecated as of M1: the canonical integration is the
+    :class:`~robustness_agent.role.backend_adapter.RobustnessAgentBackend`
+    which returns intents to the Coordinator instead of writing them
+    into the SQLite DB. The class is retained so the legacy
+    :class:`RobustnessAgent` loop keeps functioning while M3 finishes
+    multi-cli transport.
     """
 
     def __init__(self, db_path: Path):
+        import warnings
+
+        warnings.warn(
+            "IntentEmitter writes intents directly into conductor.db, which is "
+            "deprecated. Migrate to RobustnessAgentBackend (SINGLE_PROC) or the "
+            "MULTI_CLI inbox/outbox transport.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._db_path = db_path
         self._conn: Optional[sqlite3.Connection] = None
 

--- a/robustness-agent/src/robustness_agent/config.py
+++ b/robustness-agent/src/robustness_agent/config.py
@@ -30,6 +30,15 @@ ROBUST_ANALYZER_CANDIDATES: list[str] = [
     "http://robust-analyzer:8085",
 ]
 
+# robustness-server is the M1 primary data source; we look in cluster
+# DNS first and fall back to a local port-forward used during dev.
+ROBUSTNESS_SERVER_CANDIDATES: list[str] = [
+    "http://robustness-server.robustness.svc.cluster.local:8000",
+    "http://robustness-server.primus-safe.svc.cluster.local:8000",
+    "http://robustness-server:8000",
+    "http://localhost:8000",
+]
+
 SESSION_DIR_CANDIDATES: list[Path] = [
     Path("/workspace/session"),
     Path("/tmp/robustness-session"),
@@ -42,6 +51,9 @@ class Config:
 
     # Filled by auto-detection; empty means local-only mode.
     robust_analyzer_url: str = ""
+
+    # Primary M1 data source; empty means "skip server, only use local probe".
+    robustness_server_url: str = ""
 
     @property
     def conductor_db_path(self) -> Path:
@@ -71,6 +83,29 @@ class Config:
     llm_api_key: str = ""
     rca_max_turns: int = 10
 
+    # -- M1.5 LLM RCA throttle / activation --
+    # ``None`` = auto-enable when llm_base_url + llm_api_key are both set.
+    # ``False`` = forcibly disable (env override
+    # ROBUSTNESS_LLM_RCA_DISABLED=1 also flips this off).
+    llm_rca_enabled: Optional[bool] = None
+    llm_rca_severity_min: str = "high"  # one of low/medium/high
+    llm_rca_cooldown_s: float = 60.0
+    llm_rca_max_calls_per_tick: int = 1
+    llm_rca_timeout_s: float = 8.0
+    llm_rca_max_chars: int = 1500
+
+    # -- M1 reactor knobs --
+    cooldown_ticks: int = 5
+    metrics_window_s: int = 300
+    server_request_timeout_s: float = 5.0
+    source_fail_threshold: int = 3
+    source_recheck_interval_s: float = 30.0
+    standalone_tick_interval_s: float = 10.0
+
+    # -- M1.5 LocalProbe extras --
+    health_probe_targets: list[str] = field(default_factory=list)
+    health_probe_timeout_s: float = 1.5
+
     # -- ring buffer (local mode only) --
     local_metrics_history_s: int = 3600
     local_metrics_sample_interval: int = 5
@@ -88,18 +123,21 @@ class Config:
         """Auto-detect all configuration from the runtime environment."""
         session_dir = _discover_session_dir()
         analyzer_url = await _probe_robust_analyzer()
+        server_url = await _probe_robustness_server()
         llm_base_url, llm_api_key = _discover_llm_credentials()
 
         config = cls(
             session_dir=session_dir,
             robust_analyzer_url=analyzer_url,
+            robustness_server_url=server_url,
             llm_base_url=llm_base_url,
             llm_api_key=llm_api_key,
         )
 
         log.info(
-            "Config discovered: session_dir=%s analyzer=%s llm=%s",
+            "Config discovered: session_dir=%s server=%s analyzer=%s llm=%s",
             config.session_dir,
+            config.robustness_server_url or "(local-only)",
             config.robust_analyzer_url or "(local mode)",
             "(configured)" if config.llm_base_url else "(not available)",
         )
@@ -144,6 +182,28 @@ async def _probe_robust_analyzer() -> str:
             continue
 
     log.info("Robust-analyzer not reachable, will use local provider")
+    return ""
+
+
+async def _probe_robustness_server() -> str:
+    """Probe known robustness-server endpoints + ROBUSTNESS_SERVER_URL env."""
+    candidates: list[str] = []
+    env_url = os.environ.get("ROBUSTNESS_SERVER_URL", "").strip()
+    if env_url:
+        candidates.append(env_url.rstrip("/"))
+    candidates.extend(ROBUSTNESS_SERVER_CANDIDATES)
+
+    for url in candidates:
+        try:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(3.0)) as client:
+                resp = await client.get(f"{url}/healthz")
+                if resp.status_code == 200:
+                    log.info("Robustness-server reachable at %s", url)
+                    return url
+        except Exception:
+            continue
+
+    log.info("Robustness-server not reachable, will use local-only fallback")
     return ""
 
 

--- a/robustness-agent/src/robustness_agent/decision/__init__.py
+++ b/robustness-agent/src/robustness_agent/decision/__init__.py
@@ -1,0 +1,20 @@
+"""Decision layer.
+
+* :mod:`policy_aware` — local mirror of upstream PolicyGate payload
+  schema, used to validate intents before they leave the reactor.
+* :mod:`action_ladder` (M1) — symptom -> intent translation in the
+  observe / diagnose / recommend tiers.
+* :mod:`rca_engine` (M1 stub) — LLM-backed RCA, disabled by default in
+  M1 and exercised in M2.
+"""
+
+from .action_ladder import ActionLadder, ActionLadderConfig, Finding
+from .policy_aware import PolicyAware, PolicyViolation
+
+__all__ = [
+    "ActionLadder",
+    "ActionLadderConfig",
+    "Finding",
+    "PolicyAware",
+    "PolicyViolation",
+]

--- a/robustness-agent/src/robustness_agent/decision/action_ladder.py
+++ b/robustness-agent/src/robustness_agent/decision/action_ladder.py
@@ -1,0 +1,233 @@
+"""Translate Symptoms into Coordinator Intents.
+
+The ladder has three tiers, matching DESIGN v0.6 §13.2 / §19.3:
+
+1. **observe** — low severity: emit ``send_message(topic="observation")``
+   so the orchestration agent has visibility but no pause is triggered.
+2. **diagnose** — medium severity: emit ``alert(severity="medium")``
+   carrying the symptom evidence; the orchestration agent runs a
+   focused RCA next tick.
+3. **recommend** — high severity: emit ``alert(severity="high")`` plus
+   one of the scheduling-police intents (``escalate_strategy_change``,
+   ``prune_branch``, ``kill_task``) when the symptom comes with a
+   concrete suggestion.
+
+To avoid flooding the inbox the ladder maintains a per-key cooldown:
+the same ``Symptom.dedup_key()`` will not produce another intent until
+``cooldown_ticks`` ticks have elapsed.
+
+Findings — one persistent record per intent batch — are emitted
+alongside the intents and consumed by :class:`FindingSink` (T9).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Iterable
+
+from ..role.envelope import (
+    Intent,
+    build_alert,
+    build_escalate,
+    build_heartbeat,
+    build_prune_branch,
+    build_send_message,
+)
+from ..signals import Symptom, SymptomSeverity
+
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class Finding:
+    """Persistent record describing one ladder firing.
+
+    Stored on disk by the FindingSink for later inspection / reporting
+    to robustness-server.
+    """
+
+    tick_index: int
+    timestamp_unix: float
+    symptom_name: str
+    severity: str
+    summary: str
+    intents: list[dict[str, Any]] = field(default_factory=list)
+    evidence: dict[str, Any] = field(default_factory=dict)
+    rca_text: str = ""
+
+
+@dataclass
+class ActionLadderConfig:
+    """Tunables for the ladder."""
+
+    cooldown_ticks: int = 5
+
+
+@dataclass
+class _LadderResult:
+    intents: list[Intent]
+    findings: list[Finding]
+
+
+class ActionLadder:
+    """Stateful ladder that maps symptoms onto intents and findings.
+
+    The ladder is deliberately conservative in M1: it emits intents
+    only for symptoms whose dedup key is outside the cooldown window
+    and falls back to a heartbeat when the symptom set is empty.
+    """
+
+    def __init__(self, *, config: ActionLadderConfig | None = None) -> None:
+        self._config = config or ActionLadderConfig()
+        self._last_emitted_tick: dict[tuple[str, ...], int] = {}
+
+    async def decide(
+        self,
+        symptoms: list[Symptom],
+        *,
+        tick_index: int,
+        now_unix: float,
+        rca_provider: Any | None = None,
+    ) -> _LadderResult:
+        """Produce intents (+ findings) for this tick.
+
+        ``rca_provider`` may be ``None`` (no RCA), or any object exposing
+        ``async def summarize(symptom) -> str``. When the provider has a
+        ``set_tick(int)`` hook (e.g. :class:`LlmRcaEngine`) we call it
+        once per tick so per-tick budgets reset deterministically.
+        """
+        intents: list[Intent] = []
+        findings: list[Finding] = []
+        any_emit = False
+        if rca_provider is not None:
+            set_tick = getattr(rca_provider, "set_tick", None)
+            if callable(set_tick):
+                try:
+                    set_tick(tick_index)
+                except Exception:
+                    log.exception("rca_provider.set_tick failed; ignoring")
+        for sym in symptoms:
+            key = sym.dedup_key()
+            if not self._cooldown_elapsed(key, tick_index):
+                continue
+            sym_intents = self._intents_for(sym)
+            if not sym_intents:
+                continue
+            any_emit = True
+            self._last_emitted_tick[key] = tick_index
+            rca_text = await _safe_rca(rca_provider, sym)
+            findings.append(
+                _build_finding(
+                    sym,
+                    sym_intents,
+                    tick_index=tick_index,
+                    now_unix=now_unix,
+                    rca_text=rca_text,
+                )
+            )
+            intents.extend(sym_intents)
+
+        if not any_emit:
+            intents.append(build_heartbeat())
+        return _LadderResult(intents=intents, findings=findings)
+
+    def _cooldown_elapsed(self, key: tuple[str, ...], tick_index: int) -> bool:
+        cooldown = self._config.cooldown_ticks
+        last = self._last_emitted_tick.get(key)
+        if last is None:
+            return True
+        return (tick_index - last) >= cooldown
+
+    def _intents_for(self, sym: Symptom) -> list[Intent]:
+        if sym.severity is SymptomSeverity.LOW:
+            return self._observe(sym)
+        if sym.severity is SymptomSeverity.MEDIUM:
+            return self._diagnose(sym)
+        return self._recommend(sym)
+
+    def _observe(self, sym: Symptom) -> list[Intent]:
+        return [
+            build_send_message(
+                "observation",
+                body_md=f"{sym.name}: {sym.summary}",
+                extras={"detail": _detail(sym)},
+            )
+        ]
+
+    def _diagnose(self, sym: Symptom) -> list[Intent]:
+        return [build_alert("medium", sym.summary, detail=_detail(sym))]
+
+    def _recommend(self, sym: Symptom) -> list[Intent]:
+        intents: list[Intent] = [build_alert("high", sym.summary, detail=_detail(sym))]
+        if sym.name in {"crash_count_emergency", "crash_count_high"}:
+            intents.append(
+                build_escalate(
+                    reason=sym.name,
+                    next_action_hint=sym.suggestion or "revert to known-good baseline",
+                    severity="high",
+                )
+            )
+        elif sym.name == "agent_stall" and sym.severity is SymptomSeverity.HIGH:
+            intents.append(
+                build_escalate(
+                    reason="agent_stall_high",
+                    next_action_hint=sym.suggestion or "force_dispatch head queued task",
+                    severity="high",
+                )
+            )
+        elif sym.name == "repeated_failure":
+            family = sym.evidence.get("family") if isinstance(sym.evidence, dict) else None
+            if isinstance(family, str) and family.strip():
+                intents.append(build_prune_branch(family=family, reason="repeated_failure"))
+        return intents
+
+
+def _detail(sym: Symptom) -> dict[str, Any]:
+    body = {
+        "symptom": sym.name,
+        "severity": sym.severity.value,
+        "subject": sym.subject,
+        "source": sym.source,
+        "evidence": sym.evidence,
+    }
+    if sym.suggestion:
+        body["suggestion"] = sym.suggestion
+    return body
+
+
+def _build_finding(
+    sym: Symptom,
+    intents: Iterable[Intent],
+    *,
+    tick_index: int,
+    now_unix: float,
+    rca_text: str,
+) -> Finding:
+    return Finding(
+        tick_index=tick_index,
+        timestamp_unix=now_unix,
+        symptom_name=sym.name,
+        severity=sym.severity.value,
+        summary=sym.summary,
+        intents=[i.to_envelope_item() for i in intents],
+        evidence=dict(sym.evidence) if isinstance(sym.evidence, dict) else {},
+        rca_text=rca_text,
+    )
+
+
+async def _safe_rca(provider: Any | None, sym: Symptom) -> str:
+    if provider is None:
+        return ""
+    try:
+        result = provider.summarize(sym)
+        if hasattr(result, "__await__"):
+            result = await result
+        return result or ""
+    except Exception:
+        log.exception("rca provider raised; continuing without RCA text")
+        return ""
+
+
+__all__ = ["ActionLadder", "ActionLadderConfig", "Finding"]

--- a/robustness-agent/src/robustness_agent/decision/policy_aware.py
+++ b/robustness-agent/src/robustness_agent/decision/policy_aware.py
@@ -1,0 +1,255 @@
+"""Local payload-schema check matching upstream PolicyGate.
+
+The Coordinator's ``PolicyGate.validate_intent`` is the source of truth.
+It runs server-side and rejects malformed intents with ``PolicyDenied``;
+the Coordinator then writes a ``policy_denied`` observation to the
+sender's inbox so the LLM can self-correct.
+
+For the robustness reactor that loop is wasteful: any payload bug
+manifests as silent inactivity for at least one tick. :class:`PolicyAware`
+performs the same checks locally and surfaces them as
+:class:`PolicyViolation` (raised, not swallowed) so unit tests catch
+schema drift immediately.
+
+The schema mirrored here is intentionally a subset of upstream rules
+limited to what the robustness role can emit. A contract test
+(``tests/test_role_contract.py``) cross-checks against the upstream
+``PolicyGate`` table when the inference_optimizer package is importable.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..role.envelope import (
+    ALERT_SEVERITIES,
+    CORE_STATE_FIELDS,
+    Intent,
+    IntentType,
+    KILL_TASK_ALLOWED_SCOPES,
+    PAYLOAD_REQUIRED,
+    ROBUSTNESS_ALLOWED_INTENTS,
+    ROBUSTNESS_DELEGATE_ACTIONS,
+    ROBUSTNESS_ONLY_INTENTS,
+    ROBUSTNESS_STATE_FIELDS,
+)
+
+
+class PolicyViolation(ValueError):
+    """Raised when an intent fails local PolicyGate-equivalent checks.
+
+    Attributes:
+        rule: short identifier matching upstream ``PolicyDenied.rule``
+            (``role`` / ``payload`` / ``state_field`` / ``kill_scope`` /
+            ``robustness_only_source`` / ``delegate_action``).
+        hint: optional one-line corrective suggestion.
+    """
+
+    def __init__(self, reason: str, *, rule: str, hint: str | None = None):
+        super().__init__(reason)
+        self.rule = rule
+        self.hint = hint
+
+
+class PolicyAware:
+    """Local validator for intents the robustness reactor is about to emit.
+
+    Construct once and reuse; the validator is stateless. Use either
+    :meth:`assert_payload_complete` (raise on first violation) or
+    :meth:`validate_all` (collect every violation for diagnostics).
+    """
+
+    def assert_payload_complete(self, intent: Intent) -> None:
+        """Raise :class:`PolicyViolation` if the intent is not emit-safe.
+
+        Order of checks matches upstream ``PolicyGate.validate_intent``:
+        role allowlist -> required fields -> per-intent extra rules.
+        """
+        self._check_role(intent)
+        self._check_required_fields(intent)
+        self._check_per_intent(intent)
+
+    def validate_all(self, intent: Intent) -> list[PolicyViolation]:
+        """Return every violation without raising.
+
+        Used in unit tests to assert exhaustive coverage of a malformed
+        intent. The reactor calls :meth:`assert_payload_complete` only.
+        """
+        violations: list[PolicyViolation] = []
+        for check in (self._check_role, self._check_required_fields, self._check_per_intent):
+            try:
+                check(intent)
+            except PolicyViolation as exc:
+                violations.append(exc)
+        return violations
+
+    # -- internal checks -------------------------------------------------
+
+    def _check_role(self, intent: Intent) -> None:
+        if intent.type not in ROBUSTNESS_ALLOWED_INTENTS:
+            raise PolicyViolation(
+                f"role=robustness cannot emit intent_type={intent.type.value!r}",
+                rule="role",
+                hint="see ROBUSTNESS_ALLOWED_INTENTS in role.envelope",
+            )
+
+    def _check_required_fields(self, intent: Intent) -> None:
+        required = PAYLOAD_REQUIRED.get(intent.type, ())
+        payload = intent.payload or {}
+        for field_name in required:
+            if field_name not in payload:
+                raise PolicyViolation(
+                    f"intent_type={intent.type.value!r} missing required "
+                    f"payload field {field_name!r}",
+                    rule="payload",
+                    hint=f"required fields: {required!r}",
+                )
+
+    def _check_per_intent(self, intent: Intent) -> None:
+        payload = intent.payload or {}
+        if intent.type == IntentType.ALERT:
+            self._check_alert(payload)
+        elif intent.type == IntentType.ESCALATE_STRATEGY_CHANGE:
+            self._check_escalate(payload)
+        elif intent.type == IntentType.KILL_TASK:
+            self._check_kill_task(payload)
+        elif intent.type == IntentType.FORCE_DISPATCH:
+            self._check_force_dispatch(payload)
+        elif intent.type == IntentType.PRUNE_BRANCH:
+            self._check_prune_branch(payload)
+        elif intent.type == IntentType.DELEGATE:
+            self._check_delegate(payload)
+        elif intent.type == IntentType.UPDATE_STATE:
+            self._check_update_state(payload)
+        elif intent.type == IntentType.SEND_MESSAGE:
+            self._check_send_message(payload)
+
+        if intent.type in ROBUSTNESS_ONLY_INTENTS:
+            # Locally we cannot validate ``source``, but we can record the
+            # invariant and ensure callers reach this code path; upstream
+            # PolicyGate enforces source=robustness with
+            # ``ROBUSTNESS_ONLY_SOURCE_ALLOWLIST``.
+            pass
+
+    def _check_alert(self, payload: dict[str, Any]) -> None:
+        severity = str(payload.get("severity", "")).strip()
+        if severity not in ALERT_SEVERITIES:
+            raise PolicyViolation(
+                f"alert.severity={severity!r} not in "
+                f"{sorted(ALERT_SEVERITIES)!r}",
+                rule="payload",
+            )
+        summary = str(payload.get("summary", "")).strip()
+        if not summary:
+            raise PolicyViolation(
+                "alert.summary must be a non-empty string",
+                rule="payload",
+            )
+
+    def _check_escalate(self, payload: dict[str, Any]) -> None:
+        reason = str(payload.get("reason", "")).strip()
+        if not reason:
+            raise PolicyViolation(
+                "escalate_strategy_change.reason must be non-empty",
+                rule="payload",
+            )
+        hint = str(payload.get("next_action_hint", "")).strip()
+        if not hint:
+            raise PolicyViolation(
+                "escalate_strategy_change.next_action_hint must be non-empty",
+                rule="payload",
+            )
+        severity = payload.get("severity")
+        if severity is not None and severity not in ALERT_SEVERITIES:
+            raise PolicyViolation(
+                f"escalate severity={severity!r} not in "
+                f"{sorted(ALERT_SEVERITIES)!r}",
+                rule="payload",
+            )
+
+    def _check_kill_task(self, payload: dict[str, Any]) -> None:
+        task_id = str(payload.get("task_id", "")).strip()
+        if not task_id:
+            raise PolicyViolation("kill_task.task_id must be non-empty", rule="payload")
+        reason = str(payload.get("reason", "")).strip()
+        if not reason:
+            raise PolicyViolation("kill_task.reason must be non-empty", rule="payload")
+        scope = str(payload.get("scope", "task")).strip()
+        if scope not in KILL_TASK_ALLOWED_SCOPES:
+            raise PolicyViolation(
+                f"kill_task.scope={scope!r} not in "
+                f"{sorted(KILL_TASK_ALLOWED_SCOPES)!r}",
+                rule="kill_scope",
+                hint="upstream v0.6 keeps server / process kills out per IR-5",
+            )
+
+    def _check_force_dispatch(self, payload: dict[str, Any]) -> None:
+        task_id = str(payload.get("task_id", "")).strip()
+        if not task_id:
+            raise PolicyViolation(
+                "force_dispatch.task_id must be non-empty", rule="payload"
+            )
+        reason = str(payload.get("reason", "")).strip()
+        if not reason:
+            raise PolicyViolation(
+                "force_dispatch.reason must be non-empty", rule="payload"
+            )
+
+    def _check_prune_branch(self, payload: dict[str, Any]) -> None:
+        family = str(payload.get("family", "")).strip()
+        if not family:
+            raise PolicyViolation(
+                "prune_branch.family must be non-empty", rule="payload"
+            )
+        reason = str(payload.get("reason", "")).strip()
+        if not reason:
+            raise PolicyViolation(
+                "prune_branch.reason must be non-empty", rule="payload"
+            )
+
+    def _check_delegate(self, payload: dict[str, Any]) -> None:
+        action_name = str(payload.get("action_name", "")).strip()
+        if not action_name:
+            raise PolicyViolation(
+                "delegate.action_name must be non-empty", rule="payload"
+            )
+        if action_name not in ROBUSTNESS_DELEGATE_ACTIONS:
+            raise PolicyViolation(
+                f"delegate.action_name={action_name!r} not allowed for "
+                f"robustness; allowed: "
+                f"{sorted(ROBUSTNESS_DELEGATE_ACTIONS)!r}",
+                rule="delegate_action",
+                hint="kernel-owned actions go via REQUEST(target_agent='kernel')",
+            )
+
+    def _check_update_state(self, payload: dict[str, Any]) -> None:
+        changes = payload.get("changes")
+        if not isinstance(changes, dict) or not changes:
+            raise PolicyViolation(
+                "update_state.changes must be a non-empty dict",
+                rule="payload",
+            )
+        core_fields = sorted(set(changes.keys()) & CORE_STATE_FIELDS)
+        if core_fields:
+            raise PolicyViolation(
+                "update_state cannot mutate core state fields: "
+                f"{core_fields!r}",
+                rule="state_field",
+            )
+        non_robust = sorted(set(changes.keys()) - ROBUSTNESS_STATE_FIELDS)
+        if non_robust:
+            raise PolicyViolation(
+                "update_state contains fields outside robustness allowlist: "
+                f"{non_robust!r}",
+                rule="state_field",
+                hint=f"allowed: {sorted(ROBUSTNESS_STATE_FIELDS)!r}",
+            )
+
+    def _check_send_message(self, payload: dict[str, Any]) -> None:
+        topic = str(payload.get("topic", "")).strip()
+        if not topic:
+            raise PolicyViolation(
+                "send_message.topic must be non-empty", rule="payload"
+            )
+        # Upstream soft-degrades unknown topics to ``observation``; we do
+        # not reject, so callers can surface ad-hoc observations.

--- a/robustness-agent/src/robustness_agent/decision/rca_engine.py
+++ b/robustness-agent/src/robustness_agent/decision/rca_engine.py
@@ -1,0 +1,295 @@
+"""RCA engines.
+
+M1.5 ships two engines:
+
+* :class:`NoopRcaEngine` — default. Returns "" so the ActionLadder skips
+  the ``rca_text`` field on findings.
+* :class:`LlmRcaEngine` — calls an OpenAI-compatible chat completion
+  endpoint (the chat-server proxying Codex / Claude). The engine is
+  guarded by :class:`RcaThrottle` so cost stays bounded:
+
+    - severity gate (default: only ``high`` symptoms),
+    - per-dedup-key cooldown (default 60s),
+    - per-tick cap (default 1 LLM call).
+
+Both engines expose ``async def summarize(symptom) -> str``. The
+ActionLadder ``await``s each call.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol, runtime_checkable
+
+import httpx
+
+from ..signals import Symptom, SymptomSeverity
+
+
+log = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class RcaEngine(Protocol):
+    """Minimal contract the ActionLadder consumes."""
+
+    async def summarize(self, symptom: Symptom) -> str:
+        ...
+
+
+@dataclass
+class NoopRcaEngine:
+    """Default engine: emits no RCA text."""
+
+    label: str = "noop"
+
+    async def summarize(self, symptom: Symptom) -> str:
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Throttle
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RcaThrottleConfig:
+    severity_min: SymptomSeverity = SymptomSeverity.HIGH
+    cooldown_seconds: float = 60.0
+    max_calls_per_tick: int = 1
+
+
+class RcaThrottle:
+    """Tick-aware cost guard for LLM RCA calls.
+
+    The ActionLadder/Reactor calls :meth:`begin_tick` once per tick (the
+    LlmRcaEngine does it lazily on the first ``summarize`` of a tick).
+    :meth:`should_call` then both checks the budget and returns whether
+    the engine should actually contact the LLM.
+    """
+
+    def __init__(self, config: RcaThrottleConfig | None = None) -> None:
+        self._config = config or RcaThrottleConfig()
+        self._last_called_unix: dict[tuple[str, ...], float] = {}
+        self._tick_calls = 0
+        self._tick_id: int | None = None
+
+    @property
+    def config(self) -> RcaThrottleConfig:
+        return self._config
+
+    def begin_tick(self, tick_id: int) -> None:
+        if self._tick_id != tick_id:
+            self._tick_id = tick_id
+            self._tick_calls = 0
+
+    def should_call(self, sym: Symptom, *, now_unix: float, tick_id: int) -> bool:
+        self.begin_tick(tick_id)
+        if sym.severity.rank < self._config.severity_min.rank:
+            return False
+        if self._tick_calls >= self._config.max_calls_per_tick:
+            return False
+        last = self._last_called_unix.get(sym.dedup_key())
+        if last is not None and (now_unix - last) < self._config.cooldown_seconds:
+            return False
+        return True
+
+    def record(self, sym: Symptom, *, now_unix: float) -> None:
+        self._last_called_unix[sym.dedup_key()] = now_unix
+        self._tick_calls += 1
+
+
+# ---------------------------------------------------------------------------
+# LLM engine
+# ---------------------------------------------------------------------------
+
+_SYSTEM_PROMPT = """\
+You are a Hyperloom robustness reactor RCA assistant. Given one symptom and \
+its evidence, write a concise root-cause summary in <= 6 sentences. \
+Focus on actionable remediation hints and observable evidence. If the \
+evidence is insufficient, reply exactly with: insufficient evidence.
+"""
+
+
+@dataclass
+class LlmRcaEngine:
+    """Async OpenAI-compatible RCA engine (chat-server proxy).
+
+    The HTTP layer goes directly through ``httpx.AsyncClient`` rather
+    than the ``openai`` SDK to keep error handling explicit and
+    mocking trivial. ``base_url`` should already include any version
+    prefix (eg. ``/v1``).
+    """
+
+    base_url: str
+    api_key: str
+    model: str = "claude-opus-4-7"
+    timeout_s: float = 8.0
+    max_chars: int = 1500
+    throttle: RcaThrottle | None = None
+    client: httpx.AsyncClient | None = None
+    extra_evidence_provider: Any | None = None
+    _owns_client: bool = field(default=False, init=False, repr=False)
+    _config_warned: bool = field(default=False, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if not self.base_url or not self.api_key:
+            log.warning("LlmRcaEngine constructed without base_url/api_key; calls will be skipped")
+        if self.client is None:
+            self.client = httpx.AsyncClient(
+                base_url=self.base_url.rstrip("/"),
+                timeout=httpx.Timeout(self.timeout_s),
+                headers={
+                    "Authorization": f"Bearer {self.api_key}",
+                    "Content-Type": "application/json",
+                },
+            )
+            self._owns_client = True
+        if self.throttle is None:
+            self.throttle = RcaThrottle()
+
+    async def aclose(self) -> None:
+        if self._owns_client and self.client is not None:
+            await self.client.aclose()
+
+    async def summarize(self, symptom: Symptom) -> str:
+        if not self.base_url or not self.api_key:
+            return ""
+        now_unix = time.time()
+        # tick_id = -1 routes per-tick budget to a single bucket when
+        # callers don't provide one; ActionLadder calls begin_tick via
+        # its own wrapper to scope buckets per tick (see decide()).
+        tick_id = getattr(self, "_current_tick_id", -1)
+        assert self.throttle is not None
+        if not self.throttle.should_call(symptom, now_unix=now_unix, tick_id=tick_id):
+            return ""
+
+        text = await self._call(symptom)
+        self.throttle.record(symptom, now_unix=now_unix)
+        return _truncate(text, self.max_chars)
+
+    def set_tick(self, tick_id: int) -> None:
+        """Hook used by ActionLadder to scope per-tick budgets."""
+        self._current_tick_id = tick_id
+        if self.throttle is not None:
+            self.throttle.begin_tick(tick_id)
+
+    async def _call(self, symptom: Symptom) -> str:
+        prompt = _build_user_prompt(symptom, self.extra_evidence_provider)
+        payload = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": _SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ],
+            "max_tokens": 600,
+            "temperature": 0.2,
+        }
+        try:
+            assert self.client is not None
+            resp = await self.client.post("/chat/completions", json=payload)
+        except httpx.TimeoutException:
+            log.warning("LlmRcaEngine: chat-server call timed out")
+            return ""
+        except httpx.RequestError as exc:
+            log.warning("LlmRcaEngine: chat-server request failed: %s", exc)
+            return ""
+        if resp.status_code >= 400:
+            log.warning(
+                "LlmRcaEngine: chat-server status=%d body=%s",
+                resp.status_code,
+                resp.text[:200],
+            )
+            return ""
+        try:
+            body = resp.json()
+        except ValueError:
+            log.warning("LlmRcaEngine: chat-server returned non-json body")
+            return ""
+        choices = body.get("choices") if isinstance(body, dict) else None
+        if not choices:
+            return ""
+        message = choices[0].get("message") if isinstance(choices[0], dict) else None
+        if not isinstance(message, dict):
+            return ""
+        content = message.get("content")
+        if isinstance(content, list):
+            # Some providers return a list of content parts
+            content = "".join(
+                part.get("text", "")
+                for part in content
+                if isinstance(part, dict)
+            )
+        return str(content or "").strip()
+
+
+def _build_user_prompt(
+    sym: Symptom,
+    extra_evidence_provider: Any | None,
+) -> str:
+    lines = [
+        f"symptom: {sym.name}",
+        f"severity: {sym.severity.value}",
+        f"summary: {sym.summary}",
+    ]
+    if sym.subject:
+        lines.append("subject:")
+        for k, v in sorted(sym.subject.items()):
+            lines.append(f"  {k}={v}")
+    if sym.evidence:
+        lines.append("evidence:")
+        lines.extend(_format_evidence(sym.evidence))
+    if sym.suggestion:
+        lines.append(f"suggestion_hint: {sym.suggestion}")
+    extra = _safe_extra_evidence(extra_evidence_provider, sym)
+    if extra:
+        lines.append("recent_log_errors:")
+        for entry in extra[:5]:
+            lines.append(f"  - {entry}")
+    return "\n".join(lines)
+
+
+def _format_evidence(payload: Any, prefix: str = "  ") -> list[str]:
+    if isinstance(payload, Mapping):
+        out: list[str] = []
+        for k in sorted(payload.keys()):
+            v = payload[k]
+            if isinstance(v, (str, int, float, bool)) or v is None:
+                out.append(f"{prefix}{k}: {v}")
+            else:
+                out.append(f"{prefix}{k}:")
+                out.extend(_format_evidence(v, prefix + "  "))
+        return out
+    if isinstance(payload, (list, tuple)):
+        return [f"{prefix}- {item}" for item in payload[:10]]
+    return [f"{prefix}{payload}"]
+
+
+def _safe_extra_evidence(provider: Any | None, sym: Symptom) -> list[str]:
+    if provider is None:
+        return []
+    try:
+        items = provider(sym)
+    except Exception:
+        log.exception("rca extra evidence provider failed")
+        return []
+    if not isinstance(items, list):
+        return []
+    return [str(it)[:240] for it in items][:10]
+
+
+def _truncate(text: str, max_chars: int) -> str:
+    text = (text or "").strip()
+    if len(text) <= max_chars:
+        return text
+    return text[: max_chars - 3].rstrip() + "..."
+
+
+__all__ = [
+    "LlmRcaEngine",
+    "NoopRcaEngine",
+    "RcaEngine",
+    "RcaThrottle",
+    "RcaThrottleConfig",
+]

--- a/robustness-agent/src/robustness_agent/factory.py
+++ b/robustness-agent/src/robustness_agent/factory.py
@@ -1,0 +1,247 @@
+"""High-level builders that turn a :class:`Config` into a running reactor.
+
+Two entry points:
+
+* :func:`build_reactor_components` returns the M1
+  :class:`~robustness_agent.role.reactor.ReactorComponents` plus the
+  underlying :class:`~robustness_agent.findings.sink.FindingSink` and
+  :class:`~robustness_agent.sources.server_client.RobustnessServerClient`
+  so callers can manage their lifecycles (e.g. ``await client.aclose()``
+  on shutdown).
+* :func:`build_backend` wraps :func:`build_reactor_components` and
+  hands back a ready-to-register
+  :class:`~robustness_agent.role.backend_adapter.RobustnessAgentBackend`.
+
+The factories never block on remote services — :class:`Config.discover`
+already probed reachability and recorded the URLs.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+import os
+
+from .config import Config
+from .decision.action_ladder import ActionLadder, ActionLadderConfig
+from .decision.policy_aware import PolicyAware
+from .decision.rca_engine import (
+    LlmRcaEngine,
+    NoopRcaEngine,
+    RcaEngine,
+    RcaThrottle,
+    RcaThrottleConfig,
+)
+from .findings.sink import FindingSink, FindingSinkConfig
+from .role.backend_adapter import RobustnessAgentBackend
+from .role.reactor import Reactor, ReactorComponents
+from .signals import Classifier, SymptomSeverity
+from .signals.crash import CrashConfig
+from .signals.event import EventConfig
+from .signals.health import HealthConfig
+from .signals.local_health import LocalHealthConfig
+from .signals.stall import StallConfig
+from .sources.base import DegradeRouter, Source, SourceData, SourceUnavailable
+from .sources.local_probe import LocalProbeConfig, LocalProbeSource
+from .sources.server_client import (
+    RobustnessServerClient,
+    RobustnessServerSource,
+)
+
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class ReactorBundle:
+    """Aggregate of reactor + lifecycle handles a caller needs to manage."""
+
+    reactor: Reactor
+    components: ReactorComponents
+    server_client: RobustnessServerClient | None
+    sink: FindingSink
+
+    async def aclose(self) -> None:
+        if self.server_client is not None:
+            await self.server_client.aclose()
+
+
+def build_reactor_components(
+    config: Config,
+    *,
+    rca: RcaEngine | None = None,
+    session_id: str | None = None,
+) -> ReactorBundle:
+    """Construct everything the reactor needs.
+
+    Parameters
+    ----------
+    config:
+        Discovered :class:`Config` — typically the result of
+        ``await Config.discover()``.
+    rca:
+        Optional RCA engine override. Defaults to :class:`NoopRcaEngine`
+        because M1 ships RCA disabled.
+    session_id:
+        Override for the FindingSink filename.  Defaults to
+        ``config.session_dir.name`` so each per-session sandbox writes
+        to a stable file.
+    """
+    # Primary source: robustness-server (omitted in local-only mode).
+    server_client: RobustnessServerClient | None = None
+    primary: Source
+    if config.robustness_server_url:
+        server_client = RobustnessServerClient(
+            config.robustness_server_url,
+            timeout_s=config.server_request_timeout_s,
+        )
+        primary = RobustnessServerSource(
+            server_client,
+            metrics_window_s=config.metrics_window_s,
+        )
+    else:
+        primary = _NoServerSource(
+            "robustness-server",
+            "config.robustness_server_url is empty",
+        )
+
+    fallback = LocalProbeSource(
+        LocalProbeConfig(
+            session_dir=config.session_dir,
+            process_patterns=tuple(
+                config.server_process_patterns + config.benchmark_process_patterns
+            ),
+            health_probe_targets=tuple(config.health_probe_targets),
+            health_probe_timeout_s=config.health_probe_timeout_s,
+        )
+    )
+
+    router = DegradeRouter(
+        primary,
+        fallback,
+        fail_threshold=config.source_fail_threshold,
+        recheck_interval_s=config.source_recheck_interval_s,
+    )
+
+    classifier = Classifier(
+        stall_config=StallConfig(
+            stall_timeout_s=config.agent_stall_timeout_s,
+        ),
+        crash_config=CrashConfig(),
+        event_config=EventConfig(),
+        health_config=HealthConfig(),
+        local_health_config=LocalHealthConfig(
+            gpu_temp_warn_c=config.gpu_temp_warn_c,
+        ),
+    )
+
+    ladder = ActionLadder(
+        config=ActionLadderConfig(cooldown_ticks=config.cooldown_ticks),
+    )
+
+    sink_session_id = session_id or config.session_dir.name or "default"
+    sink = FindingSink(
+        FindingSinkConfig(session_dir=config.session_dir, session_id=sink_session_id)
+    )
+
+    rca_engine: RcaEngine = rca if rca is not None else _build_rca_engine(config)
+
+    components = ReactorComponents(
+        router=router,
+        classifier=classifier,
+        ladder=ladder,
+        policy=PolicyAware(),
+        sink=sink,
+        rca=rca_engine,
+    )
+    return ReactorBundle(
+        reactor=Reactor(components),
+        components=components,
+        server_client=server_client,
+        sink=sink,
+    )
+
+
+def build_backend(
+    config: Config,
+    *,
+    rca: RcaEngine | None = None,
+    session_id: str | None = None,
+) -> tuple[RobustnessAgentBackend, ReactorBundle]:
+    """Return a Backend instance + the bundle to manage its lifecycle."""
+    bundle = build_reactor_components(config, rca=rca, session_id=session_id)
+    backend = RobustnessAgentBackend(reactor=bundle.reactor)
+    return backend, bundle
+
+
+def _build_rca_engine(config: Config) -> RcaEngine:
+    """Choose between Noop and Llm based on config + env override."""
+    if os.environ.get("ROBUSTNESS_LLM_RCA_DISABLED", "").lower() in {"1", "true", "yes"}:
+        log.info("LLM RCA disabled via ROBUSTNESS_LLM_RCA_DISABLED env override")
+        return NoopRcaEngine()
+    if config.llm_rca_enabled is False:
+        return NoopRcaEngine()
+    if not config.llm_base_url or not config.llm_api_key:
+        if config.llm_rca_enabled is True:
+            log.warning("llm_rca_enabled=True but base_url/api_key missing; using NoopRcaEngine")
+        return NoopRcaEngine()
+
+    severity_min = _parse_severity(config.llm_rca_severity_min)
+    throttle = RcaThrottle(
+        RcaThrottleConfig(
+            severity_min=severity_min,
+            cooldown_seconds=config.llm_rca_cooldown_s,
+            max_calls_per_tick=config.llm_rca_max_calls_per_tick,
+        )
+    )
+    log.info(
+        "LLM RCA enabled: model=%s severity_min=%s cooldown=%.1fs max_per_tick=%d",
+        config.llm_model,
+        severity_min.value,
+        config.llm_rca_cooldown_s,
+        config.llm_rca_max_calls_per_tick,
+    )
+    return LlmRcaEngine(
+        base_url=config.llm_base_url,
+        api_key=config.llm_api_key,
+        model=config.llm_model,
+        timeout_s=config.llm_rca_timeout_s,
+        max_chars=config.llm_rca_max_chars,
+        throttle=throttle,
+    )
+
+
+def _parse_severity(value: str) -> SymptomSeverity:
+    normalized = (value or "").strip().lower()
+    if normalized in {"low", "info", "observe"}:
+        return SymptomSeverity.LOW
+    if normalized in {"medium", "warn", "warning"}:
+        return SymptomSeverity.MEDIUM
+    return SymptomSeverity.HIGH
+
+
+@dataclass
+class _NoServerSource:
+    """Permanent stub used when no robustness-server URL is configured.
+
+    DegradeRouter degrades it after ``fail_threshold`` ticks, after which
+    the LocalProbe takes over without further probes.
+    """
+
+    name: str
+    reason: str
+
+    async def fetch(self, ctx: Any) -> SourceData:
+        raise SourceUnavailable(self.reason)
+
+
+__all__ = [
+    "ReactorBundle",
+    "build_backend",
+    "build_reactor_components",
+]

--- a/robustness-agent/src/robustness_agent/findings/__init__.py
+++ b/robustness-agent/src/robustness_agent/findings/__init__.py
@@ -1,0 +1,11 @@
+"""Persistent findings sink.
+
+The reactor hands :class:`~robustness_agent.decision.action_ladder.Finding`
+records to a sink each tick. M1 only writes a JSONL file under the
+session directory; the M5 milestone replaces / augments this with an
+HTTP POST to robustness-server.
+"""
+
+from .sink import FindingSink, FindingSinkConfig
+
+__all__ = ["FindingSink", "FindingSinkConfig"]

--- a/robustness-agent/src/robustness_agent/findings/sink.py
+++ b/robustness-agent/src/robustness_agent/findings/sink.py
@@ -1,0 +1,87 @@
+"""Append-only JSONL sink for ladder findings.
+
+File layout::
+
+    {session_dir}/agents/robustness/findings/{session_id}.jsonl
+
+Each line is one :class:`Finding`, serialised by :func:`finding_to_row`.
+Writes go through :func:`asyncio.to_thread` so the reactor's tick
+budget is not blocked on disk I/O.
+
+The sink is best-effort: a write failure logs a single WARN per error
+class but never raises into the reactor.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+import asyncio
+
+from ..decision.action_ladder import Finding
+
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class FindingSinkConfig:
+    """Where the sink writes."""
+
+    session_dir: Path
+    session_id: str = "default"
+    subdir: str = "agents/robustness/findings"
+
+    @property
+    def file_path(self) -> Path:
+        safe = self.session_id or "default"
+        return self.session_dir / self.subdir / f"{safe}.jsonl"
+
+
+class FindingSink:
+    """JSONL append sink with simple error suppression."""
+
+    def __init__(self, config: FindingSinkConfig) -> None:
+        self._config = config
+        self._warned: set[str] = set()
+
+    @property
+    def file_path(self) -> Path:
+        return self._config.file_path
+
+    async def append_many(self, findings: Iterable[Finding]) -> int:
+        rows = [finding_to_row(f) for f in findings]
+        if not rows:
+            return 0
+        await asyncio.to_thread(self._write_rows, rows)
+        return len(rows)
+
+    def _write_rows(self, rows: list[dict[str, Any]]) -> None:
+        path = self._config.file_path
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as handle:
+                for row in rows:
+                    handle.write(json.dumps(row, ensure_ascii=False))
+                    handle.write("\n")
+        except OSError as exc:
+            self._warn_once("io", f"finding sink io error: {exc}")
+
+    def _warn_once(self, key: str, message: str) -> None:
+        if key in self._warned:
+            return
+        log.warning("findings sink: %s", message)
+        self._warned.add(key)
+
+
+def finding_to_row(finding: Finding) -> dict[str, Any]:
+    """Serialise a :class:`Finding` for JSONL persistence."""
+    row = asdict(finding)
+    return row
+
+
+__all__ = ["FindingSink", "FindingSinkConfig", "finding_to_row"]

--- a/robustness-agent/src/robustness_agent/main.py
+++ b/robustness-agent/src/robustness_agent/main.py
@@ -1,14 +1,29 @@
-"""Entry point for the Robustness Agent daemon."""
+"""Entry point for the Robustness Agent daemon.
+
+Two run modes:
+
+* ``--mode reactor`` (default, M1): runs the new symptom -> intent
+  pipeline in standalone form, polling sources every
+  ``standalone_tick_interval_s`` seconds and writing findings to disk.
+  This is mainly used for dev / smoke testing; production uses the
+  SINGLE_PROC backend invoked by the Coordinator.
+* ``--mode legacy``: keeps the previous RobustnessAgent loop available
+  for environments that still depend on direct conductor.db writes.
+"""
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import logging
 import signal
 import sys
+import time
+from pathlib import Path
 
-from .agent import RobustnessAgent
 from .config import Config
+from .factory import build_backend
+from .role.prompt_inputs import ReactorContext, SharedStateSnapshot
 
 
 def _setup_logging() -> None:
@@ -20,13 +35,63 @@ def _setup_logging() -> None:
     )
 
 
-async def _async_main() -> None:
+async def _run_reactor_mode(config: Config) -> None:
+    """Standalone reactor loop for dev / debugging.
+
+    Polls the configured sources at ``standalone_tick_interval_s`` and
+    writes findings to disk. Coordinator integration uses the same
+    Backend instance through SINGLE_PROC instead.
+    """
     log = logging.getLogger("robustness_agent")
+    backend, bundle = build_backend(config)
 
-    config = await Config.discover()
+    stop = asyncio.Event()
+    loop = asyncio.get_running_loop()
 
+    def _shutdown(sig: signal.Signals) -> None:
+        log.info("Received %s, shutting down", sig.name)
+        stop.set()
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(sig, _shutdown, sig)
+        except NotImplementedError:
+            pass
+
+    log.info(
+        "Reactor mode running tick=%.1fs server=%s session_dir=%s",
+        config.standalone_tick_interval_s,
+        config.robustness_server_url or "(local-only)",
+        config.session_dir,
+    )
+
+    try:
+        while not stop.is_set():
+            ctx = ReactorContext(
+                tick_index=0,
+                shared_state=SharedStateSnapshot(session_id=config.session_dir.name),
+                inbox=[],
+                now_unix=time.time(),
+            )
+            try:
+                intents = await bundle.reactor.tick(ctx)
+                log.debug("tick=%d emitted %d intents", bundle.reactor.tick_index, len(intents))
+            except Exception:
+                log.exception("standalone reactor tick failed")
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=config.standalone_tick_interval_s)
+            except asyncio.TimeoutError:
+                pass
+    finally:
+        await bundle.aclose()
+
+
+async def _run_legacy_mode(config: Config) -> None:
+    """Original event-driven RobustnessAgent loop, kept for compatibility."""
+    from .agent import RobustnessAgent
+
+    log = logging.getLogger("robustness_agent")
     agent = RobustnessAgent(config)
-
     loop = asyncio.get_running_loop()
 
     def _shutdown(sig: signal.Signals) -> None:
@@ -40,6 +105,26 @@ async def _async_main() -> None:
             pass
 
     await agent.run_forever()
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="robustness-agent")
+    parser.add_argument(
+        "--mode",
+        choices=("reactor", "legacy"),
+        default="reactor",
+        help="reactor: M1 standalone loop (default); legacy: previous agent.py loop",
+    )
+    return parser.parse_args(argv)
+
+
+async def _async_main(argv: list[str] | None = None) -> None:
+    args = _parse_args(argv)
+    config = await Config.discover()
+    if args.mode == "reactor":
+        await _run_reactor_mode(config)
+    else:
+        await _run_legacy_mode(config)
 
 
 def main() -> None:

--- a/robustness-agent/src/robustness_agent/role/__init__.py
+++ b/robustness-agent/src/robustness_agent/role/__init__.py
@@ -1,0 +1,44 @@
+"""Robustness reactor role layer.
+
+Bridges the Coordinator's Backend protocol (or a multi-cli inbox/outbox
+transport in later milestones) to the agent's symptom -> decision pipeline.
+
+Only the wire-format primitives (envelope + prompt_inputs) are
+re-exported at package level. Higher-level pieces (:class:`Reactor`,
+:class:`RobustnessAgentBackend`) live in submodules to avoid circular
+imports between ``role`` and ``decision``.
+"""
+
+from .envelope import (
+    BackendTurnResult,
+    Intent,
+    IntentType,
+    build_alert,
+    build_envelope_dict,
+    build_escalate,
+    build_heartbeat,
+    build_send_message,
+    build_update_state,
+)
+from .prompt_inputs import (
+    InboxItem,
+    ReactorContext,
+    SharedStateSnapshot,
+    from_coordinator_prompt,
+)
+
+__all__ = [
+    "BackendTurnResult",
+    "InboxItem",
+    "Intent",
+    "IntentType",
+    "ReactorContext",
+    "SharedStateSnapshot",
+    "build_alert",
+    "build_envelope_dict",
+    "build_escalate",
+    "build_heartbeat",
+    "build_send_message",
+    "build_update_state",
+    "from_coordinator_prompt",
+]

--- a/robustness-agent/src/robustness_agent/role/backend_adapter.py
+++ b/robustness-agent/src/robustness_agent/role/backend_adapter.py
@@ -1,0 +1,74 @@
+"""SINGLE_PROC adapter: expose :class:`Reactor` as a Coordinator Backend.
+
+Mirrors the Backend protocol declared by
+``inference_optimizer/orchestrator/backends/base.py``:
+
+.. code-block:: python
+
+    class Backend(Protocol):
+        name: str
+
+        async def run(
+            self,
+            prompt: str,
+            *,
+            system_prompt: str | None = None,
+            tools: list[str] | None = None,
+            max_turns: int = 1,
+        ) -> BackendTurnResult: ...
+
+The Coordinator imports :class:`RobustnessAgentBackend` directly from
+this module when the orchestration plan selects ``robustness`` and the
+deployment is configured for SINGLE_PROC. Multi-CLI / Claw subsession
+modes do not use this adapter — they ship the reactor inside a long-
+running CLI that reads/writes JSONL files instead (M3).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from .envelope import BackendTurnResult
+from .prompt_inputs import from_coordinator_prompt
+from .reactor import Reactor
+
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class RobustnessAgentBackend:
+    """Async :class:`Reactor` -> Coordinator Backend bridge."""
+
+    reactor: Reactor
+    name: str = "robustness"
+
+    async def run(
+        self,
+        prompt: str,
+        *,
+        system_prompt: str | None = None,
+        tools: list[str] | None = None,
+        max_turns: int = 1,
+    ) -> BackendTurnResult:
+        ctx = from_coordinator_prompt(prompt)
+        intents = await self.reactor.tick(ctx)
+        if ctx.parse_warnings:
+            log.debug(
+                "robustness reactor parse warnings: %s",
+                ctx.parse_warnings,
+            )
+        metadata: dict[str, Any] = {
+            "tick_index": self.reactor.tick_index,
+            "parse_warnings": list(ctx.parse_warnings),
+        }
+        return BackendTurnResult(
+            intents=intents,
+            raw_text="(robustness-agent)",
+            metadata=metadata,
+        )
+
+
+__all__ = ["RobustnessAgentBackend"]

--- a/robustness-agent/src/robustness_agent/role/envelope.py
+++ b/robustness-agent/src/robustness_agent/role/envelope.py
@@ -1,0 +1,365 @@
+"""Intent envelope contract.
+
+This module mirrors the wire shape defined by
+``inference_optimizer/orchestrator/intent_parser.py`` so that the
+robustness reactor can construct intents that the Coordinator's
+``PolicyGate`` accepts without change.
+
+Two integration surfaces are supported:
+
+* SINGLE_PROC: the Coordinator imports :class:`RobustnessAgentBackend`
+  and calls ``backend.run(...)`` per tick. The backend returns
+  :class:`BackendTurnResult` carrying a list of :class:`Intent`.
+
+* MULTI_CLI (later milestone): the long-running CLI writes one envelope
+  dict per line into ``$SESSION_DIR/agents/robustness/outbox.jsonl``.
+  :func:`build_envelope_dict` produces that JSON-serialisable shape.
+
+The class layout intentionally avoids importing from inference_optimizer
+to keep this package independent. A contract test cross-checks the
+``IntentType`` / ``_PAYLOAD_REQUIRED`` table against the upstream module
+when both packages are importable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Mapping
+
+
+class IntentType(str, Enum):
+    """Intent vocabulary mirrored from upstream ``intent_parser.IntentType``.
+
+    Values are the exact strings the Coordinator persists; do not rename
+    without coordinating with inference_optimizer.
+    """
+
+    SEND_MESSAGE = "send_message"
+    DELEGATE = "delegate"
+    PROPOSE_ACTION = "propose_action"
+    UPDATE_STATE = "update_state"
+    UPDATE_PERSONA = "update_persona"
+    ASK_QUESTION = "ask_question"
+    ANSWER = "answer"
+    ALERT = "alert"
+    REQUEST = "request"
+    RESPONSE = "response"
+    REVIEW_VERDICT = "review_verdict"
+    KILL_TASK = "kill_task"
+    FORCE_DISPATCH = "force_dispatch"
+    PRUNE_BRANCH = "prune_branch"
+    ESCALATE_STRATEGY_CHANGE = "escalate_strategy_change"
+
+
+# Per-intent required payload fields. Identical to upstream
+# ``policy._PAYLOAD_REQUIRED``; ``decision.policy_aware`` reuses the same
+# table to validate intents before they leave the reactor.
+PAYLOAD_REQUIRED: Mapping[IntentType, tuple[str, ...]] = {
+    IntentType.SEND_MESSAGE: ("topic",),
+    IntentType.DELEGATE: ("action_name",),
+    IntentType.PROPOSE_ACTION: ("action_name", "predicted_gain_pct"),
+    IntentType.UPDATE_STATE: ("changes",),
+    IntentType.UPDATE_PERSONA: ("body_md",),
+    IntentType.ASK_QUESTION: ("topic", "question"),
+    IntentType.ANSWER: ("in_reply_to", "answer"),
+    IntentType.ALERT: ("severity", "summary"),
+    IntentType.REQUEST: ("target_agent", "kind"),
+    IntentType.RESPONSE: ("in_reply_to", "kind"),
+    IntentType.REVIEW_VERDICT: ("target_proposal_msg_id", "verdict"),
+    IntentType.KILL_TASK: ("task_id", "reason"),
+    IntentType.FORCE_DISPATCH: ("task_id", "reason"),
+    IntentType.PRUNE_BRANCH: ("family", "reason"),
+    IntentType.ESCALATE_STRATEGY_CHANGE: ("reason", "next_action_hint"),
+}
+
+
+# Intents that PolicyGate restricts to ``source == "robustness"``. The
+# reactor guards these locally to surface configuration / programming
+# bugs early; the gate still enforces them server-side.
+ROBUSTNESS_ONLY_INTENTS: frozenset[IntentType] = frozenset({
+    IntentType.KILL_TASK,
+    IntentType.FORCE_DISPATCH,
+    IntentType.PRUNE_BRANCH,
+    IntentType.ESCALATE_STRATEGY_CHANGE,
+})
+
+
+# Intents the robustness role may emit. Mirrors ``_ROBUSTNESS_INTENTS``
+# in upstream agent_role.py. PROPOSE_ACTION / REQUEST / RESPONSE /
+# REVIEW_VERDICT / ASK_QUESTION continuations handled by other roles are
+# excluded so a programming mistake is caught at construction time.
+ROBUSTNESS_ALLOWED_INTENTS: frozenset[IntentType] = frozenset({
+    IntentType.SEND_MESSAGE,
+    IntentType.ASK_QUESTION,
+    IntentType.ANSWER,
+    IntentType.ALERT,
+    IntentType.UPDATE_PERSONA,
+    IntentType.UPDATE_STATE,
+    IntentType.DELEGATE,
+    IntentType.KILL_TASK,
+    IntentType.FORCE_DISPATCH,
+    IntentType.PRUNE_BRANCH,
+    IntentType.ESCALATE_STRATEGY_CHANGE,
+})
+
+
+# Severities accepted by ``alert`` and ``escalate_strategy_change`` per
+# DESIGN v0.6 13.2. ``high`` raises priority 0 broadcasts.
+ALERT_SEVERITIES: frozenset[str] = frozenset({"low", "medium", "high"})
+
+
+# Allowed kill_task scopes per upstream ``KILL_TASK_ALLOWED_SCOPES``.
+KILL_TASK_ALLOWED_SCOPES: frozenset[str] = frozenset({"task"})
+
+
+# Handle actions the robustness role is allowed to delegate. Upstream
+# documents the trio in ``system_prompts/robustness.md``.
+ROBUSTNESS_DELEGATE_ACTIONS: frozenset[str] = frozenset({
+    "accuracy_gate",
+    "recover",
+    "server_lifecycle",
+})
+
+
+# Core SharedState fields the robustness role must not write via
+# ``update_state``. Mirrors upstream ``CORE_STATE_FIELDS``.
+CORE_STATE_FIELDS: frozenset[str] = frozenset({
+    "current_best",
+    "stop_reason",
+    "cumulative_gain",
+    "baseline_tput",
+    "baseline_accuracy",
+    "session_id",
+    "model_path",
+    "model_name",
+    "model_class",
+    "start_ts",
+    "max_minutes",
+})
+
+
+# Robustness may only mutate these state fields directly.
+ROBUSTNESS_STATE_FIELDS: frozenset[str] = frozenset({
+    "crash_count",
+    "current_action",
+})
+
+
+@dataclass
+class Intent:
+    """One validated intent from the reactor.
+
+    The shape matches upstream ``intent_parser.Intent``: a typed enum
+    plus a free-form ``payload`` dict. Construction does not validate
+    payload contents; use :func:`assert_payload_valid` (see
+    ``decision.policy_aware``) before emitting.
+    """
+
+    type: IntentType
+    payload: dict[str, Any] = field(default_factory=dict)
+
+    def to_envelope_item(self) -> dict[str, Any]:
+        """Return the dict shape used inside an ``intents`` envelope."""
+        return {"intent_type": self.type.value, "payload": dict(self.payload)}
+
+
+@dataclass
+class BackendTurnResult:
+    """Mirror of upstream ``backends.base.BackendTurnResult``.
+
+    The Coordinator inspects ``intents`` and ignores the rest in
+    P0-3 / P0-4. ``raw_text`` is recorded for debugging only.
+    """
+
+    intents: list[Intent] = field(default_factory=list)
+    raw_text: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Intent builders
+# ---------------------------------------------------------------------------
+
+def build_heartbeat(body_md: str = "ok (robustness-agent)") -> Intent:
+    """Default tick-end fallback when no symptom warrants an emit."""
+    return Intent(
+        type=IntentType.SEND_MESSAGE,
+        payload={"topic": "heartbeat", "body_md": body_md},
+    )
+
+
+def build_send_message(
+    topic: str,
+    *,
+    body_md: str | None = None,
+    to: str | None = None,
+    extras: Mapping[str, Any] | None = None,
+) -> Intent:
+    """Generic send_message builder.
+
+    The Coordinator soft-degrades unknown topics to ``observation`` per
+    DESIGN v0.6 13.2; callers should still use a known topic.
+    """
+    payload: dict[str, Any] = {"topic": topic}
+    if body_md is not None:
+        payload["body_md"] = body_md
+    if to:
+        payload["to"] = to
+    if extras:
+        for k, v in extras.items():
+            if k == "topic":
+                continue
+            payload[k] = v
+    return Intent(type=IntentType.SEND_MESSAGE, payload=payload)
+
+
+def build_alert(
+    severity: str,
+    summary: str,
+    *,
+    detail: Mapping[str, Any] | None = None,
+) -> Intent:
+    """Construct an ``alert`` intent.
+
+    severity must be one of :data:`ALERT_SEVERITIES`. ``summary`` is the
+    one-line message PolicyGate sees; ``detail`` carries structured
+    evidence the Coordinator persists verbatim.
+    """
+    if severity not in ALERT_SEVERITIES:
+        raise ValueError(
+            f"alert severity {severity!r} not in {sorted(ALERT_SEVERITIES)!r}"
+        )
+    if not summary:
+        raise ValueError("alert summary must be non-empty")
+    payload: dict[str, Any] = {"severity": severity, "summary": summary}
+    if detail is not None:
+        payload["detail"] = dict(detail)
+    return Intent(type=IntentType.ALERT, payload=payload)
+
+
+def build_escalate(
+    reason: str,
+    next_action_hint: str,
+    *,
+    severity: str = "medium",
+) -> Intent:
+    """Construct an ``escalate_strategy_change`` intent.
+
+    Robustness-only. Non-destructive priority-0 broadcast hint per
+    DESIGN v0.6 19.3.4.
+    """
+    if not reason:
+        raise ValueError("escalate reason must be non-empty")
+    if not next_action_hint:
+        raise ValueError("escalate next_action_hint must be non-empty")
+    if severity not in ALERT_SEVERITIES:
+        raise ValueError(
+            f"escalate severity {severity!r} not in {sorted(ALERT_SEVERITIES)!r}"
+        )
+    return Intent(
+        type=IntentType.ESCALATE_STRATEGY_CHANGE,
+        payload={
+            "reason": reason,
+            "next_action_hint": next_action_hint,
+            "severity": severity,
+        },
+    )
+
+
+def build_kill_task(task_id: str, reason: str) -> Intent:
+    """Construct a ``kill_task`` intent.
+
+    Robustness-only. ``scope`` is hardcoded to ``"task"`` because the
+    upstream PolicyGate v0.6 rejects any other value (server / process
+    kills go through delegate(server_lifecycle) under IR-5).
+    """
+    if not task_id:
+        raise ValueError("kill_task task_id must be non-empty")
+    if not reason:
+        raise ValueError("kill_task reason must be non-empty")
+    return Intent(
+        type=IntentType.KILL_TASK,
+        payload={"task_id": task_id, "reason": reason, "scope": "task"},
+    )
+
+
+def build_force_dispatch(task_id: str, reason: str) -> Intent:
+    """Construct a ``force_dispatch`` intent. Robustness-only."""
+    if not task_id:
+        raise ValueError("force_dispatch task_id must be non-empty")
+    if not reason:
+        raise ValueError("force_dispatch reason must be non-empty")
+    return Intent(
+        type=IntentType.FORCE_DISPATCH,
+        payload={"task_id": task_id, "reason": reason},
+    )
+
+
+def build_prune_branch(family: str, reason: str) -> Intent:
+    """Construct a ``prune_branch`` intent. Robustness-only."""
+    if not family:
+        raise ValueError("prune_branch family must be non-empty")
+    if not reason:
+        raise ValueError("prune_branch reason must be non-empty")
+    return Intent(
+        type=IntentType.PRUNE_BRANCH,
+        payload={"family": family, "reason": reason},
+    )
+
+
+def build_delegate(
+    action_name: str,
+    *,
+    params: Mapping[str, Any] | None = None,
+    idempotency_key: str | None = None,
+) -> Intent:
+    """Construct a ``delegate`` intent.
+
+    Robustness may only delegate handle actions listed in
+    :data:`ROBUSTNESS_DELEGATE_ACTIONS`. Other action names will be
+    rejected by PolicyGate's ``KERNEL_OWNED_ACTIONS`` / role check; we
+    fail fast locally to keep error context.
+    """
+    if action_name not in ROBUSTNESS_DELEGATE_ACTIONS:
+        raise ValueError(
+            f"delegate action_name {action_name!r} not allowed for robustness "
+            f"(allowed: {sorted(ROBUSTNESS_DELEGATE_ACTIONS)!r})"
+        )
+    payload: dict[str, Any] = {"action_name": action_name}
+    if params is not None:
+        payload["params"] = dict(params)
+    if idempotency_key:
+        payload["idempotency_key"] = idempotency_key
+    return Intent(type=IntentType.DELEGATE, payload=payload)
+
+
+def build_update_state(changes: Mapping[str, Any]) -> Intent:
+    """Construct an ``update_state`` intent.
+
+    Restricted to fields in :data:`ROBUSTNESS_STATE_FIELDS`;
+    fields in :data:`CORE_STATE_FIELDS` are rejected upstream.
+    """
+    if not changes:
+        raise ValueError("update_state changes must be a non-empty mapping")
+    illegal = sorted(set(changes.keys()) - ROBUSTNESS_STATE_FIELDS)
+    if illegal:
+        raise ValueError(
+            "update_state contains fields outside robustness allowlist: "
+            f"{illegal!r}; allowed: {sorted(ROBUSTNESS_STATE_FIELDS)!r}"
+        )
+    return Intent(type=IntentType.UPDATE_STATE, payload={"changes": dict(changes)})
+
+
+# ---------------------------------------------------------------------------
+# Envelope serialisation (multi-cli outbox, jsonl rows)
+# ---------------------------------------------------------------------------
+
+def build_envelope_dict(intents: list[Intent]) -> dict[str, Any]:
+    """Serialise a list of intents into a single envelope dict.
+
+    Matches upstream ``INTENT_ENVELOPE_SCHEMA``. Used by the multi-cli
+    transport's outbox writer; the SINGLE_PROC backend uses the
+    :class:`BackendTurnResult` form instead.
+    """
+    return {"intents": [i.to_envelope_item() for i in intents]}

--- a/robustness-agent/src/robustness_agent/role/prompt_inputs.py
+++ b/robustness-agent/src/robustness_agent/role/prompt_inputs.py
@@ -1,0 +1,291 @@
+"""Parse Coordinator-rendered prompts and inbox.jsonl into ReactorContext.
+
+The Coordinator's ``_compose_prompt`` (DESIGN v0.6 §8.3) emits a
+deterministic two-section text:
+
+    === Shared session state ===
+    session_id=...
+    model=<name>  class=<klass>
+    baseline_tput=...  baseline_acc=...
+    ...
+    crash_count=...
+    current_action=...
+    ...
+    === Inbox for <agent> [(newest last)] ===
+      seq=<int> msg_id=<hex> from=<agent> topic=<topic> payload={'k': 'v', ...}
+      ...
+
+Or, when no new messages exist:
+
+    === Inbox for <agent> ===
+    (no new messages)
+
+The robustness reactor only consumes a handful of the SharedState
+fields plus the inbox tail, so this module deliberately ignores most of
+the prompt.  Parse failures are logged once and surface as an empty
+:class:`ReactorContext` rather than raising — the reactor's heartbeat
+fallback keeps the loop alive even if upstream renames a section.
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+
+log = logging.getLogger(__name__)
+
+
+# Regex ordering: anchored to the row prefix the Coordinator emits with two
+# leading spaces; ``.+?`` for topic guards against payloads whose dict repr
+# contains a literal ``topic=`` substring.
+_INBOX_LINE_RE = re.compile(
+    r"^\s+seq=(?P<seq>\d+)\s+msg_id=(?P<msg_id>\S+)\s+from=(?P<from_agent>\S+)\s+"
+    r"topic=(?P<topic>\S+)\s+payload=(?P<payload>.+)$"
+)
+
+_SHARED_HEADER = "=== Shared session state ==="
+_INBOX_HEADER_PREFIX = "=== Inbox for "
+_KB_HEADER_PREFIX = "=== Knowledge base hints"
+
+# SharedState lines we care about for M1.
+_SCALAR_KEYS = {
+    "session_id",
+    "baseline_tput",
+    "cumulative_gain",
+    "crash_count",
+    "current_action",
+}
+
+
+@dataclass
+class InboxItem:
+    seq: int
+    msg_id: str
+    from_agent: str
+    topic: str
+    payload: dict[str, Any] = field(default_factory=dict)
+    raw_payload: str = ""
+
+
+@dataclass
+class SharedStateSnapshot:
+    session_id: str = ""
+    model_name: str = ""
+    model_class: str = ""
+    baseline_tput: float = 0.0
+    cumulative_gain: float = 0.0
+    crash_count: int = 0
+    current_action: str = ""
+
+
+@dataclass
+class ReactorContext:
+    """Per-tick input for :class:`Reactor`.
+
+    Built by :func:`from_coordinator_prompt` (SINGLE_PROC) or
+    :func:`from_inbox_jsonl` (MULTI_CLI; M3).  The reactor does not need
+    to know which transport produced the context.
+    """
+
+    tick_index: int = 0
+    shared_state: SharedStateSnapshot = field(default_factory=SharedStateSnapshot)
+    inbox: list[InboxItem] = field(default_factory=list)
+    now_unix: float = field(default_factory=time.time)
+    parse_warnings: list[str] = field(default_factory=list)
+
+
+def from_coordinator_prompt(
+    prompt: str,
+    *,
+    tick_index: int = 0,
+    now_unix: float | None = None,
+) -> ReactorContext:
+    """Parse the text produced by ``Coordinator._compose_prompt``.
+
+    Returns an empty / partially populated context on parse drift; the
+    reactor's heartbeat fallback ensures liveness, and a single WARN is
+    logged so deployments notice schema drift.
+    """
+    if now_unix is None:
+        now_unix = time.time()
+    if not prompt:
+        return ReactorContext(
+            tick_index=tick_index,
+            now_unix=now_unix,
+            parse_warnings=["empty prompt"],
+        )
+
+    sections = _split_sections(prompt)
+    snapshot = _parse_shared_state(sections.get("shared_state", ""))
+    inbox, warnings = _parse_inbox(sections.get("inbox", ""))
+    if not sections:
+        warnings.append("no recognised sections in prompt")
+    return ReactorContext(
+        tick_index=tick_index,
+        shared_state=snapshot,
+        inbox=inbox,
+        now_unix=now_unix,
+        parse_warnings=warnings,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section splitting
+# ---------------------------------------------------------------------------
+
+def _split_sections(prompt: str) -> dict[str, str]:
+    """Walk the prompt line-by-line and group lines by section.
+
+    Returns a dict with keys ``shared_state`` / ``inbox``; KB hints and
+    other sections are dropped because the robustness reactor does not
+    consume them.
+    """
+    sections: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in prompt.splitlines():
+        stripped = line.strip()
+        if stripped == _SHARED_HEADER:
+            current = "shared_state"
+            sections.setdefault(current, [])
+            continue
+        if stripped.startswith(_INBOX_HEADER_PREFIX) and stripped.endswith("==="):
+            current = "inbox"
+            sections.setdefault(current, [])
+            continue
+        if stripped.startswith(_KB_HEADER_PREFIX):
+            current = "kb"
+            sections.setdefault(current, [])
+            continue
+        if current is None:
+            continue
+        sections[current].append(line)
+    return {k: "\n".join(v) for k, v in sections.items()}
+
+
+# ---------------------------------------------------------------------------
+# Shared state parsing
+# ---------------------------------------------------------------------------
+
+def _parse_shared_state(body: str) -> SharedStateSnapshot:
+    snapshot = SharedStateSnapshot()
+    for raw in body.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith("model="):
+            snapshot.model_name, snapshot.model_class = _parse_model_line(line)
+            continue
+        key, sep, value = line.partition("=")
+        if not sep:
+            continue
+        key = key.strip()
+        value = value.strip()
+        if key not in _SCALAR_KEYS:
+            continue
+        head = _split_double_space(value)
+        if key == "session_id":
+            snapshot.session_id = "" if head == "(unset)" else head
+        elif key == "baseline_tput":
+            snapshot.baseline_tput = _coerce_float(head)
+        elif key == "cumulative_gain":
+            snapshot.cumulative_gain = _coerce_float(head.rstrip("%"))
+        elif key == "crash_count":
+            snapshot.crash_count = _coerce_int(head)
+        elif key == "current_action":
+            snapshot.current_action = "" if head == "(idle)" else head
+    return snapshot
+
+
+def _parse_model_line(line: str) -> tuple[str, str]:
+    """Decode ``model=<name>  class=<klass>`` (double-space separator)."""
+    body = line[len("model="):]
+    name, _, rest = body.partition("  class=")
+    name = name.strip()
+    klass = rest.strip()
+    if name == "(unset)":
+        name = ""
+    if klass == "(unset)":
+        klass = ""
+    return name, klass
+
+
+def _split_double_space(value: str) -> str:
+    """Trim a SharedState scalar value at the next ``key=`` neighbour.
+
+    ``to_prompt_summary`` joins two scalars with two spaces in a few
+    lines (``baseline_tput=...  baseline_acc=...``); the second key/value
+    is not interesting to the robustness reactor, so we cut at the
+    double-space boundary.
+    """
+    return value.split("  ", 1)[0].strip()
+
+
+def _coerce_float(value: str) -> float:
+    try:
+        return float(value)
+    except ValueError:
+        return 0.0
+
+
+def _coerce_int(value: str) -> int:
+    try:
+        return int(value)
+    except ValueError:
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# Inbox parsing
+# ---------------------------------------------------------------------------
+
+def _parse_inbox(body: str) -> tuple[list[InboxItem], list[str]]:
+    items: list[InboxItem] = []
+    warnings: list[str] = []
+    for raw in body.splitlines():
+        if not raw.strip():
+            continue
+        if raw.lstrip().startswith("(no new messages)"):
+            return [], warnings
+        match = _INBOX_LINE_RE.match(raw)
+        if not match:
+            warnings.append(f"unparsable inbox line: {raw!r}")
+            log.warning("prompt_inputs: skipping unparsable inbox line: %r", raw)
+            continue
+        try:
+            seq = int(match.group("seq"))
+        except ValueError:
+            warnings.append(f"non-integer seq in {raw!r}")
+            continue
+        payload_text = match.group("payload")
+        payload, payload_warn = _decode_payload(payload_text)
+        if payload_warn:
+            warnings.append(payload_warn)
+        items.append(
+            InboxItem(
+                seq=seq,
+                msg_id=match.group("msg_id"),
+                from_agent=match.group("from_agent"),
+                topic=match.group("topic"),
+                payload=payload,
+                raw_payload=payload_text,
+            )
+        )
+    return items, warnings
+
+
+def _decode_payload(text: str) -> tuple[dict[str, Any], str | None]:
+    text = text.rstrip()
+    if not text:
+        return {}, None
+    try:
+        decoded = ast.literal_eval(text)
+    except (SyntaxError, ValueError):
+        return {"raw": text}, f"payload not a python literal: {text!r}"
+    if isinstance(decoded, dict):
+        return decoded, None
+    return {"raw": text, "decoded_type": type(decoded).__name__}, None

--- a/robustness-agent/src/robustness_agent/role/reactor.py
+++ b/robustness-agent/src/robustness_agent/role/reactor.py
@@ -1,0 +1,132 @@
+"""Reactor: the heart of the robustness role.
+
+A single :meth:`Reactor.tick` runs the M1 pipeline:
+
+1. :class:`DegradeRouter` produces one :class:`SourceData` snapshot.
+2. :class:`Classifier` distils the snapshot into :class:`Symptom` list.
+3. :class:`ActionLadder` maps symptoms onto Intents + Findings.
+4. :class:`PolicyAware` filters every intent through PolicyGate-equivalent
+   checks before they leave the agent.
+5. :class:`FindingSink` persists the findings to disk.
+6. The reactor returns the validated intents.
+
+The Reactor holds tick state (tick index, last data snapshot) but no
+business logic; that lives in classifier + ladder so transports can be
+swapped without recompiling rules.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from ..decision.action_ladder import ActionLadder, Finding
+from ..decision.policy_aware import PolicyAware, PolicyViolation
+from ..decision.rca_engine import NoopRcaEngine, RcaEngine
+from ..findings.sink import FindingSink
+from ..signals import Classifier, Symptom
+from ..sources.base import DegradeRouter
+from .envelope import Intent
+from .prompt_inputs import ReactorContext
+
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class ReactorComponents:
+    """Aggregate constructor argument so callers do not pass 6 positional kw."""
+
+    router: DegradeRouter
+    classifier: Classifier
+    ladder: ActionLadder
+    policy: PolicyAware
+    sink: FindingSink | None = None
+    rca: RcaEngine | None = None
+
+
+class Reactor:
+    """Stateful pipeline driver.
+
+    Each call to :meth:`tick` advances the internal tick index. The
+    reactor is single-task: callers must not run multiple ``tick`` coros
+    concurrently against the same instance.
+    """
+
+    def __init__(self, components: ReactorComponents) -> None:
+        self._router = components.router
+        self._classifier = components.classifier
+        self._ladder = components.ladder
+        self._policy = components.policy
+        self._sink = components.sink
+        self._rca: RcaEngine = components.rca or NoopRcaEngine()
+        self._tick_index = 0
+        self._last_symptoms: list[Symptom] = []
+        self._last_data_summary: dict[str, Any] = {}
+
+    @property
+    def tick_index(self) -> int:
+        return self._tick_index
+
+    @property
+    def last_symptoms(self) -> list[Symptom]:
+        return list(self._last_symptoms)
+
+    async def tick(self, ctx: ReactorContext) -> list[Intent]:
+        self._tick_index += 1
+        now_unix = ctx.now_unix or time.time()
+
+        data = await self._router.collect(ctx)
+        symptoms = self._classifier.classify(data, ctx)
+        result = await self._ladder.decide(
+            symptoms,
+            tick_index=self._tick_index,
+            now_unix=now_unix,
+            rca_provider=self._rca,
+        )
+
+        validated_intents: list[Intent] = []
+        rejected: list[tuple[str, str]] = []
+        for intent in result.intents:
+            try:
+                self._policy.assert_payload_complete(intent)
+            except PolicyViolation as exc:
+                rejected.append((intent.type.value, str(exc)))
+                continue
+            validated_intents.append(intent)
+
+        if rejected:
+            log.warning(
+                "reactor tick=%d dropped %d intents due to policy violations: %s",
+                self._tick_index,
+                len(rejected),
+                rejected,
+            )
+
+        if self._sink is not None and result.findings:
+            try:
+                await self._sink.append_many(result.findings)
+            except Exception:  # noqa: BLE001 — sink already swallows IO errors
+                log.exception("reactor tick=%d sink.append_many failed", self._tick_index)
+
+        self._last_symptoms = symptoms
+        self._last_data_summary = _summarise(data, symptoms, result.findings)
+        return validated_intents
+
+
+def _summarise(
+    data: Any,
+    symptoms: list[Symptom],
+    findings: list[Finding],
+) -> dict[str, Any]:
+    return {
+        "sources_used": list(getattr(data, "sources_used", []) or []),
+        "degraded_reason": getattr(data, "degraded_reason", None),
+        "symptom_count": len(symptoms),
+        "finding_count": len(findings),
+    }
+
+
+__all__ = ["Reactor", "ReactorComponents"]

--- a/robustness-agent/src/robustness_agent/signals/__init__.py
+++ b/robustness-agent/src/robustness_agent/signals/__init__.py
@@ -1,0 +1,36 @@
+"""Signal rules.
+
+Each rule consumes :class:`ReactorContext` plus :class:`SourceData` and
+yields zero or more :class:`Symptom` records. The classifier composes
+the rules and de-duplicates by ``(name, subject_key)``.
+
+M1 implements four rules:
+
+* :func:`evaluate_stall_signals` — agent reactor went silent
+* :func:`evaluate_crash_signals` — repeated session crashes
+* :func:`evaluate_event_signals` — policy_denied / delegated_result
+  patterns from the inbox and Coordinator events
+* :func:`evaluate_health_signals` — pod-level phase failures from the
+  robustness-server snapshot
+
+The full GPU / disk / log rule set lands in M2.
+"""
+
+from .classifier import Classifier
+from .crash import evaluate_crash_signals
+from .event import evaluate_event_signals
+from .health import evaluate_health_signals
+from .local_health import evaluate_local_health_signals
+from .stall import evaluate_stall_signals
+from .symptom import Symptom, SymptomSeverity
+
+__all__ = [
+    "Classifier",
+    "Symptom",
+    "SymptomSeverity",
+    "evaluate_crash_signals",
+    "evaluate_event_signals",
+    "evaluate_health_signals",
+    "evaluate_local_health_signals",
+    "evaluate_stall_signals",
+]

--- a/robustness-agent/src/robustness_agent/signals/classifier.py
+++ b/robustness-agent/src/robustness_agent/signals/classifier.py
@@ -1,0 +1,75 @@
+"""Run all signal rules and de-duplicate Symptoms.
+
+The classifier is intentionally dumb: it iterates a fixed list of
+evaluators and appends whatever they emit. De-duplication uses
+``Symptom.dedup_key()`` so the same rule firing on the same subject
+twice (e.g. via inbox + coordinator events) folds into a single record;
+the highest severity wins on ties.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable
+
+from ..role.prompt_inputs import ReactorContext
+from ..sources.base import SourceData
+from .crash import CrashConfig, evaluate_crash_signals
+from .event import EventConfig, evaluate_event_signals
+from .health import HealthConfig, evaluate_health_signals
+from .local_health import LocalHealthConfig, evaluate_local_health_signals
+from .stall import StallConfig, evaluate_stall_signals
+from .symptom import Symptom
+
+
+SignalEvaluator = Callable[[ReactorContext, SourceData], list[Symptom]]
+
+
+@dataclass
+class Classifier:
+    """Compose the configured signal evaluators."""
+
+    stall_config: StallConfig = field(default_factory=StallConfig)
+    crash_config: CrashConfig = field(default_factory=CrashConfig)
+    event_config: EventConfig = field(default_factory=EventConfig)
+    health_config: HealthConfig = field(default_factory=HealthConfig)
+    local_health_config: LocalHealthConfig = field(default_factory=LocalHealthConfig)
+    extra_evaluators: list[SignalEvaluator] = field(default_factory=list)
+
+    def classify(self, data: SourceData, ctx: ReactorContext) -> list[Symptom]:
+        symptoms: list[Symptom] = []
+        symptoms.extend(
+            evaluate_stall_signals(ctx, data, config=self.stall_config)
+        )
+        symptoms.extend(
+            evaluate_crash_signals(ctx, data, config=self.crash_config)
+        )
+        symptoms.extend(
+            evaluate_event_signals(ctx, data, config=self.event_config)
+        )
+        symptoms.extend(
+            evaluate_health_signals(ctx, data, config=self.health_config)
+        )
+        symptoms.extend(
+            evaluate_local_health_signals(ctx, data, config=self.local_health_config)
+        )
+        for fn in self.extra_evaluators:
+            symptoms.extend(fn(ctx, data))
+        return _dedup(symptoms)
+
+
+def _dedup(symptoms: list[Symptom]) -> list[Symptom]:
+    by_key: dict[tuple[str, ...], Symptom] = {}
+    for sym in symptoms:
+        key = sym.dedup_key()
+        existing = by_key.get(key)
+        if existing is None or sym.severity.rank > existing.severity.rank:
+            by_key[key] = sym
+    # Stable order: HIGH first, then MEDIUM, then LOW; tie-break by name.
+    return sorted(
+        by_key.values(),
+        key=lambda s: (-s.severity.rank, s.name, sorted(s.subject.items())),
+    )
+
+
+__all__ = ["Classifier", "SignalEvaluator"]

--- a/robustness-agent/src/robustness_agent/signals/crash.py
+++ b/robustness-agent/src/robustness_agent/signals/crash.py
@@ -1,0 +1,74 @@
+"""Crash-count signal.
+
+DESIGN v0.6 §9.1 lets ``crash_count >= crash_emergency_threshold``
+(default 25) terminate the run with ``stop_reason=emergency``. We fire
+escalating severity well before that:
+
+* >= 2  consecutive crashes -> medium symptom suggesting recover delegate
+* >= 5  consecutive crashes -> high symptom suggesting strategy change
+* >= 10 consecutive crashes -> high symptom flagged ``emergency``
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..role.prompt_inputs import ReactorContext
+from ..sources.base import SourceData
+from .symptom import Symptom, SymptomSeverity
+
+
+@dataclass
+class CrashConfig:
+    medium_threshold: int = 2
+    high_threshold: int = 5
+    emergency_threshold: int = 10
+
+
+def evaluate_crash_signals(
+    ctx: ReactorContext,
+    data: SourceData,
+    *,
+    config: CrashConfig | None = None,
+) -> list[Symptom]:
+    cfg = config or CrashConfig()
+    crash_count = ctx.shared_state.crash_count
+    if crash_count < cfg.medium_threshold:
+        return []
+
+    severity: SymptomSeverity
+    suggestion: str
+    name: str
+    if crash_count >= cfg.emergency_threshold:
+        severity = SymptomSeverity.HIGH
+        name = "crash_count_emergency"
+        suggestion = "escalate_strategy_change with stop / emergency hint"
+    elif crash_count >= cfg.high_threshold:
+        severity = SymptomSeverity.HIGH
+        name = "crash_count_high"
+        suggestion = "escalate_strategy_change suggesting baseline revert"
+    else:
+        severity = SymptomSeverity.MEDIUM
+        name = "crash_count_rising"
+        suggestion = "delegate(recover) or escalate strategy change"
+
+    return [
+        Symptom(
+            name=name,
+            severity=severity,
+            summary=(
+                f"crash_count={crash_count} (>= {cfg.medium_threshold}); "
+                f"current_action={ctx.shared_state.current_action or '(idle)'}"
+            ),
+            evidence={
+                "crash_count": crash_count,
+                "current_action": ctx.shared_state.current_action,
+            },
+            subject={"agent": "session"},
+            source="shared_state",
+            suggestion=suggestion,
+        )
+    ]
+
+
+__all__ = ["CrashConfig", "evaluate_crash_signals"]

--- a/robustness-agent/src/robustness_agent/signals/event.py
+++ b/robustness-agent/src/robustness_agent/signals/event.py
@@ -1,0 +1,197 @@
+"""Coordinator-event-driven signals.
+
+Two patterns the robustness role watches per DESIGN v0.6 §7.4 / §19.3:
+
+* Repeated ``policy_denied`` observations from the same source within
+  a short window indicate either a misconfigured agent or a
+  systemically-rejected action — emit a medium-severity alert
+  suggesting the operator review the ActionRegistry.
+* ``delegated_result`` events with ``state == "failed"`` clustering on
+  the same action family hint at a stuck branch, suggesting a
+  ``prune_branch`` action.
+
+Inputs come from both ``ctx.inbox`` (rendered into the prompt) and
+``data.coordinator_events`` (read directly from the local conductor.db
+when robustness-server is unavailable).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from dataclasses import dataclass
+from typing import Any
+
+from ..role.prompt_inputs import InboxItem, ReactorContext
+from ..sources.base import SourceData
+from .symptom import Symptom, SymptomSeverity
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class EventConfig:
+    """Knobs for :func:`evaluate_event_signals`."""
+
+    policy_denied_threshold: int = 3
+    delegated_failure_threshold: int = 2
+
+
+def evaluate_event_signals(
+    ctx: ReactorContext,
+    data: SourceData,
+    *,
+    config: EventConfig | None = None,
+) -> list[Symptom]:
+    cfg = config or EventConfig()
+    inbox_view = _normalise_inbox(ctx.inbox)
+    coord_view = _normalise_events(data.coordinator_events)
+    combined = inbox_view + coord_view
+
+    out: list[Symptom] = []
+    out.extend(_policy_denied_symptoms(combined, cfg))
+    out.extend(_delegated_failure_symptoms(combined, cfg))
+    return out
+
+
+def _policy_denied_symptoms(
+    events: list[dict[str, Any]],
+    cfg: EventConfig,
+) -> list[Symptom]:
+    sources: Counter[str] = Counter()
+    rules: Counter[str] = Counter()
+    for ev in events:
+        if ev.get("topic") != "observation":
+            continue
+        payload = ev.get("payload") or {}
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("kind") != "policy_denied":
+            continue
+        target = ev.get("agent") or payload.get("source") or "unknown"
+        rule = payload.get("rule") or "unknown"
+        sources[target] += 1
+        rules[rule] += 1
+
+    out: list[Symptom] = []
+    for source, count in sources.items():
+        if count < cfg.policy_denied_threshold:
+            continue
+        top_rule = rules.most_common(1)[0][0] if rules else "unknown"
+        out.append(
+            Symptom(
+                name="repeated_policy_denied",
+                severity=SymptomSeverity.MEDIUM,
+                summary=(
+                    f"agent {source} hit policy_denied {count} times "
+                    f"(>= {cfg.policy_denied_threshold}); top rule={top_rule}"
+                ),
+                evidence={
+                    "from": source,
+                    "count": count,
+                    "top_rule": top_rule,
+                    "rule_distribution": dict(rules),
+                },
+                subject={"agent": source},
+                source="coordinator_events",
+                suggestion="escalate_strategy_change to review ActionRegistry / role config",
+            )
+        )
+    return out
+
+
+def _delegated_failure_symptoms(
+    events: list[dict[str, Any]],
+    cfg: EventConfig,
+) -> list[Symptom]:
+    family_counts: Counter[str] = Counter()
+    last_evidence: dict[str, dict[str, Any]] = {}
+    for ev in events:
+        if ev.get("topic") != "delegated_result":
+            continue
+        payload = ev.get("payload") or {}
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("state") != "failed":
+            continue
+        family = _family_of(payload)
+        if not family:
+            continue
+        family_counts[family] += 1
+        last_evidence[family] = {
+            "task_id": payload.get("task_id"),
+            "kind": payload.get("kind"),
+            "error": payload.get("error"),
+        }
+
+    out: list[Symptom] = []
+    for family, count in family_counts.items():
+        if count < cfg.delegated_failure_threshold:
+            continue
+        out.append(
+            Symptom(
+                name="repeated_failure",
+                severity=SymptomSeverity.MEDIUM,
+                summary=(
+                    f"action family {family!r} failed {count} times "
+                    f"(>= {cfg.delegated_failure_threshold})"
+                ),
+                evidence={
+                    "family": family,
+                    "count": count,
+                    "last_failure": last_evidence.get(family, {}),
+                },
+                subject={"family": family},
+                source="coordinator_events",
+                suggestion=f"prune_branch family={family}",
+            )
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Normalisation helpers
+# ---------------------------------------------------------------------------
+
+def _normalise_inbox(inbox: list[InboxItem]) -> list[dict[str, Any]]:
+    return [
+        {
+            "agent": item.from_agent,
+            "topic": item.topic,
+            "payload": item.payload,
+            "ts": None,
+        }
+        for item in inbox
+    ]
+
+
+def _normalise_events(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for ev in events:
+        out.append(
+            {
+                "agent": ev.get("agent", ""),
+                "topic": ev.get("topic", ""),
+                "payload": ev.get("payload"),
+                "ts": ev.get("ts") or ev.get("timestamp"),
+            }
+        )
+    return out
+
+
+def _family_of(payload: dict[str, Any]) -> str:
+    """Best-effort family inference from a delegated_result payload.
+
+    Coordinator does not always tag a family; fall back to ``kind``
+    when present so the rule still groups by action name.
+    """
+    family = payload.get("family")
+    if isinstance(family, str) and family.strip():
+        return family.strip()
+    kind = payload.get("kind")
+    if isinstance(kind, str) and kind.strip():
+        return kind.strip()
+    return ""
+
+
+__all__ = ["EventConfig", "evaluate_event_signals"]

--- a/robustness-agent/src/robustness_agent/signals/health.py
+++ b/robustness-agent/src/robustness_agent/signals/health.py
@@ -1,0 +1,141 @@
+"""Pod-health signal driven by robustness-server's session snapshot.
+
+The current session may include both brain (shared) and hands
+(session-bound) pods.  ``session_pods`` rows shaped by
+``robustness-server`` carry ``pod.namespace`` / ``pod.name`` /
+``role`` / ``t_start`` / ``t_end`` and (when summary is fetched)
+``available_metrics``.
+
+For M1 we emit medium-severity alerts when:
+
+* a pod's record carries a non-empty ``phase`` other than ``Running``
+  (data shape varies; we accept ``phase`` at the top level or under
+  ``pod.phase``).
+* ``session_summary.pods`` reports an empty ``available_metrics`` list
+  for a hands pod that started more than ``no_metrics_warn_s`` seconds
+  ago (likely Pod is alive but no telemetry — surface low severity).
+
+GPU thermal / utilisation symptoms move into M2 once the cluster
+proxy endpoints land.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ..role.prompt_inputs import ReactorContext
+from ..sources.base import SourceData
+from .symptom import Symptom, SymptomSeverity
+
+
+@dataclass
+class HealthConfig:
+    no_metrics_warn_s: float = 600.0
+
+
+_POD_RUNNING_PHASES: frozenset[str] = frozenset({
+    "Running",
+    "Succeeded",
+    "Pending",  # transient; we do not flag Pending here
+    "",         # missing phase
+})
+
+
+def evaluate_health_signals(
+    ctx: ReactorContext,
+    data: SourceData,
+    *,
+    config: HealthConfig | None = None,
+) -> list[Symptom]:
+    cfg = config or HealthConfig()
+    out: list[Symptom] = []
+
+    for assignment in data.session_pods:
+        if not isinstance(assignment, dict):
+            continue
+        pod = _pod_dict(assignment)
+        phase = _phase(assignment, pod)
+        if phase and phase not in _POD_RUNNING_PHASES:
+            ns = str(pod.get("namespace") or "")
+            name = str(pod.get("name") or "")
+            role = str(assignment.get("role") or "")
+            severity = (
+                SymptomSeverity.HIGH if phase == "Failed" else SymptomSeverity.MEDIUM
+            )
+            out.append(
+                Symptom(
+                    name="pod_not_running",
+                    severity=severity,
+                    summary=f"pod {ns}/{name} ({role}) phase={phase}",
+                    evidence={
+                        "namespace": ns,
+                        "name": name,
+                        "role": role,
+                        "phase": phase,
+                        "assignment_id": assignment.get("assignment_id"),
+                    },
+                    subject={"namespace": ns, "name": name, "phase": phase},
+                    source="server",
+                    suggestion=(
+                        "kill_task on the related task and escalate"
+                        " strategy" if phase == "Failed" else
+                        "escalate_strategy_change to monitor recovery"
+                    ),
+                )
+            )
+
+    summary = data.session_summary
+    if isinstance(summary, dict):
+        for entry in summary.get("pods") or []:
+            if not isinstance(entry, dict):
+                continue
+            available = entry.get("available_metrics")
+            if available not in (None, []):
+                continue
+            t_start = entry.get("t_start")
+            if not isinstance(t_start, (int, float)):
+                continue
+            age = ctx.now_unix - float(t_start)
+            if age < cfg.no_metrics_warn_s:
+                continue
+            pod = _pod_dict(entry)
+            ns = str(pod.get("namespace") or "")
+            name = str(pod.get("name") or "")
+            role = str(entry.get("role") or "")
+            out.append(
+                Symptom(
+                    name="pod_no_metrics",
+                    severity=SymptomSeverity.LOW,
+                    summary=(
+                        f"pod {ns}/{name} ({role}) has no metric series for "
+                        f"{int(age)}s"
+                    ),
+                    evidence={
+                        "namespace": ns,
+                        "name": name,
+                        "role": role,
+                        "age_seconds": int(age),
+                    },
+                    subject={"namespace": ns, "name": name, "kind": "no_metrics"},
+                    source="server",
+                    suggestion="verify exporter / cluster_proxy data path",
+                )
+            )
+
+    return out
+
+
+def _pod_dict(entry: dict[str, Any]) -> dict[str, Any]:
+    pod = entry.get("pod")
+    if isinstance(pod, dict):
+        return pod
+    return {}
+
+
+def _phase(entry: dict[str, Any], pod: dict[str, Any]) -> str:
+    phase = entry.get("phase") or pod.get("phase")
+    return str(phase or "").strip()
+
+
+__all__ = ["HealthConfig", "evaluate_health_signals"]

--- a/robustness-agent/src/robustness_agent/signals/local_health.py
+++ b/robustness-agent/src/robustness_agent/signals/local_health.py
@@ -1,0 +1,177 @@
+"""Symptoms derived from LocalProbe-only data.
+
+These rules fire only when DegradeRouter has handed control to
+:class:`LocalProbeSource` (i.e. robustness-server is unreachable),
+which is exactly the single-mode dev / disconnected scenario M1.5
+exists to support.  When the server is healthy the corresponding
+signals come from cluster sources (M2+) and these rules stay silent
+because the SourceData fields are empty.
+
+Three sub-rules:
+
+* ``server_unreachable`` — a configured local HTTP probe target is
+  down. Medium severity by default; promoted to high if every probed
+  target fails.
+* ``log_error_pattern`` — :data:`SourceData.local_log_errors` contains
+  one or more matches. OOM / NCCL → high; anything else → medium.
+* ``gpu_thermal_high`` — any GPU's ``temperature_c`` exceeds the
+  configured warn / crit thresholds.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ..role.prompt_inputs import ReactorContext
+from ..sources.base import SourceData
+from .symptom import Symptom, SymptomSeverity
+
+
+@dataclass
+class LocalHealthConfig:
+    gpu_temp_warn_c: float = 90.0
+    gpu_temp_crit_c: float = 100.0
+
+
+# Patterns we treat as high severity (vs the default medium). Anything
+# else from ``local_log_errors`` falls back to medium.
+_HIGH_SEVERITY_PATTERNS: frozenset[str] = frozenset({
+    "CUDA out of memory",
+    "hipErrorOutOfMemory",
+    "HIP out of memory",
+    "NCCL error",
+    "OOMKilled",
+    "core dumped",
+    "Segmentation fault",
+})
+
+
+def evaluate_local_health_signals(
+    ctx: ReactorContext,
+    data: SourceData,
+    *,
+    config: LocalHealthConfig | None = None,
+) -> list[Symptom]:
+    cfg = config or LocalHealthConfig()
+    out: list[Symptom] = []
+    out.extend(_server_unreachable(data))
+    out.extend(_log_error_symptoms(data))
+    out.extend(_gpu_thermal_symptoms(data, cfg))
+    return out
+
+
+def _server_unreachable(data: SourceData) -> list[Symptom]:
+    if not data.local_server_health:
+        return []
+    bad = [entry for entry in data.local_server_health if not entry.get("reachable")]
+    if not bad:
+        return []
+    severity = (
+        SymptomSeverity.HIGH if len(bad) == len(data.local_server_health) else SymptomSeverity.MEDIUM
+    )
+    out: list[Symptom] = []
+    for entry in bad:
+        url = str(entry.get("url") or "")
+        status = str(entry.get("status") or "")
+        out.append(
+            Symptom(
+                name="local_server_unreachable",
+                severity=severity,
+                summary=f"local server probe {url} status={status}",
+                evidence={
+                    "url": url,
+                    "status": status,
+                    "status_code": entry.get("status_code"),
+                    "error": entry.get("error"),
+                },
+                subject={"url": url},
+                source="local",
+                suggestion=(
+                    "delegate(server_lifecycle) to restart the inference "
+                    "server" if severity is SymptomSeverity.HIGH else
+                    "monitor; alert orchestration if it persists"
+                ),
+            )
+        )
+    return out
+
+
+def _log_error_symptoms(data: SourceData) -> list[Symptom]:
+    if not data.local_log_errors:
+        return []
+    by_pattern: dict[str, list[dict[str, Any]]] = {}
+    for entry in data.local_log_errors:
+        pattern = str(entry.get("pattern") or "")
+        if not pattern:
+            continue
+        by_pattern.setdefault(pattern, []).append(entry)
+
+    out: list[Symptom] = []
+    for pattern, hits in by_pattern.items():
+        severity = (
+            SymptomSeverity.HIGH if pattern in _HIGH_SEVERITY_PATTERNS else SymptomSeverity.MEDIUM
+        )
+        out.append(
+            Symptom(
+                name="log_error_pattern",
+                severity=severity,
+                summary=f"log error pattern {pattern!r} matched {len(hits)} times",
+                evidence={
+                    "pattern": pattern,
+                    "count": len(hits),
+                    "samples": [h.get("line") for h in hits[:3]],
+                },
+                subject={"pattern": pattern},
+                source="local",
+                suggestion=(
+                    "delegate(server_lifecycle) or escalate strategy"
+                    if severity is SymptomSeverity.HIGH
+                    else "review log evidence with RCA before further action"
+                ),
+            )
+        )
+    return out
+
+
+def _gpu_thermal_symptoms(
+    data: SourceData,
+    cfg: LocalHealthConfig,
+) -> list[Symptom]:
+    gpus = data.local_gpu.get("gpus") if isinstance(data.local_gpu, dict) else None
+    if not isinstance(gpus, list):
+        return []
+    out: list[Symptom] = []
+    for snap in gpus:
+        if not isinstance(snap, dict):
+            continue
+        temp = snap.get("temperature_c")
+        if not isinstance(temp, (int, float)):
+            continue
+        if temp >= cfg.gpu_temp_crit_c:
+            severity = SymptomSeverity.HIGH
+        elif temp >= cfg.gpu_temp_warn_c:
+            severity = SymptomSeverity.MEDIUM
+        else:
+            continue
+        gpu_id = snap.get("gpu_id")
+        out.append(
+            Symptom(
+                name="gpu_thermal_high",
+                severity=severity,
+                summary=f"GPU {gpu_id} temperature_c={temp}",
+                evidence={
+                    "gpu_id": gpu_id,
+                    "temperature_c": temp,
+                    "warn_threshold": cfg.gpu_temp_warn_c,
+                    "crit_threshold": cfg.gpu_temp_crit_c,
+                },
+                subject={"gpu_id": str(gpu_id)},
+                source="local",
+                suggestion="escalate strategy change to back off thermal pressure",
+            )
+        )
+    return out
+
+
+__all__ = ["LocalHealthConfig", "evaluate_local_health_signals"]

--- a/robustness-agent/src/robustness_agent/signals/stall.py
+++ b/robustness-agent/src/robustness_agent/signals/stall.py
@@ -1,0 +1,141 @@
+"""Agent-stall detection.
+
+DESIGN v0.6 §7.4: the robustness role is expected to detect "agent
+stalls (>3min no message processed)" and emit medium-severity alerts.
+
+We compute the "last activity" timestamp per agent from
+:attr:`SourceData.coordinator_events` (newest first) and compare to
+``ctx.now_unix``. Inbox tail entries (rendered into the prompt) are
+also folded in because they may be more recent than what the local
+SQLite probe sees.
+
+Activity criterion is intentionally lenient: any event from the agent
+counts as activity, including heartbeats. That matches the upstream
+reactor protocol where every tick must emit at least one intent.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+from ..role.prompt_inputs import InboxItem, ReactorContext
+from ..sources.base import SourceData
+from .symptom import Symptom, SymptomSeverity
+
+
+# Agents we care about for stall detection. The robustness role itself
+# is excluded because it is the one running the rule.
+_TRACKED_AGENTS: frozenset[str] = frozenset({
+    "orchestration",
+    "kernel",
+    "critic",
+})
+
+
+@dataclass
+class StallConfig:
+    """Knobs for :func:`evaluate_stall_signals`."""
+
+    stall_timeout_s: float = 300.0
+    severity_high_after_s: float = 900.0
+
+
+def evaluate_stall_signals(
+    ctx: ReactorContext,
+    data: SourceData,
+    *,
+    config: StallConfig | None = None,
+) -> list[Symptom]:
+    cfg = config or StallConfig()
+    last_seen = _collect_last_seen(ctx.inbox, data.coordinator_events)
+    out: list[Symptom] = []
+    for agent in _TRACKED_AGENTS:
+        ts = last_seen.get(agent)
+        if ts is None:
+            # Without ground truth we cannot accuse the agent of being
+            # stalled; the very-first tick will always look empty.
+            continue
+        idle_s = max(0.0, ctx.now_unix - ts)
+        if idle_s < cfg.stall_timeout_s:
+            continue
+        severity = (
+            SymptomSeverity.HIGH
+            if idle_s >= cfg.severity_high_after_s
+            else SymptomSeverity.MEDIUM
+        )
+        out.append(
+            Symptom(
+                name="agent_stall",
+                severity=severity,
+                summary=(
+                    f"agent {agent} silent for {int(idle_s)}s "
+                    f"(threshold={int(cfg.stall_timeout_s)}s)"
+                ),
+                evidence={
+                    "agent": agent,
+                    "idle_seconds": int(idle_s),
+                    "last_seen_unix": int(ts),
+                    "threshold_s": int(cfg.stall_timeout_s),
+                },
+                subject={"agent": agent},
+                source="local" if data.coordinator_events else "inbox",
+                suggestion=(
+                    "force_dispatch the head queued task or escalate"
+                    " strategy if agent remains silent"
+                ),
+            )
+        )
+    return out
+
+
+def _collect_last_seen(
+    inbox: list[InboxItem],
+    coordinator_events: list[dict[str, Any]],
+) -> dict[str, float]:
+    last: dict[str, float] = {}
+
+    for item in inbox:
+        if item.from_agent not in _TRACKED_AGENTS:
+            continue
+        ts = _coerce_unix(item.payload.get("ts") if isinstance(item.payload, dict) else None)
+        if ts is None:
+            continue
+        prev = last.get(item.from_agent)
+        if prev is None or ts > prev:
+            last[item.from_agent] = ts
+
+    for ev in coordinator_events:
+        agent = str(ev.get("agent", "")).strip()
+        if agent not in _TRACKED_AGENTS:
+            continue
+        ts = _coerce_unix(ev.get("ts") or ev.get("timestamp"))
+        if ts is None:
+            continue
+        prev = last.get(agent)
+        if prev is None or ts > prev:
+            last[agent] = ts
+
+    return last
+
+
+def _coerce_unix(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        # ISO 8601 produced by SQLite WAL stores; fall back to float.
+        try:
+            from datetime import datetime
+
+            return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            try:
+                return float(value)
+            except ValueError:
+                return None
+    return None
+
+
+__all__ = ["StallConfig", "evaluate_stall_signals"]

--- a/robustness-agent/src/robustness_agent/signals/symptom.py
+++ b/robustness-agent/src/robustness_agent/signals/symptom.py
@@ -1,0 +1,63 @@
+"""Symptom data shape produced by signal rules and consumed by ActionLadder."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class SymptomSeverity(str, Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+    @property
+    def rank(self) -> int:
+        return {"low": 0, "medium": 1, "high": 2}[self.value]
+
+
+@dataclass
+class Symptom:
+    """One rule firing, ready for the ActionLadder.
+
+    Attributes
+    ----------
+    name:
+        Stable identifier the ActionLadder dispatches on
+        (e.g. ``"agent_stall"``, ``"repeated_failure"``).
+    severity:
+        :class:`SymptomSeverity`. Maps to the alert severity emitted
+        downstream and gates whether soft / hard actions are reachable.
+    summary:
+        Human-readable one-line summary surfaced in alerts and findings.
+    evidence:
+        Structured payload the alert ``detail`` field carries through;
+        keep it small (Coordinator persists it verbatim).
+    subject:
+        Identifying tuple for de-duplication and downstream targetting
+        (e.g. ``{"agent": "kernel"}`` / ``{"pod": "brain-0", "namespace": "..."}``).
+    source:
+        Label of the data source that produced the signal
+        (``"server"`` / ``"local"``).
+    suggestion:
+        Optional hint the ActionLadder uses when it builds the
+        ``next_action_hint`` for an ``escalate_strategy_change`` intent.
+    """
+
+    name: str
+    severity: SymptomSeverity
+    summary: str
+    evidence: dict[str, Any] = field(default_factory=dict)
+    subject: dict[str, str] = field(default_factory=dict)
+    source: str = "unknown"
+    suggestion: str = ""
+
+    def dedup_key(self) -> tuple[str, ...]:
+        """Stable identity used by the classifier to drop duplicates."""
+        if not self.subject:
+            return (self.name,)
+        return (self.name, *sorted(f"{k}={v}" for k, v in self.subject.items()))
+
+
+__all__ = ["Symptom", "SymptomSeverity"]

--- a/robustness-agent/src/robustness_agent/sources/__init__.py
+++ b/robustness-agent/src/robustness_agent/sources/__init__.py
@@ -1,0 +1,29 @@
+"""Data sources used by the reactor.
+
+Layered as ``robustness-server`` (preferred) -> ``local probe`` (fallback)
+through :class:`DegradeRouter`. Higher milestones add a cluster proxy
+client; the contract here is intentionally narrow so each source is a
+drop-in replacement.
+"""
+
+from .base import (
+    DegradeRouter,
+    HealthState,
+    Source,
+    SourceData,
+    SourceUnavailable,
+)
+from .local_probe import LocalProbeConfig, LocalProbeSource
+from .server_client import RobustnessServerClient, RobustnessServerSource
+
+__all__ = [
+    "DegradeRouter",
+    "HealthState",
+    "LocalProbeConfig",
+    "LocalProbeSource",
+    "RobustnessServerClient",
+    "RobustnessServerSource",
+    "Source",
+    "SourceData",
+    "SourceUnavailable",
+]

--- a/robustness-agent/src/robustness_agent/sources/base.py
+++ b/robustness-agent/src/robustness_agent/sources/base.py
@@ -1,0 +1,298 @@
+"""Source protocol + DegradeRouter.
+
+The reactor pulls a single :class:`SourceData` snapshot per tick. The
+DegradeRouter routes to a primary source (typically
+``robustness-server``) and falls back to a secondary (typically
+``local_probe``) when the primary fails repeatedly. State transitions
+emit one WARN log; in-state retries are silent so we do not flood the
+log stream.
+
+State machine
+~~~~~~~~~~~~~
+
+::
+
+    HEALTHY  --(fail_streak >= fail_threshold)-->  DEGRADED
+    DEGRADED --(success after recheck_interval_s)--> HEALTHY
+    DEGRADED --(consecutive failures still over budget)--> FAILED  (M2+)
+
+For M1 we use only the HEALTHY/DEGRADED two-state form: DEGRADED simply
+means "use the fallback for this tick"; the next tick re-probes after
+``recheck_interval_s`` has elapsed. FAILED is reserved for cases where
+the fallback itself is unhealthy and the reactor should report a
+degraded heartbeat (M2 wires this up).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Awaitable, Callable, Protocol, runtime_checkable
+
+
+log = logging.getLogger(__name__)
+
+
+class HealthState(str, Enum):
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    FAILED = "failed"
+
+
+class SourceUnavailable(RuntimeError):
+    """Raised by a :class:`Source` when its backing service is not reachable.
+
+    DegradeRouter catches this exception type and treats it as a
+    countable failure. Other exceptions propagate so genuine bugs are
+    not masked.
+    """
+
+
+@dataclass
+class SourceData:
+    """Per-tick snapshot the reactor consumes.
+
+    Every field defaults to an empty container so downstream signals can
+    treat "no data" uniformly. ``sources_used`` records which source
+    produced each tick's data; ``degraded_reason`` is set when the
+    primary was skipped or failed and the fallback served the request.
+    """
+
+    session_pods: list[dict[str, Any]] = field(default_factory=list)
+    session_metrics: dict[str, Any] = field(default_factory=dict)
+    session_events: list[dict[str, Any]] = field(default_factory=list)
+    session_summary: dict[str, Any] = field(default_factory=dict)
+    cluster_faults: list[dict[str, Any]] = field(default_factory=list)
+    local_gpu: dict[str, Any] = field(default_factory=dict)
+    local_processes: list[dict[str, Any]] = field(default_factory=list)
+    local_disk: dict[str, Any] = field(default_factory=dict)
+    local_log_tail: list[str] = field(default_factory=list)
+    local_log_errors: list[dict[str, Any]] = field(default_factory=list)
+    local_server_health: list[dict[str, Any]] = field(default_factory=list)
+    coordinator_events: list[dict[str, Any]] = field(default_factory=list)
+    sources_used: list[str] = field(default_factory=list)
+    degraded_reason: str | None = None
+
+    def merge_from(self, other: "SourceData") -> None:
+        """Merge another snapshot in, preserving non-empty existing fields.
+
+        Used by callers that want to enrich a primary result with extra
+        fallback data; M1 does not exercise this path but keeps the
+        helper available for M2 ``signals/*`` evolution.
+        """
+        for slot in (
+            "session_pods",
+            "session_events",
+            "cluster_faults",
+            "local_processes",
+            "local_log_tail",
+            "local_log_errors",
+            "local_server_health",
+            "coordinator_events",
+        ):
+            if not getattr(self, slot):
+                setattr(self, slot, list(getattr(other, slot)))
+        for slot in (
+            "session_metrics",
+            "session_summary",
+            "local_gpu",
+            "local_disk",
+        ):
+            if not getattr(self, slot):
+                setattr(self, slot, dict(getattr(other, slot)))
+        if other.degraded_reason and not self.degraded_reason:
+            self.degraded_reason = other.degraded_reason
+        for name in other.sources_used:
+            if name not in self.sources_used:
+                self.sources_used.append(name)
+
+
+@runtime_checkable
+class Source(Protocol):
+    """Async source contract the DegradeRouter consumes."""
+
+    name: str
+
+    async def fetch(self, ctx: Any) -> SourceData:
+        """Return a snapshot or raise :class:`SourceUnavailable`."""
+        ...
+
+
+@dataclass
+class _SourceState:
+    name: str
+    state: HealthState = HealthState.HEALTHY
+    fail_streak: int = 0
+    last_recheck: float = 0.0
+
+
+class DegradeRouter:
+    """Coordinator-tick routing across [primary, fallback] sources.
+
+    Parameters
+    ----------
+    primary, fallback:
+        :class:`Source` instances. The router consults the primary
+        first; on enough consecutive failures it switches to the
+        fallback for subsequent ticks and reprobes the primary every
+        ``recheck_interval_s`` seconds.
+    fail_threshold:
+        Consecutive primary failures required to mark it DEGRADED.
+    recheck_interval_s:
+        Time between primary reprobes once it is DEGRADED.
+    clock:
+        Optional ``Callable[[], float]`` providing the current time;
+        defaults to :func:`time.monotonic`. Tests inject a controllable
+        clock to assert recheck timing without sleeping.
+    """
+
+    def __init__(
+        self,
+        primary: Source,
+        fallback: Source,
+        *,
+        fail_threshold: int = 3,
+        recheck_interval_s: float = 30.0,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        self._primary = primary
+        self._fallback = fallback
+        self._fail_threshold = max(1, int(fail_threshold))
+        self._recheck_interval_s = max(0.0, float(recheck_interval_s))
+        self._clock = clock or time.monotonic
+        self._states: dict[str, _SourceState] = {
+            primary.name: _SourceState(name=primary.name),
+            fallback.name: _SourceState(name=fallback.name),
+        }
+
+    @property
+    def primary_state(self) -> HealthState:
+        return self._states[self._primary.name].state
+
+    async def collect(self, ctx: Any) -> SourceData:
+        """Fetch one tick of source data, with degrade routing."""
+        primary_state = self._states[self._primary.name]
+        if self._should_try_primary(primary_state):
+            try:
+                data = await self._primary.fetch(ctx)
+            except SourceUnavailable as exc:
+                self._record_failure(primary_state, str(exc))
+            except Exception:
+                # Treat unexpected errors as failures too, but re-raise
+                # if the source is supposed to never raise: per Source
+                # contract, unexpected exceptions go through but still
+                # count as failures so we eventually degrade.
+                self._record_failure(primary_state, "unexpected_exception")
+                log.exception("primary source %s raised unexpectedly", self._primary.name)
+            else:
+                self._record_success(primary_state)
+                if self._primary.name not in data.sources_used:
+                    data.sources_used = [*data.sources_used, self._primary.name]
+                return data
+
+        fallback_data = await self._fetch_fallback(ctx)
+        return fallback_data
+
+    async def _fetch_fallback(self, ctx: Any) -> SourceData:
+        fallback_state = self._states[self._fallback.name]
+        try:
+            data = await self._fallback.fetch(ctx)
+        except SourceUnavailable as exc:
+            self._record_failure(fallback_state, str(exc))
+            self._maybe_log_transition(
+                fallback_state,
+                HealthState.FAILED,
+                f"fallback unavailable: {exc}",
+            )
+            fallback_state.state = HealthState.FAILED
+            return SourceData(
+                degraded_reason=f"both sources unavailable: primary+{self._fallback.name}",
+                sources_used=[],
+            )
+        except Exception:
+            log.exception("fallback source %s raised unexpectedly", self._fallback.name)
+            self._record_failure(fallback_state, "fallback_exception")
+            return SourceData(
+                degraded_reason="fallback raised unexpected exception",
+                sources_used=[],
+            )
+        else:
+            self._record_success(fallback_state)
+            if self._fallback.name not in data.sources_used:
+                data.sources_used = [*data.sources_used, self._fallback.name]
+            primary_state = self._states[self._primary.name]
+            if primary_state.state is HealthState.DEGRADED and not data.degraded_reason:
+                data.degraded_reason = (
+                    f"primary {self._primary.name} degraded; using {self._fallback.name}"
+                )
+            return data
+
+    # -- state machine helpers ------------------------------------------
+
+    def _should_try_primary(self, state: _SourceState) -> bool:
+        if state.state is HealthState.HEALTHY:
+            return True
+        now = self._clock()
+        if (now - state.last_recheck) >= self._recheck_interval_s:
+            state.last_recheck = now
+            return True
+        return False
+
+    def _record_success(self, state: _SourceState) -> None:
+        if state.state is not HealthState.HEALTHY:
+            self._maybe_log_transition(state, HealthState.HEALTHY, "recovered")
+            state.state = HealthState.HEALTHY
+        state.fail_streak = 0
+        state.last_recheck = self._clock()
+
+    def _record_failure(self, state: _SourceState, reason: str) -> None:
+        state.fail_streak += 1
+        state.last_recheck = self._clock()
+        if (
+            state.state is HealthState.HEALTHY
+            and state.fail_streak >= self._fail_threshold
+        ):
+            self._maybe_log_transition(state, HealthState.DEGRADED, reason)
+            state.state = HealthState.DEGRADED
+
+    def _maybe_log_transition(
+        self,
+        state: _SourceState,
+        target: HealthState,
+        reason: str,
+    ) -> None:
+        if state.state is target:
+            return
+        log.warning(
+            "source %s state %s -> %s (reason=%s, streak=%d)",
+            state.name,
+            state.state.value,
+            target.value,
+            reason,
+            state.fail_streak,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers used by source implementations
+# ---------------------------------------------------------------------------
+
+async def call_with_timeout(
+    coro_factory: Callable[[], Awaitable[Any]],
+    *,
+    timeout_s: float,
+    label: str,
+) -> Any:
+    """Run ``coro_factory()`` under :func:`asyncio.wait_for`.
+
+    Translates :class:`asyncio.TimeoutError` to :class:`SourceUnavailable`
+    so DegradeRouter treats it as a counted failure. Other exceptions
+    propagate.
+    """
+    try:
+        return await asyncio.wait_for(coro_factory(), timeout=timeout_s)
+    except asyncio.TimeoutError as exc:
+        raise SourceUnavailable(f"{label}: timeout after {timeout_s}s") from exc

--- a/robustness-agent/src/robustness_agent/sources/local_probe.py
+++ b/robustness-agent/src/robustness_agent/sources/local_probe.py
@@ -1,0 +1,544 @@
+"""Local fallback source.
+
+Wraps a small set of best-effort probes that work on any host: a SQLite
+read of the Coordinator session DB, a ``shutil.disk_usage`` sample,
+optional ``ps``/``rocm-smi``/``nvidia-smi`` invocations, a tail of a
+configured log file plus error-pattern extraction, and an HTTP probe
+of locally-running inference servers.  Any sub-probe that fails
+returns empty data without raising — :class:`LocalProbeSource` only
+raises :class:`SourceUnavailable` when *every* sub-probe yields
+nothing, so :class:`DegradeRouter` does not get stuck switching back
+and forth.
+
+The probes here intentionally only collect data the agent itself can
+see on the host. Cluster-wide GPU time-series, workload inference
+metrics, and node-level fault detection stay with primus-robust /
+robustness-server (see plan §6.1).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import shutil
+import sqlite3
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+import httpx
+
+from .base import Source, SourceData, SourceUnavailable
+
+
+log = logging.getLogger(__name__)
+
+
+# Default process patterns we surface in ``local_processes``. Matches
+# the existing monitors so refactoring stays drop-in.
+_DEFAULT_PROCESS_PATTERNS: tuple[str, ...] = (
+    "sglang.srt",
+    "vllm.entrypoints",
+    "vllm serve",
+    "benchmark_serving",
+)
+
+
+# Default error patterns extracted from local logs. Conservative — only
+# unambiguous failure markers — to keep false-positive RCA prompts low.
+_DEFAULT_LOG_ERROR_PATTERNS: tuple[str, ...] = (
+    r"CUDA out of memory",
+    r"hipErrorOutOfMemory",
+    r"HIP out of memory",
+    r"Segmentation fault",
+    r"core dumped",
+    r"NCCL error",
+    r"RuntimeError",
+    r"Killed",
+    r"OOMKilled",
+    r"failed to allocate",
+)
+
+
+@dataclass
+class LocalProbeConfig:
+    """Inputs the LocalProbe needs from the agent config."""
+
+    session_dir: Path | None = None
+    server_log_path: Path | None = None
+    log_tail_lines: int = 200
+    disk_mountpoints: tuple[str, ...] = ("/",)
+    process_patterns: tuple[str, ...] = _DEFAULT_PROCESS_PATTERNS
+    coordinator_event_limit: int = 200
+    log_error_patterns: tuple[str, ...] = _DEFAULT_LOG_ERROR_PATTERNS
+    log_error_window_lines: int = 500
+    health_probe_targets: tuple[str, ...] = ()
+    health_probe_timeout_s: float = 1.5
+
+    @property
+    def conductor_db_path(self) -> Path | None:
+        if self.session_dir is None:
+            return None
+        return self.session_dir / "storage" / "conductor.db"
+
+
+@dataclass
+class _ProbeOutcome:
+    success: bool
+    detail: str = ""
+
+
+class LocalProbeSource:
+    """Minimum-effort local data source for the reactor.
+
+    Each :meth:`fetch` call runs the configured sub-probes
+    sequentially. CPU-bound bits (sqlite, subprocess) are off-loaded
+    to a thread pool so the tick stays responsive.
+    """
+
+    name = "local-probe"
+
+    def __init__(self, config: LocalProbeConfig | None = None) -> None:
+        self._config = config or LocalProbeConfig()
+
+    async def fetch(self, ctx: Any) -> SourceData:
+        cfg = self._config
+        coordinator_events = await asyncio.to_thread(
+            _read_coordinator_events,
+            cfg.conductor_db_path,
+            cfg.coordinator_event_limit,
+        )
+        local_disk = await asyncio.to_thread(_sample_disk, cfg.disk_mountpoints)
+        local_processes = await asyncio.to_thread(_sample_processes, cfg.process_patterns)
+        local_gpu = await asyncio.to_thread(_sample_gpu)
+        local_log_tail = await asyncio.to_thread(
+            _tail_log,
+            cfg.server_log_path,
+            cfg.log_tail_lines,
+        )
+        local_log_errors = _extract_log_errors(
+            local_log_tail,
+            cfg.log_error_patterns,
+            cfg.log_error_window_lines,
+        )
+        local_server_health = await _probe_local_servers(
+            cfg.health_probe_targets,
+            cfg.health_probe_timeout_s,
+        )
+
+        any_signal = bool(
+            coordinator_events
+            or local_disk
+            or local_processes
+            or local_gpu
+            or local_log_tail
+            or local_server_health
+        )
+        if not any_signal:
+            raise SourceUnavailable(
+                "local probe produced no data (no conductor.db, no disk, no ps, no gpu, no log, no server)"
+            )
+
+        return SourceData(
+            local_gpu=local_gpu,
+            local_processes=local_processes,
+            local_disk=local_disk,
+            local_log_tail=local_log_tail,
+            local_log_errors=local_log_errors,
+            local_server_health=local_server_health,
+            coordinator_events=coordinator_events,
+            sources_used=[self.name],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Sub-probes (all sync; called via asyncio.to_thread)
+# ---------------------------------------------------------------------------
+
+def _read_coordinator_events(
+    db_path: Path | None,
+    limit: int,
+) -> list[dict[str, Any]]:
+    if db_path is None or not db_path.exists():
+        return []
+    try:
+        conn = sqlite3.connect(
+            f"file:{db_path}?mode=ro",
+            uri=True,
+            timeout=2.0,
+        )
+    except sqlite3.Error as exc:
+        log.debug("local_probe: cannot open %s: %s", db_path, exc)
+        return []
+    try:
+        conn.row_factory = sqlite3.Row
+        # The events table uses ``seq`` as monotonic id; some schemas
+        # alias it to ``id`` ??? probe both.
+        rows = _try_select(
+            conn,
+            [
+                "SELECT seq AS id, from_agent AS agent, topic, payload, ts "
+                "FROM events ORDER BY seq DESC LIMIT ?",
+                "SELECT id, agent, topic, payload, timestamp AS ts "
+                "FROM events ORDER BY id DESC LIMIT ?",
+            ],
+            (limit,),
+        )
+        if not rows:
+            return []
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            out.append(
+                {
+                    "id": row["id"] if "id" in row.keys() else None,
+                    "agent": row["agent"] if "agent" in row.keys() else "",
+                    "topic": row["topic"] if "topic" in row.keys() else "",
+                    "payload": _maybe_decode_json(row["payload"]) if "payload" in row.keys() else None,
+                    "ts": row["ts"] if "ts" in row.keys() else None,
+                }
+            )
+        return out
+    finally:
+        conn.close()
+
+
+def _try_select(
+    conn: sqlite3.Connection,
+    candidates: Iterable[str],
+    params: tuple,
+) -> list[sqlite3.Row]:
+    last_err: sqlite3.Error | None = None
+    for sql in candidates:
+        try:
+            return list(conn.execute(sql, params).fetchall())
+        except sqlite3.Error as exc:
+            last_err = exc
+            continue
+    if last_err is not None:
+        log.debug("local_probe: events select failed: %s", last_err)
+    return []
+
+
+def _maybe_decode_json(value: Any) -> Any:
+    if isinstance(value, (bytes, bytearray)):
+        try:
+            value = value.decode("utf-8", errors="replace")
+        except Exception:
+            return None
+    if isinstance(value, str):
+        import json
+
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return value
+    return value
+
+
+def _sample_disk(mountpoints: tuple[str, ...]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for mp in mountpoints:
+        try:
+            usage = shutil.disk_usage(mp)
+        except OSError as exc:
+            log.debug("local_probe: disk_usage(%s) failed: %s", mp, exc)
+            continue
+        total_gb = usage.total / (1024**3)
+        used_gb = (usage.total - usage.free) / (1024**3)
+        out[mp] = {
+            "total_gb": round(total_gb, 2),
+            "used_gb": round(used_gb, 2),
+            "free_gb": round(usage.free / (1024**3), 2),
+            "used_pct": round((used_gb / total_gb) * 100.0, 2) if total_gb else 0.0,
+        }
+    return out
+
+
+def _sample_processes(patterns: tuple[str, ...]) -> list[dict[str, Any]]:
+    if not patterns:
+        return []
+    try:
+        proc = subprocess.run(
+            ["ps", "-eo", "pid=,rss=,cmd="],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=3.0,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        log.debug("local_probe: ps failed: %s", exc)
+        return []
+    if proc.returncode != 0:
+        return []
+    out: list[dict[str, Any]] = []
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split(None, 2)
+        if len(parts) < 3:
+            continue
+        pid_str, rss_str, cmd = parts
+        if not any(pat in cmd for pat in patterns):
+            continue
+        try:
+            pid = int(pid_str)
+            rss_kb = int(rss_str)
+        except ValueError:
+            continue
+        out.append(
+            {"pid": pid, "rss_mb": round(rss_kb / 1024.0, 1), "cmd": cmd}
+        )
+    return out
+
+
+def _sample_gpu() -> dict[str, Any]:
+    """Best-effort GPU snapshot using rocm-smi or nvidia-smi.
+
+    Returns an empty dict on any failure (binary missing, exits non-zero,
+    parse error). M2 will replace this with a robustness-server cluster
+    proxy call, so the M1 implementation is intentionally lightweight.
+    """
+    snap = _sample_rocm_smi()
+    if snap:
+        return snap
+    return _sample_nvidia_smi()
+
+
+def _sample_rocm_smi() -> dict[str, Any]:
+    if not shutil.which("rocm-smi"):
+        return {}
+    try:
+        proc = subprocess.run(
+            [
+                "rocm-smi",
+                "--showuse",
+                "--showmemuse",
+                "--showtemp",
+                "--showpower",
+                "--csv",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=3.0,
+        )
+    except subprocess.TimeoutExpired:
+        return {}
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return {}
+    gpus = _parse_rocm_smi_csv(proc.stdout)
+    if not gpus:
+        # Keep the raw text in case of parser drift so RCA still has
+        # something to look at.
+        return {"raw_csv": proc.stdout, "tool": "rocm-smi"}
+    return {"gpus": gpus, "tool": "rocm-smi"}
+
+
+# Mapping rocm-smi column header -> SourceData GPU snapshot field. The
+# column names below are stable across ROCm 5.x / 6.x; new metrics map
+# to None and stay in ``raw`` for future inspection.
+_ROCM_HEADER_MAP: dict[str, str] = {
+    "GPU use (%)": "util_gpu_pct",
+    "GPU memory use (%)": "util_mem_pct",
+    "Temperature (Sensor edge) (C)": "temperature_c",
+    "Temperature (Sensor junction) (C)": "temperature_junction_c",
+    "Temperature (Sensor memory) (C)": "temperature_memory_c",
+    "Average Graphics Package Power (W)": "power_watts",
+    "Current Socket Graphics Package Power (W)": "power_watts",
+}
+
+
+def _parse_rocm_smi_csv(text: str) -> list[dict[str, Any]]:
+    """Parse rocm-smi CSV output into ``gpus[]``.
+
+    rocm-smi emits one or more blocks separated by blank lines.  Each
+    block starts with a header row whose first column is ``device``
+    and is followed by per-device rows (``cardN``).  We accumulate all
+    metrics into a single dict per device keyed by ``gpu_id``.
+    """
+    by_id: dict[int, dict[str, Any]] = {}
+    current_columns: list[str] | None = None
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            current_columns = None
+            continue
+        cells = [c.strip() for c in line.split(",")]
+        if not cells:
+            continue
+        if cells[0].lower() == "device":
+            current_columns = cells
+            continue
+        if current_columns is None or len(cells) < 2:
+            continue
+        device = cells[0]
+        if not device.lower().startswith("card"):
+            continue
+        try:
+            gpu_id = int(device[4:])
+        except ValueError:
+            continue
+        snapshot = by_id.setdefault(gpu_id, {"gpu_id": gpu_id})
+        for col_idx in range(1, min(len(cells), len(current_columns))):
+            header = current_columns[col_idx]
+            field = _ROCM_HEADER_MAP.get(header)
+            if not field:
+                continue
+            value = _coerce_float_or_none(cells[col_idx])
+            if value is not None:
+                snapshot[field] = value
+    out: list[dict[str, Any]] = []
+    for k in sorted(by_id):
+        snap = by_id[k]
+        if len(snap) > 1:  # at least one parsed metric beyond ``gpu_id``
+            out.append(snap)
+    return out
+
+
+def _coerce_float_or_none(value: str) -> float | None:
+    if not value:
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def _sample_nvidia_smi() -> dict[str, Any]:
+    if not shutil.which("nvidia-smi"):
+        return {}
+    try:
+        proc = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=index,utilization.gpu,utilization.memory,temperature.gpu,memory.used,memory.total",
+                "--format=csv,noheader,nounits",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=3.0,
+        )
+    except subprocess.TimeoutExpired:
+        return {}
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return {}
+    gpus: list[dict[str, Any]] = []
+    for line in proc.stdout.splitlines():
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) != 6:
+            continue
+        try:
+            gpus.append(
+                {
+                    "gpu_id": int(parts[0]),
+                    "util_gpu_pct": float(parts[1]),
+                    "util_mem_pct": float(parts[2]),
+                    "temperature_c": float(parts[3]),
+                    "vram_used_mb": float(parts[4]),
+                    "vram_total_mb": float(parts[5]),
+                }
+            )
+        except ValueError:
+            continue
+    if not gpus:
+        return {}
+    return {"gpus": gpus, "tool": "nvidia-smi"}
+
+
+def _tail_log(path: Path | None, max_lines: int) -> list[str]:
+    if path is None or not path.exists() or max_lines <= 0:
+        return []
+    try:
+        with path.open("rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            file_size = handle.tell()
+            block = 4096
+            data = b""
+            while file_size > 0 and data.count(b"\n") <= max_lines:
+                read_size = min(block, file_size)
+                file_size -= read_size
+                handle.seek(file_size)
+                data = handle.read(read_size) + data
+    except OSError as exc:
+        log.debug("local_probe: tail %s failed: %s", path, exc)
+        return []
+    text = data.decode("utf-8", errors="replace")
+    lines = text.splitlines()
+    return lines[-max_lines:]
+
+
+def _extract_log_errors(
+    tail: list[str],
+    patterns: tuple[str, ...],
+    window: int,
+) -> list[dict[str, Any]]:
+    """Scan the last ``window`` log lines for fatal error patterns.
+
+    Returns one entry per matching line with the pattern that matched
+    and the line text trimmed to 240 chars (avoid blowing up the
+    `Finding.evidence` payload).
+    """
+    if not tail or not patterns:
+        return []
+    compiled = []
+    for raw in patterns:
+        try:
+            compiled.append((raw, re.compile(raw, re.IGNORECASE)))
+        except re.error:
+            log.debug("local_probe: invalid log pattern: %s", raw)
+            continue
+    if not compiled:
+        return []
+    candidate = tail[-window:] if len(tail) > window else tail
+    out: list[dict[str, Any]] = []
+    for line in candidate:
+        for pattern, regex in compiled:
+            if regex.search(line):
+                out.append(
+                    {"pattern": pattern, "line": line[:240]}
+                )
+                break
+    return out
+
+
+async def _probe_local_servers(
+    targets: tuple[str, ...],
+    timeout_s: float,
+) -> list[dict[str, Any]]:
+    """Issue a tiny GET against each target URL.
+
+    Used to detect "process is alive but server is wedged" — a common
+    failure mode in single-mode dev where the inference server
+    deadlocks and stops accepting requests.  Connection refused /
+    timeout each carry a distinct ``status`` so signals can act on
+    them.
+    """
+    if not targets:
+        return []
+    results: list[dict[str, Any]] = []
+    timeout = httpx.Timeout(max(0.2, float(timeout_s)))
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        for url in targets:
+            entry: dict[str, Any] = {"url": url, "reachable": False, "status": "error"}
+            try:
+                resp = await client.get(url)
+            except httpx.TimeoutException:
+                entry["error"] = "timeout"
+            except httpx.ConnectError as exc:
+                entry["error"] = f"connect: {exc.__class__.__name__}"
+            except httpx.RequestError as exc:
+                entry["error"] = f"request: {exc.__class__.__name__}: {exc}"
+            else:
+                entry["status_code"] = resp.status_code
+                entry["reachable"] = resp.status_code < 500
+                entry["status"] = "ok" if resp.status_code < 400 else "http_error"
+            results.append(entry)
+    return results
+
+
+__all__ = ["LocalProbeConfig", "LocalProbeSource"]

--- a/robustness-agent/src/robustness_agent/sources/server_client.py
+++ b/robustness-agent/src/robustness_agent/sources/server_client.py
@@ -1,0 +1,270 @@
+"""robustness-server client + Source adapter.
+
+The client wraps a small subset of the robustness-server REST API used
+by the M1 reactor:
+
+* ``GET  /healthz``
+* ``GET  /api/v1/sessions``
+* ``GET  /api/v1/sessions/{session_id}``
+* ``GET  /api/v1/sessions/{session_id}/pods``
+* ``GET  /api/v1/sessions/{session_id}/events``
+* ``GET  /api/v1/sessions/{session_id}/metrics``
+* ``GET  /api/v1/sessions/{session_id}/summary``
+
+Networking errors (timeout / connect refused / 5xx) are translated to
+:class:`SourceUnavailable` so :class:`DegradeRouter` can count failures
+and degrade to the local fallback. 4xx responses are returned to the
+caller as parsed JSON because they typically encode "no data for this
+session" rather than an upstream outage.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from .base import Source, SourceData, SourceUnavailable
+
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class _MetricsWindow:
+    """Optional override for the ``/metrics`` and ``/summary`` window.
+
+    The robustness-server requires explicit ``start`` / ``end`` Unix
+    seconds. The reactor decides which window to ask for; M1 defaults
+    to "last 5 minutes" computed from the context clock.
+    """
+
+    start_unix: int
+    end_unix: int
+
+
+class RobustnessServerClient:
+    """HTTP client for the subset of robustness-server we use in M1."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        timeout_s: float = 5.0,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        if not base_url:
+            raise ValueError("base_url must be non-empty")
+        self._base_url = base_url.rstrip("/")
+        self._timeout = httpx.Timeout(timeout_s)
+        self._owns_client = client is None
+        self._client = client or httpx.AsyncClient(
+            base_url=self._base_url,
+            timeout=self._timeout,
+        )
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    # -- low-level GET ---------------------------------------------------
+
+    async def _get_json(self, path: str, *, params: dict[str, Any] | None = None) -> Any:
+        try:
+            resp = await self._client.get(path, params=params)
+        except httpx.TimeoutException as exc:
+            raise SourceUnavailable(f"GET {path}: timeout") from exc
+        except httpx.RequestError as exc:
+            raise SourceUnavailable(f"GET {path}: {type(exc).__name__}: {exc}") from exc
+        if resp.status_code >= 500:
+            raise SourceUnavailable(
+                f"GET {path}: upstream {resp.status_code}"
+            )
+        if resp.status_code == 404:
+            return None
+        if resp.status_code >= 400:
+            return None
+        try:
+            return resp.json()
+        except ValueError as exc:
+            raise SourceUnavailable(f"GET {path}: invalid json") from exc
+
+    # -- public methods --------------------------------------------------
+
+    async def health(self) -> bool:
+        try:
+            resp = await self._client.get("/healthz")
+        except httpx.RequestError:
+            return False
+        return resp.status_code == 200
+
+    async def list_sessions(self, *, limit: int = 50) -> list[dict[str, Any]]:
+        body = await self._get_json("/api/v1/sessions", params={"limit": limit})
+        if isinstance(body, list):
+            return body
+        return []
+
+    async def get_session(self, session_id: str) -> dict[str, Any] | None:
+        body = await self._get_json(f"/api/v1/sessions/{session_id}")
+        return body if isinstance(body, dict) else None
+
+    async def list_session_pods(
+        self,
+        session_id: str,
+        *,
+        start_unix: int | None = None,
+        end_unix: int | None = None,
+    ) -> list[dict[str, Any]]:
+        params: dict[str, Any] = {}
+        if start_unix is not None:
+            params["start"] = _to_iso(start_unix)
+        if end_unix is not None:
+            params["end"] = _to_iso(end_unix)
+        body = await self._get_json(
+            f"/api/v1/sessions/{session_id}/pods",
+            params=params or None,
+        )
+        if isinstance(body, list):
+            return body
+        return []
+
+    async def list_session_events(
+        self,
+        session_id: str,
+        *,
+        start_unix: int | None = None,
+        end_unix: int | None = None,
+        limit: int = 200,
+    ) -> list[dict[str, Any]]:
+        params: dict[str, Any] = {"limit": limit}
+        if start_unix is not None:
+            params["start"] = _to_iso(start_unix)
+        if end_unix is not None:
+            params["end"] = _to_iso(end_unix)
+        body = await self._get_json(
+            f"/api/v1/sessions/{session_id}/events",
+            params=params,
+        )
+        if isinstance(body, dict):
+            events = body.get("events")
+            if isinstance(events, list):
+                return events
+        return []
+
+    async def get_session_summary(
+        self,
+        session_id: str,
+        window: _MetricsWindow,
+    ) -> dict[str, Any]:
+        body = await self._get_json(
+            f"/api/v1/sessions/{session_id}/summary",
+            params={"start": str(window.start_unix), "end": str(window.end_unix)},
+        )
+        return body if isinstance(body, dict) else {}
+
+    async def get_session_metrics(
+        self,
+        session_id: str,
+        window: _MetricsWindow,
+        *,
+        categories: list[str] | None = None,
+        step: str | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {
+            "start": str(window.start_unix),
+            "end": str(window.end_unix),
+        }
+        if categories:
+            params["categories"] = ",".join(categories)
+        if step:
+            params["step"] = step
+        body = await self._get_json(
+            f"/api/v1/sessions/{session_id}/metrics",
+            params=params,
+        )
+        return body if isinstance(body, dict) else {}
+
+
+def _to_iso(unix_seconds: int) -> str:
+    """Format Unix seconds as ISO-8601 UTC for ``start`` / ``end`` query args."""
+    from datetime import datetime, timezone
+
+    return datetime.fromtimestamp(int(unix_seconds), tz=timezone.utc).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Source adapter
+# ---------------------------------------------------------------------------
+
+class RobustnessServerSource:
+    """Adapter wrapping :class:`RobustnessServerClient` as a :class:`Source`.
+
+    Per tick we fetch ``pods`` + ``events`` + ``summary`` for the
+    session referenced by ``ctx.shared_state.session_id``. ``metrics``
+    is intentionally skipped in M1 because cluster-physical proxies
+    arrive in M2; the reactor still has plenty to chew on with pod
+    phase + recent events.
+    """
+
+    name = "robustness-server"
+
+    def __init__(
+        self,
+        client: RobustnessServerClient,
+        *,
+        metrics_window_s: int = 300,
+        events_limit: int = 200,
+    ) -> None:
+        self._client = client
+        self._metrics_window_s = max(60, int(metrics_window_s))
+        self._events_limit = max(1, int(events_limit))
+
+    async def fetch(self, ctx: Any) -> SourceData:
+        session_id = _extract_session_id(ctx)
+        if not session_id:
+            raise SourceUnavailable("no session_id in reactor context")
+
+        now_unix = int(getattr(ctx, "now_unix", 0)) or 0
+        window = _MetricsWindow(
+            start_unix=now_unix - self._metrics_window_s if now_unix else 0,
+            end_unix=now_unix or 0,
+        )
+
+        pods = await self._client.list_session_pods(
+            session_id,
+            start_unix=window.start_unix or None,
+            end_unix=window.end_unix or None,
+        )
+        events = await self._client.list_session_events(
+            session_id,
+            start_unix=window.start_unix or None,
+            end_unix=window.end_unix or None,
+            limit=self._events_limit,
+        )
+        summary: dict[str, Any] = {}
+        if window.start_unix and window.end_unix:
+            summary = await self._client.get_session_summary(session_id, window)
+
+        return SourceData(
+            session_pods=pods,
+            session_events=events,
+            session_summary=summary,
+            sources_used=[self.name],
+        )
+
+
+def _extract_session_id(ctx: Any) -> str:
+    shared = getattr(ctx, "shared_state", None)
+    return getattr(shared, "session_id", "") or ""
+
+
+__all__ = [
+    "RobustnessServerClient",
+    "RobustnessServerSource",
+]

--- a/robustness-agent/tests/test_decision_action_ladder.py
+++ b/robustness-agent/tests/test_decision_action_ladder.py
@@ -1,0 +1,201 @@
+"""Unit tests for :class:`ActionLadder`."""
+
+from __future__ import annotations
+
+import pytest
+
+from robustness_agent.decision.action_ladder import (
+    ActionLadder,
+    ActionLadderConfig,
+)
+from robustness_agent.role.envelope import IntentType
+from robustness_agent.signals import Symptom, SymptomSeverity
+
+pytestmark = pytest.mark.asyncio
+
+
+def _sym(
+    name: str,
+    severity: SymptomSeverity,
+    *,
+    summary: str = "summary",
+    subject: dict | None = None,
+    evidence: dict | None = None,
+    suggestion: str = "",
+) -> Symptom:
+    return Symptom(
+        name=name,
+        severity=severity,
+        summary=summary,
+        evidence=evidence or {},
+        subject=subject or {"k": "v"},
+        source="test",
+        suggestion=suggestion,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tier mapping
+# ---------------------------------------------------------------------------
+
+async def test_low_severity_yields_observation_send_message():
+    ladder = ActionLadder()
+    out = await ladder.decide(
+        [_sym("pod_no_metrics", SymptomSeverity.LOW)],
+        tick_index=0,
+        now_unix=1.0,
+    )
+    assert len(out.intents) == 1
+    assert out.intents[0].type is IntentType.SEND_MESSAGE
+    assert out.intents[0].payload["topic"] == "observation"
+    assert out.findings and out.findings[0].symptom_name == "pod_no_metrics"
+
+
+async def test_medium_severity_yields_alert_only():
+    ladder = ActionLadder()
+    out = await ladder.decide(
+        [_sym("crash_count_rising", SymptomSeverity.MEDIUM)],
+        tick_index=0,
+        now_unix=1.0,
+    )
+    assert len(out.intents) == 1
+    assert out.intents[0].type is IntentType.ALERT
+    assert out.intents[0].payload["severity"] == "medium"
+
+
+async def test_high_crash_emits_alert_plus_escalate():
+    ladder = ActionLadder()
+    out = await ladder.decide(
+        [_sym("crash_count_high", SymptomSeverity.HIGH, suggestion="revert")],
+        tick_index=0,
+        now_unix=1.0,
+    )
+    types = [i.type for i in out.intents]
+    assert IntentType.ALERT in types
+    assert IntentType.ESCALATE_STRATEGY_CHANGE in types
+    escalate = next(i for i in out.intents if i.type is IntentType.ESCALATE_STRATEGY_CHANGE)
+    assert escalate.payload["next_action_hint"] == "revert"
+
+
+async def test_high_agent_stall_emits_escalate_with_default_hint():
+    ladder = ActionLadder()
+    out = await ladder.decide(
+        [_sym("agent_stall", SymptomSeverity.HIGH, subject={"agent": "kernel"})],
+        tick_index=0,
+        now_unix=1.0,
+    )
+    types = [i.type for i in out.intents]
+    assert IntentType.ALERT in types
+    assert IntentType.ESCALATE_STRATEGY_CHANGE in types
+
+
+async def test_repeated_failure_with_family_triggers_prune_branch():
+    ladder = ActionLadder()
+    out = await ladder.decide(
+        [
+            _sym(
+                "repeated_failure",
+                SymptomSeverity.HIGH,
+                evidence={"family": "kernel_opt", "count": 3},
+                subject={"family": "kernel_opt"},
+            )
+        ],
+        tick_index=0,
+        now_unix=1.0,
+    )
+    types = [i.type for i in out.intents]
+    assert IntentType.PRUNE_BRANCH in types
+    prune = next(i for i in out.intents if i.type is IntentType.PRUNE_BRANCH)
+    assert prune.payload["family"] == "kernel_opt"
+
+
+# ---------------------------------------------------------------------------
+# Cooldown / heartbeat
+# ---------------------------------------------------------------------------
+
+async def test_no_symptoms_falls_back_to_heartbeat():
+    ladder = ActionLadder()
+    out = await ladder.decide([], tick_index=0, now_unix=1.0)
+    assert len(out.intents) == 1
+    assert out.intents[0].type is IntentType.SEND_MESSAGE
+    assert out.intents[0].payload["topic"] == "heartbeat"
+    assert out.findings == []
+
+
+async def test_cooldown_suppresses_duplicate_within_window():
+    ladder = ActionLadder(config=ActionLadderConfig(cooldown_ticks=3))
+    sym = _sym("crash_count_rising", SymptomSeverity.MEDIUM, subject={"k": "1"})
+    first = await ladder.decide([sym], tick_index=0, now_unix=1.0)
+    suppressed = await ladder.decide([sym], tick_index=1, now_unix=2.0)
+    assert any(i.type is IntentType.ALERT for i in first.intents)
+    # Suppressed tick: no symptom-derived intent emitted, only heartbeat.
+    assert all(
+        not (i.type is IntentType.ALERT) for i in suppressed.intents
+    )
+    assert any(i.payload.get("topic") == "heartbeat" for i in suppressed.intents)
+    assert suppressed.findings == []
+
+
+async def test_cooldown_releases_after_window():
+    ladder = ActionLadder(config=ActionLadderConfig(cooldown_ticks=3))
+    sym = _sym("crash_count_rising", SymptomSeverity.MEDIUM, subject={"k": "1"})
+    await ladder.decide([sym], tick_index=0, now_unix=1.0)
+    out = await ladder.decide([sym], tick_index=3, now_unix=4.0)
+    assert any(i.type is IntentType.ALERT for i in out.intents)
+
+
+async def test_finding_carries_serialised_intents_and_evidence():
+    ladder = ActionLadder()
+    out = await ladder.decide(
+        [
+            _sym(
+                "crash_count_high",
+                SymptomSeverity.HIGH,
+                summary="crash_count=5",
+                evidence={"crash_count": 5},
+                suggestion="revert",
+            )
+        ],
+        tick_index=2,
+        now_unix=10.0,
+    )
+    assert out.findings
+    finding = out.findings[0]
+    assert finding.symptom_name == "crash_count_high"
+    assert finding.tick_index == 2
+    assert finding.timestamp_unix == 10.0
+    assert any(i["intent_type"] == "escalate_strategy_change" for i in finding.intents)
+    assert finding.evidence == {"crash_count": 5}
+
+
+async def test_rca_provider_is_invoked_when_supplied():
+    ladder = ActionLadder()
+
+    class StubRca:
+        def summarize(self, sym: Symptom) -> str:
+            return f"rca({sym.name})"
+
+    out = await ladder.decide(
+        [_sym("crash_count_rising", SymptomSeverity.MEDIUM)],
+        tick_index=0,
+        now_unix=1.0,
+        rca_provider=StubRca(),
+    )
+    assert out.findings[0].rca_text == "rca(crash_count_rising)"
+
+
+async def test_rca_provider_failure_does_not_break_ladder():
+    ladder = ActionLadder()
+
+    class BadRca:
+        def summarize(self, sym):
+            raise RuntimeError("oops")
+
+    out = await ladder.decide(
+        [_sym("crash_count_rising", SymptomSeverity.MEDIUM)],
+        tick_index=0,
+        now_unix=1.0,
+        rca_provider=BadRca(),
+    )
+    assert out.findings[0].rca_text == ""
+    assert any(i.type is IntentType.ALERT for i in out.intents)

--- a/robustness-agent/tests/test_decision_policy_aware.py
+++ b/robustness-agent/tests/test_decision_policy_aware.py
@@ -1,0 +1,237 @@
+"""Unit tests for :class:`robustness_agent.decision.PolicyAware`.
+
+The validator mirrors upstream PolicyGate.  These tests pin the
+behaviour the reactor relies on:
+
+* every robustness-allowed intent built via the helpers passes.
+* missing / mistyped payload fields raise :class:`PolicyViolation` with
+  the rule label upstream PolicyGate uses.
+* validate_all collects every violation rather than short-circuiting.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from robustness_agent.decision import PolicyAware, PolicyViolation
+from robustness_agent.role.envelope import (
+    Intent,
+    IntentType,
+    build_alert,
+    build_delegate,
+    build_escalate,
+    build_force_dispatch,
+    build_heartbeat,
+    build_kill_task,
+    build_prune_branch,
+    build_send_message,
+    build_update_state,
+)
+
+
+@pytest.fixture()
+def policy() -> PolicyAware:
+    return PolicyAware()
+
+
+# ---------------------------------------------------------------------------
+# Happy path — every builder output should be emit-safe
+# ---------------------------------------------------------------------------
+
+def test_heartbeat_passes(policy: PolicyAware):
+    policy.assert_payload_complete(build_heartbeat())
+
+
+def test_send_message_observation_passes(policy: PolicyAware):
+    policy.assert_payload_complete(build_send_message("observation", body_md="x"))
+
+
+@pytest.mark.parametrize("severity", ["low", "medium", "high"])
+def test_alert_each_severity_passes(severity, policy: PolicyAware):
+    policy.assert_payload_complete(build_alert(severity, "summary"))
+
+
+def test_escalate_passes(policy: PolicyAware):
+    policy.assert_payload_complete(build_escalate("r", "next"))
+
+
+def test_kill_task_passes(policy: PolicyAware):
+    policy.assert_payload_complete(build_kill_task("t1", "stuck"))
+
+
+def test_force_dispatch_passes(policy: PolicyAware):
+    policy.assert_payload_complete(build_force_dispatch("t1", "blocked"))
+
+
+def test_prune_branch_passes(policy: PolicyAware):
+    policy.assert_payload_complete(build_prune_branch("backends", "fail x3"))
+
+
+def test_delegate_passes(policy: PolicyAware):
+    for action in ("accuracy_gate", "recover", "server_lifecycle"):
+        policy.assert_payload_complete(build_delegate(action))
+
+
+def test_update_state_passes(policy: PolicyAware):
+    policy.assert_payload_complete(build_update_state({"crash_count": 1}))
+
+
+# ---------------------------------------------------------------------------
+# Role gate
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "intent_type",
+    [
+        IntentType.PROPOSE_ACTION,
+        IntentType.REQUEST,
+        IntentType.RESPONSE,
+        IntentType.REVIEW_VERDICT,
+    ],
+)
+def test_role_blocks_disallowed_intents(intent_type, policy: PolicyAware):
+    intent = Intent(type=intent_type, payload={})
+    with pytest.raises(PolicyViolation) as excinfo:
+        policy.assert_payload_complete(intent)
+    assert excinfo.value.rule == "role"
+
+
+# ---------------------------------------------------------------------------
+# Required-field gate
+# ---------------------------------------------------------------------------
+
+def test_alert_missing_severity_is_payload_error(policy: PolicyAware):
+    intent = Intent(type=IntentType.ALERT, payload={"summary": "x"})
+    with pytest.raises(PolicyViolation) as excinfo:
+        policy.assert_payload_complete(intent)
+    assert excinfo.value.rule == "payload"
+
+
+def test_alert_missing_summary_is_payload_error(policy: PolicyAware):
+    intent = Intent(type=IntentType.ALERT, payload={"severity": "low"})
+    with pytest.raises(PolicyViolation) as excinfo:
+        policy.assert_payload_complete(intent)
+    assert excinfo.value.rule == "payload"
+
+
+def test_alert_unknown_severity_is_payload_error(policy: PolicyAware):
+    intent = Intent(
+        type=IntentType.ALERT,
+        payload={"severity": "warn", "summary": "x"},
+    )
+    with pytest.raises(PolicyViolation) as excinfo:
+        policy.assert_payload_complete(intent)
+    assert excinfo.value.rule == "payload"
+
+
+def test_kill_task_missing_task_id(policy: PolicyAware):
+    intent = Intent(type=IntentType.KILL_TASK, payload={"reason": "x"})
+    with pytest.raises(PolicyViolation) as excinfo:
+        policy.assert_payload_complete(intent)
+    assert excinfo.value.rule == "payload"
+
+
+def test_kill_task_bad_scope_uses_kill_scope_rule(policy: PolicyAware):
+    intent = Intent(
+        type=IntentType.KILL_TASK,
+        payload={"task_id": "t", "reason": "r", "scope": "process"},
+    )
+    with pytest.raises(PolicyViolation) as excinfo:
+        policy.assert_payload_complete(intent)
+    assert excinfo.value.rule == "kill_scope"
+
+
+def test_force_dispatch_required_fields(policy: PolicyAware):
+    intent = Intent(type=IntentType.FORCE_DISPATCH, payload={"task_id": ""})
+    with pytest.raises(PolicyViolation) as excinfo:
+        policy.assert_payload_complete(intent)
+    assert excinfo.value.rule == "payload"
+
+
+def test_prune_branch_required_fields(policy: PolicyAware):
+    intent = Intent(type=IntentType.PRUNE_BRANCH, payload={"family": "f"})
+    with pytest.raises(PolicyViolation):
+        policy.assert_payload_complete(intent)
+
+
+def test_escalate_missing_hint_is_payload_error(policy: PolicyAware):
+    intent = Intent(
+        type=IntentType.ESCALATE_STRATEGY_CHANGE,
+        payload={"reason": "r"},
+    )
+    with pytest.raises(PolicyViolation) as excinfo:
+        policy.assert_payload_complete(intent)
+    assert excinfo.value.rule == "payload"
+
+
+def test_escalate_invalid_severity_is_payload_error(policy: PolicyAware):
+    intent = Intent(
+        type=IntentType.ESCALATE_STRATEGY_CHANGE,
+        payload={
+            "reason": "r",
+            "next_action_hint": "h",
+            "severity": "extreme",
+        },
+    )
+    with pytest.raises(PolicyViolation):
+        policy.assert_payload_complete(intent)
+
+
+def test_delegate_kernel_owned_action_is_blocked(policy: PolicyAware):
+    intent = Intent(type=IntentType.DELEGATE, payload={"action_name": "kernel_opt"})
+    with pytest.raises(PolicyViolation) as excinfo:
+        policy.assert_payload_complete(intent)
+    assert excinfo.value.rule == "delegate_action"
+
+
+def test_update_state_core_field_blocked_with_state_field_rule(policy: PolicyAware):
+    intent = Intent(
+        type=IntentType.UPDATE_STATE,
+        payload={"changes": {"current_best": {"tput": 1.0}}},
+    )
+    with pytest.raises(PolicyViolation) as excinfo:
+        policy.assert_payload_complete(intent)
+    assert excinfo.value.rule == "state_field"
+
+
+def test_update_state_unknown_field_blocked(policy: PolicyAware):
+    intent = Intent(
+        type=IntentType.UPDATE_STATE,
+        payload={"changes": {"random": 1}},
+    )
+    with pytest.raises(PolicyViolation) as excinfo:
+        policy.assert_payload_complete(intent)
+    assert excinfo.value.rule == "state_field"
+
+
+def test_update_state_empty_changes_blocked(policy: PolicyAware):
+    intent = Intent(type=IntentType.UPDATE_STATE, payload={"changes": {}})
+    with pytest.raises(PolicyViolation) as excinfo:
+        policy.assert_payload_complete(intent)
+    assert excinfo.value.rule == "payload"
+
+
+def test_send_message_missing_topic(policy: PolicyAware):
+    intent = Intent(type=IntentType.SEND_MESSAGE, payload={})
+    with pytest.raises(PolicyViolation) as excinfo:
+        policy.assert_payload_complete(intent)
+    assert excinfo.value.rule == "payload"
+
+
+# ---------------------------------------------------------------------------
+# validate_all collects every violation
+# ---------------------------------------------------------------------------
+
+def test_validate_all_collects_multiple_violations(policy: PolicyAware):
+    bad = Intent(
+        type=IntentType.UPDATE_STATE,
+        payload={"changes": {"current_best": 1, "random": 2}},
+    )
+    violations = policy.validate_all(bad)
+    assert violations
+    rules = [v.rule for v in violations]
+    assert "state_field" in rules
+
+
+def test_validate_all_returns_empty_on_valid_intent(policy: PolicyAware):
+    assert policy.validate_all(build_heartbeat()) == []

--- a/robustness-agent/tests/test_decision_rca_engine.py
+++ b/robustness-agent/tests/test_decision_rca_engine.py
@@ -1,0 +1,302 @@
+"""Unit tests for :class:`LlmRcaEngine` and :class:`RcaThrottle`."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from robustness_agent.decision.rca_engine import (
+    LlmRcaEngine,
+    NoopRcaEngine,
+    RcaThrottle,
+    RcaThrottleConfig,
+)
+from robustness_agent.signals import Symptom, SymptomSeverity
+
+
+def _sym(
+    name: str = "crash_count_high",
+    severity: SymptomSeverity = SymptomSeverity.HIGH,
+    *,
+    summary: str = "crash_count=5",
+    subject: dict | None = None,
+    evidence: dict | None = None,
+) -> Symptom:
+    return Symptom(
+        name=name,
+        severity=severity,
+        summary=summary,
+        evidence=evidence or {"crash_count": 5},
+        subject=subject or {"agent": "session"},
+        source="test",
+    )
+
+
+def _engine(handler, *, throttle: RcaThrottle | None = None, **overrides) -> LlmRcaEngine:
+    transport = httpx.MockTransport(handler)
+    client = httpx.AsyncClient(
+        base_url="http://chat.test",
+        transport=transport,
+        timeout=httpx.Timeout(2.0),
+        headers={"Authorization": "Bearer secret", "Content-Type": "application/json"},
+    )
+    return LlmRcaEngine(
+        base_url="http://chat.test",
+        api_key="secret",
+        client=client,
+        throttle=throttle,
+        **overrides,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Noop engine
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_noop_engine_returns_empty():
+    engine = NoopRcaEngine()
+    assert await engine.summarize(_sym()) == ""
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_llm_engine_calls_chat_server_and_returns_text():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["body"] = request.read().decode()
+        captured["auth"] = request.headers.get("Authorization")
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {"message": {"content": "Likely OOM. Reduce batch_size."}}
+                ]
+            },
+        )
+
+    engine = _engine(handler)
+    try:
+        engine.set_tick(1)
+        text = await engine.summarize(_sym())
+    finally:
+        await engine.aclose()
+    assert "Likely OOM" in text
+    assert "/chat/completions" in captured["url"]
+    assert captured["auth"] == "Bearer secret"
+    assert "crash_count=5" in captured["body"]
+    assert "claude-opus-4-7" in captured["body"]
+
+
+@pytest.mark.asyncio
+async def test_llm_engine_truncates_to_max_chars():
+    long_text = "abcd" * 1000
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"choices": [{"message": {"content": long_text}}]},
+        )
+
+    engine = _engine(handler, max_chars=50)
+    try:
+        engine.set_tick(1)
+        text = await engine.summarize(_sym())
+    finally:
+        await engine.aclose()
+    assert len(text) == 50
+    assert text.endswith("...")
+
+
+@pytest.mark.asyncio
+async def test_llm_engine_handles_list_content_parts():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "message": {
+                            "content": [
+                                {"type": "text", "text": "Hello "},
+                                {"type": "text", "text": "World"},
+                            ]
+                        }
+                    }
+                ]
+            },
+        )
+
+    engine = _engine(handler)
+    try:
+        engine.set_tick(1)
+        text = await engine.summarize(_sym())
+    finally:
+        await engine.aclose()
+    assert text == "Hello World"
+
+
+# ---------------------------------------------------------------------------
+# Throttle
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_throttle_skips_low_severity_symptoms():
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200, json={"choices": [{"message": {"content": "ok"}}]})
+
+    engine = _engine(handler, throttle=RcaThrottle(RcaThrottleConfig(severity_min=SymptomSeverity.HIGH)))
+    try:
+        engine.set_tick(1)
+        result = await engine.summarize(_sym(severity=SymptomSeverity.MEDIUM))
+    finally:
+        await engine.aclose()
+    assert result == ""
+    assert calls == 0
+
+
+@pytest.mark.asyncio
+async def test_throttle_caps_calls_per_tick():
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200, json={"choices": [{"message": {"content": "ok"}}]})
+
+    engine = _engine(handler, throttle=RcaThrottle(RcaThrottleConfig(max_calls_per_tick=1)))
+    try:
+        engine.set_tick(1)
+        first = await engine.summarize(_sym(name="a", subject={"k": "1"}))
+        second = await engine.summarize(_sym(name="b", subject={"k": "2"}))
+    finally:
+        await engine.aclose()
+    assert first
+    assert second == ""
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_throttle_resets_per_tick():
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200, json={"choices": [{"message": {"content": "ok"}}]})
+
+    engine = _engine(handler, throttle=RcaThrottle(RcaThrottleConfig(max_calls_per_tick=1, cooldown_seconds=0.0)))
+    try:
+        engine.set_tick(1)
+        await engine.summarize(_sym(name="a", subject={"k": "1"}))
+        engine.set_tick(2)
+        await engine.summarize(_sym(name="b", subject={"k": "2"}))
+    finally:
+        await engine.aclose()
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_throttle_enforces_per_key_cooldown():
+    """Same dedup_key within cooldown window should not call again."""
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200, json={"choices": [{"message": {"content": "ok"}}]})
+
+    throttle = RcaThrottle(RcaThrottleConfig(max_calls_per_tick=10, cooldown_seconds=600.0))
+    engine = _engine(handler, throttle=throttle)
+    try:
+        engine.set_tick(1)
+        first = await engine.summarize(_sym(name="x", subject={"k": "1"}))
+        engine.set_tick(2)
+        second = await engine.summarize(_sym(name="x", subject={"k": "1"}))
+    finally:
+        await engine.aclose()
+    assert first
+    assert second == ""
+    assert calls == 1
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_llm_engine_returns_empty_on_500():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"detail": "boom"})
+
+    engine = _engine(handler)
+    try:
+        engine.set_tick(1)
+        result = await engine.summarize(_sym())
+    finally:
+        await engine.aclose()
+    assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_llm_engine_returns_empty_on_timeout():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.TimeoutException("slow", request=request)
+
+    engine = _engine(handler)
+    try:
+        engine.set_tick(1)
+        result = await engine.summarize(_sym())
+    finally:
+        await engine.aclose()
+    assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_llm_engine_skips_when_credentials_missing():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("should not be called")
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.AsyncClient(transport=transport, base_url="http://chat.test")
+    engine = LlmRcaEngine(base_url="", api_key="", client=client)
+    try:
+        engine.set_tick(1)
+        text = await engine.summarize(_sym())
+    finally:
+        await client.aclose()
+    assert text == ""
+
+
+# ---------------------------------------------------------------------------
+# extra_evidence_provider
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_extra_evidence_appears_in_prompt():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = request.read().decode()
+        return httpx.Response(200, json={"choices": [{"message": {"content": "ok"}}]})
+
+    def evidence(_sym):
+        return ["log line 1", "log line 2"]
+
+    engine = _engine(handler, extra_evidence_provider=evidence)
+    try:
+        engine.set_tick(1)
+        await engine.summarize(_sym())
+    finally:
+        await engine.aclose()
+    assert "log line 1" in captured["body"]
+    assert "log line 2" in captured["body"]

--- a/robustness-agent/tests/test_factory.py
+++ b/robustness-agent/tests/test_factory.py
@@ -1,0 +1,167 @@
+"""Smoke tests for the M1 factory."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from robustness_agent.config import Config
+from robustness_agent.factory import build_backend, build_reactor_components
+from robustness_agent.role.envelope import IntentType
+from robustness_agent.role.prompt_inputs import (
+    ReactorContext,
+    SharedStateSnapshot,
+)
+from robustness_agent.sources.base import HealthState
+
+
+@pytest.mark.asyncio
+async def test_build_reactor_components_local_only_mode_runs_a_tick(tmp_path: Path):
+    config = Config(session_dir=tmp_path)
+    config.robustness_server_url = ""
+    bundle = build_reactor_components(config)
+    try:
+        ctx = ReactorContext(
+            tick_index=0,
+            shared_state=SharedStateSnapshot(session_id="sess-1", crash_count=2),
+            inbox=[],
+            now_unix=1000.0,
+        )
+        intents = await bundle.reactor.tick(ctx)
+        assert intents
+        assert any(i.type is IntentType.ALERT for i in intents)
+        # No server URL means primary source degrades after fail_threshold.
+        assert bundle.server_client is None
+    finally:
+        await bundle.aclose()
+
+
+@pytest.mark.asyncio
+async def test_build_backend_returns_working_backend(tmp_path: Path):
+    config = Config(session_dir=tmp_path, robustness_server_url="")
+    backend, bundle = build_backend(config)
+    try:
+        result = await backend.run(
+            "=== Shared session state ===\n"
+            "session_id=sess-1\n"
+            "crash_count=0\n"
+            "=== Inbox for robustness ===\n"
+            "(no new messages)\n"
+        )
+        assert result.metadata["tick_index"] == 1
+        assert any(i.type is IntentType.SEND_MESSAGE for i in result.intents)
+    finally:
+        await bundle.aclose()
+
+
+@pytest.mark.asyncio
+async def test_build_reactor_components_uses_server_url_when_set(tmp_path: Path):
+    config = Config(
+        session_dir=tmp_path,
+        robustness_server_url="http://example.invalid:8000",
+    )
+    bundle = build_reactor_components(config)
+    try:
+        # We cannot reach the URL; primary source should fail and the
+        # fallback eventually serve. We just assert the bundle wires the
+        # server_client when a URL is configured.
+        assert bundle.server_client is not None
+        assert bundle.server_client.base_url == "http://example.invalid:8000"
+    finally:
+        await bundle.aclose()
+
+
+# ---------------------------------------------------------------------------
+# M1.5 LLM RCA wiring
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_factory_uses_noop_engine_when_credentials_missing(tmp_path: Path):
+    from robustness_agent.decision.rca_engine import NoopRcaEngine
+
+    config = Config(session_dir=tmp_path, robustness_server_url="")
+    bundle = build_reactor_components(config)
+    try:
+        assert isinstance(bundle.components.rca, NoopRcaEngine)
+    finally:
+        await bundle.aclose()
+
+
+@pytest.mark.asyncio
+async def test_factory_uses_llm_engine_when_credentials_present(tmp_path: Path):
+    from robustness_agent.decision.rca_engine import LlmRcaEngine
+
+    config = Config(
+        session_dir=tmp_path,
+        robustness_server_url="",
+        llm_base_url="http://chat-server.invalid/v1",
+        llm_api_key="secret",
+    )
+    bundle = build_reactor_components(config)
+    try:
+        engine = bundle.components.rca
+        assert isinstance(engine, LlmRcaEngine)
+        assert engine.model == config.llm_model
+        await engine.aclose()
+    finally:
+        await bundle.aclose()
+
+
+@pytest.mark.asyncio
+async def test_factory_respects_explicit_disable(tmp_path: Path):
+    from robustness_agent.decision.rca_engine import NoopRcaEngine
+
+    config = Config(
+        session_dir=tmp_path,
+        robustness_server_url="",
+        llm_base_url="http://chat-server.invalid/v1",
+        llm_api_key="secret",
+        llm_rca_enabled=False,
+    )
+    bundle = build_reactor_components(config)
+    try:
+        assert isinstance(bundle.components.rca, NoopRcaEngine)
+    finally:
+        await bundle.aclose()
+
+
+@pytest.mark.asyncio
+async def test_factory_respects_env_disable(monkeypatch, tmp_path: Path):
+    from robustness_agent.decision.rca_engine import NoopRcaEngine
+
+    monkeypatch.setenv("ROBUSTNESS_LLM_RCA_DISABLED", "1")
+    config = Config(
+        session_dir=tmp_path,
+        robustness_server_url="",
+        llm_base_url="http://chat-server.invalid/v1",
+        llm_api_key="secret",
+    )
+    bundle = build_reactor_components(config)
+    try:
+        assert isinstance(bundle.components.rca, NoopRcaEngine)
+    finally:
+        await bundle.aclose()
+
+
+@pytest.mark.asyncio
+async def test_factory_propagates_severity_min_config(tmp_path: Path):
+    from robustness_agent.decision.rca_engine import LlmRcaEngine
+    from robustness_agent.signals import SymptomSeverity
+
+    config = Config(
+        session_dir=tmp_path,
+        robustness_server_url="",
+        llm_base_url="http://chat-server.invalid/v1",
+        llm_api_key="secret",
+        llm_rca_severity_min="medium",
+    )
+    bundle = build_reactor_components(config)
+    try:
+        engine = bundle.components.rca
+        assert isinstance(engine, LlmRcaEngine)
+        assert engine.throttle is not None
+        assert engine.throttle.config.severity_min is SymptomSeverity.MEDIUM
+        await engine.aclose()
+    finally:
+        await bundle.aclose()

--- a/robustness-agent/tests/test_findings_sink.py
+++ b/robustness-agent/tests/test_findings_sink.py
@@ -1,0 +1,78 @@
+"""Unit tests for the findings JSONL sink."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from robustness_agent.decision.action_ladder import Finding
+from robustness_agent.findings import FindingSink, FindingSinkConfig
+
+
+def _finding(**overrides) -> Finding:
+    base = dict(
+        tick_index=1,
+        timestamp_unix=1.0,
+        symptom_name="x",
+        severity="medium",
+        summary="s",
+        intents=[{"intent_type": "alert", "payload": {"severity": "medium", "summary": "s"}}],
+        evidence={"k": 1},
+        rca_text="",
+    )
+    base.update(overrides)
+    return Finding(**base)
+
+
+@pytest.mark.asyncio
+async def test_sink_appends_jsonl_rows(tmp_path: Path):
+    sink = FindingSink(FindingSinkConfig(session_dir=tmp_path, session_id="sess-1"))
+    written = await sink.append_many([_finding(tick_index=1), _finding(tick_index=2)])
+    assert written == 2
+    path = sink.file_path
+    assert path.exists()
+    rows = [json.loads(line) for line in path.read_text().splitlines() if line]
+    assert [r["tick_index"] for r in rows] == [1, 2]
+    assert all(r["intents"][0]["intent_type"] == "alert" for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_sink_appends_across_calls(tmp_path: Path):
+    sink = FindingSink(FindingSinkConfig(session_dir=tmp_path, session_id="sess-2"))
+    await sink.append_many([_finding(tick_index=1)])
+    await sink.append_many([_finding(tick_index=2)])
+    rows = sink.file_path.read_text().splitlines()
+    assert len(rows) == 2
+
+
+@pytest.mark.asyncio
+async def test_sink_creates_subdirectories_when_missing(tmp_path: Path):
+    sink = FindingSink(FindingSinkConfig(session_dir=tmp_path, session_id="abc"))
+    assert not sink.file_path.exists()
+    await sink.append_many([_finding()])
+    assert sink.file_path.exists()
+    assert sink.file_path.parent.name == "findings"
+
+
+@pytest.mark.asyncio
+async def test_sink_is_resilient_to_io_errors(tmp_path: Path, caplog):
+    cfg = FindingSinkConfig(session_dir=tmp_path / "non-existent-mount")
+    sink = FindingSink(cfg)
+    # Block creation by pre-creating a file where the parent dir would go
+    blocker = tmp_path / "blocked"
+    blocker.write_text("dummy")
+    cfg2 = FindingSinkConfig(session_dir=blocker / "x", session_id="sess")
+    sink2 = FindingSink(cfg2)
+    with caplog.at_level("WARNING"):
+        written = await sink2.append_many([_finding()])
+    assert written == 1
+    assert any("findings sink" in rec.getMessage() for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_sink_no_op_on_empty_iterable(tmp_path: Path):
+    sink = FindingSink(FindingSinkConfig(session_dir=tmp_path, session_id="sess"))
+    assert await sink.append_many([]) == 0
+    assert not sink.file_path.exists()

--- a/robustness-agent/tests/test_inference_optimizer_integration.py
+++ b/robustness-agent/tests/test_inference_optimizer_integration.py
@@ -1,0 +1,206 @@
+"""End-to-end integration with inference_optimizer.
+
+Round-trip: build a Coordinator-style prompt, drive it through
+:class:`RobustnessAgentBackend.run`, and validate every emitted intent
+against the upstream :class:`PolicyGate`. The test is skipped when the
+inference_optimizer package is not on ``sys.path``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _try_import_upstream():
+    candidate_roots = [
+        Path.home() / "lss" / "Hyperloom",
+        Path.home() / "Hyperloom-rs-build" / "Hyperloom",
+    ]
+    for root in candidate_roots:
+        if (root / "inference_optimizer" / "orchestrator").is_dir():
+            sys.path.insert(0, str(root))
+            break
+    try:
+        from inference_optimizer.orchestrator.agent_role import default_role_registry
+        from inference_optimizer.orchestrator.intent_parser import (
+            Intent as UpstreamIntent,
+            IntentType as UpstreamIntentType,
+        )
+        from inference_optimizer.orchestrator.policy import PolicyDenied, PolicyGate
+    except ImportError:
+        return None
+    return {
+        "default_role_registry": default_role_registry,
+        "UpstreamIntent": UpstreamIntent,
+        "UpstreamIntentType": UpstreamIntentType,
+        "PolicyDenied": PolicyDenied,
+        "PolicyGate": PolicyGate,
+    }
+
+
+_UPSTREAM = _try_import_upstream()
+pytestmark = pytest.mark.skipif(
+    _UPSTREAM is None,
+    reason="inference_optimizer not importable; integration check skipped",
+)
+
+
+def _gate():
+    PolicyGate = _UPSTREAM["PolicyGate"]  # type: ignore[index]
+    default_role_registry = _UPSTREAM["default_role_registry"]  # type: ignore[index]
+    return PolicyGate(role_registry=default_role_registry())
+
+
+def _to_upstream(local_intent):
+    UpstreamIntent = _UPSTREAM["UpstreamIntent"]  # type: ignore[index]
+    UpstreamIntentType = _UPSTREAM["UpstreamIntentType"]  # type: ignore[index]
+    return UpstreamIntent(
+        type=UpstreamIntentType(local_intent.type.value),
+        payload=dict(local_intent.payload),
+    )
+
+
+@pytest.mark.asyncio
+async def test_backend_intents_pass_upstream_policy_gate(tmp_path):
+    from robustness_agent.config import Config
+    from robustness_agent.factory import build_backend
+
+    config = Config(session_dir=tmp_path, robustness_server_url="")
+    backend, bundle = build_backend(config)
+    try:
+        result = await backend.run(
+            "=== Shared session state ===\n"
+            "session_id=sess-1\n"
+            "model=qwen3-8b  class=qwen3\n"
+            "baseline_tput=10  baseline_acc=0.8\n"
+            "crash_count=2\n"
+            "current_action=baseline\n"
+            "=== Inbox for robustness (newest last) ===\n"
+            "  seq=1 msg_id=abc from=orchestration topic=observation payload={'kind': 'policy_denied', 'rule': 'role'}\n"
+        )
+    finally:
+        await bundle.aclose()
+
+    gate = _gate()
+    assert result.intents, "expected at least one intent"
+    for intent in result.intents:
+        upstream = _to_upstream(intent)
+        gate.validate_intent("robustness", upstream)
+
+
+@pytest.mark.asyncio
+async def test_backend_high_severity_path_passes_gate(tmp_path):
+    from robustness_agent.config import Config
+    from robustness_agent.factory import build_backend
+
+    config = Config(session_dir=tmp_path, robustness_server_url="")
+    backend, bundle = build_backend(config)
+    try:
+        result = await backend.run(
+            "=== Shared session state ===\n"
+            "session_id=sess-1\n"
+            "crash_count=10\n"
+            "=== Inbox for robustness ===\n"
+            "(no new messages)\n"
+        )
+    finally:
+        await bundle.aclose()
+
+    gate = _gate()
+    assert result.intents
+    types_emitted = {i.type.value for i in result.intents}
+    assert "alert" in types_emitted
+    assert "escalate_strategy_change" in types_emitted
+    for intent in result.intents:
+        upstream = _to_upstream(intent)
+        gate.validate_intent("robustness", upstream)
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_passes_gate(tmp_path):
+    from robustness_agent.config import Config
+    from robustness_agent.factory import build_backend
+
+    config = Config(session_dir=tmp_path, robustness_server_url="")
+    backend, bundle = build_backend(config)
+    try:
+        result = await backend.run(
+            "=== Shared session state ===\n"
+            "session_id=sess-1\n"
+            "crash_count=0\n"
+            "=== Inbox for robustness ===\n"
+            "(no new messages)\n"
+        )
+    finally:
+        await bundle.aclose()
+
+    gate = _gate()
+    assert len(result.intents) == 1
+    intent = result.intents[0]
+    assert intent.payload["topic"] == "heartbeat"
+    gate.validate_intent("robustness", _to_upstream(intent))
+
+
+@pytest.mark.asyncio
+async def test_repeated_failure_emits_prune_branch_passing_gate(tmp_path):
+    from robustness_agent.config import Config
+    from robustness_agent.factory import build_backend
+
+    config = Config(session_dir=tmp_path, robustness_server_url="")
+    backend, bundle = build_backend(config)
+    try:
+        # Inbox doesn't natively carry delegated_result, so we reach into
+        # the local probe via direct injection: feed a fake conductor.db
+        # entry matching delegated_result with state=failed twice on the
+        # same family.
+        import json
+        import sqlite3
+
+        storage = tmp_path / "storage"
+        storage.mkdir()
+        db = storage / "conductor.db"
+        conn = sqlite3.connect(db)
+        conn.execute(
+            "CREATE TABLE events (seq INTEGER PRIMARY KEY AUTOINCREMENT, msg_id TEXT,"
+            " from_agent TEXT, to_agent TEXT, topic TEXT, payload TEXT, ts TEXT)"
+        )
+        for tid in ("t1", "t2"):
+            conn.execute(
+                "INSERT INTO events (msg_id, from_agent, to_agent, topic, payload, ts)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    tid,
+                    "coordinator",
+                    "robustness",
+                    "delegated_result",
+                    json.dumps(
+                        {
+                            "state": "failed",
+                            "kind": "kernel_opt",
+                            "task_id": tid,
+                        }
+                    ),
+                    "",
+                ),
+            )
+        conn.commit()
+        conn.close()
+
+        result = await backend.run(
+            "=== Shared session state ===\n"
+            "session_id=sess-1\n"
+            "crash_count=0\n"
+            "=== Inbox for robustness ===\n"
+            "(no new messages)\n"
+        )
+    finally:
+        await bundle.aclose()
+
+    types_emitted = {i.type.value for i in result.intents}
+    assert "alert" in types_emitted
+    gate = _gate()
+    for intent in result.intents:
+        gate.validate_intent("robustness", _to_upstream(intent))

--- a/robustness-agent/tests/test_reactor.py
+++ b/robustness-agent/tests/test_reactor.py
@@ -1,0 +1,188 @@
+"""End-to-end reactor + backend adapter tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from robustness_agent.decision.action_ladder import ActionLadder, ActionLadderConfig
+from robustness_agent.decision.policy_aware import PolicyAware
+from robustness_agent.findings.sink import FindingSink, FindingSinkConfig
+from robustness_agent.role.envelope import IntentType
+from robustness_agent.role.prompt_inputs import (
+    ReactorContext,
+    SharedStateSnapshot,
+)
+from robustness_agent.role.reactor import Reactor, ReactorComponents
+from robustness_agent.role.backend_adapter import RobustnessAgentBackend
+from robustness_agent.signals import Classifier
+from robustness_agent.signals.crash import CrashConfig
+from robustness_agent.sources.base import (
+    DegradeRouter,
+    SourceData,
+    SourceUnavailable,
+)
+
+
+class _FakeSource:
+    def __init__(self, name: str, snapshot: SourceData | Exception):
+        self.name = name
+        self._snapshot = snapshot
+        self.calls = 0
+
+    async def fetch(self, ctx) -> SourceData:
+        self.calls += 1
+        if isinstance(self._snapshot, BaseException):
+            raise self._snapshot
+        return self._snapshot
+
+
+def _build_reactor(
+    *,
+    primary: _FakeSource,
+    fallback: _FakeSource | None = None,
+    tmp_path: Path,
+    classifier: Classifier | None = None,
+    cooldown_ticks: int = 0,
+) -> tuple[Reactor, FindingSink]:
+    fb = fallback or _FakeSource(
+        "fb", SourceData(coordinator_events=[], sources_used=["fb"])
+    )
+    router = DegradeRouter(primary, fb, fail_threshold=2, recheck_interval_s=0.0)
+    sink = FindingSink(FindingSinkConfig(session_dir=tmp_path, session_id="sess-1"))
+    components = ReactorComponents(
+        router=router,
+        classifier=classifier or Classifier(crash_config=CrashConfig(medium_threshold=2)),
+        ladder=ActionLadder(config=ActionLadderConfig(cooldown_ticks=cooldown_ticks)),
+        policy=PolicyAware(),
+        sink=sink,
+    )
+    return Reactor(components), sink
+
+
+def _ctx(crash_count: int = 0, *, session_id: str = "sess-1", now_unix: float = 1.0) -> ReactorContext:
+    return ReactorContext(
+        tick_index=0,
+        shared_state=SharedStateSnapshot(session_id=session_id, crash_count=crash_count),
+        inbox=[],
+        now_unix=now_unix,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_reactor_emits_heartbeat_when_no_symptoms(tmp_path: Path):
+    primary = _FakeSource("server", SourceData(sources_used=["server"]))
+    reactor, sink = _build_reactor(primary=primary, tmp_path=tmp_path)
+    intents = await reactor.tick(_ctx())
+    assert len(intents) == 1
+    assert intents[0].type is IntentType.SEND_MESSAGE
+    assert intents[0].payload["topic"] == "heartbeat"
+    assert reactor.tick_index == 1
+    assert not sink.file_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_reactor_emits_alert_for_crash_count_and_persists_finding(tmp_path: Path):
+    primary = _FakeSource("server", SourceData(sources_used=["server"]))
+    reactor, sink = _build_reactor(primary=primary, tmp_path=tmp_path)
+    intents = await reactor.tick(_ctx(crash_count=2))
+    assert any(i.type is IntentType.ALERT for i in intents)
+    assert sink.file_path.exists()
+    rows = sink.file_path.read_text().splitlines()
+    assert rows
+    row = json.loads(rows[0])
+    assert row["symptom_name"] == "crash_count_rising"
+    assert row["intents"][0]["intent_type"] == "alert"
+
+
+# ---------------------------------------------------------------------------
+# DegradeRouter integration
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_reactor_falls_back_to_secondary_when_primary_fails(tmp_path: Path):
+    primary = _FakeSource("server", SourceUnavailable("down"))
+    fallback = _FakeSource(
+        "local",
+        SourceData(
+            session_pods=[{"pod": {"namespace": "ns", "name": "p"}, "phase": "Failed"}],
+            sources_used=["local"],
+        ),
+    )
+    reactor, _ = _build_reactor(primary=primary, fallback=fallback, tmp_path=tmp_path)
+    # Two consecutive failures degrade primary; we only need one tick to see
+    # fallback used because fail_threshold=1 would degrade immediately. With
+    # threshold=2 the first tick still falls through to fallback after primary
+    # exception.
+    intents = await reactor.tick(_ctx())
+    assert any(i.type is IntentType.ALERT for i in intents)
+    assert any(i.payload.get("severity") == "high" for i in intents if i.type is IntentType.ALERT)
+
+
+# ---------------------------------------------------------------------------
+# Policy filtering
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_reactor_drops_invalid_intents_emitted_by_extra_evaluator(tmp_path: Path):
+    from robustness_agent.role.envelope import Intent, IntentType
+    from robustness_agent.signals import Symptom, SymptomSeverity
+
+    class CustomLadder(ActionLadder):
+        def _intents_for(self, sym):  # type: ignore[override]
+            base = super()._intents_for(sym)
+            base.append(Intent(type=IntentType.ALERT, payload={"summary": "no severity"}))
+            return base
+
+    primary = _FakeSource("server", SourceData(sources_used=["server"]))
+    fallback = _FakeSource("local", SourceData(sources_used=["local"]))
+    router = DegradeRouter(primary, fallback, fail_threshold=2, recheck_interval_s=0.0)
+    components = ReactorComponents(
+        router=router,
+        classifier=Classifier(crash_config=CrashConfig(medium_threshold=2)),
+        ladder=CustomLadder(),
+        policy=PolicyAware(),
+        sink=None,
+    )
+    reactor = Reactor(components)
+    intents = await reactor.tick(_ctx(crash_count=2))
+    # The bogus intent should be filtered, keeping only the canonical alert.
+    assert all(i.payload.get("severity") for i in intents if i.type is IntentType.ALERT)
+
+
+# ---------------------------------------------------------------------------
+# Backend adapter
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_backend_adapter_returns_turn_result(tmp_path: Path):
+    primary = _FakeSource("server", SourceData(sources_used=["server"]))
+    reactor, _ = _build_reactor(primary=primary, tmp_path=tmp_path)
+    backend = RobustnessAgentBackend(reactor=reactor)
+    prompt = (
+        "=== Shared session state ===\n"
+        "session_id=sess-1\n"
+        "crash_count=2\n"
+        "=== Inbox for robustness ===\n"
+        "(no new messages)\n"
+    )
+    result = await backend.run(prompt)
+    assert result.raw_text == "(robustness-agent)"
+    assert result.metadata["tick_index"] == 1
+    assert any(i.type is IntentType.ALERT for i in result.intents)
+
+
+@pytest.mark.asyncio
+async def test_backend_adapter_advances_tick_index_per_call(tmp_path: Path):
+    primary = _FakeSource("server", SourceData(sources_used=["server"]))
+    reactor, _ = _build_reactor(primary=primary, tmp_path=tmp_path)
+    backend = RobustnessAgentBackend(reactor=reactor)
+    for expected in (1, 2, 3):
+        result = await backend.run("=== Shared session state ===\nsession_id=s\ncrash_count=0\n=== Inbox for robustness ===\n(no new messages)\n")
+        assert result.metadata["tick_index"] == expected

--- a/robustness-agent/tests/test_role_contract.py
+++ b/robustness-agent/tests/test_role_contract.py
@@ -1,0 +1,89 @@
+"""Contract test: keep envelope tables aligned with inference_optimizer.
+
+Skipped when ``inference_optimizer`` is not importable (the agent
+package keeps it as a soft dependency). CI environments that run
+against the upstream repo should add the inference_optimizer path to
+``PYTHONPATH`` so the test executes.
+
+Locations probed automatically:
+
+* anything already on ``sys.path``
+* ``~/lss/Hyperloom`` (the standard local checkout used in dev)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _try_import_inference_optimizer():
+    candidate_roots = [
+        Path.home() / "lss" / "Hyperloom",
+        Path.home() / "Hyperloom-rs-build" / "Hyperloom",
+    ]
+    for root in candidate_roots:
+        if (root / "inference_optimizer" / "orchestrator").is_dir():
+            sys.path.insert(0, str(root))
+            break
+    try:
+        import inference_optimizer.orchestrator.intent_parser as upstream_ip
+        import inference_optimizer.orchestrator.policy as upstream_policy
+        import inference_optimizer.orchestrator.agent_role as upstream_role
+    except ImportError:
+        return None
+    return upstream_ip, upstream_policy, upstream_role
+
+
+_UPSTREAM = _try_import_inference_optimizer()
+pytestmark = pytest.mark.skipif(
+    _UPSTREAM is None,
+    reason="inference_optimizer not importable; contract check skipped",
+)
+
+
+def test_intent_type_values_match_upstream():
+    from robustness_agent.role.envelope import IntentType
+
+    upstream_ip, _, _ = _UPSTREAM  # type: ignore[misc]
+    assert {t.value for t in IntentType} == {
+        t.value for t in upstream_ip.IntentType
+    }
+
+
+def test_payload_required_matches_upstream():
+    from robustness_agent.role.envelope import IntentType, PAYLOAD_REQUIRED
+
+    upstream_ip, _, _ = _UPSTREAM  # type: ignore[misc]
+    upstream_table = upstream_ip._PAYLOAD_REQUIRED  # noqa: SLF001
+    for it in IntentType:
+        local = PAYLOAD_REQUIRED[it]
+        upstream = upstream_table[upstream_ip.IntentType(it.value)]
+        assert local == upstream, f"{it} drift: local={local} upstream={upstream}"
+
+
+def test_robustness_only_intents_match_upstream():
+    from robustness_agent.role.envelope import ROBUSTNESS_ONLY_INTENTS
+
+    _, upstream_policy, _ = _UPSTREAM  # type: ignore[misc]
+    upstream_set = {t.value for t in upstream_policy.ROBUSTNESS_ONLY_INTENTS}
+    upstream_set.add("kill_task")  # upstream lists kill_task separately as KILL_TASK_SOURCE_ALLOWLIST
+    local_set = {t.value for t in ROBUSTNESS_ONLY_INTENTS}
+    assert local_set == upstream_set
+
+
+def test_kill_task_scope_matches_upstream():
+    from robustness_agent.role.envelope import KILL_TASK_ALLOWED_SCOPES
+
+    _, upstream_policy, _ = _UPSTREAM  # type: ignore[misc]
+    assert KILL_TASK_ALLOWED_SCOPES == upstream_policy.KILL_TASK_ALLOWED_SCOPES
+
+
+def test_core_state_fields_match_upstream():
+    from robustness_agent.role.envelope import CORE_STATE_FIELDS
+
+    _, upstream_policy, _ = _UPSTREAM  # type: ignore[misc]
+    assert CORE_STATE_FIELDS == upstream_policy.CORE_STATE_FIELDS

--- a/robustness-agent/tests/test_role_envelope.py
+++ b/robustness-agent/tests/test_role_envelope.py
@@ -1,0 +1,268 @@
+"""Unit tests for :mod:`robustness_agent.role.envelope`.
+
+Covers:
+
+* every builder produces an :class:`Intent` whose ``to_envelope_item``
+  round-trips through ``build_envelope_dict``.
+* invalid arguments to builders raise ``ValueError`` (so a bad caller
+  blows up before reaching the Coordinator).
+* the static tables (``PAYLOAD_REQUIRED`` / role allowlist /
+  robustness-only set) keep the shape upstream PolicyGate expects.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from robustness_agent.role.envelope import (
+    ALERT_SEVERITIES,
+    BackendTurnResult,
+    Intent,
+    IntentType,
+    KILL_TASK_ALLOWED_SCOPES,
+    PAYLOAD_REQUIRED,
+    ROBUSTNESS_ALLOWED_INTENTS,
+    ROBUSTNESS_DELEGATE_ACTIONS,
+    ROBUSTNESS_ONLY_INTENTS,
+    ROBUSTNESS_STATE_FIELDS,
+    build_alert,
+    build_delegate,
+    build_envelope_dict,
+    build_escalate,
+    build_force_dispatch,
+    build_heartbeat,
+    build_kill_task,
+    build_prune_branch,
+    build_send_message,
+    build_update_state,
+)
+
+
+# ---------------------------------------------------------------------------
+# Builders — happy path
+# ---------------------------------------------------------------------------
+
+def test_heartbeat_builder_uses_known_topic_and_body():
+    intent = build_heartbeat()
+    assert intent.type is IntentType.SEND_MESSAGE
+    assert intent.payload["topic"] == "heartbeat"
+    assert intent.payload["body_md"]
+    assert intent.to_envelope_item() == {
+        "intent_type": "send_message",
+        "payload": {"topic": "heartbeat", "body_md": "ok (robustness-agent)"},
+    }
+
+
+def test_send_message_includes_optional_fields():
+    intent = build_send_message(
+        "observation",
+        body_md="hello",
+        to="orchestration",
+        extras={"k": "v"},
+    )
+    assert intent.payload == {
+        "topic": "observation",
+        "body_md": "hello",
+        "to": "orchestration",
+        "k": "v",
+    }
+
+
+def test_alert_builder_serialises_with_detail():
+    intent = build_alert(
+        "high",
+        "session pod failed",
+        detail={"pod": "brain-0", "phase": "Failed"},
+    )
+    assert intent.type is IntentType.ALERT
+    item = intent.to_envelope_item()
+    assert item["payload"]["severity"] == "high"
+    assert item["payload"]["summary"] == "session pod failed"
+    assert item["payload"]["detail"] == {"pod": "brain-0", "phase": "Failed"}
+
+
+def test_escalate_builder_carries_hint_and_severity():
+    intent = build_escalate(
+        "repeated_failure",
+        "switch to fp16 baseline",
+        severity="high",
+    )
+    assert intent.type is IntentType.ESCALATE_STRATEGY_CHANGE
+    payload = intent.payload
+    assert payload["reason"] == "repeated_failure"
+    assert payload["next_action_hint"] == "switch to fp16 baseline"
+    assert payload["severity"] == "high"
+
+
+def test_kill_task_builder_pins_scope_to_task():
+    intent = build_kill_task("task-123", "stuck for 10min")
+    assert intent.type is IntentType.KILL_TASK
+    assert intent.payload == {
+        "task_id": "task-123",
+        "reason": "stuck for 10min",
+        "scope": "task",
+    }
+
+
+def test_force_dispatch_builder():
+    intent = build_force_dispatch("task-456", "high-value blocked")
+    assert intent.type is IntentType.FORCE_DISPATCH
+    assert intent.payload == {"task_id": "task-456", "reason": "high-value blocked"}
+
+
+def test_prune_branch_builder():
+    intent = build_prune_branch("backends.sglang", "3 consecutive failures")
+    assert intent.type is IntentType.PRUNE_BRANCH
+    assert intent.payload == {"family": "backends.sglang", "reason": "3 consecutive failures"}
+
+
+def test_delegate_builder_passes_params_and_idempotency():
+    intent = build_delegate(
+        "recover",
+        params={"checkpoint": "latest"},
+        idempotency_key="recover-1",
+    )
+    assert intent.type is IntentType.DELEGATE
+    assert intent.payload == {
+        "action_name": "recover",
+        "params": {"checkpoint": "latest"},
+        "idempotency_key": "recover-1",
+    }
+
+
+def test_update_state_builder_only_allows_robustness_fields():
+    intent = build_update_state({"crash_count": 3, "current_action": "recover"})
+    assert intent.type is IntentType.UPDATE_STATE
+    assert intent.payload["changes"] == {"crash_count": 3, "current_action": "recover"}
+
+
+# ---------------------------------------------------------------------------
+# Builders — defensive errors
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "severity",
+    ["", "warn", "critical", "INFO", None],
+)
+def test_alert_rejects_unknown_severity(severity):
+    with pytest.raises(ValueError):
+        build_alert(severity, "x")  # type: ignore[arg-type]
+
+
+def test_alert_rejects_empty_summary():
+    with pytest.raises(ValueError):
+        build_alert("medium", "")
+
+
+def test_escalate_requires_reason_and_hint():
+    with pytest.raises(ValueError):
+        build_escalate("", "hint")
+    with pytest.raises(ValueError):
+        build_escalate("reason", "")
+
+
+@pytest.mark.parametrize(
+    "task_id,reason",
+    [("", "r"), ("t", ""), ("", "")],
+)
+def test_kill_task_requires_both_fields(task_id, reason):
+    with pytest.raises(ValueError):
+        build_kill_task(task_id, reason)
+
+
+def test_delegate_rejects_kernel_owned_action():
+    for kernel_owned in ("kernel_opt", "integrate", "deep_kernel_analysis"):
+        with pytest.raises(ValueError):
+            build_delegate(kernel_owned)
+
+
+def test_delegate_accepts_only_handle_actions():
+    for action in ROBUSTNESS_DELEGATE_ACTIONS:
+        intent = build_delegate(action)
+        assert intent.payload["action_name"] == action
+
+
+def test_update_state_rejects_core_fields():
+    with pytest.raises(ValueError):
+        build_update_state({"current_best": {"tput": 1.0}})
+
+
+def test_update_state_rejects_unknown_fields():
+    with pytest.raises(ValueError):
+        build_update_state({"random_field": 1})
+
+
+def test_update_state_rejects_empty_changes():
+    with pytest.raises(ValueError):
+        build_update_state({})
+
+
+# ---------------------------------------------------------------------------
+# Envelope serialisation
+# ---------------------------------------------------------------------------
+
+def test_envelope_dict_is_json_serialisable():
+    intents = [
+        build_heartbeat(),
+        build_alert("medium", "stall detected"),
+        build_escalate("crash_count_high", "trigger recover"),
+    ]
+    env = build_envelope_dict(intents)
+    payload = json.dumps(env)
+    restored = json.loads(payload)
+    assert restored == env
+    assert [item["intent_type"] for item in restored["intents"]] == [
+        "send_message",
+        "alert",
+        "escalate_strategy_change",
+    ]
+
+
+def test_intent_to_envelope_item_makes_a_copy_of_payload():
+    intent = build_alert("low", "noise", detail={"k": 1})
+    item = intent.to_envelope_item()
+    item["payload"]["k"] = 2
+    assert intent.payload["detail"]["k"] == 1
+
+
+def test_backend_turn_result_default_fields():
+    res = BackendTurnResult()
+    assert res.intents == []
+    assert res.raw_text == ""
+    assert res.metadata == {}
+
+
+# ---------------------------------------------------------------------------
+# Static tables — invariants
+# ---------------------------------------------------------------------------
+
+def test_payload_required_covers_every_intent_type():
+    for intent_type in IntentType:
+        assert intent_type in PAYLOAD_REQUIRED, intent_type
+
+
+def test_robustness_only_subset_of_allowed():
+    assert ROBUSTNESS_ONLY_INTENTS.issubset(ROBUSTNESS_ALLOWED_INTENTS)
+
+
+def test_robustness_only_set_matches_design_v06():
+    assert ROBUSTNESS_ONLY_INTENTS == frozenset({
+        IntentType.KILL_TASK,
+        IntentType.FORCE_DISPATCH,
+        IntentType.PRUNE_BRANCH,
+        IntentType.ESCALATE_STRATEGY_CHANGE,
+    })
+
+
+def test_kill_task_scope_locked_to_task():
+    assert KILL_TASK_ALLOWED_SCOPES == frozenset({"task"})
+
+
+def test_alert_severities_are_low_medium_high():
+    assert ALERT_SEVERITIES == frozenset({"low", "medium", "high"})
+
+
+def test_robustness_state_fields_are_minimal():
+    assert ROBUSTNESS_STATE_FIELDS == frozenset({"crash_count", "current_action"})

--- a/robustness-agent/tests/test_role_prompt_inputs.py
+++ b/robustness-agent/tests/test_role_prompt_inputs.py
@@ -1,0 +1,173 @@
+"""Unit tests for prompt -> ReactorContext parser."""
+
+from __future__ import annotations
+
+import textwrap
+
+from robustness_agent.role.prompt_inputs import (
+    ReactorContext,
+    from_coordinator_prompt,
+)
+
+
+def _prompt(shared: str, inbox: str) -> str:
+    parts = ["=== Shared session state ===", shared.rstrip(), inbox.rstrip()]
+    return "\n".join(p for p in parts if p)
+
+
+# ---------------------------------------------------------------------------
+# Empty / no-messages cases
+# ---------------------------------------------------------------------------
+
+def test_empty_prompt_returns_empty_context():
+    ctx = from_coordinator_prompt("")
+    assert isinstance(ctx, ReactorContext)
+    assert ctx.shared_state.session_id == ""
+    assert ctx.inbox == []
+    assert ctx.parse_warnings == ["empty prompt"]
+
+
+def test_no_new_messages_yields_empty_inbox():
+    prompt = _prompt(
+        textwrap.dedent(
+            """\
+            session_id=sess-1
+            model=qwen3-8b  class=qwen3
+            baseline_tput=10.5  baseline_acc=0.8
+            cumulative_gain=12.5%
+            crash_count=0
+            current_action=(idle)
+            """
+        ),
+        textwrap.dedent(
+            """\
+            === Inbox for robustness ===
+            (no new messages)
+            """
+        ),
+    )
+    ctx = from_coordinator_prompt(prompt, tick_index=3, now_unix=100.0)
+    assert ctx.tick_index == 3
+    assert ctx.now_unix == 100.0
+    assert ctx.shared_state.session_id == "sess-1"
+    assert ctx.shared_state.model_name == "qwen3-8b"
+    assert ctx.shared_state.model_class == "qwen3"
+    assert ctx.shared_state.baseline_tput == 10.5
+    assert ctx.shared_state.cumulative_gain == 12.5
+    assert ctx.shared_state.crash_count == 0
+    assert ctx.shared_state.current_action == ""
+    assert ctx.inbox == []
+    assert ctx.parse_warnings == []
+
+
+def test_inbox_parses_multiple_messages_with_python_repr_payload():
+    prompt = _prompt(
+        textwrap.dedent(
+            """\
+            session_id=sess-2
+            model=(unset)  class=(unset)
+            baseline_tput=0  baseline_acc=0
+            crash_count=2
+            current_action=baseline
+            """
+        ),
+        textwrap.dedent(
+            """\
+            === Inbox for robustness (newest last) ===
+              seq=1 msg_id=abc123 from=orchestration topic=proposal payload={'action_name': 'baseline', 'predicted_gain_pct': 0.0}
+              seq=2 msg_id=def456 from=critic topic=review_verdict payload={'verdict': 'approve', 'target_proposal_msg_id': 'abc123'}
+              seq=3 msg_id=ghi789 from=coordinator topic=event payload={'kind': 'task_queued', 'task_id': 't-1', 'action': 'baseline'}
+            """
+        ),
+    )
+    ctx = from_coordinator_prompt(prompt)
+    assert ctx.shared_state.session_id == "sess-2"
+    assert ctx.shared_state.model_name == ""
+    assert ctx.shared_state.crash_count == 2
+    assert ctx.shared_state.current_action == "baseline"
+    assert len(ctx.inbox) == 3
+    first, second, third = ctx.inbox
+    assert first.seq == 1 and first.msg_id == "abc123"
+    assert first.from_agent == "orchestration" and first.topic == "proposal"
+    assert first.payload == {"action_name": "baseline", "predicted_gain_pct": 0.0}
+    assert second.payload["verdict"] == "approve"
+    assert third.payload["task_id"] == "t-1"
+    assert ctx.parse_warnings == []
+
+
+def test_unparsable_inbox_line_is_warned_not_raised():
+    prompt = _prompt(
+        "session_id=sess-3\ncrash_count=0\n",
+        textwrap.dedent(
+            """\
+            === Inbox for robustness (newest last) ===
+              seq=1 msg_id=ok from=x topic=y payload={'a': 1}
+              this line is broken
+              seq=2 msg_id=ok2 from=y topic=z payload={'b': 2}
+            """
+        ),
+    )
+    ctx = from_coordinator_prompt(prompt)
+    assert len(ctx.inbox) == 2
+    assert ctx.inbox[0].seq == 1
+    assert ctx.inbox[1].seq == 2
+    assert any("unparsable" in w for w in ctx.parse_warnings)
+
+
+def test_payload_with_non_dict_repr_is_preserved_as_raw():
+    prompt = _prompt(
+        "session_id=sess-4\n",
+        textwrap.dedent(
+            """\
+            === Inbox for robustness ===
+              seq=10 msg_id=m1 from=x topic=y payload=this is not a dict
+            """
+        ),
+    )
+    ctx = from_coordinator_prompt(prompt)
+    assert len(ctx.inbox) == 1
+    item = ctx.inbox[0]
+    assert item.payload["raw"] == "this is not a dict"
+    assert any("not a python literal" in w for w in ctx.parse_warnings)
+
+
+def test_kb_section_is_ignored_for_robustness_role():
+    prompt = (
+        "=== Shared session state ===\n"
+        "session_id=sess-kb\n"
+        "crash_count=0\n"
+        "=== Knowledge base hints ===\n"
+        "kb-hint-do-not-parse\n"
+        "=== Inbox for robustness ===\n"
+        "(no new messages)\n"
+    )
+    ctx = from_coordinator_prompt(prompt)
+    assert ctx.shared_state.session_id == "sess-kb"
+    assert ctx.inbox == []
+
+
+def test_baseline_tput_is_coerced_to_float_safely_on_garbage():
+    prompt = _prompt(
+        "session_id=sess-bad\nbaseline_tput=??\ncrash_count=NaNa\n",
+        "=== Inbox for robustness ===\n(no new messages)\n",
+    )
+    ctx = from_coordinator_prompt(prompt)
+    assert ctx.shared_state.baseline_tput == 0.0
+    assert ctx.shared_state.crash_count == 0
+
+
+def test_payload_with_topic_substring_does_not_break_topic_field():
+    prompt = _prompt(
+        "session_id=s\ncrash_count=0\n",
+        textwrap.dedent(
+            """\
+            === Inbox for robustness ===
+              seq=7 msg_id=m1 from=x topic=alert payload={'summary': 'oops topic=alert again', 'severity': 'high'}
+            """
+        ),
+    )
+    ctx = from_coordinator_prompt(prompt)
+    assert len(ctx.inbox) == 1
+    item = ctx.inbox[0]
+    assert item.topic == "alert"
+    assert item.payload["summary"] == "oops topic=alert again"

--- a/robustness-agent/tests/test_signals.py
+++ b/robustness-agent/tests/test_signals.py
@@ -1,0 +1,345 @@
+"""Unit tests for signal rules + classifier."""
+
+from __future__ import annotations
+
+import pytest
+
+from robustness_agent.role.prompt_inputs import (
+    InboxItem,
+    ReactorContext,
+    SharedStateSnapshot,
+)
+from robustness_agent.signals import (
+    Classifier,
+    Symptom,
+    SymptomSeverity,
+    evaluate_crash_signals,
+    evaluate_event_signals,
+    evaluate_health_signals,
+    evaluate_stall_signals,
+)
+from robustness_agent.signals.crash import CrashConfig
+from robustness_agent.signals.event import EventConfig
+from robustness_agent.signals.health import HealthConfig
+from robustness_agent.signals.stall import StallConfig
+from robustness_agent.sources.base import SourceData
+
+
+def _ctx(
+    *,
+    crash_count: int = 0,
+    current_action: str = "",
+    inbox: list[InboxItem] | None = None,
+    now_unix: float = 1_700_000_000.0,
+) -> ReactorContext:
+    return ReactorContext(
+        tick_index=1,
+        shared_state=SharedStateSnapshot(
+            session_id="sess-1",
+            crash_count=crash_count,
+            current_action=current_action,
+        ),
+        inbox=list(inbox or []),
+        now_unix=now_unix,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stall
+# ---------------------------------------------------------------------------
+
+def test_stall_emits_medium_when_agent_silent_past_threshold():
+    now = 1_000.0
+    ctx = _ctx(now_unix=now)
+    data = SourceData(
+        coordinator_events=[
+            {"agent": "kernel", "topic": "heartbeat", "ts": now - 600.0},
+            {"agent": "orchestration", "topic": "heartbeat", "ts": now - 100.0},
+        ],
+    )
+    out = evaluate_stall_signals(ctx, data, config=StallConfig(stall_timeout_s=300.0, severity_high_after_s=900.0))
+    assert len(out) == 1
+    assert out[0].name == "agent_stall"
+    assert out[0].severity is SymptomSeverity.MEDIUM
+    assert out[0].evidence["agent"] == "kernel"
+
+
+def test_stall_escalates_to_high_after_long_silence():
+    now = 1_000.0
+    ctx = _ctx(now_unix=now)
+    data = SourceData(
+        coordinator_events=[{"agent": "kernel", "ts": now - 1500.0}],
+    )
+    out = evaluate_stall_signals(ctx, data, config=StallConfig(stall_timeout_s=300.0, severity_high_after_s=900.0))
+    assert out and out[0].severity is SymptomSeverity.HIGH
+
+
+def test_stall_silent_when_no_data_present():
+    ctx = _ctx()
+    data = SourceData()
+    assert evaluate_stall_signals(ctx, data) == []
+
+
+def test_stall_uses_iso_timestamps_too():
+    now = 1_700_000_500.0
+    ctx = _ctx(now_unix=now)
+    data = SourceData(
+        coordinator_events=[
+            {"agent": "kernel", "ts": "2023-11-14T22:13:20+00:00"},  # ~1700000000
+        ],
+    )
+    out = evaluate_stall_signals(ctx, data, config=StallConfig(stall_timeout_s=300.0))
+    assert out and out[0].evidence["agent"] == "kernel"
+
+
+# ---------------------------------------------------------------------------
+# Crash
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "crash_count,expected_name,expected_severity",
+    [
+        (0, None, None),
+        (1, None, None),
+        (2, "crash_count_rising", SymptomSeverity.MEDIUM),
+        (5, "crash_count_high", SymptomSeverity.HIGH),
+        (10, "crash_count_emergency", SymptomSeverity.HIGH),
+    ],
+)
+def test_crash_signal_thresholds(crash_count, expected_name, expected_severity):
+    ctx = _ctx(crash_count=crash_count, current_action="recover")
+    out = evaluate_crash_signals(ctx, SourceData(), config=CrashConfig())
+    if expected_name is None:
+        assert out == []
+    else:
+        assert len(out) == 1
+        assert out[0].name == expected_name
+        assert out[0].severity is expected_severity
+
+
+# ---------------------------------------------------------------------------
+# Event
+# ---------------------------------------------------------------------------
+
+def test_repeated_policy_denied_emits_medium_alert():
+    inbox = [
+        InboxItem(
+            seq=i,
+            msg_id=f"m{i}",
+            from_agent="orchestration",
+            topic="observation",
+            payload={"kind": "policy_denied", "rule": "kernel_owned_by_kernel_agent"},
+        )
+        for i in range(3)
+    ]
+    ctx = _ctx(inbox=inbox)
+    out = evaluate_event_signals(ctx, SourceData(), config=EventConfig(policy_denied_threshold=3))
+    assert any(s.name == "repeated_policy_denied" for s in out)
+    sym = next(s for s in out if s.name == "repeated_policy_denied")
+    assert sym.evidence["count"] == 3
+    assert sym.evidence["top_rule"] == "kernel_owned_by_kernel_agent"
+
+
+def test_policy_denied_below_threshold_is_silent():
+    inbox = [
+        InboxItem(
+            seq=i,
+            msg_id=f"m{i}",
+            from_agent="orchestration",
+            topic="observation",
+            payload={"kind": "policy_denied"},
+        )
+        for i in range(2)
+    ]
+    ctx = _ctx(inbox=inbox)
+    out = evaluate_event_signals(ctx, SourceData(), config=EventConfig(policy_denied_threshold=3))
+    assert all(s.name != "repeated_policy_denied" for s in out)
+
+
+def test_repeated_failure_groups_by_family():
+    coord_events = [
+        {
+            "topic": "delegated_result",
+            "agent": "coordinator",
+            "payload": {"state": "failed", "kind": "kernel_opt", "task_id": "t1"},
+        },
+        {
+            "topic": "delegated_result",
+            "agent": "coordinator",
+            "payload": {"state": "failed", "kind": "kernel_opt", "task_id": "t2"},
+        },
+        {
+            "topic": "delegated_result",
+            "agent": "coordinator",
+            "payload": {"state": "succeeded", "kind": "kernel_opt", "task_id": "t3"},
+        },
+    ]
+    data = SourceData(coordinator_events=coord_events)
+    out = evaluate_event_signals(_ctx(), data, config=EventConfig(delegated_failure_threshold=2))
+    assert any(s.name == "repeated_failure" for s in out)
+    sym = next(s for s in out if s.name == "repeated_failure")
+    assert sym.evidence["family"] == "kernel_opt"
+    assert sym.evidence["count"] == 2
+
+
+def test_event_handles_combined_inbox_and_coordinator_events():
+    inbox = [
+        InboxItem(
+            seq=1,
+            msg_id="m1",
+            from_agent="orchestration",
+            topic="observation",
+            payload={"kind": "policy_denied", "rule": "role"},
+        ),
+    ]
+    coord_events = [
+        {
+            "topic": "observation",
+            "agent": "orchestration",
+            "payload": {"kind": "policy_denied", "rule": "role"},
+        },
+        {
+            "topic": "observation",
+            "agent": "orchestration",
+            "payload": {"kind": "policy_denied", "rule": "payload"},
+        },
+    ]
+    data = SourceData(coordinator_events=coord_events)
+    ctx = _ctx(inbox=inbox)
+    out = evaluate_event_signals(ctx, data, config=EventConfig(policy_denied_threshold=3))
+    assert any(s.name == "repeated_policy_denied" for s in out)
+
+
+# ---------------------------------------------------------------------------
+# Health
+# ---------------------------------------------------------------------------
+
+def test_health_flags_failed_pod_as_high_severity():
+    data = SourceData(
+        session_pods=[
+            {
+                "pod": {"namespace": "ns", "name": "brain-0"},
+                "role": "brain",
+                "phase": "Failed",
+                "assignment_id": "a1",
+            },
+        ],
+    )
+    out = evaluate_health_signals(_ctx(), data)
+    assert out and out[0].severity is SymptomSeverity.HIGH
+    assert out[0].name == "pod_not_running"
+
+
+def test_health_flags_unknown_phase_as_medium():
+    data = SourceData(
+        session_pods=[
+            {
+                "pod": {"namespace": "ns", "name": "hands-0"},
+                "role": "hands",
+                "phase": "CrashLoopBackOff",
+            },
+        ],
+    )
+    out = evaluate_health_signals(_ctx(), data)
+    assert out and out[0].severity is SymptomSeverity.MEDIUM
+
+
+def test_health_silent_when_pods_running():
+    data = SourceData(
+        session_pods=[{"pod": {"namespace": "ns", "name": "p"}, "phase": "Running"}],
+    )
+    assert evaluate_health_signals(_ctx(), data) == []
+
+
+def test_health_warns_no_metrics_after_threshold():
+    now = 10_000.0
+    data = SourceData(
+        session_summary={
+            "pods": [
+                {
+                    "pod": {"namespace": "ns", "name": "p1"},
+                    "role": "hands",
+                    "t_start": now - 1200.0,
+                    "available_metrics": [],
+                }
+            ]
+        }
+    )
+    out = evaluate_health_signals(_ctx(now_unix=now), data, config=HealthConfig(no_metrics_warn_s=600))
+    assert any(s.name == "pod_no_metrics" for s in out)
+
+
+def test_health_does_not_flag_recently_started_pods_with_no_metrics():
+    now = 10_000.0
+    data = SourceData(
+        session_summary={
+            "pods": [
+                {
+                    "pod": {"namespace": "ns", "name": "p2"},
+                    "role": "hands",
+                    "t_start": now - 60.0,
+                    "available_metrics": [],
+                }
+            ]
+        }
+    )
+    assert evaluate_health_signals(_ctx(now_unix=now), data, config=HealthConfig(no_metrics_warn_s=600)) == []
+
+
+# ---------------------------------------------------------------------------
+# Classifier
+# ---------------------------------------------------------------------------
+
+def test_classifier_dedupes_same_subject_keeps_higher_severity():
+    classifier = Classifier()
+
+    def custom_a(ctx, data):
+        return [Symptom(name="x", severity=SymptomSeverity.MEDIUM, summary="m", subject={"a": "1"})]
+
+    def custom_b(ctx, data):
+        return [Symptom(name="x", severity=SymptomSeverity.HIGH, summary="h", subject={"a": "1"})]
+
+    classifier.extra_evaluators = [custom_a, custom_b]
+    out = classifier.classify(SourceData(), _ctx())
+    assert len(out) == 1
+    assert out[0].severity is SymptomSeverity.HIGH
+
+
+def test_classifier_orders_by_severity_descending():
+    classifier = Classifier()
+
+    def fn(ctx, data):
+        return [
+            Symptom(name="lo", severity=SymptomSeverity.LOW, summary="lo", subject={"k": "1"}),
+            Symptom(name="hi", severity=SymptomSeverity.HIGH, summary="hi", subject={"k": "2"}),
+            Symptom(name="md", severity=SymptomSeverity.MEDIUM, summary="md", subject={"k": "3"}),
+        ]
+
+    classifier.extra_evaluators = [fn]
+    out = classifier.classify(SourceData(), _ctx())
+    severities = [s.severity for s in out]
+    assert severities == [SymptomSeverity.HIGH, SymptomSeverity.MEDIUM, SymptomSeverity.LOW]
+
+
+def test_classifier_runs_all_default_rules():
+    inbox = [
+        InboxItem(
+            seq=i,
+            msg_id=f"m{i}",
+            from_agent="orchestration",
+            topic="observation",
+            payload={"kind": "policy_denied", "rule": "role"},
+        )
+        for i in range(3)
+    ]
+    ctx = _ctx(crash_count=2, inbox=inbox)
+    data = SourceData(
+        session_pods=[{"pod": {"namespace": "ns", "name": "p"}, "phase": "Failed"}],
+        coordinator_events=[],
+    )
+    classifier = Classifier(crash_config=CrashConfig(medium_threshold=2))
+    out = classifier.classify(data, ctx)
+    names = {s.name for s in out}
+    assert "crash_count_rising" in names
+    assert "repeated_policy_denied" in names
+    assert "pod_not_running" in names

--- a/robustness-agent/tests/test_signals_local_health.py
+++ b/robustness-agent/tests/test_signals_local_health.py
@@ -1,0 +1,153 @@
+"""Unit tests for the local-health signal rule."""
+
+from __future__ import annotations
+
+import pytest
+
+from robustness_agent.role.prompt_inputs import (
+    ReactorContext,
+    SharedStateSnapshot,
+)
+from robustness_agent.signals import (
+    Symptom,
+    SymptomSeverity,
+    evaluate_local_health_signals,
+)
+from robustness_agent.signals.local_health import LocalHealthConfig
+from robustness_agent.sources.base import SourceData
+
+
+def _ctx() -> ReactorContext:
+    return ReactorContext(
+        tick_index=0,
+        shared_state=SharedStateSnapshot(session_id="sess-1"),
+        inbox=[],
+        now_unix=1.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Server unreachable
+# ---------------------------------------------------------------------------
+
+def test_one_target_down_emits_medium_alert():
+    data = SourceData(
+        local_server_health=[
+            {"url": "http://localhost:30000", "reachable": True, "status": "ok"},
+            {"url": "http://localhost:30001", "reachable": False, "status": "error", "error": "connect"},
+        ]
+    )
+    out = evaluate_local_health_signals(_ctx(), data)
+    matched = [s for s in out if s.name == "local_server_unreachable"]
+    assert len(matched) == 1
+    assert matched[0].severity is SymptomSeverity.MEDIUM
+    assert matched[0].evidence["url"] == "http://localhost:30001"
+
+
+def test_all_targets_down_promotes_severity_to_high():
+    data = SourceData(
+        local_server_health=[
+            {"url": "http://localhost:30000", "reachable": False, "status": "error"},
+            {"url": "http://localhost:30001", "reachable": False, "status": "http_error"},
+        ]
+    )
+    out = evaluate_local_health_signals(_ctx(), data)
+    matched = [s for s in out if s.name == "local_server_unreachable"]
+    assert len(matched) == 2
+    assert all(s.severity is SymptomSeverity.HIGH for s in matched)
+
+
+def test_no_unreachable_targets_is_silent():
+    data = SourceData(
+        local_server_health=[
+            {"url": "http://localhost:30000", "reachable": True, "status": "ok"},
+        ]
+    )
+    out = evaluate_local_health_signals(_ctx(), data)
+    assert all(s.name != "local_server_unreachable" for s in out)
+
+
+# ---------------------------------------------------------------------------
+# Log error patterns
+# ---------------------------------------------------------------------------
+
+def test_oom_pattern_is_high_severity():
+    data = SourceData(
+        local_log_errors=[
+            {"pattern": "CUDA out of memory", "line": "torch ... CUDA out of memory ..."}
+        ]
+    )
+    out = evaluate_local_health_signals(_ctx(), data)
+    matched = [s for s in out if s.name == "log_error_pattern"]
+    assert matched and matched[0].severity is SymptomSeverity.HIGH
+
+
+def test_runtimeerror_pattern_is_medium_severity():
+    data = SourceData(
+        local_log_errors=[
+            {"pattern": "RuntimeError", "line": "RuntimeError: ..."}
+        ]
+    )
+    out = evaluate_local_health_signals(_ctx(), data)
+    matched = [s for s in out if s.name == "log_error_pattern"]
+    assert matched and matched[0].severity is SymptomSeverity.MEDIUM
+
+
+def test_log_error_groups_samples_by_pattern():
+    data = SourceData(
+        local_log_errors=[
+            {"pattern": "RuntimeError", "line": f"err {i}"} for i in range(5)
+        ]
+    )
+    out = evaluate_local_health_signals(_ctx(), data)
+    matched = next(s for s in out if s.name == "log_error_pattern")
+    assert matched.evidence["count"] == 5
+    assert len(matched.evidence["samples"]) == 3  # capped at 3
+
+
+# ---------------------------------------------------------------------------
+# GPU thermal
+# ---------------------------------------------------------------------------
+
+def test_gpu_at_warn_threshold_is_medium():
+    data = SourceData(local_gpu={"gpus": [{"gpu_id": 0, "temperature_c": 92.0}]})
+    out = evaluate_local_health_signals(_ctx(), data, config=LocalHealthConfig(gpu_temp_warn_c=90, gpu_temp_crit_c=100))
+    matched = [s for s in out if s.name == "gpu_thermal_high"]
+    assert matched and matched[0].severity is SymptomSeverity.MEDIUM
+
+
+def test_gpu_at_crit_threshold_is_high():
+    data = SourceData(local_gpu={"gpus": [{"gpu_id": 1, "temperature_c": 105.0}]})
+    out = evaluate_local_health_signals(_ctx(), data, config=LocalHealthConfig(gpu_temp_warn_c=90, gpu_temp_crit_c=100))
+    matched = [s for s in out if s.name == "gpu_thermal_high"]
+    assert matched and matched[0].severity is SymptomSeverity.HIGH
+
+
+def test_cool_gpu_emits_no_thermal_signal():
+    data = SourceData(local_gpu={"gpus": [{"gpu_id": 0, "temperature_c": 60.0}]})
+    out = evaluate_local_health_signals(_ctx(), data)
+    assert all(s.name != "gpu_thermal_high" for s in out)
+
+
+def test_no_local_gpu_data_silent():
+    data = SourceData(local_gpu={})
+    out = evaluate_local_health_signals(_ctx(), data)
+    assert out == []
+
+
+# ---------------------------------------------------------------------------
+# Classifier integration
+# ---------------------------------------------------------------------------
+
+def test_classifier_includes_local_health_rule():
+    from robustness_agent.signals import Classifier
+
+    data = SourceData(
+        local_log_errors=[{"pattern": "CUDA out of memory", "line": "..."}],
+        local_server_health=[{"url": "u", "reachable": False, "status": "error"}],
+        local_gpu={"gpus": [{"gpu_id": 0, "temperature_c": 99.5}]},
+    )
+    classifier = Classifier()
+    out = classifier.classify(data, _ctx())
+    names = {s.name for s in out}
+    assert {"log_error_pattern", "local_server_unreachable", "gpu_thermal_high"} <= names

--- a/robustness-agent/tests/test_sources_base.py
+++ b/robustness-agent/tests/test_sources_base.py
@@ -1,0 +1,220 @@
+"""Unit tests for sources/base.py.
+
+Covers DegradeRouter state machine + SourceData merge semantics.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import pytest
+
+from robustness_agent.sources.base import (
+    DegradeRouter,
+    HealthState,
+    Source,
+    SourceData,
+    SourceUnavailable,
+)
+
+
+@dataclass
+class _FakeClock:
+    now: float = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class _ScriptedSource:
+    """Source double whose ``fetch`` plays out a queued list of outcomes.
+
+    Each entry is either a :class:`SourceData` (returned) or an
+    exception instance (raised). Out-of-script calls raise
+    ``IndexError`` so tests catch unintended invocations.
+    """
+
+    def __init__(self, name: str, script: list[object]):
+        self.name = name
+        self._script = list(script)
+        self.calls = 0
+
+    async def fetch(self, ctx: object) -> SourceData:
+        self.calls += 1
+        if not self._script:
+            raise IndexError(f"{self.name}: no scripted outcomes left")
+        outcome = self._script.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        assert isinstance(outcome, SourceData)
+        return outcome
+
+
+def _data(label: str) -> SourceData:
+    return SourceData(session_summary={"from": label})
+
+
+# ---------------------------------------------------------------------------
+# Source data merging
+# ---------------------------------------------------------------------------
+
+def test_source_data_merge_preserves_existing_fields():
+    primary = SourceData(
+        session_pods=[{"pod": "a"}],
+        session_metrics={"x": 1},
+        sources_used=["server"],
+    )
+    secondary = SourceData(
+        session_pods=[{"pod": "b"}],
+        session_metrics={"y": 2},
+        cluster_faults=[{"fault": 1}],
+        sources_used=["local"],
+    )
+    primary.merge_from(secondary)
+    assert primary.session_pods == [{"pod": "a"}]
+    assert primary.session_metrics == {"x": 1}
+    assert primary.cluster_faults == [{"fault": 1}]
+    assert primary.sources_used == ["server", "local"]
+
+
+def test_source_data_merge_inherits_degraded_reason_when_missing():
+    primary = SourceData()
+    secondary = SourceData(degraded_reason="server timeout")
+    primary.merge_from(secondary)
+    assert primary.degraded_reason == "server timeout"
+
+
+# ---------------------------------------------------------------------------
+# DegradeRouter happy path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_router_happy_path_uses_primary_only():
+    clock = _FakeClock()
+    primary = _ScriptedSource("server", [_data("server"), _data("server"), _data("server")])
+    fallback = _ScriptedSource("local", [_data("local")])
+    router = DegradeRouter(primary, fallback, clock=clock)
+    for _ in range(3):
+        snap = await router.collect(ctx=None)
+        assert snap.sources_used == ["server"]
+        assert snap.session_summary == {"from": "server"}
+        assert snap.degraded_reason is None
+    assert primary.calls == 3
+    assert fallback.calls == 0
+
+
+# ---------------------------------------------------------------------------
+# DegradeRouter degrade after consecutive failures
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_router_degrades_after_three_failures(caplog):
+    clock = _FakeClock()
+    primary = _ScriptedSource(
+        "server",
+        [
+            SourceUnavailable("first"),
+            SourceUnavailable("second"),
+            SourceUnavailable("third"),
+            SourceUnavailable("fourth"),  # not consumed because we degrade
+        ],
+    )
+    fallback = _ScriptedSource("local", [_data("local"), _data("local"), _data("local"), _data("local")])
+    router = DegradeRouter(primary, fallback, fail_threshold=3, recheck_interval_s=30, clock=clock)
+
+    with caplog.at_level(logging.WARNING):
+        for _ in range(3):
+            snap = await router.collect(ctx=None)
+        # After 3rd failure primary is DEGRADED. Subsequent tick skips primary
+        # because clock has not advanced past recheck interval.
+        snap_post = await router.collect(ctx=None)
+
+    assert primary.calls == 3, "primary should not be retried inside recheck window"
+    assert fallback.calls == 4
+    assert router.primary_state is HealthState.DEGRADED
+    assert snap_post.degraded_reason and "degraded" in snap_post.degraded_reason
+    assert snap_post.sources_used == ["local"]
+
+    transitions = [r for r in caplog.records if "state healthy -> degraded" in r.getMessage()]
+    assert len(transitions) == 1, "single WARN on transition only"
+
+
+# ---------------------------------------------------------------------------
+# DegradeRouter recovery after recheck interval
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_router_recovers_after_recheck_window(caplog):
+    clock = _FakeClock()
+    primary = _ScriptedSource(
+        "server",
+        [
+            SourceUnavailable("a"),
+            SourceUnavailable("b"),
+            SourceUnavailable("c"),  # degrade after this
+            _data("server"),         # recovery probe
+        ],
+    )
+    fallback = _ScriptedSource("local", [_data("local"), _data("local"), _data("local")])
+    router = DegradeRouter(primary, fallback, fail_threshold=3, recheck_interval_s=30, clock=clock)
+
+    for _ in range(3):
+        await router.collect(ctx=None)
+    assert router.primary_state is HealthState.DEGRADED
+
+    # Inside recheck window: primary not probed, fallback served.
+    clock.advance(10.0)
+    await router.collect(ctx=None)
+    assert primary.calls == 3
+
+    # Past recheck window: primary probed, succeeds, state goes HEALTHY.
+    clock.advance(25.0)
+    with caplog.at_level(logging.WARNING):
+        snap = await router.collect(ctx=None)
+    assert primary.calls == 4
+    assert router.primary_state is HealthState.HEALTHY
+    assert snap.sources_used == ["server"]
+    assert snap.degraded_reason is None
+    transitions = [r for r in caplog.records if "state degraded -> healthy" in r.getMessage()]
+    assert len(transitions) == 1
+
+
+# ---------------------------------------------------------------------------
+# Fallback failures
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_router_returns_empty_when_both_unavailable():
+    clock = _FakeClock()
+    primary = _ScriptedSource("server", [SourceUnavailable("p")] * 3)
+    fallback = _ScriptedSource("local", [SourceUnavailable("f")] * 3)
+    router = DegradeRouter(primary, fallback, fail_threshold=1, recheck_interval_s=0, clock=clock)
+    snap = await router.collect(ctx=None)
+    assert snap.sources_used == []
+    assert snap.degraded_reason and "both sources unavailable" in snap.degraded_reason
+
+
+# ---------------------------------------------------------------------------
+# Unexpected exceptions in primary count as failures but do not crash
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_router_treats_unexpected_exception_as_failure(caplog):
+    clock = _FakeClock()
+
+    class Boom(Exception):
+        pass
+
+    primary = _ScriptedSource("server", [Boom("oops"), Boom("oops"), Boom("oops")])
+    fallback = _ScriptedSource("local", [_data("local"), _data("local"), _data("local")])
+    router = DegradeRouter(primary, fallback, fail_threshold=3, recheck_interval_s=10, clock=clock)
+    with caplog.at_level(logging.ERROR):
+        for _ in range(3):
+            snap = await router.collect(ctx=None)
+            assert snap.sources_used == ["local"]
+    assert router.primary_state is HealthState.DEGRADED
+    assert any("primary source server raised unexpectedly" in r.getMessage() for r in caplog.records)

--- a/robustness-agent/tests/test_sources_local_probe.py
+++ b/robustness-agent/tests/test_sources_local_probe.py
@@ -1,0 +1,387 @@
+"""Unit tests for the LocalProbe fallback source."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from robustness_agent.sources.base import SourceUnavailable
+from robustness_agent.sources.local_probe import (
+    LocalProbeConfig,
+    LocalProbeSource,
+)
+
+
+@pytest.fixture()
+def session_dir(tmp_path: Path) -> Path:
+    storage = tmp_path / "storage"
+    storage.mkdir()
+    return tmp_path
+
+
+def _seed_conductor_db(
+    session_dir: Path,
+    rows: list[dict],
+    *,
+    schema: str = "v6",
+) -> Path:
+    db = session_dir / "storage" / "conductor.db"
+    conn = sqlite3.connect(db)
+    if schema == "v6":
+        conn.execute(
+            "CREATE TABLE events ("
+            "  seq INTEGER PRIMARY KEY AUTOINCREMENT,"
+            "  msg_id TEXT,"
+            "  from_agent TEXT,"
+            "  to_agent TEXT,"
+            "  topic TEXT,"
+            "  payload TEXT,"
+            "  ts TEXT"
+            ")"
+        )
+        for row in rows:
+            conn.execute(
+                "INSERT INTO events (msg_id, from_agent, to_agent, topic, payload, ts) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    row.get("msg_id", ""),
+                    row.get("agent", ""),
+                    row.get("to_agent", ""),
+                    row.get("topic", ""),
+                    json.dumps(row.get("payload", {})),
+                    row.get("ts", ""),
+                ),
+            )
+    else:
+        conn.execute(
+            "CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, agent TEXT, "
+            "intent_type TEXT, payload TEXT, timestamp REAL, topic TEXT)"
+        )
+        for row in rows:
+            conn.execute(
+                "INSERT INTO events (agent, intent_type, payload, timestamp, topic) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (
+                    row.get("agent", ""),
+                    row.get("intent_type", ""),
+                    json.dumps(row.get("payload", {})),
+                    row.get("timestamp", 0.0),
+                    row.get("topic", ""),
+                ),
+            )
+    conn.commit()
+    conn.close()
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Coordinator events
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_local_probe_reads_v6_events_schema(session_dir: Path):
+    _seed_conductor_db(
+        session_dir,
+        [
+            {"agent": "orchestration", "topic": "heartbeat", "payload": {"x": 1}},
+            {"agent": "kernel", "topic": "alert", "payload": {"y": 2}},
+        ],
+        schema="v6",
+    )
+    cfg = LocalProbeConfig(session_dir=session_dir, disk_mountpoints=())
+    probe = LocalProbeSource(cfg)
+    data = await probe.fetch(ctx=None)
+    assert len(data.coordinator_events) == 2
+    topics = sorted(e["topic"] for e in data.coordinator_events)
+    assert topics == ["alert", "heartbeat"]
+    assert data.sources_used == ["local-probe"]
+
+
+@pytest.mark.asyncio
+async def test_local_probe_reads_legacy_events_schema(session_dir: Path):
+    _seed_conductor_db(
+        session_dir,
+        [{"agent": "kernel", "intent_type": "alert", "topic": "alert", "timestamp": 1.0}],
+        schema="legacy",
+    )
+    cfg = LocalProbeConfig(session_dir=session_dir, disk_mountpoints=())
+    data = await LocalProbeSource(cfg).fetch(ctx=None)
+    assert len(data.coordinator_events) == 1
+    assert data.coordinator_events[0]["agent"] == "kernel"
+
+
+@pytest.mark.asyncio
+async def test_local_probe_returns_disk_usage(tmp_path: Path):
+    cfg = LocalProbeConfig(
+        session_dir=None,
+        disk_mountpoints=(str(tmp_path),),
+    )
+    data = await LocalProbeSource(cfg).fetch(ctx=None)
+    assert str(tmp_path) in data.local_disk
+    snap = data.local_disk[str(tmp_path)]
+    assert snap["total_gb"] >= 0
+    assert "used_pct" in snap
+
+
+@pytest.mark.asyncio
+async def test_local_probe_unavailable_when_no_data(monkeypatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    cfg = LocalProbeConfig(
+        session_dir=None,
+        disk_mountpoints=(),
+        process_patterns=(),
+        server_log_path=None,
+    )
+
+    # Force GPU sampler to return empty
+    monkeypatch.setattr(
+        "robustness_agent.sources.local_probe._sample_gpu", lambda: {}
+    )
+
+    probe = LocalProbeSource(cfg)
+    with pytest.raises(SourceUnavailable):
+        await probe.fetch(ctx=None)
+
+
+@pytest.mark.asyncio
+async def test_local_probe_handles_missing_conductor_db(tmp_path: Path):
+    cfg = LocalProbeConfig(
+        session_dir=tmp_path,
+        disk_mountpoints=(str(tmp_path),),
+    )
+    data = await LocalProbeSource(cfg).fetch(ctx=None)
+    assert data.coordinator_events == []
+    assert str(tmp_path) in data.local_disk
+
+
+# ---------------------------------------------------------------------------
+# Log tail
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_local_probe_tails_log_file(tmp_path: Path):
+    log_path = tmp_path / "server.log"
+    log_path.write_text("\n".join(f"line {i}" for i in range(50)) + "\n")
+    cfg = LocalProbeConfig(
+        session_dir=None,
+        disk_mountpoints=(str(tmp_path),),
+        server_log_path=log_path,
+        log_tail_lines=10,
+    )
+    data = await LocalProbeSource(cfg).fetch(ctx=None)
+    assert len(data.local_log_tail) == 10
+    assert data.local_log_tail[-1] == "line 49"
+
+
+def test_parse_rocm_smi_csv_multi_block():
+    from robustness_agent.sources.local_probe import _parse_rocm_smi_csv
+
+    text = (
+        "device,GPU use (%)\n"
+        "card0,42\n"
+        "card1,17\n"
+        "\n"
+        "device,GPU memory use (%)\n"
+        "card0,68\n"
+        "card1,55\n"
+        "\n"
+        "device,Temperature (Sensor edge) (C)\n"
+        "card0,72.5\n"
+        "card1,69.0\n"
+        "\n"
+        "device,Average Graphics Package Power (W)\n"
+        "card0,210.0\n"
+        "card1,198.5\n"
+    )
+    gpus = _parse_rocm_smi_csv(text)
+    assert len(gpus) == 2
+    by_id = {g["gpu_id"]: g for g in gpus}
+    assert by_id[0]["util_gpu_pct"] == 42.0
+    assert by_id[0]["util_mem_pct"] == 68.0
+    assert by_id[0]["temperature_c"] == 72.5
+    assert by_id[0]["power_watts"] == 210.0
+    assert by_id[1]["util_gpu_pct"] == 17.0
+
+
+def test_parse_rocm_smi_csv_skips_unknown_columns_and_garbage():
+    from robustness_agent.sources.local_probe import _parse_rocm_smi_csv
+
+    text = (
+        "device,GPU use (%),Unknown column\n"
+        "card0,5,N/A\n"
+        "card2,??,whatever\n"
+        "\n"
+        "noheader,row\n"
+    )
+    gpus = _parse_rocm_smi_csv(text)
+    assert [g["gpu_id"] for g in gpus] == [0]
+    assert gpus[0]["util_gpu_pct"] == 5.0
+    assert "Unknown column" not in gpus[0]
+
+
+@pytest.mark.asyncio
+async def test_local_probe_uses_rocm_smi_when_available(monkeypatch, tmp_path: Path):
+    from robustness_agent.sources import local_probe as lp
+
+    captured: dict = {}
+
+    def fake_which(binary: str) -> str | None:
+        return "/usr/bin/rocm-smi" if binary == "rocm-smi" else None
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        sample = (
+            "device,GPU use (%)\n"
+            "card0,55\n"
+            "\n"
+            "device,Temperature (Sensor edge) (C)\n"
+            "card0,80.0\n"
+        )
+
+        class _Result:
+            returncode = 0
+            stdout = sample
+            stderr = ""
+
+        return _Result()
+
+    monkeypatch.setattr(lp.shutil, "which", fake_which)
+    monkeypatch.setattr(lp.subprocess, "run", fake_run)
+
+    cfg = lp.LocalProbeConfig(
+        session_dir=None,
+        disk_mountpoints=(str(tmp_path),),
+        process_patterns=(),
+    )
+    data = await lp.LocalProbeSource(cfg).fetch(ctx=None)
+    assert data.local_gpu.get("tool") == "rocm-smi"
+    gpus = data.local_gpu.get("gpus")
+    assert gpus and gpus[0]["util_gpu_pct"] == 55.0
+    assert gpus[0]["temperature_c"] == 80.0
+    assert "--showpower" in captured["cmd"]
+
+
+def test_extract_log_errors_finds_known_patterns():
+    from robustness_agent.sources.local_probe import _extract_log_errors
+
+    tail = [
+        "INFO  starting",
+        "RuntimeError: tensor shape mismatch",
+        "WARNING something else",
+        "torch.cuda.OutOfMemoryError: CUDA out of memory. Tried to allocate ...",
+    ]
+    out = _extract_log_errors(
+        tail,
+        patterns=("CUDA out of memory", "RuntimeError"),
+        window=10,
+    )
+    assert {e["pattern"] for e in out} == {"CUDA out of memory", "RuntimeError"}
+    assert all(len(e["line"]) <= 240 for e in out)
+
+
+def test_extract_log_errors_truncates_long_lines():
+    from robustness_agent.sources.local_probe import _extract_log_errors
+
+    long_line = "RuntimeError: " + ("x" * 1000)
+    out = _extract_log_errors([long_line], patterns=("RuntimeError",), window=10)
+    assert out and len(out[0]["line"]) == 240
+
+
+def test_extract_log_errors_returns_empty_when_no_match():
+    from robustness_agent.sources.local_probe import _extract_log_errors
+
+    assert _extract_log_errors(["INFO ok"], patterns=("OOM",), window=10) == []
+
+
+@pytest.mark.asyncio
+async def test_local_probe_emits_log_errors_alongside_tail(tmp_path: Path):
+    log_path = tmp_path / "server.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "INFO loading",
+                "torch.cuda.OutOfMemoryError: CUDA out of memory occurred",
+                "INFO recovered",
+            ]
+        )
+        + "\n"
+    )
+    from robustness_agent.sources.local_probe import (
+        LocalProbeConfig,
+        LocalProbeSource,
+    )
+
+    cfg = LocalProbeConfig(
+        session_dir=None,
+        disk_mountpoints=(str(tmp_path),),
+        process_patterns=(),
+        server_log_path=log_path,
+        log_tail_lines=10,
+        log_error_patterns=("CUDA out of memory",),
+    )
+    data = await LocalProbeSource(cfg).fetch(ctx=None)
+    assert data.local_log_errors
+    assert data.local_log_errors[0]["pattern"] == "CUDA out of memory"
+    assert "out of memory" in data.local_log_errors[0]["line"].lower()
+
+
+@pytest.mark.asyncio
+async def test_local_probe_runs_health_probes(monkeypatch, tmp_path: Path):
+    import httpx
+    from robustness_agent.sources import local_probe as lp
+
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(str(request.url))
+        if "alive" in str(request.url):
+            return httpx.Response(200, json={"ok": True})
+        if "wedged" in str(request.url):
+            return httpx.Response(503, json={"detail": "wedged"})
+        raise httpx.ConnectError("connection refused", request=request)
+
+    transport = httpx.MockTransport(handler)
+
+    class _PatchedClient(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(lp.httpx, "AsyncClient", _PatchedClient)
+
+    cfg = lp.LocalProbeConfig(
+        session_dir=None,
+        disk_mountpoints=(str(tmp_path),),
+        process_patterns=(),
+        health_probe_targets=(
+            "http://localhost:30000/alive",
+            "http://localhost:30001/wedged",
+            "http://localhost:30002/dead",
+        ),
+        health_probe_timeout_s=1.0,
+    )
+    data = await lp.LocalProbeSource(cfg).fetch(ctx=None)
+    by_url = {entry["url"]: entry for entry in data.local_server_health}
+    assert by_url["http://localhost:30000/alive"]["status"] == "ok"
+    assert by_url["http://localhost:30000/alive"]["reachable"] is True
+    assert by_url["http://localhost:30001/wedged"]["status"] == "http_error"
+    assert by_url["http://localhost:30001/wedged"]["reachable"] is False
+    assert by_url["http://localhost:30002/dead"]["status"] == "error"
+    assert "connect" in by_url["http://localhost:30002/dead"]["error"]
+    assert len(seen) == 3
+
+
+@pytest.mark.asyncio
+async def test_local_probe_skips_log_when_path_missing(tmp_path: Path):
+    cfg = LocalProbeConfig(
+        session_dir=None,
+        disk_mountpoints=(str(tmp_path),),
+        server_log_path=tmp_path / "no-such.log",
+        log_tail_lines=10,
+    )
+    data = await LocalProbeSource(cfg).fetch(ctx=None)
+    assert data.local_log_tail == []

--- a/robustness-agent/tests/test_sources_server_client.py
+++ b/robustness-agent/tests/test_sources_server_client.py
@@ -1,0 +1,220 @@
+"""Unit tests for the robustness-server client + Source adapter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import httpx
+import pytest
+
+from robustness_agent.role.prompt_inputs import (
+    ReactorContext,
+    SharedStateSnapshot,
+)
+from robustness_agent.sources.base import SourceUnavailable
+from robustness_agent.sources.server_client import (
+    RobustnessServerClient,
+    RobustnessServerSource,
+)
+
+
+def _ctx(
+    *,
+    session_id: str = "sess-1",
+    now_unix: float = 1_700_000_000.0,
+) -> ReactorContext:
+    return ReactorContext(
+        tick_index=1,
+        shared_state=SharedStateSnapshot(session_id=session_id),
+        inbox=[],
+        now_unix=now_unix,
+    )
+
+
+def _client(handler) -> RobustnessServerClient:
+    transport = httpx.MockTransport(handler)
+    http = httpx.AsyncClient(
+        base_url="http://server.test", transport=transport, timeout=5.0
+    )
+    return RobustnessServerClient("http://server.test", client=http)
+
+
+# ---------------------------------------------------------------------------
+# Client low-level behaviour
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_session_returns_none_on_404():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"detail": "session not found"})
+
+    client = _client(handler)
+    try:
+        result = await client.get_session("missing")
+    finally:
+        await client.aclose()
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_session_returns_dict_on_200():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"session_id": "sess-1", "model_name": "qwen3-8b"},
+        )
+
+    client = _client(handler)
+    try:
+        result = await client.get_session("sess-1")
+    finally:
+        await client.aclose()
+    assert result == {"session_id": "sess-1", "model_name": "qwen3-8b"}
+
+
+@pytest.mark.asyncio
+async def test_list_session_events_unwraps_envelope():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"events": [{"id": 1}, {"id": 2}]})
+
+    client = _client(handler)
+    try:
+        events = await client.list_session_events("sess-1")
+    finally:
+        await client.aclose()
+    assert events == [{"id": 1}, {"id": 2}]
+
+
+@pytest.mark.asyncio
+async def test_5xx_raises_source_unavailable():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"detail": "down"})
+
+    client = _client(handler)
+    try:
+        with pytest.raises(SourceUnavailable):
+            await client.list_session_pods("sess-1")
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_connect_error_raises_source_unavailable():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom", request=request)
+
+    client = _client(handler)
+    try:
+        with pytest.raises(SourceUnavailable):
+            await client.list_sessions(limit=10)
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_metrics_window_query_params_are_unix_seconds():
+    seen: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        return httpx.Response(200, json={"pods": []})
+
+    client = _client(handler)
+    from robustness_agent.sources.server_client import _MetricsWindow
+
+    try:
+        await client.get_session_metrics(
+            "sess-1",
+            _MetricsWindow(start_unix=100, end_unix=200),
+            categories=["gpu", "cpu"],
+            step="15s",
+        )
+    finally:
+        await client.aclose()
+    assert "start=100" in seen["url"]
+    assert "end=200" in seen["url"]
+    assert "categories=gpu%2Ccpu" in seen["url"] or "categories=gpu,cpu" in seen["url"]
+    assert "step=15s" in seen["url"]
+
+
+# ---------------------------------------------------------------------------
+# Source adapter behaviour
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_source_returns_pods_events_summary():
+    requests_seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests_seen.append(str(request.url))
+        if "/pods" in request.url.path:
+            return httpx.Response(200, json=[{"pod": {"name": "brain-0"}}])
+        if "/events" in request.url.path:
+            return httpx.Response(200, json={"events": [{"kind": "ping"}]})
+        if "/summary" in request.url.path:
+            return httpx.Response(200, json={"pods": [], "session": {}})
+        return httpx.Response(404)
+
+    client = _client(handler)
+    try:
+        source = RobustnessServerSource(client)
+        data = await source.fetch(_ctx())
+    finally:
+        await client.aclose()
+    assert data.session_pods == [{"pod": {"name": "brain-0"}}]
+    assert data.session_events == [{"kind": "ping"}]
+    assert data.session_summary == {"pods": [], "session": {}}
+    assert data.sources_used == ["robustness-server"]
+    assert any("/pods" in u for u in requests_seen)
+    assert any("/events" in u for u in requests_seen)
+    assert any("/summary" in u for u in requests_seen)
+
+
+@pytest.mark.asyncio
+async def test_source_raises_when_session_id_missing():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[])
+
+    client = _client(handler)
+    try:
+        source = RobustnessServerSource(client)
+        with pytest.raises(SourceUnavailable):
+            await source.fetch(_ctx(session_id=""))
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_source_propagates_5xx_as_source_unavailable():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"detail": "boom"})
+
+    client = _client(handler)
+    try:
+        source = RobustnessServerSource(client)
+        with pytest.raises(SourceUnavailable):
+            await source.fetch(_ctx())
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_source_skips_summary_when_now_unix_is_zero():
+    requested_paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested_paths.append(request.url.path)
+        if "/pods" in request.url.path:
+            return httpx.Response(200, json=[])
+        if "/events" in request.url.path:
+            return httpx.Response(200, json={"events": []})
+        return httpx.Response(404)
+
+    client = _client(handler)
+    try:
+        source = RobustnessServerSource(client)
+        data = await source.fetch(_ctx(now_unix=0.0))
+    finally:
+        await client.aclose()
+    assert "/api/v1/sessions/sess-1/summary" not in requested_paths
+    assert data.session_summary == {}


### PR DESCRIPTION
## Summary

Implements Milestone 1 and the M1.5 patch of the robustness-agent
([design](https://github.com/AMD-AGI/Hyperloom/blob/main/inference_optimizer/inference_optimizer-DESIGN-v2.md) §7.4 / §19 / §20). The agent can now drop straight
into the `inference_optimizer` Coordinator as a real backend
replacing `MockRobustnessBackend`, and it also runs **standalone on a
single machine** without requiring `robustness-server` — exactly the
mode the Coordinator team needs for local development.

- M1: full reactor pipeline (`role/` + `decision/` + `signals/` +
  `sources/` + `findings/`) and `RobustnessAgentBackend` matching the
  upstream `Backend` protocol; envelope schema is verified against
  `inference_optimizer.orchestrator.intent_parser._PAYLOAD_REQUIRED`
  by a contract test.
- M1.5: single-machine LocalProbe enhancements (parsed `rocm-smi`,
  local HTTP `/health` probes, log error pattern extraction) and a
  real `LlmRcaEngine` talking to an OpenAI-compatible chat server
  with severity / cooldown / per-tick throttling. ``ActionLadder.decide``
  is now async to support awaitable RCA.

213 tests passing.

## Coordinator drop-in usage (SINGLE_PROC)

```python
from robustness_agent.config import Config
from robustness_agent.factory import build_backend

config = await Config.discover()  # detects session_dir, optional server, LLM creds
backend, bundle = build_backend(config)
# register backend under name "robustness" in the Coordinator's BackendRegistry
try:
    await coordinator.run_until_stop()
finally:
    await bundle.aclose()
```

When ``robustness-server`` is unreachable (the single-machine case),
``DegradeRouter`` automatically routes to ``LocalProbeSource`` after
``source_fail_threshold`` consecutive failures and re-probes the
primary every ``source_recheck_interval_s``. The reactor consumes a
unified ``SourceData`` view, so signals do not change between
single-mode and cluster mode.

## What this PR adds

### Reactor / Backend (M1)

- ``role/envelope.py`` — ``IntentType`` / ``Intent`` /
  ``BackendTurnResult`` mirroring upstream wire shape; payload
  builders (``build_heartbeat`` / ``build_alert`` /
  ``build_escalate_strategy_change`` / etc.).
- ``role/prompt_inputs.py`` — parses Coordinator
  ``_compose_prompt`` output into ``ReactorContext`` (``InboxItem``
  list + ``SharedStateSnapshot``).
- ``role/reactor.py`` — ``Reactor.tick(ctx)`` orchestrates Source ->
  Classifier -> ActionLadder -> PolicyAware -> FindingSink.
- ``role/backend_adapter.py`` — ``RobustnessAgentBackend.run`` adapts
  the reactor to the upstream ``Backend`` protocol.
- ``decision/policy_aware.py`` — local payload-shape guard mirroring
  upstream ``PolicyGate``.
- ``decision/action_ladder.py`` — symptom -> intent ladder
  (``observe`` / ``diagnose`` / ``recommend``) with per-key cooldown.
- ``decision/rca_engine.py`` — ``RcaEngine`` protocol + ``NoopRcaEngine``.
- ``signals/{stall,crash,event,health}.py`` + ``classifier.py`` — rule
  set with de-duplication.
- ``sources/base.py`` — ``Source`` protocol, ``SourceData``,
  ``DegradeRouter``.
- ``sources/server_client.py`` — ``RobustnessServerClient`` +
  ``RobustnessServerSource`` adapter.
- ``sources/local_probe.py`` — local fallback (conductor.db, disk, ps,
  GPU, log tail).
- ``findings/sink.py`` — JSONL append sink under
  ``{session_dir}/agents/robustness/findings/{session_id}.jsonl``.
- ``factory.py`` — ``build_reactor_components`` /
  ``build_backend`` (``ReactorBundle.aclose()`` flushes lifecycles).
- ``main.py`` — ``--mode reactor`` (default) and ``--mode legacy``;
  legacy ``IntentEmitter`` now emits ``DeprecationWarning``.

### Single-machine + LLM RCA (M1.5)

- LocalProbe now parses ``rocm-smi --showuse --showmemuse --showtemp
  --showpower --csv`` into structured ``gpus[]`` (util / mem /
  temperature / power); raw_csv fallback for parser drift.
- ``SourceData.local_server_health[]`` populated by per-target HTTP
  GET probes (``Config.health_probe_targets``) with timeout, status
  classification (``ok`` / ``http_error`` / ``error``).
- ``SourceData.local_log_errors[]`` extracted from the log tail
  against patterns (CUDA OOM / HIP OOM / NCCL / segfault / RuntimeError
  / Killed / OOMKilled / etc.); samples truncated to 240 chars.
- New ``signals/local_health.py`` rule: ``local_server_unreachable``,
  ``log_error_pattern``, ``gpu_thermal_high`` — only fire when
  LocalProbe data is present, so they stay silent in cluster mode
  where the cluster sources fill the same need.
- ``LlmRcaEngine`` calls an OpenAI-compatible chat endpoint via
  ``httpx`` (no ``openai`` SDK dependency for tighter mocking).
  ``RcaThrottle`` enforces:
  - severity gate (default ``>= high``)
  - per-dedup-key cooldown (default 60s)
  - per-tick cap (default 1 LLM call)
- ``Config.llm_rca_enabled`` (None = auto when credentials present),
  ``ROBUSTNESS_LLM_RCA_DISABLED=1`` env override forces off.
- ``ActionLadder.decide`` and ``Reactor.tick`` are now async so RCA
  can be awaited without thread hops; existing tests updated.

## Symptom -> intent mapping

| Symptom | Severity | Intents | Source |
|---------|----------|---------|--------|
| ``agent_stall`` (>= stall_timeout_s) | medium / high | ``alert`` (+ ``escalate_strategy_change`` at high) | M1 |
| ``crash_count_rising`` / ``crash_count_high`` / ``crash_count_emergency`` | medium / high | ``alert`` (+ ``escalate_strategy_change`` at high) | M1 |
| ``repeated_policy_denied`` (>= 3) | medium | ``alert(medium)`` | M1 |
| ``repeated_failure`` (same family) | medium / high | ``alert`` (high tier triggers ``prune_branch``) | M1 |
| ``pod_not_running`` | medium / high | ``alert`` | M1 |
| ``pod_no_metrics`` | low | ``send_message(observation)`` | M1 |
| ``local_server_unreachable`` | medium / high (all down) | ``alert`` | M1.5 |
| ``log_error_pattern`` (CUDA OOM / NCCL / segfault) | high | ``alert`` + ``escalate_strategy_change`` | M1.5 |
| ``log_error_pattern`` (RuntimeError / generic) | medium | ``alert`` | M1.5 |
| ``gpu_thermal_high`` | medium / high | ``alert`` (+ ``escalate_strategy_change`` at crit) | M1.5 |
| (no symptoms) | — | ``send_message(heartbeat)`` | M1 |

## Test plan

- [x] Unit + integration: ``pytest`` passes (213 tests, 3 expected
  ``DeprecationWarning`` from the legacy ``IntentEmitter`` test).
- [x] Lint: no new linter errors in modified / new files.
- [x] Wire-protocol contract: ``tests/test_role_contract.py`` checks
  ``IntentType`` / ``_PAYLOAD_REQUIRED`` against
  ``inference_optimizer.orchestrator.intent_parser`` when importable.
- [x] PolicyGate integration:
  ``tests/test_inference_optimizer_integration.py`` validates every
  intent emitted by ``RobustnessAgentBackend`` with the upstream
  ``PolicyGate``.
- [ ] (follow-up) Run end-to-end against a live Coordinator with a
  real chat-server to validate ``LlmRcaEngine`` content quality.
- [ ] (follow-up) Replace ``MockRobustnessBackend`` registration in a
  real session and observe the ``Findings`` JSONL.

## Notes

- PR is targeted at ``feature/haiskong/robustness-server`` so the diff
  is purely the agent additions on top of the deployed
  ``robustness-server``. Once that branch lands on main, this branch
  can be retargeted to main.
- Hard-action intents (``kill_task`` / ``force_dispatch`` /
  ``prune_branch`` beyond medium-tier) are gated to M4 per plan §6 /
  §8 invariants — this PR keeps the safe set only.
- ``robustness-server`` is **not** required to run the single-machine
  flow; ``Config.discover`` records ``robustness_server_url=""`` when
  no candidate responds, and the agent falls through to LocalProbe.


Made with [Cursor](https://cursor.com)