### PR TITLE
fix(inference-optimizer): require Ray context for PMC roofline

### DIFF
--- a/inference_optimizer/actions/pmc_roofline.md
+++ b/inference_optimizer/actions/pmc_roofline.md
@@ -5,6 +5,32 @@ for the normal torch-profiler trace path. By default this action launches the
 server under `rocprofv3` instead of using `rocprofv3 --attach`, so it can run in
 containers that do not grant `CAP_SYS_PTRACE`.
 
+## GPU Scheduling Contract
+
+All GPU work for this action must be scheduled through Ray. Do not launch the
+PMC vLLM/SGLang server directly from the Claw client or another process that did
+not receive a Ray GPU allocation. The expected production shape is:
+
+```text
+RayJob / Ray worker
+  -> pmc_roofline action
+     -> rocprofv3 ... -- <server_cmd>
+```
+
+The action enforces this by default. It must see one of:
+
+- `task.params.ray_worker=true` from the RayJob wrapper, or
+- a Ray context environment marker such as `RAY_JOB_ID`, `RAY_ADDRESS`, or
+  `RAY_RUNTIME_ENV_CREATE_WORKING_DIR`, or
+- `HYPERLOOM_PMC_ROOFLINE_IN_RAY=1`.
+
+Only local developer debugging should bypass this with
+`task.params.allow_direct_gpu=true` or `HYPERLOOM_ALLOW_DIRECT_PMC_ROOFLINE=1`.
+
+Use the GPU visibility assigned by Ray. Do not pass `ROCR_VISIBLE_DEVICES` or
+`CUDA_VISIBLE_DEVICES` in `extra_envs` unless `allow_device_override=true` is
+explicitly set.
+
 ## Why This Is Separate
 
 ROCm only allows one rocprofiler tool registration per process. The standard
@@ -29,6 +55,10 @@ and uses that process only for `rocprofv3 --attach`.
 - `extra_envs`: extra environment variables for the dedicated server.
 - `profile_mode`: `launch` (default) or `attach`. Use `attach` only when the
   container grants ptrace permissions.
+- `ray_worker`: set to `true` when the action is running inside the RayJob/Ray
+  worker that owns the GPU allocation.
+- `allow_direct_gpu`: escape hatch for local developer debugging only.
+- `allow_device_override`: escape hatch for explicit GPU visibility overrides.
 
 ## Outputs
 

--- a/inference_optimizer/actions/pmc_roofline.md
+++ b/inference_optimizer/actions/pmc_roofline.md
@@ -31,6 +31,27 @@ Use the GPU visibility assigned by Ray. Do not pass `ROCR_VISIBLE_DEVICES` or
 `CUDA_VISIBLE_DEVICES` in `extra_envs` unless `allow_device_override=true` is
 explicitly set.
 
+## Enabling Automatic Runs
+
+`pmc_roofline` is opt-in. By default, the main optimization flow does not run it
+and therefore pays no extra GPU/server cost.
+
+Set `HYPERLOOM_ENABLE_PMC_ROOFLINE=1` to have the Coordinator enqueue one
+`pmc_roofline` task after a successful `select_kernels` response. The auto task
+reuses the materialized Magpie workload YAML from `baseline_config_path` to build
+the dedicated server and benchmark commands, so the PMC run uses the same model,
+framework, precision, TP, ISL/OSL/CONC, and server args as the Magpie workload
+contract.
+
+Useful knobs:
+
+- `HYPERLOOM_ENABLE_PMC_ROOFLINE=1`: enable automatic enqueue.
+- `HYPERLOOM_PMC_ROOFLINE_FORCE=1`: enqueue even if a roofline artifact already
+  exists for the session.
+- `HYPERLOOM_PMC_ROOFLINE_MODE=launch|attach`: default `launch`.
+- `HYPERLOOM_PMC_ROOFLINE_PORT=30001`: dedicated server port.
+- `HYPERLOOM_PMC_ROOFLINE_DURATION_MS=15000`: rocprof collection window.
+
 ## Why This Is Separate
 
 ROCm only allows one rocprofiler tool registration per process. The standard

