### PR TITLE
breakdown(roofline+attribution): Dashboard kernel_roofline / roofline sections + framework_pr surfacing + specialist key normalize

### DIFF
--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -1329,6 +1329,12 @@ def _specialist_capability_row(state: dict[str, Any]) -> dict[str, Any]:
     Single source of truth per Inv-12.2: the row never diverges from
     the ``specialist_runs`` section because both read the same
     SharedState ledger.
+
+    The headline counts (``status`` / ``attempts`` / ``keeps`` /
+    ``tested``) aggregate across every domain. ``by_specialist``
+    breaks them out per SpecialistDomain.key so the dashboard can
+    render six (or seven, including session_steward) per-specialist
+    cards without re-aggregating client-side.
     """
     rounds = state.get("specialist_rounds") or []
     if not isinstance(rounds, list) or not rounds:
@@ -1337,16 +1343,60 @@ def _specialist_capability_row(state: dict[str, Any]) -> dict[str, Any]:
             "attempts":  0,
             "keeps":     0,
             "tested":    0,
+            "by_specialist": _empty_by_specialist_capability(),
         }
+
     attempts = 0
     proposals_total = 0
     proposals_kept = 0
+    # Per-domain counters. Seeded with the catalogue so consumers
+    # iterate every known specialist without presence checks; unknown
+    # domain strings still in state survive (forward compat with new
+    # SpecialistDomain entries).
+    by_specialist_raw: dict[str, dict[str, int]] = {
+        d: {"attempts": 0, "keeps": 0, "tested": 0, "rejected": 0}
+        for d in _SPECIALIST_DOMAIN_KEYS
+    }
+
     for r in rounds:
         if not isinstance(r, dict):
             continue
         attempts += 1
         proposals_total += int(r.get("proposals_total") or 0)
         proposals_kept += int(r.get("proposals_kept") or 0)
+
+        # Per-domain tallies. Trust ``domain_breakdown`` when the
+        # Coordinator wrote it (most accurate, especially for parallel
+        # multi-domain rounds); otherwise fall back to ``domains[]``
+        # split evenly across the round's totals.
+        round_breakdown = r.get("domain_breakdown")
+        if isinstance(round_breakdown, dict) and round_breakdown:
+            for dom, payload in round_breakdown.items():
+                if not isinstance(payload, dict):
+                    continue
+                bucket = by_specialist_raw.setdefault(str(dom), {
+                    "attempts": 0, "keeps": 0, "tested": 0, "rejected": 0,
+                })
+                bucket["attempts"] += int(payload.get("dispatched") or 0)
+                bucket["keeps"] += int(payload.get("proposals_kept") or 0)
+                bucket["tested"] += int(payload.get("proposals_total") or 0)
+                bucket["rejected"] += int(payload.get("proposals_rejected") or 0)
+        else:
+            # Round predates ``domain_breakdown``; impute equal share
+            # across the listed domains so the per-domain numbers add
+            # up to the parent row even on legacy rounds.
+            domains = r.get("domains") or []
+            if isinstance(domains, list) and domains:
+                share_total = int(r.get("proposals_total") or 0) // len(domains)
+                share_kept = int(r.get("proposals_kept") or 0) // len(domains)
+                for dom in domains:
+                    bucket = by_specialist_raw.setdefault(str(dom), {
+                        "attempts": 0, "keeps": 0, "tested": 0, "rejected": 0,
+                    })
+                    bucket["attempts"] += 1
+                    bucket["tested"] += share_total
+                    bucket["keeps"] += share_kept
+
     if attempts == 0:
         status = "not_attempted"
     elif proposals_kept > 0:
@@ -1355,11 +1405,44 @@ def _specialist_capability_row(state: dict[str, Any]) -> dict[str, Any]:
         status = "tried"
     else:
         status = "attempted"
+
+    # Materialize the by_specialist dict with status derived per-domain.
+    by_specialist: dict[str, dict[str, Any]] = {}
+    for dom, raw in by_specialist_raw.items():
+        if raw["attempts"] == 0:
+            dom_status = "not_attempted"
+        elif raw["keeps"] > 0:
+            dom_status = "kept"
+        elif raw["tested"] > 0:
+            dom_status = "tried"
+        else:
+            dom_status = "attempted"
+        by_specialist[dom] = {
+            "status":   dom_status,
+            "attempts": raw["attempts"],
+            "keeps":    raw["keeps"],
+            "tested":   raw["tested"],
+        }
+
     return {
-        "status":   status,
-        "attempts": attempts,
-        "keeps":    proposals_kept,
-        "tested":   proposals_total,
+        "status":         status,
+        "attempts":       attempts,
+        "keeps":          proposals_kept,
+        "tested":         proposals_total,
+        "by_specialist":  by_specialist,
+    }
+
+
+def _empty_by_specialist_capability() -> dict[str, dict[str, Any]]:
+    """Seed every catalogue domain with a not_attempted CapabilityEntry.
+
+    Stable-shape contract: the dashboard never has to ``KeyError``-
+    guard when iterating ``capability_summary.specialist.by_specialist``
+    on a session that didn't dispatch every domain.
+    """
+    return {
+        d: {"status": "not_attempted", "attempts": 0, "keeps": 0, "tested": 0}
+        for d in _SPECIALIST_DOMAIN_KEYS
     }
 
 
@@ -2611,6 +2694,56 @@ def collect_telemetry(
 # ---------------------------------------------------------------------------
 # §14 Attribution
 # ---------------------------------------------------------------------------
+# Catalogue of the 7 SpecialistDomain.key strings
+# (specialist_domains.SPECIALIST_DOMAIN_KEYS). Kept inline rather than
+# imported so the breakdown package stays free of orchestrator deps —
+# the breakdown module is meant to be readable by tools running
+# offline against a session_dir tarball.
+_SPECIALIST_DOMAIN_KEYS: tuple[str, ...] = (
+    "serving_specialist",
+    "kernel_switch_specialist",
+    "comm_specialist",
+    "compiler_specialist",
+    "system_specialist",
+    "pr_intel_specialist",
+    "session_steward_specialist",
+)
+
+
+def _normalize_specialist_key(provenance: str) -> str:
+    """Map a raw ``provenance`` string to a stable specialist key.
+
+    The orchestrator stamps four shapes of provenance on explore
+    winners:
+
+    * ``"specialist:<domain>"`` — the canonical case for v0.8+ runs.
+      Strip the prefix so the consumer iterates one bare key per
+      catalogue entry instead of having to special-case the prefix.
+    * ``"default_grid"`` — cold-start grid run when no specialist has
+      produced a proposal_set yet.
+    * ``"llm_direct"`` — orchestration LLM authored the variant
+      directly (legacy path; PR-A9 retired this).
+    * ``"legacy:<action>"`` — resume of a pre-v0.8 session whose
+      promoted actions predate the specialist split. Folded under
+      ``"legacy_<action>"`` so it doesn't pollute the specialist
+      catalogue while still being inspectable.
+
+    Empty / unknown values become ``"unknown"`` so the by_domain dict
+    is never keyed by ``""``.
+    """
+    s = (provenance or "").strip()
+    if not s:
+        return "unknown"
+    if s.startswith("specialist:"):
+        # Trust the orchestrator's domain string verbatim — adding a new
+        # SpecialistDomain in specialist_domains.py shouldn't require a
+        # parallel update here.
+        return s[len("specialist:"):] or "unknown"
+    if s.startswith("legacy:"):
+        return f"legacy_{s[len('legacy:'):]}"
+    return s
+
+
 def _action_family(action: str) -> str:
     """Map an action label to a family for source_breakdown bucketing."""
     s = (action or "").lower()
@@ -2962,13 +3095,19 @@ def _collect_phase_breakdown(
         if phase == "explore":
             by_domain = bucket.setdefault("by_domain", {})
             fp = str(e.get("fingerprint") or e.get("variant_fingerprint") or "")
-            prov = (
+            raw_prov = (
                 provenance_by_fp.get(fp)
                 or str(e.get("provenance") or "")
                 or "default_grid"
             )
-            by_domain[prov] = round(
-                float(by_domain.get(prov, 0.0)) + float(delta), 2,
+            # Normalize to a bare specialist key (strip ``specialist:``
+            # prefix; fold ``legacy:*`` into ``legacy_*``). Without this
+            # the dashboard had to manually splice the prefix every time
+            # it iterated by_domain — error-prone and easy to miss when
+            # the orchestrator adds a new SpecialistDomain.
+            domain = _normalize_specialist_key(raw_prov)
+            by_domain[domain] = round(
+                float(by_domain.get(domain, 0.0)) + float(delta), 2,
             )
         elif phase == "kernel":
             by_kid = bucket.setdefault("by_kernel_id", {})

--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -3003,6 +3003,85 @@ def _reconstruct_gain_ledger(
 # ---------------------------------------------------------------------------
 # source_files map
 # ---------------------------------------------------------------------------
+_KERNEL_ROOFLINE_REL_PATH = "reports/kernel_roofline.json"
+
+
+def collect_kernel_roofline(
+    session_dir: Path,
+    warnings: list[str],
+) -> dict[str, Any]:
+    """Mirror ``<session_dir>/reports/kernel_roofline.json`` into the
+    breakdown's ``kernel_roofline`` section.
+
+    The kernel-agent watermark roofline pipeline writes this file once
+    per successful trace analysis (minute-cadence on a live session,
+    once at end-of-session post-mortem). The dashboard renders one row
+    per kernel for the "Kernel Roofline 表格" panel
+    (Dashboard-Roofline 对接清单 §1).
+
+    File missing → empty dict + warning. Malformed JSON → empty dict +
+    warning (``_load_json_safe`` already records the parse error).
+    Non-list ``kernels`` field is replaced with ``[]`` so the consumer
+    can iterate unconditionally.
+
+    Each kernel entry's fields are coerced through the standard helpers
+    so an upstream type change (e.g. ``call_count`` arriving as a JSON
+    float) doesn't break the dashboard's downstream parsers.
+    """
+    path = session_dir / _KERNEL_ROOFLINE_REL_PATH
+    if not path.exists():
+        # Quiet on absence — most sessions never run the roofline
+        # pipeline and a warning would clutter every breakdown.
+        return {}
+    blob = _load_json_safe(path, warnings)
+    if not isinstance(blob, dict):
+        warnings.append(
+            f"kernel_roofline: {_KERNEL_ROOFLINE_REL_PATH} is not a JSON object"
+        )
+        return {}
+
+    raw_kernels = blob.get("kernels")
+    if raw_kernels is None:
+        kernels: list[dict[str, Any]] = []
+    elif not isinstance(raw_kernels, list):
+        warnings.append(
+            "kernel_roofline.kernels is not a list; dropping entries"
+        )
+        kernels = []
+    else:
+        kernels = [_normalize_kernel_roofline_entry(k) for k in raw_kernels
+                   if isinstance(k, dict)]
+
+    out: dict[str, Any] = {
+        "schema_version":         _to_int(blob.get("schema_version")) or 1,
+        "source":                 str(blob.get("source") or ""),
+        "analysis_md_path":       str(blob.get("analysis_md_path") or ""),
+        "kernel_candidates_path": str(blob.get("kernel_candidates_path") or ""),
+        "trace_input":            str(blob.get("trace_input") or ""),
+        "trace_input_type":       str(blob.get("trace_input_type") or ""),
+        "kernels":                kernels,
+    }
+    return out
+
+
+def _normalize_kernel_roofline_entry(raw: dict[str, Any]) -> dict[str, Any]:
+    """Coerce one kernel entry to the schema shape with stable types."""
+    return {
+        "kernel_id":             str(raw.get("kernel_id") or ""),
+        "name":                  str(raw.get("name") or ""),
+        "source_file":           str(raw.get("source_file") or ""),
+        "kernel_category":       str(raw.get("kernel_category") or ""),
+        "bound_type":            str(raw.get("bound_type") or ""),
+        "arithmetic_intensity":  _to_float(raw.get("arithmetic_intensity")) or 0.0,
+        "flops_per_byte":        _to_float(raw.get("flops_per_byte")) or 0.0,
+        "efficiency_percent":    _to_float(raw.get("efficiency_percent")) or 0.0,
+        "gpu_pct":               _to_float(raw.get("gpu_pct")) or 0.0,
+        "call_count":            _to_int(raw.get("call_count")) or 0,
+        "duration_us":           _to_float(raw.get("duration_us")) or 0.0,
+        "reusable_native_kernel": bool(raw.get("reusable_native_kernel")),
+    }
+
+
 def collect_source_files(
     session_dir: Path,
     baseline_path: str | None,

--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -3006,6 +3006,195 @@ def _reconstruct_gain_ledger(
 _KERNEL_ROOFLINE_REL_PATH = "reports/kernel_roofline.json"
 
 
+# ---------------------------------------------------------------------------
+# Roofline — optimization-progress curve (Dashboard 对接清单 §2)
+# ---------------------------------------------------------------------------
+# Default ratio of vendor-peak HBM bandwidth that's actually achievable.
+# Vendor specs are theoretical maxima; sustained throughput is bounded
+# by memory-controller scheduling, cache-line granularity, thermal /
+# power throttling, and (for multi-GPU) XGMI arbitration. 70% is the
+# conservative target Hyperloom optimizes against — see Dashboard-
+# Roofline 对接清单 §2 for rationale.
+DEFAULT_ROOFLINE_TARGET_RATIO = 0.70
+
+
+def collect_roofline(
+    session_dir: Path,
+    state: dict[str, Any],
+    manifest: dict[str, Any],
+    warnings: list[str],
+) -> dict[str, Any]:
+    """Build the ``roofline`` section feeding the optimization-progress
+    chart (Dashboard-Roofline 对接清单 §2).
+
+    Pulls everything from in-memory ``state`` + ``manifest``; never
+    re-runs benchmarks. The dashboard reads sbd alone — no
+    ``state.json`` walk on the consumer side.
+
+    Output shape (RoofLine TypedDict):
+
+    * ``trajectory[]`` — 1 baseline point + N KEEP points, sorted by
+      ts. Always at least one point (baseline) when ``baseline_tput``
+      is known; empty when the session never finished baseline.
+    * ``ceiling_tok_per_sec`` / ``target_tok_per_sec`` —
+      ``state.roofline_snapshots[-1]`` (latest snapshot, not [0]; the
+      ceiling can drift across re-runs as the snapshot pipeline
+      refines its peak estimate). ``None`` when no snapshot exists;
+      ``ceiling_available`` is the explicit boolean flag.
+    * ``current_best_tput`` — last trajectory point's tput, validated
+      against ``state.current_best.tput`` when present.
+    * ``current_best_pct_of_*`` — convenience ratios for the dashboard
+      callout. ``None`` when the ceiling is missing.
+    * ``snapshots[]`` — full passthrough of ``state.roofline_snapshots``
+      for tooltips / drill-downs.
+
+    Never raises; structured failures land in ``warnings`` and the
+    section becomes a partial dict.
+    """
+    # ── Trajectory: baseline + each KEEP ────────────────────────────────
+    baseline_tput = _to_float(state.get("baseline_tput")) or 0.0
+    trajectory: list[dict[str, Any]] = []
+    if baseline_tput > 0:
+        trajectory.append({
+            "ts":         str(manifest.get("created_at_utc") or ""),
+            "tput":       baseline_tput,
+            "label":      "baseline",
+            "action":     "baseline",
+            "gain_pct":   0.0,
+            "flags":      "",
+            "extra_envs": {},
+        })
+
+    stack = state.get("optimization_stack") or []
+    if isinstance(stack, list):
+        # The stack is already in promotion order, but sort by ts as a
+        # belt-and-braces guard against legacy paths that prepended.
+        ordered = sorted(
+            (e for e in stack if isinstance(e, dict)),
+            key=lambda e: str(e.get("ts") or ""),
+        )
+        for entry in ordered:
+            tput = _to_float(entry.get("tput"))
+            if tput is None or tput <= 0:
+                continue
+            gain_pct = (
+                ((tput - baseline_tput) / baseline_tput * 100.0)
+                if baseline_tput > 0 else 0.0
+            )
+            trajectory.append({
+                "ts":         str(entry.get("ts") or ""),
+                "tput":       tput,
+                "label":      str(entry.get("variant_name") or entry.get("action") or ""),
+                "action":     str(entry.get("action") or ""),
+                "gain_pct":   round(gain_pct, 4),
+                "flags":      str(entry.get("candidate_extra_sglang_args") or ""),
+                "extra_envs": dict(entry.get("extra_envs") or {}),
+            })
+
+    # ── Reference lines: ceiling + target ───────────────────────────────
+    snapshots_raw = state.get("roofline_snapshots") or []
+    snapshots: list[dict[str, Any]] = []
+    if isinstance(snapshots_raw, list):
+        for snap in snapshots_raw:
+            if isinstance(snap, dict):
+                snapshots.append(_normalize_roofline_snapshot(snap))
+
+    # Use the LATEST snapshot for headline numbers — the ceiling
+    # estimate refines as the watermark roofline pipeline reruns.
+    latest_snap = snapshots[-1] if snapshots else None
+    ceiling_tok = (
+        _to_float(latest_snap.get("theoretical_peak_tok_per_sec"))
+        if latest_snap else None
+    )
+    ceiling_available = ceiling_tok is not None and ceiling_tok > 0
+    target_tok = (
+        round(ceiling_tok * DEFAULT_ROOFLINE_TARGET_RATIO, 4)
+        if ceiling_available else None
+    )
+
+    # ── Headline numbers ────────────────────────────────────────────────
+    current_best_tput = (
+        trajectory[-1]["tput"] if trajectory else 0.0
+    )
+    cumulative_gain_pct = _to_float(state.get("cumulative_gain")) or 0.0
+    pct_of_ceiling = (
+        round(current_best_tput / ceiling_tok * 100.0, 4)
+        if ceiling_available and current_best_tput > 0 else None
+    )
+    pct_of_target = (
+        round(current_best_tput / target_tok * 100.0, 4)
+        if (target_tok and target_tok > 0 and current_best_tput > 0) else None
+    )
+
+    out: dict[str, Any] = {
+        "ceiling_tok_per_sec":          ceiling_tok,
+        "target_tok_per_sec":           target_tok,
+        "ceiling_ratio_target":         DEFAULT_ROOFLINE_TARGET_RATIO,
+        "ceiling_available":            ceiling_available,
+        "trajectory":                   trajectory,
+        "baseline_tput":                baseline_tput,
+        "current_best_tput":            current_best_tput,
+        "cumulative_gain_pct":          round(cumulative_gain_pct, 4),
+        "current_best_pct_of_ceiling":  pct_of_ceiling,
+        "current_best_pct_of_target":   pct_of_target,
+        "roofline_failure_streak":      _to_int(state.get("roofline_failure_streak")) or 0,
+        "snapshots":                    snapshots,
+    }
+    if latest_snap:
+        out["snapshot_top_bottleneck"] = str(latest_snap.get("top_bottleneck") or "")
+        within = _to_float(latest_snap.get("within_roofline_pct"))
+        if within is not None:
+            out["snapshot_within_roofline_pct"] = within
+        gap = _to_float(latest_snap.get("gap_to_roofline_pct"))
+        if gap is not None:
+            out["snapshot_gap_to_roofline_pct"] = gap
+
+    # Sanity check: trajectory tail should match state.current_best.tput
+    # when both are known. A divergence means the stack wasn't fully
+    # promoted (resume mid-promotion) — surface it instead of hiding.
+    cb_tput = _to_float((state.get("current_best") or {}).get("tput"))
+    if (
+        cb_tput is not None and cb_tput > 0
+        and current_best_tput > 0
+        and abs(cb_tput - current_best_tput) / max(cb_tput, 1.0) > 0.001
+    ):
+        warnings.append(
+            f"roofline.current_best_tput ({current_best_tput:.2f}) does not "
+            f"match state.current_best.tput ({cb_tput:.2f}); the trajectory "
+            f"may be missing a promotion event."
+        )
+    return out
+
+
+def _normalize_roofline_snapshot(snap: dict[str, Any]) -> dict[str, Any]:
+    """Coerce one ``state.roofline_snapshots[]`` entry to the schema."""
+    top_kernel_raw = snap.get("top_kernel") or {}
+    top_kernel: dict[str, Any] = {}
+    if isinstance(top_kernel_raw, dict):
+        top_kernel = {
+            "name":           str(top_kernel_raw.get("name") or ""),
+            "bound_type":     str(top_kernel_raw.get("bound_type") or ""),
+            "efficiency_pct": _to_float(top_kernel_raw.get("efficiency_pct")) or 0.0,
+            "gpu_pct":        _to_float(top_kernel_raw.get("gpu_pct")) or 0.0,
+        }
+    return {
+        "snapshot_id":                  _to_int(snap.get("snapshot_id")) or 0,
+        "ts":                           str(snap.get("ts") or ""),
+        "achieved_tok_per_sec":         _to_float(snap.get("achieved_tok_per_sec")) or 0.0,
+        "theoretical_peak_tok_per_sec": _to_float(snap.get("theoretical_peak_tok_per_sec")) or 0.0,
+        "within_roofline_pct":          _to_float(snap.get("within_roofline_pct")) or 0.0,
+        "gap_to_roofline_pct":          _to_float(snap.get("gap_to_roofline_pct")) or 0.0,
+        "compute_pct":                  _to_float(snap.get("compute_pct")) or 0.0,
+        "idle_pct":                     _to_float(snap.get("idle_pct")) or 0.0,
+        "comm_pct":                     _to_float(snap.get("comm_pct")) or 0.0,
+        "top_bottleneck":               str(snap.get("top_bottleneck") or ""),
+        "top_kernel":                   top_kernel,
+        "analysis_md_path":             str(snap.get("analysis_md_path") or ""),
+        "kernel_roofline_path":         str(snap.get("kernel_roofline_path") or ""),
+        "trace_input":                  str(snap.get("trace_input") or ""),
+    }
+
+
 def collect_kernel_roofline(
     session_dir: Path,
     warnings: list[str],

--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -2629,6 +2629,15 @@ def _action_family(action: str) -> str:
     # single row that subsumes the legacy backends + params buckets.
     if s == "explore":
         return "explore"
+    # FRAMEWORK_PR (PRELUDE → FRAMEWORK_PR → EXPLORE).
+    # Surfaces upstream PR-driven KEEPs as their own headline row in
+    # ``source_breakdown`` so the dashboard's per-source totals reconcile
+    # against ``validated_total_pct``. Without this, framework_pr KEEPs
+    # fell through to ``"other"`` and silently disappeared from the
+    # leaderboard's per-source columns (manifest of: Params=0% +
+    # Backends=1.74% + Kernel=0% summing to ≪ Validated=22.85%).
+    if s == "framework_pr":
+        return "framework_pr"
     return "other"
 
 
@@ -2736,6 +2745,11 @@ def collect_attribution(
         # explore family (subsumes backends+params on v0.8
         # sessions; legacy buckets stay populated on legacy resume).
         "explore": 0.0,
+        # FRAMEWORK_PR family. Stays separate from the
+        # legacy ``other`` bucket so the dashboard can surface a
+        # dedicated ``framework_pr_pct_of_total`` row that reconciles
+        # against ``validated_total_pct``.
+        "framework_pr": 0.0,
     }
     for e in entries:
         if not isinstance(e, dict):
@@ -2793,6 +2807,12 @@ def collect_attribution(
             "oob_pct_of_total":      round(oob_total, 2),
             # primary row.
             "explore_pct_of_total":  round(family_totals.get("explore", 0.0), 2),
+            # FRAMEWORK_PR phase row. Tracks gain
+            # attributable to upstream PR adoption (between PRELUDE
+            # and EXPLORE). Always emitted (0.0 when the phase is
+            # disabled or contributed nothing) so the dashboard can
+            # iterate the catalogue without presence checks.
+            "framework_pr_pct_of_total": round(family_totals.get("framework_pr", 0.0), 2),
             # Legacy bucket aliases — preserved for legacy resume reports.
             "backends_pct_of_total": round(family_totals.get("backends", 0.0), 2),
             "params_pct_of_total":   round(family_totals.get("params", 0.0), 2),
@@ -2886,6 +2906,10 @@ def _collect_phase_breakdown(
 
     phase_buckets: dict[str, dict[str, Any]] = {
         "prelude": {"total_gain_pct": 0.0},
+        # FRAMEWORK_PR is the dedicated upstream-PR bake-in
+        # phase between PRELUDE and EXPLORE. KEEPs here come from
+        # framework_pr action entries (one ts/gain per adopted PR).
+        "framework_pr": {"total_gain_pct": 0.0, "by_pr": {}},
         "explore": {"total_gain_pct": 0.0, "by_domain": {}},
         "kernel":  {"total_gain_pct": 0.0, "by_kernel_id": {}},
         "sweep":   {"total_gain_pct": 0.0},
@@ -2927,6 +2951,8 @@ def _collect_phase_breakdown(
                 phase = "kernel"
             elif fam == "sweep":
                 phase = "sweep"
+            elif fam == "framework_pr":
+                phase = "framework_pr"
             else:
                 phase = "unattributed"
         bucket = phase_buckets[phase]
@@ -2949,6 +2975,20 @@ def _collect_phase_breakdown(
             kid = str(e.get("kernel_id") or e.get("action_kernel_id") or "?")
             by_kid[kid] = round(
                 float(by_kid.get(kid, 0.0)) + float(delta), 2,
+            )
+        elif phase == "framework_pr":
+            # variant_name on framework_pr entries is the PR ref
+            # (``PR:<repo>#<num>`` / ``PR:<num>``); fall back to the
+            # entry's ``ref`` field when present, else ``?`` so the
+            # bucket key is always a string.
+            by_pr = bucket.setdefault("by_pr", {})
+            pr_key = (
+                str(e.get("variant_name") or "").strip()
+                or str(e.get("ref") or "").strip()
+                or "?"
+            )
+            by_pr[pr_key] = round(
+                float(by_pr.get(pr_key, 0.0)) + float(delta), 2,
             )
 
     # Drop the empty-by-default unattributed bucket when nothing

--- a/inference_optimizer/breakdown/exporter.py
+++ b/inference_optimizer/breakdown/exporter.py
@@ -180,6 +180,15 @@ def build(
                                         ),
                                         warnings,
                                         default={})
+    # Optimization-progress curve (Dashboard §2). Stack ledger +
+    # ceiling/target reference lines, derived from state.json so the
+    # dashboard reads sbd alone.
+    roofline           = _safe_collect("roofline",
+                                        lambda: collectors.collect_roofline(
+                                            sd, state, manifest, warnings,
+                                        ),
+                                        warnings,
+                                        default={})
 
     source_files = collectors.collect_source_files(
         sd,
@@ -234,6 +243,11 @@ def build(
         # Empty dict when ``<sd>/reports/kernel_roofline.json`` is
         # absent — the dashboard hides the table on empty.
         "kernel_roofline":     kernel_roofline,
+        # Optimization-progress curve (Dashboard-Roofline 对接清单 §2).
+        # Always populated when baseline ran; ``ceiling_available`` is
+        # False on sessions that never ran the watermark roofline
+        # pipeline (dashboard hides the reference lines).
+        "roofline":            roofline,
 
         "warnings":            warnings,
         "source_files":        source_files,

--- a/inference_optimizer/breakdown/exporter.py
+++ b/inference_optimizer/breakdown/exporter.py
@@ -171,6 +171,15 @@ def build(
                                         ),
                                         warnings,
                                         default=[])
+    # Hot-kernel roofline table (Dashboard §1). Pulls
+    # ``<sd>/reports/kernel_roofline.json`` so dashboards consume sbd
+    # exclusively and never have to walk the kernel-agent tree.
+    kernel_roofline    = _safe_collect("kernel_roofline",
+                                        lambda: collectors.collect_kernel_roofline(
+                                            sd, warnings,
+                                        ),
+                                        warnings,
+                                        default={})
 
     source_files = collectors.collect_source_files(
         sd,
@@ -221,6 +230,10 @@ def build(
         "kb_provenance":       kb_provenance,
         # specialist sub-agent dispatch records.
         "specialist_runs":     specialist_runs,
+        # Hot-kernel roofline table (Dashboard-Roofline 对接清单 §1).
+        # Empty dict when ``<sd>/reports/kernel_roofline.json`` is
+        # absent — the dashboard hides the table on empty.
+        "kernel_roofline":     kernel_roofline,
 
         "warnings":            warnings,
         "source_files":        source_files,

--- a/inference_optimizer/breakdown/schema.py
+++ b/inference_optimizer/breakdown/schema.py
@@ -172,6 +172,14 @@ class CapabilityEntry(TypedDict, total=False):
     # v0.8 M3 explore-specific:
     keep_unstable_count: int      # KEEP'd variants evicted by inlined stack rebench
     winners_history: int          # cumulative explore_search.winners_history length
+    # specialist-row only — per-domain split. Keys are
+    # SpecialistDomain.key strings (``serving_specialist`` /
+    # ``kernel_switch_specialist`` / ``comm_specialist`` /
+    # ``compiler_specialist`` / ``system_specialist`` /
+    # ``pr_intel_specialist`` / ``session_steward_specialist``). Every
+    # catalogue domain is seeded with a not_attempted entry so the
+    # dashboard can iterate without presence checks.
+    by_specialist: dict[str, "CapabilityEntry"]
 
 
 class CapabilitySummary(TypedDict, total=False):
@@ -454,9 +462,17 @@ class SourceBreakdown(TypedDict, total=False):
 
 class PhaseBreakdownExplore(TypedDict, total=False):
     """v0.8 M7 (KB_design §3.12 §4.6) — explore-phase gain split by
