### PR TITLE
feat(inference): TraceLens server-patcher robustness (#194 / PR #200 follow-up)

### DIFF
--- a/inference_optimizer/orchestrator/action_executors/_inferencex_patcher.py
+++ b/inference_optimizer/orchestrator/action_executors/_inferencex_patcher.py
@@ -84,6 +84,35 @@ _PATCH_SENTINEL = '${NUM_PROMPTS:-$max_concurrency}'
 _LOCK_PATH = "/tmp/hyperloom_benchmark_lib_patcher.lock"
 
 
+# PR-D §2: ``benchmark_serving.py`` hardcodes
+# ``extra_body={"num_steps": 1, "merge_profiles": True, "profile_by_stage":
+# True}`` on the ``/start_profile`` request to SGLang. Hyperloom sets
+# ``PROFILE_EXTRA_BODY`` env var (with shape_discovery / roofline_annotations
+# + steady-state start_step/num_steps computed by ``_workload_envs``), but
+# upstream InferenceX never reads it. Without this patch the carefully-tuned
+# steady-state window collapses to the upstream default and TraceLens
+# loses the shape/roofline annotations the analysis depends on.
+#
+# Patch is a single-line replacement gated on the exact legacy text so we
+# never double-patch; sentinel is the ``PROFILE_EXTRA_BODY`` substring.
+_BENCH_SERVING_LEGACY = (
+    '                                         extra_body={"num_steps": 1, '
+    '"merge_profiles": True, "profile_by_stage": True},'
+)
+# JSON fallback uses lowercase ``true`` (the Python literal ``True``
+# would be a JSONDecodeError on the unset-env path, defeating the
+# backward-compat invariant). ``json.loads`` correctly maps ``true``
+# back to Python ``True`` so the resulting dict matches the upstream
+# literal byte-for-byte.
+_BENCH_SERVING_PATCHED = (
+    "                                         extra_body=__import__('json')."
+    "loads(__import__('os').environ.get('PROFILE_EXTRA_BODY') or "
+    '\'{"num_steps": 1, "merge_profiles": true, "profile_by_stage": true}\'),'
+)
+_BENCH_SERVING_SENTINEL = "PROFILE_EXTRA_BODY"
+_BENCH_SERVING_LOCK_PATH = "/tmp/hyperloom_benchmark_serving_patcher.lock"
+
+
 def _resolve_benchmark_lib_path(
     inferencex_path: Path | str | None,
 ) -> Path | None:
@@ -246,4 +275,140 @@ def ensure_benchmark_lib_patched(
         return _apply_patch_atomic(src)
 
 
-__all__ = ["ensure_benchmark_lib_patched"]
+# =====================================================================
+# PR-D §2: PROFILE_EXTRA_BODY consumer patch for benchmark_serving.py
+# =====================================================================
+def _resolve_benchmark_serving_path(
+    inferencex_path: Path | str | None,
+) -> Path | None:
+    """Resolve ``<inferencex_root>/utils/bench_serving/benchmark_serving.py``.
+
+    Returns ``None`` for the same reasons :func:`_resolve_benchmark_lib_path`
+    does (no INFERENCEX_PATH, or file missing). Independent of the
+    benchmark_lib.sh resolver because the two patches are independently
+    useful: shape-aware steady-state windows (this one) and
+    NUM_PROMPTS honouring (the other) sit on different files.
+    """
+    root: Path | None = None
+    if inferencex_path:
+        root = Path(inferencex_path)
+    else:
+        env = os.environ.get("INFERENCEX_PATH", "").strip()
+        if env:
+            root = Path(env)
+    if root is None:
+        return None
+    candidate = root / "utils" / "bench_serving" / "benchmark_serving.py"
+    return candidate if candidate.is_file() else None
+
+
+def _is_benchmark_serving_patched(src: Path) -> bool:
+    try:
+        return _BENCH_SERVING_SENTINEL in src.read_text(encoding="utf-8")
+    except OSError as e:
+        log.warning("_inferencex_patcher: cannot read %s: %s", src, e)
+        return False
+
+
+def _apply_benchmark_serving_patch_atomic(src: Path) -> bool:
+    """Rewrite the single hardcoded ``extra_body=`` line in
+    ``benchmark_serving.py`` to consult ``PROFILE_EXTRA_BODY`` first,
+    via temp-file + atomic rename so a crash mid-write cannot leave a
+    corrupt ``benchmark_serving.py``.
+    """
+    try:
+        original = src.read_text(encoding="utf-8")
+    except OSError as e:
+        log.warning("_inferencex_patcher: cannot read %s: %s", src, e)
+        return False
+
+    if _BENCH_SERVING_LEGACY not in original:
+        log.warning(
+            "_inferencex_patcher: expected legacy `extra_body=` line not "
+            "found in %s; InferenceX layout may have changed and Hyperloom "
+            "needs an updated patch. PROFILE_EXTRA_BODY env var will be "
+            "ignored — TraceLens shape_discovery / roofline_annotations / "
+            "steady-state start_step won't reach the server. Manual review "
+            "needed.", src,
+        )
+        return False
+
+    patched = original.replace(
+        _BENCH_SERVING_LEGACY, _BENCH_SERVING_PATCHED, 1,
+    )
+    if patched == original:
+        return False
+
+    tmp_dir = src.parent
+    try:
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=".benchmark_serving.py.hyperloom_",
+            dir=str(tmp_dir),
+        )
+    except OSError as e:
+        log.warning(
+            "_inferencex_patcher: cannot create temp file in %s: %s",
+            tmp_dir, e,
+        )
+        return False
+
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(patched)
+        os.chmod(tmp_name, src.stat().st_mode)
+        os.replace(tmp_name, src)
+    except OSError as e:
+        log.warning("_inferencex_patcher: cannot write %s: %s", src, e)
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        return False
+
+    log.info(
+        "_inferencex_patcher: patched %s to consume PROFILE_EXTRA_BODY env "
+        "var (PR-D §2: fixes silently-ignored shape_discovery / "
+        "roofline_annotations / steady-state start_step from "
+        "_workload_envs.py)", src,
+    )
+    return True
+
+
+def ensure_benchmark_serving_patched(
+    inferencex_path: Path | str | None = None,
+) -> bool:
+    """Ensure InferenceX ``benchmark_serving.py`` reads
+    ``PROFILE_EXTRA_BODY`` env var on ``/start_profile``.
+
+    Returns ``True`` when the file is in patched state at exit
+    (already-patched or freshly-patched both count); ``False`` when
+    the file could not be located or the expected legacy line is
+    missing. Non-fatal — callers are expected to log and continue
+    so that smoke / dry-run paths without a real InferenceX checkout
+    still work.
+
+    Safe to call concurrently — same flock + atomic-replace shape as
+    :func:`ensure_benchmark_lib_patched`. Independent lock file so
+    the two patches don't serialize on each other (typical workflow
+    calls both once per profile run).
+    """
+    src = _resolve_benchmark_serving_path(inferencex_path)
+    if src is None:
+        log.info(
+            "_inferencex_patcher: INFERENCEX_PATH unset or "
+            "benchmark_serving.py missing — skipping PROFILE_EXTRA_BODY "
+            "patch (this is fine for tests and dry-runs without a real "
+            "InferenceX tree)",
+        )
+        return False
+
+    if _is_benchmark_serving_patched(src):
+        return True
+
+    with _file_lock(_BENCH_SERVING_LOCK_PATH):
+        if _is_benchmark_serving_patched(src):
+            return True
+        return _apply_benchmark_serving_patch_atomic(src)
+
+
+__all__ = ["ensure_benchmark_lib_patched", "ensure_benchmark_serving_patched"]

--- a/inference_optimizer/orchestrator/action_executors/_inferencex_patcher.py
+++ b/inference_optimizer/orchestrator/action_executors/_inferencex_patcher.py
@@ -225,8 +225,15 @@ def _apply_patch_atomic(src: Path) -> bool:
         log.warning("_inferencex_patcher: cannot write %s: %s", src, e)
         try:
             os.unlink(tmp_name)
-        except OSError:
-            pass
+        except OSError as cleanup_err:
+            # Best-effort temp cleanup; the main write already failed so
+            # we propagate that failure regardless. Log at debug so the
+            # ignored exception is grep-discoverable without spamming
+            # warning logs on the unhappy path.
+            log.debug(
+                "_inferencex_patcher: best-effort cleanup failed for temp "
+                "file %s: %s", tmp_name, cleanup_err,
+            )
         return False
 
     log.info(
@@ -361,8 +368,11 @@ def _apply_benchmark_serving_patch_atomic(src: Path) -> bool:
         log.warning("_inferencex_patcher: cannot write %s: %s", src, e)
         try:
             os.unlink(tmp_name)
-        except OSError:
-            pass
+        except OSError as cleanup_err:
+            log.debug(
+                "_inferencex_patcher: best-effort cleanup failed for temp "
+                "file %s: %s", tmp_name, cleanup_err,
+            )
         return False
 
     log.info(

--- a/inference_optimizer/orchestrator/action_executors/_server_patcher.py
+++ b/inference_optimizer/orchestrator/action_executors/_server_patcher.py
@@ -92,12 +92,59 @@ _LOCK_PATH = "/tmp/hyperloom_server_patcher.lock"
 # hung NFS / weird filesystems.
 _GIT_TIMEOUT_SEC = 30
 
-# TraceLens currently ships SGLang patches only for v0.5.9. Hyperloom's
-# default deployment uses v0.5.10 — version mismatch is the *common* case
-# and must fail-soft cleanly. Bump this string when TraceLens adds new
-# versions (or refactor to discover via a manifest file inside the
-# patches directory).
-_SGLANG_SUPPORTED_VERSIONS: frozenset[str] = frozenset({"0.5.9"})
+# PR-C §2: SGLang version gate is now a *minor-version* allowlist
+# rather than an exact pin so the fuzzy patch fallback (PR-C §1) gets
+# a chance to apply TraceLens patches against a freshly bumped point
+# release. ``0.5.x`` covers all of 0.5.9, 0.5.10, 0.5.11, … which is
+# the typical bump cadence between TraceLens patch revisions.
+#
+# Behaviour at the apply layer: if the fuzzy fallback also rejects
+# the patch (real context conflict, not just whitespace drift), the
+# whole patch set fail-softs anyway — so widening the version gate
+# here is safe; it just lets borderline-compatible versions reach
+# the fuzzy path that would otherwise be rejected upfront.
+#
+# Override via ``HYPERLOOM_SGLANG_PATCH_ALLOWED_MINORS=<csv>`` for
+# operators who want to either tighten (back to exact pins) or
+# extend (e.g. ``0.5,0.6``) the allowlist without a code change.
+# Tighten to a frozenset of exact versions via
+# ``HYPERLOOM_SGLANG_PATCH_EXACT_VERSIONS=<csv>``; when set this
+# wins over the minor allowlist.
+_SGLANG_DEFAULT_ALLOWED_MINORS: tuple[str, ...] = ("0.5",)
+
+
+def _sglang_version_accepted(version: str) -> bool:
+    """Return True iff ``version`` is in the configured allowlist.
+
+    Resolution order:
+
+    1. ``$HYPERLOOM_SGLANG_PATCH_EXACT_VERSIONS`` (csv) — exact pins
+       win when set; this matches the pre-PR-C behaviour for callers
+       who want to lock down to known-good versions.
+    2. ``$HYPERLOOM_SGLANG_PATCH_ALLOWED_MINORS`` (csv) — minor-version
+       allowlist (e.g. ``0.5,0.6``); a version is accepted iff it
+       startswith one of the listed prefixes followed by ``.`` (so
+       ``0.5`` matches ``0.5.9`` but not ``0.50.0``).
+    3. :data:`_SGLANG_DEFAULT_ALLOWED_MINORS` — the built-in default.
+    """
+    text = (version or "").strip()
+    if not text:
+        return False
+    exact = os.environ.get("HYPERLOOM_SGLANG_PATCH_EXACT_VERSIONS", "").strip()
+    if exact:
+        allowed_exact = {v.strip() for v in exact.split(",") if v.strip()}
+        return text in allowed_exact
+    minors_env = os.environ.get(
+        "HYPERLOOM_SGLANG_PATCH_ALLOWED_MINORS", "",
+    ).strip()
+    if minors_env:
+        minors = tuple(v.strip() for v in minors_env.split(",") if v.strip())
+    else:
+        minors = _SGLANG_DEFAULT_ALLOWED_MINORS
+    return any(
+        text == minor or text.startswith(f"{minor}.")
+        for minor in minors
+    )
 
 # Path within the TraceLens checkout that hosts the patch sets.
 _PATCH_TREE_REL = ("examples", "custom_workflows", "inference_analysis")
@@ -236,12 +283,12 @@ def _discover_sglang_plan(arg: Path | str | None) -> _PatchPlan | None:
         return None
 
     version = (getattr(sglang, "__version__", "") or "").strip()
-    if version not in _SGLANG_SUPPORTED_VERSIONS:
+    if not _sglang_version_accepted(version):
         log.info(
-            "_server_patcher: SGLang %s not in supported set %s; skip "
-            "(TraceLens ships patches for these versions only — bump "
-            "_SGLANG_SUPPORTED_VERSIONS when TraceLens adds support)",
-            version, sorted(_SGLANG_SUPPORTED_VERSIONS),
+            "_server_patcher: SGLang %s not in supported minor allowlist "
+            "(see HYPERLOOM_SGLANG_PATCH_ALLOWED_MINORS / "
+            "HYPERLOOM_SGLANG_PATCH_EXACT_VERSIONS to override); skip",
+            version,
         )
         return None
 

--- a/inference_optimizer/orchestrator/action_executors/_server_patcher.py
+++ b/inference_optimizer/orchestrator/action_executors/_server_patcher.py
@@ -92,9 +92,9 @@ _LOCK_PATH = "/tmp/hyperloom_server_patcher.lock"
 # hung NFS / weird filesystems.
 _GIT_TIMEOUT_SEC = 30
 
-# PR-C §2: SGLang version gate is now a *minor-version* allowlist
-# rather than an exact pin so the fuzzy patch fallback (PR-C §1) gets
-# a chance to apply TraceLens patches against a freshly bumped point
+# PR-C §2: SGLang version gate is a *minor-version* allowlist rather
+# than an exact pin so the fuzzy patch fallback (PR-C §1) gets a
+# chance to apply TraceLens patches against a freshly bumped point
 # release. ``0.5.x`` covers all of 0.5.9, 0.5.10, 0.5.11, … which is
 # the typical bump cadence between TraceLens patch revisions.
 #
@@ -112,20 +112,87 @@ _GIT_TIMEOUT_SEC = 30
 # wins over the minor allowlist.
 _SGLANG_DEFAULT_ALLOWED_MINORS: tuple[str, ...] = ("0.5",)
 
+# PR-D §5: TraceLens-shipped manifest filename(s). When present in the
+# SGLang patches dir, the manifest is the source of truth for which
+# SGLang versions the patches support — Hyperloom's hardcoded default
+# allowlist is bypassed entirely. The day TraceLens starts shipping
+# this file, the Hyperloom gate auto-adapts without a code change,
+# which is the decoupling intent of the #194 §5 follow-up
+# recommendation ("discover supported SGLang versions from the
+# TraceLens patches dir rather than from a hardcoded allowlist").
+# Format: plain text, one version per line, ``#`` starts comments,
+# blank lines ignored. Operator env-var pins still beat the manifest
+# so debugging escape hatches keep working.
+_SGLANG_SUPPORTED_VERSIONS_MANIFEST_NAMES: tuple[str, ...] = (
+    "SUPPORTED_VERSIONS.txt",
+    "SUPPORTED_VERSIONS",
+)
 
-def _sglang_version_accepted(version: str) -> bool:
+
+def _load_sglang_supported_versions_from_manifest(
+    patches_dir: Path,
+) -> frozenset[str] | None:
+    """Read the TraceLens-shipped ``SUPPORTED_VERSIONS`` manifest if
+    one exists in ``patches_dir``.
+
+    Format: one version per line; ``#`` comments and blank lines are
+    skipped. Returns ``None`` if no manifest file is present (the
+    common case today — TraceLens doesn't ship one yet, so this is a
+    forward-compatible hook that auto-activates when they do).
+    Returns an empty frozenset only if the file is explicitly empty
+    after comment/blank stripping — operators see that as "TraceLens
+    declares zero supported versions", which correctly rejects all.
+    """
+    for name in _SGLANG_SUPPORTED_VERSIONS_MANIFEST_NAMES:
+        manifest = patches_dir / name
+        if not manifest.is_file():
+            continue
+        try:
+            raw = manifest.read_text(encoding="utf-8")
+        except OSError as e:
+            log.warning(
+                "_server_patcher: cannot read SGLang version manifest %s (%s);"
+                " falling back to hardcoded allowlist", manifest, e,
+            )
+            return None
+        versions: set[str] = set()
+        for line in raw.splitlines():
+            stripped = line.split("#", 1)[0].strip()
+            if stripped:
+                versions.add(stripped)
+        log.info(
+            "_server_patcher: loaded %d SGLang version(s) from TraceLens "
+            "manifest %s (PR-D §5: decoupled from Hyperloom hardcoded "
+            "allowlist)", len(versions), manifest,
+        )
+        return frozenset(versions)
+    return None
+
+
+def _sglang_version_accepted(
+    version: str, *, patches_dir: Path | None = None,
+) -> bool:
     """Return True iff ``version`` is in the configured allowlist.
 
-    Resolution order:
+    Resolution order (highest precedence first):
 
-    1. ``$HYPERLOOM_SGLANG_PATCH_EXACT_VERSIONS`` (csv) — exact pins
-       win when set; this matches the pre-PR-C behaviour for callers
+    1. ``$HYPERLOOM_SGLANG_PATCH_EXACT_VERSIONS`` (csv) — exact pins.
+       Operator escape hatch; matches pre-PR-C behaviour for callers
        who want to lock down to known-good versions.
     2. ``$HYPERLOOM_SGLANG_PATCH_ALLOWED_MINORS`` (csv) — minor-version
        allowlist (e.g. ``0.5,0.6``); a version is accepted iff it
-       startswith one of the listed prefixes followed by ``.`` (so
-       ``0.5`` matches ``0.5.9`` but not ``0.50.0``).
-    3. :data:`_SGLANG_DEFAULT_ALLOWED_MINORS` — the built-in default.
+       equals or startswith one of the listed prefixes followed by
+       ``.`` (so ``0.5`` matches ``0.5.9`` but not ``0.50.0``).
+    3. **TraceLens-shipped ``SUPPORTED_VERSIONS`` manifest** when
+       present in ``patches_dir`` (PR-D §5). The manifest fully
+       replaces the hardcoded default; if the manifest exists,
+       :data:`_SGLANG_DEFAULT_ALLOWED_MINORS` is not consulted.
+       TraceLens owns this list because TraceLens owns the patches;
+       Hyperloom learning the list from TraceLens decouples version
+       support bumps from Hyperloom code changes.
+    4. :data:`_SGLANG_DEFAULT_ALLOWED_MINORS` — the built-in default,
+       only consulted when no operator override AND no vendor
+       manifest is present.
     """
     text = (version or "").strip()
     if not text:
@@ -139,11 +206,24 @@ def _sglang_version_accepted(version: str) -> bool:
     ).strip()
     if minors_env:
         minors = tuple(v.strip() for v in minors_env.split(",") if v.strip())
-    else:
-        minors = _SGLANG_DEFAULT_ALLOWED_MINORS
+        return any(
+            text == minor or text.startswith(f"{minor}.")
+            for minor in minors
+        )
+    # PR-D §5: vendor manifest. When present, the manifest IS the
+    # allowlist — fully replaces the hardcoded default. When absent,
+    # the manifest helper returns None and we fall through to the
+    # default below (preserves PR-C.2 behaviour for today's TraceLens
+    # which doesn't ship the manifest).
+    if patches_dir is not None:
+        manifest_versions = _load_sglang_supported_versions_from_manifest(
+            patches_dir,
+        )
+        if manifest_versions is not None:
+            return text in manifest_versions
     return any(
         text == minor or text.startswith(f"{minor}.")
-        for minor in minors
+        for minor in _SGLANG_DEFAULT_ALLOWED_MINORS
     )
 
 # Path within the TraceLens checkout that hosts the patch sets.
@@ -305,20 +385,25 @@ def _discover_sglang_plan(arg: Path | str | None) -> _PatchPlan | None:
         return None
 
     version = (getattr(sglang, "__version__", "") or "").strip()
-    if not _sglang_version_accepted(version):
-        log.info(
-            "_server_patcher: SGLang %s not in supported minor allowlist "
-            "(see HYPERLOOM_SGLANG_PATCH_ALLOWED_MINORS / "
-            "HYPERLOOM_SGLANG_PATCH_EXACT_VERSIONS to override); skip",
-            version,
-        )
-        return None
 
+    # Resolve the patches dir BEFORE the version check so the gate
+    # can consult the TraceLens-shipped manifest (PR-D §5). If the
+    # patches dir itself is missing, no point checking the version.
     patches_dir = _patch_tree(tracelens_root, "sglang_roofline_patches")
     if not patches_dir.is_dir():
         log.info(
             "_server_patcher: SGLang patches directory missing (%s); skip",
             patches_dir,
+        )
+        return None
+
+    if not _sglang_version_accepted(version, patches_dir=patches_dir):
+        log.info(
+            "_server_patcher: SGLang %s not in supported version list "
+            "(consulted: $HYPERLOOM_SGLANG_PATCH_EXACT_VERSIONS, "
+            "$HYPERLOOM_SGLANG_PATCH_ALLOWED_MINORS, %s/SUPPORTED_VERSIONS, "
+            "then built-in minor allowlist %s); skip",
+            version, patches_dir, _SGLANG_DEFAULT_ALLOWED_MINORS,
         )
         return None
     patches = tuple(sorted(patches_dir.glob("*.patch")))

--- a/inference_optimizer/orchestrator/action_executors/_server_patcher.py
+++ b/inference_optimizer/orchestrator/action_executors/_server_patcher.py
@@ -558,7 +558,7 @@ def _apply_atomic(plan: _PatchPlan) -> bool:
 
     # PR-C §1: per-patch precheck. Each patch must EITHER pass
     # ``git apply --check`` (the strict path, preferred) OR pass
-    # ``patch -p1 --fuzz=10 --dry-run`` (the fuzzy fallback for minor
+    # ``patch -p1 --fuzz=2 --dry-run`` (the fuzzy fallback for minor
     # context drift when TraceLens patches haven't been rev'd against
     # a slightly newer SGLang / vLLM point release). If neither
     # accepts the patch the whole set is rejected and we fail-soft.
@@ -572,7 +572,7 @@ def _apply_atomic(plan: _PatchPlan) -> bool:
         if patch_bin and _patch_dry_run(patch_bin, p, plan.apply_root, plan.apply_strip):
             log.warning(
                 "_server_patcher: %s patch %s did not apply cleanly with "
-                "`git apply --check %s`; falling back to `patch %s --fuzz=10` "
+                "`git apply --check %s`; falling back to `patch %s --fuzz=2` "
                 "(TraceLens patch may lag deployed %s by a point release)",
                 plan.framework, p.name, strip_arg, strip_arg, plan.framework,
             )
@@ -634,10 +634,31 @@ def _apply_atomic(plan: _PatchPlan) -> bool:
     return True
 
 
+# PR-D §6: fuzz value chosen deliberately at GNU patch's default (2)
+# rather than the maximum (10).
+#
+# Rationale: fuzz=10 (PR-C §1's original value) tolerates up to 10
+# context lines of mismatch per hunk — near GNU patch's practical
+# upper limit. That lets multi-line upstream refactors near a patch
+# site silently apply the patch's CHANGE lines to a similar-looking
+# but semantically wrong location: framework imports cleanly, profile
+# hooks attach to the wrong call site, profile data is silently
+# misleading rather than absent.
+#
+# fuzz=2 (the default) still tolerates whitespace and single-line
+# context drift (the common point-release case the fuzzy fallback was
+# designed for), but rejects multi-line drift hard so the patcher
+# fail-softs visibly (apply rejected → no shape_discovery flag, but
+# no wrong-place mutation). The flag is kept explicit (not omitted)
+# so the choice is grep-discoverable and survives any future GNU
+# patch default change.
+_FUZZ = 2
+
+
 def _patch_dry_run(
     patch_bin: str, patch_file: Path, cwd: Path, strip: int = 1,
 ) -> bool:
-    """Probe ``patch -p<strip> --fuzz=10 --dry-run`` for a single patch.
+    """Probe ``patch -p<strip> --fuzz=2 --dry-run`` for a single patch.
 
     Used as a fuzzy fallback when ``git apply --check`` rejects a patch
     due to minor context drift (whitespace / single-line edits in the
@@ -646,11 +667,14 @@ def _patch_dry_run(
     apply on this check. ``strip`` matches the ``-p<N>`` flag git apply
     uses for the same patch — PR-D §1 may pass ``-p3`` for wheel
     SGLang installs vs the default ``-p1`` for editable installs.
+
+    fuzz value: see :data:`_FUZZ` — defaults to 2 (whitespace +
+    single-line tolerance only; multi-line drift is rejected hard).
     """
     try:
         with patch_file.open("rb") as fh:
             result = subprocess.run(
-                (patch_bin, f"-p{strip}", "--fuzz=10", "--dry-run", "--silent"),
+                (patch_bin, f"-p{strip}", f"--fuzz={_FUZZ}", "--dry-run", "--silent"),
                 cwd=str(cwd),
                 stdin=fh,
                 capture_output=True,
@@ -669,10 +693,10 @@ def _patch_apply(
     patch_bin: str, patch_file: Path, cwd: Path, strip: int = 1, *,
     reverse: bool = False,
 ) -> bool:
-    """Real ``patch -p<strip> --fuzz=10`` apply (or reverse). Mirrors
+    """Real ``patch -p<strip> --fuzz=2`` apply (or reverse). Mirrors
     :func:`_patch_dry_run` but actually mutates the working tree.
     Returns True iff rc == 0."""
-    args = [patch_bin, f"-p{strip}", "--fuzz=10", "--silent"]
+    args = [patch_bin, f"-p{strip}", f"--fuzz={_FUZZ}", "--silent"]
     if reverse:
         args.append("--reverse")
     try:

--- a/inference_optimizer/orchestrator/action_executors/_server_patcher.py
+++ b/inference_optimizer/orchestrator/action_executors/_server_patcher.py
@@ -196,6 +196,12 @@ class _PatchPlan:
     patches: tuple[Path, ...]    # in apply order
     sentinel_file: Path          # file we grep to detect "already patched"
     sentinel_text: str           # substring expected in sentinel_file
+    # PR-D §1: per-plan ``-p<N>`` strip count. Editable SGLang layouts
+    # and the vLLM patch set both use ``-p1`` (default); wheel-install
+    # SGLang uses ``-p3`` so the ``a/python/sglang/`` prefix is
+    # stripped relative to the wheel install dir. Always passed to
+    # both ``git apply`` and ``patch``.
+    apply_strip: int = 1
 
 
 def _resolve_tracelens_root(arg: Path | str | None) -> Path | None:
@@ -304,28 +310,30 @@ def _discover_sglang_plan(arg: Path | str | None) -> _PatchPlan | None:
         log.info("_server_patcher: SGLang patches directory empty; skip")
         return None
 
-    # The SGLang patches use ``a/python/sglang/...`` prefix — they
-    # assume an editable install where the repo's ``python/sglang/...``
-    # layout is preserved. For pip-wheel installs ``sglang/`` sits
-    # directly under site-packages with no ``python/`` parent, so the
-    # patches' ``-p1`` strip won't match.
+    # PR-D §1: support both layouts.
+    #
+    # * Editable install (``.../python/sglang/__init__.py``): apply
+    #   from the repo root with ``-p1`` so the patches' ``a/python/
+    #   sglang/...`` prefix matches the on-disk path verbatim. This is
+    #   the historical layout and the only one PR #200 supported.
+    # * Wheel install (``site-packages/sglang/__init__.py`` with no
+    #   ``python/`` parent): apply from inside the wheel sglang/ dir
+    #   itself with ``-p3`` so the prefix is stripped to ``srt/...``
+    #   (matching the wheel layout). The actual sglang/ files end up
+    #   modified in place — no symlinks, no tmpdirs, no copies, so
+    #   ``git apply``'s symlink-safety check never trips.
     sglang_module = Path(sglang.__file__).resolve()
-    if sglang_module.parent.parent.name != "python":
-        log.info(
-            "_server_patcher: SGLang install at %s is not an editable "
-            "`python/sglang/` layout — patches assume that layout, so "
-            "skip patching", sglang_module,
-        )
+    resolution = _resolve_sglang_apply_root(sglang_module)
+    if resolution is None:
         return None
-    apply_root = sglang_module.parent.parent.parent
+    apply_root, apply_strip = resolution
 
-    # Sentinel: the kernel_shape_profiler patch creates an entirely new
-    # file. Its presence + a unique content marker is a robust "already
-    # patched" signal.
-    sentinel = (
-        apply_root / "python" / "sglang" / "srt" / "utils"
-        / "kernel_shape_profiler.py"
-    )
+    # Sentinel: the kernel_shape_profiler patch creates an entirely
+    # new file. In both layouts it lands at the wheel-side path
+    # ``sglang/srt/utils/kernel_shape_profiler.py`` (relative to the
+    # parent of sglang/), so we resolve the absolute path off
+    # ``sglang_module`` itself to keep both branches symmetric.
+    sentinel = sglang_module.parent / "srt" / "utils" / "kernel_shape_profiler.py"
     return _PatchPlan(
         framework="sglang",
         version=version,
@@ -333,7 +341,34 @@ def _discover_sglang_plan(arg: Path | str | None) -> _PatchPlan | None:
         patches=patches,
         sentinel_file=sentinel,
         sentinel_text="kernel_shape_profiler",
+        apply_strip=apply_strip,
     )
+
+
+def _resolve_sglang_apply_root(sglang_module: Path) -> tuple[Path, int] | None:
+    """Pick ``(apply_root, strip_count)`` for the active SGLang install.
+
+    * Editable layout (``<repo>/python/sglang/__init__.py``):
+      ``(repo_root, 1)``. Patches reference ``a/python/sglang/...``;
+      with ``-p1`` the prefix is stripped to ``python/sglang/...``
+      relative to ``<repo>``, which matches the on-disk path.
+    * Wheel layout (``site-packages/sglang/__init__.py`` with no
+      ``python/`` parent): ``(<site-packages>/sglang, 3)``. With
+      ``-p3`` the patch path is stripped to ``srt/...`` relative to
+      the wheel install dir, which matches the wheel layout. PR-D §1.
+    * Anything else: return ``None`` so the caller fail-softs.
+    """
+    if sglang_module.parent.parent.name == "python":
+        return sglang_module.parent.parent.parent, 1
+    sglang_dir = sglang_module.parent
+    if sglang_dir.name == "sglang":
+        return sglang_dir, 3
+    log.info(
+        "_server_patcher: SGLang install at %s has unexpected layout "
+        "(parent dir name=%r); skip patching",
+        sglang_module, sglang_dir.name,
+    )
+    return None
 
 
 # ---------------------------------------------------------------------
@@ -415,24 +450,26 @@ def _apply_atomic(plan: _PatchPlan) -> bool:
     # context drift when TraceLens patches haven't been rev'd against
     # a slightly newer SGLang / vLLM point release). If neither
     # accepts the patch the whole set is rejected and we fail-soft.
+    strip_arg = f"-p{plan.apply_strip}"
+
     apply_modes: dict[Path, str] = {}
     for p in plan.patches:
-        if _git(git, ("apply", "--check", str(p)), plan.apply_root):
+        if _git(git, ("apply", "--check", strip_arg, str(p)), plan.apply_root):
             apply_modes[p] = "git"
             continue
-        if patch_bin and _patch_dry_run(patch_bin, p, plan.apply_root):
+        if patch_bin and _patch_dry_run(patch_bin, p, plan.apply_root, plan.apply_strip):
             log.warning(
                 "_server_patcher: %s patch %s did not apply cleanly with "
-                "`git apply --check`; falling back to `patch -p1 --fuzz=10` "
+                "`git apply --check %s`; falling back to `patch %s --fuzz=10` "
                 "(TraceLens patch may lag deployed %s by a point release)",
-                plan.framework, p.name, plan.framework,
+                plan.framework, p.name, strip_arg, strip_arg, plan.framework,
             )
             apply_modes[p] = "patch"
             continue
         log.warning(
-            "_server_patcher: `git apply --check` AND fuzzy `patch --dry-run` "
-            "both failed for %s (version %s, patch %s); fail-soft skip",
-            plan.framework, plan.version, p.name,
+            "_server_patcher: `git apply --check %s` AND fuzzy `patch %s "
+            "--dry-run` both failed for %s (version %s, patch %s); fail-soft "
+            "skip", strip_arg, strip_arg, plan.framework, plan.version, p.name,
         )
         return False
 
@@ -440,9 +477,11 @@ def _apply_atomic(plan: _PatchPlan) -> bool:
     for p in plan.patches:
         mode = apply_modes[p]
         if mode == "git":
-            ok = _git(git, ("apply", str(p)), plan.apply_root)
+            ok = _git(git, ("apply", strip_arg, str(p)), plan.apply_root)
         else:
-            ok = _patch_apply(patch_bin, p, plan.apply_root)  # type: ignore[arg-type]
+            ok = _patch_apply(
+                patch_bin, p, plan.apply_root, plan.apply_strip,  # type: ignore[arg-type]
+            )
         if ok:
             applied.append((p, mode))
             continue
@@ -454,11 +493,16 @@ def _apply_atomic(plan: _PatchPlan) -> bool:
         )
         for prev, prev_mode in reversed(applied):
             if prev_mode == "git":
-                rolled_back = _git(git, ("apply", "-R", str(prev)), plan.apply_root)
+                rolled_back = _git(
+                    git, ("apply", "-R", strip_arg, str(prev)), plan.apply_root,
+                )
             else:
                 rolled_back = (
                     patch_bin is not None
-                    and _patch_apply(patch_bin, prev, plan.apply_root, reverse=True)
+                    and _patch_apply(
+                        patch_bin, prev, plan.apply_root, plan.apply_strip,
+                        reverse=True,
+                    )
                 )
             if not rolled_back:
                 log.error(
@@ -478,19 +522,23 @@ def _apply_atomic(plan: _PatchPlan) -> bool:
     return True
 
 
-def _patch_dry_run(patch_bin: str, patch_file: Path, cwd: Path) -> bool:
-    """Probe ``patch -p1 --fuzz=10 --dry-run`` for a single patch.
+def _patch_dry_run(
+    patch_bin: str, patch_file: Path, cwd: Path, strip: int = 1,
+) -> bool:
+    """Probe ``patch -p<strip> --fuzz=10 --dry-run`` for a single patch.
 
     Used as a fuzzy fallback when ``git apply --check`` rejects a patch
     due to minor context drift (whitespace / single-line edits in the
     target that don't affect the diff's semantic intent). The dry-run
     has zero filesystem side effects so it's safe to gate the actual
-    apply on this check.
+    apply on this check. ``strip`` matches the ``-p<N>`` flag git apply
+    uses for the same patch — PR-D §1 may pass ``-p3`` for wheel
+    SGLang installs vs the default ``-p1`` for editable installs.
     """
     try:
         with patch_file.open("rb") as fh:
             result = subprocess.run(
-                (patch_bin, "-p1", "--fuzz=10", "--dry-run", "--silent"),
+                (patch_bin, f"-p{strip}", "--fuzz=10", "--dry-run", "--silent"),
                 cwd=str(cwd),
                 stdin=fh,
                 capture_output=True,
@@ -506,12 +554,13 @@ def _patch_dry_run(patch_bin: str, patch_file: Path, cwd: Path) -> bool:
 
 
 def _patch_apply(
-    patch_bin: str, patch_file: Path, cwd: Path, *, reverse: bool = False,
+    patch_bin: str, patch_file: Path, cwd: Path, strip: int = 1, *,
+    reverse: bool = False,
 ) -> bool:
-    """Real ``patch -p1 --fuzz=10`` apply (or reverse). Mirrors
+    """Real ``patch -p<strip> --fuzz=10`` apply (or reverse). Mirrors
     :func:`_patch_dry_run` but actually mutates the working tree.
     Returns True iff rc == 0."""
-    args = [patch_bin, "-p1", "--fuzz=10", "--silent"]
+    args = [patch_bin, f"-p{strip}", "--fuzz=10", "--silent"]
     if reverse:
         args.append("--reverse")
     try:

--- a/inference_optimizer/orchestrator/action_executors/_server_patcher.py
+++ b/inference_optimizer/orchestrator/action_executors/_server_patcher.py
@@ -192,10 +192,20 @@ class _PatchPlan:
     """All information needed to apply (or verify) a patch set."""
     framework: str
     version: str
-    apply_root: Path             # cwd for ``git apply``
-    patches: tuple[Path, ...]    # in apply order
-    sentinel_file: Path          # file we grep to detect "already patched"
-    sentinel_text: str           # substring expected in sentinel_file
+    apply_root: Path                       # cwd for ``git apply``
+    patches: tuple[Path, ...]              # in apply order
+    sentinel_file: Path                    # file we grep to detect "already patched"
+    # PR-D §4: list of substrings that MUST ALL be present in
+    # ``sentinel_file`` for the install to count as patched. A single
+    # substring (the historical case) goes in a 1-tuple; multi-element
+    # tuples raise the bar for accidental false positives if upstream
+    # ever happens to merge a field name we use as a marker (the
+    # combined probability of N marker strings ALL appearing
+    # un-coordinated is vanishingly small). The vLLM plan uses both
+    # ``capture_torch_profiler_dir`` and ``detailed_trace_annotation``,
+    # which the TraceLens patch always adds together but upstream has
+    # no reason to merge as a co-occurring pair.
+    sentinel_text: tuple[str, ...]
     # PR-D §1: per-plan ``-p<N>`` strip count. Editable SGLang layouts
     # and the vLLM patch set both use ``-p1`` (default); wheel-install
     # SGLang uses ``-p3`` so the ``a/python/sglang/`` prefix is
@@ -264,13 +274,19 @@ def _discover_vllm_plan(arg: Path | str | None) -> _PatchPlan | None:
         )
         return None
 
+    # PR-D §4: both substrings live in the same dataclass body that
+    # the TraceLens patch adds to ``profiler.py``. Requiring BOTH
+    # collapses the false-positive surface to ~zero: upstream vLLM
+    # has no reason to add a config field named both
+    # ``capture_torch_profiler_dir`` AND ``detailed_trace_annotation``
+    # without also adopting the TraceLens patch.
     return _PatchPlan(
         framework="vllm",
         version=version,
         apply_root=install_root,
         patches=(patch_file,),
         sentinel_file=sentinel,
-        sentinel_text="capture_torch_profiler_dir",
+        sentinel_text=("capture_torch_profiler_dir", "detailed_trace_annotation"),
     )
 
 
@@ -340,7 +356,11 @@ def _discover_sglang_plan(arg: Path | str | None) -> _PatchPlan | None:
         apply_root=apply_root,
         patches=patches,
         sentinel_file=sentinel,
-        sentinel_text="kernel_shape_profiler",
+        # The SGLang sentinel file ``kernel_shape_profiler.py`` is
+        # *created* by the patch — its mere existence + a unique
+        # internal identifier is already a robust signal. Kept as a
+        # 1-tuple for type uniformity with vLLM (PR-D §4).
+        sentinel_text=("kernel_shape_profiler",),
         apply_strip=apply_strip,
     )
 
@@ -387,12 +407,19 @@ def _ensure_patched(plan: _PatchPlan) -> bool:
 
 
 def _is_patched(plan: _PatchPlan) -> bool:
+    """True iff the sentinel file exists AND every marker substring in
+    ``plan.sentinel_text`` is present. The all-of-N rule (PR-D §4)
+    raises the bar for false positives if upstream ever merges one of
+    our marker identifiers without also adopting the TraceLens patch
+    — the combined probability of all N markers co-occurring
+    un-coordinated is vanishingly small."""
     try:
         if not plan.sentinel_file.exists():
             return False
-        return plan.sentinel_text in plan.sentinel_file.read_text(
+        content = plan.sentinel_file.read_text(
             encoding="utf-8", errors="replace",
         )
+        return all(marker in content for marker in plan.sentinel_text)
     except OSError:
         return False
 

--- a/inference_optimizer/orchestrator/action_executors/_server_patcher.py
+++ b/inference_optimizer/orchestrator/action_executors/_server_patcher.py
@@ -360,40 +360,136 @@ def _apply_atomic(plan: _PatchPlan) -> bool:
             plan.framework,
         )
         return False
+    patch_bin = shutil.which("patch")  # may be ``None`` — fuzzy fallback then disabled
 
+    # PR-C §1: per-patch precheck. Each patch must EITHER pass
+    # ``git apply --check`` (the strict path, preferred) OR pass
+    # ``patch -p1 --fuzz=10 --dry-run`` (the fuzzy fallback for minor
+    # context drift when TraceLens patches haven't been rev'd against
+    # a slightly newer SGLang / vLLM point release). If neither
+    # accepts the patch the whole set is rejected and we fail-soft.
+    apply_modes: dict[Path, str] = {}
     for p in plan.patches:
-        if not _git(git, ("apply", "--check", str(p)), plan.apply_root):
+        if _git(git, ("apply", "--check", str(p)), plan.apply_root):
+            apply_modes[p] = "git"
+            continue
+        if patch_bin and _patch_dry_run(patch_bin, p, plan.apply_root):
             log.warning(
-                "_server_patcher: `git apply --check` failed for %s "
-                "(version %s, patch %s); fail-soft skip",
-                plan.framework, plan.version, p.name,
+                "_server_patcher: %s patch %s did not apply cleanly with "
+                "`git apply --check`; falling back to `patch -p1 --fuzz=10` "
+                "(TraceLens patch may lag deployed %s by a point release)",
+                plan.framework, p.name, plan.framework,
             )
-            return False
+            apply_modes[p] = "patch"
+            continue
+        log.warning(
+            "_server_patcher: `git apply --check` AND fuzzy `patch --dry-run` "
+            "both failed for %s (version %s, patch %s); fail-soft skip",
+            plan.framework, plan.version, p.name,
+        )
+        return False
 
-    applied: list[Path] = []
+    applied: list[tuple[Path, str]] = []
     for p in plan.patches:
-        if _git(git, ("apply", str(p)), plan.apply_root):
-            applied.append(p)
+        mode = apply_modes[p]
+        if mode == "git":
+            ok = _git(git, ("apply", str(p)), plan.apply_root)
+        else:
+            ok = _patch_apply(patch_bin, p, plan.apply_root)  # type: ignore[arg-type]
+        if ok:
+            applied.append((p, mode))
             continue
         log.error(
             "_server_patcher: %s patch %s failed during apply after "
-            "passing --check; rolling back %d previously-applied patches",
-            plan.framework, p.name, len(applied),
+            "passing precheck (mode=%s); rolling back %d previously-applied "
+            "patches",
+            plan.framework, p.name, mode, len(applied),
         )
-        for prev in reversed(applied):
-            if not _git(git, ("apply", "-R", str(prev)), plan.apply_root):
+        for prev, prev_mode in reversed(applied):
+            if prev_mode == "git":
+                rolled_back = _git(git, ("apply", "-R", str(prev)), plan.apply_root)
+            else:
+                rolled_back = (
+                    patch_bin is not None
+                    and _patch_apply(patch_bin, prev, plan.apply_root, reverse=True)
+                )
+            if not rolled_back:
                 log.error(
-                    "_server_patcher: rollback of %s also failed — "
+                    "_server_patcher: rollback of %s (mode=%s) also failed — "
                     "install may be in inconsistent state; manual review "
-                    "required", prev.name,
+                    "required", prev.name, prev_mode,
                 )
         return False
 
+    fuzzy_count = sum(1 for _, mode in applied if mode == "patch")
     log.info(
         "_server_patcher: applied %d TraceLens patch(es) for %s %s "
-        "(issue #194 §4/§5)",
-        len(plan.patches), plan.framework, plan.version,
+        "(strict=%d, fuzzy=%d) (issue #194 §4/§5)",
+        len(applied), plan.framework, plan.version,
+        len(applied) - fuzzy_count, fuzzy_count,
     )
+    return True
+
+
+def _patch_dry_run(patch_bin: str, patch_file: Path, cwd: Path) -> bool:
+    """Probe ``patch -p1 --fuzz=10 --dry-run`` for a single patch.
+
+    Used as a fuzzy fallback when ``git apply --check`` rejects a patch
+    due to minor context drift (whitespace / single-line edits in the
+    target that don't affect the diff's semantic intent). The dry-run
+    has zero filesystem side effects so it's safe to gate the actual
+    apply on this check.
+    """
+    try:
+        with patch_file.open("rb") as fh:
+            result = subprocess.run(
+                (patch_bin, "-p1", "--fuzz=10", "--dry-run", "--silent"),
+                cwd=str(cwd),
+                stdin=fh,
+                capture_output=True,
+                timeout=_GIT_TIMEOUT_SEC,
+            )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        log.warning(
+            "_server_patcher: patch --dry-run in %s failed to spawn (%s)",
+            cwd, e,
+        )
+        return False
+    return result.returncode == 0
+
+
+def _patch_apply(
+    patch_bin: str, patch_file: Path, cwd: Path, *, reverse: bool = False,
+) -> bool:
+    """Real ``patch -p1 --fuzz=10`` apply (or reverse). Mirrors
+    :func:`_patch_dry_run` but actually mutates the working tree.
+    Returns True iff rc == 0."""
+    args = [patch_bin, "-p1", "--fuzz=10", "--silent"]
+    if reverse:
+        args.append("--reverse")
+    try:
+        with patch_file.open("rb") as fh:
+            result = subprocess.run(
+                args,
+                cwd=str(cwd),
+                stdin=fh,
+                capture_output=True,
+                timeout=_GIT_TIMEOUT_SEC,
+            )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        log.warning(
+            "_server_patcher: patch%s in %s failed to spawn (%s)",
+            " --reverse" if reverse else "", cwd, e,
+        )
+        return False
+    if result.returncode != 0:
+        err = result.stderr.decode("utf-8", errors="replace")[:500] \
+            if result.stderr else ""
+        log.debug(
+            "_server_patcher: patch%s rc=%d stderr=%r",
+            " --reverse" if reverse else "", result.returncode, err,
+        )
+        return False
     return True
 
 

--- a/inference_optimizer/orchestrator/action_executors/profile.py
+++ b/inference_optimizer/orchestrator/action_executors/profile.py
@@ -31,7 +31,10 @@ from pathlib import Path
 from typing import Any
 
 from ...paths import asset_root
-from ._inferencex_patcher import ensure_benchmark_lib_patched
+from ._inferencex_patcher import (
+    ensure_benchmark_lib_patched,
+    ensure_benchmark_serving_patched,
+)
 from .baseline import BaselineExecutor
 
 
@@ -99,6 +102,14 @@ class ProfileExecutor(BaselineExecutor):
         # this on every profile launch costs ~1 file read after the
         # first success.
         ensure_benchmark_lib_patched()
+        # PR-D §2: ensure InferenceX `benchmark_serving.py` reads our
+        # `PROFILE_EXTRA_BODY` env var. Without this patch the
+        # `/start_profile` request bakes in upstream's hardcoded
+        # `extra_body={"num_steps": 1, ...}` and silently drops
+        # shape_discovery / roofline_annotations / the steady-state
+        # start_step computed by `_workload_envs.py`. Same idempotent
+        # atomic-replace shape as `ensure_benchmark_lib_patched`.
+        ensure_benchmark_serving_patched()
         result = await super().__call__(ctx)
         # Augment with trace_dir if the workspace produced one.
         workspace_str = result.get("workspace")

--- a/inference_optimizer/tests/test_inferencex_patcher.py
+++ b/inference_optimizer/tests/test_inferencex_patcher.py
@@ -238,3 +238,184 @@ def test_concurrent_patchers_converge_to_single_patch(fake_inferencex):
     # Exactly one patched line — no doubles, no remaining legacy line.
     assert text.count(_PATCHED_LINE) == 1
     assert _LEGACY_LINE not in text
+
+
+# ===========================================================================
+# PR-D §2: benchmark_serving.py PROFILE_EXTRA_BODY consumer patch
+# ===========================================================================
+from inference_optimizer.orchestrator.action_executors._inferencex_patcher import (  # noqa: E402
+    ensure_benchmark_serving_patched,
+)
+
+
+# Verbatim copy of the line PR-D §2 targets — replicating the exact
+# 41-space leading indent because the patcher matches on that prefix.
+_BS_LEGACY_LINE = (
+    '                                         extra_body={"num_steps": 1, '
+    '"merge_profiles": True, "profile_by_stage": True},'
+)
+_BS_UPSTREAM_FIXTURE = f"""\
+async def benchmark_serving_main(...):
+    # Pretend we're inside the function-call site at line 541.
+    await async_request_openai_completions(
+                                         api_url=base_url + "/start_profile",
+                                         prompt_len=test_prompt_len,
+                                         output_len=test_output_len,
+{_BS_LEGACY_LINE}
+                                         logprobs=logprobs,
+                                         best_of=best_of,
+    )
+"""
+
+
+@pytest.fixture
+def fake_inferencex_with_benchmark_serving(tmp_path: Path) -> Path:
+    bench_dir = tmp_path / "utils" / "bench_serving"
+    bench_dir.mkdir(parents=True)
+    lib = bench_dir / "benchmark_serving.py"
+    lib.write_text(_BS_UPSTREAM_FIXTURE, encoding="utf-8")
+    lib.chmod(0o644)
+    return tmp_path
+
+
+def test_benchmark_serving_patch_adds_profile_extra_body_lookup(
+    fake_inferencex_with_benchmark_serving,
+):
+    """A clean fixture must be patched so the resulting line reads
+    ``PROFILE_EXTRA_BODY`` from env at request time. The upstream
+    literal dict must remain as the JSON fallback default so the
+    patch is backward-compatible when the env var is unset."""
+    src = (
+        fake_inferencex_with_benchmark_serving / "utils" / "bench_serving"
+        / "benchmark_serving.py"
+    )
+    rc = ensure_benchmark_serving_patched(fake_inferencex_with_benchmark_serving)
+    assert rc is True
+    text = src.read_text(encoding="utf-8")
+    assert "PROFILE_EXTRA_BODY" in text, (
+        "patched file must reference PROFILE_EXTRA_BODY env var"
+    )
+    assert _BS_LEGACY_LINE not in text, (
+        "legacy hardcoded extra_body line must be replaced, not retained"
+    )
+    # The JSON-form default dict must survive as the JSON fallback so
+    # unsetting PROFILE_EXTRA_BODY yields byte-identical request body
+    # to upstream after json.loads round-trips it back to Python.
+    # (Note: JSON uses lowercase ``true``; ``True`` would crash
+    # json.loads on the unset-env path — see PR-D §2 fix.)
+    assert (
+        '{"num_steps": 1, "merge_profiles": true, "profile_by_stage": true}'
+        in text
+    )
+
+
+def test_benchmark_serving_patch_is_idempotent(
+    fake_inferencex_with_benchmark_serving,
+):
+    """Second call must short-circuit on the sentinel — no second
+    rewrite, file content stable."""
+    src = (
+        fake_inferencex_with_benchmark_serving / "utils" / "bench_serving"
+        / "benchmark_serving.py"
+    )
+    assert ensure_benchmark_serving_patched(
+        fake_inferencex_with_benchmark_serving
+    ) is True
+    snapshot = src.read_text(encoding="utf-8")
+    assert ensure_benchmark_serving_patched(
+        fake_inferencex_with_benchmark_serving
+    ) is True
+    assert src.read_text(encoding="utf-8") == snapshot
+    # Sentinel must occur exactly once (no double-patch).
+    assert snapshot.count("PROFILE_EXTRA_BODY") == 1
+
+
+def test_benchmark_serving_patch_returns_false_when_path_missing(
+    tmp_path, monkeypatch,
+):
+    """A tmpdir without the benchmark_serving.py file must fail-soft."""
+    monkeypatch.delenv("INFERENCEX_PATH", raising=False)
+    assert ensure_benchmark_serving_patched(tmp_path) is False
+
+
+def test_benchmark_serving_patch_returns_false_when_legacy_line_missing(
+    tmp_path,
+):
+    """If upstream has refactored the extra_body= line (different
+    indent, different default dict), the patcher refuses to guess —
+    operator sees a warning and has to investigate."""
+    bench_dir = tmp_path / "utils" / "bench_serving"
+    bench_dir.mkdir(parents=True)
+    src = bench_dir / "benchmark_serving.py"
+    src.write_text(
+        "async def benchmark_serving_main(...): pass\n"
+        "# This is a hand-patched / refactored file with no legacy line.\n",
+        encoding="utf-8",
+    )
+    rc = ensure_benchmark_serving_patched(tmp_path)
+    assert rc is False
+    assert "PROFILE_EXTRA_BODY" not in src.read_text(encoding="utf-8")
+
+
+def test_benchmark_serving_patch_uses_env_var_when_no_explicit_path(
+    fake_inferencex_with_benchmark_serving, monkeypatch,
+):
+    """Like the benchmark_lib.sh patcher, this one honours
+    ``$INFERENCEX_PATH`` when no explicit path is passed."""
+    monkeypatch.setenv(
+        "INFERENCEX_PATH", str(fake_inferencex_with_benchmark_serving),
+    )
+    assert ensure_benchmark_serving_patched(None) is True
+    src = (
+        fake_inferencex_with_benchmark_serving / "utils" / "bench_serving"
+        / "benchmark_serving.py"
+    )
+    assert "PROFILE_EXTRA_BODY" in src.read_text(encoding="utf-8")
+
+
+def test_benchmark_serving_patched_line_is_executable_python(
+    fake_inferencex_with_benchmark_serving,
+):
+    """The patched line must be syntactically valid Python — otherwise
+    a profile run on a patched InferenceX would crash with a
+    SyntaxError at import time instead of just dropping env-var
+    awareness. Extract the patched line by sentinel match and feed it
+    to compile() in a synthesised function body."""
+    ensure_benchmark_serving_patched(fake_inferencex_with_benchmark_serving)
+    src = (
+        fake_inferencex_with_benchmark_serving / "utils" / "bench_serving"
+        / "benchmark_serving.py"
+    )
+    text = src.read_text(encoding="utf-8")
+    # The patched line is the unique line containing PROFILE_EXTRA_BODY.
+    patched_line = next(
+        ln for ln in text.splitlines() if "PROFILE_EXTRA_BODY" in ln
+    )
+    # Strip leading whitespace + the ``extra_body=`` prefix so we have
+    # a bare expression to evaluate. Keep the trailing comma off.
+    expr = patched_line.strip()
+    assert expr.startswith("extra_body="), expr
+    expr = expr[len("extra_body="):].rstrip(",")
+    # Must be parseable.
+    compile(expr, "<patched>", "eval")
+    # And must evaluate to the upstream default when PROFILE_EXTRA_BODY
+    # is unset — backward-compat invariant.
+    import os
+    os.environ.pop("PROFILE_EXTRA_BODY", None)
+    result = eval(expr, {"__builtins__": __builtins__})  # noqa: PGH001
+    assert result == {
+        "num_steps": 1, "merge_profiles": True, "profile_by_stage": True,
+    }, f"unexpected default extra_body: {result!r}"
+    # And must honour the env var when set.
+    os.environ["PROFILE_EXTRA_BODY"] = (
+        '{"num_steps": 10, "shape_discovery": true, "roofline_annotations": true}'
+    )
+    try:
+        result_env = eval(expr, {"__builtins__": __builtins__})  # noqa: PGH001
+        assert result_env == {
+            "num_steps": 10,
+            "shape_discovery": True,
+            "roofline_annotations": True,
+        }
+    finally:
+        os.environ.pop("PROFILE_EXTRA_BODY", None)

--- a/inference_optimizer/tests/test_server_patcher.py
+++ b/inference_optimizer/tests/test_server_patcher.py
@@ -344,14 +344,22 @@ def test_sglang_second_call_is_noop(fake_sglang_world):
 
 
 def test_sglang_rejects_unsupported_version(tmp_path, monkeypatch):
-    """SGLang versions outside `_SGLANG_SUPPORTED_VERSIONS` (today only
-    "0.5.9") must fail-soft — and crucially must NOT touch the
-    install tree on disk."""
+    """SGLang versions outside the configured minor allowlist (default
+    ``0.5.x``) must fail-soft — and crucially must NOT touch the
+    install tree on disk. PR-C widened the gate from an exact 0.5.9
+    pin to a 0.5.x prefix so freshly bumped point releases reach the
+    fuzzy patch fallback; bigger minor bumps (0.6.x, 0.4.x) still
+    fail-soft here so we don't risk applying a stale patch set against
+    an incompatible install."""
+    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_ALLOWED_MINORS", raising=False)
+    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_EXACT_VERSIONS", raising=False)
     tracelens_root = _make_fake_tracelens(tmp_path)
     apply_root = _make_fake_sglang_install(tmp_path)
     _write_fake_sglang_patches(tracelens_root)
     fake_mod = types.ModuleType("sglang")
-    fake_mod.__version__ = "0.5.10"  # current Hyperloom default — unsupported
+    # 0.6.0 — outside the 0.5.x allowlist; would need a real minor
+    # bump in TraceLens's patch set, not just fuzzy context drift.
+    fake_mod.__version__ = "0.6.0"  # type: ignore[attr-defined]
     fake_mod.__file__ = str(apply_root / "python" / "sglang" / "__init__.py")  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "sglang", fake_mod)
     monkeypatch.setenv("TRACELENS_ROOT", str(tracelens_root))
@@ -569,3 +577,71 @@ def test_patch_dry_run_returns_false_when_patch_binary_missing(tmp_path):
         "/nonexistent/patch", fake_diff, tmp_path,
     )
     assert rc is False
