### PR TITLE
fix(ci): never ship SaFE optimize task with empty promptPrefix

### DIFF
--- a/.github/workflows/optimize-submit.yml
+++ b/.github/workflows/optimize-submit.yml
@@ -105,149 +105,29 @@ on:
         required: false
         default: ''
       inferencex_path:
-        description: 'InferenceX checkout path inside the sandbox. Leave empty to use script default (/wekafs/InferenceX for core42).'
+        description: 'InferenceX checkout path inside the sandbox. Leave empty to use script default (/wekafs/hyperloom/InferenceX for core42).'
         required: false
         default: ''
       prompt_prefix:
-        # Prepended verbatim to the SaFE-generated Hyperloom prompt
-        # (PromptPrefix field on CreateTaskRequest, added in
-        # apiserver/pkg/handlers/optimization/types.go).
+        # Canonical prompt prefix lives in ci/prompt_prefix.txt (single
+        # source of truth, used by ALL trigger sources: schedule, dispatch,
+        # workflow_call, and direct CLI invocations of optimize_submit.py).
         #
-        # Default carries the entire "always do / never do" preamble we
-        # want the agent to see *before* the auto-generated Configuration
-        # block. The contents mirror the preventive instructions in
-        # /wekafs/HyperloomV2/ci/prompt_template.md, which we
-        # cannot inline directly because that file lives in a peer repo
-        # the SaFE backend does not read. Keeping the rules here means
-        # one place to update when a new failure mode shows up in the
-        # batch reports.
+        # We deliberately leave this input's `default:` empty because the
+        # YAML `default:` is ONLY substituted on `workflow_dispatch` — on
+        # `schedule` trigger `github.event.inputs.prompt_prefix` is always
+        # the empty string, which previously dropped the prefix silently
+        # and shipped tasks to SaFE with promptPrefix="" (root-causing
+        # most "scheduled run produced no artifacts" failures).
         #
-        # Critical rules below address the failure modes we hit in
-        # batch=10 (2026-05-12) — partial-report-on-abort, vLLM
-        # forbidden flags, RESULT_DIR-not-exported writes-silently,
-        # find / hangs.
-        description: 'Free-form prompt prefix prepended to the SaFE-generated Hyperloom prompt. Default carries HyperloomV2 skill pointer + partial-report-on-abort + vLLM forbidden flags + safety rules.'
+        # The Submit step reads ci/prompt_prefix.txt as the hard fallback
+        # whenever this input is empty, and refuses to submit if neither
+        # is set — so the SaFE promptPrefix field is GUARANTEED non-empty.
+        # Override here only when you intentionally want different
+        # instructions for a one-off dispatch.
+        description: 'Override prompt prefix for this run. Leave empty to use ci/prompt_prefix.txt (recommended; same prefix for schedule + dispatch).'
         required: false
