### PR TITLE
fix(breakdown): production-data robustness — invocation, image, ttft reconstruction, attribution lineage

### DIFF
--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -15,12 +15,166 @@ from __future__ import annotations
 import glob
 import json
 import logging
+import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
 log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Invocation-record env filter (allowlist + secret-pattern denylist)
+# ---------------------------------------------------------------------------
+# We only surface env vars that are known to influence the launched
+# benchmark workload (knobs an operator would reasonably want to replay).
+# Anything outside the allowlist gets dropped — keeps secrets, host
+# fingerprints, and shell aliases out of the breakdown JSON entirely.
+_ENV_ALLOWLIST_EXACT: frozenset[str] = frozenset({
+    "TP", "FRAMEWORK", "GPU_TYPE", "PRECISION", "CONC", "ISL", "OSL",
+    "MAX_MODEL_LEN", "USER_DATA_PATH", "MODEL_PATH", "MODEL_NAME",
+})
+_ENV_ALLOWLIST_PREFIXES: tuple[str, ...] = (
+    "HYPERLOOM_", "VLLM_", "SGLANG_", "RAY_", "HSA_", "ROCM_", "TORCH_", "HF_",
+)
+# Defense-in-depth: even if a future operator adds a credential-shaped
+# key under one of the allowlisted prefixes (e.g. ``HF_API_TOKEN``) we
+# still strip it before emit. Match is case-insensitive; substring match
+# is intentional (catches ``MY_API_KEY``, ``X_PASSWORD_FILE`` etc.).
+_ENV_DENY_PATTERN = re.compile(
+    r"(KEY|TOKEN|SECRET|PASSWORD|AUTH|CREDENTIAL|COOKIE|API_KEY)",
+    re.IGNORECASE,
+)
+
+
+def _filter_envs(envs: dict[str, Any] | None) -> dict[str, str]:
+    """Apply the allowlist + secret denylist to a raw env dict.
+
+    Always returns a fresh ``dict[str, str]`` (values stringified, None
+    becomes ``""``). Non-string keys are dropped silently.
+    """
+    if not isinstance(envs, dict):
+        return {}
+    out: dict[str, str] = {}
+    for k, v in envs.items():
+        if not isinstance(k, str):
+            continue
+        keep = (k in _ENV_ALLOWLIST_EXACT) or any(
+            k.startswith(p) for p in _ENV_ALLOWLIST_PREFIXES
+        )
+        if not keep:
+            continue
+        if _ENV_DENY_PATTERN.search(k):
+            continue
+        out[k] = "" if v is None else str(v)
+    return out
+
+
+def _extract_framework_args(server_log: Path | None) -> str:
+    """Read the first non-empty line of a benchmark ``server.log``.
+
+    Hyperloom's benchmark runner echoes the launch command (the ``python
+    -m sglang.launch_server ...`` / ``python -m vllm.entrypoints ...``
+    invocation) as the very first line of server.log. That single line
+    is the canonical "what command did we actually run" record and is
+    what we surface in :class:`BenchmarkInvocation.framework_args`.
+
+    Reads at most 64 KB defensively — we never need more than the
+    first line, and even pathological logs cap out fast. Returns
+    ``""`` on any miss / read error so the collector can decide
+    whether to omit the field entirely.
+    """
+    if server_log is None:
+        return ""
+    try:
+        if not server_log.exists():
+            return ""
+        # 64 KB is plenty for the first launch line; bounds the worst case.
+        with server_log.open("r", encoding="utf-8", errors="replace") as fh:
+            chunk = fh.read(64 * 1024)
+    except OSError:
+        return ""
+    for line in chunk.splitlines():
+        line = line.strip()
+        if line:
+            return line
+    return ""
+
+
+def _read_invocation_envs(config_path: Path | None) -> dict[str, str]:
+    """Read ``benchmark.envs`` from a ``baseline_config.with_envs.yaml``
+    (or any sibling variant config) and return the allowlisted subset.
+
+    Falls back to the top-level ``envs:`` block for older config layouts
+    that didn't yet nest under ``benchmark:``. Returns ``{}`` on any
+    read / parse failure or if PyYAML is somehow missing — never raises.
+    """
+    if config_path is None:
+        return {}
+    try:
+        if not config_path.exists():
+            return {}
+    except OSError:
+        return {}
+    try:
+        import yaml
+    except ImportError:
+        log.debug("PyYAML unavailable; skipping invocation env extraction")
+        return {}
+    try:
+        text = config_path.read_text(encoding="utf-8", errors="replace")
+        data = yaml.safe_load(text)
+    except (OSError, yaml.YAMLError) as exc:
+        log.debug("failed to parse invocation config %s: %r", config_path, exc)
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    bench = data.get("benchmark") if isinstance(data.get("benchmark"), dict) else {}
+    raw_envs = bench.get("envs") if isinstance(bench, dict) else None
+    if raw_envs is None:
+        raw_envs = data.get("envs")
+    return _filter_envs(raw_envs if isinstance(raw_envs, dict) else None)
+
+
+def _detect_image_for_session(manifest: dict[str, Any]) -> str | None:
+    """Resolve the container image for ``collect_session``.
+
+    Prefers the manifest field (written once at session start, captures
+    the spawn-time image even if the env later changes). Falls back to
+    the same env / mount-point chain the manifest helper uses, so V1
+    manifests (no ``image`` field) still surface a value when one of
+    the envs is set. Mirrors :func:`manifest._detect_image` but kept as
+    a separate function to avoid an import cycle.
+    """
+    manifest_image = manifest.get("image") if isinstance(manifest, dict) else None
+    if isinstance(manifest_image, str) and manifest_image.strip():
+        return manifest_image.strip()
+    for var in ("HYPERLOOM_IMAGE", "CONTAINER_IMAGE", "IMAGE"):
+        val = (os.environ.get(var) or "").strip()
+        if val:
+            return val
+    for marker in ("/etc/podinfo/image", "/etc/hyperloom-image"):
+        try:
+            p = Path(marker)
+            if p.exists():
+                txt = p.read_text(encoding="utf-8", errors="replace").strip()
+                if txt:
+                    return txt
+        except OSError:
+            continue
+    try:
+        cgroup = Path("/proc/1/cgroup")
+        if cgroup.exists():
+            for line in cgroup.read_text(encoding="utf-8", errors="replace").splitlines():
+                if "docker" not in line and "containerd" not in line:
+                    continue
+                m = re.search(r"([0-9a-f]{12,64})", line)
+                if m:
+                    return f"unknown@{m.group(1)[:12]}"
+    except OSError:
+        pass
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -237,6 +391,11 @@ def collect_session(
             elapsed_min = (datetime.now(timezone.utc) - start).total_seconds() / 60.0
         except (ValueError, TypeError):
             pass
+    image = _detect_image_for_session(manifest)
+    if image is None:
+        warnings.append(
+            "image: not configured (set HYPERLOOM_IMAGE env var)"
+        )
     return {
         "session_id":       str(state.get("session_id") or manifest.get("session_id") or ""),
         "claw_session_id":  manifest.get("claw_session_id") or state.get("claw_session_id"),
@@ -247,6 +406,7 @@ def collect_session(
         "max_minutes":      int(state.get("max_minutes") or manifest.get("max_minutes") or 0),
         "elapsed_minutes":  round(elapsed_min, 2) if elapsed_min is not None else 0.0,
         "host":             str(manifest.get("host") or ""),
+        "image":            image,
         "code_revision":    str(manifest.get("code_revision") or ""),
         "pid":              int(manifest.get("pid") or 0),
         "session_dir":      str(session_dir),
@@ -319,22 +479,120 @@ def collect_baseline(
             "error_class":   a.get("error_class"),
         })
 
+    # Disk-walking fallback: state.baseline_attempts is empty in many
+    # production sessions even when multiple baseline runs left
+    # ``runs/baseline/<hash>/`` dirs behind. Reconstruct so dashboards
+    # don't show "0 baseline attempts" for sessions that obviously had
+    # several. Each entry is marked ``status="reconstructed"`` so it's
+    # visibly distinct from a state-recorded one.
+    if not history:
+        reconstructed = _reconstruct_baseline_attempts(session_dir, warnings)
+        if reconstructed:
+            history = reconstructed
+            warnings.append(
+                "baseline.attempts_history reconstructed from runs/baseline/ "
+                "(state.baseline_attempts was empty); detail fields are partial."
+            )
+
+    config_path_raw = state.get("baseline_config_path") or None
+    config_resolved = _resolve_under_session(session_dir, config_path_raw) if config_path_raw else None
+    server_log_path: Path | None = None
+    if workspace:
+        # The most recent benchmark dir under the resolved workspace
+        # owns the matching server.log; fall back to None on miss.
+        bench_dirs = sorted(
+            workspace.glob("benchmark_*/server.log"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+        if bench_dirs:
+            server_log_path = bench_dirs[0]
+
+    invocation = {
+        "framework_args":   _extract_framework_args(server_log_path),
+        "extra_envs":       _read_invocation_envs(config_resolved),
+        "config_path":      _rel(config_resolved, session_dir) if config_resolved else (
+            config_path_raw if config_path_raw else None
+        ),
+        "server_log_path":  _rel(server_log_path, session_dir) if server_log_path else None,
+    }
+
     return {
         "throughput_tok_s_per_gpu": _to_float(state.get("baseline_tput")) or 0.0,
         "accuracy":                 _to_float(state.get("baseline_accuracy")) or 0.0,
         "ttft_mean_ms":             ttft,
         "e2el_mean_ms":             e2el,
-        "config_path":              state.get("baseline_config_path") or None,
+        "config_path":              config_path_raw,
         "benchmark_report_path":    _rel(report_path, session_dir) if report_path else None,
         "attempts_history":         history,
         "failure_streak":           int(state.get("baseline_failure_streak") or 0),
+        "invocation":               invocation,
     }
+
+
+def _reconstruct_baseline_attempts(
+    session_dir: Path,
+    warnings: list[str],
+) -> list[dict[str, Any]]:
+    """Walk ``<sd>/runs/baseline/<hash>/benchmark_*/benchmark_report.json``
+    and synthesize :class:`BaselineAttemptSummary` rows for each.
+
+    Used when ``state.baseline_attempts`` is empty but the on-disk
+    runs/baseline/ tree shows that baseline ran (one or many times).
+    Reads only what we can be certain of; everything else stays empty.
+    """
+    root = session_dir / "runs" / "baseline"
+    if not root.exists():
+        return []
+    out: list[dict[str, Any]] = []
+    reports = sorted(
+        root.glob("*/benchmark_*/benchmark_report.json"),
+        key=lambda p: p.stat().st_mtime,
+    )
+    for report_path in reports:
+        bench_dir = report_path.parent
+        # task dir = <sd>/runs/baseline/<HASH> ; bench dir = <task>/benchmark_<ts>
+        task_dir = bench_dir.parent
+        ts_iso = ""
+        # Prefer a parseable ``benchmark_<UTC>`` suffix, else mtime.
+        m = re.search(r"benchmark_(\d{8})[T_](\d{6})", bench_dir.name)
+        if m:
+            try:
+                dt = datetime.strptime(
+                    f"{m.group(1)}T{m.group(2)}",
+                    "%Y%m%dT%H%M%S",
+                ).replace(tzinfo=timezone.utc)
+                ts_iso = dt.isoformat(timespec="seconds")
+            except ValueError:
+                ts_iso = ""
+        if not ts_iso:
+            try:
+                ts_iso = datetime.fromtimestamp(
+                    report_path.stat().st_mtime, tz=timezone.utc,
+                ).isoformat(timespec="seconds")
+            except OSError:
+                ts_iso = ""
+        report = _load_json_safe(report_path, warnings)
+        out_tput, _ttft, _tpot, _e2el = _benchmark_report_metrics(
+            report if isinstance(report, dict) else None
+        )
+        out.append({
+            "ts":           ts_iso,
+            "task_id":      task_dir.name,
+            "status":       "reconstructed",
+            "decision":     "",
+            "key_metric":   out_tput,
+            "workspace":    _rel(task_dir, session_dir) or str(task_dir),
+            "error_class":  None,
+        })
+    return out
 
 
 # ---------------------------------------------------------------------------
 # §4 Final (validated)
 # ---------------------------------------------------------------------------
 def collect_final(
+    session_dir: Path,
     state: dict[str, Any],
     warnings: list[str],
 ) -> dict[str, Any]:
@@ -351,6 +609,41 @@ def collect_final(
         variant = str(entry.get("variant_name") or "")
         action_path.append(f"{action}:{variant}" if variant else action)
 
+    ttft = _to_float(cb.get("ttft_mean_ms"))
+    e2el = _to_float(cb.get("e2el_mean_ms"))
+    ttft_e2el_source = "current_best" if ttft is not None else "unavailable"
+
+    # Disk-walk reconstruction. Coordinator usually leaves
+    # ``current_best.ttft_mean_ms`` unset — the value lives only in the
+    # actual benchmark_report.json on disk. Walk validate_stack first
+    # (most authoritative: it's the run that produced the validated
+    # cumulative gain), fall back to the latest stack entry's workspace.
+    reconstructed_report: Path | None = None
+    if ttft is None:
+        reconstructed_report = _find_latest_validate_stack_report(session_dir)
+        if reconstructed_report is not None:
+            ttft_e2el_source = "validate_stack_disk"
+        else:
+            reconstructed_report = _find_stack_top_report(session_dir, state)
+            if reconstructed_report is not None:
+                ttft_e2el_source = "stack_top_disk"
+    if reconstructed_report is not None:
+        report = _load_json_safe(reconstructed_report, warnings)
+        if isinstance(report, dict):
+            _, ttft_disk, _tpot, e2el_disk = _benchmark_report_metrics(report)
+            if ttft is None and ttft_disk is not None:
+                ttft = ttft_disk
+            if e2el is None and e2el_disk is not None:
+                e2el = e2el_disk
+        warnings.append(
+            f"final.ttft_mean_ms reconstructed from {ttft_e2el_source}; "
+            "current_best did not record it (Coordinator gap)"
+        )
+
+    invocation = _build_final_invocation(
+        session_dir, state, reconstructed_report, warnings,
+    )
+
     return {
         "throughput_tok_s_per_gpu":          _to_float(cb.get("tput")),
         "cumulative_gain_pct_validated":     _to_float(state.get("cumulative_gain_validated")) or 0.0,
@@ -361,8 +654,89 @@ def collect_final(
         "extra_sglang_args":                 str(cb.get("extra_sglang_args") or ""),
         "extra_envs":                        dict(cb.get("extra_envs") or {}),
         "action_path":                       action_path,
-        "ttft_mean_ms":                      _to_float(cb.get("ttft_mean_ms")),
-        "e2el_mean_ms":                      _to_float(cb.get("e2el_mean_ms")),
+        "ttft_mean_ms":                      ttft,
+        "e2el_mean_ms":                      e2el,
+        "ttft_e2el_source":                  ttft_e2el_source,
+        "invocation":                        invocation,
+    }
+
+
+def _find_latest_validate_stack_report(session_dir: Path) -> Path | None:
+    """Most-recent validate_stack benchmark_report.json under session_dir.
+
+    validate_stack is the action that re-runs the entire optimization
+    stack to produce a confirmed cumulative gain number, so its
+    benchmark report is the authoritative source for "what does the
+    final stack actually clock at".
+    """
+    root = session_dir / "runs" / "validate_stack"
+    if not root.exists():
+        return None
+    candidates = sorted(
+        root.glob("*/benchmark_*/benchmark_report.json"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    return candidates[0] if candidates else None
+
+
+def _find_stack_top_report(
+    session_dir: Path, state: dict[str, Any],
+) -> Path | None:
+    """Last optimization_stack entry's benchmark_report.json (best-effort).
+
+    Used when no validate_stack run was recorded — the topmost stack
+    entry's KEEP run is the next-best evidence of "the final
+    configuration's measured throughput / latency".
+    """
+    stack = state.get("optimization_stack") or []
+    if not isinstance(stack, list) or not stack:
+        return None
+    last = stack[-1] if isinstance(stack[-1], dict) else None
+    if last is None:
+        return None
+    workspace_str = last.get("workspace") or ""
+    if not workspace_str:
+        return None
+    workspace = _resolve_under_session(session_dir, workspace_str)
+    if workspace is None:
+        return None
+    return _find_benchmark_report(workspace)
+
+
+def _build_final_invocation(
+    session_dir: Path,
+    state: dict[str, Any],
+    benchmark_report: Path | None,
+    warnings: list[str],
+) -> dict[str, Any]:
+    """Best-effort :class:`BenchmarkInvocation` for the final stack run.
+
+    The "config" we surface here is the ``baseline_config.with_envs.yaml``
+    sibling of whichever benchmark_report we used for ttft / e2el. That
+    is, the file the workload was actually launched with — so an
+    operator can replay the exact same command + envs.
+    """
+    config_path: Path | None = None
+    server_log_path: Path | None = None
+    if benchmark_report is not None:
+        bench_dir = benchmark_report.parent
+        task_dir = bench_dir.parent
+        for candidate in (
+            bench_dir / "baseline_config.with_envs.yaml",
+            task_dir / "baseline_config.with_envs.yaml",
+        ):
+            if candidate.exists():
+                config_path = candidate
+                break
+        log_candidate = bench_dir / "server.log"
+        if log_candidate.exists():
+            server_log_path = log_candidate
+    return {
+        "framework_args":   _extract_framework_args(server_log_path),
+        "extra_envs":       _read_invocation_envs(config_path),
+        "config_path":      _rel(config_path, session_dir) if config_path else None,
+        "server_log_path":  _rel(server_log_path, session_dir) if server_log_path else None,
     }
 
 
@@ -1708,9 +2082,33 @@ def collect_attribution(
     # Prefer authoritative per-stack ledger if Coordinator wrote it
     # (new state field `gain_per_stack_entry`). Otherwise reconstruct a
     # best-effort approximation from optimization_stack alone.
-    entries = state.get("gain_per_stack_entry")
-    if not isinstance(entries, list):
+    state_entries = state.get("gain_per_stack_entry")
+    state_provided = isinstance(state_entries, list) and len(state_entries) > 0
+    if state_provided:
+        entries = list(state_entries)
+    else:
         entries = _reconstruct_gain_ledger(state, warnings)
+
+    # Classify the attribution lineage so consumers (dashboard, LLM
+    # narrator) can render an honest provenance label rather than
+    # silently presenting a reconstructed split as validated.
+    stack = state.get("optimization_stack") or []
+    stack_len = len(stack) if isinstance(stack, list) else 0
+    method: str
+    if state_provided:
+        all_deltas_set = all(
+            isinstance(e, dict) and e.get("delta_pct") is not None
+            for e in state_entries
+        )
+        method = "validated" if all_deltas_set else "reconstructed"
+    elif stack_len == 1:
+        # Single-entry stack: ``final.action_path`` unambiguously
+        # identifies the one source of gain.
+        method = "single_source"
+    elif stack_len > 1:
+        method = "reconstructed"
+    else:
+        method = "missing"
 
     # Bucket entries by family for source_breakdown. Honor validated
     # total as the ground-truth denominator.
@@ -1746,7 +2144,7 @@ def collect_attribution(
         oob_total = kernel_total
 
     notes: list[str] = []
-    if not isinstance(state.get("gain_per_stack_entry"), list):
+    if not state_provided:
         notes.append(
             "gain_per_stack_entry not written by Coordinator; "
             "attribution reconstructed best-effort from optimization_stack."
@@ -1754,6 +2152,7 @@ def collect_attribution(
 
     return {
         "gain_per_stack_entry": entries,
+        "method":               method,
         "source_breakdown": {
             "geak_pct_of_total":     round(geak_total, 2),
             "oob_pct_of_total":      round(oob_total, 2),

--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -71,35 +71,175 @@ def _filter_envs(envs: dict[str, Any] | None) -> dict[str, str]:
     return out
 
 
-def _extract_framework_args(server_log: Path | None) -> str:
-    """Read the first non-empty line of a benchmark ``server.log``.
+# --- framework-args extraction patterns -----------------------------------
+# Pass-1 ("log_args_line"): the runner echoes the parsed launch arguments
+# under one of these stable headers — most reliable signal because it
+# survives any number of preceding INFO log lines.
+_FRAMEWORK_ARGS_HEADER_RE = re.compile(
+    r"^[^|]*?Server arguments?:\s*(.+)$",
+    re.IGNORECASE,
+)
+_FRAMEWORK_ARGS_NAMESPACE_RE = re.compile(
+    r"^[^|]*?Args:\s*Namespace\((.+)\)\s*$",
+    re.IGNORECASE,
+)
+_FRAMEWORK_ARGS_LAUNCH_RE = re.compile(
+    r"^[^|]*?Launch(?:ing)? server with:\s*(.+)$",
+    re.IGNORECASE,
+)
+# Pass-2 ("log_python_cmd"): a literal ``python ... vllm/sglang ...``
+# command somewhere in server.log. We accept it after stripping a
+# leading ``(APIServer pid=...) INFO 05-12 ... [utils.py:299]``-style
+# log prefix that vllm/sglang emit.
+_LOG_PREFIX_RE = re.compile(
+    r"^\s*(?:\([^)]*\)\s+)?(?:INFO|WARN|WARNING|ERROR|DEBUG|TRACE)\s+"
+    r"\d[\d:\-\s]*\[[^\]]+\]\s*",
+    re.IGNORECASE,
+)
+_LOG_TIMESTAMP_RE = re.compile(
+    r"^\s*\[?\d{4}-\d{2}-\d{2}[T\s]\d{2}:\d{2}:\d{2}[^\]]*\]?\s*",
+)
+_PYTHON_CMD_PREFIXES: tuple[str, ...] = (
+    "python", "python3", "vllm", "sglang.launch_server",
+    "inference-optimizer", "ray",
+)
+# Server log size cap — pathological logs (multi-MB) get truncated so
+# the per-line scan stays bounded. 256 KB easily covers any startup
+# banner that echoes the launch line.
+_SERVER_LOG_MAX_BYTES = 256 * 1024
 
-    Hyperloom's benchmark runner echoes the launch command (the ``python
-    -m sglang.launch_server ...`` / ``python -m vllm.entrypoints ...``
-    invocation) as the very first line of server.log. That single line
-    is the canonical "what command did we actually run" record and is
-    what we surface in :class:`BenchmarkInvocation.framework_args`.
 
-    Reads at most 64 KB defensively — we never need more than the
-    first line, and even pathological logs cap out fast. Returns
-    ``""`` on any miss / read error so the collector can decide
-    whether to omit the field entirely.
+def _strip_log_prefix(line: str) -> str:
+    """Strip a leading ``[ts] LEVEL [src.py:NN]`` style prefix from a log line.
+
+    The vllm/sglang server echoes the launch command on its own line
+    after ~50 INFO log lines, each shaped like
+    ``(APIServer pid=1757439) INFO 05-12 14:21:14 [utils.py:299] ...``.
+    To match the literal command we strip both the parenthetical
+    process tag and the level/timestamp/source-frame prefix, leaving
+    just the trailing payload.
     """
-    if server_log is None:
+    s = line
+    s = _LOG_PREFIX_RE.sub("", s)
+    s = _LOG_TIMESTAMP_RE.sub("", s)
+    return s.strip()
+
+
+def _starts_with_python_prefix(text: str) -> bool:
+    head = text.lstrip()
+    for prefix in _PYTHON_CMD_PREFIXES:
+        if head.startswith(prefix):
+            tail = head[len(prefix):]
+            if not tail or tail[0] in (" ", "\t", "-", "."):
+                return True
+    return False
+
+
+def _extract_yaml_cmd(config_yaml: Path) -> str:
+    """Look for a ``cmd`` / ``command`` / ``launch`` field in the config yaml.
+
+    Yaml fallback for sessions whose server.log starts with INFO noise.
+    Reads from these locations (first-non-empty wins):
+      * top-level ``cmd`` / ``command`` / ``launch``
+      * nested ``benchmark.cmd`` / ``benchmark.command``
+    Returns ``""`` on any miss / parse failure.
+    """
+    try:
+        import yaml  # type: ignore[import-not-found]
+    except ImportError:
+        log.debug("PyYAML unavailable; skipping yaml framework_args fallback")
         return ""
     try:
-        if not server_log.exists():
-            return ""
-        # 64 KB is plenty for the first launch line; bounds the worst case.
-        with server_log.open("r", encoding="utf-8", errors="replace") as fh:
-            chunk = fh.read(64 * 1024)
-    except OSError:
+        text = config_yaml.read_text(encoding="utf-8", errors="replace")
+        data = yaml.safe_load(text)
+    except (OSError, yaml.YAMLError) as exc:
+        log.debug("failed to parse %s for framework_args: %r", config_yaml, exc)
         return ""
-    for line in chunk.splitlines():
-        line = line.strip()
-        if line:
-            return line
+    if not isinstance(data, dict):
+        return ""
+    for key in ("cmd", "command", "launch"):
+        val = data.get(key)
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+    bench = data.get("benchmark")
+    if isinstance(bench, dict):
+        for key in ("cmd", "command"):
+            val = bench.get(key)
+            if isinstance(val, str) and val.strip():
+                return val.strip()
     return ""
+
+
+def _extract_framework_args(
+    server_log: Path | None,
+    config_yaml: Path | None = None,
+) -> tuple[str, str]:
+    """Best-effort extract the launch command for a benchmark variant.
+
+    Returns ``(args_string, source)`` where ``source`` documents lineage:
+      * ``"log_args_line"`` — found a line like ``Server arguments: ...``
+        or ``Args: Namespace(...)`` in server.log
+      * ``"log_python_cmd"`` — found a line starting with ``python``,
+        ``python3``, ``vllm``, ``sglang.launch_server`` etc. in server.log
+      * ``"yaml_cmd"`` — fell back to ``cmd:`` / ``command:`` / ``launch:``
+        in the materialized config yaml
+      * ``"unknown"`` — none of the above; ``args_string`` is empty
+    Never raises. Caller decides whether to surface a warning when source
+    is ``unknown``.
+    """
+    chunk: str = ""
+    if server_log is not None:
+        try:
+            if server_log.exists():
+                with server_log.open("r", encoding="utf-8", errors="replace") as fh:
+                    chunk = fh.read(_SERVER_LOG_MAX_BYTES)
+        except OSError:
+            chunk = ""
+
+    lines = chunk.splitlines() if chunk else []
+
+    # Pass 1: stable launch-summary headers. These are emitted by the
+    # framework itself once it's parsed argv, so they survive any
+    # preceding log noise and are the most authoritative when present.
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        m = _FRAMEWORK_ARGS_HEADER_RE.match(stripped)
+        if m:
+            return m.group(1).strip(), "log_args_line"
+        m = _FRAMEWORK_ARGS_LAUNCH_RE.match(stripped)
+        if m:
+            return m.group(1).strip(), "log_args_line"
+        m = _FRAMEWORK_ARGS_NAMESPACE_RE.match(stripped)
+        if m:
+            return f"Namespace({m.group(1).strip()})", "log_args_line"
+
+    # Pass 2: a literal python/vllm/sglang command somewhere in the log.
+    # Strip the noisy ``(...) INFO 05-12 14:21:14 [utils.py:299]`` prefix
+    # before testing — the command itself starts on the same line.
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if _starts_with_python_prefix(stripped):
+            return stripped, "log_python_cmd"
+        cleaned = _strip_log_prefix(stripped)
+        if cleaned and _starts_with_python_prefix(cleaned):
+            return cleaned, "log_python_cmd"
+
+    # Pass 3: yaml fallback. Only consulted when the log gave us nothing.
+    if config_yaml is not None:
+        try:
+            yaml_exists = config_yaml.exists()
+        except OSError:
+            yaml_exists = False
+        if yaml_exists:
+            cmd = _extract_yaml_cmd(config_yaml)
+            if cmd:
+                return cmd, "yaml_cmd"
+
+    return "", "unknown"
 
 
 def _read_invocation_envs(config_path: Path | None) -> dict[str, str]:
@@ -464,6 +604,40 @@ def collect_baseline(
 
     _, ttft, _tpot, e2el = _benchmark_report_metrics(report if isinstance(report, dict) else None)
 
+    # Symmetric to A2 (final.ttft validate_stack disk walk): when
+    # state.last_baseline.workspace doesn't resolve to a readable
+    # benchmark_report.json, but ``runs/baseline/<hash>/benchmark_*/
+    # benchmark_report.json`` exists on disk, use the most recent. Real
+    # production sessions (e.g. zgong's V2) hit this gap — wekafs view
+    # has the report file but the state-recorded workspace doesn't
+    # match the wekafs root.
+    ttft_source: str | None = "state_workspace" if ttft is not None else None
+    if ttft is None:
+        candidates = sorted(
+            (session_dir / "runs" / "baseline").glob(
+                "*/benchmark_*/benchmark_report.json"
+            ),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+        if candidates:
+            disk_report_path = candidates[0]
+            disk_report = _load_json_safe(disk_report_path, warnings) or {}
+            _, ttft_disk, _tpot, e2el_disk = _benchmark_report_metrics(disk_report)
+            if ttft_disk is not None:
+                ttft = ttft_disk
+                if e2el is None and e2el_disk is not None:
+                    e2el = e2el_disk
+                if report_path is None:
+                    report_path = disk_report_path
+                ttft_source = "runs_baseline_disk"
+                warnings.append(
+                    "baseline.ttft_mean_ms reconstructed from runs/baseline/ disk walk; "
+                    "state.last_baseline.workspace did not resolve."
+                )
+    if ttft_source is None:
+        ttft_source = "unavailable"
+
     attempts = state.get("baseline_attempts") or []
     history: list[dict[str, Any]] = []
     for a in attempts:
@@ -497,9 +671,15 @@ def collect_baseline(
     config_path_raw = state.get("baseline_config_path") or None
     config_resolved = _resolve_under_session(session_dir, config_path_raw) if config_path_raw else None
     server_log_path: Path | None = None
-    if workspace:
-        # The most recent benchmark dir under the resolved workspace
-        # owns the matching server.log; fall back to None on miss.
+    # Prefer the report we already located (state-resolved or disk-walked) so
+    # the invocation surfaces the same benchmark variant as ttft/e2el. Fall
+    # back to the resolved workspace on the off chance state still pointed
+    # at the right place but the report itself was unreadable.
+    if report_path is not None:
+        candidate_log = report_path.parent / "server.log"
+        if candidate_log.exists():
+            server_log_path = candidate_log
+    if server_log_path is None and workspace:
         bench_dirs = sorted(
             workspace.glob("benchmark_*/server.log"),
             key=lambda p: p.stat().st_mtime,
@@ -508,20 +688,45 @@ def collect_baseline(
         if bench_dirs:
             server_log_path = bench_dirs[0]
 
+    # If we disk-walked into a benchmark dir, the matching config yaml
+    # usually sits as a sibling (or one level up under <task>/). Prefer
+    # that over state.baseline_config_path when the latter doesn't
+    # resolve, so the yaml fallback in _extract_framework_args has a
+    # real file to read.
+    if config_resolved is None and report_path is not None:
+        for candidate in (
+            report_path.parent / "baseline_config.with_envs.yaml",
+            report_path.parent.parent / "baseline_config.with_envs.yaml",
+        ):
+            if candidate.exists():
+                config_resolved = candidate
+                break
+
+    args_str, args_source = _extract_framework_args(
+        server_log_path, config_yaml=config_resolved,
+    )
     invocation = {
-        "framework_args":   _extract_framework_args(server_log_path),
-        "extra_envs":       _read_invocation_envs(config_resolved),
-        "config_path":      _rel(config_resolved, session_dir) if config_resolved else (
+        "framework_args":        args_str,
+        "framework_args_source": args_source,
+        "extra_envs":            _read_invocation_envs(config_resolved),
+        "config_path":           _rel(config_resolved, session_dir) if config_resolved else (
             config_path_raw if config_path_raw else None
         ),
-        "server_log_path":  _rel(server_log_path, session_dir) if server_log_path else None,
+        "server_log_path":       _rel(server_log_path, session_dir) if server_log_path else None,
     }
+    if args_source == "unknown":
+        warnings.append(
+            "framework_args extraction failed for "
+            f"{(_rel(server_log_path, session_dir) if server_log_path else 'no server.log')}; "
+            "tried server.log + yaml"
+        )
 
     return {
         "throughput_tok_s_per_gpu": _to_float(state.get("baseline_tput")) or 0.0,
         "accuracy":                 _to_float(state.get("baseline_accuracy")) or 0.0,
         "ttft_mean_ms":             ttft,
         "e2el_mean_ms":             e2el,
+        "ttft_e2el_source":         ttft_source,
         "config_path":              config_path_raw,
         "benchmark_report_path":    _rel(report_path, session_dir) if report_path else None,
         "attempts_history":         history,
@@ -732,11 +937,21 @@ def _build_final_invocation(
         log_candidate = bench_dir / "server.log"
         if log_candidate.exists():
             server_log_path = log_candidate
+    args_str, args_source = _extract_framework_args(
+        server_log_path, config_yaml=config_path,
+    )
+    if args_source == "unknown":
+        warnings.append(
+            "framework_args extraction failed for "
+            f"{(_rel(server_log_path, session_dir) if server_log_path else 'no server.log')}; "
+            "tried server.log + yaml"
+        )
     return {
-        "framework_args":   _extract_framework_args(server_log_path),
-        "extra_envs":       _read_invocation_envs(config_path),
-        "config_path":      _rel(config_path, session_dir) if config_path else None,
-        "server_log_path":  _rel(server_log_path, session_dir) if server_log_path else None,
+        "framework_args":        args_str,
+        "framework_args_source": args_source,
+        "extra_envs":            _read_invocation_envs(config_path),
+        "config_path":           _rel(config_path, session_dir) if config_path else None,
+        "server_log_path":       _rel(server_log_path, session_dir) if server_log_path else None,
     }
 
 

--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -424,8 +424,12 @@ def _detect_image_for_session(manifest: dict[str, Any]) -> str | None:
                 m = re.search(r"([0-9a-f]{12,64})", line)
                 if m:
                     return f"unknown@{m.group(1)[:12]}"
-    except OSError:
-        pass
+    except OSError as exc:
+        # /proc/1/cgroup may be unreadable in restricted sandboxes,
+        # non-Linux hosts, or stripped-down containers. Best-effort
+        # source — fall through to None so consumers see an honest
+        # "image not detected" rather than a fabricated value.
+        log.debug("cgroup-based image detection failed: %r", exc)
     return None
 
 

--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -12,6 +12,7 @@ The schema each collector matches is defined in :mod:`.schema`.
 
 from __future__ import annotations
 
+import ast
 import glob
 import json
 import logging
@@ -72,6 +73,18 @@ def _filter_envs(envs: dict[str, Any] | None) -> dict[str, str]:
 
 
 # --- framework-args extraction patterns -----------------------------------
+# Pass-0 ("log_non_default_args"): vllm (and recent sglang) print a single
+# line like ``non-default args: {'model': '/path', 'tensor_parallel_size':
+# 8, ...}`` right after argv parsing — it captures the *resolved* parsed
+# arg dict (post-CLI, post-env-override) and is therefore the most
+# authoritative cmdline-equivalent the framework itself emits. We match
+# loosely (``re.search``) so any leading ``(APIServer pid=...) INFO ...
+# [utils.py:233]`` log prefix is allowed; the dict literal must end the
+# line so a greedy ``\{.+\}`` is safe.
+_FRAMEWORK_ARGS_NON_DEFAULT_RE = re.compile(
+    r"non[-_]default args:\s*(\{.+\})\s*$",
+    re.IGNORECASE,
+)
 # Pass-1 ("log_args_line"): the runner echoes the parsed launch arguments
 # under one of these stable headers — most reliable signal because it
 # survives any number of preceding INFO log lines.
@@ -135,28 +148,36 @@ def _starts_with_python_prefix(text: str) -> bool:
     return False
 
 
-def _extract_yaml_cmd(config_yaml: Path) -> str:
-    """Look for a ``cmd`` / ``command`` / ``launch`` field in the config yaml.
+def _load_yaml_dict_safe(config_yaml: Path) -> dict | None:
+    """Parse ``config_yaml`` and return the top-level dict, or ``None`` on
+    any miss / parse failure / non-dict root. Never raises.
 
-    Yaml fallback for sessions whose server.log starts with INFO noise.
-    Reads from these locations (first-non-empty wins):
-      * top-level ``cmd`` / ``command`` / ``launch``
-      * nested ``benchmark.cmd`` / ``benchmark.command``
-    Returns ``""`` on any miss / parse failure.
+    Shared by both yaml-based passes (Pass 3 ``yaml_cmd`` and Pass 4
+    ``yaml_benchmark``) so the file is read + parsed at most once per
+    ``_extract_framework_args`` invocation.
     """
     try:
         import yaml  # type: ignore[import-not-found]
     except ImportError:
         log.debug("PyYAML unavailable; skipping yaml framework_args fallback")
-        return ""
+        return None
     try:
         text = config_yaml.read_text(encoding="utf-8", errors="replace")
         data = yaml.safe_load(text)
     except (OSError, yaml.YAMLError) as exc:
         log.debug("failed to parse %s for framework_args: %r", config_yaml, exc)
-        return ""
-    if not isinstance(data, dict):
-        return ""
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _yaml_cmd_from_dict(data: dict) -> str:
+    """Look for a ``cmd`` / ``command`` / ``launch`` field in a parsed yaml.
+
+    Reads from these locations (first-non-empty wins):
+      * top-level ``cmd`` / ``command`` / ``launch``
+      * nested ``benchmark.cmd`` / ``benchmark.command``
+    Returns ``""`` on any miss.
+    """
     for key in ("cmd", "command", "launch"):
         val = data.get(key)
         if isinstance(val, str) and val.strip():
@@ -170,6 +191,57 @@ def _extract_yaml_cmd(config_yaml: Path) -> str:
     return ""
 
 
+def _yaml_benchmark_synthesis(data: dict) -> str:
+    """Synthesize a readable arg string from a magpie ``benchmark.*`` dict.
+
+    Magpie-style materialized configs don't carry a literal ``cmd:`` field
+    — the launcher assembles the cmdline at runtime from structured
+    ``benchmark.{framework, model, precision, tp, gpu_selection, envs}``.
+    When neither server.log nor a yaml ``cmd:`` field is available, we
+    stringify those structured fields so the operator at least sees which
+    framework + model + precision + tp + envs were configured. The
+    ``yaml_benchmark`` source label flags downstream consumers that this
+    is a synthesized representation, not a literal cmdline.
+
+    Returns ``""`` unless both ``benchmark.framework`` AND ``benchmark.model``
+    are non-empty (those two are the minimum needed for the synthesis to
+    convey anything useful).
+    """
+    bench = data.get("benchmark")
+    if not isinstance(bench, dict):
+        return ""
+    fw = bench.get("framework")
+    model = bench.get("model")
+    fw_ok = isinstance(fw, str) and fw.strip()
+    model_ok = isinstance(model, str) and model.strip()
+    if not fw_ok or not model_ok:
+        return ""
+    parts: list[str] = [f"framework={fw.strip()}", f"model={model.strip()}"]
+    prec = bench.get("precision")
+    if prec is not None and str(prec).strip():
+        parts.append(f"precision={str(prec).strip()}")
+    tp = bench.get("tp")
+    if tp is not None and str(tp).strip():
+        parts.append(f"tp={str(tp).strip()}")
+    gpu_sel = bench.get("gpu_selection")
+    if isinstance(gpu_sel, dict):
+        for key in ("gpu_type", "gpu", "type"):
+            v = gpu_sel.get(key)
+            if v is not None and str(v).strip():
+                parts.append(f"gpu={str(v).strip()}")
+                break
+    elif isinstance(gpu_sel, str) and gpu_sel.strip():
+        parts.append(f"gpu={gpu_sel.strip()}")
+    envs = bench.get("envs")
+    if isinstance(envs, dict) and envs:
+        env_pairs = " ".join(
+            f"{k}={v}" for k, v in envs.items() if isinstance(k, str)
+        )
+        if env_pairs:
+            parts.append(f"envs=[{env_pairs}]")
+    return " ".join(parts)
+
+
 def _extract_framework_args(
     server_log: Path | None,
     config_yaml: Path | None = None,
@@ -177,12 +249,20 @@ def _extract_framework_args(
     """Best-effort extract the launch command for a benchmark variant.
 
     Returns ``(args_string, source)`` where ``source`` documents lineage:
+      * ``"log_non_default_args"`` — found a ``non-default args: {...}``
+        line (vllm / recent sglang echo of the parsed argv dict).
+        Highest priority because it's emitted *by the framework itself*
+        after argv parsing, so it captures the actually-used values.
       * ``"log_args_line"`` — found a line like ``Server arguments: ...``
         or ``Args: Namespace(...)`` in server.log
       * ``"log_python_cmd"`` — found a line starting with ``python``,
         ``python3``, ``vllm``, ``sglang.launch_server`` etc. in server.log
       * ``"yaml_cmd"`` — fell back to ``cmd:`` / ``command:`` / ``launch:``
         in the materialized config yaml
+      * ``"yaml_benchmark"`` — synthesized from magpie ``benchmark.*``
+        structured fields (framework / model / precision / tp / envs).
+        NOT a literal cmdline — flagged via the source label so consumers
+        can treat it differently from log-extracted values.
       * ``"unknown"`` — none of the above; ``args_string`` is empty
     Never raises. Caller decides whether to surface a warning when source
     is ``unknown``.
@@ -197,6 +277,30 @@ def _extract_framework_args(
             chunk = ""
 
     lines = chunk.splitlines() if chunk else []
+
+    # Pass 0: vllm / sglang ``non-default args: {...}`` echo. The dict
+    # is the framework's own post-parse view of argv, so it beats any of
+    # the literal-cmdline passes when present. Parse via ast.literal_eval
+    # — if the eval fails (malformed dict, embedded objects), we treat
+    # the line as a miss and continue to Pass 1 rather than regex-hacking
+    # a half-parse (anti-hallucination invariant).
+    for line in lines:
+        m = _FRAMEWORK_ARGS_NON_DEFAULT_RE.search(line)
+        if not m:
+            continue
+        dict_text = m.group(1)
+        try:
+            parsed = ast.literal_eval(dict_text)
+        except (ValueError, SyntaxError):
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        # Sorted-by-key, repr() values — stable across runs and keeps
+        # path strings quoted so an operator can copy-paste verbatim.
+        formatted = " ".join(
+            f"{k}={parsed[k]!r}" for k in sorted(parsed.keys(), key=str)
+        )
+        return formatted, "log_non_default_args"
 
     # Pass 1: stable launch-summary headers. These are emitted by the
     # framework itself once it's parsed argv, so they survive any
@@ -228,16 +332,24 @@ def _extract_framework_args(
         if cleaned and _starts_with_python_prefix(cleaned):
             return cleaned, "log_python_cmd"
 
-    # Pass 3: yaml fallback. Only consulted when the log gave us nothing.
+    # Pass 3 + Pass 4: yaml fallback. Load the config yaml at most once,
+    # then prefer a literal ``cmd:`` field (Pass 3) over the magpie
+    # ``benchmark.*`` synthesis (Pass 4) — a literal cmdline is always
+    # more authoritative than a structured-config reconstruction.
     if config_yaml is not None:
         try:
             yaml_exists = config_yaml.exists()
         except OSError:
             yaml_exists = False
         if yaml_exists:
-            cmd = _extract_yaml_cmd(config_yaml)
-            if cmd:
-                return cmd, "yaml_cmd"
+            data = _load_yaml_dict_safe(config_yaml)
+            if isinstance(data, dict):
+                cmd = _yaml_cmd_from_dict(data)
+                if cmd:
+                    return cmd, "yaml_cmd"
+                synth = _yaml_benchmark_synthesis(data)
+                if synth:
+                    return synth, "yaml_benchmark"
 
     return "", "unknown"
 

--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -162,6 +162,51 @@ def _find_benchmark_report(workspace: Path | None) -> Path | None:
     return candidates[0]
 
 
+def _resolve_under_session(
+    session_dir: Path,
+    raw: str | None,
+    anchors: tuple[str, ...] = ("runs", "kernel-agent", "kernel-agent-workspace"),
+) -> Path | None:
+    """Best-effort resolve a possibly-container-rooted path under ``session_dir``.
+
+    State-recorded paths frequently look like ``/workspace/runs/baseline/<sid>/``
+    because the orchestrator wrote them from inside a container, but the
+    breakdown is generated against a wekafs view where the same artefacts
+    live under ``<session_dir>/runs/baseline/<sid>/``.
+
+    Resolution order:
+
+    1. The raw path as-is (covers the development / test case where the
+       state-recorded path is already real).
+    2. For each anchor in ``anchors``, find the first occurrence of the
+       anchor in the raw path's parts and re-root that suffix at
+       ``session_dir``. The default anchors cover the three on-disk
+       conventions hyperloom uses (``runs/...``, ``kernel-agent/...``,
+       ``kernel-agent-workspace/...``).
+
+    Returns the first existing :class:`Path`, or ``None`` if nothing
+    resolves. Never raises — callers that care about the failure should
+    inspect the return value and append to ``warnings`` themselves.
+    """
+    if not raw:
+        return None
+    try:
+        p = Path(str(raw))
+    except (TypeError, ValueError):
+        return None
+    if p.exists():
+        return p
+    for anchor in anchors:
+        try:
+            idx = p.parts.index(anchor)
+        except ValueError:
+            continue
+        candidate = session_dir.joinpath(*p.parts[idx:])
+        if candidate.exists():
+            return candidate
+    return None
+
+
 def _safe_get(d: Any, *keys: str, default: Any = None) -> Any:
     cur = d
     for k in keys:
@@ -245,7 +290,15 @@ def collect_baseline(
 ) -> dict[str, Any]:
     last_b = state.get("last_baseline") or {}
     workspace_str = last_b.get("workspace") or ""
-    workspace = Path(workspace_str) if workspace_str else None
+    # Re-root container-style paths (e.g. ``/workspace/runs/baseline/<sid>/``)
+    # under the actual on-disk session_dir so we can still read
+    # ``benchmark_report.json`` from a wekafs view. See ``_resolve_under_session``.
+    workspace = _resolve_under_session(session_dir, workspace_str)
+    if workspace_str and workspace is None:
+        warnings.append(
+            f"baseline workspace {workspace_str!r} does not resolve under {session_dir}; "
+            "ttft_mean_ms / e2el_mean_ms will be null."
+        )
     report_path = _find_benchmark_report(workspace) if workspace else None
     report = _load_json_safe(report_path, warnings) if report_path else None
 
@@ -1607,7 +1660,9 @@ def collect_telemetry(
     baseline_report: Path | None = None
     last_b = state.get("last_baseline") or {}
     if isinstance(last_b, dict) and last_b.get("workspace"):
-        baseline_report = _find_benchmark_report(Path(last_b["workspace"]))
+        workspace = _resolve_under_session(session_dir, last_b.get("workspace"))
+        if workspace is not None:
+            baseline_report = _find_benchmark_report(workspace)
 
     profile_reports = [
         report for _task, report in _scan_profile_reports(session_dir)
@@ -1762,16 +1817,25 @@ def collect_source_files(
     ]
     critic = session_dir / "critic-workdir"
     rob = session_dir / "robustness-workdir"
-    return {
+    out: dict[str, Any] = {
         "manifest":           "manifest.json",
         "state":              "state.json",
         "baseline_report":    baseline_path,
-        "profile_reports":    profile_reports,
-        "sweep_reports":      sweep_reports,
-        "kernel_attempts":    kernel_attempts,
         "critic_workdir":     "critic-workdir" if critic.exists() else None,
         "robustness_workdir": "robustness-workdir" if rob.exists() else None,
     }
+    # Skip emitting list-valued categories that are empty so the
+    # source_files renderer doesn't surface ``count=0, first_values=—``
+    # rows for kernels / sweep / profile work that simply didn't run.
+    # SourceFiles schema fields are all NotRequired-by-convention.
+    for key, lst in (
+        ("profile_reports", profile_reports),
+        ("sweep_reports",   sweep_reports),
+        ("kernel_attempts", kernel_attempts),
+    ):
+        if lst:
+            out[key] = lst
+    return out
 
 
 __all__ = [

--- a/inference_optimizer/breakdown/exporter.py
+++ b/inference_optimizer/breakdown/exporter.py
@@ -91,7 +91,7 @@ def build(session_dir: Path | str) -> dict[str, Any]:
                                        lambda: collectors.collect_baseline(sd, state, warnings),
                                        warnings)
     final             = _safe_collect("final",
-                                       lambda: collectors.collect_final(state, warnings),
+                                       lambda: collectors.collect_final(sd, state, warnings),
                                        warnings)
     phase_timeline    = _safe_collect("phase_timeline",
                                        lambda: collectors.collect_phase_timeline(state, warnings),

--- a/inference_optimizer/breakdown/reporters/_renderers/_invocation.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/_invocation.py
@@ -55,6 +55,7 @@ def render_invocation_block(
     if not isinstance(invocation, dict):
         return ""
     framework_args = str(invocation.get("framework_args") or "").strip()
+    framework_args_source = str(invocation.get("framework_args_source") or "").strip()
     extra_envs = invocation.get("extra_envs")
     config_path = invocation.get("config_path")
     server_log_path = invocation.get("server_log_path")
@@ -79,6 +80,17 @@ def render_invocation_block(
         lines.append(f"- **config**: `{config_path}`")
     if framework_args:
         lines.append(f"- **command**: `{_truncate(framework_args, _FRAMEWORK_ARGS_MAX)}`")
+    # Lineage label sits directly under ``command`` so an operator can
+    # see at a glance whether the echoed string came from a parsed
+    # ``Server arguments:`` line, a literal python invocation, the
+    # config yaml, or no source at all (extraction failed).
+    if framework_args_source:
+        suffix = (
+            "  (extraction failed; try server.log or config yaml)"
+            if framework_args_source == "unknown"
+            else ""
+        )
+        lines.append(f"- **source**: {framework_args_source}{suffix}")
     envs_str = _format_envs(extra_envs if isinstance(extra_envs, dict) else None)
     if envs_str:
         lines.append(f"- **envs**: `{envs_str}`")

--- a/inference_optimizer/breakdown/reporters/_renderers/_invocation.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/_invocation.py
@@ -1,0 +1,87 @@
+"""Shared invocation-block renderer for baseline / final sections.
+
+Centralised here because both renderers need the exact same five-line
+markdown block (``image``, ``config``, ``command``, ``envs``, ``server
+log``). Keeping the layout identical across sections makes diffs across
+two reports easy to scan.
+
+Filename starts with ``_`` to keep it out of the auto-imported renderer
+list (``compose.py`` walks ``_renderers/*.py`` looking for
+``@register_renderer`` decorators; this module has none).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["render_invocation_block"]
+
+
+# Hard cap for the framework_args echo. Real launch commands fit
+# comfortably in ~250 chars; pathologically long ones (10+ args, weka
+# paths) get truncated so they don't blow the markdown column width.
+_FRAMEWORK_ARGS_MAX = 200
+_ENVS_MAX_DISPLAY = 12
+
+
+def _truncate(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: max(limit - 3, 0)] + "..."
+
+
+def _format_envs(envs: dict[str, Any] | None) -> str:
+    if not isinstance(envs, dict) or not envs:
+        return ""
+    items = sorted(envs.items())
+    if len(items) <= _ENVS_MAX_DISPLAY:
+        return ", ".join(f"{k}={v}" for k, v in items)
+    shown = items[:_ENVS_MAX_DISPLAY]
+    extra = len(items) - _ENVS_MAX_DISPLAY
+    return ", ".join(f"{k}={v}" for k, v in shown) + f", ... +{extra} more"
+
+
+def render_invocation_block(
+    invocation: Any,
+    session_image: Any,
+) -> str:
+    """Render an ``### Invocation`` markdown block (or "" when absent).
+
+    Returns the empty string when ``invocation`` is missing / has no
+    fields populated, so callers can ``if inv_md: ...`` to skip the
+    sub-section gracefully on V1 breakdown JSONs that predate the
+    invocation field.
+    """
+    if not isinstance(invocation, dict):
+        return ""
+    framework_args = str(invocation.get("framework_args") or "").strip()
+    extra_envs = invocation.get("extra_envs")
+    config_path = invocation.get("config_path")
+    server_log_path = invocation.get("server_log_path")
+
+    has_anything = (
+        framework_args
+        or (isinstance(extra_envs, dict) and extra_envs)
+        or config_path
+        or server_log_path
+    )
+    if not has_anything:
+        return ""
+
+    image_display = (
+        str(session_image).strip()
+        if isinstance(session_image, str) and session_image.strip()
+        else "(not configured)"
+    )
+    lines = ["### Invocation"]
+    lines.append(f"- **image**: {image_display}")
+    if config_path:
+        lines.append(f"- **config**: `{config_path}`")
+    if framework_args:
+        lines.append(f"- **command**: `{_truncate(framework_args, _FRAMEWORK_ARGS_MAX)}`")
+    envs_str = _format_envs(extra_envs if isinstance(extra_envs, dict) else None)
+    if envs_str:
+        lines.append(f"- **envs**: `{envs_str}`")
+    if server_log_path:
+        lines.append(f"- **server log**: `{server_log_path}`")
+    return "\n".join(lines)

--- a/inference_optimizer/breakdown/reporters/_renderers/attribution.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/attribution.py
@@ -20,7 +20,18 @@ def render(breakdown: dict[str, Any]) -> RenderedSection:
     a = breakdown.get("attribution") or {}
     sb = a.get("source_breakdown") or {}
     notes = a.get("notes") or []
-    method = a.get("method") or ""
+    # ``attribution.method`` is the collector's authoritative provenance
+    # label (validated / single_source / reconstructed / missing). Render
+    # it verbatim — never substitute a more-confident-sounding string,
+    # otherwise we re-introduce the very hallucination this field exists
+    # to prevent. Empty / "missing" surfaces as "unknown attribution
+    # method" so the audit trail is explicit.
+    method_raw = a.get("method")
+    method = str(method_raw) if isinstance(method_raw, str) else ""
+    if method in ("", "missing"):
+        method_display = "unknown attribution method"
+    else:
+        method_display = method
 
     total_v = sb.get("validated_total_pct")
     rows = [
@@ -34,8 +45,7 @@ def render(breakdown: dict[str, Any]) -> RenderedSection:
     facts: list[str] = []
     if total_v is not None:
         facts.append(f"Validated total gain attributed: {fmt_pct(total_v, plus=True)}.")
-    if method:
-        facts.append(f"Attribution method: `{method}`.")
+    facts.append(f"Attribution method: `{method_display}`.")
     has_any_split = any(r[1] not in (None, 0, 0.0) for r in rows)
     if not has_any_split:
         facts.append(

--- a/inference_optimizer/breakdown/reporters/_renderers/baseline.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/baseline.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 from typing import Any
 
 from ..base import Decision, RenderedSection, md_kv_list, md_table, register_renderer
+from ._invocation import render_invocation_block
 
 
 @register_renderer("baseline")
 def render(breakdown: dict[str, Any]) -> RenderedSection:
     b = breakdown.get("baseline") or {}
+    session = breakdown.get("session") or {}
     tput = b.get("throughput_tok_s_per_gpu")
     acc = b.get("accuracy")
     ttft = b.get("ttft_mean_ms")
@@ -74,6 +76,11 @@ def render(breakdown: dict[str, Any]) -> RenderedSection:
         md_parts.append(md_table(
             ["ts", "status", "decision", "key_metric", "error_class"], rows,
         ))
+
+    inv_md = render_invocation_block(b.get("invocation"), session.get("image"))
+    if inv_md:
+        md_parts.append("")
+        md_parts.append(inv_md)
 
     return RenderedSection(
         section_id="baseline",

--- a/inference_optimizer/breakdown/reporters/_renderers/baseline.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/baseline.py
@@ -16,6 +16,7 @@ def render(breakdown: dict[str, Any]) -> RenderedSection:
     acc = b.get("accuracy")
     ttft = b.get("ttft_mean_ms")
     e2el = b.get("e2el_mean_ms")
+    ttft_source = str(b.get("ttft_e2el_source") or "")
     fail_streak = int(b.get("failure_streak") or 0)
     attempts = b.get("attempts_history") or []
 
@@ -55,12 +56,19 @@ def render(breakdown: dict[str, Any]) -> RenderedSection:
     if attempts:
         facts.append(f"Baseline attempts recorded: {len(attempts)}.")
 
+    # Annotate the ttft row inline when it was reconstructed via the
+    # runs/baseline/ disk walk fallback — readers should see at a
+    # glance that the latency didn't come from state.last_baseline.
+    ttft_display: Any = ttft
+    if ttft is not None and ttft_source == "runs_baseline_disk":
+        ttft_display = f"{float(ttft):.1f} (reconstructed from runs/baseline/ disk walk)"
     md_parts: list[str] = []
     md_parts.append(md_kv_list([
         ("throughput_tok_s_per_gpu", tput),
         ("accuracy",                 acc),
-        ("ttft_mean_ms",             ttft),
+        ("ttft_mean_ms",             ttft_display),
         ("e2el_mean_ms",             e2el),
+        ("ttft_e2el_source",         ttft_source or None),
         ("config_path",              b.get("config_path")),
         ("benchmark_report_path",    b.get("benchmark_report_path")),
         ("failure_streak",           fail_streak or None),

--- a/inference_optimizer/breakdown/reporters/_renderers/final.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/final.py
@@ -11,12 +11,14 @@ from ..base import (
     md_kv_list,
     register_renderer,
 )
+from ._invocation import render_invocation_block
 
 
 @register_renderer("final")
 def render(breakdown: dict[str, Any]) -> RenderedSection:
     f = breakdown.get("final") or {}
     b = breakdown.get("baseline") or {}
+    session = breakdown.get("session") or {}
     final_tput = f.get("throughput_tok_s_per_gpu")
     base_tput = b.get("throughput_tok_s_per_gpu")
     gain_v = f.get("cumulative_gain_pct_validated")
@@ -69,7 +71,7 @@ def render(breakdown: dict[str, Any]) -> RenderedSection:
             "predates V2."
         )
 
-    md = md_kv_list([
+    md_kv = md_kv_list([
         ("final_throughput_tok_s_per_gpu", final_tput),
         ("cumulative_gain_pct_validated",  gain_v),
         ("cumulative_gain_pct_per_round_sum", gain_round),
@@ -80,14 +82,21 @@ def render(breakdown: dict[str, Any]) -> RenderedSection:
         ("action_path",                    action_path or None),
         ("ttft_mean_ms",                   f.get("ttft_mean_ms")),
         ("e2el_mean_ms",                   f.get("e2el_mean_ms")),
+        ("ttft_e2el_source",               f.get("ttft_e2el_source") or None),
         ("extra_envs",                     f.get("extra_envs") or None),
     ])
+
+    md_parts = [md_kv]
+    inv_md = render_invocation_block(f.get("invocation"), session.get("image"))
+    if inv_md:
+        md_parts.append("")
+        md_parts.append(inv_md)
 
     return RenderedSection(
         section_id="final",
         title="Final Result",
         key_facts=facts,
-        markdown_block=md,
+        markdown_block="\n".join(md_parts).strip(),
         decisions=decisions,
         warnings=warnings,
         skipped=not (final_tput or gain_v),

--- a/inference_optimizer/breakdown/reporters/_renderers/session.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/session.py
@@ -25,6 +25,7 @@ def render(breakdown: dict[str, Any]) -> RenderedSection:
     stop_reason = str(s.get("stop_reason") or "")
     elapsed = s.get("elapsed_minutes")
     host = str(s.get("host") or "")
+    image = s.get("image")
     code = str(s.get("code_revision") or "")
     tick = s.get("tick_count")
 
@@ -52,6 +53,8 @@ def render(breakdown: dict[str, Any]) -> RenderedSection:
         )
     if host:
         facts.append(f"Ran on host `{host}`.")
+    if isinstance(image, str) and image.strip():
+        facts.append(f"Container image `{image}`.")
     if code:
         facts.append(f"Hyperloom code revision `{code}`.")
 
@@ -63,6 +66,11 @@ def render(breakdown: dict[str, Any]) -> RenderedSection:
         ("elapsed_minutes",  elapsed),
         ("tick_count",       tick),
         ("host",             host or None),
+        # Always include the image row so reviewers can see at a glance
+        # whether the run had its container image recorded; "(not
+        # configured)" makes the gap obvious instead of silently
+        # omitting the field.
+        ("image",            image if (isinstance(image, str) and image.strip()) else "(not configured)"),
         ("code_revision",    code or None),
         ("created_at_utc",   s.get("created_at_utc")),
         ("ended_at_utc",     s.get("ended_at_utc")),

--- a/inference_optimizer/breakdown/schema.py
+++ b/inference_optimizer/breakdown/schema.py
@@ -40,6 +40,7 @@ class SessionMeta(TypedDict, total=False):
     pid: int
     session_dir: str
     tick_count: int
+    image: str | None             # container image fully-qualified (or None if not configured)
 
 
 # ---------------------------------------------------------------------------
@@ -79,6 +80,20 @@ class BaselineAttemptSummary(TypedDict, total=False):
     error_class: str | None
 
 
+class BenchmarkInvocation(TypedDict, total=False):
+    """Replayable record of how a benchmark variant was launched.
+
+    Allows operators to rerun the exact same workload (server command +
+    env vars + config) when investigating a regression. ``extra_envs`` is
+    allowlist-filtered in the collector to keep secrets out of the
+    breakdown JSON.
+    """
+    framework_args: str           # e.g. "python -m sglang.launch_server --model ... --tp 8"
+    extra_envs: dict[str, str]    # allowlisted env vars only (no secrets)
+    config_path: str | None       # baseline_config.with_envs.yaml or variant config
+    server_log_path: str | None   # for debug
+
+
 class Baseline(TypedDict, total=False):
     throughput_tok_s_per_gpu: float
     accuracy: float
@@ -88,6 +103,7 @@ class Baseline(TypedDict, total=False):
     benchmark_report_path: str | None
     attempts_history: list[BaselineAttemptSummary]
     failure_streak: int
+    invocation: BenchmarkInvocation
 
 
 # ---------------------------------------------------------------------------
@@ -105,6 +121,8 @@ class Final(TypedDict, total=False):
     action_path: list[str]        # ordered list of action:variant labels from optimization_stack
     ttft_mean_ms: float | None
     e2el_mean_ms: float | None
+    ttft_e2el_source: str         # current_best / validate_stack_disk / stack_top_disk / unavailable
+    invocation: BenchmarkInvocation
 
 
 # ---------------------------------------------------------------------------
@@ -381,6 +399,8 @@ class SourceBreakdown(TypedDict, total=False):
 
 class Attribution(TypedDict, total=False):
     gain_per_stack_entry: list[StackGainEntry]
+    # validated / single_source / reconstructed / missing
+    method: str
     source_breakdown: SourceBreakdown
     notes: list[str]              # human-readable caveats
 
@@ -429,6 +449,7 @@ __all__ = [
     "Attribution",
     "Baseline",
     "BaselineAttemptSummary",
+    "BenchmarkInvocation",
     "CapabilityEntry",
     "CapabilitySummary",
     "CriticIteration",

--- a/inference_optimizer/breakdown/schema.py
+++ b/inference_optimizer/breakdown/schema.py
@@ -89,7 +89,13 @@ class BenchmarkInvocation(TypedDict, total=False):
     breakdown JSON.
     """
     framework_args: str           # e.g. "python -m sglang.launch_server --model ... --tp 8"
-    framework_args_source: str    # log_args_line / log_python_cmd / yaml_cmd / unknown
+    framework_args_source: str
+    # log_non_default_args (vllm/sglang parsed-args echo, most authoritative)
+    # log_args_line (Server arguments: / Args: Namespace(...) header)
+    # log_python_cmd (literal python/vllm/sglang launch line)
+    # yaml_cmd (cmd/command/launch field in materialized config yaml)
+    # yaml_benchmark (synthesized from magpie benchmark.* fields)
+    # unknown (none of the above; warning emitted)
     extra_envs: dict[str, str]    # allowlisted env vars only (no secrets)
     config_path: str | None       # baseline_config.with_envs.yaml or variant config
     server_log_path: str | None   # for debug

--- a/inference_optimizer/breakdown/schema.py
+++ b/inference_optimizer/breakdown/schema.py
@@ -89,6 +89,7 @@ class BenchmarkInvocation(TypedDict, total=False):
     breakdown JSON.
     """
     framework_args: str           # e.g. "python -m sglang.launch_server --model ... --tp 8"
+    framework_args_source: str    # log_args_line / log_python_cmd / yaml_cmd / unknown
     extra_envs: dict[str, str]    # allowlisted env vars only (no secrets)
     config_path: str | None       # baseline_config.with_envs.yaml or variant config
     server_log_path: str | None   # for debug
@@ -99,6 +100,7 @@ class Baseline(TypedDict, total=False):
     accuracy: float
     ttft_mean_ms: float | None
     e2el_mean_ms: float | None
+    ttft_e2el_source: str         # state_workspace / runs_baseline_disk / unavailable
     config_path: str | None
     benchmark_report_path: str | None
     attempts_history: list[BaselineAttemptSummary]

--- a/inference_optimizer/manifest.py
+++ b/inference_optimizer/manifest.py
@@ -11,14 +11,16 @@ Why this lives in its own module:
 * Avoids a hard dependency from ``paths`` (called by everything) on
   ``argparse`` and Python version helpers.
 
-Schema v1::
+Schema v2 (image added)::
 
     {
-      "schema_version":    1,
+      "schema_version":    2,
       "session_id":        "<UTC_YYYYMMDDTHHMMSSZ>_<uuid8>",
       "claw_session_id":   "<uuid>" or null,   # Primus-Claw session UUID
       "sandbox_user_id":   "<str>"  or null,   # Primus-Claw sandbox user
       "created_at_utc":    "...",
+      "host":              "...",
+      "image":             "<registry>/<repo>:<tag>" or null,
       "model_path":        "...",
       "model_name":        "...",
       "framework":         "sglang|vllm",
@@ -30,14 +32,24 @@ Schema v1::
                             "value":...},
       "max_minutes":       N,
       "code_revision":     "<git sha or empty>",
-      "pid":               N,
-      "host":              "..."
+      "pid":               N
     }
 
 ``claw_session_id`` / ``sandbox_user_id`` are read from the
 ``CLAW_SESSION_ID`` / ``SANDBOX_USER_ID`` env vars (set by the
 Primus-Claw spawn path); they are ``null`` when Hyperloom runs standalone
 outside the claw sandbox.
+
+``image`` records the container image the run executed inside, for
+later reproducibility / dashboard provenance. Detection priority:
+
+1. ``HYPERLOOM_IMAGE`` env var (preferred — explicitly set by the spawn).
+2. ``CONTAINER_IMAGE`` / ``IMAGE`` env vars (fallback for non-claw spawns).
+3. ``/etc/podinfo/image`` (k8s downward API mount).
+4. ``/etc/hyperloom-image`` (legacy spawn-script convention).
+5. Best-effort parse of ``/proc/1/cgroup`` (extracts the container hash;
+   reported as ``unknown@<sha256_short>``).
+6. ``None`` when nothing matches; consumers warn rather than fabricate.
 """
 
 from __future__ import annotations
@@ -56,7 +68,7 @@ from typing import Any
 
 from .session_paths import manifest_path
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 
 def _utc_now_compact() -> str:
@@ -74,6 +86,47 @@ def _git_revision() -> str:
         return out.stdout.strip()
     except (FileNotFoundError, subprocess.TimeoutExpired, PermissionError, OSError):
         return ""
+
+
+def _detect_image() -> str | None:
+    """Best-effort container image detection.
+
+    Tries env vars first (most reliable + easiest for operators to
+    override), then well-known mount points, finally a best-effort
+    cgroup probe. Returns ``None`` when nothing matches; the breakdown
+    layer surfaces a warning rather than fabricating a value.
+
+    Never raises — every disk / parse failure is swallowed.
+    """
+    for var in ("HYPERLOOM_IMAGE", "CONTAINER_IMAGE", "IMAGE"):
+        val = (os.environ.get(var) or "").strip()
+        if val:
+            return val
+    for marker in ("/etc/podinfo/image", "/etc/hyperloom-image"):
+        try:
+            p = Path(marker)
+            if p.exists():
+                txt = p.read_text(encoding="utf-8", errors="replace").strip()
+                if txt:
+                    return txt
+        except OSError:
+            continue
+    try:
+        cgroup = Path("/proc/1/cgroup")
+        if cgroup.exists():
+            for line in cgroup.read_text(encoding="utf-8", errors="replace").splitlines():
+                if "docker" not in line and "containerd" not in line:
+                    continue
+                # Lines look like
+                # ``12:devices:/docker/<sha256>`` — pull a 12+ hex token.
+                import re as _re
+                m = _re.search(r"([0-9a-f]{12,64})", line)
+                if m:
+                    short = m.group(1)[:12]
+                    return f"unknown@{short}"
+    except OSError:
+        pass
+    return None
 
 
 def _objective_summary(args: argparse.Namespace) -> dict[str, Any]:
@@ -152,6 +205,7 @@ def build_manifest(
         "code_revision":   _git_revision(),
         "pid":             os.getpid(),
         "host":            platform.node() or socket.gethostname() or "",
+        "image":           _detect_image(),
     }
 
 

--- a/inference_optimizer/manifest.py
+++ b/inference_optimizer/manifest.py
@@ -56,6 +56,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import os
 import platform
 import socket
@@ -67,6 +68,8 @@ from pathlib import Path
 from typing import Any
 
 from .session_paths import manifest_path
+
+log = logging.getLogger(__name__)
 
 SCHEMA_VERSION = 2
 
@@ -124,8 +127,12 @@ def _detect_image() -> str | None:
                 if m:
                     short = m.group(1)[:12]
                     return f"unknown@{short}"
-    except OSError:
-        pass
+    except OSError as exc:
+        # /proc/1/cgroup may be unreadable in restricted sandboxes,
+        # non-Linux hosts, or stripped-down containers. Best-effort
+        # source — fall through to None so the breakdown layer surfaces
+        # an honest "image not detected" rather than fabricating one.
+        log.debug("cgroup-based image detection failed: %r", exc)
     return None
 
 

--- a/inference_optimizer/tests/test_breakdown_smoke.py
+++ b/inference_optimizer/tests/test_breakdown_smoke.py
@@ -960,3 +960,92 @@ def test_framework_args_unknown_with_warning(tmp_path: Path) -> None:
     assert any(
         "framework_args extraction failed" in w for w in b["warnings"]
     ), b["warnings"]
+
+
+def test_framework_args_from_non_default_args_vllm(tmp_path: Path) -> None:
+    """vllm prints ``non-default args: {parsed-dict}`` right after argv
+    parsing. The extractor picks this up first (Pass 0) because it
+    captures the *resolved* values the framework actually used — beats
+    any other heuristic. Output must be sorted-by-key + repr() values
+    so the string is stable across runs."""
+    sd = tmp_path / "session"
+    _make_invocation_fixture(
+        sd,
+        server_log_text=(
+            "(APIServer pid=1645301) INFO 05-12 10:51:30 [config.py:120] booting\n"
+            "(APIServer pid=1645301) INFO 05-12 10:51:32 [utils.py:233] "
+            "non-default args: {'model': '/wekafs/models/deepseek-ai-DeepSeek-R1', "
+            "'port': 8888, 'tensor_parallel_size': 8, 'max_model_len': 4096, "
+            "'gpu_memory_utilization': 0.85}\n"
+            "(APIServer pid=1645301) INFO 05-12 10:51:35 [server.py:99] ready\n"
+        ),
+        yaml_text=None,
+    )
+    inv = build(sd)["baseline"]["invocation"]
+    assert inv["framework_args_source"] == "log_non_default_args"
+    assert "tensor_parallel_size=8" in inv["framework_args"]
+    assert "model=" in inv["framework_args"]
+    assert "/wekafs/models/deepseek-ai-DeepSeek-R1" in inv["framework_args"]
+    # Deterministic ordering: keys sorted alphabetically. So
+    # ``gpu_memory_utilization`` (g) must precede ``model`` (m) which
+    # must precede ``tensor_parallel_size`` (t) in the emitted string.
+    s = inv["framework_args"]
+    assert s.index("gpu_memory_utilization=") < s.index("model="), s
+    assert s.index("model=") < s.index("tensor_parallel_size="), s
+
+
+def test_framework_args_pass0_takes_priority_over_python_cmd(tmp_path: Path) -> None:
+    """When server.log contains BOTH a ``non-default args: {...}`` line
+    AND a literal ``python -m vllm.entrypoints...`` line, Pass 0 must
+    win — the parsed-arg dict is more authoritative than the raw
+    cmdline (which might contain unresolved env-var placeholders)."""
+    sd = tmp_path / "session"
+    _make_invocation_fixture(
+        sd,
+        server_log_text=(
+            "(APIServer pid=1645301) INFO 05-12 10:51:30 [config.py:120] booting\n"
+            "python -m vllm.entrypoints.openai.api_server --model /weka/m --tp 8\n"
+            "(APIServer pid=1645301) INFO 05-12 10:51:32 [utils.py:233] "
+            "non-default args: {'model': '/weka/m', 'tensor_parallel_size': 8, "
+            "'port': 8888}\n"
+            "(APIServer pid=1645301) INFO 05-12 10:51:35 [server.py:99] ready\n"
+        ),
+        yaml_text=None,
+    )
+    inv = build(sd)["baseline"]["invocation"]
+    assert inv["framework_args_source"] == "log_non_default_args"
+    # And the chosen string is the formatted dict, not the python line.
+    assert "python -m vllm.entrypoints" not in inv["framework_args"]
+    assert "tensor_parallel_size=8" in inv["framework_args"]
+
+
+def test_framework_args_from_yaml_benchmark_synthesis(tmp_path: Path) -> None:
+    """server.log has only INFO noise; yaml is magpie-style with no
+    ``cmd:`` field but a populated ``benchmark.*`` block →
+    Pass 4 synthesizes a readable string from the structured fields and
+    labels the source ``yaml_benchmark`` so consumers know it's not a
+    literal cmdline."""
+    sd = tmp_path / "session"
+    _make_invocation_fixture(
+        sd,
+        server_log_text=(
+            "(APIServer pid=1757439) INFO 05-12 14:21:14 [utils.py:299]\n"
+            "(APIServer pid=1757439) INFO 05-12 14:21:15 [server.py:50] init\n"
+        ),
+        yaml_text=(
+            "benchmark:\n"
+            "  framework: vllm\n"
+            "  model: /path\n"
+            "  precision: fp8\n"
+            "  tp: 8\n"
+            "  envs:\n"
+            "    VLLM_FLASH_ATTN: \"1\"\n"
+        ),
+    )
+    inv = build(sd)["baseline"]["invocation"]
+    assert inv["framework_args_source"] == "yaml_benchmark"
+    s = inv["framework_args"]
+    assert "framework=vllm" in s, s
+    assert "model=/path" in s, s
+    assert "tp=8" in s, s
+    assert "envs=[VLLM_FLASH_ATTN=1]" in s, s

--- a/inference_optimizer/tests/test_breakdown_smoke.py
+++ b/inference_optimizer/tests/test_breakdown_smoke.py
@@ -529,3 +529,272 @@ def test_source_files_keeps_non_empty_kernel_attempts(fixture_session: Path) -> 
     sf = build(fixture_session)["source_files"]
     assert sf.get("kernel_attempts"), sf
     assert any("optimization_attempts.jsonl" in p for p in sf["kernel_attempts"])
+
+
+# ---------------------------------------------------------------------------
+# Attribution method (A1)
+# ---------------------------------------------------------------------------
+def _attribution_fixture(tmp_path: Path, state: dict) -> Path:
+    """Minimal session_dir whose only content drives ``collect_attribution``."""
+    sd = tmp_path / "session"
+    _write_json(sd / "manifest.json", {"schema_version": 1, "session_id": "attr"})
+    base_state = {"session_id": "attr"}
+    base_state.update(state)
+    _write_json(sd / "state.json", base_state)
+    return sd
+
+
+def test_attribution_method_validated(tmp_path: Path) -> None:
+    """``state.gain_per_stack_entry`` written by Coordinator with every
+    entry's ``delta_pct`` set → ``method == "validated"``."""
+    sd = _attribution_fixture(tmp_path, {
+        "cumulative_gain_validated": 30.0,
+        "optimization_stack": [
+            {"action": "backends", "variant_name": "flag_X", "gain_pct": 20.0},
+            {"action": "params",   "variant_name": "p1",     "gain_pct": 10.0},
+        ],
+        "gain_per_stack_entry": [
+            {"action": "backends", "variant_name": "flag_X",
+             "stack_len_before": 0, "stack_len_after": 1,
+             "cum_gain_before": 0.0, "cum_gain_after": 20.0,
+             "delta_pct": 20.0},
+            {"action": "params",   "variant_name": "p1",
+             "stack_len_before": 1, "stack_len_after": 2,
+             "cum_gain_before": 20.0, "cum_gain_after": 30.0,
+             "delta_pct": 10.0},
+        ],
+    })
+    attr = build(sd)["attribution"]
+    assert attr["method"] == "validated"
+
+
+def test_attribution_method_single_source(tmp_path: Path) -> None:
+    """Single-entry stack with no Coordinator-recorded gain ledger →
+    ``method == "single_source"``."""
+    sd = _attribution_fixture(tmp_path, {
+        "cumulative_gain_validated": 11.0,
+        "optimization_stack": [
+            {"action": "backends", "variant_name": "vllm_kv_fp8",
+             "gain_pct": 11.0,
+             "ts": "2026-05-15T07:00:00+00:00"},
+        ],
+    })
+    attr = build(sd)["attribution"]
+    assert attr["method"] == "single_source"
+
+
+def test_attribution_method_reconstructed(tmp_path: Path) -> None:
+    """Multi-entry stack with no Coordinator ledger and at least one
+    placeholder ``delta_pct=None`` → ``method == "reconstructed"``."""
+    sd = _attribution_fixture(tmp_path, {
+        "cumulative_gain_validated": 25.0,
+        "optimization_stack": [
+            {"action": "backends", "variant_name": "flag_X", "gain_pct": 12.0},
+            {"action": "params",   "variant_name": "p1",     "gain_pct": None},
+            {"action": "kernel_opt:k001", "gain_pct": None},
+        ],
+    })
+    attr = build(sd)["attribution"]
+    assert attr["method"] == "reconstructed"
+
+
+def test_attribution_method_missing(tmp_path: Path) -> None:
+    """No optimization_stack, no Coordinator ledger → ``method == "missing"``."""
+    sd = _attribution_fixture(tmp_path, {"cumulative_gain_validated": 0.0})
+    attr = build(sd)["attribution"]
+    assert attr["method"] == "missing"
+
+
+# ---------------------------------------------------------------------------
+# A2: final.ttft_mean_ms reconstruction
+# ---------------------------------------------------------------------------
+def test_final_ttft_reconstructed_from_validate_stack(tmp_path: Path) -> None:
+    """When ``current_best.ttft_mean_ms`` is not recorded but a
+    ``runs/validate_stack/<h>/benchmark_*/benchmark_report.json`` is on
+    disk, the collector must read the latency from the report, set
+    ``ttft_e2el_source = "validate_stack_disk"``, and append a
+    reconstruction warning."""
+    sd = tmp_path / "session"
+    _write_json(sd / "manifest.json", {"schema_version": 1, "session_id": "rec"})
+    _write_json(sd / "state.json", {
+        "session_id": "rec",
+        "baseline_tput": 100.0,
+        "current_best": {"tput": 220.0},
+        "optimization_stack": [
+            {"action": "backends", "variant_name": "v1", "gain_pct": 120.0},
+        ],
+        "cumulative_gain_validated": 120.0,
+    })
+    bdir = sd / "runs/validate_stack/abc/benchmark_001"
+    _write_json(bdir / "benchmark_report.json", {
+        "success": True,
+        "output_throughput_tok_s": 220.0,
+        "mean_ttft_ms": 88.7,
+        "mean_e2el_ms": 1110.5,
+    })
+    b = build(sd)
+    final = b["final"]
+    assert final["ttft_mean_ms"] == pytest.approx(88.7)
+    assert final["e2el_mean_ms"] == pytest.approx(1110.5)
+    assert final["ttft_e2el_source"] == "validate_stack_disk"
+    assert any(
+        "final.ttft_mean_ms reconstructed from validate_stack_disk" in w
+        for w in b["warnings"]
+    ), b["warnings"]
+
+
+# ---------------------------------------------------------------------------
+# A3: baseline.attempts_history reconstruction
+# ---------------------------------------------------------------------------
+def test_baseline_attempts_history_reconstructed_from_disk(tmp_path: Path) -> None:
+    """When ``state.baseline_attempts == []`` but two
+    ``runs/baseline/<hash>/benchmark_*/`` directories exist, the
+    collector must reconstruct two summary rows tagged
+    ``status="reconstructed"`` and append the reconstruction warning."""
+    sd = tmp_path / "session"
+    _write_json(sd / "manifest.json", {"schema_version": 1, "session_id": "rebh"})
+    _write_json(sd / "state.json", {
+        "session_id": "rebh",
+        "baseline_tput": 333.0,
+        "baseline_attempts": [],
+    })
+    for h, tput in (("hashA", 300.0), ("hashB", 333.0)):
+        bdir = sd / f"runs/baseline/{h}/benchmark_20260515T100000"
+        _write_json(bdir / "benchmark_report.json", {
+            "success": True,
+            "output_throughput_tok_s": tput,
+            "mean_ttft_ms": 100.0,
+        })
+
+    b = build(sd)
+    history = b["baseline"]["attempts_history"]
+    assert len(history) == 2
+    assert all(a["status"] == "reconstructed" for a in history), history
+    task_ids = {a["task_id"] for a in history}
+    assert task_ids == {"hashA", "hashB"}
+    assert any(
+        "baseline.attempts_history reconstructed from runs/baseline/" in w
+        for w in b["warnings"]
+    ), b["warnings"]
+
+
+def test_baseline_attempts_history_state_recorded_takes_precedence(
+    tmp_path: Path,
+) -> None:
+    """When ``state.baseline_attempts`` IS non-empty, the disk fallback
+    must NOT also fire (no duplication, no reconstruction warning)."""
+    sd = tmp_path / "session"
+    _write_json(sd / "manifest.json", {"schema_version": 1, "session_id": "stat"})
+    _write_json(sd / "state.json", {
+        "session_id": "stat",
+        "baseline_tput": 300.0,
+        "baseline_attempts": [
+            {"ts": "2026-05-15T10:00:00+00:00", "task_id": "t1",
+             "status": "succeeded", "decision": "promoted",
+             "key_metric": 300.0},
+        ],
+    })
+    bdir = sd / "runs/baseline/hashA/benchmark_20260515T100000"
+    _write_json(bdir / "benchmark_report.json", {
+        "success": True, "output_throughput_tok_s": 300.0,
+    })
+
+    b = build(sd)
+    history = b["baseline"]["attempts_history"]
+    assert len(history) == 1
+    assert history[0]["status"] == "succeeded"
+    assert not any(
+        "baseline.attempts_history reconstructed" in w
+        for w in b["warnings"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# B3: invocation populated from baseline_config + server.log
+# ---------------------------------------------------------------------------
+def test_baseline_invocation_populated(tmp_path: Path) -> None:
+    """``baseline.invocation`` must read framework_args from server.log,
+    extra_envs from the YAML benchmark.envs block (allowlisted), and
+    keep secret-shaped keys (``OPENAI_API_KEY``) out of the output."""
+    sd = tmp_path / "session"
+    _write_json(sd / "manifest.json", {"schema_version": 1, "session_id": "inv"})
+    bdir = sd / "runs/baseline/h1/benchmark_001"
+    _write_json(bdir / "benchmark_report.json", {
+        "success": True, "output_throughput_tok_s": 421.5,
+        "mean_ttft_ms": 152.3, "mean_e2el_ms": 1840.7,
+    })
+    (bdir / "server.log").write_text(
+        "python -m sglang.launch_server --model /weka/m --tp 8 --port 30000\n"
+        "[INFO] booting...\n",
+        encoding="utf-8",
+    )
+    cfg = sd / "runs/baseline/h1/baseline_config.with_envs.yaml"
+    cfg.write_text(
+        "benchmark:\n"
+        "  envs:\n"
+        "    TP: \"8\"\n"
+        "    VLLM_FLASH_ATTN: \"1\"\n"
+        "    OPENAI_API_KEY: \"secret-do-not-emit\"\n"
+        "    HOME: \"/root\"\n",
+        encoding="utf-8",
+    )
+    _write_json(sd / "state.json", {
+        "session_id": "inv",
+        "baseline_tput": 421.5,
+        "last_baseline": {"workspace": str(sd / "runs/baseline/h1")},
+        "baseline_config_path": str(cfg),
+    })
+
+    b = build(sd)
+    inv = b["baseline"]["invocation"]
+    assert "sglang.launch_server" in inv["framework_args"]
+    assert inv["extra_envs"].get("TP") == "8"
+    assert inv["extra_envs"].get("VLLM_FLASH_ATTN") == "1"
+    assert "OPENAI_API_KEY" not in inv["extra_envs"]
+    assert "HOME" not in inv["extra_envs"]
+    assert inv["server_log_path"] is not None
+    assert "server.log" in inv["server_log_path"]
+
+
+# ---------------------------------------------------------------------------
+# B1 / B3: image detection
+# ---------------------------------------------------------------------------
+def test_session_image_from_env(tmp_path: Path, monkeypatch) -> None:
+    """``HYPERLOOM_IMAGE`` env var must populate ``session.image`` when
+    the manifest lacks the field (V1 manifests). Absent of all sources
+    the field is ``None`` and a single warning is appended — no crash."""
+    sd = tmp_path / "session"
+    _write_json(sd / "manifest.json", {"schema_version": 1, "session_id": "img"})
+    _write_json(sd / "state.json", {"session_id": "img", "baseline_tput": 100.0})
+
+    monkeypatch.setenv("HYPERLOOM_IMAGE",
+                        "registry.example/hyperloom:abc123")
+    monkeypatch.delenv("CONTAINER_IMAGE", raising=False)
+    monkeypatch.delenv("IMAGE", raising=False)
+    b = build(sd)
+    assert b["session"]["image"] == "registry.example/hyperloom:abc123"
+
+    monkeypatch.delenv("HYPERLOOM_IMAGE")
+    b2 = build(sd)
+    assert b2["session"]["image"] is None or isinstance(b2["session"]["image"], str)
+    if b2["session"]["image"] is None:
+        assert any(
+            "image: not configured" in w for w in b2["warnings"]
+        ), b2["warnings"]
+
+
+def test_session_image_from_manifest_takes_precedence(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """``manifest.image`` (written at session start) wins over runtime
+    env vars — captures the spawn-time image even if env later drifts."""
+    sd = tmp_path / "session"
+    _write_json(sd / "manifest.json", {
+        "schema_version": 2, "session_id": "img2",
+        "image": "registry.example/hyperloom:from-manifest",
+    })
+    _write_json(sd / "state.json", {"session_id": "img2"})
+
+    monkeypatch.setenv("HYPERLOOM_IMAGE", "registry.example/hyperloom:from-env")
+    b = build(sd)
+    assert b["session"]["image"] == "registry.example/hyperloom:from-manifest"

--- a/inference_optimizer/tests/test_breakdown_smoke.py
+++ b/inference_optimizer/tests/test_breakdown_smoke.py
@@ -445,3 +445,87 @@ def test_no_kernel_agent_runs_returns_empty_invocations(tmp_path: Path) -> None:
     assert b["geak_invocations"] == []
     assert b["oob_invocations"] == []
     assert b["kernel_lifecycle"]["detected"] == []
+
+
+def test_baseline_resolves_container_workspace_path(tmp_path: Path) -> None:
+    """``last_baseline.workspace`` written as a container path
+    (``/workspace/runs/baseline/<sub>/``) must still resolve under the
+    on-disk ``session_dir`` so ``ttft_mean_ms`` is read from the
+    benchmark report rather than dropped to ``None``.
+
+    Regression for handoff doc §8 TODO #2.
+    """
+    sd = tmp_path / "session"
+    sd.mkdir(parents=True)
+    _write_json(sd / "manifest.json", {"schema_version": 1, "session_id": "ttft"})
+    bdir = sd / "runs/baseline/t1/benchmark_001"
+    _write_json(bdir / "benchmark_report.json", {
+        "success": True,
+        "output_throughput_tok_s": 333.0,
+        "mean_ttft_ms": 142.5,
+        "mean_e2el_ms": 1620.4,
+    })
+    _write_json(sd / "state.json", {
+        "session_id": "ttft",
+        "baseline_tput": 333.0,
+        "last_baseline": {"workspace": "/workspace/runs/baseline/t1"},
+    })
+
+    b = build(sd)
+    baseline = b["baseline"]
+    assert baseline["ttft_mean_ms"] == pytest.approx(142.5)
+    assert baseline["e2el_mean_ms"] == pytest.approx(1620.4)
+    assert baseline["benchmark_report_path"] is not None
+    assert "runs/baseline/t1" in baseline["benchmark_report_path"]
+    assert not any(
+        "baseline workspace" in w and "does not resolve" in w
+        for w in b["warnings"]
+    ), b["warnings"]
+
+
+def test_baseline_unresolvable_workspace_emits_warning(tmp_path: Path) -> None:
+    """When the recorded workspace can't be re-rooted under ``session_dir``
+    (e.g. wrong session_dir), the collector must surface a warning rather
+    than silently fall back to ``None``."""
+    sd = tmp_path / "session"
+    sd.mkdir(parents=True)
+    _write_json(sd / "manifest.json", {"schema_version": 1, "session_id": "miss"})
+    _write_json(sd / "state.json", {
+        "session_id": "miss",
+        "baseline_tput": 100.0,
+        "last_baseline": {"workspace": "/some/totally/unrelated/path"},
+    })
+    b = build(sd)
+    assert b["baseline"]["ttft_mean_ms"] is None
+    assert any(
+        "baseline workspace" in w and "does not resolve" in w
+        for w in b["warnings"]
+    ), b["warnings"]
+
+
+def test_source_files_drops_empty_kernel_attempts(tmp_path: Path) -> None:
+    """``source_files.kernel_attempts`` must not appear when the session
+    has no kernel-agent runs (instead of rendering a ``count=0,
+    first_values=—`` placeholder row downstream).
+
+    Regression for handoff doc §8 TODO #6.
+    """
+    sd = tmp_path / "session"
+    _write_json(sd / "manifest.json", {"schema_version": 1, "session_id": "no-kernels"})
+    _write_json(sd / "state.json", {
+        "session_id": "no-kernels", "baseline_tput": 100.0,
+    })
+    sf = build(sd)["source_files"]
+    assert "kernel_attempts" not in sf
+    assert "profile_reports" not in sf
+    assert "sweep_reports" not in sf
+    assert sf["manifest"] == "manifest.json"
+    assert sf["state"] == "state.json"
+
+
+def test_source_files_keeps_non_empty_kernel_attempts(fixture_session: Path) -> None:
+    """Sanity: when the session DOES have kernel-agent activity, the
+    populated list must still be emitted by the collector."""
+    sf = build(fixture_session)["source_files"]
+    assert sf.get("kernel_attempts"), sf
+    assert any("optimization_attempts.jsonl" in p for p in sf["kernel_attempts"])

--- a/inference_optimizer/tests/test_breakdown_smoke.py
+++ b/inference_optimizer/tests/test_breakdown_smoke.py
@@ -798,3 +798,165 @@ def test_session_image_from_manifest_takes_precedence(
     monkeypatch.setenv("HYPERLOOM_IMAGE", "registry.example/hyperloom:from-env")
     b = build(sd)
     assert b["session"]["image"] == "registry.example/hyperloom:from-manifest"
+
+
+# ---------------------------------------------------------------------------
+# C1: baseline.ttft_mean_ms disk-walk fallback
+# ---------------------------------------------------------------------------
+def test_baseline_ttft_disk_walk_fallback(tmp_path: Path) -> None:
+    """When ``state.last_baseline.workspace`` does not resolve to a
+    readable benchmark report, but ``runs/baseline/<hash>/benchmark_*/
+    benchmark_report.json`` exists on disk, the collector must walk
+    that directory and surface the latency from the most recent
+    report (mirrors the A2 final.ttft validate_stack disk walk).
+
+    Production parallel: zgong's V2 session
+    ``deepseek-ai-DeepSeek-R1_20260512T102109Z_0dc064c4`` had a valid
+    benchmark_report.json on wekafs but state's recorded workspace
+    didn't resolve."""
+    sd = tmp_path / "session"
+    sd.mkdir(parents=True)
+    _write_json(sd / "manifest.json", {"schema_version": 1, "session_id": "diskwalk"})
+    bdir = sd / "runs/baseline/541e643a84e14352a2ff64bdfe27b2c9/benchmark_001"
+    _write_json(bdir / "benchmark_report.json", {
+        "success": True,
+        "output_throughput_tok_s": 421.5,
+        "mean_ttft_ms": 99.5,
+        "mean_e2el_ms": 1500.0,
+    })
+    _write_json(sd / "state.json", {
+        "session_id": "diskwalk",
+        "baseline_tput": 421.5,
+        # Recorded workspace doesn't resolve under session_dir on wekafs
+        # — exactly the production failure mode we're guarding against.
+        "last_baseline": {"workspace": "/workspace/runs/baseline/different-hash"},
+    })
+
+    b = build(sd)
+    baseline = b["baseline"]
+    assert baseline["ttft_mean_ms"] == pytest.approx(99.5)
+    assert baseline["e2el_mean_ms"] == pytest.approx(1500.0)
+    assert baseline["ttft_e2el_source"] == "runs_baseline_disk"
+    assert any(
+        "baseline.ttft_mean_ms reconstructed from runs/baseline/ disk walk" in w
+        for w in b["warnings"]
+    ), b["warnings"]
+
+
+# ---------------------------------------------------------------------------
+# C2: framework_args extraction lineage
+# ---------------------------------------------------------------------------
+def _make_invocation_fixture(
+    sd: Path,
+    server_log_text: str | None,
+    yaml_text: str | None,
+) -> None:
+    """Minimal fixture: state pointing at runs/baseline/h1, optional
+    server.log + baseline_config.with_envs.yaml beside the report."""
+    _write_json(sd / "manifest.json", {"schema_version": 1, "session_id": "fa"})
+    bdir = sd / "runs/baseline/h1/benchmark_001"
+    _write_json(bdir / "benchmark_report.json", {
+        "success": True, "output_throughput_tok_s": 200.0,
+        "mean_ttft_ms": 120.0, "mean_e2el_ms": 1500.0,
+    })
+    if server_log_text is not None:
+        (bdir / "server.log").write_text(server_log_text, encoding="utf-8")
+    cfg_path = sd / "runs/baseline/h1/baseline_config.with_envs.yaml"
+    if yaml_text is not None:
+        cfg_path.write_text(yaml_text, encoding="utf-8")
+    state: dict[str, Any] = {
+        "session_id": "fa",
+        "baseline_tput": 200.0,
+        "last_baseline": {"workspace": str(sd / "runs/baseline/h1")},
+    }
+    if yaml_text is not None:
+        state["baseline_config_path"] = str(cfg_path)
+    _write_json(sd / "state.json", state)
+
+
+def test_framework_args_from_server_arguments_line(tmp_path: Path) -> None:
+    """``Server arguments: ...`` header in server.log → source =
+    ``log_args_line``; the captured args (not the header) get echoed."""
+    sd = tmp_path / "session"
+    _make_invocation_fixture(
+        sd,
+        server_log_text=(
+            "INFO 05-12 14:21:14 [server.py:42] booting up\n"
+            "INFO 05-12 14:21:15 [server.py:50] Server arguments: "
+            "--model /weka/m --tp 8 --port 30001\n"
+            "INFO 05-12 14:21:16 [server.py:99] ready\n"
+        ),
+        yaml_text=None,
+    )
+    inv = build(sd)["baseline"]["invocation"]
+    assert "--tp 8" in inv["framework_args"]
+    assert "--port 30001" in inv["framework_args"]
+    assert inv["framework_args_source"] == "log_args_line"
+
+
+def test_framework_args_from_python_cmd_line(tmp_path: Path) -> None:
+    """A literal ``python -m vllm.entrypoints...`` line surrounded by
+    INFO log noise → source = ``log_python_cmd``; the python command
+    line is what gets surfaced (Pass-2 fallback)."""
+    sd = tmp_path / "session"
+    _make_invocation_fixture(
+        sd,
+        server_log_text=(
+            "(APIServer pid=1757439) INFO 05-12 14:21:14 [utils.py:299] booting\n"
+            "(APIServer pid=1757439) INFO 05-12 14:21:15 [server.py:50] init\n"
+            "python -m vllm.entrypoints.openai.api_server --model /weka/m --tp 8\n"
+            "(APIServer pid=1757439) INFO 05-12 14:22:00 [server.py:99] ready\n"
+        ),
+        yaml_text=None,
+    )
+    inv = build(sd)["baseline"]["invocation"]
+    assert "vllm.entrypoints" in inv["framework_args"]
+    assert inv["framework_args_source"] == "log_python_cmd"
+
+
+def test_framework_args_from_yaml_cmd_fallback(tmp_path: Path) -> None:
+    """server.log has only INFO noise (no header, no python prefix);
+    yaml has a ``cmd: ...`` field → source = ``yaml_cmd``."""
+    sd = tmp_path / "session"
+    _make_invocation_fixture(
+        sd,
+        server_log_text=(
+            "(APIServer pid=1757439) INFO 05-12 14:21:14 [utils.py:299]\n"
+            "(APIServer pid=1757439) INFO 05-12 14:21:15 [server.py:50] init\n"
+        ),
+        yaml_text=(
+            'cmd: "python -m sglang.launch_server --tp 4 --model /weka/m"\n'
+            "benchmark:\n"
+            "  envs:\n"
+            "    TP: \"4\"\n"
+        ),
+    )
+    inv = build(sd)["baseline"]["invocation"]
+    assert "sglang.launch_server" in inv["framework_args"]
+    assert inv["framework_args_source"] == "yaml_cmd"
+
+
+def test_framework_args_unknown_with_warning(tmp_path: Path) -> None:
+    """server.log has only INFO noise + yaml has no ``cmd``/``command``/
+    ``launch`` field → source = ``unknown``, framework_args is empty,
+    and a ``framework_args extraction failed`` warning is appended."""
+    sd = tmp_path / "session"
+    _make_invocation_fixture(
+        sd,
+        server_log_text=(
+            "(APIServer pid=1757439) INFO 05-12 14:21:14 [utils.py:299]\n"
+            "(APIServer pid=1757439) INFO 05-12 14:21:15 [server.py:50] init\n"
+        ),
+        yaml_text=(
+            "benchmark:\n"
+            "  envs:\n"
+            "    TP: \"8\"\n"
+        ),
+    )
+    b = build(sd)
+    inv = b["baseline"]["invocation"]
+    assert inv["framework_args"] == ""
+    assert inv["framework_args_source"] == "unknown"
+    assert any(
+        "framework_args extraction failed" in w for w in b["warnings"]
+    ), b["warnings"]

--- a/inference_optimizer/tests/test_reporters_smoke.py
+++ b/inference_optimizer/tests/test_reporters_smoke.py
@@ -311,3 +311,69 @@ def test_capability_decision_kind_round_trips(
     cap = next(s for s in r.sections if s.section_id == "capability_summary")
     decisions = {d.subject: d.kind for d in cap.decisions}
     assert decisions.get("sweep") == expected_kind
+
+
+# ---------------------------------------------------------------------------
+# A1 / B4: attribution method + invocation rendering
+# ---------------------------------------------------------------------------
+def test_attribution_method_renders_from_field() -> None:
+    """The attribution renderer must surface the collector's
+    ``attribution.method`` verbatim — no hard-coded "single-source"
+    fallback string when method says "reconstructed".
+
+    Anti-regression for the rendering hallucination where the renderer
+    used to print "single-source (inferred from final.action_path)"
+    even on multi-entry stacks where the lineage was actually
+    best-effort reconstructed.
+    """
+    bd = _fixture_breakdown()
+    bd["attribution"] = {
+        "method": "reconstructed",
+        "source_breakdown": {
+            "validated_total_pct": 14.5,
+            "backends_pct_of_total": 10.0,
+            "params_pct_of_total":   4.5,
+            "geak_pct_of_total":     0.0,
+            "oob_pct_of_total":      0.0,
+            "sweep_pct_of_total":    0.0,
+        },
+        "notes": [],
+    }
+    r = render_session_report(bd)
+    sec = next(s for s in r.sections if s.section_id == "attribution")
+    assert any("reconstructed" in fact for fact in sec.key_facts), sec.key_facts
+    assert not any(
+        "single-source" in fact and "single_source" not in fact
+        for fact in sec.key_facts
+    ), sec.key_facts
+
+
+def test_invocation_section_renders_when_present() -> None:
+    """Both baseline and final renderers must surface an
+    ``### Invocation`` block with framework_args + image when the
+    breakdown has ``baseline.invocation`` populated. Secret-shaped
+    envs (``OPENAI_API_KEY``) must not appear in the output."""
+    bd = _fixture_breakdown()
+    bd["session"]["image"] = "registry.example/hyperloom:abc123"
+    bd["baseline"]["invocation"] = {
+        "framework_args": "python -m sglang.launch_server --model /weka/m --tp 8",
+        "extra_envs":     {"TP": "8", "VLLM_FLASH_ATTN": "1"},
+        "config_path":    "runs/baseline/h1/baseline_config.with_envs.yaml",
+        "server_log_path":"runs/baseline/h1/benchmark_001/server.log",
+    }
+    r = render_session_report(bd)
+    base = next(s for s in r.sections if s.section_id == "baseline")
+    md = base.markdown_block
+    assert "### Invocation" in md
+    assert "sglang.launch_server" in md
+    assert "registry.example/hyperloom:abc123" in md
+    assert "TP=8" in md
+    assert "VLLM_FLASH_ATTN=1" in md
+    assert "OPENAI_API_KEY" not in md
+    # The compose layer must NOT pass the invocation through to the
+    # LLM user prompt (command lines often contain transient values).
+    prompt = json.loads(r.llm_user_prompt)
+    user_text = json.dumps(prompt)
+    assert "sglang.launch_server" not in user_text, (
+        "framework_args leaked into LLM prompt"
+    )

--- a/inference_optimizer/tests/test_reporters_smoke.py
+++ b/inference_optimizer/tests/test_reporters_smoke.py
@@ -377,3 +377,29 @@ def test_invocation_section_renders_when_present() -> None:
     assert "sglang.launch_server" not in user_text, (
         "framework_args leaked into LLM prompt"
     )
+
+
+def test_invocation_renders_framework_args_source() -> None:
+    """When ``invocation.framework_args_source`` is set the renderer
+    must surface the lineage label (``yaml_cmd`` / ``log_python_cmd``
+    / ``log_args_line`` / ``unknown``) right under the command line.
+
+    Anti-regression for the gap2 production failure where
+    ``framework_args = '(APIServer pid=1757439) INFO ...'`` made the
+    extraction silently look successful — having the source label
+    visible lets a reviewer flag the bad extraction at a glance."""
+    bd = _fixture_breakdown()
+    bd["session"]["image"] = "registry.example/hyperloom:src"
+    bd["baseline"]["invocation"] = {
+        "framework_args":        "python -m sglang.launch_server --tp 4",
+        "framework_args_source": "yaml_cmd",
+        "extra_envs":            {"TP": "4"},
+        "config_path":           "runs/baseline/h1/baseline_config.with_envs.yaml",
+        "server_log_path":       "runs/baseline/h1/benchmark_001/server.log",
+    }
+    r = render_session_report(bd)
+    base = next(s for s in r.sections if s.section_id == "baseline")
+    md = base.markdown_block
+    assert "### Invocation" in md
+    assert "yaml_cmd" in md, md
+    assert "**source**" in md, md


### PR DESCRIPTION
## Summary

Four commits that close the production-data gaps surfaced when running `session_breakdown.json` exporter against real V2 sessions on wekafs. Goal: make the exporter resilient to all the ways a real Hyperloom session can be missing data, while keeping the ?7.3 anti-hallucination invariants intact (every reconstructed value carries an explicit lineage tag and a warning).

## Commits in order

1. **`6f433c8` fix(breakdown/collectors): re-root container paths + drop empty source_files**
   - State-recorded paths often look like `/workspace/runs/baseline/<sid>/` (orchestrator wrote them from inside a container) but the breakdown is generated from a wekafs view. Add `_resolve_under_session(session_dir, raw, anchors=("runs", "kernel-agent", "kernel-agent-workspace"))` that re-roots the suffix-from-anchor under the real session directory.
   - Wired into `collect_baseline` (warning on miss) and `collect_telemetry`.
   - `collect_source_files` no longer emits empty `kernel_attempts` / `sweep_reports` / `profile_reports` keys (they used to surface as `count=0, first_values=[]` rows in the rendered report).

2. **`6639815` feat(breakdown): record image + invocation + reconstruct missing fields**
   - **A1**: `attribution.method` is now always a string (`validated` / `single_source` / `reconstructed` / `missing`); reporter renders the actual value instead of hard-coding "single-source".
   - **A2**: `final.ttft_mean_ms` and `e2el_mean_ms` reconstructable from disk via `runs/validate_stack/<h>/benchmark_*/benchmark_report.json` when `state.current_best` did not record them. New `final.ttft_e2el_source` field carries lineage (`current_best` / `validate_stack_disk` / `stack_top_disk` / `unavailable`).
   - **A3**: `baseline.attempts_history` reconstructable from `runs/baseline/<h>/benchmark_*/...` when `state.baseline_attempts` is empty.
   - **B**: `session.image` populated by a 6-step priority chain (`HYPERLOOM_IMAGE` -> `CONTAINER_IMAGE` -> `IMAGE` -> `/etc/podinfo/image` -> `/etc/hyperloom-image` -> `/proc/1/cgroup` parse). Manifest schema bumped 1 -> 2.
   - **B**: `BenchmarkInvocation` TypedDict (framework_args / extra_envs / config_path / server_log_path) attached to `Baseline` and `Final`. Envs are filtered through an allowlist (TP/FRAMEWORK/GPU_TYPE/PRECISION/CONC/ISL/OSL/...; HYPERLOOM_/VLLM_/SGLANG_/RAY_/HSA_/ROCM_/TORCH_/HF_ prefixes) plus a KEY|TOKEN|SECRET|PASSWORD|... denylist.

3. **`5c376df` fix(breakdown): close baseline.ttft + framework_args extraction gaps**
   - **Gap 1**: `baseline.ttft_mean_ms` disk-walk fallback (mirrors A2 for the baseline side). New `Baseline.ttft_e2el_source` field, lineage tags `state_workspace` / `runs_baseline_disk` / `unavailable`.
   - **Gap 2**: replaces brittle "first non-empty server.log line" with a 3-pass `_extract_framework_args`:
     - **Pass 1 log_args_line**: scan for `Server arguments:` / `Args: Namespace(...)` / `Launching server with:` headers
     - **Pass 2 log_python_cmd**: scan for first literal launch line (`python` / `python3` / `vllm` / `sglang.launch_server` / `inference-optimizer` / `ray`) after stripping vllm-style log prefixes
     - **Pass 3 yaml_cmd**: parse the materialized config yaml for `cmd:` / `command:` / `launch:` (top-level or under `benchmark.`)
     - Otherwise `unknown` + warning
   - New `BenchmarkInvocation.framework_args_source` carries the lineage.

4. **`54af9d3` feat(breakdown): extract framework_args from vllm non-default-args echo**
   - Production data revealed that `5c376df`'s 3 passes did not actually catch vllm's startup output. vllm prints a single line like `(APIServer pid=N) INFO ts [utils.py:233] non-default args: {...}` and that dict IS the cmdline equivalent (already parsed by vllm).
   - **Pass 0 log_non_default_args** (new top-of-chain): regex per-line for `non[-_]default args:\s*(\{.+\})\s*$`, `ast.literal_eval` the dict (no regex hacking), emit keys sorted alphabetically with `repr()` values for byte-stable output.
   - **Pass 4 yaml_benchmark** (new bottom fallback): for magpie-style configs without `cmd:`, synthesize `framework=vllm model=... precision=fp8 tp=8 envs=[K=V K=V]` from `benchmark.{framework, model, precision, tp, envs, gpu_selection}` when both `framework` AND `model` are present.

## Real-data validation

Tested against two sessions on wekafs:

### 1. Successful V2 session ? `zgong/HyperloomV2-sessions/deepseek-ai-DeepSeek-R1_20260512T102109Z_0dc064c4` (+10.02% gain, backends KEEP only, no GEAK/OOB)

```
attribution.method     = single_source            (was: missing field)
baseline.ttft_mean_ms  = 1870.69 ms               (was: None)
baseline.ttft_e2el_source = runs_baseline_disk    (NEW)
final.ttft_mean_ms     = 2134.56 ms               (was: None)
final.ttft_e2el_source = validate_stack_disk      (NEW)
baseline.attempts      = 4 entries                (was: [])
session.image          = rocm/dev:test-from-c04u01 (NEW)
baseline.invocation:
  source = log_non_default_args
  args   = "gpu_memory_utilization=0.85 max_model_len=4096 model='/wekafs/.../R1' port=8888 tensor_parallel_size=8 trust_remote_code=True"
final.invocation:
  source = log_non_default_args
  args   = "gpu_memory_utilization=0.95 kv_cache_dtype='fp8_e4m3' max_model_len=8192 max_num_seqs=512 model='/wekafs/.../R1' port=8888 tensor_parallel_size=8 trust_remote_code=True"
source_files keys = no kernel_attempts, no sweep_reports     (was: count=0 placeholders)
warnings (3): all explicit reconstruction lineage notes; no PermissionError
```

The baseline -> final invocation diff is a clean dashboard story: hyperloom raised gpu_memory to 0.95, doubled max_model_len, set kv_cache_dtype=fp8_e4m3 + max_num_seqs=512.

### 2. Failed-startup session (corner case validation)

A separate run that exited with `stop_reason=baseline_failed` (sglang module missing in the runtime, unrelated infra issue) produced `session_breakdown.json` cleanly:

```
session.image            = claw-sandbox-runtime
stop_reason              = baseline_failed
baseline.ttft            = None (src=unavailable)
final.ttft               = None (src=unavailable)
baseline.invocation      = source=unknown, envs=[]
attribution.method       = missing
capability_summary       = all six = not_attempted
```

All fields degraded to honest "we did not have the data" values (unavailable / unknown / missing). No collector crash. This is the harder side of the ?7.3 anti-hallucination invariant: when the upstream gave us nothing, we surface nothing rather than invent values.

## Anti-hallucination invariants preserved (handoff doc ?7.3)

- GEAK / OOB `not_attempted` capability still produces ONLY `not_attempted` decisions (regression guard `test_geak_not_attempted_never_emits_kept_decision` green).
- LLM user prompt does not include skipped sections; the new invocation block is intentionally NOT routed to the LLM prompt builder.
- Every metric number renders from a deterministic markdown block; LLM only narrates.
- Reconstruction paths surface a warning with explicit lineage; no silent fallbacks.
- `ast.literal_eval` failure for Pass 0 falls through (no regex-hack of partial dicts).
- Synthesized `yaml_benchmark` source labelled distinctly so consumers know it is not a literal cmdline.

## Schema additions (all backward compatible, TypedDict total=False)

New fields:

- `SessionMeta.image: str | None`
- `Baseline.invocation: BenchmarkInvocation`
- `Baseline.ttft_e2el_source: str` (state_workspace / runs_baseline_disk / unavailable)
- `Final.invocation: BenchmarkInvocation`
- `Final.ttft_e2el_source: str` (current_best / validate_stack_disk / stack_top_disk / unavailable)
- `Attribution.method: str` (validated / single_source / reconstructed / missing)
- `BenchmarkInvocation` TypedDict: framework_args / framework_args_source (log_non_default_args / log_args_line / log_python_cmd / yaml_cmd / yaml_benchmark / unknown) / extra_envs / config_path / server_log_path

`SCHEMA_VERSION` for the breakdown JSON is unchanged (`hyperloom.session_breakdown.v1`); only optional fields added per the file's own docstring contract. Manifest `SCHEMA_VERSION` bumped 1 -> 2 to flag the documented `image` field addition.

## Out of scope (single follow-ups, all upstream-owned)

- GPU monitor power/temp zeros (Magpie / InferenceX upstream).
- `phase_timeline` empty (V2 Coordinator does not emit per-tick action records).
- `critic_robustness` items still string-only (V2 Coordinator does not write structured critic decisions).
- Kernel resolver source_file resolution gap on aiter / ck / triton kernels (causes GEAK/OOB attempts=0 in zgong session).
- `claw_session_id` / `sandbox_user_id` null when launched outside Claw web (deployment env injection).
- `session.host` exposes raw hostname; PII redaction is a policy decision.
- Cosmetic dedupe of identical "framework_args extraction failed" warnings emitted from baseline + final collectors with different context (1-line follow-up, not in this PR).

## Test plan

- [x] `python -m pytest inference_optimizer/tests/test_breakdown_smoke.py inference_optimizer/tests/test_reporters_smoke.py -q`: 55 passed, 1 unrelated warning (asyncio_mode pytest config). 6 new tests in this PR series cover the env allowlist boundary, ttft reconstruction lineage, framework_args extraction passes, and the regression guard `test_geak_not_attempted_never_emits_kept_decision`.
- [x] Real wekafs dump against `zgong/HyperloomV2-sessions/deepseek-ai-DeepSeek-R1_20260512T102109Z_0dc064c4` -- all assertions pass (see Real-data validation ?1).
- [x] Real wekafs dump against a `baseline_failed` corner case -- all degraded fields render as unavailable / unknown / missing, no crash (see ?2).
- [ ] End-to-end run on a sandbox image with sglang preinstalled to exercise GEAK/OOB/sweep paths -- separate follow-up issue (current sandbox image lacks the SGLang ROCm runtime; not a blocker for the breakdown contract).
