### PR TITLE
fix(integrate): invalidate aiter cpp_itfs runtime cache so good kernels aren't discarded

### DIFF
--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -2244,6 +2244,29 @@ async def integrate_handler(
     )
     ctx = RunnerContext(task=fake_task, lease=None)
 
+    # GH #458: aiter cpp_itfs / runtime-compiled kernels (e.g.
+    # paged_attention -> pa_ragged) are recompiled by the server at runtime,
+    # NOT by setup.py develop, and their runtime-cache dir name hashes
+    # params (not source) so pristine + patched collide. apply_kernel_patch
+    # already moved the stale runtime cache aside for cpp_itfs targets; as
+    # belt-and-suspenders we ALSO set AITER_REBUILD=1 for the re-baseline
+    # server so aiter wipes its runtime BUILD_DIR on import and recompiles
+    # the patched kernel. Scoped to cpp_itfs applies and ALWAYS restored, so
+    # every non-cpp_itfs integrate is byte-for-byte unaffected.
+    cpp_itfs_backup = apply_result.get("cpp_itfs_cache_backup") or {}
+    force_aiter_rebuild = bool(cpp_itfs_backup.get("is_cpp_itfs"))
+    _prev_aiter_rebuild = os.environ.get("AITER_REBUILD")
+    if force_aiter_rebuild:
+        os.environ["AITER_REBUILD"] = "1"
+
+    def _restore_aiter_rebuild_env() -> None:
+        if not force_aiter_rebuild:
+            return
+        if _prev_aiter_rebuild is None:
+            os.environ.pop("AITER_REBUILD", None)
+        else:
+            os.environ["AITER_REBUILD"] = _prev_aiter_rebuild
+
     # Multi-node: apply_kernel_patch has just fanned the new source
     # files to every pod. sglang must be FULLY restarted (not resume-
     # pathed) so it re-imports the patched modules; otherwise the