-    specialist domain. ``by_domain`` keys are SpecialistDomain.key
-    strings (``serving_specialist`` / …) plus ``default_grid`` /
-    ``llm_direct`` for non-specialist provenance."""
+    specialist domain.
+
+    ``by_domain`` keys are normalized — the collector strips
+    ``specialist:`` prefixes before bucketing, so consumers see the
+    bare SpecialistDomain.key (``serving_specialist`` /
+    ``kernel_switch_specialist`` / …). Non-specialist provenance
+    appears as ``default_grid`` / ``llm_direct``; resumed-from-v1
+    sessions appear as ``legacy_<action>`` (e.g. ``legacy_backends``)
+    so they don't masquerade as a real specialist domain. Empty
+    provenance falls back to ``unknown``.
+    """
     total_gain_pct: float
     by_domain: dict[str, float]
 

--- a/inference_optimizer/breakdown/schema.py
+++ b/inference_optimizer/breakdown/schema.py
@@ -673,6 +673,51 @@ class SourceFiles(TypedDict, total=False):
     robustness_workdir: str | None
 
 
+# ---------------------------------------------------------------------------
+# Kernel Roofline — hot-kernel table for the dashboard
+# ---------------------------------------------------------------------------
+# Mirrors ``<session_dir>/reports/kernel_roofline.json`` produced by the
+# kernel-agent's tracelens roofline pipeline. The dashboard renders one row
+# per kernel (default sort = ``gpu_pct`` desc); each entry is self-contained
+# so the consumer doesn't need to read the original report file.
+class KernelRooflineEntry(TypedDict, total=False):
+    """One hot-kernel row in the dashboard's kernel roofline table.
+
+    Keys mirror the on-disk shape; collector passes them through
+    verbatim (with type coercion) to keep the schema loose-coupled to
+    the tracelens output format. Fields documented in
+    ``Dashboard-Roofline 对接清单.md`` §1.
+    """
+    kernel_id: str                 # ``k001``..``k010``
+    name: str                      # ``aiter::ck_moe_stage1`` etc
+    source_file: str               # absolute path; "" when unknown
+    kernel_category: str           # ``MoE`` / ``LayerNorm`` / ``unknown``
+    bound_type: str                # ``memory-bound`` / ``compute-bound``
+    arithmetic_intensity: float
+    flops_per_byte: float
+    efficiency_percent: float      # kernel-self efficiency 0..100
+    gpu_pct: float                 # share of overall GPU time 0..100
+    call_count: int
+    duration_us: float
+    reusable_native_kernel: bool   # True ⇒ GEAK can swap in a custom kernel
+
+
+class KernelRoofline(TypedDict, total=False):
+    """Top-level ``kernel_roofline`` section.
+
+    Loaded from ``<session_dir>/reports/kernel_roofline.json`` when
+    present; left empty (``{}``) on missing / malformed file (collector
+    appends a warning instead of raising).
+    """
+    schema_version: int                    # tracelens output schema (currently 1)
+    source: str                            # provenance label, e.g. ``tracelens_analysis``
+    analysis_md_path: str                  # absolute path to the human-readable analysis
+    kernel_candidates_path: str            # absolute path to kernel_candidates.json
+    trace_input: str                       # absolute path to the trace dir
+    trace_input_type: str                  # ``capture_dir`` / ``trace_file`` / ...
+    kernels: list[KernelRooflineEntry]
+
+
 class SessionBreakdown(TypedDict, total=False):
     schema_version: str
     exported_at_utc: str
