### PR TITLE
fix(recipe_kb): correct KB CLOSE writeback + dynamic framework source-root discovery

### DIFF
--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -9093,6 +9093,16 @@ class Coordinator:
             return is_valid_measurement(result)
         if task_kind == "sweep":
             return result.get("status") == "succeeded"
+        # ``replay_warm_recipe`` ALWAYS routes through _promote_to_shared_state
+        # -> _promote_warm_replay, which owns the full succeeded / drift /
+        # FAILED bookkeeping (it clears warm_replay_outcome.status='in_flight'
+        # on every terminal outcome). If a failed replay were sent to
+        # _handle_unpromotable_result instead, the in_flight flag would never
+        # clear and warm_replay_in_flight() would block PRELUDE forever
+        # (env-drift OOM/timeout -- exactly what warm-replay exists to detect
+        # -- would otherwise burn the whole wall-clock budget in PRELUDE).
+        if task_kind == "replay_warm_recipe":
+            return True
         return result.get("status") != "failed"
 
     def _record_intervention_for_task(
@@ -10426,8 +10436,17 @@ class Coordinator:
         if opt_stack:
             last_entry = opt_stack[-1]
             if isinstance(last_entry, dict):
+                # Read the post-rename canonical keys first
+                # (``_lift_to_current_best`` + explore winners write
+                # ``candidate_extra_server_args`` / ``extra_server_args``);
+                # keep the legacy ``*_sglang_args`` keys as a fallback for
+                # pre-migration stack entries. Reading only the legacy keys
+                # here yielded an empty string for every real (renamed)
+                # entry, silently re-breaking the #332 best_config fix.
                 stack_args = str(
-                    last_entry.get("candidate_extra_sglang_args")
+                    last_entry.get("candidate_extra_server_args")
+                    or last_entry.get("extra_server_args")
+                    or last_entry.get("candidate_extra_sglang_args")
                     or last_entry.get("extra_sglang_args")
                     or "",
                 ).strip()

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -387,6 +387,40 @@ def _baseline_params_fingerprint(params: dict[str, Any] | None) -> dict[str, Any
     return out
 
 
+# Flags whose argparse consumes multiple bare tokens before the next ``--``.
+_MULTI_VALUE_SGLANG_FLAGS: frozenset[str] = frozenset({
+    "--cuda-graph-bs",
+    "--cuda-graph-max-bs",
+})
+
+
+def _merge_cumulative_extra_sglang_args(
+    base_args: str,
+    candidate_args: str,
+    full_args: str,
+) -> str:
+    """Build cumulative launch args for a KEEP without double-stacking.
+
+    Explore variants usually record the *full* cumulative ``extra_sglang_args``
+    for the stack layer being kept. Joining ``base_args + candidate_args`` when
+    both are full stacks duplicates flags; dedupe then corrupts multi-value
+    knobs such as ``--cuda-graph-bs``.
+    """
+    base = str(base_args or "").strip()
+    candidate = str(candidate_args or "").strip()
+    full = str(full_args or "").strip()
+    if full and full != candidate:
+        merged = full
+    elif candidate and base:
+        if candidate.startswith(base) or base in candidate.split():
+            merged = candidate
+        else:
+            merged = f"{base} {candidate}".strip()
+    else:
+        merged = candidate or full or base
+    return _dedupe_extra_sglang_args(merged)
+
+
 def _dedupe_extra_sglang_args(args_str: str) -> str:
     """Collapse repeated ``--flag value`` pairs into a unique launch string.
 
@@ -405,6 +439,10 @@ def _dedupe_extra_sglang_args(args_str: str) -> str:
     was re-appended verbatim. Dedupe is a sane normalization: keep each
     flag once, with the value of its last occurrence — same semantics
     argparse would have applied at launch.
+
+    Flags in ``_MULTI_VALUE_SGLANG_FLAGS`` (e.g. ``--cuda-graph-bs``) accept
+    multiple values per occurrence; those runs are preserved so dedupe does
+    not leave stray integers between flags.
 
     Bare flags (no value, e.g. ``--enable-prefix-caching``) are also
     deduped (kept once, position preserved by first appearance).
@@ -427,12 +465,16 @@ def _dedupe_extra_sglang_args(args_str: str) -> str:
         t = tokens[i]
         if t.startswith("--"):
             flag = t
-            if i + 1 < len(tokens) and not tokens[i + 1].startswith("--"):
-                pair = [flag, tokens[i + 1]]
-                i += 2
-            else:
-                pair = [flag]
+            i += 1
+            values: list[str] = []
+            if flag in _MULTI_VALUE_SGLANG_FLAGS:
+                while i < len(tokens) and not tokens[i].startswith("--"):
+                    values.append(tokens[i])
+                    i += 1
+            elif i < len(tokens) and not tokens[i].startswith("--"):
+                values = [tokens[i]]
                 i += 1
+            pair = [flag, *values] if values else [flag]
             if flag not in pair_by_flag:
                 order.append(flag)
             pair_by_flag[flag] = pair
@@ -8744,6 +8786,18 @@ class Coordinator:
             ):
                 if key in current_best:
                     best_config[key] = current_best[key]
+        # Prefer the last validated stack layer for launch args — current_best
+        # can carry a corrupted cumulative string when promote dedupe regressed.
+        if opt_stack:
+            last_entry = opt_stack[-1]
+            if isinstance(last_entry, dict):
+                stack_args = str(
+                    last_entry.get("candidate_extra_sglang_args")
+                    or last_entry.get("extra_sglang_args")
+                    or "",
+                ).strip()
+                if stack_args:
+                    best_config["extra_sglang_args"] = stack_args
         what_worked: list[dict[str, Any]] = []
         for idx, entry in enumerate(opt_stack):
             if not isinstance(entry, dict):
@@ -9004,21 +9058,9 @@ class Coordinator:
         full_args = ""
         if isinstance(bv, dict):
             full_args = str(bv.get("extra_sglang_args") or "").strip()
-        if base_args and candidate_args and full_args == candidate_args:
-            full_args = " ".join((base_args, candidate_args))
-        elif not full_args:
-            full_args = " ".join(
-                part for part in (base_args, candidate_args) if part
-            )
-        # Dedupe repeated ``--flag value`` pairs so the cumulative
-        # extra_sglang_args reflects what argparse will actually honor
-        # (last value wins). Without this, every promote that re-applies
-        # a multi-value combo candidate (e.g.
-        # ``--cuda-graph-max-bs 32 --cuda-graph-max-bs 128 --cuda-graph-max-bs 256``)
-        # leaves multiple copies of the same flag in the final args
-        # string, which breaks reproduce-launch dashboards and the
-        # final.extra_sglang_args field surfaced by session_breakdown.
-        full_args = _dedupe_extra_sglang_args(full_args)
+        full_args = _merge_cumulative_extra_sglang_args(
+            base_args, candidate_args, full_args,
+        )
 
         variant_name = bv.get("name") if isinstance(bv, dict) else None
         if candidate_args or variant_name:

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -401,6 +401,30 @@ _MULTI_VALUE_SGLANG_FLAGS: frozenset[str] = frozenset({
 })
 
 
+_DEFAULT_ROOFLINE_WATERMARK_RATIO: float = 1.10  # 10% step over last roofline
+_ROOFLINE_WATERMARK_RATIO_ENV: str = "HYPERLOOM_ROOFLINE_WATERMARK_RATIO"
+
+
+def _resolve_roofline_watermark_ratio() -> float:
+    """Resolve the roofline watermark ratio (env-tunable, safe default).
+
+    Reads ``$HYPERLOOM_ROOFLINE_WATERMARK_RATIO`` so operators can tune the
+    re-roofline threshold without code edits. Any unparseable or unsafe
+    value (``<= 1.0`` would re-fire on every tick) falls back to the 1.10
+    default so a typo can't melt the analysis pipeline.
+    """
+    raw = (os.environ.get(_ROOFLINE_WATERMARK_RATIO_ENV) or "").strip()
+    if not raw:
+        return _DEFAULT_ROOFLINE_WATERMARK_RATIO
+    try:
+        val = float(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_ROOFLINE_WATERMARK_RATIO
+    if val <= 1.0:
+        return _DEFAULT_ROOFLINE_WATERMARK_RATIO
+    return val
+
+
 def _merge_cumulative_extra_sglang_args(
     base_args: str,
     candidate_args: str,
@@ -2199,7 +2223,7 @@ class Coordinator:
         cur = self._current_tput_from_validated_gain()
         if cur <= 0:
             return False
-        return cur / last_rl >= self._ROOFLINE_WATERMARK_RATIO
+        return cur / last_rl >= _resolve_roofline_watermark_ratio()
 
     async def _maybe_enqueue_watermark_roofline(
         self, *, reason: str,

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -8875,7 +8875,12 @@ class Coordinator:
                         break
             out.append({
                 "kernel_id":     str(kid),
-                "source_file":   str(e.get("source_file") or ""),
+                # record_kernel_opt persists the source under
+                # ``last_source_file``; ``source_file`` is a legacy
+                # fallback for older ledger snapshots.
+                "source_file":   str(
+                    e.get("last_source_file") or e.get("source_file") or ""
+                ),
                 "artifact_path": str(e.get("last_artifact_path") or ""),
                 "micro_speedup": micro,
                 "decision":      "KEEP",

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -8458,11 +8458,20 @@ class Coordinator:
         kind = classify_change_kind(
             task.kind, variant_attrs if isinstance(variant_attrs, dict) else None,
         )
-        change = summarize_change(
-            task.kind,
-            variant_attrs if isinstance(variant_attrs, dict) else {"name": variant_name},
-            None,
-        )
+        # Ensure the change summary is variant-specific. When the variant
+        # dict carries no args/envs/name, summarize_change drops to the bare
+        # task kind ("explore"), so every regressed explore variant would
+        # write an indistinguishable KB pitfall/lesson description. Fall back
+        # to the variant_name (always present) so the row identifies which
+        # variant it was about.
+        change_attrs = dict(variant_attrs) if isinstance(variant_attrs, dict) else {}
+        if not (
+            change_attrs.get("extra_sglang_args")
+            or change_attrs.get("extra_envs")
+            or change_attrs.get("name")
+        ) and variant_name:
+            change_attrs["name"] = variant_name
+        change = summarize_change(task.kind, change_attrs, None)
         error_class = None
         reason = None
         if outcome == OUTCOME_REVERT:
@@ -8858,9 +8867,15 @@ class Coordinator:
             integ = integ_by_kid.get(str(kid))
             e2e_gain = 0.0
             e2e_tput = 0.0
+            e2e_decision = ""
             integrated = False
             if isinstance(integ, dict):
                 integrated = True
+                # Integrate-layer verdict (KEEP / REVERT / NEEDS_REVIEW).
+                # ``decision`` below stays the micro-layer KEEP; this carries
+                # the E2E outcome so warm-start can skip a kernel whose patch
+                # was reverted at integrate (micro win, E2E loss).
+                e2e_decision = str(integ.get("last_decision") or "").upper()
                 try:
                     e2e_gain = float(integ.get("best_gain_pct") or 0.0)
                 except (TypeError, ValueError):
@@ -8886,6 +8901,7 @@ class Coordinator:
                 "decision":      "KEEP",
                 "e2e_gain_pct":  e2e_gain,
                 "e2e_tput":      e2e_tput,
+                "e2e_decision":  e2e_decision,
                 "integrated":    integrated,
                 "ts":            str(e.get("last_ts") or e.get("ts") or ""),
             })
@@ -8985,6 +9001,24 @@ class Coordinator:
                                     or self.session_dir.name),
                 "gain_pct":     cumulative_validated or cumulative_total,
                 "stack_len":    validated_stack_len or len(opt_stack),
+                # arbor-shape provenance so the session row is self-describing
+                # (before/after tput + when + which knobs). Previously omitted,
+                # leaving every recipe.json session at 0.0 / "" / [].
+                "throughput_before": float(getattr(ss, "baseline_tput", 0.0) or 0.0),
+                "throughput_after":  (
+                    float(current_best.get("tput", 0.0))
+                    if isinstance(current_best, dict) else 0.0
+                ),
+                "date":          datetime.now(timezone.utc).isoformat(),
+                "actions_taken": [
+                    nm for nm in (
+                        str(
+                            e.get("variant_name") or e.get("name")
+                            or e.get("action") or ""
+                        ).strip()
+                        for e in opt_stack if isinstance(e, dict)
+                    ) if nm
+                ],
             }],
         }
 
@@ -9122,16 +9156,40 @@ class Coordinator:
             }
             # Only overwrite best_config / best_throughput when THIS
             # session is an actual improvement (or the row has none).
-            # A CLOSE that ended without a validated win
-            # (best_throughput == 0.0) must NOT clobber a better
-            # historical config. Omitting the keys makes
+            # A CLOSE that ended without a validated win must NOT clobber a
+            # better historical config. Omitting the keys makes
             # ``_kb_amend_recipe`` preserve the live values.
+            #
+            # Two-part guard:
+            #   1. ``has_validated_win`` — this session produced a real
+            #      optimization (non-empty validated stack, positive validated
+            #      gain, OR a current_best that carries launch flags). A bare
+            #      baseline (no stack, gain<=0, no extra args) is NOT a win:
+            #      its tput is cross-workload-incomparable and it carries no
+            #      flags, so overwriting both drops the recipe's launch args
+            #      and clobbers a validated config (repro session
+            #      20260531T144553Z: 2813@isl256 clobbered 2532@isl1024).
+            #   2. ``my_tput > live_tput`` — even a real win must beat the
+            #      stored best before it replaces it.
             my_tput = float(attrs.get("best_throughput") or 0.0)
+            cb_now = getattr(ss, "current_best", {}) or {}
+            cb_args_now = (
+                str(cb_now.get("extra_sglang_args") or "").strip()
+                if isinstance(cb_now, dict) else ""
+            )
+            validated_gain = float(
+                getattr(ss, "cumulative_gain_validated", 0.0) or 0.0
+            )
+            has_validated_win = bool(
+                (getattr(ss, "optimization_stack", []) or [])
+                or validated_gain > 0.0
+                or cb_args_now
+            )
             try:
                 live_tput = float(existing_row.get("best_throughput") or 0.0)
             except (TypeError, ValueError):
                 live_tput = 0.0
-            if my_tput > live_tput:
+            if has_validated_win and my_tput > live_tput:
                 overrides["best_config"] = attrs["best_config"]
                 overrides["best_throughput"] = my_tput
             # Merge stack_fingerprint rather than replace: T0 stamps

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -137,6 +137,9 @@ _BASELINE_SELF_LOOP_THRESHOLD: int = 2
 _STEWARD_RECS: frozenset[str] = frozenset({
     "continue_explore", "advance_to_kernel", "stop_session",
 })
+# Retries for session_steward subprocess / LLM transport failures only.
+# Empty or malformed *LLM* verdicts still coerce to stop_session.
+_STEWARD_MAX_INFRA_RETRIES: int = 3
 
 # Actions whose output should observe the freshest ``analysis.md`` /
 # ``last_profile_trace`` snapshot. Every dispatch path
@@ -2398,19 +2401,20 @@ class Coordinator:
         min_reproduce = float(
             getattr(self, "_warm_replay_min_reproduce_pct", 0.8) or 0.8,
         )
-        # Two acceptance rules:
-        # 1. If the recipe had a recorded historical gain, we want at
-        #    least ``min_reproduce`` of that figure.
-        # 2. If the recipe didn't carry one (expected_gain=0), any
-        #    positive measurement counts (we trust the recipe at face
-        #    value because nothing else to compare to).
-        reproduced = False
-        if expected_gain > 0:
-            reproduced = measured_gain >= (expected_gain * min_reproduce)
-        else:
-            reproduced = measured_gain > 0
+        # Adopt KB best_config whenever replay beats the session baseline
+        # (operator policy: any measured uplift is worth seeding the stack).
+        # ``expected_gain`` / ``min_reproduce`` are retained in the outcome
+        # for audit only — they no longer gate promotion.
+        reproduced = measured_gain > 0
         outcome["actual_gain_pct"] = round(measured_gain, 3)
         outcome["throughput_after"] = tput
+        if expected_gain > 0:
+            historical_bar = expected_gain * min_reproduce
+            if measured_gain > 0 and measured_gain < historical_bar:
+                outcome["below_historical_reproduce_pct"] = True
+                outcome["historical_reproduce_bar_pct"] = round(
+                    historical_bar, 3,
+                )
         if reproduced:
             # R4-4 defense: pushing an empty stack entry (with no
             # extra_sglang_args / extra_envs) corrupts session_breakdown
@@ -3249,8 +3253,22 @@ class Coordinator:
             )
         return task
 
+    @staticmethod
+    def _steward_infrastructure_failure(done_payload: dict[str, Any]) -> bool:
+        """True when the steward subprocess failed before a real verdict."""
+        if not isinstance(done_payload, dict):
+            return True
+        reason = str(done_payload.get("reason") or "").strip().lower()
+        if reason.startswith("subprocess_"):
+            return True
+        if bool(done_payload.get("empty")) and not str(
+            done_payload.get("recommendation") or "",
+        ).strip():
+            return True
+        return False
+
     async def _enqueue_internal_steward_task(
-        self, *, reason: str,
+        self, *, reason: str, retry_attempt: int = 0,
     ) -> "Task | None":
         """IR-7 — enqueue a Coordinator-owned session_steward_specialist task.
 
@@ -3278,14 +3296,20 @@ class Coordinator:
             (self.shared_state.explore_search or {}).get("cursor") or 0
         )
         idempotency_key = f"internal-steward-round{round_id}"
+        if retry_attempt > 0:
+            idempotency_key = (
+                f"{idempotency_key}-retry{int(retry_attempt)}"
+            )
         # Avoid re-enqueueing if a steward verdict already landed in
         # this round (paranoia — wants_steward_assessment should have
         # returned False, but defense-in-depth).
         last = self.shared_state.last_remaining_gaps_assessment or {}
         if isinstance(last, dict) and last.get(
             "round_at_assessment"
-        ) == round_id and last.get("recommendation"):
-            return None
+        ) == round_id:
+            last_rec = str(last.get("recommendation") or "").strip().lower()
+            if last_rec in _STEWARD_RECS:
+                return None
         params: dict[str, Any] = {
             "domain": "session_steward_specialist",
             "gap_canonical_id": f"gap.steward.round{round_id}",
@@ -6815,18 +6839,73 @@ class Coordinator:
         ``continue_explore`` is coerced to ``advance_to_kernel`` so
         the EXPLORE→KERNEL transition becomes mandatory.
 
-        Out-of-vocab ``recommendation`` values are coerced to
-        ``stop_session`` (defense in depth — the LLM can write any
-        string, but we only honour the closed enum).
+        Infrastructure failures (stale heartbeat, subprocess timeout, empty
+        synthesis) schedule up to :data:`_STEWARD_MAX_INFRA_RETRIES` fresh
+        steward tasks with a new idempotency key. Only genuine LLM
+        out-of-vocab strings coerce to ``stop_session``.
         """
         raw_rec = str(done_payload.get("recommendation") or "").strip().lower()
         if raw_rec not in _STEWARD_RECS:
-            log.warning(
-                "steward: out-of-vocab recommendation=%r for task=%s; "
-                "coercing to 'stop_session'",
-                raw_rec, task.task_id,
-            )
-            raw_rec = "stop_session"
+            if Coordinator._steward_infrastructure_failure(done_payload):
+                round_at = int(
+                    (self.shared_state.explore_search or {}).get("cursor") or 0
+                )
+                failures = dict(
+                    getattr(
+                        self.shared_state,
+                        "steward_infra_failures_by_round",
+                        None,
+                    ) or {},
+                )
+                round_key = str(round_at)
+                attempt = int(failures.get(round_key, 0) or 0) + 1
+                failures[round_key] = attempt
+                self.shared_state.steward_infra_failures_by_round = failures
+                fail_reason = str(done_payload.get("reason") or "")[:240]
+                self.shared_state.record_steward_assessment(
+                    recommendation="",
+                    next_gap_canonical_id="",
+                    remaining_potential_pct_estimate=0.0,
+                    rationale=(
+                        f"steward infrastructure failure ({fail_reason}); "
+                        f"attempt {attempt}/{_STEWARD_MAX_INFRA_RETRIES}"
+                    ),
+                    task_id=task.task_id,
+                    round_at_assessment=round_at,
+                    source_payload=done_payload,
+                )
+                try:
+                    self.shared_state.save(self.session_dir)
+                except Exception:  # noqa: BLE001
+                    log.exception("steward: save after infra failure failed")
+                if attempt < _STEWARD_MAX_INFRA_RETRIES:
+                    log.warning(
+                        "steward: infrastructure failure (%s) for task=%s; "
+                        "scheduling retry %d/%d",
+                        fail_reason or "unknown",
+                        task.task_id,
+                        attempt,
+                        _STEWARD_MAX_INFRA_RETRIES,
+                    )
+                    await self._enqueue_internal_steward_task(
+                        reason="infra_retry",
+                        retry_attempt=attempt,
+                    )
+                    return
+                log.warning(
+                    "steward: infrastructure retries exhausted for "
+                    "round=%s; defaulting to advance_to_kernel "
+                    "(not stop_session)",
+                    round_at,
+                )
+                raw_rec = "advance_to_kernel"
+            else:
+                log.warning(
+                    "steward: out-of-vocab recommendation=%r for task=%s; "
+                    "coercing to 'stop_session'",
+                    raw_rec, task.task_id,
+                )
+                raw_rec = "stop_session"
         # Antiloop: only one continuation per session.
         if (
             raw_rec == "continue_explore"

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -2547,6 +2547,50 @@ class Coordinator:
         state.warm_replay_outcome = outcome
         state.save(self.session_dir)
 
+    async def _maybe_enqueue_prelude_initial_analysis_after_baseline(
+        self,
+        *,
+        baseline_tput: float | None = None,
+    ) -> None:
+        """Enqueue the PRELUDE-bootstrap roofline/profile task after baseline.
+
+        Skipped while warm-replay is ``in_flight`` so two Magpie/sglang
+        jobs do not contend for the same GPU/port. Called from the
+        baseline completion hook and again when warm-replay promotion
+        finishes (success, drift, or failure).
+        """
+        state = self.shared_state
+        if _phase_state.warm_replay_in_flight(state):
+            log.info(
+                "PRELUDE: deferring initial %s until warm-replay completes",
+                self._internal_analysis_kind(),
+            )
+            return
+        if baseline_tput is None:
+            try:
+                baseline_tput = float(state.baseline_tput or 0.0)
+            except (TypeError, ValueError):
+                baseline_tput = 0.0
+        if not isinstance(baseline_tput, (int, float)) or baseline_tput <= 0:
+            return
+        if (state.auto_roofline_pending_task_id or "").strip():
+            return
+        try:
+            rl_task = await self._enqueue_internal_analysis_task(
+                reason="prelude_initial",
+            )
+            state.auto_roofline_pending_task_id = rl_task.task_id
+            log.info(
+                "PRELUDE: baseline landed (tput=%.2f); auto-enqueued "
+                "initial %s task=%s",
+                float(baseline_tput), rl_task.kind, rl_task.task_id,
+            )
+        except Exception as exc:  # noqa: BLE001 — defensive
+            log.exception(
+                "PRELUDE: failed to enqueue initial analysis task "
+                "after baseline: %r", exc,
+            )
+
     async def _enqueue_internal_analysis_task(self, *, reason: str) -> Task:
         """Build + enqueue a Coordinator-internal analysis task.
 
@@ -9219,17 +9263,19 @@ class Coordinator:
             #   Step 1. Inject warm-recipe history into dedup ledger
             #           (so already-tested REVERTs from past sessions
             #            can't be re-proposed). Cheap + KB-disabled-safe.
-            #   Step 2. Enqueue warm-replay (operates on server lifecycle
-            #            lane; reproduces the historical best_config).
-            #   Step 3. Enqueue auto-analysis (operates on profile_lane;
-            #            different lane → runs in parallel with replay).
+            #   Step 2. Enqueue warm-replay (Magpie + sglang on GPU).
+            #   Step 3. Enqueue auto-analysis (roofline/profile) via
+            #            :meth:`_maybe_enqueue_prelude_initial_analysis_after_baseline`.
+            #            Deferred while warm-replay is ``in_flight`` and
+            #            retried when replay promotion finishes.
             #
             # Ordering rationale: history-inject before warm-replay is
             # mandatory (the replay task must inherit the up-to-date
-            # ledger). Warm-replay before analysis is preferred so that
-            # the first cumulative_gain bump and the optimization_stack
-            # seed are recorded BEFORE specialist dispatch (specialist
-            # prompts read state.json at dispatch time).
+            # ledger). Warm-replay must finish before the initial
+            # roofline — both launch Magpie on the same GPU/port even
+            # though their lane keys differ. Stack seed + cumulative_gain
+            # from a reproduced replay must land before FRAMEWORK_PR /
+            # specialist dispatch (prompts read state.json at dispatch).
             #
             # Skip conditions:
             # * baseline tput missing or invalid;
@@ -9256,22 +9302,10 @@ class Coordinator:
                     log.exception(
                         "PRELUDE: failed to enqueue warm-replay task: %r", exc,
                     )
-                # Step 3 — auto-analysis (roofline / profile).
-                try:
-                    rl_task = await self._enqueue_internal_analysis_task(
-                        reason="prelude_initial",
-                    )
-                    self.shared_state.auto_roofline_pending_task_id = rl_task.task_id
-                    log.info(
-                        "PRELUDE: baseline landed (tput=%.2f); auto-enqueued "
-                        "initial %s task=%s",
-                        float(tput), rl_task.kind, rl_task.task_id,
-                    )
-                except Exception as exc:  # noqa: BLE001 — defensive
-                    log.exception(
-                        "PRELUDE: failed to enqueue initial analysis task "
-                        "after baseline: %r", exc,
-                    )
+                # Step 3 — auto-analysis (roofline / profile); may defer.
+                await self._maybe_enqueue_prelude_initial_analysis_after_baseline(
+                    baseline_tput=float(tput),
+                )
         elif task_kind == "replay_warm_recipe":
             # GAP 1 — separate promote path so the replay result does
             # NOT overwrite ``baseline_tput`` / ``current_best`` via
@@ -9281,6 +9315,8 @@ class Coordinator:
                 self._promote_warm_replay(result, task=task)
             except Exception:  # noqa: BLE001 — defensive
                 log.exception("warm-replay promote failed")
+            # PRELUDE initial roofline was deferred while replay ran.
+            await self._maybe_enqueue_prelude_initial_analysis_after_baseline()
         elif task_kind == "profile":
             # B2 (atom): profile_executor short-circuits to
             # status="skipped" with error_class="atom_no_profiler" when

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -8643,6 +8643,84 @@ class Coordinator:
                     out[k] = v.strip()
         return out
 
+    def _build_kernel_optimizations_from_state(self) -> list[dict[str, Any]]:
+        """Collect KEEP'd kernel optimizations + their E2E verdict.
+
+        Joins two SharedState ledgers by ``kernel_id``:
+
+        * ``kernel_opt_attempts[kid]`` — the micro layer
+          (``last_decision`` / ``last_micro_speedup`` / ``last_artifact_path``
+          / ``source_file``), written by ``record_kernel_opt``.
+        * ``kernel_integrate_attempts[key]`` — the E2E integrate
+          verification (``best_gain_pct`` + the last attempt's ``new_tput``),
+          written by ``record_kernel_integrate_result``.
+
+        Only KEEP'd kernels are emitted. A KEEP'd kernel with no integrate
+        entry surfaces with ``integrated=False`` (micro-only, E2E unknown);
+        one that was integrated carries its real ``e2e_gain_pct`` / ``e2e_tput``
+        even when that gain is ~0 — that "tried, no E2E payoff" conclusion is
+        exactly the warm-start signal we previously dropped. Returns a list of
+        ``schema.KernelOptimization``-shaped dicts (the put_recipe extras
+        channel + ``Recipe.from_dict`` persist them as first-class rows).
+        """
+        ss = self.shared_state
+        opt_attempts = getattr(ss, "kernel_opt_attempts", {}) or {}
+        integ_attempts = getattr(ss, "kernel_integrate_attempts", {}) or {}
+        if not isinstance(opt_attempts, dict):
+            return []
+
+        # Index integrate results by kernel_id (last write wins; the entry
+        # already carries the rolled-up ``best_gain_pct`` across attempts).
+        integ_by_kid: dict[str, dict[str, Any]] = {}
+        if isinstance(integ_attempts, dict):
+            for entry in integ_attempts.values():
+                if not isinstance(entry, dict):
+                    continue
+                kid = str(entry.get("kernel_id") or "")
+                if kid:
+                    integ_by_kid[kid] = entry
+
+        out: list[dict[str, Any]] = []
+        for kid, e in opt_attempts.items():
+            if not isinstance(e, dict):
+                continue
+            if str(e.get("last_decision", "")).upper() != "KEEP":
+                continue
+            try:
+                micro = float(e.get("last_micro_speedup") or 0.0)
+            except (TypeError, ValueError):
+                micro = 0.0
+            integ = integ_by_kid.get(str(kid))
+            e2e_gain = 0.0
+            e2e_tput = 0.0
+            integrated = False
+            if isinstance(integ, dict):
+                integrated = True
+                try:
+                    e2e_gain = float(integ.get("best_gain_pct") or 0.0)
+                except (TypeError, ValueError):
+                    e2e_gain = 0.0
+                # Last attempt's measured throughput (the E2E re-bench number).
+                for att in reversed(list(integ.get("attempts") or [])):
+                    if isinstance(att, dict) and att.get("new_tput") is not None:
+                        try:
+                            e2e_tput = float(att.get("new_tput") or 0.0)
+                        except (TypeError, ValueError):
+                            e2e_tput = 0.0
+                        break
+            out.append({
+                "kernel_id":     str(kid),
+                "source_file":   str(e.get("source_file") or ""),
+                "artifact_path": str(e.get("last_artifact_path") or ""),
+                "micro_speedup": micro,
+                "decision":      "KEEP",
+                "e2e_gain_pct":  e2e_gain,
+                "e2e_tput":      e2e_tput,
+                "integrated":    integrated,
+                "ts":            str(e.get("last_ts") or e.get("ts") or ""),
+            })
+        return out
+
     def _build_recipe_attrs_from_state(self) -> dict[str, Any]:
         """Materialise the recipe-shaped view of :class:`SharedState`.
 
@@ -8686,6 +8764,7 @@ class Coordinator:
                     "name":  str(failure.get("name") or failure.get("action") or ""),
                     "reason": str(failure.get("reason") or failure.get("error_class") or ""),
                 })
+        kernel_optimizations = self._build_kernel_optimizations_from_state()
         cumulative_validated = float(getattr(ss, "cumulative_gain_validated", 0.0) or 0.0)
         cumulative_total = float(getattr(ss, "cumulative_gain", 0.0) or 0.0)
         validated_stack_len = int(
@@ -8715,6 +8794,7 @@ class Coordinator:
                                   if isinstance(current_best, dict) else 0.0,
             "what_worked":       what_worked,
             "what_failed":       what_failed,
+            "kernel_optimizations": kernel_optimizations,
             "stack_fingerprint": {"sha": str(stack_fingerprint)} if stack_fingerprint else {},
             "last_profiled":     str(getattr(ss, "cumulative_gain_validated_ts", "") or ""),
             "workload":          workload_tags,
@@ -8829,12 +8909,34 @@ class Coordinator:
                         exc,
                     )
 
+            # KEEP'd kernel optimizations (incl. E2E-verified-but-no-gain)
+            # ride the extras channel: put_recipe splats extras into the
+            # payload and Recipe.from_dict parses ``kernel_optimizations``
+            # as a first-class field. Merge with any prior rows on the live
+            # recipe, de-duped by kernel_id (this session's entry wins).
+            kopts_new = list(attrs.get("kernel_optimizations") or [])
+            new_kids = {
+                str((k or {}).get("kernel_id") or "")
+                for k in kopts_new if isinstance(k, dict)
+            }
+            merged_kopts: list[dict[str, Any]] = list(kopts_new)
+            for prior in (existing_row.get("kernel_optimizations") or []):
+                if not isinstance(prior, dict):
+                    continue
+                if str(prior.get("kernel_id") or "") in new_kids:
+                    continue
+                merged_kopts.append(dict(prior))
+
+            extras_payload = dict(workload_tags or {})
+            if merged_kopts:
+                extras_payload["kernel_optimizations"] = merged_kopts
+
             overrides: dict[str, Any] = {
                 "what_worked":   attrs["what_worked"],
                 "what_failed":   attrs["what_failed"],
                 "last_profiled": attrs["last_profiled"],
                 "sessions":      merged_sessions,
-                "extras":        dict(workload_tags or {}),
+                "extras":        extras_payload,
             }
             # Only overwrite best_config / best_throughput when THIS
             # session is an actual improvement (or the row has none).

--- a/inference_optimizer/orchestrator/framework_paths.py
+++ b/inference_optimizer/orchestrator/framework_paths.py
@@ -1,14 +1,16 @@
 """Framework source-root resolution for PolicyGate and flag discovery.
 
 Containers may ship framework code under ``/sgl-workspace/{aiter,sglang,vllm}``
-or under ``site-packages`` when only pip wheels are present. This module
-centralises probe order so PolicyGate, AST discovery, and install.sh agree.
+or under ``site-packages`` / ``dist-packages`` when only pip wheels are present.
+This module centralises probe order so PolicyGate, AST discovery, install.sh,
+and ``apply_kernel_patch`` agree.
 """
 
 from __future__ import annotations
 
 import importlib.util
 import os
+import sys
 from pathlib import Path
 
 _DEFAULT_SGLANG_SERVER_ARGS = Path(
@@ -24,6 +26,31 @@ _DEFAULT_SOURCE_ROOTS: tuple[str, ...] = (
     "/sgl-workspace/vllm/",
 )
 
+_FRAMEWORK_PACKAGES: tuple[str, ...] = ("aiter", "sglang", "vllm")
+
+# Parents scanned for ``python*/{site,dist}-packages/<pkg>`` wheel layouts.
+_INSTALL_GLOB_PARENTS: tuple[Path, ...] = (
+    Path("/usr/local/lib"),
+    Path("/opt/venv/lib"),
+)
+
+# aiter device sources often live in the sibling ``aiter_meta`` package.
+_AITER_META_CSRC_ROOT = "/aiter_meta/csrc/"
+
+# Minimal static fallbacks when importlib/glob find nothing (image defaults).
+_STATIC_PATCH_FALLBACK_ROOTS: tuple[str, ...] = (
+    "/opt/venv/lib/python3.10/site-packages/aiter/",
+    "/opt/venv/lib/python3.10/site-packages/sglang/",
+    "/opt/venv/lib/python3.10/site-packages/vllm/",
+    "/usr/local/lib/python3.12/dist-packages/aiter/",
+    "/usr/local/lib/python3.12/dist-packages/sglang/",
+    "/usr/local/lib/python3.12/dist-packages/vllm/",
+    "/usr/local/lib/python3.10/dist-packages/aiter/",
+    "/usr/local/lib/python3.10/dist-packages/sglang/",
+    "/usr/local/lib/python3.10/dist-packages/vllm/",
+    _AITER_META_CSRC_ROOT,
+)
+
 
 def _normalize_root(path: str) -> str:
     p = str(path or "").strip()
@@ -32,20 +59,14 @@ def _normalize_root(path: str) -> str:
     return p if p.endswith("/") else f"{p}/"
 
 
-def resolve_source_file_allowlist() -> tuple[str, ...]:
-    """Return PolicyGate ``source_file`` allowlist roots (default ∪ env)."""
-    env = os.environ.get("INFERENCE_OPTIMIZER_FRAMEWORK_SOURCE_ROOTS", "").strip()
-    if not env:
-        return _DEFAULT_SOURCE_ROOTS
-    extra = tuple(
-        _normalize_root(p) for p in env.split(":") if p.strip()
-    )
+def _merge_roots(*groups: tuple[str, ...]) -> tuple[str, ...]:
     seen: set[str] = set()
     out: list[str] = []
-    for root in (*_DEFAULT_SOURCE_ROOTS, *extra):
-        if root and root not in seen:
-            seen.add(root)
-            out.append(root)
+    for group in groups:
+        for root in group:
+            if root and root not in seen:
+                seen.add(root)
+                out.append(root)
     return tuple(out)
 
 
@@ -60,6 +81,96 @@ def _find_spec_origin(module_name: str) -> Path | None:
     if origin.name == "__init__.py":
         return origin.parent
     return origin.parent
+
+
+def _glob_install_package_roots() -> tuple[str, ...]:
+    """Discover framework package dirs under common lib layouts."""
+    patterns = (
+        "python*/dist-packages/aiter",
+        "python*/dist-packages/sglang",
+        "python*/dist-packages/vllm",
+        "python*/site-packages/aiter",
+        "python*/site-packages/sglang",
+        "python*/site-packages/vllm",
+    )
+    found: list[str] = []
+    seen: set[str] = set()
+    parents: list[Path] = list(_INSTALL_GLOB_PARENTS)
+    prefix_lib = Path(sys.prefix) / "lib"
+    if prefix_lib.is_dir() and prefix_lib not in parents:
+        parents.append(prefix_lib)
+    for parent in parents:
+        if not parent.is_dir():
+            continue
+        for pattern in patterns:
+            for match in sorted(parent.glob(pattern)):
+                if not match.is_dir():
+                    continue
+                root = _normalize_root(str(match))
+                if root and root not in seen:
+                    seen.add(root)
+                    found.append(root)
+    return tuple(found)
+
+
+def _discover_installed_framework_roots() -> tuple[str, ...]:
+    """Runtime discovery via importlib and filesystem globs."""
+    found: list[str] = []
+    seen: set[str] = set()
+
+    def add(path: str | Path) -> None:
+        root = _normalize_root(str(path))
+        if root and root not in seen:
+            seen.add(root)
+            found.append(root)
+
+    for mod in _FRAMEWORK_PACKAGES:
+        origin = _find_spec_origin(mod)
+        if origin is not None:
+            add(origin)
+
+    venv = os.environ.get("VIRTUAL_ENV", "").strip()
+    if venv:
+        site = Path(venv) / "lib"
+        if site.is_dir():
+            for pattern in (
+                "python*/site-packages/vllm",
+                "python*/site-packages/sglang",
+                "python*/site-packages/aiter",
+            ):
+                for match in sorted(site.glob(pattern)):
+                    if match.is_dir():
+                        add(match)
+
+    for root in _glob_install_package_roots():
+        add(root)
+
+    return tuple(found)
+
+
+def resolve_source_file_allowlist() -> tuple[str, ...]:
+    """Return PolicyGate ``source_file`` allowlist roots (default ∪ discovered ∪ env)."""
+    env = os.environ.get("INFERENCE_OPTIMIZER_FRAMEWORK_SOURCE_ROOTS", "").strip()
+    env_roots = tuple(
+        _normalize_root(p) for p in env.split(":") if p.strip()
+    ) if env else ()
+    return _merge_roots(
+        _DEFAULT_SOURCE_ROOTS,
+        _discover_installed_framework_roots(),
+        env_roots,
+    )
+
+
+def resolve_patch_target_roots() -> tuple[str, ...]:
+    """Roots for substring matching in patch apply + kernel classifiers.
+
+    Same as :func:`resolve_source_file_allowlist` plus static fallbacks for
+    layouts that are not importable until first use (e.g. ``aiter_meta/csrc``).
+    """
+    return _merge_roots(
+        resolve_source_file_allowlist(),
+        _STATIC_PATCH_FALLBACK_ROOTS,
+    )
 
 
 def resolve_sglang_server_args_path() -> tuple[Path, str]:
@@ -116,35 +227,16 @@ def resolve_vllm_arg_utils_path() -> tuple[Path, str]:
 def probe_framework_source_roots_for_env() -> str:
     """Colon-separated roots for ``INFERENCE_OPTIMIZER_FRAMEWORK_SOURCE_ROOTS``."""
     found: list[str] = []
-    seen: set[str] = set()
-    for root in _DEFAULT_SOURCE_ROOTS:
+    for root in resolve_source_file_allowlist():
         p = Path(root.rstrip("/"))
-        if p.is_dir() and root not in seen:
-            seen.add(root)
+        if p.is_dir():
             found.append(_normalize_root(str(p)))
-    for mod in ("vllm", "sglang", "aiter"):
-        origin = _find_spec_origin(mod)
-        if origin is not None:
-            r = _normalize_root(str(origin))
-            if r and r not in seen:
-                seen.add(r)
-                found.append(r)
-    venv = os.environ.get("VIRTUAL_ENV", "").strip()
-    if venv:
-        site = Path(venv) / "lib"
-        if site.is_dir():
-            for pattern in ("python*/site-packages/vllm", "python*/site-packages/sglang",
-                            "python*/site-packages/aiter"):
-                for match in sorted(site.glob(pattern)):
-                    r = _normalize_root(str(match))
-                    if r not in seen:
-                        seen.add(r)
-                        found.append(r)
     return ":".join(found)
 
 
 __all__ = [
     "probe_framework_source_roots_for_env",
+    "resolve_patch_target_roots",
     "resolve_sglang_server_args_path",
     "resolve_source_file_allowlist",
     "resolve_vllm_arg_utils_path",

--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -96,25 +96,13 @@ _COMPILE_GENERATED_NAME_MARKERS = (
     "torchinductor",
     "inductor",
 )
-_REUSABLE_SOURCE_ROOTS = (
-    "/sgl-workspace/aiter/",
-    "/sgl-workspace/sglang/",
-    "/sgl-workspace/vllm/",
-    "/opt/venv/lib/python3.10/site-packages/aiter/",
-    "/opt/venv/lib/python3.10/site-packages/sglang/",
-    "/opt/venv/lib/python3.10/site-packages/vllm/",
-    # Production vLLM wheel install layout (system dist-packages). Keep
-    # this in sync with ``kernel-agent/tools/tracelens_analysis.py`` so
-    # both the kernel-agent classifier and the orchestrator-side gate
-    # in ``run_optimization_handler`` agree on what counts as a
-    # reusable framework source.
-    "/usr/local/lib/python3.12/dist-packages/aiter/",
-    "/usr/local/lib/python3.12/dist-packages/sglang/",
-    "/usr/local/lib/python3.12/dist-packages/vllm/",
-    "/usr/local/lib/python3.10/dist-packages/aiter/",
-    "/usr/local/lib/python3.10/dist-packages/sglang/",
-    "/usr/local/lib/python3.10/dist-packages/vllm/",
-)
+
+
+def _reusable_source_roots() -> tuple[str, ...]:
+    """Framework install roots for patchability checks (dynamic discovery)."""
+    from .framework_paths import resolve_patch_target_roots
+
+    return resolve_patch_target_roots()
 _APPLY_TOOL_MODULE: Any | None = None
 # GEAK is FIRST per SKILL.md "high-priority handoff" contract: every kernel
 # Claude/Codex can rewrite, GEAK can rewrite too, and GEAK's GPU-only
@@ -264,7 +252,7 @@ def _is_runtime_generated_kernel(name: str, source_file: str) -> bool:
     if any(marker in lower_file for marker in _RUNTIME_GENERATED_SOURCE_MARKERS):
         return True
     if any(marker in lower_name for marker in _COMPILE_GENERATED_NAME_MARKERS):
-        return not any(root in lower_file for root in _REUSABLE_SOURCE_ROOTS)
+        return not any(root in lower_file for root in _reusable_source_roots())
     return False
 
 
@@ -481,7 +469,7 @@ def _validate_reusable_native_kernel(payload: dict) -> HandlerResult | None:
             "source_file": source_file,
         }
     lower_file = source_file.lower()
-    if not any(root in lower_file for root in _REUSABLE_SOURCE_ROOTS):
+    if not any(root in lower_file for root in _reusable_source_roots()):
         return {
             "status": "failed",
             "error_class": "unstable_source_path",

--- a/inference_optimizer/orchestrator/phase_state.py
+++ b/inference_optimizer/orchestrator/phase_state.py
@@ -883,12 +883,32 @@ def _global_terminal(state: Any) -> tuple[str, dict[str, Any]] | None:
 
 
 # ----------------------- per-phase judgments -------------------------------
+def warm_replay_in_flight(state: Any) -> bool:
+    """True while the PRELUDE warm-recipe replay task has not finished.
+
+    The Coordinator stamps ``warm_replay_outcome.status='in_flight'`` at
+    enqueue time and clears it in ``_promote_warm_replay``. PRELUDE must
+    not exit (and the initial roofline must not enqueue) until this
+    returns False — both paths launch Magpie/sglang on the same GPU.
+    """
+    outcome = getattr(state, "warm_replay_outcome", None) or {}
+    if not isinstance(outcome, dict):
+        return False
+    return str(outcome.get("status") or "").strip() == "in_flight"
+
+
 def exit_normal_prelude(state: Any) -> tuple[str, dict[str, Any]] | None:
-    """``baseline_tput > 0`` → reason=``prelude_done``, target=EXPLORE.
+    """``baseline_tput > 0`` and warm-replay settled → ``prelude_done``.
 
     Returns ``(reason, evidence)`` when ready to transition, ``None``
     otherwise. Evidence is later spliced into ``phase_history``.
+
+    Warm-replay blocks the exit while ``warm_replay_in_flight`` so
+    FRAMEWORK_PR / auto-roofline cannot start a second Magpie job on
+    the GPU before the KB config replay finishes.
     """
+    if warm_replay_in_flight(state):
+        return None
     try:
         tput = float(getattr(state, "baseline_tput", 0.0) or 0.0)
     except (TypeError, ValueError):
@@ -1645,5 +1665,6 @@ __all__ = [
     "phase_index",
     "session_remaining_seconds",
     "should_force_exit_explore",
+    "warm_replay_in_flight",
     "wants_steward_assessment",
 ]

--- a/inference_optimizer/orchestrator/phase_state.py
+++ b/inference_optimizer/orchestrator/phase_state.py
@@ -1151,9 +1151,11 @@ def wants_steward_assessment(
     if not triggered:
         return False
     assessment = getattr(state, "last_remaining_gaps_assessment", None) or {}
-    if isinstance(assessment, dict) and assessment.get("recommendation"):
-        # Already have a verdict; Coordinator should be routing on it.
-        return False
+    if isinstance(assessment, dict):
+        rec = str(assessment.get("recommendation") or "").strip().lower()
+        if rec in ("continue_explore", "advance_to_kernel", "stop_session"):
+            # Already have a routable verdict.
+            return False
     return True
 
 

--- a/inference_optimizer/orchestrator/policy.py
+++ b/inference_optimizer/orchestrator/policy.py
@@ -507,10 +507,10 @@ PATH_LIKE_FIELDS: frozenset[str] = frozenset({
 # source trees that legitimately live outside session_dir. We allowlist
 # the well-known parents here; anything else falls through to the
 # session_dir containment check.
-SOURCE_FILE_ALLOWLIST: tuple[str, ...] = resolve_source_file_allowlist()
-
 # Field name-only allowlist: when the payload key is `source_file`, the
-# value may match SOURCE_FILE_ALLOWLIST instead of being session-rooted.
+# value may match :func:`resolve_source_file_allowlist` instead of being
+# session-rooted. Resolved at check time so importlib/glob discovery and
+# env overrides apply without a process restart.
 SOURCE_LIKE_FIELDS: frozenset[str] = frozenset({"source_file"})
 
 
@@ -2235,7 +2235,7 @@ class PolicyGate:
 
     def _path_in_source_allowlist(self, value: str) -> bool:
         s = str(value)
-        return any(s.startswith(p) for p in SOURCE_FILE_ALLOWLIST)
+        return any(s.startswith(p) for p in resolve_source_file_allowlist())
 
     def _path_in_trace_allowlist(self, value: str) -> bool:
         """Match a value against runtime-resolved trace path prefixes.
@@ -2279,7 +2279,7 @@ class PolicyGate:
                 raise PolicyDenied(
                     f"role={role.name!r} {intent_type.value} payload field "
                     f"{key!r}={node!r} is not under session_dir or any of "
-                    f"{list(SOURCE_FILE_ALLOWLIST)!r}",
+                    f"{list(resolve_source_file_allowlist())!r}",
                     rule="source_file_not_allowlisted",
                     hint=("kernel-opt may only target framework source trees "
                           "under aiter/sglang/vllm; reject the request"),
@@ -2347,7 +2347,6 @@ __all__ = [
     "REVIEW_VERDICT_SOURCE_ALLOWLIST",
     "ROBUSTNESS_ONLY_INTENTS",
     "ROBUSTNESS_ONLY_SOURCE_ALLOWLIST",
-    "SOURCE_FILE_ALLOWLIST",
     "TRACE_PATH_LIKE_FIELDS",
     "SOURCE_LIKE_FIELDS",
 ]

--- a/inference_optimizer/orchestrator/shared_state.py
+++ b/inference_optimizer/orchestrator/shared_state.py
@@ -746,6 +746,11 @@ class SharedState:
     last_remaining_gaps_assessment: dict[str, Any] = field(default_factory=dict)
     remaining_gaps_assessments: list[dict[str, Any]] = field(default_factory=list)
     steward_continuation_used: bool = False
+    # Per EXPLORE-round count of steward subprocess/transport failures
+    # (used to mint retry idempotency keys; not a plateau signal).
+    steward_infra_failures_by_round: dict[str, int] = field(
+        default_factory=dict,
+    )
     # last specialist task snapshot (parity with other
     # ``last_<action>`` mirrors; useful for the orchestration prompt
     # to surface "last round's specialist outcome").

--- a/inference_optimizer/recipe_kb/schema.py
+++ b/inference_optimizer/recipe_kb/schema.py
@@ -138,6 +138,64 @@ class StackFingerprint:
 
 
 @dataclass
+class KernelOptimization:
+    """One KEEP'd kernel-optimization outcome — micro result + E2E verdict.
+
+    Hyperloom superset (arbor has no kernel-level concept). Captures a
+    kernel the GEAK/kernel agent produced and KEEP'd at the micro layer,
+    together with the end-to-end integrate verification result when the
+    optimizer actually integrated + re-benchmarked it. The point is that a
+    kernel can be a genuine micro win (``micro_speedup`` > 1) yet show no
+    end-to-end gain (``e2e_gain_pct`` ~ 0) because its share of total GPU
+    time is tiny — that whole conclusion is valuable warm-start signal
+    ("tried k006 rmsnorm: 1.32x micro, but E2E flat — skip it"), and used
+    to be dropped on the floor because ``what_worked`` only records
+    E2E-validated stack entries.
+
+    ``e2e_gain_pct`` / ``e2e_tput`` default to 0.0 and ``integrated``
+    to False for a kernel that was KEEP'd at the micro layer but never
+    integrated (so warm-start can tell "micro-only, E2E unknown" apart
+    from "E2E-verified, no gain").
+    """
+    kernel_id: str = ""
+    source_file: str = ""
+    artifact_path: str = ""
+    micro_speedup: float = 0.0
+    decision: str = ""
+    e2e_gain_pct: float = 0.0
+    e2e_tput: float = 0.0
+    integrated: bool = False
+    ts: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kernel_id":     str(self.kernel_id),
+            "source_file":   str(self.source_file),
+            "artifact_path": str(self.artifact_path),
+            "micro_speedup": float(self.micro_speedup),
+            "decision":      str(self.decision),
+            "e2e_gain_pct":  float(self.e2e_gain_pct),
+            "e2e_tput":      float(self.e2e_tput),
+            "integrated":    bool(self.integrated),
+            "ts":            str(self.ts),
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> KernelOptimization:
+        return cls(
+            kernel_id=str(d.get("kernel_id") or ""),
+            source_file=str(d.get("source_file") or ""),
+            artifact_path=str(d.get("artifact_path") or ""),
+            micro_speedup=float(d.get("micro_speedup") or 0.0),
+            decision=str(d.get("decision") or ""),
+            e2e_gain_pct=float(d.get("e2e_gain_pct") or 0.0),
+            e2e_tput=float(d.get("e2e_tput") or 0.0),
+            integrated=bool(d.get("integrated") or False),
+            ts=str(d.get("ts") or ""),
+        )
+
+
+@dataclass
 class SessionSummary:
     """One optimisation-session entry — one row per CLOSE.
 
@@ -198,6 +256,13 @@ class Recipe:
     last_profiled: str = ""
     stack_fingerprint: StackFingerprint = field(default_factory=StackFingerprint)
     sessions: list[SessionSummary] = field(default_factory=list)
+
+    # ----- hyperloom superset: KEEP'd kernel optimizations -----
+    # Records kernel-level wins (micro_speedup) + their end-to-end
+    # verification outcome. arbor consumers ignore the extra top-level
+    # key (same as framework_version / lessons). Warm-start reads it to
+    # skip re-optimizing kernels already proven to have no E2E payoff.
+    kernel_optimizations: list[KernelOptimization] = field(default_factory=list)
 
     # ----- v2 audit / wire-compat fields (kept so dispatcher can
     # round-trip to the central server) -----
@@ -263,6 +328,9 @@ class Recipe:
                  "stack_len": int(s.stack_len)}
                 for s in self.sessions
             ],
+            "kernel_optimizations": [
+                k.to_dict() for k in self.kernel_optimizations
+            ],
             "authority":     str(self.authority),
             "confidence":    float(self.confidence),
             "evidence_refs": list(self.evidence_refs),
@@ -290,6 +358,7 @@ class Recipe:
             "what_worked", "what_failed", "remaining_gaps",
             "prs_tested", "pitfalls", "lessons",
             "last_profiled", "stack_fingerprint", "sessions",
+            "kernel_optimizations",
             "authority", "confidence", "evidence_refs", "provenance",
         }
         extras = {k: v for k, v in d.items() if k not in well_known}
@@ -372,6 +441,11 @@ class Recipe:
                 for s in (d.get("sessions") or [])
                 if isinstance(s, dict)
             ],
