### PR TITLE
ci: persist session_breakdown.json alongside ci_metrics + optimization_report

### DIFF
--- a/.github/workflows/inference-optimization-ci.yml
+++ b/.github/workflows/inference-optimization-ci.yml
@@ -61,6 +61,7 @@ jobs:
           SCRIPT="$GITHUB_WORKSPACE/inference_optimization/InferenceX/utils/check_image_versions.py"
           for INFERENCEX_CONFIG in \
             "${NFS_ROOT}/InferenceX/.github/configs/amd-master.yaml" \
+            /wekafs/hyperloom/InferenceX/.github/configs/amd-master.yaml \
             /wekafs/InferenceX/.github/configs/amd-master.yaml \
             /hyperloom/InferenceX/.github/configs/amd-master.yaml; do
             if [ -f "$INFERENCEX_CONFIG" ]; then

--- a/.github/workflows/optimize-submit.yml
+++ b/.github/workflows/optimize-submit.yml
@@ -139,6 +139,7 @@ on:
             $RESULT_DIR/optimization_report.md
             $RESULT_DIR/ci_metrics.json
               {"baseline_throughput": <float>, "optimized_throughput": <float>, "gain_pct": <float>, "tok_per_gpu_baseline": <float>, "tok_per_gpu_optimized": <float>, "actions_taken": ["..."]}
+            $RESULT_DIR/session_breakdown.json   (optional but recommended — emitted by inference_optimizer; preserved alongside the two contract files for post-run audit)
 
           If the pipeline aborts (kernel apply failed / server failed to start / optimization tooling crash):
           - Set optimized_throughput = baseline_throughput, gain_pct = 0.0.
@@ -209,6 +210,7 @@ on:
               mkdir -p "$PERSIST_DIR"
               cp -f "$RESULT_DIR/ci_metrics.json"          "$PERSIST_DIR/ci_metrics.json"         2>/dev/null && echo "[PERSIST] $PERSIST_DIR/ci_metrics.json"
               cp -f "$RESULT_DIR/optimization_report.md"  "$PERSIST_DIR/optimization_report.md"  2>/dev/null && echo "[PERSIST] $PERSIST_DIR/optimization_report.md"
+              cp -f "$RESULT_DIR/session_breakdown.json"  "$PERSIST_DIR/session_breakdown.json"  2>/dev/null && echo "[PERSIST] $PERSIST_DIR/session_breakdown.json"
               ls -la "$PERSIST_DIR/"
             else
               echo "[ERR] /hyperloom/users/<uid>/ not mounted — cannot persist to wekafs"

--- a/ci/optimize_submit.py
+++ b/ci/optimize_submit.py
@@ -1125,6 +1125,12 @@ def process_model(
 DEFAULT_ARTIFACT_PATTERNS = (
     "optimization_report",   # matches optimization_report.md / *-optimization_report.md / etc.
     "ci_metrics.json",
+    # Optional but recommended audit artifact emitted by inference_optimizer
+    # (and consumed by claw-stats-service / the dashboard). Not part of the
+    # key-results gate in ``_KEY_RESULT_SUFFIXES`` — missing it must not
+    # trigger NFS fallback or retries — but we still want it copied when
+    # the agent / skill emits it.
+    "session_breakdown.json",
     "baseline_summary.json",
     "sweep_results.csv",
     "sweep_results.txt",
@@ -1421,6 +1427,14 @@ def _nfs_fallback_collect(rec: SubmissionRecord, artifacts_dir: Path) -> int:
         os.path.join(best_sess, "optimization_report.md"),
         os.path.join(best_sess, "phase10_report", "optimization_report.md"),
         os.path.join(best_sess, "reports", "final.md"),
+    ]:
+        if os.path.isfile(cand):
+            targets.append(cand)
+            break
+    # Optional audit artifact — pull it back when the agent emitted it.
+    for cand in [
+        os.path.join(best_sess, "session_breakdown.json"),
+        os.path.join(best_sess, "phase10_report", "session_breakdown.json"),
     ]:
         if os.path.isfile(cand):
             targets.append(cand)

--- a/ci/orchestrator.py
+++ b/ci/orchestrator.py
@@ -344,7 +344,15 @@ def run_model(
     # No sleep here — sandbox is already gone after session ends; download immediately.
     report_content = None
     os.makedirs(result_dir, exist_ok=True)
-    download_suffixes = ("optimization_report.md", "ci_metrics.json")
+    # session_breakdown.json is the V2 dashboard contract emitted by
+    # inference_optimizer/cli.py's finally block (or manually written by the
+    # agent when running a non-cli pipeline). claw-stats-service prefers it
+    # over ci_metrics.json, so we pull it back here when present.
+    download_suffixes = (
+        "optimization_report.md",
+        "ci_metrics.json",
+        "session_breakdown.json",
+    )
 
     # 3a. Try Claw file API (sandbox /workspace)
     try:


### PR DESCRIPTION
## Summary
- Mention `session_breakdown.json` in the Required Artifacts block of the
  optimize prompt so the agent reliably emits it (marked optional —
  `ci_metrics.json` + `optimization_report.md` remain the only two files
  in the SaFE success contract).
- Add a matching `cp -f` line in the POST-PIPELINE PERSIST snippet so the
  breakdown lands in `/hyperloom/users/<uid>/<task>-opt/` next to the
  other two artifacts — otherwise it gets cleaned up with the sandbox.

## Why
`inference_optimizer` writes a third audit artifact, `session_breakdown.json`,
covering per-phase timing/decisions/promotion sources. Until now it only
existed inside the sandbox-ephemeral `\`; the persist block at
the end of the prompt only copied `ci_metrics.json` and
`optimization_report.md` to the wekafs RW mount, so the breakdown was
lost as soon as the sandbox was reaped. Persisting it gives us the same
post-run audit trail we already get for the other two files.

## Test plan
- [ ] Manually dispatch `optimize-submit.yml` against a small model and
      confirm `session_breakdown.json` shows up under
      `/hyperloom/users/<uid>/<task>-opt/` together with the other two
      files.
- [ ] No-op for skill runs that don't emit `session_breakdown.json` —
      the `2>/dev/null` keeps `cp` quiet and `[PERSIST]` log line
      stays absent.

Made with [Cursor](https://cursor.com)