### PR TITLE
fix(kernel-agent): unblock GEAK v3.2.0 install + reach yaml run.mode: full

### DIFF
--- a/kernel-agent/SKILL.md
+++ b/kernel-agent/SKILL.md
@@ -346,7 +346,7 @@ than a silent skip.
 - **Default budget**:
   - claude / codex / cursor: **60 minutes** per attempt (`--backend-budget-min 60`)
   - GEAK: tracks `$GEAK_RUN_MODE` (set by `install.sh`, exported via
-    `kernel-agent.env.sh`). `full` (default) → **130 min**, `quick` → **65 min**.
+    `kernel-agent.env.sh`). `full` (default) → **130 min**, `quick` → **70 min**.
     Both `kernel_optimization.py` and `parallel_e2e_runner.py` read
     `$GEAK_RUN_MODE` to pick the `--geak-budget-min` default; override by
     passing the flag explicitly.
@@ -365,7 +365,7 @@ than a silent skip.
   `run.budgets.full.total_s=7200` (2 h, 5 rounds). GEAK's mini.py:435
   resolves mode by LLM-parsing the prompt-quoted budget: <120 min → quick,
   >=120 min → full. 130 min ≥ full.total_s (7200s) + finalize_grace_s (300s)
-  + kill_buffer_s (60s) + safety, and 65 min ≥ quick.total_s (3600s) + the
+  + kill_buffer_s (60s) + safety, and 70 min ≥ quick.total_s (3600s) + the
   same finalize_grace + kill_buffer + safety. Defaults sit one tier above
   their respective yaml total_s so the matching mode's last round +
   select_patch can complete (vs the old uniform 90 min default which fell

--- a/kernel-agent/SKILL.md
+++ b/kernel-agent/SKILL.md
@@ -345,27 +345,34 @@ than a silent skip.
   rms_norm 1.18x.)
 - **Default budget**:
   - claude / codex / cursor: **60 minutes** per attempt (`--backend-budget-min 60`)
-  - GEAK: **130 minutes** per attempt (`--geak-budget-min 130`)
+  - GEAK: tracks `$GEAK_RUN_MODE` (set by `install.sh`, exported via
+    `kernel-agent.env.sh`). `full` (default) → **130 min**, `quick` → **65 min**.
+    Both `kernel_optimization.py` and `parallel_e2e_runner.py` read
+    `$GEAK_RUN_MODE` to pick the `--geak-budget-min` default; override by
+    passing the flag explicitly.
 - **GEAK task parameters** (prompt-injected, align with GEAK team defaults):
-  - `max_rounds`: **5** (multi-round heterogeneous optimization)
-  - `step_limit`: **200** (GEAK recommended; 100 limits multi-round runs)
-  
+  - `max_rounds`: **5** for full / **2** for quick (driven by yaml
+    `run.presets.<mode>.orchestrator.max_rounds`).
+  - `step_limit`: **200** (GEAK recommended; 100 limits multi-round runs).
+
   Agents are instructed to **early-exit** as soon as they hit `>=1.50x` with
   passing correctness; otherwise they iterate up to ~85% of the budget and the
   runner SIGTERMs at 100%. `parallel_e2e_runner` will still extract whatever
   `optimization_report.md` / `optimized_versions/*` were on disk at SIGTERM
   time and promote the attempt to `partial` (see Proposal Rules).
-- **Why GEAK budget is 130 min**: GEAK v3.2.0 yaml ships two presets —
-  `run.budgets.quick.total_s=3600` (1 h, 2 rounds) and
+- **Why GEAK budget tracks $GEAK_RUN_MODE**: GEAK v3.2.0 yaml ships two
+  presets — `run.budgets.quick.total_s=3600` (1 h, 2 rounds) and
   `run.budgets.full.total_s=7200` (2 h, 5 rounds). GEAK's mini.py:435
   resolves mode by LLM-parsing the prompt-quoted budget: <120 min → quick,
-  >=120 min → full. 130 min ≥ `full.total_s` (7200s) + `finalize_grace_s`
-  (300s) + `kill_buffer_s` (60s) + safety margin, so the default lets the
-  full preset's 5 rounds + select_patch round actually complete (vs the
-  old 90 min default which downgraded every default run to quick / 2 rounds).
-  Older 60 min budget consistently SIGTERM'd the select_patch round
-  (observed r38/r39 fell back to per-task `best_results.json` salvage),
-  which is still the floor — do not drop GEAK budget below 60 min.
+  >=120 min → full. 130 min ≥ full.total_s (7200s) + finalize_grace_s (300s)
+  + kill_buffer_s (60s) + safety, and 65 min ≥ quick.total_s (3600s) + the
+  same finalize_grace + kill_buffer + safety. Defaults sit one tier above
+  their respective yaml total_s so the matching mode's last round +
+  select_patch can complete (vs the old uniform 90 min default which fell
+  between GEAK quick (60) and full (120) and silently downgraded every run
+  to mode=quick). 60 min is still the floor — do not drop GEAK budget below
+  it; r38/r39 SIGTERM'd the select_patch round and had to fall back to
+  per-task `best_results.json` salvage.
 
 ## Artifacts
 

