### PR TITLE
fix(kernel_optimization): Drop 1.50x early-exit and hard-coded GEAK homogeneous-mode hints from kernel optimization prompt

### DIFF
--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -896,15 +896,11 @@ def build_prompt(candidate: dict[str, Any], args: argparse.Namespace) -> str:
         "  search inside the repo, scope to the repo root: `find <repo> -name ...`\n"
         "  or `rg ... <repo>`, NEVER `find /`.\n"
         "\n"
-        "GOAL & EARLY-EXIT:\n"
-        "- Target speedup: >= 1.50x on the dominant inference shape(s).\n"
-        f"- Hard wall-clock budget: ~{budget_min} minutes. If you reach >=1.50x with\n"
-        "  passing correctness BEFORE the budget expires, STOP immediately, write the\n"
-        "  final `optimization_report.md` with `speedup: X.XXx` and exit (don't keep\n"
-        "  squeezing for marginal gains).\n"
-        f"- Otherwise iterate up to minute {int(budget_min*0.85)}, then STOP iterating\n"
-        "  and finalize the report with your best so-far measured speedup. The runner\n"
-        "  will SIGTERM at minute "
+        "GOAL & TIME BUDGET:\n"
+        f"- Hard wall-clock budget: ~{budget_min} minutes. Iterate up to minute "
+        f"{int(budget_min*0.85)},\n"
+        "  then STOP iterating and finalize the report with your best so-far measured\n"
+        "  speedup. The runner will SIGTERM at minute "
         f"{budget_min}; any in-flight work not on disk is lost.\n"
         "- Always print the final number in the form `speedup: X.XXx` (lowercase `x`)\n"
         "  at the END of `optimization_report.md` so the runner can extract it; if you\n"
@@ -1033,9 +1029,6 @@ def build_prompt(candidate: dict[str, Any], args: argparse.Namespace) -> str:
         "```json",
         json.dumps(kernel_metadata, indent=2, sort_keys=True),
         "```",
-        "",
-        "GEAK configuration (ignored by non-GEAK backends):",
-        "- Use homogeneous mode. Set max_rounds to 5.",
         "",
         hardware_notes,
         hypothesis_block,


### PR DESCRIPTION
Fixes #260 

## Summary

Removes two pieces of guidance from the prompt assembled by
`Hyperloom/kernel-agent/tools/kernel_optimization.py::build_prompt`:

1. The `GEAK configuration` block that hard-coded `homogeneous mode` and
   `max_rounds = 5` — runner/backend concerns that should not live in the
   prompt body.
2. The `EARLY-EXIT` rule that told the agent to stop optimizing as soon as
   it hit a `>= 1.50x` speedup, which capped quality below what the time
   budget actually permitted.

## Changes

- Deleted the bullet
  `- Use homogeneous mode. Set max_rounds to 5.` together with its now-empty
  `GEAK configuration (ignored by non-GEAK backends):` header and the
  trailing blank-line separator (no orphan heading).
- Deleted the `Target speedup: >= 1.50x` bullet and the
  `If you reach >=1.50x ... STOP immediately` early-exit bullet.
- Renamed the section header from `GOAL & EARLY-EXIT` to
  `GOAL & TIME BUDGET` and kept only the wall-clock budget + SIGTERM
  guidance, so the agent is steered to use the full budget to maximize
  speedup.

## Files affected

- `Hyperloom/kernel-agent/tools/kernel_optimization.py`

## Test plan

- [x] Run `rg -n "1\.50x|homogeneous mode|max_rounds|EARLY-EXIT|GEAK configuration" Hyperloom/kernel-agent/tools/kernel_optimization.py` and confirm zero matches
- [x] Run `pytest Hyperloom/kernel-agent/tools/test_kernel_optimization_verification.py -q` and confirm all `test_build_prompt_*` cases still pass
- [x] Render a prompt via `ko.build_prompt({...}, args)` and verify the `GOAL & TIME BUDGET` section is present (with `Hard wall-clock budget` and `SIGTERM at minute ...`) and that no `GEAK configuration (...)` block precedes `hardware_notes`

## Risk / rollout

- Prompt-only change; no API, schema, or runner-config changes.
- Non-GEAK backends are unaffected (they already ignored the GEAK block).