### PR TITLE
fix(cli): raise kernel Claude backend max_turns from 4 to 20

### DIFF
--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -470,7 +470,7 @@ def _build_backends(
         if kernel_codex:
             backends["kernel"] = CodexBackend(model=codex_model)
         else:
-            backends["kernel"] = ClaudeBackend(model=claude_model, max_turns_default=4)
+            backends["kernel"] = ClaudeBackend(model=claude_model, max_turns_default=20)
     return backends
 
 


### PR DESCRIPTION
## Summary

- When `--kernel-claude` is passed, the kernel agent's Claude backend gets `max_turns_default=4`
- The kernel agent needs ~15-20 turns to complete multi-step operations like `select_kernels` (trace read, TraceLens analysis, kernel candidate ranking)
- With 4 turns, Claude gets cut off mid-task, produces no results, and GEAK is never dispatched
- The default kernel backend is Codex (`--kernel-codex`), which is why this went unnoticed — the Claude path is opt-in

## Change

One-liner at `inference_optimizer/cli.py:473`: `max_turns_default=4` → `max_turns_default=20`

Note: the orchestration backend stays at `max_turns_default=4` (line 465) — that's correct for its simpler coordination role.

## Test plan

- [ ] Run with `--kernel-claude` and verify `select_kernels` completes successfully
- [ ] Verify GEAK gets dispatched after kernel selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)