--- a/inference_optimizer/actions/pmc_roofline.md
+++ b/inference_optimizer/actions/pmc_roofline.md
@@ -51,6 +51,9 @@ Useful knobs:
 - `HYPERLOOM_PMC_ROOFLINE_MODE=launch|attach`: default `launch`.
 - `HYPERLOOM_PMC_ROOFLINE_PORT=30001`: dedicated server port.
 - `HYPERLOOM_PMC_ROOFLINE_DURATION_MS=15000`: rocprof collection window.
+- `HYPERLOOM_PMC_ROOFLINE_GPU_TYPE` or `GPU_TYPE`: roofline GPU model
+  override. If unset, the action probes `rocm-smi --showproductname` and then
+  falls back to the visible ROCm architecture reported by torch.
 
 ## Why This Is Separate
 
@@ -72,6 +75,8 @@ and uses that process only for `rocprofv3 --attach`.
 - `output_dir`: artifact directory.
 - `duration_ms`: attach duration, default `15000`.
 - `precision`: roofline precision, default `fp16`.
+- `gpu_type`: roofline GPU model (`mi300x`, `mi325x`, or `mi355x`). Overrides
+  environment-based detection.
 - `startup_timeout_s`: server health timeout, default `600`.
 - `extra_envs`: extra environment variables for the dedicated server.
 - `profile_mode`: `launch` (default) or `attach`. Use `attach` only when the

--- a/inference_optimizer/orchestrator/action_executors/pmc_roofline.py
+++ b/inference_optimizer/orchestrator/action_executors/pmc_roofline.py
@@ -94,6 +94,7 @@ class PMCRooflineExecutor:
             benchmark_cmd=benchmark_cmd,
             duration_ms=int(params.get("duration_ms") or 15000),
             precision=str(params.get("precision") or "fp16"),
+            gpu_type=str(params.get("gpu_type") or ""),
             startup_timeout_s=int(params.get("startup_timeout_s") or 600),
             env_overrides=env_overrides,
             profile_mode=str(params.get("profile_mode") or "launch"),

--- a/inference_optimizer/orchestrator/action_executors/pmc_roofline.py
+++ b/inference_optimizer/orchestrator/action_executors/pmc_roofline.py
@@ -8,6 +8,7 @@ tool registration per process.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -16,6 +17,23 @@ from ..sub_agent_runner import RunnerContext
 
 
 PMC_ROOFLINE_DEFAULT_TIMEOUT_SEC = 1800
+_RAY_CONTEXT_ENV_KEYS = (
+    "HYPERLOOM_PMC_ROOFLINE_IN_RAY",
+    "RAY_ADDRESS",
+    "RAY_JOB_ID",
+    "RAY_RUNTIME_ENV_CREATE_WORKING_DIR",
+)
+_GPU_VISIBILITY_ENV_KEYS = ("ROCR_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES")
+
+
+def _truthy(value: Any) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _ray_context_present(params: dict[str, Any]) -> bool:
+    return _truthy(params.get("ray_worker")) or any(
+        os.environ.get(key) for key in _RAY_CONTEXT_ENV_KEYS
+    )
 
 
 class PMCRooflineExecutor:
@@ -23,6 +41,21 @@ class PMCRooflineExecutor:
 
     async def __call__(self, ctx: RunnerContext) -> dict[str, Any]:
         params = ctx.task.params or {}
+        allow_direct_gpu = _truthy(params.get("allow_direct_gpu")) or _truthy(
+            os.environ.get("HYPERLOOM_ALLOW_DIRECT_PMC_ROOFLINE")
+        )
+        if not allow_direct_gpu and not _ray_context_present(params):
+            return {
+                "status": "failed",
+                "error_class": "ray_worker_required",
+                "error": (
+                    "pmc_roofline must run inside a RayJob/Ray worker so GPU "
+                    "allocation is owned by Ray. Set task.params.ray_worker=true "
+                    "inside the Ray job, or pass allow_direct_gpu=true only for "
+                    "local developer debugging."
+                ),
+            }
+
         server_cmd = _as_cmd(params.get("server_cmd"))
         if not server_cmd:
             return {
@@ -41,6 +74,18 @@ class PMCRooflineExecutor:
             str(k): str(v)
             for k, v in dict(params.get("extra_envs") or {}).items()
         }
