### PR TITLE
fix(baseline): eliminate cold-start warmup artifact via server_lifecycle double-run

### DIFF
--- a/inference_optimizer/orchestrator/action_executors/baseline.py
+++ b/inference_optimizer/orchestrator/action_executors/baseline.py
@@ -38,17 +38,24 @@ import importlib.util
 import json
 import logging
 import os
+import signal
 import subprocess
 import time
 from pathlib import Path
 from typing import Any
+
+import yaml
 
 from ...compat.payload_aliases import read_extra_server_args
 from ...paths import asset_root
 from ...session_paths import runs_dir
 from ..sub_agent_runner import RunnerContext
 from ._grid_runner import sanitize_result_dir, sanitize_script_name
-from ._subprocess_kill import run_with_session_kill
+from ._subprocess_kill import (
+    _process_group_alive,
+    _signal_group,
+    run_with_session_kill,
+)
 from ._workload_envs import (
     default_baseline_config,
     materialize_config_with_envs,
@@ -60,6 +67,39 @@ from .benchmark_result import (
 
 
 log = logging.getLogger(__name__)
+
+
+# Magpie's built-in InferenceX benchmark scripts that honour
+# ``MAGPIE_RUN_PHASE=server``/``client`` and therefore support the
+# server_lifecycle reuse protocol. Mirror of Magpie's
+# ``benchmarker.MAGPIE_BUILTIN_SCRIPTS`` — duplicated (not imported) so
+# Hyperloom keeps no import-time dependency on Magpie internals (Magpie
+# is not importable in the unit-test sandbox). The baseline cold-start
+# double-run guard only engages when the resolved benchmark script is
+# one of these; any other script (model-specific InferenceX scripts,
+# exotic GPU types without a generic Magpie script) falls back to the
+# legacy single-round path.
+MAGPIE_BUILTIN_SCRIPTS = frozenset(
+    {
+        "vllm_mi300x.sh",
+        "vllm_mi355x.sh",
+        "sglang_mi300x.sh",
+        "sglang_mi355x.sh",
+    }
+)
+
+# Default HTTP port Magpie's server_lifecycle binds the persistent server
+# on when ``benchmark.envs.PORT`` is unset (matches Magpie's
+# ``benchmarker._reuse_benchmark_port`` fallback). The double-run guard
+# pins it explicitly into the per-round YAML so Magpie's reuse keying and
+# our defensive teardown agree on the same port.
+BASELINE_REUSE_PORT_DEFAULT = 8888
+
+# Server-boot budget for the persistent server phase (server_lifecycle).
+# In lifecycle mode Magpie applies ``timeout_seconds`` to the client phase
+# only and gates server startup by this value. Matches Magpie's own
+# default; override via ``INFERENCE_OPTIMIZER_BASELINE_SERVER_READY_SEC``.
+BASELINE_SERVER_READY_TIMEOUT_SEC = 2700
 
 
 # Legacy module-level constant kept pointing at the sglang yaml so existing
@@ -377,6 +417,306 @@ class BaselineExecutor:
             hook_result.setdefault("output_dir", str(output_dir))
             return hook_result
 
+        # Cold-start "warmup artifact" guard. The baseline action is the
+        # FIRST step of the optimization flow, so the server is always
+        # freshly booted for the model under test. The first benchmark
+        # window therefore pays one-time cold-start costs (kernel JIT /
+        # torch.compile first-compile, CUDA/HIP-graph first-capture,
+        # KV-cache cold allocation, GPU not yet at boost clocks); the
+        # client-side ``--num-warmups`` (hardcoded ``2 * CONC`` in
+        # InferenceX's bench scripts) is far too small to absorb those.
+        # Taking that contaminated number as the baseline inflates every
+        # later gain into a fictitious 1600%+ "improvement" (see
+        # hyperloom_models_jun1.csv rows tagged ``warmup``).
+        #
+        # Fix: run the benchmark TWICE against the SAME persistent server
+        # via Magpie's ``server_lifecycle`` reuse protocol. Round 1 boots
+        # the server and runs a full client load (paying every one-time
+        # cold cost); round 2 re-attaches to the now-hot server (client
+        # only, no restart) and its throughput is the clean baseline. This
+        # eliminates ALL cold-start contamination — not just on-disk JIT
+        # caches but also CUDA-graph capture, allocator and clock warmup —
+        # because round 2 never restarts the server.
+        #
+        # Eligibility (else fall back to the legacy single round):
+        #   * env ``INFERENCE_OPTIMIZER_BASELINE_DOUBLE_RUN`` not disabled,
+        #   * single-node (server_lifecycle is local-only; multi-node uses
+        #     a long-lived RayJob server with no per-benchmark cold start),
+        #   * the resolved benchmark script is a Magpie built-in that
+        #     honours ``MAGPIE_RUN_PHASE`` (server_lifecycle requirement),
+        #   * the profiler is off (server_lifecycle + persistent server is
+        #     incompatible with torch_profiler unless cleanup=true).
+        lifecycle = self._resolve_lifecycle_params(materialized_config_path)
+        double_run = self._double_run_enabled() and lifecycle["eligible"]
+
+        common = {
+            "timeout_sec": timeout_sec,
+            "override_result_dir": override_result_dir,
+            "resolved_model": resolved_model,
+            "materialized_config_path": materialized_config_path,
+            "params": params,
+            "ctx": ctx,
+        }
+
+        if not double_run:
+            if self._double_run_enabled() and not lifecycle["eligible"]:
+                log.info(
+                    "baseline_executor: cold-start double-run not eligible "
+                    "(%s); running single round.", lifecycle["reason"],
+                )
+            return await self._run_single_benchmark(
+                config_path=config_path, output_dir=output_dir, **common,
+            )
+
+        framework = lifecycle["framework"]
+        port = lifecycle["port"]
+        # pid_dir is SHARED across both rounds (Magpie keys the persistent
+        # server by ``<pid_dir>/<framework>_<port>.{pid,json}``) so round 2
+        # discovers the server round 1 left running. Use the task root so
+        # it is isolated per baseline task and torn down with it.
+        pid_dir = output_dir
+        try:
+            # Round 1 (warmup): boot + run server, leave it running
+            # (cleanup=false) so round 2 can re-attach. Throughput is
+            # discarded — it carries the cold-start contamination.
+            warmup_dir = output_dir / "warmup_round"
+            warmup_cfg = self._write_lifecycle_config(
+                materialized_config_path, warmup_dir,
+                cleanup=False, pid_dir=pid_dir, port=port,
+            )
+            log.info(
+                "baseline_executor: cold-start guard — warmup round "
+                "(discarded, boots persistent server) in %s", warmup_dir,
+            )
+            warmup_result = await self._run_single_benchmark(
+                config_path=warmup_cfg, output_dir=warmup_dir, **common,
+            )
+            if warmup_result.get("status") != "succeeded":
+                # Hard failure in the warmup round (server never came up,
+                # timeout, etc.) almost certainly recurs, so skip the
+                # measured round. The finally block tears down any server
+                # the warmup round may have left half-booted.
+                warmup_result.setdefault("nonfatal_warnings", [])
+                warmup_result["nonfatal_warnings"].append(
+                    "baseline_warmup_round_failed",
+                )
+                log.warning(
+                    "baseline_executor: warmup round failed (error_class=%s)"
+                    "; skipping measured round",
+                    warmup_result.get("error_class"),
+                )
+                return warmup_result
+            warmup_tput = warmup_result.get("output_throughput")
+
+            # Round 2 (measured): re-attach to the hot server (client
+            # only). cleanup=true tears the server down after this round
+            # on the happy path; the finally block is the safety net.
+            measure_dir = output_dir / "measure_round"
+            measure_cfg = self._write_lifecycle_config(
+                materialized_config_path, measure_dir,
+                cleanup=True, pid_dir=pid_dir, port=port,
+            )
+            log.info(
+                "baseline_executor: cold-start guard — measured baseline "
+                "round in %s (warmup tput=%.1f tok/s discarded, reusing "
+                "hot server)", measure_dir, warmup_tput or 0.0,
+            )
+            result = await self._run_single_benchmark(
+                config_path=measure_cfg, output_dir=measure_dir, **common,
+            )
+            if result.get("status") == "succeeded":
+                result.setdefault("nonfatal_warnings", [])
+                result["nonfatal_warnings"].append(
+                    "baseline_double_run_discarded_first",
+                )
+                result["warmup_round_tput"] = warmup_tput
+                _hot = result.get("output_throughput") or 0.0
+                _cold = warmup_tput or 0.0
+                log.info(
+                    "baseline_executor: cold-start guard — measured "
+                    "baseline=%.1f tok/s (warmup=%.1f tok/s discarded; "
+                    "artifact would have been +%.0f%%)",
+                    _hot, _cold,
+                    ((_hot / _cold - 1.0) * 100.0) if _cold > 0 else 0.0,
+                )
+            return result
+        finally:
+            # Defensive teardown: guarantees no persistent server leaks
+            # regardless of which round failed. Idempotent — on the happy
+            # path round 2's cleanup=true already removed the pid/meta
+            # files, so this is a no-op.
+            self._teardown_lifecycle_server(
+                pid_dir=pid_dir, framework=framework, port=port,
+            )
+
+    @staticmethod
+    def _double_run_enabled() -> bool:
+        return os.environ.get(
+            "INFERENCE_OPTIMIZER_BASELINE_DOUBLE_RUN", "1",
+        ).strip().lower() not in ("0", "false", "no", "")
+
+    def _resolve_lifecycle_params(
+        self, materialized_config_path: Path,
+    ) -> dict[str, Any]:
+        """Inspect the materialized YAML to decide server_lifecycle
+        eligibility for the cold-start double-run.
+
+        Returns a dict with ``eligible`` (bool), ``framework`` (str),
+        ``port`` (int) and ``reason`` (str, populated when ineligible).
+        """
+        info: dict[str, Any] = {
+            "eligible": False,
+            "framework": "",
+            "port": BASELINE_REUSE_PORT_DEFAULT,
+            "reason": "",
+        }
+        try:
+            with Path(materialized_config_path).open(encoding="utf-8") as f:
+                cfg = yaml.safe_load(f) or {}
+        except (OSError, yaml.YAMLError) as exc:
+            info["reason"] = f"could not read materialized config: {exc}"
+            return info
+        bench = cfg.get("benchmark") or {}
+        info["framework"] = str(bench.get("framework") or "").lower()
+        envs = bench.get("envs") or {}
+        try:
+            info["port"] = int(envs.get("PORT", BASELINE_REUSE_PORT_DEFAULT))
+        except (TypeError, ValueError):
+            info["port"] = BASELINE_REUSE_PORT_DEFAULT
+
+        from ._multi_node_env import is_multi_node
+        if is_multi_node():
+            info["reason"] = "multi-node (server_lifecycle is local-only)"
+            return info
+
+        script_name = Path(str(bench.get("benchmark_script") or "")).name
+        if script_name not in MAGPIE_BUILTIN_SCRIPTS:
+            info["reason"] = (
+                f"benchmark_script={script_name!r} is not a Magpie built-in "
+                f"({sorted(MAGPIE_BUILTIN_SCRIPTS)})"
+            )
+            return info
+
+        profiler_on = bool(
+            (bench.get("profiler") or {})
+            .get("torch_profiler", {})
+            .get("enabled")
+        )
+        if profiler_on:
+            info["reason"] = "torch_profiler enabled (incompatible with reuse)"
+            return info
+
+        info["eligible"] = True
+        return info
+
+    def _write_lifecycle_config(
+        self,
+        base_config_path: Path,
+        dest_dir: Path,
+        *,
+        cleanup: bool,
+        pid_dir: Path,
+        port: int,
+    ) -> Path:
+        """Render a per-round YAML that injects ``benchmark.server_lifecycle``
+        on top of the materialized baseline config.
+
+        Both rounds share ``pid_dir`` + ``port`` so round 2 re-attaches to
+        the server round 1 left running. Only ``cleanup`` differs (round 1
+        persists the server, round 2 tears it down).
+        """
+        with Path(base_config_path).open(encoding="utf-8") as f:
+            cfg = yaml.safe_load(f) or {}
+        bench = cfg.setdefault("benchmark", {})
+        ready_timeout = int(os.environ.get(
+            "INFERENCE_OPTIMIZER_BASELINE_SERVER_READY_SEC",
+            BASELINE_SERVER_READY_TIMEOUT_SEC,
+        ))
+        bench["server_lifecycle"] = {
+            "enabled": True,
+            "cleanup": bool(cleanup),
+            "force_reuse": False,
+            "pid_dir": str(pid_dir),
+            "server_ready_timeout_s": ready_timeout,
+        }
+        # Pin PORT so Magpie's reuse keying and our teardown agree.
+        envs = bench.setdefault("envs", {})
+        envs["PORT"] = int(port)
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        out = Path(dest_dir) / "baseline_lifecycle.yaml"
+        with out.open("w", encoding="utf-8") as f:
+            yaml.safe_dump(cfg, f, sort_keys=False)
+        return out
+
+    def _teardown_lifecycle_server(
+        self, *, pid_dir: Path, framework: str, port: int,
+    ) -> None:
+        """Best-effort teardown of a persistent server left by the
+        double-run rounds. Idempotent and never raises (safe in finally).
+
+        On the happy path round 2's ``cleanup=true`` already removed the
+        pid/meta files and killed the server, so this is a no-op. It only
+        does real work on the abnormal paths (warmup-round failure, an
+        exception between rounds, or a round 2 timeout that skipped
+        Magpie's own cleanup).
+        """
+        base = Path(pid_dir)
+        tag = f"{framework}_{port}"
+        pid_file = base / f"{tag}.pid"
+        meta_file = base / f"{tag}.json"
+        server_pid: int | None = None
+        server_pgid: int | None = None
+        try:
+            if pid_file.exists():
+                parts = pid_file.read_text(encoding="utf-8").split()
+                if parts:
+                    server_pid = int(parts[0])
+                if len(parts) > 1:
+                    server_pgid = int(parts[1])
+        except (OSError, ValueError):
+            server_pid = server_pid
+
+        if server_pid is not None and os.name == "posix":
+            # The persistent server is setsid'd into its own session, so
+            # its pgid equals its pid unless the pid file recorded one.
+            pgid = server_pgid if server_pgid is not None else server_pid
+            _signal_group(pgid, signal.SIGTERM)
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                if not _process_group_alive(pgid):
+                    break
+                time.sleep(0.1)
+            if _process_group_alive(pgid):
+                _signal_group(pgid, signal.SIGKILL)
+            log.info(
+                "baseline_executor: lifecycle teardown — reaped persistent "
+                "server pgid=%d (%s:%d)", pgid, framework, port,
+            )
+        for p in (pid_file, meta_file):
+            try:
+                p.unlink()
+            except OSError:
+                pass
+
+    async def _run_single_benchmark(
+        self,
+        *,
+        config_path: Path,
+        output_dir: Path,
+        timeout_sec: int,
+        override_result_dir: str | None,
+        resolved_model: str,
+        materialized_config_path: Path,
+        params: dict[str, Any],
+        ctx: RunnerContext,
+    ) -> dict[str, Any]:
+        """Run one Magpie benchmark subprocess and parse its result.
+
+        This is the single-round execution core extracted from
+        ``__call__`` so the cold-start guard can invoke it twice (warmup
+        round + measured round). ``output_dir`` is the per-round slot the
+        Magpie workspace and harvested artifacts land under.
+        """
         cmd = [
             self.magpie_python, "-m", "Magpie", "-v", "benchmark",
             "--benchmark-config", str(config_path),

--- a/inference_optimizer/orchestrator/action_executors/baseline.py
+++ b/inference_optimizer/orchestrator/action_executors/baseline.py
@@ -71,20 +71,24 @@ log = logging.getLogger(__name__)
 
 # Magpie's built-in InferenceX benchmark scripts that honour
 # ``MAGPIE_RUN_PHASE=server``/``client`` and therefore support the
-# server_lifecycle reuse protocol. Mirror of Magpie's
+# server_lifecycle reuse protocol. Static mirror of Magpie's
 # ``benchmarker.MAGPIE_BUILTIN_SCRIPTS`` — duplicated (not imported) so
-# Hyperloom keeps no import-time dependency on Magpie internals (Magpie
-# is not importable in the unit-test sandbox). The baseline cold-start
-# double-run guard only engages when the resolved benchmark script is
-# one of these; any other script (model-specific InferenceX scripts,
-# exotic GPU types without a generic Magpie script) falls back to the
-# legacy single-round path.
+# Hyperloom keeps no import-time dependency on Magpie internals (Magpie is
+# not importable in the unit-test sandbox). Keep in sync with Magpie. The
+# cold-start double-run guard only engages when the resolved benchmark
+# script is one of these; any other script (model-specific InferenceX
+# scripts, exotic GPU types without a generic Magpie script) falls back to
+# the legacy single round. ``atom_*`` per AMD-AGI/Magpie#34 (atom-as-a-
+# framework requires that PR, which also ships the phase-aware atom
+# scripts, so listing them here can never outrun Magpie support).
 MAGPIE_BUILTIN_SCRIPTS = frozenset(
     {
         "vllm_mi300x.sh",
         "vllm_mi355x.sh",
         "sglang_mi300x.sh",
         "sglang_mi355x.sh",
+        "atom_mi300x.sh",
+        "atom_mi355x.sh",
     }
 )
 

--- a/inference_optimizer/orchestrator/action_executors/baseline.py
+++ b/inference_optimizer/orchestrator/action_executors/baseline.py
@@ -507,6 +507,7 @@ class BaselineExecutor:
                 )
                 return warmup_result
             warmup_tput = warmup_result.get("output_throughput")
+            warmup_runtime = warmup_result.get("subprocess_runtime_sec")
 
             # Round 2 (measured): re-attach to the hot server (client
             # only). cleanup=true tears the server down after this round
@@ -530,6 +531,26 @@ class BaselineExecutor:
                     "baseline_double_run_discarded_first",
                 )
                 result["warmup_round_tput"] = warmup_tput
+                # Overtime-kill anchor fix: the Coordinator promotes
+                # ``subprocess_runtime_sec`` into
+                # ``SharedState.baseline_runtime_sec``, which the
+                # ExploreExecutor turns into the per-variant soft-kill
+                # deadline (``baseline_runtime_sec * kill_ratio``). Explore
+                # variants each RESTART the server (full server-boot +
+                # client), but round 2 here reused the hot server
+                # (client-only), so its wall-clock is far too small an
+                # anchor and would soft-kill normal variants as
+                # KILLED_OVERTIME. Report round 1's FULL server-boot +
+                # client wall-clock as the anchor instead (it matches the
+                # explore variants' run profile); keep round 2's client-only
+                # time under a separate key for transparency / debugging.
+                if isinstance(warmup_runtime, (int, float)) and warmup_runtime > 0:
+                    result["measure_round_runtime_sec"] = result.get(
+                        "subprocess_runtime_sec",
+                    )
+                    result["subprocess_runtime_sec"] = round(
+                        float(warmup_runtime), 2,
+                    )
                 _hot = result.get("output_throughput") or 0.0
                 _cold = warmup_tput or 0.0
                 log.info(
@@ -674,7 +695,9 @@ class BaselineExecutor:
                 if len(parts) > 1:
                     server_pgid = int(parts[1])
         except (OSError, ValueError):
-            server_pid = server_pid
+            # Best-effort: proceed with whatever (if anything) was parsed
+            # before the error. Teardown is defensive and must never raise.
+            pass
 
         if server_pid is not None and os.name == "posix":
             # The persistent server is setsid'd into its own session, so
@@ -696,6 +719,8 @@ class BaselineExecutor:
             try:
                 p.unlink()
             except OSError:
+                # File already gone (round 2 cleanup=true removed it) or
+                # unremovable; either way teardown must not raise.
                 pass
 
     async def _run_single_benchmark(

--- a/inference_optimizer/tests/test_baseline_warmup_double_run.py
+++ b/inference_optimizer/tests/test_baseline_warmup_double_run.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import asyncio
 import json
 import subprocess
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -284,6 +285,61 @@ def test_baseline_warmup_round_failure_short_circuits(tmp_path):
     assert result["status"] == "failed"
     assert state["calls"] == 1
     assert "baseline_warmup_round_failed" in result.get("nonfatal_warnings", [])
+
+
+def test_double_run_runtime_anchor_is_full_warmup_round(tmp_path):
+    """The overtime-kill anchor (``subprocess_runtime_sec`` ->
+    ``baseline_runtime_sec``) must reflect round 1's FULL server-boot +
+    client wall-clock, NOT round 2's client-only reuse time.
+
+    Otherwise the ExploreExecutor's soft-kill deadline
+    (``baseline_runtime_sec * kill_ratio``) is anchored to the tiny
+    client-only round-2 time and would kill normal full-run variants as
+    KILLED_OVERTIME. Round 1 (full run) sleeps longer than round 2
+    (reuse) here so the assertion is deterministic.
+    """
+    base = tmp_path / "base.yaml"
+    _write_yaml(base, framework="vllm")
+    output_dir = tmp_path / "ws"
+
+    state = {"calls": 0}
+
+    def fake_run(cmd, *args, **kwargs):
+        out_idx = cmd.index("--output-dir")
+        slot = Path(cmd[out_idx + 1])
+        # Round 1 (full boot + client) is slow; round 2 (client-only
+        # reuse) is fast. The executor measures wall-clock around this
+        # call, so distinct sleeps make the anchor check deterministic.
+        if state["calls"] == 0:
+            time.sleep(0.6)
+            tput = _COLD_TPUT
+        else:
+            tput = _HOT_TPUT
+        state["calls"] += 1
+        _fake_workspace(slot, tput=tput)
+        return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+    executor = _executor(base, tmp_path)
+    ctx = _make_ctx({
+        "output_dir": str(output_dir),
+        "timeout_sec": 10,
+        "gpu_type": "mi300x",
+    })
+
+    with patch(
+        "inference_optimizer.orchestrator.action_executors.baseline."
+        "run_with_session_kill",
+        side_effect=fake_run,
+    ):
+        result = _run(executor(ctx))
+
+    assert result["status"] == "succeeded"
+    assert state["calls"] == 2
+    # Anchor reflects the slow round-1 full run...
+    assert result["subprocess_runtime_sec"] >= 0.5
+    # ...and round 2's client-only time is kept separately and is smaller.
+    assert "measure_round_runtime_sec" in result
+    assert result["measure_round_runtime_sec"] < result["subprocess_runtime_sec"]
 
 
 def test_teardown_lifecycle_server_removes_state_files(tmp_path):

--- a/inference_optimizer/tests/test_baseline_warmup_double_run.py
+++ b/inference_optimizer/tests/test_baseline_warmup_double_run.py
@@ -287,6 +287,37 @@ def test_baseline_warmup_round_failure_short_circuits(tmp_path):
     assert "baseline_warmup_round_failed" in result.get("nonfatal_warnings", [])
 
 
+def test_atom_engages_double_run_like_vllm_sglang(tmp_path):
+    """Atom is a Magpie built-in (phase-aware) framework per
+    AMD-AGI/Magpie#34, so an atom baseline engages the lifecycle
+    double-run just like vllm/sglang."""
+    base = tmp_path / "base.yaml"
+    _write_yaml(base, framework="atom")
+    output_dir = tmp_path / "ws"
+
+    captured: list = []
+    fake_run, state = _cold_then_hot_fake_run(captured)
+    executor = _executor(base, tmp_path)
+    ctx = _make_ctx({
+        "output_dir": str(output_dir),
+        "timeout_sec": 10,
+        "gpu_type": "mi300x",
+    })
+
+    with patch(
+        "inference_optimizer.orchestrator.action_executors.baseline."
+        "run_with_session_kill",
+        side_effect=fake_run,
+    ):
+        result = _run(executor(ctx))
+
+    assert result["status"] == "succeeded"
+    assert state["calls"] == 2
+    assert result["output_throughput"] == pytest.approx(_HOT_TPUT)
+    assert captured[0]["benchmark"]["benchmark_script"] == "atom_mi300x.sh"
+    assert captured[0]["benchmark"]["server_lifecycle"]["enabled"] is True
+
+
 def test_double_run_runtime_anchor_is_full_warmup_round(tmp_path):
     """The overtime-kill anchor (``subprocess_runtime_sec`` ->
     ``baseline_runtime_sec``) must reflect round 1's FULL server-boot +

--- a/inference_optimizer/tests/test_baseline_warmup_double_run.py
+++ b/inference_optimizer/tests/test_baseline_warmup_double_run.py
@@ -1,0 +1,305 @@
+"""Regression tests for the baseline cold-start "warmup artifact".
+
+Root cause (see hyperloom_models_jun1.csv rows tagged ``warmup``):
+``BaselineExecutor`` used to run Magpie exactly once and take that
+throughput as ``baseline_tput``. The baseline action is the FIRST step of
+the optimization flow, so the server is always freshly booted for the
+model under test. The first benchmark window is contaminated by one-time
+cold-start costs (kernel JIT / torch.compile first-compile, CUDA/HIP-graph
+first-capture, KV-cache cold allocation, GPU not yet at boost clocks). The
+client-side ``--num-warmups`` (hardcoded ``2 * CONC``) is far too small to
+absorb them, so the measured baseline lands well below the real hot-state
+value. Every later optimization round runs against an already-hot server,
+so ``gain = final/baseline - 1`` is inflated into a fictitious
+1600%-2160% "improvement".
+
+Fix: run the benchmark TWICE against the SAME persistent server via
+Magpie's ``server_lifecycle`` reuse protocol. Round 1 boots the server and
+pays every cold cost; round 2 re-attaches to the now-hot server (client
+only, no restart) and its throughput is the clean baseline.
+
+These tests mock ``run_with_session_kill`` so the first (warmup) round
+returns a cold throughput and the second (measured) round returns a hot
+throughput, then assert the executor reports the HOT value as the
+baseline and that each round's Magpie config carries the right
+``server_lifecycle`` block.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from inference_optimizer.orchestrator.action_executors.baseline import (
+    BaselineExecutor,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_leak_root(tmp_path_factory, monkeypatch):
+    sandbox = tmp_path_factory.mktemp("isolated_leak_root_warmup")
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_LEAK_ROOTS", str(sandbox))
+    # Keep TP clamp deterministic on CPU-only CI (no GPU visible).
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_VISIBLE_GPU_COUNT", "8")
+
+
+def _write_yaml(path: Path, *, framework: str = "vllm") -> None:
+    cfg: dict = {
+        "benchmark": {
+            "framework": framework,
+            "model": "/wekafs/models/Qwen-Qwen3-8B",
+            "precision": "fp8",
+            "run_mode": "local",
+            "envs": {"TP": 1, "CONC": 64, "ISL": 1024, "OSL": 1024},
+            "timeout_seconds": 600,
+            "profiler": {
+                "torch_profiler": {"enabled": False},
+                "system_profiler": {"enabled": False},
+                "tracelens": {"enabled": False},
+            },
+            "gpu_selection": {"auto": False},
+        }
+    }
+    with path.open("w") as f:
+        yaml.safe_dump(cfg, f)
+
+
+def _fake_workspace(slot: Path, *, tput: float) -> Path:
+    ws = slot / "benchmark_vllm_20260602_010101"
+    ws.mkdir(parents=True)
+    (ws / "benchmark_report.json").write_text(json.dumps({
+        "success": True,
+        "framework": "vllm",
+        "model": "/wekafs/models/Qwen-Qwen3-8B",
+        "throughput": {
+            "request_throughput": tput / 1024,
+            "output_throughput": tput,
+            "total_token_throughput": tput * 2,
+            "completed_requests": 64,
+            "duration_seconds": 25.0,
+        },
+        "latency": {
+            "ttft": {"mean_ms": 100.0, "p99_ms": 120.0},
+            "e2el": {"mean_ms": 2000.0, "p99_ms": 2300.0},
+        },
+    }))
+    return ws
+
+
+def _make_ctx(params: dict) -> SimpleNamespace:
+    task = SimpleNamespace(task_id="t-baseline-warmup", params=params)
+    return SimpleNamespace(task=task, extra={})
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# Cold first round / hot second round throughputs, modelled on the
+# MaralGPT-Maral-7B-alpha-1 CSV row (baseline 270.9 -> final 4701.6).
+_COLD_TPUT = 270.9
+_HOT_TPUT = 4701.6
+
+
+def _cold_then_hot_fake_run(captured: list | None = None):
+    """Return a ``run_with_session_kill`` stand-in that emits a cold
+    throughput on its first call and a hot throughput thereafter.
+
+    Each call materializes a ``benchmark_*`` workspace under the
+    ``--output-dir`` slot the executor passed, and (if ``captured`` is
+    given) records the parsed ``--benchmark-config`` YAML so tests can
+    assert the per-round ``server_lifecycle`` block.
+    """
+    state = {"calls": 0}
+
+    def fake_run(cmd, *args, **kwargs):
+        out_idx = cmd.index("--output-dir")
+        slot = Path(cmd[out_idx + 1])
+        if captured is not None:
+            cfg_idx = cmd.index("--benchmark-config")
+            cfg = yaml.safe_load(Path(cmd[cfg_idx + 1]).read_text())
+            captured.append(cfg)
+        tput = _COLD_TPUT if state["calls"] == 0 else _HOT_TPUT
+        state["calls"] += 1
+        _fake_workspace(slot, tput=tput)
+        return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+    return fake_run, state
+
+
+def _executor(base: Path, tmp_path: Path) -> BaselineExecutor:
+    return BaselineExecutor(
+        magpie_python="/opt/venv/bin/python",
+        default_config_path=base,
+        session_dir=tmp_path,
+    )
+
+
+def test_baseline_discards_cold_first_round_via_lifecycle(tmp_path):
+    """The executor reports the HOT (second-round) throughput as the
+    baseline, runs two rounds, and each round carries a server_lifecycle
+    block sharing one pid_dir so round 2 reuses round 1's hot server."""
+    base = tmp_path / "base.yaml"
+    _write_yaml(base, framework="vllm")
+    output_dir = tmp_path / "ws"
+
+    captured: list = []
+    fake_run, state = _cold_then_hot_fake_run(captured)
+    executor = _executor(base, tmp_path)
+    ctx = _make_ctx({
+        "output_dir": str(output_dir),
+        "timeout_sec": 10,
+        "gpu_type": "mi300x",
+    })
+
+    with patch(
+        "inference_optimizer.orchestrator.action_executors.baseline."
+        "run_with_session_kill",
+        side_effect=fake_run,
+    ):
+        result = _run(executor(ctx))
+
+    assert result["status"] == "succeeded"
+    assert state["calls"] == 2
+    # Reported baseline is the HOT value, not the cold one.
+    assert result["output_throughput"] == pytest.approx(_HOT_TPUT)
+    # Discarded cold value surfaced for auditability.
+    assert result.get("warmup_round_tput") == pytest.approx(_COLD_TPUT)
+    assert "baseline_double_run_discarded_first" in result["nonfatal_warnings"]
+
+    # Both rounds requested server_lifecycle on a built-in vllm script.
+    assert len(captured) == 2
+    warmup_lc = captured[0]["benchmark"]["server_lifecycle"]
+    measure_lc = captured[1]["benchmark"]["server_lifecycle"]
+    assert warmup_lc["enabled"] is True and measure_lc["enabled"] is True
+    # Round 1 persists the server; round 2 tears it down.
+    assert warmup_lc["cleanup"] is False
+    assert measure_lc["cleanup"] is True
+    # Shared pid_dir + port so round 2 re-attaches to round 1's server.
+    assert warmup_lc["pid_dir"] == measure_lc["pid_dir"] == str(output_dir)
+    assert captured[0]["benchmark"]["envs"]["PORT"] == (
+        captured[1]["benchmark"]["envs"]["PORT"]
+    )
+    assert captured[0]["benchmark"]["benchmark_script"] == "vllm_mi300x.sh"
+
+
+def test_baseline_single_round_when_double_run_disabled(tmp_path, monkeypatch):
+    """``INFERENCE_OPTIMIZER_BASELINE_DOUBLE_RUN=0`` reverts to the legacy
+    single-round behaviour (which reproduces the artifact) — an operator
+    escape hatch. No server_lifecycle is injected."""
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_BASELINE_DOUBLE_RUN", "0")
+    base = tmp_path / "base.yaml"
+    _write_yaml(base, framework="vllm")
+    output_dir = tmp_path / "ws"
+
+    captured: list = []
+    fake_run, state = _cold_then_hot_fake_run(captured)
+    executor = _executor(base, tmp_path)
+    ctx = _make_ctx({
+        "output_dir": str(output_dir),
+        "timeout_sec": 10,
+        "gpu_type": "mi300x",
+    })
+
+    with patch(
+        "inference_optimizer.orchestrator.action_executors.baseline."
+        "run_with_session_kill",
+        side_effect=fake_run,
+    ):
+        result = _run(executor(ctx))
+
+    assert result["status"] == "succeeded"
+    assert state["calls"] == 1
+    assert result["output_throughput"] == pytest.approx(_COLD_TPUT)
+    assert "warmup_round_tput" not in result
+    assert "server_lifecycle" not in captured[0]["benchmark"]
+
+
+def test_baseline_single_round_when_script_not_builtin(tmp_path):
+    """When the resolved benchmark script is NOT a Magpie built-in
+    (server_lifecycle unsupported), the guard falls back to one round
+    even with double-run enabled."""
+    base = tmp_path / "base.yaml"
+    _write_yaml(base, framework="vllm")
+    output_dir = tmp_path / "ws"
+
+    captured: list = []
+    fake_run, state = _cold_then_hot_fake_run(captured)
+    executor = _executor(base, tmp_path)
+    # A model-specific InferenceX script (not in MAGPIE_BUILTIN_SCRIPTS).
+    ctx = _make_ctx({
+        "output_dir": str(output_dir),
+        "timeout_sec": 10,
+        "gpu_type": "mi300x",
+        "benchmark_script": "dsr1_fp8_mi300x.sh",
+    })
+
+    with patch(
+        "inference_optimizer.orchestrator.action_executors.baseline."
+        "run_with_session_kill",
+        side_effect=fake_run,
+    ):
+        result = _run(executor(ctx))
+
+    assert result["status"] == "succeeded"
+    assert state["calls"] == 1
+    assert result["output_throughput"] == pytest.approx(_COLD_TPUT)
+    assert "server_lifecycle" not in captured[0]["benchmark"]
+
+
+def test_baseline_warmup_round_failure_short_circuits(tmp_path):
+    """If the warmup round fails (server never came up), the executor
+    returns the failure immediately and does NOT run a second round. The
+    finally teardown runs but is a no-op (no pid file)."""
+    base = tmp_path / "base.yaml"
+    _write_yaml(base, framework="vllm")
+    output_dir = tmp_path / "ws"
+    state = {"calls": 0}
+
+    def fake_run(cmd, *args, **kwargs):
+        state["calls"] += 1
+        return subprocess.CompletedProcess(cmd, 1, "", "boom: server crashed")
+
+    executor = _executor(base, tmp_path)
+    ctx = _make_ctx({
+        "output_dir": str(output_dir),
+        "timeout_sec": 10,
+        "gpu_type": "mi300x",
+    })
+
+    with patch(
+        "inference_optimizer.orchestrator.action_executors.baseline."
+        "run_with_session_kill",
+        side_effect=fake_run,
+    ):
+        result = _run(executor(ctx))
+
+    assert result["status"] == "failed"
+    assert state["calls"] == 1
+    assert "baseline_warmup_round_failed" in result.get("nonfatal_warnings", [])
+
+
+def test_teardown_lifecycle_server_removes_state_files(tmp_path):
+    """The defensive teardown unlinks stale pid/meta files (no live
+    server in the unit env) without raising."""
+    executor = _executor(tmp_path / "base.yaml", tmp_path)
+    _write_yaml(tmp_path / "base.yaml", framework="vllm")
+    pid_dir = tmp_path / "pids"
+    pid_dir.mkdir()
+    # No real process: use a PID that is essentially never alive.
+    (pid_dir / "vllm_8888.pid").write_text("2147483646")
+    (pid_dir / "vllm_8888.json").write_text("{}")
+
+    executor._teardown_lifecycle_server(
+        pid_dir=pid_dir, framework="vllm", port=8888,
+    )
+
+    assert not (pid_dir / "vllm_8888.pid").exists()
+    assert not (pid_dir / "vllm_8888.json").exists()


### PR DESCRIPTION
## Problem

The `baseline` action is the **first** step of the optimization flow, so the inference server is always freshly booted for the model under test. The original code ran the benchmark **once** and took that throughput as `baseline_tput`. The first benchmark window is contaminated by one-time cold-start costs (CUDA/HIP graph capture, allocator warmup, GPU clock ramp, lazy kernel JIT). The hardcoded client-side `--num-warmups` (`2 * CONC`) is far too small to absorb them, so the baseline is under-reported.

Every later optimization round runs against an already-hot server, so `gain = final/baseline - 1` gets inflated into a fictitious "improvement". In `hyperloom_models_jun1.csv` this surfaced as `warmup`-tagged rows with up to **+1635%** bogus gains (e.g. MaralGPT-Maral-7B `270.9 -> 4701.6`).

## Fix

Run the benchmark **twice against the same persistent server** via Magpie's `server_lifecycle` reuse protocol:

- **Round 1 (warmup)** — boots + runs the server, pays every cold-start cost. Throughput **discarded** (surfaced as `warmup_round_tput` for auditability).
- **Round 2 (measured)** — re-attaches to the now-hot server (client only, no restart). Its throughput is the clean baseline.

Because round 2 never restarts the server, this removes **all** cold-start contamination, not just on-disk JIT caches.

### Safety / scope
- **Eligibility-gated**: single-node only (server_lifecycle is local-only), the resolved script must be a Magpie built-in that implements the `MAGPIE_RUN_PHASE` server/client split, profiler off. Otherwise falls back to the legacy single round. The gate is on the *phase-aware script*, not the framework: model-specific InferenceX scripts (e.g. `dsr1_fp8_mi300x.sh`) also fall back.
- **Frameworks**: `vllm_*` / `sglang_*` today; **`atom_*` included** per AMD-AGI/Magpie#34 (atom ships the same phase-split generic script; atom-as-a-framework already requires that PR, so the allowlist entry can never outrun Magpie support).
- **Overtime-kill anchor**: the double-run success result reports round 1's full server-boot + client wall-clock as `subprocess_runtime_sec` (the value the Coordinator promotes to `baseline_runtime_sec` for the explore soft-kill deadline), since explore variants each restart the server. Round 2's client-only reuse time is kept under `measure_round_runtime_sec` for transparency. (Avoids false KILLED_OVERTIME on normal variants.)
- **Defensive `finally` teardown** guarantees no persistent server leaks on any failure path (idempotent; happy path is handled by Magpie's `cleanup=true` on round 2).
- **Escape hatch**: `INFERENCE_OPTIMIZER_BASELINE_DOUBLE_RUN=0` reverts to single round.
- Changes live entirely in `baseline.py`.

## Real-model validation (vLLM, MI300x, TP=1 CONC=64 ISL/OSL=1024)

5 models, bf16 + fp8, each a full double-run. Hot (new) baseline is consistently above the discarded cold (old) value, and round 2 is ~2x faster (server reuse confirmed):

| model | precision | cold (old) | hot (new) | artifact |
|---|---|---|---|---|
| Qwen2.5-3B | bf16 | 9115.5 | 10101.3 | +10.8% |
| Qwen3-4B-Instruct | bf16 | 5704.0 | 6137.6 | +7.6% |
| Llama-3-8B-Instruct | bf16 | 4673.5 | 5407.1 | +15.7% |
| Llama-3.1-8B | bf16 | 4680.4 | 5413.9 | +15.7% |
| Qwen3-8B | fp8 | 4348.9 | 4852.5 | +11.6% |

Note: on vLLM the artifact is ~8-16% (graphs/compile happen at boot, before `/health`). The CSV's extreme +1635% cases were sglang/fp8 (lazy aiter JIT compile caught in the first benchmark window); the same fix removes those too since round 2 always reuses a fully-warm server. The sglang extreme was **not** re-validated here (vLLM-only environment).

## Test plan

- [x] New unit tests `test_baseline_warmup_double_run.py` (7): cold->hot via lifecycle, single-round when disabled, single-round when script not built-in, warmup-failure short-circuit, **atom engages double-run**, **overtime anchor = round-1 full run**, teardown removes state files.
- [x] Full suite: 3353 passed (pre-existing failures are unrelated missing test deps `respx` / web_tools).
- [x] 5 real vLLM models validated end-to-end (server boot, two rounds, reuse, teardown — no GPU leaks).

## Dependency
- `atom_*` lifecycle support depends on **AMD-AGI/Magpie#34** (adds the phase-aware atom scripts + atom to `MAGPIE_BUILTIN_SCRIPTS`). vllm/sglang need no Magpie change.