### PR TITLE
docs: add Google-style docstrings + Sphinx coverage across source packages

### DIFF
--- a/ci/build_rolling_pool.py
+++ b/ci/build_rolling_pool.py
@@ -39,15 +39,40 @@ from generate_hf_matrix import slugify  # noqa: E402
 
 
 def _norm(repo: str | None) -> str:
+    """Normalize a repo id for case-insensitive comparison.
+
+    Args:
+        repo: Repo id, possibly ``None``.
+
+    Returns:
+        The trimmed, lower-cased repo id (empty string when ``repo`` is falsy).
+    """
     return (repo or "").strip().lower()
 
 
 def _candidate_keys(repo_id: str) -> set[str]:
+    """Build the set of slug keys a candidate may be matched by.
+
+    Args:
+        repo_id: Full Hugging Face repo id (``org/name``).
+
+    Returns:
+        Slugs for both the full repo id and its basename, since Pulse may store
+        either form as ``model_name``.
+    """
     repo_id = (repo_id or "").strip()
     return {slugify(repo_id), slugify(repo_id.split("/")[-1])}
 
 
 def _pulse_model_keys() -> set[str]:
+    """Fetch slug keys for every model already seen in Pulse breakdowns.
+
+    Pages through the Pulse session-breakdowns API (with retries) and collects
+    a slugified key per ``model_name``.
+
+    Returns:
+        The set of slugified model keys that have already been run.
+    """
     keys: set[str] = set()
     offset = 0
     limit = 200
@@ -79,6 +104,15 @@ def _pulse_model_keys() -> set[str]:
 
 
 def main() -> int:
+    """Merge the production and new-model pools and write the rolling outputs.
+
+    Reads the curated production corpus and the new-models list, applies the
+    production exclusion policy, de-duplicates by repo id, then writes the
+    merged pool, the reserved manual top-100, and the unrun subset.
+
+    Returns:
+        Process exit code (``0`` on success).
+    """
     prod = json.loads(PROD.read_text(encoding="utf-8"))
     newm = json.loads(NEWM.read_text(encoding="utf-8"))
 
@@ -90,6 +124,15 @@ def main() -> int:
     excl_kw = [k.lower() for k in policy.get("exclusion_keywords", [])]
 
     def excluded(repo: str) -> bool:
+        """Return whether a repo is filtered out by the exclusion policy.
+
+        Args:
+            repo: Candidate repo id.
+
+        Returns:
+            ``True`` when the repo is empty, exactly excluded, or matches an
+            exclusion keyword.
+        """
         k = _norm(repo)
         if not k:
             return True
@@ -146,6 +189,13 @@ def main() -> int:
     generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
 
     def dump(path: Path, cands: list[dict], note: str) -> None:
