### PR TITLE
fix(integrate): target-type cache-invalidation registry (generalizes #459) + DEFER_TO_E2E gate

### DIFF
--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -1619,6 +1619,30 @@ async def integrate_handler(
     )
     ctx = RunnerContext(task=fake_task, lease=None)
 
+    # GH #458 + cache-invalidation registry: when apply_kernel_patch moved a
+    # toolchain's compiled/runtime cache aside (aiter cpp_itfs, Triton, torch
+    # inductor, ...), the re-baseline server must (re)compile the patched
+    # kernel from clean state -- otherwise it can dlopen/serve the stale
+    # PRE-patch binary and integrate would score the wrong kernel (the observed
+    # -0.17% on a real +2.5% paged_attention win; the same risk for the Triton
+    # fused_moe win). The registry tells us which rebuild env vars to set for
+    # the detected toolchain (e.g. AITER_REBUILD=1 for cpp_itfs; empty when the
+    # move-aside alone forces recompilation, as for Triton/inductor). Scoped to
+    # this integrate and ALWAYS restored, so every target the registry doesn't
+    # touch is byte-for-byte unaffected.
+    apply_tool = _load_apply_tool()
+    rebuild_env = apply_tool.rebuild_env_for_apply_result(apply_result)
+    _prev_rebuild_env = {k: os.environ.get(k) for k in rebuild_env}
+    for _env_k, _env_v in rebuild_env.items():
+        os.environ[_env_k] = _env_v
+
+    def _restore_rebuild_env() -> None:
+        for _env_k, _prev in _prev_rebuild_env.items():
+            if _prev is None:
+                os.environ.pop(_env_k, None)
+            else:
+                os.environ[_env_k] = _prev
+
     # Multi-node: apply_kernel_patch has just fanned the new source
     # files to every pod. sglang must be FULLY restarted (not resume-
     # pathed) so it re-imports the patched modules; otherwise the
@@ -1649,6 +1673,7 @@ async def integrate_handler(
             ctx.extra = {**(getattr(ctx, "extra", None) or {}),
                          "mn_round_restarted": True}
         except ServerRestartFailed as exc:
+            _restore_rebuild_env()
             revert_result = _maybe_revert_kernel_patch(apply_result)
             return {
                 "status": "failed",
@@ -1674,6 +1699,10 @@ async def integrate_handler(
             "apply_result": apply_result,
             "revert_result": revert_result,
         }
+    finally:
+        # Restore the rebuild env on every path once the re-baseline server has
+        # been launched, so the env override never leaks past this integrate.
+        _restore_rebuild_env()
 
     if not is_valid_measurement(bench_result):
         revert_result = _maybe_revert_kernel_patch(apply_result)
@@ -1687,6 +1716,41 @@ async def integrate_handler(
             "apply_result": apply_result,
             "revert_result": revert_result,
         }
+
+    # GH #458 (point 2), generalized by the cache-invalidation registry: don't
+    # score a stale binary. For any toolchain whose cache the apply moved aside
+    # (cpp_itfs runtime lib.so, Triton .hsaco, inductor artifact), a re-baseline
+    # that reused the stale binary would silently measure the PRE-patch kernel
+    # (the observed -0.17% on a real +2.5% paged_attention win; the same risk
+    # for the Triton fused_moe win). Before trusting gain_pct, assert a real
+    # rebuild landed: verify_rebuilt_for_apply_result() runs the detected
+    # toolchain's fresh-build check (a freshly-compiled artifact newer than the
+    # invalidation) and is a strict no-op (verified=True) when no gating cache
+    # was invalidated -- so this gate is byte-for-byte off the cache paths.
+    #
+    # Single-node only: in multi-node the served cache lives on the serving
+    # pod, not this sandbox, so the rebuild env on the pod restart is the
+    # mechanism and the sandbox-local check is skipped to avoid false aborts.
+    rebuild_check: HandlerResult = {"verified": True, "status": "skipped"}
+    if not is_multi_node():
+        rebuild_check = apply_tool.verify_rebuilt_for_apply_result(apply_result)
+        if not rebuild_check.get("verified", True):
+            revert_result = _maybe_revert_kernel_patch(apply_result)
+            return {
+                "status": "failed",
+                "error_class": "kernel_cache_rebuild_not_verified",
+                "error": (
+                    "re-baseline did not produce a freshly-built kernel cache "
+                    "artifact; refusing to score a possibly-stale binary"
+                ),
+                "decision": "NEEDS_REVIEW",
+                "kernel_id": kernel_id,
+                "patch_path": patch_path,
+                "target_file": payload.get("target_file") or payload.get("source_file"),
+                "apply_result": apply_result,
+                "revert_result": revert_result,
+                "rebuild_check": rebuild_check,
+            }
 
     new_tput = float(bench_result.get("output_throughput") or 0.0)
     gain_pct = ((new_tput - base_tput) / base_tput * 100.0) if base_tput > 0 else 0.0
@@ -1714,6 +1778,7 @@ async def integrate_handler(
         "extra_sglang_args": extra_args,
         "apply_result": apply_result,
         "revert_result": revert_result,
+        "rebuild_check": rebuild_check,
     }
 
 

--- a/inference_optimizer/orchestrator/shared_state.py
+++ b/inference_optimizer/orchestrator/shared_state.py
@@ -75,6 +75,12 @@ _DEFAULT_HOT_KERNEL_MIN_GPU_PCT = 3.0
 # a noisy trace with 15 reusable rows, only the top-N by gpu_pct are
 # enforced -- avoids the LLM stalling on dozens of tiny kernels.
 _DEFAULT_HOT_KERNEL_GATE_TOP_N = 5
+# PART C (DEFER_TO_E2E): the integrate E2E budget per kernel. Mirrors
+# ``record_kernel_integrate_result``'s ``max_attempts`` default so a
+# DEFER_TO_E2E candidate is routed to integrate only while the same E2E
+# budget allows; once exhausted it drops out of the integrate queue and
+# falls back to its non-deferred disposition.
+_DEFAULT_MAX_E2E_ATTEMPTS = 3
 
 # Per-action audit history cap. ``<action>_attempts`` lists keep the most
 # recent N entries (full audit trail — both successes and failures) so
@@ -993,9 +999,11 @@ class SharedState:
         entry["attempts"] = int(entry.get("attempts", 0)) + 1
         if decision == "PARTIAL":
             entry["partial_count"] = int(entry.get("partial_count", 0)) + 1
-        elif decision == "KEEP":
-            # A successful attempt resets streaks; a future regression
-            # should not be auto-retired on stale history.
+        elif decision in {"KEEP", "DEFER_TO_E2E"}:
+            # A KEEP -- or a DEFER_TO_E2E (correctness passed, high-impact,
+            # routed to integrate so the E2E gain_pct decides) -- resets the
+            # streaks so a promising kernel is not auto-retired on stale
+            # PARTIAL/failure history.
             entry["partial_count"] = 0
             entry["failure_count"] = 0
         if is_infra_failure:
@@ -1007,21 +1015,29 @@ class SharedState:
         entry["last_source_file"] = source_file
         entry["last_ts"] = ts
         entry["history"] = history
+        # PART C: surface the DEFER_TO_E2E disposition on the ledger entry so
+        # state inspectors / prompt rendering can see a candidate is awaiting
+        # an authoritative E2E verdict (and what it falls back to).
+        if decision == "DEFER_TO_E2E":
+            entry["deferred_to_e2e"] = True
+            entry["defer_fallback_decision"] = str(proposal.get("fallback_decision", ""))
 
         # Overwrite policy for last_kernel_opt:
-        #   * KEEP always wins (highest micro bubbles up).
-        #   * Non-KEEP only writes when there's no pending KEEP to protect.
+        #   * KEEP / DEFER_TO_E2E always win (both route to integrate).
+        #   * A non-promoting result only writes when there's no pending
+        #     KEEP / DEFER_TO_E2E to protect (PART C: a late REVERT/PARTIAL
+        #     sibling must not clobber a pending deferred candidate either).
         prev = self.last_kernel_opt or {}
         prev_decision = str(prev.get("decision", "")).upper()
         prev_kid = str(prev.get("kernel_id", ""))
         integrated_ids = self._kernel_ids_in_optimization_stack()
         prev_pending = (
-            prev_decision == "KEEP"
+            prev_decision in {"KEEP", "DEFER_TO_E2E"}
             and bool(prev_kid)
             and prev_kid not in (self.rejected_kernel_ids or [])
             and prev_kid not in integrated_ids
         )
-        if decision == "KEEP" or not prev_pending:
+        if decision in {"KEEP", "DEFER_TO_E2E"} or not prev_pending:
             self.last_kernel_opt = {
                 "kernel_id": kernel_id,
                 "decision": decision,
@@ -1107,6 +1123,55 @@ class SharedState:
                 sources.add(src)
         return sources
 
+    def _integrate_attempts_for_kernel(self, kernel_id: str) -> int:
+        """Count integrate (E2E) attempts already recorded for ``kernel_id``.
+
+        The ``kernel_integrate_attempts`` ledger is keyed by
+        ``kernel_id|patch_path|extra_args`` (the patch identity), so a kernel
+        can have several patch keys; we take the max attempt_count across the
+        keys that carry this ``kernel_id``. Used to bound the PART C
+        DEFER_TO_E2E routing by the existing max_e2e_attempts budget.
+        """
+        kid = str(kernel_id or "")
+        if not kid:
+            return 0
+        best = 0
+        for entry in (self.kernel_integrate_attempts or {}).values():
+            if not isinstance(entry, dict):
+                continue
+            if str(entry.get("kernel_id") or "") != kid:
+                continue
+            count = entry.get("attempt_count")
+            if count is None:
+                count = len(entry.get("attempts") or [])
+            try:
+                best = max(best, int(count))
+            except (TypeError, ValueError):
+                continue
+        return best
+
+    def _defer_e2e_budget_exhausted(
+        self, kernel_id: str, *, max_attempts: int | None = None,
+    ) -> bool:
+        """PART C: True iff a DEFER_TO_E2E candidate has already spent its
+        integrate (E2E) budget.
+
+        Bounds the defer by the SAME ledger that ``record_kernel_integrate_
+        result`` enforces (default 3 attempts; override via
+        ``HYPERLOOM_MAX_E2E_ATTEMPTS``) so we never blow up expensive E2E runs;
+        once exhausted the candidate drops out of the integrate queue and falls
+        back to its non-deferred disposition.
+        """
+        if max_attempts is None:
+            try:
+                max_attempts = int(os.environ.get(
+                    "HYPERLOOM_MAX_E2E_ATTEMPTS", _DEFAULT_MAX_E2E_ATTEMPTS,
+                ))
+            except (TypeError, ValueError):
+                max_attempts = _DEFAULT_MAX_E2E_ATTEMPTS
+        max_attempts = max(1, int(max_attempts))
+        return self._integrate_attempts_for_kernel(kernel_id) >= max_attempts
+
     def next_pending_keep_kernel_id(self) -> str:
         """Return next KEEP kernel_id awaiting integrate, or "" if drained.
 
@@ -1130,7 +1195,15 @@ class SharedState:
         for kid, entry in (self.kernel_opt_attempts or {}).items():
             if not isinstance(entry, dict):
                 continue
-            if str(entry.get("last_decision", "")).upper() != "KEEP":
+            # PART C: KEEP *and* DEFER_TO_E2E are routed to integrate. A
+            # DEFER_TO_E2E candidate is bounded by the E2E budget -- once it
+            # has used its max_e2e_attempts integrate runs without a KEEP it
+            # drops out of the queue (the E2E gain_pct was authoritative) and
+            # falls back to its non-deferred disposition.
+            last_decision = str(entry.get("last_decision", "")).upper()
+            if last_decision not in ("KEEP", "DEFER_TO_E2E"):
+                continue
+            if last_decision == "DEFER_TO_E2E" and self._defer_e2e_budget_exhausted(kid):
                 continue
             if kid in integrated_ids or kid in rejected:
                 continue
@@ -1166,7 +1239,12 @@ class SharedState:
         for kid, entry in (self.kernel_opt_attempts or {}).items():
             if not isinstance(entry, dict):
                 continue
-            if str(entry.get("last_decision", "")).upper() != "KEEP":
+            # PART C: include DEFER_TO_E2E alongside KEEP (both route to
+            # integrate), bounded by the per-kernel E2E budget.
+            last_decision = str(entry.get("last_decision", "")).upper()
+            if last_decision not in ("KEEP", "DEFER_TO_E2E"):
+                continue
+            if last_decision == "DEFER_TO_E2E" and self._defer_e2e_budget_exhausted(kid):
                 continue
             if kid in integrated_ids or kid in rejected:
                 continue

--- a/inference_optimizer/tests/test_defer_to_e2e_disposition.py
+++ b/inference_optimizer/tests/test_defer_to_e2e_disposition.py
@@ -1,0 +1,197 @@
+"""PART C — DEFER_TO_E2E routing + bounding in SharedState.
+
+A ``DEFER_TO_E2E`` kernel_opt result (high-impact + correctness-passed kernel
+whose micro-score was inconclusive/low) is routed to integrate through the
+SAME promotion queue as KEEP so the integrate E2E ``gain_pct`` becomes the
+authoritative KEEP/REVERT signal -- but BOUNDED by the existing
+max_e2e_attempts (E2E) ledger so we never blow up expensive E2E runs. These
+tests pin: DEFER is recorded (and never auto-rejected at the micro stage),
+queued like KEEP, bounded by the integrate-attempt budget, protected from
+clobber, and that normal KEEP / correctness-fail (REVERT) behaviour is intact.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from inference_optimizer.orchestrator.shared_state import SharedState
+
+
+@pytest.fixture
+def state() -> SharedState:
+    return SharedState()
+
+
+def _defer_result(kernel_id: str, *, micro: float = 1.0, source_file: str = "",
+                  fallback: str = "REVERT", artifact: str = "") -> dict:
+    """A kernel_optimization_handler result carrying a DEFER_TO_E2E proposal."""
+    return {
+        "status": "ok",
+        "kernel_id": kernel_id,
+        "source_file": source_file,
+        "disposition": "DEFER_TO_E2E",
+        "high_impact": True,
+        "proposal": {
+            "decision": "DEFER_TO_E2E",
+            "fallback_decision": fallback,
+            "defer_to_e2e": True,
+            "reasons": ["inconclusive micro"],
+        },
+        "verification": {
+            "micro_speedup": micro,
+            "best_artifact_path": artifact,
+            "compile_passed": True,
+            "correctness_passed": True,
+        },
+    }
+
+
+def _keep_result(kernel_id: str, *, micro: float, source_file: str = "") -> dict:
+    return {
+        "status": "ok",
+        "kernel_id": kernel_id,
+        "source_file": source_file,
+        "proposal": {"decision": "KEEP", "reasons": []},
+        "verification": {
+            "micro_speedup": micro,
+            "best_artifact_path": "",
+            "compile_passed": True,
+            "correctness_passed": True,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# DEFER is recorded + observable + NOT auto-rejected at the micro stage.
+# ---------------------------------------------------------------------------
+def test_defer_recorded_and_not_rejected(state: SharedState) -> None:
+    state.record_kernel_opt(_defer_result("k001", micro=1.0, source_file="/p/a.py"))
+    entry = state.kernel_opt_attempts["k001"]
+    assert entry["last_decision"] == "DEFER_TO_E2E"
+    assert entry["deferred_to_e2e"] is True
+    assert entry["defer_fallback_decision"] == "REVERT"
+    # A DEFER is NOT a micro-stage rejection (unlike REVERT).
+    assert "k001" not in state.rejected_kernel_ids
+    # last_kernel_opt reflects the deferred candidate.
+    assert state.last_kernel_opt["kernel_id"] == "k001"
+    assert state.last_kernel_opt["decision"] == "DEFER_TO_E2E"
+
+
+# ---------------------------------------------------------------------------
+# DEFER is routed to integrate via the KEEP promotion queue.
+# ---------------------------------------------------------------------------
+def test_defer_is_queued_for_integrate(state: SharedState) -> None:
+    state.record_kernel_opt(_defer_result("k001", micro=1.0, source_file="/p/a.py"))
+    assert state.next_pending_keep_kernel_id() == "k001"
+    assert state.pending_keep_kernel_ids() == ["k001"]
+    assert state.has_keep_pending_integrate is True
+
+
+def test_keep_outranks_defer_then_both_drain(state: SharedState) -> None:
+    """KEEP (higher micro) and DEFER coexist in the queue; KEEP is the
+    stronger lever and drains first."""
+    state.record_kernel_opt(_keep_result("k009", micro=4.0, source_file="/p/b.py"))
+    state.record_kernel_opt(_defer_result("k001", micro=1.0, source_file="/p/a.py"))
+    assert state.pending_keep_kernel_ids() == ["k009", "k001"]
+    assert state.next_pending_keep_kernel_id() == "k009"
+    # k009 integrated -> DEFER candidate is next.
+    state.optimization_stack.append({
+        "action": "integrate", "kernel_id": "k009", "target_file": "/p/b.py", "tput": 1.0,
+    })
+    assert state.next_pending_keep_kernel_id() == "k001"
+
+
+# ---------------------------------------------------------------------------
+# DEFER is BOUNDED by the existing max_e2e_attempts ledger.
+# ---------------------------------------------------------------------------
+def test_integrate_attempts_for_kernel_counts_across_patch_keys(state: SharedState) -> None:
+    state.kernel_integrate_attempts["k001|/p/a.py|"] = {
+        "kernel_id": "k001", "attempt_count": 2, "attempts": [{}, {}],
+    }
+    state.kernel_integrate_attempts["k001|/p/a.py|--flag"] = {
+        "kernel_id": "k001", "attempt_count": 1, "attempts": [{}],
+    }
+    state.kernel_integrate_attempts["other|/p/c.py|"] = {
+        "kernel_id": "other", "attempt_count": 9, "attempts": [],
+    }
+    assert state._integrate_attempts_for_kernel("k001") == 2
+    assert state._integrate_attempts_for_kernel("missing") == 0
+
+
+def test_defer_dropped_when_e2e_budget_exhausted(state: SharedState) -> None:
+    """Once a DEFER candidate has spent its max_e2e_attempts (default 3) E2E
+    runs without a KEEP, it drops out of the queue -> falls back."""
+    state.record_kernel_opt(_defer_result("k001", micro=1.0, source_file="/p/a.py"))
+    assert state.next_pending_keep_kernel_id() == "k001"  # budget available
+
+    # 3 integrate attempts recorded => budget exhausted (default max = 3).
+    state.kernel_integrate_attempts["k001|/p/a.py|"] = {
+        "kernel_id": "k001", "attempt_count": 3, "attempts": [{}, {}, {}],
+    }
+    assert state._defer_e2e_budget_exhausted("k001") is True
+    assert state.next_pending_keep_kernel_id() == ""
+    assert state.pending_keep_kernel_ids() == []
+    assert state.has_keep_pending_integrate is False
+
+
+def test_defer_budget_below_max_still_queued(state: SharedState) -> None:
+    state.record_kernel_opt(_defer_result("k001", micro=1.0, source_file="/p/a.py"))
+    state.kernel_integrate_attempts["k001|/p/a.py|"] = {
+        "kernel_id": "k001", "attempt_count": 2, "attempts": [{}, {}],
+    }
+    assert state._defer_e2e_budget_exhausted("k001") is False
+    assert state.next_pending_keep_kernel_id() == "k001"
+
+
+def test_defer_budget_env_override(state: SharedState, monkeypatch) -> None:
+    monkeypatch.setenv("HYPERLOOM_MAX_E2E_ATTEMPTS", "1")
+    state.record_kernel_opt(_defer_result("k001", micro=1.0, source_file="/p/a.py"))
+    state.kernel_integrate_attempts["k001|/p/a.py|"] = {
+        "kernel_id": "k001", "attempt_count": 1, "attempts": [{}],
+    }
+    assert state._defer_e2e_budget_exhausted("k001") is True
+    assert state.next_pending_keep_kernel_id() == ""
+
+
+# ---------------------------------------------------------------------------
+# DEFER does not break KEEP / REVERT behaviour.
+# ---------------------------------------------------------------------------
+def test_normal_keep_still_routes(state: SharedState) -> None:
+    state.record_kernel_opt(_keep_result("k009", micro=4.0, source_file="/p/b.py"))
+    assert state.next_pending_keep_kernel_id() == "k009"
+    assert "k009" not in state.rejected_kernel_ids
+
+
+def test_revert_still_rejected_and_not_queued(state: SharedState) -> None:
+    state.record_kernel_opt({
+        "status": "ok", "kernel_id": "k002", "source_file": "/p/x.py",
+        "proposal": {"decision": "REVERT", "reasons": []},
+        "verification": {"micro_speedup": 0.8, "compile_passed": True,
+                         "correctness_passed": True},
+    })
+    assert "k002" in state.rejected_kernel_ids
+    assert state.next_pending_keep_kernel_id() == ""
+
+
+def test_pending_defer_survives_later_revert_sibling(state: SharedState) -> None:
+    """A pending DEFER must not be clobbered in last_kernel_opt by a later
+    REVERT on a different kernel (same protection a pending KEEP gets)."""
+    state.record_kernel_opt(_defer_result("k001", micro=1.0, source_file="/p/a.py"))
+    state.record_kernel_opt({
+        "status": "ok", "kernel_id": "k002", "source_file": "/p/x.py",
+        "proposal": {"decision": "REVERT", "reasons": []},
+        "verification": {"micro_speedup": 0.8, "compile_passed": True,
+                         "correctness_passed": True},
+    })
+    assert state.last_kernel_opt["kernel_id"] == "k001"
+    assert state.last_kernel_opt["decision"] == "DEFER_TO_E2E"
+    # the DEFER candidate is still queued for integrate.
+    assert state.next_pending_keep_kernel_id() == "k001"
+
+
+def test_defer_excluded_once_integrated(state: SharedState) -> None:
+    state.record_kernel_opt(_defer_result("k001", micro=1.0, source_file="/p/a.py"))
+    state.optimization_stack.append({
+        "action": "integrate", "kernel_id": "k001", "target_file": "/p/a.py", "tput": 1.0,
+    })
+    assert state.next_pending_keep_kernel_id() == ""

--- a/kernel-agent/tools/apply_kernel_patch.py
+++ b/kernel-agent/tools/apply_kernel_patch.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import importlib.util
 import json
 import os
 import py_compile
@@ -12,9 +13,10 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable
 
 
 COMPILED_SOURCE_SUFFIXES = {".c", ".cc", ".cpp", ".cu", ".cuh", ".h", ".hpp", ".hip"}
@@ -323,6 +325,1078 @@ def _clear_python_kernel_caches(target: Path) -> dict[str, Any]:
     return {"status": "ok", "removed": removed}
 
 
+# ---------------------------------------------------------------------------
+# PR-K: aiter JIT cache invalidation around compiled-source rebuilds.
+#
+# aiter ships ``@compile_ops("module_<name>", gen_func=...)`` decorators that
+# JIT-codegen + hipcc-compile per-instance ``.so`` files into
+# ``<aiter>/jit/build/module_<name>_<sig>/``. ``setup.py develop`` rebuilds the
+# python package + statically-compiled ``.so`` but does NOT invalidate the
+# jit/build entries: a patch under ``aiter/csrc/ck_gemm_moe_2stages_codegen/``
+# would rebuild the wheel yet the next ``import aiter.ops.moe_op`` would still
+# pick up the pre-patch ``module_moe_ck2stages_*.so`` from jit/build/, leaving
+# the integrate benchmark to measure unchanged performance and emit REVERT.
+#
+# We move (NOT copy) the entire jit/build/ directory aside before the rebuild
+# step so the post-rebuild first-import re-codegens + re-compiles every module
+# from clean state. ``shutil.move`` is atomic on the same filesystem and zero-
+# copy. Revert moves the backup back, removing any regenerated jit/build/ dir
+# first so the pre-patch state is restored bit-for-bit.
+#
+# Scope: ONLY aiter is affected. sglang's sgl-kernel and vllm have no JIT
+# codegen layer — their ``.so`` are produced by setup.py at install time, so
+# the standard ``setup.py develop`` rebuild + cache_clear is sufficient and
+# this invalidation step is a no-op for those targets.
+# ---------------------------------------------------------------------------
+_AITER_CSRC_MARKER = "/aiter/csrc/"
+
+
+def _target_is_in_aiter_csrc(target_file: Path) -> bool:
+    """Return True iff ``target_file`` resides under any ``aiter/csrc/`` tree.
+
+    Matches both the editable checkout (``/sgl-workspace/aiter/csrc/...``) and
+    the dist-packages layout (``/usr/local/lib/python3.10/dist-packages/aiter/
+    csrc/...``) — in both cases the relative segment ``aiter/csrc/`` appears
+    verbatim in the absolute path.
+    """
+    return _AITER_CSRC_MARKER in str(target_file).replace(os.sep, "/")
+
+
+def _aiter_jit_build_dir() -> Path | None:
+    """Return ``<aiter>/jit/build`` for the importable aiter, or ``None``.
+
+    Resolved via ``importlib.util.find_spec("aiter")`` so editable installs
+    (``/sgl-workspace/aiter/aiter/__init__.py``), wheel installs
+    (``/usr/local/lib/python3.12/dist-packages/aiter/__init__.py``) and any
+    other layout on ``sys.path`` resolve correctly without hardcoding.
+
+    Returns ``None`` when aiter is not importable in the current interpreter
+    (the kernel-agent sandbox container always has aiter available; this
+    fallback exists so unit tests on a host without aiter still pass).
+    """
+    try:
+        spec = importlib.util.find_spec("aiter")
+    except (ImportError, ValueError):
+        return None
+    if spec is None or not spec.submodule_search_locations:
+        return None
+    aiter_pkg = Path(list(spec.submodule_search_locations)[0])
+    return aiter_pkg / "jit" / "build"
+
+
+def _invalidate_aiter_jit_build(
+    target_file: Path,
+    backup_dir: Path,
+    *,
+    jit_build_dir_override: Path | None = None,
+) -> dict[str, Any]:
+    """Move aiter ``jit/build/`` aside so a post-rebuild first import re-JITs.
+
+    No-op for targets outside ``aiter/csrc/`` and for sandboxes where the
+    aiter package isn't importable / hasn't populated its jit/build/ yet.
+    Returns one of:
+
+      * ``{"status": "ok", "src": ..., "backup_path": ..., "moved_at": ...}``
+        — backup written; caller must persist this in the manifest before
+        rebuild so revert can find it.
+      * ``{"status": "skipped", "reason": ...}`` — non-aiter target, aiter
+        not importable, or jit/build already absent/empty.
+      * ``{"status": "failed", "error": ...}`` — backup path collision; the
+        caller is expected to abort apply rather than rebuild against an
+        inconsistent jit cache.
+
+    ``jit_build_dir_override`` is a test-only escape hatch so unit tests can
+    point at a synthetic jit/build/ tree without an importable aiter package.
+    """
+    if not _target_is_in_aiter_csrc(target_file):
+        return {"status": "skipped", "reason": "target not under aiter/csrc/"}
+    jit_build = jit_build_dir_override or _aiter_jit_build_dir()
+    if jit_build is None:
+        return {"status": "skipped", "reason": "aiter package not importable"}
+    if not jit_build.exists():
+        return {"status": "skipped", "reason": "aiter jit/build/ does not exist"}
+    try:
+        is_empty = not any(jit_build.iterdir())
+    except OSError as exc:
+        return {
+            "status": "failed",
+            "error": f"failed to scan {jit_build}: {exc}",
+            "src": str(jit_build),
+        }
+    if is_empty:
+        return {"status": "skipped", "reason": "aiter jit/build/ is empty"}
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    backup_path = backup_dir / "jit_build"
+    if backup_path.exists():
+        return {
+            "status": "failed",
+            "error": f"jit/build backup path already exists: {backup_path}",
+            "src": str(jit_build),
+        }
+    try:
+        shutil.move(str(jit_build), str(backup_path))
+    except (OSError, shutil.Error) as exc:
+        return {
+            "status": "failed",
+            "error": f"shutil.move failed: {exc}",
+            "src": str(jit_build),
+            "backup_path": str(backup_path),
+        }
+    return {
+        "status": "ok",
+        "src": str(jit_build),
+        "backup_path": str(backup_path),
+        "moved_at": _now(),
+    }
+
+
+def _restore_aiter_jit_build(jit_build_backup: dict[str, Any]) -> dict[str, Any]:
+    """Reverse of :func:`_invalidate_aiter_jit_build`.
+
+    Moves the backup back to its original location. If the post-rebuild first
+    import already regenerated a fresh jit/build/, that fresh dir is removed
+    first so the pre-patch state is restored bit-for-bit (revert semantics).
+    """
+    if not isinstance(jit_build_backup, dict) or jit_build_backup.get("status") != "ok":
+        return {"status": "skipped", "reason": "no backup recorded"}
+    src = Path(jit_build_backup.get("src", ""))
+    backup_path = Path(jit_build_backup.get("backup_path", ""))
+    if not src or not backup_path:
+        return {"status": "skipped", "reason": "incomplete backup record"}
+    if not backup_path.exists():
+        return {
+            "status": "skipped",
+            "reason": f"backup path missing: {backup_path}",
+        }
+    if src.exists():
+        try:
+            shutil.rmtree(src)
+        except OSError as exc:
+            return {
+                "status": "failed",
+                "error": f"failed to clear regenerated jit/build/: {exc}",
+                "src": str(src),
+            }
+    try:
+        src.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(backup_path), str(src))
+    except (OSError, shutil.Error) as exc:
+        return {
+            "status": "failed",
+            "error": f"shutil.move failed during restore: {exc}",
+            "src": str(src),
+            "backup_path": str(backup_path),
+        }
+    return {"status": "ok", "restored_to": str(src)}
+
+
+# ---------------------------------------------------------------------------
+# PR-K2: aiter cpp_itfs RUNTIME-compiled cache invalidation.
+#
+# Distinct from the ``@compile_ops`` jit/build cache handled above. aiter's
+# ``csrc/cpp_itfs`` kernels (e.g. paged_attention -> ``pa_ragged``) are NOT
+# produced by ``setup.py develop``; they are runtime-compiled on first call
+# by ``compile_template_op`` (aiter ``csrc/cpp_itfs/utils.py``) into
+# ``$AITER_ROOT_DIR/build/<md_name>_<md5(params)>/lib.so`` (default
+# ``$HOME/.aiter/build``). The cache folder name hashes kernel *parameters*,
+# NOT source content, so the pristine and the patched build of the same
+# kernel collide on the SAME directory. ``compile_template_op`` rebuilds only
+# when ``lib.so`` is missing (``not_built``), so after we patch the ``.cuh``
+# and run the (no-op for this class) ``setup.py develop``, the next server
+# reuses the STALE pristine ``lib.so``; the integrate re-baseline then
+# measures ~0% and a genuinely-good kernel is flagged NEEDS_REVIEW / REVERT
+# (observed -0.17% on a +2.5% paged_attention kernel; see GH #458).
+#
+# ``setup.py develop`` cannot refresh this kernel class, and the jit/build
+# move above never touches ``$HOME/.aiter/build``. So for cpp_itfs targets we
+# ALSO move the affected runtime-cache dirs aside before the rebuild step --
+# scoped to the patched module's ``MD_NAME`` prefix(es) when determinable,
+# else the whole cpp_itfs build root the scheduler uses -- so the re-baseline
+# server runtime-recompiles the patched kernel from clean state.
+# ``shutil.move`` keeps it reversible; :func:`_restore_aiter_cpp_itfs_cache`
+# moves the backup back on revert. ``integrate_handler`` additionally sets
+# ``AITER_REBUILD=1`` on the re-baseline server and gates KEEP on a verified
+# fresh rebuild via :func:`verify_cpp_itfs_rebuilt`.
+#
+# Scope: ONLY aiter cpp_itfs targets. Non-cpp_itfs aiter targets, sglang and
+# vllm keep their current behaviour bit-for-bit (this is a no-op for them).
+# ---------------------------------------------------------------------------
+_AITER_CPP_ITFS_MARKER = "/aiter/csrc/cpp_itfs/"
+_MD_NAME_RE = re.compile(r"""(?m)^\s*MD_NAME\s*=\s*["']([^"']+)["']""")
+
+
+def _target_is_in_aiter_cpp_itfs(target_file: Path) -> bool:
+    """True iff ``target_file`` lives under any ``aiter/csrc/cpp_itfs/`` tree.
+
+    Strict subset of :func:`_target_is_in_aiter_csrc`: these are the
+    runtime-compiled kernels whose served ``.so`` lives in
+    ``$HOME/.aiter/build`` rather than in ``<aiter>/jit/build`` or the
+    statically-linked wheel. Matches both the editable checkout
+    (``/sgl-workspace/aiter/csrc/cpp_itfs/...``) and the dist-packages
+    layout (``.../aiter/csrc/cpp_itfs/...``).
+    """
+    return _AITER_CPP_ITFS_MARKER in str(target_file).replace(os.sep, "/")
+
+
+def _aiter_cpp_itfs_build_dir() -> Path:
+    """Resolve aiter's cpp_itfs runtime ``BUILD_DIR``.
+
+    Mirrors aiter ``csrc/cpp_itfs/utils.py``: ``$AITER_ROOT_DIR/build`` with
+    ``$AITER_ROOT_DIR`` defaulting to ``$HOME/.aiter``. Honouring both env
+    vars keeps non-default deployments + unit tests correct without importing
+    aiter into this standalone tool.
+    """
+    root = os.environ.get("AITER_ROOT_DIR", "").strip()
+    if not root:
+        home = Path(os.environ.get("HOME", "~")).expanduser()
+        root = str(home / ".aiter")
+    return Path(root) / "build"
+
+
+def _cpp_itfs_module_names(target_file: Path) -> list[str]:
+    """Best-effort ``MD_NAME`` prefix(es) for the cpp_itfs module(s) the
+    patched source feeds.
+
+    The cpp_itfs ``.py`` driver next to the patched source declares
+    ``MD_NAME = "pa_ragged"`` (etc.), which becomes the
+    ``<md_name>_<hash>`` runtime-cache folder prefix. A single shared
+    ``.cuh`` (e.g. ``pa_kernels.cuh``) is pulled into several drivers in the
+    same directory, so we collect EVERY ``MD_NAME`` declared in the target's
+    directory. An empty result tells the caller to fall back to clearing the
+    whole cpp_itfs build root.
+    """
+    names: set[str] = set()
+    search_dir = target_file.parent
+    try:
+        py_files = sorted(search_dir.glob("*.py"))
+    except OSError:
+        py_files = []
+    if target_file.suffix.lower() == ".py":
+        py_files = list(dict.fromkeys([target_file, *py_files]))
+    for py in py_files:
+        try:
+            text = py.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for match in _MD_NAME_RE.finditer(text):
+            names.add(match.group(1))
+    return sorted(names)
+
+
+def _invalidate_aiter_cpp_itfs_cache(
+    target_file: Path,
+    backup_dir: Path,
+    *,
+    build_dir_override: Path | None = None,
+) -> dict[str, Any]:
+    """Move aiter cpp_itfs runtime-cache dirs aside so the re-baseline server
+    runtime-recompiles the patched kernel from clean state.
+
+    No-op (``skipped``, ``is_cpp_itfs=False``) for non-cpp_itfs targets. For
+    cpp_itfs targets the affected ``<build_dir>/<md_name>_*`` dirs (scoped by
+    ``MD_NAME`` when determinable, else every child of the build root) are
+    MOVED into ``backup_dir/cpp_itfs_cache/`` so the operation is reversible.
+    The record always carries ``is_cpp_itfs`` + ``build_dir`` +
+    ``module_names`` + ``invalidated_unix`` (even when nothing was cached
+    yet) so integrate can later verify a fresh rebuild actually landed.
+
+    Returns one of ``ok`` / ``skipped`` / ``failed`` mirroring
+    :func:`_invalidate_aiter_jit_build`. ``build_dir_override`` is a
+    test-only hook.
+    """
+    if not _target_is_in_aiter_cpp_itfs(target_file):
+        return {
+            "status": "skipped",
+            "is_cpp_itfs": False,
+            "reason": "target not under aiter/csrc/cpp_itfs/",
+        }
+    build_dir = build_dir_override or _aiter_cpp_itfs_build_dir()
+    module_names = _cpp_itfs_module_names(target_file)
+    scope = "module" if module_names else "build_root"
+    record: dict[str, Any] = {
+        "is_cpp_itfs": True,
+        "build_dir": str(build_dir),
+        "module_names": module_names,
+        "scope": scope,
+        "invalidated_at": _now(),
+        "invalidated_unix": time.time(),
+    }
+    if not build_dir.exists():
+        # Nothing cached yet -> the re-baseline server will build fresh into
+        # this dir on first kernel call. No stale binary to mask.
+        record.update({
+            "status": "skipped",
+            "reason": "cpp_itfs build dir does not exist",
+            "moved": [],
+        })
+        return record
+    try:
+        if module_names:
+            to_move: list[Path] = []
+            for md in module_names:
+                to_move.extend(p for p in build_dir.glob(f"{md}_*") if p.is_dir())
+        else:
+            to_move = [p for p in build_dir.iterdir() if p.is_dir()]
+    except OSError as exc:
+        record.update({"status": "failed", "error": f"failed to scan {build_dir}: {exc}"})
+        return record
+    # De-dup: a shared .cuh can match overlapping MD_NAME globs.
+    to_move = sorted({p.resolve() for p in to_move})
+    if not to_move:
+        record.update({
+            "status": "skipped",
+            "reason": "no matching cpp_itfs cache entries",
+            "moved": [],
+        })
+        return record
+    cache_backup_root = backup_dir / "cpp_itfs_cache"
+    moved: list[dict[str, str]] = []
+    try:
+        cache_backup_root.mkdir(parents=True, exist_ok=True)
+        for src in to_move:
+            dst = cache_backup_root / src.name
+            if dst.exists():
+                record.update({
+                    "status": "failed",
+                    "error": f"cpp_itfs cache backup path already exists: {dst}",
+                    "moved": moved,
+                })
+                return record
+            shutil.move(str(src), str(dst))
+            moved.append({"src": str(src), "backup_path": str(dst)})
+    except (OSError, shutil.Error) as exc:
+        record.update({
+            "status": "failed",
+            "error": f"shutil.move failed: {exc}",
+            "moved": moved,
+        })
+        return record
+    record.update({"status": "ok", "moved": moved})
+    return record
+
+
+def _restore_aiter_cpp_itfs_cache(cache_backup: dict[str, Any]) -> dict[str, Any]:
+    """Reverse :func:`_invalidate_aiter_cpp_itfs_cache` (revert path).
+
+    Moves each backed-up cache dir back to its original location, removing
+    any dir the re-baseline server regenerated there first so the pre-patch
+    runtime cache is restored bit-for-bit.
+    """
+    if not isinstance(cache_backup, dict) or cache_backup.get("status") != "ok":
+        return {"status": "skipped", "reason": "no cpp_itfs cache backup recorded"}
+    moved = cache_backup.get("moved") or []
+    if not moved:
+        return {"status": "skipped", "reason": "nothing was moved"}
+    restored: list[str] = []
+    for entry in moved:
+        src = Path(entry.get("src", ""))  # original cache location
+        backup_path = Path(entry.get("backup_path", ""))
+        if not str(src) or not str(backup_path) or not backup_path.exists():
+            continue
+        if src.exists():
+            try:
+                shutil.rmtree(src)
+            except OSError as exc:
+                return {
+                    "status": "failed",
+                    "error": f"failed to clear regenerated cache dir {src}: {exc}",
+                }
+        try:
+            src.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(backup_path), str(src))
+        except (OSError, shutil.Error) as exc:
+            return {
+                "status": "failed",
+                "error": f"shutil.move failed during restore: {exc}",
+            }
+        restored.append(str(src))
+    return {"status": "ok", "restored": restored}
+
+
+def verify_cpp_itfs_rebuilt(cache_backup: dict[str, Any]) -> dict[str, Any]:
+    """Assert the re-baseline actually runtime-recompiled the patched kernel.
+
+    After :func:`_invalidate_aiter_cpp_itfs_cache` moved the stale cache
+    aside, a faithful re-baseline must repopulate
+    ``<build_dir>/<md_name>_*/lib.so`` (the served binary) with an mtime at
+    or after the invalidation. If no such fresh ``lib.so`` exists, the server
+    dlopened a stale binary (or the kernel was never exercised) and the
+    measured gain is meaningless -- the integrate KEEP/REVERT gate uses this
+    to flag/abort instead of scoring a stale binary (GH #458 point 2).
+
+    Returns ``{"verified": bool, ...}``. ``verified`` is True for
+    non-cpp_itfs targets so the caller's gate is a strict no-op off the
+    cpp_itfs path.
+    """
+    if not isinstance(cache_backup, dict) or not cache_backup.get("is_cpp_itfs"):
+        return {"verified": True, "status": "skipped", "reason": "non-cpp_itfs target"}
+    build_dir = Path(cache_backup.get("build_dir", ""))
+    since = float(cache_backup.get("invalidated_unix") or 0.0)
+    module_names = list(cache_backup.get("module_names") or [])
+    if not str(build_dir) or not build_dir.exists():
+        return {
+            "verified": False,
+            "status": "stale",
+            "reason": f"cpp_itfs build dir absent after re-baseline: {build_dir}",
+        }
+    globs = [f"{md}_*/lib.so" for md in module_names] or ["*/lib.so"]
+    fresh: list[str] = []
+    for pattern in globs:
+        for so in build_dir.glob(pattern):
+            try:
+                mtime = so.stat().st_mtime
+            except OSError:
+                continue
+            # 1s slack absorbs build-dir-create vs lib.so-flush ordering.
+            if mtime + 1.0 >= since:
+                fresh.append(str(so))
+    if fresh:
+        return {"verified": True, "status": "ok", "fresh_lib_so": sorted(set(fresh))[:8]}
+    return {
+        "verified": False,
+        "status": "stale",
+        "reason": (
+            "no freshly-built cpp_itfs lib.so found after re-baseline; "
+            "served binary is stale"
+        ),
+        "build_dir": str(build_dir),
+        "module_names": module_names,
+    }
+
+
+# ---------------------------------------------------------------------------
+# PR-K3: Triton (@triton.jit) kernel cache invalidation.
+#
+# Triton kernels -- e.g. sglang's editable fused_moe at
+# ``python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py`` or aiter's
+# triton ops -- are NOT built by ``setup.py``; the Triton runtime
+# AOT-compiles each kernel on first launch into ``$TRITON_CACHE_DIR``
+# (default ``~/.triton/cache``) keyed by a hash of the kernel IR + signature,
+# emitting ``*.hsaco`` / ``*.json`` / IR artifacts. A whole-file source patch
+# usually changes that hash so the patched kernel recompiles -- but a
+# config-only retune (e.g. the fused_moe ``64x64x32 -> 128x128x64`` tile
+# change) or an autotune-key collision can re-serve a STALE compiled artifact,
+# so the integrate re-baseline would measure the PRE-patch kernel. We move the
+# Triton cache dir aside before the re-baseline so the server recompiles from
+# clean state; revert moves it back. No-op for non-Triton targets. THIS makes
+# the integrate re-baseline robust for the proven editable Triton fused_moe.
+# ---------------------------------------------------------------------------
+_TRITON_SOURCE_MARKERS = (
+    "@triton.jit", "import triton", "from triton", "triton.jit",
+    "tl.load", "tl.store", "tl.program_id", "tl.arange",
+)
+_TRITON_PATH_MARKERS = ("/triton/", "fused_moe_triton", "triton_kernels", "_triton_kernels")
+
+
+def _target_is_triton(target_file: Path) -> bool:
+    """Best-effort: is ``target_file`` an editable Triton (@triton.jit) kernel?
+
+    Conservative: a ``.py`` file whose text imports/uses triton
+    (``@triton.jit`` / ``import triton`` / ``tl.load`` ...), or a ``.py`` under
+    a well-known Triton path segment. Non-``.py`` targets and plain-python
+    files without triton usage are rejected so the whole-cache move-aside only
+    fires for real Triton kernels.
+    """
+    if target_file.suffix.lower() != ".py":
+        return False
+    s = str(target_file).replace(os.sep, "/")
+    if any(m in s for m in _TRITON_PATH_MARKERS):
+        return True
+    try:
+        text = target_file.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    return any(m in text for m in _TRITON_SOURCE_MARKERS)
+
+
+def _triton_cache_dir() -> Path:
+    """Resolve the Triton compile cache dir: ``$TRITON_CACHE_DIR`` else
+    ``~/.triton/cache`` (the Triton runtime default)."""
+    cache = os.environ.get("TRITON_CACHE_DIR", "").strip()
+    if cache:
+        return Path(cache)
+    home = Path(os.environ.get("HOME", "~")).expanduser()
+    return home / ".triton" / "cache"
+
+
+# ---------------------------------------------------------------------------
+# PR-K4: torch inductor cache invalidation.
+#
+# ``torch.compile`` / TorchInductor AOT-compiles fused kernels into an on-disk
+# cache (``$TORCHINDUCTOR_CACHE_DIR`` else ``~/.cache/torch/inductor`` and/or
+# ``/tmp/torchinductor_<user>``). Like Triton, a stale entry can be re-served
+# so the integrate re-baseline measures the pre-patch kernel. We move the
+# inductor cache dir(s) aside before the re-baseline so the server recompiles
+# from clean state; revert moves them back. No-op for non-inductor targets.
+# ---------------------------------------------------------------------------
+_INDUCTOR_PATH_MARKERS = ("torchinductor", "/torch/_inductor/", "_inductor_cache")
+_INDUCTOR_SOURCE_MARKERS = ("torch._inductor", "torch.compile", "from torch._inductor")
+
+
+def _target_is_inductor(target_file: Path) -> bool:
+    """Best-effort: is ``target_file`` a torch inductor target?
+
+    Path under a torchinductor cache / ``torch/_inductor`` tree, or a ``.py``
+    file that uses ``torch.compile`` / ``torch._inductor``. Conservative so the
+    cache move-aside only fires for real inductor targets.
+    """
+    s = str(target_file).replace(os.sep, "/")
+    if any(m in s for m in _INDUCTOR_PATH_MARKERS):
+        return True
+    if target_file.suffix.lower() != ".py":
+        return False
+    try:
+        text = target_file.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    return any(m in text for m in _INDUCTOR_SOURCE_MARKERS)
+
+
+def _inductor_cache_dirs() -> list[Path]:
+    """Resolve torch inductor cache dir(s): ``$TORCHINDUCTOR_CACHE_DIR`` if set,
+    else ``~/.cache/torch/inductor`` plus ``/tmp/torchinductor_<user>``."""
+    dirs: list[Path] = []
+    env = os.environ.get("TORCHINDUCTOR_CACHE_DIR", "").strip()
+    if env:
+        dirs.append(Path(env))
+    else:
+        home = Path(os.environ.get("HOME", "~")).expanduser()
+        dirs.append(home / ".cache" / "torch" / "inductor")
+        user = (os.environ.get("USER") or os.environ.get("LOGNAME") or "").strip()
+        if user:
+            dirs.append(Path("/tmp") / f"torchinductor_{user}")
+    seen: set[str] = set()
+    out: list[Path] = []
+    for d in dirs:
+        if str(d) not in seen:
+            seen.add(str(d))
+            out.append(d)
+    return out
+
+
+def _move_cache_dirs_aside(
+    dirs: Iterable[Path], backup_dir: Path, *, label: str,
+) -> tuple[list[dict[str, str]], str | None]:
+    """Move each existing dir in ``dirs`` into ``backup_dir/<label>/<name>``.
+
+    Returns ``(moved, error)``. ``moved`` is a reversible list of
+    ``{"src", "backup_path"}`` records (empty when nothing existed). ``error``
+    is non-None on the first failure (backup collision / move error) so the
+    caller can bail without scoring against an inconsistent cache.
+    """
+    moved: list[dict[str, str]] = []
+    existing = [d for d in dirs if d.exists()]
+    if not existing:
+        return moved, None
+    dest_root = backup_dir / label
+    try:
+        dest_root.mkdir(parents=True, exist_ok=True)
+        for src in existing:
+            dst = dest_root / src.name
+            if dst.exists():
+                return moved, f"cache backup path already exists: {dst}"
+            shutil.move(str(src), str(dst))
+            moved.append({"src": str(src), "backup_path": str(dst)})
+    except (OSError, shutil.Error) as exc:
+        return moved, f"shutil.move failed: {exc}"
+    return moved, None
+
+
+def _restore_moved_cache(cache_backup: dict[str, Any]) -> dict[str, Any]:
+    """Reverse :func:`_move_cache_dirs_aside` (shared Triton/inductor restore).
+
+    Moves each backed-up dir back to its original location, removing any dir
+    the re-baseline regenerated there first so the pre-patch state is restored
+    bit-for-bit.
+    """
+    if not isinstance(cache_backup, dict) or cache_backup.get("status") != "ok":
+        return {"status": "skipped", "reason": "no cache backup recorded"}
+    moved = cache_backup.get("moved") or []
+    if not moved:
+        return {"status": "skipped", "reason": "nothing was moved"}
+    restored: list[str] = []
+    for entry in moved:
+        src = Path(entry.get("src", ""))
+        backup_path = Path(entry.get("backup_path", ""))
+        if not str(src) or not str(backup_path) or not backup_path.exists():
+            continue
+        if src.exists():
+            try:
+                shutil.rmtree(src)
+            except OSError as exc:
+                return {
+                    "status": "failed",
+                    "error": f"failed to clear regenerated cache dir {src}: {exc}",
+                }
+        try:
+            src.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(backup_path), str(src))
+        except (OSError, shutil.Error) as exc:
+            return {
+                "status": "failed",
+                "error": f"shutil.move failed during restore: {exc}",
+            }
+        restored.append(str(src))
+    return {"status": "ok", "restored": restored}
+
+
+def _verify_moved_cache_rebuilt(
+    cache_backup: dict[str, Any], *, kind_key: str, label: str,
+) -> dict[str, Any]:
+    """Shared fresh-build check for the move-aside toolchains (Triton/inductor).
+
+    ``verified`` is True for non-matching targets and when nothing was moved
+    aside (cache absent/empty at invalidation -> can't conclude staleness, so
+    never false-abort). When a non-empty cache WAS moved aside, requires a
+    file in the recreated cache dir with mtime at/after the invalidation
+    (proof the patched kernel recompiled); otherwise reports ``stale``.
+    """
+    if not isinstance(cache_backup, dict) or not cache_backup.get(kind_key):
+        return {"verified": True, "status": "skipped", "reason": f"non-{label} target"}
+    moved = cache_backup.get("moved") or []
+    if cache_backup.get("status") != "ok" or not moved:
+        return {
+            "verified": True,
+            "status": "skipped",
+            "reason": f"{label} cache was empty/absent at invalidation; nothing to verify",
+        }
+    since = float(cache_backup.get("invalidated_unix") or 0.0)
+    fresh: list[str] = []
+    for m in moved:
+        cache_dir = Path(m.get("src", ""))  # original (now-recreated) location
+        if not cache_dir.exists():
+            continue
+        try:
+            for p in cache_dir.rglob("*"):
+                try:
+                    if p.is_file() and p.stat().st_mtime + 1.0 >= since:
+                        fresh.append(str(p))
+                except OSError:
+                    continue
+                if len(fresh) >= 8:
+                    break
+        except OSError:
+            continue
+        if len(fresh) >= 8:
+            break
+    if fresh:
+        return {"verified": True, "status": "ok", "fresh_artifacts": sorted(set(fresh))[:8]}
+    return {
+        "verified": False,
+        "status": "stale",
+        "reason": (
+            f"no freshly-compiled {label} artifact found after re-baseline; "
+            "served binary may be stale"
+        ),
+    }
+
+
+def _invalidate_triton_cache(
+    target_file: Path,
+    backup_dir: Path,
+    *,
+    cache_dir_override: Path | None = None,
+) -> dict[str, Any]:
+    """Move the Triton compile cache aside so the re-baseline recompiles.
+
+    No-op (``skipped``, ``is_triton=False``) for non-Triton targets.
+    ``cache_dir_override`` is a test-only hook.
+    """
+    if not _target_is_triton(target_file):
+        return {
+            "status": "skipped",
+            "is_triton": False,
+            "reason": "target is not a Triton kernel",
+        }
+    cache_dir = cache_dir_override or _triton_cache_dir()
+    record: dict[str, Any] = {
+        "is_triton": True,
+        "toolchain": "triton",
+        "cache_dirs": [str(cache_dir)],
+        "scope": "triton_cache_dir",
+        "invalidated_at": _now(),
+        "invalidated_unix": time.time(),
+    }
+    moved, error = _move_cache_dirs_aside([cache_dir], backup_dir, label="triton_cache")
+    if error is not None:
+        record.update({"status": "failed", "error": error, "moved": moved})
+        return record
+    if not moved:
+        record.update({
+            "status": "skipped",
+            "reason": "triton cache dir does not exist",
+            "moved": [],
+        })
+        return record
+    record.update({"status": "ok", "moved": moved})
+    return record
+
+
+def _restore_triton_cache(cache_backup: dict[str, Any]) -> dict[str, Any]:
+    """Reverse :func:`_invalidate_triton_cache` (revert path)."""
+    return _restore_moved_cache(cache_backup)
+
+
+def verify_triton_rebuilt(cache_backup: dict[str, Any]) -> dict[str, Any]:
+    """Assert the re-baseline freshly recompiled the patched Triton kernel."""
+    return _verify_moved_cache_rebuilt(cache_backup, kind_key="is_triton", label="triton")
+
+
+def _invalidate_torch_inductor_cache(
+    target_file: Path,
+    backup_dir: Path,
+    *,
+    cache_dirs_override: Iterable[Path] | None = None,
+) -> dict[str, Any]:
+    """Move the torch inductor cache dir(s) aside so the re-baseline recompiles.
+
+    No-op (``skipped``, ``is_inductor=False``) for non-inductor targets.
+    ``cache_dirs_override`` is a test-only hook.
+    """
+    if not _target_is_inductor(target_file):
+        return {
+            "status": "skipped",
+            "is_inductor": False,
+            "reason": "target is not a torch inductor kernel",
+        }
+    cache_dirs = list(cache_dirs_override) if cache_dirs_override is not None else _inductor_cache_dirs()
+    record: dict[str, Any] = {
+        "is_inductor": True,
+        "toolchain": "torch_inductor",
+        "cache_dirs": [str(d) for d in cache_dirs],
+        "scope": "inductor_cache_dirs",
+        "invalidated_at": _now(),
+        "invalidated_unix": time.time(),
+    }
+    moved, error = _move_cache_dirs_aside(cache_dirs, backup_dir, label="inductor_cache")
+    if error is not None:
+        record.update({"status": "failed", "error": error, "moved": moved})
+        return record
+    if not moved:
+        record.update({
+            "status": "skipped",
+            "reason": "torch inductor cache dir(s) do not exist",
+            "moved": [],
+        })
+        return record
+    record.update({"status": "ok", "moved": moved})
+    return record
+
+
+def _restore_torch_inductor_cache(cache_backup: dict[str, Any]) -> dict[str, Any]:
+    """Reverse :func:`_invalidate_torch_inductor_cache` (revert path)."""
+    return _restore_moved_cache(cache_backup)
+
+
+def verify_inductor_rebuilt(cache_backup: dict[str, Any]) -> dict[str, Any]:
+    """Assert the re-baseline freshly recompiled the patched inductor kernel."""
+    return _verify_moved_cache_rebuilt(cache_backup, kind_key="is_inductor", label="inductor")
+
+
+# ---------------------------------------------------------------------------
+# Cache-invalidation REGISTRY: ONE dispatch keyed by toolchain.
+#
+# Each :class:`ToolchainCacheEntry` declares, for one toolchain, the cache it
+# owns and how to {invalidate (move-aside), restore, verify a fresh build} +
+# the rebuild env the integrate re-baseline must set. ``apply_kernel_patch``
+# drives invalidation through this table, ``revert_kernel_patch`` restores
+# through it, and ``integrate_handler`` reads ``rebuild_env_for_apply_result``
+# / ``verify_rebuilt_for_apply_result`` to set the right env + run the right
+# verification gate. The aiter entries delegate to the pre-existing
+# ``_invalidate_aiter_jit_build`` / ``_invalidate_aiter_cpp_itfs_cache`` (and
+# their restore/verify) so behaviour is byte-for-byte preserved and the
+# GH #458 (#459) public names stay importable + identically-shaped. Every
+# entry self-gates (``invalidate`` returns ``skipped`` off its toolchain) so a
+# target the registry doesn't handle is bit-for-bit unaffected.
+# ---------------------------------------------------------------------------
+class ToolchainCacheEntry:
+    """One toolchain's cache-invalidation policy.
+
+    A plain class (not a ``@dataclass``) on purpose: this module is loaded via
+    ``importlib.util.spec_from_file_location`` (kernel_request_handlers'
+    ``_load_apply_tool`` + the unit tests) WITHOUT being registered in
+    ``sys.modules``, and ``@dataclass`` + ``from __future__ import annotations``
+    introspects ``sys.modules[cls.__module__]`` at class-creation time and
+    crashes when the module isn't registered. The fields below are stored
+    verbatim; callables are kept as plain attributes (never bound as methods,
+    so ``entry.invalidate(target, backup_dir)`` calls the bare function).
+
+    Fields:
+      name                    stable toolchain id
+      manifest_key            where the invalidation record is stored
+      restore_key             where the restore record is stored
+      matches(path)->bool     path-based detection (for classification)
+      invalidate(target, backup_dir)->record
+      restore(record)->result
+      verify(record)->{"verified": bool, ...}
+      engaged(record)->bool   did this toolchain apply to the target?
+      requires_compiled       only run inside the compiled-rebuild path
+      gates_keep              integrate hard-gates KEEP on this entry's verify
+      on_failure_error_class  error_class surfaced when invalidate fails
+      failure_error_prefix    human prefix for the failure error message
+      rebuild_env             env the re-baseline server must set
+      skipped_default         record shape when the entry does not run
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        manifest_key: str,
+        restore_key: str,
+        matches: Callable[[Path], bool],
+        invalidate: Callable[..., dict[str, Any]],
+        restore: Callable[[dict[str, Any]], dict[str, Any]],
+        verify: Callable[[dict[str, Any]], dict[str, Any]],
+        engaged: Callable[[dict[str, Any]], bool],
+        requires_compiled: bool,
+        gates_keep: bool,
+        on_failure_error_class: str,
+        failure_error_prefix: str,
+        rebuild_env: dict[str, str],
+        skipped_default: dict[str, Any],
+    ) -> None:
+        self.name = name
+        self.manifest_key = manifest_key
+        self.restore_key = restore_key
+        self.matches = matches
+        self.invalidate = invalidate
+        self.restore = restore
+        self.verify = verify
+        self.engaged = engaged
+        self.requires_compiled = requires_compiled
+        self.gates_keep = gates_keep
+        self.on_failure_error_class = on_failure_error_class
+        self.failure_error_prefix = failure_error_prefix
+        self.rebuild_env = rebuild_env
+        self.skipped_default = skipped_default
+
+
+CACHE_INVALIDATION_REGISTRY: list[ToolchainCacheEntry] = [
+    ToolchainCacheEntry(
+        name="aiter_compile_ops",
+        manifest_key="jit_build_backup",
+        restore_key="jit_build_restore",
+        matches=_target_is_in_aiter_csrc,
+        invalidate=_invalidate_aiter_jit_build,
+        restore=_restore_aiter_jit_build,
+        verify=lambda rec: {"verified": True, "status": "skipped", "reason": "jit/build not gated"},
+        engaged=lambda rec: rec.get("status") == "ok",
+        requires_compiled=True,
+        gates_keep=False,
+        on_failure_error_class="aiter_jit_invalidation_failed",
+        failure_error_prefix="aiter jit/build/ invalidation failed",
+        rebuild_env={},
+        skipped_default={"status": "skipped", "reason": "rebuild not run"},
+    ),
+    ToolchainCacheEntry(
+        name="aiter_cpp_itfs",
+        manifest_key="cpp_itfs_cache_backup",
+        restore_key="cpp_itfs_cache_restore",
+        matches=_target_is_in_aiter_cpp_itfs,
+        invalidate=_invalidate_aiter_cpp_itfs_cache,
+        restore=_restore_aiter_cpp_itfs_cache,
+        verify=verify_cpp_itfs_rebuilt,
+        engaged=lambda rec: bool(rec.get("is_cpp_itfs")),
+        requires_compiled=True,
+        gates_keep=True,
+        on_failure_error_class="aiter_cpp_itfs_invalidation_failed",
+        failure_error_prefix="aiter cpp_itfs runtime cache invalidation failed",
+        rebuild_env={"AITER_REBUILD": "1"},
+        skipped_default={"status": "skipped", "reason": "rebuild not run", "is_cpp_itfs": False},
+    ),
+    ToolchainCacheEntry(
+        name="triton",
+        manifest_key="triton_cache_backup",
+        restore_key="triton_cache_restore",
+        matches=_target_is_triton,
+        invalidate=_invalidate_triton_cache,
+        restore=_restore_triton_cache,
+        verify=verify_triton_rebuilt,
+        engaged=lambda rec: bool(rec.get("is_triton")),
+        requires_compiled=False,
+        gates_keep=True,
+        on_failure_error_class="triton_cache_invalidation_failed",
+        failure_error_prefix="triton cache invalidation failed",
+        rebuild_env={},
+        skipped_default={"status": "skipped", "reason": "not run", "is_triton": False},
+    ),
+    ToolchainCacheEntry(
+        name="torch_inductor",
+        manifest_key="inductor_cache_backup",
+        restore_key="inductor_cache_restore",
+        matches=_target_is_inductor,
+        invalidate=_invalidate_torch_inductor_cache,
+        restore=_restore_torch_inductor_cache,
+        verify=verify_inductor_rebuilt,
+        engaged=lambda rec: bool(rec.get("is_inductor")),
+        requires_compiled=False,
+        gates_keep=True,
+        on_failure_error_class="torch_inductor_cache_invalidation_failed",
+        failure_error_prefix="torch inductor cache invalidation failed",
+        rebuild_env={},
+        skipped_default={"status": "skipped", "reason": "not run", "is_inductor": False},
+    ),
+]
+
+
+def toolchain_for(target_file: str | Path, strategy: dict[str, Any] | None = None) -> str | None:
+    """Classify ``target_file`` to a single registry toolchain (most-specific
+    first), or ``None`` when no toolchain owns its cache.
+
+    Note this is for observability/classification only; the apply-time
+    invalidation runs EVERY matching entry (a cpp_itfs target is also under
+    aiter/csrc, so both the @compile_ops jit/build and cpp_itfs caches are
+    invalidated, preserving the pre-registry behaviour).
+    """
+    p = Path(target_file)
+    if _target_is_in_aiter_cpp_itfs(p):
+        return "aiter_cpp_itfs"
+    if _target_is_inductor(p):
+        return "torch_inductor"
+    if _target_is_triton(p):
+        return "triton"
+    if _target_is_in_aiter_csrc(p):
+        return "aiter_compile_ops"
+    return None
+
+
+def _invalidate_caches_for_apply(
+    target: Path,
+    backup_dir: Path,
+    *,
+    strategy: dict[str, Any],
+    skip_rebuild: bool,
+    manifest: dict[str, Any],
+    manifest_path: Path,
+    source_backup: dict[str, str],
+) -> tuple[dict[str, dict[str, Any]], dict[str, Any] | None]:
+    """Run the registry's invalidations for ``target`` before re-baseline.
+
+    Returns ``(records, failure)``:
+      * ``records`` maps every entry's ``manifest_key`` -> its record
+        (skipped-default for entries that did not run), preserving the apply
+        return/manifest shape for all callers + the GH #458 tests.
+      * ``failure`` is ``None`` on success, else a ready-to-return failed dict
+        (source + any already-moved caches have already been restored).
+
+    Each successful (``ok``) record is persisted to the manifest immediately so
+    a later rebuild failure can restore the moved-aside cache via
+    :func:`revert_kernel_patch`. Compiled-only entries (aiter jit/build,
+    cpp_itfs) run only inside the compiled-rebuild path -- identical to the
+    pre-registry gating; the source-cache entries (Triton, inductor) run for
+    ``.py`` targets too since their cache is invalidated by relocation, not by
+    ``setup.py``.
+    """
+    records: dict[str, dict[str, Any]] = {
+        e.manifest_key: dict(e.skipped_default) for e in CACHE_INVALIDATION_REGISTRY
+    }
+    if skip_rebuild:
+        return records, None
+    succeeded: list[tuple[ToolchainCacheEntry, dict[str, Any]]] = []
+    for entry in CACHE_INVALIDATION_REGISTRY:
+        if entry.requires_compiled and not strategy.get("compiled"):
+            continue
+        rec = entry.invalidate(target, backup_dir)
+        records[entry.manifest_key] = rec
+        if rec.get("status") == "failed":
+            # Refuse to re-baseline against an inconsistent cache: restore the
+            # source + every already-moved cache (reverse order), then bail.
+            try:
+                shutil.copy2(source_backup["backup_path"], target)
+            except OSError:
+                pass
+            for done_entry, done_rec in reversed(succeeded):
+                done_entry.restore(done_rec)
+            return records, {
+                "status": "failed",
+                "error_class": entry.on_failure_error_class,
+                "error": f"{entry.failure_error_prefix}: {rec.get('error')}",
+                "manifest_path": str(manifest_path),
+                entry.manifest_key: rec,
+            }
+        if rec.get("status") == "ok":
+            succeeded.append((entry, rec))
+            # Persist BEFORE rebuild so a rebuild failure can restore it.
+            manifest[entry.manifest_key] = rec
+            manifest_path.write_text(
+                json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+    return records, None
+
+
+def restore_caches_from_manifest(manifest: dict[str, Any]) -> list[str]:
+    """Restore every toolchain cache the manifest records as moved-aside.
+
+    Iterates the registry (aiter jit/build, cpp_itfs, Triton, inductor),
+    restoring each ``ok`` record and writing the restore result under the
+    entry's ``restore_key``. Returns the list of restored paths. No-op for
+    caches that were not moved. Used by :func:`revert_kernel_patch`.
+    """
+    restored: list[str] = []
+    for entry in CACHE_INVALIDATION_REGISTRY:
+        rec = manifest.get(entry.manifest_key) or {}
+        if rec.get("status") != "ok":
+            continue
+        res = entry.restore(rec)
+        manifest[entry.restore_key] = res
+        if res.get("status") == "ok":
+            if res.get("restored_to"):
+                restored.append(str(res["restored_to"]))
+            restored.extend(str(p) for p in (res.get("restored") or []))
+    return restored
+
+
+def rebuild_env_for_apply_result(apply_result: dict[str, Any]) -> dict[str, str]:
+    """Env vars the integrate re-baseline server must set for whatever
+    toolchain caches the apply invalidated.
+
+    Preserves GH #458: a cpp_itfs apply -> ``{"AITER_REBUILD": "1"}``. Empty
+    for toolchains whose move-aside alone forces recompilation (Triton,
+    inductor) and for targets the registry doesn't touch.
+    """
+    env: dict[str, str] = {}
+    if not isinstance(apply_result, dict):
+        return env
+    for entry in CACHE_INVALIDATION_REGISTRY:
+        rec = apply_result.get(entry.manifest_key) or {}
+        if entry.engaged(rec):
+            env.update(entry.rebuild_env)
+    return env
+
+
+def verify_rebuilt_for_apply_result(apply_result: dict[str, Any]) -> dict[str, Any]:
+    """Run the fresh-build verification for every gating toolchain whose cache
+    the apply invalidated; aggregate into one ``{"verified": bool, ...}``.
+
+    A strict no-op (``verified=True``) when no gating cache was invalidated, so
+    integrate's KEEP/REVERT gate is unaffected off the cache-invalidation
+    paths. Generalizes the GH #458 cpp_itfs gate to Triton + inductor.
+    """
+    if not isinstance(apply_result, dict):
+        return {"verified": True, "status": "skipped", "reason": "no apply result"}
+    per: dict[str, Any] = {}
+    verified = True
+    for entry in CACHE_INVALIDATION_REGISTRY:
+        if not entry.gates_keep:
+            continue
+        rec = apply_result.get(entry.manifest_key) or {}
+        if not entry.engaged(rec):
+            continue
+        v = entry.verify(rec)
+        per[entry.name] = v
+        if not v.get("verified", True):
+            verified = False
+    if not per:
+        return {"verified": True, "status": "skipped", "reason": "no gating cache invalidated"}
+    return {
+        "verified": verified,
+        "status": "ok" if verified else "stale",
+        "per_toolchain": per,
+    }
+
+
 def _detect_strategy(target_file: Path, *, allow_unknown_target: bool) -> dict[str, Any]:
     target = str(target_file)
     lower = target.lower()
@@ -434,6 +1508,16 @@ def revert_kernel_patch(manifest_path: str | Path) -> dict[str, Any]:
             restored.append(str(dst))
             if dst.suffix.lower() in PYTHON_SOURCE_SUFFIXES:
                 manifest["revert_cache_clear"] = _clear_python_kernel_caches(dst)
+
+    # Registry-driven cache restore: put every toolchain cache the apply
+    # moved aside back (aiter jit/build, aiter cpp_itfs runtime cache, Triton,
+    # torch inductor), removing any dir the re-baseline regenerated first so
+    # the pre-patch state is restored bit-for-bit. Done after source/artifact
+    # restore but before multi-node fan-out so the host-local caches are back
+    # in place even if pod-side revert subsequently fails. No-op for caches
+    # that weren't moved (status != "ok"). Preserves the GH #458 jit/build +
+    # cpp_itfs restore order + restored-path collection.
+    restored.extend(restore_caches_from_manifest(manifest))
 
     # Multi-node: also fan-out a revert to every pod that received the
     # corresponding apply. Best-effort; sandbox revert above already
@@ -605,6 +1689,25 @@ def apply_kernel_patch(
         command = list(strategy["rebuild_command"])
 
     rebuild = {"status": "skipped", "reason": "source-only patch or skip_rebuild=true"}
+    # Registry-driven cache invalidation: ONE dispatch keyed by toolchain
+    # (aiter @compile_ops jit/build, aiter cpp_itfs runtime cache, Triton
+    # cache, torch inductor cache). Each entry self-gates so a target that
+    # doesn't match a toolchain is bit-for-bit unaffected. Moves the right
+    # cache(s) aside BEFORE rebuild/re-baseline so the patched kernel is
+    # (re)compiled from clean state; on invalidation failure the source +
+    # any already-moved caches are restored and we bail rather than score
+    # against an inconsistent cache. The aiter entries delegate to the
+    # GH #458 (#459) functions so cpp_itfs / jit-build behaviour is preserved.
+    cache_records, invalidation_failure = _invalidate_caches_for_apply(
+        target, backup_dir,
+        strategy=strategy, skip_rebuild=skip_rebuild,
+        manifest=manifest, manifest_path=manifest_path, source_backup=source_backup,
+    )
+    if invalidation_failure is not None:
+        return invalidation_failure
+    jit_build_backup = cache_records["jit_build_backup"]
+    cpp_itfs_cache_backup = cache_records["cpp_itfs_cache_backup"]
+
     if strategy["compiled"] and not skip_rebuild:
         cwd = Path(strategy["root"] or target.parent)
         rebuild = _run_rebuild(command, cwd, rebuild_timeout_sec)
@@ -622,6 +1725,12 @@ def apply_kernel_patch(
     manifest["applied_at"] = _now()
     manifest["rebuild"] = rebuild
     manifest["cache_clear"] = cache_clear
+    # Surface every toolchain cache record (incl. skipped reasons) so manifest
+    # readers can audit which caches were invalidated, integrate can verify a
+    # fresh rebuild landed, and revert can restore the moved-aside caches.
+    for _ck, _crec in cache_records.items():
+        if _crec.get("status") in {"ok", "skipped"}:
+            manifest[_ck] = _crec
     # multinode block (when present) is already persisted at fan-out
     # time above; we don't rewrite it here to avoid clobbering the
     # per-host backup map.
@@ -635,6 +1744,8 @@ def apply_kernel_patch(
         "artifact_count": len(artifacts),
         "cache_clear": cache_clear,
         "rebuild": rebuild,
+        "toolchain": toolchain_for(target, strategy),
+        **cache_records,
     }
     # Only attach the multinode key when fan-out actually ran. Keeps
     # single-node callers' return shape bit-for-bit identical to

--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -2412,15 +2412,35 @@ def build_verification(args: argparse.Namespace, attempts: list[dict[str, Any]],
     ):
         bp_geak = (best.get("backend_paths") or {}).get("geak_final_report", "")
         geak_status = ""
+        geak_verified: float | None = None
         if bp_geak and Path(bp_geak).is_file():
             try:
-                geak_status = str(
-                    json.loads(Path(bp_geak).read_text(encoding="utf-8"))
-                    .get("status") or ""
-                ).lower()
+                _geak_doc = json.loads(Path(bp_geak).read_text(encoding="utf-8"))
+                geak_status = str(_geak_doc.get("status") or "").lower()
+                _gv = _geak_doc.get("verified_speedup")
+                if _gv is None:
+                    _gv = _geak_doc.get("best_speedup_verified")
+                geak_verified = float(_gv) if isinstance(_gv, (int, float)) else None
             except Exception:  # noqa: BLE001
-                geak_status = ""
-        if geak_status in {"complete", "succeeded", "ok"}:
+                geak_status, geak_verified = "", None
+        # GEAK's finalized-success statuses are broader than {complete,
+        # succeeded, ok}: a multi-round run finalizes as
+        # ``incremental_after_round_<N>`` (the common case for --mode full /
+        # mixed), and single-round runs may report ``auto_finalized`` /
+        # ``finalized``. The original whitelist silently missed those, so a
+        # GEAK best with a VERIFIED speedup (e.g. fused_moe 1.53x,
+        # status=incremental_after_round_2) was scored correctness=missing ->
+        # NEEDS_REVIEW and never reached integrate. Treat any non-failure
+        # finalized status -- or a report that carries a verified speedup
+        # >= 1.0 -- as a successful, correct GEAK run (the integrate E2E
+        # benchmark remains the ground-truth functional check).
+        _geak_finalized = (
+            geak_status in {"complete", "completed", "succeeded", "success",
+                            "ok", "auto_finalized", "finalized"}
+            or geak_status.startswith("incremental")
+        )
+        _geak_verified_ok = geak_verified is not None and geak_verified >= 1.0
+        if _geak_finalized or _geak_verified_ok:
             correctness_signal = True
             correctness_source = "geak_assumed_pass"
     if correctness_signal is None and getattr(args, "accuracy_passed", None) is True:
@@ -2465,7 +2485,71 @@ def build_verification(args: argparse.Namespace, attempts: list[dict[str, Any]],
     }
 
 
-def make_proposal(verification: dict[str, Any]) -> dict[str, Any]:
+# PART C (DEFER_TO_E2E): "high impact" mirrors SharedState.untried_hot_
+# reusable_kernels' gpu_pct gate (default 3% of GPU time, override via
+# HYPERLOOM_KERNEL_OPT_MIN_GPU_PCT) so the defer lever only fires for kernels
+# whose roofline/time-share makes an expensive E2E re-baseline worthwhile.
+_DEFAULT_HIGH_IMPACT_GPU_PCT = 3.0
+
+
+def _candidate_is_high_impact(candidate: dict[str, Any], *, min_pct: float | None = None) -> bool:
+    """True iff the candidate's TraceLens time-share / roofline impact clears
+    the high-impact threshold (default 3%).
+
+    Reads whichever of ``gpu_pct`` / ``percent_of_total`` / roofline
+    ``impact_*_e2e_pct`` the candidate carries (plus its task_group rows), and
+    compares the max to ``min_pct``. Conservative: no impact field => not
+    high-impact => DEFER_TO_E2E never fires (current behaviour preserved).
+    """
+    if not isinstance(candidate, dict):
+        return False
+    if min_pct is None:
+        try:
+            min_pct = float(os.environ.get(
+                "HYPERLOOM_KERNEL_OPT_MIN_GPU_PCT", _DEFAULT_HIGH_IMPACT_GPU_PCT,
+            ))
+        except (TypeError, ValueError):
+            min_pct = _DEFAULT_HIGH_IMPACT_GPU_PCT
+    pcts: list[float] = []
+    for key in ("gpu_pct", "percent_of_total", "impact_high_e2e_pct", "impact_low_e2e_pct"):
+        if candidate.get(key) is not None:
+            pcts.append(_safe_float(candidate.get(key)))
+    tg = candidate.get("task_group")
+    if isinstance(tg, dict):
+        for row in (tg.get("rows") or []):
+            if isinstance(row, dict):
+                val = row.get("percent_of_total")
+                if val is None:
+                    val = row.get("gpu_pct")
+                if val is not None:
+                    pcts.append(_safe_float(val))
+    return bool(pcts) and max(pcts) >= float(min_pct)
+
+
+def _defer_to_e2e_proposal(
+    reasons: list[str], *, fallback: str, verification: dict[str, Any],
+) -> dict[str, Any]:
+    """Build a DEFER_TO_E2E proposal.
+
+    Carries ``fallback_decision`` (what the disposition would have been
+    without the defer) so the orchestrator can fall back when the E2E budget
+    is exhausted, and ``defer_to_e2e=True`` + ``micro_speedup`` for observable
+    state/result dicts.
+    """
+    return {
+        "decision": "DEFER_TO_E2E",
+        "reasons": reasons + [
+            "high-impact + correctness-passed kernel with inconclusive/low "
+            "micro-score; deferring KEEP/REVERT to the integrate E2E gain_pct "
+            "(a self-measurement artifact must not silently discard a real win)"
+        ],
+        "fallback_decision": fallback,
+        "defer_to_e2e": True,
+        "micro_speedup": verification.get("micro_speedup"),
+    }
+
+
+def make_proposal(verification: dict[str, Any], *, high_impact: bool = False) -> dict[str, Any]:
     reasons: list[str] = []
     if not verification["compile_passed"]:
         return {"decision": "REVERT", "reasons": ["compile failed"]}
@@ -2473,6 +2557,24 @@ def make_proposal(verification: dict[str, Any]) -> dict[str, Any]:
         reasons.append("correctness evidence missing or failed")
     if not verification.get("artifact_valid"):
         reasons.append("optimized source artifact missing or invalid")
+
+    # PART C (DEFER_TO_E2E): a HIGH-IMPACT, correctness-PASSED, artifact-valid
+    # kernel whose MICRO score is inconclusive/low (~1.0x or below the KEEP
+    # threshold) but is NOT a hard correctness / compile / E2E-regression /
+    # accuracy failure must not be silently discarded on a possibly
+    # artifact-corrupted self-measurement (GEAK's fused_moe self-score read
+    # 1.0x on a real +20.9% E2E win). We route it to integrate so the E2E
+    # gain_pct is the authoritative KEEP/REVERT signal. Defer is OFF by default
+    # (high_impact False) so every non-high-impact / non-correct kernel keeps
+    # its current disposition bit-for-bit; the orchestrator bounds the defer by
+    # the existing max_e2e_attempts ledger and falls back to fallback_decision
+    # when the E2E budget is exhausted.
+    defer_eligible = (
+        high_impact
+        and bool(verification.get("correctness_passed"))
+        and bool(verification.get("artifact_valid"))
+    )
+
     # Distinguish "we have artifacts but didn't measure a speedup" (PARTIAL,
     # human review can salvage) from "we measured and it's a regression"
     # (REVERT). The signal is verification["micro_speedup_source"]:
@@ -2484,8 +2586,15 @@ def make_proposal(verification: dict[str, Any]) -> dict[str, Any]:
         # don't punish as REVERT (regression) and don't lie as KEEP — leave
         # it at PARTIAL so a human reviewer can salvage from the report.
         reasons.append("no measurable speedup found in any backend report")
+        if defer_eligible:
+            return _defer_to_e2e_proposal(reasons, fallback="PARTIAL", verification=verification)
         return {"decision": "PARTIAL", "reasons": reasons}
     if verification["micro_speedup"] <= 1.0:
+        if defer_eligible:
+            return _defer_to_e2e_proposal(
+                reasons + ["microbench did not improve (micro <= 1.0x)"],
+                fallback="REVERT", verification=verification,
+            )
         return {"decision": "REVERT", "reasons": ["microbench did not improve"]}
     # Goal threshold: 1.10x lets modest but real shape-specific wins
     # (claude r19 GEMM 1.32x, GEAK r39 rms_norm 1.18x, codex r25 GEMM 1.66x)
@@ -2508,6 +2617,10 @@ def make_proposal(verification: dict[str, Any]) -> dict[str, Any]:
         reasons.append("accuracy evidence missing")
 
     if reasons:
+        # micro in (1.0, 1.10) but below KEEP, correctness/artifact ok ->
+        # NEEDS_REVIEW, or DEFER_TO_E2E when the kernel is high-impact.
+        if defer_eligible:
+            return _defer_to_e2e_proposal(reasons, fallback="NEEDS_REVIEW", verification=verification)
         return {"decision": "NEEDS_REVIEW", "reasons": reasons}
     if verification["e2e_gain_pct"] is None or verification["accuracy_passed"] is None:
         return {
@@ -2622,6 +2735,11 @@ def main() -> int:
             args.source_file, candidate, args.kernel_id, log_path
         )
         args.source_file = resolved_source
+        # Fix #1: for the autonomously-surfaced fused_moe candidate, route GEAK
+        # at the tile-config SELECTION site with the real gpt-oss-120b MoE shapes
+        # + M>=4096 prefill regime. Reassign resolved_source so result.source_file
+        # (the integrate apply target) matches the file GEAK actually edits.
+        resolved_source = _specialize_fused_moe_target(args, candidate, log_path)
         # Forward the candidate's repo root onto args so build_verification's
         # GEAK-worktree artifact recovery can map ``source_file`` (an
         # absolute path produced by the TraceLens resolver) back to the
@@ -2663,7 +2781,21 @@ def main() -> int:
         correctness = None if args.correctness_passed == "unknown" else args.correctness_passed == "true"
         args.correctness_passed = correctness
         verification = build_verification(args, attempts, benchmark_available)
-        proposal = make_proposal(verification)
+        # PART C: high-impact (roofline/time-share) + correctness-passed kernels
+        # with an inconclusive/low micro-score are routed to integrate as
+        # DEFER_TO_E2E so the E2E gain_pct is authoritative (a self-measurement
+        # artifact must not silently discard a real win). Off for low-impact
+        # kernels -> their disposition is unchanged.
+        high_impact = _candidate_is_high_impact(candidate)
+        proposal = make_proposal(verification, high_impact=high_impact)
+        if proposal.get("decision") == "DEFER_TO_E2E":
+            append_log(
+                log_path,
+                f"disposition=DEFER_TO_E2E high_impact={high_impact} "
+                f"micro_speedup={verification.get('micro_speedup')} "
+                f"fallback={proposal.get('fallback_decision')} "
+                f"-> routing to integrate; E2E gain_pct is authoritative",
+            )
 
         verification_path = run_dir / "verification" / f"{args.kernel_id}.json"
         atomic_write_json(verification_path, verification)
@@ -2682,6 +2814,8 @@ def main() -> int:
             "xs_memory_hits": [],
             "verification": verification,
             "proposal": proposal,
+            "disposition": proposal.get("decision"),
+            "high_impact": high_impact,
             "cli_log_path": str(log_path),
             "status_path": str(status_path),
             "artifact_paths": {

--- a/kernel-agent/tools/test_apply_kernel_patch_cpp_itfs_invalidation.py
+++ b/kernel-agent/tools/test_apply_kernel_patch_cpp_itfs_invalidation.py
@@ -1,0 +1,416 @@
+"""PR-K2 — aiter cpp_itfs RUNTIME-compiled cache invalidation (GH #458).
+
+Background
+----------
+aiter ``csrc/cpp_itfs`` kernels (e.g. ``paged_attention`` ->
+``csrc/cpp_itfs/pa/pa_kernels.cuh``) are NOT built by ``setup.py develop``;
+they are runtime-compiled on first call by ``compile_template_op``
+(``csrc/cpp_itfs/utils.py``) into
+``$AITER_ROOT_DIR/build/<md_name>_<md5(params)>/lib.so`` (default
+``$HOME/.aiter/build``). The cache folder name hashes kernel *parameters*,
+NOT source content, so a pristine and a patched build of the same kernel
+collide on the SAME directory; ``compile_template_op`` only rebuilds when
+``lib.so`` is missing, so after :mod:`apply_kernel_patch` lands the new
+``.cuh`` (and runs the no-op-for-this-class ``setup.py develop``), the next
+server reuses the STALE pristine ``lib.so`` and integrate measures ~0% gain
+on a genuinely-good kernel (observed -0.17% on a +2.5% pa kernel, RUN2).
+
+These tests cover the fix:
+
+* ``_target_is_in_aiter_cpp_itfs`` recognizes cpp_itfs editable + dist layouts
+  and rejects non-cpp_itfs aiter csrc / sglang / vllm targets.
+* ``_cpp_itfs_module_names`` scrapes ``MD_NAME`` from the drivers next to the
+  patched source so invalidation can be scoped to the impacted module(s).
+* ``_invalidate_aiter_cpp_itfs_cache`` moves only the matching
+  ``<md_name>_*`` cache dirs aside (leaving unrelated modules intact), falls
+  back to the whole build root when no MD_NAME is determinable, skips when
+  the build dir is absent, and refuses to clobber a pre-existing backup.
+* ``_restore_aiter_cpp_itfs_cache`` round-trips the move, clearing any dir
+  the re-baseline regenerated first.
+* ``verify_cpp_itfs_rebuilt`` is a no-op for non-cpp_itfs, reports ``stale``
+  when no fresh ``lib.so`` landed, and ``ok`` when one did.
+* End-to-end ``apply_kernel_patch`` against a synthetic cpp_itfs target moves
+  the runtime cache aside + records ``cpp_itfs_cache_backup`` (and revert
+  restores it), while a non-cpp_itfs (sglang) target leaves the cpp_itfs
+  build root untouched.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import time
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+_APPLY_TOOL_PATH = Path(__file__).resolve().parent / "apply_kernel_patch.py"
+
+
+@pytest.fixture(scope="module")
+def apply_tool() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "_apply_kernel_patch_cpp_itfs_under_test", _APPLY_TOOL_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# _target_is_in_aiter_cpp_itfs
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "target_path,expected",
+    [
+        ("/sgl-workspace/aiter/csrc/cpp_itfs/pa/pa_kernels.cuh", True),
+        ("/sgl-workspace/aiter/csrc/cpp_itfs/pa/pa_ragged.cpp.jinja", True),
+        ("/usr/local/lib/python3.12/dist-packages/aiter/csrc/cpp_itfs/mha/x.cuh", True),
+        # Negative — aiter csrc but NOT cpp_itfs, plus sglang / vllm.
+        ("/sgl-workspace/aiter/csrc/ck_gemm_moe_2stages_codegen/gemm.cu", False),
+        ("/sgl-workspace/aiter/csrc/include/foo.cuh", False),
+        ("/sgl-workspace/sglang/sgl-kernel/csrc/cpp_itfs/foo.cu", False),
+        ("/sgl-workspace/vllm/csrc/foo.cu", False),
+    ],
+)
+def test_target_is_in_aiter_cpp_itfs(apply_tool, target_path: str, expected: bool) -> None:
+    assert apply_tool._target_is_in_aiter_cpp_itfs(Path(target_path)) is expected
+
+
+# ---------------------------------------------------------------------------
+# _cpp_itfs_module_names
+# ---------------------------------------------------------------------------
+def test_cpp_itfs_module_names_scrapes_md_name(apply_tool, tmp_path: Path) -> None:
+    pa_dir = tmp_path / "aiter" / "csrc" / "cpp_itfs" / "pa"
+    pa_dir.mkdir(parents=True)
+    (pa_dir / "pa_kernels.cuh").write_text("// shared kernel header\n")
+    (pa_dir / "pa_ragged.py").write_text('MD_NAME = "pa_ragged"\n')
+    (pa_dir / "pa.py").write_text("MD_NAME = 'pa'\n")
+    (pa_dir / "notes.py").write_text("X = 1  # no MD_NAME here\n")
+
+    names = apply_tool._cpp_itfs_module_names(pa_dir / "pa_kernels.cuh")
+    assert names == ["pa", "pa_ragged"]
+
+
+def test_cpp_itfs_module_names_empty_when_no_driver(apply_tool, tmp_path: Path) -> None:
+    d = tmp_path / "aiter" / "csrc" / "cpp_itfs" / "mystery"
+    d.mkdir(parents=True)
+    (d / "kernel.cuh").write_text("// no python driver next to me\n")
+    assert apply_tool._cpp_itfs_module_names(d / "kernel.cuh") == []
+
+
+# ---------------------------------------------------------------------------
+# _invalidate_aiter_cpp_itfs_cache
+# ---------------------------------------------------------------------------
+def _make_cache_dir(build_dir: Path, name: str, content: bytes = b"v0") -> Path:
+    d = build_dir / name
+    d.mkdir(parents=True)
+    (d / "lib.so").write_bytes(content)
+    return d
+
+
+def test_invalidate_skips_non_cpp_itfs_target(apply_tool, tmp_path: Path) -> None:
+    target = tmp_path / "aiter" / "csrc" / "ck_gemm" / "gemm.cu"
+    target.parent.mkdir(parents=True)
+    target.write_text("// non cpp_itfs aiter csrc\n")
+    build_dir = tmp_path / "build"
+    _make_cache_dir(build_dir, "gemm_abc")
+
+    out = apply_tool._invalidate_aiter_cpp_itfs_cache(
+        target, tmp_path / "backup", build_dir_override=build_dir,
+    )
+    assert out["status"] == "skipped"
+    assert out["is_cpp_itfs"] is False
+    # Untouched.
+    assert (build_dir / "gemm_abc" / "lib.so").is_file()
+
+
+def test_invalidate_scopes_to_module_md_names(apply_tool, tmp_path: Path) -> None:
+    """Only the patched module's <md_name>_* dirs are moved aside; unrelated
+    modules (e.g. gemm_*) stay put."""
+    pa_dir = tmp_path / "aiter" / "csrc" / "cpp_itfs" / "pa"
+    pa_dir.mkdir(parents=True)
+    target = pa_dir / "pa_kernels.cuh"
+    target.write_text("// shared by pa + pa_ragged\n")
+    (pa_dir / "pa_ragged.py").write_text('MD_NAME = "pa_ragged"\n')
+    (pa_dir / "pa.py").write_text('MD_NAME = "pa"\n')
+
+    build_dir = tmp_path / "build"
+    _make_cache_dir(build_dir, "pa_ragged_HASHA")
+    _make_cache_dir(build_dir, "pa_HASHB")
+    _make_cache_dir(build_dir, "gemm_HASHC")  # unrelated module — must survive
+
+    backup = tmp_path / "backup"
+    out = apply_tool._invalidate_aiter_cpp_itfs_cache(
+        target, backup, build_dir_override=build_dir,
+    )
+
+    assert out["status"] == "ok"
+    assert out["is_cpp_itfs"] is True
+    assert out["scope"] == "module"
+    assert out["module_names"] == ["pa", "pa_ragged"]
+    moved_srcs = {Path(m["src"]).name for m in out["moved"]}
+    assert moved_srcs == {"pa_ragged_HASHA", "pa_HASHB"}
+    # Affected module dirs moved aside; unrelated gemm_* untouched.
+    assert not (build_dir / "pa_ragged_HASHA").exists()
+    assert not (build_dir / "pa_HASHB").exists()
+    assert (build_dir / "gemm_HASHC" / "lib.so").is_file()
+    # Backup holds the originals.
+    assert (backup / "cpp_itfs_cache" / "pa_ragged_HASHA" / "lib.so").is_file()
+    assert (backup / "cpp_itfs_cache" / "pa_HASHB" / "lib.so").is_file()
+
+
+def test_invalidate_falls_back_to_build_root_without_md_name(
+    apply_tool, tmp_path: Path,
+) -> None:
+    d = tmp_path / "aiter" / "csrc" / "cpp_itfs" / "mystery"
+    d.mkdir(parents=True)
+    target = d / "kernel.cuh"
+    target.write_text("// no driver -> clear whole cpp_itfs build root\n")
+
+    build_dir = tmp_path / "build"
+    _make_cache_dir(build_dir, "alpha_1")
+    _make_cache_dir(build_dir, "beta_2")
+
+    out = apply_tool._invalidate_aiter_cpp_itfs_cache(
+        target, tmp_path / "backup", build_dir_override=build_dir,
+    )
+    assert out["status"] == "ok"
+    assert out["scope"] == "build_root"
+    assert {Path(m["src"]).name for m in out["moved"]} == {"alpha_1", "beta_2"}
+    assert not (build_dir / "alpha_1").exists()
+    assert not (build_dir / "beta_2").exists()
+
+
+def test_invalidate_skips_when_build_dir_missing(apply_tool, tmp_path: Path) -> None:
+    pa_dir = tmp_path / "aiter" / "csrc" / "cpp_itfs" / "pa"
+    pa_dir.mkdir(parents=True)
+    target = pa_dir / "pa_kernels.cuh"
+    target.write_text("// fake\n")
+    (pa_dir / "pa_ragged.py").write_text('MD_NAME = "pa_ragged"\n')
+
+    out = apply_tool._invalidate_aiter_cpp_itfs_cache(
+        target, tmp_path / "backup", build_dir_override=tmp_path / "nope",
+    )
+    assert out["status"] == "skipped"
+    assert out["is_cpp_itfs"] is True
+    assert "does not exist" in out["reason"]
+    # The record still carries enough for the verify gate.
+    assert out["module_names"] == ["pa_ragged"]
+    assert "invalidated_unix" in out
+
+
+def test_invalidate_refuses_to_clobber_existing_backup(
+    apply_tool, tmp_path: Path,
+) -> None:
+    pa_dir = tmp_path / "aiter" / "csrc" / "cpp_itfs" / "pa"
+    pa_dir.mkdir(parents=True)
+    target = pa_dir / "pa_kernels.cuh"
+    target.write_text("// fake\n")
+    (pa_dir / "pa_ragged.py").write_text('MD_NAME = "pa_ragged"\n')
+
+    build_dir = tmp_path / "build"
+    _make_cache_dir(build_dir, "pa_ragged_HASHA")
+
+    backup = tmp_path / "backup"
+    (backup / "cpp_itfs_cache" / "pa_ragged_HASHA").mkdir(parents=True)
+    (backup / "cpp_itfs_cache" / "pa_ragged_HASHA" / "stale.txt").write_text("old")
+
+    out = apply_tool._invalidate_aiter_cpp_itfs_cache(
+        target, backup, build_dir_override=build_dir,
+    )
+    assert out["status"] == "failed"
+    assert "already exists" in out["error"]
+    # Live cache untouched so the caller can recover.
+    assert (build_dir / "pa_ragged_HASHA" / "lib.so").is_file()
+
+
+# ---------------------------------------------------------------------------
+# _restore_aiter_cpp_itfs_cache
+# ---------------------------------------------------------------------------
+def test_restore_round_trip(apply_tool, tmp_path: Path) -> None:
+    pa_dir = tmp_path / "aiter" / "csrc" / "cpp_itfs" / "pa"
+    pa_dir.mkdir(parents=True)
+    target = pa_dir / "pa_kernels.cuh"
+    target.write_text("// fake\n")
+    (pa_dir / "pa_ragged.py").write_text('MD_NAME = "pa_ragged"\n')
+
+    build_dir = tmp_path / "build"
+    _make_cache_dir(build_dir, "pa_ragged_HASHA", b"v0")
+
+    backup = tmp_path / "backup"
+    invalidate = apply_tool._invalidate_aiter_cpp_itfs_cache(
+        target, backup, build_dir_override=build_dir,
+    )
+    assert invalidate["status"] == "ok"
+    assert not (build_dir / "pa_ragged_HASHA").exists()
+
+    # Simulate the re-baseline regenerating a fresh (patched) dir on top.
+    _make_cache_dir(build_dir, "pa_ragged_HASHA", b"v1")
+
+    restore = apply_tool._restore_aiter_cpp_itfs_cache(invalidate)
+    assert restore["status"] == "ok"
+    # Pre-patch (v0) content restored; regenerated v1 cleared first.
+    assert (build_dir / "pa_ragged_HASHA" / "lib.so").read_bytes() == b"v0"
+    assert not (backup / "cpp_itfs_cache" / "pa_ragged_HASHA").exists()
+
+
+def test_restore_skips_when_no_backup(apply_tool) -> None:
+    assert apply_tool._restore_aiter_cpp_itfs_cache(
+        {"status": "skipped", "is_cpp_itfs": False},
+    )["status"] == "skipped"
+    assert apply_tool._restore_aiter_cpp_itfs_cache({})["status"] == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# verify_cpp_itfs_rebuilt
+# ---------------------------------------------------------------------------
+def test_verify_noop_for_non_cpp_itfs(apply_tool) -> None:
+    out = apply_tool.verify_cpp_itfs_rebuilt({"is_cpp_itfs": False})
+    assert out["verified"] is True
+    assert out["status"] == "skipped"
+
+
+def test_verify_stale_when_no_fresh_lib_so(apply_tool, tmp_path: Path) -> None:
+    build_dir = tmp_path / "build"
+    # A lib.so that predates the invalidation -> stale.
+    old = _make_cache_dir(build_dir, "pa_ragged_HASHA")
+    invalidated_unix = time.time()
+    old_mtime = invalidated_unix - 1000.0
+    os.utime(old / "lib.so", (old_mtime, old_mtime))
+
+    out = apply_tool.verify_cpp_itfs_rebuilt({
+        "is_cpp_itfs": True,
+        "build_dir": str(build_dir),
+        "module_names": ["pa_ragged"],
+        "invalidated_unix": invalidated_unix,
+    })
+    assert out["verified"] is False
+    assert out["status"] == "stale"
+
+
+def test_verify_ok_when_fresh_lib_so(apply_tool, tmp_path: Path) -> None:
+    build_dir = tmp_path / "build"
+    invalidated_unix = time.time()
+    fresh = _make_cache_dir(build_dir, "pa_ragged_HASHA")
+    new_mtime = invalidated_unix + 5.0
+    os.utime(fresh / "lib.so", (new_mtime, new_mtime))
+
+    out = apply_tool.verify_cpp_itfs_rebuilt({
+        "is_cpp_itfs": True,
+        "build_dir": str(build_dir),
+        "module_names": ["pa_ragged"],
+        "invalidated_unix": invalidated_unix,
+    })
+    assert out["verified"] is True
+    assert out["status"] == "ok"
+    assert any("pa_ragged_HASHA" in p for p in out["fresh_lib_so"])
+
+
+# ---------------------------------------------------------------------------
+# End-to-end apply_kernel_patch → revert_kernel_patch.
+# ---------------------------------------------------------------------------
+_CUH_V0 = "#include <hip/hip_runtime.h>\n__global__ void pa_kernel_v0() {}\n"
+_CUH_V1 = "#include <hip/hip_runtime.h>\n__global__ void pa_kernel_v1() {}\n"
+
+_FAKE_REBUILD_OK = {
+    "status": "ok",
+    "returncode": 0,
+    "stdout_tail": "ok",
+    "stderr_tail": "",
+    "command": ["fake-rebuild"],
+    "cwd": "",
+}
+
+
+def test_apply_then_revert_invalidates_and_restores_cpp_itfs_cache(
+    apply_tool, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "sgl-workspace" / "aiter"
+    pa_dir = repo / "csrc" / "cpp_itfs" / "pa"
+    pa_dir.mkdir(parents=True)
+    target = pa_dir / "pa_kernels.cuh"
+    target.write_text(_CUH_V0)
+    (pa_dir / "pa_ragged.py").write_text('MD_NAME = "pa_ragged"\n')
+
+    patch_file = tmp_path / "patched.cuh"
+    patch_file.write_text(_CUH_V1)
+
+    # Hermetic cpp_itfs runtime cache via $AITER_ROOT_DIR -> $.../build.
+    aiter_root = tmp_path / "aiterroot"
+    monkeypatch.setenv("AITER_ROOT_DIR", str(aiter_root))
+    build_dir = aiter_root / "build"
+    _make_cache_dir(build_dir, "pa_ragged_HASHA", b"stale-pristine")
+    _make_cache_dir(build_dir, "gemm_HASHC", b"unrelated")
+
+    # Make the orthogonal @compile_ops jit/build invalidation a clean skip
+    # (and never touch the real /sgl-workspace/aiter) by stubbing the jit
+    # build-dir resolver to "aiter not importable". Patching the narrow
+    # helper avoids globally mocking importlib.find_spec, which would break
+    # unrelated lazy imports during apply.
+    with patch.object(apply_tool, "_aiter_jit_build_dir", return_value=None), \
+         patch.object(apply_tool, "_run_rebuild", return_value=dict(_FAKE_REBUILD_OK)):
+        result = apply_tool.apply_kernel_patch(
+            patch_path=patch_file,
+            target_file=target,
+            backup_root=tmp_path / "backups",
+            kernel_id="k_pa",
+            allow_unknown_target=True,
+        )
+
+    assert result["status"] == "ok", result
+    backup = result["cpp_itfs_cache_backup"]
+    assert backup["status"] == "ok"
+    assert backup["is_cpp_itfs"] is True
+    assert backup["module_names"] == ["pa_ragged"]
+    # Patched source landed.
+    assert "pa_kernel_v1" in target.read_text()
+    # Stale pristine cache moved aside; unrelated module survived.
+    assert not (build_dir / "pa_ragged_HASHA").exists()
+    assert (build_dir / "gemm_HASHC" / "lib.so").is_file()
+
+    # Simulate the re-baseline server recompiling the patched kernel.
+    _make_cache_dir(build_dir, "pa_ragged_HASHA", b"fresh-patched")
+
+    revert = apply_tool.revert_kernel_patch(result["manifest_path"])
+    assert revert["status"] == "ok"
+    # Source + runtime cache restored to pristine.
+    assert "pa_kernel_v0" in target.read_text()
+    assert (build_dir / "pa_ragged_HASHA" / "lib.so").read_bytes() == b"stale-pristine"
+
+
+def test_non_cpp_itfs_apply_leaves_cpp_itfs_cache_untouched(
+    apply_tool, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-cpp_itfs (sglang) target must NOT touch $HOME/.aiter/build."""
+    target = tmp_path / "sgl-workspace" / "sglang" / "sgl-kernel" / "csrc" / "x.cu"
+    target.parent.mkdir(parents=True)
+    target.write_text(_CUH_V0)
+    patch_file = tmp_path / "patched.cu"
+    patch_file.write_text(_CUH_V1)
+
+    aiter_root = tmp_path / "aiterroot"
+    monkeypatch.setenv("AITER_ROOT_DIR", str(aiter_root))
+    build_dir = aiter_root / "build"
+    _make_cache_dir(build_dir, "pa_ragged_HASHA", b"must-survive")
+
+    with patch.object(apply_tool, "_aiter_jit_build_dir", return_value=None), \
+         patch.object(apply_tool, "_run_rebuild", return_value=dict(_FAKE_REBUILD_OK)):
+        result = apply_tool.apply_kernel_patch(
+            patch_path=patch_file,
+            target_file=target,
+            backup_root=tmp_path / "backups",
+            kernel_id="k_sgl",
+            allow_unknown_target=True,
+        )
+
+    assert result["status"] == "ok", result
+    assert result["cpp_itfs_cache_backup"]["is_cpp_itfs"] is False
+    # cpp_itfs runtime cache completely untouched for a non-cpp_itfs target.
+    assert (build_dir / "pa_ragged_HASHA" / "lib.so").read_bytes() == b"must-survive"

--- a/kernel-agent/tools/test_cache_invalidation_registry.py
+++ b/kernel-agent/tools/test_cache_invalidation_registry.py
@@ -1,0 +1,376 @@
+"""PART B2 — target-type -> toolchain cache-invalidation REGISTRY.
+
+Covers the single dispatch in ``apply_kernel_patch.py`` that generalizes the
+GH #458 (#459) aiter cpp_itfs invalidation + the pre-existing aiter
+@compile_ops jit/build invalidation into a registry keyed by toolchain, plus
+the two NEW toolchains:
+
+* **Triton** -- ``$TRITON_CACHE_DIR`` (default ``~/.triton/cache``) move-aside
+  so the integrate re-baseline recompiles the patched ``@triton.jit`` kernel
+  (THE robustness fix for the editable Triton fused_moe win).
+* **torch inductor** -- ``$TORCHINDUCTOR_CACHE_DIR`` / ``~/.cache/torch/
+  inductor`` / ``/tmp/torchinductor_*`` move-aside.
+
+Each toolchain entry is checked for: correct detection, invalidate/restore
+round-trip, fresh-build verification, and a strict no-op for unhandled
+targets. The aiter entries delegate to the existing functions so the #459
+behaviour is preserved (those names are exercised by
+``test_apply_kernel_patch_cpp_itfs_invalidation.py``); here we pin the
+registry wiring + the new Triton/inductor entries + the integrate dispatch
+helpers (``rebuild_env_for_apply_result`` / ``verify_rebuilt_for_apply_result``).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import time
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+_APPLY_TOOL_PATH = Path(__file__).resolve().parent / "apply_kernel_patch.py"
+
+
+@pytest.fixture(scope="module")
+def apply_tool() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "_apply_kernel_patch_registry_under_test", _APPLY_TOOL_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _mk_cache(d: Path, *files: str, content: bytes = b"v0") -> Path:
+    d.mkdir(parents=True, exist_ok=True)
+    for f in files:
+        (d / f).write_bytes(content)
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Registry shape + toolchain_for classification.
+# ---------------------------------------------------------------------------
+def test_registry_has_all_four_toolchains(apply_tool) -> None:
+    names = [e.name for e in apply_tool.CACHE_INVALIDATION_REGISTRY]
+    assert names == ["aiter_compile_ops", "aiter_cpp_itfs", "triton", "torch_inductor"]
+    keys = {e.manifest_key for e in apply_tool.CACHE_INVALIDATION_REGISTRY}
+    assert keys == {
+        "jit_build_backup", "cpp_itfs_cache_backup",
+        "triton_cache_backup", "inductor_cache_backup",
+    }
+
+
+@pytest.mark.parametrize(
+    "target,expected",
+    [
+        ("/sgl-workspace/aiter/csrc/cpp_itfs/pa/pa_kernels.cuh", "aiter_cpp_itfs"),
+        ("/sgl-workspace/aiter/csrc/ck_gemm/gemm.cu", "aiter_compile_ops"),
+        ("/x/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py", "triton"),
+        ("/tmp/torchinductor_root/abc/kernel.py", "torch_inductor"),
+        ("/sgl-workspace/sglang/x.cu", None),
+        ("/sgl-workspace/sglang/plain_helper.py", None),
+    ],
+)
+def test_toolchain_for_classifies(apply_tool, target, expected) -> None:
+    assert apply_tool.toolchain_for(target) == expected
+
+
+# ---------------------------------------------------------------------------
+# Triton detection.
+# ---------------------------------------------------------------------------
+def test_triton_detection_by_source_markers(apply_tool, tmp_path) -> None:
+    f = tmp_path / "kernel.py"
+    f.write_text("import triton\nimport triton.language as tl\n@triton.jit\ndef k():\n    tl.load(p)\n")
+    assert apply_tool._target_is_triton(f) is True
+
+
+def test_triton_detection_by_path(apply_tool, tmp_path) -> None:
+    d = tmp_path / "fused_moe_triton"
+    d.mkdir()
+    f = d / "fused_moe.py"
+    f.write_text("# no explicit markers, but path says triton\n")
+    assert apply_tool._target_is_triton(f) is True
+
+
+def test_triton_rejects_non_py_and_plain_py(apply_tool, tmp_path) -> None:
+    cu = tmp_path / "x.cu"
+    cu.write_text("__global__ void k() {}\n")
+    assert apply_tool._target_is_triton(cu) is False
+    plain = tmp_path / "plain.py"
+    plain.write_text("import numpy as np\ndef f():\n    return 1\n")
+    assert apply_tool._target_is_triton(plain) is False
+
+
+def test_triton_cache_dir_honours_env(apply_tool, monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("TRITON_CACHE_DIR", str(tmp_path / "tc"))
+    assert apply_tool._triton_cache_dir() == tmp_path / "tc"
+    monkeypatch.delenv("TRITON_CACHE_DIR", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    assert apply_tool._triton_cache_dir() == tmp_path / "home" / ".triton" / "cache"
+
+
+# ---------------------------------------------------------------------------
+# Triton invalidate / restore round-trip + verify.
+# ---------------------------------------------------------------------------
+def test_triton_invalidate_skips_non_triton(apply_tool, tmp_path) -> None:
+    cu = tmp_path / "x.cu"
+    cu.write_text("__global__ void k() {}\n")
+    out = apply_tool._invalidate_triton_cache(
+        cu, tmp_path / "backup", cache_dir_override=tmp_path / "tc",
+    )
+    assert out["status"] == "skipped"
+    assert out["is_triton"] is False
+
+
+def test_triton_invalidate_moves_cache_aside_and_restores(apply_tool, tmp_path) -> None:
+    target = tmp_path / "fused_moe.py"
+    target.write_text("import triton\n@triton.jit\ndef k():\n    pass\n")
+    cache = tmp_path / "tritoncache"
+    _mk_cache(cache / "HASHA", "kernel.hsaco", content=b"v0")
+
+    out = apply_tool._invalidate_triton_cache(
+        target, tmp_path / "backup", cache_dir_override=cache,
+    )
+    assert out["status"] == "ok"
+    assert out["is_triton"] is True
+    assert not cache.exists()  # moved aside
+    assert (tmp_path / "backup" / "triton_cache" / "tritoncache" / "HASHA" / "kernel.hsaco").is_file()
+
+    # re-baseline recompiles into a fresh cache dir
+    _mk_cache(cache / "HASHB", "new.hsaco", content=b"v1")
+    restore = apply_tool._restore_triton_cache(out)
+    assert restore["status"] == "ok"
+    assert (cache / "HASHA" / "kernel.hsaco").read_bytes() == b"v0"
+    assert not (cache / "HASHB").exists()  # regenerated cleared on restore
+
+
+def test_triton_invalidate_skips_when_cache_absent(apply_tool, tmp_path) -> None:
+    target = tmp_path / "fused_moe.py"
+    target.write_text("import triton\n@triton.jit\ndef k():\n    pass\n")
+    out = apply_tool._invalidate_triton_cache(
+        target, tmp_path / "backup", cache_dir_override=tmp_path / "nope",
+    )
+    assert out["status"] == "skipped"
+    assert out["is_triton"] is True
+    assert "does not exist" in out["reason"]
+
+
+def test_triton_verify_noop_stale_and_ok(apply_tool, tmp_path) -> None:
+    # non-triton -> verified True (no-op)
+    assert apply_tool.verify_triton_rebuilt({"is_triton": False})["verified"] is True
+    # moved a non-empty cache but nothing fresh -> stale
+    cache = tmp_path / "tc"
+    _mk_cache(cache, "old.hsaco")
+    since = time.time()
+    old = since - 1000.0
+    os.utime(cache / "old.hsaco", (old, old))
+    rec = {
+        "is_triton": True, "status": "ok", "invalidated_unix": since,
+        "moved": [{"src": str(cache), "backup_path": str(tmp_path / "b")}],
+    }
+    assert apply_tool.verify_triton_rebuilt(rec)["verified"] is False
+    # a fresh artifact appears -> verified
+    fresh = cache / "fresh.hsaco"
+    fresh.write_bytes(b"x")
+    os.utime(fresh, (since + 5, since + 5))
+    assert apply_tool.verify_triton_rebuilt(rec)["verified"] is True
+
+
+# ---------------------------------------------------------------------------
+# torch inductor detection + invalidate/restore/verify.
+# ---------------------------------------------------------------------------
+def test_inductor_detection(apply_tool, tmp_path) -> None:
+    f = tmp_path / "m.py"
+    f.write_text("import torch\nm = torch.compile(net)\n")
+    assert apply_tool._target_is_inductor(f) is True
+    assert apply_tool._target_is_inductor(Path("/tmp/torchinductor_root/x/k.py")) is True
+    plain = tmp_path / "plain.py"
+    plain.write_text("def f():\n    return 1\n")
+    assert apply_tool._target_is_inductor(plain) is False
+
+
+def test_inductor_cache_dirs_env_and_default(apply_tool, monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("TORCHINDUCTOR_CACHE_DIR", str(tmp_path / "ic"))
+    assert apply_tool._inductor_cache_dirs() == [tmp_path / "ic"]
+    monkeypatch.delenv("TORCHINDUCTOR_CACHE_DIR", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("USER", "alice")
+    dirs = apply_tool._inductor_cache_dirs()
+    assert tmp_path / "home" / ".cache" / "torch" / "inductor" in dirs
+    assert Path("/tmp/torchinductor_alice") in dirs
+
+
+def test_inductor_invalidate_moves_and_restores(apply_tool, tmp_path) -> None:
+    target = tmp_path / "compiled_model.py"
+    target.write_text("import torch\ntorch.compile(x)\n")
+    c1 = tmp_path / "ind1"
+    _mk_cache(c1 / "frag", "out.py", content=b"v0")
+    out = apply_tool._invalidate_torch_inductor_cache(
+        target, tmp_path / "backup", cache_dirs_override=[c1],
+    )
+    assert out["status"] == "ok"
+    assert out["is_inductor"] is True
+    assert not c1.exists()
+    restore = apply_tool._restore_torch_inductor_cache(out)
+    assert restore["status"] == "ok"
+    assert (c1 / "frag" / "out.py").read_bytes() == b"v0"
+
+
+def test_inductor_invalidate_skips_non_inductor(apply_tool, tmp_path) -> None:
+    plain = tmp_path / "plain.py"
+    plain.write_text("def f():\n    return 1\n")
+    out = apply_tool._invalidate_torch_inductor_cache(
+        plain, tmp_path / "backup", cache_dirs_override=[tmp_path / "ic"],
+    )
+    assert out["status"] == "skipped"
+    assert out["is_inductor"] is False
+
+
+# ---------------------------------------------------------------------------
+# @compile_ops + cpp_itfs registry entries delegate to the existing funcs.
+# ---------------------------------------------------------------------------
+def test_compile_ops_entry_delegates(apply_tool) -> None:
+    entry = next(e for e in apply_tool.CACHE_INVALIDATION_REGISTRY if e.name == "aiter_compile_ops")
+    assert entry.invalidate is apply_tool._invalidate_aiter_jit_build
+    assert entry.restore is apply_tool._restore_aiter_jit_build
+    assert entry.requires_compiled is True
+    assert entry.gates_keep is False
+    assert entry.rebuild_env == {}
+
+
+def test_cpp_itfs_entry_delegates_and_preserves_names(apply_tool) -> None:
+    entry = next(e for e in apply_tool.CACHE_INVALIDATION_REGISTRY if e.name == "aiter_cpp_itfs")
+    assert entry.invalidate is apply_tool._invalidate_aiter_cpp_itfs_cache
+    assert entry.restore is apply_tool._restore_aiter_cpp_itfs_cache
+    assert entry.verify is apply_tool.verify_cpp_itfs_rebuilt
+    assert entry.requires_compiled is True
+    assert entry.gates_keep is True
+    assert entry.rebuild_env == {"AITER_REBUILD": "1"}
+    # #459 public names stay importable from apply_kernel_patch.
+    for name in (
+        "_target_is_in_aiter_cpp_itfs", "_cpp_itfs_module_names",
+        "_invalidate_aiter_cpp_itfs_cache", "_restore_aiter_cpp_itfs_cache",
+        "verify_cpp_itfs_rebuilt",
+    ):
+        assert callable(getattr(apply_tool, name))
+
+
+# ---------------------------------------------------------------------------
+# integrate dispatch helpers.
+# ---------------------------------------------------------------------------
+def test_rebuild_env_for_apply_result(apply_tool) -> None:
+    assert apply_tool.rebuild_env_for_apply_result(
+        {"cpp_itfs_cache_backup": {"is_cpp_itfs": True}},
+    ) == {"AITER_REBUILD": "1"}
+    assert apply_tool.rebuild_env_for_apply_result(
+        {"cpp_itfs_cache_backup": {"is_cpp_itfs": False}},
+    ) == {}
+    # triton move-aside needs no env
+    assert apply_tool.rebuild_env_for_apply_result(
+        {"triton_cache_backup": {"is_triton": True, "status": "ok"}},
+    ) == {}
+    assert apply_tool.rebuild_env_for_apply_result({}) == {}
+
+
+def test_verify_rebuilt_for_apply_result_is_noop_off_paths(apply_tool) -> None:
+    out = apply_tool.verify_rebuilt_for_apply_result({
+        "cpp_itfs_cache_backup": {"is_cpp_itfs": False},
+        "triton_cache_backup": {"is_triton": False},
+    })
+    assert out["verified"] is True
+    assert out["status"] == "skipped"
+
+
+def test_verify_rebuilt_for_apply_result_gates_triton(apply_tool, tmp_path) -> None:
+    cache = tmp_path / "tc"
+    _mk_cache(cache, "old.hsaco")
+    since = time.time()
+    old = since - 500.0
+    os.utime(cache / "old.hsaco", (old, old))
+    apply_result = {
+        "triton_cache_backup": {
+            "is_triton": True, "status": "ok", "invalidated_unix": since,
+            "moved": [{"src": str(cache), "backup_path": str(tmp_path / "b")}],
+        },
+    }
+    out = apply_tool.verify_rebuilt_for_apply_result(apply_result)
+    assert out["verified"] is False
+    assert "triton" in out["per_toolchain"]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end apply -> revert for a Triton target (THE fused_moe robustness).
+# ---------------------------------------------------------------------------
+_TRITON_V0 = "import triton\nimport triton.language as tl\n\n@triton.jit\ndef fused_moe_kernel():\n    pass\n"
+_TRITON_V1 = "import triton\nimport triton.language as tl\n\n@triton.jit\ndef fused_moe_kernel():\n    return 1\n"
+_FAKE_REBUILD_OK = {"status": "ok", "returncode": 0, "stdout_tail": "ok", "stderr_tail": "", "command": ["x"], "cwd": ""}
+
+
+def test_triton_apply_then_revert_e2e(apply_tool, tmp_path, monkeypatch) -> None:
+    target = tmp_path / "sglang" / "fused_moe_triton" / "fused_moe.py"
+    target.parent.mkdir(parents=True)
+    target.write_text(_TRITON_V0)
+    patch_file = tmp_path / "patched.py"
+    patch_file.write_text(_TRITON_V1)
+
+    cache = tmp_path / "tritoncache"
+    monkeypatch.setenv("TRITON_CACHE_DIR", str(cache))
+    _mk_cache(cache / "HASHA", "kernel.hsaco", content=b"stale")
+
+    with patch.object(apply_tool, "_run_rebuild", return_value=dict(_FAKE_REBUILD_OK)):
+        result = apply_tool.apply_kernel_patch(
+            patch_path=patch_file, target_file=target,
+            backup_root=tmp_path / "backups", kernel_id="k_fmoe",
+            allow_unknown_target=True,
+        )
+    assert result["status"] == "ok", result
+    assert result["toolchain"] == "triton"
+    tb = result["triton_cache_backup"]
+    assert tb["is_triton"] is True and tb["status"] == "ok"
+    assert "return 1" in target.read_text()
+    assert not cache.exists()  # stale triton cache moved aside
+    # cpp_itfs / jit / inductor untouched for a .py triton target
+    assert result["cpp_itfs_cache_backup"]["is_cpp_itfs"] is False
+    assert result["inductor_cache_backup"]["is_inductor"] is False
+
+    # re-baseline recompiles
+    _mk_cache(cache / "HASHB", "fresh.hsaco", content=b"fresh")
+    revert = apply_tool.revert_kernel_patch(result["manifest_path"])
+    assert revert["status"] == "ok"
+    assert "return 1" not in target.read_text()  # source restored to v0
+    assert (cache / "HASHA" / "kernel.hsaco").read_bytes() == b"stale"
+
+
+def test_unhandled_py_target_is_full_noop(apply_tool, tmp_path, monkeypatch) -> None:
+    """A plain (non-triton, non-inductor) .py target leaves every toolchain
+    cache untouched -- the registry is a strict no-op off its paths."""
+    target = tmp_path / "sglang" / "plain_layer.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("import numpy as np\n\ndef forward(x):\n    return x\n")
+    patch_file = tmp_path / "patched.py"
+    patch_file.write_text("import numpy as np\n\ndef forward(x):\n    return x + 1\n")
+
+    cache = tmp_path / "tritoncache"
+    monkeypatch.setenv("TRITON_CACHE_DIR", str(cache))
+    _mk_cache(cache / "HASHA", "kernel.hsaco", content=b"must-survive")
+
+    result = apply_tool.apply_kernel_patch(
+        patch_path=patch_file, target_file=target,
+        backup_root=tmp_path / "backups", kernel_id="k_plain",
+        allow_unknown_target=True,
+    )
+    assert result["status"] == "ok", result
+    assert result["toolchain"] is None
+    assert result["triton_cache_backup"]["is_triton"] is False
+    assert result["cpp_itfs_cache_backup"]["is_cpp_itfs"] is False
+    assert result["inductor_cache_backup"]["is_inductor"] is False
+    # triton cache completely untouched
+    assert (cache / "HASHA" / "kernel.hsaco").read_bytes() == b"must-survive"

--- a/kernel-agent/tools/test_defer_to_e2e_proposal.py
+++ b/kernel-agent/tools/test_defer_to_e2e_proposal.py
@@ -1,0 +1,166 @@
+"""PART C — DEFER_TO_E2E disposition in ``make_proposal`` (kernel_optimization).
+
+A HIGH-IMPACT (roofline/time-share), correctness-PASSED, artifact-valid kernel
+whose MICRO score is inconclusive/low (~1.0x or below the 1.10x KEEP threshold,
+but NOT a hard correctness / compile / E2E-regression / accuracy failure) must
+be routed to integrate as ``DEFER_TO_E2E`` so the E2E ``gain_pct`` is the
+authoritative KEEP/REVERT signal -- a self-measurement artifact (GEAK's
+fused_moe self-score read 1.0x on a real +20.9% E2E win) must not silently
+discard a real win.
+
+These tests pin: the defer triggers only for high-impact + correctness-passed
+inconclusive/low-micro cases (with the right ``fallback_decision``), and that
+every other path (KEEP, hard correctness/compile/E2E/accuracy fail, and
+low-impact kernels) keeps its current disposition bit-for-bit.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+_TOOL_PATH = Path(__file__).resolve().parent / "kernel_optimization.py"
+
+
+@pytest.fixture(scope="module")
+def ko() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location("_kernel_optimization_defer_under_test", _TOOL_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _verif(
+    *,
+    compile_passed=True,
+    correctness_passed=True,
+    artifact_valid=True,
+    micro_speedup=1.0,
+    micro_speedup_source="report_scan",
+    e2e_gain_pct=None,
+    accuracy_passed=None,
+) -> dict:
+    return {
+        "compile_passed": compile_passed,
+        "correctness_passed": correctness_passed,
+        "artifact_valid": artifact_valid,
+        "micro_speedup": micro_speedup,
+        "micro_speedup_source": micro_speedup_source,
+        "e2e_gain_pct": e2e_gain_pct,
+        "accuracy_passed": accuracy_passed,
+    }
+
+
+# ---------------------------------------------------------------------------
+# DEFER_TO_E2E fires for high-impact + correctness-passed inconclusive/low micro
+# ---------------------------------------------------------------------------
+def test_defer_on_measured_one_x_when_high_impact(ko) -> None:
+    """The headline case: a real win whose micro self-score reads ~1.0x. With
+    high_impact + correctness, route to E2E instead of REVERT."""
+    v = _verif(micro_speedup=1.0, micro_speedup_source="report_scan")
+    prop = ko.make_proposal(v, high_impact=True)
+    assert prop["decision"] == "DEFER_TO_E2E"
+    assert prop["fallback_decision"] == "REVERT"
+    assert prop["defer_to_e2e"] is True
+
+
+def test_defer_on_unmeasured_when_high_impact(ko) -> None:
+    v = _verif(micro_speedup=1.0, micro_speedup_source="default_unmeasured")
+    prop = ko.make_proposal(v, high_impact=True)
+    assert prop["decision"] == "DEFER_TO_E2E"
+    assert prop["fallback_decision"] == "PARTIAL"
+
+
+def test_defer_on_below_keep_threshold_when_high_impact(ko) -> None:
+    v = _verif(micro_speedup=1.05, micro_speedup_source="report_scan")
+    prop = ko.make_proposal(v, high_impact=True)
+    assert prop["decision"] == "DEFER_TO_E2E"
+    assert prop["fallback_decision"] == "NEEDS_REVIEW"
+
+
+# ---------------------------------------------------------------------------
+# NO defer: low-impact, or hard correctness/compile/E2E/accuracy failures
+# ---------------------------------------------------------------------------
+def test_no_defer_when_low_impact_keeps_revert(ko) -> None:
+    v = _verif(micro_speedup=1.0, micro_speedup_source="report_scan")
+    assert ko.make_proposal(v, high_impact=False)["decision"] == "REVERT"
+
+
+def test_no_defer_when_low_impact_unmeasured_keeps_partial(ko) -> None:
+    v = _verif(micro_speedup=1.0, micro_speedup_source="default_unmeasured")
+    assert ko.make_proposal(v, high_impact=False)["decision"] == "PARTIAL"
+
+
+def test_no_defer_on_correctness_fail_even_high_impact(ko) -> None:
+    """Hard correctness failure must NEVER be deferred (preserve the
+    hard-correctness-fail path)."""
+    v = _verif(correctness_passed=False, micro_speedup=1.0)
+    assert ko.make_proposal(v, high_impact=True)["decision"] == "REVERT"
+
+
+def test_no_defer_on_compile_fail_even_high_impact(ko) -> None:
+    v = _verif(compile_passed=False)
+    assert ko.make_proposal(v, high_impact=True)["decision"] == "REVERT"
+
+
+def test_no_defer_on_e2e_regression_even_high_impact(ko) -> None:
+    """A measured E2E regression is a hard REVERT, not a defer."""
+    v = _verif(micro_speedup=1.2, e2e_gain_pct=-3.0)
+    assert ko.make_proposal(v, high_impact=True)["decision"] == "REVERT"
+
+
+def test_no_defer_on_accuracy_fail_even_high_impact(ko) -> None:
+    v = _verif(micro_speedup=1.2, accuracy_passed=False)
+    assert ko.make_proposal(v, high_impact=True)["decision"] == "REVERT"
+
+
+# ---------------------------------------------------------------------------
+# KEEP path unaffected
+# ---------------------------------------------------------------------------
+def test_keep_unaffected_by_high_impact(ko) -> None:
+    v = _verif(micro_speedup=1.3, e2e_gain_pct=2.0, accuracy_passed=True)
+    assert ko.make_proposal(v, high_impact=True)["decision"] == "KEEP"
+    assert ko.make_proposal(v, high_impact=False)["decision"] == "KEEP"
+
+
+def test_default_high_impact_false_preserves_legacy(ko) -> None:
+    """make_proposal(verification) with no high_impact kwarg is bit-for-bit
+    the legacy disposition."""
+    assert ko.make_proposal(_verif(micro_speedup=1.0))["decision"] == "REVERT"
+    assert ko.make_proposal(
+        _verif(micro_speedup=1.0, micro_speedup_source="default_unmeasured"),
+    )["decision"] == "PARTIAL"
+
+
+# ---------------------------------------------------------------------------
+# _candidate_is_high_impact
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "candidate,expected",
+    [
+        ({"gpu_pct": 6.8}, True),
+        ({"gpu_pct": 1.2}, False),
+        ({"percent_of_total": 4.0}, True),
+        ({"impact_high_e2e_pct": 10.4}, True),
+        ({"impact_high_e2e_pct": 0.5}, False),
+        ({}, False),
+        ({"name": "x"}, False),
+        ({"task_group": {"rows": [{"percent_of_total": 5.0}]}}, True),
+        ({"task_group": {"rows": [{"gpu_pct": 0.4}]}}, False),
+    ],
+)
+def test_candidate_is_high_impact(ko, candidate, expected) -> None:
+    assert ko._candidate_is_high_impact(candidate) is expected
+
+
+def test_candidate_high_impact_env_override(ko, monkeypatch) -> None:
+    monkeypatch.setenv("HYPERLOOM_KERNEL_OPT_MIN_GPU_PCT", "10.0")
+    assert ko._candidate_is_high_impact({"gpu_pct": 6.8}) is False
+    assert ko._candidate_is_high_impact({"gpu_pct": 12.0}) is True

--- a/kernel-agent/tools/test_geak_correctness_status.py
+++ b/kernel-agent/tools/test_geak_correctness_status.py
@@ -1,0 +1,113 @@
+"""Regression: GEAK finalized-success status recognition in build_verification.
+
+Root cause of the hands-off loop never closing: GEAK finalizes a multi-round
+run as ``status="incremental_after_round_<N>"`` (and single-round as
+``auto_finalized``/``finalized``), but the correctness-trust gate only accepted
+``{complete, succeeded, ok}``. A GEAK best with a VERIFIED speedup (fused_moe
+1.5257x, status=incremental_after_round_2) was therefore scored
+``correctness=missing`` -> NEEDS_REVIEW and never reached integrate. The fix
+trusts any non-failure finalized status, or a report carrying a verified
+speedup >= 1.0, as a successful + correct GEAK run.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_TOOL_PATH = Path(__file__).resolve().parent / "kernel_optimization.py"
+
+
+@pytest.fixture(scope="module")
+def ko() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location("_ko_status_under_test", _TOOL_PATH)
+    assert spec is not None and spec.loader is not None
+    m = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+def _report(tmp_path: Path, status: str, verified=1.5257) -> Path:
+    p = tmp_path / "final_report.json"
+    doc: dict = {"status": status}
+    if verified is not None:
+        doc["verified_speedup"] = verified
+        doc["best_speedup_verified"] = verified
+    p.write_text(json.dumps(doc), encoding="utf-8")
+    return p
+
+
+def _attempt(report: Path, speedup="1.5257") -> dict:
+    return {
+        "status": "completed",
+        "backend": "geak",
+        "attempt_id": "geak-test",
+        "returncode": 0,
+        "optimized_path": str(report.parent / "opt.py"),
+        "backend_paths": {
+            "geak_final_report": str(report),
+            "geak_per_task_best_speedup": speedup,
+        },
+    }
+
+
+def _args(src: Path) -> SimpleNamespace:
+    return SimpleNamespace(
+        correctness_passed=None, micro_speedup=None, source_file=str(src),
+        kernel_repo="", repo="", accuracy_passed=None, e2e_gain_pct=None,
+    )
+
+
+def _patch_artifact(ko, monkeypatch, src: Path) -> None:
+    src.write_text("def get_default_config():\n    return {}\n", encoding="utf-8")
+    monkeypatch.setattr(ko, "_select_source_artifact", lambda *a, **k: (str(src), "source_file", ""))
+
+
+@pytest.mark.parametrize(
+    "status",
+    ["incremental_after_round_2", "incremental_after_round_5", "complete",
+     "completed", "auto_finalized", "finalized"],
+)
+def test_geak_finalized_status_is_trusted_and_keeps(ko, tmp_path, monkeypatch, status):
+    src = tmp_path / "opt.py"
+    _patch_artifact(ko, monkeypatch, src)
+    monkeypatch.setenv("HYPERLOOM_TRUST_GEAK_CORRECTNESS", "1")
+    v = ko.build_verification(_args(src), [_attempt(_report(tmp_path, status))], True)
+    assert v["correctness_passed"] is True, v
+    assert v["correctness_source"] == "geak_assumed_pass"
+    assert v["micro_speedup"] >= 1.10
+    # A verified >=1.10 micro + trusted correctness -> straight KEEP (the loop closes).
+    assert ko.make_proposal(v, high_impact=True)["decision"] == "KEEP"
+
+
+def test_geak_verified_speedup_trusted_even_with_unknown_status(ko, tmp_path, monkeypatch):
+    src = tmp_path / "opt.py"
+    _patch_artifact(ko, monkeypatch, src)
+    monkeypatch.setenv("HYPERLOOM_TRUST_GEAK_CORRECTNESS", "1")
+    # status the whitelist doesn't know, but a verified speedup is present.
+    v = ko.build_verification(_args(src), [_attempt(_report(tmp_path, "brand_new_status", 1.4), "1.4")], True)
+    assert v["correctness_passed"] is True
+
+
+def test_geak_failed_status_without_verified_is_not_trusted(ko, tmp_path, monkeypatch):
+    src = tmp_path / "opt.py"
+    _patch_artifact(ko, monkeypatch, src)
+    monkeypatch.setenv("HYPERLOOM_TRUST_GEAK_CORRECTNESS", "1")
+    # status=failed AND no verified speedup -> must NOT be auto-trusted.
+    v = ko.build_verification(_args(src), [_attempt(_report(tmp_path, "failed", verified=None), "1.4")], True)
+    assert v["correctness_passed"] is False
+
+
+def test_trust_disabled_restores_conservative_behaviour(ko, tmp_path, monkeypatch):
+    src = tmp_path / "opt.py"
+    _patch_artifact(ko, monkeypatch, src)
+    monkeypatch.setenv("HYPERLOOM_TRUST_GEAK_CORRECTNESS", "0")
+    v = ko.build_verification(_args(src), [_attempt(_report(tmp_path, "incremental_after_round_2"))], True)
+    assert v["correctness_passed"] is False


### PR DESCRIPTION
Closes #484 · builds on #459 (Closes #458)

## Summary
Two integrate-side robustness fixes so a genuinely-good kernel is never silently discarded:
- **Part B** — generalize #459's aiter-cpp_itfs cache invalidation into a **target-type → toolchain registry** (aiter @compile_ops, aiter cpp_itfs, **Triton**, **torch inductor**), and make `integrate_handler` drive it so the E2E re-baseline always recompiles the patched kernel (no stale-binary scoring) — including the editable Triton `fused_moe`.
- **Part C** — a **`DEFER_TO_E2E`** disposition so a high-impact, correctness-PASSED candidate with an inconclusive/low micro-score is routed to integrate (E2E `gain_pct` authoritative) instead of being hard-killed as `NEEDS_REVIEW`.

## Root cause
1. #459 invalidates only `cpp_itfs` (`$HOME/.aiter/build`). For a **Triton** kernel (sglang `fused_moe`), the served `.hsaco` lives in `TRITON_CACHE_DIR`; if the integrate re-baseline reuses it, it scores the PRE-patch kernel.
2. A low/inconclusive **micro**-score hard-drops a candidate before E2E. When that score is a measurement artifact (cf. the GEAK patch-capture bug where a real ~1.7x read 1.0x), a real win is discarded.
3. (Loop-closer) `build_verification` only trusted GEAK `status ∈ {complete,succeeded,ok}`; GEAK finalizes multi-round runs as `incremental_after_round_<N>`, so a **verified** GEAK win was scored `correctness=missing → NEEDS_REVIEW` and never reached integrate.

## Fix
- `apply_kernel_patch.py`: `CACHE_INVALIDATION_REGISTRY` keyed by toolchain; entries `{detect, invalidate, restore, verify, rebuild_env, gates_keep}`. Adds Triton (`TRITON_CACHE_DIR` move-aside + fresh-`.hsaco` verify) and torch-inductor entries; **refactors #459's cpp_itfs funcs into the registry, preserving their public names + return shapes** (so #459's tests stay green). `toolchain_for` / `rebuild_env_for_apply_result` / `verify_rebuilt_for_apply_result`. Strict no-op (byte-for-byte) off the cache paths.
- `kernel_request_handlers.py::integrate_handler`: registry-driven rebuild env (scoped + always restored) + verified-rebuild KEEP gate (single-node), generalizing #459.
- `kernel_optimization.py`: `make_proposal(..., high_impact=…)` returns `DEFER_TO_E2E` for high-impact + correctness-passed + inconclusive/low micro (OFF by default; carries `fallback_decision`); `build_verification` trusts GEAK finalized statuses / verified speedup as correctness.
- `shared_state.py`: route `KEEP` **and** `DEFER_TO_E2E` to the integrate queue, bounded by the existing `max_e2e_attempts` ledger (`_defer_e2e_budget_exhausted`).

## Test plan (all green)
- `test_apply_kernel_patch_cpp_itfs_invalidation.py` (**#459, 21 — unchanged, stays green after the registry refactor**)
- `test_cache_invalidation_registry.py` (26 — 4 toolchains: detect/invalidate/restore/verify + Triton apply→revert E2E + strict no-op)
- `test_defer_to_e2e_proposal.py` (21) + `test_defer_to_e2e_disposition.py` (11) — defer fires only for high-impact+passed+inconclusive; KEEP / hard-fail / low-impact unchanged; bounded by max_e2e_attempts
- `test_geak_correctness_status.py` (9) — finalized-status / verified-speedup trust; failed-status + trust-disabled stay conservative
- Full `inference_optimizer/tests` suite green except 7 pre-existing/environmental failures (WekaFS mount absent, ray-head, process-reaping) confirmed unrelated via `git stash`.

## End-to-end validation (fully hands-off, bf16 gpt-oss-120B, TP=4, prefill-heavy ISL=4096/OSL=64, CONC=64)
With the GEAK patch-capture fix + this PR, the loop closes with **no human apply**:
- GEAK self-scored the real `micro_speedup = 1.7098x` → `last_kernel_opt.decision = KEEP` (correctness via `geak_assumed_pass`).
- `integrate_handler` ran hands-off: `apply_result.toolchain = triton`, `triton_cache_backup{is_triton:true}`, `cache_clear` removed `~/.triton/cache` + inductor dir → E2E re-baseline **+21.68%** (746.15 → 907.94 tok/s/gpu); `optimization_stack` non-empty.
- Independent CONC=128 standalone cross-check: **+13.04%** (926.7 → 1047.6 output tok/s).
- Provenance: integrated config md5 == GEAK `optimized_codes` (`a6749912…`); serve logs show the `get_default_config` path with **zero** `E=128,N=720` JSON loads.

Made with [Cursor](https://cursor.com)