### PR TITLE
ci: slim prompt_prefix, key SaFE delivery on session_breakdown.json

### DIFF
--- a/.github/workflows/optimize-submit.yml
+++ b/.github/workflows/optimize-submit.yml
@@ -328,7 +328,6 @@ jobs:
           # for these two critical values. SaFE consumes them and renders the
           # generated prompt tail consistently with the CI prefix.
           ARGS+=(--max-hours "${INPUT_MAX_HOURS:-12}")
-          ARGS+=(--results-path '$USER_DATA_PATH')
           # Hard guarantee: SaFE promptPrefix MUST be non-empty. Workflow
           # input is only populated on workflow_dispatch — for schedule
           # trigger we fall back to ci/prompt_prefix.txt (single source of

--- a/.github/workflows/optimize-submit.yml
+++ b/.github/workflows/optimize-submit.yml
@@ -32,12 +32,12 @@ name: SaFE Optimize Submit
 #   • Quick HF top-N probe   : `-f hf_top=10 -f min_params=7`
 
 on:
-  # Production large-B pool: 100 models every 8 hours, firing at UTC
-  # 04:00 / 12:00 / 20:00 (Beijing 12:00 / 20:00 / 04:00). The matrix
-  # generator rotates deterministically by UTC 8-hour slot — these hours
-  # map cleanly to hour//8 -> 0 / 1 / 2 so the rotation stays continuous.
+  # Production large-B pool: 100 models twice a day, firing at UTC
+  # 00:00 / 12:00 (Beijing 08:00 / 20:00). The matrix generator rotates
+  # deterministically by UTC 12-hour slot — these hours map cleanly to
+  # hour//12 -> 0 / 1 so the rotation stays continuous.
   schedule:
-    - cron: '0 4,12,20 * * *'
+    - cron: '0 0,12 * * *'
   workflow_dispatch:
     inputs:
       # ── Model source (priority: models > candidates_file > hf_top) ──────
@@ -290,10 +290,7 @@ jobs:
           INPUT_WAIT:             ${{ github.event.inputs.wait_for_completion }}
           INPUT_COLLECT:          ${{ github.event.inputs.collect_artifacts }}
           INPUT_TASK_TIMEOUT_MIN: ${{ github.event.inputs.task_timeout_min }}
-          # Schedule runs the production pool at an 8h per-task optimizer
-          # budget (matches the 8-hour cron cadence); dispatch keeps its input
-          # (default 12).
-          INPUT_MAX_HOURS:        ${{ github.event_name == 'schedule' && '8' || github.event.inputs.max_hours }}
+          INPUT_MAX_HOURS:        ${{ github.event.inputs.max_hours }}
           # Cron rotates through the production pool — operators can't go
           # back and re-fetch sandbox state after the fact, so force
           # `--all-artifacts=true` on schedule. workflow_dispatch keeps

--- a/.github/workflows/optimize-submit.yml
+++ b/.github/workflows/optimize-submit.yml
@@ -290,7 +290,10 @@ jobs:
           INPUT_WAIT:             ${{ github.event.inputs.wait_for_completion }}
           INPUT_COLLECT:          ${{ github.event.inputs.collect_artifacts }}
           INPUT_TASK_TIMEOUT_MIN: ${{ github.event.inputs.task_timeout_min }}
-          INPUT_MAX_HOURS:        ${{ github.event.inputs.max_hours }}
+          # Schedule runs the production pool at an 8h per-task optimizer
+          # budget (matches the 8-hour cron cadence); dispatch keeps its input
+          # (default 12).
+          INPUT_MAX_HOURS:        ${{ github.event_name == 'schedule' && '8' || github.event.inputs.max_hours }}
           # Cron rotates through the production pool — operators can't go
           # back and re-fetch sandbox state after the fact, so force
           # `--all-artifacts=true` on schedule. workflow_dispatch keeps
@@ -328,7 +331,7 @@ jobs:
           # for these two critical values. SaFE consumes them and renders the
           # generated prompt tail consistently with the CI prefix.
           ARGS+=(--max-hours "${INPUT_MAX_HOURS:-12}")
-          ARGS+=(--results-path '$RESULT_DIR')
+          ARGS+=(--results-path '$USER_DATA_PATH')
           # Hard guarantee: SaFE promptPrefix MUST be non-empty. Workflow
           # input is only populated on workflow_dispatch — for schedule
           # trigger we fall back to ci/prompt_prefix.txt (single source of

