### PR TITLE
feat(ci): normalize and publish Hyperloom optimization results

### DIFF
--- a/.cursor/skills/inference-optimization/actions/report.md
+++ b/.cursor/skills/inference-optimization/actions/report.md
@@ -99,3 +99,44 @@ How to compute:
 - `gain_pct` = `(optimized - baseline) / baseline * 100`
 
 The CI parser requires these exact six field names. Missing or renamed fields → N/A.
+
+### Auto-publish normalized results
+
+After `optimization_report.md` and any available `ci_metrics.json` are written,
+always attempt to normalize and publish the result directory. This is non-fatal:
+if the results service is not reachable, keep the normalized files and continue
+the final report normally.
+
+```bash
+HYPERLOOM_REPO="${HYPERLOOM_REPO:-}"
+if [ -z "$HYPERLOOM_REPO" ]; then
+  for candidate in \
+    /workspace/Hyperloom \
+    /wekafs/hyperloom/Hyperloom \
+    /wekafs/zgong/Hyperloom \
+    /opt/hyperloom; do
+    if [ -f "$candidate/ci/publish_artifacts.py" ]; then
+      HYPERLOOM_REPO="$candidate"
+      break
+    fi
+  done
+fi
+
+if [ -n "$HYPERLOOM_REPO" ]; then
+  python3 "$HYPERLOOM_REPO/ci/publish_artifacts.py" \
+    --task-dir "${WORK_DIR:-/workspace/hyperloom}" \
+    --out-dir "${WORK_DIR:-/workspace/hyperloom}/normalized" \
+    --model "${MODEL_NAME:-${MODEL:-unknown}}" \
+    --display-name "${DISPLAY_NAME:-hyperloom-auto-publish}" || true
+else
+  echo "Hyperloom publish_artifacts.py not found; skipping result publish"
+fi
+```
+
+Default publish target:
+
+```text
+http://hyperloom-results-service.primus-claw-dev.svc.cluster.local
+```
+
+Override with `HYPERLOOM_RESULTS_SERVICE_URL` if needed.

