### PR TITLE
fix(close): persist stop_reason before session_breakdown write

### DIFF
--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -3768,6 +3768,27 @@ class Coordinator:
                  from_phase or "<unknown>")
         await self._record_close_step("sequencer_started", status="running")
 
+        # stop_reason MUST be persisted BEFORE step 2 writes the
+        # session_breakdown. The breakdown executor runs as a subprocess
+        # that reads state.json from disk, and the collector derives both
+        # ``stop_reason`` and ``ended_at_utc`` from it. The old code only
+        # set stop_reason in step 5 (below), AFTER the breakdown was
+        # already serialized — so any CLOSE reached via a non-wall-clock
+        # path (e.g. an LLM ``report`` terminal transition, where the loop
+        # had not yet stamped a reason) shipped an empty stop_reason /
+        # ended_at_utc downstream. Filling it here (only when still blank;
+        # real reasons like baseline_failed / target_reached are already
+        # set before CLOSE) closes that race. Step 5 stays as an
+        # idempotent backstop.
+        if not self.shared_state.stop_reason:
+            self.shared_state.set_stop_reason("time_exhausted")
+            try:
+                self.shared_state.save(self.session_dir)
+            except Exception:  # noqa: BLE001 — defensive
+                log.exception(
+                    "CLOSE: early stop_reason persist failed; step 5 will retry"
+                )
+
         # CLOSE-entry auto-roofline (former N31) was deleted in favour
         # of the EXPLORE-entry / KERNEL-entry hooks; the gain-only
         # freshness gate (:meth:`_needs_fresh_roofline`) keeps the
@@ -3862,7 +3883,10 @@ class Coordinator:
         # The wall-clock deadline path (``_enter_closing_phase``) sets
         # ``time_exhausted`` from the loop body (line ~1971); both
         # paths converge on the same vocab term per
-        # ``STOP_REASON_VOCAB``.
+        # ``STOP_REASON_VOCAB``. NOTE: this is now an idempotent
+        # backstop — the early persist at the top of the sequencer has
+        # normally already filled a blank stop_reason before step 2's
+        # breakdown was serialized.
         if not self.shared_state.stop_reason:
             self.shared_state.set_stop_reason("time_exhausted")
         try:

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -3723,6 +3723,35 @@ class Coordinator:
     CLOSE_SESSION_BREAKDOWN_TIMEOUT_SEC: float = 300.0
     CLOSE_NDJSON_DRAIN_TIMEOUT_SEC: float = 60.0
 
+    def _derive_close_stop_reason(self) -> str:
+        """Best-effort ``stop_reason`` for a CLOSE reached with a blank one.
+
+        Most CLOSE entries are *not* wall-clock timeouts. The phase
+        machine records the transition reason on the latest
+        ``phase_history`` row (e.g. ``sweep_done`` / ``conc_sweep_done``
+        for a normal SWEEP completion), but those are non-terminal
+        transitions so ``_advance_phase_if_needed`` never mirrored them
+        onto ``state.stop_reason``. Recover the reason from the most
+        recent row that lands in CLOSE when it is a valid vocab term;
+        otherwise fall back to ``time_exhausted`` (the wall-clock
+        deadline is the only common path that reaches CLOSE without a
+        recorded phase-exit reason).
+        """
+        history = self.shared_state.phase_history or []
+        for row in reversed(history):
+            if not isinstance(row, dict):
+                continue
+            if (row.get("to_phase") or "").strip().upper() != \
+                    _phase_state.PHASE_CLOSE:
+                continue
+            reason = (row.get("reason") or "").strip()
+            if reason and _phase_state.is_valid_stop_reason(reason):
+                return reason
+            # Newest CLOSE-bound row had no usable reason — stop scanning
+            # rather than picking up a stale older transition.
+            break
+        return "time_exhausted"
+
     async def _on_enter_close(self, *, from_phase: str) -> None:
         """CLOSE phase sequencer.
 
@@ -3780,8 +3809,20 @@ class Coordinator:
         # real reasons like baseline_failed / target_reached are already
         # set before CLOSE) closes that race. Step 5 stays as an
         # idempotent backstop.
+        #
+        # DO NOT unconditionally stamp ``time_exhausted``: most CLOSE
+        # entries are NOT wall-clock timeouts. A normal SWEEP / conc-sweep
+        # completion transitions to CLOSE with a perfectly good
+        # phase-exit reason (``sweep_done`` / ``conc_sweep_done`` — both
+        # valid STOP_REASON_VOCAB terms) recorded on the latest
+        # ``phase_history`` row by ``_advance_phase_if_needed``, but it is
+        # NOT a terminal evidence transition, so the early mirror at line
+        # ~1407 left ``stop_reason`` blank. Derive the reason from that
+        # row first; only fall back to ``time_exhausted`` when the run
+        # genuinely has no usable phase-exit reason.
         if not self.shared_state.stop_reason:
-            self.shared_state.set_stop_reason("time_exhausted")
+            derived = self._derive_close_stop_reason()
+            self.shared_state.set_stop_reason(derived)
             try:
                 self.shared_state.save(self.session_dir)
             except Exception:  # noqa: BLE001 — defensive
@@ -3886,9 +3927,11 @@ class Coordinator:
         # ``STOP_REASON_VOCAB``. NOTE: this is now an idempotent
         # backstop — the early persist at the top of the sequencer has
         # normally already filled a blank stop_reason before step 2's
-        # breakdown was serialized.
+        # breakdown was serialized. We re-derive (rather than hard-code
+        # ``time_exhausted``) so this backstop matches the early path and
+        # never mislabels a normal SWEEP/conc-sweep completion.
         if not self.shared_state.stop_reason:
-            self.shared_state.set_stop_reason("time_exhausted")
+            self.shared_state.set_stop_reason(self._derive_close_stop_reason())
         try:
             self.shared_state.save(self.session_dir)
         except Exception:  # noqa: BLE001

--- a/inference_optimizer/tests/test_close_phase_sequencer.py
+++ b/inference_optimizer/tests/test_close_phase_sequencer.py
@@ -384,24 +384,46 @@ async def test_close_sequencer_runs_all_steps_in_order_happy_path(
     assert rows[5]["status"] == "done"     # done
     # close_sequence_done flag set.
     assert coord.shared_state.close_sequence_done is True
-    # v0.8 §3.2 §5.5 — sequencer last step must set stop_reason so
-    # the main loop terminates on the next tick.
-    assert coord.shared_state.stop_reason == "time_exhausted"
+    # v0.8 §3.2 §5.5 — sequencer must set stop_reason so the main loop
+    # terminates on the next tick. A normal SWEEP completion carries a
+    # ``sweep_done`` phase-exit reason, which must be preserved (NOT
+    # mislabelled ``time_exhausted``).
+    assert coord.shared_state.stop_reason == "sweep_done"
 
 
 @pytest.mark.asyncio
-async def test_close_sequencer_sets_time_exhausted_stop_reason(coord):
-    """Step 5 stamps ``stop_reason='time_exhausted'`` when no other
-    step set it first. ``time_exhausted`` is the canonical CLOSE
-    vocab term in :data:`STOP_REASON_VOCAB` and matches the
-    wall-clock-deadline path's terminator (Coordinator.run).
+async def test_close_sequencer_falls_back_to_time_exhausted(coord):
+    """The sequencer falls back to ``stop_reason='time_exhausted'`` only
+    when the run reached CLOSE with no usable phase-exit reason (the
+    wall-clock-deadline path is the common case). ``time_exhausted`` is
+    the canonical fallback vocab term in :data:`STOP_REASON_VOCAB`.
     """