+            kernel_optimizations=[
+                KernelOptimization.from_dict(k)
+                for k in (d.get("kernel_optimizations") or [])
+                if isinstance(k, dict)
+            ],
             authority=str(d.get("authority") or "EXPERIENTIAL"),
             confidence=float(d.get("confidence") or 0.85),
             evidence_refs=list(d.get("evidence_refs") or []),
@@ -441,6 +515,7 @@ __all__ = [
     "Failure",
     "Finding",
     "Gap",
+    "KernelOptimization",
     "Lesson",
     "Pitfall",
     "PRResult",

--- a/inference_optimizer/recipe_kb/schema.py
+++ b/inference_optimizer/recipe_kb/schema.py
@@ -164,6 +164,10 @@ class KernelOptimization:
     decision: str = ""
     e2e_gain_pct: float = 0.0
     e2e_tput: float = 0.0
+    # Integrate-layer verdict (KEEP / REVERT / NEEDS_REVIEW). ``decision``
+    # above stays the micro-layer KEEP; this carries the E2E outcome so
+    # warm-start can skip a kernel whose patch was reverted at integrate.
+    e2e_decision: str = ""
     integrated: bool = False
     ts: str = ""
 
@@ -176,6 +180,7 @@ class KernelOptimization:
             "decision":      str(self.decision),
             "e2e_gain_pct":  float(self.e2e_gain_pct),
             "e2e_tput":      float(self.e2e_tput),
+            "e2e_decision":  str(self.e2e_decision),
             "integrated":    bool(self.integrated),
             "ts":            str(self.ts),
         }