--- a/ci/generate_hf_matrix.py
+++ b/ci/generate_hf_matrix.py
@@ -338,12 +338,12 @@ def _resolve_batch_index(pool_size: int, batch_size: int) -> int:
 
 
 def _cron_batch_index(pool_size: int, batch_size: int) -> int:
-    """Deterministic production-pool rotation for the 8-hour production cron.
+    """Deterministic production-pool rotation for the twice-daily cron.
 
     Manual workflow dispatches increment GitHub's run number, so using
     ``GITHUB_RUN_NUMBER`` for schedule rotation makes the next cron batch depend
-    on ad-hoc smoke runs. Instead, schedule uses the UTC 8-hour slot:
-    00:00-07:59 => slot 0, 08:00-15:59 => slot 1, 16:00-23:59 => slot 2.
+    on ad-hoc smoke runs. Instead, schedule uses the UTC 12-hour slot:
+    00:00-11:59 => slot 0, 12:00-23:59 => slot 1 (cron fires at 00:00 / 12:00).
     The epoch is pinned to the production pool date so every operator can
     predict the slice before cron fires.
     """
@@ -359,8 +359,8 @@ def _cron_batch_index(pool_size: int, batch_size: int) -> int:
         now_utc = datetime.now(timezone.utc)
     now_utc = now_utc.astimezone(timezone.utc)
     days = (now_utc.date() - epoch.date()).days
-    eight_hour_slot = min(now_utc.hour // 8, 2)
-    slot = max(days, 0) * 3 + eight_hour_slot
+    half_day_slot = min(now_utc.hour // 12, 1)
+    slot = max(days, 0) * 2 + half_day_slot
     batch_index = slot % batches
     print(
         "cron rotation: "

--- a/ci/optimize_submit.py
+++ b/ci/optimize_submit.py
@@ -2439,8 +2439,9 @@ def wait_and_collect_one(
 
     Two-stage collection:
       1. SaFE API: list_artifacts(task_id) -> download each via /artifacts/download
-      2. NFS fallback: if we still don't have ci_metrics.json + optimization_report.md,
-         walk the canonical NFS result directories for a matching model dir
+      2. NFS fallback: if we still don't have session_breakdown.json (the CI
+         delivery contract), walk the canonical NFS result directories for a
+         matching model dir
     """
     if not rec.task_id:
         return rec  # nothing to wait for (skipped/failed during submit)
