### PR TITLE
feat(orchestrator): default integrate_handler inputs from SharedState

### DIFF
--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -497,6 +497,46 @@ def _find_selected_kernel_source(state: Any, kernel_id: str) -> str:
     return ""
 
 
+def _fill_integrate_defaults_from_state(
+    payload: dict, *, session_dir: Path,
+) -> dict:
+    """Pull ``base_tput`` / ``config_path`` / ``extra_sglang_args`` defaults from SharedState.
+
+    Sibling of ``_resolve_integrate_payload`` but runs *before* the
+    ``base_tput > 0`` hard-check at the top of ``integrate_handler``.
+    ``_resolve_integrate_payload`` already handles ``patch_path`` /
+    ``source_file`` defaulting; the three fields filled here are the
+    other Magpie re-baseline inputs that Orchestration tends to omit
+    when it sends a bare ``{"kernel_id": ...}`` payload.
+
+    Always returns a (shallow) copy of ``payload`` so the caller can
+    treat it as a fresh dict; never raises on a missing SharedState
+    snapshot (returns the input dict unchanged in that case).
+    """
+    from .shared_state import SharedState
+
+    resolved = dict(payload)
+    state = SharedState.load_or_init(session_dir)
+
+    if float(resolved.get("base_tput", 0.0) or 0.0) <= 0:
+        bt = float(getattr(state, "baseline_tput", 0.0) or 0.0)
+        if bt > 0:
+            resolved["base_tput"] = bt
+
+    if not resolved.get("config_path"):
+        cfg = getattr(state, "baseline_config_path", "") or ""
+        if cfg:
+            resolved["config_path"] = cfg
+
+    current_best = getattr(state, "current_best", None) or {}
+    if not resolved.get("extra_sglang_args") and isinstance(current_best, dict):
+        cb_args = current_best.get("extra_sglang_args") or ""
+        if cb_args:
+            resolved["extra_sglang_args"] = cb_args
+
+    return resolved
+
+
 def _resolve_integrate_payload(payload: dict, *, session_dir: Path) -> tuple[dict, HandlerResult | None]:
     """Fill integrate inputs from SharedState when Orchestration sends only kernel_id.
 
@@ -1582,8 +1622,17 @@ async def integrate_handler(
     """
     from .action_executors.baseline import BaselineExecutor
     from .action_executors.benchmark_result import is_valid_measurement
+    from .shared_state import SharedState
     from .sub_agent_runner import RunnerContext
     from .task_registry import Task
+
+    # Orchestration often calls integrate with just {kernel_id} — the
+    # already-materialised baseline / current-best config lives in
+    # SharedState. Fill it in before the hard ``base_tput > 0`` check so
+    # a well-prepared session_dir is self-sufficient and we don't fail
+    # the integrate task with a phantom "missing base_tput" when the
+    # number is right there on disk.
+    payload = _fill_integrate_defaults_from_state(payload, session_dir=session_dir)
 
     base_tput = float(payload.get("base_tput", 0.0))
     if base_tput <= 0:

