### PR TITLE
feat(critic): optional substrate KB assess enrichment for proposals

### DIFF
--- a/critic-agent/actions/review_coordinator_inbox.md
+++ b/critic-agent/actions/review_coordinator_inbox.md
@@ -44,6 +44,18 @@ For each proposal in `proposals`:
    [references/verdict_schema.md](../references/verdict_schema.md) for
    per-verdict required fields, and any
    `kb_priors_by_proposal[<msg_id>]` returned in Step 1.
+4. If present, factor in
+   `kb_assess_by_proposal[<msg_id>]` — the substrate KB's calibrated
+   reasonableness verdict for that proposal's optimisation levers:
+   - `reasonable = "supported"` → measured KB evidence backs the levers;
+     a point in favour, but not on its own a reason to approve.
+   - `reasonable = "contested"` → at least one lever **contradicts** measured
+     evidence (`verdicts[].status` is `deviated` / `conflicts`); treat as a
+     risk signal and cite the offending lever in `kb_evidence`.
+   - `reasonable = "insufficient_basis"` (or field absent) → the KB has no
+     opinion; ignore it, do **not** penalise the proposal.
+   This field is advisory enrichment and is only present when the operator
+   configured `CORTEX_KB_URL`; never block solely on its absence.
 
 Default behavior summary:
 

--- a/critic-agent/runtime/decision_reviewer.py
+++ b/critic-agent/runtime/decision_reviewer.py
@@ -335,6 +335,17 @@ class JudgeBundle:
     # Substrate KB per-proposal reasonableness verdicts (optional enrichment),
     # keyed by proposal ``msg_id``; empty when assess is unconfigured/skipped.
     kb_assess_by_proposal: dict[str, dict[str, Any]] = field(default_factory=dict)
+    # Audit trail for the KB assess call: whether it was configured, why it was
+    # skipped (if so), the focus used, and the exact request levers sent per
+    # proposal. Consumed by the Coordinator backend for trace/SBD; NOT fed to
+    # the LLM (the verdicts in ``kb_assess_by_proposal`` are the LLM-facing view).
+    kb_assess_trace: dict[str, Any] = field(default_factory=dict)
+    # Audit trail for the historical KB prior reads (``list_priors``): the shared
+    # scope_filter/limit and the exact per-proposal request (topic/kind) plus the
+    # cache/count of each lookup. Consumed by the Coordinator backend for
+    # trace/SBD; the priors themselves live in ``kb_priors_by_proposal`` /
+    # ``kb_priors_for_decision`` (which ARE fed to the LLM).
+    kb_priors_trace: dict[str, Any] = field(default_factory=dict)
     # Recent Robustness findings so the SKILL can factor in what already broke;
     # empty when absent or disabled.
     robustness_priors: list[dict[str, Any]] = field(default_factory=list)
@@ -367,6 +378,8 @@ class JudgeBundle:
             "kb_assess_by_proposal": {
                 k: dict(v) for k, v in self.kb_assess_by_proposal.items()
             },
+            "kb_assess_trace": dict(self.kb_assess_trace),
+            "kb_priors_trace": dict(self.kb_priors_trace),
             "robustness_priors": [dict(p) for p in self.robustness_priors],
             "kb_read_skipped_reason": self.kb_read_skipped_reason,
             "review_constraints": dict(self.review_constraints),
@@ -630,6 +643,8 @@ class DecisionReviewer:
         topic_hits: dict[str, list[dict[str, Any]]] = {}
         ctx = WriteContext(session_id=req.session_id, review_id=req.decision_id)
         any_kb_unreachable = False
+        prior_limit = int(os.environ.get("CRITIC_KB_PRIOR_LIMIT", "5"))
+        priors_requests: list[dict[str, Any]] = []
         if req.proposals:
             for p in req.proposals:
                 topic = self._topic_for_proposal(p)
@@ -638,7 +653,7 @@ class DecisionReviewer:
                     kind=None,
                     topic=topic,
                     metadata_filter=None,
-                    limit=int(os.environ.get("CRITIC_KB_PRIOR_LIMIT", "5")),
+                    limit=prior_limit,
                     ctx=ctx,
                 )
                 topic_hits[p.msg_id] = priors.get("priors") or []
@@ -646,6 +661,12 @@ class DecisionReviewer:
                     any_kb_unreachable = True
                 self.session_memory.append_event(req.session_id, {
                     "kind": "kb_prior_lookup",
+                    "msg_id": p.msg_id,
+                    "topic": topic,
+                    "cache": priors.get("cache"),
+                    "count": len(topic_hits[p.msg_id]),
+                })
+                priors_requests.append({
                     "msg_id": p.msg_id,
                     "topic": topic,
                     "cache": priors.get("cache"),
@@ -659,7 +680,7 @@ class DecisionReviewer:
                 kind=None,
                 topic=topic,
                 metadata_filter=None,
-                limit=int(os.environ.get("CRITIC_KB_PRIOR_LIMIT", "5")),
+                limit=prior_limit,
                 ctx=ctx,
             )
             bundle.kb_priors_for_decision = priors.get("priors") or []
@@ -671,6 +692,24 @@ class DecisionReviewer:
                 "cache": priors.get("cache"),
                 "count": len(bundle.kb_priors_for_decision),
             })
+            priors_requests.append({
+                "msg_id": None,
+                "topic": topic,
+                "cache": priors.get("cache"),
+                "count": len(bundle.kb_priors_for_decision),
+            })
+
+        # Audit trail for the historical KB prior reads (always injected; no
+        # env gate). The priors themselves feed the LLM; this records what we
+        # asked and what came back so the Coordinator can trace it into the SBD.
+        bundle.kb_priors_trace = {
+            "configured": True,
+            "mode": "per_proposal" if req.proposals else "per_decision",
+            "client_mode": os.environ.get("CRITIC_KB_CLIENT_MODE", ""),
+            "scope_filter": dict(scope_filter),
+            "limit": prior_limit,
+            "requests": priors_requests,
+        }
 
         if any_kb_unreachable:
             bundle.kb_read_skipped_reason = "kb_unreachable"
@@ -711,25 +750,56 @@ class DecisionReviewer:
             req (CriticRequest): The parsed request (for proposals).
         """
         client = self.kb_assess_client
-        if client is None or not req.proposals:
+        trace: dict[str, Any] = {
+            "configured": client is not None,
+            "skipped_reason": None,
+            "focus": {},
+            "requests": [],
+        }
+        if client is None:
+            trace["skipped_reason"] = "not_configured"
+            bundle.kb_assess_trace = trace
+            return
+        if not req.proposals:
+            trace["skipped_reason"] = "no_proposals"
+            bundle.kb_assess_trace = trace
             return
         focus = self._assess_focus(bundle.merged_context)
+        trace["focus"] = dict(focus)
         if not focus.get("model"):
+            trace["skipped_reason"] = "unknown_model"
+            bundle.kb_assess_trace = trace
             return
         results: dict[str, dict[str, Any]] = {}
         for p in req.proposals:
             params, envs, args = _proposal_levers(p.payload)
             if not params and not envs and not args:
+                trace["requests"].append({
+                    "msg_id": p.msg_id,
+                    "skipped": "no_levers",
+                })
                 continue
             verdict = client.assess(focus=focus, params=params, envs=envs, args=args)
+            req_entry: dict[str, Any] = {
+                "msg_id": p.msg_id,
+                "params_keys": sorted(params.keys()),
+                "envs_keys": sorted(envs.keys()),
+                "args_count": len(args),
+                "responded": verdict is not None,
+            }
             if verdict is None:
+                trace["requests"].append(req_entry)
                 continue
+            req_entry["reasonable"] = verdict.get("reasonable")
+            trace["requests"].append(req_entry)
             results[p.msg_id] = verdict
             self.session_memory.append_event(req.session_id, {
                 "kind": "kb_assess_lookup",
                 "msg_id": p.msg_id,
                 "reasonable": verdict.get("reasonable"),
             })
+        trace["verdict_count"] = len(results)
+        bundle.kb_assess_trace = trace
         if results:
             bundle.kb_assess_by_proposal = results
             bundle.notes.append(

--- a/critic-agent/runtime/decision_reviewer.py
+++ b/critic-agent/runtime/decision_reviewer.py
@@ -37,6 +37,7 @@ from .intent_envelope import (
     build_heartbeat_intent,
     build_review_verdict_intent,
 )
+from .kb_assess_client import KBAssessClient
 from .kb_client import KBClient
 from .kb_writer import KBWriter, WriteContext
 from .metrics import CRITIC_REVIEW_VERDICT_TOTAL, get_registry
@@ -60,6 +61,63 @@ def _now_iso() -> str:
         str: The current UTC timestamp with microsecond precision.
     """
     return datetime.now(timezone.utc).isoformat(timespec="microseconds")
+
+
+# Proposal-payload keys that carry environment-variable / CLI-arg levers as
+# containers rather than direct param values; pulled out so the rest of
+# ``params`` resolves cleanly to substrate knobs.
+_LEVER_ENV_KEYS: tuple[str, ...] = ("extra_envs", "envs", "env")
+_LEVER_ARG_KEYS: tuple[str, ...] = ("extra_server_args", "server_args", "args")
+_LEVER_CONTAINER_KEYS: frozenset[str] = frozenset(
+    _LEVER_ENV_KEYS + _LEVER_ARG_KEYS + ("grid",)
+)
+
+
+def _proposal_levers(
+    payload: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any], str]:
+    """Extract ``(params, envs, args)`` levers from a proposal payload.
+
+    Best-effort, schema-tolerant: pulls env-var and CLI-arg containers out of
+    ``payload['params']`` (or ``payload`` itself) and treats the remaining
+    scalar params as direct levers. CLI args given as a list are space-joined.
+
+    Args:
+        payload (dict[str, Any]): The raw proposal payload.
+
+    Returns:
+        tuple[dict, dict, str]: The resolved ``params``, ``envs`` and ``args``.
+    """
+    if not isinstance(payload, dict):
+        return {}, {}, ""
+    # Levers live under ``params``; the top-level payload is proposal metadata
+    # (action_name / predicted_gain_pct / reason) and must not be mistaken for
+    # tunable levers. No ``params`` dict → nothing to assess.
+    src = payload.get("params")
+    if not isinstance(src, dict):
+        return {}, {}, ""
+
+    envs: dict[str, Any] = {}
+    for key in _LEVER_ENV_KEYS:
+        val = src.get(key)
+        if isinstance(val, dict):
+            envs.update(val)
+
+    args_parts: list[str] = []
+    for key in _LEVER_ARG_KEYS:
+        val = src.get(key)
+        if isinstance(val, str) and val.strip():
+            args_parts.append(val.strip())
+        elif isinstance(val, (list, tuple)):
+            args_parts.extend(str(a) for a in val if a is not None)
+    args = " ".join(args_parts).strip()
+
+    params: dict[str, Any] = {
+        k: v
+        for k, v in src.items()
+        if k not in _LEVER_CONTAINER_KEYS and isinstance(v, (str, int, float, bool))
+    }
+    return params, envs, args
 
 
 # Review-constraints taxonomy: a single strict checklist would deadlock the
@@ -274,6 +332,9 @@ class JudgeBundle:
     decision: dict[str, Any] = field(default_factory=dict)
     kb_priors_by_proposal: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
     kb_priors_for_decision: list[dict[str, Any]] = field(default_factory=list)
+    # Substrate KB per-proposal reasonableness verdicts (optional enrichment),
+    # keyed by proposal ``msg_id``; empty when assess is unconfigured/skipped.
+    kb_assess_by_proposal: dict[str, dict[str, Any]] = field(default_factory=dict)
     # Recent Robustness findings so the SKILL can factor in what already broke;
     # empty when absent or disabled.
     robustness_priors: list[dict[str, Any]] = field(default_factory=list)
@@ -303,6 +364,9 @@ class JudgeBundle:
                 k: [dict(p) for p in v] for k, v in self.kb_priors_by_proposal.items()
             },
             "kb_priors_for_decision": [dict(p) for p in self.kb_priors_for_decision],
+            "kb_assess_by_proposal": {
+                k: dict(v) for k, v in self.kb_assess_by_proposal.items()
+            },
             "robustness_priors": [dict(p) for p in self.robustness_priors],
             "kb_read_skipped_reason": self.kb_read_skipped_reason,
             "review_constraints": dict(self.review_constraints),
@@ -368,6 +432,7 @@ class DecisionReviewer:
         session_memory: SessionMemory | None = None,
         kb_client: KBClient | None = None,
         kb_writer: KBWriter | None = None,