-        default: |
-          Use the skill at /wekafs/HyperloomV2/inference_optimizer/SKILL.md to optimize this model.
-          Working directory: cd /wekafs/HyperloomV2 before running any skill commands.
-
-          CRITICAL — Required Artifacts (the canonical SaFE success contract):
-          At the end of the run, ALWAYS write both files to $RESULT_DIR (defaults to /workspace/hyperloom/).
-          If these files are missing, SaFE marks the task Failed regardless of whether the skill made real progress.
-
-            $RESULT_DIR/optimization_report.md
-            $RESULT_DIR/ci_metrics.json
-              {"baseline_throughput": <float>, "optimized_throughput": <float>, "gain_pct": <float>, "tok_per_gpu_baseline": <float>, "tok_per_gpu_optimized": <float>, "actions_taken": ["..."]}
-            $RESULT_DIR/session_breakdown.json   (optional but recommended — emitted by inference_optimizer; preserved alongside the two contract files for post-run audit)
-
-          If the pipeline aborts (kernel apply failed / server failed to start / optimization tooling crash):
-          - Set optimized_throughput = baseline_throughput, gain_pct = 0.0.
-          - Set actions_taken = ["aborted: <one-line reason>"].
-          - Still emit BOTH files. A partial report with baseline-only numbers is far more useful than no report at all.
-
-          MANUAL FALLBACK (V2 orchestrator stuck in kernel-opt loop — observed pattern):
-          If the V2 orchestrator runs past 2.5h without producing
-          $RESULT_DIR/ci_metrics.json (it's spinning forever in the kernel-opt
-          phase, re-optimizing the same 1-2 kernels every 60min cycle), DO NOT
-          wait for it. Manually compose ci_metrics.json + optimization_report.md
-          from the measurements you already have on disk:
-            * baseline number: $SESSION_DIR/phase02_baseline/baseline_results.json
-              (output_throughput field — that's tok/s/GPU at TP=1, or total tok/s
-              divided by TP for higher TP)
-            * profile classification: $SESSION_DIR/phase03_profile/profile_results.json
-              + any TraceLens analysis already written
-            * kernel info: $SESSION_DIR/phase05_kernel_opt/*/optimization_summary.json
-            * sweep best: $SESSION_DIR/phase06_sweep/* or run a single
-              `--decode-attention-backend aiter` / `--max-num-batched-tokens N`
-              sweep with the same server config to test ONE param change
-            * If you cannot get an optimized number, set optimized_throughput =
-              baseline_throughput, gain_pct = 0.0 (honest "no headroom" report).
-
-          This is the path the Mistral-7B-v0.1 run on 2026-05-13 took
-          (run 25795816178) — it produced a clean +0.10% report after the
-          orchestrator stalled. Better an honest small-gain row than a missing
-          row for a 2-3h run.
-
-          CRITICAL — vLLM Forbidden Flags (server will crash with "unrecognized arguments"):
-          - --num-scheduler-steps   (removed in vLLM v0.4.0)
-          - --chunked-prefill-size  (SGLang-only, NOT vLLM)
-          - --enable-chunked-prefill (only safe on vLLM >= 0.6.0; check version first)
-
-          CRITICAL — Result Directory:
-          Before running any skill script (run_baseline.sh, run_sweep.sh, etc.), export:
-            export NFS_ROOT=/wekafs
-            export RESULT_DIR=/workspace/hyperloom/
-          Otherwise baseline/sweep writes fail silently and the job will hang.
-
-          CRITICAL — POST-PIPELINE PERSIST (the most common reason a successful run shows up Failed):
-          $RESULT_DIR (=/workspace/hyperloom/) lives inside the sandbox
-          container's ephemeral storage. When SaFE marks the task Failed
-          (or times out) the pod gets cleaned up and EVERYTHING under
-          /workspace is lost — including the ci_metrics.json and
-          optimization_report.md you just spent 2-3h producing. Even
-          when SaFE marks the task Succeeded it only collects /workspace
-          for a short window before deletion, and the CI side has no
-          kubectl-exec access to read it back.
-
-          To survive any of this you MUST copy the two artifacts to a
-          persistent location under /hyperloom/users/<your-safe-uuid>/
-          (which is the wekafs RW mount inside the sandbox — the
-          CI / NFS Stage B fallback scans this path). Run this AFTER
-          you have written the final ci_metrics.json + optimization_report.md:
-
-            mkdir -p $RESULT_DIR
-            # Persist to wekafs so it survives sandbox shutdown and CI
-            # can collect via NFS fallback even when SaFE artifact upload
-            # fails (Failed status, timeout, etc.).
-            UID_HEX=$(ls /hyperloom/users 2>/dev/null | head -1)
-            if [ -n "$UID_HEX" ]; then
-              # Use a unique session name that won't collide with prior runs
-              # (display_name + task_id last 8 chars).
-              MODEL_TAG=$(echo "${DISPLAYNAME:-task}" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9-' '-' | sed 's/-*$//')
-              TASK_TAG="${SAFE_TASK_ID:-$(date +%Y%m%d%H%M%S)}"
-              PERSIST_DIR="/hyperloom/users/$UID_HEX/${MODEL_TAG}-${TASK_TAG##*-}-opt"
-              mkdir -p "$PERSIST_DIR"
-              cp -f "$RESULT_DIR/ci_metrics.json"          "$PERSIST_DIR/ci_metrics.json"         2>/dev/null && echo "[PERSIST] $PERSIST_DIR/ci_metrics.json"
-              cp -f "$RESULT_DIR/optimization_report.md"  "$PERSIST_DIR/optimization_report.md"  2>/dev/null && echo "[PERSIST] $PERSIST_DIR/optimization_report.md"
-              cp -f "$RESULT_DIR/session_breakdown.json"  "$PERSIST_DIR/session_breakdown.json"  2>/dev/null && echo "[PERSIST] $PERSIST_DIR/session_breakdown.json"
-              ls -la "$PERSIST_DIR/"
-            else
-              echo "[ERR] /hyperloom/users/<uid>/ not mounted — cannot persist to wekafs"
-            fi
-
-            # Legacy back-fill direction: when the V2 orchestrator writes
-            # into /wekafs/users/<uid>/<sess>/ (older skill versions did
-            # this), the snippet below pulls it into $RESULT_DIR so SaFE
-            # sees the canonical files. Kept for backward compat — when
-            # we already wrote $RESULT_DIR ourselves above this is a no-op.
-            CI=$(ls -t /wekafs/users/*/*/ci_metrics.json \
-                       /wekafs/users/*/*/phase10_report/ci_metrics.json \
-                       /wekafs/users/*/*/results/ci_metrics.json \
-                       2>/dev/null | head -1)
-            REPORT=$(ls -t /wekafs/users/*/*/optimization_report.md \
-                           /wekafs/users/*/*/phase10_report/optimization_report.md \
-                           /wekafs/users/*/*/reports/final.md \
-                           2>/dev/null | head -1)
-            if [ -n "$CI" ] && [ ! -s "$RESULT_DIR/ci_metrics.json" ]; then
-              cp -f "$CI" $RESULT_DIR/ci_metrics.json
-              echo "[BACKFILL] $CI -> $RESULT_DIR/ci_metrics.json"
-            fi
-            if [ -n "$REPORT" ] && [ ! -s "$RESULT_DIR/optimization_report.md" ]; then
-              cp -f "$REPORT" $RESULT_DIR/optimization_report.md
-              echo "[BACKFILL] $REPORT -> $RESULT_DIR/optimization_report.md"
-            fi
-            ls -la $RESULT_DIR/
-
-          The ci_metrics.json values you write here MUST match what the V2
-          orchestrator actually measured (proper baseline from phase 1 / best
-          from phase 6-8) — do NOT recompute gain_pct from a partial-run
-          eager-mode baseline that the orchestrator did not endorse.
-
-          SAFETY:
-          - NEVER `find /` or `find /wekafs` without `-maxdepth 4`. Prefer which/ls/$PATH lookups.
-          - NEVER run `kill -9 $(ps aux | grep ...)` — this kills the sandbox executor itself.
-          - Per-bash timeouts must be <= 120s; use short polling loops rather than one long blocking call.
+        default: ''
       target_gpu:
         description: 'Reference GPU for InferenceX comparison in the summary table'
         required: false
