### PR TITLE
fix(coordinator): drop validate_stack gate after 10 consecutive failu…

### DIFF
--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -111,6 +111,7 @@ _BASELINE_FINGERPRINT_KEYS: tuple[str, ...] = (
     "disable_run_eval",
 )
 _BASELINE_SELF_LOOP_THRESHOLD: int = 2
+_VALIDATE_STACK_FAIL_THRESHOLD: int = 10
 
 
 def effective_closing_grace_sec(
@@ -268,6 +269,7 @@ class Coordinator:
         self.state = CoordinatorState()
         self._stop = asyncio.Event()
         self._tasks_running: list[asyncio.Task] = []
+        self._validate_stack_gate_skip_warned: bool = False
 
         # Stable tick order derived from the live role_registry. Must NOT
         # use the module-level `roles_for_run()` which is a cached hardcoded
@@ -1290,6 +1292,20 @@ class Coordinator:
                     "explore."
                 )
         if self.shared_state.optimization_stack_has_unvalidated_keeps():
+            if self._validate_stack_gate_skipped():
+                return (
+                    "TODO 5/5: validate_stack RECOMMENDED but not required. "
+                    f"The last {_VALIDATE_STACK_FAIL_THRESHOLD} validate_stack "
+                    "attempts failed in a row, so the mandatory gate is "
+                    "dropped and other actions are unlocked. "
+                    "cumulative_gain_validated will stay stale "
+                    f"(validated_at_len="
+                    f"{self.shared_state.cumulative_gain_validated_stack_len} "
+                    f"vs stack_len={len(self.shared_state.optimization_stack)}) "
+                    "until a validate_stack succeeds — fix the underlying "
+                    "failure (check workload_envs / TP / GPU visibility) and "
+                    "re-emit `validate_stack` when ready."
+                )
             return (
                 "TODO 5/5: validate_stack required. New KEEP'd entries have "
                 "landed on optimization_stack since the last validate_stack run "
@@ -1409,6 +1425,44 @@ class Coordinator:
             rule="baseline_self_loop",
             hint=hint,
         )
