### PR TITLE
fix(kernel-opt): harden GEAK routing against invalid kernel ids

### DIFF
--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -1209,6 +1209,22 @@ async def run_optimization_handler(
             single_payload["kernel_id"] = _reconcile_kernel_id(
                 single_payload.get("kernel_id"), candidates,
             )
+        else:
+            # No routable hot candidate (the common TraceLens-failure case
+            # where every candidate is non-routable and lives only in
+            # ``skipped_kernels``). The downstream reusable-native guard
+            # rejects this kernel anyway, but it keys the rejection off the
+            # payload id -- so canonicalize an aliased id (``kn001`` ->
+            # ``k001``) against the full candidate set first, so the
+            # rejection lands on the real ``k00x`` instead of accumulating
+            # hallucinated aliases in ``rejected_kernel_ids``. A pure
+            # hallucination that resolves to nothing is left untouched.
+            canon = _resolve_candidate_id(
+                single_payload.get("kernel_id"),
+                _all_kernel_candidates(payload),
+            )
+            if canon:
+                single_payload["kernel_id"] = canon
         single_payload["_single_kernel"] = True
         return await _run_optimization_single(single_payload, session_dir=session_dir)
     return await _run_optimization_batch(
@@ -1324,27 +1340,87 @@ def _reconcile_kernel_id(
     """Resolve the LLM-supplied kernel_id to a real candidate id.
 
     Resolution order: exact ``kernel_id``/``name`` match, then normalized
-    ``kernel_id`` match, otherwise fall back to the first candidate. The
-    fallback is safe here because this path only runs when there is a single
-    eligible candidate, so "the kernel the LLM meant" is unambiguous.
+    ``kernel_id`` match. Only a missing id falls back to the first candidate;
+    a non-empty id that cannot be reconciled is left untouched so the
+    downstream guard/CLI can skip it rather than guessing a target.
     """
     req = str(requested or "")
     if req:
         for cand in candidates:
-            if str(cand.get("kernel_id") or "") == req or str(cand.get("name") or "") == req:
-                return req
+            cid = str(cand.get("kernel_id") or "")
+            if cid == req or str(cand.get("name") or "") == req:
+                return cid or req
         target = _normalize_kernel_id(req)
         for cand in candidates:
             cid = str(cand.get("kernel_id") or "")
             if _normalize_kernel_id(cid) == target:
                 return cid
-    fallback = str(candidates[0].get("kernel_id") or "")
-    if req and req != fallback:
         log.warning(
-            "kernel_id %r did not match any candidate %s; falling back to %r",
-            req, [str(c.get("kernel_id") or "") for c in candidates], fallback,
+            "kernel_id %r did not match any candidate %s; leaving unchanged",
+            req, [str(c.get("kernel_id") or "") for c in candidates],
         )
+        return req
+    fallback = str(candidates[0].get("kernel_id") or "")
     return fallback
+
+
+def _resolve_candidate_id(
+    requested: Any, candidates: list[dict[str, Any]],
+) -> str:
+    """Return the canonical ``k00x`` id for ``requested`` or ``""``.
+
+    Mirrors ``kernel_optimization.find_candidate`` resolution (exact
+    ``kernel_id``, then a unique routable ``name``, then a normalized
+    ``kn``/``rn`` prefix) but, unlike :func:`_reconcile_kernel_id`, has no
+    first-candidate fallback: a pure hallucination that matches nothing
+    returns ``""`` so the caller leaves the id untouched. Used to
+    canonicalize aliased ids against the full ``hot ∪ skipped`` set when
+    there is no routable hot candidate to reconcile against.
+    """
+    req = str(requested or "")
+    if not req:
+        return ""
+    for cand in candidates:
+        if str(cand.get("kernel_id") or "") == req:
+            return req
+    name_matches = [
+        cand
+        for cand in candidates
+        if str(cand.get("name") or "") == req
+        and cand.get("reusable_native_kernel") is not False
+        and cand.get("source_file")
+    ]
+    if len(name_matches) == 1:
+        return str(name_matches[0].get("kernel_id") or "")
+    target = _normalize_kernel_id(req)
+    for cand in candidates:
+        if _normalize_kernel_id(str(cand.get("kernel_id") or "")) == target:
+            return str(cand.get("kernel_id") or "")
+    return ""
+
+
+def _all_kernel_candidates(payload: dict) -> list[dict[str, Any]]:
+    """Load every candidate (``hot_kernels`` ∪ ``skipped_kernels``).
+
+    The batch dispatcher reads only ``hot_kernels``; this union mirrors the
+    kernel-agent CLI's ``load_candidates`` so id canonicalization can still
+    resolve against the skipped rows when ``hot_kernels`` is empty.
+    """
+    candidates_path = payload.get("candidates_path")
+    if not candidates_path:
+        return []
+    try:
+        data = json.loads(Path(candidates_path).read_text(encoding="utf-8"))
+    except Exception:
+        return []
+    if not isinstance(data, dict):
+        return []
+    out: list[dict[str, Any]] = []
+    for key in ("hot_kernels", "kernel_candidates", "skipped_kernels"):
+        value = data.get(key)
+        if isinstance(value, list):
+            out.extend(item for item in value if isinstance(item, dict))
+    return out
 
 
 def _batch_kernel_candidates(

--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -1198,8 +1198,17 @@ async def run_optimization_handler(
     candidates = _batch_kernel_candidates(payload, session_dir=session_dir)
     if len(candidates) <= 1:
         single_payload = dict(payload)
-        if candidates and not single_payload.get("kernel_id"):
-            single_payload["kernel_id"] = candidates[0].get("kernel_id")
+        if candidates:
+            # Reconcile the LLM-supplied kernel_id against the real
+            # TraceLens candidate. The Orchestration LLM frequently echoes an
+            # operator name or a hallucinated id (e.g. ``aiter.silu_and_mul``,
+            # ``kn001``) that does not match the candidate's ``k00x`` id;
+            # forwarding it verbatim made the kernel-agent CLI crash with a
+            # KeyError. Fall back to the real candidate id when the supplied
+            # id is missing or unknown so the kernel actually gets optimized.
+            single_payload["kernel_id"] = _reconcile_kernel_id(
+                single_payload.get("kernel_id"), candidates,
+            )
         single_payload["_single_kernel"] = True
         return await _run_optimization_single(single_payload, session_dir=session_dir)
     return await _run_optimization_batch(
@@ -1294,6 +1303,48 @@ def _in_flight_kernel_ids(session_dir: Path) -> set[str]:
         if kid:
             in_flight.add(kid)
     return in_flight
+
+
+def _normalize_kernel_id(value: str) -> str:
+    """Fold hallucinated ``kn``/``rn`` prefixes onto the real ``k`` numbering.
+
+    Mirrors ``kernel_optimization._normalize_kernel_id`` at the orchestrator
+    boundary so the reconciliation here and the kernel-agent CLI agree.
+    """
+    s = str(value or "").strip().lower()
+    for prefix in ("kn", "rn"):
+        if s.startswith(prefix) and s[len(prefix):].isdigit():
+            return "k" + s[len(prefix):]
+    return s
+
+
+def _reconcile_kernel_id(
+    requested: Any, candidates: list[dict[str, Any]],
+) -> str:
+    """Resolve the LLM-supplied kernel_id to a real candidate id.
+
+    Resolution order: exact ``kernel_id``/``name`` match, then normalized
+    ``kernel_id`` match, otherwise fall back to the first candidate. The
+    fallback is safe here because this path only runs when there is a single
+    eligible candidate, so "the kernel the LLM meant" is unambiguous.
+    """
+    req = str(requested or "")
+    if req:
+        for cand in candidates:
+            if str(cand.get("kernel_id") or "") == req or str(cand.get("name") or "") == req:
+                return req
+        target = _normalize_kernel_id(req)
+        for cand in candidates:
+            cid = str(cand.get("kernel_id") or "")
+            if _normalize_kernel_id(cid) == target:
+                return cid
+    fallback = str(candidates[0].get("kernel_id") or "")
+    if req and req != fallback:
+        log.warning(
+            "kernel_id %r did not match any candidate %s; falling back to %r",
+            req, [str(c.get("kernel_id") or "") for c in candidates], fallback,
+        )
+    return fallback
 
 
 def _batch_kernel_candidates(

--- a/inference_optimizer/orchestrator/shared_state.py
+++ b/inference_optimizer/orchestrator/shared_state.py
@@ -4576,7 +4576,9 @@ class SharedState:
                 if isinstance(s, dict) and s.get("kernel_id")
             ]
             if rendered_sk:
-                skipped_suffix = f" skipped=[{'; '.join(rendered_sk)}]"
+                skipped_suffix = (
+                    f" skipped_kernels_top=[{'; '.join(rendered_sk)}]"
+                )
         # T3 / T4 finishing-touches: when TraceLens emitted a routing
         # signal (high GPU idle → prefer params; permanent failure →
         # don't keep waiting on kernel candidates), surface it inline

--- a/inference_optimizer/orchestrator/shared_state.py
+++ b/inference_optimizer/orchestrator/shared_state.py
@@ -2624,6 +2624,31 @@ class SharedState:
             if reusable and kid:
                 reusable_ids.append(str(kid))
 
+        # Project the skipped (non-routable) candidates so the prompt can
+        # show the LLM that these operators were *seen* but cannot be
+        # optimized (e.g. "source file not resolved"). Without this the
+        # structured block renders an empty candidate list whenever
+        # hot_kernels is empty, leaving analysis.md's operator names as the
+        # only kernel identifiers in the prompt -- which the LLM then echoes
+        # as a hallucinated kernel_id (operator names are also non-unique,
+        # e.g. several k00x all named ``aten::mm``). Surfacing (id, name,
+        # reason) lets the LLM avoid re-requesting them by id.
+        skipped = result.get("skipped_kernels") or []
+        skipped_summary: list[dict[str, Any]] = []
+        if isinstance(skipped, list):
+            skipped_sorted = sorted(
+                (e for e in skipped if isinstance(e, dict)),
+                key=lambda e: float(e.get("gpu_pct") or 0.0),
+                reverse=True,
+            )
+            for entry in skipped_sorted[:15]:
+                skipped_summary.append({
+                    "kernel_id": entry.get("kernel_id"),
+                    "name": entry.get("name"),
+                    "skip_reason": entry.get("skip_reason") or "",
+                    "gpu_pct": entry.get("gpu_pct"),
+                })
+
         raw_warnings = result.get("trace_health_warnings") or []
         warnings_cleaned: list[dict[str, Any]] = []
         if isinstance(raw_warnings, list):
@@ -2667,6 +2692,7 @@ class SharedState:
             "kernel_roofline_path": str(kernel_roofline_path),
             "hot_kernels_top15": summary,
             "kernel_roofline_top15": kernel_roofline,
+            "skipped_kernels_top": skipped_summary,
             "task_groups": task_groups,
             "reusable_native_kernel_ids": reusable_ids,
             "trace_health_warnings": warnings_cleaned,
@@ -4535,6 +4561,22 @@ class SharedState:
             f"candidates_path={blob.get('candidates_path','?')} "
             f"top={ids or []} reusable_native={reusable or []}"
         )
+        # When there are no routable candidates, surface the skipped
+        # operators (id:name:reason) so the LLM sees they were detected but
+        # cannot be rewritten -- rather than an empty list that pushes it to
+        # echo analysis.md operator names as a (non-unique, invalid)
+        # kernel_id. Suppressed when candidates exist to keep the
+        # steady-state prompt format stable.
+        skipped_suffix = ""
+        if not ids:
+            sk = blob.get("skipped_kernels_top") or []
+            rendered_sk = [
+                f"{s.get('kernel_id')}:{s.get('name')}:{s.get('skip_reason') or '?'}"
+                for s in sk
+                if isinstance(s, dict) and s.get("kernel_id")
+            ]
+            if rendered_sk:
+                skipped_suffix = f" skipped=[{'; '.join(rendered_sk)}]"
         # T3 / T4 finishing-touches: when TraceLens emitted a routing
         # signal (high GPU idle → prefer params; permanent failure →
         # don't keep waiting on kernel candidates), surface it inline
@@ -4547,7 +4589,7 @@ class SharedState:
         # gratuitous additions.
         warnings = blob.get("trace_health_warnings") or []
         if not warnings:
-            return base
+            return base + skipped_suffix
         rendered: list[str] = []
         for w in warnings:
             if not isinstance(w, dict):
@@ -4563,7 +4605,7 @@ class SharedState:
                 rendered.append(f"{code}({','.join(extras)})")
             else:
                 rendered.append(code)
-        return f"{base} warnings=[{'; '.join(rendered)}]"
+        return f"{base}{skipped_suffix} warnings=[{'; '.join(rendered)}]"
 
     def _format_last_sweep(self) -> str:
         if not self.last_sweep:

--- a/inference_optimizer/orchestrator/system_prompts/prompt_builder.py
+++ b/inference_optimizer/orchestrator/system_prompts/prompt_builder.py
@@ -671,6 +671,13 @@ Pick the next id from `last_trace_analyze.reusable_native_kernel_ids`
 (NEVER from raw `hot_kernels_top15` — vendor binaries reject as
 `non_reusable_kernel`); if that list is empty, don't propose kernel_opt.
 
+The `kernel_id` MUST be one of those ids copied verbatim (e.g. `k001`).
+NEVER invent an id and NEVER pass an operator name (e.g. `aten::mm`,
+`aiter.silu_and_mul`) or any token from `analysis_md` — operator names
+are non-unique (several kernels share `aten::mm`) and are rejected.
+`skipped_kernels_top` lists operators TraceLens detected but cannot
+rewrite (each with a `skip_reason`); they are off-limits, not targets.
+
   request{target_agent: 'kernel', kind: 'run_optimization',
           params: {kernel_id: <picked kernel_id>,
                    source_file: <hot_kernels[i].source_file>,

--- a/inference_optimizer/tests/test_kernel_request_handlers_units.py
+++ b/inference_optimizer/tests/test_kernel_request_handlers_units.py
@@ -631,8 +631,9 @@ class TestReconcileKernelId:
         assert krh._reconcile_kernel_id("k010", self.CANDS) == "k010"
 
     def test_name_match_kept(self):
-        # An exact operator-name match is a valid request; keep it.
-        assert krh._reconcile_kernel_id("aten::mm", self.CANDS) == "aten::mm"
+        # An exact operator-name match is canonicalized to the candidate id so
+        # downstream lifecycle/results are keyed by the stable k00x id.
+        assert krh._reconcile_kernel_id("aten::mm", self.CANDS) == "k001"
 
     def test_normalized_prefix_resolves_to_real_id(self):
         assert krh._reconcile_kernel_id("kn001", self.CANDS) == "k001"
@@ -642,13 +643,71 @@ class TestReconcileKernelId:
         assert krh._reconcile_kernel_id("", self.CANDS) == "k001"
         assert krh._reconcile_kernel_id(None, self.CANDS) == "k001"
 
-    def test_hallucinated_id_falls_back_not_passthrough(self):
-        # The key regression: an unknown operator name must NOT pass through
-        # to the CLI (which would KeyError); fall back to the real candidate.
-        assert krh._reconcile_kernel_id("aiter.silu_and_mul", self.CANDS) == "k001"
+    def test_hallucinated_id_is_left_for_guard_or_cli_skip(self):
+        # Non-empty ids are never guessed. A pure hallucination should flow to
+        # the reusable-native guard / CLI skip path rather than being mapped to
+        # an unrelated candidate.
+        assert (
+            krh._reconcile_kernel_id("aiter.silu_and_mul", self.CANDS)
+            == "aiter.silu_and_mul"
+        )
         assert (
             krh._reconcile_kernel_id(
                 "framework_sglang_silu_and_mul_m64", self.CANDS
             )
-            == "k001"
+            == "framework_sglang_silu_and_mul_m64"
         )
+
+
+# ---------------------------------------------------------------------------
+# _resolve_candidate_id / _all_kernel_candidates
+#
+# When hot_kernels is empty the batch dispatcher returns no candidates, so
+# _reconcile_kernel_id never runs. _resolve_candidate_id canonicalizes an
+# aliased id against the full hot ∪ skipped set (no fallback) so the
+# downstream reusable-native guard rejects the real k00x rather than the
+# raw hallucinated alias.
+# ---------------------------------------------------------------------------
+
+class TestResolveCandidateId:
+    SKIPPED = [
+        {"kernel_id": "k001", "name": "aten::mm",
+         "reusable_native_kernel": False, "source_file": ""},
+        {"kernel_id": "k003", "name": "aten::mm",
+         "reusable_native_kernel": False, "source_file": ""},
+        {"kernel_id": "k010", "name": "aiter::rmsnorm",
+         "reusable_native_kernel": False, "source_file": ""},
+    ]
+
+    def test_exact_id(self):
+        assert krh._resolve_candidate_id("k003", self.SKIPPED) == "k003"
+
+    def test_kn_prefix_alias_canonicalized(self):
+        assert krh._resolve_candidate_id("kn001", self.SKIPPED) == "k001"
+        assert krh._resolve_candidate_id("rn010", self.SKIPPED) == "k010"
+
+    def test_non_unique_or_nonroutable_name_not_resolved(self):
+        # ``aten::mm`` is non-unique and non-routable -> cannot disambiguate,
+        # so leave it untouched (returns "") rather than guess a k00x.
+        assert krh._resolve_candidate_id("aten::mm", self.SKIPPED) == ""
+
+    def test_pure_hallucination_returns_empty(self):
+        assert krh._resolve_candidate_id("aiter.silu_and_mul", self.SKIPPED) == ""
+
+    def test_empty_request_returns_empty(self):
+        assert krh._resolve_candidate_id("", self.SKIPPED) == ""
+        assert krh._resolve_candidate_id(None, self.SKIPPED) == ""
+
+
+class TestAllKernelCandidates:
+    def test_union_of_hot_and_skipped(self, tmp_path):
+        cp = tmp_path / "kc.json"
+        cp.write_text(json.dumps({
+            "hot_kernels": [{"kernel_id": "k005", "name": "moe"}],
+            "skipped_kernels": [{"kernel_id": "k001", "name": "aten::mm"}],
+        }), encoding="utf-8")
+        out = krh._all_kernel_candidates({"candidates_path": str(cp)})
+        assert {c["kernel_id"] for c in out} == {"k005", "k001"}
+
+    def test_missing_path_returns_empty(self):
+        assert krh._all_kernel_candidates({}) == []

--- a/inference_optimizer/tests/test_kernel_request_handlers_units.py
+++ b/inference_optimizer/tests/test_kernel_request_handlers_units.py
@@ -615,3 +615,40 @@ class TestDefaultKernelBatchParallel:
             krh._default_kernel_batch_parallel()
             == krh._DEFAULT_KERNEL_BATCH_PARALLEL
         )
+
+
+# ---------------------------------------------------------------------------
+# _reconcile_kernel_id
+# ---------------------------------------------------------------------------
+
+class TestReconcileKernelId:
+    CANDS = [
+        {"kernel_id": "k001", "name": "aten::mm"},
+        {"kernel_id": "k010", "name": "aiter::rmsnorm"},
+    ]
+
+    def test_exact_id_kept(self):
+        assert krh._reconcile_kernel_id("k010", self.CANDS) == "k010"
+
+    def test_name_match_kept(self):
+        # An exact operator-name match is a valid request; keep it.
+        assert krh._reconcile_kernel_id("aten::mm", self.CANDS) == "aten::mm"
+
+    def test_normalized_prefix_resolves_to_real_id(self):
+        assert krh._reconcile_kernel_id("kn001", self.CANDS) == "k001"
+        assert krh._reconcile_kernel_id("rn010", self.CANDS) == "k010"
+
+    def test_missing_id_falls_back_to_first(self):
+        assert krh._reconcile_kernel_id("", self.CANDS) == "k001"
+        assert krh._reconcile_kernel_id(None, self.CANDS) == "k001"
+
+    def test_hallucinated_id_falls_back_not_passthrough(self):
+        # The key regression: an unknown operator name must NOT pass through
+        # to the CLI (which would KeyError); fall back to the real candidate.
+        assert krh._reconcile_kernel_id("aiter.silu_and_mul", self.CANDS) == "k001"
+        assert (
+            krh._reconcile_kernel_id(
+                "framework_sglang_silu_and_mul_m64", self.CANDS
+            )
+            == "k001"
+        )

--- a/inference_optimizer/tests/test_record_trace_analyze_analysis_md.py
+++ b/inference_optimizer/tests/test_record_trace_analyze_analysis_md.py
@@ -365,7 +365,10 @@ def test_blob_renders_skipped_when_no_routable_candidates() -> None:
         "trace_health_warnings": [],
     }
     rendered = state._format_trace_analyze_blob(blob)
-    assert "skipped=[k001:aten::mm:source file not resolved]" in rendered
+    assert (
+        "skipped_kernels_top=[k001:aten::mm:source file not resolved]"
+        in rendered
+    )
 
 
 def test_blob_format_stable_when_candidates_present() -> None:
@@ -383,5 +386,30 @@ def test_blob_format_stable_when_candidates_present() -> None:
     }
     rendered = state._format_trace_analyze_blob(blob)
     # Candidates present → legacy format, no skipped suffix injected.
-    assert "skipped=" not in rendered
+    assert "skipped_kernels_top=" not in rendered
     assert "top=['k002']" in rendered
+
+
+def test_non_routable_kernel_opt_skip_rejects_canonical_id() -> None:
+    state = SharedState()
+    state.record_kernel_opt({
+        "status": "skipped",
+        "decision": "REVERT",
+        "error_class": "missing_native_source",
+        "reason": "non_routable_candidate",
+        "kernel_id": "k001",
+        "requested_kernel_id": "kn001",
+        "resolved_kernel_id": "k001",
+        "kernel_name": "aten::mm",
+        "verification": {"micro_speedup": 0.0, "best_artifact_path": ""},
+        "proposal": {
+            "decision": "REVERT",
+            "reasons": ["source file not resolved"],
+        },
+    })
+
+    assert "k001" in state.rejected_kernel_ids
+    entry = state.kernel_opt_attempts["k001"]
+    assert entry["last_decision"] == "REVERT"
+    assert entry["last_status"] == "skipped"
+    assert entry["rejected_reason"] == "revert_decision"

--- a/inference_optimizer/tests/test_record_trace_analyze_analysis_md.py
+++ b/inference_optimizer/tests/test_record_trace_analyze_analysis_md.py
@@ -289,3 +289,99 @@ def test_record_trace_analyze_preserves_kernel_roofline_fields(
     # the bucket label instead of an empty string.
     assert row["kernel_category"] == "LayerNorm"
     assert cached["kernel_roofline_top15"][0] == row
+
+
+# ---------------------------------------------------------------------------
+# skipped_kernels projection + prompt rendering (GEAK kernel-id routing)
+#
+# When TraceLens routes every candidate to ``skipped_kernels`` (e.g. all
+# ``aten::mm`` with "source file not resolved"), ``hot_kernels`` is empty and
+# the prompt's candidate list renders ``top=[] reusable_native=[]``. With no
+# real ``k00x`` id visible, the Orchestration LLM echoes analysis.md operator
+# names as a hallucinated kernel_id. Projecting the skipped candidates lets
+# the prompt show they were detected-but-unoptimizable instead.
+# ---------------------------------------------------------------------------
+
+
+def _result_with_skipped(skipped: list[dict]) -> dict:
+    return {
+        "hot_kernels": [],
+        "skipped_kernels": skipped,
+        "trace_health_warnings": [],
+    }
+
+
+def test_skipped_kernels_projected_when_hot_empty() -> None:
+    state = SharedState()
+    state.record_trace_analyze(
+        {"trace_input": "x"},
+        _result_with_skipped([
+            {"kernel_id": "k001", "name": "aten::mm",
+             "skip_reason": "source file not resolved", "gpu_pct": 3.3},
+            {"kernel_id": "k003", "name": "aten::mm",
+             "skip_reason": "source file not resolved", "gpu_pct": 17.1},
+        ]),
+    )
+    proj = state.last_trace_analyze["skipped_kernels_top"]
+    # Sorted by gpu_pct desc so the heaviest operator leads.
+    assert [p["kernel_id"] for p in proj] == ["k003", "k001"]
+    assert proj[0]["name"] == "aten::mm"
+    assert proj[0]["skip_reason"] == "source file not resolved"
+
+
+def test_skipped_projection_truncates_to_15() -> None:
+    state = SharedState()
+    many = [
+        {"kernel_id": f"k{i:03d}", "name": "aten::mm",
+         "skip_reason": "source file not resolved", "gpu_pct": float(i)}
+        for i in range(1, 26)
+    ]
+    state.record_trace_analyze({"trace_input": "x"}, _result_with_skipped(many))
+    proj = state.last_trace_analyze["skipped_kernels_top"]
+    assert len(proj) == 15
+    assert proj[0]["kernel_id"] == "k025"  # highest gpu_pct first
+
+
+def test_skipped_top_empty_when_no_skipped() -> None:
+    state = SharedState()
+    state.record_trace_analyze(
+        {"trace_input": "x"},
+        {"hot_kernels": [], "trace_health_warnings": []},
+    )
+    assert state.last_trace_analyze["skipped_kernels_top"] == []
+
+
+def test_blob_renders_skipped_when_no_routable_candidates() -> None:
+    state = SharedState()
+    blob = {
+        "trace_input": "/t.json",
+        "candidates_path": "/kc.json",
+        "hot_kernels_top15": [],
+        "reusable_native_kernel_ids": [],
+        "skipped_kernels_top": [
+            {"kernel_id": "k001", "name": "aten::mm",
+             "skip_reason": "source file not resolved", "gpu_pct": 3.3},
+        ],
+        "trace_health_warnings": [],
+    }
+    rendered = state._format_trace_analyze_blob(blob)
+    assert "skipped=[k001:aten::mm:source file not resolved]" in rendered
+
+
+def test_blob_format_stable_when_candidates_present() -> None:
+    state = SharedState()
+    blob = {
+        "trace_input": "/t.json",
+        "candidates_path": "/kc.json",
+        "hot_kernels_top15": [{"kernel_id": "k002", "name": "rmsnorm"}],
+        "reusable_native_kernel_ids": ["k002"],
+        "skipped_kernels_top": [
+            {"kernel_id": "k001", "name": "aten::mm",
+             "skip_reason": "x", "gpu_pct": 3.3},
+        ],
+        "trace_health_warnings": [],
+    }
+    rendered = state._format_trace_analyze_blob(blob)
+    # Candidates present → legacy format, no skipped suffix injected.
+    assert "skipped=" not in rendered
+    assert "top=['k002']" in rendered

--- a/kernel-agent/tools/backends/geak_submit.py
+++ b/kernel-agent/tools/backends/geak_submit.py
@@ -17,6 +17,7 @@ import time
 from pathlib import Path
 
 from ray_runtime import (
+    ensure_ray_cluster,
     quiet_ray_init,
 )
 

--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -165,15 +165,29 @@ def find_candidate(
 ) -> dict[str, Any] | None:
     """Resolve a candidate by ``kernel_id`` / ``name``.
 
-    Resolution order: exact ``kernel_id`` or ``name`` match, then a
+    Resolution order: exact ``kernel_id`` match, then a unique routable
+    ``name`` match, then a
     normalized ``kernel_id`` match (case-insensitive, ``kn``/``rn`` prefix
     folded to ``k``). Returns ``None`` when nothing matches so the caller can
     skip the kernel gracefully instead of crashing the whole run with a
     ``KeyError`` on an LLM-hallucinated id.
     """
     for candidate in candidates:
-        if candidate.get("kernel_id") == kernel_id or candidate.get("name") == kernel_id:
+        if candidate.get("kernel_id") == kernel_id:
             return candidate
+    # Operator names are not stable identifiers: several TraceLens candidates
+    # can share names like ``aten::mm``. Accept a name only when it uniquely
+    # identifies a routable candidate; otherwise treat it as an invalid
+    # kernel_id so the caller can skip instead of optimizing the wrong target.
+    name_matches = [
+        candidate
+        for candidate in candidates
+        if candidate.get("name") == kernel_id
+        and candidate.get("reusable_native_kernel") is not False
+        and candidate.get("source_file")
+    ]
+    if len(name_matches) == 1:
+        return name_matches[0]
     target = _normalize_kernel_id(kernel_id)
     for candidate in candidates:
         if _normalize_kernel_id(str(candidate.get("kernel_id") or "")) == target:
@@ -2978,7 +2992,54 @@ def main() -> int:
                 "kernel_id": args.kernel_id,
                 "status": "skipped",
                 "reason": "kernel_id_not_in_candidates",
+                "error_class": "invalid_kernel_id",
                 "known_kernel_ids": known,
+                "cli_log_path": str(log_path),
+                "status_path": str(status_path),
+            }, indent=2, sort_keys=True))
+            return 0
+        if (
+            candidate.get("reusable_native_kernel") is False
+            or not candidate.get("source_file")
+        ):
+            reason = (
+                candidate.get("skip_reason")
+                or candidate.get("optimization_notes")
+                or "candidate is not a reusable native kernel"
+            )
+            msg = (
+                f"kernel_id {args.kernel_id!r} resolved to non-routable "
+                f"TraceLens candidate {candidate.get('kernel_id')!r}: {reason}"
+            )
+            append_log(log_path, f"[skip] {msg}")
+            update_status(status_path, state="skipped", current_step="skipped",
+                          log_path=log_path, artifact_paths=artifacts,
+                          run_id=run_id, started_at=started_at, error=msg)
+            print(json.dumps({
+                "tool": "kernel_optimization",
+                "session_id": session_id,
+                "run_id": run_id,
+                "kernel_id": candidate.get("kernel_id") or args.kernel_id,
+                "requested_kernel_id": args.kernel_id,
+                "resolved_kernel_id": candidate.get("kernel_id"),
+                "kernel_name": candidate.get("name"),
+                "status": "skipped",
+                "decision": "REVERT",
+                "error_class": (
+                    "missing_native_source"
+                    if not candidate.get("source_file")
+                    else "non_reusable_kernel"
+                ),
+                "reason": "non_routable_candidate",
+                "skip_reason": reason,
+                "verification": {
+                    "micro_speedup": 0.0,
+                    "best_artifact_path": "",
+                },
+                "proposal": {
+                    "decision": "REVERT",
+                    "reasons": [reason],
+                },
                 "cli_log_path": str(log_path),
                 "status_path": str(status_path),
             }, indent=2, sort_keys=True))

--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -144,12 +144,41 @@ def load_candidates(path: Path) -> list[dict[str, Any]]:
     return candidates
 
 
-def find_candidate(candidates: list[dict[str, Any]], kernel_id: str) -> dict[str, Any]:
-    """Find a candidate by ``kernel_id`` (or name) or raise KeyError."""
+def _normalize_kernel_id(value: str) -> str:
+    """Fold hallucinated synthetic prefixes (``kn``/``rn``) onto the real
+    ``k`` numbering and lower-case for a tolerant comparison.
+
+    The Orchestration LLM sometimes returns ``kn001`` / ``rn010`` instead of
+    the TraceLens ``k001`` / ``k010`` it was offered; collapsing the leading
+    letter run to a single ``k`` recovers the intended candidate without
+    guessing across unrelated kernels.
+    """
+    s = value.strip().lower()
+    for prefix in ("kn", "rn"):
+        if s.startswith(prefix) and s[len(prefix):].isdigit():
+            return "k" + s[len(prefix):]
+    return s
+
+
+def find_candidate(
+    candidates: list[dict[str, Any]], kernel_id: str
+) -> dict[str, Any] | None:
+    """Resolve a candidate by ``kernel_id`` / ``name``.
+
+    Resolution order: exact ``kernel_id`` or ``name`` match, then a
+    normalized ``kernel_id`` match (case-insensitive, ``kn``/``rn`` prefix
+    folded to ``k``). Returns ``None`` when nothing matches so the caller can
+    skip the kernel gracefully instead of crashing the whole run with a
+    ``KeyError`` on an LLM-hallucinated id.
+    """
     for candidate in candidates:
         if candidate.get("kernel_id") == kernel_id or candidate.get("name") == kernel_id:
             return candidate
-    raise KeyError(f"kernel not found in candidates: {kernel_id}")
+    target = _normalize_kernel_id(kernel_id)
+    for candidate in candidates:
+        if _normalize_kernel_id(str(candidate.get("kernel_id") or "")) == target:
+            return candidate
+    return None
 
 
 def existing_path(value: str) -> str:
@@ -2925,7 +2954,35 @@ def main() -> int:
                       log_path=log_path, artifact_paths=artifacts, run_id=run_id,
                       started_at=started_at)
         candidates_path = Path(args.candidates_path) if args.candidates_path else run_dir / "kernel_candidates.json"
-        candidate = find_candidate(load_candidates(candidates_path), args.kernel_id)
+        all_candidates = load_candidates(candidates_path)
+        candidate = find_candidate(all_candidates, args.kernel_id)
+        if candidate is None:
+            # The Orchestration LLM supplied a kernel_id that matches no
+            # TraceLens candidate (e.g. a hallucinated operator name). Skip
+            # this kernel cleanly instead of crashing the whole subprocess
+            # with a KeyError, so the orchestrator can move on to the next
+            # decision rather than burning the run.
+            known = [str(c.get("kernel_id") or "") for c in all_candidates]
+            msg = (
+                f"kernel_id {args.kernel_id!r} not found among TraceLens "
+                f"candidates {known}; skipping (no fabricated target)"
+            )
+            append_log(log_path, f"[skip] {msg}")
+            update_status(status_path, state="skipped", current_step="skipped",
+                          log_path=log_path, artifact_paths=artifacts,
+                          run_id=run_id, started_at=started_at, error=msg)
+            print(json.dumps({
+                "tool": "kernel_optimization",
+                "session_id": session_id,
+                "run_id": run_id,
+                "kernel_id": args.kernel_id,
+                "status": "skipped",
+                "reason": "kernel_id_not_in_candidates",
+                "known_kernel_ids": known,
+                "cli_log_path": str(log_path),
+                "status_path": str(status_path),
+            }, indent=2, sort_keys=True))
+            return 0
         # TraceLens is the source of truth for kernel_id → source_file.
         # ``_resolve_source_file`` overrides any LLM-supplied path that
         # disagrees with ``candidate.source_file`` and logs the override,

--- a/kernel-agent/tools/test_geak_submit_imports.py
+++ b/kernel-agent/tools/test_geak_submit_imports.py
@@ -1,0 +1,28 @@
+"""Regression: geak_submit must import ``ensure_ray_cluster``.
+
+``geak_submit.run_geak`` calls ``ensure_ray_cluster(...)`` (around line 266)
+to boot/attach a Ray cluster before submitting the GEAK job, mirroring
+``oob_submit``. The import block only pulled ``quiet_ray_init``, so the call
+raised ``NameError: name 'ensure_ray_cluster' is not defined`` at runtime,
+failing every GEAK attempt that reached the backend.
+
+This test pins the module-level symbol so the regression cannot reappear.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "backends"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import geak_submit  # noqa: E402
+
+
+def test_ensure_ray_cluster_is_in_scope():
+    # The name must be resolvable in the module globals; otherwise the
+    # call site at run_geak() would NameError at runtime.
+    assert hasattr(geak_submit, "ensure_ray_cluster"), (
+        "geak_submit calls ensure_ray_cluster() but never imported it"
+    )
+    assert callable(geak_submit.ensure_ray_cluster)

--- a/kernel-agent/tools/test_kernel_id_mismatch.py
+++ b/kernel-agent/tools/test_kernel_id_mismatch.py
@@ -1,0 +1,52 @@
+"""kernel_id mismatch handling at the kernel-agent boundary.
+
+The Orchestration LLM occasionally supplies a ``kernel_id`` that does not
+match any TraceLens candidate (e.g. it echoes an operator name like
+``aiter.silu_and_mul`` or a hallucinated ``kn001`` instead of the real
+``k001``). Previously ``find_candidate`` raised ``KeyError`` on the first
+lookup, crashing the entire kernel-optimization subprocess before GEAK was
+ever invoked.
+
+Contract:
+
+* ``find_candidate`` resolves by ``kernel_id`` / ``name`` exactly, then via a
+  normalized match (case-insensitive, ``kn``/``rn`` prefix folded to ``k``).
+* When nothing matches it returns ``None`` instead of raising, so the caller
+  can skip the kernel gracefully rather than aborting the whole run.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import kernel_optimization as ko  # noqa: E402
+
+
+CANDIDATES = [
+    {"kernel_id": "k001", "name": "aten::mm"},
+    {"kernel_id": "k002", "name": "sgl_kernel::silu_and_mul"},
+    {"kernel_id": "k010", "name": "aiter::rmsnorm"},
+]
+
+
+def test_exact_id_match():
+    assert ko.find_candidate(CANDIDATES, "k002")["name"] == "sgl_kernel::silu_and_mul"
+
+
+def test_name_match():
+    assert ko.find_candidate(CANDIDATES, "aten::mm")["kernel_id"] == "k001"
+
+
+def test_normalized_prefix_match():
+    # LLM hallucinated ``kn001`` / ``rn010``; fold the synthetic prefix back to
+    # the real ``k`` numbering.
+    assert ko.find_candidate(CANDIDATES, "kn001")["kernel_id"] == "k001"
+    assert ko.find_candidate(CANDIDATES, "rn010")["kernel_id"] == "k010"
+
+
+def test_unknown_id_returns_none_not_raise():
+    # Pure hallucination that maps to nothing must NOT crash the subprocess.
+    assert ko.find_candidate(CANDIDATES, "aiter.silu_and_mul") is None
+    assert ko.find_candidate(CANDIDATES, "framework_sglang_silu_and_mul_m64") is None

--- a/kernel-agent/tools/test_kernel_id_mismatch.py
+++ b/kernel-agent/tools/test_kernel_id_mismatch.py
@@ -9,25 +9,54 @@ ever invoked.
 
 Contract:
 
-* ``find_candidate`` resolves by ``kernel_id`` / ``name`` exactly, then via a
-  normalized match (case-insensitive, ``kn``/``rn`` prefix folded to ``k``).
+* ``find_candidate`` resolves by exact ``kernel_id`` and normalized
+  ``kernel_id`` match (case-insensitive, ``kn``/``rn`` prefix folded to
+  ``k``). It accepts a ``name`` only when that name uniquely identifies a
+  routable candidate.
 * When nothing matches it returns ``None`` instead of raising, so the caller
   can skip the kernel gracefully rather than aborting the whole run.
 """
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import kernel_optimization as ko  # noqa: E402
 
 
+ROUTABLE = {
+    "kernel_id": "k002",
+    "name": "sgl_kernel::silu_and_mul",
+    "reusable_native_kernel": True,
+    "source_file": "/sgl-kernel/elementwise.py",
+}
+
 CANDIDATES = [
     {"kernel_id": "k001", "name": "aten::mm"},
-    {"kernel_id": "k002", "name": "sgl_kernel::silu_and_mul"},
-    {"kernel_id": "k010", "name": "aiter::rmsnorm"},
+    ROUTABLE,
+    {"kernel_id": "k010", "name": "aiter::rmsnorm", "source_file": "/aiter/rms.py"},
+]
+
+SKIPPED_CANDIDATES = [
+    {
+        "kernel_id": "k001",
+        "name": "aten::mm",
+        "reusable_native_kernel": False,
+        "source_file": "",
+        "skip_reason": "source file not resolved",
+    },
+    {
+        "kernel_id": "k003",
+        "name": "aten::mm",
+        "reusable_native_kernel": False,
+        "source_file": "",
+        "skip_reason": "source file not resolved",
+    },
 ]
 
 
@@ -35,8 +64,15 @@ def test_exact_id_match():
     assert ko.find_candidate(CANDIDATES, "k002")["name"] == "sgl_kernel::silu_and_mul"
 
 
-def test_name_match():
-    assert ko.find_candidate(CANDIDATES, "aten::mm")["kernel_id"] == "k001"
+def test_unique_routable_name_match():
+    assert ko.find_candidate(CANDIDATES, "sgl_kernel::silu_and_mul")["kernel_id"] == "k002"
+
+
+def test_operator_name_for_skipped_or_non_unique_candidates_returns_none():
+    # Real TraceLens failures often list several skipped ``aten::mm`` rows.
+    # The operator name is non-unique and non-routable, so it must not resolve
+    # to k001 and accidentally send a skipped candidate into optimization.
+    assert ko.find_candidate(SKIPPED_CANDIDATES, "aten::mm") is None
 
 
 def test_normalized_prefix_match():
@@ -50,3 +86,42 @@ def test_unknown_id_returns_none_not_raise():
     # Pure hallucination that maps to nothing must NOT crash the subprocess.
     assert ko.find_candidate(CANDIDATES, "aiter.silu_and_mul") is None
     assert ko.find_candidate(CANDIDATES, "framework_sglang_silu_and_mul_m64") is None
+
+
+@pytest.mark.parametrize("requested", ["kn001", "aten::mm"])
+def test_main_skips_skipped_candidates_without_backend_dispatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    requested: str,
+) -> None:
+    candidates_path = tmp_path / "kernel_candidates.json"
+    candidates_path.write_text(
+        json.dumps({"hot_kernels": [], "skipped_kernels": SKIPPED_CANDIDATES}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "kernel_optimization.py",
+            "--kernel-id", requested,
+            "--session-id", "s1",
+            "--workspace-path", str(tmp_path),
+            "--candidates-path", str(candidates_path),
+        ],
+    )
+
+    assert ko.main() == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["status"] == "skipped"
+    if requested == "kn001":
+        assert out["kernel_id"] == "k001"
+        assert out["requested_kernel_id"] == requested
+        assert out["decision"] == "REVERT"
+        assert out["error_class"] == "missing_native_source"
+        assert out["reason"] == "non_routable_candidate"
+    else:
+        assert out["kernel_id"] == requested
+        assert out["error_class"] == "invalid_kernel_id"
+        assert out["reason"] == "kernel_id_not_in_candidates"


### PR DESCRIPTION
## Summary
- Fix GEAK backend startup by importing `ensure_ray_cluster` in `geak_submit.py` (it was called but never imported, raising `NameError` on every GEAK attempt that reached the backend).
- Stop invalid/hallucinated `kernel_id` values from crashing kernel optimization: `find_candidate` no longer raises `KeyError`; it canonicalizes safe aliases (`kn001`/`rn010` → `k001`/`k010`) and skips non-routable candidates instead of dispatching a backend.
- Canonicalize aliased ids against the full `hot ∪ skipped` candidate set when `hot_kernels` is empty, so rejection lands on the real `k00x` rather than accumulating hallucinated aliases in `rejected_kernel_ids`. Non-unique / non-routable operator names (e.g. `aten::mm`) and pure hallucinations are never guessed.
- Surface skipped TraceLens candidates (`skipped_kernels_top`) in the orchestration prompt and require `kernel_id` to be copied verbatim from reusable candidate ids, so the LLM stops echoing operator names from `analysis.md`.

## Test plan
- [x] `python3 -m pytest inference_optimizer/tests/ -q -k "prompt or trace_analyze or shared_state or kernel_request or roofline" --ignore=inference_optimizer/tests/test_local_kb_requirements.py --ignore=inference_optimizer/tests/test_recipe_kb_dispatcher.py --ignore=inference_optimizer/tests/test_remote_client.py -p no:cacheprovider` → 715 passed, 1 skipped
- [x] `python3 -m pytest kernel-agent/tools/test_kernel_id_mismatch.py kernel-agent/tools/test_geak_submit_imports.py kernel-agent/tools/test_geak_param_resolution.py -q` → 31 passed
- [x] Manual `run_optimization_handler` check on empty `hot_kernels` + `skipped_kernels` artifacts: `kn001`/`k001` reject as `k001`; `aten::mm` and pure hallucinations stay unguessed.