@@ -190,6 +195,7 @@ class KernelOptimization:
             decision=str(d.get("decision") or ""),
             e2e_gain_pct=float(d.get("e2e_gain_pct") or 0.0),
             e2e_tput=float(d.get("e2e_tput") or 0.0),
+            e2e_decision=str(d.get("e2e_decision") or ""),
             integrated=bool(d.get("integrated") or False),
             ts=str(d.get("ts") or ""),
         )

--- a/inference_optimizer/tests/test_apply_kernel_patch_roots.py
+++ b/inference_optimizer/tests/test_apply_kernel_patch_roots.py
@@ -1,0 +1,58 @@
+"""apply_kernel_patch known-target roots (dist-packages / dynamic discovery)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from inference_optimizer.orchestrator import framework_paths as fp
+
+_APPLY_TOOL_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "kernel-agent"
+    / "tools"
+    / "apply_kernel_patch.py"
+)
+
+
+@pytest.fixture(scope="module")
+def apply_tool() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "_apply_kernel_patch_roots_test", _APPLY_TOOL_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_known_target_roots_includes_dist_packages_vllm(
+    apply_tool, monkeypatch,
+) -> None:
+    monkeypatch.setattr(fp, "_discover_installed_framework_roots", lambda: (
+        "/usr/local/lib/python3.12/dist-packages/vllm/",
+    ))
+    monkeypatch.delenv("INFERENCE_OPTIMIZER_FRAMEWORK_SOURCE_ROOTS", raising=False)
+    apply_tool._CACHED_KNOWN_TARGET_ROOTS = None
+    roots = apply_tool.known_target_roots()
+    assert "/usr/local/lib/python3.12/dist-packages/vllm/" in roots
+
+
+def test_detect_strategy_accepts_dist_packages_vllm_py(
+    apply_tool, monkeypatch,
+) -> None:
+    target = Path(
+        "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/parameter.py",
+    )
+    monkeypatch.setattr(
+        apply_tool,
+        "known_target_roots",
+        lambda: ("/usr/local/lib/python3.12/dist-packages/vllm/",),
+    )
+    strat = apply_tool._detect_strategy(target, allow_unknown_target=False)
+    assert strat["compiled"] is False

--- a/inference_optimizer/tests/test_assess_remaining_gaps.py
+++ b/inference_optimizer/tests/test_assess_remaining_gaps.py
@@ -108,6 +108,16 @@ def test_wants_steward_assessment_already_have_verdict():
     assert phase_state.wants_steward_assessment(state) is False
 
 
+def test_wants_steward_assessment_after_infra_failure_empty_rec():
+    """Empty recommendation after a transport failure should allow retry."""
+    state = _make_plateau_state()
+    state.last_remaining_gaps_assessment = {
+        "recommendation": "",
+        "rationale": "steward infrastructure failure (subprocess_stale_heartbeat)",
+    }
+    assert phase_state.wants_steward_assessment(state) is True
+
+
 def test_wants_steward_assessment_disabled_via_override():
     state = _make_plateau_state()
     state.plateau_overrides = {"steward_disabled": True}
@@ -337,6 +347,45 @@ async def test_route_continue_explore_grants_first_then_coerces_second():
     )
     assert state.pending_escalate_hint == "skip_to_kernel"
     assert state.last_remaining_gaps_assessment["recommendation"] == "advance_to_kernel"
+
+
+@pytest.mark.asyncio
+async def test_route_infra_failure_retries_without_stop(tmp_path):
+    from inference_optimizer.orchestrator.coordinator import Coordinator
+
+    class _StewardTaskRegistry:
+        def __init__(self) -> None:
+            self.calls: list[dict] = []
+
+        async def create_or_return_existing(self, **kwargs):
+            self.calls.append(dict(kwargs))
+            return SimpleNamespace(
+                task_id="retry-steward",
+                kind=kwargs.get("kind"),
+                state="queued",
+            ), False
+
+    state = SharedState(session_id="t-route-infra", phase="EXPLORE")
+    state.explore_search = {"cursor": 2}
+    coord = Coordinator.__new__(Coordinator)
+    coord.shared_state = state
+    coord.session_dir = tmp_path
+    coord.tasks = _StewardTaskRegistry()
+    coord.knowledge_plane = None
+
+    task = SimpleNamespace(task_id="task-infra-1", params={})
+    payload = {
+        "domain": "session_steward_specialist",
+        "empty": True,
+        "reason": "subprocess_stale_heartbeat",
+        "summary": "subprocess_stale_heartbeat",
+    }
+    await coord._route_steward_verdict(task=task, done_payload=payload)
+    assert state.stop_reason in ("", None)
+    assert state.last_remaining_gaps_assessment["recommendation"] == ""
+    assert state.steward_infra_failures_by_round == {"2": 1}
+    assert len(coord.tasks.calls) == 1
+    assert "retry1" in coord.tasks.calls[0]["idempotency_key"]
 
 
 @pytest.mark.asyncio

--- a/inference_optimizer/tests/test_close_phase_sequencer.py
+++ b/inference_optimizer/tests/test_close_phase_sequencer.py
@@ -169,6 +169,28 @@ class _StubCortex:
         return {"status": "auto_accepted"}
 
 
+class _StubSubResult:
+    """Minimal sub-agent run result: only ``.state`` is read by the
+    CLOSE sequencer (terminal 'succeeded' → step marked done)."""
+
+    def __init__(self, state: str = "succeeded"):
+        self.state = state
+
+
+class _StubSubAgentRunner:
+    """``Coordinator.sub`` double. The CLOSE sequencer awaits
+    ``self.sub.run_task(task)`` for the report / session_breakdown steps;
+    return a terminal-succeeded result so the happy-path sequencer
+    advances without a real sub-agent."""
+
+    def __init__(self):
+        self.run_calls: list[Any] = []
+
+    async def run_task(self, task, *args, **kwargs):
+        self.run_calls.append(task)
+        return _StubSubResult(state="succeeded")
+
+
 @pytest.fixture
 def coord(tmp_path: Path):
     """Lean Coordinator stub for hook unit tests."""
@@ -176,6 +198,7 @@ def coord(tmp_path: Path):
     c.session_dir = tmp_path
     c.shared_state = _BareState()
     c.tasks = _StubTaskRegistry()
+    c.sub = _StubSubAgentRunner()
     c.cortex_kb = None
     c.knowledge_plane = None
     c.role_registry = {}

--- a/inference_optimizer/tests/test_coordinator_kb_writes.py
+++ b/inference_optimizer/tests/test_coordinator_kb_writes.py
@@ -228,3 +228,76 @@ def test_close_does_not_clobber_better_best_config(tmp_path: Path) -> None:
     assert row["best_config"].get("name") == "good"
     # T0-written fingerprint version survives the CLOSE fingerprint merge.
     assert row["stack_fingerprint"].get("vllm_version") == "0.6.0"
+
+
+# ===========================================================================
+# R-7: KEEP'd kernel optimizations (incl. E2E-verified-but-no-gain) must be
+# persisted into the recipe row. Repro for overnight session 20260529T132829Z
+# where k006 (micro 1.32x, KEEP, E2E gain -0.094%) vanished from recipe.json
+# entirely — because ``what_worked`` is built only from optimization_stack,
+# which a no-E2E-gain kernel never enters.
+# ===========================================================================
+def _seed_kept_kernel(coord: Coordinator) -> None:
+    """Populate SharedState the way a KEEP'd + E2E-integrated kernel leaves
+    it, mirroring the real shapes:
+
+    * ``kernel_opt_attempts[kid]`` — micro result (record_kernel_opt)
+    * ``kernel_integrate_attempts[key]`` — E2E verification outcome
+      (record_kernel_integrate_result), joined back by ``kernel_id``.
+    """
+    ss = coord.shared_state
+    ss.kernel_opt_attempts = {
+        "k006": {
+            "last_decision": "KEEP",
+            "last_micro_speedup": 1.3202,
+            "last_artifact_path": "/x/optimized_versions/v1_n128_launch_tuning.cu",
+            "source_file": "/sgl-workspace/aiter/csrc/kernels/rmsnorm_quant_kernels.cu",
+        },
+    }
+    ss.kernel_integrate_attempts = {
+        "k006|/x/optimized_versions/v1_n128_launch_tuning.cu|": {
+            "kernel_id": "k006",
+            "patch_path": "/x/optimized_versions/v1_n128_launch_tuning.cu",
+            "best_gain_pct": -0.094,
+            "last_decision": "NEEDS_REVIEW",
+            "attempts": [
+                {"decision": "NEEDS_REVIEW", "new_tput": 2477.82,
+                 "gain_pct": -0.094},
+            ],
+        },
+    }
+
+
+def test_build_recipe_attrs_surfaces_kept_kernel(tmp_path: Path) -> None:
+    """``_build_recipe_attrs_from_state`` must emit a ``kernel_optimizations``
+    entry for the KEEP'd kernel, carrying BOTH micro_speedup and the E2E
+    verification outcome. Before the fix this dict has no such key."""
+    coord = _make_coordinator(tmp_path)
+    _seed_kept_kernel(coord)
+    attrs = coord._build_recipe_attrs_from_state()
+    kopts = attrs.get("kernel_optimizations") or []
+    assert kopts, "KEEP'd kernel k006 missing from recipe attrs"
+    k = next((x for x in kopts if x.get("kernel_id") == "k006"), None)
+    assert k is not None, f"k006 not in {kopts}"
+    assert k["micro_speedup"] == 1.3202
+    assert k["decision"] == "KEEP"
+    # E2E verification outcome must be carried, not dropped.
+    assert k["e2e_gain_pct"] == -0.094
+    assert k["e2e_tput"] == 2477.82
+    assert k["integrated"] is True
+
+
+def test_close_finalize_persists_kept_kernel_to_kb(tmp_path: Path) -> None:
+    """End-to-end: after CLOSE finalize, recipe.json must carry the KEEP'd
+    kernel under ``kernel_optimizations`` so warm-start can reuse it."""
+    coord = _make_coordinator(tmp_path)
+    _seed_kept_kernel(coord)
+    coord.cortex_finalize_recipe_and_journal()
+    row = coord.cortex_kb.get_recipe(canonical_id=_expected_cid())
+    assert row is not None
+    kopts = row.get("kernel_optimizations") or []
+    ids = [k.get("kernel_id") for k in kopts]
+    assert "k006" in ids, f"k006 not persisted to KB: {row.get('kernel_optimizations')}"
+    k006 = next(k for k in kopts if k.get("kernel_id") == "k006")
+    assert k006["micro_speedup"] == 1.3202
+    assert k006["e2e_gain_pct"] == -0.094

--- a/inference_optimizer/tests/test_coordinator_kb_writes.py
+++ b/inference_optimizer/tests/test_coordinator_kb_writes.py
@@ -293,6 +293,10 @@ def test_build_recipe_attrs_surfaces_kept_kernel(tmp_path: Path) -> None:
     assert k["e2e_gain_pct"] == -0.094
     assert k["e2e_tput"] == 2477.82
     assert k["integrated"] is True
+    # ``decision`` stays the micro-layer KEEP; the integrate verdict rides
+    # the separate ``e2e_decision`` field so warm-start can tell a kept
+    # micro win from its (possibly reverted) E2E outcome.
+    assert k["e2e_decision"] == "NEEDS_REVIEW"
 
 
 def test_close_finalize_persists_kept_kernel_to_kb(tmp_path: Path) -> None:
@@ -309,3 +313,205 @@ def test_close_finalize_persists_kept_kernel_to_kb(tmp_path: Path) -> None:
     k006 = next(k for k in kopts if k.get("kernel_id") == "k006")
     assert k006["micro_speedup"] == 1.3202
     assert k006["e2e_gain_pct"] == -0.094
+
+
+# ===========================================================================
+# R-8 (P0): a bare-baseline CLOSE whose tput happens to exceed a historical
+# best (different workload shape, no flags) must NOT overwrite the validated
+# best_config. Repro for session 20260531T144553Z where a flagless baseline
+# (2813 tok/s @ ISL/OSL=256) clobbered the warm_replay recipe (2532 tok/s @
+# ISL/OSL=1024), dropping every extra_sglang_arg from the KB.
+# ===========================================================================
+def test_close_does_not_clobber_with_bare_baseline_higher_tput(
+    tmp_path: Path,
+) -> None:
+    coord = _make_coordinator(tmp_path)
+    cid = _expected_cid()
+    coord.cortex_kb.put_recipe(
+        canonical_id=cid, model=_MODEL, hardware=_HW, framework=_FW,
+        framework_version=_FWV, precision=_PREC,
+        best_config={
+            "name": "warm_replay",
+            "extra_sglang_args": "--schedule-policy lpm --page-size 16",
+            "tput": "2532",
+        },
+        best_throughput=2532.0,
+    )
+    # This session ended on the bare baseline: no validated stack, no
+    # validated gain, current_best is the baseline itself (no flags) — but
+    # its tput (different workload) is numerically higher than the stored
+    # best. The numeric better-throughput guard alone would let it through.
+    ss = coord.shared_state
+    ss.current_best = {"action": "baseline", "name": "baseline", "tput": 2813.5}
+    ss.optimization_stack = []
+    ss.cumulative_gain_validated = 0.0
+    ss.cumulative_gain = 0.0
+    coord.cortex_finalize_recipe_and_journal()
+    row = coord.cortex_kb.get_recipe(canonical_id=cid)
+    assert row["best_throughput"] == 2532.0, (
+        "bare-baseline CLOSE clobbered a validated best_throughput"
+    )
+    assert row["best_config"].get("extra_sglang_args") == (
+        "--schedule-policy lpm --page-size 16"
+    ), "warm_replay launch flags were dropped by a flagless baseline overwrite"
+
+
+def test_close_overwrites_best_when_validated_win(tmp_path: Path) -> None:
+    """Counterpart guard: a genuine validated win (non-empty stack, real
+    flags, higher tput) DOES update best_config/best_throughput."""
+    coord = _make_coordinator(tmp_path)
+    cid = _expected_cid()
+    coord.cortex_kb.put_recipe(
+        canonical_id=cid, model=_MODEL, hardware=_HW, framework=_FW,
+        framework_version=_FWV, precision=_PREC,
+        best_config={"name": "old", "extra_sglang_args": "--page-size 16",
+                     "tput": "2000"},
+        best_throughput=2000.0,
+    )
+    ss = coord.shared_state
+    ss.current_best = {
+        "name": "tuned",
+        "extra_sglang_args": "--page-size 32 --schedule-policy lpm",
+        "tput": 2200.0,
+    }
+    ss.optimization_stack = [{
+        "action": "explore", "variant_name": "page32",
+        "extra_sglang_args": "--page-size 32 --schedule-policy lpm",
+    }]
+    ss.cumulative_gain_validated = 10.0
+    coord.cortex_finalize_recipe_and_journal()
+    row = coord.cortex_kb.get_recipe(canonical_id=cid)
+    assert row["best_throughput"] == 2200.0
+    assert "--page-size 32" in row["best_config"].get("extra_sglang_args", "")
+
+
+# ===========================================================================
+# R-9 (P1): kernel_optimizations[].e2e_decision must carry the integrate
+# verdict (KEEP/REVERT/NEEDS_REVIEW). Repro for session 20260531T144553Z
+# where k007 integrate REVERT'd (E2E -1.05%) but the recipe row only showed
+# the micro-layer decision=KEEP, hiding that the patch was rolled back.
+# ===========================================================================
+def test_kernel_e2e_decision_reflects_integrate_revert(tmp_path: Path) -> None:
+    coord = _make_coordinator(tmp_path)
+    ss = coord.shared_state
+    ss.kernel_opt_attempts = {
+        "k007": {
+            "last_decision": "KEEP",
+            "last_micro_speedup": 2.42,
+            "last_artifact_path": "/x/optimized_versions/v1_multirow.cu",
+            "last_source_file": "/sgl-workspace/aiter/csrc/kernels/rmsnorm_quant_kernels.cu",
+        },
+    }
+    ss.kernel_integrate_attempts = {
+        "k007|/x/optimized_versions/v1_multirow.cu|": {
+            "kernel_id": "k007",
+            "best_gain_pct": -1.0488865062914727,
+            "last_decision": "REVERT",
+            "attempts": [
+                {"decision": "REVERT", "new_tput": 2784.0072254162687,
+                 "gain_pct": -1.0488865062914727},
+            ],
+        },
+    }
+    attrs = coord._build_recipe_attrs_from_state()
+    kopts = attrs.get("kernel_optimizations") or []
+    k = next((x for x in kopts if x.get("kernel_id") == "k007"), None)
+    assert k is not None, f"k007 missing from {kopts}"
+    # Micro-layer KEEP is preserved (kernel agent did keep its artifact).
+    assert k["decision"] == "KEEP"
+    # E2E integrate verdict must be surfaced as REVERT — NOT hidden.
+    assert k["e2e_decision"] == "REVERT"
+    assert k["integrated"] is True
+    assert round(k["e2e_gain_pct"], 2) == -1.05
+
+
+def test_kernel_e2e_decision_micro_only_when_not_integrated(
+    tmp_path: Path,
+) -> None:
+    """A micro-KEEP kernel that never reached integrate has no E2E verdict;
+    e2e_decision stays empty and integrated is False."""
+    coord = _make_coordinator(tmp_path)
+    ss = coord.shared_state
+    ss.kernel_opt_attempts = {
+        "k009": {
+            "last_decision": "KEEP",
+            "last_micro_speedup": 1.241,
+            "last_artifact_path": "/x/optimized_versions/v1_multirow.cu",
+            "last_source_file": "/sgl-workspace/aiter/csrc/kernels/rmsnorm_quant_kernels.cu",
+        },
+    }
+    ss.kernel_integrate_attempts = {}
+    attrs = coord._build_recipe_attrs_from_state()
+    kopts = attrs.get("kernel_optimizations") or []
+    k = next((x for x in kopts if x.get("kernel_id") == "k009"), None)
+    assert k is not None
+    assert k["decision"] == "KEEP"
+    assert k["integrated"] is False
+    assert k["e2e_decision"] == ""
+
+
+# ===========================================================================
+# R-10 (P3): sessions[] entry must carry throughput_before/after, a date,
+# and the list of stack actions. Repro for recipe.json where every session
+# row had throughput_before/after=0.0, date="", actions_taken=[].
+# ===========================================================================
+def test_session_entry_carries_throughput_date_and_actions(
+    tmp_path: Path,
+) -> None:
+    coord = _make_coordinator(tmp_path)
+    ss = coord.shared_state
+    ss.baseline_tput = 2000.0
+    ss.current_best = {
+        "name": "tuned", "tput": 2150.0,
+        "extra_sglang_args": "--page-size 32",
+    }
+    ss.optimization_stack = [
+        {"action": "explore", "variant_name": "page32"},
+        {"action": "explore", "variant_name": "stream_interval_4"},
+    ]
+    ss.cumulative_gain_validated = 7.5
+    ss.cumulative_gain_validated_stack_len = 2
+    attrs = coord._build_recipe_attrs_from_state()
+    sessions = attrs.get("sessions") or []
+    assert sessions, "no session entry emitted"
+    s = sessions[0]
+    assert s["throughput_before"] == 2000.0
+    assert s["throughput_after"] == 2150.0
+    assert s["date"], "session date must not be empty"
+    assert s["actions_taken"] == ["page32", "stream_interval_4"]
+
+
+# ===========================================================================
+# R-11 (P4): a per-variant pitfall whose variant dict is empty must still
+# carry the variant NAME in its description, not collapse to the bare task
+# kind ("explore"). Repro for recipe.json where five distinct regressed
+# explore variants all wrote the indistinguishable description
+# "[sglang] explore → regress on ...".
+# ===========================================================================
+def test_pitfall_description_uses_variant_name_not_bare_kind(
+    tmp_path: Path,
+) -> None:
+    from types import SimpleNamespace
+
+    coord = _make_coordinator(tmp_path)
+    task = SimpleNamespace(kind="explore", task_id="t-1")
+    coord._record_fact_per_variant(
+        task=task,
+        source_session_id="sess-1",
+        variant_outcome={
+            "outcome": "REVERT",
+            "variant_name": "page64_no_radix",
+            # Empty variant dict is the bug trigger: summarize_change used
+            # to drop to task.kind ("explore") instead of the variant name.
+            "variant": {},
+            "metrics": {"gain_pct": -10.0},
+        },
+    )
+    row = coord.cortex_kb.get_recipe(canonical_id=_expected_cid())
+    descs = [p.get("description") for p in (row.get("pitfalls") or [])]
+    assert any("page64_no_radix" in (d or "") for d in descs), descs
+    # The bare-kind description must NOT be what we wrote.
+    assert not any(
+        (d or "") == f"[{_FW}] explore → regress on {_MODEL}/{_HW}"
+        for d in descs
+    ), descs

--- a/inference_optimizer/tests/test_coordinator_kb_writes.py
+++ b/inference_optimizer/tests/test_coordinator_kb_writes.py
@@ -356,6 +356,42 @@ def test_close_does_not_clobber_with_bare_baseline_higher_tput(
     ), "warm_replay launch flags were dropped by a flagless baseline overwrite"
 
 
+def test_best_config_reads_stack_args_from_canonical_server_key(
+    tmp_path: Path,
+) -> None:
+    """Review #2 repro: the 'prefer last validated stack layer's launch
+    args' correction (fix for #332) must read the post-rename canonical
+    ``candidate_extra_server_args`` / ``extra_server_args`` keys that
+    _lift_to_current_best + explore winners actually write. Reading only
+    the legacy ``*_sglang_args`` keys yields an empty string, silently
+    re-breaking best_config for every real (renamed) stack entry."""
+    coord = _make_coordinator(tmp_path)
+    ss = coord.shared_state
+    # current_best carries a deliberately-corrupted cumulative string so
+    # the stack-layer override is the path under test.
+    ss.current_best = {
+        "name": "tuned",
+        "extra_server_args": "--page-size 16 --page-size 16",  # corrupted dup
+        "tput": 2200.0,
+    }
+    # Real post-rename stack entry: canonical key only.
+    ss.optimization_stack = [{
+        "action": "explore",
+        "variant_name": "page32",
+        "candidate_extra_server_args": "--page-size 32 --schedule-policy lpm",
+        "extra_server_args": "--page-size 32 --schedule-policy lpm",
+    }]
+    ss.cumulative_gain_validated = 10.0
+    attrs = coord._build_recipe_attrs_from_state()
+    assert attrs["best_config"]["extra_sglang_args"] == (
+        "--page-size 32 --schedule-policy lpm"
+    ), (
+        "stack-layer launch args must be read from the canonical "
+        "extra_server_args key; got "
+        f"{attrs['best_config'].get('extra_sglang_args')!r}"
+    )
+
+
 def test_close_overwrites_best_when_validated_win(tmp_path: Path) -> None:
     """Counterpart guard: a genuine validated win (non-empty stack, real
     flags, higher tput) DOES update best_config/best_throughput."""
@@ -515,37 +551,3 @@ def test_pitfall_description_uses_variant_name_not_bare_kind(
         (d or "") == f"[{_FW}] explore → regress on {_MODEL}/{_HW}"
         for d in descs
     ), descs
-# Regression: recipe write-back must read the renamed canonical
-# ``extra_server_args`` off current_best / optimization_stack (state is
-# migrated on load) and still emit the KB-legacy ``extra_sglang_args``
-# field. Reading the stale name silently dropped the server args and
-# broke warm-replay reproduction in the next session.
-# ===========================================================================
-def test_recipe_attrs_read_canonical_extra_server_args(tmp_path: Path) -> None:
-    coord = _make_coordinator(tmp_path)
-    ss = coord.shared_state
-    ss.current_best = {
-        "action": "explore",
-        "name": "win",
-        "tput": 900.0,
-        # canonical key, as written by _lift_to_current_best post-rename
-        "extra_server_args": "--page-size 16",
-        "extra_envs": {"SGLANG_X": "1"},
-    }
-    ss.optimization_stack = [{
-        "action": "explore",
-        "name": "win",
-        "extra_server_args": "--page-size 16",
-        "extra_envs": {"SGLANG_X": "1"},
-    }]
-    ss.gain_per_stack_entry = [12.5]
-
-    attrs = coord._build_recipe_attrs_from_state()
-
-    # best_config carries the args under the KB-legacy field name, read
-    # from the canonical state key.
-    assert attrs["best_config"]["extra_sglang_args"] == "--page-size 16"
-    # what_worked entries likewise carry the args (not an empty string).
-    assert attrs["what_worked"], "what_worked should not be empty"
-    assert attrs["what_worked"][0]["extra_sglang_args"] == "--page-size 16"
-    assert attrs["what_worked"][0]["gain_pct"] == 12.5

--- a/inference_optimizer/tests/test_coordinator_kb_writes.py
+++ b/inference_optimizer/tests/test_coordinator_kb_writes.py
@@ -251,7 +251,9 @@ def _seed_kept_kernel(coord: Coordinator) -> None:
             "last_decision": "KEEP",
             "last_micro_speedup": 1.3202,
             "last_artifact_path": "/x/optimized_versions/v1_n128_launch_tuning.cu",
-            "source_file": "/sgl-workspace/aiter/csrc/kernels/rmsnorm_quant_kernels.cu",
+            # record_kernel_opt persists the source under ``last_source_file``
+            # (NOT ``source_file``); the recipe builder must read that key.
+            "last_source_file": "/sgl-workspace/aiter/csrc/kernels/rmsnorm_quant_kernels.cu",
         },
     }
     ss.kernel_integrate_attempts = {
@@ -281,6 +283,12 @@ def test_build_recipe_attrs_surfaces_kept_kernel(tmp_path: Path) -> None:
     assert k is not None, f"k006 not in {kopts}"
     assert k["micro_speedup"] == 1.3202
     assert k["decision"] == "KEEP"
+    # source_file is read from the ``last_source_file`` ledger key
+    # (record_kernel_opt's actual field) so warm-start can relocate the
+    # patched source; an empty string means the wrong key was read.
+    assert k["source_file"] == (
+        "/sgl-workspace/aiter/csrc/kernels/rmsnorm_quant_kernels.cu"
+    )
     # E2E verification outcome must be carried, not dropped.
     assert k["e2e_gain_pct"] == -0.094
     assert k["e2e_tput"] == 2477.82

--- a/inference_optimizer/tests/test_dynamic_action_invariants.py
+++ b/inference_optimizer/tests/test_dynamic_action_invariants.py
@@ -489,6 +489,9 @@ class TestInvariant_4_KernelOwnedDenial:
             "deep_kernel_analysis",
             "operator_tuning",
             "vendor_kernel_config",
+            # Added by the fp8 gemm-tuning integration (#371): gemm_tuning
+            # is a kernel-owned action, so the locked set grows by one.
+            "gemm_tuning",
         })
 
 

--- a/inference_optimizer/tests/test_extra_sglang_args_merge.py
+++ b/inference_optimizer/tests/test_extra_sglang_args_merge.py
@@ -1,0 +1,42 @@
+"""Regression tests for cumulative extra_sglang_args merge/dedupe."""
+
+from __future__ import annotations
+
+from inference_optimizer.orchestrator.coordinator import (
+    _dedupe_extra_sglang_args,
+    _merge_cumulative_extra_sglang_args,
+)
+
+
+_CLEAN_STACK = (
+    "--schedule-policy lpm --cuda-graph-bs 1 2 4 8 16 24 32 48 64 80 "
+    "--mem-fraction-static 0.92 --page-size 16"
+)
+
+
+def test_merge_does_not_double_stack_when_candidate_is_cumulative() -> None:
+    base = "--schedule-policy lpm --cuda-graph-bs 1 2 4 8 16 24 32 48 64 80 --mem-fraction-static 0.92"
+    candidate = _CLEAN_STACK
+    merged = _merge_cumulative_extra_sglang_args(base, candidate, candidate)
+    assert merged == _CLEAN_STACK
+    assert "0.92 2 4 8" not in merged
+
+
+def test_merge_appends_delta_candidate() -> None:
+    base = "--schedule-policy lpm"
+    candidate = "--page-size 16"
+    merged = _merge_cumulative_extra_sglang_args(base, candidate, candidate)
+    assert merged == "--schedule-policy lpm --page-size 16"
+
+
+def test_dedupe_preserves_cuda_graph_bs_multi_values() -> None:
+    args = (
+        "--schedule-policy lpm --cuda-graph-bs 1 2 4 8 16 24 32 48 64 80 "
+        "--mem-fraction-static 0.92 --page-size 16"
+    )
+    assert _dedupe_extra_sglang_args(args) == args
+
+
+def test_dedupe_last_wins_single_value_flags() -> None:
+    args = "--mem-fraction-static 0.90 --mem-fraction-static 0.92"
+    assert _dedupe_extra_sglang_args(args) == "--mem-fraction-static 0.92"

--- a/inference_optimizer/tests/test_framework_paths_units.py
+++ b/inference_optimizer/tests/test_framework_paths_units.py
@@ -42,10 +42,20 @@ class TestNormalizeRoot:
 
 
 class TestResolveSourceFileAllowlist:
-    def test_default_when_env_empty(self):
+    def test_default_when_env_empty(self, monkeypatch):
+        monkeypatch.setattr(fp, "_discover_installed_framework_roots", lambda: ())
         assert fp.resolve_source_file_allowlist() == fp._DEFAULT_SOURCE_ROOTS
 
+    def test_merges_discovered_roots(self, monkeypatch):
+        monkeypatch.setattr(fp, "_discover_installed_framework_roots", lambda: (
+            "/usr/local/lib/python3.12/dist-packages/vllm/",
+        ))
+        roots = fp.resolve_source_file_allowlist()
+        assert fp._DEFAULT_SOURCE_ROOTS[0] in roots
+        assert "/usr/local/lib/python3.12/dist-packages/vllm/" in roots
+
     def test_appends_extra_roots_unique_in_order(self, monkeypatch):
+        monkeypatch.setattr(fp, "_discover_installed_framework_roots", lambda: ())
         monkeypatch.setenv(
             "INFERENCE_OPTIMIZER_FRAMEWORK_SOURCE_ROOTS",
             "/opt/custom/sglang:/sgl-workspace/aiter:/opt/other/vllm",
@@ -176,15 +186,35 @@ class TestResolveVllmArgUtils:
         assert "not found" in source
 
 
+class TestGlobInstallPackageRoots:
+    def test_finds_dist_packages_under_usr_local(self, tmp_path, monkeypatch):
+        base = tmp_path / "usr_local_lib" / "python3.12" / "dist-packages"
+        (base / "vllm").mkdir(parents=True)
+        monkeypatch.setattr(
+            fp, "_INSTALL_GLOB_PARENTS", (tmp_path / "usr_local_lib",),
+        )
+        roots = fp._glob_install_package_roots()
+        assert any("dist-packages/vllm/" in r for r in roots)
+
+
+class TestResolvePatchTargetRoots:
+    def test_includes_static_fallback_when_discovery_empty(self, monkeypatch):
+        monkeypatch.setattr(fp, "_discover_installed_framework_roots", lambda: ())
+        monkeypatch.delenv("INFERENCE_OPTIMIZER_FRAMEWORK_SOURCE_ROOTS", raising=False)
+        roots = fp.resolve_patch_target_roots()
+        assert "/usr/local/lib/python3.12/dist-packages/vllm/" in roots
+        assert "/aiter_meta/csrc/" in roots
+
+
 class TestProbeFrameworkSourceRootsForEnv:
-    def test_returns_default_dirs_when_present(self, tmp_path, monkeypatch):
-        # Simulate /sgl-workspace/* existing for one of the defaults.
+    def test_returns_existing_dirs_only(self, tmp_path, monkeypatch):
         present = tmp_path / "fake_root"
         present.mkdir()
-        monkeypatch.setattr(
-            fp, "_DEFAULT_SOURCE_ROOTS", (f"{present}/",),
-        )
-        monkeypatch.setattr(fp, "_find_spec_origin", lambda name: None)
+        monkeypatch.setattr(fp, "_discover_installed_framework_roots", lambda: (
+            f"{present}/",
+            f"{tmp_path / 'missing'}/",
+        ))
+        monkeypatch.setattr(fp, "_DEFAULT_SOURCE_ROOTS", ())
         result = fp.probe_framework_source_roots_for_env()
         assert result == f"{present}/"
 
@@ -197,20 +227,8 @@ class TestProbeFrameworkSourceRootsForEnv:
             (site / name).mkdir(parents=True)
         monkeypatch.setattr(fp, "_DEFAULT_SOURCE_ROOTS", ())
         monkeypatch.setattr(fp, "_find_spec_origin", lambda name: None)
+        monkeypatch.setattr(fp, "_glob_install_package_roots", lambda: ())
         monkeypatch.setenv("VIRTUAL_ENV", str(venv))
         result = fp.probe_framework_source_roots_for_env()
         for name in ("vllm", "sglang", "aiter"):
             assert f"{name}/" in result
-
-    def test_dedupes_origins_against_defaults(self, tmp_path, monkeypatch):
-        # When find_spec returns the same path as a default root, the
-        # de-dupe keeps only the first occurrence.
-        shared = tmp_path / "shared"
-        shared.mkdir()
-        monkeypatch.setattr(
-            fp, "_DEFAULT_SOURCE_ROOTS", (f"{shared}/",),
-        )
-        monkeypatch.setattr(fp, "_find_spec_origin", lambda name: shared)
-        result = fp.probe_framework_source_roots_for_env()
-        # Single entry, even though spec lookups all resolved to the same dir.
-        assert result == f"{shared}/"

--- a/inference_optimizer/tests/test_kernel_request_handlers_units.py
+++ b/inference_optimizer/tests/test_kernel_request_handlers_units.py
@@ -94,7 +94,7 @@ class TestRuntimeGeneratedKernel:
 
     def test_reusable_source_root_overrides_compile_marker(self):
         markers = krh._COMPILE_GENERATED_NAME_MARKERS
-        roots = krh._REUSABLE_SOURCE_ROOTS
+        roots = krh._reusable_source_roots()
         if not markers or not roots:
             pytest.skip("required tables empty in build")
         marker = next(iter(markers))

--- a/inference_optimizer/tests/test_no_legacy_writer_sites.py
+++ b/inference_optimizer/tests/test_no_legacy_writer_sites.py
@@ -153,6 +153,20 @@ ALLOWED_FILES: dict[str, str] = {
         "IR-8 entry names the legacy extra_sglang_args alias as "
         "compat-surface context",
 
+    # Watermark-refresh profile executor inherits current_best's launch
+    # args through the canonical channel; the comment + params key name
+    # the legacy alias for the downstream reader's back-compat path.
+    "inference_optimizer/orchestrator/action_executors/profile.py":
+        "watermark-refresh inheritance comments name the legacy "
+        "extra_sglang_args channel for the downstream reader",
+    "inference_optimizer/tests/test_profile_and_kernel_handlers.py":
+        "profile/kernel handler tests exercise the legacy "
+        "extra_sglang_args inheritance channel",
+    # Back-compat regression for the cumulative-merge helper, which is
+    # named after the legacy field it dedupes.
+    "inference_optimizer/tests/test_extra_sglang_args_merge.py":
+        "cumulative extra_sglang_args merge/dedupe back-compat tests",
+
 }
 
 
@@ -163,6 +177,9 @@ _SKIP_DIRECTORIES: tuple[str, ...] = (
     ".git/",
     "node_modules/",
     "__pycache__/",
+    # setuptools build metadata (regenerated SOURCES.txt mirrors file
+    # names, not source content — not a real writer site).
+    "hyperloom_inference_optimizer.egg-info/",
 )
 
 

--- a/inference_optimizer/tests/test_phase_state_machine.py
+++ b/inference_optimizer/tests/test_phase_state_machine.py
@@ -135,6 +135,18 @@ def test_exit_normal_prelude_triggers_on_baseline_tput():
     assert evidence["baseline_tput"] == 1234.5
 
 
+def test_exit_normal_prelude_blocked_while_warm_replay_in_flight():
+    """PRELUDE must not advance to FRAMEWORK_PR until warm-replay settles."""
+    state = SimpleNamespace(
+        baseline_tput=1234.5,
+        warm_replay_outcome={"status": "in_flight", "replay_task_id": "abc"},
+    )
+    assert phase_state.exit_normal_prelude(state) is None
+    state.warm_replay_outcome = {"status": "failed"}
+    out = phase_state.exit_normal_prelude(state)
+    assert out is not None and out[0] == "prelude_done"
+
+
 def test_exit_terminal_prelude_after_three_baseline_failures():
     state = SimpleNamespace(baseline_failure_streak=2)
     assert phase_state.exit_terminal_prelude(state) is None

--- a/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -878,6 +878,10 @@ async def test_profile_executor_skips_when_framework_atom(monkeypatch, tmp_path)
     so the historical structured ``skipped`` short-circuit is retired.
     """
     monkeypatch.setenv("FRAMEWORK", "atom")
