### PR TITLE
fix(install): /opt/venv preference + torch-wheel gate + missing robustness_monitor template (#232, #233)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,13 @@ venv/
 trace_rank*.json
 .rocprofv3/
 
-# Optimization run artifacts
-optimizer_runs/
+# Optimization run artifacts (runtime per-session output; ignored). One
+# tracked exception: the .example template SKILL.md tells operators to
+# `cp` from at session start. Use ``optimizer_runs/*`` (not the bare
+# ``optimizer_runs/`` directory) so git still recurses into the dir
+# and the negation pattern below can re-include the .example file.
+optimizer_runs/*
+!optimizer_runs/robustness_monitor.sh.example
 optimization_logs/
 optimization_reports/
 optimized_versions/

--- a/inference_optimizer/scripts/install.sh
+++ b/inference_optimizer/scripts/install.sh
@@ -89,16 +89,24 @@ run() {
 }
 
 # --- 0. Resolve PYTHON ---
-# Prefer the existing PYTHON env (callers may have already pinned it),
-# then /opt/venv/bin/python (default for hyperloom containers), then
-# whatever python3 is on PATH. We do NOT hardcode /opt/venv/bin into
-# subsequent PATH; we only use this binary to drive `pip install`.
+# On hyperloom / sgl-workspace containers the canonical ROCm stack lives in
+# /opt/venv (preinstalled torch+rocm, sglang, vllm, aiter, sgl_kernel,
+# triton, Magpie, inference_optimizer, claude_agent_sdk, ray). Always
+# prefer that interpreter — bare-image PYTHONs (e.g. /usr/bin/python3) on a
+# ROCm pod silently pull plain `torch` from PyPI on `pip install -e .[test]`,
+# which is the NVIDIA CUDA wheel and crashes downstream RAG / baseline
+# steps with "Found no NVIDIA driver". Operators who really need a custom
+# interpreter can opt out with INFERENCE_OPTIMIZER_FORCE_PYTHON=1.
 resolve_python() {
-  if [ -n "${PYTHON:-}" ] && [ -x "$PYTHON" ]; then
+  if [ -x "/opt/venv/bin/python" ] && [ "${INFERENCE_OPTIMIZER_FORCE_PYTHON:-0}" != "1" ]; then
+    if [ -n "${PYTHON:-}" ] && [ "${PYTHON}" != "/opt/venv/bin/python" ]; then
+      log "preferring /opt/venv/bin/python over PYTHON=${PYTHON} (canonical ROCm stack)"
+      log "  set INFERENCE_OPTIMIZER_FORCE_PYTHON=1 to honor PYTHON verbatim"
+    fi
+    PYTHON="/opt/venv/bin/python"
     return 0
   fi
-  if [ -x "/opt/venv/bin/python" ]; then
-    PYTHON="/opt/venv/bin/python"
+  if [ -n "${PYTHON:-}" ] && [ -x "$PYTHON" ]; then
     return 0
   fi
   if command -v python3 >/dev/null 2>&1; then
@@ -110,6 +118,84 @@ resolve_python() {
 
 resolve_python
 log "PYTHON=${PYTHON}"
+# Export PYTHON + prepend its bin dir so the chained kernel-agent installer's
+# bare `python3 -m pip ...` calls (kernel-agent/scripts/install.sh) land in
+# the same interpreter. Otherwise PATH-only resolution can split the
+# installation across two different pythons.
+export PYTHON
+PATH="$(dirname "$PYTHON"):${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}"
+export PATH
+
+# --- 0a. Torch compatibility gate (ROCm-aware) ---
+# If rocm-smi reports devices, the resolved PYTHON must already have a
+# ROCm-built torch importable. Two failure modes we explicitly catch:
+#   1. torch missing entirely on a ROCm pod -- letting pip install proceed
+#      will pull the NVIDIA CUDA wheel from PyPI (default `torch`).
+#   2. torch present but built against CUDA (torch.version.hip is None)
+#      -- the chained RAG-index step auto-detects device=cuda and crashes
+#      at torch._C._cuda_init() with "Found no NVIDIA driver".
+ensure_torch_compatible_with_gpu() {
+  if ! command -v rocm-smi >/dev/null 2>&1; then
+    return 0
+  fi
+  if ! rocm-smi --showid >/dev/null 2>&1; then
+    return 0
+  fi
+  local probe
+  probe="$("$PYTHON" - <<'PY' 2>/dev/null || true
+import json, sys
+out = {"rc": 0}
+try:
+    import torch
+    out["torch_version"] = torch.__version__
+    out["hip"] = getattr(torch.version, "hip", None)
+    out["cuda_str"] = getattr(torch.version, "cuda", None)
+except Exception as exc:
+    out["rc"] = 2
+    out["error"] = type(exc).__name__ + ": " + str(exc)[:200]
+print(json.dumps(out))
+PY
+)"
+  if [ -z "$probe" ]; then
+    warn "torch probe produced no output (PYTHON=${PYTHON})"
+    return 0
+  fi
+  local rc; rc="$("$PYTHON" -c "import json,sys; d=json.loads(sys.argv[1]); print(d.get('rc',0))" "$probe" 2>/dev/null || echo 0)"
+  if [ "$rc" = "2" ]; then
+    warn "torch is NOT importable from PYTHON=${PYTHON}"
+    warn "this pod has ROCm GPUs (rocm-smi works) -- letting pip install proceed"
+    warn "would pull plain 'torch' from PyPI (= NVIDIA CUDA wheel) and break"
+    warn "downstream RAG / baseline / kernel steps with 'Found no NVIDIA driver'."
+    warn "Fixes (pick one):"
+    warn "  * use the canonical ROCm stack:   unset PYTHON; install.sh will pick /opt/venv"
+    warn "  * install the ROCm torch wheel:    \"\$PYTHON\" -m pip install --pre torch --index-url https://download.pytorch.org/whl/rocm6.x"
+    warn "  * opt out of this gate:            INFERENCE_OPTIMIZER_FORCE_PYTHON=1 INFERENCE_OPTIMIZER_SKIP_TORCH_GATE=1 install.sh"
+    if [ "${INFERENCE_OPTIMIZER_SKIP_TORCH_GATE:-0}" != "1" ]; then
+      die "refusing to install on ROCm pod with no torch in PYTHON=${PYTHON}"
+    fi
+    warn "INFERENCE_OPTIMIZER_SKIP_TORCH_GATE=1 set; continuing despite missing torch"
+    return 0
+  fi
+  local hip; hip="$("$PYTHON" -c "import json,sys; d=json.loads(sys.argv[1]); print(d.get('hip') or '')" "$probe" 2>/dev/null || echo "")"
+  local tv;  tv="$("$PYTHON"  -c "import json,sys; d=json.loads(sys.argv[1]); print(d.get('torch_version') or '')" "$probe" 2>/dev/null || echo "")"
+  if [ -z "$hip" ]; then
+    warn "torch=${tv} in PYTHON=${PYTHON} is NOT a ROCm build (torch.version.hip is None)"
+    warn "but this pod reports ROCm GPUs via rocm-smi. RAG-index / baseline / kernel"
+    warn "steps will crash at torch._C._cuda_init() with 'Found no NVIDIA driver'."
+    warn "Fixes (pick one):"
+    warn "  * use the canonical ROCm stack:   unset PYTHON; install.sh will pick /opt/venv"
+    warn "  * install the ROCm torch wheel:    \"\$PYTHON\" -m pip install --force-reinstall --pre torch --index-url https://download.pytorch.org/whl/rocm6.x"
+    warn "  * opt out of this gate:            INFERENCE_OPTIMIZER_SKIP_TORCH_GATE=1 install.sh"
+    if [ "${INFERENCE_OPTIMIZER_SKIP_TORCH_GATE:-0}" != "1" ]; then
+      die "refusing to install: torch=${tv} is CUDA-built on a ROCm pod"
+    fi
+    warn "INFERENCE_OPTIMIZER_SKIP_TORCH_GATE=1 set; continuing despite torch/GPU mismatch"
+    return 0
+  fi
+  log "torch=${tv} (hip=${hip}) -- ROCm-compatible OK"
+}
+
+ensure_torch_compatible_with_gpu
 log "REPO_ROOT=${REPO_ROOT}"
 log "USER_DATA_PATH=${USER_DATA_PATH}"
 log "HYPERLOOM_RUNTIME_DIR=${HYPERLOOM_RUNTIME_DIR}"
@@ -129,15 +215,30 @@ fi
 
 # pip --break-system-packages when PYTHON is the system interpreter
 # (e.g. bare ubuntu/debian image without a venv). Detect by comparing
-# sys.prefix vs sys.base_prefix; equal == not in venv.
+# sys.prefix vs sys.base_prefix; equal == not in venv. The flag was added
+# in pip 23.0.1; older pips reject it as an unknown option, so we probe
+# `pip install --break-system-packages --help` before adopting it.
 PIP_EXTRA=()
 if "$PYTHON" - <<'PY' 2>/dev/null
 import sys
 raise SystemExit(0 if sys.prefix == sys.base_prefix else 1)
 PY
 then
-  PIP_EXTRA=(--break-system-packages)
-  log "non-venv PYTHON; pip will use --break-system-packages"
+  if "$PYTHON" -m pip install --break-system-packages --help >/dev/null 2>&1; then
+    PIP_EXTRA=(--break-system-packages)
+    log "non-venv PYTHON; pip will use --break-system-packages"
+  else
+    pip_ver="$("$PYTHON" -m pip --version 2>&1 | awk '{print $2}')"
+    warn "non-venv PYTHON detected (PYTHON=${PYTHON}) but pip ${pip_ver}"
+    warn "is too old for --break-system-packages (requires >= 23.0.1)."
+    warn "Fixes (pick one):"
+    warn "  * use the canonical ROCm stack: unset PYTHON; install.sh will pick /opt/venv"
+    warn "  * create a venv:                python3 -m venv \"\$USER_DATA_PATH/venv\" \\"
+    warn "                                  && \"\$USER_DATA_PATH/venv/bin/python\" -m pip install -U pip wheel \\"
+    warn "                                  && export PYTHON=\"\$USER_DATA_PATH/venv/bin/python\""
+    warn "  * upgrade system pip:           \"\$PYTHON\" -m pip install --user -U 'pip>=23.0.1'"
+    die "refusing to run pip without a working --break-system-packages on a non-venv interpreter"
+  fi
 fi
 
 # --- 1. inference_optimizer + claude_agent_sdk via [test] ---

--- a/optimizer_runs/robustness_monitor.sh.example
+++ b/optimizer_runs/robustness_monitor.sh.example
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Robustness monitor for long-running ``inference_optimizer optimize`` runs.
+#
+# Polls ``$INFERENCE_OPTIMIZER_SESSION_DIR/state.json`` every 300s. On a
+# terminal ``stop_reason`` (``target_reached`` / ``no_more_leverage`` /
+# ``time_exhausted`` / ``max_ticks``), exits 0. If the optimizer process has
+# disappeared from ``/proc`` (crashed / killed), re-launches it with
+# ``--resume`` and updates ``$PID_FILE`` with the new pid. Logs the
+# resume invocation to ``$REPO_ROOT/optimizer_runs/resume_<ts>.log``.
+#
+# Required env (caller MUST export):
+#   PID_FILE        path to the optimizer's pidfile; rewritten on each resume
+#   REPO_ROOT       Hyperloom checkout root; resume logs land in
+#                   ``$REPO_ROOT/optimizer_runs/resume_<timestamp>.log``
+#
+# Optional env (defaults shown):
+#   MAX_HOURS                          24    deadline (this watchdog exits
+#                                            after MAX_HOURS + 1 buffer)
+#   TARGET_GAIN                        10    --target-gain forwarded to
+#                                            ``inference_optimizer optimize --resume``
+#   INFERENCE_OPTIMIZER_SESSION_DIR    /workspace/hyperloom
+#                                            session-dir holding state.json
+#   MAGPIE_PYTHON                      /opt/venv/bin/python
+#                                            interpreter forwarded to the
+#                                            resume launch
+#
+# Invocation pattern (see ``inference_optimizer/SKILL.md`` §"Robustness
+# Monitor for Long Runs"):
+#
+#   export RUN_DIR="${USER_DATA_PATH:-/workspace/hyperloom}/optimizer_runs"
+#   mkdir -p "$RUN_DIR"
+#   cp "$REPO_ROOT/optimizer_runs/robustness_monitor.sh.example" \
+#      "$RUN_DIR/robustness_monitor.sh"
+#   chmod +x "$RUN_DIR/robustness_monitor.sh"
+#   setsid nohup bash "$RUN_DIR/robustness_monitor.sh" \
+#     > "$RUN_DIR/robustness_monitor_$(date +%Y%m%d_%H%M%S).log" \
+#     2>&1 < /dev/null &
+#
+# Edit the defaults above before copying if your run uses different
+# values. The ``stop_reason`` interpretation matches the ``Monitoring``
+# section of SKILL.md (same terminal-state set).
+
+set -u
+
+# Required envs — fail early with a clear message instead of a generic
+# "unbound variable" cascade further down.
+# (NOTE: avoid apostrophes inside the :? text; bash tracks quote state
+# through parameter-expansion default values and would treat them as
+# unmatched single-quote openers.)
+: "${PID_FILE:?error: PID_FILE must point at the optimizer pidfile (set before invoking robustness_monitor.sh)}"
+: "${REPO_ROOT:?error: REPO_ROOT must be the Hyperloom checkout root (resume logs land in \$REPO_ROOT/optimizer_runs/)}"
+
+export MAGPIE_PYTHON="${MAGPIE_PYTHON:-/opt/venv/bin/python}"
+session_dir="${INFERENCE_OPTIMIZER_SESSION_DIR:-/workspace/hyperloom}"
+deadline=$(( $(date +%s) + (${MAX_HOURS:-24} + 1) * 3600 ))
+
+read_stop() {
+  python3 -c "import json,pathlib,sys; p=pathlib.Path(sys.argv[1]); print((json.loads(p.read_text()).get('stop_reason') or '').strip() if p.exists() else '')" "$session_dir/state.json"
+}
+
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  pid=""
+  [ -f "$PID_FILE" ] && read -r pid < "$PID_FILE" || true
+
+  case "$(read_stop)" in
+    target_reached|no_more_leverage|time_exhausted|max_ticks)
+      echo "[robustness] terminal $(date -Is)"
+      exit 0
+      ;;
+  esac
+
+  if [ -n "$pid" ] && [ -d "/proc/$pid" ]; then
+    sleep 300
+    continue
+  fi
+
+  echo "[robustness] optimizer stopped; resuming $(date -Is)"
+  resume_log="$REPO_ROOT/optimizer_runs/resume_$(date +%Y%m%d_%H%M%S).log"
+  MAGPIE_PYTHON="${MAGPIE_PYTHON}" setsid nohup inference_optimizer --verbose optimize --resume \
+    --target-gain "${TARGET_GAIN:-10}" --max-hours "${MAX_HOURS:-24}" \
+    --tick-interval-sec 30 --kernel-claude \
+    > "$resume_log" 2>&1 < /dev/null &
+  echo $! > "$PID_FILE"
+  sleep 300
+done


### PR DESCRIPTION
Closes #232, closes #233.

Both bugs hit the same fresh MI355X pod and chain into each other — operator runs `bash inference_optimizer/scripts/install.sh`, the install "succeeds" but with the wrong torch wheel, then the GEAK RAG step explodes with `Found no NVIDIA driver`; even after that's worked around, the SKILL.md `cp` for the robustness monitor fails because the template was never in the repo. So bundling them.

## Two commits

### 1. `fix(install.sh): prefer /opt/venv ROCm stack, gate torch wheel, detect old pip (#232)`

Four changes in `inference_optimizer/scripts/install.sh`:

* `resolve_python()` prefers `/opt/venv/bin/python` over a caller-supplied `$PYTHON` when both exist (escape hatch: `INFERENCE_OPTIMIZER_FORCE_PYTHON=1`). Stops a stale ambient `$PYTHON` from silently bypassing the canonical ROCm stack.
* Exports `$PYTHON` and prepends its `bin/` to `$PATH` before chaining to `kernel-agent/scripts/install.sh`. That installer's own `_resolve_magpie_python` is correct, but its bare `python3 -m pip` calls fall through to `$PATH` resolution — without this, the two installers can land in different interpreters.
* New `ensure_torch_compatible_with_gpu` step. On hosts where `rocm-smi` works, asserts `torch.version.hip is not None`. Two failure modes surfaced separately: torch missing entirely (next `pip install -e .[test]` would pull NVIDIA cu130 from PyPI) and torch-built-against-CUDA (RAG step crashes at `torch._C._cuda_init()`). Both fail with three actionable fixes; both honour `INFERENCE_OPTIMIZER_SKIP_TORCH_GATE=1`.
* Old-pip detection. `--break-system-packages` was added in pip 23.0.1 and is rejected as unknown by older pips. Probe `pip install --break-system-packages --help` before adopting; if unsupported, fail fast with three options (use `/opt/venv`, create a venv, upgrade pip) instead of running pip with an unknown flag.

### 2. `fix(SKILL): ship optimizer_runs/robustness_monitor.sh.example template (#233)`

Adds `optimizer_runs/robustness_monitor.sh.example`, the template `inference_optimizer/SKILL.md:695` already tells operators to `cp` from. The script was never in the repo (`git log --diff-filter=D` empty for the path); SKILL.md had been pointing at a file that didn't exist. Behaviour matches SKILL §Robustness Monitor for Long Runs verbatim: poll `state.json` every 300s, exit on terminal `stop_reason`, auto-resume via `inference_optimizer optimize --resume` when the optimizer disappears from `/proc`.

Polish vs the inline scripts operators have been hand-writing during the gap:
- Required (`PID_FILE`, `REPO_ROOT`) and optional (`MAX_HOURS`, `TARGET_GAIN`, etc.) envs documented in the header with defaults shown; SKILL invocation pattern reproduced inline.
- `: \"\${PID_FILE:?...}\"` preflight fails fast with a clear message instead of letting `set -u` cascade into a generic "unbound variable" later.

`.gitignore` adjustment: `optimizer_runs/` is the runtime per-session output and stays ignored, but the bare directory rule prevents git from recursing — switching to `optimizer_runs/*` + `!optimizer_runs/robustness_monitor.sh.example` keeps everything else ignored while letting this one tracked template through.

## Test plan

- [x] `bash -n` passes on both `inference_optimizer/scripts/install.sh` and the new `.example`.
- [x] All 4 install.sh fixes exercised in 4 dry-run scenarios on the live pod (reported in the original repro session): stale-PYTHON wins fail, FORCE_PYTHON opt-out works, torch-gate fails with actionable message on bare interpreter, fresh shell auto-picks `/opt/venv`.
- [x] `optimizer_runs/robustness_monitor.sh.example` is the same script that ran healthily as PID 22949 on the live pod (multiple resume cycles observed) — adapted only for header docs + preflight-env validation.
- [x] Re-run `install.sh` on a fresh MI355X pod with no env exports: confirm it auto-picks `/opt/venv/bin/python`, torch gate passes, RAG index build succeeds, no `--break-system-packages` invocation.
- [x] Re-run on a fresh ROCm pod with bare `/usr/bin/python3` + no `/opt/venv`: confirm torch gate fails with the three-option message instead of letting `pip install -e .[test]` pull the NVIDIA wheel.
