### PR TITLE
fix(gpu): add MI308X detection and runner mapping (#376)

### DIFF
--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -183,9 +183,13 @@ _GFX_TO_RUNNER: dict[str, str] = {
 
 
 def _gpu_runner_type(gpu_type: str) -> str:
-    """Return the Magpie runner label for a resolved real GPU type."""
+    """Return the Magpie runner label for a resolved real GPU type.
+
+    MI308X and MI325X share the gfx942 / CDNA3 die with MI300X and reuse
+    the same Magpie benchmark scripts (sglang_mi300x.sh / vllm_mi300x.sh).
+    """
     normalized = str(gpu_type or "").strip().lower()
-    if normalized == "mi325x":
+    if normalized in ("mi325x", "mi308x"):
         return "mi300x"
     return normalized
 
@@ -476,14 +480,14 @@ def _clean_stale_aiter_locks(
 
 
 def _autodetect_gpu_type() -> str | None:
-    """Return mi300x|mi325x|mi355x or None if undetectable (rocm-smi then torch gcnArchName, best-effort)."""
+    """Return mi300x|mi308x|mi325x|mi355x or None if undetectable (rocm-smi then torch gcnArchName, best-effort)."""
     import subprocess
     try:
         out = subprocess.run(
             ["rocm-smi", "--showproductname"],
             capture_output=True, text=True, timeout=5,
         ).stdout.upper()
-        for tag in ("MI355X", "MI325X", "MI300X"):
+        for tag in ("MI355X", "MI325X", "MI308X", "MI300X"):
             if tag in out:
                 return tag.lower()
     except (FileNotFoundError, subprocess.TimeoutExpired, PermissionError, OSError):
@@ -3235,8 +3239,9 @@ async def _run_optimize(args: argparse.Namespace) -> int:
         runner_gpu_type = _gpu_runner_type(gpu_type)
         if gpu_type and runner_gpu_type != gpu_type:
             print(
-                "WARN: mi325x uses mi300x as Magpie runner_type (same arch; "
-                "Magpie has no sglang_mi325x.sh / vllm_mi325x.sh yet)",
+                f"WARN: {gpu_type} uses {runner_gpu_type} as Magpie "
+                f"runner_type (same gfx942/CDNA3 arch; Magpie has no "
+                f"sglang_{gpu_type}.sh / vllm_{gpu_type}.sh yet)",
                 file=sys.stderr,
             )
         args.gpu_type = gpu_type or None

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -3712,7 +3712,7 @@ def _build_parser() -> argparse.ArgumentParser:
              "quantization. Ignored if --quantize (free text) is also given.",
     )
     opt.add_argument(
-        "--gpu-type", choices=["mi300x", "mi325x", "mi355x"], default=None,
+        "--gpu-type", choices=["mi300x", "mi308x", "mi325x", "mi355x"], default=None,
         help="Hint for the real target GPU. The rocm-smi probe always "
              "wins when both are present and disagree; a WARN is "
              "emitted to stderr so the operator sees the typo. Used "

--- a/inference_optimizer/orchestrator/roofline_ceiling.py
+++ b/inference_optimizer/orchestrator/roofline_ceiling.py
@@ -37,6 +37,10 @@ HW_SPECS: dict[str, dict[str, Any]] = {
         "hbm_gb": 192.0, "hbm_bw_gbps": 5300.0,
         "peak_tflops": _MI300X_PEAK_TFLOPS,
     },
+    "mi308x": {
+        "hbm_gb": 192.0, "hbm_bw_gbps": 5300.0,
+        "peak_tflops": _MI300X_PEAK_TFLOPS,
+    },
     "mi325x": {
         "hbm_gb": 256.0, "hbm_bw_gbps": 6000.0,
         "peak_tflops": _MI300X_PEAK_TFLOPS,

--- a/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -92,6 +92,41 @@ def test_mi325x_keeps_real_gpu_type_but_uses_mi300x_runner(tmp_path, monkeypatch
     assert os.environ["GPU_TYPE"] == "mi300x"
 
 
+def test_mi308x_keeps_real_gpu_type_but_uses_mi300x_runner(tmp_path, monkeypatch):
+    monkeypatch.setenv("FRAMEWORK", "sglang")
+    monkeypatch.setenv("GPU_TYPE", "mi300x")
+    monkeypatch.setenv("TARGET_GPU_TYPE", "mi308x")
+    args = SimpleNamespace(
+        model="/models/Qwen3",
+        model_class="",
+        target_summary="",
+        max_hours=1,
+        no_kernel=False,
+        gpu_type="mi308x",
+        target_gain=None,
+        target_tput=None,
+    )
+
+    assert optimizer_cli._gpu_runner_type("mi308x") == "mi300x"
+    manifest = build_manifest(tmp_path, args=args, session_id="mi308x-session")
+    state = optimizer_cli._seed_shared_state(
+        tmp_path, args, session_id="mi308x-session",
+    )
+
+    assert manifest["gpu_type"] == "mi308x"
+    assert state.gpu_type == "mi308x"
+    assert os.environ["TARGET_GPU_TYPE"] == "mi308x"
+    assert os.environ["GPU_TYPE"] == "mi300x"
+
+
+def test_cli_parser_accepts_mi308x():
+    parser = optimizer_cli._build_parser()
+    args = parser.parse_args([
+        "optimize", "--model", "/tmp/model", "--gpu-type", "mi308x",
+    ])
+    assert args.gpu_type == "mi308x"
+
+
 @pytest.fixture(autouse=True)
 def _isolate_leak_root(tmp_path_factory, monkeypatch):
     """Pin ``INFERENCE_OPTIMIZER_LEAK_ROOTS`` to an empty sandbox so the artifact harvest doesn't pick up the host's ``/workspace``."""

--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -465,6 +465,14 @@ _GPU_HW: dict[str, dict[str, Any]] = {
         "mem": "HBM3 (~5.3 TB/s peak), 256 MB Infinity Cache",
         "build_flag": "--offload-arch=gfx942",
     },
+    "mi308x": {
+        "name": "MI308X",
+        "arch": "gfx942",
+        "uarch": "CDNA3",
+        "cus": 304,
+        "mem": "HBM3 (~5.3 TB/s peak), 256 MB Infinity Cache",
+        "build_flag": "--offload-arch=gfx942",
+    },
     "mi325x": {
         "name": "MI325X",
         "arch": "gfx942",

--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -1792,6 +1792,7 @@ def load_model_kernel_params(model_name: str) -> dict[str, Any]:
 
 _FLYDSL_TARGET_ARCH_BY_PLATFORM = {
     "mi300x": "gfx942",
+    "mi308x": "gfx942",
     "mi325x": "gfx942",
     "mi355x": "gfx950",
 }


### PR DESCRIPTION
## Summary

Fixes #376 — MI308X (gfx942/CDNA3) was not recognized by `_autodetect_gpu_type()`, causing the profiler to produce no `.trace.json.gz` and blocking the kernel optimization pipeline.

### Root Cause

`_autodetect_gpu_type()` only checked for `MI355X`, `MI325X`, `MI300X` in `rocm-smi` output — MI308X was missing. When the torch GFX fallback also failed, the raw `mi308x` string was passed through as Magpie `runner_type`, but no `sglang_mi308x.sh` script exists.

### Changes

- **`cli.py`**: Add MI308X to rocm-smi detection list; map `mi308x → mi300x` in `_gpu_runner_type()` (same gfx942/CDNA3 die)
- **`roofline_ceiling.py`**: Add `mi308x` to `HW_SPECS` (192 GB HBM3, 5.3 TB/s, same compute as MI300X)
- **`kernel_optimization.py`**: Add `mi308x` to `_GPU_HW` table
- **`tracelens_analysis.py`**: Add `mi308x → gfx942` to `_FLYDSL_TARGET_ARCH_BY_PLATFORM`

## Test Plan

- [x] Existing 26 tests pass (test_startup_robustness, test_profile_and_kernel_handlers, test_roofline_ceiling)
- [x] Mock-verified: MI308X rocm-smi detection returns `mi308x`
- [x] Mock-verified: `_gpu_runner_type('mi308x')` returns `mi300x`
- [ ] Needs on-hardware validation on actual MI308X node

Closes #376