### PR TITLE
Run stability follow-ups: stop_reason vocab, manifest resolve guard, monitor launch-info wait

### DIFF
--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -1149,8 +1149,9 @@ def _preflight_context_window(args: argparse.Namespace, session_dir: Path) -> bo
         f"(ISL={isl} + OSL={osl} + headroom={headroom}). The workload exceeds "
         f"the model context window; every request would 400. Refusing to run "
         f"(no --context-length override by policy). Lower ISL/OSL for this "
-        f"model, or raise {_CONTEXT_HEADROOM_ENV} if the headroom is too "
-        f"conservative."
+        f"model, or lower {_CONTEXT_HEADROOM_ENV} if the headroom is too "
+        f"conservative (it is added to `required`, so raising it makes "
+        f"admission stricter, not looser)."
     )
     # Persist the stop reason so CI / the robustness monitor read it from
     # state.json + reports/final.json instead of grepping the run log.
@@ -1163,7 +1164,11 @@ def _preflight_context_window(args: argparse.Namespace, session_dir: Path) -> bo
         from .session_paths import reports_dir
 
         state = SharedState.load_or_init(session_dir)
-        state.stop_reason = "model_context_window_too_small"
+        # Use the validated writer so the vocab-closed invariant (Inv-8.3)
+        # holds: the term is registered in STOP_REASON_VOCAB, so this neither
+        # maps to 'unknown' (lenient) nor raises (strict), and the robustness
+        # monitor's vocab-based terminal check recognises the fail-fast.
+        state.set_stop_reason("model_context_window_too_small")
         state.closing_phase = True
         state.save(session_dir)
         summary = _build_summary_dict(state, {}, [], external_baseline=None)

--- a/inference_optimizer/manifest.py
+++ b/inference_optimizer/manifest.py
@@ -212,7 +212,11 @@ def _path_is_relative_to(path: Path, root: Path) -> bool:
     try:
         path.resolve(strict=False).relative_to(root.resolve(strict=False))
         return True
-    except (OSError, ValueError):
+    except (OSError, ValueError, RuntimeError):
+        # RuntimeError: CPython's resolve() raises "Symlink loop from ..." on a
+        # self-referential symlink (ELOOP); OSError covers broken mounts. Treat
+        # either as "not provably inside root" rather than letting it escape and
+        # crash manifest generation.
         return False
 
 
@@ -242,7 +246,14 @@ def _warn_if_dependency_escapes_user_data(env_var: str, raw: str) -> None:
     dep_path = Path(raw)
     if _path_is_relative_to(dep_path, Path(user_data)):
         return
-    resolved = str(dep_path.resolve(strict=False))
+    try:
+        resolved = str(dep_path.resolve(strict=False))
+    except (OSError, RuntimeError):
+        # Provenance capture must never raise out (see _describe_dep): an
+        # unresolvable dep path (broken mount -> OSError, symlink loop ->
+        # RuntimeError) cannot be proven pod-local, so skip the warning
+        # instead of crashing manifest writing.
+        return
     is_pod_local = any(
         resolved == p or resolved.startswith(p + "/")
         for p in _POD_LOCAL_PREFIXES

--- a/inference_optimizer/orchestrator/phase_state.py
+++ b/inference_optimizer/orchestrator/phase_state.py
@@ -270,6 +270,11 @@ STOP_REASON_VOCAB: frozenset[str] = frozenset({
     "framework_pr_phase_done",
     "framework_pr_plateau",
     "framework_pr_force_exit_low_budget",
+
+    # Pre-run context-window preflight (``cli._preflight_context_window``):
+    # the model's max_position_embeddings cannot hold ISL+OSL+headroom, so we
+    # fail fast before booting a server that would 400 every request.
+    "model_context_window_too_small",
 })
 
 

--- a/inference_optimizer/tests/test_context_window_preflight.py
+++ b/inference_optimizer/tests/test_context_window_preflight.py
@@ -167,3 +167,68 @@ def test_max_model_len_fallback_when_maxpos_unknown(tmp_path):
         cli._resolve_max_model_len(1024, 1024, str(model))
         == 1024 + 1024 + cli._MAX_MODEL_LEN_HEADROOM
     )
