### PR TITLE
fix: inference-optimizer stability fixes (sglang OOM, model gate, patcher drift, pin deps)

### DIFF
--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -831,6 +831,52 @@ def _load_model_arch(workspace_root: Path, model_name: str) -> dict:
     return data
 
 
+def _load_model_config_dict(model_path: str) -> dict | None:
+    """Best-effort parse of ``<model_path>/config.json`` into a dict.
+
+    Shared soft-degrade reader used by every config.json-derived preflight /
+    KB-tag loader (never blocks launch): returns the parsed mapping, or
+    ``None`` when ``config.json`` is missing / unreadable / invalid-JSON /
+    not a JSON object. Callers decide how to treat ``None`` (the KB-tag loader
+    degrades to ``{}``; the unsupported-model gate degrades to "do not block").
+    """
+    if not model_path:
+        return None
+    cfg_path = Path(model_path) / "config.json"
+    try:
+        raw = cfg_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        logging.warning("model_config_unreadable: %s (%s)", cfg_path, exc)
+        return None
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError) as exc:
+        logging.warning("model_config_invalid_json: %s (%s)", cfg_path, exc)
+        return None
+    if not isinstance(data, dict):
+        logging.warning(
+            "model_config_not_a_dict: %s (got %s)", cfg_path, type(data).__name__,
+        )
+        return None
+    return data
+
+
+def _config_architectures(config: dict) -> list[str]:
+    """Normalise ``config["architectures"]`` to a list of non-empty strings.
+
+    Tolerates a scalar ``architectures`` by wrapping it in a single-item list;
+    returns ``[]`` when the key is absent or yields no non-empty entries.
+    """
+    arches_raw = config.get("architectures")
+    if isinstance(arches_raw, list):
+        return [str(a).strip() for a in arches_raw if str(a or "").strip()]
+    if isinstance(arches_raw, str) and arches_raw.strip():
+        return [arches_raw.strip()]
+    return []
+
+
 def _load_model_config_tags(model_path: str) -> dict:
     """Best-effort loader for KB architecture tags from ``config.json``.
 
@@ -852,41 +898,133 @@ def _load_model_config_tags(model_path: str) -> dict:
     its normalised value is empty, so callers can ``.get(key, default)``
     without re-checking for ``[]`` / ``""``.
     """
-    if not model_path:
-        return {}
-    cfg_path = Path(model_path) / "config.json"
-    try:
-        raw = cfg_path.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        return {}
-    except OSError as exc:
-        logging.warning("model_config_tags_unreadable: %s (%s)", cfg_path, exc)
-        return {}
-    try:
-        data = json.loads(raw)
-    except (json.JSONDecodeError, ValueError) as exc:
-        logging.warning("model_config_tags_invalid_json: %s (%s)", cfg_path, exc)
-        return {}
-    if not isinstance(data, dict):
-        logging.warning(
-            "model_config_tags_not_a_dict: %s (got %s)",
-            cfg_path,
-            type(data).__name__,
-        )
+    data = _load_model_config_dict(model_path)
+    if data is None:
         return {}
     out: dict = {}
-    arches_raw = data.get("architectures")
-    if isinstance(arches_raw, list):
-        arches = [str(a).strip() for a in arches_raw if str(a or "").strip()]
-        if arches:
-            out["architectures"] = arches
-    elif isinstance(arches_raw, str) and arches_raw.strip():
-        # Tolerate a scalar ``architectures`` by wrapping it in a list.
-        out["architectures"] = [arches_raw.strip()]
+    arches = _config_architectures(data)
+    if arches:
+        out["architectures"] = arches
     model_type = str(data.get("model_type") or "").strip()
     if model_type:
         out["model_type"] = model_type
     return out
+
+
+# ---------------------------------------------------------------------------
+# Unsupported-model (multimodal / vision) preflight gate
+# ---------------------------------------------------------------------------
+# Hyperloom only supports text-generation (decoder-only causal LM) models.
+# Multimodal / vision models occasionally leak past the upstream submission
+# filter and only fail ~5 minutes into the run with a cryptic vLLM
+# ``OSError: Can't load image processor ...``, burning a full session slot.
+# The constants below drive a fail-fast classifier that runs before the
+# (expensive) baseline server boot.
+
+# config.json ``model_type`` values that denote a multimodal / vision model.
+_MULTIMODAL_MODEL_TYPES = frozenset({
+    "gemma3",
+    "mllama",
+    "llava",
+    "llava_next",
+    "qwen2_vl",
+    "qwen2_5_vl",
+    "idefics",
+    "idefics2",
+    "idefics3",
+    "paligemma",
+    "pixtral",
+    "internvl_chat",
+    "phi3_v",
+})
+
+# Known multimodal architecture class names whose mere presence is decisive.
+# Most also end with ``ForConditionalGeneration`` (caught by the suffix rule),
+# but a few (``InternVLChatModel``, ``Phi3VForCausalLM``) do not, so they are
+# listed explicitly as a belt-and-suspenders.
+_KNOWN_MULTIMODAL_ARCHITECTURES = frozenset({
+    "Gemma3ForConditionalGeneration",
+    "LlavaForConditionalGeneration",
+    "LlavaNextForConditionalGeneration",
+    "MllamaForConditionalGeneration",
+    "PaliGemmaForConditionalGeneration",
+    "Qwen2VLForConditionalGeneration",
+    "Qwen2_5_VLForConditionalGeneration",
+    "Idefics2ForConditionalGeneration",
+    "Idefics3ForConditionalGeneration",
+    "PixtralForConditionalGeneration",
+    "InternVLChatModel",
+    "Phi3VForCausalLM",
+})
+
+# config.json keys whose mere presence signals a vision / multimodal model.
+_MULTIMODAL_CONFIG_KEYS = ("vision_config", "image_token_id", "image_token_index")
+
+
+def _arch_is_unsupported_multimodal(arch: str) -> bool:
+    """True when an architecture class name denotes a multimodal/vision model.
+
+    Three signals (any matches): an explicit known-multimodal class name; the
+    ``ForConditionalGeneration`` suffix (seq2seq / multimodal generation heads,
+    never a decoder-only causal LM); or a ``Vision`` substring.
+    """
+    a = (arch or "").strip()
+    if not a:
+        return False
+    if a in _KNOWN_MULTIMODAL_ARCHITECTURES:
+        return True
+    if a.endswith("ForConditionalGeneration"):
+        return True
+    if "Vision" in a:
+        return True
+    return False
+
+
+def _detect_unsupported_model(model_path: str) -> dict | None:
+    """Best-effort classification of a model as unsupported multimodal/vision.
+
+    Reads ``config.json`` (via :func:`_load_model_config_dict`) and flags the
+    model as unsupported when ANY of these hold:
+
+      * an entry in ``architectures`` is a known multimodal class, ends with
+        ``ForConditionalGeneration``, or contains ``Vision``;
+      * ``model_type`` is in the multimodal blocklist;
+      * a vision marker key (``vision_config`` / ``image_token_id`` /
+        ``image_token_index``) is present.
+
+    Returns a dict ``{"architecture", "model_type", "signal"}`` describing the
+    offending signal when unsupported, else ``None``. ``None`` also covers the
+    best-effort case where ``config.json`` is missing / unreadable / invalid:
+    we deliberately do NOT hard-block on a config we cannot read (the upstream
+    submission filter and the downstream model loader still apply).
+    """
+    config = _load_model_config_dict(model_path)
+    if config is None:
+        return None
+    architectures = _config_architectures(config)
+    model_type = str(config.get("model_type") or "").strip()
+
+    for arch in architectures:
+        if _arch_is_unsupported_multimodal(arch):
+            return {
+                "architecture": arch,
+                "model_type": model_type,
+                "signal": f"architecture '{arch}'",
+            }
+    if model_type.lower() in _MULTIMODAL_MODEL_TYPES:
+        return {
+            "architecture": architectures[0] if architectures else "",
+            "model_type": model_type,
+            "signal": f"model_type '{model_type}'",
+        }
+    for key in _MULTIMODAL_CONFIG_KEYS:
+        if key in config:
+            return {
+                "architecture": architectures[0] if architectures else "",
+                "model_type": model_type,
+                "signal": f"config key '{key}'",
+            }
+    return None
 
 
 # config.json keys that carry the model's max sequence length, priority order.
@@ -1061,6 +1199,92 @@ def _preflight_context_window(args: argparse.Namespace, session_dir: Path) -> bo
         print(
             f"WARNING: failed to write session_breakdown.json on context "
             f"fail-fast: {exc!r}",
+            file=sys.stderr,
+        )
+    print(f"ERROR: {reason}", file=sys.stderr)
+    return True
+
+
+def _preflight_unsupported_model_arch(
+    args: argparse.Namespace, session_dir: Path,
+) -> bool:
+    """Fail fast when the model is an unsupported multimodal / vision model.
+
+    Hyperloom only supports text-generation (decoder-only causal LM) models.
+    A multimodal model (e.g. ``Gemma3ForConditionalGeneration``, ``qwen2_vl``)
+    that slips past the upstream submission filter would otherwise boot the
+    baseline server and only die ~5 minutes in with a cryptic vLLM
+    ``OSError: Can't load image processor ...``, wasting a full session slot.
+    We classify the model from its ``config.json`` and, when it is positively
+    identified as multimodal/vision, persist a clear stop reason
+    (state.json + reports/final.{json,md} + session_breakdown.json) and signal
+    the caller to exit non-zero — before any expensive bring-up.
+
+    Best-effort: a missing / unreadable / invalid ``config.json`` is NOT a
+    hard block (the upstream filter + downstream loader still apply); only a
+    positively-identified multimodal model is rejected.
+
+    Returns True when the model is unsupported (caller should exit); False
+    when it is a supported text model or cannot be classified (gate skipped).
+    """
+    model = str(getattr(args, "model", "") or "")
+    hit = _detect_unsupported_model(model)
+    if hit is None:
+        return False
+
+    name = Path(model).name or model
+    arch = hit.get("architecture") or "<unknown>"
+    mt = hit.get("model_type") or "<unknown>"
+    reason = (
+        f"Unsupported model '{name}': architecture '{arch}' (model_type "
+        f"'{mt}') is a multimodal/vision model. Hyperloom currently supports "
+        f"text-generation (decoder-only causal LM) models only. Matched on "
+        f"{hit.get('signal', 'a multimodal signal')}. Refusing to run (the "
+        f"baseline server would die minutes in with an image-processor load "
+        f"error). Submit a text-generation checkpoint instead."
+    )
+    # Persist the stop reason so CI / the robustness monitor read it from
+    # state.json + reports/final.json instead of grepping the run log.
+    try:
+        from .orchestrator.shared_state import SharedState
+        from .orchestrator.action_executors.report import (
+            _build_summary_dict,
+            _format_md,
+        )
+        from .session_paths import reports_dir
+
+        state = SharedState.load_or_init(session_dir)
+        # Validated writer keeps the vocab-closed invariant: the term is
+        # registered in STOP_REASON_VOCAB, so this neither maps to 'unknown'
+        # (lenient) nor raises (strict), and the robustness monitor's
+        # vocab-based terminal check recognises the fail-fast.
+        state.set_stop_reason("unsupported_model_arch")
+        state.closing_phase = True
+        state.save(session_dir)
+        summary = _build_summary_dict(state, {}, [], external_baseline=None)
+        summary["stop_detail"] = reason
+        rdir = reports_dir(session_dir)
+        rdir.mkdir(parents=True, exist_ok=True)
+        (rdir / "final.json").write_text(
+            json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8",
+        )
+        (rdir / "final.md").write_text(_format_md(summary), encoding="utf-8")
+    except Exception as exc:  # noqa: BLE001 — don't mask the reason on a writer bug
+        print(
+            f"WARNING: failed to persist unsupported-model stop report: {exc!r}",
+            file=sys.stderr,
+        )
+    # Delivery-artifact parity: cli's normal exit writes session_breakdown.json
+    # in coordinator.run()'s finally, but this fail-fast sys.exit(2)s before
+    # that try/finally is ever entered. Emit it here too (best-effort) so CI's
+    # delivery contract sees a clean, documented skip — not "Missing artifacts".
+    try:
+        from .breakdown import write_breakdown_json
+        write_breakdown_json(session_dir)
+    except Exception as exc:  # noqa: BLE001 — best-effort; never mask the reason
+        print(
+            f"WARNING: failed to write session_breakdown.json on unsupported-"
+            f"model fail-fast: {exc!r}",
             file=sys.stderr,
         )
     print(f"ERROR: {reason}", file=sys.stderr)
@@ -3748,6 +3972,15 @@ async def _run_optimize(args: argparse.Namespace) -> int:
         _seed_shared_state(
             session_dir, args, session_id=manifest["session_id"],
         )
+        # Unsupported-model preflight: Hyperloom only supports text-generation
+        # (decoder-only causal LM) models. Refuse to run (with a persisted stop
+        # reason) when config.json identifies a multimodal/vision model, which
+        # would otherwise boot the baseline server only to die minutes in with
+        # a cryptic image-processor load error. Runs first (most fundamental
+        # rejection) and, like the context-window gate, after the SharedState
+        # seed but before the heavy Cortex / backend / Coordinator bring-up.
+        if _preflight_unsupported_model_arch(args, session_dir):
+            sys.exit(2)
         # Context-window preflight: refuse to run (with a persisted stop
         # reason) when ISL+OSL+headroom exceeds the model's
         # max_position_embeddings, instead of booting a server that 400s every

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -919,13 +919,16 @@ def _load_model_config_tags(model_path: str) -> dict:
 # filter and only fail ~5 minutes into the run with a cryptic vLLM
 # ``OSError: Can't load image processor ...``, burning a full session slot.
 # The constants below drive a fail-fast classifier that runs before the
-# (expensive) baseline server boot. Uses a WHITELIST approach: only models
-# whose architecture matches known text-generation patterns are allowed.
+# (expensive) baseline server boot. It first rejects explicit multimodal /
+# vision signals, then uses a WHITELIST approach: only models whose
+# architecture matches known text-generation patterns are allowed.
 
-# Supported text-generation architecture suffixes. Only decoder-only causal LM
+# Supported text-generation architecture markers. Only decoder-only causal LM
 # models are supported. If a model's architecture does NOT match any of these
