### PR TITLE
feat(inference-optimizer): direct session_breakdown.json export (replaces MAE event mining)

### DIFF
--- a/inference_optimizer/actions/_meta/session_breakdown.yaml
+++ b/inference_optimizer/actions/_meta/session_breakdown.yaml
@@ -1,0 +1,22 @@
+name: session_breakdown
+family: shallow
+cost_minutes_p50: 0.2
+cost_minutes_p75: 0.5
+expected_gain_pct: [0.0, 0.0]
+accuracy_risk: 0.0
+crash_risk: 0.0
+prerequisites: []
+requires_lanes: []
+allowed_tools:
+  - emit_intent
+  - Read
+side_effects:
+  - writes_results
+preferred_backend: claude
+preferred_model: claude-opus-4-7
+max_turns: 5
+lease_ttl_sec: 90
+description: "Refresh $SESSION_DIR/session_breakdown.json for downstream dashboards (cheap, idempotent). End-of-session export already runs from cli.py finally; only dispatch mid-run for live consumers."
+pipeline_phase: finalize
+typical_runtime_min: 0.2
+applicable_when: []

--- a/inference_optimizer/breakdown/SKILL.md
+++ b/inference_optimizer/breakdown/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: session_breakdown
+description: |
+  Build a single self-contained `session_breakdown.json` capturing every
+  fact a dashboard needs about one hyperloom optimization session. Use
+  when the user mentions session-breakdown, kernel attribution,
+  stats-service, capability summary, or wants to surface hyperloom data
+  to an external consumer (claw-stats-service, results service, notebook).
+globs:
+  - "**/breakdown/**"
+  - "**/session_breakdown*"
+  - "**/dump_session_breakdown*"
+---
+
+# Session Breakdown Skill
+
+## What it produces
+
+A single JSON file: **`<session_dir>/session_breakdown.json`**.
+
+- Schema:   `hyperloom.session_breakdown.v1` (see `breakdown/schema.py`)
+- Producer: `inference_optimizer/breakdown/exporter.py`
+- Filename: `BREAKDOWN_FILENAME` (= `session_breakdown.json`)
+
+The JSON has 14 top-level sections plus envelope:
+
+| Section              | What it carries                                                                                          |
+|----------------------|----------------------------------------------------------------------------------------------------------|
+| `session`            | Internal `session_id`, Claw `claw_session_id`, sandbox user, start/end ts, stop_reason, host, code SHA.  |
+| `workload`           | Framework, model, GPU, TP, CONC/ISL/OSL/precision, objective.                                            |
+| `baseline`           | Baseline throughput / accuracy / latency, config path, benchmark report path, failure streak.            |
+| `final`              | `current_best` throughput, validated cumulative gain, action path, extra args/envs.                      |
+| `phase_timeline`     | Chronological list of every action attempt + kernel_opt + integrate event.                               |
+| `capability_summary` | One row per family: geak / oob / backends / params / sweep / validate_stack with status + attempts + keeps. |
+| `geak_invocations`   | Per-attempt detail: prompt path, optimized files, verification, decision, micro_speedup.                 |
+| `oob_invocations`    | Same schema as `geak_invocations`, with `backend ∈ {claude, codex}`.                                     |
+| `kernel_lifecycle`   | 5 stages: `detected` / `recommended` / `optimized` / `adopted` / `rejected`.                             |
+| `param_search`       | Backends + params search ledgers (tested / accepted / rejected / top_by_gain / winner_history).          |
+| `sweep`              | Grid size, best_overall, pareto_front, every variant's benchmark numbers.                                |
+| `critic_robustness`  | Per-iter critic verdicts + robustness signals.                                                           |
+| `telemetry`          | Paths to `benchmark_report.json` / `torch_trace` / `system_profile` / server logs + aggregated GPU monitor. |
+| `attribution`        | Per-stack-entry gain ledger + family breakdown (geak / oob / backends / params / sweep / validated).     |
+| `warnings`           | Best-effort caveats (missing files, partial sections, reconstructed fields).                             |
+| `source_files`       | Mapping from logical section to relative path under `session_dir`.                                       |
+
+## Who reads it
+
+- **`claw-stats-service`** — primary consumer. Replaces the
+  MAE-synthesized `raw_report` / `fact_sheet`. Read order in
+  stats-service should be: prefer `session_breakdown.json` if present,
+  fall back to legacy MAE output otherwise.
+- **`hyperloom-results-service`** — `ci/publish_artifacts.py` POSTs this
+  JSON when `HYPERLOOM_RESULTS_SERVICE_URL` is set.
+- **Offline / notebook analysis** — single file, easy to load, no DB
+  needed.
+
+## When to refresh (LLM Orchestrator decision tree)
+
+The Coordinator's `cli.py` finally block writes `session_breakdown.json`
+unconditionally at end-of-session — that's the safety net. But you
+should ALSO refresh it eagerly when downstream dashboards may be
+watching this session live:
+
+1. **Always** at end-of-session (handled by `cli.py finally` — you do not need to dispatch this).
+2. After every successful `validate_stack` (cumulative gain just changed).
+3. After every KEEP'd kernel/backends/params variant when a live
+   dashboard is observing this session.
+4. **Never** mid-action — collectors expect a coherent state snapshot.
+
+Dispatch action `session_breakdown` (yaml meta lives at
+`actions/_meta/session_breakdown.yaml`) — it's a single 1-minute action,
+no inputs required.
+
+## How to invoke
+
+### LLM-driven (Coordinator action)
+
+```yaml
+# Issue an action intent like any other action
+{ "action": "session_breakdown", "params": {} }
+```
+
+### Code-driven (Python import)
+
+```python
+from inference_optimizer.breakdown import build, write_breakdown_json
+
+# Just compute the dict (no side effects)
+breakdown = build("/workspace/hyperloom")
+
+# Compute + atomically write to <sd>/session_breakdown.json
+out_path = write_breakdown_json("/workspace/hyperloom")
+```
+
+### CLI / offline (`scripts/dump_session_breakdown.py`)
+
+```bash
+# Live session in this sandbox
+python -m inference_optimizer.scripts.dump_session_breakdown
+
+# Historical session on WekaFS
+python -m inference_optimizer.scripts.dump_session_breakdown \
+    --session-dir /wekafs/users/zgong/inference_optimizer-sessions/<sid>
+
+# Override output path (e.g. write to a staging area)
+python -m inference_optimizer.scripts.dump_session_breakdown \
+    --session-dir <SD> --output /tmp/breakdown.json
+```
+
+### Bulk historical (operator)
+
+```bash
+for d in /wekafs/users/*/inference_optimizer-sessions/*; do
+    [ -d "$d" ] || continue
+    python -m inference_optimizer.scripts.dump_session_breakdown \
+        --session-dir "$d" > /dev/null
+done
+```
+
+## Field reference (what comes from where)
+
+The collector for each section reads only from the listed sources. All
+collectors are pure functions; failure in one section never poisons
+another (each becomes a `warnings[]` entry instead).
+
+| Section              | Reads from                                                                                                            |
+|----------------------|----------------------------------------------------------------------------------------------------------------------|
+| `session`            | `manifest.json` + `state.{session_id, stop_reason, max_minutes, tick, start_ts}`                                     |
+| `workload`           | `manifest.{framework, model_*, gpu_type, tp, workload, objective}` + `state.{model_class, framework, gpu_type}`      |
+| `baseline`           | `state.{baseline_tput, baseline_accuracy, last_baseline.workspace, baseline_attempts}` + `<workspace>/benchmark_*/benchmark_report.json` |
+| `final`              | `state.{current_best, cumulative_gain, cumulative_gain_validated_*, optimization_stack}`                            |
+| `phase_timeline`     | `state.{<action>_attempts, kernel_opt_attempts.history, kernel_integrate_attempts.attempts}` sorted by `ts`           |
+| `capability_summary` | Reduces invocations + per-action attempts + search ledgers into 6 rows                                              |
+| `geak_invocations`   | `kernel-agent-workspace/.../kernel-agent/runs/<sid>/{optimization_attempts.jsonl, prompts/, optimized/, results/, verification/}` filtered by `backend == "geak"` |
+| `oob_invocations`    | Same as GEAK, filtered by `backend ∈ {claude, codex}`                                                                |
+| `kernel_lifecycle`   | `runs/profile/*/benchmark_*/benchmark_report.json` (detected) + `state.last_select_kernels` (recommended) + invocations folded (optimized) + `state.{kernel_integrate_attempts, rejected_kernel_*}` (adopted/rejected) |
+| `param_search`       | `state.{params_search, backends_search, params_winner_history, synergy_attempted, discovered_flags, backend_winners_history}` |
+| `sweep`              | `state.last_sweep` + `runs/sweep/<task>/variant_*/benchmark_*/benchmark_report.json`                                |
+| `critic_robustness`  | `critic-workdir/<NNN>/{request,judge_bundle,emit,review}.json` + `robustness-workdir/<NNN>/{signal,action}.json`   |
+| `telemetry`          | All `runs/**/benchmark_*/benchmark_report.json` + `torch_trace/` + `system_profile/` + `server*.log`                  |
+| `attribution`        | `state.gain_per_stack_entry` (preferred) OR best-effort reconstruction from `state.optimization_stack`              |
+
+## What is NOT in scope
+
+- **Real-time event streaming** — use `claw_session_events` for that.
+- **LLM-based attribution** — every collector is deterministic /
+  rule-based. Attribution is `delta_pct` math, not natural language.
+- **Schema migration** — consumers MUST check `schema_version` and gate
+  features on it.
+- **Cross-session aggregation** — one file per session. Use
+  `ci/build_summary.py` (or a Jupyter notebook) for fleet views.
+
+## Failure modes
+
+| Symptom                                            | Cause                                                                                            | Mitigation                                                                                |
+|----------------------------------------------------|--------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
+| `warnings: ["state.json missing"]`                 | Session was created (manifest written) but `Coordinator.save()` never ran                        | Sections fall back to manifest-only data.                                                  |
+| `warnings: ["manifest.json missing"]`              | Session was created without the standard cli.py path (rare)                                      | `session.session_id` falls back to `state.session_id`.                                     |
+| `attribution.notes ≠ []`                            | `Coordinator` did not write `state.gain_per_stack_entry`                                         | Attribution is reconstructed from `optimization_stack`; consumer should treat as approximate. |
+| Empty `geak_invocations` & `oob_invocations`        | Kernel-agent never ran, or wrote to a non-standard workspace                                     | Verify `$SD/kernel-agent-workspace/kernel-agent/runs/` exists.                              |
+| `kernel_lifecycle.detected = []`                    | `profile` action never ran or its `benchmark_report.json` had no `kernel_summary`                | Re-run profile, or fall back to `recommended` from `state.last_select_kernels`.            |
+| Large `warnings[]`                                   | Multiple JSON parse failures on `optimization_attempts.jsonl`                                    | Inspect `kernel-agent-workspace/.../logs/` for the corresponding kernel-agent CLI logs.    |
+
+## Versioning policy
+
+- `schema_version` (in `schema.py`) is bumped ONLY on breaking
+  changes (renamed/removed fields, changed semantics).
+- Adding optional fields is **never** a breaking change.
+- `exporter_version` tracks the exporter implementation independently;
+  consumers can ignore it.
+
+## Testing
+
+Each collector has a unit test under `tests/test_breakdown_*.py` that
+runs it against a fixture session_dir tree. An end-to-end test calls
+`build(...)` on a fully-populated fixture and JSON-schema-validates the
+result. Run:
+
+```bash
+pytest tests/test_breakdown_*.py -v
+```

--- a/inference_optimizer/breakdown/__init__.py
+++ b/inference_optimizer/breakdown/__init__.py
@@ -1,0 +1,29 @@
+"""Session breakdown exporter.
+
+Produces ``session_breakdown.json`` — a single self-contained snapshot of
+every fact a dashboard needs about one hyperloom session.
+
+Public surface:
+
+* :func:`build` — pure builder (read-only, returns a dict)
+* :func:`write_breakdown_json` — build + atomic write to disk
+* :const:`BREAKDOWN_FILENAME` — canonical filename under ``session_dir``
+* :const:`SCHEMA_VERSION` — the wire-shape version string
+* :const:`EXPORTER_VERSION` — this exporter implementation version
+
+See ``SKILL.md`` for usage guidance for both LLM orchestrators and
+human operators.
+"""
+
+from __future__ import annotations
+
+from .exporter import BREAKDOWN_FILENAME, EXPORTER_VERSION, build, write_breakdown_json
+from .schema import SCHEMA_VERSION
+
+__all__ = [
+    "BREAKDOWN_FILENAME",
+    "EXPORTER_VERSION",
+    "SCHEMA_VERSION",
+    "build",
+    "write_breakdown_json",
+]

