### PR TITLE
fix(kernel-agent): add run.budgets block to rendered GEAK local.yaml

### DIFF
--- a/kernel-agent/scripts/install.sh
+++ b/kernel-agent/scripts/install.sh
@@ -504,6 +504,28 @@ model:
     max_tokens: 16384
 tools:
   rag: true
+run:
+  mode: full
+  budgets:
+    quick:
+      total_s: 3600
+      preprocess_soft_cap_s: 900
+      preprocess_hard_cap_fraction: 0.5
+      finalize_grace_s: 300
+      kill_buffer_s: 60
+    full:
+      total_s: 7200
+      preprocess_soft_cap_s: 900
+      preprocess_hard_cap_fraction: 0.5
+      finalize_grace_s: 300
+      kill_buffer_s: 60
+  presets:
+    quick:
+      orchestrator:
+        max_rounds: 2
+    full:
+      orchestrator:
+        max_rounds: 5
 EOF
       chmod 600 "$GEAK_CONFIG"
       grep -Eq '^[[:space:]]*model_class:[[:space:]]*litellm[[:space:]]*$' "$GEAK_CONFIG" \


### PR DESCRIPTION
## Summary

- Hyperloom passes `--config $GEAK_CONFIG` (rendered `local.yaml`) to GEAK, which causes GEAK to skip its default `geak.yaml` entirely ([`geak_submit.py:58`](kernel-agent/tools/backends/geak_submit.py#L58), [`mini.py:221`](geak/src/minisweagent/run/mini.py#L221))
- `geak.yaml` is the only config file that carries the `run.budgets` block, so GEAK crashes at startup with `typer.BadParameter("No run.budgets.{mode} block in config")` ([`mini.py:527-529`](geak/src/minisweagent/run/mini.py#L527-L529))
- Adds the `run.budgets` (quick: 1h, full: 2h) and `run.presets` sections to the `local.yaml` heredoc in `install.sh` so the rendered config is self-contained

## Context

Discovered during a Qwen3-30B-A3B optimization run on MI325X. The kernel agent completes `select_kernels` and dispatches GEAK, but GEAK immediately exits because the config merge chain (`mini_kernel_strategy_list.yaml` ← `local.yaml`) never includes budgets. The base config `mini_kernel_strategy_list.yaml` doesn't have them either.

## Test plan

- [ ] Run `install.sh` and verify `local.yaml` contains the `run.budgets` block
- [ ] Invoke GEAK via Hyperloom's `geak_submit.py` and confirm it no longer crashes on missing budgets
- [ ] Verify `_deep_merge()` correctly merges the budgets with the base config

🤖 Generated with [Claude Code](https://claude.com/claude-code)