@@ -403,9 +283,22 @@ jobs:
           if [ -n "${INPUT_INFERENCEX_PATH:-}" ]; then
             ARGS+=(--inferencex-path "${INPUT_INFERENCEX_PATH}")
           fi
-          if [ -n "${INPUT_PROMPT_PREFIX:-}" ]; then
-            ARGS+=(--prompt-prefix "${INPUT_PROMPT_PREFIX}")
+          # Hard guarantee: SaFE promptPrefix MUST be non-empty. Workflow
+          # input is only populated on workflow_dispatch — for schedule
+          # trigger we fall back to ci/prompt_prefix.txt (single source of
+          # truth). If both are missing the run aborts before submit so we
+          # never ship a task with empty promptPrefix again.
+          # (working-directory is `ci`, so the file is referenced directly.)
+          PROMPT_PREFIX_VALUE="${INPUT_PROMPT_PREFIX:-}"
+          if [ -z "$PROMPT_PREFIX_VALUE" ] && [ -f "prompt_prefix.txt" ]; then
+            PROMPT_PREFIX_VALUE="$(cat prompt_prefix.txt)"
+            echo "[prompt_prefix] loaded fallback from ci/prompt_prefix.txt ($(wc -c < prompt_prefix.txt) bytes)"
           fi
+          if [ -z "$PROMPT_PREFIX_VALUE" ]; then
+            echo "::error::prompt_prefix is empty and ci/prompt_prefix.txt is missing — refusing to submit to SaFE with empty promptPrefix"
+            exit 1
+          fi
+          ARGS+=(--prompt-prefix "$PROMPT_PREFIX_VALUE")
           if [ "${INPUT_WAIT:-true}" = "false" ]; then
             ARGS+=(--no-wait-for-completion)
           fi