+        if not _truthy(params.get("allow_device_override")):
+            blocked = sorted(k for k in _GPU_VISIBILITY_ENV_KEYS if k in env_overrides)
+            if blocked:
+                return {
+                    "status": "failed",
+                    "error_class": "ray_gpu_visibility_override",
+                    "error": (
+                        "pmc_roofline must use the GPU visibility assigned by Ray; "
+                        f"remove extra_envs overrides for {', '.join(blocked)} or "
+                        "set allow_device_override=true for an explicit exception."
+                    ),
+                }
 
         result = run_isolated_pmc_roofline(
             session_dir=output_dir,

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -1005,6 +1005,11 @@ class Coordinator:
         max_model_len = str(envs.get("MAX_MODEL_LEN") or os.environ.get("MAX_MODEL_LEN") or "8192")
         extra_key = "EXTRA_VLLM_ARGS" if framework == "vllm" else "EXTRA_SGLANG_ARGS"
         extra_args = shlex.split(str(envs.get(extra_key) or ""))
+        gpu_type = (
+            os.environ.get("HYPERLOOM_PMC_ROOFLINE_GPU_TYPE")
+            or self.shared_state.gpu_type
+            or os.environ.get("GPU_TYPE", "")
+        ).strip().lower()
 
         if framework == "vllm":
             dtype = "bfloat16" if precision in {"bf16", "bfloat16"} else precision
@@ -1058,6 +1063,7 @@ class Coordinator:
             "output_dir": str(Path(self.session_dir) / "runs" / "pmc_roofline" / "auto"),
             "duration_ms": int(os.environ.get("HYPERLOOM_PMC_ROOFLINE_DURATION_MS", "15000")),
             "precision": precision,
+            "gpu_type": gpu_type,
             "startup_timeout_s": int(os.environ.get("HYPERLOOM_PMC_ROOFLINE_STARTUP_TIMEOUT_S", "600")),
         }
 

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -23,8 +23,10 @@ checkpoint cadence) lands in P0-5 and beyond.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import os
+import shlex
 import signal
 import time
 from dataclasses import dataclass, field
@@ -960,6 +962,136 @@ class Coordinator:
             )
         return None
 
