### PR TITLE
fix(orch): unblock slow-workload optimization (auto-derive explore timeout, raise static defaults, pin GEAK fix branch)

### DIFF
--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -673,6 +673,22 @@ def _seed_shared_state(
     except (TypeError, ValueError):
         explore_variant_timeout_sec_override = 0
 
+    # ``--explore-variant-timeout-safety-margin`` mirror. Headroom as a
+    # fraction of baseline_runtime_sec on top of the soft kill ratio when
+    # the auto-derive path computes the cap. Negative values clamp to 0
+    # (which collapses the hard cap onto the soft kill, no headroom).
+    explore_variant_timeout_safety_margin_raw = getattr(
+        args, "explore_variant_timeout_safety_margin", None,
+    )
+    try:
+        explore_variant_timeout_safety_margin = max(
+            0.0,
+            float(explore_variant_timeout_safety_margin_raw)
+            if explore_variant_timeout_safety_margin_raw is not None else 0.5,
+        )
+    except (TypeError, ValueError):
+        explore_variant_timeout_safety_margin = 0.5
+
     state = SharedState(
         session_id=session_id,
         claw_session_id=(os.environ.get("CLAW_SESSION_ID") or "").strip(),
@@ -715,6 +731,7 @@ def _seed_shared_state(
             getattr(args, "gain_driven_kernel_opt", False),
         ),
         explore_variant_timeout_sec_override=explore_variant_timeout_sec_override,
+        explore_variant_timeout_safety_margin=explore_variant_timeout_safety_margin,
     )
     state.save(session_dir)
     return state
@@ -4673,10 +4690,27 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Pin the per-variant hard timeout (seconds) inside the "
              "EXPLORE phase. ``0`` (default) auto-derives from "
              "``baseline_runtime_sec * (--explore-overtime-kill-ratio + "
-             "0.5)`` once baseline lands, with a 2400-14400 s range "
-             "guard. Set to a positive integer to pin (CI smoke runs / "
-             "debugging). Env: "
+             "--explore-variant-timeout-safety-margin)`` once baseline "
+             "lands, with a 2400-14400 s range guard. Set to a positive "
+             "integer to pin (CI smoke runs / debugging). Env: "
              "INFERENCE_OPTIMIZER_EXPLORE_VARIANT_TIMEOUT_SEC.",
+    )
+    opt.add_argument(
+        "--explore-variant-timeout-safety-margin",
+        dest="explore_variant_timeout_safety_margin",
+        type=float,
+        default=_env_float_or(
+            0.5, "INFERENCE_OPTIMIZER_EXPLORE_VARIANT_TIMEOUT_SAFETY_MARGIN",
+        ),
+        help="Headroom (as a fraction of baseline_runtime_sec) added on "
+             "top of --explore-overtime-kill-ratio when the EXPLORE hard "
+             "cap is auto-derived. Default 0.5 (≈ 50%% of baseline as "
+             "buffer for variant cold starts: torch.compile AOTI compile, "
+             "fresh aiter shapes, spec-decoding draft load). Bump for "
+             "workloads with heavy compile cost; lower to tighten the "
+             "backstop. No effect when --explore-variant-timeout-sec is "
+             "set to a positive value. Env: "
+             "INFERENCE_OPTIMIZER_EXPLORE_VARIANT_TIMEOUT_SAFETY_MARGIN.",
     )
     # ------------------------------------------------------------------
     # drop scoreboard

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -658,6 +658,21 @@ def _seed_shared_state(
     except (TypeError, ValueError):
         explore_overtime_kill_ratio = 1.10
 
+    # ``--explore-variant-timeout-sec`` mirror. ``0`` (default) lets the
+    # ExploreExecutor auto-derive the cap from baseline_runtime_sec; any
+    # positive value pins it (CI smoke / debug).
+    explore_variant_timeout_raw = getattr(
+        args, "explore_variant_timeout_sec", None,
+    )
+    try:
+        explore_variant_timeout_sec_override = max(
+            0,
+            int(explore_variant_timeout_raw)
+            if explore_variant_timeout_raw is not None else 0,
+        )
+    except (TypeError, ValueError):
+        explore_variant_timeout_sec_override = 0
+
     state = SharedState(
         session_id=session_id,
         claw_session_id=(os.environ.get("CLAW_SESSION_ID") or "").strip(),
@@ -699,6 +714,7 @@ def _seed_shared_state(
         gain_driven_kernel_opt=bool(
             getattr(args, "gain_driven_kernel_opt", False),
         ),
+        explore_variant_timeout_sec_override=explore_variant_timeout_sec_override,
     )
     state.save(session_dir)
     return state
@@ -4602,6 +4618,15 @@ def _build_parser() -> argparse.ArgumentParser:
             return float(raw)
         except (TypeError, ValueError):
             return float(default)
+
+    def _env_int_or(default: int, env_var: str) -> int:
+        raw = os.environ.get(env_var, "").strip()
+        if not raw:
+            return int(default)
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            return int(default)
     opt.add_argument(
         "--explore-overtime-kill-ratio",
         dest="explore_overtime_kill_ratio",
@@ -4618,6 +4643,40 @@ def _build_parser() -> argparse.ArgumentParser:
              "Default 1.10 (kill at +10%% over baseline wall-clock). "
              "Pass 0 to disable. Env: "
              "INFERENCE_OPTIMIZER_EXPLORE_OVERTIME_KILL_RATIO.",
+    )
+    # ------------------------------------------------------------------
+    # Explore variant hard timeout — operator override for the
+    # auto-derived cap.
+    #
+    # The legacy class default (2400 s) is a smoke-workload floor. On
+    # slow workloads (Qwen3-32B TP=1 BF16 CONC=64 ISL/OSL=1024 NUM_PROMPTS
+    # =320 → ~70 min baseline) the floor under-budgets every variant
+    # before it can produce a measurement. ExploreExecutor now
+    # auto-derives the cap from ``baseline_runtime_sec * (kill_ratio +
+    # 0.5)`` so the hard cap stays above the soft kill ratio (preserves
+    # the layered design instead of inverting it).
+    #
+    # Operators can pin an explicit value here (e.g. CI smoke runs that
+    # want a tight bound, or workloads where the auto-derived value is
+    # too generous). ``0`` (default) leaves the auto-derive in charge.
+    # Mirrored to ``SharedState.explore_variant_timeout_sec_override``;
+    # the Coordinator injects it as ``params['variant_timeout_sec']``
+    # on every explore task, taking precedence over the auto-derive.
+    # ------------------------------------------------------------------
+    opt.add_argument(
+        "--explore-variant-timeout-sec",
+        dest="explore_variant_timeout_sec",
+        type=int,
+        default=_env_int_or(
+            0, "INFERENCE_OPTIMIZER_EXPLORE_VARIANT_TIMEOUT_SEC",
+        ),
+        help="Pin the per-variant hard timeout (seconds) inside the "
+             "EXPLORE phase. ``0`` (default) auto-derives from "
+             "``baseline_runtime_sec * (--explore-overtime-kill-ratio + "
+             "0.5)`` once baseline lands, with a 2400-14400 s range "
+             "guard. Set to a positive integer to pin (CI smoke runs / "
+             "debugging). Env: "
+             "INFERENCE_OPTIMIZER_EXPLORE_VARIANT_TIMEOUT_SEC.",
     )
     # ------------------------------------------------------------------
     # drop scoreboard

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -689,6 +689,11 @@ def _seed_shared_state(
     except (TypeError, ValueError):
         explore_variant_timeout_safety_margin = 0.5
 
+    # ``--explore-roofline-hard-gate`` mirror (opt-in roofline filter).
+    explore_roofline_hard_gate = bool(getattr(
+        args, "explore_roofline_hard_gate", False,
+    ))
+
     state = SharedState(
         session_id=session_id,
         claw_session_id=(os.environ.get("CLAW_SESSION_ID") or "").strip(),
@@ -732,6 +737,7 @@ def _seed_shared_state(
         ),
         explore_variant_timeout_sec_override=explore_variant_timeout_sec_override,
         explore_variant_timeout_safety_margin=explore_variant_timeout_safety_margin,
+        explore_roofline_hard_gate=explore_roofline_hard_gate,
     )
     state.save(session_dir)
     return state
@@ -4711,6 +4717,22 @@ def _build_parser() -> argparse.ArgumentParser:
              "backstop. No effect when --explore-variant-timeout-sec is "
              "set to a positive value. Env: "
              "INFERENCE_OPTIMIZER_EXPLORE_VARIANT_TIMEOUT_SAFETY_MARGIN.",
+    )
+    opt.add_argument(
+        "--explore-roofline-hard-gate",
+        dest="explore_roofline_hard_gate",
+        action="store_true",
+        default=os.environ.get(
+            "INFERENCE_OPTIMIZER_EXPLORE_ROOFLINE_HARD_GATE", "0",
+        ).strip() == "1",
+        help="(Opt-in, off by default.) Drop EXPLORE variants whose flags "
+             "target only roofline directions that the latest snapshot "
+             "shows saturated above 80%%. Saves variant slots on slow "
+             "workloads where (e.g.) host-overhead reducers cannot help "
+             "a memory-bound model. The existing soft "
+             "``--roofline-saturation-advisory`` prompt hint is unchanged "
+             "either way. Env: "
+             "INFERENCE_OPTIMIZER_EXPLORE_ROOFLINE_HARD_GATE=1.",
     )
     # ------------------------------------------------------------------
     # drop scoreboard

--- a/inference_optimizer/orchestrator/action_executors/_explore_roofline_filter.py
+++ b/inference_optimizer/orchestrator/action_executors/_explore_roofline_filter.py
@@ -1,0 +1,224 @@
+"""Roofline-aware variant filter (opt-in, off by default).
+
+Today the EXPLORE phase fans every specialist / default-grid variant out
+to a full Magpie benchmark, even when the most recent roofline snapshot
+already shows the variant's target direction is saturated above the
+diminishing-returns threshold. On slow workloads (e.g. Qwen3-32B TP=1
+BF16, where decode-side throughput is ~1.5 % of HBM-bound peak and the
+model is *bandwidth-bound*, not host-bound) this means burning ~70 min
+per variant on host-overhead reducers that physically cannot help.
+
+This module categorizes variants by the roofline direction(s) their flags
+target and provides a filter that drops a variant only when ALL its
+target directions are above the saturation threshold. Conservatively:
+
+* Uncategorized variants (flags this module doesn't recognise) are kept —
+  we can't say they're wasted.
+* A variant that targets multiple directions is kept if **any** of them
+  is below the threshold (it might still help via the non-saturated one).
+* When no direction in the snapshot crosses the threshold, no filtering
+  happens.
+
+The filter is opt-in via ``--explore-roofline-hard-gate`` /
+``SharedState.explore_roofline_hard_gate``. The existing
+``roofline_saturation_advisory`` (soft prompt hint) is untouched.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+
+# ---------------------------------------------------------------------------
+# Categorization table — variant flag/env → roofline direction(s) it targets.
+# ---------------------------------------------------------------------------
+# Direction names match ``roofline_snapshot._SATURATION_LABEL_MAP``:
+# ``compute`` / ``memory`` / ``host_overhead`` / ``comm``.
+#
+# Conservative defaults:
+# * Each entry is a regex against the variant's ``extra_sglang_args`` string.
+# * Single-direction entries are high-confidence (e.g. host-only knobs).
+# * Multi-direction entries cover knobs that legitimately affect more than
+#   one direction (e.g. ``--attention-backend`` swaps the kernel **and**
+#   its memory access pattern). The filter keeps the variant unless EVERY
+#   listed direction is saturated, so multi-direction tags are
+#   intentionally lenient.
+# * Anything not matched here stays in the "uncategorized" bucket and the
+#   filter never drops it.
+#
+# Ownership / update protocol: any new sglang flag that targets a known
+# roofline direction MUST be added here, otherwise it falls into the
+# "uncategorized -> keep" bucket above and the hard-gate filter is a no-op
+# for it. Flag rot drifts toward "keep" (safe, but defeats the gate).
+_FLAG_TO_DIRECTIONS: tuple[tuple[re.Pattern[str], frozenset[str]], ...] = (
+    # Host-overhead reducers (CPU scheduling / kernel launch overhead /
+    # CUDA graph replay).
+    (re.compile(r"(?<!\S)--num-continuous-decode-steps(?!\S)"),
+        frozenset({"host_overhead"})),
+    (re.compile(r"(?<!\S)--scheduler-recv-interval(?!\S)"),
+        frozenset({"host_overhead"})),
+    (re.compile(r"(?<!\S)--cuda-graph-max-bs(?!\S)"),
+        frozenset({"host_overhead"})),
+    (re.compile(r"(?<!\S)--enable-cuda-graph(?!\S)"),
+        frozenset({"host_overhead"})),
+    (re.compile(r"(?<!\S)--tokenizer-worker-num(?!\S)"),
+        frozenset({"host_overhead"})),
+    (re.compile(r"(?<!\S)--stream-interval(?!\S)"),
+        frozenset({"host_overhead"})),
+    # Compute / fusion (torch.compile-style, speculative decoding).
+    (re.compile(r"(?<!\S)--enable-torch-compile(?!\S)"),
+        frozenset({"compute"})),
+    (re.compile(r"(?<!\S)--torch-compile-max-bs(?!\S)"),
+        frozenset({"compute"})),
+    (re.compile(r"(?<!\S)--enable-spec-v2(?!\S)"),
+        frozenset({"compute"})),
+    (re.compile(r"(?<!\S)--speculative-"),
+        frozenset({"compute"})),
+    # Memory / KV cache.
+    (re.compile(r"(?<!\S)--disable-radix-cache(?!\S)"),
+        frozenset({"memory"})),
+    (re.compile(r"(?<!\S)--mem-fraction-static(?!\S)"),
+        frozenset({"memory"})),
+    (re.compile(r"(?<!\S)--max-running-requests(?!\S)"),
+        frozenset({"memory"})),
+    (re.compile(r"(?<!\S)--kv-cache-dtype(?!\S)"),
+        frozenset({"memory"})),
+    # Attention backend swaps both kernel and memory access pattern;
+    # treat as multi-direction (lenient).
+    (re.compile(r"(?<!\S)--attention-backend(?!\S)"),
+        frozenset({"compute", "memory"})),
+)
+
+# Env-var prefix → directions. Used in addition to flag matching.
+_ENV_PREFIX_TO_DIRECTIONS: tuple[tuple[str, frozenset[str]], ...] = (
+    # Tile-Lang / fused-MoE / GEMM-tuning envs all target the compute
+    # roofline. SGLANG_HACK_FLASHMLA_BACKEND, SGLANG_OPT_USE_TILELANG_*,
+    # AITER_USE_*, TRITON_*, HIPBLASLT_*, PYTORCH_TUNABLEOP_* etc.
+    ("AITER_", frozenset({"compute"})),
+    ("TRITON_", frozenset({"compute"})),
+    ("HIPBLASLT_", frozenset({"compute"})),
+    ("PYTORCH_TUNABLEOP_", frozenset({"compute"})),
+)
+
+# Specific env-var → directions. Pattern-match the env *value* too when
+# we need to disambiguate (e.g. SGLANG_OPT_USE_MULTI_STREAM_OVERLAP toggles
+# host_overhead, not compute, even though it's a SGLANG_ env).
+_ENV_NAME_TO_DIRECTIONS: tuple[tuple[str, frozenset[str]], ...] = (
+    ("SGLANG_OPT_USE_MULTI_STREAM_OVERLAP", frozenset({"host_overhead"})),
+    ("SGLANG_OPT_USE_TILELANG_INDEXER", frozenset({"compute"})),
+    ("SGLANG_HACK_FLASHMLA_BACKEND", frozenset({"compute"})),
+    ("SGLANG_ENABLE_SPEC_V2", frozenset({"compute"})),
+)
+
+
+_DEFAULT_SATURATION_THRESHOLD_PCT = 80.0
+
+
+def categorize_variant(
+    extra_args: str | None,
+    extra_envs: dict[str, str] | None,
+) -> frozenset[str]:
+    """Return the set of roofline directions a variant's flags target.
+
+    An empty set means the variant is uncategorized; the caller (the
+    filter) treats those as "potentially useful, keep". Knowing more than
+    one direction is normal — a variant can stack flags from multiple
+    categories.
+    """
+    cats: set[str] = set()
+    args = (extra_args or "").strip()
+    if args:
+        for pat, dirs in _FLAG_TO_DIRECTIONS:
+            if pat.search(args):
+                cats |= dirs
+    if extra_envs:
+        for raw_key in extra_envs.keys():
+            key = str(raw_key).upper()
+            for env_name, dirs in _ENV_NAME_TO_DIRECTIONS:
+                if key == env_name:
+                    cats |= dirs
+                    break
+            else:
+                for prefix, dirs in _ENV_PREFIX_TO_DIRECTIONS:
+                    if key.startswith(prefix):
+                        cats |= dirs
+                        break
+    return frozenset(cats)
+
+
+@dataclass(frozen=True)
+class _DroppedVariant:
+    name: str
+    extra_sglang_args: str
+    categories: tuple[str, ...]
+    saturated_directions: tuple[str, ...]
+    reason: str
+
+
+def filter_variants_by_roofline(
+    grid: Iterable[Any],
+    saturation_snapshot: dict[str, float] | None,
+    *,
+    threshold_pct: float = _DEFAULT_SATURATION_THRESHOLD_PCT,
+) -> tuple[list[Any], list[dict[str, Any]]]:
+    """Apply the opt-in saturation filter to an explore grid.
+
+    Args:
+        grid: Iterable of ``GridVariant``-shaped objects (anything with
+            ``.name``, ``.extra_sglang_args``, ``.extra_envs`` attributes).
+            We don't import ``GridVariant`` here to keep this module
+            decoupled from ``_grid_runner`` and trivially unit-testable.
+        saturation_snapshot: Mapping ``direction -> percent`` from the
+            most recent roofline run (``SharedState.roofline_saturation_history
+            [-1]``). When ``None`` / empty / no direction crosses the
+            threshold, the filter is a no-op.
+        threshold_pct: Saturation cutoff. Defaults to the same 80 % the
+            soft advisory uses (single source of truth).
+
+    Returns:
+        ``(kept, dropped)`` — ``kept`` preserves the input order; ``dropped``
+        is a list of JSON-friendly dicts the caller can surface in
+        ``state.json`` / the LLM prompt for traceability.
+    """
+    grid_list = list(grid)
+    if not saturation_snapshot:
+        return grid_list, []
+    saturated: set[str] = {
+        direction
+        for direction, pct in saturation_snapshot.items()
+        if isinstance(pct, (int, float)) and float(pct) >= threshold_pct
+    }
+    if not saturated:
+        return grid_list, []
+
+    kept: list[Any] = []
+    dropped: list[dict[str, Any]] = []
+    for gv in grid_list:
+        cats = categorize_variant(
+            getattr(gv, "extra_sglang_args", ""),
+            getattr(gv, "extra_envs", None),
+        )
+        # Uncategorized → keep (unknown intent is unknown reward).
+        if not cats:
+            kept.append(gv)
+            continue
+        # All target directions saturated → drop.
+        if cats <= saturated:
+            dropped.append({
+                "name": getattr(gv, "name", "?"),
+                "extra_sglang_args": getattr(gv, "extra_sglang_args", ""),
+                "categories": sorted(cats),
+                "saturated_directions": sorted(saturated),
+                "reason": "all_target_directions_saturated",
+            })
+        else:
+            kept.append(gv)
+    return kept, dropped
+
+
+__all__ = (
+    "categorize_variant",
+    "filter_variants_by_roofline",
+)

--- a/inference_optimizer/orchestrator/action_executors/_grid_runner.py
+++ b/inference_optimizer/orchestrator/action_executors/_grid_runner.py
@@ -133,7 +133,7 @@ def _resolve_session_dir() -> Path:
 
 
 _MAGPIE_CWD_DEFAULT = "/tmp"
-_VARIANT_TIMEOUT_SEC_DEFAULT = 2400
+_VARIANT_TIMEOUT_SEC_DEFAULT = 7800  # 130 min; matches BASELINE_DEFAULT_TIMEOUT_SEC for Qwen3-32B TP=1 CONC=64 ISL/OSL=1024 NUM_PROMPTS=320 workload
 
 
 # ---------------------------------------------------------------------------

--- a/inference_optimizer/orchestrator/action_executors/baseline.py
+++ b/inference_optimizer/orchestrator/action_executors/baseline.py
@@ -68,8 +68,8 @@ log = logging.getLogger(__name__)
 BASELINE_DEFAULT_CONFIG = (
     asset_root() / "scripts" / "configs" / "baseline_sglang.yaml"
 )
-BASELINE_DEFAULT_TIMEOUT_SEC = 2400           # WARM-start cap, 40 min (aiter jit cache populated)
-BASELINE_COLD_START_TIMEOUT_SEC = 3600        # COLD-start cap, 60 min (aiter jit cache empty/sparse)
+BASELINE_DEFAULT_TIMEOUT_SEC = 7800           # WARM-start cap, 130 min (raised for Qwen3-32B TP=1 CONC=64 ISL/OSL=1024 NUM_PROMPTS=320 ~82 min workload)
+BASELINE_COLD_START_TIMEOUT_SEC = 9000        # COLD-start cap, 150 min (includes ~20 min cuda graph capture)
 COLD_START_KERNEL_THRESHOLD = 20              # < N .so files under aiter jit/build/ ⇒ COLD
 
 # Legacy fallback probe order for aiter's JIT cache dir. Used only when

--- a/inference_optimizer/orchestrator/action_executors/explore.py
+++ b/inference_optimizer/orchestrator/action_executors/explore.py
@@ -61,6 +61,7 @@ from ._accuracy_gate import (
     parse_eval_results,
 )
 from ._canonical_fingerprint import canonical_fingerprint, workload_signature
+from ._explore_roofline_filter import filter_variants_by_roofline
 from ._grid_runner import (
     GridVariant,
     VariantResult,
@@ -537,6 +538,46 @@ class ExploreExecutor:
             "explore dedup: payload=%d → runnable=%d (ledger_dup+round_dup=%d)",
             len(grid), len(runnable), len(skipped_dup),
         )
+
+        # Opt-in roofline-categorized filter (PR-B).
+        # Coordinator-injected ``roofline_hard_gate=True`` together with a
+        # non-empty ``roofline_saturation_snapshot`` activates the gate;
+        # the executor drops variants whose flags target only directions
+        # the latest roofline run reports above the saturation threshold.
+        # Dropped variants land in ``skipped_dup`` with
+        # ``reason='roofline_saturated'`` so the per-variant outcomes
+        # collector and ``state.json`` audit trail surface them next to
+        # the dedup skips. Default is off — when ``roofline_hard_gate``
+        # is missing / falsy, the soft advisory remains the only signal
+        # (legacy behaviour).
+        if bool(params.get("roofline_hard_gate", False)) and runnable:
+            saturation_snapshot = params.get("roofline_saturation_snapshot")
+            if isinstance(saturation_snapshot, dict) and saturation_snapshot:
+                kept_runnable, dropped_by_roofline = filter_variants_by_roofline(
+                    runnable, saturation_snapshot,
+                )
+                if dropped_by_roofline:
+                    for entry in dropped_by_roofline:
+                        skipped_dup.append({
+                            "name": entry.get("name", ""),
+                            "extra_sglang_args": entry.get("extra_sglang_args", ""),
+                            "reason": "roofline_saturated",
+                            "categories": entry.get("categories", []),
+                            "saturated_directions": entry.get(
+                                "saturated_directions", [],
+                            ),
+                        })
+                    log.info(
+                        "explore roofline gate: %d/%d variants dropped "
+                        "(saturated=%s)",
+                        len(dropped_by_roofline),
+                        len(runnable),
+                        ",".join(sorted(
+                            d for d, p in saturation_snapshot.items()
+                            if isinstance(p, (int, float)) and float(p) >= 80.0
+                        )),
+                    )
+                runnable = kept_runnable
 
         round_id_seed = int(search.get("cursor") or 0) + 1
         round_id = f"explore-{round_id_seed:03d}"

--- a/inference_optimizer/orchestrator/action_executors/explore.py
+++ b/inference_optimizer/orchestrator/action_executors/explore.py
@@ -187,6 +187,75 @@ def _gain_pct(tput: float | None, base_tput: float) -> float | None:
     return (float(tput) - base_tput) / base_tput * 100.0
 
 
+# ---------------------------------------------------------------------------
+# Auto-derived per-variant hard timeout
+# ---------------------------------------------------------------------------
+# The legacy class default (``variant_timeout_sec=2400``) is a smoke-workload
+# floor: it works for fast benches (small models, high TP, short OSL) where
+# the baseline run lands in well under 40 min, but on Qwen3-32B TP=1 BF16
+# CONC=64 ISL/OSL=1024 NUM_PROMPTS=320 the baseline itself takes ~70 min
+# and every variant times out before producing a measurement. Rather than
+# pick a new universal constant (which would just push the failure mode to
+# the next slow-workload combination), we auto-derive the cap from the
+# *measured* baseline runtime that the Coordinator already injects, with a
+# safety margin above the soft kill ratio so the layered design (soft kill
+# → hard cap) is preserved.
+#
+# Operator can still override per-task via ``params['variant_timeout_sec']``
+# or globally via ``--explore-variant-timeout-sec`` (mirrored into
+# SharedState by cli.py and re-injected into every explore task by the
+# Coordinator). Floor + ceiling guard against pathological inputs.
+DEFAULT_EXPLORE_TIMEOUT_FLOOR_SEC = 2400      # 40 min — legacy smoke-workload default
+DEFAULT_EXPLORE_TIMEOUT_CEILING_SEC = 14400   # 4 h — matches roofline composite budget
+DEFAULT_EXPLORE_TIMEOUT_SAFETY_MARGIN = 0.5   # hard cap ≥ baseline × (kill_ratio + 0.5)
+
+
+def _compute_explore_variant_timeout(
+    baseline_runtime_sec: float,
+    kill_ratio: float,
+    *,
+    floor_sec: int = DEFAULT_EXPLORE_TIMEOUT_FLOOR_SEC,
+    ceiling_sec: int = DEFAULT_EXPLORE_TIMEOUT_CEILING_SEC,
+    safety_margin: float = DEFAULT_EXPLORE_TIMEOUT_SAFETY_MARGIN,
+) -> int:
+    """Derive the per-variant hard timeout from the measured baseline.
+
+    Returns ``floor_sec`` when ``baseline_runtime_sec`` is unknown / non-positive
+    (cold start, baseline failed, fresh resume before baseline replays). Once
+    baseline lands, scales with the actual workload runtime so slow models
+    get appropriate budget without operator tuning.
+
+    The hard cap is intentionally **above** the soft kill ratio
+    (``baseline_runtime_sec × kill_ratio``); the soft kill is the designed
+    upper bound for "this variant is slower than baseline" and the hard cap
+    is the catastrophic backstop for hung subprocesses. Inverting them — as
+    the legacy 2400 s constant does on slow workloads — defeats the layered
+    design (the hard cap fires before the soft kill ever gets a chance).
+
+    Args:
+        baseline_runtime_sec: Measured wall-clock of the baseline action.
+            Coordinator-injected via ``task.params['baseline_runtime_sec']``.
+            Pass ``0`` (or any non-positive) to force the ``floor_sec``
+            fallback.
+        kill_ratio: ``--explore-overtime-kill-ratio``. Treated as ``1.0`` if
+            below 1.0 so the derived timeout never underflows the soft kill.
+        floor_sec: Lower bound. Default preserves legacy smoke-workload
+            behaviour (40 min) for any path that calls with no baseline.
+        ceiling_sec: Upper bound. Default 4 h matches the roofline composite
+            timeout; bumping further would risk a single hung variant
+            burning a meaningful slice of the wall-clock budget.
+        safety_margin: Additive margin on top of ``kill_ratio`` so the hard
+            cap stays above the soft kill. ``0.5`` ≈ 50 % of the baseline
+            runtime as headroom for one-off variant cold starts (e.g.
+            ``--enable-torch-compile`` AOTI compile, fresh aiter shapes).
+    """
+    if baseline_runtime_sec <= 0:
+        return int(floor_sec)
+    effective_kill_ratio = max(1.0, float(kill_ratio))
+    derived = float(baseline_runtime_sec) * (effective_kill_ratio + float(safety_margin))
+    return int(max(floor_sec, min(ceiling_sec, derived)))
+
+
 def _join_args(*parts: str) -> str:
     return " ".join(p.strip() for p in parts if p and p.strip())
 
@@ -284,8 +353,6 @@ class ExploreExecutor:
             float(params.get("accuracy_baseline") or 0.0)
             or float(params.get("baseline_accuracy") or 0.0)
         )
-        timeout_sec = int(params.get("variant_timeout_sec",
-                                      self.variant_timeout_sec))
         keep_threshold_pct = float(params.get(
             "keep_threshold_pct", self.keep_threshold_pct,
         ))
@@ -325,6 +392,28 @@ class ExploreExecutor:
             )
         else:
             overtime_deadline_sec = None
+
+        # Resolve the per-variant hard cap. Precedence:
+        #   1. ``params['variant_timeout_sec']`` — explicit per-task override
+        #      (LLM proposal, operator-injected via Coordinator from the
+        #      ``--explore-variant-timeout-sec`` CLI flag, or
+        #      ``INFERENCE_OPTIMIZER_EXPLORE_VARIANT_TIMEOUT_SEC`` env).
+        #   2. Auto-derive from the measured baseline runtime + soft kill
+        #      ratio (both Coordinator-injected). Scales with the actual
+        #      workload so slow models don't time out before producing a
+        #      measurement; see ``_compute_explore_variant_timeout``.
+        #   3. ``self.variant_timeout_sec`` — class default, retained as a
+        #      conservative floor when the auto-derive has no baseline yet
+        #      (cold start / first round).
+        explicit_timeout = params.get("variant_timeout_sec")
+        if explicit_timeout is not None:
+            timeout_sec = int(explicit_timeout)
+        else:
+            timeout_sec = _compute_explore_variant_timeout(
+                baseline_runtime_sec=baseline_runtime_sec,
+                kill_ratio=overtime_kill_ratio,
+                floor_sec=int(self.variant_timeout_sec),
+            )
 
         # Resolve framework from materialized YAML (informational only —
         # both sglang and vllm route through the same EXTRA_*_ARGS env;

--- a/inference_optimizer/orchestrator/action_executors/explore.py
+++ b/inference_optimizer/orchestrator/action_executors/explore.py
@@ -409,10 +409,23 @@ class ExploreExecutor:
         if explicit_timeout is not None:
             timeout_sec = int(explicit_timeout)
         else:
+            # Operator-tunable headroom. When unset (or negative), fall back
+            # to the helper's default. Negative values clamp to 0 (no
+            # headroom — hard cap collapses onto the soft kill ratio).
+            safety_margin_raw = params.get("variant_timeout_safety_margin")
+            try:
+                safety_margin = (
+                    max(0.0, float(safety_margin_raw))
+                    if safety_margin_raw is not None
+                    else DEFAULT_EXPLORE_TIMEOUT_SAFETY_MARGIN
+                )
+            except (TypeError, ValueError):
+                safety_margin = DEFAULT_EXPLORE_TIMEOUT_SAFETY_MARGIN
             timeout_sec = _compute_explore_variant_timeout(
                 baseline_runtime_sec=baseline_runtime_sec,
                 kill_ratio=overtime_kill_ratio,
                 floor_sec=int(self.variant_timeout_sec),
+                safety_margin=safety_margin,
             )
 
         # Resolve framework from materialized YAML (informational only —

--- a/inference_optimizer/orchestrator/action_executors/integrate_patch.py
+++ b/inference_optimizer/orchestrator/action_executors/integrate_patch.py
@@ -83,7 +83,7 @@ log = logging.getLogger(__name__)
 
 
 DEFAULT_KEEP_THRESHOLD_PCT = 0.2
-DEFAULT_VARIANT_TIMEOUT_SEC = 2400
+DEFAULT_VARIANT_TIMEOUT_SEC = 7800  # 130 min; aligns with BASELINE_DEFAULT_TIMEOUT_SEC for Qwen3-32B TP=1 long workload
 
 
 def _now_iso() -> str:

--- a/inference_optimizer/orchestrator/action_executors/profile.py
+++ b/inference_optimizer/orchestrator/action_executors/profile.py
@@ -280,7 +280,7 @@ def _validate_trace_structure(
 PROFILE_DEFAULT_CONFIG = (
     asset_root() / "scripts" / "configs" / "profile_sglang.yaml"
 )
-PROFILE_DEFAULT_TIMEOUT_SEC = 2400     # Magpie + sglang profile is heavier, 40 min wall cap
+PROFILE_DEFAULT_TIMEOUT_SEC = 14400    # 4 h wall cap; Qwen3-32B TP=1 profile needs ~3 h with steady-state window
 
 
 def _trace_files_for_dir(trace_dir: Path) -> list[Path]:

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -5335,6 +5335,14 @@ class Coordinator:
             ) or 0.0)
             if kill_ratio > 0:
                 params.setdefault("explore_overtime_kill_ratio", kill_ratio)
+            # Operator-pinned hard timeout override (``0`` = auto-derive in
+            # ExploreExecutor). Injected as ``params['variant_timeout_sec']``
+            # so it takes precedence over the executor's auto-derive path.
+            variant_timeout_override = int(getattr(
+                self.shared_state, "explore_variant_timeout_sec_override", 0,
+            ) or 0)
+            if variant_timeout_override > 0:
+                params.setdefault("variant_timeout_sec", variant_timeout_override)
             # Mirror the sweep/integrate branches: inject ``base_tput`` (and
             # ``base_extra_args``) tied to current_best (or baseline_tput as
             # fallback) whenever Orchestration omits them. Without this the
@@ -5471,6 +5479,11 @@ class Coordinator:
             ) or 0.0)
             if kill_ratio > 0:
                 params.setdefault("explore_overtime_kill_ratio", kill_ratio)
+            variant_timeout_override = int(getattr(
+                self.shared_state, "explore_variant_timeout_sec_override", 0,
+            ) or 0)
+            if variant_timeout_override > 0:
+                params.setdefault("variant_timeout_sec", variant_timeout_override)
         # IR-7 — ``assess_remaining_gaps`` is a thin wrapper: rewrite
         # the kind to ``specialist`` and force the
         # ``session_steward_specialist`` domain (LLM cannot pick any

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -5343,6 +5343,17 @@ class Coordinator:
             ) or 0)
             if variant_timeout_override > 0:
                 params.setdefault("variant_timeout_sec", variant_timeout_override)
+            # Auto-derive headroom override. Has no effect when
+            # ``variant_timeout_sec`` is pinned above; otherwise the
+            # ExploreExecutor passes it as ``safety_margin`` to
+            # ``_compute_explore_variant_timeout``.
+            safety_margin_override = float(getattr(
+                self.shared_state, "explore_variant_timeout_safety_margin", -1.0,
+            ))
+            if safety_margin_override >= 0:
+                params.setdefault(
+                    "variant_timeout_safety_margin", safety_margin_override,
+                )
             # Mirror the sweep/integrate branches: inject ``base_tput`` (and
             # ``base_extra_args``) tied to current_best (or baseline_tput as
             # fallback) whenever Orchestration omits them. Without this the
@@ -5484,6 +5495,13 @@ class Coordinator:
             ) or 0)
             if variant_timeout_override > 0:
                 params.setdefault("variant_timeout_sec", variant_timeout_override)
+            safety_margin_override = float(getattr(
+                self.shared_state, "explore_variant_timeout_safety_margin", -1.0,
+            ))
+            if safety_margin_override >= 0:
+                params.setdefault(
+                    "variant_timeout_safety_margin", safety_margin_override,
+                )
         # IR-7 — ``assess_remaining_gaps`` is a thin wrapper: rewrite
         # the kind to ``specialist`` and force the
         # ``session_steward_specialist`` domain (LLM cannot pick any

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -5177,6 +5177,60 @@ class Coordinator:
                 variant_name,
             )
 
+    def _inject_explore_runtime_params(self, params: dict) -> None:
+        """Inject explore-task operational knobs from SharedState into ``params``.
+
+        Called from both ``_materialize_approved_proposal`` (Critic-gated path)
+        and ``_handle_delegate`` (direct-delegate path that bypasses the
+        verdict map: legacy resume, tests that delegate explore directly) so
+        a single source of truth controls what gets forwarded to the
+        ExploreExecutor. ``setdefault`` preserves any LLM-supplied override
+        for one-off rebench / debug variants.
+
+        Knobs:
+          * ``baseline_runtime_sec`` + ``explore_overtime_kill_ratio`` —
+            Fix E (Q1/Q5): the executor derives ``soft_deadline_sec =
+            baseline_runtime_sec * explore_overtime_kill_ratio`` for the
+            single-variant phase (stack rebench bypasses this gate per Q4).
+          * ``variant_timeout_sec`` — operator-pinned hard timeout
+            (``0`` = auto-derive in ExploreExecutor).
+          * ``variant_timeout_safety_margin`` — auto-derive headroom (no
+            effect when ``variant_timeout_sec`` is pinned above).
+          * ``roofline_hard_gate`` (+ snapshot) — opt-in saturation filter;
+            soft advisory is independent and untouched here.
+        """
+        br = float(getattr(self.shared_state, "baseline_runtime_sec", 0.0) or 0.0)
+        if br > 0:
+            params.setdefault("baseline_runtime_sec", br)
+        kill_ratio = float(getattr(
+            self.shared_state, "explore_overtime_kill_ratio", 0.0,
+        ) or 0.0)
+        if kill_ratio > 0:
+            params.setdefault("explore_overtime_kill_ratio", kill_ratio)
+        variant_timeout_override = int(getattr(
+            self.shared_state, "explore_variant_timeout_sec_override", 0,
+        ) or 0)
+        if variant_timeout_override > 0:
+            params.setdefault("variant_timeout_sec", variant_timeout_override)
+        safety_margin_override = float(getattr(
+            self.shared_state, "explore_variant_timeout_safety_margin", -1.0,
+        ))
+        if safety_margin_override >= 0:
+            params.setdefault(
+                "variant_timeout_safety_margin", safety_margin_override,
+            )
+        if bool(getattr(
+            self.shared_state, "explore_roofline_hard_gate", False,
+        )):
+            params.setdefault("roofline_hard_gate", True)
+            history = list(getattr(
+                self.shared_state, "roofline_saturation_history", [],
+            ) or [])
+            if history and isinstance(history[-1], dict):
+                params.setdefault(
+                    "roofline_saturation_snapshot", dict(history[-1]),
+                )
+
     async def _materialize_approved_proposal(
         self,
         pending: PendingProposal,
@@ -5318,57 +5372,7 @@ class Coordinator:
                     "config_path", self.shared_state.baseline_config_path
                 )
         if pending.action_name == "explore":
-            # Fix E (per-variant overtime kill — Q1 baseline-anchored,
-            # Q5 default-on-with-flag). These two fields are NOT LLM
-            # strategy: they're operational knobs the Coordinator
-            # owns. We always inject them so the ExploreExecutor can
-            # derive ``soft_deadline_sec = baseline_runtime_sec *
-            # explore_overtime_kill_ratio`` for the single-variant
-            # phase (stack rebench intentionally bypasses this gate
-            # — Q4). ``setdefault`` leaves an LLM-supplied override
-            # in place for one-off rebench / debug variants.
-            br = float(getattr(self.shared_state, "baseline_runtime_sec", 0.0) or 0.0)
-            if br > 0:
-                params.setdefault("baseline_runtime_sec", br)
-            kill_ratio = float(getattr(
-                self.shared_state, "explore_overtime_kill_ratio", 0.0,
-            ) or 0.0)
-            if kill_ratio > 0:
-                params.setdefault("explore_overtime_kill_ratio", kill_ratio)
-            # Operator-pinned hard timeout override (``0`` = auto-derive in
-            # ExploreExecutor). Injected as ``params['variant_timeout_sec']``
-            # so it takes precedence over the executor's auto-derive path.
-            variant_timeout_override = int(getattr(
-                self.shared_state, "explore_variant_timeout_sec_override", 0,
-            ) or 0)
-            if variant_timeout_override > 0:
-                params.setdefault("variant_timeout_sec", variant_timeout_override)
-            # Auto-derive headroom override. Has no effect when
-            # ``variant_timeout_sec`` is pinned above; otherwise the
-            # ExploreExecutor passes it as ``safety_margin`` to
-            # ``_compute_explore_variant_timeout``.
-            safety_margin_override = float(getattr(
-                self.shared_state, "explore_variant_timeout_safety_margin", -1.0,
-            ))
-            if safety_margin_override >= 0:
-                params.setdefault(
-                    "variant_timeout_safety_margin", safety_margin_override,
-                )
-            # Roofline hard gate (opt-in). When enabled, also forward the
-            # latest saturation snapshot so the ExploreExecutor can apply
-            # the filter without re-reading SharedState. Soft advisory is
-            # independent and untouched here.
-            if bool(getattr(
-                self.shared_state, "explore_roofline_hard_gate", False,
-            )):
-                params.setdefault("roofline_hard_gate", True)
-                history = list(getattr(
-                    self.shared_state, "roofline_saturation_history", [],
-                ) or [])
-                if history and isinstance(history[-1], dict):
-                    params.setdefault(
-                        "roofline_saturation_snapshot", dict(history[-1]),
-                    )
+            self._inject_explore_runtime_params(params)
             # Mirror the sweep/integrate branches: inject ``base_tput`` (and
             # ``base_extra_args``) tied to current_best (or baseline_tput as
             # fallback) whenever Orchestration omits them. Without this the
@@ -5491,43 +5495,11 @@ class Coordinator:
             params.setdefault(
                 "config_path", self.shared_state.baseline_config_path
             )
-        # Fix E (parity with _materialize_approved_proposal): inject
-        # overtime-kill operational knobs for direct explore delegates
-        # too. The common path is the Critic-gated reroute above, but
-        # this branch covers anything that bypasses the verdict map
-        # (legacy resume, tests that delegate explore directly).
+        # Parity with _materialize_approved_proposal: direct delegates
+        # bypass the verdict map (legacy resume, tests that delegate
+        # explore directly) but still need the same operational knobs.
         if action_name == "explore":
-            br = float(getattr(self.shared_state, "baseline_runtime_sec", 0.0) or 0.0)
-            if br > 0:
-                params.setdefault("baseline_runtime_sec", br)
-            kill_ratio = float(getattr(
-                self.shared_state, "explore_overtime_kill_ratio", 0.0,
-            ) or 0.0)
-            if kill_ratio > 0:
-                params.setdefault("explore_overtime_kill_ratio", kill_ratio)
-            variant_timeout_override = int(getattr(
-                self.shared_state, "explore_variant_timeout_sec_override", 0,
-            ) or 0)
-            if variant_timeout_override > 0:
-                params.setdefault("variant_timeout_sec", variant_timeout_override)
-            safety_margin_override = float(getattr(
-                self.shared_state, "explore_variant_timeout_safety_margin", -1.0,
-            ))
-            if safety_margin_override >= 0:
-                params.setdefault(
-                    "variant_timeout_safety_margin", safety_margin_override,
-                )
-            if bool(getattr(
-                self.shared_state, "explore_roofline_hard_gate", False,
-            )):
-                params.setdefault("roofline_hard_gate", True)
-                history = list(getattr(
-                    self.shared_state, "roofline_saturation_history", [],
-                ) or [])
-                if history and isinstance(history[-1], dict):
-                    params.setdefault(
-                        "roofline_saturation_snapshot", dict(history[-1]),
-                    )
+            self._inject_explore_runtime_params(params)
         # IR-7 — ``assess_remaining_gaps`` is a thin wrapper: rewrite
         # the kind to ``specialist`` and force the
         # ``session_steward_specialist`` domain (LLM cannot pick any

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -5354,6 +5354,21 @@ class Coordinator:
                 params.setdefault(
                     "variant_timeout_safety_margin", safety_margin_override,
                 )
+            # Roofline hard gate (opt-in). When enabled, also forward the
+            # latest saturation snapshot so the ExploreExecutor can apply
+            # the filter without re-reading SharedState. Soft advisory is
+            # independent and untouched here.
+            if bool(getattr(
+                self.shared_state, "explore_roofline_hard_gate", False,
+            )):
+                params.setdefault("roofline_hard_gate", True)
+                history = list(getattr(
+                    self.shared_state, "roofline_saturation_history", [],
+                ) or [])
+                if history and isinstance(history[-1], dict):
+                    params.setdefault(
+                        "roofline_saturation_snapshot", dict(history[-1]),
+                    )
             # Mirror the sweep/integrate branches: inject ``base_tput`` (and
             # ``base_extra_args``) tied to current_best (or baseline_tput as
             # fallback) whenever Orchestration omits them. Without this the
@@ -5502,6 +5517,17 @@ class Coordinator:
                 params.setdefault(
                     "variant_timeout_safety_margin", safety_margin_override,
                 )
+            if bool(getattr(
+                self.shared_state, "explore_roofline_hard_gate", False,
+            )):
+                params.setdefault("roofline_hard_gate", True)
+                history = list(getattr(
+                    self.shared_state, "roofline_saturation_history", [],
+                ) or [])
+                if history and isinstance(history[-1], dict):
+                    params.setdefault(
+                        "roofline_saturation_snapshot", dict(history[-1]),
+                    )
         # IR-7 — ``assess_remaining_gaps`` is a thin wrapper: rewrite
         # the kind to ``specialist`` and force the
         # ``session_steward_specialist`` domain (LLM cannot pick any

--- a/inference_optimizer/orchestrator/shared_state.py
+++ b/inference_optimizer/orchestrator/shared_state.py
@@ -460,6 +460,16 @@ class SharedState:
     # ``variant_timeout_sec`` is a sufficient backstop). Default 1.10
     # (kill at +10 % over baseline wall-clock).
     explore_overtime_kill_ratio: float = 1.10
+    # Per-variant hard timeout override for ExploreExecutor. Mirrored from
+    # ``--explore-variant-timeout-sec`` (CLI) /
+    # ``INFERENCE_OPTIMIZER_EXPLORE_VARIANT_TIMEOUT_SEC`` (env) at session
+    # start. ``0`` means "auto-derive from baseline_runtime_sec * (kill_ratio
+    # + safety_margin)" — see ``explore._compute_explore_variant_timeout``.
+    # An explicit positive value pins the cap (e.g. CI smoke runs that want
+    # a tight bound regardless of baseline). The Coordinator injects this
+    # into every explore task's params so the executor's call site honors
+    # it without each LLM proposal having to re-emit it.
+    explore_variant_timeout_sec_override: int = 0
     # Most recent workload sweep; used to reason about gains beyond the
     # smoke workload (CONC/ISL/OSL frontier).
     last_sweep: dict[str, Any] = field(default_factory=dict)

--- a/inference_optimizer/orchestrator/shared_state.py
+++ b/inference_optimizer/orchestrator/shared_state.py
@@ -470,6 +470,16 @@ class SharedState:
     # into every explore task's params so the executor's call site honors
     # it without each LLM proposal having to re-emit it.
     explore_variant_timeout_sec_override: int = 0
+    # Headroom on top of the soft kill ratio when the executor auto-derives
+    # the per-variant hard cap: ``timeout = baseline_runtime_sec *
+    # (kill_ratio + safety_margin)``. Default 0.5 (≈ 50 % of baseline as
+    # buffer for one-off variant cold starts: torch.compile AOTI compile,
+    # fresh aiter shapes, spec-decoding draft load). Mirrored from
+    # ``--explore-variant-timeout-safety-margin`` (CLI) /
+    # ``INFERENCE_OPTIMIZER_EXPLORE_VARIANT_TIMEOUT_SAFETY_MARGIN`` (env).
+    # Has no effect when ``explore_variant_timeout_sec_override > 0``
+    # (operator-pinned timeout bypasses the auto-derive).
+    explore_variant_timeout_safety_margin: float = 0.5
     # Most recent workload sweep; used to reason about gains beyond the
     # smoke workload (CONC/ISL/OSL frontier).
     last_sweep: dict[str, Any] = field(default_factory=dict)

--- a/inference_optimizer/orchestrator/shared_state.py
+++ b/inference_optimizer/orchestrator/shared_state.py
@@ -480,6 +480,15 @@ class SharedState:
     # Has no effect when ``explore_variant_timeout_sec_override > 0``
     # (operator-pinned timeout bypasses the auto-derive).
     explore_variant_timeout_safety_margin: float = 0.5
+    # Opt-in hard filter: when True AND the latest
+    # ``roofline_saturation_history`` snapshot has at least one direction
+    # crossing the saturation threshold, ExploreExecutor drops every
+    # variant whose flags target ONLY saturated directions before running
+    # the grid. Variants targeting at least one non-saturated direction
+    # (or that don't match the categorization table) are kept. The
+    # existing ``roofline_saturation_advisory`` (soft prompt hint) stays
+    # unchanged. Mirrored from ``--explore-roofline-hard-gate`` (CLI).
+    explore_roofline_hard_gate: bool = False
     # Most recent workload sweep; used to reason about gains beyond the
     # smoke workload (CONC/ISL/OSL frontier).
     last_sweep: dict[str, Any] = field(default_factory=dict)

--- a/inference_optimizer/scripts/configs/baseline_sglang.yaml
+++ b/inference_optimizer/scripts/configs/baseline_sglang.yaml
@@ -47,7 +47,7 @@ benchmark:
   gpu_selection:
     auto: false                # executor pins via ROCR_VISIBLE_DEVICES at runtime
 
-  timeout_seconds: 2400        # 40 min hard cap
+  timeout_seconds: 7200        # 120 min hard cap (Qwen-32B TP=1 CONC=64 ISL/OSL=1024 NUM_PROMPTS=320 needs ~85 min incl. server boot)
 
   profiler:
     torch_profiler:

--- a/inference_optimizer/scripts/configs/profile_sglang.yaml
+++ b/inference_optimizer/scripts/configs/profile_sglang.yaml
@@ -68,7 +68,7 @@ benchmark:
   gpu_selection:
     auto: false                # executor pins via ROCR_VISIBLE_DEVICES at runtime
 
-  timeout_seconds: 2400              # 40 min hard cap (profile adds ~30-90s vs plain baseline)
+  timeout_seconds: 14400             # 4 h hard cap (Qwen-32B TP=1 profile with steady-state window can take ~3 h)
 
   profiler:
     torch_profiler:

--- a/inference_optimizer/tests/test_explore_executor.py
+++ b/inference_optimizer/tests/test_explore_executor.py
@@ -504,6 +504,163 @@ async def test_explore_executor_safety_margin_param_overrides_default(
 
 
 @pytest.mark.asyncio
+async def test_explore_executor_roofline_hard_gate_drops_saturated_variants(
+    sub_agent_runner, tmp_path,
+):
+    """``roofline_hard_gate=True`` + a saturation snapshot drops variants
+    whose flags target only saturated directions; uncategorized / multi-
+    direction variants survive."""
+    sub, tr, _ = sub_agent_runner
+    base = tmp_path / "base.yaml"
+    _write_baseline_yaml(base)
+    output_dir = tmp_path / "explore-roofline-gate"
+
+    benched_variants: list[str] = []
+
+    async def _spy_run_grid(*args, **kwargs):
+        from inference_optimizer.orchestrator.action_executors._grid_runner import (
+            VariantResult,
+        )
+        grid = list(kwargs.get("grid") or [])
+        # The executor calls run_grid once per variant (single-element grid).
+        assert len(grid) == 1
+        gv = grid[0]
+        benched_variants.append(gv.name)
+        slot = Path(kwargs["output_root"])
+        slot.mkdir(parents=True, exist_ok=True)
+        ws = _fake_workspace(slot, tput=805.0)
+        return [VariantResult(
+            name=gv.name,
+            extra_sglang_args=gv.extra_sglang_args,
+            extra_envs=dict(gv.extra_envs),
+            status="succeeded",
+            output_throughput=805.0,
+            workspace=str(ws),
+        )]
+
+    grid = [
+        {
+            "name": "host_only",
+            "extra_args": "--num-continuous-decode-steps 4",
+            "extra_envs": {},
+            "provenance": "default_grid",
+        },
+        {
+            "name": "memory_only",
+            "extra_args": "--max-running-requests 256",
+            "extra_envs": {},
+            "provenance": "default_grid",
+        },
+        {
+            "name": "uncategorized",
+            "extra_args": "--brand-new-flag",
+            "extra_envs": {},
+            "provenance": "default_grid",
+        },
+    ]
+    task = await tr.create(
+        kind="explore",
+        params={
+            "config_path": str(base),
+            "output_dir":  str(output_dir),
+            "base_tput":   800.0,
+            "grid":        grid,
+            # Roofline says memory is at 92 % (saturated), host_overhead
+            # is at 18 % (plenty of headroom). The gate should drop
+            # `memory_only` and keep `host_only` + `uncategorized`.
+            "roofline_hard_gate": True,
+            "roofline_saturation_snapshot": {
+                "compute": 25.0, "memory": 92.0,
+                "host_overhead": 18.0, "comm": 0.0,
+            },
+        },
+        idempotency_key="ex-roofline-gate",
+    )
+    sub.register_executor("explore", ExploreExecutor(session_dir=tmp_path))
+    with patch(
+        "inference_optimizer.orchestrator.action_executors.explore.run_grid",
+        side_effect=_spy_run_grid,
+    ):
+        res = await sub.run_task(task)
+
+    assert res.state == "succeeded"
+    out = res.result
+    # The inlined stack_rebench path re-benches a KEEP'd variant under
+    # ``<name>__stack_rebench`` — ignore that suffix when asserting which
+    # base variants the gate let through.
+    base_benched = {n.split("__")[0] for n in benched_variants}
+    assert base_benched == {"host_only", "uncategorized"}
+    skip_reasons = {
+        s.get("name"): s.get("reason") for s in out.get("skipped_dup", [])
+    }
+    assert skip_reasons.get("memory_only") == "roofline_saturated"
+
+
+@pytest.mark.asyncio
+async def test_explore_executor_roofline_gate_disabled_by_default(
+    sub_agent_runner, tmp_path,
+):
+    """Without ``roofline_hard_gate=True``, the soft advisory path is the
+    only one in play and every variant runs (legacy behaviour)."""
+    sub, tr, _ = sub_agent_runner
+    base = tmp_path / "base.yaml"
+    _write_baseline_yaml(base)
+    output_dir = tmp_path / "explore-roofline-default"
+
+    benched_variants: list[str] = []
+
+    async def _spy_run_grid(*args, **kwargs):
+        from inference_optimizer.orchestrator.action_executors._grid_runner import (
+            VariantResult,
+        )
+        gv = list(kwargs.get("grid") or [])[0]
+        benched_variants.append(gv.name)
+        slot = Path(kwargs["output_root"])
+        slot.mkdir(parents=True, exist_ok=True)
+        ws = _fake_workspace(slot, tput=805.0)
+        return [VariantResult(
+            name=gv.name,
+            extra_sglang_args=gv.extra_sglang_args,
+            extra_envs=dict(gv.extra_envs),
+            status="succeeded",
+            output_throughput=805.0,
+            workspace=str(ws),
+        )]
+
+    grid = [{
+        "name": "memory_only",
+        "extra_args": "--max-running-requests 256",
+        "extra_envs": {},
+        "provenance": "default_grid",
+    }]
+    task = await tr.create(
+        kind="explore",
+        params={
+            "config_path": str(base),
+            "output_dir":  str(output_dir),
+            "base_tput":   800.0,
+            "grid":        grid,
+            # snapshot present, but flag is OFF (or omitted).
+            "roofline_saturation_snapshot": {
+                "compute": 5.0, "memory": 99.0,
+                "host_overhead": 5.0, "comm": 0.0,
+            },
+        },
+        idempotency_key="ex-roofline-off",
+    )
+    sub.register_executor("explore", ExploreExecutor(session_dir=tmp_path))
+    with patch(
+        "inference_optimizer.orchestrator.action_executors.explore.run_grid",
+        side_effect=_spy_run_grid,
+    ):
+        res = await sub.run_task(task)
+
+    assert res.state == "succeeded"
+    base_benched = {n.split("__")[0] for n in benched_variants}
+    assert base_benched == {"memory_only"}
+
+
+@pytest.mark.asyncio
 async def test_explore_executor_explicit_variant_timeout_wins(
     sub_agent_runner, tmp_path,
 ):

--- a/inference_optimizer/tests/test_explore_executor.py
+++ b/inference_optimizer/tests/test_explore_executor.py
@@ -442,6 +442,68 @@ async def test_explore_executor_auto_derives_variant_timeout(
 
 
 @pytest.mark.asyncio
+async def test_explore_executor_safety_margin_param_overrides_default(
+    sub_agent_runner, tmp_path,
+):
+    """``params['variant_timeout_safety_margin']`` widens (or shrinks) the
+    auto-derived headroom when there is no explicit ``variant_timeout_sec``.
+    """
+    sub, tr, _ = sub_agent_runner
+    base = tmp_path / "base.yaml"
+    _write_baseline_yaml(base)
+    output_dir = tmp_path / "explore-margin"
+
+    captured_timeouts: list[int] = []
+
+    async def _spy_run_grid(*args, **kwargs):
+        captured_timeouts.append(int(kwargs.get("variant_timeout_sec")))
+        from inference_optimizer.orchestrator.action_executors._grid_runner import (
+            VariantResult,
+        )
+        slot = Path(kwargs["output_root"])
+        slot.mkdir(parents=True, exist_ok=True)
+        ws = _fake_workspace(slot, tput=805.0)
+        return [VariantResult(
+            name="v_smoke",
+            extra_sglang_args="--smoke",
+            extra_envs={},
+            status="succeeded",
+            output_throughput=805.0,
+            workspace=str(ws),
+        )]
+
+    grid = [{
+        "name": "v_smoke",
+        "extra_args": "--smoke",
+        "extra_envs": {},
+        "provenance": "default_grid",
+    }]
+    task = await tr.create(
+        kind="explore",
+        params={
+            "config_path": str(base),
+            "output_dir":  str(output_dir),
+            "base_tput":   800.0,
+            "grid":        grid,
+            "baseline_runtime_sec": 4140.0,
+            "explore_overtime_kill_ratio": 1.10,
+            # Generous headroom (1.0) → 4140 * 2.10 = 8694 s.
+            "variant_timeout_safety_margin": 1.0,
+        },
+        idempotency_key="ex-margin",
+    )
+    sub.register_executor("explore", ExploreExecutor(session_dir=tmp_path))
+    with patch(
+        "inference_optimizer.orchestrator.action_executors.explore.run_grid",
+        side_effect=_spy_run_grid,
+    ):
+        res = await sub.run_task(task)
+
+    assert res.state == "succeeded"
+    assert captured_timeouts and captured_timeouts[0] == 8694
+
+
+@pytest.mark.asyncio
 async def test_explore_executor_explicit_variant_timeout_wins(
     sub_agent_runner, tmp_path,
 ):

--- a/inference_optimizer/tests/test_explore_executor.py
+++ b/inference_optimizer/tests/test_explore_executor.py
@@ -24,6 +24,11 @@ import yaml
 from inference_optimizer.orchestrator.action_executors import (
     ExploreExecutor,
 )
+from inference_optimizer.orchestrator.action_executors.explore import (
+    DEFAULT_EXPLORE_TIMEOUT_CEILING_SEC,
+    DEFAULT_EXPLORE_TIMEOUT_FLOOR_SEC,
+    _compute_explore_variant_timeout,
+)
 from inference_optimizer.orchestrator.action_executors._canonical_fingerprint import (
     canonical_fingerprint,
 )
@@ -307,6 +312,193 @@ def test_apply_explore_search_update_preserves_accepted():
     assert len(state.explore_search["accepted"]) == 1
     assert state.explore_search["accepted"][0]["name"] == "a"
     assert "bb" * 8 in state.explore_search["tested"]
+
+
+# ===========================================================================
+# _compute_explore_variant_timeout — auto-derive helper
+# ===========================================================================
+def test_compute_explore_variant_timeout_floor_when_no_baseline():
+    """No baseline yet (cold start / failed baseline) → floor."""
+    assert _compute_explore_variant_timeout(0.0, 1.10) == DEFAULT_EXPLORE_TIMEOUT_FLOOR_SEC
+    assert _compute_explore_variant_timeout(-1.0, 1.10) == DEFAULT_EXPLORE_TIMEOUT_FLOOR_SEC
+    assert (
+        _compute_explore_variant_timeout(0.0, 1.10, floor_sec=1800) == 1800
+    )
+
+
+def test_compute_explore_variant_timeout_scales_with_baseline():
+    """Hard cap auto-scales above the soft kill (kill_ratio + safety_margin)."""
+    # Qwen3-32B TP=1 BF16 example: 4140 s baseline × (1.10 + 0.5) = 6624 s.
+    derived = _compute_explore_variant_timeout(4140.0, 1.10)
+    assert derived == 6624
+
+    # 7B TP=1 example: 300 s baseline × 1.6 = 480 s → floored to 2400.
+    derived_small = _compute_explore_variant_timeout(300.0, 1.10)
+    assert derived_small == DEFAULT_EXPLORE_TIMEOUT_FLOOR_SEC
+
+
+def test_compute_explore_variant_timeout_ceiling_caps_runaway():
+    """Pathological baseline value can't push the cap past the ceiling."""
+    # Hypothetical 2.5 h baseline × 1.6 = 14400 s → exactly at ceiling.
+    at_ceiling = _compute_explore_variant_timeout(9000.0, 1.10)
+    assert at_ceiling == DEFAULT_EXPLORE_TIMEOUT_CEILING_SEC
+
+    # Above ceiling clamps.
+    over = _compute_explore_variant_timeout(20000.0, 1.10)
+    assert over == DEFAULT_EXPLORE_TIMEOUT_CEILING_SEC
+
+
+def test_compute_explore_variant_timeout_kill_ratio_below_one_clamps():
+    """A non-positive / sub-1 kill_ratio still gives a sensible cap.
+
+    The hard cap must always sit ABOVE the soft kill threshold; clamping
+    kill_ratio to ``max(1.0, kill_ratio)`` preserves that invariant when
+    callers disable the soft kill (kill_ratio=0).
+    """
+    # kill_ratio=0 (gate disabled) → effective_kill_ratio=1.0, derived = 1.5 × baseline.
+    derived = _compute_explore_variant_timeout(4140.0, 0.0)
+    assert derived == int(4140.0 * 1.5)
+
+
+def test_compute_explore_variant_timeout_safety_margin_override():
+    """Operator can shrink/expand the safety margin (e.g. for known
+    cold-start tax such as torch.compile AOTI)."""
+    # safety_margin=1.0 (very generous) → 4140 × 2.10 = 8694 s.
+    generous = _compute_explore_variant_timeout(4140.0, 1.10, safety_margin=1.0)
+    assert generous == 8694
+
+    # safety_margin=0.0 (no headroom) → 4140 × 1.10 = 4554 s, equal to soft kill.
+    tight = _compute_explore_variant_timeout(4140.0, 1.10, safety_margin=0.0)
+    assert tight == 4554
+
+
+# ===========================================================================
+# ExploreExecutor wires the auto-derived timeout through run_grid
+# ===========================================================================
+@pytest.mark.asyncio
+async def test_explore_executor_auto_derives_variant_timeout(
+    sub_agent_runner, tmp_path,
+):
+    """No ``variant_timeout_sec`` in params + Coordinator-injected
+    ``baseline_runtime_sec`` and ``explore_overtime_kill_ratio`` → executor
+    auto-derives the hard cap and forwards it to run_grid."""
+    sub, tr, _ = sub_agent_runner
+    base = tmp_path / "base.yaml"
+    _write_baseline_yaml(base)
+    output_dir = tmp_path / "explore-derive"
+
+    captured_timeouts: list[int] = []
+
+    async def _spy_run_grid(*args, **kwargs):
+        captured_timeouts.append(int(kwargs.get("variant_timeout_sec")))
+        # Return one fake successful result so the executor proceeds without
+        # crashing on the empty-results path. Reuse the existing fake
+        # workspace helper to populate the slot.
+        from inference_optimizer.orchestrator.action_executors._grid_runner import (
+            VariantResult,
+        )
+        slot = Path(kwargs["output_root"])
+        slot.mkdir(parents=True, exist_ok=True)
+        ws = _fake_workspace(slot, tput=805.0)
+        return [VariantResult(
+            name="v_smoke",
+            extra_sglang_args="--smoke",
+            extra_envs={},
+            status="succeeded",
+            output_throughput=805.0,
+            workspace=str(ws),
+        )]
+
+    grid = [{
+        "name": "v_smoke",
+        "extra_args": "--smoke",
+        "extra_envs": {},
+        "provenance": "default_grid",
+    }]
+    task = await tr.create(
+        kind="explore",
+        params={
+            "config_path": str(base),
+            "output_dir":  str(output_dir),
+            "base_tput":   800.0,
+            "grid":        grid,
+            # NO variant_timeout_sec → auto-derive should fire.
+            "baseline_runtime_sec": 4140.0,
+            "explore_overtime_kill_ratio": 1.10,
+        },
+        idempotency_key="ex-derive",
+    )
+    sub.register_executor("explore", ExploreExecutor(session_dir=tmp_path))
+    with patch(
+        "inference_optimizer.orchestrator.action_executors.explore.run_grid",
+        side_effect=_spy_run_grid,
+    ):
+        res = await sub.run_task(task)
+
+    assert res.state == "succeeded"
+    # Auto-derived: 4140 × (1.10 + 0.5) = 6624.
+    assert captured_timeouts, "run_grid was not invoked"
+    assert captured_timeouts[0] == 6624
+
+
+@pytest.mark.asyncio
+async def test_explore_executor_explicit_variant_timeout_wins(
+    sub_agent_runner, tmp_path,
+):
+    """Operator-pinned ``variant_timeout_sec`` in params takes precedence
+    over the auto-derive even when baseline_runtime_sec is set."""
+    sub, tr, _ = sub_agent_runner
+    base = tmp_path / "base.yaml"
+    _write_baseline_yaml(base)
+    output_dir = tmp_path / "explore-pinned"
+
+    captured_timeouts: list[int] = []
+
+    async def _spy_run_grid(*args, **kwargs):
+        captured_timeouts.append(int(kwargs.get("variant_timeout_sec")))
+        from inference_optimizer.orchestrator.action_executors._grid_runner import (
+            VariantResult,
+        )
+        slot = Path(kwargs["output_root"])
+        slot.mkdir(parents=True, exist_ok=True)
+        ws = _fake_workspace(slot, tput=805.0)
+        return [VariantResult(
+            name="v_smoke",
+            extra_sglang_args="--smoke",
+            extra_envs={},
+            status="succeeded",
+            output_throughput=805.0,
+            workspace=str(ws),
+        )]
+
+    grid = [{
+        "name": "v_smoke",
+        "extra_args": "--smoke",
+        "extra_envs": {},
+        "provenance": "default_grid",
+    }]
+    task = await tr.create(
+        kind="explore",
+        params={
+            "config_path": str(base),
+            "output_dir":  str(output_dir),
+            "base_tput":   800.0,
+            "grid":        grid,
+            "variant_timeout_sec": 9000,    # explicit pin
+            "baseline_runtime_sec": 4140.0,
+            "explore_overtime_kill_ratio": 1.10,
+        },
+        idempotency_key="ex-pin",
+    )
+    sub.register_executor("explore", ExploreExecutor(session_dir=tmp_path))
+    with patch(
+        "inference_optimizer.orchestrator.action_executors.explore.run_grid",
+        side_effect=_spy_run_grid,
+    ):
+        res = await sub.run_task(task)
+
+    assert res.state == "succeeded"
+    assert captured_timeouts and captured_timeouts[0] == 9000
 
 
 # ===========================================================================

--- a/inference_optimizer/tests/test_explore_roofline_filter.py
+++ b/inference_optimizer/tests/test_explore_roofline_filter.py
@@ -1,0 +1,184 @@
+"""Unit tests for the opt-in roofline-categorized variant filter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from inference_optimizer.orchestrator.action_executors._explore_roofline_filter import (
+    categorize_variant,
+    filter_variants_by_roofline,
+)
+
+
+@dataclass
+class _FakeVariant:
+    name: str
+    extra_sglang_args: str = ""
+    extra_envs: dict | None = None
+
+
+# ---------------------------------------------------------------------------
+# categorize_variant
+# ---------------------------------------------------------------------------
+def test_categorize_host_overhead_flag():
+    cats = categorize_variant("--num-continuous-decode-steps 4", {})
+    assert cats == frozenset({"host_overhead"})
+
+
+def test_categorize_torch_compile_is_compute():
+    cats = categorize_variant(
+        "--enable-torch-compile --torch-compile-max-bs 128", {},
+    )
+    assert cats == frozenset({"compute"})
+
+
+def test_categorize_attention_backend_is_multi_direction():
+    """``--attention-backend`` swaps both kernel and memory pattern."""
+    cats = categorize_variant("--attention-backend aiter", {})
+    assert cats == frozenset({"compute", "memory"})
+
+
+def test_categorize_combo_flags_unions():
+    """A variant that stacks flags from multiple categories takes their union."""
+    cats = categorize_variant(
+        "--num-continuous-decode-steps 4 --enable-torch-compile", {},
+    )
+    assert cats == frozenset({"host_overhead", "compute"})
+
+
+def test_categorize_unknown_flag_is_empty():
+    """Conservative: unknown flags → uncategorized, keeper-by-default."""
+    cats = categorize_variant("--never-heard-of-this-flag", {})
+    assert cats == frozenset()
+
+
+def test_categorize_env_specific_then_prefix():
+    """Specific env-name overrides bag with the same prefix."""
+    # Specific name wins over the SGLANG_ prefix general rule.
+    cats = categorize_variant(
+        "", {"SGLANG_OPT_USE_MULTI_STREAM_OVERLAP": "1"},
+    )
+    assert cats == frozenset({"host_overhead"})
+
+    # Generic AITER_* prefix → compute (no specific override).
+    cats = categorize_variant("", {"AITER_USE_TILELANG_GEMM": "1"})
+    assert cats == frozenset({"compute"})
+
+
+def test_categorize_combines_args_and_envs():
+    cats = categorize_variant(
+        "--disable-radix-cache",
+        {"SGLANG_OPT_USE_MULTI_STREAM_OVERLAP": "1"},
+    )
+    assert cats == frozenset({"memory", "host_overhead"})
+
+
+# ---------------------------------------------------------------------------
+# filter_variants_by_roofline
+# ---------------------------------------------------------------------------
+def test_filter_no_saturation_is_noop():
+    """No direction over threshold → grid passes through untouched."""
+    grid = [
+        _FakeVariant(name="v1", extra_sglang_args="--num-continuous-decode-steps 4"),
+        _FakeVariant(name="v2", extra_sglang_args="--enable-torch-compile"),
+    ]
+    snapshot = {"compute": 10.0, "memory": 20.0, "host_overhead": 5.0, "comm": 0.0}
+    kept, dropped = filter_variants_by_roofline(grid, snapshot)
+    assert [g.name for g in kept] == ["v1", "v2"]
+    assert dropped == []
+
+
+def test_filter_drops_only_when_all_target_dirs_saturated():
+    """Memory-bound roofline → host_overhead variants pass; memory variants drop."""
+    grid = [
+        _FakeVariant(name="ncds4", extra_sglang_args="--num-continuous-decode-steps 4"),
+        _FakeVariant(name="memflag", extra_sglang_args="--mem-fraction-static 0.85"),
+        _FakeVariant(name="combo",
+                     extra_sglang_args="--num-continuous-decode-steps 4 --mem-fraction-static 0.9"),
+        _FakeVariant(name="unknown", extra_sglang_args="--brand-new-flag"),
+    ]
+    # Memory at 92 %, host_overhead at 30 % → memory is saturated, host is not.
+    snapshot = {"compute": 10.0, "memory": 92.0, "host_overhead": 30.0, "comm": 0.0}
+    kept, dropped = filter_variants_by_roofline(grid, snapshot)
+    kept_names = [g.name for g in kept]
+    # ncds4: targets host_overhead → not all saturated → keep
+    # memflag: targets memory only → all saturated → DROP
+    # combo: targets host_overhead + memory → host_overhead not saturated → keep
+    # unknown: uncategorized → keep
+    assert "ncds4" in kept_names
+    assert "combo" in kept_names
+    assert "unknown" in kept_names
+    assert "memflag" not in kept_names
+    assert len(dropped) == 1
+    assert dropped[0]["name"] == "memflag"
+    assert dropped[0]["categories"] == ["memory"]
+    assert dropped[0]["saturated_directions"] == ["memory"]
+    assert dropped[0]["reason"] == "all_target_directions_saturated"
+
+
+def test_filter_drops_host_overhead_variant_on_qwen3_32b_shape():
+    """Bandwidth-bound Qwen3-32B-style snapshot → host-overhead reducers
+    correctly identified as wasted work."""
+    grid = [
+        _FakeVariant(name="ncds4", extra_sglang_args="--num-continuous-decode-steps 4"),
+        _FakeVariant(name="ncds16-cgmaxbs128",
+                     extra_sglang_args="--num-continuous-decode-steps 16 --cuda-graph-max-bs 128"),
+        _FakeVariant(name="combo-host-bubble-attack",
+                     extra_sglang_args=("--num-continuous-decode-steps 4 "
+                                        "--scheduler-recv-interval 4 "
+                                        "--cuda-graph-max-bs 128")),
+        _FakeVariant(name="memflag", extra_sglang_args="--max-running-requests 256"),
+    ]
+    # Roofline says memory is at 92 % (bandwidth-bound), host_overhead is at
+    # only 18 % (host is NOT the bottleneck). Memory variant correctly drops
+    # (target direction is saturated); host-overhead reducers stay because
+    # their target direction has plenty of headroom.
+    snapshot = {
+        "compute": 25.0, "memory": 92.0, "host_overhead": 18.0, "comm": 0.0,
+    }
+    kept, dropped = filter_variants_by_roofline(grid, snapshot)
+    kept_names = {g.name for g in kept}
+    dropped_names = {d["name"] for d in dropped}
+    assert kept_names == {"ncds4", "ncds16-cgmaxbs128", "combo-host-bubble-attack"}
+    assert dropped_names == {"memflag"}
+    # Now flip: host is saturated, memory is not.
+    snapshot2 = {
+        "compute": 25.0, "memory": 30.0, "host_overhead": 95.0, "comm": 0.0,
+    }
+    kept2, dropped2 = filter_variants_by_roofline(grid, snapshot2)
+    dropped_names2 = {d["name"] for d in dropped2}
+    # ncds4 + ncds16-cgmaxbs128: pure host_overhead → dropped
+    assert "ncds4" in dropped_names2
+    assert "ncds16-cgmaxbs128" in dropped_names2
+    # combo-host-bubble-attack: also pure host_overhead → dropped
+    assert "combo-host-bubble-attack" in dropped_names2
+    # memflag: pure memory → kept (memory not saturated)
+    assert "memflag" in {g.name for g in kept2}
+
+
+def test_filter_threshold_override():
+    """Custom threshold lets operators tune sensitivity."""
+    grid = [_FakeVariant(name="ncds4",
+                         extra_sglang_args="--num-continuous-decode-steps 4")]
+    snapshot = {"host_overhead": 75.0, "memory": 5.0,
+                "compute": 5.0, "comm": 0.0}
+    # Default threshold (80) → not saturated, kept.
+    kept, dropped = filter_variants_by_roofline(grid, snapshot)
+    assert [g.name for g in kept] == ["ncds4"]
+    assert dropped == []
+    # Tighter threshold (70) → saturated, dropped.
+    kept2, dropped2 = filter_variants_by_roofline(
+        grid, snapshot, threshold_pct=70.0,
+    )
+    assert kept2 == []
+    assert len(dropped2) == 1
+
+
+def test_filter_empty_snapshot_is_noop():
+    grid = [_FakeVariant(name="any", extra_sglang_args="--enable-torch-compile")]
+    kept, dropped = filter_variants_by_roofline(grid, None)
+    assert [g.name for g in kept] == ["any"]
+    assert dropped == []
+    kept2, dropped2 = filter_variants_by_roofline(grid, {})
+    assert [g.name for g in kept2] == ["any"]
+    assert dropped2 == []

--- a/kernel-agent/scripts/install.sh
+++ b/kernel-agent/scripts/install.sh
@@ -104,10 +104,15 @@ if [ -z "${SAFE_API_KEY:-}" ] || [ -z "${OPENAI_BASE_URL:-}" ] || [ -z "${CURSOR
   fi
 fi
 GEAK_REPO="${GEAK_REPO:-https://github.com/AMD-AGI/GEAK.git}"
-# Pin GEAK to the first release that ships RAG MCP retrieval and cross-session
-# memory together. Keep this overridable so future GEAK fixes can move Hyperloom
-# forward without reworking the installer contract.
-GEAK_REF="${GEAK_REF:-v3.2.0}"
+# Pin GEAK to the save-and-test-diff-fallthrough fix tip
+# (https://github.com/AMD-AGI/GEAK/pull/244, not yet released as a tag).
+# We pin to the *commit SHA* of the branch tip, NOT the branch name, so a
+# future force-push / rebase upstream cannot silently change what every
+# fresh install gets.
+# TODO(post-GEAK-PR-244): once PR #244 lands and ships in a new GEAK tag,
+# revert this pin to the tag (e.g. v3.2.1) for stronger discoverability.
+# Operators can override with GEAK_REF=<tag|branch|sha>.
+GEAK_REF="${GEAK_REF:-ec61bdbdb151904ec187a8d89518afb969c53737}"
 OOB_SRC="${OOB_SRC:-${HYPERLOOM_BUNDLE}/OOB}"
 GEAK_CONFIG="${GEAK_CONFIG:-${HYPERLOOM_RUNTIME_DIR}/geak-config/local.yaml}"
 # Pass GEAK_MODEL_NAME through unchanged; GEAK owns provider-specific routing.
@@ -616,7 +621,18 @@ ensure_geak() {
     mkdir -p "${HYPERLOOM_ROOT}" "$(dirname "$GEAK_CONFIG")" "$(dirname "$GEAK_MEMORY_STORE_PATH_VAL")"
   fi
   if [ ! -d "${HYPERLOOM_ROOT}/geak/.git" ]; then
-    run git clone --depth 1 --branch "$GEAK_REF" "$GEAK_REPO" "${HYPERLOOM_ROOT}/geak"
+    # ``git clone --branch`` only accepts tags / branches, not SHAs. Detect
+    # a 7-40 hex char SHA and use a fetch-checkout dance instead so the
+    # SHA pin above stays shallow. GitHub serves shallow SHA fetches
+    # (uploadpack.allowReachableSHA1InWant=true).
+    if [[ "$GEAK_REF" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
+      run git init -q "${HYPERLOOM_ROOT}/geak"
+      run git -C "${HYPERLOOM_ROOT}/geak" remote add origin "$GEAK_REPO"
+      run git -C "${HYPERLOOM_ROOT}/geak" fetch --depth 1 origin "$GEAK_REF"
+      run git -C "${HYPERLOOM_ROOT}/geak" checkout -q FETCH_HEAD
+    else
+      run git clone --depth 1 --branch "$GEAK_REF" "$GEAK_REPO" "${HYPERLOOM_ROOT}/geak"
+    fi
   else
     log "GEAK checkout already present: ${HYPERLOOM_ROOT}/geak"
   fi


### PR DESCRIPTION
Stacked on top of #320. Re-target to `main` once #320 merges (or GitHub will auto-retarget on branch deletion).

Closes #323.

## Summary

Five commits unblocking the slow-workload (Qwen3-32B-class) optimization path:

1. `866d494` — auto-derive explore variant timeout from baseline runtime
2. `1ea8eec` — let operators tune the auto-derive headroom (`--explore-variant-timeout-safety-margin`)
3. `6069bef` — opt-in roofline-categorized variant filter (`--explore-roofline-hard-gate`)
4. `e3d8e9f` — raise default action timeouts for slow workloads (baseline / profile / integrate / yamls)
5. `b456c45` — pin GEAK to the `save-and-test-diff-fallthrough` fix branch (upstream PR https://github.com/AMD-AGI/GEAK/pull/244, also open against GEAK's `main`); revert with `GEAK_REF=v3.2.0 bash install.sh`

## Why

On Qwen3-32B TP=1 BF16 CONC=64 ISL/OSL=1024 NUM_PROMPTS=320:

- A bare baseline run takes ~70 min. The 2400 s (40 min) default cap on EXPLORE variants kills every variant before it produces a measurement, and the kill path doesn't carry a tput value, so the plateau judge can't tell "no progress because variants are timing out" from "no progress because no winner yet". IR-6's wall-clock gate is the only thing that eventually moves the optimizer to KERNEL — at which point ~3 h of EXPLORE budget has been spent on zero usable measurements.
- `baseline.py` / `integrate_patch.py` / `profile.py` / `_grid_runner.py` and the shipped Magpie YAML defaults shared the same 2400 s constant — every action that runs a benchmark on this workload is in the same trap.

## What

### EXPLORE timeout — auto-derive (commits 1-3)

```python
hard_cap = baseline_runtime_sec × (kill_ratio + safety_margin)
clamped to [DEFAULT_EXPLORE_TIMEOUT_FLOOR_SEC, DEFAULT_EXPLORE_TIMEOUT_CEILING_SEC]
       i.e. [2400, 14400] s
```

- New helper `_compute_explore_variant_timeout(...)` in `explore.py` consumes the Coordinator-injected `baseline_runtime_sec` and `explore_overtime_kill_ratio` (already plumbed). Pre-baseline path uses the floor; post-baseline scales with measured runtime.
- New SharedState fields: `explore_variant_timeout_sec_override` (hard pin), `explore_variant_timeout_safety_margin` (headroom), `explore_roofline_hard_gate` (opt-in filter). All Coordinator-injected into every explore task's `params`.
- New CLI flags + env mirrors: `--explore-variant-timeout-sec` / `INFERENCE_OPTIMIZER_EXPLORE_VARIANT_TIMEOUT_SEC`, `--explore-variant-timeout-safety-margin` / `INFERENCE_OPTIMIZER_EXPLORE_VARIANT_TIMEOUT_SAFETY_MARGIN`, `--explore-roofline-hard-gate` / `INFERENCE_OPTIMIZER_EXPLORE_ROOFLINE_HARD_GATE`.
- New module `_explore_roofline_filter.py` with a flag→roofline-direction categorization table, opt-in (off by default). Variants whose every target direction is saturated above the threshold are dropped before dispatch with `reason='roofline_saturated'`. Soft `--roofline-saturation-advisory` prompt hint is unchanged.

### Non-EXPLORE timeouts — static bumps (commit 4)

| File | Field | 2400 → |
|---|---|---|
| `baseline.py` | `BASELINE_DEFAULT_TIMEOUT_SEC` | **7800** (130 min, WARM) |
| `baseline.py` | `BASELINE_COLD_START_TIMEOUT_SEC` | 3600 → **9000** (150 min, COLD) |
| `integrate_patch.py` | `DEFAULT_VARIANT_TIMEOUT_SEC` | **7800** |
| `profile.py` | `PROFILE_DEFAULT_TIMEOUT_SEC` | **14400** (4 h) |
| `_grid_runner.py` | `_VARIANT_TIMEOUT_SEC_DEFAULT` | **7800** |
| `baseline_sglang.yaml` | `timeout_seconds` | **7200** (120 min) |
| `profile_sglang.yaml` | `timeout_seconds` | **14400** (4 h) |

Pairs with the EXPLORE auto-derive: explore variants get a measurement-anchored cap; the actions that run *before* baseline lands or in different phases get a generous static cap matching the documented Qwen3-32B TP=1 cost.

## Test plan

- 242 tests across `test_explore_executor.py`, `test_explore_roofline_filter.py`, `test_grid_runner.py`, `test_baseline_self_loop_policy.py`, `test_baseline_param_overrides.py`, `test_integrate_patch_executor.py`, `test_profile_and_kernel_handlers.py`, `test_profile_trace_validator.py` — all pass (clean env).
- New tests cover: `_compute_explore_variant_timeout` floor / ceiling / kill-ratio clamping / safety-margin override / explicit-override-wins / auto-derive end-to-end through `run_grid`; `categorize_variant` for single / multi / unknown / env-only flag patterns; `filter_variants_by_roofline` no-op / partial / full saturation / threshold override; executor end-to-end with the gate on / off.
- Backward compatibility: old `state.json` files round-trip cleanly (new SharedState fields default to 0 / 0.5 / False = legacy behaviour). Floor on auto-derive preserves the old 2400 s default for any path without baseline data.

## Out of scope

- The earlier draft included some commented-out lines in `kernel-agent/tools/kernel_optimization.py` (debug experiment trimming the GEAK prompt). Those got lost during stash juggling and aren't included here. If they're needed they should land as a deliberate, properly-removed-not-commented-out PR.