+        kb_assess_client: "KBAssessClient | None" = None,
     ):
         """Wire up the reviewer with its memory, KB client and writer.
 
@@ -379,6 +444,11 @@ class DecisionReviewer:
                 created if both ``kb_writer`` and ``kb_client`` are ``None``.
             kb_writer (KBWriter | None): KB write façade; built from
                 ``kb_client`` and ``session_memory`` when ``None``.
+            kb_assess_client (KBAssessClient | None): Optional substrate
+                ``/v2/reasoning/assess`` client. When ``None``, one is built
+                from the environment (``CORTEX_KB_URL`` — the same cortex KB
+                recipe-snapshot uses); if that is unset too, per-proposal
+                assessment is skipped entirely.
         """
         self.session_memory = session_memory or SessionMemory()
         if kb_writer is None:
@@ -388,6 +458,9 @@ class DecisionReviewer:
                 kb_client = InMemoryKBClient()
             kb_writer = KBWriter(kb_client, session_memory=self.session_memory)
         self.kb_writer = kb_writer
+        if kb_assess_client is None:
+            kb_assess_client = KBAssessClient.from_env()
+        self.kb_assess_client = kb_assess_client
 
     # ------------------------------------------------------------------
     # Phase 0: init / close session
@@ -610,10 +683,85 @@ class DecisionReviewer:
             bundle.notes.append("scope partially unknown — proceed with caution")
         bundle.notes.append(f"scope_cache_key={scope_cache_key(scope_filter)}")
 
+        # Best-effort substrate KB per-proposal reasonableness verdicts; only
+        # runs when ``CRITIC_KB_ASSESS_URL`` is configured, never blocks review.
+        self._inject_kb_assess(bundle, req)
+
         # Best-effort last-N high-severity Robustness findings; never blocks
         # the review. Disabled via ``CRITIC_ROBUSTNESS_PRIORS_DISABLED=1``.
         self._inject_robustness_priors(bundle)
         return bundle
+
+    # ------------------------------------------------------------------
+    # Optional: associate each proposal's raw levers to the substrate KB's
+    # calibrated mechanism evidence to judge reasonableness. Opt-in via
+    # ``CORTEX_KB_URL`` (same cortex KB recipe-snapshot uses); best-effort
+    # and never blocks the review.
+    # ------------------------------------------------------------------
+    def _inject_kb_assess(self, bundle: JudgeBundle, req: CriticRequest) -> None:
+        """Populate ``bundle.kb_assess_by_proposal`` from the substrate KB.
+
+        For each proposal that carries usable optimisation levers, POST its
+        ``focus`` + levers to ``/v2/reasoning/assess`` and store the verdict
+        keyed by proposal ``msg_id``. Silently skipped when the assess client
+        is unconfigured, ``focus.model`` is unknown, or a call fails.
+
+        Args:
+            bundle (JudgeBundle): The bundle to enrich in place.
+            req (CriticRequest): The parsed request (for proposals).
+        """
+        client = self.kb_assess_client
+        if client is None or not req.proposals:
+            return
+        focus = self._assess_focus(bundle.merged_context)
+        if not focus.get("model"):
+            return
+        results: dict[str, dict[str, Any]] = {}
+        for p in req.proposals:
+            params, envs, args = _proposal_levers(p.payload)
+            if not params and not envs and not args:
+                continue
+            verdict = client.assess(focus=focus, params=params, envs=envs, args=args)
+            if verdict is None:
+                continue
+            results[p.msg_id] = verdict
+            self.session_memory.append_event(req.session_id, {
+                "kind": "kb_assess_lookup",
+                "msg_id": p.msg_id,
+                "reasonable": verdict.get("reasonable"),
+            })
+        if results:
+            bundle.kb_assess_by_proposal = results
+            bundle.notes.append(
+                f"kb_assess_injected count={len(results)}"
+            )
+
+    @staticmethod
+    def _assess_focus(merged_context: dict[str, Any]) -> dict[str, Any]:
+        """Map merged review context to the assess endpoint's ``focus``.
+
+        Args:
+            merged_context (dict[str, Any]): Session-merged review context.
+
+        Returns:
+            dict[str, Any]: A ``focus`` dict with non-empty known dimensions.
+        """
+        hardware = (
+            merged_context.get("hardware")
+            or merged_context.get("gpu_type")
+            or merged_context.get("scale")
+        )
+        candidate = {
+            "model": merged_context.get("model"),
+            "hardware": hardware,
+            "framework": merged_context.get("framework"),
+            "framework_version": merged_context.get("framework_version"),
+            "precision": merged_context.get("precision"),
+        }
+        return {
+            k: v for k, v in candidate.items()
+            if v not in (None, "", "unknown")
+        }
 
     # ------------------------------------------------------------------
     # L4 helper: pull recent HIGH-severity Robustness findings into the

