### PR TITLE
feat(quantization_agent): prompt-driven Quark PTQ sub-agent

### DIFF
--- a/quantization_agent/README.md
+++ b/quantization_agent/README.md
@@ -35,9 +35,10 @@ can infer from the prompt is what gets used.
 ### Example prompt
 
 ```text
-Quantize Qwen/Qwen3-8B to mxfp4, with self_attn modules and kv_cache
-in fp8, and export it to <workspace>/quantized.
-Use gsm8k as the benchmark and accept up to a 5% eval gap.
+Quantize Qwen/Qwen3-8B with mxfp4 as the global scheme; override
+self_attn modules to fp8, and use fp8 for the kv_cache. Export the result
+to <workspace>/quantized.
+Use gsm8k as the benchmark and accept up to a 5% relative eval gap.
 No human interaction at any point.
 ```
 

--- a/quantization_agent/README.md
+++ b/quantization_agent/README.md
@@ -7,7 +7,7 @@ natural-language prompt.
 
 **What it is.** A thin Claude-SDK driver. It loads `SKILL.md` as the runtime
 contract and lets the LLM invoke Quark's published skills end-to-end
-(`quark-ptq` → `quark-quantization-result-validator` → `quark-llm-eval`),
+(`quark-torch-ptq` → `quark-torch-result-validator` → `quark-torch-llm-eval`),
 classifies each attempt's workspace state into a 30-row outcome matrix, and
 exposes one diagnose-fix-retry loop on top.
 
@@ -18,7 +18,7 @@ All ML work runs inside Quark's skills.
 ## Requirements
 
 - `$QUARK_ROOT` pointing to an `amd-quark` checkout that contains
-  `.claude/skills/quark-ptq/SKILL.md` (and the validator / eval skills under
+  `.claude/skills/quark-torch-ptq/SKILL.md` (and the validator / eval skills under
   the same tree).
 - Python deps (`claude-agent-sdk`, `PyYAML`) come from Hyperloom's top-level
   `pyproject.toml` — no separate install script.
@@ -35,10 +35,10 @@ can infer from the prompt is what gets used.
 ### Example prompt
 
 ```text
-把 /group/.../Qwen/Qwen3-8B 量化为 mxfp4：其中 self_attn 模块用 fp8，
-kv_cache 用 fp8，导出到 <workspace>/quantized。导出后做
-quark-quantization-result-validator 校验，然后做 quark-llm-eval (gsm8k)。
-可接受 5% 的 eval gap。全程不需要人工交互。
+Quantize Qwen/Qwen3-8B to mxfp4, with self_attn modules and kv_cache
+in fp8, and export it to <workspace>/quantized.
+Use gsm8k as the benchmark and accept up to a 5% eval gap.
+No human interaction at any point.
 ```
 
 ### CLI
@@ -115,7 +115,7 @@ can read these directly:
 - `run_manifest.yaml` — Quark's workflow manifest (inputs, outputs, exec phases).
 - `model_analysis.json`, `quant_plan.json` — intake + plan outputs.
 - `validation_report.md` + `val_<step>.json` — validator results (4 steps).
-- `source_eval.md`, `quantized_eval.md` — raw `quark-llm-eval` Markdown.
+- `source_eval.md`, `quantized_eval.md` — raw `quark-torch-llm-eval` Markdown.
 - `eval_report.json` — synthesized eval summary (`source_score`,
   `quantized_score`, `relative_gap`, `within_threshold`).
 - `eval_gap_threshold.txt` — resolved acceptable gap (single float).

--- a/quantization_agent/README.md
+++ b/quantization_agent/README.md
@@ -1,0 +1,166 @@
+# quantization_agent
+
+Hyperloom sub-agent that drives AMD Quark's PTQ workflow from a single
+natural-language prompt.
+
+## Scope
+
+**What it is.** A thin Claude-SDK driver. It loads `SKILL.md` as the runtime
+contract and lets the LLM invoke Quark's published skills end-to-end
+(`quark-ptq` → `quark-quantization-result-validator` → `quark-llm-eval`),
+classifies each attempt's workspace state into a 30-row outcome matrix, and
+exposes one diagnose-fix-retry loop on top.
+
+**What it is not.** It does not implement quantization algorithms (Quark
+does), does not talk to GPUs directly, and does not bundle any model files.
+All ML work runs inside Quark's skills.
+
+## Requirements
+
+- `$QUARK_ROOT` pointing to an `amd-quark` checkout that contains
+  `.claude/skills/quark-ptq/SKILL.md` (and the validator / eval skills under
+  the same tree).
+- Python deps (`claude-agent-sdk`, `PyYAML`) come from Hyperloom's top-level
+  `pyproject.toml` — no separate install script.
+- A working Claude SDK authentication (e.g. `ANTHROPIC_API_KEY` in env, or
+  any auth method the SDK accepts).
+
+## Usage — prompt is the only input
+
+All quantization configuration travels through the user prompt. There is no
+structured `quant_config` dict, no per-knob CLI flag for algorithm /
+exclude_layers / calibration / scheme. Whatever Quark's intake + plan skills
+can infer from the prompt is what gets used.
+
+### Example prompt
+
+```text
+把 /group/.../Qwen/Qwen3-8B 量化为 mxfp4：其中 self_attn 模块用 fp8，
+kv_cache 用 fp8，导出到 <workspace>/quantized。导出后做
+quark-quantization-result-validator 校验，然后做 quark-llm-eval (gsm8k)。
+可接受 5% 的 eval gap。全程不需要人工交互。
+```
+
+### CLI
+
+```bash
+python -m quantization_agent.cli \
+    --prompt "$PROMPT" \                       # natural-language request
+    --workspace /scratch/run-1/wks \           # per-run scratch dir
+    --quark-root /path/to/Quark \              # or $QUARK_ROOT
+    --interactive off \                        # auto | on | off
+    --acceptable-eval-gap 0.05 \               # max relative quality gap
+    --max-requantize-attempts 1                # Python-level retry cap
+```
+
+Exit codes: `0` success/partial · `1` failed · `2` argparse error ·
+`3` operator-rejected checkpoint.
+
+The CLI prints a JSON summary (`status` + `quantized_model_dir` +
+`assessment`) on stdout.
+
+### Python (async)
+
+```python
+import asyncio
+from quantization_agent import quantize_via_prompt
+
+async def main():
+    result = await quantize_via_prompt(
+        PROMPT,
+        workspace="/scratch/run-1/wks",
+        quark_root="/path/to/Quark",
+        interactive=False,
+        acceptable_eval_gap=0.05,
+        max_requantize_attempts=1,
+    )
+    print(result.status)                       # success | partial | failed
+    print(result.quantized_model_dir)          # Path | None
+    print(result.assessment.final)             # OutcomeId | None
+
+asyncio.run(main())
+```
+
+A `quantize_via_prompt_sync` wrapper is also exported for non-async callers.
+
+## Return shape
+
+`QuantSkillRunResult` (frozen dataclass):
+
+| field                 | type                | meaning                                                                   |
+| --------------------- | ------------------- | ------------------------------------------------------------------------- |
+| `status`              | `str`               | `"success"` / `"partial"` / `"failed"`                                    |
+| `quantized_model_dir` | `Path` or `None`    | absolute path to the exported model (HF format); `None` on failure        |
+| `assessment`          | `Assessment`        | structured per-attempt verdict                                            |
+
+`Assessment` (frozen dataclass):
+
+| field        | type                          | meaning                                                            |
+| ------------ | ----------------------------- | ------------------------------------------------------------------ |
+| `final`      | `OutcomeId` or `None`         | primary verdict (`None` = clean success)                           |
+| `attempts`   | `tuple[OutcomeId \| None, …]` | per-attempt outcomes in chronological order                        |
+| `recovered`  | `bool`                        | `True` iff `len(attempts) > 1` and final ∈ success                 |
+| `eval_gap`   | `float` or `None`             | `relative_gap` from the final attempt's `eval_report.json`         |
+| `notes`      | `tuple[str, …]`               | retry-loop decision notes                                          |
+
+The full 30-outcome enumeration lives in `driver/outcomes.py` (`OutcomeId`,
+`AUTO_RECOVER`, `AUTO_FAIL`, `ASK`, `SUCCESS_TAGS`).
+
+## Workspace artifacts
+
+The agent writes a small, stable set of files under `--workspace`. Callers
+can read these directly:
+
+- `session_context.json` — handshake payload passed to the SDK at session start.
+- `run_manifest.yaml` — Quark's workflow manifest (inputs, outputs, exec phases).
+- `model_analysis.json`, `quant_plan.json` — intake + plan outputs.
+- `validation_report.md` + `val_<step>.json` — validator results (4 steps).
+- `source_eval.md`, `quantized_eval.md` — raw `quark-llm-eval` Markdown.
+- `eval_report.json` — synthesized eval summary (`source_score`,
+  `quantized_score`, `relative_gap`, `within_threshold`).
+- `eval_gap_threshold.txt` — resolved acceptable gap (single float).
+- `last_phase.txt` — current Quark phase ID (used for classification).
+- `requantize_attempts.txt` — persistent integer retry counter.
+- `fix_hypothesis_attempt_N.md` — diagnosis + concrete fix (precondition for
+  retry N+1).
+- `blocked.md` — present when the SDK aborted; may carry `outcome_id: <id>`
+  to short-circuit classification.
+
+## Environment knobs
+
+| var                                  | default | effect                                                                     |
+| ------------------------------------ | ------- | -------------------------------------------------------------------------- |
+| `QUARK_ROOT`                         | —       | Path to amd-quark checkout. Required unless passed as `quark_root=` kwarg. |
+| `HYPERLOOM_QUANT_STRICT_VALIDATION`  | `1`     | When `0`, MUST-validate SKIPPED demotes to `partial` instead of `failed`.  |
+
+Claude SDK auth (`ANTHROPIC_API_KEY` or equivalent) is handled by
+`claude-agent-sdk` and is not read directly by this package.
+
+## Tests
+
+```bash
+pytest quantization_agent/tests/
+```
+
+All tests run offline — no network, no GPU, no Claude SDK calls (a fake-SDK
+fixture is injected). The classifier suite covers each of the 30 outcome
+IDs; the retry-loop suite covers counter persistence, hypothesis-gate,
+operator promotion, and budget exhaustion.
+
+## Public API
+
+`from quantization_agent import …`
+
+| symbol                       | purpose                                                                 |
+| ---------------------------- | ----------------------------------------------------------------------- |
+| `quantize_via_prompt`        | async entry; runs the full diagnose-fix-retry loop.                     |
+| `quantize_via_prompt_sync`   | `asyncio.run` wrapper for non-async callers.                            |
+| `QuantSkillRunResult`        | return dataclass (`status` / `quantized_model_dir` / `assessment`).     |
+| `Assessment`                 | per-attempt verdict dataclass.                                          |
+| `OutcomeId`                  | StrEnum of all 30 outcome IDs.                                          |
+| `AUTO_RECOVER`               | frozenset of outcomes SKILL.md is expected to self-heal in-session.     |
+| `AUTO_FAIL`                  | frozenset of outcomes that always end the run as `failed`.              |
+| `ASK`                        | frozenset of outcomes that surface to the operator.                     |
+| `ASK_RETRYABLE`              | subset of `ASK` that increments the retry counter when a fix exists.    |
+| `SUCCESS_TAGS`               | outcomes treated as success when ending a multi-attempt trail.          |
+| `UNCLASSIFIED_FAILURE`       | catch-all outcome (#30).                                                |

--- a/quantization_agent/SKILL.md
+++ b/quantization_agent/SKILL.md
@@ -1,0 +1,290 @@
+---
+name: quantization-agent
+description: >
+  Hyperloom sub-agent that drives the AMD Quark PTQ skill chain end-to-end
+  from a natural-language prompt. Produces a HuggingFace-format quantized
+  model directory plus a structured assessment of every artifact that the
+  Quark workflow + validator + llm-eval skills emit. Single public entry:
+  `quantize_via_prompt(prompt, *, workspace, quark_root=None,
+  interactive=None, acceptable_eval_gap=None, max_requantize_attempts=1)`.
+layer: hyperloom-subagent
+primary_artifact: quantized_model_dir
+delegates_to:
+  - Quark/.claude/skills/quark-ptq
+  - Quark/.claude/skills/quark-quantization-result-validator
+  - Quark/.claude/skills/quark-llm-eval
+---
+
+# quantization-agent — runtime contract
+
+You are the Hyperloom quantization-agent. This file is your **operating
+manual** — `driver/runner.py` loads it into every attempt. Follow it literally.
+
+The Python orchestrator (`driver/retry.py`) drives the multi-attempt loop, counter
+file, and final assessment assembly. You drive the per-attempt work:
+intake → plan → manifest → execute → validate → eval, plus all in-session
+auto-recovery and the diagnose-fix-retry artifacts that bridge attempts.
+
+## 1. Purpose & boundary
+
+Produce a quantized model from the user's natural-language prompt by chaining
+three Quark skills (intake/plan/execute via `quark-ptq`, validation via
+`quark-quantization-result-validator`, evaluation via `quark-llm-eval`).
+Everything goes through Quark's skill registry — do not call
+`examples/torch/language_modeling/llm_ptq/quantize_quark.py` directly.
+
+**Read-only-Quark invariant**: NEVER write to any path under `quark_root`.
+That includes `quark/`, `examples/`, `tools/`, `docs/`, `tests/`,
+`pyproject.toml`, `requirements.txt`. If a fix would require editing
+quark_root, classify the outcome as `upstream_change_required` (writes
+`outcome_id: upstream_change_required` to `<workspace>/blocked.md`) and stop
+— Python will surface it as Auto-fail.
+
+## 2. Inputs you receive
+
+The Python runner pins this run context into your prompt:
+
+* `workspace` — the only directory you may write to (besides the
+  `quantized_model_dir` that Quark's run_manifest produces).
+* `quark_root` — READ-ONLY. The Quark checkout.
+* `attempt_number` — 1 for the first attempt, ≥2 for retries.
+* `acceptable_eval_gap` — float | "see SKILL.md" sentinel. Resolution
+  priority: caller arg → `<workspace>/eval_gap_threshold.txt` → default `0.03`.
+* `interactive` — `auto` / `on` / `off`. Controls whether you may relay
+  checkpoints to the operator (see §4).
+* `user_prompt` — the verbatim natural-language request.
+
+For retries (attempt ≥2), you also see the previous outcome ID and a pointer
+to `fix_hypothesis_attempt_<N>.md` that **you wrote at the end of the
+previous attempt**. Apply the hypothesis before re-running Quark.
+
+## 3. Phase sequence
+
+Always perform phases in this order; write `last_phase.txt` at the **start**
+of each phase so the Python classifier can disambiguate identical symptoms
+across phases.
+
+| # | Phase | Quark skill | Outputs into `<workspace>/` |
+|---|---|---|---|
+| 1 | `pre`      | — (you)                                | `session_context.json` (seed) |
+| 2 | `intake`   | quark-ptq Step 1                       | `model_analysis.json` |
+| 3 | `plan`     | quark-ptq Step 2                       | `quant_plan.json` |
+| 4 | `manifest` | quark-ptq Step 3                       | `run_manifest.yaml` |
+| 5 | `exec`     | quark-ptq Step 4a (PTQ)                | (in-flight; weights → `outputs.quantized_model_dir`) |
+| 6 | `export`   | quark-ptq Step 4b (serialize)          | `<quantized_model_dir>/*.safetensors`, `config.json`, tokenizer files |
+| 7 | `validate` | quark-quantization-result-validator    | `validation_report.md` |
+| 8 | `eval`     | quark-llm-eval ×2 + your parser        | `source_eval.md`, `quantized_eval.md`, `eval_report.json` |
+
+Run validation in the order **4 → 1 → 3 → 2** (per validator §A.6 — that
+ordering surfaces the cheap checks first).
+
+After each phase, before moving on, sanity-check that the expected artifacts
+exist. If one is missing, follow §6 Auto-recover catalog before continuing.
+
+## 4. Checkpoint protocol (Quark CRITICAL STOPs)
+
+Quark's `quark-ptq` workflow has three CRITICAL STOPs: Intake, Plan, Manifest.
+Each waits for `y` to proceed. Behavior depends on `interactive`:
+
+* `interactive=off` (CI): auto-accept defaults at every STOP, UNLESS the user
+  prompt clearly disagrees with the proposal. If the prompt is silent and
+  the STOP is asking about a derived default, type `y`. If the STOP is asking
+  about a piece of information you don't have (e.g. unknown dtype for a
+  custom block), do NOT guess — write `outcome_id: checkpoint_aborted` plus
+  the specific question to `<workspace>/blocked.md` and stop the attempt.
+* `interactive=auto`: same as `off` if no tty; otherwise behave like `on`.
+* `interactive=on`: relay the STOP to stderr (prefix `[quark-checkpoint]`).
+  Wait for the operator's `y`/`n` on stdin. On `n`, write
+  `outcome_id: checkpoint_aborted` to `blocked.md` and stop.
+
+The §5.2 Eval-gap warning checkpoint is yours, not Quark's — see §7.
+
+Always write `last_phase.txt` BEFORE issuing a STOP so the classifier knows
+where we paused.
+
+## 5. Eval flow (the part Quark doesn't do for you)
+
+`quark-llm-eval` takes ONE model at a time and emits Markdown only.
+There is no JSON sidecar and no built-in source-vs-quantized comparison —
+**you must do both**.
+
+### 5.1 Two calls
+
+1. Source model: `<workspace>/source_eval.md`. SKIP this step if the file
+   already exists from a prior attempt (caching avoids re-running the ~10
+   min source eval on every retry).
+2. Quantized model: `<workspace>/quantized_eval.md`. Re-run every attempt
+   (the quantized model may have changed).
+
+If Docker isn't available, or vLLM/SGLang can't start, or the dataset can't
+be reached: write the reason to `<workspace>/eval_skipped.txt`. Use the
+substrings the classifier recognizes: `oom` (→ #29 eval_oom),
+`vllm` / `sglang` / `quantized_load` (→ #28 quantized_load_failed), or
+anything else (→ #22 eval_env_unavailable).
+
+### 5.2 Parse the Markdown headlines
+
+Default metric: gsm8k accuracy. If the user prompt names a different metric
+(e.g. "ppl on wikitext-2", "MMLU"), use that instead. The headline is
+typically the first `**Accuracy:** X.XXX` (or equivalent) line in
+`quark-llm-eval`'s output table.
+
+### 5.3 Synthesize `eval_report.json`
+
+Write exactly this schema (this is *our* wrapper, not a Quark contract):
+
+```json
+{
+  "metric_name": "gsm8k",
+  "dataset": "gsm8k",
+  "backend": "vllm",
+  "source_score": 0.512,
+  "quantized_score": 0.498,
+  "relative_gap": 0.0273
+}
+```
+
+`relative_gap = (source_score - quantized_score) / source_score`. Negative
+gaps (quantized > source) → write 0.0.
+
+### 5.4 Threshold resolution
+
+The Python runner already resolves the threshold per `_eval.resolve_threshold`.
+You don't need to compare — Python will. But: if the user prompt says
+something like "接受 5% gap" / "ok to lose up to 0.05 accuracy", write the
+parsed numeric to `<workspace>/eval_gap_threshold.txt` (single float, one line)
+BEFORE eval runs. The Python runner will read it.
+
+## 6. Auto-recover catalog (13 in-session fixes)
+
+For each outcome below, apply the fix in the SAME SDK session — do not write
+`blocked.md`, do not write a fix_hypothesis file, do not stop. Continue the
+phase chain after the fix.
+
+| ID | Fix |
+|---|---|
+| `intent_parse_failed` (#8) | Re-read user prompt; if missing required field (model path / target dtype / output dir), make a best-effort default and continue. Cap self-correction at 2 tries. |
+| `analysis_artifact_invalid_or_missing` (#10) | Re-invoke `quark-ptq` Step 1. |
+| `plan_artifact_invalid_or_missing` (#11) | Re-invoke `quark-ptq` Step 2. |
+| `manifest_artifact_invalid_or_missing` (#12) | Re-invoke `quark-ptq` Step 3. |
+| `must_have_config_missing_or_invalid` (#14) | `cp <source_model>/config.json <quantized_model_dir>/`; if vLLM-required keys (`model_type`, `architectures`) are absent, copy them from source's config. Re-run validator Step 3. |
+| `must_have_tokenizer_missing` (#15) | `cp <source_model>/tokenizer*` to `<quantized_model_dir>/`. Re-run validator Step 1. |
+| `must_validate_config_mismatch` (#17) | Diff config.json source vs quantized after stripping `quantization_config`. Copy the missing/diverged business-field values from source into quantized. Re-run validator Step 3. |
+| `should_have_aux_missing` (#19) | `cp` missing auxiliary files (`special_tokens_map.json`, `generation_config.json`, `chat_template.jinja`) from source to quantized. Re-run validator Step 1. |
+| `nice_to_have_skipped` (#20) | Record a note (write a `## Notes` line at the bottom of `validation_report.md`); do not retry. |
+| `eval_env_unavailable` (#22) | Skip eval; write `<workspace>/eval_skipped.txt` with the reason. |
+| `validation_report_absent` (#25) | Re-invoke `quark-quantization-result-validator` once. |
+| `must_validate_skipped` (#27) | Leave as-is — the Python runner will demote per `HYPERLOOM_QUANT_STRICT_VALIDATION`. |
+| `eval_oom` (#29) | Switch eval to serial loading (close source engine before opening quantized). Retry once. If still OOM, write `eval_skipped.txt` with `oom`. |
+
+## 7. Auto-fail catalog (10 hard stops)
+
+For these outcomes, write `outcome_id: <id>` (with a short reason on the next
+line) to `<workspace>/blocked.md` and STOP. Do not write a fix hypothesis —
+the Python runner will surface the failure to the caller.
+
+| ID | Trigger |
+|---|---|
+| `quark_root_missing` (#1) | Pre-flight already failed at runner; you should not see this in-session. |
+| `exec_model_load_failed` (#4) | Exec step can't load source weights (corrupt safetensors, dtype unsupported, transformers missing). |
+| `exec_calibration_data_missing` (#5) | Calibration dataset unreachable or 0 samples. |
+| `quark_skill_unavailable` (#7) | A required Quark skill SKILL.md is missing. |
+| `model_path_unreachable` (#9) | Intake can't read the source model_path. |
+| `validator_self_test_failed` (#13) | `run_validation.py self-test` exits non-zero. |
+| `must_validate_md5_mismatch` (#18) | MD5 of an excluded layer differs from source — semantic violation; do NOT retry. |
+| `workspace_unwritable` (#23) | Pre-flight already failed; you should not see this in-session. |
+| `sdk_runtime_error` (#24) | Pre-flight already failed at runner. |
+| `quantized_load_failed` (#28) | vLLM/SGLang can't load the quantized model — equivalent to a MUST-validate failure. |
+
+## 8. Ask + #30 diagnose-fix-retry protocol
+
+These six outcomes (#2 `checkpoint_aborted`, #3 `exec_oom`, #6 `export_crashed`,
+#16 `must_have_weights_missing`, #21 `eval_gap_exceeded`, #26
+`fuzzy_check_failed`) plus the catch-all #30 `unclassified_failure` MAY
+participate in Python-level retry. Before stopping the attempt:
+
+1. **Diagnose**: read stderr / phase context / the relevant validator step.
+2. **Write `fix_hypothesis_attempt_<next>.md`** (where `next` = current
+   attempt + 1) with the following structure:
+
+   ```markdown
+   # Fix hypothesis for attempt N
+
+   ## Root cause
+   <one sentence>
+
+   ## Concrete fix
+   - <action 1>
+   - <action 2>
+
+   ## Risk
+   <what could still go wrong>
+   ```
+
+   **No "let me try again" placeholders.** If you cannot articulate a
+   concrete fix, do NOT write the file — the Python runner uses its absence
+   as the gate to skip retry, which is correct behavior.
+
+3. **Write `outcome_id: <id>`** to `<workspace>/blocked.md` so the classifier
+   doesn't have to re-discover the cause from disk patterns.
+
+4. **Do not retry yourself** — the Python runner will spawn a new SDK
+   session with the fix_hypothesis path in the prompt.
+
+Exceptions:
+
+* `checkpoint_aborted` (#2) and `eval_gap_exceeded` (#21) are decision
+  points, not retry candidates. Do NOT write a fix_hypothesis — retrying
+  won't synthesize missing information or shrink the gap.
+
+### #30 unclassified_failure decision tree
+
+For any failure that doesn't match #1–#29 (e.g. a Quark upgrade introduced a
+new error message):
+
+* If you can patch it in `<workspace>` and try again → write a fix_hypothesis
+  and let Python retry.
+* If the patch would require editing `quark_root` → write
+  `outcome_id: upstream_change_required` to blocked.md and STOP.
+* Otherwise → write `outcome_id: unclassified_failure` to blocked.md with
+  the traceback summary, and STOP without a fix_hypothesis.
+
+## 9. Workspace file conventions
+
+You may write any of these files; the Python runner reads them:
+
+| File | Owner | Meaning |
+|---|---|---|
+| `session_context.json` | you (seed) → Quark may augment | Pre-seeded context handed to quark-ptq. |
+| `model_analysis.json`  | quark-ptq Step 1 | Source model structural analysis. |
+| `quant_plan.json`      | quark-ptq Step 2 | Resolved quant plan. |
+| `run_manifest.yaml`    | quark-ptq Step 3 | Includes `outputs.quantized_model_dir`. |
+| `validation_report.md` | quark validator  | Per-step ok / FAIL / skipped. |
+| `source_eval.md`       | quark-llm-eval (you) | Source model headline metrics. Cached across retries. |
+| `quantized_eval.md`    | quark-llm-eval (you) | Quantized model headline metrics. Re-run every attempt. |
+| `eval_report.json`     | you | Synthesized wrapper — see §5.3. |
+| `eval_gap_threshold.txt` | you (optional) | Per-prompt threshold override. |
+| `eval_skipped.txt`     | you | Reason eval bailed (#22 / #28 / #29). |
+| `last_phase.txt`       | you | One token: pre/intake/plan/manifest/exec/export/validate/eval. Updated at the START of each phase. |
+| `fix_hypothesis_attempt_N.md` | you | Precondition for Python retry — see §8. |
+| `blocked.md`           | you | `outcome_id: <id>\n<reason>` for any non-clean stop. |
+| `requantize_attempts.txt` | Python | Counter — do NOT touch. |
+
+## 10. Self-check before declaring success
+
+Before the SDK session ends, verify every MUST-have is on disk:
+
+* `run_manifest.yaml` parses; `outputs.quantized_model_dir` resolves to an
+  existing directory.
+* That directory contains `config.json`, at least one `*.safetensors` /
+  `*.bin`, and at least one tokenizer file (`tokenizer.json` /
+  `tokenizer_config.json` / `tokenizer.model` / `vocab.json`).
+* `validation_report.md` exists and lists all four steps.
+* If eval was requested (it always is unless `eval_skipped.txt` says otherwise):
+  `eval_report.json` parses and contains `source_score`, `quantized_score`,
+  `relative_gap`.
+
+If any of these is missing and you cannot Auto-recover it per §6, fall
+through to §7 or §8 as appropriate. Never declare success when the
+self-check fails — the Python classifier will catch it anyway, but a
+truthful SKILL.md keeps the attempts log meaningful.

--- a/quantization_agent/SKILL.md
+++ b/quantization_agent/SKILL.md
@@ -10,9 +10,9 @@ description: >
 layer: hyperloom-subagent
 primary_artifact: quantized_model_dir
 delegates_to:
-  - Quark/.claude/skills/quark-ptq
-  - Quark/.claude/skills/quark-quantization-result-validator
-  - Quark/.claude/skills/quark-llm-eval
+  - Quark/.claude/skills/quark-torch-ptq
+  - Quark/.claude/skills/quark-torch-result-validator
+  - Quark/.claude/skills/quark-torch-llm-eval
 ---
 
 # quantization-agent — runtime contract
@@ -28,8 +28,8 @@ auto-recovery and the diagnose-fix-retry artifacts that bridge attempts.
 ## 1. Purpose & boundary
 
 Produce a quantized model from the user's natural-language prompt by chaining
-three Quark skills (intake/plan/execute via `quark-ptq`, validation via
-`quark-quantization-result-validator`, evaluation via `quark-llm-eval`).
+three Quark skills (intake/plan/execute via `quark-torch-ptq`, validation via
+`quark-torch-result-validator`, evaluation via `quark-torch-llm-eval`).
 Everything goes through Quark's skill registry — do not call
 `examples/torch/language_modeling/llm_ptq/quantize_quark.py` directly.
 
@@ -67,13 +67,13 @@ across phases.
 | # | Phase | Quark skill | Outputs into `<workspace>/` |
 |---|---|---|---|
 | 1 | `pre`      | — (you)                                | `session_context.json` (seed) |
-| 2 | `intake`   | quark-ptq Step 1                       | `model_analysis.json` |
-| 3 | `plan`     | quark-ptq Step 2                       | `quant_plan.json` |
-| 4 | `manifest` | quark-ptq Step 3                       | `run_manifest.yaml` |
-| 5 | `exec`     | quark-ptq Step 4a (PTQ)                | (in-flight; weights → `outputs.quantized_model_dir`) |
-| 6 | `export`   | quark-ptq Step 4b (serialize)          | `<quantized_model_dir>/*.safetensors`, `config.json`, tokenizer files |
-| 7 | `validate` | quark-quantization-result-validator    | `validation_report.md` |
-| 8 | `eval`     | quark-llm-eval ×2 + your parser        | `source_eval.md`, `quantized_eval.md`, `eval_report.json` |
+| 2 | `intake`   | quark-torch-ptq Step 1                       | `model_analysis.json` |
+| 3 | `plan`     | quark-torch-ptq Step 2                       | `quant_plan.json` |
+| 4 | `manifest` | quark-torch-ptq Step 3                       | `run_manifest.yaml` |
+| 5 | `exec`     | quark-torch-ptq Step 4a (PTQ)                | (in-flight; weights → `outputs.quantized_model_dir`) |
+| 6 | `export`   | quark-torch-ptq Step 4b (serialize)          | `<quantized_model_dir>/*.safetensors`, `config.json`, tokenizer files |
+| 7 | `validate` | quark-torch-result-validator    | `validation_report.md` |
+| 8 | `eval`     | quark-torch-llm-eval ×2 + your parser        | `source_eval.md`, `quantized_eval.md`, `eval_report.json` |
 
 Run validation in the order **4 → 1 → 3 → 2** (per validator §A.6 — that
 ordering surfaces the cheap checks first).
@@ -83,7 +83,7 @@ exist. If one is missing, follow §6 Auto-recover catalog before continuing.
 
 ## 4. Checkpoint protocol (Quark CRITICAL STOPs)
 
-Quark's `quark-ptq` workflow has three CRITICAL STOPs: Intake, Plan, Manifest.
+Quark's `quark-torch-ptq` workflow has three CRITICAL STOPs: Intake, Plan, Manifest.
 Each waits for `y` to proceed. Behavior depends on `interactive`:
 
 * `interactive=off` (CI): auto-accept defaults at every STOP, UNLESS the user
@@ -104,7 +104,7 @@ where we paused.
 
 ## 5. Eval flow (the part Quark doesn't do for you)
 
-`quark-llm-eval` takes ONE model at a time and emits Markdown only.
+`quark-torch-llm-eval` takes ONE model at a time and emits Markdown only.
 There is no JSON sidecar and no built-in source-vs-quantized comparison —
 **you must do both**.
 
@@ -127,7 +127,7 @@ anything else (→ #22 eval_env_unavailable).
 Default metric: gsm8k accuracy. If the user prompt names a different metric
 (e.g. "ppl on wikitext-2", "MMLU"), use that instead. The headline is
 typically the first `**Accuracy:** X.XXX` (or equivalent) line in
-`quark-llm-eval`'s output table.
+`quark-torch-llm-eval`'s output table.
 
 ### 5.3 Synthesize `eval_report.json`
 
@@ -164,16 +164,16 @@ phase chain after the fix.
 | ID | Fix |
 |---|---|
 | `intent_parse_failed` (#8) | Re-read user prompt; if missing required field (model path / target dtype / output dir), make a best-effort default and continue. Cap self-correction at 2 tries. |
-| `analysis_artifact_invalid_or_missing` (#10) | Re-invoke `quark-ptq` Step 1. |
-| `plan_artifact_invalid_or_missing` (#11) | Re-invoke `quark-ptq` Step 2. |
-| `manifest_artifact_invalid_or_missing` (#12) | Re-invoke `quark-ptq` Step 3. |
+| `analysis_artifact_invalid_or_missing` (#10) | Re-invoke `quark-torch-ptq` Step 1. |
+| `plan_artifact_invalid_or_missing` (#11) | Re-invoke `quark-torch-ptq` Step 2. |
+| `manifest_artifact_invalid_or_missing` (#12) | Re-invoke `quark-torch-ptq` Step 3. |
 | `must_have_config_missing_or_invalid` (#14) | `cp <source_model>/config.json <quantized_model_dir>/`; if vLLM-required keys (`model_type`, `architectures`) are absent, copy them from source's config. Re-run validator Step 3. |
 | `must_have_tokenizer_missing` (#15) | `cp <source_model>/tokenizer*` to `<quantized_model_dir>/`. Re-run validator Step 1. |
 | `must_validate_config_mismatch` (#17) | Diff config.json source vs quantized after stripping `quantization_config`. Copy the missing/diverged business-field values from source into quantized. Re-run validator Step 3. |
 | `should_have_aux_missing` (#19) | `cp` missing auxiliary files (`special_tokens_map.json`, `generation_config.json`, `chat_template.jinja`) from source to quantized. Re-run validator Step 1. |
 | `nice_to_have_skipped` (#20) | Record a note (write a `## Notes` line at the bottom of `validation_report.md`); do not retry. |
 | `eval_env_unavailable` (#22) | Skip eval; write `<workspace>/eval_skipped.txt` with the reason. |
-| `validation_report_absent` (#25) | Re-invoke `quark-quantization-result-validator` once. |
+| `validation_report_absent` (#25) | Re-invoke `quark-torch-result-validator` once. |
 | `must_validate_skipped` (#27) | Leave as-is — the Python runner will demote per `HYPERLOOM_QUANT_STRICT_VALIDATION`. |
 | `eval_oom` (#29) | Switch eval to serial loading (close source engine before opening quantized). Retry once. If still OOM, write `eval_skipped.txt` with `oom`. |
 
@@ -255,13 +255,13 @@ You may write any of these files; the Python runner reads them:
 
 | File | Owner | Meaning |
 |---|---|---|
-| `session_context.json` | you (seed) → Quark may augment | Pre-seeded context handed to quark-ptq. |
-| `model_analysis.json`  | quark-ptq Step 1 | Source model structural analysis. |
-| `quant_plan.json`      | quark-ptq Step 2 | Resolved quant plan. |
-| `run_manifest.yaml`    | quark-ptq Step 3 | Includes `outputs.quantized_model_dir`. |
+| `session_context.json` | you (seed) → Quark may augment | Pre-seeded context handed to quark-torch-ptq. |
+| `model_analysis.json`  | quark-torch-ptq Step 1 | Source model structural analysis. |
+| `quant_plan.json`      | quark-torch-ptq Step 2 | Resolved quant plan. |
+| `run_manifest.yaml`    | quark-torch-ptq Step 3 | Includes `outputs.quantized_model_dir`. |
 | `validation_report.md` | quark validator  | Per-step ok / FAIL / skipped. |
-| `source_eval.md`       | quark-llm-eval (you) | Source model headline metrics. Cached across retries. |
-| `quantized_eval.md`    | quark-llm-eval (you) | Quantized model headline metrics. Re-run every attempt. |
+| `source_eval.md`       | quark-torch-llm-eval (you) | Source model headline metrics. Cached across retries. |
+| `quantized_eval.md`    | quark-torch-llm-eval (you) | Quantized model headline metrics. Re-run every attempt. |
 | `eval_report.json`     | you | Synthesized wrapper — see §5.3. |
 | `eval_gap_threshold.txt` | you (optional) | Per-prompt threshold override. |
 | `eval_skipped.txt`     | you | Reason eval bailed (#22 / #28 / #29). |

--- a/quantization_agent/__init__.py
+++ b/quantization_agent/__init__.py
@@ -1,0 +1,34 @@
+"""quantization_agent — Hyperloom sub-agent for AMD Quark PTQ.
+
+Single public entry: ``quantize_via_prompt`` (async). See
+``docs/DESIGN.zh-CN.md`` for the contract.
+"""
+
+from __future__ import annotations
+
+from .driver.assessment import Assessment
+from .driver.outcomes import (
+    ASK,
+    ASK_RETRYABLE,
+    AUTO_FAIL,
+    AUTO_RECOVER,
+    OutcomeId,
+    SUCCESS_TAGS,
+    UNCLASSIFIED_FAILURE,
+)
+from .driver.retry import QuantSkillRunResult, quantize_via_prompt, quantize_via_prompt_sync
+
+
+__all__ = [
+    "Assessment",
+    "ASK",
+    "ASK_RETRYABLE",
+    "AUTO_FAIL",
+    "AUTO_RECOVER",
+    "OutcomeId",
+    "QuantSkillRunResult",
+    "SUCCESS_TAGS",
+    "UNCLASSIFIED_FAILURE",
+    "quantize_via_prompt",
+    "quantize_via_prompt_sync",
+]

--- a/quantization_agent/cli.py
+++ b/quantization_agent/cli.py
@@ -1,0 +1,142 @@
+"""Standalone CLI for the quantization-agent.
+
+Lets you drive the Quark PTQ skill chain from a natural-language prompt
+without going through ``inference_optimizer``. The prompt is fed to the
+Claude Agent SDK, which loads ``quantization_agent/SKILL.md`` as the
+runtime contract and invokes the Quark skills end-to-end.
+
+Example::
+
+    python -m quantization_agent.cli \\
+        --prompt "把 Qwen/Qwen3-0.5B 量化成 fp8 (kv_cache 也 fp8, 排除 lm_head)" \\
+        --workspace /scratch/qwen3-0.5b-ws \\
+        --quark-root /scratch/kewang/workspace/Quark \\
+        --interactive off \\
+        --acceptable-eval-gap 0.03 \\
+        --max-requantize-attempts 1
+
+Exit codes:
+    0   success or partial (model usable; partial means audit/eval gap)
+    1   failed (model unusable or MUST-validate violation)
+    2   argparse / input validation error
+    3   operator-rejected checkpoint (interactive 'n' on retry / eval gap)
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from typing import Any
+
+from .driver.retry import quantize_via_prompt
+from .driver.runner import DEFAULT_MODEL
+
+
+def _interactive_value(raw: str) -> bool | None:
+    raw = raw.strip().lower()
+    if raw in ("auto", "", "default"):
+        return None
+    if raw in ("on", "true", "yes", "1"):
+        return True
+    if raw in ("off", "false", "no", "0"):
+        return False
+    raise argparse.ArgumentTypeError(
+        f"--interactive expects auto / on / off (got {raw!r})"
+    )
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="quantization_agent",
+        description="Drive the AMD Quark PTQ skill chain from a natural-language prompt.",
+    )
+    p.add_argument(
+        "--prompt",
+        required=True,
+        help="Natural-language description of what to quantize.",
+    )
+    p.add_argument(
+        "--workspace",
+        required=True,
+        help="Per-run scratch dir for session_context.json, manifest, reports, eval_report.json.",
+    )
+    p.add_argument(
+        "--quark-root",
+        default=None,
+        help="Quark repo root (defaults to $QUARK_ROOT).",
+    )
+    p.add_argument(
+        "--interactive",
+        type=_interactive_value,
+        default=None,
+        metavar="auto|on|off",
+        help="Checkpoint relay mode. 'auto' uses tty detection (default).",
+    )
+    p.add_argument(
+        "--acceptable-eval-gap",
+        type=float,
+        default=None,
+        metavar="FLOAT",
+        help="Max relative quality gap (e.g. 0.03 = 3%%). "
+        "Falls back to <workspace>/eval_gap_threshold.txt or 0.03 if unset.",
+    )
+    p.add_argument(
+        "--max-requantize-attempts",
+        type=int,
+        default=1,
+        metavar="N",
+        help="Upper bound on Python-driven retries for Ask-class outcomes "
+        "(#3/#6/#16/#26) and #30. Default 1.",
+    )
+    p.add_argument(
+        "--model-id",
+        default=None,
+        help=f"Override the Claude model id used by the SDK (default {DEFAULT_MODEL}).",
+    )
+    p.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Stream SDK output lines to stderr.",
+    )
+    return p.parse_args(argv)
+
+
+async def _run(args: argparse.Namespace) -> int:
+    def log(line: str) -> None:
+        if args.verbose:
+            print(line, file=sys.stderr, flush=True)
+
+    result = await quantize_via_prompt(
+        args.prompt,
+        workspace=args.workspace,
+        quark_root=args.quark_root,
+        interactive=args.interactive,
+        acceptable_eval_gap=args.acceptable_eval_gap,
+        max_requantize_attempts=args.max_requantize_attempts,
+        model=args.model_id,
+        log=log,
+    )
+
+    summary: dict[str, Any] = {
+        "status": result.status,
+        "quantized_model_dir": (
+            str(result.quantized_model_dir) if result.quantized_model_dir else None
+        ),
+        "assessment": result.assessment.to_dict(),
+    }
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+    if result.status == "failed":
+        return 1
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    return asyncio.run(_run(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/quantization_agent/docs/DESIGN.md
+++ b/quantization_agent/docs/DESIGN.md
@@ -1,0 +1,615 @@
+# quantization-agent — Architecture Design Specification
+
+## 0. Document Purpose and Background
+
+The goal: *"embed Quark as a sub-agent inside Hyperloom… and let the module
+also stand alone to quantize models on its own."*
+
+This agent is a **thin Hyperloom → Quark adapter**:
+
+- The sole entrypoint is the coroutine `quantize_via_prompt(prompt, ...)`,
+  which feeds a natural-language prompt to a Claude Agent SDK session.
+- The session loads Quark's three skills (`quark-torch-ptq` /
+  `quark-torch-result-validator` / `quark-torch-llm-eval`) and the
+  agent's own `SKILL.md` (runtime contract).
+- Translating natural language into a `quant_plan`, filling defaults,
+  and surfacing CRITICAL STOPs are all done by the Quark skills.
+- The agent does two things only: answer checkpoints per `SKILL.md`,
+  and scan the workspace to enforce the artifact contract.
+
+This document records the design's **structure, contracts, and trade-offs**;
+runtime behavior is authoritative in `../SKILL.md`.
+
+---
+
+## 1. How Hyperloom Invokes Quark
+
+```
+  Hyperloom side                            Quark side (read-only)
+  ┌────────────────────────────┐            ┌────────────────────────────┐
+  │  quantization-agent        │  prompt    │                            │
+  │  (thin adapter)            │ ─────────▶ │  quark-torch-ptq                 │
+  │                            │            │  quark-quantization-       │
+  │  · answer per SKILL.md     │ ◀──── ?    │       result-validator     │
+  │  · _result_collector        │  answer ─▶ │  quark-torch-llm-eval            │
+  │                            │            │                            │
+  │                            │ ◀───────── │  artifacts + reports       │
+  └────────────────────────────┘            └────────────────────────────┘
+```
+
+The three arrows are: ① the initial prompt; ② Quark's three CRITICAL
+STOPs plus the warning checkpoints SKILL.md may raise (answered per
+SKILL.md: auto → default → escalate to operator); ③ artifacts and
+reports written to disk after Quark finishes. Quark stays read-only;
+all workflow logic lives in the Quark repo.
+
+---
+
+## 2. Agent Internal Invocation Flow
+
+```
+   caller
+     │  prompt
+     ▼
+   quantize_via_prompt
+     │
+     ▼
+   ┌──────────────────────────────────────────────────┐
+   │  Claude Agent SDK session (cwd = workspace)      │
+   │    loads  : quantization-agent/SKILL.md          │
+   │             + quark-torch-ptq / validator / llm-eval   │
+   │    runs   : Intake → Plan → Manifest →           │
+   │             Execute → Validate → (Eval)          │
+   │    answers: checkpoints per SKILL.md             │
+   └──────────────────────────────────────────────────┘
+     │  artifacts on disk
+     ▼
+   _result_collector             ──  artifact-presence-as-truth
+     │
+     ▼
+   QuantSkillRunResult
+```
+
+Only two layers of deterministic code remain, plus one runtime contract:
+
+| Module | Responsibility |
+|---|---|
+| `quantize_via_prompt` | Coroutine entrypoint: open SDK session, hand the prompt to the Quark skills, collect results |
+| `SKILL.md` (runtime contract) | Loaded by the SDK; dictates checkpoint-answering protocol, `acceptable_eval_gap` default, artifact naming |
+| `_result_collector` | Scans workspace artifacts and classifies the run as `success` / `partial` / `failed` |
+
+Verdict does not depend on the SDK exit code; it is derived from on-disk artifacts in two layers:
+
+1. **Presence** — contract artifacts are all there (decides `failed` vs `partial`/`success`).
+2. **Content parse** — `validation_report.md` per-step `ok` / `FAIL` / `skipped` (decides whether `partial` escalates to `failed`; full tier rules in §5.4).
+
+---
+
+## 3. Agent Input/Output Specification
+
+The agent exposes a single coroutine entry point — `quantize_via_prompt`. A
+minimal call:
+
+```python
+from quantization_agent import quantize_via_prompt
+
+result = await quantize_via_prompt(
+    "Quantize Qwen/Qwen3-8B with mxfp4; self-attention and kv-cache as fp8; "
+    "exclude lm_head; write to /scratch/qwen3-8b-mxfp4",
+    workspace="/tmp/wks-xxx",
+)
+print(result.run_result.status, result.run_result.quantized_model_dir)
+```
+
+The input is a **natural-language prompt**. The translation from natural
+language to `quant_plan` and the filling of defaults are done entirely
+inside Quark `quark-torch-ptq` at the Plan checkpoint (the user confirms or
+amends it there).
+
+### 3.1 Input Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `prompt` | str | ✅ | Natural-language quantization request; must contain at least the model, output dir, and a rough scheme |
+| `workspace` | str \| Path | ✅ | Working directory for intermediate artifacts; also the Quark workflow's cwd |
+| `quark_root` | str \| Path \| None | — | Explicit Quark checkout; otherwise auto-discovered via `$QUARK_ROOT` → `/scratch/kewang/workspace/Quark` |
+| `interactive` | bool \| None | — | Whether to allow stdin escalation (CRITICAL STOP answers). `None` = auto-detect a tty |
+| `acceptable_eval_gap` | float \| None | — | Acceptable numerical eval gap (default `0.03`). Anything larger triggers a warning checkpoint. Equivalently expressible in the prompt ("accept 5% gap"); priority rules in §5.2 |
+| `max_requantize_attempts` | int | — | Retry cap for Ask-class failures (#3 / #6 / #16 / #26 in §A), default `1`. Set to `0` to fail-fast (no retry); raise it to let the agent try more times (useful when inference_optimizer wants to manage a global retry budget). Bounded by the persistent counter `<workspace>/requantize_attempts.txt` |
+
+**Prompt example** (covering common fields — users only need to write
+the bits they care about; anything omitted is filled with defaults by the
+Quark skill):
+
+```
+Quantize /scratch/models/Qwen3-30B-A3B with mxfp4:
+- self-attention as fp8
+- kv-cache as fp8; exclude lm_head
+- calibrate with pileval, 128 samples, seq_len 512
+- export HF format; evaluation accepts 5% gap
+- write to /scratch/qwen3-30b-mxfp4
+```
+
+Quark turns the prompt into a `quant_plan` at the Plan checkpoint and
+asks the operator to confirm. See §4 for the scheme vocabulary the
+prompt may use.
+
+### 3.2 Return Structure
+
+`QuantSkillRunResult` exposes 3 fields. Anything else (audit detail,
+raw scores, traceback strings, artifact paths) stays in logs or
+fixed-name files inside `<workspace>` — it does not pollute the return
+value.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `status` | str | `success` / `partial` / `failed` (semantics below) |
+| `quantized_model_dir` | Path \| None | Quantized result directory on `success` / `partial`; `None` on `failed` |
+| `assessment` | `Assessment` | Primary outcome + the full per-attempt trail (structure below) |
+
+`Assessment` fuses four facts the caller would otherwise have to dig out of
+logs — *which outcome class this call landed in, how many attempts it took,
+whether a retry rescued an earlier failure, and the one numeric we care
+about* — into a single object:
+
+```python
+@dataclass
+class Assessment:
+    final:     str | None              # final primary outcome class ID (row name in Appendix §A); None for a clean one-shot success
+    attempts:  list[str | None]        # per-attempt outcome class IDs, in chronological order; len = number of pipeline runs performed
+    recovered: bool                    # True iff some earlier attempt failed but a later retry succeeded
+                                       # (i.e. attempts has a failure ID before a final None / success tag)
+    eval_gap:  float | None = None     # eval-stage relative_gap value; populated only when final ∈ {eval_gap_exceeded, eval_gap_accepted}
+```
+
+Field semantics:
+
+- **`final`** — the headline outcome the caller acts on. On `failed` /
+  `partial` it is the root cause (`exec_oom`, `checkpoint_aborted`,
+  `eval_gap_exceeded`, `upstream_change_required`,
+  `unclassified_failure`, …). On `success` "with a story" it is the
+  narrative tag (e.g. `eval_gap_accepted`). On a clean success it is
+  `None`. Full enumeration in Appendix §A.
+- **`attempts`** — the outcome ID of each full pipeline run
+  (Intake → Execute → Validate → Eval), oldest first. `len(attempts) - 1`
+  is the number of extra retries actually performed (bounded by §3.1
+  `max_requantize_attempts`).
+- **`recovered`** — whether the diagnose-fix-retry loop did real work for
+  this call. Callers typically use it to filter "do I need a human to
+  look at this run later?".
+- **`eval_gap`** — the only numeric we currently surface in the return
+  value, pulled into the struct so callers do not have to parse
+  `<workspace>/eval_report.json`. `None` for every outcome other than
+  the two eval-gap classes.
+
+Typical shapes:
+
+| Scenario | `final` | `attempts` | `recovered` | `eval_gap` |
+|---|---|---|---|---|
+| Clean one-shot success | `None` | `[None]` | `False` | `None` |
+| First attempt OOM, retry succeeded | `None` | `["exec_oom", None]` | `True` | `None` |
+| Two attempts, both OOM | `"exec_oom"` | `["exec_oom", "exec_oom"]` | `False` | `None` |
+| Over threshold, non-interactive → partial | `"eval_gap_exceeded"` | `["eval_gap_exceeded"]` | `False` | `0.052` |
+| Over threshold, operator accepted | `"eval_gap_accepted"` | `["eval_gap_accepted"]` | `False` | `0.041` |
+
+If the caller needs artifact paths, build them directly from the §3.3
+outbound contract's fixed names: `workspace / "validation_report.md"`,
+`workspace / "eval_report.json"`, etc. — and use `Path.exists()` to
+probe presence. Keeping the path layout knowledge on the caller side
+means the agent can reshape its workspace without breaking caller
+reporting fields.
+
+**`status` semantics** (full tier definitions in §5.4):
+
+| status | Meaning | How the caller should react |
+|---|---|---|
+| `success` | All artifacts present + every MUST-validate step ok | Hand `quantized_model_dir` to the downstream step; record `assessment.final` if non-null (e.g. `eval_gap_accepted`) for audit |
+| `partial` | Model is loadable but audit / eval artifacts missing or warned | Check `assessment.final` to decide whether to accept |
+| `failed` | Model missing or MUST-validate failed | Treat as failure; `assessment.final` is the root cause |
+
+### 3.3 Internal Contracts (with Quark)
+
+The agent maintains **one inbound and one outbound contract** with Quark:
+
+- **Hyperloom → Quark**: send the user prompt as the first SDK session
+  message. Quark's three CRITICAL STOP checkpoints are answered per the
+  SKILL.md protocol (auto / default / escalate). Optionally write
+  `session_context.json` as an audit trace.
+- **Quark → Hyperloom**: artifact list is
+  `session_context.json` / `model_analysis.json` / `quant_plan.json` /
+  `run_manifest.yaml` / `<output_dir>/{config.json, *.safetensors, tokenizer*}` /
+  `validation_report.md`; when §5.2 evaluation is enabled, `eval_report.md`
+  is added. `_result_collector` scans for these and classifies `status`.
+
+---
+
+## 4. Scheme Vocabulary Reference
+
+The prompt is free text; Quark `quark-torch-ptq` translates it into a valid
+`quant_plan` and gets user confirmation at the Plan checkpoint. This
+section is a **reference list of the terms commonly used when writing
+prompts**. **The authoritative definitions live in Quark
+`quark-llm-ptq-workflow/SKILL.md` and `quant_plan.schema.json`.**
+
+### 4.1 Common Scheme Terms
+
+| Term | Meaning | Applicable modules |
+|---|---|---|
+| `fp8` | 8-bit float (E4M3) | weight / activation / kv_cache |
+| `mxfp4` | OCP MX 4-bit float | weight / activation (mostly MoE/MLP) |
+| `int8` / `int4` | integer quantization | weight |
+| `awq` / `gptq` / `smoothquant` | algorithms (not dtypes) | combine with `int*`/`fp8` |
+| `none` / unspecified | module keeps its original dtype (bf16/fp16) | any |
+
+### 4.2 Module Names Commonly Referenced
+
+Prompts can simply say "self-attention", "MoE experts", "plain MLP",
+"kv-cache", "lm_head" — Quark maps these to `attention_scheme`,
+`layer_overrides[".*\.experts\..*"]`,
+`layer_overrides[".*\.mlp\.(?!experts\.|shared_expert).*"]`,
+`kv_cache_scheme`, and `exclude_layers` respectively. You do **not** need
+to write regexes in the prompt.
+
+### 4.3 Known Constraints
+
+- `kv_cache` is only accepted as `fp8` (or unset) in the currently
+  shipped `quark-llm-ptq-workflow` examples and `quantize_quark.py`. Other
+  values are rejected at the Plan checkpoint.
+- If the prompt names a module/scheme combination Quark does not support,
+  the Plan checkpoint will list the reasons and ask for changes.
+
+### 4.4 Defaults
+
+Fields the user doesn't mention in the prompt (calibration samples,
+sequence length, export format, evaluation_intent, …) are filled in by
+the Quark `quark-torch-ptq` skill inside the Plan checkpoint and shown to the
+operator for confirmation.
+
+---
+
+## 5. Post-Quantization Validation and Evaluation
+
+This chapter follows "what we check → how it propagates → how we gate":
+
+- §5.1 **Structural validation** — four byte-level sanity checks
+- §5.2 **Accuracy evaluation** — source vs quantized PPL/accuracy comparison
+- §5.3 **Failure propagation** — how validation outcomes become `status` and process exits
+- §5.4 **Gating policy + recovery** — artifact tiers, recovery matrix, retry cap
+
+### 5.1 Structural Validation
+
+After Execute, SKILL.md instructs the SDK to invoke Quark's
+`quark-torch-result-validator` skill in cost order
+**4 → 1 → 3 → 2** against `source_model_dir = model_path` and
+`quantized_model_dir = output_dir`, writing `<workspace>/validation_report.md`.
+
+| # | Subcommand | What it proves |
+|---|---|---|
+| 4 | `fuzzy` | Per-pattern `dtype_counts`; mixed dtypes inside one pattern flag layers not quantized as planned |
+| 1 | `auxiliary` | tokenizer / generation_config / etc. carried over; no missing / mismatched / extra |
+| 3 | `config` | `config.json` deep-equal after stripping `quantization_config` keys |
+| 2 | `md5` | Byte-identical MD5 spot-check on `exclude_layers` tensors |
+
+These are **structural / byte-level** checks only — they do not measure
+numerical quality (perplexity, accuracy).
+
+### 5.2 Accuracy Evaluation
+
+§5.1 covers only structural sanity; this section is the **accuracy-layer**
+check — compare the source model against the quantized model on the same
+test set, and surface a confirmation request when the gap exceeds the
+threshold.
+
+**Mechanism**
+
+- After Validate, SKILL.md appends a prompt segment that invokes the Quark
+  `quark-torch-llm-eval` skill.
+- The skill uses **whichever inference backend — vLLM or SGLang — is
+  already installed in the current environment** (selected by the skill
+  per availability; preference order in `quark-torch-llm-eval/SKILL.md`), spins
+  up two offline engines (source + quantized), and runs the same test set
+  (default: PPL on wikitext-2 + small gsm8k sample). **The skill performs
+  no `pip install`** — missing backends surface as `eval_env_unavailable`
+  (see Appendix §A.8) for the caller to handle at the SHOULD-have tier.
+- Output lands at `<workspace>/eval_report.md` and `eval_report.json`; the
+  latter carries `source_score` / `quantized_score` / `relative_gap`.
+
+**Gap threshold**
+
+`acceptable_eval_gap` is resolved in priority order (highest first):
+
+1. **Python argument** — explicit `quantize_via_prompt(..., acceptable_eval_gap=)`
+2. **Prompt declaration** — user writes "accept 5% gap" etc. in the prompt
+3. **SKILL.md default** — `0.03` (relative gap 3%)
+
+When the caller passes the Python argument, it wins outright; prompt and SKILL.md are not consulted.
+
+**Decision rules**
+
+| Relative gap | Operator response | status | Notes |
+|---|---|---|---|
+| `≤ threshold` | — | `success` | passes through |
+| `> threshold` | `y` | `success` | `assessment.final=eval_gap_accepted` |
+| `> threshold` | `n` | `failed` | explicit rejection is an error |
+| `> threshold` | non-interactive | `partial` | `assessment.final=eval_gap_exceeded`; upstream gating decides |
+
+When the gap is exceeded, SKILL.md prints the gap / per-metric / threshold to stderr before asking y/n.
+
+**Eval-failure fallbacks** — when eval cannot even produce a gap (distinct from "gap exceeded"; full enumeration in Appendix §A.8):
+
+| Failure | Trigger | Handling |
+|---|---|---|
+| `quantized_load_failed` | vLLM/SGLang cannot load the quantized model | escalate to MUST-validate `failed` (downstream cannot serve it either) |
+| `eval_oom` | source + quantized exceed VRAM together | retry serial-load; still OOM → `partial` + `assessment.final=eval_oom` |
+| `eval_env_unavailable` | neither vLLM nor SGLang installed, or test set missing | `partial` + `assessment.final=eval_skipped`; not a blocker |
+
+**Result-collector behavior**
+
+- `eval_report.md` / `eval_report.json` belong to the SHOULD-have tier (§5.4)
+  — absence is a warning only, not a blocker.
+- The caller can read the raw `relative_gap` straight off
+  `assessment.eval_gap` (the agent already pulls it from
+  `<workspace>/eval_report.json`). The agent also encodes the threshold
+  decision into `assessment.final`: `eval_gap_exceeded` when over
+  threshold in non-interactive mode (status=`partial`), or
+  `eval_gap_accepted` when the operator accepted it (status=`success`).
+
+### 5.3 Failure Propagation to inference_optimizer
+
+§5.1 / §5.2 give "pass or fail"; this section gives "once it has failed, how the signal leaves the agent". The outcome reaches inference_optimizer through four layers:
+
+| Layer | Produces | Signal to the next layer |
+|---|---|---|
+| `quark-torch-result-validator` / `quark-torch-llm-eval` | `validation_report.md` / `eval_report.json` | Per-step `ok` / `FAIL` / `skipped`; `relative_gap` |
+| `_result_collector.collect_artifacts` + `_assessment.classify_attempt` + `_assessment.derive_status` | `QuantSkillRunResult` | `status ∈ {success, partial, failed}` + `assessment.final` (validation_report per-step state parsed per §5.4, then collapsed into the primary outcome ID) |
+| `quantization_request_handlers.py` (prelude adapter) | payload dict | `success` → `status="ok"`; `partial` → tiered ok / failed per §5.4; `failed` → `status="failed"` |
+| `_run_quantization_prelude` | process exit / `args.model` rewrite | `SystemExit(3)` if `status != "ok"`; otherwise continue with `quantized_model_dir` |
+
+The adapter uses §5.4's tier classification to decide ok vs failed:
+
+| QuantRunResult.status | Trigger | adapter status | inference_optimizer behavior |
+|---|---|---|---|
+| `success` | Artifacts present + every MUST-validate step ok | `ok` | Proceed; `args.model` ← `quantized_model_dir` |
+| `partial` (SHOULD/NICE missing) | Model loads, MUST-validate ok, only audit / eval missing | `ok` | Continue; payload carries `quant_status="partial"` |
+| `partial` (MUST-validate FAIL/SKIPPED) | md5 / config FAIL, or SKIPPED under STRICT | `failed` | `SystemExit(3)` |
+| `failed` | `run_manifest.yaml` or quantized weights missing | `failed` | `SystemExit(3)`; stderr prints `assessment.final` |
+
+Early failures (`workspace_unwritable` / `quark_root_missing` / `sdk_runtime_error` / `checkpoint_aborted` etc. — full enumeration in Appendix §A.1 / §A.9) also produce `status="failed"` with a specific `assessment.final` and `SystemExit(3)`.
+
+> **`SystemExit(3)` ownership**: raised by `_run_quantization_prelude` in `inference_optimizer/cli.py`. Direct `quantize_via_prompt` callers (orchestrator handler, tests, ad-hoc Python drivers) never see a process exit — they get a `QuantSkillRunResult` and dispatch on `status` themselves.
+
+### 5.4 Gating Policy and Failure Recovery
+
+The table below tiers artifacts by what downstream actually needs, with an explicit gating action per tier:
+
+| Tier | Contents | Consequence if missing | Gating |
+|---|---|---|---|
+| **MUST-have** (load) | `config.json`, `*.safetensors`/`*.bin` (+ `model.safetensors.index.json` when sharded), `tokenizer*` | vLLM cannot load | abort |
+| **MUST-validate** (correctness) | validation_report Step 3 config + Step 2 md5 = ok | model loads but results lie | FAIL → abort; SKIPPED → abort by default, `HYPERLOOM_QUANT_STRICT_VALIDATION=0` downgrades to warn |
+| **SHOULD-have** (cheaply patchable) | validation_report exists + Step 1/4 ok; `model_analysis.json` / `quant_plan.json` / `run_manifest.yaml` | hard-contract violation but recoverable in seconds | FAIL → run the recovery matrix (patch + re-run validator) |
+| **NICE-to-have** | `session_context.json` | harmless | warn |
+
+> **Tier semantics**: tiers classify *which recovery path a violation takes*, not "how important the file is". Step 1 auxiliary enforces a hard contract — **"any non-weight file present in the source must be present in the quantized output"** (covers `special_tokens_map.json` / `generation_config.json` / `chat_template.jinja` etc.). It sits in SHOULD-have not because failure is acceptable, but because the fix path is "`cp` from source + re-run Step 1" (seconds) — not worth aborting an already-completed 30-minute quantization. SKIPPED is the only state that drops to warn.
+
+**Failure handling overview** — after `_result_collector` parses the artifacts, SKILL.md's checkpoint protocol drives the LLM per Appendix §A's classification:
+
+- **Auto-recover** (13 rows in §A.10): LLM patches files / re-runs the validator / fixes the plan inside the sandbox — **no human interruption**.
+- **Auto-fail** (10 rows): environment-hard errors or semantic violations — immediate `failed`, no retry (retry is meaningless).
+- **Ask** (6 rows): decision points. `interactive=True` asks the operator; `interactive=False` **auto-retries** for 4 of them (#3 / #6 / #16 / #26) using the SKILL.md `Recovery` fix hypothesis, and immediately classifies the other two (#2 lacks user info, #21 is an acceptance decision).
+- **Catch-all #30 `unclassified_failure`**: any failure not in rows 1–29 is routed through #30, where the agent diagnoses at runtime (logs + SKILL.md Recovery + stage context) and auto-routes to one of the three categories above. Details in §A.9.
+
+**Diagnose before retry**: every retry-eligible row (Ask-class + #30) must emit a concrete, executable fix hypothesis before quark-torch-ptq is re-invoked, and any patch must stay inside `<workspace>` / agent-controlled state; **no file under `quark_root` may be modified** (Quark is treated as an immutable upstream). Full flow in §A.10.
+
+Per-failure recovery actions and retry triggers are documented in Appendix §A.1–§A.9.
+
+**Re-quantization cap**: controlled by the §3.1 input parameter `max_requantize_attempts` (default `1`); applies only to Ask-class #3/#6/#16/#26, bounded by the persistent counter `<workspace>/requantize_attempts.txt`.
+
+| Mode | Behavior before retry | Counter behavior |
+|---|---|---|
+| `interactive=False` (CI) | Skip confirmation; classify as `failed` once cap is reached | Counter increments; stops at `max_requantize_attempts` |
+| `interactive=True` (operator present) | Print the fix hypothesis on stderr and ask the operator `y/n` before retrying | Same; operator decline → `SystemExit(3)` |
+
+**Caller override**: inference_optimizer can pass `max_requantize_attempts=0` to make the agent classify immediately (useful when the global retry budget has already been spent), or raise it to allow more attempts. **The Auto-recover category (13 rows) is not affected by this parameter** — those are sub-second actions inside the same SDK session and do not count against the Ask-class counter.
+
+Principle: blind retry just reproduces the failure; "retry only when SKILL.md provides a fix hypothesis" binds each retry to an explicit fix. CI can neither burn two 30-minute jobs blindly nor lose recoverable output to transient errors.
+
+---
+
+## 6. Operator-Confirmation Checkpoints (Summary)
+
+The deterministic boundary is pushed down to a minimum; the cost is that
+"should we keep going?" decisions get delegated to the operator. This
+section enumerates **every point in the design that asks the operator
+for y/n, prompt amendment, or exit confirmation** — so ops can plan
+staffing and CI can be configured to never block.
+
+| # | Checkpoint | Source | Trigger | Auto-skip | Decline effect |
+|---|---|---|---|---|---|
+| 1 | Intake CRITICAL STOP | Quark `quark-torch-ptq` | parsed model structure shown for confirmation | prompt says "accept Intake defaults" + `interactive=False` | `failed`, `assessment.final=checkpoint_aborted` |
+| 2 | Plan CRITICAL STOP | Quark `quark-torch-ptq` | natural-language → `quant_plan` translation shown for confirmation | prompt says "execute generated plan"; `interactive=False` auto-accepts | same as above |
+| 3 | Manifest CRITICAL STOP | Quark `quark-torch-ptq` | run_manifest shown before execute | prompt says "accept default manifest"; `interactive=False` auto-accepts | same as above |
+| 4 | Eval gap warning (§5.2) | SKILL.md | relative gap > `acceptable_eval_gap` (default 3%) | raise `acceptable_eval_gap` or declare in prompt | `n` → `failed`; non-interactive → `partial` + `eval_gap_exceeded` |
+| 5 | Requantize warning (§A.10) | SKILL.md | Ask-class #3/#6/#16/#26 and catch-all #30 — confirmation **after diagnosis + fix hypothesis**, before re-invoking quark-torch-ptq | `interactive=False` skips confirmation and the counter auto-retries (bounded by §3.1 `max_requantize_attempts`); diagnosis yielding no hypothesis → no retry, immediate `failed` | `n` → `SystemExit(3)`, root cause + fix hypothesis summary on stderr |
+
+**Semantics of `interactive`**: `quantize_via_prompt(..., interactive=...)`
+is the **only** knob that decides whether checkpoints 1–5 may escalate
+to stdin. `None` (default) auto-detects a tty; `True` forces stdin on;
+`False` forces the "non-interactive fallback strategy" written into
+SKILL.md (essentially "follow what the prompt or defaults say; otherwise
+decline"). Auto-fail failures (§A.10) exit directly and never hit a checkpoint.
+
+**MUST-validate SKIPPED is not a checkpoint**: the §5.4 abort / warn branch is decided by `HYPERLOOM_QUANT_STRICT_VALIDATION` at result-collector time — no runtime y/n. CI sets it once at deployment.
+
+**Recommended CI recipe**: `interactive=False` + the prompt spells out
+all Intake/Plan/Manifest choices + `acceptable_eval_gap` either set large
+or declared explicitly in the prompt + `HYPERLOOM_QUANT_STRICT_VALIDATION`
+left at default. With this, only genuinely fatal errors will halt a run
+— nothing will sit waiting for a human at a checkpoint.
+
+---
+
+## 7. Agent Positioning and Differences vs Other Agents
+
+quantization-agent is a **one-shot prelude before the reactor loop**: called once by `inference_optimizer/cli.py::_run_quantization_prelude` when `--quantize "<prompt>"` is set, invokes `quantize_via_prompt`, returns `quantized_model_dir`, writes it back to `args.model`, then exits. It does not participate in any subsequent tick.
+
+```
+   User CLI               quantization-agent        Coordinator         reactor loop
+   --quantize "<prompt>" ──►  (one-shot)       ──►  (bootstrap)    ──►  re-invoked per tick
+                             returns quantized_model_dir                orchestration / kernel
+                             rewrites args.model                        critic / robustness
+```
+
+Compared with reactor-loop agents:
+
+| Dimension | Reactor-loop agents | quantization-agent |
+|---|---|---|
+| Examples | `orchestration` / `kernel` / `critic` / `robustness` | this agent |
+| Lifecycle | Re-invoked every tick | Called once before the loop boots |
+| Output channel | `emit_intent` → PolicyGate → dispatch | Returns a Python `dict` directly to the caller |
+| Registered in `AgentRole` | ✅ | ❌ |
+
+---
+
+## 8. Read-Only Guarantees on the Quark Repository
+
+The agent treats the Quark repo as strictly read-only: `quantization-agent/SKILL.md` and the Quark workflow SKILL.md files both forbid edits to `quark/`, `examples/`, `tools/`, `docs/`, `tests/`, `pyproject.toml`, `requirements.txt`. Any custom script (new flag, new model template) is written under `<workspace>/` and referenced from `run_manifest.yaml`, so reproducibility against a clean Quark install is preserved.
+
+---
+
+## 9. References and Related Materials
+
+- `quantization-agent/SKILL.md` — **runtime contract**: checkpoint-answering protocol, Quark skill invocation order, eval gap threshold
+- `quantization-agent/__init__.py` — exports the `quantize_via_prompt` coroutine entrypoint
+- `quantization_agent/_result_collector.py` — artifact harvest (the deterministic boundary)
+- `inference_optimizer/orchestrator/quantization_request_handlers.py` — programmatic dispatch (the `quantize_via_prompt` adapter shim)
+- `inference_optimizer/cli.py::_run_quantization_prelude` — `--quantize "<prompt>"` pre-hook
+- Quark `quark-torch-ptq/SKILL.md` — PTQ workflow contract this agent drives
+- Quark `quark-torch-result-validator/SKILL.md` — the four structural checks invoked in §5.1
+- Quark `quark-torch-llm-eval/SKILL.md` — accuracy evaluation skill invoked in §5.2
+- `kernel-agent/tools/tracelens_skill_runner.py` — the architectural template
+
+---
+
+## Appendix A. Failure-Handling Matrix (by stage)
+
+This appendix enumerates every failure quantization-agent may surface across the pipeline, with each row's **category** (Auto-recover / Auto-fail / Ask), **specific description**, and **CI / interactive behavior**. Principles:
+
+- **Auto-recover** — LLM self-heals inside the sandbox; no human disturbance.
+- **Auto-fail** — unfixable or retry-useless; immediately `failed`.
+- **Ask** — decision point. CI auto-retries (only when SKILL.md `Recovery` provides a fix hypothesis and the LLM has written out a concrete fix action); interactive mode asks the user. Retry budget is controlled by the §3.1 input parameter `max_requantize_attempts` (default `1`) and persisted in `<workspace>/requantize_attempts.txt` — exceeding it means immediate `failed`.
+- **Catch-all #30** — any failure not in rows 1–29 lands on #30, where the agent diagnoses at runtime and maps it to one of the three categories above.
+
+**Universal constraint**: every retry must be preceded by a diagnostic pass that produces a **concrete** fix hypothesis; **patches may only touch files inside `<workspace>` — never under `quark_root`** (Quark is treated as an immutable upstream so shared checkouts stay clean). Full flow in §A.10.
+
+### A.1 Stage 1 · Pre (preflight)
+
+| # | Failure | Category | Specific description | CI=False | interactive=True |
+|---|---------|----------|---------------------|----------|------------------|
+| 1 | `quark_root_missing` | Auto-fail | `quark_root` path doesn't exist / unreadable / not a git checkout; probed once at startup | immediate **failed** | immediate **failed** |
+| 7 | `quark_skill_unavailable` | Auto-fail | Any of `quark_root/.claude/skills/{quark-torch-ptq,validator,llm-eval}/SKILL.md` missing or registration fails | immediate **failed** | immediate **failed** |
+| 8 | `intent_parse_failed` | Auto-recover | LLM cannot produce a valid `hyperloom_quant_intent` from the prompt: missing model_path / target_dtype / output_dir, or type errors | LLM self-corrects ≤2 times; still fails → **failed** | After 2 self-correct attempts, asks user to amend prompt |
+| 23 | `workspace_unwritable` | Auto-fail | `workspace` path cannot be mkdir-ed, or exists but `os.access(W_OK)=False`; probed via touch in Pre to avoid a 30-minute quant exposing it later | immediate **failed** (with the specific PermissionError) | immediate **failed** |
+
+### A.2 Stage 2 · Intake (quark-torch-ptq Step 1)
+
+| # | Failure | Category | Specific description | CI=False | interactive=True |
+|---|---------|----------|---------------------|----------|------------------|
+| 9 | `model_path_unreachable` | Auto-fail | quark-torch-ptq Step 1 tries to load source model but `model_path` is unreachable / unreadable / lacks `config.json` | immediate **failed** | immediate **failed** |
+| 10 | `analysis_artifact_invalid_or_missing` | Auto-recover | `model_analysis.json` not produced, or schema-invalid / JSON-corrupt | LLM re-runs Step 1 → continue | same |
+
+### A.3 Stage 3 · Plan (quark-torch-ptq Step 2)
+
+| # | Failure | Category | Specific description | CI=False | interactive=True |
+|---|---------|----------|---------------------|----------|------------------|
+| 2 | `checkpoint_aborted` | Ask | Any Intake/Plan/Manifest CRITICAL STOP triggered without a "accept default" line in the prompt under non-interactive mode | If prompt declares defaults → auto-accept; else **failed** (missing info, retry pointless) | Ask user to accept / rewrite prompt |
+| 11 | `plan_artifact_invalid_or_missing` | Auto-recover | `quant_plan.json` missing or fails schema (scheme not in whitelist, layer_overrides regex invalid, etc.) | LLM re-runs Step 2 → continue | same |
+
+### A.4 Stage 4 · Manifest (quark-torch-ptq Step 3)
+
+| # | Failure | Category | Specific description | CI=False | interactive=True |
+|---|---------|----------|---------------------|----------|------------------|
+| 12 | `manifest_artifact_invalid_or_missing` | Auto-recover | `run_manifest.yaml` missing, or parsed but lacks `outputs.quantized_model_dir` | LLM re-runs Step 3 → continue | same |
+
+### A.5 Stage 5 · Exec (quark-torch-ptq Step 4a, PTQ compute)
+
+| # | Failure | Category | Specific description | CI=False | interactive=True |
+|---|---------|----------|---------------------|----------|------------------|
+| 3 | `exec_oom` | Ask | quark-torch-ptq Step 4a OOMs during PTQ; root causes: batch too large / seq_len too long / kv_cache quant flag | LLM reduces batch/seq_len + auto-retry once → success / **failed** | same + confirm params before retry |
+| 4 | `exec_model_load_failed` | Auto-fail | Exec-stage source model load fails (distinct from #9: path exists but weights corrupted / dtype unsupported / transformers missing) | immediate **failed** | immediate **failed** |
+| 5 | `exec_calibration_data_missing` | Auto-fail | calibration dataset (pileval / wikitext / custom) unreachable or sample count 0 | immediate **failed** | immediate **failed** |
+
+### A.6 Stage 6 · Export (quark-torch-ptq Step 4b, writing to disk)
+
+| # | Failure | Category | Specific description | CI=False | interactive=True |
+|---|---------|----------|---------------------|----------|------------------|
+| 6 | `export_crashed` | Ask | Step 4b crashes while serializing quantized state_dict → safetensors; common causes: disk full / NFS jitter / temp-file contention / config write conflict | LLM auto-retries once → success / **failed** | same + confirm before retry |
+
+### A.7 Stage 7 · Validate (quark-torch-result-validator)
+
+| # | Failure | Category | Specific description | CI=False | interactive=True |
+|---|---------|----------|---------------------|----------|------------------|
+| 13 | `validator_self_test_failed` | Auto-fail | `run_validation.py self-test` exits non-zero; Quark validation script broken or import errors | immediate **failed** | immediate **failed** |
+| 14 | `must_have_config_missing_or_invalid` | Auto-recover | `<quantized_dir>/config.json` missing or JSON-corrupt, or lacking vLLM-required core fields (`model_type` / `architectures`) | LLM copies from source + restores `quantization_config` → re-run Step 3 → continue | same |
+| 15 | `must_have_tokenizer_missing` | Auto-recover | `tokenizer.json` / `tokenizer_config.json` or other required tokenizer files missing | LLM `cp`s the full tokenizer set from source → re-run Step 1 → continue | same |
+| 16 | `must_have_weights_missing` | Ask | No `*.safetensors` / `*.bin` under `<quantized_dir>`; Step 4 produced no weights | LLM auto-retries once → success / **failed** | same + confirm before retry |
+| 17 | `must_validate_config_mismatch` | Auto-recover | Step 3 `config` FAIL: after stripping `quantization_config`, non-quant fields still differ | LLM fixes fields (whitelist additions / business-field copy-over from source) → re-run Step 3 → continue | same |
+| 18 | `must_validate_md5_mismatch` | Auto-fail | Step 2 `md5` FAIL: tensors named in `exclude_layers` show byte-level MD5 diff from source — **promised untouched yet touched** | immediate **failed** (semantic violation) | immediate **failed** |
+| 19 | `should_have_aux_missing` | Auto-recover | Step 1 `auxiliary` FAIL: non-weight files present in source but missing in quantized dir (`special_tokens_map.json` / `generation_config.json` / `chat_template.jinja`, etc.) | LLM `cp`s missing files → re-run Step 1 → continue | same |
+| 20 | `nice_to_have_skipped` | Auto-recover | PyYAML missing causing manifest-parse degrade; or `session_context.json` missing — artifacts that don't affect downstream | record note → continue success | same |
+| 25 | `validation_report_absent` | Auto-recover | `validation_report.md` not produced at all — validator wasn't called by SKILL.md, or the call crashed entirely; distinct from "produced but some step FAILed" | LLM invokes `quark-torch-result-validator` once → continue | same |
+| 26 | `fuzzy_check_failed` | Ask | Step 4 `fuzzy` FAIL: same pattern shows mixed dtypes, or safetensors header anomalies; mostly plan errors (mixed precision), rarely file corruption | LLM cross-checks `model_analysis.json` to fix plan + auto-retries once → success / **failed** | same + confirm before retry |
+| 27 | `must_validate_skipped` | Auto-recover | Step 2 md5 or Step 3 config SKIPPED due to environment (source unreachable, quant_config has no exclude, etc.) — **distinct from FAIL**: unproven ≠ violated | `HYPERLOOM_QUANT_STRICT_VALIDATION=1` (default) → **failed**; `=0` → partial + warning | same (one-time env var decides) |
+
+### A.8 Stage 8 · Eval (quark-torch-llm-eval)
+
+| # | Failure | Category | Specific description | CI=False | interactive=True |
+|---|---------|----------|---------------------|----------|------------------|
+| 21 | `eval_gap_exceeded` | Ask | quark-torch-llm-eval finishes with `relative_gap > acceptable_eval_gap` — acceptance decision, not retryable | auto → **partial** + `eval_gap_exceeded` | Ask user to accept partial / re-plan |
+| 22 | `eval_env_unavailable` | Auto-recover | Neither vLLM nor SGLang installed, or test dataset unreachable, or no GPU at all; **the skill does NOT auto-install backends** | skip eval → success + note `eval_skipped` | same |
+| 28 | `quantized_load_failed` | Auto-fail | Eval-stage vLLM/SGLang fails to load the quantized model (distinct from #4 which loads the *source* model) — downstream serving will fail identically, equivalent to a MUST-validate violation | escalate to MUST-validate **failed** | same |
+| 29 | `eval_oom` | Auto-recover | source + quantized dual-engine doesn't fit on the same GPU; distinct from #3: happens during vLLM/SGLang inference, not PTQ operator compute | auto-switch to serial loading; still OOM → **partial** + note `eval_oom` | same |
+
+### A.9 Cross-stage
+
+| # | Failure | Category | Specific description | CI=False | interactive=True |
+|---|---------|----------|---------------------|----------|------------------|
+| 24 | `sdk_runtime_error` | Auto-fail | Claude Agent SDK session itself raises (rate-limit / network / context overflow / authentication); unrelated to Quark or validation logic | immediate **failed** with sdk traceback summary | immediate **failed** |
+| 30 | `unclassified_failure` | Auto-recover\* | Any failure not matching rows 1–29: e.g. new error class from a Quark upgrade, novel SKILL.md output, unfamiliar traceback. The agent **must** diagnose first (read stderr / stage context / corresponding SKILL.md `Recovery` table) and then **auto-decide** which known category applies: patch in workspace → Auto-recover; retryable with a fix hypothesis → Ask (bounded by §3.1 `max_requantize_attempts`); otherwise Auto-fail. **Editing any file under `quark_root` is forbidden** — Quark is treated as immutable upstream. | Diagnose → if patchable, patch workspace + retry; otherwise **failed** + `assessment.final=unclassified_failure` (diagnosis summary attached) | Same; operator may override the auto-selected strategy via stderr prompt |
+
+### A.10 Distribution and retry mechanism
+
+> **Orthogonality**: the "tier" in §5.4 (MUST-have / MUST-validate / SHOULD-have / NICE-to-have) describes **the consequence of violating a contract**; the "category" in this appendix (Auto-recover / Auto-fail / Ask) describes **the handling behavior**. E.g. #14 `must_have_config_missing` is tier = MUST-have (can't load without it) and category = Auto-recover (LLM can rebuild it); #18 `must_validate_md5_mismatch` is tier = MUST-validate (semantic violation) and category = Auto-fail (unfixable).
+
+**Diagnose → Fix → Retry flow**: every retry-eligible row (Ask-class plus catch-all #30) must run an explicit diagnostic pass before invoking quark-torch-ptq again:
+
+1. **Diagnose**: read the failing stage's stderr, artifacts, and the corresponding SKILL.md `Recovery` column to locate the root cause.
+2. **Form a fix hypothesis**: it must be **concrete and executable** (e.g. `batch_size 32→16`, `exclude lm_head`, `bump calibration samples to 256`, `amend prompt to "execute generated plan"`). Vague "just try again" doesn't count.
+3. **Apply the patch**: limit the change to files under `<workspace>` or the agent's own controllable state (prompt, `quant_plan.json`, env vars). **No file under `quark_root` may be modified** — Quark is treated as an immutable upstream; any failure whose only fix is to patch Quark is reclassified as Auto-fail with `assessment.final=upstream_change_required`.
+4. **Retry**: re-run the failed stage with the patched inputs; counter increments by 1.
+
+If diagnosis cannot produce a fix hypothesis, the row is classified `failed` immediately — no blind retry.
+
+**Category distribution** (30 rows total):
+
+| Category | Count | Row numbers |
+|----------|-------|-------------|
+| Auto-recover | 13 | 8, 10, 11, 12, 14, 15, 17, 19, 20, 22, 25, 27, 29 |
+| Auto-fail | 10 | 1, 4, 5, 7, 9, 13, 18, 23, 24, 28 |
+| Ask | 6 | 2, 3, 6, 16, 21, 26 |
+| Auto-recover\* (catch-all, runtime-classified) | 1 | 30 |
+
+**Retry mechanism**: Ask-class rows (and catch-all #30 when routed to Ask) that auto-retry are bounded by the §3.1 input parameter `max_requantize_attempts` (default `1`), persisted via `<workspace>/requantize_attempts.txt`. Callers can override (e.g. `max_requantize_attempts=0` for fail-fast). Auto-recover rows (13 total) are *not* counted against this cap — they run inside the same SDK session and complete in seconds.
+
+**CI retry-triggering rows** (Ask-class #3 / #6 / #16 / #26 only):
+
+| # | Source of fix hypothesis |
+|---|--------------------------|
+| 3 `exec_oom` | quark-torch-ptq SKILL.md Recovery: reduce batch / seq_len |
+| 6 `export_crashed` | Empirical: clear tmp + retry with same params (usually transient) |
+| 16 `must_have_weights_missing` | Union of #3 / #6 (PTQ produced no weights) |
+| 26 `fuzzy_check_failed` | LLM corrects `layer_overrides` in plan against `model_analysis.json` |
+
+**Ask-class rows that do NOT auto-retry**:
+
+- **#2** `checkpoint_aborted` — missing info is *user decision data*; a retry still lacks it.
+- **#21** `eval_gap_exceeded` — acceptance call, not retryable; same plan yields same gap.

--- a/quantization_agent/docs/DESIGN.zh-CN.html
+++ b/quantization_agent/docs/DESIGN.zh-CN.html
@@ -1,0 +1,1329 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Hyperloom Quantization-Agent 架构设计说明书</title>
+<style>
+:root{
+  --bg:#fafafa; --surface:#ffffff; --text:#1f2328; --muted:#656d76;
+  --accent:#0969da; --accent-soft:#ddf4ff; --border:#d0d7de;
+  --code-bg:#0d1117; --code-text:#e6edf3; --code-inline:#eff1f3;
+  --table-stripe:#f6f8fa; --table-hover:#eaeef2;
+}
+*{box-sizing:border-box}
+html,body{margin:0;padding:0}
+body{
+  font-family:-apple-system,BlinkMacSystemFont,"PingFang SC","Hiragino Sans GB","Microsoft YaHei","Segoe UI",Helvetica,Arial,sans-serif;
+  font-size:15px; line-height:1.7; color:var(--text); background:var(--bg);
+}
+.layout{display:flex; min-height:100vh; max-width:1400px; margin:0 auto;}
+aside.toc{
+  position:sticky; top:0; align-self:flex-start;
+  width:280px; flex-shrink:0; height:100vh; overflow-y:auto;
+  padding:32px 20px; border-right:1px solid var(--border); background:var(--surface);
+}
+aside.toc h2{font-size:13px; text-transform:uppercase; letter-spacing:.06em; color:var(--muted); margin:0 0 14px;}
+aside.toc ul{list-style:none; padding:0; margin:0;}
+aside.toc li{margin:4px 0;}
+aside.toc a{color:var(--text); text-decoration:none; display:block; padding:4px 8px; border-radius:6px; font-size:13.5px; line-height:1.4;}
+aside.toc a:hover{background:var(--accent-soft); color:var(--accent);}
+aside.toc ul ul{padding-left:14px; margin-top:2px;}
+aside.toc ul ul a{font-size:12.5px; color:var(--muted);}
+main.content{flex:1; min-width:0; padding:48px 56px; background:var(--surface);}
+main.content h1{font-size:28px; font-weight:700; margin:0 0 8px; padding-bottom:14px; border-bottom:2px solid var(--border);}
+main.content h2{font-size:22px; font-weight:600; margin:40px 0 14px; padding-bottom:8px; border-bottom:1px solid var(--border);}
+main.content h3{font-size:17px; font-weight:600; margin:28px 0 10px;}
+main.content h4{font-size:15px; font-weight:600; margin:20px 0 8px; color:var(--muted);}
+main.content p{margin:10px 0;}
+main.content a{color:var(--accent); text-decoration:none;}
+main.content a:hover{text-decoration:underline;}
+main.content hr{border:none; border-top:1px solid var(--border); margin:32px 0;}
+main.content blockquote{
+  margin:14px 0; padding:10px 16px; border-left:4px solid var(--accent);
+  background:var(--accent-soft); border-radius:0 6px 6px 0; color:#024;
+}
+main.content blockquote p{margin:6px 0;}
+main.content ul,main.content ol{padding-left:24px;}
+main.content li{margin:4px 0;}
+table{
+  border-collapse:separate; border-spacing:0; width:100%;
+  margin:14px 0; border:1px solid var(--border); border-radius:8px; overflow:hidden;
+  font-size:13.5px;
+}
+th,td{padding:9px 12px; text-align:left; border-bottom:1px solid var(--border); vertical-align:top;}
+th{background:var(--table-stripe); font-weight:600; color:var(--text);}
+tbody tr:nth-child(even){background:var(--table-stripe);}
+tbody tr:hover{background:var(--table-hover);}
+tbody tr:last-child td{border-bottom:none;}
+code{
+  font-family:"SF Mono","Menlo","Monaco","Consolas",monospace;
+  font-size:.88em; background:var(--code-inline); padding:1px 5px;
+  border-radius:4px; color:#cf222e;
+}
+pre{
+  background:var(--code-bg); color:var(--code-text); padding:16px 20px;
+  border-radius:8px; overflow-x:auto; font-size:13px; line-height:1.55;
+  margin:14px 0;
+}
+pre code{background:transparent; color:inherit; padding:0; border-radius:0; font-size:13px;}
+.highlight pre{background:var(--code-bg);}
+.highlight .hll{background-color:#2d333b}
+.highlight .c,.highlight .c1,.highlight .cm,.highlight .cp,.highlight .cpf,.highlight .cs{color:#7d8590;font-style:italic}
+.highlight .k,.highlight .kc,.highlight .kd,.highlight .kn,.highlight .kp,.highlight .kr,.highlight .kt{color:#ff7b72}
+.highlight .s,.highlight .s1,.highlight .s2,.highlight .sb,.highlight .sc,.highlight .sd,.highlight .se,.highlight .sh,.highlight .si,.highlight .sx,.highlight .sr,.highlight .ss{color:#a5d6ff}
+.highlight .m,.highlight .mf,.highlight .mh,.highlight .mi,.highlight .mo,.highlight .il{color:#79c0ff}
+.highlight .n,.highlight .nb,.highlight .nc,.highlight .nd,.highlight .ne,.highlight .nf,.highlight .ni,.highlight .nl,.highlight .nn,.highlight .no,.highlight .nt,.highlight .nv,.highlight .nx{color:#e6edf3}
+.highlight .o,.highlight .ow,.highlight .p{color:#e6edf3}
+.highlight .err{color:#f85149}
+.highlight .gp{color:#8b949e}
+pre:has(.language-text), pre code.language-text{color:#e6edf3 !important;}
+@media (max-width: 1024px){
+  .layout{flex-direction:column;}
+  aside.toc{position:relative; width:100%; height:auto; border-right:none; border-bottom:1px solid var(--border);}
+  main.content{padding:28px 20px;}
+}
+</style>
+</head>
+<body>
+<div class="layout">
+<aside class="toc">
+<h2>目录</h2>
+<div class="toc">
+<div class="toc">
+<ul>
+<li><a href="#0">0. 文档目的与背景</a></li>
+<li><a href="#1-hyperloom-quark">1. Hyperloom 使用 Quark 的流程图</a></li>
+<li><a href="#2-agent">2. Agent 内部调用流程</a></li>
+<li><a href="#3-agent">3. Agent 输入输出规范</a><ul>
+<li><a href="#31">3.1 输入参数</a></li>
+<li><a href="#32">3.2 返回结构</a></li>
+<li><a href="#33-quark">3.3 内部合约（与 Quark 的接口）</a></li>
+</ul>
+</li>
+<li><a href="#4-scheme">4. Scheme 词表参考</a><ul>
+<li><a href="#41-scheme">4.1 常用 scheme 术语</a></li>
+<li><a href="#42">4.2 常被引用的模块名</a></li>
+<li><a href="#43">4.3 当前已知约束</a></li>
+<li><a href="#44">4.4 默认值</a></li>
+</ul>
+</li>
+<li><a href="#5-validation-evaluation">5. 量化后的 Validation 与 Evaluation</a><ul>
+<li><a href="#51-validation">5.1 结构性 Validation</a></li>
+<li><a href="#52-evaluation">5.2 精度 Evaluation</a></li>
+<li><a href="#53-inference_optimizer">5.3 失败传播：如何向 inference_optimizer 返回</a></li>
+<li><a href="#54">5.4 门控策略与失败兜底</a></li>
+</ul>
+</li>
+<li><a href="#6-checkpoint">6. 需要操作者确认的检查点（Checkpoint 汇总）</a></li>
+<li><a href="#7-agent-agent">7. Agent 定位与其他 Agent 的区别</a></li>
+<li><a href="#8-quark">8. Quark 仓库只读性保证</a></li>
+<li><a href="#9">9. 参考资料</a></li>
+<li><a href="#a">附录 A. 异常处置矩阵（按阶段分组）</a><ul>
+<li><a href="#a1-1-pre">A.1 阶段 1 · Pre（预检）</a></li>
+<li><a href="#a2-2-intakequark-torch-ptq-step-1">A.2 阶段 2 · Intake（quark-torch-ptq Step 1）</a></li>
+<li><a href="#a3-3-planquark-torch-ptq-step-2">A.3 阶段 3 · Plan（quark-torch-ptq Step 2）</a></li>
+<li><a href="#a4-4-manifestquark-torch-ptq-step-3">A.4 阶段 4 · Manifest（quark-torch-ptq Step 3）</a></li>
+<li><a href="#a5-5-execquark-torch-ptq-step-4aptq">A.5 阶段 5 · Exec（quark-torch-ptq Step 4a，PTQ 计算）</a></li>
+<li><a href="#a6-6-exportquark-torch-ptq-step-4b">A.6 阶段 6 · Export（quark-torch-ptq Step 4b，写盘）</a></li>
+<li><a href="#a7-7-validatequark-torch-result-validator">A.7 阶段 7 · Validate（quark-torch-result-validator）</a></li>
+<li><a href="#a8-8-evalquark-torch-llm-eval">A.8 阶段 8 · Eval（quark-torch-llm-eval）</a></li>
+<li><a href="#a9">A.9 跨阶段</a></li>
+<li><a href="#a10">A.10 分布与重跑机制</a></li>
+</ul>
+</li>
+</ul>
+</div>
+
+</div>
+</aside>
+<main class="content">
+<h1 id="hyperloom-quantization-agent">Hyperloom Quantization-Agent 架构设计说明书</h1>
+<h2 id="0">0. 文档目的与背景</h2>
+<p>立项目标：<em>"将 Quark 作为一个 sub agent 嵌入至 hyperloom 中…该模块也可以独立完成模型的量化"</em>。</p>
+<p>本 agent 是 <strong>Hyperloom → Quark 的薄适配层（thin adapter）</strong>：</p>
+<ul>
+<li>唯一入口是协程 <code>quantize_via_prompt(prompt, ...)</code>，把自然语言 prompt 喂给 Claude Agent SDK session。</li>
+<li>session 加载 Quark 的三个 skills（<code>quark-torch-ptq</code> / <code>quark-torch-result-validator</code> / <code>quark-torch-llm-eval</code>）与 agent 自身的 <code>SKILL.md</code>（运行时合约）。</li>
+<li>自然语言到 <code>quant_plan</code> 的翻译、默认值填充、CRITICAL STOP 的呈现都由 Quark skills 完成。</li>
+<li>agent 自身只做两件事：按 <code>SKILL.md</code> 应答 checkpoint，扫描 workspace 校验产物。</li>
+</ul>
+<p>本文档记录这套设计的 <strong>结构、合约与权衡</strong>；运行时行为以 <code>../SKILL.md</code> 为准。</p>
+<hr />
+<h2 id="1-hyperloom-quark">1. Hyperloom 使用 Quark 的流程图</h2>
+<div class="codehilite"><pre><span></span><code>  Hyperloom 侧                              Quark 侧（只读）
+  ┌────────────────────────────┐            ┌────────────────────────────┐
+  │  quantization-agent        │  prompt    │                            │
+  │  （薄适配层）              │ ─────────▶ │  quark-torch-ptq                 │
+  │                            │            │  quark-quantization-       │
+  │  · 按 SKILL.md 应答        │ ◀──── ?    │       result-validator     │
+  │  · result_collector 收产物 │  answer ─▶ │  quark-torch-llm-eval            │
+  │                            │            │                            │
+  │                            │ ◀───────── │  artifacts + reports       │
+  └────────────────────────────┘            └────────────────────────────┘
+</code></pre></div>
+
+<p>三个箭头分别表示：① 首条 prompt；② Quark 三个 CRITICAL STOP 与 SKILL.md 触发的 warning checkpoint（按 SKILL.md：自动 → 默认 → 升级操作者）；③ Quark 工作完成后落盘的产物与报告。Quark 始终只读，所有 workflow 逻辑由 Quark 仓库自身维护。</p>
+<hr />
+<h2 id="2-agent">2. Agent 内部调用流程</h2>
+<div class="codehilite"><pre><span></span><code>   调用方
+     │  prompt
+     ▼
+   quantize_via_prompt
+     │
+     ▼
+   ┌──────────────────────────────────────────────────┐
+   │  Claude Agent SDK session (cwd = workspace)      │
+   │    loads  : quantization-agent/SKILL.md          │
+   │             + quark-torch-ptq / validator / llm-eval   │
+   │    runs   : Intake → Plan → Manifest →           │
+   │             Execute → Validate → (Eval)          │
+   │    answers: checkpoints per SKILL.md             │
+   └──────────────────────────────────────────────────┘
+     │  artifacts on disk
+     ▼
+   result_collector             ──  artifact-presence-as-truth
+     │
+     ▼
+   QuantSkillRunResult
+</code></pre></div>
+
+<p>确定性代码只剩两层 + 一份运行时合约：</p>
+<table>
+<thead>
+<tr>
+<th>模块</th>
+<th>职责</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>quantize_via_prompt</code></td>
+<td>协程入口：起 SDK session、把 prompt 投递给 Quark skills、收集结果</td>
+</tr>
+<tr>
+<td><code>SKILL.md</code>（运行时合约）</td>
+<td>SDK 加载；规定 checkpoint 应答策略、<code>acceptable_eval_gap</code> 默认值、产物命名</td>
+</tr>
+<tr>
+<td><code>result_collector</code></td>
+<td>扫描 workspace artifact，判定 <code>success</code> / <code>partial</code> / <code>failed</code></td>
+</tr>
+</tbody>
+</table>
+<p>判定不依赖 SDK 退出码，而是基于落盘产物，分两层：</p>
+<ol>
+<li><strong>存在性</strong>——合约 artifact 是否齐全（决定 <code>failed</code> vs <code>partial</code>/<code>success</code>）。</li>
+<li><strong>内容解析</strong>——<code>validation_report.md</code> 中各 step 的 <code>ok</code> / <code>FAIL</code> / <code>skipped</code>（决定 <code>partial</code> 是否升级为 <code>failed</code>，门控细则见 §5.4）。</li>
+</ol>
+<hr />
+<h2 id="3-agent">3. Agent 输入输出规范</h2>
+<p>Agent 对外暴露唯一的协程入口 <code>quantize_via_prompt</code>。一次最小调用如下：</p>
+<div class="codehilite"><pre><span></span><code><span class="kn">from</span><span class="w"> </span><span class="nn">quantization_agent</span><span class="w"> </span><span class="kn">import</span> <span class="n">quantize_via_prompt</span>
+
+<span class="n">result</span> <span class="o">=</span> <span class="k">await</span> <span class="n">quantize_via_prompt</span><span class="p">(</span>
+    <span class="s2">&quot;把 Qwen/Qwen3-8B 进行 mxfp4 量化，self-attention 与 kv-cache 用 fp8，&quot;</span>
+    <span class="s2">&quot;排除 lm_head，输出到 /scratch/qwen3-8b-mxfp4&quot;</span><span class="p">,</span>
+    <span class="n">workspace</span><span class="o">=</span><span class="s2">&quot;/tmp/wks-xxx&quot;</span><span class="p">,</span>
+<span class="p">)</span>
+<span class="nb">print</span><span class="p">(</span><span class="n">result</span><span class="o">.</span><span class="n">run_result</span><span class="o">.</span><span class="n">status</span><span class="p">,</span> <span class="n">result</span><span class="o">.</span><span class="n">run_result</span><span class="o">.</span><span class="n">quantized_model_dir</span><span class="p">)</span>
+</code></pre></div>
+
+<p>输入是<strong>自然语言 prompt</strong>。自然语言到 <code>quant_plan</code> 的映射、默认值填充都由 Quark <code>quark-torch-ptq</code> 在 Plan checkpoint 里完成；用户在 checkpoint 里确认或调整。</p>
+<h3 id="31">3.1 输入参数</h3>
+<table>
+<thead>
+<tr>
+<th>参数</th>
+<th>类型</th>
+<th>必填</th>
+<th>说明</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>prompt</code></td>
+<td>str</td>
+<td>✅</td>
+<td>自然语言量化请求；至少包含模型 + 输出目录 + 大致量化方案</td>
+</tr>
+<tr>
+<td><code>workspace</code></td>
+<td>str | Path</td>
+<td>✅</td>
+<td>agent 写中间产物的工作目录；Quark workflow 的 cwd</td>
+</tr>
+<tr>
+<td><code>quark_root</code></td>
+<td>str | Path | None</td>
+<td>—</td>
+<td>显式指定 Quark checkout；缺省按 <code>$QUARK_ROOT</code> → <code>/scratch/kewang/workspace/Quark</code> 自动发现</td>
+</tr>
+<tr>
+<td><code>interactive</code></td>
+<td>bool | None</td>
+<td>—</td>
+<td>是否允许 stdin 升级（CRITICAL STOP 应答）。<code>None</code> = tty 自动判断</td>
+</tr>
+<tr>
+<td><code>acceptable_eval_gap</code></td>
+<td>float | None</td>
+<td>—</td>
+<td>数值评测可接受 gap（默认 0.03）。超过即触发 warning checkpoint。也可在 prompt 里写"接受 5% gap"等价表达，优先级见 §5.2</td>
+</tr>
+<tr>
+<td><code>max_requantize_attempts</code></td>
+<td>int</td>
+<td>—</td>
+<td>Ask 类失败（§A 中 #3/#6/#16/#26）重跑上限，默认 <code>1</code>。设 <code>0</code> 即 fail-fast，不重跑；调大允许 caller 让 agent 多试几次（适合 inference_optimizer 想做整体重试预算时覆写）。受 <code>&lt;workspace&gt;/requantize_attempts.txt</code> 持久化计数器约束</td>
+</tr>
+</tbody>
+</table>
+<p><strong>prompt 示例</strong>（含常见字段——用户只写他在意的部分即可，未写项由 Quark skill 填默认）：</p>
+<div class="codehilite"><pre><span></span><code>把 /scratch/models/Qwen3-30B-A3B 进行 mxfp4 量化：
+- self-attention 用 fp8 量化
+- kv-cache 用 fp8、排除 lm_head
+- 校准用 pileval、128 条、序列长度 512
+- 导出 HF 格式，evaluation 可接受 5% gap
+- 输出到 /scratch/qwen3-30b-mxfp4
+</code></pre></div>
+
+<p>Quark 在 Plan checkpoint 里把 prompt 翻译成 <code>quant_plan</code> 并请求用户确认。可用 scheme 词表见 §4。</p>
+<h3 id="32">3.2 返回结构</h3>
+<p>调用返回 <code>QuantSkillRunResult</code>，只暴露 3 个字段（其余审计信息走日志 / <code>&lt;workspace&gt;</code> 内固定命名的 artifact 文件，不进返回值）：</p>
+<table>
+<thead>
+<tr>
+<th>字段</th>
+<th>类型</th>
+<th>说明</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>status</code></td>
+<td>str</td>
+<td><code>success</code> / <code>partial</code> / <code>failed</code>（语义见下表）</td>
+</tr>
+<tr>
+<td><code>quantized_model_dir</code></td>
+<td>Path | None</td>
+<td><code>success</code> / <code>partial</code> 时指向量化结果目录；<code>failed</code> 时为 <code>None</code></td>
+</tr>
+<tr>
+<td><code>assessment</code></td>
+<td><code>Assessment</code></td>
+<td>主结论 + 多次尝试的完整轨迹（结构见下）</td>
+</tr>
+</tbody>
+</table>
+<p><code>Assessment</code> 把"这次调用最后落在哪一类、一共跑了几次、有没有靠重跑救回来、关键数值是多少"四件事合并成一个对象，避免调用方再去翻日志：</p>
+<div class="codehilite"><pre><span></span><code><span class="nd">@dataclass</span>
+<span class="k">class</span><span class="w"> </span><span class="nc">Assessment</span><span class="p">:</span>
+    <span class="n">final</span><span class="p">:</span>     <span class="nb">str</span> <span class="o">|</span> <span class="kc">None</span>              <span class="c1"># 最终主结论 ID（§A 中的行名）；干净一次过为 None</span>
+    <span class="n">attempts</span><span class="p">:</span>  <span class="nb">list</span><span class="p">[</span><span class="nb">str</span> <span class="o">|</span> <span class="kc">None</span><span class="p">]</span>        <span class="c1"># 每次量化尝试的主结论 ID，按时间顺序；len = 实际跑过的次数</span>
+    <span class="n">recovered</span><span class="p">:</span> <span class="nb">bool</span>                    <span class="c1"># True 当且仅当：前面有尝试失败、但后续重跑成功（即 attempts 中既有失败 ID 又以 None/成功 tag 收尾）</span>
+    <span class="n">eval_gap</span><span class="p">:</span>  <span class="nb">float</span> <span class="o">|</span> <span class="kc">None</span> <span class="o">=</span> <span class="kc">None</span>     <span class="c1"># eval 阶段的 relative_gap 数值；仅当 final ∈ {eval_gap_exceeded, eval_gap_accepted} 时填充</span>
+</code></pre></div>
+
+<p>字段语义：</p>
+<ul>
+<li><strong><code>final</code></strong>：本次调用对外公布的"主结论"。<code>failed</code> / <code>partial</code> 时是根因（如 <code>exec_oom</code>、<code>checkpoint_aborted</code>、<code>eval_gap_exceeded</code>、<code>upstream_change_required</code>、<code>unclassified_failure</code>）；<code>success</code> 但"有故事"时是叙事 tag（如 <code>eval_gap_accepted</code>）；干净成功为 <code>None</code>。所有可能取值见附录 §A。</li>
+<li><strong><code>attempts</code></strong>：每次完整流水线（Intake → Execute → Validate → Eval）的主结论 ID，最早一次在 <code>[0]</code>。<code>len(attempts) - 1</code> 即额外重跑次数（受 §3.1 <code>max_requantize_attempts</code> 上限约束）。</li>
+<li><strong><code>recovered</code></strong>：诊断 → 修补 → 重跑机制是否真正起作用。常被调用方用作"该不该把这次结果列入'需要人复盘'"的过滤条件。</li>
+<li><strong><code>eval_gap</code></strong>：把唯一一个目前会暴露的数值字段抬到结构里，免得调用方再去 parse <code>&lt;workspace&gt;/eval_report.json</code>。其它结论一律为 <code>None</code>。</li>
+</ul>
+<p>典型场景：</p>
+<table>
+<thead>
+<tr>
+<th>场景</th>
+<th><code>final</code></th>
+<th><code>attempts</code></th>
+<th><code>recovered</code></th>
+<th><code>eval_gap</code></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>干净一次过</td>
+<td><code>None</code></td>
+<td><code>[None]</code></td>
+<td><code>False</code></td>
+<td><code>None</code></td>
+</tr>
+<tr>
+<td>首次 OOM、重跑成功</td>
+<td><code>None</code></td>
+<td><code>["exec_oom", None]</code></td>
+<td><code>True</code></td>
+<td><code>None</code></td>
+</tr>
+<tr>
+<td>两次都 OOM</td>
+<td><code>"exec_oom"</code></td>
+<td><code>["exec_oom", "exec_oom"]</code></td>
+<td><code>False</code></td>
+<td><code>None</code></td>
+</tr>
+<tr>
+<td>超阈值、非交互直接 partial</td>
+<td><code>"eval_gap_exceeded"</code></td>
+<td><code>["eval_gap_exceeded"]</code></td>
+<td><code>False</code></td>
+<td><code>0.052</code></td>
+</tr>
+<tr>
+<td>超阈值、操作者接受</td>
+<td><code>"eval_gap_accepted"</code></td>
+<td><code>["eval_gap_accepted"]</code></td>
+<td><code>False</code></td>
+<td><code>0.041</code></td>
+</tr>
+</tbody>
+</table>
+<p>调用方若要 artifact 路径，直接按 §3.3 出站合约固定命名拼：<code>workspace / "validation_report.md"</code>、<code>workspace / "eval_report.json"</code> 等；存在性 <code>Path.exists()</code> 自验。这样路径模式归调用方自己掌握，agent 改产物布局不会破坏调用方的上报字段。</p>
+<p><strong><code>status</code> 语义</strong>（精确分档见 §5.4）</p>
+<table>
+<thead>
+<tr>
+<th>status</th>
+<th>含义</th>
+<th>调用方处理</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>success</code></td>
+<td>全部 artifact 齐全 + MUST-validate 全 ok</td>
+<td>把 <code>quantized_model_dir</code> 切给下游；<code>assessment.final</code> 若非空（如 <code>eval_gap_accepted</code>），记审计</td>
+</tr>
+<tr>
+<td><code>partial</code></td>
+<td>量化模型可加载，但审计 / eval 类工件缺失或有警告</td>
+<td>看 <code>assessment.final</code> 决定是否接受</td>
+</tr>
+<tr>
+<td><code>failed</code></td>
+<td>模型缺失或 MUST-validate 失败</td>
+<td>视为失败，<code>assessment.final</code> 即根因</td>
+</tr>
+</tbody>
+</table>
+<h3 id="33-quark">3.3 内部合约（与 Quark 的接口）</h3>
+<p>agent 与 Quark 只有<strong>一条入站合约 + 一条出站合约</strong>：</p>
+<ul>
+<li><strong>Hyperloom → Quark</strong>：把用户 prompt 作为 SDK session 的首条消息发出；Quark 的 3 个 CRITICAL STOP 由 SKILL.md 规定的 checkpoint 应答协议自动 / 默认 / 升级处理。可选择性写 <code>session_context.json</code> 作为审计 trace。</li>
+<li><strong>Quark → Hyperloom</strong>：合约 artifact 列表为 <code>session_context.json</code> / <code>model_analysis.json</code> / <code>quant_plan.json</code> / <code>run_manifest.yaml</code> / <code>&lt;output_dir&gt;/{config.json, *.safetensors, tokenizer*}</code> / <code>validation_report.md</code>；§5.2 评估开启时再加 <code>eval_report.md</code>。由 <code>result_collector</code> 扫描并据此判定 status。</li>
+</ul>
+<hr />
+<h2 id="4-scheme">4. Scheme 词表参考</h2>
+<p>prompt 是自由文本，Quark <code>quark-torch-ptq</code> 在 Plan checkpoint 中负责把它翻译为合法 <code>quant_plan</code> 并由用户确认。本节只列<strong>写 prompt 时常用的术语</strong>作为参考。<strong>权威定义见 Quark <code>quark-llm-ptq-workflow/SKILL.md</code> 与 <code>quant_plan.schema.json</code></strong>。</p>
+<h3 id="41-scheme">4.1 常用 scheme 术语</h3>
+<table>
+<thead>
+<tr>
+<th>术语</th>
+<th>含义</th>
+<th>适用模块</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>fp8</code></td>
+<td>8-bit 浮点（E4M3）</td>
+<td>weight / activation / kv_cache</td>
+</tr>
+<tr>
+<td><code>mxfp4</code></td>
+<td>OCP MX 4-bit 浮点</td>
+<td>weight / activation（主要用于 MoE/MLP）</td>
+</tr>
+<tr>
+<td><code>int8</code> / <code>int4</code></td>
+<td>整数量化</td>
+<td>weight</td>
+</tr>
+<tr>
+<td><code>awq</code> / <code>gptq</code> / <code>smoothquant</code></td>
+<td>量化算法（非 dtype）</td>
+<td>与 <code>int*</code>/<code>fp8</code> 组合使用</td>
+</tr>
+<tr>
+<td><code>none</code> / 不写</td>
+<td>该模块保持原 dtype（bf16/fp16）</td>
+<td>任意</td>
+</tr>
+</tbody>
+</table>
+<h3 id="42">4.2 常被引用的模块名</h3>
+<p>写 prompt 时可以直接说"self-attention"、"MoE expert"、"普通 MLP"、"kv-cache"、"lm_head"——Quark 会把它们对应到 <code>attention_scheme</code>、<code>layer_overrides[".*\.experts\..*"]</code>、<code>layer_overrides[".*\.mlp\.(?!experts\.|shared_expert).*"]</code>、<code>kv_cache_scheme</code>、<code>exclude_layers</code> 上。无需在 prompt 里写正则。</p>
+<h3 id="43">4.3 当前已知约束</h3>
+<ul>
+<li><code>kv_cache</code> 在 Quark 当前发布版的 <code>quark-llm-ptq-workflow</code> 示例与 <code>quantize_quark.py</code> 中只接受 <code>fp8</code> 或不启用；其他值会在 Quark Plan checkpoint 被拒。</li>
+<li>若 prompt 中模块/scheme 组合 Quark 不支持，Plan checkpoint 会列出原因并要求修改。</li>
+</ul>
+<h3 id="44">4.4 默认值</h3>
+<p>用户在 prompt 没指定的字段（calibration 样本、序列长度、导出格式、evaluation_intent 等），由 Quark <code>quark-torch-ptq</code> skill 在 Plan checkpoint 内填默认并展示给用户确认。</p>
+<hr />
+<h2 id="5-validation-evaluation">5. 量化后的 Validation 与 Evaluation</h2>
+<p>本章四节按"检查什么 → 怎么传播 → 怎么门控"展开：</p>
+<ul>
+<li>§5.1 <strong>结构性 validation</strong>——4 个字节级 sanity check</li>
+<li>§5.2 <strong>精度 evaluation</strong>——源模型 vs 量化模型 PPL/accuracy 对比</li>
+<li>§5.3 <strong>失败传播</strong>——validation 结果如何变成 <code>status</code> 与进程退出</li>
+<li>§5.4 <strong>门控策略 + 失败兜底</strong>——artifact 分档、recovery 矩阵、retry 上限</li>
+</ul>
+<h3 id="51-validation">5.1 结构性 Validation</h3>
+<p>Execute 完成后，SKILL.md 指示 SDK 按 <strong>4 → 1 → 3 → 2</strong>
+顺序调用 Quark 的 <code>quark-torch-result-validator</code>，入参为
+<code>source_model_dir = model_path</code> 与 <code>quantized_model_dir = output_dir</code>，
+产物写到 <code>&lt;workspace&gt;/validation_report.md</code>。</p>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>子命令</th>
+<th>判定依据</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>4</td>
+<td><code>fuzzy</code></td>
+<td>每个 pattern 的 <code>dtype_counts</code>；同一 pattern 出现混合 dtype 即有层未按计划量化</td>
+</tr>
+<tr>
+<td>1</td>
+<td><code>auxiliary</code></td>
+<td>tokenizer / generation_config 等辅助文件全部转移，无 missing / mismatched / extra</td>
+</tr>
+<tr>
+<td>3</td>
+<td><code>config</code></td>
+<td>剥掉 <code>quantization_config</code> 等键后 <code>config.json</code> 深度相等</td>
+</tr>
+<tr>
+<td>2</td>
+<td><code>md5</code></td>
+<td><code>exclude_layers</code> 张量字节级 MD5 抽样比对</td>
+</tr>
+</tbody>
+</table>
+<p>这些是 <strong>结构 / 字节级 sanity check</strong>，不覆盖数值精度（perplexity、accuracy）。</p>
+<h3 id="52-evaluation">5.2 精度 Evaluation</h3>
+<p>§5.1 只覆盖结构；本节是<strong>精度层</strong>校验——直接对比原模型 vs 量化模型在同一组测试上的差距，gap 超阈值即提请用户确认。</p>
+<p><strong>机制</strong></p>
+<ul>
+<li>SKILL.md 在 Validate 阶段后追加一段 prompt，调用 Quark <code>quark-torch-llm-eval</code> skill。</li>
+<li>Skill 使用<strong>当前环境中已安装的 vLLM 或 SGLang</strong> 作为推理后端（由 skill 内部按可用性选择，优先级见 <code>quark-torch-llm-eval/SKILL.md</code>），启动两个 offline engine（源模型 + 量化模型），跑同一组测试（默认 PPL on wikitext-2 + 小规模 gsm8k 抽样）。<strong>Skill 不做任何 <code>pip install</code></strong>——后端缺失即报 <code>eval_env_unavailable</code>（见附录 §A.8），由调用方按 SHOULD-have 档处理。</li>
+<li>产物写到 <code>&lt;workspace&gt;/eval_report.md</code> 与 <code>eval_report.json</code>，后者含 <code>source_score</code> / <code>quantized_score</code> / <code>relative_gap</code> 字段。</li>
+</ul>
+<p><strong>Gap 阈值</strong></p>
+<p><code>acceptable_eval_gap</code> 按以下优先级解析（高到低）：</p>
+<ol>
+<li><strong>Python 入参</strong> — <code>quantize_via_prompt(..., acceptable_eval_gap=)</code> 显式传值</li>
+<li><strong>Prompt 内声明</strong> — 用户在 prompt 里写明"接受 5% gap"等</li>
+<li><strong>SKILL.md 默认</strong> — <code>0.03</code>（相对 gap 3%）</li>
+</ol>
+<p>调用方传了 Python 入参就直接生效，不再看 prompt 与 SKILL.md。</p>
+<p><strong>判定规则</strong></p>
+<table>
+<thead>
+<tr>
+<th>相对 gap</th>
+<th>操作者响应</th>
+<th>status</th>
+<th>备注</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>≤ 阈值</code></td>
+<td>—</td>
+<td><code>success</code></td>
+<td>直接通过</td>
+</tr>
+<tr>
+<td><code>&gt; 阈值</code></td>
+<td><code>y</code></td>
+<td><code>success</code></td>
+<td><code>assessment.final=eval_gap_accepted</code></td>
+</tr>
+<tr>
+<td><code>&gt; 阈值</code></td>
+<td><code>n</code></td>
+<td><code>failed</code></td>
+<td>显式拒绝视为错误</td>
+</tr>
+<tr>
+<td><code>&gt; 阈值</code></td>
+<td>非交互</td>
+<td><code>partial</code></td>
+<td><code>assessment.final=eval_gap_exceeded</code>，上游 gating 自决</td>
+</tr>
+</tbody>
+</table>
+<p>gap 超阈值时 SKILL.md 把 gap / 单条 metric / 阈值打到 stderr 后再要求 y/n。</p>
+<p><strong>Eval 阶段自身的失败</strong>（eval 跑不起来，区别于"gap 超阈值"——完整枚举见附录 §A.8）：</p>
+<table>
+<thead>
+<tr>
+<th>故障</th>
+<th>触发</th>
+<th>处理</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>quantized_load_failed</code></td>
+<td>vLLM/SGLang 无法加载量化模型</td>
+<td>升级为 MUST-validate <code>failed</code>（下游同样无法 serve）</td>
+</tr>
+<tr>
+<td><code>eval_oom</code></td>
+<td>source + quantized 同卡放不下</td>
+<td>改串行加载；仍 OOM → <code>partial</code> + <code>assessment.final=eval_oom</code></td>
+</tr>
+<tr>
+<td><code>eval_env_unavailable</code></td>
+<td>环境中既无 vLLM 也无 SGLang，或测试集缺失</td>
+<td><code>partial</code> + <code>assessment.final=eval_skipped</code>；不阻断</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Result collector 行为</strong></p>
+<ul>
+<li><code>eval_report.md</code> / <code>eval_report.json</code> 归入 SHOULD-have（§5.4）——缺失只警告，不阻断。</li>
+<li>调用方若需要原始 <code>relative_gap</code> 数值，可直接读 <code>assessment.eval_gap</code>（agent 已从 <code>&lt;workspace&gt;/eval_report.json</code> 抽出）；agent 在超阈值时把判定结果写入 <code>assessment.final</code>：非交互模式下为 <code>eval_gap_exceeded</code>（status=<code>partial</code>），操作者接受时为 <code>eval_gap_accepted</code>（status=<code>success</code>）。</li>
+</ul>
+<h3 id="53-inference_optimizer">5.3 失败传播：如何向 inference_optimizer 返回</h3>
+<p>§5.1 / §5.2 给出"是否通过";本节给出"未通过时这条信号怎么走出 agent"。校验结果经四层向上传播：</p>
+<table>
+<thead>
+<tr>
+<th>层</th>
+<th>产出</th>
+<th>给下一层的信号</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>quark-torch-result-validator</code> / <code>quark-torch-llm-eval</code></td>
+<td><code>validation_report.md</code> / <code>eval_report.json</code></td>
+<td>每步 <code>ok</code> / <code>FAIL</code> / <code>skipped</code>；<code>relative_gap</code></td>
+</tr>
+<tr>
+<td><code>result_collector.collect_results</code></td>
+<td><code>QuantRunResult</code></td>
+<td><code>status ∈ {success, partial, failed}</code> + <code>assessment.final</code>（按 §5.4 解析 validation_report 各 step 状态后归并到主结论 ID）</td>
+</tr>
+<tr>
+<td><code>quantization_request_handlers.py</code>（prelude 适配层）</td>
+<td>payload dict</td>
+<td><code>success</code> → <code>status="ok"</code>；<code>partial</code> → 按 §5.4 四档分级 ok / failed；<code>failed</code> → <code>status="failed"</code></td>
+</tr>
+<tr>
+<td><code>_run_quantization_prelude</code></td>
+<td>进程退出 / <code>args.model</code> 改写</td>
+<td><code>status != "ok"</code> 则 <code>SystemExit(3)</code>；否则继续，并把 <code>quantized_model_dir</code> 注入下游</td>
+</tr>
+</tbody>
+</table>
+<p>适配层按 §5.4 四档分级决定 ok / failed：</p>
+<table>
+<thead>
+<tr>
+<th>QuantRunResult.status</th>
+<th>触发条件</th>
+<th>适配层 status</th>
+<th>inference_optimizer 行为</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>success</code></td>
+<td>artifact 齐全 + MUST-validate 全 ok</td>
+<td><code>ok</code></td>
+<td>继续；<code>args.model</code> ← <code>quantized_model_dir</code></td>
+</tr>
+<tr>
+<td><code>partial</code>（SHOULD/NICE 缺）</td>
+<td>模型可加载、MUST-validate ok，仅审计/eval 缺</td>
+<td><code>ok</code></td>
+<td>继续；payload 标注 <code>quant_status="partial"</code></td>
+</tr>
+<tr>
+<td><code>partial</code>（MUST-validate FAIL/SKIPPED）</td>
+<td>md5 / config FAIL，或 STRICT 下 SKIPPED</td>
+<td><code>failed</code></td>
+<td><code>SystemExit(3)</code></td>
+</tr>
+<tr>
+<td><code>failed</code></td>
+<td><code>run_manifest.yaml</code> 或量化权重缺</td>
+<td><code>failed</code></td>
+<td><code>SystemExit(3)</code>，stderr 打印 <code>assessment.final</code></td>
+</tr>
+</tbody>
+</table>
+<p>早期失败（<code>workspace_unwritable</code> / <code>quark_root_missing</code> / <code>sdk_runtime_error</code> / <code>checkpoint_aborted</code> 等，完整枚举见附录 §A.1 / §A.9）同样走 <code>status="failed"</code> + <code>assessment.final</code> + <code>SystemExit(3)</code>。</p>
+<blockquote>
+<p><strong><code>SystemExit(3)</code> 归属</strong>：由 <code>_run_quantization_prelude</code>（CLI 适配层）抛出；直接调用 <code>quantize_via_prompt</code> 不退进程，只返回 <code>QuantSkillRunResult</code>，由调用方读 <code>status</code> 自行处置。这是 agent 独立于 inference_optimizer 可用的前提（立项目标）。</p>
+</blockquote>
+<h3 id="54">5.4 门控策略与失败兜底</h3>
+<p>按"下游是否真的需要"把 artifact 分四档,每档给出明确门控动作:</p>
+<table>
+<thead>
+<tr>
+<th>档次</th>
+<th>内容</th>
+<th>缺失后果</th>
+<th>门控动作</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>MUST-have</strong>(加载)</td>
+<td><code>config.json</code>、<code>*.safetensors</code>/<code>*.bin</code>（多分片时加 <code>model.safetensors.index.json</code>）、<code>tokenizer*</code></td>
+<td>vLLM 无法加载</td>
+<td>缺即终止</td>
+</tr>
+<tr>
+<td><strong>MUST-validate</strong>(正确性)</td>
+<td>validation_report 中 Step 3 config + Step 2 md5 = ok</td>
+<td>模型能加载但结果错</td>
+<td>FAIL 终止;SKIPPED 默认终止,<code>HYPERLOOM_QUANT_STRICT_VALIDATION=0</code> 改为只警告</td>
+</tr>
+<tr>
+<td><strong>SHOULD-have</strong>(可低成本修复)</td>
+<td>validation_report 存在 + Step 1/4 ok;<code>model_analysis.json</code> / <code>quant_plan.json</code> / <code>run_manifest.yaml</code></td>
+<td>违反硬契约但可秒级修复</td>
+<td>FAIL → 走兜底矩阵补文件 + 重跑 validator</td>
+</tr>
+<tr>
+<td><strong>NICE-to-have</strong></td>
+<td><code>session_context.json</code></td>
+<td>缺失无害</td>
+<td>仅警告</td>
+</tr>
+</tbody>
+</table>
+<blockquote>
+<p><strong>档次语义</strong>：分档判定的是"违反时走哪条修复路径"，不是"重不重要"。Step 1 auxiliary 同样 enforce 一条硬契约——<strong>"源目录里有的非权重文件，量化目录必须有"</strong>（覆盖 <code>special_tokens_map.json</code> / <code>generation_config.json</code> / <code>chat_template.jinja</code> 等"源有则必须有"的文件）。它留在 SHOULD-have 不是因为允许失败，而是因为修复路径是"从 source <code>cp</code> + 重跑 Step 1"（秒级），不值得 abort 已完成的量化。SKIPPED 才走警告路径。</p>
+</blockquote>
+<p><strong>失败处置概览</strong>——<code>result_collector</code> 解析 artifact 后，SKILL.md 中的 checkpoint 协议按附录 §A 的分类驱动 LLM 处置：</p>
+<ul>
+<li><strong>Auto-recover</strong>（§A.10 列出 13 条）：LLM 在 sandbox 内补文件 / 重跑 validator / 修 plan，<strong>不打扰人</strong>。</li>
+<li><strong>Auto-fail</strong>（10 条）：环境硬错或语义违约——立即 <code>failed</code>，不重跑（重跑无意义）。</li>
+<li><strong>Ask</strong>（6 条）：决策点。<code>interactive=True</code> 询问操作者；<code>interactive=False</code> 时其中 4 条（#3 / #6 / #16 / #26）按 SKILL.md <code>Recovery</code> 中的 fix hypothesis <strong>自动重跑 1 次</strong>，其余两条（#2 缺信息、#21 验收决策）立即定性。</li>
+<li><strong>兜底 #30 <code>unclassified_failure</code></strong>：不在已枚举行内的失败，agent 在运行时分析（log + SKILL.md Recovery + 阶段上下文），自动落到上面三类之一。详见 §A.9。</li>
+</ul>
+<p><strong>重跑前必须先诊断</strong>：所有进入重跑路径的行（Ask 类 + #30）在再次调用 quark-torch-ptq 前，必须先输出一份具体可执行的 fix hypothesis，并把补丁仅落在 <code>&lt;workspace&gt;</code> 及 agent 自身可控范围；<strong>不得修改 <code>quark_root</code> 下任何文件</strong>（Quark 视为不可变上游）。流程细节见 §A.10。</p>
+<p>每条失败的具体兜底动作与重跑触发条件见附录 §A.1–§A.9。</p>
+<p><strong>重跑量化上限</strong>：由 §3.1 入参 <code>max_requantize_attempts</code>（默认 <code>1</code>）控制，仅对 Ask 类 #3/#6/#16/#26 生效，通过 <code>&lt;workspace&gt;/requantize_attempts.txt</code> 持久化计数器约束。</p>
+<table>
+<thead>
+<tr>
+<th>模式</th>
+<th>重跑前是否询问</th>
+<th>计数行为</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>interactive=False</code>（CI）</td>
+<td>跳过询问，到达上限即 <code>failed</code></td>
+<td>计数器自增；达 <code>max_requantize_attempts</code> 即停</td>
+</tr>
+<tr>
+<td><code>interactive=True</code>（人在场）</td>
+<td>重跑前在 stderr 打印 fix hypothesis 请操作者 <code>y/n</code></td>
+<td>同上；操作者拒绝 → <code>SystemExit(3)</code></td>
+</tr>
+</tbody>
+</table>
+<p><strong>Caller 覆写</strong>：inference_optimizer 可以传 <code>max_requantize_attempts=0</code> 让 agent 立即定性（适合全局重试预算已用完的场景），也可调高让 agent 多试几次。<strong>Auto-recover 类（13 条）的 LLM 内部修复不受此参数限制</strong>——那些是同 SDK session 内秒级动作，不计入 Ask 类计数。</p>
+<p>原则：盲目重跑只是复现同一次失败；"有 SKILL.md fix hypothesis 才重跑"把每次重跑绑定到明确的修复假设，CI 在无人值守下既不会被 30 分钟量化盲跑两遍，也不会因瞬态错误失掉值得救的产物。</p>
+<hr />
+<h2 id="6-checkpoint">6. 需要操作者确认的检查点（Checkpoint 汇总）</h2>
+<p>确定性边界压到最薄,代价是把"是否继续"的判断让给操作者。本节把<strong>所有会向操作者要 y/n / 让其改 prompt / 让其确认退出的点</strong>一次列清,便于运维侧排班、CI 侧关停。</p>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>Checkpoint</th>
+<th>来源</th>
+<th>触发条件</th>
+<th>自动跳过</th>
+<th>拒绝后果</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1</td>
+<td>Intake CRITICAL STOP</td>
+<td>Quark <code>quark-torch-ptq</code></td>
+<td>解析完模型结构请求确认</td>
+<td>prompt 写"接受 Intake 默认" + <code>interactive=False</code></td>
+<td><code>failed</code>,<code>assessment.final=checkpoint_aborted</code></td>
+</tr>
+<tr>
+<td>2</td>
+<td>Plan CRITICAL STOP</td>
+<td>Quark <code>quark-torch-ptq</code></td>
+<td>自然语言翻译为 <code>quant_plan</code> 后请求确认</td>
+<td>prompt 写"按生成方案执行";<code>interactive=False</code> 自动接受</td>
+<td>同上</td>
+</tr>
+<tr>
+<td>3</td>
+<td>Manifest CRITICAL STOP</td>
+<td>Quark <code>quark-torch-ptq</code></td>
+<td>执行前展示 run_manifest</td>
+<td>prompt 写"接受默认 manifest";<code>interactive=False</code> 自动接受</td>
+<td>同上</td>
+</tr>
+<tr>
+<td>4</td>
+<td>Eval gap warning(§5.2)</td>
+<td>SKILL.md</td>
+<td>相对 gap &gt; <code>acceptable_eval_gap</code>(默认 3%)</td>
+<td><code>acceptable_eval_gap</code> 调大或 prompt 内声明</td>
+<td><code>n</code> → <code>failed</code>;非交互 → <code>partial</code> + <code>eval_gap_exceeded</code></td>
+</tr>
+<tr>
+<td>5</td>
+<td>Requantize warning(§A.10)</td>
+<td>SKILL.md</td>
+<td>Ask 类 #3/#6/#16/#26 与兜底 #30 在<strong>完成诊断 → 形成 fix hypothesis</strong> 之后、重跑之前请求确认</td>
+<td><code>interactive=False</code> 跳过确认直接由计数器自动重跑（受 §3.1 <code>max_requantize_attempts</code> 约束）；诊断给不出 hypothesis → 不重跑直接 <code>failed</code></td>
+<td><code>n</code> → <code>SystemExit(3)</code>,根因+fix hypothesis 摘要到 stderr</td>
+</tr>
+</tbody>
+</table>
+<p><strong>关于 <code>interactive</code> 的语义</strong>:<code>quantize_via_prompt(..., interactive=...)</code> 是<strong>唯一</strong>控制以上 1–5 是否允许向 stdin 升级的开关。Auto-fail 类失败（§A.10）直接退出，不经过 checkpoint。<code>None</code>(默认)按 tty 自动判断;<code>True</code> 强开 stdin;<code>False</code> 强制走 SKILL.md 里写的"非交互回退策略"(基本上是"按 prompt / 按默认值,否则拒绝")。</p>
+<p><strong>MUST-validate SKIPPED 不是 checkpoint</strong>——§5.4 的"终止 / 警告"分支在 result_collector 时由 <code>HYPERLOOM_QUANT_STRICT_VALIDATION</code> 决定，没有运行时 y/n；CI 在部署时设一次即可。</p>
+<p><strong>CI 推荐配方</strong>:<code>interactive=False</code> + prompt 内显式写全 Intake/Plan/Manifest 想要的选择 + <code>acceptable_eval_gap</code> 设大或为 prompt 显式声明阈值 + <code>HYPERLOOM_QUANT_STRICT_VALIDATION</code> 保持默认。这样除了真实致命错误外不会停在任何 checkpoint 上等人。</p>
+<hr />
+<h2 id="7-agent-agent">7. Agent 定位与其他 Agent 的区别</h2>
+<p>quantization-agent 是 <strong>reactor loop 启动前的一次性 prelude</strong>：用户带 <code>--quantize "&lt;prompt&gt;"</code> 启动 CLI 时，由 <code>inference_optimizer/cli.py::_run_quantization_prelude</code> 调用一次 <code>quantize_via_prompt</code>，返回 <code>quantized_model_dir</code> 并写回 <code>args.model</code>，随后退出，不参与任何 tick。</p>
+<div class="codehilite"><pre><span></span><code>   用户 CLI                quantization-agent         Coordinator        reactor loop
+   --quantize &quot;&lt;prompt&gt;&quot; ──►   (一次性)         ──►   (启动)        ──►  每 tick 唤起
+                              返回 quantized_model_dir                   orchestration / kernel
+                              写回 args.model                            critic / robustness
+</code></pre></div>
+
+<p>与 reactor-loop agent 的对照：</p>
+<table>
+<thead>
+<tr>
+<th>维度</th>
+<th>Reactor-loop agent</th>
+<th>quantization-agent</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>例子</td>
+<td><code>orchestration</code> / <code>kernel</code> / <code>critic</code> / <code>robustness</code></td>
+<td>本 agent</td>
+</tr>
+<tr>
+<td>生命周期</td>
+<td>每个 tick 被重新唤起</td>
+<td>reactor loop 启动前调用一次</td>
+</tr>
+<tr>
+<td>输出方式</td>
+<td><code>emit_intent</code> → PolicyGate → dispatch</td>
+<td>直接以 Python <code>dict</code> 返回调用方</td>
+</tr>
+<tr>
+<td>注册进 <code>AgentRole</code></td>
+<td>✅</td>
+<td>❌</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="8-quark">8. Quark 仓库只读性保证</h2>
+<p>Agent 严格视 Quark 仓库为只读：<code>quantization-agent/SKILL.md</code> 与 Quark 各 workflow SKILL.md 都禁止修改 <code>quark/</code>、<code>examples/</code>、<code>tools/</code>、<code>docs/</code>、<code>tests/</code>、<code>pyproject.toml</code>、<code>requirements.txt</code>。如确需自定义脚本（新旗标、新模板），agent 写入 <code>&lt;workspace&gt;/</code> 并由 <code>run_manifest.yaml</code> 引用，从而保留对干净 Quark 安装的复现性。</p>
+<hr />
+<h2 id="9">9. 参考资料</h2>
+<ul>
+<li><code>quantization-agent/SKILL.md</code> — <strong>运行时合约</strong>：checkpoint 应答协议、Quark skill 调用顺序、eval gap 阈值</li>
+<li><code>quantization-agent/__init__.py</code> — 暴露 <code>quantize_via_prompt</code> 协程入口</li>
+<li><code>quantization-agent/tools/result_collector.py</code> — artifact 收集（唯一确定性边界）</li>
+<li><code>inference_optimizer/orchestrator/quantization_request_handlers.py</code> — 程序化派发（<code>quantize_via_prompt</code> 适配层）</li>
+<li><code>inference_optimizer/cli.py::_run_quantization_prelude</code> — <code>--quantize "&lt;prompt&gt;"</code> pre-hook</li>
+<li>Quark <code>quark-llm-ptq-workflow/SKILL.md</code> — 本 agent 驱动的 workflow 合约</li>
+<li>Quark <code>quark-torch-result-validator/SKILL.md</code> — §5.1 四项结构性检查的实现</li>
+<li>Quark <code>quark-torch-llm-eval/SKILL.md</code> — §5.2 精度评测中调用的 skill</li>
+<li><code>kernel-agent/tools/tracelens_skill_runner.py</code> — 架构模板</li>
+</ul>
+<hr />
+<h2 id="a">附录 A. 异常处置矩阵（按阶段分组）</h2>
+<p>本附录把 quantization-agent 全流程可能出现的失败一次列清，给出每条的<strong>类别</strong>（Auto-recover / Auto-fail / Ask）、<strong>具体说明</strong>与<strong>CI / 交互两种模式下的处置</strong>。原则：</p>
+<ul>
+<li><strong>Auto-recover</strong>：LLM 在 sandbox 内能自愈，无需打扰人。</li>
+<li><strong>Auto-fail</strong>：修不了或重跑无意义，立即 <code>failed</code>。</li>
+<li><strong>Ask</strong>：决策点。CI 默认重跑（前提：SKILL.md <code>Recovery</code> 中有 fix hypothesis 且 LLM 已写出具体修复动作）；交互模式向用户请示。重跑由 <code>&lt;workspace&gt;/requantize_attempts.txt</code> 持久化计数器约束，上限由 §3.1 入参 <code>max_requantize_attempts</code>（默认 <code>1</code>）控制，超限即 <code>failed</code>。</li>
+<li><strong>兜底行 #30</strong>：未列入 1–29 的任何失败统一进入 #30，agent 运行时诊断后映射到上面三类之一。</li>
+</ul>
+<p><strong>通用约束</strong>：所有重跑前必须先诊断并给出<strong>具体</strong>的 fix hypothesis；<strong>任何修复仅可改 <code>&lt;workspace&gt;</code> 内容，不得改 <code>quark_root</code> 下文件</strong>（Quark 视为不可变上游，避免污染共享 checkout）。完整流程见 §A.10。</p>
+<h3 id="a1-1-pre">A.1 阶段 1 · Pre（预检）</h3>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>异常</th>
+<th>类别</th>
+<th>具体说明</th>
+<th>CI=False</th>
+<th>interactive=True</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1</td>
+<td><code>quark_root_missing</code></td>
+<td>Auto-fail</td>
+<td><code>quark_root</code> 参数对应路径不存在 / 不可读 / 非 git checkout；首次启动时探测一次</td>
+<td>立即 <strong>failed</strong></td>
+<td>立即 <strong>failed</strong></td>
+</tr>
+<tr>
+<td>7</td>
+<td><code>quark_skill_unavailable</code></td>
+<td>Auto-fail</td>
+<td><code>quark_root/.claude/skills/{quark-torch-ptq,validator,llm-eval}/SKILL.md</code> 任一缺失或注册失败</td>
+<td>立即 <strong>failed</strong></td>
+<td>立即 <strong>failed</strong></td>
+</tr>
+<tr>
+<td>8</td>
+<td><code>intent_parse_failed</code></td>
+<td>Auto-recover</td>
+<td>LLM 读 prompt 后无法产出合法 <code>hyperloom_quant_intent</code>：缺 model_path / target_dtype / output_dir 必填字段，或字段类型错</td>
+<td>LLM 内部自纠 ≤2 次；仍失败 → <strong>failed</strong></td>
+<td>LLM 自纠 2 次失败后向用户请求补全 prompt</td>
+</tr>
+<tr>
+<td>23</td>
+<td><code>workspace_unwritable</code></td>
+<td>Auto-fail</td>
+<td><code>workspace</code> 路径无法 mkdir 或目录存在但 <code>os.access(W_OK)=False</code>；Pre 阶段 touch 探测一次，避免量化跑 30 分钟才暴露</td>
+<td>立即 <strong>failed</strong>（带具体 PermissionError）</td>
+<td>立即 <strong>failed</strong></td>
+</tr>
+</tbody>
+</table>
+<h3 id="a2-2-intakequark-torch-ptq-step-1">A.2 阶段 2 · Intake（quark-torch-ptq Step 1）</h3>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>异常</th>
+<th>类别</th>
+<th>具体说明</th>
+<th>CI=False</th>
+<th>interactive=True</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>9</td>
+<td><code>model_path_unreachable</code></td>
+<td>Auto-fail</td>
+<td>quark-torch-ptq Step 1 尝试装载源模型时 <code>model_path</code> 不可达 / 不可读 / 不含 <code>config.json</code></td>
+<td>立即 <strong>failed</strong></td>
+<td>立即 <strong>failed</strong></td>
+</tr>
+<tr>
+<td>10</td>
+<td><code>analysis_artifact_invalid_or_missing</code></td>
+<td>Auto-recover</td>
+<td><code>model_analysis.json</code> 完全没产出、或产出后 schema 不合法 / JSON 损坏</td>
+<td>LLM 重跑 Step 1 → 继续</td>
+<td>同左</td>
+</tr>
+</tbody>
+</table>
+<h3 id="a3-3-planquark-torch-ptq-step-2">A.3 阶段 3 · Plan（quark-torch-ptq Step 2）</h3>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>异常</th>
+<th>类别</th>
+<th>具体说明</th>
+<th>CI=False</th>
+<th>interactive=True</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>2</td>
+<td><code>checkpoint_aborted</code></td>
+<td>Ask</td>
+<td>Intake/Plan/Manifest 任一 CRITICAL STOP 触发；非交互模式下 prompt 又没写「接受默认」</td>
+<td>prompt 写默认 → 自动接受；否则 <strong>failed</strong>（缺信息，重跑无用）</td>
+<td>询问用户接受 / 改写 prompt</td>
+</tr>
+<tr>
+<td>11</td>
+<td><code>plan_artifact_invalid_or_missing</code></td>
+<td>Auto-recover</td>
+<td><code>quant_plan.json</code> 缺失或字段 schema 不合法（scheme 不在白名单、layer_overrides 正则非法等）</td>
+<td>LLM 重跑 Step 2 → 继续</td>
+<td>同左</td>
+</tr>
+</tbody>
+</table>
+<h3 id="a4-4-manifestquark-torch-ptq-step-3">A.4 阶段 4 · Manifest（quark-torch-ptq Step 3）</h3>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>异常</th>
+<th>类别</th>
+<th>具体说明</th>
+<th>CI=False</th>
+<th>interactive=True</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>12</td>
+<td><code>manifest_artifact_invalid_or_missing</code></td>
+<td>Auto-recover</td>
+<td><code>run_manifest.yaml</code> 缺失，或解析后缺 <code>outputs.quantized_model_dir</code> 字段</td>
+<td>LLM 重跑 Step 3 → 继续</td>
+<td>同左</td>
+</tr>
+</tbody>
+</table>
+<h3 id="a5-5-execquark-torch-ptq-step-4aptq">A.5 阶段 5 · Exec（quark-torch-ptq Step 4a，PTQ 计算）</h3>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>异常</th>
+<th>类别</th>
+<th>具体说明</th>
+<th>CI=False</th>
+<th>interactive=True</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>3</td>
+<td><code>exec_oom</code></td>
+<td>Ask</td>
+<td>quark-torch-ptq Step 4a 执行 PTQ 时 GPU OOM；根因：batch 太大 / seq_len 太长 / kv_cache 量化开关问题</td>
+<td>LLM 减 batch/seq_len + 自动重跑 1 次 → success / <strong>failed</strong></td>
+<td>同左 + 重跑前请用户确认参数</td>
+</tr>
+<tr>
+<td>4</td>
+<td><code>exec_model_load_failed</code></td>
+<td>Auto-fail</td>
+<td>Exec 阶段装载源模型失败（与 #9 不同：路径在但权重损坏 / dtype 不支持 / 缺 transformers 依赖）</td>
+<td>立即 <strong>failed</strong></td>
+<td>立即 <strong>failed</strong></td>
+</tr>
+<tr>
+<td>5</td>
+<td><code>exec_calibration_data_missing</code></td>
+<td>Auto-fail</td>
+<td>calibration 数据集（pileval / wikitext / 自定义）不可达，或样本数为 0</td>
+<td>立即 <strong>failed</strong></td>
+<td>立即 <strong>failed</strong></td>
+</tr>
+</tbody>
+</table>
+<h3 id="a6-6-exportquark-torch-ptq-step-4b">A.6 阶段 6 · Export（quark-torch-ptq Step 4b，写盘）</h3>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>异常</th>
+<th>类别</th>
+<th>具体说明</th>
+<th>CI=False</th>
+<th>interactive=True</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>6</td>
+<td><code>export_crashed</code></td>
+<td>Ask</td>
+<td>Step 4b 序列化 quantized state_dict → safetensors 时崩溃；常见：磁盘满 / NFS 抖 / 临时文件竞争 / config 写入冲突</td>
+<td>LLM 自动重跑 1 次 → success / <strong>failed</strong></td>
+<td>同左 + 重跑前确认</td>
+</tr>
+</tbody>
+</table>
+<h3 id="a7-7-validatequark-torch-result-validator">A.7 阶段 7 · Validate（quark-torch-result-validator）</h3>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>异常</th>
+<th>类别</th>
+<th>具体说明</th>
+<th>CI=False</th>
+<th>interactive=True</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>13</td>
+<td><code>validator_self_test_failed</code></td>
+<td>Auto-fail</td>
+<td><code>run_validation.py self-test</code> 退出非零；Quark 验证脚本损坏或导入错误</td>
+<td>立即 <strong>failed</strong></td>
+<td>立即 <strong>failed</strong></td>
+</tr>
+<tr>
+<td>14</td>
+<td><code>must_have_config_missing_or_invalid</code></td>
+<td>Auto-recover</td>
+<td><code>&lt;quantized_dir&gt;/config.json</code> 缺失，或 JSON 损坏，或 vLLM 加载所需的核心字段（<code>model_type</code> / <code>architectures</code>）缺</td>
+<td>LLM 从 source 拷贝 + 补 <code>quantization_config</code> → 重跑 Step 3 → 继续</td>
+<td>同左</td>
+</tr>
+<tr>
+<td>15</td>
+<td><code>must_have_tokenizer_missing</code></td>
+<td>Auto-recover</td>
+<td><code>tokenizer.json</code> / <code>tokenizer_config.json</code> 等 tokenizer 必需文件缺失</td>
+<td>LLM 从 source <code>cp</code> tokenizer 全集 → 重跑 Step 1 → 继续</td>
+<td>同左</td>
+</tr>
+<tr>
+<td>16</td>
+<td><code>must_have_weights_missing</code></td>
+<td>Ask</td>
+<td><code>&lt;quantized_dir&gt;</code> 下没有 <code>*.safetensors</code> / <code>*.bin</code>；Step 4 实际没产出权重</td>
+<td>LLM 自动重跑 1 次 → success / <strong>failed</strong></td>
+<td>同左 + 重跑前确认</td>
+</tr>
+<tr>
+<td>17</td>
+<td><code>must_validate_config_mismatch</code></td>
+<td>Auto-recover</td>
+<td>Step 3 <code>config</code> FAIL：剥离 <code>quantization_config</code> 后仍有非量化字段差异</td>
+<td>LLM 修复字段（白名单加白 / 业务字段从 source 覆写）→ 重跑 Step 3 → 继续</td>
+<td>同左</td>
+</tr>
+<tr>
+<td>18</td>
+<td><code>must_validate_md5_mismatch</code></td>
+<td>Auto-fail</td>
+<td>Step 2 <code>md5</code> FAIL：<code>exclude_layers</code> 中声明的张量字节级 MD5 与 source 不一致——<strong>承诺不动却动了</strong></td>
+<td>立即 <strong>failed</strong>（语义违约）</td>
+<td>立即 <strong>failed</strong></td>
+</tr>
+<tr>
+<td>19</td>
+<td><code>should_have_aux_missing</code></td>
+<td>Auto-recover</td>
+<td>Step 1 <code>auxiliary</code> FAIL：源目录有但 quantized 目录缺的非权重文件（<code>special_tokens_map.json</code> / <code>generation_config.json</code> / <code>chat_template.jinja</code> 等）</td>
+<td>LLM <code>cp</code> 缺失文件 → 重跑 Step 1 → 继续</td>
+<td>同左</td>
+</tr>
+<tr>
+<td>20</td>
+<td><code>nice_to_have_skipped</code></td>
+<td>Auto-recover</td>
+<td>PyYAML 缺失导致 manifest 解析降级；或 <code>session_context.json</code> 缺失等不影响下游的工件</td>
+<td>记 note → 继续 success</td>
+<td>同左</td>
+</tr>
+<tr>
+<td>25</td>
+<td><code>validation_report_absent</code></td>
+<td>Auto-recover</td>
+<td><code>validation_report.md</code> 完全没产出——validator 未被 SKILL.md 调用，或调用时整体崩溃；区别于"产出但某 step FAIL"</td>
+<td>LLM 直接调一次 <code>quark-torch-result-validator</code> → 继续</td>
+<td>同左</td>
+</tr>
+<tr>
+<td>26</td>
+<td><code>fuzzy_check_failed</code></td>
+<td>Ask</td>
+<td>Step 4 <code>fuzzy</code> FAIL：同一 pattern 出现混合 dtype，或 safetensors header 异常；多数是 plan 写错（mixed precision），少数是文件损坏</td>
+<td>LLM 比对 <code>model_analysis.json</code> 修正 plan + 自动重跑 1 次 → success / <strong>failed</strong></td>
+<td>同左 + 重跑前确认</td>
+</tr>
+<tr>
+<td>27</td>
+<td><code>must_validate_skipped</code></td>
+<td>Auto-recover</td>
+<td>Step 2 md5 或 Step 3 config 因环境原因 SKIPPED（source 不可达、quant_config 无 exclude 等）——<strong>与 FAIL 不同</strong>：未证实 ≠ 已违约</td>
+<td><code>HYPERLOOM_QUANT_STRICT_VALIDATION=1</code>（默认）→ <strong>failed</strong>；<code>=0</code> → partial + warning</td>
+<td>同左（一次性环境变量决定）</td>
+</tr>
+</tbody>
+</table>
+<h3 id="a8-8-evalquark-torch-llm-eval">A.8 阶段 8 · Eval（quark-torch-llm-eval）</h3>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>异常</th>
+<th>类别</th>
+<th>具体说明</th>
+<th>CI=False</th>
+<th>interactive=True</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>21</td>
+<td><code>eval_gap_exceeded</code></td>
+<td>Ask</td>
+<td>quark-torch-llm-eval 跑完后 <code>relative_gap &gt; acceptable_eval_gap</code> —— 验收决策问题，非重跑可解</td>
+<td>自动 → <strong>partial</strong> + <code>eval_gap_exceeded</code></td>
+<td>询问用户接受 partial / 重新 plan</td>
+</tr>
+<tr>
+<td>22</td>
+<td><code>eval_env_unavailable</code></td>
+<td>Auto-recover</td>
+<td>环境中既无 vLLM 也无 SGLang，或测试数据集不可达、或无 GPU；<strong>skill 不会自行安装后端</strong></td>
+<td>跳过 eval → success + note <code>eval_skipped</code></td>
+<td>同左</td>
+</tr>
+<tr>
+<td>28</td>
+<td><code>quantized_load_failed</code></td>
+<td>Auto-fail</td>
+<td>Eval 阶段 vLLM/SGLang 尝试加载量化模型失败（区别于 #4 装载的是源模型）——下游推理同样无法 serve，等价于 MUST-validate 违约</td>
+<td>升级为 MUST-validate <strong>failed</strong></td>
+<td>同左</td>
+</tr>
+<tr>
+<td>29</td>
+<td><code>eval_oom</code></td>
+<td>Auto-recover</td>
+<td>Eval 阶段 source + quantized 双 engine 同卡放不下；区别于 #3：发生在 vLLM/SGLang 推理而非 PTQ 算子计算</td>
+<td>自动改串行加载；仍 OOM → <strong>partial</strong> + note <code>eval_oom</code></td>
+<td>同左</td>
+</tr>
+</tbody>
+</table>
+<h3 id="a9">A.9 跨阶段</h3>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>异常</th>
+<th>类别</th>
+<th>具体说明</th>
+<th>CI=False</th>
+<th>interactive=True</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>24</td>
+<td><code>sdk_runtime_error</code></td>
+<td>Auto-fail</td>
+<td>Claude Agent SDK session 本身抛异常（rate-limit / network / context overflow / authentication）；与 Quark / 验证逻辑无关</td>
+<td>立即 <strong>failed</strong>，附 sdk traceback 摘要</td>
+<td>立即 <strong>failed</strong></td>
+</tr>
+<tr>
+<td>30</td>
+<td><code>unclassified_failure</code></td>
+<td>Auto-recover*</td>
+<td>任何不匹配第 1–29 行的失败：例如 Quark 升级引入的新异常类型、未识别的 SKILL.md 输出、陌生 traceback。Agent 必须先做诊断（读 stderr / 阶段上下文 / 对应 SKILL.md 的 <code>Recovery</code> 表），再<strong>自动决定</strong>按哪种已知类别处置：能在 workspace 内打补丁就走 Auto-recover；适合重跑且有 fix hypothesis 走 Ask（受 §3.1 <code>max_requantize_attempts</code> 约束）；否则走 Auto-fail。<strong>全过程禁止修改 <code>quark_root</code> 下任何文件</strong>——Quark 视为上游不可变。</td>
+<td>诊断 → 可修则修补 workspace 后重跑；不可修 → <strong>failed</strong> + <code>assessment.final=unclassified_failure</code>（附诊断摘要）</td>
+<td>同左；操作者可在 stderr 上覆写自动选定的策略</td>
+</tr>
+</tbody>
+</table>
+<h3 id="a10">A.10 分布与重跑机制</h3>
+<blockquote>
+<p><strong>正交关系</strong>：§5.4 的"档次"（MUST-have / MUST-validate / SHOULD-have / NICE-to-have）描述<strong>违反一条契约后产生的后果</strong>；本附录的"类别"（Auto-recover / Auto-fail / Ask）描述<strong>处置行为</strong>。例如 #14 <code>must_have_config_missing</code> 档次 = MUST-have（没有就不能加载），类别 = Auto-recover（LLM 能补出来）；#18 <code>must_validate_md5_mismatch</code> 档次 = MUST-validate（语义违约），类别 = Auto-fail（修不了）。</p>
+</blockquote>
+<p><strong>诊断 → 修复 → 重跑流程</strong>：所有 Ask 类（#3 / #6 / #16 / #26）以及兜底行 #30 在执行任何重跑之前，必须先走一次显式诊断：</p>
+<ol>
+<li><strong>诊断</strong>：读失败阶段的 stderr、artifacts、对应 SKILL.md 的 <code>Recovery</code> 列，定位根因。</li>
+<li><strong>形成 fix hypothesis</strong>：必须是<strong>具体、可执行</strong>的修改（例如 <code>batch_size 32→16</code>、<code>exclude lm_head</code>、<code>扩大 calibration 样本到 256</code>、<code>改 prompt 加 "execute generated plan"</code>）。空泛的"再跑一次试试"不算。</li>
+<li><strong>应用修复</strong>：补丁仅落在 <code>&lt;workspace&gt;</code> 下（修 prompt / 修 <code>quant_plan.json</code> / 调环境变量）或 agent 自身可控的状态里。<strong>严禁修改 <code>quark_root</code> 下任何文件</strong>——Quark 被视为不可变上游；任何"需要改 Quark 才能修"的失败一律转 Auto-fail，<code>assessment.final=upstream_change_required</code>。</li>
+<li><strong>重跑</strong>：用补丁后的输入重新执行失败阶段；计数器递增 1。</li>
+</ol>
+<p>诊断给不出 fix hypothesis 的，立即 <code>failed</code>——不做盲目重跑。</p>
+<p><strong>类别分布</strong>（共 30 行）：</p>
+<table>
+<thead>
+<tr>
+<th>类别</th>
+<th>行数</th>
+<th>行号</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Auto-recover</td>
+<td>13</td>
+<td>8, 10, 11, 12, 14, 15, 17, 19, 20, 22, 25, 27, 29</td>
+</tr>
+<tr>
+<td>Auto-fail</td>
+<td>10</td>
+<td>1, 4, 5, 7, 9, 13, 18, 23, 24, 28</td>
+</tr>
+<tr>
+<td>Ask</td>
+<td>6</td>
+<td>2, 3, 6, 16, 21, 26</td>
+</tr>
+<tr>
+<td>Auto-recover* (兜底，运行时分类)</td>
+<td>1</td>
+<td>30</td>
+</tr>
+</tbody>
+</table>
+<p><strong>CI 重跑触发行</strong>（仅 Ask 类 #3 / #6 / #16 / #26）：</p>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>fix hypothesis 来源</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>3 <code>exec_oom</code></td>
+<td>quark-torch-ptq SKILL.md Recovery：减 batch / seq_len</td>
+</tr>
+<tr>
+<td>6 <code>export_crashed</code></td>
+<td>经验：清 tmp + 同参重试（多为瞬态）</td>
+</tr>
+<tr>
+<td>16 <code>must_have_weights_missing</code></td>
+<td>等同 #3 / #6 的合集（PTQ 没产出权重）</td>
+</tr>
+<tr>
+<td>26 <code>fuzzy_check_failed</code></td>
+<td>LLM 对照 <code>model_analysis.json</code> 修正 plan 的 layer_overrides</td>
+</tr>
+</tbody>
+</table>
+<p><strong>不自动重跑的 Ask 类</strong>：</p>
+<ul>
+<li><strong>#2</strong> <code>checkpoint_aborted</code> — 缺的是用户决策信息，重跑还是缺。</li>
+<li><strong>#21</strong> <code>eval_gap_exceeded</code> — 验收决策，非重跑可解；同 plan 仍是同 gap。</li>
+</ul>
+</main>
+</div>
+</body>
+</html>

--- a/quantization_agent/docs/DESIGN.zh-CN.md
+++ b/quantization_agent/docs/DESIGN.zh-CN.md
@@ -1,0 +1,528 @@
+# Hyperloom Quantization-Agent 架构设计说明书
+
+## 0. 文档目的与背景
+
+立项目标：*"将 Quark 作为一个 sub agent 嵌入至 hyperloom 中…该模块也可以独立完成模型的量化"*。
+
+本 agent 是 **Hyperloom → Quark 的薄适配层（thin adapter）**：
+
+- 唯一入口是协程 `quantize_via_prompt(prompt, ...)`，把自然语言 prompt 喂给 Claude Agent SDK session。
+- session 加载 Quark 的三个 skills（`quark-torch-ptq` / `quark-torch-result-validator` / `quark-torch-llm-eval`）与 agent 自身的 `SKILL.md`（运行时合约）。
+- 自然语言到 `quant_plan` 的翻译、默认值填充、CRITICAL STOP 的呈现都由 Quark skills 完成。
+- agent 自身只做两件事：按 `SKILL.md` 应答 checkpoint，扫描 workspace 校验产物。
+
+本文档记录这套设计的 **结构、合约与权衡**；运行时行为以 `../SKILL.md` 为准。
+
+---
+
+## 1. Hyperloom 使用 Quark 的流程图
+
+```
+  Hyperloom 侧                              Quark 侧（只读）
+  ┌────────────────────────────┐            ┌────────────────────────────┐
+  │  quantization-agent        │  prompt    │                            │
+  │  （薄适配层）              │ ─────────▶ │  quark-torch-ptq                 │
+  │                            │            │  quark-quantization-       │
+  │  · 按 SKILL.md 应答        │ ◀──── ?    │       result-validator     │
+  │  · _result_collector 收产物 │  answer ─▶ │  quark-torch-llm-eval            │
+  │                            │            │                            │
+  │                            │ ◀───────── │  artifacts + reports       │
+  └────────────────────────────┘            └────────────────────────────┘
+```
+
+三个箭头分别表示：① 首条 prompt；② Quark 三个 CRITICAL STOP 与 SKILL.md 触发的 warning checkpoint（按 SKILL.md：自动 → 默认 → 升级操作者）；③ Quark 工作完成后落盘的产物与报告。Quark 始终只读，所有 workflow 逻辑由 Quark 仓库自身维护。
+
+---
+
+## 2. Agent 内部调用流程
+
+```
+   调用方
+     │  prompt
+     ▼
+   quantize_via_prompt
+     │
+     ▼
+   ┌──────────────────────────────────────────────────┐
+   │  Claude Agent SDK session (cwd = workspace)      │
+   │    loads  : quantization-agent/SKILL.md          │
+   │             + quark-torch-ptq / validator / llm-eval   │
+   │    runs   : Intake → Plan → Manifest →           │
+   │             Execute → Validate → (Eval)          │
+   │    answers: checkpoints per SKILL.md             │
+   └──────────────────────────────────────────────────┘
+     │  artifacts on disk
+     ▼
+   _result_collector             ──  artifact-presence-as-truth
+     │
+     ▼
+   QuantSkillRunResult
+```
+
+确定性代码按职责拆成几个小模块，外加一份运行时合约：
+
+| 模块 | 职责 |
+|---|---|
+| `__init__.py` | 公共 API：`quantize_via_prompt` / `Assessment` / `OutcomeId` / `QuantSkillRunResult` |
+| `cli.py` | 独立 CLI 入口（`python -m quantization_agent.cli`），把 stdin/argv 翻译成 `quantize_via_prompt` 调用 |
+| `_runner.py` | 单次 SDK session 驱动：装载 `SKILL.md`、注入 run context、把 sdk_error 收集为字符串而非抛出 |
+| `_retry.py` | 多次尝试编排：bootstrap 检查、`_decide_next_step` 决策表、`requantize_attempts.txt` 计数器、操作者 y/n |
+| `_assessment.py` | `classify_attempt`（disk → OutcomeId）+ `Assessment` 数据类 + `derive_status` |
+| `_outcomes.py` | `OutcomeId` 枚举 + `AUTO_RECOVER` / `AUTO_FAIL` / `ASK` / `ASK_RETRYABLE` / `SUCCESS_TAGS` / `MUST_HAVE_RECOVERS_THAT_FAIL_WITHOUT_ARTIFACT` 类别集 |
+| `_result_collector.py` | 单次磁盘扫描 → `CollectedArtifacts` typed snapshot |
+| `_eval.py` | `eval_report.json` 阈值判定与解析 |
+| `SKILL.md`（运行时合约） | SDK 加载；checkpoint 应答策略、阶段顺序、auto-recover 矩阵、retry 协议 |
+
+判定不依赖 SDK 退出码，而是基于落盘产物，分两层：
+
+1. **存在性**——合约 artifact 是否齐全（决定 `failed` vs `partial`/`success`）。
+2. **内容解析**——`validation_report.md` 中各 step 的 `ok` / `FAIL` / `skipped`（决定 `partial` 是否升级为 `failed`，门控细则见 §5.4）。
+
+---
+
+## 3. Agent 输入输出规范
+
+Agent 对外暴露唯一的协程入口 `quantize_via_prompt`。一次最小调用如下：
+
+```python
+from quantization_agent import quantize_via_prompt
+
+result = await quantize_via_prompt(
+    "把 Qwen/Qwen3-8B 进行 mxfp4 量化，self-attention 与 kv-cache 用 fp8，"
+    "排除 lm_head，输出到 /scratch/qwen3-8b-mxfp4",
+    workspace="/tmp/wks-xxx",
+)
+print(result.run_result.status, result.run_result.quantized_model_dir)
+```
+
+输入是**自然语言 prompt**。自然语言到 `quant_plan` 的映射、默认值填充都由 Quark `quark-torch-ptq` 在 Plan checkpoint 里完成；用户在 checkpoint 里确认或调整。
+
+### 3.1 输入参数
+
+| 参数 | 类型 | 必填 | 说明 |
+|---|---|---|---|
+| `prompt` | str | ✅ | 自然语言量化请求；至少包含模型 + 输出目录 + 大致量化方案 |
+| `workspace` | str \| Path | ✅ | agent 写中间产物的工作目录；Quark workflow 的 cwd |
+| `quark_root` | str \| Path \| None | — | 显式指定 Quark checkout；缺省按 `$QUARK_ROOT` → `/scratch/kewang/workspace/Quark` 自动发现 |
+| `interactive` | bool \| None | — | 是否允许 stdin 升级（CRITICAL STOP 应答）。`None` = tty 自动判断 |
+| `acceptable_eval_gap` | float \| None | — | 数值评测可接受 gap（默认 0.03）。超过即触发 warning checkpoint。也可在 prompt 里写"接受 5% gap"等价表达，优先级见 §5.2 |
+| `max_requantize_attempts` | int | — | Ask 类失败（§A 中 #3/#6/#16/#26）重跑上限，默认 `1`。设 `0` 即 fail-fast，不重跑；调大允许 caller 让 agent 多试几次（适合 inference_optimizer 想做整体重试预算时覆写）。受 `<workspace>/requantize_attempts.txt` 持久化计数器约束 |
+
+**prompt 示例**（含常见字段——用户只写他在意的部分即可，未写项由 Quark skill 填默认）：
+
+```
+把 /scratch/models/Qwen3-30B-A3B 进行 mxfp4 量化：
+- self-attention 用 fp8 量化
+- kv-cache 用 fp8、排除 lm_head
+- 校准用 pileval、128 条、序列长度 512
+- 导出 HF 格式，evaluation 可接受 5% gap
+- 输出到 /scratch/qwen3-30b-mxfp4
+```
+
+Quark 在 Plan checkpoint 里把 prompt 翻译成 `quant_plan` 并请求用户确认。可用 scheme 词表见 §4。
+
+### 3.2 返回结构
+
+调用返回 `QuantSkillRunResult`，只暴露 3 个字段（其余审计信息走日志 / `<workspace>` 内固定命名的 artifact 文件，不进返回值）：
+
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| `status` | str | `success` / `partial` / `failed`（语义见下表） |
+| `quantized_model_dir` | Path \| None | `success` / `partial` 时指向量化结果目录；`failed` 时为 `None` |
+| `assessment` | `Assessment` | 主结论 + 多次尝试的完整轨迹（结构见下） |
+
+`Assessment` 把"这次调用最后落在哪一类、一共跑了几次、有没有靠重跑救回来、关键数值是多少"四件事合并成一个对象，避免调用方再去翻日志：
+
+```python
+@dataclass
+class Assessment:
+    final:     str | None              # 最终主结论 ID（§A 中的行名）；干净一次过为 None
+    attempts:  list[str | None]        # 每次量化尝试的主结论 ID，按时间顺序；len = 实际跑过的次数
+    recovered: bool                    # True 当且仅当：前面有尝试失败、但后续重跑成功（即 attempts 中既有失败 ID 又以 None/成功 tag 收尾）
+    eval_gap:  float | None = None     # eval 阶段的 relative_gap 数值；仅当 final ∈ {eval_gap_exceeded, eval_gap_accepted} 时填充
+```
+
+字段语义：
+
+- **`final`**：本次调用对外公布的"主结论"。`failed` / `partial` 时是根因（如 `exec_oom`、`checkpoint_aborted`、`eval_gap_exceeded`、`upstream_change_required`、`unclassified_failure`）；`success` 但"有故事"时是叙事 tag（如 `eval_gap_accepted`）；干净成功为 `None`。所有可能取值见附录 §A。
+- **`attempts`**：每次完整流水线（Intake → Execute → Validate → Eval）的主结论 ID，最早一次在 `[0]`。`len(attempts) - 1` 即额外重跑次数（受 §3.1 `max_requantize_attempts` 上限约束）。
+- **`recovered`**：诊断 → 修补 → 重跑机制是否真正起作用。常被调用方用作"该不该把这次结果列入'需要人复盘'"的过滤条件。
+- **`eval_gap`**：把唯一一个目前会暴露的数值字段抬到结构里，免得调用方再去 parse `<workspace>/eval_report.json`。其它结论一律为 `None`。
+
+典型场景：
+
+| 场景 | `final` | `attempts` | `recovered` | `eval_gap` |
+|---|---|---|---|---|
+| 干净一次过 | `None` | `[None]` | `False` | `None` |
+| 首次 OOM、重跑成功 | `None` | `["exec_oom", None]` | `True` | `None` |
+| 两次都 OOM | `"exec_oom"` | `["exec_oom", "exec_oom"]` | `False` | `None` |
+| 超阈值、非交互直接 partial | `"eval_gap_exceeded"` | `["eval_gap_exceeded"]` | `False` | `0.052` |
+| 超阈值、操作者接受 | `"eval_gap_accepted"` | `["eval_gap_accepted"]` | `False` | `0.041` |
+
+调用方若要 artifact 路径，直接按 §3.3 出站合约固定命名拼：`workspace / "validation_report.md"`、`workspace / "eval_report.json"` 等；存在性 `Path.exists()` 自验。这样路径模式归调用方自己掌握，agent 改产物布局不会破坏调用方的上报字段。
+
+**`status` 语义**（精确分档见 §5.4）
+
+| status | 含义 | 调用方处理 |
+|---|---|---|
+| `success` | 全部 artifact 齐全 + MUST-validate 全 ok | 把 `quantized_model_dir` 切给下游；`assessment.final` 若非空（如 `eval_gap_accepted`），记审计 |
+| `partial` | 量化模型可加载，但审计 / eval 类工件缺失或有警告 | 看 `assessment.final` 决定是否接受 |
+| `failed` | 模型缺失或 MUST-validate 失败 | 视为失败，`assessment.final` 即根因 |
+
+### 3.3 内部合约（与 Quark 的接口）
+
+agent 与 Quark 只有**一条入站合约 + 一条出站合约**：
+
+- **Hyperloom → Quark**：把用户 prompt 作为 SDK session 的首条消息发出；Quark 的 3 个 CRITICAL STOP 由 SKILL.md 规定的 checkpoint 应答协议自动 / 默认 / 升级处理。可选择性写 `session_context.json` 作为审计 trace。
+- **Quark → Hyperloom**：合约 artifact 列表为 `session_context.json` / `model_analysis.json` / `quant_plan.json` / `run_manifest.yaml` / `<output_dir>/{config.json, *.safetensors, tokenizer*}` / `validation_report.md`；§5.2 评估开启时再加 `eval_report.md`。由 `_result_collector` 扫描并据此判定 status。
+
+---
+
+## 4. Scheme 词表参考
+
+prompt 是自由文本，Quark `quark-torch-ptq` 在 Plan checkpoint 中负责把它翻译为合法 `quant_plan` 并由用户确认。本节只列**写 prompt 时常用的术语**作为参考。**权威定义见 Quark `quark-llm-ptq-workflow/SKILL.md` 与 `quant_plan.schema.json`**。
+
+### 4.1 常用 scheme 术语
+
+| 术语 | 含义 | 适用模块 |
+|---|---|---|
+| `fp8` | 8-bit 浮点（E4M3） | weight / activation / kv_cache |
+| `mxfp4` | OCP MX 4-bit 浮点 | weight / activation（主要用于 MoE/MLP） |
+| `int8` / `int4` | 整数量化 | weight |
+| `awq` / `gptq` / `smoothquant` | 量化算法（非 dtype） | 与 `int*`/`fp8` 组合使用 |
+| `none` / 不写 | 该模块保持原 dtype（bf16/fp16） | 任意 |
+
+### 4.2 常被引用的模块名
+
+写 prompt 时可以直接说"self-attention"、"MoE expert"、"普通 MLP"、"kv-cache"、"lm_head"——Quark 会把它们对应到 `attention_scheme`、`layer_overrides[".*\.experts\..*"]`、`layer_overrides[".*\.mlp\.(?!experts\.|shared_expert).*"]`、`kv_cache_scheme`、`exclude_layers` 上。无需在 prompt 里写正则。
+
+### 4.3 当前已知约束
+
+- `kv_cache` 在 Quark 当前发布版的 `quark-llm-ptq-workflow` 示例与 `quantize_quark.py` 中只接受 `fp8` 或不启用；其他值会在 Quark Plan checkpoint 被拒。
+- 若 prompt 中模块/scheme 组合 Quark 不支持，Plan checkpoint 会列出原因并要求修改。
+
+### 4.4 默认值
+
+用户在 prompt 没指定的字段（calibration 样本、序列长度、导出格式、evaluation_intent 等），由 Quark `quark-torch-ptq` skill 在 Plan checkpoint 内填默认并展示给用户确认。
+
+---
+
+## 5. 量化后的 Validation 与 Evaluation
+
+本章四节按"检查什么 → 怎么传播 → 怎么门控"展开：
+
+- §5.1 **结构性 validation**——4 个字节级 sanity check
+- §5.2 **精度 evaluation**——源模型 vs 量化模型 PPL/accuracy 对比
+- §5.3 **失败传播**——validation 结果如何变成 `status` 与进程退出
+- §5.4 **门控策略 + 失败兜底**——artifact 分档、recovery 矩阵、retry 上限
+
+### 5.1 结构性 Validation
+
+Execute 完成后，SKILL.md 指示 SDK 按 **4 → 1 → 3 → 2**
+顺序调用 Quark 的 `quark-torch-result-validator`，入参为
+`source_model_dir = model_path` 与 `quantized_model_dir = output_dir`，
+产物写到 `<workspace>/validation_report.md`。
+
+| # | 子命令 | 判定依据 |
+|---|---|---|
+| 4 | `fuzzy` | 每个 pattern 的 `dtype_counts`；同一 pattern 出现混合 dtype 即有层未按计划量化 |
+| 1 | `auxiliary` | tokenizer / generation_config 等辅助文件全部转移，无 missing / mismatched / extra |
+| 3 | `config` | 剥掉 `quantization_config` 等键后 `config.json` 深度相等 |
+| 2 | `md5` | `exclude_layers` 张量字节级 MD5 抽样比对 |
+
+这些是 **结构 / 字节级 sanity check**，不覆盖数值精度（perplexity、accuracy）。
+
+### 5.2 精度 Evaluation
+
+§5.1 只覆盖结构；本节是**精度层**校验——直接对比原模型 vs 量化模型在同一组测试上的差距，gap 超阈值即提请用户确认。
+
+**机制**
+
+- SKILL.md 在 Validate 阶段后追加一段 prompt，调用 Quark `quark-torch-llm-eval` skill。
+- Skill 使用**当前环境中已安装的 vLLM 或 SGLang** 作为推理后端（由 skill 内部按可用性选择，优先级见 `quark-torch-llm-eval/SKILL.md`），启动两个 offline engine（源模型 + 量化模型），跑同一组测试（默认 PPL on wikitext-2 + 小规模 gsm8k 抽样）。**Skill 不做任何 `pip install`**——后端缺失即报 `eval_env_unavailable`（见附录 §A.8），由调用方按 SHOULD-have 档处理。
+- 产物写到 `<workspace>/eval_report.md` 与 `eval_report.json`，后者含 `source_score` / `quantized_score` / `relative_gap` 字段。
+
+**Gap 阈值**
+
+`acceptable_eval_gap` 按以下优先级解析（高到低）：
+
+1. **Python 入参** — `quantize_via_prompt(..., acceptable_eval_gap=)` 显式传值
+2. **Prompt 内声明** — 用户在 prompt 里写明"接受 5% gap"等
+3. **SKILL.md 默认** — `0.03`（相对 gap 3%）
+
+调用方传了 Python 入参就直接生效，不再看 prompt 与 SKILL.md。
+
+**判定规则**
+
+| 相对 gap | 操作者响应 | status | 备注 |
+|---|---|---|---|
+| `≤ 阈值` | — | `success` | 直接通过 |
+| `> 阈值` | `y` | `success` | `assessment.final=eval_gap_accepted` |
+| `> 阈值` | `n` | `failed` | 显式拒绝视为错误 |
+| `> 阈值` | 非交互 | `partial` | `assessment.final=eval_gap_exceeded`，上游 gating 自决 |
+
+gap 超阈值时 SKILL.md 把 gap / 单条 metric / 阈值打到 stderr 后再要求 y/n。
+
+**Eval 阶段自身的失败**（eval 跑不起来，区别于"gap 超阈值"——完整枚举见附录 §A.8）：
+
+| 故障 | 触发 | 处理 |
+|---|---|---|
+| `quantized_load_failed` | vLLM/SGLang 无法加载量化模型 | 升级为 MUST-validate `failed`（下游同样无法 serve） |
+| `eval_oom` | source + quantized 同卡放不下 | 改串行加载；仍 OOM → `partial` + `assessment.final=eval_oom` |
+| `eval_env_unavailable` | 环境中既无 vLLM 也无 SGLang，或测试集缺失 | `partial` + `assessment.final=eval_skipped`；不阻断 |
+
+**Result collector 行为**
+
+- `eval_report.md` / `eval_report.json` 归入 SHOULD-have（§5.4）——缺失只警告，不阻断。
+- 调用方若需要原始 `relative_gap` 数值，可直接读 `assessment.eval_gap`（agent 已从 `<workspace>/eval_report.json` 抽出）；agent 在超阈值时把判定结果写入 `assessment.final`：非交互模式下为 `eval_gap_exceeded`（status=`partial`），操作者接受时为 `eval_gap_accepted`（status=`success`）。
+
+### 5.3 失败传播：如何向 inference_optimizer 返回
+
+§5.1 / §5.2 给出"是否通过";本节给出"未通过时这条信号怎么走出 agent"。校验结果经四层向上传播：
+
+| 层 | 产出 | 给下一层的信号 |
+|---|---|---|
+| `quark-torch-result-validator` / `quark-torch-llm-eval` | `validation_report.md` / `eval_report.json` | 每步 `ok` / `FAIL` / `skipped`；`relative_gap` |
+| `_result_collector.collect_artifacts` + `_assessment.classify_attempt` + `_assessment.derive_status` | `QuantSkillRunResult` | `status ∈ {success, partial, failed}` + `assessment.final`（按 §5.4 解析 validation_report 各 step 状态后归并到主结论 ID） |
+| `quantization_request_handlers.py`（prelude 适配层） | payload dict | `success` → `status="ok"`；`partial` → 按 §5.4 四档分级 ok / failed；`failed` → `status="failed"` |
+| `_run_quantization_prelude` | 进程退出 / `args.model` 改写 | `status != "ok"` 则 `SystemExit(3)`；否则继续，并把 `quantized_model_dir` 注入下游 |
+
+适配层按 §5.4 四档分级决定 ok / failed：
+
+| QuantRunResult.status | 触发条件 | 适配层 status | inference_optimizer 行为 |
+|---|---|---|---|
+| `success` | artifact 齐全 + MUST-validate 全 ok | `ok` | 继续；`args.model` ← `quantized_model_dir` |
+| `partial`（SHOULD/NICE 缺） | 模型可加载、MUST-validate ok，仅审计/eval 缺 | `ok` | 继续；payload 标注 `quant_status="partial"` |
+| `partial`（MUST-validate FAIL/SKIPPED） | md5 / config FAIL，或 STRICT 下 SKIPPED | `failed` | `SystemExit(3)` |
+| `failed` | `run_manifest.yaml` 或量化权重缺 | `failed` | `SystemExit(3)`，stderr 打印 `assessment.final` |
+
+早期失败（`workspace_unwritable` / `quark_root_missing` / `sdk_runtime_error` / `checkpoint_aborted` 等，完整枚举见附录 §A.1 / §A.9）同样走 `status="failed"` + `assessment.final` + `SystemExit(3)`。
+
+> **`SystemExit(3)` 归属**：由 `_run_quantization_prelude`（CLI 适配层）抛出；直接调用 `quantize_via_prompt` 不退进程，只返回 `QuantSkillRunResult`，由调用方读 `status` 自行处置。这是 agent 独立于 inference_optimizer 可用的前提（立项目标）。
+
+### 5.4 门控策略与失败兜底
+
+按"下游是否真的需要"把 artifact 分四档,每档给出明确门控动作:
+
+| 档次 | 内容 | 缺失后果 | 门控动作 |
+|---|---|---|---|
+| **MUST-have**(加载) | `config.json`、`*.safetensors`/`*.bin`（多分片时加 `model.safetensors.index.json`）、`tokenizer*` | vLLM 无法加载 | 缺即终止 |
+| **MUST-validate**(正确性) | validation_report 中 Step 3 config + Step 2 md5 = ok | 模型能加载但结果错 | FAIL 终止;SKIPPED 默认终止,`HYPERLOOM_QUANT_STRICT_VALIDATION=0` 改为只警告 |
+| **SHOULD-have**(可低成本修复) | validation_report 存在 + Step 1/4 ok;`model_analysis.json` / `quant_plan.json` / `run_manifest.yaml` | 违反硬契约但可秒级修复 | FAIL → 走兜底矩阵补文件 + 重跑 validator |
+| **NICE-to-have** | `session_context.json` | 缺失无害 | 仅警告 |
+
+> **档次语义**：分档判定的是"违反时走哪条修复路径"，不是"重不重要"。Step 1 auxiliary 同样 enforce 一条硬契约——**"源目录里有的非权重文件，量化目录必须有"**（覆盖 `special_tokens_map.json` / `generation_config.json` / `chat_template.jinja` 等"源有则必须有"的文件）。它留在 SHOULD-have 不是因为允许失败，而是因为修复路径是"从 source `cp` + 重跑 Step 1"（秒级），不值得 abort 已完成的量化。SKIPPED 才走警告路径。
+
+**失败处置概览**——`_result_collector` 解析 artifact 后，SKILL.md 中的 checkpoint 协议按附录 §A 的分类驱动 LLM 处置：
+
+- **Auto-recover**（§A.10 列出 13 条）：LLM 在 sandbox 内补文件 / 重跑 validator / 修 plan，**不打扰人**。
+- **Auto-fail**（10 条）：环境硬错或语义违约——立即 `failed`，不重跑（重跑无意义）。
+- **Ask**（6 条）：决策点。`interactive=True` 询问操作者；`interactive=False` 时其中 4 条（#3 / #6 / #16 / #26）按 SKILL.md `Recovery` 中的 fix hypothesis **自动重跑 1 次**，其余两条（#2 缺信息、#21 验收决策）立即定性。
+- **兜底 #30 `unclassified_failure`**：不在已枚举行内的失败，agent 在运行时分析（log + SKILL.md Recovery + 阶段上下文），自动落到上面三类之一。详见 §A.9。
+
+**重跑前必须先诊断**：所有进入重跑路径的行（Ask 类 + #30）在再次调用 quark-torch-ptq 前，必须先输出一份具体可执行的 fix hypothesis，并把补丁仅落在 `<workspace>` 及 agent 自身可控范围；**不得修改 `quark_root` 下任何文件**（Quark 视为不可变上游）。流程细节见 §A.10。
+
+每条失败的具体兜底动作与重跑触发条件见附录 §A.1–§A.9。
+
+**重跑量化上限**：由 §3.1 入参 `max_requantize_attempts`（默认 `1`）控制，仅对 Ask 类 #3/#6/#16/#26 生效，通过 `<workspace>/requantize_attempts.txt` 持久化计数器约束。
+
+| 模式 | 重跑前是否询问 | 计数行为 |
+|---|---|---|
+| `interactive=False`（CI） | 跳过询问，到达上限即 `failed` | 计数器自增；达 `max_requantize_attempts` 即停 |
+| `interactive=True`（人在场） | 重跑前在 stderr 打印 fix hypothesis 请操作者 `y/n` | 同上；操作者拒绝 → `SystemExit(3)` |
+
+**Caller 覆写**：inference_optimizer 可以传 `max_requantize_attempts=0` 让 agent 立即定性（适合全局重试预算已用完的场景），也可调高让 agent 多试几次。**Auto-recover 类（13 条）的 LLM 内部修复不受此参数限制**——那些是同 SDK session 内秒级动作，不计入 Ask 类计数。
+
+原则：盲目重跑只是复现同一次失败；"有 SKILL.md fix hypothesis 才重跑"把每次重跑绑定到明确的修复假设，CI 在无人值守下既不会被 30 分钟量化盲跑两遍，也不会因瞬态错误失掉值得救的产物。
+
+---
+
+## 6. 需要操作者确认的检查点（Checkpoint 汇总）
+
+确定性边界压到最薄,代价是把"是否继续"的判断让给操作者。本节把**所有会向操作者要 y/n / 让其改 prompt / 让其确认退出的点**一次列清,便于运维侧排班、CI 侧关停。
+
+| # | Checkpoint | 来源 | 触发条件 | 自动跳过 | 拒绝后果 |
+|---|---|---|---|---|---|
+| 1 | Intake CRITICAL STOP | Quark `quark-torch-ptq` | 解析完模型结构请求确认 | prompt 写"接受 Intake 默认" + `interactive=False` | `failed`,`assessment.final=checkpoint_aborted` |
+| 2 | Plan CRITICAL STOP | Quark `quark-torch-ptq` | 自然语言翻译为 `quant_plan` 后请求确认 | prompt 写"按生成方案执行";`interactive=False` 自动接受 | 同上 |
+| 3 | Manifest CRITICAL STOP | Quark `quark-torch-ptq` | 执行前展示 run_manifest | prompt 写"接受默认 manifest";`interactive=False` 自动接受 | 同上 |
+| 4 | Eval gap warning(§5.2) | SKILL.md | 相对 gap > `acceptable_eval_gap`(默认 3%) | `acceptable_eval_gap` 调大或 prompt 内声明 | `n` → `failed`;非交互 → `partial` + `eval_gap_exceeded` |
+| 5 | Requantize warning(§A.10) | SKILL.md | Ask 类 #3/#6/#16/#26 与兜底 #30 在**完成诊断 → 形成 fix hypothesis** 之后、重跑之前请求确认 | `interactive=False` 跳过确认直接由计数器自动重跑（受 §3.1 `max_requantize_attempts` 约束）；诊断给不出 hypothesis → 不重跑直接 `failed` | `n` → `SystemExit(3)`,根因+fix hypothesis 摘要到 stderr |
+
+**关于 `interactive` 的语义**:`quantize_via_prompt(..., interactive=...)` 是**唯一**控制以上 1–5 是否允许向 stdin 升级的开关。Auto-fail 类失败（§A.10）直接退出，不经过 checkpoint。`None`(默认)按 tty 自动判断;`True` 强开 stdin;`False` 强制走 SKILL.md 里写的"非交互回退策略"(基本上是"按 prompt / 按默认值,否则拒绝")。
+
+**MUST-validate SKIPPED 不是 checkpoint**——§5.4 的"终止 / 警告"分支在 _result_collector 时由 `HYPERLOOM_QUANT_STRICT_VALIDATION` 决定，没有运行时 y/n；CI 在部署时设一次即可。
+
+**CI 推荐配方**:`interactive=False` + prompt 内显式写全 Intake/Plan/Manifest 想要的选择 + `acceptable_eval_gap` 设大或为 prompt 显式声明阈值 + `HYPERLOOM_QUANT_STRICT_VALIDATION` 保持默认。这样除了真实致命错误外不会停在任何 checkpoint 上等人。
+
+---
+
+## 7. Agent 定位与其他 Agent 的区别
+
+quantization-agent 是 **reactor loop 启动前的一次性 prelude**：用户带 `--quantize "<prompt>"` 启动 CLI 时，由 `inference_optimizer/cli.py::_run_quantization_prelude` 调用一次 `quantize_via_prompt`，返回 `quantized_model_dir` 并写回 `args.model`，随后退出，不参与任何 tick。
+
+```
+   用户 CLI                quantization-agent         Coordinator        reactor loop
+   --quantize "<prompt>" ──►   (一次性)         ──►   (启动)        ──►  每 tick 唤起
+                              返回 quantized_model_dir                   orchestration / kernel
+                              写回 args.model                            critic / robustness
+```
+
+与 reactor-loop agent 的对照：
+
+| 维度 | Reactor-loop agent | quantization-agent |
+|---|---|---|
+| 例子 | `orchestration` / `kernel` / `critic` / `robustness` | 本 agent |
+| 生命周期 | 每个 tick 被重新唤起 | reactor loop 启动前调用一次 |
+| 输出方式 | `emit_intent` → PolicyGate → dispatch | 直接以 Python `dict` 返回调用方 |
+| 注册进 `AgentRole` | ✅ | ❌ |
+
+---
+
+## 8. Quark 仓库只读性保证
+
+Agent 严格视 Quark 仓库为只读：`quantization-agent/SKILL.md` 与 Quark 各 workflow SKILL.md 都禁止修改 `quark/`、`examples/`、`tools/`、`docs/`、`tests/`、`pyproject.toml`、`requirements.txt`。如确需自定义脚本（新旗标、新模板），agent 写入 `<workspace>/` 并由 `run_manifest.yaml` 引用，从而保留对干净 Quark 安装的复现性。
+
+---
+
+## 9. 参考资料
+
+- `quantization_agent/SKILL.md` — **运行时合约**：checkpoint 应答协议、Quark skill 调用顺序、eval gap 阈值
+- `quantization_agent/__init__.py` — 公共 API（`quantize_via_prompt` / `Assessment` / `OutcomeId` / `QuantSkillRunResult`）
+- `quantization_agent/cli.py` — 独立 CLI（`python -m quantization_agent.cli`）
+- `quantization_agent/_runner.py` — 单次 SDK session 驱动
+- `quantization_agent/_retry.py` — 多次尝试编排 + 计数器 + 操作者 y/n
+- `quantization_agent/_assessment.py` — `classify_attempt` / `build_assessment` / `derive_status`
+- `quantization_agent/_outcomes.py` — `OutcomeId` 枚举与类别集
+- `quantization_agent/_result_collector.py` — workspace artifact 扫描（确定性边界）
+- `quantization_agent/_eval.py` — `eval_report.json` 阈值判定
+- `inference_optimizer/orchestrator/quantization_request_handlers.py` — 程序化派发（`quantize_via_prompt` 适配层）
+- `inference_optimizer/cli.py::_run_quantization_prelude` — `--quantize "<prompt>"` pre-hook
+- Quark `quark-torch-ptq/SKILL.md` — 本 agent 驱动的 PTQ workflow 合约
+- Quark `quark-torch-result-validator/SKILL.md` — §5.1 四项结构性检查的实现
+- Quark `quark-torch-llm-eval/SKILL.md` — §5.2 精度评测中调用的 skill
+- `kernel-agent/tools/tracelens_skill_runner.py` — 架构模板
+
+---
+
+## 附录 A. 异常处置矩阵（按阶段分组）
+
+本附录把 quantization-agent 全流程可能出现的失败一次列清，给出每条的**类别**（Auto-recover / Auto-fail / Ask）、**具体说明**与**CI / 交互两种模式下的处置**。原则：
+
+- **Auto-recover**：LLM 在 sandbox 内能自愈，无需打扰人。
+- **Auto-fail**：修不了或重跑无意义，立即 `failed`。
+- **Ask**：决策点。CI 默认重跑（前提：SKILL.md `Recovery` 中有 fix hypothesis 且 LLM 已写出具体修复动作）；交互模式向用户请示。重跑由 `<workspace>/requantize_attempts.txt` 持久化计数器约束，上限由 §3.1 入参 `max_requantize_attempts`（默认 `1`）控制，超限即 `failed`。
+- **兜底行 #30**：未列入 1–29 的任何失败统一进入 #30，agent 运行时诊断后映射到上面三类之一。
+
+**通用约束**：所有重跑前必须先诊断并给出**具体**的 fix hypothesis；**任何修复仅可改 `<workspace>` 内容，不得改 `quark_root` 下文件**（Quark 视为不可变上游，避免污染共享 checkout）。完整流程见 §A.10。
+
+### A.1 阶段 1 · Pre（预检）
+
+| # | 异常 | 类别 | 具体说明 | CI=False | interactive=True |
+|---|------|------|---------|----------|------------------|
+| 1 | `quark_root_missing` | Auto-fail | `quark_root` 参数对应路径不存在 / 不可读 / 非 git checkout；首次启动时探测一次 | 立即 **failed** | 立即 **failed** |
+| 7 | `quark_skill_unavailable` | Auto-fail | `quark_root/.claude/skills/{quark-torch-ptq,validator,llm-eval}/SKILL.md` 任一缺失或注册失败 | 立即 **failed** | 立即 **failed** |
+| 8 | `intent_parse_failed` | Auto-recover | LLM 读 prompt 后无法产出合法 `hyperloom_quant_intent`：缺 model_path / target_dtype / output_dir 必填字段，或字段类型错 | LLM 内部自纠 ≤2 次；仍失败 → **failed** | LLM 自纠 2 次失败后向用户请求补全 prompt |
+| 23 | `workspace_unwritable` | Auto-fail | `workspace` 路径无法 mkdir 或目录存在但 `os.access(W_OK)=False`；Pre 阶段 touch 探测一次，避免量化跑 30 分钟才暴露 | 立即 **failed**（带具体 PermissionError） | 立即 **failed** |
+
+### A.2 阶段 2 · Intake（quark-torch-ptq Step 1）
+
+| # | 异常 | 类别 | 具体说明 | CI=False | interactive=True |
+|---|------|------|---------|----------|------------------|
+| 9 | `model_path_unreachable` | Auto-fail | quark-torch-ptq Step 1 尝试装载源模型时 `model_path` 不可达 / 不可读 / 不含 `config.json` | 立即 **failed** | 立即 **failed** |
+| 10 | `analysis_artifact_invalid_or_missing` | Auto-recover | `model_analysis.json` 完全没产出、或产出后 schema 不合法 / JSON 损坏 | LLM 重跑 Step 1 → 继续 | 同左 |
+
+### A.3 阶段 3 · Plan（quark-torch-ptq Step 2）
+
+| # | 异常 | 类别 | 具体说明 | CI=False | interactive=True |
+|---|------|------|---------|----------|------------------|
+| 2 | `checkpoint_aborted` | Ask | Intake/Plan/Manifest 任一 CRITICAL STOP 触发；非交互模式下 prompt 又没写「接受默认」 | prompt 写默认 → 自动接受；否则 **failed**（缺信息，重跑无用） | 询问用户接受 / 改写 prompt |
+| 11 | `plan_artifact_invalid_or_missing` | Auto-recover | `quant_plan.json` 缺失或字段 schema 不合法（scheme 不在白名单、layer_overrides 正则非法等） | LLM 重跑 Step 2 → 继续 | 同左 |
+
+### A.4 阶段 4 · Manifest（quark-torch-ptq Step 3）
+
+| # | 异常 | 类别 | 具体说明 | CI=False | interactive=True |
+|---|------|------|---------|----------|------------------|
+| 12 | `manifest_artifact_invalid_or_missing` | Auto-recover | `run_manifest.yaml` 缺失，或解析后缺 `outputs.quantized_model_dir` 字段 | LLM 重跑 Step 3 → 继续 | 同左 |
+
+### A.5 阶段 5 · Exec（quark-torch-ptq Step 4a，PTQ 计算）
+
+| # | 异常 | 类别 | 具体说明 | CI=False | interactive=True |
+|---|------|------|---------|----------|------------------|
+| 3 | `exec_oom` | Ask | quark-torch-ptq Step 4a 执行 PTQ 时 GPU OOM；根因：batch 太大 / seq_len 太长 / kv_cache 量化开关问题 | LLM 减 batch/seq_len + 自动重跑 1 次 → success / **failed** | 同左 + 重跑前请用户确认参数 |
+| 4 | `exec_model_load_failed` | Auto-fail | Exec 阶段装载源模型失败（与 #9 不同：路径在但权重损坏 / dtype 不支持 / 缺 transformers 依赖） | 立即 **failed** | 立即 **failed** |
+| 5 | `exec_calibration_data_missing` | Auto-fail | calibration 数据集（pileval / wikitext / 自定义）不可达，或样本数为 0 | 立即 **failed** | 立即 **failed** |
+
+### A.6 阶段 6 · Export（quark-torch-ptq Step 4b，写盘）
+
+| # | 异常 | 类别 | 具体说明 | CI=False | interactive=True |
+|---|------|------|---------|----------|------------------|
+| 6 | `export_crashed` | Ask | Step 4b 序列化 quantized state_dict → safetensors 时崩溃；常见：磁盘满 / NFS 抖 / 临时文件竞争 / config 写入冲突 | LLM 自动重跑 1 次 → success / **failed** | 同左 + 重跑前确认 |
+
+### A.7 阶段 7 · Validate（quark-torch-result-validator）
+
+| # | 异常 | 类别 | 具体说明 | CI=False | interactive=True |
+|---|------|------|---------|----------|------------------|
+| 13 | `validator_self_test_failed` | Auto-fail | `run_validation.py self-test` 退出非零；Quark 验证脚本损坏或导入错误 | 立即 **failed** | 立即 **failed** |
+| 14 | `must_have_config_missing_or_invalid` | Auto-recover | `<quantized_dir>/config.json` 缺失，或 JSON 损坏，或 vLLM 加载所需的核心字段（`model_type` / `architectures`）缺 | LLM 从 source 拷贝 + 补 `quantization_config` → 重跑 Step 3 → 继续 | 同左 |
+| 15 | `must_have_tokenizer_missing` | Auto-recover | `tokenizer.json` / `tokenizer_config.json` 等 tokenizer 必需文件缺失 | LLM 从 source `cp` tokenizer 全集 → 重跑 Step 1 → 继续 | 同左 |
+| 16 | `must_have_weights_missing` | Ask | `<quantized_dir>` 下没有 `*.safetensors` / `*.bin`；Step 4 实际没产出权重 | LLM 自动重跑 1 次 → success / **failed** | 同左 + 重跑前确认 |
+| 17 | `must_validate_config_mismatch` | Auto-recover | Step 3 `config` FAIL：剥离 `quantization_config` 后仍有非量化字段差异 | LLM 修复字段（白名单加白 / 业务字段从 source 覆写）→ 重跑 Step 3 → 继续 | 同左 |
+| 18 | `must_validate_md5_mismatch` | Auto-fail | Step 2 `md5` FAIL：`exclude_layers` 中声明的张量字节级 MD5 与 source 不一致——**承诺不动却动了** | 立即 **failed**（语义违约） | 立即 **failed** |
+| 19 | `should_have_aux_missing` | Auto-recover | Step 1 `auxiliary` FAIL：源目录有但 quantized 目录缺的非权重文件（`special_tokens_map.json` / `generation_config.json` / `chat_template.jinja` 等） | LLM `cp` 缺失文件 → 重跑 Step 1 → 继续 | 同左 |
+| 20 | `nice_to_have_skipped` | Auto-recover | PyYAML 缺失导致 manifest 解析降级；或 `session_context.json` 缺失等不影响下游的工件 | 记 note → 继续 success | 同左 |
+| 25 | `validation_report_absent` | Auto-recover | `validation_report.md` 完全没产出——validator 未被 SKILL.md 调用，或调用时整体崩溃；区别于"产出但某 step FAIL" | LLM 直接调一次 `quark-torch-result-validator` → 继续 | 同左 |
+| 26 | `fuzzy_check_failed` | Ask | Step 4 `fuzzy` FAIL：同一 pattern 出现混合 dtype，或 safetensors header 异常；多数是 plan 写错（mixed precision），少数是文件损坏 | LLM 比对 `model_analysis.json` 修正 plan + 自动重跑 1 次 → success / **failed** | 同左 + 重跑前确认 |
+| 27 | `must_validate_skipped` | Auto-recover | Step 2 md5 或 Step 3 config 因环境原因 SKIPPED（source 不可达、quant_config 无 exclude 等）——**与 FAIL 不同**：未证实 ≠ 已违约 | `HYPERLOOM_QUANT_STRICT_VALIDATION=1`（默认）→ **failed**；`=0` → partial + warning | 同左（一次性环境变量决定） |
+
+### A.8 阶段 8 · Eval（quark-torch-llm-eval）
+
+| # | 异常 | 类别 | 具体说明 | CI=False | interactive=True |
+|---|------|------|---------|----------|------------------|
+| 21 | `eval_gap_exceeded` | Ask | quark-torch-llm-eval 跑完后 `relative_gap > acceptable_eval_gap` —— 验收决策问题，非重跑可解 | 自动 → **partial** + `eval_gap_exceeded` | 询问用户接受 partial / 重新 plan |
+| 22 | `eval_env_unavailable` | Auto-recover | 环境中既无 vLLM 也无 SGLang，或测试数据集不可达、或无 GPU；**skill 不会自行安装后端** | 跳过 eval → success + note `eval_skipped` | 同左 |
+| 28 | `quantized_load_failed` | Auto-fail | Eval 阶段 vLLM/SGLang 尝试加载量化模型失败（区别于 #4 装载的是源模型）——下游推理同样无法 serve，等价于 MUST-validate 违约 | 升级为 MUST-validate **failed** | 同左 |
+| 29 | `eval_oom` | Auto-recover | Eval 阶段 source + quantized 双 engine 同卡放不下；区别于 #3：发生在 vLLM/SGLang 推理而非 PTQ 算子计算 | 自动改串行加载；仍 OOM → **partial** + note `eval_oom` | 同左 |
+
+### A.9 跨阶段
+
+| # | 异常 | 类别 | 具体说明 | CI=False | interactive=True |
+|---|------|------|---------|----------|------------------|
+| 24 | `sdk_runtime_error` | Auto-fail | Claude Agent SDK session 本身抛异常（rate-limit / network / context overflow / authentication）；与 Quark / 验证逻辑无关 | 立即 **failed**，附 sdk traceback 摘要 | 立即 **failed** |
+| 30 | `unclassified_failure` | Auto-recover\* | 任何不匹配第 1–29 行的失败：例如 Quark 升级引入的新异常类型、未识别的 SKILL.md 输出、陌生 traceback。Agent 必须先做诊断（读 stderr / 阶段上下文 / 对应 SKILL.md 的 `Recovery` 表），再**自动决定**按哪种已知类别处置：能在 workspace 内打补丁就走 Auto-recover；适合重跑且有 fix hypothesis 走 Ask（受 §3.1 `max_requantize_attempts` 约束）；否则走 Auto-fail。**全过程禁止修改 `quark_root` 下任何文件**——Quark 视为上游不可变。 | 诊断 → 可修则修补 workspace 后重跑；不可修 → **failed** + `assessment.final=unclassified_failure`（附诊断摘要） | 同左；操作者可在 stderr 上覆写自动选定的策略 |
+
+### A.10 分布与重跑机制
+
+> **正交关系**：§5.4 的"档次"（MUST-have / MUST-validate / SHOULD-have / NICE-to-have）描述**违反一条契约后产生的后果**；本附录的"类别"（Auto-recover / Auto-fail / Ask）描述**处置行为**。例如 #14 `must_have_config_missing` 档次 = MUST-have（没有就不能加载），类别 = Auto-recover（LLM 能补出来）；#18 `must_validate_md5_mismatch` 档次 = MUST-validate（语义违约），类别 = Auto-fail（修不了）。
+
+**诊断 → 修复 → 重跑流程**：所有 Ask 类（#3 / #6 / #16 / #26）以及兜底行 #30 在执行任何重跑之前，必须先走一次显式诊断：
+
+1. **诊断**：读失败阶段的 stderr、artifacts、对应 SKILL.md 的 `Recovery` 列，定位根因。
+2. **形成 fix hypothesis**：必须是**具体、可执行**的修改（例如 `batch_size 32→16`、`exclude lm_head`、`扩大 calibration 样本到 256`、`改 prompt 加 "execute generated plan"`）。空泛的"再跑一次试试"不算。
+3. **应用修复**：补丁仅落在 `<workspace>` 下（修 prompt / 修 `quant_plan.json` / 调环境变量）或 agent 自身可控的状态里。**严禁修改 `quark_root` 下任何文件**——Quark 被视为不可变上游；任何"需要改 Quark 才能修"的失败一律转 Auto-fail，`assessment.final=upstream_change_required`。
+4. **重跑**：用补丁后的输入重新执行失败阶段；计数器递增 1。
+
+诊断给不出 fix hypothesis 的，立即 `failed`——不做盲目重跑。
+
+**类别分布**（共 30 行）：
+
+| 类别 | 行数 | 行号 |
+|------|------|------|
+| Auto-recover | 13 | 8, 10, 11, 12, 14, 15, 17, 19, 20, 22, 25, 27, 29 |
+| Auto-fail | 10 | 1, 4, 5, 7, 9, 13, 18, 23, 24, 28 |
+| Ask | 6 | 2, 3, 6, 16, 21, 26 |
+| Auto-recover\* (兜底，运行时分类) | 1 | 30 |
+
+**CI 重跑触发行**（仅 Ask 类 #3 / #6 / #16 / #26）：
+
+| # | fix hypothesis 来源 |
+|---|---------------------|
+| 3 `exec_oom` | quark-torch-ptq SKILL.md Recovery：减 batch / seq_len |
+| 6 `export_crashed` | 经验：清 tmp + 同参重试（多为瞬态） |
+| 16 `must_have_weights_missing` | 等同 #3 / #6 的合集（PTQ 没产出权重） |
+| 26 `fuzzy_check_failed` | LLM 对照 `model_analysis.json` 修正 plan 的 layer_overrides |
+
+**不自动重跑的 Ask 类**：
+
+- **#2** `checkpoint_aborted` — 缺的是用户决策信息，重跑还是缺。
+- **#21** `eval_gap_exceeded` — 验收决策，非重跑可解；同 plan 仍是同 gap。

--- a/quantization_agent/driver/__init__.py
+++ b/quantization_agent/driver/__init__.py
@@ -1,0 +1,8 @@
+"""Internal driver package for quantization_agent.
+
+Drives the Claude SDK session per ``SKILL.md``: single-attempt session
+runner, multi-attempt retry orchestrator, artifact collection, eval gap
+gating, and outcome classification. Public symbols are re-exported by
+``quantization_agent.__init__``; do not import from ``driver`` directly
+from outside this package.
+"""

--- a/quantization_agent/driver/assessment.py
+++ b/quantization_agent/driver/assessment.py
@@ -1,0 +1,436 @@
+"""Assessment dataclass + ``classify_attempt`` — turn one attempt's
+workspace state into a single ``OutcomeId``.
+
+``classify_attempt`` is a pure function (workspace snapshot + sdk_error +
+phase hint → OutcomeId | None). The retry loop accumulates per-attempt
+outcomes into a multi-attempt ``Assessment``.
+
+## Classification precedence
+
+Decisions are made in this order. The first match wins:
+
+  1. **Hard SDK-level signatures in ``sdk_error``** that map to bootstrap-class
+     outcomes (#1 quark_root, #7 quark_skill, #23 workspace_unwritable, #24
+     sdk_runtime_error). These are decisive even if some artifacts exist.
+  2. **Explicit ``blocked.md`` outcome marker**. SKILL.md writes
+     ``outcome_id: <id>`` (one line) when it knows the outcome — e.g. it
+     parsed a Quark stderr we don't have to re-parse. The classifier respects
+     that hint as long as the ID is a known ``OutcomeId``.
+  3. **Phase-aware artifact gaps** (intake → analysis missing, plan → plan
+     missing, …) — disk evidence under the recorded ``last_phase``.
+  4. **MUST-have model files** on the quantized directory.
+  5. **Validator step results** (FAIL > SKIPPED > absent step heading).
+  6. **Eval phase** — ``eval_skipped.txt`` first (env failure / OOM), then
+     ``eval_report.json`` gap vs. threshold.
+  7. **sdk_error pattern match** (exec_oom, exec_model_load_failed,
+     export_crashed, eval_oom, quantized_load_failed) — these can fire even
+     when artifacts look partially intact.
+  8. **Fallback**: ``unclassified_failure`` if any failure signal is present,
+     otherwise ``None`` for clean success (with the ``eval_gap_accepted``
+     narrative tag when the gap is non-zero and within budget).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .eval import DEFAULT_ACCEPTABLE_GAP, decide as decide_eval
+from .outcomes import (
+    ASK,
+    ASK_RETRYABLE,
+    AUTO_FAIL,
+    AUTO_RECOVER,
+    MUST_HAVE_RECOVERS_THAT_FAIL_WITHOUT_ARTIFACT,
+    OutcomeId,
+    SUCCESS_TAGS,
+)
+from .result_collector import CollectedArtifacts, collect_artifacts
+
+
+_BLOCKED_OUTCOME_RE = re.compile(
+    r"(?:^|\n)\s*outcome_id\s*:\s*([A-Za-z_][A-Za-z0-9_]*)", re.IGNORECASE
+)
+
+_GAP_NARRATIVE_EPSILON = 1e-4  # gaps smaller than this are "clean success"
+
+
+@dataclass(frozen=True)
+class Assessment:
+    """Public summary of a (possibly multi-attempt) quantize call.
+
+    Mirrors ``docs/DESIGN.zh-CN.md §3.2``:
+
+    * ``final`` — primary verdict. ``None`` = clean success; otherwise an
+      ``OutcomeId``.
+    * ``attempts`` — per-attempt outcomes in chronological order; len == 1
+      for single-shot runs.
+    * ``recovered`` — ``True`` iff len(attempts) > 1 AND final is in
+      ``SUCCESS_TAGS`` (i.e. an earlier attempt failed and a later one
+      cleaned up).
+    * ``eval_gap`` — the ``relative_gap`` from the final attempt's
+      ``eval_report.json`` when present (regardless of accept/reject).
+    """
+
+    final: OutcomeId | None
+    attempts: tuple[OutcomeId | None, ...]
+    recovered: bool
+    eval_gap: float | None
+    notes: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict:
+        return {
+            "final": self.final.value if self.final is not None else None,
+            "attempts": [a.value if a is not None else None for a in self.attempts],
+            "recovered": self.recovered,
+            "eval_gap": self.eval_gap,
+            "notes": list(self.notes),
+        }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# pattern banks
+# ─────────────────────────────────────────────────────────────────────────────
+
+_SDK_RUNTIME_PATTERNS = (
+    "rate limit", "rate_limit", "ratelimit",
+    "authentication", "auth_error", "unauthorized", "api key",
+    "context length", "context_length", "context window",
+    "connectionerror", "timeouterror", "anyio.endofstream",
+    "anthropic.", "claude_agent_sdk",
+)
+
+_OOM_PATTERNS = ("out of memory", "cuda out of memory", "oom", "torch.outofmemoryerror")
+
+_MODEL_LOAD_PATTERNS = (
+    "safetensorerror", "missing keys", "no such file",
+    "from_pretrained", "transformers.utils.import_utils",
+    "weight shape", "dtype mismatch",
+)
+
+_EXPORT_PATTERNS = (
+    "save_pretrained", "safetensors.write", "ioerror", "no space left",
+    "stale file handle", "nfs",
+)
+
+_QUANTIZED_LOAD_PATTERNS = (
+    "vllm", "sglang", "engine.start", "engine startup",
+)
+
+
+def _contains_any(haystack: str, needles: tuple[str, ...]) -> bool:
+    for n in needles:
+        if n in haystack:
+            return True
+    return False
+
+
+def _parse_blocked_outcome(text: str | None) -> OutcomeId | None:
+    if not text:
+        return None
+    m = _BLOCKED_OUTCOME_RE.search(text)
+    if not m:
+        return None
+    raw = m.group(1).lower()
+    try:
+        return OutcomeId(raw)
+    except ValueError:
+        return None
+
+
+def _classify_eval_outcome(
+    art: CollectedArtifacts,
+    *,
+    acceptable_eval_gap: float | None,
+) -> OutcomeId | None:
+    """Map eval-phase artifacts → outcome. ``None`` means 'eval not exercised'."""
+
+    if art.eval_skipped_reason:
+        reason = art.eval_skipped_reason.lower()
+        if _contains_any(reason, _OOM_PATTERNS):
+            return OutcomeId.eval_oom
+        if _contains_any(reason, _QUANTIZED_LOAD_PATTERNS):
+            return OutcomeId.quantized_load_failed
+        return OutcomeId.eval_env_unavailable
+
+    if not art.eval_report_present:
+        return None  # eval was simply not run this attempt
+
+    decision = decide_eval(
+        art.eval_report_data,
+        workspace=art.workspace,
+        acceptable_eval_gap=acceptable_eval_gap,
+    )
+    if decision.status == "missing":
+        # File present but unparsable — fall back to env-unavailable rather
+        # than silently passing.
+        return OutcomeId.eval_env_unavailable
+    if decision.status == "exceeded":
+        return OutcomeId.eval_gap_exceeded
+    # "within" — narrative tag only when gap is large enough to mention
+    if decision.relative_gap and decision.relative_gap > _GAP_NARRATIVE_EPSILON:
+        return OutcomeId.eval_gap_accepted
+    return None
+
+
+def _classify_sdk_phase_error(
+    sdk_error: str,
+    phase: str | None,
+) -> OutcomeId | None:
+    """Map ``sdk_error`` text under a known phase to a phase-specific outcome.
+
+    Returns ``None`` if the message doesn't look phase-specific; the caller
+    then falls through to bootstrap-level patterns.
+    """
+
+    msg = sdk_error.lower()
+    if phase == "exec":
+        if _contains_any(msg, _OOM_PATTERNS):
+            return OutcomeId.exec_oom
+        if _contains_any(msg, _MODEL_LOAD_PATTERNS):
+            return OutcomeId.exec_model_load_failed
+        if "calibration" in msg or "dataloader" in msg:
+            return OutcomeId.exec_calibration_data_missing
+    if phase == "export":
+        if _contains_any(msg, _EXPORT_PATTERNS):
+            return OutcomeId.export_crashed
+    if phase == "eval":
+        if _contains_any(msg, _OOM_PATTERNS):
+            return OutcomeId.eval_oom
+        if _contains_any(msg, _QUANTIZED_LOAD_PATTERNS):
+            return OutcomeId.quantized_load_failed
+        return OutcomeId.eval_env_unavailable
+    if phase == "intake":
+        if "config.json" in msg or "no such file" in msg or "not a directory" in msg:
+            return OutcomeId.model_path_unreachable
+    return None
+
+
+_MANIFEST_REQUIRED_PHASES = frozenset({"manifest", "exec", "export", "validate", "eval"})
+
+
+def _classify_phase_artifact_gap(
+    art: CollectedArtifacts,
+    phase: str | None,
+) -> OutcomeId | None:
+    """Disk-evidence gaps that depend on which phase last wrote ``last_phase.txt``.
+
+    Returns ``None`` if nothing is amiss at this phase boundary — the caller
+    then continues to MUST-have / validator / eval checks.
+    """
+
+    if phase == "intake" and not art.model_analysis_present:
+        return OutcomeId.analysis_artifact_invalid_or_missing
+    if phase == "plan" and not art.quant_plan_present:
+        return OutcomeId.plan_artifact_invalid_or_missing
+    if not art.manifest_present and phase in _MANIFEST_REQUIRED_PHASES:
+        return OutcomeId.manifest_artifact_invalid_or_missing
+    if art.manifest_present and art.manifest_parse_error:
+        if art.manifest_parse_error == "pyyaml_missing":
+            return OutcomeId.nice_to_have_skipped
+        return OutcomeId.manifest_artifact_invalid_or_missing
+    return None
+
+
+def _classify_bootstrap_sdk_error(sdk_error: str) -> OutcomeId | None:
+    msg = sdk_error.lower()
+    if "quark_root" in msg or ("quark root" in msg and ("missing" in msg or "not found" in msg)):
+        return OutcomeId.quark_root_missing
+    if "permissionerror" in msg and ("workspace" in msg or "permission denied" in msg):
+        return OutcomeId.workspace_unwritable
+    if "skill.md" in msg and ("missing" in msg or "not found" in msg):
+        return OutcomeId.quark_skill_unavailable
+    if _contains_any(msg, _SDK_RUNTIME_PATTERNS):
+        return OutcomeId.sdk_runtime_error
+    return None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# main entry
+# ─────────────────────────────────────────────────────────────────────────────
+
+def classify_attempt(
+    workspace: Path,
+    *,
+    sdk_error: str | None = None,
+    last_phase: str | None = None,
+    acceptable_eval_gap: float | None = None,
+    artifacts: CollectedArtifacts | None = None,
+) -> OutcomeId | None:
+    """Classify a single attempt's workspace state.
+
+    Returns ``None`` for clean success, an ``OutcomeId`` otherwise. The retry
+    loop assembles attempts and derives the final ``Assessment``.
+
+    ``artifacts`` may be supplied if the caller already scanned the workspace
+    (saves a duplicate disk pass).
+    """
+
+    art = artifacts if artifacts is not None else collect_artifacts(Path(workspace))
+    phase = last_phase or art.last_phase
+
+    # (1) Bootstrap-class sdk_error wins over disk evidence.
+    if sdk_error:
+        boot = _classify_bootstrap_sdk_error(sdk_error)
+        if boot is not None:
+            return boot
+
+    # (2) Explicit blocked.md marker.
+    blocked_oid = _parse_blocked_outcome(art.blocked_reason)
+    if blocked_oid is not None:
+        return blocked_oid
+
+    # (3) Phase-aware artifact gaps before the model is fully produced.
+    phase_gap = _classify_phase_artifact_gap(art, phase)
+    if phase_gap is not None:
+        return phase_gap
+
+    # (3b) Phase-tagged sdk_error (exec_oom, export_crashed, …) before
+    # generic artifact checks — these can fire even when partial artifacts
+    # remain on disk from a prior run.
+    if sdk_error:
+        phase_outcome = _classify_sdk_phase_error(sdk_error, phase)
+        if phase_outcome is not None:
+            return phase_outcome
+
+    # (4) MUST-have files on the quantized directory.
+    # ``quantized_dir_exists`` covers "manifest pointed to a path that wasn't
+    # created"; the granular file checks then differentiate which gap matters.
+    if art.manifest_present and not art.manifest_parse_error:
+        if not art.quantized_dir_exists or not art.has_weights:
+            return OutcomeId.must_have_weights_missing
+        if not art.has_config_json:
+            return OutcomeId.must_have_config_missing_or_invalid
+        if not art.has_tokenizer:
+            return OutcomeId.must_have_tokenizer_missing
+
+    # (5) Validator results.
+    if art.manifest_present and not art.manifest_parse_error:
+        if not art.validation_report_present:
+            return OutcomeId.validation_report_absent
+        steps = art.validation_steps
+        if steps.md5 == "FAIL":
+            return OutcomeId.must_validate_md5_mismatch
+        if steps.config == "FAIL":
+            return OutcomeId.must_validate_config_mismatch
+        if steps.fuzzy == "FAIL":
+            return OutcomeId.fuzzy_check_failed
+        if steps.auxiliary == "FAIL":
+            return OutcomeId.should_have_aux_missing
+        if steps.md5 == "skipped" or steps.config == "skipped":
+            # Tier mapping (strict/lenient) is the retry loop's job — classifier
+            # only emits the ID.
+            return OutcomeId.must_validate_skipped
+
+    # (6) Eval phase.
+    eval_outcome = _classify_eval_outcome(art, acceptable_eval_gap=acceptable_eval_gap)
+    if eval_outcome is not None:
+        return eval_outcome
+
+    # (7) Residual sdk_error with no specific bucket → unclassified.
+    if sdk_error:
+        return OutcomeId.unclassified_failure
+
+    # Clean success.
+    return None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Assessment assembly
+# ─────────────────────────────────────────────────────────────────────────────
+
+def build_assessment(
+    attempts: list[OutcomeId | None],
+    *,
+    workspace: Path,
+    artifacts: CollectedArtifacts | None = None,
+    notes: tuple[str, ...] = (),
+) -> Assessment:
+    """Assemble an ``Assessment`` from a chronological attempts list.
+
+    * ``final`` = last attempt's outcome.
+    * ``recovered`` = True iff len(attempts) > 1 AND final ∈ SUCCESS_TAGS.
+    * ``eval_gap`` = ``relative_gap`` from the latest ``eval_report.json``.
+    """
+
+    if not attempts:
+        attempts = [OutcomeId.unclassified_failure]
+
+    art = artifacts if artifacts is not None else collect_artifacts(Path(workspace))
+    final = attempts[-1]
+    recovered = len(attempts) > 1 and final in SUCCESS_TAGS
+
+    eval_gap: float | None = None
+    if isinstance(art.eval_report_data, dict):
+        raw = art.eval_report_data.get("relative_gap")
+        try:
+            eval_gap = float(raw) if raw is not None else None
+        except (TypeError, ValueError):
+            eval_gap = None
+
+    return Assessment(
+        final=final,
+        attempts=tuple(attempts),
+        recovered=recovered,
+        eval_gap=eval_gap,
+        notes=tuple(notes),
+    )
+
+
+def derive_status(assessment: Assessment, artifacts: CollectedArtifacts) -> str:
+    """Map an ``Assessment`` to a public status string per design §5.4.
+
+    Returns ``"success"`` / ``"partial"`` / ``"failed"``. Consumed by
+    :class:`quantization_agent.driver.retry.QuantSkillRunResult`.
+    """
+
+    final = assessment.final
+    # Clean / accepted success.
+    if final is None or final == OutcomeId.eval_gap_accepted:
+        return "success"
+
+    # Auto-fail buckets always fail.
+    if final in AUTO_FAIL:
+        return "failed"
+
+    # eval_gap_exceeded is partial per §5.2 in CI mode (model usable, but
+    # quality bar didn't meet user's stated budget).
+    if final == OutcomeId.eval_gap_exceeded:
+        return "partial"
+
+    # must_validate_skipped — STRICT controls demotion (see §5.4 + the
+    # HYPERLOOM_QUANT_STRICT_VALIDATION env knob in _result_collector).
+    if final == OutcomeId.must_validate_skipped:
+        return "failed" if artifacts.strict_validation else "partial"
+
+    # Auto-recover outcomes reaching the final attempt mean SKILL.md couldn't
+    # self-heal in-session and the Python loop chose not to retry. Treat as
+    # partial — quantized model is usable but the audit/eval chain didn't
+    # complete — UNLESS the missing artifact is a MUST-have file the user
+    # can't load without (config.json / tokenizer / config field divergence).
+    if final in AUTO_RECOVER:
+        if final in MUST_HAVE_RECOVERS_THAT_FAIL_WITHOUT_ARTIFACT and not (
+            artifacts.has_config_json and artifacts.has_tokenizer
+        ):
+            return "failed"
+        return "partial"
+
+    if final in ASK or final == OutcomeId.unclassified_failure:
+        return "failed"
+
+    # Defensive — partition is exhaustive, but be loud rather than silent.
+    return "failed"
+
+
+__all__ = [
+    "Assessment",
+    "classify_attempt",
+    "build_assessment",
+    "derive_status",
+    "AUTO_FAIL",
+    "AUTO_RECOVER",
+    "ASK",
+    "ASK_RETRYABLE",
+    "SUCCESS_TAGS",
+]

--- a/quantization_agent/driver/eval.py
+++ b/quantization_agent/driver/eval.py
@@ -1,8 +1,8 @@
 """Eval-gap policy: threshold resolution + acceptance check.
 
-``quark-llm-eval`` runs one model at a time and only emits Markdown — there is
+``quark-torch-llm-eval`` runs one model at a time and only emits Markdown — there is
 no JSON sidecar and no built-in source-vs-quantized comparison. So SKILL.md is
-instructed to invoke ``quark-llm-eval`` twice (once on source, once on
+instructed to invoke ``quark-torch-llm-eval`` twice (once on source, once on
 quantized), parse the headline metric from both reports, and synthesize an
 agent-owned ``eval_report.json`` wrapper:
 

--- a/quantization_agent/driver/eval.py
+++ b/quantization_agent/driver/eval.py
@@ -1,0 +1,136 @@
+"""Eval-gap policy: threshold resolution + acceptance check.
+
+``quark-llm-eval`` runs one model at a time and only emits Markdown — there is
+no JSON sidecar and no built-in source-vs-quantized comparison. So SKILL.md is
+instructed to invoke ``quark-llm-eval`` twice (once on source, once on
+quantized), parse the headline metric from both reports, and synthesize an
+agent-owned ``eval_report.json`` wrapper:
+
+    {
+        "metric_name": "gsm8k",
+        "dataset": "gsm8k",
+        "backend": "vllm",
+        "source_score": 0.512,
+        "quantized_score": 0.498,
+        "relative_gap": 0.0273,
+    }
+
+This module reads that file, resolves the acceptance threshold, and decides
+whether the gap is within budget. It does **not** parse the raw Markdown — the
+LLM is responsible for normalizing scores into the schema above. We trust the
+schema and validate keys; if anything is missing the classifier maps the
+attempt to ``eval_env_unavailable`` (the closest "eval didn't really finish"
+bucket) rather than silently treating absent fields as zero.
+
+Threshold resolution priority (§3.1):
+
+    1. ``acceptable_eval_gap`` Python arg (caller-supplied; not None)
+    2. ``<workspace>/eval_gap_threshold.txt`` (LLM writes this when the
+       prompt mentions a tolerance)
+    3. Default ``0.03`` (3%)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+DEFAULT_ACCEPTABLE_GAP = 0.03
+
+_REQUIRED_EVAL_KEYS = ("source_score", "quantized_score", "relative_gap")
+
+
+@dataclass(frozen=True)
+class EvalDecision:
+    """Outcome of comparing ``relative_gap`` to the acceptance threshold.
+
+    * ``status == "within"``: gap ≤ threshold — counts as success. Caller may
+      attach ``eval_gap_accepted`` narrative tag when a prior attempt
+      exceeded the threshold and the user accepted it.
+    * ``status == "exceeded"``: gap > threshold — classifier maps to #21
+      ``eval_gap_exceeded``.
+    * ``status == "missing"``: eval_report.json absent or malformed — handled
+      by the classifier upstream (it inspects ``eval_skipped.txt`` first).
+    """
+
+    status: str  # "within" | "exceeded" | "missing"
+    relative_gap: float | None
+    threshold: float
+    threshold_source: str  # "arg" | "file" | "default"
+
+
+def resolve_threshold(
+    workspace: Path,
+    *,
+    acceptable_eval_gap: float | None,
+) -> tuple[float, str]:
+    """Return ``(threshold, source)`` per §3.1 priority chain."""
+
+    if acceptable_eval_gap is not None:
+        return float(acceptable_eval_gap), "arg"
+    threshold_file = workspace / "eval_gap_threshold.txt"
+    if threshold_file.is_file():
+        raw = threshold_file.read_text(encoding="utf-8").strip()
+        if raw:
+            try:
+                return float(raw), "file"
+            except ValueError:
+                # Malformed file falls through to default rather than raising —
+                # SKILL.md may have written a stray comment; default is safe.
+                pass
+    return DEFAULT_ACCEPTABLE_GAP, "default"
+
+
+def decide(
+    eval_report: dict | None,
+    *,
+    workspace: Path,
+    acceptable_eval_gap: float | None,
+) -> EvalDecision:
+    threshold, source = resolve_threshold(
+        workspace, acceptable_eval_gap=acceptable_eval_gap
+    )
+
+    if not isinstance(eval_report, dict):
+        return EvalDecision(
+            status="missing",
+            relative_gap=None,
+            threshold=threshold,
+            threshold_source=source,
+        )
+
+    missing = [k for k in _REQUIRED_EVAL_KEYS if k not in eval_report]
+    if missing:
+        return EvalDecision(
+            status="missing",
+            relative_gap=None,
+            threshold=threshold,
+            threshold_source=source,
+        )
+
+    try:
+        gap = float(eval_report["relative_gap"])
+    except (TypeError, ValueError):
+        return EvalDecision(
+            status="missing",
+            relative_gap=None,
+            threshold=threshold,
+            threshold_source=source,
+        )
+
+    status = "within" if gap <= threshold else "exceeded"
+    return EvalDecision(
+        status=status,
+        relative_gap=gap,
+        threshold=threshold,
+        threshold_source=source,
+    )
+
+
+__all__ = [
+    "DEFAULT_ACCEPTABLE_GAP",
+    "EvalDecision",
+    "decide",
+    "resolve_threshold",
+]

--- a/quantization_agent/driver/outcomes.py
+++ b/quantization_agent/driver/outcomes.py
@@ -1,0 +1,156 @@
+"""Outcome taxonomy for quantization-agent.
+
+Enumerates the 30 failure rows from ``docs/DESIGN.zh-CN.md`` Appendix §A plus
+the narrative success tag ``eval_gap_accepted`` and the upstream-mutation
+sentinel ``upstream_change_required`` (the resolution #30 takes when the LLM
+diagnoses that the fix would require editing files under ``quark_root``).
+
+The IDs here are the **vocabulary** that ``_assessment.classify_attempt``
+emits and that ``Assessment.final`` / ``Assessment.attempts`` carry to the
+caller. Category sets (``AUTO_RECOVER`` / ``AUTO_FAIL`` / ``ASK``) drive the
+retry-loop branching in ``_retry.run_with_retries``.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class OutcomeId(StrEnum):
+    # §A.1 Bootstrap / environment
+    quark_root_missing = "quark_root_missing"                       # #1   Auto-fail
+    quark_skill_unavailable = "quark_skill_unavailable"             # #7   Auto-fail
+    intent_parse_failed = "intent_parse_failed"                     # #8   Auto-recover
+    workspace_unwritable = "workspace_unwritable"                   # #23  Auto-fail
+
+    # §A.2 Intake (Quark Step 1)
+    model_path_unreachable = "model_path_unreachable"               # #9   Auto-fail
+    analysis_artifact_invalid_or_missing = "analysis_artifact_invalid_or_missing"  # #10  Auto-recover
+
+    # §A.3 Plan (Quark Step 2)
+    checkpoint_aborted = "checkpoint_aborted"                       # #2   Ask
+    plan_artifact_invalid_or_missing = "plan_artifact_invalid_or_missing"          # #11  Auto-recover
+
+    # §A.4 Manifest (Quark Step 3)
+    manifest_artifact_invalid_or_missing = "manifest_artifact_invalid_or_missing"  # #12  Auto-recover
+
+    # §A.5 Execute (Quark Step 4a)
+    exec_oom = "exec_oom"                                           # #3   Ask
+    exec_model_load_failed = "exec_model_load_failed"               # #4   Auto-fail
+    exec_calibration_data_missing = "exec_calibration_data_missing"  # #5   Auto-fail
+
+    # §A.6 Export (Quark Step 4b)
+    export_crashed = "export_crashed"                               # #6   Ask
+
+    # §A.7 Validate (validator workflow)
+    validator_self_test_failed = "validator_self_test_failed"       # #13  Auto-fail
+    must_have_config_missing_or_invalid = "must_have_config_missing_or_invalid"   # #14  Auto-recover
+    must_have_tokenizer_missing = "must_have_tokenizer_missing"     # #15  Auto-recover
+    must_have_weights_missing = "must_have_weights_missing"         # #16  Ask
+    must_validate_config_mismatch = "must_validate_config_mismatch"  # #17  Auto-recover
+    must_validate_md5_mismatch = "must_validate_md5_mismatch"       # #18  Auto-fail
+    should_have_aux_missing = "should_have_aux_missing"             # #19  Auto-recover
+    nice_to_have_skipped = "nice_to_have_skipped"                   # #20  Auto-recover
+    validation_report_absent = "validation_report_absent"           # #25  Auto-recover
+    fuzzy_check_failed = "fuzzy_check_failed"                       # #26  Ask
+    must_validate_skipped = "must_validate_skipped"                 # #27  Auto-recover
+
+    # §A.8 Eval
+    eval_gap_exceeded = "eval_gap_exceeded"                         # #21  Ask
+    eval_env_unavailable = "eval_env_unavailable"                   # #22  Auto-recover
+    quantized_load_failed = "quantized_load_failed"                 # #28  Auto-fail
+    eval_oom = "eval_oom"                                           # #29  Auto-recover
+
+    # §A.9 SDK / catch-all
+    sdk_runtime_error = "sdk_runtime_error"                         # #24  Auto-fail
+    unclassified_failure = "unclassified_failure"                   # #30  Auto-recover* (runtime-classified)
+
+    # Narrative / derived tags (not in the 30-row table):
+    #   eval_gap_accepted — success with gap-within-threshold, worth surfacing
+    #   upstream_change_required — #30 diagnosed as "needs quark_root edit";
+    #                              promoted to Auto-fail per §A bottom note
+    eval_gap_accepted = "eval_gap_accepted"
+    upstream_change_required = "upstream_change_required"
+
+
+# Partition of the 30 IDs from Appendix §A (rows #1–#29 explicit + #30 catch-all).
+AUTO_RECOVER: frozenset[OutcomeId] = frozenset({
+    OutcomeId.intent_parse_failed,                       # #8
+    OutcomeId.analysis_artifact_invalid_or_missing,      # #10
+    OutcomeId.plan_artifact_invalid_or_missing,          # #11
+    OutcomeId.manifest_artifact_invalid_or_missing,      # #12
+    OutcomeId.must_have_config_missing_or_invalid,       # #14
+    OutcomeId.must_have_tokenizer_missing,               # #15
+    OutcomeId.must_validate_config_mismatch,             # #17
+    OutcomeId.should_have_aux_missing,                   # #19
+    OutcomeId.nice_to_have_skipped,                      # #20
+    OutcomeId.eval_env_unavailable,                      # #22
+    OutcomeId.validation_report_absent,                  # #25
+    OutcomeId.must_validate_skipped,                     # #27
+    OutcomeId.eval_oom,                                  # #29
+})
+
+AUTO_FAIL: frozenset[OutcomeId] = frozenset({
+    OutcomeId.quark_root_missing,                        # #1
+    OutcomeId.exec_model_load_failed,                    # #4
+    OutcomeId.exec_calibration_data_missing,             # #5
+    OutcomeId.quark_skill_unavailable,                   # #7
+    OutcomeId.model_path_unreachable,                    # #9
+    OutcomeId.validator_self_test_failed,                # #13
+    OutcomeId.must_validate_md5_mismatch,                # #18
+    OutcomeId.workspace_unwritable,                      # #23
+    OutcomeId.sdk_runtime_error,                         # #24
+    OutcomeId.quantized_load_failed,                     # #28
+    OutcomeId.upstream_change_required,                  # derived from #30
+})
+
+ASK: frozenset[OutcomeId] = frozenset({
+    OutcomeId.checkpoint_aborted,                        # #2
+    OutcomeId.exec_oom,                                  # #3
+    OutcomeId.export_crashed,                            # #6
+    OutcomeId.must_have_weights_missing,                 # #16
+    OutcomeId.eval_gap_exceeded,                         # #21
+    OutcomeId.fuzzy_check_failed,                        # #26
+})
+
+UNCLASSIFIED_FAILURE: OutcomeId = OutcomeId.unclassified_failure  # #30 sentinel
+
+# Outcomes that count as ``recovered=True`` when a multi-attempt trail ends on
+# them. ``None`` is the clean-success marker; ``eval_gap_accepted`` is the
+# narrative tag emitted when the user/threshold accepted a gap that earlier
+# attempts exceeded. (Plain success with no story is just ``None``.)
+SUCCESS_TAGS: frozenset[OutcomeId | None] = frozenset({None, OutcomeId.eval_gap_accepted})
+
+
+# Ask-class IDs that participate in Python-driven retry (§A bottom of table).
+# These are the only outcomes that increment ``requantize_attempts.txt``.
+ASK_RETRYABLE: frozenset[OutcomeId] = frozenset({
+    OutcomeId.exec_oom,                # #3
+    OutcomeId.export_crashed,          # #6
+    OutcomeId.must_have_weights_missing,  # #16
+    OutcomeId.fuzzy_check_failed,      # #26
+})
+
+
+# Auto-recover outcomes that should still demote to "failed" (not "partial")
+# when the underlying MUST-have artifact is still missing on the final
+# attempt. SKILL.md's §6 fix is `cp` from source; if those files aren't on
+# disk by the end, the model isn't usable even if classification is lenient.
+# Consumed by ``_assessment.derive_status``.
+MUST_HAVE_RECOVERS_THAT_FAIL_WITHOUT_ARTIFACT: frozenset[OutcomeId] = frozenset({
+    OutcomeId.must_have_config_missing_or_invalid,
+    OutcomeId.must_have_tokenizer_missing,
+    OutcomeId.must_validate_config_mismatch,
+})
+
+
+__all__ = [
+    "OutcomeId",
+    "AUTO_RECOVER",
+    "AUTO_FAIL",
+    "ASK",
+    "ASK_RETRYABLE",
+    "MUST_HAVE_RECOVERS_THAT_FAIL_WITHOUT_ARTIFACT",
+    "UNCLASSIFIED_FAILURE",
+    "SUCCESS_TAGS",
+]

--- a/quantization_agent/driver/result_collector.py
+++ b/quantization_agent/driver/result_collector.py
@@ -1,0 +1,277 @@
+"""Workspace artifact scan — converts files on disk into a typed snapshot.
+
+``collect_artifacts`` is a pure function: it does NOT classify outcomes, it
+only inventories what SKILL.md left behind in ``<workspace>/`` and in the
+quantized model directory (resolved from ``run_manifest.yaml``). The classifier
+in ``driver/assessment.py`` consumes the snapshot and decides which ``OutcomeId``
+applies.
+
+The split exists so the classifier can stay declarative (decision table) while
+disk I/O lives here in one place. It also keeps tests cheap — feed a fixture
+workspace directory, get a frozen snapshot, assert on fields.
+
+Only the **MUST-have** and **MUST-validate** files from §5.4 are interpreted;
+SHOULD-have and NICE-to-have presence is recorded but not graded — that's
+classifier territory.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+
+STRICT_VALIDATION_ENV = "HYPERLOOM_QUANT_STRICT_VALIDATION"
+
+# §5.4 MUST-have file globs for the quantized model directory.
+# (Multi-shard models also require ``model.safetensors.index.json``, but its
+# absence on single-file models is not a failure — the weights-glob covers
+# both cases.)
+_WEIGHT_GLOBS = ("*.safetensors", "*.bin")
+_TOKENIZER_FILES = (
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "tokenizer.model",
+    "vocab.json",
+)
+
+
+@dataclass(frozen=True)
+class ValidationSteps:
+    """Per-step status parsed from ``validation_report.md``.
+
+    ``None`` means the step heading wasn't found in the report (distinct from
+    ``"skipped"`` which the validator emits explicitly). The classifier needs
+    that distinction: an absent step usually means the validator was never
+    run / crashed early, not that the step was skipped on purpose.
+    """
+
+    auxiliary: str | None = None   # Step 1
+    md5: str | None = None         # Step 2
+    config: str | None = None      # Step 3
+    fuzzy: str | None = None       # Step 4
+
+
+@dataclass(frozen=True)
+class CollectedArtifacts:
+    workspace: Path
+    strict_validation: bool
+
+    # Manifest + resolution
+    manifest_present: bool
+    manifest_parse_error: str | None
+    quantized_model_dir: Path | None
+
+    # SHOULD-have / Plan artifacts
+    model_analysis_present: bool
+    quant_plan_present: bool
+    session_context_present: bool
+
+    # MUST-have on quantized_model_dir
+    quantized_dir_exists: bool
+    has_config_json: bool
+    has_weights: bool
+    has_tokenizer: bool  # any tokenizer file present
+
+    # Validator
+    validation_report_present: bool
+    validation_steps: ValidationSteps
+
+    # Eval
+    source_eval_present: bool
+    quantized_eval_present: bool
+    eval_report_present: bool
+    eval_report_data: dict | None       # parsed eval_report.json (or None)
+    eval_skipped_reason: str | None     # contents of eval_skipped.txt if present
+
+    # SKILL.md control-plane files
+    last_phase: str | None              # contents of last_phase.txt
+    blocked_reason: str | None          # contents of blocked.md
+    fix_hypothesis_attempts: tuple[int, ...] = field(default_factory=tuple)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# parsing helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Matches a line like ``**Step 2 — MD5 spot-check**: ok``.
+# The validator emits one of ``ok`` / ``FAIL`` / ``skipped`` exactly.
+_STEP_LINE_RE = re.compile(
+    r"^\*\*Step\s+(?P<num>[1-4])\b[^*]*\*\*\s*:\s*(?P<status>ok|FAIL|skipped)\b",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+
+def _parse_validation_report(text: str) -> ValidationSteps:
+    by_num: dict[str, str] = {}
+    for m in _STEP_LINE_RE.finditer(text):
+        # Normalize to lower-case "ok"/"fail"/"skipped" for downstream compares.
+        status = m.group("status").lower()
+        if status == "fail":
+            status = "FAIL"  # keep FAIL upper-case to match the spec text
+        by_num[m.group("num")] = status
+    return ValidationSteps(
+        auxiliary=by_num.get("1"),
+        md5=by_num.get("2"),
+        config=by_num.get("3"),
+        fuzzy=by_num.get("4"),
+    )
+
+
+def _read_text(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError:
+        return None
+
+
+def _read_json(path: Path) -> tuple[dict | None, str | None]:
+    raw = _read_text(path)
+    if raw is None:
+        return None, None
+    try:
+        return json.loads(raw), None
+    except json.JSONDecodeError as exc:
+        return None, f"json_decode_error: {exc.msg} at line {exc.lineno}"
+
+
+def _resolve_quantized_dir(workspace: Path) -> tuple[Path | None, bool, str | None]:
+    """Read ``run_manifest.yaml`` and pull ``outputs.quantized_model_dir``.
+
+    Returns ``(path, manifest_present, parse_error)``. PyYAML is imported
+    lazily so the agent stays installable without it — falling back to the
+    ``nice_to_have_skipped`` (#20) outcome in that case.
+    """
+
+    manifest = workspace / "run_manifest.yaml"
+    if not manifest.is_file():
+        return None, False, None
+
+    try:
+        import yaml  # type: ignore[import-not-found]
+    except ImportError:
+        return None, True, "pyyaml_missing"
+
+    try:
+        data = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        return None, True, f"yaml_error: {exc}"
+
+    if not isinstance(data, dict):
+        return None, True, "manifest_not_mapping"
+
+    outputs = data.get("outputs") or {}
+    raw_path = outputs.get("quantized_model_dir") if isinstance(outputs, dict) else None
+    if not raw_path:
+        return None, True, "missing_outputs_quantized_model_dir"
+
+    path = Path(str(raw_path))
+    if not path.is_absolute():
+        # Manifest paths are conventionally relative to workspace.
+        path = (workspace / path).resolve()
+    return path, True, None
+
+
+def _has_any(directory: Path, names: Iterable[str]) -> bool:
+    for name in names:
+        if (directory / name).is_file():
+            return True
+    return False
+
+
+def _has_glob(directory: Path, patterns: Iterable[str]) -> bool:
+    for pat in patterns:
+        for _ in directory.glob(pat):
+            return True
+    return False
+
+
+def _scan_hypothesis_attempts(workspace: Path) -> tuple[int, ...]:
+    """Find ``fix_hypothesis_attempt_N.md`` files and return the sorted Ns.
+
+    The classifier uses these to decide if SKILL.md actually diagnosed a fix
+    before the retry was attempted (precondition for incrementing the
+    retry counter — see §A.10).
+    """
+
+    pattern = re.compile(r"^fix_hypothesis_attempt_(\d+)\.md$")
+    ns: list[int] = []
+    try:
+        for entry in workspace.iterdir():
+            m = pattern.match(entry.name)
+            if m and entry.is_file():
+                ns.append(int(m.group(1)))
+    except FileNotFoundError:
+        return ()
+    return tuple(sorted(ns))
+
+
+def _strict_validation_enabled(env: dict[str, str] | None = None) -> bool:
+    raw = (env if env is not None else os.environ).get(STRICT_VALIDATION_ENV, "1")
+    return raw.strip().lower() not in ("0", "false", "no", "")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# public entry
+# ─────────────────────────────────────────────────────────────────────────────
+
+def collect_artifacts(
+    workspace: Path,
+    *,
+    env: dict[str, str] | None = None,
+) -> CollectedArtifacts:
+    workspace = Path(workspace)
+
+    qdir, manifest_present, manifest_err = _resolve_quantized_dir(workspace)
+
+    quantized_dir_exists = bool(qdir and qdir.is_dir())
+    has_config = bool(quantized_dir_exists and (qdir / "config.json").is_file())  # type: ignore[union-attr]
+    has_weights = bool(quantized_dir_exists and _has_glob(qdir, _WEIGHT_GLOBS))   # type: ignore[arg-type]
+    has_tokenizer = bool(quantized_dir_exists and _has_any(qdir, _TOKENIZER_FILES))  # type: ignore[arg-type]
+
+    validation_text = _read_text(workspace / "validation_report.md")
+    validation_present = validation_text is not None
+    validation_steps = (
+        _parse_validation_report(validation_text) if validation_text else ValidationSteps()
+    )
+
+    eval_data, _ = _read_json(workspace / "eval_report.json")
+
+    return CollectedArtifacts(
+        workspace=workspace,
+        strict_validation=_strict_validation_enabled(env),
+        manifest_present=manifest_present,
+        manifest_parse_error=manifest_err,
+        quantized_model_dir=qdir,
+        model_analysis_present=(workspace / "model_analysis.json").is_file(),
+        quant_plan_present=(workspace / "quant_plan.json").is_file(),
+        session_context_present=(workspace / "session_context.json").is_file(),
+        quantized_dir_exists=quantized_dir_exists,
+        has_config_json=has_config,
+        has_weights=has_weights,
+        has_tokenizer=has_tokenizer,
+        validation_report_present=validation_present,
+        validation_steps=validation_steps,
+        source_eval_present=(workspace / "source_eval.md").is_file(),
+        quantized_eval_present=(workspace / "quantized_eval.md").is_file(),
+        eval_report_present=(workspace / "eval_report.json").is_file(),
+        eval_report_data=eval_data,
+        eval_skipped_reason=_read_text(workspace / "eval_skipped.txt"),
+        last_phase=(_read_text(workspace / "last_phase.txt") or "").strip() or None,
+        blocked_reason=_read_text(workspace / "blocked.md"),
+        fix_hypothesis_attempts=_scan_hypothesis_attempts(workspace),
+    )
+
+
+__all__ = [
+    "CollectedArtifacts",
+    "ValidationSteps",
+    "STRICT_VALIDATION_ENV",
+    "collect_artifacts",
+]

--- a/quantization_agent/driver/retry.py
+++ b/quantization_agent/driver/retry.py
@@ -1,0 +1,364 @@
+"""Multi-attempt orchestration: ``quantize_via_prompt`` public entry.
+
+Wraps :func:`_runner.run_one_attempt` with the diagnose-fix-retry protocol
+from ``docs/DESIGN.zh-CN.md §A.10``:
+
+  * Each attempt → classifier → outcome.
+  * ``None`` / ``eval_gap_accepted``                → done, build assessment.
+  * ``AUTO_FAIL`` (including ``upstream_change_required``) → done, failed.
+  * ``AUTO_RECOVER`` outcomes that surfaced to the final attempt → done,
+    partial (per §5.4 — SKILL.md should have auto-recovered in-session;
+    if we see one here it means the auto-recovery itself ran out of
+    budget and Python should not loop on it).
+  * ``ASK_RETRYABLE`` (#3 / #6 / #16 / #26) + ``unclassified_failure`` (#30)
+    → require ``fix_hypothesis_attempt_N.md`` from SKILL.md as the precondition
+    for incrementing ``requantize_attempts.txt`` and trying again. Hard cap
+    by ``max_requantize_attempts`` (default 1).
+  * ``checkpoint_aborted`` (#2) and ``eval_gap_exceeded`` (#21) — Ask-class
+    decision points that retrying won't help. In ``interactive=True`` we
+    relay to stdin (y/n on stderr). In CI we stop and let the assessment
+    surface the call.
+
+The counter file persists across interpreter restarts so a CI re-invocation
+of ``quantize_via_prompt`` on the same workspace continues counting from
+where the prior run left off (matters when the caller wraps us in its own
+retry budget).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+from .assessment import (
+    ASK,
+    ASK_RETRYABLE,
+    AUTO_FAIL,
+    AUTO_RECOVER,
+    Assessment,
+    build_assessment,
+    classify_attempt,
+    derive_status,
+)
+from .outcomes import OutcomeId, SUCCESS_TAGS, UNCLASSIFIED_FAILURE
+from .result_collector import CollectedArtifacts, collect_artifacts
+from .runner import AttemptResult, RunOneAttemptFn, run_one_attempt
+
+
+_COUNTER_FILE = "requantize_attempts.txt"
+
+
+@dataclass(frozen=True)
+class QuantSkillRunResult:
+    """Public return shape of :func:`quantize_via_prompt`.
+
+    Mirrors ``docs/DESIGN.zh-CN.md §3.2``. Exactly three fields by design;
+    legacy ``intent_digest`` / ``artifact_paths`` / ``sdk_error`` are folded
+    into ``assessment`` (`final` / `attempts` / `recovered` / `eval_gap` +
+    `notes`) so caller code never has to negotiate a sprawling result dict.
+    """
+
+    status: str  # "success" | "partial" | "failed"
+    quantized_model_dir: Path | None
+    assessment: Assessment
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# counter file
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _read_counter(workspace: Path) -> int:
+    f = workspace / _COUNTER_FILE
+    if not f.is_file():
+        return 0
+    try:
+        return int(f.read_text(encoding="utf-8").strip() or "0")
+    except (OSError, ValueError):
+        return 0
+
+
+def _bump_counter(workspace: Path) -> int:
+    n = _read_counter(workspace) + 1
+    (workspace / _COUNTER_FILE).write_text(str(n), encoding="utf-8")
+    return n
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# interactive prompt
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _resolve_interactive(interactive: bool | None) -> bool:
+    if interactive is not None:
+        return interactive
+    # Auto: only enable if stdin is a tty AND stderr is a tty (we use stderr
+    # for the question to avoid clobbering structured stdout). Matches the
+    # convention in the existing CLI prelude.
+    try:
+        return sys.stdin.isatty() and sys.stderr.isatty()
+    except (AttributeError, OSError):
+        return False
+
+
+def _ask_operator(message: str) -> bool:
+    print(message, file=sys.stderr, flush=True)
+    try:
+        line = sys.stdin.readline()
+    except (EOFError, KeyboardInterrupt):
+        return False
+    return line.strip().lower() in ("y", "yes")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# retry decision
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _has_fix_hypothesis(workspace: Path, attempt_number: int) -> bool:
+    """Look for the hypothesis written by SKILL.md for the NEXT attempt.
+
+    Per §A.10, before re-running quark-ptq SKILL.md must drop a concrete fix
+    plan at ``fix_hypothesis_attempt_<next>.md``. Absence is the gate that
+    prevents blind retries.
+    """
+
+    return (workspace / f"fix_hypothesis_attempt_{attempt_number + 1}.md").is_file()
+
+
+@dataclass(frozen=True)
+class _RetryDecision:
+    """Outcome of one ``_decide_next_step`` call.
+
+    Exactly one of ``retry`` / ``promote_to`` is meaningful at a time:
+    * ``retry=True`` → run another attempt; loop bumps counter.
+    * ``retry=False`` and ``promote_to`` set → operator overrode the outcome
+      (currently only ``eval_gap_exceeded → eval_gap_accepted``); loop stops
+      and rewrites the last attempt's outcome.
+    * ``retry=False`` and ``promote_to`` unset → terminal, assemble assessment.
+
+    ``note`` is appended to ``Assessment.notes`` either way for caller debugging.
+    """
+
+    retry: bool
+    note: str
+    promote_to: OutcomeId | None = None
+
+
+def _decide_next_step(
+    outcome: OutcomeId | None,
+    *,
+    workspace: Path,
+    attempt_number: int,
+    interactive: bool,
+    max_requantize_attempts: int,
+    counter: int,
+) -> _RetryDecision:
+    """Decide whether to retry, accept, or stop after one attempt."""
+
+    if outcome is None or outcome in SUCCESS_TAGS:
+        return _RetryDecision(retry=False, note="")
+    if outcome in AUTO_FAIL:
+        return _RetryDecision(retry=False, note=f"auto_fail:{outcome}")
+    if outcome in AUTO_RECOVER:
+        # Auto-recover that surfaced here means SKILL.md couldn't self-heal
+        # inside the session; Python looping won't help. §5.4.
+        return _RetryDecision(retry=False, note=f"auto_recover_unresolved:{outcome}")
+
+    # Remaining: ASK + unclassified_failure.
+    if outcome == OutcomeId.checkpoint_aborted:
+        # #2: missing prompt info — retry won't synthesize what the operator
+        # didn't say. Caller needs to amend prompt.
+        return _RetryDecision(retry=False, note="checkpoint_aborted_needs_prompt_change")
+
+    if outcome == OutcomeId.eval_gap_exceeded:
+        # #21: decision point, not a re-run candidate.
+        if interactive and _ask_operator(
+            f"[quantization-agent] Eval gap exceeded ({outcome}). "
+            f"Accept partial result? [y/N]: "
+        ):
+            return _RetryDecision(
+                retry=False,
+                note="eval_gap_accepted_by_operator",
+                promote_to=OutcomeId.eval_gap_accepted,
+            )
+        return _RetryDecision(retry=False, note="eval_gap_exceeded_rejected")
+
+    # ASK_RETRYABLE (#3 / #6 / #16 / #26) + UNCLASSIFIED_FAILURE (#30) — only
+    # these increment ``requantize_attempts.txt``.
+    if outcome in ASK_RETRYABLE or outcome == UNCLASSIFIED_FAILURE:
+        if counter >= max_requantize_attempts:
+            return _RetryDecision(
+                retry=False,
+                note=f"max_attempts_exhausted:counter={counter}/{max_requantize_attempts}",
+            )
+        if not _has_fix_hypothesis(workspace, attempt_number):
+            return _RetryDecision(retry=False, note="no_fix_hypothesis")
+        if interactive and not _ask_operator(
+            f"[quantization-agent] Outcome `{outcome}` → fix hypothesis at "
+            f"fix_hypothesis_attempt_{attempt_number + 1}.md. Retry? [y/N]: "
+        ):
+            return _RetryDecision(retry=False, note="operator_declined_retry")
+        return _RetryDecision(retry=True, note="")
+
+    # Other ASK rows (none currently — partition keeps them in the sets above).
+    return _RetryDecision(retry=False, note=f"non_retryable_ask:{outcome}")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# main entry
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def quantize_via_prompt(
+    prompt: str,
+    *,
+    workspace: str | os.PathLike,
+    quark_root: str | os.PathLike | None = None,
+    interactive: bool | None = None,
+    acceptable_eval_gap: float | None = None,
+    max_requantize_attempts: int = 1,
+    model: str | None = None,
+    runner_fn: RunOneAttemptFn | None = None,
+    log: Callable[[str], None] | None = None,
+) -> QuantSkillRunResult:
+    """Run the quantization-agent against ``prompt`` and return a result.
+
+    All inputs except ``prompt`` and ``workspace`` are optional. ``quark_root``
+    falls back to ``$QUARK_ROOT`` then to a hard error (mapped to
+    ``quark_root_missing`` at the assessment level). The threshold resolves
+    per ``_eval.resolve_threshold``; the interactive flag per
+    ``_resolve_interactive``.
+    """
+
+    workspace_path = Path(workspace).resolve()
+    workspace_path.mkdir(parents=True, exist_ok=True)
+
+    if quark_root is None:
+        quark_root_env = os.environ.get("QUARK_ROOT")
+        if not quark_root_env:
+            return _build_failed_bootstrap_result(
+                workspace_path, OutcomeId.quark_root_missing,
+                "QUARK_ROOT not set and quark_root not passed",
+            )
+        quark_root = quark_root_env
+    quark_root_path = Path(quark_root).expanduser()
+    if not quark_root_path.is_dir():
+        return _build_failed_bootstrap_result(
+            workspace_path, OutcomeId.quark_root_missing,
+            f"quark_root path does not exist or is not a directory: {quark_root_path}",
+        )
+
+    interactive_resolved = _resolve_interactive(interactive)
+    run_attempt: RunOneAttemptFn = runner_fn or run_one_attempt
+
+    attempts_list: list[OutcomeId | None] = []
+    notes: list[str] = []
+    last_outcome: OutcomeId | None = None
+    artifacts: CollectedArtifacts | None = None
+
+    attempt_n = 1
+    while True:
+        attempt_result = await run_attempt(
+            user_prompt=prompt,
+            workspace=workspace_path,
+            quark_root=quark_root_path,
+            attempt_number=attempt_n,
+            acceptable_eval_gap=acceptable_eval_gap,
+            interactive=interactive_resolved,
+            previous_outcome=last_outcome.value if isinstance(last_outcome, OutcomeId) else None,
+            model=model,
+            log=log,
+        )
+
+        artifacts = collect_artifacts(workspace_path)
+        outcome = classify_attempt(
+            workspace_path,
+            sdk_error=attempt_result.sdk_error or None,
+            last_phase=artifacts.last_phase,
+            acceptable_eval_gap=acceptable_eval_gap,
+            artifacts=artifacts,
+        )
+        attempts_list.append(outcome)
+        last_outcome = outcome
+
+        counter = _read_counter(workspace_path)
+        decision = _decide_next_step(
+            outcome,
+            workspace=workspace_path,
+            attempt_number=attempt_n,
+            interactive=interactive_resolved,
+            max_requantize_attempts=max_requantize_attempts,
+            counter=counter,
+        )
+        if decision.note:
+            notes.append(decision.note)
+        if decision.promote_to is not None:
+            # Operator overrode the outcome — rewrite the final attempt so the
+            # assembled Assessment is self-consistent (no post-hoc patching).
+            attempts_list[-1] = decision.promote_to
+            last_outcome = decision.promote_to
+        if not decision.retry:
+            break
+
+        new_counter = _bump_counter(workspace_path)
+        if log:
+            log(
+                f"quantization-agent: retrying after outcome={outcome} "
+                f"(counter={new_counter}/{max_requantize_attempts})"
+            )
+        attempt_n += 1
+
+    assessment = build_assessment(
+        attempts_list, workspace=workspace_path, artifacts=artifacts, notes=tuple(notes)
+    )
+
+    status = derive_status(assessment, artifacts)  # type: ignore[arg-type]
+    quantized_model_dir = (
+        artifacts.quantized_model_dir
+        if artifacts and status != "failed" and artifacts.quantized_model_dir and artifacts.has_weights
+        else None
+    )
+    return QuantSkillRunResult(
+        status=status,
+        quantized_model_dir=quantized_model_dir,
+        assessment=assessment,
+    )
+
+
+def _build_failed_bootstrap_result(
+    workspace: Path,
+    outcome: OutcomeId,
+    note: str,
+) -> QuantSkillRunResult:
+    """Fast-path failure that bypasses the SDK (used for bootstrap errors).
+
+    Produces a well-formed ``QuantSkillRunResult`` so callers can branch on
+    ``status`` / ``assessment.final`` without special-casing pre-flight
+    failures.
+    """
+
+    return QuantSkillRunResult(
+        status="failed",
+        quantized_model_dir=None,
+        assessment=Assessment(
+            final=outcome,
+            attempts=(outcome,),
+            recovered=False,
+            eval_gap=None,
+            notes=(note,),
+        ),
+    )
+
+
+# Convenience sync wrapper for the CLI smoke path. The library entry remains
+# async to compose cleanly with the orchestrator's asyncio loop.
+def quantize_via_prompt_sync(prompt: str, **kwargs: Any) -> QuantSkillRunResult:
+    return asyncio.run(quantize_via_prompt(prompt, **kwargs))
+
+
+__all__ = [
+    "QuantSkillRunResult",
+    "quantize_via_prompt",
+    "quantize_via_prompt_sync",
+]

--- a/quantization_agent/driver/retry.py
+++ b/quantization_agent/driver/retry.py
@@ -119,7 +119,7 @@ def _ask_operator(message: str) -> bool:
 def _has_fix_hypothesis(workspace: Path, attempt_number: int) -> bool:
     """Look for the hypothesis written by SKILL.md for the NEXT attempt.
 
-    Per §A.10, before re-running quark-ptq SKILL.md must drop a concrete fix
+    Per §A.10, before re-running quark-torch-ptq SKILL.md must drop a concrete fix
     plan at ``fix_hypothesis_attempt_<next>.md``. Absence is the gate that
     prevents blind retries.
     """

--- a/quantization_agent/driver/runner.py
+++ b/quantization_agent/driver/runner.py
@@ -1,0 +1,273 @@
+"""One-attempt SDK driver for the quantization-agent.
+
+Mirrors :mod:`kernel-agent.tools.tracelens_skill_runner`:
+
+* keyword-only public API,
+* lazy ``_import_sdk`` with explicit ``sdk_query_factory`` / ``sdk_options_cls``
+  injection seams so tests don't need the SDK installed,
+* ``cwd = quark_root`` with graceful fallback for older SDK builds,
+* SDK errors are stored on the result rather than raised — the classifier in
+  :mod:`driver.assessment` decides whether to fail the attempt by reading the
+  workspace state alongside ``sdk_error``,
+* a single ``log`` callable so the caller can route output to its logger.
+
+The agent leans entirely on ``SKILL.md`` as the runtime contract: this module
+just plumbs ``(workspace, quark_root, attempt_n, threshold, interactive,
+user_prompt)`` into a templated prompt and hands it to the SDK.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Iterable
+
+
+DEFAULT_MODEL = "claude-opus-4-7"
+DEFAULT_ALLOWED_TOOLS = ["Read", "Write", "Edit", "Bash"]
+DEFAULT_MAX_TURNS = 240  # ~ Quark workflow has 4 STOPs + validator + eval; generous
+
+SKILL_RELATIVE_PATH = "SKILL.md"
+
+
+@dataclass
+class AttemptResult:
+    """Low-level output of one SDK session.
+
+    The classifier consumes ``workspace`` + ``sdk_error`` + ``last_phase``;
+    ``raw_text`` is kept for debugging / logging only.
+    """
+
+    workspace: Path
+    sdk_error: str = ""
+    raw_text: str = ""
+    chunks: list[str] = field(default_factory=list)
+
+
+def _import_sdk() -> tuple[Any, Any]:
+    try:
+        import claude_agent_sdk as sdk  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - exercised via injection seams in tests
+        raise RuntimeError(
+            "claude_agent_sdk not installed; run the quantization-agent installer"
+        ) from exc
+    if not (hasattr(sdk, "query") and hasattr(sdk, "ClaudeAgentOptions")):
+        raise RuntimeError("claude_agent_sdk missing query / ClaudeAgentOptions")
+    return sdk.query, sdk.ClaudeAgentOptions
+
+
+def _iter_message_text(message: Any) -> Iterable[str]:
+    for block in list(getattr(message, "content", None) or []):
+        text = getattr(block, "text", None)
+        if isinstance(text, str) and text:
+            yield text
+        elif isinstance(block, dict) and isinstance(block.get("text"), str):
+            yield block["text"]
+    result_text = getattr(message, "result", None)
+    if isinstance(result_text, str) and result_text:
+        yield result_text
+
+
+def resolve_skill_path(package_root: Path | None = None) -> Path:
+    """Return the on-disk path of ``quantization_agent/SKILL.md``.
+
+    The SKILL is the runtime contract loaded into every attempt; resolution
+    is centralized here so callers (including the CLI smoke test) don't
+    hardcode the layout.
+    """
+
+    # __file__ is .../quantization_agent/driver/runner.py — SKILL.md lives one
+    # level up at the package root (a runtime contract, not a driver detail).
+    root = package_root if package_root is not None else Path(__file__).resolve().parent.parent
+    return root / SKILL_RELATIVE_PATH
+
+
+def build_attempt_prompt(
+    *,
+    user_prompt: str,
+    skill_path: Path,
+    workspace: Path,
+    quark_root: Path,
+    attempt_number: int,
+    acceptable_eval_gap: float | None,
+    interactive: bool | None,
+    previous_outcome: str | None,
+    fix_hypothesis_path: Path | None,
+) -> str:
+    """Assemble the prompt handed to the SDK for one attempt.
+
+    The runtime contract is in ``SKILL.md``; this prompt just pins the run
+    context (workspace / quark_root / attempt / threshold / interactivity)
+    and embeds the verbatim user prompt. Retry attempts also reference the
+    prior outcome ID + the fix-hypothesis file SKILL.md wrote at the end of
+    the previous attempt, so the LLM can target the diagnosed cause rather
+    than re-running the same plan blindly.
+    """
+
+    interactive_str = (
+        "auto (use stdin if a tty is attached)"
+        if interactive is None
+        else ("on (always relay checkpoints to operator)" if interactive else "off (batch / non-interactive)")
+    )
+    threshold_str = (
+        f"{acceptable_eval_gap:.4f} (caller-supplied)"
+        if acceptable_eval_gap is not None
+        else "see SKILL.md §Eval (caller did not override; resolve from eval_gap_threshold.txt or default 0.03)"
+    )
+    retry_block = ""
+    if attempt_number > 1 and previous_outcome:
+        hint = (
+            f"\n- Fix hypothesis from prior attempt: {fix_hypothesis_path}"
+            if fix_hypothesis_path is not None
+            else ""
+        )
+        retry_block = (
+            f"\n\n## Retry context\nThis is attempt #{attempt_number}. The previous "
+            f"attempt ended with outcome `{previous_outcome}`. Diagnose and apply the "
+            f"fix you wrote in `fix_hypothesis_attempt_{attempt_number}.md` before "
+            f"re-running quark-ptq.{hint}"
+        )
+
+    return f"""You are the Hyperloom quantization-agent.
+
+Read and follow the FULL runtime contract in this skill file:
+{skill_path}
+
+## Run context (passed in via prompt; SKILL.md tells you what to do with these)
+- Workspace (write all your artifacts here): {workspace}
+- Quark project root (READ-ONLY; never edit files under this path): {quark_root}
+- Attempt number: {attempt_number}
+- Acceptable eval gap: {threshold_str}
+- Interactive mode: {interactive_str}{retry_block}
+
+## User prompt (verbatim)
+{user_prompt}
+
+Begin the workflow now. Do not ask the user clarifying questions unless the
+SKILL.md retry/checkpoint protocol explicitly requires it.
+"""
+
+
+async def run_one_attempt(
+    *,
+    user_prompt: str,
+    workspace: Path,
+    quark_root: Path,
+    attempt_number: int = 1,
+    acceptable_eval_gap: float | None = None,
+    interactive: bool | None = None,
+    previous_outcome: str | None = None,
+    skill_path: Path | None = None,
+    model: str | None = None,
+    max_turns: int = DEFAULT_MAX_TURNS,
+    allowed_tools: list[str] | None = None,
+    sdk_query_factory: Callable[..., Any] | None = None,
+    sdk_options_cls: Any | None = None,
+    log: Callable[[str], None] | None = None,
+) -> AttemptResult:
+    """Run one SDK session driving SKILL.md.
+
+    Errors raised by the SDK (rate limits, max turns, network) are captured
+    and returned via ``AttemptResult.sdk_error`` rather than propagated, so
+    the retry loop can read the workspace state — which often contains valid
+    artifacts even when the SDK aborted late.
+    """
+
+    workspace = Path(workspace)
+    workspace.mkdir(parents=True, exist_ok=True)
+    quark_root = Path(quark_root)
+
+    skill_path = skill_path or resolve_skill_path()
+    if not skill_path.is_file():
+        raise FileNotFoundError(f"SKILL.md not found at {skill_path}")
+
+    fix_hypothesis_path: Path | None = None
+    if attempt_number > 1:
+        candidate = workspace / f"fix_hypothesis_attempt_{attempt_number}.md"
+        fix_hypothesis_path = candidate if candidate.is_file() else None
+
+    prompt = build_attempt_prompt(
+        user_prompt=user_prompt,
+        skill_path=skill_path,
+        workspace=workspace,
+        quark_root=quark_root,
+        attempt_number=attempt_number,
+        acceptable_eval_gap=acceptable_eval_gap,
+        interactive=interactive,
+        previous_outcome=previous_outcome,
+        fix_hypothesis_path=fix_hypothesis_path,
+    )
+
+    if sdk_query_factory is None or sdk_options_cls is None:
+        query, options_cls = _import_sdk()
+        sdk_query_factory = sdk_query_factory or query
+        sdk_options_cls = sdk_options_cls or options_cls
+
+    system_prompt = (
+        "You are the Hyperloom quantization-agent. Drive the Quark workflow per "
+        "SKILL.md. Never modify files under quark_root. Treat artifact presence "
+        "in workspace as the source of truth; do not lie about success."
+    )
+    kwargs: dict[str, Any] = {
+        "max_turns": max_turns,
+        "system_prompt": system_prompt,
+        "allowed_tools": allowed_tools or DEFAULT_ALLOWED_TOOLS,
+        "stderr": (lambda line: log(f"[claude-sdk] {line.rstrip()}")) if log else None,
+    }
+    if model:
+        kwargs["model"] = model
+    kwargs["cwd"] = str(quark_root)
+
+    try:
+        options = sdk_options_cls(**kwargs)
+    except TypeError:
+        # Older SDK builds may not support cwd; prompt + SKILL.md use absolute
+        # paths so retrying without cwd is safe.
+        kwargs.pop("cwd", None)
+        options = sdk_options_cls(**kwargs)
+
+    chunks: list[str] = []
+    sdk_error = ""
+
+    if log:
+        log(
+            f"quantization-agent SDK runner: workspace={workspace} "
+            f"quark_root={quark_root} attempt={attempt_number}"
+        )
+
+    try:
+        async for message in sdk_query_factory(prompt=prompt, options=options):
+            for text in _iter_message_text(message):
+                chunks.append(text)
+                if log:
+                    log(f"[claude-sdk] {text[:1000]}")
+    except Exception as exc:  # noqa: BLE001
+        # Per kernel-agent precedent: capture the error but don't raise —
+        # SKILL.md may have produced valid artifacts before the SDK aborted
+        # (e.g. "max turns reached" after validate phase finished).
+        sdk_error = f"{type(exc).__name__}: {exc}"
+        if log:
+            log(f"[claude-sdk] WARNING: {sdk_error}")
+
+    return AttemptResult(
+        workspace=workspace,
+        sdk_error=sdk_error,
+        raw_text="\n".join(chunks),
+        chunks=chunks,
+    )
+
+
+# Type alias for the injection seam used in tests + by driver/retry.py.
+RunOneAttemptFn = Callable[..., Awaitable[AttemptResult]]
+
+
+__all__ = [
+    "AttemptResult",
+    "DEFAULT_ALLOWED_TOOLS",
+    "DEFAULT_MAX_TURNS",
+    "DEFAULT_MODEL",
+    "RunOneAttemptFn",
+    "build_attempt_prompt",
+    "resolve_skill_path",
+    "run_one_attempt",
+]

--- a/quantization_agent/driver/runner.py
+++ b/quantization_agent/driver/runner.py
@@ -125,7 +125,7 @@ def build_attempt_prompt(
             f"\n\n## Retry context\nThis is attempt #{attempt_number}. The previous "
             f"attempt ended with outcome `{previous_outcome}`. Diagnose and apply the "
             f"fix you wrote in `fix_hypothesis_attempt_{attempt_number}.md` before "
-            f"re-running quark-ptq.{hint}"
+            f"re-running quark-torch-ptq.{hint}"
         )
 
     return f"""You are the Hyperloom quantization-agent.

--- a/quantization_agent/scripts/install.sh
+++ b/quantization_agent/scripts/install.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# quantization-agent installer.
+#
+# Sets up the runtime quantization-agent needs:
+#   - claude-agent-sdk  (already pinned in inference_optimizer's pyproject.toml,
+#                        but we install it explicitly so the agent is usable
+#                        standalone)
+#   - amd-quark         (editable install from $QUARK_ROOT/Quark so the agent's
+#                        Step 1 model-intake helper can resolve quark.*)
+#   - PyYAML            (used by result_collector to parse run_manifest.yaml)
+#
+# Mirrors the contract of kernel-agent/scripts/install.sh but is deliberately
+# small — quantization-agent is a thin SDK wrapper, not a build/test rig.
+
+set -euo pipefail
+
+QUANTIZATION_AGENT_ROOT="${QUANTIZATION_AGENT_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+
+# QUARK_ROOT defaults to the canonical checkout location on Hyperloom hosts.
+# Operators should override when their checkout lives elsewhere — the runner's
+# resolve_quark_root() honours $QUARK_ROOT as the first fallback after the
+# explicit kwarg.
+QUARK_ROOT="${QUARK_ROOT:-/scratch/kewang/workspace/Quark}"
+
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+log() { printf '[quantization-agent install] %s\n' "$*"; }
+
+# 1. Sanity-check the Quark checkout.
+if [ ! -d "$QUARK_ROOT" ]; then
+  log "ERROR: QUARK_ROOT=$QUARK_ROOT does not exist."
+  log "       Either clone amd-quark there, or export QUARK_ROOT=<path-to-Quark> before re-running."
+  exit 1
+fi
+SKILL_ENTRY="$QUARK_ROOT/.claude/skills/quark-torch-ptq/SKILL.md"
+if [ ! -f "$SKILL_ENTRY" ]; then
+  log "ERROR: $SKILL_ENTRY not found — does this Quark checkout include the .claude/skills tree?"
+  exit 1
+fi
+log "Quark repo: $QUARK_ROOT"
+log "PTQ skill entry: $SKILL_ENTRY"
+
+# 2. claude-agent-sdk — try to import first to keep idempotent reruns cheap.
+if ! "$PYTHON_BIN" -c "import claude_agent_sdk" >/dev/null 2>&1; then
+  log "installing claude-agent-sdk via pip"
+  "$PYTHON_BIN" -m pip install --quiet 'claude-agent-sdk>=0.1.65'
+else
+  log "claude-agent-sdk already importable"
+fi
+
+# 3. amd-quark — install editable from $QUARK_ROOT if the repo has a setup.py /
+# pyproject.toml. Otherwise fall back to pip's amd-quark wheel (Quark publishes
+# wheels for cuda + rocm builds; pip picks the right one).
+if ! "$PYTHON_BIN" -c "import quark" >/dev/null 2>&1; then
+  if [ -f "$QUARK_ROOT/pyproject.toml" ] || [ -f "$QUARK_ROOT/setup.py" ]; then
+    log "installing amd-quark editable from $QUARK_ROOT"
+    "$PYTHON_BIN" -m pip install --quiet -e "$QUARK_ROOT"
+  else
+    log "installing amd-quark wheel via pip (no setup.py/pyproject.toml at $QUARK_ROOT)"
+    "$PYTHON_BIN" -m pip install --quiet amd-quark
+  fi
+else
+  log "quark already importable"
+fi
+
+# 4. PyYAML — required by result_collector for run_manifest.yaml parsing.
+if ! "$PYTHON_BIN" -c "import yaml" >/dev/null 2>&1; then
+  log "installing PyYAML"
+  "$PYTHON_BIN" -m pip install --quiet 'PyYAML>=6.0'
+else
+  log "PyYAML already importable"
+fi
+
+# 5. Self-test: import the agent's own modules to surface syntax errors early.
+log "self-test: importing quantization-agent modules"
+PYTHONPATH="$QUANTIZATION_AGENT_ROOT/tools:${PYTHONPATH:-}" \
+  "$PYTHON_BIN" -c "
+import intent, result_collector, runner
+i = intent.normalize_intent({'global_scheme': 'fp8'})
+assert i.global_scheme == 'fp8'
+print(f'intent_digest={intent.intent_hash(i)}')
+print('OK')
+"
+
+# 6. Optional: persist QUARK_ROOT to a small env file so other shells pick it
+# up. Skipped if HYPERLOOM_RUNTIME_DIR is unset to avoid polluting random
+# /tmp paths.
+if [ -n "${HYPERLOOM_RUNTIME_DIR:-}" ]; then
+  ENV_FILE="${HYPERLOOM_RUNTIME_DIR}/quantization-agent.env.sh"
+  mkdir -p "$(dirname "$ENV_FILE")"
+  cat > "$ENV_FILE" <<EOF
+export QUARK_ROOT="$QUARK_ROOT"
+export QUANTIZATION_AGENT_ROOT="$QUANTIZATION_AGENT_ROOT"
+EOF
+  log "wrote $ENV_FILE"
+fi
+
+log "install complete"

--- a/quantization_agent/tests/conftest.py
+++ b/quantization_agent/tests/conftest.py
@@ -1,0 +1,276 @@
+"""Shared fixtures for quantization_agent tests.
+
+Most tests build a synthetic workspace on tmp_path and feed it to the
+classifier / retry loop directly. Two helpers are exposed here:
+
+* ``build_workspace`` — turn a small dict of artifact stubs into a
+  workspace dir, no Quark / SDK needed.
+* ``FakeSDK`` — a callable matching the injection seam in
+  ``driver.runner.run_one_attempt`` (``sdk_query_factory`` + ``sdk_options_cls``).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, AsyncIterator, Callable
+
+import pytest
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# workspace builder
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Validation-report snippets keyed by short tag. Tests pick the tag they need
+# rather than copy-paste markdown.
+_VALIDATION_REPORTS: dict[str, str] = {
+    "all_ok": (
+        "## Validation Report — quark-quantization-result-validator\n\n"
+        "**Step 4 — fuzzy tensor names**: ok\n\n"
+        "**Step 1 — auxiliary files**: ok\n\n"
+        "**Step 3 — config.json**: ok\n\n"
+        "**Step 2 — MD5 spot-check**: ok\n"
+    ),
+    "md5_fail": (
+        "**Step 4 — fuzzy tensor names**: ok\n"
+        "**Step 1 — auxiliary files**: ok\n"
+        "**Step 3 — config.json**: ok\n"
+        "**Step 2 — MD5 spot-check**: FAIL\n"
+    ),
+    "config_fail": (
+        "**Step 4 — fuzzy tensor names**: ok\n"
+        "**Step 1 — auxiliary files**: ok\n"
+        "**Step 3 — config.json**: FAIL\n"
+        "**Step 2 — MD5 spot-check**: ok\n"
+    ),
+    "fuzzy_fail": (
+        "**Step 4 — fuzzy tensor names**: FAIL\n"
+        "**Step 1 — auxiliary files**: ok\n"
+        "**Step 3 — config.json**: ok\n"
+        "**Step 2 — MD5 spot-check**: ok\n"
+    ),
+    "aux_fail": (
+        "**Step 4 — fuzzy tensor names**: ok\n"
+        "**Step 1 — auxiliary files**: FAIL\n"
+        "**Step 3 — config.json**: ok\n"
+        "**Step 2 — MD5 spot-check**: ok\n"
+    ),
+    "must_validate_skipped": (
+        "**Step 4 — fuzzy tensor names**: ok\n"
+        "**Step 1 — auxiliary files**: ok\n"
+        "**Step 3 — config.json**: skipped\n"
+        "**Step 2 — MD5 spot-check**: skipped\n"
+    ),
+}
+
+
+def _write_manifest(workspace: Path, quantized_dir: Path) -> None:
+    """Write a minimal run_manifest.yaml. PyYAML required (skip otherwise)."""
+
+    pytest.importorskip("yaml")
+    import yaml
+
+    payload = {
+        "version": "1",
+        "outputs": {"quantized_model_dir": str(quantized_dir)},
+    }
+    (workspace / "run_manifest.yaml").write_text(
+        yaml.safe_dump(payload), encoding="utf-8"
+    )
+
+
+def _make_quantized_dir(
+    workspace: Path,
+    *,
+    include_config: bool = True,
+    include_weights: bool = True,
+    include_tokenizer: bool = True,
+) -> Path:
+    qdir = workspace / "quantized-model"
+    qdir.mkdir(parents=True, exist_ok=True)
+    if include_config:
+        (qdir / "config.json").write_text("{}", encoding="utf-8")
+    if include_weights:
+        (qdir / "model.safetensors").write_bytes(b"\x00" * 16)
+    if include_tokenizer:
+        (qdir / "tokenizer.json").write_text("{}", encoding="utf-8")
+    return qdir
+
+
+@dataclass
+class WorkspaceBuilder:
+    """Fluent builder mirroring the artifact fields SKILL.md writes.
+
+    Defaults to a fully-successful run (manifest + quantized dir + all-ok
+    validation_report + eval_report with 0% gap). Tests subtract or override
+    pieces to simulate failure modes.
+    """
+
+    workspace: Path
+    include_manifest: bool = True
+    include_quantized_dir: bool = True
+    include_config: bool = True
+    include_weights: bool = True
+    include_tokenizer: bool = True
+    include_validation_report: bool = True
+    validation_tag: str = "all_ok"
+    include_eval_report: bool = True
+    eval_report: dict[str, Any] | None = None
+    eval_skipped_reason: str | None = None
+    last_phase: str | None = None
+    blocked_md: str | None = None
+    fix_hypotheses: tuple[int, ...] = ()
+    requantize_attempts: int | None = None
+    eval_gap_threshold: float | None = None
+    model_analysis: bool = True
+    quant_plan: bool = True
+    session_context: bool = True
+
+    def build(self) -> Path:
+        ws = self.workspace
+        ws.mkdir(parents=True, exist_ok=True)
+
+        if self.model_analysis:
+            (ws / "model_analysis.json").write_text("{}", encoding="utf-8")
+        if self.quant_plan:
+            (ws / "quant_plan.json").write_text("{}", encoding="utf-8")
+        if self.session_context:
+            (ws / "session_context.json").write_text("{}", encoding="utf-8")
+
+        if self.include_quantized_dir:
+            qdir = _make_quantized_dir(
+                ws,
+                include_config=self.include_config,
+                include_weights=self.include_weights,
+                include_tokenizer=self.include_tokenizer,
+            )
+        else:
+            qdir = ws / "quantized-model"  # path referenced by manifest but absent
+
+        if self.include_manifest:
+            _write_manifest(ws, qdir)
+
+        if self.include_validation_report:
+            (ws / "validation_report.md").write_text(
+                _VALIDATION_REPORTS[self.validation_tag], encoding="utf-8"
+            )
+
+        if self.include_eval_report:
+            payload = self.eval_report or {
+                "metric_name": "gsm8k",
+                "dataset": "gsm8k",
+                "backend": "vllm",
+                "source_score": 0.50,
+                "quantized_score": 0.50,
+                "relative_gap": 0.0,
+            }
+            (ws / "eval_report.json").write_text(json.dumps(payload), encoding="utf-8")
+            (ws / "source_eval.md").write_text("source", encoding="utf-8")
+            (ws / "quantized_eval.md").write_text("quantized", encoding="utf-8")
+
+        if self.eval_skipped_reason is not None:
+            (ws / "eval_skipped.txt").write_text(self.eval_skipped_reason, encoding="utf-8")
+
+        if self.last_phase is not None:
+            (ws / "last_phase.txt").write_text(self.last_phase, encoding="utf-8")
+
+        if self.blocked_md is not None:
+            (ws / "blocked.md").write_text(self.blocked_md, encoding="utf-8")
+
+        for n in self.fix_hypotheses:
+            (ws / f"fix_hypothesis_attempt_{n}.md").write_text(
+                f"# Fix hypothesis for attempt {n}\n", encoding="utf-8"
+            )
+
+        if self.requantize_attempts is not None:
+            (ws / "requantize_attempts.txt").write_text(
+                str(self.requantize_attempts), encoding="utf-8"
+            )
+
+        if self.eval_gap_threshold is not None:
+            (ws / "eval_gap_threshold.txt").write_text(
+                str(self.eval_gap_threshold), encoding="utf-8"
+            )
+
+        return ws
+
+
+@pytest.fixture
+def build_workspace(tmp_path: Path) -> Callable[..., Path]:
+    """Return a factory: ``build_workspace(**overrides) → Path``."""
+
+    def _factory(**overrides: Any) -> Path:
+        ws = overrides.pop("workspace", tmp_path)
+        builder = WorkspaceBuilder(workspace=ws, **overrides)
+        return builder.build()
+
+    return _factory
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# fake SDK
+# ─────────────────────────────────────────────────────────────────────────────
+
+class FakeMessage:
+    def __init__(self, text: str):
+        self.content = [type("Block", (), {"text": text})()]
+
+
+@dataclass
+class FakeOptions:
+    """Captures kwargs passed to ``sdk_options_cls``. Plays the role of
+    ``claude_agent_sdk.ClaudeAgentOptions`` in tests without touching network.
+    """
+
+    kwargs: dict[str, Any] = field(default_factory=dict)
+
+    def __init__(self, **kwargs: Any):
+        # Accept any kwarg set without validation.
+        self.kwargs = dict(kwargs)
+
+
+@dataclass
+class FakeSDK:
+    """Stub for ``sdk_query_factory`` — records prompts and replays scripted
+    responses. Pass to ``run_one_attempt(sdk_query_factory=..., sdk_options_cls=...)``.
+
+    ``side_effect`` (when set) is raised on the next call. ``scripted_chunks``
+    yields each string as a separate message.
+    """
+
+    scripted_chunks: list[str] = field(default_factory=lambda: ["fake-sdk: ok"])
+    side_effect: Exception | None = None
+    received_prompts: list[str] = field(default_factory=list)
+    received_options: list[FakeOptions] = field(default_factory=list)
+
+    def __call__(self, *, prompt: str, options: FakeOptions) -> AsyncIterator[Any]:
+        self.received_prompts.append(prompt)
+        self.received_options.append(options)
+        if self.side_effect is not None:
+            err = self.side_effect
+
+            async def _raise() -> AsyncIterator[Any]:
+                raise err
+                yield  # pragma: no cover
+
+            return _raise()
+
+        chunks = list(self.scripted_chunks)
+
+        async def _gen() -> AsyncIterator[Any]:
+            for c in chunks:
+                yield FakeMessage(c)
+
+        return _gen()
+
+
+@pytest.fixture
+def fake_sdk() -> FakeSDK:
+    return FakeSDK()
+
+
+@pytest.fixture
+def fake_options_cls() -> type[FakeOptions]:
+    return FakeOptions

--- a/quantization_agent/tests/conftest.py
+++ b/quantization_agent/tests/conftest.py
@@ -27,7 +27,7 @@ import pytest
 # rather than copy-paste markdown.
 _VALIDATION_REPORTS: dict[str, str] = {
     "all_ok": (
-        "## Validation Report — quark-quantization-result-validator\n\n"
+        "## Validation Report — quark-torch-result-validator\n\n"
         "**Step 4 — fuzzy tensor names**: ok\n\n"
         "**Step 1 — auxiliary files**: ok\n\n"
         "**Step 3 — config.json**: ok\n\n"

--- a/quantization_agent/tests/test_assessment_classifier.py
+++ b/quantization_agent/tests/test_assessment_classifier.py
@@ -36,7 +36,7 @@ def test_workspace_unwritable_from_sdk_error(build_workspace):
 def test_quark_skill_unavailable_from_sdk_error(build_workspace):
     ws = build_workspace()
     assert classify_attempt(
-        ws, sdk_error="Quark skill.md missing at .claude/skills/quark-ptq/SKILL.md"
+        ws, sdk_error="Quark skill.md missing at .claude/skills/quark-torch-ptq/SKILL.md"
     ) == OutcomeId.quark_skill_unavailable
 
 

--- a/quantization_agent/tests/test_assessment_classifier.py
+++ b/quantization_agent/tests/test_assessment_classifier.py
@@ -1,0 +1,388 @@
+"""classify_attempt — one fixture per outcome row (where artifact-driven).
+
+A few outcomes (e.g. quark_skill_unavailable, validator_self_test_failed) are
+only visible to the runner via sdk_error or the LLM's blocked.md; the
+classifier covers them via the sdk_error pattern path or the
+blocked.md outcome-id parser.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from quantization_agent.driver.assessment import Assessment, build_assessment, classify_attempt, derive_status
+from quantization_agent.driver.outcomes import OutcomeId
+from quantization_agent.driver.result_collector import collect_artifacts
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# bootstrap / sdk_error path
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_quark_root_missing_from_sdk_error(build_workspace):
+    ws = build_workspace()
+    assert classify_attempt(
+        ws, sdk_error="RuntimeError: QUARK_ROOT not set; quark_root missing"
+    ) == OutcomeId.quark_root_missing
+
+
+def test_workspace_unwritable_from_sdk_error(build_workspace):
+    ws = build_workspace()
+    assert classify_attempt(
+        ws, sdk_error="PermissionError: [Errno 13] cannot write to workspace /tmp/foo"
+    ) == OutcomeId.workspace_unwritable
+
+
+def test_quark_skill_unavailable_from_sdk_error(build_workspace):
+    ws = build_workspace()
+    assert classify_attempt(
+        ws, sdk_error="Quark skill.md missing at .claude/skills/quark-ptq/SKILL.md"
+    ) == OutcomeId.quark_skill_unavailable
+
+
+def test_sdk_runtime_error_rate_limit(build_workspace):
+    ws = build_workspace()
+    assert classify_attempt(
+        ws, sdk_error="anthropic.RateLimitError: 429 rate limit exceeded"
+    ) == OutcomeId.sdk_runtime_error
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# explicit blocked.md outcome marker
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_blocked_md_outcome_marker_wins(build_workspace):
+    # Even with a fully-successful artifact set, an explicit blocked.md
+    # marker overrides — SKILL.md knows something disk evidence doesn't.
+    ws = build_workspace(blocked_md="outcome_id: upstream_change_required\nreason: needs quark patch")
+    assert classify_attempt(ws) == OutcomeId.upstream_change_required
+
+
+def test_blocked_md_invalid_outcome_id_ignored(build_workspace):
+    # Unknown outcome string in blocked.md → fall through to disk scan.
+    ws = build_workspace(blocked_md="outcome_id: not_a_real_outcome\n")
+    assert classify_attempt(ws) is None  # successful artifacts
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# phase-aware artifact gaps
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_analysis_missing_under_intake_phase(build_workspace):
+    ws = build_workspace(
+        include_manifest=False,
+        include_quantized_dir=False,
+        include_validation_report=False,
+        include_eval_report=False,
+        model_analysis=False,
+        quant_plan=False,
+        last_phase="intake",
+    )
+    assert classify_attempt(ws) == OutcomeId.analysis_artifact_invalid_or_missing
+
+
+def test_plan_missing_under_plan_phase(build_workspace):
+    ws = build_workspace(
+        include_manifest=False,
+        include_quantized_dir=False,
+        include_validation_report=False,
+        include_eval_report=False,
+        quant_plan=False,
+        last_phase="plan",
+    )
+    assert classify_attempt(ws) == OutcomeId.plan_artifact_invalid_or_missing
+
+
+def test_manifest_missing_under_manifest_phase(build_workspace):
+    ws = build_workspace(
+        include_manifest=False,
+        include_quantized_dir=False,
+        include_validation_report=False,
+        include_eval_report=False,
+        last_phase="manifest",
+    )
+    assert classify_attempt(ws) == OutcomeId.manifest_artifact_invalid_or_missing
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# MUST-have on quantized dir
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_must_have_weights_missing(build_workspace):
+    ws = build_workspace(include_weights=False, include_validation_report=False)
+    assert classify_attempt(ws) == OutcomeId.must_have_weights_missing
+
+
+def test_must_have_config_missing(build_workspace):
+    ws = build_workspace(include_config=False, include_validation_report=False)
+    assert classify_attempt(ws) == OutcomeId.must_have_config_missing_or_invalid
+
+
+def test_must_have_tokenizer_missing(build_workspace):
+    ws = build_workspace(include_tokenizer=False, include_validation_report=False)
+    assert classify_attempt(ws) == OutcomeId.must_have_tokenizer_missing
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# validator
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_validation_report_absent(build_workspace):
+    ws = build_workspace(include_validation_report=False)
+    assert classify_attempt(ws) == OutcomeId.validation_report_absent
+
+
+def test_md5_fail(build_workspace):
+    ws = build_workspace(validation_tag="md5_fail")
+    assert classify_attempt(ws) == OutcomeId.must_validate_md5_mismatch
+
+
+def test_config_fail(build_workspace):
+    ws = build_workspace(validation_tag="config_fail")
+    assert classify_attempt(ws) == OutcomeId.must_validate_config_mismatch
+
+
+def test_fuzzy_fail(build_workspace):
+    ws = build_workspace(validation_tag="fuzzy_fail")
+    assert classify_attempt(ws) == OutcomeId.fuzzy_check_failed
+
+
+def test_aux_fail(build_workspace):
+    ws = build_workspace(validation_tag="aux_fail")
+    assert classify_attempt(ws) == OutcomeId.should_have_aux_missing
+
+
+def test_must_validate_skipped(build_workspace):
+    ws = build_workspace(validation_tag="must_validate_skipped")
+    assert classify_attempt(ws) == OutcomeId.must_validate_skipped
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# eval
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_eval_gap_within_threshold_no_narrative_when_zero(build_workspace):
+    # Default eval_report has gap=0.0 — clean success, no narrative tag.
+    ws = build_workspace()
+    assert classify_attempt(ws) is None
+
+
+def test_eval_gap_within_threshold_narrative_tag(build_workspace):
+    ws = build_workspace(
+        eval_report={
+            "metric_name": "gsm8k", "dataset": "gsm8k", "backend": "vllm",
+            "source_score": 0.5, "quantized_score": 0.49, "relative_gap": 0.02,
+        }
+    )
+    assert classify_attempt(ws, acceptable_eval_gap=0.03) == OutcomeId.eval_gap_accepted
+
+
+def test_eval_gap_exceeded(build_workspace):
+    ws = build_workspace(
+        eval_report={
+            "metric_name": "gsm8k", "dataset": "gsm8k", "backend": "vllm",
+            "source_score": 0.5, "quantized_score": 0.45, "relative_gap": 0.10,
+        }
+    )
+    assert classify_attempt(ws, acceptable_eval_gap=0.03) == OutcomeId.eval_gap_exceeded
+
+
+def test_eval_env_unavailable(build_workspace):
+    ws = build_workspace(
+        include_eval_report=False,
+        eval_skipped_reason="docker not available",
+    )
+    assert classify_attempt(ws) == OutcomeId.eval_env_unavailable
+
+
+def test_eval_oom(build_workspace):
+    ws = build_workspace(
+        include_eval_report=False,
+        eval_skipped_reason="quantized engine OOM on MI300X",
+    )
+    assert classify_attempt(ws) == OutcomeId.eval_oom
+
+
+def test_quantized_load_failed_from_eval_skipped(build_workspace):
+    ws = build_workspace(
+        include_eval_report=False,
+        eval_skipped_reason="vLLM engine.start failed: quantized model can't load",
+    )
+    assert classify_attempt(ws) == OutcomeId.quantized_load_failed
+
+
+def test_eval_report_malformed_treated_as_env_unavailable(build_workspace):
+    ws = build_workspace(
+        eval_report={"metric_name": "gsm8k"},  # missing required keys
+    )
+    assert classify_attempt(ws) == OutcomeId.eval_env_unavailable
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# phase-tagged sdk errors
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_exec_oom_via_sdk_error_under_exec_phase(build_workspace):
+    ws = build_workspace(
+        include_manifest=False,
+        include_quantized_dir=False,
+        include_validation_report=False,
+        include_eval_report=False,
+        last_phase="exec",
+    )
+    # Need to add manifest so we get past §3 phase-gap check; instead pass
+    # last_phase via sdk path. With no manifest under exec phase, the
+    # phase-aware check fires first and returns manifest_artifact_*.
+    # So test phase-tagged sdk_error path with manifest present but quantized
+    # dir absent + sdk error.
+    ws2 = build_workspace(
+        include_quantized_dir=False,
+        include_validation_report=False,
+        include_eval_report=False,
+        last_phase="exec",
+    )
+    assert classify_attempt(
+        ws2, sdk_error="torch.OutOfMemoryError: CUDA out of memory"
+    ) == OutcomeId.exec_oom
+
+
+def test_export_crashed_via_sdk_error(build_workspace):
+    ws = build_workspace(
+        include_quantized_dir=False,
+        include_validation_report=False,
+        include_eval_report=False,
+        last_phase="export",
+    )
+    assert classify_attempt(
+        ws, sdk_error="OSError: [Errno 28] No space left on device during save_pretrained"
+    ) == OutcomeId.export_crashed
+
+
+def test_exec_calibration_data_missing_via_sdk_error(build_workspace):
+    ws = build_workspace(
+        include_quantized_dir=False,
+        include_validation_report=False,
+        include_eval_report=False,
+        last_phase="exec",
+    )
+    assert classify_attempt(
+        ws, sdk_error="RuntimeError: calibration dataloader returned 0 samples"
+    ) == OutcomeId.exec_calibration_data_missing
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# fallback
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_unclassified_failure_when_unknown_sdk_error(build_workspace):
+    ws = build_workspace()
+    assert classify_attempt(
+        ws, sdk_error="Mysterious upstream error nobody has seen before"
+    ) == OutcomeId.unclassified_failure
+
+
+def test_clean_success_returns_none(build_workspace):
+    ws = build_workspace()
+    assert classify_attempt(ws) is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Assessment assembly
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_build_assessment_single_clean_attempt(build_workspace):
+    ws = build_workspace()
+    art = collect_artifacts(ws)
+    a = build_assessment([None], workspace=ws, artifacts=art)
+    assert a.final is None
+    assert a.attempts == (None,)
+    assert a.recovered is False
+    assert a.eval_gap == 0.0
+
+
+def test_build_assessment_recovered_after_failure(build_workspace):
+    ws = build_workspace()
+    art = collect_artifacts(ws)
+    a = build_assessment([OutcomeId.exec_oom, None], workspace=ws, artifacts=art)
+    assert a.final is None
+    assert a.recovered is True
+
+
+def test_build_assessment_failed_final(build_workspace):
+    ws = build_workspace(validation_tag="md5_fail")
+    art = collect_artifacts(ws)
+    a = build_assessment([OutcomeId.must_validate_md5_mismatch], workspace=ws, artifacts=art)
+    assert a.final == OutcomeId.must_validate_md5_mismatch
+    assert a.recovered is False
+
+
+def test_assessment_to_dict_roundtrip(build_workspace):
+    ws = build_workspace()
+    art = collect_artifacts(ws)
+    a = build_assessment([OutcomeId.exec_oom, OutcomeId.eval_gap_accepted], workspace=ws, artifacts=art)
+    d = a.to_dict()
+    assert d["final"] == "eval_gap_accepted"
+    assert d["attempts"] == ["exec_oom", "eval_gap_accepted"]
+    assert d["recovered"] is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# derive_status
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_derive_status_clean_success(build_workspace):
+    ws = build_workspace()
+    art = collect_artifacts(ws)
+    a = build_assessment([None], workspace=ws, artifacts=art)
+    assert derive_status(a, art) == "success"
+
+
+def test_derive_status_eval_gap_accepted_is_success(build_workspace):
+    ws = build_workspace()
+    art = collect_artifacts(ws)
+    a = build_assessment([OutcomeId.eval_gap_accepted], workspace=ws, artifacts=art)
+    assert derive_status(a, art) == "success"
+
+
+def test_derive_status_md5_mismatch_failed(build_workspace):
+    ws = build_workspace(validation_tag="md5_fail")
+    art = collect_artifacts(ws)
+    a = build_assessment([OutcomeId.must_validate_md5_mismatch], workspace=ws, artifacts=art)
+    assert derive_status(a, art) == "failed"
+
+
+def test_derive_status_eval_gap_exceeded_partial(build_workspace):
+    ws = build_workspace()
+    art = collect_artifacts(ws)
+    a = build_assessment([OutcomeId.eval_gap_exceeded], workspace=ws, artifacts=art)
+    assert derive_status(a, art) == "partial"
+
+
+def test_derive_status_must_validate_skipped_strict(build_workspace, monkeypatch):
+    monkeypatch.setenv("HYPERLOOM_QUANT_STRICT_VALIDATION", "1")
+    ws = build_workspace(validation_tag="must_validate_skipped")
+    art = collect_artifacts(ws)
+    a = build_assessment([OutcomeId.must_validate_skipped], workspace=ws, artifacts=art)
+    assert derive_status(a, art) == "failed"
+
+
+def test_derive_status_must_validate_skipped_lenient(build_workspace, monkeypatch):
+    monkeypatch.setenv("HYPERLOOM_QUANT_STRICT_VALIDATION", "0")
+    ws = build_workspace(validation_tag="must_validate_skipped")
+    art = collect_artifacts(ws)
+    a = build_assessment([OutcomeId.must_validate_skipped], workspace=ws, artifacts=art)
+    assert derive_status(a, art) == "partial"
+
+
+def test_derive_status_eval_env_unavailable_is_partial(build_workspace):
+    ws = build_workspace(include_eval_report=False, eval_skipped_reason="docker missing")
+    art = collect_artifacts(ws)
+    a = build_assessment([OutcomeId.eval_env_unavailable], workspace=ws, artifacts=art)
+    assert derive_status(a, art) == "partial"
+
+
+def test_derive_status_unclassified_is_failed(build_workspace):
+    ws = build_workspace()
+    art = collect_artifacts(ws)
+    a = build_assessment([OutcomeId.unclassified_failure], workspace=ws, artifacts=art)
+    assert derive_status(a, art) == "failed"

--- a/quantization_agent/tests/test_eval.py
+++ b/quantization_agent/tests/test_eval.py
@@ -1,0 +1,139 @@
+"""Tests for `driver.eval` — threshold resolution + acceptance decision."""
+
+from __future__ import annotations
+
+import pytest
+
+from quantization_agent.driver.eval import (
+    DEFAULT_ACCEPTABLE_GAP,
+    EvalDecision,
+    decide,
+    resolve_threshold,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# resolve_threshold — priority chain (§3.1)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_resolve_threshold_default_when_nothing_provided(tmp_path):
+    t, src = resolve_threshold(tmp_path, acceptable_eval_gap=None)
+    assert t == DEFAULT_ACCEPTABLE_GAP
+    assert src == "default"
+
+
+def test_resolve_threshold_arg_wins_over_file(tmp_path):
+    (tmp_path / "eval_gap_threshold.txt").write_text("0.10", encoding="utf-8")
+    t, src = resolve_threshold(tmp_path, acceptable_eval_gap=0.05)
+    assert t == 0.05
+    assert src == "arg"
+
+
+def test_resolve_threshold_file_used_when_no_arg(tmp_path):
+    (tmp_path / "eval_gap_threshold.txt").write_text("0.07\n", encoding="utf-8")
+    t, src = resolve_threshold(tmp_path, acceptable_eval_gap=None)
+    assert t == 0.07
+    assert src == "file"
+
+
+def test_resolve_threshold_malformed_file_falls_to_default(tmp_path):
+    (tmp_path / "eval_gap_threshold.txt").write_text("not-a-float", encoding="utf-8")
+    t, src = resolve_threshold(tmp_path, acceptable_eval_gap=None)
+    assert t == DEFAULT_ACCEPTABLE_GAP
+    assert src == "default"
+
+
+def test_resolve_threshold_empty_file_falls_to_default(tmp_path):
+    (tmp_path / "eval_gap_threshold.txt").write_text("   \n", encoding="utf-8")
+    t, src = resolve_threshold(tmp_path, acceptable_eval_gap=None)
+    assert t == DEFAULT_ACCEPTABLE_GAP
+    assert src == "default"
+
+
+def test_resolve_threshold_arg_zero_is_respected(tmp_path):
+    # 0.0 is a valid (strict) threshold — arg path must not collapse to None.
+    t, src = resolve_threshold(tmp_path, acceptable_eval_gap=0.0)
+    assert t == 0.0
+    assert src == "arg"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# decide — gap acceptance
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _report(gap: float) -> dict:
+    return {
+        "metric_name": "gsm8k",
+        "dataset": "gsm8k",
+        "backend": "vllm",
+        "source_score": 0.50,
+        "quantized_score": 0.50 * (1 - gap),
+        "relative_gap": gap,
+    }
+
+
+def test_decide_within_threshold(tmp_path):
+    d = decide(_report(0.02), workspace=tmp_path, acceptable_eval_gap=0.03)
+    assert d.status == "within"
+    assert d.relative_gap == 0.02
+    assert d.threshold == 0.03
+    assert d.threshold_source == "arg"
+
+
+def test_decide_exactly_at_threshold_is_within(tmp_path):
+    d = decide(_report(0.03), workspace=tmp_path, acceptable_eval_gap=0.03)
+    assert d.status == "within"
+
+
+def test_decide_exceeded(tmp_path):
+    d = decide(_report(0.10), workspace=tmp_path, acceptable_eval_gap=0.03)
+    assert d.status == "exceeded"
+    assert d.relative_gap == 0.10
+
+
+def test_decide_missing_when_report_is_none(tmp_path):
+    d = decide(None, workspace=tmp_path, acceptable_eval_gap=None)
+    assert d.status == "missing"
+    assert d.relative_gap is None
+    assert d.threshold == DEFAULT_ACCEPTABLE_GAP
+
+
+def test_decide_missing_when_required_key_absent(tmp_path):
+    d = decide({"metric_name": "gsm8k"}, workspace=tmp_path, acceptable_eval_gap=None)
+    assert d.status == "missing"
+    assert d.relative_gap is None
+
+
+def test_decide_missing_when_gap_not_float(tmp_path):
+    bad = _report(0.02)
+    bad["relative_gap"] = "n/a"
+    d = decide(bad, workspace=tmp_path, acceptable_eval_gap=None)
+    assert d.status == "missing"
+
+
+def test_decide_uses_file_threshold_when_no_arg(tmp_path):
+    (tmp_path / "eval_gap_threshold.txt").write_text("0.05", encoding="utf-8")
+    d = decide(_report(0.04), workspace=tmp_path, acceptable_eval_gap=None)
+    assert d.status == "within"
+    assert d.threshold == 0.05
+    assert d.threshold_source == "file"
+
+
+def test_decide_uses_default_threshold_when_nothing_set(tmp_path):
+    d = decide(_report(0.029), workspace=tmp_path, acceptable_eval_gap=None)
+    assert d.status == "within"
+    assert d.threshold == DEFAULT_ACCEPTABLE_GAP
+    assert d.threshold_source == "default"
+
+
+def test_decide_negative_gap_is_within(tmp_path):
+    # Quantized scored higher than source (rare but possible with noisy evals).
+    d = decide(_report(-0.01), workspace=tmp_path, acceptable_eval_gap=0.03)
+    assert d.status == "within"
+    assert d.relative_gap == -0.01
+
+
+def test_eval_decision_is_frozen():
+    d = EvalDecision(status="within", relative_gap=0.0, threshold=0.03, threshold_source="default")
+    with pytest.raises(Exception):
+        d.status = "exceeded"  # type: ignore[misc]

--- a/quantization_agent/tests/test_outcomes.py
+++ b/quantization_agent/tests/test_outcomes.py
@@ -1,0 +1,113 @@
+"""Tests for the 30-row outcome taxonomy."""
+
+from __future__ import annotations
+
+from quantization_agent.driver.outcomes import (
+    ASK,
+    ASK_RETRYABLE,
+    AUTO_FAIL,
+    AUTO_RECOVER,
+    OutcomeId,
+    SUCCESS_TAGS,
+    UNCLASSIFIED_FAILURE,
+)
+
+
+# The 30 rows from Appendix §A, grouped by category. Numbers are the table
+# IDs; the enum stores them by name only (the row number is implicit in the
+# §A documentation).
+_AUTO_RECOVER_NAMES = {
+    "intent_parse_failed",                        # #8
+    "analysis_artifact_invalid_or_missing",       # #10
+    "plan_artifact_invalid_or_missing",           # #11
+    "manifest_artifact_invalid_or_missing",       # #12
+    "must_have_config_missing_or_invalid",        # #14
+    "must_have_tokenizer_missing",                # #15
+    "must_validate_config_mismatch",              # #17
+    "should_have_aux_missing",                    # #19
+    "nice_to_have_skipped",                       # #20
+    "eval_env_unavailable",                       # #22
+    "validation_report_absent",                   # #25
+    "must_validate_skipped",                      # #27
+    "eval_oom",                                   # #29
+}
+
+_AUTO_FAIL_NAMES = {
+    "quark_root_missing",                # #1
+    "exec_model_load_failed",            # #4
+    "exec_calibration_data_missing",     # #5
+    "quark_skill_unavailable",           # #7
+    "model_path_unreachable",            # #9
+    "validator_self_test_failed",        # #13
+    "must_validate_md5_mismatch",        # #18
+    "workspace_unwritable",              # #23
+    "sdk_runtime_error",                 # #24
+    "quantized_load_failed",             # #28
+    "upstream_change_required",          # derived from #30
+}
+
+_ASK_NAMES = {
+    "checkpoint_aborted",                # #2
+    "exec_oom",                          # #3
+    "export_crashed",                    # #6
+    "must_have_weights_missing",         # #16
+    "eval_gap_exceeded",                 # #21
+    "fuzzy_check_failed",                # #26
+}
+
+
+def test_category_sizes_match_design_appendix_a():
+    assert len(AUTO_RECOVER) == 13
+    assert len(AUTO_FAIL) == 11  # 10 from #1..#28 + upstream_change_required
+    assert len(ASK) == 6
+
+
+def test_partition_is_disjoint():
+    assert AUTO_RECOVER.isdisjoint(AUTO_FAIL)
+    assert AUTO_RECOVER.isdisjoint(ASK)
+    assert AUTO_FAIL.isdisjoint(ASK)
+    assert UNCLASSIFIED_FAILURE not in AUTO_RECOVER
+    assert UNCLASSIFIED_FAILURE not in AUTO_FAIL
+    assert UNCLASSIFIED_FAILURE not in ASK
+
+
+def test_category_names_match_design():
+    assert {o.value for o in AUTO_RECOVER} == _AUTO_RECOVER_NAMES
+    assert {o.value for o in AUTO_FAIL} == _AUTO_FAIL_NAMES
+    assert {o.value for o in ASK} == _ASK_NAMES
+
+
+def test_unclassified_failure_is_sentinel():
+    assert UNCLASSIFIED_FAILURE == OutcomeId.unclassified_failure
+    assert UNCLASSIFIED_FAILURE.value == "unclassified_failure"
+
+
+def test_success_tags_include_none_and_eval_accepted():
+    assert None in SUCCESS_TAGS
+    assert OutcomeId.eval_gap_accepted in SUCCESS_TAGS
+    # eval_gap_exceeded is NOT a success tag — it's an Ask-class failure.
+    assert OutcomeId.eval_gap_exceeded not in SUCCESS_TAGS
+
+
+def test_ask_retryable_subset_of_ask():
+    assert ASK_RETRYABLE.issubset(ASK)
+    # The four CI-auto-retry rows per design §A bottom of table.
+    assert {o.value for o in ASK_RETRYABLE} == {
+        "exec_oom", "export_crashed", "must_have_weights_missing", "fuzzy_check_failed",
+    }
+    # checkpoint_aborted and eval_gap_exceeded are Ask but NOT retryable —
+    # retrying them won't synthesize missing info / shrink the gap.
+    assert OutcomeId.checkpoint_aborted not in ASK_RETRYABLE
+    assert OutcomeId.eval_gap_exceeded not in ASK_RETRYABLE
+
+
+def test_enum_is_string_valued():
+    # StrEnum members compare equal to their string values — important for
+    # blocked.md parsing and JSON round-trips through Assessment.to_dict().
+    assert OutcomeId.exec_oom == "exec_oom"
+    assert str(OutcomeId.exec_oom) == "exec_oom"
+
+
+def test_enum_size_is_32_total():
+    # 30 rows from §A + eval_gap_accepted narrative tag + upstream_change_required.
+    assert len(list(OutcomeId)) == 32

--- a/quantization_agent/tests/test_result_collector.py
+++ b/quantization_agent/tests/test_result_collector.py
@@ -1,0 +1,143 @@
+"""Tests for ``collect_artifacts`` — disk scan only, no classification."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from quantization_agent.driver.result_collector import (
+    STRICT_VALIDATION_ENV,
+    collect_artifacts,
+)
+
+
+def test_clean_workspace_returns_zero_artifacts(tmp_path):
+    art = collect_artifacts(tmp_path)
+    assert art.manifest_present is False
+    assert art.quantized_model_dir is None
+    assert art.quantized_dir_exists is False
+    assert art.validation_report_present is False
+    assert art.eval_report_data is None
+    assert art.fix_hypothesis_attempts == ()
+    assert art.last_phase is None
+
+
+def test_full_artifact_set(build_workspace):
+    ws = build_workspace()
+    art = collect_artifacts(ws)
+    assert art.manifest_present is True
+    assert art.manifest_parse_error is None
+    assert art.quantized_model_dir is not None and art.quantized_model_dir.exists()
+    assert art.has_config_json
+    assert art.has_weights
+    assert art.has_tokenizer
+    assert art.validation_report_present
+    assert art.validation_steps.md5 == "ok"
+    assert art.validation_steps.config == "ok"
+    assert art.validation_steps.fuzzy == "ok"
+    assert art.validation_steps.auxiliary == "ok"
+    assert art.eval_report_data is not None
+    assert art.eval_report_data["relative_gap"] == 0.0
+
+
+def test_validation_step_fail_parsed(build_workspace):
+    ws = build_workspace(validation_tag="md5_fail")
+    art = collect_artifacts(ws)
+    assert art.validation_steps.md5 == "FAIL"
+    assert art.validation_steps.config == "ok"
+
+
+def test_validation_step_skipped_parsed(build_workspace):
+    ws = build_workspace(validation_tag="must_validate_skipped")
+    art = collect_artifacts(ws)
+    assert art.validation_steps.md5 == "skipped"
+    assert art.validation_steps.config == "skipped"
+
+
+def test_missing_validation_step_returns_none(tmp_path):
+    # Report present but without all 4 step lines.
+    (tmp_path / "validation_report.md").write_text(
+        "**Step 4 — fuzzy tensor names**: ok\n", encoding="utf-8"
+    )
+    art = collect_artifacts(tmp_path)
+    assert art.validation_steps.fuzzy == "ok"
+    assert art.validation_steps.md5 is None
+    assert art.validation_steps.config is None
+    assert art.validation_steps.auxiliary is None
+
+
+def test_manifest_missing_outputs_key(tmp_path):
+    pytest.importorskip("yaml")
+    (tmp_path / "run_manifest.yaml").write_text(
+        "version: '1'\n", encoding="utf-8"
+    )
+    art = collect_artifacts(tmp_path)
+    assert art.manifest_present is True
+    assert art.manifest_parse_error == "missing_outputs_quantized_model_dir"
+    assert art.quantized_model_dir is None
+
+
+def test_manifest_yaml_malformed(tmp_path):
+    pytest.importorskip("yaml")
+    (tmp_path / "run_manifest.yaml").write_text("not: [valid: yaml", encoding="utf-8")
+    art = collect_artifacts(tmp_path)
+    assert art.manifest_present is True
+    assert art.manifest_parse_error is not None
+    assert "yaml_error" in art.manifest_parse_error
+
+
+def test_eval_report_json_malformed(tmp_path):
+    (tmp_path / "eval_report.json").write_text("{not json", encoding="utf-8")
+    art = collect_artifacts(tmp_path)
+    assert art.eval_report_present is True
+    assert art.eval_report_data is None
+
+
+def test_fix_hypothesis_attempts_sorted(build_workspace):
+    ws = build_workspace(fix_hypotheses=(3, 1, 2))
+    art = collect_artifacts(ws)
+    assert art.fix_hypothesis_attempts == (1, 2, 3)
+
+
+def test_last_phase_stripped(tmp_path):
+    (tmp_path / "last_phase.txt").write_text("  exec  \n", encoding="utf-8")
+    art = collect_artifacts(tmp_path)
+    assert art.last_phase == "exec"
+
+
+def test_blocked_md_carried_through(build_workspace):
+    ws = build_workspace(blocked_md="outcome_id: exec_oom\n")
+    art = collect_artifacts(ws)
+    assert art.blocked_reason is not None
+    assert "exec_oom" in art.blocked_reason
+
+
+def test_strict_validation_default_true(tmp_path, monkeypatch):
+    monkeypatch.delenv(STRICT_VALIDATION_ENV, raising=False)
+    art = collect_artifacts(tmp_path)
+    assert art.strict_validation is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "FALSE", "no", ""])
+def test_strict_validation_disabled_values(tmp_path, monkeypatch, value):
+    monkeypatch.setenv(STRICT_VALIDATION_ENV, value)
+    art = collect_artifacts(tmp_path)
+    assert art.strict_validation is False
+
+
+def test_quantized_dir_resolved_relative(tmp_path):
+    pytest.importorskip("yaml")
+    qdir = tmp_path / "out"
+    qdir.mkdir()
+    (qdir / "config.json").write_text("{}", encoding="utf-8")
+    (qdir / "model.safetensors").write_bytes(b"\x00")
+    (qdir / "tokenizer.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "run_manifest.yaml").write_text(
+        "outputs:\n  quantized_model_dir: out\n", encoding="utf-8"
+    )
+    art = collect_artifacts(tmp_path)
+    assert art.quantized_model_dir is not None
+    assert art.quantized_model_dir.name == "out"
+    assert art.has_weights

--- a/quantization_agent/tests/test_retry_loop.py
+++ b/quantization_agent/tests/test_retry_loop.py
@@ -1,0 +1,513 @@
+"""Tests for `quantize_via_prompt` — retry orchestration.
+
+The runner SDK call is stubbed via the `runner_fn` injection seam so these
+tests stay pure-Python. Each stub configures the workspace state before
+returning an AttemptResult, mirroring what SKILL.md would have left behind.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+
+from quantization_agent.driver.outcomes import OutcomeId
+from quantization_agent.driver.retry import (
+    QuantSkillRunResult,
+    _decide_next_step,
+    _read_counter,
+    _resolve_interactive,
+    quantize_via_prompt,
+)
+from quantization_agent.driver.runner import AttemptResult
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+class _StubRunner:
+    """Records calls + lets each attempt mutate workspace before returning."""
+
+    def __init__(self, side_effects: list[Callable[[Path, int], str | None]]):
+        # Each entry mutates the workspace and returns an sdk_error (or None).
+        self.side_effects = side_effects
+        self.calls: list[dict[str, Any]] = []
+
+    async def __call__(self, **kwargs: Any) -> AttemptResult:
+        self.calls.append(kwargs)
+        workspace = Path(kwargs["workspace"])
+        attempt = kwargs["attempt_number"]
+        idx = attempt - 1
+        sdk_error = ""
+        if idx < len(self.side_effects):
+            err = self.side_effects[idx](workspace, attempt)
+            if err:
+                sdk_error = err
+        return AttemptResult(workspace=workspace, sdk_error=sdk_error)
+
+
+def _materialize_clean_workspace(build_workspace, **overrides):
+    """Build a complete-success workspace at a known path."""
+
+    return build_workspace(**overrides)
+
+
+@pytest.fixture
+def quark_root(tmp_path: Path) -> Path:
+    """A dummy quark_root dir so the bootstrap check passes."""
+
+    qr = tmp_path / "quark_root"
+    qr.mkdir()
+    return qr
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# bootstrap — quark_root resolution
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_quark_root_missing_fast_path(tmp_path, monkeypatch):
+    monkeypatch.delenv("QUARK_ROOT", raising=False)
+
+    async def _never_called(**kwargs: Any) -> AttemptResult:  # pragma: no cover
+        raise AssertionError("runner should not be invoked when bootstrap fails")
+
+    result = await quantize_via_prompt(
+        "do it",
+        workspace=tmp_path / "ws",
+        runner_fn=_never_called,
+    )
+    assert result.status == "failed"
+    assert result.assessment.final == OutcomeId.quark_root_missing
+    assert result.quantized_model_dir is None
+
+
+@pytest.mark.asyncio
+async def test_quark_root_nonexistent_dir_fast_path(tmp_path):
+    async def _never_called(**kwargs: Any) -> AttemptResult:  # pragma: no cover
+        raise AssertionError("runner should not be invoked")
+
+    result = await quantize_via_prompt(
+        "do it",
+        workspace=tmp_path / "ws",
+        quark_root=tmp_path / "does_not_exist",
+        runner_fn=_never_called,
+    )
+    assert result.status == "failed"
+    assert result.assessment.final == OutcomeId.quark_root_missing
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# happy path — single clean attempt
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_single_clean_attempt_returns_success(tmp_path, quark_root, build_workspace):
+    ws = tmp_path / "ws"
+
+    def populate(workspace: Path, attempt: int) -> str | None:
+        # Reuse build_workspace by pointing it at the same dir.
+        build_workspace(workspace=workspace)
+        return None
+
+    runner = _StubRunner([populate])
+    result = await quantize_via_prompt(
+        "fp8 it",
+        workspace=ws,
+        quark_root=quark_root,
+        runner_fn=runner,
+        interactive=False,
+    )
+    assert result.status == "success"
+    assert result.assessment.final is None
+    assert result.assessment.attempts == (None,)
+    assert result.quantized_model_dir is not None
+    assert result.quantized_model_dir.exists()
+    assert len(runner.calls) == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# retry hypothesis gate
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_no_retry_without_fix_hypothesis(tmp_path, quark_root, build_workspace):
+    """ASK_RETRYABLE outcome but no fix_hypothesis_attempt_2.md → no retry."""
+
+    ws = tmp_path / "ws"
+
+    def populate(workspace: Path, attempt: int) -> str | None:
+        # Set up workspace with a quantized dir missing weights → must_have_weights_missing.
+        build_workspace(
+            workspace=workspace,
+            include_weights=False,
+            include_validation_report=False,
+        )
+        return None
+
+    runner = _StubRunner([populate])
+    result = await quantize_via_prompt(
+        "fp8 it",
+        workspace=ws,
+        quark_root=quark_root,
+        runner_fn=runner,
+        interactive=False,
+        max_requantize_attempts=3,
+    )
+    assert len(runner.calls) == 1  # gated; no retry
+    assert result.assessment.final == OutcomeId.must_have_weights_missing
+    assert any("no_fix_hypothesis" in n for n in result.assessment.notes)
+
+
+@pytest.mark.asyncio
+async def test_retry_with_hypothesis_then_recover(tmp_path, quark_root, build_workspace):
+    """Attempt 1 fails with weights missing, hypothesis written, attempt 2 clean."""
+
+    ws = tmp_path / "ws"
+
+    def fail_then_hypothesize(workspace: Path, attempt: int) -> str | None:
+        build_workspace(
+            workspace=workspace,
+            include_weights=False,
+            include_validation_report=False,
+        )
+        # SKILL.md drops a hypothesis for the next attempt.
+        (workspace / "fix_hypothesis_attempt_2.md").write_text(
+            "## Fix\nRerun export with disk space cleared.\n", encoding="utf-8"
+        )
+        return None
+
+    def succeed(workspace: Path, attempt: int) -> str | None:
+        # Clear any prior broken state, then build a clean workspace.
+        for f in workspace.iterdir():
+            if f.is_file():
+                f.unlink()
+            elif f.is_dir():
+                import shutil
+                shutil.rmtree(f)
+        build_workspace(workspace=workspace)
+        return None
+
+    runner = _StubRunner([fail_then_hypothesize, succeed])
+    result = await quantize_via_prompt(
+        "fp8 it",
+        workspace=ws,
+        quark_root=quark_root,
+        runner_fn=runner,
+        interactive=False,
+        max_requantize_attempts=2,
+    )
+    assert len(runner.calls) == 2
+    assert result.assessment.final is None
+    assert result.assessment.recovered is True
+    assert result.assessment.attempts == (OutcomeId.must_have_weights_missing, None)
+    assert result.status == "success"
+
+
+@pytest.mark.asyncio
+async def test_counter_persists_and_caps_retries(tmp_path, quark_root, build_workspace):
+    """Even with hypothesis present, counter ≥ max → no retry."""
+
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    # Pre-seed the counter at the max so the first attempt is already at the cap.
+    (ws / "requantize_attempts.txt").write_text("1", encoding="utf-8")
+
+    def fail(workspace: Path, attempt: int) -> str | None:
+        build_workspace(
+            workspace=workspace,
+            include_weights=False,
+            include_validation_report=False,
+        )
+        (workspace / "fix_hypothesis_attempt_2.md").write_text("x", encoding="utf-8")
+        return None
+
+    runner = _StubRunner([fail])
+    result = await quantize_via_prompt(
+        "fp8 it",
+        workspace=ws,
+        quark_root=quark_root,
+        runner_fn=runner,
+        interactive=False,
+        max_requantize_attempts=1,
+    )
+    assert len(runner.calls) == 1
+    assert any("max_attempts_exhausted" in n for n in result.assessment.notes)
+    # Counter should still be 1 (no bump beyond the cap).
+    assert _read_counter(ws) == 1
+
+
+@pytest.mark.asyncio
+async def test_max_requantize_attempts_zero_no_retry(tmp_path, quark_root, build_workspace):
+    ws = tmp_path / "ws"
+
+    def fail(workspace: Path, attempt: int) -> str | None:
+        build_workspace(
+            workspace=workspace,
+            include_weights=False,
+            include_validation_report=False,
+        )
+        (workspace / "fix_hypothesis_attempt_2.md").write_text("x", encoding="utf-8")
+        return None
+
+    runner = _StubRunner([fail])
+    result = await quantize_via_prompt(
+        "fp8 it",
+        workspace=ws,
+        quark_root=quark_root,
+        runner_fn=runner,
+        interactive=False,
+        max_requantize_attempts=0,
+    )
+    assert len(runner.calls) == 1
+    assert any("max_attempts_exhausted" in n for n in result.assessment.notes)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# auto_fail stops immediately
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_auto_fail_stops_immediately(tmp_path, quark_root, build_workspace):
+    ws = tmp_path / "ws"
+
+    def md5_fail(workspace: Path, attempt: int) -> str | None:
+        build_workspace(workspace=workspace, validation_tag="md5_fail")
+        # Even if SKILL.md drops a hypothesis, AUTO_FAIL stops the loop.
+        (workspace / "fix_hypothesis_attempt_2.md").write_text("x", encoding="utf-8")
+        return None
+
+    runner = _StubRunner([md5_fail])
+    result = await quantize_via_prompt(
+        "fp8 it",
+        workspace=ws,
+        quark_root=quark_root,
+        runner_fn=runner,
+        interactive=False,
+        max_requantize_attempts=3,
+    )
+    assert len(runner.calls) == 1
+    assert result.assessment.final == OutcomeId.must_validate_md5_mismatch
+    assert result.status == "failed"
+    assert any("auto_fail" in n for n in result.assessment.notes)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# eval_gap_exceeded with operator acceptance
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_eval_gap_exceeded_accepted_by_operator_promotes_to_accepted(
+    tmp_path, quark_root, build_workspace, monkeypatch
+):
+    ws = tmp_path / "ws"
+
+    def gap_exceeded(workspace: Path, attempt: int) -> str | None:
+        build_workspace(
+            workspace=workspace,
+            eval_report={
+                "metric_name": "gsm8k", "dataset": "gsm8k", "backend": "vllm",
+                "source_score": 0.5, "quantized_score": 0.4, "relative_gap": 0.20,
+            },
+        )
+        return None
+
+    # Stub the interactive yes/no — answer "y".
+    import quantization_agent.driver.retry as retry_mod
+    monkeypatch.setattr(retry_mod, "_ask_operator", lambda msg: True)
+
+    runner = _StubRunner([gap_exceeded])
+    result = await quantize_via_prompt(
+        "fp8 it",
+        workspace=ws,
+        quark_root=quark_root,
+        runner_fn=runner,
+        interactive=True,
+        acceptable_eval_gap=0.03,
+    )
+    assert result.assessment.final == OutcomeId.eval_gap_accepted
+    assert result.assessment.attempts[-1] == OutcomeId.eval_gap_accepted
+    assert result.status == "success"
+    assert result.quantized_model_dir is not None
+
+
+@pytest.mark.asyncio
+async def test_eval_gap_exceeded_rejected_stays_partial(
+    tmp_path, quark_root, build_workspace, monkeypatch
+):
+    ws = tmp_path / "ws"
+
+    def gap_exceeded(workspace: Path, attempt: int) -> str | None:
+        build_workspace(
+            workspace=workspace,
+            eval_report={
+                "metric_name": "gsm8k", "dataset": "gsm8k", "backend": "vllm",
+                "source_score": 0.5, "quantized_score": 0.4, "relative_gap": 0.20,
+            },
+        )
+        return None
+
+    import quantization_agent.driver.retry as retry_mod
+    monkeypatch.setattr(retry_mod, "_ask_operator", lambda msg: False)
+
+    runner = _StubRunner([gap_exceeded])
+    result = await quantize_via_prompt(
+        "fp8 it",
+        workspace=ws,
+        quark_root=quark_root,
+        runner_fn=runner,
+        interactive=True,
+        acceptable_eval_gap=0.03,
+    )
+    assert result.assessment.final == OutcomeId.eval_gap_exceeded
+    assert result.status == "partial"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# auto_recover surfaces as partial (Python doesn't loop on it)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_auto_recover_surfaced_does_not_retry(tmp_path, quark_root, build_workspace):
+    ws = tmp_path / "ws"
+
+    def env_unavailable(workspace: Path, attempt: int) -> str | None:
+        build_workspace(
+            workspace=workspace,
+            include_eval_report=False,
+            eval_skipped_reason="docker missing",
+        )
+        (workspace / "fix_hypothesis_attempt_2.md").write_text("x", encoding="utf-8")
+        return None
+
+    runner = _StubRunner([env_unavailable])
+    result = await quantize_via_prompt(
+        "fp8 it",
+        workspace=ws,
+        quark_root=quark_root,
+        runner_fn=runner,
+        interactive=False,
+        max_requantize_attempts=3,
+    )
+    assert len(runner.calls) == 1
+    assert result.assessment.final == OutcomeId.eval_env_unavailable
+    assert result.status == "partial"
+    assert any("auto_recover_unresolved" in n for n in result.assessment.notes)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _resolve_interactive
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_resolve_interactive_explicit_true():
+    assert _resolve_interactive(True) is True
+
+
+def test_resolve_interactive_explicit_false():
+    assert _resolve_interactive(False) is False
+
+
+def test_resolve_interactive_auto_no_tty(monkeypatch):
+    import sys
+    class _NotTTY:
+        def isatty(self) -> bool:
+            return False
+    monkeypatch.setattr(sys, "stdin", _NotTTY())
+    monkeypatch.setattr(sys, "stderr", _NotTTY())
+    assert _resolve_interactive(None) is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _decide_next_step unit table
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_decide_next_step_none_outcome(tmp_path):
+    d = _decide_next_step(
+        None, workspace=tmp_path, attempt_number=1, interactive=False,
+        max_requantize_attempts=3, counter=0,
+    )
+    assert d.retry is False
+    assert d.promote_to is None
+
+
+def test_decide_next_step_auto_fail(tmp_path):
+    d = _decide_next_step(
+        OutcomeId.must_validate_md5_mismatch, workspace=tmp_path,
+        attempt_number=1, interactive=False, max_requantize_attempts=3, counter=0,
+    )
+    assert d.retry is False
+    assert "auto_fail" in d.note
+
+
+def test_decide_next_step_auto_recover(tmp_path):
+    d = _decide_next_step(
+        OutcomeId.eval_env_unavailable, workspace=tmp_path,
+        attempt_number=1, interactive=False, max_requantize_attempts=3, counter=0,
+    )
+    assert d.retry is False
+    assert "auto_recover_unresolved" in d.note
+
+
+def test_decide_next_step_ask_retryable_with_hypothesis(tmp_path):
+    (tmp_path / "fix_hypothesis_attempt_2.md").write_text("x", encoding="utf-8")
+    d = _decide_next_step(
+        OutcomeId.exec_oom, workspace=tmp_path,
+        attempt_number=1, interactive=False, max_requantize_attempts=2, counter=0,
+    )
+    assert d.retry is True
+
+
+def test_decide_next_step_ask_retryable_without_hypothesis(tmp_path):
+    d = _decide_next_step(
+        OutcomeId.exec_oom, workspace=tmp_path,
+        attempt_number=1, interactive=False, max_requantize_attempts=2, counter=0,
+    )
+    assert d.retry is False
+    assert d.note == "no_fix_hypothesis"
+
+
+def test_decide_next_step_unclassified_failure(tmp_path):
+    (tmp_path / "fix_hypothesis_attempt_2.md").write_text("x", encoding="utf-8")
+    d = _decide_next_step(
+        OutcomeId.unclassified_failure, workspace=tmp_path,
+        attempt_number=1, interactive=False, max_requantize_attempts=2, counter=0,
+    )
+    assert d.retry is True
+
+
+def test_decide_next_step_checkpoint_aborted_never_retries(tmp_path):
+    (tmp_path / "fix_hypothesis_attempt_2.md").write_text("x", encoding="utf-8")
+    d = _decide_next_step(
+        OutcomeId.checkpoint_aborted, workspace=tmp_path,
+        attempt_number=1, interactive=True, max_requantize_attempts=2, counter=0,
+    )
+    assert d.retry is False
+    assert "checkpoint_aborted" in d.note
+
+
+def test_decide_next_step_eval_gap_accepted_promotes(tmp_path, monkeypatch):
+    import quantization_agent.driver.retry as rmod
+    monkeypatch.setattr(rmod, "_ask_operator", lambda msg: True)
+    d = _decide_next_step(
+        OutcomeId.eval_gap_exceeded, workspace=tmp_path,
+        attempt_number=1, interactive=True, max_requantize_attempts=0, counter=0,
+    )
+    assert d.retry is False
+    assert d.promote_to == OutcomeId.eval_gap_accepted
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# QuantSkillRunResult shape
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_quant_skill_run_result_is_frozen():
+    from quantization_agent.driver.assessment import Assessment
+    r = QuantSkillRunResult(
+        status="success", quantized_model_dir=None,
+        assessment=Assessment(final=None, attempts=(None,), recovered=False, eval_gap=None),
+    )
+    with pytest.raises(Exception):
+        r.status = "failed"  # type: ignore[misc]

--- a/quantization_agent/tests/test_runner.py
+++ b/quantization_agent/tests/test_runner.py
@@ -1,0 +1,333 @@
+"""Tests for `driver.runner` — prompt assembly + SDK injection.
+
+Uses ``FakeSDK`` / ``FakeOptions`` from conftest to bypass the real SDK.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from quantization_agent.driver.runner import (
+    DEFAULT_ALLOWED_TOOLS,
+    AttemptResult,
+    build_attempt_prompt,
+    resolve_skill_path,
+    run_one_attempt,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# resolve_skill_path
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_resolve_skill_path_defaults_to_package():
+    p = resolve_skill_path()
+    assert p.name == "SKILL.md"
+    assert p.is_file(), f"SKILL.md must exist next to runner.py (parent of driver/) (got {p})"
+
+
+def test_resolve_skill_path_respects_override(tmp_path):
+    (tmp_path / "SKILL.md").write_text("x", encoding="utf-8")
+    p = resolve_skill_path(package_root=tmp_path)
+    assert p == tmp_path / "SKILL.md"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# build_attempt_prompt
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_build_attempt_prompt_includes_skill_and_user_prompt(tmp_path):
+    skill = tmp_path / "SKILL.md"
+    skill.write_text("skill body", encoding="utf-8")
+    text = build_attempt_prompt(
+        user_prompt="Quantize Qwen/Qwen3-0.5B in fp8",
+        skill_path=skill,
+        workspace=tmp_path / "ws",
+        quark_root=tmp_path / "qr",
+        attempt_number=1,
+        acceptable_eval_gap=0.05,
+        interactive=False,
+        previous_outcome=None,
+        fix_hypothesis_path=None,
+    )
+    assert str(skill) in text
+    assert "Quantize Qwen/Qwen3-0.5B in fp8" in text
+    assert str(tmp_path / "ws") in text
+    assert str(tmp_path / "qr") in text
+    assert "0.0500" in text
+    assert "off (batch / non-interactive)" in text
+    assert "Retry context" not in text
+
+
+def test_build_attempt_prompt_retry_block_added_on_attempt_2(tmp_path):
+    skill = tmp_path / "SKILL.md"
+    skill.write_text("x", encoding="utf-8")
+    fix_hyp = tmp_path / "fix_hypothesis_attempt_2.md"
+    text = build_attempt_prompt(
+        user_prompt="do",
+        skill_path=skill,
+        workspace=tmp_path,
+        quark_root=tmp_path,
+        attempt_number=2,
+        acceptable_eval_gap=None,
+        interactive=None,
+        previous_outcome="exec_oom",
+        fix_hypothesis_path=fix_hyp,
+    )
+    assert "Retry context" in text
+    assert "exec_oom" in text
+    assert "fix_hypothesis_attempt_2.md" in text
+    assert str(fix_hyp) in text
+    assert "auto" in text  # interactive=None description
+
+
+def test_build_attempt_prompt_interactive_on(tmp_path):
+    skill = tmp_path / "SKILL.md"
+    skill.write_text("x", encoding="utf-8")
+    text = build_attempt_prompt(
+        user_prompt="x",
+        skill_path=skill,
+        workspace=tmp_path,
+        quark_root=tmp_path,
+        attempt_number=1,
+        acceptable_eval_gap=None,
+        interactive=True,
+        previous_outcome=None,
+        fix_hypothesis_path=None,
+    )
+    assert "on (always relay checkpoints to operator)" in text
+
+
+def test_build_attempt_prompt_default_threshold_message(tmp_path):
+    skill = tmp_path / "SKILL.md"
+    skill.write_text("x", encoding="utf-8")
+    text = build_attempt_prompt(
+        user_prompt="x",
+        skill_path=skill,
+        workspace=tmp_path,
+        quark_root=tmp_path,
+        attempt_number=1,
+        acceptable_eval_gap=None,
+        interactive=False,
+        previous_outcome=None,
+        fix_hypothesis_path=None,
+    )
+    assert "caller did not override" in text
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# run_one_attempt — SDK injection
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_run_one_attempt_invokes_sdk_with_prompt(
+    tmp_path, fake_sdk, fake_options_cls
+):
+    skill = tmp_path / "SKILL.md"
+    skill.write_text("skill", encoding="utf-8")
+    qr = tmp_path / "qr"
+    qr.mkdir()
+
+    result = await run_one_attempt(
+        user_prompt="my prompt",
+        workspace=tmp_path / "ws",
+        quark_root=qr,
+        skill_path=skill,
+        sdk_query_factory=fake_sdk,
+        sdk_options_cls=fake_options_cls,
+    )
+
+    assert isinstance(result, AttemptResult)
+    assert result.sdk_error == ""
+    assert len(fake_sdk.received_prompts) == 1
+    assert "my prompt" in fake_sdk.received_prompts[0]
+    assert str(skill) in fake_sdk.received_prompts[0]
+
+
+@pytest.mark.asyncio
+async def test_run_one_attempt_sets_cwd_to_quark_root(
+    tmp_path, fake_sdk, fake_options_cls
+):
+    skill = tmp_path / "SKILL.md"
+    skill.write_text("x", encoding="utf-8")
+    qr = tmp_path / "qr"
+    qr.mkdir()
+
+    await run_one_attempt(
+        user_prompt="x",
+        workspace=tmp_path / "ws",
+        quark_root=qr,
+        skill_path=skill,
+        sdk_query_factory=fake_sdk,
+        sdk_options_cls=fake_options_cls,
+    )
+    options = fake_sdk.received_options[0]
+    assert options.kwargs.get("cwd") == str(qr)
+    assert options.kwargs.get("allowed_tools") == DEFAULT_ALLOWED_TOOLS
+
+
+@pytest.mark.asyncio
+async def test_run_one_attempt_captures_sdk_exception(
+    tmp_path, fake_sdk, fake_options_cls
+):
+    skill = tmp_path / "SKILL.md"
+    skill.write_text("x", encoding="utf-8")
+    qr = tmp_path / "qr"
+    qr.mkdir()
+
+    fake_sdk.side_effect = RuntimeError("boom from SDK")
+    result = await run_one_attempt(
+        user_prompt="x",
+        workspace=tmp_path / "ws",
+        quark_root=qr,
+        skill_path=skill,
+        sdk_query_factory=fake_sdk,
+        sdk_options_cls=fake_options_cls,
+    )
+    assert "RuntimeError" in result.sdk_error
+    assert "boom from SDK" in result.sdk_error
+    # Workspace dir should still be created.
+    assert (tmp_path / "ws").is_dir()
+
+
+@pytest.mark.asyncio
+async def test_run_one_attempt_aggregates_chunks(
+    tmp_path, fake_sdk, fake_options_cls
+):
+    skill = tmp_path / "SKILL.md"
+    skill.write_text("x", encoding="utf-8")
+    qr = tmp_path / "qr"
+    qr.mkdir()
+    fake_sdk.scripted_chunks = ["part one", "part two", "part three"]
+
+    result = await run_one_attempt(
+        user_prompt="x",
+        workspace=tmp_path / "ws",
+        quark_root=qr,
+        skill_path=skill,
+        sdk_query_factory=fake_sdk,
+        sdk_options_cls=fake_options_cls,
+    )
+    assert result.chunks == ["part one", "part two", "part three"]
+    assert "part one\npart two\npart three" == result.raw_text
+
+
+@pytest.mark.asyncio
+async def test_run_one_attempt_skill_missing_raises(tmp_path, fake_sdk, fake_options_cls):
+    qr = tmp_path / "qr"
+    qr.mkdir()
+    with pytest.raises(FileNotFoundError):
+        await run_one_attempt(
+            user_prompt="x",
+            workspace=tmp_path / "ws",
+            quark_root=qr,
+            skill_path=tmp_path / "nope.md",
+            sdk_query_factory=fake_sdk,
+            sdk_options_cls=fake_options_cls,
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_one_attempt_retry_picks_up_hypothesis(
+    tmp_path, fake_sdk, fake_options_cls
+):
+    skill = tmp_path / "SKILL.md"
+    skill.write_text("x", encoding="utf-8")
+    qr = tmp_path / "qr"
+    qr.mkdir()
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    hyp = ws / "fix_hypothesis_attempt_2.md"
+    hyp.write_text("retry plan", encoding="utf-8")
+
+    await run_one_attempt(
+        user_prompt="x",
+        workspace=ws,
+        quark_root=qr,
+        attempt_number=2,
+        previous_outcome="exec_oom",
+        skill_path=skill,
+        sdk_query_factory=fake_sdk,
+        sdk_options_cls=fake_options_cls,
+    )
+    prompt = fake_sdk.received_prompts[0]
+    assert "exec_oom" in prompt
+    assert "fix_hypothesis_attempt_2.md" in prompt
+    assert str(hyp) in prompt
+
+
+@pytest.mark.asyncio
+async def test_run_one_attempt_falls_back_when_cwd_unsupported(
+    tmp_path, fake_sdk
+):
+    """Older SDK builds without `cwd` kwarg should retry without it."""
+
+    skill = tmp_path / "SKILL.md"
+    skill.write_text("x", encoding="utf-8")
+    qr = tmp_path / "qr"
+    qr.mkdir()
+
+    class _StrictOptions:
+        def __init__(self, **kwargs):
+            if "cwd" in kwargs:
+                raise TypeError("cwd unsupported")
+            self.kwargs = kwargs
+
+    result = await run_one_attempt(
+        user_prompt="x",
+        workspace=tmp_path / "ws",
+        quark_root=qr,
+        skill_path=skill,
+        sdk_query_factory=fake_sdk,
+        sdk_options_cls=_StrictOptions,
+    )
+    assert result.sdk_error == ""
+    # cwd must have been stripped from the retry.
+    assert "cwd" not in fake_sdk.received_options[0].kwargs
+
+
+@pytest.mark.asyncio
+async def test_run_one_attempt_passes_model(
+    tmp_path, fake_sdk, fake_options_cls
+):
+    skill = tmp_path / "SKILL.md"
+    skill.write_text("x", encoding="utf-8")
+    qr = tmp_path / "qr"
+    qr.mkdir()
+
+    await run_one_attempt(
+        user_prompt="x",
+        workspace=tmp_path / "ws",
+        quark_root=qr,
+        skill_path=skill,
+        model="custom-model-id",
+        sdk_query_factory=fake_sdk,
+        sdk_options_cls=fake_options_cls,
+    )
+    assert fake_sdk.received_options[0].kwargs.get("model") == "custom-model-id"
+
+
+@pytest.mark.asyncio
+async def test_run_one_attempt_log_callback_captures_chunks(
+    tmp_path, fake_sdk, fake_options_cls
+):
+    skill = tmp_path / "SKILL.md"
+    skill.write_text("x", encoding="utf-8")
+    qr = tmp_path / "qr"
+    qr.mkdir()
+    captured: list[str] = []
+    fake_sdk.scripted_chunks = ["alpha", "beta"]
+
+    await run_one_attempt(
+        user_prompt="x",
+        workspace=tmp_path / "ws",
+        quark_root=qr,
+        skill_path=skill,
+        sdk_query_factory=fake_sdk,
+        sdk_options_cls=fake_options_cls,
+        log=captured.append,
+    )
+    assert any("alpha" in line for line in captured)
+    assert any("beta" in line for line in captured)


### PR DESCRIPTION
## Summary

Adds `quantization_agent/` — a thin Claude-SDK driver that runs AMD Quark PTQ
end-to-end from **a single natural-language prompt**. Loads `SKILL.md` as the
runtime contract, lets the LLM drive Quark's published skills
(`quark-torch-ptq` → `quark-torch-result-validator` → `quark-torch-llm-eval`),
classifies each attempt into a 30-outcome matrix, and exposes one
diagnose-fix-retry loop.

This PR ships the **standalone agent only**. Caller-side integration
(`inference_optimizer` flag wiring + request handler) is out of scope and
will land in a follow-up PR.

End-to-end validated on real models (prompt → agent → Quark, via the
standalone CLI):

| Model | Result | eval_gap |
|---|---|---|
| Qwen/Qwen3-8B mxfp4 + self_attn fp8 + kv_cache fp8 | success | 2.68% |
| Qwen/Qwen3-30B-A3B mxfp4 + self_attn fp8 + kv_cache fp8 | success | 0.44% |

## Agent interface

**Entry**: `quantize_via_prompt(prompt, *, workspace, quark_root=None,
interactive=None, acceptable_eval_gap=None, max_requantize_attempts=1)`
(async; a `quantize_via_prompt_sync` wrapper is also exported).

All quantization config — scheme, kv_cache, layer overrides, eval intent,
gap tolerance — travels through `prompt`. There is no structured config
object. `workspace` is the only place the agent writes; `quark_root` is
strictly read-only.

**Return** — `QuantSkillRunResult`:

| field | type | meaning |
|---|---|---|
| `status` | `str` | `"success"` / `"partial"` / `"failed"` |
| `quantized_model_dir` | `Path \| None` | exported HF-format model; `None` on failure |
| `assessment` | `Assessment` | `final` (OutcomeId) + `attempts` + `recovered` + `eval_gap` + `notes` |

CLI exit codes: `0` success/partial · `1` failed · `2` argparse error ·
`3` operator-rejected checkpoint.

Full field tables, workspace-file conventions, and env knobs:
[`quantization_agent/README.md`](quantization_agent/README.md).

## Suggested integration shape (not part of this PR)

For downstream callers (e.g. `inference_optimizer`), the recommended pattern
is to expose a single user-facing flag carrying the natural-language prompt,
forward it together with a per-run workspace into `quantize_via_prompt`, and
on `status != "failed"` use `result.quantized_model_dir` as the path to the
quantized model for subsequent stages. Specific flag names, request-handler
wiring, and error-to-exit-code mapping are deliberately left to the caller —
this PR does not prescribe them.

## Error catalog (30 outcomes)

Enumerated in code at [`quantization_agent/driver/outcomes.py`](quantization_agent/driver/outcomes.py);
the four category sets and the public-API surface are summarised in the
[Public API section of `quantization_agent/README.md`](quantization_agent/README.md#public-api).

Four disjoint sets: `AUTO_RECOVER` (13, SKILL.md self-heals in-session) +
`AUTO_FAIL` (10, fatal) + `ASK` (6, needs operator decision) +
`{unclassified_failure}` (1 catch-all). `SUCCESS_TAGS = {None,
eval_gap_accepted}` is what counts as a successful end of a multi-attempt run.

For callers: switch on `result.assessment.final` (stable `OutcomeId` string)
if you need to act on a specific failure reason.

## Standalone usage

```bash
python -m quantization_agent.cli \
    --prompt "Quantize Qwen/Qwen3-8B with mxfp4 as the global scheme; \
override self_attn modules to fp8, and use fp8 for the kv_cache. \
Export to <workspace>/quantized. Use gsm8k as the benchmark and accept \
up to a 5% relative eval gap. No human interaction at any point." \
    --workspace /scratch/run-1/wks \
    --quark-root "$QUARK_ROOT" \
    --interactive off \
    --acceptable-eval-gap 0.05
```

Workspace artifacts (~10 files: `eval_report.json`, `validation_report.md`,
`quant_plan.json`, …) remain under `--workspace` for offline inspection. See
[`quantization_agent/README.md`](quantization_agent/README.md) for the
Python async example.

## Testing

```bash
pytest quantization_agent/tests/ -q     # 122 tests, all offline
```

All unit tests are offline (fake-SDK fixture injected — no GPU, no Claude
SDK, no network). Coverage: outcome partition, classifier per fixture,
result collection, eval threshold / caching, retry loop (hypothesis-gate +
counter persistence + budget exhaustion), runner SDK seam.

End-to-end (manual): example prompt against any Qwen3 model;
`Qwen3-0.5B` smokes in ~5 min on a single MI300.

## Test plan

- [x] `pytest quantization_agent/tests/` — 122 passed offline
- [x] Qwen3-8B mxfp4 end-to-end through `quantization_agent.cli` — success
- [x] Qwen3-30B-A3B mxfp4 end-to-end through `quantization_agent.cli` — success
- [ ] Reviewer-side: rerun unit tests after `git am`