### PR TITLE
refactor(orchestrator): loosen policy gates and remove run-abort loop…

### DIFF
--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -1127,9 +1127,6 @@ def _seed_shared_state(
         # ``--no-explore`` skips the EXPLORE phase entirely (PRELUDE /
         # FRAMEWORK_PR → KERNEL, or → SWEEP when kernel is also off).
         explore_enabled=not bool(getattr(args, "no_explore", False)),
-        gain_driven_kernel_opt=bool(
-            getattr(args, "gain_driven_kernel_opt", False),
-        ),
         explore_variant_timeout_sec_override=explore_variant_timeout_sec_override,
         explore_variant_timeout_safety_margin=explore_variant_timeout_safety_margin,
         explore_roofline_hard_gate=explore_roofline_hard_gate,
@@ -5431,22 +5428,6 @@ def _build_parser() -> argparse.ArgumentParser:
     def _env_default_on(env_var: str) -> bool:
         return os.environ.get(env_var, "1").strip() != "0"
 
-    # The standalone FRAMEWORK_PR phase is on by default; use
-    # ``--no-framework`` to disable it (mirrors the install-side
-    # ``INFERENCE_OPTIMIZER_NO_FRAMEWORK=1`` opt-out).
-    opt.add_argument(
-        "--gain-driven-kernel-opt",
-        dest="gain_driven_kernel_opt",
-        action="store_true",
-        default=os.environ.get(
-            "INFERENCE_OPTIMIZER_GAIN_DRIVEN_KERNEL_OPT", "0",
-        ).strip() == "1",
-        help="Lock ``kernel_opt`` until the 3-round moving "
-             "average of ``last_explore_delta_gain_pct`` drops below "
-             "epsilon (0.5%%). Prevents premature deep work while cheap "
-             "exploration is still earning. Default off. Env: "
-             "INFERENCE_OPTIMIZER_GAIN_DRIVEN_KERNEL_OPT=1.",
-    )
     opt.add_argument(
         "--enable-roofline",
         dest="enable_roofline",

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -3996,7 +3996,6 @@ class Coordinator:
         # Stash so ``_compose_prompt`` can update target_gap_pct.
         self._current_objective = objective
         grace_sec = effective_closing_grace_sec(max_minutes, closing_grace_sec)
-        idle_close_ticks_threshold = _resolve_silent_ticks_closing_threshold()
         deadline = (
             time.monotonic() + max_minutes * 60.0 if max_minutes else None
         )
@@ -4101,34 +4100,13 @@ class Coordinator:
                 if objective.reached(self.shared_state):
                     stop_reason = "target_reached"
                     break
-                if await self._has_no_more_leverage():
-                    # No-more-leverage is no longer terminal: instead of
-                    # aborting, wind the session down through SWEEP ->
-                    # CLOSE via the skip_to_sweep hint. Only nudge from
-                    # EXPLORE/KERNEL; SWEEP/CLOSE already own their own
-                    # wind-down (auto-sweep / report), and PRELUDE never
-                    # satisfies the safety net. The next tick's
-                    # _advance_phase_if_needed picks the hint up and
-                    # routes to SWEEP, whose entry hook auto-enqueues a
-                    # sweep task (so the safety net stops firing).
-                    phase_now = (self.shared_state.phase or "").strip().upper()
-                    if phase_now in (
-                        _phase_state.PHASE_EXPLORE,
-                        _phase_state.PHASE_KERNEL,
-                    ) and (
-                        self.shared_state.pending_escalate_hint
-                        != _phase_state.ESCALATE_HINT_SKIP_TO_SWEEP
-                    ):
-                        self.shared_state.set_pending_escalate_hint(
-                            _phase_state.ESCALATE_HINT_SKIP_TO_SWEEP,
-                        )
-                        self.shared_state.save(self.session_dir)
-                        log.info(
-                            "Coordinator: no-more-leverage safety net fired "
-                            "in phase=%s; set skip_to_sweep hint "
-                            "(non-terminal wind-down to SWEEP -> CLOSE)",
-                            phase_now,
-                        )
+                # The ``_has_no_more_leverage`` safety net (which used to
+                # wind the session down to SWEEP -> CLOSE via the
+                # skip_to_sweep hint when cheap rounds plateaued and every
+                # reusable kernel was rejected) has been removed to
+                # prioritise long-run continuity: the run keeps exploring
+                # until the wall-clock deadline rather than self-winding
+                # down on a plateau judgment.
                 if (
                     deadline is not None
                     and time.monotonic() >= deadline
@@ -4141,39 +4119,13 @@ class Coordinator:
                         grace_sec=grace_sec,
                     )
                     continue
-                # N33: if the run has been silent for
-                # ``idle_close_ticks_threshold`` consecutive ticks (LLM
-                # has stopped proposing anything actionable, no tasks in
-                # flight, no pending proposals), short-circuit to closing
-                # phase NOW instead of idling until the wall-clock
-                # deadline. This is the common failure mode where the
-                # LLM keeps re-proposing rejected ``report`` actions (or
-                # no actions at all) and would otherwise burn the
-                # remaining budget for nothing. ``threshold <= 0``
-                # disables the early-close (legacy behaviour).
-                if (
-                    idle_close_ticks_threshold > 0
-                    and not in_closing
-                    and self.shared_state.consecutive_silent_ticks
-                        >= idle_close_ticks_threshold
-                ):
-                    log.warning(
-                        "Coordinator: idle for %d consecutive ticks "
-                        "(threshold=%d); entering closing phase early "
-                        "to flush final report instead of waiting for "
-                        "wall-clock deadline (max_minutes=%.0f).",
-                        self.shared_state.consecutive_silent_ticks,
-                        idle_close_ticks_threshold,
-                        max_minutes_value,
-                    )
-                    if grace_sec <= 0:
-                        stop_reason = "idle_timeout"
-                        break
-                    closing_deadline = await self._enter_closing_phase(
-                        grace_sec=grace_sec,
-                    )
-                    self.shared_state.consecutive_silent_ticks = 0
-                    continue
+                # N33 idle-timeout early-close has been removed to
+                # prioritise long-run continuity. ``consecutive_silent_ticks``
+                # is still tracked (the LLM / breakdown can read it), but
+                # the run no longer short-circuits into the closing phase
+                # when the LLM stops proposing actionable work — it keeps
+                # ticking until the wall-clock deadline (or another
+                # stop_reason) fires.
                 if in_closing:
                     report_terminal = await self._closing_report_terminal()
                     grace_blown = (
@@ -5339,21 +5291,14 @@ class Coordinator:
                 rule="execution_order",
                 hint="emit request kind='run_gemm_tuning' before run_optimization",
             )
-        # Note (c900791): main also gates ``run_optimization`` here on a
-        # gain-driven N19c rule (snapshot_id >= 1 + cheap-attempt
-        # recorded + last_cheap_delta_gain < EPSILON). On this branch
-        # the equivalent lives in PolicyGate as
-        # ``_validate_gain_driven_kernel_opt`` (F3-5 N19c, reads
-        # ``gain_per_stack_entry``), so the Coordinator-side gate is
-        # intentionally omitted here.
         return None
 
     @staticmethod
     def _allow_early_kernel_opt() -> bool:
         """Escape hatch — ``INFERENCE_OPTIMIZER_ALLOW_EARLY_KERNEL_OPT=1``
-        opens the kernel_opt request gate unconditionally (skips both
-        the snapshot check and the gain-driven N19c check). Used by
-        v0-baseline-comparison flows and unit tests."""
+        opens the kernel_opt request gate unconditionally (skips the
+        roofline-snapshot check). Used by v0-baseline-comparison flows
+        and unit tests."""
         return os.environ.get(
             "INFERENCE_OPTIMIZER_ALLOW_EARLY_KERNEL_OPT", "",
         ).strip().lower() in {"1", "true", "yes", "on"}
@@ -5363,20 +5308,9 @@ class Coordinator:
         right now — i.e. when the hot-kernel report-gate (PR-C) should
         fire and the LLM should be pushed toward kernel_opt.
 
-        Mirrors PolicyGate's F3-5 N19c ``_validate_gain_driven_kernel_opt``
-        check so the two gates never disagree. Without this yield-to-N19c
-        on the Coordinator side the LLM oscillates between
-        ``hot_kernel_unfinished`` (PR-C, deny report) and
-        ``n19c_gain_driven_kernel_opt`` (PolicyGate, deny kernel_opt
-        proposal) until ``policy_loop`` auto-stops the session
-        (Qwen3-30B-A3B-Base 20260523T014653Z died this way at tick=14).
-
         The gate is open when ANY of the following hold:
           * escape hatch env set;
-          * the gain-driven N19c toggle is off (legacy F3 default);
-          * the last ``_N19C_HISTORY_WINDOW`` cheap-round deltas in
-            ``gain_per_stack_entry`` average below the F3-5 epsilon
-            (i.e. cheap exploration has actually plateaued).
+          * a roofline snapshot exists (``roofline_snapshot_id`` >= 1).
         """
         if self._allow_early_kernel_opt():
             return True
@@ -5385,28 +5319,7 @@ class Coordinator:
         snapshot_id = ta.get("roofline_snapshot_id", 0)
         if not isinstance(snapshot_id, int) or snapshot_id < 1:
             return False
-        if not bool(getattr(ss, "gain_driven_kernel_opt", False)):
-            # F3-5 toggle off → mirror PolicyGate's early-return; gate
-            # is considered open once a roofline snapshot exists.
-            return True
-        try:
-            from .policy import PolicyGate as _PolicyGate
-            window = _PolicyGate._N19C_HISTORY_WINDOW
-            epsilon = _PolicyGate._N19C_EPSILON_PCT
-        except Exception:  # noqa: BLE001 — defensive, fall back to F3-5 defaults
-            window, epsilon = 3, 0.5
-        history = list(getattr(ss, "gain_per_stack_entry", []) or [])
-        deltas: list[float] = []
-        for entry in reversed(history):
-            if isinstance(entry, dict):
-                d = entry.get("delta_pct")
-                if isinstance(d, (int, float)):
-                    deltas.append(float(d))
-            if len(deltas) >= window:
-                break
-        if len(deltas) < window:
-            return False
-        return (sum(deltas) / float(len(deltas))) < float(epsilon)
+        return True
 
     @staticmethod
     def _skip_gemm_tuning() -> bool:
@@ -9017,7 +8930,15 @@ class Coordinator:
         resolved_action = action_name or str(
             (intent.payload or {}).get("action_name") or ""
         )
-        streak = self.shared_state.record_policy_denial(
+        # the streak counter is still a fact (LLM sees it via
+        # policy_denial_history for self-correction), but the system no
+        # longer reacts to it: neither auto-pruning the action family
+        # (streak >= 5) nor terminating the run with a ``policy_loop``
+        # stop_reason (streak >= 10). Long-run continuity is prioritised
+        # over loop-detection stop-loss — the LLM may keep retrying a
+        # denied action and the run continues until the wall-clock
+        # deadline (or another stop_reason) fires.
+        self.shared_state.record_policy_denial(
             action_name=resolved_action,
             rule=str(denied.rule or ""),
             hint=str(denied.hint or ""),
@@ -9025,24 +8946,6 @@ class Coordinator:
             tick=int(self.shared_state.tick or 0),
             intent_payload=intent.payload,
         )
-        # the streak counter is still a fact (LLM sees it
-        # via policy_denial_history), but we no longer mirror it onto
-        # a scoreboard ``locked_reason``. The phase machine's
-        # ``policy_loop`` stop_reason at streak ≥ 10 (below) remains
-        # the only system-side reaction.
-        if resolved_action and streak >= 5:
-            self.shared_state.prune_family(resolved_action)
-            await self._record_observation(
-                "coordinator", "observation",
-                {
-                    "kind": "auto_prune",
-                    "action": resolved_action,
-                    "rule": denied.rule,
-                    "streak": streak,
-                },
-            )
-        if streak >= 10:
-            self.shared_state.set_stop_reason("policy_loop")
 
     async def _record_observation(self, source: str, topic: str, payload: dict) -> None:
         await self.bus.append_and_seq(Message.new(source, "*", topic, payload))
@@ -9547,34 +9450,13 @@ class Coordinator:
                 )
             else:
                 await self._handle_unpromotable_result(task, result.result)
-            # N34 Bug #4 (May 2026): a successful ``report`` task is the
-            # canonical terminal signal — ``final.md`` / ``final.json``
-            # are already on disk, so any further LLM-driven exploration
-            # is waste. Set ``stop_reason='report_emitted'`` so the next
-            # run-loop iteration breaks out. Skip when ``stop_reason``
-            # is already set (signal / other terminal already won) so
-            # we don't paper over an earlier failure.
-            # N34 Bug #4 (May 2026) only fires for LLM-driven report
-            # tasks (kind="report" outside the closing phase). When the
-            # closing-phase report task is already in flight,
-            # ``in_closing`` owns the stop-reason transition — let the
-            # run loop's existing ``time_exhausted`` / ``no_more_leverage``
-            # path resolve it. Otherwise an LLM-proposed mid-run report
-            # would burn the rest of the budget without this guard.
-            if (
-                task.kind == "report"
-                and result.state == "succeeded"
-                and not (self.shared_state.stop_reason or "").strip()
-                and not self.shared_state.closing_report_task_id
-            ):
-                log.info(
-                    "Coordinator: report task %s succeeded; setting "
-                    "stop_reason='report_emitted' to terminate the run "
-                    "loop (N34 Bug #4 fix).",
-                    task.task_id,
-                )
-                self.shared_state.stop_reason = "report_emitted"
-                self.shared_state.save(self.session_dir)
+            # N34 Bug #4's ``report_emitted`` self-stop has been removed
+            # to prioritise long-run continuity: a successful mid-run
+            # ``report`` task no longer terminates the run loop. The LLM
+            # may emit a report snapshot and then keep exploring; the run
+            # continues until the wall-clock deadline (or another
+            # stop_reason) fires. The closing-phase report path still owns
+            # its own terminal transition via ``in_closing``.
             # Fact-write hook. Always called so KEEP / REVERT lands
             # in the local optimization_journal + (when enabled and the
             # threshold matches) a KB lesson / pitfall write. The

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -4100,13 +4100,13 @@ class Coordinator:
                 if objective.reached(self.shared_state):
                     stop_reason = "target_reached"
                     break
-                # The ``_has_no_more_leverage`` safety net (which used to
-                # wind the session down to SWEEP -> CLOSE via the
-                # skip_to_sweep hint when cheap rounds plateaued and every
-                # reusable kernel was rejected) has been removed to
-                # prioritise long-run continuity: the run keeps exploring
-                # until the wall-clock deadline rather than self-winding
-                # down on a plateau judgment.
+                # The no-more-leverage safety net (which used to wind the
+                # session down to SWEEP -> CLOSE via the skip_to_sweep hint
+                # when cheap rounds plateaued and every reusable kernel was
+                # rejected) has been removed to prioritise long-run
+                # continuity: the run keeps exploring until the wall-clock
+                # deadline rather than self-winding down on a plateau
+                # judgment.
                 if (
                     deadline is not None
                     and time.monotonic() >= deadline
@@ -4193,32 +4193,6 @@ class Coordinator:
                     pass
         return self.shared_state.stop_reason
 
-    async def _has_no_more_leverage(self) -> bool:
-        """Return True when automated explore/kernel levers are exhausted.
-
-        v0.8 plateau judgment lives in :mod:`phase_state`; this helper
-        is the safety-net check the closing-phase path consults before
-        winding the session down. We require:
-
-        1. baseline + current_best present (otherwise we are still in
-           PRELUDE / never finished a round)
-        2. no pending proposals or queued / running tasks
-        3. ``params_no_promote_streak >= 5`` (proxy still used as
-           the cross-phase plateau hint; see KB_gaps/Gap-15)
-        4. every reusable kernel_id is rejected.
-        """
-        if self.shared_state.baseline_tput <= 0:
-            return False
-        if not self.shared_state.current_best:
-            return False
-        if self.state.pending_proposals:
-            return False
-        if await self.tasks.queued() or await self.tasks.running():
-            return False
-        if self.shared_state.params_no_promote_streak < 5:
-            return False
-        return self._all_reusable_kernels_rejected()
-
     async def _enter_closing_phase(self, *, grace_sec: float) -> float:
         """Enter report-flush phase after the wall-clock deadline.
 
@@ -4294,27 +4268,6 @@ class Coordinator:
         return task.state in {
             "succeeded", "failed", "cancelled", "needs_manual_review",
         }
-
-    def _all_reusable_kernels_rejected(self) -> bool:
-        select = self.shared_state.last_trace_analyze or {}
-        reusable = {
-            str(k) for k in (select.get("reusable_native_kernel_ids") or [])
-            if k
-        }
-        if not reusable:
-            return bool(self.shared_state.last_profile_trace)
-
-        rejected = {
-            str(k) for k in (self.shared_state.rejected_kernel_ids or [])
-            if k
-        }
-        for entry in self.shared_state.rejected_kernel_patches or []:
-            if isinstance(entry, dict) and entry.get("kernel_id"):
-                rejected.add(str(entry["kernel_id"]))
-        last = self.shared_state.last_kernel_opt or {}
-        if last.get("kernel_id") and last.get("decision") == "REVERT":
-            rejected.add(str(last["kernel_id"]))
-        return reusable <= rejected
 
     # ==================================================================
     # Reactor

--- a/inference_optimizer/orchestrator/phase_state.py
+++ b/inference_optimizer/orchestrator/phase_state.py
@@ -190,7 +190,7 @@ PHASE_EXIT_REASONS: frozenset[str] = frozenset({
     "no_kernel_skipped",                # EXPLORE → SWEEP when kernel disabled
     "kernel_phase_aborted_no_trace",    # KERNEL → SWEEP when profile fails
     "explore_force_exit_low_budget",    # EXPLORE → next phase when total remaining or phase remaining drops below operator-configured thresholds
-    "no_more_leverage",                 # EXPLORE/KERNEL → SWEEP (non-terminal): steward stop_session or the _has_no_more_leverage safety net via the skip_to_sweep hint. Reclassified from a terminal stop_reason — it now winds the session down through SWEEP → CLOSE instead of aborting.
+    "no_more_leverage",                 # EXPLORE/KERNEL → SWEEP (non-terminal): steward stop_session via the skip_to_sweep hint. (The Coordinator's automatic no-more-leverage safety net was removed for long-run continuity.) Reclassified from a terminal stop_reason — it now winds the session down through SWEEP → CLOSE instead of aborting.
     # FRAMEWORK_PR phase transitions (PR-A1 / FRAMEWORK_PR phase).
     "framework_pr_phase_done",          # FRAMEWORK_PR → EXPLORE normal completion (no more candidates)
     "framework_pr_plateau",             # FRAMEWORK_PR → EXPLORE; 3 consecutive batches with no candidate ≥1% gain
@@ -362,9 +362,10 @@ ESCALATE_HINT_PAUSE_SPECIALIST_PREFIX: str = "pause_specialist_"
 # the optimization. Unlike ``skip_to_close`` (which is terminal via
 # ``_global_terminal`` → ``robustness_escalated``), ``skip_to_sweep``
 # still runs the SWEEP validation pass and produces a clean report.
-# It is set by the IR-7 steward's ``stop_session`` verdict and by the
-# Coordinator's ``_has_no_more_leverage`` safety net — both of which
-# used to set a terminal ``stop_reason='no_more_leverage'``.
+# It is set by the IR-7 steward's ``stop_session`` verdict, which used
+# to set a terminal ``stop_reason='no_more_leverage'``. (The Coordinator
+# also used to drive this via an automatic no-more-leverage safety net;
+# that net was removed for long-run continuity.)
 ESCALATE_HINT_VOCAB: frozenset[str] = frozenset({
     ESCALATE_HINT_SKIP_TO_KERNEL,
     ESCALATE_HINT_SKIP_TO_SWEEP,
@@ -991,9 +992,9 @@ def exit_normal_explore(
             "evidence": "llm_escalation",
             "hint": hint,
         }
-    # Non-terminal "no more leverage" signal (steward stop_session or the
-    # Coordinator's _has_no_more_leverage safety net). Winds EXPLORE down
-    # to SWEEP (skipping KERNEL) → CLOSE rather than aborting the session.
+    # Non-terminal "no more leverage" signal (steward stop_session). Winds
+    # EXPLORE down to SWEEP (skipping KERNEL) → CLOSE rather than aborting
+    # the session.
     # compute_next_phase routes the ``no_more_leverage`` reason to SWEEP.
     if hint == ESCALATE_HINT_SKIP_TO_SWEEP:
         return "no_more_leverage", {
@@ -1184,7 +1185,7 @@ def exit_normal_kernel(
        ``stop_reason=robustness_escalated``). Returns ``None`` here so
        the global path wins.
     2. ``skip_to_sweep`` hint (non-terminal "no more leverage" from the
-       _has_no_more_leverage safety net) → ``no_more_leverage``; KERNEL
+       steward's ``stop_session`` verdict) → ``no_more_leverage``; KERNEL
        already exits to SWEEP so this just forces the wind-down now.
     3. FP8 GEMM tuning completed and no source-level kernel attempts are
        queued/recorded → move on to SWEEP. GEMM tuning is the deterministic

--- a/inference_optimizer/orchestrator/policy.py
+++ b/inference_optimizer/orchestrator/policy.py
@@ -339,19 +339,6 @@ FRAMEWORK_PR_INTERNAL_ACTION_NAMES: frozenset[str] = frozenset({
 #: request.kind collision.
 KB_WRITE_TOOL_NAMES: frozenset[str] = frozenset({
     "mcp__cortex_kb__propose_point",
-    # The methods these tool names map to (propose_edge / hypothesize /
-    # ingest_attempt / verify / commit) have been retired from the
-    # client, but the tool names stay on the denylist because the
-    # safety contract — KB writes are Coordinator-owned, not
-    # specialist-callable — is independent of which methods currently
-    # exist. Specialists that attempt to invoke any of these get an
-    # immediate ``kb_write_unauthorized`` denial rather than a confusing
-    # "tool not found" downstream.
-    "mcp__cortex_kb__propose_edge",
-    "mcp__cortex_kb__hypothesize",
-    "mcp__cortex_kb__ingest_attempt",
-    "mcp__cortex_kb__verify",
-    "mcp__cortex_kb__commit",
 })
 
 #: KB *readonly* surfaces. R5 ``tool_whitelist_role`` requires the
@@ -907,11 +894,9 @@ class PolicyGate:
         # vllm engines on init; see _validate_sweep_singleton.
         if action_name == SWEEP_ACTION_NAME:
             self._validate_sweep_singleton(payload, intent_kind="delegate")
-        # Same gain-driven / explore-minimum gates apply at the
-        # delegate channel so kernel_opt cannot bypass them by skipping
-        # propose_action.
+        # Same explore-minimum gate applies at the delegate channel so
+        # kernel_opt cannot bypass it by skipping propose_action.
         self._validate_fp8_only_action(action_name, intent_kind="delegate")
-        self._validate_gain_driven_kernel_opt(action_name)
         self._validate_explore_minimum_before_kernel_opt(action_name)
         # If an ActionRegistry is wired, refuse delegate for unknown action names.
         # No registry → fall through (P0 / dev-mode where registry isn't loaded).
@@ -1010,11 +995,7 @@ class PolicyGate:
         if action_name == EXPLORE_ACTION_NAME:
             self._validate_explore_provenance(payload)
             self._validate_explore_grid_size(payload)
-        # F3-2 (Roofline-v2 N19c): gain-driven kernel_opt lock — until
-        # cheap rounds have plateaued, kernel_opt is denied so we don't
-        # spend a 30 min GPU lane on a cheap-still-earning frontier.
         self._validate_fp8_only_action(action_name, intent_kind="propose_action")
-        self._validate_gain_driven_kernel_opt(action_name)
         # F3-5: explore-attempt minimum guard — kernel_opt requires at
         # least one successful explore round on record.
         self._validate_explore_minimum_before_kernel_opt(action_name)
@@ -1032,81 +1013,8 @@ class PolicyGate:
     # Propose_action sub-gates (F3 series)
     #
     # Reading order in the dispatch path:
-    #   1. _validate_gain_driven_kernel_opt                 (N19c)
-    #   2. _validate_explore_minimum_before_kernel_opt      (F3-5)
+    #   1. _validate_explore_minimum_before_kernel_opt      (F3-5)
     # ------------------------------------------------------------------
-
-    _N19C_HISTORY_WINDOW: int = 3
-    _N19C_EPSILON_PCT: float = 0.5
-
-    def _validate_gain_driven_kernel_opt(self, action_name: str) -> None:
-        """F3-2 (N19c): lock ``kernel_opt`` until cheap exploration
-        plateaus.
-
-        Reads the last ``_N19C_HISTORY_WINDOW`` entries of
-        :attr:`SharedState.gain_per_stack_entry` (the canonical
-        per-KEEP delta_pct ledger this branch already maintains; v0.8
-        replacement for v0.6's ``last_cheap_explore_gain_pct``).
-        Denies if the moving-average ``delta_pct`` is still
-        ``>= _N19C_EPSILON_PCT``: cheap rounds are still earning,
-        burning a kernel-opt lane is premature.
-
-        Toggle: :attr:`SharedState.gain_driven_kernel_opt` (F0-10,
-        default off).
-        """
-        if action_name != "kernel_opt":
-            return
-        ss = getattr(self, "shared_state", None)
-        if ss is None:
-            return
-        if not bool(getattr(ss, "gain_driven_kernel_opt", False)):
-            return
-        # Defer to the phase allowlist when kernel_opt is proposed
-        # outside the KERNEL phase — the phase_incompatible rule's
-        # message is more actionable there. N19c is a within-KERNEL
-        # gate, not a phase gate.
-        if str(getattr(ss, "phase", "") or "") != "KERNEL":
-            return
-        history = list(getattr(ss, "gain_per_stack_entry", []) or [])
-        # Keep only entries with a real per-round delta on record
-        # (resumed / seeded entries use ``delta_pct=None``).
-        deltas: list[float] = []
-        for entry in reversed(history):
-            if not isinstance(entry, dict):
-                continue
-            d = entry.get("delta_pct")
-            if isinstance(d, (int, float)):
-                deltas.append(float(d))
-            if len(deltas) >= self._N19C_HISTORY_WINDOW:
-                break
-        if len(deltas) < self._N19C_HISTORY_WINDOW:
-            raise PolicyDenied(
-                f"propose_action: kernel_opt is locked: only "
-                f"{len(deltas)} cheap-round delta(s) on record "
-                f"(need {self._N19C_HISTORY_WINDOW} for the gain-trend "
-                f"window). Run more explore / specialist rounds first.",
-                rule="n19c_gain_driven_kernel_opt",
-                hint=(
-                    "propose_action{action_name='explore'} or "
-                    "delegate{action_name='specialist', ...} until the "
-                    "ledger has at least "
-                    f"{self._N19C_HISTORY_WINDOW} integrated rounds."
-                ),
-            )
-        avg = sum(deltas) / float(len(deltas))
-        if avg >= self._N19C_EPSILON_PCT:
-            raise PolicyDenied(
-                f"propose_action: kernel_opt is locked: cheap rounds "
-                f"still earning (last {len(deltas)} avg "
-                f"{avg:+.2f}% >= {self._N19C_EPSILON_PCT:.2f}%). "
-                f"Continue cheap rounds until the average drops below "
-                f"the threshold.",
-                rule="n19c_gain_driven_kernel_opt",
-                hint=(
-                    "propose_action{action_name='explore'} or "
-                    "delegate{action_name='specialist', ...}"
-                ),
-            )
 
     def _validate_explore_minimum_before_kernel_opt(
         self, action_name: str,
@@ -1158,8 +1066,6 @@ class PolicyGate:
                 hint=("include at least one allowed field, e.g. "
                       "{'changes': {'current_action': '<action_name>'}}"),
             )
-        if role.can_mutate_core_state:
-            return
         violating = sorted(set(changes.keys()) & CORE_STATE_FIELDS)
         if violating:
             raise PolicyDenied(

--- a/inference_optimizer/orchestrator/shared_state.py
+++ b/inference_optimizer/orchestrator/shared_state.py
@@ -663,9 +663,6 @@ class SharedState:
     # remain Coordinator-internal and are denied by PolicyGate when
     # proposed by the LLM (``analysis_action_not_llm_proposable``).
     enable_roofline: bool = True
-    # Cheap-rounds gain gate is opt-in — only locks ``kernel_opt`` when
-    # the operator has tuned the thresholds for their workload.
-    gain_driven_kernel_opt: bool = False
     # Per-variant overtime kill multiplier for ExploreExecutor: when
     # > 0 AND ``baseline_runtime_sec`` > 0, single-variant Magpie runs
     # in the explore loop are killed once their wall-clock exceeds

--- a/inference_optimizer/tests/test_coordinator_runtime.py
+++ b/inference_optimizer/tests/test_coordinator_runtime.py
@@ -1423,7 +1423,11 @@ async def _async_return(value: Any) -> Any:
 
 
 @pytest.mark.asyncio
-async def test_report_success_sets_stop_reason(session_dir):
+async def test_report_success_does_not_stop_run(session_dir):
+    """Long-run continuity: a successful mid-run ``report`` task no
+    longer sets ``stop_reason='report_emitted'``. The LLM may emit a
+    report snapshot and keep exploring; the run continues until the
+    wall-clock deadline (or another stop_reason) fires."""
     _write_marker_target_baseline(session_dir)
     c = Coordinator(session_dir, backends=_silent_backends())
     c.sub.register_executor("report", report_executor)
@@ -1438,9 +1442,7 @@ async def test_report_success_sets_stop_reason(session_dir):
         await c._pump_dispatcher_once()
         after = await c.tasks.get(task.task_id)
         assert after.state == "succeeded"
-        assert c.shared_state.stop_reason == "report_emitted"
-        on_disk = json.loads((session_dir / "state.json").read_text())
-        assert on_disk["stop_reason"] == "report_emitted"
+        assert not (c.shared_state.stop_reason or "").strip()
     finally:
         await c.stop()
 

--- a/inference_optimizer/tests/test_delegate_denial_loop.py
+++ b/inference_optimizer/tests/test_delegate_denial_loop.py
@@ -134,7 +134,10 @@ async def test_policy_denial_streak_records_streak_at_two(session_dir):
 
 
 @pytest.mark.asyncio
-async def test_policy_denial_streak_prunes_family_at_five(session_dir):
+async def test_policy_denial_streak_no_longer_prunes_family_at_five(session_dir):
+    """Long-run continuity: the streak >= 5 auto-prune_family reaction
+    was removed. A repeatedly-denied action family is NOT pruned; the
+    streak is still recorded as a fact the LLM can see."""
     c = _silent_coordinator(session_dir)
     try:
         from inference_optimizer.orchestrator.policy import PolicyDenied
@@ -144,13 +147,19 @@ async def test_policy_denial_streak_prunes_family_at_five(session_dir):
             await c._record_policy_denied(
                 "orchestration", intent, pd, action_name="params",
             )
-        assert "params" in c.shared_state.pruned_families
+        assert "params" not in c.shared_state.pruned_families
+        assert c.shared_state.policy_denial_streak.get(
+            "params:duplicate_idempotency_key", 0,
+        ) == 5
     finally:
         await c.stop()
 
 
 @pytest.mark.asyncio
-async def test_policy_denial_streak_sets_stop_reason_at_ten(session_dir):
+async def test_policy_denial_streak_no_longer_stops_run_at_ten(session_dir):
+    """Long-run continuity: the streak >= 10 ``policy_loop`` stop was
+    removed. A repeatedly-denied action no longer terminates the run;
+    the streak keeps climbing but stop_reason stays unset."""
     c = _silent_coordinator(session_dir)
     try:
         from inference_optimizer.orchestrator.policy import PolicyDenied
@@ -160,7 +169,10 @@ async def test_policy_denial_streak_sets_stop_reason_at_ten(session_dir):
             await c._record_policy_denied(
                 "orchestration", intent, pd, action_name="backends",
             )
-        assert c.shared_state.stop_reason == "policy_loop"
+        assert not (c.shared_state.stop_reason or "").strip()
+        assert c.shared_state.policy_denial_streak.get(
+            "backends:duplicate_idempotency_key", 0,
+        ) == 10
     finally:
         await c.stop()
 

--- a/inference_optimizer/tests/test_per_domain_prompts.py
+++ b/inference_optimizer/tests/test_per_domain_prompts.py
@@ -812,10 +812,7 @@ def test_specialist_tool_denylist_excludes_kb_write_paths():
     remain blocked because the KB lifecycle is Coordinator-owned.
     """
     for forbidden in (
-        "mcp__cortex_kb__hypothesize",
-        "mcp__cortex_kb__ingest_attempt",
-        "mcp__cortex_kb__verify",
-        "mcp__cortex_kb__commit",
+        "mcp__cortex_kb__propose_point",
     ):
         assert forbidden in SPECIALIST_TOOL_DENYLIST
         assert forbidden not in DEFAULT_SPECIALIST_TOOLS

--- a/inference_optimizer/tests/test_policy_gate_evolution.py
+++ b/inference_optimizer/tests/test_policy_gate_evolution.py
@@ -221,7 +221,7 @@ def test_delegate_with_kb_write_name_denied():
     gate = _gate()
     intent = Intent(
         type=IntentType.DELEGATE,
-        payload={"action_name": "mcp__cortex_kb__verify"},
+        payload={"action_name": "mcp__cortex_kb__propose_point"},
     )
     with pytest.raises(PolicyDenied) as excinfo:
         gate.validate_intent("orchestration", intent)
@@ -238,7 +238,7 @@ def test_request_kind_with_kb_write_name_denied():
         type=IntentType.REQUEST,
         payload={
             "target_agent": "kernel",
-            "kind": "mcp__cortex_kb__propose_edge",
+            "kind": "mcp__cortex_kb__propose_point",
         },
     )
     with pytest.raises(PolicyDenied) as excinfo:

--- a/inference_optimizer/tests/test_required_step_gates.py
+++ b/inference_optimizer/tests/test_required_step_gates.py
@@ -348,8 +348,9 @@ def test_report_denied_when_hot_reusable_kernels_untried(session_dir):
     being reusable hot kernels with zero attempts. The new gate must
     deny report and surface the untried set in the hint.
 
-    Requires N19c to be unlocked so the hot_kernel_unfinished rule
-    activates -- simulated here via cheap-exhausted (last_delta < EPS).
+    Requires the kernel_opt request gate to be open so the
+    hot_kernel_unfinished rule activates -- a roofline snapshot on
+    record opens it.
     """
     coord = Coordinator(session_dir, backends=_backends_full())
     _seed_post_baseline(coord)
@@ -363,7 +364,6 @@ def test_report_denied_when_hot_reusable_kernels_untried(session_dir):
     ])
     coord.shared_state.last_trace_analyze["roofline_snapshot_id"] = 1
     coord.shared_state.explore_attempts = [{"variant_name": "x"}]
-    coord.shared_state.last_cheap_delta_gain = 0.05  # below EPS
 
     denied = coord._sequence_denial_for_action("report")
     assert isinstance(denied, PolicyDenied)
@@ -416,9 +416,8 @@ def test_required_next_step_surfaces_untried_hot_kernels(session_dir):
     """``_required_next_step`` should also surface the TODO 4a line so
     Orchestration sees the explicit list when no KEEP is pending.
 
-    Requires N19c unlocked (cheap exhausted) -- otherwise the TODO is
-    intentionally hidden to avoid the death-spiral covered by the
-    test below.
+    Requires the kernel_opt request gate open (roofline snapshot on
+    record) -- otherwise the TODO is intentionally hidden.
     """
     coord = Coordinator(session_dir, backends=_backends_full())
     _seed_post_baseline(coord)
@@ -430,7 +429,6 @@ def test_required_next_step_surfaces_untried_hot_kernels(session_dir):
     ])
     coord.shared_state.last_trace_analyze["roofline_snapshot_id"] = 1
     coord.shared_state.explore_attempts = [{"variant_name": "x"}]
-    coord.shared_state.last_cheap_delta_gain = 0.05  # below EPS
     todo = coord._required_next_step()
     assert "TODO 4a/5" in todo
     # Highest gpu_pct first
@@ -454,109 +452,56 @@ def test_report_gate_inactive_when_no_reusable_hot_kernel_above_threshold(
 
 
 # ---------------------------------------------------------------------------
-# PR-C death-spiral guard: hot_kernel_unfinished must yield to N19c
-# (reproduces session 20260523T014653Z bug)
+# PR-C hot-kernel report gate: ``_kernel_opt_unlocked`` opens once a
+# roofline snapshot exists (or the escape hatch is set).
 # ---------------------------------------------------------------------------
-def _seed_post_cheap_round(coord, *, snapshot_id=1, last_delta=0.77):
-    """Mimic 'cheap action ran once'. On this branch
-    ``_kernel_opt_unlocked`` reads the F3-5 ``gain_per_stack_entry``
-    ledger (window=3, EPSILON=0.5%) instead of main's v0.6
-    ``backends_attempts`` + ``last_cheap_delta_gain``, so we seed the
-    last-3 deltas at ``last_delta`` and flip the
-    ``gain_driven_kernel_opt`` toggle on.
-
-    With ``last_delta=0.77`` (>= 0.5) the gate is CLOSED; with
-    ``last_delta=0.1`` (< 0.5) the gate is OPEN.
-    """
+def _seed_roofline_snapshot(coord, *, snapshot_id=1):
+    """Mark a roofline snapshot as recorded so ``_kernel_opt_unlocked``
+    reports the kernel_opt request gate as open."""
     coord.shared_state.last_trace_analyze = dict(
         coord.shared_state.last_trace_analyze or {}
     )
     coord.shared_state.last_trace_analyze["roofline_snapshot_id"] = snapshot_id
-    coord.shared_state.gain_driven_kernel_opt = True
-    coord.shared_state.gain_per_stack_entry = [
-        {"delta_pct": float(last_delta)} for _ in range(3)
-    ]
 
 
-def test_report_gate_yields_when_kernel_opt_locked_by_n19c(session_dir):
-    """20260523T014653Z death-spiral repro:
-
-    1. Cheap round produced +0.77% delta (> EPSILON=0.3%)
-       -> N19c locks kernel_opt
-    2. PR-C's untried_hot_reusable_kernels has k001/k002/k005/k008
-       -> hot_kernel_unfinished previously denied `report`
-    3. LLM tried run_optimization -> N19c denied execution_order
-    4. 10 consecutive execution_order denials -> policy_loop auto-stop
-
-    Fix: report's hot_kernel_unfinished rule must yield when
-    ``_kernel_opt_unlocked()`` returns False. The LLM can then either
-    propose another cheap round (preferred -- cheap is still earning)
-    or emit ``report`` if no cheap actions are left.
-    """
+def test_report_gate_fires_once_snapshot_exists(session_dir):
+    """With a roofline snapshot on record, ``_kernel_opt_unlocked`` is
+    open and PR-C's hot_kernel_unfinished rule denies ``report`` while
+    reusable hot kernels remain untried."""
     coord = Coordinator(session_dir, backends=_backends_full())
     _seed_post_baseline(coord)
     _seed_trace_analyze(coord, hot_kernels=[
         {"kernel_id": "k001", "gpu_pct": 31.9, "reusable_native_kernel": True,
          "source_file": "/p/moe_op.py"},
-        {"kernel_id": "k002", "gpu_pct": 47.9, "reusable_native_kernel": True,
+    ])
+    _seed_roofline_snapshot(coord, snapshot_id=1)
+
+    assert coord._kernel_opt_unlocked() is True
+    denied = coord._sequence_denial_for_action("report")
+    assert isinstance(denied, PolicyDenied)
+    assert denied.rule == "hot_kernel_unfinished"
+
+
+def test_report_gate_closed_without_snapshot(session_dir):
+    """Without a roofline snapshot (and no escape hatch),
+    ``_kernel_opt_unlocked`` is closed so hot_kernel_unfinished does
+    not push the LLM toward kernel_opt."""
+    coord = Coordinator(session_dir, backends=_backends_full())
+    _seed_post_baseline(coord)
+    _seed_trace_analyze(coord, hot_kernels=[
+        {"kernel_id": "k001", "gpu_pct": 31.9, "reusable_native_kernel": True,
          "source_file": "/p/moe_op.py"},
     ])
-    _seed_post_cheap_round(coord, snapshot_id=1, last_delta=0.77)
 
-    # N19c is locked (cheap still earning)
     assert coord._kernel_opt_unlocked() is False
-    # ... so hot_kernel_unfinished must NOT deny report
     denied = coord._sequence_denial_for_action("report")
     if denied is not None:
         assert denied.rule != "hot_kernel_unfinished", denied
 
 
-def test_required_next_step_hides_todo_4a_when_kernel_opt_locked(session_dir):
-    """Symmetric to the report-gate yield: TODO 4a must not push the
-    LLM toward `run_optimization` if N19c will just reject it."""
-    coord = Coordinator(session_dir, backends=_backends_full())
-    _seed_post_baseline(coord)
-    _seed_trace_analyze(coord, hot_kernels=[
-        {"kernel_id": "k001", "gpu_pct": 31.9, "reusable_native_kernel": True,
-         "source_file": "/p/moe_op.py"},
-    ])
-    _seed_post_cheap_round(coord, snapshot_id=1, last_delta=0.77)
-
-    todo = coord._required_next_step()
-    assert "TODO 4a" not in todo, (
-        f"TODO 4a leaked while N19c locks kernel_opt: {todo!r}"
-    )
-
-
-def test_report_gate_fires_again_after_cheap_exhausts(session_dir):
-    """Once cheap delta falls below EPSILON, N19c unlocks and PR-C
-    re-activates -- gate must fire again."""
-    coord = Coordinator(session_dir, backends=_backends_full())
-    _seed_post_baseline(coord)
-    _seed_trace_analyze(coord, hot_kernels=[
-        {"kernel_id": "k001", "gpu_pct": 31.9, "reusable_native_kernel": True,
-         "source_file": "/p/moe_op.py"},
-    ])
-    # First: cheap still earning -> gate yields
-    _seed_post_cheap_round(coord, snapshot_id=1, last_delta=0.77)
-    denied_1 = coord._sequence_denial_for_action("report")
-    assert denied_1 is None or denied_1.rule != "hot_kernel_unfinished"
-
-    # Then: cheap exhausted (delta drops below F3-5 epsilon=0.5%) ->
-    # gate fires
-    coord.shared_state.gain_per_stack_entry = [
-        {"delta_pct": 0.1} for _ in range(3)
-    ]
-    assert coord._kernel_opt_unlocked() is True
-    denied_2 = coord._sequence_denial_for_action("report")
-    assert isinstance(denied_2, PolicyDenied)
-    assert denied_2.rule == "hot_kernel_unfinished"
-
-
 def test_report_gate_active_with_escape_hatch(session_dir, monkeypatch):
-    """ALLOW_EARLY_KERNEL_OPT bypasses N19c -> kernel_opt is
-    immediately dispatchable -> hot_kernel_unfinished fires even
-    without a prior cheap round."""
+    """ALLOW_EARLY_KERNEL_OPT unlocks kernel_opt unconditionally ->
+    hot_kernel_unfinished fires even without a roofline snapshot."""
     monkeypatch.setenv("INFERENCE_OPTIMIZER_ALLOW_EARLY_KERNEL_OPT", "1")
     coord = Coordinator(session_dir, backends=_backends_full())
     _seed_post_baseline(coord)
@@ -564,7 +509,7 @@ def test_report_gate_active_with_escape_hatch(session_dir, monkeypatch):
         {"kernel_id": "k001", "gpu_pct": 31.9, "reusable_native_kernel": True,
          "source_file": "/p/moe_op.py"},
     ])
-    # No cheap round at all; escape hatch unlocks kernel_opt.
+    # No snapshot at all; escape hatch unlocks kernel_opt.
     assert coord._kernel_opt_unlocked() is True
     denied = coord._sequence_denial_for_action("report")
     assert isinstance(denied, PolicyDenied)

--- a/inference_optimizer/tests/test_specialist_subprocess.py
+++ b/inference_optimizer/tests/test_specialist_subprocess.py
@@ -219,9 +219,7 @@ def test_kb_write_tools_remain_denied():
     """KB lifecycle stays Coordinator-owned — Inv-2 / Inv-6.1 cannot
     be relaxed by PR-A2."""
     for kb_tool in (
-        "mcp__cortex_kb__hypothesize",
-        "mcp__cortex_kb__verify",
-        "mcp__cortex_kb__commit",
+        "mcp__cortex_kb__propose_point",
     ):
         assert kb_tool in SPECIALIST_TOOL_DENYLIST
 


### PR DESCRIPTION
… guards

Prioritises long-run continuity over loop-detection / plateau stop-loss.

PolicyGate cleanup (dead / always-off rules):
- Remove the N19c gain-driven kernel_opt lock (default toggle was always off; rule never fired in production). Drops the PolicyGate validator, the SharedState.gain_driven_kernel_opt field, the CLI flag, and the Coordinator-side mirror in _kernel_opt_unlocked (now snapshot-only).
- Drop 5 retired KB-write tool names from KB_WRITE_TOOL_NAMES (the methods were retired from the client; only propose_point remains).
- Remove the unreachable can_mutate_core_state exemption branch (no role sets the flag True).

Run-abort gate removal (long-run continuity):
- policy_loop stop (denial streak >= 10) and the streak >= 5 auto prune_family reaction. The streak is still recorded as a fact for LLM self-correction, but the system no longer prunes or terminates.
- _has_no_more_leverage -> skip_to_sweep early wind-down safety net.
- idle_timeout early-close on consecutive silent ticks.
- report_emitted self-stop on a successful mid-run report task.

Kept intact: execution_order / hot_kernel_unfinished / stack_rebench sequencing, baseline_failed / emergency crash protection, and the real wall-clock / signal / target_reached run boundaries.

Tests updated to assert the new behaviour; full inference_optimizer suite passes (3397 passed, 1 skipped).

- Description: what and why
- Linked issue(s): close/fix refs
- Tests: added/updated? commands run?
- Breaking changes: yes/no (details if yes)
