### PR TITLE
feat(kb): stamp config.json architectures/model_type as recipe tags

### DIFF
--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -937,6 +937,64 @@ def _load_model_arch(workspace_root: Path, model_name: str) -> dict:
     return data
 
 
+def _load_model_config_tags(model_path: str) -> dict:
+    """Best-effort loader for KB architecture tags from ``config.json``.
+
+    Reads ``<model_path>/config.json`` (the HF weights dir) and lifts the
+    two architecture-identity fields the recipe-snapshot KB stamps as
+    ``extras`` tags:
+
+      * ``architectures`` — a list like ``["LlamaForCausalLM"]``.
+      * ``model_type``    — a string like ``"llama"``.
+
+    Both are shared by a base model and the models fine-tuned from it, so
+    stamping them lets a fine-tuned recipe be recognised as carrying the
+    base model's architecture identity.
+
+    Soft-degrade contract (never blocks launch): a missing / unreadable /
+    invalid-JSON / non-dict ``config.json`` returns ``{}``. Individual
+    fields are normalised (``architectures`` -> list of non-empty strings;
+    ``model_type`` -> stripped string) and a key is omitted entirely when
+    its normalised value is empty, so callers can ``.get(key, default)``
+    without re-checking for ``[]`` / ``""``.
+    """
+    if not model_path:
+        return {}
+    cfg_path = Path(model_path) / "config.json"
+    try:
+        raw = cfg_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {}
+    except OSError as exc:
+        logging.warning("model_config_tags_unreadable: %s (%s)", cfg_path, exc)
+        return {}
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError) as exc:
+        logging.warning("model_config_tags_invalid_json: %s (%s)", cfg_path, exc)
+        return {}
+    if not isinstance(data, dict):
+        logging.warning(
+            "model_config_tags_not_a_dict: %s (got %s)",
+            cfg_path,
+            type(data).__name__,
+        )
+        return {}
+    out: dict = {}
+    arches_raw = data.get("architectures")
+    if isinstance(arches_raw, list):
+        arches = [str(a).strip() for a in arches_raw if str(a or "").strip()]
+        if arches:
+            out["architectures"] = arches
+    elif isinstance(arches_raw, str) and arches_raw.strip():
+        # Tolerate a scalar ``architectures`` by wrapping it in a list.
+        out["architectures"] = [arches_raw.strip()]
+    model_type = str(data.get("model_type") or "").strip()
+    if model_type:
+        out["model_type"] = model_type
+    return out
+
+
 def _seed_shared_state(
     session_dir: Path,
     args: argparse.Namespace,
@@ -1100,6 +1158,11 @@ def _seed_shared_state(
         args, "explore_roofline_hard_gate", False,
     ))
 