--- a/kernel-agent/SKILL.md
+++ b/kernel-agent/SKILL.md
@@ -67,7 +67,12 @@ are accepted as no-ops for backwards compat):
 - GEAK CLI from `GEAK_REF` (default `v3.2.0`) +
   `${HYPERLOOM_ROOT}/geak-config/local.yaml` (model resolution:
   `GEAK_MODEL_NAME` / `GEAK_API_KEY` / `GEAK_BASE_URL` from env, default
-  `claude-opus-4-7`)
+  `claude-opus-4-7`). Run-mode default for the generated yaml is
+  controlled by `GEAK_RUN_MODE` (`quick` or `full`; defaults to `full`,
+  which selects the 2 h / 5-round `run.budgets.full` preset). Set
+  `GEAK_RUN_MODE=quick` before `install.sh` for the 1 h / 2-round smoke
+  preset. Other yaml budget knobs are not env-overridable on purpose —
+  edit `$GEAK_CONFIG` directly if you need to tune them per pod.
 - GEAK MCP tools — installed as four pip packages from
   `${HYPERLOOM_ROOT}/geak/mcp_tools/`. The bundled `minisweagent` imports
   these at preprocess + run time; missing any of them fails the GEAK

--- a/kernel-agent/SKILL.md
+++ b/kernel-agent/SKILL.md
@@ -64,11 +64,11 @@ are accepted as no-ops for backwards compat):
   verifies `TraceLens_generate_perf_report_pytorch_inference --help`
   (Hyperloom is inference-only since v0.4; the training-mode CLI is no
   longer accepted)
-- GEAK CLI from `GEAK_REF` (default `v3.1.0`) +
+- GEAK CLI from `GEAK_REF` (default `v3.2.0`) +
   `${HYPERLOOM_ROOT}/geak-config/local.yaml` (model resolution:
   `GEAK_MODEL_NAME` / `GEAK_API_KEY` / `GEAK_BASE_URL` from env, default
   `claude-opus-4-7`)
-- GEAK MCP tools — installed as five pip packages from
+- GEAK MCP tools — installed as four pip packages from
   `${HYPERLOOM_ROOT}/geak/mcp_tools/`. The bundled `minisweagent` imports
   these at preprocess + run time; missing any of them fails the GEAK
   attempt fast (observed on Qwen3-32B 2026-05-15: `profiler_mcp` not
@@ -80,9 +80,10 @@ are accepted as no-ops for backwards compat):
       `GEAK_RAG_INDEX_DEVICE=cuda` by default because CPU embedding can
       take hours; set `GEAK_RAG_INDEX_DEVICE=cpu` only for CPU-only
       environments.
-    - `profiler-mcp` — Metrix-backed instrumented profiling
-      (`preprocessor.py` Step 5/7); produces `profile.json` per attempt.
-    - `metrix-mcp` — AMD Metrix backend for `profiler-mcp`.
+    - `profiler-mcp` — unified profiling MCP (Metrix + rocprof-compute);
+      produces `profile.json` per attempt. Metrix is no longer a separate
+      `metrix-mcp` folder in v3.2.0 — it is pulled in transitively via
+      `profiler-mcp/pyproject.toml` (`dependencies = ["metrix>=0.1.0"]`).
     - `cross-session-memory-mcp` — SQLite-backed cross-session memory
       retriever; points at `GEAK_MEMORY_STORE_PATH` (default
       `/wekafs/hyperloom/geak-memory/memory.db`).
@@ -339,7 +340,7 @@ than a silent skip.
   rms_norm 1.18x.)
 - **Default budget**:
   - claude / codex / cursor: **60 minutes** per attempt (`--backend-budget-min 60`)
-  - GEAK: **90 minutes** per attempt (`--geak-budget-min 90`)
+  - GEAK: **130 minutes** per attempt (`--geak-budget-min 130`)
 - **GEAK task parameters** (prompt-injected, align with GEAK team defaults):
   - `max_rounds`: **5** (multi-round heterogeneous optimization)
   - `step_limit`: **200** (GEAK recommended; 100 limits multi-round runs)
@@ -349,15 +350,17 @@ than a silent skip.
   runner SIGTERMs at 100%. `parallel_e2e_runner` will still extract whatever
   `optimization_report.md` / `optimized_versions/*` were on disk at SIGTERM
   time and promote the attempt to `partial` (see Proposal Rules).
