### PR TITLE
fix: prevent explore in KERNEL phase with --no-explore & auto-dispatch integrate after KEEP

### DIFF
--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -156,6 +156,7 @@ def _objective_summary_for_prompt(objective: Objective) -> tuple[str, float | st
 def _build_orchestration_prompt(
     *,
     no_kernel: bool,
+    no_explore: bool = False,
     framework: str,
     objective: Objective,
     max_minutes: int,
@@ -170,6 +171,7 @@ def _build_orchestration_prompt(
         enabled_actions=enabled,
         framework=framework,
         kernel_enabled=not no_kernel,
+        explore_enabled=not no_explore,
         objective_kind=kind,
         objective_value=value,
         max_minutes=int(max_minutes),
@@ -3945,6 +3947,7 @@ async def _run_optimize(args: argparse.Namespace) -> int:
     prompts: dict[str, str] = {
         "orchestration": args.orch_prompt or _build_orchestration_prompt(
             no_kernel=no_kernel,
+            no_explore=bool(getattr(args, "no_explore", False)),
             framework=framework_for_prompt,
             objective=objective,
             max_minutes=max_minutes_for_prompt,

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -6425,6 +6425,9 @@ class Coordinator:
                     ):
                         self.shared_state.record_kernel_opt(result)
                     self.shared_state.save(self.session_dir)
+                    # Auto-enqueue integrate for KEEP'd kernels that haven't
+                    # been integrated yet (IR-3: integration is mandatory).
+                    await self._auto_enqueue_pending_integrations()
                 if kind == "run_gemm_tuning":
                     self.shared_state.record_gemm_tuning(result)
                     self.shared_state.save(self.session_dir)
@@ -6737,6 +6740,64 @@ class Coordinator:
         if latest:
             top = latest[0]
             await self.cursors.advance(agent_name, seq=top.seq, msg_id=top.msg_id)
+
+    async def _auto_enqueue_pending_integrations(self) -> None:
+        """Auto-dispatch integrate for KEEP'd kernels not yet integrated (IR-3).
+
+        After kernel_opt completes, any kernel with decision=KEEP that has no
+        entry in kernel_integrate_attempts is immediately queued as an integrate
+        REQUEST on the kernel agent's bus. This prevents the LLM from proposing
+        explore/specialist instead of integrate after a successful kernel_opt.
+        """
+        state = self.shared_state
+        opt_attempts = getattr(state, "kernel_opt_attempts", None) or {}
+        integ_attempts = getattr(state, "kernel_integrate_attempts", None) or {}
+        if not isinstance(opt_attempts, dict):
+            return
+
+        integrated_kids: set[str] = set()
+        if isinstance(integ_attempts, dict):
+            for entry in integ_attempts.values():
+                if isinstance(entry, dict):
+                    kid = str(entry.get("kernel_id") or "")
+                    if kid:
+                        integrated_kids.add(kid)
+
+        # Track dispatched auto-integrates across ticks via instance set.
+        if not hasattr(self, "_auto_integrate_dispatched"):
+            self._auto_integrate_dispatched: set[str] = set()
+
+        pending_kids: list[str] = []
+        for kid, data in opt_attempts.items():
+            if not isinstance(data, dict):
+                continue
+            decision = str(data.get("last_decision") or "").upper()
+            if (
+                decision == "KEEP"
+                and kid not in integrated_kids
+                and kid not in self._auto_integrate_dispatched
+            ):
+                pending_kids.append(kid)
+
+        if not pending_kids:
+            return
+
+        for kid in pending_kids:
+            log.info(
+                "auto-integrate: dispatching integrate for KEEP'd kernel %s "
+                "(IR-3 mandatory integration)",
+                kid,
+            )
+            await self.bus.append_and_seq(Message.new(
+                "orchestration", "kernel", "request",
+                {
+                    "kind": "integrate",
+                    "kernel_id": kid,
+                    "source": "auto_integrate_after_kernel_opt",
+                },
+                priority=2,
+            ))
+            self._auto_integrate_dispatched.add(kid)
 
     def _record_kernel_opt_partial(self, result: dict[str, Any]) -> None:
         """Streaming callback for ``_run_optimization_batch`` sub-attempts: write each per-kernel entry to kernel_opt_attempts immediately so the next-tick prompt is accurate mid-batch."""

--- a/inference_optimizer/orchestrator/phase_state.py
+++ b/inference_optimizer/orchestrator/phase_state.py
@@ -127,6 +127,12 @@ _INTERLEAVE_KERNEL_EXTRAS: frozenset[str] = frozenset({
     "explore", "specialist", "integrate_patch",
 })
 
+# When --no-explore, only integrate_patch is useful in KERNEL interleave
+# (explore/specialist dispatch config variants that belong to the EXPLORE phase).
+_INTERLEAVE_KERNEL_NO_EXPLORE: frozenset[str] = frozenset({
+    "integrate_patch",
+})
+
 
 def is_phase_interleave_enabled() -> bool:
     """Return True when EXPLORE↔KERNEL interleave is enabled (default ON, P3_18; env is rollback knob)."""
@@ -136,8 +142,15 @@ def is_phase_interleave_enabled() -> bool:
 
 def llm_proposable_actions_for_with_interleave(
     phase: str, *, interleave: bool | None = None,
+    explore_enabled: bool | None = None,
 ) -> frozenset[str]:
-    """Return the active LLM-proposable set for ``phase`` (when interleave on, EXPLORE adds kernel-owned names, KERNEL adds the explore triple)."""
+    """Return the active LLM-proposable set for ``phase``.
+
+    When interleave is on, EXPLORE adds kernel-owned names and KERNEL adds the
+    explore triple.  However, when ``explore_enabled=False`` (--no-explore), the
+    KERNEL extras are narrowed to ``integrate_patch`` only — explore/specialist
+    are EXPLORE-phase actions and must not leak into a kernel-only session.
+    """
     key = (phase or "").strip().upper()
     base = PHASE_LLM_PROPOSABLE_ACTIONS.get(key, frozenset())
     if interleave is None:
@@ -147,17 +160,20 @@ def llm_proposable_actions_for_with_interleave(
     if key == PHASE_EXPLORE:
         return base | _INTERLEAVE_EXPLORE_EXTRAS
     if key == PHASE_KERNEL:
+        if explore_enabled is False:
+            return base | _INTERLEAVE_KERNEL_NO_EXPLORE
         return base | _INTERLEAVE_KERNEL_EXTRAS
     return base
 
 
 def is_action_llm_proposable_in_phase_with_interleave(
     action_name: str, phase: str, *, interleave: bool | None = None,
+    explore_enabled: bool | None = None,
 ) -> bool:
     """Mirror of :func:`is_action_llm_proposable_in_phase` honoring the
     interleave flag."""
     proposable = llm_proposable_actions_for_with_interleave(
-        phase, interleave=interleave,
+        phase, interleave=interleave, explore_enabled=explore_enabled,
     )
     return (action_name or "").strip() in proposable
 

--- a/inference_optimizer/orchestrator/policy.py
+++ b/inference_optimizer/orchestrator/policy.py
@@ -1009,10 +1009,14 @@ class PolicyGate:
             return
         if is_action_llm_proposable_in_phase_with_interleave(
             action_name, phase,
+            explore_enabled=getattr(state, "explore_enabled", None),
         ):
             return
         allowed = tuple(sorted(
-            llm_proposable_actions_for_with_interleave(phase)
+            llm_proposable_actions_for_with_interleave(
+                phase,
+                explore_enabled=getattr(state, "explore_enabled", None),
+            )
         ))
         hint = (
             f"you are in phase={phase}; action {action_name!r} is not in "

--- a/inference_optimizer/orchestrator/shared_state.py
+++ b/inference_optimizer/orchestrator/shared_state.py
@@ -2791,7 +2791,10 @@ class SharedState:
                 f"elapsed_sec={elapsed} remaining_sec={int(remaining)}"
             )
         proposable = tuple(sorted(
-            llm_proposable_actions_for_with_interleave(phase)
+            llm_proposable_actions_for_with_interleave(
+                phase,
+                explore_enabled=self.explore_enabled if hasattr(self, "explore_enabled") else None,
+            )
         ))
         allowed_line = (
             f"allowed   : {', '.join(proposable) if proposable else '(none)'}"

--- a/inference_optimizer/orchestrator/system_prompts/prompt_builder.py
+++ b/inference_optimizer/orchestrator/system_prompts/prompt_builder.py
@@ -133,7 +133,7 @@ def _section_session_context(
     ]
 
 
-def _section_phase_semantics(*, kernel_enabled: bool) -> list[str]:
+def _section_phase_semantics(*, kernel_enabled: bool, explore_enabled: bool = True) -> list[str]:
     """Render the per-phase allowed-action contract (current phase injected
     dynamically by the Coordinator)."""
     from ..phase_state import (
@@ -156,6 +156,7 @@ def _section_phase_semantics(*, kernel_enabled: bool) -> list[str]:
         proposable = sorted(
             llm_proposable_actions_for_with_interleave(
                 phase, interleave=interleave,
+                explore_enabled=explore_enabled if interleave else None,
             )
         )
         if not kernel_enabled and phase == "KERNEL":
@@ -760,6 +761,7 @@ def build_orchestration_prompt(
     enabled_actions: Iterable[str],
     framework: str = "sglang",
     kernel_enabled: bool | None = None,
+    explore_enabled: bool = True,
     objective_kind: str = "time_only",
     objective_value: float | str | None = None,
     max_minutes: int = 0,
@@ -798,7 +800,7 @@ def build_orchestration_prompt(
             framework_source_roots=framework_source_roots,
         ),
         _section_pipeline_and_budget(actions, max_minutes=max_minutes),
-        _section_phase_semantics(kernel_enabled=kernel_enabled),
+        _section_phase_semantics(kernel_enabled=kernel_enabled, explore_enabled=explore_enabled),
         _section_action_catalogue(actions),
         _section_decision_framework(kernel_enabled=kernel_enabled),
     ]


### PR DESCRIPTION
## Summary

- When `--no-explore` is set, phase interleave no longer widens KERNEL's proposable actions with `explore`/`specialist` — only `integrate_patch` remains. This prevents the LLM orchestrator from proposing explore variants during the KERNEL phase when explore is explicitly disabled.
- After `kernel_opt` returns KEEP, the Coordinator now auto-dispatches `integrate` requests for all un-integrated KEEP'd kernels (enforcing IR-3: "integration is mandatory"). This eliminates the race where the LLM could choose explore over integrate after successful optimization.

## Root cause

1. `is_phase_interleave_enabled()` only checked the env var `INFERENCE_OPTIMIZER_PHASE_INTERLEAVE`, completely ignoring `shared_state.explore_enabled`. So `--no-explore` skipped the EXPLORE *phase* but still allowed explore *actions* in KERNEL via interleave.
2. `integrate` dispatch was entirely LLM-driven (no Coordinator-side automation). The LLM orchestrator freely chose `explore` (legal via interleave) over `integrate` after kernel_opt KEEP.

## Test plan

- [x] All 3613 existing tests pass (0 failures)
- [x] `test_cli_no_explore.py` passes
- [x] `test_phase_state*.py` passes (129 tests)
- [x] Policy/interleave tests pass (222 tests)


Made with [Cursor](https://cursor.com)