@@ -707,6 +752,10 @@ class SessionBreakdown(TypedDict, total=False):
     kb_provenance: KBProvenance      # Cortex KB audit
     # specialist sub-agent dispatch records.
     specialist_runs: list[SpecialistRound]
+    # Hot-kernel table for the dashboard (Dashboard-Roofline 对接清单
+    # §1). Mirrors ``<sd>/reports/kernel_roofline.json`` so consumers
+    # don't have to walk the kernel-agent output tree themselves.
+    kernel_roofline: KernelRoofline
 
     warnings: list[str]
     source_files: SourceFiles

--- a/inference_optimizer/breakdown/schema.py
+++ b/inference_optimizer/breakdown/schema.py
@@ -674,6 +674,108 @@ class SourceFiles(TypedDict, total=False):
 
 
 # ---------------------------------------------------------------------------
+# Roofline — optimization-progress curve for the dashboard
+# ---------------------------------------------------------------------------
+# Drives the "优化进度曲线" panel (Dashboard-Roofline 对接清单 §2): a
+# stepped line from baseline through every KEEP, plotted against two
+# horizontal reference lines (ceiling = vendor peak, target = ceiling
+# × 0.70). All inputs derived from ``state.json`` so the dashboard
+# only needs to read ``session_breakdown.json``.
+class RooflineTrajectoryPoint(TypedDict, total=False):
+    """One x/y/tooltip on the optimization-progress curve.
+
+    ``x`` is an iso UTC timestamp; the dashboard may convert to a step
+    index for the horizontal axis. The first point is always
+    ``label = "baseline"`` (taken from ``manifest.created_at_utc`` +
+    ``state.baseline_tput``); subsequent points come from
+    ``state.optimization_stack[]`` in promotion order.
+    """
+    ts: str                          # iso UTC, x value
+    tput: float                      # tok/s, y value
+    label: str                       # "baseline" / variant_name
+    action: str                      # "baseline" / "explore" / "kernel_opt" / ...
+    gain_pct: float                  # cumulative gain vs baseline at this point
+    flags: str                       # candidate_extra_sglang_args
+    extra_envs: dict[str, str]       # KEY=value pairs the variant set
+
+
+class RooflineSnapshot(TypedDict, total=False):
+    """One ``state.roofline_snapshots[]`` entry mirrored verbatim.
+
+    Kept as a list (the dashboard reads ``snapshots[0]`` for the
+    headline ceiling but downstream tooling may want the full
+    history). Field shape mirrors the on-disk record so a future
+    snapshot field addition flows through transparently.
+    """
+    snapshot_id: int
+    ts: str
+    achieved_tok_per_sec: float
+    theoretical_peak_tok_per_sec: float       # ceiling, vendor peak (unreachable)
+    within_roofline_pct: float                # achieved / peak * 100
+    gap_to_roofline_pct: float
+    compute_pct: float
+    idle_pct: float
+    comm_pct: float
+    top_bottleneck: str                       # "MoE_unfused" etc
+    top_kernel: dict[str, Any]                # {name, bound_type, efficiency_pct, gpu_pct}
+    analysis_md_path: str
+    kernel_roofline_path: str
+    trace_input: str
+
+
+class Roofline(TypedDict, total=False):
+    """Top-level ``roofline`` section.
+
+    Two products in one structure:
+
+    1. **Reference lines** (``ceiling_tok_per_sec`` / ``target_tok_per_sec``):
+       horizontal dashed lines on the chart. ``ceiling`` is the
+       vendor's theoretical peak (from the latest snapshot);
+       ``target = ceiling × ceiling_ratio_target`` (default 0.70 — see
+       Dashboard 对接清单 §2.1 for why we don't aim at 100%).
+
+    2. **Trajectory** (``trajectory[]``): the stepped line itself —
+       baseline + every KEEP, sorted by ts.
+
+    ``snapshots[]`` carries the raw ``state.roofline_snapshots[]``
+    entries verbatim for tooltips / drill-downs; consumers that just
+    want to render the chart can ignore it.
+
+    Edge cases (Dashboard-Roofline 对接清单 §5):
+    * No snapshot ever taken → ``ceiling_available = False``,
+      ``ceiling_tok_per_sec / target_tok_per_sec`` absent. Dashboard
+      hides the reference lines.
+    * No KEEP yet → ``trajectory`` has the single baseline point only.
+      ``current_best_tput == baseline_tput`` and
+      ``cumulative_gain_pct == 0.0``.
+    """
+    # Reference lines (only set when snapshots[] is non-empty)
+    ceiling_tok_per_sec: float | None
+    target_tok_per_sec: float | None
+    ceiling_ratio_target: float                # default 0.70
+    ceiling_available: bool
+    snapshot_top_bottleneck: str               # tooltip on the ceiling line
+    snapshot_within_roofline_pct: float
+    snapshot_gap_to_roofline_pct: float
+
+    # Trajectory
+    trajectory: list[RooflineTrajectoryPoint]
+
+    # Headline numbers (also derivable from trajectory[-1] /
+    # state.cumulative_gain — surfaced here so the dashboard's "current"
+    # callout doesn't need to compute them).
+    baseline_tput: float
+    current_best_tput: float
+    cumulative_gain_pct: float
+    current_best_pct_of_ceiling: float | None  # tput/ceiling*100, None when no ceiling
+    current_best_pct_of_target: float | None   # tput/target*100, None when no ceiling
+
+    # Audit / staleness
+    roofline_failure_streak: int               # consecutive watermark roofline failures
+    snapshots: list[RooflineSnapshot]
+
+
+# ---------------------------------------------------------------------------
 # Kernel Roofline — hot-kernel table for the dashboard
 # ---------------------------------------------------------------------------
 # Mirrors ``<session_dir>/reports/kernel_roofline.json`` produced by the
