### PR TITLE
fix: repair merge-conflict breakage on main blocking full-repo CI

### DIFF
--- a/inference_optimizer/orchestrator/action_executors/profile.py
+++ b/inference_optimizer/orchestrator/action_executors/profile.py
@@ -53,11 +53,67 @@ log = logging.getLogger(__name__)
 # sentinel in a properly-patched run).
 _TRACE_INSPECT_BYTES = 2_000_000
 
+# Upper bound (decompressed bytes) for the confirmation streaming scan
+# used only when the cheap leading-window sample finds zero of a
+# sentinel. A full main trace can be 600 MB+ decompressed; the
+# ``execute_*`` per-step annotations are interleaved with the kernel
+# event stream and routinely land well past the leading 2 MB window,
+# so a window-only check false-positives on large traces. Streaming up
+# to this cap (well under a full decompress) confirms genuine absence
+# before we emit a warning. Override via
+# ``INFERENCE_OPTIMIZER_TRACE_CONFIRM_BYTES``.
+_TRACE_CONFIRM_BYTES = 64_000_000
+
 # Minimum fraction of ``cpu_op`` events that should carry an
 # ``Input Dims`` field for a ``capture_traces/`` file to be considered
 # healthy (Deval's reference run reports 99.97%; we set the gate
 # generously low so trivial misses don't false-positive).
 _INPUT_DIMS_FRACTION_FLOOR = 0.90
+
+
+def _trace_contains(path: Path, substring: str, max_bytes: int | None = None) -> bool:
+    """Stream-decompress ``path`` looking for ``substring``, reading at
+    most ``max_bytes`` decompressed bytes (default
+    :data:`_TRACE_CONFIRM_BYTES`, overridable via
+    ``INFERENCE_OPTIMIZER_TRACE_CONFIRM_BYTES``).
+
+    Used as a confirmation pass when the cheap leading-window sample
+    (:func:`_sample_trace_text`) finds zero occurrences — large traces
+    interleave the per-step annotations far past the 2 MB window, so a
+    window-only "absent" verdict must be confirmed before warning.
+    Returns ``False`` on any IO/decode error (best-effort, never raises).
+    """
+    if not substring:
+        return False
+    if max_bytes is None:
+        try:
+            max_bytes = int(
+                os.environ.get(
+                    "INFERENCE_OPTIMIZER_TRACE_CONFIRM_BYTES",
+                    _TRACE_CONFIRM_BYTES,
+                )
+            )
+        except (TypeError, ValueError):
+            max_bytes = _TRACE_CONFIRM_BYTES
+    read = 0
+    carry = ""
+    chunk_size = 4_000_000
+    try:
+        with gzip.open(path, "rt", encoding="utf-8", errors="replace") as fh:
+            while read < max_bytes:
+                chunk = fh.read(chunk_size)
+                if not chunk:
+                    break
+                read += len(chunk)
+                if substring in (carry + chunk):
+                    return True
+                # Keep a tail long enough to catch a sentinel split
+                # across the chunk boundary.
+                carry = chunk[-(len(substring)):]
+    except (OSError, EOFError, UnicodeDecodeError) as e:
+        log.debug("_trace_contains: cannot stream %s: %s", path, e)
+        return False
+    return False
 
 
 def _sample_trace_text(path: Path) -> str | None:
@@ -151,12 +207,22 @@ def _validate_trace_structure(
             cpu_op_count = _count_substring_occurrences(text, '"name": "cpu_op"')
             input_dims_count = _count_substring_occurrences(text, '"Input Dims"')
             if cpu_op_count == 0:
+                # ROCm / SGLang builds frequently record graph-capture
+                # kernel events under names other than the literal
+                # ``"name": "cpu_op"`` (e.g. ``sglang_profiler::*``
+                # entries), so a zero count here does NOT by itself mean
+                # capture failed — shape discovery can still have fired
+                # (see the server-side ``kernel_shape_profiler enabled``
+                # log line and Check [5]). Keep this as an informational
+                # signal, not a regression verdict.
                 issues.append(
-                    f"[2] capture file {target.name} has no cpu_op events "
-                    f"in the first {_TRACE_INSPECT_BYTES//1_000_000} MB — "
-                    "graph capture wrote files but they don't contain "
-                    "kernel-level events. Possible upstream profiler "
-                    "regression."
+                    f"[2] capture file {target.name} has no literal "
+                    f"'cpu_op' events in the first "
+                    f"{_TRACE_INSPECT_BYTES//1_000_000} MB — on ROCm/SGLang "
+                    "this is often just an event-naming difference (kernels "
+                    "logged under 'sglang_profiler::*'); cross-check Check "
+                    "[5] (kernel_shape_profiler) and the server log before "
+                    "treating it as a capture regression."
                 )
             elif input_dims_count / max(cpu_op_count, 1) < _INPUT_DIMS_FRACTION_FLOOR:
                 pct = 100.0 * input_dims_count / cpu_op_count
@@ -187,22 +253,36 @@ def _validate_trace_structure(
                 main_text, '"name": "user_annotation"',
             )
             execute_count = _count_substring_occurrences(main_text, '"execute_')
-            if user_ann_count == 0:
-                issues.append(
-                    f"[3] main trace {main_traces[0].name} has no "
-                    "user_annotation events — InferenceX per-step "
-                    "annotations didn't fire. Verify roofline_annotations "
-                    "reached the framework (PROFILE_EXTRA_BODY consumed; "
-                    "see #210)."
+            # The real health signal for "per-step instrumentation fired"
+            # is the presence of ``execute_*`` annotation labels — those
+            # are what the trace splitter keys on and what roofline
+            # analysis consumes. The ``"name": "user_annotation"`` wrapper
+            # is profiler-version-dependent: some torch / SGLang builds
+            # (e.g. sglang 0.5.11 on ROCm) emit the ``execute_*`` markers
+            # under a different event ``name`` / ``cat`` and never produce
+            # the literal ``user_annotation`` string, so gating the warning
+            # on ``user_ann_count == 0`` false-positives on a perfectly
+            # healthy trace. Only warn when the ``execute_*`` labels are
+            # genuinely absent (both signals missing). The leading 2 MB
+            # window routinely misses ``execute_*`` markers on a 600 MB+
+            # trace, so confirm genuine absence with a bounded streaming
+            # scan before warning — otherwise a healthy run emits a
+            # misleading "annotations didn't fire" warning every profile.
+            if execute_count == 0 and user_ann_count == 0:
+                confirmed_absent = not (
+                    _trace_contains(main_traces[0], '"execute_')
+                    or _trace_contains(
+                        main_traces[0], '"name": "user_annotation"'
+                    )
                 )
-            elif execute_count == 0:
-                issues.append(
-                    f"[3] main trace {main_traces[0].name} has "
-                    f"user_annotation events but no execute_* annotations "
-                    "— InferenceX is annotating but the per-step "
-                    "execute_* labels are missing. Check the InferenceX "
-                    "version actually loaded by Magpie."
-                )
+                if confirmed_absent:
+                    issues.append(
+                        f"[3] main trace {main_traces[0].name} has no "
+                        "execute_* / user_annotation events — InferenceX "
+                        "per-step annotations didn't fire. Verify "
+                        "roofline_annotations reached the framework "
+                        "(PROFILE_EXTRA_BODY consumed; see #210)."
+                    )
 
     # --- Check 4 (Deval): per-file execute_* in trace_split/ ---
     # Each splitter output should contain its own slice of execute_*

--- a/inference_optimizer/orchestrator/specialist_runner.py
+++ b/inference_optimizer/orchestrator/specialist_runner.py
@@ -477,7 +477,6 @@ class SpecialistRunner:
                 # ``_format_version_note`` can annotate version-mismatched
                 # lessons / pitfalls. Both empty when the Coordinator
                 # didn't warm them (legacy callers / pre-PR sessions).
-                framework=str(params.get("framework") or ""),
                 framework_version=str(params.get("framework_version") or ""),
                 workspace_path=(
                     str(workspace_for_prompt) if workspace_for_prompt else ""

--- a/inference_optimizer/tests/test_framework_pr_critic_gate.py
+++ b/inference_optimizer/tests/test_framework_pr_critic_gate.py
@@ -17,6 +17,7 @@ import asyncio
 from pathlib import Path
 from typing import Any
 
+import pytest
 
 from inference_optimizer.orchestrator.backends.critic_mock import (
     MockCriticBackend,

--- a/inference_optimizer/tests/test_profile_trace_validator.py
+++ b/inference_optimizer/tests/test_profile_trace_validator.py
@@ -256,60 +256,82 @@ def test_validator_warns_when_capture_file_has_no_cpu_op(tmp_path, caplog):
     caplog.set_level(logging.WARNING)
     _validate_trace_structure(trace_dir, "sglang")
     msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
-    assert any("no cpu_op events" in m for m in msgs), msgs
+    # Wording softened: zero literal ``cpu_op`` events on ROCm/SGLang is
+    # often just an event-naming difference, not a capture regression.
+    assert any("no literal 'cpu_op' events" in m for m in msgs), msgs
 
 
 # ---------------------------------------------------------------------------
 # Check [3] (Deval) main trace has user_annotation + execute_*
 # ---------------------------------------------------------------------------
-def test_validator_warns_when_main_trace_lacks_user_annotation(
+def test_validator_no_warning_when_execute_star_present_without_user_annotation(
     tmp_path, caplog,
 ):
-    """Main trace with no ``user_annotation`` events → InferenceX
-    per-step annotations didn't fire. Separate failure mode from
-    [5] kernel_shape_profiler absence — a partially-patched run can
-    have one without the other."""
+    """Regression guard for the profiler-version false positive: some
+    torch / SGLang builds (e.g. sglang 0.5.11 on ROCm) emit the
+    ``execute_*`` per-step annotation labels WITHOUT wrapping them in a
+    literal ``"name": "user_annotation"`` event. That trace is healthy —
+    the splitter and roofline analysis key on ``execute_*`` — so Check
+    [3] MUST NOT warn just because the ``user_annotation`` wrapper is
+    absent."""
     trace_dir = _build_healthy_layout(tmp_path)
     main = next(trace_dir.glob("*.trace.json.gz"))
     main.unlink()
-    _write_minimal_sglang_trace(
-        main,
-        with_kernel_shape_profiler=True,
-        with_user_annotation=False,  # the smoking-gun for check [3]
-    )
+    # execute_* label present, but emitted under a non-user_annotation
+    # event name (mimics the ROCm/SGLang 0.5.11 profiler shape).
+    payload = {
+        "schemaVersion": 1,
+        "traceEvents": [
+            {"name": "cpu_op", "ph": "X", "ts": 0, "dur": 1},
+            {
+                "name": "kernel",
+                "ph": "X",
+                "args": {
+                    "label": "execute_16384_context_16(sq16384sk16384)"
+                },
+            },
+            {"name": "python_function", "ph": "i",
+             "args": {"frame": "kernel_shape_profiler"}},
+        ],
+    }
+    with gzip.open(main, "wt", encoding="utf-8") as fh:
+        json.dump(payload, fh)
 
     caplog.set_level(logging.WARNING)
     _validate_trace_structure(trace_dir, "sglang")
     msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
-    assert any("no user_annotation events" in m for m in msgs), msgs
-    assert any("PROFILE_EXTRA_BODY" in m for m in msgs), (
-        "should point operators at the #210 fix path"
+    assert not any("[3]" in m for m in msgs), (
+        "execute_* present → Check [3] must not warn even without the "
+        f"user_annotation wrapper; got: {msgs}"
     )
 
 
-def test_validator_warns_when_main_trace_lacks_execute_star_annotations(
+def test_validator_warns_when_main_trace_lacks_all_annotations(
     tmp_path, caplog,
 ):
-    """user_annotation events present but no ``execute_*`` labels →
-    the per-step instrumentation labels are missing; InferenceX is
-    annotating something else. Hints at version mismatch between
-    Magpie's bundled InferenceX and the patcher's expectations."""
+    """Genuine absence: neither ``execute_*`` labels NOR
+    ``user_annotation`` events anywhere in the trace → InferenceX
+    per-step annotations really didn't fire. This is the only case
+    Check [3] should warn on."""
     trace_dir = _build_healthy_layout(tmp_path)
     main = next(trace_dir.glob("*.trace.json.gz"))
     main.unlink()
     _write_minimal_sglang_trace(
         main,
         with_kernel_shape_profiler=True,
-        with_user_annotation=True,
-        with_execute_star=False,  # smoking-gun: annotations without execute_*
+        with_user_annotation=False,   # no user_annotation wrapper
+        with_execute_star=False,      # and no execute_* labels at all
     )
 
     caplog.set_level(logging.WARNING)
     _validate_trace_structure(trace_dir, "sglang")
     msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
     assert any(
-        "no execute_* annotations" in m and "Magpie" in m for m in msgs
+        "[3]" in m and "per-step annotations didn't fire" in m for m in msgs
     ), msgs
+    assert any("PROFILE_EXTRA_BODY" in m for m in msgs), (
+        "should point operators at the #210 fix path"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# fix: repair merge-conflict breakage on main blocking full-repo CI

## Summary

Two P0 defects landed on `main` via the `d8d9f5c` *"Merge origin/main into
atom branch"* conflict resolution (Atom framework branch #361) and broke
**test collection for the entire repository**, which is why the `test` job
fails at the collection stage (5 errors) across #362 / #361 / #360 / #359 /
#347. The failures are not from those PRs — `main` itself is broken. (#342
still shows green only because its CI ran on an older base that predates the
bad merge commit.)

This branch fixes both blockers, plus a related profile trace-validator
false positive discovered during a live `mi355x` / `sglang` Qwen3-32B
optimization run.

## Root cause

`d8d9f5c` mis-resolved the merge conflict when folding the Atom framework
work (#361) into `main`:

1. The Atom-side `framework=` and the original `framework_version=` keyword
   arguments in `SpecialistPromptInputs(...)` were **both kept**, leaving a
   duplicated `framework=` kwarg.
2. A `@pytest.mark.parametrize` decorator was kept without its `import pytest`.

## Changes

### 1. `specialist_runner.py` — `SyntaxError: keyword argument repeated: framework`

`SpecialistPromptInputs(...)` carried `framework=str(params.get("framework") or "")`
twice (lines 454 **and** 480). Python raises `SyntaxError: keyword argument
repeated: framework` at import time, crashing **every module that imports
`specialist_runner`**:

- `test_per_domain_prompts`
- `test_pr_monitor`
- `test_specialist_runner_truncation`
- `test_specialist_subprocess`

**Fix:** drop the duplicate (the one under the GAP-8 comment block, which was
meant to introduce only `framework_version=`); keep a single `framework=` and
`framework_version=`.

### 2. `test_framework_pr_critic_gate.py` — `NameError` at collection

Line 317 uses `@pytest.mark.parametrize` but the module never imported
`pytest`, so collection raises `NameError`.

**Fix:** add `import pytest` to the import block.

### 3. `profile.py` — trace-validator false positive (Check [3]) + Check [2] wording

Surfaced on a live `mi355x` / `sglang 0.5.11` / FP8 Qwen3-32B run: every
profile logged

> `[3] main trace ...TP-1.trace.json.gz has no user_annotation events —
> InferenceX per-step annotations didn't fire`

even though `trace_analyze` succeeded and EXPLORE proceeded normally. Two
underlying issues:

- **Logic:** Check [3] gated the warning on the literal `"name":
  "user_annotation"` substring. Some ROCm / SGLang 0.5.11 + torch-profiler
  builds emit the `execute_*` per-step labels — the signal the trace splitter
  and roofline analysis actually consume — **without** the `user_annotation`
  wrapper. Evidence from the live run: full decompression of the 638 MB trace
  showed `user_annotation = 0` but `execute_* = 768`. The check therefore
  flagged a perfectly healthy trace.
- **Sampling:** `_sample_trace_text` only reads the leading 2 MB of the
  decompressed trace. On 600 MB+ traces the per-step annotations are
  interleaved far past that window, so a window-only "absent" verdict is
  unreliable.

**Fix:**
- Treat `execute_*` presence as the **primary** health signal; only warn when
  **both** `execute_*` and `user_annotation` are absent.
- Add `_trace_contains()` — a bounded streaming scan (default 64 MB cap,
  overridable via `INFERENCE_OPTIMIZER_TRACE_CONFIRM_BYTES`) — to confirm
  genuine absence before warning.
- Soften Check [2]'s `cpu_op` message: zero literal `"name": "cpu_op"` events
  on ROCm/SGLang is usually just an event-naming difference (kernels logged
  under `sglang_profiler::*`), not a capture regression. Cross-references
  Check [5] (`kernel_shape_profiler`).

### 4. `test_profile_trace_validator.py` — tests updated to corrected behavior

- New `test_validator_no_warning_when_execute_star_present_without_user_annotation`
  — regression guard for the profiler-version false positive.
- Repurposed the old "missing user_annotation" test into
  `test_validator_warns_when_main_trace_lacks_all_annotations` (warns only when
  **both** signals are absent).
- Updated Check [2] assertion to match the softened wording.

## Files changed

```
 inference_optimizer/orchestrator/action_executors/profile.py | 120 +++++++++++++++----
 inference_optimizer/orchestrator/specialist_runner.py        |   1 -
 inference_optimizer/tests/test_framework_pr_critic_gate.py   |   1 +
 inference_optimizer/tests/test_profile_trace_validator.py    |  66 ++++++++----
 4 files changed, 145 insertions(+), 43 deletions(-)
```

## Test plan

- [x] `specialist_runner.py` compiles and imports (`py_compile` + import).
- [x] Formerly-broken modules collect cleanly (clean env to avoid an
      unrelated `$MAGPIE_DIR` / `$INFERENCEX_PATH` env-leak in
      `test_inferencex_patcher.py`):
      `test_per_domain_prompts`, `test_pr_monitor`,
      `test_specialist_runner_truncation`, `test_specialist_subprocess`,
      `test_framework_pr_critic_gate` → **111 tests collected, 0 errors**.
- [x] `test_framework_pr_critic_gate.py` → **14 passed**.
- [x] `test_profile_trace_validator.py` → **11 passed**.
- [x] No linter errors on the touched files.

## Notes

- The fixes are import/collection-level and validator-only; no runtime
  behavior of the optimizer loop changes (the trace-validator only *logs*,
  never raises). A live run already in progress is unaffected until its next
  fresh session / `--resume`.
- The unrelated `test_inferencex_patcher.py` failures observed when running
  inside a configured optimizer shell are a pre-existing test-isolation issue
  (the tests read the real `$MAGPIE_DIR` / `$INFERENCEX_PATH` env vars); they
  pass in a clean environment and are out of scope for this PR.
