### PR TITLE
Bugfix/yunkai/#194

### DIFF
--- a/inference_optimizer/orchestrator/action_executors/_inferencex_patcher.py
+++ b/inference_optimizer/orchestrator/action_executors/_inferencex_patcher.py
@@ -1,0 +1,249 @@
+"""Idempotent, backward-compatible patcher for InferenceX
+``benchmarks/benchmark_lib.sh`` (Hyperloom issue #194 §2).
+
+Background
+----------
+
+When ``PROFILE=1``, upstream ``run_benchmark_serving`` in
+``benchmark_lib.sh`` unconditionally resets ``num_prompts`` after CLI
+parsing:
+
+.. code-block:: bash
+
+   if [[ "${PROFILE:-}" == "1" ]]; then
+       ...
+       num_prompts="$max_concurrency"
+   fi
+
+This stomps anything the caller passes via ``--num-prompts`` *and*
+ignores any environment variable.  With the TraceLens-aligned steady-
+state window (``delay_iters`` reaches into the thousands for large
+``OSL``), the benchmark engine finishes long before the profiling
+window opens — yielding empty or warmup-only traces (see issue #194 §1
+follow-up).
+
+Approach
+--------
+
+Apply the smallest possible **backward-compatible** patch:
+
+.. code-block:: diff
+
+   -        num_prompts="$max_concurrency"
+   +        num_prompts="${NUM_PROMPTS:-$max_concurrency}"
+
+When ``NUM_PROMPTS`` env is *unset* the line behaves bit-for-bit
+identically to upstream — so every existing InferenceX consumer
+(``single_node/*.sh``, ``multi_node/*.sh``, etc.) is unaffected.  When
+Hyperloom's profile path exports ``NUM_PROMPTS`` (sized to cover
+``delay_iters + max_iters``), the engine has enough prompts to reach
+the profiling window.
+
+Lifecycle
+---------
+
+The patch is applied **in place, once, and never reverted**.  Repeated
+calls are O(1) no-ops (we grep for a sentinel substring).  Concurrent
+attempts from multiple processes are serialized via ``fcntl.flock`` on
+a system-wide lock file so two writers never race on the same byte
+range.  The write itself is atomic (temp file + ``os.replace``) so a
+crash mid-write can never corrupt ``benchmark_lib.sh``.
+
+If the expected legacy line is missing (e.g. someone has hand-patched
+the file to a different shape, or the upstream layout changed), the
+patcher logs a warning and returns ``False`` so callers can decide
+whether to fail-loud.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import logging
+import os
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+log = logging.getLogger(__name__)
+
+
+# Exact upstream line. Leading-whitespace-anchored so we cannot
+# accidentally match an unrelated reference to ``num_prompts`` elsewhere
+# in the file (and there are several — e.g. in helper-function arg
+# lists).
+_LEGACY_LINE = '        num_prompts="$max_concurrency"'
+_PATCHED_LINE = '        num_prompts="${NUM_PROMPTS:-$max_concurrency}"'
+# Substring uniquely present after patching; used as the "already
+# patched?" sentinel so we don't have to re-derive the patched line.
+_PATCH_SENTINEL = '${NUM_PROMPTS:-$max_concurrency}'
+
+# System-wide lock. ``/tmp`` is writable inside containers and on the
+# validation Slurm nodes; persistence across reboots isn't needed (the
+# patch itself is persistent on disk).
+_LOCK_PATH = "/tmp/hyperloom_benchmark_lib_patcher.lock"
+
+
+def _resolve_benchmark_lib_path(
+    inferencex_path: Path | str | None,
+) -> Path | None:
+    """Resolve ``<inferencex_root>/benchmarks/benchmark_lib.sh``.
+
+    Returns ``None`` when the path is unconfigured or missing on disk
+    so callers can treat "no InferenceX checkout" as "skip patching"
+    (this is what unit tests need — they exercise profile YAML
+    rendering without provisioning a real InferenceX tree).
+    """
+    root: Path | None = None
+    if inferencex_path:
+        root = Path(inferencex_path)
+    else:
+        env = os.environ.get("INFERENCEX_PATH", "").strip()
+        if env:
+            root = Path(env)
+    if root is None:
+        return None
+    candidate = root / "benchmarks" / "benchmark_lib.sh"
+    return candidate if candidate.is_file() else None
+
+
+@contextmanager
+def _file_lock(lock_path: str) -> Iterator[None]:
+    """Best-effort cross-process mutex via ``fcntl.flock``.
+
+    If the lock file can't be opened (read-only ``/tmp``, exotic
+    sandbox), we fall through *without* exclusion rather than crash:
+    the atomic-replace path below still guarantees no torn writes, and
+    in the worst case two concurrent patchers each produce the same
+    patched bytes (idempotent).
+    """
+    try:
+        fp = open(lock_path, "w")
+    except OSError as e:
+        log.warning(
+            "_inferencex_patcher: cannot open lock file %s (%s); "
+            "proceeding without exclusion",
+            lock_path, e,
+        )
+        yield
+        return
+    try:
+        fcntl.flock(fp.fileno(), fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            fcntl.flock(fp.fileno(), fcntl.LOCK_UN)
+        finally:
+            fp.close()
+
+
+def _is_patched(src: Path) -> bool:
+    try:
+        return _PATCH_SENTINEL in src.read_text(encoding="utf-8")
+    except OSError as e:
+        log.warning("_inferencex_patcher: cannot read %s: %s", src, e)
+        return False
+
+
+def _apply_patch_atomic(src: Path) -> bool:
+    """Rewrite ``src`` via temp-file + atomic rename so a crash
+    mid-write cannot leave a corrupt ``benchmark_lib.sh``.
+    """
+    try:
+        original = src.read_text(encoding="utf-8")
+    except OSError as e:
+        log.warning("_inferencex_patcher: cannot read %s: %s", src, e)
+        return False
+
+    if _LEGACY_LINE not in original:
+        log.warning(
+            "_inferencex_patcher: expected legacy line not found in %s; "
+            "the file may already have been hand-patched to a "
+            "different shape, or the upstream layout has changed. "
+            "Manual review needed.",
+            src,
+        )
+        return False
+
+    patched = original.replace(_LEGACY_LINE, _PATCHED_LINE, 1)
+    if patched == original:
+        # Defence in depth — should never trip given the membership
+        # check above, but cheap to verify.
+        return False
+
+    tmp_dir = src.parent
+    try:
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=".benchmark_lib.sh.hyperloom_",
+            dir=str(tmp_dir),
+        )
+    except OSError as e:
+        log.warning(
+            "_inferencex_patcher: cannot create temp file in %s: %s",
+            tmp_dir, e,
+        )
+        return False
+
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(patched)
+        # Preserve the executable bit (and any other perms) from the
+        # original so the patched file is still runnable as a sourced
+        # library.
+        os.chmod(tmp_name, src.stat().st_mode)
+        os.replace(tmp_name, src)
+    except OSError as e:
+        log.warning("_inferencex_patcher: cannot write %s: %s", src, e)
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        return False
+
+    log.info(
+        "_inferencex_patcher: applied NUM_PROMPTS-respecting patch to "
+        "%s (Hyperloom issue #194 §2)",
+        src,
+    )
+    return True
+
+
+def ensure_benchmark_lib_patched(
+    inferencex_path: Path | str | None = None,
+) -> bool:
+    """Ensure InferenceX ``benchmark_lib.sh`` honours ``$NUM_PROMPTS``.
+
+    Returns ``True`` when the file is in patched state at exit
+    (already-patched or freshly-patched both count); ``False`` when
+    the file could not be located or the expected legacy line is
+    missing.  The latter is non-fatal — callers are expected to log
+    and continue so that smoke / dry-run paths without a real
+    InferenceX checkout still work.
+
+    Safe to call from any number of processes concurrently — the
+    flock serializes the read-then-write window; the temp-file +
+    rename guarantees no torn writes; and the fast-path bypasses the
+    lock entirely when the file is already patched (which is the case
+    for every call after the first on a given checkout).
+    """
+    src = _resolve_benchmark_lib_path(inferencex_path)
+    if src is None:
+        log.info(
+            "_inferencex_patcher: INFERENCEX_PATH unset or "
+            "benchmark_lib.sh missing — skipping patch (this is fine "
+            "for tests and dry-runs without a real InferenceX tree)",
+        )
+        return False
+
+    if _is_patched(src):
+        return True
+
+    with _file_lock(_LOCK_PATH):
+        # Re-check under the lock: another process may have patched
+        # while we were blocked on flock.
+        if _is_patched(src):
+            return True
+        return _apply_patch_atomic(src)
+
+
+__all__ = ["ensure_benchmark_lib_patched"]

--- a/inference_optimizer/orchestrator/action_executors/_server_patcher.py
+++ b/inference_optimizer/orchestrator/action_executors/_server_patcher.py
@@ -1,0 +1,429 @@
+"""Idempotent run-time patcher for vLLM and SGLang server installs
+(Hyperloom issue #194 §4 / §5).
+
+Background
+----------
+
+The TraceLens magpie-benchmark-profiling skill requires three flags
+that are *not* in upstream vLLM / SGLang:
+
+* vLLM:   ``--profiler-config.capture_torch_profiler_dir``
+* vLLM:   ``--profiler-config.detailed_trace_annotation``
+* SGLang: ``--enable-shape-discovery-for-cuda-graph-profile``
+
+These only exist in builds that have the TraceLens patch set applied
+(``TraceLens-internal/examples/custom_workflows/inference_analysis/``).
+Without the patch, vLLM rejects ``capture_torch_profiler_dir`` as an
+"unknown JSON key" and SGLang ``argparse`` errors on the unknown flag —
+the server fails to start and the entire profile run is wasted.
+
+TraceLens's official path is "rebuild a docker image with the patch
+baked in" via ``build_docker_vllm.sh`` / ``build_docker_sglang_*.sh``.
+This module gives Hyperloom users an automatic fallback: at the start
+of every profile run we runtime-patch the in-container Python install
+so the flags become available. Users who already run a TraceLens-
+patched image short-circuit on the idempotent check after the first
+session.
+
+Design contract
+---------------
+
+* **Per-framework, independent**: vLLM and SGLang have separate
+  patchers. The caller invokes only the one matching the YAML's
+  framework (no point patching SGLang if we're running vLLM).
+* **Default on, kill-switchable**: caller is responsible for honouring
+  ``HYPERLOOM_ENABLE_PATCH != "0"`` — this module just answers
+  "did patching succeed?" so the caller knows whether to inject the
+  TraceLens-only flags.
+* **Fail-soft**: any failure (TraceLens repo missing, version
+  unsupported, install layout unexpected, patches don't apply
+  cleanly, file not writable, ``git`` unavailable) returns ``False``.
+  Callers MUST treat ``False`` as "skip TraceLens flags" so the
+  benchmark continues with today's safe behaviour.
+* **Idempotent**: a sentinel-substring check on a known patched file
+  short-circuits subsequent calls in O(1). The Coordinator may invoke
+  this many times in one session (profile, sweep, params, …) — only
+  the first call does real work.
+* **Concurrency-safe**: ``fcntl.flock`` serializes the read-then-write
+  window across processes. Subprocess-level ``git apply`` writes are
+  themselves atomic on a per-file basis (``git`` uses tmp+rename).
+* **All-or-nothing for multi-patch sets**: SGLang requires 10 patches
+  applied together. We run ``git apply --check`` on every patch
+  first; only if every check passes do we apply for real. A mid-flight
+  failure rolls back via ``git apply -R`` on the patches we already
+  applied.
+* **Patches are TraceLens's responsibility**: this module never reads
+  patch contents or maps versions in code. The vLLM patch filename is
+  derived from ``vllm.__version__``; the SGLang patch set is the
+  whole directory. When TraceLens ships a new vLLM version's patch,
+  Hyperloom picks it up transparently.
+
+The patches are backward-compatible by design: vLLM ones add new
+``ProfilerConfig`` dataclass fields with default ``""`` / ``False``;
+SGLang ones add a new ``store_true`` server argument. Behaviour is
+unchanged unless callers explicitly opt in via the new flags. Hence
+the patches are safe to leave applied permanently — no revert path.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import logging
+import os
+import shutil
+import subprocess
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, Sequence
+
+log = logging.getLogger(__name__)
+
+
+# Tunables -------------------------------------------------------------
+
+# System-wide lock file. ``/tmp`` is writable inside containers and on
+# the validation Slurm nodes; cross-reboot persistence isn't needed (the
+# patch itself is persistent on disk inside the container).
+_LOCK_PATH = "/tmp/hyperloom_server_patcher.lock"
+
+# Per-``git`` invocation timeout. ``git apply`` on a single patch is
+# millisecond-fast in practice; this cap is purely defensive against
+# hung NFS / weird filesystems.
+_GIT_TIMEOUT_SEC = 30
+
+# TraceLens currently ships SGLang patches only for v0.5.9. Hyperloom's
+# default deployment uses v0.5.10 — version mismatch is the *common* case
+# and must fail-soft cleanly. Bump this string when TraceLens adds new
+# versions (or refactor to discover via a manifest file inside the
+# patches directory).
+_SGLANG_SUPPORTED_VERSIONS: frozenset[str] = frozenset({"0.5.9"})
+
+# Path within the TraceLens checkout that hosts the patch sets.
+_PATCH_TREE_REL = ("examples", "custom_workflows", "inference_analysis")
+
+
+# ---------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------
+
+def ensure_vllm_patched_for_tracelens(
+    tracelens_root: Path | str | None = None,
+) -> bool:
+    """Apply the TraceLens config patch matching the installed vLLM
+    version. Returns ``True`` if the install is in patched state at
+    exit (already-patched or freshly-patched both count); ``False`` on
+    any fail-soft outcome. Callers MUST treat ``False`` as "do not
+    inject TraceLens-only profiler flags".
+    """
+    plan = _discover_vllm_plan(tracelens_root)
+    if plan is None:
+        return False
+    return _ensure_patched(plan)
+
+
+def ensure_sglang_patched_for_tracelens(
+    tracelens_root: Path | str | None = None,
+) -> bool:
+    """SGLang counterpart of :func:`ensure_vllm_patched_for_tracelens`.
+    Applies the 10-patch roofline / shape-discovery set as a single
+    atomic transaction (``--check`` all first, rollback on mid-apply
+    failure)."""
+    plan = _discover_sglang_plan(tracelens_root)
+    if plan is None:
+        return False
+    return _ensure_patched(plan)
+
+
+# ---------------------------------------------------------------------
+# Plan discovery
+# ---------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _PatchPlan:
+    """All information needed to apply (or verify) a patch set."""
+    framework: str
+    version: str
+    apply_root: Path             # cwd for ``git apply``
+    patches: tuple[Path, ...]    # in apply order
+    sentinel_file: Path          # file we grep to detect "already patched"
+    sentinel_text: str           # substring expected in sentinel_file
+
+
+def _resolve_tracelens_root(arg: Path | str | None) -> Path | None:
+    """Resolve TRACELENS_ROOT from arg → env → None. Fail-soft when
+    the path is unset or missing on disk so tests / dry-runs without
+    a real TraceLens checkout don't crash."""
+    if arg:
+        root = Path(arg)
+    else:
+        env = os.environ.get("TRACELENS_ROOT", "").strip()
+        if not env:
+            return None
+        root = Path(env)
+    return root if root.is_dir() else None
+
+
+def _patch_tree(tracelens_root: Path, leaf: str) -> Path:
+    """``<tracelens>/examples/custom_workflows/inference_analysis/<leaf>``."""
+    return tracelens_root.joinpath(*_PATCH_TREE_REL, leaf)
+
+
+def _discover_vllm_plan(arg: Path | str | None) -> _PatchPlan | None:
+    tracelens_root = _resolve_tracelens_root(arg)
+    if tracelens_root is None:
+        log.info(
+            "_server_patcher: TRACELENS_ROOT unset/missing — skip vLLM patch"
+        )
+        return None
+
+    try:
+        import vllm  # type: ignore  # noqa: I001 - runtime probe
+    except Exception as e:  # noqa: BLE001 - any import failure → fail-soft
+        log.info("_server_patcher: vllm not importable (%s); skip patch", e)
+        return None
+
+    version = (getattr(vllm, "__version__", "") or "").strip()
+    if not version:
+        log.info("_server_patcher: vllm has no __version__; skip patch")
+        return None
+
+    patch_file = _patch_tree(tracelens_root, "vllm_patches") / (
+        f"config_vllm_v{version}.patch"
+    )
+    if not patch_file.is_file():
+        log.info(
+            "_server_patcher: no TraceLens patch for vLLM %s "
+            "(looked for %s); skip", version, patch_file,
+        )
+        return None
+
+    # ``Path(vllm.__file__)`` is ``.../site-packages/vllm/__init__.py``;
+    # the apply root for the patch (which uses ``a/vllm/...`` prefix) is
+    # the parent of the ``vllm/`` package directory, i.e. site-packages.
+    install_root = Path(vllm.__file__).resolve().parent.parent
+    sentinel = install_root / "vllm" / "config" / "profiler.py"
+    if not sentinel.is_file():
+        log.info(
+            "_server_patcher: vLLM install layout unexpected "
+            "(no %s); skip patch", sentinel,
+        )
+        return None
+
+    return _PatchPlan(
+        framework="vllm",
+        version=version,
+        apply_root=install_root,
+        patches=(patch_file,),
+        sentinel_file=sentinel,
+        sentinel_text="capture_torch_profiler_dir",
+    )
+
+
+def _discover_sglang_plan(arg: Path | str | None) -> _PatchPlan | None:
+    tracelens_root = _resolve_tracelens_root(arg)
+    if tracelens_root is None:
+        log.info(
+            "_server_patcher: TRACELENS_ROOT unset/missing — skip SGLang patch"
+        )
+        return None
+
+    try:
+        import sglang  # type: ignore  # noqa: I001 - runtime probe
+    except Exception as e:  # noqa: BLE001
+        log.info("_server_patcher: sglang not importable (%s); skip patch", e)
+        return None
+
+    version = (getattr(sglang, "__version__", "") or "").strip()
+    if version not in _SGLANG_SUPPORTED_VERSIONS:
+        log.info(
+            "_server_patcher: SGLang %s not in supported set %s; skip "
+            "(TraceLens ships patches for these versions only — bump "
+            "_SGLANG_SUPPORTED_VERSIONS when TraceLens adds support)",
+            version, sorted(_SGLANG_SUPPORTED_VERSIONS),
+        )
+        return None
+
+    patches_dir = _patch_tree(tracelens_root, "sglang_roofline_patches")
+    if not patches_dir.is_dir():
+        log.info(
+            "_server_patcher: SGLang patches directory missing (%s); skip",
+            patches_dir,
+        )
+        return None
+    patches = tuple(sorted(patches_dir.glob("*.patch")))
+    if not patches:
+        log.info("_server_patcher: SGLang patches directory empty; skip")
+        return None
+
+    # The SGLang patches use ``a/python/sglang/...`` prefix — they
+    # assume an editable install where the repo's ``python/sglang/...``
+    # layout is preserved. For pip-wheel installs ``sglang/`` sits
+    # directly under site-packages with no ``python/`` parent, so the
+    # patches' ``-p1`` strip won't match.
+    sglang_module = Path(sglang.__file__).resolve()
+    if sglang_module.parent.parent.name != "python":
+        log.info(
+            "_server_patcher: SGLang install at %s is not an editable "
+            "`python/sglang/` layout — patches assume that layout, so "
+            "skip patching", sglang_module,
+        )
+        return None
+    apply_root = sglang_module.parent.parent.parent
+
+    # Sentinel: the kernel_shape_profiler patch creates an entirely new
+    # file. Its presence + a unique content marker is a robust "already
+    # patched" signal.
+    sentinel = (
+        apply_root / "python" / "sglang" / "srt" / "utils"
+        / "kernel_shape_profiler.py"
+    )
+    return _PatchPlan(
+        framework="sglang",
+        version=version,
+        apply_root=apply_root,
+        patches=patches,
+        sentinel_file=sentinel,
+        sentinel_text="kernel_shape_profiler",
+    )
+
+
+# ---------------------------------------------------------------------
+# Application core
+# ---------------------------------------------------------------------
+
+
+def _ensure_patched(plan: _PatchPlan) -> bool:
+    """Fast no-lock path → lock → re-check → atomic apply."""
+    if _is_patched(plan):
+        return True
+    with _file_lock(_LOCK_PATH):
+        if _is_patched(plan):
+            return True
+        return _apply_atomic(plan)
+
+
+def _is_patched(plan: _PatchPlan) -> bool:
+    try:
+        if not plan.sentinel_file.exists():
+            return False
+        return plan.sentinel_text in plan.sentinel_file.read_text(
+            encoding="utf-8", errors="replace",
+        )
+    except OSError:
+        return False
+
+
+@contextmanager
+def _file_lock(path: str) -> Iterator[None]:
+    """Best-effort cross-process exclusion. If ``/tmp`` is read-only we
+    proceed unsynchronized — the worst case is two patchers each
+    deciding "I'll apply", at which point only the first wins (``git
+    apply`` of an already-applied patch errors out, and the second
+    patcher then re-checks the sentinel and short-circuits)."""
+    try:
+        fp = open(path, "w")
+    except OSError as e:
+        log.warning(
+            "_server_patcher: cannot open lock %s (%s); proceeding without "
+            "exclusion", path, e,
+        )
+        yield
+        return
+    try:
+        fcntl.flock(fp.fileno(), fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            fcntl.flock(fp.fileno(), fcntl.LOCK_UN)
+        finally:
+            fp.close()
+
+
+def _apply_atomic(plan: _PatchPlan) -> bool:
+    """Apply every patch in ``plan.patches`` as a transaction.
+
+    Strategy:
+
+    1. ``git apply --check`` every patch first. If any pre-check
+       fails, none get applied → caller stays in fail-soft mode.
+    2. Apply for real one at a time. If patch *k* fails after we have
+       already applied 0..k-1, reverse-apply 0..k-1 to leave the
+       install in its original state, then return ``False``.
+    """
+    git = shutil.which("git")
+    if git is None:
+        log.warning(
+            "_server_patcher: `git` not on PATH — cannot apply %s patches "
+            "(install git in the runtime image to enable TraceLens flags)",
+            plan.framework,
+        )
+        return False
+
+    for p in plan.patches:
+        if not _git(git, ("apply", "--check", str(p)), plan.apply_root):
+            log.warning(
+                "_server_patcher: `git apply --check` failed for %s "
+                "(version %s, patch %s); fail-soft skip",
+                plan.framework, plan.version, p.name,
+            )
+            return False
+
+    applied: list[Path] = []
+    for p in plan.patches:
+        if _git(git, ("apply", str(p)), plan.apply_root):
+            applied.append(p)
+            continue
+        log.error(
+            "_server_patcher: %s patch %s failed during apply after "
+            "passing --check; rolling back %d previously-applied patches",
+            plan.framework, p.name, len(applied),
+        )
+        for prev in reversed(applied):
+            if not _git(git, ("apply", "-R", str(prev)), plan.apply_root):
+                log.error(
+                    "_server_patcher: rollback of %s also failed — "
+                    "install may be in inconsistent state; manual review "
+                    "required", prev.name,
+                )
+        return False
+
+    log.info(
+        "_server_patcher: applied %d TraceLens patch(es) for %s %s "
+        "(issue #194 §4/§5)",
+        len(plan.patches), plan.framework, plan.version,
+    )
+    return True
+
+
+def _git(git: str, args: Sequence[str], cwd: Path) -> bool:
+    """Run ``git <args>`` in ``cwd``. Returns True iff rc == 0."""
+    try:
+        result = subprocess.run(
+            (git, *args),
+            cwd=str(cwd),
+            capture_output=True,
+            timeout=_GIT_TIMEOUT_SEC,
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        log.warning(
+            "_server_patcher: git %s in %s failed to spawn (%s)",
+            list(args), cwd, e,
+        )
+        return False
+    if result.returncode != 0:
+        err = result.stderr.decode("utf-8", errors="replace")[:500] \
+            if result.stderr else ""
+        log.debug(
+            "_server_patcher: git %s rc=%d stderr=%r",
+            list(args), result.returncode, err,
+        )
+        return False
+    return True
+
+
+__all__ = [
+    "ensure_vllm_patched_for_tracelens",
+    "ensure_sglang_patched_for_tracelens",
+]

--- a/inference_optimizer/orchestrator/action_executors/_workload_envs.py
+++ b/inference_optimizer/orchestrator/action_executors/_workload_envs.py
@@ -45,8 +45,32 @@ import yaml
 
 from ...paths import asset_root
 from ._grid_runner import server_args_env_name
+from ._server_patcher import (
+    ensure_sglang_patched_for_tracelens,
+    ensure_vllm_patched_for_tracelens,
+)
 
 log = logging.getLogger(__name__)
+
+
+def _tracelens_patch_enabled() -> bool:
+    """Read the ``HYPERLOOM_ENABLE_PATCH`` kill switch (default on).
+
+    Set ``HYPERLOOM_ENABLE_PATCH=0`` to disable runtime patching of
+    vLLM / SGLang — Hyperloom then keeps today's safe behaviour
+    (no TraceLens-only profiler flags injected). Useful when:
+
+    * the user runs a custom vLLM/SGLang fork they don't want touched,
+    * the patcher itself ships a bug and the user needs an escape hatch
+      without a Hyperloom release,
+    * compliance / audit forbids modifying installed packages at runtime.
+
+    Default is ``"1"`` (patching on) because the patches are backward-
+    compatible and add no flags by themselves — they only enable
+    capabilities Hyperloom requests via ``EXTRA_VLLM_ARGS`` /
+    ``EXTRA_SGLANG_ARGS`` when patching succeeds.
+    """
+    return os.environ.get("HYPERLOOM_ENABLE_PATCH", "1").strip() != "0"
 
 
 def default_baseline_config() -> Path:
@@ -192,19 +216,44 @@ def materialize_config_with_envs(
         )
         profile_num_prompts = max(safe_conc, iters_to_prompts * 2)
         fw = str(bench.get("framework") or "").lower()
+        # Issue #194 §4 / §5: TraceLens-required profiler flags exist
+        # only in patched vLLM / SGLang builds. Try to apply the
+        # TraceLens patch set to the in-container install; on success
+        # we inject the extra flags below, on failure we silently fall
+        # back to today's safe set so vanilla images keep working.
+        # Default-on, disable via HYPERLOOM_ENABLE_PATCH=0.
+        tracelens_patch_ok = False
+        if _tracelens_patch_enabled():
+            if "vllm" in fw:
+                tracelens_patch_ok = ensure_vllm_patched_for_tracelens()
+            else:
+                tracelens_patch_ok = ensure_sglang_patched_for_tracelens()
         if "vllm" in fw:
             existing_vllm_args = str(envs.get("EXTRA_VLLM_ARGS", ""))
-            # Do not inject capture_torch_profiler_dir by default: the vLLM
-            # build on current MI355X validation nodes rejects that field in
-            # --profiler-config. Magpie's vllm_*.sh already injects the
-            # supported torch profiler fields and we add TraceLens' stable
-            # timing/annotation knobs here.
-            profiler_args = (
-                f"--profiler-config.delay_iterations {delay_iters} "
-                f"--profiler-config.max_iterations {max_iters}"
-            )
+            profiler_args_parts = [
+                f"--profiler-config.delay_iterations {delay_iters}",
+                f"--profiler-config.max_iterations {max_iters}",
+            ]
+            if tracelens_patch_ok:
+                # #194 §4: a TraceLens-patched vLLM exposes
+                # capture_torch_profiler_dir + detailed_trace_annotation
+                # on its ProfilerConfig. Both are new dataclass fields
+                # with safe defaults — unpatched vLLM rejects them as
+                # unknown JSON keys, which is why we gate on the
+                # patcher result.
+                capture_dir = output_dir / "capture_traces"
+                profiler_args_parts.append(
+                    "--profiler-config.capture_torch_profiler_dir "
+                    f"{capture_dir}"
+                )
+                profiler_args_parts.append(
+                    "--profiler-config.detailed_trace_annotation True"
+                )
+            profiler_args = " ".join(profiler_args_parts)
             if "delay_iterations" not in existing_vllm_args:
-                envs["EXTRA_VLLM_ARGS"] = f"{existing_vllm_args} {profiler_args}".strip()
+                envs["EXTRA_VLLM_ARGS"] = (
+                    f"{existing_vllm_args} {profiler_args}".strip()
+                )
         else:
             import json as _json
             try:
@@ -218,6 +267,18 @@ def materialize_config_with_envs(
             extra_body.setdefault("shape_discovery", True)
             extra_body.setdefault("roofline_annotations", True)
             envs["PROFILE_EXTRA_BODY"] = _json.dumps(extra_body)
+            if tracelens_patch_ok:
+                # #194 §5: a TraceLens-patched SGLang exposes
+                # --enable-shape-discovery-for-cuda-graph-profile as a
+                # server CLI flag. Without the patch SGLang's argparse
+                # errors out on this flag — gate strictly on the
+                # patcher result.
+                existing_sglang = str(envs.get("EXTRA_SGLANG_ARGS", ""))
+                if "shape-discovery-for-cuda-graph-profile" not in existing_sglang:
+                    envs["EXTRA_SGLANG_ARGS"] = (
+                        f"{existing_sglang} "
+                        "--enable-shape-discovery-for-cuda-graph-profile"
+                    ).strip()
 
     if profile_num_prompts is not None:
         # Profile mode: force-override caller/YAML NUM_PROMPTS — we need a

--- a/inference_optimizer/orchestrator/action_executors/_workload_envs.py
+++ b/inference_optimizer/orchestrator/action_executors/_workload_envs.py
@@ -162,12 +162,14 @@ def materialize_config_with_envs(
         str(envs.get("PROFILE", "")).strip() == "1"
         or (bench.get("profiler", {}).get("torch_profiler", {}).get("enabled") is True)
     )
+    profile_num_prompts: int | None = None
     if is_profile:
         try:
             r_val = float(envs.get("RANDOM_RANGE_RATIO", 1.0))
         except (TypeError, ValueError):
             r_val = 1.0
         safe_conc = max(conc_val, 1)
+        safe_osl = max(osl_val, 1)
         max_iters = min(1024, max(256, (osl_val * 16) // safe_conc))
         delay_iters = int(osl_val * (r_val + 1) * 3 - max_iters / 2)
         # Guard against pathological inputs (tiny OSL / huge R producing a
@@ -175,6 +177,20 @@ def materialize_config_with_envs(
         # captures warmup). Clamp to >= 0.
         if delay_iters < 0:
             delay_iters = 0
+        # TraceLens #194 §2: NUM_PROMPTS must be large enough that the
+        # benchmark engine reaches `delay_iters + max_iters` decode steps
+        # before it runs out of prompts. With continuous batching at
+        # concurrency CONC and average output length OSL, processing N
+        # prompts costs roughly N * OSL / CONC engine iterations; invert
+        # to get the prompt floor, then apply a 2x safety buffer for
+        # prefill / scheduling drift. Hyperloom owns this — we ignore any
+        # NUM_PROMPTS the caller passes when PROFILE is on, otherwise an
+        # under-sized value silently empties the trace.
+        required_iters = delay_iters + max_iters
+        iters_to_prompts = max(
+            1, (required_iters * safe_conc + safe_osl - 1) // safe_osl,
+        )
+        profile_num_prompts = max(safe_conc, iters_to_prompts * 2)
         fw = str(bench.get("framework") or "").lower()
         if "vllm" in fw:
             existing_vllm_args = str(envs.get("EXTRA_VLLM_ARGS", ""))
@@ -203,17 +219,23 @@ def materialize_config_with_envs(
             extra_body.setdefault("roofline_annotations", True)
             envs["PROFILE_EXTRA_BODY"] = _json.dumps(extra_body)
 
-    seq_cost = isl_val + osl_val
-    if seq_cost <= 1024:
-        factor = 10
-    elif seq_cost <= 4096:
-        factor = 5
-    elif seq_cost <= 16384:
-        factor = 3
+    if profile_num_prompts is not None:
+        # Profile mode: force-override caller/YAML NUM_PROMPTS — we need a
+        # specific minimum to reach the steady-state window, and an
+        # under-sized value silently empties the trace.
+        envs["NUM_PROMPTS"] = profile_num_prompts
     else:
-        factor = 2
-    if "NUM_PROMPTS" not in envs:
-        envs["NUM_PROMPTS"] = max(conc_val * factor, conc_val)
+        seq_cost = isl_val + osl_val
+        if seq_cost <= 1024:
+            factor = 10
+        elif seq_cost <= 4096:
+            factor = 5
+        elif seq_cost <= 16384:
+            factor = 3
+        else:
+            factor = 2
+        if "NUM_PROMPTS" not in envs:
+            envs["NUM_PROMPTS"] = max(conc_val * factor, conc_val)
     if "NUM_WARMUPS" not in envs:
         envs["NUM_WARMUPS"] = min(conc_val, 8)
     if server_args:

--- a/inference_optimizer/orchestrator/action_executors/_workload_envs.py
+++ b/inference_optimizer/orchestrator/action_executors/_workload_envs.py
@@ -112,11 +112,17 @@ def materialize_config_with_envs(
         bench.pop("benchmark_script", None)
     envs = bench.setdefault("envs", {})
     for env_key in (
-        "CONC", "ISL", "OSL", "MAX_MODEL_LEN", "TP", "RANDOM_RANGE_RATIO",
+        "CONC", "ISL", "OSL", "MAX_MODEL_LEN", "TP",
     ):
         val = os.environ.get(env_key, "").strip()
         if val:
             envs[env_key] = int(val)
+    # RANDOM_RANGE_RATIO is a float (skill default 1.0; common values include
+    # 0.5). It feeds the steady-state delay/max formulas below; do not coerce
+    # to int or the prefill window estimate collapses for fractional ratios.
+    r_env = os.environ.get("RANDOM_RANGE_RATIO", "").strip()
+    if r_env:
+        envs["RANDOM_RANGE_RATIO"] = float(r_env)
     rocr_env = os.environ.get("ROCR_VISIBLE_DEVICES", "").strip()
     if rocr_env:
         envs["ROCR_VISIBLE_DEVICES"] = rocr_env
@@ -138,17 +144,37 @@ def materialize_config_with_envs(
     osl_val = int(os.environ.get("OSL") or envs.get("OSL") or 256)
     conc_val = int(os.environ.get("CONC") or envs.get("CONC") or 8)
 
-    # TraceLens #126: compute steady-state window for profiling configs.
+    # TraceLens #194: compute steady-state window for profiling configs.
     # Only inject when this is a profile yaml — detected by PROFILE env or
     # `profiler.torch_profiler.enabled: true` in the YAML. The formulas
-    # match issue #126 §3.1.6.
+    # match the TraceLens magpie-benchmark-profiling skill (Option A:
+    # targeted steady-state window) so that Hyperloom-driven profiles
+    # capture the same decode-heavy slice as a manual TraceLens run.
+    #
+    # Skill formulas (RANDOM_RANGE_RATIO defaults to 1.0 if absent):
+    #   max_iters   = min(1024, max(256, OSL * 16 / CONC))
+    #   delay_iters = OSL * (R + 1) * 3 - max_iters / 2
+    #
+    # Example OSL=1024 / CONC=32 / R=1 → max=512, delay=5888 (vs. the
+    # previous 5*CONC / clamp(16*OSL/CONC,4,64) which gave 160 / 64 —
+    # roughly 1/8 of the steady-state window the skill recommends).
     is_profile = (
         str(envs.get("PROFILE", "")).strip() == "1"
         or (bench.get("profiler", {}).get("torch_profiler", {}).get("enabled") is True)
     )
     if is_profile:
-        delay_iters = 5 * conc_val
-        max_iters = max(4, min(64, 16 * osl_val // max(conc_val, 1)))
+        try:
+            r_val = float(envs.get("RANDOM_RANGE_RATIO", 1.0))
+        except (TypeError, ValueError):
+            r_val = 1.0
+        safe_conc = max(conc_val, 1)
+        max_iters = min(1024, max(256, (osl_val * 16) // safe_conc))
+        delay_iters = int(osl_val * (r_val + 1) * 3 - max_iters / 2)
+        # Guard against pathological inputs (tiny OSL / huge R producing a
+        # negative delay collapses to "profile from step 0", which still
+        # captures warmup). Clamp to >= 0.
+        if delay_iters < 0:
+            delay_iters = 0
         fw = str(bench.get("framework") or "").lower()
         if "vllm" in fw:
             existing_vllm_args = str(envs.get("EXTRA_VLLM_ARGS", ""))

--- a/inference_optimizer/orchestrator/action_executors/profile.py
+++ b/inference_optimizer/orchestrator/action_executors/profile.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import Any
 
 from ...paths import asset_root
+from ._inferencex_patcher import ensure_benchmark_lib_patched
 from .baseline import BaselineExecutor
 
 
@@ -89,6 +90,15 @@ class ProfileExecutor(BaselineExecutor):
                 ctx.extra = {"workspace": str(output_dir)}
             else:
                 extra["workspace"] = str(output_dir)
+        # Issue #194 §2: ensure InferenceX's benchmark_lib.sh honours
+        # $NUM_PROMPTS. _workload_envs computes a NUM_PROMPTS large
+        # enough to reach the steady-state window, but unpatched
+        # upstream stomps it on every PROFILE=1 run — silently
+        # producing empty traces. The patch is backward-compatible
+        # (no-op when NUM_PROMPTS is unset) and idempotent, so calling
+        # this on every profile launch costs ~1 file read after the
+        # first success.
+        ensure_benchmark_lib_patched()
         result = await super().__call__(ctx)
         # Augment with trace_dir if the workspace produced one.
         workspace_str = result.get("workspace")

--- a/inference_optimizer/scripts/configs/profile_sglang.yaml
+++ b/inference_optimizer/scripts/configs/profile_sglang.yaml
@@ -41,11 +41,15 @@ benchmark:
     # --- Profiler: graph capture (#126; shape-discovery flag dropped
     # because the deployed SGLang argparse rejects it) ---
     EXTRA_SGLANG_ARGS: "--enable-profile-cuda-graph"
-    # --- Profiler: steady-state window via extra_body (#126) ---
+    # --- Profiler: steady-state window via extra_body (#194) ---
     # PROFILE_EXTRA_BODY is consumed by InferenceX benchmark_lib.sh to inject
     # into the benchmark request body. start_step skips warmup, num_steps
     # limits trace size. Values are overridden at runtime by
-    # _materialize_config_with_envs based on ISL/OSL/CONC.
+    # _materialize_config_with_envs using the TraceLens magpie skill
+    # formulas (issue #194):
+    #   num_steps   (max_iters)   = min(1024, max(256, OSL * 16 / CONC))
+    #   start_step  (delay_iters) = OSL * (RANDOM_RANGE_RATIO + 1) * 3
+    #                                 - max_iters / 2
     PROFILE_EXTRA_BODY: '{"shape_discovery": true, "roofline_annotations": true, "start_step": 40, "num_steps": 16, "merge_profiles": false, "profile_by_stage": false}'
     # --- Profile mode: cap prompts to reduce trace size ---
     PROFILE: "1"

--- a/inference_optimizer/scripts/configs/profile_sglang.yaml
+++ b/inference_optimizer/scripts/configs/profile_sglang.yaml
@@ -11,12 +11,23 @@
 #   3. Steady-state windowing (PROFILE_EXTRA_BODY start_step/num_steps)
 # These are required for TraceLens fusion / roofline analysis.
 #
-# Note: upstream issue #126 also lists
-# `--enable-shape-discovery-for-cuda-graph-profile`, but the SGLang
-# build on the current validation nodes rejects it ("unrecognized
-# arguments"). It stays out of the default args until the deployed
-# SGLang accepts it; override via EXTRA_SGLANG_ARGS or the materialized
-# ASSET_ROOT yaml when running on a newer SGLang.
+# Issue #194 §5: `--enable-shape-discovery-for-cuda-graph-profile` is
+# *not* in upstream SGLang argparse — it comes from the TraceLens patch
+# set at TraceLens-internal/examples/custom_workflows/inference_analysis/
+# sglang_roofline_patches/. Hyperloom's runtime patcher
+# (HYPERLOOM_ENABLE_PATCH=1, default) tries to apply the 10-patch
+# atomic transaction to the in-container SGLang install at the start
+# of every profile, but only when the installed SGLang version matches
+# TraceLens's supported set (currently v0.5.9; bump in
+# `_server_patcher._SGLANG_SUPPORTED_VERSIONS` when TraceLens adds more).
+# If patching succeeds, materialize_config_with_envs auto-appends the
+# flag to EXTRA_SGLANG_ARGS; if it fails (version unsupported,
+# non-editable install layout, fs read-only, ...) we fall back to
+# today's safe behaviour: only --enable-profile-cuda-graph plus the
+# client-side PROFILE_EXTRA_BODY shape_discovery / roofline_annotations
+# settings (which go through SGLang's /start_profile API and don't need
+# a patched server). Set HYPERLOOM_ENABLE_PATCH=0 to disable runtime
+# patching entirely.
 
 benchmark:
   framework: sglang

--- a/inference_optimizer/scripts/configs/profile_vllm.yaml
+++ b/inference_optimizer/scripts/configs/profile_vllm.yaml
@@ -14,12 +14,18 @@
 #      vllm_*.sh when PROFILE=1.
 # These are required for TraceLens fusion / roofline analysis.
 #
-# Note: `--profiler-config.detailed_trace_annotation` was a transient
-# field on a fork of vLLM 0.15. It is NOT part of the upstream
-# ProfilerConfig schema (vLLM 0.19 rejects it as an unknown JSON key),
-# so we no longer inject it. capture_torch_profiler_dir is also not
-# in the upstream schema yet; re-enable both once they land in the
-# deployed vLLM build.
+# Issue #194 §4: `capture_torch_profiler_dir` and
+# `detailed_trace_annotation` are *not* in upstream vLLM 0.19 — they
+# come from the TraceLens patch set at
+# TraceLens-internal/examples/custom_workflows/inference_analysis/vllm_patches/.
+# Hyperloom's runtime patcher (HYPERLOOM_ENABLE_PATCH=1, default) tries
+# to apply the matching `config_vllm_v<version>.patch` against the
+# in-container vLLM install at the start of every profile. If patching
+# succeeds, materialize_config_with_envs auto-appends those two flags
+# to EXTRA_VLLM_ARGS; if it fails (version unsupported, fs read-only,
+# already-patched fork, etc.) we fall back to today's safe behaviour:
+# only delay_iterations / max_iterations + ignore_frontend get injected.
+# Set HYPERLOOM_ENABLE_PATCH=0 to disable runtime patching entirely.
 
 benchmark:
   framework: vllm

--- a/inference_optimizer/scripts/configs/profile_vllm.yaml
+++ b/inference_optimizer/scripts/configs/profile_vllm.yaml
@@ -44,8 +44,10 @@ benchmark:
     # record_shapes / with_memory / with_flops / use_gzip); we add the
     # TraceLens-relevant knobs that map to upstream ProfilerConfig in
     # the validation vLLM build (0.19+). delay_iterations and
-    # max_iterations are overridden by _materialize_config_with_envs:
-    #   delay = 5 * CONC (skip warmup); max = clamp(16 * OSL / CONC, 4, 64)
+    # max_iterations are overridden by _materialize_config_with_envs
+    # using the TraceLens magpie skill formulas (issue #194):
+    #   max_iters   = min(1024, max(256, OSL * 16 / CONC))
+    #   delay_iters = OSL * (RANDOM_RANGE_RATIO + 1) * 3 - max_iters / 2
     EXTRA_VLLM_ARGS: "--profiler-config.ignore_frontend True"
     # vLLM timeout must be extended during profiling (graph capture is slow)
     VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "1200"

--- a/inference_optimizer/tests/test_inferencex_patcher.py
+++ b/inference_optimizer/tests/test_inferencex_patcher.py
@@ -1,0 +1,239 @@
+"""Tests for `_inferencex_patcher.ensure_benchmark_lib_patched`
+(Hyperloom issue #194 §2).
+
+The patcher's contract:
+
+* Apply a minimal, backward-compatible patch to
+  ``<INFERENCEX_PATH>/benchmarks/benchmark_lib.sh`` so it honours
+  ``$NUM_PROMPTS`` when set, but behaves identically to upstream when
+  it is unset.
+* Idempotent — repeated calls are no-ops once the sentinel substring
+  is present.
+* Concurrency-safe — two callers racing the same checkout end up with
+  one patched file, not double-patched garbage.
+* Fail-soft — missing ``INFERENCEX_PATH``, missing file, or an
+  already-mutated file all return ``False`` instead of raising, so
+  unrelated unit tests and dry-runs don't blow up.
+
+The fixtures here synthesize a fake ``InferenceX/benchmarks/`` tree in
+a tmp dir so we never touch the real ``/wekafs/InferenceX``.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from inference_optimizer.orchestrator.action_executors._inferencex_patcher import (
+    ensure_benchmark_lib_patched,
+)
+
+
+# A reduced fixture that captures the exact upstream shape the patcher
+# targets. Keeping this verbatim (including the leading 8-space indent)
+# is load-bearing — the patcher matches on that exact prefix to avoid
+# false-positive matches against unrelated `num_prompts` references.
+_UPSTREAM_FIXTURE = """\
+#!/usr/bin/env bash
+run_benchmark_serving() {
+    local num_prompts=""
+    local max_concurrency=""
+    # ... arg parsing elided for fixture brevity ...
+    if [[ "${PROFILE:-}" == "1" ]]; then
+        profile_flag+=(--profile)
+        num_prompts="$max_concurrency"
+    fi
+    invoke_benchmark --num-prompts "$num_prompts"
+}
+"""
+
+_PATCHED_LINE = '        num_prompts="${NUM_PROMPTS:-$max_concurrency}"'
+_LEGACY_LINE = '        num_prompts="$max_concurrency"'
+
+
+@pytest.fixture
+def fake_inferencex(tmp_path: Path) -> Path:
+    """Build a minimal `<root>/benchmarks/benchmark_lib.sh` tree."""
+    bench_dir = tmp_path / "benchmarks"
+    bench_dir.mkdir()
+    lib = bench_dir / "benchmark_lib.sh"
+    lib.write_text(_UPSTREAM_FIXTURE, encoding="utf-8")
+    return tmp_path
+
+
+# ===========================================================================
+# Happy path: fresh checkout → patch lands; second call is a no-op.
+# ===========================================================================
+def test_first_call_patches_the_legacy_line(fake_inferencex):
+    rc = ensure_benchmark_lib_patched(fake_inferencex)
+    assert rc is True
+    text = (fake_inferencex / "benchmarks" / "benchmark_lib.sh").read_text()
+    assert _PATCHED_LINE in text
+    assert _LEGACY_LINE not in text
+
+
+def test_second_call_is_a_noop(fake_inferencex):
+    """Idempotency: re-applying must not double-patch or change bytes."""
+    ensure_benchmark_lib_patched(fake_inferencex)
+    after_first = (fake_inferencex / "benchmarks" / "benchmark_lib.sh").read_text()
+    rc = ensure_benchmark_lib_patched(fake_inferencex)
+    assert rc is True
+    after_second = (fake_inferencex / "benchmarks" / "benchmark_lib.sh").read_text()
+    assert after_first == after_second, (
+        "Second call mutated the file — patch is not idempotent"
+    )
+
+
+def test_patched_line_appears_exactly_once(fake_inferencex):
+    """Belt-and-braces: even with multiple invocations, the sentinel
+    must appear exactly once. A double-patch (sentinel-in-sentinel)
+    would corrupt bash parsing."""
+    for _ in range(5):
+        ensure_benchmark_lib_patched(fake_inferencex)
+    text = (fake_inferencex / "benchmarks" / "benchmark_lib.sh").read_text()
+    assert text.count(_PATCHED_LINE) == 1
+
+
+# ===========================================================================
+# Backward-compatibility: the patched shell expression must reduce to
+# the original behavior when NUM_PROMPTS is unset. We verify this by
+# running the snippet through bash and inspecting the resulting value.
+# ===========================================================================
+def test_patch_is_backward_compatible_when_num_prompts_unset(
+    fake_inferencex, tmp_path, monkeypatch,
+):
+    """Sanity-check that the patched line evaluates identically to the
+    original when NUM_PROMPTS is not in the environment."""
+    import shutil
+    import subprocess
+    if shutil.which("bash") is None:
+        pytest.skip("bash unavailable in this environment")
+    ensure_benchmark_lib_patched(fake_inferencex)
+    # Eval a minimal harness that mirrors the patched line.
+    snippet = (
+        'max_concurrency=42\n'
+        'unset NUM_PROMPTS\n'
+        'num_prompts="${NUM_PROMPTS:-$max_concurrency}"\n'
+        'echo "$num_prompts"\n'
+    )
+    out = subprocess.run(
+        ["bash", "-c", snippet],
+        capture_output=True, text=True, check=True,
+    )
+    assert out.stdout.strip() == "42"
+
+
+def test_patched_line_uses_num_prompts_when_set(fake_inferencex):
+    """The patch's whole point: when NUM_PROMPTS env IS set, it wins
+    over the hard-coded reset."""
+    import shutil
+    import subprocess
+    if shutil.which("bash") is None:
+        pytest.skip("bash unavailable in this environment")
+    ensure_benchmark_lib_patched(fake_inferencex)
+    snippet = (
+        'max_concurrency=42\n'
+        'NUM_PROMPTS=999\n'
+        'num_prompts="${NUM_PROMPTS:-$max_concurrency}"\n'
+        'echo "$num_prompts"\n'
+    )
+    out = subprocess.run(
+        ["bash", "-c", snippet],
+        capture_output=True, text=True, check=True,
+    )
+    assert out.stdout.strip() == "999"
+
+
+# ===========================================================================
+# Fail-soft: missing config / file / legacy line must NOT raise.
+# ===========================================================================
+def test_returns_false_when_inferencex_path_unset(tmp_path, monkeypatch):
+    """No INFERENCEX_PATH and no explicit arg → returns False, no
+    crash. Lets dry-runs and CI-without-real-checkout proceed."""
+    monkeypatch.delenv("INFERENCEX_PATH", raising=False)
+    assert ensure_benchmark_lib_patched(None) is False
+
+
+def test_returns_false_when_benchmark_lib_missing(tmp_path):
+    """A valid root with no benchmarks/ subtree must not raise."""
+    assert ensure_benchmark_lib_patched(tmp_path) is False
+
+
+def test_returns_false_when_legacy_line_missing(tmp_path):
+    """If the file has been hand-patched to an unexpected shape or
+    upstream layout has changed, the patcher refuses to guess. Caller
+    sees False and can fall back to logging / failing-loud."""
+    bench_dir = tmp_path / "benchmarks"
+    bench_dir.mkdir()
+    lib = bench_dir / "benchmark_lib.sh"
+    # Deliberately omit the legacy line.
+    lib.write_text(
+        "#!/usr/bin/env bash\n"
+        "# This file was hand-patched to use a different shape.\n"
+        "run_benchmark_serving() { echo 'something else'; }\n",
+        encoding="utf-8",
+    )
+    rc = ensure_benchmark_lib_patched(tmp_path)
+    assert rc is False
+    # And the file must NOT have been mutated.
+    assert "something else" in lib.read_text()
+
+
+def test_already_patched_file_short_circuits(fake_inferencex):
+    """If the sentinel is already present (e.g. left over from a
+    previous run, possibly even by hand), the patcher returns True
+    without touching the file."""
+    lib = fake_inferencex / "benchmarks" / "benchmark_lib.sh"
+    # Pre-apply the patch.
+    lib.write_text(
+        lib.read_text().replace(_LEGACY_LINE, _PATCHED_LINE),
+        encoding="utf-8",
+    )
+    before = lib.read_text()
+    rc = ensure_benchmark_lib_patched(fake_inferencex)
+    assert rc is True
+    assert lib.read_text() == before
+
+
+# ===========================================================================
+# INFERENCEX_PATH env fallback (when no explicit arg is provided).
+# ===========================================================================
+def test_env_var_is_used_when_no_explicit_path(fake_inferencex, monkeypatch):
+    monkeypatch.setenv("INFERENCEX_PATH", str(fake_inferencex))
+    rc = ensure_benchmark_lib_patched(None)
+    assert rc is True
+    lib = fake_inferencex / "benchmarks" / "benchmark_lib.sh"
+    assert _PATCHED_LINE in lib.read_text()
+
+
+# ===========================================================================
+# Concurrency: multiple threads racing the same checkout must converge
+# on a singly-patched file, never a double-patched or torn one.
+# (Threads inside a single process is a slightly weaker test than
+# multi-process flock, but it does exercise the under-lock re-check
+# and the atomic-rename write path.)
+# ===========================================================================
+def test_concurrent_patchers_converge_to_single_patch(fake_inferencex):
+    results: list[bool] = []
+    errors: list[BaseException] = []
+
+    def worker() -> None:
+        try:
+            results.append(ensure_benchmark_lib_patched(fake_inferencex))
+        except BaseException as exc:  # noqa: BLE001 - test-only
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == [], errors
+    assert all(results), results
+    text = (fake_inferencex / "benchmarks" / "benchmark_lib.sh").read_text()
+    # Exactly one patched line — no doubles, no remaining legacy line.
+    assert text.count(_PATCHED_LINE) == 1
+    assert _LEGACY_LINE not in text

--- a/inference_optimizer/tests/test_inferencex_patcher.py
+++ b/inference_optimizer/tests/test_inferencex_patcher.py
@@ -15,8 +15,9 @@ The patcher's contract:
   already-mutated file all return ``False`` instead of raising, so
   unrelated unit tests and dry-runs don't blow up.
 
-The fixtures here synthesize a fake ``InferenceX/benchmarks/`` tree in
-a tmp dir so we never touch the real ``/wekafs/InferenceX``.
+The fixtures here synthesize a fake ``InferenceX/benchmarks/`` tree
+inside ``tmp_path`` so we never touch the real InferenceX checkout
+pointed at by ``$INFERENCEX_PATH``.
 """
 
 from __future__ import annotations

--- a/inference_optimizer/tests/test_p2_2_profile_and_handlers.py
+++ b/inference_optimizer/tests/test_p2_2_profile_and_handlers.py
@@ -378,6 +378,115 @@ def test_materialize_profile_window_clamps_to_skill_floor(
 
 
 # ===========================================================================
+# Regression #194 §2: NUM_PROMPTS must be sized to cover the steady-state
+# window. With the skill formulas, delay_iters reaches into the thousands
+# for non-trivial OSL — an under-sized NUM_PROMPTS makes the engine exit
+# before the profile window opens, yielding empty traces.
+#
+# The formula (from `_workload_envs`):
+#   required_iters    = delay_iters + max_iters
+#   iters_to_prompts  = ceil(required_iters * CONC / OSL)   # batch math
+#   NUM_PROMPTS       = max(CONC, iters_to_prompts * 2)     # 2x buffer
+#
+# Profile mode FORCE-overrides any caller-supplied NUM_PROMPTS — we own
+# the floor and an under-sized value silently kills the trace.
+# ===========================================================================
+def test_materialize_profile_num_prompts_covers_steady_state_window(
+    tmp_path, monkeypatch,
+):
+    """OSL=1024 / CONC=32 / R=1 → delay+max = 6400 iters ⇒ NUM_PROMPTS=400."""
+    import yaml
+    _clear_workload_env(monkeypatch)
+    src = _profile_yaml(tmp_path, "vllm", {"CONC": 32, "ISL": 256, "OSL": 1024})
+    out = _materialize_config_with_envs(src, tmp_path)
+    envs = yaml.safe_load(out.read_text())["benchmark"]["envs"]
+    # delay=5888, max=512 → required=6400; 6400*32/1024 = 200; *2 = 400.
+    assert envs["NUM_PROMPTS"] == 400, envs.get("NUM_PROMPTS")
+
+
+def test_materialize_profile_num_prompts_floors_at_conc_for_tiny_osl(
+    tmp_path, monkeypatch,
+):
+    """Tiny OSL with skill floor max_iters=256 still produces a sane
+    NUM_PROMPTS (covers the floor's delay+max window)."""
+    import yaml
+    _clear_workload_env(monkeypatch)
+    src = _profile_yaml(tmp_path, "vllm", {"CONC": 32, "ISL": 64, "OSL": 64})
+    out = _materialize_config_with_envs(src, tmp_path)
+    envs = yaml.safe_load(out.read_text())["benchmark"]["envs"]
+    # max=256, delay=64*2*3-128=256, required=512; 512*32/64=256; *2=512.
+    assert envs["NUM_PROMPTS"] == 512, envs.get("NUM_PROMPTS")
+
+
+def test_materialize_profile_force_overrides_user_num_prompts(
+    tmp_path, monkeypatch,
+):
+    """Profile mode must IGNORE caller-supplied NUM_PROMPTS — an
+    under-sized value (skill default `max_concurrency * 1`) would
+    silently empty the trace."""
+    import yaml
+    _clear_workload_env(monkeypatch)
+    src = _profile_yaml(
+        tmp_path, "vllm",
+        # Caller deliberately under-sizes to trip the regression.
+        {"CONC": 32, "ISL": 256, "OSL": 1024, "NUM_PROMPTS": 32},
+    )
+    out = _materialize_config_with_envs(src, tmp_path)
+    envs = yaml.safe_load(out.read_text())["benchmark"]["envs"]
+    # Hyperloom-computed 400 must win over the caller's 32.
+    assert envs["NUM_PROMPTS"] == 400, envs.get("NUM_PROMPTS")
+
+
+def test_materialize_non_profile_keeps_legacy_seq_cost_factor(
+    tmp_path, monkeypatch,
+):
+    """The §2 override is profile-only. Baseline / sweep paths must
+    still get the existing seq_cost-based NUM_PROMPTS (or honour a
+    caller-supplied value), so the §2 fix can't accidentally explode
+    baseline run lengths."""
+    import yaml
+    _clear_workload_env(monkeypatch)
+    src = tmp_path / "baseline.yaml"
+    src.write_text(yaml.safe_dump({
+        "benchmark": {
+            "framework": "vllm",
+            "model": "/m",
+            "envs": {"CONC": 32, "ISL": 256, "OSL": 1024},
+            # No profiler.torch_profiler.enabled, no PROFILE=1.
+        },
+    }))
+    out = _materialize_config_with_envs(src, tmp_path)
+    envs = yaml.safe_load(out.read_text())["benchmark"]["envs"]
+    # seq_cost=1280 → factor=5 → CONC*5 = 160 (legacy baseline path).
+    assert envs["NUM_PROMPTS"] == 160, envs.get("NUM_PROMPTS")
+
+
+def test_profile_executor_calls_benchmark_lib_patcher():
+    """ProfileExecutor must call ensure_benchmark_lib_patched before
+    launching Magpie, or the steady-state NUM_PROMPTS we just
+    computed gets stomped by upstream `benchmark_lib.sh` and the
+    trace is silently empty.
+
+    We don't run the full subprocess machinery — that's gated by
+    BaselineExecutor.__call__ which already has its own coverage.
+    Here we just lock down the seam: the symbol is imported by name
+    in profile.py and invoked unconditionally inside __call__.
+    """
+    import inference_optimizer.orchestrator.action_executors.profile as profile_mod
+    # The symbol must be re-exportable from the module (so monkey-
+    # patching in tests / integration sites is straightforward).
+    assert profile_mod.ensure_benchmark_lib_patched is not None
+    # And the source of __call__ must reference it; this is a cheap
+    # regression guard against silent removal during refactors.
+    import inspect
+    src = inspect.getsource(profile_mod.ProfileExecutor.__call__)
+    assert "ensure_benchmark_lib_patched" in src, (
+        "ProfileExecutor.__call__ must invoke ensure_benchmark_lib_patched "
+        "before super().__call__ — otherwise issue #194 §2 regresses."
+    )
+
+
+# ===========================================================================
 # Regression: $FRAMEWORK env switches the default yaml between sglang/vllm
 # without anyone passing config_path explicitly. Locks down the entry-layer
 # fix for vLLM support — the optimizer used to be sglang-only because all 5

--- a/inference_optimizer/tests/test_p2_2_profile_and_handlers.py
+++ b/inference_optimizer/tests/test_p2_2_profile_and_handlers.py
@@ -461,6 +461,188 @@ def test_materialize_non_profile_keeps_legacy_seq_cost_factor(
     assert envs["NUM_PROMPTS"] == 160, envs.get("NUM_PROMPTS")
 
 
+# ===========================================================================
+# Regression #194 §4 / §5: when the runtime patcher (server_patcher)
+# successfully applies TraceLens's patches to the in-container vLLM /
+# SGLang install, materialize must auto-append the flags that only
+# exist in the patched build:
+#
+#   * vLLM:   --profiler-config.capture_torch_profiler_dir <dir>
+#   * vLLM:   --profiler-config.detailed_trace_annotation True
+#   * SGLang: --enable-shape-discovery-for-cuda-graph-profile
+#
+# When the patcher fails-soft (returns False), materialize must NOT
+# inject any of those — otherwise unpatched vLLM rejects them as
+# unknown JSON keys and crashes the entire profile.
+#
+# The kill switch HYPERLOOM_ENABLE_PATCH=0 must short-circuit the
+# patcher entirely so users can disable runtime patching when their
+# image is a custom fork / read-only / under audit.
+# ===========================================================================
+def _mock_patchers(monkeypatch, *, vllm: bool, sglang: bool) -> dict[str, int]:
+    """Replace the two patcher symbols on `_workload_envs` with stubs
+    that record invocation counts so we can assert per-framework
+    dispatch (vLLM path must not invoke the SGLang patcher and vice
+    versa)."""
+    from inference_optimizer.orchestrator.action_executors import _workload_envs
+    counts = {"vllm": 0, "sglang": 0}
+
+    def _vllm_stub() -> bool:
+        counts["vllm"] += 1
+        return vllm
+
+    def _sglang_stub() -> bool:
+        counts["sglang"] += 1
+        return sglang
+
+    monkeypatch.setattr(
+        _workload_envs, "ensure_vllm_patched_for_tracelens", _vllm_stub,
+    )
+    monkeypatch.setattr(
+        _workload_envs, "ensure_sglang_patched_for_tracelens", _sglang_stub,
+    )
+    return counts
+
+
+def test_materialize_profile_vllm_injects_tracelens_flags_when_patched(
+    tmp_path, monkeypatch,
+):
+    """Patcher returns True for vLLM ⇒ EXTRA_VLLM_ARGS gains
+    capture_torch_profiler_dir + detailed_trace_annotation, on top of
+    the §1 delay/max iterations."""
+    import yaml
+    _clear_workload_env(monkeypatch)
+    counts = _mock_patchers(monkeypatch, vllm=True, sglang=False)
+    src = _profile_yaml(tmp_path, "vllm", {"CONC": 32, "ISL": 256, "OSL": 1024})
+    out = _materialize_config_with_envs(src, tmp_path)
+    extra = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
+    assert "--profiler-config.delay_iterations 5888" in extra, extra
+    assert "--profiler-config.max_iterations 512" in extra, extra
+    assert "--profiler-config.capture_torch_profiler_dir " in extra, extra
+    assert "--profiler-config.detailed_trace_annotation True" in extra, extra
+    # Per-framework dispatch: the SGLang patcher must NOT be invoked
+    # when the YAML's framework is vLLM (saves an unnecessary file
+    # probe + lock acquisition).
+    assert counts == {"vllm": 1, "sglang": 0}, counts
+
+
+def test_materialize_profile_vllm_omits_tracelens_flags_when_patch_fails(
+    tmp_path, monkeypatch,
+):
+    """Patcher returns False (unpatchable image) ⇒ EXTRA_VLLM_ARGS
+    keeps only the §1 safe set. Otherwise unpatched vLLM would
+    crash on `unknown JSON key`."""
+    import yaml
+    _clear_workload_env(monkeypatch)
+    _mock_patchers(monkeypatch, vllm=False, sglang=False)
+    src = _profile_yaml(tmp_path, "vllm", {"CONC": 32, "ISL": 256, "OSL": 1024})
+    out = _materialize_config_with_envs(src, tmp_path)
+    extra = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
+    assert "--profiler-config.delay_iterations 5888" in extra, extra
+    assert "capture_torch_profiler_dir" not in extra, extra
+    assert "detailed_trace_annotation" not in extra, extra
+
+
+def test_materialize_profile_sglang_injects_shape_discovery_when_patched(
+    tmp_path, monkeypatch,
+):
+    """Patcher returns True for SGLang ⇒ EXTRA_SGLANG_ARGS gains
+    --enable-shape-discovery-for-cuda-graph-profile."""
+    import yaml
+    _clear_workload_env(monkeypatch)
+    counts = _mock_patchers(monkeypatch, vllm=False, sglang=True)
+    src = _profile_yaml(tmp_path, "sglang", {"CONC": 32, "ISL": 256, "OSL": 1024})
+    out = _materialize_config_with_envs(src, tmp_path)
+    extra = yaml.safe_load(out.read_text())["benchmark"]["envs"].get(
+        "EXTRA_SGLANG_ARGS", "",
+    )
+    assert "--enable-shape-discovery-for-cuda-graph-profile" in extra, extra
+    # Per-framework dispatch in reverse: the vLLM patcher must NOT be
+    # invoked when the YAML's framework is SGLang.
+    assert counts == {"vllm": 0, "sglang": 1}, counts
+
+
+def test_materialize_profile_sglang_omits_shape_discovery_when_patch_fails(
+    tmp_path, monkeypatch,
+):
+    """Patcher returns False ⇒ no shape-discovery flag (otherwise
+    SGLang argparse errors on the unknown flag)."""
+    import yaml
+    _clear_workload_env(monkeypatch)
+    _mock_patchers(monkeypatch, vllm=False, sglang=False)
+    src = _profile_yaml(tmp_path, "sglang", {"CONC": 32, "ISL": 256, "OSL": 1024})
+    out = _materialize_config_with_envs(src, tmp_path)
+    extra = yaml.safe_load(out.read_text())["benchmark"]["envs"].get(
+        "EXTRA_SGLANG_ARGS", "",
+    )
+    assert "shape-discovery" not in extra, extra
+
+
+def test_materialize_profile_kill_switch_skips_patcher_entirely(
+    tmp_path, monkeypatch,
+):
+    """HYPERLOOM_ENABLE_PATCH=0 must short-circuit the patcher call
+    entirely — neither vLLM nor SGLang patcher should be touched, and
+    no TraceLens-only flags should land in the YAML. This is the
+    escape hatch for users with custom forks / read-only filesystems
+    / compliance requirements."""
+    import yaml
+    _clear_workload_env(monkeypatch)
+    monkeypatch.setenv("HYPERLOOM_ENABLE_PATCH", "0")
+    counts = _mock_patchers(monkeypatch, vllm=True, sglang=True)
+    src = _profile_yaml(tmp_path, "vllm", {"CONC": 32, "ISL": 256, "OSL": 1024})
+    out = _materialize_config_with_envs(src, tmp_path)
+    extra = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
+    # Safe §1 flags still present.
+    assert "--profiler-config.delay_iterations 5888" in extra, extra
+    # TraceLens-only flags absent.
+    assert "capture_torch_profiler_dir" not in extra, extra
+    assert "detailed_trace_annotation" not in extra, extra
+    # Patchers never invoked.
+    assert counts == {"vllm": 0, "sglang": 0}, counts
+
+
+def test_materialize_profile_kill_switch_default_is_on(
+    tmp_path, monkeypatch,
+):
+    """Unset HYPERLOOM_ENABLE_PATCH == default-on. The patcher must
+    be invoked so users on TraceLens-patched images get the enhanced
+    flags without any opt-in step. Symmetric to the kill-switch test
+    above."""
+    import yaml
+    _clear_workload_env(monkeypatch)
+    monkeypatch.delenv("HYPERLOOM_ENABLE_PATCH", raising=False)
+    counts = _mock_patchers(monkeypatch, vllm=True, sglang=False)
+    src = _profile_yaml(tmp_path, "vllm", {"CONC": 32, "ISL": 256, "OSL": 1024})
+    _materialize_config_with_envs(src, tmp_path)
+    assert counts["vllm"] == 1, counts
+
+
+def test_materialize_profile_sglang_does_not_duplicate_shape_discovery(
+    tmp_path, monkeypatch,
+):
+    """If EXTRA_SGLANG_ARGS already mentions
+    --enable-shape-discovery-for-cuda-graph-profile (e.g. user
+    pre-populated it in the YAML or via env), the materializer must
+    NOT append a duplicate copy."""
+    import yaml
+    _clear_workload_env(monkeypatch)
+    _mock_patchers(monkeypatch, vllm=False, sglang=True)
+    src = _profile_yaml(
+        tmp_path, "sglang",
+        {
+            "CONC": 32, "ISL": 256, "OSL": 1024,
+            "EXTRA_SGLANG_ARGS": (
+                "--enable-profile-cuda-graph "
+                "--enable-shape-discovery-for-cuda-graph-profile"
+            ),
+        },
+    )
+    out = _materialize_config_with_envs(src, tmp_path)
+    extra = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_SGLANG_ARGS"]
+    assert extra.count("--enable-shape-discovery-for-cuda-graph-profile") == 1, extra
+
+
 def test_profile_executor_calls_benchmark_lib_patcher():
     """ProfileExecutor must call ensure_benchmark_lib_patched before
     launching Magpie, or the steady-state NUM_PROMPTS we just

--- a/inference_optimizer/tests/test_p2_2_profile_and_handlers.py
+++ b/inference_optimizer/tests/test_p2_2_profile_and_handlers.py
@@ -271,6 +271,113 @@ def test_materialize_config_rocr_unchanged_when_tp1(tmp_path, monkeypatch):
 
 
 # ===========================================================================
+# Regression #194: steady-state window must follow the TraceLens magpie
+# skill formulas, not the old `delay = 5*CONC; max = clamp(16*OSL/CONC,4,64)`
+# placeholders.
+#
+# Skill:
+#   max_iters   = min(1024, max(256, OSL * 16 / CONC))
+#   delay_iters = OSL * (RANDOM_RANGE_RATIO + 1) * 3 - max_iters / 2
+#
+# Worked example used in the issue: OSL=1024, CONC=32, R=1
+#   max_iters   = min(1024, max(256, 1024*16/32))   = max(256, 512) = 512
+#   delay_iters = 1024 * (1+1) * 3 - 512/2          = 6144 - 256    = 5888
+#
+# Previous Hyperloom code gave (160, 64) for the same inputs — roughly 1/8
+# of the skill window and ignored R entirely, so issue #194 §1 flagged
+# Optimizer-driven profiles as under-representing decode-heavy steady state.
+# ===========================================================================
+def _profile_yaml(tmp_path, framework: str, envs: dict) -> Path:
+    """Synthesize a minimal profile YAML the materializer recognises as
+    PROFILE=1 + torch_profiler.enabled=True.
+    """
+    import yaml as _yaml
+    src = tmp_path / f"src_{framework}.yaml"
+    src.write_text(_yaml.safe_dump({
+        "benchmark": {
+            "framework": framework,
+            "model": "/m",
+            "envs": {"PROFILE": "1", **envs},
+            "profiler": {"torch_profiler": {"enabled": True}},
+        },
+    }))
+    return src
+
+
+def _clear_workload_env(monkeypatch):
+    for k in (
+        "CONC", "ISL", "OSL", "TP", "MAX_MODEL_LEN",
+        "RANDOM_RANGE_RATIO", "ROCR_VISIBLE_DEVICES", "FRAMEWORK",
+    ):
+        monkeypatch.delenv(k, raising=False)
+
+
+def test_materialize_profile_window_vllm_skill_formula_default_R(
+    tmp_path, monkeypatch,
+):
+    """vLLM: OSL=1024, CONC=32, R unset → max=512, delay=5888 per skill."""
+    import yaml
+    _clear_workload_env(monkeypatch)
+    src = _profile_yaml(tmp_path, "vllm", {"CONC": 32, "ISL": 256, "OSL": 1024})
+    out = _materialize_config_with_envs(src, tmp_path)
+    rendered = yaml.safe_load(out.read_text())
+    extra = rendered["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
+    assert "--profiler-config.delay_iterations 5888" in extra, extra
+    assert "--profiler-config.max_iterations 512" in extra, extra
+
+
+def test_materialize_profile_window_vllm_skill_formula_explicit_R(
+    tmp_path, monkeypatch,
+):
+    """vLLM: explicit R=0.5 must shrink delay (skill: 3*OSL*(R+1) term)."""
+    import yaml
+    _clear_workload_env(monkeypatch)
+    monkeypatch.setenv("RANDOM_RANGE_RATIO", "0.5")
+    src = _profile_yaml(tmp_path, "vllm", {"CONC": 32, "ISL": 256, "OSL": 1024})
+    out = _materialize_config_with_envs(src, tmp_path)
+    rendered = yaml.safe_load(out.read_text())
+    envs = rendered["benchmark"]["envs"]
+    # R=0.5: delay = 1024 * 1.5 * 3 - 512/2 = 4608 - 256 = 4352; max=512.
+    extra = envs["EXTRA_VLLM_ARGS"]
+    assert "--profiler-config.delay_iterations 4352" in extra, extra
+    assert "--profiler-config.max_iterations 512" in extra, extra
+    # And R must round-trip into the YAML as a float, not stringified-int.
+    assert envs["RANDOM_RANGE_RATIO"] == 0.5
+
+
+def test_materialize_profile_window_sglang_skill_formula(
+    tmp_path, monkeypatch,
+):
+    """SGLang path writes the same window into PROFILE_EXTRA_BODY."""
+    import json
+    import yaml
+    _clear_workload_env(monkeypatch)
+    src = _profile_yaml(tmp_path, "sglang", {"CONC": 32, "ISL": 256, "OSL": 1024})
+    out = _materialize_config_with_envs(src, tmp_path)
+    rendered = yaml.safe_load(out.read_text())
+    body = json.loads(rendered["benchmark"]["envs"]["PROFILE_EXTRA_BODY"])
+    assert body["start_step"] == 5888
+    assert body["num_steps"] == 512
+
+
+def test_materialize_profile_window_clamps_to_skill_floor(
+    tmp_path, monkeypatch,
+):
+    """Skill: max_iters has a floor of 256 (not 4) and a ceiling of 1024.
+
+    OSL=256, CONC=64 ⇒ 16*OSL/CONC = 64, so the floor must kick in.
+    Old formula clamped to 64; new formula must clamp to 256.
+    """
+    import yaml
+    _clear_workload_env(monkeypatch)
+    src = _profile_yaml(tmp_path, "vllm", {"CONC": 64, "ISL": 256, "OSL": 256})
+    out = _materialize_config_with_envs(src, tmp_path)
+    rendered = yaml.safe_load(out.read_text())
+    extra = rendered["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
+    assert "--profiler-config.max_iterations 256" in extra, extra
+
+
+# ===========================================================================
 # Regression: $FRAMEWORK env switches the default yaml between sglang/vllm
 # without anyone passing config_path explicitly. Locks down the entry-layer
 # fix for vLLM support — the optimizer used to be sglang-only because all 5

--- a/inference_optimizer/tests/test_server_patcher.py
+++ b/inference_optimizer/tests/test_server_patcher.py
@@ -14,7 +14,7 @@ version):
 
 The tests synthesize a fake vLLM / SGLang install tree + a fake
 TraceLens patch directory inside ``tmp_path`` so we never touch the
-real ``/wekafs/InferenceX`` or any real ``site-packages``.
+real ``$TRACELENS_ROOT`` or any real ``site-packages``.
 """
 
 from __future__ import annotations

--- a/inference_optimizer/tests/test_server_patcher.py
+++ b/inference_optimizer/tests/test_server_patcher.py
@@ -1,0 +1,474 @@
+"""Tests for ``_server_patcher`` (Hyperloom issue #194 §4 / §5).
+
+Contract recap (see ``_server_patcher.py`` docstring for the long
+version):
+
+* Per-framework patchers (vLLM, SGLang) — caller invokes only the one
+  matching the YAML's framework.
+* Fail-soft on every error path — caller treats ``False`` as
+  "do not inject TraceLens-only flags".
+* Idempotent — sentinel check short-circuits after the first apply.
+* Concurrency-safe — flock serializes the write window.
+* Atomic for multi-patch sets — ``--check`` all first, rollback on
+  mid-apply failure.
+
+The tests synthesize a fake vLLM / SGLang install tree + a fake
+TraceLens patch directory inside ``tmp_path`` so we never touch the
+real ``/wekafs/InferenceX`` or any real ``site-packages``.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import textwrap
+import threading
+import types
+from pathlib import Path
+
+import pytest
+
+from inference_optimizer.orchestrator.action_executors import _server_patcher
+from inference_optimizer.orchestrator.action_executors._server_patcher import (
+    ensure_sglang_patched_for_tracelens,
+    ensure_vllm_patched_for_tracelens,
+)
+
+
+# ===========================================================================
+# Fixtures: fake TraceLens patch tree + fake vLLM / SGLang installs
+# ===========================================================================
+_FAKE_VLLM_VERSION = "0.99.0-fake"
+_FAKE_SGLANG_VERSION = "0.5.9"  # must match one of _SGLANG_SUPPORTED_VERSIONS
+
+
+def _make_fake_tracelens(tmp_path: Path) -> Path:
+    """Build the ``<root>/examples/custom_workflows/inference_analysis/``
+    skeleton the patcher expects to find patches under."""
+    root = tmp_path / "TraceLens-internal"
+    base = root / "examples" / "custom_workflows" / "inference_analysis"
+    (base / "vllm_patches").mkdir(parents=True)
+    (base / "sglang_roofline_patches").mkdir(parents=True)
+    return root
+
+
+def _make_fake_vllm_install(tmp_path: Path) -> Path:
+    """Build a fake ``site-packages/vllm/...`` tree with a sentinel
+    file (``vllm/config/profiler.py``) ready to be patched."""
+    site_packages = tmp_path / "site_packages"
+    vllm_pkg = site_packages / "vllm"
+    (vllm_pkg / "config").mkdir(parents=True)
+    (vllm_pkg / "__init__.py").write_text(
+        f'__version__ = "{_FAKE_VLLM_VERSION}"\n',
+        encoding="utf-8",
+    )
+    (vllm_pkg / "config" / "profiler.py").write_text(
+        textwrap.dedent(
+            """\
+            # Synthetic vLLM profiler config — used only by tests.
+            class ProfilerConfig:
+                profiler: str = ""
+                ignore_frontend: bool = False
+            """
+        ),
+        encoding="utf-8",
+    )
+    return site_packages
+
+
+def _write_fake_vllm_patch(
+    tracelens_root: Path, version: str, sentinel: str = "capture_torch_profiler_dir",
+) -> Path:
+    """Generate a minimal unified diff that adds the sentinel string
+    to the fake profiler.py — `git apply` accepts it without needing
+    a real .git/ directory."""
+    patch_path = (
+        tracelens_root
+        / "examples" / "custom_workflows" / "inference_analysis"
+        / "vllm_patches" / f"config_vllm_v{version}.patch"
+    )
+    patch_path.write_text(
+        textwrap.dedent(
+            f"""\
+            diff --git a/vllm/config/profiler.py b/vllm/config/profiler.py
+            index 0000001..0000002 100644
+            --- a/vllm/config/profiler.py
+            +++ b/vllm/config/profiler.py
+            @@ -1,4 +1,5 @@
+             # Synthetic vLLM profiler config — used only by tests.
+             class ProfilerConfig:
+                 profiler: str = ""
+            +    {sentinel}: str = ""
+                 ignore_frontend: bool = False
+            """
+        ),
+        encoding="utf-8",
+    )
+    return patch_path
+
+
+@pytest.fixture
+def fake_vllm_world(tmp_path: Path, monkeypatch):
+    """Set up: fake TRACELENS_ROOT + fake vllm in sys.modules + a
+    matching patch file. Returns (tracelens_root, install_root, patch_file)."""
+    tracelens_root = _make_fake_tracelens(tmp_path)
+    install_root = _make_fake_vllm_install(tmp_path)
+    patch_file = _write_fake_vllm_patch(tracelens_root, _FAKE_VLLM_VERSION)
+
+    # Inject a fake `vllm` module so `import vllm` inside the discover
+    # function sees our staged install rather than the real one (which
+    # may or may not be present in CI).
+    fake_mod = types.ModuleType("vllm")
+    fake_mod.__version__ = _FAKE_VLLM_VERSION  # type: ignore[attr-defined]
+    fake_mod.__file__ = str(install_root / "vllm" / "__init__.py")  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "vllm", fake_mod)
+    monkeypatch.setenv("TRACELENS_ROOT", str(tracelens_root))
+
+    return tracelens_root, install_root, patch_file
+
+
+def _make_fake_sglang_install(tmp_path: Path) -> Path:
+    """SGLang patches use `a/python/sglang/...` prefix so the install
+    must have a `python/sglang/...` layout (the editable repo form).
+    Returns the apply root (parent of `python/`)."""
+    apply_root = tmp_path / "sgl_repo"
+    pkg = apply_root / "python" / "sglang" / "srt" / "utils"
+    pkg.mkdir(parents=True)
+    (apply_root / "python" / "sglang" / "__init__.py").write_text(
+        f'__version__ = "{_FAKE_SGLANG_VERSION}"\n',
+        encoding="utf-8",
+    )
+    (apply_root / "python" / "sglang" / "srt" / "__init__.py").write_text("")
+    (apply_root / "python" / "sglang" / "srt" / "utils" / "__init__.py").write_text("")
+    return apply_root
+
+
+def _write_fake_sglang_patches(
+    tracelens_root: Path, *, count: int = 1, include_new_file: bool = True,
+) -> list[Path]:
+    """Write ``count`` minimal patches into the sglang patches dir.
+
+    The first patch always creates ``kernel_shape_profiler.py``
+    (matching the real patch set's sentinel file). Additional patches
+    are no-op header-comment additions to make the multi-patch atomic
+    apply path testable.
+    """
+    base = (
+        tracelens_root / "examples" / "custom_workflows"
+        / "inference_analysis" / "sglang_roofline_patches"
+    )
+    patches: list[Path] = []
+    if include_new_file:
+        p1 = base / "kernel_shape_profiler.patch"
+        p1.write_text(
+            textwrap.dedent(
+                """\
+                diff --git a/python/sglang/srt/utils/kernel_shape_profiler.py b/python/sglang/srt/utils/kernel_shape_profiler.py
+                new file mode 100644
+                index 000000000..1111111
+                --- /dev/null
+                +++ b/python/sglang/srt/utils/kernel_shape_profiler.py
+                @@ -0,0 +1,3 @@
+                +# kernel_shape_profiler stub — TraceLens patch fixture.
+                +def hello():
+                +    return "kernel_shape_profiler"
+                """
+            ),
+            encoding="utf-8",
+        )
+        patches.append(p1)
+    for i in range(len(patches), count):
+        p = base / f"misc_{i}.patch"
+        # Touch a fresh file each time so patches don't conflict.
+        target = f"python/sglang/srt/utils/extra_{i}.py"
+        p.write_text(
+            textwrap.dedent(
+                f"""\
+                diff --git a/{target} b/{target}
+                new file mode 100644
+                index 000000000..2222222
+                --- /dev/null
+                +++ b/{target}
+                @@ -0,0 +1 @@
+                +# extra_{i} stub
+                """
+            ),
+            encoding="utf-8",
+        )
+        patches.append(p)
+    return patches
+
+
+@pytest.fixture
+def fake_sglang_world(tmp_path: Path, monkeypatch):
+    tracelens_root = _make_fake_tracelens(tmp_path)
+    apply_root = _make_fake_sglang_install(tmp_path)
+    patches = _write_fake_sglang_patches(tracelens_root, count=3)
+
+    fake_mod = types.ModuleType("sglang")
+    fake_mod.__version__ = _FAKE_SGLANG_VERSION  # type: ignore[attr-defined]
+    fake_mod.__file__ = str(apply_root / "python" / "sglang" / "__init__.py")  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "sglang", fake_mod)
+    monkeypatch.setenv("TRACELENS_ROOT", str(tracelens_root))
+
+    return tracelens_root, apply_root, patches
+
+
+def _git_available() -> bool:
+    return shutil.which("git") is not None
+
+
+_REQUIRES_GIT = pytest.mark.skipif(
+    not _git_available(), reason="git not available in test environment",
+)
+
+
+# ===========================================================================
+# vLLM happy path + idempotency
+# ===========================================================================
+@_REQUIRES_GIT
+def test_vllm_first_call_applies_patch(fake_vllm_world):
+    _, install_root, _ = fake_vllm_world
+    rc = ensure_vllm_patched_for_tracelens()
+    assert rc is True
+    text = (install_root / "vllm" / "config" / "profiler.py").read_text()
+    assert "capture_torch_profiler_dir" in text
+
+
+@_REQUIRES_GIT
+def test_vllm_second_call_is_noop(fake_vllm_world):
+    """Idempotency: sentinel-based short-circuit — re-applying must not
+    mutate the file."""
+    _, install_root, _ = fake_vllm_world
+    sentinel_path = install_root / "vllm" / "config" / "profiler.py"
+    ensure_vllm_patched_for_tracelens()
+    after_first = sentinel_path.read_text()
+    rc = ensure_vllm_patched_for_tracelens()
+    assert rc is True
+    assert sentinel_path.read_text() == after_first
+
+
+# ===========================================================================
+# vLLM fail-soft paths
+# ===========================================================================
+def test_vllm_returns_false_without_tracelens_root(monkeypatch):
+    """No TRACELENS_ROOT, no explicit arg → fail-soft False (callers
+    treat as "don't inject TraceLens flags")."""
+    monkeypatch.delenv("TRACELENS_ROOT", raising=False)
+    assert ensure_vllm_patched_for_tracelens(None) is False
+
+
+def test_vllm_returns_false_when_vllm_not_importable(
+    fake_vllm_world, monkeypatch,
+):
+    """Even with TRACELENS_ROOT set, an environment without vllm
+    must not crash — discover returns None → patcher returns False."""
+    monkeypatch.delitem(sys.modules, "vllm", raising=False)
+    # Block re-import to simulate vllm-less environment.
+
+    def _blocked_import(name, *args, **kwargs):  # noqa: ANN001 - hook
+        if name == "vllm":
+            raise ImportError("vllm not installed (test simulation)")
+        return _real_import(name, *args, **kwargs)
+
+    import builtins
+    _real_import = builtins.__import__
+    monkeypatch.setattr(builtins, "__import__", _blocked_import)
+    assert ensure_vllm_patched_for_tracelens() is False
+
+
+def test_vllm_returns_false_when_no_patch_for_version(
+    tmp_path, monkeypatch,
+):
+    """vLLM version exists but TraceLens hasn't shipped a matching
+    patch file → fail-soft (this is the common case for brand-new
+    vLLM releases)."""
+    tracelens_root = _make_fake_tracelens(tmp_path)
+    install_root = _make_fake_vllm_install(tmp_path)
+    # NB: we deliberately do not write a patch file.
+    fake_mod = types.ModuleType("vllm")
+    fake_mod.__version__ = "9.9.9-no-patch"  # type: ignore[attr-defined]
+    fake_mod.__file__ = str(install_root / "vllm" / "__init__.py")  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "vllm", fake_mod)
+    monkeypatch.setenv("TRACELENS_ROOT", str(tracelens_root))
+    assert ensure_vllm_patched_for_tracelens() is False
+
+
+def test_vllm_returns_false_when_install_layout_unexpected(
+    tmp_path, monkeypatch,
+):
+    """`vllm.__file__` points at a path whose parent.parent is NOT a
+    site-packages-like dir — install layout broken, fail-soft."""
+    tracelens_root = _make_fake_tracelens(tmp_path)
+    _write_fake_vllm_patch(tracelens_root, _FAKE_VLLM_VERSION)
+    bogus = tmp_path / "isolated_no_config" / "vllm" / "__init__.py"
+    bogus.parent.mkdir(parents=True)
+    bogus.write_text("")
+    fake_mod = types.ModuleType("vllm")
+    fake_mod.__version__ = _FAKE_VLLM_VERSION  # type: ignore[attr-defined]
+    fake_mod.__file__ = str(bogus)  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "vllm", fake_mod)
+    monkeypatch.setenv("TRACELENS_ROOT", str(tracelens_root))
+    assert ensure_vllm_patched_for_tracelens() is False
+
+
+# ===========================================================================
+# SGLang happy path + version gating + atomic application
+# ===========================================================================
+@_REQUIRES_GIT
+def test_sglang_first_call_applies_all_patches(fake_sglang_world):
+    _, apply_root, _ = fake_sglang_world
+    rc = ensure_sglang_patched_for_tracelens()
+    assert rc is True
+    sentinel = (
+        apply_root / "python" / "sglang" / "srt" / "utils"
+        / "kernel_shape_profiler.py"
+    )
+    assert sentinel.exists()
+    assert "kernel_shape_profiler" in sentinel.read_text()
+
+
+@_REQUIRES_GIT
+def test_sglang_second_call_is_noop(fake_sglang_world):
+    _, apply_root, _ = fake_sglang_world
+    ensure_sglang_patched_for_tracelens()
+    sentinel = (
+        apply_root / "python" / "sglang" / "srt" / "utils"
+        / "kernel_shape_profiler.py"
+    )
+    before = sentinel.read_text()
+    rc = ensure_sglang_patched_for_tracelens()
+    assert rc is True
+    assert sentinel.read_text() == before
+
+
+def test_sglang_rejects_unsupported_version(tmp_path, monkeypatch):
+    """SGLang versions outside `_SGLANG_SUPPORTED_VERSIONS` (today only
+    "0.5.9") must fail-soft — and crucially must NOT touch the
+    install tree on disk."""
+    tracelens_root = _make_fake_tracelens(tmp_path)
+    apply_root = _make_fake_sglang_install(tmp_path)
+    _write_fake_sglang_patches(tracelens_root)
+    fake_mod = types.ModuleType("sglang")
+    fake_mod.__version__ = "0.5.10"  # current Hyperloom default — unsupported
+    fake_mod.__file__ = str(apply_root / "python" / "sglang" / "__init__.py")  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "sglang", fake_mod)
+    monkeypatch.setenv("TRACELENS_ROOT", str(tracelens_root))
+    assert ensure_sglang_patched_for_tracelens() is False
+    sentinel = (
+        apply_root / "python" / "sglang" / "srt" / "utils"
+        / "kernel_shape_profiler.py"
+    )
+    assert not sentinel.exists(), (
+        "patcher must NOT have written to disk for unsupported version"
+    )
+
+
+def test_sglang_rejects_non_editable_install_layout(tmp_path, monkeypatch):
+    """A pip-wheel install where `sglang/` sits directly in site-packages
+    (no `python/` parent) cannot use the `a/python/sglang/...` patches —
+    fail-soft so wheel users keep working."""
+    tracelens_root = _make_fake_tracelens(tmp_path)
+    _write_fake_sglang_patches(tracelens_root)
+    # Layout: site-packages/sglang/__init__.py (no `python/` dir).
+    install = tmp_path / "site_packages" / "sglang"
+    install.mkdir(parents=True)
+    (install / "__init__.py").write_text(
+        f'__version__ = "{_FAKE_SGLANG_VERSION}"\n',
+        encoding="utf-8",
+    )
+    fake_mod = types.ModuleType("sglang")
+    fake_mod.__version__ = _FAKE_SGLANG_VERSION  # type: ignore[attr-defined]
+    fake_mod.__file__ = str(install / "__init__.py")  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "sglang", fake_mod)
+    monkeypatch.setenv("TRACELENS_ROOT", str(tracelens_root))
+    assert ensure_sglang_patched_for_tracelens() is False
+
+
+@_REQUIRES_GIT
+def test_sglang_precheck_failure_skips_all(tmp_path, monkeypatch):
+    """If ANY patch in the set fails `git apply --check`, NONE are
+    applied — the install stays in its original state."""
+    tracelens_root = _make_fake_tracelens(tmp_path)
+    apply_root = _make_fake_sglang_install(tmp_path)
+    # First patch is fine.
+    _write_fake_sglang_patches(tracelens_root, count=1)
+    # Add a corrupt patch that won't apply (refers to a file that
+    # doesn't exist in our fake install).
+    bad = (
+        tracelens_root / "examples" / "custom_workflows"
+        / "inference_analysis" / "sglang_roofline_patches" / "zzz_bad.patch"
+    )
+    bad.write_text(
+        textwrap.dedent(
+            """\
+            diff --git a/python/sglang/does_not_exist.py b/python/sglang/does_not_exist.py
+            index 0000001..0000002 100644
+            --- a/python/sglang/does_not_exist.py
+            +++ b/python/sglang/does_not_exist.py
+            @@ -1,1 +1,1 @@
+            -original
+            +modified
+            """
+        ),
+        encoding="utf-8",
+    )
+    fake_mod = types.ModuleType("sglang")
+    fake_mod.__version__ = _FAKE_SGLANG_VERSION  # type: ignore[attr-defined]
+    fake_mod.__file__ = str(apply_root / "python" / "sglang" / "__init__.py")  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "sglang", fake_mod)
+    monkeypatch.setenv("TRACELENS_ROOT", str(tracelens_root))
+
+    assert ensure_sglang_patched_for_tracelens() is False
+    sentinel = (
+        apply_root / "python" / "sglang" / "srt" / "utils"
+        / "kernel_shape_profiler.py"
+    )
+    assert not sentinel.exists(), (
+        "patcher partial-applied even though --check predicted failure"
+    )
+
+
+# ===========================================================================
+# Concurrency: threads racing the same fake install converge.
+# ===========================================================================
+@_REQUIRES_GIT
+def test_vllm_concurrent_patchers_converge(fake_vllm_world):
+    _, install_root, _ = fake_vllm_world
+    results: list[bool] = []
+    errors: list[BaseException] = []
+
+    def worker() -> None:
+        try:
+            results.append(ensure_vllm_patched_for_tracelens())
+        except BaseException as exc:  # noqa: BLE001 - test-only
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(6)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == [], errors
+    assert all(results), results
+    text = (install_root / "vllm" / "config" / "profiler.py").read_text()
+    # Sentinel substring appears exactly once — no double-patching.
+    assert text.count("capture_torch_profiler_dir") == 1
+
+
+# ===========================================================================
+# Misc: missing git binary
+# ===========================================================================
+def test_returns_false_when_git_missing(fake_vllm_world, monkeypatch):
+    """If `git` isn't on PATH we cannot apply patches; fail-soft so
+    containers without git still run benchmarks (just without
+    TraceLens flags)."""
+    monkeypatch.setattr(_server_patcher.shutil, "which", lambda _name: None)
+    # Reset to pre-patch state by removing the sentinel from profiler.py.
+    _, install_root, _ = fake_vllm_world
+    # The sentinel file is freshly written by the fixture — no
+    # cleanup needed; the patcher will see "not patched" → try git →
+    # find no git → return False.
+    assert ensure_vllm_patched_for_tracelens() is False

--- a/kernel-agent/tools/test_tracelens_csv.py
+++ b/kernel-agent/tools/test_tracelens_csv.py
@@ -1007,6 +1007,159 @@ def test_127_splitter_cli_uses_positional_trace_path_and_find_steady_state(tmp_p
 
 
 # ===========================================================================
+# #194 §3 — splitter must receive --R so mixed-window selection uses the
+# analytic PD ratio. Source: tracelens_analysis must pass --R when given
+# either via --split-r CLI arg or via the RANDOM_RANGE_RATIO env var (the
+# same env Hyperloom propagates from the YAML config to the benchmark
+# subprocess). Without --R the splitter falls back to an empirical
+# heuristic, drifting from the benchmark-contract ratio the skill aligns
+# the rest of the pipeline to.
+# ===========================================================================
+def _drive_main_capturing_subprocess(tmp_path, extra_argv, env_overrides=None):
+    """Helper: stage a TraceLens-ish tree, stub subprocess.run + which,
+    drive tla.main() once, and return the list of captured argvs."""
+    import gzip
+    import json as _json
+    import os as _os
+    from unittest.mock import patch
+
+    tl_root = tmp_path / "TraceLens-internal"
+    skill_dir = (
+        tl_root / "TraceLens" / "Agent" / "Analysis" / ".cursor" / "skills"
+    )
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "analysis-orchestrator.md").write_text("stub")
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    capture = tmp_path / "capture_traces"
+    capture.mkdir()
+    trace = tmp_path / "trace.json.gz"
+    with gzip.open(trace, "wt") as f:
+        _json.dump({"traceEvents": [
+            {"cat": "kernel", "name": "void some_real_kernel<...>", "dur": 5.0},
+        ]}, f)
+
+    captured: list[list[str]] = []
+
+    class _Result:
+        def __init__(self, returncode=0, stdout=""):
+            self.returncode = returncode
+            self.stdout = stdout
+
+    def fake_run(cmd, *_a, **_kw):
+        captured.append(list(cmd))
+        return _Result(returncode=0, stdout="ok")
+
+    argv = [
+        "tracelens_analysis.py",
+        "--trace-input", str(trace),
+        "--workspace-path", str(workspace),
+        "--tracelens-root", str(tl_root),
+        "--target-platform", "MI300X",
+        "--top-k", "5",
+        "--budget-minutes", "1",
+        "--no-llm-orchestrator",
+        "--capture-folder", str(capture),
+        *extra_argv,
+    ]
+
+    env_backup = dict(_os.environ)
+    try:
+        for k, v in (env_overrides or {}).items():
+            if v is None:
+                _os.environ.pop(k, None)
+            else:
+                _os.environ[k] = v
+        with patch.object(tla.subprocess, "run", side_effect=fake_run), \
+             patch.object(tla.shutil, "which", side_effect=lambda n: f"/usr/bin/{n}"), \
+             patch.object(tla.sys, "argv", argv):
+            try:
+                tla.main()
+            except SystemExit:
+                pass
+    finally:
+        _os.environ.clear()
+        _os.environ.update(env_backup)
+
+    return captured, trace
+
+
+def _find_splitter_cmd(captured):
+    return next(
+        (c for c in captured
+         if any("split_inference_trace_annotation" in str(p) for p in c)),
+        None,
+    )
+
+
+def test_194_3_splitter_receives_R_from_cli_arg(tmp_path):
+    """`--split-r 0.5` on the wrapper must produce `--R 0.5` on the
+    splitter argv. Floating-point ratios must survive verbatim — the
+    splitter declares `type=float` and any string coercion to int
+    would silently truncate fractional R."""
+    captured, _ = _drive_main_capturing_subprocess(
+        tmp_path,
+        extra_argv=[
+            "--split-conc", "32",
+            "--split-osl", "1024",
+            "--split-r", "0.5",
+        ],
+        env_overrides={"RANDOM_RANGE_RATIO": None},
+    )
+    splitter_cmd = _find_splitter_cmd(captured)
+    assert splitter_cmd is not None, f"splitter never invoked; cmds={captured}"
+    assert "--R" in splitter_cmd, splitter_cmd
+    # The value must immediately follow --R.
+    assert splitter_cmd[splitter_cmd.index("--R") + 1] == "0.5", splitter_cmd
+
+
+def test_194_3_splitter_receives_R_from_random_range_ratio_env(tmp_path):
+    """Without --split-r, the wrapper falls back to RANDOM_RANGE_RATIO
+    env — the same variable Hyperloom propagates from the YAML config
+    into every Magpie subprocess. Locks down the env→splitter seam."""
+    captured, _ = _drive_main_capturing_subprocess(
+        tmp_path,
+        extra_argv=["--split-conc", "32", "--split-osl", "1024"],
+        env_overrides={"RANDOM_RANGE_RATIO": "0.8"},
+    )
+    splitter_cmd = _find_splitter_cmd(captured)
+    assert splitter_cmd is not None, f"splitter never invoked; cmds={captured}"
+    assert "--R" in splitter_cmd, splitter_cmd
+    assert splitter_cmd[splitter_cmd.index("--R") + 1] == "0.8", splitter_cmd
+
+
+def test_194_3_splitter_omits_R_when_unset(tmp_path):
+    """No --split-r and no RANDOM_RANGE_RATIO env → the splitter must
+    not see --R. The splitter's built-in default (`R=None`) keeps the
+    old heuristic path live for legacy traces that pre-date the
+    skill-aligned formulas."""
+    captured, _ = _drive_main_capturing_subprocess(
+        tmp_path,
+        extra_argv=["--split-conc", "32", "--split-osl", "1024"],
+        env_overrides={"RANDOM_RANGE_RATIO": None, "TRACELENS_SPLIT_R": None},
+    )
+    splitter_cmd = _find_splitter_cmd(captured)
+    assert splitter_cmd is not None, f"splitter never invoked; cmds={captured}"
+    assert "--R" not in splitter_cmd, splitter_cmd
+
+
+def test_194_3_splitter_ignores_non_numeric_R(tmp_path):
+    """A malformed env value must NOT be propagated to the splitter —
+    the splitter would `argparse.error` and abort the whole pipeline
+    on a value error. Silently dropping (with a log line) is the
+    least-bad option; it falls back to the splitter's default heuristic
+    which is exactly the pre-#194-§3 behaviour."""
+    captured, _ = _drive_main_capturing_subprocess(
+        tmp_path,
+        extra_argv=["--split-conc", "32", "--split-osl", "1024"],
+        env_overrides={"RANDOM_RANGE_RATIO": "not-a-float"},
+    )
+    splitter_cmd = _find_splitter_cmd(captured)
+    assert splitter_cmd is not None, f"splitter never invoked; cmds={captured}"
+    assert "--R" not in splitter_cmd, splitter_cmd
+
+
+# ===========================================================================
 # parse_analysis_md — TraceLens v0.3 final-report contract (#155 review)
 # ===========================================================================
 _FIXTURE_LLAMA70B_ANALYSIS_MD = (

--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -1820,6 +1820,21 @@ def main() -> int:
             "Maps to --OSL. Defaults to $OSL when set."
         ),
     )
+    parser.add_argument(
+        "--split-r",
+        default=(
+            os.environ.get("TRACELENS_SPLIT_R", "")
+            or os.environ.get("RANDOM_RANGE_RATIO", "")
+        ),
+        help=(
+            "OSL window ratio R for the splitter (#194 §3). Maps to "
+            "--R on TraceLens.TraceUtils.split_inference_trace_annotation. "
+            "Pairs with --CONC / --OSL so mixed-window selection uses the "
+            "benchmark-contract PD ratio instead of an empirical default. "
+            "Defaults to $RANDOM_RANGE_RATIO when set; leave empty to let "
+            "the splitter fall back to its built-in heuristic."
+        ),
+    )
     args = parser.parse_args()
 
     session_id = args.session_id or uuid.uuid4().hex[:12]
@@ -1918,10 +1933,15 @@ def main() -> int:
                 # TraceLens splitter CLI (real interface):
                 #   python -m TraceLens.TraceUtils.split_inference_trace_annotation
                 #     <trace_path> -o <output_dir> --find-steady-state
-                #     [--num-steps N] [--CONC C] [--OSL O]
+                #     [--num-steps N] [--CONC C] [--OSL O] [--R r]
                 # `--platform` does not exist; --find-steady-state writes
                 # mixed_steady_state_* / decode_only_steady_state_* /
                 # prefilldecode_steady_state_* into output_dir.
+                # --R (#194 §3) feeds mixed-window selection's analytic
+                # PD-ratio computation: per-request OSL is sampled from
+                # [R*OSL, OSL], so without --R the splitter has to guess
+                # the workload's prefill/decode mix from heuristics and
+                # may pick a sub-optimal steady-state window.
                 split_cmd = [
                     sys.executable, "-m",
                     "TraceLens.TraceUtils.split_inference_trace_annotation",
@@ -1936,6 +1956,24 @@ def main() -> int:
                 osl = args.split_osl or os.environ.get("OSL", "").strip()
                 if str(osl).strip():
                     split_cmd += ["--OSL", str(osl).strip()]
+                # --R is a float (splitter declares `type=float`); we
+                # only pass it through when the user / env provided one
+                # so the splitter's built-in default keeps working for
+                # legacy trace files that pre-date the #194 alignment.
+                r_raw = args.split_r or os.environ.get(
+                    "RANDOM_RANGE_RATIO", "",
+                )
+                r_str = str(r_raw).strip()
+                if r_str:
+                    try:
+                        float(r_str)
+                    except ValueError:
+                        append_log(
+                            log_path,
+                            f"split_trace: ignoring non-numeric --R={r_str!r}",
+                        )
+                    else:
+                        split_cmd += ["--R", r_str]
                 split_rc = run_command(
                     split_cmd,
                     cwd=tl_root,


### PR DESCRIPTION
Close #194 

Steady-state window formulas
Replaced the formulas in _workload_envs.py with the skill-recommended versions and wired RANDOM_RANGE_RATIO into the computation.

benchmark_lib.sh num_prompts override
In _workload_envs.py, NUM_PROMPTS is now computed dynamically from the delay_iters + max_iters derived in https://github.com/AMD-AGI/Hyperloom/pull/1 and force-overridden. In parallel, a new _inferencex_patcher.py applies a minimal, backward-compatible patch to benchmark_lib.sh.

Splitter missing --R
Added a --split-r CLI argument to tracelens_analysis.py, falling back to the RANDOM_RANGE_RATIO env var by default.

4./ 5. Missing TraceLens-only flags for vLLM and SGLang

Added _server_patcher.py, which attempts to apply the matching TraceLens patch from the TraceLens repo at profile launch. The required flags are injected only when the patch succeeds; on failure it fail-softs back to the original config. Can be disabled via HYPERLOOM_ENABLE_PATCH=0.