@@ -756,6 +858,11 @@ class SessionBreakdown(TypedDict, total=False):
     # §1). Mirrors ``<sd>/reports/kernel_roofline.json`` so consumers
     # don't have to walk the kernel-agent output tree themselves.
     kernel_roofline: KernelRoofline
+    # Optimization-progress curve for the dashboard
+    # (Dashboard-Roofline 对接清单 §2). Carries the trajectory
+    # (baseline + KEEP points), the ceiling/target reference lines,
+    # and the headline current-best numbers.
+    roofline: Roofline
 
     warnings: list[str]
     source_files: SourceFiles

--- a/inference_optimizer/breakdown/schema.py
+++ b/inference_optimizer/breakdown/schema.py
@@ -440,6 +440,12 @@ class SourceBreakdown(TypedDict, total=False):
     oob_pct_of_total: float
     # primary explore family bucket.
     explore_pct_of_total: float
+    # FRAMEWORK_PR phase contribution (PRELUDE → FRAMEWORK_PR →
+    # EXPLORE). Tracks gain from upstream-PR bake-ins as a separate
+    # row so the dashboard's per-source totals reconcile against
+    # ``validated_total_pct``; previously these KEEPs fell into
+    # ``other`` and silently disappeared.
+    framework_pr_pct_of_total: float
     backends_pct_of_total: float
     params_pct_of_total: float
     sweep_pct_of_total: float
@@ -462,9 +468,19 @@ class PhaseBreakdownKernel(TypedDict, total=False):
     by_kernel_id: dict[str, float]
 
 
+class PhaseBreakdownFrameworkPr(TypedDict, total=False):
+    """FRAMEWORK_PR phase gain split by adopted PR
+    reference. ``by_pr`` keys are the entry's ``variant_name`` (PR
+    label, typically ``PR:<repo>#<num>`` or ``PR:<num>``); empty
+    string falls back to ``"?"``."""
+    total_gain_pct: float
+    by_pr: dict[str, float]
+
+
 class PhaseBreakdown(TypedDict, total=False):
     """v0.8 M7 per-phase gain attribution (KB_design §3.13 M7 §6)."""
     prelude: PhaseBreakdownExplore         # always 0 by definition
+    framework_pr: PhaseBreakdownFrameworkPr  # PRELUDE → FRAMEWORK_PR → EXPLORE
     explore: PhaseBreakdownExplore
     kernel:  PhaseBreakdownKernel
     sweep:   PhaseBreakdownExplore         # usually 0 (sweep is measurement)

