### PR TITLE
fix(tracelens): fall back to AgenticMode/Standalone skill path

### DIFF
--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -1823,7 +1823,9 @@ def main() -> int:
             # TRACELENS_ROOT / --tracelens-root for older release branches.
             skill = tl_root / "TraceLens/Agent/Analysis/.cursor/skills/analysis-orchestrator.md"
             if not skill.exists():
-                raise FileNotFoundError(f"TraceLens standalone skill not found: {skill}")
+                skill = tl_root / "TraceLens/AgenticMode/Standalone/.cursor/skills/standalone-analysis-orchestrator.md"
+            if not skill.exists():
+                raise FileNotFoundError(f"TraceLens standalone skill not found (tried Agent/Analysis and AgenticMode/Standalone paths): {skill}")
             append_log(log_path, f"TraceLens skill: {skill}")
 
             tracelens_dir = run_dir / "tracelens"


### PR DESCRIPTION
## Summary

- TraceLens checkouts that haven't been restructured to `Agent/Analysis/` still use the older `AgenticMode/Standalone/` layout
- Hyperloom hardcodes the new path (`TraceLens/Agent/Analysis/.cursor/skills/analysis-orchestrator.md`), so every TraceLens analysis attempt fails with `FileNotFoundError` on older checkouts
- This causes `deep_kernel_analysis` to fail repeatedly, which accumulates crashes until the emergency threshold (25) stops the run — preventing any kernel optimization from happening

## Fix

Try the new path first, fall back to the old `AgenticMode/Standalone/.cursor/skills/standalone-analysis-orchestrator.md` before raising.

## Code

`kernel-agent/tools/tracelens_analysis.py:1824`

## Test plan

- [ ] With a TraceLens checkout using the old `AgenticMode/Standalone/` layout, verify TraceLens analysis no longer crashes
- [ ] With a TraceLens checkout using the new `Agent/Analysis/` layout, verify the new path is still preferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)