### PR TITLE
docs: add Primus-SaFE access instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Block 5-6 - Validated Delivery: The agent optimizes for throughput while maintai
 | **[How the Optimization Loop Works](docs/HOW_THE_OPTIMIZATION_LOOP_WORKS.md)** | Scoring heuristics, stack mechanics, dynamic branching, and the self-evolving knowledge base |
 | **[GLM-5 — Discovering Optimizations Hard to Spot Manually](docs/CASE_STUDY_GLM5.md)** | Hidden GEMM configs, cross-repo kernel patches, +193% throughput |
 | **[DeepSeek-R1 — Fast Scale-Up on a New Workload](docs/CASE_STUDY_DEEPSEEK_R1.md)** | 7 configs to optimal in one session, MTP scheduling fix, +97% over B200 |
+| **[Requesting Access](docs/REQUESTING_ACCESS.md)** | Primus-SaFE access request, provisioning, and AMD SSO sign-in flow for Hyperloom |
 | **[Auth & Environment Guide](docs/ENV_AND_AUTH.md)** | Single authoritative auth/env reference; the inline tables in this README are a convenience excerpt |
 | **[Configuration Reference](docs/CONFIGURATION_REFERENCE.md)** | Every environment variable read by the runtime |
 | **[Knowledge-Base Guide](docs/KB_GUIDE.md)** | How to obtain or skip `INFERENCE_OPTIMIZER_KB_ROOT` |
@@ -26,6 +27,25 @@ Block 5-6 - Validated Delivery: The agent optimizes for throughput while maintai
 | **[Operations & Self-Host Runbook](docs/OPERATIONS.md)** | k8s sizing, `USER_DATA_PATH` backup, disaster recovery |
 | **[Troubleshooting](docs/TROUBLESHOOTING.md)** | Auth-proxy 401, Ray `--num-gpus`, VRAM IR-1, and other recurring failures |
 | **[Upgrading](docs/UPGRADING.md)** | Per-version migration steps (companion to [`CHANGELOG.md`](CHANGELOG.md)) |
+
+---
+
+## Requesting Access (Hyperloom Web UI)
+
+Before using the hosted [Hyperloom UI](https://core42.primus-safe.amd.com/hyperloom/),
+request access to the Primus-SaFE cluster you plan to use. The same flow applies
+to the Core42 and TensorWeave (TW) clusters: submit an AISE access request, wait
+for administrator provisioning and account sync, then sign in with AMD SSO.
+
+<!-- Screenshot placeholder: add the access request screenshot at slides/primus_safe_access_request.png, then replace this paragraph with:
+<p align="center"><img width="500" alt="Primus-SaFE access request form" src="slides/primus_safe_access_request.png" /></p>
+-->
+
+_Screenshot: Primus-SaFE access request form (to be added)._
+
+For the full step-by-step flow, including cluster URLs and what to include in
+the access request, see [Requesting Access](docs/REQUESTING_ACCESS.md). Internal
+reference: [TensorWeave MI325 cluster with Primus-SaFE](https://amd.atlassian.net/wiki/spaces/~712020ea4fade82ae94a95b7c0ba1cb554d2a8/pages/1178771460/TensorWeave+MI325+cluster+with+Primus-SaFE).
 
 ---
 

--- a/docs/REQUESTING_ACCESS.md
+++ b/docs/REQUESTING_ACCESS.md
@@ -1,0 +1,64 @@
+# Requesting Access to the Hyperloom Web UI
+
+The hosted Hyperloom web UI runs on Primus-SaFE. AMD users and approved
+partners need Primus-SaFE access before they can open the Hyperloom UI, bind an
+LLM Gateway key, or launch hosted optimization jobs.
+
+The same access-request flow applies to the Core42 and TensorWeave (TW)
+Primus-SaFE clusters:
+
+| Cluster | URL |
+|---|---|
+| Core42 | [https://core42.primus-safe.amd.com/](https://core42.primus-safe.amd.com/) |
+| TensorWeave (TW) | [https://tw325.primus-safe.amd.com/login](https://tw325.primus-safe.amd.com/login) |
+
+## 1. Submit an access request
+
+Open the [AISE access request form](https://amd-hub.atlassian.net/jira/software/c/projects/AISE/form/35?isEligibleForUserSurvey=true)
+and fill in:
+
+- **Issue Sub-Type:** `Access Issue`
+- **Components:** `Operations`
+- **Description:** include the AMD NTID(s) that need access
+
+<!-- Screenshot placeholder: add the access request form screenshot at slides/primus_safe_access_request.png, then replace this paragraph with:
+<p align="center"><img width="600" alt="Primus-SaFE access request form" src="../slides/primus_safe_access_request.png" /></p>
+-->
+
+_Screenshot: Primus-SaFE access request form (to be added)._
+
+## 2. Wait for provisioning and account sync
+
+After the request is submitted, an administrator adds the requested account(s)
+to the cluster. Once the account is added, allow about 15 minutes for access to
+synchronize before trying to sign in.
+
+## 3. Sign in with AMD SSO
+
+Open the cluster URL and choose **Continue with AMD**:
+
+- Core42: [https://core42.primus-safe.amd.com/](https://core42.primus-safe.amd.com/)
+- TensorWeave (TW): [https://tw325.primus-safe.amd.com/login](https://tw325.primus-safe.amd.com/login)
+
+<!-- Screenshot placeholder: add the AMD SSO login screenshot at slides/primus_safe_sso_login.png, then replace this paragraph with:
+<p align="center"><img width="600" alt="Primus-SaFE AMD SSO login" src="../slides/primus_safe_sso_login.png" /></p>
+-->
+
+_Screenshot: Primus-SaFE AMD SSO login (to be added)._
+
+## Next step: bind your LLM Gateway key
+
+After you can sign in to Primus-SaFE, bind your
+[LLM Gateway](https://llm.amd.com/) key to
+[Hyperloom](https://core42.primus-safe.amd.com/hyperloom/) to obtain your
+`AK_YOUR_API_KEY`. That key is required for both the hosted Hyperloom UI and the
+local optimization workflow.
+
+See the root [README](../README.md#prerequisites) and the
+[Authentication & Environment Guide](ENV_AND_AUTH.md) for the credential setup
+that follows access provisioning.
+
+## Reference
+
+This flow mirrors the internal Confluence guidance for
+[TensorWeave MI325 cluster with Primus-SaFE](https://amd.atlassian.net/wiki/spaces/~712020ea4fade82ae94a95b7c0ba1cb554d2a8/pages/1178771460/TensorWeave+MI325+cluster+with+Primus-SaFE).


### PR DESCRIPTION
- Description: Adds Primus-SaFE access-request instructions for the hosted Hyperloom UI, covering the AISE request form, provisioning/sync timing, and AMD SSO sign-in for Core42 and TensorWeave (TW). Includes README guidance plus a dedicated access doc with screenshot placeholders.
- Linked issue(s): Refs #472. The issue is currently closed; Andrew will reopen it separately.
- Tests: ReadLints on README.md and docs/REQUESTING_ACCESS.md; reviewed git diff. No runtime tests run because this is documentation-only.
- Breaking changes: No.

Made with [Cursor](https://cursor.com)