### PR TITLE
[Feat] advisory multi-model proposal scorer

### DIFF
--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -786,7 +786,7 @@ def _build_proposal_scorer(
 
     Returns ``None`` when ``--no-proposal-scoring`` is set or the
     resolved model list is empty. Models default to
-    :data:`DEFAULT_SCORER_MODELS` (``claude-opus-4-7,gpt-5.4``). Adding a
+    :data:`DEFAULT_SCORER_MODELS` (``claude-opus-4-8,gpt-5.5``). Adding a
     model = appending its gateway slug to ``--proposal-scorer-models``.
     The scorer is purely advisory and never gates anything.
     """
@@ -5336,7 +5336,7 @@ def _build_parser() -> argparse.ArgumentParser:
         default=",".join(DEFAULT_SCORER_MODELS),
         help="Comma-separated gateway model slugs that independently "
              "score each specialist proposal_set (advisory only; never "
-             "gates). Default 'claude-opus-4-7,gpt-5.4'. Add a model by "
+             "gates). Default 'claude-opus-4-8,gpt-5.5'. Add a model by "
              "appending its slug. Empty list disables scoring.",
     )
     opt.add_argument(

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -786,8 +786,8 @@ def _build_proposal_scorer(
 
     Returns ``None`` when ``--no-proposal-scoring`` is set or the
     resolved model list is empty. Models default to
-    :data:`DEFAULT_SCORER_MODELS`
-    (``claude-opus-4-8,claude-opus-4-7,gpt-5.5,dvue-aoai-005-Kimi-K2.6``).
+    :data:`DEFAULT_SCORER_MODELS` (``claude-opus-4-8,gpt-5.5,
+    dvue-aoai-005-Kimi-K2.6,gemini/gemini-3.1-pro-preview``).
     Adding a
     model = appending its gateway slug to ``--proposal-scorer-models``.
     The scorer is purely advisory and never gates anything.
@@ -5365,8 +5365,8 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Comma-separated gateway model slugs that independently "
              "score each specialist proposal_set (advisory only; never "
              "gates; rater identities are anonymized in the orchestration "
-             "prompt). Default "
-             "'claude-opus-4-8,claude-opus-4-7,gpt-5.5,dvue-aoai-005-Kimi-K2.6'. "
+             "prompt). Default 'claude-opus-4-8,gpt-5.5,"
+             "dvue-aoai-005-Kimi-K2.6,gemini/gemini-3.1-pro-preview'. "
              "Add a model by "
              "appending its slug. Empty list disables scoring.",
     )

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -73,6 +73,7 @@ from .orchestrator.backends import (
 from .manifest import load_manifest, write_manifest
 from .orchestrator.action_registry import ActionRegistry
 from .orchestrator.coordinator import Coordinator
+from .orchestrator.proposal_scorer import DEFAULT_SCORER_MODELS, ProposalScorer
 from .orchestrator.cortex_t0 import run_t0_anchor
 from .orchestrator.framework_paths import resolve_source_file_allowlist
 from .orchestrator.objective import Objective, build_objective
@@ -776,6 +777,31 @@ def _build_backends(
         else:
             backends["kernel"] = ClaudeBackend(model=claude_model, max_turns_default=4)
     return backends
+
+
+def _build_proposal_scorer(
+    args: argparse.Namespace,
+) -> ProposalScorer | None:
+    """Construct the advisory specialist-proposal scorer, or ``None``.
+
+    Returns ``None`` when ``--no-proposal-scoring`` is set or the
+    resolved model list is empty. Models default to
+    :data:`DEFAULT_SCORER_MODELS` (``claude-opus-4-7,gpt-5.4``). Adding a
+    model = appending its gateway slug to ``--proposal-scorer-models``.
+    The scorer is purely advisory and never gates anything.
+    """
+    if getattr(args, "no_proposal_scoring", False):
+        return None
+    raw = getattr(args, "proposal_scorer_models", None)
+    if raw is None:
+        models = tuple(DEFAULT_SCORER_MODELS)
+    else:
+        models = tuple(
+            m for m in (s.strip() for s in str(raw).split(",")) if m
+        )
+    if not models:
+        return None
+    return ProposalScorer(models=models)
 
 
 def _resume_safe_flag(
@@ -4429,6 +4455,11 @@ async def _run_optimize(args: argparse.Namespace) -> int:
         # ``None`` when --degraded-kb; otherwise wraps Cortex KB +
         # PR Monitor for specialist prompt assembly.
         knowledge_plane=knowledge_plane,
+        # Advisory multi-model specialist-proposal scorer. ``None`` when
+        # --no-proposal-scoring or an empty model list; otherwise scores
+        # each proposal_set and surfaces the results to Orchestration as
+        # one reference among many (never gates anything).
+        proposal_scorer=_build_proposal_scorer(args),
         # GAP 1 — Warm-recipe replay controls. Default ON, fires when
         # warm_start_recipe.confidence >= min_confidence and the
         # measured gain reproduces at least min_reproduce_pct of the
@@ -5290,6 +5321,29 @@ def _build_parser() -> argparse.ArgumentParser:
              "the PR-A3 default (Arbor-into-Hyperloom); 6 is the M6 "
              "hard cap. Range [0, 6]; values above 6 are silently "
              "clamped down. Locked at session start.",
+    )
+    # ------------------------------------------------------------------
+    # Advisory specialist-proposal scorer (ProposalScorer). Scores each
+    # specialist proposal_set with one or more gateway models (single
+    # 0-10 composite + one-line reason) and surfaces the results to
+    # Orchestration as one reference among many — never gates anything.
+    # Adding a model = appending its gateway slug to the comma list.
+    # ------------------------------------------------------------------
+    opt.add_argument(
+        "--proposal-scorer-models",
+        dest="proposal_scorer_models",
+        type=str,
+        default=",".join(DEFAULT_SCORER_MODELS),
+        help="Comma-separated gateway model slugs that independently "
+             "score each specialist proposal_set (advisory only; never "
+             "gates). Default 'claude-opus-4-7,gpt-5.4'. Add a model by "
+             "appending its slug. Empty list disables scoring.",
+    )
+    opt.add_argument(
+        "--no-proposal-scoring",
+        dest="no_proposal_scoring",
+        action="store_true",
+        help="Disable the advisory specialist-proposal scorer entirely.",
     )
     # ------------------------------------------------------------------
     # v0.8 §3.5 / §3.13 M5 + specialist sub-agent

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -786,7 +786,8 @@ def _build_proposal_scorer(
 
     Returns ``None`` when ``--no-proposal-scoring`` is set or the
     resolved model list is empty. Models default to
-    :data:`DEFAULT_SCORER_MODELS` (``claude-opus-4-8,gpt-5.5``). Adding a
+    :data:`DEFAULT_SCORER_MODELS`
+    (``claude-opus-4-8,claude-opus-4-7,gpt-5.5,gpt-5.4``). Adding a
     model = appending its gateway slug to ``--proposal-scorer-models``.
     The scorer is purely advisory and never gates anything.
     """
@@ -5362,7 +5363,9 @@ def _build_parser() -> argparse.ArgumentParser:
         default=",".join(DEFAULT_SCORER_MODELS),
         help="Comma-separated gateway model slugs that independently "
              "score each specialist proposal_set (advisory only; never "
-             "gates). Default 'claude-opus-4-8,gpt-5.5'. Add a model by "
+             "gates; rater identities are anonymized in the orchestration "
+             "prompt). Default "
+             "'claude-opus-4-8,claude-opus-4-7,gpt-5.5,gpt-5.4'. Add a model by "
              "appending its slug. Empty list disables scoring.",
     )
     opt.add_argument(

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -787,7 +787,8 @@ def _build_proposal_scorer(
     Returns ``None`` when ``--no-proposal-scoring`` is set or the
     resolved model list is empty. Models default to
     :data:`DEFAULT_SCORER_MODELS`
-    (``claude-opus-4-8,claude-opus-4-7,gpt-5.5,gpt-5.4``). Adding a
+    (``claude-opus-4-8,claude-opus-4-7,gpt-5.5,dvue-aoai-005-Kimi-K2.6``).
+    Adding a
     model = appending its gateway slug to ``--proposal-scorer-models``.
     The scorer is purely advisory and never gates anything.
     """
@@ -5365,7 +5366,8 @@ def _build_parser() -> argparse.ArgumentParser:
              "score each specialist proposal_set (advisory only; never "
              "gates; rater identities are anonymized in the orchestration "
              "prompt). Default "
-             "'claude-opus-4-8,claude-opus-4-7,gpt-5.5,gpt-5.4'. Add a model by "
+             "'claude-opus-4-8,claude-opus-4-7,gpt-5.5,dvue-aoai-005-Kimi-K2.6'. "
+             "Add a model by "
              "appending its slug. Empty list disables scoring.",
     )
     opt.add_argument(

--- a/inference_optimizer/orchestrator/action_executors/framework_pr.py
+++ b/inference_optimizer/orchestrator/action_executors/framework_pr.py
@@ -149,16 +149,30 @@ def _git_reset_hard(framework_root: Path, sha: str) -> tuple[bool, str]:
 def _git_commit_keep(
     framework_root: Path, message: str,
 ) -> tuple[str | None, str]:
-    """``git commit -am <message>`` with hyperloom identity, then return
-    the new HEAD sha. Identity is forced via ``-c`` so callers don't need
-    to depend on whatever user.email is configured in the framework_root
-    git repo (Magpie clones may not have one)."""
+    """``git add -A && git commit -m <message>`` with hyperloom identity,
+    then return the new HEAD sha. ``add -A`` (not ``commit -am``) is used
+    so a PR that adds *new* files is captured in the KEEP commit — ``-am``
+    only stages already-tracked modifications, which would either leave a
+    new file untracked in the worktree (polluting the next candidate's
+    baseline) or fail outright for an add-only PR. Identity is forced via
+    ``-c`` so callers don't need to depend on whatever user.email is
+    configured in the framework_root git repo (Magpie clones may not have
+    one)."""
+    add = ["git", "-C", str(framework_root), "add", "-A"]
+    try:
+        cp_add = subprocess.run(
+            add, capture_output=True, text=True, timeout=60.0, check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        return None, f"git add -A spawn failed: {exc!r}"
+    if cp_add.returncode != 0:
+        return None, cp_add.stderr.strip()
     cmd = [
         "git",
         "-c", "user.email=framework-pr@hyperloom.local",
         "-c", "user.name=hyperloom framework_pr",
         "-C", str(framework_root),
-        "commit", "-am", message,
+        "commit", "-m", message,
     ]
     try:
         cp = subprocess.run(
@@ -229,6 +243,62 @@ def _run_git(
     if cp.returncode != 0:
         return False, cp.stdout or "", (cp.stderr or "").strip()
     return True, cp.stdout or "", cp.stderr or ""
+
+
+def _normalize_repo_id(url_or_slug: str) -> str:
+    """Reduce a repo URL or ``owner/name`` slug to a canonical
+    ``owner/name`` lowercase token for same-repo comparison. Tolerates
+    ``https://github.com/Owner/Name.git``, ``git@github.com:Owner/Name``,
+    and a bare ``Owner/Name``."""
+    s = (url_or_slug or "").strip().lower()
+    if not s:
+        return ""
+    s = s.rstrip("/")
+    if s.endswith(".git"):
+        s = s[:-4]
+    # Strip scheme / host so only the trailing owner/name remains.
+    for sep in ("github.com/", "github.com:"):
+        if sep in s:
+            s = s.split(sep, 1)[1]
+            break
+    parts = [p for p in s.split("/") if p]
+    if len(parts) >= 2:
+        return "/".join(parts[-2:])
+    return s
+
+
+def _candidate_is_same_repo(
+    candidate: dict[str, Any], framework_root: Path,
+) -> bool:
+    """True unless we can POSITIVELY prove the candidate lives in a
+    different repo than the live framework_root's origin (in which case
+    checkout-head's ``git fetch origin`` would resolve the wrong ref).
+
+    Fails OPEN (returns True) whenever the comparison is inconclusive:
+    no candidate repo, unreadable origin, or an origin that is not a
+    GitHub-style ``owner/name`` URL (e.g. a local-path clone). The guard
+    only fires when BOTH sides yield an ``owner/name`` token and they
+    differ — so a normal single-repo session is never downgraded."""
+    cand_repo = _normalize_repo_id(
+        str(candidate.get("repo") or candidate.get("discovered_repo_url") or "")
+    )
+    # A candidate repo token without an owner/name shape can't be compared.
+    if not cand_repo or "/" not in cand_repo:
+        return True
+    ok, out, _err = _run_git(
+        ["-C", str(framework_root), "remote", "get-url", "origin"],
+        timeout=30.0,
+    )
+    if not ok or not out.strip():
+        return True
+    origin_raw = out.strip()
+    # Only a GitHub-style origin gives an owner/name token directly
+    # comparable to the candidate's ``repo`` slug. A local-path / mirror
+    # / non-GitHub origin is inconclusive → fail open (don't downgrade a
+    # legitimate same-repo session whose clone uses a local path).
+    if "github.com" not in origin_raw.lower():
+        return True
+    return _normalize_repo_id(origin_raw) == cand_repo
 
 
 def _materialize_pr_diff_via_worktree(
@@ -475,6 +545,21 @@ class FrameworkPrExecutor:
             use_checkout_head = explicit_checkout or (
                 not diff_url and has_checkout_ref
             )
+            # Same-repo guard: checkout-head fetches the candidate's ref
+            # from the LIVE framework_root's origin, so it only works when
+            # the PR lives in that same repo. A cross-repo candidate (e.g.
+            # a ROCm/vllm PR while the live tree is sglang) would fetch the
+            # wrong ref, so disable checkout-head and rely on diff_url.
+            if use_checkout_head and not _candidate_is_same_repo(
+                candidate, framework_root,
+            ):
+                log.info(
+                    "framework_pr: candidate repo %r differs from live "
+                    "framework_root origin; disabling checkout-head, "
+                    "using diff_url",
+                    candidate.get("repo") or candidate.get("discovered_repo_url"),
+                )
+                use_checkout_head = False
             if not diff_url and not use_checkout_head:
                 # No served diff and nothing to check out → genuine
                 # no-patch (preserves the pre-checkout-head contract).
@@ -602,6 +687,7 @@ class FrameworkPrExecutor:
                 "batch_id": batch_id,
                 "patches_applied": [str(p) for p in applied],
                 "patches_reverted": [],
+                "patch_source_mode": patch_source_mode,
                 "reason": "apply_only=True; benchmark skipped",
                 "workspace": str(output_root),
             }

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -593,6 +593,7 @@ class Coordinator:
         cortex_kb: RecipeKB | None = None,
         phase_budget_pct: dict[str, float] | None = None,
         knowledge_plane: Any = None,
+        proposal_scorer: Any = None,
         warm_replay_enabled: bool = True,
         warm_replay_min_confidence: float = 0.7,
         warm_replay_min_reproduce_pct: float = 0.8,
@@ -632,6 +633,14 @@ class Coordinator:
         # (no warmup; specialist still runs but sees empty knowledge
         # surface).
         self.knowledge_plane: Any = knowledge_plane
+        # ProposalScorer facade (advisory). When non-None, a non-empty
+        # specialist ``proposal_set`` is scored by one or more gateway
+        # models in ``_record_specialist_result``; the scores ride on
+        # the specialist round entry under ``ensemble_scores`` and are
+        # surfaced to Orchestration as one reference among many (parallel
+        # to gaps / KB / analysis.md). ``None`` keeps the legacy path
+        # (no scoring). Never gates anything (Inv-9.1: no scoreboard).
+        self._proposal_scorer: Any = proposal_scorer
         # phase budget percentages (KB_design §3.8 §5.3 +
         # §3.13 M2 §7). ``None`` means library defaults; CLI flags
         # populate this dict from ``--max-minutes-<phase>-pct``. We
@@ -4660,6 +4669,18 @@ class Coordinator:
             if gaps_block:
                 sections.append("=== Current gaps ===")
                 sections.append(gaps_block)
+            # Advisory multi-model proposal scores (ProposalScorer).
+            # One reference among many — parallel to gaps / KB /
+            # analysis.md, NOT a ranking directive (Inv-9.1). Section
+            # omitted entirely when no recent round carries scores.
+            try:
+                scores_block = self.shared_state.to_proposal_scores_summary()
+            except Exception:  # noqa: BLE001 — defensive
+                log.exception("Coordinator: proposal_scores_summary failed")
+                scores_block = ""
+            if scores_block:
+                sections.append("=== Specialist proposal scores (advisory) ===")
+                sections.append(scores_block)
 
         # Robustness gets a phase budget telemetry +
         # specialist health block so it can fire the medium-severity
@@ -8233,6 +8254,33 @@ class Coordinator:
         round_entry = self._build_specialist_round_entry(
             task=task, done_payload=done_payload, source=source,
         )
+        # Advisory multi-model scoring of the proposal_set. Purely
+        # informational — the scores ride on the round entry and surface
+        # to Orchestration as one reference among many; they gate
+        # nothing. Defensive: any scorer failure leaves the entry
+        # score-free and the run continues unchanged.
+        _scorer = getattr(self, "_proposal_scorer", None)
+        if _scorer is not None and proposals:
+            try:
+                scores = await _scorer.score(
+                    gap={
+                        "domain": domain,
+                        "gap_canonical_id": done_payload.get(
+                            "gap_canonical_id", ""
+                        ),
+                        "gap_symptom": (task.params or {}).get("gap_symptom"),
+                        "gap_evidence": (task.params or {}).get("gap_evidence"),
+                        "summary": done_payload.get("summary", ""),
+                    },
+                    proposals=proposals,
+                )
+                if scores and scores.get("models"):
+                    round_entry["ensemble_scores"] = scores
+            except Exception:  # noqa: BLE001 — advisory; never block
+                log.exception(
+                    "specialist bookkeeping: proposal scoring failed for "
+                    "task=%s (continuing without scores)", task.task_id,
+                )
         try:
             self.shared_state.record_specialist_round(round_entry)
         except Exception:  # noqa: BLE001

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -1874,6 +1874,7 @@ class Coordinator:
         # PR that another repo's serving overlap already produced, padding
         # the batch with duplicates that the plateau judge then counts.
         seen_ids = self._framework_pr_known_candidate_ids()
+        primary_repo_url = repo_urls[0] if repo_urls else ""
         # Normalise each candidate so the executor's slug helper has
         # consistent fields and the progress ledger has a stable id.
         norm: list[dict[str, Any]] = []
@@ -1887,10 +1888,21 @@ class Coordinator:
             if cand_id and cand_id in seen_ids:
                 continue
             seen_ids.add(cand_id)
+            # Stamp the repo URL the candidate came from so the executor's
+            # checkout-head path knows whether the PR lives in the live
+            # framework_root's origin (same-repo, fetchable) or a foreign
+            # repo (must fall back to diff_url). fa already returns a
+            # ``repo_url`` per candidate when known; otherwise fall back to
+            # the batch's primary repo URL.
+            discovered_repo_url = str(
+                c.get("repo_url") or c.get("discovered_repo_url")
+                or primary_repo_url
+            )
             norm.append({
                 **c,
                 "candidate_id": cand_id,
                 "batch_id": batch_id,
+                "discovered_repo_url": discovered_repo_url,
             })
         if not norm:
             return False

--- a/inference_optimizer/orchestrator/policy.py
+++ b/inference_optimizer/orchestrator/policy.py
@@ -660,6 +660,18 @@ CORE_STATE_FIELDS: frozenset[str] = frozenset({
     # outcomes via UPDATE_STATE.
     "dynamic_actions",
     "dynamic_action_round_count",
+    # FRAMEWORK_PR per-repo discovery budget. Coordinator-controlled
+    # search depth knob (mirrors research_lane_capacity's "set once,
+    # don't let the LLM raise mid-flight" intent); locking it stops a
+    # non-core role from inflating the per-batch search / bench queue
+    # via update_state.
+    "framework_pr_max_candidates",
+    # Advisory model-architecture profile. Produced pre-launch by the
+    # SKILL launcher into state.json; drives no deterministic gating but
+    # is injected into specialist prompts, so lock it to keep the
+    # launcher / state.json as the sole source of truth (an LLM
+    # update_state must not pollute the specialist prompt context).
+    "model_arch",
 })
 
 

--- a/inference_optimizer/orchestrator/proposal_scorer.py
+++ b/inference_optimizer/orchestrator/proposal_scorer.py
@@ -51,13 +51,17 @@ log = logging.getLogger(__name__)
 
 DEFAULT_SCORER_MODELS: tuple[str, ...] = (
     "claude-opus-4-8",
-    "claude-opus-4-7",
     "gpt-5.5",
-    # Kimi K2.6 is a reasoning model: it spends completion tokens on
-    # internal reasoning before emitting the JSON, so it needs the
-    # larger ``max_completion_tokens`` default below (4096) — at 1200 it
-    # returns finish_reason=length with empty content.
+    # Kimi K2.6 and Gemini 3.1 Pro are reasoning models: they spend
+    # completion tokens on internal reasoning before emitting the JSON,
+    # so they need the larger ``max_completion_tokens`` default below
+    # (4096) — at 1200 Kimi returns finish_reason=length with empty
+    # content. Gemini MUST carry the ``gemini/`` provider prefix: the
+    # bare ``gemini-3.1-pro-preview`` slug routes to a broken Vertex ADC
+    # path on the gateway (APIConnectionError), while ``gemini/…`` routes
+    # to a working backend.
     "dvue-aoai-005-Kimi-K2.6",
+    "gemini/gemini-3.1-pro-preview",
 )
 
 # Soft cap on what we feed each model so a pathological proposal_set

--- a/inference_optimizer/orchestrator/proposal_scorer.py
+++ b/inference_optimizer/orchestrator/proposal_scorer.py
@@ -53,7 +53,11 @@ DEFAULT_SCORER_MODELS: tuple[str, ...] = (
     "claude-opus-4-8",
     "claude-opus-4-7",
     "gpt-5.5",
-    "gpt-5.4",
+    # Kimi K2.6 is a reasoning model: it spends completion tokens on
+    # internal reasoning before emitting the JSON, so it needs the
+    # larger ``max_completion_tokens`` default below (4096) — at 1200 it
+    # returns finish_reason=length with empty content.
+    "dvue-aoai-005-Kimi-K2.6",
 )
 
 # Soft cap on what we feed each model so a pathological proposal_set
@@ -164,7 +168,10 @@ class ProposalScorer:
     models: tuple[str, ...] = DEFAULT_SCORER_MODELS
     api_key_env: str = "ANTHROPIC_AUTH_TOKEN"  # AMD proxy; accepts OPENAI too
     base_url_env: str = "OPENAI_BASE_URL"
-    max_completion_tokens: int = 1200
+    # 4096 (not 1200) so reasoning raters (e.g. Kimi K2.6) have room to
+    # finish their internal reasoning AND still emit the scores JSON;
+    # non-reasoning models stop early and never approach the cap.
+    max_completion_tokens: int = 4096
     call_timeout_s: float = field(
         default_factory=lambda: parse_call_timeout_env(
             "INFERENCE_OPTIMIZER_PROPOSAL_SCORER_TIMEOUT_SEC",

--- a/inference_optimizer/orchestrator/proposal_scorer.py
+++ b/inference_optimizer/orchestrator/proposal_scorer.py
@@ -1,0 +1,325 @@
+"""ProposalScorer — advisory multi-model scorer for specialist proposals.
+
+This component is **purely advisory**. It scores each variant in a
+specialist's ``proposal_set`` with one or more LLM models on the AMD
+gateway, then hands the scores to the Coordinator which surfaces them
+to Orchestration as *one reference among many* (parallel to gaps / KB /
+``analysis.md`` priority markers). It NEVER:
+
+* touches the Critic (no ``verdict`` / ``verdict_map``),
+* touches PolicyGate / the phase machine / the intent schema,
+* sorts, ranks, or auto-selects proposals.
+
+Design parallels :class:`CodexBackend`: every model is just a ``model=``
+string on the *same* OpenAI-style gateway client (``OPENAI_BASE_URL`` +
+``ANTHROPIC_AUTH_TOKEN`` / ``OPENAI_API_KEY``). Adding a model = adding
+a slug to ``models``. Each model is scored independently and concurrently
+via ``asyncio.gather`` so one model's failure / missing-slug / timeout
+never blocks the others.
+
+Output schema (``score`` return value)::
+
+    {
+        "scale": "0-10",
+        "models": {
+            "<model_slug>": {
+                "<proposal_name>": {"score": <float 0-10>, "reason": "<str>"},
+                ...
+            },
+            ...
+        },
+        "errors": {"<model_slug>": "<reason>", ...},
+    }
+
+Test seam: pass ``client_factory`` to bypass real client construction.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from .backends.base import parse_call_timeout_env
+
+log = logging.getLogger(__name__)
+
+
+DEFAULT_SCORER_MODELS: tuple[str, ...] = ("claude-opus-4-7", "gpt-5.4")
+
+# Soft cap on what we feed each model so a pathological proposal_set
+# can't blow up the scoring prompt. proposal_set is already capped
+# upstream (DEFAULT_SPECIALIST_MAX_PROPOSALS), this is defense-in-depth.
+_MAX_PROPOSALS_SCORED: int = 12
+_MAX_FIELD_CHARS: int = 600
+
+
+_SCORING_INSTRUCTIONS = """
+You are scoring candidate serving-config variants proposed by a perf
+specialist for an LLM-inference optimization run on AMD GPUs.
+
+For EACH proposal below, output a single composite score from 0 to 10:
+how likely / how much this variant improves serving THROUGHPUT for the
+stated gap, grounded ONLY in the evidence shown. 10 = very likely a
+large win; 0 = irrelevant or likely harmful. Be calibrated, not generous.
+
+Output ONLY one compact JSON object, no prose, no markdown fence needed:
+
+{"scores": {"<proposal_name>": {"score": <0-10 number>, "reason": "<= 15 words"}}}
+
+Rules:
+- One entry per proposal, keyed by its exact "name".
+- "reason" MUST be <= 15 words. Keep it terse to keep the reply short.
+- Do not add keys other than "score" and "reason".
+""".strip()
+
+
+# Match a fenced ```json ... ``` block (preferred) then a bare top-level
+# object containing "scores". Mirrors CodexBackend._extract_envelope.
+_FENCED_JSON_RE = re.compile(r"```(?:json)?\s*(\{.*?\})\s*```", re.DOTALL)
+_BARE_JSON_RE = re.compile(r"(\{.*?\"scores\".*\})", re.DOTALL)
+
+
+def _extract_scores_json(text: str) -> dict[str, Any] | None:
+    """Pull the first valid ``{"scores": {...}}`` object out of a reply."""
+    if not text:
+        return None
+    for m in _FENCED_JSON_RE.finditer(text):
+        try:
+            data = json.loads(m.group(1))
+        except json.JSONDecodeError:
+            continue
+        if isinstance(data, dict) and "scores" in data:
+            return data
+    for m in _BARE_JSON_RE.finditer(text):
+        candidate = m.group(1)
+        for end in range(len(candidate), 0, -1):
+            try:
+                data = json.loads(candidate[:end])
+            except json.JSONDecodeError:
+                continue
+            if isinstance(data, dict) and "scores" in data:
+                return data
+            break  # parsed but wrong shape; don't keep shrinking
+    return None
+
+
+def _clip(value: Any, *, limit: int = _MAX_FIELD_CHARS) -> str:
+    s = "" if value is None else str(value)
+    return s if len(s) <= limit else (s[:limit] + "…")
+
+
+def _coerce_score(raw: Any) -> float | None:
+    """Coerce a model-emitted score into a clamped [0, 10] float."""
+    try:
+        val = float(raw)
+    except (TypeError, ValueError):
+        return None
+    if val != val:  # NaN
+        return None
+    return max(0.0, min(10.0, val))
+
+
+def _normalise_model_scores(
+    parsed: dict[str, Any], *, proposal_names: list[str],
+) -> dict[str, dict[str, Any]]:
+    """Project a model's parsed ``{"scores": {...}}`` onto known names.
+
+    Drops unknown names, clamps scores to [0, 10], truncates reasons.
+    Proposals the model omitted simply don't appear (the renderer shows
+    a placeholder).
+    """
+    out: dict[str, dict[str, Any]] = {}
+    scores = parsed.get("scores")
+    if not isinstance(scores, dict):
+        return out
+    known = set(proposal_names)
+    for name, entry in scores.items():
+        key = str(name)
+        if key not in known or not isinstance(entry, dict):
+            continue
+        score = _coerce_score(entry.get("score"))
+        if score is None:
+            continue
+        out[key] = {
+            "score": score,
+            "reason": _clip(entry.get("reason"), limit=160),
+        }
+    return out
+
+
+@dataclass
+class ProposalScorer:
+    """Advisory multi-model scorer (see module docstring)."""
+
+    models: tuple[str, ...] = DEFAULT_SCORER_MODELS
+    api_key_env: str = "ANTHROPIC_AUTH_TOKEN"  # AMD proxy; accepts OPENAI too
+    base_url_env: str = "OPENAI_BASE_URL"
+    max_completion_tokens: int = 1200
+    call_timeout_s: float = field(
+        default_factory=lambda: parse_call_timeout_env(
+            "INFERENCE_OPTIMIZER_PROPOSAL_SCORER_TIMEOUT_SEC",
+            default=120.0,
+        )
+    )
+
+    # Test seam — set to bypass real OpenAI client construction.
+    client_factory: Callable[[], Any] | None = None
+
+    _client: Any = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self.models = tuple(
+            m for m in (str(x).strip() for x in (self.models or ())) if m
+        )
+        if self.client_factory is not None:
+            self._client = self.client_factory()
+            return
+        # Lazy: construct the gateway client on first use so an
+        # unconfigured environment fails per-call (degrade) rather than
+        # at Coordinator boot. Mirrors CodexBackend env resolution.
+        self._client = None
+
+    def _ensure_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        try:
+            from openai import AsyncOpenAI  # type: ignore[import-not-found]
+        except ImportError as exc:  # pragma: no cover
+            raise RuntimeError(
+                "openai SDK not installed; run `pip install openai>=1.50`"
+            ) from exc
+        api_key = (
+            os.environ.get(self.api_key_env)
+            or os.environ.get("OPENAI_API_KEY")
+        )
+        if not api_key:
+            raise RuntimeError(
+                f"{self.api_key_env} not set in env (ProposalScorer cannot auth)"
+            )
+        base_url = (
+            os.environ.get(self.base_url_env)
+            or os.environ.get("OPENAI_BASE_URL")
+            or os.environ.get("ANTHROPIC_BASE_URL")
+        )
+        kwargs: dict[str, Any] = {"api_key": api_key}
+        if base_url:
+            kwargs["base_url"] = base_url
+        self._client = AsyncOpenAI(**kwargs)
+        return self._client
+
+    # ------------------------------------------------------------------
+    def _build_prompt(
+        self, *, gap: dict[str, Any], proposals: list[dict[str, Any]],
+    ) -> str:
+        """Build ONE group-scoring prompt covering every proposal."""
+        lines: list[str] = ["=== Gap ==="]
+        lines.append(f"domain: {_clip(gap.get('domain'), limit=80)}")
+        lines.append(
+            f"gap_canonical_id: {_clip(gap.get('gap_canonical_id'), limit=160)}"
+        )
+        symptom = gap.get("gap_symptom") or gap.get("summary")
+        if symptom:
+            lines.append(f"symptom: {_clip(symptom)}")
+        evidence = gap.get("gap_evidence")
+        if evidence:
+            lines.append(f"evidence: {_clip(json.dumps(evidence, sort_keys=True))}")
+
+        lines.append("")
+        lines.append("=== Proposals to score ===")
+        for i, p in enumerate(proposals):
+            name = str(p.get("name") or f"proposal_{i}")
+            lines.append(f"- name: {name}")
+            if p.get("extra_args"):
+                lines.append(f"  extra_args: {_clip(p.get('extra_args'))}")
+            if p.get("extra_envs"):
+                lines.append(
+                    f"  extra_envs: {_clip(json.dumps(p.get('extra_envs'), sort_keys=True))}"
+                )
+            if p.get("reason"):
+                lines.append(f"  reason: {_clip(p.get('reason'))}")
+            if p.get("kb_evidence"):
+                lines.append(
+                    f"  kb_evidence: {_clip(json.dumps(p.get('kb_evidence'), sort_keys=True))}"
+                )
+        return "\n".join(lines)
+
+    async def _score_one_model(
+        self, model: str, prompt: str, proposal_names: list[str],
+    ) -> dict[str, dict[str, Any]]:
+        """Score every proposal with a single model. Raises on failure;
+        the caller (``score``) catches and records the error per-model.
+        """
+        client = self._ensure_client()
+        full_prompt = f"{prompt}\n\n{_SCORING_INSTRUCTIONS}"
+        messages = [{"role": "user", "content": full_prompt}]
+        try:
+            resp = await asyncio.wait_for(
+                client.chat.completions.create(
+                    model=model,
+                    messages=messages,
+                    max_completion_tokens=self.max_completion_tokens,
+                ),
+                timeout=self.call_timeout_s,
+            )
+        except asyncio.TimeoutError as exc:
+            raise RuntimeError(
+                f"timed out after {self.call_timeout_s:.0f}s"
+            ) from exc
+        text = (resp.choices[0].message.content or "")
+        parsed = _extract_scores_json(text)
+        if parsed is None:
+            raise RuntimeError(
+                f"no parseable scores JSON (reply_chars={len(text)})"
+            )
+        return _normalise_model_scores(parsed, proposal_names=proposal_names)
+
+    async def score(
+        self, *, gap: dict[str, Any], proposals: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Score ``proposals`` against ``gap`` with every configured model.
+
+        Returns the advisory envelope (see module docstring). Never
+        raises for per-model failures — they land in ``errors``. Returns
+        an empty ``models`` dict (with ``errors``) if everything failed,
+        so the caller can still attach it (and the renderer omits it).
+        """
+        proposals = [p for p in (proposals or []) if isinstance(p, dict)]
+        if not proposals or not self.models:
+            return {"scale": "0-10", "models": {}, "errors": {}}
+        if len(proposals) > _MAX_PROPOSALS_SCORED:
+            proposals = proposals[:_MAX_PROPOSALS_SCORED]
+        proposal_names = [
+            str(p.get("name") or f"proposal_{i}")
+            for i, p in enumerate(proposals)
+        ]
+        prompt = self._build_prompt(gap=gap, proposals=proposals)
+
+        results = await asyncio.gather(
+            *(
+                self._score_one_model(m, prompt, proposal_names)
+                for m in self.models
+            ),
+            return_exceptions=True,
+        )
+        models_out: dict[str, dict[str, Any]] = {}
+        errors: dict[str, str] = {}
+        for model, res in zip(self.models, results):
+            if isinstance(res, BaseException):
+                errors[model] = f"{type(res).__name__}: {str(res)[:200]}"
+                log.warning(
+                    "ProposalScorer: model=%s failed: %r", model, res,
+                )
+                continue
+            if res:
+                models_out[model] = res
+            else:
+                errors[model] = "no usable scores returned"
+        return {"scale": "0-10", "models": models_out, "errors": errors}
+
+
+__all__ = ["ProposalScorer", "DEFAULT_SCORER_MODELS", "_extract_scores_json"]

--- a/inference_optimizer/orchestrator/proposal_scorer.py
+++ b/inference_optimizer/orchestrator/proposal_scorer.py
@@ -49,7 +49,7 @@ from .backends.base import parse_call_timeout_env
 log = logging.getLogger(__name__)
 
 
-DEFAULT_SCORER_MODELS: tuple[str, ...] = ("claude-opus-4-7", "gpt-5.4")
+DEFAULT_SCORER_MODELS: tuple[str, ...] = ("claude-opus-4-8", "gpt-5.5")
 
 # Soft cap on what we feed each model so a pathological proposal_set
 # can't blow up the scoring prompt. proposal_set is already capped

--- a/inference_optimizer/orchestrator/proposal_scorer.py
+++ b/inference_optimizer/orchestrator/proposal_scorer.py
@@ -49,7 +49,12 @@ from .backends.base import parse_call_timeout_env
 log = logging.getLogger(__name__)
 
 
-DEFAULT_SCORER_MODELS: tuple[str, ...] = ("claude-opus-4-8", "gpt-5.5")
+DEFAULT_SCORER_MODELS: tuple[str, ...] = (
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+    "gpt-5.5",
+    "gpt-5.4",
+)
 
 # Soft cap on what we feed each model so a pathological proposal_set
 # can't blow up the scoring prompt. proposal_set is already capped

--- a/inference_optimizer/orchestrator/shared_state.py
+++ b/inference_optimizer/orchestrator/shared_state.py
@@ -3872,11 +3872,19 @@ class SharedState:
         Reads the ``ensemble_scores`` blob attached to the most recent
         :attr:`specialist_rounds` entries by the ProposalScorer (see
         ``orchestrator/proposal_scorer.py``). Each line shows a variant's
-        per-model ``score ("reason")`` side-by-side so Orchestration can
+        per-rater ``score ("reason")`` side-by-side so Orchestration can
         see agreement / disagreement. There is deliberately NO mean and
         NO sorting — these are one reference among many (parallel to
         gaps / KB / analysis.md), not a ranking directive (Inv-9.1: no
         system-side scoreboard).
+
+        The rater identities are **anonymized** (``rater_1``, ``rater_2``,
+        …) so Orchestration weighs the scores on their merits and reasons
+        alone, free of any per-model prior / brand bias. The mapping is
+        *stable within a render* (the same model maps to the same
+        ``rater_N`` across every round shown) so cross-round agreement is
+        still legible, but the real model slugs never reach the prompt —
+        they stay in ``ensemble_scores`` (state.json) for debug / audit.
 
         Returns ``""`` when no recent round carries scores so the caller
         skips the whole section header.
@@ -3884,7 +3892,7 @@ class SharedState:
         Format::
 
             round=<round_id> domain=<domain>
-              - <variant_name>: claude-opus-4-7=8.0 ("..."), gpt-5.4=6.5 ("...")
+              - <variant_name>: rater_1=8.0 ("..."), rater_2=6.5 ("...")
         """
         rounds = [
             r for r in (self.specialist_rounds or [])
@@ -3894,13 +3902,30 @@ class SharedState:
         ]
         if not rounds:
             return ""
+        shown = rounds[-max_rounds:]
+        # Stable, anonymized rater labels: collect every real model slug
+        # across the rounds being shown, sort for determinism, and map
+        # each to ``rater_N``. The same model gets the same label across
+        # rounds (cross-round agreement stays legible) while the real
+        # slug never reaches the prompt — Orchestration must weigh scores
+        # on merit, not on which brand emitted them (avoids model bias).
+        all_slugs: set[str] = set()
+        for r in shown:
+            models = r["ensemble_scores"].get("models") or {}
+            all_slugs.update(str(s) for s in models.keys())
+            errs = r["ensemble_scores"].get("errors") or {}
+            all_slugs.update(str(s) for s in errs.keys())
+        rater_label = {
+            slug: f"rater_{i}"
+            for i, slug in enumerate(sorted(all_slugs), start=1)
+        }
         rows: list[str] = [
             "(Advisory only — one reference among many, NOT a ranking "
             "directive. Scores are 0-10 likelihood-of-throughput-gain "
-            "priors from independent models; weigh alongside gaps / KB / "
-            "analysis.md.)",
+            "priors from independent anonymized raters; weigh on merit "
+            "alongside gaps / KB / analysis.md.)",
         ]
-        for r in rounds[-max_rounds:]:
+        for r in shown:
             ens = r["ensemble_scores"]
             models = ens.get("models") or {}
             scale = str(ens.get("scale") or "0-10")
@@ -3923,27 +3948,41 @@ class SharedState:
                         if nm not in seen:
                             ordered_names.append(nm)
                             seen.add(nm)
+            # Render raters in stable label order (rater_1, rater_2, …)
+            # so a given column means the same model across every round
+            # without ever printing the model slug.
+            ordered_slugs = sorted(
+                (s for s in models if s in rater_label),
+                key=lambda s: rater_label[s],
+            )
             for nm in ordered_names:
                 parts: list[str] = []
-                for model_slug, per_model in models.items():
+                for model_slug in ordered_slugs:
+                    per_model = models.get(model_slug)
                     if not isinstance(per_model, dict):
                         continue
+                    label = rater_label[model_slug]
                     cell = per_model.get(nm)
                     if isinstance(cell, dict) and cell.get("score") is not None:
                         reason = str(cell.get("reason") or "").replace("\n", " ")
                         if len(reason) > 80:
                             reason = reason[:77] + "..."
                         parts.append(
-                            f"{model_slug}={float(cell['score']):.1f} "
+                            f"{label}={float(cell['score']):.1f} "
                             f"(\"{reason}\")"
                         )
                     else:
-                        parts.append(f"{model_slug}=n/a")
+                        parts.append(f"{label}=n/a")
                 rows.append(f"  - {nm}: " + ", ".join(parts))
             errors = ens.get("errors") or {}
             if errors:
-                err_models = ", ".join(sorted(errors))
-                rows.append(f"  · models unavailable this round: {err_models}")
+                err_labels = ", ".join(
+                    sorted(
+                        rater_label.get(str(s), "rater_?")
+                        for s in errors
+                    )
+                )
+                rows.append(f"  · raters unavailable this round: {err_labels}")
         return "\n".join(rows)
 
     def to_prompt_summary(self) -> str:

--- a/inference_optimizer/orchestrator/shared_state.py
+++ b/inference_optimizer/orchestrator/shared_state.py
@@ -3866,6 +3866,86 @@ class SharedState:
             )
         return "\n".join(rows)
 
+    def to_proposal_scores_summary(self, *, max_rounds: int = 2) -> str:
+        """Render advisory multi-model proposal scores for Orchestration.
+
+        Reads the ``ensemble_scores`` blob attached to the most recent
+        :attr:`specialist_rounds` entries by the ProposalScorer (see
+        ``orchestrator/proposal_scorer.py``). Each line shows a variant's
+        per-model ``score ("reason")`` side-by-side so Orchestration can
+        see agreement / disagreement. There is deliberately NO mean and
+        NO sorting — these are one reference among many (parallel to
+        gaps / KB / analysis.md), not a ranking directive (Inv-9.1: no
+        system-side scoreboard).
+
+        Returns ``""`` when no recent round carries scores so the caller
+        skips the whole section header.
+
+        Format::
+
+            round=<round_id> domain=<domain>
+              - <variant_name>: claude-opus-4-7=8.0 ("..."), gpt-5.4=6.5 ("...")
+        """
+        rounds = [
+            r for r in (self.specialist_rounds or [])
+            if isinstance(r, dict)
+            and isinstance(r.get("ensemble_scores"), dict)
+            and (r["ensemble_scores"].get("models") or {})
+        ]
+        if not rounds:
+            return ""
+        rows: list[str] = [
+            "(Advisory only — one reference among many, NOT a ranking "
+            "directive. Scores are 0-10 likelihood-of-throughput-gain "
+            "priors from independent models; weigh alongside gaps / KB / "
+            "analysis.md.)",
+        ]
+        for r in rounds[-max_rounds:]:
+            ens = r["ensemble_scores"]
+            models = ens.get("models") or {}
+            scale = str(ens.get("scale") or "0-10")
+            round_id = str(r.get("round_id") or "?")
+            domain = str(r.get("domain") or "?")
+            rows.append(f"round={round_id} domain={domain} scale={scale}")
+            # Collect every variant name seen across models, preserving
+            # the proposal_set order when available.
+            ordered_names: list[str] = []
+            seen: set[str] = set()
+            for variant in (r.get("proposal_set") or []):
+                if isinstance(variant, dict):
+                    nm = str(variant.get("name") or "")
+                    if nm and nm not in seen:
+                        ordered_names.append(nm)
+                        seen.add(nm)
+            for per_model in models.values():
+                if isinstance(per_model, dict):
+                    for nm in per_model:
+                        if nm not in seen:
+                            ordered_names.append(nm)
+                            seen.add(nm)
+            for nm in ordered_names:
+                parts: list[str] = []
+                for model_slug, per_model in models.items():
+                    if not isinstance(per_model, dict):
+                        continue
+                    cell = per_model.get(nm)
+                    if isinstance(cell, dict) and cell.get("score") is not None:
+                        reason = str(cell.get("reason") or "").replace("\n", " ")
+                        if len(reason) > 80:
+                            reason = reason[:77] + "..."
+                        parts.append(
+                            f"{model_slug}={float(cell['score']):.1f} "
+                            f"(\"{reason}\")"
+                        )
+                    else:
+                        parts.append(f"{model_slug}=n/a")
+                rows.append(f"  - {nm}: " + ", ".join(parts))
+            errors = ens.get("errors") or {}
+            if errors:
+                err_models = ", ".join(sorted(errors))
+                rows.append(f"  · models unavailable this round: {err_models}")
+        return "\n".join(rows)
+
     def to_prompt_summary(self) -> str:
         """Compact, human-readable snapshot for prompt injection (DESIGN §8.3)."""
         lines = [

--- a/inference_optimizer/orchestrator/system_prompts/orchestration.md
+++ b/inference_optimizer/orchestrator/system_prompts/orchestration.md
@@ -70,6 +70,21 @@ grid-runner entry):
     Critic reviews each variant against KB priors before it benches;
     rejected variants drop silently (`critic_filtered_count`).
 
+    **Advisory proposal scores**: after a specialist round, the prompt
+    MAY carry a `=== Specialist proposal scores (advisory) ===` block —
+    per proposal, an independent 0-10 likelihood-of-throughput-gain prior
+    from one or more models (e.g. `claude-opus-4-7=8.0 ("…"),
+    gpt-5.4=6.5 ("…")`). These are **one reference among many**: weigh
+    them alongside `gaps[]`, the KB sub-graph, recent winners, and the
+    `analysis.md` 🔴/🟡/🟢 markers, with no more authority than those.
+    They are model *priors*, not measurements, and may be correlated or
+    wrong. Per §3.9 Inv-9.1 there is no system-side scoreboard: the
+    scores do NOT rank or pre-select anything — the at-most-one
+    `provenance='specialist:*'` variant you pick remains YOUR judgment.
+    Cross-model disagreement is itself an uncertainty signal; when scores
+    conflict with the analysis.md markers or KB evidence, prefer the
+    measured / evidence-backed signal.
+
     **Self-stop**: when EXPLORE's plateau fires, the Coordinator runs
     a `session_steward_specialist` and routes its
     `recommendation in {continue_explore, advance_to_kernel,

--- a/inference_optimizer/orchestrator/system_prompts/orchestration.md
+++ b/inference_optimizer/orchestrator/system_prompts/orchestration.md
@@ -72,18 +72,20 @@ grid-runner entry):
 
     **Advisory proposal scores**: after a specialist round, the prompt
     MAY carry a `=== Specialist proposal scores (advisory) ===` block —
-    per proposal, an independent 0-10 likelihood-of-throughput-gain prior
-    from one or more models (e.g. `claude-opus-4-7=8.0 ("…"),
-    gpt-5.4=6.5 ("…")`). These are **one reference among many**: weigh
-    them alongside `gaps[]`, the KB sub-graph, recent winners, and the
-    `analysis.md` 🔴/🟡/🟢 markers, with no more authority than those.
-    They are model *priors*, not measurements, and may be correlated or
-    wrong. Per §3.9 Inv-9.1 there is no system-side scoreboard: the
-    scores do NOT rank or pre-select anything — the at-most-one
-    `provenance='specialist:*'` variant you pick remains YOUR judgment.
-    Cross-model disagreement is itself an uncertainty signal; when scores
-    conflict with the analysis.md markers or KB evidence, prefer the
-    measured / evidence-backed signal.
+    per proposal, independent 0-10 likelihood-of-throughput-gain priors
+    from several **anonymized raters** (e.g. `rater_1=8.0 ("…"),
+    rater_2=6.5 ("…")`). The rater identities are deliberately hidden so
+    you judge each score on its stated reasoning alone, with no brand /
+    model prior — do NOT speculate which model a `rater_N` is. These are
+    **one reference among many**: weigh them alongside `gaps[]`, the KB
+    sub-graph, recent winners, and the `analysis.md` 🔴/🟡/🟢 markers,
+    with no more authority than those. They are priors, not measurements,
+    and may be correlated or wrong. Per §3.9 Inv-9.1 there is no
+    system-side scoreboard: the scores do NOT rank or pre-select anything
+    — the at-most-one `provenance='specialist:*'` variant you pick
+    remains YOUR judgment. Cross-rater disagreement is itself an
+    uncertainty signal; when scores conflict with the analysis.md markers
+    or KB evidence, prefer the measured / evidence-backed signal.
 
     **Self-stop**: when EXPLORE's plateau fires, the Coordinator runs
     a `session_steward_specialist` and routes its

--- a/inference_optimizer/tests/test_framework_pr_executor.py
+++ b/inference_optimizer/tests/test_framework_pr_executor.py
@@ -742,6 +742,92 @@ async def test_executor_no_diff_url_falls_back_to_checkout_head(tmp_path: Path):
     assert (repo / "src.py").read_text().endswith("return 2\n")
 
 
+@pytest.mark.asyncio
+async def test_executor_keep_adds_new_file_pr(tmp_path: Path):
+    """P2 regression: a PR that ADDS a new file (no edits to tracked
+    files) must KEEP cleanly — _git_commit_keep runs ``git add -A`` so the
+    new file is captured in the commit instead of being dropped by
+    ``commit -am`` (which would either leave it untracked or fail)."""
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    repo = tmp_path / "framework"
+    _init_git_repo(repo)
+    patch_path = tmp_path / "add.patch"
+    patch_path.write_text(_PATCH_B_ADDS_FILE, encoding="utf-8")
+
+    executor = FrameworkPrExecutor(session_dir=session_dir)
+    cand = _make_candidate()
+
+    async def fake_bench(self, *, params, output_root, slug):  # noqa: ARG001
+        return (
+            {"status": "succeeded", "output_throughput": 1100.0},
+            {"accuracy_pass": None},
+        )
+
+    ctx = _make_ctx("t-fp-addfile", {
+        "candidate": cand,
+        "patches": [str(patch_path)],
+        "framework_source_root": str(repo),
+        "base_tput": 1000.0,
+        "keep_threshold_pct": 1.0,
+    })
+    with patch.object(FrameworkPrExecutor, "_bench_candidate", new=fake_bench):
+        result = await executor(ctx)
+
+    assert result["status"] == "kept", result
+    assert result.get("keep_commit_sha")
+    # The new file is present AND committed (not left as untracked debris).
+    assert (repo / "new.py").exists()
+    status = subprocess.run(
+        ["git", "-C", str(repo), "status", "--porcelain"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert status == "", f"worktree not clean after KEEP: {status!r}"
+
+
+@pytest.mark.asyncio
+async def test_executor_cross_repo_disables_checkout_head(tmp_path: Path):
+    """P1 regression: a candidate whose repo differs from the live
+    framework_root's origin must NOT use checkout-head (which would fetch
+    the wrong ref from the live origin). Even with apply_mode=checkout_head
+    explicitly set, the executor falls back to diff_url."""
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    repo = tmp_path / "framework"
+    _init_git_repo(repo)
+    # Point the live origin at sgl-project/sglang.
+    subprocess.run(
+        ["git", "-C", str(repo), "remote", "add", "origin",
+         "https://github.com/sgl-project/sglang.git"],
+        check=True, capture_output=True,
+    )
+    # A served diff_url so the fallback has something to apply.
+    diff_file = tmp_path / "served.patch"
+    diff_file.write_text(_VALID_PATCH, encoding="utf-8")
+
+    executor = FrameworkPrExecutor(session_dir=session_dir)
+    cand = {
+        "repo": "ROCm/vllm",  # cross-repo vs the sglang live origin
+        "pr_number": 42,
+        "ref": "pr-head",
+        "title": "cross-repo PR",
+        "diff_url": f"file://{diff_file}",
+        "apply_mode": "checkout_head",  # explicitly requested, but cross-repo
+    }
+    ctx = _make_ctx("t-fp-crossrepo", {
+        "candidate": cand,
+        "framework_source_root": str(repo),
+        "apply_only": True,
+    })
+    result = await executor(ctx)
+
+    assert result["status"] == "applied_no_bench", result
+    # Fell back to the served diff_url (not checkout_head).
+    assert result.get("patch_source_mode") == "diff_url"
+    # The served diff actually landed.
+    assert (repo / "src.py").read_text().endswith("return 2\n")
+
+
 # ---------------------------------------------------------------------------
 # 4. Registration / import surface
 # ---------------------------------------------------------------------------

--- a/inference_optimizer/tests/test_proposal_scorer.py
+++ b/inference_optimizer/tests/test_proposal_scorer.py
@@ -220,7 +220,7 @@ def test_default_models_constant():
         "claude-opus-4-8",
         "claude-opus-4-7",
         "gpt-5.5",
-        "gpt-5.4",
+        "dvue-aoai-005-Kimi-K2.6",
     )
 
 

--- a/inference_optimizer/tests/test_proposal_scorer.py
+++ b/inference_optimizer/tests/test_proposal_scorer.py
@@ -216,7 +216,12 @@ def test_extract_scores_json_bare_and_fenced():
 
 
 def test_default_models_constant():
-    assert DEFAULT_SCORER_MODELS == ("claude-opus-4-8", "gpt-5.5")
+    assert DEFAULT_SCORER_MODELS == (
+        "claude-opus-4-8",
+        "claude-opus-4-7",
+        "gpt-5.5",
+        "gpt-5.4",
+    )
 
 
 # ===========================================================================
@@ -387,10 +392,15 @@ def test_render_shows_per_model_side_by_side():
     text = st.to_proposal_scores_summary()
     assert "Advisory only" in text
     assert "cuda_graph_bs_512" in text
-    assert "claude-opus-4-7=8.0" in text
-    assert "gpt-5.4=6.5" in text
-    # gpt-5.4 omitted disable_radix → rendered as n/a.
-    assert "gpt-5.4=n/a" in text
+    # Identities are anonymized: real model slugs MUST NOT leak into the
+    # orchestration-facing render. Sorted slugs map claude-opus-4-7 ->
+    # rater_1, gpt-5.4 -> rater_2 (stable within a render).
+    assert "claude-opus-4-7" not in text
+    assert "gpt-5.4" not in text
+    assert "rater_1=8.0" in text
+    assert "rater_2=6.5" in text
+    # rater_2 omitted disable_radix → rendered as n/a.
+    assert "rater_2=n/a" in text
 
 
 def test_render_reports_unavailable_models():
@@ -406,7 +416,55 @@ def test_render_reports_unavailable_models():
         },
     }]
     text = st.to_proposal_scores_summary()
-    assert "models unavailable this round: bad" in text
+    # Anonymized: the failing model slug "bad" must not leak; sorted
+    # slugs map bad -> rater_1, good -> rater_2.
+    assert "bad" not in text
+    assert "raters unavailable this round: rater_1" in text
+
+
+def test_render_rater_labels_stable_across_rounds():
+    """The same model maps to the same rater_N in every rendered round,
+    and no real model slug ever appears in the orchestration text."""
+    st = _real_state()
+    st.specialist_rounds = [
+        {
+            "round_id": "r1",
+            "domain": "serving_specialist",
+            "proposal_set": [{"name": "v1"}],
+            "ensemble_scores": {
+                "scale": "0-10",
+                "models": {
+                    "claude-opus-4-8": {"v1": {"score": 8.0, "reason": "a"}},
+                    "gpt-5.5": {"v1": {"score": 6.0, "reason": "b"}},
+                },
+                "errors": {},
+            },
+        },
+        {
+            "round_id": "r2",
+            "domain": "kernel_switch_specialist",
+            "proposal_set": [{"name": "v2"}],
+            "ensemble_scores": {
+                "scale": "0-10",
+                "models": {
+                    # Deliberately different dict order to prove the label
+                    # is keyed on the slug, not on iteration order.
+                    "gpt-5.5": {"v2": {"score": 5.0, "reason": "c"}},
+                    "claude-opus-4-8": {"v2": {"score": 9.0, "reason": "d"}},
+                },
+                "errors": {},
+            },
+        },
+    ]
+    text = st.to_proposal_scores_summary(max_rounds=2)
+    for slug in ("claude-opus-4-8", "gpt-5.5", "claude", "gpt"):
+        assert slug not in text, f"model slug {slug!r} leaked into prompt"
+    # claude-opus-4-8 sorts before gpt-5.5 → rater_1 / rater_2, stable
+    # across both rounds: rater_1 carries claude's 8.0 then 9.0.
+    assert "rater_1=8.0" in text
+    assert "rater_2=6.0" in text
+    assert "rater_2=5.0" in text
+    assert "rater_1=9.0" in text
 
 
 # ===========================================================================

--- a/inference_optimizer/tests/test_proposal_scorer.py
+++ b/inference_optimizer/tests/test_proposal_scorer.py
@@ -218,9 +218,9 @@ def test_extract_scores_json_bare_and_fenced():
 def test_default_models_constant():
     assert DEFAULT_SCORER_MODELS == (
         "claude-opus-4-8",
-        "claude-opus-4-7",
         "gpt-5.5",
         "dvue-aoai-005-Kimi-K2.6",
+        "gemini/gemini-3.1-pro-preview",
     )
 
 

--- a/inference_optimizer/tests/test_proposal_scorer.py
+++ b/inference_optimizer/tests/test_proposal_scorer.py
@@ -1,0 +1,430 @@
+"""Tests for the advisory specialist-proposal scorer (ProposalScorer).
+
+Covers:
+
+* Scorer unit — group prompt shape, JSON parse, per-model independent
+  degrade (timeout / bad JSON / one model raises / unknown-slug 404),
+  score clamping + unknown-name drop.
+* Coordinator wiring — ``_record_specialist_result`` attaches
+  ``ensemble_scores`` to the round entry when a scorer is present;
+  absent scorer → no key; scorer exception → entry still recorded.
+* Renderer — ``SharedState.to_proposal_scores_summary`` text + the
+  section is omitted when no round carries scores.
+* Resume idempotency — re-recording the same ``round_id`` does not
+  duplicate (delegated to existing ``record_specialist_round``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from inference_optimizer.orchestrator.proposal_scorer import (
+    DEFAULT_SCORER_MODELS,
+    ProposalScorer,
+    _extract_scores_json,
+)
+from inference_optimizer.orchestrator.policy import SPECIALIST_FROM_AGENT_PREFIX
+
+
+# ===========================================================================
+# Fake OpenAI client (test seam)
+# ===========================================================================
+@dataclass
+class _FakeMessage:
+    content: str
+
+
+@dataclass
+class _FakeChoice:
+    message: _FakeMessage
+
+
+@dataclass
+class _FakeResp:
+    choices: list[_FakeChoice]
+
+
+class _FakeCompletions:
+    """Per-model scripted behaviour keyed by ``model=``.
+
+    ``behaviour`` maps a model slug to either a string (returned as the
+    reply content) or an Exception instance (raised to simulate a
+    gateway error / 404 / timeout).
+    """
+
+    def __init__(self, behaviour: dict[str, Any]):
+        self._behaviour = behaviour
+        self.calls: list[dict[str, Any]] = []
+
+    async def create(self, *, model: str, messages, max_completion_tokens):
+        self.calls.append({"model": model, "messages": messages})
+        result = self._behaviour.get(model)
+        if isinstance(result, BaseException):
+            raise result
+        return _FakeResp(choices=[_FakeChoice(_FakeMessage(result or ""))])
+
+
+class _FakeChat:
+    def __init__(self, completions: _FakeCompletions):
+        self.completions = completions
+
+
+class _FakeClient:
+    def __init__(self, behaviour: dict[str, Any]):
+        self.chat = _FakeChat(_FakeCompletions(behaviour))
+
+
+def _make_scorer(behaviour: dict[str, Any], *, models=None) -> ProposalScorer:
+    client = _FakeClient(behaviour)
+    return ProposalScorer(
+        models=tuple(models or behaviour.keys()),
+        client_factory=lambda: client,
+    )
+
+
+_GAP = {
+    "domain": "serving_specialist",
+    "gap_canonical_id": "gap.framework.cuda_graph.session-1",
+    "gap_symptom": "cuda graph capture stalls at high concurrency",
+    "summary": "specialist explored cuda graph bracket",
+}
+
+_PROPOSALS = [
+    {
+        "name": "cuda_graph_bs_512",
+        "extra_args": "--cuda-graph-max-bs 512",
+        "extra_envs": {"FOO": "1"},
+        "reason": "bracket the live CONC",
+        "kb_evidence": ["kb-123"],
+    },
+    {
+        "name": "disable_radix",
+        "extra_args": "--disable-radix-cache",
+        "reason": "reduce scheduler overhead",
+    },
+]
+
+
+def _scores_json(*pairs: tuple[str, float, str]) -> str:
+    body = ", ".join(
+        f'"{name}": {{"score": {score}, "reason": "{reason}"}}'
+        for name, score, reason in pairs
+    )
+    return f'```json\n{{"scores": {{{body}}}}}\n```'
+
+
+# ===========================================================================
+# 1. Scorer unit
+# ===========================================================================
+@pytest.mark.asyncio
+async def test_score_two_models_happy_path():
+    behaviour = {
+        "claude-opus-4-7": _scores_json(
+            ("cuda_graph_bs_512", 8.0, "strong fit"),
+            ("disable_radix", 4.0, "marginal"),
+        ),
+        "gpt-5.4": _scores_json(
+            ("cuda_graph_bs_512", 6.5, "plausible"),
+            ("disable_radix", 5.0, "ok"),
+        ),
+    }
+    scorer = _make_scorer(behaviour)
+    out = await scorer.score(gap=_GAP, proposals=_PROPOSALS)
+
+    assert out["scale"] == "0-10"
+    assert set(out["models"]) == {"claude-opus-4-7", "gpt-5.4"}
+    assert out["models"]["claude-opus-4-7"]["cuda_graph_bs_512"]["score"] == 8.0
+    assert out["models"]["gpt-5.4"]["disable_radix"]["score"] == 5.0
+    assert out["errors"] == {}
+
+
+@pytest.mark.asyncio
+async def test_group_prompt_contains_all_proposals_and_gap():
+    behaviour = {"m1": _scores_json(("cuda_graph_bs_512", 7.0, "x"))}
+    scorer = _make_scorer(behaviour)
+    await scorer.score(gap=_GAP, proposals=_PROPOSALS)
+    client = scorer._client
+    sent = client.chat.completions.calls[0]["messages"][0]["content"]
+    # group scoring → one prompt names every proposal + the gap.
+    assert "cuda_graph_bs_512" in sent
+    assert "disable_radix" in sent
+    assert "cuda graph capture stalls" in sent
+    assert "0 to 10" in sent  # instruction present
+
+
+@pytest.mark.asyncio
+async def test_per_model_degrade_one_raises_other_survives():
+    behaviour = {
+        "good": _scores_json(("cuda_graph_bs_512", 9.0, "great")),
+        "bad": RuntimeError("gateway 404 unknown model"),
+    }
+    scorer = _make_scorer(behaviour)
+    out = await scorer.score(gap=_GAP, proposals=_PROPOSALS)
+    assert "good" in out["models"]
+    assert out["models"]["good"]["cuda_graph_bs_512"]["score"] == 9.0
+    assert "bad" in out["errors"]
+    assert "404" in out["errors"]["bad"]
+
+
+@pytest.mark.asyncio
+async def test_unparseable_reply_recorded_as_error():
+    behaviour = {"m1": "I cannot produce JSON, sorry."}
+    scorer = _make_scorer(behaviour)
+    out = await scorer.score(gap=_GAP, proposals=_PROPOSALS)
+    assert out["models"] == {}
+    assert "m1" in out["errors"]
+
+
+@pytest.mark.asyncio
+async def test_scores_clamped_and_unknown_names_dropped():
+    behaviour = {
+        "m1": _scores_json(
+            ("cuda_graph_bs_512", 99.0, "over"),       # clamp to 10
+            ("disable_radix", -3.0, "under"),          # clamp to 0
+            ("ghost_variant", 5.0, "not in set"),      # dropped
+        ),
+    }
+    scorer = _make_scorer(behaviour)
+    out = await scorer.score(gap=_GAP, proposals=_PROPOSALS)
+    m = out["models"]["m1"]
+    assert m["cuda_graph_bs_512"]["score"] == 10.0
+    assert m["disable_radix"]["score"] == 0.0
+    assert "ghost_variant" not in m
+
+
+@pytest.mark.asyncio
+async def test_empty_proposals_returns_empty_envelope():
+    scorer = _make_scorer({"m1": "irrelevant"})
+    out = await scorer.score(gap=_GAP, proposals=[])
+    assert out["models"] == {}
+    assert out["errors"] == {}
+    # No model call should have been made.
+    assert scorer._client.chat.completions.calls == []
+
+
+def test_extract_scores_json_bare_and_fenced():
+    fenced = _scores_json(("a", 1.0, "x"))
+    assert _extract_scores_json(fenced)["scores"]["a"]["score"] == 1.0
+    bare = '{"scores": {"a": {"score": 2, "reason": "y"}}}'
+    assert _extract_scores_json(bare)["scores"]["a"]["score"] == 2
+    assert _extract_scores_json("no json here") is None
+
+
+def test_default_models_constant():
+    assert DEFAULT_SCORER_MODELS == ("claude-opus-4-7", "gpt-5.4")
+
+
+# ===========================================================================
+# 2. Coordinator wiring
+# ===========================================================================
+@dataclass
+class _StubTask:
+    task_id: str
+    kind: str = "specialist"
+    params: dict[str, Any] = field(default_factory=dict)
+
+
+class _StubSharedState:
+    def __init__(self):
+        self.specialist_rounds: list[dict[str, Any]] = []
+        self.specialist_domain_empty_streak: dict[str, int] = {}
+        self.last_specialist: dict[str, Any] = {}
+        self.saved: int = 0
+
+    def record_specialist_round(self, entry: dict[str, Any]) -> None:
+        round_id = str(entry.get("round_id") or "").strip()
+        if round_id:
+            for i, prev in enumerate(self.specialist_rounds):
+                if str(prev.get("round_id") or "") == round_id:
+                    self.specialist_rounds[i] = dict(entry)
+                    return
+        self.specialist_rounds.append(dict(entry))
+
+    def bump_specialist_domain_empty_streak(self, domain, *, empty) -> int:
+        d = domain or "unknown"
+        self.specialist_domain_empty_streak[d] = (
+            0 if not empty
+            else self.specialist_domain_empty_streak.get(d, 0) + 1
+        )
+        return self.specialist_domain_empty_streak[d]
+
+    def update_last_specialist(self, snapshot) -> None:
+        self.last_specialist = dict(snapshot)
+
+    def save(self, _sd) -> None:
+        self.saved += 1
+
+
+def _coord(tmp_path: Path, scorer):
+    from inference_optimizer.orchestrator.coordinator import Coordinator
+
+    c = Coordinator.__new__(Coordinator)
+    c.session_dir = tmp_path
+    c.shared_state = _StubSharedState()
+    c._proposal_scorer = scorer
+    c._record_observation = AsyncMock()  # type: ignore[method-assign]
+    return c
+
+
+def _done():
+    return {
+        "domain": "serving_specialist",
+        "gap_canonical_id": "gap.framework.cuda_graph.session-1",
+        "proposal_set": list(_PROPOSALS),
+        "empty": False,
+        "summary": "explored",
+        "reason": "kb_evidence",
+        "confidence": 0.7,
+        "new_findings": [],
+        "residual_questions": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_coordinator_attaches_ensemble_scores(tmp_path):
+    scorer = _make_scorer({
+        "claude-opus-4-7": _scores_json(("cuda_graph_bs_512", 8.0, "fit")),
+    })
+    c = _coord(tmp_path, scorer)
+    task = _StubTask(task_id="t1", params={"gap_symptom": "cuda stalls"})
+    await c._record_specialist_result(
+        task=task, done_payload=_done(),
+        source=f"{SPECIALIST_FROM_AGENT_PREFIX}t1",
+    )
+    row = c.shared_state.specialist_rounds[0]
+    assert "ensemble_scores" in row
+    assert row["ensemble_scores"]["models"]["claude-opus-4-7"][
+        "cuda_graph_bs_512"
+    ]["score"] == 8.0
+
+
+@pytest.mark.asyncio
+async def test_coordinator_no_scorer_no_key(tmp_path):
+    c = _coord(tmp_path, None)
+    task = _StubTask(task_id="t1", params={})
+    await c._record_specialist_result(
+        task=task, done_payload=_done(),
+        source=f"{SPECIALIST_FROM_AGENT_PREFIX}t1",
+    )
+    assert "ensemble_scores" not in c.shared_state.specialist_rounds[0]
+
+
+@pytest.mark.asyncio
+async def test_coordinator_scorer_exception_still_records(tmp_path):
+    class _BoomScorer:
+        async def score(self, **_kw):
+            raise RuntimeError("scorer blew up")
+
+    c = _coord(tmp_path, _BoomScorer())
+    task = _StubTask(task_id="t1", params={})
+    await c._record_specialist_result(
+        task=task, done_payload=_done(),
+        source=f"{SPECIALIST_FROM_AGENT_PREFIX}t1",
+    )
+    # Round still recorded, just without scores.
+    assert len(c.shared_state.specialist_rounds) == 1
+    assert "ensemble_scores" not in c.shared_state.specialist_rounds[0]
+
+
+@pytest.mark.asyncio
+async def test_coordinator_empty_proposals_not_scored(tmp_path):
+    scorer = _make_scorer({"m1": _scores_json(("x", 1.0, "y"))})
+    c = _coord(tmp_path, scorer)
+    payload = _done()
+    payload["proposal_set"] = []
+    payload["empty"] = True
+    task = _StubTask(task_id="t1", params={})
+    await c._record_specialist_result(
+        task=task, done_payload=payload,
+        source=f"{SPECIALIST_FROM_AGENT_PREFIX}t1",
+    )
+    assert "ensemble_scores" not in c.shared_state.specialist_rounds[0]
+    assert scorer._client.chat.completions.calls == []
+
+
+# ===========================================================================
+# 3. Renderer
+# ===========================================================================
+def _real_state():
+    from inference_optimizer.orchestrator.shared_state import SharedState
+    return SharedState()
+
+
+def test_render_omits_section_when_no_scores():
+    st = _real_state()
+    st.specialist_rounds = [
+        {"round_id": "r1", "domain": "serving_specialist",
+         "proposal_set": [{"name": "v1"}]},
+    ]
+    assert st.to_proposal_scores_summary() == ""
+
+
+def test_render_shows_per_model_side_by_side():
+    st = _real_state()
+    st.specialist_rounds = [{
+        "round_id": "r1",
+        "domain": "serving_specialist",
+        "proposal_set": [{"name": "cuda_graph_bs_512"}, {"name": "disable_radix"}],
+        "ensemble_scores": {
+            "scale": "0-10",
+            "models": {
+                "claude-opus-4-7": {
+                    "cuda_graph_bs_512": {"score": 8.0, "reason": "fit"},
+                    "disable_radix": {"score": 4.0, "reason": "marginal"},
+                },
+                "gpt-5.4": {
+                    "cuda_graph_bs_512": {"score": 6.5, "reason": "plausible"},
+                },
+            },
+            "errors": {},
+        },
+    }]
+    text = st.to_proposal_scores_summary()
+    assert "Advisory only" in text
+    assert "cuda_graph_bs_512" in text
+    assert "claude-opus-4-7=8.0" in text
+    assert "gpt-5.4=6.5" in text
+    # gpt-5.4 omitted disable_radix → rendered as n/a.
+    assert "gpt-5.4=n/a" in text
+
+
+def test_render_reports_unavailable_models():
+    st = _real_state()
+    st.specialist_rounds = [{
+        "round_id": "r1",
+        "domain": "comm_specialist",
+        "proposal_set": [{"name": "v1"}],
+        "ensemble_scores": {
+            "scale": "0-10",
+            "models": {"good": {"v1": {"score": 7.0, "reason": "ok"}}},
+            "errors": {"bad": "timed out"},
+        },
+    }]
+    text = st.to_proposal_scores_summary()
+    assert "models unavailable this round: bad" in text
+
+
+# ===========================================================================
+# 4. Resume idempotency
+# ===========================================================================
+@pytest.mark.asyncio
+async def test_resume_idempotent_on_round_id(tmp_path):
+    scorer = _make_scorer({
+        "m1": _scores_json(("cuda_graph_bs_512", 8.0, "fit")),
+    })
+    c = _coord(tmp_path, scorer)
+    task = _StubTask(task_id="t1", params={}, )
+    # round_id defaults to task_id; record twice.
+    for _ in range(2):
+        await c._record_specialist_result(
+            task=task, done_payload=_done(),
+            source=f"{SPECIALIST_FROM_AGENT_PREFIX}t1",
+        )
+    # Idempotent on round_id → exactly one row.
+    assert len(c.shared_state.specialist_rounds) == 1
+    assert "ensemble_scores" in c.shared_state.specialist_rounds[0]

--- a/inference_optimizer/tests/test_proposal_scorer.py
+++ b/inference_optimizer/tests/test_proposal_scorer.py
@@ -216,7 +216,7 @@ def test_extract_scores_json_bare_and_fenced():
 
 
 def test_default_models_constant():
-    assert DEFAULT_SCORER_MODELS == ("claude-opus-4-7", "gpt-5.4")
+    assert DEFAULT_SCORER_MODELS == ("claude-opus-4-8", "gpt-5.5")
 
 
 # ===========================================================================

--- a/robustness-agent/src/robustness_agent/role/envelope.py
+++ b/robustness-agent/src/robustness_agent/role/envelope.py
@@ -215,6 +215,11 @@ CORE_STATE_FIELDS: frozenset[str] = frozenset({
     # outcomes via UPDATE_STATE).
     "dynamic_actions",
     "dynamic_action_round_count",
+    # FRAMEWORK_PR per-repo discovery budget (Coordinator-controlled
+    # search depth knob).
+    "framework_pr_max_candidates",
+    # Advisory model-architecture profile (launcher / state.json owned).
+    "model_arch",
 })
 
 


### PR DESCRIPTION
and minor framework_pr correctness fixes

This branch bundles two independent workstreams that landed against
`feature/zhenggong/overhaul`:

1. **`framework_pr` correctness & state-locking fixes** (1 commit)
2. **Advisory multi-model specialist-proposal scorer** (3 commits + 1 `main` merge)

Both are additive and default-safe: the scorer is opt-out (advisory-only,
gates nothing), and the `framework_pr` fixes only change behavior in the
specific broken cases they target.

Net diff vs `main`: **10 files, +1265 / -5**.

---

## Commits (oldest → newest)

| SHA | Subject |
| --- | --- |
| `b84244e1` | Fix framework_pr cross-repo checkout-head, KEEP add-only files, and lock discovery budget |
| `28cce86f` | feat(scorer): advisory multi-model specialist-proposal scorer |
| `d1e7d1e5` | chore(scorer): bump default scorer models to claude-opus-4-8 + gpt-5.5 |
| `89a0e952` | Merge remote-tracking branch 'origin/main' into feature/zhenggong/overhaul |
| `f0b04549` | feat(scorer): 4-rater default pool + anonymized rater identities |

---

## Workstream 1 — `framework_pr` correctness & state locking

Three latent bugs in the recently-enhanced `framework_pr` executor /
Coordinator path, plus two missing PolicyGate locks.

### P1 — cross-repo `checkout-head` fetched the wrong ref

`checkout-head` mode fetches the candidate's head ref from the **live
`framework_root`'s `origin`**, so it only works for PRs that actually live in
that repo. The cross-repo `pr_intel_specialist` discovery can sample
candidates from *other* repos (e.g. a `ROCm/vllm` PR while the live tree is
`sglang`), which would fetch a non-existent ref and fail the candidate.

- **Coordinator** (`coordinator.py`): stamp every normalized candidate with
  `discovered_repo_url` (from the candidate's own `repo_url`, falling back to
  the batch's primary repo URL).
- **Executor** (`framework_pr.py`): add a **same-repo guard**
  (`_candidate_is_same_repo` + `_normalize_repo_id`). When the live `origin`
  is a GitHub URL that *positively differs* from the candidate's repo,
  checkout-head is disabled and the candidate falls back to `diff_url`. The
  guard **fails open** for local-path / non-GitHub / unreadable origins, so a
  normal single-repo session is never downgraded.

### P2 — KEEP commit silently dropped new files

`_git_commit_keep` used `git commit -am`, which only stages already-tracked
modifications. A PR that **adds new files** would either leave them untracked
in the worktree (polluting the next candidate's baseline) or fail outright for
an add-only PR.

- Switched to `git add -A` + `git commit -m`, so add-only PRs are captured in
  the KEEP commit and the worktree is left clean.

### P3 / P4 — unlocked control-plane state fields

Two `SharedState` fields were not protected by PolicyGate's
`CORE_STATE_FIELDS`, allowing a non-core role / LLM to mutate them via
`update_state`:

- **`framework_pr_max_candidates`** (P3) — per-repo discovery budget; locking
  it stops a role from inflating the per-batch search / bench queue mid-run.
- **`model_arch`** (P4) — advisory launcher-owned profile injected into
  specialist prompts; locking it keeps the launcher / `state.json` as the sole
  source of truth.
- Both added to `CORE_STATE_FIELDS` in `policy.py` and mirrored in the
  `robustness-agent` envelope contract (enforced by the lock-step test).

### Tests

- `test_executor_keep_adds_new_file_pr` — add-only PR is KEPT with a clean
  worktree.
- `test_executor_cross_repo_disables_checkout_head` — explicit
  `apply_mode=checkout_head` on a cross-repo candidate downgrades to
  `diff_url` (also added `patch_source_mode` to the `applied_no_bench` return
  for observability).

---

## Workstream 2 — advisory multi-model specialist-proposal scorer

Adds `ProposalScorer`: each specialist `proposal_set` is scored by several
independent gateway models in parallel (one `0–10` composite + a one-line
reason per proposal) and surfaced to Orchestration as **one reference among
many**. It is strictly **advisory** — it never ranks, pre-selects, or gates
any proposal (Inv-9.1: no system-side scoreboard).

### Core mechanism (`28cce86f`)

- **`proposal_scorer.py`** (new): async group-scoring against the AMD LLM
  proxy with compact-JSON parsing, `[0, 10]` clamping, and **per-model
  isolation** — one model's failure degrades to the surviving models' scores
  (or none) without ever blocking the loop.
- **`coordinator.py`**: wire the scorer into `_record_specialist_result`;
  attach `ensemble_scores` to the specialist round entry; render the advisory
  block into the orchestration prompt. All failures are caught and logged,
  never raised.
- **`shared_state.to_proposal_scores_summary()`**: side-by-side per-variant
  render — no mean, no sorting.
- **`cli.py`**: `--proposal-scorer-models` and `--no-proposal-scoring` flags.
- **`orchestration.md`**: frames the scores as advisory-only context.

### Default model pool (`d1e7d1e5`, `f0b04549`)

- Bumped defaults to current gateway models, then expanded to a **4-rater
  pool**: `claude-opus-4-8`, `gpt-5.5`, `KIMI-K2.6`, `Gemini3.1 Pro`.
- **Anonymized rater identities**: each real model slug is mapped to a stable
  `rater_N` label in the prompt (sorted slugs, consistent across the rounds
  shown), so Orchestration weighs each score on its stated reasoning alone
  with no per-model brand prior. Real slugs stay in `ensemble_scores`
  (`state.json`) for debug / audit — only the prompt is anonymized.

### Tests

- `test_proposal_scorer.py` (new): scorer unit tests, coordinator wiring,
  renderer behavior, resume idempotency, slug-leak assertions, `rater_N`
  rendering, stable cross-round labels, and the default-pool tuple.

---

## Safety / compatibility

- **Default-safe**: with no flags, the scorer runs advisory-only and gates
  nothing; `--no-proposal-scoring` disables it entirely.
- **No gating impact**: `ProposalScorer` and the `model_arch` field are
  prompt-only references; no deterministic decision depends on them.
- **Cross-package contract** kept in sync: the `CORE_STATE_FIELDS` additions
  are mirrored in `robustness-agent` and verified by the lock-step
  `test_role_contract` suite.

## Test status

- `inference_optimizer`: **3437 passed, 1 skipped**
- `robustness-agent`: **698 passed**
- policy / state subset: **327 passed**
- `robustness-agent` role-contract lock-step: **5 passed**
