### PR TITLE
fix: rocprof path persistence, dual-chunk/kimi-k2 preflight, roofline profile retry, rocprof Python deps

### DIFF
--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -1057,6 +1057,12 @@ _ROPE_CONFIG_KEYS = ("rope_scaling", "rope_parameters", "rope_theta")
 _AMD_UNSUPPORTED_MODEL_TYPES = frozenset({"deepseek_v32"})
 _AMD_UNSUPPORTED_ARCHITECTURES = frozenset({"deepseekv32forcausallm"})
 
+# model_type values that ship a custom AutoConfig (auto_map) but aren't
+# registered in sglang/vLLM's config mapping. sglang falls back to
+# PreTrainedConfig (base class), which lacks max_position_embeddings etc.,
+# causing AttributeError deep in engine init.
+_UNREGISTERED_CUSTOM_CONFIG_TYPES = frozenset({"kimi_k2"})
+
 
 def _detect_incompatible_model_config(
     model_path: str, gpu_type: str | None = None,
@@ -1125,6 +1131,32 @@ def _detect_incompatible_model_config(
             f"({', '.join(_MAXPOS_CONFIG_KEYS)}); transformers/vLLM rope "
             "init dereferences a missing max_position_embeddings and crashes "
             "in engine init (DeepSeek-V3.2-Exp class)."
+        )
+    # Custom AutoConfig with unregistered model_type: sglang/vLLM fall
+    # back to PreTrainedConfig (no max_position_embeddings attr) → crash.
+    auto_map = data.get("auto_map")
+    model_type = str(data.get("model_type") or "").strip().lower()
+    if (
+        isinstance(auto_map, dict)
+        and auto_map.get("AutoConfig")
+        and model_type in _UNREGISTERED_CUSTOM_CONFIG_TYPES
+    ):
+        return (
+            f"model_type '{model_type}' ships a custom AutoConfig "
+            f"({auto_map['AutoConfig']}) but is not registered in sglang/"
+            f"vLLM's config mapping; the engine falls back to "
+            f"PreTrainedConfig which lacks key attributes "
+            f"(max_position_embeddings) and crashes in init."
+        )
+    # Dual-chunk attention on AMD/ROCm: sglang hard-requires
+    # dual_chunk_flash_attn (sm90+ only) and rejects all other backends.
+    if _resolve_amd_gpu_type(gpu_type) and _model_has_dual_chunk_attention(
+        model_path
+    ):
+        return (
+            "model declares dual_chunk_attention_config but sglang requires "
+            "the dual_chunk_flash_attn backend which only builds on sm90+ "
+            "(NVIDIA Hopper); no compatible backend exists for AMD/ROCm."
         )
     return None
 

--- a/inference_optimizer/orchestrator/action_executors/_grid_runner.py
+++ b/inference_optimizer/orchestrator/action_executors/_grid_runner.py
@@ -874,23 +874,18 @@ def inject_sglang_context_length(
 def _resolve_dual_chunk_backend(gpu_type: str | None = None) -> str:
     """Pick the dual-chunk attention backend for the current hardware.
 
-    ``dual_chunk_flash_attn`` is an sgl-kernel flash-attn path that only
-    builds for sm90+ (NVIDIA Hopper); on AMD/ROCm (MI300X/MI325X/MI355X,
-    gfx9) sglang raises ``flash_attn at sgl-kernel is only supported on
-    sm90 and above`` and the server is killed before baseline. ``triton``
-    is the ROCm-capable backend that still honours dual-chunk attention,
-    so we fall back to it on any AMD GPU. The hardware is resolved from the
-    explicit ``gpu_type`` first (the caller already knows it and writes it
-    into the runner), then ``GPU_TYPE``, then a runtime autodetect, so a
-    missing ``rocm-smi``/torch probe at this call site cannot silently fall
-    back to the sm90-only kernel. Override via ``$HYPERLOOM_DUAL_CHUNK_BACKEND``.
+    ``dual_chunk_flash_attn`` is the only backend sglang accepts when the
+    model declares ``dual_chunk_attention_config``. It requires sm90+
+    (NVIDIA Hopper); on AMD/ROCm the preflight gate
+    (``_detect_incompatible_model_config``) blocks these models before
+    they reach this point. If a session somehow arrives here on AMD
+    (e.g. operator override), return the canonical backend and let sglang
+    raise the clear error rather than silently injecting triton which
+    sglang also rejects.  Override via ``$HYPERLOOM_DUAL_CHUNK_BACKEND``.
     """
     override = os.environ.get("HYPERLOOM_DUAL_CHUNK_BACKEND", "").strip()
     if override:
         return override
-    from ...cli import _resolve_amd_gpu_type
-    if _resolve_amd_gpu_type(gpu_type):
-        return "triton"
     return _SGLANG_DUAL_CHUNK_BACKEND
 
 

--- a/inference_optimizer/orchestrator/action_executors/roofline.py
+++ b/inference_optimizer/orchestrator/action_executors/roofline.py
@@ -22,11 +22,16 @@ Design constraints (§4/§6):
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from ..sub_agent_runner import RunnerContext
+
+log = logging.getLogger(__name__)
+
+_PROFILE_MAX_ATTEMPTS = 3
 
 
 def _now_iso() -> str:
@@ -168,29 +173,68 @@ class RooflineExecutor:
 
         session_dir = self._resolve_session_dir(ctx)
 
-        # ---- Step 1: profile ------------------------------------------------
-        profile_ctx = self._wrap_profile_ctx(ctx)
-        try:
-            profile_result = await profile_executor(profile_ctx)
-        except Exception as exc:  # noqa: BLE001 — surface sub-step errors
-            return _failed("profile", f"profile_executor raised: {exc!r}")
-        if not isinstance(profile_result, dict):
+        # ---- Step 1: profile (with retry) ------------------------------------
+        # sglang's torch profiler on MI300X/ROCm is unstable: ~86% per-attempt
+        # failure rate (SIGQUIT / "Profiling is not in progress" / engine init
+        # crash). Retry up to _PROFILE_MAX_ATTEMPTS times; each call to
+        # profile_executor manages its own server lifecycle, so a fresh attempt
+        # starts with a clean profiling state.
+        profile_result: dict[str, Any] | None = None
+        trace_path = ""
+        last_error = ""
+        for attempt in range(1, _PROFILE_MAX_ATTEMPTS + 1):
+            profile_ctx = self._wrap_profile_ctx(ctx)
+            try:
+                profile_result = await profile_executor(profile_ctx)
+            except Exception as exc:  # noqa: BLE001
+                last_error = f"profile_executor raised: {exc!r}"
+                log.warning(
+                    "roofline profile attempt %d/%d failed (exception): %s",
+                    attempt, _PROFILE_MAX_ATTEMPTS, last_error,
+                )
+                continue
+            if not isinstance(profile_result, dict):
+                last_error = (
+                    f"profile_executor returned non-dict: "
+                    f"{type(profile_result).__name__}"
+                )
+                log.warning(
+                    "roofline profile attempt %d/%d failed (bad return): %s",
+                    attempt, _PROFILE_MAX_ATTEMPTS, last_error,
+                )
+                continue
+            if profile_result.get("status") != "succeeded":
+                last_error = str(
+                    profile_result.get("error") or "profile sub-step failed"
+                )
+                log.warning(
+                    "roofline profile attempt %d/%d failed: %s",
+                    attempt, _PROFILE_MAX_ATTEMPTS, last_error,
+                )
+                continue
+            trace_path = _extract_trace_path(profile_result)
+            if not trace_path:
+                last_error = (
+                    "profile succeeded but no trace_path in result "
+                    "(missing both main_trace_path and trace_files[0])"
+                )
+                log.warning(
+                    "roofline profile attempt %d/%d: no trace path",
+                    attempt, _PROFILE_MAX_ATTEMPTS,
+                )
+                continue
+            # Success
+            if attempt > 1:
+                log.info(
+                    "roofline profile succeeded on attempt %d/%d",
+                    attempt, _PROFILE_MAX_ATTEMPTS,
+                )
+            break
+        else:
             return _failed(
                 "profile",
-                f"profile_executor returned non-dict: {type(profile_result).__name__}",
-            )
-        if profile_result.get("status") != "succeeded":
-            return _failed(
-                "profile",
-                str(profile_result.get("error") or "profile sub-step failed"),
-                sub_result=profile_result,
-            )
-        trace_path = _extract_trace_path(profile_result)
-        if not trace_path:
-            return _failed(
-                "profile_no_trace",
-                "profile succeeded but no trace_path in result "
-                "(missing both main_trace_path and trace_files[0])",
+                f"all {_PROFILE_MAX_ATTEMPTS} profile attempts failed; "
+                f"last: {last_error}",
                 sub_result=profile_result,
             )
 

--- a/inference_optimizer/orchestrator/action_executors/roofline.py
+++ b/inference_optimizer/orchestrator/action_executors/roofline.py
@@ -182,11 +182,15 @@ class RooflineExecutor:
         profile_result: dict[str, Any] | None = None
         trace_path = ""
         last_error = ""
+        # Track the last failure kind so the no-trace contract is preserved
+        # (profile_no_trace_failed) instead of collapsing into profile_failed.
+        last_phase = "profile"
         for attempt in range(1, _PROFILE_MAX_ATTEMPTS + 1):
             profile_ctx = self._wrap_profile_ctx(ctx)
             try:
                 profile_result = await profile_executor(profile_ctx)
             except Exception as exc:  # noqa: BLE001
+                last_phase = "profile"
                 last_error = f"profile_executor raised: {exc!r}"
                 log.warning(
                     "roofline profile attempt %d/%d failed (exception): %s",
@@ -194,6 +198,7 @@ class RooflineExecutor:
                 )
                 continue
             if not isinstance(profile_result, dict):
+                last_phase = "profile"
                 last_error = (
                     f"profile_executor returned non-dict: "
                     f"{type(profile_result).__name__}"
@@ -204,6 +209,7 @@ class RooflineExecutor:
                 )
                 continue
             if profile_result.get("status") != "succeeded":
+                last_phase = "profile"
                 last_error = str(
                     profile_result.get("error") or "profile sub-step failed"
                 )
@@ -214,6 +220,7 @@ class RooflineExecutor:
                 continue
             trace_path = _extract_trace_path(profile_result)
             if not trace_path:
+                last_phase = "profile_no_trace"
                 last_error = (
                     "profile succeeded but no trace_path in result "
                     "(missing both main_trace_path and trace_files[0])"
@@ -232,7 +239,7 @@ class RooflineExecutor:
             break
         else:
             return _failed(
-                "profile",
+                last_phase,
                 f"all {_PROFILE_MAX_ATTEMPTS} profile attempts failed; "
                 f"last: {last_error}",
                 sub_result=profile_result,

--- a/inference_optimizer/scripts/install.sh
+++ b/inference_optimizer/scripts/install.sh
@@ -741,14 +741,102 @@ ensure_bench_serving_deps() {
 ROCPROF_COMPUTE_BIN="${ROCPROF_COMPUTE_BIN:-rocprof-compute}"
 ROCPROF_COMPUTE_PATH="${HYPERLOOM_ROCPROF_COMPUTE_PATH:-${ROCPROF_COMPUTE_PATH:-/opt/rocm/bin/rocprof-compute}}"
 ROCPROF_APT_BIN="${ROCPROF_APT_BIN:-apt-get}"
+ROCPROF_REQUIREMENTS="${ROCPROF_REQUIREMENTS:-}"
 
 _rocprof_compute_present() {
   command -v "$ROCPROF_COMPUTE_BIN" >/dev/null 2>&1 || [ -x "$ROCPROF_COMPUTE_PATH" ]
 }
 
+_rocprof_compute_runnable() {
+  local bin="$1"
+  "$bin" --version >/dev/null 2>&1
+}
+
+_rocprof_find_requirements() {
+  local bin="$1"
+  if [ -n "$ROCPROF_REQUIREMENTS" ] && [ -f "$ROCPROF_REQUIREMENTS" ]; then
+    echo "$ROCPROF_REQUIREMENTS"; return 0
+  fi
+  local hint
+  hint="$("$bin" --version 2>&1 | grep -oP '(?<=See: )\S+requirements\.txt' | head -1)" || true
+  if [ -n "$hint" ] && [ -f "$hint" ]; then
+    echo "$hint"; return 0
+  fi
+  local d
+  for d in /opt/rocm/libexec/rocprofiler-compute /opt/rocm-*/libexec/rocprofiler-compute; do
+    if [ -f "$d/requirements.txt" ]; then
+      echo "$d/requirements.txt"; return 0
+    fi
+  done
+  return 1
+}
+
+_rocprof_fix_python_deps() {
+  local bin="$1"
+  if _rocprof_compute_runnable "$bin"; then return 0; fi
+  log "rocprof-compute binary present but --version failed; checking Python deps"
+  local req
+  if ! req="$(_rocprof_find_requirements "$bin")"; then
+    warn "rocprof-compute --version failed and requirements.txt not found; roofline may be degraded"
+    return 1
+  fi
+  if [ "$CHECK_ONLY" -eq 1 ]; then
+    warn "rocprof-compute deps missing (check-only; would pip install -r $req)"
+    return 1
+  fi
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "would pip install rocprof-compute Python deps from $req"
+    return 1
+  fi
+  # vllm images ship apt-installed python3-blinker 1.4 (distutils
+  # egg-info, no RECORD) which pip cannot uninstall.
+  if "$PYTHON" -c "import vllm" >/dev/null 2>&1; then
+    log "vllm detected; pre-installing blinker to work around distutils conflict"
+    "$PYTHON" -m pip install --quiet --no-cache-dir --break-system-packages \
+      --ignore-installed "blinker>=1.9" >/dev/null 2>&1 || true
+  fi
+  log "installing rocprof-compute Python deps from $req"
+  if "$PYTHON" -m pip install --quiet --no-cache-dir --break-system-packages \
+       -r "$req" >/dev/null 2>&1 \
+     && _rocprof_compute_runnable "$bin"; then
+    log "rocprof-compute Python deps installed OK"
+    return 0
+  fi
+  warn "rocprof-compute Python dep install failed; roofline may be degraded"
+  return 1
+}
+
+_rocprof_fix_pandas3() {
+  # rocprof-compute 3.4.0 is incompatible with pandas 3.0+ (Arrow
+  # string backend changes dtype, breaking Agent_Id conversion).
+  if "$PYTHON" -c "import pandas; v=tuple(int(x) for x in pandas.__version__.split('.')[:2]); exit(0 if v>=(3,0) else 1)" 2>/dev/null; then
+    log "pandas 3.x detected; downgrading to 2.x for rocprof-compute compat"
+    if [ "$CHECK_ONLY" -eq 1 ] || [ "$DRY_RUN" -eq 1 ]; then
+      log "would pip install 'pandas>=2.1,<3'"
+      return 0
+    fi
+    "$PYTHON" -m pip install --quiet --no-cache-dir --break-system-packages \
+      "pandas>=2.1,<3" >/dev/null 2>&1 \
+      && log "pandas downgraded to $("$PYTHON" -c 'import pandas; print(pandas.__version__)')" \
+      || warn "pandas downgrade failed; rocprof-compute roofline may produce empty results"
+  fi
+}
+
 ensure_rocprof_compute() {
   if _rocprof_compute_present; then
-    log "rocprof-compute present"
+    # Persist the resolved absolute path so Ray workers (trimmed PATH) can find it.
+    local resolved
+    resolved="$(command -v "$ROCPROF_COMPUTE_BIN" 2>/dev/null)" || resolved=""
+    [ -z "$resolved" ] && [ -x "$ROCPROF_COMPUTE_PATH" ] && resolved="$ROCPROF_COMPUTE_PATH"
+    if [ -n "$resolved" ]; then
+      export HYPERLOOM_ROCPROF_COMPUTE_PATH="$resolved"
+      _rocprof_fix_python_deps "$resolved" || true
+      _rocprof_fix_pandas3
+      log "rocprof-compute present at ${resolved}"
+    else
+      _rocprof_fix_pandas3
+      log "rocprof-compute present"
+    fi
     return 0
   fi
   if ! command -v "$ROCPROF_APT_BIN" >/dev/null 2>&1; then
@@ -768,7 +856,13 @@ ensure_rocprof_compute() {
   if "$ROCPROF_APT_BIN" update -qq >/dev/null 2>&1 \
       && "$ROCPROF_APT_BIN" install -y --no-install-recommends rocprofiler-compute >/dev/null 2>&1 \
       && _rocprof_compute_present; then
-    log "rocprofiler-compute installed OK"
+    local resolved
+    resolved="$(command -v "$ROCPROF_COMPUTE_BIN" 2>/dev/null)" || resolved=""
+    [ -z "$resolved" ] && [ -x "$ROCPROF_COMPUTE_PATH" ] && resolved="$ROCPROF_COMPUTE_PATH"
+    [ -n "$resolved" ] && export HYPERLOOM_ROCPROF_COMPUTE_PATH="$resolved"
+    [ -n "$resolved" ] && _rocprof_fix_python_deps "$resolved" || true
+    _rocprof_fix_pandas3
+    log "rocprofiler-compute installed OK${resolved:+ at ${resolved}}"
   else
     warn "rocprofiler-compute install failed; kernel roofline data will be skipped (preinstall it in the image to fix)"
   fi

--- a/inference_optimizer/tests/test_install_rocprof_compute.py
+++ b/inference_optimizer/tests/test_install_rocprof_compute.py
@@ -87,6 +87,7 @@ export PATH="{fake_bin}:/usr/bin:/bin"
 export ROCPROF_COMPUTE_BIN="{rocprof_bin}"
 export HYPERLOOM_ROCPROF_COMPUTE_PATH="{rocprof_path}"
 export ROCPROF_APT_BIN="{apt_bin}"
+export PYTHON="$(command -v python3 || echo /usr/bin/python3)"
 log() {{ echo "[log] $*"; }}
 warn() {{ echo "[warn] $*"; }}
 CHECK_ONLY={check_only}
@@ -147,3 +148,45 @@ def test_dry_run_does_not_install(tmp_path: Path) -> None:
     )
     assert not apt_called, f"--dry-run must not install:\n{out}"
     assert "would install" in out
+
+
+def test_present_path_persisted_for_ray_workers(tmp_path: Path) -> None:
+    """ensure_rocprof_compute must export the resolved absolute path so
+    Ray workers with a trimmed PATH can locate the binary (root cause of
+    the 2026-06-09 rocprof failures)."""
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    rocprof_stub = tmp_path / "rocprof-compute-stub"
+    _make_exec(rocprof_stub, "#!/bin/sh\nexit 0\n")
+    # Feed the path via the legacy ROCPROF_COMPUTE_PATH input (not the
+    # HYPERLOOM_ output var) so the assertion truly observes the export,
+    # not a leaked input.
+    harness = f"""#!/usr/bin/env bash
+set -euo pipefail
+export PATH="{fake_bin}:/usr/bin:/bin"
+export ROCPROF_COMPUTE_BIN="definitely-not-a-real-cmd"
+unset HYPERLOOM_ROCPROF_COMPUTE_PATH
+export ROCPROF_COMPUTE_PATH="{rocprof_stub}"
+export ROCPROF_APT_BIN="definitely-not-a-real-apt"
+export PYTHON="$(command -v python3 || echo /usr/bin/python3)"
+log() {{ echo "[log] $*"; }}
+warn() {{ echo "[warn] $*"; }}
+CHECK_ONLY=0
+DRY_RUN=0
+
+{_extract_ensure_rocprof_compute()}
+
+ensure_rocprof_compute
+echo "RESOLVED=${{HYPERLOOM_ROCPROF_COMPUTE_PATH:-<unset>}}"
+"""
+    script = tmp_path / "harness.sh"
+    script.write_text(harness, encoding="utf-8")
+    proc = subprocess.run(
+        ["bash", str(script)], cwd=REPO_ROOT, text=True,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False,
+    )
+    assert proc.returncode == 0, f"harness failed:\n{proc.stdout}"
+    assert f"RESOLVED={rocprof_stub}" in proc.stdout, (
+        f"resolved path must be persisted for Ray workers:\n{proc.stdout}"
+    )
+    assert "rocprof-compute present at" in proc.stdout

--- a/inference_optimizer/tests/test_model_config_compat_preflight.py
+++ b/inference_optimizer/tests/test_model_config_compat_preflight.py
@@ -129,6 +129,54 @@ def test_detect_rope_in_nested_text_config(tmp_path):
     assert reason is not None
 
 
+def test_detect_dual_chunk_blocks_on_amd(tmp_path):
+    m = tmp_path / "dual_chunk_amd"
+    _write_config(
+        m,
+        model_type="qwen2",
+        max_position_embeddings=1010000,
+        dual_chunk_attention_config={"chunk_size": 262144},
+    )
+    reason = cli._detect_incompatible_model_config(str(m), gpu_type="mi300x")
+    assert reason is not None
+    assert "dual_chunk" in reason
+
+
+def test_detect_dual_chunk_not_blocked_off_amd(tmp_path):
+    m = tmp_path / "dual_chunk_non_amd"
+    _write_config(
+        m,
+        model_type="qwen2",
+        max_position_embeddings=1010000,
+        dual_chunk_attention_config={"chunk_size": 262144},
+    )
+    assert cli._detect_incompatible_model_config(str(m)) is None
+
+
+def test_detect_unregistered_custom_config_blocks(tmp_path):
+    m = tmp_path / "kimi_k2"
+    _write_config(
+        m,
+        model_type="kimi_k2",
+        max_position_embeddings=131072,
+        auto_map={"AutoConfig": "configuration_deepseek.DeepseekV3Config"},
+    )
+    reason = cli._detect_incompatible_model_config(str(m))
+    assert reason is not None
+    assert "kimi_k2" in reason
+
+
+def test_detect_custom_automap_known_type_not_blocked(tmp_path):
+    m = tmp_path / "known_automap"
+    _write_config(
+        m,
+        model_type="llama",
+        max_position_embeddings=8192,
+        auto_map={"AutoConfig": "configuration_custom.CustomConfig"},
+    )
+    assert cli._detect_incompatible_model_config(str(m)) is None
+
+
 # ---------------------------------------------------------------------------
 # _preflight_model_config_compat — persistence + return contract
 # ---------------------------------------------------------------------------

--- a/inference_optimizer/tests/test_sglang_context_length_cap.py
+++ b/inference_optimizer/tests/test_sglang_context_length_cap.py
@@ -313,16 +313,15 @@ def test_dual_chunk_injects_via_nested_text_config(tmp_path):
     assert "--attention-backend dual_chunk_flash_attn" in out
 
 
-def test_dual_chunk_falls_back_to_triton_on_amd(tmp_path, monkeypatch):
-    """On AMD/ROCm dual_chunk_flash_attn is unsupported (sm90+), so the
-    injected backend must fall back to triton."""
+def test_dual_chunk_on_amd_returns_canonical_backend(tmp_path, monkeypatch):
+    """AMD dual-chunk models are blocked by preflight; if inject still runs
+    it should return the canonical backend (not triton which sglang rejects)."""
     monkeypatch.setattr(
         "inference_optimizer.cli._autodetect_gpu_type", lambda: "mi300x",
     )
     model = _write_dual_chunk_model(tmp_path, dual_chunk=True)
     out = inject_sglang_attention_backend("--foo bar", "sglang", model)
-    assert "--attention-backend triton" in out
-    assert "dual_chunk_flash_attn" not in out
+    assert "--attention-backend dual_chunk_flash_attn" in out
     assert "--foo bar" in out
 
 
@@ -332,8 +331,7 @@ def test_dual_chunk_uses_explicit_gpu_type_before_autodetect(tmp_path):
     out = inject_sglang_attention_backend(
         "--foo bar", "sglang", model, gpu_type="mi300x",
     )
-    assert "--attention-backend triton" in out
-    assert "dual_chunk_flash_attn" not in out
+    assert "--attention-backend dual_chunk_flash_attn" in out
 
 
 def test_dual_chunk_backend_env_override(tmp_path, monkeypatch):
@@ -387,5 +385,4 @@ def test_materialize_sglang_uses_runner_type_for_dual_chunk_backend(tmp_path):
         tmp_path, framework="sglang", model=model, runner_type="mi300x",
     )
     sglang_args = envs["EXTRA_SGLANG_ARGS"]
-    assert "--attention-backend triton" in sglang_args
-    assert "dual_chunk_flash_attn" not in sglang_args
+    assert "--attention-backend dual_chunk_flash_attn" in sglang_args

--- a/kernel-agent/scripts/install.sh
+++ b/kernel-agent/scripts/install.sh
@@ -1232,6 +1232,7 @@ write_env_file() {
     [ -n "${GEAK_SAVE_TO_KNOWLEDGE_BASE_VAL}" ] && echo "export GEAK_SAVE_TO_KNOWLEDGE_BASE='${GEAK_SAVE_TO_KNOWLEDGE_BASE_VAL}'"
     [ -n "${GEAK_MEMORY_MIN_SPEEDUP_VAL}" ] && echo "export GEAK_MEMORY_MIN_SPEEDUP='${GEAK_MEMORY_MIN_SPEEDUP_VAL}'"
     [ -n "${CODEX_MODEL_VAL}" ] && echo "export CODEX_MODEL='${CODEX_MODEL_VAL}'"
+    [ -n "${HYPERLOOM_ROCPROF_COMPUTE_PATH:-}" ] && echo "export HYPERLOOM_ROCPROF_COMPUTE_PATH='${HYPERLOOM_ROCPROF_COMPUTE_PATH}'"
   } > "$env_file"
   chmod 600 "$env_file"
   log "wrote ${env_file} (source it before running kernel-agent tools)"


### PR DESCRIPTION

1. rocprof-compute path persistence: ensure_rocprof_compute now resolves the absolute path via command -v and exports HYPERLOOM_ROCPROF_COMPUTE_PATH into kernel-agent.env.sh so Ray workers with trimmed PATH can find it.

2. rocprof-compute Python deps & pandas compat: add _rocprof_fix_python_deps (auto-install missing deps from requirements.txt, with vllm blinker workaround) and _rocprof_fix_pandas3 (downgrade pandas 3.x to 2.x for rocprof-compute 3.4.0 compat).

3. dual-chunk AMD preflight: AMD + dual_chunk_attention_config models are now blocked at preflight (model_config_incompatible) instead of injecting triton backend which sglang also rejects. Remove the dead AMD triton fallback from _resolve_dual_chunk_backend.

4. kimi_k2 preflight: add _UNREGISTERED_CUSTOM_CONFIG_TYPES to detect model_type values with custom AutoConfig not in sglang CONFIG_MAPPING (fallback to PreTrainedConfig → AttributeError on max_position_embeddings).

5. roofline profile retry: RooflineExecutor now retries the profile sub-step up to 3 times (sglang torch profiler on MI300X/ROCm has ~86% per-attempt failure rate due to SIGQUIT / "Profiling is not in progress"). Each retry gets a fresh server lifecycle via profile_executor.

Tests: 77 passed (preflight, install, sglang cap, rocprof, magpie).
