### PR TITLE
feat(breakdown): author-time recorder for session_breakdown with collector fallback

### DIFF
--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -2389,6 +2389,38 @@ def _patch_winners_history(
     return out
 
 
+def _shape_winners_history(
+    explore_search: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    """Persist ``explore_search.winners_history`` rows with their join key + source.
+
+    ``_shape_ledger`` drops this history, so without re-emitting it the exported
+    ``explore_search`` carries no ``fingerprint``→``provenance`` map and downstream
+    consumers can't reconstruct ``phase_breakdown.explore.by_domain`` offline.
+    """
+    if not isinstance(explore_search, dict):
+        return []
+    rows = explore_search.get("winners_history")
+    if not isinstance(rows, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for w in rows:
+        if not isinstance(w, dict):
+            continue
+        out.append({
+            "round_id":     str(w.get("round_id") or ""),
+            "variant_name": str(w.get("variant_name") or w.get("name") or ""),
+            "fingerprint":  str(w.get("fingerprint") or ""),
+            "provenance":   str(w.get("provenance") or ""),
+            "scope":        str(w.get("scope") or ""),
+            "gain_pct":     _to_float(w.get("gain_pct")),
+            "extra_args":   str(w.get("extra_args") or w.get("extra_server_args") or ""),
+            "extra_envs":   dict(w.get("extra_envs") or {}),
+            "ts":           str(w.get("ts") or ""),
+        })
+    return out
+
+
 def collect_explore_search(
     state: dict[str, Any],
     warnings: list[str],
@@ -2396,6 +2428,11 @@ def collect_explore_search(
     # Emit all three ledgers (unified explore + legacy params/backends) so
     # breakdown reprocesses both vintages; unused ones shape to empty shells.
     explore_ledger = _shape_ledger(state.get("explore_search"))
+    # Persist provenance+fingerprint winners_history so offline recompute /
+    # downstream can recover the explore specialist attribution.
+    explore_ledger["winners_history"] = _shape_winners_history(
+        state.get("explore_search")
+    )
     explore_ledger["winner_history"] = list(state.get("params_winner_history") or [])
     explore_ledger["no_promote_streak"] = int(
         state.get("params_no_promote_streak") or 0
@@ -2849,7 +2886,7 @@ def _promote_legacy_gain_entries(
             cum_after = None
         delta = (cum_after - prev_cum) if cum_after is not None else None
         se = stack[i] if i < len(stack) and isinstance(stack[i], dict) else {}
-        out.append({
+        promoted: dict[str, Any] = {
             "ts": str(se.get("ts") or ""),
             "action": str(se.get("action") or ""),
             "variant_name": se.get("variant_name") or se.get("kernel_id"),
@@ -2863,7 +2900,17 @@ def _promote_legacy_gain_entries(
                 or se.get("candidate_extra_server_args")
                 or ""
             ),
-        })
+        }
+        # Carry the explore join key / source forward when the Coordinator
+        # stamped them, so phase_breakdown.explore.by_domain can attribute
+        # the gain to its specialist provenance instead of ``default_grid``.
+        fp = str(se.get("fingerprint") or se.get("variant_fingerprint") or "")
+        if fp:
+            promoted["fingerprint"] = fp
+        prov = str(se.get("provenance") or "").strip()
+        if prov:
+            promoted["provenance"] = prov
+        out.append(promoted)
         if cum_after is not None:
             prev_cum = cum_after
     return out
@@ -3226,7 +3273,7 @@ def _reconstruct_gain_ledger(
             continue
         delta = _to_float(entry.get("gain_pct"))
         cum_after = cum_before + (delta or 0.0)
-        out.append({
+        row: dict[str, Any] = {
             "ts":                str(entry.get("ts") or ""),
             "stack_len_before":  i,
             "stack_len_after":   i + 1,
@@ -3236,7 +3283,16 @@ def _reconstruct_gain_ledger(
             "cum_gain_after":    round(cum_after, 4),
             "delta_pct":         delta,
             "extra_server_args": str(entry.get("extra_server_args") or ""),
-        })
+        }
+        # Preserve the explore join key / source so attribution can resolve the
+        # specialist provenance (else by_domain collapses into ``default_grid``).
+        fp = str(entry.get("fingerprint") or entry.get("variant_fingerprint") or "")
+        if fp:
+            row["fingerprint"] = fp
+        prov = str(entry.get("provenance") or "").strip()
+        if prov:
+            row["provenance"] = prov
+        out.append(row)
         cum_before = cum_after
     return out
 

--- a/inference_optimizer/breakdown/exporter.py
+++ b/inference_optimizer/breakdown/exporter.py
@@ -79,37 +79,56 @@ def build(
     state = _load_state(sd, warnings)
     manifest = _load_manifest(sd, warnings)
 
+    # Author-time recorder fragments (write-side spool). When present they are
+    # the source of truth for their section (they capture facts the collectors
+    # can miss: pre-dispatch/infra failures, pruned robustness signals, ...);
+    # when absent the legacy collectors are used as fallback, so historical
+    # sessions and recorder-disabled runs behave exactly as before.
+    assembled = _load_assembled(sd, warnings)
+
+    def _pick(section: str, collector_value: Any) -> Any:
+        """Fragment value if recorded and non-empty, else the collector value."""
+        frag = assembled.get(section)
+        if isinstance(frag, list) and frag:
+            return frag
+        if isinstance(frag, dict) and frag:
+            return frag
+        return collector_value
+
     from datetime import datetime, timezone
     exported_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
 
     # Section collectors (each catches its own errors via warnings).
-    session_meta      = _safe_collect("session",
+    session_meta      = _pick("session", _safe_collect("session",
                                        lambda: collectors.collect_session(sd, state, manifest, warnings),
-                                       warnings)
-    workload          = _safe_collect("workload",
+                                       warnings))
+    workload          = _pick("workload", _safe_collect("workload",
                                        lambda: collectors.collect_workload(state, manifest, warnings),
-                                       warnings)
-    baseline          = _safe_collect("baseline",
+                                       warnings))
+    baseline          = _pick("baseline", _safe_collect("baseline",
                                        lambda: collectors.collect_baseline(sd, state, warnings),
-                                       warnings)
-    final             = _safe_collect("final",
+                                       warnings))
+    final             = _pick("final", _safe_collect("final",
                                        lambda: collectors.collect_final(sd, state, warnings),
-                                       warnings)
-    phase_timeline    = _safe_collect("phase_timeline",
+                                       warnings))
+    phase_timeline    = _pick("phase_timeline", _safe_collect("phase_timeline",
                                        lambda: collectors.collect_phase_timeline(sd, state, warnings),
-                                       warnings)
+                                       warnings))
+    # Derived from the resolved (fragment-or-collector) phase_timeline.
     phase_segments    = _safe_collect("phase_segments",
                                        lambda: collectors.collect_phase_segments(
                                            state, phase_timeline, warnings,
                                        ),
                                        warnings,
                                        default=[])
-    geak_invocations, oob_invocations = _safe_collect(
+    geak_c, oob_c = _safe_collect(
         "invocations",
         lambda: collectors.collect_kernel_invocations(sd, warnings),
         warnings,
         default=([], []),
     )
+    geak_invocations = _pick("geak_invocations", geak_c)
+    oob_invocations = _pick("oob_invocations", oob_c)
     capability_summary = _safe_collect("capability_summary",
                                         lambda: collectors.collect_capability_summary(
                                             state, geak_invocations, oob_invocations, warnings,
@@ -120,18 +139,18 @@ def build(
                                             sd, state, geak_invocations, oob_invocations, warnings,
                                         ),
                                         warnings)
-    explore_search     = _safe_collect("explore_search",
+    explore_search     = _pick("explore_search", _safe_collect("explore_search",
                                         lambda: collectors.collect_explore_search(state, warnings),
-                                        warnings)
-    sweep              = _safe_collect("sweep",
+                                        warnings))
+    sweep              = _pick("sweep", _safe_collect("sweep",
                                         lambda: collectors.collect_sweep(sd, state, warnings),
-                                        warnings)
-    critic_robustness  = _safe_collect("critic_robustness",
+                                        warnings))
+    critic_robustness  = _pick("critic_robustness", _safe_collect("critic_robustness",
                                         lambda: collectors.collect_critic_robustness(sd, warnings),
-                                        warnings)
-    telemetry          = _safe_collect("telemetry",
+                                        warnings))
+    telemetry          = _pick("telemetry", _safe_collect("telemetry",
                                         lambda: collectors.collect_telemetry(sd, state, warnings),
-                                        warnings)
+                                        warnings))
     attribution        = _safe_collect("attribution",
                                         lambda: collectors.collect_attribution(
                                             state, geak_invocations, oob_invocations,
@@ -139,61 +158,61 @@ def build(
                                             warnings,
                                         ),
                                         warnings)
-    kb_provenance      = _safe_collect("kb_provenance",
+    kb_provenance      = _pick("kb_provenance", _safe_collect("kb_provenance",
                                         lambda: collectors.collect_kb_provenance(
                                             session_dir, state, manifest, warnings,
                                         ),
-                                        warnings)
+                                        warnings))
     # specialist sub-agent dispatch records (single source: state + on-disk transcripts).
-    specialist_runs    = _safe_collect("specialist_runs",
+    specialist_runs    = _pick("specialist_runs", _safe_collect("specialist_runs",
                                         lambda: collectors.collect_specialist_runs(
                                             sd, state, warnings,
                                             include_transcripts=include_transcripts,
                                         ),
                                         warnings,
-                                        default=[])
+                                        default=[]))
     # Raw ``state.optimization_stack[]`` passthrough (full per-entry evidence; never raises).
-    optimization_stack = _safe_collect("optimization_stack",
+    optimization_stack = _pick("optimization_stack", _safe_collect("optimization_stack",
                                         lambda: collectors.collect_optimization_stack(state),
                                         warnings,
-                                        default=[])
+                                        default=[]))
     # Hot-kernel roofline table (Dashboard §1) from ``<sd>/reports/kernel_roofline.json``.
-    kernel_roofline    = _safe_collect("kernel_roofline",
+    kernel_roofline    = _pick("kernel_roofline", _safe_collect("kernel_roofline",
                                         lambda: collectors.collect_kernel_roofline(
                                             sd, warnings,
                                         ),
                                         warnings,
-                                        default={})
+                                        default={}))
     # Kernel-agent attempt outcome summary (Breakdown panel integration spec §A1);
     # mirrors ``reports/kernel_optimization_summary.json``, empty → dashboard hides Block 1.
-    kernel_optimization_summary = _safe_collect(
+    kernel_optimization_summary = _pick("kernel_optimization_summary", _safe_collect(
         "kernel_optimization_summary",
         lambda: collectors.collect_kernel_optimization_summary(sd, warnings),
         warnings,
-        default={})
+        default={}))
     # Post-optimization concurrency sweep (Breakdown panel integration spec §A2);
     # mirrors ``reports/conc_sweep_summary.json``, empty → dashboard hides Block 2.
-    conc_sweep_summary = _safe_collect(
+    conc_sweep_summary = _pick("conc_sweep_summary", _safe_collect(
         "conc_sweep_summary",
         lambda: collectors.collect_conc_sweep_summary(sd, warnings),
         warnings,
-        default={})
+        default={}))
     # Per-snapshot roofline comparison list (markdown ``## Roofline`` source) from ``state.roofline_snapshots``.
-    roofline           = _safe_collect("roofline",
+    roofline           = _pick("roofline", _safe_collect("roofline",
                                         lambda: collectors.collect_roofline(
                                             state, warnings,
                                         ),
                                         warnings,
-                                        default=[])
+                                        default=[]))
     # Optimization-progress curve (Dashboard §2): stack ledger + ceiling/target
     # lines from state.json. Renamed from ``roofline`` to avoid clashing with the
     # list-shaped section above.
-    roofline_progress  = _safe_collect("roofline_progress",
+    roofline_progress  = _pick("roofline_progress", _safe_collect("roofline_progress",
                                         lambda: collectors.collect_roofline_progress(
                                             sd, state, manifest, warnings,
                                         ),
                                         warnings,
-                                        default={})
+                                        default={}))
 
     source_files = collectors.collect_source_files(
         sd,
@@ -248,6 +267,31 @@ def build(
         "warnings":            warnings,
         "source_files":        source_files,
     }
+
+
+def _load_assembled(
+    session_dir: Path,
+    warnings: list[str],
+) -> dict[str, Any]:
+    """Assemble recorder fragments into ``{section: value}`` (empty on opt-out
+    or when no fragments exist). Never raises — a recorder bug must not poison
+    the export; it just falls back to collectors."""
+    disabled = os.environ.get(
+        "INFERENCE_OPTIMIZER_BREAKDOWN_DISABLE_RECORDER", "",
+    ).strip().lower() in ("1", "true", "yes")
+    if disabled:
+        return {}
+    try:
+        from .recorder import assemble_parts, has_parts
+
+        if not has_parts(session_dir):
+            return {}
+        out = assemble_parts(session_dir, warnings=warnings)
+        return out if isinstance(out, dict) else {}
+    except Exception as exc:  # noqa: BLE001
+        log.exception("recorder: assemble_parts failed")
+        warnings.append(f"recorder: assemble_parts failed: {type(exc).__name__}: {exc}")
+        return {}
 
 
 def _safe_collect(

--- a/inference_optimizer/breakdown/recorder/__init__.py
+++ b/inference_optimizer/breakdown/recorder/__init__.py
@@ -1,0 +1,63 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Breakdown recorder: author-time capture of ``session_breakdown.json`` data.
+
+Producers record facts where they are born (see :func:`get_recorder`); the
+exporter assembles them at finalize (see :func:`assemble_parts`). Each section
+has a single owning producer, so there is no cross-producer write contention.
+
+Write side::
+
+    from inference_optimizer.breakdown.recorder import get_recorder
+
+    rec = get_recorder(session_dir, producer="sweep")
+    rec.record_singleton("sweep", sweep_payload)          # one final blob
+    rec.record_item("phase_timeline", event, key=task_id)  # event stream
+
+Read side::
+
+    from inference_optimizer.breakdown.recorder import assemble_parts, has_parts
+
+    sections = assemble_parts(session_dir)   # {section: list | dict}
+"""
+
+from __future__ import annotations
+
+from . import instrument
+from .assembler import assemble_parts, has_parts, parts_dir
+from .instrument import (
+    record_critic_iteration,
+    record_kernel_invocations,
+    record_phase_event,
+    record_robustness_signal,
+    record_singleton_section,
+    record_specialist_round,
+    snapshot_state_sections,
+)
+from .recorder import Recorder, get_recorder
+from .sections import (
+    DERIVED_SECTIONS,
+    SECTION_SHAPES,
+    SectionShape,
+    section_shape,
+)
+
+__all__ = [
+    "DERIVED_SECTIONS",
+    "SECTION_SHAPES",
+    "Recorder",
+    "SectionShape",
+    "assemble_parts",
+    "get_recorder",
+    "has_parts",
+    "instrument",
+    "parts_dir",
+    "record_critic_iteration",
+    "record_kernel_invocations",
+    "record_phase_event",
+    "record_robustness_signal",
+    "record_singleton_section",
+    "record_specialist_round",
+    "section_shape",
+    "snapshot_state_sections",
+]

--- a/inference_optimizer/breakdown/recorder/assembler.py
+++ b/inference_optimizer/breakdown/recorder/assembler.py
@@ -1,0 +1,127 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Read-side of the breakdown recorder.
+
+Assembles the per-producer fragments written by :class:`~.recorder.Recorder`
+into a ``{section: value}`` mapping ready to drop into the
+``session_breakdown.json`` envelope:
+
+* ``singleton`` sections -> the payload of the latest fragment (by ``ts``).
+* ``item`` sections      -> payloads concatenated into a list, ordered by
+  ``seq`` then ``ts``.
+
+There is no cross-producer conflict resolution because each section has a
+single owner. Bad/partial fragments are skipped and noted in ``warnings``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def parts_dir(session_dir: Path | str) -> Path:
+    from ...session_paths import breakdown_parts_dir  # local: avoid import cycle
+
+    return breakdown_parts_dir(Path(session_dir))
+
+
+def has_parts(session_dir: Path | str) -> bool:
+    """True iff at least one record fragment exists for this session."""
+    d = parts_dir(session_dir)
+    return d.is_dir() and any(d.glob("*.json"))
+
+
+def _load(path: Path, warnings: list[str]) -> dict[str, Any] | None:
+    try:
+        rec = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"recorder: failed to read {path.name}: {exc!r}")
+        return None
+    if not isinstance(rec, dict):
+        warnings.append(f"recorder: {path.name} is not an object")
+        return None
+    return rec
+
+
+def assemble_parts(
+    session_dir: Path | str,
+    *,
+    warnings: list[str] | None = None,
+) -> dict[str, Any]:
+    """Return ``{section: list | dict}`` assembled from the spool directory.
+
+    Empty mapping when no fragments exist (caller falls back to collectors).
+    """
+    warns = warnings if warnings is not None else []
+    d = parts_dir(session_dir)
+    if not d.is_dir():
+        return {}
+
+    items: dict[str, list[dict[str, Any]]] = {}
+    singletons: dict[str, dict[str, Any]] = {}
+
+    for path in sorted(d.glob("*.json")):
+        rec = _load(path, warns)
+        if rec is None:
+            continue
+        section = rec.get("section")
+        if not isinstance(section, str) or not section:
+            warns.append(f"recorder: {path.name} missing 'section'")
+            continue
+        if rec.get("kind") == "singleton":
+            prev = singletons.get(section)
+            if prev is None or str(rec.get("ts") or "") >= str(prev.get("ts") or ""):
+                singletons[section] = rec
+        else:
+            items.setdefault(section, []).append(rec)
+
+    out: dict[str, Any] = {}
+    for section, recs in items.items():
+        recs.sort(key=lambda r: (int(r.get("seq") or 0), str(r.get("ts") or "")))
+        out[section] = [r.get("payload") for r in recs]
+    for section, rec in singletons.items():
+        out[section] = rec.get("payload")
+
+    _compose_critic_robustness(out)
+    return out
+
+
+def _compose_critic_robustness(out: dict[str, Any]) -> None:
+    """Fold the ``critic_iterations`` / ``robustness_signals`` item substreams
+    into the ``critic_robustness`` singleton (shape mirrors
+    ``collectors.collect_critic_robustness``). Pops the raw substreams so they
+    don't leak into the breakdown envelope."""
+    critic_iters = out.pop("critic_iterations", None)
+    rob_signals = out.pop("robustness_signals", None)
+    if critic_iters is None and rob_signals is None:
+        return
+    # A directly-recorded singleton (if any) takes precedence over substreams.
+    if "critic_robustness" in out:
+        return
+    critic_iters = critic_iters if isinstance(critic_iters, list) else []
+    rob_signals = rob_signals if isinstance(rob_signals, list) else []
+    out["critic_robustness"] = {
+        "critic_iterations":  critic_iters,
+        "robustness_signals": rob_signals,
+        "kb_writes_summary":  _kb_writes_summary(critic_iters),
+    }
+
+
+def _kb_writes_summary(critic_iters: list[Any]) -> dict[str, Any]:
+    """Count each critic iteration's verdict (mirrors the collector)."""
+    by_verdict: dict[str, int] = {}
+    total = 0
+    for entry in critic_iters:
+        if not isinstance(entry, dict):
+            continue
+        verdict = str(entry.get("verdict") or "").strip().upper()
+        if not verdict:
+            continue
+        total += 1
+        by_verdict[verdict] = by_verdict.get(verdict, 0) + 1
+    return {"total": total, "by_verdict": by_verdict}
+
+
+__all__ = ["assemble_parts", "has_parts", "parts_dir"]

--- a/inference_optimizer/breakdown/recorder/instrument.py
+++ b/inference_optimizer/breakdown/recorder/instrument.py
@@ -1,0 +1,499 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Author-time instrumentation for ``session_breakdown.json``.
+
+These helpers are called from the producing code (the Coordinator's
+``SharedState``) to record breakdown facts where they are born, via the
+recorder toolkit, instead of having the exporter re-walk artifacts later.
+
+Every helper is best-effort: instrumentation must never break the optimizer,
+so all failures are swallowed (logged at debug). Payloads are shaped to the
+matching ``schema.py`` TypedDict so assembly stays structure-preserving.
+
+Coverage in this module (state-owned sections; single owner = Coordinator):
+
+* ``session`` / ``workload`` / ``final`` / ``explore_search`` / ``sweep``
+  -- singletons snapshotted from in-memory state at each persist.
+* ``optimization_stack`` / ``roofline`` -- event items keyed by a stable id
+  (idempotent: re-recording overwrites rather than duplicates).
+* ``phase_timeline`` -- one event per recorded action attempt.
+
+File-born sections (geak/oob invocations, kernel/conc-sweep report summaries,
+critic_robustness, specialist_runs, telemetry, kb_provenance) are produced by
+other processes/executors and are instrumented at those sites separately.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+PRODUCER_COORDINATOR = "coordinator"
+PRODUCER_KERNEL_AGENT = "kernel-agent"
+
+# kernel-agent backend -> invocation section. geak is its own lane; the
+# out-of-band LLM backends (claude/codex) share the oob lane.
+_GEAK_BACKENDS = frozenset({"geak"})
+_OOB_BACKENDS = frozenset({"claude", "codex"})
+
+_FAILED_STATUSES = frozenset({"failed", "error", "crashed", "timeout"})
+
+
+def _to_float(value: Any) -> float | None:
+    try:
+        if value is None or isinstance(value, bool):
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _recorder(session_dir: Path | str, producer: str):
+    from .recorder import get_recorder
+
+    return get_recorder(session_dir, producer=producer)
+
+
+def _rel(path: Path, session_dir: Path | str) -> str:
+    """Render ``path`` relative to ``session_dir`` (falls back to str)."""
+    try:
+        return str(Path(path).relative_to(Path(session_dir)))
+    except (ValueError, TypeError):
+        return str(path)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    import json
+
+    try:
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def record_phase_event(
+    session_dir: Path | str | None,
+    *,
+    action: str,
+    entry: dict[str, Any],
+    producer: str = PRODUCER_COORDINATOR,
+) -> None:
+    """Record one ``phase_timeline`` event from a ``record_action_attempt`` entry."""
+    if not session_dir or not isinstance(entry, dict):
+        return
+    try:
+        task_id = str(entry.get("task_id") or "")
+        payload = {
+            "ts":              str(entry.get("ts") or ""),
+            "action":          str(action or ""),
+            "task_id":         task_id,
+            "status":          str(entry.get("status") or ""),
+            "decision":        str(entry.get("decision") or ""),
+            "key_metric":      _to_float(entry.get("key_metric")),
+            "key_metric_kind": entry.get("key_metric_kind"),
+            "workspace":       entry.get("workspace"),
+            "error_class":     entry.get("error_class"),
+            "extras":          dict(entry.get("extras") or {}),
+        }
+        # Stable key per (action, task) so a re-recorded attempt overwrites.
+        key = f"{action}-{task_id}" if task_id else None
+        _recorder(session_dir, producer).record_item(
+            "phase_timeline", payload, key=key,
+        )
+    except Exception:  # noqa: BLE001
+        log.debug("record_phase_event failed", exc_info=True)
+
+
+def snapshot_state_sections(
+    session_dir: Path | str | None,
+    state: Any,
+    *,
+    producer: str = PRODUCER_COORDINATOR,
+) -> None:
+    """Snapshot every state-owned breakdown section from a live ``SharedState``.
+
+    Singletons overwrite the producer's own file; event-stream items are keyed
+    by a stable id so repeated snapshots are idempotent. Best-effort per
+    section: one failing section never blocks the others.
+    """
+    if not session_dir or state is None:
+        return
+    rec = None
+    try:
+        rec = _recorder(session_dir, producer)
+    except Exception:  # noqa: BLE001
+        log.debug("recorder unavailable", exc_info=True)
+        return
+
+    for name, fn in (
+        ("session",            _snapshot_session),
+        ("workload",           _snapshot_workload),
+        ("final",              _snapshot_final),
+        ("explore_search",     _snapshot_explore_search),
+        ("sweep",              _snapshot_sweep),
+        ("optimization_stack", _snapshot_optimization_stack),
+        ("roofline",           _snapshot_roofline),
+    ):
+        try:
+            fn(rec, state)
+        except Exception:  # noqa: BLE001
+            log.debug("snapshot section %s failed", name, exc_info=True)
+
+
+def _snapshot_session(rec, st: Any) -> None:
+    session_id = str(getattr(st, "session_id", "") or "")
+    if not session_id:
+        return
+    rec.record_singleton("session", {
+        "session_id":      session_id,
+        "claw_session_id": getattr(st, "claw_session_id", "") or "",
+        "sandbox_user_id": getattr(st, "sandbox_user_id", "") or "",
+        "start_ts":        str(getattr(st, "start_ts", "") or ""),
+        "stop_reason":     str(getattr(st, "stop_reason", "") or ""),
+        "max_minutes":     int(getattr(st, "max_minutes", 0) or 0),
+        "tick_count":      int(getattr(st, "tick", 0) or 0),
+        "phase":           str(getattr(st, "phase", "") or ""),
+    })
+
+
+def _snapshot_workload(rec, st: Any) -> None:
+    framework = str(getattr(st, "framework", "") or "")
+    model = str(getattr(st, "model_name", "") or getattr(st, "model_path", "") or "")
+    if not framework and not model:
+        return
+    rec.record_singleton("workload", {
+        "framework":     framework,
+        "model_name":    str(getattr(st, "model_name", "") or ""),
+        "model_path":    str(getattr(st, "model_path", "") or ""),
+        "model_class":   str(getattr(st, "model_class", "") or ""),
+        "gpu_type":      str(getattr(st, "gpu_type", "") or ""),
+        "tp":            int(getattr(st, "tp", 0) or 0),
+        "ep":            int(getattr(st, "ep", 0) or 0),
+        "precision":     str(getattr(st, "precision", "") or ""),
+        "conc":          int(getattr(st, "conc", 0) or 0),
+        "isl":           int(getattr(st, "isl", 0) or 0),
+        "osl":           int(getattr(st, "osl", 0) or 0),
+        "max_model_len": int(getattr(st, "max_model_len", 0) or 0),
+    })
+
+
+def _snapshot_final(rec, st: Any) -> None:
+    cb = getattr(st, "current_best", None) or {}
+    stack = getattr(st, "optimization_stack", None) or []
+    if not cb and not stack:
+        return
+    rec.record_singleton("final", {
+        "current_best_action":                str(cb.get("action") or ""),
+        "throughput_tok_s_per_gpu":           _to_float(cb.get("tput")),
+        "cumulative_gain_pct_validated":      _to_float(
+            getattr(st, "cumulative_gain_validated", 0.0)) or 0.0,
+        "cumulative_gain_pct_per_round_sum":  _to_float(
+            getattr(st, "cumulative_gain", 0.0)) or 0.0,
+        "validated_ts":                       str(
+            getattr(st, "cumulative_gain_validated_ts", "") or ""),
+        "stack_len":                          len(stack),
+        "extra_server_args":                  str(cb.get("extra_server_args") or ""),
+        "extra_envs":                         dict(cb.get("extra_envs") or {}),
+    })
+
+
+def _snapshot_explore_search(rec, st: Any) -> None:
+    search = dict(getattr(st, "explore_search", None) or {})
+    if not search:
+        return
+    search["winner_history"] = list(getattr(st, "params_winner_history", None) or [])
+    search["no_promote_streak"] = int(
+        getattr(st, "params_no_promote_streak", 0) or 0)
+    search["discovered_flags"] = dict(getattr(st, "discovered_flags", None) or {})
+    search["synergy_attempted"] = list(getattr(st, "synergy_attempted", None) or [])
+    search["backend_winners_history"] = list(
+        getattr(st, "backend_winners_history", None) or [])
+    rec.record_singleton("explore_search", search)
+
+
+def _snapshot_sweep(rec, st: Any) -> None:
+    last_sweep = dict(getattr(st, "last_sweep", None) or {})
+    if not last_sweep:
+        return
+    rec.record_singleton("sweep", last_sweep)
+
+
+def _snapshot_optimization_stack(rec, st: Any) -> None:
+    stack = getattr(st, "optimization_stack", None) or []
+    gains = getattr(st, "gain_per_stack_entry", None) or []
+    for i, entry in enumerate(stack):
+        if not isinstance(entry, dict):
+            continue
+        payload = dict(entry)
+        if payload.get("gain_pct") is None and i < len(gains):
+            payload["gain_pct"] = _to_float(gains[i])
+        rec.record_item("optimization_stack", payload, key=str(i))
+
+
+def _snapshot_roofline(rec, st: Any) -> None:
+    snapshots = getattr(st, "roofline_snapshots", None) or []
+    for idx, snap in enumerate(snapshots):
+        if not isinstance(snap, dict):
+            continue
+        sid = str(snap.get("snapshot_id") or snap.get("id") or idx)
+        rec.record_item("roofline", snap, key=sid)
+
+
+def _best_attempt_id(
+    attempts: list[Any],
+    verification: dict[str, Any],
+) -> str:
+    """Pick the adopted attempt id: verification hint, else highest speedup.
+
+    Mirrors the collector's selection so the kernel-level decision lands on the
+    same attempt the breakdown would attribute it to.
+    """
+    rows = [a for a in attempts if isinstance(a, dict)]
+    if not rows:
+        return ""
+    want_id = str(verification.get("best_attempt_id") or "")
+    if want_id:
+        return want_id
+    want_backend = str(verification.get("best_backend") or "").lower()
+    candidates = rows
+    if want_backend:
+        backend_rows = [
+            a for a in rows if str(a.get("backend") or "").lower() == want_backend
+        ]
+        if backend_rows:
+            candidates = backend_rows
+
+    def _spd(a: dict[str, Any]) -> float:
+        v = _to_float(a.get("micro_speedup") or a.get("speedup"))
+        return v if v is not None else float("-inf")
+
+    best = max(candidates, key=_spd)
+    return str(best.get("attempt_id") or best.get("id") or "")
+
+
+def _invocation_section(backend: str) -> str | None:
+    b = str(backend or "").lower()
+    if b in _GEAK_BACKENDS:
+        return "geak_invocations"
+    if b in _OOB_BACKENDS:
+        return "oob_invocations"
+    return None
+
+
+def record_kernel_invocations(
+    session_dir: Path | str | None,
+    result: dict[str, Any],
+    *,
+    producer: str = PRODUCER_KERNEL_AGENT,
+) -> None:
+    """Record geak/oob invocations from an in-process kernel-agent result.
+
+    Reads ``result['attempts']`` (per-backend ladder) so backend-level
+    failures are captured even when the kernel-agent crashed before persisting
+    ``optimization_attempts.jsonl`` (the on-disk source the collector reads).
+    When the whole invocation failed before any backend ran (pre-dispatch
+    gating: non_reusable_kernel / missing_source / kernel_agent_root_missing /
+    ...), a single ``FAILED`` marker is recorded so the failure is never
+    invisible in the geak/oob view.
+    """
+    if not session_dir or not isinstance(result, dict):
+        return
+    try:
+        rec = _recorder(session_dir, producer)
+        kid = str(result.get("kernel_id") or "")
+        run_id = str(result.get("run_id") or result.get("session_id") or "")
+        attempts = result.get("attempts")
+        attempts = attempts if isinstance(attempts, list) else []
+        verification = result.get("verification") or {}
+        proposal = result.get("proposal") or {}
+        kernel_decision = str(proposal.get("decision") or "").upper()
+        best_attempt_id = _best_attempt_id(attempts, verification)
+
+        recorded_any = False
+        for att in attempts:
+            if not isinstance(att, dict):
+                continue
+            backend = str(att.get("backend") or "").lower()
+            section = _invocation_section(backend)
+            if section is None:
+                continue
+            status = str(att.get("status") or "").lower()
+            decision = str(att.get("decision") or "").upper()
+            if not decision and status in _FAILED_STATUSES:
+                decision = "FAILED"
+            attempt_id = str(att.get("attempt_id") or att.get("id") or "")
+            # Stamp the kernel-level KEEP/PARTIAL/REVERT onto the adopted (best)
+            # attempt, mirroring the collector's _stamp_kernel_level_decisions.
+            if kernel_decision and attempt_id and attempt_id == best_attempt_id:
+                decision = kernel_decision
+            optimized = att.get("optimized_path") or att.get("optimized_file")
+            payload = {
+                "kernel_id":       kid,
+                "attempt_id":      attempt_id,
+                "run_id":          run_id,
+                "ts":              str(att.get("ts") or att.get("started_at") or ""),
+                "backend":         backend,
+                "decision":        decision,
+                "status":          status,
+                "micro_speedup":   _to_float(
+                    att.get("micro_speedup") or att.get("speedup")),
+                "optimized_files": [str(optimized)] if optimized else [],
+                "error":           att.get("error") or att.get("error_message"),
+            }
+            key = attempt_id or f"{kid}-{backend}"
+            rec.record_item(section, payload, key=key)
+            recorded_any = True
+
+        if recorded_any:
+            return
+
+        # No per-backend attempts: capture a pre-dispatch / infra failure so
+        # the geak/oob view still shows it (root cause of invisible failures).
+        status = str(result.get("status") or "").lower()
+        err_class = str(result.get("error_class") or "")
+        decision = str(
+            (result.get("proposal") or {}).get("decision") or "").upper()
+        failed = status in _FAILED_STATUSES or (
+            decision == "REVERT" and bool(err_class)
+        )
+        if not failed:
+            return
+        backend = str(result.get("backend") or "").lower()
+        section = _invocation_section(backend) or "geak_invocations"
+        payload = {
+            "kernel_id":            kid,
+            "attempt_id":           "",
+            "run_id":               run_id,
+            "backend":              backend or "geak",
+            "decision":             "FAILED",
+            "status":               status or "failed",
+            "error":                result.get("error") or err_class or None,
+            "error_class":          err_class or None,
+            # Distinguishes a pre-dispatch gating failure (no backend ran) from
+            # a backend that ran and failed.
+            "pre_dispatch_failure": True,
+        }
+        rec.record_item(section, payload, key=f"{kid}-predispatch" if kid else None)
+    except Exception:  # noqa: BLE001
+        log.debug("record_kernel_invocations failed", exc_info=True)
+
+
+def record_specialist_round(
+    session_dir: Path | str | None,
+    entry: dict[str, Any],
+    *,
+    producer: str = PRODUCER_COORDINATOR,
+) -> None:
+    """Record one ``specialist_runs`` round (idempotent by ``round_id``)."""
+    if not session_dir or not isinstance(entry, dict) or not entry:
+        return
+    try:
+        key = str(entry.get("round_id") or "") or None
+        _recorder(session_dir, producer).record_item(
+            "specialist_runs", dict(entry), key=key,
+        )
+    except Exception:  # noqa: BLE001
+        log.debug("record_specialist_round failed", exc_info=True)
+
+
+def record_critic_iteration(
+    session_dir: Path | str | None,
+    *,
+    iter_n: int,
+    review: dict[str, Any] | None,
+    emit: dict[str, Any] | None,
+    workdir: Path | str | None,
+    producer: str = "critic",
+) -> None:
+    """Record one ``critic_robustness.critic_iterations`` item.
+
+    Recorded per-iteration (idempotent on ``iter_n``) so the critic backend's
+    workdir pruning never erases history; payload mirrors
+    ``collectors.collect_critic_robustness``.
+    """
+    if not session_dir:
+        return
+    try:
+        review = review if isinstance(review, dict) else {}
+        emit = emit if isinstance(emit, dict) else {}
+        wd = Path(workdir) if workdir else None
+        payload = {
+            "iter":    int(iter_n),
+            "ts":      str(emit.get("ts") or review.get("ts") or ""),
+            "topic":   str(emit.get("topic") or review.get("topic") or ""),
+            "verdict": str(review.get("verdict") or emit.get("verdict") or ""),
+            "summary": str(review.get("summary") or emit.get("summary") or "")[:500],
+            "request_path":      _rel(wd / "request.json", session_dir) if wd else None,
+            "judge_bundle_path": _rel(wd / "judge_bundle.json", session_dir) if wd else None,
+            "emit_path":         _rel(wd / "emit.json", session_dir) if wd else None,
+            "review_path":       _rel(wd / "review.json", session_dir) if wd else None,
+        }
+        _recorder(session_dir, producer).record_item(
+            "critic_iterations", payload, key=str(iter_n),
+        )
+    except Exception:  # noqa: BLE001
+        log.debug("record_critic_iteration failed", exc_info=True)
+
+
+def record_robustness_signal(
+    session_dir: Path | str | None,
+    *,
+    workdir: Path | str | None,
+    producer: str = "robustness",
+) -> None:
+    """Record one ``critic_robustness.robustness_signals`` item.
+
+    Reads ``signal.json`` / ``action.json`` from the just-written ``workdir``
+    (idempotent on the workdir name) so the signal is captured before the
+    robustness backend prunes old workdirs; payload mirrors the collector.
+    """
+    if not session_dir or not workdir:
+        return
+    try:
+        wd = Path(workdir)
+        signal_data = _read_json(wd / "signal.json")
+        action_data = _read_json(wd / "action.json")
+        payload = {
+            "ts":      str(signal_data.get("ts") or action_data.get("ts") or ""),
+            "signal":  str(signal_data.get("signal") or signal_data.get("kind") or ""),
+            "action":  str(action_data.get("action") or action_data.get("kind") or ""),
+            "workdir": _rel(wd, session_dir),
+        }
+        _recorder(session_dir, producer).record_item(
+            "robustness_signals", payload, key=wd.name,
+        )
+    except Exception:  # noqa: BLE001
+        log.debug("record_robustness_signal failed", exc_info=True)
+
+
+def record_singleton_section(
+    session_dir: Path | str | None,
+    section: str,
+    payload: dict[str, Any],
+    *,
+    producer: str,
+) -> None:
+    """Record a producer-owned singleton section (report summaries, etc.)."""
+    if not session_dir or not isinstance(payload, dict) or not payload:
+        return
+    try:
+        _recorder(session_dir, producer).record_singleton(section, payload)
+    except Exception:  # noqa: BLE001
+        log.debug("record_singleton_section %s failed", section, exc_info=True)
+
+
+__all__ = [
+    "PRODUCER_COORDINATOR",
+    "PRODUCER_KERNEL_AGENT",
+    "record_critic_iteration",
+    "record_kernel_invocations",
+    "record_phase_event",
+    "record_robustness_signal",
+    "record_singleton_section",
+    "record_specialist_round",
+    "snapshot_state_sections",
+]

--- a/inference_optimizer/breakdown/recorder/recorder.py
+++ b/inference_optimizer/breakdown/recorder/recorder.py
@@ -1,0 +1,168 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Write-side of the breakdown recorder.
+
+A :class:`Recorder` lets the code that *produces* a fact record it at author
+time, into a per-session spool directory, instead of having the exporter
+re-walk heterogeneous artifacts later. Each producer owns its own files:
+
+* :meth:`Recorder.record_singleton` — one final dict per section; the owner
+  overwrites its own stable file (safe: single writer of that file).
+* :meth:`Recorder.record_item` — one fragment per event; uniquely named so
+  concurrent producers never collide. Pass ``key`` for an idempotent
+  (overwrite-on-rewrite) item that survives resume without duplicating.
+
+Writes are atomic (tmp + ``os.replace``) and filenames are unique per
+(section, producer), so this is safe across processes and on network
+filesystems (no shared-append dependency).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from .sections import SECTION_SHAPES
+
+_SANITIZE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds")
+
+
+def _slug(value: str) -> str:
+    """Filesystem-safe token; empty input collapses to ``unknown``."""
+    s = _SANITIZE.sub("-", str(value or "").strip())
+    return s.strip("-.") or "unknown"
+
+
+class Recorder:
+    """Per-(session, producer) writer of breakdown record fragments."""
+
+    def __init__(self, parts_dir: Path | str, *, producer: str) -> None:
+        self._dir = Path(parts_dir)
+        self._producer = _slug(producer)
+        self._seq = 0
+        self._lock = threading.Lock()
+
+    @property
+    def producer(self) -> str:
+        return self._producer
+
+    @property
+    def parts_dir(self) -> Path:
+        return self._dir
+
+    def _next_seq(self) -> int:
+        with self._lock:
+            self._seq += 1
+            return self._seq
+
+    def record_singleton(
+        self,
+        section: str,
+        payload: Mapping[str, Any],
+    ) -> Path:
+        """Write/overwrite this producer's single final blob for ``section``."""
+        self._check_shape(section, "singleton")
+        filename = f"{_slug(section)}__{self._producer}.json"
+        return self._write(section, "singleton", payload, filename=filename)
+
+    def record_item(
+        self,
+        section: str,
+        payload: Mapping[str, Any],
+        *,
+        key: str | None = None,
+    ) -> Path:
+        """Append one event fragment to the ``section`` stream.
+
+        ``key`` (optional): a stable per-item identity. When given the fragment
+        filename is derived from it, so re-recording the same key overwrites
+        rather than duplicates (idempotent across retries / resume).
+        """
+        self._check_shape(section, "item")
+        if key:
+            filename = f"{_slug(section)}__{self._producer}__{_slug(key)}.json"
+        else:
+            seq = self._next_seq()
+            filename = (
+                f"{_slug(section)}__{self._producer}__"
+                f"{os.getpid()}-{seq:06d}.json"
+            )
+        return self._write(section, "item", payload, filename=filename)
+
+    @staticmethod
+    def _check_shape(section: str, kind: str) -> None:
+        declared = SECTION_SHAPES.get(section)
+        if declared is not None and declared != kind:
+            raise ValueError(
+                f"section {section!r} is declared {declared!r}, "
+                f"not {kind!r}"
+            )
+
+    def _write(
+        self,
+        section: str,
+        kind: str,
+        payload: Mapping[str, Any],
+        *,
+        filename: str,
+    ) -> Path:
+        self._dir.mkdir(parents=True, exist_ok=True)
+        record = {
+            "section":  section,
+            "kind":     kind,
+            "seq":      self._next_seq(),
+            "ts":       _now_iso(),
+            "producer": self._producer,
+            "payload":  dict(payload) if isinstance(payload, Mapping) else payload,
+        }
+        data = json.dumps(record, ensure_ascii=False, sort_keys=True, default=str)
+        target = self._dir / filename
+        fd, tmp = tempfile.mkstemp(
+            prefix=f".{filename}.", suffix=".tmp", dir=str(self._dir),
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(data)
+            os.replace(tmp, target)
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+        return target
+
+
+_RECORDERS: dict[tuple[str, str], Recorder] = {}
+_RECORDERS_LOCK = threading.Lock()
+
+
+def get_recorder(session_dir: Path | str, *, producer: str) -> Recorder:
+    """Return a process-cached :class:`Recorder` for ``(session_dir, producer)``.
+
+    Lets deep call sites obtain the writer without threading it through every
+    function signature.
+    """
+    from ...session_paths import breakdown_parts_dir  # local: avoid import cycle
+
+    pd = breakdown_parts_dir(Path(session_dir))
+    cache_key = (str(pd), _slug(producer))
+    with _RECORDERS_LOCK:
+        rec = _RECORDERS.get(cache_key)
+        if rec is None:
+            rec = Recorder(pd, producer=producer)
+            _RECORDERS[cache_key] = rec
+        return rec
+
+
+__all__ = ["Recorder", "get_recorder"]

--- a/inference_optimizer/breakdown/recorder/sections.py
+++ b/inference_optimizer/breakdown/recorder/sections.py
@@ -1,0 +1,75 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Per-section wire-shape registry for the breakdown recorder.
+
+Each ``session_breakdown.json`` section has exactly one owning producer, so
+there is never cross-producer write contention. A section is one of:
+
+* ``singleton`` — one final dict; the owner rewrites its own file on update
+  (last write by ``ts`` wins at assembly time).
+* ``item`` — an append-only event stream concatenated into a list (ordered by
+  ``seq`` then ``ts``) at assembly time.
+
+Derived sections (see :data:`DERIVED_SECTIONS`) are NOT written by producers
+during the run; they are computed at finalize from in-memory ``SharedState``
+(the Coordinator owns every input), so they never appear as fragments.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+SectionShape = Literal["item", "singleton"]
+
+# Producer-written sections and their fragment shape. Payloads match the
+# corresponding ``schema.py`` TypedDict so assembly is structure-preserving.
+SECTION_SHAPES: dict[str, SectionShape] = {
+    "session":                     "singleton",
+    "workload":                    "singleton",
+    "baseline":                    "singleton",
+    "final":                       "singleton",
+    "phase_timeline":              "item",
+    "geak_invocations":            "item",
+    "oob_invocations":             "item",
+    "kernel_lifecycle":            "singleton",
+    "explore_search":              "singleton",
+    "sweep":                       "singleton",
+    "critic_robustness":           "singleton",
+    # Author-time item substreams composed into the ``critic_robustness``
+    # singleton at assembly (recorded per-iteration so the backend's workdir
+    # pruning never erases history).
+    "critic_iterations":           "item",
+    "robustness_signals":          "item",
+    "telemetry":                   "singleton",
+    "kb_provenance":               "singleton",
+    "specialist_runs":             "item",
+    "optimization_stack":          "item",
+    "kernel_roofline":             "singleton",
+    "kernel_optimization_summary": "singleton",
+    "conc_sweep_summary":          "singleton",
+    "roofline":                    "item",
+    "roofline_progress":           "singleton",
+}
+
+# Sections computed at finalize from in-memory state, never written as
+# fragments. Listed so the assembler can distinguish "expected absent" from
+# "missing producer".
+DERIVED_SECTIONS: frozenset[str] = frozenset({
+    "capability_summary",
+    "attribution",
+    "phase_segments",
+    "source_files",
+})
+
+
+def section_shape(section: str) -> SectionShape | None:
+    """Return the declared shape for ``section`` (``None`` if unregistered)."""
+    return SECTION_SHAPES.get(section)
+
+
+__all__ = [
+    "DERIVED_SECTIONS",
+    "SECTION_SHAPES",
+    "SectionShape",
+    "section_shape",
+]

--- a/inference_optimizer/orchestrator/action_executors/report.py
+++ b/inference_optimizer/orchestrator/action_executors/report.py
@@ -526,6 +526,15 @@ def _write_kernel_opt_summary(
         out_path = output_dir / "kernel_optimization_summary.json"
         with out_path.open("w", encoding="utf-8") as f:
             json.dump(summary, f, indent=2, sort_keys=True)
+        # Author-time breakdown capture: mirror the summary into the recorder.
+        try:
+            from ...breakdown.recorder import instrument
+            instrument.record_singleton_section(
+                session_dir, "kernel_optimization_summary", summary,
+                producer="coordinator",
+            )
+        except Exception:  # noqa: BLE001
+            pass
         return out_path
     except Exception as exc:  # noqa: BLE001
         log.warning(

--- a/inference_optimizer/orchestrator/backends/critic_agent.py
+++ b/inference_optimizer/orchestrator/backends/critic_agent.py
@@ -615,6 +615,20 @@ class CriticAgentBackend:
             "workdir": str(workdir),
         })
 
+        # Author-time breakdown capture: record this critic iteration before the
+        # workdir can be pruned (composed into critic_robustness at assembly).
+        try:
+            from ...breakdown.recorder import instrument
+            instrument.record_critic_iteration(
+                self.session_dir,
+                iter_n=turn_idx,
+                review=review,
+                emit=emit,
+                workdir=workdir,
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
         return BackendTurnResult(
             intents=intents,
             raw_text=llm_text,

--- a/inference_optimizer/orchestrator/backends/robustness_agent.py
+++ b/inference_optimizer/orchestrator/backends/robustness_agent.py
@@ -226,6 +226,16 @@ class RobustnessAgentBackend:
             "workdir": str(workdir),
         })
 
+        # Author-time breakdown capture: record this robustness signal before
+        # the backend prunes old workdirs (composed into critic_robustness).
+        try:
+            from ...breakdown.recorder import instrument
+            instrument.record_robustness_signal(
+                self.session_dir, workdir=workdir,
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
         return BackendTurnResult(
             intents=intents,
             raw_text="(robustness-agent)",

--- a/inference_optimizer/orchestrator/conc_sweep.py
+++ b/inference_optimizer/orchestrator/conc_sweep.py
@@ -523,6 +523,14 @@ async def run_conc_sweep(
             encoding="utf-8",
         )
         _write_csv(csv_path, baseline_points + optimized_points)
+        # Author-time breakdown capture: mirror the summary into the recorder.
+        try:
+            from ..breakdown.recorder import instrument
+            instrument.record_singleton_section(
+                session_dir, "conc_sweep_summary", payload, producer="conc_sweep",
+            )
+        except Exception:  # noqa: BLE001
+            pass
         # final.json pointer is added by report.py at CLOSE (this action runs before CLOSE).
 
     log.info(

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -7553,6 +7553,28 @@ class Coordinator:
                 }
                 if gap_canonical_id:
                     stack_entry["gap_canonical_id"] = gap_canonical_id
+                # Stamp the variant's stable join key (and source) so breakdown
+                # attribution can map this explore gain back to its specialist
+                # provenance via explore_search.winners_history. Without it the
+                # phase_breakdown.explore.by_domain join always misses and every
+                # gain collapses into ``default_grid``.
+                fp_val = ""
+                prov_val = ""
+                if isinstance(bv, dict):
+                    fp_val = str(bv.get("fingerprint") or "").strip()
+                    if not fp_val:
+                        from .action_executors._canonical_fingerprint import (
+                            canonical_fingerprint,
+                        )
+                        fp_val = canonical_fingerprint(
+                            candidate_args or full_args,
+                            dict(bv.get("extra_envs") or {}),
+                        )
+                    prov_val = str(bv.get("provenance") or "").strip()
+                if fp_val:
+                    stack_entry["fingerprint"] = fp_val
+                if prov_val:
+                    stack_entry["provenance"] = prov_val
                 self.shared_state.optimization_stack.append(stack_entry)
                 # Mirror append into gain_per_stack_entry so the two parallel lists stay index-aligned.
                 self.shared_state.append_stack_gain_entry(

--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -1717,6 +1717,25 @@ def _parse_tool_stdout(stdout: str) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+def _record_kernel_roofline_sidecar(session_dir: Path) -> None:
+    """Transcribe ``reports/kernel_roofline.json`` (written by the external
+    kernel-agent tool) into the breakdown recorder as a ``kernel_roofline``
+    singleton. Best-effort; never raises."""
+    try:
+        sidecar_path = Path(session_dir) / "reports" / "kernel_roofline.json"
+        if not sidecar_path.is_file():
+            return
+        payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict) or not payload:
+            return
+        from ..breakdown.recorder import instrument
+        instrument.record_singleton_section(
+            session_dir, "kernel_roofline", payload, producer="kernel-agent",
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+
 def _lookup_kernel_roofline_name(session_dir: Path, kernel_id: str) -> str:
     """Resolve the TraceLens/device kernel name for a roofline sidecar row."""
     sidecar_path = session_dir / "reports" / "kernel_roofline.json"
@@ -1918,6 +1937,9 @@ async def _run_after_kernel_opt_rocprof(
             rocprof_status=status,
             phase="after_kernel_opt",
         )
+        # Author-time breakdown capture: transcribe the external tool's sidecar
+        # (reports/kernel_roofline.json) into the recorder right after it lands.
+        _record_kernel_roofline_sidecar(session_dir)
     except Exception as exc:
         log.warning("integrate: after_kernel_opt sidecar update failed: %s", exc)
 

--- a/inference_optimizer/orchestrator/shared_state.py
+++ b/inference_optimizer/orchestrator/shared_state.py
@@ -477,6 +477,11 @@ class SharedState:
     # Orchestration working memory — durable compacted reasoning snapshot for compaction + crash-recovery rebuild; Coordinator-only writer, not in session_breakdown.
     orchestration_memory: dict[str, Any] = field(default_factory=dict)
 
+    # Non-field instance attr (set in load_or_init / save): session dir used by
+    # breakdown instrumentation. Plain class attr => not a dataclass field, so
+    # asdict()/state.json never serialize it.
+    _session_dir = None
+
     # Persistence
     @classmethod
     def state_path(cls, session_dir: Path) -> Path:
@@ -487,10 +492,15 @@ class SharedState:
         """Load existing ``state.json`` or return a fresh blank instance."""
         path = cls.state_path(session_dir)
         if not path.exists():
-            return cls()
-        with path.open(encoding="utf-8") as f:
-            raw = json.load(f)
-        return cls.from_dict(raw)
+            inst = cls()
+        else:
+            with path.open(encoding="utf-8") as f:
+                raw = json.load(f)
+            inst = cls.from_dict(raw)
+        # Remember the session dir so breakdown instrumentation can record
+        # fragments at author time (non-field attr; not serialized by asdict).
+        inst._session_dir = Path(session_dir)
+        return inst
 
     @classmethod
     def from_dict(cls, raw: dict[str, Any]) -> "SharedState":
@@ -710,6 +720,14 @@ class SharedState:
             except OSError:
                 pass
             raise
+        # Author-time breakdown capture: snapshot state-owned sections into the
+        # recorder spool right after persisting. Best-effort; never blocks save.
+        self._session_dir = Path(session_dir)
+        try:
+            from ..breakdown.recorder import instrument
+            instrument.snapshot_state_sections(session_dir, self)
+        except Exception:  # noqa: BLE001
+            pass
 
     # Mutators (Coordinator only — LLM agents go via intents)
     def add_pruned_family(self, family: str) -> bool:
@@ -1085,6 +1103,16 @@ class SharedState:
         """Capture kernel_optimization_handler result for the next Orch turn; empty kernel_id no-op, non-KEEP can't overwrite a pending KEEP, retires kernel_id (r24 guard) after >= max_partial PARTIALs (INFERENCE_OPTIMIZER_KERNEL_OPT_MAX_PARTIAL)."""
         if not isinstance(result, dict):
             return
+        # Author-time breakdown capture: record geak/oob invocations (incl.
+        # backend + pre-dispatch failures) before the metadata-less early
+        # return so no failed attempt becomes invisible in the geak/oob view.
+        try:
+            from ..breakdown.recorder import instrument
+            instrument.record_kernel_invocations(
+                getattr(self, "_session_dir", None), result,
+            )
+        except Exception:  # noqa: BLE001
+            pass
         kernel_id = str(result.get("kernel_id") or "")
         if not kernel_id:
             # Metadata-less failure: preserve prior streaming-record KEEP.
@@ -1509,6 +1537,14 @@ class SharedState:
             history = history[-max_history:]
         setattr(self, attempts_attr, history)
         setattr(self, last_attr, dict(entry))
+        # Author-time breakdown capture: one phase_timeline event per attempt.
+        try:
+            from ..breakdown.recorder import instrument
+            instrument.record_phase_event(
+                getattr(self, "_session_dir", None), action=action, entry=entry,
+            )
+        except Exception:  # noqa: BLE001
+            pass
         return entry
 
     def record_action_failure(
@@ -1881,13 +1917,24 @@ class SharedState:
         round_id = str(entry.get("round_id") or "").strip()
         if not round_id:
             self.specialist_rounds.append(dict(entry))
-            return
-        existing = self.specialist_rounds
-        for i, prev in enumerate(existing):
-            if isinstance(prev, dict) and str(prev.get("round_id") or "") == round_id:
-                existing[i] = dict(entry)
-                return
-        existing.append(dict(entry))
+        else:
+            existing = self.specialist_rounds
+            matched = False
+            for i, prev in enumerate(existing):
+                if isinstance(prev, dict) and str(prev.get("round_id") or "") == round_id:
+                    existing[i] = dict(entry)
+                    matched = True
+                    break
+            if not matched:
+                existing.append(dict(entry))
+        # Author-time breakdown capture: one specialist_runs item per round.
+        try:
+            from ..breakdown.recorder import instrument
+            instrument.record_specialist_round(
+                getattr(self, "_session_dir", None), entry,
+            )
+        except Exception:  # noqa: BLE001
+            pass
 
     def bump_specialist_domain_empty_streak(
         self, domain: str, *, empty: bool,

--- a/inference_optimizer/session_paths.py
+++ b/inference_optimizer/session_paths.py
@@ -125,6 +125,16 @@ def patches_dir(session_dir: Path, kernel_id: str) -> Path:
     return Path(session_dir) / "patches" / kid
 
 
+# Session-breakdown record fragments (recorder write-side spool).
+def breakdown_parts_dir(session_dir: Path) -> Path:
+    """``<sd>/runtime/breakdown/parts/`` — per-producer breakdown record
+    fragments. Each owner writes its own files here (atomic + uniquely named);
+    the exporter assembles them into ``session_breakdown.json``. Single-owner
+    per section, so there is no cross-producer write contention.
+    """
+    return Path(session_dir) / "runtime" / "breakdown" / "parts"
+
+
 # Reports / logs
 def reports_dir(session_dir: Path) -> Path:
     return Path(session_dir) / "reports"
@@ -339,6 +349,7 @@ __all__ = [
     "agent_outbox",
     "agent_persona",
     "agent_prompt_snapshot",
+    "breakdown_parts_dir",
     "competitor_target_json",
     "cortex_audit_jsonl",
     "cortex_dead_letter_ndjson",


### PR DESCRIPTION
## Summary

Records `session_breakdown.json` facts **where they are produced** (author time) instead of re-walking heterogeneous on-disk artifacts at export time. This surfaces failures and history that the disk-based collectors structurally cannot see, while staying fully backward compatible.

- **recorder package** (`inference_optimizer/breakdown/recorder/`): atomic, multi-producer-safe fragment spool with `singleton` + `item` shapes and idempotent keys; a read-side assembler concatenates/overlays fragments into breakdown sections.
- **geak/oob invocations**: instrument `record_kernel_opt` to capture per-backend attempts from the in-process result — including backend-level failures and **pre-dispatch / infra failures** that never reach `optimization_attempts.jsonl` (the collector's only source). Fixes the invisible-failure problem; kernel-level KEEP/PARTIAL/REVERT is stamped on the adopted attempt like the collector does.
- **critic / robustness**: record each iteration/signal as an item at author time so the robustness backend's workdir pruning no longer drops history; composed back into the `critic_robustness` singleton at assembly.
- **report summaries**: mirror `kernel_optimization_summary`, `conc_sweep_summary`, `kernel_roofline`, and `specialist_runs` into the recorder at their write sites.
- **exporter.build**: merges fragments with a **fragment-preferred overlay + collector fallback** — no fragments ⇒ output identical to before. Adds `INFERENCE_OPTIMIZER_BREAKDOWN_DISABLE_RECORDER` kill-switch; recorder errors only warn, never poison the export.

## Test plan

- [x] Recorder round-trip: singleton/item write + assemble, idempotent keys.
- [x] geak/oob: backend KEEP stamping, backend-level FAILED, pre-dispatch FAILED, metadata-less infra FAILED all captured.
- [x] critic/robustness: composed `critic_robustness` + `kb_writes_summary`; retains signals across simulated workdir pruning (collector loses them).
- [x] exporter merge: no-fragments fallback, fragment override, kill-switch, derived sections (`capability_summary`) use resolved invocations, no substream leakage.
- [x] Existing `test_breakdown_exporter_units.py` (13 cases) still pass.
- [ ] Validate on a real session run (CI / reviewer).

Made with [Cursor](https://cursor.com)