### PR TITLE
fix(tracelens): resolve v0.3.1 per-version sglang patch subdirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Prepare the source trees from the corresponding repositories:
 - Hyperloom: this repository; clone it and point `REPO_ROOT` at the repo root.
 - OOB: clone the [AMD-AGI/Primus-Claw](https://github.com/AMD-AGI/Primus-Claw) repository, then point `OOB_SRC` at its `OOB/` subdirectory.
 - InferenceX: [SemiAnalysisAI/InferenceX](https://github.com/SemiAnalysisAI/InferenceX); point `INFERENCEX_PATH` at the local repo root.
-- TraceLens-internal: [AMD-AGI/TraceLens-internal](https://github.com/AMD-AGI/TraceLens-internal/); checkout `release/hyperloom_integration_v0.3` and point `TRACELENS_ROOT` at that checkout.
+- TraceLens-internal: [AMD-AGI/TraceLens-internal](https://github.com/AMD-AGI/TraceLens-internal/); checkout `release/hyperloom_integration_v0.3.1` (or the matching `Hyperloom_integration_v0.3.1` tag) and point `TRACELENS_ROOT` at that checkout. Older `release/hyperloom_integration_v0.3` checkouts also work via `_server_patcher`'s backward-compat fallback.
 
 > `SAFE_API_KEY` is obtained from [LLM Gateway](https://core42.primus-safe.amd.com/litellm-gateway). GEAK and OOB (claude/codex) API Key / Base URL are automatically inherited from `SAFE_API_KEY` / `OPENAI_BASE_URL`. You can place these values in `$REPO_ROOT/.env`; no separate GEAK or OOB configuration is needed. The OOB **cursor** backend is the exception: it talks to Cursor's own gateway and requires a separate `CURSOR_API_KEY`. If `CURSOR_API_KEY` is unset, cursor is silently skipped from default kernel-opt selection.
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Prepare the source trees from the corresponding repositories:
 - Hyperloom: this repository; clone it and point `REPO_ROOT` at the repo root.
 - OOB: clone the [AMD-AGI/Primus-Claw](https://github.com/AMD-AGI/Primus-Claw) repository, then point `OOB_SRC` at its `OOB/` subdirectory.
 - InferenceX: [SemiAnalysisAI/InferenceX](https://github.com/SemiAnalysisAI/InferenceX); point `INFERENCEX_PATH` at the local repo root.
-- TraceLens-internal: [AMD-AGI/TraceLens-internal](https://github.com/AMD-AGI/TraceLens-internal/); checkout `release/hyperloom_integration_v0.3.1` (or the matching `Hyperloom_integration_v0.3.1` tag) and point `TRACELENS_ROOT` at that checkout. Older `release/hyperloom_integration_v0.3` checkouts also work via `_server_patcher`'s backward-compat fallback.
+- TraceLens-internal: [AMD-AGI/TraceLens-internal](https://github.com/AMD-AGI/TraceLens-internal/); checkout `release/hyperloom_integration_v0.3.1` (or the matching `Hyperloom_integration_v0.3.1` tag) and point `TRACELENS_ROOT` at that checkout. The per-version `sglang_roofline_patches/sglang_<minor>_<patch>/` layout is required; pre-v0.3.1 flat checkouts are no longer supported.
 
 > `SAFE_API_KEY` is obtained from [LLM Gateway](https://core42.primus-safe.amd.com/litellm-gateway). GEAK and OOB (claude/codex) API Key / Base URL are automatically inherited from `SAFE_API_KEY` / `OPENAI_BASE_URL`. You can place these values in `$REPO_ROOT/.env`; no separate GEAK or OOB configuration is needed. The OOB **cursor** backend is the exception: it talks to Cursor's own gateway and requires a separate `CURSOR_API_KEY`. If `CURSOR_API_KEY` is unset, cursor is silently skipped from default kernel-opt selection.
 

--- a/inference_optimizer/SKILL.md
+++ b/inference_optimizer/SKILL.md
@@ -74,9 +74,10 @@ in `.env.template`).
 
 Inputs that stay outside `$USER_DATA_PATH` by design (read-only sources
 or warm-start caches): `$TRACELENS_ROOT` (default `/wekafs/hyperloom/
-TraceLens-internal`; expected at tag `Hyperloom_integration_v0.3.1` or
-the matching `release/hyperloom_integration_v0.3.1` branch — older v0.3
-flat checkouts still work via the patcher's backward-compat fallback),
+TraceLens-internal`; **must** be at tag `Hyperloom_integration_v0.3.1`
+or the matching `release/hyperloom_integration_v0.3.1` branch — the
+per-version `sglang_roofline_patches/sglang_<minor>_<patch>/` layout is
+required by `_server_patcher`),
 `$OOB_SRC` / `$HYPERLOOM_BUNDLE`,
 `/sgl-workspace/{aiter,sglang,vllm}/`, `~/.claude/config.json` +
 `~/.codex/auth.json`, `~/.cache/amd-ai-devtool/semantic-index/`

--- a/inference_optimizer/SKILL.md
+++ b/inference_optimizer/SKILL.md
@@ -74,7 +74,10 @@ in `.env.template`).
 
 Inputs that stay outside `$USER_DATA_PATH` by design (read-only sources
 or warm-start caches): `$TRACELENS_ROOT` (default `/wekafs/hyperloom/
-TraceLens-internal`), `$OOB_SRC` / `$HYPERLOOM_BUNDLE`,
+TraceLens-internal`; expected at tag `Hyperloom_integration_v0.3.1` or
+the matching `release/hyperloom_integration_v0.3.1` branch — older v0.3
+flat checkouts still work via the patcher's backward-compat fallback),
+`$OOB_SRC` / `$HYPERLOOM_BUNDLE`,
 `/sgl-workspace/{aiter,sglang,vllm}/`, `~/.claude/config.json` +
 `~/.codex/auth.json`, `~/.cache/amd-ai-devtool/semantic-index/`
 (GEAK RAG embedding cache), `/wekafs/hyperloom/geak-memory/memory.db`

--- a/inference_optimizer/orchestrator/action_executors/_server_patcher.py
+++ b/inference_optimizer/orchestrator/action_executors/_server_patcher.py
@@ -230,6 +230,56 @@ def _sglang_version_accepted(
 _PATCH_TREE_REL = ("examples", "custom_workflows", "inference_analysis")
 
 
+def _versioned_patches_subdir_name(version: str) -> str | None:
+    """Map ``sglang.__version__`` to the per-version patch subdir name
+    TraceLens ``Hyperloom_integration_v0.3.1`` introduced (e.g.
+    ``0.5.11`` -> ``sglang_0_5_11``). Returns ``None`` when ``version``
+    has no recognisable dotted numeric head (so the caller fail-softs
+    to the legacy flat layout)."""
+    text = (version or "").strip()
+    if not text:
+        return None
+    # Strip dev/local suffixes (e.g. ``0.5.11-rc1`` -> ``0.5.11``) so
+    # point-release tags still resolve to a versioned subdir.
+    head = text.split("-", 1)[0].split("+", 1)[0]
+    parts = head.split(".") if head else []
+    if not parts or not all(p.isdigit() for p in parts):
+        return None
+    return "sglang_" + "_".join(parts)
+
+
+def _resolve_sglang_patches_dir(
+    patches_root: Path, version: str,
+) -> tuple[Path, bool] | None:
+    """Locate the SGLang patches dir for the running ``sglang`` version.
+
+    TraceLens ``Hyperloom_integration_v0.3.1`` split the previously-flat
+    ``sglang_roofline_patches/`` into per-version subdirs
+    (``sglang_0_5_9/``, ``sglang_0_5_11/``, ...). Resolution order:
+
+    1. Versioned subdir matching the installed sglang (e.g.
+       ``sglang_0_5_11/``) when it exists AND contains at least one
+       ``*.patch`` file.
+    2. Flat ``sglang_roofline_patches/`` itself when it directly
+       contains ``*.patch`` files (the v0.3 layout) — kept as a
+       backward-compat fallback so checkouts pinned at v0.3 keep
+       working without code changes.
+
+    Returns ``(patches_dir, versioned)`` where ``versioned`` lets the
+    caller skip the v0.3 ``optional_missing`` shim (v0.3.1+ ships a
+    complete per-version patch set, so no patch should be optional).
+    Returns ``None`` when neither layout yields any patches.
+    """
+    subdir_name = _versioned_patches_subdir_name(version)
+    if subdir_name is not None:
+        candidate = patches_root / subdir_name
+        if candidate.is_dir() and any(candidate.glob("*.patch")):
+            return candidate, True
+    if any(patches_root.glob("*.patch")):
+        return patches_root, False
+    return None
+
+
 # ---------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------
@@ -393,14 +443,27 @@ def _discover_sglang_plan(arg: Path | str | None) -> _PatchPlan | None:
 
     # Resolve the patches dir BEFORE the version check so the gate
     # can consult the TraceLens-shipped manifest (PR-D §5). If the
-    # patches dir itself is missing, no point checking the version.
-    patches_dir = _patch_tree(tracelens_root, "sglang_roofline_patches")
-    if not patches_dir.is_dir():
+    # patches root itself is missing, no point checking the version.
+    patches_root = _patch_tree(tracelens_root, "sglang_roofline_patches")
+    if not patches_root.is_dir():
         log.info(
-            "_server_patcher: SGLang patches directory missing (%s); skip",
-            patches_dir,
+            "_server_patcher: SGLang patches root missing (%s); skip",
+            patches_root,
         )
         return None
+
+    # TraceLens v0.3.1 introduced per-version subdirs; v0.3 was flat.
+    # Prefer the versioned subdir, fall back to flat for backward compat.
+    patches_resolution = _resolve_sglang_patches_dir(patches_root, version)
+    if patches_resolution is None:
+        log.info(
+            "_server_patcher: no SGLang patches found under %s for "
+            "version %s (looked for %s/ then flat layout); skip",
+            patches_root, version,
+            _versioned_patches_subdir_name(version) or "<unknown>",
+        )
+        return None
+    patches_dir, versioned_layout = patches_resolution
 
     if not _sglang_version_accepted(version, patches_dir=patches_dir):
         log.info(
@@ -429,32 +492,41 @@ def _discover_sglang_plan(arg: Path | str | None) -> _PatchPlan | None:
     #   modified in place — no symlinks, no tmpdirs, no copies, so
     #   ``git apply``'s symlink-safety check never trips.
     sglang_module = Path(sglang.__file__).resolve()
-    resolution = _resolve_sglang_apply_root(sglang_module)
-    if resolution is None:
+    apply_resolution = _resolve_sglang_apply_root(sglang_module)
+    if apply_resolution is None:
         return None
-    apply_root, apply_strip = resolution
+    apply_root, apply_strip = apply_resolution
 
-    optional_missing = {
-        # Dense inference and SGLang 0.5.11 do not have this legacy path.
-        "fused_moe_triton_kernels.patch":
-            "python/sglang/srt/layers/moe/fused_moe_triton/"
-            "fused_moe_triton_kernels.py",
-        # The old mixin was folded/renamed in newer SGLang. http_server.py
-        # and io_struct.py cover the /start_profile request path we use.
-        "tokenizer_communicator_mixin.patch":
-            "python/sglang/srt/managers/tokenizer_communicator_mixin.py",
-    }
-    filtered_patches: list[Path] = []
-    for patch_file in patches:
-        optional_target = optional_missing.get(patch_file.name)
-        if optional_target and not (apply_root / optional_target).exists():
-            log.info(
-                "_server_patcher: skipping optional SGLang patch %s because "
-                "target %s is absent in installed SGLang %s",
-                patch_file.name, optional_target, version,
-            )
-            continue
-        filtered_patches.append(patch_file)
+    if versioned_layout:
+        # TraceLens v0.3.1 per-version subdirs ship a complete patch
+        # set authored against that exact sglang release, so every
+        # patch must apply. No legacy optional-skip needed.
+        filtered_patches: list[Path] = list(patches)
+    else:
+        # v0.3 flat layout was authored against 0.5.9. On newer point
+        # releases some target files moved or were dropped — skip those
+        # patches when the target is absent so the rest still apply.
+        optional_missing = {
+            # Dense inference and SGLang 0.5.11 do not have this legacy path.
+            "fused_moe_triton_kernels.patch":
+                "python/sglang/srt/layers/moe/fused_moe_triton/"
+                "fused_moe_triton_kernels.py",
+            # The old mixin was folded/renamed in newer SGLang. http_server.py
+            # and io_struct.py cover the /start_profile request path we use.
+            "tokenizer_communicator_mixin.patch":
+                "python/sglang/srt/managers/tokenizer_communicator_mixin.py",
+        }
+        filtered_patches = []
+        for patch_file in patches:
+            optional_target = optional_missing.get(patch_file.name)
+            if optional_target and not (apply_root / optional_target).exists():
+                log.info(
+                    "_server_patcher: skipping optional SGLang patch %s because "
+                    "target %s is absent in installed SGLang %s",
+                    patch_file.name, optional_target, version,
+                )
+                continue
+            filtered_patches.append(patch_file)
 
     # Sentinel: the kernel_shape_profiler patch creates an entirely
     # new file. In both layouts it lands at the wheel-side path
@@ -541,6 +613,13 @@ def _ensure_sglang_tokenizer_control_profile_args(plan: _PatchPlan) -> bool:
     patch, HTTP /start_profile accepts ``shape_discovery`` in the request model
     but raises ``unexpected keyword argument`` before the scheduler ever sees
     the flag, so no execution-step trace is recorded.
+
+    Status note: TraceLens ``Hyperloom_integration_v0.3.1`` ships an upstream
+    ``sglang_0_5_11/tokenizer_communicator_mixin.patch`` that targets the same
+    file with the same fields, so when the versioned patch layout is in use
+    the idempotency short-circuit below returns True without mutating anything.
+    This shim only does real work for users still pinned at the v0.3 flat
+    layout where the upstream 0.5.11 patch isn't available.
     """
     sglang_pkg = plan.sentinel_file.parents[2]
     target = sglang_pkg / "srt" / "managers" / "tokenizer_control_mixin.py"

--- a/inference_optimizer/orchestrator/action_executors/_server_patcher.py
+++ b/inference_optimizer/orchestrator/action_executors/_server_patcher.py
@@ -250,33 +250,23 @@ def _versioned_patches_subdir_name(version: str) -> str | None:
 
 def _resolve_sglang_patches_dir(
     patches_root: Path, version: str,
-) -> tuple[Path, bool] | None:
+) -> Path | None:
     """Locate the SGLang patches dir for the running ``sglang`` version.
 
     TraceLens ``Hyperloom_integration_v0.3.1`` split the previously-flat
     ``sglang_roofline_patches/`` into per-version subdirs
-    (``sglang_0_5_9/``, ``sglang_0_5_11/``, ...). Resolution order:
+    (``sglang_0_5_9/``, ``sglang_0_5_11/``, ...). Hyperloom requires
+    this layout; the flat v0.3 layout is no longer supported.
 
-    1. Versioned subdir matching the installed sglang (e.g.
-       ``sglang_0_5_11/``) when it exists AND contains at least one
-       ``*.patch`` file.
-    2. Flat ``sglang_roofline_patches/`` itself when it directly
-       contains ``*.patch`` files (the v0.3 layout) — kept as a
-       backward-compat fallback so checkouts pinned at v0.3 keep
-       working without code changes.
-
-    Returns ``(patches_dir, versioned)`` where ``versioned`` lets the
-    caller skip the v0.3 ``optional_missing`` shim (v0.3.1+ ships a
-    complete per-version patch set, so no patch should be optional).
-    Returns ``None`` when neither layout yields any patches.
+    Returns the versioned subdir when it exists AND contains at least
+    one ``*.patch`` file, else ``None`` (caller fail-softs).
     """
     subdir_name = _versioned_patches_subdir_name(version)
-    if subdir_name is not None:
-        candidate = patches_root / subdir_name
-        if candidate.is_dir() and any(candidate.glob("*.patch")):
-            return candidate, True
-    if any(patches_root.glob("*.patch")):
-        return patches_root, False
+    if subdir_name is None:
+        return None
+    candidate = patches_root / subdir_name
+    if candidate.is_dir() and any(candidate.glob("*.patch")):
+        return candidate
     return None
 
 
@@ -309,7 +299,7 @@ def ensure_sglang_patched_for_tracelens(
     plan = _discover_sglang_plan(tracelens_root)
     if plan is None:
         return False
-    return _ensure_patched(plan) and _ensure_sglang_tokenizer_control_profile_args(plan)
+    return _ensure_patched(plan)
 
 
 # ---------------------------------------------------------------------
@@ -452,18 +442,19 @@ def _discover_sglang_plan(arg: Path | str | None) -> _PatchPlan | None:
         )
         return None
 
-    # TraceLens v0.3.1 introduced per-version subdirs; v0.3 was flat.
-    # Prefer the versioned subdir, fall back to flat for backward compat.
-    patches_resolution = _resolve_sglang_patches_dir(patches_root, version)
-    if patches_resolution is None:
+    # TraceLens v0.3.1+ ships per-version subdirs (sglang_0_5_11/, ...);
+    # Hyperloom requires this layout. Pre-v0.3.1 flat checkouts must
+    # be upgraded — see README "Prepare Source Trees".
+    patches_dir = _resolve_sglang_patches_dir(patches_root, version)
+    if patches_dir is None:
         log.info(
-            "_server_patcher: no SGLang patches found under %s for "
-            "version %s (looked for %s/ then flat layout); skip",
-            patches_root, version,
+            "_server_patcher: no SGLang patches found under %s/%s/ for "
+            "version %s; upgrade TraceLens to Hyperloom_integration_v0.3.1+",
+            patches_root,
             _versioned_patches_subdir_name(version) or "<unknown>",
+            version,
         )
         return None
-    patches_dir, versioned_layout = patches_resolution
 
     if not _sglang_version_accepted(version, patches_dir=patches_dir):
         log.info(
@@ -497,36 +488,9 @@ def _discover_sglang_plan(arg: Path | str | None) -> _PatchPlan | None:
         return None
     apply_root, apply_strip = apply_resolution
 
-    if versioned_layout:
-        # TraceLens v0.3.1 per-version subdirs ship a complete patch
-        # set authored against that exact sglang release, so every
-        # patch must apply. No legacy optional-skip needed.
-        filtered_patches: list[Path] = list(patches)
-    else:
-        # v0.3 flat layout was authored against 0.5.9. On newer point
-        # releases some target files moved or were dropped — skip those
-        # patches when the target is absent so the rest still apply.
-        optional_missing = {
-            # Dense inference and SGLang 0.5.11 do not have this legacy path.
-            "fused_moe_triton_kernels.patch":
-                "python/sglang/srt/layers/moe/fused_moe_triton/"
-                "fused_moe_triton_kernels.py",
-            # The old mixin was folded/renamed in newer SGLang. http_server.py
-            # and io_struct.py cover the /start_profile request path we use.
-            "tokenizer_communicator_mixin.patch":
-                "python/sglang/srt/managers/tokenizer_communicator_mixin.py",
-        }
-        filtered_patches = []
-        for patch_file in patches:
-            optional_target = optional_missing.get(patch_file.name)
-            if optional_target and not (apply_root / optional_target).exists():
-                log.info(
-                    "_server_patcher: skipping optional SGLang patch %s because "
-                    "target %s is absent in installed SGLang %s",
-                    patch_file.name, optional_target, version,
-                )
-                continue
-            filtered_patches.append(patch_file)
+    # v0.3.1+ per-version subdirs ship a complete patch set authored
+    # against that exact sglang release; every patch must apply.
+    filtered_patches: list[Path] = list(patches)
 
     # Sentinel: the kernel_shape_profiler patch creates an entirely
     # new file. In both layouts it lands at the wheel-side path
@@ -602,87 +566,6 @@ def _resolve_sglang_apply_root(sglang_module: Path) -> tuple[Path, int] | None:
         sglang_module, sglang_dir.name,
     )
     return None
-
-
-def _ensure_sglang_tokenizer_control_profile_args(plan: _PatchPlan) -> bool:
-    """Adapt TraceLens's legacy tokenizer communicator patch to SGLang 0.5.11.
-
-    TraceLens ships ``tokenizer_communicator_mixin.patch`` for older SGLang
-    layouts. In 0.5.11 the relevant ``start_profile`` method lives in
-    ``tokenizer_control_mixin.py`` instead. Without this small compatibility
-    patch, HTTP /start_profile accepts ``shape_discovery`` in the request model
-    but raises ``unexpected keyword argument`` before the scheduler ever sees
-    the flag, so no execution-step trace is recorded.
-
-    Status note: TraceLens ``Hyperloom_integration_v0.3.1`` ships an upstream
-    ``sglang_0_5_11/tokenizer_communicator_mixin.patch`` that targets the same
-    file with the same fields, so when the versioned patch layout is in use
-    the idempotency short-circuit below returns True without mutating anything.
-    This shim only does real work for users still pinned at the v0.3 flat
-    layout where the upstream 0.5.11 patch isn't available.
-    """
-    sglang_pkg = plan.sentinel_file.parents[2]
-    target = sglang_pkg / "srt" / "managers" / "tokenizer_control_mixin.py"
-    if not target.is_file():
-        # Older layouts use tokenizer_communicator_mixin.py; the TraceLens
-        # patch set handles that file directly.
-        return True
-    try:
-        text = target.read_text(encoding="utf-8")
-    except OSError as exc:
-        log.warning(
-            "_server_patcher: cannot read %s to patch profile args: %s",
-            target, exc,
-        )
-        return False
-    if "shape_discovery: bool = False" in text and "roofline_annotations: bool = False" in text:
-        return True
-    sig_old = (
-        "        profile_prefix: Optional[str] = None,\n"
-        "        profile_stages: Optional[List[str]] = None,\n"
-        "    ):\n"
-    )
-    sig_new = (
-        "        profile_prefix: Optional[str] = None,\n"
-        "        profile_stages: Optional[List[str]] = None,\n"
-        "        shape_discovery: bool = False,\n"
-        "        roofline_annotations: bool = False,\n"
-        "    ):\n"
-    )
-    req_old = (
-        "            profile_prefix=profile_prefix,\n"
-        "            profile_stages=profile_stages,\n"
-        "        )\n"
-    )
-    req_new = (
-        "            profile_prefix=profile_prefix,\n"
-        "            profile_stages=profile_stages,\n"
-        "            shape_discovery=shape_discovery,\n"
-        "            roofline_annotations=roofline_annotations,\n"
-        "        )\n"
-    )
-    if sig_old not in text or req_old not in text:
-        log.warning(
-            "_server_patcher: tokenizer_control_mixin.py layout changed; "
-            "cannot inject shape_discovery / roofline_annotations into %s",
-            target,
-        )
-        return False
-    patched = text.replace(sig_old, sig_new, 1).replace(req_old, req_new, 1)
-    try:
-        target.write_text(patched, encoding="utf-8")
-    except OSError as exc:
-        log.warning(
-            "_server_patcher: cannot write patched profile args to %s: %s",
-            target, exc,
-        )
-        return False
-    log.info(
-        "_server_patcher: patched %s to forward shape_discovery / "
-        "roofline_annotations to ProfileReq",
-        target,
-    )
-    return True
 
 
 # ---------------------------------------------------------------------

--- a/inference_optimizer/tests/test_server_patcher.py
+++ b/inference_optimizer/tests/test_server_patcher.py
@@ -45,12 +45,21 @@ _FAKE_SGLANG_VERSION = "0.5.9"  # must match one of _SGLANG_SUPPORTED_VERSIONS
 
 def _make_fake_tracelens(tmp_path: Path) -> Path:
     """Build the ``<root>/examples/custom_workflows/inference_analysis/``
-    skeleton the patcher expects to find patches under."""
+    skeleton the patcher expects to find patches under. v0.3.1+ layout:
+    SGLang patches live under per-version subdirs (``sglang_0_5_9/``)."""
     root = tmp_path / "TraceLens-internal"
     base = root / "examples" / "custom_workflows" / "inference_analysis"
     (base / "vllm_patches").mkdir(parents=True)
-    (base / "sglang_roofline_patches").mkdir(parents=True)
+    (
+        base / "sglang_roofline_patches"
+        / _versioned_subdir_for_fake_sglang()
+    ).mkdir(parents=True)
     return root
+
+
+def _versioned_subdir_for_fake_sglang() -> str:
+    """Subdir name TraceLens v0.3.1 ships for ``_FAKE_SGLANG_VERSION``."""
+    return _server_patcher._versioned_patches_subdir_name(_FAKE_SGLANG_VERSION) or ""
 
 
 def _make_fake_vllm_install(tmp_path: Path) -> Path:
@@ -160,7 +169,7 @@ def _make_fake_sglang_install(tmp_path: Path) -> Path:
 def _write_fake_sglang_patches(
     tracelens_root: Path, *, count: int = 1, include_new_file: bool = True,
 ) -> list[Path]:
-    """Write ``count`` minimal patches into the sglang patches dir.
+    """Write ``count`` minimal patches into the v0.3.1 per-version subdir.
 
     The first patch always creates ``kernel_shape_profiler.py``
     (matching the real patch set's sentinel file). Additional patches
@@ -170,6 +179,7 @@ def _write_fake_sglang_patches(
     base = (
         tracelens_root / "examples" / "custom_workflows"
         / "inference_analysis" / "sglang_roofline_patches"
+        / _versioned_subdir_for_fake_sglang()
     )
     patches: list[Path] = []
     if include_new_file:
@@ -421,10 +431,12 @@ def test_sglang_precheck_failure_skips_all(tmp_path, monkeypatch):
     # First patch is fine.
     _write_fake_sglang_patches(tracelens_root, count=1)
     # Add a corrupt patch that won't apply (refers to a file that
-    # doesn't exist in our fake install).
+    # doesn't exist in our fake install). Land it in the per-version
+    # subdir so the simplified resolver sees it.
     bad = (
         tracelens_root / "examples" / "custom_workflows"
-        / "inference_analysis" / "sglang_roofline_patches" / "zzz_bad.patch"
+        / "inference_analysis" / "sglang_roofline_patches"
+        / _versioned_subdir_for_fake_sglang() / "zzz_bad.patch"
     )
     bad.write_text(
         textwrap.dedent(
@@ -1010,56 +1022,6 @@ def test_sglang_plan_keeps_single_marker_sentinel(fake_sglang_world):
     assert plan.sentinel_text == ("kernel_shape_profiler",), plan.sentinel_text
 
 
-def test_sglang_tokenizer_control_profile_args_patch(tmp_path):
-    """SGLang 0.5.11 moved start_profile to tokenizer_control_mixin.py.
-
-    Hyperloom must inject the two TraceLens profile args there or
-    /start_profile rejects PROFILE_EXTRA_BODY before the scheduler sees it.
-    """
-    sglang_pkg = tmp_path / "python" / "sglang"
-    target = sglang_pkg / "srt" / "managers" / "tokenizer_control_mixin.py"
-    target.parent.mkdir(parents=True)
-    target.write_text(
-        textwrap.dedent(
-            """\
-            class TokenizerControlMixin:
-                async def start_profile(
-                    self,
-                    output_dir=None,
-                    profile_prefix: Optional[str] = None,
-                    profile_stages: Optional[List[str]] = None,
-                ):
-                    req = ProfileReq(
-                        profile_prefix=profile_prefix,
-                        profile_stages=profile_stages,
-                    )
-                    return await self._execute_profile(req)
-            """
-        ),
-        encoding="utf-8",
-    )
-    sentinel = sglang_pkg / "srt" / "utils" / "kernel_shape_profiler.py"
-    sentinel.parent.mkdir(parents=True)
-    sentinel.write_text("kernel_shape_profiler", encoding="utf-8")
-    plan = _server_patcher._PatchPlan(
-        framework="sglang",
-        version="0.5.11",
-        apply_root=tmp_path,
-        patches=(),
-        sentinel_file=sentinel,
-        sentinel_text=("kernel_shape_profiler",),
-    )
-
-    assert _server_patcher._ensure_sglang_tokenizer_control_profile_args(plan)
-    text = target.read_text(encoding="utf-8")
-    assert "shape_discovery: bool = False" in text
-    assert "roofline_annotations: bool = False" in text
-    assert "shape_discovery=shape_discovery" in text
-    assert "roofline_annotations=roofline_annotations" in text
-    # Idempotent second call.
-    assert _server_patcher._ensure_sglang_tokenizer_control_profile_args(plan)
-
-
 # ===========================================================================
 # PR-D §5: TraceLens-shipped SUPPORTED_VERSIONS manifest takes precedence
 # over the hardcoded minor allowlist. The day TraceLens starts shipping
@@ -1067,15 +1029,19 @@ def test_sglang_tokenizer_control_profile_args_patch(tmp_path):
 # the decoupling intent of the #194 §5 follow-up recommendation.
 # ===========================================================================
 def _write_sglang_versions_manifest(
-    tracelens_root: Path, body: str, *, filename: str = "SUPPORTED_VERSIONS.txt",
+    tracelens_root: Path, body: str, *,
+    version: str = _FAKE_SGLANG_VERSION,
+    filename: str = "SUPPORTED_VERSIONS.txt",
 ) -> Path:
-    """Write a TraceLens-style version manifest into the SGLang patches
-    dir. Tests use this fixture to simulate TraceLens shipping the
-    decoupling manifest before it actually does."""
+    """Write a TraceLens-style version manifest into the per-version
+    SGLang patches subdir (v0.3.1 layout). The TraceLens-shipped
+    manifest is consulted by ``_sglang_version_accepted``."""
+    subdir = _server_patcher._versioned_patches_subdir_name(version) or ""
     patches_dir = (
         tracelens_root / "examples" / "custom_workflows"
-        / "inference_analysis" / "sglang_roofline_patches"
+        / "inference_analysis" / "sglang_roofline_patches" / subdir
     )
+    patches_dir.mkdir(parents=True, exist_ok=True)
     manifest = patches_dir / filename
     manifest.write_text(body, encoding="utf-8")
     return manifest
@@ -1277,8 +1243,8 @@ def test_sglang_e2e_manifest_admits_version_outside_default_allowlist(
     # injected module and the on-disk __init__.py.
     sgl_init = apply_root / "python" / "sglang" / "__init__.py"
     sgl_init.write_text('__version__ = "0.7.0"\n', encoding="utf-8")
-    _write_fake_sglang_patches(tracelens_root, count=1)
-    _write_sglang_versions_manifest(tracelens_root, "0.7.0\n")
+    _write_versioned_sglang_patches(tracelens_root, "sglang_0_7_0", count=1)
+    _write_sglang_versions_manifest(tracelens_root, "0.7.0\n", version="0.7.0")
 
     fake_mod = types.ModuleType("sglang")
     fake_mod.__version__ = "0.7.0"  # type: ignore[attr-defined]
@@ -1372,59 +1338,36 @@ def test_versioned_patches_subdir_name_helper():
     assert _server_patcher._versioned_patches_subdir_name(None) is None  # type: ignore[arg-type]
 
 
-def test_resolve_sglang_patches_dir_prefers_versioned_subdir(tmp_path):
-    """When ``sglang_0_5_11/`` is present and non-empty, the resolver
-    must return it with ``versioned=True``, ignoring any flat patches
-    at the root."""
+def test_resolve_sglang_patches_dir_returns_versioned_subdir(tmp_path):
+    """The resolver returns the per-version subdir when it exists AND
+    contains at least one ``*.patch`` file."""
     root = tmp_path / "sglang_roofline_patches"
     root.mkdir()
-    # Plant a flat patch to make sure the versioned branch wins anyway.
-    (root / "decoy.patch").write_text("placeholder\n", encoding="utf-8")
     subdir = root / "sglang_0_5_11"
     subdir.mkdir()
     (subdir / "kernel_shape_profiler.patch").write_text("p\n", encoding="utf-8")
-    result = _server_patcher._resolve_sglang_patches_dir(root, "0.5.11")
-    assert result is not None
-    patches_dir, versioned = result
-    assert patches_dir == subdir
-    assert versioned is True
+    assert (
+        _server_patcher._resolve_sglang_patches_dir(root, "0.5.11") == subdir
+    )
 
 
-def test_resolve_sglang_patches_dir_falls_back_to_flat(tmp_path):
-    """v0.3 checkouts have flat ``*.patch`` at the root and no
-    versioned subdirs — the resolver must return the root with
-    ``versioned=False`` so the legacy optional-skip shim runs."""
+def test_resolve_sglang_patches_dir_returns_none_when_subdir_missing(tmp_path):
+    """No ``sglang_0_5_11/`` subdir → ``None`` (flat layout is no longer
+    supported; users must upgrade to Hyperloom_integration_v0.3.1+)."""
     root = tmp_path / "sglang_roofline_patches"
     root.mkdir()
-    (root / "kernel_shape_profiler.patch").write_text("p\n", encoding="utf-8")
-    result = _server_patcher._resolve_sglang_patches_dir(root, "0.5.11")
-    assert result is not None
-    patches_dir, versioned = result
-    assert patches_dir == root
-    assert versioned is False
-
-
-def test_resolve_sglang_patches_dir_returns_none_when_empty(tmp_path):
-    """Neither versioned subdir nor flat *.patch at root → None.
-    Caller then logs + skips patching entirely."""
-    root = tmp_path / "sglang_roofline_patches"
-    root.mkdir()
-    (root / "sglang_0_5_11").mkdir()  # subdir exists but is empty
+    # Even with a flat *.patch present, the simplified resolver ignores
+    # it and reports no patches available.
+    (root / "decoy.patch").write_text("placeholder\n", encoding="utf-8")
     assert _server_patcher._resolve_sglang_patches_dir(root, "0.5.11") is None
 
 
-def test_resolve_sglang_patches_dir_skips_empty_versioned_subdir(tmp_path):
-    """An empty ``sglang_0_5_11/`` must not shadow the flat fallback
-    when flat patches actually exist at the root."""
+def test_resolve_sglang_patches_dir_returns_none_when_subdir_empty(tmp_path):
+    """An empty ``sglang_0_5_11/`` is not a valid patch set."""
     root = tmp_path / "sglang_roofline_patches"
     root.mkdir()
     (root / "sglang_0_5_11").mkdir()
-    (root / "kernel_shape_profiler.patch").write_text("p\n", encoding="utf-8")
-    result = _server_patcher._resolve_sglang_patches_dir(root, "0.5.11")
-    assert result is not None
-    patches_dir, versioned = result
-    assert patches_dir == root
-    assert versioned is False
+    assert _server_patcher._resolve_sglang_patches_dir(root, "0.5.11") is None
 
 
 @_REQUIRES_GIT
@@ -1478,69 +1421,3 @@ def test_discover_sglang_plan_marks_versioned_layout(tmp_path, monkeypatch):
             f"versioned layout should be selected, got patch path {p}"
         )
 
-
-@_REQUIRES_GIT
-def test_sglang_versioned_layout_does_not_filter_optional(tmp_path, monkeypatch):
-    """Under the versioned layout the patcher must NOT drop a patch
-    just because its target file is absent on disk — v0.3.1 ships
-    a complete per-version set, so a missing target indicates a
-    deployment problem, not a "skip-and-continue" case."""
-    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_ALLOWED_MINORS", raising=False)
-    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_EXACT_VERSIONS", raising=False)
-    tracelens_root = _make_fake_tracelens(tmp_path)
-    apply_root = _make_fake_sglang_install(tmp_path)
-    sgl_init = apply_root / "python" / "sglang" / "__init__.py"
-    sgl_init.write_text('__version__ = "0.5.11"\n', encoding="utf-8")
-    # Land a benign patch + a patch named like one of the v0.3 optional
-    # entries. Under flat fallback the latter would be dropped because
-    # its target doesn't exist; under versioned it must stay in the set.
-    versioned_dir = (
-        tracelens_root / "examples" / "custom_workflows"
-        / "inference_analysis" / "sglang_roofline_patches" / "sglang_0_5_11"
-    )
-    versioned_dir.mkdir(parents=True)
-    (versioned_dir / "kernel_shape_profiler.patch").write_text(
-        textwrap.dedent(
-            """\
-            diff --git a/python/sglang/srt/utils/kernel_shape_profiler.py b/python/sglang/srt/utils/kernel_shape_profiler.py
-            new file mode 100644
-            index 000000000..1111111
-            --- /dev/null
-            +++ b/python/sglang/srt/utils/kernel_shape_profiler.py
-            @@ -0,0 +1,1 @@
-            +# kernel_shape_profiler stub
-            """
-        ),
-        encoding="utf-8",
-    )
-    # Name matches the legacy optional list; target is a file path that
-    # would not be present in the synthetic install. Versioned branch
-    # should keep this patch in the set, so the plan must contain it.
-    (versioned_dir / "fused_moe_triton_kernels.patch").write_text(
-        textwrap.dedent(
-            """\
-            diff --git a/python/sglang/srt/utils/extra_marker.py b/python/sglang/srt/utils/extra_marker.py
-            new file mode 100644
-            index 000000000..3333333
-            --- /dev/null
-            +++ b/python/sglang/srt/utils/extra_marker.py
-            @@ -0,0 +1,1 @@
-            +# extra marker stub
-            """
-        ),
-        encoding="utf-8",
-    )
-
-    fake_mod = types.ModuleType("sglang")
-    fake_mod.__version__ = "0.5.11"  # type: ignore[attr-defined]
-    fake_mod.__file__ = str(sgl_init)  # type: ignore[attr-defined]
-    monkeypatch.setitem(sys.modules, "sglang", fake_mod)
-    monkeypatch.setenv("TRACELENS_ROOT", str(tracelens_root))
-
-    plan = _server_patcher._discover_sglang_plan(None)
-    assert plan is not None
-    patch_names = {p.name for p in plan.patches}
-    assert "fused_moe_triton_kernels.patch" in patch_names, (
-        "versioned layout must not drop patches by name even when the "
-        "legacy optional_missing dict would have"
-    )

--- a/inference_optimizer/tests/test_server_patcher.py
+++ b/inference_optimizer/tests/test_server_patcher.py
@@ -1265,11 +1265,11 @@ def test_sglang_e2e_manifest_admits_version_outside_default_allowlist(
 
 # ===========================================================================
 # TraceLens Hyperloom_integration_v0.3.1: per-version patch subdirs
-# (sglang_0_5_9/, sglang_0_5_11/, ...) replace the previous flat
-# sglang_roofline_patches/*.patch layout. Hyperloom must resolve the
-# correct subdir for the running sglang version and stop applying the
-# v0.3 ``optional_missing`` shim once the upstream per-version set is
-# in use (since the per-version set is authored against that release).
+# (sglang_0_5_9/, sglang_0_5_11/, ...) are the only layout Hyperloom
+# supports. The previous flat sglang_roofline_patches/*.patch v0.3
+# layout has been retired together with its legacy optional_missing
+# shim; the per-version subdir is authored against the matching sglang
+# release, so every patch in it is required.
 # ===========================================================================
 def _write_versioned_sglang_patches(
     tracelens_root: Path, subdir: str, *, count: int = 1,
@@ -1373,8 +1373,8 @@ def test_resolve_sglang_patches_dir_returns_none_when_subdir_empty(tmp_path):
 @_REQUIRES_GIT
 def test_sglang_e2e_versioned_layout_applies_from_subdir(tmp_path, monkeypatch):
     """End-to-end: sglang 0.5.11 + a TraceLens checkout that ships
-    ``sglang_roofline_patches/sglang_0_5_11/`` (no flat fallback). The
-    patcher must pick the versioned subdir and apply its patches."""
+    ``sglang_roofline_patches/sglang_0_5_11/``. The patcher must
+    resolve the per-version subdir and apply every patch in it."""
     tracelens_root = _make_fake_tracelens(tmp_path)
     apply_root = _make_fake_sglang_install(tmp_path)
     sgl_init = apply_root / "python" / "sglang" / "__init__.py"
@@ -1399,9 +1399,8 @@ def test_sglang_e2e_versioned_layout_applies_from_subdir(tmp_path, monkeypatch):
 
 def test_discover_sglang_plan_marks_versioned_layout(tmp_path, monkeypatch):
     """The discovered ``_PatchPlan``'s patches must point inside the
-    versioned subdir when that layout is present — guards against
-    accidentally regressing to flat resolution and double-checks that
-    versioned discovery short-circuits before flat is even consulted."""
+    per-version subdir — guards against any regression that would
+    resolve patches outside ``sglang_<minor>_<patch>/``."""
     tracelens_root = _make_fake_tracelens(tmp_path)
     apply_root = _make_fake_sglang_install(tmp_path)
     sgl_init = apply_root / "python" / "sglang" / "__init__.py"

--- a/inference_optimizer/tests/test_server_patcher.py
+++ b/inference_optimizer/tests/test_server_patcher.py
@@ -1295,3 +1295,252 @@ def test_sglang_e2e_manifest_admits_version_outside_default_allowlist(
         "0.7.0 should have been patched because the manifest admits it — "
         "the default 0.5.x allowlist alone would have rejected"
     )
+
+
+# ===========================================================================
+# TraceLens Hyperloom_integration_v0.3.1: per-version patch subdirs
+# (sglang_0_5_9/, sglang_0_5_11/, ...) replace the previous flat
+# sglang_roofline_patches/*.patch layout. Hyperloom must resolve the
+# correct subdir for the running sglang version and stop applying the
+# v0.3 ``optional_missing`` shim once the upstream per-version set is
+# in use (since the per-version set is authored against that release).
+# ===========================================================================
+def _write_versioned_sglang_patches(
+    tracelens_root: Path, subdir: str, *, count: int = 1,
+) -> list[Path]:
+    """Write minimal v0.3.1-style patches into a per-version subdir.
+    Reuses the flat-layout fixture body but lands under
+    ``sglang_roofline_patches/<subdir>/`` rather than the root."""
+    base = (
+        tracelens_root / "examples" / "custom_workflows"
+        / "inference_analysis" / "sglang_roofline_patches" / subdir
+    )
+    base.mkdir(parents=True, exist_ok=True)
+    patches: list[Path] = []
+    p1 = base / "kernel_shape_profiler.patch"
+    p1.write_text(
+        textwrap.dedent(
+            """\
+            diff --git a/python/sglang/srt/utils/kernel_shape_profiler.py b/python/sglang/srt/utils/kernel_shape_profiler.py
+            new file mode 100644
+            index 000000000..1111111
+            --- /dev/null
+            +++ b/python/sglang/srt/utils/kernel_shape_profiler.py
+            @@ -0,0 +1,3 @@
+            +# kernel_shape_profiler stub — TraceLens patch fixture.
+            +def hello():
+            +    return "kernel_shape_profiler"
+            """
+        ),
+        encoding="utf-8",
+    )
+    patches.append(p1)
+    for i in range(len(patches), count):
+        p = base / f"misc_{i}.patch"
+        target = f"python/sglang/srt/utils/extra_{i}.py"
+        p.write_text(
+            textwrap.dedent(
+                f"""\
+                diff --git a/{target} b/{target}
+                new file mode 100644
+                index 000000000..2222222
+                --- /dev/null
+                +++ b/{target}
+                @@ -0,0 +1 @@
+                +# extra_{i} stub
+                """
+            ),
+            encoding="utf-8",
+        )
+        patches.append(p)
+    return patches
+
+
+def test_versioned_patches_subdir_name_helper():
+    """Dotted numeric versions map to ``sglang_<underscored>`` subdir
+    names; non-numeric or empty inputs return None so the caller
+    fail-softs to the flat layout."""
+    assert _server_patcher._versioned_patches_subdir_name("0.5.11") == "sglang_0_5_11"
+    assert _server_patcher._versioned_patches_subdir_name("0.5.9") == "sglang_0_5_9"
+    assert _server_patcher._versioned_patches_subdir_name("1.2.3.4") == "sglang_1_2_3_4"
+    # Dev / rc / local suffixes are stripped to the numeric head.
+    assert _server_patcher._versioned_patches_subdir_name("0.5.11-rc1") == "sglang_0_5_11"
+    assert _server_patcher._versioned_patches_subdir_name("0.5.11+local") == "sglang_0_5_11"
+    # Bad input → None (caller falls back to flat).
+    assert _server_patcher._versioned_patches_subdir_name("") is None
+    assert _server_patcher._versioned_patches_subdir_name("not-a-version") is None
+    assert _server_patcher._versioned_patches_subdir_name(None) is None  # type: ignore[arg-type]
+
+
+def test_resolve_sglang_patches_dir_prefers_versioned_subdir(tmp_path):
+    """When ``sglang_0_5_11/`` is present and non-empty, the resolver
+    must return it with ``versioned=True``, ignoring any flat patches
+    at the root."""
+    root = tmp_path / "sglang_roofline_patches"
+    root.mkdir()
+    # Plant a flat patch to make sure the versioned branch wins anyway.
+    (root / "decoy.patch").write_text("placeholder\n", encoding="utf-8")
+    subdir = root / "sglang_0_5_11"
+    subdir.mkdir()
+    (subdir / "kernel_shape_profiler.patch").write_text("p\n", encoding="utf-8")
+    result = _server_patcher._resolve_sglang_patches_dir(root, "0.5.11")
+    assert result is not None
+    patches_dir, versioned = result
+    assert patches_dir == subdir
+    assert versioned is True
+
+
+def test_resolve_sglang_patches_dir_falls_back_to_flat(tmp_path):
+    """v0.3 checkouts have flat ``*.patch`` at the root and no
+    versioned subdirs — the resolver must return the root with
+    ``versioned=False`` so the legacy optional-skip shim runs."""
+    root = tmp_path / "sglang_roofline_patches"
+    root.mkdir()
+    (root / "kernel_shape_profiler.patch").write_text("p\n", encoding="utf-8")
+    result = _server_patcher._resolve_sglang_patches_dir(root, "0.5.11")
+    assert result is not None
+    patches_dir, versioned = result
+    assert patches_dir == root
+    assert versioned is False
+
+
+def test_resolve_sglang_patches_dir_returns_none_when_empty(tmp_path):
+    """Neither versioned subdir nor flat *.patch at root → None.
+    Caller then logs + skips patching entirely."""
+    root = tmp_path / "sglang_roofline_patches"
+    root.mkdir()
+    (root / "sglang_0_5_11").mkdir()  # subdir exists but is empty
+    assert _server_patcher._resolve_sglang_patches_dir(root, "0.5.11") is None
+
+
+def test_resolve_sglang_patches_dir_skips_empty_versioned_subdir(tmp_path):
+    """An empty ``sglang_0_5_11/`` must not shadow the flat fallback
+    when flat patches actually exist at the root."""
+    root = tmp_path / "sglang_roofline_patches"
+    root.mkdir()
+    (root / "sglang_0_5_11").mkdir()
+    (root / "kernel_shape_profiler.patch").write_text("p\n", encoding="utf-8")
+    result = _server_patcher._resolve_sglang_patches_dir(root, "0.5.11")
+    assert result is not None
+    patches_dir, versioned = result
+    assert patches_dir == root
+    assert versioned is False
+
+
+@_REQUIRES_GIT
+def test_sglang_e2e_versioned_layout_applies_from_subdir(tmp_path, monkeypatch):
+    """End-to-end: sglang 0.5.11 + a TraceLens checkout that ships
+    ``sglang_roofline_patches/sglang_0_5_11/`` (no flat fallback). The
+    patcher must pick the versioned subdir and apply its patches."""
+    tracelens_root = _make_fake_tracelens(tmp_path)
+    apply_root = _make_fake_sglang_install(tmp_path)
+    sgl_init = apply_root / "python" / "sglang" / "__init__.py"
+    sgl_init.write_text('__version__ = "0.5.11"\n', encoding="utf-8")
+    _write_versioned_sglang_patches(tracelens_root, "sglang_0_5_11", count=1)
+
+    fake_mod = types.ModuleType("sglang")
+    fake_mod.__version__ = "0.5.11"  # type: ignore[attr-defined]
+    fake_mod.__file__ = str(sgl_init)  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "sglang", fake_mod)
+    monkeypatch.setenv("TRACELENS_ROOT", str(tracelens_root))
+
+    assert ensure_sglang_patched_for_tracelens() is True
+    sentinel = (
+        apply_root / "python" / "sglang" / "srt" / "utils"
+        / "kernel_shape_profiler.py"
+    )
+    assert sentinel.exists(), (
+        "0.5.11 should pick sglang_0_5_11/ subdir and apply its patches"
+    )
+
+
+def test_discover_sglang_plan_marks_versioned_layout(tmp_path, monkeypatch):
+    """The discovered ``_PatchPlan``'s patches must point inside the
+    versioned subdir when that layout is present — guards against
+    accidentally regressing to flat resolution and double-checks that
+    versioned discovery short-circuits before flat is even consulted."""
+    tracelens_root = _make_fake_tracelens(tmp_path)
+    apply_root = _make_fake_sglang_install(tmp_path)
+    sgl_init = apply_root / "python" / "sglang" / "__init__.py"
+    sgl_init.write_text('__version__ = "0.5.11"\n', encoding="utf-8")
+    _write_versioned_sglang_patches(tracelens_root, "sglang_0_5_11", count=1)
+
+    fake_mod = types.ModuleType("sglang")
+    fake_mod.__version__ = "0.5.11"  # type: ignore[attr-defined]
+    fake_mod.__file__ = str(sgl_init)  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "sglang", fake_mod)
+    monkeypatch.setenv("TRACELENS_ROOT", str(tracelens_root))
+
+    plan = _server_patcher._discover_sglang_plan(None)
+    assert plan is not None
+    for p in plan.patches:
+        assert "sglang_0_5_11" in p.parts, (
+            f"versioned layout should be selected, got patch path {p}"
+        )
+
+
+@_REQUIRES_GIT
+def test_sglang_versioned_layout_does_not_filter_optional(tmp_path, monkeypatch):
+    """Under the versioned layout the patcher must NOT drop a patch
+    just because its target file is absent on disk — v0.3.1 ships
+    a complete per-version set, so a missing target indicates a
+    deployment problem, not a "skip-and-continue" case."""
+    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_ALLOWED_MINORS", raising=False)
+    monkeypatch.delenv("HYPERLOOM_SGLANG_PATCH_EXACT_VERSIONS", raising=False)
+    tracelens_root = _make_fake_tracelens(tmp_path)
+    apply_root = _make_fake_sglang_install(tmp_path)
+    sgl_init = apply_root / "python" / "sglang" / "__init__.py"
+    sgl_init.write_text('__version__ = "0.5.11"\n', encoding="utf-8")
+    # Land a benign patch + a patch named like one of the v0.3 optional
+    # entries. Under flat fallback the latter would be dropped because
+    # its target doesn't exist; under versioned it must stay in the set.
+    versioned_dir = (
+        tracelens_root / "examples" / "custom_workflows"
+        / "inference_analysis" / "sglang_roofline_patches" / "sglang_0_5_11"
+    )
+    versioned_dir.mkdir(parents=True)
+    (versioned_dir / "kernel_shape_profiler.patch").write_text(
+        textwrap.dedent(
+            """\
+            diff --git a/python/sglang/srt/utils/kernel_shape_profiler.py b/python/sglang/srt/utils/kernel_shape_profiler.py
+            new file mode 100644
+            index 000000000..1111111
+            --- /dev/null
+            +++ b/python/sglang/srt/utils/kernel_shape_profiler.py
+            @@ -0,0 +1,1 @@
+            +# kernel_shape_profiler stub
+            """
+        ),
+        encoding="utf-8",
+    )
+    # Name matches the legacy optional list; target is a file path that
+    # would not be present in the synthetic install. Versioned branch
+    # should keep this patch in the set, so the plan must contain it.
+    (versioned_dir / "fused_moe_triton_kernels.patch").write_text(
+        textwrap.dedent(
+            """\
+            diff --git a/python/sglang/srt/utils/extra_marker.py b/python/sglang/srt/utils/extra_marker.py
+            new file mode 100644
+            index 000000000..3333333
+            --- /dev/null
+            +++ b/python/sglang/srt/utils/extra_marker.py
+            @@ -0,0 +1,1 @@
+            +# extra marker stub
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    fake_mod = types.ModuleType("sglang")
+    fake_mod.__version__ = "0.5.11"  # type: ignore[attr-defined]
+    fake_mod.__file__ = str(sgl_init)  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "sglang", fake_mod)
+    monkeypatch.setenv("TRACELENS_ROOT", str(tracelens_root))
+
+    plan = _server_patcher._discover_sglang_plan(None)
+    assert plan is not None
+    patch_names = {p.name for p in plan.patches}
+    assert "fused_moe_triton_kernels.patch" in patch_names, (
+        "versioned layout must not drop patches by name even when the "
+        "legacy optional_missing dict would have"
+    )

--- a/kernel-agent/scripts/install.sh
+++ b/kernel-agent/scripts/install.sh
@@ -64,6 +64,10 @@ _resolve_magpie_python() {
 MAGPIE_PYTHON="$(_resolve_magpie_python)"
 PYTHONPATH="${MAGPIE_DIR}:${PYTHONPATH:-}"
 INFERENCEX_PATH="${INFERENCEX_PATH:-}"
+# TraceLens checkout root. Expected to point at a checkout of the
+# AMD-AGI/TraceLens-internal repo at tag `Hyperloom_integration_v0.3.1`
+# (or newer release/hyperloom_integration_v0.3.1 branch). Older v0.3
+# flat-layout checkouts still work via _server_patcher backward-compat.
 TRACELENS_ROOT="${TRACELENS_ROOT:-/wekafs/hyperloom/TraceLens-internal}"
 # Writable mirror for TraceLens when $TRACELENS_ROOT is on a read-only mount
 # (e.g. /wekafs/...). Mirrors the OOB pattern: cp -r the read-only source into

--- a/kernel-agent/scripts/install.sh
+++ b/kernel-agent/scripts/install.sh
@@ -64,10 +64,11 @@ _resolve_magpie_python() {
 MAGPIE_PYTHON="$(_resolve_magpie_python)"
 PYTHONPATH="${MAGPIE_DIR}:${PYTHONPATH:-}"
 INFERENCEX_PATH="${INFERENCEX_PATH:-}"
-# TraceLens checkout root. Expected to point at a checkout of the
+# TraceLens checkout root. MUST point at a checkout of the
 # AMD-AGI/TraceLens-internal repo at tag `Hyperloom_integration_v0.3.1`
-# (or newer release/hyperloom_integration_v0.3.1 branch). Older v0.3
-# flat-layout checkouts still work via _server_patcher backward-compat.
+# or newer (release/hyperloom_integration_v0.3.1 branch). The per-version
+# sglang_roofline_patches/sglang_<minor>_<patch>/ layout is required by
+# _server_patcher; pre-v0.3.1 flat checkouts are no longer supported.
 TRACELENS_ROOT="${TRACELENS_ROOT:-/wekafs/hyperloom/TraceLens-internal}"
 # Writable mirror for TraceLens when $TRACELENS_ROOT is on a read-only mount
 # (e.g. /wekafs/...). Mirrors the OOB pattern: cp -r the read-only source into


### PR DESCRIPTION
TraceLens Hyperloom_integration_v0.3.1 (AMD-AGI/TraceLens-internal#441)
reorganised `sglang_roofline_patches/` into per-version subdirs
(`sglang_0_5_9/`, `sglang_0_5_11/`, ...) and shipped the SGLang 0.5.11
patches Hyperloom previously worked around in d677492 via the
`optional_missing` shim plus the in-tree `tokenizer_control_mixin`
compat patch.

The previous flat-glob discovery in `_server_patcher` silently skips
SGLang patching when `TRACELENS_ROOT` points at v0.3.1:
`patches_dir.glob("*.patch")` returns 0 because the `*.patch` files
now live one level deeper. That breaks the profile phase end-to-end —
SGLang server starts without the TraceLens flags, torch.profiler emits
unannotated traces, and `select_kernels` raises
`trace_split_no_steady_state`.

The PR also retires the v0.3 flat-layout workaround entirely (split
across an initial `fix` + a follow-up `refactor` commit so reviewers
can see the design evolution):

- the `optional_missing` shim that skipped 2 missing patches on 0.5.11
- the in-tree `_ensure_sglang_tokenizer_control_profile_args` compat
  function that hand-patched `tokenizer_control_mixin.py`
- the `versioned_layout` boolean threading through the planner

Upstream `sglang_0_5_11/...patch` files in v0.3.1 supersede all three.

⚠ **Breaking**: Pre-v0.3.1 flat checkouts of TraceLens are no longer
supported. Operators must `git fetch && git checkout
Hyperloom_integration_v0.3.1` on `$TRACELENS_ROOT` before deploying
this Hyperloom version.

## Changes

`_server_patcher.py`:

- Add `_versioned_patches_subdir_name`: `'0.5.11'` -> `'sglang_0_5_11'`
  with dev/rc/local suffix tolerance (`'0.5.11-rc1'` -> `'sglang_0_5_11'`).
- Add `_resolve_sglang_patches_dir`: returns the matching per-version
  subdir or `None` when it's missing/empty (fail-soft).
- `_discover_sglang_plan` is now a single straight-line path — no
  `versioned_layout` branching, no `optional_missing` filtering.
- Remove `_ensure_sglang_tokenizer_control_profile_args` (72 lines).
  v0.3.1's `sglang_0_5_11/tokenizer_communicator_mixin.patch` targets
  `tokenizer_control_mixin.py` with the same `shape_discovery` /
  `roofline_annotations` fields the shim used to inject.
- `ensure_sglang_patched_for_tracelens` collapses to
  `_ensure_patched(plan)` (no shim chain).

`tests/test_server_patcher.py`: 51 tests; fixtures land patches in the
per-version subdir derived from `_FAKE_SGLANG_VERSION`. Obsolete tests
(flat-fallback resolver path, tokenizer_control_mixin shim,
versioned-layout-bypasses-optional-filtering) are removed.

`README.md`, `inference_optimizer/SKILL.md`,
`kernel-agent/scripts/install.sh`: bump `$TRACELENS_ROOT` requirement
to `Hyperloom_integration_v0.3.1`.

## Validation

- `pytest test_server_patcher.py`: **51/51 pass**.
- `pytest test_p2_2_profile_and_handlers + test_p0_3_coordinator +
  test_p2_4_integrate_report` regression: **103/103 pass** (62 async
  skipped, pre-existing pytest-asyncio gap).
- L3 plan resolution (real `/sgl-workspace/sglang@v0.5.11` +
  `/wekafs/shuoshuo/TraceLens-internal-v0.3.1`):
  `_discover_sglang_plan` returns 10 patches all under
  `sglang_0_5_11/`, `apply_root=/sgl-workspace/sglang`, `-p1`.
- `git apply --check` dry-run: **10/10 OK** against sglang v0.5.11.
- **Fresh-apply e2e** (Qwen3-32B / MI300X / TP=8): profile phase
  logged `_server_patcher: applied 10 TraceLens patch(es) for sglang
  0.5.11 (strict=10, fuzzy=0)` — verified once on the initial PR
  revision and a second time after the simplification.
- **Idempotency e2e** (subsequent resume on already-patched sglang):
  sentinel check short-circuited, no re-apply, no fuzzy fallback.
- **Full TraceLens pipeline e2e (11h run)**: produced `analysis.md`
  (188 KB, LLM-synthesised summary), `kernel_candidates.json` with 5
  hot kernels (`k001`/`k002` `aten::mm` skipped — `source_file` not
  resolved; `k003`-`k005` `aiter::rmsnorm` `reusable=python` pointing
  at `/sgl-workspace/aiter/aiter/ops/rmsnorm.py`), and triggered
  downstream GEAK with 9 optimization attempts across
  `geak`/`claude`/`codex` backends.
- Standalone TraceLens splitter on the resulting trace: 255
  steady-state steps -> mixed/decode_only/prefilldecode chunks.
- Standalone `TraceLens_generate_perf_report_pytorch_inference`: 1213
  GPU events accounted; GEMM/RMSNorm/CustomCollective category reports
  produced.

## Pre-merge checklist

- [ ] `/wekafs/hyperloom/TraceLens-internal` checked out at
      `Hyperloom_integration_v0.3.1` tag (operator-driven; coordinate
      via email thread w/ @tsrikris and @mohbasit re: #210)

## Refs

- Resolve this issue #255 (per @mohbasit's request to consume TraceLens v0.3.1)
- AMD-AGI/TraceLens-internal#441 (new set of sglang patches —
  `patch/update_sglang`, `Hyperloom_integration_v0.3.1`)
- Per email thread w/ @tsrikris and @mohbasit re: Profiling Fix:
  InferenceX in HyperLoom #210
- Hyperloom d677492 (v0.3 workaround fully retired)

## CC

@xiaofei-zheng (original `_server_patcher.py` author),
@tsrikris, @mohbasit