### PR TITLE
fix(orch): GEAK budget tracks GEAK_RUN_MODE + adaptive batch parallelism

### DIFF
--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -36,6 +36,7 @@ can monkey-patch in tests.
 from __future__ import annotations
 
 import asyncio
+import functools
 import importlib.util
 import json
 import logging
@@ -121,17 +122,83 @@ _DEFAULT_KERNEL_BACKEND_ORDER = ("geak", "claude", "codex", "cursor")
 # layer below: GEAK / OOB submitters register their work as
 # ``ray.remote(num_gpus=...)`` tasks, so Ray serializes any oversubscription
 # against the cluster's actual GPU resources (typical MI300X / MI355X node
-# = 8 GPU). This default mirrors that node size so a single
-# ``run_optimization`` request can fan out to one GEAK/OOB attempt per GPU
-# without the asyncio semaphore artificially capping below Ray's view.
-# Pre-PR-X default was 3, which throttled even small batches (e.g. A3B's
-# 3 kernel units were already at the cap, and larger TraceLens outputs
-# silently serialized behind sem). Override via
-# ``KERNEL_OPT_MAX_PARALLEL`` env (>=1) on nodes with fewer GPUs or when
-# the LLM API gateway becomes the new bottleneck.
+# = 8 GPU). 8 is the legacy MI300X-tuned cap and the fallback used when
+# ``torch.cuda.device_count()`` can't tell us the visible-GPU count
+# (CI / mocks / pre-driver init). For all other cases the active value
+# is computed by ``_default_kernel_batch_parallel()`` -- ``min(cap,
+# visible_gpus / per_task_gpus)`` -- so smaller pods (4-GPU labs,
+# partial-node CI shards) don't admit more siblings than Ray can
+# actually schedule. Operators can still pin via
+# ``KERNEL_OPT_MAX_PARALLEL`` env (>=1).
 _DEFAULT_KERNEL_BATCH_PARALLEL = 8
 _DEFAULT_OOB_BUDGET_MINUTES = 60.0