+    @staticmethod
+    def _pmc_roofline_enabled() -> bool:
+        return os.environ.get("HYPERLOOM_ENABLE_PMC_ROOFLINE", "").strip().lower() in {
+            "1", "true", "yes", "on",
+        }
+
+    @staticmethod
+    def _pmc_roofline_force() -> bool:
+        return os.environ.get("HYPERLOOM_PMC_ROOFLINE_FORCE", "").strip().lower() in {
+            "1", "true", "yes", "on",
+        }
+
+    def _build_pmc_roofline_params(self) -> dict[str, Any] | None:
+        """Build pmc_roofline task params from the materialized Magpie YAML."""
+        config_path = self.shared_state.baseline_config_path
+        if not config_path:
+            log.info("PMC roofline enabled but baseline_config_path is empty")
+            return None
+        path = Path(config_path)
+        if not path.exists():
+            log.warning("PMC roofline config missing: %s", path)
+            return None
+        try:
+            import yaml  # type: ignore[import-untyped]
+            cfg = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        except Exception as exc:  # noqa: BLE001
+            log.warning("Failed to read PMC roofline workload config %s: %s", path, exc)
+            return None
+
+        bench = cfg.get("benchmark") if isinstance(cfg.get("benchmark"), dict) else {}
+        envs = bench.get("envs") if isinstance(bench.get("envs"), dict) else {}
+        framework = str(bench.get("framework") or self.shared_state.framework or "vllm").lower()
+        model = str(bench.get("model") or self.shared_state.model_path or "").strip()
+        if not model:
+            log.warning("PMC roofline config has no model path")
+            return None
+
+        port = int(os.environ.get("HYPERLOOM_PMC_ROOFLINE_PORT", "30001"))
+        tp = str(envs.get("TP") or os.environ.get("TP") or "1")
+        precision = str(bench.get("precision") or os.environ.get("PRECISION") or "bf16").lower()
+        max_model_len = str(envs.get("MAX_MODEL_LEN") or os.environ.get("MAX_MODEL_LEN") or "8192")
+        extra_key = "EXTRA_VLLM_ARGS" if framework == "vllm" else "EXTRA_SGLANG_ARGS"
+        extra_args = shlex.split(str(envs.get(extra_key) or ""))
+
+        if framework == "vllm":
+            dtype = "bfloat16" if precision in {"bf16", "bfloat16"} else precision
+            server_cmd = [
+                "vllm", "serve", model,
+                "--host", "0.0.0.0",
+                "--port", str(port),
+                "--tensor-parallel-size", tp,
+                "--trust-remote-code",
+                "--dtype", dtype,
+                "--max-model-len", max_model_len,
+            ] + extra_args
+            backend = "vllm"
+        else:
+            server_cmd = [
+                "python", "-m", "sglang.launch_server",
+                "--model-path", model,
+                "--host", "0.0.0.0",
+                "--port", str(port),
+                "--tensor-parallel-size", tp,
+                "--trust-remote-code",
+                "--max-model-len", max_model_len,
+            ] + extra_args
+            backend = "sglang"
+
+        inferencex = os.environ.get("INFERENCEX_PATH", "/hyperloom/InferenceX").rstrip("/")
+        bench_script = f"{inferencex}/utils/bench_serving/benchmark_serving.py"
+        isl = str(envs.get("ISL") or os.environ.get("ISL") or "256")
+        osl = str(envs.get("OSL") or os.environ.get("OSL") or "256")
+        conc = int(envs.get("CONC") or os.environ.get("CONC") or 1)
+        num_prompts = str(envs.get("NUM_PROMPTS") or max(conc, 1))
+        benchmark_cmd = [
+            "python", bench_script,
+            "--backend", backend,
+            "--base-url", f"http://127.0.0.1:{port}",
+            "--model", model,
+            "--dataset-name", "random",
+            "--random-input-len", isl,
+            "--random-output-len", osl,
+            "--num-prompts", num_prompts,
+            "--max-concurrency", str(conc),
+            "--request-rate", "inf",
+            "--ignore-eos",
+        ]
+
+        return {
+            "profile_mode": os.environ.get("HYPERLOOM_PMC_ROOFLINE_MODE", "launch"),
+            "server_cmd": server_cmd,
+            "health_url": f"http://127.0.0.1:{port}/health",
+            "benchmark_cmd": benchmark_cmd,
+            "output_dir": str(Path(self.session_dir) / "runs" / "pmc_roofline" / "auto"),
+            "duration_ms": int(os.environ.get("HYPERLOOM_PMC_ROOFLINE_DURATION_MS", "15000")),
+            "precision": precision,
+            "startup_timeout_s": int(os.environ.get("HYPERLOOM_PMC_ROOFLINE_STARTUP_TIMEOUT_S", "600")),
+        }
+
+    async def _maybe_enqueue_pmc_roofline(self) -> None:
+        if not self._pmc_roofline_enabled():
+            return
+        if self.shared_state.last_profile_roofline and not self._pmc_roofline_force():
+            return
+        params = self._build_pmc_roofline_params()
+        if not params:
+            return
+        key_src = "|".join([
+            self.shared_state.last_profile_trace or "",
+            self.shared_state.baseline_config_path or "",
+            str(params.get("profile_mode") or ""),
+        ])
+        key = hashlib.sha256(key_src.encode("utf-8", errors="ignore")).hexdigest()[:16]
+        task = await self.tasks.create(
+            kind="pmc_roofline",
+            params=params,
+            idempotency_key=f"auto-pmc-roofline-{key}",
+            requires_lanes=["profile_lane"],
+            lease_ttl_sec=1800,
+        )
+        await self.bus.append_and_seq(Message.new(
+            "coordinator", "*", "event",
+            {
+                "kind": "task_queued",
+                "task_id": task.task_id,
+                "source": "coordinator_auto_pmc_roofline",
+                "action": "pmc_roofline",
+            },
+        ))
+
     # ==================================================================
     # Intent handling
     # ==================================================================
@@ -1311,6 +1443,7 @@ class Coordinator:
                     and result.get("status") in ("ok", "succeeded")
                 ):
                     self.shared_state.record_select_kernels(merged_payload, result)
+                    await self._maybe_enqueue_pmc_roofline()
                     self.shared_state.save(self.session_dir)
                 # Mirror kernel-opt outcomes into SharedState so Orch
                 # sees decision/speedup in its prompt next tick and