@@ -2483,14 +2484,18 @@ def wait_and_collect_one(
         wanted = [it for it in items
                   if _is_wanted_artifact(it.get("path", ""), all_artifacts)]
         wanted_paths = [it.get("path", "").lower() for it in wanted]
-        has_safe_metrics = any(p.endswith("ci_metrics.json") for p in wanted_paths)
-        has_safe_report = any(p.endswith("optimization_report.md") for p in wanted_paths)
-        if has_safe_metrics and has_safe_report:
+        # session_breakdown.json is the CI delivery contract — the optimizer's
+        # cli.finally always writes it (even on abort). ci_metrics.json /
+        # optimization_report.md are no longer hand-written by the prompt, so
+        # we retry only until the breakdown shows up.
+        has_safe_breakdown = any(
+            p.endswith("session_breakdown.json") for p in wanted_paths
+        )
+        if has_safe_breakdown:
             break
         if attempt < 2:
-            log.info("[task %s] safe artifacts missing key files on attempt %d "
-                     "(metrics=%s report=%s); retrying",
-                     rec.task_id, attempt + 1, has_safe_metrics, has_safe_report)
+            log.info("[task %s] safe artifacts missing session_breakdown.json on "
+                     "attempt %d; retrying", rec.task_id, attempt + 1)
             time.sleep(15)
     log.info("[task %s] safe artifacts: %d total, %d to download",
              rec.task_id, len(items), len(wanted))
@@ -2521,12 +2526,18 @@ def wait_and_collect_one(
         except Exception as e:
             log.warning("[task %s] failed to download %s: %s", rec.task_id, path, e)
 
-    # Stage 2: NFS fallback if we didn't get the key result files via Claw.
-    has_metrics = any(p.endswith("ci_metrics.json") for p in rec.artifact_files)
-    has_report = any(p.endswith("optimization_report.md") for p in rec.artifact_files)
-    if not (has_metrics and has_report):
-        log.info("[task %s] missing key files (metrics=%s report=%s) — trying NFS fallback",
-                 rec.task_id, has_metrics, has_report)
+    # Stage 2: NFS fallback if Stage 1 didn't deliver the key result file.
+    # The CI delivery contract is session_breakdown.json (auto-written by the
+    # optimizer's cli.finally to the wekafs session dir, then discovered here
+    # by the recursive NFS scan). ci_metrics.json / optimization_report.md are
+    # no longer required (the prompt no longer hand-writes them), so they no
+    # longer gate the fallback.
+    has_breakdown = any(
+        p.endswith("session_breakdown.json") for p in rec.artifact_files
+    )
+    if not has_breakdown:
+        log.info("[task %s] missing session_breakdown.json — trying NFS fallback",
+                 rec.task_id)
         copy_full_session = all_artifacts or _env_truthy("SAFE_OPTIMIZE_COPY_FULL_SESSION")
         n_added = _nfs_fallback_collect(
             rec,

--- a/ci/prompt_prefix.txt
+++ b/ci/prompt_prefix.txt
@@ -6,27 +6,20 @@ NOT fall back to /wekafs/HyperloomV2 — those trees drift and are not
 reproducible. If clone fails: ABORT with gain_pct=0.0 and
 actions_taken=["aborted: source checkout failed"].
 
-  # If Claw mounted USER_DATA_PATH on wekafs, align RESULT_DIR to it so the
-  # V2 session_dir and its artifacts share one persistent tree.
-  case "${USER_DATA_PATH:-}" in
-    /hyperloom/*|/wekafs/*)
-      : "${RESULT_DIR:=$USER_DATA_PATH}"
-      echo "[CI_PATH] aligned RESULT_DIR=$RESULT_DIR with USER_DATA_PATH (already persistent in wekafs)"
-      ;;
-    *)
-      : "${RESULT_DIR:=/workspace/hyperloom/}"
-      echo "[CI_PATH] RESULT_DIR=$RESULT_DIR is sandbox-ephemeral; the V2 session_dir under wekafs is the persistent copy CI reads"
-      ;;
-  esac
-  export RESULT_DIR
+  # Production: USER_DATA_PATH is the wekafs path Claw mounts for this run.
+  # The V2 session_dir + audit files live directly under it (already
+  # persistent — CI reads them straight from wekafs, no copy needed).
+  : "${USER_DATA_PATH:=/workspace/hyperloom}"
+  export USER_DATA_PATH
+  echo "[CI_PATH] USER_DATA_PATH=$USER_DATA_PATH (persistent session + artifact root)"
   export HYPERLOOM_SOURCE_REPO="${HYPERLOOM_SOURCE_REPO:-https://github.com/AMD-AGI/Hyperloom.git}"
   export HYPERLOOM_SOURCE_REF="${HYPERLOOM_SOURCE_REF:-main}"
-  # Clone OUTSIDE $RESULT_DIR so the ~100MB shallow checkout is not mirrored
-  # into the persistent tree on every run. The audit files written below
-  # (hyperloom_source_commit.txt + source_commits.json) still live in
-  # $RESULT_DIR so they remain with the session.
+  # Clone OUTSIDE $USER_DATA_PATH so the ~100MB shallow checkout is not
+  # mirrored into the persistent tree on every run. The audit files written
+  # below (hyperloom_source_commit.txt + source_commits.json) still live
+  # under $USER_DATA_PATH so they remain with the session.
   export HYPERLOOM_SOURCE_DIR="${HYPERLOOM_SOURCE_DIR:-/workspace/Hyperloom-main}"
-  mkdir -p "$RESULT_DIR"
+  mkdir -p "$USER_DATA_PATH"
   mkdir -p "$(dirname "$HYPERLOOM_SOURCE_DIR")"
   rm -rf "$HYPERLOOM_SOURCE_DIR"
   # 1) shallow clone main (always works regardless of HYPERLOOM_SOURCE_REF).
@@ -45,7 +38,7 @@ actions_taken=["aborted: source checkout failed"].
     git checkout --detach FETCH_HEAD
   fi
   HYPERLOOM_SOURCE_COMMIT=$(git rev-parse HEAD)
-  printf '%s\n' "$HYPERLOOM_SOURCE_COMMIT" > "$RESULT_DIR/hyperloom_source_commit.txt"
+  printf '%s\n' "$HYPERLOOM_SOURCE_COMMIT" > "$USER_DATA_PATH/hyperloom_source_commit.txt"
   python3 - <<'PY'
 import json, os, subprocess
 def git_out(args):
@@ -54,7 +47,7 @@ def git_out(args):
     except Exception:
         return ""
 source_dir = os.environ.get("HYPERLOOM_SOURCE_DIR", "")
-result_dir = os.environ.get("RESULT_DIR", "/workspace/hyperloom/")
+result_dir = os.environ.get("USER_DATA_PATH", "/workspace/hyperloom")
 # Strip the embedded token from the remote URL we record (the token is OK
 # inside the sandbox env but should never end up in a persisted artifact).
 def _sanitize(url: str) -> str:

--- a/ci/prompt_prefix.txt
+++ b/ci/prompt_prefix.txt
@@ -78,3 +78,8 @@ Then run the skill at $HYPERLOOM_SOURCE_DIR/inference_optimizer/SKILL.md from
 that directory (cd "$HYPERLOOM_SOURCE_DIR").
 
   export CORTEX_KB_URL=https://global.primus-safe.amd.com/knowledge-base
+
+SAFETY:
+- NEVER `find /` or `find /wekafs` without `-maxdepth 4`. Prefer which/ls/$PATH lookups.
+- NEVER run `kill -9 $(ps aux | grep ...)` — this kills the sandbox executor itself.
+- Per-bash timeouts must be <= 120s; use short polling loops rather than one long blocking call.

--- a/ci/prompt_prefix.txt
+++ b/ci/prompt_prefix.txt
@@ -46,7 +46,10 @@ def git_out(args):
     except Exception:
         return ""
 source_dir = os.environ.get("HYPERLOOM_SOURCE_DIR", "")
-result_dir = os.environ.get("USER_DATA_PATH", "/workspace/hyperloom")
+# Write the audit file next to the session on wekafs (USER_DATA_PATH). Never
+# fall back to /workspace — if the platform did not set USER_DATA_PATH we skip
+# the write rather than scatter artifacts onto ephemeral sandbox disk.
+result_dir = os.environ.get("USER_DATA_PATH", "")
 # Strip the embedded token from the remote URL we record (the token is OK
 # inside the sandbox env but should never end up in a persisted artifact).
 def _sanitize(url: str) -> str:
@@ -61,9 +64,10 @@ payload = {
         "remote": _sanitize(git_out(["git", "-C", source_dir, "config", "--get", "remote.origin.url"])) if source_dir else "",
     }
 }
-os.makedirs(result_dir, exist_ok=True)
-with open(os.path.join(result_dir, "source_commits.json"), "w", encoding="utf-8") as f:
-    json.dump(payload, f, indent=2)
+if result_dir:
+    os.makedirs(result_dir, exist_ok=True)
+    with open(os.path.join(result_dir, "source_commits.json"), "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
 PY
 
 Then run the skill at $HYPERLOOM_SOURCE_DIR/inference_optimizer/SKILL.md from

--- a/ci/prompt_prefix.txt
+++ b/ci/prompt_prefix.txt
@@ -9,7 +9,6 @@ actions_taken=["aborted: source checkout failed"].
   # Production: USER_DATA_PATH is the wekafs path Claw mounts for this run.
   # The V2 session_dir + audit files live directly under it (already
   # persistent — CI reads them straight from wekafs, no copy needed).
-  : "${USER_DATA_PATH:=/workspace/hyperloom}"
   export USER_DATA_PATH
   echo "[CI_PATH] USER_DATA_PATH=$USER_DATA_PATH (persistent session + artifact root)"
   export HYPERLOOM_SOURCE_REPO="${HYPERLOOM_SOURCE_REPO:-https://github.com/AMD-AGI/Hyperloom.git}"
@@ -71,6 +70,7 @@ Then run the skill at $HYPERLOOM_SOURCE_DIR/inference_optimizer/SKILL.md from
 that directory (cd "$HYPERLOOM_SOURCE_DIR").
 
   export CORTEX_KB_URL=https://global.primus-safe.amd.com/knowledge-base
+  export NODE_TLS_REJECT_UNAUTHORIZED=0
 
 SAFETY:
 - NEVER `find /` or `find /wekafs` without `-maxdepth 4`. Prefer which/ls/$PATH lookups.

--- a/ci/prompt_prefix.txt
+++ b/ci/prompt_prefix.txt
@@ -1,11 +1,5 @@
 Use the inference-optimization skill from a fresh Hyperloom checkout for this model.
 
-CRITICAL — Fresh Source Checkout (REQUIRED): run the optimizer from a freshly
-cloned Hyperloom tree (CI injects an authenticated HYPERLOOM_SOURCE_REPO). Do
-NOT fall back to /wekafs/HyperloomV2 — those trees drift and are not
-reproducible. If clone fails: ABORT with gain_pct=0.0 and
-actions_taken=["aborted: source checkout failed"].
-
   # Production: USER_DATA_PATH is the wekafs path Claw mounts for this run.
   # The V2 session_dir + audit files live directly under it (already
   # persistent — CI reads them straight from wekafs, no copy needed).
@@ -69,9 +63,6 @@ if result_dir:
     with open(os.path.join(result_dir, "source_commits.json"), "w", encoding="utf-8") as f:
         json.dump(payload, f, indent=2)
 PY
-
-Then run the skill at $HYPERLOOM_SOURCE_DIR/inference_optimizer/SKILL.md from
-that directory (cd "$HYPERLOOM_SOURCE_DIR").
 
   export CORTEX_KB_URL=https://global.primus-safe.amd.com/knowledge-base
   export NODE_TLS_REJECT_UNAUTHORIZED=0

--- a/ci/prompt_prefix.txt
+++ b/ci/prompt_prefix.txt
@@ -7,7 +7,7 @@ reproducible. If clone fails: ABORT with gain_pct=0.0 and
 actions_taken=["aborted: source checkout failed"].
 
   # If Claw mounted USER_DATA_PATH on wekafs, align RESULT_DIR to it so the
-  # V2 session_dir and the contract files share one persistent tree.
+  # V2 session_dir and its artifacts share one persistent tree.
   case "${USER_DATA_PATH:-}" in
     /hyperloom/*|/wekafs/*)
       : "${RESULT_DIR:=$USER_DATA_PATH}"
@@ -15,16 +15,16 @@ actions_taken=["aborted: source checkout failed"].
       ;;
     *)
       : "${RESULT_DIR:=/workspace/hyperloom/}"
-      echo "[CI_PATH] RESULT_DIR=$RESULT_DIR is sandbox-ephemeral; PERSIST cp will mirror it later"
+      echo "[CI_PATH] RESULT_DIR=$RESULT_DIR is sandbox-ephemeral; the V2 session_dir under wekafs is the persistent copy CI reads"
       ;;
   esac
   export RESULT_DIR
   export HYPERLOOM_SOURCE_REPO="${HYPERLOOM_SOURCE_REPO:-https://github.com/AMD-AGI/Hyperloom.git}"
   export HYPERLOOM_SOURCE_REF="${HYPERLOOM_SOURCE_REF:-main}"
-  # Clone OUTSIDE $RESULT_DIR — otherwise the ~100MB shallow checkout gets
-  # copied into $PERSIST_DIR on every run (waste of wekafs). The audit
-  # files written below (hyperloom_source_commit.txt + source_commits.json)
-  # still live in $RESULT_DIR so they DO get persisted.
+  # Clone OUTSIDE $RESULT_DIR so the ~100MB shallow checkout is not mirrored
+  # into the persistent tree on every run. The audit files written below
+  # (hyperloom_source_commit.txt + source_commits.json) still live in
+  # $RESULT_DIR so they remain with the session.
   export HYPERLOOM_SOURCE_DIR="${HYPERLOOM_SOURCE_DIR:-/workspace/Hyperloom-main}"
   mkdir -p "$RESULT_DIR"
   mkdir -p "$(dirname "$HYPERLOOM_SOURCE_DIR")"
@@ -87,135 +87,13 @@ Pass `--max-hours 12` to `inference_optimizer optimize` (do not use the cli
 default). Kernel backend ladder is GEAK first, then Claude, then Codex; do NOT
 request a Claude-only backend unless explicitly told to.
 
-CRITICAL — Required Artifacts (the canonical SaFE success contract):
-At the end of the run, ALWAYS write ALL THREE files to $RESULT_DIR (defaults
-to /workspace/hyperloom/). If ANY of them is missing — or if the wekafs
-persist step below does not echo `[PERSIST OK]` — the task is considered
-Failed and we cannot recover any data from the sandbox after cleanup.
-
-  $RESULT_DIR/optimization_report.md
-  $RESULT_DIR/ci_metrics.json
-    {"baseline_throughput": <float>, "optimized_throughput": <float>, "gain_pct": <float>, "tok_per_gpu_baseline": <float>, "tok_per_gpu_optimized": <float>, "actions_taken": ["..."]}
-  $RESULT_DIR/session_breakdown.json
-    Written by inference_optimizer/cli.py's finally block. Required — the
-    dashboard prefers it over ci_metrics.json.
-
-If the pipeline aborts (kernel apply / server start / tooling crash): set
-optimized_throughput = baseline_throughput, gain_pct = 0.0,
-actions_taken = ["aborted: <reason>"], and still emit ALL THREE files. Only
-hand-write ci_metrics.json from on-disk phase results (phase02_baseline/,
-phase06_sweep/) near the END of the 12h budget if the orchestrator is
-genuinely stuck — never bail early on a 12h run.
-
-CRITICAL — vLLM Forbidden Flags (server will crash with "unrecognized arguments"):
-- --num-scheduler-steps   (removed in vLLM v0.4.0)
-- --chunked-prefill-size  (SGLang-only, NOT vLLM)
-- --enable-chunked-prefill (only safe on vLLM >= 0.6.0; check version first)
-
-CRITICAL — Result Directory: RESULT_DIR was selected for you above (see the
-[CI_PATH] log line) and aligned with USER_DATA_PATH so the V2 session_dir and
-all three artifacts land in the same tree. Trust the exported value; never
-hard-code /workspace/hyperloom/.
-
-CRITICAL — POST-PIPELINE PERSIST (LAST step; the run is Failed unless
-`[PERSIST OK]` is echoed). RESULT_DIR is either sandbox-ephemeral
-/workspace/hyperloom/ (must be mirrored to /hyperloom/users/<uid>/ before the
-pod is cleaned up) or a wekafs-backed USER_DATA_PATH (already persistent —
-verify in place). Run this snippet after the three artifacts are written:
-
-  mkdir -p "$RESULT_DIR"
-  case "$RESULT_DIR" in
-    /hyperloom/*|/wekafs/*)
-      # Case (b): RESULT_DIR == USER_DATA_PATH on wekafs. Skip cp -a;
-      # just verify the three contract files exist somewhere under it.
-      # CI's NFS Stage B fallback scans this exact path when artifact
-      # upload fails, so no extra mirroring is needed.
-      echo "[PERSIST] RESULT_DIR=$RESULT_DIR is already wekafs-backed (Claw mode); skipping cp -a"
-      PERSIST_SCAN_DIR="$RESULT_DIR"
-      ;;
-    *)
-      # Case (a): RESULT_DIR is sandbox-ephemeral. Mirror to wekafs.
-      UID_HEX="$(ls /hyperloom/users 2>/dev/null | head -1)"
-      if [ -z "$UID_HEX" ]; then
-        echo "[PERSIST FAIL] /hyperloom/users/<uid>/ not mounted in this sandbox — cannot persist to wekafs" >&2
-        ls -la "$RESULT_DIR/"
-        PERSIST_SCAN_DIR="$RESULT_DIR"
-      else
-        MODEL_TAG="$(echo "${DISPLAYNAME:-task}" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9-' '-' | sed 's/-*$//')"
-        TASK_TAG="${SAFE_TASK_ID:-$(date +%Y%m%d%H%M%S)}"
-        PERSIST_DIR="/hyperloom/users/$UID_HEX/${MODEL_TAG}-${TASK_TAG##*-}-opt"
-        mkdir -p "$PERSIST_DIR"
-        # Copy the FULL result tree (logs, phases, kernels, traces, audit
-        # files) so everything survives sandbox cleanup, not just the three
-        # contract files.
-        if cp -a "$RESULT_DIR/." "$PERSIST_DIR/"; then
-          echo "[PERSIST] cp -a $RESULT_DIR/. -> $PERSIST_DIR/ succeeded"
-        else
-          echo "[PERSIST FAIL] cp -a returned non-zero exit; partial state may exist in $PERSIST_DIR/" >&2
-        fi
-        PERSIST_SCAN_DIR="$PERSIST_DIR"
-      fi
-      ;;
-  esac
-  # V2 cli writes the authoritative session_breakdown.json (full phases[],
-  # 30-50 KB) under <USER_DATA_PATH>/<model>/<ts>/. Pull it in alongside the
-  # agent's compact copy so the artifact zip has phase-level detail.
-  V2_SESSION_ROOTS=()
-  [ -n "${USER_DATA_PATH:-}" ] && V2_SESSION_ROOTS+=("$USER_DATA_PATH")
-  [ -n "${UID_HEX:-}" ] && V2_SESSION_ROOTS+=("/hyperloom/users/$UID_HEX")
-  for _root in "${V2_SESSION_ROOTS[@]}"; do
-    [ -d "$_root" ] || continue
-    # Pick the most recent non-trivial breakdown (>4 KB rules out the agent
-    # placeholder; -mmin -720 avoids stale sessions from prior runs).
-    _v2_bd="$(find "$_root" -mindepth 3 -maxdepth 3 -name session_breakdown.json -size +4k -mmin -720 2>/dev/null | xargs -r ls -t 2>/dev/null | head -1)"
-    [ -z "$_v2_bd" ] && continue
-    _v2_sess="$(dirname "$_v2_bd")"
-    echo "[PERSIST V2] found populated breakdown: $_v2_bd ($(stat -c %s "$_v2_bd") bytes)"
-    # Keep both copies: rename V2's version so the agent's contract file
-    # stays at the canonical path.
-    cp "$_v2_bd" "$PERSIST_SCAN_DIR/session_breakdown_v2.json" 2>/dev/null \
-      && echo "[PERSIST V2] copied to $PERSIST_SCAN_DIR/session_breakdown_v2.json"
-    # Also pull manifest.json + state.json + any phase* subdirs if V2
-    # produced them; these only exist when V2 reached its finalize step.
-    for _f in manifest.json state.json optimizer_runs.json; do
-      [ -f "$_v2_sess/$_f" ] && cp "$_v2_sess/$_f" "$PERSIST_SCAN_DIR/$_f" 2>/dev/null \
-        && echo "[PERSIST V2] copied $_f"
-    done
-    # Mirror the full V2 session dir under a sub-folder for forensic depth.
-    mkdir -p "$PERSIST_SCAN_DIR/v2_session"
-    cp -a "$_v2_sess/." "$PERSIST_SCAN_DIR/v2_session/" 2>/dev/null \
-      && echo "[PERSIST V2] mirrored full V2 session dir -> $PERSIST_SCAN_DIR/v2_session/"
-    break
-  done
-  unset _root _v2_bd _v2_sess _f V2_SESSION_ROOTS
-
-  # Verify each Required Artifact appears under PERSIST_SCAN_DIR (find,
-  # because V2 nests session_breakdown.json in <model>/<ts>/). A miss is a
-  # contract violation and routes the run to manual review.
-  if [ -n "${PERSIST_SCAN_DIR:-}" ]; then
-    PERSIST_MISSING=""
-    for f in ci_metrics.json optimization_report.md session_breakdown.json; do
-      hit="$(find "$PERSIST_SCAN_DIR" -name "$f" -type f \! -size 0 2>/dev/null | head -1)"
-      if [ -n "$hit" ]; then
-        echo "[PERSIST] ok: $f -> $hit"
-      else
-        echo "[PERSIST FAIL] missing required artifact: $f (searched $PERSIST_SCAN_DIR)" >&2
-        PERSIST_MISSING="${PERSIST_MISSING} $f"
-      fi
-    done
-    if [ -z "$PERSIST_MISSING" ]; then
-      echo "[PERSIST OK] all three required artifacts present under $PERSIST_SCAN_DIR/"
-    else
-      echo "[PERSIST FAIL] missing required artifact(s):$PERSIST_MISSING" >&2
-      echo "[PERSIST] note: USER_DATA_PATH=${USER_DATA_PATH:-<unset>} RESULT_DIR=$RESULT_DIR — check both for stragglers." >&2
-    fi
-    ls -la "$PERSIST_SCAN_DIR/"
-  fi
-  ls -la "$RESULT_DIR/"
-
-ci_metrics.json values MUST match what the V2 orchestrator measured (phase-1
-baseline / phase 6-8 best) — do NOT recompute gain_pct from a partial-run
-eager-mode baseline.
+Artifacts are written automatically by the optimizer — you do NOT need to
+hand-write them. `inference_optimizer/cli.py`'s finally block always
+materializes the session_breakdown.json (the CI delivery contract that the
+dashboard and CI both read) plus reports/final.md under the session dir, even
+when the run aborts. ci_metrics.json values, when present, MUST match what the
+V2 orchestrator measured (phase-1 baseline / phase 6-8 best) — never recompute
+gain_pct from a partial-run eager-mode baseline. Do not bail early on a 12h run.
 
 SAFETY:
 - NEVER `find /` or `find /wekafs` without `-maxdepth 4`. Prefer which/ls/$PATH lookups.

--- a/ci/prompt_prefix.txt
+++ b/ci/prompt_prefix.txt
@@ -77,25 +77,4 @@ PY
 Then run the skill at $HYPERLOOM_SOURCE_DIR/inference_optimizer/SKILL.md from
 that directory (cd "$HYPERLOOM_SOURCE_DIR").
 
-Environment (export before launching `inference_optimizer optimize`):
-  export NFS_ROOT=/wekafs
   export CORTEX_KB_URL=https://global.primus-safe.amd.com/knowledge-base
-  export KERNEL_OPT_BACKEND_ORDER="${KERNEL_OPT_BACKEND_ORDER:-geak,claude,codex}"
-  export HYPERLOOM_GEAK_BUDGET_MIN="${HYPERLOOM_GEAK_BUDGET_MIN:-130}"
-  export HYPERLOOM_KERNEL_OPT_GATE_TOP_N="${HYPERLOOM_KERNEL_OPT_GATE_TOP_N:-5}"
-Pass `--max-hours 12` to `inference_optimizer optimize` (do not use the cli
-default). Kernel backend ladder is GEAK first, then Claude, then Codex; do NOT
-request a Claude-only backend unless explicitly told to.
-
-Artifacts are written automatically by the optimizer — you do NOT need to
-hand-write them. `inference_optimizer/cli.py`'s finally block always
-materializes the session_breakdown.json (the CI delivery contract that the
-dashboard and CI both read) plus reports/final.md under the session dir, even
-when the run aborts. ci_metrics.json values, when present, MUST match what the
-V2 orchestrator measured (phase-1 baseline / phase 6-8 best) — never recompute
-gain_pct from a partial-run eager-mode baseline. Do not bail early on a 12h run.
-
-SAFETY:
-- NEVER `find /` or `find /wekafs` without `-maxdepth 4`. Prefer which/ls/$PATH lookups.
-- NEVER run `kill -9 $(ps aux | grep ...)` — this kills the sandbox executor itself.
-- Per-bash timeouts must be <= 120s; use short polling loops rather than one long blocking call.


### PR DESCRIPTION
## Summary
The optimizer now auto-writes the key artifacts, so the CI prompt prefix no longer needs to instruct the sandbox agent to hand-write them.

- **`ci/prompt_prefix.txt` trimmed 224 -> 95 lines.** Kept: the fresh-source-checkout bootstrap (clone + `RESULT_DIR` alignment + `hyperloom_source_commit.txt` / `source_commits.json`), the env exports, a short artifacts note, and the SAFETY guardrails. Removed: the 3-file "Required Artifacts" hand-write contract, the vLLM forbidden-flags list, the verbose Result-Directory explanation, and the whole POST-PIPELINE PERSIST mirror block.
- **`ci/optimize_submit.py` delivery now keys on `session_breakdown.json`.** Both the Stage-1 artifact-API retry and the Stage-2 NFS fallback trigger previously required `ci_metrics.json` AND `optimization_report.md`; they now gate on `session_breakdown.json`, which `cli.finally` (`write_breakdown_json`) always materializes — even on abort. `_mark_record_delivery` already keyed success on `session_breakdown.json`, so this aligns the collection path with the delivery contract.

## Why this is safe
- `session_breakdown.json` + `reports/final.md` are written by `inference_optimizer/cli.py`'s finally block unconditionally; `ci_metrics.json` / `optimization_report.md` were only ever produced by the agent following the prompt (zero writers in `inference_optimizer/**/*.py`).
- In production `USER_DATA_PATH` is wekafs-backed, so the optimizer writes `session_breakdown.json` straight onto the persistent session dir; CI's recursive NFS scan (`_nfs_fallback_collect`) finds it without the PERSIST mirror.
- `_KEY_RESULT_SUFFIXES` still lists all three, so `ci_metrics.json` / `optimization_report.md` are still collected opportunistically when present — they just no longer gate the fallback.

## Risk / follow-up
- `ci_metrics.json` will normally no longer be produced, so `build_summary.py` loses it as a throughput backfill source; `session_breakdown.json` is the preferred source and remains.
- Ephemeral-`RESULT_DIR` runs (non-wekafs `USER_DATA_PATH`) lose the explicit wekafs mirror. Production is wekafs-backed so this is not expected to fire, but worth noting.

## Test plan
- [ ] Dispatch one model and confirm `session_breakdown.json` is collected (Stage 1 or NFS Stage 2) and `ci_status=Delivered`.
- [ ] Confirm the sandbox still clones a fresh checkout and writes `source_commits.json`.
- [ ] Confirm a run that produces no `ci_metrics.json` is no longer marked failed.
