### PR TITLE
docs: add MIT LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,28 @@
+MIT License
+
+Copyright (c) 2025 Advanced Micro Devices, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## Third-Party Tools and Agents
+
+Hyperloom uses the Cursor, Visual Studio, and Claude Code agents. These tools
+are governed by their own separate license terms and are not covered by the
+MIT license above. Users are responsible for reviewing and complying with the
+individual licenses for each of those tools.


### PR DESCRIPTION
## Summary
- Add a root `LICENSE.md` declaring the project under the **MIT License** (Copyright (c) 2025 Advanced Micro Devices, Inc.).
- Includes a **Third-Party Tools and Agents** note: Hyperloom uses the Cursor, Visual Studio, and Claude Code agents, which carry their own separate license terms that users must review independently.

## Notes
- The repo already ships an Apache-2.0 `LICENSE` file. This PR adds `LICENSE.md` (MIT) as requested; maintainers should decide whether to reconcile the two so the project declares a single license.

## Test plan
- [ ] Confirm the MIT text and copyright line are correct.
- [ ] Decide whether the existing Apache-2.0 `LICENSE` should be removed/replaced to avoid a dual-license conflict.

Made with [Cursor](https://cursor.com)