+    # KB architecture tags from the model weights' config.json
+    # (``architectures`` + ``model_type``). Fresh-launch only — resume
+    # rehydrates the persisted values from state.json (see load_or_init).
+    _cfg_tags = _load_model_config_tags(str(args.model))
+
     state = SharedState(
         session_id=session_id,
         claw_session_id=(os.environ.get("CLAW_SESSION_ID") or "").strip(),
@@ -1114,6 +1177,11 @@ def _seed_shared_state(
         model_arch=_load_model_arch(
             _workspace_root_resolve(), Path(args.model).name
         ),
+        # Architecture-identity tags lifted from config.json; stamped into
+        # the recipe-snapshot ``extras`` so a fine-tuned model carries the
+        # base model's identity (see ``_load_model_config_tags``).
+        model_architectures=_cfg_tags.get("architectures", []),
+        model_type=_cfg_tags.get("model_type", ""),
         framework=os.environ.get("FRAMEWORK", "sglang"),
         gpu_type=str(getattr(args, "gpu_type", None) or os.environ.get("GPU_TYPE", "")),
         # Workload metadata mirrored from CLI / env at fresh-session time

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -5751,6 +5751,19 @@ class Coordinator:
         }
         prior_extras = {k: v for k, v in live.items() if k not in _reserved}
         merged_extras = {**prior_extras, **(overrides.get("extras") or {})}
+        # Re-stamp the config.json architecture-identity tags
+        # (``architectures`` / ``model_type``) on every amend so the row
+        # always carries the current model's identity. Carried on
+        # SharedState by ``cli._load_model_config_tags``; skipped when
+        # unset so a prior T0-stamped value is preserved.
+        _arch = getattr(ss, "model_architectures", None) or []
+        if isinstance(_arch, list):
+            _arch_list = [str(a).strip() for a in _arch if str(a or "").strip()]
+            if _arch_list:
+                merged_extras["architectures"] = _arch_list
+        _mtype = str(getattr(ss, "model_type", "") or "").strip()
+        if _mtype:
+            merged_extras["model_type"] = _mtype
         put_kwargs: dict[str, Any] = {
             "canonical_id":      cid,
             "model":             ss.model_name or "unknown_model",

--- a/inference_optimizer/orchestrator/cortex_t0.py
+++ b/inference_optimizer/orchestrator/cortex_t0.py
@@ -257,6 +257,17 @@ def run_t0_anchor(
     _extras: dict[str, Any] = {}
     if _model_class:
         _extras["model_class"] = _model_class
+    # Architecture-identity tags from the model's config.json (carried on
+    # SharedState by ``cli._load_model_config_tags``). Stamped so a
+    # fine-tuned model's recipe records the same architecture as its base.
+    _architectures = getattr(shared_state, "model_architectures", None) or []
+    if isinstance(_architectures, list):
+        _arch_list = [str(a).strip() for a in _architectures if str(a or "").strip()]
+        if _arch_list:
+            _extras["architectures"] = _arch_list
+    _model_type = str(getattr(shared_state, "model_type", "") or "").strip()
+    if _model_type:
+        _extras["model_type"] = _model_type
     rocm_v = str(fp.get("rocm") or "").strip()
     if rocm_v and rocm_v != "unknown":
         _extras["rocm_version"] = rocm_v

--- a/inference_optimizer/orchestrator/policy.py
+++ b/inference_optimizer/orchestrator/policy.py
@@ -660,6 +660,13 @@ CORE_STATE_FIELDS: frozenset[str] = frozenset({
     # launcher / state.json as the sole source of truth (an LLM
     # update_state must not pollute the specialist prompt context).
     "model_arch",
+    # Architecture-identity tags lifted from the model weights' config.json
+    # (carried on SharedState by ``cli._load_model_config_tags``). Fact-layer
+    # data fanned into the recipe-snapshot ``extras`` by the T0 anchor /
+    # ``_kb_amend_recipe`` writes, so lock them — an LLM update_state must
+    # not pollute the KB recipe tags that drive cross-session reuse.
+    "model_architectures",
+    "model_type",
 })
 
 

--- a/inference_optimizer/orchestrator/shared_state.py
+++ b/inference_optimizer/orchestrator/shared_state.py
@@ -18,6 +18,10 @@ fields:
                                 structured + free-text notes) loaded from
                                 the launcher's ``$USER_DATA_PATH/model_arch.json``;
                                 prompt-context only, no deterministic gating
+    model_architectures list  — config.json ``architectures``; stamped into
+                                the recipe-snapshot ``extras`` as a KB tag
+    model_type          str   — config.json ``model_type``; stamped into
+                                the recipe-snapshot ``extras`` as a KB tag
     target_summary      str   — set by `target_analysis` action
     baseline_tput       float — tok/s/GPU after `baseline` action
     baseline_accuracy   float — GSM8K score after `baseline`
@@ -316,6 +320,16 @@ class SharedState:
     # filter / framework gap token / recipe key stay on ``model_class``).
     # Empty dict means "no profile available"; renderers omit the block.
     model_arch: dict = field(default_factory=dict)
+    # KB tags lifted verbatim from the model weights' ``config.json``
+    # (``architectures`` list + ``model_type`` string). Populated at
+    # fresh-launch by ``cli._load_model_config_tags``; resume rehydrates
+    # the persisted values from state.json. Stamped into the recipe-snapshot
+    # ``extras`` on every KB write (T0 anchor + KEEP/REVERT/CLOSE amend) so a
+    # fine-tuned model carries the same architecture identity as the base
+    # model it derives from. Empty (``[]`` / ``""``) means "config.json
+    # absent or unreadable".
+    model_architectures: list[str] = field(default_factory=list)
+    model_type: str = ""
     framework: str = ""
     gpu_type: str = ""
     # Workload metadata mirrored from manifest.json at session start

--- a/inference_optimizer/tests/test_agent_roles_and_policy.py
+++ b/inference_optimizer/tests/test_agent_roles_and_policy.py
@@ -482,6 +482,28 @@ def test_gate_orchestration_update_state_core_field_rejected(gate):
     assert exc.value.rule == "state_field"
 
 
+def test_core_state_fields_includes_model_arch_tags():
+    """``model_architectures`` / ``model_type`` are fact-layer tags lifted
+    from the model weights' config.json (launcher / CLI owned). Locking
+    them keeps an LLM ``update_state`` from polluting the recipe-snapshot
+    tags that ``_kb_amend_recipe`` stamps into the KB."""
+    assert "model_architectures" in CORE_STATE_FIELDS
+    assert "model_type" in CORE_STATE_FIELDS
+
+
+def test_gate_update_state_model_arch_tags_rejected(gate):
+    """A non-core-mutating role must not overwrite the config.json
+    architecture tags via ``update_state`` (else the next
+    ``_kb_amend_recipe`` writes the polluted value into the recipe row)."""
+    for field_name in ("model_architectures", "model_type"):
+        with pytest.raises(PolicyDenied) as exc:
+            gate.validate_intent("orchestration", Intent(
+                type=IntentType.UPDATE_STATE,
+                payload={"changes": {field_name: ["X"]}},
+            ))
+        assert exc.value.rule == "state_field", field_name
+
+
 # ===========================================================================
 # allowed_tools_for_agent
 # ===========================================================================

--- a/inference_optimizer/tests/test_coordinator_kb_writes.py
+++ b/inference_optimizer/tests/test_coordinator_kb_writes.py
@@ -100,6 +100,37 @@ def test_kb_amend_recipe_persists_pitfall(tmp_path: Path) -> None:
     assert "ep=8 OOMs on 30B" in descs
 
 
+def test_kb_amend_recipe_stamps_architecture_tags(tmp_path: Path) -> None:
+    """KEEP / REVERT / CLOSE amend stamps the config.json
+    architecture-identity tags (``architectures`` + ``model_type``) into
+    the recipe ``extras`` so a fine-tuned model's row records the same
+    architecture as the base model it derives from."""
+    coord = _make_coordinator(tmp_path)
+    coord.shared_state.model_architectures = ["LlamaForCausalLM"]
+    coord.shared_state.model_type = "llama"
+    coord._kb_amend_recipe(
+        append_lesson={"statement": "raise tp to 8", "measured_impact": "+12%"},
+    )
+    row = coord.cortex_kb.get_recipe(canonical_id=_expected_cid())
+    assert row is not None
+    assert row.get("architectures") == ["LlamaForCausalLM"]
+    assert row.get("model_type") == "llama"
+
+
+def test_kb_amend_recipe_skips_empty_architecture_tags(tmp_path: Path) -> None:
+    """With no config.json tags on SharedState the amend must NOT stamp
+    empty ``architectures`` / ``model_type`` keys (no row pollution)."""
+    coord = _make_coordinator(tmp_path)
+    # model_architectures / model_type left at their defaults ([] / "").
+    coord._kb_amend_recipe(
+        append_lesson={"statement": "raise tp to 8", "measured_impact": "+12%"},
+    )
+    row = coord.cortex_kb.get_recipe(canonical_id=_expected_cid())
+    assert row is not None
+    assert "architectures" not in row
+    assert "model_type" not in row
+
+
 def test_recipe_kb_enabled_is_true(tmp_path: Path) -> None:
     """P1-2: RecipeKB exposes ``enabled`` (always True) so callers that
     probe ``client.enabled`` (the coordinator T0 gate) don't silently

--- a/inference_optimizer/tests/test_model_config_tags.py
+++ b/inference_optimizer/tests/test_model_config_tags.py
@@ -1,0 +1,181 @@
+"""Tests for the config.json-derived KB architecture tags.
+
+Covers two layers:
+
+1. ``cli._load_model_config_tags`` — the soft-degrade loader that lifts
+   ``architectures`` + ``model_type`` out of a model's ``config.json``.
+2. The T0 anchor write path — ``run_t0_anchor`` stamps those tags into the
+   recipe-snapshot ``extras`` so a fine-tuned model's row records the same
+   architecture identity as the base model it derives from.
+
+The amend (KEEP / REVERT / CLOSE) write path is covered in
+``test_coordinator_kb_writes.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from inference_optimizer.cli import _load_model_config_tags
+from inference_optimizer.orchestrator.cortex_t0 import run_t0_anchor
+from inference_optimizer.recipe_kb import (
+    LocalRecipeStore,
+    RecipeKB,
+    recipe_canonical_id,
+)
+
+
+def _write_config(model_dir: Path, payload: Any) -> Path:
+    model_dir.mkdir(parents=True, exist_ok=True)
+    cfg = model_dir / "config.json"
+    if isinstance(payload, str):
+        cfg.write_text(payload, encoding="utf-8")
+    else:
+        cfg.write_text(json.dumps(payload), encoding="utf-8")
+    return cfg
+
+
+# ===========================================================================
+# 1. _load_model_config_tags — happy path + soft-degrade matrix
+# ===========================================================================
+def test_load_config_tags_valid(tmp_path: Path) -> None:
+    _write_config(tmp_path / "m", {
+        "architectures": ["LlamaForCausalLM"],
+        "model_type": "llama",
+        "hidden_size": 4096,
+    })
+    out = _load_model_config_tags(str(tmp_path / "m"))
+    assert out == {"architectures": ["LlamaForCausalLM"], "model_type": "llama"}
+
+
+def test_load_config_tags_missing_file_returns_empty(tmp_path: Path) -> None:
+    assert _load_model_config_tags(str(tmp_path / "nonexistent")) == {}
+
+
+def test_load_config_tags_empty_path_returns_empty() -> None:
+    assert _load_model_config_tags("") == {}
+
+
+def test_load_config_tags_invalid_json_returns_empty(tmp_path: Path) -> None:
+    _write_config(tmp_path / "m", "{not valid json")
+    assert _load_model_config_tags(str(tmp_path / "m")) == {}
+
+
+def test_load_config_tags_non_dict_returns_empty(tmp_path: Path) -> None:
+    _write_config(tmp_path / "m", ["LlamaForCausalLM"])
+    assert _load_model_config_tags(str(tmp_path / "m")) == {}
+
+
+def test_load_config_tags_scalar_architectures_wrapped(tmp_path: Path) -> None:
+    _write_config(tmp_path / "m", {
+        "architectures": "LlamaForCausalLM",
+        "model_type": "llama",
+    })
+    out = _load_model_config_tags(str(tmp_path / "m"))
+    assert out["architectures"] == ["LlamaForCausalLM"]
+
+
+def test_load_config_tags_omits_empty_fields(tmp_path: Path) -> None:
+    # Only model_type present -> architectures key omitted entirely.
+    _write_config(tmp_path / "m", {"model_type": "qwen3_moe"})
+    assert _load_model_config_tags(str(tmp_path / "m")) == {"model_type": "qwen3_moe"}
+    # Only architectures present -> model_type key omitted.
+    _write_config(tmp_path / "n", {"architectures": ["Qwen3MoeForCausalLM"]})
+    assert _load_model_config_tags(str(tmp_path / "n")) == {
+        "architectures": ["Qwen3MoeForCausalLM"],
+    }
+
+
+def test_load_config_tags_drops_blank_entries(tmp_path: Path) -> None:
+    _write_config(tmp_path / "m", {
+        "architectures": ["LlamaForCausalLM", "", "  "],
+        "model_type": "  llama  ",
+    })
+    out = _load_model_config_tags(str(tmp_path / "m"))
+    assert out["architectures"] == ["LlamaForCausalLM"]
+    assert out["model_type"] == "llama"
+
+
+# ===========================================================================
+# 2. T0 anchor stamps the tags into the recipe extras
+# ===========================================================================
+@dataclass
+class _FakeSharedState:
+    cortex_session_id: str = ""
+    warm_start_ts: str = ""
+    warm_start_recipe: dict[str, Any] = field(default_factory=dict)
+    warm_start_pitfalls: list[Any] = field(default_factory=list)
+    warm_start_lessons: list[Any] = field(default_factory=list)
+    framework: str = "sglang"
+    framework_version: str = "0.4.5"
+    precision: str = "fp8"
+    tp: int = 8
+    ep: int = 0
+    conc: int = 0
+    isl: int = 0
+    osl: int = 0
+    max_model_len: int = 0
+    model_class: str = ""
+    model_architectures: list[str] = field(default_factory=list)
+    model_type: str = ""
+
+    def save(self, _path: Path) -> None:  # noqa: D401
+        """No-op save — these tests don't assert on disk persistence."""
+
+
+@pytest.fixture
+def kb(tmp_path: Path) -> RecipeKB:
+    return RecipeKB(local=LocalRecipeStore(root=tmp_path / "kb"), remote=None)
+
+
+def _cid(state: _FakeSharedState, workload: str, hw: str) -> str:
+    return recipe_canonical_id(
+        model=workload, hardware=hw,
+        framework=state.framework,
+        framework_version=state.framework_version,
+        precision=state.precision,
+    )
+
+
+def test_t0_anchor_stamps_architecture_tags(kb: RecipeKB, tmp_path: Path) -> None:
+    sd = tmp_path / "session"
+    sd.mkdir()
+    state = _FakeSharedState(
+        model_architectures=["LlamaForCausalLM"],
+        model_type="llama",
+    )
+    run_t0_anchor(
+        kb, state,
+        workload="Llama-3.1-8B-MyFinetune", hw="MI300X",
+        extra_attrs={"framework": "sglang"},
+        session_dir=sd,
+    )
+    row = kb.get_recipe(
+        canonical_id=_cid(state, "Llama-3.1-8B-MyFinetune", "MI300X"),
+    )
+    assert row is not None
+    assert row.get("architectures") == ["LlamaForCausalLM"]
+    assert row.get("model_type") == "llama"
+
+
+def test_t0_anchor_skips_empty_architecture_tags(
+    kb: RecipeKB, tmp_path: Path,
+) -> None:
+    sd = tmp_path / "session"
+    sd.mkdir()
+    state = _FakeSharedState()  # no config.json tags
+    run_t0_anchor(
+        kb, state,
+        workload="m", hw="mi300x",
+        extra_attrs={"framework": "sglang"},
+        session_dir=sd,
+    )
+    row = kb.get_recipe(canonical_id=_cid(state, "m", "mi300x"))
+    assert row is not None
+    assert "architectures" not in row
+    assert "model_type" not in row

--- a/robustness-agent/src/robustness_agent/role/envelope.py
+++ b/robustness-agent/src/robustness_agent/role/envelope.py
@@ -220,6 +220,11 @@ CORE_STATE_FIELDS: frozenset[str] = frozenset({
     "framework_pr_max_candidates",
     # Advisory model-architecture profile (launcher / state.json owned).
     "model_arch",
+    # Architecture-identity tags lifted from config.json (recipe-snapshot
+    # KB tags). Fact-layer; locked to mirror upstream
+    # ``policy.CORE_STATE_FIELDS``.
+    "model_architectures",
+    "model_type",
 })
 
 


### PR DESCRIPTION
## Summary
- Lift `architectures` and `model_type` from the model weights' `config.json` and stamp them into the recipe-snapshot `extras` on every KB write (T0 anchor + KEEP/REVERT/CLOSE amend), so a fine-tuned model's recipe records the same architecture identity as the base model it derives from.
- `cli._load_model_config_tags`: soft-degrade loader (missing / invalid / non-dict `config.json` -> `{}`); normalises `architectures` to a string list and drops empty fields.
- `SharedState`: new `model_architectures` / `model_type` fields (round-trip via the existing field filter; resume rehydrates from `state.json`).
- Write-side only: warm-start still matches on the exact 5-tuple, so this records the tags without changing recipe reuse yet.

## Test plan
- [x] `test_model_config_tags.py`: loader happy-path + soft-degrade matrix (8) + T0 stamp/skip (2)
- [x] `test_coordinator_kb_writes.py`: amend stamp/skip (2)
- [x] Regression: cortex_t0 / model_arch advisory / shared_state evolution / resume / warm_replay (61 + 79 passed)