--- a/critic-agent/runtime/kb_assess_client.py
+++ b/critic-agent/runtime/kb_assess_client.py
@@ -1,0 +1,131 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Optional client for the substrate KB ``/v2/reasoning/assess`` endpoint.
+
+The Critic can *associate* each proposal's raw optimisation levers (server
+args / env vars / params) to the knowledge substrate's calibrated mechanism
+evidence to judge whether the proposal is reasonable. This is strictly
+best-effort enrichment that reuses the **same** cortex KB endpoint the
+recipe-snapshot integration already points at — there is no separate Critic
+KB URL. It honours recipe-snapshot's "no URL = no network" contract:
+
+* ``CORTEX_KB_URL`` set (or explicit ``base_url``) → POST per proposal to
+  ``{CORTEX_KB_URL}/v2/reasoning/assess`` and fold the verdict into the bundle;
+* unset → :func:`from_env` returns ``None`` and the Critic never calls out.
+
+Config mirrors :mod:`inference_optimizer.recipe_kb.remote_client`:
+``CORTEX_KB_URL`` (URL), ``CORTEX_KB_HTTP_TIMEOUT_SEC`` (timeout),
+``KB_SERVICE_TOKEN`` (bearer).
+
+Uses ``urllib`` (no ``httpx``) so it installs in the minimal Codex container,
+consistent with :mod:`runtime.kb_client`. All failures are swallowed — the
+verdict is advisory, never a gate on the review.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+ASSESS_PATH = "/v2/reasoning/assess"
+DEFAULT_TIMEOUT_SEC = 3.0
+
+
+class KBAssessClient:
+    """Minimal sync POST client for ``/v2/reasoning/assess`` (best-effort)."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        token: str | None = None,
+        timeout_sec: float = DEFAULT_TIMEOUT_SEC,
+    ) -> None:
+        """Configure the transport.
+
+        Args:
+            base_url (str): KB service base URL; trailing slash is stripped.
+            token (str | None): Bearer token; falls back to ``KB_SERVICE_TOKEN``.
+            timeout_sec (float): Per-request timeout in seconds.
+
+        Raises:
+            ValueError: If ``base_url`` is empty.
+        """
+        if not base_url:
+            raise ValueError("KBAssessClient: base_url is required")
+        self.base_url = base_url.rstrip("/")
+        self.token = token or os.environ.get("KB_SERVICE_TOKEN") or ""
+        self.timeout_sec = float(timeout_sec)
+
+    @classmethod
+    def from_env(cls) -> "KBAssessClient | None":
+        """Build a client from env, or ``None`` when no cortex KB is configured.
+
+        Reuses recipe-snapshot's config: ``CORTEX_KB_URL`` (no default by
+        design — the Critic never silently connects to a remote KB) and
+        ``CORTEX_KB_HTTP_TIMEOUT_SEC`` for the per-request timeout.
+
+        Returns:
+            KBAssessClient | None: A client when ``CORTEX_KB_URL`` is set,
+            else ``None``.
+        """
+        url = (os.environ.get("CORTEX_KB_URL") or "").strip()
+        if not url:
+            return None
+        try:
+            timeout = float(
+                os.environ.get("CORTEX_KB_HTTP_TIMEOUT_SEC", str(DEFAULT_TIMEOUT_SEC))
+            )
+        except ValueError:
+            timeout = DEFAULT_TIMEOUT_SEC
+        return cls(url, timeout_sec=timeout)
+
+    def assess(
+        self,
+        *,
+        focus: dict[str, Any],
+        params: dict[str, Any] | None = None,
+        envs: dict[str, Any] | None = None,
+        args: str = "",
+    ) -> dict[str, Any] | None:
+        """POST one proposal to ``/v2/reasoning/assess``.
+
+        Args:
+            focus (dict[str, Any]): Subject of the proposal; at least
+                ``{"model": ...}``.
+            params (dict[str, Any] | None): Numeric/string levers.
+            envs (dict[str, Any] | None): Environment-variable levers.
+            args (str): CLI arg string.
+
+        Returns:
+            dict[str, Any] | None: The decoded assessment, or ``None`` on any
+            error (best-effort; never raises).
+        """
+        body: dict[str, Any] = {"focus": focus, "args": args or ""}
+        if params:
+            body["params"] = params
+        if envs:
+            body["envs"] = envs
+
+        url = f"{self.base_url}{ASSESS_PATH}"
+        data = json.dumps(body).encode("utf-8")
+        headers = {"Content-Type": "application/json", "Accept": "application/json"}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout_sec) as resp:
+                payload = resp.read().decode("utf-8") or "{}"
+                return json.loads(payload) if payload else {}
+        except (urllib.error.URLError, ValueError, OSError) as exc:
+            log.warning("critic: KB assess call failed (%s): %r", url, exc)
+            return None
+
+
+__all__ = ["KBAssessClient", "ASSESS_PATH", "DEFAULT_TIMEOUT_SEC"]

--- a/critic-agent/runtime/tests/test_decision_reviewer.py
+++ b/critic-agent/runtime/tests/test_decision_reviewer.py
@@ -542,3 +542,61 @@ def test_kb_assess_skips_proposal_without_levers(tmp_path):
     bundle = rev.prepare_review(_coordinator_request(_PROMPT_WITH_TWO_PROPOSALS, "sess_nolevers"))
     assert bundle.kb_assess_by_proposal == {}
     assert fake.calls == []
+
+
+# -----------------------------------------------------------------
+# KB trace audit fields (kb_assess_trace / kb_priors_trace)
+# -----------------------------------------------------------------
+def test_kb_assess_trace_not_configured(tmp_path, monkeypatch):
+    monkeypatch.delenv("CORTEX_KB_URL", raising=False)
+    sm = SessionMemory(root=tmp_path / "sm")
+    writer = KBWriter(InMemoryKBClient(), session_memory=sm)
+    rev = DecisionReviewer(session_memory=sm, kb_writer=writer)
+    bundle = rev.prepare_review(_coordinator_request(_PROMPT_WITH_LEVERS, "sess_t1"))
+    assert bundle.kb_assess_trace["configured"] is False
+    assert bundle.kb_assess_trace["skipped_reason"] == "not_configured"
+
+
+def test_kb_assess_trace_records_requests(tmp_path):
+    sm = SessionMemory(root=tmp_path / "sm")
+    writer = KBWriter(InMemoryKBClient(), session_memory=sm)
+    fake = _FakeAssess()
+    rev = DecisionReviewer(session_memory=sm, kb_writer=writer, kb_assess_client=fake)
+    bundle = rev.prepare_review(_coordinator_request(_PROMPT_WITH_LEVERS, "sess_t2"))
+    trace = bundle.kb_assess_trace
+    assert trace["configured"] is True
+    assert trace["skipped_reason"] is None
+    assert trace["focus"]["model"] == "Qwen3-14B"
+    assert trace["verdict_count"] == 1
+    req = trace["requests"][0]
+    assert req["msg_id"] == "lev1"
+    assert req["params_keys"] == ["kv_cache_dtype"]
+    assert req["responded"] is True
+    assert req["reasonable"] == "supported"
+
+
+def test_kb_priors_trace_records_scope_and_requests(tmp_path):
+    sm = SessionMemory(root=tmp_path / "sm")
+    kb = InMemoryKBClient()
+    kb.upsert({
+        "scope": {
+            "org": "hyperloom", "framework": "sglang", "model": "qwen3-14b",
+            "model_family": "qwen", "workload": "decode", "precision": "fp8",
+        },
+        "kind": "pitfall", "slug": "active-path-unproven-pitfall",
+        "importance": 0.5, "metadata": {"topic": "active path"},
+    })
+    writer = KBWriter(kb, session_memory=sm)
+    rev = DecisionReviewer(session_memory=sm, kb_writer=writer)
+    prompt = (
+        "=== Shared session state ===\n"
+        "model=qwen3-14b framework=sglang workload=decode precision=fp8\n"
+        "=== Inbox for critic ===\n"
+        "  seq=1 msg_id=aaa from=orchestration topic=proposal payload={'action_name': 'kernel_opt'}\n"
+    )
+    bundle = rev.prepare_review(_coordinator_request(prompt, "sess_pt"))
+    trace = bundle.kb_priors_trace
+    assert trace["configured"] is True
+    assert trace["mode"] == "per_proposal"
+    assert trace["scope_filter"].get("model") == "qwen3-14b"
+    assert any(r["msg_id"] == "aaa" for r in trace["requests"])

--- a/critic-agent/runtime/tests/test_decision_reviewer.py
+++ b/critic-agent/runtime/tests/test_decision_reviewer.py
@@ -469,3 +469,76 @@ def test_kb_priors_cache_hit_avoids_second_kb_call(reviewer):
     bundle = rev.prepare_review(_coordinator_request(prompt, "sess_cache_e2e"))
     # KB is now empty, but the bundle still has priors from the cache hit.
     assert bundle.kb_priors_by_proposal["aaa"]
+
+
+# -----------------------------------------------------------------
+# Optional substrate KB /v2/reasoning/assess enrichment
+# -----------------------------------------------------------------
+class _FakeAssess:
+    """Records assess() calls and returns a canned verdict."""
+
+    def __init__(self, verdict=None):
+        self.verdict = verdict if verdict is not None else {
+            "reasonable": "supported", "verdicts": [], "summary": {"confirmed": 1},
+        }
+        self.calls = []
+
+    def assess(self, *, focus, params=None, envs=None, args=""):
+        self.calls.append({"focus": focus, "params": params, "envs": envs, "args": args})
+        return self.verdict
+
+
+_PROMPT_WITH_LEVERS = (
+    "=== Shared session state ===\n"
+    "model=Qwen3-14B framework=sglang baseline_tput=1200\n"
+    "=== Inbox for critic ===\n"
+    "  seq=1 msg_id=lev1 from=orchestration topic=proposal payload="
+    "{'action_name': 'sweep', 'params': {'kv_cache_dtype': 'fp8', "
+    "'extra_envs': {'VLLM_USE_AITER': '1'}, 'extra_server_args': '--quantization fp8'}}\n"
+)
+
+
+def test_kb_assess_skipped_when_unconfigured(tmp_path, monkeypatch):
+    monkeypatch.delenv("CORTEX_KB_URL", raising=False)
+    sm = SessionMemory(root=tmp_path / "sm")
+    kb = InMemoryKBClient()
+    writer = KBWriter(kb, session_memory=sm)
+    rev = DecisionReviewer(session_memory=sm, kb_writer=writer)
+    # no CORTEX_KB_URL → no assess client built from env
+    assert rev.kb_assess_client is None
+    bundle = rev.prepare_review(_coordinator_request(_PROMPT_WITH_LEVERS, "sess_noassess"))
+    assert bundle.kb_assess_by_proposal == {}
+
+
+def test_kb_assess_injected_when_client_configured(tmp_path):
+    sm = SessionMemory(root=tmp_path / "sm")
+    kb = InMemoryKBClient()
+    writer = KBWriter(kb, session_memory=sm)
+    fake = _FakeAssess()
+    rev = DecisionReviewer(session_memory=sm, kb_writer=writer, kb_assess_client=fake)
+
+    bundle = rev.prepare_review(_coordinator_request(_PROMPT_WITH_LEVERS, "sess_assess"))
+
+    assert "lev1" in bundle.kb_assess_by_proposal
+    assert bundle.kb_assess_by_proposal["lev1"]["reasonable"] == "supported"
+    # focus mapped from merged context
+    call = fake.calls[0]
+    assert call["focus"]["model"] == "Qwen3-14B"
+    assert call["focus"]["framework"] == "sglang"
+    # levers split out of payload params
+    assert call["params"] == {"kv_cache_dtype": "fp8"}
+    assert call["envs"] == {"VLLM_USE_AITER": "1"}
+    assert call["args"] == "--quantization fp8"
+
+
+def test_kb_assess_skips_proposal_without_levers(tmp_path):
+    sm = SessionMemory(root=tmp_path / "sm")
+    kb = InMemoryKBClient()
+    writer = KBWriter(kb, session_memory=sm)
+    fake = _FakeAssess()
+    rev = DecisionReviewer(session_memory=sm, kb_writer=writer, kb_assess_client=fake)
+
+    # baseline proposal carries no params/envs/args → no assess call
+    bundle = rev.prepare_review(_coordinator_request(_PROMPT_WITH_TWO_PROPOSALS, "sess_nolevers"))
+    assert bundle.kb_assess_by_proposal == {}
+    assert fake.calls == []

--- a/critic-agent/runtime/tests/test_kb_assess_client.py
+++ b/critic-agent/runtime/tests/test_kb_assess_client.py
@@ -1,0 +1,78 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for the optional ``/v2/reasoning/assess`` client."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+from io import BytesIO
+
+import pytest
+
+from runtime.kb_assess_client import ASSESS_PATH, KBAssessClient
+
+
+def test_from_env_returns_none_when_unset(monkeypatch):
+    monkeypatch.delenv("CORTEX_KB_URL", raising=False)
+    assert KBAssessClient.from_env() is None
+
+
+def test_from_env_builds_client_when_url_set(monkeypatch):
+    monkeypatch.setenv("CORTEX_KB_URL", "http://kb.local/")
+    monkeypatch.setenv("CORTEX_KB_HTTP_TIMEOUT_SEC", "1.5")
+    client = KBAssessClient.from_env()
+    assert client is not None
+    assert client.base_url == "http://kb.local"  # trailing slash stripped
+    assert client.timeout_sec == 1.5
+
+
+def test_assess_posts_to_v2_reasoning_assess(monkeypatch):
+    captured = {}
+
+    class _Resp:
+        status = 200
+
+        def read(self):
+            return json.dumps({"reasonable": "supported", "verdicts": []}).encode()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def _fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["body"] = json.loads(req.data.decode())
+        captured["timeout"] = timeout
+        return _Resp()
+
+    monkeypatch.setattr("runtime.kb_assess_client.urllib.request.urlopen", _fake_urlopen)
+
+    client = KBAssessClient("http://kb.local", timeout_sec=2.0)
+    out = client.assess(
+        focus={"model": "Qwen3-14B"}, params={"kv_cache_dtype": "fp8"},
+        envs={"VLLM_USE_AITER": "1"}, args="--quantization fp8")
+
+    assert out == {"reasonable": "supported", "verdicts": []}
+    assert captured["url"] == f"http://kb.local{ASSESS_PATH}"
+    assert captured["body"]["focus"] == {"model": "Qwen3-14B"}
+    assert captured["body"]["params"] == {"kv_cache_dtype": "fp8"}
+    assert captured["body"]["envs"] == {"VLLM_USE_AITER": "1"}
+    assert captured["body"]["args"] == "--quantization fp8"
+    assert captured["timeout"] == 2.0
+
+
+def test_assess_swallows_errors_and_returns_none(monkeypatch):
+    def _boom(req, timeout=None):
+        raise urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr("runtime.kb_assess_client.urllib.request.urlopen", _boom)
+    client = KBAssessClient("http://kb.local")
+    assert client.assess(focus={"model": "m"}, params={"x": 1}) is None
+
+
+def test_empty_base_url_raises():
+    with pytest.raises(ValueError):
+        KBAssessClient("")

--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -4434,6 +4434,7 @@ def collect_kb_provenance(
         cortex_flusher_status_json as _flusher_status_path,
         cortex_pending_ndjson as _pending_path,
         pr_monitor_status_json as _pr_status_path,
+        recipe_snapshot_audit_jsonl as _recipe_audit_path,
     )
 
     # Surface the PR Monitor reachability snapshot via ``warnings`` so it's greppable.
@@ -4510,6 +4511,23 @@ def collect_kb_provenance(
         st = str(row.get("status") or "unknown")
         status_counts[st] = status_counts.get(st, 0) + 1
 
+    # Recipe-snapshot / gbrain remote read audit (RecipeKB.audit_hook ->
+    # recipe_snapshot/.audit.jsonl). Summarises whether the snapshot KB was
+    # actually consulted, which backend served it, and how each read resolved.
+    recipe_audit = _read_last_n_audit(_recipe_audit_path(session_dir), n=50)
+    recipe_by_resolution: dict[str, int] = {}
+    recipe_by_remote: dict[str, int] = {}
+    recipe_hits = 0
+    for row in recipe_audit:
+        recipe_by_resolution[str(row.get("resolution") or "unknown")] = (
+            recipe_by_resolution.get(str(row.get("resolution") or "unknown"), 0) + 1
+        )
+        recipe_by_remote[str(row.get("remote") or "unknown")] = (
+            recipe_by_remote.get(str(row.get("remote") or "unknown"), 0) + 1
+        )
+        if row.get("hit"):
+            recipe_hits += 1
+
     cortex_sid = (state.get("cortex_session_id") or "").strip()
     warm = state.get("warm_start_recipe") or {}
     pitfalls = state.get("warm_start_pitfalls") or []
@@ -4536,6 +4554,13 @@ def collect_kb_provenance(
         },
         "audit_tail_count":     len(audit_tail),
         "audit_status_counts":  status_counts,
+        "recipe_snapshot_reads": {
+            "count":         len(recipe_audit),
+            "hits":          recipe_hits,
+            "by_resolution": recipe_by_resolution,
+            "by_remote":     recipe_by_remote,
+            "tail":          recipe_audit[-10:],
+        },
         "flusher_status": _collect_flusher_status(
             session_dir,
             status_path=_flusher_status_path(session_dir),

--- a/inference_optimizer/breakdown/recorder/instrument.py
+++ b/inference_optimizer/breakdown/recorder/instrument.py
@@ -882,6 +882,8 @@ def record_critic_iteration(
     review: dict[str, Any] | None,
     emit: dict[str, Any] | None,
     workdir: Path | str | None,
+    kb_assess: dict[str, Any] | None = None,
+    kb_priors: dict[str, Any] | None = None,
     producer: str = "critic",
 ) -> None:
     """Record one ``critic_robustness.critic_iterations`` item.