+
+
+# ===========================================================================
+# PR-C §2: SGLang minor-version allowlist (was: exact-version pin)
+# ===========================================================================
+def test_sglang_version_accepted_default_minor_covers_059(monkeypatch):
+    """Default allowlist must still accept the original exact pin so
+    pre-PR-C behaviour is preserved on the current deployment."""
+    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_ALLOWED_MINORS", raising=False)
+    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_EXACT_VERSIONS", raising=False)
+    assert _server_patcher._sglang_version_accepted("0.5.9") is True
+
+
+def test_sglang_version_accepted_default_minor_covers_0510(monkeypatch):
+    """Default allowlist accepts a freshly bumped point release —
+    the whole point of PR-C is to let 0.5.10 / 0.5.11 reach the
+    fuzzy fallback layer (which can still reject if the patch
+    fundamentally conflicts)."""
+    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_ALLOWED_MINORS", raising=False)
+    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_EXACT_VERSIONS", raising=False)
+    assert _server_patcher._sglang_version_accepted("0.5.10") is True
+    assert _server_patcher._sglang_version_accepted("0.5.11") is True
+
+
+def test_sglang_version_accepted_default_minor_rejects_different_minor(monkeypatch):
+    """0.5.x allowlist must NOT accept 0.6.x or 0.4.x — those are
+    minor-version bumps with bigger surface change than fuzzy patch
+    contextual drift can tolerate."""
+    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_ALLOWED_MINORS", raising=False)
+    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_EXACT_VERSIONS", raising=False)
+    assert _server_patcher._sglang_version_accepted("0.6.0") is False
+    assert _server_patcher._sglang_version_accepted("0.4.9") is False
+    # Edge case: 0.50.0 must not match the 0.5 prefix — guard against
+    # naive ``startswith``.
+    assert _server_patcher._sglang_version_accepted("0.50.0") is False
+
+
+def test_sglang_version_accepted_exact_pin_env_overrides_minor(monkeypatch):
+    """Operators who want to lock down to a known-good list can set
+    ``HYPERLOOM_SGLANG_PATCH_EXACT_VERSIONS`` — exact pins win over
+    the minor allowlist for the duration of the run."""
+    monkeypatch.setenv("HYPERLOOM_SGLANG_PATCH_EXACT_VERSIONS", "0.5.9")
+    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_ALLOWED_MINORS", raising=False)
+    assert _server_patcher._sglang_version_accepted("0.5.9") is True
+    # 0.5.10 IS in the default minor allowlist, but the exact-pin env
+    # narrows it back to just 0.5.9.
+    assert _server_patcher._sglang_version_accepted("0.5.10") is False
+
+
+def test_sglang_version_accepted_minor_env_extends_default(monkeypatch):
+    """``HYPERLOOM_SGLANG_PATCH_ALLOWED_MINORS=0.5,0.6`` lets operators
+    extend the default allowlist when TraceLens promises a coming
+    patch set for the next minor."""
+    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_EXACT_VERSIONS", raising=False)
+    monkeypatch.setenv("HYPERLOOM_SGLANG_PATCH_ALLOWED_MINORS", "0.5,0.6")
+    assert _server_patcher._sglang_version_accepted("0.5.9") is True
+    assert _server_patcher._sglang_version_accepted("0.6.0") is True
+    assert _server_patcher._sglang_version_accepted("0.7.0") is False
+
+
+def test_sglang_version_accepted_empty_version_rejected(monkeypatch):
+    """Empty / whitespace ``sglang.__version__`` must not silently
+    pass — the patcher needs a real version to pick the right patch
+    set."""
+    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_ALLOWED_MINORS", raising=False)
+    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_EXACT_VERSIONS", raising=False)
+    assert _server_patcher._sglang_version_accepted("") is False
+    assert _server_patcher._sglang_version_accepted("   ") is False

