### PR TITLE
fix by codeql_report

### DIFF
--- a/ci/pr_submitter.py
+++ b/ci/pr_submitter.py
@@ -74,7 +74,10 @@ def _llm_extract_changes(report_content: str, api_key: str) -> dict:
             json={"model": "openai/gpt-4.1-mini",
                   "messages": [{"role": "user", "content": prompt}],
                   "temperature": 0, "max_tokens": 500},
-            timeout=30, verify=False,
+            timeout=30,
+            verify=os.environ.get(
+                "SSL_CERT_FILE", os.environ.get("REQUESTS_CA_BUNDLE", True)
+            ),
         )
         resp.raise_for_status()
         content = resp.json()["choices"][0]["message"]["content"].strip()
@@ -114,6 +117,29 @@ def _parse_flags_string(s: str) -> dict[str, str]:
     return flags
 
 
+_LAUNCH_CMD_RE = re.compile(
+    r"(?:python3?\s+-m\s+\S+\.launch_server|vllm\s+serve)\b",
+)
+
+
+def _extract_fenced_bash_blocks(report: str) -> list[str]:
+    """Return bodies of ``` / ```bash fenced blocks (linear-time scan)."""
+    blocks: list[str] = []
+    opener = re.compile(r"```(?:bash)?\s*\n", re.IGNORECASE)
+    pos = 0
+    while True:
+        m = opener.search(report, pos)
+        if not m:
+            break
+        start = m.end()
+        end = report.find("\n```", start)
+        if end == -1:
+            break
+        blocks.append(report[start:end])
+        pos = end + 4
+    return blocks
+
+
 def _extract_optimized_flags(report: str) -> dict[str, str]:
     """Extract the final/optimized flag set from the report.
 
@@ -134,14 +160,11 @@ def _extract_optimized_flags(report: str) -> dict[str, str]:
         log.debug("Extracted flags from EXTRA_VLLM_ARGS YAML")
         return _parse_flags_string(args_text)
 
-    cmd_re = re.compile(
-        r"```(?:bash)?\s*\n((?:export\s+\S+=\S+\n)*"
-        r"(?:python3?\s+-m\s+\S+\.launch_server|vllm\s+serve)\b.*?)\n```",
-        re.DOTALL,
-    )
-    blocks = cmd_re.findall(report)
-    if blocks:
-        block = blocks[-1].replace("\\\n", " ")
+    launch_blocks = [
+        b for b in _extract_fenced_bash_blocks(report) if _LAUNCH_CMD_RE.search(b)
+    ]
+    if launch_blocks:
+        block = launch_blocks[-1].replace("\\\n", " ")
         log.debug("Extracted flags from bash launch command")
         return _parse_flags_string(block)
 

--- a/ci/report_generator.py
+++ b/ci/report_generator.py
@@ -42,7 +42,10 @@ def _extract_metrics_via_llm(report_content: str) -> dict:
             headers={"Content-Type": "application/json", "Authorization": f"Bearer {api_key}"},
             json={"model": "openai/gpt-4.1-mini", "messages": [{"role": "user", "content": prompt}],
                   "temperature": 0, "max_tokens": 200},
-            timeout=30, verify=False,
+            timeout=30,
+            verify=os.environ.get(
+                "SSL_CERT_FILE", os.environ.get("REQUESTS_CA_BUNDLE", True)
+            ),
         )
         resp.raise_for_status()
         content = resp.json()["choices"][0]["message"]["content"].strip()

--- a/ci/send_webhook.py
+++ b/ci/send_webhook.py
@@ -19,7 +19,6 @@ from pathlib import Path
 from typing import Any
 
 import requests
-import urllib3
 
 
 def _fmt_num(v: Any) -> str:
@@ -253,13 +252,19 @@ def main() -> int:
         print("summary has no rows; skipping webhook")
         return 0
 
-    urllib3.disable_warnings()
     chunks = [rows[i:i + args.rows_per_card] for i in range(0, len(rows), args.rows_per_card)]
     for idx, chunk in enumerate(chunks, 1):
         body = _build_payload(chunk, rows, idx, len(chunks), args.dashboard_url)
         body_bytes = len(json.dumps(body, ensure_ascii=False).encode("utf-8"))
         print(f"Webhook part {idx}/{len(chunks)}: {len(chunk)} rows, {body_bytes} bytes")
-        response = requests.post(args.url, json=body, timeout=args.timeout, verify=False)
+        response = requests.post(
+            args.url,
+            json=body,
+            timeout=args.timeout,
+            verify=os.environ.get(
+                "SSL_CERT_FILE", os.environ.get("REQUESTS_CA_BUNDLE", True)
+            ),
+        )
         print(f"Webhook part {idx}: HTTP {response.status_code}")
         if response.status_code >= 300:
             print(response.text[:500])

--- a/framework-agent/src/framework_agent/sources/_shared.py
+++ b/framework-agent/src/framework_agent/sources/_shared.py
@@ -8,6 +8,9 @@ can produce uniform candidate records without circular imports.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from urllib.parse import urlparse
+
+_GITHUB_HOST = "github.com"
 
 
 @dataclass(frozen=True)
@@ -38,11 +41,23 @@ def _repo_slug(repo_url: str) -> str:
     raw = repo_url.strip()
     if raw.endswith(".git"):
         raw = raw[:-4]
+
+    path: str
     if raw.startswith("git@github.com:"):
-        raw = raw.split(":", 1)[1]
-    elif "github.com/" in raw:
-        raw = raw.split("github.com/", 1)[1]
-    parts = [p for p in raw.strip("/").split("/") if p]
+        path = raw.split(":", 1)[1]
+    elif raw.startswith("ssh://git@github.com/"):
+        parsed = urlparse(raw)
+        if (parsed.hostname or "").lower() != _GITHUB_HOST:
+            raise ValueError(f"cannot derive GitHub repo from repo_url={repo_url!r}")
+        path = parsed.path
+    else:
+        candidate = raw if "://" in raw else f"https://{raw}"
+        parsed = urlparse(candidate)
+        if (parsed.hostname or "").lower() != _GITHUB_HOST:
+            raise ValueError(f"cannot derive GitHub repo from repo_url={repo_url!r}")
+        path = parsed.path
+
+    parts = [p for p in path.strip("/").split("/") if p]
     if len(parts) < 2:
         raise ValueError(f"cannot derive GitHub repo from repo_url={repo_url!r}")
     return f"{parts[0]}/{parts[1]}"

--- a/framework-agent/tests/test_sources_primus_cortex.py
+++ b/framework-agent/tests/test_sources_primus_cortex.py
@@ -62,6 +62,14 @@ def test_repo_slug_rejects_malformed() -> None:
         _repo_slug("not-a-url")
 
 
+def test_repo_slug_rejects_github_substring_in_path() -> None:
+    """URLs that embed github.com in the path must not be accepted."""
+    with pytest.raises(ValueError):
+        _repo_slug("https://evil.com/github.com/owner/repo.git")
+    with pytest.raises(ValueError):
+        _repo_slug("https://github.com.evil.com/owner/repo.git")
+
+
 # list_perf_prs ----------------------------------------------------------
 
 


### PR DESCRIPTION
Description
Fix CodeQL security findings: safer GitHub URL parsing, ReDoS fix in pr_submitter, and enable HTTPS certificate verification in CI scripts.

Linked issue(s)
py/incomplete-url-substring-sanitization — _shared.py
py/redos — pr_submitter.py
py/request-without-cert-validation — pr_submitter.py, report_generator.py, send_webhook.py
Tests
Added: test_repo_slug_rejects_github_substring_in_path
Run: 3 _repo_slug pytest cases; manual ReDoS smoke test for pr_submitter
Breaking changes
Yes (limited)

Internal HTTPS that relied on verify=False needs SSL_CERT_FILE or REQUESTS_CA_BUNDLE
Spoofed URLs with embedded github.com/ now raise errors (valid GitHub URLs unchanged)