@@ -889,6 +891,11 @@ def record_critic_iteration(
     Recorded per-iteration (idempotent on ``iter_n``) so the critic backend's
     workdir pruning never erases history; payload mirrors
     ``collectors.collect_critic_robustness``.
+
+    ``kb_assess`` / ``kb_priors`` (when provided) carry the per-iteration KB
+    integration trace: whether the substrate assess / historical priors were
+    used, the request, the response, and whether the final verdict referenced
+    them. Omitted from the payload when empty so historical items are unchanged.
     """
     if not session_dir:
         return
@@ -907,6 +914,10 @@ def record_critic_iteration(
             "emit_path":         _rel(wd / "emit.json", session_dir) if wd else None,
             "review_path":       _rel(wd / "review.json", session_dir) if wd else None,
         }
+        if isinstance(kb_assess, dict) and kb_assess:
+            payload["kb_assess"] = kb_assess
+        if isinstance(kb_priors, dict) and kb_priors:
+            payload["kb_priors"] = kb_priors
         _recorder(session_dir, producer).record_item(
             "critic_iterations", payload, key=str(iter_n),
         )

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -4028,6 +4028,7 @@ async def _run_optimize(args: argparse.Namespace) -> int:
         session_dir=session_dir,
         critic_agent_root=critic_agent_root,
         critic_kb_mode=critic_kb_mode,
+        cortex_kb_url=(getattr(args, "cortex_kb_url", None) or "").strip() or None,
         robustness_choice=robustness_choice,
         robustness_agent_root=robustness_agent_root,
         robustness_options=robustness_options,

--- a/inference_optimizer/cli_backends.py
+++ b/inference_optimizer/cli_backends.py
@@ -34,6 +34,7 @@ def _build_backends(
     session_dir: Path,
     critic_agent_root: Path | None = None,
     critic_kb_mode: str = "inmemory",
+    cortex_kb_url: str | None = None,
     robustness_choice: str = "mock",
     robustness_agent_root: Path | None = None,
     robustness_options: dict[str, Any] | None = None,
@@ -78,6 +79,7 @@ def _build_backends(
             session_dir=session_dir,
             codex_model=codex_model,
             kb_mode=critic_kb_mode,
+            cortex_kb_url=cortex_kb_url,
             action_verdict_policy=_policy,
         )
 

--- a/inference_optimizer/cli_kb.py
+++ b/inference_optimizer/cli_kb.py
@@ -43,6 +43,48 @@ def _resolve_local_kb_root(args: argparse.Namespace) -> Path:
     return _workspace_root_resolve() / "kb"
 
 
+def _attach_recipe_audit_hook(kb: Any, session_dir: Path | None) -> None:
+    """Wire ``RecipeKB.audit_hook`` to append remote-read trace events.
+
+    Each recipe-snapshot remote read (``get_recipe`` / ``search``) is appended
+    to ``recipe_snapshot/.audit.jsonl`` so the trace records whether the
+    snapshot KB (gbrain / cortex) was consulted, the request, and how it
+    resolved. Best-effort and never raises into the KB op. No-op without a
+    session dir or when the dispatcher predates ``audit_hook``.
+
+    Args:
+        kb (Any): The RecipeKB dispatcher (or a mirroring wrapper around it).
+        session_dir (Path | None): Session dir hosting the audit log.
+    """
+    if session_dir is None:
+        return
+    # Unwrap the inline gbrain-mirroring wrapper so the hook lands on the
+    # actual RecipeKB whose reads emit the audit events.
+    target = getattr(kb, "_inner", kb)
+    if not hasattr(target, "audit_hook"):
+        return
+
+    from datetime import datetime, timezone
+
+    from .session_paths import recipe_snapshot_audit_jsonl
+
+    audit_path = recipe_snapshot_audit_jsonl(Path(session_dir))
+
+    def _hook(event: dict[str, Any]) -> None:
+        try:
+            audit_path.parent.mkdir(parents=True, exist_ok=True)
+            row = {
+                "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                **event,
+            }
+            with audit_path.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(row, sort_keys=True) + "\n")
+        except Exception:  # noqa: BLE001 — audit must never break a KB op
+            log.debug("recipe_snapshot audit append failed", exc_info=True)
+
+    target.audit_hook = _hook
+
+
 def _build_recipe_kb_dispatcher(
     args: argparse.Namespace,
 ) -> Any:
@@ -143,6 +185,8 @@ def _bootstrap_cortex_kb(
     (fail_fast=False); a hard T0 failure warns and continues warm-start-empty.
     """
     kb = _build_recipe_kb_dispatcher(args)
+    # Trace every recipe-snapshot remote read into the session audit log.
+    _attach_recipe_audit_hook(kb, session_dir)
 
     state = SharedState.load_or_init(session_dir)
     workload = (

--- a/inference_optimizer/orchestrator/backends/critic_agent.py
+++ b/inference_optimizer/orchestrator/backends/critic_agent.py
@@ -236,6 +236,26 @@ def _proposal_scope_literal(proposal: dict[str, Any]) -> str:
     return ""
 
 
+def _verdict_references_kb(review: dict[str, Any] | None) -> bool:
+    """Whether any final review verdict cites KB evidence.
+
+    Scans ``review_verdicts[].kb_evidence`` for a truthy reference. Used by the
+    KB trace to record whether the decision actually leaned on KB data.
+
+    Args:
+        review (dict[str, Any] | None): The parsed review object.
+
+    Returns:
+        bool: ``True`` if at least one verdict references KB evidence.
+    """
+    if not isinstance(review, dict):
+        return False
+    for v in review.get("review_verdicts") or []:
+        if isinstance(v, dict) and v.get("kb_evidence"):
+            return True
+    return False
+
+
 def _maybe_inject_cross_domain_constraints(judge_bundle: dict[str, Any]) -> None:
     """Set ``review_constraints.cross_domain`` + rule descriptors when any
     proposal is cross-domain (unified ``scope == 'domains'`` dial). Idempotent."""
@@ -318,6 +338,11 @@ class CriticAgentBackend:
     # Per-action verdict policy (action_name -> archival/exploration/promotion)
     # enriched onto ``review_constraints.action_verdict_policy`` post prepare-review.
     action_verdict_policy: dict[str, str] = field(default_factory=dict)
+    # Substrate KB assess injection switch. ``None`` reads the
+    # ``CORTEX_KB_ASSESS_INJECT`` env at turn time (default OFF = dry-run: the
+    # assess verdicts are still fetched + traced, but withheld from the LLM
+    # prompt so they don't steer the decision). ``True``/``False`` force it.
+    kb_assess_inject: bool | None = None
     name: str = "critic-agent"
     # #170 — optional web tools (web_search / web_fetch). ``web_tools_config``
     # None reads from env; ``web_tool_clients_factory`` injects test clients.
@@ -653,11 +678,20 @@ class CriticAgentBackend:
             (i.payload.get("verdict"), i.payload.get("source"))
             for i in intents if i.type.value == "review_verdict"
         ]
+        assess_injected = self._kb_assess_inject_enabled()
+        kb_assess_trace = self._build_kb_assess_trace(
+            judge_bundle, review, injected=assess_injected,
+        )
+        kb_priors_trace = self._build_kb_priors_trace(judge_bundle, review)
         log.info(
             "critic_agent_backend turn=%d session=%s proposals=%d "
-            "verdicts=%s kb_skipped=%s required_context=%s finish=%s",
+            "verdicts=%s kb_skipped=%s required_context=%s finish=%s "
+            "kb_assess_mode=%s kb_assess_verdicts=%d kb_priors=%d",
             turn_idx, session_id, len(proposals),
             verdicts_summary, kb_skipped, required_context, llm_finish,
+            kb_assess_trace.get("mode") or "n/a",
+            kb_assess_trace.get("verdict_count") or 0,
+            kb_priors_trace.get("prior_count") or 0,
         )
         self.calls.append({
             "turn_idx": turn_idx,
@@ -667,6 +701,9 @@ class CriticAgentBackend:
             "required_context": required_context,
             "finish_reason": llm_finish,
             "workdir": str(workdir),
+            "kb_assess_mode": kb_assess_trace.get("mode"),
+            "kb_assess_verdicts": kb_assess_trace.get("verdict_count") or 0,
+            "kb_priors_count": kb_priors_trace.get("prior_count") or 0,
         })
 
         # Author-time breakdown capture: record this critic iteration before the
@@ -679,9 +716,19 @@ class CriticAgentBackend:
                 review=review,
                 emit=emit,
                 workdir=workdir,
+                kb_assess=kb_assess_trace,
+                kb_priors=kb_priors_trace,
             )
         except Exception:  # noqa: BLE001
             pass
+
+        # Second sink: mirror the KB integration trace into Langfuse (opt-in,
+        # best-effort) so it lands on the same trace as the critic generations.
+        self._mirror_kb_trace_to_langfuse(
+            turn_idx=turn_idx,
+            kb_assess=kb_assess_trace,
+            kb_priors=kb_priors_trace,
+        )
 
         return BackendTurnResult(
             intents=intents,
@@ -852,6 +899,156 @@ class CriticAgentBackend:
                 )
         return env
 