+    # Anchor session/runs paths under the test tmp dir. Without this the
+    # executor falls back to the ``/workspace/hyperloom`` default, which is
+    # not writable on a clean CI runner (PermissionError on ``/workspace``).
+    monkeypatch.setenv("USER_DATA_PATH", str(tmp_path))
     pe = ProfileExecutor()
     # Sentinel-patch the parent __call__ so we can prove the normal path
     # is reached without launching Magpie in this unit test.

--- a/inference_optimizer/tests/test_recipe_kb_kernel_opt.py
+++ b/inference_optimizer/tests/test_recipe_kb_kernel_opt.py
@@ -1,0 +1,87 @@
+"""Regression tests: KEEP'd kernel optimizations (incl. E2E-verified-but-
+no-gain) must be persisted into the recipe row.
+
+Bug context (overnight 12h Qwen3-32B session 20260529T132829Z):
+``k006`` rmsnorm_quant kernel optimization reached micro_speedup=1.32x,
+compiled + passed correctness, was KEEP'd, AND went through E2E integrate
+verification (new_tput=2477.82, gain_pct=-0.094%). Yet recipe.json had
+``what_worked=[]`` and no trace of k006 at all — the entire kernel-opt +
+E2E-verification outcome was dropped because ``what_worked`` is built
+ONLY from ``optimization_stack`` (which a micro-only / no-E2E-gain kernel
+never enters).
+
+These tests pin the fix: a ``kernel_optimizations`` array on the recipe
+that captures BOTH the micro result and the E2E verification outcome, so
+a future warm-start can see "k006 tried: micro 1.32x but E2E flat" and
+skip re-doing it.
+"""
+
+from __future__ import annotations
+
+from inference_optimizer.recipe_kb.schema import KernelOptimization, Recipe
+
+
+def test_kernel_optimization_roundtrip() -> None:
+    """KernelOptimization survives to_dict -> from_dict byte-for-byte."""
+    ko = KernelOptimization(
+        kernel_id="k006",
+        source_file="/sgl-workspace/aiter/csrc/kernels/rmsnorm_quant_kernels.cu",
+        artifact_path="/x/optimized_versions/v1_n128_launch_tuning.cu",
+        micro_speedup=1.3202,
+        decision="KEEP",
+        e2e_gain_pct=-0.094,
+        e2e_tput=2477.82,
+        integrated=True,
+        ts="2026-05-29T19:17:27+00:00",
+    )
+    d = ko.to_dict()
+    assert d["kernel_id"] == "k006"
+    assert d["micro_speedup"] == 1.3202
+    assert d["e2e_gain_pct"] == -0.094
+    assert d["e2e_tput"] == 2477.82
+    assert d["integrated"] is True
+    back = KernelOptimization.from_dict(d)
+    assert back == ko
+
+
+def test_recipe_carries_kernel_optimizations_roundtrip() -> None:
+    """Recipe.kernel_optimizations is a first-class field that round-trips
+    through to_dict/from_dict and lands at the top level on disk."""
+    r = Recipe(
+        canonical_id="inference:qwen-qwen3-32b:mi355x:sglang:0.5.11:bf16",
+        kernel_optimizations=[
+            KernelOptimization(
+                kernel_id="k006",
+                source_file="rmsnorm_quant_kernels.cu",
+                artifact_path="v1_n128_launch_tuning.cu",
+                micro_speedup=1.3202,
+                decision="KEEP",
+                e2e_gain_pct=-0.094,
+                e2e_tput=2477.82,
+                integrated=True,
+            ),
+        ],
+    )
+    out = r.to_dict()
+    assert "kernel_optimizations" in out, out.keys()
+    assert out["kernel_optimizations"][0]["kernel_id"] == "k006"
+    assert out["kernel_optimizations"][0]["micro_speedup"] == 1.3202
+    # Re-parse: the field must NOT get bucketed into extras.
+    back = Recipe.from_dict(out)
+    assert len(back.kernel_optimizations) == 1
+    assert back.kernel_optimizations[0].kernel_id == "k006"
+    assert back.kernel_optimizations[0].e2e_gain_pct == -0.094
+    assert "kernel_optimizations" not in back.extras
+
+
+def test_recipe_from_dict_tolerates_missing_field() -> None:
+    """Legacy recipe.json (no kernel_optimizations key) parses to []."""
+    legacy = {
+        "canonical_id": "inference:m:h:f:1.0:bf16",
+        "version": 3,
+        "what_worked": [],
+    }
+    r = Recipe.from_dict(legacy)
+    assert r.kernel_optimizations == []
+    # And re-serializing always emits the key (empty list).
+    assert r.to_dict()["kernel_optimizations"] == []