+
+
+# ---------------------------------------------------------------------------
+# follow-up #1: the preflight stop_reason must be a canonical
+# STOP_REASON_VOCAB term written through the validated set_stop_reason()
+# writer — not a raw off-vocab attribute assignment. Otherwise the robustness
+# monitor's vocab-based terminal check (and any set_stop_reason round-trip)
+# treats the context-window fail-fast as a non-terminal / 'unknown' stop.
+# ---------------------------------------------------------------------------
+def test_context_window_stop_reason_is_canonical_vocab():
+    from inference_optimizer.orchestrator.phase_state import (
+        STOP_REASON_VOCAB,
+        is_valid_stop_reason,
+    )
+
+    assert "model_context_window_too_small" in STOP_REASON_VOCAB
+    assert is_valid_stop_reason("model_context_window_too_small")
+
+
+def test_preflight_persists_stop_reason_under_strict_env(tmp_path, monkeypatch):
+    """Under ``INFERENCE_OPTIMIZER_STRICT_STOP_REASON=1`` the preflight must
+    still persist the canonical stop_reason. This proves the writer goes
+    through the validated ``set_stop_reason()`` path AND that the term is
+    registered in the vocab — an off-vocab term would raise in strict mode and
+    abort the report, leaving no final.json/state.json."""
+    monkeypatch.delenv(cli._CONTEXT_HEADROOM_ENV, raising=False)
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_STRICT_STOP_REASON", "1")
+    model = tmp_path / "ctx2048strict"
+    _write_config(model, model_type="llama", max_position_embeddings=2048)
+    sd = tmp_path / "session_strict"
+    _seed_state(sd, monkeypatch)
+
+    assert cli._preflight_context_window(_args(str(model)), sd) is True
+    state = json.loads((sd / "state.json").read_text())
+    assert state["stop_reason"] == "model_context_window_too_small"
+    final = json.loads((sd / "reports" / "final.json").read_text())
+    assert final["stop_reason"] == "model_context_window_too_small"
+
+
+def test_monitor_offline_vocab_includes_context_window():
+    """The robustness monitor's offline STOP_REASON_VOCAB fallback (used when
+    phase_state is not importable) must list the preflight stop_reason so an
+    offline monitor still treats a context-window fail-fast as terminal."""
+    import inference_optimizer
+
+    repo_root = Path(inference_optimizer.__file__).resolve().parents[1]
+    monitor = repo_root / "optimizer_runs" / "robustness_monitor.sh.example"
+    text = monitor.read_text(encoding="utf-8")
+    assert "model_context_window_too_small" in text
+
+
+def test_preflight_reason_suggests_lowering_headroom(tmp_path, monkeypatch):
+    """follow-up #4: the fail-fast advice must tell operators to LOWER the
+    headroom env (which shrinks `required`), not raise it — raising makes
+    admission stricter, the opposite of relaxing a too-conservative gate."""
+    monkeypatch.delenv(cli._CONTEXT_HEADROOM_ENV, raising=False)
+    model = tmp_path / "ctx2048reason"
+    _write_config(model, max_position_embeddings=2048)
+    sd = tmp_path / "session_reason"
+    _seed_state(sd, monkeypatch)
+
+    assert cli._preflight_context_window(_args(str(model)), sd) is True
+    detail = json.loads((sd / "reports" / "final.json").read_text())["stop_detail"]
+    assert f"lower {cli._CONTEXT_HEADROOM_ENV}".lower() in detail.lower()
+    assert f"raise {cli._CONTEXT_HEADROOM_ENV}".lower() not in detail.lower()

--- a/inference_optimizer/tests/test_manifest_units.py
+++ b/inference_optimizer/tests/test_manifest_units.py
@@ -186,3 +186,37 @@ class TestWriteAndLoad:
     def test_load_raises_when_missing(self, tmp_path):
         with pytest.raises(FileNotFoundError):
             mf.load_manifest(tmp_path)
