### PR TITLE
PR-K: source attribution + per-source attempts + aiter jit cache invalidation

### DIFF
--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -1015,16 +1015,43 @@ def _batch_kernel_candidates(
                 session_dir,
             )
 
-    def _is_live(kid: str) -> bool:
+    def _is_live(kid: str, current_source: str = "") -> bool:
         """A kernel_id is live (eligible for batch) iff it is NOT
         rejected, NOT in-flight, and has fewer than max_attempts
-        recorded attempts. ``max_attempts = 1`` (default) means: any
-        prior attempt at all -> not live."""
+        recorded attempts AGAINST THE CURRENT CANDIDATE'S source_file.
+
+        ``max_attempts = 1`` (default) means: any prior attempt against
+        the same source_file -> not live, but a prior attempt against a
+        DIFFERENT source_file is ignored. This is what lets PR-K's
+        launcher → device source promotion unlock a fresh attempt:
+        when ``aiter::ck_moe_stage1`` was first dispatched against the
+        python wrapper ``aiter/ops/moe_op.py`` and PARTIAL'd, a
+        subsequent dispatch with ``current_source`` pointing at the
+        promoted device file ``csrc/.../gemm_moe_ck2stages.cu`` is
+        treated as a fresh target with its own quota. Without this,
+        the wrapper's first failed attempt would lock the entire
+        task_group as ``group_exhausted`` even though the device path
+        had never been tried (Qwen3-30B-A3B-Base session
+        20260523T162026Z burned 2 hours on this).
+
+        Falls back to the cumulative ``attempts`` counter when:
+          * ``current_source`` is empty (legacy callers / synthetic
+            test fixtures that don't carry source_file);
+          * the entry was written by a v1 ``record_kernel_opt`` that
+            predated ``attempts_per_source`` (resumed state.json from
+            before this PR).
+        Both fallbacks preserve the pre-PR-K behaviour byte-for-byte.
+        """
         if kid in rejected_kernel_ids:
             return False
         if kid in in_flight:
             return False
         entry = attempts_by_kid.get(kid) or {}
+        if current_source:
+            per_source = entry.get("attempts_per_source")
+            if isinstance(per_source, dict):
+                src_attempts = int(per_source.get(current_source, 0))
+                return src_attempts < max_attempts
         if int(entry.get("attempts", 0)) >= max_attempts:
             return False
         return True
@@ -1072,7 +1099,7 @@ def _batch_kernel_candidates(
             primary_cand is not None
             and primary_cand.get("reusable_native_kernel") is True
             and bool(primary_cand.get("source_file"))
-            and _is_live(primary)
+            and _is_live(primary, str(primary_cand.get("source_file") or ""))
         )
         if not primary_live:
             primary_cand = next(
@@ -1082,7 +1109,7 @@ def _batch_kernel_candidates(
                     if m in kernel_by_id
                     and kernel_by_id[m].get("reusable_native_kernel") is True
                     and kernel_by_id[m].get("source_file")
-                    and _is_live(m)
+                    and _is_live(m, str(kernel_by_id[m].get("source_file") or ""))
                 ),
                 None,
             )
@@ -1125,7 +1152,7 @@ def _batch_kernel_candidates(
             continue
         if not item.get("source_file"):
             continue
-        if not _is_live(kernel_id):
+        if not _is_live(kernel_id, str(item.get("source_file") or "")):
             skipped[kernel_id] = "not_live"
             continue
         try:

--- a/inference_optimizer/orchestrator/shared_state.py
+++ b/inference_optimizer/orchestrator/shared_state.py
@@ -991,6 +991,22 @@ class SharedState:
         })
         history = history[-10:]
         entry["attempts"] = int(entry.get("attempts", 0)) + 1
+        # PR-K: per-source attempts ledger. The dispatcher's ``_is_live``
+        # consults this dict so that promoting a kernel's source from the
+        # python @compile_ops wrapper (e.g. ``aiter/ops/moe_op.py``) to
+        # the device .cu (e.g. ``csrc/.../gemm_moe_ck2stages.cu``) does
+        # NOT inherit the wrapper's attempts counter -- the device path
+        # is treated as a fresh target with its own attempts_per_source
+        # quota. Empty ``source_file`` is normalized to ``""`` so the
+        # resume from a v1 state.json (no per-source field) is bit-for-
+        # bit transparent: every entry gets a valid key, the dispatcher
+        # falls back to ``attempts`` total when no per-source row matches
+        # the candidate's current source_file, and the cumulative
+        # ``attempts`` field above continues to reflect "any source".
+        per_source = dict(entry.get("attempts_per_source") or {})
+        src_key = source_file or ""
+        per_source[src_key] = int(per_source.get(src_key, 0)) + 1
+        entry["attempts_per_source"] = per_source
         if decision == "PARTIAL":
             entry["partial_count"] = int(entry.get("partial_count", 0)) + 1
         elif decision == "KEEP":

--- a/inference_optimizer/tests/test_pr_k_attempts_per_source.py
+++ b/inference_optimizer/tests/test_pr_k_attempts_per_source.py
@@ -1,0 +1,296 @@
+"""PR-K — per-source attempts ledger unlocks device retry post-promotion.
+
+Background
+----------
+Pre-PR-K, ``_batch_kernel_candidates._is_live`` consulted only the
+cumulative ``attempts`` counter on each ``kernel_opt_attempts[kid]``
+entry. With ``max_attempts=1`` (the default), a single attempt against
+the python ``@compile_ops`` wrapper (e.g. ``aiter/ops/moe_op.py``) would
+flip every member of that kernel's task_group to ``not_live`` on the
+next batch — even though the wrapper rewrite was structurally a no-op
+and the device source ``.cu`` had never been tried. Qwen3-30B-A3B-Base
+session 20260523T162026Z burned its full 2h budget after one wrapper
+attempt produced ``group_exhausted`` for every reusable hot kernel.
+
+PR-K's promotion (see ``upgrade_aiter_compile_ops_launcher``) flips
+``source_file`` to the device ``.cu`` on the next batch. This test file
+pins the contract that the new ``attempts_per_source`` ledger plus
+``_is_live`` per-source check actually unlock the device retry:
+
+* ``record_kernel_opt`` writes the cumulative ``attempts`` AND the new
+  ``attempts_per_source[source_file]`` counter.
+* ``_is_live(kid, current_source)`` returns True when the entry has a
+  per-source row showing ``attempts_per_source[current_source] <
+  max_attempts``, even when the cumulative ``attempts`` exceeds the
+  threshold (because all those attempts were against a different
+  source path).
+* ``_is_live`` falls back to cumulative ``attempts`` when the entry
+  predates per-source tracking (resume from a v1 state.json) or when
+  the caller passes an empty source — pre-PR-K behaviour preserved
+  byte-for-byte for legacy callers.
+* End-to-end: a candidate whose pre-batch ``source_file`` was promoted
+  from wrapper to device source IS dispatched even though the kernel
+  has a recorded wrapper attempt.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from inference_optimizer.orchestrator import kernel_request_handlers as krh
+from inference_optimizer.orchestrator.shared_state import SharedState
+
+
+# ---------------------------------------------------------------------------
+# fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def session_dir(tmp_path: Path, monkeypatch) -> Path:
+    monkeypatch.setenv("USER_DATA_PATH", str(tmp_path))
+    sd = tmp_path
+    (sd / "manifest.json").write_text("{}", encoding="utf-8")
+    return sd
+
+
+@pytest.fixture
+def candidates_factory(tmp_path: Path):
+    """Write a kernel_candidates.json fixture and return its path."""
+
+    def _make(hot_kernels: list[dict], task_groups: list[dict] | None = None) -> str:
+        path = tmp_path / "kernel_candidates.json"
+        path.write_text(
+            json.dumps({
+                "hot_kernels": hot_kernels,
+                "task_groups": task_groups or [],
+                "reusable_native_kernel_ids": [],
+            }),
+            encoding="utf-8",
+        )
+        return str(path)
+
+    return _make
+
+
+# ---------------------------------------------------------------------------
+# record_kernel_opt — writes the per-source ledger.
+# ---------------------------------------------------------------------------
+def test_record_kernel_opt_writes_attempts_per_source(
+    session_dir: Path,
+) -> None:
+    state = SharedState.load_or_init(session_dir)
+    state.record_kernel_opt({
+        "status": "ok",
+        "kernel_id": "k001",
+        "source_file": "/sgl-workspace/aiter/aiter/ops/moe_op.py",
+        "proposal": {"decision": "PARTIAL"},
+        "verification": {"micro_speedup": 1.02},
+    })
+    entry = state.kernel_opt_attempts["k001"]
+    assert entry["attempts"] == 1
+    assert entry["attempts_per_source"] == {
+        "/sgl-workspace/aiter/aiter/ops/moe_op.py": 1,
+    }
+
+
+def test_record_kernel_opt_increments_per_source_independently(
+    session_dir: Path,
+) -> None:
+    """Same kernel attempted against two distinct source paths produces
+    a per-source dict with separate counters; cumulative ``attempts``
+    sums across all sources."""
+    state = SharedState.load_or_init(session_dir)
+    wrapper = "/sgl-workspace/aiter/aiter/ops/moe_op.py"
+    device = "/sgl-workspace/aiter/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages.cu"
+
+    state.record_kernel_opt({
+        "status": "ok", "kernel_id": "k001",
+        "source_file": wrapper,
+        "proposal": {"decision": "PARTIAL"},
+        "verification": {"micro_speedup": 0.99},
+    })
+    state.record_kernel_opt({
+        "status": "ok", "kernel_id": "k001",
+        "source_file": device,
+        "proposal": {"decision": "REVERT"},
+        "verification": {"micro_speedup": 0.95},
+    })
+    entry = state.kernel_opt_attempts["k001"]
+    assert entry["attempts"] == 2
+    assert entry["attempts_per_source"] == {wrapper: 1, device: 1}
+
+
+def test_record_kernel_opt_normalizes_empty_source_file(
+    session_dir: Path,
+) -> None:
+    """When the result lacks a source_file (legacy caller / failed
+    attempt before resolution), the empty key ``""`` is used so the
+    ledger remains a valid dict and resume from a v1 state.json with no
+    per-source field is bit-for-bit transparent."""
+    state = SharedState.load_or_init(session_dir)
+    state.record_kernel_opt({
+        "status": "failed", "kernel_id": "k042",
+        # source_file omitted on purpose.
+        "proposal": {"decision": "REVERT"},
+    })
+    entry = state.kernel_opt_attempts["k042"]
+    assert entry["attempts_per_source"] == {"": 1}
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: promotion unlocks a fresh attempt against the device source.
+# ---------------------------------------------------------------------------
+def test_batch_candidates_unlocks_promoted_device_source_after_wrapper_attempt(
+    session_dir: Path, candidates_factory,
+) -> None:
+    """The PR-K core scenario.
+
+    Round 1: kernel was dispatched against the python wrapper, came
+    back PARTIAL → ``attempts_per_source[wrapper] = 1``, kernel is on
+    the cumulative attempts list.
+
+    Round 2: tracelens_analysis re-ran and promoted the source from
+    wrapper to device .cu (kernel name like ``aiter::ck_moe_stage1``
+    triggers ``upgrade_aiter_compile_ops_launcher``); the candidates
+    file now lists the device path.
+
+    Pre-PR-K: ``_is_live(kid)`` returned False because cumulative
+    ``attempts >= 1`` → ``group_exhausted`` → integrate never fires.
+    Post-PR-K: ``_is_live(kid, device_path)`` consults
+    ``attempts_per_source[device_path]`` (zero) and returns True →
+    candidate is dispatched.
+    """
+    wrapper = "/sgl-workspace/aiter/aiter/ops/moe_op.py"
+    device = "/sgl-workspace/aiter/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages.cu"
+
+    state = SharedState.load_or_init(session_dir)
+    # Simulate a wrapper attempt that PARTIAL'd.
+    state.record_kernel_opt({
+        "status": "ok", "kernel_id": "k001",
+        "source_file": wrapper,
+        "proposal": {"decision": "PARTIAL"},
+        "verification": {"micro_speedup": 1.01},
+    })
+    state.save(session_dir)
+
+    # Round 2 candidates: source_file now points at device .cu.
+    cpath = candidates_factory([
+        {
+            "kernel_id": "k001", "gpu_pct": 25.0,
+            "reusable_native_kernel": True,
+            "source_file": device,
+            "name": "aiter::ck_moe_stage1",
+        },
+    ])
+    out = krh._batch_kernel_candidates(
+        {"candidates_path": cpath}, session_dir=session_dir,
+    )
+    assert [c["kernel_id"] for c in out] == ["k001"], (
+        "promoted device source must unlock a fresh dispatch"
+    )
+
+
+def test_batch_candidates_skips_kernel_when_same_source_already_attempted(
+    session_dir: Path, candidates_factory,
+) -> None:
+    """Mirror image of the previous test: when round 2's candidate
+    source_file MATCHES the round-1 attempted source, the kernel is
+    correctly skipped (no infinite-attempt loop on the same target)."""
+    wrapper = "/sgl-workspace/aiter/aiter/ops/moe_op.py"
+
+    state = SharedState.load_or_init(session_dir)
+    state.record_kernel_opt({
+        "status": "ok", "kernel_id": "k001",
+        "source_file": wrapper,
+        "proposal": {"decision": "PARTIAL"},
+        "verification": {"micro_speedup": 1.0},
+    })
+    state.save(session_dir)
+
+    cpath = candidates_factory([
+        {
+            "kernel_id": "k001", "gpu_pct": 25.0,
+            "reusable_native_kernel": True,
+            "source_file": wrapper,  # same as the recorded attempt
+        },
+    ])
+    out = krh._batch_kernel_candidates(
+        {"candidates_path": cpath}, session_dir=session_dir,
+    )
+    assert out == []
+
+
+def test_batch_candidates_falls_back_to_cumulative_for_legacy_entry(
+    session_dir: Path, candidates_factory,
+) -> None:
+    """Resume from a pre-PR-K state.json: the entry has cumulative
+    ``attempts`` but no ``attempts_per_source``. ``_is_live`` must fall
+    back to the cumulative counter so old sessions keep their pre-PR-K
+    skip semantics (no surprise floods of re-attempts on resume)."""
+    state = SharedState.load_or_init(session_dir)
+    # Synthesize a v1 entry by writing kernel_opt_attempts directly,
+    # WITHOUT going through record_kernel_opt (which would populate the
+    # new field).
+    state.kernel_opt_attempts = {
+        "k001": {
+            "attempts": 1, "partial_count": 1,
+            "last_decision": "PARTIAL",
+            "last_source_file": "/p/moe_op.py",
+        },
+    }
+    state.save(session_dir)
+
+    cpath = candidates_factory([
+        {
+            "kernel_id": "k001", "gpu_pct": 25.0,
+            "reusable_native_kernel": True,
+            "source_file": "/p/different.cu",  # different source on round 2
+        },
+    ])
+    out = krh._batch_kernel_candidates(
+        {"candidates_path": cpath}, session_dir=session_dir,
+    )
+    # Legacy entry: no per-source ledger → cumulative ``attempts >= 1``
+    # → skipped, even though on-disk source differs. This is the
+    # conservative resume contract the user requested for PR-K.
+    assert out == []
+
+
+def test_batch_candidates_task_group_promotion_unlocks_primary(
+    session_dir: Path, candidates_factory,
+) -> None:
+    """Task_group flow: primary k002 was dispatched against the wrapper
+    and PARTIAL'd. Round 2 promotes both members to the device source.
+    The group must dispatch as primary again (k002), not skip with
+    ``group_exhausted``."""
+    wrapper = "/sgl-workspace/aiter/aiter/ops/moe_op.py"
+    device = "/sgl-workspace/aiter/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages.cu"
+
+    state = SharedState.load_or_init(session_dir)
+    state.record_kernel_opt({
+        "status": "ok", "kernel_id": "k002",
+        "source_file": wrapper,
+        "proposal": {"decision": "PARTIAL"},
+        "verification": {"micro_speedup": 1.0},
+    })
+    state.save(session_dir)
+
+    cpath = candidates_factory(
+        hot_kernels=[
+            {"kernel_id": "k001", "gpu_pct": 24.0, "reusable_native_kernel": True,
+             "source_file": device, "name": "aiter::ck_moe_stage1"},
+            {"kernel_id": "k002", "gpu_pct": 37.0, "reusable_native_kernel": True,
+             "source_file": device, "name": "aiter::ck_moe_stage2"},
+        ],
+        task_groups=[
+            {"primary_kernel_id": "k002", "kernel_ids": ["k001", "k002"]},
+        ],
+    )
+    out = krh._batch_kernel_candidates(
+        {"candidates_path": cpath}, session_dir=session_dir,
+    )
+    assert len(out) == 1
+    assert out[0]["kernel_id"] == "k002"
+    assert out[0]["source_file"] == device

--- a/kernel-agent/tools/apply_kernel_patch.py
+++ b/kernel-agent/tools/apply_kernel_patch.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import importlib.util
 import json
 import os
 import py_compile
@@ -323,6 +324,171 @@ def _clear_python_kernel_caches(target: Path) -> dict[str, Any]:
     return {"status": "ok", "removed": removed}
 
 
+# ---------------------------------------------------------------------------
+# PR-K: aiter JIT cache invalidation around compiled-source rebuilds.
+#
+# aiter ships ``@compile_ops("module_<name>", gen_func=...)`` decorators that
+# JIT-codegen + hipcc-compile per-instance ``.so`` files into
+# ``<aiter>/jit/build/module_<name>_<sig>/``. ``setup.py develop`` rebuilds the
+# python package + statically-compiled ``.so`` but does NOT invalidate the
+# jit/build entries: a patch under ``aiter/csrc/ck_gemm_moe_2stages_codegen/``
+# would rebuild the wheel yet the next ``import aiter.ops.moe_op`` would still
+# pick up the pre-patch ``module_moe_ck2stages_*.so`` from jit/build/, leaving
+# the integrate benchmark to measure unchanged performance and emit REVERT.
+#
+# We move (NOT copy) the entire jit/build/ directory aside before the rebuild
+# step so the post-rebuild first-import re-codegens + re-compiles every module
+# from clean state. ``shutil.move`` is atomic on the same filesystem and zero-
+# copy. Revert moves the backup back, removing any regenerated jit/build/ dir
+# first so the pre-patch state is restored bit-for-bit.
+#
+# Scope: ONLY aiter is affected. sglang's sgl-kernel and vllm have no JIT
+# codegen layer — their ``.so`` are produced by setup.py at install time, so
+# the standard ``setup.py develop`` rebuild + cache_clear is sufficient and
+# this invalidation step is a no-op for those targets.
+# ---------------------------------------------------------------------------
+_AITER_CSRC_MARKER = "/aiter/csrc/"
+
+
+def _target_is_in_aiter_csrc(target_file: Path) -> bool:
+    """Return True iff ``target_file`` resides under any ``aiter/csrc/`` tree.
+
+    Matches both the editable checkout (``/sgl-workspace/aiter/csrc/...``) and
+    the dist-packages layout (``/usr/local/lib/python3.10/dist-packages/aiter/
+    csrc/...``) — in both cases the relative segment ``aiter/csrc/`` appears
+    verbatim in the absolute path.
+    """
+    return _AITER_CSRC_MARKER in str(target_file).replace(os.sep, "/")
+
+
+def _aiter_jit_build_dir() -> Path | None:
+    """Return ``<aiter>/jit/build`` for the importable aiter, or ``None``.
+
+    Resolved via ``importlib.util.find_spec("aiter")`` so editable installs
+    (``/sgl-workspace/aiter/aiter/__init__.py``), wheel installs
+    (``/usr/local/lib/python3.12/dist-packages/aiter/__init__.py``) and any
+    other layout on ``sys.path`` resolve correctly without hardcoding.
+
+    Returns ``None`` when aiter is not importable in the current interpreter
+    (the kernel-agent sandbox container always has aiter available; this
+    fallback exists so unit tests on a host without aiter still pass).
+    """
+    try:
+        spec = importlib.util.find_spec("aiter")
+    except (ImportError, ValueError):
+        return None
+    if spec is None or not spec.submodule_search_locations:
+        return None
+    aiter_pkg = Path(list(spec.submodule_search_locations)[0])
+    return aiter_pkg / "jit" / "build"
+
+
+def _invalidate_aiter_jit_build(
+    target_file: Path,
+    backup_dir: Path,
+    *,
+    jit_build_dir_override: Path | None = None,
+) -> dict[str, Any]:
+    """Move aiter ``jit/build/`` aside so a post-rebuild first import re-JITs.
+
+    No-op for targets outside ``aiter/csrc/`` and for sandboxes where the
+    aiter package isn't importable / hasn't populated its jit/build/ yet.
+    Returns one of:
+
+      * ``{"status": "ok", "src": ..., "backup_path": ..., "moved_at": ...}``
+        — backup written; caller must persist this in the manifest before
+        rebuild so revert can find it.
+      * ``{"status": "skipped", "reason": ...}`` — non-aiter target, aiter
+        not importable, or jit/build already absent/empty.
+      * ``{"status": "failed", "error": ...}`` — backup path collision; the
+        caller is expected to abort apply rather than rebuild against an
+        inconsistent jit cache.
+
+    ``jit_build_dir_override`` is a test-only escape hatch so unit tests can
+    point at a synthetic jit/build/ tree without an importable aiter package.
+    """
+    if not _target_is_in_aiter_csrc(target_file):
+        return {"status": "skipped", "reason": "target not under aiter/csrc/"}
+    jit_build = jit_build_dir_override or _aiter_jit_build_dir()
+    if jit_build is None:
+        return {"status": "skipped", "reason": "aiter package not importable"}
+    if not jit_build.exists():
+        return {"status": "skipped", "reason": "aiter jit/build/ does not exist"}
+    try:
+        is_empty = not any(jit_build.iterdir())
+    except OSError as exc:
+        return {
+            "status": "failed",
+            "error": f"failed to scan {jit_build}: {exc}",
+            "src": str(jit_build),
+        }
+    if is_empty:
+        return {"status": "skipped", "reason": "aiter jit/build/ is empty"}
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    backup_path = backup_dir / "jit_build"
+    if backup_path.exists():
+        return {
+            "status": "failed",
+            "error": f"jit/build backup path already exists: {backup_path}",
+            "src": str(jit_build),
+        }
+    try:
+        shutil.move(str(jit_build), str(backup_path))
+    except (OSError, shutil.Error) as exc:
+        return {
+            "status": "failed",
+            "error": f"shutil.move failed: {exc}",
+            "src": str(jit_build),
+            "backup_path": str(backup_path),
+        }
+    return {
+        "status": "ok",
+        "src": str(jit_build),
+        "backup_path": str(backup_path),
+        "moved_at": _now(),
+    }
+
+
+def _restore_aiter_jit_build(jit_build_backup: dict[str, Any]) -> dict[str, Any]:
+    """Reverse of :func:`_invalidate_aiter_jit_build`.
+
+    Moves the backup back to its original location. If the post-rebuild first
+    import already regenerated a fresh jit/build/, that fresh dir is removed
+    first so the pre-patch state is restored bit-for-bit (revert semantics).
+    """
+    if not isinstance(jit_build_backup, dict) or jit_build_backup.get("status") != "ok":
+        return {"status": "skipped", "reason": "no backup recorded"}
+    src = Path(jit_build_backup.get("src", ""))
+    backup_path = Path(jit_build_backup.get("backup_path", ""))
+    if not src or not backup_path:
+        return {"status": "skipped", "reason": "incomplete backup record"}
+    if not backup_path.exists():
+        return {
+            "status": "skipped",
+            "reason": f"backup path missing: {backup_path}",
+        }
+    if src.exists():
+        try:
+            shutil.rmtree(src)
+        except OSError as exc:
+            return {
+                "status": "failed",
+                "error": f"failed to clear regenerated jit/build/: {exc}",
+                "src": str(src),
+            }
+    try:
+        src.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(backup_path), str(src))
+    except (OSError, shutil.Error) as exc:
+        return {
+            "status": "failed",
+            "error": f"shutil.move failed during restore: {exc}",
+            "src": str(src),
+            "backup_path": str(backup_path),
+        }
+    return {"status": "ok", "restored_to": str(src)}
+
+
 def _detect_strategy(target_file: Path, *, allow_unknown_target: bool) -> dict[str, Any]:
     target = str(target_file)
     lower = target.lower()