--- a/inference_optimizer/tests/test_server_patcher.py
+++ b/inference_optimizer/tests/test_server_patcher.py
@@ -877,3 +877,240 @@ def test_sglang_plan_keeps_single_marker_sentinel(fake_sglang_world):
     assert plan is not None
     assert isinstance(plan.sentinel_text, tuple)
     assert plan.sentinel_text == ("kernel_shape_profiler",), plan.sentinel_text
+
+
+# ===========================================================================
+# PR-D §5: TraceLens-shipped SUPPORTED_VERSIONS manifest takes precedence
+# over the hardcoded minor allowlist. The day TraceLens starts shipping
+# this file, Hyperloom's version gate auto-adapts without a code change —
+# the decoupling intent of the #194 §5 follow-up recommendation.
+# ===========================================================================
+def _write_sglang_versions_manifest(
+    tracelens_root: Path, body: str, *, filename: str = "SUPPORTED_VERSIONS.txt",
+) -> Path:
+    """Write a TraceLens-style version manifest into the SGLang patches
+    dir. Tests use this fixture to simulate TraceLens shipping the
+    decoupling manifest before it actually does."""
+    patches_dir = (
+        tracelens_root / "examples" / "custom_workflows"
+        / "inference_analysis" / "sglang_roofline_patches"
+    )
+    manifest = patches_dir / filename
+    manifest.write_text(body, encoding="utf-8")
+    return manifest
+
+
+def test_load_sglang_manifest_returns_none_when_absent(tmp_path):
+    """Today's TraceLens doesn't ship the manifest. The loader must
+    return None (not an empty frozenset) so the caller falls back to
+    the PR-C.2 minor allowlist — preserving today's behaviour
+    byte-for-byte until TraceLens decides to ship the file."""
+    patches_dir = tmp_path / "sglang_roofline_patches"
+    patches_dir.mkdir()
+    assert _server_patcher._load_sglang_supported_versions_from_manifest(
+        patches_dir,
+    ) is None
+
+
+def test_load_sglang_manifest_parses_versions_skipping_comments(tmp_path):
+    """Format contract: one version per line, ``#`` starts a comment,
+    blank lines ignored. Whitespace around versions is stripped."""
+    patches_dir = tmp_path / "sglang_roofline_patches"
+    patches_dir.mkdir()
+    (patches_dir / "SUPPORTED_VERSIONS.txt").write_text(
+        "# TraceLens-supported SGLang versions\n"
+        "0.5.9\n"
+        "   0.5.10   \n"
+        "\n"
+        "0.6.0  # post-bump\n"
+        "# 0.7.0  (planned, not yet shipped)\n",
+        encoding="utf-8",
+    )
+    versions = _server_patcher._load_sglang_supported_versions_from_manifest(
+        patches_dir,
+    )
+    assert versions == frozenset({"0.5.9", "0.5.10", "0.6.0"}), versions
+
+
+def test_load_sglang_manifest_empty_returns_empty_frozenset(tmp_path):
+    """If TraceLens explicitly ships an empty manifest (all entries
+    commented out, no versions listed), the loader returns an empty
+    frozenset — NOT None. Caller then rejects every version, which is
+    the operator's signal that TraceLens has declared no versions
+    are supported on this patch revision."""
+    patches_dir = tmp_path / "sglang_roofline_patches"
+    patches_dir.mkdir()
+    (patches_dir / "SUPPORTED_VERSIONS.txt").write_text(
+        "# Intentionally empty — no versions supported.\n"
+        "\n",
+        encoding="utf-8",
+    )
+    assert _server_patcher._load_sglang_supported_versions_from_manifest(
+        patches_dir,
+    ) == frozenset()
+
+
+def test_load_sglang_manifest_prefers_dot_txt_over_no_extension(tmp_path):
+    """Both ``SUPPORTED_VERSIONS.txt`` and ``SUPPORTED_VERSIONS`` are
+    valid filenames; precedence is ``.txt`` first (more discoverable
+    in IDEs / file-listing tooling). Both files present → ``.txt``
+    wins."""
+    patches_dir = tmp_path / "sglang_roofline_patches"
+    patches_dir.mkdir()
+    (patches_dir / "SUPPORTED_VERSIONS.txt").write_text(
+        "from_dot_txt\n", encoding="utf-8",
+    )
+    (patches_dir / "SUPPORTED_VERSIONS").write_text(
+        "from_no_extension\n", encoding="utf-8",
+    )
+    assert _server_patcher._load_sglang_supported_versions_from_manifest(
+        patches_dir,
+    ) == frozenset({"from_dot_txt"})
+
+
+def test_load_sglang_manifest_falls_back_to_no_extension(tmp_path):
+    """If only the no-extension variant exists, the loader picks it
+    up. Lets TraceLens use the LICENSE/README naming convention if
+    they prefer it."""
+    patches_dir = tmp_path / "sglang_roofline_patches"
+    patches_dir.mkdir()
+    (patches_dir / "SUPPORTED_VERSIONS").write_text(
+        "0.5.9\n", encoding="utf-8",
+    )
+    assert _server_patcher._load_sglang_supported_versions_from_manifest(
+        patches_dir,
+    ) == frozenset({"0.5.9"})
+
+
+def test_sglang_version_accepted_consults_manifest_when_present(
+    tmp_path, monkeypatch,
+):
+    """End-to-end gate semantics: when a manifest is shipped, IT is
+    the source of truth — bypasses the hardcoded ``0.5.x`` default.
+    A version that the default would accept but the manifest doesn't
+    list must be rejected; a version the manifest lists but the
+    default wouldn't accept must be accepted."""
+    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_EXACT_VERSIONS", raising=False)
+    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_ALLOWED_MINORS", raising=False)
+    patches_dir = tmp_path / "sglang_roofline_patches"
+    patches_dir.mkdir()
+    (patches_dir / "SUPPORTED_VERSIONS.txt").write_text(
+        "0.6.0\n0.7.0\n", encoding="utf-8",
+    )
+    # 0.5.9 — accepted by default allowlist, NOT listed in manifest
+    # → manifest must override and reject.
+    assert _server_patcher._sglang_version_accepted(
+        "0.5.9", patches_dir=patches_dir,
+    ) is False
+    # 0.7.0 — rejected by default allowlist (0.7.x not in 0.5.x), IS
+    # listed in manifest → manifest must override and accept.
+    assert _server_patcher._sglang_version_accepted(
+        "0.7.0", patches_dir=patches_dir,
+    ) is True
+
+
+def test_sglang_version_accepted_empty_manifest_rejects_all(
+    tmp_path, monkeypatch,
+):
+    """An explicit empty manifest means "TraceLens declares no
+    supported versions" — and that declaration beats the hardcoded
+    default. Operators see all versions rejected, prompting them to
+    investigate whether the patch set has been deprecated or split."""
+    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_EXACT_VERSIONS", raising=False)
+    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_ALLOWED_MINORS", raising=False)
+    patches_dir = tmp_path / "sglang_roofline_patches"
+    patches_dir.mkdir()
+    (patches_dir / "SUPPORTED_VERSIONS.txt").write_text(
+        "# all entries commented out → empty manifest\n", encoding="utf-8",
+    )
+    assert _server_patcher._sglang_version_accepted(
+        "0.5.9", patches_dir=patches_dir,
+    ) is False, (
+        "empty manifest must reject every version — not silently fall through "
+        "to the hardcoded default"
+    )
+
+
+def test_sglang_version_accepted_no_manifest_falls_back_to_default(
+    tmp_path, monkeypatch,
+):
+    """Today's behaviour: TraceLens doesn't ship the manifest, so the
+    helper falls back to ``_SGLANG_DEFAULT_ALLOWED_MINORS = ("0.5",)``.
+    This preserves PR-C.2 byte-for-byte and is the safety net that
+    prevents D.5 from regressing anyone who hasn't pulled the new
+    TraceLens release."""
+    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_EXACT_VERSIONS", raising=False)
+    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_ALLOWED_MINORS", raising=False)
+    patches_dir = tmp_path / "sglang_roofline_patches"
+    patches_dir.mkdir()  # No manifest written.
+    assert _server_patcher._sglang_version_accepted(
+        "0.5.9", patches_dir=patches_dir,
+    ) is True
+    assert _server_patcher._sglang_version_accepted(
+        "0.5.99", patches_dir=patches_dir,
+    ) is True  # 0.5.x covers all point releases.
+    assert _server_patcher._sglang_version_accepted(
+        "0.6.0", patches_dir=patches_dir,
+    ) is False  # 0.6 not in default allowlist; no manifest to override.
+
+
+def test_sglang_version_accepted_operator_env_vars_beat_manifest(
+    tmp_path, monkeypatch,
+):
+    """The operator escape hatch must still work even when TraceLens
+    ships a manifest — an operator pinning a specific version (e.g.
+    to roll back after a bad release) takes precedence over the
+    vendor's declared support list."""
+    patches_dir = tmp_path / "sglang_roofline_patches"
+    patches_dir.mkdir()
+    (patches_dir / "SUPPORTED_VERSIONS.txt").write_text(
+        "0.5.9\n", encoding="utf-8",
+    )
+    # Operator pins 0.7.0 exactly, even though manifest doesn't list it.
+    monkeypatch.setenv("HYPERLOOM_SGLANG_PATCH_EXACT_VERSIONS", "0.7.0")
+    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_ALLOWED_MINORS", raising=False)
+    assert _server_patcher._sglang_version_accepted(
+        "0.7.0", patches_dir=patches_dir,
+    ) is True
+    # And the manifest-listed 0.5.9 is now REJECTED because the
+    # operator's exact pinset takes over completely.
+    assert _server_patcher._sglang_version_accepted(
+        "0.5.9", patches_dir=patches_dir,
+    ) is False
+
+
+@_REQUIRES_GIT
+def test_sglang_e2e_manifest_admits_version_outside_default_allowlist(
+    tmp_path, monkeypatch,
+):
+    """Full integration: SGLang 0.7.0 (well outside the hardcoded
+    ``0.5.x`` default) gets patched because TraceLens has shipped a
+    manifest that explicitly lists it. This is the exact "TraceLens
+    bumps support without requiring a Hyperloom code change" workflow
+    the reviewer asked for."""
+    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_EXACT_VERSIONS", raising=False)
+    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_ALLOWED_MINORS", raising=False)
+    tracelens_root = _make_fake_tracelens(tmp_path)
+    apply_root = _make_fake_sglang_install(tmp_path)
+    # Replace the fake sglang's __version__ with 0.7.0 in both the
+    # injected module and the on-disk __init__.py.
+    sgl_init = apply_root / "python" / "sglang" / "__init__.py"
+    sgl_init.write_text('__version__ = "0.7.0"\n', encoding="utf-8")
+    _write_fake_sglang_patches(tracelens_root, count=1)
+    _write_sglang_versions_manifest(tracelens_root, "0.7.0\n")
+
+    fake_mod = types.ModuleType("sglang")
+    fake_mod.__version__ = "0.7.0"  # type: ignore[attr-defined]
+    fake_mod.__file__ = str(sgl_init)  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "sglang", fake_mod)
+    monkeypatch.setenv("TRACELENS_ROOT", str(tracelens_root))
+
+    assert ensure_sglang_patched_for_tracelens() is True
+    sentinel = (
+        apply_root / "python" / "sglang" / "srt" / "utils"
+        / "kernel_shape_profiler.py"
+    )
+    assert sentinel.exists(), (
+        "0.7.0 should have been patched because the manifest admits it — "
+        "the default 0.5.x allowlist alone would have rejected"
+    )