+
+
+class TestDependencyEscapeGuard:
+    """``_describe_dep`` must never raise out (provenance-capture contract),
+    even when the dependency path makes ``Path.resolve`` raise.
+
+    On CPython 3.10 ``Path.resolve(strict=False)`` raises
+    ``RuntimeError('Symlink loop ...')`` on a self-referential symlink. The
+    escape-guard's ``resolve`` calls only caught ``(OSError, ValueError)``, so
+    such a dep path bubbled the RuntimeError out of manifest generation.
+    """
+
+    def test_describe_dep_survives_symlink_loop(self, tmp_path, monkeypatch):
+        udp = tmp_path / "udp"
+        udp.mkdir()
+        monkeypatch.setenv(mf._paths.ENV_USER_DATA_PATH, str(udp))
+        # Real a -> b -> a loop; resolve(strict=False) raises RuntimeError.
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.symlink_to(b)
+        b.symlink_to(a)
+        monkeypatch.setenv("HYPERLOOM_TEST_DEP_LOOP", str(a))
+
+        out = mf._describe_dep("HYPERLOOM_TEST_DEP_LOOP")  # must not raise
+
+        assert out == {"path": str(a), "commit": "", "remote": ""}
+
+    def test_path_is_relative_to_handles_symlink_loop(self, tmp_path):
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.symlink_to(b)
+        b.symlink_to(a)
+        # Unresolvable path must degrade to False, not raise.
+        assert mf._path_is_relative_to(a, tmp_path) is False

--- a/inference_optimizer/tests/test_robustness_monitor.py
+++ b/inference_optimizer/tests/test_robustness_monitor.py
@@ -147,3 +147,46 @@ def test_monitor_times_out_when_launch_info_never_appears(tmp_path):
     # Waited at least most of the window before giving up.
     assert elapsed >= 2, f"should have polled the wait window, took {elapsed:.1f}s"
     assert "session dir is unknown" in proc.stderr
