### PR TITLE
ci: auto-close issues 3 days after SaFE team's last reply

### DIFF
--- a/.github/workflows/issue-ball-tracker.yml
+++ b/.github/workflows/issue-ball-tracker.yml
@@ -1,0 +1,128 @@
+name: Track Issue Reply Ownership
+
+# Tags issues based on who replied last, so the stale workflow knows
+# which issues are waiting on the original (non-SaFE) author.
+#
+#   SaFE member replied (and author is non-SaFE)
+#     -> add label    'awaiting-author-response'
+#     -> remove label 'stale'
+#
+#   Anyone else replied (the author or any external user)
+#     -> remove label 'awaiting-author-response'
+#     -> remove label 'stale'
+#
+# Issues opened BY a SaFE member are skipped entirely (team handles them
+# manually; we never auto-close internal planning / umbrella issues).
+#
+# The roster of SaFE members is fetched live from
+#   https://github.com/orgs/AMD-AGI/teams/safe
+# using the SAFE_TEAM_READ_TOKEN secret (OAuth or PAT with read:org).
+# If the live fetch fails (token expired, org policy change, network),
+# the workflow falls back to a baked-in list so labeling still works.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  track:
+    # Only act on issue comments, not PR comments
+    if: ${{ !github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch SaFE team members
+        id: team
+        env:
+          GH_TOKEN: ${{ secrets.SAFE_TEAM_READ_TOKEN }}
+        run: |
+          set -e
+
+          MEMBERS_RAW=$(gh api orgs/AMD-AGI/teams/safe/members --paginate --jq '.[].login' 2>&1 || true)
+          MEMBERS_CLEAN=$(echo "$MEMBERS_RAW" | grep -E '^[a-zA-Z][a-zA-Z0-9_-]*$' || true)
+          COUNT=$(echo "$MEMBERS_CLEAN" | grep -c . || true)
+
+          if [ "${COUNT:-0}" -ge 1 ]; then
+            echo "Fetched $COUNT SaFE members live:"
+            echo "$MEMBERS_CLEAN"
+            JSON=$(echo "$MEMBERS_CLEAN" | jq -R . | jq -s -c .)
+            {
+              echo "members=$JSON"
+              echo "source=live"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Could not fetch SaFE team live; using fallback list"
+            echo "API response was:"
+            echo "$MEMBERS_RAW"
+            # Fallback list (last refreshed: 2026-05-21)
+            # To refresh:
+            #   gh api orgs/AMD-AGI/teams/safe/members --paginate --jq '.[].login'
+            {
+              echo 'members=["nehaprakriya","haishuok0525","chaojhou","weilei0120","zhanglei-amd","fengshaoyi-amd","xiaofei-zheng","chennyiiis","lishuoshuo-amd","luochen-amd","BaoYunkai","ZhengGong-amd"]'
+              echo "source=fallback"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update reply-ownership labels
+        uses: actions/github-script@v7
+        env:
+          SAFE_TEAM_JSON: ${{ steps.team.outputs.members }}
+          SAFE_TEAM_SOURCE: ${{ steps.team.outputs.source }}
+        with:
+          script: |
+            const SAFE_TEAM = JSON.parse(process.env.SAFE_TEAM_JSON);
+            const source = process.env.SAFE_TEAM_SOURCE;
+            const safeSet = new Set(SAFE_TEAM.map(s => s.toLowerCase()));
+            core.info(`SaFE roster (${source}, ${safeSet.size} members): ${[...safeSet].join(', ')}`);
+
+            const AWAIT_LABEL = 'awaiting-author-response';
+            const STALE_LABEL = 'stale';
+
+            const issue = context.payload.issue;
+            const comment = context.payload.comment;
+            const commenter = comment.user.login.toLowerCase();
+            const author = issue.user.login.toLowerCase();
+            const isBot = comment.user.type === 'Bot' || commenter.endsWith('[bot]');
+
+            core.info(`issue #${issue.number} opened by @${author}, comment by @${commenter} (bot=${isBot})`);
+
+            if (isBot) {
+              core.info('Bot comment, skipping');
+              return;
+            }
+            if (safeSet.has(author)) {
+              core.info('Issue author is on SaFE team -> manual handling, skipping');
+              return;
+            }
+
+            const currentLabels = new Set((issue.labels || []).map(l => l.name));
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = issue.number;
+
+            async function addLabel(name) {
+              if (currentLabels.has(name)) return;
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [name] });
+              core.info(`+ label: ${name}`);
+            }
+            async function removeLabel(name) {
+              if (!currentLabels.has(name)) return;
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number, name });
+                core.info(`- label: ${name}`);
+              } catch (e) {
+                if (e.status !== 404) throw e;
+              }
+            }
+
+            if (safeSet.has(commenter)) {
+              // SaFE replied -> ball is now on the (non-SaFE) author
+              await addLabel(AWAIT_LABEL);
+              await removeLabel(STALE_LABEL);
+            } else {
+              // Author or anyone else replied -> ball back to us, reset
+              await removeLabel(AWAIT_LABEL);
+              await removeLabel(STALE_LABEL);
+            }

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,55 @@
+name: Auto-close stale issues awaiting author response
+
+# Runs hourly. Only acts on issues labeled 'awaiting-author-response':
+#   - After ~48h with no activity -> add 'stale' + post warning comment
+#   - After another ~24h          -> close + post farewell comment
+#
+# PRs are never touched. Issues labeled 'pinned' or 'keep-open' are exempt.
+# The 'awaiting-author-response' label is managed by issue-ball-tracker.yml.
+
+on:
+  schedule:
+    - cron: '30 * * * *'      # Every hour at HH:30 UTC
+  workflow_dispatch:           # Manual trigger for testing
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # ---- Scope: issues only, never touch PRs ----
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+
+          # ---- Only act on issues waiting on the author ----
+          any-of-issue-labels: 'awaiting-author-response'
+
+          # ---- Never auto-close issues marked to keep open ----
+          exempt-issue-labels: 'pinned,keep-open'
+
+          # ---- Timing: 2 days no activity -> stale, +1 day -> close ----
+          days-before-issue-stale: 2
+          days-before-issue-close: 1
+
+          stale-issue-label: 'stale'
+
+          # When the issue is updated (commented / edited), remove 'stale'
+          remove-stale-when-updated: true
+
+          stale-issue-message: |
+            This issue has been quiet for about **2 days** since our last reply.
+
+            It will be closed automatically in **1 day** if there is no further activity.
+            If you are still working on this, please leave a comment with any update — that will reset the timer.
+
+          close-issue-message: |
+            This issue has been automatically closed because there was no response for about **3 days** after our last comment.
+
+            If you would like to continue the discussion, please feel free to reopen this issue or leave a new comment — we will be happy to take another look.
+
+          # Be polite to the API
+          operations-per-run: 100