-    coord.shared_state.phase_history = [_close_phase_history_row()]
+    # CLOSE-bound row with no recorded reason → genuine fallback.
+    coord.shared_state.phase_history = [
+        {"to_phase": "CLOSE", "reason": "", "evidence": {}},
+    ]
     assert coord.shared_state.stop_reason == ""
 
     await coord._on_enter_close(from_phase="SWEEP")
 
     assert coord.shared_state.stop_reason == "time_exhausted"
+
+
+@pytest.mark.asyncio
+async def test_close_sequencer_derives_sweep_done_from_phase_history(coord):
+    """A normal SWEEP → CLOSE transition records ``reason='sweep_done'``
+    (a valid STOP_REASON_VOCAB term) on the latest phase_history row.
+    The sequencer must derive that reason rather than blanket-stamping
+    ``time_exhausted`` — otherwise a clean run is mislabelled a timeout
+    in session_breakdown.json / downstream dashboards (P1 regression)."""
+    coord.shared_state.phase_history = [
+        {"to_phase": "CLOSE", "reason": "conc_sweep_done", "evidence": {}},
+    ]
+    assert coord.shared_state.stop_reason == ""
+
+    await coord._on_enter_close(from_phase="SWEEP")
+
+    assert coord.shared_state.stop_reason == "conc_sweep_done"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Persist `stop_reason` before the CLOSE sequencer writes `session_breakdown.json`.

## Problem
The CLOSE sequencer set `stop_reason` only in **step 5**, AFTER **step 2** had already serialized `session_breakdown.json`. The breakdown executor runs as a subprocess that reads `state.json` from disk, and the collector derives both `stop_reason` and `ended_at_utc` from it:

```python
"ended_at_utc": _utc_now_iso() if stop_reason else "",
"stop_reason":  stop_reason,
```

So any CLOSE reached via a **non-wall-clock path** (e.g. an LLM `report` terminal transition, where the loop had not yet stamped a reason) shipped an empty `stop_reason` / `ended_at_utc` downstream (sbd passthrough was empty). The wall-clock timeout path happened to set the reason before CLOSE, which is why it was "sometimes written, sometimes not".

## Fix
Persist a blank `stop_reason` (`time_exhausted`) right after `sequencer_started`, **before step 2**. The guard only fills when still blank, so real reasons (`baseline_failed` / `target_reached` / `signal`) are preserved. Step 5 remains an idempotent backstop.

## Test plan
- [ ] `pytest inference_optimizer/tests/test_close_phase_sequencer.py -q` (Linux; local Windows lacks `fcntl`)
- [ ] Verify a phase-machine-terminated run now emits non-empty `stop_reason` / `ended_at_utc` in `session_breakdown.json`