-_DEFAULT_GEAK_BUDGET_MINUTES = 90.0
+
+
+@functools.lru_cache(maxsize=1)
+def _default_geak_budget_minutes() -> float:
+    """Default per-GEAK-attempt budget tracking ``$GEAK_RUN_MODE``.
+
+    Mirrors the default in ``kernel-agent/tools/kernel_optimization.py``
+    and ``kernel-agent/tools/parallel_e2e_runner.py`` so the installer /
+    driver / orchestrator agree on one budget. The legacy hard-coded 90
+    silently clamped every GEAK attempt below the full-mode threshold
+    (130) even when ``install.sh`` had exported ``GEAK_RUN_MODE=full``,
+    forcing quick-mode timing on the orchestrator path while the
+    upstream tool ran in full mode (PR #301 fixed only the kernel-agent
+    side; this is the matching orchestrator-side fix).
+
+    Override via payload ``geak_budget_min`` or env
+    ``HYPERLOOM_GEAK_BUDGET_MIN``.
+
+    Cached: ``$GEAK_RUN_MODE`` is set by ``install.sh`` before the
+    optimizer process starts and does not change in-session. Tests that
+    monkeypatch the env must call ``cache_clear()``; the
+    ``inference_optimizer/tests/conftest.py`` autouse fixture handles
+    this for every test.
+    """
+    raw = (os.environ.get("GEAK_RUN_MODE") or "").strip().lower()
+    return 70.0 if raw == "quick" else 130.0
+
+
+@functools.lru_cache(maxsize=1)
+def _default_kernel_batch_parallel() -> int:
+    """Adaptive batch fanout: ``min(cap, visible_gpus // per_task_gpus)``.
+
+    The legacy hard-coded 8 assumed a full MI300X / MI355X node. On
+    smaller pods it lets the asyncio semaphore admit more concurrent
+    sibling attempts than Ray can schedule, so they stack against the
+    GPU lock and one fast kernel waits behind a stuck GEAK for many
+    minutes. We use ``torch.cuda.device_count()`` for the visible-GPU
+    count (works for both ROCm and CUDA backends) and
+    ``$KERNEL_AGENT_NUM_GPUS`` for the per-attempt GPU reservation
+    (set by the kernel-agent submitter). Falls back to the legacy
+    ``_DEFAULT_KERNEL_BATCH_PARALLEL`` when torch can't tell us
+    (CI / mocks / pre-driver init). Operators can still pin via
+    ``KERNEL_OPT_MAX_PARALLEL``.
+
+    Cached: visible GPU count and ``$KERNEL_AGENT_NUM_GPUS`` are fixed
+    at process start; ``torch.cuda.device_count()`` is a driver query
+    we don't want to re-issue on every batch dispatch. Tests that
+    monkeypatch torch / env must call ``cache_clear()``; the
+    ``inference_optimizer/tests/conftest.py`` autouse fixture handles
+    this for every test.
+    """
+    try:
+        import torch  # local import: torch driver init can be expensive
+        n_gpus = int(torch.cuda.device_count() or 0)
+    except Exception:  # noqa: BLE001 -- torch missing / driver init failure
+        return _DEFAULT_KERNEL_BATCH_PARALLEL
+    if n_gpus <= 0:
+        return _DEFAULT_KERNEL_BATCH_PARALLEL
+    try:
+        per_task = int(os.environ.get("KERNEL_AGENT_NUM_GPUS", "0") or 0)
+    except (TypeError, ValueError):
+        per_task = 0
+    if per_task <= 0:
+        per_task = 1
+    return max(1, min(_DEFAULT_KERNEL_BATCH_PARALLEL, n_gpus // per_task))
+
+
 _CANDIDATE_ENV_KEYS = {
     "CONC",
     "ISL",
@@ -872,7 +939,8 @@ async def run_optimization_handler(
 def _geak_budget_minutes(payload: dict) -> float:
     return float(
         payload.get("geak_budget_min")
-        or os.environ.get("HYPERLOOM_GEAK_BUDGET_MIN", _DEFAULT_GEAK_BUDGET_MINUTES)
+        or os.environ.get("HYPERLOOM_GEAK_BUDGET_MIN")
+        or _default_geak_budget_minutes()
     )
 
 
@@ -1273,7 +1341,8 @@ async def _run_optimization_batch(
     """
     max_parallel = int(
         payload.get("max_parallel")
-        or os.environ.get("KERNEL_OPT_MAX_PARALLEL", _DEFAULT_KERNEL_BATCH_PARALLEL)
+        or os.environ.get("KERNEL_OPT_MAX_PARALLEL")
+        or _default_kernel_batch_parallel()
     )
     max_parallel = max(1, max_parallel)
     sem = asyncio.Semaphore(max_parallel)
@@ -1374,7 +1443,8 @@ async def _run_optimization_single(
     Optional payload:
         backends:        comma-separated 'geak,claude,codex,cursor' (auto-pick if empty)
         budget_minutes:  default 60 (OOB backends)
-        geak_budget_min: default 90 (GEAK only; also ``HYPERLOOM_GEAK_BUDGET_MIN``)
+        geak_budget_min: tracks ``$GEAK_RUN_MODE`` (full -> 130, quick -> 70);
+                         override via payload or ``HYPERLOOM_GEAK_BUDGET_MIN``
         source_file:     path to original kernel source (for context)
         candidates_path: path to JSON describing candidates (optional)
         extra_sglang_args: SGLang runtime flags for GEAK metadata (optional)

--- a/inference_optimizer/tests/conftest.py
+++ b/inference_optimizer/tests/conftest.py
@@ -89,6 +89,20 @@ def _isolate_session_layout_env(monkeypatch, tmp_path_factory):
     monkeypatch.delenv("INFERENCE_OPTIMIZER_NODES", raising=False)
 
 
+@pytest.fixture(autouse=True)
+def _clear_kernel_request_handler_caches():
+    """Clear ``lru_cache`` state on env-bound helpers between tests.
+
+    ``_default_geak_budget_minutes`` and ``_default_kernel_batch_parallel``
+    cache their ``$GEAK_RUN_MODE`` / ``$KERNEL_AGENT_NUM_GPUS`` /
+    ``torch.cuda.device_count()`` reads (these don't change in-session
+    in production). Tests that monkeypatch any of those need a fresh
+    cache so the helper actually re-reads the patched value.
+    """
+    from inference_optimizer.orchestrator import kernel_request_handlers as krh
+    krh._default_geak_budget_minutes.cache_clear()
+    krh._default_kernel_batch_parallel.cache_clear()
+
 
 def _bootstrap_kernel_agent_env() -> None:
     """Point HYPERLOOM_KERNEL_AGENT_ROOT at the in-repo kernel-agent checkout."""

--- a/inference_optimizer/tests/test_kernel_request_handlers_units.py
+++ b/inference_optimizer/tests/test_kernel_request_handlers_units.py
@@ -220,3 +220,142 @@ class TestEnrichCandidate:
     def test_enrich_candidates_artifact_noop_when_missing_path(self):
         # Should not raise even though path does not exist.
         krh._enrich_candidates_artifact("", {"env_vars": {}}, trace_report_path="")
+
+
+# ---------------------------------------------------------------------------
+# _default_geak_budget_minutes / _geak_budget_minutes
+#
+# Orchestrator-side mirror of the kernel-agent default (PR #301). The
+# legacy hard-coded 90 forced quick-mode timing on the orchestrator path
+# even when ``install.sh`` had set ``GEAK_RUN_MODE=full``.
+# ---------------------------------------------------------------------------
+
+class TestDefaultGeakBudgetMinutes:
+    @pytest.mark.parametrize(
+        "geak_run_mode, expected",
+        [
+            (None, 130.0),       # unset -> full default
+            ("", 130.0),         # empty -> full default
+            ("full", 130.0),
+            ("FULL", 130.0),     # case-insensitive
+            ("  full  ", 130.0), # whitespace tolerated
+            ("garbage", 130.0),  # unknown values fall back to full
+            ("quick", 70.0),
+            ("QUICK", 70.0),
+            ("  quick  ", 70.0),
+        ],
+    )
+    def test_tracks_geak_run_mode(self, monkeypatch, geak_run_mode, expected):
+        if geak_run_mode is None:
+            monkeypatch.delenv("GEAK_RUN_MODE", raising=False)
+        else:
+            monkeypatch.setenv("GEAK_RUN_MODE", geak_run_mode)
+        assert krh._default_geak_budget_minutes() == expected
+
+
+class TestGeakBudgetMinutes:
+    def test_payload_override_wins(self, monkeypatch):
+        monkeypatch.setenv("GEAK_RUN_MODE", "quick")
+        monkeypatch.setenv("HYPERLOOM_GEAK_BUDGET_MIN", "500")
+        # payload wins over both env signals
+        assert krh._geak_budget_minutes({"geak_budget_min": 100}) == 100.0
+
+    def test_env_override_beats_default(self, monkeypatch):
+        monkeypatch.setenv("GEAK_RUN_MODE", "quick")
+        monkeypatch.setenv("HYPERLOOM_GEAK_BUDGET_MIN", "115")
+        # env wins over the GEAK_RUN_MODE-derived default
+        assert krh._geak_budget_minutes({}) == 115.0
+
+    @pytest.mark.parametrize("geak_run_mode, expected", [
+        ("full", 130.0),
+        ("quick", 70.0),
+    ])
+    def test_falls_through_to_helper_when_no_overrides(
+        self, monkeypatch, geak_run_mode, expected,
+    ):
+        monkeypatch.delenv("HYPERLOOM_GEAK_BUDGET_MIN", raising=False)
+        monkeypatch.setenv("GEAK_RUN_MODE", geak_run_mode)
+        assert krh._geak_budget_minutes({}) == expected
+
+    def test_empty_env_value_falls_through_to_helper(self, monkeypatch):
+        # Pre-fix code would let "" propagate into ``float("")`` and raise.
+        monkeypatch.setenv("HYPERLOOM_GEAK_BUDGET_MIN", "")
+        monkeypatch.delenv("GEAK_RUN_MODE", raising=False)
+        assert krh._geak_budget_minutes({}) == 130.0
+
+
+# ---------------------------------------------------------------------------
+# _default_kernel_batch_parallel
+#
+# Adaptive batch fanout. The legacy hard-coded 8 over-admitted on smaller
+# pods (4-GPU labs, partial-node CI shards), letting the asyncio
+# semaphore queue up siblings that Ray could not actually schedule.
+# ---------------------------------------------------------------------------
+
+class TestDefaultKernelBatchParallel:
+    @pytest.fixture
+    def patch_torch(self, monkeypatch):
+        """Returns a setter that overrides ``torch.cuda.device_count`` and
+        ``$KERNEL_AGENT_NUM_GPUS`` for the helper under test."""
+        import torch
+
+        def _set(n_gpus, per_task=None):
+            monkeypatch.setattr(torch.cuda, "device_count", lambda: n_gpus)
+            if per_task is None:
+                monkeypatch.delenv("KERNEL_AGENT_NUM_GPUS", raising=False)
+            else:
+                monkeypatch.setenv("KERNEL_AGENT_NUM_GPUS", str(per_task))
+
+        return _set
+
+    @pytest.mark.parametrize(
+        "n_gpus, per_task, expected",
+        [
+            # Exact full-node match (8 GPU, 1 GPU/task) -> cap kicks in at 8.
+            (8, 1, 8),
+            # Partial node -> floor at the visible-GPU count.
+            (4, 1, 4),
+            # 8-GPU node with 4-GPU GEAK reservations -> 2 concurrent.
+            (8, 4, 2),
+            # 4-GPU pod with 2-GPU per task -> 2 concurrent.
+            (4, 2, 2),
+            # Larger-than-cap node -> cap still kicks in.
+            (16, 1, 8),
+            # Per-task larger than visible -> floor at 1 (don't stall the
+            # batch with semaphore=0).
+            (1, 4, 1),
+        ],
+    )
+    def test_scales_with_visible_gpus(
+        self, patch_torch, n_gpus, per_task, expected,
+    ):
+        patch_torch(n_gpus, per_task=per_task)
+        assert krh._default_kernel_batch_parallel() == expected
+
+    def test_per_task_unset_defaults_to_one(self, patch_torch):
+        patch_torch(4, per_task=None)
+        assert krh._default_kernel_batch_parallel() == 4
+
+    def test_per_task_invalid_falls_back_to_one(self, patch_torch):
+        patch_torch(4, per_task="not-an-int")
+        assert krh._default_kernel_batch_parallel() == 4
+
+    def test_zero_visible_gpus_returns_legacy_fallback(self, patch_torch):
+        patch_torch(0)
+        assert (
+            krh._default_kernel_batch_parallel()
+            == krh._DEFAULT_KERNEL_BATCH_PARALLEL
+        )
+
+    def test_torch_failure_returns_legacy_fallback(self, monkeypatch):
+        import torch
+
+        def _boom():
+            raise RuntimeError("driver init failed")
+
+        monkeypatch.setattr(torch.cuda, "device_count", _boom)
+        monkeypatch.delenv("KERNEL_AGENT_NUM_GPUS", raising=False)
+        assert (
+            krh._default_kernel_batch_parallel()
+            == krh._DEFAULT_KERNEL_BATCH_PARALLEL
+        )

--- a/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -1983,8 +1983,19 @@ async def test_trace_analyze_handler_t4_failure_appends_to_existing_warnings(
     assert warnings[1]["code"] == "tracelens_analysis_failed"
 
 
-def test_optimization_wrapper_timeout_sec_geak_default_90min():
-    assert krh._optimization_wrapper_timeout_sec({"backends": "geak"}) == 90 * 60 + 180
+def test_optimization_wrapper_timeout_sec_geak_default_full_mode_130min(monkeypatch):
+    # Default tracks ``$GEAK_RUN_MODE`` (full -> 130 min) so the
+    # orchestrator wrapper agrees with the kernel-agent installer /
+    # driver defaults (PR #301 + matching orchestrator-side fix).
+    monkeypatch.delenv("GEAK_RUN_MODE", raising=False)
+    monkeypatch.delenv("HYPERLOOM_GEAK_BUDGET_MIN", raising=False)
+    assert krh._optimization_wrapper_timeout_sec({"backends": "geak"}) == 130 * 60 + 180
+
+
+def test_optimization_wrapper_timeout_sec_geak_quick_mode_70min(monkeypatch):
+    monkeypatch.setenv("GEAK_RUN_MODE", "quick")
+    monkeypatch.delenv("HYPERLOOM_GEAK_BUDGET_MIN", raising=False)
+    assert krh._optimization_wrapper_timeout_sec({"backends": "geak"}) == 70 * 60 + 180
 
 
 def test_optimization_wrapper_timeout_sec_oob_default_60min():


### PR DESCRIPTION
Closes #337.
Closes #338.

## Summary

Two orchestrator-side defaults in `kernel_request_handlers.py` were silently overriding what the kernel-agent installer / driver already do. PR #301 fixed only the kernel-agent layer of the GEAK budget; this is the matching orchestrator fix, plus a sibling fix for the static batch-parallelism constant.

## Why

### `_DEFAULT_GEAK_BUDGET_MINUTES = 90.0` (#337)

`install.sh` defaults `GEAK_RUN_MODE=full`. PR #301 made the kernel-agent layer (`kernel_optimization.py`, `parallel_e2e_runner.py`) return 70 / 130 based on that env. The orchestrator has its own constant pinned at 90, which is below the 130-min full-mode threshold, so unless an operator explicitly exports `HYPERLOOM_GEAK_BUDGET_MIN=130` or passes `geak_budget_min` in the LLM payload, the orchestrator clamp wins and GEAK runs in quick-mode timing.

### `_DEFAULT_KERNEL_BATCH_PARALLEL = 8` (#338)

Calibrated for a full MI300X / MI355X node. On smaller pods (4-GPU labs, partial-node CI shards) the asyncio semaphore lets all 8 siblings start, but Ray can only schedule `floor(visible_gpus / num_gpus_per_task)` of them at a time. The rest stack against the GPU lock, so a fast kernel that *would* finish quickly waits behind a stuck GEAK on the semaphore for many minutes. We've seen this in the Qwen3-30B-A3B-Base session 20260522T093903Z (3-hour serialization on a single hot kernel) and on the Qwen3-32B GEAK-preprocess-hang case from this week.

## What

| Symbol | Old | New |
|---|---|---|
| `_DEFAULT_GEAK_BUDGET_MINUTES = 90.0` | constant 90 | `_default_geak_budget_minutes()` -> 70 / 130 based on `$GEAK_RUN_MODE` |
| `_DEFAULT_KERNEL_BATCH_PARALLEL = 8` | constant 8 | constant retained as cap + torch-unavailable fallback; active value computed by `_default_kernel_batch_parallel()` -> `min(cap, visible_gpus // KERNEL_AGENT_NUM_GPUS)` |

Override knobs are unchanged: payload `geak_budget_min`, `HYPERLOOM_GEAK_BUDGET_MIN`, payload `max_parallel`, `KERNEL_OPT_MAX_PARALLEL`.

The legacy hard-coded constants stay defined: `_DEFAULT_KERNEL_BATCH_PARALLEL = 8` is still the cap and fallback, and the GEAK helper falls through to 130 when `GEAK_RUN_MODE` is unset (which is the same as the install-time default), so the only real behaviour change is that the orchestrator stops *clamping* full-mode GEAK below the kernel-agent's full-mode budget.

## Test plan

- `inference_optimizer/tests/test_kernel_request_handlers_units.py` (52 tests, +23 new)
  - `TestDefaultGeakBudgetMinutes` — env unset / empty / `full` / `FULL` / `  full  ` / `garbage` / `quick` / `QUICK` / `  quick  ` (parametrized).
  - `TestGeakBudgetMinutes` — payload override wins, env override beats default, helper fall-through, empty-env-string fall-through (plugs a pre-existing `float("")` edge case).
  - `TestDefaultKernelBatchParallel` — 8/1, 4/1, 8/4, 4/2, 16/1, 1/4 GPU-count / per-task combinations; per-task unset / invalid; zero visible GPUs; torch-failure fallback.
- `inference_optimizer/tests/test_profile_and_kernel_handlers.py` — renamed `test_optimization_wrapper_timeout_sec_geak_default_90min` -> `_full_mode_130min`, added a `_quick_mode_70min` sibling. The pre-existing `_DEFAULT_KERNEL_BATCH_PARALLEL == 8` assertion still holds (constant retained as cap / fallback).

All 153 tests in those files pass except 3 pre-existing unrelated failures on `main` (`backend_ladder_prefers_keep_over_higher_micro_non_keep`, `backend_ladder_falls_back_to_highest_micro_when_no_keep`, `batch_candidates_default_min_gpu_pct_matches_sharedstate_gate` — unchanged on this branch vs. `main`, separate concern).

Made with [Cursor](https://cursor.com)