+
+    def _validate_stack_gate_skipped(self) -> bool:
+        """Drop the mandatory ``validate_stack`` gate after
+        ``_VALIDATE_STACK_FAIL_THRESHOLD`` consecutive failures.
+
+        Walks ``validate_stack_attempts`` from the tail; a single
+        ``status="succeeded"`` resets the streak. Returns ``True`` once
+        the threshold is reached, emitting one ``log.warning`` on the
+        transition (subsequent ticks return ``True`` silently).
+        """
+        attempts = list(self.shared_state.validate_stack_attempts or [])
+        consecutive_failures = 0
+        last_failure: dict[str, Any] | None = None
+        for entry in reversed(attempts):
+            if not isinstance(entry, dict):
+                break
+            if entry.get("status") == "succeeded":
+                break
+            consecutive_failures += 1
+            if last_failure is None:
+                last_failure = entry
+        if consecutive_failures < _VALIDATE_STACK_FAIL_THRESHOLD:
+            self._validate_stack_gate_skip_warned = False
+            return False
+        if not self._validate_stack_gate_skip_warned:
+            err_class = (last_failure or {}).get("error_class") or "unknown"
+            err_excerpt = (last_failure or {}).get("error_excerpt") or ""
+            log.warning(
+                "validate_stack gate SKIPPED after %d consecutive failures "
+                "(>= threshold %d). Other actions are now allowed; "
+                "cumulative_gain_validated will remain stale until a "
+                "validate_stack succeeds. Last failure: "
+                "error_class=%r error_excerpt=%r.",
+                consecutive_failures, _VALIDATE_STACK_FAIL_THRESHOLD,
+                err_class, err_excerpt,
+            )
+            self._validate_stack_gate_skip_warned = True
+        return True
 
     def _sequence_denial_for_action(
         self,
@@ -1530,10 +1584,12 @@ class Coordinator:
         # rebench before any further explore / report. We allow:
         #   - validate_stack itself
         #   - baseline (ad-hoc re-baseline is still okay; rare)
-        # and deny the rest.
+        # and deny the rest, unless validate_stack has hit its consecutive
+        # failure cap (``_validate_stack_gate_skipped``).
         if (
             self.shared_state.optimization_stack_has_unvalidated_keeps()
             and action not in {"validate_stack", "baseline"}
+            and not self._validate_stack_gate_skipped()
         ):
             return PolicyDenied(
                 f"action={action!r} denied: validate_stack required first",

--- a/inference_optimizer/tests/test_validate_stack_gate_skip.py
+++ b/inference_optimizer/tests/test_validate_stack_gate_skip.py
@@ -1,0 +1,216 @@
+"""PolicyGate ``validate_stack`` skip-after-N-failures tests.
+
+Coordinator drops the otherwise-mandatory ``validate_stack`` gate after
+``_VALIDATE_STACK_FAIL_THRESHOLD`` consecutive failed validate_stack
+attempts, so a doomed environment doesn't burn LLM calls every tick on
+the same retry.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from inference_optimizer.orchestrator.backends import (
+    MockBackend,
+    ScriptedPlan,
+)
+from inference_optimizer.orchestrator.coordinator import (
+    Coordinator,
+    _VALIDATE_STACK_FAIL_THRESHOLD,
+)
+from inference_optimizer.orchestrator.intent_parser import Intent, IntentType
+from inference_optimizer.orchestrator.task_registry import Task
+from inference_optimizer.paths import make_session_dir
+from inference_optimizer.session_paths import target_baseline_json
+
+
+def _heartbeat() -> Intent:
+    return Intent(
+        type=IntentType.SEND_MESSAGE,
+        payload={"topic": "heartbeat", "body_md": "ok"},
+    )
+
+
+def _silent_backends() -> dict[str, object]:
+    silent = ScriptedPlan(turns=[], default_intent=_heartbeat())
+    return {
+        "orchestration": MockBackend(silent, name="o"),
+        "kernel":        MockBackend(silent, name="k"),
+        "critic":        MockBackend(silent, name="c"),
+        "robustness":    MockBackend(silent, name="r"),
+    }
+
+
+@pytest.fixture
+def session_dir(tmp_path, monkeypatch) -> Path:
+    monkeypatch.setenv("USER_DATA_PATH", str(tmp_path))
+    return make_session_dir()
+
+
+def _seed_target_analysis_marker(sd: Path) -> None:
+    """Satisfy the unconditional ``target_analysis`` gate.
+
+    Tests targeting the validate_stack gate must reach the validate_stack
+    branch in ``_sequence_denial_for_action``; without this marker the
+    earlier ``target_analysis must run first`` rule short-circuits.
+    """
+    path = target_baseline_json(sd)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"status": "skipped",
+                    "reason": "no_target_gpu_configured"}),
+        encoding="utf-8",
+    )
+
+
+def _bypass_upstream_gates(c: Coordinator) -> None:
+    """Pre-seed every prerequisite the validate_stack gate sits behind.
+
+    The gate is the *last* rule in ``_sequence_denial_for_action``: any
+    earlier rule (baseline / profile / select_kernels / integrate) would
+    short-circuit our integration test before the validate_stack branch
+    is reached. We satisfy them all so the assertion isolates the
+    behaviour under test.
+    """
+    c.shared_state.baseline_tput = 1500.0
+    c.shared_state.last_profile_trace = "/tmp/fake-trace"
+    c.shared_state.last_profile_pmc_summary = "/tmp/fake-pmc.json"
+    c.shared_state.last_select_kernels = {"trace_input": "/tmp/fake-trace"}
+    c.shared_state.action_scores = {}
+
+
+def _seed_unvalidated_keep(c: Coordinator) -> None:
+    """Make ``optimization_stack_has_unvalidated_keeps()`` return True.
+
+    Coordinator only enforces the validate_stack gate while there is at
+    least one KEEP on the stack that has not been validated end-to-end.
+    """
+    c.shared_state.optimization_stack = [
+        {
+            "action": "params",
+            "variant_name": "v0",
+            "extra_sglang_args": "--foo 1",
+            "extra_envs": {},
+            "tput": 1500.0,
+        }
+    ]
+    c.shared_state.cumulative_gain_validated_stack_len = 0
+
+
+async def _record_validate_stack_failure(c: Coordinator, idx: int) -> None:
+    """Drive one failed validate_stack through ``_handle_unpromotable_result``.
+
+    This is the same path the dispatcher uses post-task, so the failure
+    lands on ``validate_stack_attempts`` exactly the way the gate-skip
+    helper reads it.
+    """
+    task = Task(
+        task_id=f"vs-fail-{idx}",
+        kind="validate_stack",
+        state="queued",
+        params={},
+        idempotency_key=f"idem-vs-{idx}",
+    )
+    await c._handle_unpromotable_result(
+        task,
+        {
+            "status": "failed",
+            "error_class": "tp_mismatch",
+            "error": "TP=8 requested but only 4 GPUs visible",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# _validate_stack_gate_skipped() direct helper
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_gate_skipped_after_threshold_failures(session_dir, caplog):
+    """N consecutive failures → skip returns True and warns exactly once."""
+    c = Coordinator(session_dir, backends=_silent_backends())
+    try:
+        for i in range(_VALIDATE_STACK_FAIL_THRESHOLD):
+            await _record_validate_stack_failure(c, i)
+        with caplog.at_level("WARNING"):
+            assert c._validate_stack_gate_skipped() is True
+            assert c._validate_stack_gate_skipped() is True
+        warns = [r for r in caplog.records if "gate SKIPPED" in r.getMessage()]
+        assert len(warns) == 1
+        assert "tp_mismatch" in warns[0].getMessage()
+    finally:
+        await c.stop()
+
+
+@pytest.mark.asyncio
+async def test_gate_held_under_threshold(session_dir):
+    """N-1 failures must NOT trip the skip — gate stays mandatory."""
+    c = Coordinator(session_dir, backends=_silent_backends())
+    try:
+        for i in range(_VALIDATE_STACK_FAIL_THRESHOLD - 1):
+            await _record_validate_stack_failure(c, i)
+        assert c._validate_stack_gate_skipped() is False
+    finally:
+        await c.stop()
+
+
+@pytest.mark.asyncio
+async def test_gate_skip_resets_after_success(session_dir):
+    """A successful validate_stack between failures resets the streak."""
+    c = Coordinator(session_dir, backends=_silent_backends())
+    try:
+        for i in range(_VALIDATE_STACK_FAIL_THRESHOLD):
+            await _record_validate_stack_failure(c, i)
+        assert c._validate_stack_gate_skipped() is True
+        c.shared_state.validate_stack_attempts.append(
+            {
+                "ts": "2026-01-01T00:00:00",
+                "task_id": "vs-ok",
+                "status": "succeeded",
+                "decision": "promoted",
+                "error_class": None,
+                "error_excerpt": None,
+                "extras": {},
+            }
+        )
+        assert c._validate_stack_gate_skipped() is False
+        assert c._validate_stack_gate_skip_warned is False
+    finally:
+        await c.stop()
+
+
+@pytest.mark.asyncio
+async def test_gate_denies_other_actions_under_threshold(session_dir):
+    """Below threshold the gate still denies non-validate_stack actions."""
+    c = Coordinator(session_dir, backends=_silent_backends())
+    _seed_target_analysis_marker(session_dir)
+    try:
+        _bypass_upstream_gates(c)
+        _seed_unvalidated_keep(c)
+        for i in range(_VALIDATE_STACK_FAIL_THRESHOLD - 1):
+            await _record_validate_stack_failure(c, i)
+        denial = c._sequence_denial_for_action("backends")
+        assert denial is not None
+        assert denial.rule == "validate_stack_required"
+    finally:
+        await c.stop()
+
+
+@pytest.mark.asyncio
+async def test_gate_allows_other_actions_at_threshold(session_dir):
+    """At threshold the gate is dropped — `backends` (and friends) pass."""
+    c = Coordinator(session_dir, backends=_silent_backends())
+    _seed_target_analysis_marker(session_dir)
+    try:
+        _bypass_upstream_gates(c)
+        _seed_unvalidated_keep(c)
+        for i in range(_VALIDATE_STACK_FAIL_THRESHOLD):
+            await _record_validate_stack_failure(c, i)
+        assert c._sequence_denial_for_action("backends") is None
+        assert c._sequence_denial_for_action("params") is None
+        assert c._sequence_denial_for_action("report") is None
+        assert c._sequence_denial_for_action("validate_stack") is None
+    finally:
+        await c.stop()


### PR DESCRIPTION
## Summary

Adds an escape hatch to PolicyGate so the mandatory `validate_stack` gate drops itself after 10 consecutive `validate_stack` failures. Without this, a doomed environment (e.g. the TP / GPU mismatch in #248) burns hundreds of LLM calls retrying the same failure every tick. Observed: 400+ ticks (~3.5h at 30s/tick) on a Qwen3-30B-A3B run on MI325X before manual intervention.

Closes #245.

## Problem

After any explore round (`backends` / `params` / `kernel_opt`) produces a KEEP, Coordinator sets a mandatory `validate_stack required` rule in `_sequence_denial_for_action`: no other action is allowed until `validate_stack` succeeds. There is no failure cap, so an environment-level error makes the orchestrator retry every tick indefinitely while kernel optimization stays blocked.

## Fix

- New constant `_VALIDATE_STACK_FAIL_THRESHOLD = 10` next to the existing `_BASELINE_SELF_LOOP_THRESHOLD`.
- New helper `Coordinator._validate_stack_gate_skipped()` walks `shared_state.validate_stack_attempts` from the tail and counts consecutive `status="failed"` entries (a single `succeeded` resets the streak).
- The validate_stack branch in `_sequence_denial_for_action` now ANDs `not self._validate_stack_gate_skipped()` into its condition — once the threshold is reached, other actions are no longer denied.
- The matching TODO in `_next_todo_hint` is downgraded from "required" to "RECOMMENDED but not required" so Orchestration sees a consistent signal and stops re-emitting validate_stack.
- The first transition into the skipped state emits one `log.warning` with the last failure's `error_class` and `error_excerpt`. A per-Coordinator `_validate_stack_gate_skip_warned` flag prevents per-tick repeats; a successful validate_stack re-arms the warning so a fresh failure streak surfaces a new log line.

`cumulative_gain_validated` intentionally stays stale until a `validate_stack` succeeds. The final report continues to quote the last validated number with the gap visible (`validated_at_len` vs `stack_len`), which is strictly better than stalling the entire run.

## Test plan

- [x] New `tests/test_validate_stack_gate_skip.py` (5 cases): threshold trip, below-threshold hold, success-resets-streak (with warning re-arm), end-to-end denial below threshold, end-to-end pass-through at threshold.
- [x] Existing PolicyGate / Coordinator regression tests pass (`test_baseline_self_loop_policy.py`, `test_p0_3_coordinator.py`, `test_p3_bugfixes.py`, `test_coordinator_audit_wiring.py` — 44 tests).
- [x] No linter errors.