--- a/inference_optimizer/tests/test_server_patcher.py
+++ b/inference_optimizer/tests/test_server_patcher.py
@@ -373,14 +373,19 @@ def test_sglang_rejects_unsupported_version(tmp_path, monkeypatch):
     )
 
 
-def test_sglang_rejects_non_editable_install_layout(tmp_path, monkeypatch):
-    """A pip-wheel install where `sglang/` sits directly in site-packages
-    (no `python/` parent) cannot use the `a/python/sglang/...` patches —
-    fail-soft so wheel users keep working."""
+def test_sglang_rejects_unknown_install_layout(tmp_path, monkeypatch):
+    """SGLang installed at neither ``python/sglang/`` (editable) nor
+    ``site-packages/sglang/`` (wheel) — e.g. someone renamed the
+    package or placed it under a custom dir — must fail-soft. Wheel
+    installs now go through the shim path (covered by the
+    ``test_sglang_wheel_install_uses_symlink_shim`` test); only
+    layouts the resolver doesn't recognise return None here."""
     tracelens_root = _make_fake_tracelens(tmp_path)
     _write_fake_sglang_patches(tracelens_root)
-    # Layout: site-packages/sglang/__init__.py (no `python/` dir).
-    install = tmp_path / "site_packages" / "sglang"
+    # Place the module under a parent dir named something other than
+    # ``sglang`` so the wheel-install check rejects it. (A real-world
+    # cause would be a namespace-package install or a fork rename.)
+    install = tmp_path / "weird_namespace" / "not_sglang"
     install.mkdir(parents=True)
     (install / "__init__.py").write_text(
         f'__version__ = "{_FAKE_SGLANG_VERSION}"\n',
@@ -645,3 +650,124 @@ def test_sglang_version_accepted_empty_version_rejected(monkeypatch):
     monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_EXACT_VERSIONS", raising=False)
     assert _server_patcher._sglang_version_accepted("") is False
     assert _server_patcher._sglang_version_accepted("   ") is False
+
+
+# ===========================================================================
+# PR-D §1: wheel-install SGLang patching via -p3 strip
+# ===========================================================================
+def _make_fake_wheel_sglang_install(tmp_path: Path) -> Path:
+    """Synthesise a pip-wheel SGLang layout: ``site-packages/sglang/...``
+    with no ``python/`` parent. Mirrors what
+    ``pip install sglang --no-build-isolation`` produces from a release
+    wheel, distinct from the editable repo layout the fixture above
+    builds."""
+    site_packages = tmp_path / "site-packages"
+    pkg = site_packages / "sglang" / "srt" / "utils"
+    pkg.mkdir(parents=True)
+    (site_packages / "sglang" / "__init__.py").write_text(
+        f'__version__ = "{_FAKE_SGLANG_VERSION}"\n',
+        encoding="utf-8",
+    )
+    (site_packages / "sglang" / "srt" / "__init__.py").write_text("")
+    (site_packages / "sglang" / "srt" / "utils" / "__init__.py").write_text("")
+    return site_packages
+
+
+@_REQUIRES_GIT
+def test_sglang_wheel_install_patches_via_p3_strip(tmp_path, monkeypatch):
+    """A wheel-layout SGLang install (``site-packages/sglang/...`` with
+    no ``python/`` parent) must apply patches with ``-p3`` from inside
+    the wheel sglang/ dir itself — no symlinks, no tmpdirs, real
+    wheel files modified in place. ``git apply``'s symlink-safety
+    check would refuse a symlink-shim approach (verified empirically
+    on git 2.40+); ``-p3`` sidesteps the issue entirely by stripping
+    the patch's ``a/python/sglang/`` prefix down to the wheel-relative
+    ``srt/...`` path."""
+    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_ALLOWED_MINORS", raising=False)
+    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_EXACT_VERSIONS", raising=False)
+    tracelens_root = _make_fake_tracelens(tmp_path)
+    site_packages = _make_fake_wheel_sglang_install(tmp_path)
+    _write_fake_sglang_patches(tracelens_root, count=1)
+
+    fake_mod = types.ModuleType("sglang")
+    fake_mod.__version__ = _FAKE_SGLANG_VERSION  # type: ignore[attr-defined]
+    fake_mod.__file__ = str(site_packages / "sglang" / "__init__.py")  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "sglang", fake_mod)
+    monkeypatch.setenv("TRACELENS_ROOT", str(tracelens_root))
+
+    rc = ensure_sglang_patched_for_tracelens()
+    assert rc is True
+    # Patch landed on the real wheel install file.
+    sentinel_real = (
+        site_packages / "sglang" / "srt" / "utils" / "kernel_shape_profiler.py"
+    )
+    assert sentinel_real.exists(), (
+        "wheel install's sglang/srt/utils/kernel_shape_profiler.py must exist "
+        "after patching — the -p3 path should have modified the wheel directly"
+    )
+    assert "kernel_shape_profiler" in sentinel_real.read_text(encoding="utf-8")
+
+
+@_REQUIRES_GIT
+def test_sglang_wheel_install_is_idempotent(tmp_path, monkeypatch):
+    """Second invocation short-circuits via the sentinel check without
+    re-running git apply. Guards against the wheel-install path
+    racing on every call."""
+    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_ALLOWED_MINORS", raising=False)
+    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_EXACT_VERSIONS", raising=False)
+    tracelens_root = _make_fake_tracelens(tmp_path)
+    site_packages = _make_fake_wheel_sglang_install(tmp_path)
+    _write_fake_sglang_patches(tracelens_root, count=1)
+
+    fake_mod = types.ModuleType("sglang")
+    fake_mod.__version__ = _FAKE_SGLANG_VERSION  # type: ignore[attr-defined]
+    fake_mod.__file__ = str(site_packages / "sglang" / "__init__.py")  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "sglang", fake_mod)
+    monkeypatch.setenv("TRACELENS_ROOT", str(tracelens_root))
+
+    assert ensure_sglang_patched_for_tracelens() is True
+    sentinel_real = (
+        site_packages / "sglang" / "srt" / "utils" / "kernel_shape_profiler.py"
+    )
+    snapshot = sentinel_real.read_text(encoding="utf-8")
+    assert ensure_sglang_patched_for_tracelens() is True
+    assert sentinel_real.read_text(encoding="utf-8") == snapshot
+
+
+def test_resolve_sglang_apply_root_editable_returns_p1(tmp_path):
+    """Editable install (``<repo>/python/sglang/__init__.py``) keeps
+    the historical ``-p1`` strip + repo-root apply path."""
+    repo = tmp_path / "sgl_repo"
+    pkg = repo / "python" / "sglang"
+    pkg.mkdir(parents=True)
+    sglang_module = pkg / "__init__.py"
+    sglang_module.write_text("__version__ = '0.5.9'", encoding="utf-8")
+    result = _server_patcher._resolve_sglang_apply_root(sglang_module)
+    assert result is not None
+    apply_root, strip = result
+    assert apply_root == repo
+    assert strip == 1
+
+
+def test_resolve_sglang_apply_root_wheel_returns_p3(tmp_path):
+    """Wheel install (``site-packages/sglang/__init__.py``) returns
+    ``(<sglang_dir>, 3)`` so the patch's ``a/python/sglang/`` prefix
+    is stripped down to the wheel layout's ``srt/...`` path."""
+    site_packages = _make_fake_wheel_sglang_install(tmp_path)
+    sglang_module = site_packages / "sglang" / "__init__.py"
+    result = _server_patcher._resolve_sglang_apply_root(sglang_module)
+    assert result is not None
+    apply_root, strip = result
+    assert apply_root == site_packages / "sglang"
+    assert strip == 3
+
+
+def test_resolve_sglang_apply_root_rejects_unexpected_layout(tmp_path):
+    """An sglang module that lives under neither ``python/sglang/`` nor
+    ``site-packages/sglang/`` (e.g. the user moved it under a custom
+    dir, or a fork renamed the package) must fail-soft."""
+    weird_root = tmp_path / "weird_namespace" / "not_sglang"
+    weird_root.mkdir(parents=True)
+    sglang_module = weird_root / "__init__.py"
+    sglang_module.write_text("__version__ = '0.5.9'", encoding="utf-8")
+    assert _server_patcher._resolve_sglang_apply_root(sglang_module) is None

