### PR TITLE
add compliance docs and harden CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,4 @@
+- Description: what and why
+- Linked issue(s): close/fix refs
+- Tests: added/updated? commands run?
+- Breaking changes: yes/no (details if yes)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/ci"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+
 env:
   REPO: ${{ github.repository }}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,24 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: python
+          queries: security-and-quality
+      - uses: github/codeql-action/analyze@v3

--- a/.github/workflows/github-weekly-report.yml
+++ b/.github/workflows/github-weekly-report.yml
@@ -3,6 +3,9 @@ name: github-weekly-report
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   weekly-issues-report:
     runs-on: ubuntu-latest

--- a/.github/workflows/inference-ab-test.yml
+++ b/.github/workflows/inference-ab-test.yml
@@ -32,6 +32,9 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: read
+
 env:
   SAFE_BASE_URL: ${{ secrets.SAFE_BASE_URL }}
   NFS_ROOT: ${{ secrets.NFS_ROOT }}

--- a/.github/workflows/inference-optimization-ci.yml
+++ b/.github/workflows/inference-optimization-ci.yml
@@ -14,6 +14,9 @@ on:
         required: false
         default: 'manual'
 
+permissions:
+  contents: read
+
 env:
   SAFE_BASE_URL: ${{ secrets.SAFE_BASE_URL }}
   NFS_ROOT: ${{ secrets.NFS_ROOT }}

--- a/.github/workflows/inference-optimization-pr-ci.yml
+++ b/.github/workflows/inference-optimization-pr-ci.yml
@@ -23,6 +23,9 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions:
+  contents: read
+
 env:
   SAFE_BASE_URL: ${{ secrets.SAFE_BASE_URL }}
   NFS_ROOT: ${{ secrets.NFS_ROOT }}

--- a/.github/workflows/issue-ball-tracker.yml
+++ b/.github/workflows/issue-ball-tracker.yml
@@ -25,10 +25,12 @@ on:
     types: [created]
 
 permissions:
-  issues: write
+  contents: read
 
 jobs:
   track:
+    permissions:
+      issues: write
     # Only act on issue comments, not PR comments
     if: ${{ !github.event.issue.pull_request }}
     runs-on: ubuntu-latest

--- a/.github/workflows/manual-poke-issues.yml
+++ b/.github/workflows/manual-poke-issues.yml
@@ -30,10 +30,12 @@ on:
         default: '48'
 
 permissions:
-  issues: write
+  contents: read
 
 jobs:
   scan-and-poke:
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - name: Fetch SaFE team members

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -8,6 +8,9 @@ on:
   issues:
     types: [opened, assigned, reopened]
 
+permissions:
+  contents: read
+
 env:
   PROJECT_NUMBER: "43"
   ORGANIZATION: "AMD-AGI"

--- a/.github/workflows/release-provenance.yml
+++ b/.github/workflows/release-provenance.yml
@@ -1,0 +1,27 @@
+name: Release Provenance
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  attest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Build distributions
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+          python -m build
+      - name: Generate provenance attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: 'dist/*'

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -13,10 +13,12 @@ on:
   workflow_dispatch:           # Manual trigger for testing
 
 permissions:
-  issues: write
+  contents: read
 
 jobs:
   stale:
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+- Add repository governance docs (LICENSE, SECURITY.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md).
+
+## [v0.3] - 2026-05-14
+### Added
+- Opt-in PMC roofline action gated after `select_kernels`, deriving workload from materialized Magpie config.
+- PMC roofline integration tests for Ray-based execution path.
+
+### Fixed
+- Enforce PMC roofline GPU work to run inside a Ray-owned worker while preserving local debug escape hatches.
+- Resolve PMC roofline GPU spec handling for Ray contexts.
+
+## [v0.2] - 2026-04-22
+### Added
+- Hardened marathon protocol with deep kernel analysis, KM feed pipeline improvements, micro-benchmarking, and GPU time-share handling.
+- Vendor kernel configuration guidance and updated kernel-manager skills/actions (including local-test flow).
+- Launcher scripts refinements for orchestrator/kernel manager panes.
+
+[Unreleased]: https://github.com/AMD-AGI/Hyperloom/compare/v0.3...HEAD
+[v0.3]: https://github.com/AMD-AGI/Hyperloom/releases/tag/v0.3
+[v0.2]: https://github.com/AMD-AGI/Hyperloom/releases/tag/v0.2

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,79 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others’ private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at security@amd.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla’s code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to Hyperloom
+
+Thank you for helping improve Hyperloom. This guide covers the expected workflow, local setup, and quality checks.
+
+## Pull Request workflow
+- Create a feature branch off `main`.
+- Keep changes focused and include context in the PR description (problem, approach, test coverage).
+- Ensure all checks below pass before requesting review.
+- Avoid committing generated artifacts; keep diffs minimal.
+
+## Development setup
+- Python 3.10+.
+- Create and activate a virtual environment.
+- Install dependencies (including test extras):  
+  `pip install -e .[test]`
+- If you plan to run lint/type checks, install tools:  
+  `pip install ruff mypy`
+
+## Testing
+- Run the full test suite from the repo root:  
+  `pytest`
+- To target a directory or file:  
+  `pytest inference_optimizer/tests`  
+  `pytest inference_optimizer/tests/test_prompt_builder.py -k subset`
+
+## Linting and formatting
+- Ruff:  
+  `ruff check .`
+- Type checks (mypy):  
+  `mypy inference_optimizer kernel-agent robustness-agent`
+  - Adjust paths if you change package locations.
+
+## Before opening a PR
+- [ ] Tests pass (`pytest`).
+- [ ] Lint clean (`ruff check .`).
+- [ ] Type checks clean (`mypy ...`).
+- [ ] No unwanted files (build artifacts, large logs, credentials).
+
+## Security
+- Do not include secrets in code or logs.
+- Report vulnerabilities privately as described in `SECURITY.md`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,89 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work.
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!) The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,89 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work.
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!) The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,7 @@
+version = 1
+
+[[annotations]]
+path = "**"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 Advanced Micro Devices, Inc."
+SPDX-License-Identifier = "Apache-2.0"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Please do not open public issues.**
+
+Preferred: use GitHub Private Vulnerability Reporting (Settings → Code security → Private vulnerability reporting → Enable). If enabled, submit via “Report a vulnerability” in the repo Security tab.
+
+Alternative: use the AMD Product Security portal: https://www.amd.com/en/resources/product-security.html
+
+When reporting, include:
+- Description and impact
+- Steps to reproduce or proof of concept
+- Affected versions or commit hashes
+- Relevant logs or environment details (if available)
+
+We aim to acknowledge reports within 1 business day.
+
+## Scope
+
+This policy covers code and configuration in this repository. If the issue is in third-party dependencies, please report upstream; for AMD products unrelated to this repo, use the AMD Product Security portal.

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -398,6 +398,7 @@ class Coordinator:
         compare_against_gpu: str | None = None,
         model_class: str | None = None,
     ):
+        """Wire core coordinator dependencies and runtime configuration."""
         self.session_dir = Path(session_dir)
         self.role_registry = role_registry or default_role_registry()
         # External-SKILL-driven configuration. Both replace the deleted
@@ -2825,6 +2826,7 @@ class Coordinator:
     # Intent handling
     # ==================================================================
     async def _handle_intent(self, source: str, intent: Intent) -> None:
+        """Validate policy, then dispatch the intent to the appropriate handler."""
         try:
             self.policy.validate_intent(source, intent)
         except PolicyDenied as denied:
@@ -2868,6 +2870,7 @@ class Coordinator:
     # PROPOSE_ACTION + REVIEW_VERDICT
     # ------------------------------------------------------------------
     async def _handle_propose_action(self, source: str, intent: Intent) -> None:
+        """Persist a proposed action, gate it, and enqueue for Critic review."""
         action_name = intent.payload["action_name"]
         # Pruned-family check reads from persistent SharedState so resume
         # after crash still respects the prune.
@@ -3492,6 +3495,7 @@ class Coordinator:
         }
 
     async def _handle_response(self, source: str, intent: Intent) -> None:
+        """Fan-out a RESPONSE intent back to the original requester."""
         in_reply_to = intent.payload["in_reply_to"]
         # Locate the original requester so we can address the response.
         original = await self.bus.lookup_by_id(in_reply_to)
@@ -3573,6 +3577,7 @@ class Coordinator:
         ))
 
     async def _handle_update_state(self, source: str, intent: Intent) -> None:
+        """Apply allowed SharedState mutations and broadcast the diff."""
         # Apply to persistent SharedState (PolicyGate already enforced that
         # the source role can't write CORE_STATE_FIELDS unless allowed).
         applied = self.shared_state.apply_changes(

--- a/kernel-agent/scripts/install.sh
+++ b/kernel-agent/scripts/install.sh
@@ -390,7 +390,18 @@ ensure_node() {
 
   log "installing Node.js 20 from NodeSource"
   apt-get -y purge libnode-dev libnode72 nodejs nodejs-doc npm >/dev/null 2>&1 || true
-  if ! curl -fsSL https://deb.nodesource.com/setup_20.x 2>/dev/null | bash - >/dev/null 2>&1; then
+  local ns_url="https://deb.nodesource.com/setup_20.x"
+  local ns_sha="2c4c6683a17b6f4128898a7b521e3c8bb725a99ffaf1b5e32ac97c6fa7d381be"
+  local ns_script="/tmp/nodesource_setup_20.x"
+  if ! curl -fsSL "$ns_url" -o "$ns_script"; then
+    verify_die "NodeSource setup download failed; cannot install Node.js/npm for claude/codex CLIs"
+    return 0
+  fi
+  if ! echo "${ns_sha}  ${ns_script}" | sha256sum -c - >/dev/null 2>&1; then
+    verify_die "NodeSource setup SHA256 mismatch; aborting Node.js/npm install"
+    return 0
+  fi
+  if ! bash "$ns_script" >/dev/null 2>&1; then
     verify_die "NodeSource setup failed; cannot install Node.js/npm for claude/codex CLIs"
     return 0
   fi

--- a/kernel-agent/tools/apply_kernel_patch.py
+++ b/kernel-agent/tools/apply_kernel_patch.py
@@ -184,19 +184,23 @@ def _dispatch_multinode_revert(
 
 
 def _now() -> str:
+    """Return the current UTC timestamp as an ISO8601 string."""
     return datetime.now(timezone.utc).isoformat()
 
 
 def _safe_name(value: str) -> str:
+    """Sanitize a filename component to a safe, short identifier."""
     cleaned = "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in value)
     return cleaned[:80] or "kernel"
 
 
 def _path_hash(path: Path) -> str:
+    """Return a short, stable hash for ``path`` to disambiguate backups."""
     return hashlib.sha256(str(path).encode("utf-8")).hexdigest()[:16]
 
 
 def _copy_to_backup(path: Path, backup_dir: Path, group: str) -> dict[str, str]:
+    """Copy a file into the backup tree and return the manifest entry."""
     dst = backup_dir / group / f"{_path_hash(path)}_{path.name}"
     dst.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(path, dst)
@@ -204,6 +208,7 @@ def _copy_to_backup(path: Path, backup_dir: Path, group: str) -> dict[str, str]:
 
 
 def _source_text_looks_complete(text: str, suffix: str) -> bool:
+    """Heuristically check that the patch text is a full source file."""
     stripped = text.strip()
     if not stripped or "```" in stripped:
         return False

--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -28,10 +28,12 @@ sys.path.pop(0)
 
 
 def utc_now() -> str:
+    """Return the current UTC time as an ISO8601 string."""
     return datetime.now(timezone.utc).isoformat()
 
 
 def atomic_write_json(path: Path, data: dict[str, Any]) -> None:
+    """Atomically write JSON to ``path`` using a temp file then rename."""
     path.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.NamedTemporaryFile("w", dir=str(path.parent), delete=False) as tmp:
         json.dump(data, tmp, indent=2, sort_keys=True)
@@ -41,18 +43,21 @@ def atomic_write_json(path: Path, data: dict[str, Any]) -> None:
 
 
 def append_jsonl(path: Path, data: dict[str, Any]) -> None:
+    """Append one JSON object as a line to the given JSONL file."""
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(data, sort_keys=True) + "\n")
 
 
 def append_log(log_path: Path, message: str) -> None:
+    """Append a log line to ``log_path`` (ensuring parent dirs exist)."""
     log_path.parent.mkdir(parents=True, exist_ok=True)
     with log_path.open("a", encoding="utf-8") as fh:
         fh.write(message.rstrip() + "\n")
 
 
 def read_last_lines(log_path: Path, limit: int = 20) -> list[str]:
+    """Return the last ``limit`` lines of a log file, empty if missing."""
     if not log_path.exists():
         return []
     lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
@@ -70,6 +75,7 @@ def update_status(
     started_at: str,
     error: str | None = None,
 ) -> None:
+    """Persist a status snapshot for the current run."""
     payload: dict[str, Any] = {
         "tool": "kernel_optimization",
         "run_id": run_id,
@@ -89,6 +95,7 @@ def update_status(
 
 
 def load_candidates(path: Path) -> list[dict[str, Any]]:
+    """Load kernel candidates from JSON, normalizing legacy shapes."""
     payload = json.loads(path.read_text(encoding="utf-8"))
     if isinstance(payload, list):
         return payload
@@ -108,6 +115,7 @@ def load_candidates(path: Path) -> list[dict[str, Any]]:
 
 
 def find_candidate(candidates: list[dict[str, Any]], kernel_id: str) -> dict[str, Any]:
+    """Find a candidate by ``kernel_id`` (or name) or raise KeyError."""
     for candidate in candidates:
         if candidate.get("kernel_id") == kernel_id or candidate.get("name") == kernel_id:
             return candidate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,20 @@ version = "0.6.0"
 description = "Inference Optimizer v0.6 — single-mode 4-agent (Orchestration/Kernel/Critic/Robustness) autonomous LLM inference optimization runtime for AMD GPU platforms."
 readme = "README.md"
 requires-python = ">=3.10"
+license = { text = "Apache-2.0" }
 dependencies = [
     "claude-agent-sdk>=0.1.65",
     "openai>=1.50",
     "httpx>=0.27",
     "PyYAML>=6.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/AMD-AGI/Hyperloom"
+Source = "https://github.com/AMD-AGI/Hyperloom"
+Issues = "https://github.com/AMD-AGI/Hyperloom/issues"
+Changelog = "https://github.com/AMD-AGI/Hyperloom/blob/main/CHANGELOG.md"
+Security = "https://github.com/AMD-AGI/Hyperloom/security/policy"
 
 [project.optional-dependencies]
 test = [

--- a/robustness-agent/src/robustness_agent/agent.py
+++ b/robustness-agent/src/robustness_agent/agent.py
@@ -50,6 +50,7 @@ class RobustnessAgent:
         self._tasks: list[asyncio.Task[Any]] = []
 
     async def start(self) -> None:
+        """Initialize monitors/checks and spawn monitoring tasks."""
         log.info("Robustness Agent starting (session_dir=%s)", self.config.session_dir)
 
         self._provider = await create_provider(self.config)
@@ -80,6 +81,7 @@ class RobustnessAgent:
         log.info("Robustness Agent started with %d monitoring tasks", len(self._tasks))
 
     async def stop(self) -> None:
+        """Stop all tasks and close Conductor connections."""
         log.info("Robustness Agent stopping")
         self._running = False
         for task in self._tasks:
@@ -90,6 +92,7 @@ class RobustnessAgent:
         log.info("Robustness Agent stopped")
 
     async def run_forever(self) -> None:
+        """Start the agent and run until cancelled."""
         await self.start()
         try:
             await asyncio.gather(*self._tasks)
@@ -101,6 +104,7 @@ class RobustnessAgent:
     # -- monitoring loops --
 
     async def _loop_process_check(self) -> None:
+        """Poll process health and emit alerts at configured cadence."""
         while self._running:
             try:
                 alerts = await self._process_monitor.check()
@@ -110,6 +114,7 @@ class RobustnessAgent:
             await asyncio.sleep(self.config.process_check_interval)
 
     async def _loop_gpu_check(self) -> None:
+        """Poll GPU health and emit alerts at configured cadence."""
         while self._running:
             try:
                 alerts = await self._gpu_monitor.check()
@@ -119,6 +124,7 @@ class RobustnessAgent:
             await asyncio.sleep(self.config.gpu_check_interval)
 
     async def _loop_health_check(self) -> None:
+        """Poll server health endpoints and emit alerts."""
         while self._running:
             try:
                 _, alerts = await self._server_health.check()
@@ -128,6 +134,7 @@ class RobustnessAgent:
             await asyncio.sleep(self.config.health_check_interval)
 
     async def _loop_log_check(self) -> None:
+        """Tail logs for errors and emit alerts."""
         while self._running:
             try:
                 alerts = await self._log_tailer.check()
@@ -137,6 +144,7 @@ class RobustnessAgent:
             await asyncio.sleep(5.0)
 
     async def _loop_disk_check(self) -> None:
+        """Monitor disk usage and emit alerts."""
         while self._running:
             try:
                 alerts = await self._disk_check.check()
@@ -146,6 +154,7 @@ class RobustnessAgent:
             await asyncio.sleep(self.config.disk_check_interval)
 
     async def _loop_event_poll(self) -> None:
+        """Poll Conductor events and turn them into alerts."""
         while self._running:
             try:
                 events = self._conductor_reader.poll_events()
@@ -157,6 +166,7 @@ class RobustnessAgent:
             await asyncio.sleep(self.config.event_poll_interval)
 
     async def _loop_stall_check(self) -> None:
+        """Detect orchestration stalls via Conductor state."""
         while self._running:
             try:
                 alerts = await self._stall_check.check()
@@ -166,6 +176,7 @@ class RobustnessAgent:
             await asyncio.sleep(60.0)
 
     async def _loop_rca(self) -> None:
+        """Trigger RCA when thresholds are met and execute actions."""
         while self._running:
             try:
                 if self._rca_engine.should_trigger():
@@ -183,6 +194,7 @@ class RobustnessAgent:
             await asyncio.sleep(30.0)
 
     async def _loop_heartbeat(self) -> None:
+        """Emit periodic heartbeat events for liveness tracking."""
         while self._running:
             self._intent_emitter._write_event("send_message", {
                 "topic": "heartbeat",
@@ -193,6 +205,7 @@ class RobustnessAgent:
     # -- alert handling --
 
     def _handle_alerts(self, alerts: list[Alert]) -> None:
+        """Persist and forward alerts to Coordinator and RCA engine."""
         for alert in alerts:
             self._alert_history.append(alert)
             log.warning("[%s] %s: %s", alert.severity.value, alert.check_name, alert.summary)

--- a/robustness-agent/src/robustness_agent/models.py
+++ b/robustness-agent/src/robustness_agent/models.py
@@ -13,6 +13,7 @@ from typing import Any, Optional
 
 @dataclass
 class GpuSnapshot:
+    """One-time GPU metrics snapshot collected by monitors."""
     gpu_id: int
     utilization: float
     vram_used_mb: float
@@ -24,6 +25,7 @@ class GpuSnapshot:
 
     @property
     def vram_used_pct(self) -> float:
+        """VRAM utilization percentage (0 if total is zero)."""
         if self.vram_total_mb <= 0:
             return 0.0
         return (self.vram_used_mb / self.vram_total_mb) * 100.0
@@ -31,6 +33,7 @@ class GpuSnapshot:
 
 @dataclass
 class ProcessInfo:
+    """Minimal process info surfaced by process monitors."""
     pid: int
     state: str
     cmd: str
@@ -40,6 +43,7 @@ class ProcessInfo:
 
 @dataclass
 class DiskSnapshot:
+    """Disk usage snapshot for a single mount."""
     mount: str
     total_gb: float
     used_gb: float
@@ -47,6 +51,7 @@ class DiskSnapshot:
 
     @property
     def used_pct(self) -> float:
+        """Disk utilization percentage (0 if total is zero)."""
         if self.total_gb <= 0:
             return 0.0
         return (self.used_gb / self.total_gb) * 100.0
@@ -54,6 +59,7 @@ class DiskSnapshot:
 
 @dataclass
 class ServerHealthStatus:
+    """HTTP health probe result for a service endpoint."""
     url: str
     reachable: bool
     response_time_ms: float = 0.0
@@ -63,6 +69,7 @@ class ServerHealthStatus:
 
 @dataclass
 class FaultEvent:
+    """Raw fault event emitted by monitors for downstream checks."""
     monitor_id: str
     category: str
     severity: str
@@ -89,6 +96,7 @@ class CheckResult(str, Enum):
 
 @dataclass
 class Alert:
+    """Structured alert emitted by checks and forwarded to the Coordinator."""
     check_name: str
     severity: Severity
     summary: str
@@ -99,6 +107,7 @@ class Alert:
 
 @dataclass
 class RcaFinding:
+    """RCA output capturing root cause, recommended action, and evidence."""
     trigger_alerts: list[Alert]
     root_cause: str
     suggested_action: str
@@ -114,6 +123,7 @@ class RcaFinding:
 
 @dataclass
 class ConductorEvent:
+    """Subset of Conductor events consumed by the robustness agent."""
     event_id: int
     agent: str
     intent_type: str


### PR DESCRIPTION
- add Apache-2.0 license artifacts, governance docs (CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, PULL_REQUEST_TEMPLATE), changelog, REUSE metadata, and pip/URL provenance attestation
- tighten GitHub Actions permissions, add CodeQL and release provenance workflows, dependabot updates, and pin NodeSource installer via sha256