### PR TITLE
feat(backends): env-var override for Claude/Codex call_timeout_s

### DIFF
--- a/inference_optimizer/orchestrator/backends/base.py
+++ b/inference_optimizer/orchestrator/backends/base.py
@@ -8,10 +8,47 @@ backends only need to produce intents.
 
 from __future__ import annotations
 
+import logging
+import os
 from dataclasses import dataclass, field
 from typing import Any, Protocol, runtime_checkable
 
 from ..intent_parser import Intent
+
+log = logging.getLogger(__name__)
+
+
+def parse_call_timeout_env(env_name: str, *, default: float) -> float:
+    """Read a per-call wall-clock timeout from ``env_name``, default on miss/error.
+
+    Operators bump ``call_timeout_s`` for the LLM backends when a heavy
+    orchestrator prompt + multi-turn agentic loop reproducibly exceeds the
+    120s default on the AMD gateway. Reading the env var lets them tune
+    without code changes / redeploys.
+
+    Returns ``default`` (not raising) when the env var is unset, empty, or
+    not a positive finite float — a malformed knob must not be a fatal
+    boot-time error for the orchestrator. Mis-parses are logged at WARNING
+    so the operator sees the fallback in the boot logs.
+    """
+    raw = os.environ.get(env_name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        log.warning(
+            "%s=%r is not a float; using default %.1fs",
+            env_name, raw, default,
+        )
+        return default
+    if value <= 0 or value != value:  # NaN check via inequality
+        log.warning(
+            "%s=%r is not a positive finite number; using default %.1fs",
+            env_name, raw, default,
+        )
+        return default
+    return value
 
 
 class BackendError(RuntimeError):
@@ -50,4 +87,4 @@ class Backend(Protocol):
     ) -> BackendTurnResult: ...
 
 
-__all__ = ["Backend", "BackendError", "BackendTurnResult"]
+__all__ = ["Backend", "BackendError", "BackendTurnResult", "parse_call_timeout_env"]

--- a/inference_optimizer/orchestrator/backends/base.py
+++ b/inference_optimizer/orchestrator/backends/base.py
@@ -9,6 +9,7 @@ backends only need to produce intents.
 from __future__ import annotations
 
 import logging
+import math
 import os
 from dataclasses import dataclass, field
 from typing import Any, Protocol, runtime_checkable
@@ -42,7 +43,7 @@ def parse_call_timeout_env(env_name: str, *, default: float) -> float:
             env_name, raw, default,
         )
         return default