@@ -434,6 +600,20 @@ def revert_kernel_patch(manifest_path: str | Path) -> dict[str, Any]:
             restored.append(str(dst))
             if dst.suffix.lower() in PYTHON_SOURCE_SUFFIXES:
                 manifest["revert_cache_clear"] = _clear_python_kernel_caches(dst)
+
+    # PR-K: restore aiter jit/build/ if it was moved aside during apply.
+    # Done after source/artifact restore but before multi-node fan-out so
+    # the host-local jit cache is back in place even if pod-side revert
+    # subsequently fails. Manifest's ``jit_build_backup`` carries ``src``
+    # and ``backup_path`` set by :func:`_invalidate_aiter_jit_build` and
+    # is only present (with status=ok) when the apply actually moved the
+    # dir aside.
+    jit_build_backup = manifest.get("jit_build_backup") or {}
+    if jit_build_backup.get("status") == "ok":
+        jit_build_restore = _restore_aiter_jit_build(jit_build_backup)
+        manifest["jit_build_restore"] = jit_build_restore
+        if jit_build_restore.get("status") == "ok" and jit_build_restore.get("restored_to"):
+            restored.append(str(jit_build_restore["restored_to"]))
 
     # Multi-node: also fan-out a revert to every pod that received the
     # corresponding apply. Best-effort; sandbox revert above already
