### PR TITLE
fix(inferencex-patcher): patch every InferenceX root + post-profile trace validator (#210)

### DIFF
--- a/inference_optimizer/orchestrator/action_executors/_grid_runner.py
+++ b/inference_optimizer/orchestrator/action_executors/_grid_runner.py
@@ -965,6 +965,20 @@ def _run_magpie(
     from ._multi_node_env import magpie_remote_env
     env.update(magpie_remote_env())
 
+    # #210 (Deval, comment 8): pin Magpie's InferenceX-resolution to
+    # ``$INFERENCEX_PATH`` so Magpie loads the SAME InferenceX checkout
+    # that Hyperloom's ``_inferencex_patcher`` has patched. Without
+    # this, Magpie's ``_resolve_default_inferencex_dir`` falls through
+    # to ``./InferenceX`` next to its repo or
+    # ``$XDG_CACHE_HOME/magpie/InferenceX``, either of which may be a
+    # separate, unpatched checkout — the symptom reported in #210
+    # comments 4 + 6. ``MAGPIE_INFERENCEX_PATH`` is the highest-
+    # precedence resolution rung in Magpie itself
+    # (``Magpie/modes/benchmark/inferencex.py:43``), so this is the
+    # documented contract for tying the two checkouts together.
+    inferencex_path = os.environ.get("INFERENCEX_PATH", "").strip()
+    if inferencex_path:
+        env["MAGPIE_INFERENCEX_PATH"] = inferencex_path
     # Always-on RESULT_DIR default: covers Magpie scripts that respect
     # the env var (and would otherwise fall back to a hardcoded path).
     # Scripts that ignore RESULT_DIR (e.g. ``dsr1_fp8_mi300x.sh`` with its

--- a/inference_optimizer/orchestrator/action_executors/_inferencex_patcher.py
+++ b/inference_optimizer/orchestrator/action_executors/_inferencex_patcher.py
@@ -113,27 +113,88 @@ _BENCH_SERVING_SENTINEL = "PROFILE_EXTRA_BODY"
 _BENCH_SERVING_LOCK_PATH = "/tmp/hyperloom_benchmark_serving_patcher.lock"
 
 
+def _discover_inferencex_roots(
+    inferencex_path: Path | str | None,
+) -> list[Path]:
+    """Return every InferenceX checkout root Hyperloom should patch.
+
+    #210 root cause (Deval, 2026-05-15 — see issue #210 comments 4 + 6):
+    Magpie loads its own bundled InferenceX from
+    ``$MAGPIE_DIR/InferenceX`` at runtime, NOT from
+    ``$INFERENCEX_PATH``. If those two paths differ, patching only
+    ``$INFERENCEX_PATH`` leaves Magpie's actual runtime copy untouched
+    — ``profile_by_stage=True`` leaks through, ``PROFILE_EXTRA_BODY``
+    is ignored, and the trace folder ends up with separate
+    ``_extend_*`` / ``_decode_*`` files instead of the expected
+    ``_steady_state_*`` (the smoking-gun symptom mohbasit reported on
+    the same issue).
+
+    Patches ALL discovered roots (deduplicated by resolved absolute
+    path) so the patch reaches whichever InferenceX Magpie actually
+    imports at runtime:
+
+    1. ``inferencex_path`` arg (caller-provided override)
+    2. ``$INFERENCEX_PATH`` env (existing behaviour, PR #207's path)
+    3. ``$MAGPIE_DIR/InferenceX`` (the new path — the #210 fix)
+
+    Returns ``[]`` when no roots resolve to existing directories;
+    callers fail-soft as before. Same paths from multiple sources
+    collapse to one entry (the standard install layout where
+    ``$INFERENCEX_PATH = $MAGPIE_DIR/InferenceX`` produces one root,
+    not two).
+    """
+    roots: list[Path] = []
+    seen: set[Path] = set()
+
+    def _add(candidate: Path | str | None) -> None:
+        if not candidate:
+            return
+        try:
+            resolved = Path(candidate).expanduser().resolve()
+        except OSError:
+            return
+        if not resolved.is_dir():
+            return
+        if resolved in seen:
+            return
+        seen.add(resolved)
+        roots.append(resolved)
+
+    _add(inferencex_path)
+    _add(os.environ.get("INFERENCEX_PATH", "").strip() or None)
+    magpie_dir = os.environ.get("MAGPIE_DIR", "").strip()
+    if magpie_dir:
+        _add(Path(magpie_dir) / "InferenceX")
+    return roots
+
+
+def _resolve_benchmark_lib_paths(
+    inferencex_path: Path | str | None,
+) -> list[Path]:
+    """Return every existing ``<root>/benchmarks/benchmark_lib.sh`` to
+    patch (one per InferenceX root from :func:`_discover_inferencex_roots`).
+
+    Returns ``[]`` when no root has the expected file so callers can
+    treat "no InferenceX checkout" as "skip patching".
+    """
+    out: list[Path] = []
+    for root in _discover_inferencex_roots(inferencex_path):
+        candidate = root / "benchmarks" / "benchmark_lib.sh"
+        if candidate.is_file():
+            out.append(candidate)
+    return out
+
+
+# Back-compat: existing callers / tests that import this single-path
+# helper get the first discovered candidate (or None). New code must
+# use :func:`_resolve_benchmark_lib_paths` to patch every root.
 def _resolve_benchmark_lib_path(
     inferencex_path: Path | str | None,
 ) -> Path | None:
-    """Resolve ``<inferencex_root>/benchmarks/benchmark_lib.sh``.
-
-    Returns ``None`` when the path is unconfigured or missing on disk
-    so callers can treat "no InferenceX checkout" as "skip patching"
-    (this is what unit tests need — they exercise profile YAML
-    rendering without provisioning a real InferenceX tree).
-    """
-    root: Path | None = None
-    if inferencex_path:
-        root = Path(inferencex_path)
-    else:
-        env = os.environ.get("INFERENCEX_PATH", "").strip()
-        if env:
-            root = Path(env)
-    if root is None:
-        return None
-    candidate = root / "benchmarks" / "benchmark_lib.sh"
-    return candidate if candidate.is_file() else None
+    """Single-path back-compat shim — returns first
+    :func:`_resolve_benchmark_lib_paths` result."""
+    paths = _resolve_benchmark_lib_paths(inferencex_path)
+    return paths[0] if paths else None
 
 
 @contextmanager
@@ -262,51 +323,79 @@ def ensure_benchmark_lib_patched(
     lock entirely when the file is already patched (which is the case
     for every call after the first on a given checkout).
     """
-    src = _resolve_benchmark_lib_path(inferencex_path)
-    if src is None:
+    sources = _resolve_benchmark_lib_paths(inferencex_path)
+    if not sources:
         log.info(
-            "_inferencex_patcher: INFERENCEX_PATH unset or "
+            "_inferencex_patcher: no InferenceX root discovered "
+            "(checked $INFERENCEX_PATH, $MAGPIE_DIR/InferenceX) or "
             "benchmark_lib.sh missing — skipping patch (this is fine "
             "for tests and dry-runs without a real InferenceX tree)",
         )
         return False
 
-    if _is_patched(src):
-        return True
+    # #210 fix: patch every discovered InferenceX root, not just the
+    # first. Magpie loads its bundled InferenceX from
+    # $MAGPIE_DIR/InferenceX at runtime regardless of $INFERENCEX_PATH;
+    # patching only one of the two leaves the actual runtime copy
+    # untouched. Single-lock-for-all-paths is fine — each individual
+    # patch is microsecond-fast, and the loop preserves atomic-replace
+    # per-file.
+    any_patched = False
+    pre_patched = [src for src in sources if _is_patched(src)]
+    if len(pre_patched) == len(sources):
+        return True  # all paths already patched, fast-path no lock
 
     with _file_lock(_LOCK_PATH):
-        # Re-check under the lock: another process may have patched
-        # while we were blocked on flock.
-        if _is_patched(src):
-            return True
-        return _apply_patch_atomic(src)
+        for src in sources:
+            # Re-check under the lock: another process may have patched
+            # while we were blocked on flock.
+            if _is_patched(src):
+                any_patched = True
+                continue
+            if _apply_patch_atomic(src):
+                any_patched = True
+            else:
+                log.warning(
+                    "_inferencex_patcher: failed to patch %s; other "
+                    "discovered roots will still be attempted", src,
+                )
+    return any_patched
 
 
 # =====================================================================
 # PR-D §2: PROFILE_EXTRA_BODY consumer patch for benchmark_serving.py
 # =====================================================================
+def _resolve_benchmark_serving_paths(
+    inferencex_path: Path | str | None,
+) -> list[Path]:
+    """Return every existing
+    ``<root>/utils/bench_serving/benchmark_serving.py`` to patch
+    (one per InferenceX root from :func:`_discover_inferencex_roots`).
+
+    Independent of the benchmark_lib.sh resolver because the two
+    patches are independently useful: shape-aware steady-state windows
+    (this one — PROFILE_EXTRA_BODY) and NUM_PROMPTS honouring (the
+    other) sit on different files.
+
+    #210 fix: includes Magpie's bundled InferenceX so Hyperloom
+    patches the file Magpie actually loads at runtime, not just
+    whatever ``$INFERENCEX_PATH`` resolves to.
+    """
+    out: list[Path] = []
+    for root in _discover_inferencex_roots(inferencex_path):
+        candidate = root / "utils" / "bench_serving" / "benchmark_serving.py"
+        if candidate.is_file():
+            out.append(candidate)
+    return out
+
+
 def _resolve_benchmark_serving_path(
     inferencex_path: Path | str | None,
 ) -> Path | None:
-    """Resolve ``<inferencex_root>/utils/bench_serving/benchmark_serving.py``.
-
-    Returns ``None`` for the same reasons :func:`_resolve_benchmark_lib_path`
-    does (no INFERENCEX_PATH, or file missing). Independent of the
-    benchmark_lib.sh resolver because the two patches are independently
-    useful: shape-aware steady-state windows (this one) and
-    NUM_PROMPTS honouring (the other) sit on different files.
-    """
-    root: Path | None = None
-    if inferencex_path:
-        root = Path(inferencex_path)
-    else:
-        env = os.environ.get("INFERENCEX_PATH", "").strip()
-        if env:
-            root = Path(env)
-    if root is None:
-        return None
-    candidate = root / "utils" / "bench_serving" / "benchmark_serving.py"
-    return candidate if candidate.is_file() else None
+    """Single-path back-compat shim — returns first
+    :func:`_resolve_benchmark_serving_paths` result."""
+    paths = _resolve_benchmark_serving_paths(inferencex_path)
+    return paths[0] if paths else None
 
 
 def _is_benchmark_serving_patched(src: Path) -> bool:
@@ -402,23 +491,40 @@ def ensure_benchmark_serving_patched(
     the two patches don't serialize on each other (typical workflow
     calls both once per profile run).
     """
-    src = _resolve_benchmark_serving_path(inferencex_path)
-    if src is None:
+    sources = _resolve_benchmark_serving_paths(inferencex_path)
+    if not sources:
         log.info(
-            "_inferencex_patcher: INFERENCEX_PATH unset or "
+            "_inferencex_patcher: no InferenceX root discovered "
+            "(checked $INFERENCEX_PATH, $MAGPIE_DIR/InferenceX) or "
             "benchmark_serving.py missing — skipping PROFILE_EXTRA_BODY "
             "patch (this is fine for tests and dry-runs without a real "
             "InferenceX tree)",
         )
         return False
 
-    if _is_benchmark_serving_patched(src):
-        return True
+    # #210 fix: patch every discovered InferenceX root, not just the
+    # first. Magpie loads its bundled InferenceX at runtime; patching
+    # only $INFERENCEX_PATH leaves Magpie's $MAGPIE_DIR/InferenceX
+    # copy untouched, which is exactly the silent failure mode Deval
+    # diagnosed in #210 comments 4 + 6.
+    if all(_is_benchmark_serving_patched(src) for src in sources):
+        return True  # all paths already patched, fast-path no lock
 
+    any_patched = False
     with _file_lock(_BENCH_SERVING_LOCK_PATH):
-        if _is_benchmark_serving_patched(src):
-            return True
-        return _apply_benchmark_serving_patch_atomic(src)
+        for src in sources:
+            if _is_benchmark_serving_patched(src):
+                any_patched = True
+                continue
+            if _apply_benchmark_serving_patch_atomic(src):
+                any_patched = True
+            else:
+                log.warning(
+                    "_inferencex_patcher: failed to PROFILE_EXTRA_BODY-"
+                    "patch %s; other discovered roots will still be "
+                    "attempted", src,
+                )
+    return any_patched
 
 
 __all__ = ["ensure_benchmark_lib_patched", "ensure_benchmark_serving_patched"]

--- a/inference_optimizer/orchestrator/action_executors/baseline.py
+++ b/inference_optimizer/orchestrator/action_executors/baseline.py
@@ -392,6 +392,20 @@ class BaselineExecutor:
         # `python3` resolves to one with torch+rocm. Magpie YAML also sets
         # this but defending in depth costs nothing.
         env["PATH"] = f"/opt/venv/bin:{env.get('PATH', '')}"
+        # #210 (Deval, comment 8): pin Magpie's InferenceX-resolution
+        # to ``$INFERENCEX_PATH`` so Magpie loads the SAME InferenceX
+        # checkout that Hyperloom's ``_inferencex_patcher`` has
+        # patched. ``MAGPIE_INFERENCEX_PATH`` is the highest-precedence
+        # resolution rung in Magpie's
+        # ``_resolve_default_inferencex_dir`` (``Magpie/modes/
+        # benchmark/inferencex.py:43``); without setting it, Magpie
+        # falls through to ``./InferenceX`` next to its repo or the
+        # ``$XDG_CACHE_HOME/magpie/InferenceX`` cache, either of which
+        # may be a separate, unpatched checkout (the symptom reported
+        # in #210 comments 4 + 6).
+        inferencex_path = os.environ.get("INFERENCEX_PATH", "").strip()
+        if inferencex_path:
+            env["MAGPIE_INFERENCEX_PATH"] = inferencex_path
         # Always-on ``$RESULT_DIR`` default: covers Magpie scripts that
         # respect the env var (and would otherwise fall back to a
         # hardcoded path under ``/workspace/``). Scripts that ignore

--- a/inference_optimizer/orchestrator/action_executors/profile.py
+++ b/inference_optimizer/orchestrator/action_executors/profile.py
@@ -26,6 +26,7 @@ works unchanged.
 
 from __future__ import annotations
 
+import gzip
 import logging
 import os
 from pathlib import Path
@@ -42,6 +43,236 @@ from .baseline import BaselineExecutor
 
 
 log = logging.getLogger(__name__)
+
+
+# Bytes of a trace file to sample when scanning for sentinel
+# substrings. Reading the entire decompressed trace would burn tens of
+# seconds on a 100 MB+ rank-0 trace; the leading 2 MB is enough to
+# catch presence/absence of the markers we care about (per Deval's
+# check_torch_trace.py reference output: thousands of events for each
+# sentinel in a properly-patched run).
+_TRACE_INSPECT_BYTES = 2_000_000
+
+# Minimum fraction of ``cpu_op`` events that should carry an
+# ``Input Dims`` field for a ``capture_traces/`` file to be considered
+# healthy (Deval's reference run reports 99.97%; we set the gate
+# generously low so trivial misses don't false-positive).
+_INPUT_DIMS_FRACTION_FLOOR = 0.90
+
+
+def _sample_trace_text(path: Path) -> str | None:
+    """Read up to ``_TRACE_INSPECT_BYTES`` of decompressed text from a
+    gzipped trace file. Returns ``None`` (and debug-logs) on any IO /
+    decode error so callers can skip the check rather than fail the
+    profile path."""
+    try:
+        with gzip.open(path, "rt", encoding="utf-8", errors="replace") as fh:
+            return fh.read(_TRACE_INSPECT_BYTES)
+    except (OSError, EOFError, UnicodeDecodeError) as e:
+        # gzip raises ``EOFError`` on truncated streams, ``OSError``
+        # on read failures, ``UnicodeDecodeError`` on malformed
+        # UTF-8. Validator is best-effort — never let a malformed
+        # sample fail the profile post-execution path.
+        log.debug(
+            "_validate_trace_structure: cannot sample %s: %s", path, e,
+        )
+        return None
+
+
+def _count_substring_occurrences(text: str, substring: str) -> int:
+    """Count non-overlapping ``substring`` occurrences in ``text``.
+    Used as a cheap proxy for "this kind of event appears N times in
+    the trace JSON" without paying for full JSON parsing — JSON event
+    names appear as ``"name": "<value>"`` so a substring count is a
+    reasonable lower-bound."""
+    if not substring:
+        return 0
+    return text.count(substring)
+
+
+def _validate_trace_structure(
+    trace_dir: Path, framework: str, expected_pieces: int = 1,
+) -> None:
+    """Post-profile sanity check (#210 / Deval's ``check_torch_trace.py``).
+
+    Logs *warnings* — never raises — when the trace folder structure
+    or contents suggest TraceLens-only profiling features didn't
+    reach the live framework. Mirrors the 5 checks in
+    ``check_torch_trace.py`` (Deval, #210 comment 1) plus one
+    Hyperloom-specific check for the #210 smoking-gun symptom:
+
+    1. ``capture_traces/`` exists with files (graph capture fired)
+    2. capture files contain ``cpu_op`` events with ``Input Dims``
+       (shape-discovery instrumentation recording per-event shapes)
+    3. main-directory trace has ``user_annotation`` events including
+       ``execute_*`` annotations (InferenceX per-step instrumentation
+       fired — relates to ``roofline_annotations`` flag landing)
+    4. ``trace_split/`` per-file ``execute_*`` user_annotations
+       counted (splitter ran AND each split is non-empty)
+    5. (sglang only) main trace contains ``kernel_shape_profiler``
+       substring (server-side patch from PR #207 landed)
+    6. (Hyperloom-specific) ``trace_split/`` has ``_steady_state_*``
+       files, NOT ``_extend_*`` / ``_decode_*`` (the #210 smoking-
+       gun: profile_by_stage leaked through PROFILE_EXTRA_BODY)
+
+    Read-only; safe to call after every profile execution. Each
+    check's failure produces an independent warning so partial
+    signals stay actionable.
+    """
+    issues: list[str] = []
+
+    # --- Check 1: capture_traces/ presence ---
+    capture = trace_dir / "capture_traces"
+    capture_files: list[Path] = []
+    if not capture.is_dir():
+        issues.append(
+            "[1] capture_traces/ subdirectory missing — graph capture "
+            "didn't fire. Verify EXTRA_VLLM_ARGS / EXTRA_SGLANG_ARGS "
+            "include the TraceLens flag and the server-side patch landed."
+        )
+    else:
+        capture_files = sorted(p for p in capture.iterdir() if p.is_file())
+        if not capture_files:
+            issues.append(
+                "[1] capture_traces/ exists but is empty — graph capture "
+                "path fired but produced no files."
+            )
+
+    # --- Check 2 (Deval): capture file has cpu_op + Input Dims ---
+    # Sample the heaviest capture file and count cpu_op events vs
+    # cpu_op events with an "Input Dims" field. A healthy run has
+    # >= 99% with Input Dims (Deval ref: 12441/12445 = 99.97%); we
+    # gate at _INPUT_DIMS_FRACTION_FLOOR to avoid false positives on
+    # tiny traces with rounding noise.
+    if capture_files:
+        target = max(capture_files, key=lambda p: p.stat().st_size)
+        text = _sample_trace_text(target)
+        if text is not None:
+            cpu_op_count = _count_substring_occurrences(text, '"name": "cpu_op"')
+            input_dims_count = _count_substring_occurrences(text, '"Input Dims"')
+            if cpu_op_count == 0:
+                issues.append(
+                    f"[2] capture file {target.name} has no cpu_op events "
+                    f"in the first {_TRACE_INSPECT_BYTES//1_000_000} MB — "
+                    "graph capture wrote files but they don't contain "
+                    "kernel-level events. Possible upstream profiler "
+                    "regression."
+                )
+            elif input_dims_count / max(cpu_op_count, 1) < _INPUT_DIMS_FRACTION_FLOOR:
+                pct = 100.0 * input_dims_count / cpu_op_count
+                issues.append(
+                    f"[2] capture file {target.name}: only {pct:.1f}% of "
+                    f"cpu_op events carry 'Input Dims' (expected ≥ "
+                    f"{int(_INPUT_DIMS_FRACTION_FLOOR * 100)}%). Shape-"
+                    "discovery instrumentation may not be fully active — "
+                    "verify TraceLens server patch and capture flag."
+                )
+
+    # --- Check 3 (Deval): main trace has user_annotation + execute_* ---
+    # The execute_* annotations are what InferenceX writes per-step
+    # when roofline_annotations=True is honoured by the server. Their
+    # absence is a separate failure mode from kernel_shape_profiler
+    # absence (check 5) — a partially-patched run can have one
+    # without the other.
+    main_traces = sorted(
+        (p for p in trace_dir.glob("*.trace.json.gz") if p.is_file()),
+        key=lambda p: p.stat().st_size,
+        reverse=True,
+    )
+    main_text: str | None = None
+    if main_traces:
+        main_text = _sample_trace_text(main_traces[0])
+        if main_text is not None:
+            user_ann_count = _count_substring_occurrences(
+                main_text, '"name": "user_annotation"',
+            )
+            execute_count = _count_substring_occurrences(main_text, '"execute_')
+            if user_ann_count == 0:
+                issues.append(
+                    f"[3] main trace {main_traces[0].name} has no "
+                    "user_annotation events — InferenceX per-step "
+                    "annotations didn't fire. Verify roofline_annotations "
+                    "reached the framework (PROFILE_EXTRA_BODY consumed; "
+                    "see #210)."
+                )
+            elif execute_count == 0:
+                issues.append(
+                    f"[3] main trace {main_traces[0].name} has "
+                    f"user_annotation events but no execute_* annotations "
+                    "— InferenceX is annotating but the per-step "
+                    "execute_* labels are missing. Check the InferenceX "
+                    "version actually loaded by Magpie."
+                )
+
+    # --- Check 4 (Deval): per-file execute_* in trace_split/ ---
+    # Each splitter output should contain its own slice of execute_*
+    # annotations; an empty split means the splitter ran but received
+    # no usable events for that window.
+    split = trace_dir / "trace_split"
+    split_files: list[Path] = []
+    if split.is_dir():
+        split_files = sorted(p for p in split.iterdir() if p.is_file())
+        empty_splits: list[str] = []
+        for sp in split_files:
+            if not sp.name.endswith(".json.gz"):
+                continue
+            text = _sample_trace_text(sp)
+            if text is None:
+                continue
+            if _count_substring_occurrences(text, '"execute_') == 0:
+                empty_splits.append(sp.name)
+        if split_files and empty_splits:
+            issues.append(
+                f"[4] {len(empty_splits)} trace_split/ file(s) have NO "
+                "execute_* user_annotations: "
+                f"{', '.join(empty_splits[:3])}"
+                + (f" (and {len(empty_splits) - 3} more)" if len(empty_splits) > 3 else "")
+                + " — splitter ran but the chunks are empty. Likely the "
+                "trace lacks the per-step annotations needed for splitting "
+                "(see check [3])."
+            )
+
+    # --- Check 6 (Hyperloom-specific #210 smoking-gun): _extend_* / ---
+    # _decode_* without _steady_state_* in trace_split/.
+    if split.is_dir():
+        names = [p.name for p in split_files]
+        has_extend = any("_extend_" in n or "extend_only_" in n for n in names)
+        has_decode = any("_decode_" in n or "decode_only_" in n for n in names)
+        has_steady_state = any("steady_state" in n for n in names)
+        # Single ``decode_only_steady_state_*`` is fine (steady-state
+        # decode chunk per Deval's example layout); the failure mode is
+        # ``_extend_<step>_*`` / ``_decode_<step>_*`` per-step files
+        # without any ``steady_state`` marker.
+        if (has_extend or has_decode) and not has_steady_state:
+            issues.append(
+                "[6] trace_split/ has _extend_* / _decode_* files but NO "
+                "_steady_state_* — profile_by_stage=True leaked through, "
+                "PROFILE_EXTRA_BODY env was not consumed by the framework. "
+                "Confirm _inferencex_patcher patched Magpie's bundled "
+                "InferenceX (#210; check $MAGPIE_DIR/InferenceX/utils/"
+                "bench_serving/benchmark_serving.py)."
+            )
+
+    # --- Check 5 (Deval): sglang kernel_shape_profiler presence ---
+    if framework.lower() == "sglang" and main_text is not None:
+        if "kernel_shape_profiler" not in main_text:
+            issues.append(
+                f"[5] sglang main trace ({main_traces[0].name}, sampled "
+                f"first {_TRACE_INSPECT_BYTES//1_000_000} MB) lacks "
+                "kernel_shape_profiler events — shape-discovery "
+                "patch didn't reach the live SGLang. Verify "
+                "_server_patcher (PR #207) succeeded for the "
+                "deployed SGLang version (check log warnings)."
+            )
+
+    if issues:
+        for issue in issues:
+            log.warning("trace structure check: %s", issue)
+        log.warning(
+            "trace structure check: %d issue(s) detected — TraceLens "
+            "downstream analysis may be degraded. See per-issue messages "
+            "above for the actionable check.", len(issues),
+        )
 
 
 # Legacy constant kept pointing at the sglang profile yaml for fixture use.
@@ -394,6 +625,21 @@ class ProfileExecutor(BaselineExecutor):
                     if main_trace.name.startswith("merged-")
                     else "trace_dir_preferred"
                 )
+                # #210 / Deval's check_torch_trace.py guidance: warn
+                # if the trace folder shape suggests PROFILE_EXTRA_BODY
+                # leaked / shape-discovery missing. Read-only inspect;
+                # never blocks the run.
+                try:
+                    framework = str(
+                        getattr(ctx, "framework", "")
+                        or (extra.get("framework") if isinstance(extra, dict) else "")
+                        or ""
+                    )
+                    _validate_trace_structure(selected_trace_dir, framework)
+                except Exception as e:  # noqa: BLE001 - validator is best-effort
+                    log.debug(
+                        "profile_executor: trace structure validator failed: %s", e,
+                    )
             else:
                 result["trace_dir"] = None
                 result["trace_files"] = []

--- a/inference_optimizer/tests/test_baseline_param_overrides.py
+++ b/inference_optimizer/tests/test_baseline_param_overrides.py
@@ -290,6 +290,50 @@ def test_baseline_executor_defaults_result_dir_to_workspace(tmp_path):
     assert captured["env"]["RESULT_DIR"] == str(output_dir)
 
 
+def test_baseline_executor_pins_magpie_inferencex_path(tmp_path, monkeypatch):
+    """#210 fix (Deval, comment 8): the baseline executor's Magpie
+    subprocess must inherit ``MAGPIE_INFERENCEX_PATH=$INFERENCEX_PATH``
+    so Magpie's ``_resolve_default_inferencex_dir`` picks the same
+    InferenceX checkout Hyperloom's ``_inferencex_patcher`` patched.
+    Symmetric to the ``_grid_runner._run_magpie`` test in
+    test_p2_3_param_executors — both Magpie invocation sites must
+    set this env."""
+    monkeypatch.setenv("INFERENCEX_PATH", "/wekafs/hyperloom/InferenceX")
+    base = tmp_path / "base.yaml"
+    _write_yaml(base)
+    output_dir = tmp_path / "ws"
+    captured: dict = {}
+
+    def fake_run(cmd, *args, **kwargs):
+        out_idx = cmd.index("--output-dir")
+        slot = Path(cmd[out_idx + 1])
+        captured["env"] = dict(kwargs.get("env") or {})
+        _fake_workspace(slot)
+        return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+    executor = BaselineExecutor(
+        magpie_python="/opt/venv/bin/python",
+        default_config_path=base,
+        session_dir=tmp_path,
+    )
+    ctx = _make_ctx({"output_dir": str(output_dir), "timeout_sec": 10})
+
+    with patch(
+        "inference_optimizer.orchestrator.action_executors.baseline."
+        "run_with_session_kill",
+        side_effect=fake_run,
+    ):
+        result = _run(executor(ctx))
+
+    assert result["status"] == "succeeded"
+    assert captured["env"].get("MAGPIE_INFERENCEX_PATH") == (
+        "/wekafs/hyperloom/InferenceX"
+    ), (
+        "MAGPIE_INFERENCEX_PATH must equal $INFERENCEX_PATH so Magpie "
+        "loads the patched checkout (#210 root cause)"
+    )
+
+
 def test_baseline_executor_rejects_bad_param(tmp_path):
     base = tmp_path / "base.yaml"
     _write_yaml(base)

--- a/inference_optimizer/tests/test_inferencex_patcher.py
+++ b/inference_optimizer/tests/test_inferencex_patcher.py
@@ -27,6 +27,7 @@ from pathlib import Path
 
 import pytest
 
+from inference_optimizer.orchestrator.action_executors import _inferencex_patcher
 from inference_optimizer.orchestrator.action_executors._inferencex_patcher import (
     ensure_benchmark_lib_patched,
 )
@@ -419,3 +420,181 @@ def test_benchmark_serving_patched_line_is_executable_python(
         }
     finally:
         os.environ.pop("PROFILE_EXTRA_BODY", None)
+
+
+# ===========================================================================
+# #210 fix (Deval comments 4 + 6): patch every InferenceX root, not just
+# $INFERENCEX_PATH. Magpie loads its bundled $MAGPIE_DIR/InferenceX at
+# runtime regardless of $INFERENCEX_PATH; patching only one of the two
+# leaves Magpie's actual runtime copy unpatched → profile_by_stage
+# leaks → trace_split has _extend_* / _decode_* instead of
+# _steady_state_*. These tests pin the multi-root contract.
+# ===========================================================================
+def _make_inferencex_tree_with_serving(
+    root: Path, profile_by_stage: bool = True,
+) -> Path:
+    """Build a minimal ``<root>/utils/bench_serving/benchmark_serving.py``
+    fixture so the patcher has something concrete to rewrite."""
+    bench_dir = root / "utils" / "bench_serving"
+    bench_dir.mkdir(parents=True, exist_ok=True)
+    f = bench_dir / "benchmark_serving.py"
+    f.write_text(
+        "async def x():\n"
+        "    await async_request(\n"
+        "                                         api_url=base + \"/start_profile\",\n"
+        "                                         prompt_len=test_prompt_len,\n"
+        "                                         output_len=test_output_len,\n"
+        '                                         extra_body={"num_steps": 1, '
+        '"merge_profiles": True, "profile_by_stage": True},\n'
+        "    )\n",
+        encoding="utf-8",
+    )
+    f.chmod(0o644)
+    return f
+
+
+def test_discover_inferencex_roots_dedupes_when_paths_resolve_same(
+    tmp_path, monkeypatch,
+):
+    """When ``$INFERENCEX_PATH`` and ``$MAGPIE_DIR/InferenceX`` resolve
+    to the SAME directory (the standard install layout where
+    ``ensure_inferencex`` set ``INFERENCEX_PATH=$MAGPIE_DIR/InferenceX``),
+    the discovery returns one entry, not two. Otherwise we'd patch
+    the same file twice (idempotent so harmless, but visually
+    confusing in logs)."""
+    inferencex = tmp_path / "InferenceX"
+    inferencex.mkdir()
+    magpie = tmp_path / "Magpie"
+    magpie.mkdir()
+    # Standard layout: Magpie bundles InferenceX as a sibling.
+    (magpie / "InferenceX").symlink_to(inferencex)
+    monkeypatch.setenv("INFERENCEX_PATH", str(inferencex))
+    monkeypatch.setenv("MAGPIE_DIR", str(magpie))
+    roots = _inferencex_patcher._discover_inferencex_roots(None)
+    assert len(roots) == 1, f"expected dedup to one root, got {roots}"
+    assert roots[0] == inferencex.resolve()
+
+
+def test_discover_inferencex_roots_includes_both_when_paths_differ(
+    tmp_path, monkeypatch,
+):
+    """The #210 case: ``$INFERENCEX_PATH`` points elsewhere (e.g. a
+    /wekafs path) while Magpie loads its OWN bundled checkout from
+    ``$MAGPIE_DIR/InferenceX``. Both paths must show up so both
+    files get patched."""
+    inferencex_external = tmp_path / "external" / "InferenceX"
+    inferencex_external.mkdir(parents=True)
+    magpie_dir = tmp_path / "workspace" / "Magpie"
+    (magpie_dir / "InferenceX").mkdir(parents=True)
+    monkeypatch.setenv("INFERENCEX_PATH", str(inferencex_external))
+    monkeypatch.setenv("MAGPIE_DIR", str(magpie_dir))
+    roots = _inferencex_patcher._discover_inferencex_roots(None)
+    assert len(roots) == 2, f"expected 2 distinct roots, got {roots}"
+    resolved = {p.resolve() for p in roots}
+    assert inferencex_external.resolve() in resolved
+    assert (magpie_dir / "InferenceX").resolve() in resolved
+
+
+def test_discover_inferencex_roots_when_only_magpie_dir_set(
+    tmp_path, monkeypatch,
+):
+    """If operator set only ``$MAGPIE_DIR`` (no ``$INFERENCEX_PATH``),
+    Magpie's bundled InferenceX is still discovered. This is the
+    fail-safe path: patcher functions even when the env layout drifts."""
+    magpie_dir = tmp_path / "Magpie"
+    (magpie_dir / "InferenceX").mkdir(parents=True)
+    monkeypatch.delenv("INFERENCEX_PATH", raising=False)
+    monkeypatch.setenv("MAGPIE_DIR", str(magpie_dir))
+    roots = _inferencex_patcher._discover_inferencex_roots(None)
+    assert len(roots) == 1
+    assert roots[0] == (magpie_dir / "InferenceX").resolve()
+
+
+def test_discover_inferencex_roots_returns_empty_when_nothing_set(monkeypatch):
+    """No env, no caller arg → empty list (caller fail-softs)."""
+    monkeypatch.delenv("INFERENCEX_PATH", raising=False)
+    monkeypatch.delenv("MAGPIE_DIR", raising=False)
+    assert _inferencex_patcher._discover_inferencex_roots(None) == []
+
+
+def test_ensure_benchmark_serving_patched_patches_both_roots_when_they_differ(
+    tmp_path, monkeypatch,
+):
+    """End-to-end: when ``$INFERENCEX_PATH`` and
+    ``$MAGPIE_DIR/InferenceX`` are different on-disk paths, both
+    ``benchmark_serving.py`` files MUST get patched. This is the
+    exact #210 invariant — patching only one leaves Magpie's runtime
+    copy on the unpatched legacy line."""
+    external = tmp_path / "external" / "InferenceX"
+    external.mkdir(parents=True)
+    magpie = tmp_path / "Magpie"
+    (magpie / "InferenceX").mkdir(parents=True)
+    f_external = _make_inferencex_tree_with_serving(external)
+    f_magpie = _make_inferencex_tree_with_serving(magpie / "InferenceX")
+    monkeypatch.setenv("INFERENCEX_PATH", str(external))
+    monkeypatch.setenv("MAGPIE_DIR", str(magpie))
+
+    rc = ensure_benchmark_serving_patched()
+    assert rc is True
+    text_external = f_external.read_text(encoding="utf-8")
+    text_magpie = f_magpie.read_text(encoding="utf-8")
+    assert "PROFILE_EXTRA_BODY" in text_external, (
+        "$INFERENCEX_PATH file must be patched"
+    )
+    assert "PROFILE_EXTRA_BODY" in text_magpie, (
+        "$MAGPIE_DIR/InferenceX file must ALSO be patched (the #210 fix)"
+    )
+
+
+def test_ensure_benchmark_serving_patched_returns_true_when_only_magpie_path_present(
+    tmp_path, monkeypatch,
+):
+    """Symmetry test: when ``$INFERENCEX_PATH`` exists but lacks the
+    ``benchmark_serving.py`` (broken / partial checkout) and Magpie's
+    bundled InferenceX has it, the patcher still patches Magpie's
+    copy and reports success."""
+    external = tmp_path / "external" / "InferenceX"
+    external.mkdir(parents=True)  # no benchmark_serving.py here
+    magpie = tmp_path / "Magpie"
+    (magpie / "InferenceX").mkdir(parents=True)
+    f_magpie = _make_inferencex_tree_with_serving(magpie / "InferenceX")
+    monkeypatch.setenv("INFERENCEX_PATH", str(external))
+    monkeypatch.setenv("MAGPIE_DIR", str(magpie))
+
+    rc = ensure_benchmark_serving_patched()
+    assert rc is True
+    assert "PROFILE_EXTRA_BODY" in f_magpie.read_text(encoding="utf-8")
+
+
+def test_ensure_benchmark_lib_patched_patches_both_roots_when_they_differ(
+    tmp_path, monkeypatch,
+):
+    """Same multi-root contract for ``benchmark_lib.sh``."""
+    # Build two InferenceX-like roots, each with the legacy line.
+    legacy = (
+        "#!/usr/bin/env bash\n"
+        "run_benchmark_serving() {\n"
+        "    local num_prompts=\"\"\n"
+        "    local max_concurrency=\"\"\n"
+        "    if [[ \"${PROFILE:-}\" == \"1\" ]]; then\n"
+        "        num_prompts=\"$max_concurrency\"\n"
+        "    fi\n"
+        "}\n"
+    )
+    external = tmp_path / "external" / "InferenceX"
+    (external / "benchmarks").mkdir(parents=True)
+    f_external = external / "benchmarks" / "benchmark_lib.sh"
+    f_external.write_text(legacy, encoding="utf-8")
+    magpie = tmp_path / "Magpie"
+    (magpie / "InferenceX" / "benchmarks").mkdir(parents=True)
+    f_magpie = magpie / "InferenceX" / "benchmarks" / "benchmark_lib.sh"
+    f_magpie.write_text(legacy, encoding="utf-8")
+    monkeypatch.setenv("INFERENCEX_PATH", str(external))
+    monkeypatch.setenv("MAGPIE_DIR", str(magpie))
+
+    rc = ensure_benchmark_lib_patched()
+    assert rc is True
+    assert "${NUM_PROMPTS:-$max_concurrency}" in f_external.read_text(encoding="utf-8")
+    assert "${NUM_PROMPTS:-$max_concurrency}" in f_magpie.read_text(encoding="utf-8"), (
+        "Magpie's bundled InferenceX benchmark_lib.sh must ALSO be patched"
+    )

--- a/inference_optimizer/tests/test_p2_3_param_executors.py
+++ b/inference_optimizer/tests/test_p2_3_param_executors.py
@@ -257,6 +257,80 @@ def test_run_magpie_prepends_magpie_dir_to_pythonpath(tmp_path, monkeypatch):
     assert env["PYTHONPATH"].split(":")[:2] == ["/workspace/Magpie", "/existing"]
 
 
+def test_run_magpie_pins_magpie_inferencex_path_to_inferencex_path(
+    tmp_path, monkeypatch,
+):
+    """#210 fix (Deval, comment 8): when ``$INFERENCEX_PATH`` is set,
+    the Magpie subprocess must inherit ``$MAGPIE_INFERENCEX_PATH``
+    pointing at the SAME path. This is the canonical contract: Magpie's
+    ``_resolve_default_inferencex_dir`` reads ``$MAGPIE_INFERENCEX_PATH``
+    first, so Magpie loads the same InferenceX checkout Hyperloom's
+    ``_inferencex_patcher`` patched. Without this, Magpie falls through
+    to its own default (``./InferenceX`` next to its repo or
+    ``$XDG_CACHE_HOME/magpie/InferenceX``) and the patches never reach
+    the file actually loaded at runtime."""
+    monkeypatch.setenv("INFERENCEX_PATH", "/wekafs/hyperloom/InferenceX")
+    monkeypatch.delenv("MAGPIE_INFERENCEX_PATH", raising=False)
+    seen: dict[str, object] = {}
+
+    def fake_run(cmd, *args, **kwargs):
+        seen["env"] = kwargs["env"]
+        return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+    monkeypatch.setattr(
+        "inference_optimizer.orchestrator.action_executors._grid_runner.run_with_session_kill",
+        fake_run,
+    )
+    _run_magpie(
+        magpie_python="/opt/venv/bin/python",
+        config_path=tmp_path / "config.yaml",
+        output_dir=tmp_path / "out",
+        timeout_sec=5,
+        cwd=str(tmp_path),
+    )
+    env = seen["env"]
+    assert env.get("MAGPIE_INFERENCEX_PATH") == "/wekafs/hyperloom/InferenceX", (
+        "MAGPIE_INFERENCEX_PATH must be set to $INFERENCEX_PATH so Magpie "
+        "uses the same checkout that Hyperloom's _inferencex_patcher patched"
+    )
+
+
+def test_run_magpie_does_not_set_magpie_inferencex_path_when_inferencex_unset(
+    tmp_path, monkeypatch,
+):
+    """When ``$INFERENCEX_PATH`` is unset (smoke / dry-run shape), do
+    NOT set ``$MAGPIE_INFERENCEX_PATH`` to an empty string — that
+    would force Magpie's resolver to use the empty path verbatim
+    (``Magpie/modes/benchmark/inferencex.py:44`` falls through only
+    when the env value is unset, not when it's empty). Letting Magpie
+    fall through to its own discovery cascade is the correct behaviour
+    when Hyperloom doesn't have an opinion."""
+    monkeypatch.delenv("INFERENCEX_PATH", raising=False)
+    monkeypatch.delenv("MAGPIE_INFERENCEX_PATH", raising=False)
+    seen: dict[str, object] = {}
+
+    def fake_run(cmd, *args, **kwargs):
+        seen["env"] = kwargs["env"]
+        return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+    monkeypatch.setattr(
+        "inference_optimizer.orchestrator.action_executors._grid_runner.run_with_session_kill",
+        fake_run,
+    )
+    _run_magpie(
+        magpie_python="/opt/venv/bin/python",
+        config_path=tmp_path / "config.yaml",
+        output_dir=tmp_path / "out",
+        timeout_sec=5,
+        cwd=str(tmp_path),
+    )
+    env = seen["env"]
+    assert "MAGPIE_INFERENCEX_PATH" not in env or env["MAGPIE_INFERENCEX_PATH"] == "", (
+        "no $INFERENCEX_PATH set → MAGPIE_INFERENCEX_PATH must NOT be "
+        "force-injected (would shadow Magpie's own discovery cascade)"
+    )
+
+
 @pytest.mark.asyncio
 async def test_run_grid_writes_per_variant_yaml_and_parses_report(tmp_path):
     base = tmp_path / "base.yaml"

--- a/inference_optimizer/tests/test_profile_trace_validator.py
+++ b/inference_optimizer/tests/test_profile_trace_validator.py
@@ -1,0 +1,406 @@
+"""Tests for ``profile._validate_trace_structure`` (#210 / Deval's
+``check_torch_trace.py`` guidance).
+
+The validator's contract:
+
+* Read-only inspection of the trace folder; never mutates anything.
+* Logs WARNINGs (does NOT raise) so a partial / silently-degraded
+  profile run still completes — operators see actionable messages
+  pointing at the specific symptom (PROFILE_EXTRA_BODY leaked,
+  shape-discovery patch missed, etc.).
+* No false positives on the healthy reference layout from Deval's
+  comment 1.
+* Detects the smoking-gun symptom: ``trace_split/`` carrying
+  ``_extend_*`` / ``_decode_*`` files instead of ``_steady_state_*``
+  (proves ``profile_by_stage=True`` leaked through).
+* Detects the sglang-specific symptom: main rank-0 trace lacking
+  ``kernel_shape_profiler`` substring (proves the server-side patch
+  from PR #207 didn't reach the deployed SGLang).
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import logging
+from pathlib import Path
+
+from inference_optimizer.orchestrator.action_executors.profile import (
+    _validate_trace_structure,
+)
+
+
+def _write_minimal_sglang_trace(
+    path: Path,
+    *,
+    with_kernel_shape_profiler: bool,
+    with_user_annotation: bool = True,
+    with_execute_star: bool = True,
+) -> None:
+    """Write a tiny gzipped JSON trace blob carrying enough event
+    structure to satisfy the validator's substring-based content
+    checks. The validator counts:
+
+    * ``"name": "cpu_op"`` events
+    * ``"name": "user_annotation"`` events
+    * ``"execute_`` substrings (per-step InferenceX annotations)
+    * ``kernel_shape_profiler`` substring (sglang-specific marker)
+
+    Each flag here lets a test selectively turn off the corresponding
+    signal to assert the validator's per-check warnings independently.
+    """
+    events: list[dict] = [
+        {"name": "cpu_op", "ph": "X", "ts": 0, "dur": 1, "args": {"Input Dims": [[1, 2, 3]]}},
+    ]
+    if with_user_annotation:
+        events.append({
+            "name": "user_annotation",
+            "ph": "i",
+            "args": {
+                "label": (
+                    "execute_16384_context_16(sq16384sk16384)_generation_0(sq0sk0)"
+                    if with_execute_star
+                    else "some_other_annotation_label"
+                ),
+            },
+        })
+    if with_kernel_shape_profiler:
+        events.append({
+            "name": "python_function",
+            "ph": "i",
+            "args": {"frame": "kernel_shape_profiler"},
+        })
+    payload = {"schemaVersion": 1, "traceEvents": events}
+    with gzip.open(path, "wt", encoding="utf-8") as fh:
+        json.dump(payload, fh)
+
+
+def _write_capture_file(
+    path: Path, *, cpu_op_count: int, with_input_dims_fraction: float = 1.0,
+) -> None:
+    """Synthesize a ``capture_traces/<file>.json.gz`` carrying
+    ``cpu_op_count`` events; ``with_input_dims_fraction`` of them
+    have an ``Input Dims`` arg field (rest don't). Used to test
+    Deval check [2]: capture file shape-discovery instrumentation."""
+    events: list[dict] = []
+    threshold = int(round(cpu_op_count * with_input_dims_fraction))
+    for i in range(cpu_op_count):
+        ev = {"name": "cpu_op", "ph": "X", "ts": i, "dur": 1, "args": {}}
+        if i < threshold:
+            ev["args"]["Input Dims"] = [[1, 2, 3]]
+        events.append(ev)
+    payload = {"schemaVersion": 1, "traceEvents": events}
+    with gzip.open(path, "wt", encoding="utf-8") as fh:
+        json.dump(payload, fh)
+
+
+def _write_split_file(path: Path, *, with_execute_star: bool = True) -> None:
+    """Synthesize a ``trace_split/<file>.json.gz`` carrying (or not)
+    ``execute_*`` user_annotations. Used to test Deval check [4]."""
+    events: list[dict] = [
+        {"name": "cpu_op", "ph": "X", "ts": 0, "dur": 1},
+    ]
+    if with_execute_star:
+        events.append({
+            "name": "user_annotation",
+            "ph": "i",
+            "args": {"label": "execute_32_context_1(sq32sk1025)_generation_0(sq0sk0)"},
+        })
+    payload = {"schemaVersion": 1, "traceEvents": events}
+    with gzip.open(path, "wt", encoding="utf-8") as fh:
+        json.dump(payload, fh)
+
+
+def _build_healthy_layout(tmp_path: Path) -> Path:
+    """Build a complete reference layout that satisfies all 6 checks.
+    Used by tests that need a 'no false positives' baseline AND by
+    targeted-symptom tests as a starting point to selectively
+    invalidate one piece."""
+    trace_dir = tmp_path / "torch_trace"
+    trace_dir.mkdir()
+    capture = trace_dir / "capture_traces"
+    capture.mkdir()
+    _write_capture_file(
+        capture / "bs_104_rank0.json.gz",
+        cpu_op_count=200, with_input_dims_fraction=0.99,
+    )
+    split = trace_dir / "trace_split"
+    split.mkdir()
+    _write_split_file(
+        split / "decode_only_steady_state_chunk0.json.gz",
+        with_execute_star=True,
+    )
+    _write_split_file(
+        split / "mixed_steady_state_chunk0.json.gz",
+        with_execute_star=True,
+    )
+    main_trace = trace_dir / "1776409856.2485812-TP-0.trace.json.gz"
+    _write_minimal_sglang_trace(
+        main_trace,
+        with_kernel_shape_profiler=True,
+        with_user_annotation=True,
+        with_execute_star=True,
+    )
+    return trace_dir
+
+
+def test_validator_no_warnings_on_healthy_layout(tmp_path, caplog):
+    """Reference healthy layout from Deval's example output (issue
+    #210, comment 1) MUST NOT trip any of the 6 checks:
+
+    * [1] ``capture_traces/`` exists with files
+    * [2] capture file has ``cpu_op`` + ``Input Dims`` ≥ floor
+    * [3] main trace has ``user_annotation`` + ``execute_*``
+    * [4] every ``trace_split/`` file has ``execute_*``
+    * [5] (sglang) main trace has ``kernel_shape_profiler``
+    * [6] ``trace_split/`` has only ``_steady_state_*`` (no _extend/_decode)
+    """
+    trace_dir = _build_healthy_layout(tmp_path)
+    caplog.set_level(logging.WARNING)
+    _validate_trace_structure(trace_dir, "sglang")
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings == [], (
+        f"healthy layout produced unexpected warnings: "
+        f"{[r.getMessage() for r in warnings]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Check [6] (Hyperloom-specific #210 smoking-gun)
+# ---------------------------------------------------------------------------
+def test_validator_warns_on_extend_decode_files_without_steady_state(
+    tmp_path, caplog,
+):
+    """The exact #210 / mohbasit-comment-3 symptom: ``trace_split/``
+    carries ``_extend_*`` / ``_decode_*`` files (per-stage splits)
+    instead of ``_steady_state_*`` files. This is the visible signal
+    that ``profile_by_stage=True`` leaked through and PROFILE_EXTRA_BODY
+    didn't reach the framework."""
+    trace_dir = _build_healthy_layout(tmp_path)
+    # Replace the healthy steady_state split files with the smoking-gun
+    # _extend_* / _decode_* layout.
+    split = trace_dir / "trace_split"
+    for p in list(split.iterdir()):
+        p.unlink()
+    _write_split_file(
+        split / "_extend_step_0_TP-0.trace.json.gz", with_execute_star=True,
+    )
+    _write_split_file(
+        split / "_decode_step_0_TP-0.trace.json.gz", with_execute_star=True,
+    )
+
+    caplog.set_level(logging.WARNING)
+    _validate_trace_structure(trace_dir, "sglang")
+    msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("profile_by_stage=True leaked through" in m for m in msgs), msgs
+    assert any("$MAGPIE_DIR/InferenceX" in m for m in msgs), (
+        "warning message should point operators at the #210 fix surface"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Check [1] capture_traces/ presence
+# ---------------------------------------------------------------------------
+def test_validator_warns_when_capture_traces_missing(tmp_path, caplog):
+    """When ``capture_traces/`` doesn't exist at all, graph capture
+    didn't fire — typically because the server-side patch from PR
+    #207 didn't land. The validator should call this out explicitly."""
+    trace_dir = _build_healthy_layout(tmp_path)
+    # Remove the healthy capture_traces/ subtree to trigger check [1].
+    capture = trace_dir / "capture_traces"
+    for p in list(capture.iterdir()):
+        p.unlink()
+    capture.rmdir()
+
+    caplog.set_level(logging.WARNING)
+    _validate_trace_structure(trace_dir, "sglang")
+    msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("capture_traces/" in m and "missing" in m for m in msgs), msgs
+
+
+# ---------------------------------------------------------------------------
+# Check [2] (Deval) capture file has cpu_op + Input Dims
+# ---------------------------------------------------------------------------
+def test_validator_warns_when_capture_file_lacks_input_dims(tmp_path, caplog):
+    """Capture file with cpu_op events but missing the ``Input Dims``
+    field on most events → shape-discovery instrumentation isn't
+    fully active. Healthy reference is 99.97% (Deval); validator
+    floors at 90%."""
+    trace_dir = _build_healthy_layout(tmp_path)
+    capture = trace_dir / "capture_traces"
+    bad = capture / "bs_104_rank0.json.gz"
+    bad.unlink()
+    # Only 50% of cpu_op events have Input Dims — well below the 90%
+    # floor.
+    _write_capture_file(bad, cpu_op_count=200, with_input_dims_fraction=0.5)
+
+    caplog.set_level(logging.WARNING)
+    _validate_trace_structure(trace_dir, "sglang")
+    msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any(
+        "Input Dims" in m and "Shape-discovery instrumentation" in m for m in msgs
+    ), msgs
+
+
+def test_validator_warns_when_capture_file_has_no_cpu_op(tmp_path, caplog):
+    """Capture file present but contains zero ``cpu_op`` events →
+    graph capture wrote files but they don't carry kernel-level
+    events. Distinct failure mode from missing capture_traces/
+    entirely."""
+    trace_dir = _build_healthy_layout(tmp_path)
+    capture = trace_dir / "capture_traces"
+    bad = capture / "bs_104_rank0.json.gz"
+    bad.unlink()
+    _write_capture_file(bad, cpu_op_count=0)
+
+    caplog.set_level(logging.WARNING)
+    _validate_trace_structure(trace_dir, "sglang")
+    msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("no cpu_op events" in m for m in msgs), msgs
+
+
+# ---------------------------------------------------------------------------
+# Check [3] (Deval) main trace has user_annotation + execute_*
+# ---------------------------------------------------------------------------
+def test_validator_warns_when_main_trace_lacks_user_annotation(
+    tmp_path, caplog,
+):
+    """Main trace with no ``user_annotation`` events → InferenceX
+    per-step annotations didn't fire. Separate failure mode from
+    [5] kernel_shape_profiler absence — a partially-patched run can
+    have one without the other."""
+    trace_dir = _build_healthy_layout(tmp_path)
+    main = next(trace_dir.glob("*.trace.json.gz"))
+    main.unlink()
+    _write_minimal_sglang_trace(
+        main,
+        with_kernel_shape_profiler=True,
+        with_user_annotation=False,  # the smoking-gun for check [3]
+    )
+
+    caplog.set_level(logging.WARNING)
+    _validate_trace_structure(trace_dir, "sglang")
+    msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("no user_annotation events" in m for m in msgs), msgs
+    assert any("PROFILE_EXTRA_BODY" in m for m in msgs), (
+        "should point operators at the #210 fix path"
+    )
+
+
+def test_validator_warns_when_main_trace_lacks_execute_star_annotations(
+    tmp_path, caplog,
+):
+    """user_annotation events present but no ``execute_*`` labels →
+    the per-step instrumentation labels are missing; InferenceX is
+    annotating something else. Hints at version mismatch between
+    Magpie's bundled InferenceX and the patcher's expectations."""
+    trace_dir = _build_healthy_layout(tmp_path)
+    main = next(trace_dir.glob("*.trace.json.gz"))
+    main.unlink()
+    _write_minimal_sglang_trace(
+        main,
+        with_kernel_shape_profiler=True,
+        with_user_annotation=True,
+        with_execute_star=False,  # smoking-gun: annotations without execute_*
+    )
+
+    caplog.set_level(logging.WARNING)
+    _validate_trace_structure(trace_dir, "sglang")
+    msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any(
+        "no execute_* annotations" in m and "Magpie" in m for m in msgs
+    ), msgs
+
+
+# ---------------------------------------------------------------------------
+# Check [4] (Deval) per-file execute_* in trace_split/
+# ---------------------------------------------------------------------------
+def test_validator_warns_when_split_file_lacks_execute_star(
+    tmp_path, caplog,
+):
+    """Splitter ran but a chunk has no ``execute_*`` annotations →
+    the chunk is empty (or worse, the source trace was already
+    missing execute_* labels). Validator names the offending
+    file(s) so operators can grep them."""
+    trace_dir = _build_healthy_layout(tmp_path)
+    split = trace_dir / "trace_split"
+    bad = split / "decode_only_steady_state_chunk0.json.gz"
+    bad.unlink()
+    _write_split_file(bad, with_execute_star=False)  # empty split
+
+    caplog.set_level(logging.WARNING)
+    _validate_trace_structure(trace_dir, "sglang")
+    msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any(
+        "trace_split/ file(s) have NO execute_* user_annotations" in m
+        for m in msgs
+    ), msgs
+    assert any(
+        "decode_only_steady_state_chunk0.json.gz" in m for m in msgs
+    ), "warning should name the offending file"
+
+
+# ---------------------------------------------------------------------------
+# Check [5] (Deval) sglang kernel_shape_profiler presence
+# ---------------------------------------------------------------------------
+def test_validator_warns_when_kernel_shape_profiler_absent_in_sglang(
+    tmp_path, caplog,
+):
+    """sglang trace lacking the ``kernel_shape_profiler`` substring →
+    server-side shape-discovery patch didn't land. Pointer to PR #207
+    in the message so operators know where to look."""
+    trace_dir = _build_healthy_layout(tmp_path)
+    main = next(trace_dir.glob("*.trace.json.gz"))
+    main.unlink()
+    _write_minimal_sglang_trace(
+        main,
+        with_kernel_shape_profiler=False,  # smoking-gun for check [5]
+    )
+
+    caplog.set_level(logging.WARNING)
+    _validate_trace_structure(trace_dir, "sglang")
+    msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("kernel_shape_profiler" in m for m in msgs), msgs
+    assert any("PR #207" in m for m in msgs), (
+        "warning should point at the server-side patcher PR for diagnosis"
+    )
+
+
+def test_validator_skips_kernel_shape_check_for_non_sglang(tmp_path, caplog):
+    """vLLM traces don't carry ``kernel_shape_profiler`` events — that
+    sentinel is sglang-specific. The validator must NOT fire that
+    warning when ``framework != "sglang"``, otherwise vLLM runs would
+    log a false-positive on every profile."""
+    trace_dir = _build_healthy_layout(tmp_path)
+    main = next(trace_dir.glob("*.trace.json.gz"))
+    main.unlink()
+    _write_minimal_sglang_trace(
+        main,
+        with_kernel_shape_profiler=False,  # would fire on sglang…
+    )
+
+    caplog.set_level(logging.WARNING)
+    _validate_trace_structure(trace_dir, "vllm")  # …but framework=vllm
+    msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert not any("kernel_shape_profiler" in m for m in msgs), (
+        f"vLLM run should NOT produce kernel_shape_profiler warnings, got: {msgs}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Defensive: validator is best-effort
+# ---------------------------------------------------------------------------
+def test_validator_never_raises_even_on_unreadable_trace(tmp_path, caplog):
+    """Validator is best-effort — if the gzipped trace is malformed /
+    truncated, the check must continue and log a debug message, never
+    raise (would fail the profile post-execution path otherwise)."""
+    trace_dir = tmp_path / "torch_trace"
+    trace_dir.mkdir()
+    (trace_dir / "capture_traces").mkdir()
+    # Truncated gzip header — gzip.open() succeeds, .read() raises.
+    (trace_dir / "capture_traces" / "x.json.gz").write_bytes(b"\x1f\x8b")
+    (trace_dir / "trace_split").mkdir()
+    (trace_dir / "trace_split" / "decode_only_steady_state.json.gz").write_bytes(b"\x1f\x8b")
+    (trace_dir / "broken.trace.json.gz").write_bytes(b"\x1f\x8b")
+    # Should not raise:
+    _validate_trace_structure(trace_dir, "sglang")


### PR DESCRIPTION
Refs #210 — addresses the **InferenceX patch** half of the issue (the original problem statement: `PROFILE_EXTRA_BODY` not read because Magpie loads a different InferenceX checkout). PR #207's earlier fix was incomplete; @devalshahamd / @mohbasit verified the residual symptom on the issue thread. The thread has since expanded to cover three more sub-problems that are **not** in this PR's scope and need separate follow-ups, so #210 should stay open after this lands:

- `capture_folder` threading gap (tsrikris RCA, 2026-05-15): SharedState ↔ Orchestration prompt ↔ kernel-agent handler ↔ `tracelens_analysis.py` — 3 explicit fixes proposed there.
- TraceLens versioned-subdir patch layout (mohbasit, 2026-05-18 → `release/hyperloom_integration_0.3.1`): `_server_patcher.py` currently does flat `glob("*.patch")` and misses the new `sglang_0_5_9/` / `sglang_0_5_11/` subdirs — observed live during this PR's v0.5.9 smoke (worked around locally).
- Idle% > 20% gate suppressing kernel candidates (xiaofei experiments, 2026-05-16).

> **Stacked on PR #206**. Base ref is `feat/aditysin/tracelens-prose-and-aggregation` (PR #206's branch), not `main` directly — the two PRs touch disjoint files (PR #206: `kernel-agent/tools/`; PR #224: `inference_optimizer/orchestrator/action_executors/`) so there's no functional dependency, but stacking signals the merge order: review/merge #206 first, then this. Once #206 merges, GitHub auto-rebases this PR's base back to `main` and the diff stays exactly the three commits below.

## Why

PR #207 (`d7c81928`) patched the `benchmark_serving.py` at `$INFERENCEX_PATH`, but Magpie loads its own bundled InferenceX from `$MAGPIE_DIR/InferenceX` at runtime — when the two paths differ, Magpie's runtime copy stays on the unpatched legacy line and `profile_by_stage=True` leaks through. mohbasit's smoke run on `lmsysorg/sglang:v0.5.11-rocm720-mi30x` (#210 comment 3) confirmed: trace still split into separate EXTEND / DECODE files, roofline annotations absent.

@devalshahamd diagnosed the root cause (#210 comments 4 + 6), shipped a verification harness (`check_torch_trace.py`, comment 1), and pointed out the canonical fix lives in Magpie's `MAGPIE_INFERENCEX_PATH` env var (#210 comment 8) — this PR addresses all three.

## Three commits, layered

### 1. `fix(inferencex-patcher): patch every InferenceX root, not just $INFERENCEX_PATH (#210)` — defense in depth

`_discover_inferencex_roots` returns deduped list of every existing InferenceX checkout: caller-provided arg → `$INFERENCEX_PATH` → `$MAGPIE_DIR/InferenceX`. `ensure_benchmark_lib_patched` and `ensure_benchmark_serving_patched` patch each. Returns True iff at least one was patched. 7 tests pin the multi-root contract.

### 2. `feat(profile): post-profile trace structure validator (#210, full Deval check_torch_trace.py parity)` — detection

Read-only post-profile sanity check (`_validate_trace_structure`) implementing all 5 checks from `check_torch_trace.py` plus one Hyperloom-specific check for the #210 smoking-gun (`_extend_*`/`_decode_*` files in `trace_split/` instead of `_steady_state_*`). Logs WARNINGs (never raises). 11 tests cover the healthy-layout zero-warning baseline + each individual symptom in isolation.

### 3. `fix(magpie): pin MAGPIE_INFERENCEX_PATH=$INFERENCEX_PATH so Magpie loads the patched checkout (#210)` — canonical fix

@devalshahamd's preferred approach (#210 comment 8): set Magpie's documented env var at both Hyperloom→Magpie subprocess launch sites (`_grid_runner._run_magpie` and `BaselineExecutor.__call__`) so Magpie's `_resolve_default_inferencex_dir` picks the same InferenceX checkout that Hyperloom's `_inferencex_patcher` patches. Single source of truth, no patch-every-discoverable-root dance for the standard install. 3 tests pin both invocation sites + the no-`$INFERENCEX_PATH`-set fallthrough.

## Layered fix story

| Layer | What it does | When it fires |
|---|---|---|
| **Primary (commit 3)**: `MAGPIE_INFERENCEX_PATH` env-pin | Tells Magpie which InferenceX to use | Always (when `$INFERENCEX_PATH` set) |
| **Defense (commit 1)**: multi-root patcher | Patches every discoverable InferenceX | Catches older Magpie versions that don't honour `MAGPIE_INFERENCEX_PATH` yet, or operator overrides that bypass the env |
| **Detection (commit 2)**: post-profile validator | Logs actionable warnings on the smoking-gun symptoms | When something still slipped through and operators need to know |

## Test plan

- [x] 89 new + updated tests pass on `feat/aditysin/inferencex-magpie-multiroot`.
- [x] Branched cleanly off PR #206's HEAD (`6711fe5c`); rebase produced zero conflicts.
- [x] Smoke on `lmsysorg/sglang:v0.5.9-rocm700-mi30x` (per @devalshahamd #210 comment 8 — current in-repo SGLang patches target `v0.5.9`) — see smoke verification comment for per-sub-bullet evidence:
  - [x] `MAGPIE_INFERENCEX_PATH` set in the Magpie subprocess env (verified via `/proc/<pid>/environ` on the live subprocesses)
  - [x] `$INFERENCEX_PATH/utils/bench_serving/benchmark_serving.py` carries the `PROFILE_EXTRA_BODY` substring after the profile run (sentinels present pre AND post)
  - [x] trace folder has `trace_split/_steady_state_*` (NO `_extend_*` / `_decode_*`) — splitter produced `decode_only_steady_state_*`, `mixed_steady_state_*`, `prefilldecode_steady_state_*`; commit-2 check `[6]` correctly silent
  - [x] main rank-0 trace contains `kernel_shape_profiler` — 14,472 occurrences in 822 MB main trace; ~3,592 in each of 45 `capture_traces/bs_*_rank0.json.gz` files
- [x] Smoke on standard layout where `$INFERENCEX_PATH = $MAGPIE_DIR/InferenceX`: validator silent (no warnings), patcher dedup works (one patch applied, not two).
- [ ] (Once @mohbasit ships the v0.5.11 patch refresh) repeat smoke on `lmsysorg/sglang:v0.5.11-rocm720-mi30x`.

## Scope

Strictly the #210 fix. Zero overlap with PR #206 (TraceLens prose extraction + GEAK ladder).

cc: @devalshahamd @mohbasit @tsrikris @BaoYunkai (PR #207 author)