--- a/inference_optimizer/tests/test_server_patcher.py
+++ b/inference_optimizer/tests/test_server_patcher.py
@@ -78,16 +78,29 @@ def _make_fake_vllm_install(tmp_path: Path) -> Path:
 
 
 def _write_fake_vllm_patch(
-    tracelens_root: Path, version: str, sentinel: str = "capture_torch_profiler_dir",
+    tracelens_root: Path, version: str,
+    sentinels: tuple[str, ...] = (
+        "capture_torch_profiler_dir", "detailed_trace_annotation",
+    ),
 ) -> Path:
-    """Generate a minimal unified diff that adds the sentinel string
+    """Generate a minimal unified diff that adds the sentinel strings
     to the fake profiler.py — `git apply` accepts it without needing
-    a real .git/ directory."""
+    a real .git/ directory.
+
+    PR-D §4: real TraceLens vLLM patches add BOTH
+    ``capture_torch_profiler_dir`` and ``detailed_trace_annotation`` as
+    new fields on ``ProfilerConfig``; the _server_patcher sentinel
+    requires BOTH to be present before declaring the install patched.
+    The fixture must follow suit so the synthetic patch leaves both
+    markers in the file, matching the real-world contract.
+    """
     patch_path = (
         tracelens_root
         / "examples" / "custom_workflows" / "inference_analysis"
         / "vllm_patches" / f"config_vllm_v{version}.patch"
     )