### PR DESCRIPTION
﻿## Summary

Adds two GitHub Actions workflows that auto-close issues which have been silent for ~3 days **after a SaFE team member replied** (i.e. the ball is on the original author).

- **issue-ball-tracker** (`.github/workflows/issue-ball-tracker.yml`): on each issue comment, toggles the `awaiting-author-response` label based on whether the commenter is in the `AMD-AGI/safe` team. Roster is fetched live via API using the `SAFE_TEAM_READ_TOKEN` secret, with a hardcoded fallback list so labeling keeps working if the token ever expires.
- **stale-issues** (`.github/workflows/stale-issues.yml`): hourly cron via `actions/stale@v9`. Acts only on issues carrying `awaiting-author-response`, adds `stale` + warning comment after ~48h of inactivity, closes the issue with a friendly note after another ~24h.

## How it works

```
   issue comment evt                         hourly cron
        |                                          |
        v                                          v
  issue-ball-tracker                         stale-issues
  - fetch SaFE roster (live + fallback)      - find issues w/ yellow label
  - SaFE replied -> +yellow                  - >=48h -> +gray + warn comment
  - anyone else  -> -yellow                  - >=72h -> close + farewell
```

## Setup already done on `main`

- Repo secret `SAFE_TEAM_READ_TOKEN` added (OAuth token with `read:org`)
- Labels created: `awaiting-author-response` (yellow), `stale` (gray), `keep-open` (green)

## Behavior

- Issues opened **by SaFE members themselves are skipped entirely** (manual handling, e.g. feature umbrella issues)
- Issues labeled `pinned` or `keep-open` are **never auto-closed**
- **PRs are completely untouched** (`days-before-pr-*` set to `-1`)
- Any new activity (comment / edit) resets the timer

## Test plan

- [x] After merge, manually run `stale-issues` once via Actions UI; verify log output
- [ ] Find an open external issue; have a SaFE member comment on it; verify `awaiting-author-response` is added within ~1 min
- [ ] Post a comment as the issue author; verify the yellow label is removed
- [ ] Optionally wait ~3 days on a sacrificial issue to confirm the full warn+close cycle