--- a/ci/optimize_submit.py
+++ b/ci/optimize_submit.py
@@ -89,11 +89,50 @@ DEFAULT_VOLUME = "/wekafs"
 DEFAULT_PROXY = "harbor.core42.primus-safe.amd.com/proxy"
 # Cluster-aware defaults: SaFE backend's NormalizePromptConfig uses MI355X /
 # /hyperloom/InferenceX which are wrong for core42 (it's MI300X and the
-# InferenceX checkout actually lives on /wekafs). Without overriding here the
-# generated prompt sends the agent on a 5-10 min wild goose chase looking for
+# canonical hyperloom-managed InferenceX checkout lives at
+# /wekafs/hyperloom/InferenceX). Without overriding here the generated prompt
+# sends the agent on a 5-10 min wild goose chase looking for
 # /hyperloom/InferenceX, and it picks GPU-architecture-wrong heuristics later.
+#
+# /wekafs/hyperloom/InferenceX is the same priority path that:
+#   - inference_optimizer/cli.py:1586          uses as the V2 skill default
+#   - inference_optimizer/scripts/install.sh   bootstraps into
+#   - .github/workflows/inference-optimization-ci.yml lists FIRST after
+#     ${NFS_ROOT}/InferenceX in the config-file probe loop
+# Keeping this aligned avoids the agent landing on a stale /wekafs/InferenceX
+# checkout (left over from earlier non-hyperloom layouts on some sandboxes).
 DEFAULT_GPU_TYPE = "MI300X"