+        """Write a candidate pool to ``path`` as the standard corpus JSON.
+
+        Args:
+            path: Destination file; its stem is used as the ``pool_id``.
+            cands: Candidate records to serialize.
+            note: Human-readable description stored under the ``note`` key.
+        """
         path.write_text(json.dumps({
             "schema_version": "hyperloom.production_corpus.v1",
             "pool_id": path.stem,

--- a/ci/claw_client.py
+++ b/ci/claw_client.py
@@ -232,6 +232,15 @@ class ClawClient:
         ))["data"]
 
     def download_file(self, session_id: str, file_path: str) -> bytes:
+        """Download a sandbox file and return its raw bytes.
+
+        Args:
+            session_id (str): Session id owning the file.
+            file_path (str): Path of the file within the sandbox.
+
+        Returns:
+            bytes: The file's contents.
+        """
         # Percent-encode the full path including any leading slash.
         encoded = quote(file_path, safe="")
         resp = self._session.get(

--- a/ci/generate_hf_matrix.py
+++ b/ci/generate_hf_matrix.py
@@ -339,8 +339,18 @@ def _entry_slug(entry: dict | str) -> str:
 
 
 def _parse_explicit_models(value: str) -> list[str]:
-    # Whitespace OR comma separated, both supported (workflow_dispatch UI is
-    # space-friendly; downstream callers may comma-list).
+    """Split an explicit model list into individual repo ids.
+
+    Accepts whitespace- or comma-separated input so both the
+    ``workflow_dispatch`` UI (space-friendly) and programmatic callers
+    (comma-lists) work.
+
+    Args:
+        value: Raw model-list string.
+
+    Returns:
+        The non-empty repo ids in order.
+    """
     return [r for r in re.split(r"[\s,]+", value.strip()) if r]
 
 

--- a/ci/generate_matrix.py
+++ b/ci/generate_matrix.py
@@ -16,6 +16,17 @@ def _entry_key(m: dict) -> str:
 
 
 def generate_matrix(config_path: str = "ci-config.yaml", selected_models: str = "") -> dict:
+    """Build a GitHub Actions matrix from the CI config.
+
+    Args:
+        config_path: Path to ``ci-config.yaml``.
+        selected_models: Optional comma-separated list of model keys to
+            include; when empty, all configured models are used.
+
+    Returns:
+        A dict of the form ``{"include": [{"key": ...}, ...]}`` suitable for a
+        GitHub Actions matrix.
+    """
     # Force UTF-8: ci-config.yaml uses box-drawing chars (──); Windows cp1252 would raise UnicodeDecodeError.
     with open(config_path, encoding="utf-8") as f:
         config = yaml.safe_load(f)

--- a/ci/optimize_submit.py
+++ b/ci/optimize_submit.py
@@ -145,6 +145,15 @@ def normalize_gpu_profile(gpu_type: str | None, *, warn: bool = True) -> str | N
 
 
 def canonical_gpu_type(gpu_type: str | None) -> str:
+    """Resolve a GPU type string to its canonical form.
+
+    Args:
+        gpu_type: Free-form GPU type/alias, or ``None``.
+
+    Returns:
+        The canonical GPU type from the matching profile, or the trimmed input
+        (falling back to ``DEFAULT_GPU_TYPE``) when no profile matches.
+    """
     profile_key = normalize_gpu_profile(gpu_type, warn=False)
     if profile_key:
         return str(GPU_PROFILES[profile_key]["gpu_type"])
@@ -288,6 +297,13 @@ def _proxy() -> str:
 
 
 def _default_sglang_image() -> str:
+    """Return the default SGLang server image.
+
+    Returns:
+        The pinned ``profilerfix`` SGLang image whose patched
+        libamdhip64/libroctracer let rocprofiler capture kernels under
+        ``HipGraphLaunch`` (issue #352).
+    """
     # profilerfix: patched libamdhip64/libroctracer so rocprofiler captures
     # kernels under HipGraphLaunch (issue #352). Pre-profilerfix image (revert):
     # lmsysorg/sglang:v0.5.11-rocm720-mi30x
@@ -295,6 +311,12 @@ def _default_sglang_image() -> str:
 
 
 def _default_vllm_image() -> str:
+    """Return the default vLLM server image.
+
+    Returns:
+        The proxy-qualified vLLM image (v0.19.0, one minor ahead of the
+        InferenceX baseline to avoid v0.20 breakage).
+    """
     # v0.19.0: one minor ahead of InferenceX baseline v0.17.0, avoiding v0.20 breakage.
     return f"{_proxy()}/vllm/vllm-openai-rocm:v0.19.0"
 
@@ -538,6 +560,19 @@ def context_too_short(
     osl: int,
     reserve_tokens: int = DEFAULT_CONTEXT_RESERVE_TOKENS,
 ) -> bool:
+    """Return whether the model context cannot fit the requested workload.
+
+    Args:
+        max_context_tokens: Model's maximum context length; ``<= 0`` means
+            unknown, in which case the check is skipped.
+        isl: Input sequence length.
+        osl: Output sequence length.
+        reserve_tokens: Headroom kept free beyond input + output.
+
+    Returns:
+        ``True`` when the context is known and smaller than
+        ``isl + osl + reserve_tokens``; otherwise ``False``.
+    """
     if max_context_tokens <= 0:
         return False
     return max_context_tokens < (isl + osl + reserve_tokens)
@@ -597,11 +632,35 @@ def _sglang_image_for(repo_id: str = "") -> str:
 
 
 def detect_image(framework: str, repo_id: str = "") -> str:
+    """Select the server image for a framework and model.
+
+    Args:
+        framework: Serving framework (``vllm`` / ``sglang``).
+        repo_id: Model repo id, used to honor per-model image overrides.
+
+    Returns:
+        The default vLLM image for ``vllm``; otherwise the SGLang image chosen
+        by :func:`_sglang_image_for`.
+    """
     return _default_vllm_image() if framework == "vllm" else _sglang_image_for(repo_id)
 
 
 def auto_detect(hf: HuggingFaceClient, repo_id: str,
                 gpu_type: str | None = None) -> DetectedConfig | None:
+    """Derive a benchmark configuration from a model's HF metadata.
+
+    Fetches model info and ``config.json`` and infers framework, precision,
+    tensor parallelism, concurrency, image, and context limits.
+
+    Args:
+        hf: Hugging Face client used to fetch metadata.
+        repo_id: Model repo id to inspect.
+        gpu_type: Target GPU type, used for TP/profile selection.
+
+    Returns:
+        A :class:`DetectedConfig`, or ``None`` when the HF metadata cannot be
+        fetched.
+    """
     log.info("[%s] fetching HF metadata", repo_id)
     try:
         info = hf.model_info(repo_id)
@@ -704,6 +763,21 @@ class SafeOptimizeClient:
 
     def _request(self, method: str, path: str, body: dict | None = None,
                  timeout: float | None = None) -> dict:
+        """Send an HTTP request to the SaFE API and return the parsed JSON.
+
+        Args:
+            method: HTTP method (e.g. ``GET``, ``POST``).
+            path: API path appended to ``base_url``.
+            body: Optional JSON request body.
+            timeout: Optional per-request timeout; falls back to the client
+                default.
+
+        Returns:
+            The decoded JSON response, or an empty dict when there is no body.
+
+        Raises:
+            RuntimeError: If the response status code is ``>= 400``.
+        """
         url = f"{self.base_url}/{path.lstrip('/')}"
         resp = self._sess.request(method, url, json=body,
                                   timeout=timeout or self.timeout)
@@ -837,6 +911,36 @@ class SafeOptimizeClient:
         target_gain: float | None = None,
         results_path: str | None = None,
     ) -> dict:
+        """Submit an optimization task to SaFE and return the API response.
+
+        Builds the task request body from the model and benchmark parameters,
+        choosing a target workspace (single or round-robin across the pool).
+
+        Args:
+            model_id: Registered SaFE model id.
+            display_name: Human-readable task name.
+            framework: Serving framework (``vllm`` / ``sglang``).
+            precision: Model precision (e.g. ``BF16``, ``FP8``).
+            tp: Tensor-parallel size.
+            concurrency: Benchmark concurrency level.
+            isl: Input sequence length.
+            osl: Output sequence length.
+            image: Server image to run, or ``None`` for the framework default.
+            mode: Submission mode (e.g. ``local``).
+            gpu_type: Target GPU type.
+            inferencex_path: Optional InferenceX checkout path.
+            oob_path: Optional out-of-box baseline path.
+            tracelens_root: Optional TraceLens root path.
+            prompt_prefix: Optional prompt prefix override.
+            prompt_suffix: Optional prompt suffix override.
+            kernel_backends: Optional list of kernel backends to enable.
+            max_hours: Optional wall-clock budget for the task.
+            target_gain: Optional target performance gain.
+            results_path: Optional path where results should be written.
+
+        Returns:
+            The decoded API response for the submitted task.
+        """
         # Pick the workspace: single submit_workspace, or round-robin across the
         # pool. Counter is per-instance, not thread-safe — fine since submit_task
         # runs serially (only wait_and_collect is parallel, after submit returns).
@@ -2261,6 +2365,15 @@ def _backfill_wekafs_in_place(rec: SubmissionRecord) -> int:
     n = 0
 
     def _session_has_matching_json(sess_path: str) -> bool:
+        """Return whether a session dir holds JSON matching the target model.
+
+        Args:
+            sess_path: Session directory to scan.
+
+        Returns:
+            ``True`` if any target JSON file under the known subdirs has a
+            model field matching ``rec``; otherwise ``False``.
+        """
         for sub in subdirs:
             base = os.path.join(sess_path, sub) if sub else sess_path
             if not os.path.isdir(base):
@@ -2279,6 +2392,15 @@ def _backfill_wekafs_in_place(rec: SubmissionRecord) -> int:
         return False
 
     def _backfill_files(sess_path: str) -> int:
+        """Backfill the model field into target JSON files in a session dir.
+
+        Args:
+            sess_path: Session directory whose target JSON files should be
+                updated.
+
+        Returns:
+            The number of files updated.
+        """
         updated = 0
         for sub in subdirs:
             base = os.path.join(sess_path, sub) if sub else sess_path

--- a/framework-agent/src/framework_agent/kb.py
+++ b/framework-agent/src/framework_agent/kb.py
@@ -411,6 +411,12 @@ def _synthesize_via_llm(
     import asyncio
 
     async def _drive() -> None:
+        """Stream the SDK query and accumulate text into ``chunks``.
+
+        Iterates the async generator returned by ``sdk.query`` and appends every
+        non-empty text fragment from each message to the enclosing ``chunks``
+        list.
+        """
         async for message in sdk.query(prompt=prompt, options=options):
             for text in _iter_message_text(message):
                 if text:

--- a/inference_optimizer/baseline_comparison/target_analyzer.py
+++ b/inference_optimizer/baseline_comparison/target_analyzer.py
@@ -198,6 +198,14 @@ def _target_row_to_point(row: dict[str, Any]) -> BaselinePoint | None:
     present) is informational only and not folded into the point shape.
     """
     def _fnum(key: str) -> float:
+        """Read a float field from the enclosing ``row``.
+
+        Args:
+            key: Field name to look up.
+
+        Returns:
+            The value as a float, or ``0.0`` if missing or unparseable.
+        """
         try:
             return float(row.get(key))
         except (TypeError, ValueError):

--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -579,6 +579,14 @@ def _benchmark_report_candidates(root: Path) -> list[Path]:
 
 
 def _latest_benchmark_report(candidates: Iterable[Path]) -> Path | None:
+    """Return the most recently modified existing report among candidates.
+
+    Args:
+        candidates: Candidate report paths.
+
+    Returns:
+        The newest existing path by mtime, or ``None`` when none exist.
+    """
     reports = [p for p in candidates if p.exists()]
     if not reports:
         return None
@@ -669,6 +677,17 @@ def _close_phase_stop_reason(state: dict[str, Any]) -> tuple[str, str]:
 
 
 def _should_use_close_stop_reason(stop_reason: str, close_stop_reason: str) -> bool:
+    """Decide whether the CLOSE-phase stop reason should override the session's.
+
+    Args:
+        stop_reason: The session-level stop reason.
+        close_stop_reason: The CLOSE-phase stop reason.
+
+    Returns:
+        ``True`` when the close reason is more specific — i.e. it is set and the
+        session reason is empty, or the session merely timed out while the close
+        reason did not.
+    """
     if not close_stop_reason:
         return False
     if not stop_reason:
@@ -1521,6 +1540,17 @@ def collect_capability_summary(
     oob_invocations: list[dict[str, Any]],
     warnings: list[str],
 ) -> dict[str, Any]:
+    """Summarize kernel-optimization capability outcomes for the breakdown.
+
+    Args:
+        state: Session state mapping.
+        geak_invocations: GEAK backend invocation records.
+        oob_invocations: Out-of-box backend invocation records.
+        warnings: Mutable list that collected warnings are appended to.
+
+    Returns:
+        A capability-summary dict (per-kernel status, attempt and keep counts).
+    """
     # Integrate (e2e) outcome per kernel: a kernel-opt KEEP REVERTED at
     # integrate is not a real adoption, so don't inflate the geak/oob tally.
     integ = state.get("kernel_integrate_attempts") or {}
@@ -2716,6 +2746,15 @@ def collect_explore_search(
     state: dict[str, Any],
     warnings: list[str],
 ) -> dict[str, Any]:
+    """Collect the explore-phase search summary for the breakdown.
+
+    Args:
+        state: Session state mapping.
+        warnings: Mutable list that collected warnings are appended to.
+
+    Returns:
+        A dict summarizing the explore-phase search activity and outcomes.
+    """
     # Emit all three ledgers (unified explore + legacy params/backends) so
     # breakdown reprocesses both vintages; unused ones shape to empty shells.
     explore_ledger = _shape_ledger(state.get("explore_search"))
@@ -3379,6 +3418,21 @@ def collect_attribution(
     adopted_kernels: list[dict[str, Any]],
     warnings: list[str],
 ) -> dict[str, Any]:
+    """Attribute end-to-end gains to individual optimization-stack entries.
+
+    Prefers the authoritative ``gain_per_stack_entry`` ledger and falls back to
+    reconstructing attribution from the optimization stack.
+
+    Args:
+        state: Session state mapping.
+        geak_invocations: GEAK backend invocation records.
+        oob_invocations: Out-of-box backend invocation records.
+        adopted_kernels: Kernels adopted into the optimized stack.
+        warnings: Mutable list that collected warnings are appended to.
+
+    Returns:
+        An attribution dict mapping stack entries to their measured gains.
+    """
     # Prefer the authoritative ``gain_per_stack_entry`` ledger; else reconstruct from optimization_stack.
     state_entries = state.get("gain_per_stack_entry")
     state_provided = isinstance(state_entries, list) and len(state_entries) > 0
@@ -4192,6 +4246,15 @@ def collect_phase_segments(
     sub_events = [r for r in rows if not str(r.get("to_phase") or "")]
 
     def _unix(row: dict[str, Any]) -> float | None:
+        """Return a row's timestamp as a Unix epoch float.
+
+        Args:
+            row: Event row carrying ``ts_unix`` and/or ``ts``.
+
+        Returns:
+            The ``ts_unix`` value when numeric, else the parsed ISO ``ts``,
+            else ``None``.
+        """
         u = row.get("ts_unix")
         if isinstance(u, (int, float)):
             return float(u)
@@ -4679,6 +4742,11 @@ def _coerce_token(value: Any) -> int:
 
 
 def _empty_token_bucket() -> dict[str, int]:
+    """Return a fresh, zeroed token-rollup bucket.
+
+    Returns:
+        A dict with zeroed input/output/cache token totals and call count.
+    """
     return {
         "total_in": 0,
         "total_out": 0,
@@ -4689,6 +4757,12 @@ def _empty_token_bucket() -> dict[str, int]:
 
 
 def _fold_call_into_bucket(bucket: dict[str, int], call: dict[str, Any]) -> None:
+    """Add one call's token counts into a rollup bucket in place.
+
+    Args:
+        bucket: Token bucket to accumulate into (mutated).
+        call: Per-call record carrying token counters.
+    """
     bucket["total_in"] += _coerce_token(call.get(_TOKEN_IN_KEY))
     bucket["total_out"] += _coerce_token(call.get(_TOKEN_OUT_KEY))
     bucket["total_cache_creation"] += _coerce_token(

--- a/inference_optimizer/breakdown/legacy_collectors.py
+++ b/inference_optimizer/breakdown/legacy_collectors.py
@@ -55,12 +55,30 @@ def is_legacy_session(state: dict[str, Any]) -> bool:
 
 
 def _phase_for_event(action: str, prev_phase: str) -> str:
+    """Determine the phase associated with an action event.
+
+    Args:
+        action: The action name from the event.
+        prev_phase: The phase carried over from the previous event.
+
+    Returns:
+        The mapped phase, the previous phase for phase-neutral actions,
+        or the default phase as a fallback.
+    """
     if action in _PHASE_NEUTRAL:
         return prev_phase or _DEFAULT_PHASE
     return _ACTION_PHASE.get(action, _DEFAULT_PHASE)
 
 
 def _stack_adoptions(state: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract timestamped optimization-stack adoption entries.
+
+    Args:
+        state: Session state mapping holding ``optimization_stack``.
+
+    Returns:
+        The stack entries that are dicts carrying a ``ts`` timestamp.
+    """
     stack = state.get("optimization_stack") or []
     out: list[dict[str, Any]] = []
     if isinstance(stack, list):

--- a/inference_optimizer/breakdown/reporters/llm_client.py
+++ b/inference_optimizer/breakdown/reporters/llm_client.py
@@ -63,6 +63,15 @@ class OpenAIHttpClient:
     timeout_sec: float = 60.0
 
     def complete(self, *, system: str, user: str) -> str:
+        """Issue a single chat-completion request and return the text.
+
+        Args:
+            system: System prompt content.
+            user: User prompt content.
+
+        Returns:
+            The content of the first choice's message.
+        """
         import httpx  # local import (see module docstring)
 
         url = self.base_url.rstrip("/") + "/chat/completions"

--- a/inference_optimizer/breakdown/session_package.py
+++ b/inference_optimizer/breakdown/session_package.py
@@ -119,6 +119,12 @@ _MAX_TOTAL_BYTES = 256 * 1024 * 1024  # 256 MB
 
 
 def _dest_root() -> Path:
+    """Resolve the destination root for session packages.
+
+    Returns:
+        The path from ``ENV_PACKAGE_DEST_ROOT`` when set, otherwise the
+        default destination root.
+    """
     override = (os.environ.get(ENV_PACKAGE_DEST_ROOT) or "").strip()
     return Path(override) if override else DEFAULT_DEST_ROOT
 
@@ -235,6 +241,19 @@ def _build_manifest(
     truncated: bool = False,
     dropped_files: list[str] | None = None,
 ) -> dict:
+    """Build the manifest dict describing a session package.
+
+    Args:
+        session_dir: Source session directory.
+        session_id: Identifier of the session.
+        included: ``(relative_path, size_bytes)`` pairs that were bundled.
+        missing_globs: Selection globs that matched no files.
+        truncated: Whether a size/count cap stopped the bundle short.
+        dropped_files: Files omitted due to truncation.
+
+    Returns:
+        A JSON-serializable manifest mapping.
+    """
     total = sum(sz for _, sz in included)
     return {
         "schema_version": PACKAGE_SCHEMA_VERSION,
@@ -254,6 +273,14 @@ def _build_manifest(
 
 
 def _manifest_text(manifest: dict) -> str:
+    """Render a manifest dict as a human-readable text summary.
+
+    Args:
+        manifest: Manifest mapping produced by :func:`_build_manifest`.
+
+    Returns:
+        A multi-line plain-text description of the package contents.
+    """
     lines = [
         "Hyperloom session artifact package",
         f"  session_id   : {manifest.get('session_id') or '?'}",

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -1524,6 +1524,19 @@ def _seed_shared_state(
     *,
     session_id: str,
 ) -> SharedState:
+    """Construct and persist the initial :class:`SharedState` for a run.
+
+    Seeds the state from parsed CLI args, clamping the research-lane
+    capacity to a safe range to protect quota and the PR-Monitor.
+
+    Args:
+        session_dir: Directory for the new session.
+        args: Parsed CLI arguments.
+        session_id: Identifier assigned to the session.
+
+    Returns:
+        The seeded :class:`SharedState` instance.
+    """
     # research_lane capacity is locked for the session; clamp to [0, ceiling] (2×GPU) to protect quota/PR-Monitor.
     from inference_optimizer.orchestrator.policy import (
         research_lane_ceiling,
@@ -3442,6 +3455,17 @@ def _export_workload_envs_for_optimize(
 
 
 async def _run_optimize(args: argparse.Namespace) -> int:
+    """Run the ``optimize`` subcommand end to end.
+
+    Resolves topology arguments (nodes, TP/EP, GPUs per node), runs
+    preflight, and drives the optimization session to completion.
+
+    Args:
+        args: Parsed CLI arguments for the ``optimize`` subcommand.
+
+    Returns:
+        Process exit code (``0`` on success).
+    """
     # Surface --nodes (CLI flag wins) before _preflight runs.
     nodes_resolved = max(1, int(args.nodes))
     tp_resolved = max(1, int(getattr(args, "tp", 1) or 1))
@@ -4324,6 +4348,11 @@ def _default_research_lane_capacity() -> int:
 
 
 def _build_parser() -> argparse.ArgumentParser:
+    """Build the top-level CLI argument parser and subcommands.
+
+    Returns:
+        The configured :class:`argparse.ArgumentParser`.
+    """
     from inference_optimizer.orchestrator.specialist_domains import (
         DEFAULT_SPECIALIST_MAX_TURNS as _DEFAULT_SPECIALIST_MAX_TURNS,
     )

--- a/inference_optimizer/cli_executors.py
+++ b/inference_optimizer/cli_executors.py
@@ -42,6 +42,14 @@ log = logging.getLogger(__name__)
 
 
 async def _noop_prep(ctx) -> dict:
+    """No-op preparation executor used as a stub.
+
+    Args:
+        ctx: Action context (only ``ctx.task.kind`` is read).
+
+    Returns:
+        A success result envelope tagged as a noop stub.
+    """
     return {"status": "succeeded", "kind": ctx.task.kind, "note": "noop-stub"}
 
 
@@ -153,6 +161,14 @@ def _build_specialist_executor(
         )
     else:
         def _backend_factory(domain: Any) -> Any:
+            """Build an in-process Claude backend for a specialist domain.
+
+            Args:
+                domain: The specialist domain requesting a backend.
+
+            Returns:
+                A configured :class:`ClaudeBackend` instance.
+            """
             # in-process Claude path (fallback).
             return ClaudeBackend(
                 model=claude_model, max_turns_default=max_turns,

--- a/inference_optimizer/multi_node/_internal/safe_client.py
+++ b/inference_optimizer/multi_node/_internal/safe_client.py
@@ -32,6 +32,13 @@ class SafeApiError(RuntimeError):
     """
 
     def __init__(self, status: int | None, body: str, *, endpoint: str) -> None:
+        """Initialize the SaFE error with response context.
+
+        Args:
+            status: HTTP status code, or ``None`` if unavailable.
+            body: Raw response body (truncated in the message).
+            endpoint: The SaFE endpoint that produced the error.
+        """
         # Truncate body to keep the agent's stderr legible.
         snippet = body[:500] + ("..." if len(body) > 500 else "")
         super().__init__(f"SaFE {endpoint} -> status={status} body={snippet}")

--- a/inference_optimizer/orchestrator/action_executors/_grid_runner.py
+++ b/inference_optimizer/orchestrator/action_executors/_grid_runner.py
@@ -81,6 +81,17 @@ def _resolve_magpie_python() -> str:
     validated and skipped to avoid ``ModuleNotFoundError`` at benchmark time.
     """
     def _can_import_magpie(py: str) -> bool:
+        """Whether an interpreter can import Magpie and its ``yaml`` dep.
+
+        Probes both ``Magpie`` and ``yaml`` so interpreters that resolve
+        Magpie via a ``.pth`` but lack PyYAML are rejected.
+
+        Args:
+            py: Path to the candidate Python interpreter.
+
+        Returns:
+            ``True`` if both imports succeed in the interpreter.
+        """
         # Probe Magpie AND its top-level runtime dep ``yaml``: an editable
         # install puts Magpie on sys.path via a .pth regardless of whether
         # the interpreter has PyYAML, so ``import Magpie`` alone can succeed
@@ -454,6 +465,16 @@ class GridVariant:
         *,
         extra_sglang_args: str | None = None,
     ) -> None:
+        """Initialize a grid variant descriptor.
+
+        Args:
+            name: Variant name.
+            extra_server_args: Extra server CLI args for this variant.
+            extra_envs: Extra environment variables for this variant.
+            note: Optional reason/category note.
+            extra_sglang_args: Deprecated alias for ``extra_server_args``;
+                routed into the canonical attribute with a warning.
+        """
         # Back-compat alias for the historical ``extra_sglang_args`` kwarg;
         # routed into the canonical attribute with a DeprecationWarning.
         if extra_sglang_args is not None:

--- a/inference_optimizer/orchestrator/action_executors/_magpie_patcher.py
+++ b/inference_optimizer/orchestrator/action_executors/_magpie_patcher.py
@@ -427,6 +427,12 @@ class MagpiePatchStatus:
 
     @property
     def ok(self) -> bool:
+        """Whether the patch result is fully successful.
+
+        Returns:
+            ``True`` only when both the atomic write and remote-trust
+            checks succeeded.
+        """
         return self.atomic_ok and self.remote_trust_ok
 
     @property

--- a/inference_optimizer/orchestrator/action_executors/_robustness_pulse.py
+++ b/inference_optimizer/orchestrator/action_executors/_robustness_pulse.py
@@ -31,6 +31,14 @@ _OFF_VALUES = frozenset({"0", "false", "no", "off", ""})
 
 
 def _enabled() -> bool:
+    """Whether the robustness pulse should run.
+
+    Disabled under pytest (the pulse spawns a real subprocess that
+    bypasses test mocks) and via ``HYPERLOOM_GRID_ROBUSTNESS_PULSE``.
+
+    Returns:
+        ``True`` if the pulse is enabled in the current environment.
+    """
     # Disable inside pytest — the pulse spawns a real subprocess that bypasses
     # test mocks. Mirrors ``_run_magpie``'s guard.
     if os.environ.get("PYTEST_CURRENT_TEST"):

--- a/inference_optimizer/orchestrator/action_executors/_subprocess_kill.py
+++ b/inference_optimizer/orchestrator/action_executors/_subprocess_kill.py
@@ -201,6 +201,12 @@ class _StreamCapture:
     """Capture child output while mirroring each line to the parent stream."""
 
     def __init__(self, proc: subprocess.Popen, *, text: bool) -> None:
+        """Set up capture/mirror threads for a child's stdout and stderr.
+
+        Args:
+            proc: The child process whose pipes should be captured.
+            text: Whether the pipes are in text (``str``) or bytes mode.
+        """
         self._text = text
         self._stdout_chunks: list[str | bytes] = []
         self._stderr_chunks: list[str | bytes] = []
@@ -219,10 +225,20 @@ class _StreamCapture:
             ))
 
     def start(self) -> None:
+        """Start the capture threads."""
         for thread in self._threads:
             thread.start()
 
     def finish(self, timeout: float = 2.0) -> tuple[str | bytes, str | bytes]:
+        """Join the capture threads and return the captured output.
+
+        Args:
+            timeout: Per-thread join timeout in seconds.
+
+        Returns:
+            A ``(stdout, stderr)`` tuple of the captured streams (``str`` or
+            ``bytes`` depending on the capture mode).
+        """
         for thread in self._threads:
             thread.join(timeout=timeout)
         empty: str | bytes = "" if self._text else b""
@@ -232,9 +248,24 @@ class _StreamCapture:
         )
 
     def _join(self, chunks: list[str | bytes]) -> str | bytes:
+        """Concatenate captured chunks using the appropriate empty separator.
+
+        Args:
+            chunks: Captured stdout or stderr chunks.
+
+        Returns:
+            The joined ``str`` or ``bytes`` output.
+        """
         return "".join(chunks) if self._text else b"".join(chunks)  # type: ignore[arg-type,return-value]
 
     def _pump(self, pipe, chunks: list[str | bytes], mirror) -> None:
+        """Read a pipe line-by-line, capturing and mirroring each line.
+
+        Args:
+            pipe: The child pipe to read from.
+            chunks: List that read chunks are appended to.
+            mirror: Parent stream the chunks are echoed to.
+        """
         try:
             while True:
                 chunk = pipe.readline()
@@ -249,6 +280,12 @@ class _StreamCapture:
                 pass
 
     def _mirror(self, chunk: str | bytes, mirror) -> None:
+        """Echo a captured chunk to the parent stream, ignoring errors.
+
+        Args:
+            chunk: The captured ``str``/``bytes`` chunk.
+            mirror: Parent stream to write to.
+        """
         try:
             if isinstance(chunk, bytes):
                 stream = getattr(mirror, "buffer", mirror)
@@ -466,6 +503,13 @@ class _ServerDeadDetected(Exception):
     def __init__(
         self, *, marker: str, grace_sec: float, elapsed_sec: float,
     ) -> None:
+        """Build the error message describing the hung-after-death condition.
+
+        Args:
+            marker: Log marker that indicated the server init died.
+            grace_sec: Grace period the parent was allowed after the marker.
+            elapsed_sec: Actual wall-clock elapsed at trip time.
+        """
         super().__init__(
             f"server init died (marker={marker!r}) and parent hung past "
             f"grace {grace_sec:.1f}s (elapsed={elapsed_sec:.1f}s)"

--- a/inference_optimizer/orchestrator/action_executors/baseline.py
+++ b/inference_optimizer/orchestrator/action_executors/baseline.py
@@ -759,6 +759,13 @@ class BaselineExecutor:
 
     @staticmethod
     def _double_run_enabled() -> bool:
+        """Whether baseline double-run is enabled.
+
+        Controlled by ``INFERENCE_OPTIMIZER_BASELINE_DOUBLE_RUN``.
+
+        Returns:
+            ``True`` unless the env var is set to a falsey value.
+        """
         return os.environ.get(
             "INFERENCE_OPTIMIZER_BASELINE_DOUBLE_RUN", "1",
         ).strip().lower() not in ("0", "false", "no", "")

--- a/inference_optimizer/orchestrator/action_executors/conc_sweep.py
+++ b/inference_optimizer/orchestrator/action_executors/conc_sweep.py
@@ -33,6 +33,15 @@ class ConcSweepExecutor:
     """ActionRunner for ``conc_sweep``. See module docstring."""
 
     async def __call__(self, ctx) -> dict[str, Any]:
+        """Run the concurrency sweep action for the given context.
+
+        Args:
+            ctx: Action context; ``ctx.extra['session_dir']`` is required.
+
+        Returns:
+            A result dict with a ``status`` field (and error metadata on
+            failure, such as a missing ``session_dir``).
+        """
         extra = getattr(ctx, "extra", None) or {}
         session_dir_str = str(extra.get("session_dir") or "").strip()
         if not session_dir_str:

--- a/inference_optimizer/orchestrator/action_executors/profile.py
+++ b/inference_optimizer/orchestrator/action_executors/profile.py
@@ -580,6 +580,18 @@ class ProfileExecutor(BaselineExecutor):
         return None
 
     async def __call__(self, ctx) -> dict[str, Any]:
+        """Run the profiling action for the given context.
+
+        Launches a profiling run (sglang/vllm or the Magpie atom path),
+        merging the current-best server args with caller params, and
+        returns the captured trace artifacts.
+
+        Args:
+            ctx: Action context carrying the task and its parameters.
+
+        Returns:
+            A result dict describing the profiling outcome and artifacts.
+        """
         # atom: the Magpie atom wrapper bridges PROFILE=1 to atom's
         # --torch-profiler-dir; atom writes standard *.pt.trace.json.gz that
         # _candidate_trace_dirs + TraceLens consume unchanged, so the executor

--- a/inference_optimizer/orchestrator/action_executors/report.py
+++ b/inference_optimizer/orchestrator/action_executors/report.py
@@ -705,6 +705,16 @@ class ReportExecutor:
         self.max_highlights = int(max_highlights)
 
     async def __call__(self, ctx) -> dict[str, Any]:
+        """Run the report-generation action for the given context.
+
+        Args:
+            ctx: Action context; used to resolve the session directory
+                and report parameters.
+
+        Returns:
+            A result dict with a ``status`` field, failing when the
+            session directory cannot be resolved.
+        """
         session_dir = self._resolve_session_dir(ctx)
         if session_dir is None:
             return {"status": "failed",

--- a/inference_optimizer/orchestrator/action_executors/roofline.py
+++ b/inference_optimizer/orchestrator/action_executors/roofline.py
@@ -166,6 +166,17 @@ class RooflineExecutor:
         self.shared_state = shared_state
 
     async def __call__(self, ctx: RunnerContext) -> dict[str, Any]:
+        """Run the roofline action for the given context.
+
+        Performs a profile sub-step and feeds the resulting trace into
+        TraceLens analysis to produce a roofline characterization.
+
+        Args:
+            ctx: Runner context carrying the task and session metadata.
+
+        Returns:
+            A result dict describing the roofline outcome and artifacts.
+        """
         # atom: the profile sub-step produces *.pt.trace.json.gz that
         # TraceLens consumes unchanged, so this falls through to the
         # sglang/vllm path. Lazy imports keep shell-out/yaml off module load.

--- a/inference_optimizer/orchestrator/action_executors/sweep.py
+++ b/inference_optimizer/orchestrator/action_executors/sweep.py
@@ -189,6 +189,17 @@ class SweepExecutor:
         default_num_prompts_factor: int = DEFAULT_NUM_PROMPTS_FACTOR,
         variant_timeout_sec: int = 2400,
     ):
+        """Initialize the sweep executor with default sweep parameters.
+
+        Args:
+            default_config_path: Benchmark config path; ``None`` resolves
+                from ``$FRAMEWORK`` at call time.
+            session_dir: Default session directory for outputs.
+            default_conc_values: Default concurrency values to sweep.
+            default_isl_osl_configs: Default input/output length configs.
+            default_num_prompts_factor: Multiplier for prompt count.
+            variant_timeout_sec: Per-variant timeout in seconds.
+        """
         # None = resolve at call time from $FRAMEWORK; explicit fixture wins.
         self.default_config_path = (
             Path(default_config_path) if default_config_path else None

--- a/inference_optimizer/orchestrator/backends/claude.py
+++ b/inference_optimizer/orchestrator/backends/claude.py
@@ -238,6 +238,20 @@ class ClaudeBackend:
         max_turns: int = 1,
         allow_no_intent: bool = False,
     ) -> BackendTurnResult:
+        """Run a single backend turn against Claude and parse the result.
+
+        Args:
+            prompt: User prompt for this turn.
+            system_prompt: Optional system prompt override.
+            tools: Tool names to enable for the turn.
+            max_turns: Maximum agent turns; falls back to the backend
+                default when falsy.
+            allow_no_intent: When ``True``, relax the guard that requires
+                an ``emit_intent`` (e.g. for summary/checkpoint turns).
+
+        Returns:
+            The parsed :class:`BackendTurnResult` for the turn.
+        """
         # ``allow_no_intent`` (plan Step 4): a summary/checkpoint turn asks
         # for plain-text instead of emit_intent, so relax the no-intent guard.
         full_prompt = self._compose_prompt(prompt)
@@ -386,6 +400,11 @@ class ClaudeBackend:
 
     @property
     def has_context_tools(self) -> bool:
+        """Whether the context-tools MCP server is configured.
+
+        Returns:
+            ``True`` if a context-server config was set up successfully.
+        """
         return self._context_server_config is not None
 
     def reset_conversation(self) -> None:

--- a/inference_optimizer/orchestrator/backends/mcp_context_tools.py
+++ b/inference_optimizer/orchestrator/backends/mcp_context_tools.py
@@ -22,6 +22,14 @@ MCP_SERVER_NAME = "inference_optimizer_context"
 
 
 def _qualified(tool_name: str) -> str:
+    """Return the fully-qualified MCP tool name.
+
+    Args:
+        tool_name: Bare tool name.
+
+    Returns:
+        The name prefixed with ``mcp__<server>__``.
+    """
     return f"mcp__{MCP_SERVER_NAME}__{tool_name}"
 
 
@@ -45,6 +53,16 @@ class ContextProvider:
     action_runner: Callable[[str, dict[str, Any]], str] | None = None
 
     def _safe(self, fn: Callable[[], str], label: str) -> str:
+        """Invoke a projection callable, never letting it crash the reactor.
+
+        Args:
+            fn: Zero-argument projection returning a summary string.
+            label: Short name used in log and fallback messages.
+
+        Returns:
+            The projection output, or a short error/empty marker string when
+            ``fn`` raises or returns nothing usable.
+        """
         try:
             out = fn()
         except Exception as exc:  # noqa: BLE001 — never crash a pull
@@ -54,28 +72,43 @@ class ContextProvider:
 
     # Projections backed by SharedState.to_*_summary.
     def mission_status(self) -> str:
+        """Return the mission-status summary projection."""
         return self._safe(self.shared_state.to_mission_summary, "mission_status")
 
     def shared_state_summary(self) -> str:
+        """Return the prompt-oriented shared-state summary projection."""
         return self._safe(self.shared_state.to_prompt_summary, "shared_state")
 
     def gaps(self) -> str:
+        """Return the open-gaps summary projection."""
         return self._safe(self.shared_state.to_gaps_summary, "gaps")
 
     def warm_start(self) -> str:
+        """Return the warm-start summary projection."""
         return self._safe(self.shared_state.to_warm_start_summary, "warm_start")
 
     def proposal_scores(self) -> str:
+        """Return the proposal-scores summary projection."""
         return self._safe(
             self.shared_state.to_proposal_scores_summary, "proposal_scores"
         )
 
     def intervention_mix(self) -> str:
+        """Return the intervention-mix summary projection."""
         return self._safe(
             self.shared_state.to_intervention_mix_summary, "intervention_mix"
         )
 
     def why_denied(self, top_k: int = 6) -> str:
+        """Return a summary of recent policy denials.
+
+        Args:
+            top_k: Maximum number of denial entries to include.
+
+        Returns:
+            The denial summary from the denial reader when wired, otherwise the
+            shared-state policy-denial projection.
+        """
         if self.denial_reader is not None:
             return self._safe(lambda: self.denial_reader(top_k), "why_denied")
         return self._safe(
@@ -84,16 +117,38 @@ class ContextProvider:
         )
 
     def analysis_md(self) -> str:
+        """Return the current ``analysis.md`` contents.
+
+        Returns:
+            The analysis text, or a not-wired marker when no reader is bound.
+        """
         if self.analysis_reader is None:
             return "(analysis.md reader not wired)"
         return self._safe(self.analysis_reader, "analysis_md")
 
     def inbox(self, since_seq: int = 0) -> str:
+        """Return inbox messages newer than a sequence number.
+
+        Args:
+            since_seq: Only messages with a sequence greater than this are
+                returned.
+
+        Returns:
+            The inbox text, or a not-wired marker when no reader is bound.
+        """
         if self.inbox_reader is None:
             return "(inbox reader not wired)"
         return self._safe(lambda: self.inbox_reader(since_seq), "inbox")
 
     def recent_outcomes(self, top_k: int = 8) -> str:
+        """Return a summary of recent action outcomes.
+
+        Args:
+            top_k: Maximum number of recent outcomes to include.
+
+        Returns:
+            The outcomes summary, or a not-wired marker when no reader is bound.
+        """
         if self.recent_outcomes_reader is None:
             return "(recent outcomes reader not wired)"
         return self._safe(
@@ -103,6 +158,16 @@ class ContextProvider:
     def run_action_now(
         self, action_name: str = "", params: dict[str, Any] | None = None,
     ) -> str:
+        """Run a whitelisted lane-light action inline.
+
+        Args:
+            action_name: Name of the action to run.
+            params: Optional action parameters.
+
+        Returns:
+            The action result string, or a not-wired marker when no action
+            runner is bound.
+        """
         if self.action_runner is None:
             return "(run_action_now not wired)"
         return self._safe(
@@ -240,6 +305,16 @@ CONTEXT_TOOL_QUALIFIED_NAMES: tuple[str, ...] = tuple(
 
 
 def _resolve_sdk(sdk_module: Any | None) -> Any | None:
+    """Resolve the Claude Agent SDK module.
+
+    Args:
+        sdk_module: Explicit module to use (for tests), or ``None`` to import
+            the real SDK.
+
+    Returns:
+        The provided or imported SDK module, or ``None`` when it is not
+        installed.
+    """
     if sdk_module is not None:
         return sdk_module
     try:
@@ -254,6 +329,15 @@ def _make_handler(
     """Build an async MCP handler returning the provider method's string."""
 
     async def _handler(args: dict[str, Any]) -> dict[str, Any]:
+        """Invoke the bound provider method and wrap its string result.
+
+        Args:
+            args: Tool call arguments; recognized keys (``top_k``,
+                ``since_seq``, ``action_name``, ``params``) are forwarded.
+
+        Returns:
+            An MCP tool result dict carrying the provider method's output.
+        """
         method = getattr(provider, method_name)
         kwargs: dict[str, Any] = {}
         if isinstance(args, dict):

--- a/inference_optimizer/orchestrator/conc_sweep.py
+++ b/inference_optimizer/orchestrator/conc_sweep.py
@@ -297,6 +297,15 @@ def _build_roofline_ceiling(
             t_peak = t_mem
 
         def _mbu_pct(measured: Any) -> float | None:
+            """Express a measured throughput as a percent of peak.
+
+            Args:
+                measured: Measured throughput value.
+
+            Returns:
+                The ratio to ``t_peak`` as a percentage, or ``None`` when
+                inputs are non-positive or invalid.
+            """
             if not isinstance(measured, (int, float)) or measured <= 0:
                 return None
             if t_peak <= 0:

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -1067,12 +1067,24 @@ class Coordinator:
             )
 
     def _kernel_enabled(self) -> bool:
+        """Whether the kernel role is registered and enabled.
+
+        Returns:
+            ``True`` if the kernel role exists and the persisted
+            ``kernel_enabled`` flag is set.
+        """
         # Mirror persisted kernel_enabled flag; --no-kernel removes the kernel role.
         return "kernel" in self.role_registry and bool(
             getattr(self.shared_state, "kernel_enabled", True)
         )
 
     def _explore_enabled(self) -> bool:
+        """Whether the EXPLORE phase is enabled for this run.
+
+        Returns:
+            ``True`` unless ``--no-explore`` disabled it (collapsing to
+            KERNEL/SWEEP).
+        """
         # Mirror persisted explore_enabled flag; --no-explore collapses to KERNEL/SWEEP. EXPLORE is a phase, not a role.
         return bool(getattr(self.shared_state, "explore_enabled", True))
 
@@ -4335,6 +4347,15 @@ class Coordinator:
         return "\n".join(sections)
 
     async def _load_system_prompt(self, agent_name: str) -> str:
+        """Load the system prompt for an agent, honoring overrides.
+
+        Args:
+            agent_name: Name of the agent/role whose prompt to load.
+
+        Returns:
+            The override prompt if configured, the role's prompt file
+            contents, or a placeholder string when none exists.
+        """
         # Demo/test override via self.system_prompt_overrides[agent_name].
         override = getattr(self, "system_prompt_overrides", {}).get(agent_name)
         if override is not None:
@@ -6606,6 +6627,15 @@ class Coordinator:
         ))
 
     async def _handle_force_dispatch(self, source: str, intent: Intent) -> None:
+        """Handle a ``force_dispatch`` intent by emitting an event.
+
+        Currently a P0-3 stub: it broadcasts a ``force_dispatch`` event;
+        real dispatcher reordering arrives in P0-5 with the priority queue.
+
+        Args:
+            source: Identifier of the intent's originating agent.
+            intent: The ``force_dispatch`` intent carrying ``task_id``.
+        """
         # P0-3 stub: emit an event; real dispatcher reordering lands in P0-5 with the priority queue.
         await self.bus.append_and_seq(Message.new(
             source, "*", "event",

--- a/inference_optimizer/orchestrator/coordinator_helpers.py
+++ b/inference_optimizer/orchestrator/coordinator_helpers.py
@@ -44,6 +44,16 @@ def _infer_model_class_from_config(model_path: str) -> str:
     text = " ".join(text_parts)
 
     def _positive_int(*keys: str) -> bool:
+        """Whether any of the given payload keys holds a positive integer.
+
+        Booleans are explicitly ignored (they are not treated as ints).
+
+        Args:
+            *keys: Payload keys to check.
+
+        Returns:
+            ``True`` if at least one key parses to an integer > 0.
+        """
         for key in keys:
             val = payload.get(key)
             if isinstance(val, bool):

--- a/inference_optimizer/orchestrator/gpu_pool.py
+++ b/inference_optimizer/orchestrator/gpu_pool.py
@@ -20,10 +20,20 @@ DEFAULT_GPU_LEASE_TTL_SEC = 1800
 
 
 def _now_iso() -> str:
+    """Return the current UTC time as a microsecond ISO-8601 string."""
     return datetime.now(timezone.utc).isoformat(timespec="microseconds")
 
 
 def _parse_gpu_list(raw: str) -> list[int]:
+    """Parse a comma/semicolon-separated GPU id list.
+
+    Args:
+        raw: Raw string of GPU ids (``,`` or ``;`` separated).
+
+    Returns:
+        Unique non-negative GPU ids in first-seen order; malformed entries are
+        skipped.
+    """
     out: list[int] = []
     for part in (raw or "").replace(";", ",").split(","):
         p = part.strip()
@@ -73,11 +83,19 @@ class SpecialistGpuPool:
         *,
         gpu_ids: list[int] | tuple[int, ...],
     ):
+        """Initialize the pool over a fixed set of GPU ids.
+
+        Args:
+            db: SQLite connection backing the lease table.
+            gpu_ids: GPU ids managed by this pool; duplicates and negatives are
+                dropped.
+        """
         self.db = db
         self.gpu_ids = tuple(dict.fromkeys(int(g) for g in gpu_ids if int(g) >= 0))
 
     @property
     def capacity(self) -> int:
+        """Return the number of GPUs the pool manages."""
         return len(self.gpu_ids)
 
     async def try_acquire(
@@ -133,6 +151,11 @@ class SpecialistGpuPool:
         )
 
     async def release(self, lease: GpuLease | None) -> None:
+        """Release the GPUs held by a lease.
+
+        Args:
+            lease: The lease to release; ``None`` or an empty lease is a no-op.
+        """
         if lease is None or not lease.gpu_ids:
             return
         placeholders = ",".join("?" * len(lease.gpu_ids))
@@ -145,6 +168,11 @@ class SpecialistGpuPool:
             )
 
     async def heartbeat(self, lease: GpuLease | None) -> None:
+        """Refresh the heartbeat timestamp for a lease's GPUs.
+
+        Args:
+            lease: The lease to refresh; ``None`` or an empty lease is a no-op.
+        """
         if lease is None or not lease.gpu_ids:
             return
         now_iso = _now_iso()

--- a/inference_optimizer/orchestrator/kernel_attempt_summary.py
+++ b/inference_optimizer/orchestrator/kernel_attempt_summary.py
@@ -553,6 +553,16 @@ def _render_unattempted_row(
     reason_code: str,
     reason_detail: str,
 ) -> dict[str, Any]:
+    """Build a summary row for a kernel that was not attempted.
+
+    Args:
+        top_entry: The kernel's roofline/top-list entry.
+        reason_code: Machine-readable reason the kernel was skipped.
+        reason_detail: Human-readable explanation of the skip.
+
+    Returns:
+        A row dict tagged with the unattempted category and reason.
+    """
     return {
         "kernel_id": str(top_entry.get("kernel_id") or ""),
         "kernel_name": str(top_entry.get("name") or ""),
@@ -580,6 +590,22 @@ def _render_attempted_row(
     session_dir: Path,
     last_kernel_opt: dict[str, Any] | None,
 ) -> dict[str, Any]:
+    """Build a summary row for a kernel that was attempted.
+
+    Loads the backend ladder and kernel result, then assembles a row
+    capturing the attempt outcome and verification details.
+
+    Args:
+        top_entry: The kernel's roofline/top-list entry.
+        attempt: The recorded attempt metadata.
+        category: Outcome category for the row.
+        results_dir: Directory holding per-kernel result artifacts.
+        session_dir: Session directory for the run.
+        last_kernel_opt: Most recent kernel-optimization record, if any.
+
+    Returns:
+        A row dict describing the attempt and its results.
+    """
     kid = str(top_entry.get("kernel_id") or attempt.get("kernel_id") or "")
     ladder, ladder_unavailable = _load_backend_ladder(results_dir, kid)
     kernel_result, _ = _load_kernel_result(results_dir, kid)
@@ -814,6 +840,14 @@ def _find_highest_impact_missed(
 
 
 def _to_float(v: Any) -> float | None:
+    """Coerce a value to a 4-decimal float, or ``None`` on failure.
+
+    Args:
+        v: Arbitrary value to convert.
+
+    Returns:
+        The rounded float, or ``None`` if it cannot be parsed.
+    """
     if v is None:
         return None
     try:

--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -2369,6 +2369,14 @@ def _record_after_kernel_opt_rocprof_status(
 
 
 def _rocprof_timeout_sec() -> int:
+    """Resolve the rocprof roofline subprocess timeout in seconds.
+
+    Reads ``HYPERLOOM_ROCPROF_ROOFLINE_TIMEOUT_SEC`` and clamps it to a
+    minimum of 60 seconds.
+
+    Returns:
+        The timeout in seconds (defaults to 1800).
+    """
     try:
         return max(60, int(os.environ.get("HYPERLOOM_ROCPROF_ROOFLINE_TIMEOUT_SEC", "1800")))
     except (TypeError, ValueError):
@@ -2376,6 +2384,17 @@ def _rocprof_timeout_sec() -> int:
 
 
 def _rocprof_profile_command(test_command: str) -> str:
+    """Rewrite a test command to run in rocprof profiling mode.
+
+    Swaps a ``--correctness`` flag for ``--profile`` only when the command
+    targets a recognized unittest harness; otherwise returns it unchanged.
+
+    Args:
+        test_command: The original kernel test command.
+
+    Returns:
+        The (possibly rewritten) command string.
+    """
     if "--correctness" not in test_command:
         return test_command
     if "/unittest/harness_" not in test_command and " harness_" not in test_command:
@@ -2536,6 +2555,20 @@ def _schedule_after_kernel_opt_rocprof(
     session_dir: Path,
     log: logging.Logger,
 ) -> dict[str, Any]:
+    """Schedule a background rocprof roofline run after a kernel integrate.
+
+    Honors ``HYPERLOOM_ROCPROF_ROOFLINE`` to disable profiling; otherwise
+    records a ``scheduled`` status and launches the run as a tracked
+    background task.
+
+    Args:
+        kernel_id: Identifier of the integrated kernel.
+        session_dir: Session directory for status sidecars.
+        log: Logger for status and error reporting.
+
+    Returns:
+        A status dict indicating whether the run was scheduled or skipped.
+    """
     rocprof_env = os.environ.get("HYPERLOOM_ROCPROF_ROOFLINE", "1").strip().lower()
     if rocprof_env in {"0", "false", "no", "off"}:
         _record_after_kernel_opt_rocprof_status(
@@ -2562,6 +2595,11 @@ def _schedule_after_kernel_opt_rocprof(
     _BACKGROUND_ROCPROF_TASKS.add(task)
 
     def _done(done_task: asyncio.Task[Any]) -> None:
+        """Completion callback that drops the task and logs failures.
+
+        Args:
+            done_task: The finished background rocprof task.
+        """
         _BACKGROUND_ROCPROF_TASKS.discard(done_task)
         try:
             done_task.result()
@@ -2664,6 +2702,11 @@ async def integrate_handler(
         os.environ["AITER_REBUILD"] = "1"
 
     def _restore_aiter_rebuild_env() -> None:
+        """Restore the ``AITER_REBUILD`` env var to its prior value.
+
+        No-op unless a forced rebuild was applied for this re-baseline;
+        otherwise pops or restores the original value (GH #458).
+        """
         if not force_aiter_rebuild:
             return
         if _prev_aiter_rebuild is None:

--- a/inference_optimizer/orchestrator/knowledge_plane.py
+++ b/inference_optimizer/orchestrator/knowledge_plane.py
@@ -188,6 +188,14 @@ class KnowledgePlane:
 
     @property
     def cortex_enabled(self) -> bool:
+        """Whether Cortex is enabled (always ``False``).
+
+        Backwards-compatible shim; the knowledge plane no longer wires
+        Cortex.
+
+        Returns:
+            ``False``.
+        """
         # Backwards-compatible shim; KnowledgePlane no longer wires Cortex.
         return False
 

--- a/inference_optimizer/orchestrator/objective.py
+++ b/inference_optimizer/orchestrator/objective.py
@@ -142,6 +142,15 @@ class TargetGainObjective(Objective):
         return state.cumulative_gain >= self.target_gain_pct
 
     def pressure_input(self, state: "SharedState") -> float:
+        """Compute normalized progress toward the gain target.
+
+        Args:
+            state: Current shared state.
+
+        Returns:
+            Progress in ``[0.0, 1.0]``; stays ``0.0`` until the baseline
+            throughput has been measured.
+        """
         # Stays 0 until baseline finishes.
         if state.baseline_tput <= 0:
             return 0.0

--- a/inference_optimizer/orchestrator/orchestration_memory.py
+++ b/inference_optimizer/orchestrator/orchestration_memory.py
@@ -29,6 +29,7 @@ _MEMORY_KEYS: tuple[str, ...] = (
 
 
 def _now_iso() -> str:
+    """Return the current UTC time as a second-resolution ISO-8601 string."""
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
 
 
@@ -50,6 +51,18 @@ class CheckpointPolicy:
         chars_since_last: int,
         phase_changed: bool,
     ) -> bool:
+        """Decide whether a checkpoint is due under this policy.
+
+        Args:
+            ticks_since_last: Ticks elapsed since the last checkpoint.
+            minutes_since_last: Minutes elapsed since the last checkpoint.
+            chars_since_last: Characters accumulated since the last checkpoint.
+            phase_changed: Whether a phase boundary was just crossed.
+
+        Returns:
+            ``True`` when any enabled trigger (phase boundary, tick, time, or
+            char budget) is met.
+        """
         if phase_changed and self.on_phase_boundary:
             return True
         if self.every_ticks > 0 and ticks_since_last >= self.every_ticks:
@@ -118,6 +131,16 @@ def parse_checkpoint_reply(raw_text: str) -> dict[str, Any]:
 
 
 def _extract_json_object(text: str) -> dict[str, Any] | None:
+    """Extract the first JSON object embedded in free-form text.
+
+    Args:
+        text: Text that may contain a fenced ```json``` block or a bare
+            ``{ ... }`` span.
+
+    Returns:
+        The parsed JSON object, or ``None`` when none is found or it does not
+        parse to a dict.
+    """
     if not text:
         return None
     # Prefer a fenced ```json ... ``` block.
@@ -184,6 +207,12 @@ def render_memory_for_seed(memory: dict[str, Any]) -> str:
         lines.append(f"current_plan: {plan}")
 
     def _block(label: str, key: str) -> None:
+        """Append a labeled bullet block for a memory list field.
+
+        Args:
+            label: Section heading to render.
+            key: Memory key whose list items are rendered as bullets.
+        """
         items = memory.get(key) or []
         if items:
             lines.append(f"{label}:")
@@ -212,9 +241,21 @@ class CheckpointTracker:
     last_phase: str = ""
 
     def chars_add(self, n: int) -> None:
+        """Accumulate characters produced since the last checkpoint.
+
+        Args:
+            n: Number of characters to add (negatives are clamped to 0).
+        """
         self.chars_since_last += max(0, int(n))
 
     def reset(self, *, tick: int, minute_mark: float, phase: str) -> None:
+        """Reset the tracker after a checkpoint lands.
+
+        Args:
+            tick: Current tick to record as the last checkpoint tick.
+            minute_mark: Current minute mark to record.
+            phase: Current phase to record.
+        """
         self.last_tick = int(tick)
         self.last_minute_mark = float(minute_mark)
         self.chars_since_last = 0

--- a/inference_optimizer/orchestrator/phase_state.py
+++ b/inference_optimizer/orchestrator/phase_state.py
@@ -839,6 +839,19 @@ def exit_terminal_prelude(state: Any) -> tuple[str, dict[str, Any]] | None:
 
 
 def abort_prelude(state: Any) -> tuple[str, dict[str, Any]] | None:
+    """Detect a PRELUDE-aborting stop reason on the state.
+
+    Recognizes terminal stop reasons (e.g. ``cortex_t0_failed``,
+    ``time_exhausted_during_prelude``) so phase history captures the
+    boundary.
+
+    Args:
+        state: Object exposing a ``stop_reason`` attribute.
+
+    Returns:
+        A ``(reason, metadata)`` tuple when an abort reason is present,
+        otherwise ``None``.
+    """
     # Treat cortex_t0_failed / time_exhausted_during_prelude etc. as a PRELUDE
     # abort so phase_history captures the boundary.
     sr = (getattr(state, "stop_reason", "") or "").strip()

--- a/inference_optimizer/orchestrator/policy.py
+++ b/inference_optimizer/orchestrator/policy.py
@@ -473,6 +473,12 @@ class PolicyGate:
     strict_phase: bool = False
 
     def __post_init__(self) -> None:  # noqa: D401 — dataclass hook
+        """Apply environment overrides for strict-mode flags.
+
+        Lets ``INFERENCE_OPTIMIZER_STRICT_PATHS`` and
+        ``INFERENCE_OPTIMIZER_STRICT_PHASE`` enable strict behavior
+        without threading a constructor argument through every caller.
+        """
         # Allow env to enable strict mode without threading a constructor arg through every caller.
         import os as _os
         if not self.strict_paths and _os.environ.get(
@@ -1874,6 +1880,18 @@ class PolicyGate:
     def _validate_robustness_only(
         self, role: "AgentRole", intent_type: IntentType, payload: dict[str, Any]
     ) -> None:
+        """Enforce that only allowed roles emit robustness-only intents.
+
+        Args:
+            role: The agent role attempting to emit the intent.
+            intent_type: The intent being validated.
+            payload: The intent payload (checked for required fields).
+
+        Raises:
+            PolicyDenied: If the role is not permitted to emit the intent,
+                or a required payload field (e.g. ``family`` for
+                ``PRUNE_BRANCH``) is missing.
+        """
         # Per-intent source override takes precedence; default is robustness-only.
         allowed_sources = _ROBUSTNESS_ONLY_INTENT_SOURCES.get(
             intent_type, ROBUSTNESS_ONLY_SOURCE_ALLOWLIST,

--- a/inference_optimizer/orchestrator/proposal_scorer.py
+++ b/inference_optimizer/orchestrator/proposal_scorer.py
@@ -95,6 +95,15 @@ def _extract_scores_json(text: str) -> dict[str, Any] | None:
 
 
 def _clip(value: Any, *, limit: int = _MAX_FIELD_CHARS) -> str:
+    """Stringify a value and truncate it to a maximum length.
+
+    Args:
+        value: Value to stringify (``None`` becomes an empty string).
+        limit: Maximum number of characters to keep.
+
+    Returns:
+        The string, suffixed with an ellipsis if it was truncated.
+    """
     s = "" if value is None else str(value)
     return s if len(s) <= limit else (s[:limit] + "…")
 
@@ -161,6 +170,13 @@ class ProposalScorer:
     _client: Any = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
+        """Normalize the model list and optionally eager-build the client.
+
+        Strips and de-blanks the configured model names. If a
+        ``client_factory`` is provided the client is built immediately;
+        otherwise it is constructed lazily on first use so an
+        unconfigured environment degrades per-call rather than at boot.
+        """
         self.models = tuple(
             m for m in (str(x).strip() for x in (self.models or ())) if m
         )
@@ -171,6 +187,15 @@ class ProposalScorer:
         self._client = None
 
     def _ensure_client(self) -> Any:
+        """Return the cached client, constructing one on first use.
+
+        Returns:
+            The OpenAI-compatible async client.
+
+        Raises:
+            RuntimeError: If the ``openai`` SDK is missing or no API key
+                is configured in the environment.
+        """
         if self._client is not None:
             return self._client
         try:

--- a/inference_optimizer/orchestrator/quantization_schemes.py
+++ b/inference_optimizer/orchestrator/quantization_schemes.py
@@ -116,6 +116,15 @@ def _join_clauses(items: Sequence[str]) -> str:
 
 
 def _strategy_paragraph(cfg: QuantizationConfig) -> str:
+    """Render the quantization-strategy paragraph for a prompt.
+
+    Args:
+        cfg: Quantization configuration to describe.
+
+    Returns:
+        A prose paragraph covering the global scheme, layer overrides,
+        kv-cache handling, exclusions, and output directory.
+    """
     sentences = [f"Apply {cfg.global_scheme} as the global quantization scheme."]
     if cfg.layer_overrides:
         clauses = [
@@ -136,6 +145,15 @@ def _strategy_paragraph(cfg: QuantizationConfig) -> str:
 
 
 def _calibration_paragraph(cfg: QuantizationConfig) -> str | None:
+    """Render the calibration paragraph, composing only set fields.
+
+    Args:
+        cfg: Quantization configuration to describe.
+
+    Returns:
+        A calibration paragraph, or ``None`` when no calibration fields
+        are configured.
+    """
     if cfg.calib_dataset is None and cfg.num_calib_data is None and cfg.seq_len is None:
         return None
     # Compose only the parts that were set, e.g. "Calibrate with the pileval
@@ -151,6 +169,15 @@ def _calibration_paragraph(cfg: QuantizationConfig) -> str | None:
 
 
 def _evaluation_paragraph(cfg: QuantizationConfig) -> str | None:
+    """Render the evaluation paragraph describing the accuracy budget.
+
+    Args:
+        cfg: Quantization configuration to describe.
+
+    Returns:
+        An evaluation paragraph, or ``None`` when no acceptable eval gap
+        is configured.
+    """
     if cfg.acceptable_eval_gap is None:
         return None
     pct = f"{cfg.acceptable_eval_gap * 100:g}"

--- a/inference_optimizer/orchestrator/research_hints.py
+++ b/inference_optimizer/orchestrator/research_hints.py
@@ -74,6 +74,14 @@ def load_hints(session_dir: Path) -> list[dict[str, Any]]:
 
 
 def _render_md(hints: list[dict[str, Any]]) -> str:
+    """Render research hints as a Markdown document.
+
+    Args:
+        hints: Normalized hint records.
+
+    Returns:
+        Markdown text, with a placeholder note when there are no hints.
+    """
     lines = ["# Research Hints", ""]
     if not hints:
         lines += [
@@ -97,6 +105,12 @@ def _render_md(hints: list[dict[str, Any]]) -> str:
 
 
 def _atomic_write(path: Path, text: str) -> None:
+    """Write text to a file atomically via a temp file and rename.
+
+    Args:
+        path: Destination file path.
+        text: Text content to write.
+    """
     tmp = path.with_suffix(path.suffix + ".tmp")
     tmp.write_text(text, encoding="utf-8")
     os.replace(tmp, path)
@@ -112,6 +126,12 @@ def write_hints_skeleton(session_dir: Path) -> None:
 
 
 def _persist(session_dir: Path, hints: list[dict[str, Any]]) -> None:
+    """Persist hints to the session's JSON and Markdown artifacts.
+
+    Args:
+        session_dir: Session directory to write into.
+        hints: Hint records to serialize.
+    """
     sd = Path(session_dir)
     sd.mkdir(parents=True, exist_ok=True)
     try:
@@ -317,6 +337,14 @@ def full_gap_summary(
 
 
 def _to_num(value: Any) -> float | None:
+    """Coerce a value to ``float``, returning ``None`` on failure.
+
+    Args:
+        value: Arbitrary value to convert.
+
+    Returns:
+        The float value, or ``None`` if it cannot be parsed.
+    """
     try:
         return float(value)
     except (TypeError, ValueError):
@@ -338,6 +366,17 @@ _STOPWORDS: frozenset[str] = frozenset({
 
 
 def _tokens(text: str) -> set[str]:
+    """Tokenize text into a set of lowercase content words.
+
+    Splits on non-alphanumeric characters and drops short tokens and
+    stopwords so the remaining set is useful for overlap matching.
+
+    Args:
+        text: Free-form text to tokenize.
+
+    Returns:
+        Set of distinct content tokens (length >= 3, non-stopword).
+    """
     out: set[str] = set()
     for raw in re.split(r"[^a-z0-9]+", str(text).lower()):
         tok = raw.strip()

--- a/inference_optimizer/orchestrator/roofline_ceiling.py
+++ b/inference_optimizer/orchestrator/roofline_ceiling.py
@@ -156,11 +156,29 @@ def _read_baseline_yaml_benchmark(state: Any) -> dict[str, Any]:
 
 
 def _benchmark_envs(benchmark: dict[str, Any]) -> dict[str, Any]:
+    """Return the ``envs`` mapping from a benchmark record.
+
+    Args:
+        benchmark: Benchmark record.
+
+    Returns:
+        The ``envs`` dict, or ``{}`` when absent or not a dict.
+    """
     envs = benchmark.get("envs") or {}
     return envs if isinstance(envs, dict) else {}
 
 
 def _env_int(envs: dict[str, Any], key: str) -> int:
+    """Read a positive integer from an env mapping.
+
+    Args:
+        envs: Environment mapping.
+        key: Key to read.
+
+    Returns:
+        The parsed positive integer, or ``0`` when missing, non-positive, or
+        unparseable.
+    """
     raw = envs.get(key)
     if raw is None:
         return 0
@@ -172,6 +190,14 @@ def _env_int(envs: dict[str, Any], key: str) -> int:
 
 
 def _server_args_from_envs(envs: dict[str, Any]) -> str:
+    """Assemble server CLI args from recognized env keys.
+
+    Args:
+        envs: Environment mapping.
+
+    Returns:
+        A space-joined string of the non-empty server-arg env values.
+    """
     parts = [
         str(envs[k]).strip()
         for k in _RUNTIME_SERVER_ARG_ENV_KEYS
@@ -285,6 +311,15 @@ def resolve_runtime_workload(
     envs = _benchmark_envs(benchmark)
 
     def _state_int(name: str) -> int:
+        """Read a positive integer attribute from ``state``.
+
+        Args:
+            name: Attribute name to read.
+
+        Returns:
+            The positive integer value, or ``0`` when missing, non-positive, or
+            unparseable.
+        """
         try:
             parsed = int(getattr(state, name, 0) or 0)
             return parsed if parsed > 0 else 0
@@ -792,6 +827,14 @@ _EMPTY_BREAKDOWN = RooflineBreakdown(0.0, 0.0, 0.0, "unknown")
 
 
 def _activation_kv_dtype_bytes(meta: ModelMeta) -> float:
+    """Return the per-element byte size for activation/KV tensors.
+
+    Args:
+        meta: Model metadata.
+
+    Returns:
+        The dtype byte width used for activation and KV-cache sizing.
+    """
     return max(float(meta.weight_dtype_bytes or 2.0), 2.0)
 
 
@@ -1175,11 +1218,33 @@ def compute_roofline_from_perfmodel(
         linears.append(("lm_head", hidden, vocab, 1))
 
     def _roofline_time(fl: float, by: float) -> tuple[float, str, float, float]:
+        """Roofline time for one op given its FLOPs and byte traffic.
+
+        Args:
+            fl: Floating-point operations for the op.
+            by: Bytes moved for the op.
+
+        Returns:
+            A tuple ``(time, bound_kind, t_mem, t_cmp)`` where ``time`` is the
+            roofline max of compute and memory time and ``bound_kind`` is
+            ``"compute"`` or ``"memory"``.
+        """
         t_cmp = fl / f_peak if f_peak > 0 else 1e30
         t_mem = by / bw_bps if bw_bps > 0 else 1e30
         return max(t_cmp, t_mem), "compute" if t_cmp >= t_mem else "memory", t_mem, t_cmp
 
     def _forward(batch: int, s_q: int, s_kv: int) -> tuple[float, float, float, list[OpBreakdown]]:
+        """Roofline-model one forward pass for the given shapes.
+
+        Args:
+            batch: Batch size (concurrency).
+            s_q: Query sequence length.
+            s_kv: Key/value sequence length.
+
+        Returns:
+            A tuple ``(total_time, total_mem_time, total_cmp_time, ops)`` where
+            ``ops`` is the per-op breakdown list.
+        """
         total_t = 0.0
         total_mem_t = 0.0
         total_cmp_t = 0.0

--- a/inference_optimizer/orchestrator/shared_state.py
+++ b/inference_optimizer/orchestrator/shared_state.py
@@ -560,6 +560,19 @@ class SharedState:
 
     @classmethod
     def from_dict(cls, raw: dict[str, Any]) -> "SharedState":
+        """Construct a :class:`SharedState` from a raw mapping, migrating it.
+
+        Acts as the unified migration entry point: an absent
+        ``schema_version`` is treated as 1, legacy keys are renamed to
+        their canonical form, and unknown keys are dropped. The operation
+        is idempotent and short-circuits when already at the latest schema.
+
+        Args:
+            raw: Decoded state mapping (e.g. from JSON on disk).
+
+        Returns:
+            A fully-populated, migrated :class:`SharedState` instance.
+        """
         # Unified migration entry point; absent schema_version treated as 1. Idempotent (latest version short-circuits).
         incoming_version = int(raw.get("schema_version") or 1)
         needs_migration = incoming_version < LATEST_STATE_SCHEMA_VERSION
@@ -2426,6 +2439,14 @@ class SharedState:
         ledger = [e for e in (self.intervention_mix or []) if isinstance(e, dict)]
 
         def _ct(entry: dict[str, Any]) -> str:
+            """Return an entry's normalized ``change_type`` string.
+
+            Args:
+                entry: A single intervention-mix ledger entry.
+
+            Returns:
+                The lowercased, stripped change type (empty if absent).
+            """
             return str(entry.get("change_type") or "").strip().lower()
 
         total_config = sum(1 for e in ledger if _ct(e) == "config")
@@ -3506,6 +3527,11 @@ class SharedState:
         )
 
     def _format_last_trace_analyze(self) -> str:
+        """Render the most recent trace-analyze blob for the prompt.
+
+        Returns:
+            A formatted summary of ``last_trace_analyze``.
+        """
         return self._format_trace_analyze_blob(self.last_trace_analyze)
 
     def _format_trace_analyze_blob(self, blob: dict[str, Any] | None) -> str:

--- a/inference_optimizer/orchestrator/specialist_bench.py
+++ b/inference_optimizer/orchestrator/specialist_bench.py
@@ -91,10 +91,27 @@ MAX_BENCH_WALL_CLOCK_SEC: float = 60.0
 
 
 def _error(reason: str, **extra: Any) -> dict[str, Any]:
+    """Build a failure result envelope.
+
+    Args:
+        reason: Human-readable failure reason.
+        **extra: Additional fields to merge into the envelope.
+
+    Returns:
+        Dict with ``ok=False`` plus the reason and any extra fields.
+    """
     return {"ok": False, "reason": reason, **extra}
 
 
 def _ok(payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Build a success result envelope.
+
+    Args:
+        payload: Optional fields to merge into the envelope.
+
+    Returns:
+        Dict with ``ok=True`` plus any payload fields.
+    """
     out: dict[str, Any] = {"ok": True}
     if payload:
         out.update(payload)

--- a/inference_optimizer/orchestrator/specialist_domains.py
+++ b/inference_optimizer/orchestrator/specialist_domains.py
@@ -160,6 +160,14 @@ EXTRA_KNOWLEDGE_DOMAIN_TAGS: tuple[str, ...] = ()
 
 
 def _derive_knowledge_domain_tags() -> tuple[str, ...]:
+    """Collect the distinct knowledge-domain tags from the catalogue.
+
+    Combines the ``kb_anchor`` of each specialist domain with any extra
+    standalone tags, preserving first-seen order and dropping blanks.
+
+    Returns:
+        Ordered tuple of unique knowledge-domain tags.
+    """
     seen: dict[str, None] = {}
     for d in SPECIALIST_DOMAINS:
         anchor = (d.kb_anchor or "").strip()
@@ -179,6 +187,13 @@ KNOWLEDGE_DOMAIN_TAG_SET: frozenset[str] = frozenset(KNOWLEDGE_DOMAIN_TAGS)
 # Map each knowledge-domain tag back to a representative catalogue entry.
 # The first catalogue entry that owns the anchor wins.
 def _anchor_to_domain_map() -> dict[str, "SpecialistDomain"]:
+    """Build a map from KB anchor to its representative domain entry.
+
+    The first catalogue entry that owns a given anchor wins.
+
+    Returns:
+        Mapping of ``kb_anchor`` to the owning :class:`SpecialistDomain`.
+    """
     out: dict[str, SpecialistDomain] = {}
     for d in SPECIALIST_DOMAINS:
         anchor = (d.kb_anchor or "").strip()

--- a/inference_optimizer/orchestrator/specialist_profile.py
+++ b/inference_optimizer/orchestrator/specialist_profile.py
@@ -60,10 +60,20 @@ class SpecialistProfile:
 
     @property
     def is_freeform(self) -> bool:
+        """Whether this profile uses the free-form (unscoped) scope.
+
+        Returns:
+            ``True`` if the scope is free-form.
+        """
         return self.scope == SCOPE_FREEFORM
 
     @property
     def is_cross_domain(self) -> bool:
+        """Whether this profile spans multiple knowledge domains.
+
+        Returns:
+            ``True`` if the scope is the multi-domain scope.
+        """
         return self.scope == SCOPE_DOMAINS
 
     @property
@@ -75,6 +85,18 @@ class SpecialistProfile:
 
 
 def _coerce_bool(value: Any, default: bool) -> bool:
+    """Coerce a loosely-typed value to a boolean.
+
+    Accepts native bools, numbers, and common truthy/falsey strings
+    (``"true"``/``"yes"``/``"on"`` and their negatives).
+
+    Args:
+        value: Value to interpret.
+        default: Fallback returned when ``value`` is ``None`` or unrecognized.
+
+    Returns:
+        The interpreted boolean, or ``default`` when undecidable.
+    """
     if value is None:
         return default
     if isinstance(value, bool):

--- a/inference_optimizer/orchestrator/specialist_runner.py
+++ b/inference_optimizer/orchestrator/specialist_runner.py
@@ -976,6 +976,14 @@ class SpecialistRunner:
         search_bases = [b for b in (prep.worktree, workspace) if b is not None]
 
         def _resolve_existing_patch(p: Any) -> str | None:
+            """Resolve a claimed patch path against known search bases.
+
+            Args:
+                p: Patch path (absolute or relative to a search base).
+
+            Returns:
+                The first existing file path as a string, or ``None``.
+            """
             raw = Path(str(p))
             candidates = [raw] if raw.is_absolute() else []
             for base in search_bases:
@@ -1122,8 +1130,18 @@ class SpecialistRunner:
 
     # Workspace file protocol
     def _resolve_workspace(self, ctx: RunnerContext) -> Path | None:
-        # Prefer the SubAgentRunner-premkdir'd workspace, else
-        # ``runs/specialist/<task_id>/``.
+        """Resolve (and create) the workspace directory for a run.
+
+        Prefers a pre-created workspace supplied on the context's ``extra``
+        mapping, otherwise falls back to ``runs/specialist/<task_id>/``
+        under the session directory.
+
+        Args:
+            ctx: Runner context for the current dispatch.
+
+        Returns:
+            The workspace path, or ``None`` if no session directory is set.
+        """
         extra = getattr(ctx, "extra", None) or {}
         ws = extra.get("workspace")
         if ws:

--- a/inference_optimizer/orchestrator/system_prompts/specialist_prompt_builder.py
+++ b/inference_optimizer/orchestrator/system_prompts/specialist_prompt_builder.py
@@ -379,6 +379,15 @@ def _focus_pr_intel_specialist(inp: SpecialistPromptInputs) -> list[str]:
 def _focus_research_scout_specialist(
     inp: SpecialistPromptInputs,
 ) -> list[str]:
+    """Build the focus section for the research-scout specialist prompt.
+
+    Args:
+        inp: Assembled prompt inputs for the current dispatch.
+
+    Returns:
+        Prompt lines highlighting already-proven priors and steering the
+        scout toward net-new findings.
+    """
     proven_lines: list[str] = []
     if inp.already_proven:
         proven_lines.append(
@@ -832,6 +841,16 @@ def _is_cold_start(inp: SpecialistPromptInputs) -> bool:
 
 
 def _section_kb_subgraph(inp: SpecialistPromptInputs) -> list[str]:
+    """Build the advisory KB-context section of the specialist prompt.
+
+    Falls back to research hints when the structured KB subgraph is empty.
+
+    Args:
+        inp: Assembled prompt inputs for the current dispatch.
+
+    Returns:
+        Prompt lines rendering the KB subgraph (or hint-based fallback).
+    """
     rows = ["## 4. KB CONTEXT (optional, advisory)", ""]
     cold = _is_cold_start(inp)
     if not inp.kb_subgraph:

--- a/inference_optimizer/orchestrator/trace/conversation_trace.py
+++ b/inference_optimizer/orchestrator/trace/conversation_trace.py
@@ -103,10 +103,23 @@ def redact_secrets(text: str) -> str:
 
 
 def _now_iso() -> str:
+    """Return the current UTC time as a microsecond-precision ISO string.
+
+    Returns:
+        ISO 8601 timestamp in UTC.
+    """
     return datetime.now(timezone.utc).isoformat(timespec="microseconds")
 
 
 def _coerce_optional_str(value: Any) -> str | None:
+    """Coerce a value to a non-empty stripped string or ``None``.
+
+    Args:
+        value: Arbitrary value to normalize.
+
+    Returns:
+        The stripped string, or ``None`` if it is empty or ``None``.
+    """
     if value is None:
         return None
     s = str(value).strip()
@@ -114,6 +127,14 @@ def _coerce_optional_str(value: Any) -> str | None:
 
 
 def _coerce_optional_int(value: Any) -> int | None:
+    """Coerce a value to ``int`` or ``None`` if it cannot be parsed.
+
+    Args:
+        value: Arbitrary value to convert.
+
+    Returns:
+        The integer value, or ``None`` on failure.
+    """
     if value is None:
         return None
     try:

--- a/inference_optimizer/orchestrator/trace/langfuse_emitter.py
+++ b/inference_optimizer/orchestrator/trace/langfuse_emitter.py
@@ -54,10 +54,26 @@ log = logging.getLogger(__name__)
 
 
 def _manifest_path(session_dir: Path) -> Path:
+    """Return the path to a session's ``manifest.json``.
+
+    Args:
+        session_dir: Session directory.
+
+    Returns:
+        The manifest file path.
+    """
     return session_dir / "manifest.json"
 
 
 def _receipt_path(session_dir: Path) -> Path:
+    """Return the path to a session's Langfuse receipt file.
+
+    Args:
+        session_dir: Session directory.
+
+    Returns:
+        The ``langfuse_receipt.json`` path under the trace directory.
+    """
     return trace_dir(session_dir) / "langfuse_receipt.json"
 
 
@@ -220,6 +236,15 @@ def _set_trace_attrs(
 
 
 def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Load a JSONL file into a list of dict records.
+
+    Args:
+        path: Path to the ``.jsonl`` file.
+
+    Returns:
+        The dict records; missing files, unreadable files, and malformed lines
+        yield (or are skipped to) an empty/partial list.
+    """
     import json
 
     out: list[dict[str, Any]] = []
@@ -243,6 +268,15 @@ def _load_jsonl(path: Path) -> list[dict[str, Any]]:
 
 
 def _load_json(path: Path) -> dict[str, Any]:
+    """Load a JSON object file.
+
+    Args:
+        path: Path to the JSON file.
+
+    Returns:
+        The parsed object, or ``{}`` when the file is missing, unreadable, or
+        not a JSON object.
+    """
     import json
 
     if not path.exists():
@@ -264,6 +298,15 @@ class LangfuseEmitter:
     """
 
     def __init__(self, session_dir: Path) -> None:
+        """Initialize the per-session emitter.
+
+        Resolves the manifest and correlation labels unconditionally (even when
+        the live push is disabled) so the receipt always reports the right trace
+        and correlation ids.
+
+        Args:
+            session_dir: Session directory whose traces are emitted.
+        """
         self.session_dir = Path(session_dir)
         self._lock = threading.Lock()
         # pair_key -> partial generation parts ({"llm": row} / {"conv": row}).
@@ -346,10 +389,16 @@ class LangfuseEmitter:
 
     @property
     def enabled(self) -> bool:
+        """Whether live push to Langfuse is enabled for this session."""
         return self._enabled
 
     # -- span hierarchy (trace -> phase -> agent -> generation) ---------
     def _trace_name(self) -> str:
+        """Return the human-readable trace name.
+
+        Returns:
+            The model name, else the session label, else ``"hyperloom"``.
+        """
         return str(self._manifest.get("model_name") or self._session_label or "hyperloom")
 
     def _ensure_root(self, start: Any) -> Any:
@@ -374,6 +423,15 @@ class LangfuseEmitter:
         return self._root_span
 
     def _ensure_phase_span(self, phase: str, start: Any) -> Any:
+        """Get-or-create the span for a phase under the trace root.
+
+        Args:
+            phase: Phase name.
+            start: Span start time.
+
+        Returns:
+            The cached or newly opened phase span.
+        """
         span = self._phase_spans.get(phase)
         if span is None:
             root = self._ensure_root(start)
@@ -422,6 +480,12 @@ class LangfuseEmitter:
             log.debug("langfuse: record_conversation failed", exc_info=True)
 
     def _buffer(self, row: dict[str, Any], *, half: str) -> None:
+        """Buffer one half of a generation and emit once both halves arrive.
+
+        Args:
+            row: The token (``llm``) or conversation (``conv``) row.
+            half: Which half this row represents (``"llm"`` or ``"conv"``).
+        """
         key = lfmap.pair_key(row)
         emit_parts: dict[str, dict[str, Any]] | None = None
         with self._lock:
@@ -521,6 +585,11 @@ class LangfuseEmitter:
 
     @staticmethod
     def _safe_end(span: Any) -> None:
+        """End a span, swallowing any errors.
+
+        Args:
+            span: The span object to end.
+        """
         try:
             span.end()
         except Exception:  # noqa: BLE001
@@ -572,6 +641,13 @@ class LangfuseEmitter:
     def _create_score(
         self, score: dict[str, Any], *, phase: str, agent: str,
     ) -> None:
+        """Attach a Langfuse Score to the owning agent span or the trace.
+
+        Args:
+            score: Score payload (``name``, ``value``, ``data_type``, ...).
+            phase: Phase that owns the decision, used to locate the span.
+            agent: Agent/component that owns the decision.
+        """
         span = self._agent_spans.get((phase, agent))
         try:
             if span is not None and hasattr(span, "score"):

--- a/inference_optimizer/orchestrator/trace/llm_trace.py
+++ b/inference_optimizer/orchestrator/trace/llm_trace.py
@@ -88,6 +88,11 @@ class LLMTraceRowError(ValueError):
 
 
 def _now_iso() -> str:
+    """Return the current UTC time as a microsecond-precision ISO string.
+
+    Returns:
+        ISO 8601 timestamp in UTC.
+    """
     return datetime.now(timezone.utc).isoformat(timespec="microseconds")
 
 
@@ -206,6 +211,14 @@ class LLMCallRecord:
 
 
 def _coerce_optional_str(value: Any) -> str | None:
+    """Coerce a value to a non-empty stripped string or ``None``.
+
+    Args:
+        value: Arbitrary value to normalize.
+
+    Returns:
+        The stripped string, or ``None`` if it is empty or ``None``.
+    """
     if value is None:
         return None
     s = str(value).strip()

--- a/inference_optimizer/orchestrator/trace/parse_usage.py
+++ b/inference_optimizer/orchestrator/trace/parse_usage.py
@@ -48,6 +48,14 @@ _TOKEN_KEYS: tuple[str, ...] = (
 
 
 def _coerce_optional_int(value: Any) -> int | None:
+    """Coerce a value to ``int`` or ``None`` if it cannot be parsed.
+
+    Args:
+        value: Arbitrary value to convert.
+
+    Returns:
+        The integer value, or ``None`` on failure.
+    """
     if value is None:
         return None
     try:

--- a/inference_optimizer/recipe_kb/composite_remote.py
+++ b/inference_optimizer/recipe_kb/composite_remote.py
@@ -99,6 +99,14 @@ def _precedence_key(row: dict[str, Any]) -> tuple[int, float, int, float]:
 
 
 def _is_empty(value: Any) -> bool:
+    """Return whether a value counts as empty for back-fill purposes.
+
+    Args:
+        value: Value to test.
+
+    Returns:
+        ``True`` for ``None``, empty containers/strings, and numeric zero.
+    """
     if value is None:
         return True
     if isinstance(value, (str, list, dict, tuple)) and len(value) == 0:
@@ -197,6 +205,14 @@ class CompositeRemoteRecipeClient:
     returns_arbor_shape = True
 
     def __init__(self, sources: Iterable[Any], *, names: list[str] | None = None) -> None:
+        """Initialize the composite over an ordered list of sub-remotes.
+
+        Args:
+            sources: Sub-remote clients, in precedence order; ``None`` entries
+                are dropped.
+            names: Optional display names parallel to ``sources``; defaults to
+                each source's ``_name`` or class name.
+        """
         self._sources = [s for s in sources if s is not None]
         self._names = names or [
             getattr(s, "_name", None) or type(s).__name__ for s in self._sources
@@ -208,6 +224,12 @@ class CompositeRemoteRecipeClient:
         return any(getattr(s, "enabled", False) for s in self._sources)
 
     def _active(self) -> list[tuple[str, Any]]:
+        """Return ``(name, source)`` pairs for the enabled sub-remotes.
+
+        Returns:
+            The enabled sources paired with their display names, in precedence
+            order.
+        """
         return [
             (self._names[i], s)
             for i, s in enumerate(self._sources)
@@ -234,6 +256,15 @@ class CompositeRemoteRecipeClient:
         return out
 
     def _merged_search(self, *, per_source_limit: int, kwargs: dict[str, Any]) -> list[dict[str, Any]]:
+        """Fan out a search to all active sources and merge by canonical id.
+
+        Args:
+            per_source_limit: Row limit applied to each sub-remote.
+            kwargs: Search keyword arguments forwarded to each source.
+
+        Returns:
+            Field-merged rows, one per canonical id, sorted by precedence.
+        """
         sub_kwargs = dict(kwargs)
         sub_kwargs["limit"] = per_source_limit
         grouped: dict[str, list[dict[str, Any]]] = {}
@@ -259,6 +290,20 @@ class CompositeRemoteRecipeClient:
         limit: int = 50,
         prefer: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
+        """Search all active sources and return merged, ranked rows.
+
+        Args:
+            label_match: Exact label filters (the 5-tuple identity labels).
+            metric_filters: ``{metric: {min, max}}`` filters.
+            updated_since: Lower bound on ``updated_at``.
+            order_by: Ordering directive forwarded to sub-remotes.
+            limit: Maximum number of merged rows to return.
+            prefer: Workload-similarity hints (accepted for parity; rerank is
+                applied by the dispatcher).
+
+        Returns:
+            Up to ``limit`` merged recipe rows.
+        """
         # Main's dispatcher passes workload-similarity hints through this
         # parameter. Sub-remotes accept it for interface parity while the
         # dispatcher performs the actual client-side rerank.
@@ -299,6 +344,14 @@ class CompositeRemoteRecipeClient:
     # are only hit by direct callers). Delegate to the first capable source.
     # ------------------------------------------------------------------
     def list_recent(self, *, limit: int = 50) -> list[dict[str, Any]]:
+        """Return the most recent merged recipes across all sources.
+
+        Args:
+            limit: Maximum number of rows to return.
+
+        Returns:
+            Up to ``limit`` merged recipe rows ordered most-recent first.
+        """
         return self._merged_search(
             per_source_limit=max(int(limit), _FETCH_FLOOR),
             kwargs={"label_match": None, "limit": limit, "metric_filters": None,
@@ -306,19 +359,47 @@ class CompositeRemoteRecipeClient:
         )[: int(limit)]
 
     def _first_active(self) -> Any | None:
+        """Return the first enabled sub-remote, or ``None`` if none are active."""
         for _name, source in self._active():
             return source
         return None
 
     def list_attempts(self, *, canonical_id: str, limit: int = 100) -> list[dict[str, Any]]:
+        """Return attempt rows for a recipe from the first active source.
+
+        Args:
+            canonical_id: Canonical recipe id.
+            limit: Maximum number of attempts.
+
+        Returns:
+            Attempt rows from the first active source, or ``[]`` when none are
+            active.
+        """
         src = self._first_active()
         return src.list_attempts(canonical_id=canonical_id, limit=limit) if src else []
 
     def list_session_attempts(self, *, session_id: str, limit: int = 500) -> list[dict[str, Any]]:
+        """Return attempt rows for a session from the first active source.
+
+        Args:
+            session_id: Session identifier.
+            limit: Maximum number of attempts.
+
+        Returns:
+            Session attempt rows, or ``[]`` when no source is active.
+        """
         src = self._first_active()
         return src.list_session_attempts(session_id=session_id, limit=limit) if src else []
 
     def session_summary(self, *, session_id: str) -> dict[str, Any] | None:
+        """Return a session summary from the first active source.
+
+        Args:
+            session_id: Session identifier.
+
+        Returns:
+            The session summary, or ``None`` when no source is active.
+        """
         src = self._first_active()
         return src.session_summary(session_id=session_id) if src else None
 
@@ -333,6 +414,7 @@ class CompositeRemoteRecipeClient:
         return False
 
     def close(self) -> None:
+        """Close all sub-remotes, ignoring individual close failures."""
         for source in self._sources:
             try:
                 source.close()

--- a/inference_optimizer/recipe_kb/gbrain_ingest.py
+++ b/inference_optimizer/recipe_kb/gbrain_ingest.py
@@ -57,6 +57,17 @@ _TAG_CLEAN = str.maketrans({" ": "-", "\t": "-", "/": "-"})
 
 
 def _tag_value(value: Any) -> str:
+    """Normalize a value into a slug-style tag token.
+
+    Lowercases the value and replaces whitespace and slashes with
+    hyphens, trimming leading/trailing hyphens.
+
+    Args:
+        value: Arbitrary value to slugify.
+
+    Returns:
+        The tag slug, or ``"unknown"`` when the value is empty.
+    """
     return str(value or "").strip().lower().translate(_TAG_CLEAN).strip("-") or "unknown"
 
 
@@ -330,10 +341,27 @@ class GbrainMirroringRecipeKB:
     """
 
     def __init__(self, inner: Any, mcp: _GbrainMcp | None) -> None:
+        """Wrap an inner dispatcher with a gbrain mirroring side-effect.
+
+        Args:
+            inner: The wrapped recipe dispatcher to delegate to.
+            mcp: Optional gbrain MCP client used for mirroring writes.
+        """
         self._inner = inner
         self._mcp = mcp
 
     def put_recipe(self, **kwargs: Any) -> Any:
+        """Write a recipe locally, then best-effort mirror it to gbrain.
+
+        The local write is authoritative; mirroring failures are logged
+        and swallowed so they never block the local result.
+
+        Args:
+            **kwargs: Recipe fields forwarded to the inner dispatcher.
+
+        Returns:
+            The result of the wrapped ``put_recipe`` call.
+        """
         result = self._inner.put_recipe(**kwargs)
         try:
             mirror_recipe(kwargs, self._mcp)
@@ -342,12 +370,29 @@ class GbrainMirroringRecipeKB:
         return result
 
     def __getattr__(self, name: str) -> Any:
+        """Delegate all other attribute access to the wrapped dispatcher.
+
+        Args:
+            name: Attribute name to resolve on the inner dispatcher.
+
+        Returns:
+            The corresponding attribute from the wrapped dispatcher.
+        """
         # Delegate everything else (get_recipe / search / append_attempt /
         # local / remote / ...) to the wrapped dispatcher.
         return getattr(self._inner, name)
 
 
 def main(argv: list[str] | None = None) -> int:
+    """CLI entry point to bulk-ingest local recipes into gbrain.
+
+    Args:
+        argv: Optional argument vector; defaults to ``sys.argv`` when
+            ``None``.
+
+    Returns:
+        Process exit code (``0`` on success, non-zero on usage errors).
+    """
     ap = argparse.ArgumentParser(description="Bulk-ingest local recipe snapshots into gbrain.")
     ap.add_argument("--local-kb-root", default=os.environ.get("HYPERLOOM_LOCAL_KB_ROOT", ""),
                     help="LocalRecipeStore root (default: $HYPERLOOM_LOCAL_KB_ROOT)")

--- a/inference_optimizer/recipe_kb/gbrain_remote_client.py
+++ b/inference_optimizer/recipe_kb/gbrain_remote_client.py
@@ -78,6 +78,13 @@ class GbrainRemoteError(RemoteRecipeClientError):
     """
 
     def __init__(self, message: str, *, category: str = "transport", **kwargs: Any) -> None:
+        """Initialize the error.
+
+        Args:
+            message: Human-readable error message.
+            category: Error category (defaults to ``transport``).
+            **kwargs: Additional fields forwarded to the base exception.
+        """
         super().__init__(message, category=category, **kwargs)
 
 
@@ -85,11 +92,32 @@ class _GbrainMcp:
     """Minimal JSON-RPC-over-HTTP MCP client (list_pages / get_page)."""
 
     def __init__(self, base_url: str, token: str, timeout_sec: float) -> None:
+        """Initialize the MCP client.
+
+        Args:
+            base_url: Base URL of the gbrain MCP endpoint.
+            token: Bearer token for authorization.
+            timeout_sec: Per-request timeout in seconds (floored at 0.5).
+        """
         self._base = base_url.rstrip("/")
         self._token = token
         self._timeout = max(0.5, float(timeout_sec))
 
     def call(self, tool: str, arguments: dict[str, Any]) -> Any:
+        """Invoke an MCP tool over JSON-RPC and return its decoded result.
+
+        Args:
+            tool: MCP tool name to call.
+            arguments: Tool arguments.
+
+        Returns:
+            The decoded tool result: parsed JSON content when present, else the
+            raw content text, else the result object.
+
+        Raises:
+            GbrainRemoteError: On transport failures, malformed envelopes, or
+                JSON-RPC / tool-level errors.
+        """
         envelope = {
             "jsonrpc": "2.0", "id": "1", "method": "tools/call",
             "params": {"name": tool, "arguments": arguments},
@@ -140,6 +168,14 @@ class _GbrainMcp:
 
 
 def _as_float(value: Any) -> float:
+    """Coerce a value to float, defaulting to ``0.0`` on failure.
+
+    Args:
+        value: Value to convert.
+
+    Returns:
+        The parsed float, or ``0.0`` when conversion fails.
+    """
     try:
         return float(value)
     except (TypeError, ValueError):
@@ -318,6 +354,15 @@ class GbrainRemoteRecipeClient:
         enabled: bool = True,
         timeout_sec: float | None = None,
     ) -> None:
+        """Initialize the gbrain-backed recipe client.
+
+        Args:
+            base_url: Base URL of the gbrain endpoint.
+            token: Bearer token for authorization.
+            enabled: Whether the client is active (also requires a URL/token).
+            timeout_sec: Per-request timeout; defaults to the foreground HTTP
+                budget when ``None``.
+        """
         self.base_url = (base_url or "").strip()
         self.token = (token or "").strip()
         # Foreground-friendly default: gbrain is a read side-channel, so
@@ -334,9 +379,16 @@ class GbrainRemoteRecipeClient:
 
     # -- lifecycle ---------------------------------------------------------
     def close(self) -> None:  # symmetry with RemoteRecipeClient
+        """Release the underlying MCP client."""
         self._mcp = None
 
     def health(self) -> bool:
+        """Probe gbrain reachability with a tiny ``list_pages`` call.
+
+        Returns:
+            ``True`` if the probe succeeds; ``False`` when disabled or the
+            probe errors.
+        """
         if not self.enabled or self._mcp is None:
             return False
         try:
@@ -348,6 +400,12 @@ class GbrainRemoteRecipeClient:
 
     # -- internal scan -----------------------------------------------------
     def _scan_cache_ttl(self) -> float:
+        """Return the recipe-scan cache TTL in seconds.
+
+        Returns:
+            The value from ``GBRAIN_RECIPE_SCAN_TTL_SEC`` when valid, otherwise
+            the default TTL.
+        """
         raw = os.environ.get("GBRAIN_RECIPE_SCAN_TTL_SEC", "").strip()
         if raw:
             try:
@@ -457,10 +515,28 @@ class GbrainRemoteRecipeClient:
         return rows[0] if rows else None
 
     def get_history(self, *, canonical_id: str, limit: int = 100) -> list[dict[str, Any]]:
+        """Return the version history for a recipe.
+
+        Args:
+            canonical_id: Canonical recipe id.
+            limit: Maximum number of history entries.
+
+        Returns:
+            Always ``[]`` — gbrain does not retain a versioned recipe archive
+            (provided for interface parity).
+        """
         # gbrain does not retain a versioned recipe archive.
         return []
 
     def list_recent(self, *, limit: int = 50) -> list[dict[str, Any]]:
+        """Return the most recently updated recipes.
+
+        Args:
+            limit: Maximum number of recipes to return.
+
+        Returns:
+            Recent recipe rows, or ``[]`` when the client is disabled.
+        """
         if not self.enabled:
             return []
         return self._scan_recipes(limit=limit)
@@ -497,14 +573,41 @@ class GbrainRemoteRecipeClient:
         return rows[: int(limit)] if limit and limit > 0 else rows
 
     def list_attempts(self, *, canonical_id: str, limit: int = 100) -> list[dict[str, Any]]:
+        """Return attempt rows for a recipe.
+
+        Args:
+            canonical_id: Canonical recipe id.
+            limit: Maximum number of attempts.
+
+        Returns:
+            Always ``[]`` — attempt rows live in the local store, so the
+            dispatcher falls through to local on gbrain absence.
+        """
         # Attempt rows live on local store under this design; gbrain
         # absence falls the dispatcher through to local.
         return []
 
     def list_session_attempts(self, *, session_id: str, limit: int = 200) -> list[dict[str, Any]]:
+        """Return attempt rows for a session.
+
+        Args:
+            session_id: Session identifier.
+            limit: Maximum number of attempts.
+
+        Returns:
+            Always ``[]`` — session attempts are served from the local store.
+        """
         return []
 
     def session_summary(self, *, session_id: str) -> dict[str, Any] | None:
+        """Return a session summary.
+
+        Args:
+            session_id: Session identifier.
+
+        Returns:
+            Always ``None`` — gbrain does not serve session summaries.
+        """
         return None
 
 

--- a/inference_optimizer/scripts/backfill_langfuse.py
+++ b/inference_optimizer/scripts/backfill_langfuse.py
@@ -93,6 +93,15 @@ UNPHASED = lfmap.UNPHASED
 # IO helpers
 # ---------------------------------------------------------------------------
 def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Load a JSONL file into a list of dict records.
+
+    Args:
+        path: Path to the ``.jsonl`` file.
+
+    Returns:
+        The dict records; a missing file yields ``[]`` and malformed lines are
+        skipped.
+    """
     out: list[dict[str, Any]] = []
     if not path.exists():
         return out
@@ -110,6 +119,15 @@ def _load_jsonl(path: Path) -> list[dict[str, Any]]:
 
 
 def _load_json(path: Path) -> dict[str, Any]:
+    """Load a JSON object file.
+
+    Args:
+        path: Path to the JSON file.
+
+    Returns:
+        The parsed object, or ``{}`` when the file is missing, unreadable, or
+        not a JSON object.
+    """
     if not path.exists():
         return {}
     try:
@@ -185,6 +203,15 @@ def build_plan(session_dir: Path) -> dict[str, Any]:
 
 
 def _time_bounds(gens: list[dict]) -> tuple[datetime | None, datetime | None]:
+    """Return the earliest and latest timestamps across generations.
+
+    Args:
+        gens: Generation rows each carrying a ``ts`` field.
+
+    Returns:
+        A ``(min, max)`` datetime tuple, or ``(None, None)`` when no row has a
+        parseable timestamp.
+    """
     times = [lfmap.parse_ts(g["ts"]) for g in gens]
     times = [t for t in times if t is not None]
     if not times:
@@ -195,6 +222,14 @@ def _time_bounds(gens: list[dict]) -> tuple[datetime | None, datetime | None]:
 def _phase_time_bounds(
     agents: "OrderedDict[str, list[dict]]",
 ) -> tuple[datetime | None, datetime | None]:
+    """Return the time bounds across all agents in a phase.
+
+    Args:
+        agents: Mapping of agent name to its generation rows.
+
+    Returns:
+        A ``(min, max)`` datetime tuple over every generation in the phase.
+    """
     flat = [g for gens in agents.values() for g in gens]
     return _time_bounds(flat)
 
@@ -203,6 +238,11 @@ def _phase_time_bounds(
 # Dry-run printer
 # ---------------------------------------------------------------------------
 def print_plan(plan: dict[str, Any]) -> None:
+    """Print a human-readable dry-run summary of a backfill plan.
+
+    Args:
+        plan: The plan dict produced by the plan builder.
+    """
     s = plan["stats"]
     print(f"Trace: {plan['name']}  (session_id={plan['session_id']})")
     print(f"  claw_session_id = {plan.get('claw_session_id') or '(none)'}  "
@@ -242,6 +282,18 @@ def print_plan(plan: dict[str, Any]) -> None:
 # Real ingest (needs the langfuse SDK)
 # ---------------------------------------------------------------------------
 def ingest(plan: dict[str, Any]) -> int:
+    """Emit a backfill plan to Langfuse as a full trace tree.
+
+    Recreates the trace -> phase -> agent -> generation hierarchy from a
+    completed session and attaches decision scores to the owning agent spans.
+
+    Args:
+        plan: The backfill plan produced by the plan builder.
+
+    Returns:
+        Process exit code: ``0`` on success, ``3`` when the Langfuse SDK is not
+        importable.
+    """
     try:
         from langfuse import get_client  # type: ignore
     except Exception as exc:  # noqa: BLE001
@@ -348,6 +400,11 @@ def ingest(plan: dict[str, Any]) -> int:
 # CLI
 # ---------------------------------------------------------------------------
 def _build_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser.
+
+    Returns:
+        The configured :class:`argparse.ArgumentParser`.
+    """
     p = argparse.ArgumentParser(
         prog="backfill_langfuse",
         description=__doc__,
@@ -362,6 +419,14 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: build and (optionally) emit a backfill plan.
+
+    Args:
+        argv: Argument list to parse; defaults to ``sys.argv`` when ``None``.
+
+    Returns:
+        Process exit code from the plan/ingest path.
+    """
     args = _build_parser().parse_args(argv)
     logging.basicConfig(
         level=(logging.DEBUG if args.verbose >= 2

--- a/inference_optimizer/scripts/roofline_sweep.py
+++ b/inference_optimizer/scripts/roofline_sweep.py
@@ -60,6 +60,17 @@ class LaunchTemplate:
 
 
 def load_session_state(session_dir: Path) -> dict[str, Any]:
+    """Load a session's ``state.json``.
+
+    Args:
+        session_dir: Hyperloom session directory.
+
+    Returns:
+        The parsed state mapping.
+
+    Raises:
+        SystemExit: If ``state.json`` is missing.
+    """
     state_path = session_dir / "state.json"
     if not state_path.is_file():
         raise SystemExit(f"state.json not found at {state_path}")
@@ -108,6 +119,18 @@ class SglangServer:
         gpu_id: int,
         ready_timeout_sec: int = 900,
     ) -> None:
+        """Initialize the sglang server wrapper.
+
+        Args:
+            model_path: Path to the model to serve.
+            tp: Tensor-parallel size.
+            port: Port to bind the server on.
+            extra_args: Extra server CLI args (space-separated).
+            extra_envs: Extra environment variables for the server process.
+            log_path: File to capture server stdout/stderr.
+            gpu_id: Physical GPU id to pin via ``ROCR_VISIBLE_DEVICES``.
+            ready_timeout_sec: Max seconds to wait for the server to be ready.
+        """
         self.model_path = model_path
         self.tp = tp
         self.port = port
@@ -119,6 +142,14 @@ class SglangServer:
         self.proc: subprocess.Popen | None = None
 
     def __enter__(self) -> "SglangServer":
+        """Launch the server process and block until it is ready.
+
+        Returns:
+            This server instance.
+
+        Raises:
+            RuntimeError: If the server dies or never becomes ready.
+        """
         cmd = [
             sys.executable, "-m", "sglang.launch_server",
             f"--model-path={self.model_path}",
@@ -156,6 +187,12 @@ class SglangServer:
         return self
 
     def _wait_ready(self) -> None:
+        """Poll the health endpoint until the server is ready or times out.
+
+        Raises:
+            RuntimeError: If the server process dies or does not become ready
+                within ``ready_timeout_sec``.
+        """
         import urllib.request
         deadline = time.time() + self.ready_timeout_sec
         url = f"http://127.0.0.1:{self.port}/health_generate"
@@ -177,6 +214,11 @@ class SglangServer:
         )
 
     def __exit__(self, *_exc: Any) -> None:
+        """Terminate the server process group on context exit.
+
+        Args:
+            *_exc: Exception info from the ``with`` block (unused).
+        """
         if self.proc is None:
             return
         try:
@@ -192,6 +234,7 @@ class SglangServer:
 
     @property
     def base_url(self) -> str:
+        """Return the server's local base URL."""
         return f"http://127.0.0.1:{self.port}"
 
 
@@ -248,6 +291,22 @@ def compute_ceiling(
     *, model_meta: Any, gpu_type: str, num_gpus: int,
     conc: int, isl: int, osl: int,
 ) -> float:
+    """Compute the theoretical peak output throughput for one concurrency.
+
+    Thin wrapper over :func:`compute_theoretical_peak_output_tok_per_sec` that
+    unpacks the model metadata fields.
+
+    Args:
+        model_meta: Loaded model metadata (weights, layers, KV shape, ...).
+        gpu_type: GPU type key into the hardware specs.
+        num_gpus: Number of GPUs (tensor-parallel size).
+        conc: Concurrency level.
+        isl: Input sequence length.
+        osl: Output sequence length.
+
+    Returns:
+        The theoretical peak output tokens/second.
+    """
     return compute_theoretical_peak_output_tok_per_sec(
         gpu_type=gpu_type,
         num_gpus=num_gpus,
@@ -275,6 +334,27 @@ def sweep_one_template(
     concs: list[int], dataset: str, num_prompts_factor: int,
     output_dir: Path,
 ) -> list[dict[str, Any]]:
+    """Sweep a launch template across all concurrencies on one reused server.
+
+    Args:
+        tmpl: Launch template (baseline or optimized).
+        model_path: Path to the model to serve.
+        model_meta: Loaded model metadata used for ceiling computation.
+        gpu_type: GPU type key.
+        tp: Tensor-parallel size.
+        gpu_id: Physical GPU id to pin.
+        port: Server port.
+        isl: Input sequence length.
+        osl: Output sequence length.
+        concs: Concurrency levels to benchmark.
+        dataset: Benchmark dataset name.
+        num_prompts_factor: ``num_prompts = max(conc * factor, 16)``.
+        output_dir: Directory for server/bench logs.
+
+    Returns:
+        One result row per concurrency with measured throughput, ceiling, MBU,
+        and status.
+    """
     rows: list[dict[str, Any]] = []
     server_log = output_dir / f"server_{tmpl.label}.log"
     bench_out_dir = output_dir / f"bench_{tmpl.label}"
@@ -326,6 +406,12 @@ def sweep_one_template(
 # Output: csv + svg
 # ---------------------------------------------------------------------------
 def write_csv(rows: list[dict[str, Any]], csv_path: Path) -> None:
+    """Write sweep result rows to a CSV file.
+
+    Args:
+        rows: Result rows from :func:`sweep_one_template`.
+        csv_path: Destination CSV path (parents created as needed).
+    """
     csv_path.parent.mkdir(parents=True, exist_ok=True)
     fields = ["conc", "config", "measured_tps", "ceiling_tps", "target_70_tps", "mbu_pct", "status"]
     with csv_path.open("w", newline="", encoding="utf-8") as f:
@@ -340,12 +426,33 @@ def plot_svg(
     model_label: str, gpu_label: str, tp: int, isl: int, osl: int,
     target_ratio: float = 0.70,
 ) -> None:
+    """Render the dual-panel throughput/MBU roofline chart as SVG.
+
+    Args:
+        rows: Sweep result rows.
+        svg_path: Destination SVG path.
+        model_label: Model name shown in the title.
+        gpu_label: GPU label shown in the title.
+        tp: Tensor-parallel size shown in the title.
+        isl: Input sequence length shown in the title.
+        osl: Output sequence length shown in the title.
+        target_ratio: Roofline fraction drawn as the target line.
+    """
     import matplotlib
     matplotlib.use("Agg")
     import matplotlib.pyplot as plt
 
     concs = sorted({r["conc"] for r in rows})
     def _series(label: str, key: str) -> list[float | None]:
+        """Return per-concurrency values for one config/metric.
+
+        Args:
+            label: Config label (``baseline`` / ``optimized``).
+            key: Metric key to extract from each row.
+
+        Returns:
+            A list aligned with ``concs``; ``None`` where a value is missing.
+        """
         out: list[float | None] = []
         for c in concs:
             row = next((r for r in rows if r["conc"] == c and r["config"] == label), None)
@@ -429,6 +536,14 @@ def plot_svg(
 # CLI
 # ---------------------------------------------------------------------------
 def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for the roofline concurrency sweep.
+
+    Args:
+        argv: Argument list to parse; defaults to ``sys.argv`` when ``None``.
+
+    Returns:
+        Process exit code (``0`` on success).
+    """
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     ap.add_argument("--session-dir", required=True, type=Path,
                     help="Hyperloom session directory (contains state.json)")

--- a/kernel-agent/tools/backends/geak_submit.py
+++ b/kernel-agent/tools/backends/geak_submit.py
@@ -136,6 +136,24 @@ def run_via_ray(prompt_file: Path, output_dir: Path, kernel_path: str,
     @ray.remote(num_gpus=num_gpus)
     def _task(prompt_file_str: str, output_dir_str: str, kernel_path: str,
               cost_limit, timeout_s: int, kernel_repo: str, test_command: str) -> dict:
+        """Run one GEAK CLI attempt inside a Ray worker.
+
+        Self-contained because Ray workers do not inherit the driver's
+        ``sys.path``; all imports and GPU-visibility remapping happen here.
+
+        Args:
+            prompt_file_str: Path to the prompt file.
+            output_dir_str: Output directory for this attempt.
+            kernel_path: Path to the kernel under optimization.
+            cost_limit: Optional cost ceiling for the GEAK run.
+            timeout_s: Per-attempt timeout in seconds.
+            kernel_repo: Kernel repository identifier.
+            test_command: Command used to validate the kernel.
+
+        Returns:
+            A result dict with ``returncode``, ``stdout_tail``,
+            ``stderr_tail``, ``gpu_ids``, ``elapsed_s``, and ``cmd``.
+        """
         # Self-contained: Ray workers lack the driver's sys.path.
         import os as _os, shutil as _shutil, subprocess as _sp, time as _t
         import re as _re
@@ -245,6 +263,25 @@ def run_via_ray(prompt_file: Path, output_dir: Path, kernel_path: str,
 def run_via_cli(prompt_file: Path, output_dir: Path, kernel_path: str,
                 cost_limit: float | None, timeout_s: int,
                 kernel_repo: str = "", test_command: str = "") -> dict:
+    """Run one GEAK CLI attempt in a subprocess (non-Ray path).
+
+    Builds a child environment with ROCR→logical GPU remapping and per-attempt
+    compile caches, then runs the GEAK CLI under a timeout.
+
+    Args:
+        prompt_file: Path to the prompt file.
+        output_dir: Output directory for this attempt.
+        kernel_path: Path to the kernel under optimization.
+        cost_limit: Optional cost ceiling for the GEAK run.
+        timeout_s: Per-attempt timeout in seconds.
+        kernel_repo: Kernel repository identifier.
+        test_command: Command used to validate the kernel.
+
+    Returns:
+        A result dict with ``returncode``, ``stdout_tail``, ``stderr_tail``,
+        ``gpu_ids``, ``elapsed_s``, and ``cmd``. Timeouts return code ``124``
+        and input errors return code ``2``.
+    """
     # Child env with ROCR→logical GPU mapping; avoids leaking GPU vars to later steps.
     child_env = os.environ.copy()
     rocr_raw = child_env.get("ROCR_VISIBLE_DEVICES", "")

--- a/kernel-agent/tools/backends/oob_submit.py
+++ b/kernel-agent/tools/backends/oob_submit.py
@@ -227,6 +227,26 @@ def run_via_ray(agent: str, prompt_file: Path, output_dir: Path, source_file: st
     def _task(agent: str, prompt_file_str: str, output_dir_str: str,
               source_file: str, max_turns: int, timeout_s: int,
               extra_files: list[str], system_prompt: str) -> dict:
+        """Run one out-of-box (OOB) agent attempt inside a Ray worker.
+
+        Self-contained because Ray workers do not inherit the driver's
+        ``sys.path``; GPU visibility and compile caches are set up here.
+
+        Args:
+            agent: Agent identifier to run.
+            prompt_file_str: Path to the prompt file.
+            output_dir_str: Output directory for this attempt.
+            source_file: Path to the kernel source file.
+            max_turns: Maximum agent turns.
+            timeout_s: Per-attempt timeout in seconds.
+            extra_files: Additional files to make available to the agent.
+            system_prompt: System prompt text for the run.
+
+        Returns:
+            A result dict with ``returncode``, ``stdout``/``stdout_tail``,
+            ``stderr_tail``, ``gpu_ids``, ``elapsed_s``, and ``cmd`` (return
+            code ``127`` when the ``oob`` CLI is missing on the worker).
+        """
         # Self-contained: workers don't share the driver sys.path.
         import os as _os, shutil as _shutil, subprocess as _sp, time as _t
         if not _shutil.which("oob"):

--- a/kernel-agent/tools/backends/ray_runtime.py
+++ b/kernel-agent/tools/backends/ray_runtime.py
@@ -37,6 +37,12 @@ def _fd_limit_warn(msg: str) -> None:
 
 
 def _min_nofile_target() -> int:
+    """Return the target soft RLIMIT_NOFILE value.
+
+    Returns:
+        The positive integer from ``RAY_MIN_NOFILE`` when set, otherwise
+        ``DEFAULT_MIN_NOFILE``.
+    """
     raw = os.environ.get("RAY_MIN_NOFILE", "").strip()
     if raw.isdigit() and int(raw) > 0:
         return int(raw)
@@ -313,6 +319,7 @@ def quiet_ray_init(num_gpus: Optional[int] = None, log_path: Optional[Path] = No
     runtime_env = safe_runtime_env()
 
     def _init() -> None:
+        """Call ``ray.init`` with stdout suppressed and standard options."""
         buf = io.StringIO()
         with contextlib.redirect_stdout(buf):
             ray.init(

--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -1883,11 +1883,22 @@ def _try_generate_harness(
 
 
 def _rocprof_roofline_enabled() -> bool:
+    """Return whether rocprof roofline profiling is enabled.
+
+    Returns:
+        ``True`` unless ``HYPERLOOM_ROCPROF_ROOFLINE`` is set to a falsy value.
+    """
     value = os.environ.get("HYPERLOOM_ROCPROF_ROOFLINE", "1").strip().lower()
     return value not in {"0", "false", "no", "off"}
 
 
 def _rocprof_timeout_sec() -> int:
+    """Return the per-kernel rocprof roofline timeout in seconds.
+
+    Returns:
+        The value from ``HYPERLOOM_ROCPROF_ROOFLINE_TIMEOUT_SEC`` (floored at
+        60s), or ``1800`` when unset or invalid.
+    """
     try:
         return max(60, int(os.environ.get("HYPERLOOM_ROCPROF_ROOFLINE_TIMEOUT_SEC", "1800")))
     except ValueError:
@@ -1895,6 +1906,17 @@ def _rocprof_timeout_sec() -> int:
 
 
 def _rocprof_workdir(candidate: dict[str, Any], source_file: str, out_dir: Path) -> Path:
+    """Choose a working directory for the rocprof profiling run.
+
+    Args:
+        candidate: Candidate metadata containing ``kernel_repo``.
+        source_file: Path to the kernel source file.
+        out_dir: Fallback directory when no candidate path resolves.
+
+    Returns:
+        The first existing directory derived from the candidate/source paths,
+        else ``out_dir``.
+    """
     for raw in (candidate.get("kernel_repo"), source_file):
         if not raw:
             continue
@@ -1907,6 +1929,15 @@ def _rocprof_workdir(candidate: dict[str, Any], source_file: str, out_dir: Path)
 
 
 def _rocprof_profile_command(test_command: str) -> str:
+    """Convert a harness correctness command into a profiling command.
+
+    Args:
+        test_command: Original harness test command.
+
+    Returns:
+        The command with a single ``--correctness`` swapped for ``--profile``
+        when it targets a generated harness; otherwise the command unchanged.
+    """
     if "--correctness" not in test_command:
         return test_command
     if "/unittest/harness_" not in test_command and " harness_" not in test_command:
@@ -1915,6 +1946,15 @@ def _rocprof_profile_command(test_command: str) -> str:
 
 
 def _compact_rocprof_prompt(payload: dict[str, Any]) -> str:
+    """Render a compact roofline-evidence addendum for the agent prompt.
+
+    Args:
+        payload: Structured rocprof roofline payload.
+
+    Returns:
+        A Markdown snippet summarizing up to three kernels' roofline signals,
+        or an empty string when there are no results.
+    """
     rows = payload.get("results") if isinstance(payload, dict) else []
     if not isinstance(rows, list) or not rows:
         return ""
@@ -1950,6 +1990,23 @@ def _run_rocprof_roofline(
     prompt_file: Path,
     log_path: Path | None,
 ) -> dict[str, Any]:
+    """Run rocprof roofline before GEAK and append evidence to the prompt.
+
+    Profiles the kernel via the ``rocprof_roofline.py`` helper, writes the
+    JSON/text artifacts, and appends a compact evidence section to the prompt.
+
+    Args:
+        test_command: Harness command used to exercise the kernel.
+        candidate: Candidate kernel metadata.
+        source_file: Path to the kernel source file.
+        out_dir: Output directory for this attempt.
+        prompt_file: Prompt file to append roofline evidence to.
+        log_path: Optional log file for progress messages.
+
+    Returns:
+        A status dict with the run outcome and artifact paths (``status`` is
+        ``skipped``/``failed``/``ok``).
+    """
     roof_dir = out_dir / "rocprof_roofline"
     roof_dir.mkdir(parents=True, exist_ok=True)
     out_json = roof_dir / "before.json"
@@ -2013,6 +2070,15 @@ def _run_rocprof_roofline(
 
 
 def _rocprof_kernel_matches(row: dict[str, Any], target_kernel: str) -> bool:
+    """Return whether a roofline result row matches the target kernel.
+
+    Args:
+        row: Result row with ``matched_kernel_name`` / ``name`` fields.
+        target_kernel: Kernel name to match; empty matches any row.
+
+    Returns:
+        ``True`` if the row corresponds to ``target_kernel``.
+    """
     if not target_kernel:
         return True
     target = target_kernel.strip()
@@ -2024,6 +2090,17 @@ def _rocprof_kernel_matches(row: dict[str, Any], target_kernel: str) -> bool:
 
 
 def _rocprof_sidecar_from_payload(payload: dict[str, Any], txt_path: str, json_path: str) -> dict[str, Any]:
+    """Project a roofline payload into a sidecar record for one kernel.
+
+    Args:
+        payload: Structured rocprof roofline payload.
+        txt_path: Path to the text report, recorded on the result.
+        json_path: Path to the JSON report, recorded on the result.
+
+    Returns:
+        A roofline record for the matched (or first) kernel, or a
+        skipped/failed status record when no match is found.
+    """
     rows = payload.get("results") if isinstance(payload, dict) else []
     if not isinstance(rows, list) or not rows:
         return {
@@ -2065,6 +2142,15 @@ def _rocprof_sidecar_from_payload(payload: dict[str, Any], txt_path: str, json_p
 
 
 def _rocprof_phase_has_measurement(phase_data: dict[str, Any]) -> bool:
+    """Return whether a roofline phase contains real numeric measurements.
+
+    Args:
+        phase_data: A before/after roofline phase record.
+
+    Returns:
+        ``True`` only when the phase did not fail/skip and carries at least one
+        numeric roofline metric (metadata alone does not count).
+    """
     status = str(phase_data.get("status") or "").lower()
     if status in {"failed", "skipped"}:
         return False
@@ -2230,6 +2316,15 @@ def _restore_env(previous: dict[str, str | None]) -> None:
 
 
 def _oob_output_dir(session_id: str, prompt_file: Path) -> Path:
+    """Return the per-attempt output directory for an OOB run.
+
+    Args:
+        session_id: Session identifier for the run.
+        prompt_file: Prompt file whose stem scopes the attempt directory.
+
+    Returns:
+        The created ``.../oob/<session_id>/<prompt_stem>`` directory.
+    """
     # Per-attempt, mirroring _geak_output_dir. A session-level dir would let
     # concurrent OOB attempts share artifacts AND the per-attempt compile
     # caches (isolated_compile_cache_env keys off output_dir), reintroducing
@@ -3216,6 +3311,20 @@ def _select_source_artifact(
 
 
 def build_verification(args: argparse.Namespace, attempts: list[dict[str, Any]], benchmark_available: bool) -> dict[str, Any]:
+    """Summarize attempt results into a verification record.
+
+    Selects the best usable attempt (by extracted speedup, falling back to the
+    first usable one) and reports whether a real speedup was measured.
+
+    Args:
+        args: Parsed CLI arguments for the run.
+        attempts: Per-attempt result records.
+        benchmark_available: Whether a benchmark/harness was available to
+            measure speedups.
+
+    Returns:
+        A verification dict describing the best attempt and measured speedup.
+    """
     # Usable = completed cleanly OR killed-but-left-artifacts (status=partial).
     usable = [a for a in attempts if a.get("status") in {"completed", "partial"}]
     best = None

--- a/kernel-agent/tools/parallel_e2e_runner.py
+++ b/kernel-agent/tools/parallel_e2e_runner.py
@@ -266,6 +266,24 @@ def run_one_attempt(
     harness_path: str,
     num_gpus: int = 1,
 ) -> dict[str, Any]:
+    """Run a single backend/replica kernel-optimization attempt.
+
+    Args:
+        backend: Backend name to run (e.g. ``geak`` / ``oob``).
+        replica: Replica index within the backend's parallel fan-out.
+        gpu_id: Logical GPU id assigned to this attempt (informational; Ray
+            sets the visible-device env vars in workers).
+        args: Parsed CLI arguments for the run.
+        run_dir: Per-run output directory.
+        env: Base environment to extend for the child process.
+        kernel_id: Identifier of the kernel being optimized.
+        source_file: Path to the kernel source file.
+        harness_path: Path to the benchmark/validation harness.
+        num_gpus: Number of GPUs allotted to this attempt.
+
+    Returns:
+        A result dict describing the attempt's outcome and artifact paths.
+    """
     # Do NOT set HIP/ROCR/CUDA_VISIBLE_DEVICES here; Ray assigns them in workers.
     local_env = {
         **env,

--- a/kernel-agent/tools/rocprof_roofline.py
+++ b/kernel-agent/tools/rocprof_roofline.py
@@ -29,6 +29,14 @@ SATURATION_PCT = 60.0
 
 
 def _safe_float(value: str) -> float | None:
+    """Parse a string to float, returning ``None`` on failure.
+
+    Args:
+        value: String to convert.
+
+    Returns:
+        The parsed float, or ``None`` when ``value`` is not numeric.
+    """
     try:
         return float(value)
     except (TypeError, ValueError):
@@ -36,6 +44,14 @@ def _safe_float(value: str) -> float | None:
 
 
 def _bound_type(bound: str) -> str:
+    """Classify a roofline bound description into a short category.
+
+    Args:
+        bound: Free-form bound text (e.g. ``"memory-bound ..."``).
+
+    Returns:
+        One of ``"memory"``, ``"compute"``, ``"latency"``, or ``"unknown"``.
+    """
     lower = (bound or "").lower()
     if lower.startswith("memory-bound"):
         return "memory"
@@ -47,6 +63,14 @@ def _bound_type(bound: str) -> str:
 
 
 def _resolve_rocprof_compute() -> str | None:
+    """Locate the ``rocprof-compute`` executable.
+
+    Checks the ``HYPERLOOM_ROCPROF_COMPUTE_PATH`` / ``ROCPROF_COMPUTE_PATH``
+    environment variables, then ``PATH``, then the default ROCm install path.
+
+    Returns:
+        The resolved executable path, or ``None`` when not found.
+    """
     configured = (
         os.environ.get("HYPERLOOM_ROCPROF_COMPUTE_PATH", "").strip()
         or os.environ.get("ROCPROF_COMPUTE_PATH", "").strip()
@@ -65,6 +89,12 @@ def _resolve_rocprof_compute() -> str | None:
 
 
 def _check_rocprof_compute() -> str | None:
+    """Verify ``rocprof-compute`` runs and report its version.
+
+    Returns:
+        The detected version string (``"unknown"`` if unparsable), or ``None``
+        when the tool is missing or ``--version`` fails.
+    """
     tool = _resolve_rocprof_compute()
     if not tool:
         return None
@@ -85,10 +115,22 @@ class RocprofRooflineAnalyzer:
     """Small parser around rocprof-compute section 4 roofline output."""
 
     def __init__(self, output_path: str | Path | None = None):
+        """Initialize the analyzer.
+
+        Args:
+            output_path: Directory for rocprof-compute output; a temporary
+                directory is created when omitted.
+        """
         self.output_path = Path(output_path or tempfile.mkdtemp(prefix="rocprof_roofline_")).resolve()
         self.content = ""
 
     def parse_roofline_blocks(self) -> list[tuple[str, dict[str, tuple[float, float, str]]]]:
+        """Parse section 4.1 roofline rate metrics from the analyze output.
+
+        Returns:
+            A list of ``(kernel_name, rates)`` tuples, where ``rates`` maps a
+            metric name to ``(actual, peak, unit)``.
+        """
         blocks: list[tuple[str, dict[str, tuple[float, float, str]]]] = []
         current_name = "Unknown"
         rates: dict[str, tuple[float, float, str]] = {}
@@ -125,6 +167,13 @@ class RocprofRooflineAnalyzer:
         return blocks
 
     def parse_roofline_ai(self) -> list[dict[str, tuple[float, str]]]:
+        """Parse section 4.2 roofline AI plot points from the analyze output.
+
+        Returns:
+            A per-kernel list of metric maps, each mapping an AI/performance
+            metric name to ``(value, unit)`` (performance is normalized to
+            TFLOPS).
+        """
         out: list[dict[str, tuple[float, str]]] = []
         metrics: dict[str, tuple[float, str]] = {}
         in_section = False
@@ -160,6 +209,11 @@ class RocprofRooflineAnalyzer:
         return out
 
     def parse_real_hbm_peak(self) -> float | None:
+        """Extract the measured (real) HBM peak bandwidth from the output.
+
+        Returns:
+            The real HBM peak bandwidth in GB/s, or ``None`` when not present.
+        """
         for line in self.content.splitlines():
             if "│" in line and "17.1.5" in line:
                 parts = [p.strip() for p in line.split("│")]
@@ -182,6 +236,20 @@ class RocprofRooflineAnalyzer:
         ai_metrics: dict[str, tuple[float, str]],
         real_hbm_peak: float | None,
     ) -> dict[str, Any]:
+        """Compute roofline efficiency and bottleneck classification.
+
+        Args:
+            rates: Section 4.1 rate metrics mapping name to
+                ``(actual, peak, unit)``.
+            ai_metrics: Section 4.2 AI metrics mapping name to ``(value, unit)``.
+            real_hbm_peak: Measured HBM peak bandwidth, or ``None`` to fall
+                back to the empirical peak.
+
+        Returns:
+            A dict of derived metrics including the bound description and type,
+            compute/bandwidth utilization, arithmetic intensity, and roofline
+            efficiency against both empirical and real peaks.
+        """
         hbm_actual = hbm_emp_peak = None
         if "HBM Bandwidth" in rates:
             hbm_actual, hbm_emp_peak, _ = rates["HBM Bandwidth"]
@@ -250,6 +318,12 @@ class RocprofRooflineAnalyzer:
         }
 
     def analyze_structured(self) -> dict[str, Any]:
+        """Parse the analyze output into a structured per-kernel result.
+
+        Returns:
+            A dict with ``schema_version``, ``source``, ``real_hbm_peak``, and
+            a ``results`` list of per-kernel roofline records.
+        """
         blocks = self.parse_roofline_blocks()
         ai_list = self.parse_roofline_ai()
         real_hbm_peak = self.parse_real_hbm_peak()
@@ -282,6 +356,22 @@ class RocprofRooflineAnalyzer:
         analyze_blocks: str = "0 1 2 4 7 10 11 16 17",
         timeout_sec: int = 21600,
     ) -> tuple[bool, str | None]:
+        """Profile and analyze a command with rocprof-compute.
+
+        Runs ``rocprof-compute profile`` followed by ``analyze``, storing the
+        analyze text on ``self.content``.
+
+        Args:
+            workdir: Working directory in which to run the command.
+            cmd: Benchmark command to profile.
+            target_kernel: Optional kernel name filter.
+            analyze_blocks: Space-separated analyze block ids to request.
+            timeout_sec: Timeout applied to each subprocess.
+
+        Returns:
+            A ``(success, error)`` tuple; ``error`` carries the captured output
+            on failure and is ``None`` on success.
+        """
         tool = _resolve_rocprof_compute()
         if tool is None:
             return False, "rocprof-compute is not installed or not on PATH"
@@ -324,6 +414,15 @@ class RocprofRooflineAnalyzer:
 
 
 def recommended_actions(bound_type: str) -> list[str]:
+    """Return suggested optimization actions for a bottleneck type.
+
+    Args:
+        bound_type: Bottleneck category (``memory`` / ``compute`` / ``latency``).
+
+    Returns:
+        A list of human-readable optimization suggestions (empty for unknown
+        types).
+    """
     if bound_type == "memory":
         return ["Improve memory coalescing/locality", "Increase arithmetic intensity", "Use LDS/cache tiling when applicable"]
     if bound_type == "compute":
@@ -334,6 +433,14 @@ def recommended_actions(bound_type: str) -> list[str]:
 
 
 def build_text_report(payload: dict[str, Any]) -> str:
+    """Render a structured roofline payload into a human-readable report.
+
+    Args:
+        payload: Structured payload from :meth:`RocprofRooflineAnalyzer.analyze_structured`.
+
+    Returns:
+        A multi-line text report summarizing each kernel's roofline metrics.
+    """
     lines = ["Below is the rocprof-compute roofline information of the kernel:"]
     for row in payload.get("results", []):
         roof = row.get("rocprof_roofline") or {}
@@ -357,6 +464,12 @@ def build_text_report(payload: dict[str, Any]) -> str:
 
 
 def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
+    """Write JSON to ``path`` atomically via a temp file and rename.
+
+    Args:
+        path: Destination file path.
+        data: JSON-serializable data to write.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.NamedTemporaryFile("w", dir=str(path.parent), delete=False) as tmp:
         json.dump(data, tmp, indent=2, sort_keys=True)
@@ -366,6 +479,15 @@ def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
 
 
 def _kernel_name_matches(row: dict[str, Any], target_kernel: str) -> bool:
+    """Return whether a result row matches the target kernel name.
+
+    Args:
+        row: A result row with ``matched_kernel_name`` / ``name`` fields.
+        target_kernel: Kernel name to match; an empty value matches any row.
+
+    Returns:
+        ``True`` if the row corresponds to ``target_kernel``.
+    """
     if not target_kernel:
         return True
     target = target_kernel.strip()
@@ -464,6 +586,16 @@ def _generate_harness_for_candidate(
 
 
 def _profile_workdir(candidate: dict[str, Any], fallback: Path) -> Path:
+    """Pick a working directory for profiling a candidate kernel.
+
+    Args:
+        candidate: Candidate metadata with ``kernel_repo`` / ``source_file``.
+        fallback: Directory to use when no candidate path resolves.
+
+    Returns:
+        The first existing directory derived from the candidate paths, else
+        ``fallback``.
+    """
     for raw in (candidate.get("kernel_repo"), candidate.get("source_file")):
         if not raw:
             continue
@@ -529,6 +661,11 @@ def enrich_kernel_roofline_sidecar(
     fallback_workdir = Path(workdir).expanduser() if workdir else sidecar_p.parent
 
     def _log(msg: str) -> None:
+        """Forward a message to ``log_fn`` if one was provided.
+
+        Args:
+            msg: Message to log; sink errors are swallowed.
+        """
         if callable(log_fn):
             try:
                 log_fn(msg)
@@ -653,6 +790,14 @@ def enrich_kernel_roofline_sidecar(
 
 
 def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: profile a command and write roofline JSON/text.
+
+    Args:
+        argv: Argument list to parse; defaults to ``sys.argv`` when ``None``.
+
+    Returns:
+        Process exit code: ``0`` on success, ``1`` when profiling fails.
+    """
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--workdir", required=True)
     parser.add_argument("--cmd", required=True)

--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -2054,10 +2054,27 @@ def _coerce_float(value: Any) -> float | None:
 
 
 def _lower_keyed(row: dict) -> dict[str, Any]:
+    """Return a copy of ``row`` with keys trimmed and lower-cased.
+
+    Args:
+        row: Source mapping (e.g. a CSV/JSON record).
+
+    Returns:
+        A new dict keyed by the normalized column names.
+    """
     return {str(k).strip().lower(): v for k, v in row.items()}
 
 
 def _first_present(low: dict[str, Any], keys: tuple[str, ...]) -> str:
+    """Return the first non-empty value among candidate keys.
+
+    Args:
+        low: Lower-keyed record to read from.
+        keys: Candidate keys, in priority order.
+
+    Returns:
+        The first present, non-empty value as a stripped string, or ``""``.
+    """
     for k in keys:
         v = low.get(k)
         if v is not None and str(v).strip():
@@ -2101,6 +2118,14 @@ def _record_gpu_us(low: dict[str, Any]) -> float | None:
 
 
 def _record_gpu_pct(low: dict[str, Any]) -> float | None:
+    """Extract the GPU-time percentage from a per-op ranking record.
+
+    Args:
+        low: Lower-keyed ranking record.
+
+    Returns:
+        The GPU-time percentage, or ``None`` when no recognized key parses.
+    """
     for k in _RANK_PCT_KEYS:
         if k in low:
             val = _coerce_float(low[k])
@@ -2110,6 +2135,15 @@ def _record_gpu_pct(low: dict[str, Any]) -> float | None:
 
 
 def _ranking_record(raw: dict) -> dict[str, Any] | None:
+    """Normalize a raw ranking row into a standard candidate record.
+
+    Args:
+        raw: Raw CSV/JSON ranking row.
+
+    Returns:
+        A dict with ``name``, ``category``, ``gpu_us``, and ``gpu_pct``, or
+        ``None`` when the row has no usable op name.
+    """
     low = _lower_keyed(raw)
     name = _first_present(low, _RANK_NAME_KEYS)
     if not name:
@@ -2123,6 +2157,15 @@ def _ranking_record(raw: dict) -> dict[str, Any] | None:
 
 
 def _load_ops_ranking_csv(path: Path) -> list[dict[str, Any]]:
+    """Load per-op ranking records from a CSV sidecar.
+
+    Args:
+        path: Path to the CSV file.
+
+    Returns:
+        Normalized ranking records, or ``[]`` when the file is missing or
+        cannot be read.
+    """
     if not path.is_file():
         return []
     out: list[dict[str, Any]] = []
@@ -2138,6 +2181,17 @@ def _load_ops_ranking_csv(path: Path) -> list[dict[str, Any]]:
 
 
 def _iter_json_ranking_records(data: Any) -> list[dict]:
+    """Extract the list of ranking record dicts from parsed JSON.
+
+    Accepts either a top-level list or a dict containing the records under one
+    of several known keys.
+
+    Args:
+        data: Parsed JSON value.
+
+    Returns:
+        The list of dict records, or ``[]`` when none are found.
+    """
     if isinstance(data, list):
         return [r for r in data if isinstance(r, dict)]
     if isinstance(data, dict):
@@ -2152,6 +2206,15 @@ def _iter_json_ranking_records(data: Any) -> list[dict]:
 
 
 def _load_ops_ranking_json(path: Path) -> list[dict[str, Any]]:
+    """Load per-op ranking records from a JSON sidecar.
+
+    Args:
+        path: Path to the JSON file.
+
+    Returns:
+        Normalized ranking records, or ``[]`` when the file is missing or
+        cannot be parsed.
+    """
     if not path.is_file():
         return []
     try:
@@ -2192,6 +2255,12 @@ def load_ops_ranking(
 
 
 def _resolve_other_bucket_min_gpu_pct() -> float:
+    """Return the minimum GPU-time percentage for other-bucket recovery.
+
+    Returns:
+        The value from ``HYPERLOOM_OTHER_BUCKET_MIN_GPU_PCT`` when set to a
+        valid non-negative number, otherwise the default threshold.
+    """
     raw = os.environ.get(_OTHER_BUCKET_MIN_GPU_PCT_ENV, "").strip()
     if raw:
         val = _coerce_float(raw)
@@ -2201,6 +2270,15 @@ def _resolve_other_bucket_min_gpu_pct() -> float:
 
 
 def _is_other_like_category(category: str) -> bool:
+    """Return whether a category counts as the ``other`` bucket.
+
+    Args:
+        category: Raw or upstream category label.
+
+    Returns:
+        ``True`` if the label (or its normalized upstream form) is an
+        other-like category.
+    """
     raw_l = str(category or "").strip().lower()
     if raw_l in _OTHER_LIKE_CATEGORIES:
         return True
@@ -2254,6 +2332,15 @@ def recover_other_bucket_candidates(
     ) or 0.0
 
     def _pct(rec: dict[str, Any]) -> float | None:
+        """Return a record's GPU-time percentage.
+
+        Args:
+            rec: A ranking record.
+
+        Returns:
+            The explicit ``gpu_pct`` when present, else the share of
+            ``total_us`` derived from ``gpu_us``, else ``None``.
+        """
         if rec.get("gpu_pct") is not None:
             return float(rec["gpu_pct"])
         if total_us > 0 and rec.get("gpu_us") is not None:
@@ -2453,6 +2540,18 @@ def run_command(
     timeout_s: int,
     env: dict[str, str] | None = None,
 ) -> int:
+    """Run a subprocess, tee its output to a log, and return the exit code.
+
+    Args:
+        cmd: Command and arguments to execute.
+        cwd: Working directory, or ``None`` to inherit the current one.
+        log_path: Log file the command line and output are appended to.
+        timeout_s: Subprocess timeout in seconds.
+        env: Optional environment for the child process.
+
+    Returns:
+        The process return code.
+    """
     append_log(log_path, f"$ {' '.join(cmd)}")
     proc = subprocess.run(
         cmd,

--- a/kernel-agent/tools/tracelens_arch_benchmark.py
+++ b/kernel-agent/tools/tracelens_arch_benchmark.py
@@ -78,6 +78,14 @@ _VISIBLE_DEVICE_VARS = (
 
 
 def normalize_platform(platform: str) -> str:
+    """Normalize a platform/arch name to its canonical upper-case form.
+
+    Args:
+        platform: Platform or architecture name.
+
+    Returns:
+        The trimmed, upper-cased platform name.
+    """
     return (platform or "").strip().upper()
 
 
@@ -168,6 +176,15 @@ def resolve_arch_json_path(platform: str) -> Path | None:
 
 
 def default_arch_output_path(tracelens_root: Path, platform: str) -> Path:
+    """Return the default arch-spec JSON path for a platform.
+
+    Args:
+        tracelens_root: Root of the TraceLens checkout.
+        platform: Platform/architecture name.
+
+    Returns:
+        The conventional ``.../arch/<PLATFORM>.json`` path.
+    """
     canonical = normalize_platform(platform)
     return (
         tracelens_root

--- a/quantization_agent/cli.py
+++ b/quantization_agent/cli.py
@@ -35,6 +35,18 @@ from .driver.runner import DEFAULT_MODEL
 
 
 def _interactive_value(raw: str) -> bool | None:
+    """Parse the ``--interactive`` flag into a tri-state value.
+
+    Args:
+        raw: Raw flag value supplied on the command line.
+
+    Returns:
+        ``None`` for ``auto`` (tty auto-detection), ``True`` for the on-style
+        values, and ``False`` for the off-style values.
+
+    Raises:
+        argparse.ArgumentTypeError: If ``raw`` is not a recognized value.
+    """
     raw = raw.strip().lower()
     if raw in ("auto", "", "default"):
         return None
@@ -48,6 +60,14 @@ def _interactive_value(raw: str) -> bool | None:
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Build the argument parser and parse the CLI arguments.
+
+    Args:
+        argv: Argument list to parse; defaults to ``sys.argv`` when ``None``.
+
+    Returns:
+        The populated :class:`argparse.Namespace`.
+    """
     p = argparse.ArgumentParser(
         prog="quantization_agent",
         description="Drive the AMD Quark PTQ skill chain from a natural-language prompt.",
@@ -104,7 +124,21 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 async def _run(args: argparse.Namespace) -> int:
+    """Run one quantization request and print a JSON summary.
+
+    Args:
+        args: Parsed CLI arguments.
+
+    Returns:
+        Process exit code: ``0`` on success or partial success, ``1`` when the
+        resulting model is unusable.
+    """
     def log(line: str) -> None:
+        """Write a line to stderr when verbose output is enabled.
+
+        Args:
+            line: Text to emit.
+        """
         if args.verbose:
             print(line, file=sys.stderr, flush=True)
 
@@ -134,6 +168,14 @@ async def _run(args: argparse.Namespace) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for the quantization agent.
+
+    Args:
+        argv: Argument list to parse; defaults to ``sys.argv`` when ``None``.
+
+    Returns:
+        The process exit code produced by :func:`_run`.
+    """
     args = _parse_args(argv)
     return asyncio.run(_run(args))
 

--- a/quantization_agent/driver/assessment.py
+++ b/quantization_agent/driver/assessment.py
@@ -80,6 +80,12 @@ class Assessment:
     notes: tuple[str, ...] = field(default_factory=tuple)
 
     def to_dict(self) -> dict:
+        """Serialize the assessment to a JSON-friendly dictionary.
+
+        Returns:
+            A dict with the final outcome, per-attempt outcomes, recovery flag,
+            evaluation gap, and notes, using enum *values* for outcome ids.
+        """
         return {
             "final": self.final.value if self.final is not None else None,
             "attempts": [a.value if a is not None else None for a in self.attempts],
@@ -120,6 +126,15 @@ _QUANTIZED_LOAD_PATTERNS = (
 
 
 def _contains_any(haystack: str, needles: tuple[str, ...]) -> bool:
+    """Return whether any needle substring appears in ``haystack``.
+
+    Args:
+        haystack: String to search within.
+        needles: Candidate substrings to look for.
+
+    Returns:
+        ``True`` if at least one needle is found, otherwise ``False``.
+    """
     for n in needles:
         if n in haystack:
             return True
@@ -127,6 +142,15 @@ def _contains_any(haystack: str, needles: tuple[str, ...]) -> bool:
 
 
 def _parse_blocked_outcome(text: str | None) -> OutcomeId | None:
+    """Extract an explicit ``BLOCKED`` outcome id from agent output text.
+
+    Args:
+        text: Free-form text that may contain a ``BLOCKED`` outcome marker.
+
+    Returns:
+        The matching :class:`OutcomeId`, or ``None`` when no valid marker is
+        present.
+    """
     if not text:
         return None
     m = _BLOCKED_OUTCOME_RE.search(text)
@@ -234,6 +258,15 @@ def _classify_phase_artifact_gap(
 
 
 def _classify_bootstrap_sdk_error(sdk_error: str) -> OutcomeId | None:
+    """Classify a bootstrap-phase SDK error message into an outcome.
+
+    Args:
+        sdk_error: Raw error text raised before the skill chain started.
+
+    Returns:
+        The matching bootstrap :class:`OutcomeId` (e.g. missing Quark root,
+        unwritable workspace, runtime error), or ``None`` if unrecognized.
+    """
     msg = sdk_error.lower()
     if "quark_root" in msg or ("quark root" in msg and ("missing" in msg or "not found" in msg)):
         return OutcomeId.quark_root_missing

--- a/quantization_agent/driver/eval.py
+++ b/quantization_agent/driver/eval.py
@@ -88,6 +88,18 @@ def decide(
     workspace: Path,
     acceptable_eval_gap: float | None,
 ) -> EvalDecision:
+    """Decide whether an evaluation report passes the quality gap threshold.
+
+    Args:
+        eval_report: Parsed evaluation report, or ``None`` when absent.
+        workspace: Run workspace, used to resolve a per-run gap threshold file.
+        acceptable_eval_gap: Explicit maximum relative gap; falls back to the
+            workspace threshold or the default when ``None``.
+
+    Returns:
+        An :class:`EvalDecision` describing the status (``missing``,
+        ``within``, or ``exceeded``), the relative gap, and the threshold used.
+    """
     threshold, source = resolve_threshold(
         workspace, acceptable_eval_gap=acceptable_eval_gap
     )

--- a/quantization_agent/driver/outcomes.py
+++ b/quantization_agent/driver/outcomes.py
@@ -21,6 +21,7 @@ except ImportError:  # Python 3.10 fallback — mirror 3.11 StrEnum semantics
 
     class StrEnum(str, Enum):
         def __str__(self) -> str:
+            """Return the enum's string value (mirrors 3.11 ``StrEnum``)."""
             return str(self.value)
 
 

--- a/quantization_agent/driver/result_collector.py
+++ b/quantization_agent/driver/result_collector.py
@@ -107,6 +107,15 @@ _STEP_LINE_RE = re.compile(
 
 
 def _parse_validation_report(text: str) -> ValidationSteps:
+    """Parse the validator's Markdown report into per-step statuses.
+
+    Args:
+        text: Contents of ``validation_report.md``.
+
+    Returns:
+        A :class:`ValidationSteps` with the auxiliary, MD5, config, and fuzzy
+        step statuses (``ok`` / ``FAIL`` / ``skipped`` / ``None`` if absent).
+    """
     by_num: dict[str, str] = {}
     for m in _STEP_LINE_RE.finditer(text):
         # Normalize to lower-case "ok"/"fail"/"skipped" for downstream compares.
@@ -123,6 +132,14 @@ def _parse_validation_report(text: str) -> ValidationSteps:
 
 
 def _read_text(path: Path) -> str | None:
+    """Read a UTF-8 text file, returning ``None`` if it cannot be read.
+
+    Args:
+        path: File to read.
+
+    Returns:
+        The file contents, or ``None`` when the file is missing or unreadable.
+    """
     try:
         return path.read_text(encoding="utf-8")
     except FileNotFoundError:
@@ -132,6 +149,17 @@ def _read_text(path: Path) -> str | None:
 
 
 def _read_json(path: Path) -> tuple[dict | None, str | None]:
+    """Read and parse a JSON file.
+
+    Args:
+        path: File to read.
+
+    Returns:
+        A ``(data, error)`` tuple. On success ``data`` is the parsed object and
+        ``error`` is ``None``; on a decode failure ``data`` is ``None`` and
+        ``error`` is a human-readable message. A missing file yields
+        ``(None, None)``.
+    """
     raw = _read_text(path)
     if raw is None:
         return None, None
@@ -179,6 +207,15 @@ def _resolve_quantized_dir(workspace: Path) -> tuple[Path | None, bool, str | No
 
 
 def _has_any(directory: Path, names: Iterable[str]) -> bool:
+    """Return whether any of the named files exists in ``directory``.
+
+    Args:
+        directory: Directory to check.
+        names: Candidate file names.
+
+    Returns:
+        ``True`` if at least one named file exists, otherwise ``False``.
+    """
     for name in names:
         if (directory / name).is_file():
             return True
@@ -186,6 +223,15 @@ def _has_any(directory: Path, names: Iterable[str]) -> bool:
 
 
 def _has_glob(directory: Path, patterns: Iterable[str]) -> bool:
+    """Return whether any glob pattern matches a file in ``directory``.
+
+    Args:
+        directory: Directory to search.
+        patterns: Glob patterns to test.
+
+    Returns:
+        ``True`` if at least one pattern matches an entry, otherwise ``False``.
+    """
     for pat in patterns:
         for _ in directory.glob(pat):
             return True
@@ -213,6 +259,15 @@ def _scan_hypothesis_attempts(workspace: Path) -> tuple[int, ...]:
 
 
 def _strict_validation_enabled(env: dict[str, str] | None = None) -> bool:
+    """Return whether strict validation mode is enabled.
+
+    Args:
+        env: Environment mapping to read from; defaults to ``os.environ``.
+
+    Returns:
+        ``True`` unless ``STRICT_VALIDATION_ENV`` is explicitly set to a
+        falsy value (``0``, ``false``, ``no``, or empty).
+    """
     raw = (env if env is not None else os.environ).get(STRICT_VALIDATION_ENV, "1")
     return raw.strip().lower() not in ("0", "false", "no", "")
 
@@ -226,6 +281,21 @@ def collect_artifacts(
     *,
     env: dict[str, str] | None = None,
 ) -> CollectedArtifacts:
+    """Scan a run workspace and summarize the on-disk artifacts.
+
+    Inspects the run manifest, quantized model directory, validation report,
+    eval report, and retry/hypothesis markers to build the evidence record the
+    outcome classifier consumes.
+
+    Args:
+        workspace: Per-run workspace directory to inspect.
+        env: Environment mapping used for feature flags; defaults to
+            ``os.environ``.
+
+    Returns:
+        A :class:`CollectedArtifacts` describing which expected outputs are
+        present and any parse errors encountered.
+    """
     workspace = Path(workspace)
 
     qdir, manifest_present, manifest_err = _resolve_quantized_dir(workspace)

--- a/quantization_agent/driver/retry.py
+++ b/quantization_agent/driver/retry.py
@@ -82,6 +82,15 @@ class QuantSkillRunResult:
 # ─────────────────────────────────────────────────────────────────────────────
 
 def _read_counter(workspace: Path) -> int:
+    """Read the persisted requantize-attempt counter.
+
+    Args:
+        workspace: Run workspace holding the counter file.
+
+    Returns:
+        The current counter value, or ``0`` when the file is absent or
+        unreadable.
+    """
     f = workspace / _COUNTER_FILE
     if not f.is_file():
         return 0
@@ -92,6 +101,14 @@ def _read_counter(workspace: Path) -> int:
 
 
 def _bump_counter(workspace: Path) -> int:
+    """Increment and persist the requantize-attempt counter.
+
+    Args:
+        workspace: Run workspace holding the counter file.
+
+    Returns:
+        The new counter value after incrementing.
+    """
     n = _read_counter(workspace) + 1
     (workspace / _COUNTER_FILE).write_text(str(n), encoding="utf-8")
     return n
@@ -102,6 +119,15 @@ def _bump_counter(workspace: Path) -> int:
 # ─────────────────────────────────────────────────────────────────────────────
 
 def _resolve_interactive(interactive: bool | None) -> bool:
+    """Resolve the effective interactive mode.
+
+    Args:
+        interactive: Explicit mode, or ``None`` to auto-detect from the tty.
+
+    Returns:
+        The explicit value when provided, otherwise ``True`` only when both
+        stdin and stderr are attached to a tty.
+    """
     if interactive is not None:
         return interactive
     # Auto: only enable if stdin is a tty AND stderr is a tty (we use stderr
@@ -114,6 +140,15 @@ def _resolve_interactive(interactive: bool | None) -> bool:
 
 
 def _ask_operator(message: str) -> bool:
+    """Prompt the operator on stderr for a yes/no decision.
+
+    Args:
+        message: Question to display.
+
+    Returns:
+        ``True`` if the operator answers ``y``/``yes``; ``False`` otherwise,
+        including on EOF or interrupt.
+    """
     print(message, file=sys.stderr, flush=True)
     try:
         line = sys.stdin.readline()
@@ -364,6 +399,15 @@ def _build_failed_bootstrap_result(
 # Convenience sync wrapper for the CLI smoke path. The library entry remains
 # async to compose cleanly with the orchestrator's asyncio loop.
 def quantize_via_prompt_sync(prompt: str, **kwargs: Any) -> QuantSkillRunResult:
+    """Synchronous wrapper around :func:`quantize_via_prompt`.
+
+    Args:
+        prompt: Natural-language quantization request.
+        **kwargs: Keyword arguments forwarded to :func:`quantize_via_prompt`.
+
+    Returns:
+        The :class:`QuantSkillRunResult` produced by the async entry point.
+    """
     return asyncio.run(quantize_via_prompt(prompt, **kwargs))
 
 

--- a/quantization_agent/driver/runner.py
+++ b/quantization_agent/driver/runner.py
@@ -45,6 +45,15 @@ class AttemptResult:
 
 
 def _import_sdk() -> tuple[Any, Any]:
+    """Import the Claude Agent SDK and return its query primitives.
+
+    Returns:
+        A ``(query, ClaudeAgentOptions)`` tuple from ``claude_agent_sdk``.
+
+    Raises:
+        RuntimeError: If the SDK is not installed or is missing the required
+            ``query`` / ``ClaudeAgentOptions`` attributes.
+    """
     try:
         import claude_agent_sdk as sdk  # type: ignore[import-not-found]
     except ImportError as exc:  # pragma: no cover - exercised via injection seams in tests
@@ -57,6 +66,17 @@ def _import_sdk() -> tuple[Any, Any]:
 
 
 def _iter_message_text(message: Any) -> Iterable[str]:
+    """Yield text fragments from a Claude Agent SDK message.
+
+    Handles the varying SDK message shapes: ``.content`` blocks exposing
+    ``.text`` (object or dict) and a top-level ``.result`` string.
+
+    Args:
+        message: An SDK message object.
+
+    Yields:
+        Each non-empty text fragment found on the message.
+    """
     for block in list(getattr(message, "content", None) or []):
         text = getattr(block, "text", None)
         if isinstance(text, str) and text:

--- a/robustness-agent/src/robustness_agent/config.py
+++ b/robustness-agent/src/robustness_agent/config.py
@@ -485,6 +485,17 @@ def _discover_workload_uid() -> str:
 
 
 def _env_bool(name: str, default: bool) -> bool:
+    """Read a boolean configuration value from the environment.
+
+    Args:
+        name: Name of the environment variable to read.
+        default: Value to return when the variable is unset.
+
+    Returns:
+        ``True`` when the variable is set to one of ``1``, ``true``, ``yes``,
+        or ``on`` (case-insensitive); ``False`` for any other set value; and
+        ``default`` when the variable is unset.
+    """
     raw = os.environ.get(name)
     if raw is None:
         return default
@@ -492,6 +503,17 @@ def _env_bool(name: str, default: bool) -> bool:
 
 
 def _env_int(name: str, default: int) -> int:
+    """Read an integer configuration value from the environment.
+
+    Args:
+        name: Name of the environment variable to read.
+        default: Value to return when the variable is unset, empty, or not a
+            valid integer.
+
+    Returns:
+        The parsed integer, or ``default`` when the variable is missing or
+        cannot be parsed.
+    """
     raw = (os.environ.get(name) or "").strip()
     if not raw:
         return default

--- a/robustness-agent/src/robustness_agent/factory.py
+++ b/robustness-agent/src/robustness_agent/factory.py
@@ -490,6 +490,16 @@ class _QuietFallback:
     reason: str
 
     async def fetch(self, ctx: Any) -> SourceData:  # noqa: ARG002 - protocol
+        """Return empty source data describing the disabled local probe.
+
+        Args:
+            ctx: Fetch context supplied by the source protocol; unused because
+                this fallback never collects data.
+
+        Returns:
+            A :class:`SourceData` with no signals, annotated with a
+            ``degraded_reason`` explaining that the local probe is disabled.
+        """
         return SourceData(
             degraded_reason=f"local-probe disabled: {self.reason}",
             sources_used=[self.name],


### PR DESCRIPTION
## Summary

Re-applies the Google-style docstring + Sphinx documentation effort (previously PR #398/#329) on top of current main. The original pass was largely lost when the docs branch was merged with the refactored main using `-X theirs` (main won every conflicting hunk), dropping docstrings on ~145 source files. This PR restores comprehensive docstring coverage directly on top of latest main.

Scope: **source/importable packages only** (tests excluded), matching what the Sphinx `autosummary` reference documents. The Sphinx scaffold (Furo + Napoleon + recursive autosummary) already lives in `docs/` on main and is reused as-is.

Target: ~1,608 source functions flagged as missing docstrings (280) or having non-Google-style docstrings (1,328). This PR adds them incrementally, package by package.

### Progress
- [x] framework-agent
- [x] robustness-agent
- [x] quantization_agent
- [x] ci scripts
- [ ] kernel-agent
- [ ] inference_optimizer
- [ ] docstring upgrades for thin/non-Google docstrings
- [ ] Sphinx build verification (0 warnings)

## Test plan
- [ ] `cd docs && make html` builds cleanly (0 warnings)
- [ ] Spot-check rendered API pages for the documented packages

Made with [Cursor](https://cursor.com)