### PR TITLE
feat(breakdown): surface kernel_optimization_summary + conc_sweep_summary in sbd

### DIFF
--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -3618,6 +3618,150 @@ def _normalize_kernel_roofline_entry(raw: dict[str, Any]) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Kernel Optimization Summary (Breakdown 面板对接文档 §A1; PR #399)
+# ---------------------------------------------------------------------------
+_KERNEL_OPT_SUMMARY_REL_PATH = "reports/kernel_optimization_summary.json"
+
+
+def collect_kernel_optimization_summary(
+    session_dir: Path,
+    warnings: list[str],
+) -> dict[str, Any]:
+    """Mirror ``<session_dir>/reports/kernel_optimization_summary.json``
+    into the breakdown's ``kernel_optimization_summary`` section
+    (Breakdown 面板对接文档 §A1).
+
+    The file is produced deterministically by the ``report`` action
+    (``orchestrator.kernel_attempt_summary.build_kernel_optimization_summary``),
+    which runs as CLOSE step 1 — strictly *before* the
+    ``session_breakdown`` action (step 2) writes this breakdown — so the
+    report is already on disk for a normally-closed session. Mirroring
+    it here lets the dashboard read sbd alone instead of walking the
+    ``reports/`` + kernel-agent tree itself.
+
+    Behaviour (matches :func:`collect_kernel_roofline`):
+
+    * File missing → ``{}``, **no warning**. Offline / pre-#399 sessions
+      and any session where the ``report`` action never ran simply won't
+      have it; the dashboard hides Block 1 on an empty dict.
+    * Malformed / non-object JSON → ``{}`` + warning (never raises).
+    * Otherwise the report is mirrored **verbatim** (so producer-side
+      field additions ride through without a breakdown schema change),
+      apart from light shape guards on the containers the dashboard
+      iterates (``by_kernel`` list; ``totals`` /
+      ``*_breakdown`` / ``field_glossary`` objects), plus an added
+      ``report_path`` rel-link to the source file.
+    """
+    path = session_dir / _KERNEL_OPT_SUMMARY_REL_PATH
+    if not path.exists():
+        # Quiet on absence — keeps breakdowns of legacy / non-report
+        # sessions warning-free (mirrors collect_kernel_roofline).
+        return {}
+    blob = _load_json_safe(path, warnings)
+    if not isinstance(blob, dict):
+        warnings.append(
+            f"kernel_optimization_summary: {_KERNEL_OPT_SUMMARY_REL_PATH} "
+            "is not a JSON object"
+        )
+        return {}
+
+    out = dict(blob)
+
+    raw_by_kernel = out.get("by_kernel")
+    if raw_by_kernel is None:
+        out["by_kernel"] = []
+    elif not isinstance(raw_by_kernel, list):
+        warnings.append(
+            "kernel_optimization_summary.by_kernel is not a list; dropping entries"
+        )
+        out["by_kernel"] = []
+    else:
+        # Drop any non-dict rows so the dashboard can iterate safely;
+        # otherwise pass each row through verbatim (nested verification /
+        # backend_ladder shapes documented in §A1.4).
+        out["by_kernel"] = [r for r in raw_by_kernel if isinstance(r, dict)]
+
+    for key in (
+        "totals", "rejection_breakdown", "unattempted_reason_breakdown",
+        "failure_reason_breakdown", "field_glossary",
+    ):
+        val = out.get(key)
+        if val is not None and not isinstance(val, dict):
+            warnings.append(
+                f"kernel_optimization_summary.{key} is not an object; dropping"
+            )
+            out[key] = {}
+
+    takeaways = out.get("top_takeaways")
+    if takeaways is not None and not isinstance(takeaways, list):
+        warnings.append(
+            "kernel_optimization_summary.top_takeaways is not a list; dropping"
+        )
+        out["top_takeaways"] = []
+
+    out["report_path"] = _rel(path, session_dir) or _KERNEL_OPT_SUMMARY_REL_PATH
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Conc Sweep Summary (Breakdown 面板对接文档 §A2; PR #399)
+# ---------------------------------------------------------------------------
+_CONC_SWEEP_SUMMARY_REL_PATH = "reports/conc_sweep_summary.json"
+
+
+def collect_conc_sweep_summary(
+    session_dir: Path,
+    warnings: list[str],
+) -> dict[str, Any]:
+    """Mirror ``<session_dir>/reports/conc_sweep_summary.json`` into the
+    breakdown's ``conc_sweep_summary`` section (Breakdown 面板对接文档 §A2).
+
+    Produced by the ``conc_sweep`` action during SWEEP (well before
+    CLOSE), so it is already on disk when sbd exports. Surfacing it here
+    extends the single-CONC headline gain into the full baseline-vs-
+    current_best CONC ladder for the dashboard's dual-curve chart.
+
+    Behaviour:
+
+    * File missing → ``{}``, **no warning** (conc_sweep often disabled /
+      skipped; the dashboard hides Block 2 on an empty dict).
+    * Malformed / non-object JSON → ``{}`` + warning (never raises).
+    * Otherwise mirrored **verbatim** + an added ``report_path``. The
+      only shape guard is on ``comparison`` (the array the dual-curve
+      chart iterates directly).
+
+    IMPORTANT — do **not** synthesize the optional blocks: when the
+    producer writes ``status="skipped"`` it intentionally omits
+    ``baseline`` / ``optimized`` / ``comparison`` / ``summary`` (§A2.4),
+    and ``roofline_ceiling`` (§A2.9) is absent on older products.
+    Consumers must branch on ``status`` before reading those keys; we
+    pass through exactly what the producer wrote.
+    """
+    path = session_dir / _CONC_SWEEP_SUMMARY_REL_PATH
+    if not path.exists():
+        return {}
+    blob = _load_json_safe(path, warnings)
+    if not isinstance(blob, dict):
+        warnings.append(
+            f"conc_sweep_summary: {_CONC_SWEEP_SUMMARY_REL_PATH} "
+            "is not a JSON object"
+        )
+        return {}
+
+    out = dict(blob)
+
+    comparison = out.get("comparison")
+    if comparison is not None and not isinstance(comparison, list):
+        warnings.append(
+            "conc_sweep_summary.comparison is not a list; dropping entries"
+        )
+        out["comparison"] = []
+
+    out["report_path"] = _rel(path, session_dir) or _CONC_SWEEP_SUMMARY_REL_PATH
+    return out
+
+
+# ---------------------------------------------------------------------------
 # Optimization stack — raw KEEP ledger passthrough
 # ---------------------------------------------------------------------------
 # ``state.optimization_stack[]`` is the authoritative ordered list of

--- a/inference_optimizer/breakdown/exporter.py
+++ b/inference_optimizer/breakdown/exporter.py
@@ -188,6 +188,24 @@ def build(
                                         ),
                                         warnings,
                                         default={})
+    # Kernel-agent attempt outcome summary (Breakdown 面板对接文档 §A1).
+    # Mirrors ``<sd>/reports/kernel_optimization_summary.json`` (written
+    # by the report action at CLOSE step 1, before this export at step
+    # 2). Empty dict when absent → dashboard hides Block 1.
+    kernel_optimization_summary = _safe_collect(
+        "kernel_optimization_summary",
+        lambda: collectors.collect_kernel_optimization_summary(sd, warnings),
+        warnings,
+        default={})
+    # Post-optimization concurrency sweep (Breakdown 面板对接文档 §A2).
+    # Mirrors ``<sd>/reports/conc_sweep_summary.json`` (written by the
+    # conc_sweep action during SWEEP). Empty dict when absent →
+    # dashboard hides Block 2.
+    conc_sweep_summary = _safe_collect(
+        "conc_sweep_summary",
+        lambda: collectors.collect_conc_sweep_summary(sd, warnings),
+        warnings,
+        default={})
     # Per-snapshot roofline comparison list driving the markdown-
     # report ``## Roofline`` section. Built from
     # ``state.roofline_snapshots`` history.
@@ -267,6 +285,14 @@ def build(
         # Empty dict when ``<sd>/reports/kernel_roofline.json`` is
         # absent — the dashboard hides the table on empty.
         "kernel_roofline":     kernel_roofline,
+        # Kernel-agent attempt outcome summary (Breakdown 面板对接文档
+        # §A1). Mirror of ``reports/kernel_optimization_summary.json``;
+        # empty dict on absence (dashboard hides Block 1).
+        "kernel_optimization_summary": kernel_optimization_summary,
+        # Post-optimization concurrency sweep (Breakdown 面板对接文档
+        # §A2). Mirror of ``reports/conc_sweep_summary.json``; empty
+        # dict on absence (dashboard hides Block 2).
+        "conc_sweep_summary":  conc_sweep_summary,
         # Per-snapshot roofline comparison list (markdown-report
         # source). Built from ``state.roofline_snapshots``.
         "roofline":            roofline,

--- a/inference_optimizer/breakdown/schema.py
+++ b/inference_optimizer/breakdown/schema.py
@@ -22,10 +22,15 @@ from typing import Any, TypedDict
 
 #: breakdown schema version. v2 adds the
 #: ``specialist_runs`` section, ``capability_summary.specialist``
-#: row, ``critic_robustness.kb_writes_summary`` sub-block, and the
+#: row, ``critic_robustness.kb_writes_summary`` sub-block, the
 #: top-level ``action_timeline`` / ``explore_search`` v1-reader
-#: aliases. Inv-12.1 guarantees a v0.6 / reader can still
-#: consume the file because v2 only *adds* fields.
+#: aliases, and (additively) the ``kernel_optimization_summary`` /
+#: ``conc_sweep_summary`` sections mirrored from
+#: ``reports/kernel_optimization_summary.json`` and
+#: ``reports/conc_sweep_summary.json`` (PR #399 lishuoshuo). Inv-12.1
+#: guarantees a v0.6 / v1 reader can still consume the file because v2
+#: only *adds* fields — the version string does not bump for additive
+#: sections.
 SCHEMA_VERSION = "hyperloom.session_breakdown.v2"
 
 
@@ -937,6 +942,65 @@ class KernelRoofline(TypedDict, total=False):
     kernels: list[KernelRooflineEntry]
 
 
+# ---------------------------------------------------------------------------
+# Kernel Optimization Summary (Breakdown 面板对接文档 A1; PR #399 lishuoshuo)
+# ---------------------------------------------------------------------------
+# Mirror of ``<session_dir>/reports/kernel_optimization_summary.json``
+# (produced deterministically by the ``report`` action via
+# ``orchestrator/kernel_attempt_summary.build_kernel_optimization_summary``).
+# Answers "did each top kernel get optimized by the kernel-agent, and
+# why did it fail" without the dashboard walking the kernel-agent tree.
+# The collector mirrors the report verbatim (light top-level shape
+# guards only) so new producer fields ride through without a schema
+# change; the deeply-nested ``by_kernel[]`` rows therefore stay loose
+# (``dict``) and are documented in roofline优化对接文档.md §A1.4.
+class KernelOptimizationSummary(TypedDict, total=False):
+    schema_version: int                    # producer schema (currently 1; int, unlike conc_sweep's str)
+    session_id: str                        # global id ``{model}_{ts}_{short_uuid}``
+    model_name: str
+    cumulative_gain_validated_pct: float
+    totals: dict[str, int]                 # {top_candidates, attempted, integrated, keep_pending, rejected, in_flight, unattempted}
+    rejection_breakdown: dict[str, int]
+    unattempted_reason_breakdown: dict[str, int]
+    failure_reason_breakdown: dict[str, int]
+    field_glossary: dict[str, str]         # {field_name: explanation} for tooltips
+    top_takeaways: list[str]               # 2-4 deterministic (non-LLM) sentences
+    by_kernel: list[dict[str, Any]]        # one row per top kernel, sorted gpu_pct desc; shape per §A1.4
+    report_path: str                       # rel-to-session path to the mirrored source report
+
+
+# ---------------------------------------------------------------------------
+# Conc Sweep Summary (Breakdown 面板对接文档 A2; PR #399 lishuoshuo)
+# ---------------------------------------------------------------------------
+# Mirror of ``<session_dir>/reports/conc_sweep_summary.json`` (produced
+# by the ``conc_sweep`` action during SWEEP). Extends the single-CONC
+# headline gain into a baseline-vs-current_best curve across a CONC
+# ladder. Absent when conc_sweep never ran (Block hidden). When
+# ``status="skipped"`` the producer omits the baseline/optimized/
+# comparison/summary blocks — read ``status`` before those keys.
+class ConcSweepSummary(TypedDict, total=False):
+    schema_version: str                    # producer schema (currently "1.0"; str, unlike kernel summary's int)
+    status: str                            # succeeded / failed / skipped
+    skip_reason: str                       # only when status="skipped"
+    session_id: str
+    isl: int
+    osl: int
+    tp: int
+    concs_requested: list[int]
+    baseline: dict[str, Any]               # {extra_server_args, extra_envs, points[]}
+    optimized: dict[str, Any]              # {extra_server_args, extra_envs, points[]}
+    comparison: list[dict[str, Any]]       # per-CONC paired rows (feeds the dual curve + speedup bars)
+    summary: dict[str, Any]                # {successful_pairs, failed_pairs, best_conc, best_speedup, median_speedup, mean_speedup}
+    workspace: str
+    elapsed_sec: float
+    total_budget_sec: int                  # None when budget gate disabled
+    budget_exhausted: bool
+    report_json_path: str
+    report_csv_path: str                   # for the "download CSV" button
+    roofline_ceiling: dict[str, Any]       # per-CONC theoretical peak + MBU% (§A2.9); may be absent on old products
+    report_path: str                       # rel-to-session path to the mirrored source report
+
+
 class SessionBreakdown(TypedDict, total=False):
     schema_version: str
     exported_at_utc: str
@@ -987,6 +1051,15 @@ class SessionBreakdown(TypedDict, total=False):
     # §1). Mirrors ``<sd>/reports/kernel_roofline.json`` so consumers
     # don't have to walk the kernel-agent output tree themselves.
     kernel_roofline: KernelRoofline
+    # Kernel-agent attempt outcome summary (Breakdown 面板对接文档 §A1).
+    # Mirrors ``<sd>/reports/kernel_optimization_summary.json``. Empty
+    # dict when the report is absent (session predates PR #399 or the
+    # ``report`` action never ran) — the dashboard hides Block 1.
+    kernel_optimization_summary: KernelOptimizationSummary
+    # Post-optimization concurrency sweep (Breakdown 面板对接文档 §A2).
+    # Mirrors ``<sd>/reports/conc_sweep_summary.json``. Empty dict when
+    # conc_sweep never ran — the dashboard hides Block 2.
+    conc_sweep_summary: ConcSweepSummary
     # Per-snapshot roofline comparison list (one entry per
     # ``state.roofline_snapshots`` history pass). Drives the markdown-
     # report ``## Roofline`` section. Each entry has ``source_path /
@@ -1013,6 +1086,7 @@ __all__ = [
     "BenchmarkInvocation",
     "CapabilityEntry",
     "CapabilitySummary",
+    "ConcSweepSummary",
     "CriticIteration",
     "CriticKBWritesSummary",
     "CriticRobustness",
@@ -1028,6 +1102,7 @@ __all__ = [
     "LaneTimelineEntry",
     "KernelLifecycle",
     "KernelMetadata",
+    "KernelOptimizationSummary",
     "OptimizedKernel",
     "ParamSearch",
     "ParamSearchEntry",

--- a/inference_optimizer/tests/test_breakdown_smoke.py
+++ b/inference_optimizer/tests/test_breakdown_smoke.py
@@ -1274,6 +1274,240 @@ def test_kernel_roofline_empty_kernels_list_is_valid(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# kernel_optimization_summary (Breakdown 面板对接文档 §A1; PR #399)
+# ---------------------------------------------------------------------------
+# The collector mirrors ``<sd>/reports/kernel_optimization_summary.json``
+# verbatim (light shape guards only) so the dashboard reads sbd alone.
+# Written by the report action at CLOSE step 1, before sbd export at
+# step 2 — so a normally-closed session always has it on disk.
+def _report_fixture(tmp_path: Path, rel_path: str, payload: dict | None) -> Path:
+    """Session_dir with an optional ``reports/<file>.json``."""
+    sd = tmp_path / "session"
+    _write_json(sd / "manifest.json", {"schema_version": 1, "session_id": "rep"})
+    _write_json(sd / "state.json", {"session_id": "rep"})
+    if payload is not None:
+        _write_json(sd / rel_path, payload)
+    return sd
+
+
+def test_kernel_opt_summary_missing_file_returns_empty_dict(tmp_path: Path) -> None:
+    """No report → empty dict, no warning (legacy / non-report sessions
+    must stay warning-free; dashboard hides Block 1)."""
+    sd = _report_fixture(tmp_path, "reports/kernel_optimization_summary.json", None)
+    bd = build(sd)
+    assert bd["kernel_optimization_summary"] == {}
+    assert not any("kernel_optimization_summary" in w for w in bd["warnings"])
+
+
+def test_kernel_opt_summary_full_payload_passes_through(tmp_path: Path) -> None:
+    """Happy path: every documented field round-trips verbatim,
+    including the deeply-nested by_kernel rows (verification +
+    backend_ladder), and a rel ``report_path`` is added."""
+    payload = {
+        "schema_version": 1,
+        "session_id": "Qwen-Qwen3-30B-A3B-Base_20260602T134619Z_f70dd15b",
+        "model_name": "Qwen-Qwen3-30B-A3B-Base",
+        "cumulative_gain_validated_pct": 1.01,
+        "totals": {
+            "top_candidates": 15, "attempted": 6, "integrated": 1,
+            "keep_pending": 0, "rejected": 5, "in_flight": 0, "unattempted": 9,
+        },
+        "rejection_breakdown": {"revert_decision": 1, "max_failures_without_keep": 2,
+                                 "max_partial_attempts_without_keep": 2, "other": 0},
+        "unattempted_reason_breakdown": {"no_source_file": 4, "not_reusable_native_kernel": 2,
+                                          "no_recommended_backend": 2, "below_priority_cutoff": 1,
+                                          "unknown": 0},
+        "failure_reason_breakdown": {"ladder_all_failed": 3, "correctness_failed": 1},
+        "field_glossary": {"gpu_pct": "GPU time share 0-100"},
+        "top_takeaways": [
+            "1 of 6 attempted kernels reached KEEP and integrated; 5 were rejected.",
+        ],
+        "by_kernel": [
+            {
+                "kernel_id": "k001", "kernel_name": "aiter::ck_moe_stage1",
+                "kernel_category": "MoE", "source_file": "/abs/foo.cu",
+                "gpu_pct": 9.2, "efficiency_pct": 48.3, "bound_type": "memory-bound",
+                "arithmetic_intensity": 104.4, "category": "ATTEMPTED_REJECTED",
+                "attempts_total": 3, "rejected_reason": "max_failures_without_keep",
+                "verification": {"compile_passed": False, "correctness_passed": None,
+                                  "micro_speedup": 1.0},
+                "backend_ladder": [
+                    {"backend": "geak", "status": "failed", "produced_artifact": False,
+                     "elapsed_sec": 213.5, "error_class": "preprocess_failed",
+                     "error_message": "preprocess reported 1 error(s)"},
+                    {"backend": "claude", "status": "failed", "produced_artifact": False,
+                     "elapsed_sec": 483.5, "error_class": "timeout",
+                     "error_message": "Timed out after 480s"},
+                ],
+            },
+            {
+                "kernel_id": "k002", "kernel_name": "aten::mm", "kernel_category": "GEMM",
+                "source_file": "", "gpu_pct": 6.1, "category": "UNATTEMPTED",
+                "reusable_native_kernel": False, "recommended_backends": [],
+                "unattempted_reason": "no_source_file",
+                "unattempted_detail": "vendor-library op; address via backend swap",
+            },
+        ],
+    }
+    sd = _report_fixture(tmp_path, "reports/kernel_optimization_summary.json", payload)
+    ks = build(sd)["kernel_optimization_summary"]
+
+    # Envelope (note int schema_version, unlike conc_sweep's str).
+    assert ks["schema_version"] == 1
+    assert ks["model_name"] == "Qwen-Qwen3-30B-A3B-Base"
+    assert ks["cumulative_gain_validated_pct"] == pytest.approx(1.01)
+    assert ks["totals"]["top_candidates"] == 15
+    assert ks["failure_reason_breakdown"]["ladder_all_failed"] == 3
+    assert ks["top_takeaways"][0].startswith("1 of 6 attempted")
+
+    # by_kernel verbatim passthrough incl. nested structures + order.
+    assert [k["kernel_id"] for k in ks["by_kernel"]] == ["k001", "k002"]
+    k1 = ks["by_kernel"][0]
+    assert k1["category"] == "ATTEMPTED_REJECTED"
+    assert k1["verification"]["compile_passed"] is False
+    assert k1["verification"]["correctness_passed"] is None
+    assert k1["backend_ladder"][1]["error_class"] == "timeout"
+    assert ks["by_kernel"][1]["unattempted_reason"] == "no_source_file"
+
+    # Added rel link to the source report.
+    assert ks["report_path"] == "reports/kernel_optimization_summary.json"
+
+
+def test_kernel_opt_summary_all_zero_totals_is_valid(tmp_path: Path) -> None:
+    """Report action always writes a summary even when no kernel was
+    attempted (all-zero totals + empty by_kernel) — that's a valid,
+    warning-free Block-1-empty state, not a malformed file."""
+    payload = {
+        "schema_version": 1, "session_id": "s", "model_name": "m",
+        "cumulative_gain_validated_pct": 0.0,
+        "totals": {"top_candidates": 0, "attempted": 0, "integrated": 0,
+                    "keep_pending": 0, "rejected": 0, "in_flight": 0, "unattempted": 0},
+        "by_kernel": [], "top_takeaways": [],
+    }
+    sd = _report_fixture(tmp_path, "reports/kernel_optimization_summary.json", payload)
+    bd = build(sd)
+    ks = bd["kernel_optimization_summary"]
+    assert ks["by_kernel"] == []
+    assert ks["totals"]["attempted"] == 0
+    assert not any("kernel_optimization_summary" in w for w in bd["warnings"])
+
+
+def test_kernel_opt_summary_by_kernel_not_a_list_drops_to_empty(tmp_path: Path) -> None:
+    """``by_kernel`` arriving as a non-list is replaced with [] + warning;
+    envelope still round-trips (collector never raises)."""
+    payload = {"schema_version": 1, "totals": {"top_candidates": 1},
+               "by_kernel": {"k001": {"name": "broken"}}}
+    sd = _report_fixture(tmp_path, "reports/kernel_optimization_summary.json", payload)
+    bd = build(sd)
+    ks = bd["kernel_optimization_summary"]
+    assert ks["schema_version"] == 1
+    assert ks["by_kernel"] == []
+    assert any("by_kernel is not a list" in w for w in bd["warnings"])
+
+
+def test_kernel_opt_summary_non_dict_blob_returns_empty(tmp_path: Path) -> None:
+    """Top-level JSON is not an object → empty dict + warning, never raise."""
+    sd = tmp_path / "session"
+    _write_json(sd / "manifest.json", {"schema_version": 1, "session_id": "rep"})
+    _write_json(sd / "state.json", {"session_id": "rep"})
+    (sd / "reports").mkdir(parents=True, exist_ok=True)
+    (sd / "reports" / "kernel_optimization_summary.json").write_text(
+        json.dumps([{"kernel_id": "k001"}]), encoding="utf-8",
+    )
+    bd = build(sd)
+    assert bd["kernel_optimization_summary"] == {}
+    assert any("kernel_optimization_summary" in w and "not a JSON object" in w
+               for w in bd["warnings"])
+
+
+# ---------------------------------------------------------------------------
+# conc_sweep_summary (Breakdown 面板对接文档 §A2; PR #399)
+# ---------------------------------------------------------------------------
+def test_conc_sweep_summary_missing_file_returns_empty_dict(tmp_path: Path) -> None:
+    """No report → empty dict, no warning (conc_sweep often disabled;
+    dashboard hides Block 2)."""
+    sd = _report_fixture(tmp_path, "reports/conc_sweep_summary.json", None)
+    bd = build(sd)
+    assert bd["conc_sweep_summary"] == {}
+    assert not any("conc_sweep_summary" in w for w in bd["warnings"])
+
+
+def test_conc_sweep_summary_full_payload_passes_through(tmp_path: Path) -> None:
+    """Happy path: comparison rows, summary KPIs and the optional
+    roofline_ceiling block all round-trip verbatim; report_path added."""
+    payload = {
+        "schema_version": "1.0", "status": "succeeded", "session_id": "s",
+        "isl": 1024, "osl": 1024, "tp": 8, "concs_requested": [1, 2, 4, 8],
+        "baseline": {"extra_server_args": "", "extra_envs": {},
+                      "points": [{"arm": "baseline", "conc": 8, "status": "succeeded",
+                                   "output_throughput": 1300.34, "ttft_mean_ms": 145.2}]},
+        "optimized": {"extra_server_args": "--num-continuous-decode-steps 4",
+                       "extra_envs": {"ROCM_QUICK_REDUCE_QUANTIZATION": "FP"},
+                       "points": [{"arm": "optimized", "conc": 8, "status": "succeeded",
+                                    "output_throughput": 1313.54}]},
+        "comparison": [{"conc": 8, "baseline_tput": 1300.34, "optimized_tput": 1313.54,
+                         "speedup": 1.0101, "delta_pct": 1.01,
+                         "baseline_status": "succeeded", "optimized_status": "succeeded"}],
+        "summary": {"successful_pairs": 8, "failed_pairs": 0, "best_conc": 16,
+                     "best_speedup": 1.142, "median_speedup": 1.071, "mean_speedup": 1.083},
+        "workspace": "/abs/ws", "elapsed_sec": 123.4,
+        "total_budget_sec": 9000, "budget_exhausted": False,
+        "report_csv_path": "/abs/reports/conc_sweep_raw.csv",
+        "roofline_ceiling": {
+            "schema_version": 1, "source": "roofline_ceiling.py", "gpu_type": "mi300x",
+            "rows": [{"conc": 8, "t_peak_tok_s": 4032.76, "bound_kind": "memory",
+                       "mbu_baseline_pct": 66.17, "mbu_optimized_pct": 66.14}],
+        },
+    }
+    sd = _report_fixture(tmp_path, "reports/conc_sweep_summary.json", payload)
+    cs = build(sd)["conc_sweep_summary"]
+
+    # Envelope (note str schema_version, unlike kernel summary's int).
+    assert cs["schema_version"] == "1.0"
+    assert cs["status"] == "succeeded"
+    assert cs["optimized"]["extra_server_args"] == "--num-continuous-decode-steps 4"
+    assert cs["comparison"][0]["speedup"] == pytest.approx(1.0101)
+    assert cs["summary"]["best_conc"] == 16
+    # Optional roofline_ceiling rides through verbatim.
+    assert cs["roofline_ceiling"]["rows"][0]["t_peak_tok_s"] == pytest.approx(4032.76)
+    assert cs["roofline_ceiling"]["schema_version"] == 1  # int, distinct from top-level "1.0"
+    assert cs["report_path"] == "reports/conc_sweep_summary.json"
+
+
+def test_conc_sweep_summary_skipped_preserves_sparse_shape(tmp_path: Path) -> None:
+    """status="skipped" → producer omits baseline/optimized/comparison/
+    summary; collector must pass that sparse shape through verbatim (do
+    NOT fabricate the missing blocks)."""
+    payload = {"schema_version": "1.0", "status": "skipped",
+               "skip_reason": "no_optimization_to_compare", "session_id": "s",
+               "isl": 1024, "osl": 1024, "tp": 8, "concs_requested": [1, 2, 4]}
+    sd = _report_fixture(tmp_path, "reports/conc_sweep_summary.json", payload)
+    bd = build(sd)
+    cs = bd["conc_sweep_summary"]
+    assert cs["status"] == "skipped"
+    assert cs["skip_reason"] == "no_optimization_to_compare"
+    assert "comparison" not in cs
+    assert "summary" not in cs
+    assert "baseline" not in cs
+    assert not any("conc_sweep_summary" in w for w in bd["warnings"])
+
+
+def test_conc_sweep_summary_non_dict_blob_returns_empty(tmp_path: Path) -> None:
+    """Top-level JSON is not an object → empty dict + warning, never raise."""
+    sd = tmp_path / "session"
+    _write_json(sd / "manifest.json", {"schema_version": 1, "session_id": "rep"})
+    _write_json(sd / "state.json", {"session_id": "rep"})
+    (sd / "reports").mkdir(parents=True, exist_ok=True)
+    (sd / "reports" / "conc_sweep_summary.json").write_text(
+        json.dumps("not-an-object"), encoding="utf-8",
+    )
+    bd = build(sd)
+    assert bd["conc_sweep_summary"] == {}
+    assert any("conc_sweep_summary" in w and "not a JSON object" in w
+               for w in bd["warnings"])
+
+
+# ---------------------------------------------------------------------------
 # A1.2: roofline_progress (Dashboard-Roofline 对接清单 §2)
 # ---------------------------------------------------------------------------
 # The optimization-progress chart consumer. Inputs are entirely


### PR DESCRIPTION
## Summary
- PR #399 (lishuoshuo) added two new report files — `reports/kernel_optimization_summary.json` and `reports/conc_sweep_summary.json` — but the breakdown exporter never mirrored them, so stats-service / dashboard could not read these two panels (per `roofline优化对接文档.md` §A1 / §A2) from the single `session_breakdown.json` artifact.
- Adds two passthrough collectors (`collect_kernel_optimization_summary` / `collect_conc_sweep_summary`) that mirror each report **verbatim** (light container shape guards only, so producer-side field additions ride through without a schema change) plus an added rel `report_path`, wires them into `exporter.build()`, and adds `KernelOptimizationSummary` / `ConcSweepSummary` TypedDicts.
- Quiet on absence (empty dict, no warning) so legacy / non-report sessions stay clean — the dashboard hides the block on an empty dict (same pattern as `kernel_roofline`).
- **Additive only**: `schema_version` stays `hyperloom.session_breakdown.v2` (Inv-12.1 backward-compat; a v0.6 / v1 reader still consumes the file).

## Timing (why reading by fixed path is safe)
The CLOSE sequencer runs the `report` action (step 1, writes `kernel_optimization_summary.json`) strictly **before** the `session_breakdown` action (step 2, exports sbd); `conc_sweep_summary.json` is written even earlier in SWEEP. So both report files are already on disk when sbd exports.

## Test plan
- [x] 9 new smoke tests in `test_breakdown_smoke.py` (happy-path verbatim passthrough incl. nested `verification` + `backend_ladder` rows; missing file → empty dict + no warning; all-zero totals; `by_kernel` non-list → `[]` + warning; non-object blob → empty + warning; `conc_sweep` `status=skipped` sparse-shape passthrough; int-vs-str `schema_version` distinction).
- [x] Full breakdown suite green (102 passed; the 3 `fcntl` collection failures are a pre-existing Windows-only limitation in CLI tests, unrelated to this change).
- [x] Verified end-to-end against a real `rf_case2` V2 session: both sections mirror the source reports verbatim (totals, KEEP_PENDING kernel ladder+verification, 8-conc comparison/summary/roofline_ceiling), zero new warnings.

Made with [Cursor](https://cursor.com)