--- a/inference_optimizer/orchestrator/roofline_integration.py
+++ b/inference_optimizer/orchestrator/roofline_integration.py
@@ -19,7 +19,7 @@ import time
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 from urllib.request import urlopen
 
 
@@ -435,7 +435,65 @@ class GPUSpec:
         self.ridge_point_fp8 = (self.peak_flops_fp8 * 1e12) / bandwidth
 
 
+MI300X_SPEC = GPUSpec("MI300X", 1307.0, 2614.0, 0.0, 163.4, 5.3, 304, 64, 256, 4)
+MI325X_SPEC = GPUSpec("MI325X", 1307.0, 2614.0, 0.0, 163.4, 6.0, 304, 64, 256, 4)
 MI355X_SPEC = GPUSpec("MI355X", 1311.0, 2621.0, 5243.0, 163.9, 8.0, 304, 128, 256, 4)
+_GPU_TYPE_ENV_KEYS = ("HYPERLOOM_PMC_ROOFLINE_GPU_TYPE", "GPU_TYPE")
+_GFX_TO_GPU_TYPE = {
+    "gfx942": "mi300x",
+    "gfx950": "mi355x",
+    "gfx1100": "mi325x",
+}
+
+
+def _autodetect_gpu_type() -> str:
+    """Best-effort ROCm GPU type probe for standalone PMC runs."""
+    try:
+        out = subprocess.run(
+            ["rocm-smi", "--showproductname"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        ).stdout.upper()
+        for tag in ("MI355X", "MI325X", "MI300X"):
+            if tag in out:
+                return tag.lower()
+    except (FileNotFoundError, PermissionError, subprocess.TimeoutExpired, OSError):
+        pass
+
+    try:
+        import torch  # type: ignore[import-not-found]
+
+        arch = torch.cuda.get_device_properties(0).gcnArchName
+        return _GFX_TO_GPU_TYPE.get(arch.split(":", 1)[0].lower(), "")
+    except Exception:  # noqa: BLE001 - torch may be absent on coordinator hosts.
+        return ""
+
+
+def resolve_gpu_type(gpu_type: str | None = None, env: Mapping[str, str] | None = None) -> str:
+    """Resolve roofline GPU type from task params, env, then ROCm probing."""
+    explicit = str(gpu_type or "").strip().lower()
+    if explicit:
+        return explicit
+
+    merged_env = env or os.environ
+    for key in _GPU_TYPE_ENV_KEYS:
+        value = str(merged_env.get(key) or os.environ.get(key) or "").strip().lower()
+        if value:
+            return value
+
+    return _autodetect_gpu_type()
+
+
+def gpu_spec_from_name(name: str | None) -> GPUSpec:
+    normalized = (name or "").strip().lower().replace("_", "").replace("-", "")
+    if "mi355" in normalized or "gfx950" in normalized:
+        return MI355X_SPEC
+    if "mi325" in normalized:
+        return MI325X_SPEC
+    if "mi300" in normalized or "gfx942" in normalized:
+        return MI300X_SPEC
+    return MI300X_SPEC
 
 
 @dataclass
@@ -475,8 +533,8 @@ class KernelRooflineResult:
 
 
 class RooflineAnalyzer:
-    def __init__(self, gpu_spec: GPUSpec = MI355X_SPEC):
-        self.spec = gpu_spec
+    def __init__(self, gpu_spec: GPUSpec | None = None, *, gpu_type: str | None = None):
+        self.spec = gpu_spec or gpu_spec_from_name(resolve_gpu_type(gpu_type))
 
     def analyze_kernels(self, pmc_data: list[dict[str, Any]], precision: str = "fp16") -> list[KernelRooflineResult]:
         results = [self._analyze_single(kernel, precision) for kernel in pmc_data]
@@ -708,6 +766,7 @@ def run_isolated_pmc_roofline(
     benchmark_cmd: list[str] | None = None,
     duration_ms: int = 15000,
     precision: str = "fp16",
+    gpu_type: str = "",
     startup_timeout_s: int = 600,
     env_overrides: dict[str, str] | None = None,
     profile_mode: str = "launch",
@@ -789,7 +848,9 @@ def run_isolated_pmc_roofline(
                 gpu_pct = result.duration_ns / total_ns * 100.0 if total_ns else 0.0
             pmc_dicts.append(result.to_roofline_dict(gpu_pct=float(gpu_pct or 0.0)))
 
-        roofline_results = RooflineAnalyzer().analyze_kernels(pmc_dicts, precision=precision)
+        resolved_gpu_type = resolve_gpu_type(gpu_type, env)
+        gpu_spec = gpu_spec_from_name(resolved_gpu_type)
+        roofline_results = RooflineAnalyzer(gpu_spec).analyze_kernels(pmc_dicts, precision=precision)
         roofline_path = session_dir / "profiles" / "roofline.json"
         roofline_path.write_text(
             json.dumps([result.to_dict() for result in roofline_results], indent=2, sort_keys=True) + "\n",
@@ -804,6 +865,8 @@ def run_isolated_pmc_roofline(
         return {
             "status": "ok",
             "profile_mode": mode,
+            "gpu_type": resolved_gpu_type,
+            "gpu_spec": gpu_spec.name,
             "server_log": str(log_path),
             "pmc_summary_path": str(pmc_summary_path),
             "roofline_path": str(roofline_path),

--- a/inference_optimizer/orchestrator/roofline_integration.py
+++ b/inference_optimizer/orchestrator/roofline_integration.py
@@ -459,6 +459,7 @@ def _autodetect_gpu_type() -> str:
             if tag in out:
                 return tag.lower()
     except (FileNotFoundError, PermissionError, subprocess.TimeoutExpired, OSError):
+        # rocm-smi is a best-effort probe; fall back to torch device metadata.
         pass
 
     try:

--- a/inference_optimizer/tests/test_roofline_integration.py
+++ b/inference_optimizer/tests/test_roofline_integration.py
@@ -1,0 +1,88 @@
+"""Regression tests for PMC roofline GPU resolution."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from inference_optimizer.orchestrator import roofline_integration as roofline
+from inference_optimizer.orchestrator.action_executors import pmc_roofline
+from inference_optimizer.orchestrator.coordinator import Coordinator
+from inference_optimizer.orchestrator.sub_agent_runner import RunnerContext
+from inference_optimizer.orchestrator.task_registry import Task
+
+
+def test_roofline_analyzer_resolves_gpu_from_env(monkeypatch):
+    monkeypatch.delenv("HYPERLOOM_PMC_ROOFLINE_GPU_TYPE", raising=False)
+    monkeypatch.setenv("GPU_TYPE", "mi300x")
+    assert roofline.RooflineAnalyzer().spec.name == "MI300X"
+
+    monkeypatch.setenv("HYPERLOOM_PMC_ROOFLINE_GPU_TYPE", "mi355x")
+    assert roofline.RooflineAnalyzer().spec.name == "MI355X"
+
+
+def test_roofline_gpu_resolution_uses_autodetect_when_env_missing(monkeypatch):
+    monkeypatch.delenv("HYPERLOOM_PMC_ROOFLINE_GPU_TYPE", raising=False)
+    monkeypatch.delenv("GPU_TYPE", raising=False)
+    monkeypatch.setattr(roofline, "_autodetect_gpu_type", lambda: "mi325x")
+
+    assert roofline.resolve_gpu_type("") == "mi325x"
+    assert roofline.RooflineAnalyzer().spec.name == "MI325X"
+
+
+def test_coordinator_pmc_params_include_session_gpu_type(tmp_path, monkeypatch):
+    config_path = tmp_path / "baseline.yaml"
+    config_path.write_text(
+        """
+benchmark:
+  framework: sglang
+  model: /models/test
+  envs:
+    TP: "1"
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("HYPERLOOM_PMC_ROOFLINE_GPU_TYPE", raising=False)
+    monkeypatch.delenv("GPU_TYPE", raising=False)
+
+    coord = Coordinator.__new__(Coordinator)
+    coord.session_dir = tmp_path
+    coord.shared_state = SimpleNamespace(
+        baseline_config_path=str(config_path),
+        framework="sglang",
+        model_path="/models/test",
+        gpu_type="mi300x",
+    )
+
+    params = coord._build_pmc_roofline_params()
+    assert params is not None
+    assert params["gpu_type"] == "mi300x"
+
+
+@pytest.mark.asyncio
+async def test_pmc_roofline_executor_forwards_gpu_type(tmp_path, monkeypatch):
+    captured: dict[str, object] = {}
+
+    def fake_run_isolated_pmc_roofline(**kwargs):
+        captured.update(kwargs)
+        return {"status": "ok"}
+
+    monkeypatch.setattr(pmc_roofline, "run_isolated_pmc_roofline", fake_run_isolated_pmc_roofline)
+    task = Task(
+        task_id="task123456",
+        kind="pmc_roofline",
+        state="queued",
+        params={
+            "allow_direct_gpu": True,
+            "server_cmd": ["true"],
+            "output_dir": str(tmp_path),
+            "gpu_type": "mi355x",
+        },
+        idempotency_key="pmc-test",
+    )
+
+    result = await pmc_roofline.PMCRooflineExecutor()(RunnerContext(task=task, lease=None))
+
+    assert result["status"] == "ok"
+    assert captured["gpu_type"] == "mi355x"


### PR DESCRIPTION
﻿## Summary
- Require `pmc_roofline` GPU work to run inside a RayJob/Ray worker by default, so it cannot accidentally launch vLLM/SGLang directly from the Claw client and bypass Ray GPU scheduling.
- Reject default attempts to override Ray-assigned `ROCR_VISIBLE_DEVICES` / `CUDA_VISIBLE_DEVICES` through `extra_envs` unless an explicit escape hatch is set.
- Add opt-in automatic `pmc_roofline` enqueue after successful `select_kernels` via `HYPERLOOM_ENABLE_PMC_ROOFLINE=1`.
- Derive the auto-enqueued `pmc_roofline` workload from the same materialized Magpie config used by the TraceLens/profile/select_kernels path.
- Resolve roofline GPU specs dynamically from `gpu_type`, `HYPERLOOM_PMC_ROOFLINE_GPU_TYPE`, `GPU_TYPE`, or ROCm/torch probing instead of hardcoding MI355X.
- Document the Ray scheduling contract and local-debug escape hatches in `pmc_roofline.md`.

## Validation
- Hyperloom smoke test on `fix/luochen/pmc-ray @ 5c5ee946` using AMD Instinct MI300X: `60/60 PASS`.
  - Covered PMC roofline opt-in gating, post-`select_kernels` auto-enqueue, separate action execution, Ray GPU scheduling guards, GPU visibility override protection, output artifacts, dynamic GPU spec resolution, and GPU spec data integrity.
  - Verified generated artifacts: `pmc_summary.json`, `roofline.json`, and `kernel_breakdown.json`.
  - Verified MI300X resolves to `gpu_spec=MI300X`.
- Focused Magpie workload config validation on `fix/luochen/pmc-ray @ 5c5ee946`: PASS.
  - TraceLens/profile/select_kernels and auto-enqueued `pmc_roofline` both derive workload parameters from the same materialized Magpie config, `baseline_config.with_envs.yaml`, stored in `shared_state.baseline_config_path`.
  - All 14 compared fields matched exactly: config path, model, framework, precision, TP, EP, ISL, OSL, CONC, NUM_PROMPTS, MAX_MODEL_LEN, extra server args, and backend.
- Unit tests from focused validation: `5 passed, 571 deselected`.
- Existing roofline integration tests from smoke validation: `test_roofline_integration.py` passed `4/4`.
- Local checks after code-quality fix on latest commit `9629e9c`:
  - `python -m py_compile inference_optimizer/orchestrator/roofline_integration.py`
  - `ReadLints`: no linter errors for `roofline_integration.py`

## Test plan
- `python -m py_compile inference_optimizer/orchestrator/action_executors/pmc_roofline.py inference_optimizer/orchestrator/roofline_integration.py inference_optimizer/orchestrator/coordinator.py`
- Hyperloom smoke test in Web/Claw environment with `HYPERLOOM_ENABLE_PMC_ROOFLINE=1` and `HYPERLOOM_PMC_ROOFLINE_GPU_TYPE=mi300x`.
- Focused validation comparing TraceLens-derived workload fields against auto-enqueued `pmc_roofline` task params from the same materialized Magpie config.