+    new_lines = "\n".join(f"+    {s}: str = \"\"" for s in sentinels)
+    added_count = len(sentinels)
     patch_path.write_text(
         textwrap.dedent(
             f"""\
@@ -95,11 +108,11 @@ def _write_fake_vllm_patch(
             index 0000001..0000002 100644
             --- a/vllm/config/profiler.py
             +++ b/vllm/config/profiler.py
-            @@ -1,4 +1,5 @@
+            @@ -1,4 +1,{4 + added_count} @@
              # Synthetic vLLM profiler config — used only by tests.
              class ProfilerConfig:
                  profiler: str = ""
-            +    {sentinel}: str = ""
+            {new_lines}
                  ignore_frontend: bool = False
             """
         ),
@@ -771,3 +784,96 @@ def test_resolve_sglang_apply_root_rejects_unexpected_layout(tmp_path):
     sglang_module = weird_root / "__init__.py"
     sglang_module.write_text("__version__ = '0.5.9'", encoding="utf-8")
     assert _server_patcher._resolve_sglang_apply_root(sglang_module) is None
+
+
+# ===========================================================================
+# PR-D §4: tuple-of-substrings sentinel for vLLM (false-positive guard)
+# ===========================================================================
+def test_is_patched_requires_all_substrings_in_tuple(tmp_path):
+    """``_is_patched`` must require EVERY substring in
+    ``plan.sentinel_text`` to be present. Drop one of the two vLLM
+    markers and the check must reject — that's the false-positive
+    guard if upstream ever merges one of the marker identifiers
+    without adopting the rest of the TraceLens patch."""
+    sentinel = tmp_path / "fake_sentinel.py"
+    # Has only the first marker, not the second.
+    sentinel.write_text(
+        "class ProfilerConfig:\n    capture_torch_profiler_dir: str = ''\n",
+        encoding="utf-8",
+    )
+    plan = _server_patcher._PatchPlan(
+        framework="vllm",
+        version="0.20.0",
+        apply_root=tmp_path,
+        patches=(),
+        sentinel_file=sentinel,
+        sentinel_text=("capture_torch_profiler_dir", "detailed_trace_annotation"),
+    )
+    assert _server_patcher._is_patched(plan) is False, (
+        "_is_patched must require BOTH markers; one alone is not enough"
+    )
+    # Add the second marker → now it counts as patched.
+    sentinel.write_text(
+        "class ProfilerConfig:\n"
+        "    capture_torch_profiler_dir: str = ''\n"
+        "    detailed_trace_annotation: bool = False\n",
+        encoding="utf-8",
+    )
+    assert _server_patcher._is_patched(plan) is True
+
+
+def test_is_patched_handles_single_element_tuple(tmp_path):
+    """Single-element tuple sentinel (the SGLang case) behaves
+    identically to the historical single-string sentinel: presence
+    of the lone marker counts as patched."""
+    sentinel = tmp_path / "fake_kernel_shape_profiler.py"
+    sentinel.write_text(
+        "# kernel_shape_profiler module stub\n", encoding="utf-8",
+    )
+    plan = _server_patcher._PatchPlan(
+        framework="sglang",
+        version="0.5.9",
+        apply_root=tmp_path,
+        patches=(),
+        sentinel_file=sentinel,
+        sentinel_text=("kernel_shape_profiler",),
+    )
+    assert _server_patcher._is_patched(plan) is True
+    # Wipe the marker → rejected.
+    sentinel.write_text("# unrelated file\n", encoding="utf-8")
+    assert _server_patcher._is_patched(plan) is False
+
+
+def test_vllm_plan_uses_two_marker_sentinel(tmp_path, monkeypatch):
+    """The vLLM plan must declare a 2-tuple sentinel
+    (``capture_torch_profiler_dir`` AND ``detailed_trace_annotation``).
+    This is the structural guarantee PR-D §4 makes: changing the plan
+    to a 1-tuple would silently revert to the false-positive-prone
+    historical behaviour, so we pin it explicitly."""
+    tracelens_root = _make_fake_tracelens(tmp_path)
+    install_root = _make_fake_vllm_install(tmp_path)
+    _write_fake_vllm_patch(tracelens_root, _FAKE_VLLM_VERSION)
+    fake_mod = types.ModuleType("vllm")
+    fake_mod.__version__ = _FAKE_VLLM_VERSION  # type: ignore[attr-defined]
+    fake_mod.__file__ = str(install_root / "vllm" / "__init__.py")  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "vllm", fake_mod)
+    monkeypatch.setenv("TRACELENS_ROOT", str(tracelens_root))
+
+    plan = _server_patcher._discover_vllm_plan(None)
+    assert plan is not None
+    assert isinstance(plan.sentinel_text, tuple)
+    assert set(plan.sentinel_text) == {
+        "capture_torch_profiler_dir", "detailed_trace_annotation",
+    }, plan.sentinel_text
+
+
+def test_sglang_plan_keeps_single_marker_sentinel(fake_sglang_world):
+    """SGLang's sentinel file is *created* by the patch — its presence
+    + a unique internal identifier is already false-positive-proof, so
+    we keep the historical single-substring sentinel wrapped in a
+    1-tuple for type uniformity with the vLLM plan (PR-D §4)."""
+    tracelens_root, _, _ = fake_sglang_world
+    plan = _server_patcher._discover_sglang_plan(tracelens_root)
+    assert plan is not None
+    assert isinstance(plan.sentinel_text, tuple)
+    assert plan.sentinel_text == ("kernel_shape_profiler",), plan.sentinel_text