-    if value <= 0 or value != value:  # NaN check via inequality
+    if value <= 0 or not math.isfinite(value):
         log.warning(
             "%s=%r is not a positive finite number; using default %.1fs",
             env_name, raw, default,

--- a/inference_optimizer/orchestrator/backends/claude.py
+++ b/inference_optimizer/orchestrator/backends/claude.py
@@ -36,7 +36,7 @@ from ..intent_parser import (
     NoIntentEmitted,
     validate_envelope,
 )
-from .base import BackendError, BackendTurnResult
+from .base import BackendError, BackendTurnResult, parse_call_timeout_env
 from .mcp_emit_intent import (
     EMIT_INTENT_TOOL_NAME,
     EMIT_INTENT_TOOL_QUALIFIED,
@@ -135,7 +135,19 @@ class ClaudeBackend:
     # gateway; if the gateway is unreachable the subprocess can hang
     # on TCP for minutes, stalling the orchestrator reactor. 120s is
     # well above a normal turn (~10–30s) but bounds the worst case.
-    call_timeout_s: float = 120.0
+    #
+    # Env-var override ``INFERENCE_OPTIMIZER_CLAUDE_CALL_TIMEOUT_SEC`` lets
+    # operators bump this when opus-class models with a heavy orchestrator
+    # system prompt (~22 KB) and a 4-turn agentic loop consistently exceed
+    # 120 s on the AMD gateway under load. Invalid values fall back to the
+    # 120s default rather than crashing backend construction; backend
+    # boot-time refuses to die for a malformed env-var.
+    call_timeout_s: float = field(
+        default_factory=lambda: parse_call_timeout_env(
+            "INFERENCE_OPTIMIZER_CLAUDE_CALL_TIMEOUT_SEC",
+            default=120.0,
+        )
+    )
 
     # Test seams — set these to bypass SDK import / network calls.
     sdk_query_factory: Callable[..., Any] | None = None

--- a/inference_optimizer/orchestrator/backends/codex.py
+++ b/inference_optimizer/orchestrator/backends/codex.py
@@ -42,7 +42,7 @@ from ..intent_parser import (
     NoIntentEmitted,
     validate_envelope,
 )
-from .base import BackendError, BackendTurnResult
+from .base import BackendError, BackendTurnResult, parse_call_timeout_env
 
 
 _OUTPUT_INSTRUCTIONS = """
@@ -130,7 +130,16 @@ class CodexBackend:
     # ``await create(...)`` for the full TCP timeout. Bounding it at
     # asyncio level guarantees the orchestrator reactor never sits idle
     # past this budget.
-    call_timeout_s: float = 120.0
+    #
+    # Env-var override ``INFERENCE_OPTIMIZER_CODEX_CALL_TIMEOUT_SEC`` mirrors
+    # the claude backend knob; same rationale (heavy critic / kernel prompts
+    # may exceed 120 s on the AMD gateway under load).
+    call_timeout_s: float = field(
+        default_factory=lambda: parse_call_timeout_env(
+            "INFERENCE_OPTIMIZER_CODEX_CALL_TIMEOUT_SEC",
+            default=120.0,
+        )
+    )
 
     # Test seam — set to bypass real OpenAI client construction.
     client_factory: Callable[[], Any] | None = None

--- a/inference_optimizer/tests/test_backend_call_timeout_env.py
+++ b/inference_optimizer/tests/test_backend_call_timeout_env.py
@@ -1,0 +1,156 @@
+"""Per-backend ``call_timeout_s`` env-var override tests.
+
+``parse_call_timeout_env`` (orchestrator/backends/base.py) reads
+``INFERENCE_OPTIMIZER_*_CALL_TIMEOUT_SEC`` so operators can bump the
+asyncio wall-clock cap on a ``ClaudeBackend`` / ``CodexBackend`` call
+without code changes. The helper returns ``default`` for unset / empty
+/ malformed / non-positive / non-finite values so a typo in the env can
+never crash backend boot.
+
+These tests pin both contracts:
+
+1. Helper-level: unset/empty/garbage/negative/nan -> default; happy path
+   returns the parsed float verbatim.
+2. Backend-level: ``ClaudeBackend()`` and ``CodexBackend()`` instantiated
+   under a chosen env value pick up that value as ``call_timeout_s``,
+   and instantiated without the env fall back to 120.0.
+
+Backend tests use ``dataclasses.fields(...).default_factory`` -- the
+``call_timeout_s`` value is read at instantiation, not at import, so
+``monkeypatch.setenv`` after the module is already imported still wins.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from inference_optimizer.orchestrator.backends.base import parse_call_timeout_env
+
+
+CLAUDE_ENV = "INFERENCE_OPTIMIZER_CLAUDE_CALL_TIMEOUT_SEC"
+CODEX_ENV = "INFERENCE_OPTIMIZER_CODEX_CALL_TIMEOUT_SEC"
+PROBE_ENV = "INFERENCE_OPTIMIZER_TIMEOUT_ENV_PROBE_SEC"
+
+
+class TestParseCallTimeoutEnv:
+    def test_unset_returns_default(self, monkeypatch):
+        monkeypatch.delenv(PROBE_ENV, raising=False)
+        assert parse_call_timeout_env(PROBE_ENV, default=120.0) == 120.0
+
+    def test_empty_returns_default(self, monkeypatch):
+        monkeypatch.setenv(PROBE_ENV, "")
+        assert parse_call_timeout_env(PROBE_ENV, default=77.0) == 77.0
+
+    def test_whitespace_returns_default(self, monkeypatch):
+        monkeypatch.setenv(PROBE_ENV, "   ")
+        assert parse_call_timeout_env(PROBE_ENV, default=42.0) == 42.0
+
+    def test_happy_path_float(self, monkeypatch):
+        monkeypatch.setenv(PROBE_ENV, "240")
+        assert parse_call_timeout_env(PROBE_ENV, default=120.0) == 240.0
+
+    def test_happy_path_fractional(self, monkeypatch):
+        monkeypatch.setenv(PROBE_ENV, "12.5")
+        assert parse_call_timeout_env(PROBE_ENV, default=120.0) == 12.5
+
+    def test_garbage_returns_default(self, monkeypatch, caplog):
+        monkeypatch.setenv(PROBE_ENV, "not-a-float")
+        with caplog.at_level("WARNING"):
+            assert parse_call_timeout_env(PROBE_ENV, default=120.0) == 120.0
+        assert any("not a float" in rec.message for rec in caplog.records)
+
+    def test_zero_returns_default(self, monkeypatch, caplog):
+        monkeypatch.setenv(PROBE_ENV, "0")
+        with caplog.at_level("WARNING"):
+            assert parse_call_timeout_env(PROBE_ENV, default=120.0) == 120.0
+
+    def test_negative_returns_default(self, monkeypatch, caplog):
+        monkeypatch.setenv(PROBE_ENV, "-30")
+        with caplog.at_level("WARNING"):
+            assert parse_call_timeout_env(PROBE_ENV, default=120.0) == 120.0
+        assert any("not a positive finite" in rec.message for rec in caplog.records)
+
+    def test_nan_returns_default(self, monkeypatch, caplog):
+        monkeypatch.setenv(PROBE_ENV, "nan")
+        with caplog.at_level("WARNING"):
+            result = parse_call_timeout_env(PROBE_ENV, default=120.0)
+        assert result == 120.0
+        assert not math.isnan(result)
+
+
+class TestClaudeBackendHonoursEnv:
+    def test_default_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv(CLAUDE_ENV, raising=False)
+        backend = _new_claude_backend_with_seams()
+        assert backend.call_timeout_s == 120.0
+
+    def test_env_override_picked_up_at_instantiation(self, monkeypatch):
+        monkeypatch.setenv(CLAUDE_ENV, "300")
+        backend = _new_claude_backend_with_seams()
+        assert backend.call_timeout_s == 300.0
+
+    def test_bad_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv(CLAUDE_ENV, "garbage")
+        backend = _new_claude_backend_with_seams()
+        assert backend.call_timeout_s == 120.0
+
+
+class TestCodexBackendHonoursEnv:
+    def test_default_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv(CODEX_ENV, raising=False)
+        from inference_optimizer.orchestrator.backends.codex import CodexBackend
+
+        backend = CodexBackend(
+            api_key_env="OPENAI_API_KEY_TEST",
+            base_url_env="OPENAI_BASE_URL_TEST",
+            client_factory=lambda: object(),
+        )
+        assert backend.call_timeout_s == 120.0
+
+    def test_env_override_picked_up_at_instantiation(self, monkeypatch):
+        monkeypatch.setenv(CODEX_ENV, "240")
+        from inference_optimizer.orchestrator.backends.codex import CodexBackend
+
+        backend = CodexBackend(
+            api_key_env="OPENAI_API_KEY_TEST",
+            base_url_env="OPENAI_BASE_URL_TEST",
+            client_factory=lambda: object(),
+        )
+        assert backend.call_timeout_s == 240.0
+
+    def test_bad_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv(CODEX_ENV, "negative-one")
+        from inference_optimizer.orchestrator.backends.codex import CodexBackend
+
+        backend = CodexBackend(
+            api_key_env="OPENAI_API_KEY_TEST",
+            base_url_env="OPENAI_BASE_URL_TEST",
+            client_factory=lambda: object(),
+        )
+        assert backend.call_timeout_s == 120.0
+
+
+def _new_claude_backend_with_seams():
+    """Build a ClaudeBackend that skips real SDK import + MCP server.
+
+    ``__post_init__`` accepts ``enable_mcp_emit_intent=False`` and a
+    minimal pair of seams to skip both the real SDK import and the MCP
+    server build (mirroring ``test_claude_backend.py``'s pattern).
+    """
+    from inference_optimizer.orchestrator.backends.claude import ClaudeBackend
+
+    return ClaudeBackend(
+        sdk_query_factory=lambda *a, **kw: iter(()),
+        sdk_options_cls=type("FakeOpts", (), {"__init__": lambda self, **kw: None}),
+        enable_mcp_emit_intent=False,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_probe_env(monkeypatch):
+    """Ensure tests never leak the probe env to each other."""
+    for key in (CLAUDE_ENV, CODEX_ENV, PROBE_ENV):
+        monkeypatch.delenv(key, raising=False)
+    yield

--- a/inference_optimizer/tests/test_backend_call_timeout_env.py
+++ b/inference_optimizer/tests/test_backend_call_timeout_env.py
@@ -79,6 +79,19 @@ class TestParseCallTimeoutEnv:
         assert result == 120.0
         assert not math.isnan(result)
 
+    @pytest.mark.parametrize("raw", ["inf", "-inf", "infinity"])
+    def test_infinity_returns_default(self, monkeypatch, caplog, raw):
+        """``math.isfinite`` rejects both ``+inf`` and ``-inf`` -- a wall-clock
+        timeout can never be infinite. This pins the CodeQL fix that swapped
+        the NaN-only ``value != value`` check for ``not math.isfinite(value)``.
+        """
+        monkeypatch.setenv(PROBE_ENV, raw)
+        with caplog.at_level("WARNING"):
+            result = parse_call_timeout_env(PROBE_ENV, default=120.0)
+        assert result == 120.0
+        assert math.isfinite(result)
+        assert any("not a positive finite" in rec.message for rec in caplog.records)
+
 
 class TestClaudeBackendHonoursEnv:
     def test_default_when_env_unset(self, monkeypatch):
@@ -105,7 +118,7 @@ class TestCodexBackendHonoursEnv:
         backend = CodexBackend(
             api_key_env="OPENAI_API_KEY_TEST",
             base_url_env="OPENAI_BASE_URL_TEST",
-            client_factory=lambda: object(),
+            client_factory=object,
         )
         assert backend.call_timeout_s == 120.0
 
@@ -116,7 +129,7 @@ class TestCodexBackendHonoursEnv:
         backend = CodexBackend(
             api_key_env="OPENAI_API_KEY_TEST",
             base_url_env="OPENAI_BASE_URL_TEST",
-            client_factory=lambda: object(),
+            client_factory=object,
         )
         assert backend.call_timeout_s == 240.0
 
@@ -127,7 +140,7 @@ class TestCodexBackendHonoursEnv:
         backend = CodexBackend(
             api_key_env="OPENAI_API_KEY_TEST",
             base_url_env="OPENAI_BASE_URL_TEST",
-            client_factory=lambda: object(),
+            client_factory=object,
         )
         assert backend.call_timeout_s == 120.0
 


### PR DESCRIPTION
## Summary

- Add a shared `parse_call_timeout_env` helper in [inference_optimizer/orchestrator/backends/base.py](inference_optimizer/orchestrator/backends/base.py).
- Wire it through `dataclasses.field(default_factory=...)` in [claude.py](inference_optimizer/orchestrator/backends/claude.py) and [codex.py](inference_optimizer/orchestrator/backends/codex.py) so each backend's `call_timeout_s` honours a per-backend env var at instantiation time.
- New env vars (both optional, both default 120s):
  - `INFERENCE_OPTIMIZER_CLAUDE_CALL_TIMEOUT_SEC`
  - `INFERENCE_OPTIMIZER_CODEX_CALL_TIMEOUT_SEC`
- 15 new tests in [test_backend_call_timeout_env.py](inference_optimizer/tests/test_backend_call_timeout_env.py).

## Motivation

Both backends wrap their LLM call in `asyncio.wait_for(..., timeout=self.call_timeout_s)`. The 120s default is well above a typical turn (~10-30s) but is reproducibly truncated on the AMD gateway under load when an opus-class model gets a heavy orchestrator system prompt (~22 KB) and runs a 4-turn agentic loop, or when the Codex critic loop processes a long kernel-optimization rollout. Today the only way to bump the cap is to edit the dataclass default and rebuild.

Exposing the cap as an env var lets operators tune per-cluster without code changes or redeploys. It also keeps the class-level default at 120.0, so existing tests / operators who don't set the env var see *no* behavior change.

## Safety / failure modes

`parse_call_timeout_env` returns the default (not raising) when the env is:

- unset / empty / whitespace,
- not a float (e.g. `"abc"`),
- non-positive (`0`, `-30`),
- NaN.

Mis-parses are logged at WARNING so the operator sees the fallback in the boot logs. A malformed knob must never crash backend boot.

## Tests

```
pytest inference_optimizer/tests/test_backend_call_timeout_env.py \
       inference_optimizer/tests/test_claude_backend.py \
       inference_optimizer/tests/test_codex_backend.py \
       inference_optimizer/tests/test_claude_backend_cache_metric.py \
       inference_optimizer/tests/test_mock_backends.py \
       inference_optimizer/tests/test_critic_agent_backend.py -q
# 96 passed in 9.04s
```

Coverage:
- 8 helper tests: unset / empty / whitespace / happy-path / fractional / garbage / zero / negative / NaN.
- 3 Claude wiring tests: default-when-unset / env-override picked-up / bad-env falls back.
- 3 Codex wiring tests: same shape.

## Test plan

- [x] All backend tests still pass.
- [x] No behavior change for the default code path (no env set).
- [ ] Operator sanity-check: set `INFERENCE_OPTIMIZER_CLAUDE_CALL_TIMEOUT_SEC=300`, instantiate a `ClaudeBackend`, confirm `backend.call_timeout_s == 300.0`.

Made with [Cursor](https://cursor.com)


Closes #318