+    def _mirror_kb_trace_to_langfuse(
+        self,
+        *,
+        turn_idx: int,
+        kb_assess: dict[str, Any],
+        kb_priors: dict[str, Any],
+    ) -> None:
+        """Mirror the per-iteration KB trace into Langfuse (best-effort).
+
+        Emits one span per non-empty trace under the ``critic`` agent so the
+        "was KB used / request / response / influenced decision" evidence is
+        visible alongside the critic generations. No-op when Langfuse is
+        disabled; never raises into the review path.
+
+        Args:
+            turn_idx (int): The critic iteration index.
+            kb_assess (dict[str, Any]): The assess trace (may be empty).
+            kb_priors (dict[str, Any]): The priors trace (may be empty).
+        """
+        try:
+            from ..trace.langfuse_emitter import get_emitter
+            emitter = get_emitter(self.session_dir)
+            if not emitter.enabled:
+                return
+            if kb_assess:
+                emitter.record_kb_span(
+                    name=f"kb_assess:iter_{turn_idx}",
+                    agent="critic",
+                    output=kb_assess,
+                    metadata={
+                        "kind": "kb_assess",
+                        "iter": turn_idx,
+                        "mode": kb_assess.get("mode"),
+                        "verdict_count": kb_assess.get("verdict_count") or 0,
+                        "referenced_in_verdict": bool(
+                            kb_assess.get("referenced_in_verdict")
+                        ),
+                    },
+                )
+            if kb_priors:
+                emitter.record_kb_span(
+                    name=f"kb_priors:iter_{turn_idx}",
+                    agent="critic",
+                    output=kb_priors,
+                    metadata={
+                        "kind": "kb_priors",
+                        "iter": turn_idx,
+                        "prior_count": kb_priors.get("prior_count") or 0,
+                        "referenced_in_verdict": bool(
+                            kb_priors.get("referenced_in_verdict")
+                        ),
+                    },
+                )
+        except Exception:  # noqa: BLE001 — trace must never break the review
+            log.debug("critic_agent: langfuse kb mirror failed", exc_info=True)
+
+    def _kb_assess_inject_enabled(self) -> bool:
+        """Whether substrate assess verdicts are fed to the LLM this turn.
+
+        ``kb_assess_inject`` (when not ``None``) forces the mode; otherwise the
+        ``CORTEX_KB_ASSESS_INJECT`` env decides, defaulting to OFF (dry-run).
+
+        Returns:
+            bool: ``True`` to inject the verdicts into the prompt.
+        """
+        if self.kb_assess_inject is not None:
+            return bool(self.kb_assess_inject)
+        return os.environ.get(
+            "CORTEX_KB_ASSESS_INJECT", "",
+        ).strip().lower() in ("1", "true", "yes", "on")
+
+    @staticmethod
+    def _build_kb_assess_trace(
+        judge_bundle: dict[str, Any],
+        review: dict[str, Any] | None,
+        *,
+        injected: bool,
+    ) -> dict[str, Any]:
+        """Assemble the substrate-assess KB trace for one critic iteration.
+
+        Folds the runtime-captured ``kb_assess_trace`` (configured? skip reason?
+        focus? per-proposal requests) with the resolved verdict count, whether
+        the verdicts were injected into the prompt this turn (vs dry-run), and
+        whether the final verdict referenced KB evidence.
+
+        Args:
+            judge_bundle (dict[str, Any]): The prepared judge bundle.
+            review (dict[str, Any] | None): The parsed review object.
+            injected (bool): Whether the verdicts were fed to the LLM.
+
+        Returns:
+            dict[str, Any]: The assess trace (empty when nothing was captured).
+        """
+        trace = dict(judge_bundle.get("kb_assess_trace") or {})
+        verdicts = judge_bundle.get("kb_assess_by_proposal") or {}
+        if not trace and not verdicts:
+            return {}
+        return {
+            "configured": bool(trace.get("configured")),
+            "skipped_reason": trace.get("skipped_reason"),
+            "focus": trace.get("focus") or {},
+            "requests": trace.get("requests") or [],
+            "verdict_count": len(verdicts),
+            "injected": bool(injected),
+            "mode": "injected" if injected else "dry_run",
+            "referenced_in_verdict": (
+                _verdict_references_kb(review) if injected else False
+            ),
+        }
+
+    @staticmethod
+    def _build_kb_priors_trace(
+        judge_bundle: dict[str, Any],
+        review: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        """Assemble the historical-priors KB trace for one critic iteration.
+
+        Folds the runtime-captured ``kb_priors_trace`` (scope/limit/per-request
+        cache+count) with the total prior count, the skip reason (if any), and
+        whether the final verdict referenced KB evidence. Priors are always
+        injected, so ``referenced_in_verdict`` is unconditional here.
+
+        Args:
+            judge_bundle (dict[str, Any]): The prepared judge bundle.
+            review (dict[str, Any] | None): The parsed review object.
+
+        Returns:
+            dict[str, Any]: The priors trace (empty when nothing was captured).
+        """
+        trace = dict(judge_bundle.get("kb_priors_trace") or {})
+        by_proposal = judge_bundle.get("kb_priors_by_proposal") or {}
+        for_decision = judge_bundle.get("kb_priors_for_decision") or []
+        skipped = judge_bundle.get("kb_read_skipped_reason")
+        if not trace and not by_proposal and not for_decision and not skipped:
+            return {}
+        total = sum(
+            len(v) for v in by_proposal.values() if isinstance(v, list)
+        ) + len(for_decision)
+        return {
+            "configured": bool(trace.get("configured")),
+            "mode": trace.get("mode"),
+            "client_mode": trace.get("client_mode"),
+            "scope_filter": trace.get("scope_filter") or {},
+            "limit": trace.get("limit"),
+            "requests": trace.get("requests") or [],
+            "skipped_reason": skipped,
+            "prior_count": total,
+            "referenced_in_verdict": _verdict_references_kb(review),
+        }
+
     async def _reason(
         self,
         *,
@@ -875,25 +1072,29 @@ class CriticAgentBackend:
             raw model text, and the final finish reason.
         """
         preamble = self._load_skill_preamble()
-        bundle_text = json.dumps(
-            {
-                "kind": judge_bundle.get("kind"),
-                "session_id": judge_bundle.get("session_id"),
-                "decision_id": judge_bundle.get("decision_id"),
-                "merged_context": judge_bundle.get("merged_context"),
-                "missing_context": judge_bundle.get("missing_context"),
-                "required_context": judge_bundle.get("required_context"),
-                "proposals": judge_bundle.get("proposals"),
-                "kb_priors_by_proposal": judge_bundle.get("kb_priors_by_proposal"),
-                "kb_priors_for_decision": judge_bundle.get("kb_priors_for_decision"),
-                "kb_assess_by_proposal": judge_bundle.get("kb_assess_by_proposal"),
-                "kb_read_skipped_reason": judge_bundle.get("kb_read_skipped_reason"),
-                "review_constraints": judge_bundle.get("review_constraints"),
-                "notes": judge_bundle.get("notes"),
-            },
-            ensure_ascii=False,
-            indent=2,
-        )
+        bundle_view: dict[str, Any] = {
+            "kind": judge_bundle.get("kind"),
+            "session_id": judge_bundle.get("session_id"),
+            "decision_id": judge_bundle.get("decision_id"),
+            "merged_context": judge_bundle.get("merged_context"),
+            "missing_context": judge_bundle.get("missing_context"),
+            "required_context": judge_bundle.get("required_context"),
+            "proposals": judge_bundle.get("proposals"),
+            "kb_priors_by_proposal": judge_bundle.get("kb_priors_by_proposal"),
+            "kb_priors_for_decision": judge_bundle.get("kb_priors_for_decision"),
+            "kb_read_skipped_reason": judge_bundle.get("kb_read_skipped_reason"),
+            "review_constraints": judge_bundle.get("review_constraints"),
+            "notes": judge_bundle.get("notes"),
+        }
+        # Dry-run gate: only feed the substrate assess verdicts to the LLM when
+        # injection is explicitly enabled. When OFF the verdicts are still
+        # fetched + traced (see _build_kb_assess_trace) but kept out of the
+        # prompt so they cannot steer the decision.
+        if self._kb_assess_inject_enabled():
+            bundle_view["kb_assess_by_proposal"] = judge_bundle.get(
+                "kb_assess_by_proposal"
+            )
+        bundle_text = json.dumps(bundle_view, ensure_ascii=False, indent=2)
         user_prompt = (
             f"{preamble}\n\n"
             f"==== JUDGE BUNDLE ====\n{bundle_text}\n==== END JUDGE BUNDLE ====\n\n"

--- a/inference_optimizer/orchestrator/backends/critic_agent.py
+++ b/inference_optimizer/orchestrator/backends/critic_agent.py
@@ -288,6 +288,12 @@ class CriticAgentBackend:
         Extra env vars merged into the runtime.cli subprocess env when
         ``kb_mode == "live"``. Caller is responsible for filling
         ``KB_BASE_URL`` / ``KB_TIMEOUT_MS`` / ``KB_DEAD_LETTER_DIR`` etc.
+    cortex_kb_url:
+        Optional cortex kb-service base URL (the ``--cortex-kb-url`` flag).
+        When set, it is exported as ``CORTEX_KB_URL`` into the runtime.cli
+        subprocess env (unless already present) so the critic runtime's
+        optional ``/v2/reasoning/assess`` enrichment can reach the same KB
+        recipe-snapshot uses. ``None`` leaves env-based config untouched.
     runtime_caller_factory:
         Test seam returning a :data:`RuntimeCaller`. Tests override this
         to bypass the real Python subprocess.
@@ -305,6 +311,7 @@ class CriticAgentBackend:
     codex_client_factory: Callable[[], Any] | None = None
     kb_mode: Literal["inmemory", "live"] = "inmemory"
     kb_env: dict[str, str] | None = None
+    cortex_kb_url: str | None = None
     runtime_caller_factory: Callable[[], RuntimeCaller] | None = None
     static_context: dict[str, Any] | None = None
     known_actions: tuple[str, ...] = ()
@@ -814,6 +821,13 @@ class CriticAgentBackend:
         dlq_dir = self.session_dir / "critic-kb-dead-letter"
         env.setdefault("KB_DEAD_LETTER_DIR", str(dlq_dir))
 
+        # Propagate the --cortex-kb-url flag into the subprocess so the critic
+        # runtime's optional /v2/reasoning/assess enrichment can reach the same
+        # cortex KB recipe-snapshot uses. An explicit env var still wins.
+        cortex_kb_url = (self.cortex_kb_url or "").strip()
+        if cortex_kb_url and not env.get("CORTEX_KB_URL"):
+            env["CORTEX_KB_URL"] = cortex_kb_url
+
         if self.kb_mode == "live":
             for k, v in (self.kb_env or {}).items():
                 env[k] = v
@@ -858,6 +872,7 @@ class CriticAgentBackend:
                 "proposals": judge_bundle.get("proposals"),
                 "kb_priors_by_proposal": judge_bundle.get("kb_priors_by_proposal"),
                 "kb_priors_for_decision": judge_bundle.get("kb_priors_for_decision"),
+                "kb_assess_by_proposal": judge_bundle.get("kb_assess_by_proposal"),
                 "kb_read_skipped_reason": judge_bundle.get("kb_read_skipped_reason"),
                 "review_constraints": judge_bundle.get("review_constraints"),
                 "notes": judge_bundle.get("notes"),

--- a/inference_optimizer/orchestrator/trace/langfuse_emitter.py
+++ b/inference_optimizer/orchestrator/trace/langfuse_emitter.py
@@ -37,6 +37,7 @@ from typing import Any
 
 from ...session_paths import (
     decision_trace_path,
+    recipe_snapshot_audit_jsonl,
     trace_dir,
     trace_ext_dir,
 )
@@ -341,6 +342,8 @@ class LangfuseEmitter:
             "spans_opened": 0,          # phase + agent spans created
             "ext_shards_read": 0,       # out-of-process ext/*.jsonl files swept
             "breakdown_recorded": 0,    # 1 once the full SBD JSON was attached
+            "kb_spans_sent": 0,         # KB trace spans (assess/priors/recipe)
+            "recipe_audit_read": 0,     # recipe_snapshot/.audit.jsonl rows swept
             "errors": 0,                # swallowed send failures
         }
         self._flushed = False
@@ -500,6 +503,54 @@ class LangfuseEmitter:
                 conv_row=emit_parts.get("conv"),
             )
 
+    def record_kb_span(
+        self,
+        *,
+        name: str,
+        agent: str,
+        output: Any,
+        phase: str = lfmap.UNPHASED,
+        metadata: dict[str, Any] | None = None,
+        ts: str | None = None,
+    ) -> None:
+        """Emit one non-LLM KB trace as a span nested under its agent span.
+
+        Used for the KB integration trace (substrate ``kb_assess`` /
+        historical ``kb_priors`` per critic iteration, and recipe-snapshot /
+        gbrain remote reads) so the "was KB used, what did we ask, what came
+        back, did it influence the decision" evidence lands on the same trace
+        as the LLM generations. The full trace dict goes in ``output``; a small
+        scalar summary goes in ``metadata`` for filtering. Best-effort and a
+        no-op unless live push is enabled.
+
+        Args:
+            name (str): Span name (e.g. ``"kb_assess:iter_3"``).
+            agent (str): Owning agent (``"critic"`` / ``"recipe_kb"``).
+            output (Any): The trace payload attached as the span output.
+            phase (str): Phase bucket; defaults to ``(unphased)``.
+            metadata (dict[str, Any] | None): Scalar summary for filtering.
+            ts (str | None): ISO timestamp for span start, if known.
+        """
+        if not self._enabled:
+            return
+        try:
+            start = lfmap.parse_ts(ts)
+            parent = self._ensure_agent_span(phase, agent, start)
+            obs = _start_obs(
+                parent,
+                name=name,
+                as_type="span",
+                start_time=start,
+                input=None,
+                output=output,
+                metadata=metadata or {},
+            )
+            _end_obs(obs, start)
+            self._counts["kb_spans_sent"] += 1
+        except Exception:  # noqa: BLE001 — trace must never break the loop
+            self._counts["errors"] += 1
+            log.debug("langfuse: record_kb_span failed", exc_info=True)
+
     def _emit_generation(
         self,
         *,
@@ -561,6 +612,7 @@ class LangfuseEmitter:
         try:
             self._flush_pending_halves()
             self._flush_ext_shards()
+            self._flush_recipe_kb_audit()
             self._flush_decision_scores()
             self._close_spans()
         except Exception:  # noqa: BLE001
@@ -678,6 +730,35 @@ class LangfuseEmitter:
             self._counts["ext_shards_read"] += 1
             for row in _load_jsonl(shard):
                 self._emit_generation(token_row=row, conv_row=None)
+
+    def _flush_recipe_kb_audit(self) -> None:
+        """Backfill recipe-snapshot / gbrain remote reads from the audit log.
+
+        The recipe KB dispatcher appends one row per remote read to
+        ``runtime/recipe_snapshot/.audit.jsonl`` (it has no Langfuse handle, by
+        design). Each row becomes a ``kb:recipe_snapshot:<method>`` span under
+        the ``recipe_kb`` agent so the trace shows which backend served the
+        warm-start recipe, the request, and how it resolved. Read out-of-band
+        at session end (mirrors :meth:`_flush_ext_shards`); idempotent via the
+        ``flush_session`` guard.
+        """
+        rows = _load_jsonl(recipe_snapshot_audit_jsonl(self.session_dir))
+        for row in rows:
+            self._counts["recipe_audit_read"] += 1
+            method = str(row.get("method") or "read")
+            self.record_kb_span(
+                name=f"kb:recipe_snapshot:{method}",
+                agent="recipe_kb",
+                output=row,
+                metadata={
+                    "kind": "recipe_snapshot",
+                    "method": method,
+                    "remote": row.get("remote"),
+                    "resolution": row.get("resolution"),
+                    "hit": bool(row.get("hit")),
+                },
+                ts=row.get("ts"),
+            )
 
     def _flush_decision_scores(self) -> None:
         """Convert each decision_trace row into Langfuse Score(s).

--- a/inference_optimizer/recipe_kb/dispatcher.py
+++ b/inference_optimizer/recipe_kb/dispatcher.py
@@ -77,6 +77,15 @@ from .remote_client import RemoteRecipeClient, RemoteRecipeClientError
 
 log = logging.getLogger(__name__)
 
+# Short, stable labels for the configured remote backend keyed by client class
+# name (used by :meth:`RecipeKB._remote_label` for logs/audit trace). Unknown
+# backends fall back to their class name.
+_REMOTE_LABELS: dict[str, str] = {
+    "RemoteRecipeClient": "cortex",
+    "GbrainRemoteRecipeClient": "gbrain",
+    "CompositeRemoteRecipeClient": "composite",
+}
+
 
 def _labels_from_canonical_id(canonical_id: str) -> dict[str, str]:
     """Decode a canonical_id into the 5-key ``label_match`` dict the
@@ -317,11 +326,18 @@ class RecipeKB:
             Defaults to ``log.warning`` so audit-collector hooks
             can wire a structured event in without a
             dispatcher-internal change.
+        audit_hook: Optional callback invoked (best-effort, never
+            raising into the caller) after every read/write with a
+            structured event dict describing whether the remote was
+            used, the request, and the resolution. Defaults to
+            ``None`` (no audit). Wired by the CLI to append a
+            ``recipe_snapshot/.audit.jsonl`` trace.
     """
 
     local: LocalRecipeStore
     remote: RemoteRecipeClient | None = None
     on_remote_failure: Any = None
+    audit_hook: Any = None
 
     # ------------------------------------------------------------------
     # Capability flags
@@ -375,6 +391,91 @@ class RecipeKB:
         through untouched rather than being silently emptied.
         """
         return _v2_to_arbor(row)
+
+    def _remote_label(self) -> str:
+        """A short, stable label for the configured remote backend.
+
+        Returns:
+            str: ``"none"`` when no remote, else ``"cortex"`` /
+                ``"gbrain"`` / ``"composite"`` (falling back to the
+                client class name for any future backend).
+        """
+        if self.remote is None:
+            return "none"
+        return _REMOTE_LABELS.get(
+            type(self.remote).__name__, type(self.remote).__name__,
+        )
+
+    def _emit_audit(self, event: dict[str, Any]) -> None:
+        """Best-effort emit one audit event to ``audit_hook`` (never raises).
+
+        Args:
+            event (dict[str, Any]): The structured audit record.
+        """
+        hook = self.audit_hook
+        if not callable(hook):
+            return
+        try:
+            hook(event)
+        except Exception:  # noqa: BLE001 - audit must never break a KB op
+            log.debug("recipe_kb: audit_hook raised", exc_info=True)
+
+    def _read_audit_event(
+        self,
+        *,
+        method: str,
+        resolution: str,
+        row: dict[str, Any] | None,
+        canonical_id: str = "",
+        prefer: dict[str, Any] | None = None,
+        label_match: dict[str, Any] | None = None,
+        candidates: int = 0,
+    ) -> dict[str, Any]:
+        """Build a structured audit record for one recipe-snapshot read.
+
+        Captures whether the remote was consulted and which backend served
+        the row (``remote``), the request (``canonical_id`` / ``prefer`` /
+        ``label_match``), how it resolved (``remote`` / ``remote_miss`` /
+        ``remote_error`` / ``local``), and a compact view of the returned row
+        so the trace answers "was the recipe-snapshot used, what did we ask,
+        and what came back" without storing the full payload.
+
+        Args:
+            method (str): The read method (``get_recipe`` / ``search``).
+            resolution (str): How the read resolved.
+            row (dict[str, Any] | None): The resolved row (or first row).
+            canonical_id (str): Requested canonical id (``get_recipe``).
+            prefer (dict[str, Any] | None): Rerank hints, if any.
+            label_match (dict[str, Any] | None): Search filter, if any.
+            candidates (int): Number of remote candidate rows considered.
+
+        Returns:
+            dict[str, Any]: The audit event (no timestamp; the hook stamps it).
+        """
+        result: dict[str, Any] | None = None
+        if isinstance(row, dict):
+            result = {
+                "canonical_id": str(row.get("canonical_id") or ""),
+                "exact": bool(
+                    canonical_id
+                    and str(row.get("canonical_id") or "") == canonical_id
+                ),
+                "best_throughput": float(row.get("best_throughput") or 0.0),
+                "best_config_nonempty": bool(row.get("best_config")),
+            }
+        return {
+            "method": method,
+            "remote": self._remote_label(),
+            "resolution": resolution,
+            "hit": row is not None,
+            "candidates": int(candidates),
+            "request": {
+                "canonical_id": canonical_id or None,
+                "prefer_keys": sorted((prefer or {}).keys()),
+                "label_match": label_match or None,
+            },
+            "result": result,
+        }
 
     def _note_failure(self, method: str, exc: Exception) -> None:
         """Report a remote read failure before local fall-through.
@@ -595,6 +696,7 @@ class RecipeKB:
             dict[str, Any] | None: The recipe row in arbor shape, or
                 ``None`` when neither store has the row.
         """
+        resolution = "local"
         if version is None and self._remote_active():
             try:
                 labels = _labels_from_canonical_id(canonical_id)
@@ -608,17 +710,30 @@ class RecipeKB:
                 if rows:
                     normalized = [self._normalize_remote_row(r) for r in rows]
                     ranked = _rerank_by_prefer(normalized, prefer)
+                    self._emit_audit(self._read_audit_event(
+                        method="get_recipe", resolution="remote",
+                        row=ranked[0], canonical_id=canonical_id,
+                        prefer=prefer, candidates=len(rows),
+                    ))
                     return ranked[0]
                 # remote miss — fall through to local.
+                resolution = "remote_miss"
             except RemoteRecipeClientError as exc:
                 self._note_failure("get_recipe", exc)
+                resolution = "remote_error"
             except InvalidCanonicalIdError as exc:
                 # Can't build label_match from a malformed cid; the
                 # local store applies the same parse, so just degrade.
                 log.warning("get_recipe: %s; local-only read", exc)
-        return self.local.get_recipe(
+                resolution = "remote_error"
+        local_row = self.local.get_recipe(
             canonical_id=canonical_id, version=version,
         )
+        self._emit_audit(self._read_audit_event(
+            method="get_recipe", resolution=resolution, row=local_row,
+            canonical_id=canonical_id, prefer=prefer,
+        ))
+        return local_row
 
     def get_history(
         self,
@@ -688,6 +803,7 @@ class RecipeKB:
         ``prefer`` only reorders; the ``required`` filter
         (``label_match`` / ``metric_filters``) decides membership.
         """
+        resolution = "local"
         if self._remote_active():
             try:
                 rows = self.remote.search(  # type: ignore[union-attr]
@@ -705,9 +821,18 @@ class RecipeKB:
                 # hasn't received our local writes yet.
                 if rows:
                     normalized = [self._normalize_remote_row(r) for r in rows]
-                    return _rerank_by_prefer(normalized, prefer)
+                    ranked = _rerank_by_prefer(normalized, prefer)
+                    self._emit_audit(self._read_audit_event(
+                        method="search", resolution="remote",
+                        row=ranked[0] if ranked else None,
+                        label_match=label_match, prefer=prefer,
+                        candidates=len(rows),
+                    ))
+                    return ranked
+                resolution = "remote_miss"
             except RemoteRecipeClientError as exc:
                 self._note_failure("search", exc)
+                resolution = "remote_error"
         local_rows = self.local.search(
             label_match=label_match,
             metric_filters=metric_filters,
@@ -715,7 +840,13 @@ class RecipeKB:
             order_by=order_by,
             limit=limit,
         )
-        return _rerank_by_prefer(local_rows, prefer)
+        ranked_local = _rerank_by_prefer(local_rows, prefer)
+        self._emit_audit(self._read_audit_event(
+            method="search", resolution=resolution,
+            row=ranked_local[0] if ranked_local else None,
+            label_match=label_match, prefer=prefer,
+        ))
+        return ranked_local
 
     def list_attempts(
         self,

--- a/inference_optimizer/scripts/backfill_langfuse.py
+++ b/inference_optimizer/scripts/backfill_langfuse.py
@@ -77,6 +77,7 @@ from inference_optimizer.orchestrator.trace.langfuse_emitter import (
     _set_trace_attrs,
     _start_obs,
 )
+from inference_optimizer.session_paths import recipe_snapshot_audit_jsonl
 
 log = logging.getLogger("backfill_langfuse")
 
@@ -146,6 +147,7 @@ def build_plan(session_dir: Path) -> dict[str, Any]:
     llm = _load_jsonl(tdir / LLM_CALLS)
     conv = _load_jsonl(tdir / CONVERSATIONS)
     decisions = _load_jsonl(tdir / DECISION_TRACE)
+    recipe_audit = _load_jsonl(recipe_snapshot_audit_jsonl(session_dir))
     manifest = _load_json(session_dir / MANIFEST)
 
     conv_by_key: dict[tuple, dict[str, Any]] = {}
@@ -192,12 +194,14 @@ def build_plan(session_dir: Path) -> dict[str, Any]:
         "created_at": manifest.get("created_at_utc"),
         "phases": phases,
         "decisions": decisions,
+        "recipe_audit": recipe_audit,
         "stats": {
             "llm_calls": len(llm),
             "conversations": len(conv),
             "decisions": len(decisions),
             "generations_with_text": paired,
             "phase_count": len(phases),
+            "recipe_audit": len(recipe_audit),
         },
     }
 
@@ -276,6 +280,8 @@ def print_plan(plan: dict[str, Any]) -> None:
     )
     print(f"  Scores: {len(plan['decisions'])} decisions "
           f"(KEEP={keep} REVERT={rev} no_promote={nop}; gain_pct set={gainful})")
+    print(f"  Recipe-snapshot reads: {len(plan.get('recipe_audit') or [])} "
+          f"audit row(s)")
 
 
 # ---------------------------------------------------------------------------
@@ -365,6 +371,33 @@ def ingest(plan: dict[str, Any]) -> int:
         _end_obs(phase_span, p_hi or p_lo or trace_start)
         if p_hi is not None:
             last_end = p_hi
+
+    # Recipe-snapshot / gbrain remote reads -> spans under a recipe_kb agent.
+    recipe_audit = plan.get("recipe_audit") or []
+    if recipe_audit:
+        ra_times = [lfmap.parse_ts(r.get("ts")) for r in recipe_audit]
+        ra_times = [t for t in ra_times if t is not None]
+        ra_lo = min(ra_times) if ra_times else last_end
+        ra_span = _start_obs(
+            root,
+            name=f"agent:recipe_kb", as_type="span", start_time=ra_lo or trace_start,
+            metadata={"phase": UNPHASED, "agent": "recipe_kb",
+                      "read_count": len(recipe_audit)},
+        )
+        for r in recipe_audit:
+            r_start = lfmap.parse_ts(r.get("ts"))
+            method = str(r.get("method") or "read")
+            obs = _start_obs(
+                ra_span,
+                name=f"kb:recipe_snapshot:{method}", as_type="span",
+                start_time=r_start, input=None, output=r,
+                metadata={"kind": "recipe_snapshot", "method": method,
+                          "remote": r.get("remote"),
+                          "resolution": r.get("resolution"),
+                          "hit": bool(r.get("hit"))},
+            )
+            _end_obs(obs, r_start)
+        _end_obs(ra_span, (max(ra_times) if ra_times else None) or trace_start)
 
     # Decision scores -> the owning agent span (trace-level fallback).
     for i, drow in enumerate(plan["decisions"]):

--- a/inference_optimizer/tests/test_backfill_langfuse_unit.py
+++ b/inference_optimizer/tests/test_backfill_langfuse_unit.py
@@ -1,0 +1,74 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit coverage for the offline Langfuse backfill plan builder.
+
+Focuses on the recipe-snapshot / gbrain audit folding (the live emitter's
+``_flush_recipe_kb_audit`` counterpart): a finished session's
+``runtime/recipe_snapshot/.audit.jsonl`` must surface in the backfill plan so
+a recovery replay re-creates the KB read spans on the same trace.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from inference_optimizer.scripts import backfill_langfuse as bf
+from inference_optimizer.session_paths import recipe_snapshot_audit_jsonl
+
+
+def _seed(session_dir: Path) -> None:
+    tdir = session_dir / "reports" / "trace"
+    tdir.mkdir(parents=True, exist_ok=True)
+    (tdir / "llm_calls.jsonl").write_text(
+        json.dumps({
+            "session_id": "SID", "component": "critic", "role": "critic",
+            "model": "gpt-5.4", "ts": "2026-06-09T15:14:54Z",
+            "input_tokens": 10, "output_tokens": 5,
+        }) + "\n",
+        encoding="utf-8",
+    )
+    (session_dir / "manifest.json").write_text(
+        json.dumps({"session_id": "SID", "model_name": "M"}), encoding="utf-8",
+    )
+
+
+def test_build_plan_includes_recipe_audit(tmp_path):
+    sd = tmp_path / "SID"
+    _seed(sd)
+    audit = recipe_snapshot_audit_jsonl(sd)
+    audit.parent.mkdir(parents=True, exist_ok=True)
+    audit.write_text("\n".join(json.dumps(r) for r in [
+        {"ts": "2026-06-09T15:14:54Z", "method": "get_recipe",
+         "remote": "gbrain", "resolution": "remote", "hit": True},
+        {"ts": "2026-06-09T15:14:55Z", "method": "search",
+         "remote": "cortex", "resolution": "local", "hit": False},
+    ]) + "\n", encoding="utf-8")
+
+    plan = bf.build_plan(sd)
+    assert plan["stats"]["recipe_audit"] == 2
+    assert len(plan["recipe_audit"]) == 2
+    assert plan["recipe_audit"][0]["method"] == "get_recipe"
+
+
+def test_build_plan_recipe_audit_empty_when_absent(tmp_path):
+    sd = tmp_path / "SID"
+    _seed(sd)
+    plan = bf.build_plan(sd)
+    assert plan["stats"]["recipe_audit"] == 0
+    assert plan["recipe_audit"] == []
+
+
+def test_print_plan_reports_recipe_reads(tmp_path, capsys):
+    sd = tmp_path / "SID"
+    _seed(sd)
+    audit = recipe_snapshot_audit_jsonl(sd)
+    audit.parent.mkdir(parents=True, exist_ok=True)
+    audit.write_text(
+        json.dumps({"ts": "2026-06-09T15:14:54Z", "method": "get_recipe",
+                    "remote": "gbrain", "resolution": "remote", "hit": True}) + "\n",
+        encoding="utf-8",
+    )
+    bf.print_plan(bf.build_plan(sd))
+    out = capsys.readouterr().out
+    assert "Recipe-snapshot reads: 1 audit row(s)" in out

--- a/inference_optimizer/tests/test_cli_kb_unit.py
+++ b/inference_optimizer/tests/test_cli_kb_unit.py
@@ -113,6 +113,51 @@ def test_dispatcher_both_no_sources(tmp_path, monkeypatch) -> None:
     assert kb.remote is None
 
 
+# -- _attach_recipe_audit_hook ---------------------------------------------
+def test_attach_recipe_audit_hook_appends_jsonl(tmp_path) -> None:
+    import json
+
+    from inference_optimizer.recipe_kb import LocalRecipeStore, RecipeKB
+    from inference_optimizer.session_paths import recipe_snapshot_audit_jsonl
+
+    kb = RecipeKB(local=LocalRecipeStore(root=tmp_path / "kb"), remote=None)
+    cli_kb._attach_recipe_audit_hook(kb, tmp_path)
+    assert callable(kb.audit_hook)
+    kb.audit_hook({"method": "get_recipe", "resolution": "local", "hit": False})
+    path = recipe_snapshot_audit_jsonl(tmp_path)
+    assert path.exists()
+    row = json.loads(path.read_text(encoding="utf-8").strip())
+    assert row["method"] == "get_recipe"
+    assert "ts" in row
+
+
+def test_attach_recipe_audit_hook_unwraps_mirror(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HYPERLOOM_LOCAL_KB_ROOT", str(tmp_path / "kb"))
+    monkeypatch.setenv("RECIPE_KB_REMOTE", "gbrain")
+    monkeypatch.setenv("RECIPE_KB_MIRROR_MODE", "inline")
+
+    class _Remote:
+        enabled = True
+
+    from inference_optimizer.recipe_kb import gbrain_ingest as gi
+    from inference_optimizer.recipe_kb import gbrain_remote_client as grc
+    monkeypatch.setattr(grc, "build_gbrain_remote_from_env", lambda: _Remote())
+    monkeypatch.setattr(gi, "build_mirror_mcp_from_env", lambda: object())
+    kb = cli_kb._build_recipe_kb_dispatcher(_args())
+    assert isinstance(kb, gi.GbrainMirroringRecipeKB)
+    cli_kb._attach_recipe_audit_hook(kb, tmp_path)
+    # The hook lands on the inner RecipeKB whose reads emit the audit.
+    assert callable(kb._inner.audit_hook)
+
+
+def test_attach_recipe_audit_hook_noop_without_session_dir(tmp_path) -> None:
+    from inference_optimizer.recipe_kb import LocalRecipeStore, RecipeKB
+
+    kb = RecipeKB(local=LocalRecipeStore(root=tmp_path / "kb"), remote=None)
+    cli_kb._attach_recipe_audit_hook(kb, None)
+    assert kb.audit_hook is None
+
+
 # -- _bootstrap_cortex_kb --------------------------------------------------
 def test_bootstrap_cortex_kb_success(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("HYPERLOOM_LOCAL_KB_ROOT", str(tmp_path / "kb"))

--- a/inference_optimizer/tests/test_critic_agent_backend.py
+++ b/inference_optimizer/tests/test_critic_agent_backend.py
@@ -24,6 +24,7 @@ from inference_optimizer.orchestrator.backends import (
 from inference_optimizer.orchestrator.backends.base import BackendError
 from inference_optimizer.orchestrator.backends.critic_agent import (
     _extract_review_json,
+    _verdict_references_kb,
 )
 from inference_optimizer.protocol.intent import IntentType
 
@@ -1254,3 +1255,206 @@ async def test_critic_agent_heartbeat_when_no_proposal(
             f"LLM should be skipped when proposals are empty; calls={client.completions.calls}"
     finally:
         await c.stop()
+
+
+# -----------------------------------------------------------------
+# KB trace + dry-run injection gate
+# -----------------------------------------------------------------
+def test_verdict_references_kb_helper():
+    assert _verdict_references_kb(None) is False
+    assert _verdict_references_kb({"review_verdicts": []}) is False
+    assert _verdict_references_kb(
+        {"review_verdicts": [{"verdict": "approve"}]}
+    ) is False
+    assert _verdict_references_kb(
+        {"review_verdicts": [{"verdict": "reject", "kb_evidence": ["kb_x"]}]}
+    ) is True
+
+
+def test_build_kb_assess_trace_dry_run_vs_injected():
+    judge_bundle = {
+        "kb_assess_trace": {
+            "configured": True, "skipped_reason": None,
+            "focus": {"model": "m"},
+            "requests": [{"msg_id": "p1", "responded": True}],
+        },
+        "kb_assess_by_proposal": {"p1": {"reasonable": "supported"}},
+    }
+    review = {"review_verdicts": [{"verdict": "reject", "kb_evidence": ["k"]}]}
+    dry = CriticAgentBackend._build_kb_assess_trace(
+        judge_bundle, review, injected=False,
+    )
+    assert dry["mode"] == "dry_run"
+    assert dry["injected"] is False
+    assert dry["verdict_count"] == 1
+    # In dry-run the verdict can't have been steered by assess, so False.
+    assert dry["referenced_in_verdict"] is False
+
+    inj = CriticAgentBackend._build_kb_assess_trace(
+        judge_bundle, review, injected=True,
+    )
+    assert inj["mode"] == "injected"
+    assert inj["referenced_in_verdict"] is True
+
+
+def test_build_kb_assess_trace_empty_when_nothing_captured():
+    assert CriticAgentBackend._build_kb_assess_trace({}, {}, injected=False) == {}
+
+
+def test_build_kb_priors_trace_counts_and_reference():
+    judge_bundle = {
+        "kb_priors_trace": {
+            "configured": True, "mode": "per_proposal",
+            "client_mode": "live", "scope_filter": {"model": "m"},
+            "limit": 5, "requests": [{"msg_id": "p1", "count": 2}],
+        },
+        "kb_priors_by_proposal": {"p1": [{"slug": "a"}, {"slug": "b"}]},
+        "kb_priors_for_decision": [],
+        "kb_read_skipped_reason": None,
+    }
+    review = {"review_verdicts": [{"verdict": "approve", "kb_evidence": ["k"]}]}
+    trace = CriticAgentBackend._build_kb_priors_trace(judge_bundle, review)
+    assert trace["configured"] is True
+    assert trace["mode"] == "per_proposal"
+    assert trace["prior_count"] == 2
+    assert trace["referenced_in_verdict"] is True
+
+
+def test_build_kb_priors_trace_carries_skip_reason():
+    judge_bundle = {
+        "kb_priors_trace": {},
+        "kb_priors_by_proposal": {},
+        "kb_priors_for_decision": [],
+        "kb_read_skipped_reason": "kb_unreachable",
+    }
+    trace = CriticAgentBackend._build_kb_priors_trace(judge_bundle, None)
+    assert trace["skipped_reason"] == "kb_unreachable"
+    assert trace["prior_count"] == 0
+
+
+def test_kb_assess_inject_enabled_resolution(
+    fake_critic_root: Path, fake_session_dir: Path, monkeypatch,
+):
+    monkeypatch.delenv("CORTEX_KB_ASSESS_INJECT", raising=False)
+    backend = CriticAgentBackend(
+        critic_agent_root=fake_critic_root,
+        session_dir=fake_session_dir,
+        codex_client_factory=lambda: FakeOpenAIClient([]),
+        runtime_caller_factory=lambda: (lambda call: None),
+    )
+    # Default: dry-run (off).
+    assert backend._kb_assess_inject_enabled() is False
+    monkeypatch.setenv("CORTEX_KB_ASSESS_INJECT", "true")
+    assert backend._kb_assess_inject_enabled() is True
+    # Explicit field overrides the env.
+    backend.kb_assess_inject = False
+    assert backend._kb_assess_inject_enabled() is False
+
+
+def _assess_judge_bundle() -> dict[str, Any]:
+    return {
+        "kind": "coordinator_inbox",
+        "merged_context": {"model": "m", "framework": "sglang"},
+        "proposals": [
+            {"msg_id": "p1", "from_agent": "orchestration",
+             "action_name": "sweep", "payload": {}, "predicted_gain_pct": 1.0},
+        ],
+        "kb_priors_by_proposal": {"p1": []},
+        "kb_priors_for_decision": [],
+        "kb_priors_trace": {
+            "configured": True, "mode": "per_proposal", "client_mode": "",
+            "scope_filter": {"model": "m"}, "limit": 5,
+            "requests": [{"msg_id": "p1", "cache": "miss", "count": 0}],
+        },
+        "kb_assess_by_proposal": {"p1": {"reasonable": "supported"}},
+        "kb_assess_trace": {
+            "configured": True, "skipped_reason": None, "focus": {"model": "m"},
+            "requests": [{"msg_id": "p1", "responded": True}],
+            "verdict_count": 1,
+        },
+        "kb_read_skipped_reason": None,
+        "review_constraints": {},
+        "notes": [],
+        "missing_context": [],
+        "required_context": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_dry_run_withholds_assess_from_prompt(
+    fake_critic_root: Path, fake_session_dir: Path, monkeypatch,
+):
+    monkeypatch.delenv("CORTEX_KB_ASSESS_INJECT", raising=False)
+    reply = '{"review_verdicts": [{"target_proposal_msg_id": "p1", "verdict": "approve", "source": "critic"}]}'
+    backend, fake = _make_backend(
+        fake_critic_root, fake_session_dir,
+        codex_replies=[reply], judge_bundle=_assess_judge_bundle(),
+    )
+    await backend.run("prompt")
+    prompt = fake.completions.calls[0]["messages"][-1]["content"]
+    assert "kb_assess_by_proposal" not in prompt
+    # priors are always present in the prompt.
+    assert "kb_priors_by_proposal" in prompt
+    assert backend.calls[0]["kb_assess_mode"] == "dry_run"
+    assert backend.calls[0]["kb_assess_verdicts"] == 1
+
+
+@pytest.mark.asyncio
+async def test_run_inject_enabled_feeds_assess_to_prompt(
+    fake_critic_root: Path, fake_session_dir: Path, monkeypatch,
+):
+    monkeypatch.setenv("CORTEX_KB_ASSESS_INJECT", "1")
+    reply = '{"review_verdicts": [{"target_proposal_msg_id": "p1", "verdict": "approve", "source": "critic"}]}'
+    backend, fake = _make_backend(
+        fake_critic_root, fake_session_dir,
+        codex_replies=[reply], judge_bundle=_assess_judge_bundle(),
+    )
+    await backend.run("prompt")
+    prompt = fake.completions.calls[0]["messages"][-1]["content"]
+    assert "kb_assess_by_proposal" in prompt
+    assert backend.calls[0]["kb_assess_mode"] == "injected"
+
+
+class _FakeKbEmitter:
+    def __init__(self):
+        self.enabled = True
+        self.spans: list[dict[str, Any]] = []
+
+    def record_kb_span(self, **kwargs):
+        self.spans.append(kwargs)
+
+
+@pytest.mark.asyncio
+async def test_run_mirrors_kb_trace_to_langfuse(
+    fake_critic_root: Path, fake_session_dir: Path, monkeypatch,
+):
+    fake_em = _FakeKbEmitter()
+    from inference_optimizer.orchestrator.trace import langfuse_emitter as lfe
+    monkeypatch.setattr(lfe, "get_emitter", lambda sd: fake_em)
+    reply = '{"review_verdicts": [{"target_proposal_msg_id": "p1", "verdict": "approve", "source": "critic"}]}'
+    backend, _ = _make_backend(
+        fake_critic_root, fake_session_dir,
+        codex_replies=[reply], judge_bundle=_assess_judge_bundle(),
+    )
+    await backend.run("prompt")
+    names = sorted(s["name"] for s in fake_em.spans)
+    assert names == ["kb_assess:iter_0", "kb_priors:iter_0"]
+    agents = {s["agent"] for s in fake_em.spans}
+    assert agents == {"critic"}
+
+
+@pytest.mark.asyncio
+async def test_run_skips_langfuse_mirror_when_disabled(
+    fake_critic_root: Path, fake_session_dir: Path, monkeypatch,
+):
+    fake_em = _FakeKbEmitter()
+    fake_em.enabled = False
+    from inference_optimizer.orchestrator.trace import langfuse_emitter as lfe
+    monkeypatch.setattr(lfe, "get_emitter", lambda sd: fake_em)
+    reply = '{"review_verdicts": [{"target_proposal_msg_id": "p1", "verdict": "approve", "source": "critic"}]}'
+    backend, _ = _make_backend(
+        fake_critic_root, fake_session_dir,
+        codex_replies=[reply], judge_bundle=_assess_judge_bundle(),
+    )
+    await backend.run("prompt")
+    assert fake_em.spans == []

--- a/inference_optimizer/tests/test_critic_agent_backend.py
+++ b/inference_optimizer/tests/test_critic_agent_backend.py
@@ -207,6 +207,50 @@ def _make_backend(
     return backend, fake_client
 
 
+def test_cortex_kb_url_propagated_to_runtime_env(
+    fake_critic_root, fake_session_dir, monkeypatch
+):
+    monkeypatch.delenv("CORTEX_KB_URL", raising=False)
+    backend = CriticAgentBackend(
+        critic_agent_root=fake_critic_root,
+        session_dir=fake_session_dir,
+        codex_client_factory=lambda: FakeOpenAIClient([]),
+        runtime_caller_factory=lambda: (lambda call: None),
+        cortex_kb_url="http://kb.local/",
+    )
+    env = backend._build_runtime_env()
+    assert env["CORTEX_KB_URL"] == "http://kb.local/"
+
+
+def test_explicit_cortex_kb_url_env_wins(
+    fake_critic_root, fake_session_dir, monkeypatch
+):
+    monkeypatch.setenv("CORTEX_KB_URL", "http://from-env.local")
+    backend = CriticAgentBackend(
+        critic_agent_root=fake_critic_root,
+        session_dir=fake_session_dir,
+        codex_client_factory=lambda: FakeOpenAIClient([]),
+        runtime_caller_factory=lambda: (lambda call: None),
+        cortex_kb_url="http://from-flag.local",
+    )
+    env = backend._build_runtime_env()
+    assert env["CORTEX_KB_URL"] == "http://from-env.local"
+
+
+def test_no_cortex_kb_url_leaves_env_unset(
+    fake_critic_root, fake_session_dir, monkeypatch
+):
+    monkeypatch.delenv("CORTEX_KB_URL", raising=False)
+    backend = CriticAgentBackend(
+        critic_agent_root=fake_critic_root,
+        session_dir=fake_session_dir,
+        codex_client_factory=lambda: FakeOpenAIClient([]),
+        runtime_caller_factory=lambda: (lambda call: None),
+    )
+    env = backend._build_runtime_env()
+    assert "CORTEX_KB_URL" not in env
+
+
 # _extract_review_json
 def test_extract_review_json_fenced():
     text = """Reasoning prose.

--- a/inference_optimizer/tests/test_knowledge_plane.py
+++ b/inference_optimizer/tests/test_knowledge_plane.py
@@ -442,6 +442,39 @@ def test_collect_kb_provenance_no_warning_when_marker_missing(
     assert not any(w.startswith("pr_monitor:") for w in warnings_list)
 
 
+def test_collect_kb_provenance_summarises_recipe_snapshot_reads(
+    tmp_path: Path,
+):
+    """The recipe-snapshot read audit is summarised into kb_provenance."""
+    from inference_optimizer.breakdown.collectors import collect_kb_provenance
+    from inference_optimizer.session_paths import recipe_snapshot_audit_jsonl
+
+    audit = recipe_snapshot_audit_jsonl(tmp_path)
+    audit.parent.mkdir(parents=True, exist_ok=True)
+    audit.write_text("\n".join(json.dumps(r) for r in [
+        {"method": "get_recipe", "remote": "gbrain", "resolution": "remote", "hit": True},
+        {"method": "get_recipe", "remote": "gbrain", "resolution": "remote_miss", "hit": False},
+        {"method": "get_recipe", "remote": "cortex", "resolution": "local", "hit": True},
+    ]) + "\n", encoding="utf-8")
+
+    out = collect_kb_provenance(tmp_path, state={}, manifest={}, warnings=[])
+    rs = out["recipe_snapshot_reads"]
+    assert rs["count"] == 3
+    assert rs["hits"] == 2
+    assert rs["by_remote"] == {"gbrain": 2, "cortex": 1}
+    assert rs["by_resolution"] == {"remote": 1, "remote_miss": 1, "local": 1}
+    assert len(rs["tail"]) == 3
+
+
+def test_collect_kb_provenance_recipe_reads_empty_when_no_audit(
+    tmp_path: Path,
+):
+    from inference_optimizer.breakdown.collectors import collect_kb_provenance
+    out = collect_kb_provenance(tmp_path, state={}, manifest={}, warnings=[])
+    assert out["recipe_snapshot_reads"]["count"] == 0
+    assert out["recipe_snapshot_reads"]["hits"] == 0
+
+
 # 4. KB_gaps/Gap-16 — CLI flag plumbing reaches _bootstrap_knowledge_plane
 def _parse_optimize_args(extra: list[str]) -> argparse.Namespace:
     """Pin the dest-name + default contract the bootstrap reads."""

--- a/inference_optimizer/tests/test_langfuse_emitter.py
+++ b/inference_optimizer/tests/test_langfuse_emitter.py
@@ -517,6 +517,86 @@ def test_flush_creates_decision_scores(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# KB trace spans (record_kb_span + recipe-snapshot audit flush)
+# ---------------------------------------------------------------------------
+def test_record_kb_span_disabled_is_noop(tmp_path, monkeypatch):
+    monkeypatch.delenv("HYPERLOOM_LANGFUSE_ENABLE", raising=False)
+    em = lfe.LangfuseEmitter(tmp_path)
+    em.record_kb_span(name="kb_assess:iter_0", agent="critic", output={"x": 1})
+    assert em._counts["kb_spans_sent"] == 0
+
+
+def test_record_kb_span_nests_under_agent(tmp_path, monkeypatch):
+    _enable_env(monkeypatch)
+    client = _FakeClient()
+    _install_fake_sdk(monkeypatch, client)
+    sd = tmp_path / "SID"
+    _write_manifest(sd)
+    em = lfe.LangfuseEmitter(sd)
+    em.record_kb_span(
+        name="kb_assess:iter_2", agent="critic",
+        output={"mode": "dry_run", "verdict_count": 1},
+        metadata={"kind": "kb_assess", "iter": 2},
+        ts="2026-06-09T15:14:54.100000+00:00",
+    )
+    span = client.span_named("kb_assess:iter_2")
+    assert span is not None
+    assert span.kwargs["output"] == {"mode": "dry_run", "verdict_count": 1}
+    assert span.kwargs["metadata"]["kind"] == "kb_assess"
+    # nested under agent:critic
+    assert client.span_named("agent:critic") is not None
+    assert span.ended is True
+    assert em._counts["kb_spans_sent"] == 1
+
+
+def test_flush_backfills_recipe_snapshot_audit(tmp_path, monkeypatch):
+    _enable_env(monkeypatch)
+    client = _FakeClient()
+    _install_fake_sdk(monkeypatch, client)
+    sd = _seed_trace_dir(tmp_path)
+    from inference_optimizer.session_paths import recipe_snapshot_audit_jsonl
+    audit = recipe_snapshot_audit_jsonl(sd)
+    audit.parent.mkdir(parents=True, exist_ok=True)
+    audit.write_text("\n".join(json.dumps(r) for r in [
+        {"ts": "2026-06-09T15:14:54Z", "method": "get_recipe",
+         "remote": "gbrain", "resolution": "remote", "hit": True},
+        {"ts": "2026-06-09T15:14:55Z", "method": "search",
+         "remote": "cortex", "resolution": "local", "hit": False},
+    ]) + "\n", encoding="utf-8")
+    em = lfe.LangfuseEmitter(sd)
+    em.flush_session()
+    assert client.span_named("kb:recipe_snapshot:get_recipe") is not None
+    assert client.span_named("kb:recipe_snapshot:search") is not None
+    assert client.span_named("agent:recipe_kb") is not None
+    persisted = lfe.read_receipt(sd)
+    assert persisted["counts"]["recipe_audit_read"] == 2
+    assert persisted["counts"]["kb_spans_sent"] == 2
+
+
+def test_flush_recipe_audit_idempotent(tmp_path, monkeypatch):
+    _enable_env(monkeypatch)
+    client = _FakeClient()
+    _install_fake_sdk(monkeypatch, client)
+    sd = _seed_trace_dir(tmp_path)
+    from inference_optimizer.session_paths import recipe_snapshot_audit_jsonl
+    audit = recipe_snapshot_audit_jsonl(sd)
+    audit.parent.mkdir(parents=True, exist_ok=True)
+    audit.write_text(
+        json.dumps({"ts": "2026-06-09T15:14:54Z", "method": "get_recipe",
+                    "remote": "gbrain", "resolution": "remote", "hit": True}) + "\n",
+        encoding="utf-8",
+    )
+    em = lfe.LangfuseEmitter(sd)
+    em.flush_session()
+    n = len([s for s in client.spans
+             if s.kwargs.get("name", "").startswith("kb:recipe_snapshot")])
+    em.flush_session()
+    n2 = len([s for s in client.spans
+              if s.kwargs.get("name", "").startswith("kb:recipe_snapshot")])
+    assert n == 1 and n2 == 1
+
+
+# ---------------------------------------------------------------------------
 # Best-effort fault posture
 # ---------------------------------------------------------------------------
 def test_send_exception_is_swallowed(tmp_path, monkeypatch):

--- a/inference_optimizer/tests/test_recipe_kb_dispatcher.py
+++ b/inference_optimizer/tests/test_recipe_kb_dispatcher.py
@@ -361,6 +361,80 @@ def test_disabled_remote_treated_as_no_remote(
     assert out["model"] == "local-marker"
 
 
+# Audit hook — recipe-snapshot read trace
+def test_audit_hook_emitted_on_remote_hit(kb: RecipeKB) -> None:
+    cid = _cid()
+    events: list[dict[str, Any]] = []
+    kb.audit_hook = lambda e: events.append(e)
+    v2_payload = {
+        "canonical_id": cid, "version": 5,
+        "labels": {"model": "remote-model", "hardware": "mi300x"},
+        "body": {"best_config": {"tp": "16"}}, "metrics": {"throughput": 30000.0},
+    }
+    with respx.mock(base_url=KB_URL) as mock:
+        mock.post(PATH_RECIPES_SEARCH).mock(
+            return_value=httpx.Response(200, json={"recipes": [v2_payload]}),
+        )
+        kb.get_recipe(canonical_id=cid, prefer={"tp": 8})
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["method"] == "get_recipe"
+    assert ev["remote"] == "cortex"
+    assert ev["resolution"] == "remote"
+    assert ev["hit"] is True
+    assert ev["request"]["canonical_id"] == cid
+    assert ev["request"]["prefer_keys"] == ["tp"]
+    assert ev["result"]["exact"] is True
+    assert ev["result"]["best_throughput"] == 30000.0
+
+
+def test_audit_hook_emitted_on_local_fallthrough(
+    kb: RecipeKB, local_store: LocalRecipeStore,
+) -> None:
+    cid = _cid()
+    local_store.put_recipe(canonical_id=cid, model="local-marker")
+    events: list[dict[str, Any]] = []
+    kb.audit_hook = lambda e: events.append(e)
+    with respx.mock(base_url=KB_URL) as mock:
+        mock.post(PATH_RECIPES_SEARCH).mock(
+            return_value=httpx.Response(503, json={"detail": "down"}),
+        )
+        kb.get_recipe(canonical_id=cid)
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["resolution"] == "remote_error"
+    assert ev["hit"] is True  # served from local
+
+
+def test_audit_hook_no_remote_records_local(
+    local_store: LocalRecipeStore,
+) -> None:
+    kb = RecipeKB(local=local_store, remote=None)
+    cid = _cid()
+    events: list[dict[str, Any]] = []
+    kb.audit_hook = lambda e: events.append(e)
+    kb.get_recipe(canonical_id=cid)
+    assert len(events) == 1
+    assert events[0]["remote"] == "none"
+    assert events[0]["resolution"] == "local"
+    assert events[0]["hit"] is False
+
+
+def test_audit_hook_never_raises_into_caller(kb: RecipeKB) -> None:
+    cid = _cid()
+
+    def _boom(_e: dict[str, Any]) -> None:
+        raise RuntimeError("audit sink down")
+
+    kb.audit_hook = _boom
+    with respx.mock(base_url=KB_URL) as mock:
+        mock.post(PATH_RECIPES_SEARCH).mock(
+            return_value=httpx.Response(200, json={"recipes": []}),
+        )
+        # Must not raise despite the failing hook.
+        assert kb.get_recipe(canonical_id=cid) is None
+
+
 # Lifecycle
 def test_close_releases_remote_transport(
     local_store: LocalRecipeStore, remote: RemoteRecipeClient,


### PR DESCRIPTION
## Summary

Adds a **best-effort, opt-in** path for the Critic agent to judge whether a proposal is *reasonable* by associating its raw optimisation levers (params / env vars / server args) to the cortex knowledge substrate's calibrated mechanism evidence, via `POST {CORTEX_KB_URL}/v2/reasoning/assess`.

- Reuses recipe-snapshot's configuration contract **verbatim** — no new env var:
  - URL: `--cortex-kb-url` / `$CORTEX_KB_URL` (no default; never a silent remote connect)
  - timeout: `$CORTEX_KB_HTTP_TIMEOUT_SEC`
  - bearer: `$KB_SERVICE_TOKEN`
- When no URL is configured, the Critic never calls out and behaviour is **unchanged**.
- The verdict is advisory only: any timeout / 5xx / connection error is swallowed and never gates the review.

## Changes

- `critic-agent/runtime/kb_assess_client.py` (new): `urllib`-based client (avoids `httpx` for the minimal Codex container, consistent with `kb_client.py`). `from_env()` returns `None` unless `CORTEX_KB_URL` is set.
- `critic-agent/runtime/decision_reviewer.py`: `JudgeBundle` gains `kb_assess_by_proposal`; `prepare_review` resolves per-proposal levers and folds verdicts in. Levers are read only from `payload['params']` (proposal metadata is never mistaken for a lever).
- `inference_optimizer/orchestrator/backends/critic_agent.py`: new `cortex_kb_url` field propagated into the runtime subprocess env (an explicit `CORTEX_KB_URL` env still wins); `_reason()` serialises `kb_assess_by_proposal` into the judge bundle the LLM sees.
- `inference_optimizer/cli.py`, `inference_optimizer/cli_backends.py`: thread `--cortex-kb-url` through to the critic backend.
- `critic-agent/actions/review_coordinator_inbox.md`: instruct the Critic how to weigh the verdict (`supported` / `contested` / `insufficient_basis`).

## Config / resolution order

1. `--cortex-kb-url` flag → propagated to the critic subprocess env
2. `$CORTEX_KB_URL` (wins if already set; inherited automatically)
3. neither → assess is skipped entirely

## Test plan

- [x] `critic-agent/runtime/tests/test_kb_assess_client.py` — env gating, POST shape, error swallowing
- [x] `critic-agent/runtime/tests/test_decision_reviewer.py` — skipped when unconfigured, injected when configured, proposals without levers skipped
- [x] `inference_optimizer/tests/test_critic_agent_backend.py` — flag→env propagation, explicit env wins, unset leaves env clean
- [x] existing critic-agent runtime suite (170 passed) and coordinator runtime suite stay green

> Depends on the cortex `kb-service` exposing `POST /v2/reasoning/assess` (separate PR in primus-cortex-internal).

Made with [Cursor](https://cursor.com)