### PR TITLE
fix(kernel-opt): stop bloating prompts with full analysis.md; filter non-routable kernels from candidates

### DIFF
--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -95,11 +95,42 @@ def update_status(
 
 
 def load_candidates(path: Path) -> list[dict[str, Any]]:
-    """Load kernel candidates from JSON, normalizing legacy shapes."""
+    """Load kernel candidates from JSON, normalizing legacy shapes.
+
+    Per AMD-AGI/Hyperloom#314 the canonical ``hot_kernels`` field now only
+    carries kernels that ``classify_patchability`` marked routable, with the
+    rejected ones moved to ``skipped_kernels`` (full candidate dicts, not a
+    compact audit projection). Batch dispatchers (parallel_e2e_runner,
+    ``_batch_kernel_candidates``) read ``hot_kernels`` directly and benefit
+    from the filter. The kernel-opt CLI's direct lookup path
+    (``find_candidate(load_candidates(...), kid)``) still needs to be able
+    to resolve a non-routable kernel by id — both for operator debugging
+    ("what does the backend selector say about k001?") and so the
+    dispatcher's ``_validate_reusable_native_kernel`` guard fires with the
+    real ``reusable_native_kernel=False`` candidate instead of an empty
+    "missing native source" stub. Return the union so both call sites
+    work; the older flat-list / ``kernel_candidates`` legacy shapes are
+    still respected.
+    """
     payload = json.loads(path.read_text(encoding="utf-8"))
     if isinstance(payload, list):
         return payload
     candidates = list(payload.get("hot_kernels") or payload.get("kernel_candidates") or [])
+    skipped = payload.get("skipped_kernels") or []
+    if isinstance(skipped, list):
+        seen_ids = {
+            c.get("kernel_id") for c in candidates
+            if isinstance(c, dict) and c.get("kernel_id")
+        }
+        for entry in skipped:
+            if not isinstance(entry, dict):
+                continue
+            kid = entry.get("kernel_id")
+            if kid and kid in seen_ids:
+                continue
+            candidates.append(entry)
+            if kid:
+                seen_ids.add(kid)
     artifact_paths = payload.get("artifact_paths")
     if not isinstance(artifact_paths, dict):
         artifact_paths = {}

--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -1296,32 +1296,45 @@ def build_prompt(
             "still measure compute/IO improvements.\n"
         )
     tracelens_context_block = ""
-    report_path_str = str(candidate.get("trace_report_path") or "")
-    report_path = Path(report_path_str) if report_path_str else None
-    if report_path and report_path.exists():
-        try:
-            full_report = report_path.read_text(encoding="utf-8", errors="replace")
-        except Exception:
-            full_report = ""
-        if full_report:
-            from inference_optimizer.tracelens_md import strip_base64_data_urls
+    # Per AMD-AGI/Hyperloom#307: the per-kernel TraceLens prose
+    # (Identification / Reasoning / Recommended direction / Impact
+    # estimate) is already extracted into ``hypothesis_block`` above
+    # via ``_build_hypothesis_block``, and the bound-specific lever
+    # list is in ``priority_block``. Dumping the full analysis.md on
+    # top of that bloats the prompt by ~300 lines (~40% of the body
+    # in a real Qwen3-32B run) and surfaces other P-items that this
+    # very prompt tells the agent NOT to optimize. Only fall back to
+    # the full-report dump when no per-kernel hypothesis could be
+    # rendered (raw-trace / csv-fallback path with empty prose), so
+    # the agent still has *some* TraceLens grounding in that edge
+    # case.
+    if not hypothesis_block.strip():
+        report_path_str = str(candidate.get("trace_report_path") or "")
+        report_path = Path(report_path_str) if report_path_str else None
+        if report_path and report_path.exists():
+            try:
+                full_report = report_path.read_text(encoding="utf-8", errors="replace")
+            except Exception:
+                full_report = ""
+            if full_report:
+                from inference_optimizer.tracelens_md import strip_base64_data_urls
 
-            full_report = strip_base64_data_urls(full_report)
-            rank = candidate.get("tracelens_pitem_rank")
-            title = candidate.get("tracelens_pitem_title", "")
-            if rank:
-                focus_line = (
-                    f"Focus on **P{rank}: {title}** in the report below. "
-                    "Other P-items are context only — do not optimize them.\n"
+                full_report = strip_base64_data_urls(full_report)
+                rank = candidate.get("tracelens_pitem_rank")
+                title = candidate.get("tracelens_pitem_title", "")
+                if rank:
+                    focus_line = (
+                        f"Focus on **P{rank}: {title}** in the report below. "
+                        "Other P-items are context only — do not optimize them.\n"
+                    )
+                else:
+                    focus_line = "Use the report below as full context for this kernel.\n"
+                tracelens_context_block = (
+                    "\n## TraceLens Context\n\n"
+                    + focus_line
+                    + "\n"
+                    + full_report
                 )
-            else:
-                focus_line = "Use the report below as full context for this kernel.\n"
-            tracelens_context_block = (
-                "\n## TraceLens Context\n\n"
-                + focus_line
-                + "\n"
-                + full_report
-            )
     # Use GEAK task_parser field names (kernel_name/kernel_url/kernel_type/repo)
     # so its LLM-based parser can extract them; OOB agents read the same body
     # as a normal natural-language prompt.

--- a/kernel-agent/tools/test_tracelens_csv.py
+++ b/kernel-agent/tools/test_tracelens_csv.py
@@ -290,10 +290,19 @@ def test_write_reports_enriches_candidates_with_runtime_metadata(tmp_path):
         "duration_us": 100.0,
         "call_count": 2,
         "gpu_pct": 10.0,
-        "source_file": "/tmp/paged_attention.py",
+        "source_file": "/sgl-workspace/aiter/paged_attention.py",
         "shapes": [[1, 32, 128]],
         "is_multigpu": False,
         "num_gpus_recommended": 1,
+        # Per AMD-AGI/Hyperloom#314, ``kernel_candidates.json::hot_kernels``
+        # now only carries candidates that ``classify_patchability`` marked
+        # routable. In production this field is set by
+        # ``_finalize_candidates`` before ``write_reports`` runs; this
+        # unit test bypasses ``_finalize_candidates`` and passes a raw
+        # candidate straight into ``write_reports``, so set the routing
+        # marker explicitly to mirror the production fixture and keep
+        # the downstream assertions on ``hot_kernels[0]`` valid.
+        "reusable_native_kernel": True,
     }
     args = Namespace(
         trace_input=str(trace),
@@ -422,8 +431,10 @@ def test_write_reports_enriches_head_size_from_model_config(tmp_path):
         "duration_us": 100.0,
         "call_count": 2,
         "gpu_pct": 10.0,
-        "source_file": "/tmp/paged_attention.py",
+        "source_file": "/sgl-workspace/aiter/paged_attention.py",
         "shapes": [[1, 32, 128]],
+        # Per AMD-AGI/Hyperloom#314, see twin fixture above.
+        "reusable_native_kernel": True,
     }
     args = Namespace(
         trace_input=str(trace),

--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -1985,9 +1985,33 @@ def write_reports(
     }
     atomic_write_json(run_dir / "trace_input_manifest.json", manifest)
     atomic_write_json(tracelens_dir / "tracelens_report.json", report)
+    # Per AMD-AGI/Hyperloom#314: ``kernel_candidates.json::hot_kernels``
+    # is the dispatch payload consumed by the kernel-opt path
+    # (``kernel_optimization.load_candidates``, ``parallel_e2e_runner``,
+    # ``kernel_request_handlers``). Filter it down to candidates that
+    # ``classify_patchability`` actually marked routable so downstream
+    # batch dispatchers no longer have to re-apply the same filter and
+    # so ``num_hot_kernels`` accounting reflects what we will really
+    # send to a backend. The full unfiltered list stays available in
+    # ``tracelens/tracelens_report.json`` for audit, and the routable
+    # vs. skipped split is also surfaced in ``tracelens/summary.json``
+    # (``tasks[]`` / ``skipped[]``). ``skipped_kernels[]`` carries the
+    # FULL candidate dicts (not just an audit projection) so direct
+    # lookup paths (``kernel_optimization.load_candidates``, the CLI's
+    # ``find_candidate``) can still resolve a non-routable kernel by
+    # id; the dispatcher's ``_validate_reusable_native_kernel`` guard
+    # is what blocks them from reaching a backend.
+    routable_candidates = [
+        c for c in candidates
+        if isinstance(c, dict) and c.get("reusable_native_kernel") is True
+    ]
+    skipped_kernels = [
+        c for c in candidates
+        if isinstance(c, dict) and c.get("reusable_native_kernel") is not True
+    ]
     atomic_write_json(
         run_dir / "kernel_candidates.json",
-        {"hot_kernels": candidates, "task_groups": task_groups, **report},
+        {**report, "hot_kernels": routable_candidates, "skipped_kernels": skipped_kernels},
     )
 
     # PR-A §3: per-run audit sidecar listing which TraceLens hot kernels


### PR DESCRIPTION
## Summary

Fixes two kernel-opt data-plumbing bugs uncovered by a Qwen3-32B / sglang / MI300X run. Both share the same shape — the audit / source-of-truth list and the dispatch payload were being conflated — so they're worth addressing together.

- Closes #307 — full \`tracelens/analysis.md\` was unconditionally appended to every kernel-opt prompt (~300 lines, ~40% of the prompt body in the example Qwen3-32B run), even though the per-kernel TraceLens prose was already emitted at the top via \`_build_hypothesis_block\`. The dump also surfaced other P-items that the prompt itself flags as out of scope (\"Other P-items are context only — do not optimize them\").
- Closes #314 — \`kernel_candidates.json::hot_kernels\` was a byte-identical pass-through of the unfiltered TraceLens list. In the Qwen3-32B run 8 of 10 \`hot_kernels\` entries were \`aten::mm\` GEMMs with \`source_file=\"\"\` — already flagged \`reusable_native_kernel=false\` upstream — yet downstream consumers (\`shared_state\`, \`kernel_request_handlers\`, \`parallel_e2e_runner\`) each had to re-apply the filter themselves, and \`num_hot_kernels\` accounting overcounted by ~5x.

## Changes by commit

### \`fix(kernel-opt): stop appending full analysis.md to GEAK prompt (#307)\`

\`kernel-agent/tools/kernel_optimization.py\`: gate the \`tracelens_context_block\` fallback on \`not hypothesis_block.strip()\`, so the full report is only attached when no per-kernel hypothesis could be rendered (raw-trace / csv-fallback path). Production runs that have per-kernel TraceLens prose now skip the dump entirely.

### \`fix(kernel-opt): filter non-routable kernels from kernel_candidates.json (#314)\`

- \`kernel-agent/tools/tracelens_analysis.py::write_reports\`: filter \`kernel_candidates.json::hot_kernels\` to \`reusable_native_kernel is True\` and write a parallel \`skipped_kernels[]\` sidecar containing the FULL candidate dicts (not just a compact audit projection) for the rejected ones.
- \`kernel-agent/tools/kernel_optimization.py::load_candidates\`: read-side union over \`hot_kernels\` + \`skipped_kernels\` so the CLI's direct ID-lookup path (\`find_candidate(load_candidates(...), kid)\`) still resolves a non-routable kernel by id (operator debugging, and the dispatcher's \`_validate_reusable_native_kernel\` guard fires with the real \`reusable_native_kernel=False\` candidate instead of an empty \"missing native source\" stub). Batch dispatchers continue to read the \`hot_kernels\` field directly and see only routable kernels — the contract #314 was after.
- \`kernel-agent/tools/test_tracelens_csv.py\`: two unit-test fixtures that bypass \`_finalize_candidates\` and pass a raw candidate dict straight into \`write_reports\` now set \`reusable_native_kernel: True\` explicitly (mirroring what production \`_finalize_candidates\` would do) and use a source path under a reusable framework root, so the post-write \`payload[\"hot_kernels\"][0]\` assertions stay valid under the new contract.

## Audit surface (what stays where)

| Artifact | Before | After |
|---|---|---|
| \`tracelens/tracelens_report.json::hot_kernels\` | full unfiltered list | full unfiltered list (unchanged — TraceLens-team contract) |
| \`kernel_candidates.json::hot_kernels\` | full unfiltered list | **routable only** (new dispatch contract) |
| \`kernel_candidates.json::skipped_kernels\` | (did not exist) | non-routable candidates with skip_reason (full dicts) |
| \`tracelens/summary.json::tasks[]\`/\`skipped[]\` | already split correctly | unchanged |
| \`load_candidates(path)\` | unfiltered | union of routable + skipped (back-compat for CLI direct lookup) |

## Test plan

Verified end-to-end on a Qwen3-32B-shaped fixture (10 candidates: 8 GEMM \`aten::mm\` with empty source_file + 2 routable \`aiter::rmsnorm\` at \`/sgl-workspace/aiter/aiter/ops/rmsnorm.py\`).

**#307**
- [x] Production case (TraceLens prose attached): prompt is **175 lines**, no \`## TraceLens Context\` section.
- [x] Fallback case (no prose, e.g. raw-trace / csv-fallback): prompt is **465 lines**, full report attached.
- [x] ~290 lines of bloat eliminated per kernel in the common case.

**#314**
- [x] \`kernel_candidates.json::hot_kernels\` = 2 (k009, k010 — routable rmsnorm)
- [x] \`kernel_candidates.json::skipped_kernels\` = 8 (k001–k008 — full dicts with \`skip_reason: \"source file not resolved\"\`)
- [x] \`tracelens_report.json::hot_kernels\` = 10 (full audit list — unchanged)
- [x] \`load_candidates(...)\` returns 10 entries (union, back-compat for CLI lookup)
- [x] \`find_candidate(..., \"k001\")\` succeeds and returns a candidate with \`reusable_native_kernel=False\` (dispatcher's \`_validate_reusable_native_kernel\` correctly rejects it with \`non_reusable_kernel\` error class)

**Unit tests**
- [x] \`kernel-agent/tools/test_tracelens_csv.py\` — all 132 tests pass (6 \`test_write_reports_*\` cases verified against the new contract).
- [x] \`kernel-agent/tools/test_kernel_optimization_verification.py\` — 54/55 pass; the one failure is the pre-existing \`test_build_prompt_includes_benchmark_cases_when_task_group_present\` env issue unrelated to this PR.
- [x] \`kernel-agent/tools/test_prompt_promotion_block.py\` — all 6 pass.
- [x] \`kernel-agent/tests/test_kernel_agent.py\` — 20/23 pass (the 3 failures — \`test_install_help_and_dry_run_backend_flags\`, \`test_geak_submit_build_cmd_omits_when_none\`, \`test_geak_submit_build_cmd_propagates_zero\` — all fail with the same pre-existing \`GEAK_CONFIG is required\` env error on clean \`main\` too; unrelated to this PR).

No new test regressions are introduced. The two unit-test fixture updates are minimal and explained inline; they mirror what \`_finalize_candidates\` does in the production candidate-enrichment path.

## Backward compatibility

- \`tracelens/tracelens_report.json\` is byte-for-byte unchanged (TraceLens-team interface preserved).
- \`tracelens/summary.json\` is unchanged (the audit \`tasks[]\`/\`skipped[]\` split was already correct upstream).
- Older \`kernel_candidates.json\` files written before this change (with the full unfiltered \`hot_kernels\`) continue to work — \`load_candidates\` and \`_load_candidate_metadata\` already handle the absence of \`skipped_kernels\` gracefully (\`payload.get(\"skipped_kernels\") or []\`).

Made with [Cursor](https://cursor.com)