@@ -605,7 +785,47 @@ def apply_kernel_patch(
         command = list(strategy["rebuild_command"])
 
     rebuild = {"status": "skipped", "reason": "source-only patch or skip_rebuild=true"}
+    jit_build_backup: dict[str, Any] = {
+        "status": "skipped", "reason": "rebuild not run",
+    }
     if strategy["compiled"] and not skip_rebuild:
+        # PR-K: aiter @compile_ops modules cache JIT-built .so under
+        # <aiter>/jit/build/module_*/. setup.py develop rebuilds the
+        # python package + statically-linked .so but does NOT touch
+        # jit/build/, so a patched .cu under aiter/csrc/ would rebuild
+        # yet the next import would still load the pre-patch .so. Move
+        # jit/build/ aside before rebuild so the post-rebuild first
+        # import re-codegens + re-compiles cleanly. No-op for sglang/
+        # vllm targets (they have no JIT codegen layer).
+        jit_build_backup = _invalidate_aiter_jit_build(target, backup_dir)
+        if jit_build_backup.get("status") == "failed":
+            # Refuse to rebuild against an inconsistent jit cache state:
+            # restore source from backup so the on-disk file matches v0
+            # again, then bail out.
+            try:
+                shutil.copy2(source_backup["backup_path"], target)
+            except OSError:
+                pass
+            return {
+                "status": "failed",
+                "error_class": "aiter_jit_invalidation_failed",
+                "error": (
+                    "aiter jit/build/ invalidation failed: "
+                    f"{jit_build_backup.get('error')}"
+                ),
+                "manifest_path": str(manifest_path),
+                "jit_build_backup": jit_build_backup,
+            }
+        if jit_build_backup.get("status") == "ok":
+            # Persist the backup record into the manifest BEFORE rebuild
+            # so a rebuild failure can still trigger restore via
+            # revert_kernel_patch (which reads the manifest).
+            manifest["jit_build_backup"] = jit_build_backup
+            manifest_path.write_text(
+                json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+
         cwd = Path(strategy["root"] or target.parent)
         rebuild = _run_rebuild(command, cwd, rebuild_timeout_sec)
         if rebuild["status"] != "ok":
@@ -622,6 +842,11 @@ def apply_kernel_patch(
     manifest["applied_at"] = _now()
     manifest["rebuild"] = rebuild
     manifest["cache_clear"] = cache_clear
+    if jit_build_backup.get("status") in {"ok", "skipped"}:
+        # Surface skipped reason too so manifest readers can audit why
+        # invalidation didn't run on a particular apply (e.g. non-aiter
+        # target, aiter not importable in this sandbox).
+        manifest["jit_build_backup"] = jit_build_backup
     # multinode block (when present) is already persisted at fan-out
     # time above; we don't rewrite it here to avoid clobbering the
     # per-host backup map.
@@ -635,6 +860,7 @@ def apply_kernel_patch(
         "artifact_count": len(artifacts),
         "cache_clear": cache_clear,
         "rebuild": rebuild,
+        "jit_build_backup": jit_build_backup,
     }
     # Only attach the multinode key when fan-out actually ran. Keeps
     # single-node callers' return shape bit-for-bit identical to

--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -1022,6 +1022,18 @@ def build_kernel_metadata(candidate: dict[str, Any], args: argparse.Namespace) -
         "runtime_flags": runtime_flags,
         "env_vars": candidate.get("env_vars") or {},
         "kernel_params": kernel_params,
+        # PR-K: source attribution. ``launcher_source_file`` is the python
+        # @compile_ops wrapper TraceLens originally attributed the kernel
+        # to (e.g. ``aiter/ops/moe_op.py``); ``kernel_path`` above is the
+        # device source the LLM must actually rewrite (e.g.
+        # ``csrc/.../gemm_moe_ck2stages.cu``). Both fields are empty /
+        # False when the candidate was NOT promoted, so this metadata
+        # block is a non-event for vendor-style kernels whose trace
+        # source already pointed at the device file.
+        "launcher_source_file": str(candidate.get("launcher_source_file", "") or ""),
+        "source_promoted_from_launcher": bool(
+            candidate.get("source_promoted_from_launcher"),
+        ),
     }
 
 
@@ -1057,6 +1069,42 @@ def build_prompt(
     geak_kernel_type = _GEAK_KERNEL_TYPE.get(str(candidate.get("source_type", "unknown")), "other")
     kernel_name = str(candidate.get("name", args.kernel_id))
     kernel_metadata = build_kernel_metadata(candidate, args)
+    # PR-K: source attribution note. When TraceLens originally attributed a
+    # kernel to a python ``@compile_ops`` wrapper (e.g. ``aiter/ops/moe_op.py``
+    # for ``ck_moe_stage1``) and tracelens_analysis promoted it to the device
+    # source, render a hard-rule notice at the top of the prompt so the LLM
+    # rewrites the device file and not the bypassed wrapper. Empty for
+    # un-promoted kernels — does not bloat the legacy prompt by even a byte.
+    promotion_block = ""
+    launcher_source = str(candidate.get("launcher_source_file", "") or "").strip()
+    if candidate.get("source_promoted_from_launcher") and launcher_source:
+        promotion_block = (
+            "\n>>> SOURCE ATTRIBUTION NOTE — READ FIRST <<<\n"
+            f"This kernel (`{kernel_name}`) was originally traced at the Python launcher:\n"
+            f"  {launcher_source}\n"
+            "which is a thin `@compile_ops` wrapper. The wrapper does NOT contain the\n"
+            "compute path — at runtime the `@compile_ops` decorator dispatches to a\n"
+            "JIT-compiled `.so` under `<aiter>/jit/build/module_*/` and bypasses the\n"
+            "Python wrapper entirely. Patching the wrapper has ZERO runtime effect.\n"
+            "\n"
+            "Your rewrite target is the DEVICE SOURCE shown above as `kernel_url`:\n"
+            f"  {source_file}\n"
+            "\n"
+            "Hard rules for this kernel:\n"
+            "1. DO NOT modify the Python wrapper at the launcher path above. Patches\n"
+            "   there are silently bypassed by the @compile_ops .so loader and the\n"
+            "   integrate baseline will measure -0% E2E gain followed by REVERT.\n"
+            "2. The device source may be a CODEGEN ENTRY (e.g. `gemm_moe_ck2stages.cu`)\n"
+            "   that hipcc compiles into per-(dtype, quant, act) `module_*.so` instances\n"
+            "   under `<aiter>/jit/build/`. The orchestrator clears the matching jit/\n"
+            "   build/ entries before rebuild so your patch actually takes effect on\n"
+            "   next import (no manual cache invalidation needed on your side).\n"
+            "3. Preserve function names, signatures, host entry points, and the\n"
+            "   `aiter` namespace exactly as in the original — the apply step rejects\n"
+            "   patches that drop required host entry functions or that submit a\n"
+            "   standalone `PYBIND11_MODULE` / `TORCH_LIBRARY` block absent from the\n"
+            "   target file.\n"
+        )
     # Quote the per-backend wall-clock so GEAK v3.2.0's LLM task-mode parser
     # (mini.py:435 task_extracted_mode) infers the right mode (>=120min→full,
     # else quick), instead of always seeing the OOB 60min default.
@@ -1288,6 +1336,7 @@ def build_prompt(
         f"repo: {kernel_repo}",
         f"GPU percent: {candidate.get('gpu_pct', 'unknown')}",
         f"Shapes: {json.dumps(candidate.get('shapes', []), sort_keys=True)}",
+        promotion_block,
         "",
         "Kernel runtime metadata (structured context for GEAK; unknown fields are null, empty arrays, or empty objects):",
         "```json",

--- a/kernel-agent/tools/test_aiter_compile_ops_promotion.py
+++ b/kernel-agent/tools/test_aiter_compile_ops_promotion.py
@@ -1,0 +1,266 @@
+"""PR-K — aiter @compile_ops launcher → device source promotion.
+
+Background
+----------
+aiter ships ``@compile_ops("module_<name>", gen_func=...)`` decorators on
+its top-level Python wrappers under ``aiter/ops/``. The decorator JIT-
+codegens + hipcc-compiles a per-instance ``.so`` into
+``<aiter>/jit/build/module_<name>_<sig>/`` on first import. Trace events
+name the wrapper as the call site, so torch.profiler / TraceLens propagate
+``aiter/ops/moe_op.py`` as the kernel's ``source_file``.
+
+But the actual compute lives in ``csrc/`` (e.g.
+``csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages.cu`` for
+``ck_moe_stage1/2``). Rewriting the wrapper is futile because the compiled
+``.so`` bypasses the wrapper at runtime via the @compile_ops dispatch.
+
+:func:`upgrade_aiter_compile_ops_launcher` promotes the wrapper path to
+the device-source ``.cu`` BEFORE the candidate is handed to GEAK / Codex
+/ Claude, so the LLM gets the correct rewrite target. The promotion is
+intentionally narrow (only applies to a small allowlist of @compile_ops
+modules whose device sources we have validated); anything else falls
+through with the wrapper unchanged so the LLM still gets a valid signal.
+
+Tests cover:
+
+* Promotion fires for ``ck_moe_stage1`` / ``ck_moe_stage2`` etc. when the
+  expected ``.cu`` exists at the resolved kernel_repo.
+* Promotion fires for ``topk_softmax``, ``topk_softmax_group``,
+  ``moe_align_block_size``, ``moe_fused_gate``.
+* Promotion is a no-op for non-aiter / non-Python sources.
+* Promotion is a no-op when the kernel name doesn't match any rule
+  (e.g. ``aiter::rmsnorm`` is left as the wrapper for now — it has no
+  @compile_ops codegen layer).
+* Promotion falls back to ``/sgl-workspace/aiter`` when the wrapper is
+  in a wheel install layout (no co-located ``csrc/``) and the editable
+  checkout is at the standard sandbox path.
+* Promotion is a no-op when the corresponding ``.cu`` is missing on disk
+  (refuses to fabricate a path).
+* :func:`_finalize_candidates` end-to-end: a candidate whose source is
+  ``aiter/ops/moe_op.py`` and name is ``aiter::ck_moe_stage1`` ends up
+  with ``source_file`` pointing at the codegen ``.cu`` AND
+  ``launcher_source_file`` carrying the original wrapper path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+_TLA_PATH = Path(__file__).resolve().parent / "tracelens_analysis.py"
+
+
+@pytest.fixture(scope="module")
+def tla() -> types.ModuleType:
+    """Load tracelens_analysis.py without running its full CLI bootstrap."""
+    spec = importlib.util.spec_from_file_location(
+        "_tracelens_analysis_under_test", _TLA_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def aiter_repo(tmp_path: Path) -> Path:
+    """Build a synthetic aiter editable-checkout tree with the device
+    sources we expect promotion to find."""
+    repo = tmp_path / "aiter_editable" / "aiter"  # mimic /sgl-workspace/aiter/
+    # Python wrappers under aiter/ops/.
+    (repo / "aiter" / "ops").mkdir(parents=True)
+    (repo / "aiter" / "ops" / "moe_op.py").write_text(
+        '"""@compile_ops wrapper around module_moe_ck2stages."""\n'
+    )
+    (repo / "aiter" / "ops" / "rmsnorm.py").write_text('# Triton wrapper.\n')
+
+    # Real device sources under csrc/.
+    (repo / "csrc" / "ck_gemm_moe_2stages_codegen").mkdir(parents=True)
+    (repo / "csrc" / "ck_gemm_moe_2stages_codegen" / "gemm_moe_ck2stages.cu").write_text(
+        '// codegen entry for module_moe_ck2stages\n'
+    )
+    (repo / "csrc" / "kernels").mkdir()
+    (repo / "csrc" / "kernels" / "topk_softmax_kernels.cu").write_text("// topk\n")
+    (repo / "csrc" / "kernels" / "topk_softmax_kernels_group.cu").write_text("// topk_group\n")
+    (repo / "csrc" / "kernels" / "moe_align_block_size_kernels.cu").write_text("// align\n")
+    (repo / "csrc" / "kernels" / "moe_fused_gate.cu").write_text("// gate\n")
+
+    # ``find_repo_root`` walks up looking for ``.git/``.
+    (repo / ".git").mkdir()
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# upgrade_aiter_compile_ops_launcher
+# ---------------------------------------------------------------------------
+def test_promotes_ck_moe_stage1_wrapper_to_codegen_cu(
+    tla, aiter_repo: Path,
+) -> None:
+    wrapper = aiter_repo / "aiter" / "ops" / "moe_op.py"
+    out = tla.upgrade_aiter_compile_ops_launcher(
+        str(wrapper), "aiter::ck_moe_stage1", str(aiter_repo),
+    )
+    assert out == str(aiter_repo / "csrc" / "ck_gemm_moe_2stages_codegen" / "gemm_moe_ck2stages.cu")
+
+
+def test_promotes_ck_moe_stage2_wrapper_to_codegen_cu(
+    tla, aiter_repo: Path,
+) -> None:
+    wrapper = aiter_repo / "aiter" / "ops" / "moe_op.py"
+    out = tla.upgrade_aiter_compile_ops_launcher(
+        str(wrapper), "aiter::ck_moe_stage2", str(aiter_repo),
+    )
+    assert out.endswith("gemm_moe_ck2stages.cu")
+
+
+@pytest.mark.parametrize("kernel_name,expected_basename", [
+    ("aiter::topk_softmax_group", "topk_softmax_kernels_group.cu"),
+    ("aiter::topk_softmax", "topk_softmax_kernels.cu"),
+    ("aiter::moe_align_block_size", "moe_align_block_size_kernels.cu"),
+    ("aiter::moe_fused_gate", "moe_fused_gate.cu"),
+])
+def test_promotes_named_compile_ops_to_kernels_cu(
+    tla, aiter_repo: Path, kernel_name: str, expected_basename: str,
+) -> None:
+    wrapper = aiter_repo / "aiter" / "ops" / "moe_op.py"
+    out = tla.upgrade_aiter_compile_ops_launcher(
+        str(wrapper), kernel_name, str(aiter_repo),
+    )
+    assert Path(out).name == expected_basename
+
+
+def test_promotion_noop_when_source_not_aiter_ops(tla, aiter_repo: Path) -> None:
+    """Non-aiter sources (sglang/vllm) are never promoted by this rule."""
+    fake = aiter_repo / "fake_sglang.py"
+    fake.write_text("# not aiter\n")
+    out = tla.upgrade_aiter_compile_ops_launcher(
+        str(fake), "aiter::ck_moe_stage1", str(aiter_repo),
+    )
+    assert out == str(fake)
+
+
+def test_promotion_noop_when_source_not_python(tla, aiter_repo: Path) -> None:
+    """A .cu / .cuh source already IS device source — no promotion needed."""
+    cu = aiter_repo / "csrc" / "ck_gemm_moe_2stages_codegen" / "gemm_moe_ck2stages.cu"
+    out = tla.upgrade_aiter_compile_ops_launcher(
+        str(cu), "aiter::ck_moe_stage1", str(aiter_repo),
+    )
+    assert out == str(cu)
+
+
+def test_promotion_noop_when_kernel_name_unmatched(
+    tla, aiter_repo: Path,
+) -> None:
+    """rmsnorm has no @compile_ops codegen — wrapper is the right target."""
+    wrapper = aiter_repo / "aiter" / "ops" / "rmsnorm.py"
+    out = tla.upgrade_aiter_compile_ops_launcher(
+        str(wrapper), "aiter::rmsnorm2d_fwd", str(aiter_repo),
+    )
+    assert out == str(wrapper)
+
+
+def test_promotion_noop_when_target_cu_missing(
+    tla, aiter_repo: Path, tmp_path: Path, monkeypatch,
+) -> None:
+    """If the expected ``.cu`` isn't on disk (e.g. aiter version drift),
+    refuse to fabricate a path — return the wrapper unchanged so the
+    caller can either fail-fast or fall back to wrapper rewrite."""
+    # Delete the ck_moe codegen .cu to simulate a version mismatch.
+    (aiter_repo / "csrc" / "ck_gemm_moe_2stages_codegen" / "gemm_moe_ck2stages.cu").unlink()
+    # Point the fallback at an empty directory so the promoter cannot
+    # silently succeed via the sandbox's real ``/sgl-workspace/aiter``
+    # (which carries the canonical .cu and would mask the missing-target
+    # contract this test pins).
+    empty_fallback = tmp_path / "no_aiter_here"
+    empty_fallback.mkdir()
+    monkeypatch.setattr(tla, "_AITER_FALLBACK_REPO", str(empty_fallback))
+    wrapper = aiter_repo / "aiter" / "ops" / "moe_op.py"
+    out = tla.upgrade_aiter_compile_ops_launcher(
+        str(wrapper), "aiter::ck_moe_stage1", str(aiter_repo),
+    )
+    assert out == str(wrapper)
+
+
+def test_promotion_falls_back_to_sgl_workspace_aiter_for_wheel_install(
+    tla, tmp_path: Path, monkeypatch,
+) -> None:
+    """A wrapper at a wheel-install path (``/usr/.../aiter/ops/moe_op.py``)
+    has no co-located ``csrc/``. The promoter falls back to the editable
+    checkout at the canonical sandbox path."""
+    # Wheel-install layout (no csrc/ here).
+    wheel_root = tmp_path / "wheel_dist" / "aiter"
+    (wheel_root / "ops").mkdir(parents=True)
+    wrapper = wheel_root / "ops" / "moe_op.py"
+    wrapper.write_text("# wheel wrapper\n")
+
+    # Editable checkout that DOES have csrc/.
+    editable = tmp_path / "sgl-workspace" / "aiter"
+    (editable / "csrc" / "ck_gemm_moe_2stages_codegen").mkdir(parents=True)
+    cu = editable / "csrc" / "ck_gemm_moe_2stages_codegen" / "gemm_moe_ck2stages.cu"
+    cu.write_text("// codegen\n")
+    (editable / ".git").mkdir()
+
+    # Point the fallback at our editable test layout.
+    monkeypatch.setattr(tla, "_AITER_FALLBACK_REPO", str(editable))
+
+    out = tla.upgrade_aiter_compile_ops_launcher(
+        str(wrapper), "aiter::ck_moe_stage1", "",  # no kernel_repo from caller
+    )
+    assert out == str(cu)
+
+
+# ---------------------------------------------------------------------------
+# _finalize_candidates end-to-end with launcher_source_file capture.
+# ---------------------------------------------------------------------------
+def test_finalize_candidates_records_launcher_source_file_on_promotion(
+    tla, aiter_repo: Path,
+) -> None:
+    """End-to-end: a candidate whose pre-finalize ``source_file`` is the
+    aiter wrapper and whose ``name`` is ``aiter::ck_moe_stage1`` exits
+    finalize with:
+      * ``source_file`` == the codegen ``.cu`` (rewrite target);
+      * ``launcher_source_file`` == the original wrapper (prompt context);
+      * ``source_promoted_from_launcher`` == True (audit flag).
+    """
+    wrapper = str(aiter_repo / "aiter" / "ops" / "moe_op.py")
+    candidates = [{
+        "name": "aiter::ck_moe_stage1",
+        "duration_us": 5000.0,
+        "call_count": 100,
+        "source_file": wrapper,
+        "shapes": [[128, 4096]],
+    }]
+    out = tla._finalize_candidates(candidates, total_dur=10000.0)
+    cand = out[0]
+    assert cand["source_file"].endswith("gemm_moe_ck2stages.cu")
+    assert cand["launcher_source_file"] == wrapper
+    assert cand["source_promoted_from_launcher"] is True
+    # Source type should reflect the upgraded device file, not the wrapper.
+    assert cand["source_type"] == "hip_cpp"
+
+
+def test_finalize_candidates_no_launcher_field_when_no_promotion(
+    tla, aiter_repo: Path,
+) -> None:
+    """When promotion does not fire (rmsnorm is not in the allowlist),
+    finalize must NOT add ``launcher_source_file`` — otherwise downstream
+    prompt builders would render a duplicate kernel_url."""
+    wrapper = str(aiter_repo / "aiter" / "ops" / "rmsnorm.py")
+    candidates = [{
+        "name": "aiter::rmsnorm2d_fwd",
+        "duration_us": 1000.0,
+        "call_count": 50,
+        "source_file": wrapper,
+        "shapes": [[128, 4096]],
+    }]
+    out = tla._finalize_candidates(candidates, total_dur=2000.0)
+    cand = out[0]
+    assert cand["source_file"] == wrapper
+    assert "launcher_source_file" not in cand
+    assert cand.get("source_promoted_from_launcher") is not True

--- a/kernel-agent/tools/test_apply_kernel_patch_jit_invalidation.py
+++ b/kernel-agent/tools/test_apply_kernel_patch_jit_invalidation.py
@@ -1,0 +1,449 @@
+"""PR-K — aiter JIT cache invalidation around .cu/.cuh rebuilds.
+
+Background
+----------
+``aiter`` ships ``@compile_ops("module_<name>", gen_func=...)`` decorators
+that JIT-codegen + hipcc-compile per-instance ``.so`` files into
+``<aiter>/jit/build/module_<name>_<sig>/``. ``setup.py develop`` (the
+default rebuild for an aiter editable install) rebuilds the python package
++ statically-linked ``.so`` but does NOT touch ``jit/build/`` entries — so
+a patch under ``aiter/csrc/ck_gemm_moe_2stages_codegen/`` would rebuild
+the wheel yet the next ``import aiter.ops.moe_op`` would still load the
+pre-patch ``module_moe_ck2stages_*.so`` from ``jit/build/``. Net effect on
+historical Qwen3-30B-A3B-Base sessions: integrate measured the unchanged
+kernel and emitted REVERT, masking patch effectiveness as -2.66% E2E.
+
+The :mod:`apply_kernel_patch` tool now moves ``<aiter>/jit/build/`` aside
+into the per-(kernel, target) backup_root BEFORE the rebuild step so the
+post-rebuild first import re-codegens + re-compiles every module from
+clean state. ``shutil.move`` is atomic on the same filesystem and zero-
+copy. :func:`revert_kernel_patch` moves the backup back, removing any
+regenerated ``jit/build/`` first so the pre-patch state is restored
+bit-for-bit.
+
+Scope: ONLY aiter is affected. ``sglang`` and ``vllm`` have no JIT codegen
+layer (their ``.so`` are produced by setup.py at install time), so the
+invalidation step is a no-op for those targets and the standard
+``setup.py develop`` rebuild + ``cache_clear`` is sufficient.
+
+Tests:
+
+* ``_target_is_in_aiter_csrc`` recognizes editable + dist-packages layouts.
+* ``_invalidate_aiter_jit_build`` skips on non-aiter targets, missing /
+  empty jit/build, and refuses to clobber a pre-existing backup.
+* On ok, the entire jit/build/ tree is moved aside (NOT copied) so the
+  source location is empty / absent post-call.
+* ``_restore_aiter_jit_build`` undoes the move, including the case where
+  rebuild + first-import regenerated a fresh jit/build/ on top.
+* End-to-end ``apply_kernel_patch`` against a synthetic aiter-csrc target
+  produces a manifest with ``jit_build_backup`` and the live jit/build/
+  is gone post-apply; ``revert_kernel_patch`` restores it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Tool import — apply_kernel_patch.py is a standalone shell tool, not a
+# package. ``importlib.util`` loads it from the source tree so this test can
+# run without ``HYPERLOOM_KERNEL_AGENT_ROOT`` env / install.sh side-effects.
+# ---------------------------------------------------------------------------
+_APPLY_TOOL_PATH = Path(__file__).resolve().parent / "apply_kernel_patch.py"
+
+
+@pytest.fixture(scope="module")
+def apply_tool() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "_apply_kernel_patch_under_test", _APPLY_TOOL_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# _target_is_in_aiter_csrc
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "target_path,expected",
+    [
+        ("/sgl-workspace/aiter/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages.cu", True),
+        ("/sgl-workspace/aiter/csrc/include/foo.cuh", True),
+        ("/usr/local/lib/python3.12/dist-packages/aiter/csrc/include/bar.hpp", True),
+        ("/opt/venv/lib/python3.10/site-packages/aiter/csrc/baz.cpp", True),
+        # Negative — sglang/vllm csrc, aiter python source, unrelated paths.
+        ("/sgl-workspace/sglang/sgl-kernel/csrc/foo.cu", False),
+        ("/sgl-workspace/vllm/csrc/bar.cu", False),
+        ("/sgl-workspace/aiter/aiter/ops/moe_op.py", False),
+        ("/tmp/foo/aiter.cu", False),
+        # Edge: ``aiter/csrc`` substring inside another package name must
+        # not match — the leading-slash anchor in ``/aiter/csrc/`` prevents
+        # collisions with ``myaiter`` / ``test_aiter`` / etc.
+        ("/sgl-workspace/myaiter/csrc/foo.cu", False),
+    ],
+)
+def test_target_is_in_aiter_csrc(apply_tool, target_path: str, expected: bool) -> None:
+    assert apply_tool._target_is_in_aiter_csrc(Path(target_path)) is expected
+
+
+# ---------------------------------------------------------------------------
+# _invalidate_aiter_jit_build
+# ---------------------------------------------------------------------------
+def test_invalidate_skips_when_target_not_aiter_csrc(
+    apply_tool, tmp_path: Path,
+) -> None:
+    """sglang / vllm / non-csrc targets must NOT touch jit/build/."""
+    sglang_target = tmp_path / "fake_sglang" / "sgl-kernel" / "csrc" / "x.cu"
+    sglang_target.parent.mkdir(parents=True)
+    sglang_target.write_text("// fake")
+
+    backup = tmp_path / "backup"
+    out = apply_tool._invalidate_aiter_jit_build(sglang_target, backup)
+    assert out["status"] == "skipped"
+    assert "aiter/csrc" in out["reason"]
+
+
+def test_invalidate_skips_when_jit_build_missing(
+    apply_tool, tmp_path: Path,
+) -> None:
+    """aiter csrc target but no jit/build/ on disk → skipped."""
+    target = tmp_path / "aiter_root" / "aiter" / "csrc" / "foo.cu"
+    target.parent.mkdir(parents=True)
+    target.write_text("// fake")
+
+    backup = tmp_path / "backup"
+    fake_jit_build = tmp_path / "aiter_root" / "aiter" / "jit" / "build"
+    # Don't create fake_jit_build — should be skipped.
+    out = apply_tool._invalidate_aiter_jit_build(
+        target, backup, jit_build_dir_override=fake_jit_build,
+    )
+    assert out["status"] == "skipped"
+    assert "does not exist" in out["reason"]
+
+
+def test_invalidate_skips_when_jit_build_empty(
+    apply_tool, tmp_path: Path,
+) -> None:
+    """aiter csrc target + empty jit/build/ → skipped (nothing to move)."""
+    target = tmp_path / "aiter_root" / "aiter" / "csrc" / "foo.cu"
+    target.parent.mkdir(parents=True)
+    target.write_text("// fake")
+
+    backup = tmp_path / "backup"
+    fake_jit_build = tmp_path / "aiter_root" / "aiter" / "jit" / "build"
+    fake_jit_build.mkdir(parents=True)
+
+    out = apply_tool._invalidate_aiter_jit_build(
+        target, backup, jit_build_dir_override=fake_jit_build,
+    )
+    assert out["status"] == "skipped"
+    assert "empty" in out["reason"]
+    assert fake_jit_build.is_dir(), "empty dir should not have been moved"
+
+
+def test_invalidate_moves_jit_build_when_populated(
+    apply_tool, tmp_path: Path,
+) -> None:
+    """Populated jit/build/ is MOVED (not copied) into backup_dir/jit_build."""
+    target = tmp_path / "aiter_root" / "aiter" / "csrc" / "ck_gemm_moe_2stages_codegen" / "gemm_moe_ck2stages.cu"
+    target.parent.mkdir(parents=True)
+    target.write_text("// fake codegen entry")
+
+    fake_jit_build = tmp_path / "aiter_root" / "aiter" / "jit" / "build"
+    fake_jit_build.mkdir(parents=True)
+    # Populate with two synthetic compile_ops modules so the directory has
+    # real content like a live aiter sandbox would.
+    (fake_jit_build / "module_moe_ck2stages_b16_b16_silu_no").mkdir()
+    (fake_jit_build / "module_moe_ck2stages_b16_b16_silu_no" / "module.so").write_bytes(b"\x7fELF\x02fake_so")
+    (fake_jit_build / "module_moe_topksoftmax_asm").mkdir()
+    (fake_jit_build / "module_moe_topksoftmax_asm" / "module.so").write_bytes(b"\x7fELF\x02fake_so")
+
+    backup = tmp_path / "backup"
+    out = apply_tool._invalidate_aiter_jit_build(
+        target, backup, jit_build_dir_override=fake_jit_build,
+    )
+
+    assert out["status"] == "ok"
+    assert out["src"] == str(fake_jit_build)
+    assert out["backup_path"] == str(backup / "jit_build")
+    assert "moved_at" in out
+
+    # Source is GONE (moved, not copied).
+    assert not fake_jit_build.exists(), \
+        "jit/build/ must be moved aside, not copied"
+    # Backup contains the original tree intact.
+    assert (backup / "jit_build" / "module_moe_ck2stages_b16_b16_silu_no" / "module.so").is_file()
+    assert (backup / "jit_build" / "module_moe_topksoftmax_asm" / "module.so").is_file()
+
+
+def test_invalidate_refuses_to_clobber_existing_backup(
+    apply_tool, tmp_path: Path,
+) -> None:
+    """A pre-existing backup_dir/jit_build/ from a prior dirty run must
+    fail the apply rather than silently overwriting the previous backup."""
+    target = tmp_path / "aiter_root" / "aiter" / "csrc" / "foo.cu"
+    target.parent.mkdir(parents=True)
+    target.write_text("// fake")
+
+    fake_jit_build = tmp_path / "aiter_root" / "aiter" / "jit" / "build"
+    fake_jit_build.mkdir(parents=True)
+    (fake_jit_build / "module_x").mkdir()
+    (fake_jit_build / "module_x" / "x.so").write_bytes(b"so")
+
+    backup = tmp_path / "backup"
+    backup.mkdir()
+    # Prior backup left over from earlier failed apply.
+    (backup / "jit_build").mkdir()
+    (backup / "jit_build" / "leftover.txt").write_text("stale")
+
+    out = apply_tool._invalidate_aiter_jit_build(
+        target, backup, jit_build_dir_override=fake_jit_build,
+    )
+    assert out["status"] == "failed"
+    assert "already exists" in out["error"]
+    # Live jit/build/ unchanged — caller can recover by clearing the
+    # collision before retrying.
+    assert (fake_jit_build / "module_x" / "x.so").is_file()
+
+
+# ---------------------------------------------------------------------------
+# _restore_aiter_jit_build
+# ---------------------------------------------------------------------------
+def test_restore_moves_backup_back(apply_tool, tmp_path: Path) -> None:
+    """Round-trip: invalidate then restore returns to pre-apply state."""
+    target = tmp_path / "aiter_root" / "aiter" / "csrc" / "foo.cu"
+    target.parent.mkdir(parents=True)
+    target.write_text("// fake")
+
+    fake_jit_build = tmp_path / "aiter_root" / "aiter" / "jit" / "build"
+    fake_jit_build.mkdir(parents=True)
+    (fake_jit_build / "module_a").mkdir()
+    (fake_jit_build / "module_a" / "a.so").write_bytes(b"so_a")
+
+    backup = tmp_path / "backup"
+    invalidate = apply_tool._invalidate_aiter_jit_build(
+        target, backup, jit_build_dir_override=fake_jit_build,
+    )
+    assert invalidate["status"] == "ok"
+    assert not fake_jit_build.exists()
+
+    restore = apply_tool._restore_aiter_jit_build(invalidate)
+    assert restore["status"] == "ok"
+    assert restore["restored_to"] == str(fake_jit_build)
+    assert (fake_jit_build / "module_a" / "a.so").read_bytes() == b"so_a"
+    # Backup path is gone after restore (mv is one-way).
+    assert not (backup / "jit_build").exists()
+
+
+def test_restore_clears_regenerated_dir_first(
+    apply_tool, tmp_path: Path,
+) -> None:
+    """After rebuild, the first import may have already regenerated
+    jit/build/ on top of the original location. Restore must wipe that
+    fresh dir before moving the backup back so the pre-patch state is
+    restored bit-for-bit (otherwise shutil.move would fail or nest)."""
+    target = tmp_path / "aiter_root" / "aiter" / "csrc" / "foo.cu"
+    target.parent.mkdir(parents=True)
+    target.write_text("// fake")
+
+    fake_jit_build = tmp_path / "aiter_root" / "aiter" / "jit" / "build"
+    fake_jit_build.mkdir(parents=True)
+    (fake_jit_build / "module_old").mkdir()
+    (fake_jit_build / "module_old" / "v0.so").write_bytes(b"v0")
+
+    backup = tmp_path / "backup"
+    invalidate = apply_tool._invalidate_aiter_jit_build(
+        target, backup, jit_build_dir_override=fake_jit_build,
+    )
+    assert invalidate["status"] == "ok"
+
+    # Simulate rebuild + first-import regenerating jit/build/ with fresh
+    # patched-version compile artifacts.
+    fake_jit_build.mkdir(parents=True)
+    (fake_jit_build / "module_new").mkdir()
+    (fake_jit_build / "module_new" / "v1.so").write_bytes(b"v1")
+
+    restore = apply_tool._restore_aiter_jit_build(invalidate)
+    assert restore["status"] == "ok"
+    # Pre-patch state restored: only module_old, no module_new.
+    assert (fake_jit_build / "module_old" / "v0.so").read_bytes() == b"v0"
+    assert not (fake_jit_build / "module_new").exists(), \
+        "regenerated jit/build/ must be cleared before restore"
+
+
+def test_restore_skips_when_no_backup(apply_tool) -> None:
+    """A manifest that never recorded a jit_build_backup (non-aiter apply,
+    or skipped invalidation) must produce a 'skipped' restore, not a crash."""
+    out = apply_tool._restore_aiter_jit_build(
+        {"status": "skipped", "reason": "target not under aiter/csrc/"}
+    )
+    assert out["status"] == "skipped"
+
+    out = apply_tool._restore_aiter_jit_build({})
+    assert out["status"] == "skipped"
+
+
+def test_restore_skips_when_backup_path_missing(
+    apply_tool, tmp_path: Path,
+) -> None:
+    """If something deleted the backup between apply and revert, restore
+    must skip cleanly (no crash) so the rest of revert can still run."""
+    fake_src = tmp_path / "aiter_root" / "aiter" / "jit" / "build"
+    fake_backup = tmp_path / "backup" / "jit_build"
+    out = apply_tool._restore_aiter_jit_build({
+        "status": "ok",
+        "src": str(fake_src),
+        "backup_path": str(fake_backup),
+        "moved_at": "2026-05-24T00:00:00Z",
+    })
+    assert out["status"] == "skipped"
+    assert "missing" in out["reason"]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: apply_kernel_patch → revert_kernel_patch with jit invalidation.
+# ---------------------------------------------------------------------------
+def _write_aiter_repo(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Build a synthetic aiter editable-checkout layout:
+
+        <repo>/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages.cu  (target)
+        <repo>/aiter/jit/build/module_moe_ck2stages_*/...              (jit cache)
+    """
+    repo = tmp_path / "sgl-workspace" / "aiter"
+    csrc_dir = repo / "csrc" / "ck_gemm_moe_2stages_codegen"
+    csrc_dir.mkdir(parents=True)
+    target = csrc_dir / "gemm_moe_ck2stages.cu"
+    target.write_text(
+        '#include <cstdio>\n'
+        'namespace aiter {\n'
+        'void ck_moe_stage1(int x) { printf("v0\\n"); }\n'
+        '}\n'
+    )
+
+    jit_build = repo / "aiter" / "jit" / "build"
+    jit_build.mkdir(parents=True)
+    (jit_build / "module_moe_ck2stages_b16_b16_silu_no").mkdir()
+    (jit_build / "module_moe_ck2stages_b16_b16_silu_no" / "kernel.so").write_bytes(b"v0")
+
+    return repo, target, jit_build
+
+
+def test_apply_then_revert_roundtrip_invalidates_and_restores_jit_cache(
+    apply_tool, tmp_path: Path,
+) -> None:
+    """End-to-end ``apply_kernel_patch`` → ``revert_kernel_patch`` cycle.
+
+    The rebuild step is mocked (``_run_rebuild`` → status=ok) so the test
+    stays hermetic, but the rebuild path is exercised — that's the only
+    branch where invalidation runs. Skipping rebuild entirely (the
+    ``skip_rebuild=True`` shortcut) intentionally does NOT invalidate
+    jit/build/ on the assumption that an operator who said "don't rebuild"
+    has already handled cache state themselves.
+
+    Verifies:
+      * manifest + apply result carry ``jit_build_backup`` with status=ok
+      * live jit/build/ is moved aside post-apply (NOT present at the
+        original location)
+      * the patched source landed at the target
+      * revert restores BOTH source and jit/build/ to pre-apply state
+    """
+    repo, target, jit_build = _write_aiter_repo(tmp_path)
+
+    patch_file = tmp_path / "patched.cu"
+    patch_file.write_text(
+        '#include <cstdio>\n'
+        'namespace aiter {\n'
+        'void ck_moe_stage1(int x) { printf("v1\\n"); }\n'
+        '}\n'
+    )
+
+    backup_root = tmp_path / "backups"
+
+    # Force the apply to think aiter is importable at our synthetic layout
+    # so _aiter_jit_build_dir() returns repo/aiter/jit/build.
+    fake_spec = types.SimpleNamespace(submodule_search_locations=[str(repo / "aiter")])
+    fake_rebuild_ok = {
+        "status": "ok",
+        "returncode": 0,
+        "stdout_tail": "ok",
+        "stderr_tail": "",
+        "command": ["fake-rebuild"],
+        "cwd": str(repo),
+    }
+    with patch.object(apply_tool.importlib.util, "find_spec",
+                      return_value=fake_spec), \
+         patch.object(apply_tool, "_run_rebuild",
+                      return_value=fake_rebuild_ok):
+        # Allow the unknown target root since our synthetic /tmp/.../
+        # sgl-workspace/aiter/ tree isn't in KNOWN_TARGET_ROOTS.
+        result = apply_tool.apply_kernel_patch(
+            patch_path=patch_file,
+            target_file=target,
+            backup_root=backup_root,
+            kernel_id="k001",
+            allow_unknown_target=True,
+        )
+
+    assert result["status"] == "ok", result
+    assert result["jit_build_backup"]["status"] == "ok", result["jit_build_backup"]
+    assert result["jit_build_backup"]["src"] == str(jit_build)
+    # Live jit/build/ has been moved aside.
+    assert not jit_build.exists(), \
+        "live jit/build/ must be moved aside before rebuild"
+    backup_jit_build = Path(result["jit_build_backup"]["backup_path"])
+    assert (backup_jit_build / "module_moe_ck2stages_b16_b16_silu_no" / "kernel.so").is_file()
+    # The patched source landed at the target.
+    assert "v1" in target.read_text()
+
+    # Revert: restores both source and jit/build/.
+    revert = apply_tool.revert_kernel_patch(result["manifest_path"])
+    assert revert["status"] == "ok"
+    assert "v0" in target.read_text()
+    assert (jit_build / "module_moe_ck2stages_b16_b16_silu_no" / "kernel.so").read_bytes() == b"v0"
+    assert not backup_jit_build.exists(), "restore should consume the backup"
+
+
+def test_skip_rebuild_does_not_invalidate_jit_build(
+    apply_tool, tmp_path: Path,
+) -> None:
+    """Operator-supplied ``skip_rebuild=True`` means "I'll handle rebuild
+    myself" — apply must NOT touch jit/build/ in that case (otherwise the
+    operator's manual rebuild would lose its jit cache for unrelated
+    modules they were not patching)."""
+    repo, target, jit_build = _write_aiter_repo(tmp_path)
+
+    patch_file = tmp_path / "patched.cu"
+    patch_file.write_text(
+        '#include <cstdio>\n'
+        'namespace aiter {\n'
+        'void ck_moe_stage1(int x) { printf("v1\\n"); }\n'
+        '}\n'
+    )
+
+    fake_spec = types.SimpleNamespace(submodule_search_locations=[str(repo / "aiter")])
+    with patch.object(apply_tool.importlib.util, "find_spec",
+                      return_value=fake_spec):
+        result = apply_tool.apply_kernel_patch(
+            patch_path=patch_file,
+            target_file=target,
+            backup_root=tmp_path / "backups",
+            kernel_id="k001",
+            skip_rebuild=True,
+            allow_unknown_target=True,
+        )
+
+    assert result["status"] == "ok"
+    assert result["jit_build_backup"]["status"] == "skipped"
+    # jit/build/ untouched.
+    assert (jit_build / "module_moe_ck2stages_b16_b16_silu_no" / "kernel.so").is_file()

--- a/kernel-agent/tools/test_prompt_promotion_block.py
+++ b/kernel-agent/tools/test_prompt_promotion_block.py
@@ -1,0 +1,168 @@
+"""PR-K — Prompt rendering carries the source-promotion notice.
+
+When :mod:`tracelens_analysis` promotes a candidate from a python
+``@compile_ops`` wrapper to the device source ``.cu`` (see PR-K's
+``upgrade_aiter_compile_ops_launcher``), the candidate dict carries:
+
+* ``source_file`` set to the device source path (rewrite target);
+* ``launcher_source_file`` set to the original wrapper path;
+* ``source_promoted_from_launcher = True`` (audit flag).
+
+:func:`kernel_optimization.build_prompt` must surface this information
+so the LLM does not silently rewrite the python wrapper (zero runtime
+effect, REVERT @-0% E2E). The contract pinned by these tests:
+
+* When promoted, the prompt body contains a ``SOURCE ATTRIBUTION NOTE``
+  block naming both the launcher and the device source, and tells the
+  LLM in three numbered hard rules NOT to modify the wrapper.
+* When NOT promoted, the prompt body must NOT contain the notice (no
+  byte-level bloat or contradictory guidance for vendor / Triton kernels
+  whose trace source already pointed at the right file).
+* :func:`build_kernel_metadata` carries ``launcher_source_file`` and
+  ``source_promoted_from_launcher`` so non-text consumers (GEAK
+  task_parser JSON path) see the same fields.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import kernel_optimization as ko  # noqa: E402
+
+
+def _build_args(**overrides) -> Namespace:
+    base = {
+        "source_file": "",
+        "kernel_id": "k001",
+        "num_gpus": 1,
+        "budget_minutes": 60,
+        "target_platform": "MI355X",
+        "geak_cost_limit": 5.0,
+        "oob_max_turns": 8,
+        "dry_run": False,
+        "extra_sglang_args": "",
+    }
+    base.update(overrides)
+    return Namespace(**base)
+
+
+def _candidate(**overrides) -> dict:
+    base = {
+        "name": "aiter::ck_moe_stage1",
+        "kernel_id": "k001",
+        "source_file": "/sgl-workspace/aiter/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages.cu",
+        "source_type": "hip_cpp",
+        "kernel_repo": "/sgl-workspace/aiter",
+        "gpu_pct": 25.0,
+        "shapes": [[128, 4096]],
+        "duration_us": 1234.5,
+        "call_count": 100,
+        "is_multigpu": False,
+        "num_gpus_recommended": 1,
+        "benchmark_files": [],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_build_prompt_renders_promotion_block_for_promoted_candidate() -> None:
+    """A promoted candidate's prompt must contain the SOURCE ATTRIBUTION
+    NOTE block with both the launcher and device source paths plus the
+    three hard rules."""
+    cand = _candidate(
+        launcher_source_file="/sgl-workspace/aiter/aiter/ops/moe_op.py",
+        source_promoted_from_launcher=True,
+    )
+    args = _build_args()
+    prompt = ko.build_prompt(cand, args)
+
+    assert "SOURCE ATTRIBUTION NOTE" in prompt
+    assert "/sgl-workspace/aiter/aiter/ops/moe_op.py" in prompt
+    assert "/sgl-workspace/aiter/csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages.cu" in prompt
+    # Three numbered hard rules must all be present so the LLM can't
+    # silently fall through one.
+    assert "1. DO NOT modify the Python wrapper" in prompt
+    assert "2. The device source may be a CODEGEN ENTRY" in prompt
+    assert "3. Preserve function names, signatures" in prompt
+    # The notice must explicitly call out the bypass mechanism so the
+    # LLM understands WHY wrapper patches don't work (not just that they
+    # shouldn't be made).
+    assert "@compile_ops" in prompt
+    assert "ZERO runtime effect" in prompt
+
+
+def test_build_prompt_no_promotion_block_for_un_promoted_candidate() -> None:
+    """Vendor / Triton / direct-device kernels traced to the right file
+    on the first pass must NOT carry the notice — it would either
+    contradict the actual trace attribution (if launcher is empty) or
+    duplicate kernel_url uselessly (if launcher == source_file)."""
+    cand = _candidate(
+        # No launcher_source_file, no source_promoted_from_launcher flag.
+    )
+    args = _build_args()
+    prompt = ko.build_prompt(cand, args)
+    assert "SOURCE ATTRIBUTION NOTE" not in prompt
+    assert "@compile_ops" not in prompt
+
+
+def test_build_prompt_no_promotion_block_when_flag_false_with_launcher() -> None:
+    """Defensive: even if a stray ``launcher_source_file`` field leaked
+    through without the explicit promotion flag (e.g. partial state from
+    an interrupted finalize), the notice must NOT render. The flag is
+    the contract gate, not the field's mere presence."""
+    cand = _candidate(
+        launcher_source_file="/sgl-workspace/aiter/aiter/ops/moe_op.py",
+        # Missing source_promoted_from_launcher → no notice.
+    )
+    args = _build_args()
+    prompt = ko.build_prompt(cand, args)
+    assert "SOURCE ATTRIBUTION NOTE" not in prompt
+
+
+def test_build_kernel_metadata_carries_launcher_fields_when_promoted() -> None:
+    """The structured JSON metadata block (parsed by GEAK's task_parser)
+    must surface the same launcher / promoted-from fields so non-prose
+    consumers see the attribution."""
+    cand = _candidate(
+        launcher_source_file="/sgl-workspace/aiter/aiter/ops/moe_op.py",
+        source_promoted_from_launcher=True,
+    )
+    args = _build_args()
+    md = ko.build_kernel_metadata(cand, args)
+    assert md["kernel_path"].endswith("gemm_moe_ck2stages.cu")
+    assert md["launcher_source_file"] == "/sgl-workspace/aiter/aiter/ops/moe_op.py"
+    assert md["source_promoted_from_launcher"] is True
+
+
+def test_build_kernel_metadata_default_launcher_fields_when_not_promoted() -> None:
+    """Un-promoted candidates carry empty / False values — never None
+    (downstream JSON parsers expect string + bool, not null)."""
+    cand = _candidate()
+    args = _build_args()
+    md = ko.build_kernel_metadata(cand, args)
+    assert md["launcher_source_file"] == ""
+    assert md["source_promoted_from_launcher"] is False
+
+
+def test_build_kernel_metadata_metadata_is_json_serializable_when_promoted() -> None:
+    """The metadata block is dropped into the prompt as ``json.dumps(...)``
+    — a non-serializable value here would render as ``<not serializable>``
+    and silently corrupt GEAK's task_parser. Round-trip the metadata
+    through json to pin the contract."""
+    cand = _candidate(
+        launcher_source_file="/sgl-workspace/aiter/aiter/ops/moe_op.py",
+        source_promoted_from_launcher=True,
+    )
+    args = _build_args()
+    md = ko.build_kernel_metadata(cand, args)
+    # Should NOT raise.
+    encoded = json.dumps(md, sort_keys=True)
+    parsed = json.loads(encoded)
+    assert parsed["launcher_source_file"] == "/sgl-workspace/aiter/aiter/ops/moe_op.py"
+    assert parsed["source_promoted_from_launcher"] is True

--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -1173,6 +1173,119 @@ def _is_pybind_shim(source_file: str) -> bool:
     return "PYBIND11_MODULE" in text or "pybind11" in text
 
 
+# ---------------------------------------------------------------------------
+# PR-K: aiter @compile_ops launcher → device source promotion.
+#
+# aiter ships ``@compile_ops("module_<x>", gen_func=...)`` decorators on its
+# top-level Python wrappers under ``aiter/ops/`` (e.g. ``aiter/ops/moe_op.py``
+# for the ``ck_moe_stage1/2`` family). Trace events name the wrapper as the
+# call-site, so torch.profiler / TraceLens propagate ``aiter/ops/moe_op.py``
+# as the kernel's ``source_file`` — but the actual compute lives in
+# ``csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages.cu`` (codegen entry
+# that hipcc compiles into ``module_moe_ck2stages_*.so`` under
+# ``<aiter>/jit/build/``). Rewriting the wrapper is a no-op at runtime
+# because the compiled .so bypasses the wrapper via the @compile_ops
+# dispatch path. Hyperloom Qwen3-30B-A3B-Base sessions burned 5+ rounds on
+# wrapper rewrites that GEAK/Codex correctly compiled but had zero E2E
+# effect (REVERT @-2.66%); the fix is to promote the wrapper to the
+# device-source ``.cu`` BEFORE handing the candidate to the LLM.
+#
+# Scope is intentionally narrow: only kernels whose name matches one of the
+# entries in :data:`_AITER_COMPILE_OPS_PROMOTIONS` get promoted, and only
+# when the corresponding ``.cu`` exists on disk under the resolved
+# ``kernel_repo``. Anything else falls through with the wrapper unchanged
+# (LLM still gets the original signal — better than a fabricated guess).
+# ---------------------------------------------------------------------------
+# Each entry: (kernel_name_substring_lowercase, ordered_csrc_relpaths_to_try).
+# First on-disk match wins. Order matters when a kernel name matches multiple
+# patterns or when several ``.cu`` files implement variants of the same op.
+_AITER_COMPILE_OPS_PROMOTIONS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    # ck_moe_stage1 / ck_moe_stage2 — @compile_ops("module_moe_ck2stages",
+    # gen_func=cmdGenFunc_ck_moe_stage). The ``.cu`` here is the codegen
+    # entry; hipcc compiles per-(dtype, quant, act) instances into
+    # module_moe_ck2stages_*.so under <aiter>/jit/build/. PR-K's
+    # apply_kernel_patch invalidates that jit/build/ before rebuild so the
+    # patched .cu actually takes effect on the next import.
+    ("ck_moe_stage", (
+        "csrc/ck_gemm_moe_2stages_codegen/gemm_moe_ck2stages.cu",
+    )),
+    # topk_softmax decode kernels.
+    ("topk_softmax_group", ("csrc/kernels/topk_softmax_kernels_group.cu",)),
+    ("topk_softmax", ("csrc/kernels/topk_softmax_kernels.cu",)),
+    # moe_align_block_size — pre-GEMM expert routing prep.
+    ("moe_align_block_size", ("csrc/kernels/moe_align_block_size_kernels.cu",)),
+    # moe_fused_gate — gating + top-k in fused form.
+    ("moe_fused_gate", ("csrc/kernels/moe_fused_gate.cu",)),
+)
+
+# Fallback aiter editable-checkout root for cases where ``find_repo_root``
+# cannot resolve from the wrapper path (e.g. wrapper is at
+# ``/usr/local/lib/python3.12/dist-packages/aiter/ops/moe_op.py`` from a
+# wheel install — wheel layouts strip ``csrc/`` so we have to look at the
+# co-located editable repo). Keep aligned with ``KNOWN_SEARCH_ROOTS``.
+_AITER_FALLBACK_REPO = "/sgl-workspace/aiter"
+
+
+def upgrade_aiter_compile_ops_launcher(
+    source_file: str, kernel_name: str, kernel_repo: str,
+) -> str:
+    """Promote an aiter ``@compile_ops`` Python wrapper to the device ``.cu``.
+
+    Returns the promoted absolute path when:
+      * ``source_file`` is a Python file under any ``aiter/ops/`` tree
+        (matches both editable-checkout and dist-packages layouts);
+      * ``kernel_name`` lowercased contains one of the
+        :data:`_AITER_COMPILE_OPS_PROMOTIONS` substring patterns;
+      * the corresponding ``.cu`` exists on disk under ``kernel_repo``
+        (or under :data:`_AITER_FALLBACK_REPO` when the wrapper lives in
+        a wheel install whose layout has no ``csrc/``).
+
+    Otherwise returns ``source_file`` unchanged so the LLM still gets a
+    valid (if suboptimal) signal — the caller will note the promotion
+    miss in ``optimization_notes`` so operators can audit it.
+    """
+    if not source_file or not kernel_name:
+        return source_file
+    s = source_file.replace(os.sep, "/")
+    if "/aiter/ops/" not in s or not s.endswith(".py"):
+        return source_file
+
+    name_lower = kernel_name.lower()
+    matched_pattern: str | None = None
+    matched_relpaths: tuple[str, ...] = ()
+    for pattern, relpaths in _AITER_COMPILE_OPS_PROMOTIONS:
+        if pattern in name_lower:
+            matched_pattern = pattern
+            matched_relpaths = relpaths
+            break
+    if matched_pattern is None:
+        return source_file
+
+    candidate_repos: list[str] = []
+    if kernel_repo:
+        candidate_repos.append(kernel_repo)
+    elif source_file:
+        derived = find_repo_root(source_file)
+        if derived:
+            candidate_repos.append(derived)
+    if _AITER_FALLBACK_REPO not in candidate_repos:
+        candidate_repos.append(_AITER_FALLBACK_REPO)
+
+    seen: set[str] = set()
+    for repo_str in candidate_repos:
+        if not repo_str or repo_str in seen:
+            continue
+        seen.add(repo_str)
+        repo = Path(repo_str)
+        if not repo.is_dir():
+            continue
+        for relpath in matched_relpaths:
+            candidate = repo / relpath
+            if candidate.is_file():
+                return str(candidate)
+    return source_file
+
+
 def upgrade_pybind_shim_source(source_file: str, kernel_name: str,
                                kernel_repo: str) -> str:
     """If `source_file` is a tiny pybind11 registration TU, walk the repo to
@@ -1388,6 +1501,23 @@ def _finalize_candidates(
         item["source_file"] = upgrade_pybind_shim_source(
             item.get("source_file", ""), item["name"], item.get("kernel_repo", "")
         )
+        # PR-K: aiter @compile_ops launcher → device source promotion.
+        # Capture the wrapper path BEFORE the upgrade so the LLM prompt
+        # builder can render BOTH (device source as the rewrite target +
+        # python launcher as call-site context). Only set
+        # ``launcher_source_file`` when promotion actually changed the
+        # path — otherwise the field would carry the same value as
+        # ``source_file`` and add nothing to the prompt. ``tracelens_
+        # launcher_path`` (the verbatim TraceLens kernel-path string) is
+        # set elsewhere in tracelens_skill_runner._row_to_candidate and
+        # is preserved through this pass for AST-grouping consumers.
+        wrapper_before_promotion = item.get("source_file", "")
+        item["source_file"] = upgrade_aiter_compile_ops_launcher(
+            wrapper_before_promotion, item["name"], item.get("kernel_repo", "")
+        )
+        if item["source_file"] != wrapper_before_promotion:
+            item["launcher_source_file"] = wrapper_before_promotion
+            item["source_promoted_from_launcher"] = True
         # Re-resolve repo in case the upgraded path lives in a different repo
         # (rare, but defensive).
         item["kernel_repo"] = find_repo_root(item.get("source_file", "")) or item["kernel_repo"]


### PR DESCRIPTION
## Summary

Fixes two bugs in the kernel-opt dispatch chain that caused Hyperloom on Qwen3-30B-A3B-Base to silently waste hot-MoE-kernel attempts:

1. **TraceLens attributes ck_moe / topk_softmax / moe_align_block_size etc. to the python `@compile_ops` wrapper** (`aiter/ops/moe_op.py`). Patching the wrapper has zero runtime effect — the `@compile_ops` decorator dispatches to a JIT-compiled `.so` under `<aiter>/jit/build/module_*/` that bypasses the Python wrapper entirely. Pre-PR-K kernel-opt sessions wasted GEAK budget on wrapper rewrites that produced 0 KEEP.
2. **`_batch_kernel_candidates._is_live` consults a cumulative `attempts` counter**, so a single failed wrapper attempt locked every member of the kernel's task_group to `not_live` on the next batch — even though the device source `.cu` had never been tried. Qwen3-30B-A3B-Base session 20260523T162026Z burned 2 h producing `group_exhausted` for every reusable hot kernel.

PR-K is split into 4 independent commits, each self-contained (apply / revert friendly):

| commit | scope | files |
|---|---|---|
| 1/4 (D) | Move `<aiter>/jit/build/` aside before `setup.py develop` so the post-rebuild first import re-codegens + re-compiles cleanly. mv-based, atomic, zero-copy on same fs. Restore on revert; clear regenerated dir first so pre-patch state is restored bit-for-bit. **Aiter-only** (sglang/vllm have no JIT codegen layer; no-op for those targets). | `apply_kernel_patch.py` + 20-test new file |
| 2/4 (A) | `upgrade_aiter_compile_ops_launcher`: kernel-name allowlist (ck_moe_stage1/2, topk_softmax, topk_softmax_group, moe_align_block_size, moe_fused_gate) → device codegen `.cu` under `csrc/`. Falls back to /sgl-workspace/aiter for wheel-install layouts. `_finalize_candidates` stamps `launcher_source_file` + `source_promoted_from_launcher=True` on promotion. | `tracelens_analysis.py` + 13-test new file |
| 3/4 (B) | `build_prompt` renders a `SOURCE ATTRIBUTION NOTE — READ FIRST` block above the kernel_metadata JSON when `source_promoted_from_launcher=True`, with three hard rules telling the LLM not to modify the wrapper, the device source may be a codegen entry, the orchestrator clears matching jit/build/ entries before rebuild. Un-promoted candidates produce a byte-identical prompt to pre-PR-K. | `kernel_optimization.py` + 6-test new file |
| 4/4 (C) | `record_kernel_opt` writes a per-source `attempts_per_source[source_file]` ledger alongside cumulative `attempts`. `_is_live(kid, current_source)` consults `attempts_per_source[current_source]` first; falls back to cumulative for legacy v1 entries (resume from a state.json that predates this PR). Wrapper attempts no longer lock out a fresh device-source attempt. | `shared_state.py` + `kernel_request_handlers.py` + 7-test new file |

## Test plan

- [x] 46 new unit tests across the 4 commits (D=20, A=13, B=6, C=7), all passing
- [x] Full regression on related modules: `apply_kernel_patch`, `tracelens`, `kernel_optimization`, `shared_state`, `kernel_request_handlers`, `integrate`, `p2_2`, `p2_4` — **389 passed, 0 regressions**
- [x] Lint clean
- [x] Schema-compatible: legacy `state.json` from before this PR resumes byte-for-byte (no surprise reattempts on resume)
- [x] **Production dry-run on Qwen3-30B-A3B-Base** (session 20260524T020943Z, 6h41min, 19 ticks):
  - A verified: 4 ck_moe kernels (k001-k004) all promote `aiter/ops/moe_op.py` → `csrc/.../gemm_moe_ck2stages.cu`
  - B verified: SOURCE ATTRIBUTION NOTE renders in GEAK prompt (`prompts/geak-c5d9823b.md`) with all three hard rules
  - C verified: `kernel_opt_attempts[k001-k004].attempts_per_source['..gemm_moe_ck2stages.cu']=1` written to `state.json`
  - C verified end-to-end: after k001/k004 reject, k002/k003 dispatched in next batch (was `group_exhausted` pre-PR-K)
  - D **NOT verified in production**: 0 KEEP candidates → 0 integrate calls → `_invalidate_aiter_jit_build` never reached. Only single-test coverage.

## Known limitations / scope

- **Does NOT solve the GEAK-can't-rewrite-CK-codegen-`.cu` issue**: this PR fixes the upstream attribution + ledger bugs so GEAK at least sees the right rewrite target with a fresh attempt budget. Whether GEAK can actually produce a useful patch on `gemm_moe_ck2stages.cu` is a separate problem (left to GEAK side). The session above produced 0 KEEP because GEAK timed out at 5580s/93min on every device-source attempt without producing a `.cu` rewrite.
- **D is a logical-necessity fix without production trigger data**: aiter's `@compile_ops` persistent `.so` cache means a patched `csrc/.../gemm_moe_ck2stages.cu` would otherwise rebuild the wheel but the next import would still load the pre-patch `module_moe_ck2stages_*.so` from `jit/build/` — so the patch silently no-ops at runtime. B-prompt explicitly promises the LLM that "the orchestrator clears the matching jit/build/ entries before rebuild"; removing D would make that prompt lie. Single-test coverage exercises mv/restore boundaries (target detection, missing/empty/populated jit/build, backup-collision refusal, restore round-trip, restore clears regenerated dir, full apply→revert E2E with mocked rebuild, skip_rebuild noop), but the end-to-end "patched .cu actually takes effect on next import" link can only be verified once GEAK produces a KEEP.
- **Promotion allowlist is intentionally narrow**: only kernels we've validated against real aiter trees (ck_moe / topk_softmax / moe_align_block_size / moe_fused_gate). Anything else falls through with the wrapper unchanged so the LLM still gets a valid signal. Add new entries to `_AITER_COMPILE_OPS_PROMOTIONS` as new high-leverage MoE-style ops surface.
- **Multi-node**: aiter csrc patch + jit_build invalidation operate on the sandbox node only. Existing `_dispatch_multinode_apply` fan-out still mirrors the source patch to every pod; pod-side jit caches are invalidated at server restart in `integrate_handler`, not by this PR.

## Production session as evidence

| metric | pre-PR-K (162026Z) | this PR (020943Z) |
|---|---|---|
| Run time | 2h 11min | 6h 41min |
| Ticks | 8 | 19 |
| ck_moe members tried | k001 + k002 (wrapper, group_exhausted at batch 2) | k001-k004 all (device .cu) |
| GEAK source target | `aiter/ops/moe_op.py` | `csrc/.../gemm_moe_ck2stages.cu` |
| Group fallback | locked at `group_exhausted` | k002/k003 auto-dispatched after k001/k004 reject |
| validated_gain | 0% | 0.26% (from `--attention-backend aiter`, not kernel-opt) |
| stop_reason | report_emitted (LLM gave up early) | report_emitted (ran out of leverage to test) |

PR-K does not deliver a positive throughput gain on this model on this run — that requires GEAK to produce a working CK kernel rewrite, which is out of scope. PR-K's contribution is letting the dispatch chain reach that decision instead of being silently locked out at the wrong target.

## Branch hygiene

- Cherry-picked from `feature/xiaofei/in-flight-pid-liveness-check` (PR-J) to a clean branch on top of `origin/main` (`3e016e1`); resolved one trivial conflict in `kernel_optimization.py::build_prompt` against the PR-301 budget_min change (kept both — backend-specific budget_min + new promotion_block).

Made with [Cursor](https://cursor.com)