### PR TITLE
Run stability: USER_DATA_PATH write-guard, install flock, sglang watchdog, launch-info session discovery

### DIFF
--- a/ci/inferenceX_parser.py
+++ b/ci/inferenceX_parser.py
@@ -361,7 +361,7 @@ def merge_model_config(
         "inferencex_path": defaults.get("inferencex_path") or (get_nfs_root() + "/InferenceX"),
         "oob_path": defaults.get("oob_path") or (get_nfs_root() + "/OOB"),
         "tracelens_root": defaults.get("tracelens_root") or (get_nfs_root() + "/TraceLens-internal"),
-        "result_dir": defaults.get("result_dir", "/workspace/hyperloom"),
+        "result_dir": defaults.get("result_dir") or os.environ.get("USER_DATA_PATH") or "/workspace/hyperloom",
         "inferenceX_benchmarks": ifx_benchmarks,
         "inferenceX_api_name": model_cfg.get("inferenceX_api_name", ""),
         "inferenceX_key": model_cfg.get("inferenceX_key", ""),

--- a/ci/publish_artifacts.py
+++ b/ci/publish_artifacts.py
@@ -62,7 +62,7 @@ def _host_reachable(url: str) -> tuple[bool, str]:
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--task-dir", default=os.environ.get("HYPERLOOM_RESULT_DIR", "/workspace/hyperloom"))
+    parser.add_argument("--task-dir", default=os.environ.get("HYPERLOOM_RESULT_DIR") or os.environ.get("USER_DATA_PATH") or "/workspace/hyperloom")
     parser.add_argument("--out-dir", default="")
     parser.add_argument("--model", default="")
     parser.add_argument("--display-name", default="")

--- a/inference_optimizer/SKILL.md
+++ b/inference_optimizer/SKILL.md
@@ -104,10 +104,14 @@ the mirrors by hand.
 **Session rule:** never treat ``$USER_DATA_PATH`` as the session dir when
 ``$INFERENCE_OPTIMIZER_CURRENT_SESSION_DIR`` is set. Read
 ``manifest.json`` / ``state.json`` / ``coordinator.db`` from the
-**session dir**. For monitoring after launch, parse the CLI's
-``Session dir : …`` line first; if it is unavailable, walk
-``$USER_DATA_PATH/<model_basename>/`` for the latest ``*T*Z/`` timestamp
-dir.
+**session dir**. For monitoring after launch, learn the session dir from
+the **launch-info JSON** written by ``--launch-info-file`` (``jq -r
+.session_dir <file>``) or, equivalently, from the single
+``HYPERLOOM_LAUNCH key=value …`` sentinel line the CLI prints to stdout
+(``session_dir=…``). Those are the authoritative, machine-readable
+sources. Never guess by walking ``$USER_DATA_PATH/<model_basename>/`` for
+the latest ``*T*Z/`` timestamp dir — overlapping sessions on the same
+host make "latest" pick the wrong run.
 
 Inputs that stay outside `$USER_DATA_PATH` by design (read-only sources
 or warm-start caches): **TraceLens** — `$TRACELENS_ROOT` (default
@@ -779,8 +783,10 @@ if [ -f "$REPO_ROOT/.env" ]; then set -a; . "$REPO_ROOT/.env"; set +a; fi
 . "${KERNEL_AGENT_ENV:-${USER_DATA_PATH:-/workspace/hyperloom}/runtime/kernel-agent.env.sh}"
 export PATH="$(dirname "$PYTHON"):/usr/local/bin:$PATH"
 export RUN_TAG="$(basename "$MODEL_PATH")-$(date +%Y%m%d_%H%M%S)"
-# RUN_LOG/PID under workspace until session_dir is known; move or re-tail
-# from $session_dir/optimizer_runs/ after parsing "Session dir" from stdout.
+# RUN_LOG/PID/launch-info live under the workspace until the session_dir
+# is known; move or re-tail from $session_dir/optimizer_runs/ after reading
+# session_dir from the launch-info JSON below.
+# /workspace/hyperloom is only the fallback when $USER_DATA_PATH is unset.
 export RUN_DIR="${USER_DATA_PATH:-/workspace/hyperloom}/optimizer_runs"
 export RUN_LOG="$RUN_DIR/run_${RUN_TAG}.log"
 export PID_FILE="$RUN_DIR/run_${RUN_TAG}.pid"
@@ -793,6 +799,7 @@ setsid nohup inference_optimizer --verbose optimize \
   --max-hours "${MAX_HOURS:-5}" \
   --tick-interval-sec 30 \
   --kernel-claude \
+  --launch-info-file "$RUN_DIR/launch_${RUN_TAG}.json" \
   > "$RUN_LOG" 2>&1 < /dev/null &
 echo $! > "$PID_FILE"
 ```
@@ -812,11 +819,16 @@ After launching, do a short health check:
 sleep 30
 pid="$(cat "$PID_FILE")"
 test -d "/proc/$pid" && echo "optimizer_alive=true pid=$pid"
-# Parse session dir from RUN_LOG or resolve latest timestamp subdir:
-session_dir="$(grep -m1 '^Session dir' "$RUN_LOG" 2>/dev/null | sed 's/^Session dir[[:space:]]*:[[:space:]]*//')"
+# Authoritative session dir from the launch-info JSON (--launch-info-file).
+# Never guess by timestamp: overlapping sessions break any "latest dir" pick.
+launch_info="$RUN_DIR/launch_${RUN_TAG}.json"
+session_dir="$(jq -r '.session_dir // empty' "$launch_info" 2>/dev/null)"
 if [ -z "$session_dir" ]; then
-  model_base="$(basename "$MODEL_PATH")"
-  session_dir="$(ls -d "${USER_DATA_PATH:-/workspace/hyperloom}/$model_base/"*T*Z 2>/dev/null | sort | tail -1)"
+  echo "ERROR: no .session_dir in $launch_info (launch-info JSON missing or" \
+       "malformed). The optimizer likely died before emitting launch info;" \
+       "inspect the HYPERLOOM_LAUNCH line and errors in $RUN_LOG." \
+       "Refusing to guess the session dir from timestamps." >&2
+  return 1 2>/dev/null || exit 1
 fi
 test -f "$session_dir/manifest.json" && echo "manifest_present=true session_dir=$session_dir"
 test -f "$session_dir/state.json" && echo "state_exists=true" \
@@ -851,6 +863,10 @@ without those markers (unexpected crash).
 ```bash
 export RUN_DIR="${USER_DATA_PATH:-/workspace/hyperloom}/optimizer_runs"
 mkdir -p "$RUN_DIR"
+# Point the monitor at the authoritative session dir: it reads
+# $INFERENCE_OPTIMIZER_SESSION_DIR first, else .session_dir from the
+# launch-info JSON in $LAUNCH_INFO_FILE (written by --launch-info-file).
+export LAUNCH_INFO_FILE="$RUN_DIR/launch_${RUN_TAG}.json"
 cp "$REPO_ROOT/optimizer_runs/robustness_monitor.sh.example" \
    "$RUN_DIR/robustness_monitor.sh"
 chmod +x "$RUN_DIR/robustness_monitor.sh"
@@ -859,9 +875,12 @@ setsid nohup bash "$RUN_DIR/robustness_monitor.sh" \
   2>&1 < /dev/null &
 ```
 
-Reads `$PID_FILE` and (optional) `$USER_DATA_PATH` / `$MAX_HOURS` /
-`$TARGET_GAIN`. Edit the example before copying if defaults need to
-change. `stop_reason` interpretation matches the `## Monitoring` reader.
+Reads `$PID_FILE` plus (optional) `$INFERENCE_OPTIMIZER_SESSION_DIR` /
+`$LAUNCH_INFO_FILE` / `$MAX_HOURS` / `$TARGET_GAIN`. The session dir comes
+from `$INFERENCE_OPTIMIZER_SESSION_DIR` when set, else from `.session_dir`
+in the launch-info JSON at `$LAUNCH_INFO_FILE` (never from a timestamp
+guess). Edit the example before copying if defaults need to change.
+`stop_reason` interpretation matches the `## Monitoring` reader.
 
 ## Monitoring
 

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -1041,6 +1041,15 @@ _MAXPOS_CONFIG_KEYS = (
 _CONTEXT_HEADROOM_ENV = "HYPERLOOM_CONTEXT_HEADROOM_TOKENS"
 _CONTEXT_HEADROOM_DEFAULT = 512
 
+# Extra context budget (tokens) layered on top of ISL+OSL when sizing the
+# server-facing ``MAX_MODEL_LEN`` (KV-cache ceiling). Larger than the preflight
+# headroom because it also absorbs decode-side slack, but ALWAYS clamped to the
+# model's native window by :func:`_resolve_max_model_len` so it can never stretch
+# the context. sglang ignores MAX_MODEL_LEN (its ``context_length`` stays None),
+# but the vllm benchmark wires it into ``--max-model-len``, so an unclamped value
+# above the native window would crash that server.
+_MAX_MODEL_LEN_HEADROOM = 4096
+
 
 def _load_model_max_position_embeddings(model_path: str) -> int | None:
     """Best-effort read of the model's max sequence length from config.json.
@@ -1083,6 +1092,29 @@ def _context_headroom_tokens() -> int:
     except ValueError:
         return _CONTEXT_HEADROOM_DEFAULT
     return val if val >= 0 else _CONTEXT_HEADROOM_DEFAULT
+
+
+def _resolve_max_model_len(isl: int, osl: int, model_path: str) -> int:
+    """Resolve ``MAX_MODEL_LEN`` = ISL+OSL+headroom, clamped to the native window.
+
+    Never returns a value above the model's ``max_position_embeddings``: by
+    policy we do not stretch the context (RoPE extrapolation / learned-absolute
+    position breakage), and the vllm benchmark wires this value straight into
+    ``--max-model-len`` — an unclamped ISL+OSL+4096 above a small native window
+    would crash the server. The clamp keeps it aligned with the preflight gate
+    (which already guarantees ``maxpos >= ISL+OSL+headroom``), so the resolved
+    value always lands in ``[ISL+OSL, max_position_embeddings]``. When the native
+    window is unknown the headroom default stands (prior behaviour).
+
+    sglang ignores ``MAX_MODEL_LEN`` (its ``context_length`` stays None), but the
+    value is still mirrored into the benchmark YAML, so it must not advertise a
+    length above the model's real window there either.
+    """
+    desired = int(isl) + int(osl) + _MAX_MODEL_LEN_HEADROOM
+    maxpos = _load_model_max_position_embeddings(model_path)
+    if maxpos:
+        return min(desired, maxpos)
+    return desired
 
 
 def _preflight_context_window(args: argparse.Namespace, session_dir: Path) -> bool:
@@ -1145,6 +1177,19 @@ def _preflight_context_window(args: argparse.Namespace, session_dir: Path) -> bo
     except Exception as exc:  # noqa: BLE001 — don't mask the reason on a writer bug
         print(
             f"WARNING: failed to persist context-window stop report: {exc!r}",
+            file=sys.stderr,
+        )
+    # Delivery-artifact parity: cli's normal exit writes session_breakdown.json
+    # in coordinator.run()'s finally, but this fail-fast sys.exit(2)s before that
+    # try/finally is ever entered. Emit it here too (best-effort) so CI's
+    # delivery contract sees a clean, documented skip — not "Missing artifacts".
+    try:
+        from .breakdown import write_breakdown_json
+        write_breakdown_json(session_dir)
+    except Exception as exc:  # noqa: BLE001 — best-effort; never mask the reason
+        print(
+            f"WARNING: failed to write session_breakdown.json on context "
+            f"fail-fast: {exc!r}",
             file=sys.stderr,
         )
     print(f"ERROR: {reason}", file=sys.stderr)
@@ -4708,8 +4753,13 @@ async def _run_optimize(args: argparse.Namespace) -> int:
             args.gpu_type = None
             print("GPU type        : <unset> (Magpie will auto-detect)")
 
-        # Compute MAX_MODEL_LEN = ISL + OSL + 4096 headroom, export for yaml injection.
-        max_model_len = args.isl + args.osl + 4096
+        # MAX_MODEL_LEN = ISL + OSL + headroom, clamped to the model's native
+        # window (no context stretch); see _resolve_max_model_len. Exported for
+        # YAML injection — vllm wires it into --max-model-len; sglang ignores it
+        # (context_length stays None) but still mirrors it into the config.
+        max_model_len = _resolve_max_model_len(
+            args.isl, args.osl, str(args.model or ""),
+        )
         os.environ["MAX_MODEL_LEN"] = str(max_model_len)
         os.environ["ISL"] = str(args.isl)
         os.environ["OSL"] = str(args.osl)

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -2319,7 +2319,7 @@ def _check_tracelens_cli() -> None:
     ]
     if not missing:
         return
-    session_dir = os.environ.get("USER_DATA_PATH", "/workspace/hyperloom")
+    session_dir = str(_workspace_root_resolve())
     print(
         f"ERROR: TraceLens CLI(s) not on PATH: {missing}. The pod-local "
         f"/opt/venv/bin/TraceLens_* console_scripts are installed by "
@@ -2988,7 +2988,7 @@ def _run_ir3_preflight(args: argparse.Namespace) -> None:
         args.pr_degraded_reason = "explicit_flag"
         return
 
-    user_data = Path(os.environ.get("USER_DATA_PATH", "/workspace/hyperloom"))
+    user_data = _workspace_root_resolve()
     marker_path = user_data / "runtime" / "cortex" / ".kb_preflight.json"
     script = (
         Path(__file__).resolve().parent / "scripts" / "preflight_kb.sh"
@@ -3284,11 +3284,13 @@ def _resolve_local_kb_root(args: argparse.Namespace) -> Path:
     1. ``--local-kb-root <path>`` — explicit operator override
        (typically only used by tests).
     2. ``$HYPERLOOM_LOCAL_KB_ROOT`` — env override.
-    3. ``$USER_DATA_PATH/kb`` — the documented default. A single
-       ``USER_DATA_PATH`` override moves the whole KB tail.
-    4. ``/workspace/hyperloom/kb`` — container fallback when
-       ``$USER_DATA_PATH`` isn't set (degraded sandbox / fresh-image
-       boot).
+    3. ``paths.workspace_root() / "kb"`` — the documented default.
+       :func:`~inference_optimizer.paths.workspace_root` returns
+       ``$USER_DATA_PATH`` when set (so a single ``USER_DATA_PATH``
+       override moves the whole KB tail) and otherwise falls back to
+       ``/workspace/hyperloom`` while emitting a one-shot loud warning,
+       so a degraded sandbox / fresh-image boot lands at
+       ``/workspace/hyperloom/kb`` but never silently.
 
     The directory is NOT created here — :class:`LocalRecipeStore`
     handles lazy creation on first write so a degraded run that
@@ -3300,10 +3302,7 @@ def _resolve_local_kb_root(args: argparse.Namespace) -> Path:
     )
     if explicit:
         return Path(str(explicit).strip())
-    user_data = os.environ.get("USER_DATA_PATH", "").strip()
-    if user_data:
-        return Path(user_data) / "kb"
-    return Path("/workspace/hyperloom") / "kb"
+    return _workspace_root_resolve() / "kb"
 
 
 def _build_recipe_kb_dispatcher(

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -1023,6 +1023,134 @@ def _load_model_config_tags(model_path: str) -> dict:
     return out
 
 
+# config.json keys that carry the model's max sequence length, priority order.
+# Most modern decoders use max_position_embeddings; a few legacy/alt configs
+# use these aliases.
+_MAXPOS_CONFIG_KEYS = (
+    "max_position_embeddings",
+    "n_positions",
+    "max_sequence_length",
+    "seq_length",
+    "max_seq_len",
+)
+
+# Safety headroom (tokens) the model context window must have ABOVE the nominal
+# ISL+OSL workload: covers the BOS token, chat-template tokens, and random-
+# dataset length jitter (a nominal 2048 workload has been observed to emit
+# requests up to ~2568). Operator-tunable via env.
+_CONTEXT_HEADROOM_ENV = "HYPERLOOM_CONTEXT_HEADROOM_TOKENS"
+_CONTEXT_HEADROOM_DEFAULT = 512
+
+
+def _load_model_max_position_embeddings(model_path: str) -> int | None:
+    """Best-effort read of the model's max sequence length from config.json.
+
+    Returns the first positive integer among the known max-length keys (also
+    checking a nested ``text_config`` for multimodal configs), or None when
+    config.json is missing/unreadable/has none of them — callers then skip the
+    context preflight rather than guessing.
+    """
+    if not model_path:
+        return None
+    cfg_path = Path(model_path) / "config.json"
+    try:
+        data = json.loads(cfg_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    candidates = [data]
+    nested = data.get("text_config")
+    if isinstance(nested, dict):
+        candidates.append(nested)
+    for cfg in candidates:
+        for key in _MAXPOS_CONFIG_KEYS:
+            val = cfg.get(key)
+            if isinstance(val, bool):
+                continue
+            if isinstance(val, int) and val > 0:
+                return val
+    return None
+
+
+def _context_headroom_tokens() -> int:
+    """Resolve the context headroom (tokens); env override, else default."""
+    raw = os.environ.get(_CONTEXT_HEADROOM_ENV, "").strip()
+    if not raw:
+        return _CONTEXT_HEADROOM_DEFAULT
+    try:
+        val = int(raw)
+    except ValueError:
+        return _CONTEXT_HEADROOM_DEFAULT
+    return val if val >= 0 else _CONTEXT_HEADROOM_DEFAULT
+
+
+def _preflight_context_window(args: argparse.Namespace, session_dir: Path) -> bool:
+    """Fail fast when the model context window cannot hold ISL+OSL+headroom.
+
+    We deliberately do NOT pass ``--context-length`` to stretch a small window:
+    that forces RoPE extrapolation (quality loss) and can CUDA-error on models
+    with learned absolute position embeddings. Instead, when
+    ``max_position_embeddings < ISL + OSL + headroom`` we persist a clear stop
+    reason (state.json + reports/final.{json,md}) and signal the caller to exit
+    non-zero — far better than booting a server that 400s every request and
+    dies on the scheduler watchdog (the observed baseline_failed mode for
+    stale 2048-ctx checkpoints).
+
+    Returns True when the workload does NOT fit (caller should exit); False
+    when it fits or the model's max length is unknown (gate skipped).
+    """
+    isl = int(getattr(args, "isl", 0) or 0)
+    osl = int(getattr(args, "osl", 0) or 0)
+    if isl <= 0 or osl <= 0:
+        return False
+    maxpos = _load_model_max_position_embeddings(str(getattr(args, "model", "") or ""))
+    if not maxpos:
+        return False
+    headroom = _context_headroom_tokens()
+    required = isl + osl + headroom
+    if maxpos >= required:
+        return False
+
+    reason = (
+        f"model max_position_embeddings={maxpos} < required {required} "
+        f"(ISL={isl} + OSL={osl} + headroom={headroom}). The workload exceeds "
+        f"the model context window; every request would 400. Refusing to run "
+        f"(no --context-length override by policy). Lower ISL/OSL for this "
+        f"model, or raise {_CONTEXT_HEADROOM_ENV} if the headroom is too "
+        f"conservative."
+    )
+    # Persist the stop reason so CI / the robustness monitor read it from
+    # state.json + reports/final.json instead of grepping the run log.
+    try:
+        from .orchestrator.shared_state import SharedState
+        from .orchestrator.action_executors.report import (
+            _build_summary_dict,
+            _format_md,
+        )
+        from .session_paths import reports_dir
+
+        state = SharedState.load_or_init(session_dir)
+        state.stop_reason = "model_context_window_too_small"
+        state.closing_phase = True
+        state.save(session_dir)
+        summary = _build_summary_dict(state, {}, [], external_baseline=None)
+        summary["stop_detail"] = reason
+        rdir = reports_dir(session_dir)
+        rdir.mkdir(parents=True, exist_ok=True)
+        (rdir / "final.json").write_text(
+            json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8",
+        )
+        (rdir / "final.md").write_text(_format_md(summary), encoding="utf-8")
+    except Exception as exc:  # noqa: BLE001 — don't mask the reason on a writer bug
+        print(
+            f"WARNING: failed to persist context-window stop report: {exc!r}",
+            file=sys.stderr,
+        )
+    print(f"ERROR: {reason}", file=sys.stderr)
+    return True
+
+
 def _seed_shared_state(
     session_dir: Path,
     args: argparse.Namespace,
@@ -4603,6 +4731,15 @@ async def _run_optimize(args: argparse.Namespace) -> int:
         _seed_shared_state(
             session_dir, args, session_id=manifest["session_id"],
         )
+        # Context-window preflight: refuse to run (with a persisted stop
+        # reason) when ISL+OSL+headroom exceeds the model's
+        # max_position_embeddings, instead of booting a server that 400s every
+        # request and dies on the scheduler watchdog. No --context-length
+        # stretch by policy. Runs after the SharedState seed (so the stop
+        # reason lands in state.json/final.*) but before the heavy Cortex /
+        # backend / Coordinator bring-up.
+        if _preflight_context_window(args, session_dir):
+            sys.exit(2)
         # Cortex KB T0 anchor. Must run after the SharedState
         # seed (so model_name / gpu_type / framework are populated for
         # recipe_canonical_id derivation) but before Coordinator is

--- a/inference_optimizer/manifest.py
+++ b/inference_optimizer/manifest.py
@@ -216,26 +216,45 @@ def _path_is_relative_to(path: Path, root: Path) -> bool:
         return False
 
 
-def _warn_if_dependency_escapes_user_data(env_var: str, raw: str) -> None:
-    """Warn when a dependency checkout path escapes an explicit USER_DATA_PATH.
+# Pod-local, non-persistent roots. A dependency checkout under one of these
+# (e.g. the ``/workspace/hyperloom_runtime_*`` override seen in the wild) is
+# erased on pod recycle and is the real "artefacts disappeared" failure mode.
+# A persistent shared checkout outside USER_DATA_PATH (e.g. a WekaFS InferenceX
+# or TraceLens mirror under /wekafs or /hyperloom) is legitimate by design and
+# must NOT warn.
+_POD_LOCAL_PREFIXES = ("/workspace", "/tmp", "/root")
 
-    Operators expect Magpie / InferenceX runtime checkouts to live under the
-    same workspace root as session data.  The env vars are still honoured for
-    advanced/debug flows, but an out-of-tree override should be loud in the
-    manifest logs because it is otherwise very hard to explain why artefacts
-    appeared under /workspace instead of the configured data root.
+
+def _warn_if_dependency_escapes_user_data(env_var: str, raw: str) -> None:
+    """Warn when a dependency checkout escapes USER_DATA_PATH into a
+    pod-local, non-persistent location.
+
+    Operators expect the Magpie / InferenceX runtime checkouts that
+    install.sh creates to live under USER_DATA_PATH. An override that
+    points them at a pod-local path (``/workspace/...``, ``/tmp/...``) is
+    erased on pod recycle — that is the failure mode worth a loud manifest
+    warning. A persistent shared checkout outside USER_DATA_PATH (a WekaFS
+    InferenceX / TraceLens mirror) is legitimate and does NOT warn.
     """
     user_data = (os.environ.get(_paths.ENV_USER_DATA_PATH) or "").strip()
     if not user_data:
         return
     dep_path = Path(raw)
-    root = Path(user_data)
-    if not _path_is_relative_to(dep_path, root):
-        log.warning(
-            "%s=%s is outside %s=%s; this run may read/write runtime "
-            "artefacts outside the configured Hyperloom workspace root.",
-            env_var, raw, _paths.ENV_USER_DATA_PATH, user_data,
-        )
+    if _path_is_relative_to(dep_path, Path(user_data)):
+        return
+    resolved = str(dep_path.resolve(strict=False))
+    is_pod_local = any(
+        resolved == p or resolved.startswith(p + "/")
+        for p in _POD_LOCAL_PREFIXES
+    )
+    if not is_pod_local:
+        return
+    log.warning(
+        "%s=%s is a pod-local path outside %s=%s; runtime artefacts there are "
+        "erased on pod recycle. install.sh writes dependencies under "
+        "%s/runtime by default — point %s back there to persist them.",
+        env_var, raw, _paths.ENV_USER_DATA_PATH, user_data, user_data, env_var,
+    )
 
 
 def _describe_dep(env_var: str) -> dict[str, str]:

--- a/inference_optimizer/manifest.py
+++ b/inference_optimizer/manifest.py
@@ -83,6 +83,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from . import paths as _paths
 from .session_paths import manifest_path
 
 log = logging.getLogger(__name__)
@@ -206,6 +207,37 @@ def _git_remote_at(path: Path) -> str:
         return ""
 
 
+def _path_is_relative_to(path: Path, root: Path) -> bool:
+    """Return True when ``path`` is inside ``root`` after best-effort resolution."""
+    try:
+        path.resolve(strict=False).relative_to(root.resolve(strict=False))
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def _warn_if_dependency_escapes_user_data(env_var: str, raw: str) -> None:
+    """Warn when a dependency checkout path escapes an explicit USER_DATA_PATH.
+
+    Operators expect Magpie / InferenceX runtime checkouts to live under the
+    same workspace root as session data.  The env vars are still honoured for
+    advanced/debug flows, but an out-of-tree override should be loud in the
+    manifest logs because it is otherwise very hard to explain why artefacts
+    appeared under /workspace instead of the configured data root.
+    """
+    user_data = (os.environ.get(_paths.ENV_USER_DATA_PATH) or "").strip()
+    if not user_data:
+        return
+    dep_path = Path(raw)
+    root = Path(user_data)
+    if not _path_is_relative_to(dep_path, root):
+        log.warning(
+            "%s=%s is outside %s=%s; this run may read/write runtime "
+            "artefacts outside the configured Hyperloom workspace root.",
+            env_var, raw, _paths.ENV_USER_DATA_PATH, user_data,
+        )
+
+
 def _describe_dep(env_var: str) -> dict[str, str]:
     """Build a `{path, commit, remote}` provenance dict for one dependency
     pointed at by ``$env_var``. All fields default to empty string when
@@ -215,6 +247,7 @@ def _describe_dep(env_var: str) -> dict[str, str]:
     raw = (os.environ.get(env_var) or "").strip()
     if not raw:
         return {"path": "", "commit": "", "remote": ""}
+    _warn_if_dependency_escapes_user_data(env_var, raw)
     path = Path(raw)
     if not path.is_dir():
         return {"path": raw, "commit": "", "remote": ""}

--- a/inference_optimizer/orchestrator/action_executors/_grid_runner.py
+++ b/inference_optimizer/orchestrator/action_executors/_grid_runner.py
@@ -90,13 +90,18 @@ def variant_fingerprint(
 def _resolve_magpie_python() -> str:
     """Resolve the Python interpreter for Magpie subprocesses.
 
-    Order: $MAGPIE_PYTHON env > first `python3` on PATH that can
-    ``import Magpie`` > /opt/venv/bin/python (if it exists).
-    """
-    env_val = os.environ.get("MAGPIE_PYTHON", "").strip()
-    if env_val:
-        return env_val
+    Order: $MAGPIE_PYTHON env (only when it can actually ``import Magpie``)
+    > first `python3` on PATH that can ``import Magpie``
+    > /opt/venv/bin/python (if it exists).
 
+    A stale ``$MAGPIE_PYTHON`` that points at an interpreter WITHOUT Magpie
+    must NOT be trusted blindly: ``kernel-agent/scripts/install.sh`` resolves
+    the value BEFORE Magpie is pip-installed, so a fresh env can bake in e.g.
+    ``/usr/bin/python3`` — using it makes every Magpie benchmark fail with
+    ``ModuleNotFoundError: No module named 'Magpie'`` (surfaced as
+    ``subprocess_nonzero`` / baseline_failed). We validate the env value and
+    fall through to auto-detection instead.
+    """
     def _can_import_magpie(py: str) -> bool:
         try:
             proc = run_with_session_kill(
@@ -106,6 +111,18 @@ def _resolve_magpie_python() -> str:
             return getattr(proc, "returncode", 1) == 0
         except Exception:
             return False
+
+    env_val = os.environ.get("MAGPIE_PYTHON", "").strip()
+    if env_val:
+        if _can_import_magpie(env_val):
+            return env_val
+        log.warning(
+            "MAGPIE_PYTHON=%s cannot import Magpie; ignoring it and "
+            "auto-detecting an interpreter that can. (A stale value is often "
+            "baked into kernel-agent.env.sh when install.sh resolved it "
+            "before Magpie was pip-installed.)",
+            env_val,
+        )
 
     candidate = shutil.which("python3")
     if candidate and _can_import_magpie(candidate):

--- a/inference_optimizer/orchestrator/action_executors/_grid_runner.py
+++ b/inference_optimizer/orchestrator/action_executors/_grid_runner.py
@@ -92,7 +92,8 @@ def _resolve_magpie_python() -> str:
 
     Order: $MAGPIE_PYTHON env (only when it can actually ``import Magpie``)
     > first `python3` on PATH that can ``import Magpie``
-    > /opt/venv/bin/python (if it exists).
+    > /opt/venv/bin/python (the canonical Magpie venv baked into the
+    Hyperloom image) as the unconditional last resort.
 
     A stale ``$MAGPIE_PYTHON`` that points at an interpreter WITHOUT Magpie
     must NOT be trusted blindly: ``kernel-agent/scripts/install.sh`` resolves
@@ -101,12 +102,23 @@ def _resolve_magpie_python() -> str:
     ``ModuleNotFoundError: No module named 'Magpie'`` (surfaced as
     ``subprocess_nonzero`` / baseline_failed). We validate the env value and
     fall through to auto-detection instead.
+
+    The last resort is returned unconditionally — we never fall back to a
+    PATH ``python3`` we already proved cannot ``import Magpie``, since
+    returning it would just resurface ``ModuleNotFoundError`` at benchmark
+    time. If even the canonical interpreter lacks Magpie the subprocess
+    fails loudly on an actionable path rather than silently benchmarking
+    with a Magpie-less ``/usr/bin/python3``.
     """
     def _can_import_magpie(py: str) -> bool:
         try:
+            # NB: ``run_with_session_kill`` always captures stdout/stderr via
+            # PIPE internally and does NOT accept ``capture_output`` — passing
+            # it raises TypeError, which the broad ``except`` would swallow as
+            # "cannot import", silently disabling the whole probe.
             proc = run_with_session_kill(
                 [py, "-c", "import Magpie"],
-                capture_output=True, timeout=10,
+                timeout=10,
             )
             return getattr(proc, "returncode", 1) == 0
         except Exception:
@@ -128,11 +140,7 @@ def _resolve_magpie_python() -> str:
     if candidate and _can_import_magpie(candidate):
         return candidate
 
-    fallback = Path("/opt/venv/bin/python")
-    if fallback.exists():
-        return str(fallback)
-
-    return candidate or "/opt/venv/bin/python"
+    return "/opt/venv/bin/python"
 
 
 def _resolve_session_dir() -> Path:

--- a/inference_optimizer/orchestrator/action_executors/_grid_runner.py
+++ b/inference_optimizer/orchestrator/action_executors/_grid_runner.py
@@ -902,6 +902,92 @@ def merge_server_args(*parts: str | None) -> str:
     return " ".join(str(p).strip() for p in parts if str(p or "").strip())
 
 
+# ---------------------------------------------------------------------------
+# sglang scheduler watchdog timeout injection
+#
+# On MI300X with the aiter attention backend, the FIRST inference request
+# JIT-compiles the ``mha_batch_prefill`` kernel; that compile can take longer
+# than sglang's default ``--watchdog-timeout`` of 300s. When it does, the
+# scheduler fires ``SIGQUIT`` and the server dies mid-warmup -> the benchmark
+# reports ``baseline_failed`` with throughput 0 (non-deterministic across
+# models: same-arch models pass once the aiter cache is warm). InferenceX's
+# ``sglang_mi300x.sh`` appends ``$EXTRA_SGLANG_ARGS`` after its own
+# DEFAULT_ARGS and never sets ``--watchdog-timeout`` itself, so routing the
+# flag through ``EXTRA_SGLANG_ARGS`` reliably reaches
+# ``python -m sglang.launch_server``. We inject a longer timeout by default
+# unless the user already pinned one.
+# ---------------------------------------------------------------------------
+DEFAULT_SGLANG_WATCHDOG_TIMEOUT_SEC = 1800
+SGLANG_WATCHDOG_TIMEOUT_ENV = "SGLANG_WATCHDOG_TIMEOUT"
+_SGLANG_WATCHDOG_FLAG = "--watchdog-timeout"
+# Matches the flag in space- or equals-separated form so a user-pinned
+# ``--watchdog-timeout 600`` / ``--watchdog-timeout=600`` both suppress
+# injection, while a longer flag (no such sglang flag today, but defensive)
+# does not false-match.
+_SGLANG_WATCHDOG_RE = re.compile(r"--watchdog-timeout(?:[=\s]|$)")
+
+
+def resolve_sglang_watchdog_timeout() -> int:
+    """Resolve the sglang scheduler watchdog timeout in seconds.
+
+    Reads ``$SGLANG_WATCHDOG_TIMEOUT`` (integer seconds) and falls back to
+    :data:`DEFAULT_SGLANG_WATCHDOG_TIMEOUT_SEC` when the env var is unset,
+    empty, non-integer, or non-positive. A malformed value logs a warning
+    and uses the default rather than crashing the YAML materialization.
+    """
+    raw = os.environ.get(SGLANG_WATCHDOG_TIMEOUT_ENV, "").strip()
+    if not raw:
+        return DEFAULT_SGLANG_WATCHDOG_TIMEOUT_SEC
+    try:
+        val = int(raw)
+    except ValueError:
+        log.warning(
+            "%s=%r is not an integer; using default %ds.",
+            SGLANG_WATCHDOG_TIMEOUT_ENV, raw,
+            DEFAULT_SGLANG_WATCHDOG_TIMEOUT_SEC,
+        )
+        return DEFAULT_SGLANG_WATCHDOG_TIMEOUT_SEC
+    if val <= 0:
+        log.warning(
+            "%s=%d is not positive; using default %ds.",
+            SGLANG_WATCHDOG_TIMEOUT_ENV, val,
+            DEFAULT_SGLANG_WATCHDOG_TIMEOUT_SEC,
+        )
+        return DEFAULT_SGLANG_WATCHDOG_TIMEOUT_SEC
+    return val
+
+
+def inject_sglang_watchdog_timeout(
+    server_args: str | None, framework: str | None,
+) -> str:
+    """Append ``--watchdog-timeout <N>`` to ``server_args`` for sglang runs.
+
+    Returns ``server_args`` unchanged (coerced to a stripped string) when
+    either guard trips:
+
+    * ``framework`` does not route to ``EXTRA_SGLANG_ARGS`` — vllm / atom
+      have no such flag, so they are left untouched. Framework detection
+      reuses :func:`server_args_env_name`, so an empty/unknown framework is
+      treated as sglang (the default backend), matching how every other
+      arg-routing site in this module behaves.
+    * ``server_args`` already contains ``--watchdog-timeout`` (in space- or
+      equals-separated form) — a user/variant-supplied value wins and is
+      never doubled.
+
+    Otherwise it appends ``--watchdog-timeout <N>`` where ``N`` comes from
+    :func:`resolve_sglang_watchdog_timeout`. Only this flag is added; the
+    function never touches ``--context-length`` / ``MAX_MODEL_LEN`` or any
+    other existing flag.
+    """
+    args = str(server_args or "").strip()
+    if server_args_env_name(framework) != "EXTRA_SGLANG_ARGS":
+        return args
+    if _SGLANG_WATCHDOG_RE.search(args):
+        return args
+    timeout = resolve_sglang_watchdog_timeout()
+    return merge_server_args(args, f"{_SGLANG_WATCHDOG_FLAG} {timeout}")
+
+
 def apply_runtime_benchmark_overrides(
     bench: dict[str, Any],
     *,
@@ -1766,13 +1852,18 @@ def _write_variant_abort_marker(
 
 
 __all__ = [
+    "DEFAULT_SGLANG_WATCHDOG_TIMEOUT_SEC",
     "GridVariant",
     "MULTI_NODE_DEFAULT_KEEP_THRESHOLD_PCT",
+    "SGLANG_WATCHDOG_TIMEOUT_ENV",
     "SINGLE_NODE_DEFAULT_KEEP_THRESHOLD_PCT",
     "VariantResult",
     "apply_runtime_benchmark_overrides",
+    "inject_sglang_watchdog_timeout",
+    "merge_server_args",
     "pick_winners",
     "reorder_grid_for_multi_node",
+    "resolve_sglang_watchdog_timeout",
     "run_grid",
     "sanitize_result_dir",
     "sanitize_script_name",

--- a/inference_optimizer/orchestrator/action_executors/_workload_envs.py
+++ b/inference_optimizer/orchestrator/action_executors/_workload_envs.py
@@ -46,7 +46,7 @@ from typing import Any
 import yaml
 
 from ...paths import asset_root
-from ._grid_runner import server_args_env_name
+from ._grid_runner import inject_sglang_watchdog_timeout, server_args_env_name
 from ._server_patcher import (
     ensure_sglang_patched_for_tracelens,
     ensure_vllm_patched_for_tracelens,
@@ -510,6 +510,23 @@ def materialize_config_with_envs(
             envs[framework_env] = server_args
     for key, value in (extra_envs or {}).items():
         envs[str(key)] = str(value)
+    # MI300X cold-compile guard: ensure sglang's scheduler watchdog is long
+    # enough to survive the first-request aiter ``mha_batch_prefill`` JIT
+    # compile. sglang's 300s default fires SIGQUIT mid-warmup on a cold aiter
+    # cache and the server dies -> baseline_failed / throughput 0. We resolve
+    # the FINAL framework env (after the server_args + extra_envs merges
+    # above) so a user-pinned ``--watchdog-timeout`` (via extra_server_args,
+    # extra_envs, or the YAML) is honored and never doubled. No-op for
+    # vllm/atom, and never touches ``--context-length`` / MAX_MODEL_LEN. This
+    # is the single choke point every benchmark path (baseline / profile /
+    # sweep / explore / framework_pr / conc_sweep) funnels through before the
+    # YAML is handed to Magpie, so the flag reaches every sglang launch.
+    framework_env = server_args_env_name(bench.get("framework"))
+    resolved_server_args = inject_sglang_watchdog_timeout(
+        str(envs.get(framework_env, "")).strip(), bench.get("framework"),
+    )
+    if resolved_server_args:
+        envs[framework_env] = resolved_server_args
     # Accuracy eval (GSM8K) is OFF by default because Magpie main and
     # InferenceX main currently disagree on the lm-eval CLI shape:
     # Magpie's benchmark scripts call `run_eval ... --concurrent-requests N`,

--- a/inference_optimizer/orchestrator/action_executors/report.py
+++ b/inference_optimizer/orchestrator/action_executors/report.py
@@ -99,6 +99,9 @@ def _format_md(summary: dict[str, Any]) -> str:
     lines.append("")
     lines.append(f"- **Model**: {summary['model_name']}  (`{summary['model_path']}`)")
     lines.append(f"- **Stop reason**: `{summary['stop_reason']}`")
+    stop_detail = str(summary.get("stop_detail") or "").strip()
+    if stop_detail:
+        lines.append(f"- **Stop detail**: {stop_detail}")
     lines.append(f"- **Budget**: {summary['max_minutes']} minutes")
     lines.append(f"- **Generated**: {summary['report_generated_at']}")
     lines.append("")

--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -900,8 +900,15 @@ def _write_gemm_tuning_benchmark_script(
     to the benchmark script's own PID/trap handling. It deliberately avoids
     global `pgrep sglang` cleanup so it cannot kill the main optimizer's
     benchmark server when GEMM tuning runs inside a live session.
+
+    ``$INFERENCEX_PATH`` (honoured when set in the orchestrator env) lets an
+    operator point GEMM tuning at a relocated InferenceX checkout; the
+    legacy ``/hyperloom/InferenceX`` literal is used only as the fallback.
+    It is resolved once here so the benchmark runner path and the exported
+    ``INFERENCEX_PATH`` stay consistent.
     """
-    runner = f"/hyperloom/InferenceX/benchmarks/{framework}_{gpu_type}.sh"
+    inferencex_path = os.environ.get("INFERENCEX_PATH") or "/hyperloom/InferenceX"
+    runner = f"{inferencex_path}/benchmarks/{framework}_{gpu_type}.sh"
     path = workspace / "geak_gemm_benchmark.sh"
     path.write_text(
         f"""#!/usr/bin/env bash
@@ -919,7 +926,7 @@ export RESULT_DIR="${{RESULT_DIR:-$PWD/gemm_benchmark_result}}"
 export RESULT_FILENAME="${{RESULT_FILENAME:-bench_serving.json}}"
 export PORT="${{PORT:-18888}}"
 export PATH="/opt/node20/bin:/opt/venv/bin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-export INFERENCEX_PATH="/hyperloom/InferenceX"
+export INFERENCEX_PATH={shlex.quote(inferencex_path)}
 mkdir -p "$RESULT_DIR"
 cd "$INFERENCEX_PATH"
 exec {shlex.quote(runner)}

--- a/inference_optimizer/paths.py
+++ b/inference_optimizer/paths.py
@@ -36,9 +36,12 @@ Two distinct path concepts:
 from __future__ import annotations
 
 import datetime
+import logging
 import os
 import re
 from pathlib import Path
+
+log = logging.getLogger(__name__)
 
 DEFAULT_SESSION_DIR = Path("/workspace/hyperloom")
 ENV_USER_DATA_PATH = "USER_DATA_PATH"
@@ -47,6 +50,12 @@ ENV_SESSION_LAYOUT = "INFERENCE_OPTIMIZER_SESSION_LAYOUT"
 ENV_CURRENT_SESSION_DIR = "INFERENCE_OPTIMIZER_CURRENT_SESSION_DIR"
 
 PACKAGE_ROOT = Path(__file__).resolve().parent
+
+# One-shot guard so the "USER_DATA_PATH unset" fallback warning fires at
+# most once per process. workspace_root() is on a hot path (every
+# runtime_dir/magpie_dir/session_dir call routes through it), so a guard
+# keeps the loud signal from drowning the logs.
+_WARNED_NO_USER_DATA = False
 
 # Directory skeleton mkdir-ed on `make_session_dir()`. Order is irrelevant
 # (each dir is created with `parents=True, exist_ok=True`), but the listing
@@ -148,10 +157,30 @@ def workspace_root() -> Path:
     Per-session artefacts live under :func:`session_dir`, which is
     either this same path (legacy ``flat`` layout) or
     ``<workspace_root>/<model>/<ts>/`` (``per_model_ts`` layout).
+
+    When ``$USER_DATA_PATH`` is set this returns it verbatim and NEVER
+    yields ``DEFAULT_SESSION_DIR`` — that is the whole point of the
+    operator knob. When it is unset/empty we fall back to
+    ``DEFAULT_SESSION_DIR`` but emit a single loud ``logging.warning`` so
+    a misconfigured launcher (one that forgot to export the env) is
+    immediately visible instead of silently writing to the pod-local
+    default.
     """
+    global _WARNED_NO_USER_DATA
     user_data = os.environ.get(ENV_USER_DATA_PATH)
     if user_data:
         return Path(user_data)
+    if not _WARNED_NO_USER_DATA:
+        _WARNED_NO_USER_DATA = True
+        log.warning(
+            "%s is not set; falling back to %s. All session/run artefacts "
+            "will be written there, NOT to an operator-chosen location. "
+            "Export %s to the intended workspace root before launching to "
+            "avoid silently writing to the pod-local default.",
+            ENV_USER_DATA_PATH,
+            DEFAULT_SESSION_DIR,
+            ENV_USER_DATA_PATH,
+        )
     return DEFAULT_SESSION_DIR
 
 

--- a/inference_optimizer/scripts/install.sh
+++ b/inference_optimizer/scripts/install.sh
@@ -76,7 +76,14 @@ load_dotenv_no_clobber() {
 # freshly-copied .env.template can be the single configuration entrypoint.
 # The loader is no-clobber: explicit shell exports always win.
 load_dotenv_no_clobber
+# Capture whether USER_DATA_PATH was provided BEFORE applying the default so we
+# can warn loudly on the silent fallback. ${VAR:+1} is empty when VAR is unset
+# or empty, which is exactly the case the :- default below would absorb.
+_user_data_was_set="${USER_DATA_PATH:+1}"
 USER_DATA_PATH="${USER_DATA_PATH:-/workspace/hyperloom}"
+if [ -z "${_user_data_was_set}" ]; then
+  echo "[install WARN] USER_DATA_PATH not set; defaulting to /workspace/hyperloom. Set USER_DATA_PATH to persist artifacts under your data root." >&2
+fi
 HYPERLOOM_RUNTIME_DIR="${HYPERLOOM_RUNTIME_DIR:-${USER_DATA_PATH}/runtime}"
 KERNEL_AGENT_ENV="${KERNEL_AGENT_ENV:-${HYPERLOOM_RUNTIME_DIR}/kernel-agent.env.sh}"
 HYPERLOOM_ROOT="${HYPERLOOM_ROOT:-${HYPERLOOM_RUNTIME_DIR}/source-mirrors}"
@@ -148,6 +155,39 @@ run() {
   log "$*"
   if [ "$DRY_RUN" -eq 0 ] && [ "$CHECK_ONLY" -eq 0 ]; then
     "$@"
+  fi
+}
+
+# Serialize concurrent installs that share one $USER_DATA_PATH. Installs
+# pointed at the same data root also share
+# $HYPERLOOM_RUNTIME_DIR/source-mirrors (Magpie / InferenceX, plus
+# GEAK / OOB / TraceLens via the chained kernel-agent installer). With no
+# lock, two installs race and corrupt each other's half-cloned checkouts
+# (observed: GEAK src/minisweagent/... missing, repeated install failures).
+# We hold an flock on $HYPERLOOM_RUNTIME_DIR/.install.lock via fd 9 from the
+# first mirror-mutating step until this process exits (fd closes on exit),
+# so it guards every clone/build below and releases automatically at the end.
+# Skipped under --check-only / --dry-run (introspection only, no mutation).
+# When we chain to kernel-agent's installer we export
+# HYPERLOOM_INSTALL_LOCK_HELD=1 so that child does not deadlock re-acquiring
+# the same lock on a second open file description.
+acquire_install_lock() {
+  if [ "$CHECK_ONLY" -eq 1 ] || [ "$DRY_RUN" -eq 1 ]; then
+    return 0
+  fi
+  if [ "${HYPERLOOM_INSTALL_LOCK_HELD:-0}" = "1" ]; then
+    log "install lock already held by parent installer; not re-locking"
+    return 0
+  fi
+  mkdir -p "${HYPERLOOM_RUNTIME_DIR}"
+  exec 9>"${HYPERLOOM_RUNTIME_DIR}/.install.lock"
+  if command -v flock >/dev/null 2>&1; then
+    log "waiting for install lock: ${HYPERLOOM_RUNTIME_DIR}/.install.lock"
+    flock 9
+    log "acquired install lock"
+    export HYPERLOOM_INSTALL_LOCK_HELD=1
+  else
+    warn "flock not available; concurrent installs may race on source-mirrors"
   fi
 }
 
@@ -653,6 +693,9 @@ chain_framework_agent() {
 }
 
 ensure_inference_optimizer
+# Hold the install lock for the whole mirror-mutating region (Magpie /
+# InferenceX clones + the chained kernel-agent GEAK/OOB/TraceLens clones).
+acquire_install_lock
 ensure_magpie
 ensure_magpie_atomic_scripts_patch
 ensure_inferencex

--- a/inference_optimizer/scripts/local_setup.sh
+++ b/inference_optimizer/scripts/local_setup.sh
@@ -8,7 +8,14 @@ CHECK_ONLY=0
 
 _script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${REPO_ROOT:-$(cd "${_script_dir}/../.." && pwd)}"
+# Capture whether USER_DATA_PATH was provided BEFORE applying the default so we
+# can warn loudly on the silent fallback. ${VAR:+1} is empty when VAR is unset
+# or empty, which is exactly the case the :- default below would absorb.
+_user_data_was_set="${USER_DATA_PATH:+1}"
 USER_DATA_PATH="${USER_DATA_PATH:-/workspace/hyperloom}"
+if [ -z "${_user_data_was_set}" ]; then
+  echo "[install WARN] USER_DATA_PATH not set; defaulting to /workspace/hyperloom. Set USER_DATA_PATH to persist artifacts under your data root." >&2
+fi
 HYPERLOOM_RUNTIME_DIR="${HYPERLOOM_RUNTIME_DIR:-${USER_DATA_PATH}/runtime}"
 DEPS_ROOT_EXPLICIT=0
 if [ -n "${HYPERLOOM_DEPS_ROOT:-}" ]; then

--- a/inference_optimizer/scripts/preflight_kb.sh
+++ b/inference_optimizer/scripts/preflight_kb.sh
@@ -14,7 +14,14 @@ set -u
 
 : "${CORTEX_KB_URL:=}"
 : "${PR_MONITOR_URL:=http://primus-cortex-pr-api.primus-cortex.svc.cluster.local/v1}"
+# Capture whether USER_DATA_PATH was provided BEFORE applying the default so we
+# can warn loudly on the silent fallback. ${VAR:+1} is empty when VAR is unset
+# or empty, which is exactly the case the := default below would absorb.
+_user_data_was_set="${USER_DATA_PATH:+1}"
 : "${USER_DATA_PATH:=/workspace/hyperloom}"
+if [ -z "${_user_data_was_set}" ]; then
+  echo "[install WARN] USER_DATA_PATH not set; defaulting to /workspace/hyperloom. Set USER_DATA_PATH to persist artifacts under your data root." >&2
+fi
 : "${KB_SERVICE_TOKEN:=}"
 : "${SKIP_KB_PROBE:=}"
 : "${SKIP_PR_PROBE:=}"

--- a/inference_optimizer/tests/test_context_window_preflight.py
+++ b/inference_optimizer/tests/test_context_window_preflight.py
@@ -95,6 +95,12 @@ def test_preflight_fails_for_2048_model(tmp_path, monkeypatch):
     assert "max_position_embeddings=2048" in final_md
     state = json.loads((sd / "state.json").read_text())
     assert state["stop_reason"] == "model_context_window_too_small"
+    # PR-review-1: fail-fast exits before cli's coordinator.run try/finally, so
+    # it MUST emit session_breakdown.json itself — otherwise CI's delivery
+    # contract turns a clean skip into "Missing artifacts".
+    breakdown = sd / "session_breakdown.json"
+    assert breakdown.exists()
+    assert json.loads(breakdown.read_text(encoding="utf-8"))
 
 
 def test_preflight_passes_for_4096_model(tmp_path, monkeypatch):
@@ -126,3 +132,38 @@ def test_preflight_2048_passes_when_headroom_lowered(tmp_path, monkeypatch):
     sd = tmp_path / "session2048b"
     _seed_state(sd, monkeypatch)
     assert cli._preflight_context_window(_args(str(model), 1024, 1024), sd) is False
+
+
+# ---------------------------------------------------------------------------
+# MAX_MODEL_LEN resolution — clamp to the native window (no context stretch).
+# ---------------------------------------------------------------------------
+# Policy: MAX_MODEL_LEN = ISL+OSL+headroom, but never above the model's
+# max_position_embeddings. sglang ignores MAX_MODEL_LEN (context_length stays
+# None), but the vllm benchmark wires it into --max-model-len; an unclamped
+# ISL+OSL+4096 would exceed a small native window and crash the server (or
+# silently mis-size KV cache), defeating the "fail fast, don't stretch" policy.
+def test_max_model_len_clamped_to_native_window(tmp_path):
+    model = tmp_path / "ctx4096"
+    _write_config(model, max_position_embeddings=4096)
+    # desired = 1024 + 1024 + 4096 = 6144, native window = 4096 -> clamp to 4096.
+    assert cli._resolve_max_model_len(1024, 1024, str(model)) == 4096
+
+
+def test_max_model_len_uses_full_headroom_when_window_large(tmp_path):
+    model = tmp_path / "ctx32768"
+    _write_config(model, max_position_embeddings=32768)
+    # native window is comfortably above desired -> keep ISL+OSL+headroom.
+    assert (
+        cli._resolve_max_model_len(1024, 1024, str(model))
+        == 1024 + 1024 + cli._MAX_MODEL_LEN_HEADROOM
+    )
+
+
+def test_max_model_len_fallback_when_maxpos_unknown(tmp_path):
+    model = tmp_path / "noconfig"
+    model.mkdir()
+    # No config.json -> cannot clamp -> keep the headroom default (prior behaviour).
+    assert (
+        cli._resolve_max_model_len(1024, 1024, str(model))
+        == 1024 + 1024 + cli._MAX_MODEL_LEN_HEADROOM
+    )

--- a/inference_optimizer/tests/test_context_window_preflight.py
+++ b/inference_optimizer/tests/test_context_window_preflight.py
@@ -1,0 +1,126 @@
+"""Tests for the context-window preflight.
+
+Policy: do NOT stretch a small model context with --context-length (RoPE
+extrapolation / CUDA-error risk). Instead, when ISL+OSL+headroom exceeds the
+model's max_position_embeddings, fail fast with a persisted stop reason so the
+run does not boot a server that 400s every request and dies on the watchdog.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from inference_optimizer import cli
+
+
+def _write_config(model_dir: Path, **fields) -> None:
+    model_dir.mkdir(parents=True, exist_ok=True)
+    (model_dir / "config.json").write_text(json.dumps(fields), encoding="utf-8")
+
+
+def _args(model: str, isl: int = 1024, osl: int = 1024) -> argparse.Namespace:
+    return argparse.Namespace(model=model, isl=isl, osl=osl)
+
+
+# ---------------------------------------------------------------------------
+# max_position_embeddings loader
+# ---------------------------------------------------------------------------
+def test_loads_max_position_embeddings(tmp_path):
+    m = tmp_path / "model"
+    _write_config(m, model_type="llama", max_position_embeddings=2048)
+    assert cli._load_model_max_position_embeddings(str(m)) == 2048
+
+
+def test_loads_alias_and_nested_text_config(tmp_path):
+    m = tmp_path / "alias"
+    _write_config(m, n_positions=4096)
+    assert cli._load_model_max_position_embeddings(str(m)) == 4096
+    n = tmp_path / "nested"
+    n.mkdir()
+    (n / "config.json").write_text(
+        json.dumps({"text_config": {"max_position_embeddings": 8192}}),
+        encoding="utf-8",
+    )
+    assert cli._load_model_max_position_embeddings(str(n)) == 8192
+
+
+def test_missing_config_returns_none(tmp_path):
+    assert cli._load_model_max_position_embeddings(str(tmp_path / "nope")) is None
+
+
+# ---------------------------------------------------------------------------
+# headroom resolution
+# ---------------------------------------------------------------------------
+def test_headroom_default_and_override(monkeypatch):
+    monkeypatch.delenv(cli._CONTEXT_HEADROOM_ENV, raising=False)
+    assert cli._context_headroom_tokens() == cli._CONTEXT_HEADROOM_DEFAULT
+    monkeypatch.setenv(cli._CONTEXT_HEADROOM_ENV, "1024")
+    assert cli._context_headroom_tokens() == 1024
+    monkeypatch.setenv(cli._CONTEXT_HEADROOM_ENV, "garbage")
+    assert cli._context_headroom_tokens() == cli._CONTEXT_HEADROOM_DEFAULT
+
+
+# ---------------------------------------------------------------------------
+# preflight gate
+# ---------------------------------------------------------------------------
+def _seed_state(session_dir: Path, monkeypatch):
+    """Create a minimal seeded session so the preflight can load/save state."""
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_CURRENT_SESSION_DIR", str(session_dir))
+    from inference_optimizer.orchestrator.shared_state import SharedState
+
+    session_dir.mkdir(parents=True, exist_ok=True)
+    (session_dir / "reports").mkdir(parents=True, exist_ok=True)
+    SharedState(session_id="t", model_name="m", model_path="m").save(session_dir)
+
+
+def test_preflight_fails_for_2048_model(tmp_path, monkeypatch):
+    monkeypatch.delenv(cli._CONTEXT_HEADROOM_ENV, raising=False)
+    model = tmp_path / "ctx2048"
+    _write_config(model, model_type="llama", max_position_embeddings=2048)
+    sd = tmp_path / "session"
+    _seed_state(sd, monkeypatch)
+
+    blocked = cli._preflight_context_window(_args(str(model)), sd)
+
+    assert blocked is True
+    final = json.loads((sd / "reports" / "final.json").read_text())
+    assert final["stop_reason"] == "model_context_window_too_small"
+    assert "max_position_embeddings=2048" in final["stop_detail"]
+    assert (sd / "reports" / "final.md").exists()
+    state = json.loads((sd / "state.json").read_text())
+    assert state["stop_reason"] == "model_context_window_too_small"
+
+
+def test_preflight_passes_for_4096_model(tmp_path, monkeypatch):
+    monkeypatch.delenv(cli._CONTEXT_HEADROOM_ENV, raising=False)
+    model = tmp_path / "ctx4096"
+    _write_config(model, model_type="llama", max_position_embeddings=4096)
+    sd = tmp_path / "session4096"
+    _seed_state(sd, monkeypatch)
+
+    assert cli._preflight_context_window(_args(str(model)), sd) is False
+    assert not (sd / "reports" / "final.json").exists()
+
+
+def test_preflight_skipped_when_maxpos_unknown(tmp_path, monkeypatch):
+    model = tmp_path / "no_config"
+    model.mkdir()
+    sd = tmp_path / "session_unknown"
+    _seed_state(sd, monkeypatch)
+    # No config.json -> maxpos unknown -> gate skipped (do not block).
+    assert cli._preflight_context_window(_args(str(model)), sd) is False
+
+
+def test_preflight_2048_passes_when_headroom_lowered(tmp_path, monkeypatch):
+    """A 2048 model with ISL+OSL=1024+1024 and headroom forced to 0 just fits
+    the equality boundary (2048 >= 2048) — gate does not block."""
+    monkeypatch.setenv(cli._CONTEXT_HEADROOM_ENV, "0")
+    model = tmp_path / "ctx2048b"
+    _write_config(model, max_position_embeddings=2048)
+    sd = tmp_path / "session2048b"
+    _seed_state(sd, monkeypatch)
+    assert cli._preflight_context_window(_args(str(model), 1024, 1024), sd) is False

--- a/inference_optimizer/tests/test_context_window_preflight.py
+++ b/inference_optimizer/tests/test_context_window_preflight.py
@@ -90,7 +90,9 @@ def test_preflight_fails_for_2048_model(tmp_path, monkeypatch):
     final = json.loads((sd / "reports" / "final.json").read_text())
     assert final["stop_reason"] == "model_context_window_too_small"
     assert "max_position_embeddings=2048" in final["stop_detail"]
-    assert (sd / "reports" / "final.md").exists()
+    final_md = (sd / "reports" / "final.md").read_text(encoding="utf-8")
+    assert "model_context_window_too_small" in final_md
+    assert "max_position_embeddings=2048" in final_md
     state = json.loads((sd / "state.json").read_text())
     assert state["stop_reason"] == "model_context_window_too_small"
 

--- a/inference_optimizer/tests/test_decision_framework.py
+++ b/inference_optimizer/tests/test_decision_framework.py
@@ -52,9 +52,17 @@ def session_dir(tmp_path, monkeypatch) -> Path:
     # work even when the host env var is unset.
     kernel_agent_root = Path(__file__).resolve().parents[2] / "kernel-agent"
     monkeypatch.setenv("HYPERLOOM_KERNEL_AGENT_ROOT", str(kernel_agent_root))
-    # Skip the `python3 -c "import Magpie"` probe inside _resolve_magpie_python
-    # so subprocess.run mocks only see the actual Magpie launch command.
+    # Keep the unit test hermetic: stub the interpreter resolver so it never
+    # spawns a real ``python3 -c "import Magpie"`` probe. (Setting
+    # MAGPIE_PYTHON alone no longer short-circuits the probe — the resolver
+    # validates the env value via run_with_session_kill since the
+    # stale-interpreter self-heal landed.) The mocked Magpie launch only ever
+    # sees this fixed interpreter as ``cmd[0]``.
     monkeypatch.setenv("MAGPIE_PYTHON", "/usr/bin/python3")
+    from inference_optimizer.orchestrator.action_executors import _grid_runner
+    monkeypatch.setattr(
+        _grid_runner, "_resolve_magpie_python", lambda: "/usr/bin/python3",
+    )
     return make_session_dir()
 
 

--- a/inference_optimizer/tests/test_kernel_integrate_and_report.py
+++ b/inference_optimizer/tests/test_kernel_integrate_and_report.py
@@ -46,10 +46,17 @@ def session_dir(tmp_path, monkeypatch) -> Path:
     # inline reimport. Same convention as test_p2_2_profile_and_handlers.py.
     kernel_agent_root = Path(__file__).resolve().parents[2] / "kernel-agent"
     monkeypatch.setenv("HYPERLOOM_KERNEL_AGENT_ROOT", str(kernel_agent_root))
-    # Skip the ``python3 -c "import Magpie"`` probe inside
-    # _resolve_magpie_python so subprocess.run mocks only see the actual
-    # Magpie launch command (origin/main behaviour).
+    # Keep the unit test hermetic: stub the interpreter resolver so it never
+    # spawns a real ``python3 -c "import Magpie"`` probe. (Setting
+    # MAGPIE_PYTHON alone no longer short-circuits the probe — the resolver
+    # validates the env value via run_with_session_kill since the
+    # stale-interpreter self-heal landed.) The mocked Magpie launch only ever
+    # sees this fixed interpreter as ``cmd[0]``.
     monkeypatch.setenv("MAGPIE_PYTHON", "/usr/bin/python3")
+    from inference_optimizer.orchestrator.action_executors import _grid_runner
+    monkeypatch.setattr(
+        _grid_runner, "_resolve_magpie_python", lambda: "/usr/bin/python3",
+    )
     return make_session_dir()
 
 
@@ -424,7 +431,15 @@ async def test_integrate_handler_injects_extra_server_args(
         res = await krh.integrate_handler(payload, session_dir=session_dir)
 
     assert res["decision"] == "KEEP"
-    assert seen["envs"]["EXTRA_SGLANG_ARGS"] == "--cuda-graph-max-bs 8"
+    # The operator-supplied extra_server_args must be preserved verbatim, and
+    # the shared materialization choke point auto-appends the sglang
+    # scheduler ``--watchdog-timeout`` (MI300X cold-compile guard) on top of
+    # it. Assert both rather than exact equality so the watchdog default
+    # (1800s, or $SGLANG_WATCHDOG_TIMEOUT) can evolve without breaking this
+    # test. See ``inject_sglang_watchdog_timeout`` / test_watchdog_injection.
+    sglang_args = seen["envs"]["EXTRA_SGLANG_ARGS"]
+    assert "--cuda-graph-max-bs 8" in sglang_args
+    assert "--watchdog-timeout" in sglang_args
 
 
 @pytest.mark.asyncio

--- a/inference_optimizer/tests/test_local_setup_script.py
+++ b/inference_optimizer/tests/test_local_setup_script.py
@@ -1,12 +1,23 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 from pathlib import Path
+
+import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "inference_optimizer" / "scripts" / "local_setup.sh"
+IO_INSTALL = REPO_ROOT / "inference_optimizer" / "scripts" / "install.sh"
+KA_INSTALL = REPO_ROOT / "kernel-agent" / "scripts" / "install.sh"
+PREFLIGHT_KB = REPO_ROOT / "inference_optimizer" / "scripts" / "preflight_kb.sh"
+
+# The default that all installers fall back to when USER_DATA_PATH is unset.
+_DEFAULT_USER_DATA_PATH = "/workspace/hyperloom"
+# Substring of the loud fallback notice each script prints to stderr.
+_FALLBACK_WARNING = "USER_DATA_PATH not set"
 
 # ``local_setup.sh`` honours these env vars when present. The optimizer
 # session shell (and CI runners) routinely export them, pointing at host
@@ -240,3 +251,137 @@ def test_local_setup_session_dir_rebases_default_deps_root(tmp_path: Path) -> No
     # Open-source-only by default: internal extension is not requested/cloned.
     assert str(expected_deps / "TraceLens-internal") not in result.stdout
     assert "release/hyperloom_integration_v0.5.0" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# install-harden (feature/xiaofei/install-path-and-flock):
+#   A. loud USER_DATA_PATH fallback notice across all installers
+#   B. flock around the shared source-mirror clone/build region
+# ---------------------------------------------------------------------------
+
+# Scripts that expose ``--help``. ``--help`` runs the top-of-file
+# USER_DATA_PATH resolution (and its fallback notice) and then exits 0
+# *before* any heavy / environment-coupled install work, so it is the fast,
+# hermetic way to exercise exactly the fallback-notice code path. (A full
+# ``--check-only`` / ``--dry-run`` run would clone Magpie, import
+# inference_optimizer, chain to kernel-agent, etc. — far too heavy and
+# flaky for a path-handling unit test.)
+_HELP_SCRIPTS = {
+    "inference_optimizer_install": IO_INSTALL,
+    "kernel_agent_install": KA_INSTALL,
+    "local_setup": SCRIPT,
+}
+
+
+def _run_help(
+    script: Path, tmp_path: Path, user_data_path: str | None
+) -> subprocess.CompletedProcess[str]:
+    """Run ``bash <script> --help`` with a hermetic environment.
+
+    ``REPO_ROOT`` points at an empty stub dir so no real ``.env`` is sourced;
+    ``MAGPIE_PYTHON`` / ``GEAK_RAG_INDEX_DEVICE`` are pinned so kernel-agent's
+    top-level probes do not shell out to rocm-smi or import Magpie/torch.
+    ``USER_DATA_PATH`` is exported only when ``user_data_path`` is provided;
+    otherwise it stays stripped (by ``_clean_base_env``) so the unset
+    fallback branch fires.
+    """
+    env = _clean_base_env()
+    repo_stub = tmp_path / "repo_stub"
+    repo_stub.mkdir(exist_ok=True)
+    env["REPO_ROOT"] = str(repo_stub)
+    env["MAGPIE_PYTHON"] = "python3"
+    env["GEAK_RAG_INDEX_DEVICE"] = "cpu"
+    if user_data_path is not None:
+        env["USER_DATA_PATH"] = user_data_path
+    return subprocess.run(
+        ["bash", str(script), "--help"],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize("script", list(_HELP_SCRIPTS.values()), ids=list(_HELP_SCRIPTS))
+def test_install_warns_loudly_when_user_data_path_unset(script: Path, tmp_path: Path) -> None:
+    result = _run_help(script, tmp_path, user_data_path=None)
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert _FALLBACK_WARNING in result.stderr, result.stderr
+
+
+@pytest.mark.parametrize("script", list(_HELP_SCRIPTS.values()), ids=list(_HELP_SCRIPTS))
+def test_install_silent_when_user_data_path_set(script: Path, tmp_path: Path) -> None:
+    data_root = tmp_path / "data"
+    result = _run_help(script, tmp_path, user_data_path=str(data_root))
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert _FALLBACK_WARNING not in result.stderr, result.stderr
+
+
+@pytest.mark.parametrize("script", [IO_INSTALL, KA_INSTALL], ids=["inference_optimizer", "kernel_agent"])
+def test_install_does_not_reference_default_path_when_set(script: Path, tmp_path: Path) -> None:
+    # local_setup.sh is intentionally excluded: its --help text documents the
+    # default path, so a literal-string check there is meaningless. The two
+    # install.sh entrypoints do not mention it in --help output, so when
+    # USER_DATA_PATH is set their output must not reference the fallback root.
+    data_root = tmp_path / "data"
+    result = _run_help(script, tmp_path, user_data_path=str(data_root))
+    assert result.returncode == 0, result.stderr + result.stdout
+    combined = result.stdout + result.stderr
+    assert _DEFAULT_USER_DATA_PATH not in combined, combined
+
+
+@pytest.mark.parametrize(
+    "script",
+    [IO_INSTALL, KA_INSTALL, SCRIPT, PREFLIGHT_KB],
+    ids=["inference_optimizer", "kernel_agent", "local_setup", "preflight_kb"],
+)
+def test_all_scripts_emit_user_data_path_fallback_notice(script: Path) -> None:
+    # All four installers must detect the unset case BEFORE applying the
+    # default and warn loudly. Grep-level so it also covers preflight_kb.sh,
+    # which has no --help entrypoint to drive functionally.
+    text = script.read_text(encoding="utf-8")
+    assert "_user_data_was_set" in text, script
+    assert _FALLBACK_WARNING in text, script
+
+
+@pytest.mark.parametrize("script", [IO_INSTALL, KA_INSTALL], ids=["inference_optimizer", "kernel_agent"])
+def test_install_scripts_guard_mirror_writes_with_flock(script: Path) -> None:
+    # Both install.sh entrypoints serialize the source-mirror clone/build
+    # region with an fd-based flock on $HYPERLOOM_RUNTIME_DIR/.install.lock and
+    # hand the lock to the chained installer via HYPERLOOM_INSTALL_LOCK_HELD so
+    # the inference_optimizer -> kernel-agent chain cannot self-deadlock.
+    text = script.read_text(encoding="utf-8")
+    assert ".install.lock" in text, script
+    assert "exec 9>" in text, script
+    assert "flock 9" in text, script
+    assert "HYPERLOOM_INSTALL_LOCK_HELD" in text, script
+
+
+def test_flock_serializes_concurrent_critical_sections(tmp_path: Path) -> None:
+    # Fast, real serialization check of the exact idiom the installers use
+    # (`exec 9>LOCK; flock 9; <work>`): two workers contending on one lock
+    # must run their critical sections one-at-a-time (no interleaving).
+    if shutil.which("flock") is None:
+        pytest.skip("flock not available on this host")
+    lock = tmp_path / ".install.lock"
+    order = tmp_path / "order"
+    worker_src = (
+        'exec 9>"$1"\n'
+        "flock 9\n"
+        'echo "start-$2" >> "$3"\n'
+        "sleep 0.5\n"
+        'echo "end-$2" >> "$3"\n'
+    )
+    procs = [
+        subprocess.Popen(["bash", "-c", worker_src, "worker", str(lock), tag, str(order)])
+        for tag in ("A", "B")
+    ]
+    for proc in procs:
+        assert proc.wait(timeout=30) == 0
+    lines = order.read_text(encoding="utf-8").split()
+    assert lines in (
+        ["start-A", "end-A", "start-B", "end-B"],
+        ["start-B", "end-B", "start-A", "end-A"],
+    ), f"flock did not serialize critical sections: {lines}"

--- a/inference_optimizer/tests/test_magpie_python_resolution.py
+++ b/inference_optimizer/tests/test_magpie_python_resolution.py
@@ -12,6 +12,7 @@ value and fall through to auto-detection.
 from __future__ import annotations
 
 import logging
+import subprocess
 
 import pytest
 
@@ -25,6 +26,43 @@ def test_env_magpie_python_used_when_it_can_import(monkeypatch):
         lambda *a, **k: type("P", (), {"returncode": 0})(),
     )
     assert _grid_runner._resolve_magpie_python() == "/good/python"
+
+
+def test_can_import_probe_uses_only_supported_run_kwargs(monkeypatch):
+    """Regression guard: the ``import Magpie`` probe must call
+    ``run_with_session_kill`` with ONLY kwargs that function accepts.
+
+    The probe previously passed ``capture_output=True`` — a kwarg
+    ``run_with_session_kill`` does NOT accept (it always captures via PIPE
+    internally). Every probe therefore raised ``TypeError`` (swallowed by the
+    broad ``except`` -> ``return False``), so a perfectly valid
+    ``$MAGPIE_PYTHON`` was always rejected and the whole stale-interpreter
+    self-heal degraded to "always fall through to the hard-coded fallback".
+
+    The other tests in this module hide that bug because they patch
+    ``run_with_session_kill`` with ``lambda *a, **k`` (which swallows any
+    kwarg). This test patches it with a mock that mirrors the REAL signature,
+    so passing an unsupported kwarg raises ``TypeError`` here just like in
+    production.
+    """
+    monkeypatch.setenv("MAGPIE_PYTHON", "/good/python")
+    probe_cmds: list[list[str]] = []
+
+    def strict_run(
+        cmd, *, env=None, cwd=None, timeout=None, text=True,
+        soft_deadline_sec=None,
+    ):
+        # Mirror run_with_session_kill's real signature exactly — no
+        # ``capture_output``. A buggy probe that passes it raises TypeError
+        # at call-binding time (before this body runs).
+        probe_cmds.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(_grid_runner, "run_with_session_kill", strict_run)
+
+    assert _grid_runner._resolve_magpie_python() == "/good/python"
+    assert probe_cmds, "the probe must actually invoke run_with_session_kill"
+    assert probe_cmds[0][:2] == ["/good/python", "-c"]
 
 
 def test_stale_env_magpie_python_ignored_and_autodetected(monkeypatch, caplog):
@@ -52,12 +90,19 @@ def test_stale_env_magpie_python_ignored_and_autodetected(monkeypatch, caplog):
 
 def test_falls_back_to_opt_venv_when_path_python_cannot_import(monkeypatch, tmp_path):
     """When neither the (stale) env value nor PATH python3 can import Magpie,
-    fall back to /opt/venv/bin/python if present."""
+    return /opt/venv/bin/python as the unconditional last resort.
+
+    The resolver must NOT fall back to the PATH python3 it just proved cannot
+    import Magpie (that would silently benchmark with a Magpie-less
+    interpreter). It returns the canonical Magpie venv path regardless of
+    whether that file physically exists on this box — so the assertion is
+    deterministic in CI (where /opt/venv/bin/python may be absent) and a
+    truly broken image fails loudly on an actionable path instead.
+    """
     monkeypatch.setenv("MAGPIE_PYTHON", "/usr/bin/python3")
     monkeypatch.setattr(
         _grid_runner, "run_with_session_kill",
         lambda *a, **k: type("P", (), {"returncode": 1})(),
     )
     monkeypatch.setattr(_grid_runner.shutil, "which", lambda _n: "/usr/bin/python3")
-    # /opt/venv/bin/python exists in this image, so the resolver returns it.
     assert _grid_runner._resolve_magpie_python() == "/opt/venv/bin/python"

--- a/inference_optimizer/tests/test_magpie_python_resolution.py
+++ b/inference_optimizer/tests/test_magpie_python_resolution.py
@@ -1,0 +1,63 @@
+"""Tests for `_resolve_magpie_python` robustness.
+
+`kernel-agent/scripts/install.sh` resolves `MAGPIE_PYTHON` BEFORE Magpie is
+pip-installed, so a freshly-generated `kernel-agent.env.sh` can bake in an
+interpreter that cannot `import Magpie` (observed: `/usr/bin/python3`). Trusting
+that value blindly made every Magpie benchmark fail with
+`ModuleNotFoundError: No module named 'Magpie'` (surfaced as
+`subprocess_nonzero` / baseline_failed). The resolver must validate the env
+value and fall through to auto-detection.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from inference_optimizer.orchestrator.action_executors import _grid_runner
+
+
+def test_env_magpie_python_used_when_it_can_import(monkeypatch):
+    monkeypatch.setenv("MAGPIE_PYTHON", "/good/python")
+    monkeypatch.setattr(
+        _grid_runner, "run_with_session_kill",
+        lambda *a, **k: type("P", (), {"returncode": 0})(),
+    )
+    assert _grid_runner._resolve_magpie_python() == "/good/python"
+
+
+def test_stale_env_magpie_python_ignored_and_autodetected(monkeypatch, caplog):
+    """A MAGPIE_PYTHON that cannot import Magpie is ignored; resolver falls
+    through to a PATH python3 that can."""
+    monkeypatch.setenv("MAGPIE_PYTHON", "/usr/bin/python3")
+
+    def fake_run(cmd, *a, **k):
+        py = cmd[0]
+        # Only the auto-detected PATH python can import Magpie; the stale
+        # env value cannot.
+        rc = 0 if py == "/opt/venv/bin/python3" else 1
+        return type("P", (), {"returncode": rc})()
+
+    monkeypatch.setattr(_grid_runner, "run_with_session_kill", fake_run)
+    monkeypatch.setattr(_grid_runner.shutil, "which", lambda _n: "/opt/venv/bin/python3")
+
+    with caplog.at_level(logging.WARNING):
+        resolved = _grid_runner._resolve_magpie_python()
+
+    assert resolved == "/opt/venv/bin/python3"
+    assert any("MAGPIE_PYTHON" in r.message and "cannot import Magpie" in r.message
+               for r in caplog.records)
+
+
+def test_falls_back_to_opt_venv_when_path_python_cannot_import(monkeypatch, tmp_path):
+    """When neither the (stale) env value nor PATH python3 can import Magpie,
+    fall back to /opt/venv/bin/python if present."""
+    monkeypatch.setenv("MAGPIE_PYTHON", "/usr/bin/python3")
+    monkeypatch.setattr(
+        _grid_runner, "run_with_session_kill",
+        lambda *a, **k: type("P", (), {"returncode": 1})(),
+    )
+    monkeypatch.setattr(_grid_runner.shutil, "which", lambda _n: "/usr/bin/python3")
+    # /opt/venv/bin/python exists in this image, so the resolver returns it.
+    assert _grid_runner._resolve_magpie_python() == "/opt/venv/bin/python"

--- a/inference_optimizer/tests/test_userdata_path_guard.py
+++ b/inference_optimizer/tests/test_userdata_path_guard.py
@@ -129,29 +129,56 @@ def test_unset_warning_is_emitted_once(
 # ---------------------------------------------------------------------------
 # Manifest dependency provenance: out-of-tree runtime overrides are loud
 # ---------------------------------------------------------------------------
-def test_manifest_warns_when_dependency_escapes_user_data(
+def test_manifest_warns_when_dependency_is_pod_local(
     clean_env: None,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    """A dependency override into a pod-local /workspace path (the real
+    'artefacts vanish on pod recycle' failure mode) must warn loudly."""
     from inference_optimizer import manifest
 
     user_data = tmp_path / "user_data"
-    outside = tmp_path / "outside_runtime" / "Magpie"
-    outside.mkdir(parents=True)
+    # Simulate the observed /workspace/hyperloom_runtime_* override. The dir
+    # need not exist for the escape check (guard runs before the is_dir gate).
+    pod_local = "/workspace/hyperloom_runtime_smoke/Magpie"
     monkeypatch.setenv(paths.ENV_USER_DATA_PATH, str(user_data))
-    monkeypatch.setenv("MAGPIE_DIR", str(outside))
+    monkeypatch.setenv("MAGPIE_DIR", pod_local)
 
     with caplog.at_level(logging.WARNING, logger="inference_optimizer.manifest"):
-        dep = manifest._describe_dep("MAGPIE_DIR")
+        manifest._describe_dep("MAGPIE_DIR")
 
-    assert dep["path"] == str(outside)
     assert any(
-        "MAGPIE_DIR" in r.message
-        and "outside USER_DATA_PATH" in r.message
+        "MAGPIE_DIR" in r.message and "pod-local" in r.message
         for r in caplog.records
-    )
+    ), "expected a loud pod-local escape warning"
+
+
+def test_manifest_does_not_warn_for_persistent_shared_checkout(
+    clean_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A persistent shared checkout OUTSIDE USER_DATA_PATH (e.g. a WekaFS
+    InferenceX/TraceLens mirror) is legitimate by design and must NOT warn."""
+    from inference_optimizer import manifest
+
+    user_data = tmp_path / "user_data"
+    user_data.mkdir(parents=True)
+    # A persistent WekaFS mirror outside USER_DATA_PATH (note: NOT under a
+    # pod-local /workspace|/tmp|/root prefix). The guard runs before the
+    # is_dir gate, so the path need not exist on disk for this assertion.
+    shared = "/wekafs/shared-mirrors/InferenceX"
+    monkeypatch.setenv(paths.ENV_USER_DATA_PATH, str(user_data))
+    monkeypatch.setenv("INFERENCEX_PATH", shared)
+
+    with caplog.at_level(logging.WARNING, logger="inference_optimizer.manifest"):
+        dep = manifest._describe_dep("INFERENCEX_PATH")
+
+    assert dep["path"] == shared
+    assert not [r for r in caplog.records if "INFERENCEX_PATH" in r.message]
 
 
 def test_manifest_does_not_warn_when_dependency_under_user_data(

--- a/inference_optimizer/tests/test_userdata_path_guard.py
+++ b/inference_optimizer/tests/test_userdata_path_guard.py
@@ -1,0 +1,175 @@
+"""Guard tests for the ``$USER_DATA_PATH`` write-determinism contract.
+
+These lock the "写死" (make-it-deterministic) requirement:
+
+1. When ``$USER_DATA_PATH`` IS set, no resolver may ever yield the
+   pod-local ``/workspace/hyperloom`` default — every artefact path is
+   anchored on the operator-chosen root.
+2. When ``$USER_DATA_PATH`` is NOT set, the resolver still falls back to
+   ``/workspace/hyperloom`` (so a degraded sandbox keeps working) BUT
+   emits a single loud ``logging.warning`` so the misconfiguration is
+   never silent.
+
+Covers ``inference_optimizer.paths.workspace_root`` and the CLI helper
+``_resolve_local_kb_root`` that builds on it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+
+import pytest
+
+from inference_optimizer import paths
+from inference_optimizer.cli import _resolve_local_kb_root
+
+_DEFAULT = "/workspace/hyperloom"
+
+
+@pytest.fixture
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Wipe every env var the resolvers consult and reset the one-shot
+    warn guard so each test is fully isolated from leakage by an earlier
+    test in the same process."""
+    for key in (
+        paths.ENV_USER_DATA_PATH,
+        "HYPERLOOM_LOCAL_KB_ROOT",
+        paths.ENV_CURRENT_SESSION_DIR,
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr(paths, "_WARNED_NO_USER_DATA", False)
+
+
+def _args_without_overrides() -> argparse.Namespace:
+    """A Namespace with no KB-root override, matching the argparse
+    default so ``_resolve_local_kb_root`` exercises the env/default
+    tiers rather than the explicit flag."""
+    return argparse.Namespace(local_kb_root=None)
+
+
+# ---------------------------------------------------------------------------
+# USER_DATA_PATH SET: never returns /workspace/hyperloom
+# ---------------------------------------------------------------------------
+def test_workspace_root_returns_user_data_path_when_set(
+    clean_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    monkeypatch.setenv(paths.ENV_USER_DATA_PATH, str(tmp_path))
+    assert paths.workspace_root() == tmp_path
+
+
+def test_kb_root_under_user_data_path_when_set(
+    clean_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """With the env set, the local-KB root lands under it and the
+    pod-local default literal never appears anywhere in the path."""
+    monkeypatch.setenv(paths.ENV_USER_DATA_PATH, str(tmp_path))
+    resolved = _resolve_local_kb_root(_args_without_overrides())
+    assert resolved == tmp_path / "kb"
+    assert tmp_path in resolved.parents
+    assert _DEFAULT not in str(resolved)
+
+
+def test_no_warning_emitted_when_set(
+    clean_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The loud warning must fire ONLY on misconfiguration — a correctly
+    configured run stays quiet."""
+    monkeypatch.setenv(paths.ENV_USER_DATA_PATH, str(tmp_path))
+    with caplog.at_level(logging.WARNING, logger="inference_optimizer.paths"):
+        paths.workspace_root()
+    assert not [r for r in caplog.records if paths.ENV_USER_DATA_PATH in r.message]
+
+
+# ---------------------------------------------------------------------------
+# USER_DATA_PATH UNSET: loud fallback to /workspace/hyperloom
+# ---------------------------------------------------------------------------
+def test_workspace_root_falls_back_and_warns_when_unset(
+    clean_env: None, caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="inference_optimizer.paths"):
+        result = paths.workspace_root()
+    assert result == paths.DEFAULT_SESSION_DIR == Path(_DEFAULT)
+    warnings = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING
+        and paths.ENV_USER_DATA_PATH in r.message
+    ]
+    assert warnings, "expected a loud USER_DATA_PATH-unset warning"
+
+
+def test_kb_root_falls_back_when_unset(clean_env: None) -> None:
+    """The KB-root fallback stays at ``/workspace/hyperloom/kb`` (degraded
+    sandbox keeps working) — unchanged value, now just not silent."""
+    resolved = _resolve_local_kb_root(_args_without_overrides())
+    assert resolved == Path(_DEFAULT) / "kb"
+
+
+def test_unset_warning_is_emitted_once(
+    clean_env: None, caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Hot-path guard: many call sites route through workspace_root(); the
+    warning must fire at most once per process so it does not drown logs."""
+    with caplog.at_level(logging.WARNING, logger="inference_optimizer.paths"):
+        paths.workspace_root()
+        paths.workspace_root()
+        paths.workspace_root()
+    warnings = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING
+        and paths.ENV_USER_DATA_PATH in r.message
+    ]
+    assert len(warnings) == 1
+
+
+# ---------------------------------------------------------------------------
+# Manifest dependency provenance: out-of-tree runtime overrides are loud
+# ---------------------------------------------------------------------------
+def test_manifest_warns_when_dependency_escapes_user_data(
+    clean_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from inference_optimizer import manifest
+
+    user_data = tmp_path / "user_data"
+    outside = tmp_path / "outside_runtime" / "Magpie"
+    outside.mkdir(parents=True)
+    monkeypatch.setenv(paths.ENV_USER_DATA_PATH, str(user_data))
+    monkeypatch.setenv("MAGPIE_DIR", str(outside))
+
+    with caplog.at_level(logging.WARNING, logger="inference_optimizer.manifest"):
+        dep = manifest._describe_dep("MAGPIE_DIR")
+
+    assert dep["path"] == str(outside)
+    assert any(
+        "MAGPIE_DIR" in r.message
+        and "outside USER_DATA_PATH" in r.message
+        for r in caplog.records
+    )
+
+
+def test_manifest_does_not_warn_when_dependency_under_user_data(
+    clean_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from inference_optimizer import manifest
+
+    user_data = tmp_path / "user_data"
+    magpie = user_data / "runtime" / "Magpie"
+    magpie.mkdir(parents=True)
+    monkeypatch.setenv(paths.ENV_USER_DATA_PATH, str(user_data))
+    monkeypatch.setenv("MAGPIE_DIR", str(magpie))
+
+    with caplog.at_level(logging.WARNING, logger="inference_optimizer.manifest"):
+        dep = manifest._describe_dep("MAGPIE_DIR")
+
+    assert dep["path"] == str(magpie)
+    assert not [r for r in caplog.records if "MAGPIE_DIR" in r.message]

--- a/inference_optimizer/tests/test_watchdog_injection.py
+++ b/inference_optimizer/tests/test_watchdog_injection.py
@@ -1,0 +1,238 @@
+"""sglang ``--watchdog-timeout`` injection tests.
+
+On MI300X with the aiter attention backend the FIRST inference request
+JIT-compiles the ``mha_batch_prefill`` kernel, which can take longer than
+sglang's default scheduler ``--watchdog-timeout`` of 300s. When it does the
+scheduler fires ``SIGQUIT`` and the server dies during warmup -> the benchmark
+reports ``baseline_failed`` with throughput 0. Hyperloom injects a longer
+``--watchdog-timeout`` into the sglang server args (routed through
+``EXTRA_SGLANG_ARGS``, which InferenceX's ``sglang_mi300x.sh`` appends verbatim
+after its own DEFAULT_ARGS to ``python -m sglang.launch_server``) unless the
+user already pinned one.
+
+These tests pin the contract:
+
+* default (1800s) is injected for sglang when no user value is present;
+* ``$SGLANG_WATCHDOG_TIMEOUT`` overrides the default;
+* a user-supplied ``--watchdog-timeout`` is honored and never doubled;
+* vllm (and atom) runs get no ``--watchdog-timeout`` at all.
+
+Both layers are exercised: the pure helpers
+(``resolve_sglang_watchdog_timeout`` / ``inject_sglang_watchdog_timeout``) and
+the materialization choke point (``materialize_config_with_envs``) that every
+benchmark path funnels through.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from inference_optimizer.orchestrator.action_executors._grid_runner import (
+    DEFAULT_SGLANG_WATCHDOG_TIMEOUT_SEC,
+    inject_sglang_watchdog_timeout,
+    resolve_sglang_watchdog_timeout,
+)
+from inference_optimizer.orchestrator.action_executors._workload_envs import (
+    materialize_config_with_envs,
+)
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_env(monkeypatch):
+    """Isolate the watchdog env knob and skip the GPU TP-clamp probe.
+
+    The materializer reads several workload knobs from the process env; clear
+    them so the host shell can't leak values into the rendered YAML, and
+    disable the TP clamp so the test never shells out to ``rocm-smi`` / probes
+    ``torch.cuda`` on a CPU-only CI box.
+    """
+    monkeypatch.delenv("SGLANG_WATCHDOG_TIMEOUT", raising=False)
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_DISABLE_TP_CLAMP", "1")
+    for key in (
+        "CONC", "ISL", "OSL", "MAX_MODEL_LEN", "TP", "RANDOM_RANGE_RATIO",
+        "ROCR_VISIBLE_DEVICES", "PRECISION", "RUN_EVAL", "FRAMEWORK",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _write_yaml(path: Path, *, framework: str = "sglang") -> None:
+    cfg: dict = {
+        "benchmark": {
+            "framework": framework,
+            "model": "/wekafs/models/Qwen-Qwen3-8B",
+            "precision": "bf16",
+            "run_mode": "local",
+            "envs": {"TP": 1, "CONC": 8, "ISL": 256, "OSL": 256},
+            "timeout_seconds": 600,
+            "profiler": {
+                "torch_profiler": {"enabled": False},
+                "system_profiler": {"enabled": False},
+                "tracelens": {"enabled": False},
+            },
+            "gpu_selection": {"auto": False},
+        }
+    }
+    with path.open("w") as f:
+        yaml.safe_dump(cfg, f)
+
+
+def _materialize_envs(
+    tmp_path: Path,
+    *,
+    framework: str = "sglang",
+    extra_server_args: str = "",
+    extra_envs: dict | None = None,
+) -> dict:
+    """Render a YAML via the production choke point and return its envs map."""
+    base = tmp_path / "base.yaml"
+    _write_yaml(base, framework=framework)
+    out = tmp_path / "out"
+    out.mkdir()
+    materialized = materialize_config_with_envs(
+        base, out,
+        extra_server_args=extra_server_args,
+        extra_envs=extra_envs,
+    )
+    cfg = yaml.safe_load(materialized.read_text())
+    return cfg["benchmark"]["envs"]
+
+
+# ---------------------------------------------------------------------------
+# resolve_sglang_watchdog_timeout
+# ---------------------------------------------------------------------------
+def test_resolve_defaults_to_1800(monkeypatch):
+    monkeypatch.delenv("SGLANG_WATCHDOG_TIMEOUT", raising=False)
+    assert DEFAULT_SGLANG_WATCHDOG_TIMEOUT_SEC == 1800
+    assert resolve_sglang_watchdog_timeout() == 1800
+
+
+def test_resolve_reads_env_override(monkeypatch):
+    monkeypatch.setenv("SGLANG_WATCHDOG_TIMEOUT", "900")
+    assert resolve_sglang_watchdog_timeout() == 900
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "abc", "1.5", "0", "-5"])
+def test_resolve_bad_value_falls_back_to_default(monkeypatch, bad):
+    monkeypatch.setenv("SGLANG_WATCHDOG_TIMEOUT", bad)
+    assert resolve_sglang_watchdog_timeout() == 1800
+
+
+# ---------------------------------------------------------------------------
+# inject_sglang_watchdog_timeout (pure helper)
+# ---------------------------------------------------------------------------
+def test_inject_appends_default_for_sglang(monkeypatch):
+    monkeypatch.delenv("SGLANG_WATCHDOG_TIMEOUT", raising=False)
+    assert (
+        inject_sglang_watchdog_timeout("--foo bar", "sglang")
+        == "--foo bar --watchdog-timeout 1800"
+    )
+
+
+def test_inject_appends_when_args_empty(monkeypatch):
+    monkeypatch.delenv("SGLANG_WATCHDOG_TIMEOUT", raising=False)
+    assert (
+        inject_sglang_watchdog_timeout("", "sglang") == "--watchdog-timeout 1800"
+    )
+    # None coerces to empty and is treated identically.
+    assert (
+        inject_sglang_watchdog_timeout(None, "sglang")
+        == "--watchdog-timeout 1800"
+    )
+
+
+def test_inject_uses_env_override(monkeypatch):
+    monkeypatch.setenv("SGLANG_WATCHDOG_TIMEOUT", "900")
+    assert (
+        inject_sglang_watchdog_timeout("", "sglang") == "--watchdog-timeout 900"
+    )
+
+
+@pytest.mark.parametrize("existing", [
+    "--watchdog-timeout 600",
+    "--watchdog-timeout=600",
+    "--foo 1 --watchdog-timeout 600 --bar 2",
+])
+def test_inject_does_not_double_user_value(existing):
+    out = inject_sglang_watchdog_timeout(existing, "sglang")
+    assert out == existing
+    assert out.count("--watchdog-timeout") == 1
+    assert "1800" not in out
+
+
+def test_inject_empty_or_unknown_framework_treated_as_sglang(monkeypatch):
+    """An empty/unknown framework routes to EXTRA_SGLANG_ARGS (the default
+    backend) everywhere else in the codebase, so the watchdog is injected
+    there too rather than silently skipped."""
+    monkeypatch.delenv("SGLANG_WATCHDOG_TIMEOUT", raising=False)
+    assert inject_sglang_watchdog_timeout("", "") == "--watchdog-timeout 1800"
+    assert inject_sglang_watchdog_timeout("", None) == "--watchdog-timeout 1800"
+
+
+@pytest.mark.parametrize("framework", ["vllm", "atom"])
+def test_inject_noop_for_non_sglang(framework):
+    assert inject_sglang_watchdog_timeout("--foo", framework) == "--foo"
+    assert inject_sglang_watchdog_timeout("", framework) == ""
+    assert "--watchdog-timeout" not in inject_sglang_watchdog_timeout(
+        "--gpu-memory-utilization 0.9", framework,
+    )
+
+
+# ---------------------------------------------------------------------------
+# materialize_config_with_envs (the production choke point)
+# ---------------------------------------------------------------------------
+def test_materialize_sglang_injects_default_watchdog(tmp_path):
+    envs = _materialize_envs(tmp_path, framework="sglang")
+    assert "--watchdog-timeout 1800" in envs["EXTRA_SGLANG_ARGS"]
+
+
+def test_materialize_sglang_respects_env_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("SGLANG_WATCHDOG_TIMEOUT", "900")
+    envs = _materialize_envs(tmp_path, framework="sglang")
+    assert "--watchdog-timeout 900" in envs["EXTRA_SGLANG_ARGS"]
+    assert "1800" not in envs["EXTRA_SGLANG_ARGS"]
+
+
+def test_materialize_sglang_does_not_double_user_watchdog(tmp_path):
+    envs = _materialize_envs(
+        tmp_path, framework="sglang",
+        extra_server_args="--watchdog-timeout 600",
+    )
+    sglang_args = envs["EXTRA_SGLANG_ARGS"]
+    assert sglang_args.count("--watchdog-timeout") == 1
+    assert "600" in sglang_args
+    assert "1800" not in sglang_args
+
+
+def test_materialize_honors_user_watchdog_via_extra_envs(tmp_path):
+    """A user can also pin the flag straight into EXTRA_SGLANG_ARGS via
+    extra_envs; the injection must still not double it."""
+    envs = _materialize_envs(
+        tmp_path, framework="sglang",
+        extra_envs={"EXTRA_SGLANG_ARGS": "--watchdog-timeout 600"},
+    )
+    sglang_args = envs["EXTRA_SGLANG_ARGS"]
+    assert sglang_args.count("--watchdog-timeout") == 1
+    assert "600" in sglang_args
+
+
+def test_materialize_sglang_preserves_existing_args(tmp_path):
+    """Injection appends; it must not clobber a user-supplied flag such as
+    ``--context-length`` (the short-context pin must survive)."""
+    envs = _materialize_envs(
+        tmp_path, framework="sglang",
+        extra_server_args="--context-length 6144",
+    )
+    sglang_args = envs["EXTRA_SGLANG_ARGS"]
+    assert "--context-length 6144" in sglang_args
+    assert "--watchdog-timeout 1800" in sglang_args
+
+
+def test_materialize_vllm_does_not_inject_watchdog(tmp_path):
+    envs = _materialize_envs(tmp_path, framework="vllm")
+    # No sglang env should be created for a vllm run, and no watchdog flag
+    # should appear in any env value.
+    assert "EXTRA_SGLANG_ARGS" not in envs
+    assert "--watchdog-timeout" not in envs.get("EXTRA_VLLM_ARGS", "")

--- a/kernel-agent/scripts/install.sh
+++ b/kernel-agent/scripts/install.sh
@@ -35,7 +35,14 @@ export PATH="/opt/venv/bin:$PATH"
 KERNEL_AGENT_ROOT="${KERNEL_AGENT_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
 HYPERLOOM_KERNEL_AGENT_ROOT="${HYPERLOOM_KERNEL_AGENT_ROOT:-${KERNEL_AGENT_ROOT}}"
+# Capture whether USER_DATA_PATH was provided BEFORE applying the default so we
+# can warn loudly on the silent fallback. ${VAR:+1} is empty when VAR is unset
+# or empty, which is exactly the case the :- default below would absorb.
+_user_data_was_set="${USER_DATA_PATH:+1}"
 USER_DATA_PATH="${USER_DATA_PATH:-/workspace/hyperloom}"
+if [ -z "${_user_data_was_set}" ]; then
+  echo "[install WARN] USER_DATA_PATH not set; defaulting to /workspace/hyperloom. Set USER_DATA_PATH to persist artifacts under your data root." >&2
+fi
 HYPERLOOM_RUNTIME_DIR="${HYPERLOOM_RUNTIME_DIR:-${USER_DATA_PATH}/runtime}"
 KERNEL_AGENT_ENV="${KERNEL_AGENT_ENV:-${HYPERLOOM_RUNTIME_DIR}/kernel-agent.env.sh}"
 HYPERLOOM_ROOT="${HYPERLOOM_ROOT:-${HYPERLOOM_RUNTIME_DIR}/source-mirrors}"
@@ -338,6 +345,38 @@ run() {
   log "$*"
   if [ "$DRY_RUN" -eq 0 ] && [ "$CHECK_ONLY" -eq 0 ]; then
     "$@"
+  fi
+}
+
+# Serialize concurrent installs that share one $USER_DATA_PATH. Installs
+# pointed at the same data root also share $HYPERLOOM_ROOT (=
+# $HYPERLOOM_RUNTIME_DIR/source-mirrors): the GEAK / OOB / TraceLens
+# checkouts cloned/mirrored below. With no lock, two installs race and
+# corrupt each other's half-cloned trees. We hold an flock on
+# $HYPERLOOM_RUNTIME_DIR/.install.lock via fd 9 from the first
+# mirror-mutating step until this process exits (fd closes on exit), so it
+# guards every clone/mirror below and releases automatically at the end.
+# Skipped under --check-only / --dry-run (introspection only, no mutation).
+# When inference_optimizer's installer already holds the lock it exports
+# HYPERLOOM_INSTALL_LOCK_HELD=1; we honour that and do not re-acquire, which
+# would deadlock on a second open file description for the same path.
+acquire_install_lock() {
+  if [ "$CHECK_ONLY" -eq 1 ] || [ "$DRY_RUN" -eq 1 ]; then
+    return 0
+  fi
+  if [ "${HYPERLOOM_INSTALL_LOCK_HELD:-0}" = "1" ]; then
+    log "install lock already held by parent installer; not re-locking"
+    return 0
+  fi
+  mkdir -p "${HYPERLOOM_RUNTIME_DIR}"
+  exec 9>"${HYPERLOOM_RUNTIME_DIR}/.install.lock"
+  if command -v flock >/dev/null 2>&1; then
+    log "waiting for install lock: ${HYPERLOOM_RUNTIME_DIR}/.install.lock"
+    flock 9
+    log "acquired install lock"
+    export HYPERLOOM_INSTALL_LOCK_HELD=1
+  else
+    warn "flock not available; concurrent installs may race on source-mirrors"
   fi
 }
 
@@ -1279,6 +1318,10 @@ main() {
   ensure_moreutils
   ensure_ray
   ensure_ray_started
+  # Hold the install lock for the whole mirror-mutating region (TraceLens /
+  # GEAK / OOB clones + mirrors under $HYPERLOOM_ROOT). System-package steps
+  # above (apt/pip) do not touch source-mirrors, so they stay outside the lock.
+  acquire_install_lock
   ensure_tracelens
 
   # Always install everything; ensure_oob also calls ensure_llm_auth_files.

--- a/kernel-agent/tools/_paths.py
+++ b/kernel-agent/tools/_paths.py
@@ -1,0 +1,69 @@
+"""Workspace-root resolver for the standalone kernel-agent tools.
+
+The tools in this directory (``kernel_optimization.py``,
+``tracelens_analysis.py``, ``parallel_e2e_runner.py``) run as standalone
+scripts with ``sys.path`` injection of the tools dir and therefore
+CANNOT ``import inference_optimizer.paths``. This module mirrors the
+``workspace_root()`` semantics of that package using only the standard
+library so every kernel-agent artefact lands under ``$USER_DATA_PATH``
+just like the orchestrator's.
+
+Contract (kept in lock-step with
+``inference_optimizer/paths.py::workspace_root``):
+
+* ``$USER_DATA_PATH`` set/non-empty  -> return it verbatim; NEVER the
+  ``/workspace/hyperloom`` default.
+* ``$USER_DATA_PATH`` unset/empty     -> emit ONE loud ``logging.warning``
+  (process-wide, guarded) and return ``DEFAULT_WORKSPACE_ROOT`` so a
+  misconfigured launcher is visible instead of silently writing to the
+  pod-local default.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+# Single source of the fallback literal for the kernel-agent tools. Kept
+# byte-for-byte identical to
+# ``inference_optimizer/paths.py::DEFAULT_SESSION_DIR`` so a bare-image run
+# without ``$USER_DATA_PATH`` lands in the same place the orchestrator does.
+DEFAULT_WORKSPACE_ROOT = "/workspace/hyperloom"
+ENV_USER_DATA_PATH = "USER_DATA_PATH"
+
+log = logging.getLogger(__name__)
+
+# One-shot guard: workspace_root() is called from argparse defaults and
+# hot output-path helpers, so we only want the misconfiguration warning to
+# fire once per process.
+_WARNED_NO_USER_DATA = False
+
+
+def workspace_root() -> str:
+    """Return ``$USER_DATA_PATH`` if set, else ``DEFAULT_WORKSPACE_ROOT``.
+
+    Mirrors ``inference_optimizer.paths.workspace_root()`` for the
+    standalone kernel-agent tools. Emits exactly one ``logging.warning``
+    when ``$USER_DATA_PATH`` is unset/empty so an operator immediately
+    sees that artefacts are going to the pod-local default rather than
+    their chosen workspace root.
+    """
+    global _WARNED_NO_USER_DATA
+    user_data = os.environ.get(ENV_USER_DATA_PATH)
+    if user_data:
+        return user_data
+    if not _WARNED_NO_USER_DATA:
+        _WARNED_NO_USER_DATA = True
+        log.warning(
+            "%s is not set; falling back to %s. kernel-agent tool outputs "
+            "will be written there, NOT to an operator-chosen location. "
+            "Export %s to the intended workspace root before launching to "
+            "avoid silently writing to the pod-local default.",
+            ENV_USER_DATA_PATH,
+            DEFAULT_WORKSPACE_ROOT,
+            ENV_USER_DATA_PATH,
+        )
+    return DEFAULT_WORKSPACE_ROOT
+
+
+__all__ = ["DEFAULT_WORKSPACE_ROOT", "ENV_USER_DATA_PATH", "workspace_root"]

--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -23,6 +23,7 @@ from typing import Any
 # `parallel_e2e_runner` decision consistent here.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _collective_names import kernel_name_implies_multigpu  # noqa: E402
+from _paths import workspace_root  # noqa: E402
 sys.path.pop(0)
 
 
@@ -1547,8 +1548,12 @@ def _kernel_agent_root() -> Path:
     which keeps cross-task GEAK/OOB artefacts keyed by kernel_id).
     Legacy default was ``$WORKSPACE_PATH/kernel-agent``; the env was
     removed during the all-artefacts-under-USER_DATA_PATH migration.
+
+    Routes through :func:`_paths.workspace_root` so an unset
+    ``$USER_DATA_PATH`` is warned about loudly (once) instead of
+    silently falling back to ``/workspace/hyperloom``.
     """
-    return Path(os.environ.get("USER_DATA_PATH", "/workspace/hyperloom")) / "kernel-agent"
+    return Path(workspace_root()) / "kernel-agent"
 
 
 def _geak_output_dir(session_id: str, prompt_file: Path) -> Path:
@@ -2877,7 +2882,7 @@ def main() -> int:
     parser.add_argument("--session-id", default="")
     parser.add_argument(
         "--workspace-path",
-        default=os.environ.get("USER_DATA_PATH", "/workspace/hyperloom"),
+        default=workspace_root(),
         help=(
             "Root the tool writes under (output lands at "
             "<workspace_path>/kernel-agent/runs/<session_id>/...). "

--- a/kernel-agent/tools/parallel_e2e_runner.py
+++ b/kernel-agent/tools/parallel_e2e_runner.py
@@ -44,6 +44,7 @@ OPT_TOOL = ROOT / "tools" / "kernel_optimization.py"
 # tools dir.
 sys.path.insert(0, str(ROOT / "tools"))
 from _collective_names import kernel_name_implies_multigpu  # noqa: E402
+from _paths import workspace_root  # noqa: E402
 sys.path.pop(0)
 
 
@@ -278,7 +279,7 @@ def main() -> int:
     parser.add_argument("--model-path", default="/wekafs/models/Qwen3-30B-A3B")
     parser.add_argument(
         "--workspace-path",
-        default=os.environ.get("USER_DATA_PATH", "/workspace/hyperloom"),
+        default=workspace_root(),
         help="Root the tool writes under; defaults to $USER_DATA_PATH.",
     )
     parser.add_argument("--session-id", default=f"qwen3-30b-{int(time.time())}")

--- a/kernel-agent/tools/test_paths.py
+++ b/kernel-agent/tools/test_paths.py
@@ -1,0 +1,38 @@
+"""Tests for standalone kernel-agent path resolution helpers."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+from pathlib import Path
+
+
+TOOLS_DIR = Path(__file__).resolve().parent
+if str(TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOLS_DIR))
+
+
+def _reload_paths():
+    import _paths
+
+    return importlib.reload(_paths)
+
+
+def test_workspace_root_returns_user_data_path_when_set(monkeypatch, tmp_path):
+    monkeypatch.setenv("USER_DATA_PATH", str(tmp_path))
+    paths = _reload_paths()
+
+    assert paths.workspace_root() == str(tmp_path)
+
+
+def test_workspace_root_warns_once_when_unset(monkeypatch, caplog):
+    monkeypatch.delenv("USER_DATA_PATH", raising=False)
+    paths = _reload_paths()
+
+    with caplog.at_level(logging.WARNING, logger="_paths"):
+        assert paths.workspace_root() == "/workspace/hyperloom"
+        assert paths.workspace_root() == "/workspace/hyperloom"
+
+    warnings = [r for r in caplog.records if "USER_DATA_PATH" in r.message]
+    assert len(warnings) == 1

--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -33,6 +33,12 @@ from tracelens_skill_runner import (
     run_tracelens_skill,
 )
 
+# Standalone-tool workspace-root resolver (cannot import
+# inference_optimizer.paths; see _paths.py docstring). Used only for the
+# final fallback in _default_workspace_path() so the "USER_DATA_PATH unset"
+# warning fires instead of a silent /workspace/hyperloom default.
+from _paths import workspace_root
+
 
 HIGH_IDLE_PCT_THRESHOLD_DEFAULT = 80.0
 HIGH_IDLE_PCT_THRESHOLD_ENV = "HYPERLOOM_TRACELENS_IDLE_PCT_THRESHOLD"
@@ -2504,10 +2510,12 @@ def _default_workspace_path() -> str:
        ``/workspace``). Kept as a second-tier fallback so existing
        launchers / CI / parallel_e2e_runner that already export it
        continue to work without changes.
-    3. ``/workspace/hyperloom`` — the same hard-coded default as
-       ``inference_optimizer/paths.py::DEFAULT_SESSION_DIR``, so a
+    3. ``_paths.workspace_root()`` — the final fallback. It returns the
+       same ``/workspace/hyperloom`` default as
+       ``inference_optimizer/paths.py::DEFAULT_SESSION_DIR`` (so a
        bare-image run without either env variable lands in the same
-       place the orchestrator does.
+       place the orchestrator does) BUT emits a one-shot loud warning so
+       the missing ``$USER_DATA_PATH`` is never silent.
 
     Note: GEAK / OOB tooling (``kernel_optimization.py``, the auth
     proxy, ray_runtime, install.sh) still defaults to the legacy
@@ -2518,11 +2526,16 @@ def _default_workspace_path() -> str:
     ``test_tracelens_csv.py``) are unaffected — they pass
     ``--workspace-path`` explicitly.
     """
-    return (
-        os.environ.get("USER_DATA_PATH")
-        or os.environ.get("WORKSPACE_PATH")
-        or "/workspace/hyperloom"
-    )
+    user_data = os.environ.get("USER_DATA_PATH")
+    if user_data:
+        return user_data
+    workspace = os.environ.get("WORKSPACE_PATH")
+    if workspace:
+        return workspace
+    # Neither env set: route through the shared helper so the one-shot
+    # "USER_DATA_PATH unset" warning fires and we still return the same
+    # /workspace/hyperloom default the orchestrator uses.
+    return workspace_root()
 
 
 def main() -> int:

--- a/optimizer_runs/robustness_monitor.sh.example
+++ b/optimizer_runs/robustness_monitor.sh.example
@@ -18,11 +18,20 @@
 #                                            after MAX_HOURS + 1 buffer)
 #   TARGET_GAIN                        10    --target-gain forwarded to
 #                                            ``inference_optimizer optimize --resume``
-#   INFERENCE_OPTIMIZER_SESSION_DIR    /workspace/hyperloom
-#                                            session-dir holding state.json
+#   INFERENCE_OPTIMIZER_SESSION_DIR    (unset) session-dir holding state.json;
+#                                            when set it wins outright
+#   LAUNCH_INFO_FILE                   (unset) launch-info JSON written by
+#                                            ``optimize --launch-info-file``; its
+#                                            ``.session_dir`` is used when
+#                                            INFERENCE_OPTIMIZER_SESSION_DIR is unset
 #   MAGPIE_PYTHON                      /opt/venv/bin/python
 #                                            interpreter forwarded to the
 #                                            resume launch
+#
+# Session-dir resolution order (state.json holder; never a timestamp guess):
+#   1. $INFERENCE_OPTIMIZER_SESSION_DIR  (explicit; wins)
+#   2. .session_dir from $LAUNCH_INFO_FILE  (authoritative launch-info JSON)
+#   3. fail loudly; never guess or fall back to a timestamp/default path
 #
 # Invocation pattern (see ``inference_optimizer/SKILL.md`` §"Robustness
 # Monitor for Long Runs"):
@@ -53,7 +62,17 @@ set -u
 : "${REPO_ROOT:?error: REPO_ROOT must be the Hyperloom checkout root (resume logs land in \$REPO_ROOT/optimizer_runs/)}"
 
 export MAGPIE_PYTHON="${MAGPIE_PYTHON:-/opt/venv/bin/python}"
-session_dir="${INFERENCE_OPTIMIZER_SESSION_DIR:-/workspace/hyperloom}"
+
+# Resolve the session dir holding state.json (see resolution order above).
+# The launch-info JSON is the authoritative source; never guess by timestamp.
+session_dir="${INFERENCE_OPTIMIZER_SESSION_DIR:-}"
+if [ -z "$session_dir" ] && [ -n "${LAUNCH_INFO_FILE:-}" ] && [ -f "${LAUNCH_INFO_FILE}" ]; then
+  session_dir="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("session_dir") or "")' "${LAUNCH_INFO_FILE}" 2>/dev/null || true)"
+fi
+if [ -z "$session_dir" ]; then
+  echo "ERROR: session dir is unknown. Set INFERENCE_OPTIMIZER_SESSION_DIR or LAUNCH_INFO_FILE; refusing to fall back to /workspace/hyperloom." >&2
+  exit 2
+fi
 deadline=$(( $(date +%s) + (${MAX_HOURS:-24} + 1) * 3600 ))
 
 read_stop() {


### PR DESCRIPTION
## Summary
Fixes for recurring baseline/session failures on MI300X (root-caused from many baseline_failed runs).

- **Harden USER_DATA_PATH path resolution**: collapse scattered `os.environ.get("USER_DATA_PATH", "/workspace/hyperloom")` onto `paths.workspace_root()` (loud one-shot warning only when unset); kernel-agent standalone tools get a local `_paths.py` helper; GEMM-tuning wrapper honors `$INFERENCEX_PATH` instead of hardcoding `/hyperloom/InferenceX`; CI helpers prefer `USER_DATA_PATH`.
- **manifest dependency-escape warning**: warn only when `MAGPIE_DIR`/`INFERENCEX_PATH` escape `USER_DATA_PATH` into a *pod-local* root (`/workspace`, `/tmp`, `/root`) — the real "artefacts vanish on pod recycle" case; persistent WekaFS shared checkouts do not warn.
- **Serialize installer source-mirror writes**: `flock` on `$HYPERLOOM_RUNTIME_DIR/.install.lock` in both `install.sh` entrypoints (with `HYPERLOOM_INSTALL_LOCK_HELD` to avoid the inference_optimizer->kernel-agent self-deadlock); loud `USER_DATA_PATH`-unset warning across 4 scripts.
- **Inject sglang watchdog timeout**: single choke point in `materialize_config_with_envs` adds `--watchdog-timeout 1800` (configurable via `SGLANG_WATCHDOG_TIMEOUT`) for sglang only, never doubling a user value, never touching `--context-length`. Prevents the first-request aiter `mha_batch_prefill` JIT from tripping the 300s scheduler watchdog -> SIGQUIT -> baseline_failed.
- **Fail fast when model context is too small**: do **not** stretch context via `--context-length`; instead read `config.json` max position length and, when `maxpos < ISL + OSL + headroom` (default headroom 512, env `HYPERLOOM_CONTEXT_HEADROOM_TOKENS`), persist `stop_reason=model_context_window_too_small` plus `stop_detail` to `state.json` and `reports/final.{json,md}`, then exit non-zero. This turns stale 2048-ctx checkpoints into a clear terminal reason instead of hundreds of 400s.
- **Self-heal stale MAGPIE_PYTHON**: validate `$MAGPIE_PYTHON` can `import Magpie`; if not (install.sh bakes it in before Magpie is pip-installed, e.g. `/usr/bin/python3`), ignore it and auto-detect. Avoids ModuleNotFoundError on every benchmark.
- **Use launch-info for session discovery**: SKILL/launcher and `robustness_monitor.sh.example` read `session_dir` from `--launch-info-file` JSON (or the `HYPERLOOM_LAUNCH` sentinel); removed the unreliable `ls ... *T*Z | tail -1` guess; monitor fails loudly instead of falling back to `/workspace/hyperloom`.
- **Show stop detail in final.md**: reports now include `Stop detail` when present, so context-window exits explain the exact maxpos/required-token mismatch in the human-readable report.

## Test plan
- [x] Focused pytest suite (path guard / install / watchdog / baseline params / session layout / kb root / startup robustness / magpie-python / context-window / kernel-agent _paths) -> 167 passed
- [x] bash -n on all install/local_setup/preflight/monitor scripts; git diff --check clean
- [x] Local 1h smoke run (Llama-3.2-3B, USER_DATA_PATH=/wekafs/xiaofei/sessions): all artifacts under USER_DATA_PATH, zero writes to /workspace/hyperloom; launch-info session discovery OK; server_args watchdog_timeout=1800.0; MAGPIE_PYTHON self-heal fired; manifest guard did not false-warn on the WekaFS InferenceX checkout; baseline succeeded at 6800.9 tok/s/GPU and the 1h run ended with expected time_exhausted.

## Notes / out of scope
- Lower stack / image: aiter cold JIT cost and `hipcc` mid-build crash during the optimization phase (watchdog mitigates baseline-warmup only).
- This PR intentionally does **not** inject `--context-length`. Small/stale context models fail fast with `model_context_window_too_small` instead of forcing RoPE extrapolation or risking CUDA errors on learned-position models.

Made with [Cursor](https://cursor.com)
