### PR TITLE
breakdown: mirror session_breakdown.json into claw-synced subtree

### DIFF
--- a/inference_optimizer/breakdown/claw_mirror.py
+++ b/inference_optimizer/breakdown/claw_mirror.py
@@ -1,0 +1,55 @@
+"""Mirror ``session_breakdown.json`` into the claw-synced subtree.
+
+Hyperloom's canonical write lands in ``<session_dir>/`` which under the
+default ``per_model_ts`` layout is ``<workspace>/<model>/<ts>/``. The
+claw sandbox checkpoint sync only watches the ``hyperloom/`` subtree
+under ``$USER_DATA_PATH``, so without an explicit mirror the canonical
+artifact is lost the moment the sandbox is reaped.
+
+This module exposes a single best-effort helper, kept off ``cli.py`` so
+the unit tests can exercise it without dragging in cli's full import
+graph (``orchestrator/action_executors`` pulls ``fcntl`` and friends
+that aren't available on every dev box).
+
+Contract:
+
+* On success, returns the absolute mirror path.
+* On any failure (empty ``session_id``, missing source, unwritable
+  destination, etc.) returns ``None`` and logs — the caller MUST treat
+  the canonical write as the source of truth and never let a mirror
+  failure mask the real ``stop_reason``.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+
+from ..paths import workspace_root
+
+log = logging.getLogger(__name__)
+
+
+def mirror_breakdown_to_claw_storage(
+    breakdown_path: Path,
+    *,
+    session_id: str,
+) -> Path | None:
+    """Copy ``breakdown_path`` to ``<workspace_root>/hyperloom/<sid>/``.
+
+    See module docstring for the full contract. Never raises.
+    """
+    sid = (session_id or "").strip()
+    if not sid:
+        log.warning("session_breakdown claw-mirror skipped: empty session_id")
+        return None
+    try:
+        mirror_dir = workspace_root() / "hyperloom" / sid
+        mirror_dir.mkdir(parents=True, exist_ok=True)
+        mirror_path = mirror_dir / breakdown_path.name
+        shutil.copy2(breakdown_path, mirror_path)
+        return mirror_path
+    except Exception:  # noqa: BLE001
+        log.exception("session_breakdown claw-mirror failed (non-fatal)")
+        return None

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -2864,8 +2864,15 @@ async def _run_optimize(args: argparse.Namespace) -> int:
         # mask the actual stop_reason, so we swallow exceptions and log.
         try:
             from .breakdown import write_breakdown_json
+            from .breakdown.claw_mirror import mirror_breakdown_to_claw_storage
             breakdown_path = write_breakdown_json(session_dir)
             print(f"Session breakdown : {breakdown_path}")
+            mirror_path = mirror_breakdown_to_claw_storage(
+                breakdown_path,
+                session_id=coordinator.shared_state.session_id or "",
+            )
+            if mirror_path is not None:
+                print(f"Session breakdown (claw mirror): {mirror_path}")
         except Exception:  # noqa: BLE001
             log.exception("session_breakdown finalize failed (non-fatal)")
 

--- a/inference_optimizer/tests/test_cli_breakdown_claw_mirror.py
+++ b/inference_optimizer/tests/test_cli_breakdown_claw_mirror.py
@@ -1,0 +1,128 @@
+"""Unit tests for ``breakdown.claw_mirror.mirror_breakdown_to_claw_storage``.
+
+The hyperloom CLI writes ``session_breakdown.json`` into ``session_dir``
+(which under the default ``per_model_ts`` layout is
+``<workspace>/<model>/<ts>/``). The claw sandbox checkpoint sync only
+watches the ``hyperloom/`` subtree under ``$USER_DATA_PATH``; without
+the mirror tested here the canonical breakdown is lost when the sandbox
+is reaped, breaking ``claw-stats-service`` historical lookups.
+
+The mirror lives in its own module (rather than as a private helper on
+``cli.py``) precisely so this test file can import it without dragging
+in cli's ``orchestrator/action_executors`` graph (which imports
+``fcntl`` and other POSIX-only modules).
+
+These tests exercise the mirror helper in isolation:
+
+* happy-path mirror lands at ``<workspace_root>/hyperloom/<sid>/...``;
+* empty ``session_id`` is a no-op (warns, returns ``None``);
+* unreadable source / unwritable dest is a no-op (logs, returns ``None``)
+  — the canonical write path is the source of truth and MUST NOT be
+  broken by mirror failures.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from inference_optimizer.breakdown.claw_mirror import (
+    mirror_breakdown_to_claw_storage,
+)
+from inference_optimizer.paths import ENV_USER_DATA_PATH
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Pin ``$USER_DATA_PATH`` at ``tmp_path`` so ``workspace_root()``
+    returns a writable scratch dir for the duration of the test."""
+    monkeypatch.setenv(ENV_USER_DATA_PATH, str(tmp_path))
+    return tmp_path
+
+
+def _make_breakdown(session_dir: Path, payload: dict | None = None) -> Path:
+    """Drop a minimal ``session_breakdown.json`` under a per-model-ts
+    subdir of the workspace, mimicking hyperloom's canonical layout."""
+    session_dir.mkdir(parents=True, exist_ok=True)
+    bp = session_dir / "session_breakdown.json"
+    bp.write_text(
+        json.dumps(payload or {"schema_version": "1.1.0", "session": {}}),
+        encoding="utf-8",
+    )
+    return bp
+
+
+def test_mirrors_to_workspace_hyperloom_subtree(workspace: Path) -> None:
+    """Happy path: copy lands at ``hyperloom/<sid>/session_breakdown.json``
+    with identical bytes — that's the path the claw sync watches."""
+    sid = "abc123"
+    canonical = _make_breakdown(
+        workspace / "Llama-3.1-8B" / "20260525T040000Z",
+        payload={"schema_version": "1.1.0", "session": {"session_id": sid}},
+    )
+
+    mirror = mirror_breakdown_to_claw_storage(canonical, session_id=sid)
+
+    expected = workspace / "hyperloom" / sid / "session_breakdown.json"
+    assert mirror == expected
+    assert mirror.is_file()
+    assert mirror.read_bytes() == canonical.read_bytes()
+
+
+def test_empty_session_id_is_noop(
+    workspace: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Empty/whitespace ``session_id`` would collapse the mirror dir into
+    ``hyperloom/`` itself, which is wrong; the helper must bail out and
+    leave the canonical file untouched."""
+    canonical = _make_breakdown(workspace / "model" / "ts")
+
+    with caplog.at_level("WARNING"):
+        result = mirror_breakdown_to_claw_storage(canonical, session_id="")
+
+    assert result is None
+    assert not (workspace / "hyperloom").exists()
+    assert any("empty session_id" in r.message for r in caplog.records)
+
+
+def test_missing_source_is_swallowed(
+    workspace: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """If the canonical write didn't actually produce a file (caller
+    bug, disk full, etc.) the mirror must log + return ``None`` rather
+    than raise — the finally block in ``_run_optimize`` relies on this
+    to keep ``stop_reason`` propagation intact."""
+    bogus = workspace / "model" / "ts" / "session_breakdown.json"
+
+    with caplog.at_level("ERROR"):
+        result = mirror_breakdown_to_claw_storage(bogus, session_id="sid42")
+
+    assert result is None
+    assert any("claw-mirror failed" in r.message for r in caplog.records)
+
+
+def test_overwrites_existing_mirror(workspace: Path) -> None:
+    """Repeat runs with the same session_id (e.g. ``--resume``) must
+    overwrite the previous mirror — otherwise downstream consumers
+    would see a stale early snapshot."""
+    sid = "resumed-sid"
+    canonical = _make_breakdown(
+        workspace / "m" / "ts1",
+        payload={"schema_version": "1.1.0", "session": {"tick": 1}},
+    )
+    mirror_breakdown_to_claw_storage(canonical, session_id=sid)
+
+    # Second run, same sid, fresher payload.
+    canonical2 = _make_breakdown(
+        workspace / "m" / "ts2",
+        payload={"schema_version": "1.1.0", "session": {"tick": 99}},
+    )
+    mirror = mirror_breakdown_to_claw_storage(canonical2, session_id=sid)
+
+    assert mirror is not None
+    payload = json.loads(mirror.read_text(encoding="utf-8"))
+    assert payload["session"]["tick"] == 99


### PR DESCRIPTION
## Summary

- Mirror `session_breakdown.json` into `<workspace_root>/hyperloom/<session_id>/` so the claw sandbox checkpoint sync (which only watches the `hyperloom/` subtree) picks it up. Without this, the canonical file under `<workspace>/<model>/<ts>/` is lost the moment the sandbox is reaped, breaking `claw-stats-service` / offline forensics for any historical session.
- Mirror is best-effort and never raises: failures are swallowed + logged so the real `stop_reason` propagation stays intact.
- Helper lives in its own module `breakdown/claw_mirror.py` rather than as a private helper on `cli.py`, so the unit tests can import it without dragging in cli's `orchestrator/action_executors` graph (which imports `fcntl` and other POSIX-only modules).

## Why now

PR #281 (v1.1 schema) just landed on `main`, so the canonical sbd write is in place — this PR closes the last gap by making sure the artifact survives sandbox death and lands somewhere the claw S3 sync can see.

## Diff scope

- `inference_optimizer/cli.py` — +7 lines in the existing `finally` block.
- `inference_optimizer/breakdown/claw_mirror.py` — new, ~30 lines.
- `inference_optimizer/tests/test_cli_breakdown_claw_mirror.py` — new, 4 tests.

## Test plan

- [x] `pytest inference_optimizer/tests/test_cli_breakdown_claw_mirror.py` — 4/4 pass.
- [x] `pytest inference_optimizer/tests/test_breakdown_*.py inference_optimizer/tests/test_cli_breakdown_claw_mirror.py` — 57/57 pass (no breakdown-suite regressions).
- [x] Lint clean.
- [ ] Post-merge: smoke-check on a CI-driven hyperloom run that `<workspace>/hyperloom/<sid>/session_breakdown.json` shows up in claw's MinIO bucket and is fetchable through `claw-api`.

## Notes for reviewers

- The mirror copies the canonical file rather than re-running `build()` — `build()` is idempotent but not free (re-walks all collectors), and `shutil.copy2` preserves mtime which keeps S3 sync diffs sane.
- Path uses only the hyperloom `session_id`. `claw_session_id` is not always set (e.g. local repro runs); downstream consumers can recover it from the sbd JSON itself if they need to reverse-map.
- Empty `session_id` is a deliberate no-op (would otherwise collapse the dir into `hyperloom/` itself).