--- a/inference_optimizer/tests/test_warm_replay.py
+++ b/inference_optimizer/tests/test_warm_replay.py
@@ -487,6 +487,68 @@ def test_promote_warm_replay_failed_records_outcome(tmp_path):
 
 
 # ===========================================================================
+# Routing-gate repro (review #1): a FAILED replay_warm_recipe result must be
+# classified so the dispatcher routes it to _promote_warm_replay (which clears
+# warm_replay_outcome.status='in_flight'). Otherwise it falls to
+# _handle_unpromotable_result, which never clears the flag, and PRELUDE can
+# never exit (warm_replay_in_flight stays True) — burning the whole budget.
+#
+# The previous repro called _promote_warm_replay directly, bypassing the
+# _is_promotable_result gate that actually decides the route in
+# _pump_dispatcher_once; it gave false confidence. These assert the gate.
+# ===========================================================================
+def test_failed_replay_is_routed_to_promote_not_unpromotable(tmp_path):
+    coord = _make_coord(tmp_path, warm_start_recipe=_warm_recipe_t1())
+    # The replay reuses BaselineExecutor, so a timeout / OOM / nonzero exit
+    # surfaces as status="failed". The routing gate must NOT treat that as
+    # "unpromotable" for replay_warm_recipe, because only the promote path
+    # clears the in_flight flag.
+    assert coord._is_promotable_result(
+        "replay_warm_recipe", {"status": "failed", "error_class": "crash"},
+    ) is True, (
+        "failed replay must route to _promote_warm_replay so the in_flight "
+        "flag is cleared; otherwise PRELUDE never exits"
+    )
+    # A succeeded replay is of course promotable too.
+    assert coord._is_promotable_result(
+        "replay_warm_recipe", {"status": "succeeded", "output_throughput": 700.0},
+    ) is True
+
+
+@pytest.mark.asyncio
+async def test_failed_replay_clears_in_flight_via_full_routing(tmp_path):
+    """End-to-end through the dispatcher's promote/unpromotable decision:
+    a failed replay must leave ``warm_replay_in_flight`` False so PRELUDE
+    can exit. Mirrors the real _pump_dispatcher_once gate."""
+    from inference_optimizer.orchestrator.phase_state import (
+        warm_replay_in_flight,
+    )
+
+    coord = _make_coord(tmp_path, warm_start_recipe=_warm_recipe_t1())
+    coord.shared_state.baseline_tput = 600.0
+    coord.shared_state.warm_replay_outcome = {
+        "status": "in_flight",
+        "expected_gain_pct": 25.0,
+        "replay_task_id": "task-warm-replay-prelude",
+    }
+    assert warm_replay_in_flight(coord.shared_state) is True
+
+    failed = {"status": "failed", "error_class": "timeout", "error": "killed"}
+    task = _StubTask(kind="replay_warm_recipe")
+    # Reproduce the dispatcher decision: kept iff promotable.
+    if coord._is_promotable_result(task.kind, failed):
+        await coord._promote_to_shared_state(task.kind, failed, task=task)
+    else:
+        await coord._handle_unpromotable_result(task, failed)
+
+    assert warm_replay_in_flight(coord.shared_state) is False, (
+        "failed replay left warm_replay_in_flight True → PRELUDE would "
+        "never exit"
+    )
+    assert coord.shared_state.warm_replay_outcome["status"] == "failed"
+
+
+# ===========================================================================
 # PRELUDE bootstrap — serialize warm-replay before initial roofline
 # ===========================================================================
 @pytest.mark.asyncio