-# patterns, it is rejected as unsupported.
-_SUPPORTED_ARCH_SUFFIXES = (
+# patterns, it is rejected as unsupported. ``ForCausalLM`` is treated as an
+# infix because some text-generation variants append a suffix
+# (for example ``DeepseekV3ForCausalLMNextN`` / ``LlamaForCausalLMEagle3``).
+_SUPPORTED_ARCH_MARKERS = (
     "ForCausalLM",
     "LMHeadModel",
     "ForCausalLMWithValueHead",
@@ -946,6 +949,52 @@ _SUPPORTED_MODEL_TYPES = frozenset({
     "stablelm", "persimmon",
 })
 
+# Explicit multimodal / vision signals that must win even if an architecture
+# also happens to end with ``ForCausalLM`` (for example Phi3VForCausalLM).
+_UNSUPPORTED_MODEL_TYPES = frozenset({
+    "gemma3",
+    "mllama",
+    "llava",
+    "llava_next",
+    "qwen2_vl",
+    "qwen2_5_vl",
+    "idefics",
+    "idefics2",
+    "idefics3",
+    "paligemma",
+    "pixtral",
+    "internvl_chat",
+    "phi3_v",
+})
+
+_UNSUPPORTED_ARCHITECTURES = frozenset({
+    "Gemma3ForConditionalGeneration",
+    "InternVLChatModel",
+    "Phi3VForCausalLM",
+    "LlavaForConditionalGeneration",
+    "LlavaNextForConditionalGeneration",
+    "MllamaForConditionalGeneration",
+    "PaliGemmaForConditionalGeneration",
+    "Qwen2VLForConditionalGeneration",
+    "Qwen2_5_VLForConditionalGeneration",
+    "Idefics2ForConditionalGeneration",
+    "Idefics3ForConditionalGeneration",
+    "PixtralForConditionalGeneration",
+})
+
+_UNSUPPORTED_CONFIG_KEYS = (
+    "vision_config",
+    "image_token_id",
+    "image_token_index",
+    "mm_config",
+    "multi_modal_config",
+    "vision_tower",
+    "vision_tower_cfg",
+    "image_processor_type",
+    "projector_config",
+    "mm_projector_type",
+)
+
 
 def _arch_is_supported_text_generation(arch: str) -> bool:
     """True when an architecture class name denotes a supported text-generation
@@ -953,14 +1002,15 @@ def _arch_is_supported_text_generation(arch: str) -> bool:
     a = (arch or "").strip()
     if not a:
         return False
-    return any(a.endswith(suffix) for suffix in _SUPPORTED_ARCH_SUFFIXES)
+    return any(marker in a for marker in _SUPPORTED_ARCH_MARKERS)
 
 
 def _detect_unsupported_model(model_path: str) -> dict | None:
     """Best-effort classification of a model as unsupported (non-text-generation).
 
-    Uses a WHITELIST approach: a model is supported if its architecture ends with
-    a known text-generation suffix (ForCausalLM, LMHeadModel, etc.) OR its
+    Explicit multimodal / vision signals are rejected first. Otherwise, uses a
+    WHITELIST approach: a model is supported if its architecture ends with a
+    known text-generation suffix (ForCausalLM, LMHeadModel, etc.) OR its
     model_type is in the explicit allowlist. Everything else is rejected.
 
     Returns a dict ``{"architecture", "model_type", "signal"}`` describing why
@@ -974,22 +1024,45 @@ def _detect_unsupported_model(model_path: str) -> dict | None:
         return None
     architectures = _config_architectures(config)
     model_type = str(config.get("model_type") or "").strip()
+    model_type_l = model_type.lower()
+
+    for arch in architectures:
+        if arch in _UNSUPPORTED_ARCHITECTURES:
+            return {
+                "architecture": arch,
+                "model_type": model_type,
+                "signal": f"unsupported architecture '{arch}'",
+            }
+    if model_type_l in _UNSUPPORTED_MODEL_TYPES:
+        return {
+            "architecture": architectures[0] if architectures else "",
+            "model_type": model_type,
+            "signal": f"unsupported model_type '{model_type}'",
+        }
+    for key in _UNSUPPORTED_CONFIG_KEYS:
+        if key in config:
+            return {
+                "architecture": architectures[0] if architectures else "",
+                "model_type": model_type,
+                "signal": f"unsupported multimodal config key '{key}'",
+            }
+
+    if any(_arch_is_supported_text_generation(a) for a in architectures):
+        return None
+
+    if model_type_l in _SUPPORTED_MODEL_TYPES:
+        return None
 
     if architectures:
-        if any(_arch_is_supported_text_generation(a) for a in architectures):
-            return None
         return {
             "architecture": architectures[0],
             "model_type": model_type,
             "signal": (
                 f"architecture '{architectures[0]}' does not match any "
                 f"supported text-generation pattern "
-                f"({', '.join(_SUPPORTED_ARCH_SUFFIXES)})"
+                f"({', '.join(_SUPPORTED_ARCH_MARKERS)})"
             ),
         }
-
-    if model_type.lower() in _SUPPORTED_MODEL_TYPES:
-        return None
 
     if model_type:
         return {
@@ -1001,7 +1074,11 @@ def _detect_unsupported_model(model_path: str) -> dict | None:
             ),
         }
 
-    return None
+    return {
+        "architecture": "",
+        "model_type": "",
+        "signal": "config.json has neither architectures nor model_type",
+    }
 
 
 # config.json keys that carry the model's max sequence length, priority order.
@@ -1215,8 +1292,8 @@ def _preflight_unsupported_model_arch(
     reason = (
         f"Unsupported model '{name}': architecture '{arch}' (model_type "
         f"'{mt}') is not a supported text-generation model. Hyperloom only "
-        f"supports decoder-only causal LM models (architectures ending with "
-        f"ForCausalLM / LMHeadModel). Rejected because: "
+        f"supports decoder-only causal LM models (architectures containing "
+        f"ForCausalLM or LMHeadModel). Rejected because: "
         f"{hit.get('signal', 'unknown architecture')}. Submit a "
         f"text-generation checkpoint instead."
     )

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -919,81 +919,52 @@ def _load_model_config_tags(model_path: str) -> dict:
 # filter and only fail ~5 minutes into the run with a cryptic vLLM
 # ``OSError: Can't load image processor ...``, burning a full session slot.
 # The constants below drive a fail-fast classifier that runs before the
-# (expensive) baseline server boot.
+# (expensive) baseline server boot. Uses a WHITELIST approach: only models
+# whose architecture matches known text-generation patterns are allowed.
 
-# config.json ``model_type`` values that denote a multimodal / vision model.
-_MULTIMODAL_MODEL_TYPES = frozenset({
-    "gemma3",
-    "mllama",
-    "llava",
-    "llava_next",
-    "qwen2_vl",
-    "qwen2_5_vl",
-    "idefics",
-    "idefics2",
-    "idefics3",
-    "paligemma",
-    "pixtral",
-    "internvl_chat",
-    "phi3_v",
+# Supported text-generation architecture suffixes. Only decoder-only causal LM
+# models are supported. If a model's architecture does NOT match any of these
+# patterns, it is rejected as unsupported.
+_SUPPORTED_ARCH_SUFFIXES = (
+    "ForCausalLM",
+    "LMHeadModel",
+    "ForCausalLMWithValueHead",
+)
+
+# Explicit allowlist of supported model_type values (fallback when architectures
+# field is empty/missing). Models whose model_type is in this set pass through.
+_SUPPORTED_MODEL_TYPES = frozenset({
+    "llama", "mistral", "mixtral", "qwen2", "qwen2_moe", "qwen3", "qwen3_moe",
+    "gemma", "gemma2", "phi", "phi3", "phimoe",
+    "starcoder2", "codellama", "deepseek_v2", "deepseek_v3",
+    "falcon", "gpt_neox", "gpt2", "opt", "bloom",
+    "internlm", "internlm2", "yi", "baichuan",
+    "chatglm", "glm", "glm4",
+    "command-r", "cohere", "cohere2", "dbrx",
+    "mpt", "olmo", "olmo2", "jamba", "arctic",
+    "exaone", "granite", "granitemoeshared",
+    "stablelm", "persimmon",
 })
 
-# Known multimodal architecture class names whose mere presence is decisive.
-# Most also end with ``ForConditionalGeneration`` (caught by the suffix rule),
-# but a few (``InternVLChatModel``, ``Phi3VForCausalLM``) do not, so they are
-# listed explicitly as a belt-and-suspenders.
-_KNOWN_MULTIMODAL_ARCHITECTURES = frozenset({
-    "Gemma3ForConditionalGeneration",
-    "LlavaForConditionalGeneration",
-    "LlavaNextForConditionalGeneration",
-    "MllamaForConditionalGeneration",
-    "PaliGemmaForConditionalGeneration",
-    "Qwen2VLForConditionalGeneration",
-    "Qwen2_5_VLForConditionalGeneration",
-    "Idefics2ForConditionalGeneration",
-    "Idefics3ForConditionalGeneration",
-    "PixtralForConditionalGeneration",
-    "InternVLChatModel",
-    "Phi3VForCausalLM",
-})
 
-# config.json keys whose mere presence signals a vision / multimodal model.
-_MULTIMODAL_CONFIG_KEYS = ("vision_config", "image_token_id", "image_token_index")
-
-
-def _arch_is_unsupported_multimodal(arch: str) -> bool:
-    """True when an architecture class name denotes a multimodal/vision model.
-
-    Three signals (any matches): an explicit known-multimodal class name; the
-    ``ForConditionalGeneration`` suffix (seq2seq / multimodal generation heads,
-    never a decoder-only causal LM); or a ``Vision`` substring.
-    """
+def _arch_is_supported_text_generation(arch: str) -> bool:
+    """True when an architecture class name denotes a supported text-generation
+    (decoder-only causal LM) model."""
     a = (arch or "").strip()
     if not a:
         return False
-    if a in _KNOWN_MULTIMODAL_ARCHITECTURES:
-        return True
-    if a.endswith("ForConditionalGeneration"):
-        return True
-    if "Vision" in a:
-        return True
-    return False
+    return any(a.endswith(suffix) for suffix in _SUPPORTED_ARCH_SUFFIXES)
 
 
 def _detect_unsupported_model(model_path: str) -> dict | None:
-    """Best-effort classification of a model as unsupported multimodal/vision.
+    """Best-effort classification of a model as unsupported (non-text-generation).
 
-    Reads ``config.json`` (via :func:`_load_model_config_dict`) and flags the
-    model as unsupported when ANY of these hold:
+    Uses a WHITELIST approach: a model is supported if its architecture ends with
+    a known text-generation suffix (ForCausalLM, LMHeadModel, etc.) OR its
+    model_type is in the explicit allowlist. Everything else is rejected.
 
-      * an entry in ``architectures`` is a known multimodal class, ends with
-        ``ForConditionalGeneration``, or contains ``Vision``;
-      * ``model_type`` is in the multimodal blocklist;
-      * a vision marker key (``vision_config`` / ``image_token_id`` /
-        ``image_token_index``) is present.
-
-    Returns a dict ``{"architecture", "model_type", "signal"}`` describing the
-    offending signal when unsupported, else ``None``. ``None`` also covers the
+    Returns a dict ``{"architecture", "model_type", "signal"}`` describing why
+    the model is unsupported, else ``None`` (supported). ``None`` also covers the
     best-effort case where ``config.json`` is missing / unreadable / invalid:
     we deliberately do NOT hard-block on a config we cannot read (the upstream
     submission filter and the downstream model loader still apply).
@@ -1004,26 +975,32 @@ def _detect_unsupported_model(model_path: str) -> dict | None:
     architectures = _config_architectures(config)
     model_type = str(config.get("model_type") or "").strip()
 
-    for arch in architectures:
-        if _arch_is_unsupported_multimodal(arch):
-            return {
-                "architecture": arch,
-                "model_type": model_type,
-                "signal": f"architecture '{arch}'",
-            }
-    if model_type.lower() in _MULTIMODAL_MODEL_TYPES:
+    if architectures:
+        if any(_arch_is_supported_text_generation(a) for a in architectures):
+            return None
         return {
-            "architecture": architectures[0] if architectures else "",
+            "architecture": architectures[0],
             "model_type": model_type,
-            "signal": f"model_type '{model_type}'",
+            "signal": (
+                f"architecture '{architectures[0]}' does not match any "
+                f"supported text-generation pattern "
+                f"({', '.join(_SUPPORTED_ARCH_SUFFIXES)})"
+            ),
         }
-    for key in _MULTIMODAL_CONFIG_KEYS:
-        if key in config:
-            return {
-                "architecture": architectures[0] if architectures else "",
-                "model_type": model_type,
-                "signal": f"config key '{key}'",
-            }
+
+    if model_type.lower() in _SUPPORTED_MODEL_TYPES:
+        return None
+
+    if model_type:
+        return {
+            "architecture": "",
+            "model_type": model_type,
+            "signal": (
+                f"model_type '{model_type}' is not in the supported "
+                f"text-generation allowlist"
+            ),
+        }
+
     return None
 
 
@@ -1237,11 +1214,11 @@ def _preflight_unsupported_model_arch(
     mt = hit.get("model_type") or "<unknown>"
     reason = (
         f"Unsupported model '{name}': architecture '{arch}' (model_type "
-        f"'{mt}') is a multimodal/vision model. Hyperloom currently supports "
-        f"text-generation (decoder-only causal LM) models only. Matched on "
-        f"{hit.get('signal', 'a multimodal signal')}. Refusing to run (the "
-        f"baseline server would die minutes in with an image-processor load "
-        f"error). Submit a text-generation checkpoint instead."
+        f"'{mt}') is not a supported text-generation model. Hyperloom only "
+        f"supports decoder-only causal LM models (architectures ending with "
+        f"ForCausalLM / LMHeadModel). Rejected because: "
+        f"{hit.get('signal', 'unknown architecture')}. Submit a "
+        f"text-generation checkpoint instead."
     )
     # Persist the stop reason so CI / the robustness monitor read it from
     # state.json + reports/final.json instead of grepping the run log.

--- a/inference_optimizer/orchestrator/action_executors/_grid_runner.py
+++ b/inference_optimizer/orchestrator/action_executors/_grid_runner.py
@@ -1012,6 +1012,131 @@ def inject_sglang_watchdog_timeout(
     return merge_server_args(args, f"{_SGLANG_WATCHDOG_FLAG} {timeout}")
 
 
+# ---------------------------------------------------------------------------
+# sglang ``--context-length`` cap injection
+#
+# sglang's ``launch_server`` defaults ``context_length`` to None, which makes
+# it size ``max_total_tokens`` from the model's ``max_position_embeddings``.
+# For a model that advertises a huge native window (e.g. Mistral-Nemo-12B =
+# ``max_position_embeddings=1024000``) sglang sizes ``max_total_tokens`` to
+# ~701062 and the aiter attention backend then allocates a ``workspace_buffer``
+# of >100 GiB -> ``torch.OutOfMemoryError: HIP out of memory`` -> the server
+# exits 1 and the benchmark reports ``baseline_failed`` with throughput 0.
+# InferenceX's ``vllm_*.sh`` scripts already cap their window via
+# ``--max-model-len $MAX_MODEL_LEN`` (default 4096), but ``sglang_*.sh`` passes
+# no ``--context-length`` and never consumes the YAML's ``MAX_MODEL_LEN``, so
+# the asymmetry only hurts sglang. We cap the context to the actual workload
+# (ISL+OSL+headroom, floored to a sane minimum) but NEVER above the model's
+# native window, and NEVER when the operator/YAML already pinned the flag.
+# Routing through ``EXTRA_SGLANG_ARGS`` (appended verbatim after the script's
+# DEFAULT_ARGS) reliably reaches ``python -m sglang.launch_server``.
+# ---------------------------------------------------------------------------
+DEFAULT_SGLANG_CONTEXT_HEADROOM_TOKENS = 2048
+DEFAULT_SGLANG_CONTEXT_FLOOR_TOKENS = 8192
+SGLANG_CONTEXT_HEADROOM_ENV = "SGLANG_CONTEXT_HEADROOM_TOKENS"
+SGLANG_CONTEXT_FLOOR_ENV = "SGLANG_CONTEXT_FLOOR_TOKENS"
+_SGLANG_CONTEXT_LENGTH_FLAG = "--context-length"
+# Matches the flag in space- or equals-separated form so an operator-pinned
+# ``--context-length 6144`` / ``--context-length=6144`` both suppress
+# injection, while a longer flag never false-matches.
+_SGLANG_CONTEXT_LENGTH_RE = re.compile(r"--context-length(?:[=\s]|$)")
+
+
+def _resolve_nonneg_int_env(name: str, default: int) -> int:
+    """Read a non-negative integer env override, else return ``default``.
+
+    A blank/non-integer/negative value logs a warning and falls back to the
+    default rather than crashing the YAML materialization.
+    """
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        val = int(raw)
+    except ValueError:
+        log.warning(
+            "%s=%r is not an integer; using default %d.", name, raw, default,
+        )
+        return default
+    if val < 0:
+        log.warning(
+            "%s=%d is negative; using default %d.", name, val, default,
+        )
+        return default
+    return val
+
+
+def resolve_sglang_context_cap(isl: int, osl: int) -> int:
+    """Resolve the sglang ``--context-length`` cap for an ISL+OSL workload.
+
+    Returns ``max(isl + osl + headroom, floor)`` where ``headroom`` and
+    ``floor`` come from :data:`DEFAULT_SGLANG_CONTEXT_HEADROOM_TOKENS` /
+    :data:`DEFAULT_SGLANG_CONTEXT_FLOOR_TOKENS`, each operator-tunable via
+    ``$SGLANG_CONTEXT_HEADROOM_TOKENS`` / ``$SGLANG_CONTEXT_FLOOR_TOKENS``.
+    The headroom absorbs the BOS/chat-template tokens and random-dataset
+    length jitter on top of the nominal workload; the floor keeps short smoke
+    workloads from pinning the window absurdly low. The caller clamps the
+    result to the model's native window before injecting.
+    """
+    headroom = _resolve_nonneg_int_env(
+        SGLANG_CONTEXT_HEADROOM_ENV, DEFAULT_SGLANG_CONTEXT_HEADROOM_TOKENS,
+    )
+    floor = _resolve_nonneg_int_env(
+        SGLANG_CONTEXT_FLOOR_ENV, DEFAULT_SGLANG_CONTEXT_FLOOR_TOKENS,
+    )
+    return max(int(isl) + int(osl) + headroom, floor)
+
+
+def inject_sglang_context_length(
+    server_args: str | None,
+    framework: str | None,
+    model_path: str | None,
+    isl: int,
+    osl: int,
+) -> str:
+    """Append ``--context-length <N>`` to ``server_args`` for sglang runs.
+
+    Returns ``server_args`` unchanged (coerced to a stripped string) when any
+    guard trips:
+
+    * ``framework`` does not route to ``EXTRA_SGLANG_ARGS`` -- vllm / atom
+      already cap their window via ``--max-model-len $MAX_MODEL_LEN`` in the
+      benchmark scripts, so they are left untouched. Framework detection
+      reuses :func:`server_args_env_name`, so an empty/unknown framework is
+      treated as sglang (the default backend), matching every other
+      arg-routing site in this module.
+    * ``server_args`` already contains ``--context-length`` (in space- or
+      equals-separated form) -- an operator/YAML/``extra_sglang_args`` value
+      wins and is never overridden or doubled.
+    * the model's ``max_position_embeddings`` cannot be read -- fail-safe to
+      today's behaviour (inject nothing) rather than guessing a window.
+
+    Otherwise it appends ``--context-length min(max_pos, cap)`` where ``cap``
+    comes from :func:`resolve_sglang_context_cap`. The clamp to ``max_pos``
+    means we never stretch the context above the model's native window (RoPE
+    extrapolation / learned-absolute-position breakage); the cap means we
+    never let sglang size ``max_total_tokens`` off a huge native window and
+    OOM the aiter ``workspace_buffer``. Only this flag is added.
+    """
+    args = str(server_args or "").strip()
+    if server_args_env_name(framework) != "EXTRA_SGLANG_ARGS":
+        return args
+    if _SGLANG_CONTEXT_LENGTH_RE.search(args):
+        return args
+    # Imported lazily: cli.py is the heavy top-level module and only imports
+    # this package lazily itself, so a module-level import here would risk a
+    # cycle. The loader handles nested ``text_config`` for multimodal configs.
+    from ...cli import _load_model_max_position_embeddings
+    max_pos = _load_model_max_position_embeddings(str(model_path or ""))
+    if not max_pos:
+        return args
+    cap = resolve_sglang_context_cap(isl, osl)
+    context_length = min(int(max_pos), cap)
+    return merge_server_args(
+        args, f"{_SGLANG_CONTEXT_LENGTH_FLAG} {context_length}",
+    )
+
+
 def apply_runtime_benchmark_overrides(
     bench: dict[str, Any],
     *,

--- a/inference_optimizer/orchestrator/action_executors/_magpie_patcher.py
+++ b/inference_optimizer/orchestrator/action_executors/_magpie_patcher.py
@@ -127,11 +127,17 @@ two writers never race on the same byte range. The patch write itself is
 atomic (temp file + ``os.replace``) so a crash mid-write cannot corrupt
 ``benchmarker.py``.
 
-If the expected legacy two-line block is missing (Magpie refactored, or
-someone has hand-patched the file to a different shape) the patcher
-logs a warning and returns ``False`` so the install script can decide
-whether to fail-loud (recommended, since this is a known RCA fix; an
-unpatched Magpie means ``bugs.md`` §C #1 is still wide open).
+If the expected legacy two-line block is missing the patcher is
+upstream-aware: it first checks whether the cloned Magpie already copies
+scripts atomically (newer upstream extracted a ``_copy_benchmark_script_atomic``
+helper, or otherwise does ``tempfile.mkstemp`` + ``os.replace`` inside
+``_prepare_benchmark_scripts``). If so the race is already closed, the
+Hyperloom #C1 patch is redundant, and ``ensure_*`` logs an ``info`` line
+and returns ``True`` without touching the file. Only when *neither* the
+legacy block *nor* any atomic implementation is found does the patcher log
+a warning and return ``False`` (a genuinely-unexpected shape) so the
+install script can decide whether to fail-loud; that case means
+``bugs.md`` §C #1 cannot be confirmed mitigated.
 """
 
 from __future__ import annotations
@@ -198,6 +204,24 @@ _PATCHED_BLOCK = (
 # patched?" sentinel so we don't have to re-derive the patched block.
 _PATCH_SENTINEL = "Hyperloom #C1 patch"
 
+# Name of the static helper upstream Magpie introduced when it refactored
+# the copy loop to be race-safe on its own (``tempfile.mkstemp`` +
+# ``shutil.copy2`` + ``os.chmod`` + ``os.replace``). Its presence means the
+# legacy two-line block is *gone because upstream already fixed it*, not
+# because the checkout drifted into an unrecognised shape.
+_UPSTREAM_ATOMIC_HELPER = "_copy_benchmark_script_atomic"
+
+# Atomic-write primitives we look for *within* the
+# ``_prepare_benchmark_scripts`` body when upstream inlined the temp-file +
+# rename dance instead of extracting the named helper above.
+_ATOMIC_MKSTEMP = "tempfile.mkstemp("
+_ATOMIC_REPLACE = "os.replace("
+
+# Header used to locate the method body we scope inline-atomic detection to,
+# so an unrelated ``os.replace`` elsewhere in ``benchmarker.py`` cannot be
+# mistaken for an already-fixed copy loop.
+_PREPARE_METHOD_MARKER = "def _prepare_benchmark_scripts"
+
 # System-wide lock. ``/tmp`` is writable inside containers and on the
 # validation Slurm nodes; persistence across reboots isn't needed (the
 # patch itself is persistent on disk).
@@ -262,6 +286,52 @@ def _is_patched(src: Path) -> bool:
         return False
 
 
+def _extract_prepare_region(text: str) -> str:
+    """Return the source slice covering the ``_prepare_benchmark_scripts``
+    method body, or ``""`` when the method header is absent.
+
+    Inline-atomic detection (``mkstemp`` + ``os.replace``) is scoped to this
+    slice so an unrelated ``os.replace`` elsewhere in ``benchmarker.py``
+    cannot masquerade as an already-fixed copy loop. The slice spans from
+    the ``def`` header to the first subsequent non-blank line indented at or
+    below the header column (the next sibling ``def``/``class`` or dedented
+    code), which bounds exactly one method body.
+    """
+    start = text.find(_PREPARE_METHOD_MARKER)
+    if start == -1:
+        return ""
+    line_start = text.rfind("\n", 0, start) + 1
+    def_indent = start - line_start
+    lines = text[line_start:].splitlines(keepends=True)
+    region = [lines[0]]
+    for line in lines[1:]:
+        if not line.strip():
+            region.append(line)
+            continue
+        indent = len(line) - len(line.lstrip())
+        if indent <= def_indent:
+            break
+        region.append(line)
+    return "".join(region)
+
+
+def _upstream_is_already_atomic(text: str) -> bool:
+    """True when the cloned Magpie already copies scripts atomically, so the
+    Hyperloom #C1 patch is redundant (a no-op) rather than missing.
+
+    Either signal is sufficient:
+
+    * the file defines/uses ``_copy_benchmark_script_atomic`` — the helper
+      upstream Magpie introduced when it made the copy loop race-safe; or
+    * the ``_prepare_benchmark_scripts`` body itself performs an inline
+      temp-file + atomic rename (``tempfile.mkstemp(`` and ``os.replace(``).
+    """
+    if _UPSTREAM_ATOMIC_HELPER in text:
+        return True
+    region = _extract_prepare_region(text)
+    return _ATOMIC_MKSTEMP in region and _ATOMIC_REPLACE in region
+
+
 def _apply_patch_atomic(src: Path) -> bool:
     """Rewrite ``src`` via temp-file + atomic rename so a crash
     mid-write cannot leave a corrupt ``benchmarker.py``.
@@ -273,11 +343,20 @@ def _apply_patch_atomic(src: Path) -> bool:
         return False
 
     if _LEGACY_BLOCK not in original:
+        if _upstream_is_already_atomic(original):
+            log.info(
+                "_magpie_patcher: Magpie upstream already performs atomic "
+                "script copy (found _copy_benchmark_script_atomic / "
+                "mkstemp+os.replace); Hyperloom #C1 patch is a no-op for %s",
+                src,
+            )
+            return True
         log.warning(
-            "_magpie_patcher: expected legacy two-line block not found in %s; "
-            "Magpie may have been refactored upstream, or this checkout was "
-            "hand-patched. Hyperloom bugs.md §C #1 (script-tearing race) is "
-            "NOT mitigated — `profile`/`baseline` may hit "
+            "_magpie_patcher: neither the legacy shutil.copy2/chmod block nor "
+            "an atomic copy implementation found in %s; Magpie may have been "
+            "refactored into an unrecognised shape, or this checkout was "
+            "hand-patched. Hyperloom bugs.md §C #1 (script-tearing race) "
+            "cannot be confirmed mitigated — `profile`/`baseline` may hit "
             "`syntax error near unexpected token 'fi'` again. Manual review "
             "needed.",
             src,
@@ -327,16 +406,21 @@ def _apply_patch_atomic(src: Path) -> bool:
 def ensure_magpie_atomic_scripts_patch(
     magpie_dir: Path | str | None = None,
 ) -> bool:
-    """Ensure cloned Magpie's ``_prepare_benchmark_scripts`` uses an
-    atomic ``os.replace`` for each script copy.
+    """Ensure cloned Magpie's ``_prepare_benchmark_scripts`` copies each
+    script atomically (via ``os.replace``).
 
-    Returns ``True`` when the file is in patched state at exit
-    (already-patched or freshly-patched both count); ``False`` when
-    the file could not be located or the expected legacy block is
-    missing. The install script is expected to ``fail-loud`` on
-    ``False`` (unlike the InferenceX patcher which is best-effort) —
-    this is a known root-cause fix; an unpatched Magpie means
-    ``bugs.md`` §C #1 remains wide open.
+    Returns ``True`` when the race is closed at exit, which covers three
+    cases: freshly-patched, already-patched (sentinel present), or an
+    upstream that is *already* atomic (``_copy_benchmark_script_atomic`` /
+    inline ``mkstemp`` + ``os.replace``) — in the last case the Hyperloom
+    #C1 patch is a redundant no-op and the file is left untouched.
+
+    Returns ``False`` only when the file could not be located, or when
+    *neither* the legacy block *nor* any atomic implementation is found
+    (a genuinely-unexpected shape). The install script is expected to
+    ``fail-loud`` on ``False`` (unlike the InferenceX patcher which is
+    best-effort) — this is a known root-cause fix, and that case means
+    ``bugs.md`` §C #1 cannot be confirmed mitigated.
 
     Safe to call from any number of processes concurrently — flock
     serialises the read-then-write window; temp-file + rename

--- a/inference_optimizer/orchestrator/action_executors/_workload_envs.py
+++ b/inference_optimizer/orchestrator/action_executors/_workload_envs.py
@@ -48,7 +48,11 @@ from typing import Any
 import yaml
 
 from ...paths import asset_root
-from ._grid_runner import inject_sglang_watchdog_timeout, server_args_env_name
+from ._grid_runner import (
+    inject_sglang_context_length,
+    inject_sglang_watchdog_timeout,
+    server_args_env_name,
+)
 from ._server_patcher import (
     ensure_sglang_patched_for_tracelens,
     ensure_vllm_patched_for_tracelens,
@@ -512,20 +516,33 @@ def materialize_config_with_envs(
             envs[framework_env] = server_args
     for key, value in (extra_envs or {}).items():
         envs[str(key)] = str(value)
-    # MI300X cold-compile guard: ensure sglang's scheduler watchdog is long
-    # enough to survive the first-request aiter ``mha_batch_prefill`` JIT
-    # compile. sglang's 300s default fires SIGQUIT mid-warmup on a cold aiter
-    # cache and the server dies -> baseline_failed / throughput 0. We resolve
-    # the FINAL framework env (after the server_args + extra_envs merges
-    # above) so a user-pinned ``--watchdog-timeout`` (via extra_server_args,
-    # extra_envs, or the YAML) is honored and never doubled. No-op for
-    # vllm/atom, and never touches ``--context-length`` / MAX_MODEL_LEN. This
-    # is the single choke point every benchmark path (baseline / profile /
-    # sweep / explore / framework_pr / conc_sweep) funnels through before the
-    # YAML is handed to Magpie, so the flag reaches every sglang launch.
+    # sglang server-arg guards, applied at the FINAL framework env (after the
+    # server_args + extra_envs merges above) so any operator-pinned flag (via
+    # extra_server_args, extra_envs, or the YAML) is honored and never doubled.
+    # Both are no-ops for vllm/atom. This is the single choke point every
+    # benchmark path (baseline / profile / sweep / explore / framework_pr /
+    # conc_sweep) funnels through before the YAML is handed to Magpie, so the
+    # flags reach every sglang launch.
+    #
+    # 1. --context-length cap: sglang defaults context_length=None and sizes
+    #    max_total_tokens off the model's max_position_embeddings; a huge
+    #    native window (e.g. Mistral-Nemo's 1024000) balloons the aiter
+    #    workspace_buffer past GPU memory -> HIP OOM -> baseline_failed. We cap
+    #    to ISL+OSL+headroom (floored, clamped to the native window). vllm
+    #    already passes --max-model-len $MAX_MODEL_LEN, so this only fixes the
+    #    sglang asymmetry; sglang ignores MAX_MODEL_LEN entirely.
+    # 2. MI300X cold-compile guard: ensure sglang's scheduler watchdog is long
+    #    enough to survive the first-request aiter ``mha_batch_prefill`` JIT
+    #    compile. sglang's 300s default fires SIGQUIT mid-warmup on a cold
+    #    aiter cache and the server dies -> baseline_failed / throughput 0.
     framework_env = server_args_env_name(bench.get("framework"))
+    resolved_server_args = str(envs.get(framework_env, "")).strip()
+    resolved_server_args = inject_sglang_context_length(
+        resolved_server_args, bench.get("framework"),
+        bench.get("model"), isl_val, osl_val,
+    )
     resolved_server_args = inject_sglang_watchdog_timeout(
-        str(envs.get(framework_env, "")).strip(), bench.get("framework"),
+        resolved_server_args, bench.get("framework"),
     )
     if resolved_server_args:
         envs[framework_env] = resolved_server_args

--- a/inference_optimizer/orchestrator/phase_state.py
+++ b/inference_optimizer/orchestrator/phase_state.py
@@ -264,6 +264,13 @@ STOP_REASON_VOCAB: frozenset[str] = frozenset({
     # the model's max_position_embeddings cannot hold ISL+OSL+headroom, so we
     # fail fast before booting a server that would 400 every request.
     "model_context_window_too_small",
+    # Pre-run model-architecture preflight
+    # (``cli._preflight_unsupported_model_arch``): the model is a
+    # multimodal/vision model (e.g. Gemma3ForConditionalGeneration, qwen2_vl)
+    # but Hyperloom only supports text-generation (decoder-only causal LM)
+    # models, so we fail fast before booting a server that would die ~5min in
+    # with a cryptic image-processor load error.
+    "unsupported_model_arch",
 })
 
 

--- a/inference_optimizer/scripts/install.sh
+++ b/inference_optimizer/scripts/install.sh
@@ -11,11 +11,13 @@
 #   1. inference_optimizer + extras (pulls in claude_agent_sdk via
 #      pyproject `[test]` extra)
 #   2. Magpie (benchmark engine) into $HYPERLOOM_RUNTIME_DIR/Magpie
-#      (= $USER_DATA_PATH/runtime/Magpie by default)
+#      (= $USER_DATA_PATH/runtime/Magpie by default), pinned to MAGPIE_REF
+#      (a commit SHA, mirrors the GEAK_REF pin in kernel-agent)
 #   2b. Atomic-write patch for Magpie._prepare_benchmark_scripts
-#       (bugs.md §C #1 root-cause fix; fail-loud)
-#   3. InferenceX checkout: clone latest from upstream (no SHA pin yet),
-#      sets INFERENCEX_PATH for runtime
+#       (bugs.md §C #1 root-cause fix; fail-soft — a no-op when MAGPIE_REF
+#       is pinned to an upstream-atomic commit)
+#   3. InferenceX checkout: clone from upstream pinned to INFERENCEX_REF
+#      (a commit SHA), sets INFERENCEX_PATH for runtime
 #   4. Delegates to kernel-agent/scripts/install.sh for ray, ray-head
 #      bring-up, Node/npm, TraceLens, GEAK, OOB and CLI auth-file setup.
 #      kernel-agent itself is the canonical owner of those — we just
@@ -92,8 +94,25 @@ HYPERLOOM_ROOT="${HYPERLOOM_ROOT:-${HYPERLOOM_RUNTIME_DIR}/source-mirrors}"
 KERNEL_AGENT_ROOT="${KERNEL_AGENT_ROOT:-${REPO_ROOT}/kernel-agent}"
 FRAMEWORK_AGENT_ROOT="${FRAMEWORK_AGENT_ROOT:-${REPO_ROOT}/framework-agent}"
 MAGPIE_REPO="${MAGPIE_REPO:-https://github.com/AMD-AGI/Magpie.git}"
+# Pin Magpie to a *commit SHA* (not a branch name) so a fresh install is
+# deterministic and an upstream force-push / rebase cannot silently change
+# what every fresh clone gets. This default-branch HEAD drift is the root
+# cause of bugs.md §C #1 version skew: Magpie merged the atomic-copy refactor
+# (`_copy_benchmark_script_atomic` in Magpie/modes/benchmark/benchmarker.py)
+# between 06-06 and 06-07. Pre-refactor clones still had the legacy
+# `shutil.copy2` + `chmod` block the in-place patcher targets; post-refactor
+# clones do not ("legacy block not found"). We deliberately pin to a
+# post-refactor SHA: the upstream code is already atomic, so the in-place
+# patch (ensure_magpie_atomic_scripts_patch) becomes a no-op and is
+# fail-soft below. Operators can re-pin with MAGPIE_REF=<tag|branch|sha>
+# (mirrors GEAK_REF in kernel-agent/scripts/install.sh).
+MAGPIE_REF="${MAGPIE_REF:-b1d4dcdee7eaf7bcab4fac13ab751f61bffdc3f7}"
 MAGPIE_DIR="${MAGPIE_DIR:-${HYPERLOOM_RUNTIME_DIR}/Magpie}"
 INFERENCEX_REPO="${INFERENCEX_REPO:-https://github.com/SemiAnalysisAI/InferenceX.git}"
+# Pin InferenceX to a current default-branch HEAD *commit SHA* so the
+# per-install clone is reproducible (same rationale as MAGPIE_REF). Operators
+# can re-pin with INFERENCEX_REF=<tag|branch|sha>.
+INFERENCEX_REF="${INFERENCEX_REF:-2035a2117ad22403376359be0064dfa2c078c59b}"
 INFERENCEX_DEFAULT_DIR="${INFERENCEX_DEFAULT_DIR:-${HYPERLOOM_RUNTIME_DIR}/InferenceX}"
 
 DRY_RUN=0
@@ -127,7 +146,12 @@ Options:
 
 Env overrides:
   REPO_ROOT, KERNEL_AGENT_ROOT, FRAMEWORK_AGENT_ROOT, MAGPIE_REPO,
-  MAGPIE_DIR, INFERENCEX_REPO, INFERENCEX_DEFAULT_DIR, INFERENCEX_PATH,
+  MAGPIE_REF (commit SHA / tag / branch the Magpie clone is pinned to;
+    default is a commit that already copies benchmark scripts atomically),
+  MAGPIE_DIR, INFERENCEX_REPO,
+  INFERENCEX_REF (commit SHA / tag / branch the InferenceX clone is pinned
+    to; default is a current upstream HEAD SHA),
+  INFERENCEX_DEFAULT_DIR, INFERENCEX_PATH,
   PYTHON, TRACELENS_ROOT,
   TRACELENS_INTERNAL_ROOT (set to enable the optional internal extension;
     unset => open-source-only),
@@ -159,6 +183,30 @@ run() {
   if [ "$DRY_RUN" -eq 0 ] && [ "$CHECK_ONLY" -eq 0 ]; then
     "$@"
   fi
+}
+
+# Clone a dependency pinned to $ref into $dir, mirroring the GEAK pin in
+# kernel-agent/scripts/install.sh. `git clone --branch` only accepts
+# tags/branches, not raw SHAs, so a 7-40 hex char ref triggers a shallow
+# fetch-checkout dance instead (GitHub serves shallow SHA fetches via
+# uploadpack.allowReachableSHA1InWant=true). DRY_RUN / CHECK_ONLY are honoured
+# through the shared `run` helper. On success the checkout has a valid HEAD at
+# $ref, so manifest.py's _git_revision_at() still resolves the pinned commit.
+# Returns non-zero (stopping at the first failed step) so callers can choose
+# fail-loud (Magpie) or fail-soft (InferenceX).
+git_fetch_pinned() {
+  local repo="$1" dir="$2" ref="$3" label="$4"
+  if [[ "$ref" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
+    log "fetching ${label} pinned to commit ${ref} (shallow fetch-checkout)"
+    run git init -q "$dir" || return 1
+    run git -C "$dir" remote add origin "$repo" || return 1
+    run git -C "$dir" fetch --depth 1 origin "$ref" || return 1
+    run git -C "$dir" checkout -q FETCH_HEAD || return 1
+  else
+    log "cloning ${label} pinned to ref ${ref} (--branch)"
+    run git clone --depth 1 --branch "$ref" "$repo" "$dir" || return 1
+  fi
+  return 0
 }
 
 # Serialize concurrent installs that share one $USER_DATA_PATH. Installs
@@ -473,8 +521,8 @@ ensure_magpie() {
     mkdir -p "$(dirname "$MAGPIE_DIR")"
   fi
   if [ ! -f "$MAGPIE_DIR/setup.py" ] && [ ! -f "$MAGPIE_DIR/pyproject.toml" ]; then
-    log "cloning Magpie from $MAGPIE_REPO"
-    run git clone --depth 1 "$MAGPIE_REPO" "$MAGPIE_DIR"
+    log "cloning Magpie from $MAGPIE_REPO pinned to ${MAGPIE_REF}"
+    git_fetch_pinned "$MAGPIE_REPO" "$MAGPIE_DIR" "$MAGPIE_REF" "Magpie"
   fi
   if [ "$DRY_RUN" -eq 0 ]; then
     "$PYTHON" -m pip install --quiet "${PIP_EXTRA[@]}" -e "$MAGPIE_DIR"
@@ -492,11 +540,16 @@ ensure_magpie() {
 # patcher itself is idempotent + flock-serialised + atomic-rename
 # (see `_magpie_patcher.py`), so re-runs are O(1) no-ops.
 #
-# Escalation: this is a known root-cause fix. A `False` return means
-# Magpie was refactored upstream and our pattern no longer matches; we
-# `die` so the operator notices instead of silently shipping a broken
-# install. Override the gate via PATCH_MAGPIE=0 for the (rare) case
-# where you've already landed an upstream PR locally.
+# Fail-soft (was fail-loud): a `False` return means the legacy
+# `shutil.copy2` block was not found. With MAGPIE_REF now pinned to an
+# upstream commit that already copies scripts atomically
+# (`_copy_benchmark_script_atomic`), that is the EXPECTED no-op state —
+# bugs.md §C #1 is already mitigated upstream, so we `warn` and continue
+# instead of aborting every install. (A sibling branch makes the patcher
+# itself upstream-aware; this warn is the defense-in-depth complement.) If
+# you re-pin MAGPIE_REF to a pre-refactor commit and the patch still cannot
+# apply, the script-tearing race is genuinely unpatched — review the
+# warning. Override the gate via PATCH_MAGPIE=0 to skip the step entirely.
 ensure_magpie_atomic_scripts_patch() {
   if [ "${PATCH_MAGPIE:-1}" -eq 0 ]; then
     log "PATCH_MAGPIE=0 — skipping Magpie atomic-write patch (caller asserts upstream already fixed)"
@@ -507,7 +560,7 @@ ensure_magpie_atomic_scripts_patch() {
     return 0
   fi
   log "applying Hyperloom #C1 atomic-write patch to Magpie._prepare_benchmark_scripts"
-  MAGPIE_DIR="$MAGPIE_DIR" "$PYTHON" - <<'PY' || die "Magpie atomic-write patch failed; see warnings above. bugs.md §C #1 is NOT mitigated. Set PATCH_MAGPIE=0 to skip if you know what you are doing."
+  if MAGPIE_DIR="$MAGPIE_DIR" "$PYTHON" - <<'PY'
 import os, sys
 from inference_optimizer.orchestrator.action_executors._magpie_patcher import (
     ensure_magpie_atomic_scripts_patch,
@@ -515,7 +568,21 @@ from inference_optimizer.orchestrator.action_executors._magpie_patcher import (
 ok = ensure_magpie_atomic_scripts_patch(os.environ["MAGPIE_DIR"])
 sys.exit(0 if ok else 1)
 PY
-  log "Magpie #C1 patch OK"
+  then
+    log "Magpie #C1 patch OK"
+  else
+    # Fail-soft (was fail-loud): with MAGPIE_REF now pinned to an upstream
+    # commit that already copies benchmark scripts atomically
+    # (_copy_benchmark_script_atomic), the in-place patcher finds no legacy
+    # `shutil.copy2` block and returns False — which is the EXPECTED no-op
+    # state, not a regression. bugs.md §C #1 is already mitigated upstream in
+    # that case. A sibling branch makes the patcher upstream-aware; this warn
+    # is defense in depth so a pinned/atomic Magpie does not abort install.
+    # If you are NOT on a pinned/atomic Magpie, the script-tearing race is
+    # genuinely unpatched — review _magpie_patcher.py. PATCH_MAGPIE=0 skips
+    # this step entirely.
+    warn "Magpie atomic-write patch did not apply (legacy block not found). Expected when MAGPIE_REF is pinned to an upstream-atomic commit (patch is a no-op); otherwise bugs.md §C #1 may be unpatched — review _magpie_patcher.py or set PATCH_MAGPIE=0."
+  fi
 }
 
 # --- 3. InferenceX checkout: fresh clone from upstream ---
@@ -536,15 +603,17 @@ PY
 #   * INFERENCEX_PATH set and exists -> preserve verbatim. This is the
 #     dev / CI override (caller is explicitly opting out of fresh
 #     clones, e.g. iterating on a local edit).
-#   * Otherwise -> always `git clone --depth 1` from INFERENCEX_REPO
-#     into INFERENCEX_DEFAULT_DIR. If a clone already exists there from
-#     a previous install we leave it as-is (idempotent re-runs) — the
-#     per-install isolation guarantee is already met, and re-cloning
-#     would just churn benchmark scripts that the Magpie patch already
-#     keeps consistent on disk.
-#   * No SHA pin yet (deferred). We record whatever commit `git clone`
-#     resolves into the session manifest (see manifest.py) so failed
-#     runs can be reproduced.
+#   * Otherwise -> fetch INFERENCEX_REF from INFERENCEX_REPO into
+#     INFERENCEX_DEFAULT_DIR via the shared git_fetch_pinned() dance
+#     (SHA-aware shallow fetch-checkout, mirrors the GEAK pin). If a clone
+#     already exists there from a previous install we leave it as-is
+#     (idempotent re-runs) — the per-install isolation guarantee is already
+#     met, and re-cloning would just churn benchmark scripts that the Magpie
+#     patch already keeps consistent on disk.
+#   * Pinned to INFERENCEX_REF (a commit SHA by default) so a fresh install
+#     is reproducible. We still record the resolved commit into the session
+#     manifest (see manifest.py / _describe_dep) so runs stay traceable even
+#     when an operator overrides INFERENCEX_REF.
 ensure_inferencex() {
   if [ -n "${INFERENCEX_PATH:-}" ] && [ -d "$INFERENCEX_PATH" ]; then
     log "INFERENCEX_PATH = $INFERENCEX_PATH (preserved from env; skipping fresh clone)"
@@ -562,19 +631,19 @@ ensure_inferencex() {
     return 0
   fi
   if [ "$DRY_RUN" -eq 1 ]; then
-    log "would: git clone --depth 1 ${INFERENCEX_REPO} ${INFERENCEX_PATH}"
+    log "would fetch InferenceX pinned to INFERENCEX_REF=${INFERENCEX_REF} from ${INFERENCEX_REPO} -> ${INFERENCEX_PATH}"
     export INFERENCEX_PATH
     return 0
   fi
-  log "cloning fresh InferenceX from ${INFERENCEX_REPO} -> ${INFERENCEX_PATH}"
+  log "cloning fresh InferenceX pinned to ${INFERENCEX_REF} from ${INFERENCEX_REPO} -> ${INFERENCEX_PATH}"
   mkdir -p "$(dirname "$INFERENCEX_PATH")"
-  if ! git clone --depth 1 "$INFERENCEX_REPO" "$INFERENCEX_PATH"; then
+  if ! git_fetch_pinned "$INFERENCEX_REPO" "$INFERENCEX_PATH" "$INFERENCEX_REF" "InferenceX"; then
     warn "InferenceX clone failed. GSM8K eval will fail without it. Set"
     warn "INFERENCEX_PATH to a pre-cloned tree to skip this step."
     return 0
   fi
   export INFERENCEX_PATH
-  log "InferenceX cloned at ${INFERENCEX_PATH}"
+  log "InferenceX cloned at ${INFERENCEX_PATH} (pinned ${INFERENCEX_REF})"
 }
 
 # --- 4. InferenceX bench_serving runtime deps ---

--- a/inference_optimizer/scripts/local_setup.sh
+++ b/inference_optimizer/scripts/local_setup.sh
@@ -29,6 +29,7 @@ LOCAL_SETUP_ENV="${LOCAL_SETUP_ENV:-${HYPERLOOM_RUNTIME_DIR}/local-setup.env.sh}
 
 PRIMUS_CLAW_REPO="${PRIMUS_CLAW_REPO:-https://github.com/AMD-AGI/Primus-Claw.git}"
 INFERENCEX_REPO="${INFERENCEX_REPO:-https://github.com/SemiAnalysisAI/InferenceX.git}"
+INFERENCEX_REF="${INFERENCEX_REF:-2035a2117ad22403376359be0064dfa2c078c59b}"
 TRACELENS_REPO="${TRACELENS_REPO:-https://github.com/AMD-AGI/TraceLens.git}"
 TRACELENS_REF="${TRACELENS_REF:-c35c787ef31f0425fa0028a605ffc8c60a737c2c}"
 # Preferred container-local checkout for the public repo when operators install
@@ -57,7 +58,7 @@ Options:
 Advanced env overrides:
   REPO_ROOT, USER_DATA_PATH, HYPERLOOM_DEPS_ROOT, LOCAL_SETUP_ENV,
   OOB_SRC, INFERENCEX_PATH, TRACELENS_ROOT, TRACELENS_INTERNAL_ROOT,
-  PRIMUS_CLAW_REPO, INFERENCEX_REPO,
+  PRIMUS_CLAW_REPO, INFERENCEX_REPO, INFERENCEX_REF,
   TRACELENS_REPO, TRACELENS_REF,
   TRACELENS_INTERNAL_ROOT (path to an existing internal extension checkout;
     set to enable it, otherwise open-source-only)
@@ -287,7 +288,7 @@ resolve_inferencex() {
   fi
 
   INFERENCEX_PATH="${HYPERLOOM_DEPS_ROOT}/InferenceX"
-  clone_or_update "InferenceX" "$INFERENCEX_REPO" "$INFERENCEX_PATH" ""
+  clone_or_update "InferenceX" "$INFERENCEX_REPO" "$INFERENCEX_PATH" "$INFERENCEX_REF"
   export INFERENCEX_PATH
   log "INFERENCEX_PATH: ${INFERENCEX_PATH}"
 }

--- a/inference_optimizer/tests/test_local_setup_script.py
+++ b/inference_optimizer/tests/test_local_setup_script.py
@@ -36,6 +36,7 @@ _HOST_LEAK_VARS = (
     "LOCAL_SETUP_ENV",
     "PRIMUS_CLAW_REPO",
     "INFERENCEX_REPO",
+    "INFERENCEX_REF",
     "TRACELENS_REPO",
     "TRACELENS_REF",
     "OOB_SRC",
@@ -103,6 +104,7 @@ def test_local_setup_clones_missing_dependency_repos_and_writes_env(tmp_path: Pa
         env={
             "PRIMUS_CLAW_REPO": str(primus),
             "INFERENCEX_REPO": str(inferencex),
+            "INFERENCEX_REF": "HEAD",
             "TRACELENS_REPO": str(tracelens_public),
             "TRACELENS_REF": "HEAD",
             "SAFE_API_KEY": secret,
@@ -141,6 +143,7 @@ def test_local_setup_uses_internal_extension_when_root_set(tmp_path: Path) -> No
         env={
             "PRIMUS_CLAW_REPO": str(primus),
             "INFERENCEX_REPO": str(inferencex),
+            "INFERENCEX_REF": "HEAD",
             "TRACELENS_REPO": str(tracelens_public),
             "TRACELENS_REF": "HEAD",
             "TRACELENS_INTERNAL_ROOT": str(internal_checkout),
@@ -166,6 +169,7 @@ def test_local_setup_internal_missing_path_falls_back_to_oss_only(tmp_path: Path
         env={
             "PRIMUS_CLAW_REPO": str(primus),
             "INFERENCEX_REPO": str(inferencex),
+            "INFERENCEX_REF": "HEAD",
             "TRACELENS_REPO": str(tracelens_public),
             "TRACELENS_REF": "HEAD",
             "TRACELENS_INTERNAL_ROOT": str(tmp_path / "nope" / "TraceLens-internal"),
@@ -191,6 +195,7 @@ def test_local_setup_respects_existing_dependency_paths(tmp_path: Path) -> None:
         env={
             "OOB_SRC": str(existing_oob),
             "INFERENCEX_REPO": str(inferencex),
+            "INFERENCEX_REF": "HEAD",
             "TRACELENS_REPO": str(tracelens_public),
             "TRACELENS_REF": "HEAD",
         },

--- a/inference_optimizer/tests/test_local_setup_script.py
+++ b/inference_optimizer/tests/test_local_setup_script.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -387,3 +388,68 @@ def test_flock_serializes_concurrent_critical_sections(tmp_path: Path) -> None:
         ["start-A", "end-A", "start-B", "end-B"],
         ["start-B", "end-B", "start-A", "end-A"],
     ), f"flock did not serialize critical sections: {lines}"
+
+
+# ---------------------------------------------------------------------------
+# pin-dependency-shas (feature/xiaofei/pin-dependency-shas):
+#   inference_optimizer/scripts/install.sh must clone Magpie / InferenceX
+#   pinned to a commit SHA via the SHA-aware fetch-checkout dance (mirroring
+#   the GEAK_REF pin in kernel-agent/scripts/install.sh), and the Magpie
+#   in-place patch step must be fail-soft (warn, not die) so a pinned
+#   upstream-atomic Magpie does not abort every install.
+#
+# These are grep/static-level guards on the script text (the established
+# pattern for the install.sh entrypoints — see
+# test_install_scripts_guard_mirror_writes_with_flock). A full DRY_RUN run is
+# intentionally not driven here: it imports inference_optimizer, resolves a
+# ROCm python, and runs the torch gate, which is too heavy/host-coupled for a
+# hermetic unit test (the DRY_RUN log is exercised manually in the PR notes).
+# ---------------------------------------------------------------------------
+
+
+def test_io_install_pins_magpie_and_inferencex_to_commit_sha() -> None:
+    # Both deps are pinned to a full 40-char commit SHA and stay operator-
+    # overridable via the ``${VAR:-<sha>}`` form (mirrors GEAK_REF). Pinning a
+    # SHA — not a branch — is what makes a fresh install reproducible and
+    # immune to upstream force-push / HEAD drift (the bugs.md §C #1 root cause).
+    text = IO_INSTALL.read_text(encoding="utf-8")
+    assert re.search(
+        r'^MAGPIE_REF="\$\{MAGPIE_REF:-[0-9a-fA-F]{40}\}"', text, re.M
+    ), "MAGPIE_REF must default to a full 40-char commit SHA and be overridable"
+    assert re.search(
+        r'^INFERENCEX_REF="\$\{INFERENCEX_REF:-[0-9a-fA-F]{40}\}"', text, re.M
+    ), "INFERENCEX_REF must default to a full 40-char commit SHA and be overridable"
+
+
+def test_io_install_uses_sha_aware_fetch_checkout_for_both_deps() -> None:
+    # The clone helper must use the GEAK-style SHA-aware fetch-checkout dance
+    # (a raw SHA cannot be passed to ``git clone --branch``) and must be wired
+    # into BOTH ensure_magpie and ensure_inferencex. The old bare
+    # ``git clone --depth 1 <repo>`` of latest HEAD must be gone.
+    text = IO_INSTALL.read_text(encoding="utf-8")
+    assert "^[0-9a-fA-F]{7,40}$" in text, "missing raw-SHA detection regex"
+    assert 'fetch --depth 1 origin "$ref"' in text, "missing shallow SHA fetch"
+    assert "checkout -q FETCH_HEAD" in text, "missing detached SHA checkout"
+    assert (
+        'git_fetch_pinned "$MAGPIE_REPO" "$MAGPIE_DIR" "$MAGPIE_REF" "Magpie"' in text
+    ), "ensure_magpie must clone via the pinned fetch-checkout helper"
+    assert (
+        'git_fetch_pinned "$INFERENCEX_REPO" "$INFERENCEX_PATH" "$INFERENCEX_REF" "InferenceX"'
+        in text
+    ), "ensure_inferencex must clone via the pinned fetch-checkout helper"
+    # Regression guard: no unpinned ``clone --depth 1 <repo>`` of latest HEAD.
+    assert 'git clone --depth 1 "$MAGPIE_REPO"' not in text
+    assert 'git clone --depth 1 "$INFERENCEX_REPO"' not in text
+
+
+def test_io_install_magpie_patch_is_fail_soft() -> None:
+    # Defense in depth: with MAGPIE_REF pinned to an upstream-atomic commit the
+    # in-place patcher finds no legacy block and returns False. That must
+    # warn-and-continue (no-op), not die and abort the install. The
+    # PATCH_MAGPIE=0 hard-skip override must be preserved.
+    text = IO_INSTALL.read_text(encoding="utf-8")
+    assert "Magpie atomic-write patch did not apply" in text, "missing fail-soft warn"
+    assert "Magpie #C1 patch OK" in text, "success log must be preserved"
+    assert "PATCH_MAGPIE=0" in text, "PATCH_MAGPIE=0 override must be preserved"
+    # The previous fail-loud ``die`` on patch failure must be gone.
+    assert 'die "Magpie atomic-write patch failed' not in text

--- a/inference_optimizer/tests/test_magpie_patcher.py
+++ b/inference_optimizer/tests/test_magpie_patcher.py
@@ -27,6 +27,7 @@ method body — that is the entire surface the patcher matches against.
 
 from __future__ import annotations
 
+import logging
 import re
 import subprocess
 import sys
@@ -38,8 +39,11 @@ import pytest
 
 from inference_optimizer.orchestrator.action_executors._magpie_patcher import (
     _LEGACY_BLOCK,
-    _PATCHED_BLOCK,
     _PATCH_SENTINEL,
+    _PATCHED_BLOCK,
+    _UPSTREAM_ATOMIC_HELPER,
+    _extract_prepare_region,
+    _upstream_is_already_atomic,
     ensure_magpie_atomic_scripts_patch,
 )
 
@@ -72,6 +76,100 @@ class _FakeBenchmarker:
 """
 
 
+# Newer upstream Magpie: the copy loop was refactored to delegate to a
+# ``_copy_benchmark_script_atomic`` static method that already does
+# mkstemp + copy2 + chmod + os.replace. The legacy two-line block is gone
+# *because upstream fixed the race itself*, so the Hyperloom #C1 patch is a
+# redundant no-op here, not a layout-drift anomaly.
+_UPSTREAM_ATOMIC_BENCHMARKER_PY = """\
+\"\"\"Reduced benchmarker.py — upstream refactored to an atomic copy helper.\"\"\"
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+
+class _FakeBenchmarker:
+    def __init__(self, magpie_scripts_dir, target_dir):
+        self.magpie_scripts_dir = Path(magpie_scripts_dir)
+        self.target_dir = Path(target_dir)
+
+    def _prepare_benchmark_scripts(self):
+        magpie_scripts = self.magpie_scripts_dir
+        target_dir = self.target_dir
+        if not magpie_scripts.exists():
+            return
+        target_dir.mkdir(parents=True, exist_ok=True)
+        for script in magpie_scripts.glob("*.sh"):
+            target_file = target_dir / script.name
+            self._copy_benchmark_script_atomic(script, target_file)
+
+    @staticmethod
+    def _copy_benchmark_script_atomic(script, target_file):
+        target_file = Path(target_file)
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{target_file.name}.", dir=str(target_file.parent),
+        )
+        os.close(fd)
+        shutil.copy2(script, tmp_name)
+        os.chmod(tmp_name, 0o755)
+        os.replace(tmp_name, target_file)
+"""
+
+
+# Same race-safe outcome, but inlined: no named helper, the temp-file +
+# rename dance lives directly in ``_prepare_benchmark_scripts``. Exercises
+# the region-scoped ``mkstemp + os.replace`` detection signal.
+_INLINE_ATOMIC_BENCHMARKER_PY = """\
+\"\"\"Reduced benchmarker.py — inline atomic copy, no named helper.\"\"\"
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+
+class _FakeBenchmarker:
+    def __init__(self, magpie_scripts_dir, target_dir):
+        self.magpie_scripts_dir = Path(magpie_scripts_dir)
+        self.target_dir = Path(target_dir)
+
+    def _prepare_benchmark_scripts(self):
+        magpie_scripts = self.magpie_scripts_dir
+        target_dir = self.target_dir
+        if not magpie_scripts.exists():
+            return
+        target_dir.mkdir(parents=True, exist_ok=True)
+        for script in magpie_scripts.glob("*.sh"):
+            target_file = target_dir / script.name
+            fd, tmp_name = tempfile.mkstemp(dir=str(target_dir))
+            os.close(fd)
+            shutil.copy2(script, tmp_name)
+            os.chmod(tmp_name, 0o755)
+            os.replace(tmp_name, target_file)
+"""
+
+
+# Genuine layout drift: ``_prepare_benchmark_scripts`` is unrecognisable AND
+# the only ``mkstemp``/``os.replace`` in the file live in an *unrelated*
+# method. Region scoping must keep this out of the "already atomic" bucket.
+_GARBAGE_WITH_UNRELATED_ATOMIC_PY = """\
+\"\"\"Reduced benchmarker.py — drifted prepare; atomic ops live elsewhere.\"\"\"
+import os
+import tempfile
+
+
+class _FakeBenchmarker:
+    def _prepare_benchmark_scripts(self):
+        # body refactored to a shape the patcher does not recognise
+        raise NotImplementedError("hand-edited")
+
+    def _unrelated_helper(self, target_file):
+        fd, tmp_name = tempfile.mkstemp()
+        os.close(fd)
+        os.replace(tmp_name, target_file)
+"""
+
+
 @pytest.fixture
 def fake_magpie(tmp_path: Path) -> Path:
     """Build ``<root>/Magpie/modes/benchmark/benchmarker.py`` tree."""
@@ -82,6 +180,17 @@ def fake_magpie(tmp_path: Path) -> Path:
         _UPSTREAM_BENCHMARKER_PY, encoding="utf-8",
     )
     return tmp_path
+
+
+def _write_magpie_tree(root: Path, benchmarker_src: str) -> Path:
+    """Materialise a minimal Magpie tree under ``root`` and return the
+    ``benchmarker.py`` path."""
+    bench_dir = root / "Magpie" / "modes" / "benchmark"
+    bench_dir.mkdir(parents=True)
+    (bench_dir / "__init__.py").write_text("", encoding="utf-8")
+    bench_py = bench_dir / "benchmarker.py"
+    bench_py.write_text(benchmarker_src, encoding="utf-8")
+    return bench_py
 
 
 # ---------------------------------------------------------------------------
@@ -176,6 +285,142 @@ def test_already_patched_returns_true_without_rewriting(fake_magpie: Path):
     pre = bench_py.read_text(encoding="utf-8")
     assert ensure_magpie_atomic_scripts_patch(fake_magpie) is True
     assert bench_py.read_text(encoding="utf-8") == pre
+
+
+# ---------------------------------------------------------------------------
+# Upstream-aware: an already-atomic Magpie is "already fixed", not drifted.
+# These four cover the contract change in feature/magpie-patcher-upstream-aware:
+#   (1) atomic upstream      -> no-op True, file untouched, no warning
+#   (2) legacy block         -> patched True, sentinel present
+#   (3) already-patched      -> no-op True (sentinel fast path)
+#   (4) neither legacy/atomic -> False + warning (genuine anomaly)
+# ---------------------------------------------------------------------------
+def _patcher_warnings(caplog) -> list:
+    return [
+        r for r in caplog.records
+        if r.levelno >= logging.WARNING and "_magpie_patcher" in r.name
+    ]
+
+
+def test_atomic_helper_upstream_is_noop_true(tmp_path: Path, caplog):
+    """(1) Newer upstream delegates each copy to
+    ``_copy_benchmark_script_atomic`` (mkstemp + os.replace). The patch is
+    redundant: ``ensure_*`` returns True, leaves the file byte-for-byte
+    unchanged, emits no warning, and logs an explicit info no-op line."""
+    bench_py = _write_magpie_tree(tmp_path, _UPSTREAM_ATOMIC_BENCHMARKER_PY)
+    pre = bench_py.read_text(encoding="utf-8")
+
+    with caplog.at_level(logging.INFO):
+        result = ensure_magpie_atomic_scripts_patch(tmp_path)
+
+    assert result is True
+    post = bench_py.read_text(encoding="utf-8")
+    assert post == pre, "already-atomic upstream must not be rewritten"
+    assert _PATCH_SENTINEL not in post
+    assert not _patcher_warnings(caplog), "no-op must not warn"
+    assert any(
+        "already performs atomic script copy" in r.getMessage()
+        and "_magpie_patcher" in r.name
+        for r in caplog.records
+    ), "expected the explicit already-atomic info line"
+
+
+def test_inline_atomic_upstream_is_noop_true(tmp_path: Path, caplog):
+    """(1b) Same race-safe outcome with the temp-file + rename inlined into
+    ``_prepare_benchmark_scripts`` (no named helper) — region-scoped
+    mkstemp+os.replace detection. Still a no-op True, file untouched."""
+    bench_py = _write_magpie_tree(tmp_path, _INLINE_ATOMIC_BENCHMARKER_PY)
+    pre = bench_py.read_text(encoding="utf-8")
+
+    with caplog.at_level(logging.INFO):
+        assert ensure_magpie_atomic_scripts_patch(tmp_path) is True
+
+    assert bench_py.read_text(encoding="utf-8") == pre
+    assert not _patcher_warnings(caplog)
+
+
+def test_atomic_upstream_fixture_still_copies_scripts(tmp_path: Path):
+    """End-to-end sanity: the no-op path leaves a *working* Magpie. Exec the
+    untouched atomic fixture and confirm it copies a script with exec bit."""
+    bench_py = _write_magpie_tree(tmp_path, _UPSTREAM_ATOMIC_BENCHMARKER_PY)
+    assert ensure_magpie_atomic_scripts_patch(tmp_path) is True
+
+    src_dir = tmp_path / "magpie_scripts"
+    src_dir.mkdir()
+    (src_dir / "vllm_mi300x.sh").write_text(
+        "#!/usr/bin/env bash\necho hi\n", encoding="utf-8",
+    )
+    dst_dir = tmp_path / "InferenceX_benchmarks"
+
+    namespace: dict = {"__name__": "_atomic_benchmarker_smoke"}
+    exec(compile(bench_py.read_text("utf-8"), str(bench_py), "exec"), namespace)
+    inst = namespace["_FakeBenchmarker"](src_dir, dst_dir)
+    inst._prepare_benchmark_scripts()
+
+    out = dst_dir / "vllm_mi300x.sh"
+    assert out.is_file()
+    assert out.read_text("utf-8") == (src_dir / "vllm_mi300x.sh").read_text("utf-8")
+    assert out.stat().st_mode & 0o111
+
+
+def test_legacy_block_still_patched_true(tmp_path: Path):
+    """(2) Old Magpie (the legacy two-line block) is still patched in place:
+    returns True, sentinel present, legacy block gone. Existing behaviour
+    must survive the upstream-aware change."""
+    bench_py = _write_magpie_tree(tmp_path, _UPSTREAM_BENCHMARKER_PY)
+    assert ensure_magpie_atomic_scripts_patch(tmp_path) is True
+    text = bench_py.read_text(encoding="utf-8")
+    assert _PATCH_SENTINEL in text
+    assert _LEGACY_BLOCK not in text
+
+
+def test_already_patched_sentinel_is_noop_true(tmp_path: Path):
+    """(3) A previously Hyperloom-patched checkout (sentinel present) is a
+    fast-path no-op: returns True, bytes unchanged. Uses the real patched
+    output rather than a synthetic sentinel comment."""
+    patched_src = _UPSTREAM_BENCHMARKER_PY.replace(_LEGACY_BLOCK, _PATCHED_BLOCK, 1)
+    assert _PATCH_SENTINEL in patched_src
+    bench_py = _write_magpie_tree(tmp_path, patched_src)
+    pre = bench_py.read_text(encoding="utf-8")
+    assert ensure_magpie_atomic_scripts_patch(tmp_path) is True
+    assert bench_py.read_text(encoding="utf-8") == pre
+
+
+def test_neither_legacy_nor_atomic_warns_false(tmp_path: Path, caplog):
+    """(4) A ``_prepare_benchmark_scripts`` with neither the legacy block nor
+    any atomic implementation is a genuine anomaly: returns False, leaves the
+    file untouched, and logs a warning flagging it for manual review."""
+    drifted = (
+        "class _FakeBenchmarker:\n"
+        "    def _prepare_benchmark_scripts(self):\n"
+        "        # someone replaced the body with no copy logic at all\n"
+        "        return None\n"
+    )
+    bench_py = _write_magpie_tree(tmp_path, drifted)
+
+    with caplog.at_level(logging.INFO):
+        result = ensure_magpie_atomic_scripts_patch(tmp_path)
+
+    assert result is False
+    assert bench_py.read_text(encoding="utf-8") == drifted
+    warnings = _patcher_warnings(caplog)
+    assert warnings, "genuine anomaly must warn"
+    assert any("manual review" in r.getMessage().lower() for r in warnings)
+
+
+def test_unrelated_atomic_ops_do_not_count_as_fixed(tmp_path: Path, caplog):
+    """Region scoping guard: ``mkstemp``/``os.replace`` in an *unrelated*
+    method must NOT be read as an already-atomic ``_prepare_benchmark_scripts``.
+    This stays a genuine anomaly → False + warning, proving the detection is
+    scoped to the method body and not the whole file."""
+    bench_py = _write_magpie_tree(tmp_path, _GARBAGE_WITH_UNRELATED_ATOMIC_PY)
+
+    with caplog.at_level(logging.INFO):
+        result = ensure_magpie_atomic_scripts_patch(tmp_path)
+
+    assert result is False
+    assert bench_py.read_text(encoding="utf-8") == _GARBAGE_WITH_UNRELATED_ATOMIC_PY
+    assert _patcher_warnings(caplog)
 
 
 # ---------------------------------------------------------------------------
@@ -594,3 +839,52 @@ def test_patched_block_skips_identical_target():
     read-only shared deployment with pre-staged scripts is a no-op rather
     than a mkstemp OSError."""
     assert "_hyperloom_filecmp" in _PATCHED_BLOCK
+
+
+# ---------------------------------------------------------------------------
+# _extract_prepare_region
+# ---------------------------------------------------------------------------
+
+class TestExtractPrepareRegion:
+    def test_returns_empty_when_marker_absent(self):
+        assert _extract_prepare_region("def other():\n    pass\n") == ""
+
+    def test_bounds_a_single_method_body(self):
+        # The unrelated helper (and its atomic ops) must fall outside the slice.
+        region = _extract_prepare_region(_GARBAGE_WITH_UNRELATED_ATOMIC_PY)
+        assert "_prepare_benchmark_scripts" in region
+        assert "_unrelated_helper" not in region
+        assert "os.replace(" not in region
+
+    def test_includes_inline_atomic_body(self):
+        region = _extract_prepare_region(_INLINE_ATOMIC_BENCHMARKER_PY)
+        assert "tempfile.mkstemp(" in region
+        assert "os.replace(" in region
+
+
+# ---------------------------------------------------------------------------
+# _upstream_is_already_atomic
+# ---------------------------------------------------------------------------
+
+class TestUpstreamIsAlreadyAtomic:
+    def test_named_helper_detected(self):
+        assert _UPSTREAM_ATOMIC_HELPER in _UPSTREAM_ATOMIC_BENCHMARKER_PY
+        assert _upstream_is_already_atomic(_UPSTREAM_ATOMIC_BENCHMARKER_PY) is True
+
+    def test_inline_mkstemp_replace_detected(self):
+        assert _upstream_is_already_atomic(_INLINE_ATOMIC_BENCHMARKER_PY) is True
+
+    def test_legacy_block_is_not_atomic(self):
+        assert _upstream_is_already_atomic(_UPSTREAM_BENCHMARKER_PY) is False
+
+    def test_unrelated_atomic_ops_not_detected(self):
+        # Region scoping keeps out mkstemp/os.replace from other methods.
+        assert _upstream_is_already_atomic(_GARBAGE_WITH_UNRELATED_ATOMIC_PY) is False
+
+    def test_hyperloom_patched_output_is_atomic(self):
+        # Defence in depth: the patcher's own output also reads as atomic
+        # (the sentinel fast path normally short-circuits before this).
+        patched = _UPSTREAM_BENCHMARKER_PY.replace(
+            _LEGACY_BLOCK, _PATCHED_BLOCK, 1,
+        )
+        assert _upstream_is_already_atomic(patched) is True

--- a/inference_optimizer/tests/test_multimodal_gate.py
+++ b/inference_optimizer/tests/test_multimodal_gate.py
@@ -1,16 +1,12 @@
-"""Tests for the unsupported-multimodal-model preflight gate.
+"""Tests for the unsupported-model preflight gate (whitelist approach).
 
 Policy: Hyperloom only supports text-generation (decoder-only causal LM)
-models. Multimodal / vision models (e.g. Gemma3ForConditionalGeneration,
-qwen2_vl) occasionally leak past the upstream submission filter and only die
-~5 minutes in with a cryptic vLLM ``OSError: Can't load image processor ...``,
-wasting a full session slot. This Hyperloom-side safety net classifies the
-model from its ``config.json`` BEFORE the baseline server is launched and
-fails fast with a clear, actionable stop reason.
+models whose architecture ends with ForCausalLM / LMHeadModel. All other
+architectures are rejected BEFORE the expensive baseline server boot.
 
 Best-effort contract: a missing / unreadable / invalid ``config.json`` does
 NOT hard-block (the upstream filter + downstream loader still apply); only a
-positively-identified multimodal model is rejected.
+positively-identified non-text-generation model is rejected.
 """
 
 from __future__ import annotations
@@ -48,9 +44,10 @@ def _seed_state(session_dir: Path, monkeypatch) -> None:
 
 
 # ---------------------------------------------------------------------------
-# 1. classifier — pure detection on config.json signals
+# 1. classifier — whitelist-based detection
 # ---------------------------------------------------------------------------
-def test_detect_gemma3_conditional_generation(tmp_path):
+def test_detect_gemma3_conditional_generation_rejected(tmp_path):
+    """Gemma3ForConditionalGeneration does NOT end with ForCausalLM -> rejected."""
     m = tmp_path / "gemma3"
     _write_config(m, {
         "architectures": ["Gemma3ForConditionalGeneration"],
@@ -59,37 +56,45 @@ def test_detect_gemma3_conditional_generation(tmp_path):
     hit = cli._detect_unsupported_model(str(m))
     assert hit is not None
     assert hit["architecture"] == "Gemma3ForConditionalGeneration"
-    assert hit["model_type"] == "gemma3"
+    assert "supported text-generation pattern" in hit["signal"]
 
 
-def test_detect_qwen2_vl_model_type(tmp_path):
-    m = tmp_path / "qwen2vl"
-    # model_type alone (architectures intentionally not a *_VL class) must trip.
+def test_detect_unknown_arch_rejected(tmp_path):
+    """An unknown architecture not ending in ForCausalLM -> rejected."""
+    m = tmp_path / "custom"
     _write_config(m, {"architectures": ["SomeCustomArch"], "model_type": "qwen2_vl"})
     hit = cli._detect_unsupported_model(str(m))
     assert hit is not None
-    assert hit["model_type"] == "qwen2_vl"
+    assert hit["architecture"] == "SomeCustomArch"
 
 
-def test_detect_vision_config_key(tmp_path):
-    m = tmp_path / "visioncfg"
-    _write_config(m, {
-        "architectures": ["LlamaForCausalLM"],
-        "model_type": "llama",
-        "vision_config": {"hidden_size": 1024},
-    })
+def test_detect_vision_encoder_rejected(tmp_path):
+    """CLIPVisionModel is not a text-generation arch -> rejected."""
+    m = tmp_path / "clip"
+    _write_config(m, {"architectures": ["CLIPVisionModel"], "model_type": "clip"})
     hit = cli._detect_unsupported_model(str(m))
     assert hit is not None
-    assert "vision_config" in hit["signal"]
 
 
-def test_detect_image_token_index_key(tmp_path):
-    m = tmp_path / "imgtoken"
-    _write_config(m, {"architectures": ["FooForCausalLM"], "image_token_index": 32000})
-    assert cli._detect_unsupported_model(str(m)) is not None
+def test_detect_seq2seq_rejected(tmp_path):
+    """T5ForConditionalGeneration is not ForCausalLM -> rejected."""
+    m = tmp_path / "t5"
+    _write_config(m, {"architectures": ["T5ForConditionalGeneration"], "model_type": "t5"})
+    hit = cli._detect_unsupported_model(str(m))
+    assert hit is not None
 
 
-def test_detect_plain_text_models_allowed(tmp_path):
+def test_detect_unknown_model_type_no_arch_rejected(tmp_path):
+    """No architectures field + unknown model_type -> rejected."""
+    m = tmp_path / "weird"
+    _write_config(m, {"model_type": "some_exotic_type"})
+    hit = cli._detect_unsupported_model(str(m))
+    assert hit is not None
+    assert "allowlist" in hit["signal"]
+
+
+def test_detect_causal_lm_allowed(tmp_path):
+    """Standard ForCausalLM architectures pass through."""
     for i, arch in enumerate(
         ["MistralForCausalLM", "Qwen2ForCausalLM", "LlamaForCausalLM"]
     ):
@@ -98,8 +103,32 @@ def test_detect_plain_text_models_allowed(tmp_path):
         assert cli._detect_unsupported_model(str(m)) is None
 
 
+def test_detect_lm_head_model_allowed(tmp_path):
+    """GPT2LMHeadModel style architectures pass through."""
+    m = tmp_path / "gpt2"
+    _write_config(m, {"architectures": ["GPT2LMHeadModel"], "model_type": "gpt2"})
+    assert cli._detect_unsupported_model(str(m)) is None
+
+
+def test_detect_known_model_type_no_arch_allowed(tmp_path):
+    """No architectures field but known model_type -> allowed."""
+    m = tmp_path / "known_type"
+    _write_config(m, {"model_type": "mistral"})
+    assert cli._detect_unsupported_model(str(m)) is None
+
+
+def test_detect_causal_lm_with_vision_config_still_allowed(tmp_path):
+    """A ForCausalLM model with extra vision keys is STILL allowed (arch wins)."""
+    m = tmp_path / "visioncausal"
+    _write_config(m, {
+        "architectures": ["LlamaForCausalLM"],
+        "model_type": "llama",
+        "vision_config": {"hidden_size": 1024},
+    })
+    assert cli._detect_unsupported_model(str(m)) is None
+
+
 def test_detect_missing_config_returns_none(tmp_path):
-    # No config.json at all -> best-effort: cannot classify -> do not block.
     assert cli._detect_unsupported_model(str(tmp_path / "nope")) is None
 
 
@@ -128,40 +157,21 @@ def test_preflight_blocks_gemma3(tmp_path, monkeypatch):
     assert final["stop_reason"] == "unsupported_model_arch"
     detail = final["stop_detail"]
     assert "Gemma3ForConditionalGeneration" in detail
-    assert "gemma3" in detail
-    assert "multimodal" in detail.lower()
     assert "text-generation" in detail.lower()
-    final_md = (sd / "reports" / "final.md").read_text(encoding="utf-8")
-    assert "unsupported_model_arch" in final_md
     state = json.loads((sd / "state.json").read_text())
     assert state["stop_reason"] == "unsupported_model_arch"
-    # Delivery-artifact parity: fail-fast exits before coordinator.run()'s
-    # finally, so it MUST emit session_breakdown.json itself.
     breakdown = sd / "session_breakdown.json"
     assert breakdown.exists()
-    assert json.loads(breakdown.read_text(encoding="utf-8"))
 
 
-def test_preflight_blocks_qwen2_vl_model_type(tmp_path, monkeypatch):
-    model = tmp_path / "qwen2vl"
+def test_preflight_blocks_unknown_arch(tmp_path, monkeypatch):
+    model = tmp_path / "custom"
     _write_config(model, {"architectures": ["X"], "model_type": "qwen2_vl"})
-    sd = tmp_path / "session_qwen"
+    sd = tmp_path / "session_custom"
     _seed_state(sd, monkeypatch)
     assert cli._preflight_unsupported_model_arch(_args(str(model)), sd) is True
     final = json.loads((sd / "reports" / "final.json").read_text())
     assert final["stop_reason"] == "unsupported_model_arch"
-
-
-def test_preflight_blocks_vision_config(tmp_path, monkeypatch):
-    model = tmp_path / "visioncfg"
-    _write_config(model, {
-        "architectures": ["LlamaForCausalLM"],
-        "model_type": "llama",
-        "vision_config": {"hidden_size": 1024},
-    })
-    sd = tmp_path / "session_vision"
-    _seed_state(sd, monkeypatch)
-    assert cli._preflight_unsupported_model_arch(_args(str(model)), sd) is True
 
 
 def test_preflight_allows_plain_text(tmp_path, monkeypatch):
@@ -181,16 +191,12 @@ def test_preflight_allows_missing_config(tmp_path, monkeypatch):
     model.mkdir()
     sd = tmp_path / "session_missing"
     _seed_state(sd, monkeypatch)
-    # Missing config.json -> best-effort: do NOT hard-block.
     assert cli._preflight_unsupported_model_arch(_args(str(model)), sd) is False
     assert not (sd / "reports" / "final.json").exists()
 
 
 # ---------------------------------------------------------------------------
-# 3. stop_reason must be a canonical STOP_REASON_VOCAB term so it round-trips
-# through the validated set_stop_reason() writer (not mapped to 'unknown',
-# not raising under strict mode) and the robustness monitor treats it as
-# terminal.
+# 3. stop_reason vocabulary registration
 # ---------------------------------------------------------------------------
 def test_stop_reason_is_canonical_vocab():
     from inference_optimizer.orchestrator.phase_state import (
@@ -203,11 +209,7 @@ def test_stop_reason_is_canonical_vocab():
 
 
 def test_preflight_persists_stop_reason_under_strict_env(tmp_path, monkeypatch):
-    """Under ``INFERENCE_OPTIMIZER_STRICT_STOP_REASON=1`` the preflight must
-    still persist the canonical stop_reason — proving the writer goes through
-    the validated ``set_stop_reason()`` path AND that the term is registered in
-    the vocab (an off-vocab term would raise in strict mode and abort the
-    report)."""
+    """Under strict mode the preflight must still persist the stop_reason."""
     monkeypatch.setenv("INFERENCE_OPTIMIZER_STRICT_STOP_REASON", "1")
     model = tmp_path / "gemma3strict"
     _write_config(model, {

--- a/inference_optimizer/tests/test_multimodal_gate.py
+++ b/inference_optimizer/tests/test_multimodal_gate.py
@@ -1,8 +1,9 @@
 """Tests for the unsupported-model preflight gate (whitelist approach).
 
 Policy: Hyperloom only supports text-generation (decoder-only causal LM)
-models whose architecture ends with ForCausalLM / LMHeadModel. All other
-architectures are rejected BEFORE the expensive baseline server boot.
+models whose architecture contains ForCausalLM / LMHeadModel and has no
+explicit multimodal / vision signals. All other architectures are rejected
+BEFORE the expensive baseline server boot.
 
 Best-effort contract: a missing / unreadable / invalid ``config.json`` does
 NOT hard-block (the upstream filter + downstream loader still apply); only a
@@ -47,7 +48,7 @@ def _seed_state(session_dir: Path, monkeypatch) -> None:
 # 1. classifier — whitelist-based detection
 # ---------------------------------------------------------------------------
 def test_detect_gemma3_conditional_generation_rejected(tmp_path):
-    """Gemma3ForConditionalGeneration does NOT end with ForCausalLM -> rejected."""
+    """Gemma3ForConditionalGeneration is not a causal LM arch -> rejected."""
     m = tmp_path / "gemma3"
     _write_config(m, {
         "architectures": ["Gemma3ForConditionalGeneration"],
@@ -56,11 +57,11 @@ def test_detect_gemma3_conditional_generation_rejected(tmp_path):
     hit = cli._detect_unsupported_model(str(m))
     assert hit is not None
     assert hit["architecture"] == "Gemma3ForConditionalGeneration"
-    assert "supported text-generation pattern" in hit["signal"]
+    assert "unsupported architecture" in hit["signal"]
 
 
 def test_detect_unknown_arch_rejected(tmp_path):
-    """An unknown architecture not ending in ForCausalLM -> rejected."""
+    """An unknown architecture not matching text-generation markers -> rejected."""
     m = tmp_path / "custom"
     _write_config(m, {"architectures": ["SomeCustomArch"], "model_type": "qwen2_vl"})
     hit = cli._detect_unsupported_model(str(m))
@@ -93,12 +94,38 @@ def test_detect_unknown_model_type_no_arch_rejected(tmp_path):
     assert "allowlist" in hit["signal"]
 
 
+def test_detect_empty_config_rejected(tmp_path):
+    """A readable config without identity tags cannot prove text generation."""
+    m = tmp_path / "empty"
+    _write_config(m, {})
+    hit = cli._detect_unsupported_model(str(m))
+    assert hit is not None
+    assert "neither architectures nor model_type" in hit["signal"]
+
+
+def test_detect_phi3v_causal_lm_rejected(tmp_path):
+    """Some VLM architectures still end with ForCausalLM and need a denylist."""
+    m = tmp_path / "phi3v"
+    _write_config(m, {"architectures": ["Phi3VForCausalLM"], "model_type": "phi3_v"})
+    hit = cli._detect_unsupported_model(str(m))
+    assert hit is not None
+    assert "Phi3VForCausalLM" in hit["signal"]
+
+
 def test_detect_causal_lm_allowed(tmp_path):
     """Standard ForCausalLM architectures pass through."""
     for i, arch in enumerate(
         ["MistralForCausalLM", "Qwen2ForCausalLM", "LlamaForCausalLM"]
     ):
         m = tmp_path / f"text{i}"
+        _write_config(m, {"architectures": [arch], "model_type": "llama"})
+        assert cli._detect_unsupported_model(str(m)) is None
+
+
+def test_detect_causal_lm_variant_allowed(tmp_path):
+    """Text-generation variants with suffixes after ForCausalLM pass through."""
+    for i, arch in enumerate(["DeepseekV3ForCausalLMNextN", "LlamaForCausalLMEagle3"]):
+        m = tmp_path / f"variant{i}"
         _write_config(m, {"architectures": [arch], "model_type": "llama"})
         assert cli._detect_unsupported_model(str(m)) is None
 
@@ -117,15 +144,27 @@ def test_detect_known_model_type_no_arch_allowed(tmp_path):
     assert cli._detect_unsupported_model(str(m)) is None
 
 
-def test_detect_causal_lm_with_vision_config_still_allowed(tmp_path):
-    """A ForCausalLM model with extra vision keys is STILL allowed (arch wins)."""
+def test_detect_known_text_model_type_with_nonstandard_arch_allowed(tmp_path):
+    """Known text-generation model_type can allow non-ForCausalLM class names."""
+    m = tmp_path / "chatglm"
+    _write_config(m, {
+        "architectures": ["ChatGLMForConditionalGeneration"],
+        "model_type": "chatglm",
+    })
+    assert cli._detect_unsupported_model(str(m)) is None
+
+
+def test_detect_causal_lm_with_vision_config_rejected(tmp_path):
+    """Explicit vision keys win over a generic ForCausalLM architecture."""
     m = tmp_path / "visioncausal"
     _write_config(m, {
         "architectures": ["LlamaForCausalLM"],
         "model_type": "llama",
         "vision_config": {"hidden_size": 1024},
     })
-    assert cli._detect_unsupported_model(str(m)) is None
+    hit = cli._detect_unsupported_model(str(m))
+    assert hit is not None
+    assert "vision_config" in hit["signal"]
 
 
 def test_detect_missing_config_returns_none(tmp_path):

--- a/inference_optimizer/tests/test_multimodal_gate.py
+++ b/inference_optimizer/tests/test_multimodal_gate.py
@@ -1,0 +1,221 @@
+"""Tests for the unsupported-multimodal-model preflight gate.
+
+Policy: Hyperloom only supports text-generation (decoder-only causal LM)
+models. Multimodal / vision models (e.g. Gemma3ForConditionalGeneration,
+qwen2_vl) occasionally leak past the upstream submission filter and only die
+~5 minutes in with a cryptic vLLM ``OSError: Can't load image processor ...``,
+wasting a full session slot. This Hyperloom-side safety net classifies the
+model from its ``config.json`` BEFORE the baseline server is launched and
+fails fast with a clear, actionable stop reason.
+
+Best-effort contract: a missing / unreadable / invalid ``config.json`` does
+NOT hard-block (the upstream filter + downstream loader still apply); only a
+positively-identified multimodal model is rejected.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from inference_optimizer import cli
+
+
+def _write_config(model_dir: Path, payload) -> None:
+    model_dir.mkdir(parents=True, exist_ok=True)
+    cfg = model_dir / "config.json"
+    if isinstance(payload, str):
+        cfg.write_text(payload, encoding="utf-8")
+    else:
+        cfg.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _args(model: str) -> argparse.Namespace:
+    return argparse.Namespace(model=model)
+
+
+def _seed_state(session_dir: Path, monkeypatch) -> None:
+    """Create a minimal seeded session so the preflight can load/save state."""
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_CURRENT_SESSION_DIR", str(session_dir))
+    from inference_optimizer.orchestrator.shared_state import SharedState
+
+    session_dir.mkdir(parents=True, exist_ok=True)
+    (session_dir / "reports").mkdir(parents=True, exist_ok=True)
+    SharedState(session_id="t", model_name="m", model_path="m").save(session_dir)
+
+
+# ---------------------------------------------------------------------------
+# 1. classifier — pure detection on config.json signals
+# ---------------------------------------------------------------------------
+def test_detect_gemma3_conditional_generation(tmp_path):
+    m = tmp_path / "gemma3"
+    _write_config(m, {
+        "architectures": ["Gemma3ForConditionalGeneration"],
+        "model_type": "gemma3",
+    })
+    hit = cli._detect_unsupported_model(str(m))
+    assert hit is not None
+    assert hit["architecture"] == "Gemma3ForConditionalGeneration"
+    assert hit["model_type"] == "gemma3"
+
+
+def test_detect_qwen2_vl_model_type(tmp_path):
+    m = tmp_path / "qwen2vl"
+    # model_type alone (architectures intentionally not a *_VL class) must trip.
+    _write_config(m, {"architectures": ["SomeCustomArch"], "model_type": "qwen2_vl"})
+    hit = cli._detect_unsupported_model(str(m))
+    assert hit is not None
+    assert hit["model_type"] == "qwen2_vl"
+
+
+def test_detect_vision_config_key(tmp_path):
+    m = tmp_path / "visioncfg"
+    _write_config(m, {
+        "architectures": ["LlamaForCausalLM"],
+        "model_type": "llama",
+        "vision_config": {"hidden_size": 1024},
+    })
+    hit = cli._detect_unsupported_model(str(m))
+    assert hit is not None
+    assert "vision_config" in hit["signal"]
+
+
+def test_detect_image_token_index_key(tmp_path):
+    m = tmp_path / "imgtoken"
+    _write_config(m, {"architectures": ["FooForCausalLM"], "image_token_index": 32000})
+    assert cli._detect_unsupported_model(str(m)) is not None
+
+
+def test_detect_plain_text_models_allowed(tmp_path):
+    for i, arch in enumerate(
+        ["MistralForCausalLM", "Qwen2ForCausalLM", "LlamaForCausalLM"]
+    ):
+        m = tmp_path / f"text{i}"
+        _write_config(m, {"architectures": [arch], "model_type": "llama"})
+        assert cli._detect_unsupported_model(str(m)) is None
+
+
+def test_detect_missing_config_returns_none(tmp_path):
+    # No config.json at all -> best-effort: cannot classify -> do not block.
+    assert cli._detect_unsupported_model(str(tmp_path / "nope")) is None
+
+
+def test_detect_invalid_config_returns_none(tmp_path):
+    m = tmp_path / "bad"
+    _write_config(m, "{not valid json")
+    assert cli._detect_unsupported_model(str(m)) is None
+
+
+# ---------------------------------------------------------------------------
+# 2. preflight gate — persists a canonical stop reason and signals exit
+# ---------------------------------------------------------------------------
+def test_preflight_blocks_gemma3(tmp_path, monkeypatch):
+    model = tmp_path / "gemma3"
+    _write_config(model, {
+        "architectures": ["Gemma3ForConditionalGeneration"],
+        "model_type": "gemma3",
+    })
+    sd = tmp_path / "session"
+    _seed_state(sd, monkeypatch)
+
+    blocked = cli._preflight_unsupported_model_arch(_args(str(model)), sd)
+
+    assert blocked is True
+    final = json.loads((sd / "reports" / "final.json").read_text())
+    assert final["stop_reason"] == "unsupported_model_arch"
+    detail = final["stop_detail"]
+    assert "Gemma3ForConditionalGeneration" in detail
+    assert "gemma3" in detail
+    assert "multimodal" in detail.lower()
+    assert "text-generation" in detail.lower()
+    final_md = (sd / "reports" / "final.md").read_text(encoding="utf-8")
+    assert "unsupported_model_arch" in final_md
+    state = json.loads((sd / "state.json").read_text())
+    assert state["stop_reason"] == "unsupported_model_arch"
+    # Delivery-artifact parity: fail-fast exits before coordinator.run()'s
+    # finally, so it MUST emit session_breakdown.json itself.
+    breakdown = sd / "session_breakdown.json"
+    assert breakdown.exists()
+    assert json.loads(breakdown.read_text(encoding="utf-8"))
+
+
+def test_preflight_blocks_qwen2_vl_model_type(tmp_path, monkeypatch):
+    model = tmp_path / "qwen2vl"
+    _write_config(model, {"architectures": ["X"], "model_type": "qwen2_vl"})
+    sd = tmp_path / "session_qwen"
+    _seed_state(sd, monkeypatch)
+    assert cli._preflight_unsupported_model_arch(_args(str(model)), sd) is True
+    final = json.loads((sd / "reports" / "final.json").read_text())
+    assert final["stop_reason"] == "unsupported_model_arch"
+
+
+def test_preflight_blocks_vision_config(tmp_path, monkeypatch):
+    model = tmp_path / "visioncfg"
+    _write_config(model, {
+        "architectures": ["LlamaForCausalLM"],
+        "model_type": "llama",
+        "vision_config": {"hidden_size": 1024},
+    })
+    sd = tmp_path / "session_vision"
+    _seed_state(sd, monkeypatch)
+    assert cli._preflight_unsupported_model_arch(_args(str(model)), sd) is True
+
+
+def test_preflight_allows_plain_text(tmp_path, monkeypatch):
+    model = tmp_path / "mistral"
+    _write_config(model, {
+        "architectures": ["MistralForCausalLM"],
+        "model_type": "mistral",
+    })
+    sd = tmp_path / "session_text"
+    _seed_state(sd, monkeypatch)
+    assert cli._preflight_unsupported_model_arch(_args(str(model)), sd) is False
+    assert not (sd / "reports" / "final.json").exists()
+
+
+def test_preflight_allows_missing_config(tmp_path, monkeypatch):
+    model = tmp_path / "no_config"
+    model.mkdir()
+    sd = tmp_path / "session_missing"
+    _seed_state(sd, monkeypatch)
+    # Missing config.json -> best-effort: do NOT hard-block.
+    assert cli._preflight_unsupported_model_arch(_args(str(model)), sd) is False
+    assert not (sd / "reports" / "final.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# 3. stop_reason must be a canonical STOP_REASON_VOCAB term so it round-trips
+# through the validated set_stop_reason() writer (not mapped to 'unknown',
+# not raising under strict mode) and the robustness monitor treats it as
+# terminal.
+# ---------------------------------------------------------------------------
+def test_stop_reason_is_canonical_vocab():
+    from inference_optimizer.orchestrator.phase_state import (
+        STOP_REASON_VOCAB,
+        is_valid_stop_reason,
+    )
+
+    assert "unsupported_model_arch" in STOP_REASON_VOCAB
+    assert is_valid_stop_reason("unsupported_model_arch")
+
+
+def test_preflight_persists_stop_reason_under_strict_env(tmp_path, monkeypatch):
+    """Under ``INFERENCE_OPTIMIZER_STRICT_STOP_REASON=1`` the preflight must
+    still persist the canonical stop_reason — proving the writer goes through
+    the validated ``set_stop_reason()`` path AND that the term is registered in
+    the vocab (an off-vocab term would raise in strict mode and abort the
+    report)."""
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_STRICT_STOP_REASON", "1")
+    model = tmp_path / "gemma3strict"
+    _write_config(model, {
+        "architectures": ["Gemma3ForConditionalGeneration"],
+        "model_type": "gemma3",
+    })
+    sd = tmp_path / "session_strict"
+    _seed_state(sd, monkeypatch)
+    assert cli._preflight_unsupported_model_arch(_args(str(model)), sd) is True
+    state = json.loads((sd / "state.json").read_text())
+    assert state["stop_reason"] == "unsupported_model_arch"

--- a/inference_optimizer/tests/test_sglang_context_length_cap.py
+++ b/inference_optimizer/tests/test_sglang_context_length_cap.py
@@ -1,0 +1,308 @@
+"""sglang ``--context-length`` cap injection tests.
+
+sglang's ``launch_server`` defaults ``context_length`` to None, which makes it
+size ``max_total_tokens`` from the model's ``max_position_embeddings``. For a
+model that advertises a huge native window (e.g. Mistral-Nemo-12B =
+``max_position_embeddings=1024000``) the aiter attention backend then allocates
+a ``workspace_buffer`` of >100 GiB and the server dies with
+``torch.OutOfMemoryError: HIP out of memory`` -> the benchmark reports
+``baseline_failed`` with throughput 0.
+
+The vllm benchmark scripts already cap their window via
+``--max-model-len $MAX_MODEL_LEN`` (default 4096), but the sglang scripts pass
+no ``--context-length`` and never consume the YAML's ``MAX_MODEL_LEN``, so the
+asymmetry only hurts sglang. Hyperloom injects a workload-sized
+``--context-length`` (ISL+OSL+headroom, floored to a sane minimum, never above
+the model's native window) into ``EXTRA_SGLANG_ARGS`` -- which InferenceX's
+``sglang_mi300x.sh`` appends verbatim after its DEFAULT_ARGS to
+``python -m sglang.launch_server`` -- unless the operator already pinned one.
+
+These tests pin the contract:
+
+* a huge native window is capped to the workload (value <= cap, never OOM);
+* a small native window is respected (never advertised above it);
+* an operator-supplied ``--context-length`` is honored and never overridden;
+* vllm / atom runs get no ``--context-length`` at all;
+* an unreadable ``max_position_embeddings`` injects nothing (fail-safe).
+
+Both layers are exercised: the pure helpers
+(``resolve_sglang_context_cap`` / ``inject_sglang_context_length``) and the
+materialization choke point (``materialize_config_with_envs``) that every
+benchmark path funnels through.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from inference_optimizer.orchestrator.action_executors._grid_runner import (
+    DEFAULT_SGLANG_CONTEXT_FLOOR_TOKENS,
+    DEFAULT_SGLANG_CONTEXT_HEADROOM_TOKENS,
+    inject_sglang_context_length,
+    resolve_sglang_context_cap,
+)
+from inference_optimizer.orchestrator.action_executors._workload_envs import (
+    materialize_config_with_envs,
+)
+
+# Mistral-Nemo-12B's advertised native window -- the value that triggered the
+# 126.95 GiB aiter workspace_buffer OOM in production.
+_HUGE_MAX_POS = 1_024_000
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_env(monkeypatch):
+    """Isolate the context-cap env knobs and skip the GPU TP-clamp probe.
+
+    The materializer reads several workload knobs from the process env; clear
+    them so the host shell can't leak values into the rendered YAML, and
+    disable the TP clamp so the test never shells out to ``rocm-smi`` / probes
+    ``torch.cuda`` on a CPU-only CI box. The watchdog default still fires, so
+    every sglang assertion below tolerates it being present.
+    """
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_DISABLE_TP_CLAMP", "1")
+    for key in (
+        "SGLANG_CONTEXT_HEADROOM_TOKENS", "SGLANG_CONTEXT_FLOOR_TOKENS",
+        "SGLANG_WATCHDOG_TIMEOUT",
+        "CONC", "ISL", "OSL", "MAX_MODEL_LEN", "TP", "RANDOM_RANGE_RATIO",
+        "ROCR_VISIBLE_DEVICES", "PRECISION", "RUN_EVAL", "FRAMEWORK",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _write_model(tmp_path: Path, max_pos: int | None, *, nested: bool = False) -> str:
+    """Create a model dir with a config.json and return its path.
+
+    ``max_pos=None`` writes a config.json with no max-length key (so the loader
+    returns None); ``nested=True`` hides ``max_position_embeddings`` under a
+    ``text_config`` block (the multimodal layout the loader must still read).
+    """
+    model_dir = tmp_path / "model"
+    model_dir.mkdir(parents=True, exist_ok=True)
+    cfg: dict = {"model_type": "mistral"}
+    if max_pos is not None:
+        if nested:
+            cfg["text_config"] = {"max_position_embeddings": max_pos}
+        else:
+            cfg["max_position_embeddings"] = max_pos
+    (model_dir / "config.json").write_text(json.dumps(cfg), encoding="utf-8")
+    return str(model_dir)
+
+
+def _write_yaml(path: Path, *, framework: str, model: str) -> None:
+    cfg: dict = {
+        "benchmark": {
+            "framework": framework,
+            "model": model,
+            "precision": "bf16",
+            "run_mode": "local",
+            "envs": {"TP": 1, "CONC": 8, "ISL": 256, "OSL": 256},
+            "timeout_seconds": 600,
+            "profiler": {
+                "torch_profiler": {"enabled": False},
+                "system_profiler": {"enabled": False},
+                "tracelens": {"enabled": False},
+            },
+            "gpu_selection": {"auto": False},
+        }
+    }
+    with path.open("w") as f:
+        yaml.safe_dump(cfg, f)
+
+
+def _materialize_envs(
+    tmp_path: Path,
+    *,
+    framework: str,
+    model: str,
+    extra_server_args: str = "",
+    extra_envs: dict | None = None,
+) -> dict:
+    """Render a YAML via the production choke point and return its envs map."""
+    base = tmp_path / "base.yaml"
+    _write_yaml(base, framework=framework, model=model)
+    out = tmp_path / "out"
+    out.mkdir()
+    materialized = materialize_config_with_envs(
+        base, out,
+        extra_server_args=extra_server_args,
+        extra_envs=extra_envs,
+    )
+    cfg = yaml.safe_load(materialized.read_text())
+    return cfg["benchmark"]["envs"]
+
+
+def _context_length_value(server_args: str) -> int:
+    """Extract the single ``--context-length`` value (space- or =-separated)."""
+    tokens = server_args.replace("=", " ").split()
+    idx = tokens.index("--context-length")
+    return int(tokens[idx + 1])
+
+
+# ---------------------------------------------------------------------------
+# resolve_sglang_context_cap (pure helper)
+# ---------------------------------------------------------------------------
+def test_cap_defaults():
+    assert DEFAULT_SGLANG_CONTEXT_HEADROOM_TOKENS == 2048
+    assert DEFAULT_SGLANG_CONTEXT_FLOOR_TOKENS == 8192
+
+
+def test_cap_uses_floor_for_small_workload():
+    # 256 + 256 + 2048 = 2560 < 8192 -> floor wins.
+    assert resolve_sglang_context_cap(256, 256) == 8192
+
+
+def test_cap_uses_workload_plus_headroom_above_floor():
+    # 4096 + 4096 + 2048 = 10240 > 8192 -> workload+headroom wins.
+    assert resolve_sglang_context_cap(4096, 4096) == 10240
+
+
+def test_cap_reads_env_overrides(monkeypatch):
+    monkeypatch.setenv("SGLANG_CONTEXT_HEADROOM_TOKENS", "1024")
+    monkeypatch.setenv("SGLANG_CONTEXT_FLOOR_TOKENS", "4096")
+    assert resolve_sglang_context_cap(2048, 2048) == 2048 + 2048 + 1024
+    assert resolve_sglang_context_cap(256, 256) == 4096
+
+
+@pytest.mark.parametrize("bad", ["", "  ", "abc", "1.5", "-5"])
+def test_cap_bad_env_falls_back_to_default(monkeypatch, bad):
+    monkeypatch.setenv("SGLANG_CONTEXT_HEADROOM_TOKENS", bad)
+    monkeypatch.setenv("SGLANG_CONTEXT_FLOOR_TOKENS", bad)
+    assert resolve_sglang_context_cap(256, 256) == 8192
+
+
+# ---------------------------------------------------------------------------
+# inject_sglang_context_length (pure helper)
+# ---------------------------------------------------------------------------
+def test_inject_caps_huge_window_for_sglang(tmp_path):
+    """Required case 1: max_position_embeddings=1024000 -> the injected
+    ``--context-length`` is present and never exceeds the workload cap."""
+    model = _write_model(tmp_path, _HUGE_MAX_POS)
+    out = inject_sglang_context_length("--foo bar", "sglang", model, 256, 256)
+    assert "--context-length" in out
+    cap = resolve_sglang_context_cap(256, 256)
+    value = _context_length_value(out)
+    assert value <= cap
+    assert value <= _HUGE_MAX_POS
+    # Pre-existing flags must survive the merge.
+    assert "--foo bar" in out
+
+
+def test_inject_caps_huge_window_via_nested_text_config(tmp_path):
+    """Multimodal configs hide the window under ``text_config``; the loader
+    handles the nesting, so the cap must still apply."""
+    model = _write_model(tmp_path, _HUGE_MAX_POS, nested=True)
+    out = inject_sglang_context_length("", "sglang", model, 256, 256)
+    assert _context_length_value(out) == 8192
+
+
+def test_inject_clamps_to_small_native_window(tmp_path):
+    """A native window below the cap is never advertised above itself."""
+    model = _write_model(tmp_path, 4096)
+    out = inject_sglang_context_length("", "sglang", model, 256, 256)
+    assert _context_length_value(out) == 4096
+
+
+def test_inject_uses_cap_below_native_window(tmp_path):
+    """When the native window is large but finite, the workload cap wins."""
+    model = _write_model(tmp_path, 131072)
+    out = inject_sglang_context_length("", "sglang", model, 4096, 4096)
+    assert _context_length_value(out) == 10240
+
+
+@pytest.mark.parametrize("existing", [
+    "--context-length 6144",
+    "--context-length=6144",
+    "--foo 1 --context-length 6144 --bar 2",
+])
+def test_inject_does_not_override_existing(tmp_path, existing):
+    """Required case 2: an operator-supplied ``--context-length`` wins."""
+    model = _write_model(tmp_path, _HUGE_MAX_POS)
+    out = inject_sglang_context_length(existing, "sglang", model, 256, 256)
+    assert out == existing
+    assert out.count("--context-length") == 1
+    assert "8192" not in out
+
+
+@pytest.mark.parametrize("framework", ["vllm", "atom"])
+def test_inject_noop_for_non_sglang(tmp_path, framework):
+    """Required case 3: vllm / atom get no ``--context-length`` injected."""
+    model = _write_model(tmp_path, _HUGE_MAX_POS)
+    assert (
+        inject_sglang_context_length("--foo", framework, model, 256, 256)
+        == "--foo"
+    )
+    assert "--context-length" not in inject_sglang_context_length(
+        "--gpu-memory-utilization 0.9", framework, model, 256, 256,
+    )
+
+
+def test_inject_noop_when_maxpos_unreadable(tmp_path):
+    """Required case 4: an unreadable window injects nothing (fail-safe)."""
+    # config.json present but carries no max-length key.
+    no_key = _write_model(tmp_path / "a", None)
+    assert inject_sglang_context_length("--foo", "sglang", no_key, 256, 256) == "--foo"
+    # config.json absent entirely.
+    missing = str(tmp_path / "does-not-exist")
+    assert inject_sglang_context_length("--foo", "sglang", missing, 256, 256) == "--foo"
+    # empty / None model path.
+    assert inject_sglang_context_length("--foo", "sglang", "", 256, 256) == "--foo"
+    assert inject_sglang_context_length("--foo", "sglang", None, 256, 256) == "--foo"
+
+
+def test_inject_empty_or_unknown_framework_treated_as_sglang(tmp_path):
+    """An empty/unknown framework routes to EXTRA_SGLANG_ARGS (the default
+    backend) everywhere else in the codebase, so the cap applies there too."""
+    model = _write_model(tmp_path, _HUGE_MAX_POS)
+    assert _context_length_value(
+        inject_sglang_context_length("", "", model, 256, 256)
+    ) == 8192
+    assert _context_length_value(
+        inject_sglang_context_length("", None, model, 256, 256)
+    ) == 8192
+
+
+# ---------------------------------------------------------------------------
+# materialize_config_with_envs (the production choke point)
+# ---------------------------------------------------------------------------
+def test_materialize_sglang_injects_context_length_cap(tmp_path):
+    model = _write_model(tmp_path, _HUGE_MAX_POS)
+    envs = _materialize_envs(tmp_path, framework="sglang", model=model)
+    sglang_args = envs["EXTRA_SGLANG_ARGS"]
+    # YAML envs default ISL=OSL=256 -> floor cap 8192.
+    assert _context_length_value(sglang_args) == 8192
+    # The watchdog injection at the same choke point must still fire.
+    assert "--watchdog-timeout 1800" in sglang_args
+
+
+def test_materialize_sglang_respects_user_context_length(tmp_path):
+    model = _write_model(tmp_path, _HUGE_MAX_POS)
+    envs = _materialize_envs(
+        tmp_path, framework="sglang", model=model,
+        extra_server_args="--context-length 6144",
+    )
+    sglang_args = envs["EXTRA_SGLANG_ARGS"]
+    assert sglang_args.count("--context-length") == 1
+    assert _context_length_value(sglang_args) == 6144
+    assert "8192" not in sglang_args
+
+
+def test_materialize_sglang_noop_when_maxpos_unreadable(tmp_path):
+    # Model dir without a config.json -> no cap, but watchdog still injected.
+    model = str(tmp_path / "model")
+    Path(model).mkdir()
+    envs = _materialize_envs(tmp_path, framework="sglang", model=model)
+    sglang_args = envs["EXTRA_SGLANG_ARGS"]
+    assert "--context-length" not in sglang_args
+    assert "--watchdog-timeout 1800" in sglang_args
+
+
+def test_materialize_vllm_no_context_length(tmp_path):
+    model = _write_model(tmp_path, _HUGE_MAX_POS)
+    envs = _materialize_envs(tmp_path, framework="vllm", model=model)
+    assert "EXTRA_SGLANG_ARGS" not in envs
+    assert "--context-length" not in envs.get("EXTRA_VLLM_ARGS", "")

--- a/optimizer_runs/robustness_monitor.sh.example
+++ b/optimizer_runs/robustness_monitor.sh.example
@@ -145,7 +145,7 @@ except ImportError:
         "crash_threshold_exceeded", "user_stop_requested",
         "time_exhausted_during_prelude", "cortex_t0_failed",
         "cortex_drain_failed", "cortex_commit_failed",
-        "model_context_window_too_small",
+        "model_context_window_too_small", "unsupported_model_arch",
     })
 
 if stop and stop in STOP_REASON_VOCAB:


### PR DESCRIPTION
## Summary

Fixes 4 confirmed production failure modes discovered from 7 failed sessions after 2025-06-05 21:00 BJT:

- **sglang OOM on large-context models**: Inject `--context-length` cap into `EXTRA_SGLANG_ARGS` so models with huge `max_position_embeddings` (e.g. Mistral-Nemo 1M tokens) don't allocate 127GB workspace_buffer and crash. vllm/atom unaffected (they already pass `--max-model-len`).
- **Multimodal model fail-fast gate**: Whitelist-based preflight rejects non-text-generation models before expensive server boot. Explicit vision/multimodal signals (architecture denylist, model_type denylist, `vision_config`/`image_token_id` keys) are checked first, then text-generation markers (`ForCausalLM`/`LMHeadModel`) allow passage. Validated against 4,336 real model configs (4,209 allowed, 126 rejected, 0 errors).
- **Magpie patcher upstream-aware**: When Magpie upstream already uses atomic copy (`_copy_benchmark_script_atomic`), the patcher returns True (no-op) instead of failing with "legacy block not found".
- **Pin Magpie/InferenceX to commit SHAs**: Replicates the GEAK pin pattern (`git_fetch_pinned` helper). Eliminates version drift from upstream HEAD changes. Magpie patch step downgraded from fail-loud to fail-soft (expected no-op with pinned SHA).

## Test plan

- [x] `test_sglang_context_length_cap.py` — 24 tests covering cap logic, existing flag preservation, vllm/atom no-op, unreadable max_pos
- [x] `test_multimodal_gate.py` — 21 tests covering whitelist, denylist, vision keys, missing config, preflight persistence
- [x] `test_magpie_patcher.py` — 50 tests covering legacy patch, upstream-atomic no-op, region scoping, read-only deployment
- [x] `test_local_setup_script.py` — 3 new tests for pinned ref verification
- [x] All 141 focused regression tests pass
- [x] Real sglang server launch with Mistral-Nemo-12B (max_pos=1024000) confirms `context_length=8192`
- [x] Real model scan: `/wekafs/models` 4,336 configs classified correctly
- [x] Known problem models (`thomaskuo-gemma-3-12b-it-heretic`, `vanta-research-atom-v1-preview-12b`) correctly rejected
- [x] `bash -n` + `py_compile` on all modified files


Made with [Cursor](https://cursor.com)