### PR TITLE
feat(kernel-agent): backfill MAF for open-source TraceLens via GPU benchmark

### DIFF
--- a/inference_optimizer/scripts/local_setup.sh
+++ b/inference_optimizer/scripts/local_setup.sh
@@ -31,7 +31,8 @@ PRIMUS_CLAW_REPO="${PRIMUS_CLAW_REPO:-https://github.com/AMD-AGI/Primus-Claw.git
 INFERENCEX_REPO="${INFERENCEX_REPO:-https://github.com/SemiAnalysisAI/InferenceX.git}"
 INFERENCEX_REF="${INFERENCEX_REF:-2035a2117ad22403376359be0064dfa2c078c59b}"
 TRACELENS_REPO="${TRACELENS_REPO:-https://github.com/AMD-AGI/TraceLens.git}"
-TRACELENS_REF="${TRACELENS_REF:-c35c787ef31f0425fa0028a605ffc8c60a737c2c}"
+# TraceLens v0.6.0 integration (#474): head of release/hyperloom_integration_v0.6.0.
+TRACELENS_REF="${TRACELENS_REF:-0ebaa7109992b98b8f747a0fc0973e0f3b65d5d9}"
 # Preferred container-local checkout for the public repo when operators install
 # TraceLens manually. The internal extension is private: Hyperloom keeps NO
 # repo URL, ref, or default path for it. It is used only when an operator

--- a/inference_optimizer/tests/test_local_setup_script.py
+++ b/inference_optimizer/tests/test_local_setup_script.py
@@ -249,7 +249,7 @@ def test_local_setup_session_dir_rebases_default_deps_root(tmp_path: Path) -> No
     assert str(expected_deps / "Primus-Claw") in result.stdout
     assert str(expected_deps / "TraceLens") in result.stdout
     assert str(expected_deps / "TraceLens-internal") not in result.stdout
-    assert "c35c787ef31f0425fa0028a605ffc8c60a737c2c" in result.stdout
+    assert "0ebaa7109992b98b8f747a0fc0973e0f3b65d5d9" in result.stdout
 
 
 # install-harden: loud USER_DATA_PATH fallback notice + flock around the

--- a/kernel-agent/scripts/install.sh
+++ b/kernel-agent/scripts/install.sh
@@ -88,7 +88,12 @@ INFERENCEX_PATH="${INFERENCEX_PATH:-}"
 # The internal extension is used ONLY when $TRACELENS_INTERNAL_ROOT is set
 # (env / .env); leave it unset for the base-only report. No separate toggle.
 TRACELENS_REPO="https://github.com/AMD-AGI/TraceLens.git"
-TRACELENS_REF="c35c787ef31f0425fa0028a605ffc8c60a737c2c"
+# TraceLens v0.6.0 integration (#474): head of
+# release/hyperloom_integration_v0.6.0. The optional internal extension tracks
+# the matching release/hyperloom_integration_v0.6.0 branch of
+# AMD-AGI/TraceLens-internal, but Hyperloom keeps no pin/URL for it — the
+# operator supplies it via TRACELENS_INTERNAL_ROOT.
+TRACELENS_REF="0ebaa7109992b98b8f747a0fc0973e0f3b65d5d9"
 _tracelens_root_was_set="${TRACELENS_ROOT:+1}"
 TRACELENS_ROOT="${TRACELENS_ROOT:-${HYPERLOOM_RUNTIME_DIR}/source-mirrors/TraceLens}"
 TRACELENS_INTERNAL_ROOT="${TRACELENS_INTERNAL_ROOT:-}"

--- a/kernel-agent/tests/test_kernel_agent.py
+++ b/kernel-agent/tests/test_kernel_agent.py
@@ -288,7 +288,7 @@ class KernelAgentToolTests(unittest.TestCase):
             'TRACELENS_REPO="https://github.com/AMD-AGI/TraceLens.git"',
             install_text,
         )
-        self.assertIn('TRACELENS_REF="c35c787ef31f0425fa0028a605ffc8c60a737c2c"', install_text)
+        self.assertIn('TRACELENS_REF="0ebaa7109992b98b8f747a0fc0973e0f3b65d5d9"', install_text)
         self.assertIn('TRACELENS_ROOT="${TRACELENS_ROOT:-${HYPERLOOM_RUNTIME_DIR}/source-mirrors/TraceLens}"', install_text)
         self.assertIn('git clone --depth 1 "$TRACELENS_REPO" "$TRACELENS_ROOT"', install_text)
         self.assertIn('git -C "$TRACELENS_ROOT" fetch --depth 1 origin "$TRACELENS_REF"', install_text)