--- a/inference_optimizer/tests/test_server_patcher.py
+++ b/inference_optimizer/tests/test_server_patcher.py
@@ -472,3 +472,100 @@ def test_returns_false_when_git_missing(fake_vllm_world, monkeypatch):
     # cleanup needed; the patcher will see "not patched" → try git →
     # find no git → return False.
     assert ensure_vllm_patched_for_tracelens() is False
+
+
+# ===========================================================================
+# PR-C §1: patch -p1 --fuzz=10 fallback when git apply --check rejects
+# ===========================================================================
+_REQUIRES_PATCH = pytest.mark.skipif(
+    shutil.which("patch") is None,
+    reason="`patch` binary not available in test environment",
+)
+
+
+@_REQUIRES_GIT
+@_REQUIRES_PATCH
+def test_apply_atomic_fuzzy_fallback_when_git_strict_check_fails(fake_vllm_world):
+    """When ``git apply --check`` rejects a patch because the install
+    has drifted slightly from the patch's recorded context, but
+    ``patch -p1 --fuzz=10 --dry-run`` still accepts it, the patcher
+    falls back to the fuzzy path and applies successfully.
+
+    Simulates the common case where TraceLens hasn't shipped a
+    patch revision yet for a freshly bumped SGLang / vLLM point
+    release. Without this fallback the run silently loses the
+    TraceLens-only profiler flags."""
+    _, install_root, _ = fake_vllm_world
+    # Add a drift comment between the patched lines so the strict
+    # ``git apply --check`` context check fails but ``patch --fuzz=10``
+    # still locates the hunk.
+    target = install_root / "vllm" / "config" / "profiler.py"
+    target.write_text(
+        textwrap.dedent(
+            """\
+            # Synthetic vLLM profiler config — used only by tests.
+            # PR-C drift comment that breaks strict git apply --check.
+            class ProfilerConfig:
+                profiler: str = ""
+                ignore_frontend: bool = False
+            """
+        ),
+        encoding="utf-8",
+    )
+    rc = ensure_vllm_patched_for_tracelens()
+    assert rc is True
+    # Patch must have landed via the fuzzy fallback path.
+    assert "capture_torch_profiler_dir" in target.read_text(encoding="utf-8")
+
+
+@_REQUIRES_GIT
+def test_apply_atomic_returns_false_when_strict_and_fuzzy_both_fail(
+    fake_vllm_world, monkeypatch,
+):
+    """When ``git apply --check`` rejects the patch AND
+    ``patch -p1 --fuzz=10`` is unavailable (or itself rejects), the
+    patcher returns False without touching the install — the fuzzy
+    fallback never opens a new error mode."""
+    _, install_root, _ = fake_vllm_world
+    # Drift the target enough that strict + fuzzy both refuse the patch.
+    target = install_root / "vllm" / "config" / "profiler.py"
+    target.write_text(
+        "# Completely unrelated content — every patch hunk must miss.\n",
+        encoding="utf-8",
+    )
+    rc = ensure_vllm_patched_for_tracelens()
+    assert rc is False
+    # Install must be untouched (no half-applied patch).
+    assert "capture_torch_profiler_dir" not in target.read_text(encoding="utf-8")
+
+
+@_REQUIRES_GIT
+def test_apply_atomic_routes_clean_apply_through_strict_path(fake_vllm_world):
+    """Regression guard: when the install matches the patch context
+    exactly, the strict ``git apply --check`` accepts it and the
+    fuzzy fallback is never invoked. Without this guard PR-C could
+    accidentally route every patch through the slower fuzzy path."""
+    rc = ensure_vllm_patched_for_tracelens()
+    assert rc is True
+    _, install_root, _ = fake_vllm_world
+    # Sanity: patched content present; we can't easily mock the
+    # subprocess invocations without making the test brittle, so we
+    # rely on the next call being a no-op (the sentinel grep).
+    text = (install_root / "vllm" / "config" / "profiler.py").read_text()
+    assert "capture_torch_profiler_dir" in text
+    # Second call short-circuits without trying any apply at all.
+    assert ensure_vllm_patched_for_tracelens() is True
+
+
+def test_patch_dry_run_returns_false_when_patch_binary_missing(tmp_path):
+    """``_patch_dry_run`` must fail-soft when no ``patch`` binary is
+    on PATH so callers can decide to skip the fuzzy fallback rather
+    than crash."""
+    # Pass a non-existent ``patch_bin`` path; subprocess raises
+    # FileNotFoundError which the helper catches.
+    fake_diff = tmp_path / "fake.patch"
+    fake_diff.write_text("--- a/x\n+++ b/x\n", encoding="utf-8")
+    rc = _server_patcher._patch_dry_run(
+        "/nonexistent/patch", fake_diff, tmp_path,
+    )
+    assert rc is False

--- a/inference_optimizer/tests/test_server_patcher.py
+++ b/inference_optimizer/tests/test_server_patcher.py
@@ -501,7 +501,11 @@ def test_returns_false_when_git_missing(fake_vllm_world, monkeypatch):
 
 
 # ===========================================================================
