### PR TITLE
docs(readme): use pullable primussafe image in the own-machine docker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ docker run -d \
   --group-add video \
   -v /path/to/workspace:/workspace \
   -v /path/to/models:/models \
-  harbor.core42.primus-safe.amd.com/proxy/primussafe/sglang:v0.5.11-rocm720-mi30x-profilerfix \
+  primussafe/sglang:v0.5.11-rocm720-mi30x-profilerfix \
   tail -f /dev/null
 ```
 


### PR DESCRIPTION
Closes #500.

## Summary

One-line README fix: the "Minimal Docker example for your own GPU machine" `docker run` snippet now uses `primussafe/sglang:v0.5.11-rocm720-mi30x-profilerfix` instead of the `harbor.core42.primus-safe.amd.com/proxy/...` URL.

The harbor proxy ref only resolves inside Primus-SaFE, so it's wrong for a manual `docker run` on your own machine. The "Example images" list (used by the SaFE Authoring Pod path) keeps the harbor URL since it's correct there.