-- **Why GEAK budget is 90 min, not 60**: GEAK runs N sub-agent tasks serially
-  (each 5-10 min: baseline measurement + LLM patch generation + per-patch
-  benchmark) + a final `select_patch` round that LLM-judges all patches and
-  writes `final_report.json`. With a 60 min budget, the select_patch round
-  consistently gets SIGTERM'd before it finishes (observed r38/r39: driver
-  had to fall back to per-task `best_results.json` salvage). 90 min lets the
-  select_patch round run, producing `final_report.json` with the canonical
-  best_speedup. Do not drop GEAK budget below 60 min or it will return
-  `partial` with an empty patch.
+- **Why GEAK budget is 130 min**: GEAK v3.2.0 yaml ships two presets —
+  `run.budgets.quick.total_s=3600` (1 h, 2 rounds) and
+  `run.budgets.full.total_s=7200` (2 h, 5 rounds). GEAK's mini.py:435
+  resolves mode by LLM-parsing the prompt-quoted budget: <120 min → quick,
+  >=120 min → full. 130 min ≥ `full.total_s` (7200s) + `finalize_grace_s`
+  (300s) + `kill_buffer_s` (60s) + safety margin, so the default lets the
+  full preset's 5 rounds + select_patch round actually complete (vs the
+  old 90 min default which downgraded every default run to quick / 2 rounds).
+  Older 60 min budget consistently SIGTERM'd the select_patch round
+  (observed r38/r39 fell back to per-task `best_results.json` salvage),
+  which is still the floor — do not drop GEAK budget below 60 min.
 
 ## Artifacts
 

--- a/kernel-agent/scripts/install.sh
+++ b/kernel-agent/scripts/install.sh
@@ -112,6 +112,23 @@ OOB_SRC="${OOB_SRC:-${HYPERLOOM_BUNDLE}/OOB}"
 GEAK_CONFIG="${GEAK_CONFIG:-${HYPERLOOM_RUNTIME_DIR}/geak-config/local.yaml}"
 # Pass GEAK_MODEL_NAME through unchanged; GEAK owns provider-specific routing.
 GEAK_MODEL_NAME_VAL="${GEAK_MODEL_NAME:-claude-opus-4-7}"
+# Run mode for the GEAK CLI. Drives ``run.mode`` in the generated
+# ``$GEAK_CONFIG`` yaml: ``full`` (default) selects the 2 h / 5-round preset
+# at ``run.budgets.full`` and ``run.presets.full``; ``quick`` selects the
+# 1 h / 2-round preset for smoke tests. GEAK's ``mini.py:435`` mode
+# precedence still honours later overrides (CLI ``--mode`` or
+# LLM-parsed task hints), but this is the yaml-default operators can set
+# at install time without hand-editing $GEAK_CONFIG.
+GEAK_RUN_MODE_VAL="${GEAK_RUN_MODE:-full}"
+# Validate inline (the ``die`` helper is defined further down; calling it
+# from this top-level scope would error with "die: command not found").
+case "$GEAK_RUN_MODE_VAL" in
+  quick|full) ;;
+  *)
+    echo "[kernel-agent ERROR] GEAK_RUN_MODE must be 'quick' or 'full'; got '$GEAK_RUN_MODE_VAL'" >&2
+    exit 1
+    ;;
+esac
 RAG_INDEX_DIR="${HOME}/.cache/amd-ai-devtool/semantic-index"
 # RAG index build device. Resolution:
 #   1. If $GEAK_RAG_INDEX_DEVICE is set explicitly, honor it verbatim
@@ -584,7 +601,7 @@ model:
 tools:
   rag: true
 run:
-  mode: full
+  mode: ${GEAK_RUN_MODE_VAL}
   budgets:
     quick:
       total_s: 3600

