### PR TITLE
feat(robustness-agent): cluster-fault + cluster GPU thermal via robustness-server (M2 + M2.5)

### DIFF
--- a/robustness-agent/src/robustness_agent/decision/action_ladder.py
+++ b/robustness-agent/src/robustness_agent/decision/action_ladder.py
@@ -177,6 +177,20 @@ class ActionLadder:
                     severity="high",
                 )
             )
+        elif sym.name == "cluster_fault":
+            # Wide-blast-radius cluster faults need an escalate so the
+            # orchestration agent reroutes work away from the affected
+            # node before the fault sweeps more sessions.
+            intents.append(
+                build_escalate(
+                    reason="cluster_fault_high",
+                    next_action_hint=(
+                        sym.suggestion
+                        or "drain affected node; reschedule away from fault"
+                    ),
+                    severity="high",
+                )
+            )
         elif sym.name == "repeated_failure":
             family = sym.evidence.get("family") if isinstance(sym.evidence, dict) else None
             if isinstance(family, str) and family.strip():

--- a/robustness-agent/src/robustness_agent/signals/__init__.py
+++ b/robustness-agent/src/robustness_agent/signals/__init__.py
@@ -17,6 +17,7 @@ The full GPU / disk / log rule set lands in M2.
 """
 
 from .classifier import Classifier
+from .cluster_fault import evaluate_cluster_fault_signals
 from .crash import evaluate_crash_signals
 from .event import evaluate_event_signals
 from .health import evaluate_health_signals
@@ -28,6 +29,7 @@ __all__ = [
     "Classifier",
     "Symptom",
     "SymptomSeverity",
+    "evaluate_cluster_fault_signals",
     "evaluate_crash_signals",
     "evaluate_event_signals",
     "evaluate_health_signals",

--- a/robustness-agent/src/robustness_agent/signals/classifier.py
+++ b/robustness-agent/src/robustness_agent/signals/classifier.py
@@ -14,6 +14,7 @@ from typing import Callable
 
 from ..role.prompt_inputs import ReactorContext
 from ..sources.base import SourceData
+from .cluster_fault import ClusterFaultConfig, evaluate_cluster_fault_signals
 from .crash import CrashConfig, evaluate_crash_signals
 from .event import EventConfig, evaluate_event_signals
 from .health import HealthConfig, evaluate_health_signals
@@ -34,6 +35,9 @@ class Classifier:
     event_config: EventConfig = field(default_factory=EventConfig)
     health_config: HealthConfig = field(default_factory=HealthConfig)
     local_health_config: LocalHealthConfig = field(default_factory=LocalHealthConfig)
+    cluster_fault_config: ClusterFaultConfig = field(
+        default_factory=ClusterFaultConfig
+    )
     extra_evaluators: list[SignalEvaluator] = field(default_factory=list)
 
     def classify(self, data: SourceData, ctx: ReactorContext) -> list[Symptom]:
@@ -52,6 +56,11 @@ class Classifier:
         )
         symptoms.extend(
             evaluate_local_health_signals(ctx, data, config=self.local_health_config)
+        )
+        symptoms.extend(
+            evaluate_cluster_fault_signals(
+                ctx, data, config=self.cluster_fault_config
+            )
         )
         for fn in self.extra_evaluators:
             symptoms.extend(fn(ctx, data))

--- a/robustness-agent/src/robustness_agent/signals/cluster_fault.py
+++ b/robustness-agent/src/robustness_agent/signals/cluster_fault.py
@@ -1,0 +1,176 @@
+"""Symptoms derived from cluster-fault snapshots (M2).
+
+The reactor consumes :data:`SourceData.cluster_faults` (a list of
+fault rows pulled from robustness-server's ``/api/v1/cluster/faults``
+proxy). Each row is shaped roughly like the upstream robust-api
+``FaultSummary``::
+
+    {
+        "name": "g53-gpu_ecc",
+        "monitor_id": "gpu_ecc",
+        "node_name": "g53",
+        "phase": "Isolating",         # Isolating / Succeeded / Failed
+        "auto_repair": false,
+        "action": "isolate",
+        "created_at": "...",
+        "affected_workload_count": 3,
+        "affected_gpu_count": 8,
+    }
+
+Severity rules:
+
+* ``phase == "Failed"`` -> high (auto-repair gave up; operator action
+  required).
+* ``phase == "Isolating"`` -> medium by default, escalated to high
+  when the fault impacts >= ``high_workload_threshold`` workloads or
+  >= ``high_gpu_threshold`` GPUs (ie a non-trivial blast radius).
+* ``phase == "Succeeded"`` -> silent. Auto-repair finished; no agent
+  action needed.
+
+Per :data:`SourceData` invariant the rule does not branch on whether
+``cluster_faults`` came from the primary or fallback source: if the
+field is empty we emit nothing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ..role.prompt_inputs import ReactorContext
+from ..sources.base import SourceData
+from .symptom import Symptom, SymptomSeverity
+
+
+@dataclass
+class ClusterFaultConfig:
+    """Tunables for the cluster_fault rule."""
+
+    # Phases we treat as actionable. Anything outside this set is
+    # ignored (notably "Succeeded", which means the auto-repair flow
+    # already cleaned up).
+    actionable_phases: frozenset[str] = frozenset(
+        {"Isolating", "Failed"}
+    )
+    high_workload_threshold: int = 4
+    high_gpu_threshold: int = 8
+
+
+def evaluate_cluster_fault_signals(
+    ctx: ReactorContext,
+    data: SourceData,
+    *,
+    config: ClusterFaultConfig | None = None,
+) -> list[Symptom]:
+    cfg = config or ClusterFaultConfig()
+    if not data.cluster_faults:
+        return []
+    out: list[Symptom] = []
+    for entry in data.cluster_faults:
+        if not isinstance(entry, dict):
+            continue
+        sym = _fault_to_symptom(entry, cfg)
+        if sym is not None:
+            out.append(sym)
+    return out
+
+
+def _fault_to_symptom(
+    entry: dict[str, Any],
+    cfg: ClusterFaultConfig,
+) -> Symptom | None:
+    phase = str(entry.get("phase") or "")
+    if phase not in cfg.actionable_phases:
+        return None
+
+    name = str(entry.get("name") or "")
+    monitor_id = str(entry.get("monitor_id") or "")
+    node = str(entry.get("node_name") or "")
+    affected_workloads = _coerce_int(entry.get("affected_workload_count"))
+    affected_gpus = _coerce_int(entry.get("affected_gpu_count"))
+    auto_repair = bool(entry.get("auto_repair"))
+
+    severity = _severity_for(
+        phase=phase,
+        affected_workloads=affected_workloads,
+        affected_gpus=affected_gpus,
+        cfg=cfg,
+    )
+
+    return Symptom(
+        name="cluster_fault",
+        severity=severity,
+        summary=(
+            f"cluster fault {name or monitor_id!r} on node {node or 'unknown'} "
+            f"phase={phase} workloads={affected_workloads} gpus={affected_gpus}"
+        ),
+        evidence={
+            "fault_name": name,
+            "monitor_id": monitor_id,
+            "node": node,
+            "phase": phase,
+            "auto_repair": auto_repair,
+            "action": entry.get("action"),
+            "affected_workload_count": affected_workloads,
+            "affected_gpu_count": affected_gpus,
+            "created_at": entry.get("created_at"),
+        },
+        # ``Symptom.dedup_key`` keys off ``(name, sorted(subject))`` so
+        # putting the fault name in the subject lets the ladder cool
+        # down per-fault rather than collapsing all faults into one.
+        subject={"node": node, "fault": name or monitor_id},
+        source="server",
+        suggestion=_suggestion(phase, severity, auto_repair),
+    )
+
+
+def _severity_for(
+    *,
+    phase: str,
+    affected_workloads: int,
+    affected_gpus: int,
+    cfg: ClusterFaultConfig,
+) -> SymptomSeverity:
+    if phase == "Failed":
+        return SymptomSeverity.HIGH
+    if affected_workloads >= cfg.high_workload_threshold:
+        return SymptomSeverity.HIGH
+    if affected_gpus >= cfg.high_gpu_threshold:
+        return SymptomSeverity.HIGH
+    return SymptomSeverity.MEDIUM
+
+
+def _suggestion(phase: str, severity: SymptomSeverity, auto_repair: bool) -> str:
+    if phase == "Failed":
+        return (
+            "auto-repair failed; delegate(server_lifecycle) or escalate "
+            "strategy to drain affected workloads"
+        )
+    if severity is SymptomSeverity.HIGH:
+        return (
+            "blast radius is wide; escalate strategy or pause new "
+            "dispatches to the affected node"
+        )
+    if auto_repair:
+        return "auto-repair in progress; observe and re-evaluate next tick"
+    return "monitor the fault; alert orchestration if it persists"
+
+
+def _coerce_int(raw: Any) -> int:
+    if isinstance(raw, bool):
+        # bool is a subclass of int; reject it so we don't end up with
+        # ``True == 1`` polluting the threshold logic.
+        return 0
+    if isinstance(raw, int):
+        return raw
+    if isinstance(raw, float):
+        return int(raw)
+    if isinstance(raw, str):
+        try:
+            return int(raw)
+        except ValueError:
+            return 0
+    return 0
+
+
+__all__ = ["ClusterFaultConfig", "evaluate_cluster_fault_signals"]