-DEFAULT_INFERENCEX_PATH = "/wekafs/InferenceX"
+DEFAULT_INFERENCEX_PATH = "/wekafs/hyperloom/InferenceX"
+
+# Canonical prompt prefix lives in ci/prompt_prefix.txt next to this script.
+# Single source of truth — same file is read by the GitHub workflow Submit
+# step (.github/workflows/optimize-submit.yml) as the schedule-trigger
+# fallback, and also serves as the argparse default here so any direct
+# CLI invocation (manual debugging, peer scripts, etc.) gets the same
+# prefix without having to set $SAFE_OPTIMIZE_PROMPT_PREFIX every time.
+_PROMPT_PREFIX_FILE = Path(__file__).resolve().parent / "prompt_prefix.txt"
+
+
+def _load_default_prompt_prefix() -> str:
+    """Resolve the default prompt prefix for ``--prompt-prefix``.
+
+    Resolution order:
+      1. ``$SAFE_OPTIMIZE_PROMPT_PREFIX`` (lets ops override per-run without
+         editing the file or argparse call)
+      2. ``ci/prompt_prefix.txt`` next to this script (canonical content)
+      3. empty string (caller is responsible — submit then refuses to ship
+         an empty prefix)
+    """
+
+    env_value = os.environ.get("SAFE_OPTIMIZE_PROMPT_PREFIX", "")
+    if env_value:
+        return env_value
+    try:
+        if _PROMPT_PREFIX_FILE.is_file():
+            return _PROMPT_PREFIX_FILE.read_text(encoding="utf-8")
+    except OSError:
+        pass
+    return ""
 
 # Architectures well-supported by SGLang on ROCm 7.x.
 SGLANG_ARCHS: set[str] = {
@@ -1719,11 +1758,11 @@ def _build_parser() -> argparse.ArgumentParser:
                              f"'{DEFAULT_INFERENCEX_PATH}'). SaFE backend default is "
                              f"/hyperloom/InferenceX which doesn't exist on core42.")
     parser.add_argument("--prompt-prefix",
-                        default=os.environ.get("SAFE_OPTIMIZE_PROMPT_PREFIX", ""),
-                        help="Optional free-form prefix prepended to the SaFE-generated "
-                             "Hyperloom prompt. The CI batch uses this to point the skill "
-                             "at /wekafs/HyperloomV2/inference_optimizer/SKILL.md before "
-                             "the auto-generated body. (env: $SAFE_OPTIMIZE_PROMPT_PREFIX)")
+                        default=_load_default_prompt_prefix(),
+                        help="Free-form prefix prepended to the SaFE-generated "
+                             "Hyperloom prompt. Default resolves to "
+                             "$SAFE_OPTIMIZE_PROMPT_PREFIX -> ci/prompt_prefix.txt "
+                             "-> empty. Pass an empty string explicitly to suppress.")
     parser.add_argument("--prompt-suffix",
                         default=os.environ.get("SAFE_OPTIMIZE_PROMPT_SUFFIX", ""),
                         help="Optional free-form suffix appended to the SaFE-generated "

--- a/ci/prompt_prefix.txt
+++ b/ci/prompt_prefix.txt
@@ -1,0 +1,119 @@
+Use the skill at /wekafs/HyperloomV2/inference_optimizer/SKILL.md to optimize this model.
+Working directory: cd /wekafs/HyperloomV2 before running any skill commands.
+
+CRITICAL — Required Artifacts (the canonical SaFE success contract):
+At the end of the run, ALWAYS write both files to $RESULT_DIR (defaults to /workspace/hyperloom/).
+If these files are missing, SaFE marks the task Failed regardless of whether the skill made real progress.
+
+  $RESULT_DIR/optimization_report.md
+  $RESULT_DIR/ci_metrics.json
+    {"baseline_throughput": <float>, "optimized_throughput": <float>, "gain_pct": <float>, "tok_per_gpu_baseline": <float>, "tok_per_gpu_optimized": <float>, "actions_taken": ["..."]}
+  $RESULT_DIR/session_breakdown.json   (optional but recommended — emitted by inference_optimizer; preserved alongside the two contract files for post-run audit)
+
+If the pipeline aborts (kernel apply failed / server failed to start / optimization tooling crash):
+- Set optimized_throughput = baseline_throughput, gain_pct = 0.0.
+- Set actions_taken = ["aborted: <one-line reason>"].
+- Still emit BOTH files. A partial report with baseline-only numbers is far more useful than no report at all.
+
+MANUAL FALLBACK (V2 orchestrator stuck in kernel-opt loop — observed pattern):
+If the V2 orchestrator runs past 2.5h without producing
+$RESULT_DIR/ci_metrics.json (it's spinning forever in the kernel-opt
+phase, re-optimizing the same 1-2 kernels every 60min cycle), DO NOT
+wait for it. Manually compose ci_metrics.json + optimization_report.md
+from the measurements you already have on disk:
+  * baseline number: $SESSION_DIR/phase02_baseline/baseline_results.json
+    (output_throughput field — that's tok/s/GPU at TP=1, or total tok/s
+    divided by TP for higher TP)
+  * profile classification: $SESSION_DIR/phase03_profile/profile_results.json
+    + any TraceLens analysis already written
+  * kernel info: $SESSION_DIR/phase05_kernel_opt/*/optimization_summary.json
+  * sweep best: $SESSION_DIR/phase06_sweep/* or run a single
+    `--decode-attention-backend aiter` / `--max-num-batched-tokens N`
+    sweep with the same server config to test ONE param change
+  * If you cannot get an optimized number, set optimized_throughput =
+    baseline_throughput, gain_pct = 0.0 (honest "no headroom" report).
+
+This is the path the Mistral-7B-v0.1 run on 2026-05-13 took
+(run 25795816178) — it produced a clean +0.10% report after the
+orchestrator stalled. Better an honest small-gain row than a missing
+row for a 2-3h run.
+
+CRITICAL — vLLM Forbidden Flags (server will crash with "unrecognized arguments"):
+- --num-scheduler-steps   (removed in vLLM v0.4.0)
+- --chunked-prefill-size  (SGLang-only, NOT vLLM)
+- --enable-chunked-prefill (only safe on vLLM >= 0.6.0; check version first)
+
+CRITICAL — Result Directory:
+Before running any skill script (run_baseline.sh, run_sweep.sh, etc.), export:
+  export NFS_ROOT=/wekafs
+  export RESULT_DIR=/workspace/hyperloom/
+Otherwise baseline/sweep writes fail silently and the job will hang.
+
+CRITICAL — POST-PIPELINE PERSIST (the most common reason a successful run shows up Failed):
+$RESULT_DIR (=/workspace/hyperloom/) lives inside the sandbox
+container's ephemeral storage. When SaFE marks the task Failed
+(or times out) the pod gets cleaned up and EVERYTHING under
+/workspace is lost — including the ci_metrics.json and
+optimization_report.md you just spent 2-3h producing. Even
+when SaFE marks the task Succeeded it only collects /workspace
+for a short window before deletion, and the CI side has no
+kubectl-exec access to read it back.
+
+To survive any of this you MUST copy the two artifacts to a
+persistent location under /hyperloom/users/<your-safe-uuid>/
+(which is the wekafs RW mount inside the sandbox — the
+CI / NFS Stage B fallback scans this path). Run this AFTER
+you have written the final ci_metrics.json + optimization_report.md:
+
+  mkdir -p $RESULT_DIR
+  # Persist to wekafs so it survives sandbox shutdown and CI
+  # can collect via NFS fallback even when SaFE artifact upload
+  # fails (Failed status, timeout, etc.).
+  UID_HEX=$(ls /hyperloom/users 2>/dev/null | head -1)
+  if [ -n "$UID_HEX" ]; then
+    # Use a unique session name that won't collide with prior runs
+    # (display_name + task_id last 8 chars).
+    MODEL_TAG=$(echo "${DISPLAYNAME:-task}" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9-' '-' | sed 's/-*$//')
+    TASK_TAG="${SAFE_TASK_ID:-$(date +%Y%m%d%H%M%S)}"
+    PERSIST_DIR="/hyperloom/users/$UID_HEX/${MODEL_TAG}-${TASK_TAG##*-}-opt"
+    mkdir -p "$PERSIST_DIR"
+    cp -f "$RESULT_DIR/ci_metrics.json"          "$PERSIST_DIR/ci_metrics.json"         2>/dev/null && echo "[PERSIST] $PERSIST_DIR/ci_metrics.json"
+    cp -f "$RESULT_DIR/optimization_report.md"  "$PERSIST_DIR/optimization_report.md"  2>/dev/null && echo "[PERSIST] $PERSIST_DIR/optimization_report.md"
+    cp -f "$RESULT_DIR/session_breakdown.json"  "$PERSIST_DIR/session_breakdown.json"  2>/dev/null && echo "[PERSIST] $PERSIST_DIR/session_breakdown.json"
+    ls -la "$PERSIST_DIR/"
+  else
+    echo "[ERR] /hyperloom/users/<uid>/ not mounted — cannot persist to wekafs"
+  fi
+
+  # Legacy back-fill direction: when the V2 orchestrator writes
+  # into /wekafs/users/<uid>/<sess>/ (older skill versions did
+  # this), the snippet below pulls it into $RESULT_DIR so SaFE
+  # sees the canonical files. Kept for backward compat — when
+  # we already wrote $RESULT_DIR ourselves above this is a no-op.
+  CI=$(ls -t /wekafs/users/*/*/ci_metrics.json \
+             /wekafs/users/*/*/phase10_report/ci_metrics.json \
+             /wekafs/users/*/*/results/ci_metrics.json \
+             2>/dev/null | head -1)
+  REPORT=$(ls -t /wekafs/users/*/*/optimization_report.md \
+                 /wekafs/users/*/*/phase10_report/optimization_report.md \
+                 /wekafs/users/*/*/reports/final.md \
+                 2>/dev/null | head -1)
+  if [ -n "$CI" ] && [ ! -s "$RESULT_DIR/ci_metrics.json" ]; then
+    cp -f "$CI" $RESULT_DIR/ci_metrics.json
+    echo "[BACKFILL] $CI -> $RESULT_DIR/ci_metrics.json"
+  fi
+  if [ -n "$REPORT" ] && [ ! -s "$RESULT_DIR/optimization_report.md" ]; then
+    cp -f "$REPORT" $RESULT_DIR/optimization_report.md
+    echo "[BACKFILL] $REPORT -> $RESULT_DIR/optimization_report.md"
+  fi
+  ls -la $RESULT_DIR/
+
+The ci_metrics.json values you write here MUST match what the V2
+orchestrator actually measured (proper baseline from phase 1 / best
+from phase 6-8) — do NOT recompute gain_pct from a partial-run
+eager-mode baseline that the orchestrator did not endorse.
+
+SAFETY:
+- NEVER `find /` or `find /wekafs` without `-maxdepth 4`. Prefer which/ls/$PATH lookups.
+- NEVER run `kill -9 $(ps aux | grep ...)` — this kills the sandbox executor itself.
+- Per-bash timeouts must be <= 120s; use short polling loops rather than one long blocking call.