--- a/kernel-agent/scripts/install.sh
+++ b/kernel-agent/scripts/install.sh
@@ -847,6 +847,7 @@ write_env_file() {
     # mirror instead of falling back to the read-only /wekafs default.
     [ -n "${TRACELENS_ROOT:-}" ] && echo "export TRACELENS_ROOT='${TRACELENS_ROOT}'"
     [ -n "${GEAK_CONFIG}" ] && echo "export GEAK_CONFIG='${GEAK_CONFIG}'"
+    [ -n "${GEAK_RUN_MODE_VAL}" ] && echo "export GEAK_RUN_MODE='${GEAK_RUN_MODE_VAL}'"
     [ -n "${GEAK_MODEL_NAME_VAL}" ] && echo "export GEAK_MODEL_NAME='${GEAK_MODEL_NAME_VAL}'"
     [ -n "${GEAK_API_KEY_VAL}" ] && echo "export GEAK_API_KEY='${GEAK_API_KEY_VAL}'"
     [ -n "${GEAK_BASE_URL_VAL}" ] && echo "export GEAK_BASE_URL='${GEAK_BASE_URL_VAL}'"

--- a/kernel-agent/scripts/install.sh
+++ b/kernel-agent/scripts/install.sh
@@ -107,7 +107,7 @@ GEAK_REPO="${GEAK_REPO:-https://github.com/AMD-AGI/GEAK.git}"
 # Pin GEAK to the first release that ships RAG MCP retrieval and cross-session
 # memory together. Keep this overridable so future GEAK fixes can move Hyperloom
 # forward without reworking the installer contract.
-GEAK_REF="${GEAK_REF:-v3.1.0}"
+GEAK_REF="${GEAK_REF:-v3.2.0}"
 OOB_SRC="${OOB_SRC:-${HYPERLOOM_BUNDLE}/OOB}"
 GEAK_CONFIG="${GEAK_CONFIG:-${HYPERLOOM_RUNTIME_DIR}/geak-config/local.yaml}"
 # Pass GEAK_MODEL_NAME through unchanged; GEAK owns provider-specific routing.
@@ -535,20 +535,20 @@ ensure_geak() {
     # no-op so the flag is safe to keep unconditionally).
     _PIP_FLAGS="-q --no-cache-dir --break-system-packages"
     run python3 -m pip install ${_PIP_FLAGS} "${HYPERLOOM_ROOT}/geak"
-    # GEAK v3.1.0 ships 5 MCP tools under mcp_tools/; all of them are
-    # imported by the bundled ``minisweagent`` at preprocess time:
+    # GEAK v3.2.0 ships 4 MCP tools under mcp_tools/; all are imported
+    # by the bundled ``minisweagent`` at preprocess time:
     #   * rag-mcp                    — knowledge-base retrieval (tools.rag)
-    #   * profiler-mcp               — Metrix instrumented profiling
-    #                                  (preprocessor.py:1073 import)
-    #   * metrix-mcp                 — backend for profiler-mcp
+    #   * profiler-mcp               — Metrix-backed instrumented profiling
+    #                                  (preprocessor.py import); Metrix is now
+    #                                  a PyPI dep declared in its pyproject,
+    #                                  not a separate mcp_tools/ folder.
     #   * cross-session-memory-mcp   — GEAK_MEMORY_STORE_PATH retriever
     #   * automated-test-discovery   — pre-fills eval_command harness
-    # Installing only rag-mcp (the historical default) leaves the
-    # other four ``ModuleNotFoundError`` at runtime — observed on the
-    # 2026-05-15 Qwen3-32B GEAK attempts where ``profiler_mcp`` was
-    # missing and every GEAK attempt aborted in ~4 minutes with a
-    # zero-byte baseline. Install all five together.
-    for _geak_mcp in rag-mcp profiler-mcp metrix-mcp \
+    # v3.1.0 -> v3.2.0 change: ``metrix-mcp`` folder was removed and the
+    # metrix runtime is now consumed transitively via profiler-mcp's
+    # ``dependencies = ["metrix>=0.1.0"]``. Listing it here again would
+    # break install with "File ... does not exist".
+    for _geak_mcp in rag-mcp profiler-mcp \
                     cross-session-memory-mcp automated-test-discovery; do
       run python3 -m pip install ${_PIP_FLAGS} \
         "${HYPERLOOM_ROOT}/geak/mcp_tools/${_geak_mcp}"

--- a/kernel-agent/tests/test_kernel_agent.py
+++ b/kernel-agent/tests/test_kernel_agent.py
@@ -213,27 +213,51 @@ class KernelAgentToolTests(unittest.TestCase):
         ray_runtime_text = RAY_RUNTIME.read_text(encoding="utf-8")
 
         self.assertIn('TRACELENS_ROOT="${TRACELENS_ROOT:-/wekafs/hyperloom/TraceLens-internal}"', install_text)
-        self.assertIn('GEAK_REF="${GEAK_REF:-v3.1.0}"', install_text)
-        self.assertIn('python3 -m pip install -q --no-cache-dir "${HYPERLOOM_ROOT}/geak"', install_text)
-        # All five GEAK v3.1.0 MCP tools must be pip-installed; minisweagent
-        # imports profiler_mcp / metrix_mcp / cross_session_memory_mcp /
-        # automated_test_discovery in addition to rag-mcp. The
-        # ``for _geak_mcp in ...; do pip install ...; done`` loop has to
-        # include all five, in any order.
+        self.assertIn('GEAK_REF="${GEAK_REF:-v3.2.0}"', install_text)
+        # pip flags are factored into `_PIP_FLAGS`; assert the core flags
+        # survive (prefix match allows future additions) and the install line
+        # references the variable.
+        self.assertIn('_PIP_FLAGS="-q --no-cache-dir', install_text)
+        self.assertIn('python3 -m pip install ${_PIP_FLAGS} "${HYPERLOOM_ROOT}/geak"', install_text)
+        # GEAK v3.2.0 ships 4 MCP tool folders; minisweagent imports
+        # profiler_mcp / cross_session_memory_mcp / automated_test_discovery
+        # in addition to rag-mcp. Metrix is consumed transitively as a
+        # PyPI dependency of profiler-mcp (no standalone metrix-mcp folder
+        # in v3.2.0). Regression-guard: install.sh must NOT pip-install a
+        # ``mcp_tools/metrix-mcp`` path (it does not exist in v3.2.0 and
+        # was causing install to fail with "File ... does not exist").
+        # We assert on the path form to allow human-readable comments that
+        # explain the v3.1.0 -> v3.2.0 removal to keep mentioning the name.
         for _mcp in (
             "rag-mcp",
             "profiler-mcp",
-            "metrix-mcp",
             "cross-session-memory-mcp",
             "automated-test-discovery",
         ):
             self.assertIn(_mcp, install_text)
+        # The actual install loop iterates over hyphenated names; v3.1.0
+        # had ``rag-mcp profiler-mcp metrix-mcp ...``. Pin the v3.2.0
+        # ordering so accidental re-adding of ``metrix-mcp`` between
+        # ``profiler-mcp`` and ``cross-session-memory-mcp`` regresses
+        # this test (the comment block above is allowed to mention
+        # ``metrix-mcp`` for human readers).
         self.assertIn(
-            'python3 -m pip install -q --no-cache-dir \\\n'
+            "for _geak_mcp in rag-mcp profiler-mcp \\\n"
+            "                    cross-session-memory-mcp automated-test-discovery; do",
+            install_text,
+        )
+        self.assertIn(
+            'python3 -m pip install ${_PIP_FLAGS} \\\n'
             '        "${HYPERLOOM_ROOT}/geak/mcp_tools/${_geak_mcp}"',
             install_text,
         )
-        self.assertIn('GEAK_RAG_INDEX_DEVICE_VAL="${GEAK_RAG_INDEX_DEVICE:-cuda}"', install_text)
+        # GEAK_RAG_INDEX_DEVICE_VAL was refactored from a single-line `:-cuda`
+        # default into an auto-detect block (rocm-smi / torch.cuda) with an
+        # explicit env override. Assert the two semantic invariants instead of
+        # the old literal: cuda remains the preferred default, and the env var
+        # can still override.
+        self.assertIn('GEAK_RAG_INDEX_DEVICE_VAL="cuda"', install_text)
+        self.assertIn('GEAK_RAG_INDEX_DEVICE_VAL="${GEAK_RAG_INDEX_DEVICE}"', install_text)
         self.assertIn("python3 scripts/build_index.py --force --device", install_text)
         self.assertIn("ensure_node()", install_text)
         self.assertIn("installing Node.js 20 from NodeSource", install_text)

--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -2509,14 +2509,14 @@ def main() -> int:
                         help="Per-attempt wall-clock budget for claude/codex "
                              "OOB backends. GEAK uses --geak-budget-min.")
     # Default tracks $GEAK_RUN_MODE (exported by install.sh / env.sh):
-    # quick (yaml total_s=3600s) -> 65 min, full (yaml total_s=7200s) -> 130 min.
+    # quick (yaml total_s=3600s) -> 70 min, full (yaml total_s=7200s) -> 130 min.
     # Both sit above their yaml total_s + finalize_grace + kill_buffer + safety,
     # so the prompt-quoted budget triggers the matching mode (mini.py:435).
-    _geak_budget_default = 65.0 if os.environ.get("GEAK_RUN_MODE", "full").strip().lower() == "quick" else 130.0
+    _geak_budget_default = 70.0 if os.environ.get("GEAK_RUN_MODE", "full").strip().lower() == "quick" else 130.0
     parser.add_argument("--geak-budget-min", type=float, default=_geak_budget_default,
                         help="Per-attempt wall-clock budget for GEAK only "
                              "(default tracks $GEAK_RUN_MODE: full -> 130, "
-                             "quick -> 65; both aligned with yaml "
+                             "quick -> 70; both aligned with yaml "
                              "run.budgets.<mode>.total_s + finalize_grace + "
                              "kill_buffer + safety so the prompt-quoted "
                              "budget triggers the matching GEAK mode at "

--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -1017,7 +1017,12 @@ def build_kernel_metadata(candidate: dict[str, Any], args: argparse.Namespace) -
     }
 
 
-def build_prompt(candidate: dict[str, Any], args: argparse.Namespace) -> str:
+def build_prompt(
+    candidate: dict[str, Any],
+    args: argparse.Namespace,
+    *,
+    backend: str | None = None,
+) -> str:
     source_file = args.source_file or candidate.get("source_file", "")
     source_block = ""
     if source_file and Path(str(source_file)).exists():
@@ -1044,7 +1049,13 @@ def build_prompt(candidate: dict[str, Any], args: argparse.Namespace) -> str:
     geak_kernel_type = _GEAK_KERNEL_TYPE.get(str(candidate.get("source_type", "unknown")), "other")
     kernel_name = str(candidate.get("name", args.kernel_id))
     kernel_metadata = build_kernel_metadata(candidate, args)
-    budget_min = int(getattr(args, "budget_minutes", 60) or 60)
+    # Quote the per-backend wall-clock so GEAK v3.2.0's LLM task-mode parser
+    # (mini.py:435 task_extracted_mode) infers the right mode (>=120min→full,
+    # else quick), instead of always seeing the OOB 60min default.
+    if backend == "geak":
+        budget_min = int(getattr(args, "geak_budget_min", 130) or 130)
+    else:
+        budget_min = int(getattr(args, "budget_minutes", 60) or 60)
     target_platform = (
         getattr(args, "target_platform", "") or _env_target_platform()
     )
@@ -1093,6 +1104,12 @@ def build_prompt(candidate: dict[str, Any], args: argparse.Namespace) -> str:
         "  or `rg ... <repo>`, NEVER `find /`.\n"
         "\n"
         "GOAL & TIME BUDGET:\n"
+        # GEAK v3.2.0 LLM-parses prompt for `--mode full` / `mode=quick` etc.
+        # (prompts.py:73-76 trigger list). Emit the explicit token so the
+        # parser locks in the right preset (yaml run.budgets.<mode>) instead
+        # of leaking off other prompt phrases like "quick micro-benchmark".
+        f"- Run mode: {'full' if budget_min >= 120 else 'quick'} "
+        f"(--mode {'full' if budget_min >= 120 else 'quick'}).\n"
         f"- Hard wall-clock budget: ~{budget_min} minutes. Iterate up to minute "
         f"{int(budget_min*0.85)},\n"
         "  then STOP iterating and finalize the report with your best so-far measured\n"
@@ -1458,10 +1475,10 @@ def invoke_backend(
     # GEAK needs more wall-clock than claude/codex: a single sub-agent task
     # already takes 5-10 min (baseline + LLM patch generation + per-patch
     # benchmark), and the orchestrator typically dispatches 4-9 tasks per
-    # round + a select_patch round at the end. Empirically 60 min lets
-    # individual sub-agents finish but consistently SIGTERMs the
-    # select_patch round (r38, r39 both fell back to per-task best_results
-    # salvage). 90 min is the new default; override via --geak-budget-min.
+    # round + a select_patch round at the end. 130 min is the default so
+    # the prompt-quoted budget triggers GEAK v3.2.0's mode=full path
+    # (yaml run.budgets.full.total_s=7200s + finalize_grace + kill_buffer);
+    # override via --geak-budget-min.
     if backend == "geak":
         budget_min = float(getattr(args, "geak_budget_min", 0)
                            or getattr(args, "budget_minutes", 60) or 60)
@@ -1641,7 +1658,7 @@ def run_attempt(
     prompt_dir = run_dir / "prompts"
     prompt_dir.mkdir(parents=True, exist_ok=True)
     prompt_file = prompt_dir / f"{attempt_id}.md"
-    prompt_file.write_text(build_prompt(candidate, args), encoding="utf-8")
+    prompt_file.write_text(build_prompt(candidate, args, backend=backend), encoding="utf-8")
 
     source_file = args.source_file or str(candidate.get("source_file") or "")
     started = time.time()
@@ -2491,12 +2508,16 @@ def main() -> int:
     parser.add_argument("--budget-minutes", type=float, default=60.0,
                         help="Per-attempt wall-clock budget for claude/codex "
                              "OOB backends. GEAK uses --geak-budget-min.")
-    parser.add_argument("--geak-budget-min", type=float, default=90.0,
+    parser.add_argument("--geak-budget-min", type=float, default=130.0,
                         help="Per-attempt wall-clock budget for GEAK only "
-                             "(default 90 min; needed because GEAK runs "
-                             "per-task patch sub-agents serially + a final "
-                             "select_patch round, and 60 min consistently "
-                             "SIGTERMs the select_patch round).")
+                             "(default 130 min). Aligns with GEAK v3.2.0 "
+                             "yaml run.budgets.full.total_s=7200s + "
+                             "finalize_grace_s=300s + kill_buffer_s=60s + "
+                             "safety margin, so the prompt-quoted budget "
+                             "triggers GEAK's mode=full path (mini.py:435 "
+                             "task_extracted_mode). Older 90 min default "
+                             "fell between GEAK quick (60) and full (120), "
+                             "downgrading runs to mode=quick.")
     parser.add_argument("--micro-speedup", type=float, default=None)
     parser.add_argument("--e2e-gain-pct", type=float, default=None)
     parser.add_argument("--correctness-passed", choices=["true", "false", "unknown"], default="unknown")

--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -2508,16 +2508,19 @@ def main() -> int:
     parser.add_argument("--budget-minutes", type=float, default=60.0,
                         help="Per-attempt wall-clock budget for claude/codex "
                              "OOB backends. GEAK uses --geak-budget-min.")
-    parser.add_argument("--geak-budget-min", type=float, default=130.0,
+    # Default tracks $GEAK_RUN_MODE (exported by install.sh / env.sh):
+    # quick (yaml total_s=3600s) -> 65 min, full (yaml total_s=7200s) -> 130 min.
+    # Both sit above their yaml total_s + finalize_grace + kill_buffer + safety,
+    # so the prompt-quoted budget triggers the matching mode (mini.py:435).
+    _geak_budget_default = 65.0 if os.environ.get("GEAK_RUN_MODE", "full").strip().lower() == "quick" else 130.0
+    parser.add_argument("--geak-budget-min", type=float, default=_geak_budget_default,
                         help="Per-attempt wall-clock budget for GEAK only "
-                             "(default 130 min). Aligns with GEAK v3.2.0 "
-                             "yaml run.budgets.full.total_s=7200s + "
-                             "finalize_grace_s=300s + kill_buffer_s=60s + "
-                             "safety margin, so the prompt-quoted budget "
-                             "triggers GEAK's mode=full path (mini.py:435 "
-                             "task_extracted_mode). Older 90 min default "
-                             "fell between GEAK quick (60) and full (120), "
-                             "downgrading runs to mode=quick.")
+                             "(default tracks $GEAK_RUN_MODE: full -> 130, "
+                             "quick -> 65; both aligned with yaml "
+                             "run.budgets.<mode>.total_s + finalize_grace + "
+                             "kill_buffer + safety so the prompt-quoted "
+                             "budget triggers the matching GEAK mode at "
+                             "mini.py:435 task_extracted_mode).")
     parser.add_argument("--micro-speedup", type=float, default=None)
     parser.add_argument("--e2e-gain-pct", type=float, default=None)
     parser.add_argument("--correctness-passed", choices=["true", "false", "unknown"], default="unknown")

--- a/kernel-agent/tools/parallel_e2e_runner.py
+++ b/kernel-agent/tools/parallel_e2e_runner.py
@@ -294,13 +294,13 @@ def main() -> int:
                              "otherwise they iterate up to ~85%% of this budget "
                              "and SIGTERM at 100%%.")
     # Default tracks $GEAK_RUN_MODE (exported by install.sh / env.sh):
-    # quick -> 65 min, full -> 130 min. Both aligned with yaml
+    # quick -> 70 min, full -> 130 min. Both aligned with yaml
     # run.budgets.<mode>.total_s + finalize_grace + kill_buffer + safety.
-    _geak_budget_default = 65 if os.environ.get("GEAK_RUN_MODE", "full").strip().lower() == "quick" else 130
+    _geak_budget_default = 70 if os.environ.get("GEAK_RUN_MODE", "full").strip().lower() == "quick" else 130
     parser.add_argument("--geak-budget-min", type=float, default=_geak_budget_default,
                         help="Per-attempt wall-clock budget for GEAK only "
                              "(default tracks $GEAK_RUN_MODE: full -> 130, "
-                             "quick -> 65; aligned with yaml "
+                             "quick -> 70; aligned with yaml "
                              "run.budgets.<mode>.total_s + finalize_grace + "
                              "kill_buffer + safety so the prompt-quoted "
                              "budget triggers the matching GEAK mode).")

--- a/kernel-agent/tools/parallel_e2e_runner.py
+++ b/kernel-agent/tools/parallel_e2e_runner.py
@@ -293,12 +293,17 @@ def main() -> int:
                              "soon as they hit >=1.50x with passing correctness; "
                              "otherwise they iterate up to ~85%% of this budget "
                              "and SIGTERM at 100%%.")
-    parser.add_argument("--geak-budget-min", type=float, default=130,
+    # Default tracks $GEAK_RUN_MODE (exported by install.sh / env.sh):
+    # quick -> 65 min, full -> 130 min. Both aligned with yaml
+    # run.budgets.<mode>.total_s + finalize_grace + kill_buffer + safety.
+    _geak_budget_default = 65 if os.environ.get("GEAK_RUN_MODE", "full").strip().lower() == "quick" else 130
+    parser.add_argument("--geak-budget-min", type=float, default=_geak_budget_default,
                         help="Per-attempt wall-clock budget for GEAK only "
-                             "(default 130 min). Aligns with GEAK v3.2.0 "
-                             "yaml run.budgets.full.total_s=7200s + "
-                             "finalize_grace + kill_buffer + safety so the "
-                             "prompt-quoted budget triggers mode=full.")
+                             "(default tracks $GEAK_RUN_MODE: full -> 130, "
+                             "quick -> 65; aligned with yaml "
+                             "run.budgets.<mode>.total_s + finalize_grace + "
+                             "kill_buffer + safety so the prompt-quoted "
+                             "budget triggers the matching GEAK mode).")
     parser.add_argument("--replicas-per-backend", type=int, default=2)
     parser.add_argument("--backends", default=None,
                         help="Comma list of agentic backends. Defaults to "

--- a/kernel-agent/tools/parallel_e2e_runner.py
+++ b/kernel-agent/tools/parallel_e2e_runner.py
@@ -293,12 +293,12 @@ def main() -> int:
                              "soon as they hit >=1.50x with passing correctness; "
                              "otherwise they iterate up to ~85%% of this budget "
                              "and SIGTERM at 100%%.")
-    parser.add_argument("--geak-budget-min", type=float, default=90,
+    parser.add_argument("--geak-budget-min", type=float, default=130,
                         help="Per-attempt wall-clock budget for GEAK only "
-                             "(default 90 min). GEAK runs N sub-agent tasks "
-                             "serially + a select_patch round; 60 min "
-                             "consistently SIGTERMs the select_patch round "
-                             "(observed r38/r39).")
+                             "(default 130 min). Aligns with GEAK v3.2.0 "
+                             "yaml run.budgets.full.total_s=7200s + "
+                             "finalize_grace + kill_buffer + safety so the "
+                             "prompt-quoted budget triggers mode=full.")
     parser.add_argument("--replicas-per-backend", type=int, default=2)
     parser.add_argument("--backends", default=None,
                         help="Comma list of agentic backends. Defaults to "


### PR DESCRIPTION
Two regressions surfaced when verifying PR #241 (GEAK v3.1.0 -> v3.2.0):

1) install.sh failed at pip install with "File ... mcp_tools/metrix-mcp
   does not exist". GEAK v3.2.0 removed the standalone metrix-mcp folder
   and now pulls metrix transitively via profiler-mcp's pyproject
   (`dependencies = ["metrix>=0.1.0"]`). Update install.sh, SKILL.md, and
   test_kernel_agent.py to iterate over the 4 v3.2.0 MCP folders only,
   and add a regression assertion that install.sh must not reference
   mcp_tools/metrix-mcp.

2) Even after install succeeded, GEAK runs still ended up in mode=quick
   (2 rounds, 3600s) despite install.sh writing run.mode: full into
   $GEAK_CONFIG. Root cause: GEAK v3.2.0 mini.py:435 mode precedence is
   "CLI --mode > LLM-parsed task mode > yaml run.mode > DEFAULT", and
   Hyperloom's prompt quoted the wrong budget for GEAK. Fix:
     - build_prompt() takes a `backend` kwarg and uses --geak-budget-min when backend=geak (was always --budget-minutes / 60min default).
     - --geak-budget-min default 90 -> 130 (aligned to yaml run.budgets.full.total_s=7200s + finalize_grace + kill_buffer + safety, so default runs are above the LLM-parser's 120min full threshold). - The GOAL & TIME BUDGET prompt block now emits an explicit "Run mode: full (--mode full)" / "(--mode quick)" line, hitting prompts.py:73-76 trigger words instead of leaking off "quick micro-benchmark"-style phrasing. parallel_e2e_runner.py mirrors the new 130 default; SKILL.md updates the GEAK budget rationale.

Verified on MI300X with GEAK v3.2.0:
- install.sh: exit 0 in 37s, 4 MCPs + new run.budgets.* yaml written.
- GEAK k003 (aiter rms_norm) live run: [budget] mode=full, total=7200s, preprocess_soft_cap=900s, finalize_grace=300s, kill_buffer=60s, max_rounds=5 (source=mode; mode=full).
- 16 local unittests pass (KernelAgentToolTests + collective_names).

- Description: what and why
- Linked issue(s): close/fix refs
- Tests: added/updated? commands run?
- Breaking changes: yes/no (details if yes)
