### PR TITLE
feat(sglang): inject --moe-runner-backend triton for MoE baselines on AMD (Closes #512)

### DIFF
--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -905,6 +905,43 @@ def _model_has_dual_chunk_attention(model_path: str) -> bool:
     )
 
 
+def _model_is_moe(model_path: str) -> bool:
+    """Best-effort detect a Mixture-of-Experts model from config.json.
+
+    MoE checkpoints declare an expert count (``num_experts`` /
+    ``num_local_experts`` / ``n_routed_experts``), a ``moe_intermediate_size``,
+    or carry a ``moe`` marker in ``architectures`` / ``model_type`` (e.g.
+    Qwen3MoeForCausalLM / qwen3_moe). On ROCm/aiter, sglang's default
+    ``--moe-runner-backend auto`` routes these through aiter's CK 2-stage
+    fused-MoE kernel, whose first-request JIT build is broken in some images;
+    callers use this to switch to a ROCm-capable MoE runner. Checks the top
+    level and a nested ``text_config``. Soft-degrades to False on any missing
+    / unreadable / invalid config.
+    """
+    data = _load_model_config_dict(model_path)
+    if data is None:
+        return False
+    candidates = [data]
+    nested = data.get("text_config")
+    if isinstance(nested, dict):
+        candidates.append(nested)
+    expert_keys = ("num_experts", "num_local_experts", "n_routed_experts")
+    for cfg in candidates:
+        for key in expert_keys:
+            val = cfg.get(key)
+            if isinstance(val, bool):
+                continue
+            if isinstance(val, int) and val > 1:
+                return True
+        if cfg.get("moe_intermediate_size"):
+            return True
+        if "moe" in str(cfg.get("model_type") or "").lower():
+            return True
+        if any("moe" in arch.lower() for arch in _config_architectures(cfg)):
+            return True
+    return False
+
+
 def _context_headroom_tokens() -> int:
     """Resolve the context headroom (tokens); env override, else default."""
     raw = os.environ.get(_CONTEXT_HEADROOM_ENV, "").strip()

--- a/inference_optimizer/orchestrator/action_executors/_grid_runner.py
+++ b/inference_optimizer/orchestrator/action_executors/_grid_runner.py
@@ -846,6 +846,64 @@ def inject_sglang_attention_backend(
     )
 
 
