### PR TITLE
TraceLens GPU benchmarking for Missing MAF Values

### DIFF
--- a/kernel-agent/tools/test_tracelens_arch_benchmark.py
+++ b/kernel-agent/tools/test_tracelens_arch_benchmark.py
@@ -2,19 +2,22 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-TOOLS_DIR = Path(__file__).resolve().parent
-if str(TOOLS_DIR) not in sys.path:
-    sys.path.insert(0, str(TOOLS_DIR))
-
-import tracelens_arch_benchmark as tab  # noqa: E402
+_TOOLS_DIR = Path(__file__).resolve().parent
+_spec = importlib.util.spec_from_file_location(
+    "tracelens_arch_benchmark",
+    _TOOLS_DIR / "tracelens_arch_benchmark.py",
+)
+tab = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(tab)
 
 _VISIBLE_DEVICE_VARS = (
     "HIP_VISIBLE_DEVICES",

--- a/kernel-agent/tools/test_tracelens_arch_benchmark.py
+++ b/kernel-agent/tools/test_tracelens_arch_benchmark.py
@@ -16,6 +16,12 @@ if str(TOOLS_DIR) not in sys.path:
 
 import tracelens_arch_benchmark as tab  # noqa: E402
 
+_VISIBLE_DEVICE_VARS = (
+    "HIP_VISIBLE_DEVICES",
+    "CUDA_VISIBLE_DEVICES",
+    "ROCR_VISIBLE_DEVICES",
+)
+
 
 @pytest.mark.parametrize(
     ("raw", "expected"),
@@ -30,96 +36,54 @@ def test_normalize_platform(raw: str, expected: str) -> None:
     assert tab.normalize_platform(raw) == expected
 
 
-@pytest.mark.parametrize(
-    ("env", "device_count", "expected"),
-    [
-        ({"HIP_VISIBLE_DEVICES": "3"}, None, 1),
-        ({"CUDA_VISIBLE_DEVICES": "0,1"}, None, 2),
-        ({}, 4, 4),
-        ({}, 0, 0),
-    ],
-)
-def test_count_visible_gpus(
-    monkeypatch: pytest.MonkeyPatch,
-    env: dict[str, str],
-    device_count: int | None,
-    expected: int,
-) -> None:
-    for var in tab.VISIBLE_DEVICE_VARS:
-        monkeypatch.delenv(var, raising=False)
-    for key, value in env.items():
-        monkeypatch.setenv(key, value)
-
-    with patch.object(tab, "list_candidate_physical_gpus") as mock_list:
-        if env.get("HIP_VISIBLE_DEVICES") == "3":
-            mock_list.return_value = [3]
-        elif env.get("CUDA_VISIBLE_DEVICES") == "0,1":
-            mock_list.return_value = [0, 1]
-        elif device_count == 4:
-            mock_list.return_value = [0, 1, 2, 3]
-        else:
-            mock_list.return_value = []
-        assert tab.count_visible_gpus() == expected
-
-
 def test_list_candidate_physical_gpus_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    for var in tab.VISIBLE_DEVICE_VARS:
+    for var in _VISIBLE_DEVICE_VARS:
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("HIP_VISIBLE_DEVICES", "2,5")
     assert tab.list_candidate_physical_gpus() == [2, 5]
 
 
-def test_pin_single_physical_gpu(monkeypatch: pytest.MonkeyPatch) -> None:
-    for var in tab.VISIBLE_DEVICE_VARS:
+def test_single_physical_gpu_env_pins_subprocess_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for var in _VISIBLE_DEVICE_VARS:
         monkeypatch.delenv(var, raising=False)
-    tab.pin_single_physical_gpu(4)
-    assert os.environ["HIP_VISIBLE_DEVICES"] == "4"
-    assert os.environ["CUDA_VISIBLE_DEVICES"] == "4"
-    assert os.environ["ROCR_VISIBLE_DEVICES"] == "4"
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1,2")
+
+    env = tab.single_physical_gpu_env(4)
+
+    assert env["HIP_VISIBLE_DEVICES"] == "4"
+    assert env["CUDA_VISIBLE_DEVICES"] == "4"
+    assert env["ROCR_VISIBLE_DEVICES"] == "4"
+    assert os.environ.get("CUDA_VISIBLE_DEVICES") == "0,1,2"
 
 
 def test_select_idle_gpu_picks_first_free_from_many(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    for var in tab.VISIBLE_DEVICE_VARS:
+    for var in _VISIBLE_DEVICE_VARS:
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1,2")
 
     def _idle(logical_idx: int, *, util_threshold: int = 5):
         return logical_idx == 1, f"logical={logical_idx}"
 
-    fake_mod = type(
-        "microbench_utils",
-        (),
-        {"check_gpu_idle": staticmethod(_idle)},
-    )
-    monkeypatch.setitem(
-        sys.modules,
-        "TraceLens.PerfModel.benchmarking.microbench_utils",
-        fake_mod,
-    )
+    monkeypatch.setattr(tab, "check_gpu_idle", _idle)
 
     selected = tab.select_idle_gpu()
     assert selected == 1
-    assert os.environ["CUDA_VISIBLE_DEVICES"] == "1"
+    assert os.environ["CUDA_VISIBLE_DEVICES"] == "0,1,2"
 
 
 def test_select_idle_gpu_reuses_single_idle_gpu(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    for var in tab.VISIBLE_DEVICE_VARS:
+    for var in _VISIBLE_DEVICE_VARS:
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3")
 
-    fake_mod = type(
-        "microbench_utils",
-        (),
-        {"check_gpu_idle": staticmethod(lambda *_a, **_k: (True, "idle"))},
-    )
-    monkeypatch.setitem(
-        sys.modules,
-        "TraceLens.PerfModel.benchmarking.microbench_utils",
-        fake_mod,
+    monkeypatch.setattr(
+        tab, "check_gpu_idle", lambda *_a, **_k: (True, "idle")
     )
 
     selected = tab.select_idle_gpu()
@@ -128,30 +92,23 @@ def test_select_idle_gpu_reuses_single_idle_gpu(
 
 
 def test_select_idle_gpu_raises_when_all_busy(monkeypatch: pytest.MonkeyPatch) -> None:
-    for var in tab.VISIBLE_DEVICE_VARS:
+    for var in _VISIBLE_DEVICE_VARS:
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1")
 
-    fake_mod = type(
-        "microbench_utils",
-        (),
-        {"check_gpu_idle": staticmethod(lambda *_a, **_k: (False, "busy"))},
-    )
-    monkeypatch.setitem(
-        sys.modules,
-        "TraceLens.PerfModel.benchmarking.microbench_utils",
-        fake_mod,
+    monkeypatch.setattr(
+        tab, "check_gpu_idle", lambda *_a, **_k: (False, "busy")
     )
 
     with pytest.raises(RuntimeError, match="no unoccupied GPU"):
         tab.select_idle_gpu()
 
 
-def test_ensure_gpu_arch_json_uses_bundled_spec(tmp_path: Path) -> None:
+def test_populate_gpu_arch_json_uses_bundled_spec(tmp_path: Path) -> None:
     bundled = tmp_path / "MI300X.json"
     bundled.write_text("{}", encoding="utf-8")
     with patch.object(tab, "resolve_arch_json_path", return_value=bundled):
-        path = tab.ensure_gpu_arch_json(
+        path = tab.populate_gpu_arch_json(
             tracelens_root=tmp_path,
             platform="MI300X",
             log=lambda _msg: None,
@@ -160,13 +117,16 @@ def test_ensure_gpu_arch_json_uses_bundled_spec(tmp_path: Path) -> None:
     assert path == bundled
 
 
-def test_ensure_gpu_arch_json_runs_microbench_when_missing(
+def test_populate_gpu_arch_json_runs_microbench_when_missing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls: list[list[str]] = []
+    captured_env: dict[str, str] | None = None
 
-    def _run_command(cmd, *, cwd, timeout_s):
+    def _run_command(cmd, *, cwd, timeout_s, env=None):
+        nonlocal captured_env
+        captured_env = env
         calls.append(cmd)
         out = Path(cmd[cmd.index("--output") + 1])
         out.parent.mkdir(parents=True, exist_ok=True)
@@ -181,7 +141,7 @@ def test_ensure_gpu_arch_json_runs_microbench_when_missing(
         "select_idle_gpu",
         return_value=2,
     ):
-        path = tab.ensure_gpu_arch_json(
+        path = tab.populate_gpu_arch_json(
             tracelens_root=tmp_path,
             platform="MI355X",
             log=lambda _msg: None,
@@ -201,3 +161,5 @@ def test_ensure_gpu_arch_json_runs_microbench_when_missing(
     assert calls[0][calls[0].index("--output") + 1].endswith(
         "TraceLens/Agent/Analysis/utils/arch/MI355X.json"
     )
+    assert captured_env is not None
+    assert captured_env["CUDA_VISIBLE_DEVICES"] == "2"

--- a/kernel-agent/tools/test_tracelens_arch_benchmark.py
+++ b/kernel-agent/tools/test_tracelens_arch_benchmark.py
@@ -1,0 +1,203 @@
+"""Unit tests for TraceLens arch JSON pre-report benchmarking."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+TOOLS_DIR = Path(__file__).resolve().parent
+if str(TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOLS_DIR))
+
+import tracelens_arch_benchmark as tab  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("MI355X", "MI355X"),
+        ("mi355x", "MI355X"),
+        ("  mi300x  ", "MI300X"),
+        ("", ""),
+    ],
+)
+def test_normalize_platform(raw: str, expected: str) -> None:
+    assert tab.normalize_platform(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("env", "device_count", "expected"),
+    [
+        ({"HIP_VISIBLE_DEVICES": "3"}, None, 1),
+        ({"CUDA_VISIBLE_DEVICES": "0,1"}, None, 2),
+        ({}, 4, 4),
+        ({}, 0, 0),
+    ],
+)
+def test_count_visible_gpus(
+    monkeypatch: pytest.MonkeyPatch,
+    env: dict[str, str],
+    device_count: int | None,
+    expected: int,
+) -> None:
+    for var in tab.VISIBLE_DEVICE_VARS:
+        monkeypatch.delenv(var, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    with patch.object(tab, "list_candidate_physical_gpus") as mock_list:
+        if env.get("HIP_VISIBLE_DEVICES") == "3":
+            mock_list.return_value = [3]
+        elif env.get("CUDA_VISIBLE_DEVICES") == "0,1":
+            mock_list.return_value = [0, 1]
+        elif device_count == 4:
+            mock_list.return_value = [0, 1, 2, 3]
+        else:
+            mock_list.return_value = []
+        assert tab.count_visible_gpus() == expected
+
+
+def test_list_candidate_physical_gpus_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in tab.VISIBLE_DEVICE_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "2,5")
+    assert tab.list_candidate_physical_gpus() == [2, 5]
+
+
+def test_pin_single_physical_gpu(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in tab.VISIBLE_DEVICE_VARS:
+        monkeypatch.delenv(var, raising=False)
+    tab.pin_single_physical_gpu(4)
+    assert os.environ["HIP_VISIBLE_DEVICES"] == "4"
+    assert os.environ["CUDA_VISIBLE_DEVICES"] == "4"
+    assert os.environ["ROCR_VISIBLE_DEVICES"] == "4"
+
+
+def test_select_idle_gpu_picks_first_free_from_many(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for var in tab.VISIBLE_DEVICE_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1,2")
+
+    def _idle(logical_idx: int, *, util_threshold: int = 5):
+        return logical_idx == 1, f"logical={logical_idx}"
+
+    fake_mod = type(
+        "microbench_utils",
+        (),
+        {"check_gpu_idle": staticmethod(_idle)},
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "TraceLens.PerfModel.benchmarking.microbench_utils",
+        fake_mod,
+    )
+
+    selected = tab.select_idle_gpu()
+    assert selected == 1
+    assert os.environ["CUDA_VISIBLE_DEVICES"] == "1"
+
+
+def test_select_idle_gpu_reuses_single_idle_gpu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for var in tab.VISIBLE_DEVICE_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3")
+
+    fake_mod = type(
+        "microbench_utils",
+        (),
+        {"check_gpu_idle": staticmethod(lambda *_a, **_k: (True, "idle"))},
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "TraceLens.PerfModel.benchmarking.microbench_utils",
+        fake_mod,
+    )
+
+    selected = tab.select_idle_gpu()
+    assert selected == 3
+    assert os.environ["CUDA_VISIBLE_DEVICES"] == "3"
+
+
+def test_select_idle_gpu_raises_when_all_busy(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in tab.VISIBLE_DEVICE_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1")
+
+    fake_mod = type(
+        "microbench_utils",
+        (),
+        {"check_gpu_idle": staticmethod(lambda *_a, **_k: (False, "busy"))},
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "TraceLens.PerfModel.benchmarking.microbench_utils",
+        fake_mod,
+    )
+
+    with pytest.raises(RuntimeError, match="no unoccupied GPU"):
+        tab.select_idle_gpu()
+
+
+def test_ensure_gpu_arch_json_uses_bundled_spec(tmp_path: Path) -> None:
+    bundled = tmp_path / "MI300X.json"
+    bundled.write_text("{}", encoding="utf-8")
+    with patch.object(tab, "resolve_arch_json_path", return_value=bundled):
+        path = tab.ensure_gpu_arch_json(
+            tracelens_root=tmp_path,
+            platform="MI300X",
+            log=lambda _msg: None,
+            run_command=lambda *_a, **_k: 0,
+        )
+    assert path == bundled
+
+
+def test_ensure_gpu_arch_json_runs_microbench_when_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+
+    def _run_command(cmd, *, cwd, timeout_s):
+        calls.append(cmd)
+        out = Path(cmd[cmd.index("--output") + 1])
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(
+            json.dumps({"name": "MI300X", "mem_bw_gbps": 5000, "memory_gb": 192}),
+            encoding="utf-8",
+        )
+        return 0
+
+    with patch.object(tab, "resolve_arch_json_path", return_value=None), patch.object(
+        tab,
+        "select_idle_gpu",
+        return_value=2,
+    ):
+        path = tab.ensure_gpu_arch_json(
+            tracelens_root=tmp_path,
+            platform="MI355X",
+            log=lambda _msg: None,
+            run_command=_run_command,
+            timeout_s=60,
+        )
+
+    assert path == tmp_path / "TraceLens/Agent/Analysis/utils/arch/MI355X.json"
+    assert path.is_file()
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["name"] == "MI355X"
+    assert "-m" in calls[0]
+    assert "TraceLens.PerfModel.benchmarking.microbench" in calls[0]
+    assert "--warmup" in calls[0] and "20" in calls[0]
+    assert "--rep" in calls[0] and "50" in calls[0]
+    assert "--allow-busy" in calls[0]
+    assert calls[0][calls[0].index("--output") + 1].endswith(
+        "TraceLens/Agent/Analysis/utils/arch/MI355X.json"
+    )

--- a/kernel-agent/tools/test_tracelens_arch_benchmark.py
+++ b/kernel-agent/tools/test_tracelens_arch_benchmark.py
@@ -160,7 +160,6 @@ def test_populate_gpu_arch_json_runs_microbench_when_missing(
     assert "TraceLens.PerfModel.benchmarking.microbench" in calls[0]
     assert "--warmup" in calls[0] and "20" in calls[0]
     assert "--rep" in calls[0] and "50" in calls[0]
-    assert "--allow-busy" in calls[0]
     assert calls[0][calls[0].index("--output") + 1].endswith(
         "TraceLens/Agent/Analysis/utils/arch/MI355X.json"
     )

--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -24,6 +24,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from tracelens_arch_benchmark import ensure_gpu_arch_json
 from tracelens_skill_runner import (
     aggregate_by_source_function,
     discover_capture_folder,
@@ -2821,6 +2822,38 @@ def main() -> int:
 
             tracelens_dir = run_dir / "tracelens"
             tracelens_dir.mkdir(parents=True, exist_ok=True)
+
+            update_status(
+                status_path,
+                state="running",
+                current_step="ensure_gpu_arch_json",
+                log_path=log_path,
+                artifact_paths=artifacts,
+                run_id=run_id,
+                started_at=started_at,
+            )
+            arch_benchmark_timeout_s = max(
+                600,
+                int(
+                    os.environ.get(
+                        "TRACELENS_ARCH_BENCHMARK_TIMEOUT_SEC",
+                        str(int(args.budget_minutes * 60 // 2)),
+                    )
+                ),
+            )
+            gpu_arch_path = ensure_gpu_arch_json(
+                tracelens_root=tl_root,
+                platform=args.target_platform,
+                log=lambda msg: append_log(log_path, msg),
+                run_command=lambda cmd, *, cwd, timeout_s: run_command(
+                    cmd,
+                    cwd=cwd,
+                    log_path=log_path,
+                    timeout_s=timeout_s,
+                ),
+                timeout_s=arch_benchmark_timeout_s,
+            )
+            artifacts["tracelens_gpu_arch_json"] = str(gpu_arch_path)
 
             # ---- #127: split inference trace into steady-state chunks ----
             # The filtered trace from vLLM/SGLang spans the full benchmark

--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import csv
 import functools
 import gzip
 import json
@@ -24,7 +25,24 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from tracelens_arch_benchmark import ensure_gpu_arch_json
+try:
+    from inference_optimizer.orchestrator.framework_paths import (
+        resolve_patch_target_roots as _resolve_patch_target_roots,
+    )
+except ImportError:
+    _resolve_patch_target_roots = None
+
+try:
+    from apply_kernel_patch import known_target_roots as _known_target_roots
+except ImportError:
+    _known_target_roots = None
+
+try:
+    import aiter.jit.core as _aiter_jit_core  # type: ignore[import-untyped]
+except Exception:
+    _aiter_jit_core = None
+
+from tracelens_arch_benchmark import populate_gpu_arch_json
 from tracelens_skill_runner import (
     aggregate_by_source_function,
     discover_capture_folder,
@@ -173,8 +191,6 @@ def _check_selected_chunk_has_gpu_events(
     fails here and the coordinator re-issues with
     ``INFERENCE_OPTIMIZER_STEADY_STATE_MODE=prefilldecode``.
     """
-    import csv
-
     details_path = split_dir / "execution_details.csv"
     if not details_path.is_file():
         # Splitter didn't emit the CSV (older TraceLens?) -- cannot
@@ -337,15 +353,13 @@ def _check_selected_chunk_has_gpu_events_quality(
 
     See module-level N36 comment for the empirical case + design.
     """
-    import csv as _csv
-
     details_path = split_dir / "execution_details.csv"
     if not details_path.is_file():
         return None
     try:
         with details_path.open("r", encoding="utf-8") as fh:
-            rows = list(_csv.DictReader(fh))
-    except (OSError, _csv.Error):
+            rows = list(csv.DictReader(fh))
+    except (OSError, csv.Error):
         return None
 
     def _row_for(chunk_path: "Path") -> "dict[str, str] | None":
@@ -757,15 +771,14 @@ def _framework_patch_roots() -> tuple[str, ...]:
     the case-insensitive match working.
     """
     try:
-        from inference_optimizer.orchestrator.framework_paths import (
-            resolve_patch_target_roots,
-        )
-
-        roots = resolve_patch_target_roots()
+        if _resolve_patch_target_roots is None:
+            raise ImportError
+        roots = _resolve_patch_target_roots()
     except ImportError:
-        from apply_kernel_patch import known_target_roots
-
-        roots = known_target_roots()
+        if _known_target_roots is None:
+            roots = []
+        else:
+            roots = _known_target_roots()
     out: list[str] = []
     seen: set[str] = set()
     for root in roots:
@@ -781,11 +794,9 @@ def _aiter_csrc_root() -> str:
     """aiter's own device-source root (e.g. ``.../aiter_meta/csrc/``),
     resolved from the installed package. Empty when aiter is not importable.
     Cached once per process."""
-    try:
-        import aiter.jit.core as _jc  # type: ignore
-    except Exception:
+    if _aiter_jit_core is None:
         return ""
-    raw = (getattr(_jc, "AITER_CSRC_DIR", "") or "").replace(os.sep, "/")
+    raw = (getattr(_aiter_jit_core, "AITER_CSRC_DIR", "") or "").replace(os.sep, "/")
     return (raw.rstrip("/") + "/") if raw else ""
 
 
@@ -1024,7 +1035,6 @@ def _candidate_keywords(name: str) -> list[str]:
         # Itanium ABI uses <len><name>; walk through and slice manually so
         # consecutive segments (e.g. 5aiter26cross_device_reduce_2stage...) are
         # parsed as separate identifiers.
-        import re
         tokens = []
         pos = 0
         while pos < len(cleaned):
@@ -1611,16 +1621,15 @@ def load_op_category_map(
     csv_path = Path(perf_report_csv_dir) / "unified_perf_summary.csv"
     if not csv_path.is_file():
         return {}
-    import csv as _csv
     out: dict[str, str] = {}
     try:
         with csv_path.open(newline="", encoding="utf-8") as f:
-            for row in _csv.DictReader(f):
+            for row in csv.DictReader(f):
                 name = str(row.get("name") or "").strip()
                 cat = str(row.get("op category") or "").strip()
                 if name and cat and name not in out:
                     out[name] = cat
-    except (OSError, _csv.Error):
+    except (OSError, csv.Error):
         return {}
     return out
 
@@ -1805,11 +1814,19 @@ def build_notes(candidate: dict[str, Any]) -> str:
     return f"resolved source: {candidate['source_file']}"
 
 
-def run_command(cmd: list[str], *, cwd: Path | None, log_path: Path, timeout_s: int) -> int:
+def run_command(
+    cmd: list[str],
+    *,
+    cwd: Path | None,
+    log_path: Path,
+    timeout_s: int,
+    env: dict[str, str] | None = None,
+) -> int:
     append_log(log_path, f"$ {' '.join(cmd)}")
     proc = subprocess.run(
         cmd,
         cwd=str(cwd) if cwd else None,
+        env=env,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
@@ -2826,7 +2843,7 @@ def main() -> int:
             update_status(
                 status_path,
                 state="running",
-                current_step="ensure_gpu_arch_json",
+                current_step="populate_gpu_arch_json",
                 log_path=log_path,
                 artifact_paths=artifacts,
                 run_id=run_id,
@@ -2841,15 +2858,16 @@ def main() -> int:
                     )
                 ),
             )
-            gpu_arch_path = ensure_gpu_arch_json(
+            gpu_arch_path = populate_gpu_arch_json(
                 tracelens_root=tl_root,
                 platform=args.target_platform,
                 log=lambda msg: append_log(log_path, msg),
-                run_command=lambda cmd, *, cwd, timeout_s: run_command(
+                run_command=lambda cmd, *, cwd, timeout_s, env=None: run_command(
                     cmd,
                     cwd=cwd,
                     log_path=log_path,
                     timeout_s=timeout_s,
+                    env=env,
                 ),
                 timeout_s=arch_benchmark_timeout_s,
             )

--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -2854,7 +2854,7 @@ def main() -> int:
                 int(
                     os.environ.get(
                         "TRACELENS_ARCH_BENCHMARK_TIMEOUT_SEC",
-                        str(int(args.budget_minutes * 60 // 2)),
+                        0,
                     )
                 ),
             )

--- a/kernel-agent/tools/tracelens_arch_benchmark.py
+++ b/kernel-agent/tools/tracelens_arch_benchmark.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Ensure TraceLens GPU arch JSON exists before running the TL report.
+
+When ``TraceLens/Agent/Analysis/utils/arch/<platform>.json`` (and any
+``TL_EXTENSION`` override) is missing, run the TraceLens GPU microbenchmark
+suite to produce a measured arch spec. Selects an unoccupied GPU (pinning it
+via ``HIP_VISIBLE_DEVICES`` / ``CUDA_VISIBLE_DEVICES`` when multiple are
+present) before launching the benchmark. The microbenchmark runs with
+``--warmup 20 --rep 50 --allow-busy``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Callable
+
+
+RunCommandFn = Callable[..., int]
+LogFn = Callable[[str], None]
+
+VISIBLE_DEVICE_VARS = (
+    "HIP_VISIBLE_DEVICES",
+    "CUDA_VISIBLE_DEVICES",
+    "ROCR_VISIBLE_DEVICES",
+)
+
+
+def normalize_platform(platform: str) -> str:
+    return (platform or "").strip().upper()
+
+
+def count_visible_gpus() -> int:
+    """Return the number of GPUs visible to this process."""
+    candidates = list_candidate_physical_gpus()
+    if candidates:
+        return len(candidates)
+    return 0
+
+
+def list_candidate_physical_gpus() -> list[int]:
+    """Return physical GPU ids currently visible to this process."""
+    for var in VISIBLE_DEVICE_VARS:
+        val = os.environ.get(var, "").strip()
+        if not val:
+            continue
+        parts = [part.strip() for part in val.split(",") if part.strip()]
+        if not parts:
+            continue
+        try:
+            return [int(part) for part in parts]
+        except ValueError:
+            return list(range(len(parts)))
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            return list(range(int(torch.cuda.device_count())))
+    except Exception:
+        pass
+    return []
+
+
+def pin_single_physical_gpu(physical_id: int) -> None:
+    """Expose exactly one physical GPU to downstream CUDA/HIP consumers."""
+    value = str(physical_id)
+    os.environ["HIP_VISIBLE_DEVICES"] = value
+    os.environ["CUDA_VISIBLE_DEVICES"] = value
+    os.environ["ROCR_VISIBLE_DEVICES"] = value
+
+
+def select_idle_gpu(*, log: LogFn | None = None, util_threshold: int = 5) -> int:
+    """Pick an unoccupied GPU and pin it as the only visible device."""
+    from TraceLens.PerfModel.benchmarking.microbench_utils import check_gpu_idle
+
+    candidates = list_candidate_physical_gpus()
+    if not candidates:
+        raise RuntimeError(
+            "gpu_arch_benchmark found no GPUs; cannot run arch microbenchmark"
+        )
+
+    busy_reports: list[str] = []
+    for logical_idx, physical_id in enumerate(candidates):
+        idle, msg = check_gpu_idle(logical_idx, util_threshold=util_threshold)
+        if idle:
+            pin_single_physical_gpu(physical_id)
+            if log is not None:
+                if len(candidates) == 1:
+                    log(f"gpu_arch_json: using idle GPU {physical_id} ({msg})")
+                else:
+                    log(
+                        "gpu_arch_json: selected idle GPU "
+                        f"{physical_id} from candidates {candidates} ({msg})"
+                    )
+            return physical_id
+        busy_reports.append(f"GPU {physical_id}: {msg}")
+
+    raise RuntimeError(
+        "gpu_arch_benchmark found no unoccupied GPU among "
+        f"{candidates}. {'; '.join(busy_reports)}"
+    )
+
+
+def resolve_arch_json_path(platform: str) -> Path | None:
+    """Return the bundled arch JSON path for ``platform``, if present."""
+    from TraceLens.Agent.Analysis.utils.arch_utils import _collect_arch_jsons
+
+    canonical = normalize_platform(platform)
+    if not canonical:
+        return None
+    for name, path in _collect_arch_jsons().items():
+        if name.upper() == canonical:
+            return Path(path)
+    return None
+
+
+def default_arch_output_path(tracelens_root: Path, platform: str) -> Path:
+    canonical = normalize_platform(platform)
+    return (
+        tracelens_root
+        / "TraceLens/Agent/Analysis/utils/arch"
+        / f"{canonical}.json"
+    )
+
+
+MICROBENCH_WARMUP = 20
+MICROBENCH_REP = 50
+
+
+def ensure_gpu_arch_json(
+    *,
+    tracelens_root: Path,
+    platform: str,
+    log: LogFn,
+    run_command: RunCommandFn,
+    timeout_s: int = 3600,
+    device: int = 0,
+) -> Path:
+    """Return arch JSON path, running the microbenchmark when bundled spec is missing."""
+    existing = resolve_arch_json_path(platform)
+    if existing is not None and existing.is_file():
+        log(f"gpu_arch_json: using bundled spec {existing}")
+        return existing
+
+    canonical = normalize_platform(platform)
+    if not canonical:
+        raise RuntimeError(
+            "target platform is empty; cannot resolve or generate gpu arch JSON"
+        )
+
+    out_path = default_arch_output_path(tracelens_root, canonical)
+    log(
+        "gpu_arch_json: no bundled spec for "
+        f"{canonical}; running TraceLens microbenchmark -> {out_path}"
+    )
+
+    select_idle_gpu(log=log)
+
+    rc = run_command(
+        [
+            sys.executable,
+            "-m",
+            "TraceLens.PerfModel.benchmarking.microbench",
+            "--device",
+            str(device),
+            "--warmup",
+            str(MICROBENCH_WARMUP),
+            "--rep",
+            str(MICROBENCH_REP),
+            "--allow-busy",
+            "--output",
+            str(out_path),
+        ],
+        cwd=tracelens_root,
+        timeout_s=timeout_s,
+    )
+    if rc != 0:
+        raise RuntimeError(
+            f"gpu arch microbenchmark failed with exit code {rc}; see log for details"
+        )
+    if not out_path.is_file():
+        raise RuntimeError(
+            f"gpu arch microbenchmark finished but output is missing: {out_path}"
+        )
+
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    if payload.get("name") != canonical:
+        payload["name"] = canonical
+        out_path.write_text(json.dumps(payload, indent=4) + "\n", encoding="utf-8")
+        log(f"gpu_arch_json: patched name field -> {canonical}")
+
+    log(f"gpu_arch_json: measured spec ready at {out_path}")
+    return out_path

--- a/kernel-agent/tools/tracelens_arch_benchmark.py
+++ b/kernel-agent/tools/tracelens_arch_benchmark.py
@@ -6,7 +6,7 @@ When ``TraceLens/Agent/Analysis/utils/arch/<platform>.json`` (and any
 suite to produce a measured arch spec. Selects an unoccupied GPU and passes
 ``HIP_VISIBLE_DEVICES`` / ``CUDA_VISIBLE_DEVICES`` / ``ROCR_VISIBLE_DEVICES``
 only to the microbenchmark subprocess. The microbenchmark runs with
-``--warmup 20 --rep 50 --allow-busy``.
+``--warmup 20 --rep 50``.
 """
 
 from __future__ import annotations
@@ -175,7 +175,6 @@ def populate_gpu_arch_json(
             str(MICROBENCH_WARMUP),
             "--rep",
             str(MICROBENCH_REP),
-            "--allow-busy",
             "--output",
             str(out_path),
         ],

--- a/kernel-agent/tools/tracelens_arch_benchmark.py
+++ b/kernel-agent/tools/tracelens_arch_benchmark.py
@@ -32,6 +32,9 @@ try:
 except ImportError:
     check_gpu_idle = None  # type: ignore[assignment,misc]
 
+MICROBENCH_WARMUP = 20
+MICROBENCH_REP = 50
+
 _VISIBLE_DEVICE_VARS = (
     "HIP_VISIBLE_DEVICES",
     "CUDA_VISIBLE_DEVICES",
@@ -131,11 +134,6 @@ def default_arch_output_path(tracelens_root: Path, platform: str) -> Path:
         / "TraceLens/Agent/Analysis/utils/arch"
         / f"{canonical}.json"
     )
-
-
-MICROBENCH_WARMUP = 20
-MICROBENCH_REP = 50
-
 
 def populate_gpu_arch_json(
     *,

--- a/kernel-agent/tools/tracelens_arch_benchmark.py
+++ b/kernel-agent/tools/tracelens_arch_benchmark.py
@@ -3,9 +3,9 @@
 
 When ``TraceLens/Agent/Analysis/utils/arch/<platform>.json`` (and any
 ``TL_EXTENSION`` override) is missing, run the TraceLens GPU microbenchmark
-suite to produce a measured arch spec. Selects an unoccupied GPU (pinning it
-via ``HIP_VISIBLE_DEVICES`` / ``CUDA_VISIBLE_DEVICES`` when multiple are
-present) before launching the benchmark. The microbenchmark runs with
+suite to produce a measured arch spec. Selects an unoccupied GPU and passes
+``HIP_VISIBLE_DEVICES`` / ``CUDA_VISIBLE_DEVICES`` / ``ROCR_VISIBLE_DEVICES``
+only to the microbenchmark subprocess. The microbenchmark runs with
 ``--warmup 20 --rep 50 --allow-busy``.
 """
 
@@ -17,11 +17,22 @@ import sys
 from pathlib import Path
 from typing import Callable
 
+try:
+    import torch
+except ImportError:
+    torch = None  # type: ignore[assignment,misc]
 
-RunCommandFn = Callable[..., int]
-LogFn = Callable[[str], None]
+try:
+    from TraceLens.Agent.Analysis.utils.arch_utils import _collect_arch_jsons
+except ImportError:
+    _collect_arch_jsons = None  # type: ignore[assignment,misc]
 
-VISIBLE_DEVICE_VARS = (
+try:
+    from TraceLens.PerfModel.benchmarking.microbench_utils import check_gpu_idle
+except ImportError:
+    check_gpu_idle = None  # type: ignore[assignment,misc]
+
+_VISIBLE_DEVICE_VARS = (
     "HIP_VISIBLE_DEVICES",
     "CUDA_VISIBLE_DEVICES",
     "ROCR_VISIBLE_DEVICES",
@@ -32,17 +43,9 @@ def normalize_platform(platform: str) -> str:
     return (platform or "").strip().upper()
 
 
-def count_visible_gpus() -> int:
-    """Return the number of GPUs visible to this process."""
-    candidates = list_candidate_physical_gpus()
-    if candidates:
-        return len(candidates)
-    return 0
-
-
 def list_candidate_physical_gpus() -> list[int]:
     """Return physical GPU ids currently visible to this process."""
-    for var in VISIBLE_DEVICE_VARS:
+    for var in _VISIBLE_DEVICE_VARS:
         val = os.environ.get(var, "").strip()
         if not val:
             continue
@@ -53,27 +56,32 @@ def list_candidate_physical_gpus() -> list[int]:
             return [int(part) for part in parts]
         except ValueError:
             return list(range(len(parts)))
-    try:
-        import torch
-
-        if torch.cuda.is_available():
-            return list(range(int(torch.cuda.device_count())))
-    except Exception:
-        pass
+    if torch is not None:
+        try:
+            if torch.cuda.is_available():
+                return list(range(int(torch.cuda.device_count())))
+        except Exception:
+            pass
     return []
 
 
-def pin_single_physical_gpu(physical_id: int) -> None:
-    """Expose exactly one physical GPU to downstream CUDA/HIP consumers."""
+def single_physical_gpu_env(
+    physical_id: int, *, base_env: dict[str, str] | None = None
+) -> dict[str, str]:
+    """Return a subprocess env that exposes exactly one physical GPU."""
+    env = dict(base_env if base_env is not None else os.environ)
     value = str(physical_id)
-    os.environ["HIP_VISIBLE_DEVICES"] = value
-    os.environ["CUDA_VISIBLE_DEVICES"] = value
-    os.environ["ROCR_VISIBLE_DEVICES"] = value
+    for var in _VISIBLE_DEVICE_VARS:
+        env[var] = value
+    return env
 
 
-def select_idle_gpu(*, log: LogFn | None = None, util_threshold: int = 5) -> int:
-    """Pick an unoccupied GPU and pin it as the only visible device."""
-    from TraceLens.PerfModel.benchmarking.microbench_utils import check_gpu_idle
+def select_idle_gpu(
+    *, log: Callable[[str], None] | None = None, util_threshold: int = 5
+) -> int:
+    """Pick an unoccupied GPU for the arch microbenchmark subprocess."""
+    if check_gpu_idle is None:
+        raise RuntimeError("TraceLens is not installed; cannot check GPU idle state")
 
     candidates = list_candidate_physical_gpus()
     if not candidates:
@@ -85,7 +93,6 @@ def select_idle_gpu(*, log: LogFn | None = None, util_threshold: int = 5) -> int
     for logical_idx, physical_id in enumerate(candidates):
         idle, msg = check_gpu_idle(logical_idx, util_threshold=util_threshold)
         if idle:
-            pin_single_physical_gpu(physical_id)
             if log is not None:
                 if len(candidates) == 1:
                     log(f"gpu_arch_json: using idle GPU {physical_id} ({msg})")
@@ -105,7 +112,8 @@ def select_idle_gpu(*, log: LogFn | None = None, util_threshold: int = 5) -> int
 
 def resolve_arch_json_path(platform: str) -> Path | None:
     """Return the bundled arch JSON path for ``platform``, if present."""
-    from TraceLens.Agent.Analysis.utils.arch_utils import _collect_arch_jsons
+    if _collect_arch_jsons is None:
+        return None
 
     canonical = normalize_platform(platform)
     if not canonical:
@@ -129,12 +137,12 @@ MICROBENCH_WARMUP = 20
 MICROBENCH_REP = 50
 
 
-def ensure_gpu_arch_json(
+def populate_gpu_arch_json(
     *,
     tracelens_root: Path,
     platform: str,
-    log: LogFn,
-    run_command: RunCommandFn,
+    log: Callable[[str], None],
+    run_command: Callable[..., int],
     timeout_s: int = 3600,
     device: int = 0,
 ) -> Path:
@@ -156,7 +164,7 @@ def ensure_gpu_arch_json(
         f"{canonical}; running TraceLens microbenchmark -> {out_path}"
     )
 
-    select_idle_gpu(log=log)
+    physical_id = select_idle_gpu(log=log)
 
     rc = run_command(
         [
@@ -175,6 +183,7 @@ def ensure_gpu_arch_json(
         ],
         cwd=tracelens_root,
         timeout_s=timeout_s,
+        env=single_physical_gpu_env(physical_id),
     )
     if rc != 0:
         raise RuntimeError(

--- a/kernel-agent/tools/tracelens_arch_benchmark.py
+++ b/kernel-agent/tools/tracelens_arch_benchmark.py
@@ -63,8 +63,11 @@ def list_candidate_physical_gpus() -> list[int]:
         try:
             if torch.cuda.is_available():
                 return list(range(int(torch.cuda.device_count())))
-        except Exception:
-            pass
+        except Exception as exc:
+            print(
+                f"[tracelens_arch_benchmark] Failed to query CUDA devices via torch: {exc}",
+                file=sys.stderr,
+            )
     return []
 
 


### PR DESCRIPTION
# PR #491 — Auto-generate TraceLens GPU arch JSON via microbenchmark

## Summary

TraceLens roofline analysis needs a per-GPU architecture spec (`TraceLens/Agent/Analysis/utils/arch/<platform>.json`). Today that file must already exist (bundled with TraceLens or checked in); if it's missing for a platform like MI355X, the kernel-agent TraceLens pipeline does not produce roofline metrics.

This PR adds an automatic **pre-report GPU arch benchmark** step to `tracelens_analysis.py`:

- **New module** `tracelens_arch_benchmark.py` resolves the bundled arch JSON for `--target-platform` when present.
- **When missing**, it runs `TraceLens.PerfModel.benchmarking.microbench` to measure and write the spec before trace splitting / report generation.
- **GPU selection** picks an idle visible GPU via TraceLens `check_gpu_idle`, then pins `HIP_VISIBLE_DEVICES` / `CUDA_VISIBLE_DEVICES` / `ROCR_VISIBLE_DEVICES` **only in the microbenchmark subprocess** (parent process env unchanged).
- **Microbenchmark settings**: `--warmup 20 --rep 50`.
- **Timeout** is configurable via `TRACELENS_ARCH_BENCHMARK_TIMEOUT_SEC` (minimum 600s).
- The resolved path is recorded as artifact `tracelens_gpu_arch_json`.

Supporting changes in `tracelens_analysis.py`:

- Calls `populate_gpu_arch_json` as a new pipeline step (`populate_gpu_arch_json`) before trace splitting.
- Extends `run_command()` with an optional `env=` argument for subprocess-scoped GPU pinning.
- Hoists lazy imports (`csv`, `aiter`, framework patch roots) to module top level for clarity.

Unit tests in `test_tracelens_arch_benchmark.py` cover platform normalization, GPU candidate discovery, idle-GPU selection, bundled-spec short-circuit, and microbenchmark invocation when the spec is missing.

## Test plan

- [ ] `pytest kernel-agent/tools/test_tracelens_arch_benchmark.py`
- [ ] Run `tracelens_analysis.py` with a platform that has a **bundled** arch JSON (e.g. MI300X) — confirm log shows `using bundled spec` and no microbenchmark runs
- [ ] Run with a platform **without** bundled spec (e.g. MI355X) on a node with a free GPU with ONLY open source TraceLens (no Tracelens-internal) — confirm microbenchmark runs, writes `arch/<platform>.json`, and pipeline continues to trace split/report
- [ ] Run when all visible GPUs are busy — confirm clear `no unoccupied GPU` error
- [ ] Verify `TRACELENS_ARCH_BENCHMARK_TIMEOUT_SEC` is honored and status JSON shows step `populate_gpu_arch_json`