--- a/ci/run_dsr1_multinode.py
+++ b/ci/run_dsr1_multinode.py
@@ -50,7 +50,7 @@ MODEL_CFG: dict = {
     "ep":                  1,
     "gpu_type":            "MI300X",
     "target_gpu":          "mi300x",
-    "inferencex_path":     "/wekafs/InferenceX",
+    "inferencex_path":     "/wekafs/hyperloom/InferenceX",
     "rayjob_image":        "harbor.core42.primus-safe.amd.com/custom/sync/sglang:202604290707",
     "kernel_opt_backends": "claude",
     "kernel_opt_image":    "harbor.core42.primus-safe.amd.com/proxy/lmsysorg/sglang-rocm:v0.5.10rc0-rocm720-mi35x-20260413",


### PR DESCRIPTION
## Summary

Fixes a silent regression where every cron-triggered batch shipped SaFE
optimization tasks with an **empty `promptPrefix`**, plus aligns
`DEFAULT_INFERENCEX_PATH` with the canonical hyperloom-managed checkout.

### Bug #1 — promptPrefix dropped on every `schedule` trigger

`workflow_dispatch.inputs.<name>.default` in GitHub Actions is **only**
substituted by the dispatch UI. On `schedule` (cron) trigger
`github.event.inputs.prompt_prefix` is always `""`. The old Submit step:

```bash
if [ -n "${INPUT_PROMPT_PREFIX:-}" ]; then
  ARGS+=(--prompt-prefix "${INPUT_PROMPT_PREFIX}")
fi
```

silently dropped the flag — so SaFE saw `promptPrefix=""` and the agent
got no skill pointer, no `ci_metrics.json` contract, no
`POST-PIPELINE PERSIST` instructions, no vLLM forbidden-flag list, no
SAFETY rules.

**Evidence** — `GET /api/v1/optimization/tasks?...sortOrder=desc` for
the 30 most recent tasks (including today's 09:48 cron batch of 20):

```
[X] opt-454de040-... | pp_len=0 | 2026-05-20T09:51:54Z | alpindale-WizardLM-2-8x22B          | Running
[X] opt-ed377bfb-... | pp_len=0 | 2026-05-20T09:50:28Z | Qwen-Qwen1.5-72B                    | Running
... (28 more, all pp_len=0) ...
summary: empty=30 nonempty=0
```

This is the root cause of most "scheduled run produced no artifacts"
failures we've been chasing for the past few batches.

### Bug #2 — `DEFAULT_INFERENCEX_PATH` lags behind hyperloom layout

`ci/optimize_submit.py` still set `DEFAULT_INFERENCEX_PATH =
"/wekafs/InferenceX"`, the pre-hyperloom layout. The canonical
hyperloom-managed checkout is `/wekafs/hyperloom/InferenceX`, already
used by `inference_optimizer/cli.py:1586`, `scripts/install.sh:194`,
and the priority probe in `inference-optimization-ci.yml:64`. When the
sandbox doesn't have the legacy path mounted, the agent burns 5-10 min
hunting for it before falling back.

## Fix — belt + suspenders

| Layer | Change |
|-------|--------|
| **L1 single-source-of-truth** | New `ci/prompt_prefix.txt` (120 lines, 6826 B) — skill pointer + artifact contract + `session_breakdown.json` + POST-PIPELINE PERSIST + vLLM forbidden flags + SAFETY |
| **L2 workflow Submit step** | Reads `ci/prompt_prefix.txt` whenever the workflow input is empty; **aborts with `::error::`** (exit 1) if both are missing — so we **never** ship empty promptPrefix again |
| **L3 Python CLI** | `_load_default_prompt_prefix()` resolves `$SAFE_OPTIMIZE_PROMPT_PREFIX` → `ci/prompt_prefix.txt` → empty; argparse default uses it. Any direct CLI invocation gets the same prefix |
| **InferenceX path** | `DEFAULT_INFERENCEX_PATH` → `/wekafs/hyperloom/InferenceX` in `ci/optimize_submit.py` and `ci/run_dsr1_multinode.py`; workflow input description updated to match |

## Files

```
new  ci/prompt_prefix.txt                       (+120)
mod  .github/workflows/optimize-submit.yml      (-143 inline default / +13 fallback step / +1 description)
mod  ci/optimize_submit.py                      (+34 loader & constant, -6 old defaults)
mod  ci/run_dsr1_multinode.py                   (1 line — path constant)
```

Total: **+199 / −148** across 4 files.

## Test plan

- [x] **Static** — `python -m py_compile` on all changed `.py`; `yaml.safe_load` on workflow; ReadLints clean
- [x] **Python loader** — `_load_default_prompt_prefix()` returns 6798 chars containing skill pointer + persistence rules + `session_breakdown.json` + vLLM safety markers; `$SAFE_OPTIMIZE_PROMPT_PREFIX` override path verified
- [x] **End-to-end body assembly** — mocked `SafeOptimizeClient.submit_task` with `args.prompt_prefix` from argparse default; captured `body["promptPrefix"]` = 6798 chars and **contains the canonical skill pointer**
- [ ] **Reviewer: workflow_dispatch sanity** — trigger the workflow with `prompt_prefix=""` explicitly and confirm the step still ships the file-loaded prefix (load log line `[prompt_prefix] loaded fallback from ci/prompt_prefix.txt`)
- [ ] **Reviewer: hard-fail sanity** — temporarily rename `ci/prompt_prefix.txt` in a side branch and confirm the workflow aborts with `::error::prompt_prefix is empty and ci/prompt_prefix.txt is missing — refusing to submit to SaFE with empty promptPrefix` (don't merge that side branch)
- [ ] **Production trigger** — after merge, wait for the next scheduled cron trigger (`0 */8 * * *`) and confirm `GET /api/v1/optimization/tasks` shows `promptPrefix` populated for all new tasks

## Backfill

19 tasks currently stuck `Running` on origin/main were submitted **before**
this fix and carry empty `promptPrefix`. They are tracked separately
(see open thread on rescue/cancel); this PR does **not** modify their
state.