@@ -2274,6 +2297,7 @@ async def integrate_handler(
             ctx.extra = {**(getattr(ctx, "extra", None) or {}),
                          "mn_round_restarted": True}
         except ServerRestartFailed as exc:
+            _restore_aiter_rebuild_env()
             revert_result = _maybe_revert_kernel_patch(apply_result)
             return {
                 "status": "failed",
@@ -2299,6 +2323,10 @@ async def integrate_handler(
             "apply_result": apply_result,
             "revert_result": revert_result,
         }
+    finally:
+        # Restore AITER_REBUILD on every path once the re-baseline server has
+        # been launched, so the env override never leaks past this integrate.
+        _restore_aiter_rebuild_env()
 
     if not is_valid_measurement(bench_result):
         revert_result = _maybe_revert_kernel_patch(apply_result)
@@ -2312,6 +2340,41 @@ async def integrate_handler(
             "apply_result": apply_result,
             "revert_result": revert_result,
         }
+
+    # GH #458 (point 2): don't score a stale binary. For cpp_itfs targets the
+    # served kernel is runtime-compiled, so a re-baseline that reused a stale
+    # params-hashed lib.so would silently measure the PRE-patch kernel (the
+    # observed -0.17% on a real +2.5% paged_attention win). Before trusting
+    # gain_pct, assert a real rebuild landed: apply moved the cache aside, so
+    # a fresh <build_dir>/<md_name>_*/lib.so newer than the invalidation is
+    # proof the patched kernel was (re)compiled and served. If not, flag for
+    # review instead of emitting a KEEP/REVERT on a possibly-stale measure.
+    #
+    # Single-node only: in multi-node the served cache lives on the serving
+    # pod, not this sandbox, so AITER_REBUILD=1 on the pod restart is the
+    # mechanism and the sandbox-local check is skipped to avoid false aborts.
+    # verify_cpp_itfs_rebuilt() returns verified=True for non-cpp_itfs targets
+    # so this gate is a strict no-op off the cpp_itfs path.
+    rebuild_check: HandlerResult = {"verified": True, "status": "skipped"}
+    if force_aiter_rebuild and not is_multi_node():
+        rebuild_check = _load_apply_tool().verify_cpp_itfs_rebuilt(cpp_itfs_backup)
+        if not rebuild_check.get("verified", True):
+            revert_result = _maybe_revert_kernel_patch(apply_result)
+            return {
+                "status": "failed",
+                "error_class": "cpp_itfs_rebuild_not_verified",
+                "error": (
+                    "re-baseline did not produce a freshly-built cpp_itfs "
+                    "lib.so; refusing to score a possibly-stale binary"
+                ),
+                "decision": "NEEDS_REVIEW",
+                "kernel_id": kernel_id,
+                "patch_path": patch_path,
+                "target_file": payload.get("target_file") or payload.get("source_file"),
+                "apply_result": apply_result,
+                "revert_result": revert_result,
+                "rebuild_check": rebuild_check,
+            }
 
     new_tput = float(bench_result.get("output_throughput") or 0.0)
     gain_pct = ((new_tput - base_tput) / base_tput * 100.0) if base_tput > 0 else 0.0
@@ -2339,6 +2402,7 @@ async def integrate_handler(
         "extra_server_args": extra_args,
         "apply_result": apply_result,
         "revert_result": revert_result,
+        "rebuild_check": rebuild_check,
     }
 
 

--- a/kernel-agent/tools/apply_kernel_patch.py
+++ b/kernel-agent/tools/apply_kernel_patch.py
@@ -13,6 +13,7 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
@@ -518,6 +519,280 @@ def _restore_aiter_jit_build(jit_build_backup: dict[str, Any]) -> dict[str, Any]
     return {"status": "ok", "restored_to": str(src)}
 
 
+# ---------------------------------------------------------------------------
+# PR-K2: aiter cpp_itfs RUNTIME-compiled cache invalidation.
+#
+# Distinct from the ``@compile_ops`` jit/build cache handled above. aiter's
+# ``csrc/cpp_itfs`` kernels (e.g. paged_attention -> ``pa_ragged``) are NOT
+# produced by ``setup.py develop``; they are runtime-compiled on first call
+# by ``compile_template_op`` (aiter ``csrc/cpp_itfs/utils.py``) into
+# ``$AITER_ROOT_DIR/build/<md_name>_<md5(params)>/lib.so`` (default
+# ``$HOME/.aiter/build``). The cache folder name hashes kernel *parameters*,
+# NOT source content, so the pristine and the patched build of the same
+# kernel collide on the SAME directory. ``compile_template_op`` rebuilds only
+# when ``lib.so`` is missing (``not_built``), so after we patch the ``.cuh``
+# and run the (no-op for this class) ``setup.py develop``, the next server
+# reuses the STALE pristine ``lib.so``; the integrate re-baseline then
+# measures ~0% and a genuinely-good kernel is flagged NEEDS_REVIEW / REVERT
+# (observed -0.17% on a +2.5% paged_attention kernel; see GH #458).
+#
+# ``setup.py develop`` cannot refresh this kernel class, and the jit/build
+# move above never touches ``$HOME/.aiter/build``. So for cpp_itfs targets we
+# ALSO move the affected runtime-cache dirs aside before the rebuild step --
+# scoped to the patched module's ``MD_NAME`` prefix(es) when determinable,
+# else the whole cpp_itfs build root the scheduler uses -- so the re-baseline
+# server runtime-recompiles the patched kernel from clean state.
+# ``shutil.move`` keeps it reversible; :func:`_restore_aiter_cpp_itfs_cache`
+# moves the backup back on revert. ``integrate_handler`` additionally sets
+# ``AITER_REBUILD=1`` on the re-baseline server and gates KEEP on a verified
+# fresh rebuild via :func:`verify_cpp_itfs_rebuilt`.
+#
+# Scope: ONLY aiter cpp_itfs targets. Non-cpp_itfs aiter targets, sglang and
+# vllm keep their current behaviour bit-for-bit (this is a no-op for them).
+# ---------------------------------------------------------------------------
+_AITER_CPP_ITFS_MARKER = "/aiter/csrc/cpp_itfs/"
+_MD_NAME_RE = re.compile(r"""(?m)^\s*MD_NAME\s*=\s*["']([^"']+)["']""")
+
+
+def _target_is_in_aiter_cpp_itfs(target_file: Path) -> bool:
+    """True iff ``target_file`` lives under any ``aiter/csrc/cpp_itfs/`` tree.
+
+    Strict subset of :func:`_target_is_in_aiter_csrc`: these are the
+    runtime-compiled kernels whose served ``.so`` lives in
+    ``$HOME/.aiter/build`` rather than in ``<aiter>/jit/build`` or the
+    statically-linked wheel. Matches both the editable checkout
+    (``/sgl-workspace/aiter/csrc/cpp_itfs/...``) and the dist-packages
+    layout (``.../aiter/csrc/cpp_itfs/...``).
+    """
+    return _AITER_CPP_ITFS_MARKER in str(target_file).replace(os.sep, "/")
+
+
+def _aiter_cpp_itfs_build_dir() -> Path:
+    """Resolve aiter's cpp_itfs runtime ``BUILD_DIR``.
+
+    Mirrors aiter ``csrc/cpp_itfs/utils.py``: ``$AITER_ROOT_DIR/build`` with
+    ``$AITER_ROOT_DIR`` defaulting to ``$HOME/.aiter``. Honouring both env
+    vars keeps non-default deployments + unit tests correct without importing
+    aiter into this standalone tool.
+    """
+    root = os.environ.get("AITER_ROOT_DIR", "").strip()
+    if not root:
+        home = Path(os.environ.get("HOME", "~")).expanduser()
+        root = str(home / ".aiter")
+    return Path(root) / "build"
+
+
+def _cpp_itfs_module_names(target_file: Path) -> list[str]:
+    """Best-effort ``MD_NAME`` prefix(es) for the cpp_itfs module(s) the
+    patched source feeds.
+
+    The cpp_itfs ``.py`` driver next to the patched source declares
+    ``MD_NAME = "pa_ragged"`` (etc.), which becomes the
+    ``<md_name>_<hash>`` runtime-cache folder prefix. A single shared
+    ``.cuh`` (e.g. ``pa_kernels.cuh``) is pulled into several drivers in the
+    same directory, so we collect EVERY ``MD_NAME`` declared in the target's
+    directory. An empty result tells the caller to fall back to clearing the
+    whole cpp_itfs build root.
+    """
+    names: set[str] = set()
+    search_dir = target_file.parent
+    try:
+        py_files = sorted(search_dir.glob("*.py"))
+    except OSError:
+        py_files = []
+    if target_file.suffix.lower() == ".py":
+        py_files = list(dict.fromkeys([target_file, *py_files]))
+    for py in py_files:
+        try:
+            text = py.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for match in _MD_NAME_RE.finditer(text):
+            names.add(match.group(1))
+    return sorted(names)
+
+
+def _invalidate_aiter_cpp_itfs_cache(
+    target_file: Path,
+    backup_dir: Path,
+    *,
+    build_dir_override: Path | None = None,
+) -> dict[str, Any]:
+    """Move aiter cpp_itfs runtime-cache dirs aside so the re-baseline server
+    runtime-recompiles the patched kernel from clean state.
+
+    No-op (``skipped``, ``is_cpp_itfs=False``) for non-cpp_itfs targets. For
+    cpp_itfs targets the affected ``<build_dir>/<md_name>_*`` dirs (scoped by
+    ``MD_NAME`` when determinable, else every child of the build root) are
+    MOVED into ``backup_dir/cpp_itfs_cache/`` so the operation is reversible.
+    The record always carries ``is_cpp_itfs`` + ``build_dir`` +
+    ``module_names`` + ``invalidated_unix`` (even when nothing was cached
+    yet) so integrate can later verify a fresh rebuild actually landed.
+
+    Returns one of ``ok`` / ``skipped`` / ``failed`` mirroring
+    :func:`_invalidate_aiter_jit_build`. ``build_dir_override`` is a
+    test-only hook.
+    """
+    if not _target_is_in_aiter_cpp_itfs(target_file):
+        return {
+            "status": "skipped",
+            "is_cpp_itfs": False,
+            "reason": "target not under aiter/csrc/cpp_itfs/",
+        }
+    build_dir = build_dir_override or _aiter_cpp_itfs_build_dir()
+    module_names = _cpp_itfs_module_names(target_file)
+    scope = "module" if module_names else "build_root"
+    record: dict[str, Any] = {
+        "is_cpp_itfs": True,
+        "build_dir": str(build_dir),
+        "module_names": module_names,
+        "scope": scope,
+        "invalidated_at": _now(),
+        "invalidated_unix": time.time(),
+    }
+    if not build_dir.exists():
+        # Nothing cached yet -> the re-baseline server will build fresh into
+        # this dir on first kernel call. No stale binary to mask.
+        record.update({
+            "status": "skipped",
+            "reason": "cpp_itfs build dir does not exist",
+            "moved": [],
+        })
+        return record
+    try:
+        if module_names:
+            to_move: list[Path] = []
+            for md in module_names:
+                to_move.extend(p for p in build_dir.glob(f"{md}_*") if p.is_dir())
+        else:
+            to_move = [p for p in build_dir.iterdir() if p.is_dir()]
+    except OSError as exc:
+        record.update({"status": "failed", "error": f"failed to scan {build_dir}: {exc}"})
+        return record
+    # De-dup: a shared .cuh can match overlapping MD_NAME globs.
+    to_move = sorted({p.resolve() for p in to_move})
+    if not to_move:
+        record.update({
+            "status": "skipped",
+            "reason": "no matching cpp_itfs cache entries",
+            "moved": [],
+        })
+        return record
+    cache_backup_root = backup_dir / "cpp_itfs_cache"
+    moved: list[dict[str, str]] = []
+    try:
+        cache_backup_root.mkdir(parents=True, exist_ok=True)
+        for src in to_move:
+            dst = cache_backup_root / src.name
+            if dst.exists():
+                record.update({
+                    "status": "failed",
+                    "error": f"cpp_itfs cache backup path already exists: {dst}",
+                    "moved": moved,
+                })
+                return record
+            shutil.move(str(src), str(dst))
+            moved.append({"src": str(src), "backup_path": str(dst)})
+    except (OSError, shutil.Error) as exc:
+        record.update({
+            "status": "failed",
+            "error": f"shutil.move failed: {exc}",
+            "moved": moved,
+        })
+        return record
+    record.update({"status": "ok", "moved": moved})
+    return record
+
+
+def _restore_aiter_cpp_itfs_cache(cache_backup: dict[str, Any]) -> dict[str, Any]:
+    """Reverse :func:`_invalidate_aiter_cpp_itfs_cache` (revert path).
+
+    Moves each backed-up cache dir back to its original location, removing
+    any dir the re-baseline server regenerated there first so the pre-patch
+    runtime cache is restored bit-for-bit.
+    """
+    if not isinstance(cache_backup, dict) or cache_backup.get("status") != "ok":
+        return {"status": "skipped", "reason": "no cpp_itfs cache backup recorded"}
+    moved = cache_backup.get("moved") or []
+    if not moved:
+        return {"status": "skipped", "reason": "nothing was moved"}
+    restored: list[str] = []
+    for entry in moved:
+        src = Path(entry.get("src", ""))  # original cache location
+        backup_path = Path(entry.get("backup_path", ""))
+        if not str(src) or not str(backup_path) or not backup_path.exists():
+            continue
+        if src.exists():
+            try:
+                shutil.rmtree(src)
+            except OSError as exc:
+                return {
+                    "status": "failed",
+                    "error": f"failed to clear regenerated cache dir {src}: {exc}",
+                }
+        try:
+            src.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(backup_path), str(src))
+        except (OSError, shutil.Error) as exc:
+            return {
+                "status": "failed",
+                "error": f"shutil.move failed during restore: {exc}",
+            }
+        restored.append(str(src))
+    return {"status": "ok", "restored": restored}
+
+
+def verify_cpp_itfs_rebuilt(cache_backup: dict[str, Any]) -> dict[str, Any]:
+    """Assert the re-baseline actually runtime-recompiled the patched kernel.
+
+    After :func:`_invalidate_aiter_cpp_itfs_cache` moved the stale cache
+    aside, a faithful re-baseline must repopulate
+    ``<build_dir>/<md_name>_*/lib.so`` (the served binary) with an mtime at
+    or after the invalidation. If no such fresh ``lib.so`` exists, the server
+    dlopened a stale binary (or the kernel was never exercised) and the
+    measured gain is meaningless -- the integrate KEEP/REVERT gate uses this
+    to flag/abort instead of scoring a stale binary (GH #458 point 2).
+
+    Returns ``{"verified": bool, ...}``. ``verified`` is True for
+    non-cpp_itfs targets so the caller's gate is a strict no-op off the
+    cpp_itfs path.
+    """
+    if not isinstance(cache_backup, dict) or not cache_backup.get("is_cpp_itfs"):
+        return {"verified": True, "status": "skipped", "reason": "non-cpp_itfs target"}
+    build_dir = Path(cache_backup.get("build_dir", ""))
+    since = float(cache_backup.get("invalidated_unix") or 0.0)
+    module_names = list(cache_backup.get("module_names") or [])
+    if not str(build_dir) or not build_dir.exists():
+        return {
+            "verified": False,
+            "status": "stale",
+            "reason": f"cpp_itfs build dir absent after re-baseline: {build_dir}",
+        }
+    globs = [f"{md}_*/lib.so" for md in module_names] or ["*/lib.so"]
+    fresh: list[str] = []
+    for pattern in globs:
+        for so in build_dir.glob(pattern):
+            try:
+                mtime = so.stat().st_mtime
+            except OSError:
+                continue
+            # 1s slack absorbs build-dir-create vs lib.so-flush ordering.
+            if mtime + 1.0 >= since:
+                fresh.append(str(so))
+    if fresh:
+        return {"verified": True, "status": "ok", "fresh_lib_so": sorted(set(fresh))[:8]}
+    return {
+        "verified": False,
+        "status": "stale",
+        "reason": (
+            "no freshly-built cpp_itfs lib.so found after re-baseline; "
+            "served binary is stale"
+        ),
+        "build_dir": str(build_dir),
+        "module_names": module_names,
+    }
+
+
 def _detect_strategy(target_file: Path, *, allow_unknown_target: bool) -> dict[str, Any]:
     target = str(target_file)
     lower = target.lower()
@@ -644,6 +919,18 @@ def revert_kernel_patch(manifest_path: str | Path) -> dict[str, Any]:
         manifest["jit_build_restore"] = jit_build_restore
         if jit_build_restore.get("status") == "ok" and jit_build_restore.get("restored_to"):
             restored.append(str(jit_build_restore["restored_to"]))
+
+    # PR-K2: restore the aiter cpp_itfs runtime cache if it was moved aside
+    # during apply, so a non-KEEP decision puts the pristine params-hashed
+    # ``<build_dir>/<md_name>_*`` dirs back and the next server serves v0
+    # (removing any patched dir the re-baseline regenerated first). Only
+    # present (status=ok) when the apply actually moved cpp_itfs cache dirs.
+    cpp_itfs_cache_backup = manifest.get("cpp_itfs_cache_backup") or {}
+    if cpp_itfs_cache_backup.get("status") == "ok":
+        cpp_itfs_cache_restore = _restore_aiter_cpp_itfs_cache(cpp_itfs_cache_backup)
+        manifest["cpp_itfs_cache_restore"] = cpp_itfs_cache_restore
+        if cpp_itfs_cache_restore.get("status") == "ok":
+            restored.extend(cpp_itfs_cache_restore.get("restored", []))
 
     # Multi-node: also fan-out a revert to every pod that received the
     # corresponding apply. Best-effort; sandbox revert above already
@@ -818,6 +1105,9 @@ def apply_kernel_patch(
     jit_build_backup: dict[str, Any] = {
         "status": "skipped", "reason": "rebuild not run",
     }
+    cpp_itfs_cache_backup: dict[str, Any] = {
+        "status": "skipped", "reason": "rebuild not run", "is_cpp_itfs": False,
+    }
     if strategy["compiled"] and not skip_rebuild:
         # PR-K: aiter @compile_ops modules cache JIT-built .so under
         # <aiter>/jit/build/module_*/. setup.py develop rebuilds the
@@ -856,6 +1146,43 @@ def apply_kernel_patch(
                 encoding="utf-8",
             )
 
+        # PR-K2: aiter cpp_itfs kernels (e.g. paged_attention -> pa_ragged)
+        # are runtime-compiled into $HOME/.aiter/build/<md_name>_<hash>/ on
+        # first call, NOT by setup.py develop, and the dir name hashes
+        # params (not source) so pristine + patched collide -> the next
+        # server reuses the stale .so. Move the affected runtime-cache dirs
+        # aside so the re-baseline recompiles from clean state (GH #458).
+        # No-op for non-cpp_itfs targets (sglang / vllm / other aiter csrc).
+        cpp_itfs_cache_backup = _invalidate_aiter_cpp_itfs_cache(target, backup_dir)
+        if cpp_itfs_cache_backup.get("status") == "failed":
+            # Refuse to re-baseline against a stale runtime cache: restore
+            # source + jit/build (if moved) so on-disk state matches v0,
+            # then bail rather than score a possibly-stale binary.
+            try:
+                shutil.copy2(source_backup["backup_path"], target)
+            except OSError:
+                pass
+            if jit_build_backup.get("status") == "ok":
+                _restore_aiter_jit_build(jit_build_backup)
+            return {
+                "status": "failed",
+                "error_class": "aiter_cpp_itfs_invalidation_failed",
+                "error": (
+                    "aiter cpp_itfs runtime cache invalidation failed: "
+                    f"{cpp_itfs_cache_backup.get('error')}"
+                ),
+                "manifest_path": str(manifest_path),
+                "cpp_itfs_cache_backup": cpp_itfs_cache_backup,
+            }
+        if cpp_itfs_cache_backup.get("status") == "ok":
+            # Persist BEFORE rebuild so a rebuild failure can restore the
+            # moved-aside runtime cache via revert_kernel_patch.
+            manifest["cpp_itfs_cache_backup"] = cpp_itfs_cache_backup
+            manifest_path.write_text(
+                json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+
         cwd = Path(strategy["root"] or target.parent)
         rebuild = _run_rebuild(command, cwd, rebuild_timeout_sec)
         if rebuild["status"] != "ok":
@@ -877,6 +1204,11 @@ def apply_kernel_patch(
         # invalidation didn't run on a particular apply (e.g. non-aiter
         # target, aiter not importable in this sandbox).
         manifest["jit_build_backup"] = jit_build_backup
+    if cpp_itfs_cache_backup.get("status") in {"ok", "skipped"}:
+        # Surface the cpp_itfs record (incl. is_cpp_itfs + build_dir +
+        # module_names + invalidated_unix) so integrate can verify a fresh
+        # rebuild landed and revert can restore the runtime cache.
+        manifest["cpp_itfs_cache_backup"] = cpp_itfs_cache_backup
     # multinode block (when present) is already persisted at fan-out
     # time above; we don't rewrite it here to avoid clobbering the
     # per-host backup map.
@@ -891,6 +1223,7 @@ def apply_kernel_patch(
         "cache_clear": cache_clear,
         "rebuild": rebuild,
         "jit_build_backup": jit_build_backup,
+        "cpp_itfs_cache_backup": cpp_itfs_cache_backup,
     }
     # Only attach the multinode key when fan-out actually ran. Keeps
     # single-node callers' return shape bit-for-bit identical to

--- a/kernel-agent/tools/test_apply_kernel_patch_cpp_itfs_invalidation.py
+++ b/kernel-agent/tools/test_apply_kernel_patch_cpp_itfs_invalidation.py
@@ -1,0 +1,416 @@
+"""PR-K2 — aiter cpp_itfs RUNTIME-compiled cache invalidation (GH #458).
+
+Background
+----------
+aiter ``csrc/cpp_itfs`` kernels (e.g. ``paged_attention`` ->
+``csrc/cpp_itfs/pa/pa_kernels.cuh``) are NOT built by ``setup.py develop``;
+they are runtime-compiled on first call by ``compile_template_op``
+(``csrc/cpp_itfs/utils.py``) into
+``$AITER_ROOT_DIR/build/<md_name>_<md5(params)>/lib.so`` (default
+``$HOME/.aiter/build``). The cache folder name hashes kernel *parameters*,
+NOT source content, so a pristine and a patched build of the same kernel
+collide on the SAME directory; ``compile_template_op`` only rebuilds when
+``lib.so`` is missing, so after :mod:`apply_kernel_patch` lands the new
+``.cuh`` (and runs the no-op-for-this-class ``setup.py develop``), the next
+server reuses the STALE pristine ``lib.so`` and integrate measures ~0% gain
+on a genuinely-good kernel (observed -0.17% on a +2.5% pa kernel, RUN2).
+
+These tests cover the fix:
+
+* ``_target_is_in_aiter_cpp_itfs`` recognizes cpp_itfs editable + dist layouts
+  and rejects non-cpp_itfs aiter csrc / sglang / vllm targets.
+* ``_cpp_itfs_module_names`` scrapes ``MD_NAME`` from the drivers next to the
+  patched source so invalidation can be scoped to the impacted module(s).
+* ``_invalidate_aiter_cpp_itfs_cache`` moves only the matching
+  ``<md_name>_*`` cache dirs aside (leaving unrelated modules intact), falls
+  back to the whole build root when no MD_NAME is determinable, skips when
+  the build dir is absent, and refuses to clobber a pre-existing backup.
+* ``_restore_aiter_cpp_itfs_cache`` round-trips the move, clearing any dir
+  the re-baseline regenerated first.
+* ``verify_cpp_itfs_rebuilt`` is a no-op for non-cpp_itfs, reports ``stale``
+  when no fresh ``lib.so`` landed, and ``ok`` when one did.
+* End-to-end ``apply_kernel_patch`` against a synthetic cpp_itfs target moves
+  the runtime cache aside + records ``cpp_itfs_cache_backup`` (and revert
+  restores it), while a non-cpp_itfs (sglang) target leaves the cpp_itfs
+  build root untouched.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import time
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+_APPLY_TOOL_PATH = Path(__file__).resolve().parent / "apply_kernel_patch.py"
+
+
+@pytest.fixture(scope="module")
+def apply_tool() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "_apply_kernel_patch_cpp_itfs_under_test", _APPLY_TOOL_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# _target_is_in_aiter_cpp_itfs
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "target_path,expected",
+    [
+        ("/sgl-workspace/aiter/csrc/cpp_itfs/pa/pa_kernels.cuh", True),
+        ("/sgl-workspace/aiter/csrc/cpp_itfs/pa/pa_ragged.cpp.jinja", True),
+        ("/usr/local/lib/python3.12/dist-packages/aiter/csrc/cpp_itfs/mha/x.cuh", True),
+        # Negative — aiter csrc but NOT cpp_itfs, plus sglang / vllm.
+        ("/sgl-workspace/aiter/csrc/ck_gemm_moe_2stages_codegen/gemm.cu", False),
+        ("/sgl-workspace/aiter/csrc/include/foo.cuh", False),
+        ("/sgl-workspace/sglang/sgl-kernel/csrc/cpp_itfs/foo.cu", False),
+        ("/sgl-workspace/vllm/csrc/foo.cu", False),
+    ],
+)
+def test_target_is_in_aiter_cpp_itfs(apply_tool, target_path: str, expected: bool) -> None:
+    assert apply_tool._target_is_in_aiter_cpp_itfs(Path(target_path)) is expected
+
+
+# ---------------------------------------------------------------------------
+# _cpp_itfs_module_names
+# ---------------------------------------------------------------------------
+def test_cpp_itfs_module_names_scrapes_md_name(apply_tool, tmp_path: Path) -> None:
+    pa_dir = tmp_path / "aiter" / "csrc" / "cpp_itfs" / "pa"
+    pa_dir.mkdir(parents=True)
+    (pa_dir / "pa_kernels.cuh").write_text("// shared kernel header\n")
+    (pa_dir / "pa_ragged.py").write_text('MD_NAME = "pa_ragged"\n')
+    (pa_dir / "pa.py").write_text("MD_NAME = 'pa'\n")
+    (pa_dir / "notes.py").write_text("X = 1  # no MD_NAME here\n")
+
+    names = apply_tool._cpp_itfs_module_names(pa_dir / "pa_kernels.cuh")
+    assert names == ["pa", "pa_ragged"]
+
+
+def test_cpp_itfs_module_names_empty_when_no_driver(apply_tool, tmp_path: Path) -> None:
+    d = tmp_path / "aiter" / "csrc" / "cpp_itfs" / "mystery"
+    d.mkdir(parents=True)
+    (d / "kernel.cuh").write_text("// no python driver next to me\n")
+    assert apply_tool._cpp_itfs_module_names(d / "kernel.cuh") == []
+
+
+# ---------------------------------------------------------------------------
+# _invalidate_aiter_cpp_itfs_cache
+# ---------------------------------------------------------------------------
+def _make_cache_dir(build_dir: Path, name: str, content: bytes = b"v0") -> Path:
+    d = build_dir / name
+    d.mkdir(parents=True)
+    (d / "lib.so").write_bytes(content)
+    return d
+
+
+def test_invalidate_skips_non_cpp_itfs_target(apply_tool, tmp_path: Path) -> None:
+    target = tmp_path / "aiter" / "csrc" / "ck_gemm" / "gemm.cu"
+    target.parent.mkdir(parents=True)
+    target.write_text("// non cpp_itfs aiter csrc\n")
+    build_dir = tmp_path / "build"
+    _make_cache_dir(build_dir, "gemm_abc")
+
+    out = apply_tool._invalidate_aiter_cpp_itfs_cache(
+        target, tmp_path / "backup", build_dir_override=build_dir,
+    )
+    assert out["status"] == "skipped"
+    assert out["is_cpp_itfs"] is False
+    # Untouched.
+    assert (build_dir / "gemm_abc" / "lib.so").is_file()
+
+
+def test_invalidate_scopes_to_module_md_names(apply_tool, tmp_path: Path) -> None:
+    """Only the patched module's <md_name>_* dirs are moved aside; unrelated
+    modules (e.g. gemm_*) stay put."""
+    pa_dir = tmp_path / "aiter" / "csrc" / "cpp_itfs" / "pa"
+    pa_dir.mkdir(parents=True)
+    target = pa_dir / "pa_kernels.cuh"
+    target.write_text("// shared by pa + pa_ragged\n")
+    (pa_dir / "pa_ragged.py").write_text('MD_NAME = "pa_ragged"\n')
+    (pa_dir / "pa.py").write_text('MD_NAME = "pa"\n')
+
+    build_dir = tmp_path / "build"
+    _make_cache_dir(build_dir, "pa_ragged_HASHA")
+    _make_cache_dir(build_dir, "pa_HASHB")
+    _make_cache_dir(build_dir, "gemm_HASHC")  # unrelated module — must survive
+
+    backup = tmp_path / "backup"
+    out = apply_tool._invalidate_aiter_cpp_itfs_cache(
+        target, backup, build_dir_override=build_dir,
+    )
+
+    assert out["status"] == "ok"
+    assert out["is_cpp_itfs"] is True
+    assert out["scope"] == "module"
+    assert out["module_names"] == ["pa", "pa_ragged"]
+    moved_srcs = {Path(m["src"]).name for m in out["moved"]}
+    assert moved_srcs == {"pa_ragged_HASHA", "pa_HASHB"}
+    # Affected module dirs moved aside; unrelated gemm_* untouched.
+    assert not (build_dir / "pa_ragged_HASHA").exists()
+    assert not (build_dir / "pa_HASHB").exists()
+    assert (build_dir / "gemm_HASHC" / "lib.so").is_file()
+    # Backup holds the originals.
+    assert (backup / "cpp_itfs_cache" / "pa_ragged_HASHA" / "lib.so").is_file()
+    assert (backup / "cpp_itfs_cache" / "pa_HASHB" / "lib.so").is_file()
+
+
+def test_invalidate_falls_back_to_build_root_without_md_name(
+    apply_tool, tmp_path: Path,
+) -> None:
+    d = tmp_path / "aiter" / "csrc" / "cpp_itfs" / "mystery"
+    d.mkdir(parents=True)
+    target = d / "kernel.cuh"
+    target.write_text("// no driver -> clear whole cpp_itfs build root\n")
+
+    build_dir = tmp_path / "build"
+    _make_cache_dir(build_dir, "alpha_1")
+    _make_cache_dir(build_dir, "beta_2")
+
+    out = apply_tool._invalidate_aiter_cpp_itfs_cache(
+        target, tmp_path / "backup", build_dir_override=build_dir,
+    )
+    assert out["status"] == "ok"
+    assert out["scope"] == "build_root"
+    assert {Path(m["src"]).name for m in out["moved"]} == {"alpha_1", "beta_2"}
+    assert not (build_dir / "alpha_1").exists()
+    assert not (build_dir / "beta_2").exists()
+
+
+def test_invalidate_skips_when_build_dir_missing(apply_tool, tmp_path: Path) -> None:
+    pa_dir = tmp_path / "aiter" / "csrc" / "cpp_itfs" / "pa"
+    pa_dir.mkdir(parents=True)
+    target = pa_dir / "pa_kernels.cuh"
+    target.write_text("// fake\n")
+    (pa_dir / "pa_ragged.py").write_text('MD_NAME = "pa_ragged"\n')
+
+    out = apply_tool._invalidate_aiter_cpp_itfs_cache(
+        target, tmp_path / "backup", build_dir_override=tmp_path / "nope",
+    )
+    assert out["status"] == "skipped"
+    assert out["is_cpp_itfs"] is True
+    assert "does not exist" in out["reason"]
+    # The record still carries enough for the verify gate.
+    assert out["module_names"] == ["pa_ragged"]
+    assert "invalidated_unix" in out
+
+
+def test_invalidate_refuses_to_clobber_existing_backup(
+    apply_tool, tmp_path: Path,
+) -> None:
+    pa_dir = tmp_path / "aiter" / "csrc" / "cpp_itfs" / "pa"
+    pa_dir.mkdir(parents=True)
+    target = pa_dir / "pa_kernels.cuh"
+    target.write_text("// fake\n")
+    (pa_dir / "pa_ragged.py").write_text('MD_NAME = "pa_ragged"\n')
+
+    build_dir = tmp_path / "build"
+    _make_cache_dir(build_dir, "pa_ragged_HASHA")
+
+    backup = tmp_path / "backup"
+    (backup / "cpp_itfs_cache" / "pa_ragged_HASHA").mkdir(parents=True)
+    (backup / "cpp_itfs_cache" / "pa_ragged_HASHA" / "stale.txt").write_text("old")
+
+    out = apply_tool._invalidate_aiter_cpp_itfs_cache(
+        target, backup, build_dir_override=build_dir,
+    )
+    assert out["status"] == "failed"
+    assert "already exists" in out["error"]
+    # Live cache untouched so the caller can recover.
+    assert (build_dir / "pa_ragged_HASHA" / "lib.so").is_file()
+
+
+# ---------------------------------------------------------------------------
+# _restore_aiter_cpp_itfs_cache
+# ---------------------------------------------------------------------------
+def test_restore_round_trip(apply_tool, tmp_path: Path) -> None:
+    pa_dir = tmp_path / "aiter" / "csrc" / "cpp_itfs" / "pa"
+    pa_dir.mkdir(parents=True)
+    target = pa_dir / "pa_kernels.cuh"
+    target.write_text("// fake\n")
+    (pa_dir / "pa_ragged.py").write_text('MD_NAME = "pa_ragged"\n')
+
+    build_dir = tmp_path / "build"
+    _make_cache_dir(build_dir, "pa_ragged_HASHA", b"v0")
+
+    backup = tmp_path / "backup"
+    invalidate = apply_tool._invalidate_aiter_cpp_itfs_cache(
+        target, backup, build_dir_override=build_dir,
+    )
+    assert invalidate["status"] == "ok"
+    assert not (build_dir / "pa_ragged_HASHA").exists()
+
+    # Simulate the re-baseline regenerating a fresh (patched) dir on top.
+    _make_cache_dir(build_dir, "pa_ragged_HASHA", b"v1")
+
+    restore = apply_tool._restore_aiter_cpp_itfs_cache(invalidate)
+    assert restore["status"] == "ok"
+    # Pre-patch (v0) content restored; regenerated v1 cleared first.
+    assert (build_dir / "pa_ragged_HASHA" / "lib.so").read_bytes() == b"v0"
+    assert not (backup / "cpp_itfs_cache" / "pa_ragged_HASHA").exists()
+
+
+def test_restore_skips_when_no_backup(apply_tool) -> None:
+    assert apply_tool._restore_aiter_cpp_itfs_cache(
+        {"status": "skipped", "is_cpp_itfs": False},
+    )["status"] == "skipped"
+    assert apply_tool._restore_aiter_cpp_itfs_cache({})["status"] == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# verify_cpp_itfs_rebuilt
+# ---------------------------------------------------------------------------
+def test_verify_noop_for_non_cpp_itfs(apply_tool) -> None:
+    out = apply_tool.verify_cpp_itfs_rebuilt({"is_cpp_itfs": False})
+    assert out["verified"] is True
+    assert out["status"] == "skipped"
+
+
+def test_verify_stale_when_no_fresh_lib_so(apply_tool, tmp_path: Path) -> None:
+    build_dir = tmp_path / "build"
+    # A lib.so that predates the invalidation -> stale.
+    old = _make_cache_dir(build_dir, "pa_ragged_HASHA")
+    invalidated_unix = time.time()
+    old_mtime = invalidated_unix - 1000.0
+    os.utime(old / "lib.so", (old_mtime, old_mtime))
+
+    out = apply_tool.verify_cpp_itfs_rebuilt({
+        "is_cpp_itfs": True,
+        "build_dir": str(build_dir),
+        "module_names": ["pa_ragged"],
+        "invalidated_unix": invalidated_unix,
+    })
+    assert out["verified"] is False
+    assert out["status"] == "stale"
+
+
+def test_verify_ok_when_fresh_lib_so(apply_tool, tmp_path: Path) -> None:
+    build_dir = tmp_path / "build"
+    invalidated_unix = time.time()
+    fresh = _make_cache_dir(build_dir, "pa_ragged_HASHA")
+    new_mtime = invalidated_unix + 5.0
+    os.utime(fresh / "lib.so", (new_mtime, new_mtime))
+
+    out = apply_tool.verify_cpp_itfs_rebuilt({
+        "is_cpp_itfs": True,
+        "build_dir": str(build_dir),
+        "module_names": ["pa_ragged"],
+        "invalidated_unix": invalidated_unix,
+    })
+    assert out["verified"] is True
+    assert out["status"] == "ok"
+    assert any("pa_ragged_HASHA" in p for p in out["fresh_lib_so"])
+
+
+# ---------------------------------------------------------------------------
+# End-to-end apply_kernel_patch → revert_kernel_patch.
+# ---------------------------------------------------------------------------
+_CUH_V0 = "#include <hip/hip_runtime.h>\n__global__ void pa_kernel_v0() {}\n"
+_CUH_V1 = "#include <hip/hip_runtime.h>\n__global__ void pa_kernel_v1() {}\n"
+
+_FAKE_REBUILD_OK = {
+    "status": "ok",
+    "returncode": 0,
+    "stdout_tail": "ok",
+    "stderr_tail": "",
+    "command": ["fake-rebuild"],
+    "cwd": "",
+}
+
+
+def test_apply_then_revert_invalidates_and_restores_cpp_itfs_cache(
+    apply_tool, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "sgl-workspace" / "aiter"
+    pa_dir = repo / "csrc" / "cpp_itfs" / "pa"
+    pa_dir.mkdir(parents=True)
+    target = pa_dir / "pa_kernels.cuh"
+    target.write_text(_CUH_V0)
+    (pa_dir / "pa_ragged.py").write_text('MD_NAME = "pa_ragged"\n')
+
+    patch_file = tmp_path / "patched.cuh"
+    patch_file.write_text(_CUH_V1)
+
+    # Hermetic cpp_itfs runtime cache via $AITER_ROOT_DIR -> $.../build.
+    aiter_root = tmp_path / "aiterroot"
+    monkeypatch.setenv("AITER_ROOT_DIR", str(aiter_root))
+    build_dir = aiter_root / "build"
+    _make_cache_dir(build_dir, "pa_ragged_HASHA", b"stale-pristine")
+    _make_cache_dir(build_dir, "gemm_HASHC", b"unrelated")
+
+    # Make the orthogonal @compile_ops jit/build invalidation a clean skip
+    # (and never touch the real /sgl-workspace/aiter) by stubbing the jit
+    # build-dir resolver to "aiter not importable". Patching the narrow
+    # helper avoids globally mocking importlib.find_spec, which would break
+    # unrelated lazy imports during apply.
+    with patch.object(apply_tool, "_aiter_jit_build_dir", return_value=None), \
+         patch.object(apply_tool, "_run_rebuild", return_value=dict(_FAKE_REBUILD_OK)):
+        result = apply_tool.apply_kernel_patch(
+            patch_path=patch_file,
+            target_file=target,
+            backup_root=tmp_path / "backups",
+            kernel_id="k_pa",
+            allow_unknown_target=True,
+        )
+
+    assert result["status"] == "ok", result
+    backup = result["cpp_itfs_cache_backup"]
+    assert backup["status"] == "ok"
+    assert backup["is_cpp_itfs"] is True
+    assert backup["module_names"] == ["pa_ragged"]
+    # Patched source landed.
+    assert "pa_kernel_v1" in target.read_text()
+    # Stale pristine cache moved aside; unrelated module survived.
+    assert not (build_dir / "pa_ragged_HASHA").exists()
+    assert (build_dir / "gemm_HASHC" / "lib.so").is_file()
+
+    # Simulate the re-baseline server recompiling the patched kernel.
+    _make_cache_dir(build_dir, "pa_ragged_HASHA", b"fresh-patched")
+
+    revert = apply_tool.revert_kernel_patch(result["manifest_path"])
+    assert revert["status"] == "ok"
+    # Source + runtime cache restored to pristine.
+    assert "pa_kernel_v0" in target.read_text()
+    assert (build_dir / "pa_ragged_HASHA" / "lib.so").read_bytes() == b"stale-pristine"
+
+
+def test_non_cpp_itfs_apply_leaves_cpp_itfs_cache_untouched(
+    apply_tool, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-cpp_itfs (sglang) target must NOT touch $HOME/.aiter/build."""
+    target = tmp_path / "sgl-workspace" / "sglang" / "sgl-kernel" / "csrc" / "x.cu"
+    target.parent.mkdir(parents=True)
+    target.write_text(_CUH_V0)
+    patch_file = tmp_path / "patched.cu"
+    patch_file.write_text(_CUH_V1)
+
+    aiter_root = tmp_path / "aiterroot"
+    monkeypatch.setenv("AITER_ROOT_DIR", str(aiter_root))
+    build_dir = aiter_root / "build"
+    _make_cache_dir(build_dir, "pa_ragged_HASHA", b"must-survive")
+
+    with patch.object(apply_tool, "_aiter_jit_build_dir", return_value=None), \
+         patch.object(apply_tool, "_run_rebuild", return_value=dict(_FAKE_REBUILD_OK)):
+        result = apply_tool.apply_kernel_patch(
+            patch_path=patch_file,
+            target_file=target,
+            backup_root=tmp_path / "backups",
+            kernel_id="k_sgl",
+            allow_unknown_target=True,
+        )
+
+    assert result["status"] == "ok", result
+    assert result["cpp_itfs_cache_backup"]["is_cpp_itfs"] is False
+    # cpp_itfs runtime cache completely untouched for a non-cpp_itfs target.
+    assert (build_dir / "pa_ragged_HASHA" / "lib.so").read_bytes() == b"must-survive"


### PR DESCRIPTION
## Summary

`integrate` silently discards genuinely-good aiter **cpp_itfs / runtime-compiled** kernels (e.g. `paged_attention`, `csrc/cpp_itfs/pa/pa_kernels.cuh`). `apply_kernel_patch` lands the optimized source and invalidates the `@compile_ops` JIT cache (`<aiter>/jit/build`), but **never invalidates the cpp_itfs runtime cache** at `$HOME/.aiter/build/pa_ragged_*` — where the *served* kernel actually lives. The re-baseline therefore measures the stale **pristine** binary, scores ~0%, and the kernel is flagged `NEEDS_REVIEW` / `REVERT`.

Impact: a kernel that genuinely delivers **~+2.5%** E2E throughput re-baselined at **−0.17% (≈0%)** and would have been thrown away.

Closes #458

## Root cause

- The cpp_itfs cache folder name is `get_default_func_name(md_name, params)` = `pa_ragged_<md5(params)>` — a hash of **kernel parameters, NOT source content** — so pristine and patched builds **collide on the same directory**.
- `compile_template_op` rebuilds only when `lib.so` is missing (`not_built`), so a stale `lib.so` is dlopened regardless of source edits. With `AITER_REBUILD` unset, aiter's own `rm -rf $BUILD_DIR/*` never fires.
- `setup.py develop` (the aiter rebuild command) builds AOT/static ops; `pa_ragged` is **runtime-built** on first call, so `setup.py develop` cannot refresh this kernel class even in principle.
- The existing `_invalidate_aiter_jit_build` move only covers `@compile_ops` (`jit/build`); nothing in Hyperloom touched `$HOME/.aiter/build` or set `AITER_REBUILD`.

## Fix

1. **Invalidate the cpp_itfs runtime cache for cpp_itfs targets during apply.** New `_invalidate_aiter_cpp_itfs_cache` in `kernel-agent/tools/apply_kernel_patch.py` (mirrors the existing PR-K `jit/build` move) moves the affected `$AITER_ROOT_DIR/build/<md_name>_*` dirs aside before the re-baseline — scoped to the patched module's `MD_NAME`(s) when determinable (scraped from the cpp_itfs `.py` drivers next to the target), otherwise the whole cpp_itfs build root the scheduler uses. `_restore_aiter_cpp_itfs_cache` reverses it on revert. **Non-cpp_itfs targets (sglang / vllm / other aiter csrc) are a strict no-op and keep current behavior.**
2. **Gate KEEP/REVERT on a VERIFIED fresh rebuild.** `integrate_handler` now sets `AITER_REBUILD=1` for the re-baseline server on cpp_itfs applies (always restored afterward), and — before trusting `gain_pct` — calls `verify_cpp_itfs_rebuilt()` to assert a freshly-built `<build_dir>/<md_name>_*/lib.so` (newer than the invalidation) actually landed. If not, it flags `NEEDS_REVIEW` (`error_class=cpp_itfs_rebuild_not_verified`) and reverts instead of scoring a possibly-stale binary. Single-node only (in multi-node the served cache lives on the pod, so `AITER_REBUILD=1` on the pod restart is the mechanism and the sandbox-local check is skipped to avoid false aborts).
3. **General mechanism keyed on target type** (`_target_is_in_aiter_cpp_itfs`), so future runtime-compiled kernels are covered without per-kernel special-casing.

### Files changed
- `kernel-agent/tools/apply_kernel_patch.py` — `_target_is_in_aiter_cpp_itfs`, `_aiter_cpp_itfs_build_dir`, `_cpp_itfs_module_names`, `_invalidate_aiter_cpp_itfs_cache`, `_restore_aiter_cpp_itfs_cache`, `verify_cpp_itfs_rebuilt`; wired into `apply_kernel_patch()` (persisted as `cpp_itfs_cache_backup`) and `revert_kernel_patch()`.
- `inference_optimizer/orchestrator/kernel_request_handlers.py` — `integrate_handler`: scoped `AITER_REBUILD=1` env + the verified-rebuild KEEP gate.
- `kernel-agent/tools/test_apply_kernel_patch_cpp_itfs_invalidation.py` — new unit tests.

## Test plan

- [x] `pytest kernel-agent/tools/test_apply_kernel_patch_cpp_itfs_invalidation.py` — **21 passed** (detection, MD_NAME scoping, build-root fallback, missing-dir skip, clobber-refusal, restore round-trip, verify no-op/stale/fresh, end-to-end apply→revert, and a non-cpp_itfs target leaving the runtime cache untouched).
- [x] `pytest inference_optimizer/tests/test_kernel_integrate_and_report.py inference_optimizer/tests/test_integrate_payload_defaults.py` — **26 passed** (existing integrate handler suite; non-cpp_itfs path unaffected).
- [x] `pytest kernel-agent/tools/test_apply_kernel_patch_jit_invalidation.py` — jit unit tests pass; the 2 `find_spec`-mock e2e tests fail **identically on `main`** (pre-existing, unrelated to this change).
- No GPU benchmarks were re-run. This relies on the existing **RUN2** evidence:
  - As-shipped integrate: served `pa_ragged` `lib.so` md5 `af459837` **unchanged before/after** integrate + **no `start build`** → stale pristine binary → **−0.17%**.
  - After clearing the cpp_itfs cache: fresh build `fbd84cb8` (with `start build`) → **+2.49%** in the cleanest drift-canceled pair (≈ the hand-measured +2.5%).
  - Full diagnosis: `/wekafs/upandey/det-exp/qwen14b/hl_integrate_RUN2/diag/DIAGNOSIS.md`.