--- a/robustness-agent/src/robustness_agent/sources/cluster_decoder.py
+++ b/robustness-agent/src/robustness_agent/sources/cluster_decoder.py
@@ -1,0 +1,201 @@
+"""Decode robust-api raw responses into LocalProbe-equivalent schemas.
+
+robust-api emits Prometheus-style time-series via
+``pod-metrics/batch`` (proxied as ``/api/v1/cluster/pods/.../metrics``
+in M2). The agent's local signals consume a flatter snapshot — one
+row per device with the latest value of each metric — so this module
+bridges the two so ``signals/local_health.py`` does not have to
+care which source filled :data:`SourceData.local_gpu`.
+
+We currently decode GPU metrics only; disk / log mappings can be
+added the same way once we have a stable upstream catalogue.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+# Map of metric_name -> SourceData.local_gpu field. Adding a new
+# metric is a one-line addition; the signal layer never sees this.
+# Keys cover the three exporter conventions we currently meet on
+# core42 (rocm exporter, DCGM, generic) so signals work uniformly
+# across nodes regardless of who scraped the raw counter.
+_GPU_METRIC_FIELD: Mapping[str, str] = {
+    # rocm-exporter
+    "rocm_temperature_celsius": "temperature_c",
+    "rocm_temperature_edge_celsius": "temperature_c",
+    "rocm_temperature_junction_celsius": "temperature_junction_c",
+    "rocm_temperature_memory_celsius": "temperature_memory_c",
+    "rocm_gpu_utilization": "util_gpu_pct",
+    "rocm_memory_utilization": "util_mem_pct",
+    "rocm_power_average_watts": "power_watts",
+    # NVIDIA DCGM exporter
+    "DCGM_FI_DEV_GPU_TEMP": "temperature_c",
+    "DCGM_FI_DEV_MEMORY_TEMP": "temperature_memory_c",
+    "DCGM_FI_DEV_GPU_UTIL": "util_gpu_pct",
+    "DCGM_FI_DEV_MEM_COPY_UTIL": "util_mem_pct",
+    "DCGM_FI_DEV_POWER_USAGE": "power_watts",
+    # Generic / re-labelled
+    "gpu_temperature_celsius": "temperature_c",
+    "gpu_temperature_c": "temperature_c",
+    "gpu_util_percent": "util_gpu_pct",
+    "gpu_memory_util_percent": "util_mem_pct",
+}
+
+
+# Series labels we look at to deduce gpu_id; first match wins.
+# robust-api / Prometheus exporters disagree on the label name so we
+# accept all three conventions.
+_GPU_ID_LABELS: tuple[str, ...] = (
+    "gpu",
+    "device",
+    "device_id",
+    "minor",
+    "minor_number",
+    "DCGM_FI_DRIVER_DEVICE_ID",
+    "card",
+)
+
+
+def decode_gpu_snapshot(
+    response: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Decode pod-metrics/batch response into LocalProbe local_gpu shape.
+
+    Returns ``{"gpus": [...], "tool": "robust-api"}`` or ``{}`` when
+    no GPU metric is found. Each gpu row carries the same fields the
+    LocalProbe rocm-smi parser produces (``gpu_id``, ``temperature_c``,
+    ``util_gpu_pct`` etc.) plus ``pod_namespace`` / ``pod_name`` so
+    signals can pinpoint where the heat is coming from.
+    """
+
+    if not isinstance(response, Mapping):
+        return {}
+    data = response.get("data")
+    if not isinstance(data, Mapping):
+        return {}
+    pod_results = data.get("pods")
+    if not isinstance(pod_results, list):
+        return {}
+
+    by_id: dict[tuple[str, str, str], dict[str, Any]] = {}
+
+    for pod in pod_results:
+        if not isinstance(pod, Mapping):
+            continue
+        ns = str(pod.get("namespace") or "")
+        name = str(pod.get("name") or "")
+        results = pod.get("results")
+        if not isinstance(results, list):
+            continue
+        for result in results:
+            if not isinstance(result, Mapping):
+                continue
+            metric_name = str(result.get("name") or "")
+            field = _GPU_METRIC_FIELD.get(metric_name)
+            if field is None:
+                continue
+            for series in result.get("series") or []:
+                if not isinstance(series, Mapping):
+                    continue
+                gpu_id = _extract_gpu_id(series.get("labels"))
+                latest = _latest_value(series.get("values"))
+                if latest is None:
+                    continue
+                # Key by (ns, name, gpu_id) so two pods on the same
+                # node with overlapping GPU IDs don't collide. The
+                # caller can flatten this if it wants a single
+                # node-wide list.
+                key = (ns, name, gpu_id)
+                snap = by_id.setdefault(
+                    key,
+                    {
+                        "gpu_id": _coerce_int_id(gpu_id),
+                        "pod_namespace": ns,
+                        "pod_name": name,
+                    },
+                )
+                snap[field] = latest
+
+    if not by_id:
+        return {}
+    return {
+        "gpus": [by_id[k] for k in sorted(by_id)],
+        "tool": "robust-api",
+    }
+
+
+def merge_gpu_snapshots(
+    snapshots: list[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Combine multiple per-pod snapshots into a single ``local_gpu``.
+
+    Used by :class:`RobustnessServerSource` when fan-out across the
+    session's pods produces one decoded snapshot each. Later writes
+    win on field clashes per (pod, gpu_id), but distinct pods stay
+    distinct so the signal evidence keeps the namespace / name the
+    GPU lived under.
+    """
+
+    rows: list[dict[str, Any]] = []
+    for snap in snapshots:
+        if not isinstance(snap, Mapping):
+            continue
+        gpus = snap.get("gpus")
+        if not isinstance(gpus, list):
+            continue
+        for row in gpus:
+            if isinstance(row, Mapping):
+                rows.append(dict(row))
+    if not rows:
+        return {}
+    # Stable ordering: by (pod_namespace, pod_name, gpu_id) so test
+    # assertions are deterministic.
+    rows.sort(
+        key=lambda r: (
+            str(r.get("pod_namespace") or ""),
+            str(r.get("pod_name") or ""),
+            str(r.get("gpu_id") or ""),
+        )
+    )
+    return {"gpus": rows, "tool": "robust-api"}
+
+
+def _extract_gpu_id(labels: Any) -> str:
+    if not isinstance(labels, Mapping):
+        return ""
+    for key in _GPU_ID_LABELS:
+        if key in labels:
+            return str(labels[key])
+    return ""
+
+
+def _coerce_int_id(raw: str) -> int | str:
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return raw
+
+
+def _latest_value(values: Any) -> float | None:
+    if not isinstance(values, list) or not values:
+        return None
+    best_ts = -1
+    best_val: float | None = None
+    for entry in values:
+        if not isinstance(entry, Mapping):
+            continue
+        ts = entry.get("timestamp")
+        if not isinstance(ts, (int, float)):
+            continue
+        if ts > best_ts:
+            try:
+                best_val = float(entry.get("value"))
+            except (TypeError, ValueError):
+                continue
+            best_ts = ts
+    return best_val
+
+
+__all__ = ["decode_gpu_snapshot", "merge_gpu_snapshots"]

--- a/robustness-agent/src/robustness_agent/sources/server_client.py
+++ b/robustness-agent/src/robustness_agent/sources/server_client.py
@@ -27,6 +27,7 @@ from typing import Any
 import httpx
 
 from .base import Source, SourceData, SourceUnavailable
+from .cluster_decoder import decode_gpu_snapshot, merge_gpu_snapshots
 
 
 log = logging.getLogger(__name__)
@@ -336,6 +337,9 @@ class RobustnessServerSource:
         faults_lookback_s: int = 300,
         faults_page_size: int = 50,
         enable_cluster_faults: bool = True,
+        enable_cluster_pod_metrics: bool = False,
+        pod_metrics_categories: tuple[str, ...] = ("gpu",),
+        max_pods_per_tick: int = 16,
     ) -> None:
         self._client = client
         self._metrics_window_s = max(60, int(metrics_window_s))
@@ -343,6 +347,14 @@ class RobustnessServerSource:
         self._faults_lookback_s = max(0, int(faults_lookback_s))
         self._faults_page_size = max(1, min(500, int(faults_page_size)))
         self._enable_cluster_faults = bool(enable_cluster_faults)
+        # Cluster pod metrics are off by default: they fan out one
+        # HTTP call per pod per tick, so callers need to opt in once
+        # they are happy with the cost. Setting the flag is what
+        # makes signals/local_health.py prefer server-decoded GPU
+        # data over LocalProbe rocm-smi.
+        self._enable_cluster_pod_metrics = bool(enable_cluster_pod_metrics)
+        self._pod_metrics_categories = tuple(pod_metrics_categories)
+        self._max_pods_per_tick = max(1, int(max_pods_per_tick))
 
     async def fetch(self, ctx: Any) -> SourceData:
         session_id = _extract_session_id(ctx)
@@ -389,18 +401,97 @@ class RobustnessServerSource:
                 # server is genuinely unreachable.
                 raise
 
+        local_gpu: dict[str, Any] = {}
+        if (
+            self._enable_cluster_pod_metrics
+            and pods
+            and window.start_unix
+            and window.end_unix
+        ):
+            local_gpu = await self._fetch_cluster_pod_metrics(pods, window)
+
         return SourceData(
             session_pods=pods,
             session_events=events,
             session_summary=summary,
             cluster_faults=cluster_faults,
+            local_gpu=local_gpu,
             sources_used=[self.name],
         )
+
+    async def _fetch_cluster_pod_metrics(
+        self,
+        pods: list[dict[str, Any]],
+        window: _MetricsWindow,
+    ) -> dict[str, Any]:
+        """Fan out cluster pod metrics across the session's pods.
+
+        Decodes each per-pod response into the LocalProbe ``local_gpu``
+        schema and merges them so a single ``SourceData.local_gpu``
+        carries every device the session is using. Server-decoded
+        snapshots win over what LocalProbe might have produced
+        because we only fill ``local_gpu`` from this path when the
+        primary source is healthy.
+
+        A 5xx / transport failure on any pod re-raises as
+        :class:`SourceUnavailable` so the DegradeRouter degrades —
+        exactly the same policy as ``list_cluster_faults`` above.
+        """
+
+        refs = _unique_pod_refs(pods)
+        if not refs:
+            return {}
+        if len(refs) > self._max_pods_per_tick:
+            refs = refs[: self._max_pods_per_tick]
+
+        snapshots: list[dict[str, Any]] = []
+        for ns, name in refs:
+            try:
+                metrics = await self._client.get_cluster_pod_metrics(
+                    ns,
+                    name,
+                    window,
+                    categories=list(self._pod_metrics_categories),
+                )
+            except SourceUnavailable:
+                raise
+            decoded = decode_gpu_snapshot(metrics)
+            if decoded:
+                snapshots.append(decoded)
+        return merge_gpu_snapshots(snapshots)
 
 
 def _extract_session_id(ctx: Any) -> str:
     shared = getattr(ctx, "shared_state", None)
     return getattr(shared, "session_id", "") or ""
+
+
+def _unique_pod_refs(pods: list[dict[str, Any]]) -> list[tuple[str, str]]:
+    """Distinct (namespace, name) tuples extracted from session_pods.
+
+    ``session_pods`` rows shaped by robustness-server carry the
+    pod under ``pod.namespace`` / ``pod.name`` (mirrors
+    ``list_session_pods``). Same pod may appear in multiple
+    open/close cycles; we collapse to the unique set so the
+    cluster-metrics fan-out is not duplicated.
+    """
+
+    seen: set[tuple[str, str]] = set()
+    out: list[tuple[str, str]] = []
+    for entry in pods or []:
+        if not isinstance(entry, dict):
+            continue
+        pod = entry.get("pod") if isinstance(entry.get("pod"), dict) else entry
+        ns = str(pod.get("namespace") or "")
+        name = str(pod.get("name") or "")
+        if not ns or not name:
+            continue
+        key = (ns, name)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(key)
+    return out
 
 
 __all__ = [

--- a/robustness-agent/src/robustness_agent/sources/server_client.py
+++ b/robustness-agent/src/robustness_agent/sources/server_client.py
@@ -190,6 +190,113 @@ class RobustnessServerClient:
         )
         return body if isinstance(body, dict) else {}
 
+    # -- M2: cluster-physical proxies -----------------------------------
+
+    async def get_cluster_pod_metrics(
+        self,
+        namespace: str,
+        name: str,
+        window: _MetricsWindow,
+        *,
+        categories: list[str] | None = None,
+        step: str | None = None,
+    ) -> dict[str, Any]:
+        """GET ``/api/v1/cluster/pods/{ns}/{name}/metrics``.
+
+        Single-pod metrics; the response shape mirrors
+        ``get_session_metrics`` (``{"data": {"pods": [...]}}``).
+        """
+
+        params: dict[str, Any] = {
+            "start": str(window.start_unix),
+            "end": str(window.end_unix),
+        }
+        if categories:
+            params["categories"] = ",".join(categories)
+        if step:
+            params["step"] = step
+        body = await self._get_json(
+            f"/api/v1/cluster/pods/{namespace}/{name}/metrics",
+            params=params,
+        )
+        return body if isinstance(body, dict) else {}
+
+    async def list_cluster_pod_metric_categories(
+        self,
+        namespace: str,
+        name: str,
+        window: _MetricsWindow,
+        *,
+        categories: list[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """GET ``/api/v1/cluster/pods/{ns}/{name}/metrics/list``.
+
+        Returns the ``available`` array verbatim so callers can pick
+        which categories to query without probing each metric kind.
+        """
+
+        params: dict[str, Any] = {
+            "start": str(window.start_unix),
+            "end": str(window.end_unix),
+        }
+        if categories:
+            params["categories"] = ",".join(categories)
+        body = await self._get_json(
+            f"/api/v1/cluster/pods/{namespace}/{name}/metrics/list",
+            params=params,
+        )
+        if isinstance(body, dict):
+            available = body.get("available")
+            if isinstance(available, list):
+                return available
+        return []
+
+    async def get_cluster_workload_hierarchy(
+        self,
+        workload_id: str,
+    ) -> dict[str, Any]:
+        """GET ``/api/v1/cluster/workloads/{id}/hierarchy``."""
+
+        body = await self._get_json(
+            f"/api/v1/cluster/workloads/{workload_id}/hierarchy",
+        )
+        return body if isinstance(body, dict) else {}
+
+    async def list_cluster_faults(
+        self,
+        *,
+        since: str | None = None,
+        node: str | None = None,
+        phase: str | None = None,
+        page_size: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """GET ``/api/v1/cluster/faults``.
+
+        Returns the ``faults`` array (already paginated upstream). We
+        flatten dict / list responses so callers don't branch on shape.
+        """
+
+        params: dict[str, Any] = {}
+        if since:
+            params["since"] = since
+        if node:
+            params["node"] = node
+        if phase:
+            params["phase"] = phase
+        if page_size is not None:
+            params["page_size"] = str(page_size)
+        body = await self._get_json(
+            "/api/v1/cluster/faults",
+            params=params or None,
+        )
+        if isinstance(body, dict):
+            faults = body.get("faults")
+            if isinstance(faults, list):
+                return faults
+        if isinstance(body, list):
+            return body
+        return []
+
 
 def _to_iso(unix_seconds: int) -> str:
     """Format Unix seconds as ISO-8601 UTC for ``start`` / ``end`` query args."""
@@ -205,11 +312,17 @@ def _to_iso(unix_seconds: int) -> str:
 class RobustnessServerSource:
     """Adapter wrapping :class:`RobustnessServerClient` as a :class:`Source`.
 
-    Per tick we fetch ``pods`` + ``events`` + ``summary`` for the
-    session referenced by ``ctx.shared_state.session_id``. ``metrics``
-    is intentionally skipped in M1 because cluster-physical proxies
-    arrive in M2; the reactor still has plenty to chew on with pod
-    phase + recent events.
+    Per tick we fetch session-scoped data (``pods`` + ``events`` +
+    ``summary``) for the session referenced by
+    ``ctx.shared_state.session_id``, plus cluster-physical signals
+    (``cluster_faults``) introduced in M2 so the agent reacts to node
+    isolation events even when the local probe sees nothing wrong.
+
+    Cluster fetches are best-effort: a 4xx / 5xx on the cluster
+    endpoints does not invalidate the session-scoped snapshot. A
+    transport failure does, since it strongly suggests the server is
+    unreachable and the DegradeRouter should switch to the local
+    probe.
     """
 
     name = "robustness-server"
@@ -220,10 +333,16 @@ class RobustnessServerSource:
         *,
         metrics_window_s: int = 300,
         events_limit: int = 200,
+        faults_lookback_s: int = 300,
+        faults_page_size: int = 50,
+        enable_cluster_faults: bool = True,
     ) -> None:
         self._client = client
         self._metrics_window_s = max(60, int(metrics_window_s))
         self._events_limit = max(1, int(events_limit))
+        self._faults_lookback_s = max(0, int(faults_lookback_s))
+        self._faults_page_size = max(1, min(500, int(faults_page_size)))
+        self._enable_cluster_faults = bool(enable_cluster_faults)
 
     async def fetch(self, ctx: Any) -> SourceData:
         session_id = _extract_session_id(ctx)
@@ -251,10 +370,30 @@ class RobustnessServerSource:
         if window.start_unix and window.end_unix:
             summary = await self._client.get_session_summary(session_id, window)
 
+        cluster_faults: list[dict[str, Any]] = []
+        if self._enable_cluster_faults:
+            since = (
+                str(now_unix - self._faults_lookback_s)
+                if now_unix and self._faults_lookback_s
+                else None
+            )
+            try:
+                cluster_faults = await self._client.list_cluster_faults(
+                    since=since,
+                    page_size=self._faults_page_size,
+                )
+            except SourceUnavailable:
+                # Transport-level failure: re-raise so the DegradeRouter
+                # can count it. _get_json already wraps timeouts / 5xx
+                # into SourceUnavailable, so reaching here means the
+                # server is genuinely unreachable.
+                raise
+
         return SourceData(
             session_pods=pods,
             session_events=events,
             session_summary=summary,
+            cluster_faults=cluster_faults,
             sources_used=[self.name],
         )
 

--- a/robustness-agent/tests/test_decision_action_ladder.py
+++ b/robustness-agent/tests/test_decision_action_ladder.py
@@ -77,6 +77,51 @@ async def test_high_crash_emits_alert_plus_escalate():
     assert escalate.payload["next_action_hint"] == "revert"
 
 
+async def test_high_cluster_fault_emits_alert_plus_escalate():
+    ladder = ActionLadder()
+    out = await ladder.decide(
+        [
+            _sym(
+                "cluster_fault",
+                SymptomSeverity.HIGH,
+                summary="cluster fault on g53",
+                subject={"node": "g53", "fault": "g53-gpu_ecc"},
+                suggestion="drain g53",
+            )
+        ],
+        tick_index=0,
+        now_unix=1.0,
+    )
+    types = [i.type for i in out.intents]
+    assert IntentType.ALERT in types
+    assert IntentType.ESCALATE_STRATEGY_CHANGE in types
+    escalate = next(
+        i for i in out.intents if i.type is IntentType.ESCALATE_STRATEGY_CHANGE
+    )
+    assert escalate.payload["reason"] == "cluster_fault_high"
+    assert escalate.payload["next_action_hint"] == "drain g53"
+    assert escalate.payload["severity"] == "high"
+
+
+async def test_medium_cluster_fault_emits_alert_only():
+    ladder = ActionLadder()
+    out = await ladder.decide(
+        [
+            _sym(
+                "cluster_fault",
+                SymptomSeverity.MEDIUM,
+                summary="cluster fault on g53",
+                subject={"node": "g53", "fault": "g53-gpu_ecc"},
+            )
+        ],
+        tick_index=0,
+        now_unix=1.0,
+    )
+    types = [i.type for i in out.intents]
+    assert types == [IntentType.ALERT]
+    assert out.intents[0].payload["severity"] == "medium"
+
+
 async def test_high_agent_stall_emits_escalate_with_default_hint():
     ladder = ActionLadder()
     out = await ladder.decide(

--- a/robustness-agent/tests/test_signals_cluster_fault.py
+++ b/robustness-agent/tests/test_signals_cluster_fault.py
@@ -1,0 +1,168 @@
+"""Unit tests for ``signals/cluster_fault.py`` (M2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from robustness_agent.role.prompt_inputs import (
+    ReactorContext,
+    SharedStateSnapshot,
+)
+from robustness_agent.signals import SymptomSeverity
+from robustness_agent.signals.cluster_fault import (
+    ClusterFaultConfig,
+    evaluate_cluster_fault_signals,
+)
+from robustness_agent.sources.base import SourceData
+
+
+def _ctx() -> ReactorContext:
+    return ReactorContext(
+        tick_index=1,
+        shared_state=SharedStateSnapshot(session_id="sess-1"),
+        inbox=[],
+        now_unix=1_700_000_000.0,
+    )
+
+
+def _fault(
+    *,
+    phase: str = "Isolating",
+    name: str = "g53-gpu_ecc",
+    node: str = "g53",
+    monitor_id: str = "gpu_ecc",
+    affected_workloads: int = 1,
+    affected_gpus: int = 1,
+    auto_repair: bool = True,
+) -> dict:
+    return {
+        "name": name,
+        "monitor_id": monitor_id,
+        "node_name": node,
+        "phase": phase,
+        "auto_repair": auto_repair,
+        "affected_workload_count": affected_workloads,
+        "affected_gpu_count": affected_gpus,
+        "action": "isolate",
+        "created_at": "2026-05-09T12:00:00Z",
+    }
+
+
+def test_no_faults_yields_no_symptoms():
+    out = evaluate_cluster_fault_signals(_ctx(), SourceData(cluster_faults=[]))
+    assert out == []
+
+
+def test_succeeded_phase_is_silent():
+    """Auto-repair completed -> no agent action expected."""
+
+    data = SourceData(cluster_faults=[_fault(phase="Succeeded")])
+    out = evaluate_cluster_fault_signals(_ctx(), data)
+    assert out == []
+
+
+def test_isolating_low_blast_radius_is_medium():
+    data = SourceData(
+        cluster_faults=[
+            _fault(phase="Isolating", affected_workloads=1, affected_gpus=2)
+        ]
+    )
+    out = evaluate_cluster_fault_signals(_ctx(), data)
+    assert len(out) == 1
+    assert out[0].name == "cluster_fault"
+    assert out[0].severity is SymptomSeverity.MEDIUM
+    assert out[0].source == "server"
+    assert out[0].subject == {"node": "g53", "fault": "g53-gpu_ecc"}
+    assert out[0].evidence["phase"] == "Isolating"
+    assert out[0].evidence["affected_workload_count"] == 1
+
+
+def test_failed_phase_is_high_regardless_of_blast_radius():
+    data = SourceData(
+        cluster_faults=[
+            _fault(phase="Failed", affected_workloads=0, affected_gpus=0)
+        ]
+    )
+    out = evaluate_cluster_fault_signals(_ctx(), data)
+    assert len(out) == 1
+    assert out[0].severity is SymptomSeverity.HIGH
+    assert "auto-repair failed" in out[0].suggestion.lower()
+
+
+def test_isolating_promotes_to_high_on_workload_threshold():
+    cfg = ClusterFaultConfig(high_workload_threshold=4)
+    data = SourceData(
+        cluster_faults=[
+            _fault(phase="Isolating", affected_workloads=4, affected_gpus=1)
+        ]
+    )
+    out = evaluate_cluster_fault_signals(_ctx(), data, config=cfg)
+    assert out[0].severity is SymptomSeverity.HIGH
+
+
+def test_isolating_promotes_to_high_on_gpu_threshold():
+    cfg = ClusterFaultConfig(high_gpu_threshold=8)
+    data = SourceData(
+        cluster_faults=[
+            _fault(phase="Isolating", affected_workloads=1, affected_gpus=8)
+        ]
+    )
+    out = evaluate_cluster_fault_signals(_ctx(), data, config=cfg)
+    assert out[0].severity is SymptomSeverity.HIGH
+
+
+def test_unknown_phase_is_ignored():
+    """Future phases the upstream might add should not throw."""
+
+    data = SourceData(cluster_faults=[_fault(phase="DraftAdded")])
+    out = evaluate_cluster_fault_signals(_ctx(), data)
+    assert out == []
+
+
+def test_non_dict_entries_are_skipped():
+    data = SourceData(cluster_faults=["not a dict", None, _fault()])  # type: ignore[list-item]
+    out = evaluate_cluster_fault_signals(_ctx(), data)
+    assert len(out) == 1
+    assert out[0].evidence["fault_name"] == "g53-gpu_ecc"
+
+
+def test_string_counts_are_coerced():
+    """robust-api emits ints, but be defensive against str-typed envs."""
+
+    fault = _fault(phase="Isolating", affected_gpus=1)
+    fault["affected_workload_count"] = "5"  # promote to high via string
+    data = SourceData(cluster_faults=[fault])
+    out = evaluate_cluster_fault_signals(
+        _ctx(), data, config=ClusterFaultConfig(high_workload_threshold=4)
+    )
+    assert len(out) == 1
+    assert out[0].severity is SymptomSeverity.HIGH
+
+
+def test_multiple_faults_each_yield_one_symptom():
+    data = SourceData(
+        cluster_faults=[
+            _fault(name="g53-gpu_ecc", node="g53", phase="Isolating"),
+            _fault(name="g54-net_drop", node="g54", phase="Failed"),
+        ]
+    )
+    out = evaluate_cluster_fault_signals(_ctx(), data)
+    assert len(out) == 2
+    keys = {s.subject["fault"] for s in out}
+    assert keys == {"g53-gpu_ecc", "g54-net_drop"}
+
+
+def test_classifier_includes_cluster_fault_rule():
+    """Make sure the rule is wired into the central classifier."""
+
+    from robustness_agent.signals import Classifier
+
+    clf = Classifier()
+    data = SourceData(
+        cluster_faults=[
+            _fault(phase="Failed", affected_workloads=0, affected_gpus=0)
+        ]
+    )
+    out = clf.classify(data, _ctx())
+    names = [s.name for s in out]
+    assert "cluster_fault" in names

--- a/robustness-agent/tests/test_sources_cluster_decoder.py
+++ b/robustness-agent/tests/test_sources_cluster_decoder.py
@@ -1,0 +1,303 @@
+"""Unit tests for ``sources/cluster_decoder.py`` (M2.5)."""
+
+from __future__ import annotations
+
+from robustness_agent.sources.cluster_decoder import (
+    decode_gpu_snapshot,
+    merge_gpu_snapshots,
+)
+
+
+def _series(labels, values):
+    return {"labels": labels, "values": values}
+
+
+def _result(name, *, category="gpu", unit="C", series=()):
+    return {
+        "name": name,
+        "category": category,
+        "unit": unit,
+        "series": list(series),
+    }
+
+
+def _pod(ns, name, *, results=()):
+    return {"namespace": ns, "name": name, "results": list(results)}
+
+
+def _response(*, pods=()):
+    return {"data": {"pods": list(pods)}}
+
+
+def test_decode_returns_empty_on_garbage():
+    assert decode_gpu_snapshot(None) == {}
+    assert decode_gpu_snapshot({}) == {}
+    assert decode_gpu_snapshot({"data": {}}) == {}
+    assert decode_gpu_snapshot({"data": {"pods": "wat"}}) == {}
+
+
+def test_decode_picks_latest_value_per_metric():
+    """Multiple samples per series -> only the latest one wins."""
+
+    response = _response(
+        pods=[
+            _pod(
+                "ns1",
+                "podA",
+                results=[
+                    _result(
+                        "rocm_temperature_celsius",
+                        series=[
+                            _series(
+                                {"gpu": "0"},
+                                [
+                                    {"timestamp": 1, "value": 70.0},
+                                    {"timestamp": 5, "value": 95.0},
+                                    {"timestamp": 3, "value": 80.0},
+                                ],
+                            )
+                        ],
+                    )
+                ],
+            )
+        ]
+    )
+    out = decode_gpu_snapshot(response)
+    assert out["tool"] == "robust-api"
+    assert len(out["gpus"]) == 1
+    snap = out["gpus"][0]
+    assert snap["gpu_id"] == 0
+    assert snap["temperature_c"] == 95.0
+    assert snap["pod_namespace"] == "ns1"
+    assert snap["pod_name"] == "podA"
+
+
+def test_decode_merges_metrics_per_gpu():
+    """Same gpu_id, multiple metric kinds -> single snapshot row."""
+
+    response = _response(
+        pods=[
+            _pod(
+                "ns1",
+                "podA",
+                results=[
+                    _result(
+                        "rocm_temperature_celsius",
+                        series=[
+                            _series(
+                                {"gpu": "0"},
+                                [{"timestamp": 10, "value": 92.0}],
+                            )
+                        ],
+                    ),
+                    _result(
+                        "rocm_gpu_utilization",
+                        series=[
+                            _series(
+                                {"gpu": "0"},
+                                [{"timestamp": 10, "value": 87.5}],
+                            )
+                        ],
+                    ),
+                    _result(
+                        "rocm_power_average_watts",
+                        series=[
+                            _series(
+                                {"gpu": "0"},
+                                [{"timestamp": 10, "value": 250.0}],
+                            )
+                        ],
+                    ),
+                ],
+            )
+        ]
+    )
+    out = decode_gpu_snapshot(response)
+    assert len(out["gpus"]) == 1
+    snap = out["gpus"][0]
+    assert snap["temperature_c"] == 92.0
+    assert snap["util_gpu_pct"] == 87.5
+    assert snap["power_watts"] == 250.0
+
+
+def test_decode_handles_dcgm_metric_names():
+    response = _response(
+        pods=[
+            _pod(
+                "ns1",
+                "gpu-pod",
+                results=[
+                    _result(
+                        "DCGM_FI_DEV_GPU_TEMP",
+                        series=[
+                            _series(
+                                {"DCGM_FI_DRIVER_DEVICE_ID": "3"},
+                                [{"timestamp": 50, "value": 88.0}],
+                            )
+                        ],
+                    )
+                ],
+            )
+        ]
+    )
+    out = decode_gpu_snapshot(response)
+    assert out["gpus"][0]["gpu_id"] == 3
+    assert out["gpus"][0]["temperature_c"] == 88.0
+
+
+def test_decode_keeps_string_id_when_label_is_not_numeric():
+    response = _response(
+        pods=[
+            _pod(
+                "ns1",
+                "p1",
+                results=[
+                    _result(
+                        "rocm_temperature_celsius",
+                        series=[
+                            _series(
+                                {"device": "amdgpu0"},
+                                [{"timestamp": 1, "value": 60.0}],
+                            )
+                        ],
+                    )
+                ],
+            )
+        ]
+    )
+    out = decode_gpu_snapshot(response)
+    assert out["gpus"][0]["gpu_id"] == "amdgpu0"
+
+
+def test_decode_distinguishes_pods_with_overlapping_gpu_ids():
+    response = _response(
+        pods=[
+            _pod(
+                "ns1",
+                "podA",
+                results=[
+                    _result(
+                        "rocm_temperature_celsius",
+                        series=[
+                            _series(
+                                {"gpu": "0"},
+                                [{"timestamp": 1, "value": 80.0}],
+                            )
+                        ],
+                    )
+                ],
+            ),
+            _pod(
+                "ns1",
+                "podB",
+                results=[
+                    _result(
+                        "rocm_temperature_celsius",
+                        series=[
+                            _series(
+                                {"gpu": "0"},
+                                [{"timestamp": 1, "value": 95.0}],
+                            )
+                        ],
+                    )
+                ],
+            ),
+        ]
+    )
+    out = decode_gpu_snapshot(response)
+    assert len(out["gpus"]) == 2
+    by_pod = {r["pod_name"]: r["temperature_c"] for r in out["gpus"]}
+    assert by_pod == {"podA": 80.0, "podB": 95.0}
+
+
+def test_decode_skips_unknown_metrics():
+    response = _response(
+        pods=[
+            _pod(
+                "ns1",
+                "podA",
+                results=[
+                    _result(
+                        "vendor_specific_unknown_metric",
+                        series=[
+                            _series({"gpu": "0"}, [{"timestamp": 1, "value": 1.0}])
+                        ],
+                    )
+                ],
+            )
+        ]
+    )
+    assert decode_gpu_snapshot(response) == {}
+
+
+def test_decode_skips_series_without_values():
+    response = _response(
+        pods=[
+            _pod(
+                "ns1",
+                "podA",
+                results=[
+                    _result(
+                        "rocm_temperature_celsius",
+                        series=[_series({"gpu": "0"}, [])],
+                    )
+                ],
+            )
+        ]
+    )
+    assert decode_gpu_snapshot(response) == {}
+
+
+def test_merge_combines_multiple_pod_snapshots_in_stable_order():
+    snap1 = decode_gpu_snapshot(
+        _response(
+            pods=[
+                _pod(
+                    "ns2",
+                    "podZ",
+                    results=[
+                        _result(
+                            "rocm_temperature_celsius",
+                            series=[
+                                _series(
+                                    {"gpu": "0"},
+                                    [{"timestamp": 1, "value": 80.0}],
+                                )
+                            ],
+                        )
+                    ],
+                )
+            ]
+        )
+    )
+    snap2 = decode_gpu_snapshot(
+        _response(
+            pods=[
+                _pod(
+                    "ns1",
+                    "podA",
+                    results=[
+                        _result(
+                            "rocm_temperature_celsius",
+                            series=[
+                                _series(
+                                    {"gpu": "0"},
+                                    [{"timestamp": 1, "value": 90.0}],
+                                )
+                            ],
+                        )
+                    ],
+                )
+            ]
+        )
+    )
+    merged = merge_gpu_snapshots([snap1, snap2])
+    assert merged["tool"] == "robust-api"
+    keys = [(g["pod_namespace"], g["pod_name"], g["gpu_id"]) for g in merged["gpus"]]
+    # ns1 / podA should sort before ns2 / podZ even though it was decoded second.
+    assert keys == [("ns1", "podA", 0), ("ns2", "podZ", 0)]
+
+
+def test_merge_returns_empty_when_no_snapshots_have_gpus():
+    assert merge_gpu_snapshots([]) == {}
+    assert merge_gpu_snapshots([{}, {"tool": "x"}, {"gpus": []}]) == {}

--- a/robustness-agent/tests/test_sources_server_client.py
+++ b/robustness-agent/tests/test_sources_server_client.py
@@ -218,3 +218,224 @@ async def test_source_skips_summary_when_now_unix_is_zero():
         await client.aclose()
     assert "/api/v1/sessions/sess-1/summary" not in requested_paths
     assert data.session_summary == {}
+
+
+# ---------------------------------------------------------------------------
+# M2: cluster proxy methods + RobustnessServerSource cluster_faults fetch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_cluster_pod_metrics_forwards_window_and_categories():
+    seen: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        seen["query"] = str(request.url.query)
+        return httpx.Response(200, json={"data": {"pods": []}})
+
+    client = _client(handler)
+    from robustness_agent.sources.server_client import _MetricsWindow
+
+    try:
+        body = await client.get_cluster_pod_metrics(
+            "ns1",
+            "podA",
+            _MetricsWindow(start_unix=100, end_unix=200),
+            categories=["gpu"],
+            step="15s",
+        )
+    finally:
+        await client.aclose()
+    assert seen["path"] == "/api/v1/cluster/pods/ns1/podA/metrics"
+    assert "start=100" in seen["query"] and "end=200" in seen["query"]
+    assert "step=15s" in seen["query"]
+    assert "categories=gpu" in seen["query"]
+    assert body == {"data": {"pods": []}}
+
+
+@pytest.mark.asyncio
+async def test_list_cluster_pod_metric_categories_unwraps_available():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "namespace": "ns1",
+                "name": "podA",
+                "available": [{"name": "gpu_temp", "category": "gpu"}],
+            },
+        )
+
+    client = _client(handler)
+    from robustness_agent.sources.server_client import _MetricsWindow
+
+    try:
+        out = await client.list_cluster_pod_metric_categories(
+            "ns1", "podA", _MetricsWindow(start_unix=10, end_unix=20)
+        )
+    finally:
+        await client.aclose()
+    assert out == [{"name": "gpu_temp", "category": "gpu"}]
+
+
+@pytest.mark.asyncio
+async def test_get_cluster_workload_hierarchy_returns_dict():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "workload_id": "wl-1",
+                "pods": [{"namespace": "ns1", "name": "podA"}],
+            },
+        )
+
+    client = _client(handler)
+    try:
+        body = await client.get_cluster_workload_hierarchy("wl-1")
+    finally:
+        await client.aclose()
+    assert body == {
+        "workload_id": "wl-1",
+        "pods": [{"namespace": "ns1", "name": "podA"}],
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_cluster_faults_forwards_filters_and_unwraps():
+    seen: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        seen["query"] = str(request.url.query)
+        return httpx.Response(
+            200,
+            json={
+                "faults": [{"name": "g1-ecc", "phase": "Isolating"}],
+                "total_count": 1,
+            },
+        )
+
+    client = _client(handler)
+    try:
+        faults = await client.list_cluster_faults(
+            since="1700000000", node="g1", phase="Isolating", page_size=100
+        )
+    finally:
+        await client.aclose()
+    assert seen["path"] == "/api/v1/cluster/faults"
+    assert "since=1700000000" in seen["query"]
+    assert "node=g1" in seen["query"]
+    assert "phase=Isolating" in seen["query"]
+    assert "page_size=100" in seen["query"]
+    assert faults == [{"name": "g1-ecc", "phase": "Isolating"}]
+
+
+@pytest.mark.asyncio
+async def test_list_cluster_faults_handles_bare_array_response():
+    """Be tolerant of older robust-api builds that return a list."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[{"name": "g1-ecc"}, {"name": "g2-ecc"}])
+
+    client = _client(handler)
+    try:
+        faults = await client.list_cluster_faults()
+    finally:
+        await client.aclose()
+    assert faults == [{"name": "g1-ecc"}, {"name": "g2-ecc"}]
+
+
+@pytest.mark.asyncio
+async def test_source_fetch_populates_cluster_faults():
+    """The Source adapter calls /cluster/faults and surfaces them."""
+
+    paths_hit: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        paths_hit.append(request.url.path)
+        if "/sessions/sess-1/pods" in request.url.path:
+            return httpx.Response(200, json=[])
+        if "/sessions/sess-1/events" in request.url.path:
+            return httpx.Response(200, json={"events": []})
+        if "/sessions/sess-1/summary" in request.url.path:
+            return httpx.Response(200, json={})
+        if request.url.path == "/api/v1/cluster/faults":
+            return httpx.Response(
+                200,
+                json={
+                    "faults": [
+                        {
+                            "name": "g53-gpu_ecc",
+                            "monitor_id": "gpu_ecc",
+                            "node_name": "g53",
+                            "phase": "Isolating",
+                            "auto_repair": True,
+                            "affected_workload_count": 2,
+                            "affected_gpu_count": 4,
+                        }
+                    ],
+                    "total_count": 1,
+                },
+            )
+        return httpx.Response(404)
+
+    client = _client(handler)
+    try:
+        source = RobustnessServerSource(client)
+        data = await source.fetch(_ctx())
+    finally:
+        await client.aclose()
+
+    assert "/api/v1/cluster/faults" in paths_hit
+    assert len(data.cluster_faults) == 1
+    assert data.cluster_faults[0]["phase"] == "Isolating"
+    assert data.sources_used == ["robustness-server"]
+
+
+@pytest.mark.asyncio
+async def test_source_propagates_cluster_faults_5xx_as_source_unavailable():
+    """A 5xx on /cluster/faults must trigger DegradeRouter, not be swallowed."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "/sessions/sess-1/pods" in request.url.path:
+            return httpx.Response(200, json=[])
+        if "/sessions/sess-1/events" in request.url.path:
+            return httpx.Response(200, json={"events": []})
+        if "/sessions/sess-1/summary" in request.url.path:
+            return httpx.Response(200, json={})
+        if request.url.path == "/api/v1/cluster/faults":
+            return httpx.Response(503, json={"detail": "robust-api down"})
+        return httpx.Response(404)
+
+    client = _client(handler)
+    try:
+        source = RobustnessServerSource(client)
+        with pytest.raises(SourceUnavailable):
+            await source.fetch(_ctx())
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_source_can_disable_cluster_faults():
+    paths_hit: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        paths_hit.append(request.url.path)
+        if "/sessions/sess-1/pods" in request.url.path:
+            return httpx.Response(200, json=[])
+        if "/sessions/sess-1/events" in request.url.path:
+            return httpx.Response(200, json={"events": []})
+        if "/sessions/sess-1/summary" in request.url.path:
+            return httpx.Response(200, json={})
+        return httpx.Response(404)
+
+    client = _client(handler)
+    try:
+        source = RobustnessServerSource(client, enable_cluster_faults=False)
+        data = await source.fetch(_ctx())
+    finally:
+        await client.aclose()
+
+    assert "/api/v1/cluster/faults" not in paths_hit
+    assert data.cluster_faults == []

--- a/robustness-agent/tests/test_sources_server_client.py
+++ b/robustness-agent/tests/test_sources_server_client.py
@@ -439,3 +439,258 @@ async def test_source_can_disable_cluster_faults():
 
     assert "/api/v1/cluster/faults" not in paths_hit
     assert data.cluster_faults == []
+
+
+# ---------------------------------------------------------------------------
+# M2.5: cluster pod metrics fan-out -> SourceData.local_gpu
+# ---------------------------------------------------------------------------
+
+
+def _gpu_metric_response(value: float, *, gpu_id: str = "0", ts: int = 100):
+    """Build a robust-api-shaped pod-metrics response for one GPU."""
+
+    return {
+        "data": {
+            "pods": [
+                {
+                    "namespace": "ns1",
+                    "name": "podA",
+                    "results": [
+                        {
+                            "name": "rocm_temperature_celsius",
+                            "category": "gpu",
+                            "unit": "C",
+                            "series": [
+                                {
+                                    "labels": {"gpu": gpu_id},
+                                    "values": [
+                                        {"timestamp": ts, "value": value}
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_source_disables_cluster_pod_metrics_by_default():
+    """The fan-out costs one HTTP call per pod; default off."""
+
+    paths_hit: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        paths_hit.append(request.url.path)
+        if "/sessions/sess-1/pods" in request.url.path:
+            return httpx.Response(
+                200,
+                json=[{"pod": {"namespace": "ns1", "name": "podA"}}],
+            )
+        if "/sessions/sess-1/events" in request.url.path:
+            return httpx.Response(200, json={"events": []})
+        if "/sessions/sess-1/summary" in request.url.path:
+            return httpx.Response(200, json={})
+        if request.url.path == "/api/v1/cluster/faults":
+            return httpx.Response(200, json={"faults": []})
+        return httpx.Response(404)
+
+    client = _client(handler)
+    try:
+        source = RobustnessServerSource(client)
+        data = await source.fetch(_ctx())
+    finally:
+        await client.aclose()
+
+    assert not any("/cluster/pods/" in p for p in paths_hit)
+    assert data.local_gpu == {}
+
+
+@pytest.mark.asyncio
+async def test_source_fans_out_pod_metrics_when_enabled():
+    """With enable_cluster_pod_metrics=True, fetch hits /cluster/pods/{ns}/{name}/metrics."""
+
+    paths_hit: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        paths_hit.append(request.url.path)
+        if "/sessions/sess-1/pods" in request.url.path:
+            return httpx.Response(
+                200,
+                json=[{"pod": {"namespace": "ns1", "name": "podA"}}],
+            )
+        if "/sessions/sess-1/events" in request.url.path:
+            return httpx.Response(200, json={"events": []})
+        if "/sessions/sess-1/summary" in request.url.path:
+            return httpx.Response(200, json={})
+        if request.url.path == "/api/v1/cluster/faults":
+            return httpx.Response(200, json={"faults": []})
+        if request.url.path == "/api/v1/cluster/pods/ns1/podA/metrics":
+            return httpx.Response(200, json=_gpu_metric_response(95.0))
+        return httpx.Response(404)
+
+    client = _client(handler)
+    try:
+        source = RobustnessServerSource(client, enable_cluster_pod_metrics=True)
+        data = await source.fetch(_ctx())
+    finally:
+        await client.aclose()
+
+    assert "/api/v1/cluster/pods/ns1/podA/metrics" in paths_hit
+    assert data.local_gpu["tool"] == "robust-api"
+    assert len(data.local_gpu["gpus"]) == 1
+    assert data.local_gpu["gpus"][0]["temperature_c"] == 95.0
+    assert data.local_gpu["gpus"][0]["pod_name"] == "podA"
+
+
+@pytest.mark.asyncio
+async def test_source_pod_metrics_5xx_propagates_for_degrade():
+    """Transport / 5xx on cluster metrics still triggers DegradeRouter."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "/sessions/sess-1/pods" in request.url.path:
+            return httpx.Response(
+                200,
+                json=[{"pod": {"namespace": "ns1", "name": "podA"}}],
+            )
+        if "/sessions/sess-1/events" in request.url.path:
+            return httpx.Response(200, json={"events": []})
+        if "/sessions/sess-1/summary" in request.url.path:
+            return httpx.Response(200, json={})
+        if request.url.path == "/api/v1/cluster/faults":
+            return httpx.Response(200, json={"faults": []})
+        if request.url.path == "/api/v1/cluster/pods/ns1/podA/metrics":
+            return httpx.Response(503, text="busy")
+        return httpx.Response(404)
+
+    client = _client(handler)
+    try:
+        source = RobustnessServerSource(client, enable_cluster_pod_metrics=True)
+        with pytest.raises(SourceUnavailable):
+            await source.fetch(_ctx())
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_source_pod_metrics_dedups_repeated_pod_refs():
+    """Same pod appearing twice in session_pods should fan out once."""
+
+    seen_metrics_paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "/sessions/sess-1/pods" in request.url.path:
+            return httpx.Response(
+                200,
+                json=[
+                    {"pod": {"namespace": "ns1", "name": "podA"}},
+                    {"pod": {"namespace": "ns1", "name": "podA"}},
+                    {"pod": {"namespace": "ns1", "name": "podB"}},
+                ],
+            )
+        if "/sessions/sess-1/events" in request.url.path:
+            return httpx.Response(200, json={"events": []})
+        if "/sessions/sess-1/summary" in request.url.path:
+            return httpx.Response(200, json={})
+        if request.url.path == "/api/v1/cluster/faults":
+            return httpx.Response(200, json={"faults": []})
+        if "/api/v1/cluster/pods/" in request.url.path:
+            seen_metrics_paths.append(request.url.path)
+            return httpx.Response(200, json=_gpu_metric_response(80.0))
+        return httpx.Response(404)
+
+    client = _client(handler)
+    try:
+        source = RobustnessServerSource(client, enable_cluster_pod_metrics=True)
+        await source.fetch(_ctx())
+    finally:
+        await client.aclose()
+
+    assert sorted(seen_metrics_paths) == [
+        "/api/v1/cluster/pods/ns1/podA/metrics",
+        "/api/v1/cluster/pods/ns1/podB/metrics",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_source_pod_metrics_caps_fan_out_per_tick():
+    """Sessions with too many pods must not blow the per-tick budget."""
+
+    metrics_calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal metrics_calls
+        if "/sessions/sess-1/pods" in request.url.path:
+            return httpx.Response(
+                200,
+                json=[
+                    {"pod": {"namespace": "ns1", "name": f"pod-{i:02d}"}}
+                    for i in range(10)
+                ],
+            )
+        if "/sessions/sess-1/events" in request.url.path:
+            return httpx.Response(200, json={"events": []})
+        if "/sessions/sess-1/summary" in request.url.path:
+            return httpx.Response(200, json={})
+        if request.url.path == "/api/v1/cluster/faults":
+            return httpx.Response(200, json={"faults": []})
+        if "/api/v1/cluster/pods/" in request.url.path:
+            metrics_calls += 1
+            return httpx.Response(200, json=_gpu_metric_response(80.0))
+        return httpx.Response(404)
+
+    client = _client(handler)
+    try:
+        source = RobustnessServerSource(
+            client,
+            enable_cluster_pod_metrics=True,
+            max_pods_per_tick=3,
+        )
+        await source.fetch(_ctx())
+    finally:
+        await client.aclose()
+
+    assert metrics_calls == 3
+
+
+@pytest.mark.asyncio
+async def test_server_pod_metrics_drive_local_health_gpu_signal():
+    """End-to-end: server-decoded GPU >= warn threshold fires gpu_thermal_high."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "/sessions/sess-1/pods" in request.url.path:
+            return httpx.Response(
+                200,
+                json=[{"pod": {"namespace": "ns1", "name": "podA"}}],
+            )
+        if "/sessions/sess-1/events" in request.url.path:
+            return httpx.Response(200, json={"events": []})
+        if "/sessions/sess-1/summary" in request.url.path:
+            return httpx.Response(200, json={})
+        if request.url.path == "/api/v1/cluster/faults":
+            return httpx.Response(200, json={"faults": []})
+        if request.url.path == "/api/v1/cluster/pods/ns1/podA/metrics":
+            # 95 C  -> warn (>= 90) but below crit (100) -> medium
+            return httpx.Response(200, json=_gpu_metric_response(95.0))
+        return httpx.Response(404)
+
+    client = _client(handler)
+    try:
+        source = RobustnessServerSource(client, enable_cluster_pod_metrics=True)
+        data = await source.fetch(_ctx())
+    finally:
+        await client.aclose()
+
+    from robustness_agent.signals import (
+        Classifier,
+        SymptomSeverity,
+    )
+
+    classifier = Classifier()
+    symptoms = classifier.classify(data, _ctx())
+    thermal = [s for s in symptoms if s.name == "gpu_thermal_high"]
+    assert len(thermal) == 1
+    assert thermal[0].severity is SymptomSeverity.MEDIUM
+    assert thermal[0].evidence["temperature_c"] == 95.0


### PR DESCRIPTION
## Summary

Wires the `robustness-agent` to the M2 cluster-proxy endpoints exposed by `robustness-server` (Primus-Claw side). Two milestones land together:

- **M2 (commit ``e4e4b48``)**: cluster-fault signal. The agent pulls ``/cluster/faults?since=now-300s`` every tick, fans the response into a new ``cluster_fault`` symptom kind, and escalates to ``ESCALATE_STRATEGY_CHANGE`` on high blast radius.
- **M2.5 (commit ``7024103``)**: cluster GPU thermal. When ``enable_cluster_pod_metrics`` is on, the agent fans out to ``/cluster/pods/{ns}/{name}/metrics`` for the session's pods, decodes the Prometheus-style response into the existing ``LocalProbe`` ``local_gpu`` schema, and merges it into ``SourceData.local_gpu`` so the existing thermal signals fire transparently — no signal logic duplication.

## What changed

### Sources
- `sources/server_client.py`
  - 4 new client methods: `get_cluster_pod_metrics`, `list_cluster_pod_metric_categories`, `get_cluster_workload_hierarchy`, `list_cluster_faults` mirror the server's M2 routes.
  - `RobustnessServerSource.fetch` now pulls `cluster_faults` with a 300s `since` window; populates `SourceData.cluster_faults`.
  - Adds `enable_cluster_pod_metrics` (default **off** for safe rollout), `pod_metrics_categories`, `max_pods_per_tick`. When on, dedupes pod refs across the session and merges the decoded snapshot into `local_gpu` (preferring server data over local probes).
- `sources/cluster_decoder.py` (new): `decode_gpu_snapshot` + `merge_gpu_snapshots`. Tolerates rocm-smi / DCGM / generic metric naming conventions and several `gpu_id` / `gpu` / `device` label spellings; latest-value selection per (gpu_id, metric); pod-isolated then stable-merged.

### Signals + decision
- `signals/cluster_fault.py` (new): `Failed` -> HIGH; `Isolating` MEDIUM by default but HIGH if `affected_workload_count >= 4` or `affected_gpu_count >= 8`; `Succeeded` is silent.
- `signals/__init__.py` + `signals/classifier.py`: register and compose the new evaluator with de-dup.
- `decision/action_ladder.py`: high-severity `cluster_fault` symptoms produce `build_escalate(reason='cluster_fault_high', ...)` in addition to the standard alert.

### Tests (37 new, total 250 green, zero regressions vs. 213 baseline)
- `tests/test_signals_cluster_fault.py` (new): phase x blast-radius matrix, classifier integration.
- `tests/test_sources_cluster_decoder.py` (new, 10): metric / gpu-id naming variants, garbage tolerance, latest-value selection, pod isolation, stable merge ordering.
- `tests/test_sources_server_client.py`: cluster_* client coverage, `Source.fetch` cluster_faults path, M2.5 fan-out + dedup + `max_pods_per_tick` cap, end-to-end ``gpu_thermal_high`` via server-decoded GPU temp.
- `tests/test_decision_action_ladder.py`: high vs. medium `cluster_fault` -> alert+escalate vs. alert-only.

## Test plan

- [x] `pytest robustness-agent/tests` 250 passed.
- [x] In-process E2E smoke against fake ``robust-api`` -> robustness-server -> agent (`~/robustness/smoke/smoke_m2.py`) emits 4 alerts (2 high cluster-fault + thermal, 2 medium) and 1 escalate (`cluster_fault_high`).
- [ ] Live soak once Primus-Claw side lands and the cluster has GPU pods reporting.

## Rollout

- M2 cluster-fault is on by default (low cost, no flag).
- M2.5 cluster pod metrics is **gated** behind `enable_cluster_pod_metrics`; recommend turning on per-cluster after Primus-Claw side ships.

## Dependencies

- Server-side M2 endpoints: [AMD-AGI/Primus-Claw] M2.B PR.
- Upstream ``since`` filter: [AMD-AGI/Primus-Robust-Internal] M2.A PR. The agent passes `since` regardless; old `robust-api` builds ignore the param (the server proxy is forward-compatible).

Made with [Cursor](https://cursor.com)