+# sglang MoE runner backend injection: on MI300X/MI355X with aiter, sglang's
+# default ``--moe-runner-backend auto`` routes Mixture-of-Experts models
+# through aiter's CK 2-stage fused-MoE kernel. Its first-request JIT build
+# (``module_moe_ck2stages_*``) is broken in some ROCm images — ``thrust`` pulls
+# in a missing ``<cub/detail/detect_cuda_runtime.cuh>`` so hipcc fails to
+# compile, and the killed build leaves a stale lock that makes the next
+# attempts hang on "waiting for baton release" until sglang's 600s warmup
+# read-timeout fires -> baseline_failed. ``triton`` is the ROCm-capable
+# fused-MoE backend sglang itself falls back to (same "aiter CK kernel doesn't
+# support all GEMM dimensions" reason), so inject it for MoE models on AMD
+# unless the operator already pinned a backend. Override via
+# ``$HYPERLOOM_SGLANG_MOE_RUNNER_BACKEND``.
+HYPERLOOM_SGLANG_MOE_RUNNER_BACKEND_ENV = "HYPERLOOM_SGLANG_MOE_RUNNER_BACKEND"
+DEFAULT_SGLANG_AMD_MOE_RUNNER_BACKEND = "triton"
+_SGLANG_MOE_RUNNER_BACKEND_FLAG = "--moe-runner-backend"
+# Matches space- or equals-separated form so a user-pinned value suppresses
+# injection without false-matching a longer flag.
+_SGLANG_MOE_RUNNER_BACKEND_RE = re.compile(r"--moe-runner-backend(?:[=\s]|$)")
+
+
+def inject_sglang_moe_runner_backend(
+    server_args: str | None,
+    framework: str | None,
+    model_path: str | None,
+    gpu_type: str | None = None,
+) -> str:
+    """Append a ``--moe-runner-backend`` for MoE sglang models on AMD/ROCm.
+
+    Returns ``server_args`` unchanged when: framework is not sglang, a
+    ``--moe-runner-backend`` is already pinned (operator wins), the GPU is not
+    an AMD/ROCm runner, or the model is not Mixture-of-Experts (fail-safe:
+    inject nothing). Otherwise appends the backend from
+    ``$HYPERLOOM_SGLANG_MOE_RUNNER_BACKEND`` (default ``triton``); only this
+    flag is added.
+    """
+    args = str(server_args or "").strip()
+    if server_args_env_name(framework) != "EXTRA_SGLANG_ARGS":
+        return args
+    if _SGLANG_MOE_RUNNER_BACKEND_RE.search(args):
+        return args
+    from ...cli import _model_is_moe, _resolve_amd_gpu_type
+    if not _resolve_amd_gpu_type(gpu_type):
+        return args
+    if not _model_is_moe(str(model_path or "")):
+        return args
+    backend = (
+        os.environ.get(HYPERLOOM_SGLANG_MOE_RUNNER_BACKEND_ENV, "").strip()
+        or DEFAULT_SGLANG_AMD_MOE_RUNNER_BACKEND
+    )
+    log.info(
+        "MoE model on AMD/ROCm: injecting --moe-runner-backend %s (aiter CK "
+        "2-stage fused-MoE JIT build is broken in this image).", backend,
+    )
+    return merge_server_args(
+        args, f"{_SGLANG_MOE_RUNNER_BACKEND_FLAG} {backend}",
+    )
+
+
 def apply_runtime_benchmark_overrides(
     bench: dict[str, Any],
     *,

--- a/inference_optimizer/orchestrator/action_executors/_workload_envs.py
+++ b/inference_optimizer/orchestrator/action_executors/_workload_envs.py
@@ -31,6 +31,7 @@ from ...paths import asset_root
 from ._grid_runner import (
     inject_sglang_attention_backend,
     inject_sglang_context_length,
+    inject_sglang_moe_runner_backend,
     inject_sglang_watchdog_timeout,
     server_args_env_name,
 )
@@ -451,6 +452,15 @@ def materialize_config_with_envs(
     #    backend for them and demands dual_chunk_flash_attn. Inject it
     #    unless the operator already pinned --attention-backend.
     resolved_server_args = inject_sglang_attention_backend(
+        resolved_server_args, bench.get("framework"), bench.get("model"),
+        gpu_type=gpu_type or bench.get("runner_type"),
+    )
+    # 4. MoE runner backend: MoE models on ROCm route through aiter's CK
+    #    2-stage fused-MoE kernel, whose first-request JIT build is broken in
+    #    some images (missing cub header -> hipcc fail -> stale lock -> 600s
+    #    warmup timeout). Inject the ROCm-capable triton MoE runner unless the
+    #    operator already pinned --moe-runner-backend.
+    resolved_server_args = inject_sglang_moe_runner_backend(
         resolved_server_args, bench.get("framework"), bench.get("model"),
         gpu_type=gpu_type or bench.get("runner_type"),
     )

--- a/inference_optimizer/tests/test_moe_runner_backend_injection.py
+++ b/inference_optimizer/tests/test_moe_runner_backend_injection.py
@@ -1,0 +1,221 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""sglang ``--moe-runner-backend`` injection tests (issue #512).
+
+MoE models served by sglang on MI300X/MI355X (aiter) route through aiter's CK
+2-stage fused-MoE kernel by default (``--moe-runner-backend auto``); its
+first-request JIT build is broken in some ROCm images (missing cub header ->
+hipcc fail -> stale lock -> 600s warmup timeout -> baseline_failed). Hyperloom
+injects ``--moe-runner-backend triton`` for MoE sglang models on AMD unless the
+operator already pinned one. Exercised at both the pure-helper and
+``materialize_config_with_envs`` layers.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from inference_optimizer import cli
+from inference_optimizer.orchestrator.action_executors._grid_runner import (
+    DEFAULT_SGLANG_AMD_MOE_RUNNER_BACKEND,
+    HYPERLOOM_SGLANG_MOE_RUNNER_BACKEND_ENV,
+    inject_sglang_moe_runner_backend,
+)
+from inference_optimizer.orchestrator.action_executors._workload_envs import (
+    materialize_config_with_envs,
+)
+
+_AMD = "mi300x"
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_env(monkeypatch):
+    """Neutralise host GPU autodetect + env so AMD-gating is deterministic."""
+    monkeypatch.delenv(HYPERLOOM_SGLANG_MOE_RUNNER_BACKEND_ENV, raising=False)
+    monkeypatch.delenv("GPU_TYPE", raising=False)
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_DISABLE_TP_CLAMP", "1")
+    # Without an explicit/env GPU type, _resolve_amd_gpu_type falls back to
+    # autodetect; pin it OFF so non-AMD test cases never see real hardware.
+    monkeypatch.setattr(cli, "_autodetect_gpu_type", lambda: None)
+    for key in (
+        "CONC", "ISL", "OSL", "MAX_MODEL_LEN", "TP", "RANDOM_RANGE_RATIO",
+        "ROCR_VISIBLE_DEVICES", "PRECISION", "RUN_EVAL", "FRAMEWORK",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _write_model_config(dir_path: Path, config: dict) -> str:
+    dir_path.mkdir(parents=True, exist_ok=True)
+    (dir_path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    return str(dir_path)
+
+
+@pytest.fixture
+def moe_model(tmp_path) -> str:
+    """A Qwen3-MoE-style checkpoint dir (declares an expert count)."""
+    return _write_model_config(
+        tmp_path / "Qwen-Qwen3-30B-A3B",
+        {
+            "architectures": ["Qwen3MoeForCausalLM"],
+            "model_type": "qwen3_moe",
+            "num_experts": 128,
+        },
+    )
+
+
+@pytest.fixture
+def dense_model(tmp_path) -> str:
+    """A dense (non-MoE) checkpoint dir."""
+    return _write_model_config(
+        tmp_path / "Qwen-Qwen3-8B",
+        {"architectures": ["Qwen3ForCausalLM"], "model_type": "qwen3"},
+    )
+
+
+# _model_is_moe detection
+@pytest.mark.parametrize("config", [
+    {"num_experts": 128},
+    {"num_local_experts": 8},
+    {"n_routed_experts": 64},
+    {"moe_intermediate_size": 768},
+    {"model_type": "qwen3_moe"},
+    {"architectures": ["Qwen3MoeForCausalLM"]},
+    {"text_config": {"num_experts": 16}},
+])
+def test_model_is_moe_true(tmp_path, config):
+    path = _write_model_config(tmp_path / "m", config)
+    assert cli._model_is_moe(path) is True
+
+
+@pytest.mark.parametrize("config", [
+    {"architectures": ["Qwen3ForCausalLM"], "model_type": "qwen3"},
+    {"num_experts": 1},        # single "expert" is not MoE
+    {"num_experts": True},     # bool must not count as an int expert count
+    {},
+])
+def test_model_is_moe_false(tmp_path, config):
+    path = _write_model_config(tmp_path / "m", config)
+    assert cli._model_is_moe(path) is False
+
+
+def test_model_is_moe_missing_config_is_false(tmp_path):
+    assert cli._model_is_moe(str(tmp_path / "does-not-exist")) is False
+
+
+# inject_sglang_moe_runner_backend (pure helper)
+def test_inject_appends_triton_for_moe_on_amd(moe_model):
+    out = inject_sglang_moe_runner_backend("--foo bar", "sglang", moe_model, _AMD)
+    assert out == "--foo bar --moe-runner-backend triton"
+    assert DEFAULT_SGLANG_AMD_MOE_RUNNER_BACKEND == "triton"
+
+
+def test_inject_appends_when_args_empty(moe_model):
+    assert (
+        inject_sglang_moe_runner_backend("", "sglang", moe_model, _AMD)
+        == "--moe-runner-backend triton"
+    )
+    assert (
+        inject_sglang_moe_runner_backend(None, "sglang", moe_model, _AMD)
+        == "--moe-runner-backend triton"
+    )
+
+
+def test_inject_honors_env_override(moe_model, monkeypatch):
+    monkeypatch.setenv(HYPERLOOM_SGLANG_MOE_RUNNER_BACKEND_ENV, "ck")
+    assert (
+        inject_sglang_moe_runner_backend("", "sglang", moe_model, _AMD)
+        == "--moe-runner-backend ck"
+    )
+
+
+@pytest.mark.parametrize("existing", [
+    "--moe-runner-backend ck",
+    "--moe-runner-backend=ck",
+    "--foo 1 --moe-runner-backend ck --bar 2",
+])
+def test_inject_does_not_double_user_value(moe_model, existing):
+    out = inject_sglang_moe_runner_backend(existing, "sglang", moe_model, _AMD)
+    assert out == existing
+    assert out.count("--moe-runner-backend") == 1
+    assert "triton" not in out
+
+
+def test_inject_noop_for_dense_model(dense_model):
+    assert inject_sglang_moe_runner_backend("--foo", "sglang", dense_model, _AMD) == "--foo"
+    assert "--moe-runner-backend" not in inject_sglang_moe_runner_backend(
+        "", "sglang", dense_model, _AMD,
+    )
+
+
+def test_inject_noop_on_non_amd_gpu(moe_model):
+    # Explicit non-AMD gpu + autodetect pinned off (fixture) -> no injection.
+    assert inject_sglang_moe_runner_backend("--foo", "sglang", moe_model, "h100") == "--foo"
+
+
+@pytest.mark.parametrize("framework", ["vllm", "atom"])
+def test_inject_noop_for_non_sglang(moe_model, framework):
+    assert inject_sglang_moe_runner_backend("--foo", framework, moe_model, _AMD) == "--foo"
+    assert inject_sglang_moe_runner_backend("", framework, moe_model, _AMD) == ""
+
+
+# materialize_config_with_envs (the production choke point)
+def _write_yaml(path: Path, *, model: str, framework: str = "sglang") -> None:
+    cfg = {
+        "benchmark": {
+            "framework": framework,
+            "model": model,
+            "precision": "bf16",
+            "run_mode": "local",
+            "envs": {"TP": 1, "CONC": 8, "ISL": 256, "OSL": 256},
+            "timeout_seconds": 600,
+            "profiler": {
+                "torch_profiler": {"enabled": False},
+                "system_profiler": {"enabled": False},
+                "tracelens": {"enabled": False},
+            },
+            "gpu_selection": {"auto": False},
+        }
+    }
+    with path.open("w") as f:
+        yaml.safe_dump(cfg, f)
+
+
+def _materialize_envs(
+    tmp_path: Path, *, model: str, framework: str = "sglang",
+    extra_server_args: str = "",
+) -> dict:
+    base = tmp_path / "base.yaml"
+    _write_yaml(base, model=model, framework=framework)
+    out = tmp_path / "out"
+    out.mkdir()
+    materialized = materialize_config_with_envs(
+        base, out, extra_server_args=extra_server_args,
+    )
+    return yaml.safe_load(materialized.read_text())["benchmark"]["envs"]
+
+
+def test_materialize_injects_triton_for_moe_on_amd(tmp_path, moe_model, monkeypatch):
+    monkeypatch.setenv("GPU_TYPE", _AMD)
+    envs = _materialize_envs(tmp_path, model=moe_model)
+    assert "--moe-runner-backend triton" in envs["EXTRA_SGLANG_ARGS"]
+
+
+def test_materialize_noop_for_dense_model_on_amd(tmp_path, dense_model, monkeypatch):
+    monkeypatch.setenv("GPU_TYPE", _AMD)
+    envs = _materialize_envs(tmp_path, model=dense_model)
+    assert "--moe-runner-backend" not in envs.get("EXTRA_SGLANG_ARGS", "")
+
+
+def test_materialize_does_not_double_user_backend(tmp_path, moe_model, monkeypatch):
+    monkeypatch.setenv("GPU_TYPE", _AMD)
+    envs = _materialize_envs(
+        tmp_path, model=moe_model, extra_server_args="--moe-runner-backend ck",
+    )
+    sglang_args = envs["EXTRA_SGLANG_ARGS"]
+    assert sglang_args.count("--moe-runner-backend") == 1
+    assert "ck" in sglang_args
+    assert "triton" not in sglang_args


### PR DESCRIPTION
## Summary
sglang's default `--moe-runner-backend auto` routes MoE models on MI300X/MI355X (aiter) through aiter's CK 2-stage fused-MoE kernel, whose first-request JIT build is broken in some ROCm images (`thrust` → missing `<cub/detail/detect_cuda_runtime.cuh>` → `hipcc` fail → stale lock → 600s warmup timeout → `baseline_failed`, throughput 0). See #512.

At the single sglang server-arg choke point (`materialize_config_with_envs`), this detects MoE models on AMD/ROCm and appends `--moe-runner-backend triton` (the ROCm-capable backend sglang itself falls back to) unless the operator already pinned one. **This is what unblocked the Qwen3-30B-A3B sglang baseline.**

## Changes
- `inference_optimizer/cli.py`: add `_model_is_moe()` — best-effort MoE detection from `config.json` (`num_experts`/`num_local_experts`/`n_routed_experts` > 1, `moe_intermediate_size`, or a `moe` marker in `model_type`/`architectures`; checks nested `text_config`; soft-degrades to `False`).
- `inference_optimizer/orchestrator/action_executors/_grid_runner.py`: add `inject_sglang_moe_runner_backend()`. Fail-safe no-op when framework≠sglang, a `--moe-runner-backend` is already pinned (operator wins), GPU is non-AMD, or model is non-MoE. Backend overridable via `$HYPERLOOM_SGLANG_MOE_RUNNER_BACKEND` (default `triton`).
- `inference_optimizer/orchestrator/action_executors/_workload_envs.py`: wire the injection into the choke point as step 4 (after the attention-backend guard).
- `inference_optimizer/tests/test_moe_runner_backend_injection.py`: 25 tests covering `_model_is_moe` detection, the pure helper (append / env override / no-double / dense / non-AMD / non-sglang), and the `materialize_config_with_envs` choke point.

## Test plan
- [x] `python -m pytest inference_optimizer/tests/test_moe_runner_backend_injection.py -q` → 25 passed
- [x] `python -m pytest inference_optimizer/tests/test_watchdog_injection.py inference_optimizer/tests/test_sglang_context_length_cap.py inference_optimizer/tests/test_grid_runner.py -q` → 124 passed (no regression to sibling injections)
- [ ] CI

Closes #512

Made with [Cursor](https://cursor.com)