### PR TITLE
ci: large-B cron 100/batch + retimed slots, pause tiny schedule

### DIFF
--- a/.github/workflows/optimize-submit.yml
+++ b/.github/workflows/optimize-submit.yml
@@ -15,8 +15,9 @@ name: SaFE Optimize Submit
 #                                    register, so download is overlapped
 #                                    with the rest of the batch (no serial
 #                                    prewarm stage that blocks optimize).
-#                                    default max_parallel=60 so the whole
-#                                    scheduled batch can dispatch at once.
+#                                    schedule forces max_parallel=100 so the
+#                                    whole 100-model batch dispatches at once
+#                                    (dispatch default stays 60).
 #   3. summarize  (hyperloom-4hhzn) — aggregate per-task artifacts into a
 #                                    ranked ci_summary.{md,json} (sorted by
 #                                    Gain% desc, with medals), publish the
@@ -31,7 +32,7 @@ name: SaFE Optimize Submit
 #   • Quick HF top-N probe   : `-f hf_top=10 -f min_params=7`
 
 on:
-  # Production large-B pool: 10 models every 8 hours. The matrix generator
+  # Production large-B pool: 100 models every 8 hours. The matrix generator
   # rotates deterministically by UTC 8-hour slot.
   schedule:
     - cron: '0 */8 * * *'
@@ -73,7 +74,7 @@ on:
         required: false
         default: '7'
       max_parallel:
-        description: 'Max parallel optimize jobs (default 60 = scheduled batch size)'
+        description: 'Max parallel optimize jobs (dispatch default 60; schedule forces 100 to match the 100-model batch).'
         required: false
         default: '60'
       submit_workspaces:
@@ -188,7 +189,7 @@ jobs:
       # refreshed only when we want to bring in newly-published models.
       INPUT_CANDIDATES_FILE: ${{ github.event_name == 'schedule' && 'ci/candidates/production_1000_from_hf_2026-05-25.json' || github.event.inputs.candidates_file }}
       INPUT_BATCH_INDEX:     ${{ github.event.inputs.batch_index }}
-      INPUT_BATCH_SIZE:      ${{ github.event_name == 'schedule' && '10' || github.event.inputs.batch_size }}
+      INPUT_BATCH_SIZE:      ${{ github.event_name == 'schedule' && '100' || github.event.inputs.batch_size }}
       INPUT_HF_TOP:          ${{ github.event.inputs.hf_top }}
       INPUT_MIN_PARAMS:      ${{ github.event.inputs.min_params }}
       # Schedule no longer excludes leaderboard-known models — that was for
@@ -223,7 +224,7 @@ jobs:
     timeout-minutes: 780
     strategy:
       fail-fast: false
-      max-parallel: ${{ fromJson(github.event.inputs.max_parallel || '60') }}
+      max-parallel: ${{ fromJson(github.event_name == 'schedule' && '100' || github.event.inputs.max_parallel || '60') }}
       matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     env:
       CLAW_API_KEY:                     ${{ secrets.CLAW_API_KEY }}

--- a/.github/workflows/optimize-submit.yml
+++ b/.github/workflows/optimize-submit.yml
@@ -32,10 +32,12 @@ name: SaFE Optimize Submit
 #   • Quick HF top-N probe   : `-f hf_top=10 -f min_params=7`
 
 on:
-  # Production large-B pool: 100 models every 8 hours. The matrix generator
-  # rotates deterministically by UTC 8-hour slot.
+  # Production large-B pool: 100 models every 8 hours, firing at UTC
+  # 04:00 / 12:00 / 20:00 (Beijing 12:00 / 20:00 / 04:00). The matrix
+  # generator rotates deterministically by UTC 8-hour slot — these hours
+  # map cleanly to hour//8 -> 0 / 1 / 2 so the rotation stays continuous.
   schedule:
-    - cron: '0 */8 * * *'
+    - cron: '0 4,12,20 * * *'
   workflow_dispatch:
     inputs:
       # ── Model source (priority: models > candidates_file > hf_top) ──────

--- a/.github/workflows/optimize-tiny.yml
+++ b/.github/workflows/optimize-tiny.yml
@@ -6,8 +6,13 @@ name: SaFE Optimize Tiny
 # byte-for-byte on the same path as the regular SaFE submit workflow.
 
 on:
-  schedule:
-    - cron: '0 */4 * * *'
+  # ─── PAUSED 2026-06-03 ───────────────────────────────────────────
+  # Tiny (3B-12B) scheduled rotation is paused per operator request so
+  # the runner pool is dedicated to the large-B production cron. Manual
+  # workflow_dispatch still works for one-off tiny batches. To resume the
+  # rotation, uncomment the schedule block below.
+  # schedule:
+  #   - cron: '0 */4 * * *'
   workflow_dispatch:
     inputs:
       batch_index:


### PR DESCRIPTION
## Summary
- **large-B `optimize-submit` schedule**: `batch_size` 10 → **100**, `max-parallel` 60 → **100** so the whole 100-model batch dispatches per 8-hour slot.
- **cron retimed**: `0 */8 * * *` → `0 4,12,20 * * *` = UTC 04:00 / 12:00 / 20:00 = **Beijing 12:00 / 20:00 / 04:00**. These hours map to `hour//8 -> 0/1/2`, so the deterministic 8-hour-slot rotation in `generate_hf_matrix.py` stays continuous.
- **`optimize-tiny`**: pause the 4-hour schedule (manual `workflow_dispatch` retained) to dedicate the runner pool to the large-B cron.

## Rotation impact
- `batches = ceil(1082 / 100) = 11` (was 109). The whole pool is covered in **11 cron fires ≈ 3.67 days**.
- Next fires (continuous): slot 28 → idx 6 (rows 600-699), slot 29 → idx 7 (rows 700-799), … wrapping at idx 10 → idx 0.

## Test plan
- [ ] Confirm next scheduled run picks the expected 100-row slice in the prepare/matrix log.
- [ ] Confirm tiny no longer fires on schedule (manual dispatch still works).

Made with [Cursor](https://cursor.com)