--- a/inference_optimizer/tests/test_breakdown_smoke.py
+++ b/inference_optimizer/tests/test_breakdown_smoke.py
@@ -606,6 +606,143 @@ def test_attribution_method_missing(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# A1.0a: framework_pr surfaces in source_breakdown + phase_breakdown
+# ---------------------------------------------------------------------------
+# FRAMEWORK_PR is a phase between PRELUDE and
+# EXPLORE that bakes in upstream PRs. Before this PR landed,
+# framework_pr KEEPs fell into the legacy ``other`` family bucket and
+# silently disappeared from ``source_breakdown`` — manifesting as
+# leaderboard rows where Params + Backends + Kernel summed to far
+# below ``validated_total_pct``. These tests pin the new behaviour.
+def test_attribution_framework_pr_surfaces_in_source_breakdown(
+    tmp_path: Path,
+) -> None:
+    """A KEEP with ``action == "framework_pr"`` contributes to the new
+    ``framework_pr_pct_of_total`` field instead of being lost."""
+    sd = _attribution_fixture(tmp_path, {
+        "cumulative_gain_validated": 22.85,
+        "optimization_stack": [
+            {"action": "params",       "variant_name": "torch_compile_on", "gain_pct": 0.53},
+            {"action": "framework_pr", "variant_name": "PR:26311",         "gain_pct": 22.43},
+        ],
+        "gain_per_stack_entry": [
+            {"action": "params",       "variant_name": "torch_compile_on",
+             "stack_len_before": 0, "stack_len_after": 1,
+             "cum_gain_before": 0.0, "cum_gain_after": 0.53,
+             "delta_pct": 0.53,
+             "ts": "2026-05-29T11:00:00+00:00"},
+            {"action": "framework_pr", "variant_name": "PR:26311",
+             "stack_len_before": 1, "stack_len_after": 2,
+             "cum_gain_before": 0.53, "cum_gain_after": 22.85,
+             "delta_pct": 22.32,
+             "ts": "2026-05-29T11:30:00+00:00"},
+        ],
+    })
+    sb = build(sd)["attribution"]["source_breakdown"]
+    assert sb["framework_pr_pct_of_total"] == pytest.approx(22.32)
+    assert sb["params_pct_of_total"] == pytest.approx(0.53)
+    # Reconciliation: kernel + backends + params + sweep + framework_pr
+    # ≈ validated_total. The legacy "other" bucket no longer eats
+    # framework_pr gain.
+    summed = (
+        sb["geak_pct_of_total"]
+        + sb["oob_pct_of_total"]
+        + sb["backends_pct_of_total"]
+        + sb["params_pct_of_total"]
+        + sb["sweep_pct_of_total"]
+        + sb["framework_pr_pct_of_total"]
+    )
+    assert summed == pytest.approx(sb["validated_total_pct"], abs=0.05)
+
+
+def test_attribution_framework_pr_pct_emitted_even_when_zero(
+    tmp_path: Path,
+) -> None:
+    """``framework_pr_pct_of_total`` is always emitted (defaults to 0.0)
+    so the dashboard can iterate the catalogue without hasattr checks."""
+    sd = _attribution_fixture(tmp_path, {
+        "cumulative_gain_validated": 5.0,
+        "optimization_stack": [
+            {"action": "params", "variant_name": "p1", "gain_pct": 5.0},
+        ],
+        "gain_per_stack_entry": [
+            {"action": "params", "variant_name": "p1",
+             "stack_len_before": 0, "stack_len_after": 1,
+             "cum_gain_before": 0.0, "cum_gain_after": 5.0,
+             "delta_pct": 5.0,
+             "ts": "2026-05-29T11:00:00+00:00"},
+        ],
+    })
+    sb = build(sd)["attribution"]["source_breakdown"]
+    assert "framework_pr_pct_of_total" in sb
+    assert sb["framework_pr_pct_of_total"] == 0.0
+
+
+def test_attribution_phase_breakdown_framework_pr_by_pr(
+    tmp_path: Path,
+) -> None:
+    """``phase_breakdown.framework_pr.by_pr`` aggregates per-PR gain.
+    Each entry's ``variant_name`` is the PR label (``PR:<num>`` or
+    ``PR:<repo>#<num>``); the bucket key is the variant_name verbatim."""
+    sd = _attribution_fixture(tmp_path, {
+        "cumulative_gain_validated": 30.0,
+        "phase_history": [
+            {"to_phase": "PRELUDE",      "ts_unix": 1000.0},
+            {"to_phase": "FRAMEWORK_PR", "ts_unix": 1100.0},
+            {"to_phase": "EXPLORE",      "ts_unix": 2000.0},
+        ],
+        "optimization_stack": [
+            {"action": "framework_pr", "variant_name": "PR:26311"},
+            {"action": "framework_pr", "variant_name": "PR:sgl#9912"},
+        ],
+        "gain_per_stack_entry": [
+            {"action": "framework_pr", "variant_name": "PR:26311",
+             "stack_len_before": 0, "stack_len_after": 1,
+             "cum_gain_before": 0.0, "cum_gain_after": 18.0,
+             "delta_pct": 18.0,
+             "ts_unix": 1200.0},
+            {"action": "framework_pr", "variant_name": "PR:sgl#9912",
+             "stack_len_before": 1, "stack_len_after": 2,
+             "cum_gain_before": 18.0, "cum_gain_after": 30.0,
+             "delta_pct": 12.0,
+             "ts_unix": 1500.0},
+        ],
+    })
+    pb = build(sd)["attribution"]["phase_breakdown"]
+    assert "framework_pr" in pb
+    assert pb["framework_pr"]["total_gain_pct"] == pytest.approx(30.0)
+    assert pb["framework_pr"]["by_pr"]["PR:26311"] == pytest.approx(18.0)
+    assert pb["framework_pr"]["by_pr"]["PR:sgl#9912"] == pytest.approx(12.0)
+
+
+def test_attribution_framework_pr_phase_fallback_when_no_phase_history(
+    tmp_path: Path,
+) -> None:
+    """Without ``phase_history`` the collector falls back to action
+    family. ``framework_pr`` actions land in the framework_pr phase
+    bucket (not ``unattributed``) so the gain is still surfaced."""
+    sd = _attribution_fixture(tmp_path, {
+        "cumulative_gain_validated": 10.0,
+        "optimization_stack": [
+            {"action": "framework_pr", "variant_name": "PR:42",
+             "ts": "2026-05-29T11:00:00+00:00"},
+        ],
+        "gain_per_stack_entry": [
+            {"action": "framework_pr", "variant_name": "PR:42",
+             "stack_len_before": 0, "stack_len_after": 1,
+             "cum_gain_before": 0.0, "cum_gain_after": 10.0,
+             "delta_pct": 10.0,
+             "ts": "2026-05-29T11:00:00+00:00"},
+        ],
+    })
+    pb = build(sd)["attribution"]["phase_breakdown"]
+    assert pb["framework_pr"]["total_gain_pct"] == pytest.approx(10.0)
+    assert pb["framework_pr"]["by_pr"]["PR:42"] == pytest.approx(10.0)
+    # Nothing should leak into ``unattributed``.
+    assert "unattributed" not in pb or pb["unattributed"]["total_gain_pct"] == 0.0
+
+
+# ---------------------------------------------------------------------------
 # A1.1: kernel_roofline (Dashboard-Roofline 对接清单 §1)
 # ---------------------------------------------------------------------------
 # The collector mirrors ``<sd>/reports/kernel_roofline.json`` so the

--- a/inference_optimizer/tests/test_breakdown_smoke.py
+++ b/inference_optimizer/tests/test_breakdown_smoke.py
@@ -743,6 +743,227 @@ def test_attribution_framework_pr_phase_fallback_when_no_phase_history(
 
 
 # ---------------------------------------------------------------------------
+# A1.0b: phase_breakdown.explore.by_domain key normalization
+# ---------------------------------------------------------------------------
+# Pre-PR-B the orchestrator's raw ``provenance`` strings landed in
+# ``by_domain`` verbatim — keys looked like ``"specialist:serving_specialist"``
+# / ``"legacy:backends"`` / ``"default_grid"``. Consumers had to splice
+# the prefix every time they iterated. The collector now strips
+# ``specialist:`` and folds ``legacy:*`` into ``legacy_*``; this section
+# pins that contract.
+def test_phase_breakdown_explore_by_domain_strips_specialist_prefix(
+    tmp_path: Path,
+) -> None:
+    """``provenance = 'specialist:serving_specialist'`` surfaces under
+    the bare ``serving_specialist`` key — the dashboard never sees the
+    raw prefix. Multiple specialist provenances go to distinct buckets
+    and sum independently."""
+    sd = _attribution_fixture(tmp_path, {
+        "cumulative_gain_validated": 12.0,
+        "phase_history": [
+            {"to_phase": "EXPLORE", "ts_unix": 1000.0},
+        ],
+        "explore_search": {
+            "winners_history": [
+                {"fingerprint": "fp_serving",
+                 "provenance": "specialist:serving_specialist"},
+                {"fingerprint": "fp_kernel_switch",
+                 "provenance": "specialist:kernel_switch_specialist"},
+            ],
+        },
+        "optimization_stack": [
+            {"action": "explore", "variant_name": "v_a", "fingerprint": "fp_serving"},
+            {"action": "explore", "variant_name": "v_b", "fingerprint": "fp_kernel_switch"},
+        ],
+        "gain_per_stack_entry": [
+            {"action": "explore", "variant_name": "v_a",
+             "fingerprint": "fp_serving",
+             "stack_len_before": 0, "stack_len_after": 1,
+             "cum_gain_before": 0.0, "cum_gain_after": 7.0,
+             "delta_pct": 7.0, "ts_unix": 1100.0},
+            {"action": "explore", "variant_name": "v_b",
+             "fingerprint": "fp_kernel_switch",
+             "stack_len_before": 1, "stack_len_after": 2,
+             "cum_gain_before": 7.0, "cum_gain_after": 12.0,
+             "delta_pct": 5.0, "ts_unix": 1200.0},
+        ],
+    })
+    pb = build(sd)["attribution"]["phase_breakdown"]
+    by_domain = pb["explore"]["by_domain"]
+    assert by_domain["serving_specialist"] == pytest.approx(7.0)
+    assert by_domain["kernel_switch_specialist"] == pytest.approx(5.0)
+    # Raw prefix must not leak.
+    assert "specialist:serving_specialist" not in by_domain
+    assert "specialist:kernel_switch_specialist" not in by_domain
+
+
+def test_phase_breakdown_legacy_provenance_folded_to_legacy_prefix(
+    tmp_path: Path,
+) -> None:
+    """``provenance = 'legacy:backends'`` (resume of a pre-v0.8 session)
+    becomes ``legacy_backends`` so it sits next to specialist keys
+    without masquerading as one — the dashboard can group / hide
+    legacy buckets explicitly."""
+    sd = _attribution_fixture(tmp_path, {
+        "cumulative_gain_validated": 5.0,
+        "phase_history": [
+            {"to_phase": "EXPLORE", "ts_unix": 1000.0},
+        ],
+        "explore_search": {
+            "winners_history": [
+                {"fingerprint": "fp_legacy", "provenance": "legacy:backends"},
+            ],
+        },
+        "optimization_stack": [
+            {"action": "explore", "variant_name": "v_legacy", "fingerprint": "fp_legacy"},
+        ],
+        "gain_per_stack_entry": [
+            {"action": "explore", "variant_name": "v_legacy",
+             "fingerprint": "fp_legacy",
+             "stack_len_before": 0, "stack_len_after": 1,
+             "cum_gain_before": 0.0, "cum_gain_after": 5.0,
+             "delta_pct": 5.0, "ts_unix": 1100.0},
+        ],
+    })
+    by_domain = build(sd)["attribution"]["phase_breakdown"]["explore"]["by_domain"]
+    assert by_domain["legacy_backends"] == pytest.approx(5.0)
+    # Raw colon-form must not surface.
+    assert "legacy:backends" not in by_domain
+    # And it must NOT collide with the specialist namespace.
+    assert "backends" not in by_domain
+
+
+def test_phase_breakdown_default_grid_and_llm_direct_pass_through(
+    tmp_path: Path,
+) -> None:
+    """Non-specialist provenance (``default_grid`` / ``llm_direct``)
+    passes through verbatim — they're already valid stable keys."""
+    sd = _attribution_fixture(tmp_path, {
+        "cumulative_gain_validated": 4.0,
+        "phase_history": [
+            {"to_phase": "EXPLORE", "ts_unix": 1000.0},
+        ],
+        "explore_search": {
+            "winners_history": [
+                {"fingerprint": "fp_grid", "provenance": "default_grid"},
+                {"fingerprint": "fp_direct", "provenance": "llm_direct"},
+            ],
+        },
+        "optimization_stack": [
+            {"action": "explore", "variant_name": "v_grid",   "fingerprint": "fp_grid"},
+            {"action": "explore", "variant_name": "v_direct", "fingerprint": "fp_direct"},
+        ],
+        "gain_per_stack_entry": [
+            {"action": "explore", "variant_name": "v_grid",
+             "fingerprint": "fp_grid",
+             "stack_len_before": 0, "stack_len_after": 1,
+             "cum_gain_before": 0.0, "cum_gain_after": 1.0,
+             "delta_pct": 1.0, "ts_unix": 1100.0},
+            {"action": "explore", "variant_name": "v_direct",
+             "fingerprint": "fp_direct",
+             "stack_len_before": 1, "stack_len_after": 2,
+             "cum_gain_before": 1.0, "cum_gain_after": 4.0,
+             "delta_pct": 3.0, "ts_unix": 1200.0},
+        ],
+    })
+    by_domain = build(sd)["attribution"]["phase_breakdown"]["explore"]["by_domain"]
+    assert by_domain["default_grid"] == pytest.approx(1.0)
+    assert by_domain["llm_direct"] == pytest.approx(3.0)
+
+
+# ---------------------------------------------------------------------------
+# A1.0c: capability_summary.specialist.by_specialist per-domain split
+# ---------------------------------------------------------------------------
+def test_capability_summary_specialist_by_specialist_from_domain_breakdown(
+    tmp_path: Path,
+) -> None:
+    """``domain_breakdown`` is the authoritative source. Each round's
+    per-domain dict is folded into the headline ``by_specialist``
+    counters; status is derived per-domain."""
+    sd = tmp_path / "session"
+    sd.mkdir()
+    _write_state(sd, _basic_state(specialist_rounds=[
+        _specialist_round(
+            round_id=1,
+            domains=["serving_specialist"],
+            proposals_total=3, proposals_kept=2,
+            domain_breakdown={
+                "serving_specialist": {
+                    "dispatched": 1, "proposals_total": 3,
+                    "proposals_kept": 2, "proposals_rejected": 1,
+                },
+            },
+        ),
+        _specialist_round(
+            round_id=2,
+            domains=["kernel_switch_specialist", "comm_specialist"],
+            proposals_total=5, proposals_kept=0,
+            domain_breakdown={
+                "kernel_switch_specialist": {
+                    "dispatched": 1, "proposals_total": 3,
+                    "proposals_kept": 0, "proposals_rejected": 3,
+                },
+                "comm_specialist": {
+                    "dispatched": 1, "proposals_total": 2,
+                    "proposals_kept": 0, "proposals_rejected": 2,
+                },
+            },
+        ),
+    ]))
+    spec = build(sd)["capability_summary"]["specialist"]
+    bs = spec["by_specialist"]
+    # serving_specialist: dispatched once, 2 keeps → kept.
+    assert bs["serving_specialist"]["status"] == "kept"
+    assert bs["serving_specialist"]["attempts"] == 1
+    assert bs["serving_specialist"]["tested"] == 3
+    assert bs["serving_specialist"]["keeps"] == 2
+    # kernel_switch_specialist: tested but no keep → tried.
+    assert bs["kernel_switch_specialist"]["status"] == "tried"
+    assert bs["kernel_switch_specialist"]["tested"] == 3
+    # Untouched domains remain not_attempted.
+    for d in (
+        "compiler_specialist", "system_specialist",
+        "pr_intel_specialist", "session_steward_specialist",
+    ):
+        assert bs[d]["status"] == "not_attempted"
+        assert bs[d]["attempts"] == 0
+    # Headline row still aggregates everything.
+    assert spec["attempts"] == 2
+    assert spec["tested"] == 8
+    assert spec["keeps"] == 2
+
+
+def test_capability_summary_specialist_by_specialist_falls_back_to_domains_list(
+    tmp_path: Path,
+) -> None:
+    """Legacy round predates ``domain_breakdown``: collector imputes
+    even share across the listed ``domains`` so the per-domain
+    counters add up to the parent row."""
+    sd = tmp_path / "session"
+    sd.mkdir()
+    _write_state(sd, _basic_state(specialist_rounds=[
+        # No domain_breakdown — the helper-built fixture sets one by
+        # default, so override it explicitly to {}.
+        _specialist_round(
+            round_id=1,
+            domains=["serving_specialist", "compiler_specialist"],
+            proposals_total=4, proposals_kept=2,
+            domain_breakdown={},
+        ),
+    ]))
+    spec = build(sd)["capability_summary"]["specialist"]
+    bs = spec["by_specialist"]
+    # 4 tested split evenly = 2 each; 2 kept split evenly = 1 each.
+    assert bs["serving_specialist"]["attempts"] == 1
+    assert bs["serving_specialist"]["tested"] == 2
+    assert bs["serving_specialist"]["keeps"] == 1
+    assert bs["serving_specialist"]["status"] == "kept"
+    assert bs["compiler_specialist"]["attempts"] == 1
+    assert bs["compiler_specialist"]["tested"] == 2
+    assert bs["compiler_specialist"]["keeps"] == 1
+
+
+# ---------------------------------------------------------------------------
 # A1.1: kernel_roofline (Dashboard-Roofline 对接清单 §1)
 # ---------------------------------------------------------------------------
 # The collector mirrors ``<sd>/reports/kernel_roofline.json`` so the
@@ -1780,12 +2001,22 @@ def test_capability_summary_specialist_row_when_no_rounds(tmp_path):
     _write_state(sd, _basic_state())
     b = build(sd)
     spec = b["capability_summary"]["specialist"]
-    assert spec == {
-        "status":   "not_attempted",
-        "attempts": 0,
-        "keeps":    0,
-        "tested":   0,
-    }
+    # Headline counters
+    assert spec["status"] == "not_attempted"
+    assert spec["attempts"] == 0
+    assert spec["keeps"] == 0
+    assert spec["tested"] == 0
+    # Stable shape: every catalogue specialist seeded at zero so the
+    # dashboard can iterate without presence checks.
+    for d in (
+        "serving_specialist", "kernel_switch_specialist",
+        "comm_specialist", "compiler_specialist", "system_specialist",
+        "pr_intel_specialist", "session_steward_specialist",
+    ):
+        assert spec["by_specialist"][d] == {
+            "status": "not_attempted",
+            "attempts": 0, "keeps": 0, "tested": 0,
+        }
 
 
 def test_capability_summary_specialist_agrees_with_specialist_runs(tmp_path):

--- a/inference_optimizer/tests/test_breakdown_smoke.py
+++ b/inference_optimizer/tests/test_breakdown_smoke.py
@@ -606,6 +606,148 @@ def test_attribution_method_missing(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# A1.1: kernel_roofline (Dashboard-Roofline 对接清单 §1)
+# ---------------------------------------------------------------------------
+# The collector mirrors ``<sd>/reports/kernel_roofline.json`` so the
+# dashboard's hot-kernel table is fed directly from sbd. The on-disk
+# file is produced by the kernel-agent's tracelens roofline pipeline;
+# every field is optional from the breakdown's POV — collectors must
+# not raise when the file is missing or malformed.
+def _kernel_roofline_fixture(tmp_path: Path, payload: dict | None) -> Path:
+    """Build a session_dir with optional reports/kernel_roofline.json."""
+    sd = tmp_path / "session"
+    _write_json(sd / "manifest.json", {"schema_version": 1, "session_id": "kr"})
+    _write_json(sd / "state.json", {"session_id": "kr"})
+    if payload is not None:
+        _write_json(sd / "reports" / "kernel_roofline.json", payload)
+    return sd
+
+
+def test_kernel_roofline_missing_file_returns_empty_dict(tmp_path: Path) -> None:
+    """No ``reports/kernel_roofline.json`` → empty dict, no warning.
+    Most sessions never run the roofline pipeline; a warning would
+    spam every breakdown."""
+    sd = _kernel_roofline_fixture(tmp_path, payload=None)
+    bd = build(sd)
+    assert bd["kernel_roofline"] == {}
+    assert not any("kernel_roofline" in w for w in bd["warnings"])
+
+
+def test_kernel_roofline_full_payload_passes_through(tmp_path: Path) -> None:
+    """Happy path: every field arrives as documented in
+    Dashboard-Roofline 对接清单 §1, types are preserved, and the
+    kernels list keeps its on-disk order (dashboard sorts client-side)."""
+    payload = {
+        "schema_version": 1,
+        "source": "tracelens_analysis",
+        "analysis_md_path": "/abs/analysis.md",
+        "kernel_candidates_path": "/abs/kernel_candidates.json",
+        "trace_input": "/abs/torch_trace",
+        "trace_input_type": "capture_dir",
+        "kernels": [
+            {
+                "kernel_id": "k001",
+                "name": "aiter::ck_moe_stage2",
+                "source_file": "/sgl-workspace/aiter/csrc/foo.cu",
+                "kernel_category": "MoE",
+                "bound_type": "memory-bound",
+                "arithmetic_intensity": 104.39,
+                "flops_per_byte": 104.39,
+                "efficiency_percent": 37.77,
+                "gpu_pct": 29.002,
+                "call_count": 48,
+                "duration_us": 6874.0,
+                "reusable_native_kernel": True,
+            },
+            {
+                "kernel_id": "k002",
+                "name": "aten::mm",
+                "source_file": "",
+                "kernel_category": "unknown",
+                "bound_type": "compute-bound",
+                "arithmetic_intensity": 215.58,
+                "flops_per_byte": 215.58,
+                "efficiency_percent": 14.82,
+                "gpu_pct": 3.485,
+                "call_count": 48,
+                "duration_us": 826.0,
+                "reusable_native_kernel": False,
+            },
+        ],
+    }
+    sd = _kernel_roofline_fixture(tmp_path, payload=payload)
+    kr = build(sd)["kernel_roofline"]
+
+    # Envelope
+    assert kr["schema_version"] == 1
+    assert kr["source"] == "tracelens_analysis"
+    assert kr["analysis_md_path"] == "/abs/analysis.md"
+    assert kr["trace_input_type"] == "capture_dir"
+
+    # Order preserved (dashboard sorts client-side; we don't pre-sort).
+    assert [k["kernel_id"] for k in kr["kernels"]] == ["k001", "k002"]
+
+    # Field-by-field type fidelity on the first kernel.
+    k1 = kr["kernels"][0]
+    assert k1["kernel_category"] == "MoE"
+    assert k1["bound_type"] == "memory-bound"
+    assert k1["efficiency_percent"] == pytest.approx(37.77)
+    assert k1["gpu_pct"] == pytest.approx(29.002)
+    assert k1["call_count"] == 48
+    assert k1["duration_us"] == pytest.approx(6874.0)
+    assert k1["reusable_native_kernel"] is True
+    # Compute-bound entry preserves False explicitly.
+    assert kr["kernels"][1]["reusable_native_kernel"] is False
+
+
+def test_kernel_roofline_malformed_kernels_drops_to_empty_list(tmp_path: Path) -> None:
+    """``kernels`` arriving as something other than a list (e.g. a
+    pre-aggregation dict) is replaced with ``[]`` and a warning is
+    emitted; envelope fields still round-trip."""
+    payload = {
+        "schema_version": 1,
+        "source": "tracelens_analysis",
+        "kernels": {"k001": {"name": "broken"}},  # wrong shape
+    }
+    sd = _kernel_roofline_fixture(tmp_path, payload=payload)
+    bd = build(sd)
+    kr = bd["kernel_roofline"]
+    assert kr["schema_version"] == 1
+    assert kr["source"] == "tracelens_analysis"
+    assert kr["kernels"] == []
+    assert any("kernel_roofline.kernels is not a list" in w for w in bd["warnings"])
+
+
+def test_kernel_roofline_non_dict_blob_returns_empty(tmp_path: Path) -> None:
+    """Top-level JSON value is not an object (e.g. a stray array
+    written by an older tool) → empty dict + warning, never raise."""
+    sd = tmp_path / "session"
+    _write_json(sd / "manifest.json", {"schema_version": 1, "session_id": "kr"})
+    _write_json(sd / "state.json", {"session_id": "kr"})
+    (sd / "reports").mkdir(parents=True, exist_ok=True)
+    (sd / "reports" / "kernel_roofline.json").write_text(
+        json.dumps([{"kernel_id": "k001"}]), encoding="utf-8",
+    )
+    bd = build(sd)
+    assert bd["kernel_roofline"] == {}
+    assert any("not a JSON object" in w for w in bd["warnings"])
+
+
+def test_kernel_roofline_empty_kernels_list_is_valid(tmp_path: Path) -> None:
+    """``kernels: []`` is a legitimate state (pipeline ran but found no
+    hot kernels above threshold). Envelope passes through; no warning."""
+    payload = {
+        "schema_version": 1,
+        "source": "tracelens_analysis",
+        "kernels": [],
+    }
+    sd = _kernel_roofline_fixture(tmp_path, payload=payload)
+    bd = build(sd)
+    assert bd["kernel_roofline"]["kernels"] == []
+    assert not any("kernel_roofline" in w for w in bd["warnings"])
+
+
+# ---------------------------------------------------------------------------
 # A2: final.ttft_mean_ms reconstruction
 # ---------------------------------------------------------------------------
 def test_final_ttft_reconstructed_from_validate_stack(tmp_path: Path) -> None:

--- a/inference_optimizer/tests/test_breakdown_smoke.py
+++ b/inference_optimizer/tests/test_breakdown_smoke.py
@@ -748,6 +748,238 @@ def test_kernel_roofline_empty_kernels_list_is_valid(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# A1.2: roofline (Dashboard-Roofline 对接清单 §2)
+# ---------------------------------------------------------------------------
+# The optimization-progress chart consumer. Inputs are entirely
+# in-memory state + manifest; collector never re-runs benchmarks.
+def _roofline_fixture(
+    tmp_path: Path,
+    *,
+    state: dict,
+    manifest: dict | None = None,
+) -> Path:
+    """Session fixture for ``collect_roofline``; ``manifest`` defaults
+    to a minimal stub with ``created_at_utc``."""
+    sd = tmp_path / "session"
+    _write_json(
+        sd / "manifest.json",
+        manifest or {
+            "schema_version": 1,
+            "session_id": "rl",
+            "created_at_utc": "2026-05-29T10:40:50+00:00",
+        },
+    )
+    base_state: dict = {"session_id": "rl"}
+    base_state.update(state)
+    _write_json(sd / "state.json", base_state)
+    return sd
+
+
+def test_roofline_full_payload_baseline_plus_one_keep(tmp_path: Path) -> None:
+    """Real-shape payload from the live ``Qwen3-30B-A3B-Base`` session
+    used as the dashboard reference fixture — baseline + 1 KEEP +
+    1 snapshot. Verifies trajectory ordering, gain math, ceiling /
+    target derivation, and the percent-of-* convenience numbers."""
+    sd = _roofline_fixture(tmp_path, state={
+        "baseline_tput": 1300.34,
+        "cumulative_gain": 1.0146,
+        "current_best": {
+            "action": "explore",
+            "tput": 1313.5356953711394,
+        },
+        "optimization_stack": [
+            {
+                "action": "explore",
+                "candidate_extra_sglang_args": "--num-continuous-decode-steps 4 --scheduler-recv-interval 4",
+                "extra_envs": {},
+                "tput": 1313.5356953711394,
+                "ts": "2026-05-29T11:18:24.339975+00:00",
+                "variant_name": "continuous_decode_steps_4",
+            },
+        ],
+        "roofline_snapshots": [
+            {
+                "snapshot_id": 1,
+                "ts": "2026-05-29T11:06:03.891380+00:00",
+                "achieved_tok_per_sec": 1300.34,
+                "theoretical_peak_tok_per_sec": 1976.8214052878614,
+                "within_roofline_pct": 65.78,
+                "gap_to_roofline_pct": 34.22,
+                "compute_pct": 29.95,
+                "idle_pct": 70.02,
+                "comm_pct": 0.0,
+                "top_bottleneck": "MoE_unfused",
+                "top_kernel": {
+                    "name": "aiter::ck_moe_stage1",
+                    "bound_type": "memory",
+                    "efficiency_pct": 48.35,
+                    "gpu_pct": 9.17,
+                },
+            },
+        ],
+    })
+    rl = build(sd)["roofline"]
+
+    # Trajectory: baseline + 1 KEEP, both have ts.
+    assert len(rl["trajectory"]) == 2
+    assert rl["trajectory"][0]["label"] == "baseline"
+    assert rl["trajectory"][0]["action"] == "baseline"
+    assert rl["trajectory"][0]["ts"] == "2026-05-29T10:40:50+00:00"
+    assert rl["trajectory"][0]["tput"] == pytest.approx(1300.34)
+    assert rl["trajectory"][0]["gain_pct"] == 0.0
+    assert rl["trajectory"][1]["label"] == "continuous_decode_steps_4"
+    assert rl["trajectory"][1]["tput"] == pytest.approx(1313.5356953711394)
+    assert rl["trajectory"][1]["flags"] == "--num-continuous-decode-steps 4 --scheduler-recv-interval 4"
+    # gain at point 1 = (1313.54 - 1300.34) / 1300.34 * 100 ≈ 1.015%
+    assert rl["trajectory"][1]["gain_pct"] == pytest.approx(1.015, abs=0.01)
+
+    # Reference lines (target = ceiling × 0.70).
+    assert rl["ceiling_available"] is True
+    assert rl["ceiling_tok_per_sec"] == pytest.approx(1976.82, abs=0.01)
+    assert rl["target_tok_per_sec"] == pytest.approx(1976.82 * 0.70, abs=0.01)
+    assert rl["ceiling_ratio_target"] == pytest.approx(0.70)
+
+    # Headline numbers.
+    assert rl["baseline_tput"] == pytest.approx(1300.34)
+    assert rl["current_best_tput"] == pytest.approx(1313.5356953711394)
+    # 1313.54 / 1976.82 ≈ 66.45%
+    assert rl["current_best_pct_of_ceiling"] == pytest.approx(66.45, abs=0.05)
+    # 1313.54 / (1976.82 * 0.70) ≈ 94.93%
+    assert rl["current_best_pct_of_target"] == pytest.approx(94.93, abs=0.05)
+
+    # Tooltip carryover.
+    assert rl["snapshot_top_bottleneck"] == "MoE_unfused"
+    assert rl["snapshot_within_roofline_pct"] == pytest.approx(65.78)
+
+    # Snapshots list passthrough.
+    assert len(rl["snapshots"]) == 1
+    assert rl["snapshots"][0]["theoretical_peak_tok_per_sec"] == pytest.approx(
+        1976.8214052878614,
+    )
+
+
+def test_roofline_no_snapshot_means_no_ceiling(tmp_path: Path) -> None:
+    """Sessions that never ran the watermark roofline pipeline have
+    no ``roofline_snapshots``. The trajectory is still drawn (baseline
+    + KEEPs), but ceiling/target/percent-of-* are explicitly None and
+    ``ceiling_available`` is False so the dashboard hides the
+    reference lines."""
+    sd = _roofline_fixture(tmp_path, state={
+        "baseline_tput": 100.0,
+        "cumulative_gain": 5.0,
+        "current_best": {"tput": 105.0},
+        "optimization_stack": [
+            {"action": "explore", "tput": 105.0, "variant_name": "v1",
+             "ts": "2026-05-29T11:00:00+00:00"},
+        ],
+    })
+    rl = build(sd)["roofline"]
+
+    assert rl["ceiling_available"] is False
+    assert rl["ceiling_tok_per_sec"] is None
+    assert rl["target_tok_per_sec"] is None
+    assert rl["current_best_pct_of_ceiling"] is None
+    assert rl["current_best_pct_of_target"] is None
+    # Trajectory still present.
+    assert len(rl["trajectory"]) == 2
+    assert rl["snapshots"] == []
+
+
+def test_roofline_no_keep_yet_baseline_only(tmp_path: Path) -> None:
+    """Mid-session before any KEEP: trajectory holds only the baseline
+    point; current_best == baseline; cumulative_gain == 0."""
+    sd = _roofline_fixture(tmp_path, state={
+        "baseline_tput": 200.0,
+        "cumulative_gain": 0.0,
+        "current_best": {"tput": 200.0},
+        "optimization_stack": [],
+    })
+    rl = build(sd)["roofline"]
+
+    assert len(rl["trajectory"]) == 1
+    assert rl["trajectory"][0]["label"] == "baseline"
+    assert rl["current_best_tput"] == pytest.approx(200.0)
+    assert rl["cumulative_gain_pct"] == 0.0
+
+
+def test_roofline_baseline_failed_empty_trajectory(tmp_path: Path) -> None:
+    """When ``baseline_tput`` is 0 (baseline never finished), the
+    trajectory is empty — the dashboard surfaces "no data" instead
+    of plotting against zero."""
+    sd = _roofline_fixture(tmp_path, state={
+        "baseline_tput": 0.0,
+        "cumulative_gain": 0.0,
+        "optimization_stack": [],
+    })
+    rl = build(sd)["roofline"]
+
+    assert rl["trajectory"] == []
+    assert rl["baseline_tput"] == 0.0
+    assert rl["current_best_tput"] == 0.0
+
+
+def test_roofline_uses_latest_snapshot_for_ceiling(tmp_path: Path) -> None:
+    """Multiple ``roofline_snapshots`` exist (the watermark pipeline
+    refines the peak across reruns). The ceiling is read from the
+    LATEST snapshot, not snapshots[0]."""
+    sd = _roofline_fixture(tmp_path, state={
+        "baseline_tput": 1000.0,
+        "cumulative_gain": 0.0,
+        "current_best": {"tput": 1000.0},
+        "optimization_stack": [],
+        "roofline_snapshots": [
+            {"snapshot_id": 1, "theoretical_peak_tok_per_sec": 1500.0,
+             "ts": "2026-05-29T10:00:00+00:00"},
+            {"snapshot_id": 2, "theoretical_peak_tok_per_sec": 1700.0,
+             "ts": "2026-05-29T11:00:00+00:00",
+             "top_bottleneck": "kv_cache"},
+        ],
+    })
+    rl = build(sd)["roofline"]
+    # Ceiling pulled from snapshot[-1] not [0].
+    assert rl["ceiling_tok_per_sec"] == pytest.approx(1700.0)
+    assert rl["snapshot_top_bottleneck"] == "kv_cache"
+    assert len(rl["snapshots"]) == 2
+
+
+def test_roofline_trajectory_diverges_from_current_best_emits_warning(
+    tmp_path: Path,
+) -> None:
+    """If the trajectory tail's tput doesn't agree with
+    ``state.current_best.tput`` (resume mid-promotion bug), the
+    collector surfaces the divergence as a warning instead of hiding
+    it."""
+    sd = _roofline_fixture(tmp_path, state={
+        "baseline_tput": 100.0,
+        "cumulative_gain": 5.0,
+        "current_best": {"tput": 110.0},      # mismatched
+        "optimization_stack": [
+            {"action": "explore", "tput": 105.0, "variant_name": "v1",
+             "ts": "2026-05-29T11:00:00+00:00"},
+        ],
+    })
+    bd = build(sd)
+    assert any(
+        "roofline.current_best_tput" in w and "current_best.tput" in w
+        for w in bd["warnings"]
+    )
+
+
+def test_roofline_failure_streak_passes_through(tmp_path: Path) -> None:
+    """``roofline_failure_streak`` is consumed by the dashboard to
+    show a "stale" badge on the ceiling reference line when the
+    watermark pipeline has failed repeatedly."""
+    sd = _roofline_fixture(tmp_path, state={
+        "baseline_tput": 100.0,
+        "current_best": {"tput": 100.0},
+        "roofline_failure_streak": 3,
+        "optimization_stack": [],
+    })
+    rl = build(sd)["roofline"]
+    assert rl["roofline_failure_streak"] == 3
+
+
+# ---------------------------------------------------------------------------
 # A2: final.ttft_mean_ms reconstruction
 # ---------------------------------------------------------------------------
 def test_final_ttft_reconstructed_from_validate_stack(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Adds two new top-level sections to `session_breakdown.json` and fixes
an attribution leak around the `FRAMEWORK_PR` phase, so the dashboard
can render the **hot-kernel table** + **optimization-progress chart**
(Dashboard-Roofline list flie §1 / §2) directly out of sbd without
walking `state.json` or the kernel-agent output tree.

Branched off `main`; 4 commits, +1404 / -16. `SCHEMA_VERSION` stays at
`hyperloom.session_breakdown.v2` — every change is purely additive
(new optional fields; no rename / removal).

## What lands

### 1. New top-level `kernel_roofline` section

Mirrors `<sd>/reports/kernel_roofline.json` (produced by the
kernel-agent's tracelens roofline pipeline). One entry per hot kernel
with `kernel_id` / `name` / `source_file` / `kernel_category` /
`bound_type` / `arithmetic_intensity` / `flops_per_byte` /
`efficiency_percent` / `gpu_pct` / `call_count` / `duration_us` /
`reusable_native_kernel`. Empty `{}` when the file is absent (most
sessions don't run the pipeline) — quiet on purpose so the warning
list doesn't fill up.

### 2. New top-level `roofline` section

Drives the optimization-progress chart:

* `trajectory[]` — 1 baseline point + N KEEP points sorted by ts,
  built from `manifest.created_at_utc` + `state.baseline_tput` +
  `state.optimization_stack[]` (each entry's `tput`, `variant_name`,
  `action`, `candidate_extra_sglang_args`, `extra_envs`).
* `ceiling_tok_per_sec` / `target_tok_per_sec` — vendor peak from
  `state.roofline_snapshots[-1]` (latest, not [0]; the watermark
  pipeline refines the peak across reruns) and `ceiling × 0.70`.
  `ceiling_available` is the explicit boolean so the dashboard can
  hide the reference lines on sessions that never ran the pipeline.
* Headline numbers `current_best_tput` / `cumulative_gain_pct` /
  `current_best_pct_of_ceiling` / `current_best_pct_of_target` are
  precomputed so the dashboard callout doesn't have to.
* `snapshots[]` passes the raw `state.roofline_snapshots` through for
  tooltips / drill-downs; `roofline_failure_streak` for the "stale"
  badge when the watermark pipeline has been failing.
* A trajectory tail / `state.current_best.tput` divergence (resume
  mid-promotion) surfaces as a structured warning instead of silently
  masking the bug.

### 3. `framework_pr` surfaces in attribution

The `PRELUDE → FRAMEWORK_PR → EXPLORE` phase split introduced a
standalone `action == "framework_pr"`, but the attribution collector
never learned about it: `_action_family` returned `"other"`, no slot
in `family_totals`, no row in `source_breakdown`, no bucket in
`phase_breakdown`. Result: `framework_pr` KEEPs silently disappeared
from the dashboard's per-source totals — a 22.85% session showed up
as `geak 0% + oob 0% + backends 1.74% + params 0% + sweep 0% =
1.74%`, with the missing 21.11% (a `PR:26311` adoption) nowhere to
be found.

Three additive fixes:

* `_action_family` recognises `framework_pr` as its own family.
* `family_totals` and `phase_breakdown.phase_buckets` get a
  `framework_pr` slot; `phase_breakdown.framework_pr` carries a
  `by_pr` dict keyed on the PR ref so the dashboard can show
  per-PR contribution.
* `source_breakdown.framework_pr_pct_of_total` is always emitted
  (0.0 when the phase didn't contribute); per-source rows now
  reconcile against `validated_total_pct` within rounding.

### 4. Specialist key normalisation + per-domain capability rollup

* `phase_breakdown.explore.by_domain` keys are normalised — the
  collector strips `specialist:` prefixes and folds `legacy:<action>`
  into `legacy_<action>`, so consumers see bare `SpecialistDomain.key`
  values (`serving_specialist`, `kernel_switch_specialist`, …) plus
  `default_grid` / `llm_direct` for non-specialist provenance.
  Previously every dashboard had to splice the prefix every time it
  iterated the dict.
* `capability_summary.specialist.by_specialist` adds a per-domain
  CapabilityEntry breakdown alongside the existing headline
  counters. Every catalogue specialist (`serving_specialist`, the
  four M6-tier specialists, `pr_intel_specialist`,
  `session_steward_specialist`) is seeded with `not_attempted` so the
  dashboard can iterate without presence checks. When
  `specialist_rounds[i].domain_breakdown` is present (the
  authoritative source on v0.8+ rounds) it is folded directly; legacy
  rounds without it are imputed by even share across the round's
  `domains[]`.

## Files changed

```
 inference_optimizer/breakdown/collectors.py       | 461 ++++++++++++-
 inference_optimizer/breakdown/exporter.py         |  27 +
 inference_optimizer/breakdown/schema.py           | 194 +++++-
 inference_optimizer/tests/test_breakdown_smoke.py | 754 +++++++++++++++++++++-
 4 files changed, 1420 insertions(+), 16 deletions(-)
```

## Commits

```
a1b2a7a3 breakdown: kernel_roofline section for Dashboard hot-kernel table
3981e33a breakdown: roofline section for Dashboard optimization-progress chart
cd5fd1fe breakdown: surface framework_pr in attribution / phase_breakdown
0c822ea1 breakdown: normalize specialist keys + per-domain capability rollup
```

## Compatibility

`SCHEMA_VERSION` stays at v2; every change is additive.

* **v1-era state.json** (pre-FRAMEWORK_PR / pre-specialist /
  pre-roofline_snapshots): `kernel_roofline = {}`, `roofline.ceiling_available = False`,
  `framework_pr_pct_of_total = 0.0`. Trajectory + legacy
  `params_pct_of_total` / `backends_pct_of_total` still populate.
* **v1.1-era state.json** (specialist provenance, no
  `roofline_snapshots`): same as above; `phase_breakdown.explore.by_domain`
  picks up specialist names with the new normalised keys.
* **v2-era state.json** with no `reports/kernel_roofline.json` (e.g.
  session ended before tracelens completed): `kernel_roofline = {}`
  with no warning, `roofline` populates fully from the in-memory state.

Verified end-to-end against the dashboard reference fixture
(`Qwen-Qwen3-30B-A3B-Base/20260529T104050Z`); every number in
`Dashboard-Roofline list file §5` reconciles bit-for-bit.

## Test plan

- [x] `pytest inference_optimizer/tests/test_breakdown_smoke.py -k "kernel_roofline or roofline or framework_pr or by_specialist or by_domain or capability_summary_specialist"` — **30/30 pass**.
- [x] Full breakdown smoke suite: **71/74 pass**. The 3 failures
      (`test_cli_*_breakdown_include_transcripts*`) are pre-existing
      `main` bugs around an unrelated CLI flag — they fail before this
      branch too (verified by `git stash` + retest on plain `main`).
- [x] No new linter errors.
- [x] Compatibility smoke test: synthesised v1 / v1.1 / v2 state.json
      shapes all dump cleanly (no exceptions, new sections degrade
      to empty / 0).

## Notes

- Linked design doc: `Dashboard-Roofline duijieqingdan.md` (sections §1 §2).
- The pre-existing CLI test failures are out of scope here; can be
  addressed in a separate PR.
- Made with [Cursor](https://cursor.com).
