### PR TITLE
 Changing the priority order for capture_traces 

### DIFF
--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -588,6 +588,8 @@ def _trace_input_sort_key(path: Path) -> tuple[int, str]:
         return (0, name)
     if re.search(r"TP-\d+-DECODE\.trace\.json(?:\.gz)?$", name):
         return (2, name)
+    if name.startswith("bs_") or name.startswith("graph_capture"):
+        return (3, name)
     return (1, name)
 
 


### PR DESCRIPTION

- Description: Changing the priority order to give capture_traces the last priority so they are not selected by the splitting script by mistake.
- Linked issue(s): close https://github.com/AMD-AGI/Hyperloom/issues/394
- Tests: added/updated? commands run? Tests are not updated. Verified using local deploy mode on Qwen3-8B + vLLM
- Breaking changes: yes/no (details if yes) No