--- a/ci/artifact_normalizer.py
+++ b/ci/artifact_normalizer.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""Normalize Hyperloom optimization artifacts into a stable data shape.
+
+This module is intentionally entrypoint-agnostic: GitHub CI, the Hyperloom web
+UI, or a manual local import can all hand it a downloaded artifact directory.
+It turns loose result files into one JSON object per optimization task so later
+steps can summarize, upload, or publish without parsing markdown.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import logging
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger("artifact-normalizer")
+
+SCHEMA_VERSION = "hyperloom.ci.normalized.v1"
+
+
+def _read_json(path: Path | None, warnings: list[str]) -> Any | None:
+    if not path:
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as e:
+        warnings.append(f"failed to parse {path.name}: {e}")
+        return None
+
+
+def _to_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    text = str(value).strip().replace(",", "")
+    if not text or text.upper() == "SKIPPED":
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def _to_int(value: Any) -> int | None:
+    number = _to_float(value)
+    return int(number) if number is not None else None
+
+
+def _first_of(data: dict[str, Any], *keys: str) -> Any | None:
+    for key in keys:
+        if data.get(key) is not None:
+            return data[key]
+    return None
+
+
+def _relative(path: Path | None, root: Path) -> str | None:
+    if path is None:
+        return None
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def find_artifact(root: Path, *tails: str) -> Path | None:
+    """Find the first file whose relative path ends with one of ``tails``."""
+    if not root.exists():
+        return None
+    normalized = tuple(t.replace("\\", "/").lower().lstrip("/") for t in tails)
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(root).as_posix().lower()
+        name = path.name.lower()
+        if any(rel.endswith(tail) or name == tail for tail in normalized):
+            return path
+    return None
+
+
+def parse_env_file(path: Path | None) -> dict[str, str]:
+    if not path or not path.exists():
+        return {}
+    values: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip().strip("'").strip('"')
+    return values
+
+
+def parse_ci_metrics(data: dict[str, Any] | None) -> dict[str, Any]:
+    data = data or {}
+    baseline = _first_of(
+        data,
+        "baseline_throughput",
+        "tok_per_gpu_baseline",
+        "baseline_output_tput_per_gpu",
+        "baseline_output_tput_tok_s",
+        "baseline_tok_per_gpu",
+    )
+    optimized = _first_of(
+        data,
+        "optimized_throughput",
+        "tok_per_gpu_optimized",
+        "optimized_output_tput_per_gpu",
+        "optimized_output_tput_tok_s",
+        "optimized_tok_per_gpu",
+    )
+    gain = _first_of(data, "gain_pct", "improvement_pct", "total_improvement_pct")
+
+    metrics = {
+        "baseline_throughput": _to_float(baseline),
+        "optimized_throughput": _to_float(optimized),
+        "gain_pct": _to_float(gain),
+        "tok_per_gpu_baseline": _to_float(_first_of(data, "tok_per_gpu_baseline", "baseline_tok_per_gpu")),
+        "tok_per_gpu_optimized": _to_float(_first_of(data, "tok_per_gpu_optimized", "optimized_tok_per_gpu")),
+        "peak_throughput": _to_float(data.get("peak_throughput")),
+        "peak_throughput_conc": _to_int(data.get("peak_throughput_conc")),
+        "model": data.get("model"),
+        "framework": data.get("framework"),
+        "framework_version": data.get("framework_version"),
+        "gpu_type": data.get("gpu_type"),
+        "tp": _to_int(data.get("tp")),
+        "conc": _to_int(data.get("conc")),
+        "isl": _to_int(data.get("isl")),
+        "osl": _to_int(data.get("osl")),
+        "actions": data.get("actions_taken") or data.get("actions") or [],
+    }
+    if metrics["gain_pct"] is None and metrics["baseline_throughput"] and metrics["optimized_throughput"]:
+        metrics["gain_pct"] = round(
+            (metrics["optimized_throughput"] - metrics["baseline_throughput"])
+            / metrics["baseline_throughput"] * 100,
+            2,
+        )
+    return metrics
+
+
+def parse_baseline_summary(data: dict[str, Any] | None) -> dict[str, Any]:
+    data = data or {}
+    return {
+        "baseline_tput_per_gpu": _to_float(data.get("baseline_tput_per_gpu")),
+        "baseline_config": data.get("baseline_config"),
+        "torch_compile_status": data.get("torch_compile_status"),
+        "torch_compile_tput": _to_float(data.get("torch_compile_tput")),
+        "no_aiter_tput": _to_float(data.get("no_aiter_tput")),
+        "model": data.get("model"),
+        "gpu_type": data.get("gpu_type"),
+        "tp": _to_int(data.get("tp")),
+        "conc": _to_int(data.get("conc")),
+        "isl": _to_int(data.get("isl")),
+        "osl": _to_int(data.get("osl")),
+    }
+
+
+def parse_sweep_results(path: Path | None, warnings: list[str]) -> list[dict[str, Any]]:
+    if not path or not path.exists():
+        return []
+    points: list[dict[str, Any]] = []
+    try:
+        with path.open(newline="", encoding="utf-8") as f:
+            for row in csv.DictReader(f):
+                skipped = any(str(v).strip().upper() == "SKIPPED" for v in row.values())
+                points.append({
+                    "conc": _to_int(row.get("CONC")),
+                    "isl": _to_int(row.get("ISL")),
+                    "osl": _to_int(row.get("OSL")),
+                    "num_prompts": _to_int(row.get("NUM_PROMPTS")),
+                    "output_throughput_tok_s": _to_float(row.get("output_throughput_tok_s")),
+                    "mean_tpot_ms": _to_float(row.get("mean_tpot_ms")),
+                    "mean_ttft_ms": _to_float(row.get("mean_ttft_ms")),
+                    "status": "skipped" if skipped else "ok",
+                })
+    except Exception as e:
+        warnings.append(f"failed to parse sweep results: {e}")
+    return points
+
+
+def parse_kernel_candidates(data: Any) -> list[dict[str, Any]]:
+    if not isinstance(data, list):
+        return []
+    candidates: list[dict[str, Any]] = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        candidates.append({
+            "rank": _to_int(item.get("rank")),
+            "name": item.get("name"),
+            "tier": item.get("tier"),
+            "gpu_pct": _to_float(item.get("gpu_pct")),
+            "count": _to_int(item.get("count")),
+            "time_ms": _to_float(item.get("time_ms")),
+        })
+    return candidates
+
+
+def parse_kernel_results(data: dict[str, Any] | None) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    data = data or {}
+    kernels: list[dict[str, Any]] = []
+    for item in data.get("kernels") or []:
+        if not isinstance(item, dict):
+            continue
+        kernels.append({
+            "name": item.get("name"),
+            "micro_speedup": _to_float(item.get("micro_speedup")),
+            "correctness": item.get("correctness"),
+            "gpu_pct": _to_float(item.get("gpu_pct")),
+            "status": item.get("status"),
+            "note": item.get("note"),
+        })
+    summary = data.get("summary") if isinstance(data.get("summary"), dict) else {}
+    return kernels, summary
+
+
+def build_artifact_index(task_dir: Path) -> list[dict[str, Any]]:
+    artifacts: list[dict[str, Any]] = []
+    if not task_dir.exists():
+        return artifacts
+    for path in sorted(task_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(task_dir).as_posix()
+        artifacts.append({
+            "path": rel,
+            "size_bytes": path.stat().st_size,
+            "kind": classify_artifact(rel),
+        })
+    return artifacts
+
+
+def classify_artifact(path: str) -> str:
+    lower = path.lower()
+    if lower.endswith("ci_metrics.json"):
+        return "ci_metrics"
+    if lower.endswith("baseline_summary.json"):
+        return "baseline_summary"
+    if lower.endswith("sweep_results.csv"):
+        return "sweep_results"
+    if lower.endswith("kernel_candidates.json"):
+        return "kernel_candidates"
+    if lower.endswith("kernel_results.json"):
+        return "kernel_results"
+    if lower.endswith("optimization_report.md"):
+        return "optimization_report"
+    if lower.endswith("run_context.env"):
+        return "run_context"
+    if lower.endswith(".log"):
+        return "log"
+    return "artifact"
+
+
+def normalize_task_result(
+    task_dir: Path,
+    manifest_record: dict[str, Any],
+    run: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Normalize one task artifact directory.
+
+    ``manifest_record`` is just optional task metadata supplied by the caller.
+    The metrics themselves are read from files under ``task_dir``.
+    """
+    warnings: list[str] = []
+
+    ci_metrics_path = find_artifact(task_dir, "ci_metrics.json", "hyperloom/ci_metrics.json")
+    baseline_summary_path = find_artifact(task_dir, "results/baseline_summary.json", "baseline_summary.json")
+    sweep_path = find_artifact(task_dir, "results/sweep_results.csv", "sweep_results.csv")
+    kernel_candidates_path = find_artifact(task_dir, "results/kernel_candidates.json", "kernel_candidates.json")
+    kernel_results_path = find_artifact(task_dir, "kernel_opt/kernel_results.json", "kernel_results.json")
+    run_context_path = find_artifact(task_dir, "results/run_context.env", "run_context.env")
+    report_path = find_artifact(task_dir, "optimization_report.md")
+
+    ci_metrics = parse_ci_metrics(_read_json(ci_metrics_path, warnings))
+    baseline = parse_baseline_summary(_read_json(baseline_summary_path, warnings))
+    kernel_optimizations, kernel_summary = parse_kernel_results(_read_json(kernel_results_path, warnings))
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run": run or {},
+        "task": {
+            "task_id": manifest_record.get("task_id"),
+            "model": manifest_record.get("model"),
+            "display_name": manifest_record.get("display_name"),
+            "submit_status": manifest_record.get("status"),
+            "final_status": manifest_record.get("final_status"),
+            "final_phase": manifest_record.get("final_phase"),
+            "final_message": manifest_record.get("final_message"),
+            "detected": manifest_record.get("detected"),
+            "overrides": manifest_record.get("overrides") or {},
+        },
+        "metrics": ci_metrics,
+        "baseline": baseline,
+        "run_context": parse_env_file(run_context_path),
+        "sweep_points": parse_sweep_results(sweep_path, warnings),
+        "kernel_candidates": parse_kernel_candidates(_read_json(kernel_candidates_path, warnings)),
+        "kernel_optimizations": kernel_optimizations,
+        "kernel_summary": kernel_summary,
+        "artifacts": build_artifact_index(task_dir),
+        "source_files": {
+            "ci_metrics": _relative(ci_metrics_path, task_dir),
+            "baseline_summary": _relative(baseline_summary_path, task_dir),
+            "sweep_results": _relative(sweep_path, task_dir),
+            "kernel_candidates": _relative(kernel_candidates_path, task_dir),
+            "kernel_results": _relative(kernel_results_path, task_dir),
+            "run_context": _relative(run_context_path, task_dir),
+            "optimization_report": _relative(report_path, task_dir),
+        },
+        "warnings": warnings,
+    }
+
+
+def collect_normalized_results(
+    artifacts_dir: Path,
+    manifests_dir: Path,
+    run: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Normalize CI-collected artifacts using submission manifests.
+
+    This is the GitHub Actions adapter around the entrypoint-agnostic
+    ``normalize_task_result`` function.
+    """
+    results: list[dict[str, Any]] = []
+    manifest_files = sorted(manifests_dir.rglob("submission_manifest.json"))
+    if not manifest_files:
+        log.warning("no submission_manifest.json under %s", manifests_dir)
+        return results
+
+    for manifest_file in manifest_files:
+        try:
+            manifest = json.loads(manifest_file.read_text(encoding="utf-8"))
+        except Exception as e:
+            log.warning("skipping malformed manifest %s: %s", manifest_file, e)
+            continue
+        manifest_run = dict(run or {})
+        manifest_run.setdefault("submitted_at", manifest.get("submitted_at"))
+        manifest_run.setdefault("api_url", manifest.get("api_url"))
+        manifest_run.setdefault("register_workspace", manifest.get("register_workspace"))
+        manifest_run.setdefault("submit_workspace", manifest.get("submit_workspace"))
+        manifest_run.setdefault("volume", manifest.get("volume"))
+
+        for record in manifest.get("records") or []:
+            if not isinstance(record, dict):
+                continue
+            task_id = record.get("task_id")
+            task_dir = artifacts_dir / task_id if task_id else artifacts_dir / "__missing_task_id__"
+            results.append(normalize_task_result(task_dir, record, manifest_run))
+    return results
+
+
+def write_single_result(result: dict[str, Any], out_dir: Path) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "normalized_result.json").write_text(
+        json.dumps(result, indent=2),
+        encoding="utf-8",
+    )
+    (out_dir / "normalized_results.json").write_text(
+        json.dumps({"results": [result]}, indent=2),
+        encoding="utf-8",
+    )
+    (out_dir / "normalized_results.ndjson").write_text(
+        json.dumps(result, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Normalize one downloaded Hyperloom artifact directory.",
+    )
+    parser.add_argument(
+        "--task-dir",
+        required=True,
+        help="Downloaded task artifact directory, e.g. /path/to/hyperloom",
+    )
+    parser.add_argument("--out-dir", default="summary-out")
+    parser.add_argument("--task-id", default="manual-import")
+    parser.add_argument("--model", default="")
+    parser.add_argument("--display-name", default="")
+    parser.add_argument("--final-status", default="Succeeded")
+    parser.add_argument("--source", default="manual-web-import")
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    task_dir = Path(args.task_dir)
+    if not task_dir.exists():
+        print(f"task dir not found: {task_dir}", file=sys.stderr)
+        return 2
+
+    result = normalize_task_result(
+        task_dir,
+        {
+            "task_id": args.task_id,
+            "model": args.model or None,
+            "display_name": args.display_name or task_dir.name,
+            "status": "imported",
+            "final_status": args.final_status,
+        },
+        {"source": args.source},
+    )
+    write_single_result(result, Path(args.out_dir))
+    print(json.dumps({
+        "out_dir": args.out_dir,
+        "baseline": result["metrics"].get("baseline_throughput"),
+        "optimized": result["metrics"].get("optimized_throughput"),
+        "gain_pct": result["metrics"].get("gain_pct"),
+        "sweep_points": len(result.get("sweep_points") or []),
+        "kernel_candidates": len(result.get("kernel_candidates") or []),
+        "kernel_optimizations": len(result.get("kernel_optimizations") or []),
+        "warnings": result.get("warnings") or [],
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/ci/build_summary.py
+++ b/ci/build_summary.py
@@ -9,12 +9,14 @@ Inputs:
   --out-dir DIR         Where to write ci_summary.{json,md}
 
 Outputs:
-  ci_summary.md   — markdown table for $GITHUB_STEP_SUMMARY
-  ci_summary.json — structured rows for downstream tooling
+  ci_summary.md          — markdown table for $GITHUB_STEP_SUMMARY
+  ci_summary.json        — compact structured rows for downstream tooling
+  normalized_results.json / .ndjson
+                         — one normalized record per Hyperloom task
 
-Schema we accept from agent's ci_metrics.json (per skill report.md):
-  baseline_throughput, optimized_throughput, gain_pct,
-  tok_per_gpu_baseline, tok_per_gpu_optimized, actions_taken
+Main inputs parsed per task:
+  ci_metrics.json, baseline_summary.json, sweep_results.csv,
+  kernel_candidates.json, kernel_results.json, run_context.env
 """
 
 from __future__ import annotations
@@ -22,36 +24,16 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import sys
 from pathlib import Path
 
 import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from inferenceX_parser import fetch_benchmarks, find_benchmark   # noqa: E402
+from artifact_normalizer import collect_normalized_results       # noqa: E402
 
 log = logging.getLogger("build-summary")
-
-
-# ── ci_metrics.json parser ──────────────────────────────────────────────────────
-
-def parse_ci_metrics(metrics_path: Path) -> dict | None:
-    """Parse the agent-written ci_metrics.json. Returns the 6 documented fields
-    mapped to our column names, or None if the file is missing/malformed.
-    """
-    if not metrics_path.exists():
-        return None
-    try:
-        d = json.loads(metrics_path.read_text())
-    except Exception as e:
-        log.warning("failed to parse %s: %s", metrics_path, e)
-        return None
-    return {
-        "baseline_tok_per_gpu":  d.get("tok_per_gpu_baseline"),
-        "optimized_tok_per_gpu": d.get("tok_per_gpu_optimized"),
-        "gain_pct":              d.get("gain_pct"),
-        "actions":               d.get("actions_taken") or [],
-    }
 
 
 # ── InferenceX reference lookup ─────────────────────────────────────────────────
@@ -60,7 +42,7 @@ def load_hf_to_ifx_map(yaml_path: Path) -> dict[str, str]:
     """Read inferenceX_models.yaml → {hf_model: api_name}."""
     if not yaml_path.exists():
         return {}
-    cfg = yaml.safe_load(yaml_path.read_text()) or {}
+    cfg = yaml.safe_load(yaml_path.read_text(encoding="utf-8")) or {}
     return {
         m["hf_model"]: m["api_name"]
         for m in cfg.get("models", [])
@@ -86,6 +68,7 @@ def fetch_inferenceX_ref(
         log.info("[%s] no InferenceX api_name mapping; skipping ref lookup", repo_id)
         return None
     try:
+        from inferenceX_parser import fetch_benchmarks, find_benchmark
         benchmarks = fetch_benchmarks(api_name)
     except Exception as e:
         log.warning("[%s] InferenceX API failed: %s", api_name, e)
@@ -108,54 +91,68 @@ def collect_rows(
     target_gpu: str,
     isl: int,
     osl: int,
-) -> list[dict]:
+) -> tuple[list[dict], list[dict]]:
     rows: list[dict] = []
-    # Each matrix job uploaded its own submission-manifest-* artifact, so we
-    # walk all submission_manifest.json files we can find.
-    manifest_files = sorted(manifests_dir.rglob("submission_manifest.json"))
-    if not manifest_files:
-        log.warning("no submission_manifest.json under %s", manifests_dir)
-        return rows
-    log.info("found %d manifest file(s)", len(manifest_files))
+    normalized_results = collect_normalized_results(
+        artifacts_dir, manifests_dir, build_run_metadata())
 
-    for mfile in manifest_files:
-        try:
-            manifest = json.loads(mfile.read_text())
-        except Exception as e:
-            log.warning("skipping %s: %s", mfile, e)
-            continue
+    for item in normalized_results:
+        task = item.get("task") or {}
+        metrics = item.get("metrics") or {}
+        detected = task.get("detected") or {}
+        model = task.get("model")
+        row = {
+            "model": model,
+            "task_id": task.get("task_id"),
+            "display_name": task.get("display_name"),
+            "submit_status": task.get("submit_status"),
+            "final_status": task.get("final_status"),
+            "framework": metrics.get("framework") or detected.get("framework"),
+            "precision": detected.get("precision"),
+            "gpu_type": metrics.get("gpu_type"),
+            "baseline_tok_per_gpu": (
+                metrics.get("tok_per_gpu_baseline")
+                or metrics.get("baseline_throughput")
+            ),
+            "optimized_tok_per_gpu": (
+                metrics.get("tok_per_gpu_optimized")
+                or metrics.get("optimized_throughput")
+            ),
+            "gain_pct": metrics.get("gain_pct"),
+            "peak_throughput": metrics.get("peak_throughput"),
+            "peak_throughput_conc": metrics.get("peak_throughput_conc"),
+            "inferenceX_tok_per_gpu": None,
+            "vs_inferenceX_pct": None,
+            "actions": metrics.get("actions") or [],
+            "sweep_points": len(item.get("sweep_points") or []),
+            "kernel_candidates": len(item.get("kernel_candidates") or []),
+            "kernel_optimizations": len(item.get("kernel_optimizations") or []),
+            "artifacts": len(item.get("artifacts") or []),
+            "warnings": item.get("warnings") or [],
+        }
 
-        for rec in manifest.get("records", []):
-            row = {
-                "model":                rec.get("model"),
-                "task_id":              rec.get("task_id"),
-                "display_name":         rec.get("display_name"),
-                "submit_status":        rec.get("status"),
-                "final_status":         rec.get("final_status"),
-                "baseline_tok_per_gpu":  None,
-                "optimized_tok_per_gpu": None,
-                "gain_pct":              None,
-                "inferenceX_tok_per_gpu": None,
-                "vs_inferenceX_pct":     None,
-                "actions":               [],
-            }
-            # ci_metrics.json lives at task-artifacts/<task_id>/ci_metrics.json
-            if row["task_id"]:
-                metrics_path = artifacts_dir / row["task_id"] / "ci_metrics.json"
-                m = parse_ci_metrics(metrics_path)
-                if m:
-                    row.update(m)
+        ref = fetch_inferenceX_ref(model, hf_to_ifx, target_gpu, isl, osl) if model else None
+        row["inferenceX_tok_per_gpu"] = ref
+        opt = row["optimized_tok_per_gpu"]
+        if ref and opt:
+            row["vs_inferenceX_pct"] = (opt - ref) / ref * 100.0
 
-            ref = fetch_inferenceX_ref(
-                row["model"], hf_to_ifx, target_gpu, isl, osl)
-            row["inferenceX_tok_per_gpu"] = ref
-            opt = row["optimized_tok_per_gpu"]
-            if ref and opt:
-                row["vs_inferenceX_pct"] = (opt - ref) / ref * 100.0
+        rows.append(row)
 
-            rows.append(row)
+    return rows, normalized_results
 
-    return rows
+
+def build_run_metadata() -> dict:
+    """Capture GitHub Actions context when present; harmless for local runs."""
+    return {
+        "source": "hyperloom-ci",
+        "github_run_id": os.environ.get("GITHUB_RUN_ID"),
+        "github_run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT"),
+        "github_workflow": os.environ.get("GITHUB_WORKFLOW"),
+        "github_repository": os.environ.get("GITHUB_REPOSITORY"),
+        "github_sha": os.environ.get("GITHUB_SHA"),
+        "github_ref": os.environ.get("GITHUB_REF"),
+    }
 
 
 # ── Markdown rendering ──────────────────────────────────────────────────────────
@@ -187,21 +184,31 @@ def render_markdown(rows: list[dict], target_gpu: str, isl: int, osl: int) -> st
         f"- ISL/OSL: {isl} / {osl}",
         f"- InferenceX reference GPU: `{target_gpu}`",
         "",
-        "| Model | Baseline tok/s/GPU | Optimized tok/s/GPU | Gain % | "
-        f"InferenceX ({target_gpu}) tok/s/GPU | vs InferenceX % | Actions |",
-        "|---|---:|---:|---:|---:|---:|---|",
+        "| Model | Baseline tok/s/GPU | Optimized tok/s/GPU | Gain % | Peak | "
+        f"InferenceX ({target_gpu}) tok/s/GPU | vs InferenceX % | Data | Actions |",
+        "|---|---:|---:|---:|---:|---:|---:|---|---|",
     ]
     for r in rows:
         actions = ", ".join(r.get("actions") or []) or "—"
         # Markdown-escape pipe chars in actions list
         actions = actions.replace("|", "\\|")[:200]
+        peak = fmt_num(r.get("peak_throughput"))
+        if r.get("peak_throughput_conc"):
+            peak = f"{peak} @ c{r['peak_throughput_conc']}"
+        data = (
+            f"sweep={r.get('sweep_points', 0)}, "
+            f"kernels={r.get('kernel_optimizations', 0)}, "
+            f"files={r.get('artifacts', 0)}"
+        )
         lines.append(
             f"| `{r['model']}` "
             f"| {fmt_num(r['baseline_tok_per_gpu'])} "
             f"| {fmt_num(r['optimized_tok_per_gpu'])} "
             f"| {fmt_pct(r['gain_pct'])} "
+            f"| {peak} "
             f"| {fmt_num(r['inferenceX_tok_per_gpu'])} "
             f"| {fmt_pct(r['vs_inferenceX_pct'])} "
+            f"| {data} "
             f"| {actions} |"
         )
     return "\n".join(lines) + "\n"
@@ -237,7 +244,7 @@ def main() -> int:
     hf_to_ifx = load_hf_to_ifx_map(yaml_path)
     log.info("HF→InferenceX mappings loaded: %d", len(hf_to_ifx))
 
-    rows = collect_rows(
+    rows, normalized_results = collect_rows(
         Path(args.artifacts_dir),
         Path(args.manifests_dir),
         hf_to_ifx,
@@ -259,8 +266,20 @@ def main() -> int:
         }, indent=2),
         encoding="utf-8",
     )
-    log.info("wrote %s and %s",
-             out / "ci_summary.md", out / "ci_summary.json")
+    (out / "normalized_results.json").write_text(
+        json.dumps({
+            "target_gpu": args.target_gpu,
+            "isl": args.isl,
+            "osl": args.osl,
+            "results": normalized_results,
+        }, indent=2),
+        encoding="utf-8",
+    )
+    (out / "normalized_results.ndjson").write_text(
+        "".join(json.dumps(r, separators=(",", ":")) + "\n" for r in normalized_results),
+        encoding="utf-8",
+    )
+    log.info("wrote summary and normalized results under %s", out)
 
     # Print the table to stdout too, so the GitHub Actions log shows it
     # without having to download the artifact.

--- a/ci/optimize_submit.py
+++ b/ci/optimize_submit.py
@@ -803,6 +803,13 @@ def process_model(
 DEFAULT_ARTIFACT_PATTERNS = (
     "optimization_report",   # matches optimization_report.md / *-optimization_report.md / etc.
     "ci_metrics.json",
+    "baseline_summary.json",
+    "sweep_results.csv",
+    "sweep_results.txt",
+    "kernel_candidates.json",
+    "kernel_results.json",
+    "run_context.env",
+    "gpu_timeline.csv",
     "ci_summary.json",
     "ci_report.md",
 )

--- a/ci/publish_artifacts.py
+++ b/ci/publish_artifacts.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Normalize and publish a Hyperloom result directory.
+
+This is the one-shot end-of-run helper used by Web/skill flows:
+
+  result artifacts -> normalized_results.ndjson -> results service
+
+Failures are non-fatal by default so result publishing never invalidates an
+optimization run. Pass --strict when a caller wants publish failures to fail.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from artifact_normalizer import normalize_task_result, write_single_result  # noqa: E402
+from publish_results import publish  # noqa: E402
+
+DEFAULT_SERVICE_URL = "http://hyperloom-results-service.primus-claw-dev.svc.cluster.local"
+
+
+def _default_model(task_dir: Path) -> str:
+    env_model = os.environ.get("MODEL_NAME") or os.environ.get("MODEL")
+    if env_model:
+        return env_model.rstrip("/").split("/")[-1]
+    run_context = task_dir / "results" / "run_context.env"
+    if run_context.exists():
+        for line in run_context.read_text(encoding="utf-8", errors="replace").splitlines():
+            if line.startswith("MODEL="):
+                return line.split("=", 1)[1].rstrip("/").split("/")[-1]
+    return "unknown"
+
+
+def _task_id(model: str) -> str:
+    explicit = (
+        os.environ.get("HYPERLOOM_TASK_ID")
+        or os.environ.get("SAFE_TASK_ID")
+        or os.environ.get("CLAW_SESSION_ID")
+    )
+    if explicit:
+        return explicit
+    safe_model = "".join(ch.lower() if ch.isalnum() else "-" for ch in model).strip("-")
+    return f"web-{safe_model or 'task'}-{int(time.time())}"
+
+
+def _host_reachable(url: str) -> tuple[bool, str]:
+    host = url.split("://", 1)[-1].split("/", 1)[0].split(":", 1)[0]
+    try:
+        socket.gethostbyname(host)
+        return True, ""
+    except OSError as e:
+        return False, str(e)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--task-dir", default=os.environ.get("HYPERLOOM_RESULT_DIR", "/workspace/hyperloom"))
+    parser.add_argument("--out-dir", default="")
+    parser.add_argument("--model", default="")
+    parser.add_argument("--display-name", default="")
+    parser.add_argument("--task-id", default="")
+    parser.add_argument(
+        "--url",
+        default=os.environ.get("HYPERLOOM_RESULTS_SERVICE_URL", DEFAULT_SERVICE_URL),
+        help="Results service base URL",
+    )
+    parser.add_argument("--token", default=os.environ.get("HYPERLOOM_RESULTS_SERVICE_TOKEN", ""))
+    parser.add_argument("--timeout", type=int, default=int(os.environ.get("HYPERLOOM_RESULTS_TIMEOUT", "20")))
+    parser.add_argument("--strict", action="store_true", help="Exit non-zero when publish fails")
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    task_dir = Path(args.task_dir)
+    out_dir = Path(args.out_dir) if args.out_dir else task_dir / "normalized"
+    model = args.model or _default_model(task_dir)
+    task_id = args.task_id or _task_id(model)
+    display_name = args.display_name or task_id
+
+    result: dict[str, Any] = {
+        "task_id": task_id,
+        "model": model,
+        "display_name": display_name,
+        "published": False,
+        "normalized_dir": str(out_dir),
+    }
+
+    try:
+        normalized = normalize_task_result(
+            task_dir,
+            {
+                "task_id": task_id,
+                "model": model,
+                "display_name": display_name,
+                "status": "imported",
+                "final_status": "Succeeded",
+            },
+            {"source": "hyperloom-auto-publish"},
+        )
+        write_single_result(normalized, out_dir)
+        result["normalizer_exit_code"] = 0
+        result["warnings"] = normalized.get("warnings") or []
+
+        reachable, reason = _host_reachable(args.url)
+        if not reachable:
+            result["publish_error"] = f"results service host not resolvable: {reason}"
+            print(json.dumps(result, indent=2))
+            return 2 if args.strict else 0
+
+        response = publish([normalized], args.url, args.token, args.timeout)
+        result["published"] = True
+        result["publish_response"] = response
+        print(json.dumps(result, indent=2))
+        return 0
+    except Exception as e:
+        result["error"] = str(e)
+        print(json.dumps(result, indent=2))
+        return 1 if args.strict else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/publish_results.py
+++ b/ci/publish_results.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Publish normalized Hyperloom results to the results service."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def load_results(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        raise FileNotFoundError(f"input file not found: {path}")
+
+    if path.suffix == ".ndjson":
+        results: list[dict[str, Any]] = []
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                item = json.loads(line)
+                if isinstance(item, dict):
+                    results.append(item)
+        return results
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(payload, dict) and isinstance(payload.get("results"), list):
+        return [r for r in payload["results"] if isinstance(r, dict)]
+    if isinstance(payload, dict) and payload.get("schema_version"):
+        return [payload]
+    if isinstance(payload, list):
+        return [r for r in payload if isinstance(r, dict)]
+    return []
+
+
+def publish(results: list[dict[str, Any]], url: str, token: str = "", timeout: int = 60) -> dict:
+    import requests
+
+    endpoint = url.rstrip("/") + "/api/import"
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    resp = requests.post(
+        endpoint,
+        headers=headers,
+        json={"results": results},
+        timeout=timeout,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, help="normalized_results.json or .ndjson")
+    parser.add_argument(
+        "--url",
+        default=os.environ.get("HYPERLOOM_RESULTS_SERVICE_URL", ""),
+        help="Results service base URL, e.g. http://hyperloom-results-service",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("HYPERLOOM_RESULTS_SERVICE_TOKEN", ""),
+        help="Optional bearer token for the results service",
+    )
+    parser.add_argument("--timeout", type=int, default=60)
+    args = parser.parse_args()
+
+    if not args.url:
+        print("HYPERLOOM_RESULTS_SERVICE_URL is not set; skipping publish")
+        return 0
+
+    results = load_results(Path(args.input))
+    if not results:
+        print(f"no results found in {args.input}; skipping publish")
+        return 0
+
+    response = publish(results, args.url, args.token, args.timeout)
+    print(json.dumps(response, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/inference_optimizer/orchestrator/action_executors/report.py
+++ b/inference_optimizer/orchestrator/action_executors/report.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import subprocess
 from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
@@ -201,12 +203,14 @@ class ReportExecutor:
             "report_executor: wrote %s and %s (cumulative_gain=%.2f%%)",
             md_path, json_path, state.cumulative_gain,
         )
+        publish_result = self._maybe_publish_results(session_dir, state)
         return {
             "status":      "succeeded",
             "session_id":  state.session_id,
             "json_path":   str(json_path),
             "md_path":     str(md_path),
             "summary":     summary,
+            "publish_result": publish_result,
         }
 
     def _resolve_session_dir(self, ctx) -> Path | None:
@@ -232,6 +236,56 @@ class ReportExecutor:
         if candidate.exists() and (candidate / "state.json").exists():
             return candidate
         return None
+
+    def _maybe_publish_results(self, session_dir: Path, state: SharedState) -> dict[str, Any]:
+        """Best-effort publish hook for code-driven optimizer runs.
+
+        Prompt/skill-driven Web runs use actions/report.md directly. This hook
+        covers runs that execute the Python ReportExecutor. It is opt-in unless
+        the results service URL is explicitly configured.
+        """
+        service_url = os.environ.get("HYPERLOOM_RESULTS_SERVICE_URL", "")
+        auto_publish = os.environ.get("HYPERLOOM_RESULTS_AUTO_PUBLISH", "").lower()
+        if not service_url and auto_publish not in {"1", "true", "yes"}:
+            return {"enabled": False, "reason": "HYPERLOOM_RESULTS_SERVICE_URL not set"}
+
+        repo_root = Path(__file__).resolve().parents[3]
+        helper = repo_root / "ci" / "publish_artifacts.py"
+        if not helper.exists():
+            return {"enabled": False, "reason": f"{helper} not found"}
+
+        cmd = [
+            "python3",
+            str(helper),
+            "--task-dir",
+            str(session_dir),
+            "--out-dir",
+            str(session_dir / "normalized"),
+            "--model",
+            state.model_name or "unknown",
+            "--display-name",
+            state.session_id or "hyperloom-report",
+        ]
+        if service_url:
+            cmd.extend(["--url", service_url])
+
+        try:
+            proc = subprocess.run(
+                cmd,
+                text=True,
+                capture_output=True,
+                timeout=60,
+                check=False,
+            )
+            return {
+                "enabled": True,
+                "returncode": proc.returncode,
+                "stdout": proc.stdout[-4000:],
+                "stderr": proc.stderr[-4000:],
+            }
+        except Exception as e:
+            log.warning("report_executor: result publish failed: %s", e)
+            return {"enabled": True, "error": str(e)}
 
 
 report_executor = ReportExecutor()


### PR DESCRIPTION
## Summary
- Normalize Hyperloom optimization artifacts into stable JSON/NDJSON outputs for downstream storage and dashboards.
- Add publishing helpers and wire the report phase to auto-publish normalized results to the Hyperloom results service.
- Keep publishing best-effort so result-service availability does not fail optimization runs.

## Test plan
- `python -m py_compile ci/publish_artifacts.py ci/publish_results.py ci/artifact_normalizer.py inference_optimizer/orchestrator/action_executors/report.py`
- Ran `ci/publish_artifacts.py` smoke test against downloaded sample artifacts and verified non-fatal behavior when the service host is unavailable.
- Verified Web E2E flow publishes results to the deployed results service and the dashboard/API show new rows.
- Checked merge compatibility with latest `origin/main` using a no-commit merge dry run.