### PR TITLE
fix(ci): manual-poke skips issues that already have 'stale' label

### DIFF
--- a/.github/workflows/manual-poke-issues.yml
+++ b/.github/workflows/manual-poke-issues.yml
@@ -99,7 +99,8 @@ jobs:
             core.info(`Open issues to scan: ${issues.length}`);
             core.info('');
 
-            const candidates = [];
+            const candidates = [];     // matching issues, not yet poked
+            const alreadyPoked = [];   // matching issues but already have 'stale' label
 
             for (const issue of issues) {
               const authorLogin = issue.user.login.toLowerCase();
@@ -130,24 +131,39 @@ jobs:
               if (lastSafeAt && !nonSafeAfterSafe) {
                 const hours = (now - lastSafeAt) / 3600000;
                 if (hours >= hoursThreshold) {
-                  candidates.push({
+                  const labels = new Set((issue.labels || []).map(l => typeof l === 'string' ? l : l.name));
+                  const entry = {
                     num: issue.number,
                     author: issue.user.login,
                     lastSafeBy,
                     hours: Math.round(hours * 10) / 10,
                     title: issue.title,
-                    currentLabels: new Set((issue.labels || []).map(l => typeof l === 'string' ? l : l.name)),
-                  });
+                    currentLabels: labels,
+                  };
+                  // 'stale' label means we have already poked this issue; skip to avoid
+                  // re-posting the warning comment every time the workflow is run.
+                  if (labels.has('stale')) {
+                    alreadyPoked.push(entry);
+                  } else {
+                    candidates.push(entry);
+                  }
                 }
               }
             }
 
             candidates.sort((a, b) => b.hours - a.hours);
+            alreadyPoked.sort((a, b) => b.hours - a.hours);
 
             core.info('=== Matching issues ===');
-            core.info(`Found: ${candidates.length}`);
+            core.info(`To process: ${candidates.length}`);
             for (const c of candidates) {
               core.info(`  #${c.num} (${c.author}, ${c.hours}h since @${c.lastSafeBy}): ${c.title}`);
+            }
+            if (alreadyPoked.length > 0) {
+              core.info(`Already poked (skipped, have 'stale' label): ${alreadyPoked.length}`);
+              for (const c of alreadyPoked) {
+                core.info(`  #${c.num} (${c.author}, ${c.hours}h since @${c.lastSafeBy}): ${c.title}`);
+              }
             }
             core.info('');
 


### PR DESCRIPTION
﻿## Summary

Without this guard, every run of "Scan & poke stale issues" would re-post the warning comment on issues we already poked. Here is why:

```js
for (const c of comments) {
  const isBot = c.user.type === 'Bot' || cAuthor.endsWith('[bot]');
  if (isBot) continue;            // bot comments are skipped...
  ...
}
```

The bot warning comment is filtered out as not a "real" reply, so `lastSafeAt` still points to the original SaFE reply forever. The condition `ball-on-author + >= 48h` stays true until the human author actually replies, so every subsequent `dry_run=false` run posts another duplicate warning.

## Fix

Split matches into two buckets and only act on the first one:

| Bucket | Has `stale` label? | Action |
|---|---|---|
| `candidates` | no | label + warn |
| `alreadyPoked` | yes | log only, skipped |

Both buckets are still printed in the run log so the operator sees the full picture.

The "issue already closed" case is implicitly handled because we only scan `state=open`.

## Test plan

- [ ] After merge, re-run `Scan & poke stale issues` (dry-run) -> #255 should appear in "Already poked" not "To process"
- [ ] Re-run with `dry_run=false` -> bot does NOT add a duplicate comment on #255
- [ ] Wait for the next match (some other issue going stale) -> still gets warned correctly the first time