### PR TITLE
fix(tracelens): reject vendor-backend + torch-dispatch-shim kernels in patchability gate

### DIFF
--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -832,6 +832,48 @@ _NON_PATCHABLE_NAME_MARKERS: tuple[str, ...] = (
     "aten::copy",
 )
 
+# Vendor BLAS / closed-source compute backends. A candidate whose runtime
+# implementation is one of these has *no rewritable source* regardless of
+# which Python file the symbol resolves to: the device body lives in a
+# precompiled vendor binary (Tensile/hipBLASLt/rocBLAS/CK kernels), and the
+# attributed ``source_file`` is only the framework dispatch site. Matched
+# against the candidate's ``library`` field (case-insensitive).
+_VENDOR_BACKEND_LIBRARIES: frozenset[str] = frozenset(
+    {
+        "tensile",
+        "hipblas",
+        "hipblaslt",
+        "rocblas",
+        "rocblaslt",
+        "ck",
+        "composable_kernel",
+        "ck_kernels",
+        "miopen",
+    }
+)
+
+# torch ``__torch_function__`` / ``__torch_dispatch__`` interception shims.
+# These files intercept a tensor op and forward it to a vendor backend
+# (e.g. vLLM ``parameter.py`` forwards ``rocm_unquantized_gemm`` to Tensile);
+# the file itself contains no rewritable device kernel, so a symbol that
+# resolves here is a dispatch stub, not an editable kernel. Matched as a
+# POSIX path suffix against the resolved ``source_file``.
+_TORCH_DISPATCH_SHIM_SOURCES: tuple[str, ...] = (
+    "vllm/model_executor/parameter.py",
+)
+
+
+def is_torch_dispatch_shim_source(source_file: str) -> bool:
+    """True when ``source_file`` is a known torch-dispatch interception shim.
+
+    These ``__torch_function__`` / ``__torch_dispatch__`` files forward a
+    tensor op to a vendor backend and hold no rewritable device kernel, so a
+    symbol attributed here must be treated as a non-reusable dispatch stub
+    (same handling as ``@compile_ops`` JIT stubs in ``aiter/ops/moe_op.py``).
+    """
+    posix = str(source_file or "").replace("\\", "/")
+    return any(posix.endswith(suffix) for suffix in _TORCH_DISPATCH_SHIM_SOURCES)
+
 
 def is_runtime_generated_kernel(name: str, source_file: str) -> bool:
     """Return True for torch.compile / Inductor / cache-generated kernels.
@@ -877,13 +919,22 @@ def classify_patchability(candidate: dict[str, Any]) -> tuple[bool, str]:
         return False, "vendor binary (no rewritable source)"
     if candidate.get("vendor_dispatch_wrapper"):
         return False, f"vendor dispatch wrapper at {source_file}"
+    if is_torch_dispatch_shim_source(source_file):
+        return False, (
+            f"torch dispatch shim (no rewritable kernel body): {source_file}"
+        )
     for marker in _NON_PATCHABLE_NAME_MARKERS:
         if marker in lower_name:
             return False, (
                 f"non-patchable kernel name marker '{marker}' in {name!r}"
             )
+    library = str(candidate.get("library") or "").strip().lower()
+    if library in _VENDOR_BACKEND_LIBRARIES:
+        return False, (
+            f"vendor backend library {candidate.get('library')!r} "
+            "(precompiled binary, no rewritable source)"
+        )
     if name.startswith("aten::"):
-        library = str(candidate.get("library") or "").strip().lower()
         if not library or library in {"tensile", "pytorch native"}:
             return False, (
                 f"PyTorch native op {name!r} backed by "


### PR DESCRIPTION
Problem: classify_patchability only consulted the library field for aten::-prefixed names, so vllm::rocm_unquantized_gemm (library Tensile, source vllm/model_executor/parameter.py __torch_function__ shim) was wrongly marked reusable_native_kernel=True -> GEAK gets a non-rewritable target and wastes a REVERT. Evidence: real kernel_candidates.json k005-k010. Fix: generalize the vendor-backend library gate (Tensile/hipBLASLt/rocBLAS/CK/MIOpen) to all names and add torch __torch_function__/__torch_dispatch__ shim detection, analogous to the existing @compile_ops/moe_op.py handling. Applied cleanly; compiles, lint-clean.

Made with [Cursor](https://cursor.com)