--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -1,0 +1,1389 @@
+"""Deterministic collectors for ``session_breakdown.json``.
+
+Each ``collect_<section>`` is a pure function: it reads only from
+``session_dir``, ``state`` (a :class:`SharedState`-shaped dict) and
+``manifest`` (a manifest.json dict), and returns the matching schema
+section. Collectors NEVER mutate state, NEVER fabricate values, and
+NEVER raise — failures are caught, recorded in ``warnings``, and the
+section returns a best-effort partial.
+
+The schema each collector matches is defined in :mod:`.schema`.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import logging
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+def _load_json_safe(path: Path | None, warnings: list[str]) -> Any | None:
+    if path is None:
+        return None
+    try:
+        if not path.exists():
+            return None
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"failed to parse {path}: {exc!r}")
+        return None
+
+
+def _load_jsonl_safe(path: Path | None, warnings: list[str]) -> list[dict[str, Any]]:
+    if path is None or not path.exists():
+        return []
+    out: list[dict[str, Any]] = []
+    try:
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError as exc:
+                warnings.append(f"malformed jsonl line in {path}: {exc!r}")
+                continue
+            if isinstance(entry, dict):
+                out.append(entry)
+    except OSError as exc:
+        warnings.append(f"failed to read {path}: {exc!r}")
+    return out
+
+
+def _to_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    text = str(value).strip()
+    if not text or text.upper() == "SKIPPED":
+        return None
+    try:
+        return float(text.replace(",", ""))
+    except ValueError:
+        return None
+
+
+def _to_int(value: Any) -> int | None:
+    number = _to_float(value)
+    return int(number) if number is not None else None
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _rel(path: Path | None, session_dir: Path) -> str | None:
+    if path is None:
+        return None
+    try:
+        return path.resolve().relative_to(session_dir.resolve()).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _find_benchmark_report(workspace: Path | None) -> Path | None:
+    """Locate the ``benchmark_*/benchmark_report.json`` under a task workspace.
+
+    Returns the most recent one (by mtime) if multiple are present (e.g.
+    retries within the same task), else ``None``.
+    """
+    if workspace is None or not workspace.exists():
+        return None
+    candidates: list[Path] = []
+    for p in workspace.glob("benchmark_*/benchmark_report.json"):
+        candidates.append(p)
+    if not candidates:
+        return None
+    candidates.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    return candidates[0]
+
+
+def _safe_get(d: Any, *keys: str, default: Any = None) -> Any:
+    cur = d
+    for k in keys:
+        if not isinstance(cur, dict):
+            return default
+        if k not in cur:
+            return default
+        cur = cur[k]
+    return cur if cur is not None else default
+
+
+# ---------------------------------------------------------------------------
+# §1 Session metadata
+# ---------------------------------------------------------------------------
+def collect_session(
+    session_dir: Path,
+    state: dict[str, Any],
+    manifest: dict[str, Any],
+    warnings: list[str],
+) -> dict[str, Any]:
+    """Top-level session identification + lifecycle."""
+    start_ts = str(state.get("start_ts") or manifest.get("created_at_utc") or "")
+    stop_reason = str(state.get("stop_reason") or "")
+    elapsed_min: float | None = None
+    if start_ts:
+        try:
+            start = datetime.fromisoformat(start_ts.replace("Z", "+00:00"))
+            elapsed_min = (datetime.now(timezone.utc) - start).total_seconds() / 60.0
+        except (ValueError, TypeError):
+            pass
+    return {
+        "session_id":       str(state.get("session_id") or manifest.get("session_id") or ""),
+        "claw_session_id":  manifest.get("claw_session_id") or state.get("claw_session_id"),
+        "sandbox_user_id":  manifest.get("sandbox_user_id") or state.get("sandbox_user_id"),
+        "created_at_utc":   manifest.get("created_at_utc") or start_ts,
+        "ended_at_utc":     _utc_now_iso() if stop_reason else "",
+        "stop_reason":      stop_reason,
+        "max_minutes":      int(state.get("max_minutes") or manifest.get("max_minutes") or 0),
+        "elapsed_minutes":  round(elapsed_min, 2) if elapsed_min is not None else 0.0,
+        "host":             str(manifest.get("host") or ""),
+        "code_revision":    str(manifest.get("code_revision") or ""),
+        "pid":              int(manifest.get("pid") or 0),
+        "session_dir":      str(session_dir),
+        "tick_count":       int(state.get("tick") or 0),
+    }
+
+
+# ---------------------------------------------------------------------------
+# §2 Workload
+# ---------------------------------------------------------------------------
+def collect_workload(
+    state: dict[str, Any],
+    manifest: dict[str, Any],
+    warnings: list[str],
+) -> dict[str, Any]:
+    wl = manifest.get("workload") or {}
+    return {
+        "framework":         str(state.get("framework") or manifest.get("framework") or ""),
+        "framework_version": str(manifest.get("framework_version") or ""),
+        "model_name":        str(state.get("model_name") or manifest.get("model_name") or ""),
+        "model_path":        str(state.get("model_path") or manifest.get("model_path") or ""),
+        "model_class":       str(state.get("model_class") or ""),
+        "gpu_type":          str(state.get("gpu_type") or manifest.get("gpu_type") or ""),
+        "tp":                _to_int(manifest.get("tp")),
+        "conc":              _to_int(wl.get("conc")),
+        "isl":               _to_int(wl.get("isl")),
+        "osl":               _to_int(wl.get("osl")),
+        "max_model_len":     _to_int(wl.get("max_model_len")),
+        "precision":         str(wl.get("precision") or ""),
+        "objective":         dict(manifest.get("objective") or {"kind": "time_only", "value": None}),
+    }
+
+
+# ---------------------------------------------------------------------------
+# §3 Baseline
+# ---------------------------------------------------------------------------
+def collect_baseline(
+    session_dir: Path,
+    state: dict[str, Any],
+    warnings: list[str],
+) -> dict[str, Any]:
+    last_b = state.get("last_baseline") or {}
+    workspace_str = last_b.get("workspace") or ""
+    workspace = Path(workspace_str) if workspace_str else None
+    report_path = _find_benchmark_report(workspace) if workspace else None
+    report = _load_json_safe(report_path, warnings) if report_path else None
+
+    ttft: float | None = None
+    e2el: float | None = None
+    if isinstance(report, dict):
+        ttft = _to_float(_safe_get(report, "mean_ttft_ms") or _safe_get(report, "result", "mean_ttft_ms"))
+        e2el = _to_float(_safe_get(report, "mean_e2el_ms") or _safe_get(report, "result", "mean_e2el_ms"))
+
+    attempts = state.get("baseline_attempts") or []
+    history: list[dict[str, Any]] = []
+    for a in attempts:
+        if not isinstance(a, dict):
+            continue
+        history.append({
+            "ts":            a.get("ts"),
+            "task_id":       a.get("task_id"),
+            "status":        a.get("status"),
+            "decision":      a.get("decision"),
+            "key_metric":    _to_float(a.get("key_metric")),
+            "workspace":     a.get("workspace"),
+            "error_class":   a.get("error_class"),
+        })
+
+    return {
+        "throughput_tok_s_per_gpu": _to_float(state.get("baseline_tput")) or 0.0,
+        "accuracy":                 _to_float(state.get("baseline_accuracy")) or 0.0,
+        "ttft_mean_ms":             ttft,
+        "e2el_mean_ms":             e2el,
+        "config_path":              state.get("baseline_config_path") or None,
+        "benchmark_report_path":    _rel(report_path, session_dir) if report_path else None,
+        "attempts_history":         history,
+        "failure_streak":           int(state.get("baseline_failure_streak") or 0),
+    }
+
+
+# ---------------------------------------------------------------------------
+# §4 Final (validated)
+# ---------------------------------------------------------------------------
+def collect_final(
+    state: dict[str, Any],
+    warnings: list[str],
+) -> dict[str, Any]:
+    cb = state.get("current_best") or {}
+    stack = state.get("optimization_stack") or []
+    stack_len = len(stack) if isinstance(stack, list) else 0
+    val_stack_len = int(state.get("cumulative_gain_validated_stack_len") or 0)
+
+    action_path: list[str] = []
+    for entry in stack if isinstance(stack, list) else []:
+        if not isinstance(entry, dict):
+            continue
+        action = str(entry.get("action") or "")
+        variant = str(entry.get("variant_name") or "")
+        action_path.append(f"{action}:{variant}" if variant else action)
+
+    return {
+        "throughput_tok_s_per_gpu":          _to_float(cb.get("tput")),
+        "cumulative_gain_pct_validated":     _to_float(state.get("cumulative_gain_validated")) or 0.0,
+        "cumulative_gain_pct_per_round_sum": _to_float(state.get("cumulative_gain")) or 0.0,
+        "validated_at_stack_len":            val_stack_len,
+        "validated_ts":                      str(state.get("cumulative_gain_validated_ts") or ""),
+        "stack_changed_after_validation":    stack_len > val_stack_len > 0,
+        "extra_sglang_args":                 str(cb.get("extra_sglang_args") or ""),
+        "extra_envs":                        dict(cb.get("extra_envs") or {}),
+        "action_path":                       action_path,
+        "ttft_mean_ms":                      _to_float(cb.get("ttft_mean_ms")),
+        "e2el_mean_ms":                      _to_float(cb.get("e2el_mean_ms")),
+    }
+
+
+# ---------------------------------------------------------------------------
+# §5 Phase timeline
+# ---------------------------------------------------------------------------
+_AUDIT_ACTIONS = (
+    "baseline", "profile", "backends", "params", "sweep", "validate_stack",
+)
+
+
+def collect_phase_timeline(
+    state: dict[str, Any],
+    warnings: list[str],
+) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for action in _AUDIT_ACTIONS:
+        attempts = state.get(f"{action}_attempts") or []
+        if not isinstance(attempts, list):
+            continue
+        for entry in attempts:
+            if not isinstance(entry, dict):
+                continue
+            events.append({
+                "ts":             entry.get("ts") or "",
+                "action":         action,
+                "task_id":        str(entry.get("task_id") or ""),
+                "kernel_id":      None,
+                "status":         str(entry.get("status") or ""),
+                "decision":       str(entry.get("decision") or ""),
+                "key_metric":     _to_float(entry.get("key_metric")),
+                "key_metric_kind": entry.get("key_metric_kind"),
+                "workspace":      entry.get("workspace"),
+                "error_class":    entry.get("error_class"),
+                "extras":         dict(entry.get("extras") or {}),
+            })
+
+    # Kernel opt attempts (per-kernel history -> flatten to per-attempt rows)
+    kernel_opt = state.get("kernel_opt_attempts") or {}
+    if isinstance(kernel_opt, dict):
+        for kid, ent in kernel_opt.items():
+            if not isinstance(ent, dict):
+                continue
+            for h in ent.get("history") or []:
+                if not isinstance(h, dict):
+                    continue
+                events.append({
+                    "ts":          h.get("ts") or ent.get("last_ts") or "",
+                    "action":      "kernel_opt",
+                    "task_id":     "",
+                    "kernel_id":   str(kid),
+                    "status":      "",
+                    "decision":    str(h.get("decision") or ""),
+                    "key_metric":  None,
+                    "workspace":   None,
+                    "error_class": None,
+                    "extras":      {},
+                })
+
+    # Integrate attempts (decision history per patch key)
+    integ = state.get("kernel_integrate_attempts") or {}
+    if isinstance(integ, dict):
+        for key, ent in integ.items():
+            if not isinstance(ent, dict):
+                continue
+            for a in ent.get("attempts") or []:
+                if not isinstance(a, dict):
+                    continue
+                events.append({
+                    "ts":          a.get("ts") or "",
+                    "action":      "integrate",
+                    "task_id":     "",
+                    "kernel_id":   str(ent.get("kernel_id") or ""),
+                    "status":      str(a.get("status") or ""),
+                    "decision":    str(a.get("decision") or ""),
+                    "key_metric":  _to_float(a.get("gain_pct")),
+                    "key_metric_kind": "gain_pct",
+                    "workspace":   a.get("workspace"),
+                    "error_class": None,
+                    "extras":      {"patch_path": ent.get("patch_path"),
+                                    "report_path": a.get("report_path")},
+                })
+
+    events.sort(key=lambda e: e.get("ts") or "")
+    return events
+
+
+# ---------------------------------------------------------------------------
+# §6 Capability summary
+# ---------------------------------------------------------------------------
+def _capability_for_action(
+    state: dict[str, Any], action: str,
+) -> dict[str, Any]:
+    attempts_list = state.get(f"{action}_attempts") or []
+    n_attempts = len(attempts_list) if isinstance(attempts_list, list) else 0
+    n_keeps = sum(
+        1 for a in attempts_list
+        if isinstance(a, dict) and a.get("decision") in ("promoted", "salvaged")
+    ) if isinstance(attempts_list, list) else 0
+    status = (
+        "kept"      if n_keeps > 0 else
+        "tried"     if n_attempts > 0 else
+        "not_attempted"
+    )
+    return {
+        "status":   status,
+        "attempts": n_attempts,
+        "keeps":    n_keeps,
+    }
+
+
+def collect_capability_summary(
+    state: dict[str, Any],
+    geak_invocations: list[dict[str, Any]],
+    oob_invocations: list[dict[str, Any]],
+    warnings: list[str],
+) -> dict[str, Any]:
+    # GEAK / OOB driven by actual invocations on disk (most reliable)
+    def _from_invocations(invs: list[dict[str, Any]]) -> dict[str, Any]:
+        attempts = len(invs)
+        keeps = sum(1 for v in invs if v.get("decision") == "KEEP")
+        status = (
+            "kept"          if keeps > 0 else
+            "attempted"     if attempts > 0 else
+            "not_attempted"
+        )
+        return {"status": status, "attempts": attempts, "keeps": keeps}
+
+    geak_cap = _from_invocations(geak_invocations)
+    oob_cap = _from_invocations(oob_invocations)
+
+    backends = _capability_for_action(state, "backends")
+    backends_search = state.get("backends_search") or {}
+    if isinstance(backends_search, dict):
+        backends["tested"] = len(backends_search.get("tested") or {})
+        if backends_search.get("accepted"):
+            backends["best_gain_pct"] = max(
+                (_to_float(v.get("gain_pct")) or 0.0
+                 for v in backends_search["accepted"]
+                 if isinstance(v, dict)),
+                default=None,
+            )
+
+    params = _capability_for_action(state, "params")
+    params_search = state.get("params_search") or {}
+    if isinstance(params_search, dict):
+        params["tested"] = len(params_search.get("tested") or {})
+        if params_search.get("accepted"):
+            params["best_gain_pct"] = max(
+                (_to_float(v.get("gain_pct")) or 0.0
+                 for v in params_search["accepted"]
+                 if isinstance(v, dict)),
+                default=None,
+            )
+
+    sweep_cap = _capability_for_action(state, "sweep")
+    last_sweep = state.get("last_sweep") or {}
+    if isinstance(last_sweep, dict):
+        sweep_cap["grid_size"] = _to_int(last_sweep.get("grid_size"))
+        bo = last_sweep.get("best_overall")
+        if isinstance(bo, dict):
+            sweep_cap["best_throughput"] = _to_float(
+                bo.get("output_throughput") or bo.get("tput")
+            )
+        if sweep_cap.get("attempts", 0) > 0:
+            sweep_cap["status"] = "completed"
+
+    validate = _capability_for_action(state, "validate_stack")
+    validate["last_validated_gain_pct"] = _to_float(
+        state.get("cumulative_gain_validated")
+    )
+
+    return {
+        "geak":           geak_cap,
+        "oob":            oob_cap,
+        "backends":       backends,
+        "params":         params,
+        "sweep":          sweep_cap,
+        "validate_stack": validate,
+    }
+
+
+# ---------------------------------------------------------------------------
+# §7 / §8 GEAK / OOB invocations
+# ---------------------------------------------------------------------------
+def _kernel_agent_run_dirs(session_dir: Path) -> list[Path]:
+    """All ``$SD/kernel-agent-workspace/<*>/kernel-agent/runs/<sid>/`` dirs.
+
+    Hyperloom v2 spawns ``kernel_optimization.py --workspace-path
+    $SD/kernel-agent-workspace``; the script then creates
+    ``<workspace>/kernel-agent/runs/<session_id>/...``. We scan both the
+    canonical single-level form and the legacy nested form for safety.
+    """
+    candidates: list[Path] = []
+    root = session_dir / "kernel-agent-workspace"
+    if not root.exists():
+        return candidates
+    # Canonical: $SD/kernel-agent-workspace/kernel-agent/runs/<sid>/
+    for sub in (root / "kernel-agent" / "runs").glob("*"):
+        if sub.is_dir():
+            candidates.append(sub)
+    # Per-kernel: $SD/kernel-agent-workspace/<kid>/...  (older layout)
+    for kid_dir in root.glob("*/kernel-agent/runs/*"):
+        if kid_dir.is_dir() and kid_dir not in candidates:
+            candidates.append(kid_dir)
+    return candidates
+
+
+def _parse_invocation_attempt(
+    attempt: dict[str, Any],
+    run_dir: Path,
+    session_dir: Path,
+    warnings: list[str],
+) -> dict[str, Any]:
+    """Parse one ``optimization_attempts.jsonl`` row into an Invocation.
+
+    Per-attempt fields are read from ``attempt`` directly. Kernel-level
+    artifacts (verification / result) are referenced by path only — the
+    KEEP/PARTIAL/REVERT decision is NOT stamped here because
+    ``results/<kid>.json`` and ``verification/<kid>.json`` describe the
+    kernel's BEST attempt, not every attempt. Stamping happens in
+    :func:`_stamp_kernel_level_decisions` after all attempts are parsed.
+    """
+    kid = str(attempt.get("kernel_id") or "")
+    backend = str(attempt.get("backend") or "").lower()
+    attempt_id = str(
+        attempt.get("attempt_id")
+        or attempt.get("id")
+        or attempt.get("run_id")
+        or "",
+    )
+
+    # Resolve auxiliary paths
+    prompt_path: Path | None = None
+    for p in (run_dir / "prompts").glob(f"{attempt_id}*") if attempt_id else []:
+        prompt_path = p
+        break
+
+    optimized_files: list[str] = []
+    if attempt_id:
+        for p in sorted((run_dir / "optimized").glob(f"{attempt_id}*")):
+            optimized_files.append(_rel(p, session_dir) or str(p))
+
+    verification_path = run_dir / "verification" / f"{kid}.json" if kid else None
+    result_path = run_dir / "results" / f"{kid}.json" if kid else None
+
+    # Per-attempt decision: derived ONLY from this attempt's own fields.
+    decision = str(attempt.get("decision") or "").upper()
+    if not decision:
+        status = str(attempt.get("status") or "").lower()
+        if status in ("failed", "error", "crashed"):
+            decision = "FAILED"
+        # otherwise leave empty; kernel-level decision is stamped later
+
+    # Per-attempt speedup (preferred) — falls back to None if not recorded.
+    micro_speedup = _to_float(
+        attempt.get("speedup")
+        or attempt.get("micro_speedup")
+    )
+
+    return {
+        "kernel_id":       kid,
+        "attempt_id":      attempt_id,
+        "run_id":          str(attempt.get("run_id") or run_dir.name),
+        "ts":              str(attempt.get("ts") or attempt.get("started_at") or ""),
+        "backend":         backend,
+        "model":           attempt.get("model"),
+        "kernel_metadata": _shape_kernel_metadata({}, attempt),
+        "prompt_path":     _rel(prompt_path, session_dir) if prompt_path else None,
+        "optimized_files": optimized_files,
+        "result_path":     _rel(result_path, session_dir) if result_path and result_path.exists() else None,
+        "verification_path": _rel(verification_path, session_dir) if verification_path and verification_path.exists() else None,
+        "decision":        decision,
+        "micro_speedup":   micro_speedup,
+        # compile_passed / correctness_passed are kernel-level (in verification.json);
+        # stamped later if this attempt is the BEST one for the kernel.
+        "compile_passed":  None,
+        "correctness_passed": None,
+        "best_artifact_path": None,
+        "error":           attempt.get("error"),
+        "cli_log_path":    None,
+    }
+
+
+def _stamp_kernel_level_decisions(
+    invocations: list[dict[str, Any]],
+    run_dirs: list[Path],
+    session_dir: Path,
+    warnings: list[str],
+) -> None:
+    """Stamp the kernel-level KEEP/PARTIAL/REVERT decision onto the
+    single BEST attempt for each kernel.
+
+    For each ``(run_dir, kernel_id)`` group, find ``results/<kid>.json``
+    and ``verification/<kid>.json`` (kernel-level, one file per kernel,
+    written at the END of the kernel-agent run). Pick the attempt with
+    the highest ``micro_speedup`` (ties: latest ts), and stamp the
+    kernel-level decision + verification fields onto only that attempt.
+    All other attempts for the same kernel keep their per-attempt
+    ``decision`` (empty string for non-failed in-progress steps).
+    """
+    # Group attempts by (run_id, kernel_id) — same kid in different
+    # run_dirs is treated as separate sessions.
+    groups: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for inv in invocations:
+        key = (inv.get("run_id") or "", inv.get("kernel_id") or "")
+        if not key[1]:
+            continue
+        groups.setdefault(key, []).append(inv)
+
+    # Map run_id -> Path for kernel-level json lookup.
+    run_by_id: dict[str, Path] = {rd.name: rd for rd in run_dirs}
+
+    for (run_id, kid), atts in groups.items():
+        run_dir = run_by_id.get(run_id)
+        if run_dir is None:
+            continue
+        result_path = run_dir / "results" / f"{kid}.json"
+        verification_path = run_dir / "verification" / f"{kid}.json"
+        result = _load_json_safe(result_path if result_path.exists() else None, warnings) or {}
+        verification = _load_json_safe(verification_path if verification_path.exists() else None, warnings) or {}
+
+        decision = ""
+        proposal = result.get("proposal") if isinstance(result, dict) else None
+        if isinstance(proposal, dict):
+            decision = str(proposal.get("decision") or "").upper()
+
+        if not decision and not verification:
+            continue  # nothing to stamp
+
+        # Pick the BEST attempt: highest micro_speedup, ties broken by latest ts.
+        def _attempt_key(a: dict[str, Any]) -> tuple[float, str]:
+            spd = a.get("micro_speedup")
+            return (
+                float(spd) if isinstance(spd, (int, float)) else float("-inf"),
+                str(a.get("ts") or ""),
+            )
+
+        best = max(atts, key=_attempt_key)
+
+        if decision:
+            best["decision"] = decision
+        if isinstance(verification, dict):
+            if best.get("micro_speedup") is None and verification.get("micro_speedup") is not None:
+                best["micro_speedup"] = _to_float(verification.get("micro_speedup"))
+            best["compile_passed"] = verification.get("compile_passed")
+            best["correctness_passed"] = verification.get("correctness_passed")
+            best["best_artifact_path"] = (
+                verification.get("best_artifact_path")
+                or (result.get("best_artifact_path") if isinstance(result, dict) else None)
+            )
+        if isinstance(result, dict) and result.get("cli_log_path"):
+            best["cli_log_path"] = result["cli_log_path"]
+        # Refresh kernel metadata from the (richer) result file
+        best["kernel_metadata"] = _shape_kernel_metadata(result, {
+            "name": best.get("kernel_metadata", {}).get("name"),
+            "source_file": best.get("kernel_metadata", {}).get("source_file"),
+        })
+
+
+def _shape_kernel_metadata(
+    result: dict[str, Any],
+    attempt: dict[str, Any],
+) -> dict[str, Any]:
+    """Best-effort kernel metadata for the UI.
+
+    Prefers fields explicit in ``result['kernel_metadata']`` (newer
+    kernel_optimization.py writes that); otherwise falls back to the
+    attempt's own metadata.
+    """
+    meta = result.get("kernel_metadata") if isinstance(result, dict) else None
+    if isinstance(meta, dict) and meta:
+        return {
+            "name":        meta.get("name") or "",
+            "source_file": meta.get("source_file") or result.get("source_file") or "",
+            "shapes":      list(meta.get("shapes") or []),
+            "gpu_pct":     _to_float(meta.get("gpu_pct")),
+            "arithmetic_intensity": _to_float(meta.get("arithmetic_intensity")),
+        }
+    return {
+        "name":        str(attempt.get("name") or ""),
+        "source_file": str(attempt.get("source_file") or ""),
+        "shapes":      [],
+        "gpu_pct":     None,
+        "arithmetic_intensity": None,
+    }
+
+
+def collect_kernel_invocations(
+    session_dir: Path,
+    warnings: list[str],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Return ``(geak_invocations, oob_invocations)``.
+
+    Reads ``optimization_attempts.jsonl`` from every kernel-agent run dir,
+    splits attempts by ``backend`` field, and stamps the kernel-level
+    KEEP/PARTIAL/REVERT decision onto only the BEST attempt for each
+    kernel (via :func:`_stamp_kernel_level_decisions`).
+    """
+    all_invocations: list[dict[str, Any]] = []
+    run_dirs = _kernel_agent_run_dirs(session_dir)
+    for run_dir in run_dirs:
+        attempts = _load_jsonl_safe(run_dir / "optimization_attempts.jsonl", warnings)
+        for att in attempts:
+            inv = _parse_invocation_attempt(att, run_dir, session_dir, warnings)
+            backend = inv.get("backend") or ""
+            if not backend:
+                inv["backend"] = "unknown"
+            all_invocations.append(inv)
+
+    # Stamp kernel-level KEEP/PARTIAL/REVERT onto the BEST attempt per kernel
+    # (kernel-agent writes one verification/<kid>.json + one results/<kid>.json
+    # per kernel, not per attempt).
+    _stamp_kernel_level_decisions(all_invocations, run_dirs, session_dir, warnings)
+
+    geak: list[dict[str, Any]] = []
+    oob: list[dict[str, Any]] = []
+    for inv in all_invocations:
+        backend = inv.get("backend") or ""
+        if backend == "geak":
+            geak.append(inv)
+        elif backend in ("claude", "codex"):
+            oob.append(inv)
+        else:
+            oob.append(inv)
+    geak.sort(key=lambda e: (e.get("kernel_id") or "", e.get("ts") or ""))
+    oob.sort(key=lambda e: (e.get("kernel_id") or "", e.get("ts") or ""))
+    return geak, oob
+
+
+# ---------------------------------------------------------------------------
+# §9 Kernel lifecycle
+# ---------------------------------------------------------------------------
+def _scan_profile_reports(session_dir: Path) -> list[tuple[Path, Path]]:
+    """Return list of ``(task_dir, benchmark_report.json)`` under runs/profile/."""
+    out: list[tuple[Path, Path]] = []
+    root = session_dir / "runs" / "profile"
+    if not root.exists():
+        return out
+    for task_dir in sorted(root.iterdir()):
+        if not task_dir.is_dir():
+            continue
+        report = _find_benchmark_report(task_dir)
+        if report is not None:
+            out.append((task_dir, report))
+    return out
+
+
+def _collect_detected_kernels(
+    session_dir: Path, warnings: list[str], cap: int = 50,
+) -> list[dict[str, Any]]:
+    detected: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for task_dir, report_path in _scan_profile_reports(session_dir):
+        report = _load_json_safe(report_path, warnings)
+        if not isinstance(report, dict):
+            continue
+        kernel_summary = report.get("kernel_summary") or []
+        bottlenecks = report.get("top_bottlenecks") or []
+        bottleneck_by_kid = {
+            b.get("kernel_id"): b
+            for b in (bottlenecks if isinstance(bottlenecks, list) else [])
+            if isinstance(b, dict)
+        }
+        for k in kernel_summary if isinstance(kernel_summary, list) else []:
+            if not isinstance(k, dict):
+                continue
+            kid = str(k.get("kernel_id") or k.get("name") or "")
+            if not kid or kid in seen:
+                continue
+            seen.add(kid)
+            bn = bottleneck_by_kid.get(kid) or {}
+            detected.append({
+                "kernel_id":               kid,
+                "name":                    str(k.get("name") or ""),
+                "gpu_pct":                 _to_float(k.get("gpu_pct")),
+                "time_ms":                 _to_float(k.get("time_ms")),
+                "bottleneck":              str(bn.get("bottleneck") or k.get("bottleneck") or ""),
+                "arithmetic_intensity":    _to_float(k.get("arithmetic_intensity")),
+                "reusable_native_kernel":  bool(k.get("reusable_native_kernel")),
+                "source_file":             k.get("source_file"),
+                "detected_from_task":      task_dir.name,
+                "benchmark_report_path":   _rel(report_path, session_dir) or str(report_path),
+            })
+            if len(detected) >= cap:
+                return detected
+    return detected
+
+
+def _collect_recommended_kernels(state: dict[str, Any]) -> list[dict[str, Any]]:
+    sk = state.get("last_select_kernels") or {}
+    if not isinstance(sk, dict):
+        return []
+    out: list[dict[str, Any]] = []
+    for entry in sk.get("hot_kernels_top15") or []:
+        if not isinstance(entry, dict):
+            continue
+        out.append({
+            "kernel_id":            str(entry.get("kernel_id") or ""),
+            "name":                 str(entry.get("name") or ""),
+            "gpu_pct":              _to_float(entry.get("gpu_pct")),
+            "recommended_backends": list(entry.get("recommended_backends") or []),
+            "recommended_actions":  list(entry.get("recommended_actions") or []),
+            "bottleneck":           str(entry.get("bottleneck") or ""),
+            "reusable_native_kernel": bool(entry.get("reusable_native_kernel")),
+        })
+    return out
+
+
+def _collect_optimized_kernels(
+    geak: list[dict[str, Any]],
+    oob: list[dict[str, Any]],
+    state: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Fold per-attempt invocations into per-kernel summaries."""
+    by_kid: dict[str, dict[str, Any]] = {}
+    for invs in (geak, oob):
+        for inv in invs:
+            kid = inv.get("kernel_id") or ""
+            if not kid:
+                continue
+            entry = by_kid.setdefault(kid, {
+                "kernel_id": kid,
+                "backend": inv.get("backend") or "",
+                "total_attempts": 0,
+                "successful_attempts": 0,
+                "best_micro_speedup": None,
+                "last_decision": "",
+                "best_artifact_path": None,
+                "attempts_summary": [],
+            })
+            entry["total_attempts"] += 1
+            spd = inv.get("micro_speedup")
+            cur_best = entry["best_micro_speedup"]
+            if isinstance(spd, (int, float)):
+                if cur_best is None or spd > cur_best:
+                    entry["best_micro_speedup"] = float(spd)
+                    entry["best_artifact_path"] = inv.get("best_artifact_path") or entry["best_artifact_path"]
+            if inv.get("decision") in ("KEEP", "PARTIAL"):
+                entry["successful_attempts"] += 1
+            entry["last_decision"] = inv.get("decision") or entry["last_decision"]
+            entry["attempts_summary"].append({
+                "attempt_id":   inv.get("attempt_id"),
+                "backend":      inv.get("backend"),
+                "decision":     inv.get("decision"),
+                "micro_speedup": spd,
+                "ts":           inv.get("ts"),
+            })
+    # Cross-reference with state.kernel_opt_attempts (the orchestrator's own
+    # record of decisions — covers cases where the on-disk verification was
+    # rotated away but the orchestrator decision is still in state).
+    ko_attempts = state.get("kernel_opt_attempts") or {}
+    if isinstance(ko_attempts, dict):
+        for kid, ent in ko_attempts.items():
+            if not isinstance(ent, dict):
+                continue
+            entry = by_kid.setdefault(kid, {
+                "kernel_id": kid,
+                "backend": "",
+                "total_attempts": 0,
+                "successful_attempts": 0,
+                "best_micro_speedup": None,
+                "last_decision": "",
+                "best_artifact_path": None,
+                "attempts_summary": [],
+            })
+            entry["total_attempts"] = max(entry["total_attempts"], int(ent.get("attempts", 0)))
+            entry["last_decision"] = entry["last_decision"] or str(ent.get("last_decision") or "")
+    return sorted(by_kid.values(), key=lambda e: e.get("kernel_id") or "")
+
+
+def _collect_adopted_kernels(state: dict[str, Any]) -> list[dict[str, Any]]:
+    """KEEP-promoted kernel entries (from state.kernel_integrate_attempts + optimization_stack)."""
+    out: list[dict[str, Any]] = []
+    integ = state.get("kernel_integrate_attempts") or {}
+    if isinstance(integ, dict):
+        for key, ent in integ.items():
+            if not isinstance(ent, dict):
+                continue
+            if ent.get("last_decision") != "KEEP":
+                continue
+            out.append({
+                "kernel_id":         str(ent.get("kernel_id") or ""),
+                "patch_path":        str(ent.get("patch_path") or ""),
+                "target_file":       str(ent.get("target_file") or ""),
+                "extra_sglang_args": str(ent.get("extra_sglang_args") or ""),
+                "e2e_gain_pct":      _to_float(ent.get("best_gain_pct")),
+                "validated":         True,
+                "last_status":       str(ent.get("last_status") or ""),
+                "adopted_at":        str(ent.get("updated_at") or ""),
+                "attempt_count":     int(ent.get("attempt_count") or 0),
+            })
+    return out
+
+
+def _collect_rejected_kernels(state: dict[str, Any]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    rejected = state.get("rejected_kernel_patches") or []
+    if isinstance(rejected, list):
+        for r in rejected:
+            if not isinstance(r, dict):
+                continue
+            out.append({
+                "kernel_id":      str(r.get("kernel_id") or ""),
+                "reason":         str(r.get("reason") or ""),
+                "patch_path":     r.get("patch_path"),
+                "target_file":    r.get("target_file"),
+                "attempt_count":  int(r.get("attempt_count") or 0),
+                "best_gain_pct":  _to_float(r.get("best_gain_pct")),
+                "ts":             str(r.get("ts") or ""),
+            })
+    # also surface rejected_kernel_ids that didn't make it into rejected_kernel_patches
+    seen_ids = {entry["kernel_id"] for entry in out if entry.get("kernel_id")}
+    for kid in state.get("rejected_kernel_ids") or []:
+        kid_s = str(kid or "")
+        if not kid_s or kid_s in seen_ids:
+            continue
+        out.append({
+            "kernel_id":  kid_s,
+            "reason":     "retired",
+            "patch_path": None,
+            "target_file": None,
+            "attempt_count": 0,
+            "best_gain_pct": None,
+            "ts": "",
+        })
+    return out
+
+
+def collect_kernel_lifecycle(
+    session_dir: Path,
+    state: dict[str, Any],
+    geak: list[dict[str, Any]],
+    oob: list[dict[str, Any]],
+    warnings: list[str],
+) -> dict[str, Any]:
+    return {
+        "detected":    _collect_detected_kernels(session_dir, warnings),
+        "recommended": _collect_recommended_kernels(state),
+        "optimized":   _collect_optimized_kernels(geak, oob, state),
+        "adopted":     _collect_adopted_kernels(state),
+        "rejected":    _collect_rejected_kernels(state),
+    }
+
+
+# ---------------------------------------------------------------------------
+# §10 Param / backends search
+# ---------------------------------------------------------------------------
+def _shape_ledger(
+    ledger: dict[str, Any] | None,
+    *,
+    top_n: int = 20,
+) -> dict[str, Any]:
+    if not isinstance(ledger, dict):
+        return {
+            "schema_version": 0, "tested_count": 0,
+            "accepted": [], "rejected": [], "top_by_gain": [],
+        }
+
+    def _shape_entry(e: Any) -> dict[str, Any]:
+        if not isinstance(e, dict):
+            return {}
+        return {
+            "name":              str(e.get("name") or ""),
+            "fingerprint":       str(e.get("fingerprint") or ""),
+            "extra_sglang_args": str(e.get("extra_sglang_args") or ""),
+            "extra_envs":        dict(e.get("extra_envs") or {}),
+            "output_throughput": _to_float(e.get("output_throughput") or e.get("tput")),
+            "gain_pct":          _to_float(e.get("gain_pct")),
+            "ts":                str(e.get("ts") or ""),
+        }
+
+    accepted = [_shape_entry(e) for e in ledger.get("accepted") or []]
+    rejected = [_shape_entry(e) for e in ledger.get("rejected") or []]
+    tested = list((ledger.get("tested") or {}).values()) if isinstance(ledger.get("tested"), dict) else []
+    tested_shaped = [_shape_entry(e) for e in tested]
+    top_by_gain = sorted(
+        (e for e in tested_shaped if e.get("gain_pct") is not None),
+        key=lambda e: e.get("gain_pct") or 0.0,
+        reverse=True,
+    )[:top_n]
+    return {
+        "schema_version":  int(ledger.get("schema_version") or 0),
+        "tested_count":    len(tested),
+        "accepted":        accepted,
+        "rejected":        rejected,
+        "top_by_gain":     top_by_gain,
+    }
+
+
+def collect_param_search(
+    state: dict[str, Any],
+    warnings: list[str],
+) -> dict[str, Any]:
+    params_ledger = _shape_ledger(state.get("params_search"))
+    params_ledger["winner_history"] = list(state.get("params_winner_history") or [])
+    params_ledger["no_promote_streak"] = int(state.get("params_no_promote_streak") or 0)
+
+    backends_ledger = _shape_ledger(state.get("backends_search"))
+
+    return {
+        "params":                  params_ledger,
+        "backends":                backends_ledger,
+        "synergy_attempted":       list(state.get("synergy_attempted") or []),
+        "discovered_flags":        dict(state.get("discovered_flags") or {}),
+        "backend_winners_history": list(state.get("backend_winners_history") or []),
+    }
+
+
+# ---------------------------------------------------------------------------
+# §11 Sweep
+# ---------------------------------------------------------------------------
+_VARIANT_NAME_RE = re.compile(r"variant_(\d+)_conc(\d+)_isl(\d+)_osl(\d+)", re.IGNORECASE)
+
+
+def _scan_sweep_variants(session_dir: Path) -> list[Path]:
+    """Return list of variant directories under runs/sweep/<task>/variant_*/."""
+    root = session_dir / "runs" / "sweep"
+    if not root.exists():
+        return []
+    out: list[Path] = []
+    for task_dir in sorted(root.iterdir()):
+        if not task_dir.is_dir():
+            continue
+        for v in sorted(task_dir.glob("variant_*")):
+            if v.is_dir():
+                out.append(v)
+    return out
+
+
+def _shape_sweep_point(
+    variant_dir: Path,
+    session_dir: Path,
+    warnings: list[str],
+) -> dict[str, Any]:
+    name = variant_dir.name
+    m = _VARIANT_NAME_RE.search(name)
+    conc: int | None = None
+    isl_: int | None = None
+    osl_: int | None = None
+    if m:
+        try:
+            conc = int(m.group(2))
+            isl_ = int(m.group(3))
+            osl_ = int(m.group(4))
+        except ValueError:
+            pass
+    report = _find_benchmark_report(variant_dir)
+    report_data = _load_json_safe(report, warnings) if report else None
+    status = "ok"
+    out_tput = ttft = tpot = e2el = None
+    if isinstance(report_data, dict):
+        out_tput = _to_float(
+            _safe_get(report_data, "output_throughput_tok_s")
+            or _safe_get(report_data, "result", "output_throughput_tok_s")
+            or _safe_get(report_data, "output_throughput")
+        )
+        ttft = _to_float(
+            _safe_get(report_data, "mean_ttft_ms")
+            or _safe_get(report_data, "result", "mean_ttft_ms")
+        )
+        tpot = _to_float(
+            _safe_get(report_data, "mean_tpot_ms")
+            or _safe_get(report_data, "result", "mean_tpot_ms")
+        )
+        e2el = _to_float(
+            _safe_get(report_data, "mean_e2el_ms")
+            or _safe_get(report_data, "result", "mean_e2el_ms")
+        )
+        if report_data.get("success") is False:
+            status = "failed"
+    elif report is None:
+        status = "skipped"
+    return {
+        "variant_name":            name,
+        "conc":                    conc,
+        "isl":                     isl_,
+        "osl":                     osl_,
+        "output_throughput_tok_s": out_tput,
+        "ttft_mean_ms":            ttft,
+        "tpot_mean_ms":            tpot,
+        "e2el_mean_ms":            e2el,
+        "status":                  status,
+        "benchmark_report_path":   _rel(report, session_dir) if report else None,
+    }
+
+
+def collect_sweep(
+    session_dir: Path,
+    state: dict[str, Any],
+    warnings: list[str],
+) -> dict[str, Any]:
+    ls = state.get("last_sweep") or {}
+    if not isinstance(ls, dict):
+        ls = {}
+
+    variants_on_disk = [
+        _shape_sweep_point(v, session_dir, warnings)
+        for v in _scan_sweep_variants(session_dir)
+    ]
+    return {
+        "grid_size":          _to_int(ls.get("grid_size")) or len(variants_on_disk),
+        "best_overall":       dict(ls.get("best_overall") or {}),
+        "best_for_each_conc": list(ls.get("best_for_each_conc") or []),
+        "pareto_front":       list(ls.get("pareto_front") or []),
+        "all_variants":       variants_on_disk,
+        "config_path":        ls.get("config_path"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# §12 Critic / Robustness
+# ---------------------------------------------------------------------------
+def collect_critic_robustness(
+    session_dir: Path,
+    warnings: list[str],
+) -> dict[str, Any]:
+    critic_iters: list[dict[str, Any]] = []
+    critic_root = session_dir / "critic-workdir"
+    if critic_root.exists():
+        for iter_dir in sorted(critic_root.iterdir(), key=lambda p: p.name):
+            if not iter_dir.is_dir():
+                continue
+            try:
+                iter_n = int(iter_dir.name)
+            except ValueError:
+                iter_n = -1
+            review = _load_json_safe(iter_dir / "review.json", warnings) or {}
+            emit = _load_json_safe(iter_dir / "emit.json", warnings) or {}
+            critic_iters.append({
+                "iter":               iter_n,
+                "ts":                 str(emit.get("ts") or review.get("ts") or ""),
+                "topic":              str(emit.get("topic") or review.get("topic") or ""),
+                "verdict":            str(review.get("verdict") or emit.get("verdict") or ""),
+                "summary":            str(
+                    review.get("summary") or emit.get("summary") or ""
+                )[:500],
+                "request_path":       _rel(iter_dir / "request.json", session_dir),
+                "judge_bundle_path":  _rel(iter_dir / "judge_bundle.json", session_dir),
+                "emit_path":          _rel(iter_dir / "emit.json", session_dir),
+                "review_path":        _rel(iter_dir / "review.json", session_dir),
+            })
+
+    robustness_signals: list[dict[str, Any]] = []
+    rob_root = session_dir / "robustness-workdir"
+    if rob_root.exists():
+        for iter_dir in sorted(rob_root.iterdir(), key=lambda p: p.name):
+            if not iter_dir.is_dir():
+                continue
+            signal_data = _load_json_safe(iter_dir / "signal.json", warnings) or {}
+            action_data = _load_json_safe(iter_dir / "action.json", warnings) or {}
+            robustness_signals.append({
+                "ts":      str(signal_data.get("ts") or action_data.get("ts") or ""),
+                "signal":  str(signal_data.get("signal") or signal_data.get("kind") or ""),
+                "action":  str(action_data.get("action") or action_data.get("kind") or ""),
+                "workdir": _rel(iter_dir, session_dir) or str(iter_dir),
+            })
+
+    return {
+        "critic_iterations":  critic_iters,
+        "robustness_signals": robustness_signals,
+    }
+
+
+# ---------------------------------------------------------------------------
+# §13 Telemetry
+# ---------------------------------------------------------------------------
+def _scan_all_benchmark_reports(session_dir: Path) -> Iterable[Path]:
+    runs = session_dir / "runs"
+    if not runs.exists():
+        return ()
+    return sorted(runs.rglob("benchmark_*/benchmark_report.json"))
+
+
+def _scan_torch_traces(session_dir: Path) -> list[Path]:
+    runs = session_dir / "runs"
+    if not runs.exists():
+        return []
+    return sorted(p for p in runs.rglob("torch_trace*") if p.is_dir())
+
+
+def _scan_system_profiles(session_dir: Path) -> list[Path]:
+    runs = session_dir / "runs"
+    if not runs.exists():
+        return []
+    return sorted(p for p in runs.rglob("system_profile*") if p.is_dir())
+
+
+def _scan_server_logs(session_dir: Path) -> list[Path]:
+    runs = session_dir / "runs"
+    if not runs.exists():
+        return []
+    return sorted(runs.rglob("server*.log"))
+
+
+def _aggregate_gpu_monitor(
+    reports: list[Path],
+    warnings: list[str],
+) -> dict[str, Any]:
+    samples: list[dict[str, Any]] = []
+    for r in reports:
+        d = _load_json_safe(r, warnings)
+        if not isinstance(d, dict):
+            continue
+        gm = d.get("gpu_monitor")
+        if isinstance(gm, list):
+            for s in gm:
+                if isinstance(s, dict):
+                    samples.append(s)
+        elif isinstance(gm, dict):
+            samples.append(gm)
+    if not samples:
+        return {}
+
+    def _avg(key: str) -> float:
+        vals = [_to_float(s.get(key)) for s in samples]
+        vals = [v for v in vals if v is not None]
+        return round(sum(vals) / len(vals), 2) if vals else 0.0
+
+    def _max(key: str) -> float:
+        vals = [_to_float(s.get(key)) for s in samples]
+        vals = [v for v in vals if v is not None]
+        return round(max(vals), 2) if vals else 0.0
+
+    return {
+        "samples":       len(samples),
+        "avg_power_w":   _avg("power_w") or _avg("power"),
+        "max_power_w":   _max("power_w") or _max("power"),
+        "avg_temp_c":    _avg("temperature_c") or _avg("temperature"),
+        "max_temp_c":    _max("temperature_c") or _max("temperature"),
+        "avg_clock_mhz": _avg("clock_mhz") or _avg("sclk_mhz"),
+    }
+
+
+def collect_telemetry(
+    session_dir: Path,
+    state: dict[str, Any],
+    warnings: list[str],
+) -> dict[str, Any]:
+    baseline_report: Path | None = None
+    last_b = state.get("last_baseline") or {}
+    if isinstance(last_b, dict) and last_b.get("workspace"):
+        baseline_report = _find_benchmark_report(Path(last_b["workspace"]))
+
+    profile_reports = [
+        report for _task, report in _scan_profile_reports(session_dir)
+    ]
+    all_reports = list(_scan_all_benchmark_reports(session_dir))
+
+    return {
+        "baseline_report_path": _rel(baseline_report, session_dir) if baseline_report else None,
+        "profile_report_paths": [_rel(p, session_dir) or str(p) for p in profile_reports],
+        "torch_trace_paths":    [_rel(p, session_dir) or str(p) for p in _scan_torch_traces(session_dir)],
+        "system_profile_paths": [_rel(p, session_dir) or str(p) for p in _scan_system_profiles(session_dir)],
+        "server_log_paths":     [_rel(p, session_dir) or str(p) for p in _scan_server_logs(session_dir)],
+        "gpu_monitor_aggregate": _aggregate_gpu_monitor(all_reports, warnings),
+    }
+
+
+# ---------------------------------------------------------------------------
+# §14 Attribution
+# ---------------------------------------------------------------------------
+def _action_family(action: str) -> str:
+    """Map an action label to a family for source_breakdown bucketing."""
+    s = (action or "").lower()
+    if s.startswith("kernel_opt") or s == "integrate":
+        return "kernel"
+    if s == "backends":
+        return "backends"
+    if s == "params":
+        return "params"
+    if s == "sweep":
+        return "sweep"
+    if s == "validate_stack":
+        return "validate"
+    return "other"
+
+
+def collect_attribution(
+    state: dict[str, Any],
+    geak_invocations: list[dict[str, Any]],
+    oob_invocations: list[dict[str, Any]],
+    adopted_kernels: list[dict[str, Any]],
+    warnings: list[str],
+) -> dict[str, Any]:
+    # Prefer authoritative per-stack ledger if Coordinator wrote it
+    # (new state field `gain_per_stack_entry`). Otherwise reconstruct a
+    # best-effort approximation from optimization_stack alone.
+    entries = state.get("gain_per_stack_entry")
+    if not isinstance(entries, list):
+        entries = _reconstruct_gain_ledger(state, warnings)
+
+    # Bucket entries by family for source_breakdown. Honor validated
+    # total as the ground-truth denominator.
+    validated_total = _to_float(state.get("cumulative_gain_validated")) or 0.0
+    family_totals: dict[str, float] = {
+        "kernel": 0.0, "backends": 0.0, "params": 0.0,
+        "sweep": 0.0, "validate": 0.0, "other": 0.0,
+    }
+    for e in entries:
+        if not isinstance(e, dict):
+            continue
+        delta = _to_float(e.get("delta_pct"))
+        if delta is None:
+            continue
+        fam = _action_family(str(e.get("action") or ""))
+        family_totals[fam] = family_totals.get(fam, 0.0) + max(delta, 0.0)
+
+    # Split "kernel" between GEAK / OOB based on adopted KEEP entries' backend
+    geak_kept_kids = {inv.get("kernel_id") for inv in geak_invocations if inv.get("decision") == "KEEP"}
+    oob_kept_kids  = {inv.get("kernel_id") for inv in oob_invocations  if inv.get("decision") == "KEEP"}
+    kernel_total = family_totals.get("kernel", 0.0)
+    geak_total = 0.0
+    oob_total = 0.0
+    for k in adopted_kernels:
+        kid = k.get("kernel_id")
+        gain = _to_float(k.get("e2e_gain_pct")) or 0.0
+        if kid in geak_kept_kids:
+            geak_total += gain
+        elif kid in oob_kept_kids:
+            oob_total += gain
+    if geak_total + oob_total == 0.0 and kernel_total > 0.0:
+        # All-OOB by default when no KEEP'd adopt entry is on disk
+        oob_total = kernel_total
+
+    notes: list[str] = []
+    if not isinstance(state.get("gain_per_stack_entry"), list):
+        notes.append(
+            "gain_per_stack_entry not written by Coordinator; "
+            "attribution reconstructed best-effort from optimization_stack."
+        )
+
+    return {
+        "gain_per_stack_entry": entries,
+        "source_breakdown": {
+            "geak_pct_of_total":     round(geak_total, 2),
+            "oob_pct_of_total":      round(oob_total, 2),
+            "backends_pct_of_total": round(family_totals.get("backends", 0.0), 2),
+            "params_pct_of_total":   round(family_totals.get("params", 0.0), 2),
+            "sweep_pct_of_total":    round(family_totals.get("sweep", 0.0), 2),
+            "validated_total_pct":   round(validated_total, 2),
+        },
+        "notes": notes,
+    }
+
+
+def _reconstruct_gain_ledger(
+    state: dict[str, Any],
+    warnings: list[str],
+) -> list[dict[str, Any]]:
+    """Approximate per-stack contribution when Coordinator hasn't recorded it.
+
+    optimization_stack is an ordered list. We treat each entry's
+    ``gain_pct`` field as that step's delta. This is best-effort only;
+    consumers should check ``attribution.notes`` for the caveat.
+    """
+    stack = state.get("optimization_stack") or []
+    if not isinstance(stack, list):
+        return []
+    cum_before = 0.0
+    out: list[dict[str, Any]] = []
+    for i, entry in enumerate(stack):
+        if not isinstance(entry, dict):
+            continue
+        delta = _to_float(entry.get("gain_pct"))
+        cum_after = cum_before + (delta or 0.0)
+        out.append({
+            "ts":                str(entry.get("ts") or ""),
+            "stack_len_before":  i,
+            "stack_len_after":   i + 1,
+            "action":            str(entry.get("action") or ""),
+            "variant_name":      str(entry.get("variant_name") or ""),
+            "cum_gain_before":   round(cum_before, 4),
+            "cum_gain_after":    round(cum_after, 4),
+            "delta_pct":         delta,
+            "extra_sglang_args": str(entry.get("extra_sglang_args") or ""),
+        })
+        cum_before = cum_after
+    return out
+
+
+# ---------------------------------------------------------------------------
+# source_files map
+# ---------------------------------------------------------------------------
+def collect_source_files(
+    session_dir: Path,
+    baseline_path: str | None,
+    profile_reports: list[str],
+    sweep_reports: list[str],
+) -> dict[str, Any]:
+    kernel_attempts = [
+        _rel(run_dir / "optimization_attempts.jsonl", session_dir) or str(run_dir / "optimization_attempts.jsonl")
+        for run_dir in _kernel_agent_run_dirs(session_dir)
+        if (run_dir / "optimization_attempts.jsonl").exists()
+    ]
+    critic = session_dir / "critic-workdir"
+    rob = session_dir / "robustness-workdir"
+    return {
+        "manifest":           "manifest.json",
+        "state":              "state.json",
+        "baseline_report":    baseline_path,
+        "profile_reports":    profile_reports,
+        "sweep_reports":      sweep_reports,
+        "kernel_attempts":    kernel_attempts,
+        "critic_workdir":     "critic-workdir" if critic.exists() else None,
+        "robustness_workdir": "robustness-workdir" if rob.exists() else None,
+    }
+
+
+__all__ = [
+    "collect_attribution",
+    "collect_baseline",
+    "collect_capability_summary",
+    "collect_critic_robustness",
+    "collect_final",
+    "collect_kernel_invocations",
+    "collect_kernel_lifecycle",
+    "collect_param_search",
+    "collect_phase_timeline",
+    "collect_session",
+    "collect_source_files",
+    "collect_sweep",
+    "collect_telemetry",
+    "collect_workload",
+]

--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -790,11 +790,158 @@ def _scan_profile_reports(session_dir: Path) -> list[tuple[Path, Path]]:
     return out
 
 
-def _collect_detected_kernels(
-    session_dir: Path, warnings: list[str], cap: int = 50,
+def _read_kernel_candidates(
+    session_dir: Path, state: dict[str, Any], warnings: list[str],
 ) -> list[dict[str, Any]]:
-    detected: list[dict[str, Any]] = []
-    seen: set[str] = set()
+    """Return the ``hot_kernels`` array from ``kernel_candidates.json``.
+
+    The MAE-era dashboard required GPU duration + call count for every
+    detected kernel. That data is NOT in benchmark_report.json; it lives
+    in kernel-agent's ``kernel_candidates.json`` which is the input the
+    kernel agent uses to decide what to optimize.
+
+    Resolves the file via:
+      1. ``state.last_select_kernels.candidates_path`` — orchestrator-recorded path
+      2. ``session_dir / kernel-agent-workspace/kernel-agent/runs/hyperloom/kernel_candidates.json``
+      3. ``session_dir / kernel-agent-workspace/**/kernel_candidates.json`` glob fallback
+    """
+    sk = state.get("last_select_kernels") or {}
+    raw_path = sk.get("candidates_path") if isinstance(sk, dict) else None
+    candidate_paths: list[Path] = []
+    if raw_path:
+        # The recorded path is usually a container path (/workspace/...) that
+        # doesn't exist on wekafs; rewrite the prefix to the session_dir's
+        # actual on-disk root before falling back to glob.
+        p = Path(str(raw_path))
+        candidate_paths.append(p)
+        try:
+            idx = p.parts.index("kernel-agent-workspace")
+            candidate_paths.append(session_dir.joinpath(*p.parts[idx:]))
+        except ValueError:
+            pass
+    candidate_paths.append(
+        session_dir / "kernel-agent-workspace" / "kernel-agent"
+        / "runs" / "hyperloom" / "kernel_candidates.json"
+    )
+    candidate_paths.extend(
+        sorted((session_dir / "kernel-agent-workspace").rglob("kernel_candidates.json"))
+    )
+    for path in candidate_paths:
+        if not path or not path.exists():
+            continue
+        data = _load_json_safe(path, warnings)
+        if isinstance(data, dict):
+            hk = data.get("hot_kernels")
+            if isinstance(hk, list):
+                return hk
+    # Final fallback: state.last_select_kernels.hot_kernels_top15.
+    # This is what the orchestrator actually copied out of
+    # kernel_candidates.json — usually the same shape, just truncated to
+    # 15. Used when the on-disk file is missing (e.g. test fixtures or
+    # sessions where the kernel-agent workspace got rotated away).
+    inline = sk.get("hot_kernels_top15") if isinstance(sk, dict) else None
+    if isinstance(inline, list):
+        return inline
+    return []
+
+
+def _index_invocations_by_kernel(
+    invs: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Fold per-attempt invocations into per-kernel summary for one lane.
+
+    The returned dict maps kernel_id -> ``{attempts, best_speedup,
+    decision, last_status}`` so the detected-kernel collector can stamp
+    every detected kernel with both lanes' per-kernel verdicts.
+    """
+    out: dict[str, dict[str, Any]] = {}
+    for inv in invs:
+        kid = str(inv.get("kernel_id") or "")
+        if not kid:
+            continue
+        ent = out.setdefault(kid, {
+            "attempts": 0, "best_speedup": None,
+            "decision": "", "last_status": "",
+        })
+        ent["attempts"] += 1
+        spd = inv.get("micro_speedup")
+        if isinstance(spd, (int, float)):
+            cur = ent["best_speedup"]
+            if cur is None or float(spd) > cur:
+                ent["best_speedup"] = float(spd)
+        # KEEP/PARTIAL outrank everything else; FAILED never overrides KEEP.
+        dec = str(inv.get("decision") or "")
+        if dec in ("KEEP", "PARTIAL") or not ent["decision"]:
+            ent["decision"] = dec or ent["decision"]
+        ent["last_status"] = str(inv.get("status") or ent["last_status"])
+    return out
+
+
+def _collect_detected_kernels(
+    session_dir: Path,
+    state: dict[str, Any],
+    geak: list[dict[str, Any]],
+    oob: list[dict[str, Any]],
+    warnings: list[str],
+    *,
+    cap: int | None = None,
+) -> list[dict[str, Any]]:
+    """Build the canonical per-kernel lifecycle row used by the report.
+
+    Each entry merges:
+      * static profile fields (gpu_pct, duration_us, call_count,
+        bandwidth/compute util, kernel_category, bottleneck, name,
+        source_file, arithmetic_intensity, reusable_native_kernel) from
+        ``kernel_candidates.json`` (preferred) or ``benchmark_report.kernel_summary``,
+      * ``selected_for_optimization`` — whether the orchestrator routed
+        this kernel into the optimization pipeline,
+      * ``geak`` / ``oob`` — per-lane ``{attempts, best_speedup,
+        decision}`` summaries reduced from the invocation lists,
+      * ``adopted_by`` — which lane's patch ended up in the final stack
+        (looked up via ``kernel_integrate_attempts`` KEEP entries),
+      * ``final_decision`` — ``kept`` / ``reverted`` / ``rejected`` /
+        ``not_optimized``.
+
+    The merge is keyed by ``kernel_id``; rows from
+    ``kernel_candidates.json`` take precedence on shape conflicts since
+    that file is what the kernel agent actually consumed.
+    """
+    by_kid: dict[str, dict[str, Any]] = {}
+
+    # 1) candidates.json (preferred — has call_count / duration_us)
+    for k in _read_kernel_candidates(session_dir, state, warnings):
+        if not isinstance(k, dict):
+            continue
+        kid = str(k.get("kernel_id") or k.get("name") or "")
+        if not kid:
+            continue
+        by_kid[kid] = {
+            "kernel_id":               kid,
+            "name":                    str(k.get("name") or ""),
+            "gpu_pct":                 _to_float(k.get("gpu_pct")),
+            "duration_us":             _to_float(k.get("duration_us")),
+            "call_count":              int(k.get("call_count") or 0) or None,
+            "bandwidth_util_pct":      _to_float(k.get("bandwidth_utilization_pct")),
+            "compute_util_pct":        _to_float(k.get("compute_utilization_pct")),
+            "kernel_category":         str(k.get("kernel_category") or ""),
+            "bottleneck":              str(k.get("bottleneck") or ""),
+            "arithmetic_intensity":    _to_float(k.get("arithmetic_intensity")),
+            "reusable_native_kernel":  bool(k.get("reusable_native_kernel")),
+            "source_file":             k.get("source_file") or "",
+            "recommended_actions":     list(k.get("recommended_actions") or []),
+            "recommended_backends":    list(k.get("recommended_backends") or []),
+            "optimization_notes":      str(k.get("optimization_notes") or ""),
+        }
+
+    # 2) benchmark_report.kernel_summary fallback — pulls in the long
+    #    tail of trace kernels that didn't make the top-N candidates
+    #    list. We dedupe by name against the candidates entries (so
+    #    k001..k0NN absorb their fallback rows instead of producing
+    #    twin entries), and any genuinely new fallback entry gets a
+    #    short ``rNNN`` alias as ``kernel_id`` so the table column
+    #    stays narrow.
+    name_to_kid = {e["name"]: kid for kid, e in by_kid.items() if e.get("name")}
+    residual_counter = 0
     for task_dir, report_path in _scan_profile_reports(session_dir):
         report = _load_json_safe(report_path, warnings)
         if not isinstance(report, dict):
@@ -809,26 +956,139 @@ def _collect_detected_kernels(
         for k in kernel_summary if isinstance(kernel_summary, list) else []:
             if not isinstance(k, dict):
                 continue
-            kid = str(k.get("kernel_id") or k.get("name") or "")
-            if not kid or kid in seen:
+            name_str = str(k.get("name") or "")
+            if not name_str:
                 continue
-            seen.add(kid)
-            bn = bottleneck_by_kid.get(kid) or {}
-            detected.append({
-                "kernel_id":               kid,
-                "name":                    str(k.get("name") or ""),
-                "gpu_pct":                 _to_float(k.get("gpu_pct")),
-                "time_ms":                 _to_float(k.get("time_ms")),
-                "bottleneck":              str(bn.get("bottleneck") or k.get("bottleneck") or ""),
-                "arithmetic_intensity":    _to_float(k.get("arithmetic_intensity")),
-                "reusable_native_kernel":  bool(k.get("reusable_native_kernel")),
-                "source_file":             k.get("source_file"),
-                "detected_from_task":      task_dir.name,
-                "benchmark_report_path":   _rel(report_path, session_dir) or str(report_path),
-            })
-            if len(detected) >= cap:
-                return detected
-    return detected
+            existing_kid = name_to_kid.get(name_str)
+            if existing_kid is not None:
+                # Merge missing fields into the candidates-side entry
+                # rather than appending a duplicate row.
+                entry = by_kid[existing_kid]
+                if entry.get("gpu_pct") is None:
+                    entry["gpu_pct"] = _to_float(k.get("gpu_pct"))
+                if entry.get("duration_us") is None:
+                    t_ms = _to_float(k.get("time_ms"))
+                    entry["duration_us"] = (t_ms * 1000.0) if t_ms is not None else None
+                if not entry.get("bottleneck"):
+                    bn = bottleneck_by_kid.get(k.get("kernel_id")) or {}
+                    entry["bottleneck"] = str(bn.get("bottleneck") or k.get("bottleneck") or "")
+                if entry.get("arithmetic_intensity") is None:
+                    entry["arithmetic_intensity"] = _to_float(k.get("arithmetic_intensity"))
+                continue
+
+            input_kid = str(k.get("kernel_id") or "")
+            # Keep the input kernel_id when it's already a short alias
+            # (orchestrator-assigned, e.g. ``k002``) instead of clobbering
+            # it with a residual alias. Mangled C++ symbols (input_kid ==
+            # name, len ≫ 16) get a generated alias to keep the table
+            # narrow.
+            is_short_alias = (
+                input_kid
+                and input_kid != name_str
+                and len(input_kid) <= 8
+                and input_kid not in by_kid
+            )
+            if is_short_alias:
+                alias = input_kid
+            else:
+                residual_counter += 1
+                alias = f"r{residual_counter:03d}"
+            bn = bottleneck_by_kid.get(k.get("kernel_id")) or {}
+            t_ms = _to_float(k.get("time_ms"))
+            by_kid[alias] = {
+                "kernel_id":              alias,
+                "name":                   name_str,
+                "gpu_pct":                _to_float(k.get("gpu_pct")),
+                "duration_us":            (t_ms * 1000.0) if t_ms is not None else None,
+                "call_count":             None,
+                "bandwidth_util_pct":     None,
+                "compute_util_pct":       None,
+                "kernel_category":        "",
+                "bottleneck":             str(bn.get("bottleneck") or k.get("bottleneck") or ""),
+                "arithmetic_intensity":   _to_float(k.get("arithmetic_intensity")),
+                "reusable_native_kernel": bool(k.get("reusable_native_kernel")),
+                "source_file":            k.get("source_file") or "",
+                "recommended_actions":    [],
+                "recommended_backends":   [],
+                "optimization_notes":     "",
+                "detected_from_task":     task_dir.name,
+                "benchmark_report_path":  _rel(report_path, session_dir) or str(report_path),
+            }
+            name_to_kid[name_str] = alias
+
+    # 3) lifecycle stamps (selected / geak / oob / adopted_by / final_decision)
+    selected_ids = {
+        str(e.get("kernel_id") or "")
+        for e in ((state.get("last_select_kernels") or {}).get("hot_kernels_top15") or [])
+        if isinstance(e, dict)
+    }
+    geak_idx = _index_invocations_by_kernel(geak)
+    oob_idx = _index_invocations_by_kernel(oob)
+
+    integ = state.get("kernel_integrate_attempts") or {}
+    adopted_kids: set[str] = set()
+    reverted_kids: set[str] = set()
+    if isinstance(integ, dict):
+        for ent in integ.values():
+            if not isinstance(ent, dict):
+                continue
+            kid = str(ent.get("kernel_id") or "")
+            if not kid:
+                continue
+            dec = ent.get("last_decision")
+            if dec == "KEEP":
+                adopted_kids.add(kid)
+            elif dec in ("REVERT", "REJECT"):
+                reverted_kids.add(kid)
+
+    rejected_kids = {
+        str(k or "") for k in (state.get("rejected_kernel_ids") or [])
+    } - adopted_kids
+
+    for kid, entry in by_kid.items():
+        entry["selected_for_optimization"] = kid in selected_ids
+        entry["geak"] = geak_idx.get(kid)  # None if lane never touched this kid
+        entry["oob"] = oob_idx.get(kid)
+        if kid in adopted_kids:
+            # Disambiguate which lane's patch was kept.
+            g_kept = bool(entry["geak"] and entry["geak"]["decision"] in ("KEEP", "PARTIAL"))
+            o_kept = bool(entry["oob"] and entry["oob"]["decision"] in ("KEEP", "PARTIAL"))
+            if g_kept and not o_kept:
+                entry["adopted_by"] = "geak"
+            elif o_kept and not g_kept:
+                entry["adopted_by"] = "oob"
+            elif g_kept and o_kept:
+                # Prefer the lane with higher micro-speedup.
+                g_spd = (entry["geak"] or {}).get("best_speedup") or 0.0
+                o_spd = (entry["oob"] or {}).get("best_speedup") or 0.0
+                entry["adopted_by"] = "geak" if g_spd >= o_spd else "oob"
+            else:
+                # Integrate KEEP but neither lane recorded KEEP — likely a
+                # manually staged patch; record as 'kernel_agent' rather
+                # than guessing.
+                entry["adopted_by"] = "kernel_agent"
+            entry["final_decision"] = "kept"
+        elif kid in reverted_kids:
+            entry["adopted_by"] = None
+            entry["final_decision"] = "reverted"
+        elif kid in rejected_kids:
+            entry["adopted_by"] = None
+            entry["final_decision"] = "rejected"
+        elif entry["geak"] or entry["oob"]:
+            entry["adopted_by"] = None
+            entry["final_decision"] = "attempted"
+        else:
+            entry["adopted_by"] = None
+            entry["final_decision"] = "not_optimized"
+
+    # Sort by GPU share descending so the table is actionable top-down.
+    out = sorted(
+        by_kid.values(),
+        key=lambda e: (-(e.get("gpu_pct") or 0.0), e.get("kernel_id") or ""),
+    )
+    if cap is not None and len(out) > cap:
+        return out[:cap]
+    return out
 
 
 def _collect_recommended_kernels(state: dict[str, Any]) -> list[dict[str, Any]]:
@@ -979,7 +1239,7 @@ def collect_kernel_lifecycle(
     warnings: list[str],
 ) -> dict[str, Any]:
     return {
-        "detected":    _collect_detected_kernels(session_dir, warnings),
+        "detected":    _collect_detected_kernels(session_dir, state, geak, oob, warnings),
         "recommended": _collect_recommended_kernels(state),
         "optimized":   _collect_optimized_kernels(geak, oob, state),
         "adopted":     _collect_adopted_kernels(state),
@@ -1032,6 +1292,57 @@ def _shape_ledger(
     }
 
 
+def _patch_winners_history(
+    rows: list[Any], baseline_tput: float | None,
+) -> list[dict[str, Any]]:
+    """Fix two recurring data-quality issues in ``backend_winners_history``:
+
+    * ``base_tput`` is occasionally written as ``0.0`` (Coordinator
+      didn't stamp the round's baseline). When that happens we fall
+      back to the session's ``baseline_tput``.
+    * Per-winner ``gain_pct`` is frequently null. We compute it from
+      ``(winner.tput - base_tput) / base_tput * 100`` when both are
+      known so the dashboard table can show real gains.
+    """
+    out: list[dict[str, Any]] = []
+    for r in rows:
+        if not isinstance(r, dict):
+            continue
+        row = dict(r)
+        try:
+            bt = float(row.get("base_tput") or 0.0)
+        except (TypeError, ValueError):
+            bt = 0.0
+        if bt <= 0 and baseline_tput and baseline_tput > 0:
+            row["base_tput"] = float(baseline_tput)
+            row["base_tput_source"] = "session_baseline"
+            bt = float(baseline_tput)
+        if bt > 0:
+            winners = list(row.get("winners") or [])
+            new_winners: list[dict[str, Any]] = []
+            for w in winners:
+                if not isinstance(w, dict):
+                    continue
+                w2 = dict(w)
+                if w2.get("gain_pct") in (None, "") and w2.get("tput") is not None:
+                    try:
+                        w2["gain_pct"] = (float(w2["tput"]) - bt) / bt * 100.0
+                    except (TypeError, ValueError, ZeroDivisionError):
+                        pass
+                new_winners.append(w2)
+            row["winners"] = new_winners
+            best = row.get("best")
+            if isinstance(best, dict) and best.get("gain_pct") in (None, "") and best.get("tput") is not None:
+                try:
+                    best = dict(best)
+                    best["gain_pct"] = (float(best["tput"]) - bt) / bt * 100.0
+                    row["best"] = best
+                except (TypeError, ValueError, ZeroDivisionError):
+                    pass
+        out.append(row)
+    return out
+
+
 def collect_param_search(
     state: dict[str, Any],
     warnings: list[str],
@@ -1042,12 +1353,15 @@ def collect_param_search(
 
     backends_ledger = _shape_ledger(state.get("backends_search"))
 
+    baseline_tput = _to_float(state.get("baseline_tput"))
     return {
         "params":                  params_ledger,
         "backends":                backends_ledger,
         "synergy_attempted":       list(state.get("synergy_attempted") or []),
         "discovered_flags":        dict(state.get("discovered_flags") or {}),
-        "backend_winners_history": list(state.get("backend_winners_history") or []),
+        "backend_winners_history": _patch_winners_history(
+            state.get("backend_winners_history") or [], baseline_tput,
+        ),
     }
 
 

--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -93,6 +93,58 @@ def _rel(path: Path | None, session_dir: Path) -> str | None:
         return str(path)
 
 
+def _benchmark_report_metrics(
+    report: dict[str, Any] | None,
+) -> tuple[float | None, float | None, float | None, float | None]:
+    """Extract (output_throughput, ttft_mean_ms, tpot_mean_ms, e2el_mean_ms) from
+    a benchmark_report.json regardless of schema generation.
+
+    Supported shapes (in priority order):
+
+    * V2 (current): top-level ``throughput.output_throughput`` +
+      ``latency.<metric>.mean_ms`` (e.g. ``latency.ttft.mean_ms``).
+    * Pre-V2 flat: ``output_throughput_tok_s`` / ``mean_ttft_ms`` at the
+      top level.
+    * Legacy nested-under-result: ``result.<flat>``.
+    """
+    if not isinstance(report, dict):
+        return (None, None, None, None)
+    tput_section = report.get("throughput") if isinstance(report.get("throughput"), dict) else None
+    lat_section = report.get("latency") if isinstance(report.get("latency"), dict) else None
+    result_section = report.get("result") if isinstance(report.get("result"), dict) else None
+
+    def _from_lat(metric: str) -> Any:
+        if isinstance(lat_section, dict):
+            sub = lat_section.get(metric)
+            if isinstance(sub, dict):
+                return sub.get("mean_ms")
+        return None
+
+    out_tput = _to_float(
+        (tput_section or {}).get("output_throughput")
+        or (tput_section or {}).get("output_throughput_tok_s")
+        or report.get("output_throughput_tok_s")
+        or report.get("output_throughput")
+        or (result_section or {}).get("output_throughput_tok_s")
+    )
+    ttft = _to_float(
+        _from_lat("ttft")
+        or report.get("mean_ttft_ms")
+        or (result_section or {}).get("mean_ttft_ms")
+    )
+    tpot = _to_float(
+        _from_lat("tpot")
+        or report.get("mean_tpot_ms")
+        or (result_section or {}).get("mean_tpot_ms")
+    )
+    e2el = _to_float(
+        _from_lat("e2el")
+        or report.get("mean_e2el_ms")
+        or (result_section or {}).get("mean_e2el_ms")
+    )
+    return (out_tput, ttft, tpot, e2el)
+
+
 def _find_benchmark_report(workspace: Path | None) -> Path | None:
     """Locate the ``benchmark_*/benchmark_report.json`` under a task workspace.
 
@@ -197,11 +249,7 @@ def collect_baseline(
     report_path = _find_benchmark_report(workspace) if workspace else None
     report = _load_json_safe(report_path, warnings) if report_path else None
 
-    ttft: float | None = None
-    e2el: float | None = None
-    if isinstance(report, dict):
-        ttft = _to_float(_safe_get(report, "mean_ttft_ms") or _safe_get(report, "result", "mean_ttft_ms"))
-        e2el = _to_float(_safe_get(report, "mean_e2el_ms") or _safe_get(report, "result", "mean_e2el_ms"))
+    _, ttft, _tpot, e2el = _benchmark_report_metrics(report if isinstance(report, dict) else None)
 
     attempts = state.get("baseline_attempts") or []
     history: list[dict[str, Any]] = []
@@ -355,12 +403,44 @@ def collect_phase_timeline(
 def _capability_for_action(
     state: dict[str, Any], action: str,
 ) -> dict[str, Any]:
+    """Per-action capability tally.
+
+    Primary source is the rich ``<action>_attempts`` audit list added in
+    HL V2 (each entry has ``decision`` in
+    ``{promoted, salvaged, rejected, failed, ...}``). On older V1 sessions
+    or partial state.json snapshots those lists are missing or empty even
+    when the action actually ran successfully, so we also walk
+    ``optimization_stack`` as a fallback: every stack entry whose
+    ``action`` matches counts as a KEEP (the stack only collects
+    successfully promoted entries by construction). Without this fallback
+    sessions that had a clear ``backends:vllm_kv_fp8`` final.action_path
+    would still report ``backends: not_attempted`` in capability_summary.
+    """
     attempts_list = state.get(f"{action}_attempts") or []
     n_attempts = len(attempts_list) if isinstance(attempts_list, list) else 0
     n_keeps = sum(
         1 for a in attempts_list
         if isinstance(a, dict) and a.get("decision") in ("promoted", "salvaged")
     ) if isinstance(attempts_list, list) else 0
+
+    # Fallback / augmentation from optimization_stack — only adopted
+    # entries land here. Counts an entry once per action; the kernel
+    # integrate path uses ``action="integrate"`` so it does not collide
+    # with backends/params/sweep here.
+    stack = state.get("optimization_stack") or []
+    if isinstance(stack, list):
+        stack_keeps = sum(
+            1 for e in stack
+            if isinstance(e, dict) and str(e.get("action") or "") == action
+        )
+    else:
+        stack_keeps = 0
+    if stack_keeps > n_keeps:
+        n_keeps = stack_keeps
+        # Stack-derived keeps imply at least as many attempts.
+        if n_attempts < stack_keeps:
+            n_attempts = stack_keeps
+
     status = (
         "kept"      if n_keeps > 0 else
         "tried"     if n_attempts > 0 else
@@ -1014,23 +1094,7 @@ def _shape_sweep_point(
     status = "ok"
     out_tput = ttft = tpot = e2el = None
     if isinstance(report_data, dict):
-        out_tput = _to_float(
-            _safe_get(report_data, "output_throughput_tok_s")
-            or _safe_get(report_data, "result", "output_throughput_tok_s")
-            or _safe_get(report_data, "output_throughput")
-        )
-        ttft = _to_float(
-            _safe_get(report_data, "mean_ttft_ms")
-            or _safe_get(report_data, "result", "mean_ttft_ms")
-        )
-        tpot = _to_float(
-            _safe_get(report_data, "mean_tpot_ms")
-            or _safe_get(report_data, "result", "mean_tpot_ms")
-        )
-        e2el = _to_float(
-            _safe_get(report_data, "mean_e2el_ms")
-            or _safe_get(report_data, "result", "mean_e2el_ms")
-        )
+        out_tput, ttft, tpot, e2el = _benchmark_report_metrics(report_data)
         if report_data.get("success") is False:
             status = "failed"
     elif report is None:

--- a/inference_optimizer/breakdown/exporter.py
+++ b/inference_optimizer/breakdown/exporter.py
@@ -1,0 +1,247 @@
+"""Top-level builder for ``session_breakdown.json``.
+
+Three entrypoints share this builder:
+
+* CLI script (``scripts/dump_session_breakdown.py``) — offline / historical
+* Coordinator action (``action_executors/session_breakdown.py``) — agent-driven
+* ``cli.py`` finally block — end-of-session safety net
+
+All three call :func:`build` (pure: no side effects) or
+:func:`write_breakdown_json` (atomic ``state.json``-style write).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from . import collectors
+from .schema import SCHEMA_VERSION
+
+log = logging.getLogger(__name__)
+
+EXPORTER_VERSION = "session-breakdown-1.0.0"
+BREAKDOWN_FILENAME = "session_breakdown.json"
+
+
+def _load_state(session_dir: Path, warnings: list[str]) -> dict[str, Any]:
+    """Read ``state.json`` as a plain dict.
+
+    Falls back to an empty dict (recorded as warning) so collectors can
+    still surface manifest-only metadata if state is missing.
+    """
+    state_path = session_dir / "state.json"
+    if not state_path.exists():
+        warnings.append(f"state.json missing at {state_path}")
+        return {}
+    try:
+        return json.loads(state_path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"failed to parse state.json: {exc!r}")
+        return {}
+
+
+def _load_manifest(session_dir: Path, warnings: list[str]) -> dict[str, Any]:
+    manifest_path = session_dir / "manifest.json"
+    if not manifest_path.exists():
+        warnings.append(f"manifest.json missing at {manifest_path}")
+        return {}
+    try:
+        return json.loads(manifest_path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"failed to parse manifest.json: {exc!r}")
+        return {}
+
+
+def build(session_dir: Path | str) -> dict[str, Any]:
+    """Build a complete :class:`SessionBreakdown` for ``session_dir``.
+
+    Pure function — reads from disk, never mutates state.
+
+    Args:
+        session_dir: absolute path to a hyperloom session directory.
+                     The directory MUST contain at least ``manifest.json``
+                     or ``state.json`` for any usable output; a totally
+                     empty dir returns mostly-empty sections with warnings.
+
+    Returns:
+        A dict matching :class:`schema.SessionBreakdown`.
+    """
+    sd = Path(session_dir).resolve()
+    warnings: list[str] = []
+
+    state = _load_state(sd, warnings)
+    manifest = _load_manifest(sd, warnings)
+
+    from datetime import datetime, timezone
+    exported_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+    # ── Section collectors (each catches its own errors via warnings) ──
+    session_meta      = _safe_collect("session",
+                                       lambda: collectors.collect_session(sd, state, manifest, warnings),
+                                       warnings)
+    workload          = _safe_collect("workload",
+                                       lambda: collectors.collect_workload(state, manifest, warnings),
+                                       warnings)
+    baseline          = _safe_collect("baseline",
+                                       lambda: collectors.collect_baseline(sd, state, warnings),
+                                       warnings)
+    final             = _safe_collect("final",
+                                       lambda: collectors.collect_final(state, warnings),
+                                       warnings)
+    phase_timeline    = _safe_collect("phase_timeline",
+                                       lambda: collectors.collect_phase_timeline(state, warnings),
+                                       warnings)
+    geak_invocations, oob_invocations = _safe_collect(
+        "invocations",
+        lambda: collectors.collect_kernel_invocations(sd, warnings),
+        warnings,
+        default=([], []),
+    )
+    capability_summary = _safe_collect("capability_summary",
+                                        lambda: collectors.collect_capability_summary(
+                                            state, geak_invocations, oob_invocations, warnings,
+                                        ),
+                                        warnings)
+    kernel_lifecycle   = _safe_collect("kernel_lifecycle",
+                                        lambda: collectors.collect_kernel_lifecycle(
+                                            sd, state, geak_invocations, oob_invocations, warnings,
+                                        ),
+                                        warnings)
+    param_search       = _safe_collect("param_search",
+                                        lambda: collectors.collect_param_search(state, warnings),
+                                        warnings)
+    sweep              = _safe_collect("sweep",
+                                        lambda: collectors.collect_sweep(sd, state, warnings),
+                                        warnings)
+    critic_robustness  = _safe_collect("critic_robustness",
+                                        lambda: collectors.collect_critic_robustness(sd, warnings),
+                                        warnings)
+    telemetry          = _safe_collect("telemetry",
+                                        lambda: collectors.collect_telemetry(sd, state, warnings),
+                                        warnings)
+    attribution        = _safe_collect("attribution",
+                                        lambda: collectors.collect_attribution(
+                                            state, geak_invocations, oob_invocations,
+                                            kernel_lifecycle.get("adopted") or [],
+                                            warnings,
+                                        ),
+                                        warnings)
+
+    source_files = collectors.collect_source_files(
+        sd,
+        baseline.get("benchmark_report_path"),
+        telemetry.get("profile_report_paths") or [],
+        [p.get("benchmark_report_path") for p in (sweep.get("all_variants") or [])
+         if p.get("benchmark_report_path")],
+    )
+
+    return {
+        "schema_version":      SCHEMA_VERSION,
+        "exported_at_utc":     exported_at,
+        "exporter_version":    EXPORTER_VERSION,
+
+        "session":             session_meta,
+        "workload":            workload,
+        "baseline":            baseline,
+        "final":               final,
+        "phase_timeline":      phase_timeline,
+        "capability_summary":  capability_summary,
+        "geak_invocations":    geak_invocations,
+        "oob_invocations":     oob_invocations,
+        "kernel_lifecycle":    kernel_lifecycle,
+        "param_search":        param_search,
+        "sweep":               sweep,
+        "critic_robustness":   critic_robustness,
+        "telemetry":           telemetry,
+        "attribution":         attribution,
+
+        "warnings":            warnings,
+        "source_files":        source_files,
+    }
+
+
+def _safe_collect(
+    name: str,
+    fn: callable,
+    warnings: list[str],
+    *,
+    default: Any = None,
+):
+    """Run a collector with broad exception catching.
+
+    A bug in one collector must never poison the whole export. Each
+    failure becomes a warning entry; the section becomes ``default``
+    (an empty dict / list).
+    """
+    try:
+        return fn()
+    except Exception as exc:  # noqa: BLE001
+        log.exception("collector %s failed", name)
+        warnings.append(f"collector:{name} failed: {type(exc).__name__}: {exc}")
+        if default is not None:
+            return default
+        return {}
+
+
+def write_breakdown_json(
+    session_dir: Path | str,
+    *,
+    output_path: Path | str | None = None,
+) -> Path:
+    """Build + atomically write ``session_breakdown.json``.
+
+    Args:
+        session_dir: hyperloom session directory.
+        output_path: override target path (defaults to
+                     ``<session_dir>/session_breakdown.json``).
+
+    Returns:
+        Absolute path to the written JSON file.
+    """
+    sd = Path(session_dir).resolve()
+    target = Path(output_path).resolve() if output_path else sd / BREAKDOWN_FILENAME
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    breakdown = build(sd)
+    payload = json.dumps(breakdown, indent=2, sort_keys=True, default=_json_default)
+
+    fd, tmp = tempfile.mkstemp(
+        prefix=f".{BREAKDOWN_FILENAME}.",
+        suffix=".tmp",
+        dir=str(target.parent),
+    )
+    os.close(fd)
+    tmp_path = Path(tmp)
+    try:
+        tmp_path.write_text(payload, encoding="utf-8")
+        os.replace(tmp_path, target)
+    except Exception:
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+        raise
+    log.info("session_breakdown: wrote %s (%d bytes)", target, len(payload))
+    return target
+
+
+def _json_default(obj: Any) -> Any:
+    """Stringify objects json.dumps can't handle natively (Path, set, ...)."""
+    if isinstance(obj, Path):
+        return str(obj)
+    if isinstance(obj, set):
+        return sorted(obj)
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
+
+
+__all__ = [
+    "BREAKDOWN_FILENAME",
+    "EXPORTER_VERSION",
+    "build",
+    "write_breakdown_json",
+]

--- a/inference_optimizer/breakdown/reporters/__init__.py
+++ b/inference_optimizer/breakdown/reporters/__init__.py
@@ -1,0 +1,29 @@
+"""Section renderer + LLM compose layer that turns a
+``session_breakdown.json`` dict into a user-facing markdown report.
+
+Public API:
+
+* :func:`render_session_report` — main entry. Returns
+  :class:`ComposeResult` whose ``markdown`` attribute is the report
+  text.
+
+* :class:`RenderedSection`, :class:`Decision`, :class:`GlobalFacts` —
+  surfaced for callers that want to plug in their own composer or
+  consume the structured facts directly (UI, dashboards).
+
+See :mod:`inference_optimizer.breakdown.reporters.compose` for the
+high-level design notes and ``SKILL.md`` for operator guidance.
+"""
+
+from .base import Decision, RenderedSection
+from .compose import ComposeResult, LLMClient, render_session_report
+from .cross_section import GlobalFacts
+
+__all__ = [
+    "ComposeResult",
+    "Decision",
+    "GlobalFacts",
+    "LLMClient",
+    "RenderedSection",
+    "render_session_report",
+]

--- a/inference_optimizer/breakdown/reporters/_renderers/__init__.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/__init__.py
@@ -1,0 +1,4 @@
+"""Section renderer modules — each registers itself with the central
+REGISTRY at import time. ``compose.py`` is responsible for ordering;
+this package just hosts the implementations.
+"""

--- a/inference_optimizer/breakdown/reporters/_renderers/attribution.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/attribution.py
@@ -1,0 +1,84 @@
+"""Attribution renderer — gain split across optimization sources.
+
+Splits gain among backends / params / sweep / geak / oob. Surfaces:
+
+* the source_breakdown table (kept from the collector verbatim),
+* explicit "validated vs. reconstructed" call-out so report consumers
+  know how much to trust the split,
+* any collector ``notes`` (assumption breadcrumbs).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..base import Decision, RenderedSection, fmt_pct, md_table, register_renderer
+
+
+@register_renderer("attribution")
+def render(breakdown: dict[str, Any]) -> RenderedSection:
+    a = breakdown.get("attribution") or {}
+    sb = a.get("source_breakdown") or {}
+    notes = a.get("notes") or []
+    method = a.get("method") or ""
+
+    total_v = sb.get("validated_total_pct")
+    rows = [
+        ["backends", sb.get("backends_pct_of_total"), sb.get("backends_share_pct")],
+        ["params",   sb.get("params_pct_of_total"),   sb.get("params_share_pct")],
+        ["sweep",    sb.get("sweep_pct_of_total"),    sb.get("sweep_share_pct")],
+        ["geak",     sb.get("geak_pct_of_total"),     sb.get("geak_share_pct")],
+        ["oob",      sb.get("oob_pct_of_total"),      sb.get("oob_share_pct")],
+    ]
+
+    facts: list[str] = []
+    if total_v is not None:
+        facts.append(f"Validated total gain attributed: {fmt_pct(total_v, plus=True)}.")
+    if method:
+        facts.append(f"Attribution method: `{method}`.")
+    has_any_split = any(r[1] not in (None, 0, 0.0) for r in rows)
+    if not has_any_split:
+        facts.append(
+            "No per-source split available — either the session ran a "
+            "single capability (single-source) or attribution mining was "
+            "not executed."
+        )
+    for src, pct, share in rows:
+        if pct in (None, 0, 0.0):
+            continue
+        facts.append(
+            f"{src}: {fmt_pct(pct)} of total"
+            + (f" ({fmt_pct(share)} share)" if share is not None else "")
+        )
+    for n in notes:
+        facts.append(f"Note: {n}")
+
+    decisions: list[Decision] = []
+    for src, pct, _share in rows:
+        if pct and pct > 0:
+            decisions.append(Decision(
+                kind="kept",
+                subject=f"attribution:{src}",
+                metric_pct=float(pct),
+                rationale="contributed positive validated gain",
+            ))
+
+    # Only emit the per-source table when at least one source has a
+    # non-zero attribution. Otherwise the table is five rows of zeros
+    # which is misleading: callers can't tell "no attribution mined yet"
+    # from "every source contributed zero".
+    md = md_table(["source", "pct_of_total", "share_pct"], rows) if has_any_split else ""
+    # If we have no per-source breakdown and only the headline number
+    # was recorded, skip the section entirely — the headline is already
+    # in the executive summary, so a one-row "validated_total_pct = ..."
+    # block would be redundant noise.
+    skipped = not has_any_split
+    return RenderedSection(
+        section_id="attribution",
+        title="Source Attribution",
+        key_facts=facts,
+        markdown_block=md,
+        decisions=decisions,
+        warnings=[],
+        skipped=skipped,
+    )

--- a/inference_optimizer/breakdown/reporters/_renderers/baseline.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/baseline.py
@@ -1,0 +1,86 @@
+"""Baseline measurement renderer."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..base import Decision, RenderedSection, md_kv_list, md_table, register_renderer
+
+
+@register_renderer("baseline")
+def render(breakdown: dict[str, Any]) -> RenderedSection:
+    b = breakdown.get("baseline") or {}
+    tput = b.get("throughput_tok_s_per_gpu")
+    acc = b.get("accuracy")
+    ttft = b.get("ttft_mean_ms")
+    e2el = b.get("e2el_mean_ms")
+    fail_streak = int(b.get("failure_streak") or 0)
+    attempts = b.get("attempts_history") or []
+
+    facts: list[str] = []
+    warnings: list[str] = []
+    decisions: list[Decision] = []
+
+    if tput:
+        facts.append(f"Baseline throughput: {float(tput):.2f} tok/s/gpu.")
+        decisions.append(Decision(
+            kind="attempted",
+            subject="baseline",
+            metric_pct=None,
+            rationale=f"baseline_tput={float(tput):.2f}",
+        ))
+    else:
+        warnings.append("No baseline_tput recorded — every subsequent gain is uncomputable.")
+        decisions.append(Decision(
+            kind="not_attempted",
+            subject="baseline",
+            rationale="no throughput captured",
+        ))
+    if acc:
+        facts.append(f"Baseline accuracy: {float(acc):.4g}.")
+    if ttft is not None:
+        facts.append(f"Baseline TTFT mean: {float(ttft):.1f} ms.")
+    else:
+        warnings.append(
+            "ttft_mean_ms is null — baseline benchmark_report.json was unreachable "
+            "from the exporter's vantage point (often: ``last_baseline.workspace`` "
+            "is a container path that no longer resolves on wekafs)."
+        )
+    if e2el is not None:
+        facts.append(f"Baseline e2el mean: {float(e2el):.1f} ms.")
+    if fail_streak:
+        warnings.append(f"baseline_failure_streak={fail_streak} — baseline retried after failure(s).")
+    if attempts:
+        facts.append(f"Baseline attempts recorded: {len(attempts)}.")
+
+    md_parts: list[str] = []
+    md_parts.append(md_kv_list([
+        ("throughput_tok_s_per_gpu", tput),
+        ("accuracy",                 acc),
+        ("ttft_mean_ms",             ttft),
+        ("e2el_mean_ms",             e2el),
+        ("config_path",              b.get("config_path")),
+        ("benchmark_report_path",    b.get("benchmark_report_path")),
+        ("failure_streak",           fail_streak or None),
+    ]))
+    if attempts:
+        rows = [
+            [a.get("ts"), a.get("status"), a.get("decision"),
+             a.get("key_metric"), a.get("error_class")]
+            for a in attempts[:10]
+        ]
+        md_parts.append("")
+        md_parts.append("**Baseline attempts** (last 10):")
+        md_parts.append(md_table(
+            ["ts", "status", "decision", "key_metric", "error_class"], rows,
+        ))
+
+    return RenderedSection(
+        section_id="baseline",
+        title="Baseline",
+        key_facts=facts,
+        markdown_block="\n".join(md_parts).strip(),
+        decisions=decisions,
+        warnings=warnings,
+        skipped=not (tput or attempts),
+    )

--- a/inference_optimizer/breakdown/reporters/_renderers/capability_summary.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/capability_summary.py
@@ -1,0 +1,96 @@
+"""Capability summary renderer.
+
+Renders the ``capability_summary`` section into:
+
+* a markdown table listing each capability's status / attempts / keeps,
+* one ``Decision`` per non-``not_attempted`` capability so the LLM has
+  structured verdicts to reference,
+* ``key_facts`` that paraphrase each row in one line each.
+
+This renderer is the canonical example used as the design reference
+for the other 13 renderers — keep it terse and deterministic.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..base import Decision, RenderedSection, fmt_pct, md_table, register_renderer
+
+_CAPABILITY_ORDER = ("backends", "params", "sweep", "geak", "oob", "validate_stack")
+
+
+@register_renderer("capability_summary")
+def render(breakdown: dict[str, Any]) -> RenderedSection:
+    cap = breakdown.get("capability_summary") or {}
+    rows: list[list[Any]] = []
+    facts: list[str] = []
+    decisions: list[Decision] = []
+    warnings: list[str] = []
+
+    # Stable ordering: known capabilities first, then any extras the
+    # exporter started writing without a renderer update.
+    keys = list(_CAPABILITY_ORDER) + [k for k in cap if k not in _CAPABILITY_ORDER]
+    for name in keys:
+        v = cap.get(name)
+        if v is None:
+            continue
+        status   = str(v.get("status") or "not_attempted")
+        attempts = int(v.get("attempts") or 0)
+        keeps    = int(v.get("keeps") or 0)
+        # Disambiguate the validate_stack "not_attempted but I have a
+        # validated_gain" case: it means the validate_stack action did
+        # not re-run this session, but state carries a validated gain
+        # from an earlier round. Show that as ``stale_validated`` so
+        # the row is no longer self-contradicting.
+        if (
+            name == "validate_stack"
+            and status == "not_attempted"
+            and v.get("last_validated_gain_pct") is not None
+        ):
+            status = "stale_validated"
+        extras: list[str] = []
+        if "best_gain_pct" in v and v["best_gain_pct"] is not None:
+            extras.append(f"best_gain={fmt_pct(v['best_gain_pct'])}")
+        if "best_throughput" in v and v["best_throughput"] is not None:
+            extras.append(f"best_tput={v['best_throughput']:.2f}")
+        if "tested" in v and v["tested"] is not None:
+            extras.append(f"tested={v['tested']}")
+        if "last_validated_gain_pct" in v and v["last_validated_gain_pct"] is not None:
+            extras.append(f"validated_gain={fmt_pct(v['last_validated_gain_pct'])}")
+        if "grid_size" in v and v["grid_size"] is not None:
+            extras.append(f"grid={v['grid_size']}")
+        extras_str = " · ".join(extras) if extras else ""
+
+        rows.append([name, status, attempts, keeps, extras_str])
+        facts.append(
+            f"`{name}` status={status}, attempts={attempts}, keeps={keeps}"
+            + (f" ({extras_str})" if extras_str else "")
+        )
+        if status != "not_attempted":
+            decisions.append(Decision(
+                kind=status,
+                subject=name,
+                metric_pct=None,
+                rationale=(
+                    f"{keeps}/{attempts} attempts promoted"
+                    if attempts else "promoted via optimization_stack fallback"
+                ),
+            ))
+
+    if not rows:
+        warnings.append(
+            "capability_summary section is empty — collectors found no "
+            "<action>_attempts and no optimization_stack entries."
+        )
+
+    md = md_table(["capability", "status", "attempts", "keeps", "extra"], rows)
+    return RenderedSection(
+        section_id="capability_summary",
+        title="Capability Summary",
+        key_facts=facts,
+        markdown_block=md,
+        decisions=decisions,
+        warnings=warnings,
+        skipped=not rows,
+    )

--- a/inference_optimizer/breakdown/reporters/_renderers/critic_robustness.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/critic_robustness.py
@@ -1,0 +1,99 @@
+"""Critic robustness renderer — captures pass-rate of LLM critic /
+self-consistency checks on candidate optimizations.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..base import RenderedSection, md_table, register_renderer
+
+_MAX_ROWS = 20
+
+
+@register_renderer("critic_robustness")
+def render(breakdown: dict[str, Any]) -> RenderedSection:
+    cr = breakdown.get("critic_robustness") or []
+    if not cr:
+        return RenderedSection(
+            section_id="critic_robustness",
+            title="Critic Robustness",
+            key_facts=["No critic robustness samples recorded."],
+            markdown_block="",
+            warnings=[],
+            skipped=True,
+        )
+
+    # The collector historically wrote two shapes:
+    #   * V2: list[dict] with structured payload keys
+    #   * V1: list[str] (just the prompt body, no decision)
+    # Normalize both into dicts so the rest of this function is uniform.
+    cr_norm: list[dict[str, Any]] = []
+    for c in cr:
+        if isinstance(c, dict):
+            cr_norm.append(c)
+        else:
+            cr_norm.append({"prompt": str(c)})
+
+    total = len(cr_norm)
+    populated = [c for c in cr_norm if any(
+        c.get(k) not in (None, "", [], {}) for k in
+        ("response", "decision", "score", "rationale", "pass_count", "fail_count")
+    )]
+    facts: list[str] = []
+    facts.append(f"Recorded {total} critic robustness entries.")
+    string_only = total > 0 and all(
+        list(c.keys()) == ["prompt"] for c in cr_norm
+    )
+    if string_only:
+        facts.append(
+            "All entries are raw prompt strings — collector ran on a "
+            "session that did not persist verdicts. Decision / pass-fail "
+            "data is non-actionable for this session."
+        )
+        warnings = [
+            "critic_robustness collector produced prompt-only entries "
+            "(no decisions); section skipped from narrative."
+        ]
+        skipped = True
+        md = ""
+    elif not populated:
+        facts.append(
+            "All entries have empty payloads — collector ran but the underlying "
+            "state arrays were never populated (older Hyperloom build)."
+        )
+        warnings = [
+            "critic_robustness has entries but every payload is empty; the "
+            "section is non-actionable for this session."
+        ]
+        skipped = True
+        md = ""
+    else:
+        warnings = []
+        skipped = False
+        head = populated[:_MAX_ROWS]
+        rows = []
+        for c in head:
+            rows.append([
+                c.get("ts") or "",
+                c.get("action") or "",
+                c.get("decision") or "",
+                c.get("pass_count"),
+                c.get("fail_count"),
+                (c.get("rationale") or c.get("response") or "")[:80],
+            ])
+        md = md_table(
+            ["ts", "action", "decision", "pass", "fail", "rationale (truncated)"],
+            rows,
+        )
+        if len(populated) > _MAX_ROWS:
+            md = f"_Showing first {_MAX_ROWS} of {len(populated)} populated entries._\n\n" + md
+
+    return RenderedSection(
+        section_id="critic_robustness",
+        title="Critic Robustness",
+        key_facts=facts,
+        markdown_block=md,
+        warnings=warnings,
+        skipped=skipped,
+    )

--- a/inference_optimizer/breakdown/reporters/_renderers/final.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/final.py
@@ -1,0 +1,94 @@
+"""Final / validated result renderer."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..base import (
+    Decision,
+    RenderedSection,
+    fmt_pct,
+    md_kv_list,
+    register_renderer,
+)
+
+
+@register_renderer("final")
+def render(breakdown: dict[str, Any]) -> RenderedSection:
+    f = breakdown.get("final") or {}
+    b = breakdown.get("baseline") or {}
+    final_tput = f.get("throughput_tok_s_per_gpu")
+    base_tput = b.get("throughput_tok_s_per_gpu")
+    gain_v = f.get("cumulative_gain_pct_validated")
+    gain_round = f.get("cumulative_gain_pct_per_round_sum")
+    val_stack_len = f.get("validated_at_stack_len")
+    val_ts = f.get("validated_ts")
+    stack_changed = bool(f.get("stack_changed_after_validation"))
+    extra_args = f.get("extra_sglang_args") or ""
+    action_path = f.get("action_path") or []
+
+    facts: list[str] = []
+    warnings: list[str] = []
+    decisions: list[Decision] = []
+
+    if final_tput:
+        facts.append(f"Final throughput: {float(final_tput):.2f} tok/s/gpu.")
+    if base_tput and final_tput:
+        delta = float(final_tput) - float(base_tput)
+        facts.append(f"Delta vs baseline: {delta:+.2f} tok/s/gpu.")
+    if gain_v is not None:
+        facts.append(f"Validated cumulative gain: {fmt_pct(gain_v, plus=True)}.")
+        decisions.append(Decision(
+            kind="kept" if (gain_v or 0) > 0 else "attempted",
+            subject="final",
+            metric_pct=float(gain_v),
+            rationale=f"validated at stack_len={val_stack_len} ts={val_ts}",
+        ))
+    if gain_round is not None:
+        facts.append(
+            f"Per-round summed gain: {fmt_pct(gain_round)} "
+            "(non-additive, do not present as the user-visible number)."
+        )
+    if action_path:
+        facts.append(
+            "Final stack: " + " → ".join(f"`{p}`" for p in action_path)
+        )
+    if extra_args:
+        facts.append(f"Final extra_sglang_args: `{extra_args}`.")
+    if stack_changed:
+        warnings.append(
+            "stack_changed_after_validation = true — optimization_stack grew "
+            "after the last successful validate_stack run, so the reported "
+            "cumulative_gain_pct_validated may be stale relative to the "
+            "current best."
+        )
+    if gain_v is None and (final_tput or base_tput):
+        warnings.append(
+            "cumulative_gain_pct_validated is null while baseline/final "
+            "throughput are set — validate_stack never ran or the snapshot "
+            "predates V2."
+        )
+
+    md = md_kv_list([
+        ("final_throughput_tok_s_per_gpu", final_tput),
+        ("cumulative_gain_pct_validated",  gain_v),
+        ("cumulative_gain_pct_per_round_sum", gain_round),
+        ("validated_at_stack_len",         val_stack_len),
+        ("validated_ts",                   val_ts),
+        ("stack_changed_after_validation", stack_changed),
+        ("extra_sglang_args",              extra_args or None),
+        ("action_path",                    action_path or None),
+        ("ttft_mean_ms",                   f.get("ttft_mean_ms")),
+        ("e2el_mean_ms",                   f.get("e2el_mean_ms")),
+        ("extra_envs",                     f.get("extra_envs") or None),
+    ])
+
+    return RenderedSection(
+        section_id="final",
+        title="Final Result",
+        key_facts=facts,
+        markdown_block=md,
+        decisions=decisions,
+        warnings=warnings,
+        skipped=not (final_tput or gain_v),
+    )

--- a/inference_optimizer/breakdown/reporters/_renderers/invocations.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/invocations.py
@@ -1,0 +1,123 @@
+"""GEAK + OOB invocation renderer.
+
+Both capabilities share the same shape (attempts list keyed by kernel
+id, decisions per attempt), so this is one renderer producing TWO
+section ids — done with two thin wrappers, each delegating to a
+common ``_render_pair`` so future fields propagate to both.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..base import Decision, RenderedSection, md_table, register_renderer
+
+_MAX_ATTEMPT_ROWS = 25
+
+
+def _render_pair(
+    breakdown: dict[str, Any],
+    *,
+    section_id: str,
+    title: str,
+    invocations_key: str,
+    legacy_key: str,
+) -> RenderedSection:
+    """Render either GEAK or OOB invocations.
+
+    Reads ``breakdown["invocations"][invocations_key]`` (new schema) or
+    falls back to ``breakdown[legacy_key]`` (old schema) so this also
+    works against breakdowns dumped from older exporter versions.
+    """
+    raw = (
+        (breakdown.get("invocations") or {}).get(invocations_key)
+        or breakdown.get(legacy_key)
+        or []
+    )
+    # Defensive normalization: real wekafs sessions occasionally store
+    # plain strings (kernel ids) instead of dicts. Treat string entries
+    # as bare attempts with kernel_id=<string> so the rest of this
+    # renderer is uniform.
+    invs: list[dict[str, Any]] = []
+    for v in raw:
+        if isinstance(v, dict):
+            invs.append(v)
+        else:
+            invs.append({"kernel_id": str(v)})
+    if not invs:
+        return RenderedSection(
+            section_id=section_id,
+            title=title,
+            key_facts=[
+                f"`{section_id}` never invoked this session — no attempts on disk."
+            ],
+            markdown_block="",
+            decisions=[Decision(
+                kind="not_attempted",
+                subject=section_id,
+                rationale="no attempts found in session_breakdown",
+            )],
+            warnings=[],
+            skipped=True,
+        )
+
+    keeps = sum(1 for v in invs if v.get("decision") == "KEEP")
+    failed = sum(1 for v in invs if v.get("decision") in ("FAILED", "ERROR"))
+    decisions = [Decision(
+        kind="kept" if keeps else ("attempted" if invs else "not_attempted"),
+        subject=section_id,
+        metric_pct=None,
+        rationale=f"{keeps} KEEP / {failed} FAILED across {len(invs)} attempts",
+    )]
+    facts = [
+        f"{section_id}: {len(invs)} invocation(s), {keeps} KEEP, {failed} FAILED.",
+    ]
+    head = invs[-_MAX_ATTEMPT_ROWS:] if len(invs) > _MAX_ATTEMPT_ROWS else invs
+    rows = []
+    for v in head:
+        rows.append([
+            v.get("ts") or "",
+            v.get("kernel_id") or v.get("kernel_name") or "",
+            v.get("decision") or "",
+            v.get("micro_speedup") or "",
+            v.get("workspace") or v.get("workspace_path") or "",
+            (v.get("error") or "")[:80],
+        ])
+    md = md_table(
+        ["ts", "kernel_id", "decision", "micro_speedup", "workspace", "error"],
+        rows,
+    )
+    if len(invs) > _MAX_ATTEMPT_ROWS:
+        md = f"_Showing last {_MAX_ATTEMPT_ROWS} of {len(invs)} attempts._\n\n" + md
+
+    return RenderedSection(
+        section_id=section_id,
+        title=title,
+        key_facts=facts,
+        markdown_block=md,
+        decisions=decisions,
+        warnings=[],
+        skipped=False,
+    )
+
+
+@register_renderer("geak_invocations")
+def render_geak(breakdown: dict[str, Any]) -> RenderedSection:
+    return _render_pair(
+        breakdown,
+        section_id="geak_invocations",
+        title="GEAK Invocations",
+        invocations_key="geak",
+        legacy_key="geak_invocations",
+    )
+
+
+@register_renderer("oob_invocations")
+def render_oob(breakdown: dict[str, Any]) -> RenderedSection:
+    return _render_pair(
+        breakdown,
+        section_id="oob_invocations",
+        title="OOB Invocations",
+        invocations_key="oob",
+        legacy_key="oob_invocations",
+    )

--- a/inference_optimizer/breakdown/reporters/_renderers/kernel_lifecycle.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/kernel_lifecycle.py
@@ -1,0 +1,257 @@
+"""Kernel lifecycle renderer.
+
+Single table view: **every** detected kernel as one row with its full
+optimization lifecycle. Columns mirror the MAE dashboard contract so
+downstream consumers (TraceLens team in particular) get the same data
+they used to scrape out of MAE events:
+
+* ``kernel_id``, ``name`` (truncated to keep the table readable)
+* ``gpu_pct``        — share of GPU time on baseline trace
+* ``duration_us``    — wall time the kernel held the GPU (μs)
+* ``call_count``     — number of times the kernel was launched
+* ``bandwidth%`` / ``compute%`` — roofline utilization
+* ``selected``       — did the orchestrator route it into kernel
+                       optimization? (top-15 in last_select_kernels)
+* ``geak_speedup``   — best micro-speedup the GEAK lane achieved
+                       (None = lane never touched this kernel)
+* ``oob_speedup``    — best micro-speedup the OOB lane achieved
+* ``adopted_by``     — which lane's patch ended up in the final stack
+* ``final``          — ``kept`` / ``reverted`` / ``rejected`` /
+                       ``attempted`` / ``not_optimized``
+
+Skipped entirely when the kernel pipeline did not detect any kernels
+(rare — implies the profile phase never ran).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..base import (
+    Decision,
+    RenderedSection,
+    fmt_pct,
+    md_table,
+    register_renderer,
+)
+
+_MAX_NAME_LEN = 70
+
+
+def _short_name(name: str) -> str:
+    """Shorten a kernel name keeping head + tail.
+
+    A naive head-truncation made many CK/ROCBLAS kernels look
+    identical in the table because the discriminating template
+    arguments live at the tail of the symbol. Keeping both ends
+    (with ``…`` in the middle) lets the reader tell variants apart
+    without making the column too wide.
+    """
+    if not name:
+        return ""
+    if len(name) <= _MAX_NAME_LEN:
+        return name
+    head = _MAX_NAME_LEN // 2 - 1
+    tail = _MAX_NAME_LEN - head - 3
+    return name[:head] + "..." + name[-tail:]
+
+
+def _fmt_speedup(v: Any) -> str:
+    if v is None:
+        return "—"
+    try:
+        x = float(v)
+    except (TypeError, ValueError):
+        return "—"
+    return f"{x:.2f}x"
+
+
+def _lane_summary(lane: dict[str, Any] | None) -> str:
+    """Format a per-lane summary cell: best-speedup + attempts + last decision."""
+    if not lane:
+        return "—"
+    spd = _fmt_speedup(lane.get("best_speedup"))
+    att = int(lane.get("attempts") or 0)
+    dec = lane.get("decision") or ""
+    parts = [spd]
+    if att:
+        parts.append(f"({att} att)")
+    if dec:
+        parts.append(f"[{dec}]")
+    return " ".join(parts)
+
+
+@register_renderer("kernel_lifecycle")
+def render(breakdown: dict[str, Any]) -> RenderedSection:
+    kl = breakdown.get("kernel_lifecycle") or {}
+    raw_detected = kl.get("detected") or []
+    detected: list[dict[str, Any]] = []
+    for d in raw_detected:
+        if not isinstance(d, dict):
+            detected.append({"kernel_id": str(d)})
+            continue
+        if not d.get("kernel_id"):
+            # Filter out anonymous placeholder rows (older collector
+            # versions occasionally produced these from kernel_summary
+            # entries with neither name nor id).
+            continue
+        detected.append(d)
+
+    if not detected:
+        return RenderedSection(
+            section_id="kernel_lifecycle",
+            title="Kernel Lifecycle",
+            key_facts=["No kernels detected this session."],
+            markdown_block="",
+            decisions=[Decision(
+                kind="not_attempted",
+                subject="kernel_lifecycle",
+                rationale="no detected kernels",
+            )],
+            warnings=[],
+            skipped=True,
+        )
+
+    selected = sum(1 for d in detected if d.get("selected_for_optimization"))
+    geak_touched = sum(1 for d in detected if d.get("geak"))
+    oob_touched = sum(1 for d in detected if d.get("oob"))
+    adopted = [d for d in detected if d.get("final_decision") == "kept"]
+    reverted = [d for d in detected if d.get("final_decision") == "reverted"]
+    rejected = [d for d in detected if d.get("final_decision") == "rejected"]
+    attempted = [d for d in detected if d.get("final_decision") == "attempted"]
+
+    facts: list[str] = []
+    facts.append(
+        f"{len(detected)} kernel(s) detected, {selected} selected for "
+        f"optimization, GEAK touched {geak_touched}, OOB touched "
+        f"{oob_touched}, adopted={len(adopted)}, reverted={len(reverted)}, "
+        f"rejected={len(rejected)}, attempted-no-decision={len(attempted)}."
+    )
+    if selected and not (geak_touched or oob_touched):
+        facts.append(
+            "Kernels were selected for optimization but neither GEAK nor "
+            "OOB lane recorded an attempt — kernel optimization pipeline "
+            "stalled before launch."
+        )
+    if adopted:
+        names = ", ".join(
+            f"`{d.get('kernel_id')}`→{d.get('adopted_by') or '?'}"
+            for d in adopted[:5]
+        )
+        facts.append(f"Adopted kernels: {names}.")
+
+    decisions: list[Decision] = []
+    if adopted:
+        decisions.append(Decision(
+            kind="kept", subject="kernel_lifecycle:adopted",
+            rationale=f"{len(adopted)} kernel patches adopted",
+        ))
+    if reverted:
+        decisions.append(Decision(
+            kind="reverted", subject="kernel_lifecycle:reverted",
+            rationale=f"{len(reverted)} kernel patches reverted after integrate",
+        ))
+    if rejected:
+        decisions.append(Decision(
+            kind="rejected", subject="kernel_lifecycle:rejected",
+            rationale=f"{len(rejected)} kernel patches rejected outright",
+        ))
+    if not adopted and not reverted and not rejected and not attempted:
+        decisions.append(Decision(
+            kind="not_attempted",
+            subject="kernel_lifecycle",
+            rationale=(
+                f"all {len(detected)} detected kernels left un-optimized "
+                "(neither GEAK nor OOB attempted)"
+            ),
+        ))
+
+    # Drop bw% / compute% columns when every entry is None/0 — keeps
+    # the table compact on workloads where the trace doesn't carry
+    # roofline data (the common case on real wekafs sessions).
+    show_bw = any(d.get("bandwidth_util_pct") for d in detected)
+    show_compute = any(d.get("compute_util_pct") for d in detected)
+
+    headers: list[str] = ["kernel_id", "name", "gpu%", "duration_us", "calls"]
+    if show_bw:
+        headers.append("bw%")
+    if show_compute:
+        headers.append("compute%")
+    headers += ["selected", "GEAK", "OOB", "adopted_by", "final"]
+
+    def _row_for(d: dict[str, Any]) -> list[Any]:
+        row: list[Any] = [
+            d.get("kernel_id") or "—",
+            _short_name(d.get("name") or ""),
+            d.get("gpu_pct"),
+            d.get("duration_us"),
+            d.get("call_count"),
+        ]
+        if show_bw:
+            row.append(d.get("bandwidth_util_pct"))
+        if show_compute:
+            row.append(d.get("compute_util_pct"))
+        row += [
+            "yes" if d.get("selected_for_optimization") else "no",
+            _lane_summary(d.get("geak")),
+            _lane_summary(d.get("oob")),
+            d.get("adopted_by") or "—",
+            d.get("final_decision") or "—",
+        ]
+        return row
+
+    # Partition into "actionable" (selected for optimization, OR touched
+    # by GEAK / OOB, OR with a final decision other than not_optimized)
+    # vs. "residual" (long-tail kernels the orchestrator left alone).
+    # Residual rows go into a collapsible <details> block so the
+    # default view stays focused on what mattered for optimization.
+    actionable: list[dict[str, Any]] = []
+    residual: list[dict[str, Any]] = []
+    for d in detected:
+        if (
+            d.get("selected_for_optimization")
+            or d.get("geak")
+            or d.get("oob")
+            or (d.get("final_decision") and d["final_decision"] != "not_optimized")
+        ):
+            actionable.append(d)
+        else:
+            residual.append(d)
+
+    parts: list[str] = []
+    if actionable:
+        parts.append(md_table(headers, [_row_for(d) for d in actionable]))
+    else:
+        parts.append(
+            "_No kernel was selected for optimization, and neither "
+            "GEAK nor OOB recorded an attempt. The kernel optimization "
+            "pipeline did not run on this session._"
+        )
+    if residual:
+        total_dur = sum((d.get("duration_us") or 0.0) for d in residual)
+        total_gpu = sum((d.get("gpu_pct") or 0.0) for d in residual)
+        # Collapsible block. GitHub-flavored markdown renders <details>
+        # / <summary> as a clickable expander; the inner blank lines
+        # are required so the table inside still parses as markdown.
+        parts.append("")
+        parts.append(
+            f"<details><summary>Show {len(residual)} residual kernels "
+            f"not selected for optimization "
+            f"(Σ duration_us={total_dur:.0f}, Σ gpu%={total_gpu:.2f}%)"
+            "</summary>"
+        )
+        parts.append("")
+        parts.append(md_table(headers, [_row_for(d) for d in residual]))
+        parts.append("")
+        parts.append("</details>")
+    md = "\n".join(parts)
+
+    return RenderedSection(
+        section_id="kernel_lifecycle",
+        title="Kernel Lifecycle",
+        key_facts=facts,
+        markdown_block=md,
+        decisions=decisions,
+        warnings=[],
+        skipped=False,
+    )

--- a/inference_optimizer/breakdown/reporters/_renderers/param_search.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/param_search.py
@@ -1,0 +1,101 @@
+"""Parameter / backend DFS state renderer."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..base import RenderedSection, md_table, register_renderer
+
+
+@register_renderer("param_search")
+def render(breakdown: dict[str, Any]) -> RenderedSection:
+    ps = breakdown.get("param_search") or {}
+    backends = ps.get("backends") or {}
+    params = ps.get("params") or {}
+    flags = ps.get("discovered_flags") or {}
+    winners = ps.get("backend_winners_history") or []
+    synergy = ps.get("synergy_attempted") or []
+
+    backends_accepted = len((backends.get("accepted") or []) if isinstance(backends, dict) else [])
+    backends_tested = len((backends.get("tested") or {}) if isinstance(backends, dict) else {})
+    params_accepted = len((params.get("accepted") or []) if isinstance(params, dict) else [])
+    params_tested = len((params.get("tested") or {}) if isinstance(params, dict) else {})
+
+    facts: list[str] = []
+    facts.append(
+        f"backends DFS: tested={backends_tested}, accepted={backends_accepted}"
+    )
+    facts.append(
+        f"params DFS: tested={params_tested}, accepted={params_accepted}"
+    )
+    if winners:
+        facts.append(f"backend_winners_history: {len(winners)} round(s).")
+    if synergy:
+        facts.append(f"synergy_attempted combos: {len(synergy)}.")
+    if not flags:
+        facts.append("discovered_flags: empty (framework AST never parsed).")
+    else:
+        for k, v in flags.items():
+            if isinstance(v, dict):
+                nb = len(v.get("backend_flags") or [])
+                np = len(v.get("param_flags") or [])
+                facts.append(
+                    f"discovered_flags[{k}]: backend={nb}, param={np}, "
+                    f"source={v.get('source_path') or '?'}"
+                )
+
+    md_parts: list[str] = []
+    md_parts.append("**Backends DFS:**")
+    md_parts.append(md_table(
+        ["accepted", "tested", "cursor", "last_round"],
+        [[backends_accepted, backends_tested,
+          (backends.get("cursor") if isinstance(backends, dict) else None),
+          (backends.get("last_round") if isinstance(backends, dict) else None)]],
+    ))
+    md_parts.append("")
+    md_parts.append("**Params DFS:**")
+    md_parts.append(md_table(
+        ["accepted", "tested", "cursor", "last_round"],
+        [[params_accepted, params_tested,
+          (params.get("cursor") if isinstance(params, dict) else None),
+          (params.get("last_round") if isinstance(params, dict) else None)]],
+    ))
+
+    if winners:
+        md_parts.append("")
+        md_parts.append(f"**Backend winners history** (last 5 of {len(winners)}):")
+        rows = []
+        for w in winners[-5:]:
+            rows.append([
+                w.get("round_id"), w.get("action"),
+                w.get("base_tput"),
+                ((w.get("best") or {}).get("name") if isinstance(w.get("best"), dict) else None),
+                ((w.get("best") or {}).get("gain_pct") if isinstance(w.get("best"), dict) else None),
+                w.get("ts"),
+            ])
+        md_parts.append(md_table(
+            ["round", "action", "base_tput", "best_name", "best_gain_pct", "ts"],
+            rows,
+        ))
+
+    if synergy:
+        md_parts.append("")
+        md_parts.append("**Synergy combos attempted**: "
+                        + ", ".join(f"`{c}`" for c in synergy[:20]))
+        if len(synergy) > 20:
+            md_parts[-1] += f" (+{len(synergy)-20} more)"
+
+    no_search_data = (
+        not winners and not synergy and not flags
+        and backends_accepted == 0 and backends_tested == 0
+        and params_accepted == 0 and params_tested == 0
+    )
+
+    return RenderedSection(
+        section_id="param_search",
+        title="Parameter / Backend Search",
+        key_facts=facts,
+        markdown_block="\n".join(md_parts).strip(),
+        warnings=[],
+        skipped=no_search_data,
+    )

--- a/inference_optimizer/breakdown/reporters/_renderers/phase_timeline.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/phase_timeline.py
@@ -1,0 +1,72 @@
+"""Phase timeline renderer — chronological action events.
+
+We cap the table at 30 entries (newest last) to keep the report
+readable. The deterministic markdown block still shows total count so
+operators know the table is truncated.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..base import RenderedSection, md_table, register_renderer
+
+_MAX_ROWS = 30
+
+
+@register_renderer("phase_timeline")
+def render(breakdown: dict[str, Any]) -> RenderedSection:
+    raw_pt = breakdown.get("phase_timeline") or []
+    pt: list[dict[str, Any]] = [
+        ev if isinstance(ev, dict) else {"action": str(ev)} for ev in raw_pt
+    ]
+    if not pt:
+        return RenderedSection(
+            section_id="phase_timeline",
+            title="Phase Timeline",
+            key_facts=[],
+            markdown_block="",
+            warnings=[
+                "phase_timeline empty — no per-tick action events captured. "
+                "Without this, process reconstruction and timing analysis are "
+                "unavailable; the LLM cannot narrate how the run unfolded "
+                "tick-by-tick."
+            ],
+            skipped=True,
+        )
+
+    facts: list[str] = [
+        f"Recorded {len(pt)} phase event(s); newest = `{pt[-1].get('action')}` "
+        f"({pt[-1].get('decision') or 'no-decision'})."
+    ]
+    head = pt[-_MAX_ROWS:] if len(pt) > _MAX_ROWS else pt
+    rows = []
+    for ev in head:
+        rows.append([
+            ev.get("ts") or ev.get("timestamp") or "",
+            ev.get("action") or "",
+            ev.get("decision") or "",
+            ev.get("task_id") or ev.get("variant_name") or "",
+            ev.get("error_class") or "",
+        ])
+    md = md_table(["ts", "action", "decision", "task / variant", "error_class"], rows)
+    if len(pt) > _MAX_ROWS:
+        md = f"_Showing last {_MAX_ROWS} of {len(pt)} events._\n\n" + md
+
+    # Per-decision histogram, useful at a glance.
+    histo: dict[str, int] = {}
+    for ev in pt:
+        d = str(ev.get("decision") or "(none)")
+        histo[d] = histo.get(d, 0) + 1
+    facts.append("Decision histogram: " + ", ".join(
+        f"{k}={v}" for k, v in sorted(histo.items(), key=lambda kv: -kv[1])
+    ))
+
+    return RenderedSection(
+        section_id="phase_timeline",
+        title="Phase Timeline",
+        key_facts=facts,
+        markdown_block=md,
+        warnings=[],
+        skipped=False,
+    )

--- a/inference_optimizer/breakdown/reporters/_renderers/session.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/session.py
@@ -1,0 +1,87 @@
+"""Session identification + lifecycle renderer.
+
+Surfaces just enough of the ``session`` section so the report header
+is self-contained: session_id, claw join keys, host, code revision,
+stop reason, elapsed time. Workload (model / framework / GPU / TP /
+ISL / OSL) lives in its own section.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..base import Decision, RenderedSection, md_kv_list, register_renderer
+
+
+@register_renderer("session")
+def render(breakdown: dict[str, Any]) -> RenderedSection:
+    s = breakdown.get("session") or {}
+    facts: list[str] = []
+    warnings: list[str] = []
+
+    sid = str(s.get("session_id") or "")
+    claw = s.get("claw_session_id")
+    sandbox = s.get("sandbox_user_id")
+    stop_reason = str(s.get("stop_reason") or "")
+    elapsed = s.get("elapsed_minutes")
+    host = str(s.get("host") or "")
+    code = str(s.get("code_revision") or "")
+    tick = s.get("tick_count")
+
+    if sid:
+        facts.append(f"Hyperloom session_id=`{sid}`")
+    if claw:
+        facts.append(f"Joined to Primus-Claw session `{claw}`")
+    else:
+        facts.append(
+            "No claw_session_id recorded — this is a standalone "
+            "Hyperloom run or a pre-V2 session."
+        )
+    if sandbox:
+        facts.append(f"Sandbox user `{sandbox}`")
+    if stop_reason:
+        facts.append(f"Run ended with stop_reason=`{stop_reason}`.")
+    if elapsed is not None:
+        facts.append(f"Wall-clock elapsed: {float(elapsed):.1f} minutes.")
+    if tick and int(tick) > 0:
+        facts.append(f"Coordinator advanced through {int(tick)} ticks.")
+    elif tick == 0:
+        warnings.append(
+            "tick_count = 0 — Coordinator either resumed without a fresh "
+            "scheduler loop or this session predates per-tick counters."
+        )
+    if host:
+        facts.append(f"Ran on host `{host}`.")
+    if code:
+        facts.append(f"Hyperloom code revision `{code}`.")
+
+    md = md_kv_list([
+        ("session_id",       sid),
+        ("claw_session_id",  claw),
+        ("sandbox_user_id",  sandbox),
+        ("stop_reason",      stop_reason or None),
+        ("elapsed_minutes",  elapsed),
+        ("tick_count",       tick),
+        ("host",             host or None),
+        ("code_revision",    code or None),
+        ("created_at_utc",   s.get("created_at_utc")),
+        ("ended_at_utc",     s.get("ended_at_utc")),
+        ("max_minutes",      s.get("max_minutes")),
+        ("session_dir",      s.get("session_dir")),
+    ])
+
+    decisions = [Decision(
+        kind="attempted" if stop_reason else "not_attempted",
+        subject=f"session:{sid or 'unknown'}",
+        rationale=f"stop_reason={stop_reason or 'unset'}",
+    )] if sid else []
+
+    return RenderedSection(
+        section_id="session",
+        title="Session",
+        key_facts=facts,
+        markdown_block=md,
+        decisions=decisions,
+        warnings=warnings,
+        skipped=not (sid or host),
+    )

--- a/inference_optimizer/breakdown/reporters/_renderers/source_files.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/source_files.py
@@ -1,0 +1,43 @@
+"""Source-files manifest renderer — what files this breakdown was
+built from. Helps operators replay or audit a session.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..base import RenderedSection, md_table, register_renderer
+
+
+@register_renderer("source_files")
+def render(breakdown: dict[str, Any]) -> RenderedSection:
+    sf = breakdown.get("source_files") or {}
+    if not sf:
+        return RenderedSection(
+            section_id="source_files",
+            title="Source Files",
+            key_facts=[],
+            markdown_block="",
+            skipped=True,
+        )
+
+    rows = []
+    for k, v in sorted(sf.items()):
+        if isinstance(v, list):
+            preview = ", ".join(str(x) for x in v[:3]) if v else "—"
+            rows.append([k, len(v), preview])
+        elif v in (None, "", []):
+            # Skip empty entries entirely rather than rendering ``—`` /
+            # ``—`` rows that add visual noise without information.
+            continue
+        else:
+            rows.append([k, "1", str(v)])
+    md = md_table(["kind", "count", "first values"], rows)
+    facts = [f"source_files manifest captures {len(rows)} file kind(s)."]
+    return RenderedSection(
+        section_id="source_files",
+        title="Source Files",
+        key_facts=facts,
+        markdown_block=md,
+        skipped=False,
+    )

--- a/inference_optimizer/breakdown/reporters/_renderers/sweep.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/sweep.py
@@ -1,0 +1,97 @@
+"""Sweep matrix renderer.
+
+Sweeps are concurrency / ISL-OSL grids run on the final stack so users
+can see end-of-session frontier coverage. The renderer surfaces:
+
+* grid size, accepted vs failed count,
+* the best (highest output_throughput) point,
+* all variants in a small table (truncated to 50 rows).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..base import Decision, RenderedSection, md_table, register_renderer
+
+_MAX_ROWS = 50
+
+
+@register_renderer("sweep")
+def render(breakdown: dict[str, Any]) -> RenderedSection:
+    sw = breakdown.get("sweep") or {}
+    raw_variants = sw.get("all_variants") or []
+    variants: list[dict[str, Any]] = [
+        v if isinstance(v, dict) else {"raw": str(v)} for v in raw_variants
+    ]
+    if not variants:
+        return RenderedSection(
+            section_id="sweep",
+            title="Sweep",
+            key_facts=["No sweep run this session."],
+            markdown_block="",
+            decisions=[Decision(
+                kind="not_attempted",
+                subject="sweep",
+                rationale="no sweep variants captured",
+            )],
+            warnings=[],
+            skipped=True,
+        )
+
+    grid_size = sw.get("grid_size") or len(variants)
+    successes = [v for v in variants if v.get("status") == "success"]
+    failures = [v for v in variants if v.get("status") != "success"]
+
+    def _ot(v: dict[str, Any]) -> float:
+        try:
+            return float(v.get("output_throughput") or 0.0)
+        except (TypeError, ValueError):
+            return 0.0
+
+    best = max(successes, key=_ot, default=None)
+
+    facts: list[str] = []
+    facts.append(
+        f"Sweep grid={grid_size}, success={len(successes)}, failed={len(failures)}."
+    )
+    if best:
+        facts.append(
+            f"Best point: conc={best.get('conc')} isl={best.get('isl')} "
+            f"osl={best.get('osl')} → tput={best.get('output_throughput')} "
+            f"ttft={best.get('ttft')}ms"
+        )
+
+    decisions: list[Decision] = [Decision(
+        kind="kept" if best else "attempted",
+        subject="sweep",
+        rationale=f"{len(successes)}/{grid_size} variants succeeded",
+    )]
+
+    head = variants[:_MAX_ROWS]
+    rows = []
+    for v in head:
+        rows.append([
+            v.get("conc"), v.get("isl"), v.get("osl"),
+            v.get("status"),
+            v.get("output_throughput"),
+            v.get("ttft"),
+            v.get("e2el"),
+            (v.get("error") or "")[:60],
+        ])
+    md = md_table(
+        ["conc", "isl", "osl", "status", "tput", "ttft", "e2el", "error"],
+        rows,
+    )
+    if len(variants) > _MAX_ROWS:
+        md = f"_Showing first {_MAX_ROWS} of {len(variants)} variants._\n\n" + md
+
+    return RenderedSection(
+        section_id="sweep",
+        title="Sweep",
+        key_facts=facts,
+        markdown_block=md,
+        decisions=decisions,
+        warnings=[],
+        skipped=False,
+    )

--- a/inference_optimizer/breakdown/reporters/_renderers/workload.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/workload.py
@@ -1,0 +1,70 @@
+"""Workload renderer — model / framework / GPU / shape / objective."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..base import RenderedSection, md_kv_list, register_renderer
+
+
+@register_renderer("workload")
+def render(breakdown: dict[str, Any]) -> RenderedSection:
+    w = breakdown.get("workload") or {}
+    facts: list[str] = []
+    warnings: list[str] = []
+
+    model = w.get("model_name") or ""
+    fw = w.get("framework") or ""
+    fw_v = w.get("framework_version") or ""
+    gpu = w.get("gpu_type") or ""
+    tp = w.get("tp")
+    conc = w.get("conc")
+    isl = w.get("isl")
+    osl = w.get("osl")
+    mml = w.get("max_model_len")
+    prec = w.get("precision") or ""
+    obj = w.get("objective") or {}
+
+    if model:
+        facts.append(f"Model: `{model}` (path={w.get('model_path') or '?'}).")
+    if fw:
+        facts.append(f"Framework: `{fw}` {f'(v={fw_v})' if fw_v else ''}".strip())
+    if gpu:
+        facts.append(f"GPU: `{gpu}`.")
+    else:
+        warnings.append(
+            "gpu_type missing — manifest did not stamp GPU_TYPE; downstream "
+            "dashboards may show empty hardware fields."
+        )
+    facts.append(
+        f"Shape: tp={tp}, conc={conc}, isl={isl}, osl={osl}, max_model_len={mml}, "
+        f"precision={prec or '?'}."
+    )
+    if obj:
+        facts.append(
+            f"Objective: {obj.get('kind') or '?'}={obj.get('value')}."
+        )
+
+    md = md_kv_list([
+        ("model_name",      model),
+        ("model_path",      w.get("model_path")),
+        ("model_class",     w.get("model_class")),
+        ("framework",       fw),
+        ("framework_version", fw_v or None),
+        ("gpu_type",        gpu or None),
+        ("tp",              tp),
+        ("conc",            conc),
+        ("isl",             isl),
+        ("osl",             osl),
+        ("max_model_len",   mml),
+        ("precision",       prec or None),
+        ("objective",       obj or None),
+    ])
+    return RenderedSection(
+        section_id="workload",
+        title="Workload",
+        key_facts=facts,
+        markdown_block=md,
+        warnings=warnings,
+        skipped=not (model or fw),
+    )

--- a/inference_optimizer/breakdown/reporters/base.py
+++ b/inference_optimizer/breakdown/reporters/base.py
@@ -1,0 +1,178 @@
+"""Shared data structures + registry for ``session_breakdown`` section
+renderers.
+
+A *renderer* is a deterministic function that takes one section of the
+``session_breakdown.json`` dict and produces a :class:`RenderedSection`.
+The compose layer collects every renderer's output, optionally hands the
+``key_facts`` / ``decisions`` to an LLM for narrative connecting, and
+stitches the result back together with the deterministic markdown blocks
+unchanged.
+
+Why this layering exists:
+
+* The numbers (throughputs, gains, kernel counts, paths) MUST be
+  deterministic — the LLM has historically hallucinated them
+  (``715.2%`` gain attributed to GEAK on a session that never ran
+  GEAK, ``MI355X`` written into a report for an MI300X run, etc.).
+* The LLM is good at prose connecting / interpretation, so it is only
+  allowed to talk *about* the facts in ``key_facts``; the system
+  prompt enforces "do not invent numbers".
+* Every renderer is independently testable against a synthetic
+  ``session_breakdown.json`` fixture, and the compose layer is
+  testable with the LLM swapped out.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable
+
+__all__ = [
+    "Decision",
+    "RenderedSection",
+    "RendererFn",
+    "REGISTRY",
+    "register_renderer",
+    "renderer_names",
+]
+
+
+@dataclass(frozen=True)
+class Decision:
+    """One structured verdict surfaced by a renderer.
+
+    ``kind`` is a small, well-known vocabulary so downstream consumers
+    (UI badges, dashboards, the LLM prompt) can render verdicts without
+    parsing free-form strings.
+
+    Vocabulary:
+
+    * ``"kept"``          — capability / action produced a promoted entry.
+    * ``"reverted"``      — applied + then rolled back (e.g. integrate REVERT).
+    * ``"rejected"``      — rejected without applying (e.g. patch fail).
+    * ``"partial"``       — passed compile / correctness but no speedup.
+    * ``"attempted"``     — ran but no decision recorded yet.
+    * ``"not_attempted"`` — capability never invoked this session.
+    """
+
+    kind: str
+    subject: str
+    metric_pct: float | None = None
+    rationale: str = ""
+
+
+@dataclass(frozen=True)
+class RenderedSection:
+    """A single section's render output.
+
+    The compose layer guarantees ``markdown_block`` is preserved
+    verbatim; the LLM only sees ``key_facts`` + ``decisions`` +
+    ``warnings`` and is forbidden from rewriting numbers.
+
+    ``skipped`` is the renderer's signal to "do not narrate this
+    section at all" — used for sections whose underlying capability
+    was not exercised (e.g. ``sweep`` when the session never ran a
+    sweep). The compose layer renders a one-line "not run this
+    session" note instead of a full section block.
+    """
+
+    section_id: str
+    title: str
+    key_facts: list[str] = field(default_factory=list)
+    markdown_block: str = ""
+    decisions: list[Decision] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    skipped: bool = False
+
+
+RendererFn = Callable[[dict[str, Any]], RenderedSection]
+
+
+# Module-level registry. Renderers register themselves at import time
+# via the @register_renderer decorator; compose.py walks this list in
+# insertion order so the final report's section ordering is stable.
+REGISTRY: list[tuple[str, RendererFn]] = []
+
+
+def register_renderer(section_id: str) -> Callable[[RendererFn], RendererFn]:
+    """Decorator: append ``fn`` to :data:`REGISTRY` under ``section_id``.
+
+    Re-registration replaces the prior entry (so reload-in-place during
+    development stays sane), which is why we walk + replace instead of
+    append-only.
+    """
+
+    def _wrap(fn: RendererFn) -> RendererFn:
+        for i, (sid, _) in enumerate(REGISTRY):
+            if sid == section_id:
+                REGISTRY[i] = (section_id, fn)
+                return fn
+        REGISTRY.append((section_id, fn))
+        return fn
+
+    return _wrap
+
+
+def renderer_names() -> list[str]:
+    return [sid for sid, _ in REGISTRY]
+
+
+# ---------------------------------------------------------------------------
+# Small markdown helpers — kept here so individual renderers stay terse.
+# ---------------------------------------------------------------------------
+def md_table(headers: list[str], rows: Iterable[list[Any]]) -> str:
+    """Render a GitHub-flavored markdown table; empty rows yield ``""``."""
+    rows = list(rows)
+    if not rows:
+        return ""
+    out = ["| " + " | ".join(headers) + " |",
+           "|" + "|".join("---" for _ in headers) + "|"]
+    for r in rows:
+        out.append("| " + " | ".join(_md_cell(c) for c in r) + " |")
+    return "\n".join(out)
+
+
+def md_kv_list(items: list[tuple[str, Any]]) -> str:
+    """Render ``[(k, v), ...]`` as a bullet list, skipping ``None`` /
+    empty-string values."""
+    out = []
+    for k, v in items:
+        if v in (None, "", []):
+            continue
+        out.append(f"- **{k}**: {_md_cell(v)}")
+    return "\n".join(out)
+
+
+def _md_cell(v: Any) -> str:
+    if v is None:
+        return "—"
+    if isinstance(v, bool):
+        return "✅" if v else "❌"
+    if isinstance(v, float):
+        if v != v:  # NaN
+            return "—"
+        return f"{v:.3g}" if abs(v) < 1 or abs(v) >= 1e4 else f"{v:.2f}"
+    if isinstance(v, (list, tuple)):
+        return ", ".join(_md_cell(x) for x in v) if v else "—"
+    s = str(v)
+    return s.replace("|", "\\|").replace("\n", " ")
+
+
+def fmt_pct(v: Any, *, plus: bool = False) -> str:
+    if v is None:
+        return "—"
+    try:
+        x = float(v)
+    except (TypeError, ValueError):
+        return "—"
+    sign = "+" if (plus and x > 0) else ""
+    return f"{sign}{x:.2f}%"
+
+
+def fmt_int(v: Any) -> str:
+    if v is None:
+        return "—"
+    try:
+        return f"{int(v):,}"
+    except (TypeError, ValueError):
+        return str(v)

--- a/inference_optimizer/breakdown/reporters/compose.py
+++ b/inference_optimizer/breakdown/reporters/compose.py
@@ -1,0 +1,270 @@
+"""Top-level composer: run every renderer + (optionally) call the LLM
++ stitch the result into a single markdown document.
+
+Entry points:
+
+* :func:`render_session_report` — the main programmatic API. Takes a
+  parsed ``session_breakdown.json`` dict + an optional LLM client and
+  returns the final markdown string.
+
+Design notes:
+
+* The compose layer never inspects per-section semantics; it just
+  walks :data:`base.REGISTRY` in registration order, hands each
+  renderer the breakdown dict, and stitches outputs together. This
+  means new sections plug in with zero changes to compose.py.
+* When ``llm_client`` is ``None`` the output still works — sections
+  show only their deterministic markdown blocks, prefixed by the
+  global executive-summary computed from :class:`GlobalFacts`. This
+  is the path tests use, and is the path operators get when the LLM
+  backend is misconfigured.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Protocol
+
+from .base import REGISTRY, RenderedSection
+from .cross_section import GlobalFacts, build_global_facts
+from .llm_prompt import SYSTEM_PROMPT, build_user_prompt, parse_llm_response
+
+# Import every renderer module so its @register_renderer side effect
+# runs. Renderer order in REGISTRY is decoupled from final report
+# layout — :data:`SECTION_GROUPS` below dictates the H2/H3 grouping
+# the reader actually sees.
+from ._renderers import (   # noqa: F401  (side-effect imports)
+    session as _r_session,
+    workload as _r_workload,
+    baseline as _r_baseline,
+    final as _r_final,
+    capability_summary as _r_capability_summary,
+    phase_timeline as _r_phase_timeline,
+    kernel_lifecycle as _r_kernel_lifecycle,
+    invocations as _r_invocations,
+    param_search as _r_param_search,
+    sweep as _r_sweep,
+    critic_robustness as _r_critic_robustness,
+    attribution as _r_attribution,
+    source_files as _r_source_files,
+)
+
+
+# Final report layout: ``(group_title, [section_id, ...])``.
+#
+# Grouping mirrors the orchestration phases a hyperloom run actually
+# goes through — Session/Workload setup, performance Results, the
+# capability search loop (backends/params/sweep), kernel optimization
+# (lifecycle + GEAK/OOB invocations), and bookkeeping (attribution +
+# source files). ``telemetry`` is deliberately dropped from the report
+# (its renderer is no longer imported above) because the on-disk GPU
+# monitor data has been consistently broken on real wekafs sessions.
+SECTION_GROUPS: list[tuple[str, list[str]]] = [
+    ("Session & Workload",          ["session", "workload"]),
+    ("Performance Results",          ["baseline", "final", "attribution"]),
+    ("Capability Search",            ["capability_summary",
+                                      "param_search", "sweep"]),
+    ("Kernel Optimization",          ["kernel_lifecycle",
+                                      "geak_invocations",
+                                      "oob_invocations",
+                                      "critic_robustness"]),
+    ("Run Trace",                    ["phase_timeline"]),
+    ("Source Artifacts",             ["source_files"]),
+]
+
+__all__ = [
+    "LLMClient",
+    "ComposeResult",
+    "render_session_report",
+]
+
+
+class LLMClient(Protocol):
+    """Minimal LLM client interface the compose layer uses.
+
+    Any callable mapping ``(system, user) -> str`` works, including a
+    thin shim around :class:`ClaudeBackend`. Kept as a Protocol so we
+    can swap in mocks for tests without importing the orchestrator.
+    """
+
+    def complete(self, *, system: str, user: str) -> str: ...
+
+
+@dataclass(frozen=True)
+class ComposeResult:
+    """Full output of one compose run.
+
+    ``markdown`` is the user-facing report; the other fields are kept
+    so callers can persist them alongside the report for debugging /
+    replay (e.g. dump ``llm_user_prompt`` next to the report to
+    diagnose hallucinations).
+    """
+
+    markdown: str
+    sections: list[RenderedSection]
+    global_facts: GlobalFacts
+    llm_user_prompt: str
+    llm_raw_response: str
+    used_llm: bool
+
+
+def render_session_report(
+    breakdown: dict[str, Any],
+    *,
+    llm_client: LLMClient | None = None,
+) -> ComposeResult:
+    """Render ``breakdown`` (a parsed session_breakdown.json) to markdown."""
+    sections = [fn(breakdown) for _sid, fn in REGISTRY]
+    global_facts = build_global_facts(breakdown, sections)
+    user_prompt = build_user_prompt(sections, global_facts)
+
+    llm_raw = ""
+    narratives: dict[str, str] = {}
+    exec_summary_llm = ""
+    if llm_client is not None:
+        try:
+            llm_raw = llm_client.complete(system=SYSTEM_PROMPT, user=user_prompt)
+            parsed = parse_llm_response(llm_raw)
+            exec_summary_llm = parsed["executive_summary"]
+            narratives = parsed["section_narratives"]
+        except Exception as exc:  # noqa: BLE001
+            llm_raw = f"<llm_error: {type(exc).__name__}: {exc}>"
+
+    md = _stitch(
+        sections=sections,
+        global_facts=global_facts,
+        llm_exec_summary=exec_summary_llm,
+        llm_narratives=narratives,
+        used_llm=llm_client is not None and not llm_raw.startswith("<llm_error"),
+        breakdown=breakdown,
+    )
+    return ComposeResult(
+        markdown=md,
+        sections=sections,
+        global_facts=global_facts,
+        llm_user_prompt=user_prompt,
+        llm_raw_response=llm_raw,
+        used_llm=llm_client is not None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stitching
+# ---------------------------------------------------------------------------
+def _stitch(
+    *,
+    sections: list[RenderedSection],
+    global_facts: GlobalFacts,
+    llm_exec_summary: str,
+    llm_narratives: dict[str, str],
+    used_llm: bool,
+    breakdown: dict[str, Any],
+) -> str:
+    session = breakdown.get("session") or {}
+    title = f"# Hyperloom Session Report — {session.get('session_id') or '(no session_id)'}"
+
+    parts: list[str] = [title, ""]
+
+    parts.append("## Executive Summary")
+    if used_llm and llm_exec_summary:
+        parts.append(llm_exec_summary)
+    else:
+        parts.append(_deterministic_exec_summary(global_facts))
+    parts.append("")
+
+    parts.append("## Key Facts (deterministic)")
+    parts.append(_render_global_facts_block(global_facts))
+    parts.append("")
+
+    by_id = {s.section_id: s for s in sections}
+    for group_title, ids in SECTION_GROUPS:
+        live = [by_id[sid] for sid in ids
+                if sid in by_id and not by_id[sid].skipped]
+        if not live:
+            # All sections in this group are skipped → drop the H2 header
+            # too. Avoids "## Sweep\n_skipped_" placeholder noise.
+            continue
+        parts.append(f"## {group_title}")
+        parts.append("")
+        for sec in live:
+            parts.append(f"### {sec.title}")
+            narrative = llm_narratives.get(sec.section_id, "").strip()
+            if narrative:
+                parts.append(narrative)
+                parts.append("")
+            if sec.markdown_block:
+                parts.append(sec.markdown_block)
+                parts.append("")
+            if sec.warnings:
+                parts.append("> **Data quality notes for this section**:")
+                for w in sec.warnings:
+                    parts.append(f"> - {w}")
+                parts.append("")
+    return "\n".join(parts).rstrip() + "\n"
+
+
+def _deterministic_exec_summary(g: GlobalFacts) -> str:
+    """Fallback exec summary used when no LLM is configured / LLM failed.
+
+    Intentionally terse and bullet-point-y so it's obviously the
+    deterministic path (vs a polished LLM paragraph). Mentions every
+    data-quality flag so silent issues are never hidden.
+    """
+    out: list[str] = []
+    out.append(f"- {g.headline} (stop_reason={g.stop_reason or 'unset'}, "
+               f"elapsed={g.elapsed_minutes or 0:.0f}min, objective={g.objective}).")
+    out.append(f"- Workload: {g.workload_summary}.")
+    if g.gain_attribution_lines:
+        out.append(f"- Gain attribution ({g.attribution_method}): "
+                   + "; ".join(g.gain_attribution_lines))
+    else:
+        out.append(f"- No measurable gain recorded ({g.attribution_method}).")
+    funnel = g.kernel_pipeline_funnel
+    out.append(
+        f"- Kernel pipeline: detected={funnel['detected']} → "
+        f"recommended={funnel['recommended']} → optimized={funnel['optimized']} → "
+        f"adopted={funnel['adopted']} (reverted={funnel['reverted']}, "
+        f"rejected={funnel['rejected']}, partial={funnel['partial']})."
+    )
+    if g.capabilities_not_attempted:
+        out.append("- Capabilities never invoked: "
+                   + ", ".join(f"`{c}`" for c in g.capabilities_not_attempted) + ".")
+    if g.data_quality_flags:
+        out.append("- **Data quality flags**:")
+        for f in g.data_quality_flags:
+            out.append(f"  - {f}")
+    return "\n".join(out)
+
+
+def _render_global_facts_block(g: GlobalFacts) -> str:
+    """Render :class:`GlobalFacts` as a compact key-value block so the
+    raw computed facts are always inspectable in the report (and so
+    the LLM-written exec summary can be cross-checked against them)."""
+    funnel = g.kernel_pipeline_funnel
+    out: list[str] = []
+    out.append(f"- **Headline**: {g.headline}")
+    out.append(f"- **Stop reason**: `{g.stop_reason or 'unset'}` · "
+               f"elapsed `{g.elapsed_minutes or 0:.1f} min` · "
+               f"objective `{g.objective}`")
+    out.append(f"- **Workload**: {g.workload_summary}")
+    out.append(
+        f"- **Kernel pipeline**: detected={funnel['detected']} → "
+        f"recommended={funnel['recommended']} → optimized={funnel['optimized']} → "
+        f"adopted={funnel['adopted']} (partial={funnel['partial']}, "
+        f"reverted={funnel['reverted']}, rejected={funnel['rejected']})"
+    )
+    out.append(f"- **Capabilities kept**: "
+               + (", ".join(f"`{c}`" for c in g.capabilities_kept) or "none"))
+    out.append(f"- **Capabilities not attempted**: "
+               + (", ".join(f"`{c}`" for c in g.capabilities_not_attempted) or "none"))
+    out.append(f"- **Gain attribution** ({g.attribution_method}):")
+    if g.gain_attribution_lines:
+        for line in g.gain_attribution_lines:
+            out.append(f"  - {line}")
+    else:
+        out.append("  - (no attribution recorded)")
+    # Data quality flags appear in the Executive Summary above —
+    # don't duplicate them here (the Key Facts block is the LLM /
+    # script-facing cross-check view, not a second human-facing
+    # summary).
+    return "\n".join(out)

--- a/inference_optimizer/breakdown/reporters/cross_section.py
+++ b/inference_optimizer/breakdown/reporters/cross_section.py
@@ -1,0 +1,245 @@
+"""Cross-section fact synthesis used by the executive summary + LLM
+prompt.
+
+Every fact this module surfaces is computed deterministically from the
+``session_breakdown.json`` dict (and the renderer outputs already
+produced for each section). The LLM is forbidden from inventing
+numbers; the user prompt only contains:
+
+* the ``key_facts`` from each renderer,
+* the ``decisions`` from each renderer,
+* the ``GlobalFacts`` produced here.
+
+If you find yourself wanting the LLM to "figure something out across
+sections" (gain attribution, capability gating, data-quality flags),
+add it here instead. The numerical guard rails are this module's
+responsibility.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from .base import RenderedSection
+
+__all__ = ["GlobalFacts", "build_global_facts"]
+
+
+@dataclass(frozen=True)
+class GlobalFacts:
+    """One-shot fact pack that the LLM uses to build the executive summary.
+
+    Field naming follows the dashboard / handover-doc taxonomy so an
+    LLM that has never seen this codebase still understands what
+    "kernel_pipeline_funnel" or "attribution_method" mean.
+    """
+
+    headline: str                       # 1-line "baseline X → final Y = +Z%"
+    stop_reason: str
+    elapsed_minutes: float | None
+    objective: dict[str, Any]
+    workload_summary: str               # "DeepSeek-R1 vllm fp8 tp=8 conc=64 isl=osl=1024"
+    gain_attribution_lines: list[str]   # "100% via 1 backends KEEP (vllm_kv_fp8)"
+    capabilities_not_attempted: list[str]
+    capabilities_kept: list[str]
+    kernel_pipeline_funnel: dict[str, int]   # detected/recommended/optimized/adopted/...
+    data_quality_flags: list[str]
+    attribution_method: str             # "validated" | "best-effort reconstructed" | "missing"
+
+    def as_prompt_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _safe_pct(num: Any, denom: Any) -> float | None:
+    try:
+        n, d = float(num), float(denom)
+    except (TypeError, ValueError):
+        return None
+    if d == 0:
+        return None
+    return (n - d) / d * 100.0
+
+
+def _to_float(v: Any) -> float | None:
+    try:
+        return float(v) if v is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _workload_summary(workload: dict[str, Any]) -> str:
+    model = workload.get("model_name") or "(unknown-model)"
+    fw = workload.get("framework") or "?"
+    prec = workload.get("precision") or "?"
+    tp = workload.get("tp")
+    conc = workload.get("conc")
+    isl = workload.get("isl")
+    osl = workload.get("osl")
+    return (
+        f"{model} {fw} {prec} tp={tp} conc={conc} isl={isl} osl={osl}"
+    )
+
+
+def _gain_attribution_lines(
+    breakdown: dict[str, Any],
+) -> tuple[list[str], str]:
+    """Compute per-source gain attribution + which method we used.
+
+    Priority:
+    1. ``attribution.source_breakdown.*_pct_of_total`` when populated
+       and the sum is non-zero (validated split).
+    2. ``final.action_path`` walked sequentially when only one entry
+       exists (single-source attribution is unambiguous).
+    3. ``optimization_stack`` reconstruction (best-effort) — flagged.
+    """
+    attribution = breakdown.get("attribution") or {}
+    sb = attribution.get("source_breakdown") or {}
+    total = _to_float(sb.get("validated_total_pct"))
+    sources = {
+        "backends": _to_float(sb.get("backends_pct_of_total")),
+        "params":   _to_float(sb.get("params_pct_of_total")),
+        "geak":     _to_float(sb.get("geak_pct_of_total")),
+        "oob":      _to_float(sb.get("oob_pct_of_total")),
+        "sweep":    _to_float(sb.get("sweep_pct_of_total")),
+    }
+    nonzero = {k: v for k, v in sources.items() if v and v != 0}
+    if nonzero and total:
+        lines = [
+            f"{k}: {v:.2f}% of total (={(v/total*100):.0f}% share of {total:.2f}%)"
+            for k, v in sorted(nonzero.items(), key=lambda kv: -kv[1])
+        ]
+        return lines, "validated"
+
+    # Fall back to final.action_path single-source statement.
+    final = breakdown.get("final") or {}
+    path = final.get("action_path") or []
+    gain_v = _to_float(final.get("cumulative_gain_pct_validated"))
+    if len(path) == 1 and gain_v is not None and gain_v > 0:
+        entry = str(path[0])
+        action = entry.split(":")[0]
+        return (
+            [f"100% via 1 {action} KEEP ({entry})"],
+            "single-source (inferred from final.action_path)",
+        )
+    if len(path) > 1 and gain_v is not None and gain_v > 0:
+        return (
+            [f"{gain_v:.2f}% spread across {len(path)} stack entries: " +
+             ", ".join(str(p) for p in path)],
+            "best-effort reconstructed from optimization_stack",
+        )
+    if gain_v in (None, 0.0):
+        return ([], "missing")
+    return (
+        [f"{gain_v:.2f}% from unknown source"],
+        "best-effort reconstructed",
+    )
+
+
+def _kernel_funnel(breakdown: dict[str, Any]) -> dict[str, int]:
+    kl = breakdown.get("kernel_lifecycle") or {}
+    return {
+        "detected":    len(kl.get("detected") or []),
+        "recommended": len(kl.get("recommended") or []),
+        "optimized":   len(kl.get("optimized") or []),
+        "adopted":     len(kl.get("adopted") or []),
+        "partial":     len(kl.get("partial") or []),
+        "reverted":    len(kl.get("reverted") or []),
+        "rejected":    len(kl.get("rejected") or []),
+    }
+
+
+def _data_quality_flags(
+    breakdown: dict[str, Any],
+    rendered: list[RenderedSection],
+) -> list[str]:
+    """Collect data-quality warnings from every renderer + a few global
+    cross-section checks the renderers can't easily see.
+
+    Returns de-duplicated flags (renderer-level warnings sometimes
+    overlap with global-level checks, which used to produce 3 copies
+    of the same telemetry note).
+    """
+    flags: list[str] = []
+    seen: set[str] = set()
+
+    def _push(line: str) -> None:
+        if line in seen:
+            return
+        seen.add(line)
+        flags.append(line)
+
+    for sec in rendered:
+        # Suppress warnings on sections we'll drop from the report
+        # anyway — no point flagging them globally if the user never
+        # sees the section.
+        if sec.skipped:
+            continue
+        for w in sec.warnings:
+            _push(f"[{sec.section_id}] {w}")
+
+    # Global cross-section checks.
+    if (breakdown.get("attribution") or {}).get("notes"):
+        for n in breakdown["attribution"]["notes"]:
+            _push(f"[attribution] {n}")
+    cap = breakdown.get("capability_summary") or {}
+    val = cap.get("validate_stack") or {}
+    if val.get("status") == "not_attempted":
+        # validated cumulative gain still gets reported elsewhere, so
+        # be explicit that the validate_stack action never re-ran in
+        # this session.
+        _push(
+            "[validate_stack] never ran — cumulative_gain_pct_validated comes from "
+            "the historical validate run recorded in state, not a final re-validation."
+        )
+    return flags
+
+
+def _capabilities_split(
+    breakdown: dict[str, Any],
+) -> tuple[list[str], list[str]]:
+    cap = breakdown.get("capability_summary") or {}
+    kept = []
+    not_attempted = []
+    for name, v in cap.items():
+        status = (v or {}).get("status") or "not_attempted"
+        if status == "kept":
+            kept.append(name)
+        elif status == "not_attempted":
+            not_attempted.append(name)
+    return sorted(kept), sorted(not_attempted)
+
+
+def _headline(breakdown: dict[str, Any]) -> str:
+    b = (breakdown.get("baseline") or {}).get("throughput_tok_s_per_gpu")
+    f = (breakdown.get("final") or {}).get("throughput_tok_s_per_gpu")
+    g = (breakdown.get("final") or {}).get("cumulative_gain_pct_validated")
+    if b and f and g is not None:
+        sign = "+" if g > 0 else ""
+        return f"baseline {b:.2f} → final {f:.2f} tok/s/gpu = {sign}{g:.2f}% validated gain"
+    if b and not f:
+        return f"baseline {b:.2f} tok/s/gpu (no validated final)"
+    return "no validated throughput recorded"
+
+
+def build_global_facts(
+    breakdown: dict[str, Any],
+    rendered: list[RenderedSection],
+) -> GlobalFacts:
+    workload = breakdown.get("workload") or {}
+    session = breakdown.get("session") or {}
+    attribution_lines, attribution_method = _gain_attribution_lines(breakdown)
+    kept, not_attempted = _capabilities_split(breakdown)
+    return GlobalFacts(
+        headline=_headline(breakdown),
+        stop_reason=str(session.get("stop_reason") or ""),
+        elapsed_minutes=_to_float(session.get("elapsed_minutes")),
+        objective=dict(workload.get("objective") or {}),
+        workload_summary=_workload_summary(workload),
+        gain_attribution_lines=attribution_lines,
+        capabilities_not_attempted=not_attempted,
+        capabilities_kept=kept,
+        kernel_pipeline_funnel=_kernel_funnel(breakdown),
+        data_quality_flags=_data_quality_flags(breakdown, rendered),
+        attribution_method=attribution_method,
+    )

--- a/inference_optimizer/breakdown/reporters/llm_client.py
+++ b/inference_optimizer/breakdown/reporters/llm_client.py
@@ -1,0 +1,223 @@
+"""Thin LLM client adapters for the report narrative pass.
+
+We intentionally do NOT reuse :class:`ClaudeBackend` from
+``inference_optimizer.orchestrator.backends.claude`` — that backend is
+tightly coupled to the in-process MCP ``emit_intent`` tool contract,
+which the report layer doesn't need. The report layer just needs
+``(system, user) -> str``, so this module provides three minimal
+adapters:
+
+* :class:`OpenAIHttpClient` — POSTs to any OpenAI-compatible
+  ``/chat/completions`` endpoint. Works for both the AMD primus-safe
+  LiteLLM gateway and ``api.openai.com`` itself.
+* :class:`AnthropicHttpClient` — POSTs to the Anthropic Messages API
+  (used when only an ``ANTHROPIC_BASE_URL`` proxy is reachable).
+* :class:`NullClient` — never used by compose (you'd just pass
+  ``llm_client=None``); exposed so callers can branch cleanly.
+
+:func:`build_client_from_env` reads ``HYPERLOOM_REPORT_LLM_BACKEND``
+(``openai`` | ``anthropic`` | ``none``) and constructs the right one,
+falling back to ``None`` when configuration is missing — the compose
+layer then renders deterministic-only output, which is the desired
+behavior for offline / batch runs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# httpx is already a Hyperloom runtime dependency (cli.py preflight
+# installs it); we still import it lazily so users running offline
+# without the package don't pay the import cost.
+
+__all__ = [
+    "LLMClientError",
+    "NullClient",
+    "OpenAIHttpClient",
+    "AnthropicHttpClient",
+    "build_client_from_env",
+]
+
+
+class LLMClientError(RuntimeError):
+    """Wraps any client-side error so compose can degrade gracefully."""
+
+
+@dataclass
+class NullClient:
+    """No-op client; compose treats this exactly like ``llm_client=None``.
+
+    Kept as a real class so tests can pass a ``NullClient`` instance
+    instead of remembering "pass None".
+    """
+
+    def complete(self, *, system: str, user: str) -> str:  # noqa: D401
+        return ""
+
+
+@dataclass
+class OpenAIHttpClient:
+    """Minimal OpenAI-compatible chat-completions client.
+
+    No streaming, no tool calls, no function calling — just one POST
+    and we return ``choices[0].message.content``. Tuned for use against
+    the AMD primus-safe LiteLLM gateway (``OPENAI_BASE_URL``,
+    ``OPENAI_API_KEY``) but works against ``api.openai.com`` directly
+    too.
+    """
+
+    base_url: str
+    api_key: str
+    model: str = "claude-sonnet-4-5"
+    max_output_tokens: int = 1024
+    timeout_sec: float = 60.0
+
+    def complete(self, *, system: str, user: str) -> str:
+        import httpx  # local import (see module docstring rationale)
+
+        url = self.base_url.rstrip("/") + "/chat/completions"
+        body = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            "max_tokens": self.max_output_tokens,
+            "temperature": 0.2,  # narrative pass — keep prose stable but not robotic
+        }
+        try:
+            r = httpx.post(
+                url,
+                headers={"Authorization": f"Bearer {self.api_key}",
+                         "Content-Type": "application/json"},
+                content=json.dumps(body),
+                timeout=self.timeout_sec,
+            )
+            r.raise_for_status()
+            data = r.json()
+        except Exception as exc:  # noqa: BLE001
+            raise LLMClientError(f"openai chat-completions failed: {exc}") from exc
+        try:
+            return data["choices"][0]["message"]["content"] or ""
+        except (KeyError, IndexError, TypeError) as exc:
+            raise LLMClientError(
+                f"unexpected openai response shape: {data!r}"
+            ) from exc
+
+
+@dataclass
+class AnthropicHttpClient:
+    """Minimal Anthropic Messages-API client.
+
+    Targets the same auth-proxy on ``http://127.0.0.1:4002`` that
+    ClaudeBackend uses; the proxy rewrites ``x-api-key`` to
+    ``Authorization: Bearer`` for the upstream AMD gateway.
+    """
+
+    base_url: str
+    api_key: str
+    model: str = "claude-sonnet-4-5"
+    max_output_tokens: int = 1024
+    timeout_sec: float = 60.0
+
+    def complete(self, *, system: str, user: str) -> str:
+        import httpx
+
+        url = self.base_url.rstrip("/") + "/v1/messages"
+        body = {
+            "model": self.model,
+            "max_tokens": self.max_output_tokens,
+            "system": system,
+            "messages": [{"role": "user", "content": user}],
+        }
+        try:
+            r = httpx.post(
+                url,
+                headers={
+                    "x-api-key": self.api_key,
+                    "anthropic-version": "2023-06-01",
+                    "Content-Type": "application/json",
+                },
+                content=json.dumps(body),
+                timeout=self.timeout_sec,
+            )
+            r.raise_for_status()
+            data = r.json()
+        except Exception as exc:  # noqa: BLE001
+            raise LLMClientError(f"anthropic messages failed: {exc}") from exc
+        try:
+            blocks = data.get("content") or []
+            text_parts = [b.get("text") or "" for b in blocks if b.get("type") == "text"]
+            return "".join(text_parts)
+        except Exception as exc:  # noqa: BLE001
+            raise LLMClientError(
+                f"unexpected anthropic response shape: {data!r}"
+            ) from exc
+
+
+def build_client_from_env() -> Any | None:
+    """Construct an LLM client from environment.
+
+    Reads (in priority order):
+
+    * ``HYPERLOOM_REPORT_LLM_BACKEND`` — ``openai`` / ``anthropic`` /
+      ``none``. Defaults to ``none`` so the dump-report CLI is safe to
+      run on a stripped-down debug pod without network access.
+    * ``HYPERLOOM_REPORT_MODEL`` — model id; falls back to
+      ``claude-sonnet-4-5``.
+    * ``HYPERLOOM_REPORT_MAX_TOKENS`` — int; defaults to 1024.
+    * ``OPENAI_BASE_URL`` / ``OPENAI_API_KEY`` for the OpenAI adapter,
+      ``ANTHROPIC_BASE_URL`` / ``ANTHROPIC_API_KEY`` for the Anthropic
+      one. Missing required vars returns ``None`` (deterministic-only
+      report).
+    """
+    backend = (os.environ.get("HYPERLOOM_REPORT_LLM_BACKEND") or "none").lower()
+    if backend in ("", "none", "off", "disabled"):
+        return None
+    model = os.environ.get("HYPERLOOM_REPORT_MODEL") or "claude-sonnet-4-5"
+    try:
+        max_tokens = int(os.environ.get("HYPERLOOM_REPORT_MAX_TOKENS") or "1024")
+    except ValueError:
+        max_tokens = 1024
+
+    if backend == "openai":
+        base = os.environ.get("OPENAI_BASE_URL")
+        key = os.environ.get("OPENAI_API_KEY")
+        if not (base and key):
+            log.warning(
+                "HYPERLOOM_REPORT_LLM_BACKEND=openai but OPENAI_BASE_URL or "
+                "OPENAI_API_KEY is unset; falling back to deterministic-only "
+                "report."
+            )
+            return None
+        return OpenAIHttpClient(
+            base_url=base, api_key=key, model=model,
+            max_output_tokens=max_tokens,
+        )
+    if backend == "anthropic":
+        base = os.environ.get("ANTHROPIC_BASE_URL")
+        key = (os.environ.get("ANTHROPIC_API_KEY")
+               or os.environ.get("CLAUDE_API_KEY")
+               or os.environ.get("PRIMUS_SAFE_API_KEY"))
+        if not (base and key):
+            log.warning(
+                "HYPERLOOM_REPORT_LLM_BACKEND=anthropic but ANTHROPIC_BASE_URL "
+                "or ANTHROPIC_API_KEY is unset; falling back to "
+                "deterministic-only report."
+            )
+            return None
+        return AnthropicHttpClient(
+            base_url=base, api_key=key, model=model,
+            max_output_tokens=max_tokens,
+        )
+    log.warning(
+        "Unknown HYPERLOOM_REPORT_LLM_BACKEND=%r; falling back to "
+        "deterministic-only report.", backend,
+    )
+    return None

--- a/inference_optimizer/breakdown/reporters/llm_prompt.py
+++ b/inference_optimizer/breakdown/reporters/llm_prompt.py
@@ -1,0 +1,151 @@
+"""LLM prompt builders for the narrative pass.
+
+The LLM is allowed to do exactly two things:
+
+1. Write a 3-5 sentence executive summary that paraphrases (not
+   re-states) the ``GlobalFacts`` headline + attribution + funnel +
+   data-quality flags.
+2. Write ONE paragraph of narrative for each non-skipped section that
+   connects its ``key_facts`` to the surrounding context. The
+   deterministic ``markdown_block`` of that section is rendered
+   verbatim immediately after the LLM's paragraph; the LLM never sees
+   or rewrites it.
+
+Hard guard rails in the system prompt:
+
+* No number that does not appear in ``key_facts``, ``decisions``, or
+  ``global_facts`` may appear in the LLM output.
+* No capability may be referenced as "used" / "ran" / "contributed"
+  unless its decision is ``kept`` / ``attempted`` / ``reverted`` /
+  ``rejected`` / ``partial`` — never the bare action name. Sections
+  with ``not_attempted`` must be described as such.
+* Sections with ``skipped=True`` must not be mentioned.
+* Output must be valid JSON with the shape
+  ``{"executive_summary": str, "section_narratives": {<section_id>: str}}``.
+
+Why JSON output: stitching the LLM prose into the deterministic
+markdown skeleton needs section-keyed access, so a single text blob is
+brittle. JSON keeps the boundary clean.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from .base import RenderedSection
+from .cross_section import GlobalFacts
+
+__all__ = [
+    "SYSTEM_PROMPT",
+    "build_user_prompt",
+]
+
+
+SYSTEM_PROMPT = """\
+You are writing the narrative portions of a Hyperloom session
+performance report. The numerical facts (throughputs, gains, kernel
+counts, paths, decisions) have already been computed and rendered as
+markdown blocks that will be stitched into the final document AS-IS.
+
+You may NOT:
+- Invent numbers, percentages, kernel names, paths, or GPU types. Every
+  numeric or named entity you write MUST appear verbatim in one of:
+  ``global_facts``, ``key_facts``, or ``decisions``.
+- Describe a capability (``backends`` / ``params`` / ``sweep`` /
+  ``geak`` / ``oob`` / ``validate_stack``) as "ran" / "contributed" /
+  "applied" unless its decision is one of: ``kept`` / ``attempted`` /
+  ``reverted`` / ``rejected`` / ``partial``. Capabilities listed in
+  ``capabilities_not_attempted`` MUST be described as "never ran"
+  / "not attempted" / "not invoked".
+- Write a paragraph for any section whose ``skipped`` flag is true.
+- Rephrase or "summarize" the deterministic markdown block.
+
+You MUST:
+- Output strictly valid JSON, no leading or trailing prose, with this
+  shape:
+    {
+      "executive_summary":   "<3-5 sentences>",
+      "section_narratives":  {"<section_id>": "<1 short paragraph>", ...}
+    }
+- For each non-skipped section in the input, include one entry in
+  ``section_narratives`` (omit skipped sections entirely).
+- Surface every entry in ``global_facts.data_quality_flags`` in the
+  executive summary (concisely; users have been bitten by silent data
+  issues like all-zero GPU monitoring readings).
+- Reflect the ``attribution_method`` honestly: if it is
+  ``"best-effort reconstructed"`` or ``"missing"``, say so in plain
+  language — do not present a reconstructed attribution as validated.
+"""
+
+
+def _section_input(rendered: RenderedSection) -> dict[str, Any]:
+    return {
+        "section_id":  rendered.section_id,
+        "title":       rendered.title,
+        "skipped":     rendered.skipped,
+        "key_facts":   list(rendered.key_facts),
+        "decisions":   [
+            {
+                "kind":       d.kind,
+                "subject":    d.subject,
+                "metric_pct": d.metric_pct,
+                "rationale":  d.rationale,
+            }
+            for d in rendered.decisions
+        ],
+        "warnings":    list(rendered.warnings),
+    }
+
+
+def build_user_prompt(
+    rendered: list[RenderedSection],
+    global_facts: GlobalFacts,
+) -> str:
+    """Build the user-message JSON the LLM sees.
+
+    Returns a JSON string (not a dict) because the LLM's chat input is
+    a string and we want the exact bytes the model receives to be
+    inspectable in logs.
+    """
+    payload = {
+        "global_facts": global_facts.as_prompt_dict(),
+        # Don't show the LLM skipped sections — keeps the prompt smaller
+        # and prevents the model from being tempted to "explain" a
+        # phantom section.
+        "sections":     [_section_input(s) for s in rendered if not s.skipped],
+    }
+    return json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def parse_llm_response(raw: str) -> dict[str, Any]:
+    """Best-effort parse of the LLM's JSON output.
+
+    Tolerates a leading ```json fence and surrounding whitespace because
+    chat models sometimes hedge with code fences despite the system
+    prompt forbidding them. On any failure returns
+    ``{"executive_summary": "", "section_narratives": {}}`` so the
+    deterministic-only output path is still usable.
+    """
+    text = (raw or "").strip()
+    if text.startswith("```"):
+        # Strip optional ```json ... ``` fence.
+        lines = text.splitlines()
+        if lines and lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].startswith("```"):
+            lines = lines[:-1]
+        text = "\n".join(lines).strip()
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return {"executive_summary": "", "section_narratives": {}}
+    if not isinstance(data, dict):
+        return {"executive_summary": "", "section_narratives": {}}
+    return {
+        "executive_summary": str(data.get("executive_summary") or "").strip(),
+        "section_narratives": {
+            str(k): str(v).strip()
+            for k, v in (data.get("section_narratives") or {}).items()
+        },
+    }

--- a/inference_optimizer/breakdown/schema.py
+++ b/inference_optimizer/breakdown/schema.py
@@ -1,0 +1,460 @@
+"""Schema (TypedDict shape) for ``session_breakdown.json``.
+
+This is the single contract between ``inference_optimizer`` (producer)
+and any downstream consumer (``claw-stats-service``, results service,
+notebooks).
+
+Design notes
+------------
+* All fields are ``NotRequired``-by-convention: collectors may return
+  ``None`` / ``[]`` / ``{}`` when the underlying artifacts are not
+  present. Consumers MUST treat missing data as "not available" — never
+  fabricate values.
+* Schema is JSON-serializable; no dataclasses, no enums in the wire
+  shape. Status strings are documented in their respective TypedDicts.
+* Versioning: ``schema_version`` is bumped on any breaking change. Add
+  new optional fields freely without bumping.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+SCHEMA_VERSION = "hyperloom.session_breakdown.v1"
+
+
+# ---------------------------------------------------------------------------
+# §1 Session metadata
+# ---------------------------------------------------------------------------
+class SessionMeta(TypedDict, total=False):
+    session_id: str               # hyperloom internal id (manifest.session_id)
+    claw_session_id: str | None   # SaFE / Claw session id (env CLAW_SESSION_ID)
+    sandbox_user_id: str | None
+    created_at_utc: str
+    ended_at_utc: str
+    stop_reason: str              # target_reached / time_exhausted / no_more_leverage / max_ticks / baseline_failed / ...
+    max_minutes: int
+    elapsed_minutes: float
+    host: str
+    code_revision: str
+    pid: int
+    session_dir: str
+    tick_count: int
+
+
+# ---------------------------------------------------------------------------
+# §2 Workload configuration
+# ---------------------------------------------------------------------------
+class WorkloadObjective(TypedDict, total=False):
+    kind: str                     # gain_pct / tput / baseline / time_only
+    value: Any                    # float or str (target_baseline_dir) or None
+
+
+class Workload(TypedDict, total=False):
+    framework: str                # sglang / vllm
+    framework_version: str
+    model_name: str
+    model_path: str
+    model_class: str
+    gpu_type: str                 # mi300x / mi325x / mi355x
+    tp: int | None
+    conc: int | None
+    isl: int | None
+    osl: int | None
+    max_model_len: int | None
+    precision: str
+    objective: WorkloadObjective
+
+
+# ---------------------------------------------------------------------------
+# §3 Baseline
+# ---------------------------------------------------------------------------
+class BaselineAttemptSummary(TypedDict, total=False):
+    ts: str
+    task_id: str
+    status: str
+    decision: str
+    key_metric: float | None
+    workspace: str | None
+    error_class: str | None
+
+
+class Baseline(TypedDict, total=False):
+    throughput_tok_s_per_gpu: float
+    accuracy: float
+    ttft_mean_ms: float | None
+    e2el_mean_ms: float | None
+    config_path: str | None
+    benchmark_report_path: str | None
+    attempts_history: list[BaselineAttemptSummary]
+    failure_streak: int
+
+
+# ---------------------------------------------------------------------------
+# §4 Final state — SaFE contract core
+# ---------------------------------------------------------------------------
+class Final(TypedDict, total=False):
+    throughput_tok_s_per_gpu: float | None
+    cumulative_gain_pct_validated: float
+    cumulative_gain_pct_per_round_sum: float
+    validated_at_stack_len: int
+    validated_ts: str
+    stack_changed_after_validation: bool
+    extra_sglang_args: str
+    extra_envs: dict[str, Any]
+    action_path: list[str]        # ordered list of action:variant labels from optimization_stack
+    ttft_mean_ms: float | None
+    e2el_mean_ms: float | None
+
+
+# ---------------------------------------------------------------------------
+# §5 Phase timeline — chronological events
+# ---------------------------------------------------------------------------
+class PhaseEvent(TypedDict, total=False):
+    ts: str
+    action: str                   # baseline / profile / backends / params / sweep / validate_stack / kernel_opt / select_kernels / integrate
+    task_id: str
+    kernel_id: str | None         # only for kernel-owned actions
+    status: str                   # succeeded / failed
+    decision: str                 # promoted / discarded / salvaged / no_promote / error / KEEP / PARTIAL / REVERT
+    key_metric: float | None
+    key_metric_kind: str | None
+    workspace: str | None
+    error_class: str | None
+    extras: dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# §6 Capability summary — Capability cards in UI
+# ---------------------------------------------------------------------------
+class CapabilityEntry(TypedDict, total=False):
+    status: str                   # kept / tried / attempted / not_attempted / not_configured / failed / completed
+    attempts: int
+    keeps: int
+    tested: int                   # for backends/params: distinct variants tested
+    best_gain_pct: float | None
+    reason: str                   # human readable, e.g. "kernel-claude only this run"
+
+
+class CapabilitySummary(TypedDict, total=False):
+    geak: CapabilityEntry
+    oob: CapabilityEntry
+    backends: CapabilityEntry
+    params: CapabilityEntry
+    sweep: CapabilityEntry
+    validate_stack: CapabilityEntry
+
+
+# ---------------------------------------------------------------------------
+# §7 / §8 GEAK / OOB invocations
+# ---------------------------------------------------------------------------
+class KernelMetadata(TypedDict, total=False):
+    name: str
+    source_file: str
+    shapes: list[dict[str, Any]]
+    gpu_pct: float | None
+    arithmetic_intensity: float | None
+
+
+class Invocation(TypedDict, total=False):
+    """One backend invocation for one kernel.
+
+    Same shape for GEAK and OOB; ``backend`` distinguishes them.
+    """
+    kernel_id: str
+    attempt_id: str
+    run_id: str
+    ts: str
+    backend: str                  # geak / claude / codex
+    model: str | None
+    kernel_metadata: KernelMetadata
+    prompt_path: str | None
+    optimized_files: list[str]
+    result_path: str | None
+    verification_path: str | None
+    decision: str                 # KEEP / PARTIAL / REVERT / FAILED
+    micro_speedup: float | None
+    compile_passed: bool | None
+    correctness_passed: bool | None
+    best_artifact_path: str | None
+    error: str | None
+    cli_log_path: str | None
+
+
+# ---------------------------------------------------------------------------
+# §9 Kernel lifecycle (4+1 stages)
+# ---------------------------------------------------------------------------
+class DetectedKernel(TypedDict, total=False):
+    kernel_id: str
+    name: str
+    gpu_pct: float | None
+    time_ms: float | None
+    bottleneck: str               # compute / memory / comm
+    arithmetic_intensity: float | None
+    reusable_native_kernel: bool
+    source_file: str | None
+    detected_from_task: str       # which profile task_id surfaced it
+    benchmark_report_path: str
+
+
+class RecommendedKernel(TypedDict, total=False):
+    kernel_id: str
+    name: str
+    gpu_pct: float | None
+    recommended_backends: list[str]
+    recommended_actions: list[str]
+    bottleneck: str
+    reusable_native_kernel: bool
+
+
+class OptimizedKernel(TypedDict, total=False):
+    kernel_id: str
+    backend: str                  # geak / claude / codex (best-of)
+    total_attempts: int
+    successful_attempts: int
+    best_micro_speedup: float | None
+    last_decision: str
+    best_artifact_path: str | None
+    attempts_summary: list[dict[str, Any]]
+
+
+class AdoptedKernel(TypedDict, total=False):
+    kernel_id: str
+    patch_path: str
+    target_file: str
+    extra_sglang_args: str
+    e2e_gain_pct: float | None
+    validated: bool
+    last_status: str
+    adopted_at: str
+    attempt_count: int
+
+
+class RejectedKernel(TypedDict, total=False):
+    kernel_id: str
+    reason: str
+    patch_path: str | None
+    target_file: str | None
+    attempt_count: int
+    best_gain_pct: float | None
+    ts: str
+
+
+class KernelLifecycle(TypedDict, total=False):
+    detected: list[DetectedKernel]
+    recommended: list[RecommendedKernel]
+    optimized: list[OptimizedKernel]
+    adopted: list[AdoptedKernel]
+    rejected: list[RejectedKernel]
+
+
+# ---------------------------------------------------------------------------
+# §10 Param search
+# ---------------------------------------------------------------------------
+class ParamSearchEntry(TypedDict, total=False):
+    """One row from params_search.{tested,accepted,rejected}."""
+    name: str
+    fingerprint: str
+    extra_sglang_args: str
+    extra_envs: dict[str, Any]
+    output_throughput: float | None
+    gain_pct: float | None
+    ts: str
+    status: str                   # accepted / rejected / tested
+
+
+class ParamSearchLedger(TypedDict, total=False):
+    schema_version: int
+    tested_count: int
+    accepted: list[ParamSearchEntry]
+    rejected: list[ParamSearchEntry]
+    top_by_gain: list[ParamSearchEntry]
+    winner_history: list[dict[str, Any]]
+    no_promote_streak: int
+
+
+class ParamSearch(TypedDict, total=False):
+    params: ParamSearchLedger
+    backends: ParamSearchLedger
+    synergy_attempted: list[str]
+    discovered_flags: dict[str, Any]
+    backend_winners_history: list[dict[str, Any]]
+
+
+# ---------------------------------------------------------------------------
+# §11 Sweep
+# ---------------------------------------------------------------------------
+class SweepPoint(TypedDict, total=False):
+    variant_name: str
+    conc: int | None
+    isl: int | None
+    osl: int | None
+    output_throughput_tok_s: float | None
+    ttft_mean_ms: float | None
+    tpot_mean_ms: float | None
+    e2el_mean_ms: float | None
+    status: str                   # ok / skipped / failed
+    benchmark_report_path: str | None
+
+
+class Sweep(TypedDict, total=False):
+    grid_size: int
+    best_overall: dict[str, Any]
+    best_for_each_conc: list[dict[str, Any]]
+    pareto_front: list[dict[str, Any]]
+    all_variants: list[SweepPoint]
+    config_path: str | None
+
+
+# ---------------------------------------------------------------------------
+# §12 Critic / Robustness
+# ---------------------------------------------------------------------------
+class CriticIteration(TypedDict, total=False):
+    iter: int
+    ts: str
+    topic: str                    # what was reviewed (kernel_opt:k001, backends:flag_X, ...)
+    verdict: str                  # approve / reject / redirect / advise / needs_review
+    summary: str
+    request_path: str
+    judge_bundle_path: str
+    emit_path: str
+    review_path: str
+
+
+class RobustnessSignal(TypedDict, total=False):
+    ts: str
+    signal: str                   # crash / stall / disk_full / cluster_fault / ...
+    action: str                   # what was done
+    workdir: str
+
+
+class CriticRobustness(TypedDict, total=False):
+    critic_iterations: list[CriticIteration]
+    robustness_signals: list[RobustnessSignal]
+
+
+# ---------------------------------------------------------------------------
+# §13 Telemetry
+# ---------------------------------------------------------------------------
+class GpuMonitorAggregate(TypedDict, total=False):
+    samples: int
+    avg_power_w: float
+    max_power_w: float
+    avg_temp_c: float
+    max_temp_c: float
+    avg_clock_mhz: float
+
+
+class Telemetry(TypedDict, total=False):
+    baseline_report_path: str | None
+    profile_report_paths: list[str]
+    torch_trace_paths: list[str]
+    system_profile_paths: list[str]
+    server_log_paths: list[str]
+    gpu_monitor_aggregate: GpuMonitorAggregate
+
+
+# ---------------------------------------------------------------------------
+# §14 Attribution
+# ---------------------------------------------------------------------------
+class StackGainEntry(TypedDict, total=False):
+    """One KEEP/validation event with its incremental contribution."""
+    ts: str
+    stack_len_before: int
+    stack_len_after: int
+    action: str                   # backends / params / kernel_opt:<kid> / validate_stack
+    variant_name: str | None
+    cum_gain_before: float
+    cum_gain_after: float
+    delta_pct: float | None       # None when validate_stack re-baselined
+    extra_sglang_args: str
+
+
+class SourceBreakdown(TypedDict, total=False):
+    geak_pct_of_total: float
+    oob_pct_of_total: float
+    backends_pct_of_total: float
+    params_pct_of_total: float
+    sweep_pct_of_total: float
+    validated_total_pct: float
+
+
+class Attribution(TypedDict, total=False):
+    gain_per_stack_entry: list[StackGainEntry]
+    source_breakdown: SourceBreakdown
+    notes: list[str]              # human-readable caveats
+
+
+# ---------------------------------------------------------------------------
+# Top-level shape
+# ---------------------------------------------------------------------------
+class SourceFiles(TypedDict, total=False):
+    manifest: str
+    state: str
+    baseline_report: str | None
+    profile_reports: list[str]
+    sweep_reports: list[str]
+    kernel_attempts: list[str]
+    critic_workdir: str | None
+    robustness_workdir: str | None
+
+
+class SessionBreakdown(TypedDict, total=False):
+    schema_version: str
+    exported_at_utc: str
+    exporter_version: str
+
+    session: SessionMeta
+    workload: Workload
+    baseline: Baseline
+    final: Final
+    phase_timeline: list[PhaseEvent]
+    capability_summary: CapabilitySummary
+    geak_invocations: list[Invocation]
+    oob_invocations: list[Invocation]
+    kernel_lifecycle: KernelLifecycle
+    param_search: ParamSearch
+    sweep: Sweep
+    critic_robustness: CriticRobustness
+    telemetry: Telemetry
+    attribution: Attribution
+
+    warnings: list[str]
+    source_files: SourceFiles
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "AdoptedKernel",
+    "Attribution",
+    "Baseline",
+    "BaselineAttemptSummary",
+    "CapabilityEntry",
+    "CapabilitySummary",
+    "CriticIteration",
+    "CriticRobustness",
+    "DetectedKernel",
+    "Final",
+    "GpuMonitorAggregate",
+    "Invocation",
+    "KernelLifecycle",
+    "KernelMetadata",
+    "OptimizedKernel",
+    "ParamSearch",
+    "ParamSearchEntry",
+    "ParamSearchLedger",
+    "PhaseEvent",
+    "RecommendedKernel",
+    "RejectedKernel",
+    "RobustnessSignal",
+    "SessionBreakdown",
+    "SessionMeta",
+    "SourceBreakdown",
+    "SourceFiles",
+    "StackGainEntry",
+    "Sweep",
+    "SweepPoint",
+    "Telemetry",
+    "Workload",
+    "WorkloadObjective",
+]

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -55,6 +55,7 @@ from .orchestrator.action_executors import (
     pmc_roofline_executor,
     profile_executor,
     report_executor,
+    session_breakdown_executor,
     sweep_executor,
     validate_stack_executor,
 )
@@ -475,6 +476,8 @@ def _seed_shared_state(
 ) -> SharedState:
     state = SharedState(
         session_id=session_id,
+        claw_session_id=(os.environ.get("CLAW_SESSION_ID") or "").strip(),
+        sandbox_user_id=(os.environ.get("SANDBOX_USER_ID") or "").strip(),
         model_name=Path(args.model).name,
         model_path=str(args.model),
         model_class=args.model_class or "",
@@ -545,8 +548,9 @@ _REAL_EXECUTORS_FULL: dict[str, Any] = {
     "backends":       backends_executor,
     "params":         params_executor,
     "sweep":          sweep_executor,
-    "report":         report_executor,
-    "validate_stack": validate_stack_executor,
+    "report":            report_executor,
+    "session_breakdown": session_breakdown_executor,
+    "validate_stack":    validate_stack_executor,
 }
 
 # Real executors enabled only when kernel-mode is on (profile/pmc_roofline
@@ -1912,6 +1916,16 @@ async def _run_optimize(args: argparse.Namespace) -> int:
         )
     finally:
         await coordinator.stop()
+        # End-of-session safety net: always materialize session_breakdown.json
+        # for downstream consumers (claw-stats-service / hyperloom-results-
+        # service / offline analysis). Best-effort — a failure here MUST NOT
+        # mask the actual stop_reason, so we swallow exceptions and log.
+        try:
+            from .breakdown import write_breakdown_json
+            breakdown_path = write_breakdown_json(session_dir)
+            print(f"Session breakdown : {breakdown_path}")
+        except Exception:  # noqa: BLE001
+            log.exception("session_breakdown finalize failed (non-fatal)")
 
     _print_final_summary(coordinator.shared_state, stop_reason)
     return 0 if stop_reason in (

--- a/inference_optimizer/manifest.py
+++ b/inference_optimizer/manifest.py
@@ -14,23 +14,30 @@ Why this lives in its own module:
 Schema v1::
 
     {
-      "schema_version": 1,
-      "session_id":     "<UTC_YYYYMMDDTHHMMSSZ>_<uuid8>",
-      "created_at_utc": "...",
-      "model_path":     "...",
-      "model_name":     "...",
-      "framework":      "sglang|vllm",
-      "gpu_type":       "mi300x|mi325x|mi355x|''",
-      "tp":             N or null,
-      "workload":       {"isl":..., "osl":..., "max_model_len":...,
-                         "precision":..., "conc":...},
-      "objective":      {"kind":"gain_pct|tput|baseline|time_only",
-                         "value":...},
-      "max_minutes":    N,
-      "code_revision":  "<git sha or empty>",
-      "pid":            N,
-      "host":           "..."
+      "schema_version":    1,
+      "session_id":        "<UTC_YYYYMMDDTHHMMSSZ>_<uuid8>",
+      "claw_session_id":   "<uuid>" or null,   # Primus-Claw session UUID
+      "sandbox_user_id":   "<str>"  or null,   # Primus-Claw sandbox user
+      "created_at_utc":    "...",
+      "model_path":        "...",
+      "model_name":        "...",
+      "framework":         "sglang|vllm",
+      "gpu_type":          "mi300x|mi325x|mi355x|''",
+      "tp":                N or null,
+      "workload":          {"isl":..., "osl":..., "max_model_len":...,
+                            "precision":..., "conc":...},
+      "objective":         {"kind":"gain_pct|tput|baseline|time_only",
+                            "value":...},
+      "max_minutes":       N,
+      "code_revision":     "<git sha or empty>",
+      "pid":               N,
+      "host":              "..."
     }
+
+``claw_session_id`` / ``sandbox_user_id`` are read from the
+``CLAW_SESSION_ID`` / ``SANDBOX_USER_ID`` env vars (set by the
+Primus-Claw spawn path); they are ``null`` when Hyperloom runs standalone
+outside the claw sandbox.
 """
 
 from __future__ import annotations
@@ -125,22 +132,26 @@ def build_manifest(
             workload["osl"] = int(args.osl)
         if getattr(args, "precision", None):
             workload["precision"] = str(args.precision)
+    claw_session_id = (os.environ.get("CLAW_SESSION_ID") or "").strip() or None
+    sandbox_user_id = (os.environ.get("SANDBOX_USER_ID") or "").strip() or None
     return {
-        "schema_version": SCHEMA_VERSION,
-        "session_id":     session_id or build_session_id(model_name),
-        "created_at_utc": datetime.now(timezone.utc).isoformat(timespec="seconds"),
-        "session_dir":    str(session_dir),
-        "model_path":     model_path,
-        "model_name":     model_name,
-        "framework":      framework or "sglang",
-        "gpu_type":       gpu_type,
-        "tp":             tp,
-        "workload":       workload,
-        "objective":      _objective_summary(args) if args is not None else {"kind": "time_only", "value": None},
-        "max_minutes":    int((getattr(args, "max_hours", 0) or 0) * 60) if args is not None else 0,
-        "code_revision":  _git_revision(),
-        "pid":            os.getpid(),
-        "host":           platform.node() or socket.gethostname() or "",
+        "schema_version":  SCHEMA_VERSION,
+        "session_id":      session_id or build_session_id(model_name),
+        "claw_session_id": claw_session_id,
+        "sandbox_user_id": sandbox_user_id,
+        "created_at_utc":  datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "session_dir":     str(session_dir),
+        "model_path":      model_path,
+        "model_name":      model_name,
+        "framework":       framework or "sglang",
+        "gpu_type":        gpu_type,
+        "tp":              tp,
+        "workload":        workload,
+        "objective":       _objective_summary(args) if args is not None else {"kind": "time_only", "value": None},
+        "max_minutes":     int((getattr(args, "max_hours", 0) or 0) * 60) if args is not None else 0,
+        "code_revision":   _git_revision(),
+        "pid":             os.getpid(),
+        "host":            platform.node() or socket.gethostname() or "",
     }
 
 

--- a/inference_optimizer/orchestrator/action_executors/__init__.py
+++ b/inference_optimizer/orchestrator/action_executors/__init__.py
@@ -41,6 +41,7 @@ from .profile import (
 )
 from .pmc_roofline import PMCRooflineExecutor, pmc_roofline_executor
 from .report import ReportExecutor, report_executor
+from .session_breakdown import SessionBreakdownExecutor, session_breakdown_executor
 from .sweep import (
     DEFAULT_CONC_VALUES,
     DEFAULT_ISL_OSL,
@@ -72,6 +73,7 @@ __all__ = [
     "ProfileExecutor",
     "ReportExecutor",
     "SYNERGY_GROUPS",
+    "SessionBreakdownExecutor",
     "SweepExecutor",
     "TargetAnalysisExecutor",
     "ValidateStackExecutor",
@@ -85,6 +87,7 @@ __all__ = [
     "pmc_roofline_executor",
     "profile_executor",
     "report_executor",
+    "session_breakdown_executor",
     "sweep_executor",
     "validate_stack_executor",
 ]

--- a/inference_optimizer/orchestrator/action_executors/session_breakdown.py
+++ b/inference_optimizer/orchestrator/action_executors/session_breakdown.py
@@ -1,0 +1,103 @@
+"""ActionRunner for the ``session_breakdown`` action.
+
+Thin wrapper around :func:`inference_optimizer.breakdown.write_breakdown_json`
+so the Coordinator / orchestration agent can refresh
+``$SESSION_DIR/session_breakdown.json`` on demand (after every
+``validate_stack`` KEEP, before a planned ``report``, when a live
+dashboard is observing this session, etc.).
+
+The end-of-session safety net lives in ``cli.py``'s finally block — this
+action is the agent-driven path used **during** a session for live
+refreshes.
+
+Returned shape::
+
+    {
+      "status":         "succeeded" | "failed",
+      "breakdown_path": str,           # absolute path to the JSON file
+      "warnings":       list[str],     # from inside the build
+      "size_bytes":     int,
+    }
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+class SessionBreakdownExecutor:
+    """Materialize ``session_breakdown.json`` for the current session.
+
+    Honors ``ctx.task.params`` keys:
+
+    * ``session_dir`` (optional override; same precedence as ReportExecutor)
+    * ``output_path`` (optional override; defaults to
+      ``<session_dir>/session_breakdown.json``)
+    """
+
+    async def __call__(self, ctx) -> dict[str, Any]:
+        session_dir = self._resolve_session_dir(ctx)
+        if session_dir is None:
+            return {
+                "status": "failed",
+                "error":  "session_breakdown_executor: could not resolve session_dir",
+            }
+
+        params = ctx.task.params or {}
+        output_path = params.get("output_path")
+
+        from ...breakdown import build, write_breakdown_json
+        try:
+            target = write_breakdown_json(session_dir, output_path=output_path)
+        except Exception as exc:  # noqa: BLE001
+            log.exception("session_breakdown export failed")
+            return {
+                "status": "failed",
+                "error":  f"{type(exc).__name__}: {exc}",
+            }
+
+        # Re-read the rendered JSON to surface warnings + size to the bus
+        # event without parsing it back.
+        try:
+            warnings = build(session_dir).get("warnings") or []
+        except Exception:  # noqa: BLE001
+            warnings = []
+
+        log.info(
+            "session_breakdown_executor: wrote %s (%d warnings)",
+            target,
+            len(warnings),
+        )
+        return {
+            "status":         "succeeded",
+            "breakdown_path": str(target),
+            "warnings":       warnings,
+            "size_bytes":     int(target.stat().st_size) if target.exists() else 0,
+        }
+
+    @staticmethod
+    def _resolve_session_dir(ctx) -> Path | None:
+        """Same resolution order as :class:`ReportExecutor`."""
+        extra = getattr(ctx, "extra", None) or {}
+        if extra.get("session_dir"):
+            return Path(extra["session_dir"])
+        params = ctx.task.params or {}
+        if params.get("session_dir"):
+            return Path(params["session_dir"])
+        from ...paths import session_dir as _sd
+        candidate = _sd()
+        # Don't require state.json — a fresh session with only manifest can
+        # still produce a partial breakdown (with a warning).
+        if candidate.exists() and (candidate / "manifest.json").exists():
+            return candidate
+        return None
+
+
+session_breakdown_executor = SessionBreakdownExecutor()
+
+
+__all__ = ["SessionBreakdownExecutor", "session_breakdown_executor"]

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -2020,6 +2020,19 @@ class Coordinator:
         }
         if key not in existing:
             self.shared_state.optimization_stack.append(entry)
+            # Per-entry incremental gain (current_best vs. baseline at the
+            # moment this integrate KEEP landed). Keeps
+            # ``gain_per_stack_entry`` index-aligned with
+            # ``optimization_stack`` for session_breakdown's
+            # capability_summary attribution.
+            gain_pct_entry: float | None = None
+            try:
+                bt = float(self.shared_state.baseline_tput or 0.0)
+                if bt > 0:
+                    gain_pct_entry = (float(new_tput) - bt) / bt * 100.0
+            except (TypeError, ValueError):
+                gain_pct_entry = None
+            self.shared_state.gain_per_stack_entry.append(gain_pct_entry)
 
         self.shared_state.current_best = {
             "action": "integrate",
@@ -2215,6 +2228,17 @@ class Coordinator:
                     ),
                     "ts": datetime.now(timezone.utc).isoformat(),
                 })
+                # Mirror append into ``gain_per_stack_entry`` so indexes
+                # stay aligned across the two parallel lists. See the
+                # SharedState docstring for the contract.
+                gain_pct_entry: float | None = None
+                try:
+                    bt = float(self.shared_state.baseline_tput or 0.0)
+                    if bt > 0:
+                        gain_pct_entry = (float(best_tput) - bt) / bt * 100.0
+                except (TypeError, ValueError):
+                    gain_pct_entry = None
+                self.shared_state.gain_per_stack_entry.append(gain_pct_entry)
 
         self.shared_state.current_best = {
             "action": task_kind,

--- a/inference_optimizer/orchestrator/shared_state.py
+++ b/inference_optimizer/orchestrator/shared_state.py
@@ -100,6 +100,14 @@ _KEY_METRIC_MAP: dict[str, tuple[str, str]] = {
 @dataclass
 class SharedState:
     session_id: str = ""
+    # Primus-Claw session UUID (when Hyperloom runs inside the claw
+    # sandbox); empty when running standalone. Wired into the manifest +
+    # session_breakdown.json so downstream dashboards can join Hyperloom
+    # sessions back to claw sessions without an env-var lookup.
+    claw_session_id: str = ""
+    # Primus-Claw sandbox user id (string). Same provenance as
+    # ``claw_session_id``; empty when running standalone.
+    sandbox_user_id: str = ""
     model_name: str = ""
     model_path: str = ""
     model_class: str = ""
@@ -123,6 +131,16 @@ class SharedState:
     # records the incremental candidate that was accepted; current_best keeps
     # the materialized full args/env for execution.
     optimization_stack: list[dict[str, Any]] = field(default_factory=list)
+    # Parallel to ``optimization_stack``: per-entry incremental gain in
+    # percent (current_best vs. baseline at the moment that stack entry
+    # was promoted). Index ``i`` here aligns with index ``i`` in
+    # ``optimization_stack``. session_breakdown's capability_summary uses
+    # this to attribute "how much of the validated cumulative gain came
+    # from this action / capability" without re-walking the event log.
+    # Coordinator appends to this list at the same time it appends to
+    # ``optimization_stack`` (see ``_lift_to_current_best``); missing
+    # entries (e.g. on resumed sessions) are treated as ``None``.
+    gain_per_stack_entry: list[float | None] = field(default_factory=list)
     cumulative_gain: float = 0.0
     # Cumulative gain measured by the `validate_stack` action — i.e. by
     # actually re-baselining a fresh server with EVERY KEEP'd entry of
@@ -1339,6 +1357,12 @@ class SharedState:
             "workspace": self.current_best.get("workspace"),
             "source": "seeded_from_current_best",
         }]
+        # Keep ``gain_per_stack_entry`` aligned with ``optimization_stack``
+        # (None == we don't know the per-entry gain for seeded entries).
+        if len(self.gain_per_stack_entry) < len(self.optimization_stack):
+            self.gain_per_stack_entry.extend(
+                [None] * (len(self.optimization_stack) - len(self.gain_per_stack_entry))
+            )
 
     # ------------------------------------------------------------------
     # Time-budget helpers (Phase 2 — consumed by Coordinator._compose_prompt)

--- a/inference_optimizer/scripts/dump_session_breakdown.py
+++ b/inference_optimizer/scripts/dump_session_breakdown.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Dump ``session_breakdown.json`` for one hyperloom session directory.
+
+This is the offline / historical / debugging entrypoint. The same
+builder is used by:
+
+* Coordinator action ``session_breakdown`` (live, agent-driven)
+* ``cli.py`` finally block (live, end-of-session safety net)
+* This script (offline / batch / WekaFS sessions)
+
+Examples
+--------
+
+::
+
+    # Live session in this sandbox (USER_DATA_PATH or /workspace/hyperloom)
+    python -m inference_optimizer.scripts.dump_session_breakdown
+
+    # Historical session on WekaFS
+    python -m inference_optimizer.scripts.dump_session_breakdown \\
+        --session-dir /wekafs/users/zgong/inference_optimizer-sessions/<sid>
+
+    # Override output path (don't touch session_dir)
+    python -m inference_optimizer.scripts.dump_session_breakdown \\
+        --session-dir <SD> --output /tmp/breakdown-<sid>.json
+
+    # Bulk historical
+    for d in /wekafs/users/*/inference_optimizer-sessions/*; do
+        [ -d "$d" ] || continue
+        python -m inference_optimizer.scripts.dump_session_breakdown \\
+            --session-dir "$d" > /dev/null
+    done
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+from ..breakdown import BREAKDOWN_FILENAME, build, write_breakdown_json
+from ..paths import session_dir as default_session_dir
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="dump_session_breakdown",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--session-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Hyperloom session directory. Defaults to "
+            "$USER_DATA_PATH (set by production launchers) or "
+            "/workspace/hyperloom."
+        ),
+    )
+    parser.add_argument(
+        "--output", "-o",
+        type=Path,
+        default=None,
+        help=(
+            f"Override output file path. Defaults to "
+            f"<session_dir>/{BREAKDOWN_FILENAME}."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Build the breakdown dict and print summary stats; do not write.",
+    )
+    parser.add_argument(
+        "--print",
+        dest="print_json",
+        action="store_true",
+        help="Also print the full JSON to stdout (useful for piping).",
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="count", default=0,
+        help="-v INFO, -vv DEBUG.",
+    )
+    return parser
+
+
+def _setup_logging(verbose: int) -> None:
+    level = logging.WARNING
+    if verbose == 1:
+        level = logging.INFO
+    elif verbose >= 2:
+        level = logging.DEBUG
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+
+def _summary_line(breakdown: dict) -> str:
+    sess = breakdown.get("session") or {}
+    final = breakdown.get("final") or {}
+    cap = breakdown.get("capability_summary") or {}
+    geak_n = len(breakdown.get("geak_invocations") or [])
+    oob_n = len(breakdown.get("oob_invocations") or [])
+    lifecycle = breakdown.get("kernel_lifecycle") or {}
+    sweep = breakdown.get("sweep") or {}
+    warnings = breakdown.get("warnings") or []
+    return (
+        f"session_id={sess.get('session_id', '?')}  "
+        f"claw_session_id={sess.get('claw_session_id') or '(none)'}  "
+        f"stop_reason={sess.get('stop_reason') or '?'}  "
+        f"gain_validated={final.get('cumulative_gain_pct_validated', 0.0):.2f}%  "
+        f"geak={geak_n}  oob={oob_n}  "
+        f"detected={len(lifecycle.get('detected') or [])}  "
+        f"adopted={len(lifecycle.get('adopted') or [])}  "
+        f"sweep={len(sweep.get('all_variants') or [])}  "
+        f"warnings={len(warnings)}"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    _setup_logging(args.verbose)
+    log = logging.getLogger("dump_session_breakdown")
+
+    sd = args.session_dir if args.session_dir else default_session_dir()
+    sd = Path(sd).resolve()
+    if not sd.exists():
+        print(f"ERROR: session-dir does not exist: {sd}", file=sys.stderr)
+        return 2
+
+    if args.dry_run:
+        breakdown = build(sd)
+        print(_summary_line(breakdown))
+        if args.print_json:
+            print(json.dumps(breakdown, indent=2, sort_keys=True))
+        return 0
+
+    try:
+        out_path = write_breakdown_json(sd, output_path=args.output)
+    except Exception as exc:  # noqa: BLE001
+        log.exception("write_breakdown_json failed")
+        print(f"ERROR: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+
+    breakdown = build(sd)  # cheap rebuild for summary printing
+    print(f"Wrote {out_path}")
+    print(_summary_line(breakdown))
+    if args.print_json:
+        print(json.dumps(breakdown, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/inference_optimizer/scripts/dump_session_report.py
+++ b/inference_optimizer/scripts/dump_session_report.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Render a markdown session report from a ``session_breakdown.json``.
+
+Usage::
+
+    # Deterministic only (no LLM):
+    python -m inference_optimizer.scripts.dump_session_report \\
+        --input  /wekafs/.../session_breakdown.json \\
+        --output /wekafs/.../session_report.md
+
+    # With LLM-polished prose (OpenAI-compatible endpoint):
+    HYPERLOOM_REPORT_LLM_BACKEND=openai \\
+    OPENAI_BASE_URL=http://127.0.0.1:4002/v1 \\
+    OPENAI_API_KEY=... \\
+    python -m inference_optimizer.scripts.dump_session_report \\
+        --input  /wekafs/.../session_breakdown.json \\
+        --output /wekafs/.../session_report.md
+
+When --output is omitted the report is written to
+``<session_dir>/session_report.md`` next to the input file. The LLM
+user prompt and raw response (when used) are persisted alongside as
+``session_report_prompt.json`` / ``session_report_llm_raw.txt`` so
+hallucinations can be audited after the fact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+from inference_optimizer.breakdown.reporters import render_session_report
+from inference_optimizer.breakdown.reporters.llm_client import build_client_from_env
+
+log = logging.getLogger("dump_session_report")
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Render a Hyperloom session_breakdown.json to markdown.",
+    )
+    p.add_argument("--input", "-i", required=True, type=Path,
+                   help="Path to session_breakdown.json")
+    p.add_argument("--output", "-o", type=Path, default=None,
+                   help="Output markdown path (defaults to <session_dir>/session_report.md)")
+    p.add_argument("--no-llm", action="store_true",
+                   help="Skip LLM narrative pass even if env vars are configured")
+    p.add_argument("--debug-dump", action="store_true",
+                   help="Also write LLM prompt + raw response next to the report")
+    return p.parse_args(argv)
+
+
+def _resolve_output(input_path: Path, requested: Path | None) -> Path:
+    if requested is not None:
+        return requested
+    return input_path.parent / "session_report.md"
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("HYPERLOOM_LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    args = _parse_args(argv)
+
+    if not args.input.exists():
+        log.error("input not found: %s", args.input)
+        return 2
+    try:
+        breakdown = json.loads(args.input.read_text())
+    except Exception as exc:  # noqa: BLE001
+        log.error("failed to parse %s: %s", args.input, exc)
+        return 2
+
+    llm = None if args.no_llm else build_client_from_env()
+    if llm is not None:
+        log.info("LLM backend active: %s", type(llm).__name__)
+    else:
+        log.info("LLM backend disabled — deterministic-only report")
+
+    result = render_session_report(breakdown, llm_client=llm)
+    out_path = _resolve_output(args.input, args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(result.markdown)
+    log.info("wrote %s (%d bytes, used_llm=%s)",
+             out_path, len(result.markdown), result.used_llm)
+
+    if args.debug_dump:
+        (out_path.parent / "session_report_prompt.json").write_text(result.llm_user_prompt)
+        (out_path.parent / "session_report_llm_raw.txt").write_text(result.llm_raw_response or "")
+        log.info("wrote debug dumps next to %s", out_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/inference_optimizer/tests/test_breakdown_smoke.py
+++ b/inference_optimizer/tests/test_breakdown_smoke.py
@@ -1,0 +1,447 @@
+"""End-to-end smoke test for the breakdown exporter.
+
+Builds a synthetic but realistic session_dir tree (manifest + state +
+runs/ + kernel-agent-workspace + critic/robustness workdirs) and asserts
+that:
+
+1. ``build()`` returns a dict matching the top-level envelope.
+2. ``write_breakdown_json()`` writes valid JSON that round-trips.
+3. Per-attempt KEEP stamping correctly assigns the kernel-level decision
+   to only the BEST attempt for each kernel (not every attempt).
+4. Each of the 14 sections has the expected key facts.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from inference_optimizer.breakdown import (
+    BREAKDOWN_FILENAME,
+    SCHEMA_VERSION,
+    build,
+    write_breakdown_json,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture builder
+# ---------------------------------------------------------------------------
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _build_fixture(sd: Path) -> None:
+    sd.mkdir(parents=True, exist_ok=True)
+
+    _write_json(sd / "manifest.json", {
+        "schema_version": 1,
+        "session_id":     "DeepSeek-R1_20260514T071000Z_abcd1234",
+        "claw_session_id":"claw-test-1234",
+        "sandbox_user_id":"hai.song@core42.ai",
+        "created_at_utc": "2026-05-14T07:10:00+00:00",
+        "session_dir":    str(sd),
+        "model_path":     "/wekafs/models/DeepSeek-R1",
+        "model_name":     "DeepSeek-R1",
+        "framework":      "sglang",
+        "gpu_type":       "mi300x",
+        "tp":              8,
+        "workload":       {"isl": 1024, "osl": 1024, "max_model_len": 6144,
+                            "precision": "fp8", "conc": 64},
+        "objective":      {"kind": "gain_pct", "value": 30.0},
+        "max_minutes":    180,
+        "code_revision":  "86d2ed3",
+        "pid":             12345,
+        "host":            "core42-mi300x-r1",
+    })
+
+    _write_json(sd / "state.json", {
+        "session_id":     "DeepSeek-R1_20260514T071000Z_abcd1234",
+        "model_name":     "DeepSeek-R1",
+        "model_path":     "/wekafs/models/DeepSeek-R1",
+        "model_class":    "moe",
+        "framework":      "sglang",
+        "gpu_type":       "mi300x",
+        "baseline_tput":  421.5,
+        "baseline_accuracy": 0.84,
+        "baseline_failure_streak": 0,
+        "baseline_config_path": "runs/baseline/t1/baseline_config.with_envs.yaml",
+        "current_best":   {"tput": 776.4, "action": "validate_stack",
+                            "extra_sglang_args": "--enable-X --nccl-Y",
+                            "extra_envs": {"NCCL_DEBUG": "INFO"},
+                            "ttft_mean_ms": 110.2, "e2el_mean_ms": 1200.4},
+        "optimization_stack": [
+            {"action": "backends",     "variant_name": "flag_X", "gain_pct": 23.4,
+             "extra_sglang_args": "--enable-X",
+             "ts": "2026-05-14T07:15:00+00:00"},
+            {"action": "params",       "variant_name": "nccl_Y", "gain_pct":  7.8,
+             "extra_sglang_args": "--nccl-Y",
+             "ts": "2026-05-14T07:30:00+00:00"},
+            {"action": "kernel_opt:k001", "variant_name": "",  "gain_pct": 45.6,
+             "extra_sglang_args": "",
+             "ts": "2026-05-14T08:00:00+00:00"},
+        ],
+        "cumulative_gain": 91.5,
+        "cumulative_gain_validated": 84.2,
+        "cumulative_gain_validated_ts": "2026-05-14T08:30:00+00:00",
+        "cumulative_gain_validated_stack_len": 3,
+        "stop_reason": "target_reached",
+        "start_ts": "2026-05-14T07:10:00+00:00",
+        "max_minutes": 180,
+        "tick": 145,
+        "last_baseline": {"workspace": str(sd / "runs/baseline/t1")},
+        "baseline_attempts": [
+            {"ts": "2026-05-14T07:12:00+00:00", "task_id": "t1",
+             "status": "succeeded", "decision": "promoted",
+             "key_metric": 421.5,   "workspace": str(sd / "runs/baseline/t1")},
+        ],
+        "profile_attempts": [
+            {"ts": "2026-05-14T07:14:00+00:00", "task_id": "p1",
+             "status": "succeeded", "decision": "promoted", "key_metric": 421.5},
+        ],
+        "backends_attempts": [
+            {"ts": "2026-05-14T07:15:00+00:00", "task_id": "b1",
+             "status": "succeeded", "decision": "promoted", "key_metric": 23.4},
+        ],
+        "params_attempts": [
+            {"ts": "2026-05-14T07:30:00+00:00", "task_id": "pa1",
+             "status": "succeeded", "decision": "promoted", "key_metric": 7.8},
+        ],
+        "sweep_attempts": [
+            {"ts": "2026-05-14T08:20:00+00:00", "task_id": "s1",
+             "status": "succeeded", "decision": "promoted",
+             "key_metric": 812.0, "workspace": str(sd / "runs/sweep/s1")},
+        ],
+        "validate_stack_attempts": [
+            {"ts": "2026-05-14T08:30:00+00:00", "task_id": "v1",
+             "status": "succeeded", "decision": "promoted", "key_metric": 84.2},
+        ],
+        "last_select_kernels": {"hot_kernels_top15": [
+            {"kernel_id": "k001", "name": "fused_rmsnorm", "gpu_pct": 18.2,
+             "bottleneck": "memory", "arithmetic_intensity": 4.0,
+             "source_file": "/path/to/rmsnorm.py", "reusable_native_kernel": True,
+             "recommended_backends": ["claude", "geak"],
+             "recommended_actions": ["run_optimization"]},
+        ], "ts": "2026-05-14T07:14:30+00:00"},
+        "last_sweep": {
+            "grid_size": 9,
+            "best_overall": {"variant_name": "variant_05_conc32_isl1024_osl1024",
+                              "output_throughput": 812.0, "conc": 32},
+            "best_for_each_conc": [
+                {"conc": 32, "tput": 812.0},
+                {"conc": 64, "tput": 776.4},
+            ],
+            "pareto_front": [],
+        },
+        "last_kernel_opt": {"kernel_id": "k001", "decision": "KEEP",
+                              "micro_speedup": 1.27, "compile_passed": True,
+                              "correctness_passed": True,
+                              "best_artifact_path": "patches/k001/0001.patch",
+                              "ts": "2026-05-14T08:00:00+00:00"},
+        "kernel_opt_attempts": {"k001": {
+            "attempts": 3, "partial_count": 1, "last_decision": "KEEP",
+            "last_ts": "2026-05-14T08:00:00+00:00",
+            "history": [
+                {"decision": "PARTIAL", "ts": "2026-05-14T07:40:00+00:00"},
+                {"decision": "PARTIAL", "ts": "2026-05-14T07:50:00+00:00"},
+                {"decision": "KEEP",    "ts": "2026-05-14T08:00:00+00:00"},
+            ],
+        }},
+        "kernel_integrate_attempts": {"k001|patches/k001/0001.patch|": {
+            "key": "k001|patches/k001/0001.patch|",
+            "kernel_id": "k001", "patch_path": "patches/k001/0001.patch",
+            "target_file": "/path/to/rmsnorm.py", "extra_sglang_args": "",
+            "attempts": [
+                {"decision": "KEEP", "status": "succeeded",
+                 "new_tput": 776.4, "gain_pct": 45.6,
+                 "ts": "2026-05-14T08:00:00+00:00"},
+            ],
+            "attempt_count": 1, "best_gain_pct": 45.6,
+            "last_decision": "KEEP", "last_status": "succeeded",
+            "updated_at": "2026-05-14T08:00:00+00:00",
+        }},
+        "rejected_kernel_patches": [],
+        "rejected_kernel_ids": ["k042"],
+        "params_search": {
+            "schema_version": 2,
+            "accepted": [{"name": "nccl_Y", "fingerprint": "f1",
+                           "extra_sglang_args": "--nccl-Y", "extra_envs": {},
+                           "output_throughput": 454.3, "gain_pct": 7.8,
+                           "ts": "2026-05-14T07:30:00+00:00"}],
+            "rejected": [{"name": "bad_x", "fingerprint": "f2", "gain_pct": -2.5}],
+            "tested": {
+                "f1": {"name": "nccl_Y",  "fingerprint": "f1", "gain_pct":  7.8},
+                "f2": {"name": "bad_x",   "fingerprint": "f2", "gain_pct": -2.5},
+                "f3": {"name": "neutral", "fingerprint": "f3", "gain_pct":  0.1},
+            },
+            "name_index": {}, "cursor": 3,
+        },
+        "backends_search": {
+            "schema_version": 1,
+            "accepted": [{"name": "flag_X", "fingerprint": "g1",
+                           "gain_pct": 23.4,
+                           "ts": "2026-05-14T07:15:00+00:00"}],
+            "rejected": [],
+            "tested": {"g1": {"name": "flag_X", "fingerprint": "g1", "gain_pct": 23.4}},
+            "name_index": {}, "cursor": 1,
+        },
+    })
+
+    bdir = sd / "runs/baseline/t1/benchmark_001"
+    _write_json(bdir / "benchmark_report.json", {
+        "success": True, "output_throughput_tok_s": 421.5,
+        "mean_ttft_ms": 152.3, "mean_e2el_ms": 1840.7, "mean_tpot_ms": 8.4,
+        "gpu_monitor": [{"power_w": 420, "temperature_c": 60, "clock_mhz": 2040}],
+    })
+
+    pdir = sd / "runs/profile/p1/benchmark_001"
+    _write_json(pdir / "benchmark_report.json", {
+        "success": True,
+        "kernel_summary": [
+            {"kernel_id": "k001", "name": "fused_rmsnorm", "gpu_pct": 18.2,
+             "time_ms": 0.42, "bottleneck": "memory",
+             "arithmetic_intensity": 4.0,
+             "reusable_native_kernel": True, "source_file": "/path/to/rmsnorm.py"},
+            {"kernel_id": "k002", "name": "attention_qkv", "gpu_pct": 14.5,
+             "time_ms": 0.33, "bottleneck": "compute"},
+        ],
+        "top_bottlenecks": [{"kernel_id": "k001", "bottleneck": "memory"}],
+        "gpu_monitor": {"power_w": 510, "temperature_c": 72, "clock_mhz": 2100},
+    })
+
+    for i, conc in enumerate((32, 64, 128), 1):
+        vdir = sd / f"runs/sweep/s1/variant_0{i}_conc{conc}_isl1024_osl1024/benchmark_001"
+        _write_json(vdir / "benchmark_report.json", {
+            "success": True,
+            "output_throughput_tok_s": 600.0 + 100.0 * i,
+            "mean_ttft_ms": 120 + 5 * i,
+            "mean_tpot_ms": 7 + 0.3 * i,
+            "mean_e2el_ms": 1300 + 50 * i,
+        })
+
+    kar = sd / "kernel-agent-workspace/kernel-agent/runs/sess001"
+    for sub in ("prompts", "optimized", "results", "verification"):
+        (kar / sub).mkdir(parents=True)
+    (kar / "prompts" / "a01.md").write_text("kernel: fused_rmsnorm", encoding="utf-8")
+    (kar / "prompts" / "a02.md").write_text("kernel: fused_rmsnorm (retry)", encoding="utf-8")
+    (kar / "prompts" / "a03.md").write_text("kernel: fused_rmsnorm (final)", encoding="utf-8")
+    (kar / "optimized" / "a03_kernel.cuh").write_text("__global__ void foo() {}", encoding="utf-8")
+    _write_json(kar / "verification" / "k001.json", {
+        "micro_speedup": 1.27, "compile_passed": True, "correctness_passed": True,
+        "best_artifact_path": str(sd / "patches/k001/0001.patch"),
+    })
+    _write_json(kar / "results" / "k001.json", {
+        "tool": "kernel_optimization", "session_id": "sess001",
+        "run_id": "ko-deadbeef", "kernel_id": "k001",
+        "source_file": "/path/to/rmsnorm.py",
+        "best_artifact_path": str(sd / "patches/k001/0001.patch"),
+        "selected_backends": ["claude"],
+        "proposal": {"decision": "KEEP", "reasons": ["compile_pass"]},
+        "verification": {"micro_speedup": 1.27, "compile_passed": True,
+                          "correctness_passed": True},
+        "cli_log_path": str(kar / "logs/kernel_optimization/ko-deadbeef.log"),
+    })
+    with (kar / "optimization_attempts.jsonl").open("w", encoding="utf-8") as f:
+        for i, spd in enumerate([1.04, 1.11, 1.27], 1):
+            f.write(json.dumps({
+                "attempt_id": f"a{i:02d}",
+                "kernel_id":  "k001",
+                "backend":    "claude",
+                "model":      "claude-sonnet-4.5",
+                "ts":         f"2026-05-14T07:{40+i*5:02d}:00+00:00",
+                "status":     "succeeded",
+                "speedup":    spd,
+                "name":       "fused_rmsnorm",
+                "source_file": "/path/to/rmsnorm.py",
+            }) + "\n")
+
+    cw = sd / "critic-workdir/001"
+    _write_json(cw / "review.json", {
+        "verdict": "approve", "topic": "kernel_opt:k001",
+        "summary": "Speedup verified.",
+        "ts": "2026-05-14T08:01:00+00:00",
+    })
+    _write_json(cw / "emit.json", {"topic": "kernel_opt:k001",
+                                     "ts": "2026-05-14T08:00:30+00:00"})
+
+    rw = sd / "robustness-workdir/001"
+    _write_json(rw / "signal.json", {"signal": "stall",
+                                       "ts": "2026-05-14T07:55:00+00:00"})
+    _write_json(rw / "action.json", {"action": "force_replan",
+                                       "ts": "2026-05-14T07:55:30+00:00"})
+
+    (sd / "patches/k001").mkdir(parents=True)
+    (sd / "patches/k001" / "0001.patch").write_text("--- a\n+++ b\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def fixture_session(tmp_path: Path) -> Path:
+    sd = tmp_path / "session"
+    _build_fixture(sd)
+    return sd
+
+
+def test_envelope(fixture_session: Path) -> None:
+    """Top-level keys and schema_version match the contract."""
+    b = build(fixture_session)
+    assert b["schema_version"] == SCHEMA_VERSION
+    assert "exported_at_utc" in b
+    assert "exporter_version" in b
+    for key in (
+        "session", "workload", "baseline", "final", "phase_timeline",
+        "capability_summary", "geak_invocations", "oob_invocations",
+        "kernel_lifecycle", "param_search", "sweep", "critic_robustness",
+        "telemetry", "attribution", "warnings", "source_files",
+    ):
+        assert key in b, f"missing top-level: {key}"
+
+
+def test_write_breakdown_json_atomic(fixture_session: Path) -> None:
+    """write_breakdown_json places the file at the expected path with valid JSON."""
+    out = write_breakdown_json(fixture_session)
+    assert out == fixture_session / BREAKDOWN_FILENAME
+    assert out.exists()
+    rt = json.loads(out.read_text(encoding="utf-8"))
+    assert rt["schema_version"] == SCHEMA_VERSION
+
+
+def test_session_metadata(fixture_session: Path) -> None:
+    s = build(fixture_session)["session"]
+    assert s["session_id"] == "DeepSeek-R1_20260514T071000Z_abcd1234"
+    assert s["claw_session_id"] == "claw-test-1234"
+    assert s["sandbox_user_id"] == "hai.song@core42.ai"
+    assert s["stop_reason"] == "target_reached"
+    assert s["max_minutes"] == 180
+
+
+def test_keep_stamping_only_best_attempt(fixture_session: Path) -> None:
+    """KEEP decision must land on the BEST attempt, not every attempt."""
+    oob = build(fixture_session)["oob_invocations"]
+    assert len(oob) == 3
+    keeps = [o for o in oob if o["decision"] == "KEEP"]
+    others = [o for o in oob if o["decision"] != "KEEP"]
+    assert len(keeps) == 1, [o["decision"] for o in oob]
+    assert len(others) == 2
+    assert keeps[0]["micro_speedup"] == 1.27
+    assert keeps[0]["compile_passed"] is True
+    assert keeps[0]["correctness_passed"] is True
+    assert all(o["decision"] == "" for o in others)
+
+
+def test_capability_summary(fixture_session: Path) -> None:
+    cap = build(fixture_session)["capability_summary"]
+    assert cap["oob"]["status"] == "kept"
+    assert cap["oob"]["keeps"] == 1
+    assert cap["oob"]["attempts"] == 3
+    assert cap["geak"]["status"] == "not_attempted"
+    assert cap["backends"]["status"] == "kept"
+    assert cap["backends"]["best_gain_pct"] == pytest.approx(23.4)
+    assert cap["params"]["status"] == "kept"
+    assert cap["sweep"]["status"] == "completed"
+    assert cap["validate_stack"]["last_validated_gain_pct"] == pytest.approx(84.2)
+
+
+def test_kernel_lifecycle_five_stages(fixture_session: Path) -> None:
+    lc = build(fixture_session)["kernel_lifecycle"]
+    assert len(lc["detected"]) == 2
+    assert {k["kernel_id"] for k in lc["detected"]} == {"k001", "k002"}
+    assert len(lc["recommended"]) == 1
+    assert lc["recommended"][0]["kernel_id"] == "k001"
+    assert len(lc["optimized"]) == 1
+    assert lc["optimized"][0]["best_micro_speedup"] == pytest.approx(1.27)
+    assert lc["optimized"][0]["last_decision"] == "KEEP"
+    assert len(lc["adopted"]) == 1
+    assert lc["adopted"][0]["kernel_id"] == "k001"
+    assert lc["adopted"][0]["e2e_gain_pct"] == pytest.approx(45.6)
+    assert len(lc["rejected"]) == 1
+    assert lc["rejected"][0]["kernel_id"] == "k042"
+
+
+def test_sweep_picks_up_disk_variants(fixture_session: Path) -> None:
+    sweep = build(fixture_session)["sweep"]
+    assert len(sweep["all_variants"]) == 3
+    concs = sorted(v["conc"] for v in sweep["all_variants"])
+    assert concs == [32, 64, 128]
+    for v in sweep["all_variants"]:
+        assert v["output_throughput_tok_s"] is not None
+        assert v["benchmark_report_path"] is not None
+
+
+def test_critic_robustness(fixture_session: Path) -> None:
+    cr = build(fixture_session)["critic_robustness"]
+    assert len(cr["critic_iterations"]) == 1
+    assert cr["critic_iterations"][0]["verdict"] == "approve"
+    assert cr["critic_iterations"][0]["iter"] == 1
+    assert len(cr["robustness_signals"]) == 1
+    assert cr["robustness_signals"][0]["signal"] == "stall"
+
+
+def test_telemetry_aggregates_gpu_monitor(fixture_session: Path) -> None:
+    tel = build(fixture_session)["telemetry"]
+    assert tel["baseline_report_path"] is not None
+    assert len(tel["profile_report_paths"]) == 1
+    gm = tel["gpu_monitor_aggregate"]
+    assert gm["samples"] >= 1
+    assert gm["avg_power_w"] > 0
+    assert gm["max_power_w"] >= gm["avg_power_w"]
+
+
+def test_attribution_kernel_goes_to_oob(fixture_session: Path) -> None:
+    """The single KEEP'd kernel is OOB; family breakdown must reflect that."""
+    attr = build(fixture_session)["attribution"]
+    assert len(attr["gain_per_stack_entry"]) == 3
+    sb = attr["source_breakdown"]
+    assert sb["oob_pct_of_total"] >= 45.0
+    assert sb["geak_pct_of_total"] == 0.0
+    assert sb["backends_pct_of_total"] == pytest.approx(23.4)
+    assert sb["params_pct_of_total"] == pytest.approx(7.8)
+    assert sb["validated_total_pct"] == pytest.approx(84.2)
+
+
+def test_phase_timeline_sorted_by_ts(fixture_session: Path) -> None:
+    ts = build(fixture_session)["phase_timeline"]
+    ts_values = [e.get("ts") or "" for e in ts]
+    assert ts_values == sorted(ts_values)
+    actions = {e["action"] for e in ts}
+    assert "baseline" in actions
+    assert "validate_stack" in actions
+    assert "kernel_opt" in actions or "integrate" in actions
+
+
+def test_param_search_summary(fixture_session: Path) -> None:
+    ps = build(fixture_session)["param_search"]
+    assert ps["params"]["tested_count"] == 3
+    assert ps["backends"]["tested_count"] == 1
+    assert ps["params"]["accepted"][0]["name"] == "nccl_Y"
+    assert ps["backends"]["accepted"][0]["name"] == "flag_X"
+
+
+def test_missing_state_returns_partial_with_warnings(tmp_path: Path) -> None:
+    """A near-empty session_dir (only manifest) must still produce a valid envelope."""
+    sd = tmp_path / "session"
+    _write_json(sd / "manifest.json", {
+        "schema_version": 1, "session_id": "ghost", "model_name": "ghost",
+        "claw_session_id": "claw-ghost", "framework": "sglang", "gpu_type": "mi300x",
+    })
+    b = build(sd)
+    assert b["schema_version"] == SCHEMA_VERSION
+    assert b["session"]["session_id"] == "ghost"
+    assert b["session"]["claw_session_id"] == "claw-ghost"
+    assert any("state.json missing" in w for w in b["warnings"])
+
+
+def test_no_kernel_agent_runs_returns_empty_invocations(tmp_path: Path) -> None:
+    """A session without any kernel-agent activity must not crash collectors."""
+    sd = tmp_path / "session"
+    _write_json(sd / "manifest.json", {"schema_version": 1, "session_id": "x"})
+    _write_json(sd / "state.json", {"session_id": "x", "baseline_tput": 100.0})
+    b = build(sd)
+    assert b["geak_invocations"] == []
+    assert b["oob_invocations"] == []
+    assert b["kernel_lifecycle"]["detected"] == []

--- a/inference_optimizer/tests/test_p1_2_full_action_catalogue.py
+++ b/inference_optimizer/tests/test_p1_2_full_action_catalogue.py
@@ -29,11 +29,12 @@ EXPECTED_ACTIONS_V06: dict[str, str] = {
     # analysis (2)
     "profile":              "analysis",
     "pmc_roofline":         "analysis",
-    # shallow (4) — report lives here per DESIGN §16.1
+    # shallow (5) — report + session_breakdown live here per DESIGN §16.1
     "backends":             "shallow",
     "params":               "shallow",
     "sweep":                "shallow",
     "report":               "shallow",
+    "session_breakdown":    "shallow",
     # deep_kernel (5)
     "kernel_opt":           "deep_kernel",
     "integrate":            "deep_kernel",
@@ -213,8 +214,9 @@ def test_runs_actions_fallback_matches_registry(registry):
 def test_cli_real_executors_consistent_with_runs_actions():
     """Every action wired with a real executor in
     ``cli._register_executors`` must either be in ``_runs_actions()``
-    (writes per-task artefacts under ``runs/<kind>/<task_id>/``) or be the
-    special ``report`` action (writes to ``reports/`` instead).
+    (writes per-task artefacts under ``runs/<kind>/<task_id>/``) or be one
+    of the special session-root writers (``report`` → ``reports/``,
+    ``session_breakdown`` → ``session_breakdown.json`` at the session root).
 
     This is the primary cli ↔ session_paths drift guard: if someone adds
     a real executor without giving its yaml a ``pipeline_phase`` that
@@ -226,28 +228,29 @@ def test_cli_real_executors_consistent_with_runs_actions():
     )
     from inference_optimizer.session_paths import _runs_actions
 
-    REPORTS_ONLY = {"report"}
+    SESSION_ROOT_WRITERS = {"report", "session_breakdown"}
     runs = _runs_actions()
     real_kinds = (
         set(_REAL_EXECUTORS_FULL.keys())
         | set(_REAL_EXECUTORS_KERNEL_ONLY.keys())
     )
 
-    missing_from_runs = (real_kinds - REPORTS_ONLY) - runs
+    missing_from_runs = (real_kinds - SESSION_ROOT_WRITERS) - runs
     assert not missing_from_runs, (
         f"actions {sorted(missing_from_runs)!r} have a real executor in "
         f"cli._REAL_EXECUTORS_* but are not in _runs_actions(); "
         f"SubAgentRunner will not pre-mkdir the workspace and the "
         f"executor's runs_dir() fallback will raise. Either give the "
         f"action a yaml pipeline_phase in _RUNS_WORKSPACE_PHASES, or "
-        f"document why it should be exempt (cf. report → reports/)."
+        f"document why it should be exempt (cf. report → reports/, "
+        f"session_breakdown → session_breakdown.json)."
     )
 
-    overclaim = REPORTS_ONLY & runs
+    overclaim = SESSION_ROOT_WRITERS & runs
     assert not overclaim, (
-        f"actions {sorted(overclaim)!r} are listed in REPORTS_ONLY but "
-        f"are also in _runs_actions(); pick one (write either to runs/ "
-        f"or to reports/, not both)."
+        f"actions {sorted(overclaim)!r} are listed in SESSION_ROOT_WRITERS "
+        f"but are also in _runs_actions(); pick one (write either to "
+        f"runs/ or to the session root, not both)."
     )
 
 

--- a/inference_optimizer/tests/test_reporters_smoke.py
+++ b/inference_optimizer/tests/test_reporters_smoke.py
@@ -1,0 +1,313 @@
+"""Smoke tests for the ``breakdown.reporters`` compose pipeline.
+
+We feed each renderer a hand-built ``session_breakdown.json`` shape
+and check the cross-section + section invariants that historically
+broke. Specifically:
+
+* GEAK / OOB ``not_attempted`` MUST NOT yield decisions of any other
+  kind (the old MAE bug attributed 715% gain to GEAK on a session
+  that never ran GEAK).
+* All-zero GPU power/temp with non-zero samples MUST raise a
+  ``data_quality_flag`` (the gpu_monitor units bug).
+* ``phase_timeline=[]`` MUST be flagged so report consumers know
+  process reconstruction is unavailable.
+* Deterministic-only path (no LLM) must produce non-empty markdown
+  whose executive summary mentions the headline and every data
+  quality flag.
+* LLM path with a faulty client (e.g. JSON parse failure) must
+  degrade to the deterministic exec summary instead of crashing.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from inference_optimizer.breakdown.reporters import render_session_report
+from inference_optimizer.breakdown.reporters.base import REGISTRY
+
+
+def _fixture_breakdown(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "session": {
+            "session_id": "test-sid",
+            "claw_session_id": "test-claw",
+            "sandbox_user_id": "sandbox-1",
+            "stop_reason": "time_exhausted",
+            "elapsed_minutes": 720,
+            "tick_count": 12,
+            "host": "node-1",
+            "code_revision": "deadbeef",
+            "session_dir": "/wekafs/sessions/test",
+        },
+        "workload": {
+            "model_name": "deepseek-ai/DeepSeek-R1",
+            "framework": "vllm",
+            "gpu_type": "MI300X",
+            "tp": 8, "conc": 64, "isl": 1024, "osl": 1024,
+            "precision": "FP8", "max_model_len": 4096,
+            "objective": {"kind": "gain_pct", "value": 30.0},
+        },
+        "baseline": {
+            "throughput_tok_s_per_gpu": 2205.0,
+            "accuracy": None,
+            "ttft_mean_ms": None,
+            "e2el_mean_ms": None,
+            "failure_streak": 0,
+            "attempts_history": [],
+        },
+        "final": {
+            "throughput_tok_s_per_gpu": 2447.5,
+            "cumulative_gain_pct_validated": 10.99,
+            "cumulative_gain_pct_per_round_sum": 10.99,
+            "validated_at_stack_len": 1,
+            "validated_ts": "2026-05-12T11:54:00Z",
+            "stack_changed_after_validation": False,
+            "extra_sglang_args": "",
+            "action_path": ["backends:vllm_kv_fp8"],
+        },
+        "phase_timeline": [],
+        "capability_summary": {
+            "backends":       {"status": "kept",          "attempts": 1, "keeps": 1},
+            "params":         {"status": "not_attempted", "attempts": 0, "keeps": 0, "tested": 5},
+            "sweep":          {"status": "not_attempted", "attempts": 0, "keeps": 0, "grid_size": 9},
+            "geak":           {"status": "not_attempted", "attempts": 0, "keeps": 0},
+            "oob":            {"status": "not_attempted", "attempts": 0, "keeps": 0},
+            "validate_stack": {"status": "not_attempted", "attempts": 0, "keeps": 0},
+        },
+        "kernel_lifecycle": {
+            "detected": [{"kernel_id": f"k{i}"} for i in range(50)],
+            "recommended": [{"kernel_id": f"k{i}"} for i in range(10)],
+            "optimized": [], "adopted": [], "partial": [], "reverted": [], "rejected": [],
+        },
+        "param_search": {
+            "backends": {"accepted": ["vllm_kv_fp8"], "tested": {"vllm_kv_fp8": True}},
+            "params":   {"accepted": [], "tested": {}},
+            "discovered_flags": {},
+            "backend_winners_history": [],
+            "synergy_attempted": [],
+        },
+        "sweep": {"all_variants": [], "grid_size": 0},
+        "critic_robustness": [],
+        "telemetry": {
+            "gpu_monitor_aggregate": {
+                "samples": 52, "max_power_w": 0, "avg_power_w": 0,
+                "max_temp_c": 0, "avg_temp_c": 0,
+                "max_util_pct": 0, "avg_util_pct": 0, "source_file_count": 1,
+            },
+            "benchmark_files_total": 4,
+            "log_files_total": 3,
+            "artifact_bytes_total": 100_000,
+        },
+        "attribution": {
+            "source_breakdown": {"validated_total_pct": 10.99},
+            "notes": [],
+            "method": "single_source",
+        },
+        "source_files": {"state_json": ["state.json"]},
+    }
+    for k, v in overrides.items():
+        base[k] = v
+    return base
+
+
+def test_all_renderers_register_in_stable_order() -> None:
+    """compose.py module imports must keep this exact order."""
+    expected = [
+        "session", "workload", "baseline", "final",
+        "capability_summary", "phase_timeline", "kernel_lifecycle",
+        "geak_invocations", "oob_invocations",
+        "param_search", "sweep", "critic_robustness",
+        "attribution", "source_files",
+    ]
+    assert [sid for sid, _ in REGISTRY] == expected
+
+
+def test_telemetry_renderer_is_not_registered() -> None:
+    """Telemetry section is intentionally dropped from the report
+    layout (gpu monitor data has been consistently broken on real
+    wekafs sessions). Anti-regression for re-adding it by accident."""
+    assert "telemetry" not in [sid for sid, _ in REGISTRY]
+
+
+def test_deterministic_only_path_produces_complete_report() -> None:
+    r = render_session_report(_fixture_breakdown())
+    md = r.markdown
+    assert "# Hyperloom Session Report — test-sid" in md
+    assert "## Executive Summary" in md
+    assert "10.99%" in md
+    assert "MI300X" in md
+    # GEAK + OOB sections must mark themselves as not attempted
+    geak = next(s for s in r.sections if s.section_id == "geak_invocations")
+    assert geak.skipped
+    assert any(d.kind == "not_attempted" for d in geak.decisions)
+    oob = next(s for s in r.sections if s.section_id == "oob_invocations")
+    assert oob.skipped
+
+
+def test_skipped_sections_do_not_emit_placeholders() -> None:
+    """Previously a skipped section produced ``## Title\\n_Section
+    skipped: no data captured..._`` filler. Users complained that it
+    added visual noise without any information. Suppressing it
+    entirely is the contract now — verify by checking the markdown
+    does not mention ``geak_invocations`` / ``sweep`` / ``critic`` /
+    ``phase_timeline`` / ``not captured`` placeholder strings."""
+    r = render_session_report(_fixture_breakdown())
+    md = r.markdown
+    assert "Section skipped" not in md
+    assert "no data captured" not in md
+    # The H3 title for a skipped section must also be absent.
+    assert "### GEAK Invocations" not in md
+    assert "### Sweep" not in md
+    assert "### Phase Timeline" not in md
+
+
+def test_section_groups_use_h2_titles_with_h3_subsections() -> None:
+    r = render_session_report(_fixture_breakdown())
+    md = r.markdown
+    # H2 group titles for any group that has at least one live section.
+    assert "## Session & Workload" in md
+    assert "## Performance Results" in md
+    assert "## Capability Search" in md
+    assert "## Kernel Optimization" in md
+    # H3 subsections live underneath the H2 groups.
+    assert "### Session" in md
+    assert "### Baseline" in md
+    assert "### Capability Summary" in md
+    assert "### Kernel Lifecycle" in md
+    # Groups with all-skipped sections must NOT emit their H2 title.
+    # In the fixture sweep + phase_timeline are skipped; "Run Trace"
+    # group is phase_timeline-only so it should disappear entirely.
+    assert "## Run Trace" not in md
+
+
+def test_telemetry_section_is_absent_from_markdown() -> None:
+    """Telemetry must not appear in the report at any level."""
+    r = render_session_report(_fixture_breakdown())
+    assert "## Telemetry" not in r.markdown
+    assert "### Telemetry" not in r.markdown
+    assert "gpu_monitor_aggregate" not in r.markdown
+
+
+def test_geak_not_attempted_never_emits_kept_decision() -> None:
+    """Anti-regression for the MAE-era hallucination: GEAK got
+    attributed gain on a session it never ran on."""
+    r = render_session_report(_fixture_breakdown())
+    for sec in r.sections:
+        if sec.section_id != "geak_invocations":
+            continue
+        for d in sec.decisions:
+            assert d.kind == "not_attempted", (
+                f"GEAK section emitted non-not_attempted decision {d!r} "
+                f"despite no invocations on disk"
+            )
+
+
+def test_attribution_method_marks_single_source_when_path_len_1() -> None:
+    r = render_session_report(_fixture_breakdown())
+    g = r.global_facts
+    assert g.attribution_method.startswith("single-source")
+    assert g.gain_attribution_lines, "expected at least one attribution line"
+    assert g.gain_attribution_lines[0].startswith("100% via 1 backends KEEP")
+
+
+def test_attribution_missing_when_no_gain() -> None:
+    bd = _fixture_breakdown()
+    bd["final"] = {"throughput_tok_s_per_gpu": None,
+                   "cumulative_gain_pct_validated": None,
+                   "action_path": []}
+    r = render_session_report(bd)
+    assert r.global_facts.attribution_method == "missing"
+    assert r.global_facts.gain_attribution_lines == []
+
+
+# ---------------------------------------------------------------------------
+# LLM integration smoke
+# ---------------------------------------------------------------------------
+@dataclass
+class _GoodLLM:
+    def complete(self, *, system: str, user: str) -> str:
+        payload = json.loads(user)
+        sids = [s["section_id"] for s in payload["sections"] if not s["skipped"]]
+        return json.dumps({
+            "executive_summary": "Validated +10.99% via backends KEEP on DeepSeek-R1 MI300X.",
+            "section_narratives": {sid: f"narr-{sid}" for sid in sids},
+        })
+
+
+@dataclass
+class _BrokenLLM:
+    def complete(self, *, system: str, user: str) -> str:
+        return "Sorry, I cannot comply — { not json"
+
+
+@dataclass
+class _RaisingLLM:
+    def complete(self, *, system: str, user: str) -> str:
+        raise RuntimeError("network down")
+
+
+def test_llm_path_inserts_narratives_for_non_skipped_sections() -> None:
+    r = render_session_report(_fixture_breakdown(), llm_client=_GoodLLM())
+    assert r.used_llm
+    assert "Validated +10.99% via backends KEEP" in r.markdown
+    # Narratives must appear for non-skipped sections only.
+    assert "narr-session" in r.markdown
+    assert "narr-capability_summary" in r.markdown
+    # Skipped sections must NOT get narratives, and the LLM was never
+    # shown them in the user prompt either (see llm_prompt.build_user_prompt).
+    assert "narr-geak_invocations" not in r.markdown
+    assert "narr-sweep" not in r.markdown
+    # Skipped sections must not appear under "sections" in the LLM
+    # prompt (they may still appear under global_facts.capabilities_*
+    # which is fine — the LLM is allowed to talk about not-attempted
+    # capabilities).
+    prompt = json.loads(r.llm_user_prompt)
+    section_ids = {s["section_id"] for s in prompt["sections"]}
+    assert "geak_invocations" not in section_ids
+    assert "oob_invocations" not in section_ids
+    assert "sweep" not in section_ids
+
+
+def test_llm_broken_json_falls_back_to_deterministic_exec_summary() -> None:
+    r = render_session_report(_fixture_breakdown(), llm_client=_BrokenLLM())
+    # Deterministic exec summary must still appear (no crash).
+    assert "## Executive Summary" in r.markdown
+    assert "baseline 2205.00 → final" in r.markdown
+
+
+def test_llm_exception_does_not_crash_compose() -> None:
+    r = render_session_report(_fixture_breakdown(), llm_client=_RaisingLLM())
+    assert r.markdown  # non-empty
+    assert "<llm_error" in r.llm_raw_response
+
+
+# ---------------------------------------------------------------------------
+# Section-level invariants worth pinning
+# ---------------------------------------------------------------------------
+def test_kernel_lifecycle_funnel_propagates_to_global_facts() -> None:
+    r = render_session_report(_fixture_breakdown())
+    f = r.global_facts.kernel_pipeline_funnel
+    assert f["detected"] == 50 and f["recommended"] == 10
+    assert f["optimized"] == 0 and f["adopted"] == 0
+
+
+@pytest.mark.parametrize("cap_status,expected_kind", [
+    ("kept",     "kept"),
+    ("reverted", "reverted"),
+    ("rejected", "rejected"),
+])
+def test_capability_decision_kind_round_trips(
+    cap_status: str, expected_kind: str,
+) -> None:
+    bd = _fixture_breakdown()
+    bd["capability_summary"]["sweep"] = {
+        "status": cap_status, "attempts": 1, "keeps": 1 if cap_status == "kept" else 0,
+    }
+    r = render_session_report(bd)
+    cap = next(s for s in r.sections if s.section_id == "capability_summary")
+    decisions = {d.subject: d.kind for d in cap.decisions}
+    assert decisions.get("sweep") == expected_kind


### PR DESCRIPTION
## Summary

Hyperloom Orchestrator now writes a single self-contained
\`session_breakdown.json\` at the end of every session (and on demand
mid-run via a new \`session_breakdown\` action). It contains all 14
data sections the claw-stats-service dashboard needs — session
metadata, workload, baseline, final, phase timeline, capability
summary, GEAK/OOB invocations, kernel lifecycle (detected →
recommended → optimized → adopted), param/backend search, sweep,
critic/robustness, telemetry, attribution. Downstream consumers
(stats-service) can read this JSON directly and skip MAE's
event-stream mining for sessions where the file is present.

## What's in this PR

### New module: \`inference_optimizer/breakdown/\`

- **\`schema.py\`** — \`TypedDict\` schema (\`hyperloom.session_breakdown.v1\`)
  with 14 top-level sections; every field optional so collectors can
  fail-soft.
- **\`collectors.py\`** — 14 pure functions, one per section. Each is
  crash-isolated (records a warning instead of aborting the export).
  Reads directly from \`state.json\` / \`manifest.json\` /
  \`runs/<action>/.../benchmark_report.json\` /
  \`critic-workdir\` / \`robustness-workdir\` / \`kernel-agent-workspace\`,
  no cross-process IPC.
- **\`exporter.py\`** — \`build()\` orchestrates collectors;
  \`write_breakdown_json()\` does atomic writes via \`tempfile.mkstemp\`
  + \`os.replace\` so the file is never partially written.
- **\`SKILL.md\`** — usage doc for both LLM orchestrators and human
  operators (when to dispatch, invocation methods, field reference,
  failure modes).

### CLI / orchestration wiring

- **\`scripts/dump_session_breakdown.py\`** — standalone CLI for
  offline / batch / debugging use; points at any session dir.
- **\`cli.py\`** finally block — unconditionally calls
  \`write_breakdown_json()\` after \`Coordinator.run()\` regardless of
  stop_reason. Best-effort: a failure here is logged but never masks
  the real exit status.
- **New \`session_breakdown\` action** —
  \`orchestrator/action_executors/session_breakdown.py\` +
  \`actions/_meta/session_breakdown.yaml\` (\`family=shallow\`,
  \`pipeline_phase=finalize\`, cheap + idempotent). Registered in
  \`cli._REAL_EXECUTORS_FULL\`. Use mid-run when a live dashboard is
  observing this session and needs a fresh refresh — the
  end-of-session export is already handled by \`cli.py\` finally.
- **\`test_p1_2_full_action_catalogue.py\`** — expected catalogue +
  \`SESSION_ROOT_WRITERS\` exemption updated alongside \`report\`.

### SharedState / manifest fields

- **\`manifest.py\`** — \`claw_session_id\` + \`sandbox_user_id\` (read
  from env \`CLAW_SESSION_ID\` / \`SANDBOX_USER_ID\` set by the
  Primus-Claw spawn path). Dashboards use these to join Hyperloom
  sessions back to claw sessions without an env lookup at query time.
- **\`SharedState\`** — same two fields + \`gain_per_stack_entry: list[float|None]\`
  kept index-aligned with \`optimization_stack\` by Coordinator's two
  append sites (\`_lift_to_current_best\` + the integrate KEEP
  branch). \`session_breakdown\`'s capability_summary collector uses
  this to attribute "how much of the validated cumulative gain came
  from this stack entry" without re-walking events.

## Validation

### Local fixture tests

\`test_breakdown_smoke.py\` — synthetic session fixture + 14 cases
covering schema, atomic writes, kernel KEEP/PARTIAL/REVERT stamping
on the best attempt only, OOB / GEAK invocation parsing, missing-data
graceful degradation. Pre-existing \`test_p1_2_full_action_catalogue\`
also passes after the catalogue / SESSION_ROOT_WRITERS additions.

\`\`\`
35 passed, 1 warning in 0.89s
\`\`\`

The other 14 failing tests in the repo
(\`test_p2_4_integrate_report.*\`, \`test_p5_decision.*\` etc.) are
pre-existing env issues (\`HYPERLOOM_KERNEL_AGENT_ROOT is not set\`,
\`pytest-asyncio\` missing) — verified with \`git stash\` that the same
failures occur on \`origin/feature/zhenggong/hyperloomV2\` itself.

### Real wekafs data (core42)

Ran \`dump_session_breakdown.py\` on zgong's two latest DeepSeek-R1
sessions under \`/weka/zgong/HyperloomV2-sessions/\`. Two real-data
issues surfaced and were fixed in the second commit:

1. \`capability_summary.backends = not_attempted\` despite
   \`final.action_path = backends:vllm_kv_fp8\` — V1 sessions only
   populate \`optimization_stack\`, not the V2 \`<action>_attempts\`
   audit lists. Added an \`optimization_stack\` fallback in
   \`_capability_for_action\` so promoted entries always count as
   KEEPs regardless of attempt-list shape.
2. \`sweep.all_variants[*].output_throughput / ttft / e2el = None\` —
   current \`benchmark_report.json\` nests metrics under
   \`throughput.*\` and \`latency.<m>.mean_ms\`, but the collector was
   reading the flat pre-V2 keys. Added \`_benchmark_report_metrics()\`
   helper covering all three shapes (V2 nested + pre-V2 flat + legacy
   \`result.*\`).

After the fix, both sessions export correctly:

| session | stop_reason | gain_validated | backends keeps | sweep variants |
|---|---|---|---|---|
| \`…_0dc064c4\` | emergency | 10.02% | 1 (combo_vllm_kv_fp8+vllm_max_seqs_512) | 0 |
| \`…_6b292fcf\` | time_exhausted | 10.99% | 1 (vllm_kv_fp8) | 9 (3 ok, 6 OOM) |

## Downstream / follow-ups

- \`claw-stats-service\` will get a parallel PR
  (\`AMD-AGI/Primus-Claw\`, branch \`feature/session-breakdown-v2\`)
  that mounts wekafs read-only at \`/wekafs\` and reads
  \`session_breakdown.json\` in preference to MAE's
  \`session_analysis_results\` table. Hyperloom side is the source of
  truth.
- \`ReportExecutor\` (\`final.json\` / \`final.md\`) is intentionally
  left untouched in this PR; a follow-up will rewrite it to consume
  the breakdown's output instead of re-scanning the bus.
- Currently lands on top of \`feature/zhenggong/hyperloomV2\`; the
  branch is ~10 commits behind that base. Happy to rebase before
  merge.

## Test plan

- [x] \`pytest inference_optimizer/tests/test_breakdown_smoke.py\` — 14 / 14 pass
- [x] \`pytest inference_optimizer/tests/test_p1_2_full_action_catalogue.py\` — 21 / 21 pass
- [x] \`python -m inference_optimizer.scripts.dump_session_breakdown --session-dir <real wekafs session>\` against 2 of zgong's sessions in core42
- [ ] (zgong) review schema vs HyperloomV2 dump contract
- [ ] (zgong) confirm \`CLAW_SESSION_ID\` / \`SANDBOX_USER_ID\` are the right env-var names for the Primus-Claw spawn path
- [ ] Rebase + run full pytest once base is current


Made with [Cursor](https://cursor.com)