--- a/inference_optimizer/tests/test_integrate_payload_defaults.py
+++ b/inference_optimizer/tests/test_integrate_payload_defaults.py
@@ -1,0 +1,182 @@
+"""``_fill_integrate_defaults_from_state`` + integrate_handler defaulting.
+
+Pre-existing ``_resolve_integrate_payload`` fills ``patch_path`` and
+``source_file`` from SharedState when Orchestration sends only
+``kernel_id``. The sibling helper added here fills the three other
+Magpie re-baseline inputs that Orchestration omits just as often:
+
+* ``base_tput``         from ``state.baseline_tput``
+* ``config_path``       from ``state.baseline_config_path``
+* ``extra_sglang_args`` from ``state.current_best["extra_sglang_args"]``
+
+These tests pin (a) per-field defaulting, (b) explicit-payload wins,
+and (c) the wiring through ``integrate_handler`` so the pre-existing
+hard ``base_tput > 0`` check no longer panics when the value is
+already on disk.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from inference_optimizer.orchestrator import kernel_request_handlers as krh
+from inference_optimizer.orchestrator.shared_state import SharedState
+from inference_optimizer.paths import make_session_dir
+
+
+@pytest.fixture
+def session_dir(tmp_path, monkeypatch) -> Path:
+    monkeypatch.setenv("USER_DATA_PATH", str(tmp_path))
+    return make_session_dir()
+
+
+def _seed_state(
+    session_dir: Path,
+    *,
+    baseline_tput: float = 0.0,
+    baseline_config_path: str = "",
+    current_best_args: str = "",
+) -> SharedState:
+    state = SharedState.load_or_init(session_dir)
+    state.baseline_tput = baseline_tput
+    state.baseline_config_path = baseline_config_path
+    if current_best_args:
+        state.current_best = {
+            "action": "kernel_opt",
+            "tput": 900.0,
+            "extra_sglang_args": current_best_args,
+        }
+    state.save(session_dir)
+    return state
+
+
+class TestFillIntegrateDefaultsFromState:
+    def test_all_three_defaults_fired(self, session_dir):
+        _seed_state(
+            session_dir,
+            baseline_tput=800.0,
+            baseline_config_path="/tmp/base.yaml",
+            current_best_args="--page-size 16",
+        )
+
+        out = krh._fill_integrate_defaults_from_state(
+            {"kernel_id": "k_abc"}, session_dir=session_dir,
+        )
+
+        assert out["base_tput"] == 800.0
+        assert out["config_path"] == "/tmp/base.yaml"
+        assert out["extra_sglang_args"] == "--page-size 16"
+        assert out["kernel_id"] == "k_abc"
+
+    def test_payload_base_tput_wins(self, session_dir):
+        _seed_state(session_dir, baseline_tput=800.0)
+
+        out = krh._fill_integrate_defaults_from_state(
+            {"kernel_id": "k_abc", "base_tput": 999.0},
+            session_dir=session_dir,
+        )
+
+        assert out["base_tput"] == 999.0
+
+    def test_payload_config_path_wins(self, session_dir):
+        _seed_state(
+            session_dir,
+            baseline_tput=800.0,
+            baseline_config_path="/tmp/state.yaml",
+        )
+
+        out = krh._fill_integrate_defaults_from_state(
+            {"kernel_id": "k_abc", "config_path": "/tmp/explicit.yaml"},
+            session_dir=session_dir,
+        )
+
+        assert out["config_path"] == "/tmp/explicit.yaml"
+
+    def test_payload_extra_args_wins(self, session_dir):
+        _seed_state(session_dir, current_best_args="--from-state")
+
+        out = krh._fill_integrate_defaults_from_state(
+            {"kernel_id": "k_abc", "extra_sglang_args": "--from-payload"},
+            session_dir=session_dir,
+        )
+
+        assert out["extra_sglang_args"] == "--from-payload"
+
+    def test_empty_state_no_op(self, session_dir):
+        _seed_state(session_dir)  # all defaults zero/empty
+
+        out = krh._fill_integrate_defaults_from_state(
+            {"kernel_id": "k_abc"}, session_dir=session_dir,
+        )
+
+        assert "base_tput" not in out or out["base_tput"] in (0.0, 0)
+        assert not out.get("config_path")
+        assert not out.get("extra_sglang_args")
+
+    def test_returns_shallow_copy_not_mutating_input(self, session_dir):
+        _seed_state(session_dir, baseline_tput=800.0)
+
+        payload = {"kernel_id": "k_abc"}
+        out = krh._fill_integrate_defaults_from_state(
+            payload, session_dir=session_dir,
+        )
+
+        assert "base_tput" not in payload
+        assert out["base_tput"] == 800.0
+
+    def test_zero_base_tput_in_payload_triggers_fallback(self, session_dir):
+        _seed_state(session_dir, baseline_tput=800.0)
+
+        out = krh._fill_integrate_defaults_from_state(
+            {"kernel_id": "k_abc", "base_tput": 0.0},
+            session_dir=session_dir,
+        )
+
+        assert out["base_tput"] == 800.0
+
+    def test_zero_state_does_not_overwrite_explicit_payload(self, session_dir):
+        _seed_state(session_dir, baseline_tput=0.0)
+
+        out = krh._fill_integrate_defaults_from_state(
+            {"kernel_id": "k_abc", "base_tput": 750.0},
+            session_dir=session_dir,
+        )
+
+        assert out["base_tput"] == 750.0
+
+
+class TestIntegrateHandlerHonoursStateDefault:
+    @pytest.mark.asyncio
+    async def test_missing_base_tput_in_payload_still_runs_when_state_has_one(
+        self, session_dir, monkeypatch,
+    ):
+        """Pre-existing hard-check must not fire when state has a baseline.
+
+        We don't run the full re-baseline pipeline — just confirm that
+        integrate_handler advances PAST the ``base_tput <= 0`` early-out
+        and reports a different failure mode (e.g. missing patch_path).
+        That's enough to lock the defaulting wiring.
+        """
+        _seed_state(session_dir, baseline_tput=800.0)
+
+        result = await krh.integrate_handler(
+            {"kernel_id": "k_no_artifact"}, session_dir=session_dir,
+        )
+
+        assert result["status"] == "failed"
+        assert result.get("error") != (
+            "integrate_handler requires base_tput > 0 to compute KEEP/REVERT"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_base_tput_anywhere_still_fails_with_clear_error(
+        self, session_dir,
+    ):
+        result = await krh.integrate_handler(
+            {"kernel_id": "k_orphan"}, session_dir=session_dir,
+        )
+
+        assert result["status"] == "failed"
+        assert "base_tput" in result["error"]


### PR DESCRIPTION
## Summary

- Add `_fill_integrate_defaults_from_state` helper in [inference_optimizer/orchestrator/kernel_request_handlers.py](inference_optimizer/orchestrator/kernel_request_handlers.py).
- Run it at the *top* of `integrate_handler` — **before** the hard `base_tput > 0` early-out — so a payload of just `{"kernel_id": ...}` can complete by pulling `base_tput`, `config_path`, and `extra_sglang_args` from SharedState.
- 10 new tests in [test_integrate_payload_defaults.py](inference_optimizer/tests/test_integrate_payload_defaults.py).

## Motivation

The existing `_resolve_integrate_payload` already defaults `patch_path` and `source_file` out of SharedState. That's two of the five inputs Orchestration tends to omit when it sends `{"kernel_id": ...}` after a successful `run_optimization`. The other three — `base_tput`, `config_path`, `extra_sglang_args` — are also already on disk:

- `state.baseline_tput`
- `state.baseline_config_path`
- `state.current_best["extra_sglang_args"]`

…but `integrate_handler` short-circuits with `integrate_handler requires base_tput > 0` *before* the existing resolver runs, so the KEEP-queue replay path has to re-plumb `base_tput` through every Orchestration call. This PR closes that gap by running the new helper first.

## Behavior

- Explicit payload values always win. Helper only fills when the field is missing or (for `base_tput`) zero.
- Helper returns a shallow copy of the input dict; never mutates the caller's payload.
- When neither payload nor state has a `base_tput` the existing hard-error still fires with the same wording, so the "missing input" failure mode is preserved.

## Tests

```
pytest inference_optimizer/tests/test_kernel_integrate_and_report.py \
       inference_optimizer/tests/test_integrate_payload_defaults.py \
       inference_optimizer/tests/test_profile_and_kernel_handlers.py -q
# 126 passed in 31.90s
```

New tests:
- 8 helper tests: all-three-fired / each-field-wins (3) / empty-state-no-op / shallow-copy / zero-base_tput triggers fallback / zero-state does not overwrite explicit payload.
- 2 `integrate_handler` wiring tests: missing `base_tput` in payload + present in state advances past the early-out; missing in both still fails with the unchanged error message.

## Test plan

- [x] All 116 existing tests in `test_kernel_integrate_and_report.py` + `test_profile_and_kernel_handlers.py` still pass alongside the 10 new tests.
- [x] No change to public payload contract; only adds defaulting for previously-required fields.
- [ ] Reviewer sanity-check: visually trace `integrate_handler` to confirm the helper runs once at the top and never inside the `_resolve_integrate_payload` early-return path.

Made with [Cursor](https://cursor.com)


Closes #319