--- a/inference_optimizer/tests/test_warm_replay.py
+++ b/inference_optimizer/tests/test_warm_replay.py
@@ -394,9 +394,9 @@ def test_promote_warm_replay_reproduced_pushes_stack_and_updates_gain(
     assert coord.shared_state.current_best["tput"] == 738.0
 
 
-def test_promote_warm_replay_drift_does_not_push_stack(tmp_path):
-    """Measured gain below the reproduce threshold → tag as ``drift``
-    but do NOT push onto stack (let EXPLORE start from clean baseline)."""
+def test_promote_warm_replay_adopts_on_any_positive_gain(tmp_path):
+    """Any replay tput above baseline seeds the stack (policy A), even
+    when below the historical reproduce bar."""
     coord = _make_coord(tmp_path, warm_start_recipe=_warm_recipe_t1())
     coord.shared_state.warm_replay_outcome = {
         "status": "in_flight",
@@ -405,16 +405,37 @@ def test_promote_warm_replay_drift_does_not_push_stack(tmp_path):
     }
     task = _StubTask(params={
         "extra_sglang_args": "--attention-backend AITER",
+        "baseline_tput_anchor": 600.0,
     })
-    # 10% gain — well below 25% × 0.8 = 20% threshold.
+    # +10% vs baseline; below 25% × 0.8 historical bar but still adopted.
     result = {"status": "succeeded", "output_throughput": 660.0}
     coord._promote_warm_replay(result, task=task)
 
     outcome = coord.shared_state.warm_replay_outcome
-    assert outcome["status"] == "drift"
+    assert outcome["status"] == "reproduced"
     assert outcome["actual_gain_pct"] == 10.0
-    assert "below" in outcome["reason"]
-    # NO stack push.
+    assert outcome.get("below_historical_reproduce_pct") is True
+    assert len(coord.shared_state.optimization_stack) == 1
+    assert coord.shared_state.current_best["action"] == "warm_replay"
+
+
+def test_promote_warm_replay_no_gain_is_drift(tmp_path):
+    """Zero or negative measured gain → ``drift``, no stack push."""
+    coord = _make_coord(tmp_path, warm_start_recipe=_warm_recipe_t1())
+    coord.shared_state.warm_replay_outcome = {
+        "status": "in_flight",
+        "expected_gain_pct": 25.0,
+        "warm_recipe_tier": "exact",
+    }
+    task = _StubTask(params={
+        "extra_sglang_args": "--attention-backend AITER",
+        "baseline_tput_anchor": 600.0,
+    })
+    result = {"status": "succeeded", "output_throughput": 600.0}
+    coord._promote_warm_replay(result, task=task)
+
+    outcome = coord.shared_state.warm_replay_outcome
+    assert outcome["status"] == "drift"
     assert coord.shared_state.optimization_stack == []
     assert coord.shared_state.cumulative_gain == 0.0
 

--- a/inference_optimizer/tests/test_warm_replay.py
+++ b/inference_optimizer/tests/test_warm_replay.py
@@ -48,6 +48,9 @@ class _StubSharedState:
     warm_replay_attempted: bool = False
     warm_replay_outcome: dict = field(default_factory=dict)
     warm_history_injected: bool = False
+    auto_roofline_pending_task_id: str = ""
+    enable_roofline: bool = True
+    last_baseline: dict = field(default_factory=dict)
     explore_search: dict = field(default_factory=dict)
     optimization_stack: list = field(default_factory=list)
     gain_per_stack_entry: list = field(default_factory=list)
@@ -454,6 +457,49 @@ def test_promote_warm_replay_failed_records_outcome(tmp_path):
     assert "GPU OOM" in outcome["reason"]
     # No stack push on failure.
     assert coord.shared_state.optimization_stack == []
+
+
+# ===========================================================================
+# PRELUDE bootstrap — serialize warm-replay before initial roofline
+# ===========================================================================
+@pytest.mark.asyncio
+async def test_prelude_initial_analysis_deferred_while_warm_replay_in_flight(
+    tmp_path,
+):
+    """Initial roofline must not enqueue while KB replay is still running."""
+    coord = _make_coord(tmp_path, warm_start_recipe=_warm_recipe_t1())
+    coord.shared_state.baseline_tput = 600.0
+    await coord._maybe_enqueue_warm_replay(baseline_tput=600.0)
+    assert coord.shared_state.warm_replay_outcome["status"] == "in_flight"
+    assert len(coord.tasks.calls) == 1
+
+    await coord._maybe_enqueue_prelude_initial_analysis_after_baseline(
+        baseline_tput=600.0,
+    )
+    assert len(coord.tasks.calls) == 1
+    assert not coord.shared_state.auto_roofline_pending_task_id
+
+
+@pytest.mark.asyncio
+async def test_prelude_initial_analysis_enqueued_after_warm_replay_finishes(
+    tmp_path,
+):
+    """Deferred initial roofline enqueues once warm-replay outcome settles."""
+    coord = _make_coord(tmp_path, warm_start_recipe=_warm_recipe_t1())
+    coord.shared_state.baseline_tput = 600.0
+    await coord._maybe_enqueue_warm_replay(baseline_tput=600.0)
+    coord._promote_warm_replay(
+        {"status": "failed", "error_class": "crash", "error": "killed"},
+        task=_StubTask(),
+    )
+    assert coord.shared_state.warm_replay_outcome["status"] == "failed"
+
+    await coord._maybe_enqueue_prelude_initial_analysis_after_baseline()
+    assert len(coord.tasks.calls) == 2
+    assert coord.tasks.calls[1]["idempotency_key"] == (
+        "internal-analysis-prelude_initial"
+    )
+    assert coord.shared_state.auto_roofline_pending_task_id
 
 
 # ===========================================================================

--- a/kernel-agent/tools/apply_kernel_patch.py
+++ b/kernel-agent/tools/apply_kernel_patch.py
@@ -22,14 +22,43 @@ COMPILED_SOURCE_SUFFIXES = {".c", ".cc", ".cpp", ".cu", ".cuh", ".h", ".hpp", ".
 PYTHON_SOURCE_SUFFIXES = {".py"}
 COMPILED_ARTIFACT_SUFFIXES = {".so", ".co", ".hsaco"}
 TEXT_ARTIFACT_SUFFIXES = {".txt", ".md", ".markdown", ".log", ".patch", ".diff"}
-KNOWN_TARGET_ROOTS = (
+# Fallback when ``inference_optimizer`` is not on ``sys.path`` (standalone CLI).
+_FALLBACK_KNOWN_TARGET_ROOTS: tuple[str, ...] = (
     "/sgl-workspace/aiter/",
     "/sgl-workspace/sglang/",
     "/sgl-workspace/vllm/",
     "/opt/venv/lib/python3.10/site-packages/aiter/",
     "/opt/venv/lib/python3.10/site-packages/sglang/",
     "/opt/venv/lib/python3.10/site-packages/vllm/",
+    "/usr/local/lib/python3.12/dist-packages/aiter/",
+    "/usr/local/lib/python3.12/dist-packages/sglang/",
+    "/usr/local/lib/python3.12/dist-packages/vllm/",
+    "/usr/local/lib/python3.10/dist-packages/aiter/",
+    "/usr/local/lib/python3.10/dist-packages/sglang/",
+    "/usr/local/lib/python3.10/dist-packages/vllm/",
 )
+
+_CACHED_KNOWN_TARGET_ROOTS: tuple[str, ...] | None = None
+
+
+def known_target_roots() -> tuple[str, ...]:
+    """Resolved framework roots (importlib/glob when orchestrator is importable)."""
+    global _CACHED_KNOWN_TARGET_ROOTS
+    if _CACHED_KNOWN_TARGET_ROOTS is not None:
+        return _CACHED_KNOWN_TARGET_ROOTS
+    try:
+        from inference_optimizer.orchestrator.framework_paths import (
+            resolve_patch_target_roots,
+        )
+
+        _CACHED_KNOWN_TARGET_ROOTS = resolve_patch_target_roots()
+    except ImportError:
+        _CACHED_KNOWN_TARGET_ROOTS = _FALLBACK_KNOWN_TARGET_ROOTS
+    return _CACHED_KNOWN_TARGET_ROOTS
+
+
+# Backward-compat alias for tests / external imports.
+KNOWN_TARGET_ROOTS = _FALLBACK_KNOWN_TARGET_ROOTS
 
 
 # Default location of the multi-node patch backup directory on the
@@ -492,7 +521,8 @@ def _restore_aiter_jit_build(jit_build_backup: dict[str, Any]) -> dict[str, Any]
 def _detect_strategy(target_file: Path, *, allow_unknown_target: bool) -> dict[str, Any]:
     target = str(target_file)
     lower = target.lower()
-    if not allow_unknown_target and not any(root in lower for root in KNOWN_TARGET_ROOTS):
+    roots = known_target_roots()
+    if not allow_unknown_target and not any(root in lower for root in roots):
         raise ValueError(f"target_file is outside known reusable source roots: {target_file}")
 
     suffix = target_file.suffix.lower()

--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -685,33 +685,19 @@ _COMPILE_GENERATED_NAME_MARKERS = (
     "torchinductor",
     "inductor",
 )
-_REUSABLE_SOURCE_ROOTS = (
-    "/sgl-workspace/aiter/",
-    "/sgl-workspace/sglang/",
-    "/sgl-workspace/vllm/",
-    "/opt/venv/lib/python3.10/site-packages/aiter/",
-    "/opt/venv/lib/python3.10/site-packages/sglang/",
-    "/opt/venv/lib/python3.10/site-packages/vllm/",
-    # Production vLLM wheel install layout (system dist-packages).
-    # Required since vLLM in the current image ships under
-    # ``/usr/local/lib/python3.12/dist-packages/vllm/`` rather than the
-    # editable ``/sgl-workspace/vllm/`` checkout the legacy entries
-    # assumed. The python3.10 fallback covers older images where the
-    # interpreter has not yet been bumped.
-    "/usr/local/lib/python3.12/dist-packages/aiter/",
-    "/usr/local/lib/python3.12/dist-packages/sglang/",
-    "/usr/local/lib/python3.12/dist-packages/vllm/",
-    "/usr/local/lib/python3.10/dist-packages/aiter/",
-    "/usr/local/lib/python3.10/dist-packages/sglang/",
-    "/usr/local/lib/python3.10/dist-packages/vllm/",
-    # aiter ships its device sources (.cu/.cuh) in the sibling ``aiter_meta``
-    # package (``<...>/aiter_meta/csrc/``), NOT under ``aiter/`` — so the
-    # ``aiter/`` entries above never match a resolved device source.
-    # ``_reusable_roots()`` also adds aiter's own ``AITER_CSRC_DIR`` at
-    # runtime; this static substring covers the common wheel layout when
-    # aiter cannot be imported for the dynamic probe.
-    "/aiter_meta/csrc/",
-)
+@functools.lru_cache(maxsize=1)
+def _framework_patch_roots() -> tuple[str, ...]:
+    """Framework install roots (shared with PolicyGate / apply_kernel_patch)."""
+    try:
+        from inference_optimizer.orchestrator.framework_paths import (
+            resolve_patch_target_roots,
+        )
+
+        return resolve_patch_target_roots()
+    except ImportError:
+        from apply_kernel_patch import known_target_roots
+
+        return known_target_roots()
 
 
 @functools.lru_cache(maxsize=1)
@@ -728,13 +714,12 @@ def _aiter_csrc_root() -> str:
 
 
 def _reusable_roots() -> tuple[str, ...]:
-    """Static reusable roots plus aiter's own (dynamic) csrc root, so a device
-    source resolved via aiter's build registry counts as reusable regardless
-    of where the wheel placed ``aiter_meta``."""
+    """Discovered framework roots plus aiter's own (dynamic) csrc root."""
+    roots = _framework_patch_roots()
     csrc = _aiter_csrc_root()
-    if csrc and csrc not in _REUSABLE_SOURCE_ROOTS:
-        return _REUSABLE_SOURCE_ROOTS + (csrc,)
-    return _REUSABLE_SOURCE_ROOTS
+    if csrc and csrc not in roots:
+        return roots + (csrc,)
+    return roots
 # Kernel-name substrings that mark an operation as non-patchable regardless
 # of source-file resolution: vendor BLAS routines, RCCL/NCCL collectives,
 # raw memcpy/copy ops, and PyTorch native copy. Folded from the feature


### PR DESCRIPTION
Close #332 
## Summary

Fixes a cluster of Knowledge-Base (recipe.json) write-back bugs in the
Coordinator CLOSE path, plus makes framework source-root discovery dynamic
so kernel patches against wheel installs (`/usr/local/.../dist-packages/vllm`)
are no longer rejected. Now merged up to latest `main` (atom support +
`extra_server_args` rename adopted).

### KB write-back correctness
- **best_config / best_throughput**: a flagless baseline whose tput merely
  exceeded a historical best (different workload shape) passed the numeric
  guard and clobbered the validated config, dropping every `extra_sglang_args`.
  Now gated on a real validated win (non-empty stack / positive validated gain
  / current_best carrying launch flags). Repro: session `20260531T144553Z`
  (2813@isl256 clobbered 2532@isl1024).
- **kernel `e2e_decision`**: the integrate verdict (KEEP/REVERT/NEEDS_REVIEW)
  was dropped; the row only showed the micro-layer `decision=KEEP`, hiding that
  a patch was reverted at E2E. New `e2e_decision` field carries it.
- **kernel `source_file`**: read from the real ledger key `last_source_file`
  (was always empty, so warm-start could not relocate the patched source).
- **sessions[]**: populate `throughput_before/after`, `date`, `actions_taken`
  (were always 0.0 / "" / []).
- **pitfall/lesson description**: an empty variant dict made `summarize_change`
  fall back to the bare task kind ("explore"), producing indistinguishable
  rows; now falls back to the variant name.
- **cumulative extra_sglang_args**: prevent double-stacking corrupting
  multi-value knobs (e.g. `--cuda-graph-bs`) on KEEP.

### Framework source-root discovery
- `framework_paths.py`: dynamic importlib + `lib/python*/{site,dist}-packages`
  glob discovery, unified via `resolve_patch_target_roots()`, shared by
  PolicyGate, `apply_kernel_patch`, and the tracelens classifier (no more
  hand-maintained duplicate static lists). atom included.
- Fixes kernel-patch rejection: `target_file is outside known reusable source
  roots: /usr/local/lib/python3.12/dist-packages/vllm/...`.

### Orchestration robustness (earlier commits on this branch)
- serialize warm-replay before the PRELUDE roofline;
- steward infra-failure retry instead of false `no_more_leverage` stop;
- adopt the KB stack on any measured warm-replay uplift.

## Merge / conflict notes
Merged `origin/main` (atom support, `extra_sglang_args -> extra_server_args`
rename). Resolved 6 conflicts keeping this branch's dynamic discovery + KB
fixes while adopting main's rename. Also restored a dropped `import functools`
in `tracelens_analysis.py` (latent break the merge surfaced).

## Test plan
- [x] Full `inference_optimizer` suite run locally and diffed against
      `origin/main`: **introduces zero new failures**; additionally **fixes 2
      tests that `main` itself fails** (atom roots in sync).
- [x] 7 remaining failures are **all pre-existing on `main`** (gemm_tuning
      invariant, atom repo_url, watermark resolver, no_legacy_writer lint,
      close_sequencer) — not introduced by this PR. `main`'s own
      "Tests with Coverage" run is currently red for the same reasons.
- [x] New repro tests for every KB write-back bug in
      `test_coordinator_kb_writes.py`; dynamic-discovery tests in
      `test_framework_paths_units.py` / `test_apply_kernel_patch_roots.py`.

Made with [Cursor](https://cursor.com)