### PR TITLE
fix(cli): force line-buffered stdout/stderr to prevent log freeze (#468)

### DIFF
--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -5270,6 +5270,17 @@ def main(argv: list[str] | None = None) -> int:
         int: The process exit code (``optimize`` result, or ``2`` for no/unknown
         command).
     """
+    # Force line-buffering so output piped through `tee` (or any
+    # non-TTY sink) flushes every line immediately instead of
+    # block-buffering ~8 KB.  Without this the top-level log appears
+    # frozen for the entire duration of a Magpie subprocess (~30-60 min)
+    # because no new print() calls happen while communicate() blocks.
+    # See #468.
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(line_buffering=True)
+    if hasattr(sys.stderr, "reconfigure"):
+        sys.stderr.reconfigure(line_buffering=True)
+
     parser = _build_parser()
     args = parser.parse_args(argv)
     level = logging.WARNING - 10 * min(args.verbose, 2)

--- a/inference_optimizer/orchestrator/action_executors/_subprocess_kill.py
+++ b/inference_optimizer/orchestrator/action_executors/_subprocess_kill.py
@@ -18,6 +18,8 @@ import logging
 import os
 import signal
 import subprocess
+import sys
+import threading
 import time
 
 log = logging.getLogger(__name__)
@@ -188,6 +190,69 @@ _SERVER_DEAD_MARKERS: tuple[str, ...] = (
 # ``INFERENCE_OPTIMIZER_SERVER_DEAD_GRACE_SEC``.
 _SERVER_DEAD_GRACE_SEC_DEFAULT: float = 120.0
 
+
+class _StreamCapture:
+    """Capture child output while mirroring each line to the parent stream."""
+
+    def __init__(self, proc: subprocess.Popen, *, text: bool) -> None:
+        self._text = text
+        self._stdout_chunks: list[str | bytes] = []
+        self._stderr_chunks: list[str | bytes] = []
+        self._threads: list[threading.Thread] = []
+        if proc.stdout is not None:
+            self._threads.append(threading.Thread(
+                target=self._pump,
+                args=(proc.stdout, self._stdout_chunks, sys.stdout),
+                daemon=True,
+            ))
+        if proc.stderr is not None:
+            self._threads.append(threading.Thread(
+                target=self._pump,
+                args=(proc.stderr, self._stderr_chunks, sys.stderr),
+                daemon=True,
+            ))
+
+    def start(self) -> None:
+        for thread in self._threads:
+            thread.start()
+
+    def finish(self, timeout: float = 2.0) -> tuple[str | bytes, str | bytes]:
+        for thread in self._threads:
+            thread.join(timeout=timeout)
+        empty: str | bytes = "" if self._text else b""
+        return (
+            self._join(self._stdout_chunks) if self._stdout_chunks else empty,
+            self._join(self._stderr_chunks) if self._stderr_chunks else empty,
+        )
+
+    def _join(self, chunks: list[str | bytes]) -> str | bytes:
+        return "".join(chunks) if self._text else b"".join(chunks)  # type: ignore[arg-type,return-value]
+
+    def _pump(self, pipe, chunks: list[str | bytes], mirror) -> None:
+        try:
+            while True:
+                chunk = pipe.readline()
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                self._mirror(chunk, mirror)
+        finally:
+            try:
+                pipe.close()
+            except Exception:  # noqa: BLE001 - best-effort close
+                pass
+
+    def _mirror(self, chunk: str | bytes, mirror) -> None:
+        try:
+            if isinstance(chunk, bytes):
+                stream = getattr(mirror, "buffer", mirror)
+                stream.write(chunk)
+            else:
+                mirror.write(chunk)
+            mirror.flush()
+        except Exception:  # noqa: BLE001 - logging must not break subprocess
+            pass
+
 # Bytes read from the tail of ``server.log`` per scan (markers always land near
 # the end of the bootstrap traceback).
 _SERVER_LOG_TAIL_BYTES: int = 65536
@@ -257,6 +322,7 @@ def run_with_session_kill(
         except (TypeError, ValueError):
             server_dead_grace_sec = _SERVER_DEAD_GRACE_SEC_DEFAULT
     proc: subprocess.Popen | None = None
+    capture: _StreamCapture | None = None
     try:
         proc = subprocess.Popen(  # noqa: S603 — cmd is caller's responsibility
             cmd,
@@ -267,6 +333,8 @@ def run_with_session_kill(
             cwd=cwd,
             **new_session_kwargs(),
         )
+        capture = _StreamCapture(proc, text=text)
+        capture.start()
         try:
             stdout, stderr = _communicate_with_soft_deadline(
                 proc,
@@ -274,22 +342,21 @@ def run_with_session_kill(
                 soft_deadline_sec=soft_deadline_sec,
                 server_log_path=server_log_path,
                 server_dead_grace_sec=server_dead_grace_sec,
+                capture=capture,
             )
         except subprocess.TimeoutExpired:
             # Reap before re-raising so the caller doesn't see a running tree.
             kill_my_spawned_server(proc)
-            try:
-                # Drain the pipes so the exception carries partial output.
-                stdout, stderr = proc.communicate(timeout=2.0)
-            except subprocess.TimeoutExpired:
-                pass
+            if capture is not None:
+                capture.finish(timeout=2.0)
             raise
         except _ServerDeadDetected as exc:
             kill_my_spawned_server(proc)
-            try:
-                stdout, stderr = proc.communicate(timeout=2.0)
-            except subprocess.TimeoutExpired:
-                stdout, stderr = "", ""
+            stdout, stderr = (
+                capture.finish(timeout=2.0)
+                if capture is not None
+                else ("" if text else b"", "" if text else b"")
+            )
             log.warning(
                 "_subprocess_kill: server-liveness watchdog reaped tree — "
                 "engine/worker init died but parent hung (marker=%r, "
@@ -305,10 +372,11 @@ def run_with_session_kill(
             )
         except _SoftDeadlineExceeded as exc:
             kill_my_spawned_server(proc)
-            try:
-                stdout, stderr = proc.communicate(timeout=2.0)
-            except subprocess.TimeoutExpired:
-                stdout, stderr = "", ""
+            stdout, stderr = (
+                capture.finish(timeout=2.0)
+                if capture is not None
+                else ("" if text else b"", "" if text else b"")
+            )
             log.info(
                 "_subprocess_kill: soft_deadline_sec=%.1fs exceeded "
                 "(elapsed=%.1fs); reaped tree with sentinel returncode=%d.",
@@ -376,6 +444,7 @@ def _communicate_with_soft_deadline(
     soft_deadline_sec: float | None,
     server_log_path: str | None = None,
     server_dead_grace_sec: float | None = None,
+    capture: _StreamCapture | None = None,
 ) -> tuple[str | bytes, str | bytes]:
     """``proc.communicate`` shim enforcing the soft deadline + server watchdog.
 
@@ -398,8 +467,11 @@ def _communicate_with_soft_deadline(
     soft_active = (
         soft_deadline_sec is not None and float(soft_deadline_sec) > 0.0
     )
-    if not soft_active and not watchdog_active:
+    if capture is None and not soft_active and not watchdog_active:
         return proc.communicate(timeout=hard_timeout)
+    if capture is not None and not soft_active and not watchdog_active:
+        proc.wait(timeout=hard_timeout)
+        return capture.finish()
 
     deadline_sec = float(soft_deadline_sec) if soft_active else None
     grace_sec = float(server_dead_grace_sec) if watchdog_active else None
@@ -433,12 +505,14 @@ def _communicate_with_soft_deadline(
         if hard_timeout is not None:
             hard_remaining = float(hard_timeout) - elapsed
             if hard_remaining <= 0.0:
-                # Let proc.communicate's own TimeoutExpired path fire.
-                return proc.communicate(timeout=0.0)
+                raise subprocess.TimeoutExpired(proc.args, hard_timeout)
             slice_sec = min(slice_sec, hard_remaining)
         slice_sec = max(slice_sec, 0.0)
         try:
-            return proc.communicate(timeout=slice_sec)
+            if capture is None:
+                return proc.communicate(timeout=slice_sec)
+            proc.wait(timeout=slice_sec)
+            return capture.finish()
         except subprocess.TimeoutExpired:
             # Not yet done; loop to re-evaluate all gates.
             continue

--- a/inference_optimizer/tests/test_kill_spawned_server.py
+++ b/inference_optimizer/tests/test_kill_spawned_server.py
@@ -255,6 +255,23 @@ def test_run_with_session_kill_soft_deadline_does_not_fire_for_quick_child():
     assert "hi" in (cp.stdout or "")
 
 
+def test_run_with_session_kill_streams_child_output_to_parent(capsys):
+    """Captured child output is also mirrored immediately to parent streams."""
+    code = (
+        "import sys\n"
+        "print('child-out', flush=True)\n"
+        "print('child-err', file=sys.stderr, flush=True)\n"
+    )
+    cp = run_with_session_kill([sys.executable, "-c", code], timeout=10)
+
+    captured = capsys.readouterr()
+    assert cp.returncode == 0
+    assert "child-out" in (cp.stdout or "")
+    assert "child-err" in (cp.stderr or "")
+    assert "child-out" in captured.out
+    assert "child-err" in captured.err
+
+
 def test_run_with_session_kill_legacy_timeout_still_raises():
     """With ``soft_deadline_sec`` None, a child exceeding the hard ``timeout`` still raises ``TimeoutExpired``."""
     with pytest.raises(subprocess.TimeoutExpired):


### PR DESCRIPTION
## Summary

Fixes #468 — the top-level log (`*.log` via `tee`) appeared frozen for ~1 hour while the run was healthy.

### Root Cause

Python block-buffers stdout (~8 KB) when piped through `tee` or redirected to a file. During Magpie subprocess execution (30–60 min), the main process blocks on `communicate()` with no new `print()` calls, so the buffer never flushes.

### Fix

Call `sys.stdout.reconfigure(line_buffering=True)` (and stderr) at the top of `main()` so every `print()` line is flushed immediately, regardless of the downstream sink.

## Test Plan

- [x] `sys.stdout.line_buffering` verified True after reconfigure
- [x] E2E: piped subprocess confirms line_buffering=True
- [x] Existing 20 startup robustness tests pass
- [ ] Manual: run with `| tee` and confirm real-time log output

Closes #468