### PR TITLE
fix(recipe_kb): restore dual remote reads

### DIFF
--- a/inference_optimizer/cli_kb.py
+++ b/inference_optimizer/cli_kb.py
@@ -58,6 +58,35 @@ def _build_recipe_kb_dispatcher(
     if bool(getattr(args, "degraded_kb", False)):
         return RecipeKB(local=local_store, remote=None)  # opt-out: no network
 
+    # Aggregated read remote (opt-in: RECIPE_KB_REMOTE=both). Fans reads across
+    # gbrain (GBRAIN_*) and the cortex kb-service (--cortex-kb-url /
+    # $CORTEX_KB_URL), then dedups/field-merges same-cid rows. Writes remain
+    # local-only; mirroring policy is handled only by the gbrain-only path.
+    if os.environ.get("RECIPE_KB_REMOTE", "").strip().lower() == "both":
+        from .recipe_kb.composite_remote import CompositeRemoteRecipeClient
+        from .recipe_kb.gbrain_remote_client import build_gbrain_remote_from_env
+
+        sources: list[Any] = []
+        names: list[str] = []
+        gbrain_remote = build_gbrain_remote_from_env()
+        if gbrain_remote is not None and gbrain_remote.enabled:
+            sources.append(gbrain_remote)
+            names.append("gbrain")
+        cortex_url = (getattr(args, "cortex_kb_url", None) or "").strip()
+        if not cortex_url:
+            cortex_url = (os.environ.get("CORTEX_KB_URL", "") or "").strip()
+        if cortex_url:
+            sources.append(
+                RemoteRecipeClient(kb_url=cortex_url, foreground=True, enabled=True)
+            )
+            names.append("cortex")
+        if sources:
+            return RecipeKB(
+                local=local_store,
+                remote=CompositeRemoteRecipeClient(sources, names=names),
+            )
+        return RecipeKB(local=local_store, remote=None)
+
     # gbrain read-side remote (opt-in: RECIPE_KB_REMOTE=gbrain + GBRAIN_*).
     # Writes stay local-only; gbrain serves the read side only.
     if os.environ.get("RECIPE_KB_REMOTE", "").strip().lower() == "gbrain":

--- a/inference_optimizer/recipe_kb/composite_remote.py
+++ b/inference_optimizer/recipe_kb/composite_remote.py
@@ -1,0 +1,343 @@
+"""Fan-out read remote that aggregates several recipe-KB backends.
+
+Slots into :class:`recipe_kb.RecipeKB`'s single ``remote`` field like any
+other read client, but fans every read across an ordered list of sub-remotes
+(e.g. ``[gbrain, cortex]``) and merges the results so callers see ONE merged
+arbor-shaped corpus.
+
+Design (matches the dispatcher contract):
+
+* Writes stay local-only — this client is read-side just like the others;
+  ``put_recipe`` / ``append_attempt`` are absent.
+* Every sub-remote's row is run through :func:`dispatcher._v2_to_arbor`, which
+  is idempotent: gbrain rows (already arbor-shaped) pass through untouched and
+  cortex rows (nested v2 envelope) are projected. So the composite operates on
+  a uniform arbor shape and advertises ``returns_arbor_shape = True`` (the
+  dispatcher then re-projects nothing).
+* Merge policy (config: field-level enrichment with adaptive precedence):
+    - dedup by the 5-tuple ``canonical_id``;
+    - within a dedup group the highest-precedence row is the BASE
+      (precedence = authority rank → confidence → field richness →
+      best_throughput);
+    - list fields (lessons / pitfalls / what_worked / …) are dedup-UNIONed
+      across the group so coverage is maximised;
+    - empty scalar fields on the base are back-filled from lower-precedence
+      rows (so a base missing ``best_config`` can still inherit one);
+    - a ``_sources`` marker records which backends contributed.
+* Search results are the per-cid-merged rows ranked by the same precedence and
+  truncated to ``limit``.
+
+A sub-remote that is disabled or raises is skipped (best-effort), so a flaky
+backend degrades coverage without failing the read. Session/attempt reads are
+local-only at the dispatcher layer, so the composite delegates those to the
+first source purely for direct-use completeness.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Iterable
+
+from .canonical_id import InvalidCanonicalIdError
+from .dispatcher import _labels_from_canonical_id, _v2_to_arbor
+from .remote_client import RemoteRecipeClientError
+
+log = logging.getLogger(__name__)
+
+# Authority ladder (higher = more trustworthy). Unknown authorities sort last.
+_AUTHORITY_RANK = {
+    "EXPERIENTIAL": 3,
+    "VALIDATED": 2,
+    "HYPOTHESIZED": 1,
+}
+
+# List-valued arbor fields that get dedup-unioned across a dedup group.
+_LIST_UNION_FIELDS = (
+    "what_worked", "what_failed", "remaining_gaps", "prs_tested",
+    "pitfalls", "lessons", "evidence_refs", "sessions",
+)
+# Scalar/dict arbor fields back-filled onto the base when the base value is empty.
+_BACKFILL_FIELDS = (
+    "best_config", "best_throughput", "framework_version", "last_profiled",
+    "stack_fingerprint", "provenance", "created_at", "updated_at",
+)
+
+# Per-source fetch floor so a low caller ``limit`` (e.g. get_recipe's limit=1)
+# still pulls enough rows from each backend for a meaningful merge.
+_FETCH_FLOOR = 25
+
+
+def _richness(row: dict[str, Any]) -> int:
+    """Count populated 'rich' fields — a tie-breaker that favours the row
+    carrying actual warm-start payload over a sparse stub."""
+    score = 0
+    if row.get("best_config"):
+        score += 1
+    if row.get("what_worked"):
+        score += 1
+    if row.get("lessons"):
+        score += 1
+    if row.get("stack_fingerprint"):
+        score += 1
+    if row.get("prs_tested"):
+        score += 1
+    return score
+
+
+def _precedence_key(row: dict[str, Any]) -> tuple[int, float, int, float]:
+    """Higher tuple = preferred base. authority → confidence → richness → tput."""
+    authority = str(row.get("authority") or "")
+    try:
+        confidence = float(row.get("confidence") or 0.0)
+    except (TypeError, ValueError):
+        confidence = 0.0
+    try:
+        throughput = float(row.get("best_throughput") or 0.0)
+    except (TypeError, ValueError):
+        throughput = 0.0
+    return (_AUTHORITY_RANK.get(authority, 0), confidence, _richness(row), throughput)
+
+
+def _is_empty(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, (str, list, dict, tuple)) and len(value) == 0:
+        return True
+    if isinstance(value, (int, float)) and value == 0:
+        return True
+    return False
+
+
+def _dedup_preserve(items: Iterable[Any]) -> list[Any]:
+    """Order-preserving dedup of a small sequence."""
+    out: list[Any] = []
+    for it in items:
+        if it not in out:
+            out.append(it)
+    return out
+
+
+def _union_lists(
+    rows: list[dict[str, Any]],
+    field: str,
+) -> tuple[list[Any], list[Any]]:
+    """Order-preserving dedup-union of one list field across rows.
+
+    Returns ``(merged_items, contributor_sources)`` where ``contributor_sources``
+    is the ordered, de-duplicated list of ``_source`` tags that contributed at
+    least one element to the union (for field-level provenance).
+
+    """
+    out: list[Any] = []
+    seen: set[str] = set()
+    contributors: list[Any] = []
+    for row in rows:
+        src = row.get("_source")
+        for item in (row.get(field) or []):
+            try:
+                key = json.dumps(item, sort_keys=True, ensure_ascii=False, default=str)
+            except (TypeError, ValueError):
+                key = repr(item)
+            if key not in seen:
+                seen.add(key)
+                out.append(item)
+                if src is not None and src not in contributors:
+                    contributors.append(src)
+    return out, contributors
+
+
+def _merge_group(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Field-level enrichment merge of all rows sharing one canonical_id.
+
+    Also emits ``_field_sources``: per actionable field, which backend(s) the
+    surviving value came from — scalar fields map to the single winning/
+    back-filling source, list fields to the ordered set of contributors. This
+    is what lets the KB-eval layer attribute an outcome to gbrain vs cortex.
+    """
+    ordered = sorted(rows, key=_precedence_key, reverse=True)
+    base = dict(ordered[0])
+    base_src = base.get("_source")
+    others = ordered[1:]
+    field_sources: dict[str, Any] = {}
+
+    # List fields: dedup-union across the whole group; provenance = contributors.
+    for field in _LIST_UNION_FIELDS:
+        merged, contributors = _union_lists(ordered, field)
+        base[field] = merged
+        if merged:
+            field_sources[field] = contributors or ([base_src] if base_src else [])
+
+    # Scalar/dict fields: keep base when populated, else back-fill from the
+    # highest-precedence non-empty donor; provenance = whoever supplied it.
+    for field in _BACKFILL_FIELDS:
+        if not _is_empty(base.get(field)):
+            if base_src is not None:
+                field_sources[field] = base_src
+            continue
+        for other in others:
+            if not _is_empty(other.get(field)):
+                base[field] = other[field]
+                if other.get("_source") is not None:
+                    field_sources[field] = other["_source"]
+                break
+
+    base["_sources"] = _dedup_preserve(
+        [r.get("_source") for r in ordered if r.get("_source")]
+    )
+    base["_field_sources"] = field_sources
+    base.pop("_source", None)
+    return base
+
+
+class CompositeRemoteRecipeClient:
+    """Aggregating read remote over an ordered list of sub-remotes."""
+
+    # The composite emits already-final arbor rows; the dispatcher must not
+    # re-project them.
+    returns_arbor_shape = True
+
+    def __init__(self, sources: Iterable[Any], *, names: list[str] | None = None) -> None:
+        self._sources = [s for s in sources if s is not None]
+        self._names = names or [
+            getattr(s, "_name", None) or type(s).__name__ for s in self._sources
+        ]
+
+    @property
+    def enabled(self) -> bool:
+        """Enabled iff at least one sub-remote is enabled."""
+        return any(getattr(s, "enabled", False) for s in self._sources)
+
+    def _active(self) -> list[tuple[str, Any]]:
+        return [
+            (self._names[i], s)
+            for i, s in enumerate(self._sources)
+            if getattr(s, "enabled", False)
+        ]
+
+    def _fan_out_search(self, *, name: str, source: Any, kwargs: dict[str, Any]) -> list[dict[str, Any]]:
+        """Run one source's search, tag + normalize each row. Best-effort."""
+        try:
+            rows = source.search(**kwargs)
+        except RemoteRecipeClientError as exc:
+            log.warning("composite: source %s search failed (%s); skipping", name, exc)
+            return []
+        except Exception as exc:  # noqa: BLE001 — never let one backend break the read
+            log.warning("composite: source %s search raised %r; skipping", name, exc)
+            return []
+        out: list[dict[str, Any]] = []
+        for row in rows or []:
+            arbor = _v2_to_arbor(row)
+            if not isinstance(arbor, dict) or not arbor:
+                continue
+            arbor["_source"] = name
+            out.append(arbor)
+        return out
+
+    def _merged_search(self, *, per_source_limit: int, kwargs: dict[str, Any]) -> list[dict[str, Any]]:
+        sub_kwargs = dict(kwargs)
+        sub_kwargs["limit"] = per_source_limit
+        grouped: dict[str, list[dict[str, Any]]] = {}
+        for name, source in self._active():
+            rows = self._fan_out_search(name=name, source=source, kwargs=sub_kwargs)
+            for row in rows:
+                cid = row.get("canonical_id") or ""
+                grouped.setdefault(cid, []).append(row)
+        merged = [_merge_group(rows) for rows in grouped.values()]
+        merged.sort(key=_precedence_key, reverse=True)
+        return merged
+
+    # ------------------------------------------------------------------
+    # Read surface consumed by RecipeKB
+    # ------------------------------------------------------------------
+    def search(
+        self,
+        *,
+        label_match: dict[str, Any] | None = None,
+        metric_filters: dict[str, Any] | None = None,
+        updated_since: str | None = None,
+        order_by: str = "updated_at DESC",
+        limit: int = 50,
+        prefer: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        # Main's dispatcher passes workload-similarity hints through this
+        # parameter. Sub-remotes accept it for interface parity while the
+        # dispatcher performs the actual client-side rerank.
+        kwargs = {
+            "label_match": label_match,
+            "metric_filters": metric_filters,
+            "updated_since": updated_since,
+            "order_by": order_by,
+            "limit": limit,
+            "prefer": prefer,
+        }
+        per_source = max(int(limit), _FETCH_FLOOR)
+        return self._merged_search(per_source_limit=per_source, kwargs=kwargs)[: int(limit)]
+
+    def get_recipe(
+        self,
+        *,
+        canonical_id: str,
+        version: int | None = None,
+    ) -> dict[str, Any] | None:
+        """Exact-cid read: search every source by the 5-tuple labels, merge top."""
+        try:
+            labels = _labels_from_canonical_id(canonical_id)
+        except InvalidCanonicalIdError as exc:
+            log.warning("composite get_recipe: %s", exc)
+            return None
+        merged = self._merged_search(
+            per_source_limit=_FETCH_FLOOR,
+            kwargs={"label_match": labels, "limit": 1},
+        )
+        for row in merged:
+            if row.get("canonical_id") == canonical_id:
+                return row
+        return merged[0] if merged else None
+
+    # ------------------------------------------------------------------
+    # Completeness for direct use (dispatcher reads these LOCAL-only, so these
+    # are only hit by direct callers). Delegate to the first capable source.
+    # ------------------------------------------------------------------
+    def list_recent(self, *, limit: int = 50) -> list[dict[str, Any]]:
+        return self._merged_search(
+            per_source_limit=max(int(limit), _FETCH_FLOOR),
+            kwargs={"label_match": None, "limit": limit, "metric_filters": None,
+                    "updated_since": None, "order_by": "updated_at DESC"},
+        )[: int(limit)]
+
+    def _first_active(self) -> Any | None:
+        for _name, source in self._active():
+            return source
+        return None
+
+    def list_attempts(self, *, canonical_id: str, limit: int = 100) -> list[dict[str, Any]]:
+        src = self._first_active()
+        return src.list_attempts(canonical_id=canonical_id, limit=limit) if src else []
+
+    def list_session_attempts(self, *, session_id: str, limit: int = 500) -> list[dict[str, Any]]:
+        src = self._first_active()
+        return src.list_session_attempts(session_id=session_id, limit=limit) if src else []
+
+    def session_summary(self, *, session_id: str) -> dict[str, Any] | None:
+        src = self._first_active()
+        return src.session_summary(session_id=session_id) if src else None
+
+    def health(self) -> bool:
+        """Healthy iff any active source is healthy."""
+        for _name, source in self._active():
+            try:
+                if source.health():
+                    return True
+            except Exception:  # noqa: BLE001
+                continue
+        return False
+
+    def close(self) -> None:
+        for source in self._sources:
+            try:
+                source.close()
+            except Exception:  # noqa: BLE001 — best-effort
+                pass
+
+
+__all__ = ["CompositeRemoteRecipeClient"]

--- a/inference_optimizer/recipe_kb/gbrain_ingest.py
+++ b/inference_optimizer/recipe_kb/gbrain_ingest.py
@@ -147,18 +147,40 @@ def _best_config_split(best_config: Mapping[str, Any]) -> tuple[str, dict[str, s
     return args, envs
 
 
+def _has_shareable_signal(recipe: Mapping[str, Any]) -> bool:
+    """Return True when a seed-only recipe carries reusable prior signal."""
+    for s in (recipe.get("sessions") or []):
+        if not isinstance(s, Mapping):
+            continue
+        try:
+            tput = float(s.get("throughput_after") or 0.0)
+        except (TypeError, ValueError):
+            tput = 0.0
+        if tput > 0.0 or s.get("actions_taken"):
+            return True
+    for field in ("what_worked", "what_failed", "remaining_gaps", "pitfalls", "lessons"):
+        if recipe.get(field):
+            return True
+    if recipe.get("architectures") or recipe.get("model_class"):
+        return True
+    return False
+
+
 def recipe_to_page(recipe: Mapping[str, Any]) -> tuple[str, str] | None:
     """Map a v2 recipe dict to a (slug, content) gbrain better-landing page.
 
-    Returns ``None`` when the recipe carries no concrete ``best_config``
-    (a bare anchor is skipped — nothing useful to cache remotely).
+    Returns ``None`` only when the recipe has no ``canonical_id``. By default
+    even pure seed-only anchors are mirrored so future gbrain reads can hit the
+    5-tuple (tier=seed_only); set RECIPE_KB_MIRROR_REQUIRE_SIGNAL=1 to restore
+    the old stricter gate (best_config OR reusable prior).
     """
     best_config = recipe.get("best_config") if isinstance(recipe.get("best_config"), Mapping) else {}
-    if not best_config:
-        return None
     canonical = str(recipe.get("canonical_id") or "").strip()
     if not canonical:
         return None
+    if str(os.environ.get("RECIPE_KB_MIRROR_REQUIRE_SIGNAL", "")).strip().lower() in ("1", "true", "yes"):
+        if not best_config and not _has_shareable_signal(recipe):
+            return None
     args, envs = _best_config_split(best_config)
     model = str(recipe.get("model") or "")
     hardware = str(recipe.get("hardware") or "")
@@ -231,10 +253,20 @@ def ingest_local_to_gbrain(
     dry_run: bool,
 ) -> dict[str, int]:
     """Ingest a list of v2 recipe dicts into gbrain. Returns counters."""
-    stats = {"total": len(recipes), "ingested": 0, "skipped_no_config": 0, "errors": 0}
+    stats = {
+        "total": len(recipes),
+        "ingested": 0,
+        # Accurate name for newly skipped rows (currently: missing canonical_id,
+        # or strict-gate seed-only skeletons). Keep the legacy key below as an
+        # alias for callers that still read it.
+        "skipped_unmirrorable": 0,
+        "skipped_no_config": 0,
+        "errors": 0,
+    }
     for recipe in recipes:
         page = recipe_to_page(recipe)
         if page is None:
+            stats["skipped_unmirrorable"] += 1
             stats["skipped_no_config"] += 1
             continue
         slug, content = page

--- a/inference_optimizer/recipe_kb/gbrain_ingest.py
+++ b/inference_optimizer/recipe_kb/gbrain_ingest.py
@@ -9,10 +9,12 @@ them back to a future session's warm-start. This module is the
 store into gbrain so a remote read actually returns the champion config
 instead of a bare anchor.
 
-Policy (mirrors the gain-gate on the write side):
+Mirror gate (default: permissive so seed-only anchors participate in
+warm-start reads):
 
-* Only recipes carrying a concrete ``best_config`` are ingested — a bare
-  identity anchor with no config is not worth a remote round-trip.
+* Any recipe with a ``canonical_id`` is mirrored, including bare seed-only
+  anchors (empty ``best_config``). Set ``RECIPE_KB_MIRROR_REQUIRE_SIGNAL=1``
+  to restore the stricter gate (``best_config`` OR reusable prior signal).
 * Idempotent: each recipe maps to a stable ``type: recipe`` page keyed by
   its 5-tuple canonical id, so re-running overwrites in place.
 
@@ -285,9 +287,10 @@ def ingest_local_to_gbrain(
 def mirror_recipe(recipe: Mapping[str, Any], mcp: _GbrainMcp | None) -> bool:
     """Best-effort mirror of ONE recipe dict into gbrain (read cache).
 
-    Returns True when a page was written, False when skipped (no config /
-    no mcp) or on a transport error. Never raises — the local write is
-    authoritative and a gbrain hiccup must not affect it.
+    Returns True when a page was written, False when skipped (no
+    ``canonical_id``, strict-gate rejection, no mcp) or on a transport
+    error. Never raises — the local write is authoritative and a gbrain
+    hiccup must not affect it.
     """
     if mcp is None:
         return False
@@ -320,9 +323,10 @@ class GbrainMirroringRecipeKB:
     Preserves the local-first contract: the wrapped dispatcher's local
     write is authoritative and runs first; the gbrain mirror is a
     post-write side-effect that never blocks or fails the local result.
-    Only recipes with a concrete ``best_config`` are mirrored (a T0
-    anchor has none -> skipped). Every other call (reads / append_attempt
-    / ...) delegates to the wrapped dispatcher unchanged.
+    Mirrors any recipe with a ``canonical_id`` (seed-only anchors included
+    by default; see ``RECIPE_KB_MIRROR_REQUIRE_SIGNAL``). Every other call
+    (reads / append_attempt / ...) delegates to the wrapped dispatcher
+    unchanged.
     """
 
     def __init__(self, inner: Any, mcp: _GbrainMcp | None) -> None:

--- a/inference_optimizer/recipe_kb/gbrain_ingest.py
+++ b/inference_optimizer/recipe_kb/gbrain_ingest.py
@@ -6,8 +6,8 @@ main's ``recipe_kb`` writes recipes LOCAL-only; the gbrain read remote
 (:class:`recipe_kb.gbrain_remote_client.GbrainRemoteRecipeClient`) serves
 them back to a future session's warm-start. This module is the
 "separately-scheduled bulk ingest" that lifts the authoritative local
-store into gbrain so a remote read actually returns the champion config
-instead of a bare anchor.
+store into gbrain so remote reads can hit champion configs and
+seed-only identity anchors alike.
 
 Mirror gate (default: permissive so seed-only anchors participate in
 warm-start reads):

--- a/inference_optimizer/recipe_kb/gbrain_remote_client.py
+++ b/inference_optimizer/recipe_kb/gbrain_remote_client.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import time
 import urllib.error
 import urllib.request
 from typing import Any, Mapping
@@ -57,10 +58,12 @@ log = logging.getLogger(__name__)
 # consumable verbatim by warm-replay.
 _ENVS_KEY = "extra_envs"
 
-# Listing the whole recipe type is cheap (the corpus is small) but we
-# still cap the scan so a runaway corpus can never block the main loop.
-_RECIPE_SCAN_CAP = 500
+# Listing the whole recipe type is a fallback path; prefer exact slug reads for
+# get_recipe and cache broad scans so one warm-start tick does not issue
+# thousands of MCP get_page calls repeatedly.
+_RECIPE_SCAN_CAP = 5000
 _LIST_PAGE_SIZE = 100
+_SCAN_CACHE_TTL_SEC = 60.0
 
 
 class GbrainRemoteError(RemoteRecipeClientError):
@@ -326,6 +329,8 @@ class GbrainRemoteRecipeClient:
         )
         self.enabled = bool(enabled and self.base_url and self.token)
         self._mcp = _GbrainMcp(self.base_url, self.token, self.timeout_sec) if self.enabled else None
+        self._scan_cache: list[dict[str, Any]] | None = None
+        self._scan_cache_ts = 0.0
 
     # -- lifecycle ---------------------------------------------------------
     def close(self) -> None:  # symmetry with RemoteRecipeClient
@@ -342,32 +347,63 @@ class GbrainRemoteRecipeClient:
             return False
 
     # -- internal scan -----------------------------------------------------
+    def _scan_cache_ttl(self) -> float:
+        raw = os.environ.get("GBRAIN_RECIPE_SCAN_TTL_SEC", "").strip()
+        if raw:
+            try:
+                return max(0.0, float(raw))
+            except ValueError:
+                log.warning("invalid GBRAIN_RECIPE_SCAN_TTL_SEC=%r; using default", raw)
+        return _SCAN_CACHE_TTL_SEC
+
+    def _get_page_recipe(self, slug: str) -> dict[str, Any] | None:
+        """Fetch one gbrain recipe page by slug and project it."""
+        if not self.enabled or self._mcp is None:
+            return None
+        page = self._mcp.call("get_page", {"slug": slug})
+        fm = page.get("frontmatter") if isinstance(page, dict) else None
+        if not isinstance(fm, Mapping):
+            return None
+        return _page_to_recipe(fm)
+
     def _scan_recipes(self, *, limit: int) -> list[dict[str, Any]]:
-        """List recipe pages (newest first) and project each to a Recipe dict."""
+        """List recipe pages and project each to a Recipe dict.
+
+        Use forward pagination (``updated_asc`` + ``updated_after``). The
+        reverse cursor (``updated_desc`` + ``updated_before``) can terminate
+        early when many pages share the same ``updated_at``, hiding older
+        recipes from client-side search. Dedup by slug across page boundaries
+        and return newest-first to preserve the previous caller contract.
+        """
         if not self.enabled or self._mcp is None:
             return []
+        now = time.monotonic()
+        ttl = self._scan_cache_ttl()
+        if self._scan_cache is not None and ttl > 0.0 and now - self._scan_cache_ts <= ttl:
+            return list(self._scan_cache[: int(limit) if limit and limit > 0 else len(self._scan_cache)])
         out: list[dict[str, Any]] = []
         cursor: str | None = None
+        seen_slugs: set[str] = set()
         cap = min(int(limit) if limit and limit > 0 else _RECIPE_SCAN_CAP, _RECIPE_SCAN_CAP)
         pages = 0
-        while len(out) < cap and pages < (_RECIPE_SCAN_CAP // _LIST_PAGE_SIZE + 2):
+        max_pages = max(1, (_RECIPE_SCAN_CAP // _LIST_PAGE_SIZE) + 3)
+        while len(out) < cap and pages < max_pages:
             params: dict[str, Any] = {
-                "type": "recipe", "limit": _LIST_PAGE_SIZE, "sort": "updated_desc",
+                "type": "recipe", "limit": _LIST_PAGE_SIZE, "sort": "updated_asc",
             }
             if cursor:
-                params["updated_before"] = cursor
+                params["updated_after"] = cursor
             batch = self._mcp.call("list_pages", params)
             if not isinstance(batch, list) or not batch:
                 break
+            new_slugs = 0
             for entry in batch:
                 slug = entry.get("slug") if isinstance(entry, dict) else None
-                if not slug:
+                if not slug or slug in seen_slugs:
                     continue
-                page = self._mcp.call("get_page", {"slug": slug})
-                fm = page.get("frontmatter") if isinstance(page, dict) else None
-                if not isinstance(fm, Mapping):
-                    continue
-                recipe = _page_to_recipe(fm)
+                seen_slugs.add(slug)
+                new_slugs += 1
+                recipe = self._get_page_recipe(str(slug))
                 if recipe is not None:
                     out.append(recipe)
                     if len(out) >= cap:
@@ -376,9 +412,12 @@ class GbrainRemoteRecipeClient:
             if len(batch) < _LIST_PAGE_SIZE:
                 break
             last = batch[-1].get("updated_at") if isinstance(batch[-1], dict) else None
-            if not last or last == cursor:
+            if not last or (last == cursor and new_slugs == 0):
                 break
             cursor = last
+        out.sort(key=lambda r: str(r.get("updated_at") or ""), reverse=True)
+        self._scan_cache = list(out)
+        self._scan_cache_ts = time.monotonic()
         return out
 
     # -- read surface (mirrors RemoteRecipeClient) -------------------------
@@ -409,6 +448,11 @@ class GbrainRemoteRecipeClient:
             C.F_LABEL_FRAMEWORK_VERSION: framework_version,
             C.F_LABEL_PRECISION: precision,
         }
+        # Fast path: gbrain recipe slugs are the canonical id with ':' as path
+        # separators, so exact 5-tuple reads do not need a full corpus scan.
+        direct = self._get_page_recipe("recipe-snapshot/" + canonical_id.replace(":", "/"))
+        if direct is not None and direct.get(C.F_CANONICAL_ID) == canonical_id:
+            return direct
         rows = self.search(label_match=label_match, limit=1)
         return rows[0] if rows else None
 

--- a/inference_optimizer/tests/test_composite_remote.py
+++ b/inference_optimizer/tests/test_composite_remote.py
@@ -1,0 +1,98 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for the dual remote recipe-KB composite client."""
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+
+CID = "inference:test-model:mi300x:sglang:0.5.11:fp8"
+
+
+class _FakeSource:
+    returns_arbor_shape = True
+    enabled = True
+
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+        self.seen_prefer: dict[str, Any] | None = None
+
+    def search(self, **kwargs: Any) -> list[dict[str, Any]]:
+        self.seen_prefer = kwargs.get("prefer")
+        return list(self.rows)
+
+    def health(self) -> bool:
+        return True
+
+
+def test_composite_search_accepts_prefer_and_merges_sources() -> None:
+    from inference_optimizer.recipe_kb.composite_remote import CompositeRemoteRecipeClient
+
+    gbrain = _FakeSource([{
+        "canonical_id": CID,
+        "model": "test-model",
+        "hardware": "mi300x",
+        "framework": "sglang",
+        "framework_version": "0.5.11",
+        "precision": "fp8",
+        "authority": "EXPERIENTIAL",
+        "confidence": 0.85,
+        "best_config": {"extra_envs": {"SGLANG_USE_AITER": "1"}},
+        "best_throughput": 0.0,
+    }])
+    cortex = _FakeSource([{
+        "canonical_id": CID,
+        "model": "test-model",
+        "hardware": "mi300x",
+        "framework": "sglang",
+        "framework_version": "0.5.11",
+        "precision": "fp8",
+        "authority": "EXPERIENTIAL",
+        "confidence": 0.85,
+        "best_config": {},
+        "best_throughput": 9868.3,
+        "lessons": [{"statement": "cortex lesson"}],
+    }])
+
+    client = CompositeRemoteRecipeClient(
+        [gbrain, cortex],
+        names=["gbrain", "cortex"],
+    )
+    rows = client.search(
+        label_match={"model": "test-model"},
+        limit=5,
+        prefer={"isl": 1024, "osl": 1024},
+    )
+
+    assert gbrain.seen_prefer == {"isl": 1024, "osl": 1024}
+    assert cortex.seen_prefer == {"isl": 1024, "osl": 1024}
+    assert len(rows) == 1
+    row = rows[0]
+    assert set(row["_sources"]) == {"gbrain", "cortex"}
+    assert row["best_config"] == {"extra_envs": {"SGLANG_USE_AITER": "1"}}
+    assert row["best_throughput"] == 9868.3
+    assert row["_field_sources"]["best_config"] == "gbrain"
+    assert row["_field_sources"]["best_throughput"] == "cortex"
+    assert row["_field_sources"]["lessons"] == ["cortex"]
+
+
+def test_cli_kb_both_mode_builds_composite(tmp_path, monkeypatch) -> None:
+    from inference_optimizer.cli_kb import _build_recipe_kb_dispatcher
+    from inference_optimizer.recipe_kb.composite_remote import CompositeRemoteRecipeClient
+
+    monkeypatch.setenv("RECIPE_KB_REMOTE", "both")
+    monkeypatch.setenv("GBRAIN_BASE_URL", "http://gbrain.invalid")
+    monkeypatch.setenv("GBRAIN_TOKEN", "token")
+    monkeypatch.setenv("CORTEX_KB_URL", "http://cortex.invalid")
+
+    kb = _build_recipe_kb_dispatcher(argparse.Namespace(
+        degraded_kb=False,
+        cortex_kb_url=None,
+        local_kb_root=str(tmp_path),
+    ))
+
+    assert isinstance(kb.remote, CompositeRemoteRecipeClient)
+    assert kb.remote._names == ["gbrain", "cortex"]
+    assert len(kb.remote._sources) == 2
+    assert kb.remote.returns_arbor_shape is True

--- a/inference_optimizer/tests/test_gbrain_ingest.py
+++ b/inference_optimizer/tests/test_gbrain_ingest.py
@@ -181,7 +181,8 @@ def test_ingest_counts_and_gates(monkeypatch) -> None:
     stats = ingest_local_to_gbrain(recipes=recipes, mcp=mcp, dry_run=False)
     assert stats["total"] == 4
     assert stats["ingested"] == 3
-    assert stats["skipped_no_config"] == 1
+    assert stats["skipped_unmirrorable"] == 1
+    assert stats["skipped_no_config"] == 1  # legacy alias
     assert stats["errors"] == 0
     assert len(mcp.puts) == 3
 

--- a/inference_optimizer/tests/test_gbrain_ingest.py
+++ b/inference_optimizer/tests/test_gbrain_ingest.py
@@ -146,9 +146,16 @@ def test_negative_knowledge_absent_yields_empty() -> None:
     assert r["failures"] == [] and r["findings"] == []
 
 
-def test_recipe_to_page_skips_bare_anchor() -> None:
-    assert recipe_to_page(_recipe(best_config={})) is None
+def test_recipe_to_page_mirrors_bare_anchor_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("RECIPE_KB_MIRROR_REQUIRE_SIGNAL", raising=False)
+    assert recipe_to_page(_recipe(best_config={})) is not None
     assert recipe_to_page(_recipe(best_config={}, canonical_id="")) is None
+
+
+def test_recipe_to_page_strict_flag_skips_bare_anchor(monkeypatch) -> None:
+    monkeypatch.setenv("RECIPE_KB_MIRROR_REQUIRE_SIGNAL", "1")
+    assert recipe_to_page(_recipe(best_config={})) is None
+    assert recipe_to_page(_recipe(best_config={}, lessons=[{"statement": "x"}])) is not None
 
 
 class _FakeMcp:
@@ -161,20 +168,22 @@ class _FakeMcp:
         return {}
 
 
-def test_ingest_counts_and_gates() -> None:
+def test_ingest_counts_and_gates(monkeypatch) -> None:
+    monkeypatch.delenv("RECIPE_KB_MIRROR_REQUIRE_SIGNAL", raising=False)
     recipes = [
         _recipe(),
-        _recipe(canonical_id="inference:a:b:c:d:e", best_config={}),  # anchor -> skip
+        _recipe(canonical_id="inference:a:b:c:d:e", best_config={}),  # anchor -> mirror
+        _recipe(canonical_id="", best_config={}),                     # no cid -> skip
         _recipe(canonical_id="inference:m2:mi355x:vllm:v1:fp16",
                 model="m2", hardware="mi355x", framework="vllm"),
     ]
     mcp = _FakeMcp()
     stats = ingest_local_to_gbrain(recipes=recipes, mcp=mcp, dry_run=False)
-    assert stats["total"] == 3
-    assert stats["ingested"] == 2
+    assert stats["total"] == 4
+    assert stats["ingested"] == 3
     assert stats["skipped_no_config"] == 1
     assert stats["errors"] == 0
-    assert len(mcp.puts) == 2
+    assert len(mcp.puts) == 3
 
 
 def test_ingest_dry_run_writes_nothing() -> None:
@@ -183,13 +192,15 @@ def test_ingest_dry_run_writes_nothing() -> None:
     assert stats["ingested"] == 1 and mcp.puts == []
 
 
-def test_mirror_recipe_gates_and_writes() -> None:
+def test_mirror_recipe_gates_and_writes(monkeypatch) -> None:
     from inference_optimizer.recipe_kb.gbrain_ingest import mirror_recipe
+    monkeypatch.delenv("RECIPE_KB_MIRROR_REQUIRE_SIGNAL", raising=False)
     mcp = _FakeMcp()
     assert mirror_recipe(_recipe(), mcp) is True and len(mcp.puts) == 1
-    assert mirror_recipe(_recipe(best_config={}), mcp) is False
+    assert mirror_recipe(_recipe(best_config={}), mcp) is True
+    assert len(mcp.puts) == 2
     assert mirror_recipe(_recipe(), None) is False
-    assert len(mcp.puts) == 1
+    assert len(mcp.puts) == 2
 
 
 class _RecordingInner:

--- a/inference_optimizer/tests/test_gbrain_remote_recipe_client.py
+++ b/inference_optimizer/tests/test_gbrain_remote_recipe_client.py
@@ -98,6 +98,23 @@ def test_get_recipe_roundtrip() -> None:
     assert r is not None and r["canonical_id"] == cid
 
 
+def test_get_recipe_uses_direct_slug_fast_path() -> None:
+    slug = "recipe-snapshot/inference/qwen3-32b/mi300x/sglang/unknown_version/fp8"
+    c = _client({
+        slug: _recipe_page("Qwen3-32B", "mi300x", "sglang", "fp8"),
+        "recipe-snapshot/inference/other/mi300x/sglang/unknown_version/fp8": (
+            _recipe_page("Other", "mi300x", "sglang", "fp8")
+        ),
+    })
+    cid = "inference:qwen3-32b:mi300x:sglang:unknown_version:fp8"
+
+    r = c.get_recipe(canonical_id=cid)
+
+    assert r is not None and r["canonical_id"] == cid
+    # Exact gbrain slugs should avoid the expensive broad list_pages scan.
+    assert [tool for tool, _ in c._mcp.calls] == ["get_page"]  # type: ignore[union-attr]
+
+
 def test_get_recipe_miss_on_unknown() -> None:
     c = _client({"cortex/recipe/a/b": _recipe_page("modelA", "mi300x")})
     assert c.get_recipe(canonical_id="inference:other:mi355x:vllm:v1:fp16") is None
@@ -131,6 +148,22 @@ def test_search_filters_by_label_match() -> None:
     # framework filter
     rows = c.search(label_match={"framework": "vllm"})
     assert len(rows) == 1 and _model(rows[0]) == "llama-3-70b"
+
+
+def test_search_reuses_scan_cache() -> None:
+    c = _client({
+        "r1": _recipe_page("Qwen3-32B", "mi300x", "sglang"),
+        "r2": _recipe_page("Llama-3-70B", "mi300x", "vllm"),
+    })
+
+    assert len(c.search(label_match={"hardware": "mi300x"})) == 2
+    first_call_count = len(c._mcp.calls)  # type: ignore[union-attr]
+    assert any(tool == "list_pages" for tool, _ in c._mcp.calls)  # type: ignore[union-attr]
+
+    assert len(c.search(label_match={"framework": "vllm"})) == 1
+    # Second search should reuse the process-local scan cache; no extra MCP
+    # calls are needed.
+    assert len(c._mcp.calls) == first_call_count  # type: ignore[union-attr]
 
 
 def test_disabled_client_returns_empty() -> None:


### PR DESCRIPTION
## Summary

Restore the composite gbrain+cortex read path after the CLI KB bootstrap refactor. Make gbrain recipe scans cover the full corpus so seed-only anchors can participate in warm-start merges, remove composite unified-schema dead code, and add gbrain read-side caching plus direct `get_page` fast path.

Closes #446

## Linked issue(s)

- #446 — dual-KB warm-start / composite read restoration

## Tests

Added/updated:
- `test_composite_remote.py` — composite construction, `prefer` forwarding, source merge
- `test_gbrain_ingest.py` — bare-anchor mirror-by-default, strict `RECIPE_KB_MIRROR_REQUIRE_SIGNAL=1` gate
- `test_gbrain_remote_recipe_client.py` — direct slug `get_page`, scan TTL cache

```bash
python -m pytest inference_optimizer/tests/test_gbrain_ingest.py \
  inference_optimizer/tests/test_composite_remote.py \
  inference_optimizer/tests/test_gbrain_remote_recipe_client.py -q
```

## Breaking changes

**Yes** — gbrain mirror gate default is now permissive:

- Recipes with a `canonical_id` are mirrored even when `best_config` is empty (seed-only anchors).
- Set `RECIPE_KB_MIRROR_REQUIRE_SIGNAL=1` to restore the previous stricter gate (`best_config` OR reusable prior).