--- a/kernel-agent/tools/test_tracelens_arch_benchmark.py
+++ b/kernel-agent/tools/test_tracelens_arch_benchmark.py
@@ -1,0 +1,408 @@
+"""Unit tests for TraceLens arch JSON pre-report benchmarking.
+
+These cover both the TraceLens-internal (extension-enabled) and external
+(open-source-only) paths so the MAF backfill gate is validated for both
+deployments (#364), plus the microbenchmark mechanics themselves (#390).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_TOOLS_DIR = Path(__file__).resolve().parent
+_spec = importlib.util.spec_from_file_location(
+    "tracelens_arch_benchmark",
+    _TOOLS_DIR / "tracelens_arch_benchmark.py",
+)
+tab = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(tab)
+
+
+@pytest.fixture(scope="module")
+def tla():
+    """Import tracelens_analysis.py as a module without executing main()."""
+    spec = importlib.util.spec_from_file_location(
+        "tracelens_analysis_under_test", _TOOLS_DIR / "tracelens_analysis.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+_VISIBLE_DEVICE_VARS = (
+    "HIP_VISIBLE_DEVICES",
+    "CUDA_VISIBLE_DEVICES",
+    "ROCR_VISIBLE_DEVICES",
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("MI355X", "MI355X"),
+        ("mi355x", "MI355X"),
+        ("  mi300x  ", "MI300X"),
+        ("", ""),
+    ],
+)
+def test_normalize_platform(raw: str, expected: str) -> None:
+    assert tab.normalize_platform(raw) == expected
+
+
+def test_list_candidate_physical_gpus_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in _VISIBLE_DEVICE_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "2,5")
+    assert tab.list_candidate_physical_gpus() == [2, 5]
+
+
+def test_single_physical_gpu_env_pins_subprocess_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for var in _VISIBLE_DEVICE_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1,2")
+
+    env = tab.single_physical_gpu_env(4)
+
+    assert env["HIP_VISIBLE_DEVICES"] == "4"
+    assert env["CUDA_VISIBLE_DEVICES"] == "4"
+    assert env["ROCR_VISIBLE_DEVICES"] == "4"
+    assert os.environ.get("CUDA_VISIBLE_DEVICES") == "0,1,2"
+
+
+def test_select_idle_gpu_picks_first_free_from_many(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for var in _VISIBLE_DEVICE_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1,2")
+
+    def _idle(logical_idx: int, *, util_threshold: int = 5):
+        return logical_idx == 1, f"logical={logical_idx}"
+
+    monkeypatch.setattr(tab, "check_gpu_idle", _idle)
+
+    selected = tab.select_idle_gpu()
+    assert selected == 1
+    assert os.environ["CUDA_VISIBLE_DEVICES"] == "0,1,2"
+
+
+def test_select_idle_gpu_reuses_single_idle_gpu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for var in _VISIBLE_DEVICE_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3")
+
+    monkeypatch.setattr(
+        tab, "check_gpu_idle", lambda *_a, **_k: (True, "idle")
+    )
+
+    selected = tab.select_idle_gpu()
+    assert selected == 3
+    assert os.environ["CUDA_VISIBLE_DEVICES"] == "3"
+
+
+def test_select_idle_gpu_raises_when_all_busy(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in _VISIBLE_DEVICE_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1")
+
+    monkeypatch.setattr(
+        tab, "check_gpu_idle", lambda *_a, **_k: (False, "busy")
+    )
+
+    with pytest.raises(RuntimeError, match="no unoccupied GPU"):
+        tab.select_idle_gpu()
+
+
+def test_populate_gpu_arch_json_uses_bundled_spec(tmp_path: Path) -> None:
+    bundled = tmp_path / "MI300X.json"
+    bundled.write_text("{}", encoding="utf-8")
+    with patch.object(tab, "resolve_arch_json_path", return_value=bundled):
+        path = tab.populate_gpu_arch_json(
+            tracelens_root=tmp_path,
+            platform="MI300X",
+            internal_extension_enabled=False,
+            log=lambda _msg: None,
+            run_command=lambda *_a, **_k: 0,
+        )
+    assert path == bundled
+
+
+def test_populate_gpu_arch_json_runs_microbench_when_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+    captured_env: dict[str, str] | None = None
+
+    def _run_command(cmd, *, cwd, timeout_s, env=None):
+        nonlocal captured_env
+        captured_env = env
+        calls.append(cmd)
+        out = Path(cmd[cmd.index("--output") + 1])
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(
+            json.dumps(
+                {
+                    "name": "MI300X",
+                    "mem_bw_gbps": 5000,
+                    "memory_gb": 192,
+                    "max_achievable_tflops": {
+                        "matrix_bf16": 1000,
+                        "matrix_fp8": 2000,
+                        "matrix_fp4": 0,  # unmeasured -> dropped by sanitizer
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        return 0
+
+    with patch.object(tab, "resolve_arch_json_path", return_value=None), patch.object(
+        tab,
+        "select_idle_gpu",
+        return_value=2,
+    ):
+        path = tab.populate_gpu_arch_json(
+            tracelens_root=tmp_path,
+            platform="MI355X",
+            internal_extension_enabled=False,
+            log=lambda _msg: None,
+            run_command=_run_command,
+            timeout_s=60,
+        )
+
+    assert path == tmp_path / "TraceLens/Agent/Analysis/utils/arch/MI355X.json"
+    assert path.is_file()
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["name"] == "MI355X"
+    # 0-valued MAF key is dropped so roofline never divides by zero.
+    assert payload["max_achievable_tflops"] == {"matrix_bf16": 1000, "matrix_fp8": 2000}
+    assert "-m" in calls[0]
+    assert "TraceLens.PerfModel.benchmarking.microbench" in calls[0]
+    assert "--warmup" in calls[0] and "20" in calls[0]
+    assert "--rep" in calls[0] and "50" in calls[0]
+    assert calls[0][calls[0].index("--output") + 1].endswith(
+        "TraceLens/Agent/Analysis/utils/arch/MI355X.json"
+    )
+    assert captured_env is not None
+    assert captured_env["CUDA_VISIBLE_DEVICES"] == "2"
+
+
+def test_populate_skips_microbench_when_internal_extension_enabled(
+    tmp_path: Path,
+) -> None:
+    """Internal extension backfills MAF, so no microbenchmark runs even when
+    the bundled arch spec is missing (#390 gate)."""
+    calls: list[list[str]] = []
+
+    def _run_command(cmd, *, cwd, timeout_s, env=None):
+        calls.append(cmd)
+        return 0
+
+    with patch.object(tab, "resolve_arch_json_path", return_value=None), patch.object(
+        tab, "select_idle_gpu"
+    ) as select_idle:
+        path = tab.populate_gpu_arch_json(
+            tracelens_root=tmp_path,
+            platform="MI355X",
+            internal_extension_enabled=True,
+            log=lambda _msg: None,
+            run_command=_run_command,
+        )
+
+    assert path is None
+    assert calls == []
+    select_idle.assert_not_called()
+
+
+def test_populate_internal_extension_returns_bundled_spec_without_benchmark(
+    tmp_path: Path,
+) -> None:
+    """When the internal extension is enabled and a bundled spec exists, it is
+    returned as an artifact without running the microbenchmark."""
+    bundled = tmp_path / "MI300X.json"
+    bundled.write_text("{}", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def _run_command(cmd, *, cwd, timeout_s, env=None):
+        calls.append(cmd)
+        return 0
+
+    with patch.object(tab, "resolve_arch_json_path", return_value=bundled):
+        path = tab.populate_gpu_arch_json(
+            tracelens_root=tmp_path,
+            platform="MI300X",
+            internal_extension_enabled=True,
+            log=lambda _msg: None,
+            run_command=_run_command,
+        )
+
+    assert path == bundled
+    assert calls == []
+
+
+def test_populate_external_raises_on_microbench_failure(
+    tmp_path: Path,
+) -> None:
+    """Open-source path surfaces a non-zero microbenchmark exit code."""
+    with patch.object(tab, "resolve_arch_json_path", return_value=None), patch.object(
+        tab, "select_idle_gpu", return_value=0
+    ):
+        with pytest.raises(RuntimeError, match="exit code 7"):
+            tab.populate_gpu_arch_json(
+                tracelens_root=tmp_path,
+                platform="MI355X",
+                internal_extension_enabled=False,
+                log=lambda _msg: None,
+                run_command=lambda *_a, **_k: 7,
+            )
+
+
+def _install_fake_tracelens(
+    monkeypatch: pytest.MonkeyPatch, leaf: str, attr: str, value
+) -> None:
+    """Inject a fake ``TraceLens.…`` package tree so a lazy ``from … import``
+    succeeds without the real TraceLens being present."""
+    import sys
+    import types
+
+    parts = leaf.split(".")
+    for i in range(1, len(parts) + 1):
+        name = ".".join(parts[:i])
+        monkeypatch.setitem(sys.modules, name, types.ModuleType(name))
+    setattr(sys.modules[leaf], attr, value)
+
+
+def test_get_check_gpu_idle_resolves_after_install(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A None cache (TraceLens not importable at process start) is re-resolved
+    once TraceLens is installed by tracelens_analysis.main() (#390)."""
+    monkeypatch.setattr(tab, "check_gpu_idle", None)
+    sentinel = lambda *_a, **_k: (True, "idle")  # noqa: E731
+    _install_fake_tracelens(
+        monkeypatch,
+        "TraceLens.PerfModel.benchmarking.microbench_utils",
+        "check_gpu_idle",
+        sentinel,
+    )
+    assert tab._get_check_gpu_idle() is sentinel
+    assert tab.check_gpu_idle is sentinel  # cached on first success
+
+
+def test_get_collect_arch_jsons_resolves_after_install(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same lazy re-resolution for the arch-JSON collector (#390)."""
+    monkeypatch.setattr(tab, "_collect_arch_jsons", None)
+    sentinel = lambda: {"MI355X": "/tmp/MI355X.json"}  # noqa: E731
+    _install_fake_tracelens(
+        monkeypatch,
+        "TraceLens.Agent.Analysis.utils.arch_utils",
+        "_collect_arch_jsons",
+        sentinel,
+    )
+    assert tab._get_collect_arch_jsons() is sentinel
+    assert tab._collect_arch_jsons is sentinel
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, 600),       # unset -> floor
+        ("", 600),         # empty -> floor
+        ("   ", 600),      # whitespace -> floor
+        ("abc", 600),      # non-numeric -> floor (no ValueError)
+        ("12.5", 600),     # float string -> floor (int() would raise)
+        ("0", 600),        # below floor -> clamped up
+        ("-5", 600),       # negative -> clamped up to floor
+        ("300", 600),      # under floor -> floor
+        ("600", 600),      # exactly floor
+        ("1800", 1800),    # valid override
+        ("  900  ", 900),  # surrounding whitespace tolerated
+    ],
+)
+def test_resolve_arch_benchmark_timeout_s(
+    tla, monkeypatch: pytest.MonkeyPatch, raw, expected
+) -> None:
+    """Malformed TRACELENS_ARCH_BENCHMARK_TIMEOUT_SEC falls back to the 600s
+    floor instead of raising ValueError before the microbenchmark (#390)."""
+    if raw is None:
+        monkeypatch.delenv(tla.ARCH_BENCHMARK_TIMEOUT_ENV, raising=False)
+    else:
+        monkeypatch.setenv(tla.ARCH_BENCHMARK_TIMEOUT_ENV, raw)
+    assert tla._resolve_arch_benchmark_timeout_s() == expected
+
+
+def test_sanitize_drops_zero_maf_keys(tmp_path: Path) -> None:
+    """0-valued MAF entries are dropped so roofline skips (not divides by) them."""
+    payload = {
+        "name": "MI355X",
+        "mem_bw_gbps": 5000,
+        "max_achievable_tflops": {"matrix_bf16": 900, "matrix_fp8": 0, "matrix_int8": 0.0},
+    }
+    changed = tab._sanitize_measured_arch_spec(
+        payload, platform="MI355X", out_path=tmp_path / "MI355X.json", log=lambda _m: None
+    )
+    assert changed is True
+    assert payload["max_achievable_tflops"] == {"matrix_bf16": 900}
+
+
+def test_sanitize_keeps_spec_with_all_positive(tmp_path: Path) -> None:
+    payload = {
+        "name": "MI355X",
+        "mem_bw_gbps": 5000,
+        "max_achievable_tflops": {"matrix_bf16": 900, "matrix_fp8": 1800},
+    }
+    changed = tab._sanitize_measured_arch_spec(
+        payload, platform="MI355X", out_path=tmp_path / "MI355X.json", log=lambda _m: None
+    )
+    assert changed is False
+    assert payload["max_achievable_tflops"] == {"matrix_bf16": 900, "matrix_fp8": 1800}
+
+
+def test_sanitize_raises_when_all_maf_zero(tmp_path: Path) -> None:
+    payload = {
+        "name": "MI355X",
+        "mem_bw_gbps": 5000,
+        "max_achievable_tflops": {"matrix_bf16": 0, "matrix_fp8": 0},
+    }
+    with pytest.raises(RuntimeError, match="no positive max_achievable_tflops"):
+        tab._sanitize_measured_arch_spec(
+            payload, platform="MI355X", out_path=tmp_path / "MI355X.json",
+            log=lambda _m: None,
+        )
+
+
+def test_sanitize_raises_when_maf_missing(tmp_path: Path) -> None:
+    payload = {"name": "MI355X", "mem_bw_gbps": 5000}
+    with pytest.raises(RuntimeError, match="no max_achievable_tflops"):
+        tab._sanitize_measured_arch_spec(
+            payload, platform="MI355X", out_path=tmp_path / "MI355X.json",
+            log=lambda _m: None,
+        )
+
+
+@pytest.mark.parametrize("mem_bw", [0, 0.0, -1, None, "abc"])
+def test_sanitize_raises_on_non_positive_bandwidth(tmp_path: Path, mem_bw) -> None:
+    payload = {
+        "name": "MI355X",
+        "mem_bw_gbps": mem_bw,
+        "max_achievable_tflops": {"matrix_bf16": 900},
+    }
+    with pytest.raises(RuntimeError, match="non-positive mem_bw_gbps"):
+        tab._sanitize_measured_arch_spec(
+            payload, platform="MI355X", out_path=tmp_path / "MI355X.json",
+            log=lambda _m: None,
+        )

--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import csv
 import functools
 import gzip
 import json
@@ -25,6 +26,24 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+try:
+    from inference_optimizer.orchestrator.framework_paths import (
+        resolve_patch_target_roots as _resolve_patch_target_roots,
+    )
+except ImportError:
+    _resolve_patch_target_roots = None
+
+try:
+    from apply_kernel_patch import known_target_roots as _known_target_roots
+except ImportError:
+    _known_target_roots = None
+
+try:
+    import aiter.jit.core as _aiter_jit_core  # type: ignore[import-untyped]
+except Exception:
+    _aiter_jit_core = None
+
+from tracelens_arch_benchmark import normalize_platform, populate_gpu_arch_json
 from tracelens_skill_runner import (
     aggregate_by_source_function,
     discover_capture_folder,
@@ -40,6 +59,9 @@ from _paths import workspace_root
 
 HIGH_IDLE_PCT_THRESHOLD_DEFAULT = 80.0
 HIGH_IDLE_PCT_THRESHOLD_ENV = "HYPERLOOM_TRACELENS_IDLE_PCT_THRESHOLD"
+
+ARCH_BENCHMARK_TIMEOUT_ENV = "TRACELENS_ARCH_BENCHMARK_TIMEOUT_SEC"
+ARCH_BENCHMARK_TIMEOUT_FLOOR_S = 600
 
 
 def _resolve_idle_pct_threshold() -> float:
@@ -59,6 +81,23 @@ def _resolve_idle_pct_threshold() -> float:
     if value < 0.0:
         return HIGH_IDLE_PCT_THRESHOLD_DEFAULT
     return value
+
+
+def _resolve_arch_benchmark_timeout_s() -> int:
+    """Return the GPU arch microbenchmark timeout in seconds (floor 600s).
+
+    Configured via ``TRACELENS_ARCH_BENCHMARK_TIMEOUT_SEC``. Empty, non-numeric,
+    or out-of-range values fall back to the 600s floor rather than crashing the
+    pipeline with a ``ValueError`` before the microbenchmark runs.
+    """
+    raw = os.environ.get(ARCH_BENCHMARK_TIMEOUT_ENV, "").strip()
+    if not raw:
+        return ARCH_BENCHMARK_TIMEOUT_FLOOR_S
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return ARCH_BENCHMARK_TIMEOUT_FLOOR_S
+    return max(ARCH_BENCHMARK_TIMEOUT_FLOOR_S, value)
 
 
 def _build_high_idle_warning(
@@ -122,8 +161,6 @@ def _check_selected_chunk_has_gpu_events(
     warning the caller appends and raises on. A data-validity gate, not a reorder — falling
     back to another mode is the operator's call (never a silent swap).
     """
-    import csv
-
     details_path = split_dir / "execution_details.csv"
     if not details_path.is_file():
         # No CSV (older TraceLens): let the chunk through (T3 idle gate still applies).
@@ -252,15 +289,13 @@ def _check_selected_chunk_has_gpu_events_quality(
     materially better, or the CSV/row is absent. Otherwise a ``steady_state_chunk_low_quality``
     warning (same shape as N25 for the N26 retry path). See the module-level N36 comment.
     """
-    import csv as _csv
-
     details_path = split_dir / "execution_details.csv"
     if not details_path.is_file():
         return None
     try:
         with details_path.open("r", encoding="utf-8") as fh:
-            rows = list(_csv.DictReader(fh))
-    except (OSError, _csv.Error):
+            rows = list(csv.DictReader(fh))
+    except (OSError, csv.Error):
         return None
 
     def _row_for(chunk_path: "Path") -> "dict[str, str] | None":
@@ -606,15 +641,14 @@ _COMPILE_GENERATED_NAME_MARKERS = (
 def _framework_patch_roots() -> tuple[str, ...]:
     """Framework install roots (from framework_paths.resolve_patch_target_roots); also emits a lower-case variant of each (``/app/ATOM/atom/`` -> ``/app/atom/atom/``) for case-insensitive matching."""
     try:
-        from inference_optimizer.orchestrator.framework_paths import (
-            resolve_patch_target_roots,
-        )
-
-        roots = resolve_patch_target_roots()
+        if _resolve_patch_target_roots is None:
+            raise ImportError
+        roots = _resolve_patch_target_roots()
     except ImportError:
-        from apply_kernel_patch import known_target_roots
-
-        roots = known_target_roots()
+        if _known_target_roots is None:
+            roots = []
+        else:
+            roots = _known_target_roots()
     out: list[str] = []
     seen: set[str] = set()
     for root in roots:
@@ -627,12 +661,12 @@ def _framework_patch_roots() -> tuple[str, ...]:
 
 @functools.lru_cache(maxsize=1)
 def _aiter_csrc_root() -> str:
-    """aiter's device-source root (``.../aiter_meta/csrc/``) from the installed package; empty if aiter is unimportable."""
-    try:
-        import aiter.jit.core as _jc  # type: ignore
-    except Exception:
+    """aiter's own device-source root (e.g. ``.../aiter_meta/csrc/``),
+    resolved from the installed package. Empty when aiter is not importable.
+    Cached once per process."""
+    if _aiter_jit_core is None:
         return ""
-    raw = (getattr(_jc, "AITER_CSRC_DIR", "") or "").replace(os.sep, "/")
+    raw = (getattr(_aiter_jit_core, "AITER_CSRC_DIR", "") or "").replace(os.sep, "/")
     return (raw.rstrip("/") + "/") if raw else ""
 
 
@@ -874,8 +908,9 @@ def _candidate_keywords(name: str) -> list[str]:
     """
     cleaned = name.strip()
     if cleaned.startswith("_Z"):
-        # Itanium ABI <len><name>: slice manually so consecutive segments parse separately.
-        import re
+        # Itanium ABI uses <len><name>; walk through and slice manually so
+        # consecutive segments (e.g. 5aiter26cross_device_reduce_2stage...) are
+        # parsed as separate identifiers.
         tokens = []
         pos = 0
         while pos < len(cleaned):
@@ -1411,16 +1446,15 @@ def load_op_category_map(
     csv_path = Path(perf_report_csv_dir) / "unified_perf_summary.csv"
     if not csv_path.is_file():
         return {}
-    import csv as _csv
     out: dict[str, str] = {}
     try:
         with csv_path.open(newline="", encoding="utf-8") as f:
-            for row in _csv.DictReader(f):
+            for row in csv.DictReader(f):
                 name = str(row.get("name") or "").strip()
                 cat = str(row.get("op category") or "").strip()
                 if name and cat and name not in out:
                     out[name] = cat
-    except (OSError, _csv.Error):
+    except (OSError, csv.Error):
         return {}
     return out
 
@@ -1547,11 +1581,19 @@ def build_notes(candidate: dict[str, Any]) -> str:
     return f"resolved source: {candidate['source_file']}"
 
 
-def run_command(cmd: list[str], *, cwd: Path | None, log_path: Path, timeout_s: int) -> int:
+def run_command(
+    cmd: list[str],
+    *,
+    cwd: Path | None,
+    log_path: Path,
+    timeout_s: int,
+    env: dict[str, str] | None = None,
+) -> int:
     append_log(log_path, f"$ {' '.join(cmd)}")
     proc = subprocess.run(
         cmd,
         cwd=str(cwd) if cwd else None,
+        env=env,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
@@ -2335,6 +2377,8 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    args.target_platform = normalize_platform(args.target_platform)
+
     session_id = args.session_id or uuid.uuid4().hex[:12]
     run_id = f"tl-{uuid.uuid4().hex[:8]}"
     started_at = utc_now()
@@ -2430,7 +2474,49 @@ def main() -> int:
             tracelens_dir = run_dir / "tracelens"
             tracelens_dir.mkdir(parents=True, exist_ok=True)
 
-            # #127: split the full-window trace into steady-state chunks via TraceLens's splitter.
+            # ---- #390: backfill MAF for the open-source TraceLens path ----
+            # Public TraceLens carries no MAF values, so on MI355+ roofline
+            # (and the whole kernel-optimization loop) fails. The benchmark is
+            # gated on whether the TraceLens-internal extension is enabled:
+            # when it is, the extension backfills MAF itself and we skip the
+            # microbenchmark; when it is not (open-source path) we measure the
+            # missing arch/MAF spec on an idle GPU before report generation.
+            update_status(
+                status_path,
+                state="running",
+                current_step="populate_gpu_arch_json",
+                log_path=log_path,
+                artifact_paths=artifacts,
+                run_id=run_id,
+                started_at=started_at,
+            )
+            arch_benchmark_timeout_s = _resolve_arch_benchmark_timeout_s()
+            gpu_arch_path = populate_gpu_arch_json(
+                tracelens_root=tl_root,
+                platform=args.target_platform,
+                internal_extension_enabled=tl_internal_root is not None,
+                log=lambda msg: append_log(log_path, msg),
+                run_command=lambda cmd, *, cwd, timeout_s, env=None: run_command(
+                    cmd,
+                    cwd=cwd,
+                    log_path=log_path,
+                    timeout_s=timeout_s,
+                    env=env,
+                ),
+                timeout_s=arch_benchmark_timeout_s,
+            )
+            if gpu_arch_path is not None:
+                artifacts["tracelens_gpu_arch_json"] = str(gpu_arch_path)
+
+            # ---- #127: split inference trace into steady-state chunks ----
+            # The filtered trace from vLLM/SGLang spans the full benchmark
+            # window (warmup + tear-down + steady-state mixed together).
+            # TraceLens's perf report expects a single steady-state chunk.
+            # Use TraceLens's own splitter to produce
+            # mixed_steady_state_*_trace.json.gz, then feed the first chunk
+            # to TraceLens_generate_perf_report_pytorch_inference. Fail-soft:
+            # if the splitter is unavailable or produces no output, fall back
+            # to the original filtered trace (legacy behaviour).
             cli_trace_path = trace_files[0]
             trace_split_blocked = False
             if not args.skip_split:

--- a/kernel-agent/tools/tracelens_arch_benchmark.py
+++ b/kernel-agent/tools/tracelens_arch_benchmark.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Ensure TraceLens GPU arch JSON exists before running the TL report.
+
+The public (open-source) TraceLens does not carry MAF values; those live
+only in the TraceLens-internal extension, which backfills MAF and adjusts
+the final report. On MI355+ the missing MAF makes roofline (and therefore
+the whole kernel-optimization loop) fail (#390).
+
+To close that gap for open-source users, when the TraceLens-internal
+extension is *not* enabled we run the TraceLens GPU microbenchmark suite to
+produce a measured arch spec
+(``TraceLens/Agent/Analysis/utils/arch/<platform>.json``). When the internal
+extension *is* enabled it backfills MAF itself, so the microbenchmark is
+skipped entirely. The benchmark selects an unoccupied GPU and pins
+``HIP_VISIBLE_DEVICES`` / ``CUDA_VISIBLE_DEVICES`` / ``ROCR_VISIBLE_DEVICES``
+only on the microbenchmark subprocess. The microbenchmark runs with
+``--warmup 20 --rep 50``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Callable
+
+try:
+    import torch
+except ImportError:
+    torch = None  # type: ignore[assignment,misc]
+
+# TraceLens supplies these, but tracelens_analysis.main() pip-installs TraceLens
+# *after* this module is first imported. Binding them at import time would cache
+# ``None`` on a fresh runtime and make the open-source MI355X path fail even
+# after the install succeeds (#390). Resolve them lazily (and cache on first
+# success) via the _get_* helpers below. They stay module globals so tests can
+# still monkeypatch them.
+_collect_arch_jsons = None  # type: ignore[assignment,misc]
+check_gpu_idle = None  # type: ignore[assignment,misc]
+
+
+def _get_collect_arch_jsons():
+    """Return TraceLens' arch-JSON collector, importing lazily post-install."""
+    global _collect_arch_jsons
+    if _collect_arch_jsons is None:
+        try:
+            from TraceLens.Agent.Analysis.utils.arch_utils import (
+                _collect_arch_jsons as _fn,
+            )
+        except ImportError:
+            return None
+        _collect_arch_jsons = _fn
+    return _collect_arch_jsons
+
+
+def _get_check_gpu_idle():
+    """Return TraceLens' check_gpu_idle, importing lazily post-install."""
+    global check_gpu_idle
+    if check_gpu_idle is None:
+        try:
+            from TraceLens.PerfModel.benchmarking.microbench_utils import (
+                check_gpu_idle as _fn,
+            )
+        except ImportError:
+            return None
+        check_gpu_idle = _fn
+    return check_gpu_idle
+
+MICROBENCH_WARMUP = 20
+MICROBENCH_REP = 50
+
+_VISIBLE_DEVICE_VARS = (
+    "HIP_VISIBLE_DEVICES",
+    "CUDA_VISIBLE_DEVICES",
+    "ROCR_VISIBLE_DEVICES",
+)
+
+
+def normalize_platform(platform: str) -> str:
+    return (platform or "").strip().upper()
+
+
+def list_candidate_physical_gpus() -> list[int]:
+    """Return physical GPU ids currently visible to this process."""
+    for var in _VISIBLE_DEVICE_VARS:
+        val = os.environ.get(var, "").strip()
+        if not val:
+            continue
+        parts = [part.strip() for part in val.split(",") if part.strip()]
+        if not parts:
+            continue
+        try:
+            return [int(part) for part in parts]
+        except ValueError:
+            return list(range(len(parts)))
+    if torch is not None:
+        try:
+            if torch.cuda.is_available():
+                return list(range(int(torch.cuda.device_count())))
+        except Exception as exc:
+            print(
+                f"[tracelens_arch_benchmark] Failed to query CUDA devices via torch: {exc}",
+                file=sys.stderr,
+            )
+    return []
+
+
+def single_physical_gpu_env(
+    physical_id: int, *, base_env: dict[str, str] | None = None
+) -> dict[str, str]:
+    """Return a subprocess env that exposes exactly one physical GPU."""
+    env = dict(base_env if base_env is not None else os.environ)
+    value = str(physical_id)
+    for var in _VISIBLE_DEVICE_VARS:
+        env[var] = value
+    return env
+
+
+def select_idle_gpu(
+    *, log: Callable[[str], None] | None = None, util_threshold: int = 5
+) -> int:
+    """Pick an unoccupied GPU for the arch microbenchmark subprocess."""
+    check_idle = _get_check_gpu_idle()
+    if check_idle is None:
+        raise RuntimeError("TraceLens is not installed; cannot check GPU idle state")
+
+    candidates = list_candidate_physical_gpus()
+    if not candidates:
+        raise RuntimeError(
+            "gpu_arch_benchmark found no GPUs; cannot run arch microbenchmark"
+        )
+
+    busy_reports: list[str] = []
+    for logical_idx, physical_id in enumerate(candidates):
+        idle, msg = check_idle(logical_idx, util_threshold=util_threshold)
+        if idle:
+            if log is not None:
+                if len(candidates) == 1:
+                    log(f"gpu_arch_json: using idle GPU {physical_id} ({msg})")
+                else:
+                    log(
+                        "gpu_arch_json: selected idle GPU "
+                        f"{physical_id} from candidates {candidates} ({msg})"
+                    )
+            return physical_id
+        busy_reports.append(f"GPU {physical_id}: {msg}")
+
+    raise RuntimeError(
+        "gpu_arch_benchmark found no unoccupied GPU among "
+        f"{candidates}. {'; '.join(busy_reports)}"
+    )
+
+
+def resolve_arch_json_path(platform: str) -> Path | None:
+    """Return the bundled arch JSON path for ``platform``, if present."""
+    collect = _get_collect_arch_jsons()
+    if collect is None:
+        return None
+
+    canonical = normalize_platform(platform)
+    if not canonical:
+        return None
+    for name, path in collect().items():
+        if name.upper() == canonical:
+            return Path(path)
+    return None
+
+
+def default_arch_output_path(tracelens_root: Path, platform: str) -> Path:
+    canonical = normalize_platform(platform)
+    return (
+        tracelens_root
+        / "TraceLens/Agent/Analysis/utils/arch"
+        / f"{canonical}.json"
+    )
+
+
+def _sanitize_measured_arch_spec(
+    payload: dict,
+    *,
+    platform: str,
+    out_path: Path,
+    log: Callable[[str], None],
+) -> bool:
+    """Drop non-positive MAF entries and reject a structurally-broken spec.
+
+    The TraceLens microbenchmark writes ``0`` for any dtype it could not measure
+    (FP8/INT8/MX unsupported on the stack, or a bench that was skipped) and a
+    ``0`` bandwidth when the HBM sweep failed. Roofline consumes
+    ``max_achievable_tflops[<spec>]`` as a divisor and ``mem_bw_gbps`` as the
+    memory ceiling, so a ``0`` would divide-by-zero or yield garbage. Keep only
+    positive MAF values (roofline's lookup then returns ``None`` and skips that
+    dtype) and hard-fail when the spec is unusable. Returns True if ``payload``
+    was modified (caller persists it).
+    """
+    maf = payload.get("max_achievable_tflops")
+    if not isinstance(maf, dict) or not maf:
+        raise RuntimeError(
+            f"measured arch spec {out_path} has no max_achievable_tflops; the GPU "
+            "microbenchmark produced a spec roofline cannot use"
+        )
+
+    kept: dict = {}
+    dropped: list[str] = []
+    for key, value in maf.items():
+        try:
+            positive = float(value) > 0.0
+        except (TypeError, ValueError):
+            positive = False
+        if positive:
+            kept[key] = value
+        else:
+            dropped.append(key)
+
+    if not kept:
+        raise RuntimeError(
+            f"measured arch spec {out_path} has no positive max_achievable_tflops "
+            f"values (all of {sorted(maf)} measured as 0); the GPU microbenchmark "
+            "likely failed -- refusing to emit a spec roofline cannot use"
+        )
+
+    mem_bw = payload.get("mem_bw_gbps")
+    try:
+        mem_bw_ok = mem_bw is not None and float(mem_bw) > 0.0
+    except (TypeError, ValueError):
+        mem_bw_ok = False
+    if not mem_bw_ok:
+        raise RuntimeError(
+            f"measured arch spec {out_path} has non-positive mem_bw_gbps "
+            f"({mem_bw!r}); roofline's memory ceiling would divide by zero -- "
+            "the HBM bandwidth benchmark likely failed"
+        )
+
+    if dropped:
+        payload["max_achievable_tflops"] = kept
+        log(
+            f"gpu_arch_json: dropped non-positive MAF keys {sorted(dropped)} from "
+            f"{platform} spec (roofline skips these dtypes rather than dividing by 0)"
+        )
+        return True
+    return False
+
+
+def populate_gpu_arch_json(
+    *,
+    tracelens_root: Path,
+    platform: str,
+    internal_extension_enabled: bool,
+    log: Callable[[str], None],
+    run_command: Callable[..., int],
+    timeout_s: int = 3600,
+    device: int = 0,
+) -> Path | None:
+    """Ensure a GPU arch JSON is available for roofline, returning its path.
+
+    The microbenchmark is gated on whether the TraceLens-internal extension
+    is enabled (#390):
+
+    - When ``internal_extension_enabled`` is True the internal extension
+      backfills MAF itself, so we never run the microbenchmark. Any bundled
+      spec already on disk is returned as an artifact; otherwise ``None`` is
+      returned and the internal extension supplies MAF at report time.
+    - When it is False (open-source path) a bundled spec short-circuits, and
+      a missing spec triggers the TraceLens microbenchmark on an idle GPU.
+    """
+    if internal_extension_enabled:
+        existing = resolve_arch_json_path(platform)
+        if existing is not None and existing.is_file():
+            log(
+                "gpu_arch_json: internal extension enabled; using bundled spec "
+                f"{existing} (MAF backfilled by extension)"
+            )
+            return existing
+        log(
+            "gpu_arch_json: internal extension enabled; MAF backfilled by "
+            "extension, skipping microbenchmark"
+        )
+        return None
+
+    existing = resolve_arch_json_path(platform)
+    if existing is not None and existing.is_file():
+        log(f"gpu_arch_json: using bundled spec {existing}")
+        return existing
+
+    canonical = normalize_platform(platform)
+    if not canonical:
+        raise RuntimeError(
+            "target platform is empty; cannot resolve or generate gpu arch JSON"
+        )
+
+    out_path = default_arch_output_path(tracelens_root, canonical)
+    log(
+        "gpu_arch_json: no bundled spec for "
+        f"{canonical} and internal extension disabled; running TraceLens "
+        f"microbenchmark -> {out_path}"
+    )
+
+    physical_id = select_idle_gpu(log=log)
+
+    rc = run_command(
+        [
+            sys.executable,
+            "-m",
+            "TraceLens.PerfModel.benchmarking.microbench",
+            "--device",
+            str(device),
+            "--warmup",
+            str(MICROBENCH_WARMUP),
+            "--rep",
+            str(MICROBENCH_REP),
+            "--output",
+            str(out_path),
+        ],
+        cwd=tracelens_root,
+        timeout_s=timeout_s,
+        env=single_physical_gpu_env(physical_id),
+    )
+    if rc != 0:
+        raise RuntimeError(
+            f"gpu arch microbenchmark failed with exit code {rc}; see log for details"
+        )
+    if not out_path.is_file():
+        raise RuntimeError(
+            f"gpu arch microbenchmark finished but output is missing: {out_path}"
+        )
+
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    changed = False
+    if payload.get("name") != canonical:
+        payload["name"] = canonical
+        changed = True
+        log(f"gpu_arch_json: patched name field -> {canonical}")
+
+    # Reject / sanitize a spec with 0 (unmeasured) MAF or bandwidth before
+    # roofline consumes it as a divisor (#390).
+    changed = _sanitize_measured_arch_spec(
+        payload, platform=canonical, out_path=out_path, log=log
+    ) or changed
+
+    if changed:
+        out_path.write_text(json.dumps(payload, indent=4) + "\n", encoding="utf-8")
+
+    log(f"gpu_arch_json: measured spec ready at {out_path}")
+    return out_path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,12 @@ inference_optimizer = [
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-testpaths = ["inference_optimizer/tests", "robustness-agent/tests", "critic-agent/runtime/tests"]
+testpaths = [
+    "inference_optimizer/tests",
+    "robustness-agent/tests",
+    "critic-agent/runtime/tests",
+    "kernel-agent/tools/test_tracelens_arch_benchmark.py",
+]
 pythonpath = [".", "robustness-agent/src", "critic-agent"]
 markers = [
     "critic_agent_e2e: end-to-end tests that shell out to the real critic-agent runtime; skip with '-m \"not critic_agent_e2e\"' if critic-agent is not on disk.",


### PR DESCRIPTION
## Summary

- On MI355+ the public (open-source) TraceLens carries no MAF values, so roofline
  analysis — and the whole kernel-optimization loop — fails. This PR adds a
  pre-report step that measures the missing arch/MAF spec on an idle GPU when the
  TraceLens-internal extension is not available.
- The microbenchmark is gated on whether the internal extension is enabled
  (`TRACELENS_INTERNAL_ROOT`): when enabled, the extension backfills MAF itself and
  the benchmark is skipped; when disabled (OSS path), `populate_gpu_arch_json` runs
  `TraceLens.PerfModel.benchmarking.microbench` (`--warmup 20 --rep 50`) on an idle
  GPU and writes `TraceLens/Agent/Analysis/utils/arch/<platform>.json`.
- GPU selection picks an idle visible GPU via TraceLens `check_gpu_idle` and pins
  `HIP_VISIBLE_DEVICES` / `CUDA_VISIBLE_DEVICES` / `ROCR_VISIBLE_DEVICES` only on the
  microbenchmark subprocess (parent env unchanged). Timeout is configurable via
  `TRACELENS_ARCH_BENCHMARK_TIMEOUT_SEC` (min 600s).
- Bumps the pinned public TraceLens ref to `release/hyperloom_integration_v0.6.0`
  (0ebaa71) in `kernel-agent/scripts/install.sh` and
  `inference_optimizer/scripts/local_setup.sh`, syncing the two SHA-assertion tests.

## Related issues

- #390 — backfill MAF for open-source TraceLens via GPU benchmark
- #474 — integrate TraceLens v0.6.0 release into Hyperloom
- #364 — E2E coverage across internal/external TraceLens deployments

## Test plan

- [ ] `pytest kernel-agent/tools/test_tracelens_arch_benchmark.py`
- [ ] Platform with a bundled arch JSON (e.g. MI300X) → log shows `using bundled spec`, no microbench runs
- [ ] Platform without bundled spec (e.g. MI355X), OSS-only (no TraceLens-internal), idle GPU available → microbench runs, writes `arch/<platform>.json`, pipeline continues to split/report
- [ ] Internal extension enabled (`TRACELENS_INTERNAL_ROOT` set) → microbench skipped, MAF backfilled by extension
- [ ] All visible GPUs busy → clear `no unoccupied GPU` error
- [ ] `TRACELENS_ARCH_BENCHMARK_TIMEOUT_SEC` honored; status JSON shows step `populate_gpu_arch_json`

Made with [Cursor](https://cursor.com)