### PR TITLE
fix(ci): use sglang profilerfix images for HipGraphLaunch kernel capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,12 @@ Local Mode runs Hyperloom in a remote AMD GPU environment, then uses Cursor to c
 
 You need an AMD GPU machine that supports MI300X or MI355X, using an SGLang or vLLM ROCm inference image. Example images:
 
-- SGLang MI300X: `lmsysorg/sglang:v0.5.11-rocm720-mi30x`
-- SGLang MI355X: `lmsysorg/sglang:v0.5.11-rocm720-mi35x`
+- SGLang MI300X: `harbor.core42.primus-safe.amd.com/proxy/primussafe/sglang:v0.5.11-rocm720-mi30x-profilerfix`
+- SGLang MI355X: `harbor.core42.primus-safe.amd.com/proxy/primussafe/sglang:v0.5.11-rocm720-mi35x-profilerfix`
 - vLLM MI300X: `vllm/vllm-openai-rocm:v0.19.0`
 - vLLM MI355X: `vllm/vllm-openai-rocm:v0.19.0`
+
+> The SGLang `-profilerfix` images patch `libamdhip64`/`libroctracer` so rocprofiler captures kernels launched under HipGraphLaunch (issue #352). Use the stock `lmsysorg/sglang:v0.5.11-rocm720-*` images once that fix lands upstream in ROCm.
 
 Choose one environment:
 
@@ -90,7 +92,7 @@ docker run -d \
   --group-add video \
   -v /path/to/workspace:/workspace \
   -v /path/to/models:/models \
-  lmsysorg/sglang:v0.5.11-rocm720-mi30x \
+  harbor.core42.primus-safe.amd.com/proxy/primussafe/sglang:v0.5.11-rocm720-mi30x-profilerfix \
   tail -f /dev/null
 ```
 

--- a/ci/ci-config.yaml
+++ b/ci/ci-config.yaml
@@ -128,7 +128,9 @@ models:
   - key: glm5-multinode-fp8-mi300x-sglang
     model_hf: zai-org/GLM-5
     model_path_override: ${NFS_ROOT}/models/zai-org-GLM-5
-    image: lmsysorg/sglang:v0.5.11-rocm720-mi30x
+    # profilerfix: rocprofiler captures HipGraphLaunch kernels (issue #352)
+    # Pre-profilerfix image (restore when reverting): lmsysorg/sglang:v0.5.11-rocm720-mi30x
+    image: primussafe/sglang:v0.5.11-rocm720-mi30x-profilerfix
     framework: sglang
     precision: fp8
     conc: 64

--- a/ci/import_session_breakdown.py
+++ b/ci/import_session_breakdown.py
@@ -84,7 +84,9 @@ IMPORTER_VERSION = "1.1.0"
 # ---------------------------------------------------------------------------
 
 DEFAULT_IMAGES: Dict[str, str] = {
-    "sglang": "harbor.core42.primus-safe.amd.com/proxy/lmsysorg/sglang:v0.5.11-rocm720-mi30x",
+    # sglang profilerfix: rocprofiler captures HipGraphLaunch kernels (issue #352)
+    # Pre-profilerfix image (restore when reverting): "harbor.core42.primus-safe.amd.com/proxy/lmsysorg/sglang:v0.5.11-rocm720-mi30x"
+    "sglang": "harbor.core42.primus-safe.amd.com/proxy/primussafe/sglang:v0.5.11-rocm720-mi30x-profilerfix",
     "vllm":   "harbor.core42.primus-safe.amd.com/proxy/vllm/vllm-openai-rocm:v0.19.0",
 }
 

--- a/ci/inferenceX_parser.py
+++ b/ci/inferenceX_parser.py
@@ -90,7 +90,7 @@ def synthesize_entry_from_ci_config(model_cfg: dict) -> dict:
 
     Required fields in ``model_cfg``:
       - ``model_hf``           HF repo (e.g., ``zai-org/GLM-5``)
-      - ``image``              container image tag (e.g., ``lmsysorg/sglang:v0.5.11-rocm720-mi30x``)
+      - ``image``              container image tag (e.g., ``primussafe/sglang:v0.5.11-rocm720-mi30x-profilerfix``)
       - ``framework``          ``sglang`` or ``vllm``
       - ``precision``          ``fp8`` / ``fp4`` / ``bf16``
       - ``conc``               concurrency cap

--- a/ci/optimize_submit.py
+++ b/ci/optimize_submit.py
@@ -227,8 +227,10 @@ def _proxy() -> str:
 
 def _default_sglang_image() -> str:
     # v0.5.11 (2026-05-05): Spec V2 by default + DFLASH on ROCm + all-reduce/RMSNorm fusion.
-    # Confirmed available at harbor.core42.primus-safe.amd.com/proxy/lmsysorg/sglang.
-    return f"{_proxy()}/lmsysorg/sglang:v0.5.11-rocm720-mi30x"
+    # profilerfix: patched libamdhip64/libroctracer so rocprofiler captures kernels under
+    # HipGraphLaunch (issue #352). Drop the suffix once the fix lands in upstream ROCm.
+    # Pre-profilerfix image (restore when reverting): f"{_proxy()}/lmsysorg/sglang:v0.5.11-rocm720-mi30x"
+    return f"{_proxy()}/primussafe/sglang:v0.5.11-rocm720-mi30x-profilerfix"
 
 
 def _default_vllm_image() -> str:

--- a/docs/INTEGRATION_SESSION_BREAKDOWN.md
+++ b/docs/INTEGRATION_SESSION_BREAKDOWN.md
@@ -283,7 +283,7 @@ investigation than the breakdown summarises.
     "pid": 12345,
     "session_dir": "/workspace/hyperloom",
     "tick_count": 89,
-    "image": "lmsysorg/sglang:v0.5.11-rocm720-mi30x"
+    "image": "lmsysorg/sglang:v0.5.11-rocm720-mi30x-profilerfix"
   },
 
   "workload": {


### PR DESCRIPTION
#352 

The stock lmsysorg/sglang:v0.5.11-rocm720-* images ship a rocprofiler that misses kernels launched under HipGraphLaunch, leaving optimization-loop traces (TraceLens / session breakdown / roofline) incomplete. Switch the default sglang runtime image to the patched primussafe/sglang *-profilerfix builds, which carry fixed libamdhip64/libroctracer.

Old images kept in inline comments so they can be restored once the fix lands in upstream ROCm.