-# PR-C §1: patch -p1 --fuzz=10 fallback when git apply --check rejects
+# PR-C §1 (tightened by PR-D §6): patch -p1 --fuzz=2 fallback when git
+# apply --check rejects. fuzz=2 is GNU patch's default; tolerates
+# whitespace + single-line context drift but rejects multi-line drift
+# so the patcher can't silently mis-apply CHANGE lines to a
+# similar-looking but semantically wrong call site.
 # ===========================================================================
 _REQUIRES_PATCH = pytest.mark.skipif(
     shutil.which("patch") is None,
@@ -514,7 +518,7 @@ _REQUIRES_PATCH = pytest.mark.skipif(
 def test_apply_atomic_fuzzy_fallback_when_git_strict_check_fails(fake_vllm_world):
     """When ``git apply --check`` rejects a patch because the install
     has drifted slightly from the patch's recorded context, but
-    ``patch -p1 --fuzz=10 --dry-run`` still accepts it, the patcher
+    ``patch -p1 --fuzz=2 --dry-run`` still accepts it, the patcher
     falls back to the fuzzy path and applies successfully.
 
     Simulates the common case where TraceLens hasn't shipped a
@@ -522,9 +526,11 @@ def test_apply_atomic_fuzzy_fallback_when_git_strict_check_fails(fake_vllm_world
     release. Without this fallback the run silently loses the
     TraceLens-only profiler flags."""
     _, install_root, _ = fake_vllm_world
-    # Add a drift comment between the patched lines so the strict
-    # ``git apply --check`` context check fails but ``patch --fuzz=10``
-    # still locates the hunk.
+    # Add a single drift comment between the patched lines so the
+    # strict ``git apply --check`` context check fails but
+    # ``patch --fuzz=2`` still locates the hunk. (PR-D §6: one
+    # drift line is within the default fuzz=2 tolerance; multi-line
+    # drift would be correctly rejected by this same path.)
     target = install_root / "vllm" / "config" / "profiler.py"
     target.write_text(
         textwrap.dedent(
@@ -549,7 +555,7 @@ def test_apply_atomic_returns_false_when_strict_and_fuzzy_both_fail(
     fake_vllm_world, monkeypatch,
 ):
     """When ``git apply --check`` rejects the patch AND
-    ``patch -p1 --fuzz=10`` is unavailable (or itself rejects), the
+    ``patch -p1 --fuzz=2`` is unavailable (or itself rejects), the
     patcher returns False without touching the install — the fuzzy
     fallback never opens a new error mode."""
     _, install_root, _ = fake_vllm_world
@@ -595,6 +601,131 @@ def test_patch_dry_run_returns_false_when_patch_binary_missing(tmp_path):
         "/nonexistent/patch", fake_diff, tmp_path,
     )
     assert rc is False
+
+
+# PR-D §6 safety guarantee: the fuzz value lives in the module-level
+# ``_FUZZ`` constant and is set to GNU patch's default (2). Pinning
+# this here means any future regression that bumps the value back to
+# ``--fuzz=10`` (or higher) fails this test, surfacing the safety
+# regression in CI before it lands.
+def test_fuzz_value_is_default_two_not_maximum_ten():
+    """PR-D §6: fuzz value MUST be the GNU patch default of 2.
+
+    PR-C §1 originally used ``--fuzz=10`` (near GNU patch's
+    practical maximum), which tolerates up to 10 mismatching context
+    lines per hunk. That made multi-line upstream refactors near a
+    patch site silently mis-apply the patch's CHANGE lines to a
+    similar-looking but semantically wrong location — framework
+    imports cleanly, profile hooks attach to the wrong call site,
+    profile data is silently misleading rather than absent.
+
+    fuzz=2 (this test's invariant) still tolerates whitespace and
+    single-line drift (the common point-release case the fuzzy
+    fallback was designed for) but rejects multi-line drift hard
+    so the patcher fail-softs visibly.
+    """
+    assert _server_patcher._FUZZ == 2, (
+        f"_FUZZ must be 2 (GNU patch default, PR-D §6 safety floor); "
+        f"found {_server_patcher._FUZZ}. Bumping it back up to 10 or "
+        f"higher re-opens the silent multi-line mis-apply risk this "
+        f"constant was introduced to close."
+    )
+
+
+@_REQUIRES_GIT
+@_REQUIRES_PATCH
+def test_fuzz_fallback_rejects_multi_line_context_mismatch(fake_vllm_world):
+    """PR-D §6 safety guarantee: when MORE THAN ``_FUZZ`` (=2) context
+    lines of the hunk are mutated, the fuzzy fallback must reject.
+    This is the exact scenario fuzz=10 would silently accept and
+    fuzz=2 must refuse.
+
+    The vLLM patch's hunk has 3 before-context lines + 1 after-context
+    line (verified by reading ``_write_fake_vllm_patch``). Mutating
+    all 3 before-context lines (every one of them: the header comment,
+    the class declaration, and the existing field annotation) exceeds
+    fuzz=2's 2-line tolerance, so the patcher must fail-soft. The
+    install stays untouched — no silent wrong-place mutation.
+
+    Without PR-D §6 (i.e. with PR-C's original ``--fuzz=10``), this
+    test would have FAILED — the patcher would have applied the
+    CHANGE lines to the mutated class with the renamed field,
+    silently producing a semantically-wrong patched install."""
+    _, install_root, _ = fake_vllm_world
+    target = install_root / "vllm" / "config" / "profiler.py"
+    # All 3 before-context lines mutated, change anchor's nearest
+    # neighbour included. (Trailing context kept identical so we know
+    # rejection is driven by leading-context fuzz, not by the anchor
+    # going missing entirely.)
+    target.write_text(
+        textwrap.dedent(
+            """\
+            # COMPLETELY different header — upstream renamed the file's purpose.
+            class ProfilerConfigRenamed:
+                profile_dir: str = "renamed_field"
+                ignore_frontend: bool = False
+            """
+        ),
+        encoding="utf-8",
+    )
+    rc = ensure_vllm_patched_for_tracelens()
+    assert rc is False, (
+        "fuzz=2 must reject when 3 of 4 context lines mismatch; "
+        "fuzz=10 would have silently applied here and inserted the "
+        "TraceLens fields into the renamed class — a semantically "
+        "wrong patched install"
+    )
+    # Install untouched — no half-applied patch, no markers landed
+    # in the renamed class.
+    text = target.read_text(encoding="utf-8")
+    assert "capture_torch_profiler_dir" not in text, (
+        "fuzz=2 must not have mutated the install when context "
+        "mismatch exceeded _FUZZ tolerance"
+    )
+    assert "detailed_trace_annotation" not in text
+
+
+@_REQUIRES_GIT
+@_REQUIRES_PATCH
+def test_fuzz_fallback_tolerates_offset_slippage(fake_vllm_world):
+    """Companion to the above: pure OFFSET slippage (extra lines
+    inserted between context anchors, but every context line still
+    matches the patch verbatim) should still apply under fuzz=2
+    because GNU patch's scanner finds anchors anywhere in the file
+    as long as the context lines themselves still match. This
+    distinguishes "harmless drift" (offset only, context preserved)
+    from "dangerous drift" (context mutated) — fuzz=2 admits the
+    former and rejects the latter."""
+    _, install_root, _ = fake_vllm_world
+    target = install_root / "vllm" / "config" / "profiler.py"
+    # 5 unrelated lines inserted between header comment and class
+    # — all original context lines still present verbatim, just
+    # shifted to higher line numbers.
+    target.write_text(
+        textwrap.dedent(
+            """\
+            # Synthetic vLLM profiler config — used only by tests.
+            # Drift line 1: upstream comment from a profiler refactor.
+            # Drift line 2: docstring fragment.
+            # Drift line 3: license header chunk.
+            # Drift line 4: deprecation note.
+            # Drift line 5: TODO marker.
+            class ProfilerConfig:
+                profiler: str = ""
+                ignore_frontend: bool = False
+            """
+        ),
+        encoding="utf-8",
+    )
+    rc = ensure_vllm_patched_for_tracelens()
+    assert rc is True, (
+        "fuzz=2 must accept offset slippage when every context line "
+        "is preserved verbatim — that's the legitimate point-release "
+        "drift case the fuzzy fallback was designed for"
+    )
+    text = target.read_text(encoding="utf-8")
+    assert "capture_torch_profiler_dir" in text
+    assert "detailed_trace_annotation" in text
 
 
 # ===========================================================================

--- a/kernel-agent/scripts/install.sh
+++ b/kernel-agent/scripts/install.sh
@@ -166,9 +166,12 @@ ensure_python() {
 # Background: `inference_optimizer/orchestrator/action_executors/_server_patcher.py`
 # uses two binaries to apply TraceLens patches to vLLM/SGLang installs:
 #   * `git apply` — strict path, default; bails immediately on context drift.
-#   * `patch -p<N> --fuzz=10` — PR-C fuzzy fallback; tolerates whitespace /
-#     single-line drift between TraceLens-shipped patches and the deployed
-#     framework version (the common case on point-release bumps).
+#   * `patch -p<N> --fuzz=2` — PR-C fuzzy fallback (tightened from
+#     PR-C's original `--fuzz=10` to GNU patch's default `--fuzz=2` in
+#     PR-D §6 to reject multi-line context drift that could mis-apply
+#     patch CHANGE lines to wrong-but-similar-looking call sites).
+#     Still tolerates whitespace and single-line drift, the common
+#     point-release case the fuzzy fallback was designed for.
 #
 # Stripped runtime images (`lmsysorg/sglang:v0.5.9-rocm700-mi30x` and the
 # minimal vLLM serving images) sometimes ship without one or both binaries.
@@ -191,7 +194,7 @@ ensure_patch_tools() {
   fi
   if [ "$CHECK_ONLY" -eq 1 ]; then
     [ "$need_git" -eq 1 ]   && warn "git missing; TraceLens server-patch strict path (\`git apply\`) will fail-soft"
-    [ "$need_patch" -eq 1 ] && warn "patch missing; TraceLens server-patch fuzzy fallback (\`patch --fuzz=10\`) will fail-soft"
+    [ "$need_patch" -eq 1 ] && warn "patch missing; TraceLens server-patch fuzzy fallback (\`patch --fuzz=2\`) will fail-soft"
     return 0
   fi
   if [ "$DRY_RUN" -eq 1 ]; then

--- a/kernel-agent/scripts/install.sh
+++ b/kernel-agent/scripts/install.sh
@@ -160,6 +160,62 @@ ensure_python() {
   python3 -m pip --version >/dev/null || die "pip is required"
 }
 
+# PR-D §3: pin `git` and `patch` so the TraceLens server patcher has the
+# binaries it expects on every deployment.
+#
+# Background: `inference_optimizer/orchestrator/action_executors/_server_patcher.py`
+# uses two binaries to apply TraceLens patches to vLLM/SGLang installs:
+#   * `git apply` — strict path, default; bails immediately on context drift.
+#   * `patch -p<N> --fuzz=10` — PR-C fuzzy fallback; tolerates whitespace /
+#     single-line drift between TraceLens-shipped patches and the deployed
+#     framework version (the common case on point-release bumps).
+#
+# Stripped runtime images (`lmsysorg/sglang:v0.5.9-rocm700-mi30x` and the
+# minimal vLLM serving images) sometimes ship without one or both binaries.
+# `_server_patcher` fail-softs in that case → `--enable-shape-discovery-
+# for-cuda-graph-profile` is silently never injected → graph-replayed
+# kernels stay opaque, exactly what #194 §5 was trying to fix.
+#
+# Apt-installing here is the cheap, framework-agnostic safety net: it's
+# the same install path the existing `ensure_node` helper takes for
+# Node.js, so it carries no new failure modes.
+ensure_patch_tools() {
+  log "ensuring git + patch (required by inference_optimizer/_server_patcher fuzzy-fallback path)"
+  local need_git=0 need_patch=0
+  command -v git >/dev/null 2>&1   || need_git=1
+  command -v patch >/dev/null 2>&1 || need_patch=1
+  if [ "$need_git" -eq 0 ] && [ "$need_patch" -eq 0 ]; then
+    log "git: $(command -v git) ($(git --version 2>/dev/null | head -1))"
+    log "patch: $(command -v patch) ($(patch --version 2>/dev/null | head -1))"
+    return 0
+  fi
+  if [ "$CHECK_ONLY" -eq 1 ]; then
+    [ "$need_git" -eq 1 ]   && warn "git missing; TraceLens server-patch strict path (\`git apply\`) will fail-soft"
+    [ "$need_patch" -eq 1 ] && warn "patch missing; TraceLens server-patch fuzzy fallback (\`patch --fuzz=10\`) will fail-soft"
+    return 0
+  fi
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "would apt-get install git/patch because: git=$([ $need_git -eq 1 ] && echo missing || echo present), patch=$([ $need_patch -eq 1 ] && echo missing || echo present)"
+    return 0
+  fi
+  if ! command -v apt-get >/dev/null 2>&1; then
+    [ "$need_git" -eq 1 ]   && warn "git missing and apt-get unavailable; install \`git\` manually for TraceLens server patching"
+    [ "$need_patch" -eq 1 ] && warn "patch missing and apt-get unavailable; install \`patch\` manually for TraceLens server patching fuzzy fallback"
+    return 0
+  fi
+  local pkgs=()
+  [ "$need_git" -eq 1 ]   && pkgs+=("git")
+  [ "$need_patch" -eq 1 ] && pkgs+=("patch")
+  log "apt-get installing: ${pkgs[*]}"
+  apt-get update >/dev/null 2>&1 || warn "apt-get update failed; install may pull stale package indices"
+  if ! apt-get -y install "${pkgs[@]}" >/dev/null; then
+    warn "apt-get install of ${pkgs[*]} failed; TraceLens server patching may fail-soft on this host"
+    return 0
+  fi
+  command -v git >/dev/null 2>&1   || warn "git still missing after apt-get install"
+  command -v patch >/dev/null 2>&1 || warn "patch still missing after apt-get install"
+}
+
 ensure_node() {
   log "ensuring Node.js/npm for claude/codex CLIs"
   if command -v node >/dev/null 2>&1 && npm --version >/dev/null 2>&1; then
@@ -592,6 +648,13 @@ PY
       warn "${tool} not found"
     fi
   done
+  for tool in git patch; do
+    if command -v "$tool" >/dev/null 2>&1; then
+      log "found ${tool}: $(command -v "$tool")"
+    else
+      warn "${tool} not found (TraceLens server patcher will fail-soft without it)"
+    fi
+  done
   if [ -d "${HYPERLOOM_ROOT}/geak/.git" ]; then
     log "GEAK ref: $(git -C "${HYPERLOOM_ROOT}/geak" describe --tags --always 2>/dev/null || echo unknown)"
   else
@@ -622,6 +685,7 @@ main() {
   fi
   ensure_python
   ensure_node
+  ensure_patch_tools
   ensure_ray
   ensure_ray_started
   ensure_tracelens


### PR DESCRIPTION
Closes #205, closes #210. Follow-up to #194 / PR #200 — addresses 6 robustness gaps in `_server_patcher.py` and `_inferencex_patcher.py` identified during code review of PR #200. #210 (InferenceX SemiAnalysis fork dropping `PROFILE_EXTRA_BODY`) is fixed by the `benchmark_serving.py` patcher commit.

## Summary

PR #200 closed #194 by shipping the TraceLens server patcher + InferenceX env-var injection. Code review surfaced six follow-ups: SGLang version pin too tight, wheel-install layout unsupported, InferenceX silently dropping `PROFILE_EXTRA_BODY`, `git`/`patch` not pinned, vLLM sentinel false-positive risk, and a fuzzy-fallback `--fuzz=10` that was loose enough to mis-apply patches to wrong call sites. All six fixed here.

## Commits (8, self-contained)

**C — Tolerate point-release drift**
1. `feat(server-patcher): fuzzy patch -p1 --fuzz=10 fallback when git apply --check rejects` — falls back when context has whitespace / single-line drift.
2. `feat(server-patcher): relax SGLang version pin from frozenset to minor allowlist` — `0.5.x` covers all point releases; `HYPERLOOM_SGLANG_PATCH_EXACT_VERSIONS` / `_ALLOWED_MINORS` env overrides.

**D — Hardening + correctness**

3. `feat(server-patcher): wheel-install SGLang patching via -p3 strip` — patches `site-packages/sglang/…` in place; no symlinks (`git apply` symlink-safety check rules them out).
4. `feat(inferencex-patcher): patch benchmark_serving.py to consume PROFILE_EXTRA_BODY` — fixes the silently-ignored env var that was making `shape_discovery` / `roofline_annotations` / steady-state windows unreachable.
5. `chore(install.sh): pin git + patch for TraceLens server patcher` — apt-installs missing binaries.
6. `feat(server-patcher): tuple-of-substrings sentinel for vLLM` — require both `capture_torch_profiler_dir` AND `detailed_trace_annotation`; collapses false-positive risk.
7. `feat(server-patcher): discover SGLang versions from TraceLens manifest` — when `<patches_dir>/SUPPORTED_VERSIONS.txt` ships, it fully replaces the hardcoded default. Forward-compatible.
8. `fix(server-patcher): tighten fuzzy fallback --fuzz=10 to GNU default --fuzz=2` — rejects multi-line context drift so the patcher can't silently mis-apply CHANGE lines to similar-looking-but-wrong call sites. Pinned as a CI-enforced invariant via `_FUZZ` constant.

## Safety story

The fuzzy fallback (commit 1) was originally `--fuzz=10`, which tolerated multi-line context drift — patches could apply to wrong-but-similar call sites silently. Commit 8 tightens to `--fuzz=2` (GNU patch default): still admits whitespace + single-line drift (the legitimate point-release case), but rejects multi-line mismatches hard. A regression test (`test_fuzz_fallback_rejects_multi_line_context_mismatch`) pins the safety invariant so any future bump back to 10+ fails CI.

## Test plan

- [x] 45 server_patcher + 17 inferencex_patcher tests (62 new/updated total); all pass.
- [x] Full regression sweep: 728 passed / 17 failed (same pre-existing-on-`main` failures).
- [ ] Smoke run on default deployment image (SGLang 0.5.10 wheel install): confirm `--enable-shape-discovery-for-cuda-graph-profile` is injected, `kernel_shape_profiler.py` exists in `site-packages/sglang/srt/utils/`, and `/start_profile` request carries `shape_discovery: True` (visible via SGLang server log or tcpdump).
- [ ] Companion ask on TraceLens-internal: ship `examples/custom_workflows/inference_analysis/sglang_roofline_patches/SUPPORTED_VERSIONS.txt`.


Made with [Cursor](https://cursor.com)
