### PR TITLE
fix(storage): use synchronous=FULL to prevent coordinator.db corrupti…

### DIFF
--- a/inference_optimizer/storage/connection.py
+++ b/inference_optimizer/storage/connection.py
@@ -3,7 +3,8 @@
 Design choices:
 
 * Pure stdlib ``sqlite3`` — no extra dependency
-* Mode = WAL with ``synchronous=NORMAL`` and ``busy_timeout=30s``
+* Mode = WAL with ``synchronous=FULL`` and ``busy_timeout=30s``
+  (``FULL`` keeps writes crash-safe across WAL checkpoints; see issue #242)
 * Async surface uses ``asyncio.to_thread`` so the rest of the codebase can
   ``await`` calls without rewiring; SQLite ops are short and IO-bound, so
   the thread-hop is negligible compared to actual I/O
@@ -28,7 +29,7 @@ from .schema import ensure_schema
 
 _PRAGMAS = (
     "PRAGMA journal_mode = WAL",
-    "PRAGMA synchronous = NORMAL",
+    "PRAGMA synchronous = FULL",
     "PRAGMA foreign_keys = ON",
     "PRAGMA busy_timeout = 30000",
     "PRAGMA temp_store = MEMORY",


### PR DESCRIPTION
#242 SQLite DB corruption during long optimization runs 

The coordinator's SQLite DB could corrupt during long optimization runs (observed at ~5h and ~17h in a 24h Qwen3-8B run on MI325X). With WAL + synchronous=NORMAL, a process crash during a WAL checkpoint can leave the DB in a broken state, requiring manual deletion of coordinator.db* and a restart.

Switch to synchronous=FULL so every commit is fsync'd. Writes become crash-safe across checkpoints at the cost of slightly slower DB ops, which is negligible for our ~30s write cadence.