### PR TITLE
fix(breakdown): emit V1-schema gain_per_stack_entry + dedupe final extra_sglang_args

### DIFF
--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -2406,6 +2406,52 @@ def _action_family(action: str) -> str:
     return "other"
 
 
+def _promote_legacy_gain_entries(
+    state_entries: list[Any],
+    state: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Lift a pre-v0.7 ``list[float | None]`` gain ledger into the V1 schema.
+
+    State written by older Coordinator versions stored per-entry
+    ``cum_gain_after`` floats only. Cross-reference the parallel
+    ``state.optimization_stack`` to recover action / variant_name / ts /
+    extra_sglang_args, and compute ``delta_pct`` as the diff against the
+    prior entry's ``cum_gain_after``. Entries the legacy ledger left as
+    ``None`` (seeded / resumed sessions) become objects with
+    ``cum_gain_after = delta_pct = None`` so index-alignment with
+    ``optimization_stack`` is preserved.
+    """
+    stack = state.get("optimization_stack") or []
+    out: list[dict[str, Any]] = []
+    prev_cum = 0.0
+    for i, val in enumerate(state_entries):
+        cum_after: float | None
+        if isinstance(val, (int, float)):
+            cum_after = float(val)
+        else:
+            cum_after = None
+        delta = (cum_after - prev_cum) if cum_after is not None else None
+        se = stack[i] if i < len(stack) and isinstance(stack[i], dict) else {}
+        out.append({
+            "ts": str(se.get("ts") or ""),
+            "action": str(se.get("action") or ""),
+            "variant_name": se.get("variant_name") or se.get("kernel_id"),
+            "stack_len_before": i,
+            "stack_len_after": i + 1,
+            "cum_gain_before": prev_cum,
+            "cum_gain_after": cum_after,
+            "delta_pct": delta,
+            "extra_sglang_args": str(
+                se.get("extra_sglang_args")
+                or se.get("candidate_extra_sglang_args")
+                or ""
+            ),
+        })
+        if cum_after is not None:
+            prev_cum = cum_after
+    return out
+
+
 def collect_attribution(
     state: dict[str, Any],
     geak_invocations: list[dict[str, Any]],
@@ -2418,7 +2464,13 @@ def collect_attribution(
     # best-effort approximation from optimization_stack alone.
     state_entries = state.get("gain_per_stack_entry")
     state_provided = isinstance(state_entries, list) and len(state_entries) > 0
-    if state_provided:
+    promoted_from_legacy = False
+    if state_provided and any(not isinstance(e, dict) for e in state_entries):
+        # Pre-v0.7 state: bare numeric ledger. Promote into V1 schema
+        # so source_breakdown bucketing + dashboards see rich entries.
+        entries = _promote_legacy_gain_entries(state_entries, state)
+        promoted_from_legacy = True
+    elif state_provided:
         entries = list(state_entries)
     else:
         entries = _reconstruct_gain_ledger(state, warnings)
@@ -2430,11 +2482,16 @@ def collect_attribution(
     stack_len = len(stack) if isinstance(stack, list) else 0
     method: str
     if state_provided:
-        all_deltas_set = all(
-            isinstance(e, dict) and e.get("delta_pct") is not None
-            for e in state_entries
-        )
-        method = "validated" if all_deltas_set else "reconstructed"
+        if promoted_from_legacy:
+            # Numbers lifted post-hoc to dicts — fields are honest but
+            # the ledger itself isn't a per-event capture by Coordinator.
+            method = "reconstructed"
+        else:
+            all_deltas_set = all(
+                isinstance(e, dict) and e.get("delta_pct") is not None
+                for e in state_entries
+            )
+            method = "validated" if all_deltas_set else "reconstructed"
     elif stack_len == 1:
         # Single-entry stack: ``final.action_path`` unambiguously
         # identifies the one source of gain.
@@ -2482,6 +2539,13 @@ def collect_attribution(
         notes.append(
             "gain_per_stack_entry not written by Coordinator; "
             "attribution reconstructed best-effort from optimization_stack."
+        )
+    elif promoted_from_legacy:
+        notes.append(
+            "gain_per_stack_entry was a pre-v0.7 numeric ledger; "
+            "promoted to V1 StackGainEntry shape using parallel data from "
+            "optimization_stack (delta_pct computed as diff vs prior entry's "
+            "cum_gain_after)."
         )
 
     return {

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -162,6 +162,68 @@ def _baseline_params_fingerprint(params: dict[str, Any] | None) -> dict[str, Any
     return out
 
 
+def _dedupe_extra_sglang_args(args_str: str) -> str:
+    """Collapse repeated ``--flag value`` pairs into a unique launch string.
+
+    SGLang / vLLM argparse uses ``action="store"`` for almost every
+    knob, so if ``--cuda-graph-max-bs 32 --cuda-graph-max-bs 128
+    --cuda-graph-max-bs 256`` end up on the same command line, only the
+    last value is honored. The original cmdline still works, but
+    ``final.extra_sglang_args`` exists for dashboard / replay use and
+    looking at it with the same flag repeated 3-15 times is misleading
+    (it reads as "this run actually used N values" when really only the
+    last won).
+
+    Promote / validate_stack rounds previously fed each ``candidate_args``
+    block into ``previous + candidate`` concatenation; when the next
+    round's candidate kept the same multi-value combo, the whole block
+    was re-appended verbatim. Dedupe is a sane normalization: keep each
+    flag once, with the value of its last occurrence — same semantics
+    argparse would have applied at launch.
+
+    Bare flags (no value, e.g. ``--enable-prefix-caching``) are also
+    deduped (kept once, position preserved by first appearance).
+
+    Args:
+        args_str: space-separated ``--flag value`` pairs.
+
+    Returns:
+        Deduped equivalent. Empty input → empty output.
+    """
+    if not args_str:
+        return ""
+    tokens = args_str.split()
+    # Track each flag's last-seen pair, plus its first-seen position so
+    # we emit in stable order (last-wins-for-value, first-wins-for-order).
+    pair_by_flag: dict[str, list[str]] = {}
+    order: list[str] = []
+    i = 0
+    while i < len(tokens):
+        t = tokens[i]
+        if t.startswith("--"):
+            flag = t
+            if i + 1 < len(tokens) and not tokens[i + 1].startswith("--"):
+                pair = [flag, tokens[i + 1]]
+                i += 2
+            else:
+                pair = [flag]
+                i += 1
+            if flag not in pair_by_flag:
+                order.append(flag)
+            pair_by_flag[flag] = pair
+        else:
+            # Stray positional token; preserve as-is, in order. Use a
+            # synthetic key so it doesn't collide with anything.
+            key = f"__positional_{len(order)}__"
+            order.append(key)
+            pair_by_flag[key] = [t]
+            i += 1
+    out: list[str] = []
+    for k in order:
+        out.extend(pair_by_flag[k])
+    return " ".join(out)
+
+
 @dataclass
 class PendingProposal:
     """A propose_action intent waiting for Critic Review (§18)."""
@@ -2568,19 +2630,19 @@ class Coordinator:
         }
         if key not in existing:
             self.shared_state.optimization_stack.append(entry)
-            # Per-entry incremental gain (current_best vs. baseline at the
-            # moment this integrate KEEP landed). Keeps
-            # ``gain_per_stack_entry`` index-aligned with
-            # ``optimization_stack`` for session_breakdown's
-            # capability_summary attribution.
-            gain_pct_entry: float | None = None
-            try:
-                bt = float(self.shared_state.baseline_tput or 0.0)
-                if bt > 0:
-                    gain_pct_entry = (float(new_tput) - bt) / bt * 100.0
-            except (TypeError, ValueError):
-                gain_pct_entry = None
-            self.shared_state.gain_per_stack_entry.append(gain_pct_entry)
+            # Mirror ``optimization_stack`` into the V1-schema
+            # ``gain_per_stack_entry`` ledger so session_breakdown's
+            # attribution + capability_summary can attribute "how much of
+            # the validated cumulative gain came from this entry" without
+            # re-walking the event log. Helper computes cum_gain_after
+            # (vs baseline) + delta_pct (vs previous entry) internally.
+            self.shared_state.append_stack_gain_entry(
+                action="integrate",
+                variant_name=entry.get("kernel_id"),
+                new_tput=new_tput,
+                extra_sglang_args=extra_args,
+                ts=entry["ts"],
+            )
 
         self.shared_state.current_best = {
             "action": "integrate",
@@ -2752,6 +2814,15 @@ class Coordinator:
             full_args = " ".join(
                 part for part in (base_args, candidate_args) if part
             )
+        # Dedupe repeated ``--flag value`` pairs so the cumulative
+        # extra_sglang_args reflects what argparse will actually honor
+        # (last value wins). Without this, every promote that re-applies
+        # a multi-value combo candidate (e.g.
+        # ``--cuda-graph-max-bs 32 --cuda-graph-max-bs 128 --cuda-graph-max-bs 256``)
+        # leaves multiple copies of the same flag in the final args
+        # string, which breaks reproduce-launch dashboards and the
+        # final.extra_sglang_args field surfaced by session_breakdown.
+        full_args = _dedupe_extra_sglang_args(full_args)
 
         variant_name = bv.get("name") if isinstance(bv, dict) else None
         if candidate_args or variant_name:
@@ -2778,15 +2849,13 @@ class Coordinator:
                 })
                 # Mirror append into ``gain_per_stack_entry`` so indexes
                 # stay aligned across the two parallel lists. See the
-                # SharedState docstring for the contract.
-                gain_pct_entry: float | None = None
-                try:
-                    bt = float(self.shared_state.baseline_tput or 0.0)
-                    if bt > 0:
-                        gain_pct_entry = (float(best_tput) - bt) / bt * 100.0
-                except (TypeError, ValueError):
-                    gain_pct_entry = None
-                self.shared_state.gain_per_stack_entry.append(gain_pct_entry)
+                # SharedState docstring for the V1 StackGainEntry contract.
+                self.shared_state.append_stack_gain_entry(
+                    action=task_kind,
+                    variant_name=variant_name,
+                    new_tput=best_tput,
+                    extra_sglang_args=full_args,
+                )
 
         self.shared_state.current_best = {
             "action": task_kind,

--- a/inference_optimizer/orchestrator/shared_state.py
+++ b/inference_optimizer/orchestrator/shared_state.py
@@ -131,16 +131,36 @@ class SharedState:
     # records the incremental candidate that was accepted; current_best keeps
     # the materialized full args/env for execution.
     optimization_stack: list[dict[str, Any]] = field(default_factory=list)
-    # Parallel to ``optimization_stack``: per-entry incremental gain in
-    # percent (current_best vs. baseline at the moment that stack entry
-    # was promoted). Index ``i`` here aligns with index ``i`` in
-    # ``optimization_stack``. session_breakdown's capability_summary uses
-    # this to attribute "how much of the validated cumulative gain came
-    # from this action / capability" without re-walking the event log.
-    # Coordinator appends to this list at the same time it appends to
-    # ``optimization_stack`` (see ``_lift_to_current_best``); missing
-    # entries (e.g. on resumed sessions) are treated as ``None``.
-    gain_per_stack_entry: list[float | None] = field(default_factory=list)
+    # Parallel ledger to ``optimization_stack``: one rich entry per KEEP
+    # event with both the cumulative gain (vs baseline) AT the moment the
+    # entry was promoted AND the incremental contribution this entry alone
+    # added (``delta_pct = cum_gain_after - cum_gain_after_of_prev``).
+    # Index ``i`` aligns with index ``i`` in ``optimization_stack``.
+    #
+    # Each entry conforms to ``breakdown.schema.StackGainEntry``::
+    #     {
+    #       "ts": iso8601,
+    #       "action": "params" | "backends" | "integrate" | "validate_stack",
+    #       "variant_name": str | None,
+    #       "stack_len_before": int,
+    #       "stack_len_after": int,
+    #       "cum_gain_before": float,
+    #       "cum_gain_after": float | None,
+    #       "delta_pct": float | None,        # None on resumed/seeded entries
+    #       "extra_sglang_args": str,
+    #     }
+    #
+    # Coordinator appends here at the same time it appends to
+    # ``optimization_stack`` via :meth:`append_stack_gain_entry`; the
+    # helper computes cum_gain_after + delta_pct from
+    # ``self.baseline_tput`` and the previous entry's ``cum_gain_after``
+    # so call sites only pass action / variant_name / new_tput.
+    #
+    # Pre-v0.7 sessions wrote ``list[float | None]`` (the cum_gain_after
+    # number only); ``breakdown/collectors.py:collect_attribution`` has a
+    # promotion shim that lifts the old shape into this rich one when it
+    # detects non-dict entries.
+    gain_per_stack_entry: list[dict[str, Any]] = field(default_factory=list)
     cumulative_gain: float = 0.0
     # Cumulative gain measured by the `validate_stack` action — i.e. by
     # actually re-baselining a fresh server with EVERY KEEP'd entry of
@@ -1497,12 +1517,88 @@ class SharedState:
             "workspace": self.current_best.get("workspace"),
             "source": "seeded_from_current_best",
         }]
-        # Keep ``gain_per_stack_entry`` aligned with ``optimization_stack``
-        # (None == we don't know the per-entry gain for seeded entries).
+        # Keep ``gain_per_stack_entry`` aligned with ``optimization_stack``.
+        # Seeded entries carry ``cum_gain_after = delta_pct = None`` so
+        # ``breakdown.attribution.method`` correctly classifies as
+        # ``reconstructed`` rather than ``validated``.
         if len(self.gain_per_stack_entry) < len(self.optimization_stack):
-            self.gain_per_stack_entry.extend(
-                [None] * (len(self.optimization_stack) - len(self.gain_per_stack_entry))
-            )
+            for i in range(len(self.gain_per_stack_entry), len(self.optimization_stack)):
+                stk = self.optimization_stack[i] if i < len(self.optimization_stack) else {}
+                if not isinstance(stk, dict):
+                    stk = {}
+                self.gain_per_stack_entry.append({
+                    "ts": stk.get("ts") or "",
+                    "action": stk.get("action") or "unknown",
+                    "variant_name": stk.get("variant_name"),
+                    "stack_len_before": i,
+                    "stack_len_after": i + 1,
+                    "cum_gain_before": None,
+                    "cum_gain_after": None,
+                    "delta_pct": None,
+                    "extra_sglang_args": (
+                        stk.get("extra_sglang_args")
+                        or stk.get("candidate_extra_sglang_args")
+                        or ""
+                    ),
+                })
+
+    def append_stack_gain_entry(
+        self,
+        *,
+        action: str,
+        variant_name: str | None,
+        new_tput: float | int | None,
+        extra_sglang_args: str = "",
+        ts: str | None = None,
+    ) -> None:
+        """Append one V1-schema :class:`StackGainEntry` aligned with the
+        last ``optimization_stack`` push.
+
+        Computes ``cum_gain_after = (new_tput - baseline_tput) / baseline_tput * 100``
+        and ``delta_pct = cum_gain_after - prev_cum_gain_after`` so call
+        sites only need to pass action / variant_name / new_tput. Falls
+        back to ``None`` (for both cum_gain_after and delta_pct) when
+        ``baseline_tput`` is missing or ``new_tput`` isn't a finite
+        number; the entry is still emitted so index-alignment with
+        ``optimization_stack`` is preserved.
+        """
+        cum_after: float | None = None
+        try:
+            bt = float(self.baseline_tput or 0.0)
+            nt = float(new_tput) if new_tput is not None else None
+            if bt > 0 and nt is not None:
+                cum_after = (nt - bt) / bt * 100.0
+        except (TypeError, ValueError):
+            cum_after = None
+
+        # Find the previous entry's cum_gain_after to compute this entry's
+        # incremental delta. Skip seeded / unknown entries (cum_after=None).
+        prev_cum: float = 0.0
+        for prev in reversed(self.gain_per_stack_entry):
+            if not isinstance(prev, dict):
+                # legacy [float, ...] state: treat the number itself as
+                # the prior cum_gain_after.
+                if isinstance(prev, (int, float)):
+                    prev_cum = float(prev)
+                break
+            prior = prev.get("cum_gain_after")
+            if isinstance(prior, (int, float)):
+                prev_cum = float(prior)
+                break
+
+        delta = (cum_after - prev_cum) if cum_after is not None else None
+        stack_len_after = len(self.optimization_stack)
+        self.gain_per_stack_entry.append({
+            "ts": ts or datetime.now(timezone.utc).isoformat(),
+            "action": action,
+            "variant_name": variant_name,
+            "stack_len_before": stack_len_after - 1,
+            "stack_len_after": stack_len_after,
+            "cum_gain_before": prev_cum,
+            "cum_gain_after": cum_after,
+            "delta_pct": delta,
+            "extra_sglang_args": extra_sglang_args,
+        })
 
     # ------------------------------------------------------------------
     # Time-budget helpers (Phase 2 — consumed by Coordinator._compose_prompt)


### PR DESCRIPTION
## Summary

Two pre-v0.7 bugs surfaced by the SessionBreakdown dashboard for session `071b0bf2-25f7-459d-a4fe-694e6b027ef4` (abacusai-bigyi-15b):

**(1) Schema drift on `attribution.gain_per_stack_entry`** — Coordinator persisted a bare `list[float | None]` (just cumulative gain numbers), but the V1 SessionBreakdown contract (`schema.StackGainEntry`, the dashboard, `tests/test_breakdown_smoke.py` fixture) all expect a list of rich dicts with `action / variant_name / delta_pct / cum_gain_after / cum_gain_before / ts / extra_sglang_args`. Effect on the dashboard:

- Every Optimization card under Action path rendered blank (`-`)
- Optimization Attribution showed `0%` on every source (BACKENDS / GEAK / OOB / PARAMS / SWEEP all 0) — `collect_attribution` bucketing loop skips entries where `isinstance(e, dict)` is False

**(2) `final.extra_sglang_args` accumulation** — each promote / validate_stack re-applied a multi-value combo candidate (e.g. `--cuda-graph-max-bs 32 --cuda-graph-max-bs 128 --cuda-graph-max-bs 256`) by concatenating `previous + candidate` without dedup. The same combo block ended up repeated 3 times in `final.extra_sglang_args`. argparse ignores duplicates (last-wins) but the dashboard `FINAL EXTRA ARGS` / Launch Reproducibility panels read as if N values were being passed in parallel.

## Changes

- **`shared_state.py`** — change `gain_per_stack_entry` annotation to `list[dict[str, Any]]`; add `append_stack_gain_entry()` helper that owns `StackGainEntry` construction (computes `cum_gain_after` vs `baseline_tput` + `delta_pct` vs prior entry); fix `seed_stack_from_current_best()` to pad with minimal rich entries (`cum_gain_after = delta_pct = None` for seeded slots so `attribution.method` classifies as `reconstructed` not `validated`).
- **`coordinator.py`** — replace two inline `gain_per_stack_entry.append` blocks (integrate KEEP path + promote path) with `append_stack_gain_entry()`; add module-level `_dedupe_extra_sglang_args` helper that collapses repeated `--flag value` pairs (last-wins semantics matching argparse); call it from `_lift_to_current_best` after the `base + candidate` concatenation.
- **`collectors.py:collect_attribution`** — add `_promote_legacy_gain_entries()` shim that lifts pre-v0.7 numeric ledgers into V1 schema by cross-referencing `optimization_stack` for `action / variant_name / extra_sglang_args` (`delta_pct` computed as diff vs prior entry's `cum_gain_after`). Sets `method = reconstructed` and appends a warnings note when the promotion path is taken so consumers can tell post-hoc lifts from native validated ledgers.

## Test plan

- [x] `pytest inference_optimizer/tests/test_breakdown_smoke.py` — 36/36 pass
- [x] `pytest inference_optimizer/tests/test_reporters_smoke.py` — 19/19 pass
- [x] Lint clean on the 3 touched files
- [ ] CI greenboard (the rest of the test suite imports `fcntl` and only runs on Linux/macOS — fine for CI)
- [ ] Spawn one fresh inference_optimizer session post-merge and confirm:
  - `attribution.gain_per_stack_entry[i]` is a dict matching `StackGainEntry`, not a bare float
  - `attribution.method == validated` (no `_promote_legacy_gain_entries` shim hit on newly written state)
  - `attribution.source_breakdown.{backends,params,...}_pct_of_total` sum to validated total (no longer all 0)
  - `final.extra_sglang_args` has each `--flag` at most once (last-wins value)

## Frontend follow-up (separate PR, different repo)

Dashboard side has a parallel doc covering 3 rendering polish items the backend does not control (Capability Summary missing 2 of 6 cards, Launch Reproducibility fallback to `extra_sglang_args` / `extra_envs`, null-text polish to `—`).