+
+
+def test_monitor_tolerates_non_integer_wait_sec(tmp_path):
+    """A malformed LAUNCH_INFO_WAIT_SEC must degrade to the default wait, not
+    emit a bash arithmetic error and skip the bounded poll. Pre-fix, an invalid
+    token ('60x') makes the ``$(( ... ))`` deadline computation error out under
+    ``set -u``, so the monitor never polls the real window and bails (exit 2)
+    with a confusing 'within 60xs' message before the delayed launch-info
+    appears. Post-fix it warns, falls back to the default window, picks up the
+    launch-info, and exits 0."""
+    sess = tmp_path / "sess"
+    (sess / "reports").mkdir(parents=True)
+    (sess / "reports" / "final.md").write_text("done\n", encoding="utf-8")
+
+    launch = tmp_path / "launch.json"
+    pidfile = tmp_path / "pid"
+    pidfile.write_text("999999\n", encoding="utf-8")
+
+    env = _clean_env()
+    env.update(
+        {
+            "PID_FILE": str(pidfile),
+            "REPO_ROOT": str(tmp_path),
+            "LAUNCH_INFO_FILE": str(launch),
+            "LAUNCH_INFO_WAIT_SEC": "60x",  # invalid arithmetic token
+            "MAX_HOURS": "1",
+        }
+    )
+
+    proc = subprocess.Popen(
+        ["bash", str(MONITOR)],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    time.sleep(1.5)
+    launch.write_text(json.dumps({"session_dir": str(sess)}), encoding="utf-8")
+    out, err = proc.communicate(timeout=30)
+
+    assert proc.returncode == 0, f"rc={proc.returncode}\nstdout={out}\nstderr={err}"
+    assert "invalid LAUNCH_INFO_WAIT_SEC" in err

--- a/inference_optimizer/tests/test_robustness_monitor.py
+++ b/inference_optimizer/tests/test_robustness_monitor.py
@@ -110,8 +110,11 @@ def test_monitor_fails_fast_when_no_session_source(tmp_path):
     elapsed = time.time() - t0
 
     assert proc.returncode == 2
-    assert elapsed < 5, f"should fail fast, took {elapsed:.1f}s"
     assert "session dir is unknown" in proc.stderr
+    # Fail-fast: with no LAUNCH_INFO_FILE we must NOT enter the bounded wait
+    # loop (default 60s). A generous bound tolerates CI process-spawn latency
+    # while still proving we never polled a wait window.
+    assert elapsed < 30, f"should fail fast (no wait loop), took {elapsed:.1f}s"
 
 
 def test_monitor_times_out_when_launch_info_never_appears(tmp_path):
@@ -190,3 +193,45 @@ def test_monitor_tolerates_non_integer_wait_sec(tmp_path):
 
     assert proc.returncode == 0, f"rc={proc.returncode}\nstdout={out}\nstderr={err}"
     assert "invalid LAUNCH_INFO_WAIT_SEC" in err
+
+
+def test_monitor_handles_leading_zero_wait_sec(tmp_path):
+    """A leading-zero LAUNCH_INFO_WAIT_SEC ('08') passes a naive ^[0-9]+$ check
+    but bash arithmetic treats it as OCTAL -> '08: value too great for base'
+    under ``set -u`` (the very crash the validation was meant to prevent). The
+    deadline computation must force base-10 so '08' means 8 seconds. We point a
+    delayed launch-info at a terminal session: post-fix the monitor polls, picks
+    it up, and exits 0 with no octal arithmetic error on stderr."""
+    sess = tmp_path / "sess"
+    (sess / "reports").mkdir(parents=True)
+    (sess / "reports" / "final.md").write_text("done\n", encoding="utf-8")
+
+    launch = tmp_path / "launch.json"
+    pidfile = tmp_path / "pid"
+    pidfile.write_text("999999\n", encoding="utf-8")
+
+    env = _clean_env()
+    env.update(
+        {
+            "PID_FILE": str(pidfile),
+            "REPO_ROOT": str(tmp_path),
+            "LAUNCH_INFO_FILE": str(launch),
+            "LAUNCH_INFO_WAIT_SEC": "08",  # valid digits, but octal-invalid in bash
+            "MAX_HOURS": "1",
+        }
+    )
+
+    proc = subprocess.Popen(
+        ["bash", str(MONITOR)],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    time.sleep(1.5)
+    launch.write_text(json.dumps({"session_dir": str(sess)}), encoding="utf-8")
+    out, err = proc.communicate(timeout=30)
+
+    assert proc.returncode == 0, f"rc={proc.returncode}\nstdout={out}\nstderr={err}"
+    assert "value too great for base" not in err

--- a/inference_optimizer/tests/test_robustness_monitor.py
+++ b/inference_optimizer/tests/test_robustness_monitor.py
@@ -1,0 +1,149 @@
+"""Tests for ``optimizer_runs/robustness_monitor.sh.example`` session-dir
+resolution.
+
+The monitor resolves the session dir holding ``state.json`` from (1) an
+explicit ``$INFERENCE_OPTIMIZER_SESSION_DIR`` or (2) the ``.session_dir`` field
+of ``$LAUNCH_INFO_FILE``, and refuses to guess a timestamp/default path. When
+the launch-info JSON is configured but not yet flushed (the monitor raced ahead
+of the optimizer's launch-info write), it must poll for a bounded window rather
+than exiting immediately.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MONITOR = REPO_ROOT / "optimizer_runs" / "robustness_monitor.sh.example"
+
+# Vars the monitor consumes; strip from the inherited env so each test is
+# hermetic and only sees what it sets explicitly.
+_MONITOR_VARS = (
+    "INFERENCE_OPTIMIZER_SESSION_DIR",
+    "LAUNCH_INFO_FILE",
+    "LAUNCH_INFO_WAIT_SEC",
+    "PID_FILE",
+    "REPO_ROOT",
+    "MAX_HOURS",
+    "MAGPIE_PYTHON",
+)
+
+
+def _clean_env() -> dict[str, str]:
+    env = os.environ.copy()
+    for var in _MONITOR_VARS:
+        env.pop(var, None)
+    return env
+
+
+def test_monitor_waits_for_delayed_launch_info(tmp_path):
+    """LAUNCH_INFO_FILE set but written only after a short delay: the monitor
+    must poll (bounded) and resolve it, then go terminal (exit 0) — not give up
+    with exit 2 before the optimizer flushed launch-info."""
+    sess = tmp_path / "sess"
+    (sess / "reports").mkdir(parents=True)
+    # Terminal marker so the first main-loop iteration exits 0 right after the
+    # session dir is resolved (keeps the test from entering the resume loop).
+    (sess / "reports" / "final.md").write_text("done\n", encoding="utf-8")
+
+    launch = tmp_path / "launch.json"
+    pidfile = tmp_path / "pid"
+    pidfile.write_text("999999\n", encoding="utf-8")
+
+    env = _clean_env()
+    env.update(
+        {
+            "PID_FILE": str(pidfile),
+            "REPO_ROOT": str(tmp_path),
+            "LAUNCH_INFO_FILE": str(launch),
+            "LAUNCH_INFO_WAIT_SEC": "15",
+            "MAX_HOURS": "1",
+        }
+    )
+
+    proc = subprocess.Popen(
+        ["bash", str(MONITOR)],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    # Monitor should be polling here, not already dead with exit 2.
+    time.sleep(1.5)
+    launch.write_text(json.dumps({"session_dir": str(sess)}), encoding="utf-8")
+    out, err = proc.communicate(timeout=30)
+
+    assert proc.returncode == 0, f"rc={proc.returncode}\nstdout={out}\nstderr={err}"
+
+
+def test_monitor_fails_fast_when_no_session_source(tmp_path):
+    """No explicit session dir AND no LAUNCH_INFO_FILE -> exit 2 immediately
+    (no wasted polling), never silently falling back to /workspace/hyperloom."""
+    pidfile = tmp_path / "pid"
+    pidfile.write_text("1\n", encoding="utf-8")
+
+    env = _clean_env()
+    env.update(
+        {
+            "PID_FILE": str(pidfile),
+            "REPO_ROOT": str(tmp_path),
+            "MAX_HOURS": "1",
+        }
+    )
+
+    t0 = time.time()
+    proc = subprocess.run(
+        ["bash", str(MONITOR)],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=30,
+    )
+    elapsed = time.time() - t0
+
+    assert proc.returncode == 2
+    assert elapsed < 5, f"should fail fast, took {elapsed:.1f}s"
+    assert "session dir is unknown" in proc.stderr
+
+
+def test_monitor_times_out_when_launch_info_never_appears(tmp_path):
+    """LAUNCH_INFO_FILE configured but the file never appears: the monitor
+    polls for the bounded window then exits 2 (does not hang forever)."""
+    launch = tmp_path / "never.json"
+    pidfile = tmp_path / "pid"
+    pidfile.write_text("1\n", encoding="utf-8")
+
+    env = _clean_env()
+    env.update(
+        {
+            "PID_FILE": str(pidfile),
+            "REPO_ROOT": str(tmp_path),
+            "LAUNCH_INFO_FILE": str(launch),
+            "LAUNCH_INFO_WAIT_SEC": "3",
+            "MAX_HOURS": "1",
+        }
+    )
+
+    t0 = time.time()
+    proc = subprocess.run(
+        ["bash", str(MONITOR)],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=30,
+    )
+    elapsed = time.time() - t0
+
+    assert proc.returncode == 2
+    # Waited at least most of the window before giving up.
+    assert elapsed >= 2, f"should have polled the wait window, took {elapsed:.1f}s"
+    assert "session dir is unknown" in proc.stderr

--- a/optimizer_runs/robustness_monitor.sh.example
+++ b/optimizer_runs/robustness_monitor.sh.example
@@ -24,13 +24,17 @@
 #                                            ``optimize --launch-info-file``; its
 #                                            ``.session_dir`` is used when
 #                                            INFERENCE_OPTIMIZER_SESSION_DIR is unset
+#   LAUNCH_INFO_WAIT_SEC               60    seconds to poll for LAUNCH_INFO_FILE
+#                                            before failing (covers the monitor
+#                                            racing ahead of the optimizer write)
 #   MAGPIE_PYTHON                      /opt/venv/bin/python
 #                                            interpreter forwarded to the
 #                                            resume launch
 #
 # Session-dir resolution order (state.json holder; never a timestamp guess):
-#   1. $INFERENCE_OPTIMIZER_SESSION_DIR  (explicit; wins)
-#   2. .session_dir from $LAUNCH_INFO_FILE  (authoritative launch-info JSON)
+#   1. $INFERENCE_OPTIMIZER_SESSION_DIR  (explicit; wins instantly)
+#   2. .session_dir from $LAUNCH_INFO_FILE  (authoritative launch-info JSON;
+#      polled for up to $LAUNCH_INFO_WAIT_SEC if not yet flushed)
 #   3. fail loudly; never guess or fall back to a timestamp/default path
 #
 # Invocation pattern (see ``inference_optimizer/SKILL.md`` §"Robustness
@@ -65,12 +69,24 @@ export MAGPIE_PYTHON="${MAGPIE_PYTHON:-/opt/venv/bin/python}"
 
 # Resolve the session dir holding state.json (see resolution order above).
 # The launch-info JSON is the authoritative source; never guess by timestamp.
+# When LAUNCH_INFO_FILE is configured but not yet flushed (the monitor raced
+# ahead of the optimizer's launch-info write), poll for a bounded window
+# instead of dying immediately. An explicit INFERENCE_OPTIMIZER_SESSION_DIR
+# resolves instantly; an unset LAUNCH_INFO_FILE fails fast (no wasted wait).
 session_dir="${INFERENCE_OPTIMIZER_SESSION_DIR:-}"
-if [ -z "$session_dir" ] && [ -n "${LAUNCH_INFO_FILE:-}" ] && [ -f "${LAUNCH_INFO_FILE}" ]; then
-  session_dir="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("session_dir") or "")' "${LAUNCH_INFO_FILE}" 2>/dev/null || true)"
+if [ -z "$session_dir" ] && [ -n "${LAUNCH_INFO_FILE:-}" ]; then
+  launch_info_deadline=$(( $(date +%s) + ${LAUNCH_INFO_WAIT_SEC:-60} ))
+  while [ -z "$session_dir" ]; do
+    if [ -f "${LAUNCH_INFO_FILE}" ]; then
+      session_dir="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("session_dir") or "")' "${LAUNCH_INFO_FILE}" 2>/dev/null || true)"
+    fi
+    [ -n "$session_dir" ] && break
+    [ "$(date +%s)" -ge "$launch_info_deadline" ] && break
+    sleep 2
+  done
 fi
 if [ -z "$session_dir" ]; then
-  echo "ERROR: session dir is unknown. Set INFERENCE_OPTIMIZER_SESSION_DIR or LAUNCH_INFO_FILE; refusing to fall back to /workspace/hyperloom." >&2
+  echo "ERROR: session dir is unknown (no INFERENCE_OPTIMIZER_SESSION_DIR; LAUNCH_INFO_FILE absent or not written within ${LAUNCH_INFO_WAIT_SEC:-60}s). Refusing to fall back to /workspace/hyperloom." >&2
   exit 2
 fi
 deadline=$(( $(date +%s) + (${MAX_HOURS:-24} + 1) * 3600 ))
@@ -116,6 +132,7 @@ except ImportError:
         "crash_threshold_exceeded", "user_stop_requested",
         "time_exhausted_during_prelude", "cortex_t0_failed",
         "cortex_drain_failed", "cortex_commit_failed",
+        "model_context_window_too_small",
     })
 
 if stop and stop in STOP_REASON_VOCAB:

--- a/optimizer_runs/robustness_monitor.sh.example
+++ b/optimizer_runs/robustness_monitor.sh.example
@@ -75,7 +75,16 @@ export MAGPIE_PYTHON="${MAGPIE_PYTHON:-/opt/venv/bin/python}"
 # resolves instantly; an unset LAUNCH_INFO_FILE fails fast (no wasted wait).
 session_dir="${INFERENCE_OPTIMIZER_SESSION_DIR:-}"
 if [ -z "$session_dir" ] && [ -n "${LAUNCH_INFO_FILE:-}" ]; then
-  launch_info_deadline=$(( $(date +%s) + ${LAUNCH_INFO_WAIT_SEC:-60} ))
+  # Validate the wait BEFORE arithmetic: a non-integer value would otherwise
+  # make the $(( ... )) below error out under ``set -u`` (e.g. "60x" ->
+  # "value too great for base"), skipping the bounded wait entirely. Degrade a
+  # malformed value to the default instead of crashing / failing early.
+  launch_info_wait_sec="${LAUNCH_INFO_WAIT_SEC:-60}"
+  if ! [[ "$launch_info_wait_sec" =~ ^[0-9]+$ ]]; then
+    echo "WARN: invalid LAUNCH_INFO_WAIT_SEC='${launch_info_wait_sec}'; using default 60s." >&2
+    launch_info_wait_sec=60
+  fi
+  launch_info_deadline=$(( $(date +%s) + launch_info_wait_sec ))
   while [ -z "$session_dir" ]; do
     if [ -f "${LAUNCH_INFO_FILE}" ]; then
       session_dir="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("session_dir") or "")' "${LAUNCH_INFO_FILE}" 2>/dev/null || true)"
@@ -86,7 +95,7 @@ if [ -z "$session_dir" ] && [ -n "${LAUNCH_INFO_FILE:-}" ]; then
   done
 fi
 if [ -z "$session_dir" ]; then
-  echo "ERROR: session dir is unknown (no INFERENCE_OPTIMIZER_SESSION_DIR; LAUNCH_INFO_FILE absent or not written within ${LAUNCH_INFO_WAIT_SEC:-60}s). Refusing to fall back to /workspace/hyperloom." >&2
+  echo "ERROR: session dir is unknown (no INFERENCE_OPTIMIZER_SESSION_DIR; LAUNCH_INFO_FILE absent or not written within ${launch_info_wait_sec:-60}s). Refusing to fall back to /workspace/hyperloom." >&2
   exit 2
 fi
 deadline=$(( $(date +%s) + (${MAX_HOURS:-24} + 1) * 3600 ))

--- a/optimizer_runs/robustness_monitor.sh.example
+++ b/optimizer_runs/robustness_monitor.sh.example
@@ -84,7 +84,9 @@ if [ -z "$session_dir" ] && [ -n "${LAUNCH_INFO_FILE:-}" ]; then
     echo "WARN: invalid LAUNCH_INFO_WAIT_SEC='${launch_info_wait_sec}'; using default 60s." >&2
     launch_info_wait_sec=60
   fi
-  launch_info_deadline=$(( $(date +%s) + launch_info_wait_sec ))
+  # Force base-10: a regex-valid but leading-zero value ("08"/"09") is parsed
+  # as octal by bash arithmetic and would error ("value too great for base").
+  launch_info_deadline=$(( $(date +%s) + 10#$launch_info_wait_sec ))
   while [ -z "$session_dir" ]; do
     if [ -f "${LAUNCH_INFO_FILE}" ]; then
       session_dir="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("session_dir") or "")' "${LAUNCH_INFO_FILE}" 2>/dev/null || true)"


### PR DESCRIPTION
## Summary

Post-merge review of #430 surfaced four edge/contract issues. Each is fixed with a reproducing test (written first, fails before / passes after).

- **stop_reason vocab contract** (`cli.py`, `phase_state.py`, `robustness_monitor.sh.example`): the context-window fail-fast wrote an off-vocab `model_context_window_too_small` via raw attribute assignment, bypassing `set_stop_reason()` / `STOP_REASON_VOCAB` (Inv-8.3). The monitor's vocab-based terminal check (and any `set_stop_reason` round-trip) mis-handled it; if `final.md` failed to write, the monitor could even loop re-resuming a fail-fast. Now registered in the vocab, written via the validated setter, and mirrored in the monitor's offline fallback.
- **manifest resolve robustness** (`manifest.py`): the dependency-escape guard's `Path.resolve(strict=False)` raises `RuntimeError("Symlink loop")` on CPython 3.10 for a self-referential symlink and escaped provenance capture, breaking the "never raise out" contract. Now caught at both resolve sites.
- **monitor launch-info race** (`robustness_monitor.sh.example`): the monitor exited 2 immediately when `LAUNCH_INFO_FILE` was set but not yet flushed (monitor racing the optimizer). Now polls a bounded window (`LAUNCH_INFO_WAIT_SEC`, default 60s); explicit session dir still resolves instantly and an unset launch-info still fails fast.
- **preflight advice direction** (`cli.py`): told operators to *raise* `HYPERLOOM_CONTEXT_HEADROOM_TOKENS` to relax a too-conservative gate, but headroom is added to `required`, so raising is stricter. Fixed to *lower*.

## Test plan
- [x] Reproducing test added per fix (verified red before fix, green after)
- [x] `test_context_window_preflight.py` + `test_manifest_units.py` + `test_robustness_monitor.py` (new) + `test_phase_state_plateau.py` pass
- [x] Full suite: 3777 passed, 1 skipped (2m10s)
- [x] `bash -n` clean on the monitor script

Made with [Cursor](https://cursor.com)