### PR TITLE
docs: upgrade existing docstrings to Google style (stacked on #542)

### DIFF
--- a/ci/artifact_normalizer.py
+++ b/ci/artifact_normalizer.py
@@ -93,8 +93,18 @@ def _first_of(data: dict[str, Any], *keys: str) -> Any | None:
 
 
 def _first_nested(data: dict[str, Any], *paths: str) -> Any | None:
-    """Return the first non-None value from dotted paths (compat across the
-    several flat and nested ci_metrics schemas agents have emitted)."""
+    """Return the first non-None value found among dotted paths.
+
+    Provides compatibility across the several flat and nested ci_metrics
+    schemas agents have emitted.
+
+    Args:
+        data: The mapping to traverse.
+        *paths: Dotted key paths, probed in order.
+
+    Returns:
+        The first resolved value, or ``None`` when no path resolves.
+    """
     for path in paths:
         cur: Any = data
         ok = True
@@ -528,8 +538,14 @@ def normalize_task_result(
 ) -> dict[str, Any]:
     """Normalize one task artifact directory.
 
-    ``manifest_record`` is caller-supplied task metadata; metrics are read
-    from files under ``task_dir``.
+    Args:
+        task_dir: Directory containing the task's collected artifacts.
+        manifest_record: Caller-supplied task metadata.
+        run: Optional run-level context merged into the result.
+
+    Returns:
+        The normalized result dict (schema-versioned) with metrics read from
+        files under ``task_dir``.
     """
     warnings: list[str] = []
 
@@ -605,6 +621,15 @@ def collect_normalized_results(
     """Normalize CI-collected artifacts using submission manifests.
 
     GitHub Actions adapter around ``normalize_task_result``.
+
+    Args:
+        artifacts_dir: Root directory of collected task artifacts.
+        manifests_dir: Directory tree holding ``submission_manifest.json``
+            files.
+        run: Optional run-level context merged into each result.
+
+    Returns:
+        One normalized result dict per task record across all manifests.
     """
     results: list[dict[str, Any]] = []
     manifest_files = sorted(manifests_dir.rglob("submission_manifest.json"))

--- a/ci/build_candidates.py
+++ b/ci/build_candidates.py
@@ -202,10 +202,16 @@ class HFClient:
         return r.json()
 
     def listing(self, limit: int) -> list[dict]:
-        """Top-N text-generation by downloads (raw HF API records).
+        """Return the top-N text-generation models by downloads.
 
-        HF caps one page at 1000 entries; follow the ``Link`` header cursor
-        until ``limit`` entries are fetched.
+        HF caps one page at 1000 entries; this follows the ``Link`` header
+        cursor until ``limit`` entries are fetched.
+
+        Args:
+            limit: Maximum number of model records to return.
+
+        Returns:
+            Raw HF API model records, up to ``limit``.
         """
         out: list[dict] = []
         page_limit = min(max(limit, 1), 1000)

--- a/ci/build_production_hf_pool.py
+++ b/ci/build_production_hf_pool.py
@@ -63,10 +63,16 @@ DEFAULT_AUTHOR_SLICES = [
 
 
 def _load_yaml_exclusions(path: Path) -> tuple[set[str], list[str]]:
-    """Read ``ci/inferenceX_models.yaml`` and return ``(exact_ids, keywords)``.
+    """Read ``ci/inferenceX_models.yaml`` and return its exclusions.
 
     Consumes ``models[].hf_model`` (exact lower-case match) and
     ``production_pool_exclusion_keywords`` (substring match).
+
+    Args:
+        path: Path to the InferenceX models YAML file.
+
+    Returns:
+        An ``(exact_ids, keywords)`` tuple; empty when the file is missing.
     """
     if not path.exists():
         return set(), []

--- a/ci/build_summary.py
+++ b/ci/build_summary.py
@@ -68,10 +68,19 @@ def fetch_inferenceX_ref(
     isl: int,
     osl: int,
 ) -> float | None:
-    """Look up InferenceX output_tput_per_gpu for repo_id on target_gpu.
+    """Look up the InferenceX reference throughput for a model.
 
-    Returns None when no comparison is available (unmapped repo, no benchmarks,
-    or no (hardware, ISL, OSL) match) — the column stays blank.
+    Args:
+        repo_id: HF repo id to look up.
+        hf_to_ifx: Mapping of HF repo ids to InferenceX api names.
+        target_gpu: GPU type to match.
+        isl: Input sequence length to match.
+        osl: Output sequence length to match.
+
+    Returns:
+        The ``output_tput_per_gpu`` reference value, or ``None`` when no
+        comparison is available (unmapped repo, no benchmarks, or no
+        (hardware, ISL, OSL) match).
     """
     api_name = hf_to_ifx.get(repo_id)
     if not api_name:

--- a/ci/generate_hf_matrix.py
+++ b/ci/generate_hf_matrix.py
@@ -363,6 +363,14 @@ def _filter_entries_by_explicit_models(
     Historically INPUT_MODELS returned bare repo strings and therefore lost
     framework / precision / tp / conc from candidates JSON. For manual reruns
     of a small subset from a fixed pool, keep the candidate dicts intact.
+
+    Args:
+        entries: Candidate entries (dicts or bare repo strings).
+        explicit_repos: Repo ids to keep; empty returns all entries.
+
+    Returns:
+        The matching entries in ``explicit_repos`` order; missing repos are
+        warned about and skipped.
     """
     if not explicit_repos:
         return entries
@@ -438,10 +446,17 @@ def _apply_exclusions(repos: list[str]) -> list[str]:
 
 
 def _load_candidate_entries(cands_path: Path) -> list[dict]:
-    """Load candidates.json and take an INPUT_BATCH_INDEX/INPUT_BATCH_SIZE slice.
+    """Load and normalize entries from a candidates JSON file.
 
-    BATCH_SIZE unset/0 returns all candidates. Slice order follows the JSON
-    (HF download rank) for deterministic batch dispatch.
+    Slice order follows the JSON (HF download rank) for deterministic batch
+    dispatch.
+
+    Args:
+        cands_path: Path to the candidates JSON file.
+
+    Returns:
+        Candidate entry dicts (with ``pool_id`` / ``pool_index`` filled in);
+        empty when the file cannot be read.
     """
     try:
         data = json.loads(cands_path.read_text(encoding="utf-8"))
@@ -513,6 +528,12 @@ def _cron_fire_counter(now_utc: datetime) -> int:
     Each scheduled cron fire (UTC 4/12/20) advances the counter by exactly one,
     so consecutive cron runs step through batch 0, 1, 2, ... in order (unlike a
     half-day slot, which collapsed the 12:00 and 20:00 fires onto one index).
+
+    Args:
+        now_utc: The UTC instant to map.
+
+    Returns:
+        A strictly increasing fire counter for the instant.
     """
     idx = bisect.bisect_right(_CRON_FIRE_HOURS_UTC, now_utc.hour) - 1
     if idx < 0:
@@ -537,6 +558,13 @@ def _cron_batch_index(pool_size: int, batch_size: int) -> int:
     instead of wrapping to the pool tail: a negative ``steps % batches`` would
     otherwise land on the last batch, silently skipping the not-run backlog the
     anchor is meant to drain first.
+
+    Args:
+        pool_size: Total number of candidate entries.
+        batch_size: Entries per batch.
+
+    Returns:
+        The 0-based batch index for the current scheduled fire.
     """
     batches = max((pool_size + batch_size - 1) // batch_size, 1)
     now_raw = (os.environ.get("INPUT_CRON_NOW") or "").strip()

--- a/ci/generate_matrix.py
+++ b/ci/generate_matrix.py
@@ -11,7 +11,14 @@ import yaml
 
 
 def _entry_key(m: dict) -> str:
-    """Effective matrix/filter key: explicit `key` field overrides `inferenceX_key`."""
+    """Return the effective matrix/filter key for a model entry.
+
+    Args:
+        m: A model config entry.
+
+    Returns:
+        The explicit ``key`` field when set, otherwise ``inferenceX_key``.
+    """
     return m.get("key") or m["inferenceX_key"]
 
 

--- a/ci/import_session_breakdown.py
+++ b/ci/import_session_breakdown.py
@@ -193,7 +193,17 @@ def derive_image(framework_name: str, session_image: Optional[str]) -> str:
 
 
 def derive_image_short(image: str) -> str:
-    """Strip version tag/digest, return the last 2 path components (or 1 if only one)."""
+    """Shorten a container image reference for display.
+
+    Strips the version tag/digest and keeps the last two path components
+    (or one when only one is present).
+
+    Args:
+        image: The full container image reference.
+
+    Returns:
+        The shortened image string, or ``"unknown"`` when empty.
+    """
     img = image.split("@")[0]            # strip digest
     img = img.split(":")[0]              # strip tag
     parts = [p for p in img.split("/") if p]
@@ -203,8 +213,18 @@ def derive_image_short(image: str) -> str:
 
 
 def derive_unique_key(model_name: str, image: str) -> str:
-    """BASE64("<model_name>+<image_short>"); matches the perf-runs API unique_key
-    contract so dev rows promote to prod without rekeying."""
+    """Build the perf-runs ``unique_key`` for a (model, image) pair.
+
+    Returns ``BASE64("<model_name>+<image_short>")``, matching the perf-runs
+    API contract so dev rows promote to prod without rekeying.
+
+    Args:
+        model_name: The model name.
+        image: The container image reference.
+
+    Returns:
+        The base64-encoded unique key.
+    """
     raw = f"{model_name}+{derive_image_short(image)}"
     return base64.b64encode(raw.encode("utf-8")).decode("ascii")
 
@@ -213,8 +233,15 @@ _STOP_REASON_FAILED_TOKENS = ("timeout", "killed", "error", "failed", "abort", "
 
 
 def derive_status(session: Dict) -> str:
-    """Map session.stop_reason to {success, running, failed}: empty=>running,
-    failure token=>failed, else success (report emitted = clean termination)."""
+    """Map ``session.stop_reason`` to a coarse status.
+
+    Args:
+        session: The session dict carrying ``stop_reason``.
+
+    Returns:
+        ``"running"`` (empty stop reason), ``"failed"`` (a failure token),
+        or ``"success"`` otherwise.
+    """
     stop = (session.get("stop_reason") or "").strip().lower()
     if not stop:
         return "running"
@@ -224,8 +251,17 @@ def derive_status(session: Dict) -> str:
 
 
 def detect_category(data: Dict) -> str:
-    """MoE if a kernel category/name or model name has MoE markers; VLM for
-    vision markers; else Dense."""
+    """Classify a session as MoE, VLM, or Dense.
+
+    MoE wins when a kernel category/name or the model name has MoE markers;
+    VLM for vision markers; otherwise Dense.
+
+    Args:
+        data: The session breakdown data dict.
+
+    Returns:
+        One of ``"MoE"``, ``"VLM"``, or ``"Dense"``.
+    """
     kernels = safe_get(data, "kernel_lifecycle", "detected", default=[]) or []
     if isinstance(kernels, list):
         for k in kernels:
@@ -271,9 +307,17 @@ def reshape_snapshot(snap: Optional[Dict]) -> Optional[Dict]:
 
 
 def extract_roofline(data: Dict) -> Optional[Dict]:
-    """Pass through the first roofline entry verbatim for full fidelity (every
-    nested field). Previously reshaped fields remain under entry.baseline.* /
-    entry.latest.* — nothing removed."""
+    """Return the first roofline entry verbatim for full fidelity.
+
+    Every nested field is preserved; previously reshaped fields remain under
+    ``entry.baseline.*`` / ``entry.latest.*``.
+
+    Args:
+        data: The session breakdown data dict.
+
+    Returns:
+        A deep copy of the first roofline entry, or ``None`` when absent.
+    """
     rl_list = safe_get(data, "roofline", default=[]) or []
     if isinstance(rl_list, list) and rl_list and isinstance(rl_list[0], dict):
         return copy.deepcopy(rl_list[0])
@@ -321,8 +365,18 @@ def compute_kernel_gain(attribution_src: Dict) -> Optional[float]:
 
 
 def compute_param_gain(attribution_src: Dict) -> Optional[float]:
-    """Param-attribution gain = params choice + sweep variant search (sweep is a
-    parameter-space search, so it belongs in the 'param' category)."""
+    """Compute the param-attribution gain.
+
+    Sums the params choice and sweep variant search (a sweep is a
+    parameter-space search, so it belongs in the 'param' category).
+
+    Args:
+        attribution_src: The ``attribution.source_breakdown`` sub-dict.
+
+    Returns:
+        The combined gain rounded to two decimals, or ``None`` when both
+        values are absent.
+    """
     params = attribution_src.get("params_pct_of_total")
     sweep = attribution_src.get("sweep_pct_of_total")
     if params is None and sweep is None:
@@ -380,8 +434,18 @@ def compute_oob_gain(attribution_src: Dict) -> Optional[float]:
 
 
 def compute_framework_gain(attribution: Dict) -> Optional[float]:
-    """Framework-source gain = SUM(delta_pct) over gain_per_stack_entry[] where
-    action='framework_pr'. None when absent so normalisation collapses it to 0.00."""
+    """Compute the framework-source gain.
+
+    Sums ``delta_pct`` over ``gain_per_stack_entry[]`` where
+    ``action == "framework_pr"``.
+
+    Args:
+        attribution: The ``attribution`` sub-dict.
+
+    Returns:
+        The summed gain rounded to two decimals, or ``None`` when absent so
+        normalisation collapses it to ``0.00``.
+    """
     entries = attribution.get("gain_per_stack_entry")
     if not isinstance(entries, list):
         return None
@@ -744,9 +808,20 @@ def format_duration_pretty(seconds: Optional[int]) -> str:
 
 
 def enrich_raw_data(original: Dict, row: Dict[str, Any], meta: Optional[Dict] = None) -> Dict:
-    """Build the JSON persisted into perf_runs.raw_data: deep-copy the original,
-    backfill session.image when missing, and add a top-level `_enrichment` block
-    of inferred/computed values (`meta` carries derivation provenance)."""
+    """Build the JSON persisted into ``perf_runs.raw_data``.
+
+    Deep-copies the original, backfills ``session.image`` /
+    ``session.session_duration_seconds`` / workload dims when missing, and
+    adds a top-level ``_enrichment`` block of inferred/computed values.
+
+    Args:
+        original: The original session breakdown JSON.
+        row: The derived perf-runs row supplying fallbacks.
+        meta: Optional derivation provenance recorded under ``_enrichment``.
+
+    Returns:
+        The enriched, deep-copied data dict.
+    """
     enriched = copy.deepcopy(original)
 
     session = enriched.get("session")
@@ -1080,7 +1155,18 @@ def _sql_jsonb_literal(obj: Any) -> str:
 
 
 def build_upsert_statement_inline(row: Dict[str, Any], table: str) -> str:
-    """Build one SQL statement with all values inlined (dollar-quoted)."""
+    """Build one upsert SQL statement with all values inlined.
+
+    String values are dollar-quoted so the statement can be piped over SSH
+    without a parameter protocol.
+
+    Args:
+        row: The perf-runs row to upsert.
+        table: Target table name (sanitized internally).
+
+    Returns:
+        The complete SQL upsert statement.
+    """
     table = safe_table(table)
     parts = (
         f"INSERT INTO {table} (\n"
@@ -1148,7 +1234,19 @@ def build_upsert_statement_inline(row: Dict[str, Any], table: str) -> str:
 
 
 def build_ssh_kubectl_psql(hop1: str, namespace: str, user: str, dbname: str) -> List[str]:
-    """Return argv to invoke psql on the master postgres pod via SSH+kubectl (stdin piped)."""
+    """Build the argv to run ``psql`` on the master Postgres pod over SSH.
+
+    The SQL is expected to be piped via stdin to the returned command.
+
+    Args:
+        hop1: SSH jump host (``user@host``) to reach the cluster.
+        namespace: Kubernetes namespace of the Postgres cluster.
+        user: Postgres user to connect as.
+        dbname: Target database name.
+
+    Returns:
+        The ``ssh`` argv list invoking ``kubectl exec ... psql``.
+    """
     remote_cmd = (
         f"kubectl exec -i -n {namespace} "
         f"$(kubectl get pod -n {namespace} "
@@ -1249,8 +1347,18 @@ def looks_like_session_breakdown(data: Any) -> bool:
 
 
 def looks_like_v1_flat_schema(data: Any) -> bool:
-    """Recognise the legacy 'V1 flat' layout: top-level dict with model,
-    framework, baseline_tput and best_tput (not nested under workload/baseline)."""
+    """Recognise the legacy "V1 flat" schema layout.
+
+    A V1 flat doc is a top-level dict with ``model``, ``framework``,
+    ``baseline_tput`` and ``best_tput`` (not nested under
+    ``workload`` / ``baseline``).
+
+    Args:
+        data: The parsed JSON value to inspect.
+
+    Returns:
+        ``True`` when the value matches the V1 flat schema.
+    """
     if not isinstance(data, dict):
         return False
     return (

--- a/ci/inferenceX_parser.py
+++ b/ci/inferenceX_parser.py
@@ -198,7 +198,17 @@ def synthesize_entry_from_ci_config(model_cfg: dict) -> dict:
 
 
 def parse_model_entry(entry: dict) -> dict:
-    """Extract structured config from an amd-master.yaml model entry."""
+    """Extract structured config from an amd-master.yaml model entry.
+
+    Supports both ``seq-len-configs`` (old) and
+    ``scenarios.fixed-seq-len`` (new) layouts.
+
+    Args:
+        entry: A single model entry from the InferenceX YAML.
+
+    Returns:
+        A structured config dict (model name, seq-len pairs, search space).
+    """
     # Support both seq-len-configs (old) and scenarios.fixed-seq-len (new).
     seq_configs = (
         entry.get("seq-len-configs")

--- a/ci/optimize_submit.py
+++ b/ci/optimize_submit.py
@@ -2284,7 +2284,24 @@ def _wait_for_nfs_session_delivery(
     grace_min: float | None = None,
     idle_min: float | None = None,
 ) -> str | None:
-    """After SaFE early terminal, wait while the NFS session is still active."""
+    """Wait for NFS session delivery after a SaFE early-terminal status.
+
+    Polls the session directory while it still appears active, up to the
+    grace/idle deadlines, so delivery-contract files have time to land.
+
+    Args:
+        rec: The submission record.
+        current_session_hints: Optional session-id hints to bias matching.
+        poll_s: Poll interval in seconds.
+        grace_min: Overall grace window in minutes; resolved from env when
+            ``None``.
+        idle_min: Idle window in minutes before giving up; resolved from env
+            when ``None``.
+
+    Returns:
+        The session directory to collect from, or ``None`` when none found
+        or grace is disabled.
+    """
     grace_min = _env_float("SAFE_OPTIMIZE_NFS_LIVE_GRACE_MIN", 180.0) \
         if grace_min is None else grace_min
     idle_min = _env_float("SAFE_OPTIMIZE_NFS_IDLE_GRACE_MIN", 20.0) \
@@ -2349,16 +2366,30 @@ def _wait_for_nfs_session_delivery(
 
 
 def _category_from_arch(arch: str | None) -> str:
-    """Coarse model-shape classification: "moe" if arch contains "moe", else
-    "dense"; "" when unknown so downstream JSON stays "n/a"."""
+    """Classify a model's coarse shape from its architecture name.
+
+    Args:
+        arch: The HF architecture name, if known.
+
+    Returns:
+        ``"moe"`` when the arch contains "moe", ``"dense"`` otherwise, or
+        ``""`` when unknown (so downstream JSON stays ``"n/a"``).
+    """
     if not arch:
         return ""
     return "moe" if "moe" in arch.lower() else "dense"
 
 
 def _sandbox_duration_seconds(last_task: dict) -> float | None:
-    """SaFE-side sandbox wallclock = finishedAt - startedAt (from the task API).
-    None when either field is missing/unparseable so we don't fabricate a duration."""
+    """Compute SaFE-side sandbox wallclock (``finishedAt - startedAt``).
+
+    Args:
+        last_task: The SaFE task payload carrying timestamp fields.
+
+    Returns:
+        The duration in seconds (rounded), or ``None`` when either field is
+        missing/unparseable so a duration is never fabricated.
+    """
     from datetime import datetime
     start = (last_task or {}).get("startedAt") or ""
     end = (last_task or {}).get("finishedAt") or ""
@@ -2380,6 +2411,12 @@ def _find_hyperloom_commit_sha(start: Path) -> str:
     First hit wins: (1) hyperloom_source_commit.txt written by the agent (depth
     varies by which fallback collected it), then (2) the CI runner env
     (HYPERLOOM_SOURCE_REF, else GITHUB_SHA).
+
+    Args:
+        start: A path inside the collected session tree to search from.
+
+    Returns:
+        The resolved SHA string, or ``""`` when none is found.
     """
     candidates = [
         start.parent / "hyperloom_source_commit.txt",
@@ -2407,13 +2444,17 @@ def _find_hyperloom_commit_sha(start: Path) -> str:
 
 
 def _backfill_ci_metrics_file(path: Path, rec: SubmissionRecord) -> None:
-    """Backfill task metadata (model, image, hyperloom_commit, category,
-    sandbox_duration_seconds) into ci_metrics.json / session_breakdown.json /
-    manifest.json so each artifact is self-describing.
+    """Backfill task metadata into a CI artifact so it is self-describing.
 
-    Writes the right shape per filename: ci_metrics.json → flat top-level;
-    session_breakdown.json → under session_meta; manifest.json → flat top-level
-    (V2 cli schema; category/duration are extra keys V2 ignores on re-read).
+    Adds model, image, hyperloom_commit, category, and
+    sandbox_duration_seconds. Writes the right shape per filename:
+    ci_metrics.json → flat top-level; session_breakdown.json → under
+    session_meta; manifest.json → flat top-level (V2 cli schema;
+    category/duration are extra keys V2 ignores on re-read).
+
+    Args:
+        path: The artifact file to backfill (no-op for other filenames).
+        rec: The submission record supplying the metadata.
     """
     if path.name not in ("ci_metrics.json", "session_breakdown.json", "manifest.json"):
         return

--- a/ci/optimize_submit.py
+++ b/ci/optimize_submit.py
@@ -127,7 +127,15 @@ _KERNEL_BACKEND_ALIASES = {
 
 
 def normalize_gpu_profile(gpu_type: str | None, *, warn: bool = True) -> str | None:
-    """Return the GPU profile key when ``gpu_type`` maps to a known CI profile."""
+    """Return the GPU profile key when ``gpu_type`` maps to a known CI profile.
+
+    Args:
+        gpu_type: Free-form GPU type/alias, or ``None``.
+        warn: When True, log a warning if no profile matches.
+
+    Returns:
+        The matching profile key, or ``None`` when no profile matches.
+    """
     raw = (gpu_type or "").strip()
     compact = re.sub(r"[^a-z0-9]", "", raw.lower())
     for key, profile in GPU_PROFILES.items():
@@ -166,8 +174,14 @@ _PROMPT_PREFIX_FILE = Path(__file__).resolve().parent / "prompt_prefix.txt"
 
 
 def _load_default_prompt_prefix() -> str:
-    """Resolve the default ``--prompt-prefix``: $SAFE_OPTIMIZE_PROMPT_PREFIX,
-    else ci/prompt_prefix.txt, else empty string."""
+    """Resolve the default ``--prompt-prefix`` value.
+
+    Resolution order: ``$SAFE_OPTIMIZE_PROMPT_PREFIX``, then
+    ``ci/prompt_prefix.txt``, then an empty string.
+
+    Returns:
+        The resolved prompt prefix text.
+    """
 
     env_value = os.environ.get("SAFE_OPTIMIZE_PROMPT_PREFIX", "")
     if env_value:
@@ -187,11 +201,18 @@ _MULTINODE_BNXT_TAR = "/wekafs/primus/data/libbnxt/libbnxt_re-234.0.154.0.tar.gz
 
 
 def _multinode_prompt_suffix(nodes: int, rayjob_image: str) -> str:
-    """RayJob topology block injected into the prompt when nodes > 1.
+    """Build the RayJob topology block injected into the prompt for multi-node.
 
     The SaFE tasks body has no node-count field, so multi-node is expressed the
     same way the Claw-direct CI does: tell the agent to fan out to an N-node
-    RayJob with the exact topology. Returns "" for single-node (unchanged path).
+    RayJob with the exact topology.
+
+    Args:
+        nodes: Number of nodes; values <= 1 yield no suffix.
+        rayjob_image: RayJob container image to reference in the block.
+
+    Returns:
+        The prompt suffix, or ``""`` for single-node runs.
     """
     if nodes <= 1:
         return ""
@@ -280,8 +301,15 @@ GENERATIVE_ARCH_SUFFIXES: tuple[str, ...] = (
 
 
 def is_generative_arch(arch: str) -> bool:
-    """True if the HF arch is causal-LM-style inference; False for empty/unknown
-    (better to skip than waste a sandbox slot)."""
+    """Report whether an HF architecture is causal-LM-style for inference.
+
+    Args:
+        arch: The HF architecture name.
+
+    Returns:
+        ``True`` for generative architectures; ``False`` for empty/unknown
+        (better to skip than waste a sandbox slot).
+    """
     if not arch:
         return False
     return any(arch.endswith(s) for s in GENERATIVE_ARCH_SUFFIXES)
@@ -385,6 +413,13 @@ class HuggingFaceClient:
         Pool-then-filter: the listing API matches on tags only, so re-validate
         per-repo on pipeline_tag == "text-generation" AND a generative
         architectures[0] suffix; either failing (or a gated 401) → skip.
+
+        Args:
+            limit: Maximum number of repos to return.
+            min_params_b: Minimum parameter count in billions (0 disables).
+
+        Returns:
+            Repo ids passing all gates, in download-rank order.
         """
         pool_size = max(limit * 10, 100)
         listing = self._get(
@@ -459,10 +494,19 @@ class DetectedConfig:
 
 
 def _quant_type(config: dict) -> str:
-    """Read the quantization tag from HF config.json (vendors disagree on the
-    field name). Priority: quant_algo (NVIDIA modelopt — quant_method there is
-    just the tool name) > quant_type > quantization_type > quant_method
-    (current de-facto standard) > method. First non-empty wins, lowercased."""
+    """Read the quantization tag from an HF ``config.json``.
+
+    Vendors disagree on the field name. Priority: ``quant_algo`` (NVIDIA
+    modelopt — ``quant_method`` there is just the tool name) > ``quant_type``
+    > ``quantization_type`` > ``quant_method`` (current de-facto standard) >
+    ``method``. First non-empty wins.
+
+    Args:
+        config: An HF ``config.json`` dict.
+
+    Returns:
+        The quantization tag lowercased, or ``""`` when none is present.
+    """
     quant = config.get("quantization_config") or {}
     raw = (
         quant.get("quant_algo")
@@ -545,7 +589,15 @@ def detect_param_count(hf_info: dict, config: dict) -> float:
 
 
 def detect_max_context_tokens(config: dict) -> int:
-    """Return the model context length from HF config.json when present."""
+    """Return the model context length from an HF ``config.json``.
+
+    Args:
+        config: An HF ``config.json`` dict.
+
+    Returns:
+        The smallest positive context-length field found, or ``0`` when none
+        is present.
+    """
     candidates = []
     for key in ("max_position_embeddings", "max_sequence_length", "n_positions", "seq_length"):
         value = config.get(key)
@@ -580,9 +632,17 @@ def context_too_short(
 
 def detect_tp(params_b: float, precision: str = "BF16",
               gpu_type: str | None = None) -> int:
-    """Pick tensor parallelism from param count and GPU profile. precision is
-    kept for API compatibility but unused — CI policy stays predictable across
-    precision variants of the same model family."""
+    """Pick tensor parallelism from param count and GPU profile.
+
+    Args:
+        params_b: Parameter count in billions.
+        precision: Kept for API compatibility but unused — CI policy stays
+            predictable across precision variants of the same model family.
+        gpu_type: GPU type used to select the threshold profile.
+
+    Returns:
+        The tensor-parallel size (1, 2, 4, or 8).
+    """
     if params_b <= 0:
         return 1
     profile_key = normalize_gpu_profile(gpu_type) or DEFAULT_GPU_PROFILE
@@ -624,6 +684,12 @@ def _sglang_image_for(repo_id: str = "") -> str:
     attention CUDA-graph-capture SIGABRT. Matched on the repo basename so it
     fires for the HF repo id (the /wekafs/<org>-<repo> local path is derived
     downstream from this same id).
+
+    Args:
+        repo_id: HF repo id used to detect per-model image needs.
+
+    Returns:
+        The SGLang image reference to use.
     """
     basename = (repo_id or "").split("/")[-1].lower()
     if "mimo-v2" in basename:

--- a/ci/optimize_submit.py
+++ b/ci/optimize_submit.py
@@ -853,8 +853,17 @@ class SafeOptimizeClient:
         return resp.json() if resp.content else {}
 
     def find_model(self, repo_id: str) -> dict | None:
-        """Look up an existing SaFE Model by HF source URL, scoped to
-        register_workspace (where the canonical Model CR + LocalPaths live)."""
+        """Look up an existing SaFE Model by HF source URL.
+
+        Scoped to ``register_workspace`` (where the canonical Model CR +
+        LocalPaths live).
+
+        Args:
+            repo_id: HF repo id to look up.
+
+        Returns:
+            The matching model record, or ``None`` when not found.
+        """
         hf_url = f"https://huggingface.co/{repo_id}".rstrip("/")
         from urllib.parse import quote
         try:
@@ -875,10 +884,18 @@ class SafeOptimizeClient:
     ) -> str:
         """Register a model record with SaFE so submit_task has a model_id.
 
-        local_path set → accessMode=local_path: SaFE skips its Download Job
-        (phase=Ready immediately) since files are already on disk (prewarm path).
-        local_path empty → accessMode=local: SaFE downloads from HF (slow
-        fallback when prewarm can't run).
+        ``local_path`` set → accessMode=local_path: SaFE skips its Download Job
+        (phase=Ready immediately) since files are already on disk (prewarm
+        path). ``local_path`` empty → accessMode=local: SaFE downloads from HF
+        (slow fallback when prewarm can't run).
+
+        Args:
+            repo_id: HF repo id to register.
+            hf_token: Optional HF token for gated downloads.
+            local_path: On-disk model path; enables local_path access mode.
+
+        Returns:
+            The registered model id.
         """
         if local_path:
             # local_path mode bypasses SaFE's HF metadata fetch, so we MUST
@@ -1113,11 +1130,20 @@ class SafeOptimizeClient:
     def wait_task_done(
         self, task_id: str, timeout_min: int = 480, poll_s: int = 60,
     ) -> tuple[str, dict]:
-        """Wait until the task reaches a terminal status. Returns (status, last_task).
+        """Wait until the task reaches a terminal status.
 
-        Prefer the Claw SSE stream (SaFE's task status lags Claw by minutes), and
-        fall back to SaFE polling when no clawSessionId exists or SSE fails.
-        Returns ('Timeout', {}) if neither sees a terminal status by the deadline.
+        Prefers the Claw SSE stream (SaFE's task status lags Claw by minutes),
+        and falls back to SaFE polling when no clawSessionId exists or SSE
+        fails.
+
+        Args:
+            task_id: The SaFE task id to wait on.
+            timeout_min: Overall deadline in minutes.
+            poll_s: Poll interval in seconds for the SaFE fallback.
+
+        Returns:
+            A ``(status, last_task)`` tuple; ``("Timeout", {})`` when no
+            terminal status is seen by the deadline.
         """
         log.info("[task %s] waiting for completion (timeout=%dm, poll=%ds)",
                  task_id, timeout_min, poll_s)
@@ -1266,8 +1292,15 @@ class SafeOptimizeClient:
         return "idle_timeout"
 
     def _claw_session_id_for(self, task_id: str) -> str | None:
-        """Resolve clawSessionId for a task (per-instance cached). None when
-        SaFE has no session attached (e.g. task failed before session creation)."""
+        """Resolve the clawSessionId for a task (per-instance cached).
+
+        Args:
+            task_id: The SaFE task id.
+
+        Returns:
+            The clawSessionId, or ``None`` when SaFE has no session attached
+            (e.g. the task failed before session creation).
+        """
         if not hasattr(self, "_claw_session_cache"):
             self._claw_session_cache = {}
         if task_id in self._claw_session_cache:
@@ -1285,9 +1318,15 @@ class SafeOptimizeClient:
     def list_artifacts(self, task_id: str) -> list[dict]:
         """List task artifacts via the SaFE standard endpoint.
 
-        Returns items shaped {path, size, lastModified, downloadPath}.
-        downloadPath is server-relative; download_artifact() uses it when present,
-        else builds the /artifacts/download?path= URL from path.
+        ``downloadPath`` is server-relative; ``download_artifact`` uses it when
+        present, else builds the ``/artifacts/download?path=`` URL from path.
+
+        Args:
+            task_id: The SaFE task id.
+
+        Returns:
+            Artifact items shaped ``{path, size, lastModified, downloadPath}``
+            (empty list on error).
         """
         try:
             data = self._request(
@@ -1303,8 +1342,19 @@ class SafeOptimizeClient:
         return items
 
     def download_artifact(self, task_id: str, path_or_item: "str | dict") -> bytes:
-        """Download a single task artifact. Accepts a string path or a
-        list_artifacts item dict; prefers the item's downloadPath when present."""
+        """Download a single task artifact.
+
+        Args:
+            task_id: The SaFE task id.
+            path_or_item: An artifact path string or a ``list_artifacts``
+                item dict; the item's ``downloadPath`` is preferred.
+
+        Returns:
+            The artifact bytes.
+
+        Raises:
+            RuntimeError: If the download responds with status ``>= 400``.
+        """
         if isinstance(path_or_item, dict):
             download_path = (path_or_item.get("downloadPath") or "").strip()
             if download_path:

--- a/ci/optimize_submit.py
+++ b/ci/optimize_submit.py
@@ -1704,8 +1704,19 @@ def _is_wanted_artifact(path: str, all_artifacts: bool) -> bool:
 
 
 def _safe_local_path(artifacts_dir: Path, task_id: str, remote_path: str) -> Path:
-    """Map a session-relative remote path to a local file path, stripping leading
-    slashes / '..' so we never escape the artifacts dir."""
+    """Map a session-relative remote path to a safe local file path.
+
+    Strips leading slashes and ``..`` segments so the result never escapes
+    the artifacts directory.
+
+    Args:
+        artifacts_dir: Root artifacts directory.
+        task_id: Task id used as a subdirectory.
+        remote_path: The session-relative remote path.
+
+    Returns:
+        The sanitized local path under ``artifacts_dir/task_id``.
+    """
     rel = remote_path.lstrip("/").replace("\\", "/")
     parts = [seg for seg in rel.split("/") if seg and seg != ".." and seg != "."]
     return artifacts_dir / task_id / Path(*parts) if parts else artifacts_dir / task_id / "artifact.bin"
@@ -1864,9 +1875,17 @@ def _json_has_any_number(value) -> bool:
 
 
 def _breakdown_has_basic_data(path: Path) -> bool:
-    """True when a session_breakdown JSON carries usable audit/perf payload. The
-    delivery contract is "has structured data", not "has positive gain" (aborted
-    runs may legitimately be zero)."""
+    """Report whether a session_breakdown JSON carries usable payload.
+
+    The delivery contract is "has structured data", not "has positive gain"
+    (aborted runs may legitimately be zero).
+
+    Args:
+        path: Path to the session_breakdown JSON file.
+
+    Returns:
+        ``True`` when the file parses and contains a known data key.
+    """
     try:
         with open(path, encoding="utf-8") as f:
             data = json.load(f)
@@ -2078,7 +2097,15 @@ def _record_has_task_window(rec: SubmissionRecord) -> bool:
 
 
 def _env_float(name: str, default: float) -> float:
-    """Read a float environment setting with a safe fallback."""
+    """Read a float environment setting with a safe fallback.
+
+    Args:
+        name: Environment variable name.
+        default: Value returned when unset or unparseable.
+
+    Returns:
+        The parsed float, or ``default`` on failure.
+    """
     raw = os.environ.get(name, "").strip()
     if not raw:
         return default
@@ -2090,7 +2117,14 @@ def _env_float(name: str, default: float) -> float:
 
 
 def _read_session_state(session_dir: str | Path) -> dict:
-    """Best-effort read of a session's state.json."""
+    """Best-effort read of a session's ``state.json``.
+
+    Args:
+        session_dir: The session directory to read from.
+
+    Returns:
+        The parsed state dict, or ``{}`` when missing or unreadable.
+    """
     path = Path(session_dir) / "state.json"
     if not path.is_file():
         return {}
@@ -2102,7 +2136,15 @@ def _read_session_state(session_dir: str | Path) -> dict:
 
 
 def _session_has_terminal_marker(session_dir: str | Path) -> bool:
-    """True when a session has reached a state where CI should collect now."""
+    """Report whether a session has reached a collectable terminal state.
+
+    Args:
+        session_dir: The session directory to inspect.
+
+    Returns:
+        ``True`` when a breakdown / complete marker or close-sequence flag
+        is present.
+    """
     root = Path(session_dir)
     if (root / "session_breakdown.json").is_file():
         return True
@@ -2120,6 +2162,13 @@ def _session_activity_mtime(session_dir: str | Path) -> float:
     ``state.json`` can be quiet while long Magpie subprocesses append logs or
     traces, so include the runtime subtrees CI relies on. The file cap avoids
     expensive walks for very large sessions.
+
+    Args:
+        session_dir: The session directory to scan.
+
+    Returns:
+        The newest relevant mtime as a Unix timestamp, or ``0.0`` when none
+        found.
     """
     root = Path(session_dir)
     mtimes: list[float] = []
@@ -2160,7 +2209,16 @@ def _find_nfs_state_session_dir(
     rec: SubmissionRecord,
     current_session_hints: set[str] | None = None,
 ) -> str | None:
-    """Locate the current NFS session using state.json, not breakdown files."""
+    """Locate the current NFS session using state.json, not breakdown files.
+
+    Args:
+        rec: The submission record (user / model / task window).
+        current_session_hints: Optional session-id hints to bias matching.
+
+    Returns:
+        The best-matching session directory path, or ``None`` when none
+        match.
+    """
     nfs_root = os.environ.get("NFS_ROOT", "/wekafs")
     users_root = Path(nfs_root) / "users"
     if not rec.safe_user_id or not users_root.is_dir():

--- a/ci/optimize_submit.py
+++ b/ci/optimize_submit.py
@@ -2563,6 +2563,12 @@ def _backfill_wekafs_in_place(rec: SubmissionRecord) -> int:
     match; only sessions modified in the last 24h. Updates ci_metrics.json,
     manifest.json, session_breakdown[_v2].json across subdirs via
     _backfill_ci_metrics_file. No-op when wekafs isn't mounted.
+
+    Args:
+        rec: The submission record supplying match keys and audit fields.
+
+    Returns:
+        The number of source files updated in place.
     """
     nfs_root = os.environ.get("NFS_ROOT", "/wekafs")
     users_root = os.path.join(nfs_root, "users")
@@ -2709,9 +2715,19 @@ def _backfill_wekafs_in_place(rec: SubmissionRecord) -> int:
 
 
 def _record_matches_session_dir(rec: SubmissionRecord, sess_name: str) -> bool:
-    """Conservative directory-name match for the /wekafs/users fallback. Prefer
-    the displayName slug; fall back to basename with strict-term guards to avoid
-    cross-wiring adjacent repos (Qwen2.5 vs -AWQ, Nano vs Super, bnb, etc.)."""
+    """Conservatively match a session directory name to a record.
+
+    Prefers the displayName slug; falls back to basename with strict-term
+    guards to avoid cross-wiring adjacent repos (Qwen2.5 vs -AWQ, Nano vs
+    Super, bnb, etc.).
+
+    Args:
+        rec: The submission record.
+        sess_name: The session directory basename.
+
+    Returns:
+        ``True`` when the directory name matches the record.
+    """
     sess_slug = _slug_token(sess_name)
     sess_norm = _norm_token(sess_name)
     display = rec.display_name or ""
@@ -2737,7 +2753,15 @@ def _record_matches_session_dir(rec: SubmissionRecord, sess_name: str) -> bool:
 
 
 def _record_model_field_matches(rec: SubmissionRecord, model_field: str) -> bool:
-    """Compare a JSON model field with a SubmissionRecord conservatively."""
+    """Conservatively compare a JSON ``model`` field with a record.
+
+    Args:
+        rec: The submission record.
+        model_field: The model identifier read from a JSON artifact.
+
+    Returns:
+        ``True`` when the field matches one of the record's model aliases.
+    """
     observed = _norm_token(str(model_field or ""))
     if not observed:
         return False
@@ -2879,8 +2903,17 @@ def _env_truthy(name: str) -> bool:
 
 
 def _copy_session_tree(src_dir: str, dst_dir: Path) -> int:
-    """Copy an entire persisted session directory into ``dst_dir`` (existing files
-    untouched). Returns the number of files copied."""
+    """Copy an entire persisted session directory into ``dst_dir``.
+
+    Existing files are left untouched; VCS / cache dirs are skipped.
+
+    Args:
+        src_dir: Source session directory to copy from.
+        dst_dir: Destination directory (created if needed).
+
+    Returns:
+        The number of files copied.
+    """
     copied = 0
     dst_dir.mkdir(parents=True, exist_ok=True)
     for root, dirnames, filenames in os.walk(src_dir):
@@ -2911,13 +2944,22 @@ def _nfs_fallback_collect(
     copy_full_session: bool = False,
     current_session_hints: set[str] | None = None,
 ) -> int:
-    """Scan NFS result directories for files matching this model, used when the
-    SaFE artifact API returns nothing (V2 writes under /wekafs/users/<uid>/...).
+    """Scan NFS result directories for files matching this model.
 
-    Two stages: A. legacy canonical CI dirs, matched by dir name; B. per-user
-    session dirs, matched by each ci_metrics.json's `model` field (more accurate
-    than dir-name fuzzy match). Mirrors ci/orchestrator.py's fallback.
-    Returns count of files copied.
+    Used when the SaFE artifact API returns nothing (V2 writes under
+    ``/wekafs/users/<uid>/...``). Two stages: A. legacy canonical CI dirs,
+    matched by dir name; B. per-user session dirs, matched by each
+    ci_metrics.json's ``model`` field (more accurate than dir-name fuzzy
+    match). Mirrors ci/orchestrator.py's fallback.
+
+    Args:
+        rec: The submission record.
+        artifacts_dir: Local root to copy collected artifacts into.
+        copy_full_session: When True, copy the entire session tree.
+        current_session_hints: Optional session-id hints to bias matching.
+
+    Returns:
+        The number of files copied.
     """
     current_session_hints = set(current_session_hints or set())
     nfs_root = os.environ.get("NFS_ROOT", "/wekafs")
@@ -3219,9 +3261,25 @@ def wait_and_collect_one(
     collect: bool,
     all_artifacts: bool,
 ) -> SubmissionRecord:
-    """Wait for one task to finish, then optionally download its artifacts:
-    (1) SaFE artifacts API, then (2) NFS fallback when session_breakdown.json
-    (the CI delivery contract) is still missing."""
+    """Wait for one task to finish, then optionally download its artifacts.
+
+    Collection tries (1) the SaFE artifacts API, then (2) the NFS fallback
+    when ``session_breakdown.json`` (the CI delivery contract) is still
+    missing.
+
+    Args:
+        safe: The SaFE optimize client.
+        rec: The submission record to update in place.
+        artifacts_dir: Local root for downloaded artifacts.
+        task_timeout_min: Per-task wait deadline in minutes.
+        poll_s: Poll interval in seconds.
+        collect: When False, skip artifact collection.
+        all_artifacts: When True, download every artifact, not just the
+            delivery-contract files.
+
+    Returns:
+        The updated submission record.
+    """
     if not rec.task_id:
         return rec  # nothing to wait for (skipped/failed during submit)
 

--- a/ci/orchestrator.py
+++ b/ci/orchestrator.py
@@ -74,9 +74,16 @@ def render_prompt(merged: dict, *, pr_mode: bool = False,
                   gh_token: str | None = None) -> str:
     """Render the agent prompt for the inference_optimizer skill.
 
-    pr_mode=False (default): prompt_template.md against /wekafs/HyperloomV2.
-    pr_mode=True: prompt_template_pr.md, agent git-clones PR head; requires
-    git_ref (PR head sha) and gh_token (clones AMD-AGI/Hyperloom).
+    Args:
+        merged: Merged model/run config (workload dims, benchmarks, image).
+        pr_mode: When False, use ``prompt_template.md`` against
+            ``/wekafs/HyperloomV2``; when True, use ``prompt_template_pr.md``
+            so the agent git-clones the PR head.
+        git_ref: PR head SHA; required when ``pr_mode`` is True.
+        gh_token: GitHub token used to clone AMD-AGI/Hyperloom in PR mode.
+
+    Returns:
+        The rendered prompt string.
     """
     isl, osl = merged["isl_osl_configs"][0]
     ifx_text = format_benchmark_for_prompt(
@@ -223,7 +230,17 @@ def run_model(
 ) -> dict:
     """Execute the full optimization flow for a single model.
 
-    pr_mode + git_ref + gh_token are forwarded to render_prompt. See its docstring.
+    Args:
+        claw: The Claw client used to launch and poll the sandbox.
+        merged: Merged model/run config.
+        nfs_base: NFS base path for result collection.
+        sandbox_timeout: Sandbox wait deadline in seconds.
+        pr_mode: Forwarded to :func:`render_prompt` (PR-CI mode).
+        git_ref: PR head SHA; forwarded to :func:`render_prompt`.
+        gh_token: GitHub token; forwarded to :func:`render_prompt`.
+
+    Returns:
+        A result dict describing the run outcome and collected artifacts.
     """
     model_name = merged["model_hf"].split("/")[-1]
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M")

--- a/ci/post_perf_runs.py
+++ b/ci/post_perf_runs.py
@@ -84,10 +84,18 @@ _CRASH_STOP_REASONS = {
 
 
 def is_complete_session(data: Dict[str, Any]) -> Tuple[bool, Optional[str]]:
-    """Reject incomplete or crashed sessions; returns (ok, reason_if_rejected).
+    """Validate that a session is complete and did not crash.
 
-    A 'good' session needs baseline + final throughput_tok_s_per_gpu > 0 and a
-    stop_reason not in _CRASH_STOP_REASONS ('signal'/'time_exhausted' are kept).
+    A "good" session needs baseline + final ``throughput_tok_s_per_gpu`` > 0
+    and a ``stop_reason`` not in ``_CRASH_STOP_REASONS``
+    (``signal`` / ``time_exhausted`` are kept).
+
+    Args:
+        data: The session breakdown data dict.
+
+    Returns:
+        An ``(ok, reason_if_rejected)`` tuple; ``reason`` is ``None`` when
+        accepted.
     """
     baseline = data.get("baseline") or {}
     final = data.get("final") or {}
@@ -113,9 +121,18 @@ def is_complete_session(data: Dict[str, Any]) -> Tuple[bool, Optional[str]]:
 # ---------------------------------------------------------------------------
 
 def build_body(path: Path) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
-    """Returns (body, error_msg); body is None on error.
+    """Build the perf_runs POST body from a breakdown file.
 
-    `body` is the JSON we POST, with keys matching the perf_runs DTO 1:1.
+    Accepts four layouts (strictest first): bare V2 breakdown, V2 wrapper
+    (``{source, data}``), legacy V1 flat schema, and the universal fallback.
+
+    Args:
+        path: Path to the session breakdown JSON file.
+
+    Returns:
+        A ``(body, error_msg)`` tuple; ``body`` is ``None`` on error and
+        ``error_msg`` carries the reason. The body keys match the perf_runs
+        DTO 1:1.
     """
     try:
         with path.open("r", encoding="utf-8") as f:

--- a/ci/pr_submitter.py
+++ b/ci/pr_submitter.py
@@ -574,6 +574,12 @@ def sync_fork_from_upstream(repo_dir: str, upstream_url: str,
 
     Merge (not rebase/reset) preserves the fork-only verify-pr/sync workflow
     files while keeping the base current.
+
+    Args:
+        repo_dir: Local clone directory of the fork.
+        upstream_url: Upstream repository URL to add as a remote.
+        branch: Branch to sync from upstream.
+        token: Optional auth token for the push back to the fork.
     """
     _run_git(["remote", "add", "upstream", upstream_url], repo_dir, check=False)
     _run_git(["fetch", "upstream", branch], repo_dir)

--- a/ci/prewarm_models.py
+++ b/ci/prewarm_models.py
@@ -118,10 +118,19 @@ def tmp_dir(target_root: Path, repo_id: str) -> Path:
 
 
 def is_complete(dest: Path, repo_id: str, hf_api: HfApi, token: str) -> bool:
-    """True iff dest/ has every file the HF repo claims, with non-zero size.
+    """Report whether a local copy fully mirrors the HF repo.
 
     One ``list_repo_files`` call; partial prior runs fail this because they
     miss a file or have a zero-sized one.
+
+    Args:
+        dest: Local destination directory.
+        repo_id: HF repo id to compare against.
+        hf_api: An :class:`HfApi` client.
+        token: HF token for gated repos.
+
+    Returns:
+        ``True`` iff ``dest`` has every claimed file with non-zero size.
     """
     if not dest.is_dir():
         return False
@@ -258,8 +267,19 @@ def _load_candidates(path: Path) -> list[str]:
 
 def _slice_repos(repos: list[str], batch_index: int | None,
                  batch_size: int | None) -> list[str]:
-    """Apply optional --batch-index / --batch-size slice (same semantics as
-    generate_hf_matrix.py, so prewarm + optimize target the same repos)."""
+    """Apply an optional ``--batch-index`` / ``--batch-size`` slice.
+
+    Uses the same semantics as ``generate_hf_matrix.py`` so prewarm and
+    optimize target the same repos.
+
+    Args:
+        repos: The full repo list.
+        batch_index: 0-based batch index (defaults to 0).
+        batch_size: Entries per batch; falsy returns all repos.
+
+    Returns:
+        The selected repo slice.
+    """
     if not batch_size:
         return repos
     bi = batch_index or 0

--- a/ci/progress.py
+++ b/ci/progress.py
@@ -45,7 +45,16 @@ def _load_json(path: Path) -> dict:
 
 
 def _summary_rows(summary_path: Path) -> list[dict]:
-    """Extract rows from a ci_summary.json; accepts `{"rows": [...]}`, `{"models": [...]}`, or a bare list."""
+    """Extract rows from a ci_summary.json file.
+
+    Accepts ``{"rows": [...]}``, ``{"models": [...]}``, or a bare list.
+
+    Args:
+        summary_path: Path to the ci_summary.json file.
+
+    Returns:
+        The extracted row dicts (empty when none found).
+    """
     data = _load_json(summary_path)
     if isinstance(data, list):
         return data
@@ -53,7 +62,16 @@ def _summary_rows(summary_path: Path) -> list[dict]:
 
 
 def _classify_status(row: dict) -> tuple[str, str | None]:
-    """Return (status, reason): completed (baseline+optimized), partial (one only), or failed (no usable data)."""
+    """Classify a summary row's completion status.
+
+    Args:
+        row: A ci_summary row dict.
+
+    Returns:
+        A ``(status, reason)`` tuple where status is ``"completed"``
+        (baseline + optimized + gain), ``"partial"`` (one data point), or
+        ``"failed"`` (no usable data); ``reason`` is ``None`` when completed.
+    """
     fs = row.get("final_status")
     submit = row.get("submit_status")
     has_opt = row.get("optimized_tok_per_gpu") is not None

--- a/ci/publish_results.py
+++ b/ci/publish_results.py
@@ -57,11 +57,18 @@ def load_results(path: Path) -> list[dict[str, Any]]:
 
 
 def _normalize_submitted_at(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Move ``run.submitted_at`` ISO strings to ``run.submitted_at_iso`` (set original to None).
+    """Move ``run.submitted_at`` ISO strings to ``run.submitted_at_iso``.
 
-    Required because the ingest path binds ``submitted_at`` (timestamptz) as a str and asyncpg
-    rejects it with HTTP 500. The sibling key preserves the value in the raw_result JSONB blob.
-    Drop once the ingest path accepts ISO strings directly.
+    Required because the ingest path binds ``submitted_at`` (timestamptz) as a
+    str and asyncpg rejects it with HTTP 500. The sibling key preserves the
+    value in the raw_result JSONB blob. Drop once the ingest path accepts ISO
+    strings directly.
+
+    Args:
+        results: Normalized result dicts to clean.
+
+    Returns:
+        New result dicts with ``submitted_at`` moved to ``submitted_at_iso``.
     """
     cleaned: list[dict[str, Any]] = []
     for r in results:
@@ -87,10 +94,22 @@ def publish(
     max_retries: int = 5,
     initial_backoff_s: float = 5.0,
 ) -> dict:
-    """POST results to /api/import with exponential-backoff retry.
+    """POST results to ``/api/import`` with exponential-backoff retry.
 
-    Retries cover intermittent service-side failures: PG pool drops after a pod crashloop
-    (HTTP 500, succeeds on retry once asyncpg reconnects) and liveness-probe restarts (5xx / refused).
+    Retries cover intermittent service-side failures: PG pool drops after a pod
+    crashloop (HTTP 500, succeeds on retry once asyncpg reconnects) and
+    liveness-probe restarts (5xx / refused).
+
+    Args:
+        results: Normalized result dicts to publish.
+        url: Base service URL (``/api/import`` is appended).
+        token: Optional bearer token.
+        timeout: Per-request timeout in seconds.
+        max_retries: Maximum retry attempts.
+        initial_backoff_s: Initial backoff delay in seconds.
+
+    Returns:
+        The decoded JSON response from the import endpoint.
     """
     import time
     import requests

--- a/ci/report_generator.py
+++ b/ci/report_generator.py
@@ -102,7 +102,18 @@ def _first_of(d: dict, *keys: str) -> Any | None:
 
 
 def _parse_metrics_from_report(content: str) -> dict:
-    """Fallback: extract baseline/optimized throughput from the optimization_report.md Executive Summary table (prefers total over per-GPU)."""
+    """Extract throughput metrics from an optimization report (fallback path).
+
+    Parses the ``optimization_report.md`` Executive Summary table, preferring
+    total over per-GPU figures.
+
+    Args:
+        content: The Markdown report contents.
+
+    Returns:
+        A dict with any of ``gain_pct``, ``baseline_throughput``, and
+        ``optimized_throughput`` that could be parsed.
+    """
     import re
 
     result: dict[str, Any] = {}

--- a/ci/transform_to_session_summary_v2.py
+++ b/ci/transform_to_session_summary_v2.py
@@ -82,9 +82,17 @@ def safe_get(d: Any, *keys: str, default: Any = None) -> Any:
 # ---------------------------------------------------------------------------
 
 def _patch_baseline(data: Dict) -> List[str]:
-    """Mirror `extra_server_args` / `extra_envs` onto `baseline` (which lacks
-    them) from baseline.invocation. Reads the legacy ``extra_sglang_args`` key
-    but always writes the canonical ``extra_server_args``.
+    """Mirror ``extra_server_args`` / ``extra_envs`` onto ``baseline``.
+
+    Fills the fields from ``baseline.invocation`` when ``baseline`` lacks
+    them. Reads the legacy ``extra_sglang_args`` key but always writes the
+    canonical ``extra_server_args``.
+
+    Args:
+        data: The session summary data dict (mutated in place).
+
+    Returns:
+        Human-readable notes describing each patch applied.
     """
     notes = []
     baseline = data.get("baseline")

--- a/critic-agent/runtime/decision_reviewer.py
+++ b/critic-agent/runtime/decision_reviewer.py
@@ -133,7 +133,17 @@ _APPROVE_REQUIRES_BY_CLASS: dict[str, tuple[str, ...]] = {
 
 
 def classify_proposal_action(action_name: str | None) -> str:
-    """Map ``action_name`` to a review class; unknown/missing → evidence_producer (cold-start safe)."""
+    """Map an action name to its review class.
+
+    Unknown or missing actions fall back to the evidence-producer class,
+    which is the cold-start-safe default.
+
+    Args:
+        action_name: The proposed action's name, if any.
+
+    Returns:
+        The review class constant for the action.
+    """
     if not isinstance(action_name, str):
         return ACTION_CLASS_EVIDENCE_PRODUCER
     name = action_name.strip()
@@ -162,8 +172,15 @@ def _discover_robustness_findings_path(session_id: str) -> Path | None:
     """Locate ``<session>.jsonl`` from the Robustness FindingSink.
 
     Resolution order: ``$CRITIC_ROBUSTNESS_FINDINGS_DIR`` (explicit override
-    dir) then ``$ROBUSTNESS_AGENT_SESSION_DIR`` (auto-discovery). Returns
-    ``None`` when neither env is set or the file does not exist.
+    dir) then ``$ROBUSTNESS_AGENT_SESSION_DIR`` (auto-discovery).
+
+    Args:
+        session_id: Session identifier used to build the ``<session>.jsonl``
+            filename (falls back to ``"default"`` when empty).
+
+    Returns:
+        Path to the findings file, or ``None`` when neither env var is set
+        or the file does not exist.
     """
     explicit = os.environ.get("CRITIC_ROBUSTNESS_FINDINGS_DIR", "").strip()
     if explicit:
@@ -188,7 +205,18 @@ def _load_robustness_priors(
     limit: int,
     min_severity: str,
 ) -> list[dict[str, Any]]:
-    """Tail the JSONL and return up to ``limit`` priors matching severity."""
+    """Tail the JSONL and return priors that meet the severity floor.
+
+    Args:
+        path: Path to the robustness findings JSONL file.
+        limit: Maximum number of priors to return.
+        min_severity: Minimum severity to include (``"high"``,
+            ``"medium"``, or ``"low"``).
+
+    Returns:
+        Up to ``limit`` prior records matching the severity filter; an
+        empty list if the file cannot be read.
+    """
     min_rank = _SEVERITY_RANK.get(min_severity, _SEVERITY_RANK["high"])
     try:
         text = path.read_text(encoding="utf-8")
@@ -756,6 +784,14 @@ class DecisionReviewer:
         With ``proposals``, ``approve_requires`` is the batch's strictest
         action class and ``proposal_action_classes`` carries the per-proposal
         bar; empty/None defaults to the strict ``patch_landing`` checklist.
+
+        Args:
+            proposals: Proposals in the bundle; when ``None`` or empty the
+                strict patch-landing checklist is used.
+
+        Returns:
+            A constraints payload with allowed verdicts, the approval
+            checklist, and (when proposals are given) per-proposal classes.
         """
         constraints: dict[str, Any] = {
             "allowed_verdicts": sorted(ALLOWED_VERDICTS),

--- a/framework-agent/src/framework_agent/decision.py
+++ b/framework-agent/src/framework_agent/decision.py
@@ -13,11 +13,21 @@ def winner_decision(
     accuracy: float | None,
     completed: str,
 ) -> tuple[bool, str]:
-    """Apply throughput / accuracy / completed gates, short-circuiting on first miss; returns ``(is_winner, reason)`` with ``reason`` always set for audit.
+    """Apply throughput / accuracy / completed gates for a candidate.
 
-    Gates: (1) throughput > 0 and ratio >= min_throughput_ratio;
-    (2) when baseline accuracy set, accuracy present and drop <=
-    max_accuracy_drop; (3) ``completed`` "K/N" must have K == N.
+    Short-circuits on the first failing gate: (1) throughput > 0 and ratio
+    >= ``min_throughput_ratio``; (2) when baseline accuracy is set, accuracy
+    present and drop <= ``max_accuracy_drop``; (3) ``completed`` "K/N" must
+    have K == N.
+
+    Args:
+        req: The explore request carrying baseline and thresholds.
+        throughput: Candidate throughput, or ``None`` if unmeasured.
+        accuracy: Candidate accuracy, or ``None`` if unmeasured.
+        completed: Benchmark completion marker in ``"K/N"`` form.
+
+    Returns:
+        A ``(is_winner, reason)`` tuple; ``reason`` is always set for audit.
     """
     if throughput is None or throughput <= 0:
         return False, "missing throughput"
@@ -52,7 +62,20 @@ def candidate_score(
     throughput: float | None,
     accuracy: float | None,
 ) -> float:
-    """Sortable ranking score = ``throughput_ratio - accuracy_drop_penalty`` (higher is better); missing throughput scores 0 so failed candidates sort to the tail."""
+    """Compute a sortable ranking score for a candidate.
+
+    The score is ``throughput_ratio - accuracy_drop_penalty`` (higher is
+    better); missing throughput scores ``0.0`` so failed candidates sort to
+    the tail.
+
+    Args:
+        req: The explore request carrying baseline and thresholds.
+        throughput: Candidate throughput, or ``None`` if unmeasured.
+        accuracy: Candidate accuracy, or ``None`` if unmeasured.
+
+    Returns:
+        The ranking score as a float.
+    """
     if throughput is None or throughput <= 0 or req.baseline.throughput <= 0:
         return 0.0
     ratio = throughput / req.baseline.throughput

--- a/framework-agent/src/framework_agent/explorer.py
+++ b/framework-agent/src/framework_agent/explorer.py
@@ -227,7 +227,23 @@ def _extract_changed_files(
 
 
 def _enrich_candidate_via_primus(req: ExploreRequest, candidate: Candidate) -> Candidate:
-    """Fetch pr_get + pr_files for PR-typed candidates (hard-fails on primus errors); branch / tag / commit refs returned unchanged."""
+    """Enrich a PR-typed candidate with metadata from Primus Cortex.
+
+    Fetches ``pr_get`` + ``pr_files`` for PR candidates; branch / tag /
+    commit refs are returned unchanged.
+
+    Args:
+        req: The explore request carrying the Primus Cortex config.
+        candidate: The candidate to enrich.
+
+    Returns:
+        The enriched candidate, or the original when enrichment does not
+        apply.
+
+    Raises:
+        primus_cortex.PrimusCortexError: If the repo URL is malformed or a
+            required Primus call fails.
+    """
     if req.primus_cortex is None:
         return candidate
     number = candidate.pr_number
@@ -263,7 +279,19 @@ def _enrich_candidate_via_primus(req: ExploreRequest, candidate: Candidate) -> C
 
 
 def _passes_filter(c: Candidate, f: PrFilter) -> tuple[bool, str]:
-    """Apply :class:`PrFilter` to one candidate: ``(True, '')`` on empty filter or pass, ``(False, reason)`` otherwise; metadata-dependent constraints fail when that metadata is missing (enrichment skipped)."""
+    """Apply a :class:`PrFilter` to one candidate.
+
+    Metadata-dependent constraints fail when the required metadata is
+    missing (e.g. enrichment was skipped).
+
+    Args:
+        c: The candidate to test.
+        f: The filter to apply.
+
+    Returns:
+        ``(True, "")`` on an empty filter or a pass, otherwise
+        ``(False, reason)`` describing the first failing constraint.
+    """
     if f.is_empty:
         return True, ""
 
@@ -321,7 +349,19 @@ def _passes_filter(c: Candidate, f: PrFilter) -> tuple[bool, str]:
 def _enumerate_with_skipped(
     req: ExploreRequest,
 ) -> tuple[list[Candidate], list[dict[str, str]]]:
-    """Return ``(kept, skipped)`` after enrichment + filtering: unions sources, enriches PR candidates via primus, then applies ``req.pr_filter``; explicit candidates bypass the filter (operator intent wins) but are still enriched."""
+    """Enumerate, enrich, and filter candidates.
+
+    Unions the configured sources, enriches PR candidates via Primus, then
+    applies ``req.pr_filter``. Explicit candidates bypass the filter
+    (operator intent wins) but are still enriched.
+
+    Args:
+        req: The explore request.
+
+    Returns:
+        A ``(kept, skipped)`` tuple where ``skipped`` entries carry the
+        ref, source, and skip reason.
+    """
     from .sources import enumerate_candidates as _enum_raw
 
     raw = _enum_raw(req)
@@ -398,10 +438,20 @@ def _prepare_candidate_workspace_with_artifacts(
     index: int,
     execute: bool,
 ) -> tuple[WorkspacePaths, dict[str, str]]:
-    """Drop audit material (``pr.patches`` / ``pr_files.json``) per candidate
-    regardless of execute mode, then delegate the worktree + venv step to
-    :mod:`isolation` when execute is True. Returns ``(WorkspacePaths,
-    artifact_paths)``.
+    """Prepare a candidate workspace and drop its audit artifacts.
+
+    Drops audit material (``pr.patches`` / ``pr_files.json``) for the
+    candidate regardless of execute mode, then delegates the worktree +
+    venv step to :mod:`isolation` when ``execute`` is True.
+
+    Args:
+        req: The explore request.
+        candidate: The candidate to prepare.
+        index: Zero-based candidate index (used in the directory name).
+        execute: Whether to materialize the worktree and venv.
+
+    Returns:
+        A ``(WorkspacePaths, artifact_paths)`` tuple.
     """
     candidate_dir = req.work_dir / "candidates" / f"{index:02d}_{candidate.slug}"
     candidate_dir.mkdir(parents=True, exist_ok=True)
@@ -415,9 +465,23 @@ def _prepare_candidate_workspace_with_artifacts(
 def _write_pr_artifacts(
     req: ExploreRequest, candidate: Candidate, candidate_dir: Path
 ) -> dict[str, str]:
-    """Drop ``pr.patches`` + ``pr_files.json`` per PR candidate. No-op when
-    primus_cortex is unconfigured or the candidate is not a PR ref;
-    hard-fails on network errors (CLI converts to exit code 2).
+    """Write ``pr.patches`` + ``pr_files.json`` for a PR candidate.
+
+    No-op when Primus Cortex is unconfigured or the candidate is not a PR
+    ref; hard-fails on network errors (the CLI converts these to exit
+    code 2).
+
+    Args:
+        req: The explore request carrying the Primus config and repo URL.
+        candidate: The candidate whose artifacts to write.
+        candidate_dir: Directory to write the artifacts into.
+
+    Returns:
+        A mapping of artifact names to written file paths (empty when the
+        candidate is not a PR or Primus is unconfigured).
+
+    Raises:
+        primus_cortex.PrimusCortexError: If the repo URL is malformed.
     """
     if req.primus_cortex is None:
         return {}
@@ -532,6 +596,15 @@ def _run_single_candidate(
     free beyond the workspace it owns. Concurrency safety: callers must
     ensure two candidates never share an ``index`` (slug collisions could
     overwrite material).
+
+    Args:
+        req: The explore request.
+        candidate: The candidate to run.
+        index: Unique candidate index (must be distinct across callers).
+        execute: When False, plan only; when True, build and benchmark.
+
+    Returns:
+        The :class:`CandidateResult` for the candidate.
     """
     workspace, artifact_paths = _prepare_candidate_workspace_with_artifacts(
         req, candidate, index=index, execute=execute,
@@ -610,10 +683,19 @@ async def _run_candidates_concurrent(
     *,
     execute: bool,
 ) -> list[CandidateResult]:
-    """Run candidates with ``asyncio.gather`` bounded by a ``build_concurrency``
-    semaphore. Each task wraps :func:`_run_single_candidate` in
+    """Run candidates concurrently, bounded by a ``build_concurrency`` semaphore.
+
+    Each task wraps :func:`_run_single_candidate` in
     :func:`asyncio.to_thread`; bench/accuracy stay inside the worker so two
     candidates only overlap when concurrency > 1 (the explicit user knob).
+
+    Args:
+        req: The explore request.
+        candidates: Candidates to run.
+        execute: Whether to build and benchmark (vs plan only).
+
+    Returns:
+        The per-candidate results in submission order.
     """
     semaphore = asyncio.Semaphore(max(1, req.build_concurrency))
 
@@ -713,6 +795,17 @@ def explore(req: ExploreRequest, *, execute: bool = False) -> dict[str, Any]:
 
     Disk preflight (execute=True and ``disk_min_free_gb != 0``) runs first;
     failure raises :class:`isolation.DiskPreflightError`.
+
+    Args:
+        req: The explore request driving the run.
+        execute: When False, plan only; when True, build and benchmark.
+
+    Returns:
+        A summary dict describing the run, candidates, winner, and KB
+        contribution.
+
+    Raises:
+        isolation.DiskPreflightError: If the disk preflight check fails.
     """
     log.info(
         "explore start framework=%s repo=%s work_dir=%s execute=%s "
@@ -819,8 +912,16 @@ def _contribute_findings_to_kb(
 
     Fires only when ``execute=True``, ``req.kb_domain`` is non-empty, and a
     ``winner`` exists. Best-effort: any KB write error is captured into the
-    returned ``kb_contribution`` metadata dict so the explore summary stays
-    usable even if the KB directory is read-only.
+    returned metadata dict so the explore summary stays usable even if the
+    KB directory is read-only.
+
+    Args:
+        req: The explore request (supplies KB domain and baseline).
+        winner: The winning candidate result, if any.
+        execute: Whether the run was in execute mode.
+
+    Returns:
+        A ``kb_contribution`` metadata dict with a ``status`` field.
     """
     if not execute or not req.kb_domain or winner is None:
         return {"status": "skipped", "reason": "execute+kb_domain+winner required"}

--- a/framework-agent/src/framework_agent/isolation.py
+++ b/framework-agent/src/framework_agent/isolation.py
@@ -124,7 +124,17 @@ def disk_preflight(
 
     Required = ``max(min_free_gb, n_candidates * per_candidate_gb)``. The
     work_dir is created when missing so :func:`shutil.disk_usage` doesn't
-    fail. Raises :class:`DiskPreflightError` on failure.
+    fail.
+
+    Args:
+        work_dir: Working directory whose mount is checked.
+        n_candidates: Number of candidates used to size the requirement.
+        min_free_gb: Floor on required free space; resolved from env when
+            ``None``.
+        per_candidate_gb: Estimated disk per candidate in GB.
+
+    Raises:
+        DiskPreflightError: If free space is below the computed requirement.
     """
     floor_gb = _resolve_min_free_gb(min_free_gb)
     required_gb = max(floor_gb, float(n_candidates) * per_candidate_gb)
@@ -247,9 +257,17 @@ def prepare_candidate_workspace(
 ) -> WorkspacePaths:
     """Materialise ``candidate_dir`` + (when execute) worktree + venv.
 
-    Returns :class:`WorkspacePaths`. ``execute=False`` /
-    ``prepare_candidate_env=False`` short-circuits before the git worktree
-    and venv steps so plan mode stays cheap.
+    ``execute=False`` / ``prepare_candidate_env=False`` short-circuits
+    before the git worktree and venv steps so plan mode stays cheap.
+
+    Args:
+        req: The explore request (work dir + env policy).
+        candidate: The candidate to prepare a workspace for.
+        index: Candidate index used in the directory name.
+        execute: Whether to materialize the worktree and venv.
+
+    Returns:
+        The :class:`WorkspacePaths` for the candidate.
     """
     candidate_dir = req.work_dir / "candidates" / f"{index:02d}_{candidate.slug}"
     worktree_dir = candidate_dir / "worktree"
@@ -310,6 +328,12 @@ def cleanup_workspace(
     but ``candidate_dir`` (and its ``pr.patches`` / ``pr_files.json`` audit
     artefacts) is kept so reviewers can still diff. Best-effort: cleanup
     errors are logged, never re-raised.
+
+    Args:
+        workspace: Paths for the candidate workspace to clean up.
+        is_winner: Whether this candidate is a winner (winners are kept).
+        keep_winner_only: When False, nothing is removed.
+        repo_dir: Mirror repo dir used to detach the worktree cleanly.
     """
     if not keep_winner_only or is_winner:
         return

--- a/framework-agent/src/framework_agent/kb.py
+++ b/framework-agent/src/framework_agent/kb.py
@@ -34,9 +34,14 @@ def path_for_framework(framework: str) -> Path:
     Returns ``<KB_ROOT>/framework_optimization/<framework_lower>/``; the name
     is lowercased and stripped (``"  Atom  "`` and ``"ATOM"`` resolve to
     ``"atom"``). The partition dir may not exist until
-    ``contribute_to_kb_for_framework`` creates it. Empty / whitespace-only
-    names resolve to the ``framework_optimization`` root (treat as "not
-    selected" and fall back to the ``framework`` domain bag).
+    ``contribute_to_kb_for_framework`` creates it.
+
+    Args:
+        framework: Framework name; empty / whitespace-only resolves to the
+            ``framework_optimization`` root (treated as "not selected").
+
+    Returns:
+        The KB partition path for the framework.
     """
     fw = (framework or "").strip().lower()
     root = _resolve_kb_root()
@@ -57,6 +62,15 @@ def contribute_to_kb_for_framework(
     :func:`path_for_framework`, for findings tied to a specific framework
     rather than a cross-framework domain. Partition dir is created lazily on
     first write.
+
+    Args:
+        framework: Framework whose partition to write to.
+        finding: The finding body (Markdown).
+        source: Provenance string recorded in the entry header.
+        session_id: Session identifier recorded in the entry header.
+
+    Returns:
+        Path to the ``empirical_kb.md`` file that was appended to.
     """
     fw_dir = path_for_framework(framework)
     fw_dir.mkdir(parents=True, exist_ok=True)
@@ -106,6 +120,9 @@ def _resolve_kb_root() -> Path:
 
     Order: (1) ``FRAMEWORK_AGENT_KB_DIR``; (2) ``${FRAMEWORK_AGENT_ROOT}/kb``;
     (3) ``${repo}/framework-agent/kb`` derived from this file's location.
+
+    Returns:
+        The resolved KB root path.
     """
     explicit = os.environ.get("FRAMEWORK_AGENT_KB_DIR", "").strip()
     if explicit:
@@ -338,6 +355,13 @@ def _synthesize_pure_python(domain: str, findings: list[Finding]) -> str:
 
     Layout: ``## Synthesised findings - <domain>``, one ``###`` section per
     finding, then ``## Aggregate metrics`` when metric keys repeat.
+
+    Args:
+        domain: Domain label for the digest header.
+        findings: Findings to render.
+
+    Returns:
+        The deterministic Markdown digest.
     """
     if not findings:
         return f"## Synthesised findings - {domain}\n\n_no findings_\n"
@@ -387,9 +411,22 @@ def _synthesize_via_llm(
     *,
     model: str,
 ) -> str:
-    """Distil findings via claude_agent_sdk. ImportError surfaces a
-    RuntimeError with install hint; network / SDK errors are not caught so
-    misconfiguration is loud.
+    """Distil findings via claude_agent_sdk.
+
+    Network / SDK errors are not caught so misconfiguration is loud.
+
+    Args:
+        domain: Domain label for the synthesis.
+        findings: Findings to summarize.
+        model: SDK model identifier to use.
+
+    Returns:
+        The LLM-synthesized Markdown, falling back to the pure-Python
+        digest when the SDK returns nothing.
+
+    Raises:
+        RuntimeError: If ``claude_agent_sdk`` is missing or lacks required
+            attributes.
     """
     try:
         import claude_agent_sdk as sdk  # type: ignore  # noqa: F401
@@ -431,6 +468,12 @@ def _iter_message_text(message) -> Iterable[str]:
 
     Accepts a plain string, ``.text``, or a ``.content`` list of blocks each
     with ``.text`` (SDK message shape varies across versions).
+
+    Args:
+        message: An SDK message object or string.
+
+    Yields:
+        Each non-empty text fragment found on the message.
     """
     if isinstance(message, str):
         yield message
@@ -457,6 +500,15 @@ def synthesize_findings(
 
     Default is pure-Python (deterministic, no SDK/network). ``with_llm=True``
     routes through a lazy-imported claude_agent_sdk.
+
+    Args:
+        domain: Domain label for the synthesis.
+        findings: Findings to distill.
+        with_llm: Whether to route through the LLM synthesizer.
+        model: SDK model identifier (used only when ``with_llm`` is True).
+
+    Returns:
+        The synthesized Markdown blob.
     """
     if not with_llm:
         return _synthesize_pure_python(domain, findings)
@@ -466,8 +518,13 @@ def synthesize_findings(
 def search_kb(query: str, *, domains: list[str] | None = None) -> list[KBFile]:
     """Case-insensitive substring search across all (or selected) domains.
 
-    Returns deduplicated KBFile records whose ``content`` contains ``query``;
-    order follows :func:`_prioritized_files` within each domain.
+    Args:
+        query: Substring to search for (matched case-insensitively).
+        domains: Domains to search; defaults to all known domains.
+
+    Returns:
+        Deduplicated :class:`KBFile` records whose ``content`` contains the
+        query, ordered per :func:`_prioritized_files` within each domain.
     """
     needle = query.lower()
     domains = domains or list_domains()

--- a/framework-agent/src/framework_agent/keywords.py
+++ b/framework-agent/src/framework_agent/keywords.py
@@ -50,6 +50,12 @@ def extract_keywords(description: str) -> list[str]:
 
     Whitelist hits first, then CamelCase identifiers; if nothing matched,
     fall back to the first five 3+ letter words so callers get some signal.
+
+    Args:
+        description: The gap description text to mine.
+
+    Returns:
+        A sorted, deduplicated list of keywords.
     """
     tokens = set(re.findall(r"[a-z][a-z0-9_]+", description.lower()))
     keywords = tokens & _TECHNICAL_TERMS
@@ -66,7 +72,13 @@ def score_title_against_keywords(title: str, keywords: Sequence[str]) -> int:
     """Count keywords overlapping the title's tokens, to rerank candidate PRs.
 
     Lowercase, snake_case-aware token split mirrors :func:`extract_keywords`.
-    Returns 0 for an empty title or empty keywords list.
+
+    Args:
+        title: The PR title to score.
+        keywords: Keywords to match against the title.
+
+    Returns:
+        The overlap count; ``0`` for an empty title or keyword list.
     """
     if not keywords or not title:
         return 0
@@ -130,10 +142,16 @@ def score_title_with_anti_signal(
 
     ``positive`` = keyword tokens in the title; ``anti`` = title tokens in the
     anti-set of any active gap keyword (only :data:`_ANTI_KEYWORDS` entries
-    activate). Default ``anti_penalty`` of 2.0 means one anti hit erases two
+    activate). A default ``anti_penalty`` of 2.0 means one anti hit erases two
     positive hits, so a wrong-axis PR ranks below any single correct-axis hit.
-    Clamped to 0.0 so callers can post-filter ``score == 0`` to drop
-    anti-heavy PRs.
+
+    Args:
+        title: The PR title to score.
+        keywords: Active gap keywords driving positive and anti matches.
+        anti_penalty: Weight applied per anti-signal hit.
+
+    Returns:
+        The clamped score (>= 0.0); callers can drop ``score == 0`` PRs.
     """
     if not keywords or not title:
         return 0.0

--- a/framework-agent/src/framework_agent/logging_setup.py
+++ b/framework-agent/src/framework_agent/logging_setup.py
@@ -118,6 +118,15 @@ def configure_logging(
 
     Idempotent: each call clears previously attached handlers so re-running
     does not stack duplicates.
+
+    Args:
+        level: Log level (name or int); resolved from env when ``None``.
+        json_output: Force JSON line output; resolved from env when ``None``.
+        log_file: Optional file path to also write logs to.
+        quiet_third_party: Raise noisy third-party loggers to WARNING.
+
+    Returns:
+        The configured root logger.
     """
     use_json = (
         json_output
@@ -199,8 +208,15 @@ def stage_log(
 ) -> Iterator[dict[str, Any]]:
     """Bracket a per-stage block with start/done/failed envelopes.
 
-    Yields a mutable dict so the caller can attach result metrics (e.g.
-    ``ctx["throughput"] = 1234.5``) before the ``done`` envelope fires.
+    Args:
+        logger: Logger to emit the stage envelopes on.
+        stage: Stage name included in each envelope.
+        candidate: Optional candidate ref for context.
+        **fields: Extra structured fields attached to the envelopes.
+
+    Yields:
+        A mutable dict so the caller can attach result metrics (e.g.
+        ``ctx["throughput"] = 1234.5``) before the ``done`` envelope fires.
     """
     started = time.monotonic()
     base: dict[str, Any] = {"stage": stage}

--- a/framework-agent/src/framework_agent/models.py
+++ b/framework-agent/src/framework_agent/models.py
@@ -310,7 +310,15 @@ def _parse_keywords(raw: Any) -> tuple[str, ...]:
 
     None/empty -> ``()`` (auto-extract from gap_description); string ->
     split on comma/whitespace; list/tuple -> trimmed non-empty items.
-    Anything else raises ``ValueError``.
+
+    Args:
+        raw: The raw ``keywords`` value to coerce.
+
+    Returns:
+        A tuple of trimmed keyword strings (empty when unset).
+
+    Raises:
+        ValueError: If ``raw`` is present but not a list/tuple/str.
     """
     if raw is None or raw == "":
         return ()

--- a/framework-agent/src/framework_agent/runtime/tools_api.py
+++ b/framework-agent/src/framework_agent/runtime/tools_api.py
@@ -63,14 +63,30 @@ def find_relevant_prs_smart(
     primus_label: str | None = None,
     include_github: bool = True,
 ) -> list[Candidate]:
-    """Discover candidate PRs across one or more repos (plain-arg version of
-    :func:`framework_agent.sources.enumerate_candidates`).
+    """Discover candidate PRs across one or more repos.
 
-    Each repo is queried via primus_cortex (hard-fail) when
-    ``primus_cortex_url`` is set; GitHub Search is a best-effort secondary
-    when ``include_github=True`` (returns ``[]``, never raises). Results are
-    de-duped by ``(repo_url, ref)`` so primus_cortex wins ties. Returns ``[]``
-    when ``repos`` is empty.
+    Plain-arg version of
+    :func:`framework_agent.sources.enumerate_candidates`. Each repo is
+    queried via primus_cortex (hard-fail) when ``primus_cortex_url`` is set;
+    GitHub Search is a best-effort secondary when ``include_github=True``
+    (returns ``[]``, never raises). Results are de-duped by
+    ``(repo_url, ref)`` so primus_cortex wins ties.
+
+    Args:
+        gap_description: Description used to drive GitHub search relevance.
+        repos: Repos to query; ``None``/empty yields ``[]``.
+        primus_cortex_url: Primus Cortex base URL; enables that source.
+        primus_timeout_sec: Per-request timeout for Primus calls.
+        limit_per_repo: Max candidates per repo per source.
+        primus_state: PR state filter for Primus (e.g. ``"open"``).
+        primus_label: Optional label filter for Primus.
+        include_github: Whether to also query GitHub search.
+
+    Returns:
+        De-duplicated candidate list across all repos and sources.
+
+    Raises:
+        PrimusCortexError: If a Primus query fails when configured.
     """
     if not repos:
         return []
@@ -118,11 +134,24 @@ def fetch_pr_audit_material(
     primus_cortex_url: str,
     primus_timeout_sec: float = 30.0,
 ) -> dict[str, str]:
-    """Download ``pr.patches`` (unified diff) and ``pr_files.json``
-    ({repo, number, files}) for a single PR under ``out_dir``.
+    """Download a PR's audit material (patches + files) under ``out_dir``.
 
-    Returns the absolute paths in a dict. Hard-fails (raises
-    ``PrimusCortexError``) on primus_cortex transport / parse errors.
+    Writes ``pr.patches`` (unified diff) and ``pr_files.json``
+    (``{repo, number, files}``).
+
+    Args:
+        repo_url: Repository URL the PR belongs to.
+        pr_number: PR number to fetch.
+        out_dir: Directory to write the artifacts into (created if needed).
+        primus_cortex_url: Primus Cortex base URL.
+        primus_timeout_sec: Per-request timeout for Primus calls.
+
+    Returns:
+        A dict of absolute artifact paths (``patches_path``,
+        ``files_json_path``).
+
+    Raises:
+        PrimusCortexError: On Primus transport / parse errors.
     """
     out = Path(out_dir).expanduser()
     out.mkdir(parents=True, exist_ok=True)
@@ -210,8 +239,22 @@ def evaluate_candidate_outcome(
 
     Gate logic matches the CLI's winner decision. Inputs accept a dict, a
     Path, or a string path; missing/invalid inputs yield a ``False`` verdict
-    with a reason rather than raising. Returns a dict with keys ``winner``,
-    ``reason``, ``throughput``, ``accuracy``, ``throughput_ratio``, ``completed``.
+    with a reason rather than raising.
+
+    Args:
+        benchmark: Benchmark data (dict, JSON path, or ``None``).
+        accuracy: Accuracy data (dict, JSON path, or ``None``).
+        baseline_throughput: Baseline throughput; must be positive.
+        baseline_accuracy: Baseline accuracy, if accuracy is gated.
+        min_throughput_ratio: Minimum throughput ratio to win.
+        max_accuracy_drop: Maximum tolerated accuracy drop.
+
+    Returns:
+        A dict with keys ``winner``, ``reason``, ``throughput``,
+        ``accuracy``, ``throughput_ratio``, and ``completed``.
+
+    Raises:
+        ValueError: If ``baseline_throughput`` is not a positive float.
     """
     if baseline_throughput is None or baseline_throughput <= 0:
         raise ValueError("baseline_throughput must be a positive float")

--- a/framework-agent/src/framework_agent/shell.py
+++ b/framework-agent/src/framework_agent/shell.py
@@ -74,8 +74,19 @@ def render_template(
     """Render known ``{var}`` placeholders, raise on unknown placeholders.
 
     Leaves JSON-style ``{...}`` braces that don't match the
-    ``[A-Za-z_][A-Za-z0-9_]*`` identifier pattern untouched. ``shell_quote=True``
-    wraps each value in :func:`shlex.quote` for shell-bound strings.
+    ``[A-Za-z_][A-Za-z0-9_]*`` identifier pattern untouched.
+
+    Args:
+        template: Template string with ``{var}`` placeholders.
+        variables: Mapping of placeholder names to replacement values.
+        shell_quote: When True, wrap each value in :func:`shlex.quote` for
+            shell-bound strings.
+
+    Returns:
+        The rendered string.
+
+    Raises:
+        ValueError: If any ``{identifier}`` placeholder is left unresolved.
     """
     rendered = template
     for key, value in variables.items():

--- a/framework-agent/src/framework_agent/sources/__init__.py
+++ b/framework-agent/src/framework_agent/sources/__init__.py
@@ -64,8 +64,15 @@ def _pr_to_candidate(
 ) -> Candidate:
     """Convert a GitHubPr (any backend) into a downstream Candidate.
 
-    ``score`` is the gap-relevance value from :func:`_rank_by_keyword_overlap`;
-    0.0 for paths that skip ranking (explicit refs, label-only listing).
+    Args:
+        pr: The source PR record.
+        repo_url: Repository URL the PR belongs to.
+        source: Source label recorded on the candidate (e.g. ``"github"``).
+        score: Gap-relevance value from :func:`_rank_by_keyword_overlap`;
+            ``0.0`` for paths that skip ranking.
+
+    Returns:
+        The downstream :class:`Candidate`.
     """
     return Candidate(
         ref=pr.ref,
@@ -168,6 +175,12 @@ def _resolve_keywords(request: ExploreRequest) -> list[str]:
     Priority: (1) ``request.keywords`` non-empty -> used verbatim (lowercased,
     bypasses extract_keywords); (2) ``gap_description`` -> auto-extract via
     :func:`extract_keywords`; (3) else ``[]`` (label-only path).
+
+    Args:
+        request: The explore request carrying keywords / gap description.
+
+    Returns:
+        The resolved keyword list (possibly empty).
     """
     if request.keywords:
         return [k.lower() for k in request.keywords if k.strip()]
@@ -183,8 +196,14 @@ def _rank_by_keyword_overlap(
 
     Uses :func:`score_title_with_anti_signal` so wrong-axis PRs (e.g.
     ``MegaMoE`` when gap calls for ``dense``) are demoted below correct-axis
-    PRs. Higher score first; ties preserve upstream order. Zero-score PRs drop
-    to the tail but are not filtered out. Anti-signal is gated per-gap-keyword.
+    PRs. Zero-score PRs drop to the tail but are not filtered out.
+
+    Args:
+        prs: PRs to rerank.
+        keywords: Active keywords driving the score.
+
+    Returns:
+        PRs sorted by descending score; ties preserve upstream order.
     """
     if not keywords:
         return list(prs)
@@ -196,12 +215,22 @@ def _rank_by_keyword_overlap(
 
 
 def _run_primus_cortex(request: ExploreRequest) -> list[Candidate]:
-    """Query primus-cortex with gap-aware ranking; hard-fail on transport errors.
+    """Query primus-cortex with gap-aware ranking.
 
     With non-empty keywords, prefer the free-text ``/v1/search/prs`` endpoint
     (over-fetch, then client-rerank by title overlap, trim to
     ``max_search_candidates``); fall back to ``list_perf_prs`` if search is
     unimplemented. With no keywords, use the cheap label-only path.
+
+    Args:
+        request: The explore request carrying the Primus config.
+
+    Returns:
+        Candidates from Primus Cortex, ranked when keywords are present.
+
+    Raises:
+        SourceConfigError: If ``primus_cortex`` is requested without config.
+        PrimusCortexError: On Primus transport errors.
     """
     cfg = request.primus_cortex
     if cfg is None:

--- a/framework-agent/src/framework_agent/sources/_shared.py
+++ b/framework-agent/src/framework_agent/sources/_shared.py
@@ -40,8 +40,16 @@ class GitHubPr:
 def _repo_slug(repo_url: str) -> str:
     """Parse ``owner/name`` from a GitHub-style git URL.
 
-    Accepts https (+/- .git) and ssh forms. Raises ValueError on a non-GitHub
-    or malformed URL.
+    Accepts https (+/- .git) and ssh forms.
+
+    Args:
+        repo_url: The repository URL to parse.
+
+    Returns:
+        The ``owner/name`` slug.
+
+    Raises:
+        ValueError: On a non-GitHub or malformed URL.
     """
     raw = repo_url.strip()
     if raw.endswith(".git"):

--- a/framework-agent/src/framework_agent/sources/primus_cortex.py
+++ b/framework-agent/src/framework_agent/sources/primus_cortex.py
@@ -242,10 +242,24 @@ def list_perf_prs(
     label: str | None = None,
     timeout_sec: float = 10.0,
 ) -> list[GitHubPr]:
-    """List PRs from primus-cortex; hard-fails on transport/parse errors.
+    """List PRs from primus-cortex.
 
     Returns :class:`GitHubPr` (same as the GitHub backend) so the dispatcher
     can union both sources without per-source branching.
+
+    Args:
+        repo_url: Repository URL to list PRs for.
+        base_url: Primus Cortex base URL.
+        limit: Maximum number of PRs to return.
+        state: PR state filter (e.g. ``"open"``).
+        label: Optional label filter.
+        timeout_sec: Per-request timeout.
+
+    Returns:
+        A list of :class:`GitHubPr` records.
+
+    Raises:
+        PrimusCortexError: On bad repo URL or transport/parse errors.
     """
     try:
         repo_slug = _repo_slug(repo_url)
@@ -353,6 +367,18 @@ def pr_patches(
     ``diff --git`` / ``--- a/`` / ``+++ b/`` headers per file so ``git apply``
     can consume it. Honours ``previous_path`` / ``status`` for renames+deletes;
     items missing ``patch`` (binary) emit only the file header.
+
+    Args:
+        repo_slug: ``owner/name`` repository slug.
+        number: PR number to fetch patches for.
+        base_url: Primus Cortex base URL.
+        timeout_sec: Per-request timeout.
+
+    Returns:
+        A unified-diff string suitable for ``git apply``.
+
+    Raises:
+        PrimusCortexError: On unexpected payload shapes or transport errors.
     """
     url = _build_url(base_url, f"/v1/repos/{repo_slug}/prs/{number}/patches")
     payload = _http_get_json(url, timeout_sec=timeout_sec)

--- a/inference_optimizer/baseline_comparison/target_analyzer.py
+++ b/inference_optimizer/baseline_comparison/target_analyzer.py
@@ -196,6 +196,13 @@ def _target_row_to_point(row: dict[str, Any]) -> BaselinePoint | None:
     Returns ``None`` when ``tput_per_gpu`` is missing or non-positive.
     ``tpot_ms`` is the per-output-token latency; ``interactivity`` (when
     present) is informational only and not folded into the point shape.
+
+    Args:
+        row: A single ``per_conc`` mapping from the competitor target data.
+
+    Returns:
+        A ``BaselinePoint`` built from the row, or ``None`` when the row has
+        no usable positive ``tput_per_gpu``.
     """
     def _fnum(key: str) -> float:
         """Read a float field from the enclosing ``row``.
@@ -253,6 +260,20 @@ def analyze(
     ``reason`` mirrors ``status`` with finer granularity:
     ``ok`` / ``model_mapping_miss`` / ``no_target_gpu_configured`` /
     ``no_competitor_target``.
+
+    Args:
+        session_dir: Session directory used to load competitor data and
+            persist the resulting summary.
+        model_path: Model path or name to map to a canonical display name.
+        compare_against_gpu: Target GPU to compare against; when empty the
+            analysis is skipped.
+        framework: Optional framework name recorded on the query.
+        precision: Optional precision label recorded on the query.
+        isl: Optional input sequence length recorded on the query.
+        osl: Optional output sequence length recorded on the query.
+
+    Returns:
+        The persisted ``BaselineSummary`` describing the comparison outcome.
     """
     from ..orchestrator import research_hints
 

--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -41,7 +41,15 @@ _ENV_DENY_PATTERN = re.compile(
 
 
 def _filter_envs(envs: dict[str, Any] | None) -> dict[str, str]:
-    """Apply the allowlist + secret denylist; returns a fresh ``dict[str, str]`` (values stringified)."""
+    """Apply the allowlist + secret denylist; returns a fresh ``dict[str, str]`` (values stringified).
+
+    Args:
+        envs: Raw environment mapping to filter, or ``None``.
+
+    Returns:
+        A new dict containing only allowlisted, non-secret keys with
+        stringified values.
+    """
     if not isinstance(envs, dict):
         return {}
     out: dict[str, str] = {}
@@ -98,7 +106,14 @@ _SERVER_LOG_MAX_BYTES = 256 * 1024
 
 
 def _strip_log_prefix(line: str) -> str:
-    """Strip a leading ``[ts] LEVEL [src.py:NN]`` style prefix (incl. the process tag) from a log line."""
+    """Strip a leading ``[ts] LEVEL [src.py:NN]`` style prefix (incl. the process tag) from a log line.
+
+    Args:
+        line: A raw log line.
+
+    Returns:
+        The line with any leading log/timestamp prefix removed and trimmed.
+    """
     s = line
     s = _LOG_PREFIX_RE.sub("", s)
     s = _LOG_TIMESTAMP_RE.sub("", s)
@@ -132,6 +147,13 @@ def _load_yaml_dict_safe(config_yaml: Path) -> dict | None:
     """Parse ``config_yaml`` to its top-level dict, or ``None`` on miss/failure. Never raises.
 
     Shared by both yaml passes so the file is read at most once.
+
+    Args:
+        config_yaml: Path to the YAML config file.
+
+    Returns:
+        The parsed top-level dict, or ``None`` when PyYAML is unavailable,
+        the file cannot be read/parsed, or the root is not a mapping.
     """
     try:
         import yaml  # type: ignore[import-not-found]
@@ -148,7 +170,14 @@ def _load_yaml_dict_safe(config_yaml: Path) -> dict | None:
 
 
 def _yaml_cmd_from_dict(data: dict) -> str:
-    """Find a ``cmd`` / ``command`` / ``launch`` field (top-level or under ``benchmark``); ``""`` on miss."""
+    """Find a ``cmd`` / ``command`` / ``launch`` field (top-level or under ``benchmark``); ``""`` on miss.
+
+    Args:
+        data: Parsed YAML config dict.
+
+    Returns:
+        The first non-empty command string found, or ``""`` when none exists.
+    """
     for key in ("cmd", "command", "launch"):
         val = data.get(key)
         if isinstance(val, str) and val.strip():
@@ -167,6 +196,13 @@ def _yaml_benchmark_synthesis(data: dict) -> str:
 
     Returns ``""`` unless both ``benchmark.framework`` and
     ``benchmark.model`` are non-empty.
+
+    Args:
+        data: Parsed YAML config dict containing a ``benchmark`` mapping.
+
+    Returns:
+        A synthesized human-readable arg string, or ``""`` when the required
+        ``framework``/``model`` fields are missing.
     """
     bench = data.get("benchmark")
     if not isinstance(bench, dict):
@@ -213,6 +249,15 @@ def _extract_framework_args(
     priority order: ``log_non_default_args`` / ``log_args_line`` /
     ``log_python_cmd`` / ``yaml_cmd`` / ``yaml_benchmark`` (synthesized,
     not a literal cmdline) / ``unknown`` (empty args).
+
+    Args:
+        server_log: Path to the variant's server log, or ``None``.
+        config_yaml: Optional path to the variant config used as a fallback
+            source for the launch command.
+
+    Returns:
+        A ``(args_string, source)`` tuple; ``("", "unknown")`` when nothing
+        could be extracted.
     """
     chunk: str = ""
     if server_log is not None:
@@ -290,7 +335,15 @@ def _extract_framework_args(
 
 
 def _read_invocation_envs(config_path: Path | None) -> dict[str, str]:
-    """Read ``benchmark.envs`` (or top-level ``envs:``) from a variant config; allowlisted subset, never raises."""
+    """Read ``benchmark.envs`` (or top-level ``envs:``) from a variant config; allowlisted subset, never raises.
+
+    Args:
+        config_path: Path to the variant config YAML, or ``None``.
+
+    Returns:
+        The allowlisted, filtered environment mapping; empty when the file is
+        missing, unparseable, or has no envs.
+    """
     if config_path is None:
         return {}
     try:
@@ -511,6 +564,13 @@ def _benchmark_report_metrics(
 
     Priority: V2 nested (``throughput.*`` / ``latency.<m>.mean_ms``),
     pre-V2 flat top-level, then legacy ``result.<flat>``.
+
+    Args:
+        report: Parsed ``benchmark_report.json`` dict, or ``None``.
+
+    Returns:
+        A ``(output_throughput, ttft, tpot, e2el)`` tuple; each element is
+        ``None`` when the corresponding metric is absent.
     """
     if not isinstance(report, dict):
         return (None, None, None, None)
@@ -559,7 +619,14 @@ def _benchmark_report_metrics(
 
 
 def _benchmark_report_candidates(root: Path) -> list[Path]:
-    """Return benchmark reports under a task/workspace root (handles the several on-disk layouts used over time)."""
+    """Return benchmark reports under a task/workspace root (handles the several on-disk layouts used over time).
+
+    Args:
+        root: Task or workspace root directory to scan.
+
+    Returns:
+        Candidate ``benchmark_report.json`` paths (possibly empty).
+    """
     if not root.exists():
         return []
 
@@ -595,7 +662,14 @@ def _latest_benchmark_report(candidates: Iterable[Path]) -> Path | None:
 
 
 def _find_benchmark_report(workspace: Path | None) -> Path | None:
-    """Locate the most recent (by mtime) ``benchmark_report.json`` under a task workspace, else ``None``."""
+    """Locate the most recent (by mtime) ``benchmark_report.json`` under a task workspace, else ``None``.
+
+    Args:
+        workspace: Task workspace directory, or ``None``.
+
+    Returns:
+        The newest matching report path, or ``None`` when none exist.
+    """
     if workspace is None or not workspace.exists():
         return None
     return _latest_benchmark_report(_benchmark_report_candidates(workspace))
@@ -612,6 +686,15 @@ def _resolve_under_session(
     ``session_dir`` (container paths like ``/workspace/runs/...`` map to the
     wekafs ``<session_dir>/runs/...`` view). Returns the first existing
     path, else ``None``.
+
+    Args:
+        session_dir: Session root used to re-anchor container-rooted paths.
+        raw: The candidate path string, or ``None``.
+        anchors: Path segments to re-root under ``session_dir`` when the raw
+            path does not exist as-is.
+
+    Returns:
+        The first existing resolved path, or ``None``.
     """
     if not raw:
         return None
@@ -656,7 +739,15 @@ def _safe_get(d: Any, *keys: str, default: Any = None) -> Any:
 
 
 def _close_phase_stop_reason(state: dict[str, Any]) -> tuple[str, str]:
-    """Recover terminal reason/time from the CLOSE phase transition (next-best when ``state.stop_reason`` wasn't mirrored)."""
+    """Recover terminal reason/time from the CLOSE phase transition (next-best when ``state.stop_reason`` wasn't mirrored).
+
+    Args:
+        state: Session state mapping holding ``phase_history``.
+
+    Returns:
+        A ``(reason, timestamp)`` tuple from the CLOSE transition; both empty
+        when no CLOSE transition is recorded.
+    """
     history = state.get("phase_history") or []
     if not isinstance(history, list):
         return "", ""
@@ -1138,7 +1229,14 @@ def collect_final(
 
 
 def _find_latest_validate_stack_report(session_dir: Path) -> Path | None:
-    """Most-recent validate_stack benchmark_report.json (authoritative for the final stack's clock)."""
+    """Most-recent validate_stack benchmark_report.json (authoritative for the final stack's clock).
+
+    Args:
+        session_dir: Session root containing ``runs/validate_stack``.
+
+    Returns:
+        The newest validate_stack report path, or ``None`` when absent.
+    """
     root = session_dir / "runs" / "validate_stack"
     if not root.exists():
         return None
@@ -1153,7 +1251,15 @@ def _find_latest_validate_stack_report(session_dir: Path) -> Path | None:
 def _find_current_best_report(
     session_dir: Path, state: dict[str, Any],
 ) -> Path | None:
-    """Best-effort benchmark report for ``state.current_best`` (via workspace or action/variant/tput match)."""
+    """Best-effort benchmark report for ``state.current_best`` (via workspace or action/variant/tput match).
+
+    Args:
+        session_dir: Session root to search under.
+        state: Session state mapping holding ``current_best``.
+
+    Returns:
+        The matching benchmark report path, or ``None``.
+    """
     cb = state.get("current_best") or {}
     if not isinstance(cb, dict):
         return None
@@ -1168,7 +1274,15 @@ def _find_current_best_report(
 def _find_stack_top_report(
     session_dir: Path, state: dict[str, Any],
 ) -> Path | None:
-    """Last optimization_stack entry's benchmark_report.json (next-best when no validate_stack run exists)."""
+    """Last optimization_stack entry's benchmark_report.json (next-best when no validate_stack run exists).
+
+    Args:
+        session_dir: Session root to search under.
+        state: Session state mapping holding the optimization stack.
+
+    Returns:
+        The matching benchmark report path, or ``None``.
+    """
     cb = state.get("current_best") or {}
     stack = state.get("optimization_stack") or []
     if not stack and isinstance(cb, dict):
@@ -1193,7 +1307,16 @@ def _find_stack_top_report(
 def _find_matching_action_report(
     session_dir: Path, entry: dict[str, Any],
 ) -> Path | None:
-    """Match a report under ``runs/<action>/`` by variant name and tput (conservative; tput beats variant, latency-less reports skipped)."""
+    """Match a report under ``runs/<action>/`` by variant name and tput (conservative; tput beats variant, latency-less reports skipped).
+
+    Args:
+        session_dir: Session root to search under.
+        entry: Stack/current-best entry carrying ``action``, ``variant_name``
+            and ``tput`` used for matching.
+
+    Returns:
+        The highest-scoring matching report path, or ``None``.
+    """
     action = str(entry.get("action") or "").strip()
     if not action:
         return None
@@ -1234,7 +1357,18 @@ def _build_final_invocation(
     benchmark_report: Path | None,
     warnings: list[str],
 ) -> dict[str, Any]:
-    """Best-effort :class:`BenchmarkInvocation` for the final stack run (config = the launched ``*.with_envs.yaml`` sibling)."""
+    """Best-effort :class:`BenchmarkInvocation` for the final stack run (config = the launched ``*.with_envs.yaml`` sibling).
+
+    Args:
+        session_dir: Session root used to relativize discovered paths.
+        state: Session state mapping (reserved for future enrichment).
+        benchmark_report: The final stack's benchmark report path, or ``None``.
+        warnings: Accumulator appended to when arg extraction fails.
+
+    Returns:
+        A dict describing the final invocation (framework args, envs, config
+        and server-log paths).
+    """
     config_path: Path | None = None
     server_log_path: Path | None = None
     if benchmark_report is not None:
@@ -1281,7 +1415,14 @@ _AUDIT_ACTIONS = (
 
 
 def _parse_iso_unix(ts: Any) -> float | None:
-    """Best-effort ISO-8601 -> unix seconds. ``None`` on any failure."""
+    """Best-effort ISO-8601 -> unix seconds. ``None`` on any failure.
+
+    Args:
+        ts: Timestamp as an ISO-8601 string or numeric epoch seconds.
+
+    Returns:
+        Unix seconds as a float, or ``None`` when parsing fails.
+    """
     if ts is None:
         return None
     if isinstance(ts, (int, float)):
@@ -1303,6 +1444,13 @@ def _iso_z(ts: Any) -> str:
     The journal and ``state.phase_history`` use different suffixes;
     collapsing both keeps display and ``[entered_ts, exit_ts)`` matching
     consistent. Returns the input unchanged when empty/unparseable.
+
+    Args:
+        ts: Timestamp value to normalise.
+
+    Returns:
+        A canonical ``...Z`` UTC second-precision string, or the input
+        unchanged when empty or unparseable.
     """
     if ts is None:
         return ""
@@ -1322,7 +1470,15 @@ def _iso_z(ts: Any) -> str:
 def _load_optimization_journal(
     session_dir: Path | None, warnings: list[str],
 ) -> list[dict[str, Any]]:
-    """Read ``reports/optimization_journal.json`` entries (the canonical action ledger); ``[]`` on legacy sessions."""
+    """Read ``reports/optimization_journal.json`` entries (the canonical action ledger); ``[]`` on legacy sessions.
+
+    Args:
+        session_dir: Session root, or ``None``.
+        warnings: Accumulator appended to on read/parse failures.
+
+    Returns:
+        The journal ``entries`` list, or ``[]`` when missing.
+    """
     if session_dir is None:
         return []
     data = _load_json_safe(
@@ -1335,7 +1491,14 @@ def _load_optimization_journal(
 
 
 def _journal_entry_to_event(e: dict[str, Any]) -> dict[str, Any]:
-    """Map one optimization_journal entry to a phase_timeline event (keeps the declared ``phase`` for exact bucketing)."""
+    """Map one optimization_journal entry to a phase_timeline event (keeps the declared ``phase`` for exact bucketing).
+
+    Args:
+        e: A single optimization-journal entry dict.
+
+    Returns:
+        A normalized phase-timeline event dict.
+    """
     metric = e.get("throughput_after")
     metric_kind = "output_throughput" if metric is not None else None
     if metric is None and e.get("gain_pct") is not None:
@@ -1389,6 +1552,14 @@ def collect_phase_timeline(
     the journal copy winning, then sorted by ``ts``. Passing
     ``session_dir=None`` degrades gracefully to the audit-list scrape
     (used by unit fixtures that have no on-disk journal).
+
+    Args:
+        session_dir: Session root, or ``None`` to use only the audit lists.
+        state: Session state mapping holding the per-action attempt lists.
+        warnings: Accumulator appended to on journal read/parse failures.
+
+    Returns:
+        A de-duplicated, chronologically sorted list of timeline events.
     """
     events: list[dict[str, Any]] = []
 
@@ -1499,7 +1670,15 @@ def collect_phase_timeline(
 def _capability_for_action(
     state: dict[str, Any], action: str,
 ) -> dict[str, Any]:
-    """Per-action capability tally from ``<action>_attempts``, with an ``optimization_stack`` KEEP fallback for V1/partial state."""
+    """Per-action capability tally from ``<action>_attempts``, with an ``optimization_stack`` KEEP fallback for V1/partial state.
+
+    Args:
+        state: Session state mapping holding attempt lists and the stack.
+        action: Action name to tally.
+
+    Returns:
+        A dict with ``status``, ``attempts`` and ``keeps`` for the action.
+    """
     attempts_list = state.get(f"{action}_attempts") or []
     n_attempts = len(attempts_list) if isinstance(attempts_list, list) else 0
     n_keeps = sum(
@@ -1706,6 +1885,13 @@ def _specialist_capability_row(state: dict[str, Any]) -> dict[str, Any]:
 
     Headline counts aggregate all domains; ``by_specialist`` breaks them
     out per SpecialistDomain.key.
+
+    Args:
+        state: Session state mapping holding ``specialist_rounds``.
+
+    Returns:
+        A capability row with aggregate counts and a ``by_specialist``
+        per-domain breakdown.
     """
     rounds = state.get("specialist_rounds") or []
     if not isinstance(rounds, list) or not rounds:
@@ -1797,7 +1983,12 @@ def _specialist_capability_row(state: dict[str, Any]) -> dict[str, Any]:
 
 
 def _empty_by_specialist_capability() -> dict[str, dict[str, Any]]:
-    """Seed every catalogue domain with a not_attempted CapabilityEntry (stable shape, no KeyError-guarding)."""
+    """Seed every catalogue domain with a not_attempted CapabilityEntry (stable shape, no KeyError-guarding).
+
+    Returns:
+        A mapping of every catalogue domain to a zeroed, not_attempted
+        capability entry.
+    """
     return {
         d: {"status": "not_attempted", "attempts": 0, "keeps": 0, "tested": 0}
         for d in _SPECIALIST_DOMAIN_KEYS
@@ -1806,7 +1997,14 @@ def _empty_by_specialist_capability() -> dict[str, dict[str, Any]]:
 
 # §7 / §8 GEAK / OOB invocations
 def _kernel_agent_run_dirs(session_dir: Path) -> list[Path]:
-    """All ``<sd>/kernel-agent/runs/<sid>/`` dirs plus the two legacy layouts, so historical sessions still render."""
+    """All ``<sd>/kernel-agent/runs/<sid>/`` dirs plus the two legacy layouts, so historical sessions still render.
+
+    Args:
+        session_dir: Session root to scan for kernel-agent run dirs.
+
+    Returns:
+        The discovered run directories across canonical and legacy layouts.
+    """
     candidates: list[Path] = []
     # Canonical (current): <sd>/kernel-agent/runs/<sid>/
     new_root = session_dir / "kernel-agent" / "runs"
@@ -1925,6 +2123,13 @@ def _stamp_kernel_level_decisions(
     Reads kernel-level ``results/<kid>.json`` + ``verification/<kid>.json``;
     the best attempt is chosen by backend hint, else highest micro_speedup
     (ties: latest ts). Other attempts keep their per-attempt decision.
+
+    Args:
+        invocations: Attempt invocation dicts, mutated in place with the
+            stamped kernel-level decision and metadata.
+        run_dirs: Kernel-agent run directories to read results from.
+        session_dir: Session root used to relativize artifact paths.
+        warnings: Accumulator appended to on read/parse failures.
     """
     # Group by (run_id, kernel_id); same kid in different run_dirs is separate.
     groups: dict[tuple[str, str], list[dict[str, Any]]] = {}
@@ -2015,7 +2220,15 @@ def _shape_kernel_metadata(
     result: dict[str, Any],
     attempt: dict[str, Any],
 ) -> dict[str, Any]:
-    """Best-effort kernel metadata, preferring ``result['kernel_metadata']`` over the attempt's own."""
+    """Best-effort kernel metadata, preferring ``result['kernel_metadata']`` over the attempt's own.
+
+    Args:
+        result: The kernel-level result dict.
+        attempt: The attempt's own metadata used as a fallback.
+
+    Returns:
+        A normalized kernel-metadata dict.
+    """
     meta = result.get("kernel_metadata") if isinstance(result, dict) else None
     if isinstance(meta, dict) and meta:
         return {
@@ -2035,7 +2248,15 @@ def _shape_kernel_metadata(
 
 
 def _infer_run_dir_kernel_id(run_dir: Path) -> str:
-    """Recover the kernel id for a run dir whose attempts omit ``kernel_id``; only when the dir holds a single kid."""
+    """Recover the kernel id for a run dir whose attempts omit ``kernel_id``; only when the dir holds a single kid.
+
+    Args:
+        run_dir: Kernel-agent run directory to inspect.
+
+    Returns:
+        The single kernel id found under ``results``/``verification``, or
+        ``""`` when zero or multiple ids are present.
+    """
     kids: set[str] = set()
     for sub in ("results", "verification"):
         d = run_dir / sub
@@ -2051,7 +2272,16 @@ def collect_kernel_invocations(
     session_dir: Path,
     warnings: list[str],
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-    """Return ``(geak_invocations, oob_invocations)`` from each run dir's ``optimization_attempts.jsonl``, split by ``backend``."""
+    """Return ``(geak_invocations, oob_invocations)`` from each run dir's ``optimization_attempts.jsonl``, split by ``backend``.
+
+    Args:
+        session_dir: Session root to scan for kernel-agent run dirs.
+        warnings: Accumulator appended to on read/parse failures.
+
+    Returns:
+        A ``(geak_invocations, oob_invocations)`` tuple of attempt records,
+        each sorted by ``(kernel_id, ts)``.
+    """
     all_invocations: list[dict[str, Any]] = []
     run_dirs = _kernel_agent_run_dirs(session_dir)
     for run_dir in run_dirs:
@@ -2131,6 +2361,14 @@ def _read_kernel_candidates(
 
     Resolves via the orchestrator-recorded path, then the new and legacy
     on-disk layouts (glob fallbacks), then ``last_trace_analyze.hot_kernels_top15``.
+
+    Args:
+        session_dir: Session root to search for ``kernel_candidates.json``.
+        state: Session state mapping holding ``last_trace_analyze``.
+        warnings: Accumulator appended to on read/parse failures.
+
+    Returns:
+        The ``hot_kernels`` list, or ``[]`` when none can be resolved.
     """
     sk = state.get("last_trace_analyze") or {}
     raw_path = sk.get("candidates_path") if isinstance(sk, dict) else None
@@ -2180,7 +2418,14 @@ def _read_kernel_candidates(
 def _index_invocations_by_kernel(
     invs: list[dict[str, Any]],
 ) -> dict[str, dict[str, Any]]:
-    """Fold per-attempt invocations into a per-kernel ``{attempts, best_speedup, decision, last_status}`` summary."""
+    """Fold per-attempt invocations into a per-kernel ``{attempts, best_speedup, decision, last_status}`` summary.
+
+    Args:
+        invs: Per-attempt invocation records.
+
+    Returns:
+        A mapping of ``kernel_id`` to its aggregated summary.
+    """
     out: dict[str, dict[str, Any]] = {}
     for inv in invs:
         kid = str(inv.get("kernel_id") or "")
@@ -2219,6 +2464,17 @@ def _collect_detected_kernels(
     preferred, else ``benchmark_report.kernel_summary``),
     ``selected_for_optimization``, per-lane ``geak`` / ``oob`` summaries,
     ``adopted_by`` (from integrate KEEPs), and ``final_decision``.
+
+    Args:
+        session_dir: Session root to read candidate/profile data from.
+        state: Session state mapping.
+        geak: GEAK lane invocation records.
+        oob: Out-of-box lane invocation records.
+        warnings: Accumulator appended to on read/parse failures.
+        cap: Optional maximum number of kernel rows to return.
+
+    Returns:
+        The per-kernel lifecycle rows keyed by ``kernel_id``.
     """
     by_kid: dict[str, dict[str, Any]] = {}
 
@@ -2702,7 +2958,16 @@ def _shape_ledger(
 def _patch_winners_history(
     rows: list[Any], baseline_tput: float | None,
 ) -> list[dict[str, Any]]:
-    """Fix ``backend_winners_history`` data gaps: fall back to session ``baseline_tput`` for a 0 ``base_tput``, and compute missing per-winner ``gain_pct``."""
+    """Fix ``backend_winners_history`` data gaps: fall back to session ``baseline_tput`` for a 0 ``base_tput``, and compute missing per-winner ``gain_pct``.
+
+    Args:
+        rows: Raw ``backend_winners_history`` rows.
+        baseline_tput: Session baseline throughput used to backfill a missing
+            per-row ``base_tput``.
+
+    Returns:
+        New rows with backfilled ``base_tput`` and computed ``gain_pct``.
+    """
     out: list[dict[str, Any]] = []
     for r in rows:
         if not isinstance(r, dict):
@@ -2982,7 +3247,14 @@ def collect_critic_robustness(
 def _critic_kb_writes_summary(
     critic_iters: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    """Build ``critic_robustness.kb_writes_summary`` by counting each iteration's verdict into ``by_verdict``."""
+    """Build ``critic_robustness.kb_writes_summary`` by counting each iteration's verdict into ``by_verdict``.
+
+    Args:
+        critic_iters: Critic iteration records, each carrying a ``verdict``.
+
+    Returns:
+        A summary dict with ``total`` and per-verdict ``by_verdict`` counts.
+    """
     by_verdict: dict[str, int] = {}
     total = 0
     for entry in critic_iters:
@@ -3138,6 +3410,13 @@ def _collect_lane_timeline(
     One row per lane (capacity, live_holders, lease_expired_count). The
     per-tick holders timeline is deferred; the aggregates suffice for the
     ``benchmark_lane.peak ≤ 1`` invariant check.
+
+    Args:
+        session_dir: Session root holding ``storage/coordinator.db``.
+        warnings: Accumulator appended to on database read failures.
+
+    Returns:
+        One summary row per lane, or ``[]`` when the database is absent.
     """
     db_path = session_dir / "storage" / "coordinator.db"
     if not db_path.exists():
@@ -3281,6 +3560,12 @@ def _normalize_specialist_key(provenance: str) -> str:
     ``specialist:<domain>`` → bare ``<domain>``; ``legacy:<action>`` →
     ``legacy_<action>``; ``default_grid`` / ``llm_direct`` pass through;
     empty/unknown → ``"unknown"`` (so by_domain is never keyed by ``""``).
+
+    Args:
+        provenance: Raw provenance string to normalise.
+
+    Returns:
+        A stable specialist key, ``"unknown"`` when empty/unrecognized.
     """
     s = (provenance or "").strip()
     if not s:
@@ -3339,6 +3624,13 @@ def _promote_legacy_gain_entries(
     Recovers action/variant/ts/args from the parallel
     ``optimization_stack`` and computes ``delta_pct`` against the prior
     entry; ``None`` ledger entries stay ``None`` to keep index alignment.
+
+    Args:
+        state_entries: The legacy gain ledger (list of float or ``None``).
+        state: Session state mapping holding ``optimization_stack``.
+
+    Returns:
+        The gain ledger promoted to the V1 entry schema.
     """
     stack = state.get("optimization_stack") or []
     out: list[dict[str, Any]] = []
@@ -3380,6 +3672,13 @@ def collect_roofline(
 
     Returns ``[]`` when no snapshots exist or on parse failure
     (best-effort; errors recorded in ``warnings``).
+
+    Args:
+        state: Session state mapping holding ``roofline_snapshots``.
+        warnings: Accumulator appended to on parse failures.
+
+    Returns:
+        The roofline comparison rows, or ``[]`` when none/parse failed.
     """
     snapshots = state.get("roofline_snapshots")
     if not isinstance(snapshots, list) or not snapshots:
@@ -3557,6 +3856,15 @@ def _collect_phase_breakdown(
     Assigns each KEEP entry to the phase active at its acceptance
     timestamp (explore further splits by domain, kernel by kernel_id).
     Missing phase_history → everything lands under ``unattributed``.
+
+    Args:
+        state: Session state mapping holding ``phase_history`` and
+            ``explore_search``.
+        entries: Gain-ledger entries to attribute to phases.
+        warnings: Accumulator appended to on parse failures.
+
+    Returns:
+        A per-phase gain-attribution dict keyed by phase bucket.
     """
     # phase timeline lookup: for an entry ts, pick the latest row with ts_unix ≤ ts.
     history = state.get("phase_history") or []
@@ -3741,7 +4049,15 @@ def _reconstruct_gain_ledger(
     state: dict[str, Any],
     warnings: list[str],
 ) -> list[dict[str, Any]]:
-    """Approximate per-stack contribution (each entry's ``gain_pct`` as its delta) when Coordinator didn't record it; best-effort, see ``attribution.notes``."""
+    """Approximate per-stack contribution (each entry's ``gain_pct`` as its delta) when Coordinator didn't record it; best-effort, see ``attribution.notes``.
+
+    Args:
+        state: Session state mapping holding ``optimization_stack``.
+        warnings: Accumulator appended to on parse failures.
+
+    Returns:
+        A reconstructed gain ledger with cumulative/delta gains per entry.
+    """
     stack = state.get("optimization_stack") or []
     if not isinstance(stack, list):
         return []
@@ -3789,6 +4105,15 @@ def collect_roofline_progress(
     list-shaped key. Pure over ``state`` + ``manifest``. Output: ``trajectory[]``
     (baseline + KEEPs, ts-sorted), ceiling/target reference lines from the latest
     snapshot, headline current-best numbers, and a ``snapshots[]`` passthrough.
+
+    Args:
+        session_dir: Session root (reserved for path resolution).
+        state: Session state mapping holding snapshots and current-best.
+        manifest: Parsed session manifest dict.
+        warnings: Accumulator appended to on parse failures.
+
+    Returns:
+        The ``roofline_progress`` section dict.
     """
     # Trajectory: baseline + each KEEP.
     baseline_tput = _to_float(state.get("baseline_tput")) or 0.0
@@ -3948,6 +4273,13 @@ def collect_kernel_roofline(
     Missing file → ``{}`` (quiet); malformed → ``{}`` + warning; non-list
     ``kernels`` → ``[]``. Entries are type-coerced so upstream drift
     doesn't break consumers.
+
+    Args:
+        session_dir: Session root holding ``reports/kernel_roofline.json``.
+        warnings: Accumulator appended to on malformed input.
+
+    Returns:
+        The ``kernel_roofline`` section dict, or ``{}`` when absent/malformed.
     """
     path = session_dir / _KERNEL_ROOFLINE_REL_PATH
     if not path.exists():
@@ -4023,6 +4355,13 @@ def collect_kernel_optimization_summary(
     Missing → ``{}`` (quiet); malformed → ``{}`` + warning. Otherwise
     mirrored verbatim (producer additions ride through) apart from shape
     guards on the iterated containers + an added ``report_path``.
+
+    Args:
+        session_dir: Session root holding the summary file.
+        warnings: Accumulator appended to on malformed input.
+
+    Returns:
+        The kernel-optimization-summary section dict, or ``{}`` when absent.
     """
     path = session_dir / _KERNEL_OPT_SUMMARY_REL_PATH
     if not path.exists():
@@ -4086,6 +4425,13 @@ def collect_conc_sweep_summary(
     mirrored verbatim (only ``comparison`` shape-guarded) + ``report_path``.
     Do not synthesize the optional blocks the producer omits when
     ``status="skipped"``; pass through exactly what it wrote.
+
+    Args:
+        session_dir: Session root holding the conc-sweep summary file.
+        warnings: Accumulator appended to on malformed input.
+
+    Returns:
+        The conc-sweep-summary section dict, or ``{}`` when absent.
     """
     path = session_dir / _CONC_SWEEP_SUMMARY_REL_PATH
     if not path.exists():
@@ -4121,6 +4467,12 @@ def collect_optimization_stack(
 
     Each entry is stamped ``validated`` (within
     ``cumulative_gain_validated_stack_len``). Returns ``[]`` when absent.
+
+    Args:
+        state: Session state mapping holding ``optimization_stack``.
+
+    Returns:
+        The mirrored optimization-stack entries, or ``[]`` when absent.
     """
     stack = state.get("optimization_stack") or []
     if not isinstance(stack, list):
@@ -4142,7 +4494,15 @@ def collect_optimization_stack(
 def _normalize_optimization_stack_entry(
     raw: dict[str, Any], *, validated: bool,
 ) -> dict[str, Any]:
-    """Coerce one stack entry to the schema shape; unknown fields pass through verbatim (Inv-10.1 fact-layer compat)."""
+    """Coerce one stack entry to the schema shape; unknown fields pass through verbatim (Inv-10.1 fact-layer compat).
+
+    Args:
+        raw: A raw optimization-stack entry.
+        validated: Whether this entry falls within the validated stack prefix.
+
+    Returns:
+        The entry coerced to the schema shape with optional fields preserved.
+    """
     # Known fields — coerced types
     out: dict[str, Any] = {
         "action":                       str(raw.get("action") or ""),
@@ -4236,6 +4596,16 @@ def collect_phase_segments(
     own ``phase`` when present, else by the ``[entered_ts, exit_ts)``
     window. Empty when ``phase_history`` is missing (readers fall back to
     the flat ``phase_timeline``).
+
+    Args:
+        state: Session state mapping holding ``phase_history``.
+        phase_timeline: Flat action timeline whose events are attributed to
+            segments.
+        warnings: Accumulator appended to during attribution.
+
+    Returns:
+        The list of phase segments with folded events and actions; ``[]``
+        when ``phase_history`` is absent.
     """
     history = state.get("phase_history") or []
     if not isinstance(history, list) or not history:
@@ -4292,7 +4662,15 @@ def collect_phase_segments(
         })
 
     def _owner_by_window(ts: str) -> dict[str, Any] | None:
-        """Return the segment whose ``[entered_ts, exit_ts)`` ISO window holds ``ts`` (lexicographic compare)."""
+        """Return the segment whose ``[entered_ts, exit_ts)`` ISO window holds ``ts`` (lexicographic compare).
+
+        Args:
+            ts: ISO timestamp to locate.
+
+        Returns:
+            The owning segment, or the last segment when ``ts`` is empty or
+            unmatched; ``None`` when there are no segments.
+        """
         if not ts:
             return segments[-1] if segments else None
         for s in segments:
@@ -4369,7 +4747,17 @@ def collect_kb_provenance(
     manifest: dict[str, Any],
     warnings: list[str],
 ) -> dict[str, Any]:
-    """Collect the Cortex KB integration audit, merging SharedState warm-start fields, the NDJSON queue counts, and the audit-log status tail."""
+    """Collect the Cortex KB integration audit, merging SharedState warm-start fields, the NDJSON queue counts, and the audit-log status tail.
+
+    Args:
+        session_dir: Session root holding the Cortex queue/audit files.
+        state: Session state mapping holding warm-start fields.
+        manifest: Parsed session manifest dict.
+        warnings: Accumulator appended to with status signals and read errors.
+
+    Returns:
+        The KB-provenance audit section dict.
+    """
     from ..session_paths import (
         cortex_audit_jsonl as _audit_path,
         cortex_dead_letter_ndjson as _dl_path,
@@ -4506,7 +4894,17 @@ def _collect_flusher_status(
     pid_path: Path,
     warnings: list[str],
 ) -> dict[str, Any]:
-    """Merge the ``.kb_flusher_status.json`` boot marker with a live pid probe into one stable shape."""
+    """Merge the ``.kb_flusher_status.json`` boot marker with a live pid probe into one stable shape.
+
+    Args:
+        session_dir: Session root (reserved for path resolution).
+        status_path: Path to the flusher boot-status marker.
+        pid_path: Path to the flusher pid file.
+        warnings: Accumulator appended to on unreadable markers.
+
+    Returns:
+        A stable flusher-status dict including a live ``alive`` pid probe.
+    """
     base: dict[str, Any] = {
         "enabled":       False,
         "spawned":       False,
@@ -4557,7 +4955,15 @@ def _collect_flusher_status(
 
 # specialist_runs section
 def _coerce_round_id(value: Any) -> int | str:
-    """Normalise ``round_id`` to int when purely numeric, else keep the string (empty/None → 0). Never raises."""
+    """Normalise ``round_id`` to int when purely numeric, else keep the string (empty/None → 0). Never raises.
+
+    Args:
+        value: Raw round id value.
+
+    Returns:
+        An ``int`` for purely numeric input, ``0`` for empty/None, else the
+        stripped string.
+    """
     if value is None or value == "":
         return 0
     if isinstance(value, bool):
@@ -4584,6 +4990,16 @@ def collect_specialist_runs(
 
     ``include_transcripts`` inlines the transcript bytes under each ref's
     ``body`` (default False = path-only).
+
+    Args:
+        session_dir: Session root holding ``runs/specialist`` transcripts.
+        state: Session state mapping holding ``specialist_rounds``.
+        warnings: Accumulator appended to on read failures.
+        include_transcripts: When ``True``, inline transcript bytes under each
+            ref's ``body``.
+
+    Returns:
+        The ``specialist_runs`` section rows, or ``[]`` when none exist.
     """
     rounds = state.get("specialist_rounds") or []
     if not isinstance(rounds, list) or not rounds:
@@ -4695,7 +5111,15 @@ def _normalize_specialist_domain_breakdown(
 
 
 def _domain_for_task(round_entry: dict[str, Any], task_id: str) -> str:
-    """Best-effort domain for ``task_id`` within a round; "" when unmapped (older M5 rounds)."""
+    """Best-effort domain for ``task_id`` within a round; "" when unmapped (older M5 rounds).
+
+    Args:
+        round_entry: A single specialist round mapping.
+        task_id: Task id to resolve a domain for.
+
+    Returns:
+        The mapped domain, or ``""`` when it cannot be resolved.
+    """
     mapping = round_entry.get("task_domains")
     if isinstance(mapping, dict):
         v = mapping.get(task_id)
@@ -4732,6 +5156,12 @@ def _coerce_token(value: Any) -> int:
     The rollup sums tokens, so a missing counter contributes 0 here (the
     ``None``-vs-0 distinction matters only on the raw per-call rows, which
     we preserve verbatim in ``decision_trace.jsonl``).
+
+    Args:
+        value: Raw token-counter value.
+
+    Returns:
+        The value as an int, or ``0`` when ``None`` or unparseable.
     """
     if value is None:
         return 0
@@ -4781,6 +5211,13 @@ def _load_llm_calls(
     ``reports/trace/ext/*.jsonl`` shard written by out-of-process children.
     Best-effort: missing files / dirs yield ``[]``; malformed lines are
     skipped by :func:`_load_jsonl_safe`.
+
+    Args:
+        session_dir: Session root holding ``reports/trace``.
+        warnings: Accumulator appended to on scan/read failures.
+
+    Returns:
+        Every parsed LLM-call row across the ledger and ext shards.
     """
     trace_root = session_dir / "reports" / "trace"
     rows: list[dict[str, Any]] = list(
@@ -4806,6 +5243,13 @@ def _load_dispatch_history_all(
     Walks ``agents/orchestration/dynamic_actions/<dyn_id>/`` and stamps
     each row with its owning ``dyn_id`` so the join can key on it. Returns
     ``[]`` when the dynamic_actions tree is absent (no dynamic actions ran).
+
+    Args:
+        session_dir: Session root holding the dynamic-actions tree.
+        warnings: Accumulator appended to on scan/read failures.
+
+    Returns:
+        Every dispatch-history row stamped with its owning ``dyn_id``.
     """
     root = session_dir / "agents" / "orchestration" / "dynamic_actions"
     if not root.is_dir():
@@ -4835,6 +5279,12 @@ def _build_phase_windows(
     (real transitions). Used to backfill a call's / decision's phase from
     its ``ts`` when the producer didn't stamp one (out-of-process children,
     sub-agent runners). Empty when phase_history is missing.
+
+    Args:
+        state: Session state mapping holding ``phase_history``.
+
+    Returns:
+        A sorted list of ``(entered_unix, phase)`` window boundaries.
     """
     history = state.get("phase_history") or []
     if not isinstance(history, list):
@@ -4857,7 +5307,15 @@ def _build_phase_windows(
 
 
 def _phase_at(ts: Any, windows: list[tuple[float, str]]) -> str:
-    """Return the phase active at ``ts`` per ``windows`` (latest <= ts)."""
+    """Return the phase active at ``ts`` per ``windows`` (latest <= ts).
+
+    Args:
+        ts: Timestamp to resolve a phase for.
+        windows: Sorted ``(entered_unix, phase)`` boundaries.
+
+    Returns:
+        The phase active at ``ts``, or ``""`` when unresolved.
+    """
     unix = _parse_iso_unix(ts)
     if unix is None or not windows:
         return ""
@@ -4873,7 +5331,15 @@ def _phase_at(ts: Any, windows: list[tuple[float, str]]) -> str:
 def _decision_key(task_id: str, dyn_id: str) -> str | None:
     """Canonical join key for a decision / call: ``dyn_id`` wins over
     ``task_id`` (a dynamic_action dispatch owns both). ``None`` when
-    neither is present (the call can only be ts-window bucketed)."""
+    neither is present (the call can only be ts-window bucketed).
+
+    Args:
+        task_id: Task id, used when ``dyn_id`` is empty.
+        dyn_id: Dynamic-action id, preferred when present.
+
+    Returns:
+        A prefixed join key, or ``None`` when neither id is present.
+    """
     d = (dyn_id or "").strip()
     if d:
         return f"dyn:{d}"
@@ -4890,6 +5356,12 @@ def _token_convenience(bucket: dict[str, Any] | None) -> dict[str, int]:
     ``total_cache_creation`` / ``total_cache_read``) and the per-decision view
     (pre-summed ``total_cache``). ``total_in_out`` is prompt+completion only;
     ``grand_total`` folds in every cache token too.
+
+    Args:
+        bucket: A token bucket in either shape, or ``None``.
+
+    Returns:
+        A copy of the bucket with added ``total_in_out`` and ``grand_total``.
     """
     b = dict(bucket or {})
     ti = int(b.get("total_in", 0) or 0)
@@ -4925,6 +5397,14 @@ def collect_token_usage(
 
     Empty-but-valid (zeroed ``session_total``) when ``decision_trace`` is empty
     (e.g. a pre-trace session), so downstream readers never KeyError.
+
+    Args:
+        decision_trace: The decision-trace section holding the token rollup.
+        action_timeline: Visible action timeline rows to annotate with tokens.
+        warnings: Accumulator appended to on derivation issues.
+
+    Returns:
+        The ``token_usage`` section dict.
     """
     dt = decision_trace if isinstance(decision_trace, dict) else {}
     rollup = dt.get("token_rollup") or {}
@@ -5014,6 +5494,14 @@ def collect_langfuse(
     Either way credentials are redacted to host + presence booleans. Never
     raises: any failure degrades to a minimal ``config_only`` view so the
     breakdown still records whether the feature was even on.
+
+    Args:
+        session_dir: Session root holding the langfuse receipt/emitter state.
+        manifest: Parsed session manifest dict.
+        warnings: Accumulator appended to on read/receipt failures.
+
+    Returns:
+        The ``langfuse`` section dict (receipt, live, or config-only view).
     """
     from inference_optimizer.orchestrator.trace import langfuse_emitter as lfe
 
@@ -5086,6 +5574,15 @@ def collect_decision_trace(
     "unattributed_tokens": {...}}``. All-empty (zeroed rollup) when no
     trace files exist, so a session that ran before the trace subsystem
     landed degrades cleanly.
+
+    Args:
+        session_dir: Session root holding the trace files and journals.
+        state: Session state mapping used for phase-window backfill.
+        warnings: Accumulator appended to on read/write failures.
+
+    Returns:
+        A dict with ``decision_trace``, ``token_rollup`` and
+        ``unattributed_tokens`` keys.
     """
     calls = _load_llm_calls(session_dir, warnings)
     phase_windows = _build_phase_windows(state)
@@ -5238,6 +5735,11 @@ def _write_decision_trace_jsonl(
     the collector is the single producer, so a full rewrite is simpler than
     append + dedup and stays consistent with the latest join. Best-effort:
     OSError is recorded in ``warnings`` and swallowed.
+
+    Args:
+        session_dir: Session root holding ``reports/trace``.
+        decision_trace: The joined decision-trace rows to write.
+        warnings: Accumulator appended to on write failures.
     """
     target = session_dir / "reports" / "trace" / "decision_trace.jsonl"
     try:

--- a/inference_optimizer/breakdown/exporter.py
+++ b/inference_optimizer/breakdown/exporter.py
@@ -26,7 +26,16 @@ BREAKDOWN_FILENAME = "session_breakdown.json"
 
 
 def _load_state(session_dir: Path, warnings: list[str]) -> dict[str, Any]:
-    """Read ``state.json`` as a plain dict; empty dict + warning when missing."""
+    """Read ``state.json`` as a plain dict; empty dict + warning when missing.
+
+    Args:
+        session_dir: The hyperloom session directory.
+        warnings: Accumulator appended to when the file is missing or
+            unparseable.
+
+    Returns:
+        The parsed ``state.json`` contents, or an empty dict on any failure.
+    """
     state_path = session_dir / "state.json"
     if not state_path.exists():
         warnings.append(f"state.json missing at {state_path}")
@@ -314,7 +323,17 @@ def _safe_collect(
     *,
     default: Any = None,
 ):
-    """Run a collector with broad exception catching; failure → warning + ``default`` (a bug in one collector must not poison the export)."""
+    """Run a collector with broad exception catching; failure → warning + ``default`` (a bug in one collector must not poison the export).
+
+    Args:
+        name: Collector name used in the warning message.
+        fn: Zero-argument callable that runs the collector.
+        warnings: Accumulator appended to when the collector raises.
+        default: Value returned on failure; an empty dict when ``None``.
+
+    Returns:
+        The collector result, or ``default`` (or an empty dict) on failure.
+    """
     try:
         return fn()
     except Exception as exc:  # noqa: BLE001
@@ -335,6 +354,16 @@ def write_breakdown_json(
 
     ``output_path`` defaults to ``<session_dir>/session_breakdown.json``;
     ``include_transcripts`` is as in :func:`build`.
+
+    Args:
+        session_dir: The hyperloom session directory to build from.
+        output_path: Destination file; defaults to
+            ``<session_dir>/session_breakdown.json``.
+        include_transcripts: Whether to embed transcripts, as in
+            :func:`build`.
+
+    Returns:
+        The absolute path of the written breakdown file.
     """
     sd = Path(session_dir).resolve()
     target = Path(output_path).resolve() if output_path else sd / BREAKDOWN_FILENAME
@@ -376,6 +405,12 @@ def patch_breakdown_langfuse(session_dir: Path | str) -> bool:
     Best-effort and self-skipping: returns False (no-op) when no breakdown or
     no receipt exists yet, when live push was disabled, or on any error. Never
     raises -- it must not mask the session's stop_reason at shutdown.
+
+    Args:
+        session_dir: The hyperloom session directory holding the breakdown.
+
+    Returns:
+        ``True`` when the langfuse section was refreshed, ``False`` otherwise.
     """
     from ..orchestrator.trace.langfuse_emitter import read_receipt
 
@@ -443,6 +478,14 @@ def write_minimal_final_report(
 
     Stays minimal (one SharedState read) so it never raises or blocks
     shutdown. Idempotent: never overwrites an existing ``reports/final.md``.
+
+    Args:
+        session_dir: The hyperloom session directory.
+        output_path: Destination file; defaults to
+            ``<session_dir>/reports/final.md``.
+
+    Returns:
+        The path of the (existing or newly written) ``final.md`` file.
     """
     from ..orchestrator.shared_state import SharedState
     from ..session_paths import reports_dir

--- a/inference_optimizer/breakdown/legacy_collectors.py
+++ b/inference_optimizer/breakdown/legacy_collectors.py
@@ -49,7 +49,14 @@ _DEFAULT_PHASE = "EXPLORE"
 
 
 def is_legacy_session(state: dict[str, Any]) -> bool:
-    """A session is *legacy* when it never recorded ``phase_history``."""
+    """A session is *legacy* when it never recorded ``phase_history``.
+
+    Args:
+        state: Session state mapping to inspect.
+
+    Returns:
+        ``True`` when the session has no ``phase_history``, else ``False``.
+    """
     history = state.get("phase_history")
     return not (isinstance(history, list) and history)
 
@@ -99,6 +106,15 @@ def collect_phase_segments(
     consecutive same-phase events into segments matching the v2 collector
     wire shape; ``evidence.reconstructed_from == "legacy_audit_lists"``
     flags each as a derived view.
+
+    Args:
+        state: Session state mapping holding the optimization stack.
+        phase_timeline: Timestamped phase/action events to segment.
+        warnings: Mutable list to which any reconstruction warnings are
+            appended.
+
+    Returns:
+        The reconstructed ``phase_segments`` list in v2 collector shape.
     """
     events = [e for e in (phase_timeline or []) if isinstance(e, dict) and e.get("ts")]
     events.sort(key=lambda e: str(e.get("ts") or ""))

--- a/inference_optimizer/breakdown/reporters/_renderers/_invocation.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/_invocation.py
@@ -59,7 +59,17 @@ def render_invocation_block(
     invocation: Any,
     session_image: Any,
 ) -> str:
-    """Render an ``### Invocation`` markdown block, or "" when absent/empty."""
+    """Render an ``### Invocation`` markdown block, or "" when absent/empty.
+
+    Args:
+        invocation: Invocation record (dict) describing framework args,
+            environment overrides and config/log paths.
+        session_image: Container image associated with the session, if any.
+
+    Returns:
+        The rendered markdown block, or an empty string when the invocation
+        is missing or has nothing to show.
+    """
     if not isinstance(invocation, dict):
         return ""
     framework_args = str(invocation.get("framework_args") or "").strip()

--- a/inference_optimizer/breakdown/reporters/_renderers/data_provenance.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/data_provenance.py
@@ -14,7 +14,14 @@ from ..base import RenderedSection, md_table, register_renderer
 
 
 def _sources_summary(sources: list[dict[str, Any]]) -> str:
-    """Render a ``<found>/<total> probed`` summary, distinguishing required hits from optional."""
+    """Render a ``<found>/<total> probed`` summary, distinguishing required hits from optional.
+
+    Args:
+        sources: Probe records, each with ``found`` and ``required`` flags.
+
+    Returns:
+        A summary string of found/total counts, or ``"—"`` when empty.
+    """
     if not sources:
         return "—"
     total = len(sources)

--- a/inference_optimizer/breakdown/reporters/_renderers/invocations.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/invocations.py
@@ -19,7 +19,19 @@ def _render_pair(
     invocations_key: str,
     legacy_key: str,
 ) -> RenderedSection:
-    """Render either GEAK or OOB invocations (new ``invocations`` key, legacy fallback)."""
+    """Render either GEAK or OOB invocations (new ``invocations`` key, legacy fallback).
+
+    Args:
+        breakdown: The full ``session_breakdown.json`` dict.
+        section_id: Section identifier for the rendered block.
+        title: Human-readable section title.
+        invocations_key: Key under ``invocations`` to read records from.
+        legacy_key: Top-level fallback key for older breakdowns.
+
+    Returns:
+        The rendered section, or a skipped placeholder when no invocations
+        are present.
+    """
     raw = (
         (breakdown.get("invocations") or {}).get(invocations_key)
         or breakdown.get(legacy_key)

--- a/inference_optimizer/breakdown/reporters/_renderers/kernel_lifecycle.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/kernel_lifecycle.py
@@ -21,7 +21,15 @@ _MAX_NAME_LEN = 70
 
 
 def _short_name(name: str) -> str:
-    """Shorten a kernel name keeping head + tail (CK/ROCBLAS variants differ at the tail)."""
+    """Shorten a kernel name keeping head + tail (CK/ROCBLAS variants differ at the tail).
+
+    Args:
+        name: Full kernel name to shorten.
+
+    Returns:
+        The name unchanged when short enough, otherwise a head + tail
+        elision joined by ``"..."``.
+    """
     if not name:
         return ""
     if len(name) <= _MAX_NAME_LEN:

--- a/inference_optimizer/breakdown/reporters/base.py
+++ b/inference_optimizer/breakdown/reporters/base.py
@@ -64,7 +64,15 @@ REGISTRY: list[tuple[str, RendererFn]] = []
 
 
 def register_renderer(section_id: str) -> Callable[[RendererFn], RendererFn]:
-    """Decorator: register ``fn`` under ``section_id`` (re-registration replaces the prior entry)."""
+    """Decorator: register ``fn`` under ``section_id`` (re-registration replaces the prior entry).
+
+    Args:
+        section_id: Identifier under which the decorated renderer is stored.
+
+    Returns:
+        A decorator that registers the renderer function and returns it
+        unchanged.
+    """
 
     def _wrap(fn: RendererFn) -> RendererFn:
         """Register ``fn`` under ``section_id`` and return it unchanged.

--- a/inference_optimizer/breakdown/reporters/compose.py
+++ b/inference_optimizer/breakdown/reporters/compose.py
@@ -221,7 +221,14 @@ def _stitch(
 
 
 def _deterministic_exec_summary(g: GlobalFacts) -> str:
-    """Fallback exec summary when no LLM is configured / it failed; lists every data-quality flag."""
+    """Fallback exec summary when no LLM is configured / it failed; lists every data-quality flag.
+
+    Args:
+        g: Global facts used to populate the summary lines.
+
+    Returns:
+        The rendered executive-summary markdown block.
+    """
     out: list[str] = []
     out.append(f"- {g.headline} (stop_reason={g.stop_reason or 'unset'}, "
                f"elapsed={g.elapsed_minutes or 0:.0f}min, objective={g.objective}).")
@@ -249,7 +256,14 @@ def _deterministic_exec_summary(g: GlobalFacts) -> str:
 
 
 def _render_global_facts_block(g: GlobalFacts) -> str:
-    """Render :class:`GlobalFacts` as a compact key-value block for cross-checking the report."""
+    """Render :class:`GlobalFacts` as a compact key-value block for cross-checking the report.
+
+    Args:
+        g: Global facts to render as a key-value block.
+
+    Returns:
+        The rendered markdown key-value block.
+    """
     funnel = g.kernel_pipeline_funnel
     out: list[str] = []
     out.append(f"- **Headline**: {g.headline}")

--- a/inference_optimizer/breakdown/reporters/cross_section.py
+++ b/inference_optimizer/breakdown/reporters/cross_section.py
@@ -109,6 +109,13 @@ def _gain_attribution_lines(
 
     Priority: validated ``source_breakdown`` split, then single-entry
     ``final.action_path``, then best-effort ``optimization_stack``.
+
+    Args:
+        breakdown: The full ``session_breakdown.json`` dict.
+
+    Returns:
+        A tuple of the human-readable attribution lines and a label
+        describing the method used to derive them.
     """
     attribution = breakdown.get("attribution") or {}
     sb = attribution.get("source_breakdown") or {}
@@ -180,7 +187,15 @@ def _data_quality_flags(
     breakdown: dict[str, Any],
     rendered: list[RenderedSection],
 ) -> list[str]:
-    """Collect de-duplicated data-quality warnings from renderers + global cross-section checks."""
+    """Collect de-duplicated data-quality warnings from renderers + global cross-section checks.
+
+    Args:
+        breakdown: The full ``session_breakdown.json`` dict.
+        rendered: Rendered sections whose warnings are folded in.
+
+    Returns:
+        A de-duplicated list of data-quality flag strings.
+    """
     flags: list[str] = []
     seen: set[str] = set()
 

--- a/inference_optimizer/breakdown/reporters/llm_client.py
+++ b/inference_optimizer/breakdown/reporters/llm_client.py
@@ -170,6 +170,10 @@ def build_client_from_env() -> Any | None:
     ``HYPERLOOM_REPORT_MODEL``, ``HYPERLOOM_REPORT_MAX_TOKENS`` and the
     per-backend base-url/api-key vars; returns ``None``
     (deterministic-only) when required vars are missing.
+
+    Returns:
+        A configured backend client instance, or ``None`` when the backend
+        is disabled or required environment variables are missing.
     """
     backend = (os.environ.get("HYPERLOOM_REPORT_LLM_BACKEND") or "none").lower()
     if backend in ("", "none", "off", "disabled"):

--- a/inference_optimizer/breakdown/reporters/llm_prompt.py
+++ b/inference_optimizer/breakdown/reporters/llm_prompt.py
@@ -95,7 +95,15 @@ def build_user_prompt(
     rendered: list[RenderedSection],
     global_facts: GlobalFacts,
 ) -> str:
-    """Build the user-message JSON the LLM sees (string so the exact bytes are log-inspectable)."""
+    """Build the user-message JSON the LLM sees (string so the exact bytes are log-inspectable).
+
+    Args:
+        rendered: Rendered sections to include; skipped sections are withheld.
+        global_facts: Global facts block prepended to the prompt payload.
+
+    Returns:
+        A pretty-printed JSON string representing the user message.
+    """
     payload = {
         "global_facts": global_facts.as_prompt_dict(),
         # Skipped sections are withheld so the model can't "explain" a phantom section.
@@ -109,6 +117,13 @@ def parse_llm_response(raw: str) -> dict[str, Any]:
 
     Tolerates a code fence; on any failure returns empty fields so the
     deterministic-only output path stays usable.
+
+    Args:
+        raw: Raw text returned by the LLM, optionally wrapped in a code fence.
+
+    Returns:
+        A dict with ``executive_summary`` and ``section_narratives`` keys;
+        both empty when parsing fails.
     """
     text = (raw or "").strip()
     if text.startswith("```"):

--- a/inference_optimizer/breakdown/session_package.py
+++ b/inference_optimizer/breakdown/session_package.py
@@ -130,7 +130,11 @@ def _dest_root() -> Path:
 
 
 def _loose_enabled() -> bool:
-    """Whether to also drop loose (unzipped) copies. Defaults to True."""
+    """Whether to also drop loose (unzipped) copies. Defaults to True.
+
+    Returns:
+        ``True`` unless the env override disables loose copies.
+    """
     raw = (os.environ.get(ENV_PACKAGE_LOOSE) or "").strip().lower()
     return raw not in {"0", "false", "no", "off"}
 
@@ -149,6 +153,14 @@ def _copy_loose_tree(
     safe. A stale file from a previous, larger selection is left as-is;
     the per-run ``PACKAGE_MANIFEST`` is the source of truth for what this
     run actually included.
+
+    Args:
+        included: Tuples of ``(source path, relative path, size)`` to copy.
+        manifest: Manifest dict written alongside the copied files.
+        loose_dir: Destination root for the loose tree.
+
+    Returns:
+        The number of files successfully copied.
     """
     loose_dir.mkdir(parents=True, exist_ok=True)
     copied = 0
@@ -174,7 +186,14 @@ def _copy_loose_tree(
 
 def _iter_session_files(session_dir: Path) -> list[Path]:
     """All files under session_dir (one walk), so glob matching is a
-    single pass instead of N globs each re-walking the tree."""
+    single pass instead of N globs each re-walking the tree.
+
+    Args:
+        session_dir: Root directory to walk.
+
+    Returns:
+        Absolute paths of every file found under ``session_dir``.
+    """
     out: list[Path] = []
     for dp, _dn, fn in os.walk(session_dir):
         for f in fn:
@@ -188,6 +207,14 @@ def _select(session_dir: Path) -> tuple[list[Path], list[str]]:
     A glob is reported "unmatched" when it selected zero files — useful
     audit signal in the manifest (e.g. conc_sweep_summary absent because
     the sweep was skipped).
+
+    Args:
+        session_dir: Session directory whose files are matched against the
+            package globs.
+
+    Returns:
+        A tuple of the matched absolute paths and the patterns that matched
+        nothing.
     """
     all_files = _iter_session_files(session_dir)
     rels = {p: p.relative_to(session_dir).as_posix() for p in all_files}
@@ -220,6 +247,13 @@ def _glob_match(rel: str, pattern: str) -> bool:
       by replacing ``**`` with a sentinel that fnmatch's ``*`` covers.
     * otherwise → require the path to have the same number of segments,
       matching each segment with fnmatch so ``*`` stays within a segment.
+
+    Args:
+        rel: POSIX-style relative path to test.
+        pattern: Glob pattern, possibly containing ``**``.
+
+    Returns:
+        ``True`` when ``rel`` matches ``pattern``.
     """
     if "**" in pattern:
         # fnmatch's '*' already spans '/', so '**' == '*' for our purpose.

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -124,7 +124,11 @@ class _RetiredFlag(argparse.Action):
 
 
 def _orchestration_rules_fragment_path() -> Path:
-    """Path to the rules-only ``orchestration.md`` fragment consumed by ``prompt_builder``."""
+    """Path to the rules-only ``orchestration.md`` fragment consumed by ``prompt_builder``.
+
+    Returns:
+        Path: The path to the ``orchestration.md`` system-prompt fragment.
+    """
     return asset_system_prompts_dir() / "orchestration.md"
 
 
@@ -161,7 +165,18 @@ def _build_orchestration_prompt(
     max_minutes: int,
     action_registry: ActionRegistry | None = None,
 ) -> str:
-    """Compose the Orchestration system prompt from typed inputs (``--orch-prompt`` overrides)."""
+    """Compose the Orchestration system prompt from typed inputs (``--orch-prompt`` overrides).
+
+    Args:
+        no_kernel: When True, kernel actions are excluded from the prompt.
+        framework: The target framework name.
+        objective: The run objective to summarise into the prompt.
+        max_minutes: The session time budget in minutes.
+        action_registry: Optional preloaded action registry; loaded if omitted.
+
+    Returns:
+        str: The composed orchestration system prompt.
+    """
     registry = action_registry or ActionRegistry().load()
     enabled = default_enabled_actions(no_kernel=no_kernel)
     kind, value = _objective_summary_for_prompt(objective)
@@ -225,6 +240,12 @@ def _gpu_runner_type(gpu_type: str) -> str:
 
     MI308X and MI325X share the gfx942 / CDNA3 die with MI300X and reuse
     the same Magpie benchmark scripts (sglang_mi300x.sh / vllm_mi300x.sh).
+
+    Args:
+        gpu_type: The resolved real GPU type (e.g. ``mi325x``).
+
+    Returns:
+        str: The Magpie runner label (``mi325x``/``mi308x`` map to ``mi300x``).
     """
     normalized = str(gpu_type or "").strip().lower()
     if normalized in ("mi325x", "mi308x"):
@@ -252,7 +273,12 @@ _CRITIC_AGENT_ROOT_ENV = "CRITIC_AGENT_ROOT"
 
 
 def _resolve_critic_agent_root() -> Path | None:
-    """Return the critic-agent skill root (``$CRITIC_AGENT_ROOT`` else sibling ``critic-agent/``), or ``None``."""
+    """Return the critic-agent skill root (``$CRITIC_AGENT_ROOT`` else sibling ``critic-agent/``), or ``None``.
+
+    Returns:
+        Path | None: The resolved critic-agent root containing
+        ``runtime/cli.py``, or ``None`` when it cannot be located.
+    """
     override = os.environ.get(_CRITIC_AGENT_ROOT_ENV, "").strip()
     if override:
         p = Path(override).expanduser()
@@ -263,7 +289,14 @@ def _resolve_critic_agent_root() -> Path | None:
 
 
 def _validate_critic_agent_runtime(root: Path) -> None:
-    """Fail fast (SystemExit) if ``python -m runtime.cli --help`` doesn't work."""
+    """Fail fast (SystemExit) if ``python -m runtime.cli --help`` doesn't work.
+
+    Args:
+        root: The critic-agent skill root to validate.
+
+    Raises:
+        SystemExit: With code 2 when the runtime cannot start or exits non-zero.
+    """
     cmd = [sys.executable, "-m", "runtime.cli", "--help"]
     try:
         proc = subprocess.run(
@@ -299,7 +332,12 @@ _ROBUSTNESS_AGENT_ROOT_ENV = "ROBUSTNESS_AGENT_ROOT"
 
 
 def _resolve_robustness_agent_root() -> Path | None:
-    """Return robustness-agent skill root (``$ROBUSTNESS_AGENT_ROOT`` else sibling), or ``None``."""
+    """Return robustness-agent skill root (``$ROBUSTNESS_AGENT_ROOT`` else sibling), or ``None``.
+
+    Returns:
+        Path | None: The resolved robustness-agent root containing the runtime
+        ``cli.py``, or ``None`` when it cannot be located.
+    """
     override = os.environ.get(_ROBUSTNESS_AGENT_ROOT_ENV, "").strip()
     if override:
         p = Path(override).expanduser()
@@ -362,6 +400,15 @@ def _apply_atom_auto_tighten(args: argparse.Namespace) -> list[str]:
 
     No auto-tightening is applied; kernel/framework/profile all work on atom. Multi-node TP wiring
     is unimplemented so ``--nodes>=2`` exits 2. Returns the list of auto-disabled flags (always empty).
+
+    Args:
+        args: Parsed CLI arguments (``nodes`` is consulted).
+
+    Returns:
+        list[str]: The auto-disabled flags (always empty).
+
+    Raises:
+        SystemExit: With code 2 when ``--nodes >= 2`` (atom is single-node).
     """
     auto_disabled: list[str] = []
     if int(getattr(args, "nodes", 1) or 1) >= 2:
@@ -393,6 +440,13 @@ def _resolve_gpu_type(
     Probe always wins on disagreement (wrong --gpu-type corrupts baseline+KB rows); user value kept
     only on probe failure. Returns ``(effective_gpu_type, warnings)``; warnings go to stderr to keep
     the ``HYPERLOOM_LAUNCH`` stdout sentinel clean.
+
+    Args:
+        user_specified: The user-provided ``--gpu-type`` hint.
+        probed: The hardware-probed GPU type.
+
+    Returns:
+        tuple[str, list[str]]: The effective GPU type and any warning strings.
     """
     warnings: list[str] = []
     if probed and user_specified and probed != user_specified:
@@ -420,6 +474,19 @@ def _emit_launch_info(
     """Print the machine-readable HYPERLOOM_LAUNCH stdout line; optionally JSON-dump to ``launch_info_file``.
 
     Returns the launch_info dict for callers/tests.
+
+    Args:
+        pid: The launched process id.
+        session_dir: The session directory.
+        session_id: The session id.
+        run_log: Path to the run log.
+        gpu_type: The resolved GPU type.
+        framework: The target framework.
+        model: The model path/id.
+        launch_info_file: Optional path to also JSON-dump the launch info to.
+
+    Returns:
+        dict[str, Any]: The launch info mapping.
     """
     launch_info: dict[str, Any] = {
         "event": "launch",
@@ -453,6 +520,15 @@ def _clean_stale_aiter_locks(
     Only deletes locks with mtime older than ``stale_minutes`` (default 5; above cold-start MoE build
     time, below the hang-suspicion cliff). Build dir resolution: caller arg → $INFERENCE_OPTIMIZER_AITER_JIT_DIR
     → dynamic <aiter>/jit/build → legacy fallbacks. Returns a stats dict; never raises (errors counted).
+
+    Args:
+        aiter_jit_dir: Optional explicit JIT build dir; resolved automatically
+            when ``None``.
+        stale_minutes: Minimum lock age (minutes) before deletion.
+
+    Returns:
+        dict[str, Any]: Stats with ``dir``, ``scanned``, ``deleted``,
+        ``skipped_fresh``, and ``errors`` counts.
     """
     stats: dict[str, Any] = {
         "dir": None,
@@ -530,7 +606,12 @@ def _clean_stale_aiter_locks(
 
 
 def _autodetect_gpu_type() -> str | None:
-    """Return mi300x|mi308x|mi325x|mi355x or None if undetectable (rocm-smi then torch gcnArchName, best-effort)."""
+    """Return mi300x|mi308x|mi325x|mi355x or None if undetectable (rocm-smi then torch gcnArchName, best-effort).
+
+    Returns:
+        str | None: The detected GPU runner label, or ``None`` when it cannot
+        be determined.
+    """
     import subprocess
     try:
         out = subprocess.run(
@@ -565,6 +646,13 @@ def _resolve_amd_gpu_type(explicit: str | None = None) -> str | None:
     callers gate AMD-specific behaviour on real hardware while still honouring
     a launcher/CI-supplied ``gpu_type`` even if ``rocm-smi``/torch probing is
     unavailable at the call site.
+
+    Args:
+        explicit: An explicit GPU type hint, consulted first.
+
+    Returns:
+        str | None: The resolved AMD GPU runner label, or ``None`` when not on
+        a recognised AMD GPU.
     """
     for cand in (explicit, os.environ.get("GPU_TYPE")):
         norm = str(cand or "").strip().lower()
@@ -587,6 +675,17 @@ def _resume_safe_flag(
 
     ``invert=True`` handles the ``--no-*`` pattern (args.no_X True == disable; manifest stores positive form).
     Lets robustness_monitor.sh resume preserve original intent without re-passing the flag.
+
+    Args:
+        args: Parsed CLI arguments.
+        arg_name: The attribute name on ``args`` to read.
+        manifest: The resume manifest, or ``None``.
+        manifest_key: The manifest key to fall back to.
+        default: The default returned when neither arg nor manifest applies.
+        invert: When True, treat the arg as a ``--no-*`` (disable) flag.
+
+    Returns:
+        bool: The resolved boolean value.
     """
     raw_arg = getattr(args, arg_name, None)
     if isinstance(raw_arg, bool) and raw_arg:
@@ -606,7 +705,18 @@ def _resume_safe_numeric(
     *,
     default: float,
 ) -> float:
-    """Float-valued analog of :func:`_resume_safe_flag`: explicit non-default arg → manifest → default."""
+    """Float-valued analog of :func:`_resume_safe_flag`: explicit non-default arg → manifest → default.
+
+    Args:
+        args: Parsed CLI arguments.
+        arg_name: The attribute name on ``args`` to read.
+        manifest: The resume manifest, or ``None``.
+        manifest_key: The manifest key to fall back to.
+        default: The default returned when neither arg nor manifest applies.
+
+    Returns:
+        float: The resolved numeric value.
+    """
     raw_arg = getattr(args, arg_name, None)
     if raw_arg is not None:
         try:
@@ -628,6 +738,14 @@ def _load_model_arch(workspace_root: Path, model_name: str) -> dict:
 
     Soft-degrades to ``{}`` (never blocks launch) on missing/unreadable/invalid file. Stale-file guard:
     require ``data["model_name"]`` basename to match launched ``--model`` basename, else WARN + ``{}``.
+
+    Args:
+        workspace_root: Directory containing ``model_arch.json``.
+        model_name: The launched model name used for the freshness check.
+
+    Returns:
+        dict: The parsed model-arch profile, or ``{}`` when absent, invalid,
+        or stale.
     """
     arch_path = workspace_root / "model_arch.json"
     try:
@@ -666,7 +784,14 @@ def _load_model_arch(workspace_root: Path, model_name: str) -> dict:
 
 
 def _load_model_config_dict(model_path: str) -> dict | None:
-    """Best-effort parse of ``<model_path>/config.json`` into a dict; returns ``None`` on any failure."""
+    """Best-effort parse of ``<model_path>/config.json`` into a dict; returns ``None`` on any failure.
+
+    Args:
+        model_path: Directory containing ``config.json``.
+
+    Returns:
+        dict | None: The parsed config dict, or ``None`` on any failure.
+    """
     if not model_path:
         return None
     cfg_path = Path(model_path) / "config.json"
@@ -691,7 +816,14 @@ def _load_model_config_dict(model_path: str) -> dict | None:
 
 
 def _config_architectures(config: dict) -> list[str]:
-    """Normalise ``config["architectures"]`` to a list of non-empty strings (scalar wrapped; absent -> [])."""
+    """Normalise ``config["architectures"]`` to a list of non-empty strings (scalar wrapped; absent -> []).
+
+    Args:
+        config: A model config dict.
+
+    Returns:
+        list[str]: The non-empty architecture strings.
+    """
     arches_raw = config.get("architectures")
     if isinstance(arches_raw, list):
         return [str(a).strip() for a in arches_raw if str(a or "").strip()]
@@ -704,6 +836,13 @@ def _load_model_config_tags(model_path: str) -> dict:
     """Best-effort loader for KB architecture-identity tags (``architectures`` + ``model_type``) from config.json.
 
     Soft-degrades to ``{}`` (never blocks launch); normalised fields are omitted when empty so callers can .get().
+
+    Args:
+        model_path: Directory containing ``config.json``.
+
+    Returns:
+        dict: KB architecture-identity tags (``architectures``, ``model_type``);
+        empty when the config is absent or has no identifiable fields.
     """
     data = _load_model_config_dict(model_path)
     if data is None:
@@ -824,7 +963,14 @@ _TEXT_COERCIBLE_MODEL_TYPES = frozenset({
 
 def _arch_is_supported_text_generation(arch: str) -> bool:
     """True when an architecture class name denotes a supported text-generation
-    (decoder-only causal LM) model."""
+    (decoder-only causal LM) model.
+
+    Args:
+        arch: An architecture class name from ``config.json``.
+
+    Returns:
+        bool: ``True`` when the name carries a supported text-generation marker.
+    """
     a = (arch or "").strip()
     if not a:
         return False
@@ -839,6 +985,14 @@ def _config_declares_text_decoder(config: dict, architectures: list[str], model_
     described under ``text_config`` / ``language_config``. Treat those nested
     text blocks as capability evidence instead of requiring a per-family
     allowlist entry.
+
+    Args:
+        config: The model config dict.
+        architectures: The normalised top-level architecture names.
+        model_type_l: The lower-cased top-level ``model_type``.
+
+    Returns:
+        bool: ``True`` when a usable text decoder is positively identified.
     """
     if model_type_l in _TEXT_COERCIBLE_MODEL_TYPES:
         return True
@@ -890,6 +1044,14 @@ def _detect_unsupported_model(model_path: str) -> dict | None:
       (e.g. Kimi-K2.6 / Qwen3.6 MoE, or a generic ``ForCausalLM`` arch that
       merely carries a ``vision_config``). Caller proceeds on the text path with
       a degraded-mode warning unless ``--allow-mm-text-fallback`` is off.
+
+    Args:
+        model_path: Directory containing the model's ``config.json``.
+
+    Returns:
+        dict | None: ``None`` for a plain (or unreadable) text-generation
+        model; otherwise a dict with ``architecture``, ``model_type``,
+        ``signal``, and ``verdict``.
     """
     config = _load_model_config_dict(model_path)
     if config is None:
@@ -1004,7 +1166,15 @@ _MAX_MODEL_LEN_HEADROOM = 4096
 
 
 def _load_model_max_position_embeddings(model_path: str) -> int | None:
-    """Best-effort read of max sequence length from config.json (first positive among known keys, incl. nested ``text_config``), or None."""
+    """Best-effort read of max sequence length from config.json (first positive among known keys, incl. nested ``text_config``), or None.
+
+    Args:
+        model_path: Directory containing ``config.json``.
+
+    Returns:
+        int | None: The first positive max-sequence-length value found, or
+        ``None`` when unavailable.
+    """
     if not model_path:
         return None
     cfg_path = Path(model_path) / "config.json"
@@ -1035,6 +1205,12 @@ def _model_has_dual_chunk_attention(model_path: str) -> bool:
     default aiter attention backend and demands ``dual_chunk_flash_attn``.
     Checks the top level and a nested ``text_config``. Soft-degrades to
     False on any missing / unreadable / invalid config.
+
+    Args:
+        model_path: Directory containing ``config.json``.
+
+    Returns:
+        bool: ``True`` when a ``dual_chunk_attention_config`` is present.
     """
     data = _load_model_config_dict(model_path)
     if data is None:
@@ -1059,6 +1235,12 @@ def _model_is_moe(model_path: str) -> bool:
     callers use this to switch to a ROCm-capable MoE runner. Checks the top
     level and a nested ``text_config``. Soft-degrades to False on any missing
     / unreadable / invalid config.
+
+    Args:
+        model_path: Directory containing ``config.json``.
+
+    Returns:
+        bool: ``True`` when the config carries Mixture-of-Experts markers.
     """
     data = _load_model_config_dict(model_path)
     if data is None:
@@ -1085,7 +1267,11 @@ def _model_is_moe(model_path: str) -> bool:
 
 
 def _context_headroom_tokens() -> int:
-    """Resolve the context headroom (tokens); env override, else default."""
+    """Resolve the context headroom (tokens); env override, else default.
+
+    Returns:
+        int: The non-negative context headroom in tokens.
+    """
     raw = os.environ.get(_CONTEXT_HEADROOM_ENV, "").strip()
     if not raw:
         return _CONTEXT_HEADROOM_DEFAULT
@@ -1097,7 +1283,16 @@ def _context_headroom_tokens() -> int:
 
 
 def _resolve_max_model_len(isl: int, osl: int, model_path: str) -> int:
-    """Resolve ``MAX_MODEL_LEN`` = ISL+OSL+headroom, clamped to ``max_position_embeddings`` (never stretch context)."""
+    """Resolve ``MAX_MODEL_LEN`` = ISL+OSL+headroom, clamped to ``max_position_embeddings`` (never stretch context).
+
+    Args:
+        isl: Input sequence length.
+        osl: Output sequence length.
+        model_path: Directory containing ``config.json`` for the clamp.
+
+    Returns:
+        int: The resolved max model length, clamped to the native window.
+    """
     desired = int(isl) + int(osl) + _MAX_MODEL_LEN_HEADROOM
     maxpos = _load_model_max_position_embeddings(model_path)
     if maxpos:
@@ -1110,6 +1305,14 @@ def _preflight_context_window(args: argparse.Namespace, session_dir: Path) -> bo
 
     Persists a stop reason and returns True (caller should exit) when the workload does NOT fit; False
     when it fits or the model's max length is unknown.
+
+    Args:
+        args: Parsed CLI arguments (``isl``, ``osl``, ``model``).
+        session_dir: The session directory for the persisted stop report.
+
+    Returns:
+        bool: ``True`` when the workload does not fit (caller should exit),
+        ``False`` otherwise.
     """
     isl = int(getattr(args, "isl", 0) or 0)
     osl = int(getattr(args, "osl", 0) or 0)
@@ -1206,6 +1409,13 @@ def _detect_amd_unsupported_quant(model_path: str) -> str | None:
     Reads both ``config.json:quantization_config`` (standard HF) and the
     separate ``hf_quant_config.json`` (NVIDIA ModelOpt). Returns None when the
     format is ROCm-runnable or absent.
+
+    Args:
+        model_path: Directory containing the model's config files.
+
+    Returns:
+        str | None: A human-readable reason when the quant format is
+        unsupported on ROCm, otherwise ``None``.
     """
     if not model_path:
         return None
@@ -1266,6 +1476,14 @@ def _detect_incompatible_model_config(
 
     A fully absent ``config.json`` is NOT blocked (kept soft-degrade): the
     upstream submission filter + downstream loader still apply.
+
+    Args:
+        model_path: Directory containing the model's ``config.json``.
+        gpu_type: Resolved GPU type used to gate AMD/ROCm-only checks.
+
+    Returns:
+        str | None: A human-readable incompatibility reason, or ``None`` when
+        no statically-knowable incompatibility is found.
     """
     if not model_path:
         return None
@@ -1357,7 +1575,13 @@ def _preflight_model_config_compat(
     or a RoPE block without any max-position field) so we persist a clear stop
     reason instead of booting a server that dies cryptically in engine init.
 
-    Returns True when incompatible (caller should exit); False otherwise.
+    Args:
+        args: Parsed CLI arguments (``model``, ``gpu_type``).
+        session_dir: Session directory for the persisted stop report.
+
+    Returns:
+        bool: ``True`` when incompatible (caller should exit), ``False``
+        otherwise.
     """
     model = str(getattr(args, "model", "") or "")
     detail = _detect_incompatible_model_config(
@@ -1424,6 +1648,14 @@ def _preflight_unsupported_model_arch(
       to fail-fast.
     * ``vision_only`` (true VLM / unclassifiable) → persists
       ``stop_reason=unsupported_model_arch`` and returns True (caller exits).
+
+    Args:
+        args: Parsed CLI arguments (``model``, ``allow_mm_text_fallback``).
+        session_dir: Session directory for the persisted stop report.
+
+    Returns:
+        bool: ``True`` when the model is unsupported (caller should exit),
+        ``False`` otherwise.
     """
     model = str(getattr(args, "model", "") or "")
     hit = _detect_unsupported_model(model)
@@ -1606,6 +1838,12 @@ def _seed_shared_state(
 
         Ladder: explicit CLI/$FRAMEWORK_VERSION → auto-detect package __version__ → "" (canonical_id
         substitutes unknown_version). Auto-detect runs only when both CLI and env are empty.
+
+        Args:
+            args_in: Parsed CLI arguments (``framework_version``, ``framework``).
+
+        Returns:
+            str: The resolved framework version, or an empty string when unknown.
         """
         explicit = (
             (getattr(args_in, "framework_version", None) or "").strip()
@@ -1739,7 +1977,15 @@ def _seed_shared_state(
 
 
 def _parse_conc_sweep_concs(args: argparse.Namespace) -> list[int]:
-    """Parse ``--conc-sweep-concs '1,2,4,8'`` into a list[int]; non-integers warned+dropped, empty -> 1..128 ladder."""
+    """Parse ``--conc-sweep-concs '1,2,4,8'`` into a list[int]; non-integers warned+dropped, empty -> 1..128 ladder.
+
+    Args:
+        args: Parsed CLI arguments carrying ``conc_sweep_concs``.
+
+    Returns:
+        list[int]: The parsed concurrency ladder, or the default
+        ``[1, 2, 4, 8, 16, 32, 64, 128]`` when empty.
+    """
     raw = str(getattr(args, "conc_sweep_concs", "") or "").strip()
     if not raw:
         return [1, 2, 4, 8, 16, 32, 64, 128]
@@ -1774,7 +2020,12 @@ def _snapshot_system_prompts(
     *,
     prompts: dict[str, str],
 ) -> None:
-    """Persist each agent's effective system prompt to ``agents/<role>/system_prompt.snapshot.md``."""
+    """Persist each agent's effective system prompt to ``agents/<role>/system_prompt.snapshot.md``.
+
+    Args:
+        session_dir: Session root directory for the snapshots.
+        prompts: Mapping of agent role to its effective system prompt.
+    """
     for role, body in prompts.items():
         target = agent_prompt_snapshot(session_dir, role)
         target.parent.mkdir(parents=True, exist_ok=True)
@@ -1862,6 +2113,10 @@ def _reconcile_crash_count(state: SharedState, session_dir: Path) -> None:
     """Reconcile persisted ``crash_count`` (state.json + final.json) up to the live in-memory value.
 
     Only ever raises the persisted value (max), never lowers it; best-effort, never fatal.
+
+    Args:
+        state: The live shared state carrying the in-memory ``crash_count``.
+        session_dir: Session directory holding ``state.json`` and the report.
     """
     live = int(getattr(state, "crash_count", 0) or 0)
 
@@ -1891,7 +2146,12 @@ def _reconcile_crash_count(state: SharedState, session_dir: Path) -> None:
 
 
 def _print_kernel_opt_summary_line(state: SharedState) -> None:
-    """One-line forensic readout of kernel_opt attempts at session end (matches the on-disk report; best-effort)."""
+    """One-line forensic readout of kernel_opt attempts at session end (matches the on-disk report; best-effort).
+
+    Args:
+        state: The shared state used to resolve the session directory and
+            build the kernel-optimization summary.
+    """
     try:
         from .orchestrator.kernel_attempt_summary import (
             build_kernel_optimization_summary,
@@ -1925,7 +2185,15 @@ def _print_kernel_opt_summary_line(state: SharedState) -> None:
 
 
 def _resolve_session_dir_for_summary(state: SharedState) -> Path | None:
-    """Best-effort session_dir lookup ($HYPERLOOM_SESSION_DIR) for the stdout kernel_opt line; ``None`` if unresolved."""
+    """Best-effort session_dir lookup ($HYPERLOOM_SESSION_DIR) for the stdout kernel_opt line; ``None`` if unresolved.
+
+    Args:
+        state: The shared state (reserved for future resolution heuristics).
+
+    Returns:
+        Path | None: The resolved session directory, or ``None`` when it
+        cannot be determined.
+    """
     env_sd = os.environ.get("HYPERLOOM_SESSION_DIR", "").strip()
     if env_sd:
         p = Path(env_sd).expanduser()
@@ -1935,7 +2203,14 @@ def _resolve_session_dir_for_summary(state: SharedState) -> Path | None:
 
 
 def _derive_anthropic_base_url(openai_base_url: str) -> str:
-    """Derive ``ANTHROPIC_BASE_URL`` from ``OPENAI_BASE_URL`` by stripping a trailing ``/v1`` (SDK re-appends it)."""
+    """Derive ``ANTHROPIC_BASE_URL`` from ``OPENAI_BASE_URL`` by stripping a trailing ``/v1`` (SDK re-appends it).
+
+    Args:
+        openai_base_url: The OpenAI-style base URL to transform.
+
+    Returns:
+        str: The derived Anthropic base URL.
+    """
     from urllib.parse import urlparse, urlunparse
 
     parsed = urlparse(openai_base_url)
@@ -1948,7 +2223,12 @@ def _derive_anthropic_base_url(openai_base_url: str) -> str:
 def _reset_claude_config_to_upstream(
     safe_key: str, anthropic_base_url: str
 ) -> None:
-    """Point ``~/.claude/config.json`` ``customApiUrl`` at the upstream gateway (stale 127.0.0.1:4002 would fail)."""
+    """Point ``~/.claude/config.json`` ``customApiUrl`` at the upstream gateway (stale 127.0.0.1:4002 would fail).
+
+    Args:
+        safe_key: SaFE API key to persist as ``primaryApiKey`` when provided.
+        anthropic_base_url: Upstream gateway URL to write as ``customApiUrl``.
+    """
     import json as _json
 
     if not anthropic_base_url:
@@ -2015,7 +2295,14 @@ def _validate_credentials() -> None:
 
 
 def _is_placeholder_tracelens_path(value: str) -> bool:
-    """Treat .env.template's bare ``\\`` and whitespace-only values as unset."""
+    """Treat .env.template's bare ``\\`` and whitespace-only values as unset.
+
+    Args:
+        value: The raw configuration value to inspect.
+
+    Returns:
+        bool: ``True`` when the value is a placeholder/unset, else ``False``.
+    """
     stripped = value.strip()
     return stripped in ("", "\\")
 
@@ -2143,6 +2430,13 @@ def _ensure_python_sdks(python_exe: str, pip_extra: list[str]) -> None:
 
     Avoids first-tick BackendError after baseline burns wall time; same-interpreter install avoids
     cross-interpreter install failures.
+
+    Args:
+        python_exe: Interpreter used to both probe and install the SDKs.
+        pip_extra: Extra arguments forwarded to ``pip install``.
+
+    Raises:
+        subprocess.CalledProcessError: If a required ``pip install`` fails.
     """
     candidates = (
         ("claude_agent_sdk", "claude-agent-sdk>=0.1.65"),
@@ -2314,7 +2608,13 @@ def _emit_preflight_diagnostics(
     anthropic_base_url: str | None,
     args: argparse.Namespace | None = None,
 ) -> None:
-    """One canonical, grep-friendly diagnostics block at the end of preflight."""
+    """One canonical, grep-friendly diagnostics block at the end of preflight.
+
+    Args:
+        magpie_python: Path to the Magpie Python interpreter.
+        anthropic_base_url: Resolved Anthropic gateway URL, or ``None``.
+        args: Parsed CLI arguments used to report KB/PR-monitor status.
+    """
     from .orchestrator.action_executors.baseline import (
         BASELINE_COLD_START_TIMEOUT_SEC,
         BASELINE_DEFAULT_TIMEOUT_SEC,
@@ -2379,7 +2679,15 @@ def _emit_preflight_diagnostics(
 
 
 def _print_cortex_kb_queue_status() -> None:
-    """Emit a one-line summary of the Cortex KB offline NDJSON queue (dead-letter = permanent-reject signal)."""
+    """Emit a one-line summary of the Cortex KB offline NDJSON queue (dead-letter = permanent-reject signal).
+
+    Reads the pending, dead-letter, and flushed NDJSON queues for the resolved
+    session and prints their row counts.
+
+    Note:
+        Side-effecting: writes a one-line status summary to stdout and returns
+        nothing.
+    """
     from .session_paths import (
         cortex_dead_letter_ndjson,
         cortex_flushed_ndjson,
@@ -2431,6 +2739,14 @@ def _probe_llm_catalog(
     """Probe ``<base_url>/models`` with retry (gateway flakes); return set of model ids or None.
 
     TLS verification is on by default; ``INFERENCE_OPTIMIZER_CATALOG_PROBE_INSECURE=1`` skips it (warns).
+
+    Args:
+        base_url: Gateway base URL whose ``/models`` endpoint is probed.
+        api_key: Bearer token sent in the ``Authorization`` header.
+
+    Returns:
+        set[str] | None: The set of model ids on success, or ``None`` when the
+        probe is skipped or exhausts its retries.
     """
     import time
 
@@ -2530,6 +2846,18 @@ def _validate_and_resolve_claude_model(
 
     Probes the gateway catalog (retries); falls back 4-7→4-6 with a WARN, else sys.exit(2). Returns the
     catalog id set on success (reused by the codex smoke-test).
+
+    Args:
+        args: Parsed CLI arguments; ``claude_model`` may be mutated in place.
+        resolved_urls: Optional ``(anthropic_url, openai_url)`` pair used to
+            derive the catalog probe base URL.
+
+    Returns:
+        set[str] | None: The gateway catalog id set on success.
+
+    Raises:
+        SystemExit: If the chosen model is disallowed, the catalog is
+            unreachable, or no acceptable model is present.
     """
     chosen = (args.claude_model or "").strip()
     if chosen not in _CLAUDE_ALLOWED_MODELS:
@@ -2591,7 +2919,13 @@ def _smoke_test_codex_model(
     args: argparse.Namespace,
     catalog_ids: set[str] | None,
 ) -> None:
-    """WARN-only catalog check for ``--codex-model`` (no hard gate); flags typos before Coordinator starts."""
+    """WARN-only catalog check for ``--codex-model`` (no hard gate); flags typos before Coordinator starts.
+
+    Args:
+        args: Parsed CLI arguments (``codex_model``, ``critic_backend``,
+            ``kernel_codex``, ``no_kernel``).
+        catalog_ids: Gateway catalog id set, or ``None`` when unavailable.
+    """
     if catalog_ids is None:
         return
     # Codex is needed by the Kernel agent (kernel-codex on) and the critic-agent review path.
@@ -2627,6 +2961,12 @@ def _inferencex_checkout_ok(path: Path | str) -> bool:
     ``git init`` that then failed to fetch/checkout. Magpie sources
     ``benchmarks/benchmark_lib.sh`` at runtime, so require that file to
     exist — a complete checkout always has it, a stub never does.
+
+    Args:
+        path: Candidate InferenceX checkout directory.
+
+    Returns:
+        bool: ``True`` when the checkout looks complete, else ``False``.
     """
     return (Path(path) / "benchmarks" / "benchmark_lib.sh").is_file()
 
@@ -2642,6 +2982,12 @@ def _clone_inferencex(dest: Path) -> str | None:
     On any failure the partial ``dest`` (e.g. a bare ``git init`` with no
     fetched tree) is removed so a later preflight's detection does not
     mistake the stub for a valid checkout and skip re-cloning.
+
+    Args:
+        dest: Destination directory for the InferenceX checkout.
+
+    Returns:
+        str | None: The checkout path on success, or ``None`` on failure.
     """
     repo = os.environ.get("INFERENCEX_REPO") or _INFERENCEX_REPO_DEFAULT
     ref = os.environ.get("INFERENCEX_REF") or _INFERENCEX_REF_DEFAULT
@@ -2683,6 +3029,13 @@ def _preflight(
     Credentials fallback → auth aliases → SDK install → ANTHROPIC_BASE_URL resolve + ~/.claude reset →
     ROCm hygiene → ray/Magpie/InferenceX install → CLI presence checks → diagnostics. Returns
     ``(anthropic_base_url, openai_base_url)`` or ``None`` when ``OPENAI_BASE_URL`` is missing.
+
+    Args:
+        args: Parsed CLI arguments, or ``None`` when run outside a command.
+
+    Returns:
+        tuple[str, str] | None: ``(anthropic_base_url, openai_base_url)`` on
+        success, or ``None`` when ``OPENAI_BASE_URL`` is missing.
     """
     _load_dotenv_fallback()
     _load_kernel_agent_env_fallback()
@@ -2897,6 +3250,9 @@ def _run_ir3_preflight(args: argparse.Namespace) -> None:
 
     Mutates args: ``cortex_enabled``/``pr_monitor_enabled`` plus
     ``kb_degraded_reason``/``pr_degraded_reason`` (None|"explicit_flag"|"ir3_auto").
+
+    Args:
+        args: Parsed CLI arguments; reachability fields are mutated in place.
     """
     explicit_kb = bool(getattr(args, "degraded_kb", False))
     explicit_pr = bool(getattr(args, "degraded_pr", False))
@@ -2973,7 +3329,17 @@ _VALID_CRITIC_BACKENDS = ("mock", "agent")
 
 
 def _resolve_critic_choice(args: argparse.Namespace) -> str:
-    """Resolve the active critic backend choice (arg → DEFAULT_CRITIC_BACKEND); hard-fails on invalid."""
+    """Resolve the active critic backend choice (arg → DEFAULT_CRITIC_BACKEND); hard-fails on invalid.
+
+    Args:
+        args: Parsed CLI arguments carrying ``critic_backend``.
+
+    Returns:
+        str: The resolved critic backend name.
+
+    Raises:
+        SystemExit: If the resolved backend is not a valid choice.
+    """
     chosen = args.critic_backend
     if chosen is None:
         chosen = DEFAULT_CRITIC_BACKEND
@@ -3001,6 +3367,15 @@ def _resolve_robustness_choice(args: argparse.Namespace) -> str:
     Multi-node policy: on ``nodes>=2`` the agent's LocalProbe targets sandbox-local resources that live in
     separate pods (HIGH false positives). Keep ``agent`` only when a robustness-server is configured; else
     auto-downgrade to ``mock`` (explicit --robustness-agent gets a WARN).
+
+    Args:
+        args: Parsed CLI arguments (``robustness_backend``, ``nodes``).
+
+    Returns:
+        str: The resolved robustness backend name.
+
+    Raises:
+        SystemExit: If the resolved backend is not a valid choice.
     """
     chosen = getattr(args, "robustness_backend", None)
     explicit = chosen is not None
@@ -3037,7 +3412,11 @@ def _resolve_robustness_choice(args: argparse.Namespace) -> str:
 
 
 def _reset_state_file(session_dir: Path) -> None:
-    """Back up ``state.json`` to ``state.json.preReset.<unix_ts>`` and start fresh (Cortex KB untouched)."""
+    """Back up ``state.json`` to ``state.json.preReset.<unix_ts>`` and start fresh (Cortex KB untouched).
+
+    Args:
+        session_dir: Session directory holding the ``state.json`` to reset.
+    """
     state_path = session_dir / "state.json"
     if not state_path.exists():
         return
@@ -3069,6 +3448,11 @@ def _gc_old_profile_traces(
 
     Never blocks startup (errors swallowed). Env knobs: HYPERLOOM_MN_TRACE_RETENTION_DAYS,
     HYPERLOOM_MN_TRACE_GC_DISABLE.
+
+    Args:
+        root: Trace-root directory to scan; defaults to the multi-node root.
+        retention_days: Age threshold in days before a trace dir is removed.
+        keep: Name of a trace dir to always preserve.
     """
     if os.environ.get("HYPERLOOM_MN_TRACE_GC_DISABLE", "").strip() in (
         "1", "true", "yes",
@@ -3251,6 +3635,10 @@ def _replay_kernel_patches_for_multi_node(args: argparse.Namespace) -> None:
     """Replay every applied kernel-agent patch (manifest status=applied + multinode block) onto RayJob pods.
 
     Idempotent ``apply-patch`` fan-out, run only when ``--nodes>=2``. Best-effort: per-patch failures warn.
+
+    Args:
+        args: Parsed CLI arguments carrying ``nodes`` (replay is a no-op for
+            single-node runs).
     """
     nodes = max(1, int(getattr(args, "nodes", 1) or 1))
     if nodes < 2:
@@ -3352,6 +3740,14 @@ async def _run_quantization_prelude(args: argparse.Namespace) -> None:
         The skip is made **detectable** so a launcher / UI never mistakes the
         run for quantized: a ``QUANTIZATION_SKIPPED:`` marker line on stdout
         plus the ``$HYPERLOOM_QUANTIZATION_SKIPPED`` env var (set to the reason).
+
+    Args:
+        args: Parsed CLI arguments (``quantize``, ``quantize_scheme``,
+            ``model``, ``resume``); ``model`` is rewritten on success.
+
+    Raises:
+        SystemExit: With code 3 when an explicitly requested quantization
+            fails or is blocked.
     """
     # Free-text --quantize wins; otherwise resolve the structured
     # --quantize-scheme enum (the UI/backend path) to a prompt.
@@ -3444,7 +3840,16 @@ def _export_workload_envs_for_optimize(
     ep_resolved: int,
     argv: list[str] | None = None,
 ) -> None:
-    """Mirror explicit workload CLI flags (--tp/--conc/--ep) into env so executors' Magpie YAMLs honor them."""
+    """Mirror explicit workload CLI flags (--tp/--conc/--ep) into env so executors' Magpie YAMLs honor them.
+
+    Args:
+        args: Parsed CLI arguments (reads ``conc``).
+        nodes_resolved: Resolved node count (>=2 forces all exports).
+        tp_resolved: Resolved tensor-parallel size exported as ``$TP``.
+        ep_resolved: Resolved expert-parallel size exported as ``$EP``.
+        argv: Argument vector to scan for explicit flags; defaults to
+            ``sys.argv[1:]``.
+    """
     argv = list(sys.argv[1:] if argv is None else argv)
     if nodes_resolved >= 2 or _argv_has_option(argv, "--tp"):
         os.environ["TP"] = str(tp_resolved)
@@ -4336,7 +4741,11 @@ async def _run_optimize(args: argparse.Namespace) -> int:
 
 
 def _default_research_lane_capacity() -> int:
-    """Default ``--research-lane-capacity``: $INFERENCE_OPTIMIZER_RESEARCH_LANE_CAPACITY else the GPU ceiling (2×GPU)."""
+    """Default ``--research-lane-capacity``: $INFERENCE_OPTIMIZER_RESEARCH_LANE_CAPACITY else the GPU ceiling (2×GPU).
+
+    Returns:
+        int: The resolved default research-lane capacity.
+    """
     env = os.environ.get("INFERENCE_OPTIMIZER_RESEARCH_LANE_CAPACITY")
     if env:
         try:

--- a/inference_optimizer/cli_backends.py
+++ b/inference_optimizer/cli_backends.py
@@ -46,6 +46,26 @@ def _build_backends(
     ``critic_agent_root``). ``robustness_choice`` ∈ {``mock``, ``agent``}:
     mock is the heartbeat-only backend; ``agent`` is
     :class:`RobustnessAgentBackend` (requires ``robustness_agent_root``).
+
+    Args:
+        claude_model: Claude model id for orchestration/kernel backends.
+        codex_model: Codex model id for the kernel/critic backends.
+        kernel_codex: When True, use the Codex backend for kernel work.
+        critic_choice: ``mock`` or ``agent``.
+        session_dir: The current session directory.
+        critic_agent_root: Critic-agent runtime root (required for ``agent``).
+        critic_kb_mode: KB mode passed to the critic-agent backend.
+        robustness_choice: ``mock`` or ``agent``.
+        robustness_agent_root: Robustness-agent root (required for ``agent``).
+        robustness_options: Optional ``request.options`` overrides.
+        no_kernel: When True, omit the kernel backend.
+
+    Returns:
+        dict[str, Any]: Per-role backend instances keyed by role name.
+
+    Raises:
+        ValueError: If a choice is not in ``{'mock','agent'}`` or an ``agent``
+            choice is missing its required root.
     """
     if critic_choice not in ("mock", "agent"):
         raise ValueError(
@@ -135,6 +155,14 @@ def _build_proposal_scorer(
     ``session_dir`` is forwarded so the scorer can append its per-model
     token usage to the full-trace ledger (component=proposal_scorer); when
     omitted the scorer simply skips trace writes.
+
+    Args:
+        args: Parsed CLI arguments (scoring opt-out, model list).
+        session_dir: Optional session directory for token-usage tracing.
+
+    Returns:
+        ProposalScorer | None: The configured scorer, or ``None`` when
+        scoring is disabled or the model list resolves empty.
     """
     if getattr(args, "no_proposal_scoring", False):
         return None
@@ -158,6 +186,12 @@ def _robustness_server_configured(args: argparse.Namespace) -> bool:
     ``enable_cluster_pod_metrics`` and the sandbox-local LocalProbe false
     positives are silenced. Configured = ``--robustness-server-url`` or
     ``ROBUSTNESS_SERVER_URL`` is set.
+
+    Args:
+        args: Parsed CLI arguments (``robustness_server_url``).
+
+    Returns:
+        bool: ``True`` if a robustness-server endpoint is configured.
     """
     url = (getattr(args, "robustness_server_url", None) or "").strip()
     if url:
@@ -188,6 +222,12 @@ def _build_robustness_options(args: argparse.Namespace) -> dict[str, Any]:
     forward a workload_uid hint, disable the 127.0.0.1:8888 auto-probe,
     and lift the ``no_levers_found`` floor to 60 min. Single-node
     semantics stay untouched.
+
+    Args:
+        args: Parsed CLI arguments (robustness flags, node count).
+
+    Returns:
+        dict[str, Any]: The non-default ``request.options`` overrides.
     """
     options: dict[str, Any] = {}
     server_url = getattr(args, "robustness_server_url", None)

--- a/inference_optimizer/cli_executors.py
+++ b/inference_optimizer/cli_executors.py
@@ -92,6 +92,15 @@ def _build_specialist_executor(
     SpecialistRunner). Production uses the subprocess dispatcher (claude in a
     per-task worktree); --specialist-dispatch-mode / missing claude falls back
     to the in-process ClaudeBackend.
+
+    Args:
+        args: Parsed CLI arguments (specialist model, turns, dispatch mode).
+        session_dir: The current session directory.
+        knowledge_plane: The live KnowledgePlane used to wire MCP config.
+
+    Returns:
+        Callable[[Any], Awaitable[dict]]: An async executor that runs a
+        specialist and returns a result envelope dict.
     """
     import shutil
 
@@ -186,7 +195,15 @@ def _build_specialist_executor(
     async def _executor(ctx: Any) -> dict:
         """Adapter SubAgentRunner.run_task -> SpecialistRunner.run. Always
         returns a dict (even on failure); runner_status preserves the
-        SpecialistRunResult distinctions for breakdown analytics."""
+        SpecialistRunResult distinctions for breakdown analytics.
+
+        Args:
+            ctx: The action context passed by ``SubAgentRunner.run_task``.
+
+        Returns:
+            dict: A result envelope with runner status, task/domain ids,
+            transcript paths, and any allocated GPU ids.
+        """
         run_result = await runner.run(ctx)
         return {
             "runner_status": run_result.status,
@@ -220,6 +237,13 @@ def _register_executors(
     _REAL_EXECUTORS_FULL set, kernel-owned no-ops (skipped when no_kernel),
     the always-wired Coordinator-internal executors, and the optional
     specialist executor.
+
+    Args:
+        coordinator: The live Coordinator to register executors on.
+        no_kernel: When True, skip wiring the kernel-owned no-op executors.
+        compare_against_gpu: Optional GPU type for the target-analysis executor.
+        session_dir: Optional session directory passed to executors.
+        specialist_executor: Optional specialist executor to register.
     """
     for kind, fn in _REAL_EXECUTORS_FULL.items():
         coordinator.sub.register_executor(kind, fn)

--- a/inference_optimizer/cli_kb.py
+++ b/inference_optimizer/cli_kb.py
@@ -33,6 +33,12 @@ def _resolve_local_kb_root(args: argparse.Namespace) -> Path:
     """Resolve the local recipe-snapshot KB root: ``--local-kb-root`` ->
     ``$HYPERLOOM_LOCAL_KB_ROOT`` -> ``workspace_root()/kb``. Not created here
     (LocalRecipeStore creates it lazily on first write).
+
+    Args:
+        args: Parsed CLI arguments; ``local_kb_root`` is consulted first.
+
+    Returns:
+        Path: The resolved local KB root directory.
     """
     explicit = (
         getattr(args, "local_kb_root", None)
@@ -49,6 +55,12 @@ def _build_recipe_kb_dispatcher(
     """Build the local-write / remote-read RecipeKB dispatcher. Local store
     always wired; remote half enabled only when not --degraded-kb and a URL
     resolves (foreground 2s + 1-retry; no hard-coded default endpoint).
+
+    Args:
+        args: Parsed CLI arguments (``degraded_kb``, ``cortex_kb_url``, etc.).
+
+    Returns:
+        Any: A configured ``RecipeKB`` dispatcher (optionally gbrain-mirroring).
     """
     from .recipe_kb import LocalRecipeStore, RecipeKB, RemoteRecipeClient
 
@@ -141,6 +153,15 @@ def _bootstrap_cortex_kb(
     """Boot the recipe-snapshot KB integration, run the T0 anchor, and return
     the dispatcher. KB unavailability never aborts the launch
     (fail_fast=False); a hard T0 failure warns and continues warm-start-empty.
+
+    Args:
+        args: Parsed CLI arguments.
+        session_dir: The current session directory.
+        manifest: The session manifest dict (model, framework, fingerprint).
+        resume: Whether this launch is resuming an existing session.
+
+    Returns:
+        Any: The configured ``RecipeKB`` dispatcher.
     """
     kb = _build_recipe_kb_dispatcher(args)
 
@@ -211,6 +232,15 @@ def _bootstrap_knowledge_plane(
     """Construct the :class:`KnowledgePlane` facade. Wires the optional PR
     Monitor REST client (KB reads go through RecipeKB, so cortex_kb=None here).
     Both backends fail-soft; --degraded-pr yields a disabled PRMonitorClient.
+
+    Args:
+        args: Parsed CLI arguments (PR Monitor enablement, URLs, window).
+        cortex_client: Optional cortex client; unused (KB reads go via RecipeKB).
+        session_dir: Optional session directory; when set a status marker is
+            written for breakdown warnings.
+
+    Returns:
+        KnowledgePlane: The wired KnowledgePlane facade.
     """
     from .orchestrator.knowledge_plane import (
         KnowledgePlane,

--- a/inference_optimizer/manifest.py
+++ b/inference_optimizer/manifest.py
@@ -81,6 +81,10 @@ def _detect_stack_fingerprint() -> dict[str, str]:
     """Best-effort ``stack_fingerprint`` (KB_design §3.6.5.1). Per component,
     first non-empty wins: env var -> /opt/rocm marker (rocm only) -> package
     __version__/__commit__. Missing components map to ``"unknown"``.
+
+    Returns:
+        Mapping of component name to detected version/commit (``"unknown"``
+        when not found).
     """
     out: dict[str, str] = {}
     for component, env_vars in _STACK_FINGERPRINT_ENVS.items():
@@ -172,7 +176,15 @@ def _git_remote_at(path: Path) -> str:
 
 
 def _path_is_relative_to(path: Path, root: Path) -> bool:
-    """Return True when ``path`` is inside ``root`` after best-effort resolution."""
+    """Return True when ``path`` is inside ``root`` after best-effort resolution.
+
+    Args:
+        path: The path to test.
+        root: The root directory ``path`` may be nested under.
+
+    Returns:
+        True when ``path`` is provably inside ``root``.
+    """
     try:
         path.resolve(strict=False).relative_to(root.resolve(strict=False))
         return True
@@ -192,6 +204,10 @@ def _warn_if_dependency_escapes_user_data(env_var: str, raw: str) -> None:
     """Warn when a dependency checkout points at a pod-local, non-persistent
     path (erased on pod recycle); a shared checkout outside USER_DATA_PATH is
     legitimate and does not warn.
+
+    Args:
+        env_var: Name of the env var holding the dependency checkout path.
+        raw: The raw checkout path value.
     """
     user_data = (os.environ.get(_paths.ENV_USER_DATA_PATH) or "").strip()
     if not user_data:
@@ -251,6 +267,9 @@ def _describe_dep(env_var: str) -> dict[str, str]:
 def _build_dependencies() -> dict[str, dict[str, str]]:
     """Provenance (path/commit/remote) for the Magpie / InferenceX trees this
     session executes against, so debuggers can answer "which upstream?" later.
+
+    Returns:
+        Mapping of dependency name to its ``{path, commit, remote}`` block.
     """
     return {
         "magpie":     _describe_dep("MAGPIE_DIR"),
@@ -261,6 +280,9 @@ def _build_dependencies() -> dict[str, dict[str, str]]:
 def _detect_image() -> str | None:
     """Best-effort container image detection: env vars -> known mount points
     -> cgroup probe. Returns None when nothing matches (never raises).
+
+    Returns:
+        The detected container image string, or ``None`` when none matches.
     """
     for var in ("HYPERLOOM_IMAGE", "CONTAINER_IMAGE", "IMAGE"):
         val = (os.environ.get(var) or "").strip()
@@ -315,7 +337,14 @@ def _objective_summary(args: argparse.Namespace) -> dict[str, Any]:
 
 def build_session_id(model_name: str = "") -> str:
     """Derive an internal session_id label for manifest / SharedState / report
-    metadata (not used for path computation)."""
+    metadata (not used for path computation).
+
+    Args:
+        model_name: Model name used as the id stem; defaults to ``session``.
+
+    Returns:
+        The derived internal session-id label.
+    """
     stem = (model_name or "session").strip().replace("/", "_") or "session"
     return f"{stem}_{_utc_now_compact()}_{uuid.uuid4().hex[:8]}"
 
@@ -433,7 +462,16 @@ def write_manifest(
     session_id: str | None = None,
 ) -> dict[str, Any]:
     """Atomically write ``manifest.json`` under session_dir; returns the
-    manifest dict."""
+    manifest dict.
+
+    Args:
+        session_dir: Session directory to write the manifest into.
+        args: Parsed CLI args overriding env-based defaults, or ``None``.
+        session_id: Explicit session-id label, or ``None`` to derive one.
+
+    Returns:
+        The manifest dict that was written.
+    """
     sd = Path(session_dir)
     manifest = build_manifest(sd, args=args, session_id=session_id)
     target = manifest_path(sd)
@@ -452,7 +490,17 @@ def write_manifest(
 def load_manifest(session_dir: Path) -> dict[str, Any]:
     """Read ``manifest.json`` for an existing session. Raises
     ``FileNotFoundError`` if missing (the signal ``--resume`` uses to refuse a
-    fresh sandbox)."""
+    fresh sandbox).
+
+    Args:
+        session_dir: Session directory to read the manifest from.
+
+    Returns:
+        The parsed manifest dict.
+
+    Raises:
+        FileNotFoundError: If ``manifest.json`` does not exist.
+    """
     p = manifest_path(Path(session_dir))
     if not p.exists():
         raise FileNotFoundError(

--- a/inference_optimizer/multi_node/_internal/ray_dashboard.py
+++ b/inference_optimizer/multi_node/_internal/ray_dashboard.py
@@ -28,7 +28,14 @@ _HTTPX_TIMEOUT = httpx.Timeout(connect=10.0, read=30.0, write=30.0, pool=30.0)
 
 
 def _wrap_for_dash(body: str) -> str:
-    """Base64-wrap a bash body so it survives /bin/sh (dash), which Ray Dashboard uses to run entrypoints."""
+    """Base64-wrap a bash body so it survives /bin/sh (dash), which Ray Dashboard uses to run entrypoints.
+
+    Args:
+        body: The bash script body to wrap.
+
+    Returns:
+        str: A shell command that decodes and runs ``body`` under bash.
+    """
     import base64 as _b64
     encoded = _b64.b64encode(body.encode()).decode()
     return f'echo {encoded} | base64 -d | bash'
@@ -131,7 +138,19 @@ class RayDashboardClient:
             raise RayDashboardError(resp.status_code, resp.text, endpoint=endpoint) from e
 
     def submit_job(self, entrypoint: str, *, runtime_env: dict | None = None) -> str:
-        """POST /api/jobs/; returns the ``submission_id`` immediately (entrypoint runs async, poll :meth:`get_job`)."""
+        """POST /api/jobs/; returns the ``submission_id`` immediately (entrypoint runs async, poll :meth:`get_job`).
+
+        Args:
+            entrypoint: The shell entrypoint to run on the cluster.
+            runtime_env: Optional Ray runtime environment payload.
+
+        Returns:
+            str: The dashboard ``submission_id`` (or ``job_id``) for polling.
+
+        Raises:
+            ValueError: If ``entrypoint`` is empty.
+            RayDashboardError: On a non-200 status or a response missing an id.
+        """
         if not entrypoint:
             raise ValueError("entrypoint is empty")
         # Wrap for dash compatibility (Ray Dashboard uses /bin/sh).
@@ -150,7 +169,18 @@ class RayDashboardClient:
         return sub
 
     def get_job(self, submission_id: str) -> dict:
-        """GET /api/jobs/{submission_id}; response carries ``status`` (PENDING/RUNNING/SUCCEEDED/FAILED/STOPPED) + ``message``."""
+        """GET /api/jobs/{submission_id}; response carries ``status`` (PENDING/RUNNING/SUCCEEDED/FAILED/STOPPED) + ``message``.
+
+        Args:
+            submission_id: The dashboard submission id to query.
+
+        Returns:
+            dict: The decoded job status payload.
+
+        Raises:
+            ValueError: If ``submission_id`` is empty.
+            RayDashboardError: On any non-200 status.
+        """
         if not submission_id:
             raise ValueError("submission_id is empty")
         endpoint = f"GET /api/jobs/{submission_id}"

--- a/inference_optimizer/multi_node/_internal/safe_client.py
+++ b/inference_optimizer/multi_node/_internal/safe_client.py
@@ -140,7 +140,17 @@ class SafeClient:
             raise SafeApiError(resp.status_code, resp.text, endpoint=endpoint) from e
 
     def create_workload(self, body: dict) -> str:
-        """POST /api/v1/workloads; returns the workload_id (non-2xx raises :class:`SafeApiError`)."""
+        """POST /api/v1/workloads; returns the workload_id (non-2xx raises :class:`SafeApiError`).
+
+        Args:
+            body: The CreateWorkloadRequest body to submit.
+
+        Returns:
+            str: The created workload id.
+
+        Raises:
+            SafeApiError: On any non-2xx status or a response missing an id.
+        """
         endpoint = "POST /api/v1/workloads"
         resp = self._client.post(self._url("/api/v1/workloads"), json=body)
         if not (200 <= resp.status_code < 300):
@@ -202,7 +212,14 @@ class SafeClient:
         return data
 
     def stop_workload(self, workload_id: str) -> None:
-        """POST /api/v1/workloads/{workload_id}/stop; idempotent (404/409 treated as success)."""
+        """POST /api/v1/workloads/{workload_id}/stop; idempotent (404/409 treated as success).
+
+        Args:
+            workload_id: The workload id to stop.
+
+        Raises:
+            SafeApiError: On any status other than 200/204/404/409.
+        """
         endpoint = f"POST /api/v1/workloads/{workload_id}/stop"
         resp = self._client.post(self._url(f"/api/v1/workloads/{workload_id}/stop"))
         if resp.status_code in (200, 204, 404, 409):
@@ -212,7 +229,14 @@ class SafeClient:
         raise SafeApiError(resp.status_code, resp.text, endpoint=endpoint)
 
     def delete_workload(self, workload_id: str) -> None:
-        """DELETE /api/v1/workloads/{workload_id}; idempotent (404 treated as success)."""
+        """DELETE /api/v1/workloads/{workload_id}; idempotent (404 treated as success).
+
+        Args:
+            workload_id: The workload id to delete.
+
+        Raises:
+            SafeApiError: On any status other than 200/204/404.
+        """
         endpoint = f"DELETE /api/v1/workloads/{workload_id}"
         resp = self._client.delete(self._url(f"/api/v1/workloads/{workload_id}"))
         if resp.status_code in (200, 204, 404):
@@ -223,7 +247,14 @@ class SafeClient:
 
 
 def from_env() -> SafeClient:
-    """Construct a SafeClient from SAFE_API_URL + SAFE_API_KEY env vars; clean RuntimeError when missing."""
+    """Construct a SafeClient from SAFE_API_URL + SAFE_API_KEY env vars; clean RuntimeError when missing.
+
+    Returns:
+        SafeClient: A client configured from the environment.
+
+    Raises:
+        RuntimeError: If ``SAFE_API_URL`` or ``SAFE_API_KEY`` is missing.
+    """
     base = (os.environ.get("SAFE_API_URL") or "").strip()
     key = (os.environ.get("SAFE_API_KEY") or "").strip()
     missing = [name for name, val in (("SAFE_API_URL", base), ("SAFE_API_KEY", key)) if not val]

--- a/inference_optimizer/multi_node/_internal/workload_spec.py
+++ b/inference_optimizer/multi_node/_internal/workload_spec.py
@@ -107,7 +107,31 @@ def build_rayjob_workload_body(
     extra_env: dict[str, str] | None = None,
     extra_labels: dict[str, str] | None = None,
 ) -> dict[str, Any]:
-    """Build a SaFE CreateWorkloadRequest body for a multi-node RayJob (resource quantities as K8s-notation strings; json.dumps-safe)."""
+    """Build a SaFE CreateWorkloadRequest body for a multi-node RayJob (resource quantities as K8s-notation strings; json.dumps-safe).
+
+    Args:
+        workspace: SaFE workspace id the workload belongs to.
+        display_name: Human-readable name for the workload.
+        image: Container image used for both head and worker roles.
+        nodes: Total node count; head is 1 and workers are ``nodes - 1``.
+        gpus_per_node: GPUs requested per node.
+        cpus_per_node: CPUs requested per node.
+        mem_gi_per_node: Memory in GiB requested per node.
+        ephemeral_gi_per_node: Ephemeral storage in GiB requested per node.
+        description: Optional workload description.
+        owner_id: Optional owner id to attach to the workload.
+        session_id: Optional session id injected as ``primus-claw/session-id``
+            for Brain correlation.
+        extra_env: Optional user environment variables (reserved keys stripped).
+        extra_labels: Optional user labels (Brain-managed prefixes stripped).
+
+    Returns:
+        dict[str, Any]: A json.dumps-safe CreateWorkloadRequest body.
+
+    Raises:
+        ValueError: If ``nodes`` or ``gpus_per_node`` is below 1, or if
+            ``workspace``, ``display_name``, or ``image`` is empty.
+    """
     if nodes < 1:
         raise ValueError(f"nodes must be >= 1, got {nodes}")
     if gpus_per_node < 1:

--- a/inference_optimizer/multi_node/cli.py
+++ b/inference_optimizer/multi_node/cli.py
@@ -42,7 +42,11 @@ _DEFAULT_JIT_POLL_TIMEOUT_S = 1800
 
 
 def _resolve_poll_timeout_s() -> int:
-    """Poll budget (seconds): ``HYPERLOOM_MN_POLL_TIMEOUT_S`` env else ``_DEFAULT_POLL_TIMEOUT_S``."""
+    """Poll budget (seconds): ``HYPERLOOM_MN_POLL_TIMEOUT_S`` env else ``_DEFAULT_POLL_TIMEOUT_S``.
+
+    Returns:
+        int: The poll budget in seconds (at least 1).
+    """
     raw = (os.environ.get("HYPERLOOM_MN_POLL_TIMEOUT_S") or "").strip()
     if raw:
         try:
@@ -87,7 +91,14 @@ _TERMINAL_OK_STATUSES = {"SUCCEEDED"}
 
 
 def _normalize_extra_args(s: str | None) -> str:
-    """Normalize ``--extra-args`` whitespace for equality (order-preserving; argv order matters)."""
+    """Normalize ``--extra-args`` whitespace for equality (order-preserving; argv order matters).
+
+    Args:
+        s: The raw extra-args string, or ``None``.
+
+    Returns:
+        str: The whitespace-collapsed string.
+    """
     return " ".join((s or "").split())
 
 # Exit codes — part of the CLI's contract with the agent; keep stable.
@@ -154,7 +165,13 @@ def _checkpoint_create_rayjob_state(
     workspace: str,
     args: argparse.Namespace,
 ) -> None:
-    """Persist ``rayjob_id`` as soon as SaFE returns it, so a concurrent ``create-rayjob`` doesn't leak a second RayJob."""
+    """Persist ``rayjob_id`` as soon as SaFE returns it, so a concurrent ``create-rayjob`` doesn't leak a second RayJob.
+
+    Args:
+        wid: The workload id returned by SaFE.
+        workspace: The SaFE workspace the workload belongs to.
+        args: Parsed ``create-rayjob`` arguments (node/GPU counts, image).
+    """
     prev = _load_state()
     old = (prev.get("rayjob_id") or "").strip()
     state: dict[str, Any] = dict(prev)
@@ -196,6 +213,16 @@ def _write_rayjob_meta(
 
     Skipped when ``session_id`` is empty (it's the filename). Best-effort:
     filesystem errors are logged at WARN and swallowed.
+
+    Args:
+        wid: The RayJob workload id.
+        workspace: The SaFE workspace.
+        session_id: The sandbox session id (also the meta filename); empty
+            skips the write.
+        owner_id: Optional owner id.
+        display_name: Human-readable workload name.
+        nodes: Total node count.
+        gpus_per_node: GPUs requested per node.
     """
     if not session_id:
         return
@@ -272,7 +299,14 @@ def _b64(s: str) -> str:
 
 
 def _wrap_for_dash(body: str) -> str:
-    """Base64-wrap a bash entrypoint so it survives Ray Dashboard exec under /bin/sh (dash rejects ``set -o pipefail``)."""
+    """Base64-wrap a bash entrypoint so it survives Ray Dashboard exec under /bin/sh (dash rejects ``set -o pipefail``).
+
+    Args:
+        body: The bash entrypoint body to wrap.
+
+    Returns:
+        str: A shell command that decodes and runs ``body`` under bash.
+    """
     enc = _b64(body)
     return f"echo {enc} | base64 -d | bash"
 
@@ -303,7 +337,12 @@ def _parse_kv_list(values: list[str] | None) -> dict[str, str]:
 
 
 def _credential_fanout() -> dict[str, str]:
-    """Return the *_API_KEY / *_BASE_URL env to inject into the RayJob (keys fall back to SAFE_API_KEY per ADDENDUM-13)."""
+    """Return the *_API_KEY / *_BASE_URL env to inject into the RayJob (keys fall back to SAFE_API_KEY per ADDENDUM-13).
+
+    Returns:
+        dict[str, str]: The credential env vars present in the sandbox,
+        keyed by name.
+    """
     safe_key = os.environ.get("SAFE_API_KEY", "").strip()
     out: dict[str, str] = {}
     for name in (
@@ -362,6 +401,29 @@ def _short_poll(
     post-create 404 lag). Terminal failure raises
     :class:`WorkloadTerminalFailure` (exit 2); timeout raises
     :class:`TransientFailure` (exit 1, safe to rerun).
+
+    Args:
+        label: Human-readable label used in log lines and errors.
+        fetch: Callable returning ``(state_obj, summary_str)`` per poll.
+        is_ok: Predicate that returns True when the state is terminal-OK.
+        is_fail: Predicate that returns True when the state is terminal-fail.
+        interval_s: Seconds to sleep between polls.
+        timeout_s: Maximum seconds to poll before raising.
+        failure_diag: Optional callable mapping a failed state to a
+            ``(diag, snapshot)`` pair.
+        quiet_fetch_error_grace_s: Seconds during which a quiet fetch error
+            logs at INFO rather than WARN.
+        is_quiet_fetch_error: Optional predicate classifying an exception as
+            an expected quiet fetch error.
+
+    Returns:
+        Any: The first state object that satisfies ``is_ok``.
+
+    Raises:
+        WorkloadTerminalFailure: When ``is_fail`` matches and ``failure_diag``
+            is provided.
+        RuntimeError: When ``is_fail`` matches without a ``failure_diag``.
+        TransientFailure: When the timeout elapses before a terminal state.
     """
     started = time.monotonic()
     attempt = 0
@@ -415,7 +477,15 @@ def _short_poll(
 
 
 def _summarize_workload_failure(workload: dict[str, Any]) -> tuple[str, dict[str, Any]]:
-    """Build a one-line diagnostic + JSON-safe snapshot (phase/message/per-pod status/dispatch) from a SaFE GetWorkloadResponse."""
+    """Build a one-line diagnostic + JSON-safe snapshot (phase/message/per-pod status/dispatch) from a SaFE GetWorkloadResponse.
+
+    Args:
+        workload: A SaFE GetWorkloadResponse dict.
+
+    Returns:
+        tuple[str, dict[str, Any]]: The one-line diagnostic and a JSON-safe
+        failure snapshot.
+    """
     phase = str(workload.get("phase") or "?")
     msg = str(workload.get("message") or "").strip()
     queue = workload.get("queuePosition")
@@ -472,6 +542,12 @@ def _find_head_pod_ip(workload: dict) -> str:
 
     Priority: a ``podId`` containing ``-head-``, then ``resourceId == 0``,
     then the first pod with a ``podIP`` (the submitter pod isn't the head).
+
+    Args:
+        workload: A SaFE GetWorkloadResponse dict.
+
+    Returns:
+        str: The head pod IP, or an empty string when none is found.
     """
     pods = workload.get("pods") or []
     if not pods:
@@ -678,6 +754,13 @@ def cmd_bootstrap(args: argparse.Namespace) -> int:
 
     Streams the sandbox-side ``scripts/bootstrap.sh`` into the head pod via a
     heredoc entrypoint (``--script PATH`` overrides with a pod-visible script).
+
+    Args:
+        args: Parsed ``bootstrap`` arguments (script override, force,
+            print_logs, polling).
+
+    Returns:
+        int: ``0`` on success.
     """
     state = _require_state("rayjob_id", "head_pod_ip")
     head_ip = state["head_pod_ip"]
@@ -792,7 +875,17 @@ _SCRIPTS_DIR = Path(__file__).parent / "scripts"
 
 
 def _read_pod_script(name: str) -> str:
-    """Read a pod-side script from ``multi_node/scripts/`` (embedded into the dashboard entrypoint at submit time)."""
+    """Read a pod-side script from ``multi_node/scripts/`` (embedded into the dashboard entrypoint at submit time).
+
+    Args:
+        name: The script filename under ``multi_node/scripts/``.
+
+    Returns:
+        str: The script's text contents.
+
+    Raises:
+        RuntimeError: If the script file is missing.
+    """
     p = _SCRIPTS_DIR / name
     if not p.is_file():
         raise RuntimeError(
@@ -807,7 +900,20 @@ def _build_restart_entrypoint(
     pid_file: str,
     log_file: str,
 ) -> str:
-    """Compose the single-node restart entrypoint (heredoc kill_server.sh + launch_server.sh; IR-5 PID-file kill)."""
+    """Compose the single-node restart entrypoint (heredoc kill_server.sh + launch_server.sh; IR-5 PID-file kill).
+
+    Args:
+        args: Parsed ``restart-server`` arguments (framework, model, tp,
+            extra_args, health flag).
+        pid_file: Head-pod PID file path.
+        log_file: Head-pod server log path.
+
+    Returns:
+        str: The composed Ray Dashboard entrypoint shell command.
+
+    Raises:
+        RuntimeError: If ``args.framework`` is not sglang or vllm.
+    """
     framework = args.framework.lower()
     if framework not in ("sglang", "vllm"):
         raise RuntimeError(f"unsupported framework: {args.framework!r} (use sglang or vllm)")
@@ -912,7 +1018,15 @@ def _exec_kill_submission(
 
 
 def _build_multinode_kill_entrypoint(pid_dir: str, grace_sec: int = 5) -> str:
-    """Compose the head-pod entrypoint that kills every rank's server via heredoc-embedded kill_multinode.py (fans out via ray actors)."""
+    """Compose the head-pod entrypoint that kills every rank's server via heredoc-embedded kill_multinode.py (fans out via ray actors).
+
+    Args:
+        pid_dir: Directory of per-rank PID files to sweep.
+        grace_sec: Seconds between SIGTERM and SIGKILL.
+
+    Returns:
+        str: The composed Ray Dashboard entrypoint shell command.
+    """
     py = _read_pod_script("kill_multinode.py")
     return (
         f"{_MN_ENTRYPOINT_PREAMBLE}"
@@ -924,7 +1038,14 @@ def _build_multinode_kill_entrypoint(pid_dir: str, grace_sec: int = 5) -> str:
 
 
 def _extract_launcher_summary(launch_logs: str) -> dict:
-    """Parse the JSON summary launch_multinode.py writes to stdout (the last balanced ``{...}`` in the interleaved logs); ``{}`` on failure."""
+    """Parse the JSON summary launch_multinode.py writes to stdout (the last balanced ``{...}`` in the interleaved logs); ``{}`` on failure.
+
+    Args:
+        launch_logs: The interleaved launcher logs.
+
+    Returns:
+        dict: The parsed launcher summary, or ``{}`` if none could be found.
+    """
     if not launch_logs:
         return {}
     text = launch_logs.rstrip()
@@ -961,6 +1082,16 @@ def _build_multinode_launch_entrypoint(
 
     Killed ranks MUST be cleared before this runs (sequenced by
     cmd_restart_server) or rank 0's old process still holds :8888.
+
+    Args:
+        args: Parsed ``restart-server`` arguments (framework, model, tp, ep,
+            PD knobs, health flag, extra_args).
+        nnodes: Total node count for the launch.
+        pid_dir: Directory the per-rank PID files are written to.
+        log_dir: Directory the per-rank logs are written to.
+
+    Returns:
+        str: The composed Ray Dashboard entrypoint shell command.
     """
     py = _read_pod_script("launch_multinode.py")
     wait_flag = "--no-wait-health" if args.no_wait_health else ""
@@ -1036,7 +1167,18 @@ def _build_multinode_router_entrypoint(
     pid_dir: str,
     log_dir: str,
 ) -> str:
-    """Compose the head-pod entrypoint that detaches the PD router (rank 0 only, binds 8888) via heredoc-embedded launch_router.py."""
+    """Compose the head-pod entrypoint that detaches the PD router (rank 0 only, binds 8888) via heredoc-embedded launch_router.py.
+
+    Args:
+        args: Parsed ``restart-server`` arguments (framework, router override).
+        prefill_url: Internal prefill group URL.
+        decode_url: Internal decode group URL.
+        pid_dir: Directory the router PID file is written to.
+        log_dir: Directory the router log is written to.
+
+    Returns:
+        str: The composed Ray Dashboard entrypoint shell command.
+    """
     py = _read_pod_script("launch_router.py")
     public_port = 8888
     pid_file = f"{pid_dir.rstrip('/')}/router.pid"
@@ -1065,7 +1207,18 @@ def _build_multinode_apply_patch_entrypoint(
     kernel_id: str,
     timeout_sec: int,
 ) -> str:
-    """Compose the head-pod entrypoint that fans out a kernel patch to every pod via heredoc-embedded kernel_patch_multinode.py."""
+    """Compose the head-pod entrypoint that fans out a kernel patch to every pod via heredoc-embedded kernel_patch_multinode.py.
+
+    Args:
+        target_path: Absolute file path on each pod to overwrite.
+        patch_b64: Base64-encoded new file contents.
+        backup_dir: Directory on each pod where the original is saved.
+        kernel_id: Optional id used to construct the backup filename.
+        timeout_sec: Per-actor timeout in seconds.
+
+    Returns:
+        str: The composed Ray Dashboard entrypoint shell command.
+    """
     py = _read_pod_script("kernel_patch_multinode.py")
     return (
         f"{_MN_ENTRYPOINT_PREAMBLE}"
@@ -1086,7 +1239,16 @@ def _build_multinode_revert_patch_entrypoint(
     backup_map_json: str,
     timeout_sec: int,
 ) -> str:
-    """Compose the head-pod entrypoint that fans out a revert via heredoc-embedded kernel_patch_multinode.py (``backup_map_json`` from the matching apply)."""
+    """Compose the head-pod entrypoint that fans out a revert via heredoc-embedded kernel_patch_multinode.py (``backup_map_json`` from the matching apply).
+
+    Args:
+        target_path: Absolute file path on each pod to restore.
+        backup_map_json: JSON ``{hostname: backup_path}`` from the matching apply.
+        timeout_sec: Per-actor timeout in seconds.
+
+    Returns:
+        str: The composed Ray Dashboard entrypoint shell command.
+    """
     py = _read_pod_script("kernel_patch_multinode.py")
     return (
         f"{_MN_ENTRYPOINT_PREAMBLE}"
@@ -1108,6 +1270,13 @@ def _build_multinode_apply_tracelens_patch_entrypoint(
 
     Forwards only ``$TRACELENS_ROOT`` (patches are read on the pods'
     wekafs mount); the in-pod script is idempotent.
+
+    Args:
+        tracelens_root: Path to the TraceLens checkout visible from every pod.
+        sglang_version_pin: Optional advisory version pin; omitted when empty.
+
+    Returns:
+        str: The composed Ray Dashboard entrypoint shell command.
     """
     py = _read_pod_script("apply_tracelens_patch_multinode.py")
     pin_arg = ""
@@ -1131,7 +1300,18 @@ def _build_multinode_kernel_bench_entrypoint(
     result_glob: str,
     timeout_sec: int,
 ) -> str:
-    """Compose the head-pod entrypoint running a kernel micro-benchmark on a single GPU node via heredoc-embedded kernel_bench_multinode.py."""
+    """Compose the head-pod entrypoint running a kernel micro-benchmark on a single GPU node via heredoc-embedded kernel_bench_multinode.py.
+
+    Args:
+        workspace: Absolute dir on the pod used as CWD for the bench.
+        bench_command: Shell command run via ``bash -lc``.
+        files_b64_json: JSON ``{rel_path: base64_content}`` of files to stage.
+        result_glob: Glob (relative to workspace) of artifacts to read back.
+        timeout_sec: Hard timeout for the bench command.
+
+    Returns:
+        str: The composed Ray Dashboard entrypoint shell command.
+    """
     py = _read_pod_script("kernel_bench_multinode.py")
     return (
         f"{_MN_ENTRYPOINT_PREAMBLE}"
@@ -1148,7 +1328,15 @@ def _build_multinode_kernel_bench_entrypoint(
 
 
 def _extract_pod_json(logs: str) -> dict | None:
-    """Parse the last top-level JSON document from an interleaved Ray Dashboard job_logs blob (the in-pod scripts emit one)."""
+    """Parse the last top-level JSON document from an interleaved Ray Dashboard job_logs blob (the in-pod scripts emit one).
+
+    Args:
+        logs: The interleaved dashboard job logs.
+
+    Returns:
+        dict | None: The parsed JSON document, or ``None`` if none is found
+        or it does not parse.
+    """
     if not logs:
         return None
     text = logs.rstrip()
@@ -1192,7 +1380,19 @@ def _submit_and_collect_pod_json(
     poll_interval: int,
     poll_timeout: int,
 ) -> tuple[int, dict | None, str]:
-    """Submit ``entrypoint``, poll to terminal, parse the per-pod JSON, and return ``(returncode, parsed_or_None, logs)``."""
+    """Submit ``entrypoint``, poll to terminal, parse the per-pod JSON, and return ``(returncode, parsed_or_None, logs)``.
+
+    Args:
+        head_ip: IP of the Ray head pod's dashboard.
+        entrypoint: The entrypoint shell command to submit.
+        label: Human-readable label used in log lines and polling.
+        poll_interval: Seconds between polls.
+        poll_timeout: Maximum seconds to poll.
+
+    Returns:
+        tuple[int, dict | None, str]: The exit code, parsed per-pod JSON (or
+        ``None``), and the raw dashboard logs.
+    """
     with ray_dashboard.RayDashboardClient(head_ip) as ray:
         sub_id = ray.submit_job(_wrap_for_dash(entrypoint))
         info(f"{label} submission_id={sub_id}")
@@ -1230,7 +1430,16 @@ def _submit_and_collect_pod_json(
 
 # Subcommand: apply-patch / revert-patch / kernel-bench (multi-node only)
 def cmd_apply_patch(args: argparse.Namespace) -> int:
-    """Fan out a kernel patch to every pod via kernel_patch_multinode.py apply; multi-node only. Re-prints its JSON verbatim."""
+    """Fan out a kernel patch to every pod via kernel_patch_multinode.py apply; multi-node only. Re-prints its JSON verbatim.
+
+    Args:
+        args: Parsed ``apply-patch`` arguments (patch file, target, backup
+            dir, kernel id, polling).
+
+    Returns:
+        int: A process exit code (``EXIT_OK``/``EXIT_TRANSIENT``/
+        ``EXIT_CONFIG_ERROR``).
+    """
     state = _load_state()
     head_ip = (state.get("head_pod_ip") or "").strip()
     if not head_ip:
@@ -1271,7 +1480,15 @@ def cmd_apply_patch(args: argparse.Namespace) -> int:
 
 
 def cmd_revert_patch(args: argparse.Namespace) -> int:
-    """Fan out a kernel patch revert; ``--backup-map-json`` is the per-host map from the matching apply-patch (pass through unchanged)."""
+    """Fan out a kernel patch revert; ``--backup-map-json`` is the per-host map from the matching apply-patch (pass through unchanged).
+
+    Args:
+        args: Parsed ``revert-patch`` arguments (target, backup map, polling).
+
+    Returns:
+        int: A process exit code (``EXIT_OK``/``EXIT_TRANSIENT``/
+        ``EXIT_CONFIG_ERROR``).
+    """
     state = _load_state()
     head_ip = (state.get("head_pod_ip") or "").strip()
     if not head_ip:
@@ -1314,6 +1531,14 @@ def cmd_apply_tracelens_patch(args: argparse.Namespace) -> int:
     Needed because the sandbox can't ``import sglang`` to run the local
     patcher. Idempotent (already-patched pods return ``status=skipped``).
     Re-prints the script's JSON (``status`` + ``per_pod``) verbatim.
+
+    Args:
+        args: Parsed ``apply-tracelens-patch`` arguments (tracelens root,
+            version pin, polling).
+
+    Returns:
+        int: ``EXIT_OK`` when applied/skipped, otherwise ``EXIT_TRANSIENT`` /
+        ``EXIT_CONFIG_ERROR``.
     """
     state = _load_state()
     head_ip = (state.get("head_pod_ip") or "").strip()
@@ -1362,7 +1587,16 @@ def cmd_apply_tracelens_patch(args: argparse.Namespace) -> int:
 
 
 def cmd_kernel_bench(args: argparse.Namespace) -> int:
-    """Run a kernel micro-benchmark on a GPU-bearing pod (stages ``--workspace`` files, runs ``--bench-command``, reads back ``--result-glob``)."""
+    """Run a kernel micro-benchmark on a GPU-bearing pod (stages ``--workspace`` files, runs ``--bench-command``, reads back ``--result-glob``).
+
+    Args:
+        args: Parsed ``kernel-bench`` arguments (workspace, command, staged
+            files, result glob, polling).
+
+    Returns:
+        int: A process exit code (``EXIT_OK``/``EXIT_TRANSIENT``/
+        ``EXIT_CONFIG_ERROR``).
+    """
     state = _load_state()
     head_ip = (state.get("head_pod_ip") or "").strip()
     if not head_ip:
@@ -1405,6 +1639,14 @@ def cmd_restart_server(args: argparse.Namespace) -> int:
     Picks a path from state.json's ``nodes``: single-pod runs
     kill/launch_server.sh on the head pod; multi-pod fans
     kill/launch_multinode.py out across every node via ray actors.
+
+    Args:
+        args: Parsed ``restart-server`` arguments (framework, model, tp, ep,
+            PD knobs, pid/log files, polling).
+
+    Returns:
+        int: ``0`` on success; ``1`` on a terminal launch/router failure;
+        ``2`` for unsupported single-node PD.
     """
     state = _require_state("head_pod_ip")
     head_ip = state["head_pod_ip"]
@@ -2051,7 +2293,14 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
-    """CLI entrypoint with stable exit codes: 0 ok, 1 transient (retryable), 2 terminal workload failure (do not retry), 3 config error, 130 SIGINT."""
+    """CLI entrypoint with stable exit codes: 0 ok, 1 transient (retryable), 2 terminal workload failure (do not retry), 3 config error, 130 SIGINT.
+
+    Args:
+        argv: Optional argument vector; defaults to ``sys.argv`` when ``None``.
+
+    Returns:
+        int: The process exit code per the codes described above.
+    """
     parser = build_parser()
     args = parser.parse_args(argv)
     try:

--- a/inference_optimizer/multi_node/scripts/apply_tracelens_patch_multinode.py
+++ b/inference_optimizer/multi_node/scripts/apply_tracelens_patch_multinode.py
@@ -56,14 +56,26 @@ _GIT_TIMEOUT_SEC = 30
 
 
 def _log(msg: str) -> None:
-    """Stderr-only timestamped log line (stdout is reserved for the final JSON)."""
+    """Stderr-only timestamped log line (stdout is reserved for the final JSON).
+
+    Args:
+        msg: The message text to emit.
+    """
     ts = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime())
     sys.stderr.write(f"[tracelens_patch_multinode {ts}] {msg}\n")
     sys.stderr.flush()
 
 
 def _versioned_patches_subdir_name(version: str) -> str | None:
-    """``0.5.11`` -> ``sglang_0_5_11`` (tolerates ``-rc1`` / ``+local`` suffixes)."""
+    """``0.5.11`` -> ``sglang_0_5_11`` (tolerates ``-rc1`` / ``+local`` suffixes).
+
+    Args:
+        version: The sglang version string to convert.
+
+    Returns:
+        str | None: The versioned subdir name, or ``None`` if ``version`` is
+        empty or not a dotted numeric form.
+    """
     text = (version or "").strip()
     if not text:
         return None
@@ -75,7 +87,16 @@ def _versioned_patches_subdir_name(version: str) -> str | None:
 
 
 def _resolve_sglang_install(sglang_module_path: Path) -> tuple[Path, int] | None:
-    """Decide ``(apply_root, -p<N> strip)`` from any sglang anchor (wheel/editable/namespace-dir layouts); ``None`` if unrecognised."""
+    """Decide ``(apply_root, -p<N> strip)`` from any sglang anchor (wheel/editable/namespace-dir layouts); ``None`` if unrecognised.
+
+    Args:
+        sglang_module_path: A path anchored in the sglang install (module
+            file, submodule file, or namespace dir).
+
+    Returns:
+        tuple[Path, int] | None: The ``(apply_root, strip_level)`` pair, or
+        ``None`` if the layout is not recognised.
+    """
     resolved = sglang_module_path.resolve()
     # Pass 1: walk up to the ``sglang/`` package dir (the one with a ``srt/`` subdir).
     pkg_dir: Path | None = None
@@ -123,7 +144,15 @@ def _all_markers_present(path: Path, markers: tuple[str, ...]) -> bool:
 
 
 def _run_git(args: tuple[str, ...], cwd: Path) -> tuple[int, str, str]:
-    """Run ``git <args>``; return ``(rc, stdout, stderr)`` (never raises on non-zero exit)."""
+    """Run ``git <args>``; return ``(rc, stdout, stderr)`` (never raises on non-zero exit).
+
+    Args:
+        args: The git subcommand and arguments (without the leading ``git``).
+        cwd: Working directory to run git in.
+
+    Returns:
+        tuple[int, str, str]: The ``(returncode, stdout, stderr)`` triple.
+    """
     proc = subprocess.run(  # noqa: S603
         ["git", *args],
         cwd=str(cwd),
@@ -141,7 +170,19 @@ def _apply_on_pod(
     tracelens_internal_root: str,
     sglang_version_pin: str | None,
 ) -> dict[str, Any]:
-    """Apply (or verify) the TraceLens SGLang patch set on this pod; never raises (failures become ``status=failed``)."""
+    """Apply (or verify) the TraceLens SGLang patch set on this pod; never raises (failures become ``status=failed``).
+
+    Args:
+        tracelens_root: Path to the public TraceLens checkout on the pod.
+        tracelens_internal_root: Path to the TraceLens-internal checkout
+            (reserved; not consumed by current patch logic).
+        sglang_version_pin: Optional advisory version pin, logged on mismatch.
+
+    Returns:
+        dict[str, Any]: The per-pod summary with ``status`` (``applied``,
+        ``skipped``, or ``failed``), resolved version, applied patches, and
+        elapsed time.
+    """
     host = socket.gethostname()
     started = time.time()
     result: dict[str, Any] = {

--- a/inference_optimizer/multi_node/scripts/kernel_bench_multinode.py
+++ b/inference_optimizer/multi_node/scripts/kernel_bench_multinode.py
@@ -63,7 +63,18 @@ def _tail_bytes(s: str | None, limit: int) -> str:
 
 
 def _stage_files(workspace: Path, files_b64: dict[str, str]) -> list[str]:
-    """Decode each ``{relative_path: base64_content}`` into the workspace (rejecting ``/`` or ``..`` paths)."""
+    """Decode each ``{relative_path: base64_content}`` into the workspace (rejecting ``/`` or ``..`` paths).
+
+    Args:
+        workspace: Directory the files are decoded into.
+        files_b64: Mapping of relative path to base64-encoded content.
+
+    Returns:
+        list[str]: The absolute paths of the files written.
+
+    Raises:
+        ValueError: If a staging path is absolute or contains ``..``.
+    """
     staged: list[str] = []
     for rel, b64 in (files_b64 or {}).items():
         if rel.startswith("/") or ".." in Path(rel).parts:
@@ -84,7 +95,22 @@ def _bench_remote(
     result_glob: str,
     timeout_sec: int,
 ) -> dict:
-    """Run a kernel micro-benchmark on this (head) pod; the caller already pinned us to a GPU node."""
+    """Run a kernel micro-benchmark on this (head) pod; the caller already pinned us to a GPU node.
+
+    Args:
+        workspace: Absolute directory used as CWD for the bench command.
+        bench_command: Shell command run via ``bash -lc``.
+        files_b64_json: JSON ``{rel_path: base64_content}`` of files to stage.
+        result_glob: Glob (relative to workspace) of artifacts to read back.
+        timeout_sec: Hard timeout for the bench command.
+
+    Returns:
+        dict: Per-host result with return code, elapsed time, stdout/stderr
+        tails, staged files, and read-back artifacts.
+
+    Raises:
+        ValueError: If ``files_b64_json`` is not valid JSON.
+    """
     host = socket.gethostname()
     ws = Path(workspace)
     ws.mkdir(parents=True, exist_ok=True)
@@ -154,7 +180,14 @@ def _bench_remote(
 
 
 def _pick_gpu_node() -> str:
-    """Return the head-pod node id (GPU-bearing, co-located with the caller); fall back to any alive GPU node."""
+    """Return the head-pod node id (GPU-bearing, co-located with the caller); fall back to any alive GPU node.
+
+    Returns:
+        str: The Ray ``NodeID`` to pin the bench actor to.
+
+    Raises:
+        RuntimeError: If there are no alive nodes, or none with a GPU.
+    """
     nodes = [n for n in ray.nodes() if n.get("Alive")]
     if not nodes:
         raise RuntimeError("no alive Ray nodes for kernel bench")

--- a/inference_optimizer/multi_node/scripts/kernel_patch_multinode.py
+++ b/inference_optimizer/multi_node/scripts/kernel_patch_multinode.py
@@ -30,7 +30,11 @@ from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 
 def _log(msg: str) -> None:
-    """Stderr-only timestamped log line (stdout is reserved for the final JSON)."""
+    """Stderr-only timestamped log line (stdout is reserved for the final JSON).
+
+    Args:
+        msg: The message text to emit.
+    """
     ts = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime())
     sys.stderr.write(f"[kernel_patch_multinode {ts}] {msg}\n")
     sys.stderr.flush()
@@ -84,7 +88,23 @@ def _apply_remote(
     backup_dir: str,
     kernel_id: str,
 ) -> dict:
-    """Apply a single patch on this pod; raises on any error (surfaced via ``ray.get``)."""
+    """Apply a single patch on this pod; raises on any error (surfaced via ``ray.get``).
+
+    Args:
+        target_path: Absolute path of the file to overwrite on the pod.
+        patch_b64: Base64-encoded new file contents.
+        backup_dir: Directory where the pre-patch original is saved.
+        kernel_id: Optional id used to construct the backup filename.
+
+    Returns:
+        dict: Per-host result with the target path, backup path, byte count,
+        and compile status.
+
+    Raises:
+        FileNotFoundError: If ``target_path`` does not exist on the pod.
+        ValueError: If ``patch_b64`` is not valid base64, or if a ``.py``
+            target fails to compile (it is auto-reverted first).
+    """
     host = socket.gethostname()
     target = Path(target_path)
     if not target.is_file():
@@ -127,7 +147,16 @@ def _revert_remote(
     target_path: str,
     backup_path: str,
 ) -> dict:
-    """Restore ``target_path`` from ``backup_path`` on this pod; noop when the backup is missing."""
+    """Restore ``target_path`` from ``backup_path`` on this pod; noop when the backup is missing.
+
+    Args:
+        target_path: Absolute path of the file to restore on the pod.
+        backup_path: Path of the saved pre-patch backup.
+
+    Returns:
+        dict: Per-host result with ``status`` of ``restored`` or
+        ``noop_missing_backup``.
+    """
     host = socket.gethostname()
     target = Path(target_path)
     backup = Path(backup_path)

--- a/inference_optimizer/multi_node/scripts/kill_multinode.py
+++ b/inference_optimizer/multi_node/scripts/kill_multinode.py
@@ -39,6 +39,14 @@ def _kill_remote(pid_dir: str, grace_sec: int) -> dict:
 
     One sweep covers both colocated and PD-disaggregated modes (unused
     patterns are no-ops).
+
+    Args:
+        pid_dir: Directory containing the PID files to sweep.
+        grace_sec: Seconds to wait between SIGTERM and SIGKILL.
+
+    Returns:
+        dict: Summary with ``killed``, ``stale``, and ``missing`` lists keyed
+        by PID-file name.
     """
     summary: dict[str, list] = {"killed": [], "stale": [], "missing": []}
     p = Path(pid_dir)

--- a/inference_optimizer/multi_node/scripts/launch_multinode.py
+++ b/inference_optimizer/multi_node/scripts/launch_multinode.py
@@ -42,7 +42,14 @@ _DEFAULT_DIST_INIT_PORT = 29500
 
 
 def _pd_decode_dist_init_port(prefill_dist_init_port: int) -> int:
-    """Derive the decode rendezvous port as ``prefill + 1`` so an override shifts both endpoints in lock-step."""
+    """Derive the decode rendezvous port as ``prefill + 1`` so an override shifts both endpoints in lock-step.
+
+    Args:
+        prefill_dist_init_port: The prefill group's rendezvous port.
+
+    Returns:
+        int: The decode group's rendezvous port.
+    """
     return prefill_dist_init_port + 1
 # sglang PD bootstrap (KV transfer rendezvous) port; override via --pd-bootstrap-port.
 _PD_DEFAULT_BOOTSTRAP_PORT = 8998
@@ -53,7 +60,11 @@ _HEALTH_PROBE_TIMEOUT_SEC = int(os.environ.get('SGLANG_HEALTH_PROBE_TIMEOUT_SEC'
 
 
 def _log(msg: str) -> None:
-    """Stderr line with timestamp (no logging module to avoid handler surprises as a dashboard entry-point)."""
+    """Stderr line with timestamp (no logging module to avoid handler surprises as a dashboard entry-point).
+
+    Args:
+        msg: The message text to emit.
+    """
     ts = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime())
     sys.stderr.write(f"[launch_multinode {ts}] {msg}\n")
     sys.stderr.flush()
@@ -92,7 +103,15 @@ def _wait_for_nodes(target_n: int, timeout_s: int) -> list[dict]:
 
 
 def _pick_head_first(nodes: list[dict]) -> list[dict]:
-    """Reorder so the local (driver) node is rank 0 and the rest follow in NodeManagerAddress order."""
+    """Reorder so the local (driver) node is rank 0 and the rest follow in NodeManagerAddress order.
+
+    Args:
+        nodes: The alive GPU node rows from ``ray.nodes()``.
+
+    Returns:
+        list[dict]: The nodes reordered with the local node first, or all
+        nodes sorted by address when the driver is not on a GPU node.
+    """
     local_addr = ray.util.get_node_ip_address()
     local = [n for n in nodes if n.get("NodeManagerAddress") == local_addr]
     others = sorted(
@@ -125,8 +144,25 @@ def _build_sglang_cmd(
 
     Only rank 0 gets ``--host``/``--port`` (workers serve no HTTP).
     ``--trust-remote-code`` is default-on (custom modeling.py models need
-    it). ``ep > 1`` emits ``--expert-parallel-size N`` for true expert
+    it).     ``ep > 1`` emits ``--expert-parallel-size N`` for true expert
     parallelism (the older ``--enable-ep-moe`` pair was removed upstream).
+
+    Args:
+        model: Model path passed to the launcher.
+        tp: Tensor-parallel size.
+        nnodes: Total node count for this server group.
+        node_rank: This node's rank within the group.
+        dist_init_addr: Collective rendezvous ``host:port``.
+        extra_args: Extra args appended verbatim to the launcher.
+        ep: Expert-parallel size; ``> 1`` enables expert parallelism.
+        pd_role: PD disaggregation role (``prefill``/``decode``) or empty.
+        pd_port: HTTP port bound by rank 0.
+        pd_transfer_backend: KV-transfer backend for PD mode.
+        pd_ib_device: IB/RoCE device list for PD KV transfer.
+        pd_bootstrap_port: sglang PD bootstrap rendezvous port.
+
+    Returns:
+        list[str]: The sglang launch argv.
     """
     cmd = [
         "python3", "-m", "sglang.launch_server",
@@ -172,6 +208,20 @@ def _build_vllm_cmd(
 
     ``--tensor-parallel-size`` = total cluster GPUs; ``ep > 1`` adds
     ``--enable-expert-parallel`` (vllm infers ep_size = tp_size).
+
+    Args:
+        model: Model path passed to ``vllm serve``.
+        tp: Tensor-parallel size (total cluster GPUs).
+        extra_args: Extra args appended verbatim to the launcher.
+        ep: Expert-parallel size; ``> 1`` enables expert parallelism.
+        pd_role: PD disaggregation role (``prefill``/``decode``) or empty.
+        pd_port: HTTP port bound by the server.
+        pd_transfer_backend: KV connector name for PD mode.
+        pd_kv_rank: This group's KV rank in PD mode.
+        pd_kv_parallel_size: Total KV parallel size in PD mode.
+
+    Returns:
+        list[str]: The vLLM launch argv.
     """
     cmd = [
         "vllm", "serve", model,
@@ -203,7 +253,12 @@ def _build_vllm_cmd(
 
 
 def _probe_mec_firmware_lt_177() -> bool:
-    """Return True iff rocm-smi reports MEC firmware < 177 (gate for the HSA_NO_SCRATCH_RECLAIM workaround); False on any failure."""
+    """Return True iff rocm-smi reports MEC firmware < 177 (gate for the HSA_NO_SCRATCH_RECLAIM workaround); False on any failure.
+
+    Returns:
+        bool: ``True`` if MEC firmware is below 177; ``False`` on any probe
+        failure or higher firmware.
+    """
     try:
         proc = subprocess.run(
             ["rocm-smi", "--showfw"],
@@ -232,6 +287,9 @@ def _subprocess_env() -> dict[str, str]:
     Sets the MI300X tuning trio (SGLANG_USE_AITER / SGLANG_AITER_MLA_PERSIST,
     and HSA_NO_SCRATCH_RECLAIM when MEC firmware < 177) without clobbering
     caller-set values.
+
+    Returns:
+        dict[str, str]: The environment mapping for the launcher subprocess.
     """
     env = dict(os.environ)
     # Strip Ray's empty *_VISIBLE_DEVICES mask (num_gpus=0 actors) so the
@@ -261,7 +319,22 @@ def _detach_framework_launch(
     sub_env: dict[str, str],
     node_rank: int,
 ) -> int:
-    """Start ``cmd`` detached from the Ray worker via bash+nohup+setsid (reparents under init, PYTHONUNBUFFERED logs, fails fast with log tail)."""
+    """Start ``cmd`` detached from the Ray worker via bash+nohup+setsid (reparents under init, PYTHONUNBUFFERED logs, fails fast with log tail).
+
+    Args:
+        cmd: The framework launcher argv.
+        log_file: Path the launcher's stdout/stderr is appended to.
+        pid_file: Path the spawned launcher PID is written to.
+        sub_env: Environment passed to the spawn shell.
+        node_rank: This node's rank, used in log/error messages.
+
+    Returns:
+        int: The PID of the detached framework process.
+
+    Raises:
+        RuntimeError: If the spawn shell fails, the PID file is missing or
+            invalid, or the process exits within 0.5s of launch.
+    """
     sub_env = dict(sub_env)
     sub_env.setdefault("PYTHONUNBUFFERED", "1")
     log_q = shlex.quote(str(log_file))
@@ -344,6 +417,36 @@ def _spawn_remote(
 
     ``torch_profiler_dir`` (if set) is exported as
     ``SGLANG_TORCH_PROFILER_DIR`` for shared-path traces.
+
+    Args:
+        framework: ``sglang`` or ``vllm``.
+        model: Model path passed to the launcher.
+        tp: Tensor-parallel size.
+        nnodes: Total node count for this server group.
+        node_rank: This node's rank within the group.
+        head_ip: Rendezvous head IP.
+        dist_init_port: Collective rendezvous port.
+        pid_dir: Directory the PID file is written to.
+        log_dir: Directory the log file is written to.
+        extra_args: Extra args appended verbatim to the launcher.
+        torch_profiler_dir: Optional shared dir exported as
+            ``SGLANG_TORCH_PROFILER_DIR``.
+        ep: Expert-parallel size.
+        pd_role: PD disaggregation role (``prefill``/``decode``) or empty.
+        pd_port: HTTP port bound in PD mode.
+        pd_transfer_backend: KV-transfer backend for PD mode.
+        pd_ib_device: IB/RoCE device list for PD KV transfer.
+        pd_bootstrap_port: sglang PD bootstrap rendezvous port.
+        pd_kv_rank: vLLM KV rank for PD mode.
+        pd_kv_parallel_size: vLLM total KV parallel size for PD mode.
+        pid_file_name: Optional role-tagged PID file name.
+
+    Returns:
+        int: The spawned framework PID, or ``0`` for a no-op vLLM worker rank.
+
+    Raises:
+        RuntimeError: If ``framework`` is unsupported, or the detached launch
+            fails.
     """
     Path(pid_dir).mkdir(parents=True, exist_ok=True)
     Path(log_dir).mkdir(parents=True, exist_ok=True)
@@ -462,7 +565,15 @@ _FATAL_SCAN_TAIL_BYTES = 256 * 1024
 
 
 def _scan_rank0_log_for_fatal(log_dir: str) -> str | None:
-    """Scan rank_0.log tail for a fatal traceback / framework error; returns the matched line or ``None``."""
+    """Scan rank_0.log tail for a fatal traceback / framework error; returns the matched line or ``None``.
+
+    Args:
+        log_dir: Directory containing ``rank_0.log``.
+
+    Returns:
+        str | None: The first matched fatal line, or ``None`` if none found
+        or the log cannot be read.
+    """
     try:
         lf = Path(log_dir) / "rank_0.log"
         if not lf.is_file():
@@ -492,7 +603,18 @@ def _wait_health(
     rank0_pid: int | None = None,
     log_dir: str | None = None,
 ) -> bool:
-    """Poll rank-0 ``/health``; True on first 200, False on timeout / rank-0 death / fatal ``rank_0.log`` error."""
+    """Poll rank-0 ``/health``; True on first 200, False on timeout / rank-0 death / fatal ``rank_0.log`` error.
+
+    Args:
+        timeout_s: Maximum seconds to poll before giving up.
+        rank0_pid: Optional rank-0 PID; the wait aborts early if it dies.
+        log_dir: Optional directory whose ``rank_0.log`` is scanned for fatal
+            errors to abort early.
+
+    Returns:
+        bool: ``True`` on a first healthy response; ``False`` on timeout,
+        confirmed rank-0 death, or a fatal log error.
+    """
     import urllib.request
     import urllib.error
     started = time.monotonic()
@@ -546,7 +668,12 @@ def _emit_rank0_log_tail(log_dir: Path) -> None:
 
 
 def _log_rank0_post_spawn(log_dir: Path, rank0_pid: int | None) -> None:
-    """Emit rank-0 diagnostics after a short settle (a ``rank_0.log`` tail for early weight-load exits)."""
+    """Emit rank-0 diagnostics after a short settle (a ``rank_0.log`` tail for early weight-load exits).
+
+    Args:
+        log_dir: Directory containing ``rank_0.log``.
+        rank0_pid: The rank-0 PID to probe, or ``None`` to skip.
+    """
     if rank0_pid is None or rank0_pid <= 0:
         return
     time.sleep(3)

--- a/inference_optimizer/multi_node/scripts/launch_router.py
+++ b/inference_optimizer/multi_node/scripts/launch_router.py
@@ -29,7 +29,11 @@ _DEFAULT_LOG_FILE = "/tmp/multi_node_logs/router.log"
 
 
 def _log(msg: str) -> None:
-    """Stderr line with timestamp."""
+    """Stderr line with timestamp.
+
+    Args:
+        msg: The message text to emit.
+    """
     ts = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime())
     sys.stderr.write(f"[launch_router {ts}] {msg}\n")
     sys.stderr.flush()
@@ -40,7 +44,16 @@ def _build_sglang_router_cmd(
     decode_url: str,
     public_port: int,
 ) -> list[str]:
-    """Compose the sglang_router PD-disaggregation launch command (one prefill + one decode group)."""
+    """Compose the sglang_router PD-disaggregation launch command (one prefill + one decode group).
+
+    Args:
+        prefill_url: Internal prefill group HTTP endpoint.
+        decode_url: Internal decode group HTTP endpoint.
+        public_port: Port the router binds for the client.
+
+    Returns:
+        list[str]: The argv for launching the sglang router.
+    """
     return [
         "python3", "-m", "sglang_router.launch_router",
         "--pd-disaggregation",
@@ -57,7 +70,18 @@ def _build_vllm_router_cmd(
     public_port: int,
     override_cmd: str = "",
 ) -> list[str]:
-    """Compose the vllm router/proxy launch command; ``--vllm-router-cmd`` overrides it ({prefill}/{decode}/{port} placeholders)."""
+    """Compose the vllm router/proxy launch command; ``--vllm-router-cmd`` overrides it ({prefill}/{decode}/{port} placeholders).
+
+    Args:
+        prefill_url: Internal prefill group HTTP endpoint.
+        decode_url: Internal decode group HTTP endpoint.
+        public_port: Port the router binds for the client.
+        override_cmd: Optional full command template; supports ``{prefill}``,
+            ``{decode}``, and ``{port}`` placeholders.
+
+    Returns:
+        list[str]: The argv for launching the vllm router/proxy.
+    """
     if override_cmd:
         rendered = (
             override_cmd
@@ -80,7 +104,20 @@ def _detach_router(
     log_file: Path,
     pid_file: Path,
 ) -> int:
-    """Run ``cmd`` detached via bash+nohup+setsid so it survives the dashboard job exit and dies cleanly under kill_multinode."""
+    """Run ``cmd`` detached via bash+nohup+setsid so it survives the dashboard job exit and dies cleanly under kill_multinode.
+
+    Args:
+        cmd: The router argv to launch.
+        log_file: Path the router's stdout/stderr is appended to.
+        pid_file: Path the spawned router PID is written to.
+
+    Returns:
+        int: The PID of the detached router process.
+
+    Raises:
+        RuntimeError: If the spawn shell fails, the PID file is missing or
+            invalid, or the router is not alive 0.5s after launch.
+    """
     log_file.parent.mkdir(parents=True, exist_ok=True)
     pid_file.parent.mkdir(parents=True, exist_ok=True)
     log_q = shlex.quote(str(log_file))

--- a/inference_optimizer/orchestrator/action_executors/_canonical_fingerprint.py
+++ b/inference_optimizer/orchestrator/action_executors/_canonical_fingerprint.py
@@ -38,6 +38,13 @@ def canonical_fingerprint(
     inputs (lossless legacy → ledger merge); kept separate so call-sites depend
     on the legacy canonical identity. Normalization: args ``shlex.split`` →
     sorted tokens; envs ``(str(k), str(v))`` sorted by key; 16-char SHA-1.
+
+    Args:
+        extra_args: Extra server-arg string for the variant, or None.
+        extra_envs: Mapping of extra environment variables, or None.
+
+    Returns:
+        The 16-character SHA-1 fingerprint hex digest.
     """
     args_text = str(extra_args or "")
     try:
@@ -70,6 +77,16 @@ def workload_signature(
     cross-workload resume can warn when an old KEEP came from a different
     (CONC, ISL, OSL, precision, TP). Not part of the fingerprint hash today.
     Args default to the corresponding process env vars when omitted.
+
+    Args:
+        conc: Concurrency; defaults to the ``CONC`` env var.
+        isl: Input sequence length; defaults to the ``ISL`` env var.
+        osl: Output sequence length; defaults to the ``OSL`` env var.
+        precision: Workload precision; defaults to the ``PRECISION`` env var.
+        tp: Tensor-parallel size; defaults to the ``TP`` env var.
+
+    Returns:
+        The 12-character SHA-1 digest of the workload contract.
     """
     fields = {
         "conc": str(conc if conc is not None else os.environ.get("CONC", "")).strip(),

--- a/inference_optimizer/orchestrator/action_executors/_explore_roofline_filter.py
+++ b/inference_optimizer/orchestrator/action_executors/_explore_roofline_filter.py
@@ -75,6 +75,13 @@ def categorize_variant(
     """Return the set of roofline directions a variant's flags target.
 
     An empty set means the variant is uncategorized (no advisory).
+
+    Args:
+        extra_args: Extra server-arg string for the variant, or None.
+        extra_envs: Mapping of extra environment variables, or None.
+
+    Returns:
+        Frozenset of roofline direction names the variant targets.
     """
     cats: set[str] = set()
     args = (extra_args or "").strip()

--- a/inference_optimizer/orchestrator/action_executors/_framework_gap_composer.py
+++ b/inference_optimizer/orchestrator/action_executors/_framework_gap_composer.py
@@ -54,6 +54,12 @@ def _extract_bottleneck_from_breakdown(breakdown_path: str | Path | None) -> str
     sorted-by-time list or dict with ``top_kernels``). Best-effort: returns ""
     when the path is empty/unreadable or no kernel matches
     :data:`_OP_TO_KEYWORD`, and the caller falls back to manifest-only gap.
+
+    Args:
+        breakdown_path: Path to the kernel breakdown JSON, or None.
+
+    Returns:
+        One canonical bottleneck keyword, or "" when none is found.
     """
     if not breakdown_path:
         return ""
@@ -101,6 +107,12 @@ def _normalize_model_class(model_class: str) -> str:
 
     Same canonicalisation rule (lowercase, -/+/space → _) every other
     ``model_class`` consumer uses, keeping the gap token grep-friendly.
+
+    Args:
+        model_class: Raw model-class label.
+
+    Returns:
+        The canonical lowercase token, or "" when the input is empty.
     """
     raw = (model_class or "").strip().lower()
     if not raw:
@@ -113,6 +125,13 @@ def _model_class_to_search_token(model_class: str) -> str:
 
     fa's anti-correlation table activates on ``dense`` / ``moe``, so the gap
     must carry one of those rather than granular IO labels (``moe_mla`` ...).
+
+    Args:
+        model_class: Raw model-class label.
+
+    Returns:
+        An fa-friendly architectural token (``moe`` / ``dense`` / canonical
+        token), or "" when the input is empty.
     """
     mc = _normalize_model_class(model_class)
     if not mc:
@@ -140,9 +159,21 @@ def compose_gap(
     ``profile_kernel_breakdown_path`` (when present) adds a bottleneck keyword.
     ``tried_refs`` is accepted for forward-compat but currently unused.
 
-    Returns ``(gap_description, keywords)``: a free-text gap phrase for
-    fa's PR search, and a lowercased/deduped/sorted explicit keyword list
-    (non-empty when any of framework/gpu_type/model_class/bottleneck is known).
+    Args:
+        framework: Inference framework name.
+        gpu_type: Target GPU type.
+        model_class: Model-class label (canonicalised to a search token).
+        precision: Workload precision.
+        profile_kernel_breakdown_path: Optional path to the kernel breakdown
+            JSON used to derive a bottleneck keyword.
+        tried_refs: Previously tried PR refs; accepted for forward-compat but
+            currently unused.
+
+    Returns:
+        A ``(gap_description, keywords)`` tuple: a free-text gap phrase for
+        fa's PR search, and a lowercased/deduped/sorted explicit keyword list
+        (non-empty when any of framework/gpu_type/model_class/bottleneck is
+        known).
     """
     fw = (framework or "").strip().lower()
     gpu = (gpu_type or "").strip().lower()

--- a/inference_optimizer/orchestrator/action_executors/_grid_runner.py
+++ b/inference_optimizer/orchestrator/action_executors/_grid_runner.py
@@ -53,6 +53,13 @@ def variant_fingerprint(
 
     Name and note are NOT inputs — variants with identical content but
     different names collapse to the same fingerprint.
+
+    Args:
+        extra_server_args: The variant's server-args string, or ``None``.
+        extra_envs: The variant's env overrides, or ``None``.
+
+    Returns:
+        A 16-char SHA-1 prefix fingerprint of the normalized content.
     """
     args_text = str(extra_server_args or "")
     try:
@@ -79,6 +86,10 @@ def _resolve_magpie_python() -> str:
     Magpie venv) as unconditional last resort. A stale ``$MAGPIE_PYTHON``
     resolved before Magpie was pip-installed (e.g. ``/usr/bin/python3``) is
     validated and skipped to avoid ``ModuleNotFoundError`` at benchmark time.
+
+    Returns:
+        Path to a Python interpreter that can import Magpie, falling back to
+        the canonical ``/opt/venv/bin/python``.
     """
     def _can_import_magpie(py: str) -> bool:
         """Whether an interpreter can import Magpie and its ``yaml`` dep.
@@ -136,6 +147,9 @@ def _resolve_session_dir() -> Path:
     Reads :func:`inference_optimizer.paths.session_dir` (honors
     ``$USER_DATA_PATH``, else ``/workspace/hyperloom``). Used by fallback
     paths when ``ctx.extra["workspace"]`` was not pre-mkdir'd.
+
+    Returns:
+        The resolved active session directory.
     """
     from ...paths import session_dir as _sd
     return _sd()
@@ -219,6 +233,13 @@ def annotate_multi_node_cuda_graph_max_bs(
     cross-node decode tick), but the variant is kept in the grid and surfaced
     as an advisory rather than auto-dropped. Returns ``[]`` outside multi-node
     mode, when ``$CONC`` is unset/non-positive, or when no variant matches.
+
+    Args:
+        grid: The variants to inspect for a low ``--cuda-graph-max-bs``.
+
+    Returns:
+        A list of advisory note dicts (``name``/``source``/``reason``), or
+        ``[]`` when nothing applies.
     """
     from ._multi_node_env import is_multi_node
     if not is_multi_node():
@@ -291,6 +312,12 @@ def _probe_server_help_text(framework: str) -> str:
     fall through to NOT filtering. Empty results are NOT cached. The broad
     ``except`` is deliberate: this probe is a perf optimisation only and must
     never crash the optimizer.
+
+    Args:
+        framework: The framework name (``sglang`` / ``vllm`` / ``atom``).
+
+    Returns:
+        The ``--help`` text, or ``""`` on any failure or unknown framework.
     """
     fw = (framework or "").strip().lower()
     if fw in _HELP_TEXT_CACHE:
@@ -316,6 +343,9 @@ def _probe_sglang_help_text() -> str:
 
     Kept so tests that monkey-patch this exact name still work; new call
     sites should use ``_probe_server_help_text("sglang")``.
+
+    Returns:
+        The SGLang ``--help`` text, or ``""`` on failure.
     """
     return _probe_server_help_text("sglang")
 
@@ -327,6 +357,12 @@ def _detect_model_class(model_path: str) -> tuple[bool, bool]:
     variant before a 10-min doomed sglang restart. Misclassifications cost at
     most one restart. MLA: DeepSeek (V2/V3/R1), GLM-5, Kimi-K2; MoE: MLA set +
     Qwen3-MoE.
+
+    Args:
+        model_path: The model path/name to classify.
+
+    Returns:
+        A ``(is_mla_model, is_moe_model)`` tuple of detection flags.
     """
     p = model_path.lower()
     mla_keys = ("glm-5", "glm5", "deepseek", "kimi-k2", "kimi_k2", "kimi")
@@ -348,6 +384,13 @@ def apply_compatibility_filter(
     model class (MLA / MoE flags dropped when ``$MODEL_PATH`` lacks the family
     keyword), and sglang version (flags absent from ``launch_server --help``
     dropped). Returns the ``(kept, dropped)`` shape of ``apply_user_skip_list``.
+
+    Args:
+        grid: The candidate variants to filter.
+
+    Returns:
+        A ``(kept, dropped)`` tuple where ``dropped`` entries are
+        ``{"name", "source", "reason"}`` dicts (source=``"compatibility_filter"``).
     """
     model_path = os.environ.get("MODEL_PATH", "")
     if model_path:
@@ -409,6 +452,13 @@ def apply_user_skip_list(
 
     Returns ``(kept, dropped)`` where each dropped entry is
     ``{"name", "reason", "source"}`` with source=``"user_skip"``.
+
+    Args:
+        grid: The candidate variants to filter.
+        skip_spec: Comma/space-separated name or glob patterns to drop.
+
+    Returns:
+        A ``(kept, dropped)`` tuple of variants and drop-reason dicts.
     """
     patterns = _parse_skip_spec(skip_spec)
     if not patterns:
@@ -511,6 +561,12 @@ def coerce_extra_envs(value: Any) -> dict[str, str]:
     ``"FOO=1 BAR=2"`` string, and ``["FOO=1", "BAR=2"]`` token list — so
     downstream ``.items()`` callers never crash on a non-dict. Unknown shapes
     coerce to an empty dict.
+
+    Args:
+        value: The raw ``extra_envs`` value (dict, string, or list/tuple).
+
+    Returns:
+        A normalized ``dict[str, str]`` of environment overrides.
     """
     if isinstance(value, dict):
         return {str(k): str(v) for k, v in value.items() if k is not None}
@@ -675,6 +731,15 @@ def sanitize_script_name(value: Any) -> str | None:
 
     Must be a bare ``*.sh`` name (no slashes / ``..``). Empty/``None`` →
     ``None``; anything resembling shell injection raises ``ValueError``.
+
+    Args:
+        value: The Orchestration-supplied benchmark script name.
+
+    Returns:
+        The validated script name, or ``None`` when empty/``None``.
+
+    Raises:
+        ValueError: If ``value`` is not a bare ``*.sh`` file name.
     """
     if value is None:
         return None
@@ -695,6 +760,15 @@ def sanitize_result_dir(value: Any) -> str | None:
     Lands in a shell ``cd`` / ``mkdir`` via ``$RESULT_DIR``, so reject any
     character that could escape into a different shell word. Empty/``None`` →
     ``None``.
+
+    Args:
+        value: The Orchestration-supplied result directory path.
+
+    Returns:
+        The validated directory string, or ``None`` when empty/``None``.
+
+    Raises:
+        ValueError: If ``value`` contains whitespace or shell metacharacters.
     """
     if value is None:
         return None
@@ -735,6 +809,12 @@ def merge_server_args(*parts: str | None) -> str:
     Only removes empty chunks; does NOT de-duplicate option names, because
     repeated flags are how later args override base args (e.g. ``--block-size
     1`` then ``--block-size 256``).
+
+    Args:
+        *parts: Server-arg strings (or ``None``) in override order.
+
+    Returns:
+        The non-empty parts joined by single spaces.
     """
     return " ".join(str(p).strip() for p in parts if str(p or "").strip())
 
@@ -758,6 +838,9 @@ def resolve_sglang_watchdog_timeout() -> int:
     :data:`DEFAULT_SGLANG_WATCHDOG_TIMEOUT_SEC` when the env var is unset,
     empty, non-integer, or non-positive. A malformed value logs a warning
     and uses the default rather than crashing the YAML materialization.
+
+    Returns:
+        The resolved watchdog timeout in seconds.
     """
     raw = os.environ.get(SGLANG_WATCHDOG_TIMEOUT_ENV, "").strip()
     if not raw:
@@ -790,6 +873,13 @@ def inject_sglang_watchdog_timeout(
     (empty/unknown is treated as sglang) or the flag is already present.
     Otherwise appends the value from :func:`resolve_sglang_watchdog_timeout`;
     no other flag is touched.
+
+    Args:
+        server_args: The existing server-args string, or ``None``.
+        framework: The backend framework name.
+
+    Returns:
+        The server-args string, with the watchdog flag appended when applicable.
     """
     args = str(server_args or "").strip()
     if server_args_env_name(framework) != "EXTRA_SGLANG_ARGS":
@@ -824,6 +914,13 @@ def _resolve_nonneg_int_env(name: str, default: int) -> int:
 
     A blank/non-integer/negative value logs a warning and falls back to the
     default rather than crashing the YAML materialization.
+
+    Args:
+        name: The environment variable name to read.
+        default: The fallback value when unset/invalid.
+
+    Returns:
+        The parsed non-negative integer, or ``default``.
     """
     raw = os.environ.get(name, "").strip()
     if not raw:
@@ -850,6 +947,13 @@ def resolve_sglang_context_cap(isl: int, osl: int) -> int:
     operator-tunable via ``$SGLANG_CONTEXT_HEADROOM_TOKENS`` /
     ``$SGLANG_CONTEXT_FLOOR_TOKENS``). Caller clamps to the model's native
     window before injecting.
+
+    Args:
+        isl: Input sequence length in tokens.
+        osl: Output sequence length in tokens.
+
+    Returns:
+        The resolved context-length cap in tokens.
     """
     headroom = _resolve_nonneg_int_env(
         SGLANG_CONTEXT_HEADROOM_ENV, DEFAULT_SGLANG_CONTEXT_HEADROOM_TOKENS,
@@ -874,6 +978,16 @@ def inject_sglang_context_length(
     model's ``max_position_embeddings`` cannot be read. Otherwise appends
     ``min(max_pos, cap)`` from :func:`resolve_sglang_context_cap`; only this
     flag is added.
+
+    Args:
+        server_args: The existing server-args string, or ``None``.
+        framework: The backend framework name.
+        model_path: The model path used to read ``max_position_embeddings``.
+        isl: Input sequence length in tokens.
+        osl: Output sequence length in tokens.
+
+    Returns:
+        The server-args string, with ``--context-length`` appended when applicable.
     """
     args = str(server_args or "").strip()
     if server_args_env_name(framework) != "EXTRA_SGLANG_ARGS":
@@ -903,6 +1017,12 @@ def _resolve_dual_chunk_backend(gpu_type: str | None = None) -> str:
     (e.g. operator override), return the canonical backend and let sglang
     raise the clear error rather than silently injecting triton which
     sglang also rejects.  Override via ``$HYPERLOOM_DUAL_CHUNK_BACKEND``.
+
+    Args:
+        gpu_type: Optional caller-known GPU type (currently advisory).
+
+    Returns:
+        The dual-chunk attention backend name to inject.
     """
     override = os.environ.get("HYPERLOOM_DUAL_CHUNK_BACKEND", "").strip()
     if override:
@@ -929,6 +1049,15 @@ def inject_sglang_attention_backend(
     Returns ``server_args`` unchanged when: framework is not sglang, an
     ``--attention-backend`` is already pinned (operator wins), or the model
     config has no dual-chunk block (fail-safe: inject nothing).
+
+    Args:
+        server_args: The existing server-args string, or ``None``.
+        framework: The backend framework name.
+        model_path: The model path used to detect dual-chunk attention.
+        gpu_type: Optional caller-known GPU type, preferred over autodetect.
+
+    Returns:
+        The server-args string, with ``--attention-backend`` appended when applicable.
     """
     args = str(server_args or "").strip()
     if server_args_env_name(framework) != "EXTRA_SGLANG_ARGS":
@@ -984,6 +1113,15 @@ def inject_sglang_moe_runner_backend(
     inject nothing). Otherwise appends the backend from
     ``$HYPERLOOM_SGLANG_MOE_RUNNER_BACKEND`` (default ``triton``); only this
     flag is added.
+
+    Args:
+        server_args: The existing server-args string, or ``None``.
+        framework: The backend framework name.
+        model_path: The model path used to detect a MoE model.
+        gpu_type: Optional caller-known GPU type, preferred over autodetect.
+
+    Returns:
+        The server-args string, with ``--moe-runner-backend`` appended when applicable.
     """
     args = str(server_args or "").strip()
     if server_args_env_name(framework) != "EXTRA_SGLANG_ARGS":
@@ -1022,6 +1160,15 @@ def apply_runtime_benchmark_overrides(
     ``benchmark_script`` (must be pre-sanitized via :func:`sanitize_script_name`)
     force-selects a specific Magpie script, applied AFTER the
     ``gpu_type``-derived generic script so the operator pick wins.
+
+    Args:
+        bench: The benchmark YAML dict to mutate in place.
+        model_path: Optional model path override.
+        gpu_type: Optional GPU/runner type override.
+        benchmark_script: Optional pre-sanitized Magpie script name to force.
+
+    Returns:
+        The mutated ``envs`` sub-dict of ``bench``.
     """
     if model_path:
         bench["model"] = str(model_path)
@@ -1090,6 +1237,18 @@ def _build_variant_yaml(
     overrides the legacy hardcoded ``benchmark.model``; ``gpu_type`` pins the
     generic ``{framework}_{gpu_type}.sh``; ``benchmark_script`` (pre-sanitized)
     force-pins a script, applied last so the operator pick wins.
+
+    Args:
+        base_yaml_path: Path to the base Magpie YAML to clone.
+        base_extra_args: Server args common to every variant.
+        variant: The variant whose flags/envs are layered on top.
+        output_subdir: Directory the per-variant ``config.yaml`` is written to.
+        model_path: Optional model path override.
+        gpu_type: Optional GPU/runner type override.
+        benchmark_script: Optional pre-sanitized Magpie script name to force.
+
+    Returns:
+        Path to the materialized per-variant ``config.yaml``.
     """
     with base_yaml_path.open(encoding="utf-8") as f:
         cfg = yaml.safe_load(f)
@@ -1147,6 +1306,11 @@ def _kill_stale_servers() -> None:
     hangs ~5 min on zmq / shared-mem conflicts. Called before every Magpie
     invocation. Uses /proc scan (not pgrep) to avoid clashing with test
     subprocess mocks. No-op in multi-node mode (servers live in RayJob pods).
+
+    Note:
+        Side-effecting and best-effort: it sends signals to matching processes
+        and unlinks stale shared-memory segments, swallowing errors. Returns
+        nothing.
     """
     from ._multi_node_env import is_multi_node
     if is_multi_node():
@@ -1268,6 +1432,18 @@ def _run_magpie(
     land in the per-task workspace, not ``/workspace/``. ``soft_deadline_sec``
     is the Fix-E overtime cap: the tree is reaped and a sentinel
     ``OVERTIME_KILL_RETURNCODE`` returned instead of raising ``TimeoutExpired``.
+
+    Args:
+        magpie_python: Path to the Python interpreter that runs Magpie.
+        config_path: Path to the materialized benchmark YAML.
+        output_dir: Directory for the run's outputs (default ``$RESULT_DIR``).
+        timeout_sec: Hard subprocess timeout in seconds.
+        cwd: Working directory for the Magpie subprocess.
+        result_dir: Optional pre-sanitized override for ``$RESULT_DIR``.
+        soft_deadline_sec: Optional overtime soft cap in seconds.
+
+    Returns:
+        A ``(returncode, stdout, stderr)`` tuple from the Magpie subprocess.
     """
     # Pre-clean lingering servers + shared memory (skip under pytest).
     if not os.environ.get("PYTEST_CURRENT_TEST"):
@@ -1344,6 +1520,24 @@ async def run_grid(
     that hardcode ``--result-dir /workspace/`` (see SKILL.md "Magpie leak-path
     salvage"). ``soft_deadline_sec`` (Fix E): reap a variant once wall-clock
     exceeds it, marking it ``killed_overtime=True``; None/0 disables (legacy).
+
+    Args:
+        base_yaml_path: Path to the base Magpie YAML cloned per variant.
+        base_extra_args: Server args common to every variant.
+        grid: The variants to execute, in order.
+        output_root: Root directory under which each variant's outputs land.
+        magpie_python: Optional interpreter override; resolved when unset.
+        cwd: Working directory for each Magpie subprocess.
+        variant_timeout_sec: Hard per-variant subprocess timeout in seconds.
+        keep_going_on_failure: Whether to continue after a variant fails.
+        model_path: Optional model path forwarded to each YAML render.
+        gpu_type: Optional GPU/runner type forwarded to each YAML render.
+        benchmark_script: Optional pre-sanitized Magpie script name to force.
+        result_dir: Optional pre-sanitized override for ``$RESULT_DIR``.
+        soft_deadline_sec: Optional per-variant overtime soft cap in seconds.
+
+    Returns:
+        The per-variant :class:`VariantResult` list for every attempt.
     """
     if not magpie_python:
         magpie_python = _resolve_magpie_python()
@@ -1748,6 +1942,15 @@ def pick_winners(
     falls back to ``MULTI_NODE_DEFAULT_KEEP_THRESHOLD_PCT`` (2.0%, the empirical
     cross-node noise floor) in multi-node mode, else
     ``SINGLE_NODE_DEFAULT_KEEP_THRESHOLD_PCT`` (1.0%).
+
+    Args:
+        results: The per-variant results to filter.
+        baseline_tput: The baseline output throughput to beat.
+        keep_threshold_pct: Explicit win margin percent; resolved by mode
+            when ``None``.
+
+    Returns:
+        The succeeded variants whose throughput clears the cutoff.
     """
     if keep_threshold_pct is None:
         from ._multi_node_env import is_multi_node
@@ -1793,6 +1996,13 @@ def _write_variant_abort_marker(
     "untested". This marker lets final-report / post-mortem tools count failed
     variants and find an explicit reason even after the log rotated. Failure
     to write it is non-fatal (log and continue).
+
+    Args:
+        slot: The variant slot directory to write the marker into.
+        variant_name: The aborted variant's name.
+        error_class: Short failure-classification tag.
+        error_summary: Human-readable error summary (truncated to 2000 chars).
+        extra_args: The variant's server args, recorded for post-mortem.
     """
     try:
         slot.mkdir(parents=True, exist_ok=True)

--- a/inference_optimizer/orchestrator/action_executors/_inferencex_patcher.py
+++ b/inference_optimizer/orchestrator/action_executors/_inferencex_patcher.py
@@ -69,6 +69,13 @@ def _discover_inferencex_roots(
     unpatched. Patches ALL discovered roots (deduped by resolved path):
     ``inferencex_path`` arg, ``$INFERENCEX_PATH``, ``$MAGPIE_DIR/InferenceX``.
     Returns ``[]`` when none resolve (callers fail-soft).
+
+    Args:
+        inferencex_path: Caller-provided override root to include in the scan.
+
+    Returns:
+        A deduped list of resolved InferenceX checkout directories, or ``[]``
+        when none resolve.
     """
     roots: list[Path] = []
     seen: set[Path] = set()
@@ -108,6 +115,13 @@ def _resolve_benchmark_lib_paths(
 ) -> list[Path]:
     """Return every existing ``<root>/benchmarks/benchmark_lib.sh`` to patch
     (one per :func:`_discover_inferencex_roots` root). ``[]`` = skip patching.
+
+    Args:
+        inferencex_path: Caller-provided override root to include in the scan.
+
+    Returns:
+        A list of existing ``benchmark_lib.sh`` paths, or ``[]`` when none
+        exist.
     """
     out: list[Path] = []
     for root in _discover_inferencex_roots(inferencex_path):
@@ -142,6 +156,12 @@ def _file_lock(lock_path: str) -> Iterator[None]:
 
     Falls through without exclusion if the lock file can't be opened; the
     atomic-replace path still guarantees no torn writes (idempotent).
+
+    Args:
+        lock_path: Filesystem path of the lock file to acquire exclusively.
+
+    Yields:
+        Control while the exclusive lock is held; the lock is released on exit.
     """
     try:
         fp = open(lock_path, "w")
@@ -258,6 +278,14 @@ def ensure_benchmark_lib_patched(
     Returns ``True`` when patched at exit, ``False`` (non-fatal) when the file
     is missing or the legacy line is absent. Concurrency-safe (flock +
     atomic rename; already-patched fast-path skips the lock).
+
+    Args:
+        inferencex_path: Caller-provided override root; defaults to env-based
+            discovery when ``None``.
+
+    Returns:
+        True when at least one discovered ``benchmark_lib.sh`` is patched (or
+        already patched), False when none could be patched.
     """
     sources = _resolve_benchmark_lib_paths(inferencex_path)
     if not sources:
@@ -301,6 +329,13 @@ def _resolve_benchmark_serving_paths(
     ``<root>/utils/bench_serving/benchmark_serving.py`` to patch (one per
     :func:`_discover_inferencex_roots` root, including Magpie's bundled copy
     per the #210 fix). Independent of the benchmark_lib.sh resolver.
+
+    Args:
+        inferencex_path: Caller-provided override root to include in the scan.
+
+    Returns:
+        A list of existing ``benchmark_serving.py`` paths, or ``[]`` when none
+        exist.
     """
     out: list[Path] = []
     for root in _discover_inferencex_roots(inferencex_path):
@@ -347,6 +382,13 @@ def _is_benchmark_serving_patched(src: Path) -> bool:
 def _apply_benchmark_serving_patch_atomic(src: Path) -> bool:
     """Rewrite the hardcoded ``extra_body=`` line to consult
     ``PROFILE_EXTRA_BODY`` first, via temp-file + atomic rename.
+
+    Args:
+        src: The ``benchmark_serving.py`` file to patch in place.
+
+    Returns:
+        True when the patched bytes were written, False when the legacy line
+        is missing or any IO step fails.
     """
     try:
         original = src.read_text(encoding="utf-8")
@@ -418,6 +460,14 @@ def ensure_benchmark_serving_patched(
     Returns ``True`` when patched at exit, ``False`` (non-fatal) when missing.
     Concurrency-safe; independent lock file from
     :func:`ensure_benchmark_lib_patched` so the two patches don't serialize.
+
+    Args:
+        inferencex_path: Caller-provided override root; defaults to env-based
+            discovery when ``None``.
+
+    Returns:
+        True when at least one discovered ``benchmark_serving.py`` is patched
+        (or already patched), False when none could be patched.
     """
     sources = _resolve_benchmark_serving_paths(inferencex_path)
     if not sources:

--- a/inference_optimizer/orchestrator/action_executors/_magpie_patcher.py
+++ b/inference_optimizer/orchestrator/action_executors/_magpie_patcher.py
@@ -145,6 +145,14 @@ def _resolve_benchmarker_path(magpie_dir: Path | str | None) -> Path | None:
 
     Returns ``None`` when unconfigured or missing on disk (callers skip
     patching).
+
+    Args:
+        magpie_dir: Magpie root override; falls back to ``$MAGPIE_DIR`` when
+            falsy.
+
+    Returns:
+        The resolved ``benchmarker.py`` path, or ``None`` when unconfigured or
+        absent on disk.
     """
     root: Path | None = None
     if magpie_dir:
@@ -162,7 +170,16 @@ def _resolve_benchmarker_path(magpie_dir: Path | str | None) -> Path | None:
 def _resolve_sglang_mi300x_script_path(
     magpie_dir: Path | str | None,
 ) -> Path | None:
-    """Resolve Magpie's generic SGLang MI300X benchmark script when present."""
+    """Resolve Magpie's generic SGLang MI300X benchmark script when present.
+
+    Args:
+        magpie_dir: Magpie root override; falls back to ``$MAGPIE_DIR`` when
+            falsy.
+
+    Returns:
+        The resolved ``sglang_mi300x.sh`` path, or ``None`` when unconfigured
+        or absent on disk.
+    """
     root: Path | None = None
     if magpie_dir:
         root = Path(magpie_dir)
@@ -182,6 +199,12 @@ def _file_lock(lock_path: str) -> Iterator[None]:
 
     Falls through without exclusion if the lock file can't be opened; the
     atomic-replace still guarantees no torn writes (idempotent).
+
+    Args:
+        lock_path: Filesystem path of the lock file to acquire exclusively.
+
+    Yields:
+        Control while the exclusive lock is held; the lock is released on exit.
     """
     try:
         fp = open(lock_path, "w")  # noqa: SIM115 — kept open across yield
@@ -227,6 +250,13 @@ def _extract_prepare_region(text: str) -> str:
     Scopes inline-atomic detection to one method body (header down to the next
     line indented at/below the header column) so an unrelated ``os.replace``
     can't masquerade as a fixed copy loop.
+
+    Args:
+        text: The full ``benchmarker.py`` source text to slice.
+
+    Returns:
+        The source slice covering the ``_prepare_benchmark_scripts`` method
+        body, or ``""`` when the header is absent.
     """
     start = text.find(_PREPARE_METHOD_MARKER)
     if start == -1:
@@ -251,6 +281,13 @@ def _upstream_is_already_atomic(text: str) -> bool:
     redundant). Either signal suffices: ``_copy_benchmark_script_atomic``
     present, or an inline ``tempfile.mkstemp(`` + ``os.replace(`` in the
     ``_prepare_benchmark_scripts`` body.
+
+    Args:
+        text: The full ``benchmarker.py`` source text to inspect.
+
+    Returns:
+        True when the cloned Magpie already copies scripts atomically (making
+        the #C1 patch redundant), False otherwise.
     """
     if _UPSTREAM_ATOMIC_HELPER in text:
         return True
@@ -344,12 +381,27 @@ def _apply_patch_atomic_reason(src: Path) -> str:
 
 def _apply_patch_atomic(src: Path) -> bool:
     """Bool wrapper over :func:`_apply_patch_atomic_reason`: True when the
-    atomic-copy race is closed (applied / already-patched / upstream-atomic)."""
+    atomic-copy race is closed (applied / already-patched / upstream-atomic).
+
+    Args:
+        src: The ``benchmarker.py`` file to patch in place.
+
+    Returns:
+        True when the atomic-copy race is closed, False on a genuine failure.
+    """
     return _apply_patch_atomic_reason(src) not in _ATOMIC_REASONS_GENUINE_FAILURE
 
 
 def _is_remote_trust_patched(src: Path) -> bool:
-    """Return whether the SGLang remote-client trust gate is already present."""
+    """Return whether the SGLang remote-client trust gate is already present.
+
+    Args:
+        src: The ``sglang_mi300x.sh`` file to inspect.
+
+    Returns:
+        True iff the remote-trust sentinel is present, False on a miss or read
+        error.
+    """
     try:
         return _REMOTE_TRUST_SENTINEL in src.read_text(encoding="utf-8")
     except OSError as e:
@@ -358,7 +410,16 @@ def _is_remote_trust_patched(src: Path) -> bool:
 
 
 def _apply_remote_trust_patch_atomic(src: Path) -> bool:
-    """Patch ``sglang_mi300x.sh`` so remote clients can pass trust mode."""
+    """Patch ``sglang_mi300x.sh`` so remote clients can pass trust mode.
+
+    Args:
+        src: The ``sglang_mi300x.sh`` file to patch in place.
+
+    Returns:
+        True when the trust gate is present after the call (already patched or
+        freshly written), False when the legacy block is missing or any IO
+        step fails.
+    """
     try:
         original = src.read_text(encoding="utf-8")
     except OSError as e:
@@ -439,7 +500,12 @@ class MagpiePatchStatus:
     def atomic_genuine_failure(self) -> bool:
         """True when ``atomic_ok`` is False for a real reason (unrecognized
         shape / I/O error) — i.e. the script-tearing race is NOT mitigated, as
-        opposed to a benign no-op. A strict install should fail-loud on this."""
+        opposed to a benign no-op. A strict install should fail-loud on this.
+
+        Returns:
+            True when the atomic-copy patch failed for a genuine reason
+            (unrecognized shape / I/O error), False for a benign no-op.
+        """
         return self.atomic_reason in _ATOMIC_REASONS_GENUINE_FAILURE
 
 
@@ -451,6 +517,14 @@ def magpie_scripts_patch_status(
     This keeps a drift in the optional SGLang remote-client trust patch from
     being reported as a generic atomic-copy failure. The bool-valued
     ``ensure_magpie_atomic_scripts_patch`` wrapper remains for compatibility.
+
+    Args:
+        magpie_dir: Magpie root override; falls back to ``$MAGPIE_DIR`` when
+            falsy.
+
+    Returns:
+        A ``MagpiePatchStatus`` carrying the atomic-copy and remote-trust
+        outcomes plus the classified ``atomic_reason``.
     """
     src = _resolve_benchmarker_path(magpie_dir)
     if src is None:
@@ -515,6 +589,14 @@ def ensure_magpie_atomic_scripts_patch(
     without the atomic race being open, so it is intentionally NOT folded in
     here; callers that need both must use :func:`magpie_scripts_patch_status`
     and check ``remote_trust_ok`` / ``ok`` (install.sh does this).
+
+    Args:
+        magpie_dir: Magpie root override; falls back to ``$MAGPIE_DIR`` when
+            falsy.
+
+    Returns:
+        True when the atomic-copy race is closed, False when the file is
+        missing or neither the legacy block nor an atomic impl is found.
     """
     return magpie_scripts_patch_status(magpie_dir).atomic_ok
 

--- a/inference_optimizer/orchestrator/action_executors/_multi_node_env.py
+++ b/inference_optimizer/orchestrator/action_executors/_multi_node_env.py
@@ -64,6 +64,9 @@ def is_multi_node() -> bool:
     State file wins over env so ``--resume`` works (manifest.json doesn't
     persist ``nodes``): ``/tmp/multi_node_state.json`` ``nodes`` >= 2 wins;
     else fall back to ``$INFERENCE_OPTIMIZER_NODES``.
+
+    Returns:
+        True when operating on a >=2-node RayJob cluster, else False.
     """
     state = _read_state()
     try:
@@ -102,6 +105,9 @@ def rayjob_id_from_state() -> str:
     Reads the ``$MULTI_NODE_STATE_FILE`` checkpoint. Used to scope per-RayJob
     shared artefacts when ``$HYPERLOOM_MN_PROFILE_TRACE_DIR`` was not exported
     in-process.
+
+    Returns:
+        The SaFE-allocated RayJob workload id, or ``""`` if absent.
     """
     return str(_read_state().get("rayjob_id") or "").strip()
 
@@ -123,6 +129,10 @@ def magpie_remote_env() -> dict[str, str]:
     "BENCHMARK_BASE_URL": "<service_url>"}`` so Magpie skips its local server
     launch and points ``benchmark_serving`` at the head pod. Multi-node without
     a state file: ``{}`` + WARN (the local-launch failure surfaces clearly).
+
+    Returns:
+        Env vars to inject into the Magpie subprocess, or ``{}`` for the
+        single-node path or when no service URL is available.
     """
     if not is_multi_node():
         return {}
@@ -165,6 +175,12 @@ def log_mn_banner(
     Multi-node prints ``[MN component=<name> nodes=N head=<ip>
     service_url=<url> key=value ...]``; ``**extra`` keys are appended for
     round-specific context (e.g. ``trace_dir=`` / ``variant=``).
+
+    Args:
+        component: Name of the component emitting the banner.
+        target_log: Logger the banner line is written to.
+        **extra: Round-specific key/value context appended to the banner;
+            keys with empty or None values are skipped.
     """
     if not is_multi_node():
         return

--- a/inference_optimizer/orchestrator/action_executors/_multi_node_server_lifecycle.py
+++ b/inference_optimizer/orchestrator/action_executors/_multi_node_server_lifecycle.py
@@ -50,6 +50,12 @@ def _merge_sglang_defaults(extra_args: str) -> str:
 
     Mirrors ``sglang_mi300x.sh:74-79``; a caller's explicit value for a flag
     wins and that default is dropped.
+
+    Args:
+        extra_args: The caller's existing server-arg string.
+
+    Returns:
+        The merged server-arg string with missing defaults appended.
     """
     user = (extra_args or "").strip()
     parts = [user] if user else []
@@ -94,6 +100,24 @@ def _resolve_pd_args(
     Resolution per field: explicit kwarg > ``state["last_restart_pd_*"]`` >
     ``$PD_*`` env > defaults (mode=colocated, prefill/decode TP=tp). Validates
     ``pd_mode`` and disaggregated prefill/decode TP.
+
+    Args:
+        pd_mode: Prefill/decode mode (``colocated`` or ``disaggregated``).
+        pd_prefill_nodes: Node count for the prefill group.
+        pd_decode_nodes: Node count for the decode group.
+        pd_prefill_tp: Tensor-parallel size for the prefill group.
+        pd_decode_tp: Tensor-parallel size for the decode group.
+        pd_transfer_backend: KV transfer backend name.
+        pd_ib_device: InfiniBand device name.
+        tp_int: Resolved overall tensor-parallel size used as a TP default.
+
+    Returns:
+        A flat dict of resolved PD values for the multi_node CLI Namespace.
+
+    Raises:
+        ServerRestartFailed: If ``pd_mode`` is unsupported, the cluster has
+            fewer than 2 nodes for disaggregated mode, the prefill/decode node
+            split is invalid, or the prefill/decode TP values are non-positive.
     """
     state = _read_state()
     mode = (
@@ -202,8 +226,19 @@ def _resolve_round_args(
 
     Resolution per field: explicit kwarg > ``state["last_restart_*"]`` >
     ``$FRAMEWORK`` / ``$MODEL_PATH`` / ``$TP`` / ``$EP`` env > defaults (ep=1).
-    Raises :class:`ServerRestartFailed` if model/tp are empty, framework is
-    unsupported, or ``ep > tp``.
+
+    Args:
+        framework: Inference framework override (``sglang`` or ``vllm``).
+        model_path: Model path/id override.
+        tp: Tensor-parallel size override.
+        ep: Expert-parallel size override (defaults to 1).
+
+    Returns:
+        A ``(framework, model, tp, ep)`` tuple of resolved restart args.
+
+    Raises:
+        ServerRestartFailed: If model/tp are empty, the framework is
+            unsupported, or ``ep > tp``.
     """
     state = _read_state()
     fw = (framework or state.get("last_restart_framework")
@@ -274,7 +309,29 @@ async def restart_server_for_round(
     this invocation so a fresh kill+launch runs — required after kernel-agent
     fans patched source so sglang re-imports the new modules.
 
-    Raises :class:`ServerRestartFailed` on any failure (callers let it bubble).
+    Args:
+        extra_server_args: Extra framework server args for this round.
+        torch_profiler_dir: Per-round profiler trace dir; exported via
+            ``HYPERLOOM_MN_PROFILE_TRACE_DIR`` and restored afterward.
+        framework: Inference framework override.
+        model_path: Model path/id override.
+        tp: Tensor-parallel size override.
+        ep: Expert-parallel size override.
+        pd_mode: Prefill/decode mode override.
+        pd_prefill_nodes: Node count for the prefill group.
+        pd_decode_nodes: Node count for the decode group.
+        pd_prefill_tp: Tensor-parallel size for the prefill group.
+        pd_decode_tp: Tensor-parallel size for the decode group.
+        pd_transfer_backend: KV transfer backend name.
+        pd_ib_device: InfiniBand device name.
+        health_timeout_s: Timeout for the post-launch /health poll.
+        poll_interval_s: Poll interval passed to the restart driver.
+        force_full_restart: When True, force a fresh kill+launch instead of
+            resuming a running server.
+
+    Raises:
+        ServerRestartFailed: On any restart or post-launch /health failure
+            (callers let it bubble).
     """
     global _LAST_ROUND_TRACE_DIR
 
@@ -488,6 +545,14 @@ async def _wait_for_server_health_async(
 
     Reads ``service_url`` from ``state.json``; rewrites a ClusterIP DNS URL to
     ``head_pod_ip`` when available so the sandbox can reach it directly.
+
+    Args:
+        timeout_s: Maximum seconds to wait for a 200 from /health.
+        poll_every_s: Seconds between successive /health polls.
+
+    Raises:
+        ServerRestartFailed: If /health does not return 200 within
+            ``timeout_s``.
     """
     import time as _time
     import re as _re

--- a/inference_optimizer/orchestrator/action_executors/_server_patcher.py
+++ b/inference_optimizer/orchestrator/action_executors/_server_patcher.py
@@ -65,6 +65,13 @@ def _load_sglang_supported_versions_from_manifest(
 
     Returns ``None`` when no manifest exists (the common case today; a
     forward-compatible hook), or a frozenset of versions (empty = reject all).
+
+    Args:
+        patches_dir: SGLang patches directory that may ship the manifest.
+
+    Returns:
+        A frozenset of supported version strings, or ``None`` when no manifest
+        exists or it could not be read.
     """
     for name in _SGLANG_SUPPORTED_VERSIONS_MANIFEST_NAMES:
         manifest = patches_dir / name
@@ -101,6 +108,14 @@ def _sglang_version_accepted(
     ``$HYPERLOOM_SGLANG_PATCH_ALLOWED_MINORS`` (minor prefixes, ``0.5`` matches
     ``0.5.9`` not ``0.50.0``) > TraceLens ``SUPPORTED_VERSIONS`` manifest in
     ``patches_dir`` > :data:`_SGLANG_DEFAULT_ALLOWED_MINORS`.
+
+    Args:
+        version: The SGLang version string to test.
+        patches_dir: Optional patches directory consulted for the TraceLens
+            ``SUPPORTED_VERSIONS`` manifest.
+
+    Returns:
+        True iff ``version`` is accepted by the resolved allowlist.
     """
     text = (version or "").strip()
     if not text:
@@ -138,7 +153,15 @@ _PATCH_TREE_REL = ("examples", "custom_workflows", "inference_analysis")
 def _versioned_patches_subdir_name(version: str) -> str | None:
     """Map ``sglang.__version__`` to the per-version patch subdir name (e.g.
     ``0.5.11`` -> ``sglang_0_5_11``). Returns ``None`` when ``version`` has no
-    dotted numeric head."""
+    dotted numeric head.
+
+    Args:
+        version: The ``sglang.__version__`` string to map.
+
+    Returns:
+        The per-version patch subdir name, or ``None`` when ``version`` has no
+        dotted numeric head.
+    """
     text = (version or "").strip()
     if not text:
         return None
@@ -165,6 +188,13 @@ def _resolve_sglang_patches_dir(
     Requires the per-version subdir layout (``sglang_0_5_11/``, ...); the flat
     v0.3 layout is unsupported. Returns the subdir when it exists and has at
     least one ``*.patch``, else ``None`` (caller fail-softs).
+
+    Args:
+        patches_root: Root directory holding the per-version patch subdirs.
+        version: The running ``sglang`` version string.
+
+    Returns:
+        The resolved patches subdir, or ``None`` when it is missing or empty.
     """
     subdir_name = _versioned_patches_subdir_name(version)
     if subdir_name is None:
@@ -186,6 +216,14 @@ def ensure_vllm_patched_for_tracelens(
 
     Returns ``True`` when patched at exit, ``False`` on any fail-soft outcome
     (callers MUST then skip the TraceLens-only profiler flags).
+
+    Args:
+        tracelens_root: TraceLens checkout root; falls back to
+            ``$TRACELENS_ROOT`` when ``None``.
+
+    Returns:
+        True if the vLLM install is in patched state at exit, False on any
+        fail-soft outcome.
     """
     plan = _discover_vllm_plan(tracelens_root)
     if plan is None:
@@ -240,7 +278,16 @@ class _PatchPlan:
 
 def _resolve_tracelens_root(arg: Path | str | None) -> Path | None:
     """Resolve TRACELENS_ROOT from arg → env → None; fail-soft when unset or
-    missing on disk."""
+    missing on disk.
+
+    Args:
+        arg: Explicit TraceLens root override, or ``None`` to read
+            ``$TRACELENS_ROOT``.
+
+    Returns:
+        The resolved TraceLens root directory, or ``None`` when unset or
+        missing on disk.
+    """
     if arg:
         root = Path(arg)
     else:
@@ -462,6 +509,13 @@ def _resolve_sglang_apply_root(sglang_module: Path) -> tuple[Path, int] | None:
     Editable (``<repo>/python/sglang/``): ``(repo_root, 1)``. Wheel
     (``site-packages/sglang/`` with no ``python/`` parent):
     ``(<site-packages>/sglang, 3)``. Anything else: ``None`` (fail-soft).
+
+    Args:
+        sglang_module: Resolved path to the imported ``sglang`` package file.
+
+    Returns:
+        An ``(apply_root, strip_count)`` tuple, or ``None`` when the install
+        layout is unrecognized.
     """
     if sglang_module.parent.parent.name == "python":
         return sglang_module.parent.parent.parent, 1
@@ -500,7 +554,15 @@ def _ensure_patched(plan: _PatchPlan) -> bool:
 
 def _is_patched(plan: _PatchPlan) -> bool:
     """True iff the sentinel file (and every extra_sentinel) exists with all of
-    its marker substrings present. The all-of-N rule lowers false positives."""
+    its marker substrings present. The all-of-N rule lowers false positives.
+
+    Args:
+        plan: The resolved patch plan whose sentinels are inspected.
+
+    Returns:
+        True when every sentinel file exists with all required markers, False
+        otherwise (including on read error).
+    """
     try:
         if not plan.sentinel_file.exists():
             return False
@@ -523,7 +585,14 @@ def _is_patched(plan: _PatchPlan) -> bool:
 @contextmanager
 def _file_lock(path: str) -> Iterator[None]:
     """Best-effort cross-process exclusion; proceeds unsynchronized if ``/tmp``
-    is read-only (the second patcher re-checks the sentinel and short-circuits)."""
+    is read-only (the second patcher re-checks the sentinel and short-circuits).
+
+    Args:
+        path: Filesystem path of the lock file to acquire exclusively.
+
+    Yields:
+        Control while the exclusive lock is held; the lock is released on exit.
+    """
     try:
         fp = open(path, "w")
     except OSError as e:
@@ -549,6 +618,13 @@ def _apply_atomic(plan: _PatchPlan) -> bool:
     ``git apply --check`` every patch first (any failure → apply none); then
     apply one at a time, reverse-applying the already-applied ones if a later
     patch fails.
+
+    Args:
+        plan: The resolved patch plan to apply as a transaction.
+
+    Returns:
+        True when every patch is applied (or already applied), False on any
+        precheck/apply failure (with already-applied patches rolled back).
     """
     git = shutil.which("git")
     if git is None:
@@ -678,6 +754,15 @@ def _patch_dry_run(
     Fuzzy fallback (zero side effects) when ``git apply --check`` rejects a
     patch for minor context drift. ``strip`` matches git apply's ``-p<N>``.
     See :data:`_FUZZ`.
+
+    Args:
+        patch_bin: Path to the ``patch`` executable.
+        patch_file: The patch file to dry-run.
+        cwd: Working directory the patch is tested relative to.
+        strip: The ``-p<N>`` strip count.
+
+    Returns:
+        True iff the dry-run exits with return code 0.
     """
     try:
         with patch_file.open("rb") as fh:

--- a/inference_optimizer/orchestrator/action_executors/_subprocess_kill.py
+++ b/inference_optimizer/orchestrator/action_executors/_subprocess_kill.py
@@ -33,6 +33,10 @@ _TERM_GRACE_SECONDS = 5.0
 def new_session_kwargs() -> dict:
     """``Popen`` kwargs so the child gets its own POSIX session (killable via
     ``os.killpg``). Returns ``{}`` on non-POSIX.
+
+    Returns:
+        A kwargs dict to splat into ``Popen``; ``{"start_new_session": True}``
+        on POSIX, otherwise an empty dict.
     """
     if os.name == "posix":
         return {"start_new_session": True}
@@ -44,6 +48,13 @@ def _process_group_alive(pgid: int) -> bool:
 
     ``killpg(pgid, 0)`` raises ``ProcessLookupError`` once the group is empty;
     any other ``OSError`` (e.g. sandbox ``EPERM``) is treated as "still alive".
+
+    Args:
+        pgid: The POSIX process-group id to probe.
+
+    Returns:
+        True if the group still has at least one member (or liveness is
+        indeterminate), False once the group is empty or on non-POSIX.
     """
     if os.name != "posix":
         return False
@@ -88,6 +99,12 @@ def kill_my_spawned_server(
     warning on unexpected signalling failure). Requires the child to have been
     launched with :func:`new_session_kwargs` so its pgid is distinct from
     Hyperloom's own; asserted defensively below.
+
+    Args:
+        proc: The spawned process whose tree should be reaped; ``None`` is a
+            no-op.
+        grace_seconds: Seconds to wait after SIGTERM before SIGKILLing
+            survivors.
     """
     if proc is None:
         return
@@ -306,6 +323,13 @@ def _server_log_shows_death(path: str) -> bool:
 
     Best-effort and never raises: a missing / unreadable log (server hasn't
     written yet) reads as "not dead" so a slow cold start is never misjudged.
+
+    Args:
+        path: Filesystem path to the server's ``server.log``.
+
+    Returns:
+        True if the log tail contains a terminal engine/worker-init marker,
+        False otherwise (including when the log is missing or unreadable).
     """
     try:
         with open(path, "rb") as fh:
@@ -330,6 +354,15 @@ def server_log_death_excerpt(path: str, *, max_chars: int = 1200) -> str | None:
     excerpt keeps a couple of lines of context around the marker so the
     operator-facing ``error`` field is actionable. Best-effort: a missing /
     unreadable log reads as "no marker" (returns ``None``).
+
+    Args:
+        path: Filesystem path to the server's ``server.log``.
+        max_chars: Maximum length of the returned excerpt; the tail is kept
+            when the excerpt is longer.
+
+    Returns:
+        A short multi-line excerpt around the first terminal init marker, or
+        ``None`` when no fatal marker is present.
     """
     try:
         with open(path, "rb") as fh:
@@ -385,6 +418,30 @@ def run_with_session_kill(
     ``returncode = SERVER_DEAD_RETURNCODE`` is returned (does NOT raise). This
     turns a crashed-but-hung server (parent never exits, ``/health`` polled
     forever) into a fast fail instead of a ~2h hard-timeout stall.
+
+    Args:
+        cmd: The command and arguments to execute.
+        env: Optional environment mapping for the child process.
+        cwd: Optional working directory for the child process.
+        timeout: Hard timeout in seconds; ``TimeoutExpired`` is re-raised on
+            elapse, as with ``subprocess.run``.
+        text: Whether to capture stdout/stderr as ``str`` (vs ``bytes``).
+        soft_deadline_sec: Optional deadline firing before ``timeout``; on
+            elapse the tree is reaped and ``OVERTIME_KILL_RETURNCODE`` is
+            returned without raising.
+        server_log_path: Optional path to the spawned server's ``server.log``
+            to enable the server-liveness watchdog.
+        server_dead_grace_sec: Grace period a terminal init marker must persist
+            before the watchdog reaps the tree; defaults to the
+            ``INFERENCE_OPTIMIZER_SERVER_DEAD_GRACE_SEC`` env value or 120s.
+
+    Returns:
+        A ``CompletedProcess`` carrying the child's returncode (or one of the
+        sentinel returncodes when a soft deadline or the watchdog fired) plus
+        its captured stdout/stderr.
+
+    Raises:
+        subprocess.TimeoutExpired: When the hard ``timeout`` elapses.
     """
     if server_dead_grace_sec is None:
         try:
@@ -542,6 +599,28 @@ def _communicate_with_soft_deadline(
 
     The ``hard_timeout`` is always honoured so a stuck child can't dodge the
     gates.
+
+    Args:
+        proc: The running child process to wait on.
+        hard_timeout: Hard timeout in seconds; always enforced.
+        soft_deadline_sec: Optional soft deadline that trips before the hard
+            timeout.
+        server_log_path: Optional path to the server's ``server.log`` enabling
+            the liveness watchdog.
+        server_dead_grace_sec: Grace period a terminal init marker must persist
+            before the watchdog trips.
+        capture: Optional stream capture whose threads are joined to assemble
+            the returned output.
+
+    Returns:
+        A ``(stdout, stderr)`` tuple (``str`` or ``bytes`` per the capture
+        mode).
+
+    Raises:
+        _SoftDeadlineExceeded: When the soft deadline elapses.
+        _ServerDeadDetected: When a terminal init marker persists past the
+            grace window.
+        subprocess.TimeoutExpired: When the hard timeout elapses.
     """
     watchdog_active = bool(server_log_path) and (
         server_dead_grace_sec is not None and float(server_dead_grace_sec) > 0.0

--- a/inference_optimizer/orchestrator/action_executors/_workload_envs.py
+++ b/inference_optimizer/orchestrator/action_executors/_workload_envs.py
@@ -62,6 +62,9 @@ def _visible_gpu_count() -> int:
     tests happy), falls back to ``rocm-smi --showid``. Returns 0 on every
     failure so callers skip the clamp. Override via
     ``$INFERENCE_OPTIMIZER_VISIBLE_GPU_COUNT``.
+
+    Returns:
+        The number of visible GPUs, or 0 when none/unknown.
     """
     override = os.environ.get("INFERENCE_OPTIMIZER_VISIBLE_GPU_COUNT", "").strip()
     if override:
@@ -107,6 +110,9 @@ def _tracelens_patch_enabled() -> bool:
     Set ``HYPERLOOM_ENABLE_PATCH=0`` to disable runtime patching of vLLM /
     SGLang (keeps today's safe behaviour, no TraceLens-only flags injected).
     Default on because the patches are backward-compatible.
+
+    Returns:
+        True when runtime patching is enabled (default), else False.
     """
     return os.environ.get("HYPERLOOM_ENABLE_PATCH", "1").strip() != "0"
 
@@ -156,7 +162,23 @@ def materialize_config_with_envs(
     ``$INFERENCEX_PATH`` for existing callers). ``extra_server_args`` routes
     into the framework env; ``extra_envs`` overrides any of the above.
 
-    Returns the materialized YAML path (stable file name across calls).
+    Args:
+        config_path: Path to the source Magpie YAML to render.
+        output_dir: Directory the materialized YAML is written into.
+        extra_server_args: Extra framework server args merged into the env.
+        extra_envs: Overrides applied last over any computed env values.
+        model_path: Model path/id; overrides ``benchmark.model`` when set.
+        gpu_type: GPU type; sets ``runner_type`` and pins the generic script.
+        inferencex_path: Explicit InferenceX checkout to pin into the YAML.
+        benchmark_script: Pre-sanitized benchmark script name to re-pin.
+        out_name: File name for the materialized YAML.
+
+    Returns:
+        The materialized YAML path (stable file name across calls).
+
+    Raises:
+        FrameworkScriptMismatchError: If ``benchmark_script`` targets a
+            different known framework than the run's framework.
     """
     server_args = (extra_server_args or "").strip()
     with config_path.open(encoding="utf-8") as f:

--- a/inference_optimizer/orchestrator/action_executors/baseline.py
+++ b/inference_optimizer/orchestrator/action_executors/baseline.py
@@ -139,6 +139,12 @@ def _path_fstype(path: str) -> str:
     Picks the longest mountpoint that is a prefix of the resolved path.
     Returns ``""`` when it cannot be determined (non-Linux, unreadable
     ``/proc/mounts``, ...), which callers treat as "assume local".
+
+    Args:
+        path: The filesystem path to classify.
+
+    Returns:
+        The filesystem type string, or ``""`` when it cannot be determined.
     """
     try:
         rp = os.path.realpath(path)
@@ -172,7 +178,14 @@ def _path_fstype(path: str) -> str:
 
 
 def _is_network_fs(path: str) -> bool:
-    """True when ``path`` is backed by a revocable network filesystem."""
+    """True when ``path`` is backed by a revocable network filesystem.
+
+    Args:
+        path: The filesystem path to classify.
+
+    Returns:
+        True when ``path`` is backed by a known network filesystem type.
+    """
     return _path_fstype(path).lower() in _NETWORK_FS_TYPES
 
 
@@ -188,6 +201,12 @@ def _mirror_lock(lock_path: str) -> Iterator[None]:
     wait for the winner and then overwrite a consistent tree. Degrades to no
     exclusion when ``fcntl`` is unavailable (non-Linux) or the lock file
     cannot be opened — the unique staging dir still prevents torn copies.
+
+    Args:
+        lock_path: Filesystem path of the lock file to acquire exclusively.
+
+    Yields:
+        Control while the exclusive lock is held; the lock is released on exit.
     """
     try:
         import fcntl
@@ -238,6 +257,15 @@ def _ensure_local_inferencex(src: str, *, mirror_key: str = "") -> str:
     materialized YAML first) patches the LOCAL mirror in place — the mirror
     therefore ends up carrying the NUM_PROMPTS / PROFILE_EXTRA_BODY patches,
     and Magpie ``cd``-s into the patched local copy.
+
+    Args:
+        src: The InferenceX checkout path to mirror.
+        mirror_key: Optional caller-supplied key (e.g. task output dir) that
+            isolates concurrent tasks sharing the same source checkout.
+
+    Returns:
+        A local-disk mirror path, or ``src`` unchanged when relocation is
+        disabled, unnecessary, or fails.
     """
     src = str(src)
     if os.environ.get(
@@ -325,6 +353,10 @@ def _resolve_aiter_jit_dir_dynamic() -> list[str]:
     pre-built ``.so``); the legacy fixed ``jit/build`` list mis-reports
     every wheel install as COLD. Returns an ordered candidate list
     (``jit`` preferred over ``jit/build``); empty if aiter not found.
+
+    Returns:
+        An ordered list of candidate ``jit`` directory paths, or ``[]`` when
+        aiter is not importable.
     """
     try:
         spec = importlib.util.find_spec("aiter")
@@ -458,6 +490,13 @@ class BaselineExecutor:
 
         Order: ``task.params['output_dir']`` → ``ctx.extra['workspace']``
         → ``runs_dir(...)`` (direct-instantiation fallback for tests).
+
+        Args:
+            ctx: The runner context carrying task params and ``extra``.
+            action: The action name used to build the fallback runs dir.
+
+        Returns:
+            The resolved per-task workspace directory.
         """
         params = ctx.task.params or {}
         if params.get("output_dir"):
@@ -474,6 +513,12 @@ class BaselineExecutor:
         when the aiter jit probe reports COLD (env-overridable via
         ``INFERENCE_OPTIMIZER_COLD_START_TIMEOUT_SEC``) → warm default.
         Every path emits one log line for greppability.
+
+        Args:
+            params: The task params, optionally carrying ``timeout_sec``.
+
+        Returns:
+            The resolved subprocess timeout in seconds.
         """
         explicit = params.get("timeout_sec")
         if explicit:
@@ -524,6 +569,14 @@ class BaselineExecutor:
 
         ProfileExecutor uses this to patch/validate the InferenceX checkout
         named by the rendered YAML. No-op default keeps baseline unchanged.
+
+        Args:
+            config_path: The materialized Magpie YAML config path.
+            output_dir: The per-task output directory.
+
+        Returns:
+            ``None`` to proceed with the launch, or a failure result dict to
+            short-circuit (subclasses only).
         """
         return None
 
@@ -777,6 +830,12 @@ class BaselineExecutor:
 
         Returns a dict with ``eligible`` (bool), ``framework`` (str),
         ``port`` (int) and ``reason`` (str, populated when ineligible).
+
+        Args:
+            materialized_config_path: The materialized YAML config to inspect.
+
+        Returns:
+            A dict with ``eligible``, ``framework``, ``port`` and ``reason``.
         """
         info: dict[str, Any] = {
             "eligible": False,
@@ -836,6 +895,16 @@ class BaselineExecutor:
 
         Both rounds share ``pid_dir`` + ``port`` so round 2 re-attaches;
         only ``cleanup`` differs (round 1 persists, round 2 tears down).
+
+        Args:
+            base_config_path: The base materialized YAML to extend.
+            dest_dir: Directory the per-round YAML is written into.
+            cleanup: Whether this round tears down the persistent server.
+            pid_dir: Shared directory keying the persistent server pid/meta.
+            port: HTTP port pinned for the persistent server.
+
+        Returns:
+            The path to the rendered per-round lifecycle YAML.
         """
         with Path(base_config_path).open(encoding="utf-8") as f:
             cfg = yaml.safe_load(f) or {}
@@ -866,6 +935,11 @@ class BaselineExecutor:
         """Best-effort teardown of a persistent server left by the
         double-run rounds. Idempotent and never raises (safe in finally);
         a no-op on the happy path, real work only on abnormal paths.
+
+        Args:
+            pid_dir: Directory holding the persistent server pid/meta files.
+            framework: Framework name used to key the pid/meta filenames.
+            port: HTTP port used to key the pid/meta filenames.
         """
         base = Path(pid_dir)
         tag = f"{framework}_{port}"
@@ -923,6 +997,22 @@ class BaselineExecutor:
 
         Single-round core extracted from ``__call__`` so the cold-start
         guard can invoke it twice. ``output_dir`` is the per-round slot.
+
+        Args:
+            config_path: The materialized Magpie YAML config to run.
+            output_dir: The per-round output directory.
+            timeout_sec: Hard subprocess timeout in seconds.
+            override_result_dir: Optional ``$RESULT_DIR`` override, or ``None``.
+            resolved_model: The resolved model path (may be empty).
+            materialized_config_path: The canonical materialized config path
+                surfaced in the result for downstream reuse.
+            inferencex_path: The InferenceX checkout path Magpie should use.
+            params: The task params forwarded to server restart logic.
+            ctx: The runner context (carries ``extra`` flags).
+
+        Returns:
+            A result dict (``status="succeeded"`` with measurements, or
+            ``status="failed"`` with an ``error_class``).
         """
         cmd = [
             self.magpie_python, "-m", "Magpie", "-v", "benchmark",

--- a/inference_optimizer/orchestrator/action_executors/benchmark_result.py
+++ b/inference_optimizer/orchestrator/action_executors/benchmark_result.py
@@ -173,6 +173,14 @@ def _rescue_candidate_paths(
     When ``subprocess_started_unix`` is given, candidates older than it
     (minus :data:`_MTIME_GATE_SLACK_SEC`) are dropped as stale prior-run
     leaks. Never raises: per-candidate I/O errors are swallowed.
+
+    Args:
+        workspace: The per-task workspace; in-workspace files are skipped.
+        subprocess_started_unix: Optional launch time used to drop stale
+            prior-run leaks.
+
+    Returns:
+        Absolute paths to fresh, out-of-workspace Magpie leak destinations.
     """
     candidates: list[Path] = []
     seen: set[Path] = set()
@@ -247,6 +255,14 @@ def _materialize_rescue_into_workspace(
     self-contained. Returns the destination on success, or ``None`` on I/O
     error (caller falls back to the leak path) or when the source already
     lives inside the workspace.
+
+    Args:
+        rescue_path: The leaked InferenceX result file to copy in.
+        workspace: The per-task workspace to copy the result into.
+
+    Returns:
+        The in-workspace destination path on success, or ``None`` on I/O error
+        or when the source already lives inside the workspace.
     """
     try:
         rescue_resolved = rescue_path.resolve()
@@ -277,6 +293,13 @@ def _resolve_leak_roots(leak_root: Path | None) -> tuple[Path, ...]:
     Order: explicit ``leak_root`` kwarg (tests) →
     ``$INFERENCE_OPTIMIZER_LEAK_ROOTS`` (colon-separated) →
     :data:`_DEFAULT_LEAK_ARTIFACT_ROOT` (``/workspace``).
+
+    Args:
+        leak_root: Optional explicit root override (used by tests); when
+            ``None`` the env var or default is used.
+
+    Returns:
+        A tuple of directory roots to scan for wrapper-side leak files.
     """
     if leak_root is not None:
         return (leak_root,)
@@ -303,6 +326,17 @@ def harvest_leaked_artifacts(
     ``shutil.copy2``-s each match (source never moved). Returns
     ``(leak_path, copy_path)`` tuples for audit; never raises (per-artifact
     errors are isolated).
+
+    Args:
+        destination: Directory the harvested artifacts are copied into.
+        subprocess_started_unix: Optional launch time used to skip stale
+            prior-run leaks.
+        leak_root: Optional explicit root override forwarded to
+            :func:`_resolve_leak_roots`.
+        extra_globs: Additional filename globs to harvest beyond the defaults.
+
+    Returns:
+        A list of ``(leak_path, copy_path)`` tuples for the artifacts copied.
     """
     harvested: list[tuple[Path, Path]] = []
     leak_roots = _resolve_leak_roots(leak_root)
@@ -440,6 +474,17 @@ def extract_benchmark_measurement(
     ``subprocess_started_unix`` enables an opt-in salvage pass over the
     Magpie leak destinations (see :func:`_rescue_candidate_paths`) when the
     in-workspace search fails; only leaks written after this run are adopted.
+
+    Args:
+        report: The Magpie ``benchmark_report.json`` mapping, or ``None``.
+        workspace: Optional task workspace scanned for raw InferenceX results
+            and (as a fallback) salvageable leaks.
+        subprocess_started_unix: Optional launch time enabling the mtime-gated
+            leak salvage pass.
+
+    Returns:
+        A normalized measurement dict (including ``valid_measurement`` and any
+        ``nonfatal_warnings``).
     """
     report = report or {}
     throughput = report.get("throughput") or {}
@@ -533,6 +578,11 @@ def _derive_tpot_if_missing(
     Best-effort: only derives when end-to-end and TTFT latencies are
     available and an output sequence length greater than 1 can be
     resolved from the report. Leaves the field untouched otherwise.
+
+    Args:
+        measurement: The measurement dict to fill in place.
+        report: The Magpie report mapping used to resolve the output sequence
+            length, or ``None``.
     """
     if measurement.get("tpot_mean_ms") is not None:
         return
@@ -547,7 +597,14 @@ def _derive_tpot_if_missing(
 
 
 def _resolve_osl(report: dict[str, Any] | None) -> int | None:
-    """Pull the output sequence length from common report locations."""
+    """Pull the output sequence length from common report locations.
+
+    Args:
+        report: The Magpie report mapping to search, or ``None``.
+
+    Returns:
+        The first positive output sequence length found, or ``None``.
+    """
     if not isinstance(report, dict):
         return None
     candidates: list[Any] = [report.get("osl"), report.get("output_len")]

--- a/inference_optimizer/orchestrator/action_executors/explore.py
+++ b/inference_optimizer/orchestrator/action_executors/explore.py
@@ -123,6 +123,12 @@ def _coerce_args_str(value: Any) -> str:
     ``vllm serve ... $EXTRA_VLLM_ARGS`` splices verbatim, so the server rejects
     it as ``unrecognized arguments`` and every server-arg variant aborts.
     Lists/tuples are space-joined into individual tokens.
+
+    Args:
+        value: The raw payload value (string, list/tuple, or None).
+
+    Returns:
+        The coerced shell-arg string ("" when ``value`` is None).
     """
     if value is None:
         return ""
@@ -150,6 +156,12 @@ def _grid_variants_from_payload(payload: list[Any]) -> list[GridVariant]:
 
     Unknown keys ignored; unstamped ``provenance`` defaults to
     ``'default_grid'`` (keeps seed grids distinct from ``'llm_direct'``).
+
+    Args:
+        payload: List of variant dicts from the LLM/specialist grid.
+
+    Returns:
+        The parsed ``GridVariant`` objects (entries without a name skipped).
     """
     out: list[GridVariant] = []
     for raw in payload or []:
@@ -207,6 +219,15 @@ def _atom_default_grid(
     ``apply_compatibility_filter`` is the second-line drop for flags not in
     ``atom --help``. Variant names are ``atom_``-prefixed for cross-session
     disambiguation.
+
+    Args:
+        model_class: Model-class label that gates which variants are emitted.
+        conc: Live concurrency used to bracket cudagraph capture sizes.
+        isl: Input sequence length (reserved for future gating).
+        osl: Output sequence length (reserved for future gating).
+
+    Returns:
+        The curated list of atom ``GridVariant`` seeds.
     """
     mc_l = (model_class or "").strip().lower()
     is_moe = "moe" in mc_l
@@ -287,6 +308,16 @@ def _default_grid_for_framework(
 
     Atom returns a curated seed grid; sglang / vllm / unknown return ``[]``
     ("no programmatic seed") and rely on LLM-emitted ``default_grid`` variants.
+
+    Args:
+        framework: Inference framework name to dispatch on.
+        model_class: Model-class label forwarded to the seed grid builder.
+        conc: Live concurrency forwarded to the seed grid builder.
+        isl: Input sequence length forwarded to the seed grid builder.
+        osl: Output sequence length forwarded to the seed grid builder.
+
+    Returns:
+        The framework's default ``GridVariant`` seeds, or ``[]`` when none.
     """
     fw = (framework or "").strip().lower()
     if fw == "atom":

--- a/inference_optimizer/orchestrator/action_executors/framework_pr.py
+++ b/inference_optimizer/orchestrator/action_executors/framework_pr.py
@@ -103,7 +103,15 @@ DEFAULT_DIFF_FETCH_TIMEOUT_SEC: float = 30.0
 # resets HEAD to the pre-apply sha so a failed REJECT can't clobber prior KEEPs.
 def _git_head_sha(framework_root: Path) -> tuple[str | None, str]:
     """``git rev-parse HEAD`` in ``framework_root``; ``(sha, stderr)``,
-    sha None on failure."""
+    sha None on failure.
+
+    Args:
+        framework_root: The git checkout to read HEAD from.
+
+    Returns:
+        A ``(sha, stderr)`` tuple; ``sha`` is ``None`` on failure with the
+        error text in ``stderr``.
+    """
     cmd = ["git", "-C", str(framework_root), "rev-parse", "HEAD"]
     try:
         cp = subprocess.run(
@@ -119,7 +127,16 @@ def _git_head_sha(framework_root: Path) -> tuple[str | None, str]:
 def _git_reset_hard(framework_root: Path, sha: str) -> tuple[bool, str]:
     """Revert ``framework_root`` to ``sha``: ``git reset --hard`` +
     ``git clean -fd`` (discards untracked files the candidate added) so a
-    failed candidate can't leak state into the next candidate's baseline."""
+    failed candidate can't leak state into the next candidate's baseline.
+
+    Args:
+        framework_root: The git checkout to reset.
+        sha: The commit sha to reset ``--hard`` to.
+
+    Returns:
+        A ``(ok, stderr)`` tuple; ``ok`` is False on failure with the error
+        text in ``stderr``.
+    """
     cmd = ["git", "-C", str(framework_root), "reset", "--hard", sha]
     try:
         cp = subprocess.run(
@@ -147,7 +164,16 @@ def _git_commit_keep(
     """``git add -A && git commit`` with a forced hyperloom identity (``-c``,
     Magpie clones may lack user.email), returning the new HEAD sha. ``add -A``
     (not ``commit -am``) so add-only PRs' new files land in the KEEP commit
-    instead of polluting the next candidate's baseline."""
+    instead of polluting the next candidate's baseline.
+
+    Args:
+        framework_root: The git checkout to commit into.
+        message: The commit message for the KEEP commit.
+
+    Returns:
+        A ``(new_sha, stderr)`` tuple; ``new_sha`` is ``None`` on failure with
+        the error text in ``stderr``.
+    """
     add = ["git", "-C", str(framework_root), "add", "-A"]
     try:
         cp_add = subprocess.run(
@@ -180,7 +206,15 @@ def _git_commit_keep(
 
 def _candidate_slug(candidate: dict[str, Any]) -> str:
     """Filesystem-safe candidate id (variant names + paths). Prefer
-    ``repo/pr_number``."""
+    ``repo/pr_number``.
+
+    Args:
+        candidate: The PR metadata row.
+
+    Returns:
+        A filesystem-safe slug derived from the candidate's repo / pr_number
+        / ref.
+    """
     repo = str(candidate.get("repo") or "").replace("/", "-")
     pr = candidate.get("pr_number")
     if repo and pr not in (None, "", 0):
@@ -196,7 +230,17 @@ def _fetch_diff_to_path(
 ) -> tuple[bool, str]:
     """Curl ``diff_url`` into ``dest`` (.patch path); returns ``(ok, stderr)``.
     Uses curl (not aiohttp) for consistent HTTPS_PROXY behaviour in
-    restricted-network sessions."""
+    restricted-network sessions.
+
+    Args:
+        diff_url: The unified-diff URL to download.
+        dest: Destination ``.patch`` path to write.
+        timeout_sec: Per-request curl timeout in seconds.
+
+    Returns:
+        A ``(ok, stderr)`` tuple; ``ok`` is False on failure with the error
+        text in ``stderr``.
+    """
     dest.parent.mkdir(parents=True, exist_ok=True)
     cmd = [
         "curl", "-fsSL", "--retry", "2", "--max-time",
@@ -244,7 +288,14 @@ def _run_git(
 
 def _normalize_repo_id(url_or_slug: str) -> str:
     """Reduce a repo URL / slug to a canonical lowercase ``owner/name`` token.
-    Tolerates https, ssh, and bare ``Owner/Name`` forms."""
+    Tolerates https, ssh, and bare ``Owner/Name`` forms.
+
+    Args:
+        url_or_slug: A repo URL or slug in any supported form.
+
+    Returns:
+        The canonical lowercase ``owner/name`` token, or ``""`` when empty.
+    """
     s = (url_or_slug or "").strip().lower()
     if not s:
         return ""
@@ -270,7 +321,16 @@ def _candidate_is_same_repo(
     resolve the wrong ref).
 
     Fails OPEN when inconclusive (no candidate repo, unreadable / non-GitHub
-    origin); only fires when both sides yield differing ``owner/name`` tokens."""
+    origin); only fires when both sides yield differing ``owner/name`` tokens.
+
+    Args:
+        candidate: The PR metadata row (carries the candidate repo).
+        framework_root: The live framework checkout whose origin is compared.
+
+    Returns:
+        True unless the candidate is positively proven to live in a different
+        repo than ``framework_root``'s origin.
+    """
     cand_repo = _normalize_repo_id(
         str(candidate.get("repo") or candidate.get("discovered_repo_url") or "")
     )
@@ -307,6 +367,16 @@ def _materialize_pr_diff_via_worktree(
 
     Head ref order: ``candidate.head_sha`` → ``candidate.ref`` →
     ``refs/pull/<pr_number>/head``.
+
+    Args:
+        framework_root: The live framework checkout to fetch the PR head into.
+        candidate: The PR metadata row (head_sha / ref / pr_number).
+        dest: Destination ``.patch`` path the net diff is written to.
+        timeout_sec: Per-git-operation timeout in seconds.
+
+    Returns:
+        A ``(ok, err)`` tuple; ``ok`` is False on failure with the error text
+        in ``err``.
     """
     dest.parent.mkdir(parents=True, exist_ok=True)
     root = str(framework_root)
@@ -858,6 +928,14 @@ class FrameworkPrExecutor:
 
         Best-effort: candidates lacking both ``pr_url`` and ``head_sha``
         (no dedup key) are skipped; write errors are logged + swallowed.
+
+        Args:
+            candidate: The PR metadata row (provides the dedup key).
+            outcome: The outcome label to record (e.g. integrated / reverted).
+            tps_delta_pct: The measured throughput delta percentage.
+            patch_path: Path to the applied patch (for provenance).
+            extra: The runner ``extra`` mapping (provides the shared state /
+                session id).
         """
         pr_url = str(candidate.get("pr_url") or "").strip()
         pr_sha = str(candidate.get("head_sha") or "").strip()
@@ -900,6 +978,15 @@ class FrameworkPrExecutor:
         <pre_apply_sha>`` (prior KEEPs are committed past that sha, so they
         survive). Returns the patches reverted (full ``applied`` on success,
         empty on failure) for telemetry / schema compat.
+
+        Args:
+            framework_root: The git checkout to reset, or ``None`` (no-op).
+            applied: The patches applied this candidate.
+            pre_apply_sha: The HEAD sha captured before this candidate applied.
+
+        Returns:
+            The reverted patches (full ``applied`` on success, ``[]`` on
+            failure or no-op).
         """
         if framework_root is None or not applied:
             return []
@@ -919,7 +1006,17 @@ class FrameworkPrExecutor:
         slug: str,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         """Run a 1-variant Magpie bench under the patched server + accuracy
-        gate. Mirrors :meth:`IntegratePatchExecutor._bench_patch`."""
+        gate. Mirrors :meth:`IntegratePatchExecutor._bench_patch`.
+
+        Args:
+            params: The task params (config / model / bench knobs).
+            output_root: The per-task workspace root for the bench.
+            slug: The candidate slug used to name the variant.
+
+        Returns:
+            A ``(bench, gate_evidence)`` tuple: the bench result dict and a
+            dict carrying the ``accuracy_pass`` verdict.
+        """
         config_path = Path(
             params.get("config_path")
             or self.default_config_path

--- a/inference_optimizer/orchestrator/action_executors/integrate_patch.py
+++ b/inference_optimizer/orchestrator/action_executors/integrate_patch.py
@@ -105,6 +105,13 @@ def _resolve_framework_root(explicit: str | None) -> Path | None:
 
     Precedence: explicit param → first existing
     ``resolve_source_file_allowlist()`` entry. None when nothing resolves.
+
+    Args:
+        explicit: Explicit framework-root override, or ``None`` to use the
+            allowlist.
+
+    Returns:
+        The resolved framework source root, or ``None`` when nothing resolves.
     """
     if explicit:
         p = Path(explicit)
@@ -139,7 +146,18 @@ def _run_git_apply(
     framework_root: Path, patch_path: Path, *, p_level: int,
     three_way: bool, check_only: bool,
 ) -> tuple[bool, str]:
-    """Single ``git apply`` invocation at an explicit strip level."""
+    """Single ``git apply`` invocation at an explicit strip level.
+
+    Args:
+        framework_root: The git checkout to apply into.
+        patch_path: The patch file to apply.
+        p_level: The ``-p<N>`` strip level.
+        three_way: Whether to pass ``-3`` for a three-way merge.
+        check_only: Whether to pass ``--check`` (dry run, no mutation).
+
+    Returns:
+        A ``(ok, stderr)`` tuple; ``ok`` is True on a zero return code.
+    """
     cmd = ["git", "-C", str(framework_root), "apply", f"-p{p_level}"]
     if three_way:
         cmd.append("-3")
@@ -167,6 +185,14 @@ def _preflight_missing_targets(
     Defense-in-depth: ``specialist_patch_safety`` already drops these at
     authoring time, but patches supplied directly via ``params.patches``
     bypass that gate.
+
+    Args:
+        framework_root: The git checkout the patches target.
+        patch_paths: The patch files to preflight.
+
+    Returns:
+        A list of per-patch records (``patch`` + ``missing_targets``) for
+        patches whose targets are absent at every strip level.
     """
     records: list[dict[str, Any]] = []
     for patch in patch_paths:
@@ -183,7 +209,17 @@ def _preflight_missing_targets(
 def _detect_p_level(
     framework_root: Path, patch_path: Path, *, three_way: bool,
 ) -> int | None:
-    """Return the first ``-p`` level whose ``--check`` applies cleanly."""
+    """Return the first ``-p`` level whose ``--check`` applies cleanly.
+
+    Args:
+        framework_root: The git checkout to test against.
+        patch_path: The patch file to probe.
+        three_way: Whether to probe with ``-3``.
+
+    Returns:
+        The first ``-p<N>`` level that applies cleanly, or ``None`` when none
+        do.
+    """
     for lvl in _P_LEVELS:
         ok, _ = _run_git_apply(
             framework_root, patch_path, p_level=lvl,
@@ -200,7 +236,18 @@ def _git_apply(
 ) -> tuple[bool, str]:
     """Run ``git apply [-3] -p<auto> [--check] <patch>`` inside
     ``framework_root``, auto-detecting the strip level. Returns
-    ``(ok, stderr)``."""
+    ``(ok, stderr)``.
+
+    Args:
+        framework_root: The git checkout to apply into.
+        patch_path: The patch file to apply.
+        three_way: Whether to pass ``-3`` for a three-way merge.
+        check_only: Whether to only check (dry run) rather than mutate.
+
+    Returns:
+        A ``(ok, stderr)`` tuple; ``ok`` is True when the apply (or check)
+        succeeds.
+    """
     lvl = _detect_p_level(framework_root, patch_path, three_way=three_way)
     if lvl is None:
         # Surface a representative error at the git-native default level.
@@ -221,7 +268,16 @@ def _git_apply_reverse(
 ) -> tuple[bool, str]:
     """Reverse-apply ``patch_path`` (``git apply -R -p<auto>``) as the REVERT
     path; caller falls back to ``git checkout`` on failure. Auto-detects the
-    same strip level the forward apply used via ``-R --check``."""
+    same strip level the forward apply used via ``-R --check``.
+
+    Args:
+        framework_root: The git checkout to reverse-apply into.
+        patch_path: The patch file to reverse-apply.
+
+    Returns:
+        A ``(ok, stderr)`` tuple; ``ok`` is True when the reverse apply
+        succeeds.
+    """
     for lvl in _P_LEVELS:
         check = [
             "git", "-C", str(framework_root), "apply", "-R", f"-p{lvl}",
@@ -286,6 +342,15 @@ def _resolve_patch_paths(
     Order: ``params.patches`` → ``specialist_done.patches_written`` →
     filesystem scan of ``specialist_workspace/{worktree/,}patches/``.
     Entries normalised to absolute Paths; missing ones logged + dropped.
+
+    Args:
+        specialist_workspace: The specialist task workspace to resolve
+            relative paths / scan for patches.
+        explicit_patches: Explicit patch paths from params, or ``None``.
+        done_payload: The parsed ``specialist_done.json`` payload, or ``None``.
+
+    Returns:
+        The resolved, existing patch files as absolute Paths.
     """
     candidates: list[str] = []
     if explicit_patches:
@@ -719,6 +784,13 @@ class IntegratePatchExecutor:
         """Return the first proposal whose provenance starts with
         ``specialist:serving:framework_pr`` (F2-5); ``None`` otherwise so
         the KB writeback hook no-ops for legacy / kernel outputs.
+
+        Args:
+            done_payload: The parsed ``specialist_done.json`` payload, or
+                ``None``.
+
+        Returns:
+            The matching framework_pr proposal dict, or ``None`` when absent.
         """
         if not isinstance(done_payload, dict):
             return None
@@ -746,6 +818,14 @@ class IntegratePatchExecutor:
 
         No-op for other provenance or when both dedup keys (``fa_pr_url`` /
         ``fa_pr_sha``) are missing. Write errors are logged + swallowed.
+
+        Args:
+            done_payload: The parsed ``specialist_done.json`` payload, or
+                ``None``.
+            outcome: The outcome label to record (e.g. integrated / reverted).
+            tps_delta_pct: The measured throughput delta percentage.
+            extra: The runner ``extra`` mapping (provides shared state /
+                session id).
         """
         proposal = self._find_framework_pr_proposal(done_payload)
         if proposal is None:
@@ -793,7 +873,16 @@ class IntegratePatchExecutor:
         self, framework_root: Path | None, applied: list[Path],
     ) -> list[Path]:
         """Reverse-apply the applied patches (best-effort); returns those
-        actually reverted."""
+        actually reverted.
+
+        Args:
+            framework_root: The git checkout to revert in, or ``None`` (no-op).
+            applied: The patches that were applied this run.
+
+        Returns:
+            The patches actually reverted (may be the full ``applied`` list
+            when the checkout fallback fires).
+        """
         reverted: list[Path] = []
         if framework_root is None or not applied:
             return reverted
@@ -831,6 +920,17 @@ class IntegratePatchExecutor:
 
         Returns ``(bench_result_dict, gate_evidence)`` where gate_evidence
         carries ``accuracy_pass`` (True / False / None).
+
+        Args:
+            params: The task params (config / model / bench knobs).
+            output_root: The per-task workspace root for the bench.
+            config_changes_applied: Env overrides layered onto the variant.
+            specialist_task_id: The originating specialist task id (names the
+                variant).
+
+        Returns:
+            A ``(bench_result_dict, gate_evidence)`` tuple where
+            ``gate_evidence`` carries ``accuracy_pass`` (True / False / None).
         """
         config_path = Path(
             params.get("config_path")

--- a/inference_optimizer/orchestrator/action_executors/profile.py
+++ b/inference_optimizer/orchestrator/action_executors/profile.py
@@ -67,7 +67,14 @@ _PROFILE_UNSAFE_VALUE_FLAGS = frozenset({
 
 
 def _sanitize_profile_server_args(args: str) -> str:
-    """Drop server flags known to conflict with profiler/shape discovery."""
+    """Drop server flags known to conflict with profiler/shape discovery.
+
+    Args:
+        args: Raw server-args string to sanitize.
+
+    Returns:
+        The args string with profiler-unsafe flags (and their values) removed.
+    """
     raw = str(args or "").strip()
     if not raw:
         return ""
@@ -98,6 +105,17 @@ def _trace_contains(path: Path, substring: str, max_bytes: int | None = None) ->
 
     Confirmation pass when :func:`_sample_trace_text` finds zero
     occurrences. Returns ``False`` on any IO/decode error (never raises).
+
+    Args:
+        path: The gzipped trace file to scan.
+        substring: The marker substring to search for.
+        max_bytes: Maximum decompressed bytes to read; defaults to the
+            ``INFERENCE_OPTIMIZER_TRACE_CONFIRM_BYTES`` env value or
+            :data:`_TRACE_CONFIRM_BYTES`.
+
+    Returns:
+        True if ``substring`` is found within ``max_bytes``, False otherwise
+        (including on any IO/decode error).
     """
     if not substring:
         return False
@@ -134,7 +152,14 @@ def _trace_contains(path: Path, substring: str, max_bytes: int | None = None) ->
 def _sample_trace_text(path: Path) -> str | None:
     """Read up to ``_TRACE_INSPECT_BYTES`` of decompressed text from a
     gzipped trace. Returns ``None`` (debug-logged) on IO/decode error so the
-    check is skipped rather than failing the profile path."""
+    check is skipped rather than failing the profile path.
+
+    Args:
+        path: The gzipped trace file to sample.
+
+    Returns:
+        The decompressed leading text, or ``None`` on IO/decode error.
+    """
     try:
         with gzip.open(path, "rt", encoding="utf-8", errors="replace") as fh:
             return fh.read(_TRACE_INSPECT_BYTES)
@@ -148,7 +173,16 @@ def _sample_trace_text(path: Path) -> str | None:
 
 def _count_substring_occurrences(text: str, substring: str) -> int:
     """Count non-overlapping ``substring`` occurrences as a cheap
-    lower-bound event count (avoids full JSON parsing)."""
+    lower-bound event count (avoids full JSON parsing).
+
+    Args:
+        text: The text to scan.
+        substring: The substring to count.
+
+    Returns:
+        The number of non-overlapping occurrences (0 when ``substring`` is
+        empty).
+    """
     if not substring:
         return 0
     return text.count(substring)
@@ -180,6 +214,17 @@ def _validate_trace_structure(
     Read-only; each check warns independently so partial signals stay actionable.
 
     Returns a structured ``trace_health`` dict (#431): ``per_kernel_attribution_degraded`` (no execute_*/user_annotation events -> cuda-graph folds per-kernel time, 0 hot kernels -> triggers eager re-profile), ``capture_traces_present``, and ``issues`` (logged warning strings).
+
+    Args:
+        trace_dir: The profile workspace trace directory to inspect.
+        framework: The framework name (e.g. ``"sglang"``) gating
+            framework-specific checks.
+        expected_pieces: Expected split-piece count (reserved for future
+            checks).
+
+    Returns:
+        A ``trace_health`` dict with ``issues``,
+        ``per_kernel_attribution_degraded``, and ``capture_traces_present``.
     """
     issues: list[str] = []
     per_kernel_attribution_degraded = False
@@ -359,7 +404,14 @@ PROFILE_DEFAULT_TIMEOUT_SEC = 14400    # 4 h wall cap; Qwen3-32B TP=1 profile ne
 
 def _trace_files_for_dir(trace_dir: Path) -> list[Path]:
     """Return ``*.trace.json.gz`` files under ``trace_dir`` (recursive,
-    stable order)."""
+    stable order).
+
+    Args:
+        trace_dir: The directory to scan recursively.
+
+    Returns:
+        Sorted ``*.trace.json.gz`` paths found under ``trace_dir``.
+    """
     return sorted(trace_dir.rglob("*.trace.json.gz"))
 
 
@@ -369,6 +421,13 @@ def _preferred_main_trace_path(trace_dir: Path, trace_files: list[Path]) -> Path
     Prefer the ``merged-*`` trace (the large annotated trace the splitter
     wants); otherwise pass the trace dir so kernel-agent picks its own order
     rather than pinning a tiny single-rank slice.
+
+    Args:
+        trace_dir: The trace directory, returned as the fallback path.
+        trace_files: Candidate trace files discovered under ``trace_dir``.
+
+    Returns:
+        The preferred ``merged-*`` trace path, else ``trace_dir`` itself.
     """
     merged = sorted(p for p in trace_files if p.name.startswith("merged-"))
     return merged[0] if merged else trace_dir
@@ -413,6 +472,9 @@ def _default_profile_config() -> Path:
     wrapper script from the YAML's ``benchmark.framework`` (not $FRAMEWORK);
     falling through to the sglang yaml on FRAMEWORK=atom would launch the
     wrong wrapper.
+
+    Returns:
+        The path to the framework-specific profile YAML config.
     """
     fw = os.environ.get("FRAMEWORK", "sglang").strip().lower()
     if fw == "atom":
@@ -481,6 +543,13 @@ class ProfileExecutor(BaselineExecutor):
            last-resort so concurrent sandboxes never share a dir.
 
         The resolved dir is mkdir'd best-effort.
+
+        Args:
+            ctx: Action context (unused beyond multi-node detection).
+
+        Returns:
+            The resolved shared torch-trace base dir, or ``""`` when not
+            running multi-node.
         """
         from ._multi_node_env import is_multi_node, rayjob_id_from_state
         if not is_multi_node():
@@ -516,6 +585,14 @@ class ProfileExecutor(BaselineExecutor):
         `benchmark.inferencex_path` to its own sibling checkout); patch the
         path resolved from the materialized YAML so NUM_PROMPTS /
         PROFILE_EXTRA_BODY aren't applied to a different checkout.
+
+        Args:
+            config_path: The materialized profile YAML config to read.
+            output_dir: The run output directory (unused here).
+
+        Returns:
+            ``None`` when the InferenceX checkout is patched correctly,
+            otherwise a failure result dict describing the patch gap.
         """
         try:
             cfg = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}

--- a/inference_optimizer/orchestrator/action_executors/recover.py
+++ b/inference_optimizer/orchestrator/action_executors/recover.py
@@ -347,6 +347,9 @@ class RecoverExecutor:
 
         Returns one record per signalled PID (cmdline at discovery + final
         signal name ``"TERM"`` / ``"KILL"``).
+
+        Returns:
+            One record per signalled PID, or ``[]`` when none were stale.
         """
         candidates = self._discover_stale_pids()
         if not candidates:
@@ -369,7 +372,12 @@ class RecoverExecutor:
 
     def _discover_stale_pids(self) -> list[dict[str, Any]]:
         """Run ``pgrep -a -f -- <pattern>`` per owner pattern (matches the
-        full cmdline) and return unique PID records, excluding our own PID."""
+        full cmdline) and return unique PID records, excluding our own PID.
+
+        Returns:
+            Unique PID records matching the owner patterns, or ``[]`` when
+            ``pgrep`` is unavailable or nothing matched.
+        """
         if not shutil.which("pgrep"):
             log.warning("recover_executor: pgrep not on PATH; skipping kill stage")
             return []

--- a/inference_optimizer/orchestrator/action_executors/report.py
+++ b/inference_optimizer/orchestrator/action_executors/report.py
@@ -31,7 +31,16 @@ log = logging.getLogger(__name__)
 
 def _safe_call(state: Any, method: str, default: Any) -> Any:
     """Call a zero-arg SharedState helper, returning ``default`` when absent
-    or raising."""
+    or raising.
+
+    Args:
+        state: The object the helper is looked up on.
+        method: Name of the zero-arg method to call.
+        default: Value returned when the method is missing or raises.
+
+    Returns:
+        The method's result, or ``default`` when it is absent or raises.
+    """
     fn = getattr(state, method, None)
     if not callable(fn):
         return default
@@ -223,6 +232,13 @@ def _format_degraded_mode_section(summary: dict[str, Any]) -> list[str]:
 
     Empty when the run was not degraded. Lists each recorded model warning so
     the reader knows benchmark numbers reflect the text decoder alone.
+
+    Args:
+        summary: The summary payload built by :func:`_build_summary_dict`.
+
+    Returns:
+        Markdown lines for the degraded-mode section, or ``[]`` when the run
+        was not degraded.
     """
     warnings = summary.get("model_warnings") or []
     if not summary.get("degraded_mode") and not warnings:
@@ -247,7 +263,15 @@ def _format_degraded_mode_section(summary: dict[str, Any]) -> list[str]:
 
 def _format_completeness_annotations(summary: dict[str, Any]) -> list[str]:
     """Render honesty annotations for work left unfinished (unvalidated
-    KEEPs, untried hot kernels, KEEPs awaiting integrate)."""
+    KEEPs, untried hot kernels, KEEPs awaiting integrate).
+
+    Args:
+        summary: The summary payload built by :func:`_build_summary_dict`.
+
+    Returns:
+        Markdown lines for the completeness annotations, or ``[]`` when nothing
+        is outstanding.
+    """
     unvalidated = bool(summary.get("has_unvalidated_keeps"))
     untried = list(summary.get("untried_hot_reusable_kernels") or [])
     pending_keeps = list(summary.get("pending_keep_kernels") or [])
@@ -279,6 +303,13 @@ def _format_steward_section(summary: dict[str, Any]) -> list[str]:
 
     Steward was retired in P3_17; kept for back-compat with older state.json
     carrying a populated ``last_remaining_gaps_assessment``.
+
+    Args:
+        summary: The summary payload built by :func:`_build_summary_dict`.
+
+    Returns:
+        Markdown lines for the steward assessment section, or ``[]`` when no
+        assessment/history is present.
     """
     assessment = summary.get("remaining_gaps_assessment") or {}
     history = summary.get("remaining_gaps_assessments_history") or []
@@ -315,6 +346,13 @@ def _extract_executive_summary(analysis_md_path: str) -> str:
     """Extract the ``## Executive Summary`` block (up to the next level-2
     heading) from analysis.md. Best-effort: returns a marker string when the
     file is missing / unparseable rather than crashing the report.
+
+    Args:
+        analysis_md_path: Filesystem path to the analysis.md file.
+
+    Returns:
+        The extracted Executive Summary block (capped to ~2KB), or a marker
+        string when the path is empty, unreadable, or lacks the block.
     """
     if not analysis_md_path:
         return "(no analysis.md path recorded)"
@@ -356,6 +394,12 @@ def _format_roofline_comparison_section(cmp: dict[str, Any]) -> list[str]:
     Two modes: ``single_snapshot`` (only the PRELUDE bootstrap ran; one
     Executive Summary + Base metric table) and ``before_after`` (a watermark
     refresh produced a distinct snapshot; two summaries + Base/Opt/Δ table).
+
+    Args:
+        cmp: The roofline-comparison dict built from snapshot history.
+
+    Returns:
+        Markdown lines for the Roofline Comparison section.
     """
     from ..roofline_snapshot import format_roofline_metrics_table
 
@@ -467,6 +511,12 @@ def _format_external_baseline_section(ext: dict[str, Any]) -> list[str]:
     gap %, no "should reach" wording) so it never reads as an implicit KPI.
     Heading varies by ``ext['reason']``: ``ok`` (full reference-best),
     ``no_target_gpu_configured`` ("(not requested)"), else "(advisory)".
+
+    Args:
+        ext: The external-baseline dict from :func:`_load_external_baseline`.
+
+    Returns:
+        Markdown lines for the advisory external-baseline section.
     """
     lines: list[str] = []
     status = str(ext.get("status") or "unknown")
@@ -554,7 +604,15 @@ def _format_external_baseline_section(ext: dict[str, Any]) -> list[str]:
 def _load_external_baseline(session_dir: Path) -> dict[str, Any] | None:
     """Best-effort load of ``target_analysis/target_baseline.json``; ``None``
     when missing / unreadable (errors swallowed so a corrupt JSON never
-    breaks report generation)."""
+    breaks report generation).
+
+    Args:
+        session_dir: The session directory holding the target-analysis JSON.
+
+    Returns:
+        The parsed external-baseline mapping, or ``None`` when missing or
+        unreadable.
+    """
     try:
         from ...session_paths import target_baseline_json
         path = target_baseline_json(session_dir)
@@ -579,6 +637,14 @@ def _write_kernel_opt_summary(
     Best-effort (failure logged, returns ``None`` so the final.json write
     still happens). Aggregates ``kernel_opt_attempts`` with per-kernel
     ``results/<kid>.json`` for the "why no optimized kernel?" view.
+
+    Args:
+        state: The session's shared state.
+        session_dir: The session directory used to locate per-kernel results.
+        output_dir: The reports output directory to write the summary into.
+
+    Returns:
+        The written summary path, or ``None`` on failure.
     """
     try:
         from ..kernel_attempt_summary import build_kernel_optimization_summary
@@ -598,7 +664,15 @@ def _write_kernel_opt_summary(
 def _read_conc_sweep_pointer(session_dir: Path) -> dict[str, Any] | None:
     """Build the small ``conc_sweep_summary`` pointer for ``final.json``
     (report_path + status + summary); ``None`` when conc_sweep wrote no
-    summary."""
+    summary.
+
+    Args:
+        session_dir: The session directory holding the conc-sweep summary.
+
+    Returns:
+        A compact pointer dict for ``final.json``, or ``None`` when no
+        conc-sweep summary exists or it is unreadable.
+    """
     from ...session_paths import reports_dir as _reports_dir
     json_path = _reports_dir(session_dir) / "conc_sweep_summary.json"
     if not json_path.exists():
@@ -624,7 +698,15 @@ def _read_conc_sweep_pointer(session_dir: Path) -> dict[str, Any] | None:
 
 
 def _read_ko_summary_totals(path: Path) -> dict[str, int]:
-    """Re-read totals so the final.json pointer doesn't drift from disk."""
+    """Re-read totals so the final.json pointer doesn't drift from disk.
+
+    Args:
+        path: Path to the kernel-optimization summary JSON.
+
+    Returns:
+        A mapping of total counts read from disk, or ``{}`` on any read/parse
+        error.
+    """
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
         totals = data.get("totals") or {}
@@ -803,6 +885,13 @@ class ReportExecutor:
         Order: ``ctx.extra['session_dir']`` → ``task.params['session_dir']``
         → :func:`paths.session_dir` (only if it exists with ``state.json``)
         → None (runner returns failed).
+
+        Args:
+            ctx: Action context carrying ``extra`` / task params.
+
+        Returns:
+            The resolved session directory, or ``None`` when it cannot be
+            resolved.
         """
         extra = getattr(ctx, "extra", None) or {}
         if extra.get("session_dir"):
@@ -818,7 +907,15 @@ class ReportExecutor:
 
     def _maybe_publish_results(self, session_dir: Path, state: SharedState) -> dict[str, Any]:
         """Best-effort publish hook for code-driven optimizer runs (opt-in
-        unless the results service URL is configured)."""
+        unless the results service URL is configured).
+
+        Args:
+            session_dir: The session directory to publish artifacts from.
+            state: The session's shared state (model/session identifiers).
+
+        Returns:
+            A dict describing whether publishing ran and its outcome.
+        """
         service_url = os.environ.get("HYPERLOOM_RESULTS_SERVICE_URL", "")
         auto_publish = os.environ.get("HYPERLOOM_RESULTS_AUTO_PUBLISH", "").lower()
         if not service_url and auto_publish not in {"1", "true", "yes"}:

--- a/inference_optimizer/orchestrator/action_executors/roofline.py
+++ b/inference_optimizer/orchestrator/action_executors/roofline.py
@@ -62,9 +62,13 @@ def _extract_steady_state_retry_mode(
 ) -> "tuple[str, dict[str, Any]] | None":
     """Inspect a failed trace_analyze result for a steady-state recovery hint.
 
-    Returns ``(mode, warning_dict)`` when a recovery warning carries an
-    alternate in ``non_empty_modes`` / ``available_modes`` (first one picked,
-    splitter-sorted); ``None`` otherwise (caller falls to ``_failed()``).
+    Args:
+        ta_result: The failed trace_analyze result to inspect for warnings.
+
+    Returns:
+        ``(mode, warning_dict)`` when a recovery warning carries an alternate
+        in ``non_empty_modes`` / ``available_modes`` (first one picked,
+        splitter-sorted); ``None`` otherwise (caller falls to ``_failed()``).
     """
     if not isinstance(ta_result, dict):
         return None
@@ -93,7 +97,14 @@ def _extract_steady_state_retry_mode(
 
 def _extract_trace_path(profile_result: dict[str, Any]) -> str:
     """Pick the trace path like Coordinator's ``_promote_to_shared_state``:
-    prefer ``main_trace_path`` (merged), else ``trace_files[0]``."""
+    prefer ``main_trace_path`` (merged), else ``trace_files[0]``.
+
+    Args:
+        profile_result: The profile sub-step result to read the trace from.
+
+    Returns:
+        The resolved trace path, or an empty string if none is present.
+    """
     if not isinstance(profile_result, dict):
         return ""
     direct = profile_result.get("main_trace_path")
@@ -117,6 +128,15 @@ def _failed(
 
     ``phase`` names the failed sub-step (profile / profile_no_trace /
     trace_analyze); ``sub_result`` is pruned to known keys for audit.
+
+    Args:
+        phase: Name of the failed sub-step.
+        error: Human-readable error message.
+        sub_result: The failed sub-step's result, pruned to known keys for
+            audit when provided.
+
+    Returns:
+        The canonical failure result dict.
     """
     out: dict[str, Any] = {
         "status": "failed",
@@ -492,6 +512,12 @@ class RooflineExecutor:
         Bypasses SubAgentRunner's child Task creation (avoids double task
         accounting); the child carries kind="profile" + same params and
         inherits the lease (no profile_lane re-acquire).
+
+        Args:
+            parent_ctx: The parent runner context to derive the child from.
+
+        Returns:
+            A child ``RunnerContext`` for the profile sub-step.
         """
         from ..task_registry import Task
         parent_task = parent_ctx.task
@@ -514,7 +540,14 @@ class RooflineExecutor:
 
 
 def make_roofline_executor(*, shared_state: Any) -> RooflineExecutor:
-    """Production factory used by `cli._register_executors`."""
+    """Production factory used by `cli._register_executors`.
+
+    Args:
+        shared_state: The SharedState instance the executor will mutate.
+
+    Returns:
+        A configured ``RooflineExecutor``.
+    """
     return RooflineExecutor(shared_state=shared_state)
 
 

--- a/inference_optimizer/orchestrator/action_executors/sweep.py
+++ b/inference_optimizer/orchestrator/action_executors/sweep.py
@@ -56,7 +56,14 @@ DEFAULT_NUM_PROMPTS_FACTOR = 5
 
 def _coerce_int(value: Any) -> int:
     """Best-effort int coercion that never raises; non-numeric / None
-    collapse to 0 so an unset ``max_model_len`` disables filtering."""
+    collapse to 0 so an unset ``max_model_len`` disables filtering.
+
+    Args:
+        value: The value to coerce to an int.
+
+    Returns:
+        The parsed integer, or 0 when ``value`` is empty/non-numeric.
+    """
     if value is None or value == "":
         return 0
     try:
@@ -78,8 +85,19 @@ def _build_grid(
 
     Combos with ``ISL + OSL`` over a positive ``max_model_len`` are dropped
     up front (the server would reject every request), avoiding a wasted
-    launch. Returns ``(runnable_variants, skipped_records)`` so dropped
-    combos stay visible in the result.
+    launch.
+
+    Args:
+        conc_values: Concurrency values to fan out.
+        isl_osl_configs: ``"ISL:OSL"`` strings to fan out.
+        num_prompts_factor: Multiplier deriving ``NUM_PROMPTS`` from concurrency.
+        base_extra_args: Server args applied to every variant.
+        max_model_len: When positive, drops combos whose ``ISL + OSL`` exceeds
+            it.
+
+    Returns:
+        A ``(runnable_variants, skipped_records)`` tuple so dropped combos
+        stay visible in the result.
     """
     out: list[GridVariant] = []
     skipped: list[dict[str, Any]] = []

--- a/inference_optimizer/orchestrator/action_executors/target_analysis.py
+++ b/inference_optimizer/orchestrator/action_executors/target_analysis.py
@@ -93,7 +93,14 @@ class TargetAnalysisExecutor:
     def _resolve_session_dir(self, ctx: RunnerContext) -> Path | None:
         """Resolve session_dir: ``ctx.extra["session_dir"]`` >
         ``task.params["session_dir"]`` > constructor arg >
-        ``paths.session_dir()``; ``None`` when nothing resolves."""
+        ``paths.session_dir()``; ``None`` when nothing resolves.
+
+        Args:
+            ctx: The runner context carrying ``task.params`` and ``extra``.
+
+        Returns:
+            The resolved session directory, or ``None`` when nothing resolves.
+        """
         extra = getattr(ctx, "extra", None) or {}
         cand = extra.get("session_dir")
         if cand:
@@ -202,7 +209,17 @@ class TargetAnalysisExecutor:
         session_dir: Path,
     ) -> dict[str, Any]:
         """Build the small bus-friendly result payload (pointer + status;
-        the heavy JSON stays on disk)."""
+        the heavy JSON stays on disk).
+
+        Args:
+            ctx: The runner context (supplies ``task.kind``).
+            summary: The baseline comparison summary object.
+            session_dir: Session directory the report artefacts live under.
+
+        Returns:
+            The bus-friendly result dict with status, pointers, and best-point
+            metrics when available.
+        """
         from ...session_paths import target_analysis_report_md, target_baseline_json
         json_path = target_baseline_json(session_dir)
         md_path = target_analysis_report_md(session_dir)

--- a/inference_optimizer/orchestrator/action_registry.py
+++ b/inference_optimizer/orchestrator/action_registry.py
@@ -100,7 +100,14 @@ _DEFAULT_VERDICT_CLASS_FALLBACK: str = "exploration"
 
 
 def default_verdict_class_for(action_name: str) -> str:
-    """Look up the default ``verdict_class``; falls back to ``"exploration"``."""
+    """Look up the default ``verdict_class``; falls back to ``"exploration"``.
+
+    Args:
+        action_name: The action name to look up.
+
+    Returns:
+        The mapped verdict class, or ``"exploration"`` when unmapped.
+    """
     return _DEFAULT_VERDICT_CLASS.get(
         action_name, _DEFAULT_VERDICT_CLASS_FALLBACK,
     )

--- a/inference_optimizer/orchestrator/backends/base.py
+++ b/inference_optimizer/orchestrator/backends/base.py
@@ -24,6 +24,15 @@ def parse_call_timeout_env(env_name: str, *, default: float) -> float:
 
     Returns ``default`` (logging a WARNING) when the env var is unset, empty,
     or not a positive finite float — a malformed knob must not be fatal.
+
+    Args:
+        env_name: Name of the environment variable holding the timeout seconds.
+        default: Fallback timeout in seconds used when the env var is missing
+            or malformed.
+
+    Returns:
+        The parsed positive finite timeout in seconds, or ``default`` on any
+        miss or parse error.
     """
     raw = os.environ.get(env_name)
     if raw is None or not raw.strip():

--- a/inference_optimizer/orchestrator/backends/claude.py
+++ b/inference_optimizer/orchestrator/backends/claude.py
@@ -84,6 +84,14 @@ def _import_sdk() -> tuple[Any, Any, Any]:
     """Return ``(query, ClaudeAgentOptions, sdk_module)`` or raise.
 
     Only ``claude_agent_sdk`` is supported (``claude_code_sdk`` deprecated).
+
+    Returns:
+        A tuple of the SDK ``query`` callable, the ``ClaudeAgentOptions``
+        class, and the imported SDK module.
+
+    Raises:
+        BackendError: If ``claude_agent_sdk`` is not installed or is missing
+            the required ``query`` / ``ClaudeAgentOptions`` attributes.
     """
     try:
         sdk = importlib.import_module("claude_agent_sdk")
@@ -383,6 +391,10 @@ class ClaudeBackend:
 
         ``None`` detaches it. Best-effort: a build failure is recorded as a
         soft warning and leaves the backend usable without the pull tools.
+
+        Args:
+            provider: The context provider to back the pull tools, or ``None``
+                to detach the context-tools server.
         """
         if provider is None:
             self._context_server_config = None
@@ -416,7 +428,12 @@ class ClaudeBackend:
 
     @property
     def conversation_session_id(self) -> str | None:
-        """Current SDK session token (conversational mode), or None."""
+        """Current SDK session token (conversational mode), or None.
+
+        Returns:
+            The captured SDK session id in conversational mode, otherwise
+            ``None``.
+        """
         return self._session_id if self.conversational else None
 
     def _build_options(
@@ -485,6 +502,16 @@ class ClaudeBackend:
 
         Older SDK builds lack ``resume``; fall back to a stateless turn
         (with a one-time warning) rather than crashing the reactor.
+
+        Args:
+            kwargs: Keyword arguments to pass to the SDK options constructor.
+
+        Returns:
+            A constructed SDK options instance.
+
+        Raises:
+            TypeError: If the constructor rejects a keyword other than
+                ``resume``.
         """
         try:
             return self.sdk_options_cls(**kwargs)
@@ -518,6 +545,15 @@ class ClaudeBackend:
 
         `usage` (cache_creation/read_input_tokens) measures prompt-cache
         effectiveness against the SECTION-A/B stable-prefix design (§5.1, §8.8).
+
+        Args:
+            prompt: The composed prompt to stream to the SDK.
+            options: The SDK options object configuring this turn.
+
+        Returns:
+            A tuple ``(intents, raw_text, tool_block_count, usage, session_id)``
+            where ``usage`` is the latest cumulative usage dict and
+            ``session_id`` is the SDK session token (or ``None``).
         """
         intents: list[Intent] = []
         text_chunks: list[str] = []

--- a/inference_optimizer/orchestrator/backends/codex.py
+++ b/inference_optimizer/orchestrator/backends/codex.py
@@ -284,6 +284,13 @@ class CodexBackend:
 
         Mirrors ``ClaudeBackend._safe_int`` so both backends report
         identically-shaped token counts on metadata.
+
+        Args:
+            value: A raw usage counter of any type to coerce to an integer.
+
+        Returns:
+            The integer value, or ``0`` when ``value`` is ``None`` or not
+            coercible.
         """
         try:
             return int(value or 0)

--- a/inference_optimizer/orchestrator/backends/critic_agent.py
+++ b/inference_optimizer/orchestrator/backends/critic_agent.py
@@ -104,7 +104,15 @@ _BARE_JSON_RE = re.compile(r"(\{[^{}]*\"review_verdicts\"[\s\S]*\})", re.DOTALL)
 
 
 def _extract_review_json(text: str) -> dict[str, Any] | None:
-    """Pull the first valid review JSON out of a model reply, or ``None``."""
+    """Pull the first valid review JSON out of a model reply, or ``None``.
+
+    Args:
+        text: The raw model reply that may contain a review JSON object.
+
+    Returns:
+        The first dict containing a ``"review_verdicts"`` key, or ``None`` when
+        no parseable review object is found.
+    """
     if not text:
         return None
     for m in _FENCED_JSON_RE.finditer(text):
@@ -150,7 +158,16 @@ fake that writes the desired ``judge_bundle.json`` / ``emit.json`` to
 
 def _assistant_message_with_tool_calls(msg: Any) -> dict[str, Any]:
     """Re-serialize an OpenAI assistant message that issued tool_calls
-    (minimal dict shape, pydantic v1/v2 compatible)."""
+    (minimal dict shape, pydantic v1/v2 compatible).
+
+    Args:
+        msg: The OpenAI assistant message object carrying ``content`` and
+            ``tool_calls``.
+
+    Returns:
+        A minimal assistant-message dict with role, content, and a normalized
+        ``tool_calls`` list suitable for re-sending to the API.
+    """
     return {
         "role": "assistant",
         "content": getattr(msg, "content", None),
@@ -222,7 +239,16 @@ def _default_runtime_caller(call: RuntimeCall) -> None:
 
 # Cross-domain enrichment helper for cross-domain (scope=domains) proposals.
 def _proposal_scope_literal(proposal: dict[str, Any]) -> str:
-    """Read the ``scope`` dial off a proposal (top-level or nested ``params``)."""
+    """Read the ``scope`` dial off a proposal (top-level or nested ``params``).
+
+    Args:
+        proposal: A proposal dict that may carry ``scope`` at the top level or
+            under ``params``.
+
+    Returns:
+        The stripped scope string, or an empty string when absent or the
+        proposal is not a dict.
+    """
     if not isinstance(proposal, dict):
         return ""
     top = proposal.get("scope")
@@ -238,7 +264,13 @@ def _proposal_scope_literal(proposal: dict[str, Any]) -> str:
 
 def _maybe_inject_cross_domain_constraints(judge_bundle: dict[str, Any]) -> None:
     """Set ``review_constraints.cross_domain`` + rule descriptors when any
-    proposal is cross-domain (unified ``scope == 'domains'`` dial). Idempotent."""
+    proposal is cross-domain (unified ``scope == 'domains'`` dial). Idempotent.
+
+    Args:
+        judge_bundle: The judge bundle to enrich in place; its
+            ``review_constraints`` are updated when a cross-domain proposal is
+            present.
+    """
     proposals = judge_bundle.get("proposals") or []
     if not isinstance(proposals, list):
         return
@@ -740,6 +772,10 @@ class CriticAgentBackend:
         manifest.json (model / framework / gpu_type / model_path / tp /
         workload / precision); empty values dropped. Any read error logs a
         WARNING and returns ``{}``.
+
+        Returns:
+            A context dict built from the manifest's non-empty fields, or an
+            empty dict when the manifest is missing or unreadable.
         """
         path = manifest_path(self.session_dir)
         try:
@@ -908,6 +944,16 @@ class CriticAgentBackend:
         web_search / web_fetch up to ``self._web_tool_max_turns`` before a
         final text-only reply. Returns ``(text, finish_reason)``; tool-exec
         failures are reported back to the model, never raised.
+
+        Args:
+            messages: The running chat-completions message list; tool-use turns
+                are appended in place.
+
+        Returns:
+            A tuple of the final reply text and the final finish reason.
+
+        Raises:
+            BackendError: If any Codex chat-completions API call fails.
         """
         tools = self._web_tool_schemas
         max_turns = self._web_tool_max_turns if tools else 0
@@ -982,6 +1028,11 @@ class CriticAgentBackend:
         OpenAI reports ``prompt_tokens`` / ``completion_tokens``; map them
         onto the canonical in/out counters. Missing / bad values contribute
         0 so a single malformed response never corrupts the running sum.
+
+        Args:
+            acc: The running accumulator with ``input_tokens`` /
+                ``output_tokens`` keys, updated in place.
+            usage: An OpenAI usage object (or ``None``) to fold into ``acc``.
         """
         if usage is None:
             return
@@ -1003,6 +1054,10 @@ class CriticAgentBackend:
         ``component=critic``. tick/phase are unknown to the critic backend
         (it runs as its own reactor) — the collector backfills from the ts
         window. Best-effort: never raises into the review path.
+
+        Args:
+            usage_acc: Accumulated token counts with ``input_tokens`` /
+                ``output_tokens`` keys for this reasoning loop.
         """
         try:
             record = LLMCallRecord(
@@ -1035,6 +1090,12 @@ class CriticAgentBackend:
         (it runs as its own reactor); the collector backfills from the ts
         window. Best-effort: never raises into the review path. No-op when
         both prompt and reply are empty.
+
+        Args:
+            system_prompt: Optional system prompt prepended to the recorded
+                prompt.
+            user_prompt: The judge-bundle user prompt the critic reasoned over.
+            response: The model's externally-visible reply text.
         """
         try:
             prompt = (

--- a/inference_optimizer/orchestrator/backends/mcp_context_tools.py
+++ b/inference_optimizer/orchestrator/backends/mcp_context_tools.py
@@ -72,29 +72,53 @@ class ContextProvider:
 
     # Projections backed by SharedState.to_*_summary.
     def mission_status(self) -> str:
-        """Return the mission-status summary projection."""
+        """Return the mission-status summary projection.
+
+        Returns:
+            The mission-status summary string.
+        """
         return self._safe(self.shared_state.to_mission_summary, "mission_status")
 
     def shared_state_summary(self) -> str:
-        """Return the prompt-oriented shared-state summary projection."""
+        """Return the prompt-oriented shared-state summary projection.
+
+        Returns:
+            The shared-state summary string.
+        """
         return self._safe(self.shared_state.to_prompt_summary, "shared_state")
 
     def gaps(self) -> str:
-        """Return the open-gaps summary projection."""
+        """Return the open-gaps summary projection.
+
+        Returns:
+            The open-gaps summary string.
+        """
         return self._safe(self.shared_state.to_gaps_summary, "gaps")
 
     def warm_start(self) -> str:
-        """Return the warm-start summary projection."""
+        """Return the warm-start summary projection.
+
+        Returns:
+            The warm-start summary string.
+        """
         return self._safe(self.shared_state.to_warm_start_summary, "warm_start")
 
     def proposal_scores(self) -> str:
-        """Return the proposal-scores summary projection."""
+        """Return the proposal-scores summary projection.
+
+        Returns:
+            The proposal-scores summary string.
+        """
         return self._safe(
             self.shared_state.to_proposal_scores_summary, "proposal_scores"
         )
 
     def intervention_mix(self) -> str:
-        """Return the intervention-mix summary projection."""
+        """Return the intervention-mix summary projection.
+
+        Returns:
+            The intervention-mix summary string.
+        """
         return self._safe(
             self.shared_state.to_intervention_mix_summary, "intervention_mix"
         )
@@ -326,7 +350,16 @@ def _resolve_sdk(sdk_module: Any | None) -> Any | None:
 def _make_handler(
     provider: ContextProvider, method_name: str,
 ) -> Callable[[dict[str, Any]], Any]:
-    """Build an async MCP handler returning the provider method's string."""
+    """Build an async MCP handler returning the provider method's string.
+
+    Args:
+        provider: The context provider whose method backs the handler.
+        method_name: Name of the provider method to invoke per tool call.
+
+    Returns:
+        An async MCP handler callable that invokes the bound method and wraps
+        its result.
+    """
 
     async def _handler(args: dict[str, Any]) -> dict[str, Any]:
         """Invoke the bound provider method and wrap its string result.
@@ -381,6 +414,18 @@ def build_context_tools_server(
     Returns the SDK ``McpSdkServerConfig`` for
     :class:`ClaudeAgentOptions.mcp_servers`, or ``None`` if the SDK lacks
     in-process MCP helpers (handled gracefully by the caller).
+
+    Args:
+        provider: The context provider backing every tool handler.
+        sdk_module: Explicit SDK module to use, or ``None`` to import the real
+            one.
+        tool_factory: Override for the SDK ``tool`` decorator factory (tests).
+        server_factory: Override for the SDK ``create_sdk_mcp_server`` factory
+            (tests).
+
+    Returns:
+        The constructed in-process MCP server config, or ``None`` when the SDK
+        lacks the required in-process MCP helpers.
     """
     sdk = _resolve_sdk(sdk_module)
     if tool_factory is None:

--- a/inference_optimizer/orchestrator/backends/mcp_emit_intent.py
+++ b/inference_optimizer/orchestrator/backends/mcp_emit_intent.py
@@ -117,7 +117,15 @@ def validate_emit_intent_input(payload: dict[str, Any]) -> None:
 
 
 async def _emit_intent_handler(args: dict[str, Any]) -> dict[str, Any]:
-    """Default handler — validate then ack; errors return is_error=True."""
+    """Default handler — validate then ack; errors return is_error=True.
+
+    Args:
+        args: The raw ``emit_intent`` tool input to validate.
+
+    Returns:
+        An MCP tool result dict acknowledging success, or carrying the
+        validation error with ``is_error=True``.
+    """
     try:
         validate_emit_intent_input(args)
     except IntentValidationError as exc:
@@ -161,6 +169,19 @@ def build_emit_intent_server(
     :class:`ClaudeAgentOptions.mcp_servers`, or ``None`` if the SDK lacks
     in-process MCP helpers. ``tool_factory`` / ``server_factory`` /
     ``handler`` are test seams.
+
+    Args:
+        sdk_module: Explicit SDK module to use, or ``None`` to import the real
+            one.
+        tool_factory: Override for the SDK ``tool`` decorator factory (tests).
+        server_factory: Override for the SDK ``create_sdk_mcp_server`` factory
+            (tests).
+        handler: Override for the tool handler; defaults to
+            :func:`_emit_intent_handler`.
+
+    Returns:
+        The constructed in-process MCP server config, or ``None`` when the SDK
+        lacks the required in-process MCP helpers.
     """
     sdk = _resolve_sdk(sdk_module)
     handler = handler or _emit_intent_handler

--- a/inference_optimizer/orchestrator/backends/robustness_agent.py
+++ b/inference_optimizer/orchestrator/backends/robustness_agent.py
@@ -43,6 +43,14 @@ def _default_runtime_caller(call: RuntimeCall) -> None:
 
     Sets ``PYTHONPATH=<root>/src`` + ``cwd=<root>`` so the package resolves
     without a pip-install (matching the critic-agent convention).
+
+    Args:
+        call: The invocation descriptor with phase, request / output paths,
+            working directory, and subprocess env.
+
+    Raises:
+        BackendError: If the phase is not ``tick``, the subprocess times out,
+            cannot start, or exits non-zero.
     """
     if call.phase != "tick":
         raise BackendError(
@@ -324,7 +332,12 @@ class RobustnessAgentBackend:
 
     def _build_runtime_env(self) -> dict[str, str]:
         """Build subprocess env with ``<root>/src`` prepended to PYTHONPATH
-        (preserving any existing value) so the CLI module resolves."""
+        (preserving any existing value) so the CLI module resolves.
+
+        Returns:
+            A copy of the current environment with ``PYTHONPATH`` and the
+            robustness session-dir hint applied.
+        """
         env = dict(os.environ)
         src = str(self.robustness_agent_root / "src")
         existing = env.get("PYTHONPATH", "").strip()

--- a/inference_optimizer/orchestrator/conc_sweep.py
+++ b/inference_optimizer/orchestrator/conc_sweep.py
@@ -55,7 +55,14 @@ DEFAULT_TOTAL_BUDGET_SEC = 9000
 
 
 def _has_optimization(state: SharedState) -> tuple[bool, str, dict[str, str]]:
-    """Return ``(has_opt, args, envs)`` from ``state.current_best`` (either non-empty side counts as optimized)."""
+    """Return ``(has_opt, args, envs)`` from ``state.current_best`` (either non-empty side counts as optimized).
+
+    Args:
+        state: Shared run state whose ``current_best`` is inspected.
+
+    Returns:
+        A tuple of ``(has_optimization, extra_server_args, extra_envs)``.
+    """
     cb = state.current_best or {}
     args = str(cb.get("extra_server_args") or "").strip()
     envs_raw = cb.get("extra_envs") or {}
@@ -72,7 +79,19 @@ def _build_grid(
     optimized_args: str,
     optimized_envs: dict[str, str],
 ) -> list[GridVariant]:
-    """Two-arm grid: ``baseline`` × ``optimized`` crossed with every requested CONC."""
+    """Two-arm grid: ``baseline`` × ``optimized`` crossed with every requested CONC.
+
+    Args:
+        concs: Concurrency values to sweep.
+        isl: Input sequence length.
+        osl: Output sequence length.
+        num_prompts_factor: Multiplier applied to each CONC for NUM_PROMPTS.
+        optimized_args: Extra server args for the optimized arm.
+        optimized_envs: Extra environment variables for the optimized arm.
+
+    Returns:
+        The list of grid variants spanning both arms and all concurrencies.
+    """
     arms: list[tuple[str, str, dict[str, str]]] = [
         ("baseline",  "",              {}),
         ("optimized", optimized_args,  dict(optimized_envs)),
@@ -98,7 +117,14 @@ def _build_grid(
 
 
 def _budget_skip_result(variant: GridVariant) -> VariantResult:
-    """Synthetic VariantResult for a budget-exhausted variant; ``skipped`` status distinguishes "out of time" from "Magpie crashed"."""
+    """Synthetic VariantResult for a budget-exhausted variant; ``skipped`` status distinguishes "out of time" from "Magpie crashed".
+
+    Args:
+        variant: The grid variant that did not get to run.
+
+    Returns:
+        A ``VariantResult`` marked ``skipped`` with a budget-exhausted error.
+    """
     return VariantResult(
         name=variant.name,
         extra_server_args=variant.extra_server_args,
@@ -114,7 +140,15 @@ def _budget_skip_result(variant: GridVariant) -> VariantResult:
 
 
 def _point_from_variant(v: VariantResult, *, arm: str) -> dict[str, Any]:
-    """Flatten a ``VariantResult`` into one row of the curve."""
+    """Flatten a ``VariantResult`` into one row of the curve.
+
+    Args:
+        v: The variant result to flatten.
+        arm: The arm label (e.g. ``baseline`` or ``optimized``) for the row.
+
+    Returns:
+        A dict of the variant's metrics keyed for the curve row.
+    """
     envs = v.extra_envs or {}
     try:
         conc = int(envs.get("CONC", "0"))
@@ -145,7 +179,12 @@ def _build_comparison(
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     """Pair points by CONC, compute per-conc speedup, and aggregate.
 
-    Returns ``(per_conc_rows, summary_dict)``.
+    Args:
+        baseline_points: Curve rows for the baseline arm.
+        optimized_points: Curve rows for the optimized arm.
+
+    Returns:
+        A tuple of ``(per_conc_rows, summary_dict)``.
     """
     by_conc_b = {p["conc"]: p for p in baseline_points}
     by_conc_o = {p["conc"]: p for p in optimized_points}
@@ -214,7 +253,12 @@ def _build_comparison(
 
 
 def _write_csv(csv_path: Path, points: list[dict[str, Any]]) -> None:
-    """One row per (arm, conc) — flat columns for spreadsheet pivots."""
+    """One row per (arm, conc) — flat columns for spreadsheet pivots.
+
+    Args:
+        csv_path: Destination CSV path (parent dirs are created).
+        points: Curve rows to write, one per (arm, conc).
+    """
     columns = [
         "arm", "conc", "status",
         "output_throughput", "request_throughput", "total_token_throughput",
@@ -238,7 +282,20 @@ def _build_roofline_ceiling(
     baseline_points: list[dict[str, Any]],
     optimized_points: list[dict[str, Any]],
 ) -> dict[str, Any] | None:
-    """Per-conc decode roofline alongside the measured curves (T_cmp once, T_mem per CONC; MBU% = measured/T_peak×100). ``None`` when model meta / GPU spec is unavailable."""
+    """Per-conc decode roofline alongside the measured curves (T_cmp once, T_mem per CONC; MBU% = measured/T_peak×100). ``None`` when model meta / GPU spec is unavailable.
+
+    Args:
+        state: Shared run state providing model path, precision, GPU type, TP.
+        concs: Concurrency values to compute ceilings for.
+        isl: Input sequence length.
+        osl: Output sequence length.
+        baseline_points: Measured baseline curve rows (for MBU%).
+        optimized_points: Measured optimized curve rows (for MBU%).
+
+    Returns:
+        A roofline ceiling payload dict, or ``None`` when model meta or GPU
+        spec is unavailable.
+    """
     model_path = str(getattr(state, "model_path", "") or "")
     precision = str(getattr(state, "precision", "") or "") or "bf16"
     meta = load_model_meta(model_path, precision_hint=precision)
@@ -348,7 +405,15 @@ def _build_roofline_ceiling(
 
 
 def _skip(reason: str, **extras: Any) -> dict[str, Any]:
-    """Build a non-fatal skip envelope. Reason is operator-readable."""
+    """Build a non-fatal skip envelope. Reason is operator-readable.
+
+    Args:
+        reason: Operator-readable reason for skipping.
+        **extras: Additional key/value fields to merge into the envelope.
+
+    Returns:
+        A skip-status payload dict.
+    """
     payload: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "status":         "skipped",
@@ -368,7 +433,20 @@ async def run_conc_sweep(
     num_prompts_factor: int = DEFAULT_NUM_PROMPTS_FACTOR,
     write_reports: bool = True,
 ) -> dict[str, Any]:
-    """Run the full conc-sweep post-hook end-to-end (always returns a dict; never raises; no files written when skipped)."""
+    """Run the full conc-sweep post-hook end-to-end (always returns a dict; never raises; no files written when skipped).
+
+    Args:
+        state: Shared run state (baseline, current_best, workload shape).
+        session_dir: Session directory for workspace and report outputs.
+        concs: Concurrency ladder to sweep; ``None`` uses the default ladder.
+        variant_timeout_sec: Per-variant timeout in seconds.
+        total_budget_sec: Total wall-clock budget in seconds; ``<=0`` disables.
+        num_prompts_factor: Multiplier applied to each CONC for NUM_PROMPTS.
+        write_reports: When ``True``, write the JSON/CSV reports to disk.
+
+    Returns:
+        The sweep payload dict (a skip envelope when prerequisites are unmet).
+    """
     session_dir = Path(session_dir)
     # ``None`` → default ladder; an explicit empty list short-circuits via ``empty_conc_list`` below.
     concs = list(concs) if concs is not None else list(DEFAULT_CONCS)
@@ -551,7 +629,14 @@ async def run_conc_sweep(
 
 
 def format_summary_line(payload: dict[str, Any]) -> str:
-    """One-line stdout summary for ``_print_final_summary``."""
+    """One-line stdout summary for ``_print_final_summary``.
+
+    Args:
+        payload: The conc-sweep result payload to summarize.
+
+    Returns:
+        A single formatted summary line.
+    """
     status = payload.get("status", "?")
     if status == "skipped":
         return f"  conc_sweep           : skipped ({payload.get('skip_reason', '?')})"

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -118,7 +118,15 @@ _OUTCOME_STATUS_KEYS: tuple[str, ...] = ("status", "verdict", "outcome")
 
 
 def _first_present(d: dict[str, Any], keys: tuple[str, ...]) -> Any | None:
-    """Return ``d[k]`` for the first ``k`` in ``keys`` present + non-None."""
+    """Return ``d[k]`` for the first ``k`` in ``keys`` present + non-None.
+
+    Args:
+        d: Mapping to look up; a non-dict yields ``None``.
+        keys: Candidate keys probed in order.
+
+    Returns:
+        The first non-None value found, or ``None`` if none match.
+    """
     if not isinstance(d, dict):
         return None
     for k in keys:
@@ -129,7 +137,14 @@ def _first_present(d: dict[str, Any], keys: tuple[str, ...]) -> Any | None:
 
 
 def _format_inbox_event(m: "Message") -> str:
-    """Render one inbox ``Message`` as a compact, high-signal line (Path A/A1)."""
+    """Render one inbox ``Message`` as a compact, high-signal line (Path A/A1).
+
+    Args:
+        m: The inbox message to render.
+
+    Returns:
+        A single-line, topic-aware summary of the message.
+    """
     topic = (m.topic or "").strip()
     payload = m.payload if isinstance(m.payload, dict) else {}
     # DESIGN §13.1: canonical inbox header ordering downstream parsers anchor on.
@@ -224,7 +239,14 @@ _LIFECYCLE_PATH_KEYS: tuple[str, ...] = (
 def _lifecycle_paths(payload: Any) -> dict[str, str]:
     """Extract present, non-empty path-like fields from a kernel handler
     payload or result dict (#266). Best-effort: a non-dict argument yields
-    an empty mapping so callers never have to guard the type."""
+    an empty mapping so callers never have to guard the type.
+
+    Args:
+        payload: Kernel handler payload or result; non-dicts are tolerated.
+
+    Returns:
+        Mapping of recognised path-like keys to their non-empty string values.
+    """
     if not isinstance(payload, dict):
         return {}
     out: dict[str, str] = {}
@@ -497,7 +519,11 @@ class Coordinator:
 
     # Context-pull tools (plan Step 2)
     def _orchestration_conversational(self) -> bool:
-        """True when the orchestration backend runs in persistent-conversation mode (plan Step 1)."""
+        """True when the orchestration backend runs in persistent-conversation mode (plan Step 1).
+
+        Returns:
+            ``True`` if the orchestration backend is conversational.
+        """
         backend = self.backends.get("orchestration")
         return bool(getattr(backend, "conversational", False))
 
@@ -513,7 +539,12 @@ class Coordinator:
         self._orchestration_seeded = False
 
     def _conversation_progress_signal(self) -> dict[str, Any]:
-        """Compute the no-progress circuit-breaker signal (plan Step 6)."""
+        """Compute the no-progress circuit-breaker signal (plan Step 6).
+
+        Returns:
+            Mapping with ``ticks_without_progress``, ``threshold``,
+            ``severity`` ("ok"/"high") and ``last_progress_tick``.
+        """
         state = self.shared_state
         cur_tick = int(getattr(state, "tick", 0) or 0)
         try:
@@ -572,6 +603,14 @@ class Coordinator:
         """Compact the orchestration conversation into durable memory (plan Step 4).
 
         Returns True when a checkpoint was taken. Best-effort.
+
+        Args:
+            tick: Current coordinator tick number.
+            phase_changed: Whether the phase changed since the last checkpoint,
+                which biases the policy toward checkpointing.
+
+        Returns:
+            ``True`` when a checkpoint was taken, ``False`` otherwise.
         """
         if not self._checkpoint_enabled:
             return False
@@ -679,7 +718,15 @@ class Coordinator:
             log.exception("Coordinator: failed to attach orchestration context tools")
 
     def _context_inbox_reader(self, since_seq: int = 0) -> str:
-        """Synchronous projection of the orchestration inbox tail (sync SQLite path)."""
+        """Synchronous projection of the orchestration inbox tail (sync SQLite path).
+
+        Args:
+            since_seq: Only events with a sequence greater than this are read.
+
+        Returns:
+            Newline-joined rendering of the last inbox events, or a placeholder
+            string when none are available.
+        """
         try:
             rows = self.bus.db.fetchall_sync(
                 "SELECT * FROM events WHERE seq > ? AND "
@@ -696,7 +743,15 @@ class Coordinator:
         return "\n".join(lines)
 
     def _context_recent_outcomes_reader(self, top_k: int = 8) -> str:
-        """Synchronous projection of recent action outcomes (Path A / A2)."""
+        """Synchronous projection of recent action outcomes (Path A / A2).
+
+        Args:
+            top_k: Number of recent outcomes to include (clamped to 1..50).
+
+        Returns:
+            Newline-joined, chronologically ordered rendering of recent
+            outcomes, or a placeholder string when none exist.
+        """
         try:
             k = max(1, min(int(top_k or 8), 50))
         except (TypeError, ValueError):
@@ -725,7 +780,11 @@ class Coordinator:
     })
 
     def _inline_action_whitelist(self) -> frozenset[str]:
-        """Derive the set of actions safe to run inline (A3): lane-light, registered executor, not in _INLINE_ACTION_DENY. PolicyGate remains the real security boundary."""
+        """Derive the set of actions safe to run inline (A3): lane-light, registered executor, not in _INLINE_ACTION_DENY. PolicyGate remains the real security boundary.
+
+        Returns:
+            Frozen set of inline-eligible action names.
+        """
         reg = getattr(self, "action_registry", None)
         if reg is None:
             return frozenset()
@@ -750,7 +809,16 @@ class Coordinator:
     def _run_action_now_sync(
         self, action_name: str, params: dict[str, Any] | None = None,
     ) -> str:
-        """Bridge callable for the ``run_action_now`` context tool (A3): marshals the executor coroutine onto the Coordinator loop and blocks with a timeout."""
+        """Bridge callable for the ``run_action_now`` context tool (A3): marshals the executor coroutine onto the Coordinator loop and blocks with a timeout.
+
+        Args:
+            action_name: Name of the action to run inline.
+            params: Action parameters; ``None`` is treated as empty.
+
+        Returns:
+            A human-readable status string describing the inline run outcome
+            (completion, denial, timeout or error).
+        """
         if not self._inline_fast_actions_enabled:
             return (
                 "(run_action_now disabled: set "
@@ -804,7 +872,16 @@ class Coordinator:
     async def _run_action_now(
         self, action_name: str, params: dict[str, Any],
     ) -> str:
-        """Coordinator-loop coroutine that runs a whitelisted action inline through PolicyGate + SubAgentRunner, publishing a delegated_result for audit/inbox parity."""
+        """Coordinator-loop coroutine that runs a whitelisted action inline through PolicyGate + SubAgentRunner, publishing a delegated_result for audit/inbox parity.
+
+        Args:
+            action_name: Name of the action to run inline.
+            params: Action parameters.
+
+        Returns:
+            A human-readable status string describing the run outcome or a
+            policy/sequence denial.
+        """
         from .message_bus import Message
         # PolicyGate parity (R1): validate synthetic delegate intent so phase/role/paths/red-line gates apply.
         intent = Intent(
@@ -873,7 +950,12 @@ class Coordinator:
         return f"inline run complete: {rendered}"
 
     def _context_analysis_reader(self) -> str:
-        """Return the latest TraceLens analysis.md snapshot text."""
+        """Return the latest TraceLens analysis.md snapshot text.
+
+        Returns:
+            The analysis.md content, or a placeholder/error string when no
+            snapshot is available or the recorded path is unreadable.
+        """
         try:
             blob = self.shared_state._format_analysis_md_full()
             if blob and blob.strip():
@@ -893,7 +975,12 @@ class Coordinator:
 
     # Resume
     def _detect_resume_state(self) -> dict[str, Any]:
-        """Synchronously inspect persistence to determine if this is a resume (non-blocking)."""
+        """Synchronously inspect persistence to determine if this is a resume (non-blocking).
+
+        Returns:
+            Mapping with ``is_resume``, ``event_count``, ``state_json_present``
+            and ``rebuilt`` (set later by :meth:`replay_for_resume`).
+        """
         ev_count = self.bus.db.fetchone_sync("SELECT COUNT(*) AS c FROM events")
         events_present = (int(ev_count["c"]) if ev_count else 0) > 0
         state_path = SharedState.state_path(self.session_dir)
@@ -905,7 +992,13 @@ class Coordinator:
         }
 
     async def replay_for_resume(self) -> dict[str, Any]:
-        """Walk the event log to reconstruct ``CoordinatorState.pending_proposals``. Idempotent; a proposal is undecided when no review_verdict targets it."""
+        """Walk the event log to reconstruct ``CoordinatorState.pending_proposals``. Idempotent; a proposal is undecided when no review_verdict targets it.
+
+        Returns:
+            Mapping summarising the resume replay: ``is_resume``,
+            ``event_count``, ``state_json_present``, ``pending_restored`` and
+            ``verdicts_seen``.
+        """
         proposal_msgs = await self.bus.tail(topic="proposal", n=10_000)
         verdicts = await self.bus.tail(topic="review_verdict", n=10_000)
 
@@ -949,7 +1042,11 @@ class Coordinator:
 
     @property
     def resumed_from(self) -> dict[str, Any]:
-        """Read-only snapshot of resume detection (set by ``__init__``)."""
+        """Read-only snapshot of resume detection (set by ``__init__``).
+
+        Returns:
+            A copy of the resume-detection mapping.
+        """
         return dict(self._resumed_from)
 
     # Lifecycle
@@ -1182,7 +1279,12 @@ class Coordinator:
             log.exception("Coordinator: _on_phase_entered hook failed")
 
     async def _on_phase_entered(self, *, from_phase: str, to_phase: str) -> None:
-        """Fire per-phase entry side effects (pure dispatcher; hooks catch + log internally). CLOSE runs the 5-step sequencer (KB_design §3.2 §5.5 + KB_gaps/Gap-06; sets close_sequence_done)."""
+        """Fire per-phase entry side effects (pure dispatcher; hooks catch + log internally). CLOSE runs the 5-step sequencer (KB_design §3.2 §5.5 + KB_gaps/Gap-06; sets close_sequence_done).
+
+        Args:
+            from_phase: The phase being left.
+            to_phase: The phase just entered, used to dispatch the hook.
+        """
         # Orchestration checkpoint at the phase seam (plan Step 4); runs before per-phase side effects.
         try:
             await self._maybe_checkpoint_orchestration(
@@ -1205,7 +1307,11 @@ class Coordinator:
             await self._on_enter_close(from_phase=from_phase)
 
     async def _on_enter_explore(self, *, from_phase: str) -> None:
-        """Warm ``KnowledgePlane.pr_feed`` across specialist domains (best-effort) on EXPLORE entry. Roofline lives in PRELUDE, not here."""
+        """Warm ``KnowledgePlane.pr_feed`` across specialist domains (best-effort) on EXPLORE entry. Roofline lives in PRELUDE, not here.
+
+        Args:
+            from_phase: The phase being left, used only for logging.
+        """
         plane = self.knowledge_plane
         if plane is None:
             return
@@ -1223,7 +1329,11 @@ class Coordinator:
             )
 
     async def _on_enter_framework_pr(self, *, from_phase: str) -> None:
-        """FRAMEWORK_PR entry hook: trigger the per-batch pump once on entry (best-effort; later batches driven from the main tick)."""
+        """FRAMEWORK_PR entry hook: trigger the per-batch pump once on entry (best-effort; later batches driven from the main tick).
+
+        Args:
+            from_phase: The phase being left, used only for logging.
+        """
         log.info(
             "FRAMEWORK_PR entry (from=%s): pumping initial batch",
             from_phase or "<unknown>",
@@ -1331,7 +1441,11 @@ class Coordinator:
                 )
 
     async def _framework_pr_authoring_inflight(self) -> bool:
-        """True while a FRAMEWORK_PR-authored patch is still in flight (specialist/integrate_patch task or pending integrate_patch proposal); pump waits before advancing."""
+        """True while a FRAMEWORK_PR-authored patch is still in flight (specialist/integrate_patch task or pending integrate_patch proposal); pump waits before advancing.
+
+        Returns:
+            ``True`` if an authored patch is still being processed.
+        """
         try:
             queued = await self.tasks.queued()
             running = await self.tasks.running()
@@ -1352,7 +1466,12 @@ class Coordinator:
     async def _enqueue_framework_pr_authoring_specialist(
         self, candidate: dict[str, Any],
     ) -> None:
-        """Dispatch a write-capable specialist seeded with ``candidate`` (Inv-5.1: flows through autosubmit → Critic → integrate_patch → bench → KEEP/REVERT)."""
+        """Dispatch a write-capable specialist seeded with ``candidate`` (Inv-5.1: flows through autosubmit → Critic → integrate_patch → bench → KEEP/REVERT).
+
+        Args:
+            candidate: Discovered upstream PR candidate used to seed the
+                authoring specialist (title, urls, gap and batch ids).
+        """
         state = self.shared_state
         cand_id = str(
             candidate.get("candidate_id")
@@ -1437,7 +1556,12 @@ class Coordinator:
         )
 
     def _select_next_framework_pr_candidate(self) -> dict[str, Any] | None:
-        """Return the next unprocessed candidate in the latest batch (processed = has progress entry)."""
+        """Return the next unprocessed candidate in the latest batch (processed = has progress entry).
+
+        Returns:
+            The next candidate dict, or ``None`` when the latest batch is empty
+            or fully processed.
+        """
         state = self.shared_state
         batches = getattr(state, "framework_pr_batches", None) or []
         if not batches:
@@ -1467,7 +1591,12 @@ class Coordinator:
         return None
 
     def _framework_pr_known_candidate_ids(self) -> set[str]:
-        """All candidate ids already discovered into any prior batch (dedup for new batches)."""
+        """All candidate ids already discovered into any prior batch (dedup for new batches).
+
+        Returns:
+            Set of candidate ids seen across all batches plus PR ids already
+            mined by the research scout.
+        """
         state = self.shared_state
         ids: set[str] = set()
         batches = getattr(state, "framework_pr_batches", None) or []
@@ -1495,7 +1624,11 @@ class Coordinator:
         return ids
 
     def _framework_pr_tried_refs(self) -> list[str]:
-        """Refs already discovered this phase (fed to compose_gap to bias away from prior PR categories)."""
+        """Refs already discovered this phase (fed to compose_gap to bias away from prior PR categories).
+
+        Returns:
+            List of already-discovered candidate refs.
+        """
         refs: list[str] = []
         for cid in self._framework_pr_known_candidate_ids():
             if cid:
@@ -1503,7 +1636,14 @@ class Coordinator:
         return refs
 
     def _framework_pr_discover_repo_urls(self, framework: str) -> list[str]:
-        """Repo URLs to query for the FRAMEWORK_PR batch: framework's own repo + pr_intel_specialist cross-repo set, dedup preserving order."""
+        """Repo URLs to query for the FRAMEWORK_PR batch: framework's own repo + pr_intel_specialist cross-repo set, dedup preserving order.
+
+        Args:
+            framework: Framework name whose repo seeds the query set.
+
+        Returns:
+            Ordered, de-duplicated list of repo URLs to query.
+        """
         from . import framework_agent_client as _fa_client
 
         urls: list[str] = []
@@ -1544,7 +1684,12 @@ class Coordinator:
     def _record_framework_pr_phase_done(
         self, *, reason: str, failure_count: int,
     ) -> None:
-        """Append a framework_pr_phase_done row to phase_history describing why the pump gave up."""
+        """Append a framework_pr_phase_done row to phase_history describing why the pump gave up.
+
+        Args:
+            reason: Human-readable reason the phase finished.
+            failure_count: Number of consecutive discover failures recorded.
+        """
         state = self.shared_state
         try:
             history = getattr(state, "phase_history", None)
@@ -1563,7 +1708,12 @@ class Coordinator:
             pass
 
     async def _discover_next_framework_pr_batch(self) -> bool:
-        """Call ``fa phase-discover`` and append a batch to SharedState. Returns True iff a non-empty batch was appended; transient failures return False (see DISCOVER_FAILURE_RETRY_LIMIT)."""
+        """Call ``fa phase-discover`` and append a batch to SharedState. Returns True iff a non-empty batch was appended; transient failures return False (see DISCOVER_FAILURE_RETRY_LIMIT).
+
+        Returns:
+            ``True`` when a non-empty batch was appended, ``False`` on a
+            transient failure or empty payload.
+        """
         from . import framework_agent_client as _fa_client
 
         state = self.shared_state
@@ -1802,7 +1952,12 @@ class Coordinator:
     _CRITIC_PRIORS_OUTCOME_TAIL: int = 5
 
     def _collect_framework_pr_priors(self) -> dict[str, Any]:
-        """Return compact session-local priors for the Critic gate (recent_decisions + recent_outcomes); best-effort."""
+        """Return compact session-local priors for the Critic gate (recent_decisions + recent_outcomes); best-effort.
+
+        Returns:
+            Mapping with ``recent_decisions`` and ``recent_outcomes`` lists,
+            each bounded to a short tail.
+        """
         state = self.shared_state
         decisions: list[dict[str, Any]] = []
         try:
@@ -1842,6 +1997,13 @@ class Coordinator:
 
         Returns {"verdict": "approve"|"reject"|"abstain", "rationale": str}. abstain is the safe degraded
         path (treated as approve by caller); decisions cached in framework_pr_critic_decisions for resume.
+
+        Args:
+            candidate: The discovered PR candidate to review.
+
+        Returns:
+            Mapping with ``verdict`` ("approve"/"reject"/"abstain") and a
+            ``rationale`` string.
         """
         state = self.shared_state
         cand_id = str(
@@ -1952,7 +2114,11 @@ class Coordinator:
         return verdict_row
 
     async def _on_enter_kernel(self, *, from_phase: str) -> None:
-        """Run deterministic KERNEL-entry setup before LLM kernel work (FP8 GEMM tuning gate)."""
+        """Run deterministic KERNEL-entry setup before LLM kernel work (FP8 GEMM tuning gate).
+
+        Args:
+            from_phase: The phase being left, used for logging.
+        """
         if not self._kernel_enabled():
             # Should not happen — --no-kernel routes EXPLORE → SWEEP.
             log.info(
@@ -2152,7 +2318,11 @@ class Coordinator:
     _ROOFLINE_WATERMARK_RATIO: float = 1.10   # 10% step over last roofline
 
     def _current_tput_from_validated_gain(self) -> float:
-        """Project current tput from ``baseline_tput * (1 + cumulative_gain_validated/100)``; 0.0 when baseline unknown (watermark not-yet-armed)."""
+        """Project current tput from ``baseline_tput * (1 + cumulative_gain_validated/100)``; 0.0 when baseline unknown (watermark not-yet-armed).
+
+        Returns:
+            Projected throughput, or ``0.0`` when the baseline is unknown.
+        """
         state = self.shared_state
         try:
             base = float(state.baseline_tput or 0.0)
@@ -2167,7 +2337,11 @@ class Coordinator:
         return base * (1.0 + gain / 100.0)
 
     def _needs_roofline_for_watermark(self) -> bool:
-        """True iff projected tput crossed the 10% watermark over ``last_roofline_tput`` (bootstrap guard: False until PRELUDE roofline ran; re-arm guard: False while auto_roofline_pending_task_id is in-flight)."""
+        """True iff projected tput crossed the 10% watermark over ``last_roofline_tput`` (bootstrap guard: False until PRELUDE roofline ran; re-arm guard: False while auto_roofline_pending_task_id is in-flight).
+
+        Returns:
+            ``True`` when a fresh roofline is warranted by the watermark.
+        """
         state = self.shared_state
         try:
             last_rl = float(state.last_roofline_tput or 0.0)
@@ -2198,7 +2372,14 @@ class Coordinator:
     async def _maybe_enqueue_watermark_roofline(
         self, *, reason: str,
     ) -> bool:
-        """Enqueue a fresh roofline if the watermark crossed; idempotency-keyed via ``reason``, stamps auto_roofline_pending_task_id. Returns True when enqueued."""
+        """Enqueue a fresh roofline if the watermark crossed; idempotency-keyed via ``reason``, stamps auto_roofline_pending_task_id. Returns True when enqueued.
+
+        Args:
+            reason: Tag used for idempotency keying and logging.
+
+        Returns:
+            ``True`` when a roofline task was enqueued, ``False`` otherwise.
+        """
         if not self._needs_roofline_for_watermark():
             return False
         try:
@@ -2220,13 +2401,25 @@ class Coordinator:
         return True
 
     def _internal_analysis_kind(self) -> str:
-        """Pick the kind for the next Coordinator-internal analysis task: roofline (composite) when enable_roofline else profile. Both absent from PHASE_LLM_PROPOSABLE_ACTIONS (PolicyGate R1 denies LLM proposals)."""
+        """Pick the kind for the next Coordinator-internal analysis task: roofline (composite) when enable_roofline else profile. Both absent from PHASE_LLM_PROPOSABLE_ACTIONS (PolicyGate R1 denies LLM proposals).
+
+        Returns:
+            ``"roofline"`` when roofline is enabled, else ``"profile"``.
+        """
         return "roofline" if bool(
             getattr(self.shared_state, "enable_roofline", True),
         ) else "profile"
 
     def _registry_lanes_ttl(self, kind: str) -> tuple[list[str], int]:
-        """Resolve ``(requires_lanes, lease_ttl_sec)`` from the ActionRegistry; lanes filtered to KNOWN_LANES, returns ([], 0) for unknown actions."""
+        """Resolve ``(requires_lanes, lease_ttl_sec)`` from the ActionRegistry; lanes filtered to KNOWN_LANES, returns ([], 0) for unknown actions.
+
+        Args:
+            kind: Action name to look up in the registry.
+
+        Returns:
+            Tuple of (required lane names, lease TTL seconds); ``([], 0)`` for
+            unknown actions.
+        """
         reg = getattr(self, "action_registry", None)
         if reg is None:
             return [], 0
@@ -2240,7 +2433,11 @@ class Coordinator:
         return lanes, int(getattr(meta, "lease_ttl_sec", 0) or 0)
 
     def _warm_recipe_proven_items(self) -> list[dict[str, str]]:
-        """Summarise warm-start ``what_worked`` items the scout can skip ({name, source}); fail-soft."""
+        """Summarise warm-start ``what_worked`` items the scout can skip ({name, source}); fail-soft.
+
+        Returns:
+            List of ``{"name", "source"}`` dicts for proven warm-start items.
+        """
         state = self.shared_state
         warm = getattr(state, "warm_start_recipe", None) or {}
         if not isinstance(warm, dict) or not warm:
@@ -2261,7 +2458,11 @@ class Coordinator:
         return out
 
     def _inject_warm_recipe_history_into_ledger(self) -> int:
-        """GAP 1 — pre-fill ``explore_search.rejected`` with the warm recipe's ``what_failed`` rows (fingerprinted so the dedup gate denies re-tests). Idempotent via warm_history_injected; returns rows added."""
+        """GAP 1 — pre-fill ``explore_search.rejected`` with the warm recipe's ``what_failed`` rows (fingerprinted so the dedup gate denies re-tests). Idempotent via warm_history_injected; returns rows added.
+
+        Returns:
+            Number of rejected rows injected into the ledger.
+        """
         state = self.shared_state
         if getattr(state, "warm_history_injected", False):
             return 0
@@ -2341,6 +2542,13 @@ class Coordinator:
 
         Skips on --no-warm-replay/resume/low-confidence/empty best_config; otherwise mints an internal
         task running the baseline workload contract with the KB config applied. Idempotent via warm-replay-prelude.
+
+        Args:
+            baseline_tput: Measured baseline throughput used as the replay
+                anchor.
+
+        Returns:
+            The enqueued ``Task``, or ``None`` when the replay is skipped.
         """
         state = self.shared_state
         if not getattr(self, "_warm_replay_enabled", True):
@@ -2482,7 +2690,12 @@ class Coordinator:
     def _promote_warm_replay(
         self, result: dict, *, task: "Task | None" = None,
     ) -> None:
-        """GAP 1 — interpret a ``replay_warm_recipe`` result: any measured uplift pushes warm config onto optimization_stack + current_best; failures set status and never propagate."""
+        """GAP 1 — interpret a ``replay_warm_recipe`` result: any measured uplift pushes warm config onto optimization_stack + current_best; failures set status and never propagate.
+
+        Args:
+            result: The ``replay_warm_recipe`` task result payload.
+            task: The originating replay task, when available.
+        """
         state = self.shared_state
         outcome = dict(state.warm_replay_outcome or {})
         expected_gain = float(outcome.get("expected_gain_pct") or 0.0)
@@ -2650,7 +2863,12 @@ class Coordinator:
         *,
         baseline_tput: float | None = None,
     ) -> None:
-        """Enqueue the PRELUDE-bootstrap roofline/profile task after baseline; skipped while warm-replay is in_flight (GPU/port contention)."""
+        """Enqueue the PRELUDE-bootstrap roofline/profile task after baseline; skipped while warm-replay is in_flight (GPU/port contention).
+
+        Args:
+            baseline_tput: Measured baseline throughput; ``None`` reads it from
+                shared state.
+        """
         state = self.shared_state
         if _phase_state.warm_replay_in_flight(state):
             log.info(
@@ -2684,7 +2902,14 @@ class Coordinator:
             )
 
     async def _enqueue_internal_analysis_task(self, *, reason: str) -> Task:
-        """Build + enqueue a Coordinator-internal analysis task (roofline or profile). Kind-agnostic idempotency key internal-analysis-<reason>; omits baseline_config_path so ProfileExecutor enables torch_profiler."""
+        """Build + enqueue a Coordinator-internal analysis task (roofline or profile). Kind-agnostic idempotency key internal-analysis-<reason>; omits baseline_config_path so ProfileExecutor enables torch_profiler.
+
+        Args:
+            reason: Tag used for idempotency keying and base-args selection.
+
+        Returns:
+            The enqueued (or pre-existing idempotent) analysis ``Task``.
+        """
         state = self.shared_state
         kind = self._internal_analysis_kind()
         params: dict[str, Any] = {
@@ -2731,7 +2956,11 @@ class Coordinator:
         return task
 
     def _record_phase_entry_evidence(self, **kvs: Any) -> None:
-        """Merge ``kvs`` into the latest phase_history row's evidence dict (Gap-04; no-op when empty)."""
+        """Merge ``kvs`` into the latest phase_history row's evidence dict (Gap-04; no-op when empty).
+
+        Args:
+            **kvs: Evidence key/value pairs merged into the latest phase row.
+        """
         history = self.shared_state.phase_history or []
         if not history:
             return
@@ -2792,7 +3021,11 @@ class Coordinator:
             )
 
     async def _on_enter_sweep(self, *, from_phase: str) -> None:
-        """Auto-enqueue a ``sweep`` task on SWEEP entry (§3.2 §5.4). Idempotent via internal-sweep-phase_entry (Inv-2.1); PolicyGate's sweep_phase_singleton then denies LLM-emitted sweep (OOM race)."""
+        """Auto-enqueue a ``sweep`` task on SWEEP entry (§3.2 §5.4). Idempotent via internal-sweep-phase_entry (Inv-2.1); PolicyGate's sweep_phase_singleton then denies LLM-emitted sweep (OOM race).
+
+        Args:
+            from_phase: The phase being left, used for logging.
+        """
         state = self.shared_state
         # Bug #7 fix: drain pending KEEP integrates from prior KERNEL so sweep measures full current_best.
         if getattr(state, "has_keep_pending_integrate", False):
@@ -2830,7 +3063,14 @@ class Coordinator:
     async def _enqueue_internal_conc_sweep_task(
         self, *, reason: str,
     ) -> Task | None:
-        """Build + enqueue a Coordinator-internal ``conc_sweep`` task (caller checks conc_sweep_enabled). Idempotency key + PolicyGate singleton ensure ≤1 per SWEEP; returns None on error."""
+        """Build + enqueue a Coordinator-internal ``conc_sweep`` task (caller checks conc_sweep_enabled). Idempotency key + PolicyGate singleton ensure ≤1 per SWEEP; returns None on error.
+
+        Args:
+            reason: Tag used for idempotency keying and logging.
+
+        Returns:
+            The enqueued ``conc_sweep`` task, or ``None`` on error.
+        """
         state = self.shared_state
         params: dict[str, Any] = {
             "source": "coordinator_internal",
@@ -2871,7 +3111,14 @@ class Coordinator:
     async def _enqueue_internal_sweep_task(
         self, *, reason: str,
     ) -> Task:
-        """Build + enqueue a Coordinator-internal ``sweep`` task. Grid priority: warm_start_recipe.sweep_grid then SKILL.md defaults. Idempotency key internal-sweep-<reason>."""
+        """Build + enqueue a Coordinator-internal ``sweep`` task. Grid priority: warm_start_recipe.sweep_grid then SKILL.md defaults. Idempotency key internal-sweep-<reason>.
+
+        Args:
+            reason: Tag used for idempotency keying and logging.
+
+        Returns:
+            The enqueued (or pre-existing idempotent) ``sweep`` task.
+        """
         state = self.shared_state
         grid_params = self._build_sweep_params_from_recipe(state)
         params: dict[str, Any] = {
@@ -2908,7 +3155,15 @@ class Coordinator:
 
     @staticmethod
     def _build_sweep_params_from_recipe(state: SharedState) -> dict[str, Any]:
-        """Pick a sweep grid (§3.14 R-13): warm_start_recipe.sweep_grid takes precedence over SKILL.md defaults; per-field fallback. Returns source/conc_values/isl_osl_configs/num_prompts_factor."""
+        """Pick a sweep grid (§3.14 R-13): warm_start_recipe.sweep_grid takes precedence over SKILL.md defaults; per-field fallback. Returns source/conc_values/isl_osl_configs/num_prompts_factor.
+
+        Args:
+            state: Session shared state holding any warm-start recipe grid.
+
+        Returns:
+            Mapping with ``source``, ``conc_values``, ``isl_osl_configs`` and
+            ``num_prompts_factor``.
+        """
         from .action_executors.sweep import (
             DEFAULT_CONC_VALUES,
             DEFAULT_ISL_OSL,
@@ -3012,7 +3267,11 @@ class Coordinator:
     CLOSE_NDJSON_DRAIN_TIMEOUT_SEC: float = 60.0
 
     def _derive_close_stop_reason(self) -> str:
-        """Best-effort ``stop_reason`` for a CLOSE reached blank: recover from the newest CLOSE-bound phase_history row, else time_exhausted."""
+        """Best-effort ``stop_reason`` for a CLOSE reached blank: recover from the newest CLOSE-bound phase_history row, else time_exhausted.
+
+        Returns:
+            The recovered stop reason, or ``"time_exhausted"`` as a fallback.
+        """
         history = self.shared_state.phase_history or []
         for row in reversed(history):
             if not isinstance(row, dict):
@@ -3028,7 +3287,11 @@ class Coordinator:
         return "time_exhausted"
 
     async def _on_enter_close(self, *, from_phase: str) -> None:
-        """CLOSE 5-step sequencer (fixed order): report → session_breakdown → fact_finalize → ndjson_drain (no-op) → mark close_sequence_done + stop_reason. Best-effort steps; final done step always runs."""
+        """CLOSE 5-step sequencer (fixed order): report → session_breakdown → fact_finalize → ndjson_drain (no-op) → mark close_sequence_done + stop_reason. Best-effort steps; final done step always runs.
+
+        Args:
+            from_phase: The phase being left, used for logging.
+        """
         log.info("CLOSE entered (from=%s); starting 5-step close sequence",
                  from_phase or "<unknown>")
         await self._record_close_step("sequencer_started", status="running")
@@ -3218,6 +3481,12 @@ class Coordinator:
         """Build + enqueue a Coordinator-internal ``report`` task (idempotency_key internal-report-<reason>).
 
         Reuses closing_report_task_id when set so the wall-clock + CLOSE-sequencer paths don't race.
+
+        Args:
+            reason: Tag used for idempotency keying and logging.
+
+        Returns:
+            The enqueued (or reused) ``report`` task.
         """
         existing_id = (self.shared_state.closing_report_task_id or "").strip()
         if existing_id:
@@ -3267,7 +3536,16 @@ class Coordinator:
     async def _enqueue_internal_research_scout_task(
         self, *, reason: str, round_id: int,
     ) -> "Task | None":
-        """Enqueue a Coordinator-owned read-only research-scout specialist task; idempotency keyed by round, returns None on existing/failure (fail-soft)."""
+        """Enqueue a Coordinator-owned read-only research-scout specialist task; idempotency keyed by round, returns None on existing/failure (fail-soft).
+
+        Args:
+            reason: Tag used for idempotency keying and logging.
+            round_id: EXPLORE round number, part of the idempotency key.
+
+        Returns:
+            The dispatched scout ``Task``, or ``None`` when disabled, already
+            existing, or on failure.
+        """
         if not bool(getattr(self.shared_state, "research_scout_enabled", True)):
             return None
         idempotency_key = f"internal-research-scout-round{int(round_id)}"
@@ -3362,7 +3640,11 @@ class Coordinator:
             log.exception("research-scout: EXPLORE re-dispatch failed")
 
     def _harvest_research_scout(self, done_payload: dict[str, Any]) -> None:
-        """Persist scout output (hints, competitor target, gap seeds, dedup); all steps fail-soft."""
+        """Persist scout output (hints, competitor target, gap seeds, dedup); all steps fail-soft.
+
+        Args:
+            done_payload: The research-scout task's completion payload.
+        """
         from . import research_hints as _research_hints
 
         block = done_payload.get("research")
@@ -3435,7 +3717,14 @@ class Coordinator:
     async def _enqueue_internal_session_breakdown_task(
         self, *, reason: str,
     ) -> Task:
-        """Build + enqueue a Coordinator-internal ``session_breakdown`` task; same idempotency contract as the report helper."""
+        """Build + enqueue a Coordinator-internal ``session_breakdown`` task; same idempotency contract as the report helper.
+
+        Args:
+            reason: Tag used for idempotency keying and logging.
+
+        Returns:
+            The enqueued (or pre-existing idempotent) ``session_breakdown`` task.
+        """
         params: dict[str, Any] = {
             "source":      "coordinator_internal",
             "reason":      str(reason),
@@ -3503,7 +3792,14 @@ class Coordinator:
         task_id: str = "",
         detail: str = "",
     ) -> None:
-        """Append one row to ``phase_history[-1].evidence.close_steps`` (best-effort, per-step persist)."""
+        """Append one row to ``phase_history[-1].evidence.close_steps`` (best-effort, per-step persist).
+
+        Args:
+            step: Name of the CLOSE sequencer step.
+            status: Step status (e.g. "running", "done", "failed", "skipped").
+            task_id: Associated task id, when applicable.
+            detail: Optional free-form detail recorded with the step.
+        """
         history = self.shared_state.phase_history or []
         if not history:
             return
@@ -3543,14 +3839,22 @@ class Coordinator:
         await self.replay_for_resume()
 
     async def _pump_framework_pr_phase_safely(self, *, caller: str) -> None:
-        """Best-effort FRAMEWORK_PR pump wrapper shared by tick and run."""
+        """Best-effort FRAMEWORK_PR pump wrapper shared by tick and run.
+
+        Args:
+            caller: Name of the calling context, used for logging.
+        """
         try:
             await self._pump_framework_pr_phase()
         except Exception:  # noqa: BLE001 — defensive
             log.exception("FRAMEWORK_PR pump (%s) failed", caller)
 
     async def tick(self, n: int = 1) -> None:
-        """Run exactly ``n`` reactor passes for every agent (P0-3/P0-5/P1-4 tests); dispatcher pumps at pass end, lazy resume replay on tick 1."""
+        """Run exactly ``n`` reactor passes for every agent (P0-3/P0-5/P1-4 tests); dispatcher pumps at pass end, lazy resume replay on tick 1.
+
+        Args:
+            n: Number of reactor passes to run.
+        """
         await self._replay_resume_if_needed()
         for _ in range(n):
             self.shared_state.increment_tick()
@@ -3570,7 +3874,14 @@ class Coordinator:
         tick: int | None = None,
         agent: str = "",
     ) -> None:
-        """Record a Coordinator-side exception without killing the session."""
+        """Record a Coordinator-side exception without killing the session.
+
+        Args:
+            stage: Pipeline stage where the exception occurred.
+            exc: The caught exception.
+            tick: Tick number to record; ``None`` reads the current tick.
+            agent: Agent name associated with the exception, if any.
+        """
         try:
             self.shared_state.record_tick_exception(
                 tick=int(tick if tick is not None else self.shared_state.tick or 0),
@@ -3600,7 +3911,24 @@ class Coordinator:
         crash_emergency_threshold: int = 25,
         closing_grace_sec: float | None = None,
     ) -> str:
-        """Run reactor + dispatcher until a stop condition fires (DESIGN §9.1, priority order): signal, target_reached, time_exhausted (via closing phase), emergency, custom, max_ticks. Sets + saves + returns shared_state.stop_reason."""
+        """Run reactor + dispatcher until a stop condition fires (DESIGN §9.1, priority order): signal, target_reached, time_exhausted (via closing phase), emergency, custom, max_ticks. Sets + saves + returns shared_state.stop_reason.
+
+        Args:
+            objective: Optimization objective; ``None`` uses a
+                :class:`TimeOnlyObjective`.
+            max_minutes: Wall-clock budget in minutes; ``None`` for unbounded.
+            tick_interval_sec: Sleep between ticks.
+            max_ticks: Hard cap on ticks; ``None`` for unbounded.
+            stop_when: Optional custom stop predicate.
+            install_signal_handlers: Whether to install SIGINT/SIGTERM handlers.
+            crash_emergency_threshold: Crash count that triggers an emergency
+                stop.
+            closing_grace_sec: Grace period for the closing phase; ``None``
+                derives it from ``max_minutes``.
+
+        Returns:
+            The final ``shared_state.stop_reason``.
+        """
         objective = objective or TimeOnlyObjective()
         # Stash so _compose_prompt can update target_gap_pct.
         self._current_objective = objective
@@ -3781,7 +4109,14 @@ class Coordinator:
         return self.shared_state.stop_reason
 
     async def _enter_closing_phase(self, *, grace_sec: float) -> float:
-        """Enter report-flush phase after the wall-clock deadline (enqueue deterministic report task)."""
+        """Enter report-flush phase after the wall-clock deadline (enqueue deterministic report task).
+
+        Args:
+            grace_sec: Grace window in seconds for the closing phase.
+
+        Returns:
+            The monotonic deadline by which the closing phase should complete.
+        """
         closing_started = time.time()
         closing_deadline = time.monotonic() + float(grace_sec)
         self.shared_state.closing_phase = True
@@ -3949,6 +4284,10 @@ class Coordinator:
         Wrapped in a broad ``try`` so any unexpected error in trace
         assembly degrades to a logged warning rather than breaking the
         tick loop.
+
+        Args:
+            agent_name: Reactor role name, used as both component and role.
+            result: The backend turn result carrying token metadata.
         """
         try:
             metadata = result.metadata or {}
@@ -3991,6 +4330,10 @@ class Coordinator:
 
         Best-effort: any failure degrades to a logged warning rather than
         breaking the tick loop.
+
+        Args:
+            agent_name: Reactor role name, used as both component and role.
+            result: The backend turn result carrying prompt/response metadata.
         """
         try:
             metadata = result.metadata or {}
@@ -4018,7 +4361,12 @@ class Coordinator:
     async def _track_backend_error_streak(
         self, agent_name: str, exc: BackendError,
     ) -> None:
-        """Increment the per-agent ``BackendError`` streak; emit one backend_unhealthy event on crossing the threshold (re-arms only after a successful turn)."""
+        """Increment the per-agent ``BackendError`` streak; emit one backend_unhealthy event on crossing the threshold (re-arms only after a successful turn).
+
+        Args:
+            agent_name: Agent whose error streak is incremented.
+            exc: The backend error that occurred.
+        """
         new_value = self._backend_error_streak.get(agent_name, 0) + 1
         self._backend_error_streak[agent_name] = new_value
         threshold = self._backend_error_streak_threshold
@@ -4046,7 +4394,12 @@ class Coordinator:
             )
 
     async def _scan_stale_specialists(self) -> list[dict[str, Any]]:
-        """Return specialist task rows running longer than ``_specialist_stale_sec`` (v0.8 §3.3 §4.4); never raises, returns [] on failure."""
+        """Return specialist task rows running longer than ``_specialist_stale_sec`` (v0.8 §3.3 §4.4); never raises, returns [] on failure.
+
+        Returns:
+            List of ``{task_id, kind, running_seconds}`` dicts for stale
+            specialist tasks; empty on failure or when none are stale.
+        """
         try:
             running = await self.tasks.running()
         except Exception:  # noqa: BLE001 — defensive
@@ -4073,7 +4426,14 @@ class Coordinator:
         return stale
 
     async def _compose_prompt(self, agent_name: str) -> str:
-        """v0.6 §8.3 prompt: SharedState summary + inbox tail (with canonical msg_id per inbox row)."""
+        """v0.6 §8.3 prompt: SharedState summary + inbox tail (with canonical msg_id per inbox row).
+
+        Args:
+            agent_name: Role name whose prompt is being composed.
+
+        Returns:
+            The fully assembled prompt string for the agent.
+        """
         sections: list[str] = []
 
         # 0. SESSION_DIR contract — literal path for every agent (pairs with PolicyGate path containment).
@@ -4368,7 +4728,12 @@ class Coordinator:
 
     # Execution order guard
     def _target_analysis_baseline_exists(self) -> bool:
-        """True iff target_analysis produced ``target_baseline.json`` (file existence is a sufficient gate signal)."""
+        """True iff target_analysis produced ``target_baseline.json`` (file existence is a sufficient gate signal).
+
+        Returns:
+            ``True`` when the target baseline artifact exists (or when the
+            helper is unavailable, treated as done).
+        """
         try:
             from ..session_paths import target_baseline_json
             return target_baseline_json(self.session_dir).exists()
@@ -4376,7 +4741,11 @@ class Coordinator:
             return True
 
     def _kernel_opt_keep_pending(self) -> str:
-        """Return the next kernel_id awaiting integrate, or "" if none (delegates to SharedState.next_pending_keep_kernel_id)."""
+        """Return the next kernel_id awaiting integrate, or "" if none (delegates to SharedState.next_pending_keep_kernel_id).
+
+        Returns:
+            The next pending KEEP kernel id, or an empty string if none.
+        """
         return self.shared_state.next_pending_keep_kernel_id()
 
     def _sequence_denial_for_action(
@@ -4384,7 +4753,16 @@ class Coordinator:
         action_name: str,
         proposed_params: dict[str, Any] | None = None,
     ) -> PolicyDenied | None:
-        """Reject orchestration action/delegate attempts before baseline. Only invariant: nothing runs until baseline_tput > 0 (a data-dependency). proposed_params kept for signature compat."""
+        """Reject orchestration action/delegate attempts before baseline. Only invariant: nothing runs until baseline_tput > 0 (a data-dependency). proposed_params kept for signature compat.
+
+        Args:
+            action_name: Name of the proposed/delegated action.
+            proposed_params: Action params, kept for signature compatibility.
+
+        Returns:
+            A :class:`PolicyDenied` when the action is sequenced before
+            baseline, otherwise ``None``.
+        """
         action = str(action_name or "").strip()
         sequence_actions = {
             "target_analysis",
@@ -4409,7 +4787,16 @@ class Coordinator:
     def _sequence_denial_for_request(
         self, target_agent: str, kind: str,
     ) -> PolicyDenied | None:
-        """Reject kernel requests that skip the baseline prerequisite (invariant: nothing kernel-side runs before baseline_tput > 0)."""
+        """Reject kernel requests that skip the baseline prerequisite (invariant: nothing kernel-side runs before baseline_tput > 0).
+
+        Args:
+            target_agent: Target agent of the request (only "kernel" is gated).
+            kind: Kernel request kind.
+
+        Returns:
+            A :class:`PolicyDenied` when the request precedes baseline,
+            otherwise ``None``.
+        """
         target = str(target_agent or "").strip()
         req_kind = str(kind or "").strip()
         if target != "kernel" or self.shared_state.stop_reason:
@@ -4600,7 +4987,14 @@ class Coordinator:
         self.state.pending_proposals[msg.msg_id] = pending
 
     def _resolve_issue_canonical(self, pending: PendingProposal) -> str:
-        """Find the issue_node canonical_id this proposal addresses. Priority: payload gap_canonical_id → params gap_canonical_id → _gap_anchor_canonical_id (Gap-09)."""
+        """Find the issue_node canonical_id this proposal addresses. Priority: payload gap_canonical_id → params gap_canonical_id → _gap_anchor_canonical_id (Gap-09).
+
+        Args:
+            pending: The pending proposal whose gap anchor is resolved.
+
+        Returns:
+            The resolved issue-node canonical id.
+        """
         payload = pending.payload or {}
         explicit_top = str(payload.get("gap_canonical_id") or "").strip()
         if explicit_top:
@@ -4613,7 +5007,12 @@ class Coordinator:
         return self._gap_anchor_canonical_id()
 
     def _workload_canonical_id(self) -> str:
-        """Canonical 5-tuple recipe id for the current workload. MUST match cortex_t0.run_t0_anchor's derivation so warm-start and KEEP/REVERT/CLOSE writes target the same row."""
+        """Canonical 5-tuple recipe id for the current workload. MUST match cortex_t0.run_t0_anchor's derivation so warm-start and KEEP/REVERT/CLOSE writes target the same row.
+
+        Returns:
+            The canonical recipe id derived from model/hardware/framework/
+            framework_version/precision.
+        """
         ss = self.shared_state
         workload = ss.model_name or "unknown_model"
         hw = ss.gpu_type or "unknown_gpu"
@@ -4631,7 +5030,11 @@ class Coordinator:
         )
 
     def _gap_anchor_canonical_id(self) -> str:
-        """M1 gap anchor: delegates to _workload_canonical_id so anchor and write target never diverge."""
+        """M1 gap anchor: delegates to _workload_canonical_id so anchor and write target never diverge.
+
+        Returns:
+            The workload canonical id used as the gap anchor.
+        """
         return self._workload_canonical_id()
 
     def _kb_amend_recipe(
@@ -4642,7 +5045,15 @@ class Coordinator:
         recipe_overrides: dict[str, Any] | None = None,
         provenance_details: dict[str, Any] | None = None,
     ) -> None:
-        """Read-modify-write helper for the v2 recipe-snapshot KB: load live row, append lesson/pitfall, merge recipe_overrides (unset fields preserved), write back. Best-effort; lesson/pitfall appended without dedup (commit 4d)."""
+        """Read-modify-write helper for the v2 recipe-snapshot KB: load live row, append lesson/pitfall, merge recipe_overrides (unset fields preserved), write back. Best-effort; lesson/pitfall appended without dedup (commit 4d).
+
+        Args:
+            append_lesson: Optional lesson dict to append.
+            append_pitfall: Optional pitfall dict to append.
+            recipe_overrides: Field overrides merged into the recipe; unset
+                fields are preserved from the live row.
+            provenance_details: Optional provenance metadata for the write.
+        """
         if self.cortex_kb is None:
             return
         try:
@@ -4763,7 +5174,13 @@ class Coordinator:
             )
 
     async def _handle_review_verdict(self, source: str, intent: Intent) -> None:
-        """Apply a Critic ``review_verdict`` to its target proposal; legacy verdict_map collapsed (approve > reject > needs_review)."""
+        """Apply a Critic ``review_verdict`` to its target proposal; legacy verdict_map collapsed (approve > reject > needs_review).
+
+        Args:
+            source: Agent name issuing the verdict.
+            intent: The ``review_verdict`` intent carrying the target and
+                verdict payload.
+        """
         target = intent.payload["target_proposal_msg_id"]
         pending = self.state.pending_proposals.get(target)
         verdict_map = intent.payload.get("verdict_map")
@@ -4805,7 +5222,14 @@ class Coordinator:
         verdict: str,
         reasoning: str,
     ) -> None:
-        """Legacy v0.6 single-verdict handler (approve materialises proposal as-is); mirrors integrate_patch/specialist verdicts onto specialist_patch_verdicts for PolicyGate."""
+        """Legacy v0.6 single-verdict handler (approve materialises proposal as-is); mirrors integrate_patch/specialist verdicts onto specialist_patch_verdicts for PolicyGate.
+
+        Args:
+            source: Agent name issuing the verdict.
+            pending: The pending proposal being decided.
+            verdict: The collapsed verdict ("approve"/"reject"/"needs_review").
+            reasoning: Free-form rationale recorded with the verdict.
+        """
         pending.decided = True
         pending.verdict = verdict
         await self.bus.append_and_seq(Message.new(
@@ -4847,7 +5271,12 @@ class Coordinator:
             await self._materialize_approved_proposal(pending)
 
     def _inject_explore_runtime_params(self, params: dict) -> None:
-        """Inject explore-task operational knobs from SharedState into ``params`` (single source of truth for both propose/Critic and direct-delegate paths). setdefault preserves LLM overrides. Knobs: baseline_runtime_sec + explore_overtime_kill_ratio (Fix E soft_deadline), variant_timeout_sec, variant_timeout_safety_margin, roofline_saturation_snapshot (advisory)."""
+        """Inject explore-task operational knobs from SharedState into ``params`` (single source of truth for both propose/Critic and direct-delegate paths). setdefault preserves LLM overrides. Knobs: baseline_runtime_sec + explore_overtime_kill_ratio (Fix E soft_deadline), variant_timeout_sec, variant_timeout_safety_margin, roofline_saturation_snapshot (advisory).
+
+        Args:
+            params: Explore-task params mutated in place with operational
+                knobs (existing keys are preserved).
+        """
         br = float(getattr(self.shared_state, "baseline_runtime_sec", 0.0) or 0.0)
         if br > 0:
             params.setdefault("baseline_runtime_sec", br)
@@ -4886,7 +5315,13 @@ class Coordinator:
         *,
         approved_variant_names: set[str] | None = None,
     ) -> None:
-        """Promote an approved proposal into a TaskRegistry entry. Grid executors get current best tput as base_tput (DESIGN §16); approved_variant_names filters the explore grid (None keeps full)."""
+        """Promote an approved proposal into a TaskRegistry entry. Grid executors get current best tput as base_tput (DESIGN §16); approved_variant_names filters the explore grid (None keeps full).
+
+        Args:
+            pending: The approved proposal to materialize into a task.
+            approved_variant_names: Optional set of explore variant names to
+                keep; ``None`` keeps the full grid.
+        """
         params = dict(pending.payload.get("params") or {})
         # Filter the grid to the Critic-approved subset.
         if (
@@ -5133,7 +5568,13 @@ class Coordinator:
     def _record_framework_pr_authored_outcome(
         self, *, task: "Task", result: Any,
     ) -> None:
-        """Bridge an authored-patch ``integrate_patch`` outcome into the FRAMEWORK_PR progress ledger (else the gain is invisible). Attributed to the latest batch; only kept/reverted rows."""
+        """Bridge an authored-patch ``integrate_patch`` outcome into the FRAMEWORK_PR progress ledger (else the gain is invisible). Attributed to the latest batch; only kept/reverted rows.
+
+        Args:
+            task: The integrate_patch task carrying authoring provenance.
+            result: The task result whose ``status`` (kept/reverted) and gain
+                are recorded.
+        """
         res = getattr(result, "result", None)
         if not isinstance(res, dict):
             return
@@ -5203,7 +5644,14 @@ class Coordinator:
         normal ``_handle_delegate`` path (warm + idempotency + TaskRegistry +
         lease + reap), preserving the low-cost wide-net recon the retired
         dynamic_specialist channel provided. Per-task idempotency keys derive
-        from the wave key; non-dict / empty-description entries are skipped."""
+        from the wave key; non-dict / empty-description entries are skipped.
+
+        Args:
+            source: Agent name issuing the wave delegate.
+            intent: The originating delegate intent.
+            params: Delegate params carrying the ``tasks`` list plus shared
+                fields applied to every fanned task.
+        """
         tasks = params.get("tasks") or []
         shared = {k: v for k, v in params.items() if k != "tasks"}
         base_key = str(intent.payload.get("idempotency_key") or "").strip()
@@ -5252,7 +5700,15 @@ class Coordinator:
         (timeout / crash / stale-heartbeat, per ``classify_specialist_failure``)
         are retried, capped at :data:`SPECIALIST_AUTO_RETRY_MAX`; the failure
         reason is injected into the retry prompt. Disabled when
-        ``INFERENCE_OPTIMIZER_SPECIALIST_AUTO_RETRY`` is set to ``0``."""
+        ``INFERENCE_OPTIMIZER_SPECIALIST_AUTO_RETRY`` is set to ``0``.
+
+        Args:
+            task: The failed specialist task.
+            result: The sub-agent result classified for retry eligibility.
+
+        Returns:
+            ``True`` when a retry was scheduled, ``False`` otherwise.
+        """
         flag = os.environ.get(
             "INFERENCE_OPTIMIZER_SPECIALIST_AUTO_RETRY", "1",
         ).strip().lower()
@@ -5333,7 +5789,12 @@ class Coordinator:
 
     # specialist pre-dispatch warmup
     async def _warm_specialist_params(self, params: dict[str, Any]) -> None:
-        """Fill specialist task params with KnowledgePlane data before enqueue (mutates in place); all best-effort, missing fields stay empty."""
+        """Fill specialist task params with KnowledgePlane data before enqueue (mutates in place); all best-effort, missing fields stay empty.
+
+        Args:
+            params: Specialist task params mutated in place with KnowledgePlane
+                context.
+        """
         state = self.shared_state
         plane = self.knowledge_plane
 
@@ -5530,7 +5991,14 @@ class Coordinator:
 
     @staticmethod
     def _pr_summary_to_dict(pr: Any) -> dict[str, Any]:
-        """Flatten a PRSummary into the dict SpecialistPromptBuilder expects."""
+        """Flatten a PRSummary into the dict SpecialistPromptBuilder expects.
+
+        Args:
+            pr: A PRSummary-like object with repo/number/title/url/etc.
+
+        Returns:
+            A flat dict of the PR's summary fields.
+        """
         return {
             "repo":   str(getattr(pr, "repo", "")),
             "number": int(getattr(pr, "number", 0) or 0),
@@ -5543,7 +6011,11 @@ class Coordinator:
 
     # gaps[] ledger refresh
     async def _refresh_gaps(self, *, reason: str) -> None:
-        """Refresh :attr:`SharedState.gaps` from observable signals (Coordinator is sole writer, Inv-1). Additive upsert deduped by canonical_id; best-effort."""
+        """Refresh :attr:`SharedState.gaps` from observable signals (Coordinator is sole writer, Inv-1). Additive upsert deduped by canonical_id; best-effort.
+
+        Args:
+            reason: Tag used for logging the refresh trigger.
+        """
         state = self.shared_state
         try:
             for entry in self._extract_gaps_from_baseline():
@@ -5582,7 +6054,11 @@ class Coordinator:
         )
 
     def _extract_gaps_from_baseline(self) -> list[dict[str, Any]]:
-        """Derive initial gap rows from the baseline snapshot (throughput_below_target, baseline_unstable); reuse the M1 anchor canonical_id so traverse rows align."""
+        """Derive initial gap rows from the baseline snapshot (throughput_below_target, baseline_unstable); reuse the M1 anchor canonical_id so traverse rows align.
+
+        Returns:
+            List of gap row dicts derived from the baseline snapshot.
+        """
         state = self.shared_state
         gaps: list[dict[str, Any]] = []
         if state.baseline_tput <= 0:
@@ -5623,7 +6099,11 @@ class Coordinator:
         return gaps
 
     def _extract_gaps_from_attempts(self) -> list[dict[str, Any]]:
-        """Derive gaps from rolling failures + winners history (recurring (action, error_class) + explore plateau)."""
+        """Derive gaps from rolling failures + winners history (recurring (action, error_class) + explore plateau).
+
+        Returns:
+            List of gap row dicts derived from recent attempts.
+        """
         state = self.shared_state
         anchor = self._gap_anchor_canonical_id()
         gaps: list[dict[str, Any]] = []
@@ -5683,7 +6163,14 @@ class Coordinator:
 
     @staticmethod
     def _gap_layer_for_action(action: str) -> tuple[str, str]:
-        """Map an action name → (layer, domain_hint) for gap rows (fallback ("framework", "serving_specialist"))."""
+        """Map an action name → (layer, domain_hint) for gap rows (fallback ("framework", "serving_specialist")).
+
+        Args:
+            action: The action name to classify.
+
+        Returns:
+            Tuple of (layer, domain_hint) for the action.
+        """
         a = str(action or "").strip().lower()
         if a in {"kernel_opt", "integrate", "trace_analyze", "run_gemm_tuning", "run_optimization"}:
             return ("kernel", "kernel_switch_specialist")
@@ -5698,7 +6185,13 @@ class Coordinator:
     def _record_explore_round_gaps(
         self, *, task: "Task | None", result: dict[str, Any],
     ) -> None:
-        """Append per-variant KEEP/REVERT outcomes to the matching gap (or the anchor gap as fallback)."""
+        """Append per-variant KEEP/REVERT outcomes to the matching gap (or the anchor gap as fallback).
+
+        Args:
+            task: The explore task whose params carry the gap canonical id;
+                ``None`` is a no-op.
+            result: The explore result carrying ``per_variant_outcomes``.
+        """
         if task is None:
             return
         per_variant = result.get("per_variant_outcomes")
@@ -5734,7 +6227,12 @@ class Coordinator:
     async def _handle_specialist_done(
         self, source: str, intent: Intent,
     ) -> None:
-        """Handle a ``specialist_done`` intent (source ``specialist:<task_id>`` per Inv-5.3 / R3); bookkeeping in _record_specialist_result."""
+        """Handle a ``specialist_done`` intent (source ``specialist:<task_id>`` per Inv-5.3 / R3); bookkeeping in _record_specialist_result.
+
+        Args:
+            source: The ``specialist:<task_id>`` source agent string.
+            intent: The ``specialist_done`` intent payload.
+        """
         payload = dict(intent.payload or {})
         task_id = self._task_id_from_specialist_source(source)
         task: Task | None = None
@@ -5758,7 +6256,15 @@ class Coordinator:
 
     @staticmethod
     def _task_id_from_specialist_source(source: str) -> str:
-        """Extract the task_id from a ``specialist:<task_id>`` source ("" when prefix is absent)."""
+        """Extract the task_id from a ``specialist:<task_id>`` source ("" when prefix is absent).
+
+        Args:
+            source: The source agent string to parse.
+
+        Returns:
+            The extracted task id, or an empty string when the prefix is
+            absent.
+        """
         if not source:
             return ""
         if source.startswith(SPECIALIST_FROM_AGENT_PREFIX):
@@ -5772,7 +6278,13 @@ class Coordinator:
         done_payload: dict[str, Any],
         source: str,
     ) -> None:
-        """Common bookkeeping for any specialist task termination (dispatcher loop + intent routing); idempotent on round_id, failures logged not raised."""
+        """Common bookkeeping for any specialist task termination (dispatcher loop + intent routing); idempotent on round_id, failures logged not raised.
+
+        Args:
+            task: The terminated specialist task.
+            done_payload: The specialist's completion payload.
+            source: The source agent string for the result.
+        """
         domain = str(done_payload.get("domain") or "").strip()
         proposals = done_payload.get("proposal_set") or []
         if not isinstance(proposals, list):
@@ -5907,7 +6419,12 @@ class Coordinator:
             )
 
     def _plateau_advisory_block(self) -> str:
-        """Render the plateau-judgment advisory block (EXPLORE/KERNEL/FRAMEWORK_PR; advisory, never gates). Returns "" when no plateau signal is active."""
+        """Render the plateau-judgment advisory block (EXPLORE/KERNEL/FRAMEWORK_PR; advisory, never gates). Returns "" when no plateau signal is active.
+
+        Returns:
+            The advisory block text, or an empty string when no plateau signal
+            is active.
+        """
         state = self.shared_state
         phase = (getattr(state, "phase", "") or "").strip().upper()
         overrides = getattr(state, "plateau_overrides", None) or {}
@@ -6003,7 +6520,12 @@ class Coordinator:
         return "\n".join(lines)
 
     def _target_gap_advisory_block(self) -> str:
-        """Build the advisory "External target gap" prompt block (current-best vs competitor target; never gates)."""
+        """Build the advisory "External target gap" prompt block (current-best vs competitor target; never gates).
+
+        Returns:
+            The gap-summary block text, or an empty string when advisory is
+            disabled or no target/current-best is available.
+        """
         state = self.shared_state
         if not bool(getattr(state, "target_advisory_enabled", True)):
             return ""
@@ -6034,7 +6556,11 @@ class Coordinator:
         return _research_hints.full_gap_summary(gap)
 
     def _current_primary_gap(self) -> str | None:
-        """Resolve the dominant external gap direction ('latency'/'throughput') from the competitor target, or None when advisory is off / no target. Fail-soft."""
+        """Resolve the dominant external gap direction ('latency'/'throughput') from the competitor target, or None when advisory is off / no target. Fail-soft.
+
+        Returns:
+            The primary gap direction string, or ``None`` when unavailable.
+        """
         state = self.shared_state
         if not bool(getattr(state, "target_advisory_enabled", True)):
             return None
@@ -6075,7 +6601,14 @@ class Coordinator:
     def _recent_proposed_variants(
         self, *, max_rounds: int = 2,
     ) -> list[dict[str, Any]]:
-        """Collect proposal_set rows from the most recent specialist rounds (deduped by name; fail-soft)."""
+        """Collect proposal_set rows from the most recent specialist rounds (deduped by name; fail-soft).
+
+        Args:
+            max_rounds: Number of most-recent specialist rounds to scan.
+
+        Returns:
+            De-duplicated list of proposed variant dicts.
+        """
         rounds = [
             r for r in (getattr(self.shared_state, "specialist_rounds", []) or [])
             if isinstance(r, dict) and isinstance(r.get("proposal_set"), list)
@@ -6093,7 +6626,12 @@ class Coordinator:
         return out
 
     def _priors_match_advisory_block(self) -> str:
-        """Flag recently proposed variants aligning with proven priors / dominant external gap (advisory ordering, fail-soft)."""
+        """Flag recently proposed variants aligning with proven priors / dominant external gap (advisory ordering, fail-soft).
+
+        Returns:
+            The priors-match advisory text, or an empty string when there are
+            no recent variants or on failure.
+        """
         try:
             from . import research_hints as _research_hints
 
@@ -6111,7 +6649,13 @@ class Coordinator:
     async def _maybe_autosubmit_specialist_patches(
         self, *, task: "Task", done_payload: dict[str, Any],
     ) -> None:
-        """B3: auto-surface a specialist's source patches to the Critic via a synthetic integrate_patch proposal; idempotent per specialist."""
+        """B3: auto-surface a specialist's source patches to the Critic via a synthetic integrate_patch proposal; idempotent per specialist.
+
+        Args:
+            task: The completed specialist task.
+            done_payload: The specialist's completion payload carrying
+                ``patches_written``.
+        """
         patches = done_payload.get("patches_written") or []
         if not isinstance(patches, list) or not patches:
             return
@@ -6210,7 +6754,16 @@ class Coordinator:
         done_payload: dict[str, Any],
         source: str,
     ) -> dict[str, Any]:
-        """Translate a specialist done payload into a SharedState.specialist_rounds[] row; round_id defaults to task_id for idempotent overwrite (M5)."""
+        """Translate a specialist done payload into a SharedState.specialist_rounds[] row; round_id defaults to task_id for idempotent overwrite (M5).
+
+        Args:
+            task: The completed specialist task.
+            done_payload: The specialist's completion payload.
+            source: The source agent string for the round.
+
+        Returns:
+            A specialist-round entry dict ready to persist.
+        """
         proposals = done_payload.get("proposal_set") or []
         if not isinstance(proposals, list):
             proposals = []
@@ -6270,6 +6823,13 @@ class Coordinator:
 
         Best-effort by design: operator-facing logging must never break the
         orchestration loop, so any failure is swallowed at debug level.
+
+        Args:
+            step: Lifecycle step name.
+            status: Event status (e.g. "START", "END", "ERROR").
+            artifacts: Optional map of produced artifact names to paths.
+            detail: Optional free-form detail string.
+            duration_s: Optional step duration in seconds.
         """
         try:
             self.shared_state.record_lifecycle_event(
@@ -6530,7 +7090,16 @@ class Coordinator:
                 )
 
     def _cached_kernel_request(self, kind: str, payload: dict[str, Any]) -> dict[str, Any] | None:
-        """Return a cached programmatic_handler result if applicable (cache key last_trace_analyze)."""
+        """Return a cached programmatic_handler result if applicable (cache key last_trace_analyze).
+
+        Args:
+            kind: Kernel request kind; only ``trace_analyze`` is cacheable.
+            payload: Request payload carrying the trace input.
+
+        Returns:
+            The cached result dict, or ``None`` when there is no usable cache
+            hit.
+        """
         if kind != "trace_analyze":
             return None
         cached = self.shared_state.last_trace_analyze or {}
@@ -6644,7 +7213,12 @@ class Coordinator:
         ))
 
     async def _handle_escalate_strategy_change(self, source: str, intent: Intent) -> None:
-        """Process ``escalate_strategy_change`` (KB_design §3.8 §7.3 + §3.13 M7 §5.3); broadcasts strategy_change, acts on closed-vocab hints, drops unknown (Inv-8.2)."""
+        """Process ``escalate_strategy_change`` (KB_design §3.8 §7.3 + §3.13 M7 §5.3); broadcasts strategy_change, acts on closed-vocab hints, drops unknown (Inv-8.2).
+
+        Args:
+            source: Agent issuing the escalation.
+            intent: The ``escalate_strategy_change`` intent carrying the hint.
+        """
         payload = dict(intent.payload or {})
         # Always emit the broadcast first (back-compat with legacy contract tests).
         await self.bus.append_and_seq(Message.new(
@@ -6827,7 +7401,11 @@ class Coordinator:
             await self.cursors.advance(agent_name, seq=top.seq, msg_id=top.msg_id)
 
     def _record_kernel_opt_partial(self, result: dict[str, Any]) -> None:
-        """Streaming callback for ``_run_optimization_batch`` sub-attempts: write each per-kernel entry to kernel_opt_attempts immediately so the next-tick prompt is accurate mid-batch."""
+        """Streaming callback for ``_run_optimization_batch`` sub-attempts: write each per-kernel entry to kernel_opt_attempts immediately so the next-tick prompt is accurate mid-batch.
+
+        Args:
+            result: A per-kernel sub-attempt result to record.
+        """
         try:
             self.shared_state.record_kernel_opt(result)
             self.shared_state.save(self.session_dir)
@@ -6963,7 +7541,12 @@ class Coordinator:
     def _record_intervention_for_task(
         self, task: "Task", result: Any,
     ) -> None:
-        """PR-A8: log a completed task's change_type into SharedState.intervention_mix (explore → config; integrate_patch → code_patch_attempt or code_patch when kept). Best-effort."""
+        """PR-A8: log a completed task's change_type into SharedState.intervention_mix (explore → config; integrate_patch → code_patch_attempt or code_patch when kept). Best-effort.
+
+        Args:
+            task: The completed task whose change type is recorded.
+            result: The task result payload; non-dicts are ignored.
+        """
         if not isinstance(result, dict):
             return
         kind = (task.kind or "").strip()
@@ -7012,7 +7595,12 @@ class Coordinator:
     async def _handle_unpromotable_result(
         self, task: Task, result: dict[str, Any] | None,
     ) -> None:
-        """Record a failed / unpromotable task result into SharedState: append to last_action_failures (+ a failed attempts row for _AUDIT_ACTIONS); keep baseline failure_streak/stop_reason logic intact."""
+        """Record a failed / unpromotable task result into SharedState: append to last_action_failures (+ a failed attempts row for _AUDIT_ACTIONS); keep baseline failure_streak/stop_reason logic intact.
+
+        Args:
+            task: The failed or unpromotable task.
+            result: The task result payload; ``None`` is treated as empty.
+        """
         result_payload = result or {}
         any_changed = False
         # Per-action audit (failed attempt) for the 6 in-scope kinds.
@@ -7351,7 +7939,16 @@ class Coordinator:
         holders: dict[str, int],
         capacities: dict[str, int],
     ) -> bool:
-        """Local-view headroom hint for the concurrent dispatcher (authoritative gate is try_acquire_many)."""
+        """Local-view headroom hint for the concurrent dispatcher (authoritative gate is try_acquire_many).
+
+        Args:
+            expanded_lanes: Lane names the task requires (already expanded).
+            holders: Map of lane name to current holder count.
+            capacities: Map of lane name to capacity.
+
+        Returns:
+            ``True`` when every required lane has local headroom.
+        """
         for lane in expanded_lanes:
             cap = int(capacities.get(lane, 1))
             used = int(holders.get(lane, 0))
@@ -7364,6 +7961,9 @@ class Coordinator:
         """Return the hyperloom-local session id used as source_session_id on KB fact writes.
 
         NOT a KB-side session id; prefers cortex_session_id, falls back to session_dir.name.
+
+        Returns:
+            The hyperloom-local session id string.
         """
         return (
             str(getattr(self.shared_state, "cortex_session_id", "") or "")
@@ -7377,7 +7977,13 @@ class Coordinator:
         result: Any,
         kept: bool,
     ) -> None:
-        """Per-task fact-write entry point (per_variant for explore grids, else per-task); best-effort, never raises."""
+        """Per-task fact-write entry point (per_variant for explore grids, else per-task); best-effort, never raises.
+
+        Args:
+            task: The terminated task.
+            result: The task result (object or dict) to translate into facts.
+            kept: Whether the task's change was kept.
+        """
         result_dict = result.result if hasattr(result, "result") else (result or {})
         if not isinstance(result_dict, dict):
             result_dict = {}
@@ -7420,7 +8026,11 @@ class Coordinator:
     # Fact-write surface — journal + direct KB lesson/pitfall/recipe writes (the fact side of KB integration).
     PITFALL_REGRESS_THRESHOLD_PCT: float = -5.0  # gain_pct ≤ this → pitfall
     def _ensure_journal(self) -> Journal:
-        """Lazy-instantiate the per-session :class:`Journal` (load_or_create reads an existing file on resume)."""
+        """Lazy-instantiate the per-session :class:`Journal` (load_or_create reads an existing file on resume).
+
+        Returns:
+            The per-session :class:`Journal` instance.
+        """
         existing = getattr(self, "_journal", None)
         if existing is None:
             ss = self.shared_state
@@ -7444,7 +8054,14 @@ class Coordinator:
     def _pitfall_severity_for(
         self, result_dict: dict[str, Any] | None,
     ) -> str | None:
-        """Decide whether a failed result warrants a pitfall row (Threshold-B): crash/oom/hang → SEVERITY_CRASH; gain_pct ≤ -5% → SEVERITY_REGRESS; else None."""
+        """Decide whether a failed result warrants a pitfall row (Threshold-B): crash/oom/hang → SEVERITY_CRASH; gain_pct ≤ -5% → SEVERITY_REGRESS; else None.
+
+        Args:
+            result_dict: The task result payload; non-dicts yield ``None``.
+
+        Returns:
+            The pitfall severity tag, or ``None`` when no pitfall is warranted.
+        """
         if not isinstance(result_dict, dict):
             return None
         error_class = str(result_dict.get("error_class") or "").lower()
@@ -7478,7 +8095,14 @@ class Coordinator:
         result_dict: dict[str, Any],
         kept: bool,
     ) -> None:
-        """Per-task fact write — one journal row + maybe one KB fact (source_session_id is hyperloom-local)."""
+        """Per-task fact write — one journal row + maybe one KB fact (source_session_id is hyperloom-local).
+
+        Args:
+            task: The terminated task.
+            source_session_id: Hyperloom-local session id stamped on writes.
+            result_dict: The task result payload.
+            kept: Whether the task's change was kept.
+        """
         journal = self._ensure_journal()
         gain_raw = result_dict.get("gain_pct")
         try:
@@ -7582,7 +8206,17 @@ class Coordinator:
         gain_pct: float | None = None,  # kept for backward call-signature compat
         severity: str | None = None,
     ) -> str:
-        """Build the lesson statement / pitfall description hashed into the KB canonical_id; MUST exclude volatile fields (e.g. gain_pct) so N sessions merge instead of producing N rows. Identity = framework + change + model/hw."""
+        """Build the lesson statement / pitfall description hashed into the KB canonical_id; MUST exclude volatile fields (e.g. gain_pct) so N sessions merge instead of producing N rows. Identity = framework + change + model/hw.
+
+        Args:
+            change: Human-readable change summary.
+            kind: Statement kind ("lesson" or "pitfall").
+            gain_pct: Kept for call-signature compatibility; not hashed in.
+            severity: Pitfall severity tag (used only for pitfalls).
+
+        Returns:
+            The lesson/pitfall statement string.
+        """
         framework = str(getattr(self.shared_state, "framework", "") or "").strip()
         fw_tag = f"[{framework or '?'}] "
         model = self.shared_state.model_name or "?"
@@ -7602,7 +8236,18 @@ class Coordinator:
         measured_at: str,
         throughput_before: float | None = None,
     ) -> dict[str, Any]:
-        """GAP 3 — structured ``measured_impact`` payload (dict not legacy string so consumers parse without regex); stack_depth = stack length before this lesson lands."""
+        """GAP 3 — structured ``measured_impact`` payload (dict not legacy string so consumers parse without regex); stack_depth = stack length before this lesson lands.
+
+        Args:
+            gain_pct: Measured gain percentage, if any.
+            throughput_after: Throughput after the change, if any.
+            stack_depth: Optimization-stack length before this lesson lands.
+            measured_at: ISO timestamp of the measurement.
+            throughput_before: Throughput before the change, if any.
+
+        Returns:
+            A compact ``measured_impact`` dict with None fields stripped.
+        """
         out: dict[str, Any] = {
             "gain_pct": float(gain_pct) if gain_pct is not None else None,
             "stack_depth_at_apply": int(stack_depth),
@@ -7622,7 +8267,13 @@ class Coordinator:
         source_session_id: str,
         variant_outcome: dict[str, Any],
     ) -> None:
-        """Per-variant fact write — mirror of _record_fact_per_task for explore per-variant decisions."""
+        """Per-variant fact write — mirror of _record_fact_per_task for explore per-variant decisions.
+
+        Args:
+            task: The explore task being recorded.
+            source_session_id: Hyperloom-local session id stamped on writes.
+            variant_outcome: One per-variant outcome dict from the result.
+        """
         journal = self._ensure_journal()
         outcome_raw = str(variant_outcome.get("outcome") or "")
         if outcome_raw == "KEEP":
@@ -7749,7 +8400,11 @@ class Coordinator:
             )
 
     def _collect_workload_tags(self) -> dict[str, Any]:
-        """Return the workload-shape KB tag dict for the current session (GAP 5); shared by recipe attrs + lesson/pitfall writes so the warm-start reader filters symmetrically."""
+        """Return the workload-shape KB tag dict for the current session (GAP 5); shared by recipe attrs + lesson/pitfall writes so the warm-start reader filters symmetrically.
+
+        Returns:
+            Mapping of workload-shape KB tags for the current session.
+        """
         ss = self.shared_state
         out: dict[str, Any] = {}
         framework = str(getattr(ss, "framework", "") or "").strip()
@@ -7826,7 +8481,11 @@ class Coordinator:
         return out
 
     def _build_kernel_optimizations_from_state(self) -> list[dict[str, Any]]:
-        """Collect KEEP'd kernel optimizations + their E2E verdict by joining kernel_opt_attempts (micro) and kernel_integrate_attempts (E2E) on kernel_id; non-integrated KEEPs surface integrated=False. Returns KernelOptimization-shaped dicts."""
+        """Collect KEEP'd kernel optimizations + their E2E verdict by joining kernel_opt_attempts (micro) and kernel_integrate_attempts (E2E) on kernel_id; non-integrated KEEPs surface integrated=False. Returns KernelOptimization-shaped dicts.
+
+        Returns:
+            List of KernelOptimization-shaped dicts for KEEP'd kernels.
+        """
         ss = self.shared_state
         opt_attempts = getattr(ss, "kernel_opt_attempts", {}) or {}
         integ_attempts = getattr(ss, "kernel_integrate_attempts", {}) or {}
@@ -7894,7 +8553,12 @@ class Coordinator:
     def _collect_attempt_provenance(
         self,
     ) -> tuple[dict[str, str], dict[str, str], list[dict[str, Any]]]:
-        """Map proven optimizations to their research-hint origin from the gaps[] attempts ledger; returns (kept_sources by name/kernel, kept_by_gap by canonical_id, reverted_rows). Fail-soft."""
+        """Map proven optimizations to their research-hint origin from the gaps[] attempts ledger; returns (kept_sources by name/kernel, kept_by_gap by canonical_id, reverted_rows). Fail-soft.
+
+        Returns:
+            Tuple of (kept_sources by name/kernel, kept_by_gap by canonical_id,
+            reverted_rows list).
+        """
         kept_sources: dict[str, str] = {}
         kept_by_gap: dict[str, str] = {}
         reverted_rows: list[dict[str, Any]] = []
@@ -7929,7 +8593,11 @@ class Coordinator:
         return kept_sources, kept_by_gap, reverted_rows
 
     def _build_recipe_attrs_from_state(self) -> dict[str, Any]:
-        """Materialise the recipe-shaped view of :class:`SharedState` (kg-usage-guide §7.4; defensive getattr)."""
+        """Materialise the recipe-shaped view of :class:`SharedState` (kg-usage-guide §7.4; defensive getattr).
+
+        Returns:
+            A recipe-shaped attrs dict derived from the current shared state.
+        """
         ss = self.shared_state
         current_best = getattr(ss, "current_best", {}) or {}
         opt_stack = getattr(ss, "optimization_stack", []) or []
@@ -8191,7 +8859,15 @@ class Coordinator:
         self, task_kind: str, best_tput: float, bv: dict[str, Any],
         *, gap_canonical_id: str = "",
     ) -> None:
-        """Update SharedState.current_best + recompute cumulative_gain; gap_canonical_id (when known) is stamped onto the stack entry so provenance resolves by gap id not name."""
+        """Update SharedState.current_best + recompute cumulative_gain; gap_canonical_id (when known) is stamped onto the stack entry so provenance resolves by gap id not name.
+
+        Args:
+            task_kind: The action kind that produced the winning variant.
+            best_tput: The winning throughput to promote.
+            bv: The best-variant payload (args, envs, metrics, workspace).
+            gap_canonical_id: Optional gap id stamped onto the stack entry for
+                provenance.
+        """
         previous = self.shared_state.current_best or {}
         if not self.shared_state.optimization_stack:
             self.shared_state.seed_stack_from_current_best()
@@ -8279,7 +8955,13 @@ class Coordinator:
         *,
         task: "Task | None" = None,
     ) -> None:
-        """Lift specific action-result fields into the persistent SharedState (baseline/profile/roofline/grid)."""
+        """Lift specific action-result fields into the persistent SharedState (baseline/profile/roofline/grid).
+
+        Args:
+            task_kind: The action kind whose result is being promoted.
+            result: The action result payload; non-dicts are ignored.
+            task: The originating task, when available.
+        """
         if not isinstance(result, dict):
             return
         changed = False

--- a/inference_optimizer/orchestrator/coordinator_helpers.py
+++ b/inference_optimizer/orchestrator/coordinator_helpers.py
@@ -18,7 +18,16 @@ log = logging.getLogger(__name__)
 
 
 def _infer_model_class_from_config(model_path: str) -> str:
-    """Infer a deterministic model_class from local model metadata."""
+    """Infer a deterministic model_class from local model metadata.
+
+    Args:
+        model_path: Local filesystem path to the model directory containing
+            ``config.json``.
+
+    Returns:
+        One of ``moe_mla_nsa`` / ``moe_mla`` / ``moe_swa`` / ``dense`` derived
+        from the model's architecture and config.
+    """
     import json
     raw_path = (model_path or "").strip()
     payload: dict[str, Any] = {}
@@ -124,6 +133,15 @@ def effective_closing_grace_sec(
 
     Explicit ``closing_grace_sec`` (including ``0`` to disable) wins;
     otherwise default to ``min(120, max_minutes * 60 * 0.02)``.
+
+    Args:
+        max_minutes: Total session budget in minutes, used to derive the
+            default grace window.
+        closing_grace_sec: Explicit grace window in seconds, or ``None`` to use
+            the derived default.
+
+    Returns:
+        The closing-phase grace window in seconds.
     """
     if closing_grace_sec is not None:
         return float(closing_grace_sec)
@@ -134,6 +152,13 @@ def _parse_iso_unix(ts: str) -> float:
     """Parse an ISO 8601 UTC timestamp into unix seconds; ``0.0`` on failure.
 
     Naive timestamps are treated as UTC. Never raises.
+
+    Args:
+        ts: An ISO 8601 timestamp string (``Z`` suffix accepted).
+
+    Returns:
+        The timestamp as unix epoch seconds, or ``0.0`` when empty or
+        unparseable.
     """
     s = (ts or "").strip()
     if not s:
@@ -154,6 +179,14 @@ def _summarize_failed_variants(
 
     Returns ``[{name, error_class, error_excerpt, extra_server_args}, ...]``
     (excerpt capped at 400 chars, at most ``max_entries`` rows).
+
+    Args:
+        all_results: The grid_runner result rows to scan (non-list inputs
+            yield an empty list).
+        max_entries: Maximum number of failed rows to include.
+
+    Returns:
+        A compact list of failed-variant dicts.
     """
     if not isinstance(all_results, list):
         return []
@@ -181,6 +214,13 @@ def _parse_baseline_workload_extra(yaml_path: str) -> dict[str, Any]:
     Reads workload-shape fields outside ``_collect_workload_tags`` from
     ``benchmark.envs`` extra-args blobs and top-level ``benchmark`` fields.
     Defensive — parse errors return ``{}``.
+
+    Args:
+        yaml_path: Path to the baseline-materialized Magpie YAML file.
+
+    Returns:
+        A dict of extracted workload-tag fields, or ``{}`` on any read/parse
+        error.
     """
     import yaml as _yaml
     try:
@@ -240,6 +280,12 @@ def _baseline_params_fingerprint(params: dict[str, Any] | None) -> dict[str, Any
     Missing keys recorded as ``None``; ``extra_envs`` normalized to a sorted
     list of stringified ``[key, value]`` pairs so ordering doesn't affect
     equality.
+
+    Args:
+        params: The baseline action params to fingerprint, or ``None``.
+
+    Returns:
+        A fingerprint dict keyed by the baseline-determining params.
     """
     params = params or {}
     out: dict[str, Any] = {}
@@ -259,7 +305,12 @@ def _baseline_params_fingerprint(params: dict[str, Any] | None) -> dict[str, Any
 
 
 def _resolve_roofline_watermark_ratio() -> float:
-    """Resolve the roofline watermark ratio from ``$HYPERLOOM_ROOFLINE_WATERMARK_RATIO`` (fallback 1.10)."""
+    """Resolve the roofline watermark ratio from ``$HYPERLOOM_ROOFLINE_WATERMARK_RATIO`` (fallback 1.10).
+
+    Returns:
+        The configured ratio when it parses to a float greater than 1.0,
+        otherwise the default ``1.10``.
+    """
     raw = (os.environ.get(_ROOFLINE_WATERMARK_RATIO_ENV) or "").strip()
     if not raw:
         return _DEFAULT_ROOFLINE_WATERMARK_RATIO
@@ -281,6 +332,15 @@ def _merge_cumulative_extra_sglang_args(
 
     Prefer the full stack and dedupe, since joining ``base + candidate``
     when both are full stacks duplicates flags.
+
+    Args:
+        base_args: The baseline launch args string.
+        candidate_args: The candidate's launch args string.
+        full_args: The full cumulative stack args string, preferred when
+            present and distinct from the candidate.
+
+    Returns:
+        The merged, deduplicated launch args string.
     """
     base = str(base_args or "").strip()
     candidate = str(candidate_args or "").strip()
@@ -303,6 +363,12 @@ def _dedupe_extra_server_args(args_str: str) -> str:
     Keep each flag once with its last value (first-seen order preserved),
     since argparse ``action="store"`` only honors the last value. Flags in
     ``_MULTI_VALUE_SGLANG_FLAGS`` keep their multi-value runs.
+
+    Args:
+        args_str: The space-separated launch args string to deduplicate.
+
+    Returns:
+        The deduplicated launch args string, or ``""`` when input is empty.
     """
     if not args_str:
         return ""

--- a/inference_optimizer/orchestrator/cortex_t0.py
+++ b/inference_optimizer/orchestrator/cortex_t0.py
@@ -59,6 +59,13 @@ def _build_warm_prefer(shared_state: Any, framework_version: str) -> dict[str, A
     Only non-empty values are included; the dispatcher skips absent
     fields. ``quant_scheme`` / ``workload_mode`` ride on the per-baseline
     ``baseline_workload_extra`` map when present.
+
+    Args:
+        shared_state: The live SharedState carrying workload knobs.
+        framework_version: The resolved framework version, included when set.
+
+    Returns:
+        The ``prefer`` similarity-hint dict (non-empty fields only).
     """
     prefer: dict[str, Any] = {}
     for attr in _PREFER_NUMERIC_ATTRS:
@@ -84,6 +91,12 @@ def _remote_is_gbrain(kb: Any) -> bool:
     adapter; otherwise the source is the cortex kb-service (or local-only
     fallback, which we still label ``cortex-kb`` since that is the
     configured remote contract).
+
+    Args:
+        kb: The recipe-KB dispatcher whose active remote is inspected.
+
+    Returns:
+        ``True`` when the active remote is the gbrain adapter.
     """
     remote = getattr(kb, "remote", None)
     return type(remote).__name__ == "GbrainRemoteRecipeClient"
@@ -96,6 +109,13 @@ def _recipe_is_actionable(row: Mapping[str, Any]) -> bool:
     tags but no champion / experiential lists) is NOT actionable: treating
     it as a confident hit would let warm-replay apply an empty config and
     starve the specialist prompt of real priors.
+
+    Args:
+        row: A warm recipe row to inspect.
+
+    Returns:
+        ``True`` when the row carries a usable config, positive throughput, or
+        any experiential list worth replaying.
     """
     if not isinstance(row, Mapping):
         return False
@@ -133,6 +153,19 @@ def _build_warm_start_context(
     ready-to-replay champion plus the experiential lists, so consumers
     (warm-replay / specialist prompt / ledger) never parse the raw
     recipe shape.
+
+    Args:
+        status: The warm-start status (``hit`` / ``seed_only`` / ``miss`` /
+            ``error``).
+        tier: The match tier (e.g. ``exact`` / ``relative`` / ``seed_only``).
+        confidence: The match confidence score.
+        canonical_id: The recipe's canonical id.
+        source: The serving source label (e.g. ``gbrain`` / ``cortex-kb``).
+        recipe: The matched recipe row, or ``None``.
+
+    Returns:
+        The model-facing WarmStartContext dict; replay/prior fields are only
+        populated for a ``hit``.
     """
     ctx: dict[str, Any] = {
         "status": status,
@@ -195,6 +228,28 @@ def run_t0_anchor(
 
     Mutates ``shared_state`` in place (warm_start_* fields) and persists when
     ``save_state=True``. ``session_dir`` is required. Returns a :class:`T0Result`.
+
+    Args:
+        kb: The recipe-KB dispatcher used for the read-modify-write anchor.
+        shared_state: The live SharedState, mutated in place with warm-start
+            results.
+        workload: The model/workload identifier.
+        hw: The hardware/GPU identifier.
+        image_digest: Optional container image digest stamped as a trace tag.
+        stack_fingerprint: Optional stack-version fingerprint mapping.
+        extra_attrs: Optional extra identity/trace attributes (model_class,
+            framework, session ids).
+        resume: When ``True``, re-anchor even if already anchored.
+        fail_fast: Reserved flag for fail-fast behavior.
+        on_status: Optional status-line callback; defaults to INFO logging.
+        session_dir: The session directory (required).
+        save_state: When ``True``, persist the mutated SharedState.
+
+    Returns:
+        A :class:`T0Result` describing the anchor outcome.
+
+    Raises:
+        ValueError: If ``session_dir`` is ``None``.
     """
     emit = on_status or _default_status_emitter
     if session_dir is None:

--- a/inference_optimizer/orchestrator/framework_agent_client.py
+++ b/inference_optimizer/orchestrator/framework_agent_client.py
@@ -43,7 +43,14 @@ except ImportError:  # pragma: no cover — exercised only in IO-only test envs
     }
 
     def repo_url_for_framework(framework: str) -> str:
-        """Return the canonical GitHub repo URL for ``framework`` ("" if unknown)."""
+        """Return the canonical GitHub repo URL for ``framework`` ("" if unknown).
+
+        Args:
+            framework: The framework name (case-insensitive).
+
+        Returns:
+            The repo URL, or ``""`` when the framework is unknown.
+        """
         return _FRAMEWORK_TO_REPO_URL.get(
             (framework or "").strip().lower(), "",
         )
@@ -54,6 +61,10 @@ def _resolve_fa_binary() -> str | None:
 
     Resolution order: ``$FA_BIN``; ``shutil.which('fa')``;
     ``$FRAMEWORK_AGENT_ROOT/scripts/fa``.
+
+    Returns:
+        The absolute path to the ``fa`` binary, or ``None`` when it cannot be
+        located.
     """
     explicit = (os.environ.get("FA_BIN") or "").strip()
     if explicit and Path(explicit).exists():
@@ -80,7 +91,18 @@ def _run_fa_subcommand_sync(
     request_path: Path,
     timeout_sec: float,
 ) -> "tuple[int, str, str]":
-    """Sync helper: run ``fa <subcommand> --request <path> --out -``. Never raises."""
+    """Sync helper: run ``fa <subcommand> --request <path> --out -``. Never raises.
+
+    Args:
+        fa_bin: Path to the ``fa`` binary.
+        subcommand: The ``fa`` subcommand to run.
+        request_path: Path to the request JSON file.
+        timeout_sec: Subprocess wall-clock timeout in seconds.
+
+    Returns:
+        A ``(returncode, stdout, stderr)`` tuple; failures map to ``127``
+        (missing binary) or ``124`` (timeout).
+    """
     cmd = [fa_bin, subcommand, "--request", str(request_path), "--out", "-"]
     try:
         cp = subprocess.run(
@@ -109,6 +131,19 @@ async def _invoke_fa_phase(
     Writes ``request`` as temp JSON, runs the subcommand, returns parsed
     JSON. Raises :class:`RuntimeError` on missing binary / non-zero exit /
     parse failure.
+
+    Args:
+        subcommand: The ``fa phase-*`` subcommand to run.
+        request: The request payload serialized to temp JSON.
+        session_dir: The session directory under which the temp request lives.
+        timeout_sec: Subprocess wall-clock timeout in seconds.
+
+    Returns:
+        The parsed JSON payload returned by the subcommand.
+
+    Raises:
+        RuntimeError: If the ``fa`` binary is missing, the subcommand exits
+            non-zero, or its output is not valid JSON.
     """
     fa_bin = _resolve_fa_binary()
     if not fa_bin:
@@ -163,6 +198,23 @@ async def phase_discover(
     (fa skips its own ``extract_keywords``); empty/``None`` keeps the legacy
     behaviour. Returns the ``fa phase-discover`` payload
     ``{batch_id, framework, repo_url, candidates: [...]}``.
+
+    Args:
+        model: The model identifier.
+        framework: The target framework (defaults to ``sglang`` when empty).
+        gpu_type: The target GPU type.
+        gaps: The performance gaps driving discovery.
+        session_dir: The session directory for temp request staging.
+        repo_url: Optional explicit repo URL; resolved from ``framework`` when
+            empty.
+        keywords: Optional verbatim AND-search keywords; ``None``/empty keeps
+            the legacy keyword extraction.
+        max_candidates: Maximum number of candidate PRs to request.
+        batch_id: Optional batch identifier.
+        timeout_sec: Subprocess wall-clock timeout in seconds.
+
+    Returns:
+        The ``fa phase-discover`` payload dict.
     """
     resolved_repo_url = (repo_url or repo_url_for_framework(framework)).strip()
     request = {

--- a/inference_optimizer/orchestrator/framework_paths.py
+++ b/inference_optimizer/orchestrator/framework_paths.py
@@ -325,6 +325,10 @@ def resolve_atom_arg_utils_path() -> tuple[Path, str]:
 
     Returns ``(Path, str)`` where the str is the file path on success or a
     diagnostic message on failure.
+
+    Returns:
+        A ``(Path, str)`` tuple of the resolved path and either the file path
+        (on success) or a diagnostic message (on failure).
     """
     override = os.environ.get("INFERENCE_OPTIMIZER_ATOM_ARG_UTILS", "").strip()
     if override:
@@ -377,6 +381,12 @@ def summarise_framework_root_discovery(roots: str) -> str:
     Input is the colon-separated string from
     ``probe_framework_source_roots_for_env``; emitted in ``_FRAMEWORK_BUCKETS``
     order for stable output.
+
+    Args:
+        roots: Colon-separated source roots to summarise.
+
+    Returns:
+        A one-line ``fw=ok``/``fw=missing`` summary in bucket order.
     """
     parts: list[str] = []
     items = [p.strip().lower() for p in (roots or "").split(":") if p.strip()]

--- a/inference_optimizer/orchestrator/gpu_pool.py
+++ b/inference_optimizer/orchestrator/gpu_pool.py
@@ -20,7 +20,12 @@ DEFAULT_GPU_LEASE_TTL_SEC = 1800
 
 
 def _now_iso() -> str:
-    """Return the current UTC time as a microsecond ISO-8601 string."""
+    """Return the current UTC time as a microsecond ISO-8601 string.
+
+    Returns:
+        The current UTC time formatted as an ISO-8601 string with microsecond
+        precision.
+    """
     return datetime.now(timezone.utc).isoformat(timespec="microseconds")
 
 
@@ -53,6 +58,13 @@ def resolve_gpu_specialist_devices(capacity: int) -> list[int]:
 
     ``INFERENCE_OPTIMIZER_GPU_SPECIALIST_DEVICES`` may name an explicit pool;
     absent → ``range(capacity)``. Capacity zero disables dispatch.
+
+    Args:
+        capacity: Maximum number of GPU ids to return; zero or negative
+            disables dispatch.
+
+    Returns:
+        GPU ids available to specialists, capped at ``capacity``.
     """
     cap = max(0, int(capacity or 0))
     if cap <= 0:
@@ -95,7 +107,11 @@ class SpecialistGpuPool:
 
     @property
     def capacity(self) -> int:
-        """Return the number of GPUs the pool manages."""
+        """Return the number of GPUs the pool manages.
+
+        Returns:
+            The count of GPU ids managed by this pool.
+        """
         return len(self.gpu_ids)
 
     async def try_acquire(
@@ -106,7 +122,18 @@ class SpecialistGpuPool:
         task_id: str,
         ttl_sec: int = DEFAULT_GPU_LEASE_TTL_SEC,
     ) -> GpuLease | None:
-        """Acquire ``count`` GPU ids or return ``None`` if the pool is full."""
+        """Acquire ``count`` GPU ids or return ``None`` if the pool is full.
+
+        Args:
+            count: Number of GPU ids to acquire.
+            holder_id: Identifier of the lease holder.
+            task_id: Identifier of the task requesting the GPUs.
+            ttl_sec: Lease time-to-live in seconds before the lease expires.
+
+        Returns:
+            A ``GpuLease`` over the acquired GPU ids, or ``None`` when the
+            request cannot be satisfied (invalid count or too few free GPUs).
+        """
         n = int(count or 0)
         if n <= 0 or n > self.capacity:
             return None

--- a/inference_optimizer/orchestrator/kernel_attempt_summary.py
+++ b/inference_optimizer/orchestrator/kernel_attempt_summary.py
@@ -66,6 +66,12 @@ def _is_real_artifact_path(path: str) -> bool:
 
     Excludes stdout/stderr/log dumps kernel-agent writes on early-failure
     paths and stuffs into ``optimized_path``.
+
+    Args:
+        path: Candidate artifact path string.
+
+    Returns:
+        True when the path looks like a real kernel artifact.
     """
     if not path:
         return False
@@ -105,6 +111,12 @@ def _classify_attempt_failure(
 
     Priority: timeout → preprocess → compile → correctness → agent_error →
     unknown. ``succeeded`` attempts get ``("", "")``.
+
+    Args:
+        attempt: One attempt record dict.
+
+    Returns:
+        An ``(error_class, error_message)`` tuple.
     """
     status = str(attempt.get("status") or "").strip().lower()
     if status == "succeeded":
@@ -174,6 +186,13 @@ def _backend_results_dir(session_dir: Path, session_id: str) -> Path | None:
 
     ``key`` lookup order: ``session_dir.name``, then ``state.session_id``,
     then a lone subdir under ``kernel-agent/runs/`` (migrated-key recovery).
+
+    Args:
+        session_dir: Session directory root.
+        session_id: State session id used as a fallback lookup key.
+
+    Returns:
+        The results directory path, or ``None`` when none is found.
     """
     runs_root = Path(session_dir) / "kernel-agent" / "runs"
     if not runs_root.is_dir():
@@ -199,6 +218,13 @@ def _load_kernel_result(
 
     Returns ``(payload_dict_or_None, unavailable_reason)``; reused by ladder
     harvesting and verification passthrough.
+
+    Args:
+        results_dir: Directory holding ``<kid>.json`` result files, or ``None``.
+        kernel_id: Kernel id whose result is loaded.
+
+    Returns:
+        A ``(payload_or_None, unavailable_reason)`` tuple.
     """
     if results_dir is None:
         return None, "kernel_agent_results_dir_missing"
@@ -227,6 +253,13 @@ def _load_backend_ladder(
       ``kernel_agent_results_dir_missing``,
       ``kernel_agent_result_file_missing``, ``parse_error``,
       ``no_attempts_recorded``.
+
+    Args:
+        results_dir: Directory holding ``<kid>.json`` result files, or ``None``.
+        kernel_id: Kernel id whose ladder is parsed.
+
+    Returns:
+        A ``(ladder, unavailable_reason)`` tuple.
     """
     data, reason = _load_kernel_result(results_dir, kernel_id)
     if data is None:
@@ -262,7 +295,15 @@ def _load_backend_ladder(
 
 
 def _relative_to_session(p: Path, session_dir: Path) -> str:
-    """Render ``p`` as a path relative to ``session_dir`` when possible."""
+    """Render ``p`` as a path relative to ``session_dir`` when possible.
+
+    Args:
+        p: The path to render.
+        session_dir: Session directory to make ``p`` relative to.
+
+    Returns:
+        The relative path string, or the absolute string when not nested.
+    """
     try:
         return str(p.relative_to(session_dir))
     except ValueError:
@@ -277,7 +318,17 @@ def _classify_attempted(
     rejected_ids: set[str],
     kernel_id: str,
 ) -> str:
-    """Decide the category for a kernel that has an attempts ledger row."""
+    """Decide the category for a kernel that has an attempts ledger row.
+
+    Args:
+        entry: The kernel's attempts ledger row.
+        integrated_ids: Kernel ids already integrated.
+        rejected_ids: Kernel ids that were rejected.
+        kernel_id: The kernel id being classified.
+
+    Returns:
+        The outcome category constant.
+    """
     last_decision = str(entry.get("last_decision") or "").upper()
     if kernel_id in integrated_ids:
         return CATEGORY_INTEGRATED
@@ -293,6 +344,12 @@ def _unattempted_reason(top_entry: dict[str, Any]) -> tuple[str, str]:
 
     Order matters: ``no_source_file`` first since source-file resolve is the
     dispatcher's first gate.
+
+    Args:
+        top_entry: The kernel's top-list/roofline entry.
+
+    Returns:
+        A ``(reason_code, human_detail)`` tuple.
     """
     source = str(top_entry.get("source_file") or "").strip()
     reusable = bool(top_entry.get("reusable_native_kernel"))
@@ -332,7 +389,17 @@ def _summary_one_line(
     backend_ladder: list[dict[str, Any]],
     artifact_error: str,
 ) -> str:
-    """One-line natural-language summary, deterministic, never LLM."""
+    """One-line natural-language summary, deterministic, never LLM.
+
+    Args:
+        category: The kernel outcome category.
+        entry: The kernel's attempt ledger row.
+        backend_ladder: Per-backend attempt rows.
+        artifact_error: Verification error detail, when any.
+
+    Returns:
+        A one-line summary string (``""`` for unknown categories).
+    """
     if category == CATEGORY_INTEGRATED:
         micro = entry.get("last_micro_speedup") or 0.0
         return f"integrated into optimization_stack; micro_speedup={micro:.3f}x"
@@ -378,6 +445,14 @@ def build_kernel_optimization_summary(
     top15 with the per-kernel kernel-agent ``results/<kid>.json`` files.
     Returns a JSON-ready dict for atomic write to
     ``<session_dir>/reports/kernel_optimization_summary.json``.
+
+    Args:
+        state: The session ``SharedState`` instance.
+        session_dir: Session directory (path or string).
+        schema_version: Schema version stamped onto the output.
+
+    Returns:
+        A JSON-ready summary dict.
     """
     sd_path = Path(session_dir)
     session_id = str(getattr(state, "session_id", "") or "")
@@ -701,6 +776,12 @@ def _aggregate_failure_reasons(by_kernel: list[dict[str, Any]]) -> dict[str, int
     Priority: ``error_class``-derived buckets trump legacy structural buckets
     so root causes don't get buried in ``other``; falls back to structural
     classification when no ladder attempt carries an error_class.
+
+    Args:
+        by_kernel: The per-kernel summary rows.
+
+    Returns:
+        Mapping of failure-mode bucket to count.
     """
     breakdown: dict[str, int] = {
         # Legacy structural buckets (kept for back-compat)
@@ -763,7 +844,17 @@ def _build_top_takeaways(
     rejection_breakdown: dict[str, int],
     failure_reason_breakdown: dict[str, int],
 ) -> list[str]:
-    """Deterministic 2-4 sentence summary, no LLM."""
+    """Deterministic 2-4 sentence summary, no LLM.
+
+    Args:
+        counts: Per-category totals.
+        by_kernel: The per-kernel summary rows.
+        rejection_breakdown: Counts of rejection reasons.
+        failure_reason_breakdown: Counts of failure modes.
+
+    Returns:
+        A list of takeaway sentences.
+    """
     out: list[str] = []
     attempted = counts.get("attempted", 0)
     integrated = counts.get("integrated", 0)
@@ -824,6 +915,12 @@ def _find_highest_impact_missed(
 
     "Missed" = ``ATTEMPTED_REJECTED`` OR ``UNATTEMPTED``; ``INTEGRATED`` /
     ``KEEP_PENDING`` are excluded.
+
+    Args:
+        by_kernel: The per-kernel summary rows.
+
+    Returns:
+        The highest-``gpu_pct`` missed row, or ``None`` when none qualify.
     """
     best: dict[str, Any] | None = None
     best_gpu = -1.0

--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -83,7 +83,12 @@ _COMPILE_GENERATED_NAME_MARKERS = (
 # Shape sources trusted for kernel-opt dispatch (``torch_trace`` from TraceLens; ``tuning_csv`` reserved for a profiled sweep).
 _ALLOWED_SHAPE_PROVENANCE = frozenset({"torch_trace", "tuning_csv"})
 def _reusable_source_roots() -> tuple[str, ...]:
-    """Framework install roots for patchability checks (from :func:`framework_paths.resolve_patch_target_roots`; emits a lower-case variant per root for case-insensitive matching)."""
+    """Framework install roots for patchability checks (from :func:`framework_paths.resolve_patch_target_roots`; emits a lower-case variant per root for case-insensitive matching).
+
+    Returns:
+        The de-duplicated framework install roots (each with a lower-case
+        variant), including FlyDSL checkout roots.
+    """
     from .framework_paths import resolve_patch_target_roots
 
     roots = resolve_patch_target_roots()
@@ -118,7 +123,11 @@ _DEFAULT_GEMM_TUNING_TIMEOUT_SEC = 3 * 60 * 60
 
 @functools.lru_cache(maxsize=1)
 def _default_geak_budget_minutes() -> float:
-    """Default per-GEAK-attempt budget tracking ``$GEAK_RUN_MODE`` (quick→70, full→130). PR #301: mirrors kernel-agent tool defaults."""
+    """Default per-GEAK-attempt budget tracking ``$GEAK_RUN_MODE`` (quick→70, full→130). PR #301: mirrors kernel-agent tool defaults.
+
+    Returns:
+        The default per-attempt GEAK budget in minutes.
+    """
     raw = (os.environ.get("GEAK_RUN_MODE") or "").strip().lower()
     return 70.0 if raw == "quick" else 130.0
 
@@ -129,6 +138,10 @@ def _visible_gpu_count() -> int | None:
     Returns ``None`` when torch can't tell us (missing / driver-init
     failure) so callers can distinguish "no GPUs" (``0``) from "unknown"
     and pick the right fallback. Works for both ROCm and CUDA backends.
+
+    Returns:
+        The visible GPU count, or ``None`` when torch is unavailable or
+        driver init fails.
     """
     try:
         import torch  # local import: torch driver init can be expensive
@@ -142,6 +155,9 @@ def _per_task_gpus() -> int:
 
     Floors at 1 so a missing / invalid env never zero-divides or stalls
     the batch fanout.
+
+    Returns:
+        The per-attempt GPU reservation, always ``>= 1``.
     """
     try:
         per_task = int(os.environ.get("KERNEL_AGENT_NUM_GPUS", "0") or 0)
@@ -201,6 +217,13 @@ def _should_parallelize_backends(payload: dict, num_candidates: int) -> bool:
     Operators / tests can force the decision via payload
     ``parallel_backends`` or env ``KERNEL_OPT_PARALLEL_BACKENDS``
     (truthy ``1/true/yes/on`` enables, anything else disables).
+
+    Args:
+        payload: Request payload; ``parallel_backends`` may force the choice.
+        num_candidates: Number of kernel candidates in this request.
+
+    Returns:
+        ``True`` to race GEAK against the OOB ladder, else ``False``.
     """
     override = payload.get("parallel_backends")
     if override is None:
@@ -662,7 +685,14 @@ def _validate_reusable_native_kernel(payload: dict) -> HandlerResult | None:
 
 
 def _allow_empty_kernel_shape(payload: dict) -> bool:
-    """Escape hatch (default off) via ``payload['allow_empty_kernel_shape']`` or ``HYPERLOOM_ALLOW_EMPTY_KERNEL_SHAPE=1``."""
+    """Escape hatch (default off) via ``payload['allow_empty_kernel_shape']`` or ``HYPERLOOM_ALLOW_EMPTY_KERNEL_SHAPE=1``.
+
+    Args:
+        payload: Request payload that may carry ``allow_empty_kernel_shape``.
+
+    Returns:
+        ``True`` when empty kernel shapes are explicitly permitted.
+    """
     if bool(payload.get("allow_empty_kernel_shape")):
         return True
     return str(
@@ -673,7 +703,16 @@ def _allow_empty_kernel_shape(payload: dict) -> bool:
 def _validate_kernel_shape_and_paths(
     payload: dict, *, session_dir: Path,
 ) -> HandlerResult | None:
-    """Reject a kernel-opt dispatch with no trace-anchored shape or a missing source/workspace path (would burn budget with no anchor; guides back to ``trace_analyze``)."""
+    """Reject a kernel-opt dispatch with no trace-anchored shape or a missing source/workspace path (would burn budget with no anchor; guides back to ``trace_analyze``).
+
+    Args:
+        payload: Kernel-opt dispatch payload to validate.
+        session_dir: Session directory used as the default workspace path.
+
+    Returns:
+        A failure ``HandlerResult`` describing the rejection, or ``None`` when
+        the dispatch is valid.
+    """
     # ``dry_run`` exercises the plumbing without a backend, so no GPU budget and fake fixture paths need not exist.
     if bool(payload.get("dry_run")):
         return None
@@ -894,6 +933,13 @@ def _fill_integrate_defaults_from_state(
     Runs before the ``base_tput > 0`` hard-check in ``integrate_handler`` for
     bare ``{"kernel_id": ...}`` payloads. Always returns a shallow copy; never
     raises on a missing snapshot.
+
+    Args:
+        payload: The integrate request payload.
+        session_dir: Session directory to load SharedState from.
+
+    Returns:
+        A shallow copy of ``payload`` with defaults filled from state.
     """
     from .shared_state import SharedState
 
@@ -925,7 +971,17 @@ def _fill_integrate_defaults_from_state(
 
 
 def _resolve_integrate_payload(payload: dict, *, session_dir: Path) -> tuple[dict, HandlerResult | None]:
-    """Fill integrate inputs from SharedState when Orchestration sends only kernel_id (artifact in ``last_kernel_opt``, source in ``last_trace_analyze``)."""
+    """Fill integrate inputs from SharedState when Orchestration sends only kernel_id (artifact in ``last_kernel_opt``, source in ``last_trace_analyze``).
+
+    Args:
+        payload: The integrate request payload.
+        session_dir: Session directory to load SharedState from.
+
+    Returns:
+        A tuple of ``(resolved_payload, error_result)`` where ``error_result``
+        is a failure ``HandlerResult`` when required inputs are missing, else
+        ``None``.
+    """
     from .shared_state import SharedState
 
     resolved = dict(payload)
@@ -992,7 +1048,15 @@ def _resolve_integrate_payload(payload: dict, *, session_dir: Path) -> tuple[dic
 
 
 async def _run_subprocess(cmd: list[str], *, timeout_sec: int) -> tuple[int, str, str]:
-    """asyncio-friendly wrapper around blocking subprocess.run (keeps the reactor responsive)."""
+    """asyncio-friendly wrapper around blocking subprocess.run (keeps the reactor responsive).
+
+    Args:
+        cmd: The command and arguments to run.
+        timeout_sec: Per-run timeout in seconds.
+
+    Returns:
+        A tuple of ``(returncode, stdout, stderr)``.
+    """
     def _run() -> subprocess.CompletedProcess[str]:
         """Run the command synchronously in a worker thread.
 
@@ -1094,7 +1158,21 @@ def _write_gemm_tuning_benchmark_script(
     isl: int,
     osl: int,
 ) -> Path:
-    """Create an isolated benchmark wrapper for GEAK GEMM tuning (distinct port + no global ``pgrep sglang`` cleanup, so it can't kill the main optimizer's server)."""
+    """Create an isolated benchmark wrapper for GEAK GEMM tuning (distinct port + no global ``pgrep sglang`` cleanup, so it can't kill the main optimizer's server).
+
+    Args:
+        workspace: Directory to write the benchmark script into.
+        model_path: Path to the model under test.
+        framework: Serving framework (e.g. ``sglang``).
+        gpu_type: GPU type used to select the benchmark runner.
+        tp: Tensor-parallel degree.
+        conc: Concurrency.
+        isl: Input sequence length.
+        osl: Output sequence length.
+
+    Returns:
+        The path to the written, executable benchmark script.
+    """
     inferencex_path = os.environ.get("INFERENCEX_PATH") or "/hyperloom/InferenceX"
     runner = f"{inferencex_path}/benchmarks/{framework}_{gpu_type}.sh"
     path = workspace / "geak_gemm_benchmark.sh"
@@ -1128,7 +1206,15 @@ exec {shlex.quote(runner)}
 async def run_gemm_tuning_handler(
     payload: dict, *, session_dir: Path,
 ) -> HandlerResult:
-    """Run GEAK's FP8 block-scale GEMM tuning workflow (separate from ``run_optimization``; tunes GEMM dispatch before source-level rewrites)."""
+    """Run GEAK's FP8 block-scale GEMM tuning workflow (separate from ``run_optimization``; tunes GEMM dispatch before source-level rewrites).
+
+    Args:
+        payload: The GEMM-tuning request payload.
+        session_dir: Session directory for workspace and state.
+
+    Returns:
+        A ``HandlerResult`` describing the tuning outcome.
+    """
     from .shared_state import SharedState
 
     state = SharedState.load_or_init(session_dir)
@@ -1386,7 +1472,16 @@ async def trace_analyze_handler(
 def _validate_trace_analyze_inputs(
     payload: dict, *, session_dir: Path,
 ) -> HandlerResult | None:
-    """Confirm the run_optimization payload references a valid trace_analyze."""
+    """Confirm the run_optimization payload references a valid trace_analyze.
+
+    Args:
+        payload: The run_optimization request payload.
+        session_dir: Session directory to load SharedState from.
+
+    Returns:
+        A failure ``HandlerResult`` when no valid trace_analyze is referenced,
+        else ``None``.
+    """
     candidates_path = str(payload.get("candidates_path") or "").strip()
     if candidates_path and not Path(candidates_path).exists():
         return {
@@ -1439,6 +1534,15 @@ async def run_optimization_handler(
     With candidate metadata, upgrades single-kernel requests into a concurrent
     batch over all reusable native kernels. ``record_partial`` (optional) streams
     each batch sub-result into SharedState before gather wait-all returns.
+
+    Args:
+        payload: The run_optimization request payload.
+        session_dir: Session directory for workspace and state.
+        record_partial: Optional callback streaming each batch sub-result into
+            SharedState before the gather wait-all returns.
+
+    Returns:
+        A ``HandlerResult`` describing the optimization outcome.
     """
     data_guard = _validate_trace_analyze_inputs(payload, session_dir=session_dir)
     if data_guard is not None:
@@ -1563,7 +1667,14 @@ def _backend_order(payload: dict) -> list[str]:
 
 
 def _in_flight_kernel_ids(session_dir: Path) -> set[str]:
-    """Scan the kernel-agent run dir for ``state=running`` status files, so :func:`_batch_kernel_candidates` skips kernels still in flight from a prior batch."""
+    """Scan the kernel-agent run dir for ``state=running`` status files, so :func:`_batch_kernel_candidates` skips kernels still in flight from a prior batch.
+
+    Args:
+        session_dir: Session directory whose kernel-agent run dir is scanned.
+
+    Returns:
+        The set of kernel ids currently in flight.
+    """
     in_flight: set[str] = set()
     sid = session_dir.name
     status_dir = session_dir / "kernel-agent" / "runs" / sid / "status" / "kernel_optimization"
@@ -1589,7 +1700,14 @@ def _in_flight_kernel_ids(session_dir: Path) -> set[str]:
 
 
 def _normalize_kernel_id(value: str) -> str:
-    """Fold hallucinated ``kn``/``rn`` prefixes onto the real ``k`` numbering (mirrors ``kernel_optimization._normalize_kernel_id``)."""
+    """Fold hallucinated ``kn``/``rn`` prefixes onto the real ``k`` numbering (mirrors ``kernel_optimization._normalize_kernel_id``).
+
+    Args:
+        value: The raw kernel id to normalize.
+
+    Returns:
+        The normalized kernel id.
+    """
     s = str(value or "").strip().lower()
     for prefix in ("kn", "rn"):
         if s.startswith(prefix) and s[len(prefix):].isdigit():
@@ -1600,7 +1718,16 @@ def _normalize_kernel_id(value: str) -> str:
 def _reconcile_kernel_id(
     requested: Any, candidates: list[dict[str, Any]],
 ) -> str:
-    """Resolve the LLM kernel_id to a real candidate id (exact kernel_id/name, then normalized; only a missing id falls back to the first candidate)."""
+    """Resolve the LLM kernel_id to a real candidate id (exact kernel_id/name, then normalized; only a missing id falls back to the first candidate).
+
+    Args:
+        requested: The (possibly hallucinated) kernel id from the LLM.
+        candidates: The real candidate dicts to reconcile against.
+
+    Returns:
+        The reconciled candidate id (the first candidate's id when
+        ``requested`` is empty; ``requested`` unchanged when no match).
+    """
     req = str(requested or "")
     if req:
         for cand in candidates:
@@ -1624,7 +1751,15 @@ def _reconcile_kernel_id(
 def _resolve_candidate_id(
     requested: Any, candidates: list[dict[str, Any]],
 ) -> str:
-    """Return the canonical ``k00x`` id for ``requested`` or ``""`` (like ``find_candidate`` but with no first-candidate fallback; a pure hallucination returns ``""``)."""
+    """Return the canonical ``k00x`` id for ``requested`` or ``""`` (like ``find_candidate`` but with no first-candidate fallback; a pure hallucination returns ``""``).
+
+    Args:
+        requested: The (possibly hallucinated) kernel id to canonicalize.
+        candidates: The real candidate dicts to match against.
+
+    Returns:
+        The canonical candidate id, or ``""`` when no match is found.
+    """
     req = str(requested or "")
     if not req:
         return ""
@@ -1648,7 +1783,15 @@ def _resolve_candidate_id(
 
 
 def _all_kernel_candidates(payload: dict) -> list[dict[str, Any]]:
-    """Load every candidate (``hot_kernels`` ∪ ``skipped_kernels``) so id canonicalization resolves even when hot_kernels is empty."""
+    """Load every candidate (``hot_kernels`` ∪ ``skipped_kernels``) so id canonicalization resolves even when hot_kernels is empty.
+
+    Args:
+        payload: Request payload carrying ``candidates_path``.
+
+    Returns:
+        Every candidate dict from the artifact, or an empty list when the
+        artifact is missing or unreadable.
+    """
     candidates_path = payload.get("candidates_path")
     if not candidates_path:
         return []
@@ -1740,7 +1883,15 @@ def _batch_kernel_candidates(
             )
 
     def _is_live(kid: str, current_source: str = "") -> bool:
-        """A kernel_id is live (batch-eligible) iff NOT rejected, NOT in-flight, and < max_attempts recorded against the CURRENT source_file (PR-K per-source counting)."""
+        """A kernel_id is live (batch-eligible) iff NOT rejected, NOT in-flight, and < max_attempts recorded against the CURRENT source_file (PR-K per-source counting).
+
+        Args:
+            kid: The kernel id to test.
+            current_source: The current source file for per-source counting.
+
+        Returns:
+            ``True`` when the kernel is batch-eligible, else ``False``.
+        """
         if kid in rejected_kernel_ids:
             return False
         if kid in in_flight:
@@ -1860,6 +2011,13 @@ def _kernel_result_rank(result: HandlerResult | None) -> tuple[int, float]:
     integrate-ready patch); among equals, higher ``micro_speedup`` wins.
     Mirrors the max-key in :func:`_run_optimization_batch` so the ladder,
     the GEAK-vs-OOB race, and the batch all agree on "best".
+
+    Args:
+        result: A kernel-opt attempt result, or ``None``.
+
+    Returns:
+        A ``(keep, micro_speedup)`` sort key; KEEP verdicts rank above
+        non-KEEP, and higher ``micro_speedup`` breaks ties.
     """
     if not isinstance(result, dict):
         return (0, 0.0)
@@ -1887,6 +2045,18 @@ async def _run_backend_ladder(
     attempt log. Stops at the first KEEP so a clean GEAK KEEP still
     short-circuits *its own* ladder and OOB fallbacks (claude -> codex ->
     cursor) only fire when an earlier backend misses a KEEP.
+
+    Args:
+        base_payload: The base request payload shared by every backend.
+        candidate: The kernel candidate to optimize.
+        kernel_id: The kernel id being optimized.
+        backends: The ordered backends to try.
+        session_dir: Session directory for workspace and state.
+
+    Returns:
+        A tuple of ``(best, attempts)`` where ``best`` is the strongest
+        result by ``_kernel_result_rank`` and ``attempts`` is the ordered
+        per-backend attempt log.
     """
     attempts: list[dict[str, Any]] = []
     best: HandlerResult | None = None
@@ -1936,6 +2106,15 @@ async def _run_kernel_backend_sequence(
       first KEEP when there are spare GPUs to let OOB chase a higher
       speedup. Falls back to sequential when GEAK or every OOB backend is
       absent from the ladder (nothing to race).
+
+    Args:
+        base_payload: The base request payload shared by every backend.
+        candidate: The kernel candidate to optimize.
+        session_dir: Session directory for workspace and state.
+        parallel_backends: When ``True``, race GEAK against the OOB ladder.
+
+    Returns:
+        The strongest ``HandlerResult`` across the backends tried.
     """
     kernel_id = str(candidate.get("kernel_id") or base_payload.get("kernel_id") or "")
     order = _backend_order(base_payload)
@@ -1988,7 +2167,18 @@ async def _run_optimization_batch(
     session_dir: Path,
     record_partial: Callable[[dict], None] | None = None,
 ) -> HandlerResult:
-    """Fan ``run_optimization`` out across reusable native kernels (``record_partial`` streams each sub-attempt into SharedState before gather wait-all unblocks)."""
+    """Fan ``run_optimization`` out across reusable native kernels (``record_partial`` streams each sub-attempt into SharedState before gather wait-all unblocks).
+
+    Args:
+        payload: The run_optimization request payload.
+        candidates: The reusable native kernels to fan out across.
+        session_dir: Session directory for workspace and state.
+        record_partial: Optional callback streaming each sub-attempt into
+            SharedState before the gather wait-all unblocks.
+
+    Returns:
+        The strongest ``HandlerResult`` augmented with batch metadata.
+    """
     max_parallel = int(
         payload.get("max_parallel")
         or os.environ.get("KERNEL_OPT_MAX_PARALLEL")
@@ -2092,6 +2282,13 @@ async def _run_optimization_single(
     """Run Hyperloom/kernel-agent's kernel_optimization.py on one kernel.
 
     Required payload: ``kernel_id``. Returns the tool's JSON output verbatim.
+
+    Args:
+        payload: The single-kernel request payload (requires ``kernel_id``).
+        session_dir: Session directory for workspace and state.
+
+    Returns:
+        The kernel_optimization tool's JSON output as a ``HandlerResult``.
     """
     kernel_id = payload.get("kernel_id")
     if not kernel_id:
@@ -2217,6 +2414,10 @@ def _trace_kernel_attempt_usage(
 
     Best-effort end to end: any read/parse/append failure is logged at debug
     and swallowed so kernel optimization never breaks on a trace write.
+
+    Args:
+        result: A kernel_optimization result whose ``attempts`` are mined.
+        session_dir: Session directory the ``llm_calls.jsonl`` rows append to.
     """
     if not isinstance(result, dict):
         return
@@ -2264,7 +2465,17 @@ def _trace_kernel_attempt_usage(
 
 
 def _shape_tool_result(rc: int, stdout: str, stderr: str) -> HandlerResult:
-    """Wrap a kernel-agent tool's exit + stdout into our schema (prefer the tool's own JSON, synthesize only on parse failure)."""
+    """Wrap a kernel-agent tool's exit + stdout into our schema (prefer the tool's own JSON, synthesize only on parse failure).
+
+    Args:
+        rc: The tool's process return code.
+        stdout: The tool's captured standard output.
+        stderr: The tool's captured standard error.
+
+    Returns:
+        The tool's own JSON result (status filled from ``rc`` if absent), or a
+        synthesized failure result when stdout has no parseable JSON.
+    """
     parsed = _parse_tool_stdout(stdout)
     if parsed:
         # Trust the tool's own status; otherwise infer from rc.
@@ -2320,7 +2531,15 @@ def _parse_tool_stdout(stdout: str) -> dict[str, Any]:
 
 # ---------------------------------------------------------------------------
 def _lookup_kernel_roofline_name(session_dir: Path, kernel_id: str) -> str:
-    """Resolve the TraceLens/device kernel name for a roofline sidecar row."""
+    """Resolve the TraceLens/device kernel name for a roofline sidecar row.
+
+    Args:
+        session_dir: Session directory holding the roofline sidecar.
+        kernel_id: The kernel id to look up.
+
+    Returns:
+        The matched kernel name, or ``""`` when the sidecar/row is absent.
+    """
     sidecar_path = session_dir / "reports" / "kernel_roofline.json"
     try:
         payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
@@ -2345,7 +2564,17 @@ def _record_after_kernel_opt_rocprof_status(
     txt_path: str = "",
     log: Any = None,
 ) -> None:
-    """Best-effort sidecar status update for skipped/failed after-opt rocprof."""
+    """Best-effort sidecar status update for skipped/failed after-opt rocprof.
+
+    Args:
+        session_dir: Session directory holding the roofline sidecar.
+        kernel_id: The kernel id whose sidecar row is updated.
+        status: The rocprof status to record.
+        reason: Optional human-readable reason for the status.
+        json_path: Optional path to the rocprof JSON artifact.
+        txt_path: Optional path to the rocprof text artifact.
+        log: Optional logger for warnings on failure.
+    """
     try:
         ko_tool = _kernel_agent_tool_path("kernel_optimization.py")
         ko_dir = ko_tool.parent
@@ -2415,6 +2644,14 @@ async def _run_after_kernel_opt_rocprof(
     calls ``_update_kernel_roofline_sidecar`` with ``phase='after_kernel_opt'``.
 
     Always returns a small status dict; never raises.
+
+    Args:
+        kernel_id: The kernel id that was just integrated.
+        session_dir: Session directory for state and artifacts.
+        log: Logger for status/warning messages.
+
+    Returns:
+        A small status dict describing the rocprof outcome.
     """
     rocprof_env = os.environ.get("HYPERLOOM_ROCPROF_ROOFLINE", "1").strip().lower()
     if rocprof_env in {"0", "false", "no", "off"}:
@@ -2621,6 +2858,16 @@ async def integrate_handler(
     kernel_id, config_path, extra_server_args, keep_threshold_pct (1.0),
     budget_minutes (20). Returns ``{status, decision, base_tput, new_tput,
     gain_pct, kernel_id, patch_path, report_path, workspace}``.
+
+    Args:
+        payload: The integrate request payload (requires ``base_tput``).
+        session_dir: Session directory for workspace and state.
+
+    Returns:
+        A ``HandlerResult`` with the KEEP/REVERT decision and re-baseline
+        metrics (``status``, ``decision``, ``base_tput``, ``new_tput``,
+        ``gain_pct``, ``kernel_id``, ``patch_path``, ``report_path``,
+        ``workspace``).
     """
     from .action_executors.baseline import BaselineExecutor
     from .action_executors.benchmark_result import is_valid_measurement

--- a/inference_optimizer/orchestrator/knowledge_plane.py
+++ b/inference_optimizer/orchestrator/knowledge_plane.py
@@ -51,7 +51,11 @@ _DOMAIN_REPOS_FILENAME: str = "_domain_repos.yaml"
 
 
 def _domain_repos_path() -> Path:
-    """Where ``_domain_repos.yaml`` lives (centralised for test monkeypatching)."""
+    """Where ``_domain_repos.yaml`` lives (centralised for test monkeypatching).
+
+    Returns:
+        The path to the ``_domain_repos.yaml`` config file.
+    """
     return asset_actions_dir() / "_meta" / _DOMAIN_REPOS_FILENAME
 
 
@@ -60,6 +64,14 @@ def load_domain_repos(path: Path | None = None) -> dict[str, DomainRepos]:
 
     Returns ``{domain_key: DomainRepos}``; missing/malformed yaml returns an
     empty dict + warning log ("no PR feed for any domain").
+
+    Args:
+        path: Optional explicit config path; defaults to
+            :func:`_domain_repos_path`.
+
+    Returns:
+        A ``{domain_key: DomainRepos}`` mapping, or ``{}`` when the config is
+        missing or unparseable.
     """
     target = path or _domain_repos_path()
     if not target.exists():
@@ -215,6 +227,9 @@ class KnowledgePlane:
 
         Returns ``""`` when PR Monitor is disabled so the runner can elide
         the ``mcp__pr_monitor__*`` tool block.
+
+        Returns:
+            The PR Monitor MCP URL, or ``""`` when PR Monitor is disabled.
         """
         if not self.pr_monitor_enabled:
             return ""
@@ -232,6 +247,16 @@ class KnowledgePlane:
         Called once per EXPLORE phase entry (KB_design §3.6 §5.2). Returns a
         ``{domain: (prs, warnings)}`` map; aggregated warnings stashed on
         :attr:`last_warnings`. Fail-soft.
+
+        Args:
+            window_days: PR lookback window override, or ``None`` for the
+                configured default.
+            per_repo_limit: Max PRs per repo override, or ``None`` for the
+                configured default.
+            total_budget_sec: Total wall-clock budget for the batch warm.
+
+        Returns:
+            A ``{domain: (prs, warnings)}`` map across every known domain.
         """
         out: dict[str, tuple[list[PRSummary], list[str]]] = {}
         all_warnings: list[str] = []
@@ -267,6 +292,19 @@ class KnowledgePlane:
         Failure semantics: disabled → ``["pr_monitor:disabled"]``; unknown
         domain → ``["pr_monitor:unknown_domain:<d>"]``; per-repo failures
         fold into ``warnings`` while reachable repos still surface.
+
+        Args:
+            domain: The specialist domain key to warm.
+            extra_keywords: Additional keywords appended to the domain
+                defaults.
+            window_days: PR lookback window override, or ``None`` for the
+                configured default.
+            per_repo_limit: Max PRs per repo override, or ``None`` for the
+                configured default.
+            total_budget_sec: Total wall-clock budget for the warm.
+
+        Returns:
+            A ``(prs, warnings)`` tuple for the domain.
         """
         warnings: list[str] = []
         if not self.pr_monitor_enabled:

--- a/inference_optimizer/orchestrator/objective.py
+++ b/inference_optimizer/orchestrator/objective.py
@@ -70,7 +70,14 @@ class Objective(ABC):
 
     @abstractmethod
     def pressure_input(self, state: "SharedState") -> float:
-        """Feed to scheduler.pressure() (§12): 0.0 = relaxed, 1.0 = max urgency."""
+        """Feed to scheduler.pressure() (§12): 0.0 = relaxed, 1.0 = max urgency.
+
+        Args:
+            state: Current shared optimization state to evaluate.
+
+        Returns:
+            Urgency in the range 0.0 (relaxed) → 1.0 (maximum urgency).
+        """
 
     @abstractmethod
     def describe(self) -> str:
@@ -455,7 +462,21 @@ class TimeOnlyObjective(Objective):
 
 # ---------------------------------------------------------------------------
 def build_objective(env: dict[str, Any]) -> Objective:
-    """Factory (DESIGN §11.3): requires MAX_HOURS; at most one of TARGET_GAIN_PCT / TARGET_TPUT_PER_GPU / TARGET_DIR (none → TimeOnly)."""
+    """Factory (DESIGN §11.3): requires MAX_HOURS; at most one of TARGET_GAIN_PCT / TARGET_TPUT_PER_GPU / TARGET_DIR (none → TimeOnly).
+
+    Args:
+        env: Environment mapping; must contain ``MAX_HOURS`` and may contain at
+            most one of ``TARGET_GAIN_PCT``, ``TARGET_TPUT_PER_GPU``, or
+            ``TARGET_DIR``.
+
+    Returns:
+        The objective matching the supplied target, or a ``TimeOnlyObjective``
+        when no target is given.
+
+    Raises:
+        ObjectiveError: If ``MAX_HOURS`` is missing, non-numeric, or
+            non-positive, or if more than one ``TARGET_*`` key is supplied.
+    """
     if "MAX_HOURS" not in env:
         raise ObjectiveError("build_objective: MAX_HOURS is required")
     try:

--- a/inference_optimizer/orchestrator/optimization_journal.py
+++ b/inference_optimizer/orchestrator/optimization_journal.py
@@ -48,6 +48,13 @@ def _optional_int(value: Any) -> int | None:
     written before D1 has no ``tick`` key, and a corrupted value must not
     crash :meth:`JournalEntry.from_dict` (the journal is a best-effort
     audit artifact loaded on resume).
+
+    Args:
+        value: The value to coerce to an int.
+
+    Returns:
+        The coerced int, or ``None`` when the value is absent or not
+        convertible.
     """
     if value is None:
         return None
@@ -118,7 +125,12 @@ class JournalEntry:
         )
 
     def dedupe_key(self) -> tuple[str, int, str, str, str, str, str]:
-        """Dedup tuple for resume replay (includes variant_name + task_id so same-tick siblings don't collide)."""
+        """Dedup tuple for resume replay (includes variant_name + task_id so same-tick siblings don't collide).
+
+        Returns:
+            A tuple of ``(phase, iter, kind, change, outcome, variant_name,
+            task_id)`` uniquely identifying this decision for dedup.
+        """
         return (
             self.phase, self.iter, self.kind, self.change,
             self.outcome, self.variant_name, self.task_id,
@@ -151,7 +163,20 @@ class Journal:
         framework: str = "",
         baseline_throughput: float = 0.0,
     ) -> Journal:
-        """Return the existing journal if on disk, else mint a new one (on-disk header fields win only when the caller leaves them empty)."""
+        """Return the existing journal if on disk, else mint a new one (on-disk header fields win only when the caller leaves them empty).
+
+        Args:
+            session_dir: The session directory whose ``reports/`` holds the
+                journal file.
+            session_id: Session identifier used when minting a new journal.
+            model: Model identifier used when minting a new journal.
+            hardware: Hardware identifier used when minting a new journal.
+            framework: Optional framework identifier for a new journal.
+            baseline_throughput: Optional baseline throughput for a new journal.
+
+        Returns:
+            The loaded or newly created ``Journal`` instance.
+        """
         path = cls._journal_path(session_dir)
         if path.exists():
             try:
@@ -200,7 +225,15 @@ class Journal:
 
     # Mutation
     def append_entry(self, entry: JournalEntry) -> bool:
-        """Append a decision row and flush; ``False`` on duplicate dedupe_key (resume replay safety)."""
+        """Append a decision row and flush; ``False`` on duplicate dedupe_key (resume replay safety).
+
+        Args:
+            entry: The decision row to append; its ``ts`` is stamped when empty.
+
+        Returns:
+            ``True`` when the entry was appended and flushed, ``False`` when a
+            row with the same dedupe key already exists.
+        """
         if not entry.ts:
             entry.ts = _now_iso()
         key = entry.dedupe_key()
@@ -217,7 +250,14 @@ class Journal:
         final_throughput: float | None = None,
         total_gain_pct: float | None = None,
     ) -> None:
-        """Update top-level summary fields and flush (called once at CLOSE; partial finalize allowed)."""
+        """Update top-level summary fields and flush (called once at CLOSE; partial finalize allowed).
+
+        Args:
+            final_throughput: Final measured throughput; left unchanged when
+                ``None``.
+            total_gain_pct: Total gain percentage over baseline; left unchanged
+                when ``None``.
+        """
         if final_throughput is not None:
             self.final_throughput = float(final_throughput)
         if total_gain_pct is not None:
@@ -225,7 +265,12 @@ class Journal:
         self._flush()
 
     def update_baseline(self, baseline_throughput: float) -> None:
-        """Late-binding setter for the baseline measurement (no-op on non-positive, to avoid erasing a real value with a stale 0)."""
+        """Late-binding setter for the baseline measurement (no-op on non-positive, to avoid erasing a real value with a stale 0).
+
+        Args:
+            baseline_throughput: The measured baseline throughput; ignored when
+                non-positive.
+        """
         if baseline_throughput and baseline_throughput > 0:
             self.baseline_throughput = float(baseline_throughput)
             self._flush()
@@ -277,7 +322,14 @@ def _now_iso() -> str:
 
 
 def _variant_args(variant: dict[str, Any]) -> str:
-    """Read a variant's server-arg string, canonical (``extra_server_args``) first with a legacy ``extra_sglang_args`` fallback."""
+    """Read a variant's server-arg string, canonical (``extra_server_args``) first with a legacy ``extra_sglang_args`` fallback.
+
+    Args:
+        variant: The variant dict to read server args from.
+
+    Returns:
+        The server-arg string, or an empty string when neither key is present.
+    """
     return str(
         variant.get("extra_server_args")
         or variant.get("extra_sglang_args")
@@ -286,7 +338,16 @@ def _variant_args(variant: dict[str, Any]) -> str:
 
 
 def classify_change_kind(task_kind: str, variant: dict[str, Any] | None = None) -> str:
-    """Map a task / variant to a ``KIND_*`` value (priority: env-only > kernel_file > integrate > backend > param)."""
+    """Map a task / variant to a ``KIND_*`` value (priority: env-only > kernel_file > integrate > backend > param).
+
+    Args:
+        task_kind: The task kind to classify.
+        variant: Optional variant dict inspected for server args and envs when
+            the task kind alone is not decisive.
+
+    Returns:
+        The matching ``KIND_*`` constant.
+    """
     kind = (task_kind or "").lower()
     if kind in ("kernel_opt", "deep_kernel_analysis", "operator_tuning"):
         return KIND_KERNEL_FILE
@@ -312,7 +373,18 @@ def summarize_change(
     variant: dict[str, Any] | None = None,
     result_dict: dict[str, Any] | None = None,
 ) -> str:
-    """Human-readable one-line description used as the ``change`` field (falls back to task kind)."""
+    """Human-readable one-line description used as the ``change`` field (falls back to task kind).
+
+    Args:
+        task_kind: The task kind, used as a fallback label.
+        variant: Optional variant dict whose server args, envs, or name supply
+            the description.
+        result_dict: Optional result dict mined for identifiers (kernel id,
+            patch path, PR url) when no variant detail is available.
+
+    Returns:
+        A one-line human-readable description of the change.
+    """
     if isinstance(variant, dict):
         name = str(variant.get("name") or "").strip()
         args = _variant_args(variant).strip()

--- a/inference_optimizer/orchestrator/orchestration_memory.py
+++ b/inference_optimizer/orchestrator/orchestration_memory.py
@@ -29,7 +29,12 @@ _MEMORY_KEYS: tuple[str, ...] = (
 
 
 def _now_iso() -> str:
-    """Return the current UTC time as a second-resolution ISO-8601 string."""
+    """Return the current UTC time as a second-resolution ISO-8601 string.
+
+    Returns:
+        The current UTC time formatted as an ISO-8601 string with second
+        precision.
+    """
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
 
 
@@ -106,6 +111,14 @@ def parse_checkpoint_reply(raw_text: str) -> dict[str, Any]:
     Tolerant: accepts a fenced ```json block or bare object; missing keys
     default to empty. Never raises — malformed replies yield a best-effort
     dict (with a ``parse_error`` marker).
+
+    Args:
+        raw_text: The agent's raw checkpoint reply text.
+
+    Returns:
+        A memory-schema dict with ``current_plan`` plus the ``hypotheses``,
+        ``tried_and_why``, ``pending``, and ``learnings`` lists; includes a
+        ``parse_error`` marker when no JSON object could be extracted.
     """
     obj = _extract_json_object(raw_text)
     if obj is None:
@@ -172,6 +185,17 @@ def build_memory_record(
 
     ``learnings`` accumulate across checkpoints (deduped, capped) so durable
     lessons survive a later checkpoint that forgets to repeat them.
+
+    Args:
+        parsed: Parsed checkpoint reply (see ``parse_checkpoint_reply``).
+        seq: Conversation sequence number recorded with the checkpoint.
+        tick: Coordinator tick recorded with the checkpoint.
+        previous: Prior memory record, used to accumulate learnings and the
+            checkpoint count.
+
+    Returns:
+        The new ``orchestration_memory`` record with accumulated learnings and
+        updated checkpoint bookkeeping.
     """
     prev = previous or {}
     learnings = list(prev.get("learnings") or [])
@@ -198,6 +222,13 @@ def render_memory_for_seed(memory: dict[str, Any]) -> str:
 
     Used for compaction re-seed and resume rebuild. Returns "" when memory
     is empty (fresh session).
+
+    Args:
+        memory: An ``orchestration_memory`` record to render.
+
+    Returns:
+        A prompt-ready text block summarizing the recovered working memory, or
+        an empty string when ``memory`` is empty.
     """
     if not memory:
         return ""

--- a/inference_optimizer/orchestrator/phase_state.py
+++ b/inference_optimizer/orchestrator/phase_state.py
@@ -39,7 +39,14 @@ PHASE_INDEX: dict[str, int] = {name: i for i, name in enumerate(PHASE_NAMES)}
 
 
 def phase_index(phase: str) -> int:
-    """Return monotonic index of ``phase`` (Inv-2.1 check); unknown → -1."""
+    """Return monotonic index of ``phase`` (Inv-2.1 check); unknown → -1.
+
+    Args:
+        phase: Phase name to look up (case-insensitive).
+
+    Returns:
+        The phase's monotonic index, or ``-1`` when unknown.
+    """
     return PHASE_INDEX.get((phase or "").strip().upper(), -1)
 
 
@@ -81,7 +88,16 @@ PHASE_ALLOWED_ACTIONS: dict[str, frozenset[str]] = {
 
 
 def is_action_allowed_in_phase(action_name: str, phase: str) -> bool:
-    """Return True iff ``action_name`` is in the phase allowlist (R1; unknown phase → deny)."""
+    """Return True iff ``action_name`` is in the phase allowlist (R1; unknown phase → deny).
+
+    Args:
+        action_name: Candidate action name.
+        phase: Phase to check against (case-insensitive).
+
+    Returns:
+        ``True`` when the action is allowed in the phase, ``False`` otherwise
+        (including for unknown phases).
+    """
     allowed = PHASE_ALLOWED_ACTIONS.get((phase or "").strip().upper())
     if allowed is None:
         return False
@@ -89,7 +105,14 @@ def is_action_allowed_in_phase(action_name: str, phase: str) -> bool:
 
 
 def allowed_actions_for(phase: str) -> tuple[str, ...]:
-    """Return ``PHASE_ALLOWED_ACTIONS[phase]`` as a sorted tuple (deterministic)."""
+    """Return ``PHASE_ALLOWED_ACTIONS[phase]`` as a sorted tuple (deterministic).
+
+    Args:
+        phase: Phase whose allowed actions are returned (case-insensitive).
+
+    Returns:
+        The phase's allowed action names sorted for deterministic ordering.
+    """
     return tuple(sorted(PHASE_ALLOWED_ACTIONS.get((phase or "").strip().upper(), frozenset())))
 
 
@@ -102,7 +125,16 @@ PHASE_LLM_PROPOSABLE_ACTIONS: dict[str, frozenset[str]] = {
 
 
 def is_action_llm_proposable_in_phase(action_name: str, phase: str) -> bool:
-    """Return True iff ``action_name`` is LLM-proposable in ``phase`` (unknown → deny)."""
+    """Return True iff ``action_name`` is LLM-proposable in ``phase`` (unknown → deny).
+
+    Args:
+        action_name: Candidate action name.
+        phase: Phase to check against (case-insensitive).
+
+    Returns:
+        ``True`` when the action is LLM-proposable in the phase, ``False``
+        otherwise (including for unknown phases).
+    """
     proposable = PHASE_LLM_PROPOSABLE_ACTIONS.get((phase or "").strip().upper())
     if proposable is None:
         return False
@@ -110,7 +142,16 @@ def is_action_llm_proposable_in_phase(action_name: str, phase: str) -> bool:
 
 
 def llm_proposable_actions_for(phase: str) -> tuple[str, ...]:
-    """Return ``PHASE_LLM_PROPOSABLE_ACTIONS[phase]`` sorted (deterministic)."""
+    """Return ``PHASE_LLM_PROPOSABLE_ACTIONS[phase]`` sorted (deterministic).
+
+    Args:
+        phase: Phase whose LLM-proposable actions are returned
+            (case-insensitive).
+
+    Returns:
+        The phase's LLM-proposable action names sorted for deterministic
+        ordering.
+    """
     return tuple(sorted(
         PHASE_LLM_PROPOSABLE_ACTIONS.get((phase or "").strip().upper(), frozenset())
     ))
@@ -129,7 +170,12 @@ _INTERLEAVE_KERNEL_EXTRAS: frozenset[str] = frozenset({
 
 
 def is_phase_interleave_enabled() -> bool:
-    """Return True when EXPLORE↔KERNEL interleave is enabled (default ON, P3_18; env is rollback knob)."""
+    """Return True when EXPLORE↔KERNEL interleave is enabled (default ON, P3_18; env is rollback knob).
+
+    Returns:
+        ``True`` unless the interleave env var is set to a falsey value
+        (``0``/``false``/``no``/``off``).
+    """
     raw = (os.environ.get(PHASE_INTERLEAVE_ENV) or "").strip().lower()
     return raw not in {"0", "false", "no", "off"}
 
@@ -137,7 +183,17 @@ def is_phase_interleave_enabled() -> bool:
 def llm_proposable_actions_for_with_interleave(
     phase: str, *, interleave: bool | None = None,
 ) -> frozenset[str]:
-    """Return the active LLM-proposable set for ``phase`` (when interleave on, EXPLORE adds kernel-owned names, KERNEL adds the explore triple)."""
+    """Return the active LLM-proposable set for ``phase`` (when interleave on, EXPLORE adds kernel-owned names, KERNEL adds the explore triple).
+
+    Args:
+        phase: Phase whose proposable set is returned (case-insensitive).
+        interleave: Force interleave on/off; defaults to
+            :func:`is_phase_interleave_enabled` when ``None``.
+
+    Returns:
+        The proposable action set for the phase, widened by interleave extras
+        when interleave is active.
+    """
     key = (phase or "").strip().upper()
     base = PHASE_LLM_PROPOSABLE_ACTIONS.get(key, frozenset())
     if interleave is None:
@@ -155,7 +211,18 @@ def is_action_llm_proposable_in_phase_with_interleave(
     action_name: str, phase: str, *, interleave: bool | None = None,
 ) -> bool:
     """Mirror of :func:`is_action_llm_proposable_in_phase` honoring the
-    interleave flag."""
+    interleave flag.
+
+    Args:
+        action_name: Candidate action name.
+        phase: Phase to check against (case-insensitive).
+        interleave: Force interleave on/off; defaults to
+            :func:`is_phase_interleave_enabled` when ``None``.
+
+    Returns:
+        ``True`` when the action is LLM-proposable in the phase under the
+        resolved interleave mode.
+    """
     proposable = llm_proposable_actions_for_with_interleave(
         phase, interleave=interleave,
     )
@@ -370,7 +437,15 @@ def is_pause_specialist_hint(hint: str) -> bool:
 
 
 def is_valid_escalate_hint(hint: str) -> bool:
-    """Return True for any hint Coordinator should act on (closed vocab + ``pause_specialist_<domain>``)."""
+    """Return True for any hint Coordinator should act on (closed vocab + ``pause_specialist_<domain>``).
+
+    Args:
+        hint: Candidate escalate hint string.
+
+    Returns:
+        ``True`` when the hint is in the closed vocabulary or is a valid
+        ``pause_specialist_<domain>`` directive.
+    """
     return (hint or "").strip() in ESCALATE_HINT_VOCAB or is_pause_specialist_hint(hint)
 
 
@@ -381,7 +456,18 @@ def apply_escalate_budget_bump(
     delta: float = ESCALATE_HINT_BUDGET_BUMP_DELTA,
     cap: float = ESCALATE_HINT_BUDGET_BUMP_CAP,
 ) -> dict[str, float]:
-    """Return a budget map with ``phase`` raised by ``delta`` (capped at 80%)."""
+    """Return a budget map with ``phase`` raised by ``delta`` (capped at 80%).
+
+    Args:
+        current_budget_pct: Existing ``phase -> pct`` map, or ``None``.
+        phase: Phase whose budget is raised; unknown phases are a no-op.
+        delta: Percentage-point increase to apply.
+        cap: Absolute ceiling for the resulting budget fraction.
+
+    Returns:
+        A new budget map with the phase's budget raised by ``delta`` and
+        clamped to ``[0.0, cap]``.
+    """
     phase_key = (phase or "").strip().upper()
     if phase_key not in PHASE_NAMES:
         return dict(current_budget_pct or {})
@@ -395,7 +481,15 @@ def apply_escalate_budget_bump(
 def normalize_budget_pct(
     budget: dict[str, float] | None,
 ) -> dict[str, float]:
-    """Return a sanitized ``phase -> pct`` mapping (budgets are upper bounds, not renormalized to 1.0)."""
+    """Return a sanitized ``phase -> pct`` mapping (budgets are upper bounds, not renormalized to 1.0).
+
+    Args:
+        budget: Candidate ``phase -> pct`` map, or ``None`` for defaults.
+
+    Returns:
+        A copy of the default budget map with valid overrides applied; unknown
+        phases and out-of-range values are dropped.
+    """
     out = dict(DEFAULT_PHASE_BUDGET_PCT)
     if not budget:
         return out
@@ -415,7 +509,15 @@ def normalize_budget_pct(
 
 # Pure judgment helpers (used by Coordinator at each tick end)
 def _now_unix(state: Any) -> float:
-    """Resolve the "now" timestamp; tests can inject ``state._now_unix``."""
+    """Resolve the "now" timestamp; tests can inject ``state._now_unix``.
+
+    Args:
+        state: Frozen SharedState view; may expose a callable ``_now_unix``.
+
+    Returns:
+        The current Unix timestamp in seconds, from the injected hook when
+        present otherwise from ``time.time()``.
+    """
     if hasattr(state, "_now_unix") and callable(state._now_unix):
         return float(state._now_unix())  # type: ignore[attr-defined]
     import time as _time
@@ -442,7 +544,14 @@ def _phase_started_unix(state: Any) -> float:
 
 
 def _pending_escalate_hint(state: Any) -> str:
-    """Return a pending escalate hint to act on this tick (unknown hints → empty)."""
+    """Return a pending escalate hint to act on this tick (unknown hints → empty).
+
+    Args:
+        state: Frozen SharedState view exposing ``pending_escalate_hint``.
+
+    Returns:
+        The pending hint when it is recognized, else an empty string.
+    """
     raw = str(getattr(state, "pending_escalate_hint", "") or "").strip()
     if not raw:
         return ""
@@ -497,7 +606,18 @@ def phase_budget_remaining_seconds(
     budget_pct: dict[str, float] | None = None,
     now_unix: float | None = None,
 ) -> float | None:
-    """Return seconds remaining in the current phase's budget (``None`` when ``max_minutes`` 0 = unlimited)."""
+    """Return seconds remaining in the current phase's budget (``None`` when ``max_minutes`` 0 = unlimited).
+
+    Args:
+        state: Frozen SharedState view exposing phase and budget fields.
+        budget_pct: Override ``phase -> pct`` map; defaults to the state's
+            ``phase_budget_pct`` when ``None``.
+        now_unix: Override for the current time in seconds.
+
+    Returns:
+        Non-negative seconds remaining in the current phase's budget, or
+        ``None`` when the session is unlimited or the phase has no budget.
+    """
     mm = _max_minutes(state)
     if mm <= 0:
         return None
@@ -513,7 +633,17 @@ def phase_budget_remaining_seconds(
 def session_remaining_seconds(
     state: Any, *, now_unix: float | None = None,
 ) -> float | None:
-    """Total wall-clock seconds remaining for the session (``None`` when ``max_minutes`` 0 or ``start_ts`` unparseable)."""
+    """Total wall-clock seconds remaining for the session (``None`` when ``max_minutes`` 0 or ``start_ts`` unparseable).
+
+    Args:
+        state: Frozen SharedState view exposing ``max_minutes`` and
+            ``start_ts``.
+        now_unix: Override for the current time in seconds.
+
+    Returns:
+        Non-negative wall-clock seconds remaining, or ``None`` when the session
+        is unlimited or ``start_ts`` cannot be parsed.
+    """
     mm = _max_minutes(state)
     if mm <= 0:
         return None
@@ -550,6 +680,20 @@ def should_force_exit_explore(
     CLOSE-buffer (the "reserve 3h for a separate KERNEL phase" rationale no
     longer applies because kernel work runs inside EXPLORE). Explicit
     non-default thresholds from the caller always win.
+
+    Args:
+        state: Frozen SharedState view.
+        hours_remaining_threshold: Session-remaining hours below which the gate
+            fires; non-positive disables this check.
+        budget_pct_threshold: Phase-budget remaining fraction below which the
+            gate fires; non-positive disables this check.
+        budget_pct: Override ``phase -> pct`` map for budget computation.
+        now_unix: Override for the current time in seconds.
+
+    Returns:
+        A tuple ``(fired, evidence)`` where ``fired`` is ``True`` when the
+        force-exit gate triggers and ``evidence`` records the thresholds and
+        which checks fired.
     """
     if is_phase_interleave_enabled():
         if float(hours_remaining_threshold) == DEFAULT_EXPLORE_FORCE_EXIT_HOURS_REMAINING:
@@ -616,6 +760,20 @@ def compute_plateau_explore(
 
     Trigger (AND, KB_design §3.8 §5.1): recent_keep_gain < threshold AND
     recent_empty_streak >= empty_streak_threshold.
+
+    Args:
+        state: Frozen SharedState view exposing ``explore_search`` and
+            ``specialist_rounds``.
+        lookback: Number of recent winners to sum keep-gain over; non-positive
+            disables the judgment.
+        keep_gain_threshold_pct: Keep-gain threshold below which the gain leg
+            of the trigger is satisfied.
+        empty_streak_threshold: Trailing empty-round count required for the
+            streak leg of the trigger.
+
+    Returns:
+        A tuple ``(triggered, evidence)`` where ``evidence`` records the
+        observed keep-gain, empty streak, and the thresholds used.
     """
     if lookback <= 0:
         return False, {"reason": "lookback_disabled"}
@@ -708,6 +866,19 @@ def compute_plateau_kernel(
 
     Trigger (OR, KB_design §3.8 §5.2 — weaker than explore's AND): revert_streak
     >= threshold OR recent_keep_gain < keep_gain_threshold_pct.
+
+    Args:
+        state: Frozen SharedState view exposing ``kernel_integrate_attempts``.
+        lookback: Number of most-recent integrate attempts to consider;
+            non-positive disables the judgment.
+        revert_streak_threshold: Trailing REVERT/NEEDS_REVIEW count that
+            triggers the streak leg; non-positive disables the judgment.
+        keep_gain_threshold_pct: Keep-gain threshold below which the gain leg
+            triggers.
+
+    Returns:
+        A tuple ``(triggered, evidence)`` where ``evidence`` records the revert
+        streak, summed keep-gain, and the thresholds used.
     """
     lookback = int(lookback or 0)
     revert_streak_threshold = int(revert_streak_threshold or 0)
@@ -780,6 +951,14 @@ def _global_terminal(state: Any) -> tuple[str, dict[str, Any]] | None:
     """Return ``(stop_reason, evidence)`` for a phase-orthogonal stop.
 
     Priority: 1. ``skip_to_close`` → ``robustness_escalated``; 2. Coordinator ``stop_reason``.
+
+    Args:
+        state: Frozen SharedState view exposing ``pending_escalate_hint`` and
+            ``stop_reason``.
+
+    Returns:
+        A ``(stop_reason, evidence)`` tuple when a terminal stop applies, else
+        ``None``.
     """
     hint = _pending_escalate_hint(state)
     if hint == ESCALATE_HINT_SKIP_TO_CLOSE:
@@ -799,7 +978,14 @@ def _global_terminal(state: Any) -> tuple[str, dict[str, Any]] | None:
 
 # per-phase judgments
 def warm_replay_in_flight(state: Any) -> bool:
-    """True while the PRELUDE warm-recipe replay task has not finished (PRELUDE must not exit until False — GPU contention)."""
+    """True while the PRELUDE warm-recipe replay task has not finished (PRELUDE must not exit until False — GPU contention).
+
+    Args:
+        state: Frozen SharedState view exposing ``warm_replay_outcome``.
+
+    Returns:
+        ``True`` while the warm-replay outcome status is ``in_flight``.
+    """
     outcome = getattr(state, "warm_replay_outcome", None) or {}
     if not isinstance(outcome, dict):
         return False
@@ -807,7 +993,16 @@ def warm_replay_in_flight(state: Any) -> bool:
 
 
 def exit_normal_prelude(state: Any) -> tuple[str, dict[str, Any]] | None:
-    """``baseline_tput > 0`` and warm-replay settled → ``prelude_done`` (else ``None``)."""
+    """``baseline_tput > 0`` and warm-replay settled → ``prelude_done`` (else ``None``).
+
+    Args:
+        state: Frozen SharedState view exposing ``baseline_tput`` and
+            warm-replay status.
+
+    Returns:
+        ``("prelude_done", evidence)`` once the baseline is measured and
+        warm-replay has settled, else ``None``.
+    """
     if warm_replay_in_flight(state):
         return None
     try:
@@ -874,6 +1069,18 @@ def exit_normal_explore(
     Priority: 0. HARD force-exit (IR-6, overrides plateau); 1. ``skip_to_kernel``
     → ``plateau_explore``; 2. ``skip_to_sweep`` → ``no_more_leverage`` (non-terminal);
     3. phase budget exhausted.
+
+    Args:
+        state: Frozen SharedState view.
+        budget_pct: Override ``phase -> pct`` map for budget computation.
+        now_unix: Override for the current time in seconds.
+        force_exit_hours_remaining: Session-remaining hours threshold for the
+            IR-6 force-exit gate.
+        force_exit_budget_pct: Phase-budget remaining fraction threshold for the
+            IR-6 force-exit gate.
+
+    Returns:
+        A ``(reason, evidence)`` tuple when EXPLORE should exit, else ``None``.
     """
     forced, force_ev = should_force_exit_explore(
         state,
@@ -919,6 +1126,14 @@ def exit_normal_kernel(
 
     Priority: 1. ``skip_to_close`` defers to global terminal; 2. ``skip_to_sweep``
     → ``no_more_leverage``; 3. phase budget exhausted.
+
+    Args:
+        state: Frozen SharedState view.
+        budget_pct: Override ``phase -> pct`` map for budget computation.
+        now_unix: Override for the current time in seconds.
+
+    Returns:
+        A ``(reason, evidence)`` tuple when KERNEL should exit, else ``None``.
     """
     if _pending_escalate_hint(state) == ESCALATE_HINT_SKIP_TO_SWEEP:
         return "no_more_leverage", {
@@ -947,6 +1162,15 @@ def exit_normal_sweep(
     """SWEEP normal exit: sweep_done OR conc_sweep_done OR budget exhausted.
 
     Bug #12: conc_sweep completion emits an exit so a singleton-blocked sweep doesn't idle.
+
+    Args:
+        state: Frozen SharedState view exposing ``last_sweep`` and
+            ``last_conc_sweep``.
+        budget_pct: Override ``phase -> pct`` map for budget computation.
+        now_unix: Override for the current time in seconds.
+
+    Returns:
+        A ``(reason, evidence)`` tuple when SWEEP should exit, else ``None``.
     """
     last_sweep = getattr(state, "last_sweep", None) or {}
     if isinstance(last_sweep, dict):
@@ -971,7 +1195,15 @@ def exit_normal_sweep(
 # Transition decision (the only function the Coordinator calls each tick)
 def _resolve_plateau_overrides(state: Any) -> dict[str, Any]:
     """Pull operator-tuned plateau thresholds off
-    :attr:`SharedState.plateau_overrides` (empty → library defaults)."""
+    :attr:`SharedState.plateau_overrides` (empty → library defaults).
+
+    Args:
+        state: Frozen SharedState view exposing ``plateau_overrides``.
+
+    Returns:
+        A copy of the operator-tuned override map, or an empty dict when none
+        are set.
+    """
     overrides = getattr(state, "plateau_overrides", None) or {}
     return dict(overrides) if isinstance(overrides, dict) else {}
 
@@ -980,7 +1212,16 @@ def _framework_pr_batch_is_complete(
     batch: dict[str, Any],
     progress_by_batch: dict[str, int],
 ) -> bool:
-    """A FRAMEWORK_PR batch is complete iff every candidate has a terminal-status row in ``framework_pr_phase_progress`` (guards the plateau judge)."""
+    """A FRAMEWORK_PR batch is complete iff every candidate has a terminal-status row in ``framework_pr_phase_progress`` (guards the plateau judge).
+
+    Args:
+        batch: A FRAMEWORK_PR batch record with a ``candidates`` list.
+        progress_by_batch: Map of ``batch_id`` to processed-candidate count.
+
+    Returns:
+        ``True`` when every candidate in the batch has a progress row (or the
+        batch has no candidates).
+    """
     candidates = batch.get("candidates") or []
     if not isinstance(candidates, list) or not candidates:
         return True
@@ -1002,6 +1243,18 @@ def compute_plateau_framework_pr(
 
     Triggers when the last ``lookback`` fully-processed batches each carry
     ``max_gain_pct_observed_in_batch < keep_gain_threshold_pct``. Advisory-only.
+
+    Args:
+        state: Frozen SharedState view exposing ``framework_pr_batches`` and
+            ``framework_pr_phase_progress``.
+        lookback: Number of trailing complete batches to inspect; non-positive
+            disables the judgment.
+        keep_gain_threshold_pct: Max-gain threshold each batch must fall below
+            for the plateau to trigger.
+
+    Returns:
+        A tuple ``(triggered, evidence)`` where ``evidence`` records the
+        lookback, threshold, and the observed per-batch max gains.
     """
     batches = getattr(state, "framework_pr_batches", None) or []
     lookback_int = int(lookback or 0)
@@ -1051,7 +1304,15 @@ def compute_plateau_framework_pr(
 
 
 def _framework_pr_pending_candidate_count(state: Any) -> int:
-    """Count candidates discovered into a batch but missing a progress row."""
+    """Count candidates discovered into a batch but missing a progress row.
+
+    Args:
+        state: Frozen SharedState view exposing ``framework_pr_batches`` and
+            ``framework_pr_phase_progress``.
+
+    Returns:
+        The number of discovered candidates that lack a progress row.
+    """
     batches = getattr(state, "framework_pr_batches", None) or []
     if not isinstance(batches, list) or not batches:
         return 0
@@ -1088,6 +1349,19 @@ def exit_normal_framework_pr(
 
     Priority: 0. HARD force-exit when remaining < ratio*max_hours →
     ``framework_pr_force_exit_low_budget``; 1. ``framework_pr_phase_done``; else ``None``.
+
+    Args:
+        state: Frozen SharedState view; may expose ``remaining_minutes`` and
+            ``framework_pr_phase_done``.
+        max_hours: Total session budget in hours; enables the force-exit gate
+            when positive.
+        now_unix: Override for the current time in seconds.
+        force_exit_hours_remaining_ratio: Fraction of ``max_hours`` below which
+            the force-exit gate fires.
+
+    Returns:
+        A ``(reason, evidence)`` tuple when FRAMEWORK_PR should exit, else
+        ``None``.
     """
     if max_hours and max_hours > 0:
         remaining_min_fn = getattr(state, "remaining_minutes", None)
@@ -1123,7 +1397,15 @@ def exit_normal_framework_pr(
 
 def _post_prelude_target(*, explore_enabled: bool, kernel_enabled: bool) -> str:
     """First active phase after PRELUDE / FRAMEWORK_PR: EXPLORE, else KERNEL,
-    else SWEEP (``--no-explore`` / ``--no-kernel`` collapse the chain)."""
+    else SWEEP (``--no-explore`` / ``--no-kernel`` collapse the chain).
+
+    Args:
+        explore_enabled: Whether the EXPLORE phase is enabled.
+        kernel_enabled: Whether the KERNEL phase is enabled.
+
+    Returns:
+        The first active phase name given the enabled flags.
+    """
     if explore_enabled:
         return PHASE_EXPLORE
     if kernel_enabled:
@@ -1144,6 +1426,20 @@ def compute_next_phase(
     """Return ``(next_phase, reason, evidence)`` or ``None``.
 
     Priority (Inv-8.2 + §3.8 §7.1): global terminal first, then abort > exit_terminal > exit_normal.
+
+    Args:
+        state: Frozen SharedState view exposing the current ``phase``.
+        kernel_enabled: Whether the KERNEL phase is enabled.
+        budget_pct: Override ``phase -> pct`` map for budget computation.
+        now_unix: Override for the current time in seconds.
+        framework_phase_enabled: Whether the FRAMEWORK_PR phase runs after
+            PRELUDE.
+        explore_enabled: Whether the EXPLORE phase is enabled.
+        max_hours: Total session budget in hours (FRAMEWORK_PR force-exit gate).
+
+    Returns:
+        A ``(next_phase, reason, evidence)`` tuple when a transition is due,
+        else ``None``.
     """
     current = (getattr(state, "phase", "") or "").strip().upper() or PHASE_PRELUDE
     overrides = _resolve_plateau_overrides(state)
@@ -1253,7 +1549,19 @@ def make_history_row(
     ts: str,
     ts_unix: float,
 ) -> dict[str, Any]:
-    """Construct a canonical phase_history row (Inv-2.2 + KB_design §3.2 §6); ``reason`` unvalidated for resume tools."""
+    """Construct a canonical phase_history row (Inv-2.2 + KB_design §3.2 §6); ``reason`` unvalidated for resume tools.
+
+    Args:
+        from_phase: Phase being left.
+        to_phase: Phase being entered.
+        reason: Transition reason (left unvalidated for resume tools).
+        evidence: Optional evidence dict recorded with the row.
+        ts: ISO timestamp of the transition.
+        ts_unix: Unix timestamp of the transition.
+
+    Returns:
+        A canonical phase-history row dict.
+    """
     return {
         "from_phase": (from_phase or "").strip().upper(),
         "to_phase":   (to_phase or "").strip().upper(),
@@ -1332,6 +1640,13 @@ def lifecycle_label(name: str) -> str:
     Falls back to the phase-label table, then to the verbatim name, so an
     unmapped step still produces a sensible event rather than an empty
     label.
+
+    Args:
+        name: A step or phase name to label.
+
+    Returns:
+        The human-friendly label, falling back to the verbatim name when
+        unmapped.
     """
     key = (name or "").strip()
     if key in LIFECYCLE_STEP_LABELS:
@@ -1361,6 +1676,21 @@ def make_lifecycle_event(
     that want the strict check go through :data:`LIFECYCLE_STATUSES`.
     Empty / ``None`` artifact values are dropped so the rendered event only
     advertises paths that actually exist.
+
+    Args:
+        step: Machine step / handler name.
+        status: Lifecycle status (START/END/ERROR/ENTER); not hard-validated.
+        phase: Coordinator phase active when the event fired.
+        label: Human-friendly label; defaults to ``lifecycle_label(step)`` when
+            ``None``.
+        artifacts: Optional map of artifact name to path; empty values dropped.
+        detail: Free-form detail string.
+        duration_s: Optional duration in seconds; omitted when unparseable.
+        seq: Monotonic sequence number for the event.
+        ts: ISO timestamp of the event.
+
+    Returns:
+        A canonical lifecycle event row dict.
     """
     event: dict[str, Any] = {
         "seq":    int(seq),

--- a/inference_optimizer/orchestrator/policy.py
+++ b/inference_optimizer/orchestrator/policy.py
@@ -43,7 +43,14 @@ if TYPE_CHECKING:  # pragma: no cover — type-only
 
 
 def _value_is_present(value: Any) -> bool:
-    """Present iff a non-empty string OR non-empty container; ``None`` / whitespace count as absent."""
+    """Present iff a non-empty string OR non-empty container; ``None`` / whitespace count as absent.
+
+    Args:
+        value: The value to test for presence.
+
+    Returns:
+        True when the value is considered present.
+    """
     if value is None:
         return False
     if isinstance(value, str):
@@ -54,7 +61,15 @@ def _value_is_present(value: Any) -> bool:
 
 
 def _delegate_field_present(payload: dict[str, Any], field_name: str) -> bool:
-    """True iff ``field_name`` is present at the top of ``payload`` OR nested under ``payload["params"]`` (robustness uses params)."""
+    """True iff ``field_name`` is present at the top of ``payload`` OR nested under ``payload["params"]`` (robustness uses params).
+
+    Args:
+        payload: The intent payload dict to inspect.
+        field_name: The field name to look for.
+
+    Returns:
+        True when the field is present at the top level or under ``params``.
+    """
     if _value_is_present(payload.get(field_name)):
         return True
     nested = payload.get("params")
@@ -128,7 +143,11 @@ RESEARCH_LANE_CEILING_FALLBACK: int = 2
 
 
 def detect_gpu_count() -> int:
-    """Best-effort visible-GPU count: env masks first, then ``rocm-smi``; 0 when nothing can be probed."""
+    """Best-effort visible-GPU count: env masks first, then ``rocm-smi``; 0 when nothing can be probed.
+
+    Returns:
+        The visible GPU count, or 0 when nothing can be probed.
+    """
     for env_name in ("HIP_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES"):
         raw = os.environ.get(env_name)
         if raw is None:
@@ -163,7 +182,11 @@ def detect_gpu_count() -> int:
 
 
 def research_lane_ceiling() -> int:
-    """Dynamic ceiling on concurrent research-lane specialists (``2 × GPU``; falls back to :data:`RESEARCH_LANE_CEILING_FALLBACK`)."""
+    """Dynamic ceiling on concurrent research-lane specialists (``2 × GPU``; falls back to :data:`RESEARCH_LANE_CEILING_FALLBACK`).
+
+    Returns:
+        The research-lane concurrency ceiling.
+    """
     gpus = detect_gpu_count()
     if gpus > 0:
         return 2 * gpus
@@ -171,7 +194,15 @@ def research_lane_ceiling() -> int:
 
 
 def gpu_specialist_ceiling(shared_state: Any | None = None) -> int:
-    """Configured GPU specialist capacity (separate from serving lanes; 0 disables ``needs_gpu=true`` dispatch)."""
+    """Configured GPU specialist capacity (separate from serving lanes; 0 disables ``needs_gpu=true`` dispatch).
+
+    Args:
+        shared_state: Session state carrying the configured capacity, or
+            ``None`` to read from the environment.
+
+    Returns:
+        The configured GPU specialist capacity (>= 0).
+    """
     if shared_state is not None:
         try:
             return max(0, int(
@@ -360,7 +391,11 @@ SOURCE_LIKE_FIELDS: frozenset[str] = frozenset({"source_file"})
 
 # Multi-node profile trace dirs live outside session_dir but must be referenceable by trace_dir / main_trace_path / trace_input (runtime-resolved).
 def _trace_path_allowlist() -> tuple[str, ...]:
-    """Multi-node profile trace path-prefix allowlist (runtime-resolved; trailing ``/`` is load-bearing for the startswith check)."""
+    """Multi-node profile trace path-prefix allowlist (runtime-resolved; trailing ``/`` is load-bearing for the startswith check).
+
+    Returns:
+        A one-tuple of the allowed trace-root path prefix.
+    """
     from ..paths import mn_profile_trace_root
     root = str(mn_profile_trace_root()).rstrip("/") + "/"
     return (root,)
@@ -492,7 +527,15 @@ class PolicyGate:
 
     # Public API
     def validate_intent(self, from_agent: str, intent: Intent) -> None:
-        """Raise :class:`PolicyDenied` if the intent is not allowed (cheapest checks first: role → allowed_intents → structural → cross-source)."""
+        """Raise :class:`PolicyDenied` if the intent is not allowed (cheapest checks first: role → allowed_intents → structural → cross-source).
+
+        Args:
+            from_agent: Identity of the emitting agent.
+            intent: The parsed intent to validate.
+
+        Raises:
+            PolicyDenied: If the intent is not permitted for the agent.
+        """
         # specialist sub-agents emit under an ephemeral ``specialist:<task_id>`` identity routed to a synthetic role.
         if from_agent.startswith(SPECIALIST_FROM_AGENT_PREFIX):
             self._validate_specialist_intent(from_agent, intent)
@@ -544,7 +587,15 @@ class PolicyGate:
     def _closing_phase_denial(
         self, source: str, intent: Intent,
     ) -> PolicyDenied | None:
-        """During closing phase, allow only harmless intents and ``report`` proposals."""
+        """During closing phase, allow only harmless intents and ``report`` proposals.
+
+        Args:
+            source: Identity of the emitting agent.
+            intent: The parsed intent under evaluation.
+
+        Returns:
+            A :class:`PolicyDenied` to raise, or ``None`` when allowed.
+        """
         state = self.shared_state
         if state is None or not getattr(state, "closing_phase", False):
             return None
@@ -569,7 +620,14 @@ class PolicyGate:
         )
 
     def allowed_tools_for_agent(self, agent_name: str) -> list[str]:
-        """Return the Claude tool list a reactor may use (Codex → []; Claude → emit_intent; orchestration also gets context-pull tools + sandboxed Read)."""
+        """Return the Claude tool list a reactor may use (Codex → []; Claude → emit_intent; orchestration also gets context-pull tools + sandboxed Read).
+
+        Args:
+            agent_name: Identity of the reactor agent.
+
+        Returns:
+            The list of tool names the agent may use.
+        """
         role = self.role_registry.get(agent_name)
         if role is None:
             return []
@@ -583,7 +641,14 @@ class PolicyGate:
         return tools
 
     def allowed_tools_for_action(self, action_name: str) -> list[str]:
-        """Per-action tool intersection; action's declared ``allowed_tools`` or the default ``["emit_intent"]``."""
+        """Per-action tool intersection; action's declared ``allowed_tools`` or the default ``["emit_intent"]``.
+
+        Args:
+            action_name: The action to resolve tools for.
+
+        Returns:
+            The list of allowed tool names for the action.
+        """
         if self.action_registry is None:
             return ["emit_intent"]
         meta = self.action_registry.get(action_name)
@@ -992,7 +1057,17 @@ class PolicyGate:
         *,
         intent_kind: str,
     ) -> None:
-        """Reject an action the LLM cannot propose in the current phase (``strict_phase`` True raises, False warns; no-op when phase missing)."""
+        """Reject an action the LLM cannot propose in the current phase (``strict_phase`` True raises, False warns; no-op when phase missing).
+
+        Args:
+            role: The resolved role of the emitting agent.
+            action_name: The action being validated.
+            intent_kind: The intent kind (e.g. ``"delegate"``).
+
+        Raises:
+            PolicyDenied: If the action is not proposable in the phase and
+                ``strict_phase`` is enabled.
+        """
         if action_name in COORDINATOR_INTERNAL_ACTIONS:
             raise PolicyDenied(
                 f"action {action_name!r} is Coordinator-managed and not "
@@ -1060,7 +1135,15 @@ class PolicyGate:
         *,
         intent_kind: str,
     ) -> None:
-        """Reject GEMM tuning for non-FP8 sessions (it drives FP8 block-scale GEMM dispatch; the handler repeats the check)."""
+        """Reject GEMM tuning for non-FP8 sessions (it drives FP8 block-scale GEMM dispatch; the handler repeats the check).
+
+        Args:
+            action_name: The action being validated.
+            intent_kind: The intent kind (e.g. ``"delegate"``).
+
+        Raises:
+            PolicyDenied: If the action is FP8-only but the session is not FP8.
+        """
         if not action_name or action_name not in FP8_ONLY_ACTIONS:
             return
         state = self.shared_state
@@ -1087,7 +1170,15 @@ class PolicyGate:
         *,
         intent_kind: str,
     ) -> None:
-        """Reject any intent whose ``action_name`` / ``request.kind`` equals a Cortex KB write tool name (defense in depth; KB_design §3.11 §4.4 / Inv-11.3)."""
+        """Reject any intent whose ``action_name`` / ``request.kind`` equals a Cortex KB write tool name (defense in depth; KB_design §3.11 §4.4 / Inv-11.3).
+
+        Args:
+            action_name: The action / request kind being validated.
+            intent_kind: The intent kind (e.g. ``"delegate"``).
+
+        Raises:
+            PolicyDenied: If the name collides with a KB write tool.
+        """
         if not action_name:
             return
         if action_name not in KB_WRITE_TOOL_NAMES:
@@ -1113,7 +1204,16 @@ class PolicyGate:
         *,
         intent_kind: str,
     ) -> None:
-        """Reject an external tool name not on the caller's role whitelist (KB/PR/Web tools are specialist-only; KB_design §3.11 §4.5)."""
+        """Reject an external tool name not on the caller's role whitelist (KB/PR/Web tools are specialist-only; KB_design §3.11 §4.5).
+
+        Args:
+            role_name: The emitting role name.
+            action_name: The action / tool name being validated.
+            intent_kind: The intent kind (e.g. ``"delegate"``).
+
+        Raises:
+            PolicyDenied: If the tool is not whitelisted for the role.
+        """
         if not action_name:
             return
         # Skip KB write names (R4 owns them) so a write attempt yields ``kb_write_unauthorized``, not the less-specific R5 code.
@@ -1144,7 +1244,17 @@ class PolicyGate:
         source_role: str,
         phase: str | None = None,
     ) -> None:
-        """Raise :class:`PolicyDenied` if ``tool_name`` is not allowed for ``source_role`` (pure, Inv-11.1; ``phase`` no longer gates)."""
+        """Raise :class:`PolicyDenied` if ``tool_name`` is not allowed for ``source_role`` (pure, Inv-11.1; ``phase`` no longer gates).
+
+        Args:
+            tool_name: The canonical tool name being invoked.
+            source_role: The role invoking the tool.
+            phase: Current phase; retained for compatibility (no longer gates).
+
+        Raises:
+            PolicyDenied: If the tool is empty, a KB write, or not whitelisted
+                for the role.
+        """
         tool_name = (tool_name or "").strip()
         if not tool_name:
             raise PolicyDenied(
@@ -1184,7 +1294,15 @@ class PolicyGate:
     def _validate_sweep_singleton(
         self, payload: dict[str, Any], *, intent_kind: str,
     ) -> None:
-        """Enforce one sweep per SWEEP phase (Inv-9.4): deny agent sweeps once the auto-enqueued sweep landed (concurrent sweeps crash both vllm engines). Escape: ``params.bypass_sweep_singleton=True``."""
+        """Enforce one sweep per SWEEP phase (Inv-9.4): deny agent sweeps once the auto-enqueued sweep landed (concurrent sweeps crash both vllm engines). Escape: ``params.bypass_sweep_singleton=True``.
+
+        Args:
+            payload: The delegate/propose payload (may carry the bypass flag).
+            intent_kind: The intent kind (e.g. ``"delegate"``).
+
+        Raises:
+            PolicyDenied: If an auto-enqueued sweep already exists this phase.
+        """
         params = payload.get("params") or {}
         if isinstance(params, dict) and params.get("bypass_sweep_singleton"):
             return
@@ -1228,7 +1346,15 @@ class PolicyGate:
     def _validate_conc_sweep_singleton(
         self, payload: dict[str, Any], *, intent_kind: str,
     ) -> None:
-        """Enforce one conc_sweep per SWEEP phase (Bug #11); re-proposals burn GPU for no new data. Escape: ``params.bypass_conc_sweep_singleton=True``."""
+        """Enforce one conc_sweep per SWEEP phase (Bug #11); re-proposals burn GPU for no new data. Escape: ``params.bypass_conc_sweep_singleton=True``.
+
+        Args:
+            payload: The delegate/propose payload (may carry the bypass flag).
+            intent_kind: The intent kind (e.g. ``"delegate"``).
+
+        Raises:
+            PolicyDenied: If an auto-enqueued conc_sweep already exists this phase.
+        """
         params = payload.get("params") or {}
         if isinstance(params, dict) and params.get("bypass_conc_sweep_singleton"):
             return
@@ -1268,7 +1394,14 @@ class PolicyGate:
     def _validate_integrate_patch_critic_gate(
         self, payload: dict[str, Any],
     ) -> None:
-        """PR-A7: enforce ``integrate_patch_requires_critic_verdict`` (needs specialist_task_id + permissive verdict, unless ``params.bypass_critic=True``)."""
+        """PR-A7: enforce ``integrate_patch_requires_critic_verdict`` (needs specialist_task_id + permissive verdict, unless ``params.bypass_critic=True``).
+
+        Args:
+            payload: The integrate_patch delegate payload.
+
+        Raises:
+            PolicyDenied: If params are malformed or the critic gate is unmet.
+        """
         params = payload.get("params") or {}
         if not isinstance(params, dict):
             raise PolicyDenied(
@@ -1335,7 +1468,15 @@ class PolicyGate:
     def _validate_specialist_dispatch(
         self, role: "AgentRole", payload: dict[str, Any],
     ) -> None:
-        """Enforce the specialist-delegate contract (Inv-11.2): orchestration-only, tags ∈ vocab, gap_canonical_id required, max_turns ≤ cap."""
+        """Enforce the specialist-delegate contract (Inv-11.2): orchestration-only, tags ∈ vocab, gap_canonical_id required, max_turns ≤ cap.
+
+        Args:
+            role: The resolved role of the emitting agent.
+            payload: The specialist delegate payload.
+
+        Raises:
+            PolicyDenied: If any part of the specialist-dispatch contract fails.
+        """
         if role.name not in SPECIALIST_DISPATCH_SOURCE_ALLOWLIST:
             raise PolicyDenied(
                 f"role={role.name!r} cannot dispatch specialists "
@@ -1514,7 +1655,14 @@ class PolicyGate:
         validates only structural shape: a single ``task_description`` or a
         ``tasks=[...]`` wave (bounded by SPECIALIST_FREEFORM_WAVE_MAX), each
         with a non-empty, length-bounded description that survives the
-        red-line tripwire."""
+        red-line tripwire.
+
+        Args:
+            params: The freeform specialist delegate params.
+
+        Raises:
+            PolicyDenied: If the wave or task descriptions are malformed.
+        """
         wave = params.get("tasks")
         if wave is not None:
             if not isinstance(wave, list) or not wave:
@@ -1559,7 +1707,15 @@ class PolicyGate:
     @staticmethod
     def _check_freeform_task_description(desc: str, *, where: str) -> None:
         """Per-task structural checks for a free-form ``task_description``:
-        non-empty, length-bounded, and clear of the red-line tripwire."""
+        non-empty, length-bounded, and clear of the red-line tripwire.
+
+        Args:
+            desc: The task description to check.
+            where: Label identifying the task position, used in error messages.
+
+        Raises:
+            PolicyDenied: If the description is empty, too long, or tripwired.
+        """
         if not desc:
             raise PolicyDenied(
                 f"delegate{{action='specialist',scope='freeform'}}: "
@@ -1595,7 +1751,16 @@ class PolicyGate:
     def _validate_specialist_intent(
         self, from_agent: str, intent: Intent,
     ) -> None:
-        """Validate any intent emitted under a ``specialist:<task_id>`` identity (Inv-5.2: only SEND_MESSAGE, ALERT, and one SPECIALIST_DONE)."""
+        """Validate any intent emitted under a ``specialist:<task_id>`` identity (Inv-5.2: only SEND_MESSAGE, ALERT, and one SPECIALIST_DONE).
+
+        Args:
+            from_agent: The ``specialist:<task_id>`` emitting identity.
+            intent: The parsed intent to validate.
+
+        Raises:
+            PolicyDenied: If the task id is missing or the intent type is
+                not permitted for a specialist.
+        """
         task_id = from_agent.removeprefix(SPECIALIST_FROM_AGENT_PREFIX).strip()
         if not task_id:
             raise PolicyDenied(
@@ -1631,7 +1796,15 @@ class PolicyGate:
     def _validate_specialist_done_payload(
         self, task_id: str, payload: dict[str, Any],
     ) -> None:
-        """Per-field R3 structural checks for the ``specialist_done`` payload (gap_canonical_id, domain ∈ keys, proposal_set, empty+reason, summary ≤4096, confidence ∈ [0,1])."""
+        """Per-field R3 structural checks for the ``specialist_done`` payload (gap_canonical_id, domain ∈ keys, proposal_set, empty+reason, summary ≤4096, confidence ∈ [0,1]).
+
+        Args:
+            task_id: The specialist task id (for error context).
+            payload: The specialist_done payload to validate.
+
+        Raises:
+            PolicyDenied: If any required field is missing or malformed.
+        """
         gap = str(payload.get("gap_canonical_id") or "").strip()
         if not gap:
             raise PolicyDenied(
@@ -1806,14 +1979,31 @@ class PolicyGate:
         return any(s.startswith(p) for p in resolve_source_file_allowlist())
 
     def _path_in_trace_allowlist(self, value: str) -> bool:
-        """Match a value against runtime-resolved trace path prefixes (multi-node shared profile dir outside session_dir)."""
+        """Match a value against runtime-resolved trace path prefixes (multi-node shared profile dir outside session_dir).
+
+        Args:
+            value: The path string to test.
+
+        Returns:
+            True when ``value`` starts with an allowed trace path prefix.
+        """
         s = str(value)
         return any(s.startswith(p) for p in _trace_path_allowlist())
 
     def _validate_payload_paths(
         self, role: "AgentRole", intent_type: IntentType, payload: dict[str, Any],
     ) -> None:
-        """Walk payload (recursively); reject path-like values escaping session_dir. No-op when session_dir is None or strict_paths is False."""
+        """Walk payload (recursively); reject path-like values escaping session_dir. No-op when session_dir is None or strict_paths is False.
+
+        Args:
+            role: The resolved role of the emitting agent.
+            intent_type: The intent type being validated.
+            payload: The intent payload to walk.
+
+        Raises:
+            PolicyDenied: If a path-like value escapes session_dir and its
+                applicable allowlists.
+        """
         if self.session_dir is None or not self.strict_paths:
             return
 

--- a/inference_optimizer/orchestrator/pr_monitor.py
+++ b/inference_optimizer/orchestrator/pr_monitor.py
@@ -155,6 +155,17 @@ class PRMonitorClient:
         """GET ``base_url + path`` with ``params``; parsed JSON or raises.
 
         Response size capped at 4 MiB as defense-in-depth.
+
+        Args:
+            path: The endpoint path appended to ``base_url``.
+            params: Optional query parameters (empty/``None`` values dropped).
+
+        Returns:
+            The parsed JSON response.
+
+        Raises:
+            PRMonitorError: If the client is disabled, the request fails, or
+                the response is not valid JSON.
         """
         if not self.enabled:
             raise PRMonitorError("PR Monitor client disabled (--degraded-pr)")
@@ -214,6 +225,9 @@ class PRMonitorClient:
 
         Accepts either the array or ``{"items": [...]}`` shape and either
         ``repo_name``/``name`` field; skips ``is_active=False`` entries.
+
+        Returns:
+            The active repo names, or ``[]`` on failure.
         """
         try:
             data = self._get_json("/repos")
@@ -249,6 +263,15 @@ class PRMonitorClient:
 
         Returns :class:`PRSummary` list (empty on failure). Cached by
         rendered URL to avoid re-hitting the network within a tick.
+
+        Args:
+            repo: Canonical ``owner/name`` repo identifier.
+            state: PR state filter (``all`` / ``open`` / ``closed``).
+            since: Optional ISO lower bound on ``updated_at``.
+            limit: Maximum number of PRs to fetch.
+
+        Returns:
+            The PR summaries, or ``[]`` on failure.
         """
         params = {
             "state": state,
@@ -346,7 +369,19 @@ class PRMonitorClient:
         total_budget_sec: float = DEFAULT_PR_FEED_TOTAL_BUDGET_SEC,
         now: datetime | None = None,
     ) -> tuple[list[PRSummary], list[str]]:
-        """Return ``(prs, warnings)`` for the union of ``repos``."""
+        """Return ``(prs, warnings)`` for the union of ``repos``.
+
+        Args:
+            repos: The repos to fetch and union.
+            keywords: Optional keyword filter applied to each PR.
+            window_days: Lookback window in days for the ``since`` bound.
+            per_repo_limit: Maximum PRs fetched per repo.
+            total_budget_sec: Total wall-clock budget across all repos.
+            now: Optional reference time (for tests); defaults to current UTC.
+
+        Returns:
+            A ``(prs, warnings)`` tuple; PRs are sorted newest-first.
+        """
         out: list[PRSummary] = []
         warns: list[str] = []
         if not self.enabled:
@@ -399,6 +434,18 @@ class PRMonitorClient:
         """Same as :meth:`list_prs` but re-raises :class:`PRMonitorError`.
 
         Lets :meth:`pr_feed_warm` distinguish empty-window from fetch-failed.
+
+        Args:
+            repo: Canonical ``owner/name`` repo identifier.
+            state: PR state filter (``all`` / ``open`` / ``closed``).
+            since: Optional ISO lower bound on ``updated_at``.
+            limit: Maximum number of PRs to fetch.
+
+        Returns:
+            The PR summaries for the repo.
+
+        Raises:
+            PRMonitorError: If the underlying HTTP fetch fails.
         """
         params: dict[str, Any] = {
             "state": state,
@@ -457,7 +504,16 @@ class PRMonitorClient:
 
 
 def _matches_keywords(pr: PRSummary, keywords_lower: list[str]) -> bool:
-    """Return True iff ``pr`` (title + labels + body snippet) mentions any keyword."""
+    """Return True iff ``pr`` (title + labels + body snippet) mentions any keyword.
+
+    Args:
+        pr: The PR summary to test.
+        keywords_lower: Lowercased keywords to match (empty matches all).
+
+    Returns:
+        ``True`` when any keyword appears in the PR's title, labels, or body
+        snippet (or when no keywords are given).
+    """
     if not keywords_lower:
         return True
     haystack = " ".join([

--- a/inference_optimizer/orchestrator/proposal_scorer.py
+++ b/inference_optimizer/orchestrator/proposal_scorer.py
@@ -71,7 +71,14 @@ _BARE_JSON_RE = re.compile(r"(\{.*?\"scores\".*\})", re.DOTALL)
 
 
 def _extract_scores_json(text: str) -> dict[str, Any] | None:
-    """Pull the first valid ``{"scores": {...}}`` object out of a reply."""
+    """Pull the first valid ``{"scores": {...}}`` object out of a reply.
+
+    Args:
+        text: Raw model reply that may contain a fenced or bare JSON object.
+
+    Returns:
+        The parsed ``{"scores": {...}}`` dict, or ``None`` if none was found.
+    """
     if not text:
         return None
     for m in _FENCED_JSON_RE.finditer(text):
@@ -109,7 +116,15 @@ def _clip(value: Any, *, limit: int = _MAX_FIELD_CHARS) -> str:
 
 
 def _coerce_score(raw: Any) -> float | None:
-    """Coerce a model-emitted score into a clamped [0, 10] float."""
+    """Coerce a model-emitted score into a clamped [0, 10] float.
+
+    Args:
+        raw: Raw score value emitted by a model.
+
+    Returns:
+        The score clamped to ``[0, 10]``, or ``None`` if it could not be
+        coerced to a finite number.
+    """
     try:
         val = float(raw)
     except (TypeError, ValueError):
@@ -122,7 +137,16 @@ def _coerce_score(raw: Any) -> float | None:
 def _normalise_model_scores(
     parsed: dict[str, Any], *, proposal_names: list[str],
 ) -> dict[str, dict[str, Any]]:
-    """Project parsed ``{"scores": {...}}`` onto known names (drop unknowns, clamp [0,10], truncate reasons)."""
+    """Project parsed ``{"scores": {...}}`` onto known names (drop unknowns, clamp [0,10], truncate reasons).
+
+    Args:
+        parsed: A parsed ``{"scores": {...}}`` dict from a model reply.
+        proposal_names: Names of the proposals that were actually scored;
+            scores for any other name are discarded.
+
+    Returns:
+        A mapping of proposal name to its clamped score and truncated reason.
+    """
     out: dict[str, dict[str, Any]] = {}
     scores = parsed.get("scores")
     if not isinstance(scores, dict):
@@ -227,7 +251,15 @@ class ProposalScorer:
     def _build_prompt(
         self, *, gap: dict[str, Any], proposals: list[dict[str, Any]],
     ) -> str:
-        """Build ONE group-scoring prompt covering every proposal."""
+        """Build ONE group-scoring prompt covering every proposal.
+
+        Args:
+            gap: The gap being addressed (domain, symptom, evidence, etc.).
+            proposals: Candidate variants to embed in the prompt.
+
+        Returns:
+            The assembled prompt text describing the gap and proposals.
+        """
         lines: list[str] = ["=== Gap ==="]
         lines.append(f"domain: {_clip(gap.get('domain'), limit=80)}")
         lines.append(
@@ -262,7 +294,20 @@ class ProposalScorer:
     async def _score_one_model(
         self, model: str, prompt: str, proposal_names: list[str],
     ) -> dict[str, dict[str, Any]]:
-        """Score every proposal with a single model (raises on failure; caller records the per-model error)."""
+        """Score every proposal with a single model (raises on failure; caller records the per-model error).
+
+        Args:
+            model: The model slug to score with.
+            prompt: The base scoring prompt (instructions are appended).
+            proposal_names: Names of the proposals being scored.
+
+        Returns:
+            A mapping of proposal name to its normalised score and reason.
+
+        Raises:
+            RuntimeError: If the call times out or the reply has no
+                parseable scores JSON.
+        """
         client = self._ensure_client()
         full_prompt = f"{prompt}\n\n{_SCORING_INSTRUCTIONS}"
         messages = [{"role": "user", "content": full_prompt}]
@@ -301,6 +346,10 @@ class ProposalScorer:
         phase are unknown here (the scorer runs off the dispatch path) — the
         collector backfills phase from the ts window. Best-effort: never
         raises into the scoring path.
+
+        Args:
+            model: The model slug whose usage is being recorded.
+            usage: The OpenAI usage object from the response, or ``None``.
         """
         if self.session_dir is None:
             return
@@ -339,6 +388,11 @@ class ProposalScorer:
         unknown here (the scorer runs off the dispatch path); the collector
         backfills phase from the ts window. Best-effort: never raises into
         the scoring path.
+
+        Args:
+            model: The model slug whose conversation is being recorded.
+            prompt: The full (redacted) scoring prompt sent to the model.
+            response: The model's reply text.
         """
         if self.session_dir is None:
             return
@@ -363,7 +417,16 @@ class ProposalScorer:
     async def score(
         self, *, gap: dict[str, Any], proposals: list[dict[str, Any]],
     ) -> dict[str, Any]:
-        """Score ``proposals`` against ``gap`` with every configured model (per-model failures land in ``errors``, never raised)."""
+        """Score ``proposals`` against ``gap`` with every configured model (per-model failures land in ``errors``, never raised).
+
+        Args:
+            gap: The gap the proposals are meant to address.
+            proposals: Candidate variants to score (non-dict entries ignored).
+
+        Returns:
+            A dict with the scoring ``scale``, per-model ``models`` scores,
+            and per-model ``errors``.
+        """
         proposals = [p for p in (proposals or []) if isinstance(p, dict)]
         if not proposals or not self.models:
             return {"scale": "0-10", "models": {}, "errors": {}}

--- a/inference_optimizer/orchestrator/quantization_request_handlers.py
+++ b/inference_optimizer/orchestrator/quantization_request_handlers.py
@@ -34,6 +34,17 @@ async def run_quantization_prelude_async(
     Awaits the async ``quantize_via_prompt`` directly (the caller already
     runs inside ``asyncio.run``). Raises ``SystemExit(3)`` when no usable
     quantized model was produced.
+
+    Args:
+        prompt: User-provided quantization instructions (e.g. scheme text).
+        source_model: Path to the model to quantize.
+        workspace: Working directory; the quantized model is exported under it.
+
+    Returns:
+        The path to the exported quantized model directory.
+
+    Raises:
+        SystemExit: If quantization failed or produced no usable model.
     """
     # quantization_agent is a top-level package (sibling of inference_optimizer);
     # imported lazily so this module loads even where its deps are absent.
@@ -98,6 +109,14 @@ def run_quantization_prelude(
     DO NOT call from within a running event loop — the cli prelude awaits
     :func:`run_quantization_prelude_async` directly because ``_run_optimize``
     already runs under ``asyncio.run``.
+
+    Args:
+        prompt: User-provided quantization instructions (e.g. scheme text).
+        source_model: Path to the model to quantize.
+        workspace: Working directory; the quantized model is exported under it.
+
+    Returns:
+        The path to the exported quantized model directory.
     """
     return asyncio.run(
         run_quantization_prelude_async(

--- a/inference_optimizer/orchestrator/quantization_schemes.py
+++ b/inference_optimizer/orchestrator/quantization_schemes.py
@@ -49,6 +49,12 @@ def supported_schemes(gpu_type: str | None) -> list[str]:
 
     MI355X gets the full set; every other (DCGPU) target drops the
     ``mxfp4`` / ``mxfp4_fp8`` MI355X-only schemes.
+
+    Args:
+        gpu_type: The target GPU type, or ``None``/empty for non-MI355X.
+
+    Returns:
+        The list of schemes selectable on the given GPU type.
     """
     if (gpu_type or "").strip().lower() == "mi355x":
         return list(SUPPORTED_SCHEMES)
@@ -64,6 +70,15 @@ def validate_scheme(scheme: str | None, gpu_type: str | None) -> None:
     (the real GPU is resolved later via the rocm-smi probe) the hardware
     constraint is not enforced here — the constraint check needs a concrete
     target to act on.
+
+    Args:
+        scheme: The requested quantization scheme, or the ``none`` sentinel.
+        gpu_type: The target GPU type used to enforce hardware constraints.
+
+    Raises:
+        ValueError: If ``scheme`` is not a known supported scheme.
+        SchemeNotSupportedError: If an MI355X-only scheme is requested on a
+            known non-MI355X target.
     """
     if not scheme or scheme == NO_QUANTIZATION:
         return
@@ -106,7 +121,14 @@ class QuantizationConfig:
 
 
 def _join_clauses(items: Sequence[str]) -> str:
-    """Join clauses as ``a``, ``a and b``, or ``a, b and c``."""
+    """Join clauses as ``a``, ``a and b``, or ``a, b and c``.
+
+    Args:
+        items: The clause strings to join.
+
+    Returns:
+        The natural-language conjunction, or ``""`` when ``items`` is empty.
+    """
     items = list(items)
     if not items:
         return ""
@@ -202,6 +224,15 @@ def build_quantization_prompt(
     (no hard-coded defaults). ``model_path`` / ``skill_path`` / ``gpu_type``
     populate the intro line; the inference_optimizer prelude leaves them unset
     because its adapter folds the source model + export dir into the prompt.
+
+    Args:
+        cfg: The structured quantization config to render.
+        model_path: Optional source model path for the intro line.
+        gpu_type: Optional target GPU type for the intro line.
+        skill_path: Optional skill path referenced in the intro line.
+
+    Returns:
+        The composed natural-language quantization prompt.
     """
     paragraphs: list[str] = []
 
@@ -232,6 +263,16 @@ def resolve_scheme_prompt(scheme: str | None) -> str | None:
     Quark's intake + plan skill supplies those. Per-layer overrides and the
     other §4 knobs travel through :func:`build_quantization_prompt` with a fully
     populated :class:`QuantizationConfig` (the structured UI path).
+
+    Args:
+        scheme: The global scheme enum, or the ``none`` sentinel.
+
+    Returns:
+        The rendered ``--quantize`` prompt, or ``None`` when ``scheme`` is
+        falsy or ``"none"``.
+
+    Raises:
+        ValueError: If ``scheme`` is a non-empty unknown scheme.
     """
     if not scheme or scheme == NO_QUANTIZATION:
         return None

--- a/inference_optimizer/orchestrator/research_hints.py
+++ b/inference_optimizer/orchestrator/research_hints.py
@@ -24,7 +24,14 @@ _HINT_FIELDS = ("what", "expected_impact", "accuracy_risk", "source",
 
 
 def _coerce_hint(raw: Any) -> dict[str, Any] | None:
-    """Normalize one incoming hint; return ``None`` when it has no source."""
+    """Normalize one incoming hint; return ``None`` when it has no source.
+
+    Args:
+        raw: A raw incoming hint value.
+
+    Returns:
+        The normalized hint dict, or ``None`` when it lacks a source/claim.
+    """
     if not isinstance(raw, dict):
         return None
     source = str(raw.get("source") or "").strip()
@@ -48,12 +55,26 @@ def _coerce_hint(raw: Any) -> dict[str, Any] | None:
 
 
 def _hint_key(hint: dict[str, Any]) -> str:
-    """Dedup key for append-merge: claim + source (case-insensitive)."""
+    """Dedup key for append-merge: claim + source (case-insensitive).
+
+    Args:
+        hint: A normalized hint dict.
+
+    Returns:
+        The case-insensitive dedup key string.
+    """
     return f"{hint['what'].lower()}::{hint['source'].lower()}"
 
 
 def load_hints(session_dir: Path) -> list[dict[str, Any]]:
-    """Return the structured hints written so far (empty on miss/parse error)."""
+    """Return the structured hints written so far (empty on miss/parse error).
+
+    Args:
+        session_dir: Session directory to read hints from.
+
+    Returns:
+        The list of normalized hint dicts (empty on miss/parse error).
+    """
     path = session_paths.research_hints_json(session_dir)
     try:
         if not path.exists():
@@ -117,7 +138,11 @@ def _atomic_write(path: Path, text: str) -> None:
 
 
 def write_hints_skeleton(session_dir: Path) -> None:
-    """Ensure both hint artifacts exist before the scout returns (PRELUDE invariant; preserves prior hints)."""
+    """Ensure both hint artifacts exist before the scout returns (PRELUDE invariant; preserves prior hints).
+
+    Args:
+        session_dir: Session directory whose hint artifacts are ensured.
+    """
     md_path = session_paths.research_hints_md(session_dir)
     if md_path.exists():
         return
@@ -147,7 +172,15 @@ def _persist(session_dir: Path, hints: list[dict[str, Any]]) -> None:
 def append_hints(
     session_dir: Path, incoming: list[Any],
 ) -> tuple[int, int]:
-    """Append-merge ``incoming`` scout hints; returns ``(added, dropped)`` (dropped = missing-source rejects; duplicates not re-added)."""
+    """Append-merge ``incoming`` scout hints; returns ``(added, dropped)`` (dropped = missing-source rejects; duplicates not re-added).
+
+    Args:
+        session_dir: Session directory to merge hints into.
+        incoming: Raw incoming hint values from the scout.
+
+    Returns:
+        A ``(added, dropped)`` tuple of counts.
+    """
     existing = load_hints(session_dir)
     seen = {_hint_key(h) for h in existing}
     added = 0
@@ -168,7 +201,14 @@ def append_hints(
 
 
 def _coerce_per_conc(raw: Any) -> dict[str, Any] | None:
-    """Drop a per-concurrency target row that lacks a source."""
+    """Drop a per-concurrency target row that lacks a source.
+
+    Args:
+        raw: A raw per-concurrency target row value.
+
+    Returns:
+        The normalized row dict, or ``None`` when it lacks a source.
+    """
     if not isinstance(raw, dict):
         return None
     if not str(raw.get("source") or "").strip():
@@ -183,7 +223,15 @@ def _coerce_per_conc(raw: Any) -> dict[str, Any] | None:
 def write_competitor_target(
     session_dir: Path, target: Any,
 ) -> bool:
-    """Persist ``competitor_target.json`` after dropping sourceless rows; ``True`` when ≥1 sourced row was written."""
+    """Persist ``competitor_target.json`` after dropping sourceless rows; ``True`` when ≥1 sourced row was written.
+
+    Args:
+        session_dir: Session directory to write the target into.
+        target: The competitor target payload.
+
+    Returns:
+        True when at least one sourced row was written, else False.
+    """
     if not isinstance(target, dict):
         return False
     per_conc_in = target.get("per_conc") or []
@@ -212,7 +260,14 @@ def write_competitor_target(
 
 
 def load_competitor_target(session_dir: Path) -> dict[str, Any] | None:
-    """Read ``competitor_target.json`` keeping only sourced per-conc rows; ``None`` when absent/malformed/sourceless. Fail-soft."""
+    """Read ``competitor_target.json`` keeping only sourced per-conc rows; ``None`` when absent/malformed/sourceless. Fail-soft.
+
+    Args:
+        session_dir: Session directory to read the target from.
+
+    Returns:
+        The competitor target dict, or ``None`` when absent/malformed/sourceless.
+    """
     path = session_paths.competitor_target_json(session_dir)
     try:
         if not path.exists():
@@ -242,7 +297,15 @@ def load_competitor_target(session_dir: Path) -> dict[str, Any] | None:
 def _match_target_row(
     target: dict[str, Any], conc: int | None,
 ) -> dict[str, Any] | None:
-    """Pick the per-conc target row nearest ``conc`` (highest-throughput row when conc unknown)."""
+    """Pick the per-conc target row nearest ``conc`` (highest-throughput row when conc unknown).
+
+    Args:
+        target: A competitor target dict carrying ``per_conc`` rows.
+        conc: The concurrency to match, or ``None``.
+
+    Returns:
+        The best-matching per-conc row, or ``None`` when there are no rows.
+    """
     rows = target.get("per_conc") or []
     if not rows:
         return None
@@ -266,7 +329,17 @@ def gap_analysis(
     our_tpot_ms: float | None,
     conc: int | None = None,
 ) -> dict[str, Any] | None:
-    """Compute advisory throughput/latency gaps against a competitor row; ``None`` when no comparable row. ``primary_gap`` is "latency" when TPOT ratio outweighs throughput gap."""
+    """Compute advisory throughput/latency gaps against a competitor row; ``None`` when no comparable row. ``primary_gap`` is "latency" when TPOT ratio outweighs throughput gap.
+
+    Args:
+        target: A competitor target dict, or ``None``.
+        our_tput_per_gpu: Our achieved throughput per GPU, when known.
+        our_tpot_ms: Our achieved TPOT in milliseconds, when known.
+        conc: Concurrency to match the target row against.
+
+    Returns:
+        A gap-analysis dict, or ``None`` when no comparable row exists.
+    """
     if not target:
         return None
     row = _match_target_row(target, conc)
@@ -311,7 +384,15 @@ def full_gap_summary(
     *,
     tpot_ratio_threshold: float = 1.3,
 ) -> str:
-    """Render an advisory "External target gap" block (empty when no gap; advisory only, never gates)."""
+    """Render an advisory "External target gap" block (empty when no gap; advisory only, never gates).
+
+    Args:
+        gap: A gap-analysis dict, or ``None``.
+        tpot_ratio_threshold: TPOT ratio above which latency is called out.
+
+    Returns:
+        The advisory block text, or ``""`` when there is no gap.
+    """
     if not gap:
         return ""
     lines = ["External target gap (advisory) — competitor numbers are "
@@ -391,7 +472,16 @@ def match_variants_to_priors(
     *,
     primary_gap: str | None = None,
 ) -> dict[str, dict[str, Any]]:
-    """Annotate which variants align with proven priors (advisory; informs ordering only). Returns ``{name: {hints, latency_aligned}}`` for variants matching a hint or a dominant latency gap."""
+    """Annotate which variants align with proven priors (advisory; informs ordering only). Returns ``{name: {hints, latency_aligned}}`` for variants matching a hint or a dominant latency gap.
+
+    Args:
+        variants: Candidate variant dicts to annotate.
+        hints: Normalized prior hint dicts.
+        primary_gap: The dominant external gap (e.g. ``"latency"``), when known.
+
+    Returns:
+        Mapping of variant name to its match info dict.
+    """
     out: dict[str, dict[str, Any]] = {}
     latency_dominant = str(primary_gap or "").strip().lower() == "latency"
     hint_tokens: list[tuple[str, set[str]]] = []
@@ -442,7 +532,17 @@ def priors_match_summary(
     primary_gap: str | None = None,
     max_rows: int = 12,
 ) -> str:
-    """Render an advisory block flagging variants that match priors (empty when none; advisory ordering only)."""
+    """Render an advisory block flagging variants that match priors (empty when none; advisory ordering only).
+
+    Args:
+        variants: Candidate variant dicts to check.
+        hints: Normalized prior hint dicts.
+        primary_gap: The dominant external gap, when known.
+        max_rows: Maximum number of variant rows to render.
+
+    Returns:
+        The advisory block text, or ``""`` when no variants match.
+    """
     matches = match_variants_to_priors(
         variants, hints, primary_gap=primary_gap,
     )
@@ -468,7 +568,15 @@ def priors_match_summary(
 def summarise_for_prompt(
     session_dir: Path, *, max_entries: int = 8,
 ) -> str:
-    """Compact advisory block of proven priors for the orchestration prompt (empty when none; advisory only)."""
+    """Compact advisory block of proven priors for the orchestration prompt (empty when none; advisory only).
+
+    Args:
+        session_dir: Session directory to load hints from.
+        max_entries: Maximum number of hint entries to render inline.
+
+    Returns:
+        The advisory prompt block text, or ``""`` when there are no hints.
+    """
     hints = load_hints(session_dir)
     if not hints:
         return ""

--- a/inference_optimizer/orchestrator/resource_lock.py
+++ b/inference_optimizer/orchestrator/resource_lock.py
@@ -59,7 +59,18 @@ def _now_iso() -> str:
 
 
 def _expand_lanes(lanes: list[str]) -> list[str]:
-    """Expand requested lanes by transitive conflicts; sorted deterministically."""
+    """Expand requested lanes by transitive conflicts; sorted deterministically.
+
+    Args:
+        lanes: Requested lane names to expand.
+
+    Returns:
+        The requested lanes plus their conflicting lanes, sorted for
+        deterministic ordering.
+
+    Raises:
+        ValueError: If any requested lane is not a known lane.
+    """
     out: set[str] = set()
     for lane in lanes:
         if lane not in KNOWN_LANES:
@@ -138,6 +149,21 @@ class SqliteLeaseBackend:
 
         Same-holder retries are idempotent; raises :class:`LaneFull` (at cap)
         or :class:`LaneBusy` (different-holder conflict). Inv-7.1: serving lanes default capacity 1.
+
+        Args:
+            lanes: Lanes to acquire; transitive conflicts are co-acquired.
+            holder_id: Identifier of the lease holder.
+            task_id: Identifier of the task acquiring the lanes.
+            action: Action label recorded with the lease.
+            ttl_sec: Lease time-to-live in seconds.
+
+        Returns:
+            The acquired ``Lease`` covering the expanded set of lanes.
+
+        Raises:
+            ValueError: If ``lanes`` is empty.
+            LaneFull: If a lane is at (or disabled by) its capacity cap.
+            LaneBusy: If a capacity-1 lane is held by a different holder.
         """
         if not lanes:
             raise ValueError("acquire_many called with no lanes")
@@ -264,7 +290,16 @@ class SqliteLeaseBackend:
         )
 
     async def heartbeat(self, lease: Lease, *, ttl_sec: int) -> None:
-        """Refresh ``expires_at`` for every lane this holder owns (keyed on ``(lane, holder_id)`` PK)."""
+        """Refresh ``expires_at`` for every lane this holder owns (keyed on ``(lane, holder_id)`` PK).
+
+        Args:
+            lease: The lease whose lanes should be refreshed.
+            ttl_sec: New lifetime in seconds from now.
+
+        Raises:
+            StaleLeaseError: If the number of rows updated does not match the
+                lease's lane count (the lease no longer belongs to us).
+        """
         new_expires_iso = datetime.fromtimestamp(
             time.time() + ttl_sec, tz=timezone.utc
         ).isoformat()
@@ -306,7 +341,11 @@ class SqliteLeaseBackend:
     async def reap_expired(self) -> list[dict]:
         """Sweep expired rows; emits one ``lease_expired`` event per stale
         (lane, holder_id) row. Reaps only TTL-fired holders, leaving live
-        holders on a multi-holder lane untouched."""
+        holders on a multi-holder lane untouched.
+
+        Returns:
+            The reaped lease rows as dicts, one per deleted (lane, holder_id).
+        """
         now_iso_str = _now_iso()
         reaped: list[dict] = []
         async with self.db.transaction() as cur:
@@ -448,6 +487,14 @@ class ResourceLockManager:
 
         Returns the :class:`Lease` on success, ``None`` when any lane is
         busy or full (both LaneBusy and LaneFull map to None; retry next tick).
+
+        Args:
+            lanes: Lanes to acquire.
+            **kwargs: Forwarded to :meth:`acquire_many` (``holder_id`` /
+                ``task_id`` / ``action`` / ``ttl_sec``).
+
+        Returns:
+            The acquired ``Lease``, or ``None`` when any lane is busy or full.
         """
         try:
             return await self.acquire_many(lanes, **kwargs)

--- a/inference_optimizer/orchestrator/roofline_ceiling.py
+++ b/inference_optimizer/orchestrator/roofline_ceiling.py
@@ -98,6 +98,13 @@ def _parse_server_arg(args: str, flag: str) -> str:
     Tolerant of both ``--quantization fp8`` and ``--quantization=fp8``.
     When the flag appears multiple times, the last value wins so an
     optimized overlay can override the baseline args.
+
+    Args:
+        args: The server-args string to scan.
+        flag: The flag whose value to extract (e.g. ``--quantization``).
+
+    Returns:
+        The last value following the flag, or ``""`` when absent.
     """
     if not args:
         return ""
@@ -137,7 +144,14 @@ class RuntimeWorkload:
 
 
 def _read_baseline_yaml_benchmark(state: Any) -> dict[str, Any]:
-    """Read ``benchmark`` from the materialized baseline yaml."""
+    """Read ``benchmark`` from the materialized baseline yaml.
+
+    Args:
+        state: Shared run state carrying ``last_baseline`` provenance.
+
+    Returns:
+        The ``benchmark`` mapping, or ``{}`` when unreadable.
+    """
     last_bl = getattr(state, "last_baseline", None) or {}
     if not isinstance(last_bl, dict):
         return {}
@@ -214,6 +228,12 @@ def _read_baseline_yaml_server_args(state: Any) -> str:
     yaml), so a baseline-only run with ``--quantization fp8`` in the yaml
     would otherwise be invisible to dtype resolution. Returns ``""`` when
     the file / fields are unreadable.
+
+    Args:
+        state: Shared run state carrying ``last_baseline`` provenance.
+
+    Returns:
+        The assembled baseline server args, or ``""`` when unreadable.
     """
     return _server_args_from_envs(
         _benchmark_envs(_read_baseline_yaml_benchmark(state))
@@ -221,7 +241,14 @@ def _read_baseline_yaml_server_args(state: Any) -> str:
 
 
 def _server_args_env_override(entry: Any) -> str:
-    """Return framework server args pinned via ``extra_envs``."""
+    """Return framework server args pinned via ``extra_envs``.
+
+    Args:
+        entry: A state entry that may carry an ``extra_envs`` mapping.
+
+    Returns:
+        The server args assembled from ``extra_envs``, or ``""``.
+    """
     if not isinstance(entry, dict):
         return ""
     envs = entry.get("extra_envs") or {}
@@ -231,7 +258,14 @@ def _server_args_env_override(entry: Any) -> str:
 
 
 def _server_args_payload(entry: Any) -> str:
-    """Return framework-neutral overlay server args from an entry."""
+    """Return framework-neutral overlay server args from an entry.
+
+    Args:
+        entry: A state entry that may carry overlay server-arg keys.
+
+    Returns:
+        The first non-empty overlay server-args string, or ``""``.
+    """
     if not isinstance(entry, dict):
         return ""
     for key in ("candidate_extra_server_args", "extra_server_args", "extra_args"):
@@ -242,7 +276,14 @@ def _server_args_payload(entry: Any) -> str:
 
 
 def _server_args_from(entry: Any) -> str:
-    """Extract the final server-args string from one state entry."""
+    """Extract the final server-args string from one state entry.
+
+    Args:
+        entry: A state entry to read server args from.
+
+    Returns:
+        The env-override args if present, else the overlay payload args.
+    """
     return _server_args_env_override(entry) or _server_args_payload(entry)
 
 
@@ -250,9 +291,16 @@ def _achieved_arm_source(state: Any) -> str:
     """Which arm the roofline ``achieved`` throughput comes from.
 
     Mirrors the snapshot writer (``current_best.tput > 0`` ⇒ optimized,
-    else baseline) so the ceiling's dtype is resolved from the SAME run
+    else baseline) so the ceiling's dtype is resolved     from the SAME run
     its measured throughput came from. Returns ``"current_best"`` or
     ``"baseline"``.
+
+    Args:
+        state: Shared run state carrying ``current_best``.
+
+    Returns:
+        ``"current_best"`` when the optimized arm has positive throughput,
+        otherwise ``"baseline"``.
     """
     cb = getattr(state, "current_best", None)
     if isinstance(cb, dict):
@@ -271,6 +319,14 @@ def _collect_runtime_server_args(state: Any, *, arm: str | None = None) -> str:
     measured throughput comes from the optimized arm. ``arm`` pins the
     source explicitly ("baseline" never overlays current_best), so a
     baseline snapshot's ceiling precision stays anchored to baseline.
+
+    Args:
+        state: Shared run state to read baseline / current_best args from.
+        arm: Pins the source arm; ``None`` infers it via
+            ``_achieved_arm_source``.
+
+    Returns:
+        The server-args string for the selected arm.
     """
     base_args = (
         _read_baseline_yaml_server_args(state)
@@ -288,7 +344,15 @@ def _collect_runtime_server_args(state: Any, *, arm: str | None = None) -> str:
 
 
 def _runtime_gpu_type(state: Any, benchmark: dict[str, Any]) -> str:
-    """Resolve real hardware for roofline; runner_type is only script routing."""
+    """Resolve real hardware for roofline; runner_type is only script routing.
+
+    Args:
+        state: Shared run state carrying ``gpu_type``.
+        benchmark: Benchmark record (fallback ``runner_type``).
+
+    Returns:
+        The resolved GPU type string, or ``""`` when unknown.
+    """
     return str(
         getattr(state, "gpu_type", "")
         or os.environ.get("TARGET_GPU_TYPE", "")
@@ -306,6 +370,13 @@ def resolve_runtime_workload(
     yaml. ``arm`` only pins which arm's server args feed precision
     resolution; ``"baseline"`` keeps the ceiling's dtype anchored to
     baseline even after current_best is promoted.
+
+    Args:
+        state: Shared run state to resolve workload fields from.
+        arm: Pins which arm's server args feed precision resolution.
+
+    Returns:
+        The resolved ``RuntimeWorkload``.
     """
     benchmark = _read_baseline_yaml_benchmark(state)
     envs = _benchmark_envs(benchmark)
@@ -385,6 +456,14 @@ def resolve_runtime_dtype(
     float32 checkpoints to fp16, never keep 4B at runtime, and never go
     sub-bf16 without an explicit quantization signal. Activation dtype
     follows ``--dtype`` when present, else bf16, also floored at 2B.
+
+    Args:
+        state: Shared run state to read the runtime server args from.
+        meta: Model metadata (its on-disk weight dtype is a fallback signal).
+        arm: Pins which arm's server args feed precision resolution.
+
+    Returns:
+        The resolved ``RuntimeDtype`` provenance.
     """
     runtime = resolve_runtime_workload(state, arm=arm)
     args = runtime.server_args
@@ -439,7 +518,14 @@ def resolve_runtime_dtype(
 
 
 def _compute_tag_for_bytes(weight_bytes: float) -> str:
-    """Map weight bytes-per-element to a HW_SPECS compute precision key."""
+    """Map weight bytes-per-element to a HW_SPECS compute precision key.
+
+    Args:
+        weight_bytes: Weight bytes-per-element.
+
+    Returns:
+        The matching precision key (``fp4`` / ``fp8`` / ``bf16`` / ``fp32``).
+    """
     if weight_bytes <= 0.5:
         return "fp4"
     if weight_bytes <= 1.0:
@@ -457,6 +543,14 @@ def apply_runtime_dtype(meta: "ModelMeta", rt: RuntimeDtype) -> "ModelMeta":
     per-token weight IO must scale by ``runtime_bpe / checkpoint_bpe``.
     No-op (scale == 1.0) when the checkpoint already matches runtime
     (pre-quantized MoE fp8), so it is safe to call unconditionally.
+
+    Args:
+        meta: Model metadata whose weight byte fields are rescaled.
+        rt: Resolved runtime dtype carrying the runtime weight bytes.
+
+    Returns:
+        A new ``ModelMeta`` rescaled to the runtime weight dtype (or ``meta``
+        unchanged for non-dataclass test doubles).
     """
     import dataclasses as _dc
 
@@ -478,7 +572,15 @@ def apply_runtime_dtype(meta: "ModelMeta", rt: RuntimeDtype) -> "ModelMeta":
 
 
 def _resolve_peak_tflops(gpu_type: str | None, precision_tag: str | None) -> float:
-    """``(gpu, precision)`` → vendor dense peak TFLOPS; 0.0 on miss (safe-degrade signal → T_cmp unavailable, fall back to T_mem)."""
+    """``(gpu, precision)`` → vendor dense peak TFLOPS; 0.0 on miss (safe-degrade signal → T_cmp unavailable, fall back to T_mem).
+
+    Args:
+        gpu_type: GPU type key (matched case-insensitively).
+        precision_tag: Precision key to look up.
+
+    Returns:
+        The vendor dense peak TFLOPS, or ``0.0`` on miss.
+    """
     spec = HW_SPECS.get((gpu_type or "").strip().lower())
     if spec is None:
         return 0.0
@@ -514,7 +616,14 @@ class ModelMeta:
 
 
 def _read_total_size(model_path: Path) -> int | None:
-    """Read ``metadata.total_size`` (bytes) from the safetensors index (byte-exact)."""
+    """Read ``metadata.total_size`` (bytes) from the safetensors index (byte-exact).
+
+    Args:
+        model_path: Local HF model directory.
+
+    Returns:
+        The total weight size in bytes, or ``None`` when unavailable.
+    """
     idx = model_path / "model.safetensors.index.json"
     if idx.is_file():
         try:
@@ -531,7 +640,15 @@ def _read_total_size(model_path: Path) -> int | None:
 
 
 def _sum_weight_file_sizes(model_path: Path, pattern: str) -> int | None:
-    """Fallback weight size from local weight shards matching ``pattern``."""
+    """Fallback weight size from local weight shards matching ``pattern``.
+
+    Args:
+        model_path: Local HF model directory.
+        pattern: Glob pattern for weight shards (e.g. ``*.safetensors``).
+
+    Returns:
+        The summed shard size in bytes, or ``None`` when zero/unreadable.
+    """
     try:
         total = sum(
             p.stat().st_size
@@ -563,7 +680,14 @@ def _read_hf_config(model_path: Path) -> dict[str, Any] | None:
 
 
 def _derive_kv_heads(cfg: dict[str, Any]) -> int:
-    """GQA-aware: ``num_key_value_heads`` if present, else ``num_attention_heads``."""
+    """GQA-aware: ``num_key_value_heads`` if present, else ``num_attention_heads``.
+
+    Args:
+        cfg: Parsed HF ``config.json``.
+
+    Returns:
+        The number of KV heads, or ``0`` when neither field is present.
+    """
     kv = cfg.get("num_key_value_heads")
     if kv is None:
         kv = cfg.get("num_attention_heads")
@@ -571,7 +695,14 @@ def _derive_kv_heads(cfg: dict[str, Any]) -> int:
 
 
 def _derive_head_dim(cfg: dict[str, Any]) -> int:
-    """``head_dim`` directly, or ``hidden_size / num_attention_heads``."""
+    """``head_dim`` directly, or ``hidden_size / num_attention_heads``.
+
+    Args:
+        cfg: Parsed HF ``config.json``.
+
+    Returns:
+        The per-head dimension, or ``0`` when it cannot be derived.
+    """
     head_dim = cfg.get("head_dim")
     if head_dim:
         return int(head_dim)
@@ -588,7 +719,16 @@ def _compute_active_weight_bytes(
     weight_bytes: int,
     dtype_bytes: float,
 ) -> int:
-    """MoE-aware estimate of weight bytes fetched per token (geometry-based, avoids the ~10× over-count from the safetensors total; safe-degrades to ``weight_bytes``)."""
+    """MoE-aware estimate of weight bytes fetched per token (geometry-based, avoids the ~10× over-count from the safetensors total; safe-degrades to ``weight_bytes``).
+
+    Args:
+        cfg: Parsed HF ``config.json``.
+        weight_bytes: Total weight bytes (the safe-degrade fallback).
+        dtype_bytes: Weight bytes-per-element.
+
+    Returns:
+        The estimated per-token active weight bytes.
+    """
     active, _total_expert, _ne, _ept = _compute_expert_decomposition(
         cfg, weight_bytes=weight_bytes, dtype_bytes=dtype_bytes,
     )
@@ -601,7 +741,17 @@ def _compute_expert_decomposition(
     weight_bytes: int,
     dtype_bytes: float,
 ) -> tuple[int, int, int, int]:
-    """MoE decomposition for the batch-aware roofline; returns ``(active_weight_bytes, total_expert_bytes, num_experts, experts_per_tok)``. Safe-degrades to ``(weight_bytes, 0, 0, 0)``. Handles num_experts / n_routed_experts / num_local_experts aliases."""
+    """MoE decomposition for the batch-aware roofline; returns ``(active_weight_bytes, total_expert_bytes, num_experts, experts_per_tok)``. Safe-degrades to ``(weight_bytes, 0, 0, 0)``. Handles num_experts / n_routed_experts / num_local_experts aliases.
+
+    Args:
+        cfg: Parsed HF ``config.json``.
+        weight_bytes: Total weight bytes (the safe-degrade fallback).
+        dtype_bytes: Weight bytes-per-element.
+
+    Returns:
+        A tuple of ``(active_weight_bytes, total_expert_bytes, num_experts,
+        experts_per_tok)``, degrading to ``(weight_bytes, 0, 0, 0)``.
+    """
     num_experts = int(
         cfg.get("num_experts")
         or cfg.get("n_routed_experts")  # DeepSeek V3 alias
@@ -643,7 +793,16 @@ def load_model_meta(
     *,
     precision_hint: str = "",
 ) -> ModelMeta | None:
-    """Read ``weight_bytes`` + KV-cache shape from a local HF model dir (``None`` when unreadable). Weight-dtype priority: quantization_config.quant_method > torch_dtype > dtype > precision_hint."""
+    """Read ``weight_bytes`` + KV-cache shape from a local HF model dir (``None`` when unreadable). Weight-dtype priority: quantization_config.quant_method > torch_dtype > dtype > precision_hint.
+
+    Args:
+        model_path: Local HF model directory.
+        precision_hint: Fallback precision tag when config lacks a dtype.
+
+    Returns:
+        The populated ``ModelMeta``, or ``None`` when the dir/config/weights
+        are unreadable.
+    """
     if not model_path:
         return None
     p = Path(model_path).expanduser()
@@ -700,7 +859,17 @@ def compute_kv_bytes_per_token(
     head_dim: int,
     kv_dtype_bytes: float,
 ) -> int:
-    """KV cache footprint per generated token, summed over all layers (the ``2`` covers K + V)."""
+    """KV cache footprint per generated token, summed over all layers (the ``2`` covers K + V).
+
+    Args:
+        num_layers: Number of transformer layers.
+        num_kv_heads: Number of KV heads.
+        head_dim: Per-head dimension.
+        kv_dtype_bytes: Bytes per KV element.
+
+    Returns:
+        The KV-cache bytes per generated token.
+    """
     return int(2 * num_layers * num_kv_heads * head_dim * kv_dtype_bytes)
 
 
@@ -721,7 +890,28 @@ def compute_theoretical_peak_output_tok_per_sec(
     experts_per_tok: int = 0,
     expert_weight_bytes: int = 0,
 ) -> float:
-    """Decode-only memory-bound ceiling for ``output_throughput`` (returns 0.0, never raises, on unknown gpu_type / degenerate divisor). ``active_weight_bytes`` shrinks per-token IO for MoE."""
+    """Decode-only memory-bound ceiling for ``output_throughput`` (returns 0.0, never raises, on unknown gpu_type / degenerate divisor). ``active_weight_bytes`` shrinks per-token IO for MoE.
+
+    Args:
+        gpu_type: GPU type key for the HBM bandwidth lookup.
+        num_gpus: Number of GPUs (tensor-parallel degree).
+        weight_bytes: Total weight bytes.
+        num_layers: Number of transformer layers.
+        num_kv_heads: Number of KV heads.
+        head_dim: Per-head dimension.
+        kv_dtype_bytes: Bytes per KV element.
+        isl: Input sequence length.
+        osl: Output sequence length.
+        concurrency: Decode batch size (floored at 1).
+        active_weight_bytes: Per-token active weight bytes for MoE (0 = dense).
+        num_experts: Total experts (0 = dense).
+        experts_per_tok: Experts activated per token.
+        expert_weight_bytes: Total expert weight bytes.
+
+    Returns:
+        The memory-bound decode throughput ceiling, or ``0.0`` on unknown
+        GPU type or a degenerate divisor.
+    """
     spec = HW_SPECS.get((gpu_type or "").strip().lower())
     if spec is None:
         return 0.0
@@ -776,6 +966,18 @@ def compute_compute_bound_ceiling_tok_per_sec(
         T_cmp = (F_peak * G * dtype_bytes) / (2 * active_weight_bytes_B1)
 
     Divisor uses ``active_weight_bytes`` at B=1 (NOT batch-saturated). Returns 0.0 on missing input (degrade to T_mem).
+
+    Args:
+        gpu_type: GPU type key for the peak TFLOPS lookup.
+        num_gpus: Number of GPUs (tensor-parallel degree).
+        precision_tag: Precision key for the peak TFLOPS lookup.
+        active_weight_bytes: Per-token active weight bytes at B=1.
+        weight_bytes: Total weight bytes (fallback when active is missing).
+        weight_dtype_bytes: Weight bytes-per-element.
+
+    Returns:
+        The compute-bound decode throughput ceiling, or ``0.0`` on missing
+        input.
     """
     peak_tflops = _resolve_peak_tflops(gpu_type, precision_tag)
     if peak_tflops <= 0 or weight_dtype_bytes <= 0:
@@ -796,7 +998,14 @@ def compute_compute_bound_ceiling_tok_per_sec(
 
 
 def _read_baseline_yaml_conc(state: Any) -> int:
-    """Read ``benchmark.envs.CONC`` from the materialized baseline yaml (ground-truth concurrency; ``0`` when unreadable)."""
+    """Read ``benchmark.envs.CONC`` from the materialized baseline yaml (ground-truth concurrency; ``0`` when unreadable).
+
+    Args:
+        state: Shared run state carrying ``last_baseline`` provenance.
+
+    Returns:
+        The baseline concurrency, or ``0`` when unreadable.
+    """
     return _env_int(
         _benchmark_envs(_read_baseline_yaml_benchmark(state)),
         "CONC",
@@ -804,7 +1013,14 @@ def _read_baseline_yaml_conc(state: Any) -> int:
 
 
 def _resolve_effective_concurrency(state: Any) -> int:
-    """Resolve the concurrency the actual benchmark ran with (returns int >= 1; on-disk baseline yaml CONC wins, since ``state.conc`` can stay stale and under-count the ceiling 8x)."""
+    """Resolve the concurrency the actual benchmark ran with (returns int >= 1; on-disk baseline yaml CONC wins, since ``state.conc`` can stay stale and under-count the ceiling 8x).
+
+    Args:
+        state: Shared run state (baseline yaml CONC preferred over ``conc``).
+
+    Returns:
+        The effective concurrency, always ``>= 1``.
+    """
     yaml_conc = _read_baseline_yaml_conc(state)
     if yaml_conc > 0:
         return yaml_conc
@@ -841,7 +1057,16 @@ def _activation_kv_dtype_bytes(meta: ModelMeta) -> float:
 def compute_roofline_breakdown_from_state(
     state: Any, *, arm: str | None = None,
 ) -> RooflineBreakdown:
-    """Primary decode ceiling + T_mem/T_cmp side projections. Prefers the bottom-up PerfModel (``compute_roofline_from_perfmodel``) when model config is complete, else the legacy top-down aggregate. Never raises; returns ``_EMPTY_BREAKDOWN`` on missing fields. ``arm`` pins precision to a specific arm ("baseline" anchors the ceiling dtype to baseline)."""
+    """Primary decode ceiling + T_mem/T_cmp side projections. Prefers the bottom-up PerfModel (``compute_roofline_from_perfmodel``) when model config is complete, else the legacy top-down aggregate. Never raises; returns ``_EMPTY_BREAKDOWN`` on missing fields. ``arm`` pins precision to a specific arm ("baseline" anchors the ceiling dtype to baseline).
+
+    Args:
+        state: Shared run state to resolve the workload and dtype from.
+        arm: Pins precision to a specific arm; ``None`` infers it.
+
+    Returns:
+        The decode ``RooflineBreakdown`` (``_EMPTY_BREAKDOWN`` on missing
+        fields).
+    """
     runtime = resolve_runtime_workload(state, arm=arm)
     meta = load_model_meta(
         runtime.model_path,
@@ -922,7 +1147,15 @@ def compute_roofline_breakdown_from_state(
 
 
 def compute_peak_from_state(state: Any, *, arm: str | None = None) -> float:
-    """Convenience scalar wrapper for ``T_peak`` only (kept for backward compat; prefer ``compute_roofline_breakdown_from_state``). ``arm`` pins precision to a specific arm."""
+    """Convenience scalar wrapper for ``T_peak`` only (kept for backward compat; prefer ``compute_roofline_breakdown_from_state``). ``arm`` pins precision to a specific arm.
+
+    Args:
+        state: Shared run state to compute the ceiling from.
+        arm: Pins precision to a specific arm; ``None`` infers it.
+
+    Returns:
+        The peak decode throughput (``peak_tok_per_sec``).
+    """
     return compute_roofline_breakdown_from_state(state, arm=arm).peak_tok_per_sec
 
 
@@ -932,6 +1165,12 @@ def read_baseline_server_args(state: Any) -> str:
     Stable entry point for callers (e.g. Coordinator profile injection) that
     must read baseline's own flags without depending on the private
     ``_read_baseline_yaml_server_args`` helper.
+
+    Args:
+        state: Shared run state carrying ``last_baseline`` provenance.
+
+    Returns:
+        The baseline arm's runtime server args, or ``""`` when unreadable.
     """
     return _read_baseline_yaml_server_args(state)
 
@@ -983,7 +1222,15 @@ HW_SPECS_ACHIEVABLE: dict[str, dict[str, Any]] = {
 
 
 def _resolve_achievable_tflops(gpu_type: str | None, precision_tag: str | None) -> float:
-    """Max-achievable TFLOPS from ``HW_SPECS_ACHIEVABLE``; 0.0 on miss."""
+    """Max-achievable TFLOPS from ``HW_SPECS_ACHIEVABLE``; 0.0 on miss.
+
+    Args:
+        gpu_type: GPU type key (matched case-insensitively).
+        precision_tag: Precision key to look up.
+
+    Returns:
+        The max-achievable TFLOPS, or ``0.0`` on miss.
+    """
     spec = HW_SPECS_ACHIEVABLE.get((gpu_type or "").strip().lower())
     if spec is None:
         return 0.0
@@ -1004,6 +1251,15 @@ def _fused_moe_flops(M: int, K: int, N: int, topk: int) -> float:
       gate+up : 2 * M * K * N * topk * 2
       down    : 2 * M * K * N * topk
       aggregation: M * K * (2 * topk - 1)
+
+    Args:
+        M: Number of tokens (batch * seq).
+        K: Hidden size.
+        N: Per-expert FFN intermediate size.
+        topk: Experts activated per token.
+
+    Returns:
+        Total FLOPs for the gated SwiGLU MoE forward.
     """
     return 2.0 * M * K * N * topk * 2 + 2.0 * M * K * N * topk + M * K * (2 * topk - 1)
 
@@ -1024,6 +1280,18 @@ def _fused_moe_bytes(
     act_bpe defaults to weight_bpe when not provided. For FP8/FP4-weight
     models pass act_bpe=2.0 (bf16 activations) to match TraceLens semantics
     where input_bpe != weight_bpe.
+
+    Args:
+        M: Number of tokens (batch * seq).
+        K: Hidden size.
+        N: Per-expert FFN intermediate size.
+        num_experts: Total experts.
+        topk: Experts activated per token.
+        weight_bpe: Weight bytes-per-element.
+        act_bpe: Activation bytes-per-element; defaults to ``weight_bpe``.
+
+    Returns:
+        Total HBM bytes for the gated SwiGLU MoE forward.
     """
     if act_bpe is None:
         act_bpe = weight_bpe
@@ -1077,6 +1345,14 @@ def _gemm_flops(M: int, N: int, K: int) -> float:
     Mirrors TraceLens.PerfModel.perf_model.GEMM.flops_func (no bias path
     needed here since LLM linear layers are weight-only without bias in
     the roofline model).
+
+    Args:
+        M: Rows of the output (tokens).
+        N: Output features.
+        K: Inner/contraction dimension.
+
+    Returns:
+        Total FLOPs for the matrix multiply.
     """
     return 2.0 * M * N * K
 
@@ -1090,6 +1366,16 @@ def _gemm_bytes(
     (input activation), bpe_mat2=weight_bpe (weight), bpe_output=act_bpe (output).
     act_bpe defaults to weight_bpe; for FP8/FP4-weight models pass act_bpe=2.0
     (bf16 activations) to correctly separate activation from weight bytes.
+
+    Args:
+        M: Rows of the output (tokens).
+        N: Output features.
+        K: Inner/contraction dimension.
+        weight_bpe: Weight bytes-per-element.
+        act_bpe: Activation bytes-per-element; defaults to ``weight_bpe``.
+
+    Returns:
+        Total HBM bytes for the matrix multiply.
     """
     a = act_bpe if act_bpe is not None else weight_bpe
     return M * K * a + K * N * weight_bpe + M * N * a
@@ -1106,6 +1392,19 @@ def _sdpa_flops(
       PV    : B * H_Q * 2 * N_Q * d_h_v * N_KV
     Softmax FLOPs omitted (dominated by matmuls).
     Causal masking halves the work when N_Q == N_KV (prefill only).
+
+    Args:
+        B: Batch size.
+        N_Q: Query sequence length.
+        H_Q: Number of query heads.
+        N_KV: Key/value sequence length.
+        H_KV: Number of KV heads.
+        d_h_qk: Per-head dimension for Q/K.
+        d_h_v: Per-head dimension for V.
+        causal: Whether causal masking applies.
+
+    Returns:
+        Total FLOPs for scaled dot-product attention.
     """
     flops_qk = B * H_Q * (2.0 * N_Q * N_KV * d_h_qk)
     flops_pv = B * H_Q * (2.0 * N_Q * d_h_v * N_KV)
@@ -1124,6 +1423,20 @@ def _sdpa_bytes(
     Mirrors TraceLens.PerfModel.perf_model.SDPA.bytes_func.
     causal is accepted for API symmetry but does not change the I/O volume
     (KV is always fully read even under causal masking at the HBM level).
+
+    Args:
+        B: Batch size.
+        N_Q: Query sequence length.
+        H_Q: Number of query heads.
+        N_KV: Key/value sequence length.
+        H_KV: Number of KV heads.
+        d_h_qk: Per-head dimension for Q/K.
+        d_h_v: Per-head dimension for V.
+        causal: Accepted for API symmetry; does not change I/O volume.
+        bpe: Bytes per element for the tensors.
+
+    Returns:
+        Total HBM bytes for scaled dot-product attention.
     """
     elems = (
         B * N_Q * H_Q * d_h_qk    # Q read
@@ -1160,6 +1473,19 @@ def compute_roofline_from_perfmodel(
     The GEMM / SDPA formulas are inlined here (no TraceLens import) and
     maintained independently.  They match TraceLens PerfModel exactly
     (verified by the PoC in roofline_perfmodel_poc.py: deviation < 1.6%).
+
+    Args:
+        meta: Model metadata; complete config required (else ``None``).
+        gpu_type: GPU type key for the achievable-spec lookup.
+        concurrency: Decode batch size.
+        isl: Input sequence length.
+        osl: Output sequence length.
+        num_gpus: Number of GPUs (tensor-parallel degree).
+        precision_tag: Precision key for the achievable TFLOPS lookup.
+
+    Returns:
+        The per-op ``PerfModelBreakdown``, or ``None`` when model metadata is
+        incomplete or the GPU is unsupported.
     """
     if meta is None:
         return None
@@ -1354,6 +1680,14 @@ def compute_roofline_breakdown_from_state_v2(
     the GPU or model config is unsupported).  Its ``decode_tok_per_s`` equals
     ``breakdown.peak_tok_per_sec`` for supported configs. ``arm`` pins precision
     to a specific arm ("baseline" anchors the ceiling dtype to baseline).
+
+    Args:
+        state: Shared run state to compute the breakdowns from.
+        arm: Pins precision to a specific arm; ``None`` infers it.
+
+    Returns:
+        A tuple of ``(RooflineBreakdown, PerfModelBreakdown | None)``; the
+        second element is ``None`` when the GPU/model config is unsupported.
     """
     legacy = compute_roofline_breakdown_from_state(state, arm=arm)
     runtime = resolve_runtime_workload(state, arm=arm)

--- a/inference_optimizer/orchestrator/roofline_snapshot.py
+++ b/inference_optimizer/orchestrator/roofline_snapshot.py
@@ -129,7 +129,14 @@ SATURATION_ADVISORY_THRESHOLD_PCT: float = 80.0
 
 
 def derive_saturation_per_direction(analysis_md_text: str) -> dict[str, float]:
-    """Return ``{direction: saturation_pct}`` for the four canonical directions (F3-4 Roofline-v2; missing/unparseable degrades to ``0.0``)."""
+    """Return ``{direction: saturation_pct}`` for the four canonical directions (F3-4 Roofline-v2; missing/unparseable degrades to ``0.0``).
+
+    Args:
+        analysis_md_text: The TraceLens ``analysis.md`` text to parse.
+
+    Returns:
+        A mapping of each canonical direction to its saturation percent.
+    """
     out: dict[str, float] = {k: 0.0 for k in _SATURATION_LABEL_MAP}
     if not analysis_md_text:
         return out
@@ -222,7 +229,16 @@ def _compute_within_and_gap(
     peak: float,
     achieved: float,
 ) -> tuple[float | None, float | None]:
-    """Return ``(within_roofline_pct, gap_to_roofline_pct)``; both ``None`` when either input is non-positive."""
+    """Return ``(within_roofline_pct, gap_to_roofline_pct)``; both ``None`` when either input is non-positive.
+
+    Args:
+        peak: The theoretical peak throughput.
+        achieved: The achieved throughput.
+
+    Returns:
+        A tuple of ``(within_roofline_pct, gap_to_roofline_pct)``, both
+        ``None`` when either input is non-positive.
+    """
     if peak <= 0 or achieved <= 0:
         return None, None
     within = round(achieved / peak * 100.0, 2)
@@ -243,6 +259,20 @@ def build_roofline_snapshot(
     """Materialise one side (baseline or latest) of the comparison.
 
     ``theoretical_peak_tok_per_sec`` is the primary decode roofline ceiling (from ``roofline_ceiling.compute_roofline_breakdown_from_state``); mem/cmp sides + ``roofline_bound_kind`` persist which side dominated, and ``achieved_tok_per_sec`` is the snapshot-time ``output_throughput``. All default to 0/"unknown" so legacy callers yield ``None`` in derived pct fields.
+
+    Args:
+        snapshot_id: Monotonic snapshot id, or ``None`` for offline callers.
+        ts: ISO timestamp for the snapshot.
+        analysis_md_path: Path to the TraceLens ``analysis.md`` (empty skips
+            workload/kernel enrichment).
+        theoretical_peak_tok_per_sec: Primary decode roofline ceiling.
+        achieved_tok_per_sec: Snapshot-time achieved output throughput.
+        mem_ceiling_tok_per_sec: Memory-bound ceiling side.
+        cmp_ceiling_tok_per_sec: Compute-bound ceiling side.
+        bound_kind: Which side dominated (e.g. ``memory`` / ``compute``).
+
+    Returns:
+        The snapshot dict for one side of the comparison.
     """
     within, gap = _compute_within_and_gap(
         peak=theoretical_peak_tok_per_sec,
@@ -338,6 +368,12 @@ def build_roofline_comparison_from_history(
 
     Append-only: ``snapshots[0]`` is baseline, ``snapshots[-1]`` the latest refresh.
     Same snapshot_id → single_snapshot mode; distinct ids → before_after with ``delta``. ``None`` when history empty.
+
+    Args:
+        snapshots: The append-only snapshot history, or ``None``.
+
+    Returns:
+        The ``roofline_comparison`` block, or ``None`` when history is empty.
     """
     snapshots = list(snapshots or [])
     if not snapshots:
@@ -496,7 +532,14 @@ def _fmt_pct_cell(v: float | None) -> str:
 
 
 def format_roofline_metrics_table(cmp: dict[str, Any]) -> list[str]:
-    """Render the compact Base / Opt / Δ markdown table (session-constant ceiling rendered once above the Base/Opt columns)."""
+    """Render the compact Base / Opt / Δ markdown table (session-constant ceiling rendered once above the Base/Opt columns).
+
+    Args:
+        cmp: The ``roofline_comparison`` block to render.
+
+    Returns:
+        The markdown table as a list of lines.
+    """
 
     def cell(v: float | None) -> str:
         """Format a percentage value for a table cell.

--- a/inference_optimizer/orchestrator/shared_state.py
+++ b/inference_optimizer/orchestrator/shared_state.py
@@ -72,7 +72,15 @@ _MODEL_ARCH_STRUCTURED_FIELDS: tuple[tuple[str, str], ...] = (
 
 
 def render_model_arch_compact(arch: dict | None) -> str:
-    """Render the advisory ``model_arch`` profile as a single compact line (``""`` when empty/not a dict)."""
+    """Render the advisory ``model_arch`` profile as a single compact line (``""`` when empty/not a dict).
+
+    Args:
+        arch: The ``model_arch`` profile dict, or ``None``.
+
+    Returns:
+        A single ``key=value; ...`` line summarizing the architecture, or an
+        empty string when ``arch`` is empty or not a dict.
+    """
     if not isinstance(arch, dict) or not arch:
         return ""
     parts: list[str] = []
@@ -148,7 +156,15 @@ _PHASE4_LEGACY_KEY_RENAMES: dict[str, str] = {
 
 
 def _migrate_legacy_extra_sglang_args_keys(obj: Any) -> int:
-    """Recursively rewrite legacy ``extra_sglang_args`` field names in-place; returns count rewritten (canonical kept when both present)."""
+    """Recursively rewrite legacy ``extra_sglang_args`` field names in-place; returns count rewritten (canonical kept when both present).
+
+    Args:
+        obj: An arbitrary JSON-like structure (dict/list/scalar) mutated in
+            place.
+
+    Returns:
+        The number of legacy keys rewritten or removed across the structure.
+    """
     migrated = 0
     if isinstance(obj, dict):
         for legacy_key, canonical_key in _PHASE4_LEGACY_KEY_RENAMES.items():
@@ -703,7 +719,19 @@ class SharedState:
         params_winner_history: Any,
         synergy_attempted: Any,
     ) -> dict[str, Any]:
-        """Shape the unified ``explore_search`` ledger at load time; folds live history so resume preserves cross-round aggregation."""
+        """Shape the unified ``explore_search`` ledger at load time; folds live history so resume preserves cross-round aggregation.
+
+        Args:
+            existing: The existing ``explore_search`` dict, or any non-dict
+                (treated as empty).
+            backend_winners_history: Live backend winners history to fold in.
+            params_winner_history: Live params winner history to fold in.
+            synergy_attempted: Synergy-attempted markers to fold in.
+
+        Returns:
+            The shaped ``explore_search`` ledger dict with defaults and folded
+            winners history.
+        """
         from .action_executors._grid_runner import variant_fingerprint as _fp
 
         existing = existing if isinstance(existing, dict) else {}
@@ -932,7 +960,19 @@ class SharedState:
         *,
         strict: bool | None = None,
     ) -> str:
-        """Validated writer for :attr:`stop_reason` (Inv-8.3 closed vocab): values outside ``STOP_REASON_VOCAB`` map to ``"unknown"`` (lenient) or raise (``strict=True``, default env ``INFERENCE_OPTIMIZER_STRICT_STOP_REASON``). Returns value written."""
+        """Validated writer for :attr:`stop_reason` (Inv-8.3 closed vocab): values outside ``STOP_REASON_VOCAB`` map to ``"unknown"`` (lenient) or raise (``strict=True``, default env ``INFERENCE_OPTIMIZER_STRICT_STOP_REASON``). Returns value written.
+
+        Args:
+            value: Candidate stop-reason string.
+            strict: When ``True`` raise on an unknown value; ``None`` reads the
+                ``INFERENCE_OPTIMIZER_STRICT_STOP_REASON`` env flag.
+
+        Returns:
+            The value actually written (the input, ``""``, or ``"unknown"``).
+
+        Raises:
+            ValueError: If the value is unknown and strict mode is active.
+        """
         from .phase_state import STOP_REASON_VOCAB, is_valid_stop_reason
         text = str(value or "").strip()
         if not text:
@@ -964,7 +1004,14 @@ class SharedState:
 
     # escalate hint plumbing
     def set_pending_escalate_hint(self, hint: str) -> str:
-        """Stash the LLM-supplied hint for the next phase compute pass; unknown hints dropped (Inv-8.2: closed vocab). Returns value written."""
+        """Stash the LLM-supplied hint for the next phase compute pass; unknown hints dropped (Inv-8.2: closed vocab). Returns value written.
+
+        Args:
+            hint: Candidate escalate hint.
+
+        Returns:
+            The hint actually stored, or ``""`` when it was unknown and dropped.
+        """
         from .phase_state import is_valid_escalate_hint
         text = str(hint or "").strip()
         if text and not is_valid_escalate_hint(text):
@@ -973,7 +1020,11 @@ class SharedState:
         return text
 
     def consume_pending_escalate_hint(self) -> str:
-        """Pop the pending hint (recording consumption in audit fields) so the next tick doesn't re-trigger; returns cleared hint."""
+        """Pop the pending hint (recording consumption in audit fields) so the next tick doesn't re-trigger; returns cleared hint.
+
+        Returns:
+            The consumed hint, or ``""`` when none was pending.
+        """
         hint = (self.pending_escalate_hint or "").strip()
         if not hint:
             return ""
@@ -992,7 +1043,18 @@ class SharedState:
         ts: str | None = None,
         ts_unix: float | None = None,
     ) -> dict[str, Any]:
-        """Append a phase_history row and atomically update ``phase`` fields; ``phase``/``phase_history`` are CORE_STATE_FIELDS so LLM update_state is rejected. Returns the inserted row."""
+        """Append a phase_history row and atomically update ``phase`` fields; ``phase``/``phase_history`` are CORE_STATE_FIELDS so LLM update_state is rejected. Returns the inserted row.
+
+        Args:
+            to_phase: Phase being entered.
+            reason: Transition reason recorded in the row.
+            evidence: Optional evidence dict recorded with the row.
+            ts: Optional ISO timestamp; defaults to now.
+            ts_unix: Optional Unix timestamp; defaults to now.
+
+        Returns:
+            The inserted phase-history row.
+        """
         from datetime import datetime as _dt, timezone as _tz
         import time as _time
         # Lazy import to avoid an import-time cycle.
@@ -1046,6 +1108,19 @@ class SharedState:
         Coordinator-only writer (``policy.CORE_STATE_FIELDS`` guards
         ``lifecycle`` so an LLM ``update_state`` cannot forge events).
         Returns the inserted row.
+
+        Args:
+            step: Machine step / handler name.
+            status: Lifecycle status (START/END/ERROR/ENTER).
+            phase: Phase the event belongs to; defaults to the current phase.
+            label: Human-friendly label; defaults to the step's mapped label.
+            artifacts: Optional map of artifact name to path.
+            detail: Free-form detail string.
+            duration_s: Optional duration in seconds.
+            ts: Optional ISO timestamp; defaults to now.
+
+        Returns:
+            The inserted lifecycle event row.
         """
         # Lazy import to avoid an import-time cycle with the orchestrator
         # package (phase_state imports nothing from SharedState).
@@ -1121,7 +1196,19 @@ class SharedState:
         traceback_text: str,
         agent: str = "",
     ) -> dict[str, Any]:
-        """Persist a compact Coordinator exception summary for postmortems."""
+        """Persist a compact Coordinator exception summary for postmortems.
+
+        Args:
+            tick: Coordinator tick the exception fired on.
+            stage: Pipeline stage where the exception occurred.
+            exc_type: Exception class name.
+            message: Exception message (truncated).
+            traceback_text: Formatted traceback (truncated).
+            agent: Optional agent name associated with the exception.
+
+        Returns:
+            The recorded exception summary entry.
+        """
         entry = {
             "tick": int(tick or 0),
             "ts": _now_iso(),
@@ -1135,7 +1222,15 @@ class SharedState:
         return entry
 
     def apply_changes(self, changes: dict[str, Any], *, allow_core: bool) -> dict[str, Any]:
-        """Merge a non-empty changes dict into this state; does NOT re-validate the role/source allowlist (PolicyGate filters upstream). Returns fields actually written."""
+        """Merge a non-empty changes dict into this state; does NOT re-validate the role/source allowlist (PolicyGate filters upstream). Returns fields actually written.
+
+        Args:
+            changes: Field-name to value map to merge into the state.
+            allow_core: Whether core fields may be written (enforced upstream).
+
+        Returns:
+            The subset of changes actually applied (unknown fields skipped).
+        """
         if not changes:
             return {}
         applied: dict[str, Any] = {}
@@ -1371,7 +1466,12 @@ class SharedState:
         return entry
 
     def record_kernel_opt(self, result: dict[str, Any]) -> None:
-        """Capture kernel_optimization_handler result for the next Orch turn; empty kernel_id no-op, non-KEEP can't overwrite a pending KEEP, retires kernel_id (r24 guard) after >= max_partial PARTIALs (INFERENCE_OPTIMIZER_KERNEL_OPT_MAX_PARTIAL)."""
+        """Capture kernel_optimization_handler result for the next Orch turn; empty kernel_id no-op, non-KEEP can't overwrite a pending KEEP, retires kernel_id (r24 guard) after >= max_partial PARTIALs (INFERENCE_OPTIMIZER_KERNEL_OPT_MAX_PARTIAL).
+
+        Args:
+            result: The kernel-optimization handler result dict; an empty or
+                kernel-id-less result is a no-op.
+        """
         if not isinstance(result, dict):
             return
         kernel_id = str(result.get("kernel_id") or "")
@@ -1548,7 +1648,12 @@ class SharedState:
         }
 
     def _source_files_in_optimization_stack(self) -> set[str]:
-        """source_file paths already touched by an integrate entry; enforces "same source_file, only strongest KEEP integrated" (apply_kernel_patch is a whole-file overwrite)."""
+        """source_file paths already touched by an integrate entry; enforces "same source_file, only strongest KEEP integrated" (apply_kernel_patch is a whole-file overwrite).
+
+        Returns:
+            The set of source-file paths that appear on an ``integrate`` entry
+            of :attr:`optimization_stack`.
+        """
         sources: set[str] = set()
         for e in (self.optimization_stack or []):
             if not isinstance(e, dict) or e.get("action") != "integrate":
@@ -1559,7 +1664,12 @@ class SharedState:
         return sources
 
     def next_pending_keep_kernel_id(self) -> str:
-        """Return next KEEP kernel_id awaiting integrate ("" if drained); excludes integrated/rejected/same-file-conflict KEEPs, picks highest ``last_micro_speedup`` first."""
+        """Return next KEEP kernel_id awaiting integrate ("" if drained); excludes integrated/rejected/same-file-conflict KEEPs, picks highest ``last_micro_speedup`` first.
+
+        Returns:
+            The strongest pending KEEP kernel id, or ``""`` when the queue is
+            drained.
+        """
         integrated_ids = self._kernel_ids_in_optimization_stack()
         integrated_sources = self._source_files_in_optimization_stack()
         rejected = set(self.rejected_kernel_ids or [])
@@ -1587,7 +1697,11 @@ class SharedState:
         return best_kid
 
     def pending_keep_kernel_ids(self) -> list[str]:
-        """All KEEP kernel_ids awaiting integrate, sorted strongest-first; surfaced in the prompt so the LLM doesn't propose ``report`` before draining them."""
+        """All KEEP kernel_ids awaiting integrate, sorted strongest-first; surfaced in the prompt so the LLM doesn't propose ``report`` before draining them.
+
+        Returns:
+            Pending KEEP kernel ids sorted strongest-first, one per source file.
+        """
         integrated_ids = self._kernel_ids_in_optimization_stack()
         integrated_sources = self._source_files_in_optimization_stack()
         rejected = set(self.rejected_kernel_ids or [])
@@ -1645,7 +1759,18 @@ class SharedState:
         min_gpu_pct: float | None = None,
         top_n: int | None = None,
     ) -> list[str]:
-        """Hot kernels still owing a ``kernel_opt`` attempt (reusable, gpu_pct >= min_gpu_pct, untouched); capped to top_n by gpu_pct, one kernel_id per task_group."""
+        """Hot kernels still owing a ``kernel_opt`` attempt (reusable, gpu_pct >= min_gpu_pct, untouched); capped to top_n by gpu_pct, one kernel_id per task_group.
+
+        Args:
+            min_gpu_pct: Minimum GPU share to consider; defaults to the
+                ``HYPERLOOM_KERNEL_OPT_MIN_GPU_PCT`` env value.
+            top_n: Maximum number of kernels to return; defaults to the
+                ``HYPERLOOM_KERNEL_OPT_GATE_TOP_N`` env value.
+
+        Returns:
+            Kernel ids that still owe a ``kernel_opt`` attempt, one per task
+            group, capped to ``top_n``.
+        """
         info = self.last_trace_analyze or {}
         hot = info.get("hot_kernels_top15") or info.get("hot_kernels") or []
         task_groups = info.get("task_groups") or []
@@ -1731,7 +1856,15 @@ class SharedState:
     # Per-action audit (kernel parity for non-kernel actions)
     @staticmethod
     def _truncate_excerpt(value: Any, *, limit: int = 800) -> str | None:
-        """Coerce ``value`` to str and trim to ``limit`` chars; None for falsy inputs (renderer shows ``err=(none)``)."""
+        """Coerce ``value`` to str and trim to ``limit`` chars; None for falsy inputs (renderer shows ``err=(none)``).
+
+        Args:
+            value: Value to coerce and truncate.
+            limit: Maximum length of the returned string.
+
+        Returns:
+            The truncated string, or ``None`` for falsy inputs.
+        """
         if value is None:
             return None
         text = str(value)
@@ -1743,7 +1876,15 @@ class SharedState:
 
     @staticmethod
     def _stderr_tail(value: Any, *, limit: int = 1000) -> str | None:
-        """Pull the last ``limit`` chars from a subprocess error blob (stderr's actionable signal is at the end)."""
+        """Pull the last ``limit`` chars from a subprocess error blob (stderr's actionable signal is at the end).
+
+        Args:
+            value: Error blob to tail.
+            limit: Maximum number of trailing characters to keep.
+
+        Returns:
+            The trailing slice of the text, or ``None`` for falsy inputs.
+        """
         if value is None:
             return None
         text = str(value)
@@ -1762,7 +1903,22 @@ class SharedState:
         extras: dict[str, Any] | None = None,
         max_history: int = _DEFAULT_ATTEMPTS_HISTORY,
     ) -> dict[str, Any] | None:
-        """Append one attempt to ``<action>_attempts`` and refresh ``last_<action>``. Entry schema {ts, task_id, status, decision, key_metric, key_metric_kind, workspace, error_class, error_excerpt, stderr_tail, raw_result_path, reported_success, extras}. Returns the entry, or None when ``action`` not in the audit set (kernel-owned actions use bespoke recorders). Does NOT call :meth:`save`."""
+        """Append one attempt to ``<action>_attempts`` and refresh ``last_<action>``. Entry schema {ts, task_id, status, decision, key_metric, key_metric_kind, workspace, error_class, error_excerpt, stderr_tail, raw_result_path, reported_success, extras}. Returns the entry, or None when ``action`` not in the audit set (kernel-owned actions use bespoke recorders). Does NOT call :meth:`save`.
+
+        Args:
+            action: Audited action name; must be in the audit set.
+            task_id: Task identifier for the attempt.
+            status: Attempt status string.
+            decision: Decision string for the attempt.
+            result: The action result dict mined for the key metric and error
+                fields; ``None`` treated as empty.
+            extras: Optional extra fields stored on the entry.
+            max_history: Maximum number of attempt rows to retain.
+
+        Returns:
+            The recorded attempt entry, or ``None`` when ``action`` is not an
+            audited action.
+        """
         if action not in _AUDIT_ACTIONS:
             return None
         attempts_attr = f"{action}_attempts"
@@ -1832,7 +1988,18 @@ class SharedState:
         result: dict[str, Any] | None,
         max_history: int = _DEFAULT_LAST_FAILURES,
     ) -> dict[str, Any]:
-        """Append one rich failure record to :attr:`last_action_failures` for self-correction; invoked for EVERY unpromotable task kind, unlike :meth:`record_action_attempt`."""
+        """Append one rich failure record to :attr:`last_action_failures` for self-correction; invoked for EVERY unpromotable task kind, unlike :meth:`record_action_attempt`.
+
+        Args:
+            action: The failing action name.
+            task_id: Task identifier for the failure.
+            result: The action result dict mined for error fields; ``None``
+                treated as empty.
+            max_history: Maximum number of failure rows to retain.
+
+        Returns:
+            The recorded failure entry.
+        """
         result = result or {}
         error_class = result.get("error_class")
         error_class_str = str(error_class) if error_class else None
@@ -1874,6 +2041,9 @@ class SharedState:
         Prefers ``baseline_tput``; falls back to ``last_baseline``'s
         ``tput``/``output_throughput`` so a state that lost ``baseline_tput``
         still stamps an achieved value (avoids an empty within/gap pct).
+
+        Returns:
+            The resolved baseline throughput, or ``0.0`` when none is available.
         """
         if isinstance(self.baseline_tput, (int, float)) and self.baseline_tput > 0:
             return float(self.baseline_tput)
@@ -1890,6 +2060,10 @@ class SharedState:
         Reads ``current_best``'s ``tput``/``output_throughput`` so a
         current_best-tagged snapshot keeps its arm even when ``tput`` is
         momentarily absent (avoids silently downgrading to the baseline arm).
+
+        Returns:
+            The resolved current-best throughput, or ``0.0`` when none is
+            available.
         """
         cb = self.current_best if isinstance(self.current_best, dict) else {}
         for key in ("tput", "output_throughput"):
@@ -1903,7 +2077,12 @@ class SharedState:
         payload: dict[str, Any],
         result: dict[str, Any],
     ) -> None:
-        """Write the canonical 11-field ``last_trace_analyze`` dict (single writer). ``roofline_snapshot_id`` increments monotonically; PR #321 retired ``last_trace_analyze_baseline`` (roofline_snapshots feeds report.py Roofline Comparison)."""
+        """Write the canonical 11-field ``last_trace_analyze`` dict (single writer). ``roofline_snapshot_id`` increments monotonically; PR #321 retired ``last_trace_analyze_baseline`` (roofline_snapshots feeds report.py Roofline Comparison).
+
+        Args:
+            payload: The trace-analyze request payload.
+            result: The trace-analyze result dict; non-dicts are a no-op.
+        """
         if not isinstance(result, dict):
             return
         trace_input = (
@@ -2244,7 +2423,11 @@ class SharedState:
         }
 
     def record_conc_sweep(self, result: dict[str, Any]) -> None:
-        """Record conc_sweep task completion (mirrors record_sweep). Bug #12: status lets exit_normal_sweep return conc_sweep_done so SWEEP→CLOSE fires on conc_sweep alone."""
+        """Record conc_sweep task completion (mirrors record_sweep). Bug #12: status lets exit_normal_sweep return conc_sweep_done so SWEEP→CLOSE fires on conc_sweep alone.
+
+        Args:
+            result: The conc_sweep result dict; non-dicts are a no-op.
+        """
         if not isinstance(result, dict):
             return
         self.last_conc_sweep = {
@@ -2259,7 +2442,11 @@ class SharedState:
 
     # specialist round bookkeeping
     def record_specialist_round(self, entry: dict[str, Any]) -> None:
-        """Append one round summary to ``specialist_rounds``; idempotent on ``round_id`` (re-record overwrites)."""
+        """Append one round summary to ``specialist_rounds``; idempotent on ``round_id`` (re-record overwrites).
+
+        Args:
+            entry: The round summary dict; empty or non-dict is a no-op.
+        """
         if not isinstance(entry, dict) or not entry:
             return
         round_id = str(entry.get("round_id") or "").strip()
@@ -2276,7 +2463,16 @@ class SharedState:
     def bump_specialist_domain_empty_streak(
         self, domain: str, *, empty: bool,
     ) -> int:
-        """Increment/reset the per-domain empty-proposal streak; returns new value (escalation threshold lives in ``KB_design §3.9``, not here)."""
+        """Increment/reset the per-domain empty-proposal streak; returns new value (escalation threshold lives in ``KB_design §3.9``, not here).
+
+        Args:
+            domain: The specialist domain; blank maps to ``"unknown"``.
+            empty: Whether the latest round was empty (increment) or not
+                (reset).
+
+        Returns:
+            The new streak count for the domain.
+        """
         d = str(domain or "").strip() or "unknown"
         if empty:
             self.specialist_domain_empty_streak[d] = int(
@@ -2288,7 +2484,14 @@ class SharedState:
 
     # gaps ledger helpers
     def find_gap(self, canonical_id: str) -> dict[str, Any] | None:
-        """Return the gap entry matching ``canonical_id`` (or ``None``)."""
+        """Return the gap entry matching ``canonical_id`` (or ``None``).
+
+        Args:
+            canonical_id: The gap's canonical identifier.
+
+        Returns:
+            The matching gap entry, or ``None`` when not found.
+        """
         if not canonical_id:
             return None
         cid = str(canonical_id)
@@ -2298,7 +2501,15 @@ class SharedState:
         return None
 
     def upsert_gap(self, entry: dict[str, Any]) -> dict[str, Any]:
-        """Insert or update one gap row, keyed by ``canonical_id``. Coordinator-only writer (Inv-1 single-writer + CORE_STATE_FIELDS lock). Returns the merged entry."""
+        """Insert or update one gap row, keyed by ``canonical_id``. Coordinator-only writer (Inv-1 single-writer + CORE_STATE_FIELDS lock). Returns the merged entry.
+
+        Args:
+            entry: The gap row to insert or merge; must carry a non-empty
+                ``canonical_id``.
+
+        Returns:
+            The merged gap entry, or ``{}`` when the input is invalid.
+        """
         if not isinstance(entry, dict):
             return {}
         cid = str(entry.get("canonical_id") or "").strip()
@@ -2369,7 +2580,15 @@ class SharedState:
         canonical_id: str,
         attempt: dict[str, Any],
     ) -> dict[str, Any] | None:
-        """Append one attempt row to an existing gap; returns the gap or ``None`` when unknown (caller may ``upsert_gap`` instead)."""
+        """Append one attempt row to an existing gap; returns the gap or ``None`` when unknown (caller may ``upsert_gap`` instead).
+
+        Args:
+            canonical_id: The gap's canonical identifier.
+            attempt: The attempt row to append (timestamped when absent).
+
+        Returns:
+            The updated gap entry, or ``None`` when the gap is unknown.
+        """
         gap = self.find_gap(canonical_id)
         if gap is None:
             return None
@@ -2382,7 +2601,12 @@ class SharedState:
         return gap
 
     def replace_gaps(self, entries: list[dict[str, Any]]) -> None:
-        """Bulk-replace ``gaps`` with a fresh dedup'd list (discards stale rows wholesale); idempotent."""
+        """Bulk-replace ``gaps`` with a fresh dedup'd list (discards stale rows wholesale); idempotent.
+
+        Args:
+            entries: The replacement gap rows; non-lists are a no-op and rows
+                without a ``canonical_id`` are dropped.
+        """
         if not isinstance(entries, list):
             return
         dedup: dict[str, dict[str, Any]] = {}
@@ -2417,7 +2641,15 @@ class SharedState:
         task_id: str = "",
         delta_pct: float | None = None,
     ) -> None:
-        """Append one intervention entry and update config-only counters. consecutive-config counter advances on ``"config"``, resets on ``"code_patch"``; ``"code_patch_attempt"`` is telemetry-only."""
+        """Append one intervention entry and update config-only counters. consecutive-config counter advances on ``"config"``, resets on ``"code_patch"``; ``"code_patch_attempt"`` is telemetry-only.
+
+        Args:
+            change_type: Intervention change type (e.g. ``config`` /
+                ``code_patch``).
+            action: The action associated with the intervention.
+            task_id: Optional task identifier.
+            delta_pct: Optional measured delta percentage.
+        """
         ct = str(change_type or "").strip().lower()
         entry = {
             "change_type": ct,
@@ -2435,7 +2667,15 @@ class SharedState:
             self.consecutive_config_only_rounds = 0
 
     def get_intervention_mix(self, *, recent_window: int = 5) -> dict[str, Any]:
-        """Summarise the intervention-mix ledger as derived counts (config vs code_patch totals, recent window, consecutive_config_only, config_heavy). Read-only; unknown change_types ignored in tallies but break the trailing config-only run."""
+        """Summarise the intervention-mix ledger as derived counts (config vs code_patch totals, recent window, consecutive_config_only, config_heavy). Read-only; unknown change_types ignored in tallies but break the trailing config-only run.
+
+        Args:
+            recent_window: Number of most-recent entries to tally for the recent
+                window counts.
+
+        Returns:
+            A summary dict of derived intervention counts and flags.
+        """
         ledger = [e for e in (self.intervention_mix or []) if isinstance(e, dict)]
 
         def _ct(entry: dict[str, Any]) -> str:
@@ -2483,7 +2723,14 @@ class SharedState:
         }
 
     def bump_specialist_dispatched(self, n: int = 1) -> int:
-        """Increment the per-EXPLORE specialist dispatch counter; returns post-increment value."""
+        """Increment the per-EXPLORE specialist dispatch counter; returns post-increment value.
+
+        Args:
+            n: Amount to add to the dispatch counter.
+
+        Returns:
+            The post-increment dispatch count.
+        """
         self.explore_specialist_dispatched_count = (
             int(self.explore_specialist_dispatched_count or 0) + int(n)
         )
@@ -2494,12 +2741,27 @@ class SharedState:
         self.explore_specialist_dispatched_count = 0
 
     def bump_research_scout_runs(self, n: int = 1) -> int:
-        """Increment the research-scout dispatch counter; return new total."""
+        """Increment the research-scout dispatch counter; return new total.
+
+        Args:
+            n: Amount to add to the research-scout run counter.
+
+        Returns:
+            The new research-scout run total.
+        """
         self.research_scout_runs = int(self.research_scout_runs or 0) + int(n)
         return self.research_scout_runs
 
     def register_seen_pr_ids(self, pr_ids: Any) -> int:
-        """Add PR ids to the shared seen-set (scout + FRAMEWORK_PR dedup); returns count newly added."""
+        """Add PR ids to the shared seen-set (scout + FRAMEWORK_PR dedup); returns count newly added.
+
+        Args:
+            pr_ids: Iterable of PR ids to register; blanks and duplicates are
+                skipped.
+
+        Returns:
+            The number of PR ids newly added to the seen set.
+        """
         seen = set(self.research_scout_seen_pr_ids or [])
         added = 0
         for raw in pr_ids or []:
@@ -2512,7 +2774,14 @@ class SharedState:
         return added
 
     def has_seen_pr_id(self, pr_id: Any) -> bool:
-        """True iff ``pr_id`` was already surfaced by scout / FRAMEWORK_PR."""
+        """True iff ``pr_id`` was already surfaced by scout / FRAMEWORK_PR.
+
+        Args:
+            pr_id: The PR id to check.
+
+        Returns:
+            ``True`` when the PR id is in the seen set.
+        """
         pid = str(pr_id or "").strip()
         return bool(pid) and pid in set(self.research_scout_seen_pr_ids or [])
 
@@ -2522,14 +2791,23 @@ class SharedState:
         self.params_no_promote_streak = 0
 
     def note_explore_outcome(self, *, promoted: bool) -> None:
-        """Update the legacy plateau proxy after one explore task (KEEP resets, no-promote increments)."""
+        """Update the legacy plateau proxy after one explore task (KEEP resets, no-promote increments).
+
+        Args:
+            promoted: Whether the explore task promoted a variant; ``True``
+                resets the proxy, ``False`` increments it.
+        """
         if promoted:
             self.reset_explore_plateau_proxy()
         else:
             self.params_no_promote_streak += 1
 
     def to_intervention_mix_summary(self) -> str:
-        """Render the intervention ledger as neutral telemetry (one-line counts summary; ``""`` when empty). No directive emitted — config-vs-patch is the LLM's choice."""
+        """Render the intervention ledger as neutral telemetry (one-line counts summary; ``""`` when empty). No directive emitted — config-vs-patch is the LLM's choice.
+
+        Returns:
+            A one-line counts summary, or ``""`` when the ledger is empty.
+        """
         mix = self.intervention_mix or []
         if not mix:
             return ""
@@ -2558,7 +2836,13 @@ class SharedState:
     def record_specialist_patch_verdict(
         self, specialist_task_id: str, verdict: str,
     ) -> None:
-        """Record the Critic verdict for a specialist worktree patch; idempotent (later verdict overwrites), empty ``verdict`` clears the entry to force re-review."""
+        """Record the Critic verdict for a specialist worktree patch; idempotent (later verdict overwrites), empty ``verdict`` clears the entry to force re-review.
+
+        Args:
+            specialist_task_id: The specialist task identifier; blank is a
+                no-op.
+            verdict: The Critic verdict; an empty string clears the entry.
+        """
         sid = str(specialist_task_id or "").strip()
         if not sid:
             return
@@ -2571,7 +2855,14 @@ class SharedState:
     def get_specialist_patch_verdict(
         self, specialist_task_id: str,
     ) -> str:
-        """Return the patch verdict, or empty when no Critic decision exists."""
+        """Return the patch verdict, or empty when no Critic decision exists.
+
+        Args:
+            specialist_task_id: The specialist task identifier.
+
+        Returns:
+            The recorded verdict, or ``""`` when none exists.
+        """
         sid = str(specialist_task_id or "").strip()
         if not sid:
             return ""
@@ -2588,7 +2879,11 @@ class SharedState:
             self.last_specialist = dict(snapshot)
 
     def apply_explore_search_update(self, update: dict[str, Any]) -> None:
-        """Merge an ExploreExecutor search update into persistent state (v0.8 M3); executor never writes ``accepted`` directly — :meth:`record_explore_accepted` is the single writer for that bucket."""
+        """Merge an ExploreExecutor search update into persistent state (v0.8 M3); executor never writes ``accepted`` directly — :meth:`record_explore_accepted` is the single writer for that bucket.
+
+        Args:
+            update: The executor search-update dict; non-dicts are a no-op.
+        """
         if not isinstance(update, dict):
             return
         prior = self.explore_search if isinstance(self.explore_search, dict) else {}
@@ -2633,7 +2928,11 @@ class SharedState:
         self.explore_search = merged
 
     def record_explore_accepted(self, variant: dict[str, Any]) -> None:
-        """Append one promoted variant to ``explore_search.accepted``; dedupes by ``fingerprint`` and removes any matching ``rejected`` entry so a variant isn't in both buckets."""
+        """Append one promoted variant to ``explore_search.accepted``; dedupes by ``fingerprint`` and removes any matching ``rejected`` entry so a variant isn't in both buckets.
+
+        Args:
+            variant: The promoted variant dict; empty or non-dict is a no-op.
+        """
         if not isinstance(variant, dict) or not variant:
             return
         from .action_executors._canonical_fingerprint import canonical_fingerprint
@@ -2696,7 +2995,15 @@ class SharedState:
         param_flags: list[str] | None = None,
         source_path: str = "",
     ) -> None:
-        """Persist the AST-discovered flag list for a framework; the prompt surfaces the union so the LLM synthesizes new GridVariants beyond DEFAULT_*_GRID. Idempotent per-framework."""
+        """Persist the AST-discovered flag list for a framework; the prompt surfaces the union so the LLM synthesizes new GridVariants beyond DEFAULT_*_GRID. Idempotent per-framework.
+
+        Args:
+            framework: Framework name; blank maps to ``"unknown"``.
+            backend_flags: Discovered backend flags; left unchanged when
+                ``None``.
+            param_flags: Discovered param flags; left unchanged when ``None``.
+            source_path: Optional path the flags were discovered from.
+        """
         fw = (framework or "").strip().lower() or "unknown"
         entry = dict(self.discovered_flags.get(fw) or {})
         if backend_flags is not None:
@@ -2727,7 +3034,19 @@ class SharedState:
         extra_server_args: str = "",
         ts: str | None = None,
     ) -> float | None:
-        """Mirror an optimization_stack append into gain_per_stack_entry; computes ``(new_tput-baseline_tput)/baseline_tput*100`` and appends. Returns gain_pct (None when baseline_tput is 0 or new_tput non-positive)."""
+        """Mirror an optimization_stack append into gain_per_stack_entry; computes ``(new_tput-baseline_tput)/baseline_tput*100`` and appends. Returns gain_pct (None when baseline_tput is 0 or new_tput non-positive).
+
+        Args:
+            action: The stack action being mirrored.
+            variant_name: Optional variant name for the entry.
+            new_tput: The new throughput used to compute the gain.
+            extra_server_args: Optional server-arg string for the entry.
+            ts: Optional ISO timestamp.
+
+        Returns:
+            The computed gain percentage, or ``None`` when the baseline or new
+            throughput is non-positive.
+        """
         try:
             base = float(self.baseline_tput or 0.0)
         except (TypeError, ValueError):
@@ -2769,7 +3088,15 @@ class SharedState:
 
     # Time-budget helpers (consumed by Coordinator._compose_prompt)
     def elapsed_minutes(self, *, now: datetime | None = None) -> float:
-        """Wall-clock minutes since ``start_ts`` (0.0 when empty/unparseable)."""
+        """Wall-clock minutes since ``start_ts`` (0.0 when empty/unparseable).
+
+        Args:
+            now: Override for the current time; defaults to ``datetime.now``.
+
+        Returns:
+            Non-negative minutes elapsed since ``start_ts``, or ``0.0`` when it
+            is unset or unparseable.
+        """
         if not self.start_ts:
             return 0.0
         try:
@@ -2785,17 +3112,37 @@ class SharedState:
         return max(0.0, delta)
 
     def remaining_minutes(self, *, now: datetime | None = None) -> float | None:
-        """Minutes left in the wall-clock budget; ``None`` when ``max_minutes`` unset (unbounded), else clamped at 0."""
+        """Minutes left in the wall-clock budget; ``None`` when ``max_minutes`` unset (unbounded), else clamped at 0.
+
+        Args:
+            now: Override for the current time; defaults to ``datetime.now``.
+
+        Returns:
+            Minutes remaining in the budget, or ``None`` when the session is
+            unbounded.
+        """
         if not self.max_minutes:
             return None
         return max(0.0, float(self.max_minutes) - self.elapsed_minutes(now=now))
 
     def optimization_stack_has_unvalidated_keeps(self) -> bool:
-        """True iff a new KEEP landed since the last inline stack rebench (purely a stack-length check vs ``cumulative_gain_validated_stack_len``)."""
+        """True iff a new KEEP landed since the last inline stack rebench (purely a stack-length check vs ``cumulative_gain_validated_stack_len``).
+
+        Returns:
+            ``True`` when the optimization stack has grown since the last
+            validated rebench.
+        """
         return len(self.optimization_stack) > int(self.cumulative_gain_validated_stack_len)
 
     def to_mission_summary(self, *, now: datetime | None = None) -> str:
-        """Mission-progress block printed at the top of every tick (outcome-shaped state: raw/validated gain, time vs budget, stack staleness); distinct from :meth:`to_prompt_summary`."""
+        """Mission-progress block printed at the top of every tick (outcome-shaped state: raw/validated gain, time vs budget, stack staleness); distinct from :meth:`to_prompt_summary`.
+
+        Args:
+            now: Override for the current time used in elapsed/remaining math.
+
+        Returns:
+            A multi-line mission-progress summary block.
+        """
         elapsed = self.elapsed_minutes(now=now)
         remaining = self.remaining_minutes(now=now)
         budget_line = (
@@ -2853,7 +3200,16 @@ class SharedState:
         budget_pct: dict[str, float] | None = None,
         now_unix: float | None = None,
     ) -> str:
-        """Render the per-tick ``=== Phase ===`` block (v0.8 §3.3); compact (≤5 lines). EXPLORE adds a ``force_exit`` line showing runway before the hard force-exit gate."""
+        """Render the per-tick ``=== Phase ===`` block (v0.8 §3.3); compact (≤5 lines). EXPLORE adds a ``force_exit`` line showing runway before the hard force-exit gate.
+
+        Args:
+            budget_pct: Override ``phase -> pct`` map; defaults to the state's
+                ``phase_budget_pct``.
+            now_unix: Override for the current time in seconds.
+
+        Returns:
+            The rendered phase-status block as a multi-line string.
+        """
         from .phase_state import (
             DEFAULT_EXPLORE_FORCE_EXIT_BUDGET_PCT,
             DEFAULT_EXPLORE_FORCE_EXIT_HOURS_REMAINING,
@@ -2940,7 +3296,17 @@ class SharedState:
         budget_pct: dict[str, float] | None = None,
         now_unix: float | None = None,
     ) -> str:
-        """Render the per-phase budget telemetry block for Robustness (one ``phase: elapsed=Xs cap=Ys (Z%)`` line per phase) so it can spot budget overruns."""
+        """Render the per-phase budget telemetry block for Robustness (one ``phase: elapsed=Xs cap=Ys (Z%)`` line per phase) so it can spot budget overruns.
+
+        Args:
+            budget_pct: Override ``phase -> pct`` map; defaults to the state's
+                ``phase_budget_pct``.
+            now_unix: Override for the current time in seconds.
+
+        Returns:
+            One telemetry line per phase, or a placeholder when no phase history
+            exists yet.
+        """
         from .phase_state import (
             DEFAULT_PHASE_BUDGET_PCT,
             PHASE_NAMES,
@@ -2988,7 +3354,15 @@ class SharedState:
         return "\n".join(lines) or "(no phase history yet)"
 
     def to_warm_start_summary(self, *, max_lines: int = 12) -> str:
-        """Render T0 warm-start snapshot for the ``=== Warm start ===`` prompt section (v0.8 §3.3 §4.1); empty when no recipe/pitfalls. Capped; full JSON at runtime/cortex/.kb_warm.json / .kb_pitfalls.json."""
+        """Render T0 warm-start snapshot for the ``=== Warm start ===`` prompt section (v0.8 §3.3 §4.1); empty when no recipe/pitfalls. Capped; full JSON at runtime/cortex/.kb_warm.json / .kb_pitfalls.json.
+
+        Args:
+            max_lines: Maximum number of lines to render before truncating.
+
+        Returns:
+            The rendered warm-start block, or ``""`` when no recipe or pitfalls
+            exist.
+        """
         recipe = self.warm_start_recipe or {}
         pitfalls = self.warm_start_pitfalls or []
         if not recipe and not pitfalls:
@@ -3031,7 +3405,14 @@ class SharedState:
         return "\n".join(out)
 
     def to_gaps_summary(self, *, max_entries: int = 10) -> str:
-        """Render :attr:`gaps` for prompt injection (KB_design §3.3/§3.5); empty when no gaps. Capped at ``max_entries`` newest rows."""
+        """Render :attr:`gaps` for prompt injection (KB_design §3.3/§3.5); empty when no gaps. Capped at ``max_entries`` newest rows.
+
+        Args:
+            max_entries: Maximum number of newest gap rows to render.
+
+        Returns:
+            The rendered gaps block, or ``""`` when there are no gaps.
+        """
         if not self.gaps:
             return ""
         # Newest first by last_updated_ts (deterministic fallback to first_seen_ts/insertion).
@@ -3074,7 +3455,15 @@ class SharedState:
         return "\n".join(rows)
 
     def to_proposal_scores_summary(self, *, max_rounds: int = 2) -> str:
-        """Render advisory multi-model proposal scores for Orchestration. NO mean/sorting (Inv-9.1: no system-side scoreboard); rater identities anonymized to avoid brand bias. Empty when no recent round carries scores."""
+        """Render advisory multi-model proposal scores for Orchestration. NO mean/sorting (Inv-9.1: no system-side scoreboard); rater identities anonymized to avoid brand bias. Empty when no recent round carries scores.
+
+        Args:
+            max_rounds: Maximum number of most-recent scored rounds to render.
+
+        Returns:
+            The rendered advisory scores block, or ``""`` when no recent round
+            carries scores.
+        """
         rounds = [
             r for r in (self.specialist_rounds or [])
             if isinstance(r, dict)
@@ -3263,7 +3652,12 @@ class SharedState:
         )
 
     def _format_attempts_history(self) -> str:
-        """One-line summary across the audit actions (``baseline:total(s<succ>,f<fail>) ...``) so the LLM gauges reliability without 6x20 rows."""
+        """One-line summary across the audit actions (``baseline:total(s<succ>,f<fail>) ...``) so the LLM gauges reliability without 6x20 rows.
+
+        Returns:
+            A one-line per-action attempt summary, or a placeholder when no
+            attempts are recorded.
+        """
         parts: list[str] = []
         for action in sorted(_AUDIT_ACTIONS):
             attempts_attr = f"{action}_attempts"
@@ -3283,7 +3677,12 @@ class SharedState:
         return " ".join(parts) if parts else "(no attempts recorded)"
 
     def _format_last_action_failures(self) -> str:
-        """Render up to the 3 most-recent global failures (rich-context companion to crash_count/baseline_failure_streak); full list on disk."""
+        """Render up to the 3 most-recent global failures (rich-context companion to crash_count/baseline_failure_streak); full list on disk.
+
+        Returns:
+            A compact render of the recent failures, or ``"(none)"`` when there
+            are none.
+        """
         if not self.last_action_failures:
             return "(none)"
         rows: list[str] = []
@@ -3343,7 +3742,15 @@ class SharedState:
 
     @staticmethod
     def _format_variant_line(entry: dict[str, Any]) -> str:
-        """One-line render of a search variant for prompt blocks."""
+        """One-line render of a search variant for prompt blocks.
+
+        Args:
+            entry: The variant dict to render.
+
+        Returns:
+            A single formatted line summarizing the variant's name, gain,
+            throughput, args, and envs.
+        """
         name = str(entry.get("name") or "?")
         gain = entry.get("gain_pct")
         tput = entry.get("tput") or entry.get("output_throughput")
@@ -3370,7 +3777,16 @@ class SharedState:
     def _enrich_with_tested_gain(
         entry: dict[str, Any], tested: dict[str, Any],
     ) -> dict[str, Any]:
-        """Backfill ``gain_pct``/``tput`` from the matching ``tested[fp]`` at render time (some accepted entries don't persist gain_pct; avoids a second writer)."""
+        """Backfill ``gain_pct``/``tput`` from the matching ``tested[fp]`` at render time (some accepted entries don't persist gain_pct; avoids a second writer).
+
+        Args:
+            entry: The variant entry to enrich.
+            tested: The ``tested`` ledger keyed by fingerprint.
+
+        Returns:
+            The entry (or a copy) with ``gain_pct``/``tput`` backfilled from the
+            matching tested snapshot when available.
+        """
         if (
             entry.get("gain_pct") is not None
             and entry.get("tput") is not None
@@ -3394,7 +3810,12 @@ class SharedState:
         return out
 
     def _format_backend_winners_history(self) -> str:
-        """Multi-line render of the explore-round winners history (last 5 rounds: per-winner gain_pct/tput/flags); older rounds collapse to an elision line."""
+        """Multi-line render of the explore-round winners history (last 5 rounds: per-winner gain_pct/tput/flags); older rounds collapse to an elision line.
+
+        Returns:
+            A multi-line winners-history render, or a placeholder when no
+            explore rounds have completed.
+        """
         if not self.backend_winners_history:
             return "(no explore rounds completed)"
         last = self.backend_winners_history[-5:]
@@ -3440,7 +3861,14 @@ class SharedState:
 
     @staticmethod
     def _format_search_state(search: dict[str, Any] | None) -> str:
-        """Multi-line render of a ``*_search`` dedup ledger; each entry surfaces real ``gain_pct``. Counts on the head line; bodies show last 5 per bucket (only the prompt body is truncated)."""
+        """Multi-line render of a ``*_search`` dedup ledger; each entry surfaces real ``gain_pct``. Counts on the head line; bodies show last 5 per bucket (only the prompt body is truncated).
+
+        Args:
+            search: The ``*_search`` ledger dict, or ``None``.
+
+        Returns:
+            A multi-line render of the ledger, or ``"(none)"`` when empty.
+        """
         if not search:
             return "(none)"
         accepted = list(search.get("accepted") or [])
@@ -3490,14 +3918,26 @@ class SharedState:
 
     @staticmethod
     def _strip_base64_data_urls(text: str) -> str:
-        """Drop base64 image payloads before prompt injection (in-memory only; on-disk file intact). Delegates to ``inference_optimizer.tracelens_md``."""
+        """Drop base64 image payloads before prompt injection (in-memory only; on-disk file intact). Delegates to ``inference_optimizer.tracelens_md``.
+
+        Args:
+            text: The text to strip base64 data URLs from.
+
+        Returns:
+            The text with base64 image payloads removed.
+        """
         if not text:
             return text or ""
         from inference_optimizer.tracelens_md import strip_base64_data_urls
         return strip_base64_data_urls(text)
 
     def _format_analysis_md_full(self) -> str:
-        """Inject TraceLens analysis.md verbatim (Roofline composite design §6.1: no truncation/interpretation) between ``=== TraceLens Analysis ... ===`` bookends; header carries snapshot id + gain. Empty cache → one-line hint to propose ``roofline``."""
+        """Inject TraceLens analysis.md verbatim (Roofline composite design §6.1: no truncation/interpretation) between ``=== TraceLens Analysis ... ===`` bookends; header carries snapshot id + gain. Empty cache → one-line hint to propose ``roofline``.
+
+        Returns:
+            The bookended analysis.md block, or a one-line hint when no
+            TraceLens snapshot is cached.
+        """
         cached = self.last_trace_analyze or {}
         md_text = cached.get("analysis_md_text") or ""
         if not md_text:

--- a/inference_optimizer/orchestrator/specialist_bench.py
+++ b/inference_optimizer/orchestrator/specialist_bench.py
@@ -131,6 +131,17 @@ async def run_bench(
     Output lands under ``worktree/scratch/bench/<bench_id>/<call_id>/`` and is
     destroyed with the worktree. ``bench_dir_root`` overrides script discovery
     for tests.
+
+    Args:
+        bench_id: Registered micro-bench identifier to run.
+        worktree: Worktree the bench runs inside.
+        call_id: Unique call id used to scope the output directory.
+        params: Optional bench parameters passed via env JSON.
+        bench_dir_root: Override for bench-script discovery (tests).
+
+    Returns:
+        A result dict with ``ok`` plus bench output, or an error dict when the
+        bench is disabled/unknown/missing or the run fails or times out.
     """
     if not BENCH_TOOL_ENABLED:
         return _error(
@@ -206,7 +217,16 @@ _PATCH_PATH_RE = re.compile(r"^(?:---|\+\+\+) (?:a|b)/(?P<path>.+)$", re.M)
 def apply_patch_in_worktree(
     worktree: Path, patch_text: str,
 ) -> dict[str, Any]:
-    """Try ``git apply`` inside the worktree (self-check); not committed."""
+    """Try ``git apply`` inside the worktree (self-check); not committed.
+
+    Args:
+        worktree: Worktree the patch is applied inside.
+        patch_text: The unified-diff text to apply.
+
+    Returns:
+        A result dict with ``applied`` on success, or an error dict for an
+        empty patch, missing worktree, path escape, or git-apply failure.
+    """
     if not patch_text or not patch_text.strip():
         return _error("empty_patch")
     worktree = Path(worktree)
@@ -260,6 +280,13 @@ def capture_worktree_cumulative_diff(worktree: Path) -> str | None:
     * ``<diff>`` — uncommitted-change diff.
     * ``None``   — git failure / not a repo; callers skip the
                    cumulative-diff check rather than aborting.
+
+    Args:
+        worktree: Worktree to capture the cumulative diff from.
+
+    Returns:
+        The ``git diff HEAD`` output, ``""`` for a clean worktree, or ``None``
+        on git failure / not a repo.
     """
     worktree = Path(worktree)
     if not worktree.is_dir():
@@ -277,7 +304,11 @@ def capture_worktree_cumulative_diff(worktree: Path) -> str | None:
 
 
 def reset_worktree(worktree: Path) -> None:
-    """Discard uncommitted changes + untracked files in ``worktree``."""
+    """Discard uncommitted changes + untracked files in ``worktree``.
+
+    Args:
+        worktree: Worktree to hard-reset and clean.
+    """
     worktree = Path(worktree)
     if not worktree.is_dir():
         return

--- a/inference_optimizer/orchestrator/specialist_domains.py
+++ b/inference_optimizer/orchestrator/specialist_domains.py
@@ -207,7 +207,15 @@ _ANCHOR_TO_DOMAIN: dict[str, "SpecialistDomain"] = _anchor_to_domain_map()
 
 def domain_for_tag(tag: str) -> "SpecialistDomain | None":
     """Return a representative catalogue entry for a knowledge-domain
-    tag (matched first by ``kb_anchor``, then by ``key``)."""
+    tag (matched first by ``kb_anchor``, then by ``key``).
+
+    Args:
+        tag: The knowledge-domain tag to look up.
+
+    Returns:
+        The matching catalogue entry, or ``None`` when the tag is empty or
+        unknown.
+    """
     t = (tag or "").strip()
     if not t:
         return None
@@ -223,6 +231,12 @@ def normalize_dispatch_tags(params: dict) -> list[str]:
     Reads ``params.tags``; falls back to the ``params.domain`` alias (mapped
     to its ``kb_anchor`` when it names a catalogue entry, else verbatim) when
     absent. Order-preserving dedup; empty entries dropped.
+
+    Args:
+        params: The dispatch payload (reads ``tags`` then ``domain``).
+
+    Returns:
+        The resolved, order-preserving deduped tag list.
     """
     raw = params.get("tags")
     tags: list[str] = []

--- a/inference_optimizer/orchestrator/specialist_mcp_config.py
+++ b/inference_optimizer/orchestrator/specialist_mcp_config.py
@@ -33,13 +33,15 @@ def write_specialist_mcp_config(
     Returns ``None`` when no MCP server is wireable (caller leaves
     ``--mcp-config`` off). Idempotent.
 
-    Parameters
-    ----------
-    session_dir
-        Session root; file lands at
-        ``<session_dir>/runtime/<SPECIALIST_MCP_CONFIG_FILENAME>``.
-    pr_monitor_mcp_url
-        ``KnowledgePlane.specialist_mcp_url()`` — empty means disabled.
+    Args:
+        session_dir: Session root; the file lands at
+            ``<session_dir>/runtime/<SPECIALIST_MCP_CONFIG_FILENAME>``.
+        pr_monitor_mcp_url: ``KnowledgePlane.specialist_mcp_url()``; empty
+            means disabled.
+
+    Returns:
+        The written config file path, or ``None`` when no MCP server is
+        wireable.
     """
     servers: dict[str, dict[str, Any]] = {}
     pr_url = (pr_monitor_mcp_url or "").strip()

--- a/inference_optimizer/orchestrator/specialist_patch_safety.py
+++ b/inference_optimizer/orchestrator/specialist_patch_safety.py
@@ -83,7 +83,15 @@ _DEV_NULL = "/dev/null"
 
 
 def _strip_path_prefix(path: str, level: int) -> str:
-    """Strip ``level`` leading path components, mimicking ``git apply -p<level>``."""
+    """Strip ``level`` leading path components, mimicking ``git apply -p<level>``.
+
+    Args:
+        path: The diff header path to strip.
+        level: Number of leading components to drop (``<= 0`` is a no-op).
+
+    Returns:
+        The path with ``level`` leading components removed (basename floor).
+    """
     if level <= 0:
         return path
     parts = path.split("/")
@@ -98,6 +106,12 @@ def patch_file_targets(patch_text: str) -> list[tuple[str, str]]:
     Paths are the raw ``--- ``/``+++ `` tokens (may carry an ``a/``/``b/``
     prefix, a deep absolute prefix, or the ``/dev/null`` sentinel for a
     created/deleted file). Trailing ``\\t<timestamp>`` is stripped.
+
+    Args:
+        patch_text: The unified-diff text to scan.
+
+    Returns:
+        The list of ``(old_path, new_path)`` header pairs.
     """
     pairs: list[tuple[str, str]] = []
     lines = (patch_text or "").splitlines()
@@ -131,6 +145,14 @@ def patch_targets_missing(
     (e.g. patching a CUDA-only file on a ROCm build). Pure file *creations*
     (pre-image ``/dev/null``) are exempt. The returned paths are the raw
     pre-image tokens, suitable for an advisory back to the specialist.
+
+    Args:
+        patch_text: The unified-diff text to scan.
+        root: Framework source-tree root the targets are probed against.
+        strip_levels: ``-p`` strip levels to try when resolving each path.
+
+    Returns:
+        The raw pre-image token paths absent from ``root`` at every level.
     """
     missing: list[str] = []
     for old, _new in patch_file_targets(patch_text):
@@ -204,7 +226,12 @@ CROSS_DOMAIN_RULES: tuple[CrossDomainRule, ...] = (
 
 
 def cross_domain_rule_descriptors() -> list[dict[str, str]]:
-    """Return the cross-domain rules as the dict shape the Critic bundle uses."""
+    """Return the cross-domain rules as the dict shape the Critic bundle uses.
+
+    Returns:
+        One dict per cross-domain rule with ``rule_id`` / ``description`` /
+        ``failure_verdict`` / ``failure_reason_code`` keys.
+    """
     return [
         {
             "rule_id": r.rule_id,
@@ -217,7 +244,14 @@ def cross_domain_rule_descriptors() -> list[dict[str, str]]:
 
 
 def numeric_claims(text: str) -> list[str]:
-    """Return numeric-speedup claim substrings found in ``text``."""
+    """Return numeric-speedup claim substrings found in ``text``.
+
+    Args:
+        text: The free-text argument/summary to scan.
+
+    Returns:
+        The matched numeric-claim substrings (may be empty).
+    """
     hits: list[str] = []
     for pattern in _NUMERIC_CLAIM_PATTERNS:
         for match in pattern.finditer(text or ""):
@@ -226,12 +260,26 @@ def numeric_claims(text: str) -> list[str]:
 
 
 def is_unified_diff(text: str) -> bool:
-    """True iff ``text`` carries at least one unified-diff hunk header."""
+    """True iff ``text`` carries at least one unified-diff hunk header.
+
+    Args:
+        text: The candidate diff text.
+
+    Returns:
+        True when at least one ``@@`` hunk header is present.
+    """
     return bool(_UNIFIED_DIFF_HUNK_RE.search(text or ""))
 
 
 def normalise_diff_for_compare(text: str) -> str:
-    """Strip git-only metadata + trailing whitespace for semantic comparison."""
+    """Strip git-only metadata + trailing whitespace for semantic comparison.
+
+    Args:
+        text: The diff text to normalise.
+
+    Returns:
+        The normalised diff body (git-only lines and blank lines dropped).
+    """
     body = text or ""
     for pat in _DIFF_NORMALISE_DROP_LINES:
         body = pat.sub("", body)
@@ -241,7 +289,15 @@ def normalise_diff_for_compare(text: str) -> str:
 
 
 def patch_escapes_tree(patch_text: str) -> str | None:
-    """Return the first offending path that escapes the tree, else ``None``."""
+    """Return the first offending path that escapes the tree, else ``None``.
+
+    Args:
+        patch_text: The unified-diff text to scan.
+
+    Returns:
+        The first absolute or ``..``-containing path, or ``None`` when none
+        escape the tree.
+    """
     for hit in _PATCH_PATH_RE.finditer(patch_text or ""):
         cand = hit.group("path").strip()
         if cand.startswith("/") or ".." in Path(cand).parts:
@@ -274,6 +330,9 @@ class PatchGroundingResult:
         never apply, so it is dropped before it wastes an ``integrate_patch``
         benchmark slot (unlike ``stale``, which is kept because integrate's
         ``-p`` auto-detect / 3-way merge may still salvage it).
+
+        Returns:
+            True for structural-failure verdicts that should drop the patch.
         """
         return self.verdict in (
             GROUND_NOT_DIFF, GROUND_PATH_ESCAPE, GROUND_MISSING_TARGET,
@@ -292,6 +351,15 @@ def ground_patch_text(
     ``git apply --check`` grounding runs only when ``base_checkout`` is a real
     git checkout; otherwise the result is ``GROUND_UNCHECKED`` (advisory, never
     drops the patch) so a missing base never produces a false negative.
+
+    Args:
+        patch_text: The unified-diff text to validate and ground.
+        base_checkout: Clean git checkout to ground against, or ``None`` to
+            skip the ``git apply --check`` step.
+        git_timeout_sec: Timeout for the ``git apply --check`` subprocess.
+
+    Returns:
+        The :class:`PatchGroundingResult` with the verdict and detail.
     """
     if not is_unified_diff(patch_text):
         return PatchGroundingResult(GROUND_NOT_DIFF, "no unified-diff hunk header")
@@ -339,7 +407,11 @@ class PatchSafetyReport:
     forbidden_fields: list[str] = field(default_factory=list)
 
     def notes(self) -> list[str]:
-        """Render audit notes for SpecialistRunResult / session_breakdown."""
+        """Render audit notes for SpecialistRunResult / session_breakdown.
+
+        Returns:
+            Human-readable audit note strings for the recorded findings.
+        """
         out: list[str] = []
         if self.dropped:
             out.append(
@@ -374,6 +446,13 @@ def scan_quantitative_claims(payload: dict[str, Any]) -> tuple[list[str], list[s
     Forbidden quantitative fields are a hard signal; numeric claims in the
     summary / qualitative argument are advisory warnings (the Coordinator's
     measured gain is the truth, not the claim).
+
+    Args:
+        payload: The specialist_done payload to scan.
+
+    Returns:
+        A ``(forbidden_fields_present, numeric_warning_strings)`` tuple, each
+        de-duped with order preserved.
     """
     forbidden = sorted(set((payload or {}).keys()) & FORBIDDEN_PROPOSAL_FIELDS)
     warnings: list[str] = []
@@ -405,8 +484,15 @@ def vet_patches(
 ) -> tuple[list[str], list[dict[str, str]], dict[str, str]]:
     """Ground each patch file; drop clear garbage (non-diff / path escape).
 
-    Returns ``(kept_paths, dropped_records, grounding_by_path)``. Stale-but-valid
-    patches are kept (integrate_patch + Critic adjudicate) with a grounding note.
+    Stale-but-valid patches are kept (integrate_patch + Critic adjudicate)
+    with a grounding note.
+
+    Args:
+        patch_paths: File paths of the candidate patches to vet.
+        base_checkout: Clean git checkout to ground against, or ``None``.
+
+    Returns:
+        A ``(kept_paths, dropped_records, grounding_by_path)`` tuple.
     """
     kept: list[str] = []
     dropped: list[dict[str, str]] = []

--- a/inference_optimizer/orchestrator/specialist_profile.py
+++ b/inference_optimizer/orchestrator/specialist_profile.py
@@ -80,7 +80,11 @@ class SpecialistProfile:
     def grants_bench_tool(self) -> bool:
         """True iff this dispatch may use the in-loop ``run_bench`` tool. Only
         patch-authoring specialists with ``bench=True`` qualify (bench has no
-        meaning for read-only research)."""
+        meaning for read-only research).
+
+        Returns:
+            True when the dispatch is patch-authoring with bench enabled.
+        """
         return self.mode == MODE_PATCH and self.bench
 
 
@@ -117,6 +121,13 @@ def resolve_specialist_profile(params: dict[str, Any] | None) -> SpecialistProfi
     Unknown / missing values fall back to the legacy-compatible defaults so the
     resolver never raises; PolicyGate is the place that *rejects* malformed
     dispatches, this helper only normalises for the runtime.
+
+    Args:
+        params: The dispatch params (reads ``scope`` / ``mode`` / ``bench`` /
+            ``lane``), or ``None``.
+
+    Returns:
+        The normalised :class:`SpecialistProfile`.
     """
     p = params or {}
 

--- a/inference_optimizer/orchestrator/specialist_runner.py
+++ b/inference_optimizer/orchestrator/specialist_runner.py
@@ -59,7 +59,15 @@ log = logging.getLogger(__name__)
 def _extra_focus_tags(
     params: dict[str, Any], domain: "SpecialistDomain",
 ) -> tuple[str, ...]:
-    """Knowledge-domain tags beyond the primary domain's anchor (anchor dropped to avoid double-rendering)."""
+    """Knowledge-domain tags beyond the primary domain's anchor (anchor dropped to avoid double-rendering).
+
+    Args:
+        params: The dispatch params carrying the tag list.
+        domain: The primary specialist domain whose anchor is excluded.
+
+    Returns:
+        The extra focus tags, excluding the primary domain's anchor.
+    """
     tags = normalize_dispatch_tags(params)
     primary_anchor = (domain.kb_anchor or "").strip()
     return tuple(t for t in tags if t and t != primary_anchor)
@@ -212,6 +220,13 @@ def classify_specialist_failure(
     / crash); ``empty_synthesised`` means it exited cleanly without a usable
     ``specialist_done`` (genuine empty, max-turns, or a config error encoded in
     ``error``).
+
+    Args:
+        runner_status: The :class:`SpecialistRunResult` status string.
+        error: The associated error string (drives sub-classification).
+
+    Returns:
+        A ``(failure_type, retry_eligible)`` tuple.
     """
     status = (runner_status or "").strip().lower()
     err = (error or "").strip().lower()
@@ -245,6 +260,15 @@ def build_empty_specialist_done(
 
     Satisfies PolicyGate R3 schema (``empty=true``, ``proposal_set=[]``,
     non-empty summary).
+
+    Args:
+        gap_canonical_id: Canonical id of the gap the specialist addressed.
+        domain: The specialist domain key.
+        reason: Why the specialist exited empty (becomes summary/reason).
+        confidence: Confidence score, clamped to ``[0.0, 1.0]``.
+
+    Returns:
+        The canonical empty ``specialist_done`` payload dict.
     """
     return {
         "gap_canonical_id": gap_canonical_id,
@@ -282,6 +306,19 @@ class SpecialistRunner:
         Exactly one of ``backend_factory`` (in-process, tests) /
         ``subprocess_config`` (PR-A2 ``claude`` subprocess, production) must
         be supplied. ``knowledge_plane`` gates ``mcp__pr_monitor__*`` tools.
+
+        Args:
+            backend_factory: In-process backend factory (tests path).
+            subprocess_config: Subprocess spawn config (production path).
+            session_dir: Session output directory.
+            default_tools: Default tool whitelist for specialists.
+            default_max_turns: Default per-task max turn budget.
+            per_turn_max_seconds: Per-turn wall-clock soft limit.
+            knowledge_plane: KnowledgePlane gating ``mcp__pr_monitor__*`` tools.
+
+        Raises:
+            ValueError: If neither or both of ``backend_factory`` and
+                ``subprocess_config`` are supplied.
         """
         if backend_factory is None and subprocess_config is None:
             raise ValueError(
@@ -319,6 +356,14 @@ class SpecialistRunner:
         ``Task.allowed_tools``; grants the worktree-scoped ``run_bench`` tool
         only to bench-enabled specialists (``grant_bench`` and the bench tool
         globally enabled); enforces :data:`SPECIALIST_TOOL_DENYLIST` last.
+
+        Args:
+            task_allowed_tools: Narrower per-task tool whitelist override.
+            grant_bench: When True (and bench globally enabled), grant the
+                worktree-scoped ``run_bench`` tool.
+
+        Returns:
+            The resolved per-task tool whitelist.
         """
         tools = (
             list(task_allowed_tools)
@@ -363,6 +408,14 @@ class SpecialistRunner:
 
         Never raises a Backend error past the boundary — every failure ends
         with a valid specialist_done payload (Inv-5.3 single exit).
+
+        Args:
+            ctx: The runner context for this specialist task.
+            prompt_inputs: Pre-built prompt inputs; built from ``ctx`` when
+                omitted.
+
+        Returns:
+            The :class:`SpecialistRunResult` for the task.
         """
         prep = await self._prepare(ctx, prompt_inputs=prompt_inputs)
         if prep.early_return is not None:
@@ -565,6 +618,11 @@ class SpecialistRunner:
         No-op when ``self.session_dir`` is unset (some test harnesses run
         the runner without a session dir) or the backend reported no token
         counters. Wrapped broadly so a trace failure never aborts the run.
+
+        Args:
+            task_id: The specialist task id.
+            turn: The turn index being traced.
+            metadata: Backend turn metadata carrying token counters.
         """
         if self.session_dir is None:
             return
@@ -605,6 +663,11 @@ class SpecialistRunner:
         """Append one ``conversations.jsonl`` row for an in-process specialist
         turn. Persists the full (redacted) prompt + completion the backend put
         on ``metadata``. No-op without a session dir; best-effort otherwise.
+
+        Args:
+            task_id: The specialist task id.
+            turn: The turn index being recorded.
+            metadata: Backend turn metadata carrying the prompt + response.
         """
         if self.session_dir is None:
             return
@@ -636,7 +699,15 @@ class SpecialistRunner:
         self, ctx: RunnerContext, prep: "_PreparedRun",
     ) -> SpecialistRunResult:
         """Drive ``Backend.run`` one turn at a time until a specialist_done
-        intent shows up."""
+        intent shows up.
+
+        Args:
+            ctx: The runner context for this specialist task.
+            prep: The prepared-run state (domain, gap, workspace, prompts).
+
+        Returns:
+            The :class:`SpecialistRunResult` for the task.
+        """
         assert self.backend_factory is not None  # narrowed by run()
         domain = prep.domain
         gap = prep.gap
@@ -1077,9 +1148,16 @@ class SpecialistRunner:
     ) -> tuple[Path | None, Path | None, str]:
         """Provision a per-task git worktree when in subprocess mode.
 
-        Returns ``(worktree_dir, worktree_base, error)``; empty/None in
-        in-process mode or on git failure. Best-effort: the specialist still
-        dispatches without isolation and the reason lands in ``notes``.
+        Best-effort: the specialist still dispatches without isolation and the
+        reason lands in ``notes``.
+
+        Args:
+            ctx: The runner context for this specialist task.
+            workspace: The task workspace the worktree is created under.
+
+        Returns:
+            A ``(worktree_dir, worktree_base, error)`` tuple; ``worktree_dir``
+            is ``None`` in in-process/readonly mode or on git failure.
         """
         if self.subprocess_config is None or workspace is None:
             return None, None, ""

--- a/inference_optimizer/orchestrator/specialist_subprocess.py
+++ b/inference_optimizer/orchestrator/specialist_subprocess.py
@@ -139,6 +139,12 @@ def _pick_worktree_base(roots: tuple[str, ...]) -> Path | None:
 
     Falls back to None when none exist — the runner then runs the
     specialist without an isolated worktree.
+
+    Args:
+        roots: Candidate root paths to probe for a ``.git`` marker.
+
+    Returns:
+        The first git-checkout root, or ``None`` when none qualify.
     """
     for r in roots:
         p = Path(r)
@@ -159,6 +165,15 @@ def _setup_worktree(
 
     Best-effort: on git error returns ``(None, err)`` so the caller can
     proceed without isolation (PR-A2 default) or hard-fail.
+
+    Args:
+        base: Git checkout the worktree is branched off of.
+        worktree_path: Destination path for the new worktree.
+        branch: Branch name to create for the worktree.
+
+    Returns:
+        A ``(worktree_path, "")`` tuple on success, or ``(None, error)`` on
+        git failure.
     """
     if worktree_path.exists():
         # Resume / retry: reuse an existing worktree (stale ones are rare).
@@ -191,6 +206,10 @@ def _teardown_worktree(base: Path | None, worktree_path: Path) -> None:
 
     Called only on the REVERT / synth-empty path; the KEEP path leaves the
     worktree in place so ``integrate_patch`` can pull patches out of it.
+
+    Args:
+        base: Git checkout the worktree was created from, or ``None``.
+        worktree_path: Path of the worktree to remove.
     """
     if not worktree_path.exists():
         return

--- a/inference_optimizer/orchestrator/sub_agent_runner.py
+++ b/inference_optimizer/orchestrator/sub_agent_runner.py
@@ -116,6 +116,13 @@ class SubAgentRunner:
 
         Returns the path (stashed on ``RunnerContext.extra``) or None when
         the task kind is not a known runs/ action.
+
+        Args:
+            task: The task whose workspace directory should be pre-created.
+
+        Returns:
+            The created workspace path, or ``None`` when there is no session
+            dir or the task kind is not a known runs/ action.
         """
         if self.session_dir is None:
             return None
@@ -139,6 +146,16 @@ class SubAgentRunner:
         Bug-fix N34: a long-running task's row can vanish before its terminal
         transition; swallowing TaskNotFound keeps the pipeline running.
         Returns True on success, False on the swallowed-TaskNotFound branch.
+
+        Args:
+            task_id: The task to transition.
+            new_state: The target state.
+            evidence: Optional evidence dict recorded with the transition.
+            context: Short label describing the transition call site.
+
+        Returns:
+            ``True`` on success, ``False`` on the swallowed-``TaskNotFound``
+            branch.
         """
         try:
             await self.tasks.transition(task_id, new_state, evidence=evidence or {})
@@ -165,6 +182,16 @@ class SubAgentRunner:
         Always transitions to ``running`` first (state machine constraint).
         With ``prebound_lease`` the runner skips its own acquire but still
         owns the release in its finally block.
+
+        Args:
+            task: The task to execute.
+            prebound_lease: Optional already-acquired lease; when given, the
+                runner skips its own acquire but still releases it.
+            extra_context: Optional extra values merged into the
+                :class:`RunnerContext`.
+
+        Returns:
+            The :class:`SubAgentResult` capturing terminal state and payload.
         """
         # queued → running first (state machine constraint).
         await self._transition_resilient(

--- a/inference_optimizer/orchestrator/system_prompts/critic_prompt_builder.py
+++ b/inference_optimizer/orchestrator/system_prompts/critic_prompt_builder.py
@@ -99,7 +99,11 @@ def _section_run_context(
 
 def _section_phase_review_contract() -> list[str]:
     """Static phase-aware verdict contract (v0.8 §3.3 §4.3); mirrors
-    ``phase_state.PHASE_LLM_PROPOSABLE_ACTIONS`` (PolicyGate R1)."""
+    ``phase_state.PHASE_LLM_PROPOSABLE_ACTIONS`` (PolicyGate R1).
+
+    Returns:
+        The rendered phase-review-contract lines.
+    """
     from ..phase_state import (
         PHASE_NAMES,
         is_phase_interleave_enabled,
@@ -333,20 +337,20 @@ def build_critic_prompt(
 ) -> str:
     """Compose the Critic system prompt (deterministic for given inputs).
 
-    Parameters
-    ----------
-    action_registry:
-        Pre-loaded ``ActionRegistry`` (caller calls ``.load()``).
-    enabled_actions:
-        Action names enabled for this run (same set as orchestration).
-    framework:
-        ``sglang`` / ``vllm`` / ``atom`` — printed in RUN CONTEXT verbatim.
-    kernel_enabled:
-        ``None`` derives from whether any KERNEL_OWNED action is enabled.
-    max_minutes:
-        Wall-clock budget for the run.
-    rules_fragment_path:
-        Path to ``critic.md`` rules fragment.
+    Args:
+        action_registry: Pre-loaded ``ActionRegistry`` (caller calls
+            ``.load()``).
+        enabled_actions: Action names enabled for this run (same set as
+            orchestration).
+        framework: ``sglang`` / ``vllm`` / ``atom`` — printed in RUN CONTEXT
+            verbatim.
+        kernel_enabled: ``None`` derives from whether any KERNEL_OWNED action
+            is enabled.
+        max_minutes: Wall-clock budget for the run.
+        rules_fragment_path: Path to the ``critic.md`` rules fragment.
+
+    Returns:
+        The composed Critic system prompt string.
     """
     actions = _filter_actions(action_registry, enabled_actions)
     if kernel_enabled is None:

--- a/inference_optimizer/orchestrator/system_prompts/prompt_builder.py
+++ b/inference_optimizer/orchestrator/system_prompts/prompt_builder.py
@@ -135,7 +135,14 @@ def _section_session_context(
 
 def _section_phase_semantics(*, kernel_enabled: bool) -> list[str]:
     """Render the per-phase allowed-action contract (current phase injected
-    dynamically by the Coordinator)."""
+    dynamically by the Coordinator).
+
+    Args:
+        kernel_enabled: Whether kernel-owned actions are enabled.
+
+    Returns:
+        The rendered phase-contract lines.
+    """
     from ..phase_state import (
         PHASE_NAMES,
         is_phase_interleave_enabled,
@@ -227,7 +234,15 @@ def _filter_actions(
 
 
 def _phase_eta_summary(actions: list[ActionMetadata]) -> list[tuple[str, float, list[str]]]:
-    """Group actions by phase in _PHASE_ORDER; return (phase, eta_min_sum, names)."""
+    """Group actions by phase in _PHASE_ORDER; return (phase, eta_min_sum, names).
+
+    Args:
+        actions: The action metadata to group.
+
+    Returns:
+        Per-phase ``(phase, eta_min_sum, action_names)`` tuples ordered by
+        ``_PHASE_ORDER`` with any unranked phases appended.
+    """
     bucket: dict[str, list[ActionMetadata]] = {}
     for a in actions:
         bucket.setdefault(a.pipeline_phase, []).append(a)
@@ -366,7 +381,14 @@ def _format_emit_hint(meta: ActionMetadata) -> str:
 
 
 def _format_grid_injection_hint(name: str) -> str | None:
-    """Return a per-action one-liner showing how to override grid, or None."""
+    """Return a per-action one-liner showing how to override grid, or None.
+
+    Args:
+        name: The action name to render a grid-injection hint for.
+
+    Returns:
+        The grid-injection hint line, or ``None`` when the action has none.
+    """
     if name == "explore":
         return (
             "GRID INPUT (v0.8 M3, REQUIRED): emit "
@@ -770,15 +792,23 @@ def build_orchestration_prompt(
 ) -> str:
     """Compose the Orchestration system prompt (deterministic for given inputs).
 
-    Parameters
-    ----------
-    action_registry: pre-loaded ``ActionRegistry`` (caller calls ``.load()``).
-    enabled_actions: enabled action names; final ordering is by pipeline_phase.
-    framework: ``sglang`` / ``vllm`` — printed in SESSION CONTEXT.
-    kernel_enabled: explicit override; ``None`` derives from KERNEL_OWNED actions.
-    objective_kind / objective_value: :mod:`objective` strings, printed verbatim.
-    max_minutes: wall-clock budget for the run.
-    rules_fragment_path: path to ``orchestration.md``; placeholder if unreadable.
+    Args:
+        action_registry: Pre-loaded ``ActionRegistry`` (caller calls ``.load()``).
+        enabled_actions: Enabled action names; final ordering is by
+            pipeline_phase.
+        framework: ``sglang`` / ``vllm`` — printed in SESSION CONTEXT.
+        kernel_enabled: Explicit override; ``None`` derives from KERNEL_OWNED
+            actions.
+        objective_kind: :mod:`objective` kind string, printed verbatim.
+        objective_value: :mod:`objective` value, printed verbatim.
+        max_minutes: Wall-clock budget for the run.
+        rules_fragment_path: Path to ``orchestration.md``; placeholder if
+            unreadable.
+        framework_source_roots: Framework source roots printed in SESSION
+            CONTEXT.
+
+    Returns:
+        The composed Orchestration system prompt string.
     """
     actions = _filter_actions(action_registry, enabled_actions)
     if kernel_enabled is None:

--- a/inference_optimizer/orchestrator/system_prompts/specialist_prompt_builder.py
+++ b/inference_optimizer/orchestrator/system_prompts/specialist_prompt_builder.py
@@ -39,7 +39,14 @@ from inference_optimizer.orchestrator.policy import (
 
 def _is_atom(inp: SpecialistPromptInputs) -> bool:
     """True when ``_focus_*`` blocks should use atom-flavoured hints
-    (empty framework falls back to the canonical sglang/vllm block)."""
+    (empty framework falls back to the canonical sglang/vllm block).
+
+    Args:
+        inp: The specialist prompt inputs.
+
+    Returns:
+        True when the framework is ``atom``.
+    """
     return (inp.framework or "").strip().lower() == "atom"
 
 
@@ -631,7 +638,14 @@ def _auto_retry_note_block(inp: SpecialistPromptInputs) -> list[str]:
     """Heads-up block when this dispatch is a bounded auto-retry of a prior
     transient (timeout / crash / stale-heartbeat) attempt. Advisory only —
     the mandate is unchanged; the note nudges the specialist to scope its work
-    so it finishes within budget this time."""
+    so it finishes within budget this time.
+
+    Args:
+        inp: The specialist prompt inputs (reads ``auto_retry_reason``).
+
+    Returns:
+        The rendered auto-retry notice lines.
+    """
     reason = inp.auto_retry_reason.strip()
     return [
         "",
@@ -651,7 +665,15 @@ def _auto_retry_note_block(inp: SpecialistPromptInputs) -> list[str]:
 def _bench_block(inp: SpecialistPromptInputs) -> list[str]:
     """In-loop micro-bench mandate appended for bench-enabled specialists
     (``mode=patch`` & ``bench=true``). Lists the whitelisted ``bench_id``s and
-    the worktree-scoped contract; the ``run_bench`` tool executes them."""
+    the worktree-scoped contract; the ``run_bench`` tool executes them.
+
+    Args:
+        inp: The specialist prompt inputs.
+
+    Returns:
+        The rendered micro-bench mandate lines, or ``[]`` when no benches are
+        registered.
+    """
     from ..specialist_bench import BENCH_REGISTRY, MAX_BENCH_WALL_CLOCK_SEC
     if not BENCH_REGISTRY:
         return []
@@ -683,7 +705,14 @@ def _freeform_block(inp: SpecialistPromptInputs) -> list[str]:
     """Free-form mandate appended when ``scope == 'freeform'`` (absorbed from
     the retired dynamic_specialist wave channel). The specialist is NOT bound
     to the domain catalogue — the Orchestration ``task_description`` is the
-    whole mandate. The single deliverable is still ONE ``specialist_done``."""
+    whole mandate. The single deliverable is still ONE ``specialist_done``.
+
+    Args:
+        inp: The specialist prompt inputs (reads ``task_description``).
+
+    Returns:
+        The rendered free-form mandate lines.
+    """
     desc = (inp.task_description or "").strip() or "(no task description provided)"
     return [
         "",
@@ -709,7 +738,15 @@ def _cross_domain_block(inp: SpecialistPromptInputs) -> list[str]:
     """Cross-domain mandate appended when ``scope == 'domains'`` (absorbed
     from the retired dynamic_action channel). The single deliverable is still
     ONE ``specialist_done``; the difference is the patch may span every domain
-    in scope and the Critic will hold it to the cross-domain rules."""
+    in scope and the Critic will hold it to the cross-domain rules.
+
+    Args:
+        inp: The specialist prompt inputs (reads ``extra_focus_tags`` /
+            ``domain``).
+
+    Returns:
+        The rendered cross-domain mandate lines.
+    """
     tags = ", ".join(inp.extra_focus_tags) if inp.extra_focus_tags else inp.domain.key
     return [
         "",
@@ -829,7 +866,14 @@ def _section_gap(inp: SpecialistPromptInputs) -> list[str]:
 # Section 4 — optional KB context
 def _is_cold_start(inp: SpecialistPromptInputs) -> bool:
     """Issue-J: all prior sources empty, so inject a cold-start directive
-    instead of letting specialists return an empty proposal_set."""
+    instead of letting specialists return an empty proposal_set.
+
+    Args:
+        inp: The specialist prompt inputs.
+
+    Returns:
+        True when every prior KB/PR/research source is empty.
+    """
     return (
         not inp.kb_subgraph
         and not inp.warm_start_recipe
@@ -920,7 +964,14 @@ def _section_kb_subgraph(inp: SpecialistPromptInputs) -> list[str]:
 # Section 4a — Roofline / TraceLens evidence
 def _section_roofline_evidence(inp: SpecialistPromptInputs) -> list[str]:
     """Render the ROOFLINE EVIDENCE section from ``inp.roofline_evidence``;
-    empty evidence renders a heading + ``(none)`` placeholder."""
+    empty evidence renders a heading + ``(none)`` placeholder.
+
+    Args:
+        inp: The specialist prompt inputs (reads ``roofline_evidence``).
+
+    Returns:
+        The rendered roofline-evidence section lines.
+    """
     rows = ["## 4a. ROOFLINE EVIDENCE", ""]
     ev = inp.roofline_evidence or {}
     if not isinstance(ev, dict) or not ev:
@@ -1074,7 +1125,14 @@ def _section_recipe(inp: SpecialistPromptInputs) -> list[str]:
 # Section 5b — Related lessons (positive priors from prior KEEPs)
 def _section_lessons(inp: SpecialistPromptInputs) -> list[str]:
     """Render KB ``kind=lesson`` points from prior KEEPs, compactly
-    (statement + measured_impact)."""
+    (statement + measured_impact).
+
+    Args:
+        inp: The specialist prompt inputs (reads ``warm_start_lessons``).
+
+    Returns:
+        The rendered related-lessons section lines.
+    """
     rows = ["## 5b. RELATED LESSONS (prior KEEPs on this model+hw)", ""]
     if not inp.warm_start_lessons:
         rows.append(_NONE_PLACEHOLDER)
@@ -1117,7 +1175,16 @@ def _format_version_note(
 ) -> str:
     """GAP 8 — render a ``[from sglang@X.Y, you're on A.B]`` annotation when
     the lesson's framework_version differs; empty when either side is
-    unknown or they match."""
+    unknown or they match.
+
+    Args:
+        inp: The specialist prompt inputs (reads ``framework`` /
+            ``framework_version``).
+        lesson_attrs: The lesson's attrs (reads ``framework_version``).
+
+    Returns:
+        The version-mismatch annotation, or "" when unknown or matching.
+    """
     lesson_fv = str(lesson_attrs.get("framework_version") or "").strip()
     current_fv = (inp.framework_version or "").strip()
     if not lesson_fv or not current_fv:
@@ -1130,7 +1197,14 @@ def _format_version_note(
 
 def _render_measured_impact(raw: Any) -> str:
     """Back-compat renderer for ``attrs.measured_impact`` (dict, legacy
-    string, or other)."""
+    string, or other).
+
+    Args:
+        raw: The ``measured_impact`` value (dict, string, None, or other).
+
+    Returns:
+        A compact human-readable impact string ("" when ``raw`` is None).
+    """
     if isinstance(raw, dict):
         parts: list[str] = []
         gain = raw.get("gain_pct")
@@ -1156,7 +1230,14 @@ def _render_measured_impact(raw: Any) -> str:
 # Section 5c — Known pitfalls (anti-priors from prior REVERTs)
 def _section_pitfalls(inp: SpecialistPromptInputs) -> list[str]:
     """Render KB ``kind=pitfall`` points from prior REVERTs (description +
-    severity); framed as forbidden paths, not suggestions."""
+    severity); framed as forbidden paths, not suggestions.
+
+    Args:
+        inp: The specialist prompt inputs (reads ``warm_start_pitfalls``).
+
+    Returns:
+        The rendered known-pitfalls section lines.
+    """
     rows = ["## 5c. KNOWN PITFALLS (do NOT repeat — prior REVERTs)", ""]
     if not inp.warm_start_pitfalls:
         rows.append(_NONE_PLACEHOLDER)

--- a/inference_optimizer/orchestrator/task_registry.py
+++ b/inference_optimizer/orchestrator/task_registry.py
@@ -158,7 +158,22 @@ class TaskRegistry:
         lease_ttl_sec: int = 0,
         task_id: str | None = None,
     ) -> tuple[Task, bool]:
-        """Insert a new task row OR return the existing one keyed by idempotency_key. Returns ``(task, was_existing)``."""
+        """Insert a new task row OR return the existing one keyed by idempotency_key. Returns ``(task, was_existing)``.
+
+        Args:
+            kind: Task kind tag.
+            params: Task parameters serialised into the row.
+            idempotency_key: Key used to detect and return an existing task.
+            requires_lanes: Lanes the task must hold while running.
+            allowed_tools: Tools the task is permitted to use.
+            side_effects: Declared side effects of the task.
+            lease_ttl_sec: Lease time-to-live in seconds.
+            task_id: Optional explicit task id; generated when omitted.
+
+        Returns:
+            A tuple ``(task, was_existing)`` where ``was_existing`` is ``True``
+            when a task with the same idempotency key already existed.
+        """
         existing = await self.db.fetchone(
             "SELECT * FROM tasks WHERE idempotency_key=?", (idempotency_key,)
         )
@@ -220,7 +235,21 @@ class TaskRegistry:
         lease_ttl_sec: int = 0,
         task_id: str | None = None,
     ) -> Task:
-        """Thin wrapper around :meth:`create_or_return_existing` for callers that don't need ``was_existing``."""
+        """Thin wrapper around :meth:`create_or_return_existing` for callers that don't need ``was_existing``.
+
+        Args:
+            kind: Task kind tag.
+            params: Task parameters serialised into the row.
+            idempotency_key: Key used to detect and return an existing task.
+            requires_lanes: Lanes the task must hold while running.
+            allowed_tools: Tools the task is permitted to use.
+            side_effects: Declared side effects of the task.
+            lease_ttl_sec: Lease time-to-live in seconds.
+            task_id: Optional explicit task id; generated when omitted.
+
+        Returns:
+            The created or pre-existing ``Task``.
+        """
         task, _was_existing = await self.create_or_return_existing(
             kind=kind,
             params=params,
@@ -352,7 +381,14 @@ class TaskRegistry:
         return [Task.from_row(r) for r in rows]
 
     async def cancel_family(self, family_kinds: list[str]) -> list[str]:
-        """Bulk-cancel queued tasks of the given kinds (Robustness prune_branch); returns cancelled task_ids."""
+        """Bulk-cancel queued tasks of the given kinds (Robustness prune_branch); returns cancelled task_ids.
+
+        Args:
+            family_kinds: Task kinds whose queued tasks should be cancelled.
+
+        Returns:
+            The task ids that were cancelled (empty when none matched).
+        """
         if not family_kinds:
             return []
         cancelled: list[str] = []

--- a/inference_optimizer/orchestrator/trace/conversation_trace.py
+++ b/inference_optimizer/orchestrator/trace/conversation_trace.py
@@ -93,6 +93,12 @@ def redact_secrets(text: str) -> str:
     redacted line still reads sensibly, only the secret material is
     replaced with ``[REDACTED]``. Returns ``text`` unchanged when it
     carries no recognizable secret shape.
+
+    Args:
+        text: Raw text that may embed secret values.
+
+    Returns:
+        The text with recognizable secret values replaced by ``[REDACTED]``.
     """
     if not text:
         return text
@@ -144,7 +150,14 @@ def _coerce_optional_int(value: Any) -> int | None:
 
 
 def _coerce_text(value: Any) -> str:
-    """Normalize a prompt / response field to a (possibly empty) string."""
+    """Normalize a prompt / response field to a (possibly empty) string.
+
+    Args:
+        value: Arbitrary prompt/response value.
+
+    Returns:
+        The value as a string, or ``""`` when ``None``.
+    """
     if value is None:
         return ""
     return value if isinstance(value, str) else str(value)
@@ -173,7 +186,11 @@ class ConversationRecord:
 
     def to_row(self) -> dict[str, Any]:
         """Serialize to the on-disk row dict, stamping ``ts`` and redacting
-        the prompt / response text."""
+        the prompt / response text.
+
+        Returns:
+            The on-disk conversation row dict.
+        """
         return {
             "session_id": str(self.session_id),
             "ts": _now_iso(),
@@ -191,7 +208,15 @@ class ConversationRecord:
 
 
 def _validate_row(row: dict[str, Any]) -> None:
-    """Fail fast if ``row`` deviates from the closed schema."""
+    """Fail fast if ``row`` deviates from the closed schema.
+
+    Args:
+        row: A serialized conversation row dict.
+
+    Raises:
+        ConversationRowError: If the row has extra/missing fields, an empty
+            ``session_id``, or an unknown ``component``.
+    """
     keys = set(row.keys())
     extra = sorted(keys - _ROW_FIELDS)
     missing = sorted(_ROW_FIELDS - keys)
@@ -229,6 +254,15 @@ def append_conversation(
 
     A schema violation (:class:`ConversationRowError`) is *not* swallowed:
     that is a programming error at the call site and must surface in tests.
+
+    Args:
+        session_dir: Session directory used to resolve the ledger path.
+        record: The conversation record to serialize and append.
+        target: Optional override destination (e.g. an ext shard path);
+            defaults to the session's conversations ledger.
+
+    Raises:
+        ConversationRowError: If the serialized row violates the schema.
     """
     row = record.to_row()
     _validate_row(row)

--- a/inference_optimizer/orchestrator/trace/langfuse_emitter.py
+++ b/inference_optimizer/orchestrator/trace/langfuse_emitter.py
@@ -78,7 +78,11 @@ def _receipt_path(session_dir: Path) -> Path:
 
 
 def _sdk_available() -> bool:
-    """Whether the optional ``langfuse`` SDK can be imported (no side effects)."""
+    """Whether the optional ``langfuse`` SDK can be imported (no side effects).
+
+    Returns:
+        True when the ``langfuse`` SDK is importable.
+    """
     import importlib.util
 
     try:
@@ -93,6 +97,12 @@ def _to_ns(dt: Any) -> int | None:
     v4's OTEL-based SDK wants integer ns for ``end_time``; v2/v3 accepted a
     ``datetime``. Returns None for a None/zero input so callers can omit the
     kwarg entirely. Best-effort: an unparseable value yields None.
+
+    Args:
+        dt: A ``datetime`` (or other value) to convert.
+
+    Returns:
+        Integer nanoseconds since epoch, or ``None`` when not convertible.
     """
     if dt is None:
         return None
@@ -115,6 +125,13 @@ def _start_obs(parent: Any, **kwargs: Any) -> Any:
     TypeError, retry without it. This keeps backdated timestamps where the
     SDK supports them and degrades to "start = now" only on the SDKs that
     require it, instead of unconditionally dropping the timestamp.
+
+    Args:
+        parent: The client or span to create the observation under.
+        **kwargs: Observation kwargs forwarded to ``start_observation``.
+
+    Returns:
+        The created observation object.
     """
     try:
         return parent.start_observation(**kwargs)
@@ -132,6 +149,12 @@ def _end_time_wants_int(obs: Any) -> bool:
     OTEL span, so a "try datetime then retry int" pattern double-ends the
     span and emits a noisy "Calling end() on an ended span" warning.
     Falls back to datetime (False) when the annotation can't be read.
+
+    Args:
+        obs: The observation whose ``end`` signature is inspected.
+
+    Returns:
+        True when ``end(end_time=...)`` expects integer nanoseconds.
     """
     try:
         import inspect
@@ -150,6 +173,10 @@ def _end_obs(obs: Any, end_dt: Any) -> None:
     Picks the right ``end_time`` type up front (see :func:`_end_time_wants_int`)
     so the span is never ended twice. Falls back to a bare ``end()`` if the
     typed call is rejected, so a signature change can't strand an open span.
+
+    Args:
+        obs: The observation to end (no-op when ``None``).
+        end_dt: The end ``datetime``, or ``None`` for a bare ``end()``.
     """
     if obs is None:
         return
@@ -178,6 +205,12 @@ def _otel_attr_value(v: Any) -> Any:
     the SDK log ``Invalid type ... for attribute`` and drop it. So: skip
     ``None``, pass scalars through, and JSON-stringify everything else
     (e.g. the ``workload`` dict) so it still lands on the trace as text.
+
+    Args:
+        v: The metadata value to coerce.
+
+    Returns:
+        An OTEL-acceptable scalar/string, or ``None`` to skip the attribute.
     """
     if v is None:
         return None
@@ -205,6 +238,12 @@ def _set_trace_attrs(
     attributes directly on the underlying span (``langfuse.trace.name``,
     ``session.id``, ``langfuse.trace.metadata.*``). Best-effort: a missing
     API on either side just means the trace label isn't set, never a raise.
+
+    Args:
+        span: The root span whose trace attributes are stamped.
+        name: Trace name to set, when provided.
+        session_id: Langfuse session id to set, when provided.
+        metadata: Trace-level metadata to stamp, when provided.
     """
     try:
         span.update_trace(name=name, session_id=session_id, metadata=metadata)
@@ -352,6 +391,9 @@ class LangfuseEmitter:
         Records ``_disabled_reason`` (``disabled`` / ``no_credentials`` /
         ``sdk_missing`` / ``init_failed``) so the receipt can explain *why*
         nothing was pushed. Correlation is already resolved in ``__init__``.
+
+        Returns:
+            True when all gates pass and the client was built, else False.
         """
         if not langfuse_live_enabled():
             self._disabled_reason = "disabled"
@@ -389,7 +431,11 @@ class LangfuseEmitter:
 
     @property
     def enabled(self) -> bool:
-        """Whether live push to Langfuse is enabled for this session."""
+        """Whether live push to Langfuse is enabled for this session.
+
+        Returns:
+            True when live push is enabled.
+        """
         return self._enabled
 
     # -- span hierarchy (trace -> phase -> agent -> generation) ---------
@@ -402,7 +448,14 @@ class LangfuseEmitter:
         return str(self._manifest.get("model_name") or self._session_label or "hyperloom")
 
     def _ensure_root(self, start: Any) -> Any:
-        """Lazily open the root span and stamp trace-level attrs once."""
+        """Lazily open the root span and stamp trace-level attrs once.
+
+        Args:
+            start: Span start time.
+
+        Returns:
+            The cached or newly opened root span.
+        """
         if self._root_span is None:
             self._root_span = _start_obs(
                 self._client,
@@ -446,7 +499,16 @@ class LangfuseEmitter:
 
     def _ensure_agent_span(self, phase: str, agent: str, start: Any) -> Any:
         """Get-or-create the per-(phase, agent) span. This is the 'which agent
-        did what' layer; Generations and decision Scores attach here."""
+        did what' layer; Generations and decision Scores attach here.
+
+        Args:
+            phase: Phase name.
+            agent: Agent/component name.
+            start: Span start time.
+
+        Returns:
+            The cached or newly opened agent span.
+        """
         key = (phase, agent)
         span = self._agent_spans.get(key)
         if span is None:
@@ -462,7 +524,11 @@ class LangfuseEmitter:
 
     # -- live ingest ----------------------------------------------------
     def record_llm_call(self, row: dict[str, Any]) -> None:
-        """Buffer a token row; emit the Generation if its text half is in."""
+        """Buffer a token row; emit the Generation if its text half is in.
+
+        Args:
+            row: The token (``llm_calls``) trace row.
+        """
         if not self._enabled:
             return
         try:
@@ -471,7 +537,11 @@ class LangfuseEmitter:
             log.debug("langfuse: record_llm_call failed", exc_info=True)
 
     def record_conversation(self, row: dict[str, Any]) -> None:
-        """Buffer a conversation row; emit the Generation if its tokens are in."""
+        """Buffer a conversation row; emit the Generation if its tokens are in.
+
+        Args:
+            row: The conversation trace row.
+        """
         if not self._enabled:
             return
         try:
@@ -505,7 +575,12 @@ class LangfuseEmitter:
         token_row: dict[str, Any] | None,
         conv_row: dict[str, Any] | None,
     ) -> None:
-        """Emit one Generation, nested under its phase -> agent span."""
+        """Emit one Generation, nested under its phase -> agent span.
+
+        Args:
+            token_row: The token half of the call, or ``None``.
+            conv_row: The conversation (text) half of the call, or ``None``.
+        """
         base = token_row or conv_row or {}
         phase = lfmap.phase_of(base)
         agent = lfmap.agent_of(base)
@@ -685,6 +760,9 @@ class LangfuseEmitter:
         is True once :meth:`flush_session` has run (so the out-of-process ext
         shards and decision scores are reflected); before that it reports the
         in-process running totals.
+
+        Returns:
+            A redacted receipt dict mirroring the breakdown ``langfuse`` section.
         """
         creds = langfuse_credentials()
         config = {
@@ -737,7 +815,14 @@ _REGISTRY_LOCK = threading.Lock()
 
 
 def get_emitter(session_dir: Path) -> LangfuseEmitter:
-    """Return the per-session emitter, building it once (cached by session)."""
+    """Return the per-session emitter, building it once (cached by session).
+
+    Args:
+        session_dir: Session directory keying the emitter.
+
+    Returns:
+        The cached or newly built :class:`LangfuseEmitter`.
+    """
     key = str(Path(session_dir).resolve())
     with _REGISTRY_LOCK:
         emitter = _REGISTRY.get(key)
@@ -748,7 +833,11 @@ def get_emitter(session_dir: Path) -> LangfuseEmitter:
 
 
 def flush_session(session_dir: Path) -> None:
-    """Module-level convenience: flush the emitter for ``session_dir``."""
+    """Module-level convenience: flush the emitter for ``session_dir``.
+
+    Args:
+        session_dir: Session directory whose emitter is flushed.
+    """
     get_emitter(session_dir).flush_session()
 
 
@@ -759,6 +848,12 @@ def read_receipt(session_dir: Path) -> dict[str, Any] | None:
     collector, since its counts are final) or ``None`` if no receipt was
     written -- e.g. the breakdown is being assembled before ``flush_session``
     ran, or live push never happened.
+
+    Args:
+        session_dir: Session directory whose receipt is read.
+
+    Returns:
+        The receipt dict, or ``None`` when no receipt was written.
     """
     import json
 

--- a/inference_optimizer/orchestrator/trace/langfuse_mapping.py
+++ b/inference_optimizer/orchestrator/trace/langfuse_mapping.py
@@ -38,6 +38,13 @@ def correlation_seed(manifest: dict[str, Any], fallback: str) -> str:
     and any future claw-side upload -- collapses onto the same Langfuse trace
     / session view. Falls back to the internal session id (e.g. the session
     dir name) for standalone/local runs where no claw id exists.
+
+    Args:
+        manifest: Session manifest dict carrying id fields.
+        fallback: Seed used when no id is present in the manifest.
+
+    Returns:
+        The chosen correlation seed string.
     """
     claw = str(manifest.get("claw_session_id") or "").strip()
     if claw:
@@ -52,6 +59,13 @@ def langfuse_session_id(manifest: dict[str, Any], fallback: str) -> str:
     Same precedence as :func:`correlation_seed` (claw id wins) -- this is the
     human-facing session grouping in the Langfuse UI, whereas the trace_id is
     its hashed form.
+
+    Args:
+        manifest: Session manifest dict carrying id fields.
+        fallback: Seed used when no id is present in the manifest.
+
+    Returns:
+        The Langfuse session grouping id.
     """
     return correlation_seed(manifest, fallback)
 
@@ -63,17 +77,37 @@ def agent_of(row: dict[str, Any]) -> str:
     specialist / critic / geak / oob / robustness / proposal_scorer /
     tracelens / breakdown); it is the "which agent did this" axis used for the
     per-agent span layer.
+
+    Args:
+        row: A trace row dict.
+
+    Returns:
+        The producing agent name, or ``UNKNOWN_AGENT`` when absent.
     """
     return str(row.get("component") or row.get("role") or UNKNOWN_AGENT)
 
 
 def phase_of(row: dict[str, Any]) -> str:
-    """The phase a row belongs to (``(unphased)`` when absent)."""
+    """The phase a row belongs to (``(unphased)`` when absent).
+
+    Args:
+        row: A trace row dict.
+
+    Returns:
+        The phase name, or ``UNPHASED`` when absent.
+    """
     return str(row.get("phase") or UNPHASED)
 
 
 def span_key(row: dict[str, Any]) -> tuple[str, str]:
-    """(phase, agent) key identifying which agent-span a Generation nests in."""
+    """(phase, agent) key identifying which agent-span a Generation nests in.
+
+    Args:
+        row: A trace row dict.
+
+    Returns:
+        A ``(phase, agent)`` tuple.
+    """
     return (phase_of(row), agent_of(row))
 
 
@@ -83,6 +117,12 @@ def derive_trace_id(seed: str) -> str:
     Langfuse trace ids must be 32-char lowercase hex; deriving from the
     session id keeps re-runs / live+backfill of the same session writing to
     one trace instead of duplicating it.
+
+    Args:
+        seed: Session id or any seed string to hash.
+
+    Returns:
+        A 32-char lowercase hex trace id.
     """
     return hashlib.sha256(str(seed).encode("utf-8")).hexdigest()[:32]
 
@@ -92,6 +132,12 @@ def parse_ts(ts: str | None) -> datetime | None:
 
     Returns ``None`` for missing / unparseable input so callers can fall
     back to a span/trace-level time without crashing.
+
+    Args:
+        ts: Timestamp string in ISO+offset or ``...Z`` form, or ``None``.
+
+    Returns:
+        The parsed ``datetime``, or ``None`` when missing/unparseable.
     """
     if not ts:
         return None
@@ -107,6 +153,12 @@ def utc_second_key(ts: str | None) -> str:
     ``llm_calls.jsonl`` and ``conversations.jsonl`` stamp their own ``ts`` a
     few milliseconds apart for the same logical call, so pairing is done at
     whole-second resolution.
+
+    Args:
+        ts: Timestamp string, or ``None``.
+
+    Returns:
+        The UTC second key string, or ``""`` when unparseable.
     """
     dt = parse_ts(ts)
     if dt is None:
@@ -128,6 +180,12 @@ def pair_key(row: dict[str, Any]) -> tuple:
     ``asyncio.gather``, so multiple rows land in the same second with
     otherwise identical keys. Older rows that predate any field carry
     ``None``, so the key degrades gracefully to the previous behaviour.
+
+    Args:
+        row: A token or conversation trace row dict.
+
+    Returns:
+        A tuple join key pairing the row across streams.
     """
     return (
         str(row.get("component") or ""),
@@ -147,6 +205,12 @@ def usage_details(row: dict[str, Any]) -> dict[str, int]:
     Drops ``None`` counters (so an unreported counter is absent rather than
     a misleading zero) and maps our canonical names onto the short Langfuse
     keys.
+
+    Args:
+        row: A token trace row dict.
+
+    Returns:
+        Mapping of Langfuse usage key to integer count (``None`` dropped).
     """
     raw = {
         "input": row.get("input_tokens"),
@@ -158,14 +222,30 @@ def usage_details(row: dict[str, Any]) -> dict[str, int]:
 
 
 def generation_name(row: dict[str, Any]) -> str:
-    """Human-friendly Generation name: component, falling back to role."""
+    """Human-friendly Generation name: component, falling back to role.
+
+    Args:
+        row: A token trace row dict.
+
+    Returns:
+        The Generation display name.
+    """
     return str(row.get("component") or row.get("role") or "llm_call")
 
 
 def generation_metadata(
     row: dict[str, Any], *, phase: str, has_text: bool,
 ) -> dict[str, Any]:
-    """Assemble the per-Generation metadata block (join keys + flags)."""
+    """Assemble the per-Generation metadata block (join keys + flags).
+
+    Args:
+        row: A token trace row dict.
+        phase: Phase name to stamp onto the metadata.
+        has_text: Whether a paired conversation text was found.
+
+    Returns:
+        The per-Generation metadata dict.
+    """
     return {
         "phase": phase,
         "tick": row.get("tick"),
@@ -179,7 +259,14 @@ def generation_metadata(
 
 
 def trace_metadata(manifest: dict[str, Any]) -> dict[str, Any]:
-    """Assemble the trace-level metadata block from ``manifest.json``."""
+    """Assemble the trace-level metadata block from ``manifest.json``.
+
+    Args:
+        manifest: Parsed ``manifest.json`` dict.
+
+    Returns:
+        The trace-level metadata dict.
+    """
     workload = manifest.get("workload") or {}
     return {
         "model_name": manifest.get("model_name"),
@@ -204,6 +291,12 @@ def decision_to_scores(decision_row: dict[str, Any]) -> list[dict[str, Any]]:
     carries a measured gain. Each returned dict is transport-agnostic
     (``name`` / ``value`` / ``data_type`` / ``comment`` / ``metadata``) so the
     caller can hand it to the SDK or a REST body unchanged.
+
+    Args:
+        decision_row: One ``decision_trace.jsonl`` row dict.
+
+    Returns:
+        A list of transport-agnostic Score dicts (one or two entries).
     """
     dec = decision_row.get("decision") or {}
     meta = {

--- a/inference_optimizer/orchestrator/trace/llm_trace.py
+++ b/inference_optimizer/orchestrator/trace/llm_trace.py
@@ -147,6 +147,9 @@ class LLMCallRecord:
         Normalizes the identity fields to ``str`` and the four token
         counters via :func:`_coerce_optional_int` so a stray float / numpy
         scalar from an SDK ``usage`` object never lands raw in the ledger.
+
+        Returns:
+            The on-disk LLM-call row dict.
         """
         return {
             "session_id": str(self.session_id),
@@ -191,6 +194,20 @@ class LLMCallRecord:
         orchestration/kernel, A2 dynamic_action, A3 specialist fallback).
         Missing token keys degrade to ``None`` rather than ``0`` so the
         collector can distinguish "unreported" from "reported zero".
+
+        Args:
+            session_id: Cross-process aggregation primary key.
+            component: Producer label; must be in :data:`VALID_COMPONENTS`.
+            metadata: Backend turn metadata carrying model + token counters.
+            role: Reactor role name, when known.
+            task_id: Decision-association task id, when known.
+            dyn_id: Dynamic-action id, when known.
+            tick: Timeline tick, when known.
+            phase: Phase name, when known.
+            turn: Multi-turn sub-agent sequence index, when known.
+
+        Returns:
+            A populated :class:`LLMCallRecord`.
         """
         md = metadata or {}
         return cls(
@@ -231,6 +248,12 @@ def _coerce_optional_int(value: Any) -> int | None:
     Unlike the backends' ``_safe_int`` (which floors to 0), this keeps
     ``None`` distinct from ``0``: a backend that does not report a counter
     must not be indistinguishable from one that genuinely spent zero.
+
+    Args:
+        value: Arbitrary token / index value.
+
+    Returns:
+        The integer value, or ``None`` on a miss or bad type.
     """
     if value is None:
         return None
@@ -241,7 +264,15 @@ def _coerce_optional_int(value: Any) -> int | None:
 
 
 def _validate_row(row: dict[str, Any]) -> None:
-    """Fail fast if ``row`` deviates from the closed schema."""
+    """Fail fast if ``row`` deviates from the closed schema.
+
+    Args:
+        row: A serialized LLM-call row dict.
+
+    Raises:
+        LLMTraceRowError: If the row has extra/missing fields, an empty
+            ``session_id``, or an unknown ``component``.
+    """
     keys = set(row.keys())
     extra = sorted(keys - _ROW_FIELDS)
     missing = sorted(_ROW_FIELDS - keys)
@@ -286,6 +317,15 @@ def append_llm_call(
     :class:`LLMTraceRowError` (schema violation) is *not* swallowed: a
     malformed row is a programming error at the call site, not a runtime
     disk condition, and must surface in tests.
+
+    Args:
+        session_dir: Session directory used to resolve the ledger path.
+        record: The LLM-call record to serialize and append.
+        target: Optional override destination (e.g. an ext shard path);
+            defaults to the session's ``llm_calls.jsonl``.
+
+    Raises:
+        LLMTraceRowError: If the serialized row violates the closed schema.
     """
     row = record.to_row()
     _validate_row(row)
@@ -313,7 +353,11 @@ def append_llm_call(
 
 
 def row_field_set() -> frozenset[str]:
-    """Public accessor for the closed row schema (used by the collector)."""
+    """Public accessor for the closed row schema (used by the collector).
+
+    Returns:
+        The frozenset of canonical row field names.
+    """
     return _ROW_FIELDS
 
 

--- a/inference_optimizer/orchestrator/trace/parse_usage.py
+++ b/inference_optimizer/orchestrator/trace/parse_usage.py
@@ -71,6 +71,12 @@ def normalize_usage(usage: dict[str, Any] | None) -> dict[str, int | None] | Non
     recognized counters (so a stray ``{}`` or an unrelated dict doesn't
     masquerade as a real measurement). Unknown keys are dropped; absent
     counters become ``None``.
+
+    Args:
+        usage: Arbitrary usage dict, or ``None``.
+
+    Returns:
+        The canonical four-key token dict, or ``None`` when nothing usable.
     """
     if not isinstance(usage, dict) or not usage:
         return None
@@ -100,6 +106,12 @@ def parse_claude_stream_json_usage(
     onto a different terminal message still works). Malformed lines are
     skipped. Returns ``None`` if the file is missing or no ``usage`` is
     found.
+
+    Args:
+        log_path: Path to the Claude CLI ``stream-json`` log.
+
+    Returns:
+        The canonical token dict, or ``None`` when no usage was found.
     """
     path = Path(log_path)
     last_usage: dict[str, Any] | None = None
@@ -161,6 +173,12 @@ def parse_claude_stream_json_response(
     Tolerant by contract: a missing file, malformed lines, or a stream with
     no recoverable text returns ``None`` so the best-effort trace path
     degrades to "no response captured" instead of raising.
+
+    Args:
+        log_path: Path to the Claude CLI ``stream-json`` log.
+
+    Returns:
+        The recovered response text, or ``None`` when none could be read.
     """
     path = Path(log_path)
     result_text: str | None = None
@@ -222,6 +240,12 @@ def parse_oob_json_usage(stdout: str) -> dict[str, int | None] | None:
 
     OpenAI-style OOB has no prompt-cache split, so ``cache_*`` stay
     ``None``. Returns ``None`` when nothing parseable is found.
+
+    Args:
+        stdout: Captured ``oob run --json`` stdout text.
+
+    Returns:
+        The canonical token dict, or ``None`` when nothing parseable.
     """
     if not stdout or not stdout.strip():
         return None
@@ -264,6 +288,12 @@ def parse_geak_usage(
 
     No prompt-cache split, so ``cache_*`` stay ``None``. Returns ``None``
     when nothing parseable is found.
+
+    Args:
+        payload: A parsed litellm response dict, a JSON string, or ``None``.
+
+    Returns:
+        The canonical token dict, or ``None`` when nothing parseable.
     """
     obj: Any = payload
     if isinstance(payload, str):
@@ -292,6 +322,13 @@ def _find_usage_in_obj(obj: Any, _depth: int = 0) -> dict[str, Any] | None:
     keys, then recurses one extra level into nested dicts. Bounded depth
     keeps this cheap and avoids pathological deep structures; out-of-process
     envelopes nest ``usage`` at most a couple of levels down in practice.
+
+    Args:
+        obj: Arbitrary parsed JSON value to search.
+        _depth: Internal recursion depth guard.
+
+    Returns:
+        The first ``usage``/``token_usage`` dict found, or ``None``.
     """
     if _depth > 4 or not isinstance(obj, dict):
         return None

--- a/inference_optimizer/orchestrator/trace/trace_env.py
+++ b/inference_optimizer/orchestrator/trace/trace_env.py
@@ -33,6 +33,13 @@ def env_flag(name: str, default: bool = False) -> bool:
 
     Accepts ``1/true/yes/on`` (True) and ``0/false/no/off`` (False),
     case-insensitive. An unset or unrecognized value returns ``default``.
+
+    Args:
+        name: Environment variable name to read.
+        default: Value returned when the var is unset or unrecognized.
+
+    Returns:
+        The parsed boolean, or ``default`` when not recognized.
     """
     raw = os.environ.get(name)
     if raw is None:
@@ -46,7 +53,11 @@ def env_flag(name: str, default: bool = False) -> bool:
 
 
 def langfuse_live_enabled() -> bool:
-    """Report whether the live-Langfuse master switch is on (default off)."""
+    """Report whether the live-Langfuse master switch is on (default off).
+
+    Returns:
+        True when the master switch env var is enabled.
+    """
     return env_flag(ENV_LANGFUSE_ENABLE, default=False)
 
 
@@ -55,6 +66,9 @@ def langfuse_credentials() -> dict[str, str]:
 
     Missing / blank vars are omitted; callers treat an incomplete set as
     "not configured" and degrade to a no-op.
+
+    Returns:
+        Mapping of env var name to stripped value for each set variable.
     """
     out: dict[str, str] = {}
     for key in (ENV_LANGFUSE_HOST, ENV_LANGFUSE_PUBLIC_KEY, ENV_LANGFUSE_SECRET_KEY):
@@ -65,7 +79,11 @@ def langfuse_credentials() -> dict[str, str]:
 
 
 def langfuse_credentials_complete() -> bool:
-    """True iff all three Langfuse connection vars are present and non-empty."""
+    """True iff all three Langfuse connection vars are present and non-empty.
+
+    Returns:
+        True when all three connection vars are set and non-empty.
+    """
     return len(langfuse_credentials()) == 3
 
 

--- a/inference_optimizer/paths.py
+++ b/inference_optimizer/paths.py
@@ -89,6 +89,9 @@ def workspace_root() -> Path:
     ``DEFAULT_SESSION_DIR``), regardless of layout mode. Workspace-shared
     artefacts (runtime/, logs/) live here. Falling back to the default emits
     one loud warning so a misconfigured launcher is visible.
+
+    Returns:
+        The workspace root path.
     """
     global _WARNED_NO_USER_DATA
     user_data = os.environ.get(ENV_USER_DATA_PATH)
@@ -110,7 +113,11 @@ def workspace_root() -> Path:
 
 def _layout_mode() -> str:
     """Effective layout mode: ``flat`` or ``per_model_ts`` (default), pinnable
-    via the env override."""
+    via the env override.
+
+    Returns:
+        Either ``"flat"`` or ``"per_model_ts"``.
+    """
     raw = (os.environ.get(ENV_SESSION_LAYOUT) or "").strip().lower()
     if raw in ("flat", "per_model_ts"):
         return raw
@@ -119,7 +126,14 @@ def _layout_mode() -> str:
 
 def _sanitize_model_basename(model_name: str | os.PathLike[str]) -> str:
     """Reduce ``model_name`` (path, HF id, or Path) to a filename-safe
-    basename (trailing path component). Empty/all-invalid -> ``"session"``."""
+    basename (trailing path component). Empty/all-invalid -> ``"session"``.
+
+    Args:
+        model_name: Model path, HF id, or Path to reduce to a basename.
+
+    Returns:
+        A filename-safe basename, or ``"session"`` when empty/all-invalid.
+    """
     stem = ("" if model_name is None else str(model_name)).strip()
     if not stem:
         return "session"
@@ -135,6 +149,9 @@ def session_dir() -> Path:
     ``$INFERENCE_OPTIMIZER_CURRENT_SESSION_DIR`` (pin from make_session_dir,
     inherited by subprocesses) -> ``$USER_DATA_PATH`` (flat layout) ->
     ``DEFAULT_SESSION_DIR``.
+
+    Returns:
+        The absolute session directory for the current run.
     """
     pinned = os.environ.get(ENV_CURRENT_SESSION_DIR)
     if pinned:
@@ -149,6 +166,13 @@ def find_latest_per_session_dir(
     ``--resume`` without ``--resume-from``). Selects by the
     ``%Y%m%dT%H%M%SZ`` timestamp in the directory name (lex sort), not mtime.
     Returns None when no matching subdir exists.
+
+    Args:
+        model_name: Restrict the scan to one model's subtree, or ``None`` to
+            scan every model basename.
+
+    Returns:
+        The latest per-session directory, or ``None`` when none match.
     """
     ws = workspace_root()
     if not ws.is_dir():
@@ -184,6 +208,13 @@ def make_session_dir(model_name: str | os.PathLike[str] | None = None) -> Path:
     is ``<workspace_root>/<model>/<UTC_ts>/`` and is pinned via
     ``$INFERENCE_OPTIMIZER_CURRENT_SESSION_DIR``; otherwise it is
     workspace_root (flat layout). Idempotent.
+
+    Args:
+        model_name: Model name selecting the per-model subtree, or ``None``
+            for the flat layout.
+
+    Returns:
+        The created (and pinned) session directory.
     """
     ws = workspace_root()
     ws.mkdir(parents=True, exist_ok=True)
@@ -282,7 +313,15 @@ def asset_kernel_opt_dir() -> Path:
 
 def agent_session_dir(session_dir: Path, agent_name: str) -> Path:
     """Per-agent inbox/outbox dir under the session (created by
-    make_session_dir; this only computes the path)."""
+    make_session_dir; this only computes the path).
+
+    Args:
+        session_dir: The session directory root.
+        agent_name: The agent name subdirectory.
+
+    Returns:
+        ``<session_dir>/agents/<agent_name>``.
+    """
     return Path(session_dir) / "agents" / agent_name
 
 
@@ -293,6 +332,12 @@ def runtime_dir(session_dir: Path | None = None) -> Path:
     """``<workspace_root>/runtime/`` — workspace-shared writable runtime
     (kernel-agent env file, GEAK litellm config). Survives across sessions;
     the ``session_dir`` param is ignored (back-compat).
+
+    Args:
+        session_dir: Ignored; accepted for back-compat.
+
+    Returns:
+        ``<workspace_root>/runtime``.
     """
     return workspace_root() / "runtime"
 
@@ -303,6 +348,9 @@ def open_source_root() -> Path:
     ``${TMPDIR:-/tmp}/hyperloom/open-source-repos``. Decoupled from
     ``$USER_DATA_PATH`` so a shared workspace root never collocates concurrent
     pods' checkouts.
+
+    Returns:
+        The pod-local open-source repos root path.
     """
     override = os.environ.get("HYPERLOOM_OPEN_SOURCE_ROOT")
     if override:
@@ -315,6 +363,12 @@ def magpie_dir(session_dir: Path | None = None) -> Path:
     """``<open_source_root>/Magpie/`` — Magpie clone (pod-local; ``$MAGPIE_DIR``
     overrides). Aligned with install.sh so script and runtime resolve the same
     checkout. ``session_dir`` param ignored (back-compat).
+
+    Args:
+        session_dir: Ignored; accepted for back-compat.
+
+    Returns:
+        The Magpie checkout path.
     """
     override = os.environ.get("MAGPIE_DIR")
     if override:
@@ -326,13 +380,26 @@ def kernel_agent_runs_root(session_dir: Path) -> Path:
     """``<sd>/kernel-agent/`` — kernel-agent CLI tool output root (one
     ``runs/<session_id>/`` per invocation). Distinct from the kernel_id-keyed
     ``<sd>/kernel-agent-workspace/``.
+
+    Args:
+        session_dir: The session directory root.
+
+    Returns:
+        ``<session_dir>/kernel-agent``.
     """
     return Path(session_dir) / "kernel-agent"
 
 
 def optimizer_runs_dir(session_dir: Path) -> Path:
     """``<sd>/optimizer_runs/`` — launcher stdout / PID / robustness monitor
-    logs."""
+    logs.
+
+    Args:
+        session_dir: The session directory root.
+
+    Returns:
+        ``<session_dir>/optimizer_runs``.
+    """
     return Path(session_dir) / "optimizer_runs"
 
 
@@ -341,6 +408,9 @@ def mn_profile_trace_root() -> Path:
     root (``<rayjob_id>/torch_trace/`` per provision). Multi-node operators
     MUST set ``$USER_DATA_PATH`` to a cluster-shared path or the sandbox never
     sees pod-side trace files. Single-node never reads this.
+
+    Returns:
+        ``<workspace_root>/profile-traces``.
     """
     return workspace_root() / "profile-traces"
 

--- a/inference_optimizer/protocol/intent.py
+++ b/inference_optimizer/protocol/intent.py
@@ -256,6 +256,14 @@ def _validate_review_verdict_payload(
 
     PolicyGate handles content validation (verdict vocab, variant_name vs
     grid); this only guarantees at-most-one-present for downstream callers.
+
+    Args:
+        payload: The REVIEW_VERDICT intent payload to validate.
+        index: Position of the intent in the envelope (for error messages).
+
+    Raises:
+        IntentValidationError: If neither or both of ``verdict`` and
+            ``verdict_map`` are present, or ``verdict_map`` is malformed.
     """
     has_single = "verdict" in payload
     has_map = "verdict_map" in payload

--- a/inference_optimizer/recipe_kb/composite_remote.py
+++ b/inference_optimizer/recipe_kb/composite_remote.py
@@ -69,7 +69,14 @@ _FETCH_FLOOR = 25
 
 def _richness(row: dict[str, Any]) -> int:
     """Count populated 'rich' fields — a tie-breaker that favours the row
-    carrying actual warm-start payload over a sparse stub."""
+    carrying actual warm-start payload over a sparse stub.
+
+    Args:
+        row: An arbor-shaped recipe row.
+
+    Returns:
+        The count of populated rich fields (0-5).
+    """
     score = 0
     if row.get("best_config"):
         score += 1
@@ -85,7 +92,15 @@ def _richness(row: dict[str, Any]) -> int:
 
 
 def _precedence_key(row: dict[str, Any]) -> tuple[int, float, int, float]:
-    """Higher tuple = preferred base. authority → confidence → richness → tput."""
+    """Higher tuple = preferred base. authority → confidence → richness → tput.
+
+    Args:
+        row: An arbor-shaped recipe row.
+
+    Returns:
+        A sortable precedence tuple ``(authority_rank, confidence, richness,
+        throughput)``; higher sorts first.
+    """
     authority = str(row.get("authority") or "")
     try:
         confidence = float(row.get("confidence") or 0.0)
@@ -117,7 +132,14 @@ def _is_empty(value: Any) -> bool:
 
 
 def _dedup_preserve(items: Iterable[Any]) -> list[Any]:
-    """Order-preserving dedup of a small sequence."""
+    """Order-preserving dedup of a small sequence.
+
+    Args:
+        items: The sequence to deduplicate.
+
+    Returns:
+        A list with duplicates removed, preserving first-seen order.
+    """
     out: list[Any] = []
     for it in items:
         if it not in out:
@@ -135,6 +157,12 @@ def _union_lists(
     is the ordered, de-duplicated list of ``_source`` tags that contributed at
     least one element to the union (for field-level provenance).
 
+    Args:
+        rows: The rows whose ``field`` lists are unioned.
+        field: The list field name to union across rows.
+
+    Returns:
+        A tuple of the merged item list and the ordered contributor sources.
     """
     out: list[Any] = []
     seen: set[str] = set()
@@ -161,6 +189,13 @@ def _merge_group(rows: list[dict[str, Any]]) -> dict[str, Any]:
     surviving value came from — scalar fields map to the single winning/
     back-filling source, list fields to the ordered set of contributors. This
     is what lets the KB-eval layer attribute an outcome to gbrain vs cortex.
+
+    Args:
+        rows: All rows sharing one canonical id.
+
+    Returns:
+        The merged row with unioned list fields, back-filled scalars, and
+        ``_sources`` / ``_field_sources`` provenance markers.
     """
     ordered = sorted(rows, key=_precedence_key, reverse=True)
     base = dict(ordered[0])
@@ -220,7 +255,11 @@ class CompositeRemoteRecipeClient:
 
     @property
     def enabled(self) -> bool:
-        """Enabled iff at least one sub-remote is enabled."""
+        """Enabled iff at least one sub-remote is enabled.
+
+        Returns:
+            ``True`` when any sub-remote reports ``enabled``.
+        """
         return any(getattr(s, "enabled", False) for s in self._sources)
 
     def _active(self) -> list[tuple[str, Any]]:
@@ -237,7 +276,17 @@ class CompositeRemoteRecipeClient:
         ]
 
     def _fan_out_search(self, *, name: str, source: Any, kwargs: dict[str, Any]) -> list[dict[str, Any]]:
-        """Run one source's search, tag + normalize each row. Best-effort."""
+        """Run one source's search, tag + normalize each row. Best-effort.
+
+        Args:
+            name: Display name of the source (used as the ``_source`` tag).
+            source: The sub-remote client to query.
+            kwargs: Search keyword arguments forwarded to the source.
+
+        Returns:
+            The source's arbor-normalized rows tagged with ``_source``, or
+            ``[]`` when the source is disabled or raises.
+        """
         try:
             rows = source.search(**kwargs)
         except RemoteRecipeClientError as exc:
@@ -324,7 +373,16 @@ class CompositeRemoteRecipeClient:
         canonical_id: str,
         version: int | None = None,
     ) -> dict[str, Any] | None:
-        """Exact-cid read: search every source by the 5-tuple labels, merge top."""
+        """Exact-cid read: search every source by the 5-tuple labels, merge top.
+
+        Args:
+            canonical_id: The canonical recipe id to look up.
+            version: Accepted for interface parity; not used for selection.
+
+        Returns:
+            The merged row matching ``canonical_id``, the top merged row when
+            no exact match, or ``None`` when nothing is found.
+        """
         try:
             labels = _labels_from_canonical_id(canonical_id)
         except InvalidCanonicalIdError as exc:
@@ -359,7 +417,11 @@ class CompositeRemoteRecipeClient:
         )[: int(limit)]
 
     def _first_active(self) -> Any | None:
-        """Return the first enabled sub-remote, or ``None`` if none are active."""
+        """Return the first enabled sub-remote, or ``None`` if none are active.
+
+        Returns:
+            The first active sub-remote, or ``None`` when none are enabled.
+        """
         for _name, source in self._active():
             return source
         return None
@@ -404,7 +466,11 @@ class CompositeRemoteRecipeClient:
         return src.session_summary(session_id=session_id) if src else None
 
     def health(self) -> bool:
-        """Healthy iff any active source is healthy."""
+        """Healthy iff any active source is healthy.
+
+        Returns:
+            ``True`` when any active sub-remote's health probe succeeds.
+        """
         for _name, source in self._active():
             try:
                 if source.health():

--- a/inference_optimizer/recipe_kb/dispatcher.py
+++ b/inference_optimizer/recipe_kb/dispatcher.py
@@ -261,7 +261,15 @@ _PREFER_STRING_KEYS: tuple[str, ...] = (
 
 
 def _prefer_score(row: dict[str, Any], prefer: dict[str, Any]) -> int:
-    """Count how many ``prefer`` fields the (flat arbor) row matches."""
+    """Count how many ``prefer`` fields the (flat arbor) row matches.
+
+    Args:
+        row: A flat arbor recipe row.
+        prefer: Workload-similarity hints to compare against the row.
+
+    Returns:
+        The count of matching numeric and string preference fields.
+    """
     if not isinstance(row, dict):
         return 0
     score = 0
@@ -294,6 +302,14 @@ def _rerank_by_prefer(
 
     No-op when ``prefer`` is empty. Never drops rows; only reorders so a
     closer-workload recipe surfaces first.
+
+    Args:
+        rows: The flat arbor rows to reorder.
+        prefer: Workload-similarity hints, or ``None`` to leave order intact.
+
+    Returns:
+        The rows reordered by descending preference score (or unchanged when
+        ``prefer`` is empty).
     """
     if not prefer:
         return rows
@@ -373,6 +389,12 @@ class RecipeKB:
         :func:`_v2_to_arbor` keeps an idempotency guard so a row that is
         already in flat arbor shape (e.g. a mis-built adapter) passes
         through untouched rather than being silently emptied.
+
+        Args:
+            row: The remote row in the unified nested KB-interface envelope.
+
+        Returns:
+            The row projected into the flat arbor shape callers expect.
         """
         return _v2_to_arbor(row)
 
@@ -687,6 +709,18 @@ class RecipeKB:
 
         ``prefer`` only reorders; the ``required`` filter
         (``label_match`` / ``metric_filters``) decides membership.
+
+        Args:
+            label_match: Identity labels deciding membership.
+            metric_filters: ``{metric: {min, max}}`` bounds deciding membership.
+            updated_since: Lower bound on ``updated_at``.
+            order_by: Ordering directive forwarded to the store.
+            limit: Maximum number of rows to return.
+            prefer: Workload-similarity hints used only to rerank results.
+
+        Returns:
+            The matching recipe rows (remote-first, local fall-through),
+            reranked by ``prefer``.
         """
         if self._remote_active():
             try:

--- a/inference_optimizer/recipe_kb/gbrain_ingest.py
+++ b/inference_optimizer/recipe_kb/gbrain_ingest.py
@@ -79,6 +79,12 @@ def _scalar(value: Any) -> str:
     ``type``. Everything else is JSON double-quoted (valid YAML) so the
     parser never reinterprets a number-ish / bool-ish / underscore-
     separated token — e.g. ``0_5_11`` must not become octal ``329``.
+
+    Args:
+        value: The scalar value to render.
+
+    Returns:
+        A YAML-safe token: bare for safe identifiers, JSON-quoted otherwise.
     """
     if value is None:
         return "null"
@@ -93,7 +99,15 @@ def _scalar(value: Any) -> str:
 
 
 def _emit_yaml(obj: Mapping[str, Any], indent: int = 0) -> str:
-    """Minimal recursive YAML emitter for scalars / nested dicts / scalar lists."""
+    """Minimal recursive YAML emitter for scalars / nested dicts / scalar lists.
+
+    Args:
+        obj: The mapping to render as YAML.
+        indent: Current indentation depth (two spaces per level).
+
+    Returns:
+        The rendered YAML text.
+    """
     pad = "  " * indent
     lines: list[str] = []
     for key, val in obj.items():
@@ -143,6 +157,12 @@ def _best_config_split(best_config: Mapping[str, Any]) -> tuple[str, dict[str, s
     Reads the args via the compat helper (canonical with read-only legacy
     fallback). For envs, a nested map wins; otherwise the remaining scalar
     sibling keys (minus non-env metadata) are taken as flat envs.
+
+    Args:
+        best_config: The champion config dict in either nested or flat shape.
+
+    Returns:
+        A tuple of the launch-args string and the env-var dict.
     """
     args = read_extra_server_args(dict(best_config)).strip()
     nested = best_config.get("extra_envs")
@@ -161,7 +181,15 @@ def _best_config_split(best_config: Mapping[str, Any]) -> tuple[str, dict[str, s
 
 
 def _has_shareable_signal(recipe: Mapping[str, Any]) -> bool:
-    """Return True when a seed-only recipe carries reusable prior signal."""
+    """Return True when a seed-only recipe carries reusable prior signal.
+
+    Args:
+        recipe: The recipe dict to inspect.
+
+    Returns:
+        ``True`` when the recipe has a positive-throughput session, any
+        negative-knowledge list, or architecture/model-class hints.
+    """
     for s in (recipe.get("sessions") or []):
         if not isinstance(s, Mapping):
             continue
@@ -186,6 +214,13 @@ def recipe_to_page(recipe: Mapping[str, Any]) -> tuple[str, str] | None:
     even pure seed-only anchors are mirrored so future gbrain reads can hit the
     5-tuple (tier=seed_only); set RECIPE_KB_MIRROR_REQUIRE_SIGNAL=1 to restore
     the old stricter gate (best_config OR reusable prior).
+
+    Args:
+        recipe: The v2 recipe dict to convert.
+
+    Returns:
+        A ``(slug, content)`` page tuple, or ``None`` when the recipe lacks a
+        canonical id (or fails the strict mirror gate).
     """
     best_config = recipe.get("best_config") if isinstance(recipe.get("best_config"), Mapping) else {}
     canonical = str(recipe.get("canonical_id") or "").strip()
@@ -265,7 +300,17 @@ def ingest_local_to_gbrain(
     mcp: _GbrainMcp | None,
     dry_run: bool,
 ) -> dict[str, int]:
-    """Ingest a list of v2 recipe dicts into gbrain. Returns counters."""
+    """Ingest a list of v2 recipe dicts into gbrain. Returns counters.
+
+    Args:
+        recipes: The v2 recipe dicts to ingest.
+        mcp: The gbrain MCP client, or ``None`` to skip the actual writes.
+        dry_run: When ``True``, count rows as ingested without writing.
+
+    Returns:
+        A counters dict with ``total`` / ``ingested`` / ``skipped_*`` /
+        ``errors`` tallies.
+    """
     stats = {
         "total": len(recipes),
         "ingested": 0,
@@ -302,6 +347,13 @@ def mirror_recipe(recipe: Mapping[str, Any], mcp: _GbrainMcp | None) -> bool:
     ``canonical_id``, strict-gate rejection, no mcp) or on a transport
     error. Never raises — the local write is authoritative and a gbrain
     hiccup must not affect it.
+
+    Args:
+        recipe: The recipe dict to mirror.
+        mcp: The gbrain MCP client, or ``None`` to skip mirroring.
+
+    Returns:
+        ``True`` when a page was written, ``False`` when skipped or on error.
     """
     if mcp is None:
         return False
@@ -318,7 +370,12 @@ def mirror_recipe(recipe: Mapping[str, Any], mcp: _GbrainMcp | None) -> bool:
 
 
 def build_mirror_mcp_from_env() -> _GbrainMcp | None:
-    """Build a write-side gbrain MCP client from env (background timeout)."""
+    """Build a write-side gbrain MCP client from env (background timeout).
+
+    Returns:
+        A configured :class:`_GbrainMcp`, or ``None`` when ``GBRAIN_BASE_URL``
+        / ``GBRAIN_TOKEN`` are not set.
+    """
     base_url = (os.environ.get("GBRAIN_BASE_URL", "") or "").strip()
     token = (os.environ.get("GBRAIN_TOKEN", "") or "").strip()
     if not base_url or not token:

--- a/inference_optimizer/recipe_kb/gbrain_remote_client.py
+++ b/inference_optimizer/recipe_kb/gbrain_remote_client.py
@@ -191,6 +191,12 @@ def _json_list(value: Any) -> list[Any]:
     only renders scalar lists. Tolerates an already-decoded list (in case
     a future page stores them natively) and degrades to ``[]`` on absence
     or malformed content so a bad page never breaks warm-start.
+
+    Args:
+        value: A list, a JSON-encoded list string, or anything else.
+
+    Returns:
+        The decoded list, or ``[]`` when the value is absent or malformed.
     """
     if isinstance(value, list):
         return value
@@ -216,6 +222,13 @@ def _best_config_from_attrs(attrs: Mapping[str, Any]) -> dict[str, Any]:
     be invisible to the consumer's nested ``best_config["extra_envs"]``
     read and the high-confidence warm recipe would be skipped as
     ``best_config_empty``.
+
+    Args:
+        attrs: The flat gbrain recipe page attrs mapping.
+
+    Returns:
+        The canonical ``best_config`` dict with launch args under the
+        canonical key and the env map nested under ``extra_envs``.
     """
     out: dict[str, Any] = {}
     args = str(attrs.get("best_config_args") or "").strip()
@@ -239,6 +252,13 @@ def _page_to_recipe(frontmatter: Mapping[str, Any]) -> dict[str, Any] | None:
 
     Returns ``None`` when the page lacks the minimum identity (model /
     hardware) needed to build a canonical id.
+
+    Args:
+        frontmatter: The gbrain recipe page frontmatter mapping.
+
+    Returns:
+        The nested KB-interface recipe envelope, or ``None`` when the page
+        lacks the model/hardware identity needed for a canonical id.
     """
     attrs = frontmatter.get("attrs") if isinstance(frontmatter.get("attrs"), Mapping) else {}
     model = str(attrs.get("model") or "").strip()
@@ -301,6 +321,15 @@ def _labels_match(recipe: Mapping[str, Any], label_match: Mapping[str, Any]) -> 
     :func:`_page_to_recipe`); the caller's ``label_match`` may be a raw or
     slugged value, so we re-run it through ``canonical_labels`` to make
     the comparison slug-normalized (``Qwen/Qwen3`` vs ``qwen3`` converge).
+
+    Args:
+        recipe: The candidate recipe carrying slugged ``labels``.
+        label_match: The constraining labels (raw or slugged); empty matches
+            everything.
+
+    Returns:
+        ``True`` when every constrained label equals the recipe's slugged
+        value.
     """
     if not label_match:
         return True
@@ -415,7 +444,15 @@ class GbrainRemoteRecipeClient:
         return _SCAN_CACHE_TTL_SEC
 
     def _get_page_recipe(self, slug: str) -> dict[str, Any] | None:
-        """Fetch one gbrain recipe page by slug and project it."""
+        """Fetch one gbrain recipe page by slug and project it.
+
+        Args:
+            slug: The gbrain page slug to fetch.
+
+        Returns:
+            The projected recipe envelope, or ``None`` when disabled, missing,
+            or lacking frontmatter.
+        """
         if not self.enabled or self._mcp is None:
             return None
         page = self._mcp.call("get_page", {"slug": slug})
@@ -432,6 +469,13 @@ class GbrainRemoteRecipeClient:
         early when many pages share the same ``updated_at``, hiding older
         recipes from client-side search. Dedup by slug across page boundaries
         and return newest-first to preserve the previous caller contract.
+
+        Args:
+            limit: Maximum number of recipes to return (capped at the internal
+                scan cap).
+
+        Returns:
+            Newest-first projected recipe dicts, or ``[]`` when disabled.
         """
         if not self.enabled or self._mcp is None:
             return []
@@ -486,6 +530,17 @@ class GbrainRemoteRecipeClient:
 
         gbrain keeps no per-version archive, so ``version`` is accepted
         for interface parity but only ``version in (None, 1)`` can match.
+
+        Args:
+            canonical_id: The canonical recipe id to look up.
+            version: Optional version; only ``None`` or ``1`` can match.
+
+        Returns:
+            The matching recipe envelope, or ``None`` on miss / disabled /
+            non-matching version.
+
+        Raises:
+            ValueError: If ``canonical_id`` is empty.
         """
         if not self.enabled:
             return None
@@ -557,6 +612,19 @@ class GbrainRemoteRecipeClient:
         unified KB-interface signature; the dispatcher applies the
         client-side rerank over the normalized rows, so this adapter
         only honours the ``required`` (``label_match`` / metric) filter.
+
+        Args:
+            label_match: Identity labels to filter on (empty matches all).
+            metric_filters: ``{metric: {min, max}}`` bounds to apply.
+            updated_since: Keep only rows with ``updated_at`` at or after this.
+            order_by: Ordering key; ASC variants reverse the default newest-
+                first order.
+            limit: Maximum number of rows to return.
+            prefer: Accepted for signature parity; ignored here (rerank lives
+                in the dispatcher).
+
+        Returns:
+            The filtered, ordered recipe rows, or ``[]`` when disabled.
         """
         del prefer  # client-side rerank lives in RecipeKB
         if not self.enabled:
@@ -617,6 +685,13 @@ def _passes_metric_filters(recipe: Mapping[str, Any], metric_filters: Mapping[st
     The recipe is the nested KB-interface envelope, so throughput lives
     under ``metrics.throughput`` / ``body.best_throughput``. We accept
     both the ``throughput`` and the ``best_throughput`` filter aliases.
+
+    Args:
+        recipe: The nested KB-interface recipe envelope.
+        metric_filters: ``{metric: {min, max}}`` bounds to apply.
+
+    Returns:
+        ``True`` when the recipe satisfies every metric bound.
     """
     metrics = recipe.get("metrics") if isinstance(recipe.get("metrics"), Mapping) else {}
     body = recipe.get("body") if isinstance(recipe.get("body"), Mapping) else {}
@@ -642,6 +717,10 @@ def build_gbrain_remote_from_env() -> GbrainRemoteRecipeClient | None:
 
     Returns ``None`` when the env is not configured so the caller can
     fall back to local-only or the cortex remote.
+
+    Returns:
+        A configured :class:`GbrainRemoteRecipeClient`, or ``None`` when the
+        base URL / token env vars are not set.
     """
     base_url = (os.environ.get("GBRAIN_BASE_URL", "") or "").strip()
     token = (os.environ.get("GBRAIN_TOKEN", "") or "").strip()

--- a/inference_optimizer/recipe_kb/local_store.py
+++ b/inference_optimizer/recipe_kb/local_store.py
@@ -438,6 +438,10 @@ class LocalRecipeStore:
           rather than indexing it);
         * the ``history`` subdir (six levels deep, the recipe.json
           presence check naturally rules it out).
+
+        Yields:
+            Each recipe directory at the documented 5-level depth that holds a
+            live ``recipe.json``.
         """
         if not self.root.is_dir():
             return
@@ -466,6 +470,10 @@ class LocalRecipeStore:
         against a cid that doesn't (yet) have a parent recipe row
         are still discoverable. Mirrors the central server contract
         that attempts have no FK to the parent recipe.
+
+        Yields:
+            Each canonical-id directory at the 5-level depth holding either a
+            ``recipe.json`` or an ``attempts.ndjson`` (deduplicated).
         """
         if not self.root.is_dir():
             return

--- a/inference_optimizer/recipe_kb/remote_client.py
+++ b/inference_optimizer/recipe_kb/remote_client.py
@@ -592,6 +592,18 @@ class RemoteRecipeClient:
         server-side prefer ranking, so the dispatcher applies a
         client-side rerank over the returned rows; this client only
         forwards the ``required`` filter.
+
+        Args:
+            label_match: Identity labels to filter on.
+            metric_filters: ``{metric: {min, max}}`` bounds to apply.
+            updated_since: Lower bound on ``updated_at``.
+            order_by: Ordering directive forwarded to the server.
+            limit: Maximum number of rows to request.
+            prefer: Accepted for signature parity; ignored here (rerank lives
+                in the dispatcher).
+
+        Returns:
+            The matching recipe rows, or ``[]`` when the client is disabled.
         """
         del prefer  # client-side rerank lives in RecipeKB
         if not self.enabled:

--- a/inference_optimizer/recipe_snapshot_constants.py
+++ b/inference_optimizer/recipe_snapshot_constants.py
@@ -194,6 +194,13 @@ def _slug(value: str, default: str) -> str:
     Slugged for lookup stability (``--model /path/Qwen3`` and ``qwen3`` must
     converge) and filesystem safety in the local KB store. ``/`` resolves to
     the basename first (HF paths collapse to the stem).
+
+    Args:
+        value: The raw value to slugify.
+        default: Fallback slug returned when ``value`` is empty.
+
+    Returns:
+        The slugified value, or ``default`` when empty.
     """
     raw = (value or "").strip()
     if not raw:
@@ -221,6 +228,16 @@ def recipe_canonical_id(
     useful before all components are known. Keyword-only to prevent
     positional re-ordering; missing components fall back to ``DEFAULT_*_SLUG``
     so the id is always well-formed (6 colon-separated segments).
+
+    Args:
+        model: The model identifier.
+        hardware: The hardware/GPU identifier.
+        framework: The serving framework name.
+        framework_version: The framework version.
+        precision: The precision/quantization scheme.
+
+    Returns:
+        The six-segment colon-separated canonical id.
     """
     return (
         f"inference:"
@@ -243,6 +260,16 @@ def canonical_labels(
     """Return the five-key ``labels`` dict mirroring the canonical id, so
     ``/recipes/search`` can ``label_match`` by individual dimension. Slug
     values match :func:`recipe_canonical_id`.
+
+    Args:
+        model: The model identifier.
+        hardware: The hardware/GPU identifier.
+        framework: The serving framework name.
+        framework_version: The framework version.
+        precision: The precision/quantization scheme.
+
+    Returns:
+        The five-key labels dict mirroring the canonical id.
     """
     return {
         F_LABEL_MODEL:             _slug(model,             DEFAULT_MODEL_SLUG),
@@ -268,6 +295,12 @@ def detect_framework_version(framework: str) -> str:
     top-level package and reading ``__version__``. Failures degrade to
     :data:`DEFAULT_FRAMEWORK_VERSION_SLUG` (the optimizer must boot without
     the framework importable).
+
+    Args:
+        framework: The serving framework name to probe.
+
+    Returns:
+        The detected version slug, or the default on any failure.
     """
     fw_slug = _slug(framework, "")
     if not fw_slug:
@@ -296,6 +329,13 @@ def format_recipe_path(template: str, canonical_id: str) -> str:
     """Substitute ``{canonical_id}`` into a path template without
     percent-encoding (server treats canonical_id as ``:path``-typed, so HF
     stems like ``Qwen/Qwen3-30B-A3B`` must reach it verbatim).
+
+    Args:
+        template: The path template containing ``{canonical_id}``.
+        canonical_id: The canonical id to substitute verbatim.
+
+    Returns:
+        The template with ``{canonical_id}`` replaced.
     """
     return template.replace("{canonical_id}", canonical_id)
 

--- a/inference_optimizer/scripts/backfill_langfuse.py
+++ b/inference_optimizer/scripts/backfill_langfuse.py
@@ -141,7 +141,15 @@ def _load_json(path: Path) -> dict[str, Any]:
 # Plan building (pure -- no SDK, dry-run friendly)
 # ---------------------------------------------------------------------------
 def build_plan(session_dir: Path) -> dict[str, Any]:
-    """Parse the trace files into a Langfuse-shaped plan dict (pure)."""
+    """Parse the trace files into a Langfuse-shaped plan dict (pure).
+
+    Args:
+        session_dir: The session directory holding trace and manifest files.
+
+    Returns:
+        A Langfuse-shaped plan dict with trace seed, session id, and phase
+        hierarchy.
+    """
     tdir = session_dir / TRACE_SUBDIR
     llm = _load_jsonl(tdir / LLM_CALLS)
     conv = _load_jsonl(tdir / CONVERSATIONS)

--- a/inference_optimizer/scripts/roofline_sweep.py
+++ b/inference_optimizer/scripts/roofline_sweep.py
@@ -84,6 +84,16 @@ def extract_templates(state: dict[str, Any]) -> tuple[LaunchTemplate, LaunchTemp
     state.current_best.extra_server_args + extra_envs. The optimized
     template is the hard KPI of this sweep — when empty, the caller
     should refuse to run.
+
+    Args:
+        state: Parsed ``state.json`` contents.
+
+    Returns:
+        A ``(baseline, optimized)`` tuple of launch templates.
+
+    Raises:
+        SystemExit: If ``current_best`` has neither extra server args nor
+            extra envs.
     """
     cb = state.get("current_best") or {}
     opt_args = (cb.get("extra_server_args") or "").strip()
@@ -234,7 +244,11 @@ class SglangServer:
 
     @property
     def base_url(self) -> str:
-        """Return the server's local base URL."""
+        """Return the server's local base URL.
+
+        Returns:
+            The ``http://127.0.0.1:<port>`` base URL.
+        """
         return f"http://127.0.0.1:{self.port}"
 
 
@@ -248,6 +262,21 @@ def run_bench(
     """Invoke ``sglang.bench_serving`` once; return parsed metrics dict.
 
     Returns ``{}`` on subprocess failure (caller can mark as OOM/ERROR).
+
+    Args:
+        base_url: The server base URL to benchmark against.
+        model_path: The served model path.
+        conc: Maximum concurrency for the run.
+        isl: Random input sequence length.
+        osl: Random output sequence length.
+        num_prompts: Number of prompts to send.
+        dataset: Dataset name passed to ``bench_serving``.
+        output_dir: Directory for the bench output file.
+        port: Server port (used for logging/output naming).
+
+    Returns:
+        The parsed metrics dict, or ``{}`` on subprocess failure or missing
+        output.
     """
     output_dir.mkdir(parents=True, exist_ok=True)
     out_file = output_dir / f"bench_conc{conc}.jsonl"

--- a/inference_optimizer/session_paths.py
+++ b/inference_optimizer/session_paths.py
@@ -69,6 +69,9 @@ def _runs_actions() -> frozenset[str]:
     """Action names that own a ``runs/<kind>/<task_id>/`` workspace, from
     action metadata. Lazy + cached; falls back to ``_RUNS_ACTIONS_FALLBACK``
     when the registry can't load.
+
+    Returns:
+        The set of action names that own a runs-workspace.
     """
     try:
         from .orchestrator.action_registry import ActionRegistry  # local: avoid import-time cycle
@@ -149,6 +152,14 @@ def kernel_workspace(session_dir: Path, kernel_id: str) -> Path:
     GEAK/OOB candidates, and the chosen patch for one kernel. Keyed by
     ``kernel_id`` and survives across tasks (vs the per-invocation
     :func:`kernel_agent_runs_dir`).
+
+    Args:
+        session_dir: The session root directory.
+        kernel_id: Kernel id keying the workspace; blank falls back to
+            ``"unknown"``.
+
+    Returns:
+        ``<session_dir>/kernel-agent-workspace/<kernel_id>``.
     """
     kid = str(kernel_id or "").strip() or "unknown"
     return Path(session_dir) / "kernel-agent-workspace" / kid
@@ -159,6 +170,14 @@ def kernel_agent_runs_dir(session_dir: Path, session_id: str) -> Path:
     kernel-agent output (logs, status JSON, optimization_attempts.jsonl,
     TraceLens analysis). Keyed by tool-invocation session id (vs the
     kernel_id-keyed :func:`kernel_workspace`).
+
+    Args:
+        session_dir: The session root directory.
+        session_id: Tool-invocation session id; blank falls back to
+            ``"unknown"``.
+
+    Returns:
+        ``<session_dir>/kernel-agent/runs/<session_id>``.
     """
     sid = str(session_id or "").strip() or "unknown"
     return Path(session_dir) / "kernel-agent" / "runs" / sid
@@ -167,6 +186,14 @@ def kernel_agent_runs_dir(session_dir: Path, session_id: str) -> Path:
 def patches_dir(session_dir: Path, kernel_id: str) -> Path:
     """``<sd>/patches/<kernel_id>/`` — KEEP-promoted on-disk changes: the
     original source backup + applied patch (REVERT restores from backup).
+
+    Args:
+        session_dir: The session root directory.
+        kernel_id: Kernel id keying the patch dir; blank falls back to
+            ``"unknown"``.
+
+    Returns:
+        ``<session_dir>/patches/<kernel_id>``.
     """
     kid = str(kernel_id or "").strip() or "unknown"
     return Path(session_dir) / "patches" / kid
@@ -213,7 +240,14 @@ def report_file(session_dir: Path, ts: str, suffix: str = "md") -> Path:
 # All trace writers are best-effort and swallow OSError; these helpers only
 # compute paths (callers mkdir the parent before writing).
 def trace_dir(session_dir: Path) -> Path:
-    """``<sd>/reports/trace/`` — root of the unified token+decision trace."""
+    """``<sd>/reports/trace/`` — root of the unified token+decision trace.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/reports/trace``.
+    """
     return reports_dir(session_dir) / "trace"
 
 
@@ -224,13 +258,26 @@ def llm_calls_path(session_dir: Path) -> Path:
 
     Out-of-process children write to :func:`ext_trace_path` instead; the
     collector merges both streams.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/reports/trace/llm_calls.jsonl``.
     """
     return trace_dir(session_dir) / "llm_calls.jsonl"
 
 
 def trace_ext_dir(session_dir: Path) -> Path:
     """``<sd>/reports/trace/ext/`` — parent of every out-of-process child's
-    own ``<component>-<pid>.jsonl`` shard."""
+    own ``<component>-<pid>.jsonl`` shard.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/reports/trace/ext``.
+    """
     return trace_dir(session_dir) / "ext"
 
 
@@ -241,6 +288,14 @@ def ext_trace_path(session_dir: Path, component: str, pid: int) -> Path:
     CLI / tracelens) writes its own shard so concurrent children never
     contend on a shared file; the collector globs ``ext/*.jsonl`` and merges.
     The ``pid`` keeps shards disjoint across re-spawns of the same component.
+
+    Args:
+        session_dir: The session root directory.
+        component: Producer component name; blank falls back to ``"unknown"``.
+        pid: Process id of the producing child.
+
+    Returns:
+        ``<session_dir>/reports/trace/ext/<component>-<pid>.jsonl``.
     """
     comp = str(component or "").strip() or "unknown"
     return trace_ext_dir(session_dir) / f"{comp}-{int(pid)}.jsonl"
@@ -248,7 +303,14 @@ def ext_trace_path(session_dir: Path, component: str, pid: int) -> Path:
 
 def decision_trace_path(session_dir: Path) -> Path:
     """``<sd>/reports/trace/decision_trace.jsonl`` — collector output joining
-    every decision to its LLM token spend along the phase→tick timeline."""
+    every decision to its LLM token spend along the phase→tick timeline.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/reports/trace/decision_trace.jsonl``.
+    """
     return trace_dir(session_dir) / "decision_trace.jsonl"
 
 
@@ -262,25 +324,52 @@ def conversations_path(session_dir: Path) -> Path:
     can be replayed or exported (e.g. to Langfuse) after the fact. Both share
     the same ``session_id`` / ``component`` / ``tick`` / ``phase`` join keys
     so the two streams line up against ``decision_trace``.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/reports/trace/conversations.jsonl``.
     """
     return trace_dir(session_dir) / "conversations.jsonl"
 
 
 def research_hints_md(session_dir: Path) -> Path:
     """``<sd>/research_hints.md`` — human-readable proven-prior hints
-    collected by the research scout."""
+    collected by the research scout.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/research_hints.md``.
+    """
     return Path(session_dir) / "research_hints.md"
 
 
 def research_hints_json(session_dir: Path) -> Path:
     """``<sd>/research_hints.json`` — structured mirror of the research
-    hints (machine-readable; advisory gap-scoring reads this)."""
+    hints (machine-readable; advisory gap-scoring reads this).
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/research_hints.json``.
+    """
     return Path(session_dir) / "research_hints.json"
 
 
 def competitor_target_json(session_dir: Path) -> Path:
     """``<sd>/competitor_target.json`` — LLM-authored competitor target
-    numbers (each per-concurrency entry carries its own source)."""
+    numbers (each per-concurrency entry carries its own source).
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/competitor_target.json``.
+    """
     return Path(session_dir) / "competitor_target.json"
 
 
@@ -314,6 +403,12 @@ def optimizer_runs_dir(session_dir: Path) -> Path:
     """``<sd>/optimizer_runs/`` — launcher artefacts (run_<tag>.log / .pid /
     robustness_monitor_*.log). Under $USER_DATA_PATH so one override moves
     the whole run tail.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/optimizer_runs``.
     """
     return Path(session_dir) / "optimizer_runs"
 
@@ -426,6 +521,12 @@ def agent_prompt_snapshot(session_dir: Path, role: str) -> Path:
 def target_analysis_dir(session_dir: Path) -> Path:
     """``<sd>/target_analysis/`` — external baseline artefacts. Owner:
     TargetAnalysisExecutor; reader: ReportExecutor.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/target_analysis``.
     """
     return Path(session_dir) / "target_analysis"
 
@@ -479,6 +580,12 @@ def cortex_dir(session_dir: Path) -> Path:
 def cortex_sid_file(session_dir: Path) -> Path:
     """``<sd>/runtime/cortex/.kb_sid`` — Cortex session id from T0 ``session
     begin`` (resume reuses it). Absent => --degraded-kb or T0 not yet run.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/runtime/cortex/.kb_sid``.
     """
     return cortex_dir(session_dir) / ".kb_sid"
 
@@ -517,6 +624,12 @@ def cortex_pending_ndjson(session_dir: Path) -> Path:
     """``<sd>/runtime/cortex/.kb_pending.ndjson`` — append-only async write
     queue for T2/T3 ops. Consumed by the cortex_kb_flusher daemon; drained at
     T4 before ``session commit``.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/runtime/cortex/.kb_pending.ndjson``.
     """
     return cortex_dir(session_dir) / ".kb_pending.ndjson"
 
@@ -555,6 +668,12 @@ def cortex_dead_letter_ndjson(session_dir: Path) -> Path:
 def cortex_audit_jsonl(session_dir: Path) -> Path:
     """``<sd>/runtime/cortex/.kb_audit.jsonl`` — append-only audit of every
     direct Cortex CLI invocation. Source of truth for breakdown.kb_provenance.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/runtime/cortex/.kb_audit.jsonl``.
     """
     return cortex_dir(session_dir) / ".kb_audit.jsonl"
 
@@ -579,6 +698,12 @@ def recipe_snapshot_dir(session_dir: Path) -> Path:
 def recipe_snapshot_audit_jsonl(session_dir: Path) -> Path:
     """``<sd>/runtime/recipe_snapshot/.audit.jsonl`` — append-only audit of
     every recipe-snapshot remote READ call (writes are local-only and skip it).
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/runtime/recipe_snapshot/.audit.jsonl``.
     """
     return recipe_snapshot_dir(session_dir) / ".audit.jsonl"
 
@@ -588,6 +713,12 @@ def pr_monitor_status_json(session_dir: Path) -> Path:
     reachability snapshot; breakdown reads it for pr_monitor:* warnings.
 
     Schema: ``{enabled, url, reachable, mcp_url, window_days, status_text}``.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/runtime/cortex/.pr_monitor_status.json``.
     """
     return cortex_dir(session_dir) / ".pr_monitor_status.json"
 
@@ -614,6 +745,12 @@ def cortex_flusher_status_json(session_dir: Path) -> Path:
 
     Schema: ``{enabled, spawned, pid, cmd, cortex_kb_url, interval_sec,
     batch_size, reason, ts}``.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/runtime/cortex/.kb_flusher_status.json``.
     """
     return cortex_dir(session_dir) / ".kb_flusher_status.json"
 

--- a/inference_optimizer/storage/connection.py
+++ b/inference_optimizer/storage/connection.py
@@ -156,7 +156,12 @@ class SqliteConnection:
 
     @contextlib.contextmanager
     def transaction_sync(self) -> Iterator[sqlite3.Cursor]:
-        """Synchronous BEGIN IMMEDIATE -> COMMIT/ROLLBACK."""
+        """Synchronous BEGIN IMMEDIATE -> COMMIT/ROLLBACK.
+
+        Yields:
+            An open cursor inside the immediate write transaction; the
+            transaction commits on clean exit and rolls back on exception.
+        """
         with self._sync_lock:
             cur = self._conn.cursor()
             try:
@@ -233,6 +238,10 @@ class SqliteConnection:
             async with conn.transaction() as cur:
                 cur.execute("INSERT INTO events (...) VALUES (...)", row)
                 cur.execute("UPDATE cursors SET ...", row2)
+
+        Yields:
+            An open cursor inside the immediate write transaction; the
+            transaction commits on clean exit and rolls back on exception.
         """
         await self._async_lock.acquire()
         try:

--- a/inference_optimizer/storage/schema.py
+++ b/inference_optimizer/storage/schema.py
@@ -139,6 +139,13 @@ def _migrate_leases_v1_to_v2(cur: sqlite3.Cursor) -> bool:
     ``(lane, holder_id)``). Returns True when a migration ran, False when
     already migrated / unknown shape. Snapshots rows, recreates the table,
     re-inserts; runs inside the caller's BEGIN IMMEDIATE.
+
+    Args:
+        cur: Open SQLite cursor within the caller's transaction.
+
+    Returns:
+        ``True`` when a migration ran, ``False`` when already migrated or the
+        table has an unknown shape.
     """
     try:
         cur.execute("PRAGMA table_info(leases)")
@@ -193,7 +200,11 @@ def _migrate_leases_v1_to_v2(cur: sqlite3.Cursor) -> bool:
 
 def _seed_default_lane_capacity(cur: sqlite3.Cursor) -> None:
     """Idempotently insert default capacity rows; existing rows are left
-    alone so a resume preserves the operator's choice."""
+    alone so a resume preserves the operator's choice.
+
+    Args:
+        cur: Open SQLite cursor within the caller's transaction.
+    """
     for lane, capacity in DEFAULT_LANE_CAPACITIES.items():
         cur.execute(
             "INSERT OR IGNORE INTO lane_capacity(lane, capacity) "
@@ -265,6 +276,12 @@ def ensure_schema(conn: sqlite3.Connection) -> int:
     """Idempotently create all tables, run the leases PK migration, seed
     lane_capacity defaults, and record the schema version. Single
     transaction so readers never see an intermediate schema.
+
+    Args:
+        conn: Open database connection.
+
+    Returns:
+        The current (max) recorded schema version.
     """
     cur = conn.cursor()
     try:

--- a/kernel-agent/tools/_collective_names.py
+++ b/kernel-agent/tools/_collective_names.py
@@ -27,7 +27,14 @@ _CAMEL_BOUNDARY = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
 
 
 def _normalise_kernel_name(name: str) -> str:
-    """Lowercase + underscore-delimit *name* so substring tests are stable."""
+    """Lowercase and underscore-delimit a name so substring tests are stable.
+
+    Args:
+        name: The raw kernel name.
+
+    Returns:
+        The normalized name, or an empty string if ``name`` is falsy.
+    """
     if not name:
         return ""
     s = _CAMEL_BOUNDARY.sub("_", str(name))
@@ -37,7 +44,16 @@ def _normalise_kernel_name(name: str) -> str:
 
 
 def kernel_name_implies_multigpu(name: str) -> bool:
-    """Return True iff *name* matches a known collective-op pattern (leaf-name only)."""
+    """Report whether a kernel name implies a multi-GPU collective op.
+
+    Matching uses the leaf name only against known collective-op patterns.
+
+    Args:
+        name: The kernel name to test.
+
+    Returns:
+        ``True`` if the name matches a known collective-op pattern.
+    """
     norm = _normalise_kernel_name(name)
     if not norm:
         return False

--- a/kernel-agent/tools/_paths.py
+++ b/kernel-agent/tools/_paths.py
@@ -21,7 +21,14 @@ _WARNED_NO_USER_DATA = False
 
 
 def workspace_root() -> str:
-    """Return ``$USER_DATA_PATH`` if set, else ``DEFAULT_WORKSPACE_ROOT`` (warns once)."""
+    """Resolve the workspace root for kernel-agent tool outputs.
+
+    Returns ``$USER_DATA_PATH`` when set; otherwise falls back to
+    ``DEFAULT_WORKSPACE_ROOT`` and logs a one-time misconfiguration warning.
+
+    Returns:
+        The resolved workspace root path.
+    """
     global _WARNED_NO_USER_DATA
     user_data = os.environ.get(ENV_USER_DATA_PATH)
     if user_data:

--- a/kernel-agent/tools/_payload_aliases.py
+++ b/kernel-agent/tools/_payload_aliases.py
@@ -40,10 +40,17 @@ def _coerce_str(value: Any) -> str:
 
 
 def read_extra_server_args(payload: dict, *, default: str = "") -> str:
-    """Read ``extra_server_args`` with a read-only fallback to legacy ``extra_sglang_args``.
+    """Read ``extra_server_args`` with a fallback to legacy ``extra_sglang_args``.
 
-    Canonical wins silently; legacy-only emits one DeprecationWarning; neither
-    returns ``default``.
+    The canonical key wins silently; a legacy-only payload emits one
+    ``DeprecationWarning``; if neither key is present, ``default`` is returned.
+
+    Args:
+        payload: The payload dict to read from.
+        default: Value returned when neither key is present.
+
+    Returns:
+        The coerced string value for the server args.
     """
     if CANONICAL_KEY in payload:
         return _coerce_str(payload[CANONICAL_KEY])

--- a/kernel-agent/tools/apply_kernel_patch.py
+++ b/kernel-agent/tools/apply_kernel_patch.py
@@ -99,7 +99,12 @@ _MN_STATE_FILE = Path(_MN_STATE_FILE_DEFAULT)
 
 
 def _is_multi_node() -> bool:
-    """True iff a multi-node RayJob is active (nodes >= 2); missing/unreadable → False."""
+    """Report whether a multi-node RayJob is active.
+
+    Returns:
+        ``True`` when the state file reports ``nodes >= 2``; ``False`` when the
+        state file is missing or unreadable.
+    """
     state_path = _mn_state_path()
     try:
         if not state_path.is_file():
@@ -118,10 +123,21 @@ def _dispatch_multinode_apply(
     backup_dir_on_pod: str,
     timeout_sec: int = 180,
 ) -> dict[str, Any]:
-    """Fan the patch out to every pod (head + workers); return parsed JSON.
+    """Fan a patch out to every pod (head + workers).
 
-    Raises RuntimeError on subprocess failure / non-JSON / pod status != ok so
-    the caller can roll back the sandbox-local copy.
+    Args:
+        target_file: The file to patch on each pod.
+        patch_path: Path to the patch file to apply.
+        kernel_id: Identifier of the kernel being patched.
+        backup_dir_on_pod: Directory on each pod to store backups.
+        timeout_sec: Subprocess timeout in seconds.
+
+    Returns:
+        The parsed JSON result from the multi-node dispatch.
+
+    Raises:
+        RuntimeError: On subprocess failure, non-JSON output, or a pod status
+            other than ``ok`` (so the caller can roll back the local copy).
     """
     cmd = [
         sys.executable, "-m", "inference_optimizer.multi_node",
@@ -162,7 +178,18 @@ def _dispatch_multinode_revert(
     backup_map: dict[str, str],
     timeout_sec: int = 120,
 ) -> dict[str, Any]:
-    """Restore the original file on every pod that received the apply (best-effort)."""
+    """Restore the original file on every pod that received the apply.
+
+    Best-effort: failures are reported in the result rather than raised.
+
+    Args:
+        target_path: The patched file path to restore on each pod.
+        backup_map: Mapping of pod identifier to its backup path.
+        timeout_sec: Subprocess timeout in seconds.
+
+    Returns:
+        The parsed JSON result, or an empty dict when output is not JSON.
+    """
     cmd = [
         sys.executable, "-m", "inference_optimizer.multi_node",
         "revert-patch",
@@ -439,12 +466,24 @@ _AITER_CSRC_MARKER = "/aiter/csrc/"
 
 
 def _target_is_in_aiter_csrc(target_file: Path) -> bool:
-    """Return True iff ``target_file`` resides under any ``aiter/csrc/`` tree."""
+    """Report whether a file resides under an ``aiter/csrc/`` tree.
+
+    Args:
+        target_file: The file path to test.
+
+    Returns:
+        ``True`` if the path is under an ``aiter/csrc/`` directory.
+    """
     return _AITER_CSRC_MARKER in str(target_file).replace(os.sep, "/")
 
 
 def _aiter_jit_build_dir() -> Path | None:
-    """Return ``<aiter>/jit/build`` for the importable aiter, or ``None`` if absent."""
+    """Locate the importable aiter package's ``jit/build`` directory.
+
+    Returns:
+        The ``<aiter>/jit/build`` path, or ``None`` when aiter is not
+        importable.
+    """
     try:
         spec = importlib.util.find_spec("aiter")
     except (ImportError, ValueError):
@@ -461,9 +500,16 @@ def _invalidate_aiter_jit_build(
     *,
     jit_build_dir_override: Path | None = None,
 ) -> dict[str, Any]:
-    """Move aiter ``jit/build/`` aside so a post-rebuild first import re-JITs.
+    """Move aiter ``jit/build/`` aside so a post-rebuild import re-JITs.
 
-    Returns status ok / skipped / failed; ``jit_build_dir_override`` is test-only.
+    Args:
+        target_file: The file being patched (gates the operation).
+        backup_dir: Directory to move the ``jit/build`` tree into.
+        jit_build_dir_override: Test-only override for the jit/build location.
+
+    Returns:
+        A status dict with ``status`` of ``ok``, ``skipped``, or ``failed``
+        and supporting fields.
     """
     if not _target_is_in_aiter_csrc(target_file):
         return {"status": "skipped", "reason": "target not under aiter/csrc/"}
@@ -508,7 +554,17 @@ def _invalidate_aiter_jit_build(
 
 
 def _restore_aiter_jit_build(jit_build_backup: dict[str, Any]) -> dict[str, Any]:
-    """Reverse of :func:`_invalidate_aiter_jit_build`: restore the backup, removing any regenerated dir first."""
+    """Restore an aiter ``jit/build`` backup, reversing the invalidation.
+
+    Any regenerated ``jit/build`` directory is removed first.
+
+    Args:
+        jit_build_backup: The backup record returned by
+            :func:`_invalidate_aiter_jit_build`.
+
+    Returns:
+        A status dict with ``status`` of ``ok``, ``skipped``, or ``failed``.
+    """
     if not isinstance(jit_build_backup, dict) or jit_build_backup.get("status") != "ok":
         return {"status": "skipped", "reason": "no backup recorded"}
     src = Path(jit_build_backup.get("src", ""))
@@ -578,7 +634,7 @@ _MD_NAME_RE = re.compile(r"""(?m)^\s*MD_NAME\s*=\s*["']([^"']+)["']""")
 
 
 def _target_is_in_aiter_cpp_itfs(target_file: Path) -> bool:
-    """True iff ``target_file`` lives under any ``aiter/csrc/cpp_itfs/`` tree.
+    """Report whether a file lives under an ``aiter/csrc/cpp_itfs/`` tree.
 
     Strict subset of :func:`_target_is_in_aiter_csrc`: these are the
     runtime-compiled kernels whose served ``.so`` lives in
@@ -586,6 +642,12 @@ def _target_is_in_aiter_cpp_itfs(target_file: Path) -> bool:
     statically-linked wheel. Matches both the editable checkout
     (``/sgl-workspace/aiter/csrc/cpp_itfs/...``) and the dist-packages
     layout (``.../aiter/csrc/cpp_itfs/...``).
+
+    Args:
+        target_file: The file path to test.
+
+    Returns:
+        ``True`` if the path is under an ``aiter/csrc/cpp_itfs/`` directory.
     """
     return _AITER_CPP_ITFS_MARKER in str(target_file).replace(os.sep, "/")
 
@@ -597,6 +659,9 @@ def _aiter_cpp_itfs_build_dir() -> Path:
     ``$AITER_ROOT_DIR`` defaulting to ``$HOME/.aiter``. Honouring both env
     vars keeps non-default deployments + unit tests correct without importing
     aiter into this standalone tool.
+
+    Returns:
+        The resolved cpp_itfs ``build`` directory path.
     """
     root = os.environ.get("AITER_ROOT_DIR", "").strip()
     if not root:
@@ -606,16 +671,21 @@ def _aiter_cpp_itfs_build_dir() -> Path:
 
 
 def _cpp_itfs_module_names(target_file: Path) -> list[str]:
-    """Best-effort ``MD_NAME`` prefix(es) for the cpp_itfs module(s) the
-    patched source feeds.
+    """Collect ``MD_NAME`` prefixes for the cpp_itfs module(s) a source feeds.
 
     The cpp_itfs ``.py`` driver next to the patched source declares
     ``MD_NAME = "pa_ragged"`` (etc.), which becomes the
     ``<md_name>_<hash>`` runtime-cache folder prefix. A single shared
     ``.cuh`` (e.g. ``pa_kernels.cuh``) is pulled into several drivers in the
     same directory, so we collect EVERY ``MD_NAME`` declared in the target's
-    directory. An empty result tells the caller to fall back to clearing the
-    whole cpp_itfs build root.
+    directory.
+
+    Args:
+        target_file: The patched source file whose directory is scanned.
+
+    Returns:
+        The discovered ``MD_NAME`` prefixes. An empty list tells the caller to
+        fall back to clearing the whole cpp_itfs build root.
     """
     names: set[str] = set()
     search_dir = target_file.parent
@@ -651,6 +721,14 @@ def _invalidate_aiter_cpp_itfs_cache(
     The record always carries ``is_cpp_itfs`` + ``build_dir`` +
     ``module_names`` + ``invalidated_unix`` (even when nothing was cached
     yet) so integrate can later verify a fresh rebuild actually landed.
+
+    Args:
+        target_file: The file being patched (gates the operation).
+        backup_dir: Directory to move affected cache dirs into.
+        build_dir_override: Test-only override for the cpp_itfs build root.
+
+    Returns:
+        A status dict recording what was moved and the invalidation metadata.
 
     Returns one of ``ok`` / ``skipped`` / ``failed`` mirroring
     :func:`_invalidate_aiter_jit_build`. ``build_dir_override`` is a
@@ -733,6 +811,13 @@ def _restore_aiter_cpp_itfs_cache(cache_backup: dict[str, Any]) -> dict[str, Any
     Moves each backed-up cache dir back to its original location, removing
     any dir the re-baseline server regenerated there first so the pre-patch
     runtime cache is restored bit-for-bit.
+
+    Args:
+        cache_backup: The backup record from
+            :func:`_invalidate_aiter_cpp_itfs_cache`.
+
+    Returns:
+        A status dict with ``status`` of ``ok``, ``skipped``, or ``failed``.
     """
     if not isinstance(cache_backup, dict) or cache_backup.get("status") != "ok":
         return {"status": "skipped", "reason": "no cpp_itfs cache backup recorded"}
@@ -776,9 +861,14 @@ def verify_cpp_itfs_rebuilt(cache_backup: dict[str, Any]) -> dict[str, Any]:
     measured gain is meaningless -- the integrate KEEP/REVERT gate uses this
     to flag/abort instead of scoring a stale binary (GH #458 point 2).
 
-    Returns ``{"verified": bool, ...}``. ``verified`` is True for
-    non-cpp_itfs targets so the caller's gate is a strict no-op off the
-    cpp_itfs path.
+    Args:
+        cache_backup: The invalidation record from
+            :func:`_invalidate_aiter_cpp_itfs_cache`.
+
+    Returns:
+        A dict ``{"verified": bool, ...}``. ``verified`` is ``True`` for
+        non-cpp_itfs targets so the caller's gate is a strict no-op off the
+        cpp_itfs path.
     """
     if not isinstance(cache_backup, dict) or not cache_backup.get("is_cpp_itfs"):
         return {"verified": True, "status": "skipped", "reason": "non-cpp_itfs target"}

--- a/kernel-agent/tools/backends/oob_submit.py
+++ b/kernel-agent/tools/backends/oob_submit.py
@@ -133,7 +133,18 @@ def _build_cmd(agent: str, prompt_file: Path, output_dir: Path,
 
 
 def _parse_oob_init(stdout: str) -> dict[str, str]:
-    """Extract cwd / session_id / thread_id from oob run --json output (trailing summary, else ndjson init)."""
+    """Extract workspace and session identifiers from ``oob run`` JSON output.
+
+    Prefers the trailing oob-run JSON summary, falling back to the ndjson init
+    record.
+
+    Args:
+        stdout: The captured stdout from ``oob run --json``.
+
+    Returns:
+        A dict with ``cli_workspace``, ``session_id``, and ``thread_id`` keys
+        (empty strings when not found).
+    """
     info = {"cli_workspace": "", "session_id": "", "thread_id": ""}
     if not stdout:
         return info

--- a/kernel-agent/tools/backends/ray_runtime.py
+++ b/kernel-agent/tools/backends/ray_runtime.py
@@ -27,11 +27,13 @@ DEFAULT_MIN_NOFILE = 65536
 
 
 def _fd_limit_warn(msg: str) -> None:
-    """Single indirection for fd-limit warnings.
+    """Emit an fd-limit warning to stderr with a stable prefix.
 
     Kept as a module function so tests can capture it and so every warning
-    carries the same prefix. Goes to stderr; callers that own a log_path
-    also get a line in the Ray lifecycle log.
+    carries the same prefix.
+
+    Args:
+        msg: The warning message body.
     """
     print(f"[kernel-agent WARN] {msg}", file=sys.stderr)
 
@@ -52,8 +54,7 @@ def _min_nofile_target() -> int:
 def ensure_fd_limit(
     min_soft: Optional[int] = None, log_path: Optional[Path] = None,
 ) -> Tuple[int, int]:
-    """Raise this process's RLIMIT_NOFILE soft limit before Ray spawns the
-    raylet (issue #433).
+    """Raise this process's RLIMIT_NOFILE soft limit before Ray starts.
 
     The child ``ray start`` process inherits this process's limits, so the
     raylet's open-files ceiling is whatever we set here. We raise the soft
@@ -61,9 +62,15 @@ def ensure_fd_limit(
     cap needs no privileges; lifting the hard cap does (CAP_SYS_RESOURCE),
     so when the hard cap is itself below ``min_soft`` we raise soft as high
     as allowed and warn — only ``docker run --ulimit nofile=...`` at
-    container launch can lift the hard cap in an unprivileged container.
+    container launch can lift the hard cap in an unprivileged container
+    (issue #433).
 
-    Returns the ``(soft, hard)`` limit in effect after the call.
+    Args:
+        min_soft: Target soft limit; defaults to the configured target.
+        log_path: Optional path to append a lifecycle log line.
+
+    Returns:
+        The ``(soft, hard)`` limit in effect after the call.
     """
     if min_soft is None:
         min_soft = _min_nofile_target()
@@ -127,6 +134,13 @@ def isolated_compile_cache_env(output_dir, base_env: Optional[dict] = None) -> d
     ``AITER_ROOT_DIR`` only steers aiter's cpp_itfs ``BUILD_DIR`` -- sources
     and configs resolve off the package dir -- so redirecting it is
     compile-safe.
+
+    Args:
+        output_dir: The per-attempt output directory caches are nested under.
+        base_env: Base environment to copy; defaults to ``os.environ``.
+
+    Returns:
+        An environment dict with per-attempt cache directories set.
     """
     env = dict(os.environ if base_env is None else base_env)
     base = os.path.join(str(output_dir), ".cache")
@@ -163,7 +177,15 @@ def ray_status_ok() -> bool:
 def ensure_ray_cluster(num_gpus: Optional[int] = None, log_path: Optional[Path] = None) -> bool:
     """Ensure a Ray cluster is reachable, starting a head node if needed.
 
-    Returns True if this call started Ray, False if already running; raises on failure.
+    Args:
+        num_gpus: Optional GPU count to pass to ``ray start --head``.
+        log_path: Optional path to append ``ray start`` output.
+
+    Returns:
+        ``True`` if this call started Ray, ``False`` if it was already running.
+
+    Raises:
+        RuntimeError: If starting the Ray head node fails.
     """
     if ray_status_ok():
         return False
@@ -210,14 +232,36 @@ def stop_ray_if_owned(started: bool, log_path: Optional[Path] = None) -> None:
 
 
 def _is_ray_version_mismatch(text: str) -> bool:
-    """True when Ray refused the job due to a cluster started under a different Python/Ray (issue #432); matches the stable ``Version mismatch`` banner."""
+    """Detect Ray's version-mismatch banner in captured output.
+
+    Indicates the cluster was started under a different Python/Ray than this
+    process (issue #432).
+
+    Args:
+        text: The captured error or output text.
+
+    Returns:
+        ``True`` if the text contains the stable version-mismatch banner.
+    """
     return "version mismatch" in (text or "").lower()
 
 
 def force_restart_local_cluster(
     num_gpus: Optional[int] = None, log_path: Optional[Path] = None,
 ) -> None:
-    """Tear down any reachable Ray cluster and start a fresh local head under THIS interpreter. Recovers from a stale/foreign cluster (issue #432) whose version mismatch otherwise mislabels as a "compile failed" REVERT; also clears raylet zombies. Raises RuntimeError if the fresh head fails to start."""
+    """Tear down any reachable Ray cluster and start a fresh local head.
+
+    The fresh head runs under this interpreter, recovering from a
+    stale/foreign cluster (issue #432) whose version mismatch otherwise
+    mislabels as a "compile failed" REVERT; this also clears raylet zombies.
+
+    Args:
+        num_gpus: Optional GPU count for the fresh head node.
+        log_path: Optional path to append restart output.
+
+    Raises:
+        RuntimeError: If the fresh head node fails to start.
+    """
     # issue #433: raise the open-files limit before the fresh raylet starts
     # so it inherits a high enough ceiling (the container default 1024 makes
     # the raylet abort on startup / linger as a zombie).
@@ -312,6 +356,10 @@ def quiet_ray_init(num_gpus: Optional[int] = None, log_path: Optional[Path] = No
     once. ``num_gpus`` / ``log_path`` are threaded through to the restart so
     the new head matches the requested GPU count and the action is audited
     in ``ray_lifecycle.log``.
+
+    Args:
+        num_gpus: Optional GPU count forwarded to a restart, if needed.
+        log_path: Optional path to audit Ray lifecycle actions.
     """
     import contextlib
     import io

--- a/kernel-agent/tools/geak_prompt_patcher.py
+++ b/kernel-agent/tools/geak_prompt_patcher.py
@@ -39,10 +39,14 @@ _DEFAULT_REL_PATH = Path("minisweagent/config/mini_kernel_strategy_list.yaml")
 
 
 def _locate_yaml() -> Path | None:
-    """Return the bundled GEAK strategy YAML path.
+    """Locate the bundled GEAK strategy YAML.
 
-    Resolves ``$HYPERLOOM_GEAK_PROMPT_YAML`` (test override) then the
-    minisweagent package; ``None`` when the package isn't importable.
+    Resolves ``$HYPERLOOM_GEAK_PROMPT_YAML`` (test override) first, then the
+    ``minisweagent`` package location.
+
+    Returns:
+        The YAML path, or ``None`` when the override file is missing or the
+        package isn't importable.
     """
     override = os.environ.get("HYPERLOOM_GEAK_PROMPT_YAML", "").strip()
     if override:
@@ -60,7 +64,12 @@ def _locate_yaml() -> Path | None:
 
 
 def _atomic_write(target: Path, content: str) -> None:
-    """Write ``content`` to ``target`` atomically via tempfile + replace."""
+    """Write content to a file atomically via a tempfile and replace.
+
+    Args:
+        target: Destination file path.
+        content: Text to write.
+    """
     with tempfile.NamedTemporaryFile(
         "w", dir=str(target.parent), delete=False, encoding="utf-8",
     ) as tmp:
@@ -74,7 +83,15 @@ def _atomic_write(target: Path, content: str) -> None:
 
 
 def ensure_geak_prompt_patched() -> tuple[bool, str]:
-    """Patch the bundled YAML in-place; idempotent and fail-soft. Returns ``(ok, message)``."""
+    """Patch the bundled GEAK strategy YAML in place.
+
+    The operation is idempotent and fail-soft: it skips when already patched,
+    when the package is absent, or when upstream wording has drifted.
+
+    Returns:
+        A ``(ok, message)`` tuple where ``ok`` indicates success and
+        ``message`` is a human-readable status.
+    """
     yaml_path = _locate_yaml()
     if yaml_path is None:
         return False, "minisweagent not installed (skip)"
@@ -100,7 +117,14 @@ def ensure_geak_prompt_patched() -> tuple[bool, str]:
 
 
 def main() -> int:
-    """CLI entry for install.sh; exits 0 unless ``$HYPERLOOM_GEAK_PROMPT_PATCH_REQUIRED == 1``."""
+    """Run the patcher as a CLI entry point for ``install.sh``.
+
+    Exits 0 unless the patch fails and
+    ``$HYPERLOOM_GEAK_PROMPT_PATCH_REQUIRED == 1``.
+
+    Returns:
+        Process exit code (0 on success or soft-skip, 1 on required failure).
+    """
     ok, msg = ensure_geak_prompt_patched()
     status = "OK" if ok else "WARN"
     print(f"[geak-prompt-patcher] {status}: {msg}")

--- a/kernel-agent/tools/harness_generator.py
+++ b/kernel-agent/tools/harness_generator.py
@@ -167,7 +167,15 @@ class BenchmarkAnalyzer:
     def classify_functions(
         self, decorated: dict[str, FuncInfo]
     ) -> tuple[FuncInfo | None, FuncInfo | None]:
-        """Classify decorated functions into (reference, kernel); either can be None."""
+        """Classify decorated functions into a reference/kernel pair.
+
+        Args:
+            decorated: Mapping of function name to its :class:`FuncInfo`.
+
+        Returns:
+            A ``(reference, kernel)`` tuple; either element may be ``None``
+            when no suitable candidate is found.
+        """
         ref_candidates: list[FuncInfo] = []
         kernel_candidates: list[FuncInfo] = []
 
@@ -218,7 +226,14 @@ class BenchmarkAnalyzer:
         return ref, kernel
 
     def get_test_function(self, decorated: dict[str, FuncInfo]) -> FuncInfo | None:
-        """Find the main test/benchmark orchestrator function."""
+        """Find the main test/benchmark orchestrator function.
+
+        Args:
+            decorated: Mapping of function name to its :class:`FuncInfo`.
+
+        Returns:
+            The orchestrator :class:`FuncInfo`, or ``None`` if none is found.
+        """
         # Prefer a @benchmark-decorated function; else a top-level test_*/bench_* caller.
         for fi in decorated.values():
             if fi.decorator == "benchmark":
@@ -373,7 +388,14 @@ class BenchmarkAnalyzer:
 # Config builder — from TraceLens input_shapes
 
 def _build_configs(candidate: dict) -> tuple[str, str, str]:
-    """Build (ALL_CONFIGS, cfg unpack, config_str) code from candidate shapes."""
+    """Build harness config code from a candidate's trace shapes.
+
+    Args:
+        candidate: Candidate dict carrying ``input_shapes`` from TraceLens.
+
+    Returns:
+        A tuple of ``(ALL_CONFIGS, cfg unpack, config_str)`` code fragments.
+    """
     input_shapes = candidate.get("input_shapes") or []
     if not input_shapes:
         return _default_configs()
@@ -507,7 +529,20 @@ def _generate_setup_inputs(
     ref_func: FuncInfo | None,
     kernel_func: FuncInfo | None,
 ) -> str:
-    """Generate the setup_inputs(cfg) body, creating inputs only for args the test actually passes."""
+    """Generate the ``setup_inputs(cfg)`` body for the harness.
+
+    Inputs are created only for args the test actually passes.
+
+    Args:
+        analyzer: The benchmark analyzer for the source module.
+        test_func: The orchestrator test function, if any.
+        cfg_unpack: The config-unpack code line (e.g. ``M, N = cfg``).
+        ref_func: The reference function, if any.
+        kernel_func: The kernel function, if any.
+
+    Returns:
+        The generated ``setup_inputs`` body as source text.
+    """
     dim_vars = cfg_unpack.replace(" = cfg", "").split(", ")
     dim_vars = [v.strip() for v in dim_vars if v.strip() != "dtype"]
 
@@ -567,7 +602,17 @@ def _generate_setup_inputs(
 def _match_call_args_to_params(
     call: CallInfo, params: list[str]
 ) -> list[tuple[str, str | None]]:
-    """Match call args to params, returning [(param, call_value_or_None), ...] (positional + tensor kwargs)."""
+    """Match a call's args to a function's parameters.
+
+    Handles positional args and tensor keyword args.
+
+    Args:
+        call: The call-site info to match.
+        params: The target function's parameter names.
+
+    Returns:
+        A list of ``(param, call_value_or_None)`` tuples.
+    """
     result: list[tuple[str, str | None]] = []
 
     # Positional args are always required.
@@ -675,7 +720,18 @@ def _generate_run_func_body(
     test_func: FuncInfo | None,
     target_func: FuncInfo,
 ) -> str:
-    """Generate a body that calls target_func with inputs dict values; missing params use defaults."""
+    """Generate a run-function body that calls the target function.
+
+    Arguments are pulled from the inputs dict; missing params use defaults.
+
+    Args:
+        analyzer: The benchmark analyzer for the source module.
+        test_func: The orchestrator test function, if any.
+        target_func: The function the generated body should call.
+
+    Returns:
+        The generated run-function body as source text.
+    """
     call = None
     if test_func:
         call = analyzer.extract_call_to(test_func, target_func.name)

--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -155,6 +155,12 @@ def resolve_candidates_path(run_dir: Path) -> Path:
     Falls back to the flat path (which ``load_candidates`` will surface as a
     clean ``FileNotFoundError``) when nothing matches, preserving the
     "no fabricated target" failure mode for genuinely missing analyses.
+
+    Args:
+        run_dir: The ``runs/<session_id>/`` root for the session.
+
+    Returns:
+        The resolved ``kernel_candidates.json`` path (possibly non-existent).
     """
     flat = run_dir / "kernel_candidates.json"
     if flat.is_file():
@@ -176,7 +182,15 @@ def resolve_candidates_path(run_dir: Path) -> Path:
 def load_candidates(path: Path) -> list[dict[str, Any]]:
     """Load kernel candidates from JSON, normalizing legacy shapes.
 
-    Per Hyperloom#314 returns the union of ``hot_kernels`` (routable) + ``skipped_kernels`` so id lookup still resolves non-routable kernels; legacy flat-list / ``kernel_candidates`` shapes respected.
+    Per Hyperloom#314 returns the union of ``hot_kernels`` (routable) +
+    ``skipped_kernels`` so id lookup still resolves non-routable kernels;
+    legacy flat-list / ``kernel_candidates`` shapes are respected.
+
+    Args:
+        path: Path to the ``kernel_candidates.json`` file.
+
+    Returns:
+        The list of candidate dicts, with trace-report paths backfilled.
     """
     payload = json.loads(path.read_text(encoding="utf-8"))
     if isinstance(payload, list):
@@ -212,7 +226,17 @@ def load_candidates(path: Path) -> list[dict[str, Any]]:
 
 
 def _normalize_kernel_id(value: str) -> str:
-    """Fold hallucinated ``kn``/``rn`` prefixes onto the real ``k`` numbering, lower-cased, for tolerant comparison."""
+    """Normalize a kernel id for tolerant comparison.
+
+    Folds hallucinated ``kn``/``rn`` prefixes onto the real ``k`` numbering and
+    lower-cases the value.
+
+    Args:
+        value: The raw kernel id.
+
+    Returns:
+        The normalized kernel id.
+    """
     s = value.strip().lower()
     for prefix in ("kn", "rn"):
         if s.startswith(prefix) and s[len(prefix):].isdigit():
@@ -223,7 +247,19 @@ def _normalize_kernel_id(value: str) -> str:
 def find_candidate(
     candidates: list[dict[str, Any]], kernel_id: str
 ) -> dict[str, Any] | None:
-    """Resolve a candidate by exact ``kernel_id``, then unique routable ``name``, then normalized id (``kn``/``rn``→``k``); ``None`` if nothing matches (caller skips gracefully)."""
+    """Resolve a candidate by id with progressively looser matching.
+
+    Tries exact ``kernel_id`` first, then a unique routable ``name`` match,
+    then a normalized id (``kn``/``rn`` → ``k``).
+
+    Args:
+        candidates: The candidate dicts to search.
+        kernel_id: The kernel id (or name) to resolve.
+
+    Returns:
+        The matching candidate, or ``None`` when nothing matches (the caller
+        skips gracefully).
+    """
     for candidate in candidates:
         if candidate.get("kernel_id") == kernel_id:
             return candidate
@@ -299,6 +335,15 @@ def _resolve_source_file(
     kernel, e.g. DeepSeek-R1 routed an MHA rewrite at ``fused_moe.py``); a
     differing LLM path emits a ``[source-override]`` warning. Falls back to the
     LLM path when the candidate has no source_file.
+
+    Args:
+        llm_source: The LLM-supplied ``--source-file`` path.
+        candidate: The TraceLens candidate dict (source of truth).
+        kernel_id: The kernel id, used in log messages.
+        log_path: Optional path to append override/fallback notes.
+
+    Returns:
+        The effective source file path to use.
     """
     cand_source = str((candidate or {}).get("source_file") or "").strip()
     llm = str(llm_source or "").strip()
@@ -398,6 +443,13 @@ def _match_benchmark_for_kernel(
     kernel-name regex hoists that family's bench files to the front (earlier
     patterns win). No match preserves the original order. Prevents picking an
     off-topic benchmark (e.g. fmha → test_pa.py stalling GEAK Step-5).
+
+    Args:
+        kernel_name: The kernel name to match patterns against.
+        bench_files: Candidate benchmark file paths.
+
+    Returns:
+        The benchmark paths reordered so the matching family comes first.
     """
     existing = [p for p in (bench_files or []) if isinstance(p, str) and p]
     if not existing:
@@ -434,8 +486,11 @@ def _profile_timeout_sec() -> int:
 
     Injected as a ``timeout <N>`` prefix on the test_command so a default-matrix
     benchmark (e.g. aiter test_pa.py) can't stall Step 5 for hours; SIGTERM at N
-    surfaces as a normal profiling failure. Default 600s, override via
-    ``KERNEL_OPT_PROFILE_TIMEOUT_SEC``, floored at 1.
+    surfaces as a normal profiling failure.
+
+    Returns:
+        The timeout in seconds: 600 by default, overridable via
+        ``KERNEL_OPT_PROFILE_TIMEOUT_SEC``, floored at 1.
     """
     try:
         value = int(os.environ.get("KERNEL_OPT_PROFILE_TIMEOUT_SEC", "600"))
@@ -701,7 +756,15 @@ def _env_target_platform() -> str:
 
 
 def _format_shapes_for_case(shapes: Any) -> str:
-    """Render a candidate row's ``shapes`` field as one comma-joined line."""
+    """Render a candidate row's ``shapes`` field as a comma-joined line.
+
+    Args:
+        shapes: A shapes value (string, list, or list of ``{call_num, shape}``
+            dicts).
+
+    Returns:
+        The rendered single-line shapes string, or empty when none.
+    """
     if not shapes:
         return ""
     if isinstance(shapes, str):
@@ -732,6 +795,13 @@ def _build_captured_shapes_block(candidate: dict[str, Any]) -> str:
     speedup will not translate to an end-to-end gain. Generic: applies to any
     candidate carrying captured shapes; returns ``""`` when none exist so the
     prompt stays byte-identical to legacy in that case.
+
+    Args:
+        candidate: The kernel candidate dict, possibly carrying captured
+            shapes.
+
+    Returns:
+        The captured-shapes prompt block, or ``""`` when no shapes exist.
     """
     shapes = candidate.get("shapes") or candidate.get("kernel_shapes")
     rendered = _format_shapes_for_case(shapes)
@@ -754,7 +824,18 @@ def _build_captured_shapes_block(candidate: dict[str, Any]) -> str:
 def _build_benchmark_cases_block(candidate: dict[str, Any]) -> str:
     """Render the multi-row benchmark cases section for a task_group.
 
-    Falls back to :func:`_build_captured_shapes_block` when ``candidate["task_group"]`` is absent/empty so captured shapes still reach GEAK. With a task_group, emits one bullet per TraceLens row (sorted by aggregate time desc) surfacing operation/args/aggregate_time_ms/percent_e2e/count/per_call_ms/flops_per_byte/efficiency/bound (bound + per_call_ms drive backend dispatch).
+    Falls back to :func:`_build_captured_shapes_block` when
+    ``candidate["task_group"]`` is absent/empty so captured shapes still reach
+    GEAK. With a task_group, emits one bullet per TraceLens row (sorted by
+    aggregate time descending) surfacing operation, args, aggregate time,
+    percent E2E, count, per-call ms, flops/byte, efficiency, and bound (bound +
+    per-call ms drive backend dispatch).
+
+    Args:
+        candidate: The kernel candidate dict, optionally with a ``task_group``.
+
+    Returns:
+        The rendered benchmark-cases prompt block.
     """
     group = candidate.get("task_group")
     rows = group.get("rows") if isinstance(group, dict) else None
@@ -910,7 +991,14 @@ _PRIORITY_BULLETS: dict[str, list[str]] = {
 
 
 def _classify_bound(bound_type: str) -> str:
-    """Map TraceLens ``bound`` strings to one of ``memory`` / ``compute`` / ``unknown``."""
+    """Classify a TraceLens ``bound`` string into a coarse bucket.
+
+    Args:
+        bound_type: The TraceLens bound description.
+
+    Returns:
+        One of ``"memory"``, ``"compute"``, or ``"unknown"``.
+    """
     text = (bound_type or "").lower()
     if "memory" in text or "bandwidth" in text or "hbm" in text:
         return "memory"
@@ -920,9 +1008,16 @@ def _classify_bound(bound_type: str) -> str:
 
 
 def _build_priority_block(candidate: dict[str, Any]) -> str:
-    """Render the bound-keyed optimization priority list (uses the primary row's bound for a task_group).
+    """Render the bound-keyed optimization priority list.
 
-    Empty string when ``bound_type`` is missing and no ``task_group`` is attached.
+    Uses the primary row's bound when the candidate carries a ``task_group``.
+
+    Args:
+        candidate: The kernel candidate dict.
+
+    Returns:
+        The priority-list prompt block, or ``""`` when ``bound_type`` is
+        missing and no ``task_group`` is attached.
     """
     group = candidate.get("task_group")
     bound_type = str(candidate.get("bound_type") or "").strip()
@@ -1002,6 +1097,13 @@ def _build_hypothesis_block(candidate: dict[str, Any]) -> str:
     every P-item's prose under a ``### P{rank}`` header; otherwise a single block.
     The reasoning/resolution prose is labelled a hypothesis to validate (it is
     itself LLM-generated); the numeric impact range is roofline arithmetic.
+
+    Args:
+        candidate: The kernel candidate dict, optionally with a ``task_group``
+            carrying P-item prose.
+
+    Returns:
+        The hypothesis prompt block, or ``""`` when no prose is present.
     """
     # Multi-P-item case (Q2): render every P-item's prose so GEAK sees all framings.
     group = candidate.get("task_group")
@@ -1650,7 +1752,17 @@ def _backends_module_dir() -> Path:
 
 
 def _import_backend(name: str):
-    """Dynamically load kernel-agent/tools/backends/<name>.py (dir added to sys.path so submodules cross-import)."""
+    """Dynamically import a per-backend submitter module.
+
+    The ``backends`` directory is added to ``sys.path`` so its submodules can
+    cross-import each other.
+
+    Args:
+        name: The backend module name (without ``.py``).
+
+    Returns:
+        The imported backend module.
+    """
     backends_dir = _backends_module_dir()
     if str(backends_dir) not in sys.path:
         sys.path.insert(0, str(backends_dir))
@@ -1659,7 +1771,14 @@ def _import_backend(name: str):
 
 
 def _kernel_agent_root() -> Path:
-    """Output root for kernel-agent tools at ``$USER_DATA_PATH/kernel-agent`` (via workspace_root, which warns once when unset)."""
+    """Resolve the kernel-agent tools output root.
+
+    Uses :func:`workspace_root` (which warns once when ``$USER_DATA_PATH`` is
+    unset).
+
+    Returns:
+        The ``$USER_DATA_PATH/kernel-agent`` output root path.
+    """
     return Path(workspace_root()) / "kernel-agent"
 
 
@@ -1731,7 +1850,18 @@ _DEFAULT_GEAK_FALLBACK_TIMEOUT_SEC = 3600
 
 
 def _ensure_yaml_env_timeout(text: str, *, timeout: int = _DEFAULT_GEAK_FALLBACK_TIMEOUT_SEC) -> str:
-    """Inject ``env.timeout`` (default 3600s) if absent; mini-swe-agent defaults to 30s and would kill the test command."""
+    """Ensure the GEAK YAML carries a sufficient ``env.timeout``.
+
+    Injects or raises ``env.timeout`` (default 3600s) because mini-swe-agent
+    defaults to 30s and would kill the test command.
+
+    Args:
+        text: The original GEAK YAML config text.
+        timeout: Desired timeout in seconds (floored at 60).
+
+    Returns:
+        The YAML text with ``env.timeout`` set to at least ``timeout``.
+    """
     timeout = max(60, int(timeout))
     has_env = re.search(r"^env\s*:\s*(?:#.*)?$", text, flags=re.MULTILINE)
     if has_env:
@@ -2196,6 +2326,17 @@ def _update_kernel_roofline_sidecar(
     Even when ``_run_rocprof_roofline`` skipped (e.g. no ``test_command``)
     or failed, we still write a tagged entry so the dashboard can distinguish
     "considered but skipped/failed" from "not yet evaluated" (``null``).
+
+    Args:
+        workspace_path: Workspace root containing ``reports/``.
+        kernel_id: The kernel id whose sidecar entry is updated.
+        rocprof_json_path: Path to the rocprof JSON artifact, if any.
+        rocprof_txt_path: Path to the rocprof text report, if any.
+        log_path: Optional path to append diagnostics.
+        rocprof_status: Status tag to record when no JSON is available.
+        rocprof_reason: Reason tag to record when no JSON is available.
+        phase: Which sub-key to write (``before_kernel_opt`` or
+            ``after_kernel_opt``).
     """
     sidecar_path = Path(workspace_path) / "reports" / "kernel_roofline.json"
     if not sidecar_path.is_file():
@@ -2356,7 +2497,14 @@ def _mirror_path_link(run_dir: Path, mirror: Path) -> None:
 
 
 def _git_checkout_fallback(kernel_repo: str, log_path: Path) -> None:
-    """Best-effort `git checkout -- .` to undo rogue agent writes under the kernel repo. Idempotent."""
+    """Run a best-effort ``git checkout -- .`` to undo rogue agent writes.
+
+    Idempotent and safe to call when the repo has no changes.
+
+    Args:
+        kernel_repo: Path to the kernel repo to clean.
+        log_path: Path to append checkout diagnostics.
+    """
     if not kernel_repo:
         return
     git_dir = Path(kernel_repo) / ".git"
@@ -2847,7 +2995,16 @@ _AUTH_RETRY_THRESHOLD = 3
 
 
 def _count_auth_failures(text: str) -> int:
-    """Count distinct inner-LLM auth-failure markers in *text* (distinguishes a transient 401 from an unrecoverable loop)."""
+    """Count inner-LLM auth-failure markers in captured text.
+
+    Distinguishes a transient 401 from an unrecoverable loop.
+
+    Args:
+        text: The captured backend output to scan.
+
+    Returns:
+        The number of auth-failure markers found.
+    """
     if not text:
         return 0
     total = 0
@@ -2857,7 +3014,17 @@ def _count_auth_failures(text: str) -> int:
 
 
 def _extract_speedup_from_report(report_path: str | Path) -> float | None:
-    """Best-effort scan of an OOB optimization_report.md for a speedup figure (median-of-top-3; None if absent)."""
+    """Scan an OOB ``optimization_report.md`` for a speedup figure.
+
+    Uses a median-of-top-3 to dodge cherry-picked best-shape numbers.
+
+    Args:
+        report_path: Path to the optimization report.
+
+    Returns:
+        The estimated speedup, or ``None`` when the report is missing or no
+        plausible figure is found.
+    """
     if not report_path:
         return None
     p = Path(report_path)
@@ -2963,6 +3130,10 @@ def _trust_geak_correctness() -> bool:
     GEAK's save_and_test only checks compile + import, not numerical output, so without this
     every GEAK KEEP would degrade to NEEDS_REVIEW; integrate's E2E magpie benchmark is the
     ground-truth check. Set ``HYPERLOOM_TRUST_GEAK_CORRECTNESS=0`` to restore the conservative behaviour.
+
+    Returns:
+        ``True`` when GEAK correctness should be trusted (the default),
+        ``False`` when the env var disables it.
     """
     raw = os.environ.get("HYPERLOOM_TRUST_GEAK_CORRECTNESS", "").strip().lower()
     if raw in {"0", "false", "no", "off"}:
@@ -3122,9 +3293,17 @@ def _extract_source_block(text_path: Path, target_suffix: str, output_path: Path
 
 
 def _geak_best_worktree(best_patch_path: str) -> Path | None:
-    """Map a GEAK best-patch file path to the ``worktrees/slot_<M>`` it edited (shares ``parallel_<M>``'s suffix).
+    """Map a GEAK best-patch path to the ``worktrees/slot_<M>`` it edited.
 
-    Lets callers pick up the real source file instead of scraping a diff; ``None`` on layout mismatch.
+    The slot shares the ``parallel_<M>`` suffix, letting callers pick up the
+    real source file instead of scraping a diff.
+
+    Args:
+        best_patch_path: Path to the GEAK best-patch file.
+
+    Returns:
+        The corresponding ``worktrees/slot_<M>`` path, or ``None`` on layout
+        mismatch.
     """
     if not best_patch_path:
         return None
@@ -3147,10 +3326,18 @@ def _worktree_source_paths(
     source_file: str,
     kernel_repo: str,
 ) -> list[Path]:
-    """Return existing files under ``worktree`` mirroring ``source_file``.
+    """Find existing files under a worktree mirroring a source file.
 
-    Tries source_file relative to kernel_repo first, then a basename rglob within
-    the worktree. Empty list when nothing matches.
+    Tries ``source_file`` relative to ``kernel_repo`` first, then a basename
+    rglob within the worktree.
+
+    Args:
+        worktree: The worktree directory to search.
+        source_file: The source file path to mirror.
+        kernel_repo: The kernel repo root used for relative resolution.
+
+    Returns:
+        Matching paths under the worktree, or an empty list when none match.
     """
     if not worktree.is_dir() or not source_file:
         return []

--- a/kernel-agent/tools/rocprof_roofline.py
+++ b/kernel-agent/tools/rocprof_roofline.py
@@ -499,7 +499,15 @@ def _kernel_name_matches(row: dict[str, Any], target_kernel: str) -> bool:
 
 
 def _project_payload_to_row(payload: dict[str, Any], target_kernel: str = "") -> dict[str, Any]:
-    """Project the row that matches ``target_kernel`` into ``kernel_roofline.json``."""
+    """Project the matching result row into a ``kernel_roofline.json`` row.
+
+    Args:
+        payload: The rocprof roofline payload with a ``results`` list.
+        target_kernel: Kernel name to match; empty selects the first row.
+
+    Returns:
+        The projected roofline row, or a status dict when no row matches.
+    """
     rows = payload.get("results") if isinstance(payload, dict) else None
     if not isinstance(rows, list) or not rows:
         return {"status": payload.get("status", "failed") if isinstance(payload, dict) else "failed"}
@@ -537,10 +545,19 @@ def _generate_harness_for_candidate(
     out_dir: Path,
     log_fn: Any,
 ) -> tuple[str, str | None]:
-    """Best-effort harness generation for a TraceLens hot-kernel candidate.
+    """Generate a benchmark harness for a TraceLens hot-kernel candidate.
 
-    Returns ``(test_command, error)``. ``test_command`` is empty when no
-    benchmark file resolves; the caller should mark the row as skipped.
+    Best-effort: returns an empty command rather than raising when no
+    benchmark file resolves.
+
+    Args:
+        candidate: The hot-kernel candidate metadata.
+        out_dir: Directory to write the generated harness into.
+        log_fn: Logging callable for progress/diagnostics.
+
+    Returns:
+        A ``(test_command, error)`` tuple. ``test_command`` is empty when no
+        benchmark file resolves and ``error`` names the reason.
     """
     bench_files = candidate.get("benchmark_files") or []
     if not isinstance(bench_files, list) or not bench_files:
@@ -626,7 +643,17 @@ def enrich_kernel_roofline_sidecar(
       this row was considered (vs. silently ``null``).
     * Per-kernel rocprof timeout / failure marks the row ``status='failed'``
       but never aborts enrichment of remaining rows.
-    * Returns a small summary suitable for caller logging.
+
+    Args:
+        sidecar_path: Path to the ``kernel_roofline.json`` sidecar to update.
+        candidates_path: Path to the candidates JSON to read kernels from.
+        workdir: Optional working directory for profiling.
+        timeout_sec_per_kernel: Per-kernel rocprof timeout in seconds.
+        log_fn: Optional logging callable.
+
+    Returns:
+        A summary dict with ``matched``, ``skipped``, ``failed``, and ``rows``
+        counts suitable for caller logging.
     """
     sidecar_p = Path(sidecar_path).expanduser()
     cand_p = Path(candidates_path).expanduser()

--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -2273,7 +2273,16 @@ _RANK_PCT_KEYS = (
 
 
 def _coerce_float(value: Any) -> float | None:
-    """Parse a CSV/JSON cell to float (strips ``%`` / commas); ``None`` if not numeric."""
+    """Parse a CSV/JSON cell into a float.
+
+    Strips a trailing ``%`` and comma thousands separators.
+
+    Args:
+        value: The raw cell value.
+
+    Returns:
+        The parsed float, or ``None`` when not numeric.
+    """
     if isinstance(value, bool):
         return None
     if isinstance(value, (int, float)):
@@ -2322,6 +2331,12 @@ def _clean_category_label(raw: str) -> str:
     The real ``ops_summary.csv`` stores the category as a Python list-repr
     string, e.g. ``['MoE_fused']`` or ``['GEMM', 'Reduce']`` — return the first
     element (``MoE_fused`` / ``GEMM``). Plain labels pass through unchanged.
+
+    Args:
+        raw: The raw category cell value.
+
+    Returns:
+        The bare category label.
     """
     s = str(raw or "").strip()
     if s.startswith("[") and s.endswith("]"):
@@ -2337,7 +2352,14 @@ def _clean_category_label(raw: str) -> str:
 
 
 def _record_gpu_us(low: dict[str, Any]) -> float | None:
-    """Best-effort GPU time in microseconds from a per-op ranking record."""
+    """Extract GPU time in microseconds from a per-op ranking record.
+
+    Args:
+        low: A per-op ranking record with lower-cased keys.
+
+    Returns:
+        The GPU time in microseconds, or ``None`` when no time field resolves.
+    """
     for k in _RANK_TIME_MS_KEYS:
         if k in low:
             val = _coerce_float(low[k])
@@ -2470,9 +2492,16 @@ def load_ops_ranking(
 
     Returns ``[{name, category, gpu_us, gpu_pct}]`` from the first sidecar that
     yields rows (ops_summary.csv / unified_perf_summary.csv /
-    priority_data.json, under the output dir or its ``perf_report_csvs/``);
-    ``[]`` when none is present/parseable. Used only by the ``other``-bucket
-    recovery fallback — the contracted candidate source remains analysis.md.
+    priority_data.json, under the output dir or its ``perf_report_csvs/``).
+    Used only by the ``other``-bucket recovery fallback — the contracted
+    candidate source remains analysis.md.
+
+    Args:
+        skill_output_dir: The TraceLens skill output directory to scan.
+
+    Returns:
+        A list of ``{name, category, gpu_us, gpu_pct}`` rows, or ``[]`` when no
+        sidecar is present or parseable.
     """
     if not skill_output_dir:
         return []
@@ -2545,10 +2574,19 @@ def recover_other_bucket_candidates(
     the recovery net does not route non-patchable kernels to GEAK.
 
     Fires for ops that are (a) absent from ``existing_candidates`` by name and
-    (b) at or above ``min_gpu_pct`` of total GPU time (env
-    ``HYPERLOOM_OTHER_BUCKET_MIN_GPU_PCT``, default 10%). Returns ``[]`` when no
-    sidecar is available or nothing qualifies, so analysis.md stays the primary
-    source.
+    (b) at or above ``min_gpu_pct`` of total GPU time.
+
+    Args:
+        skill_output_dir: The TraceLens skill output directory to scan.
+        existing_candidates: Candidates already extracted from analysis.md.
+        top_k: Maximum number of recovered candidates to return.
+        min_gpu_pct: Minimum GPU-time percentage to qualify; defaults to the
+            ``HYPERLOOM_OTHER_BUCKET_MIN_GPU_PCT`` env value (10%).
+        log: Optional logging callable for diagnostics.
+
+    Returns:
+        The recovered candidate dicts, or ``[]`` when no sidecar is available
+        or nothing qualifies (so analysis.md stays primary).
     """
     ranking = load_ops_ranking(skill_output_dir)
     if not ranking:
@@ -2628,9 +2666,21 @@ def _finalize_candidates(
     top: list[dict[str, Any]], *, total_dur: float | None = None,
     perf_report_csv_dir: Path | str | None = None,
 ) -> list[dict[str, Any]]:
-    """Shared post-processing for parsed candidate rows (source resolution / pybind upgrade / backend recommend / notes); mutates ``top`` in place.
+    """Apply shared post-processing to parsed candidate rows.
 
-    When ``perf_report_csv_dir`` is given, populates each item's ``tracelens_category`` from the CSV.
+    Resolves source files, promotes pybind/launcher shims, recommends
+    backends, classifies patchability, and attaches notes; mutates ``top`` in
+    place.
+
+    Args:
+        top: The parsed candidate rows to finalize (mutated in place).
+        total_dur: Total GPU duration for percentage computation; summed from
+            ``top`` when omitted.
+        perf_report_csv_dir: Optional CSV directory used to populate each
+            item's ``tracelens_category``.
+
+    Returns:
+        The finalized candidate list (the same ``top`` object).
     """
     op_cat_map = (
         load_op_category_map(perf_report_csv_dir)
@@ -2724,9 +2774,16 @@ def _finalize_candidates(
 
 
 def recommend_backends(candidate: dict[str, Any]) -> list[str]:
-    """Recommend a backend ladder (GEAK first, then claude/codex) for a reusable native kernel.
+    """Recommend a backend ladder for a reusable native kernel.
 
-    Returns ``[]`` for unresolved source, non-reusable, vendor-binary, or runtime-generated kernels.
+    Orders GEAK first, then claude/codex.
+
+    Args:
+        candidate: The hot-kernel candidate dict.
+
+    Returns:
+        The recommended backend names, or ``[]`` for unresolved source,
+        non-reusable, vendor-binary, or runtime-generated kernels.
     """
     source_type = candidate.get("source_type")
     if not candidate.get("source_file"):
@@ -2965,7 +3022,22 @@ def build_kernel_roofline_payload(
     roofline_json_path: str,
     candidates: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    """Build the per-kernel roofline sidecar (a view over candidates + optional --roofline-json; missing counters stay null)."""
+    """Build the per-kernel roofline sidecar payload.
+
+    A view over the candidates plus an optional ``--roofline-json``; missing
+    counters stay null.
+
+    Args:
+        trace_input: The trace input path recorded in the payload.
+        trace_input_type: Whether ``trace_input`` is a file or capture dir.
+        analysis_md_path: Path to the source analysis report.
+        kernel_candidates_path: Path to the candidates JSON.
+        roofline_json_path: Optional path to an external roofline JSON.
+        candidates: The finalized hot-kernel candidate rows.
+
+    Returns:
+        The kernel-roofline sidecar payload dict.
+    """
     rows = [
         _kernel_roofline_row(candidate)
         for candidate in candidates
@@ -2988,6 +3060,12 @@ def kernel_roofline_path_for_run(run_dir: Path) -> Path:
 
     PR-C layout is ``.../runs/<session_id>/<ts>_<run_id>/``; the pre-PR-C
     ``.../runs/<session_id>/`` layout is still handled by the fallback branch.
+
+    Args:
+        run_dir: The ``runs/<session_id>/`` root for the session.
+
+    Returns:
+        The stable session-level kernel roofline report path.
     """
     try:
         # PR-C layout: .../runs/<session_id>/<ts>_<run_id>/
@@ -3108,7 +3186,15 @@ _FLYDSL_BUFFER_LOAD_MARKERS = (
 
 
 def _resolve_flydsl_source_fallback() -> str:
-    """Resolve the real FlyDSL MoE kernel source ($DSL2_ROOT/kernels/moe_gemm_2stage.py) for synthetic PR #668 pseudo-ops; first existing path or ""."""
+    """Resolve the real FlyDSL MoE kernel source for synthetic pseudo-ops.
+
+    Used for PR #668 pseudo-ops, looking for
+    ``$DSL2_ROOT/kernels/moe_gemm_2stage.py`` and known fallback roots.
+
+    Returns:
+        The first existing FlyDSL MoE kernel source path, or ``""`` when none
+        exists.
+    """
     roots = [
         os.environ.get("DSL2_ROOT", "").strip(),
         os.environ.get("FLYDSL_ROOT", "").strip(),
@@ -3127,7 +3213,18 @@ def _resolve_flydsl_source_fallback() -> str:
 def _flydsl_kernel_params(
     source_file: str, target_platform: str,
 ) -> dict[str, Any]:
-    """Return FlyDSL-specific kernel_params (target arch, JIT cache state, smem/buffer-load usage); best-effort, never raises."""
+    """Build FlyDSL-specific kernel params.
+
+    Captures target arch, JIT cache state, and smem/buffer-load usage;
+    best-effort and never raises.
+
+    Args:
+        source_file: The FlyDSL kernel source path.
+        target_platform: The target GPU platform name.
+
+    Returns:
+        The FlyDSL kernel-params dict (possibly partial).
+    """
     params: dict[str, Any] = {}
     arch = _FLYDSL_TARGET_ARCH_BY_PLATFORM.get(
         (target_platform or "").strip().lower(),
@@ -3227,10 +3324,18 @@ def build_task_groups(
     *,
     source_root: Path | str | None = None,
 ) -> list[dict[str, Any]]:
-    """Aggregate reusable candidates by AST-resolved source function (wrapper over aggregate_by_source_function).
+    """Aggregate reusable candidates by AST-resolved source function.
 
-    Only reusable_native_kernel candidates are grouped. Returns ``[]`` when none carries a
-    parseable launcher path, so callers fall through to per-kernel dispatch.
+    A wrapper over :func:`aggregate_by_source_function`; only
+    ``reusable_native_kernel`` candidates are grouped.
+
+    Args:
+        candidates: The hot-kernel candidate rows.
+        source_root: Optional root to resolve relative source paths against.
+
+    Returns:
+        The task-group dicts, or ``[]`` when none carries a parseable launcher
+        path (callers fall through to per-kernel dispatch).
     """
     reusable = [c for c in candidates if isinstance(c, dict) and c.get("reusable_native_kernel")]
     if not reusable:
@@ -3247,7 +3352,22 @@ def build_audit_summary(
     task_groups: list[dict[str, Any]] | None = None,
     trace_health_warnings: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
-    """Build the ``tracelens/summary.json`` payload, splitting candidates into routable ``tasks`` and ``skipped`` (each with ``skip_reason``), preserving priority order. Pure function."""
+    """Build the ``tracelens/summary.json`` payload.
+
+    Splits candidates into routable ``tasks`` and ``skipped`` (each with a
+    ``skip_reason``), preserving priority order. Pure function.
+
+    Args:
+        candidates: The hot-kernel candidate rows.
+        trace_input: The trace input path recorded in the summary.
+        framework: Optional framework name recorded in the summary.
+        target_platform: Optional target platform recorded in the summary.
+        task_groups: Optional task-group projections to include.
+        trace_health_warnings: Optional trace-health warnings to include.
+
+    Returns:
+        The ``summary.json`` payload dict.
+    """
     tasks: list[dict[str, Any]] = []
     skipped: list[dict[str, Any]] = []
     for cand in candidates:
@@ -3321,8 +3441,24 @@ def write_reports(
 ) -> dict[str, str]:
     """Write Hyperloom-owned sidecar JSONs and surface the upstream ``analysis.md``.
 
-    ``analysis.md`` is owned by the TraceLens SDK orchestrator and not copied/aliased (#203).
-    Raises ``RuntimeError`` rather than fabricating a report when the orchestrator didn't produce it.
+    ``analysis.md`` is owned by the TraceLens SDK orchestrator and not
+    copied/aliased (#203).
+
+    Args:
+        run_dir: The per-run output directory to write sidecars into.
+        trace_input_type: Whether the trace input is a file or capture dir.
+        trace_files: The resolved trace files for the manifest.
+        candidates: The finalized hot-kernel candidate rows.
+        args: Parsed CLI args carrying model/framework/platform settings.
+        existing_report_path: Optional pre-existing report path to surface.
+        trace_health_warnings: Optional trace-health warnings to record.
+
+    Returns:
+        A mapping of report name to its written/surfaced path.
+
+    Raises:
+        RuntimeError: When the orchestrator did not produce ``analysis.md``
+            (rather than fabricating a report).
     """
     tracelens_dir = run_dir / "tracelens"
     (tracelens_dir / "system_findings").mkdir(parents=True, exist_ok=True)
@@ -3474,6 +3610,9 @@ def _default_workspace_path() -> str:
 
     Fallback order: ``$USER_DATA_PATH``, then legacy ``$WORKSPACE_PATH``, then
     ``_paths.workspace_root()`` (which warns once when ``$USER_DATA_PATH`` is unset).
+
+    Returns:
+        The resolved default workspace path.
     """
     user_data = os.environ.get("USER_DATA_PATH")
     if user_data:

--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -1572,7 +1572,19 @@ def _known_harness_files(name: str, source_file: str) -> list[Path]:
 
 
 def find_benchmark_files(name: str, repo_root: str, source_file: str = "") -> list[str]:
-    """Find test/benchmark files matching the kernel keywords under *repo_root*'s known subdirs (absolute paths)."""
+    """Find test/benchmark files matching a kernel under a repo's subdirs.
+
+    Searches ``repo_root``'s known benchmark/test subdirectories for the
+    kernel keywords, returning absolute paths.
+
+    Args:
+        name: Kernel symbol/name.
+        repo_root: Repo root to search; empty returns only curated harnesses.
+        source_file: Resolved source-file path, used to derive extra keywords.
+
+    Returns:
+        Up to ten matching harness paths, with multi-GPU tests demoted.
+    """
     known = _known_harness_files(name, source_file)
     if not repo_root:
         return [str(p) for p in known[:10]]
@@ -1724,9 +1736,18 @@ def upgrade_aiter_compile_ops_launcher(
 ) -> str:
     """Promote an aiter ``@compile_ops`` Python wrapper to the device ``.cu``.
 
-    Promotes when source_file is a ``.py`` under ``aiter/ops/``, kernel_name matches a
-    :data:`_AITER_COMPILE_OPS_PROMOTIONS` pattern, and the ``.cu`` exists under kernel_repo
-    (or :data:`_AITER_FALLBACK_REPO`). Otherwise returns source_file unchanged.
+    Promotes when source_file is a ``.py`` under ``aiter/ops/``, kernel_name
+    matches a :data:`_AITER_COMPILE_OPS_PROMOTIONS` pattern, and the ``.cu``
+    exists under kernel_repo (or :data:`_AITER_FALLBACK_REPO`).
+
+    Args:
+        source_file: The candidate's resolved source path.
+        kernel_name: The kernel name used for pattern matching.
+        kernel_repo: The resolved kernel repo root.
+
+    Returns:
+        The promoted device ``.cu`` path, or ``source_file`` unchanged when no
+        promotion applies.
     """
     if not source_file or not kernel_name:
         return source_file
@@ -1772,10 +1793,20 @@ def upgrade_aiter_compile_ops_launcher(
 
 def upgrade_pybind_shim_source(source_file: str, kernel_name: str,
                                kernel_repo: str) -> str:
-    """If `source_file` is a tiny pybind11 shim, find the real device .cu/.cuh implementing `kernel_name`.
+    """Promote a tiny pybind11 shim to the real device source.
 
-    Prefers a same-stem file under csrc/py_itfs_cu|kernels|include, then greps the symbol.
-    Returns `source_file` unchanged if no better target is found.
+    When ``source_file`` is a pybind11 shim, finds the ``.cu``/``.cuh``
+    implementing ``kernel_name``, preferring a same-stem file under
+    ``csrc/py_itfs_cu|kernels|include`` before grepping the symbol.
+
+    Args:
+        source_file: The candidate's resolved source path.
+        kernel_name: The kernel name used to locate the device source.
+        kernel_repo: The resolved kernel repo root.
+
+    Returns:
+        The real device source path, or ``source_file`` unchanged when no
+        better target is found.
     """
     if not _is_pybind_shim(source_file):
         return source_file
@@ -1882,7 +1913,14 @@ def _shape_call_entries(shapes: Any, call_num: Any = None) -> list[dict[str, Any
 def derive_kernel_category(candidate: dict[str, Any]) -> str:
     """Map a candidate to its GEAK-facing kernel category (#125).
 
-    Priority: explicit TraceLens category (normalized), then a kernel-name heuristic, then ``unknown``.
+    Priority: explicit TraceLens category (normalized), then a kernel-name
+    heuristic, then ``unknown``.
+
+    Args:
+        candidate: The hot-kernel candidate dict.
+
+    Returns:
+        The GEAK-facing kernel category string.
     """
     cat = (candidate.get("tracelens_category") or "").strip()
     if cat:
@@ -2003,7 +2041,16 @@ def analyze_trace_files(trace_files: list[Path], top_k: int) -> list[dict[str, A
 def load_op_category_map(
     perf_report_csv_dir: Path | str,
 ) -> dict[str, str]:
-    """Read ``{name: raw TraceLens op category}`` from unified_perf_summary.csv (first non-empty per name; ``{}`` when absent)."""
+    """Read a ``{name: raw op category}`` map from the unified perf summary.
+
+    Args:
+        perf_report_csv_dir: Directory containing
+            ``unified_perf_summary.csv``.
+
+    Returns:
+        A mapping of kernel name to its first non-empty TraceLens op category,
+        or ``{}`` when the CSV is absent or unreadable.
+    """
     csv_path = Path(perf_report_csv_dir) / "unified_perf_summary.csv"
     if not csv_path.is_file():
         return {}
@@ -2065,7 +2112,15 @@ _TRACE_DTYPE_SUFFIX = {
 
 
 def _format_trace_shape(dims: Any, dtype: Any) -> str | None:
-    """Render one operand as ``(d0,d1,...) <dtype>`` (matching TraceLens shape strings); ``None`` for scalar/empty operands."""
+    """Render one operand as a TraceLens-style ``(d0,d1,...) <dtype>`` string.
+
+    Args:
+        dims: The operand dimensions (list/tuple of ints).
+        dtype: The operand dtype token.
+
+    Returns:
+        The formatted shape string, or ``None`` for scalar/empty operands.
+    """
     if not isinstance(dims, (list, tuple)) or not dims:
         return None
     try:
@@ -2085,8 +2140,15 @@ def resolve_fused_moe_shapes_from_csv(
     Reads each per-shape row whose op name embeds ``invoke_fused_moe_kernel`` and
     parses its ``Input Dims`` / ``Input type`` tuple-of-tuples into TraceLens-style
     shape strings (e.g. ``(15360,2048) bf16``), deduped across rows in first-seen
-    order. Returns ``[]`` when the sidecar is absent or carries no fused-MoE rows
-    (so callers leave the candidate's empty ``shapes`` untouched).
+    order.
+
+    Args:
+        perf_report_csv_dir: Directory containing ``ops_unique_args.csv``.
+
+    Returns:
+        The recovered operand shape strings, or ``[]`` when the sidecar is
+        absent or carries no fused-MoE rows (callers then leave the
+        candidate's empty ``shapes`` untouched).
     """
     if not perf_report_csv_dir:
         return []
@@ -2122,7 +2184,16 @@ def resolve_fused_moe_shapes_from_csv(
 
 
 def _is_fused_moe_candidate(item: dict[str, Any]) -> bool:
-    """True for the Triton fused-MoE expert-kernel candidate (by op name or moe_fused category)."""
+    """Detect the Triton fused-MoE expert-kernel candidate.
+
+    Matches by op name or the ``moe_fused`` category.
+
+    Args:
+        item: The candidate dict to test.
+
+    Returns:
+        ``True`` when the candidate is the fused-MoE expert kernel.
+    """
     name = str(item.get("name") or "").lower()
     if _FUSED_MOE_KERNEL_MARKER in name:
         return True

--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -71,6 +71,9 @@ def _resolve_idle_pct_threshold() -> float:
     Relaxed from the docx §2 ~20% target to 80% because real SGLang inference traces
     sit structurally at ~50-60% idle (host scheduling + JIT/launch overhead), which the
     20% gate over-suppressed. Pin via ``HYPERLOOM_TRACELENS_IDLE_PCT_THRESHOLD``.
+
+    Returns:
+        The idle-percent gate threshold.
     """
     raw = os.environ.get(HIGH_IDLE_PCT_THRESHOLD_ENV, "").strip()
     if not raw:
@@ -90,6 +93,9 @@ def _resolve_arch_benchmark_timeout_s() -> int:
     Configured via ``TRACELENS_ARCH_BENCHMARK_TIMEOUT_SEC``. Empty, non-numeric,
     or out-of-range values fall back to the 600s floor rather than crashing the
     pipeline with a ``ValueError`` before the microbenchmark runs.
+
+    Returns:
+        The arch microbenchmark timeout in seconds (at least the 600s floor).
     """
     raw = os.environ.get(ARCH_BENCHMARK_TIMEOUT_ENV, "").strip()
     if not raw:
@@ -104,7 +110,18 @@ def _resolve_arch_benchmark_timeout_s() -> int:
 def _build_high_idle_warning(
     *, idle_pct: float, threshold_pct: float, report_path: Path,
 ) -> dict[str, Any]:
-    """Build the ``trace_health_warnings[]`` entry for a high-idle trace (consumed by trace_analyze_handler T4 to route to param optimization)."""
+    """Build the ``trace_health_warnings[]`` entry for a high-idle trace.
+
+    Consumed by ``trace_analyze_handler`` T4 to route to param optimization.
+
+    Args:
+        idle_pct: The measured GPU idle percentage.
+        threshold_pct: The idle-gate threshold that was exceeded.
+        report_path: Path to the source report, recorded in the entry.
+
+    Returns:
+        The structured ``high_gpu_idle_pct`` warning entry.
+    """
     return {
         "code": "high_gpu_idle_pct",
         "severity": "warning",
@@ -178,6 +195,17 @@ def _check_selected_chunk_has_gpu_events(
     returns ``None`` when the chunk carries real GPU work, else a ``steady_state_chunk_empty``
     warning the caller appends and raises on. A data-validity gate, not a reorder — falling
     back to another mode is the operator's call (never a silent swap).
+
+    Args:
+        split_dir: Directory holding the splitter's ``execution_details.csv``.
+        selected_chunk: The chunk file selected by the steady-state mode.
+        mode: The requested ``--steady-state-mode``.
+        available_modes: Mapping of mode to its ``(label, chunks)`` for
+            surfacing non-empty alternatives.
+
+    Returns:
+        ``None`` when the chunk has real GPU work, else a
+        ``steady_state_chunk_empty`` warning dict.
     """
     details_path = split_dir / "execution_details.csv"
     if not details_path.is_file():
@@ -305,7 +333,17 @@ def _resolve_min_busy_ratio() -> float:
 
 
 def _busy_ratio(num_events: float, busy_us: float, dur_us: float) -> float | None:
-    """Return ``busy_us / dur_us`` or ``None`` when undefined (caller defers to N25)."""
+    """Compute the clamped busy ratio for a chunk.
+
+    Args:
+        num_events: GPU event count for the chunk.
+        busy_us: GPU busy duration in microseconds.
+        dur_us: Total chunk duration in microseconds.
+
+    Returns:
+        ``busy_us / dur_us`` clamped to ``[0, 1]``, or ``None`` when undefined
+        (the caller defers to the N25 structural gate).
+    """
     if dur_us <= 0.0 or num_events <= 0:
         return None
     return max(0.0, min(1.0, busy_us / dur_us))
@@ -320,9 +358,19 @@ def _check_selected_chunk_has_gpu_events_quality(
 ) -> "dict[str, Any] | None":
     """Quality gate complementing N25's structural gate.
 
-    ``None`` when the chunk is acceptable (busy_ratio >= threshold), no alternate is
-    materially better, or the CSV/row is absent. Otherwise a ``steady_state_chunk_low_quality``
-    warning (same shape as N25 for the N26 retry path). See the module-level N36 comment.
+    See the module-level N36 comment for the gate's rationale.
+
+    Args:
+        split_dir: Directory holding the splitter's ``execution_details.csv``.
+        selected_chunk: The chunk file selected by the steady-state mode.
+        mode: The requested ``--steady-state-mode``.
+        available_modes: Mapping of mode to its ``(label, chunks)`` for
+            evaluating better alternatives.
+
+    Returns:
+        ``None`` when the chunk is acceptable (busy_ratio >= threshold), no
+        alternate is materially better, or the CSV/row is absent. Otherwise a
+        ``steady_state_chunk_low_quality`` warning dict (same shape as N25).
     """
     details_path = split_dir / "execution_details.csv"
     if not details_path.is_file():
@@ -605,9 +653,17 @@ def open_json(path: Path) -> dict[str, Any]:
 
 
 def count_gpu_kernel_events(trace_file: Path, max_events: int = 1_000_000) -> int:
-    """Count GPU kernel events in a torch_profiler trace (pre-flight check for CPU-only traces).
+    """Count GPU kernel events in a torch_profiler trace.
 
-    Counts only real GPU kernels via :func:`is_kernel_event`, not host-side wrappers.
+    Used as a pre-flight check for CPU-only traces. Counts only real GPU
+    kernels via :func:`is_kernel_event`, not host-side wrappers.
+
+    Args:
+        trace_file: Path to the torch_profiler trace (JSON or ``.gz``).
+        max_events: Early-exit cap on the number of events counted.
+
+    Returns:
+        The GPU kernel event count, or 0 when the trace is unreadable.
     """
     try:
         payload = open_json(trace_file)
@@ -626,7 +682,17 @@ def count_gpu_kernel_events(trace_file: Path, max_events: int = 1_000_000) -> in
 
 
 def _trace_input_sort_key(path: Path) -> tuple[int, str]:
-    """Prefer the merged annotated trace over rank/phase shards during directory discovery (TraceLens splitter needs the large trace)."""
+    """Compute the discovery sort key for a trace input path.
+
+    Prefers the merged annotated trace over rank/phase shards (the TraceLens
+    splitter needs the large trace).
+
+    Args:
+        path: The trace file path to rank.
+
+    Returns:
+        A ``(priority, name)`` sort key (lower priority sorts first).
+    """
     name = path.name
     if name.startswith("merged-"):
         return (0, name)
@@ -677,7 +743,17 @@ def discover_trace_inputs(trace_input: Path) -> tuple[str, list[Path]]:
 
 
 def is_kernel_event(event: dict[str, Any]) -> bool:
-    """Strict GPU-kernel filter: only ``cat == 'kernel'`` events (excludes host-side sync/launch wrappers that would eclipse real kernels)."""
+    """Apply a strict GPU-kernel filter to a trace event.
+
+    Only ``cat == 'kernel'`` events qualify, excluding host-side sync/launch
+    wrappers that would eclipse real kernels.
+
+    Args:
+        event: A single trace event dict.
+
+    Returns:
+        ``True`` if the event is a real GPU kernel.
+    """
     cat = str(event.get("cat") or event.get("category") or "").lower()
     if cat != "kernel":
         return False
@@ -741,7 +817,16 @@ _FLYDSL_SCAN_BYTES = 4096
 
 
 def _looks_like_flydsl_source(source_file: str) -> bool:
-    """Return True when ``source_file`` is a FlyDSL kernel source (content-sniff first 4 KiB for FlyDSL markers)."""
+    """Detect whether a source file is a FlyDSL kernel source.
+
+    Content-sniffs the first 4 KiB for FlyDSL markers.
+
+    Args:
+        source_file: Path to the candidate ``.py`` source.
+
+    Returns:
+        ``True`` when FlyDSL markers are found in the file head.
+    """
     if not source_file or not source_file.endswith(".py"):
         return False
     try:
@@ -808,7 +893,15 @@ _COMPILE_GENERATED_NAME_MARKERS = (
 )
 @functools.lru_cache(maxsize=1)
 def _framework_patch_roots() -> tuple[str, ...]:
-    """Framework install roots (from framework_paths.resolve_patch_target_roots); also emits a lower-case variant of each (``/app/ATOM/atom/`` -> ``/app/atom/atom/``) for case-insensitive matching."""
+    """Resolve framework install roots for patch-target matching.
+
+    Roots come from ``framework_paths.resolve_patch_target_roots``; a
+    lower-case variant of each (e.g. ``/app/ATOM/atom/`` ->
+    ``/app/atom/atom/``) is also emitted for case-insensitive matching.
+
+    Returns:
+        The framework install roots, including lower-case variants.
+    """
     try:
         if _resolve_patch_target_roots is None:
             raise ImportError
@@ -830,9 +923,14 @@ def _framework_patch_roots() -> tuple[str, ...]:
 
 @functools.lru_cache(maxsize=1)
 def _aiter_csrc_root() -> str:
-    """aiter's own device-source root (e.g. ``.../aiter_meta/csrc/``),
-    resolved from the installed package. Empty when aiter is not importable.
-    Cached once per process."""
+    """Resolve aiter's own device-source root from the installed package.
+
+    Cached once per process.
+
+    Returns:
+        The aiter csrc root (e.g. ``.../aiter_meta/csrc/``), or ``""`` when
+        aiter is not importable.
+    """
     if _aiter_jit_core is None:
         return ""
     raw = (getattr(_aiter_jit_core, "AITER_CSRC_DIR", "") or "").replace(os.sep, "/")
@@ -840,7 +938,13 @@ def _aiter_csrc_root() -> str:
 
 
 def _flydsl_reusable_roots() -> tuple[str, ...]:
-    """FlyDSL checkout root(s) for PR #668 moe_flydsl pseudo-ops, lower-cased ($DSL2_ROOT/$FLYDSL_ROOT take precedence over the WekaFS default)."""
+    """Resolve FlyDSL checkout root(s) for PR #668 moe_flydsl pseudo-ops.
+
+    ``$DSL2_ROOT`` / ``$FLYDSL_ROOT`` take precedence over the WekaFS default.
+
+    Returns:
+        The lower-cased FlyDSL checkout roots.
+    """
     out: list[str] = []
     for env_key in ("DSL2_ROOT", "FLYDSL_ROOT"):
         val = (os.environ.get(env_key, "") or "").strip()
@@ -921,13 +1025,30 @@ def is_torch_dispatch_shim_source(source_file: str) -> bool:
     tensor op to a vendor backend and hold no rewritable device kernel, so a
     symbol attributed here must be treated as a non-reusable dispatch stub
     (same handling as ``@compile_ops`` JIT stubs in ``aiter/ops/moe_op.py``).
+
+    Args:
+        source_file: The resolved source-file path.
+
+    Returns:
+        ``True`` when the file is a known torch-dispatch interception shim.
     """
     posix = str(source_file or "").replace("\\", "/")
     return any(posix.endswith(suffix) for suffix in _TORCH_DISPATCH_SHIM_SOURCES)
 
 
 def is_runtime_generated_kernel(name: str, source_file: str) -> bool:
-    """Return True for torch.compile / Inductor / cache-generated kernels (not portable across serving runs)."""
+    """Detect torch.compile / Inductor / cache-generated kernels.
+
+    These are not portable across serving runs.
+
+    Args:
+        name: The kernel symbol/name.
+        source_file: The resolved source-file path.
+
+    Returns:
+        ``True`` for a runtime-generated kernel that is not a stable in-repo
+        Triton source.
+    """
     lower_name = (name or "").lower()
     lower_file = (source_file or "").lower()
     if any(marker in lower_file for marker in _RUNTIME_GENERATED_SOURCE_MARKERS):
@@ -941,9 +1062,16 @@ def is_runtime_generated_kernel(name: str, source_file: str) -> bool:
 def classify_patchability(candidate: dict[str, Any]) -> tuple[bool, str]:
     """Return ``(reusable, skip_reason)`` for a hot-kernel candidate.
 
-    Single source of truth for the kernel-opt routing gate; ``skip_reason`` is empty
-    when reusable, else a short audit explanation. Also rejects vendor/collective/native-op
-    name markers (:data:`_NON_PATCHABLE_NAME_MARKERS`) and library-less ``aten::*`` ops.
+    Single source of truth for the kernel-opt routing gate. Also rejects
+    vendor/collective/native-op name markers
+    (:data:`_NON_PATCHABLE_NAME_MARKERS`) and library-less ``aten::*`` ops.
+
+    Args:
+        candidate: The hot-kernel candidate dict.
+
+    Returns:
+        A ``(reusable, skip_reason)`` tuple; ``skip_reason`` is empty when
+        reusable, else a short audit explanation.
     """
     source_file = str(candidate.get("source_file") or "")
     name = str(candidate.get("name") or "")
@@ -1025,7 +1153,19 @@ _VENDOR_KEYWORD_NAMES = (
 
 
 def is_vendor_dispatch_wrapper(name: str, source_file: str) -> bool:
-    """Heuristic: True when source_file is a thin dispatch wrapper around a precompiled vendor binary (.so/.co); nothing to rewrite."""
+    """Detect a thin dispatch wrapper around a precompiled vendor binary.
+
+    Uses a small file size plus content signatures so that real small kernels
+    survive (conservative).
+
+    Args:
+        name: The kernel symbol/name.
+        source_file: The resolved source-file path.
+
+    Returns:
+        ``True`` when the source is a dispatch wrapper around a ``.so``/``.co``
+        with nothing to rewrite.
+    """
     nm = (name or "").lower()
     if any(kw in nm for kw in _VENDOR_KEYWORD_NAMES):
         return True
@@ -1249,6 +1389,13 @@ def _compound_subwindow_keywords(name: str) -> list[str]:
     shorter trailing windows (longest first, most specific) so the embedded
     function symbol (e.g. ``invoke_fused_moe_kernel``) still resolves. The
     namespace/profiler prefix and a trailing numeric id are stripped first.
+
+    Args:
+        name: The compound/profiler-wrapped symbol name.
+
+    Returns:
+        Progressively shorter trailing snake_case windows (longest first),
+        capped at six.
     """
     cleaned = _strip_template_args(name.strip())
     if "::" in cleaned:
@@ -1275,7 +1422,15 @@ def _file_defines_symbol(path: Path, keyword: str) -> bool:
     Distinguishes a kernel's definition site (``def invoke_fused_moe_kernel``,
     a Triton ``@triton.jit`` function, or a C/HIP ``__global__``) from a file
     that only calls/wraps it (e.g. sglang's ``kernel_shape_profiler.py`` dispatch
-    shim). Best-effort: returns False on read errors.
+    shim).
+
+    Args:
+        path: The source file to inspect.
+        keyword: The symbol name to look for a definition of.
+
+    Returns:
+        ``True`` when the file defines the symbol; ``False`` on read errors or
+        when it only mentions it.
     """
     kw = re.escape(keyword)
     try:
@@ -1291,7 +1446,15 @@ def _file_defines_symbol(path: Path, keyword: str) -> bool:
 
 
 def _prefer_symbol_definition(keyword: str, hits: list[Path]) -> list[Path]:
-    """Rank definition sites of ``keyword`` ahead of mere mentions."""
+    """Rank definition sites of a symbol ahead of mere mentions.
+
+    Args:
+        keyword: The symbol name to prefer definitions of.
+        hits: Candidate source paths to rank.
+
+    Returns:
+        The ranked paths, preferring files that define ``keyword``.
+    """
     definers = [h for h in hits if _file_defines_symbol(h, keyword)]
     return _rank_paths(definers) if definers else _rank_paths(hits)
 

--- a/kernel-agent/tools/tracelens_arch_benchmark.py
+++ b/kernel-agent/tools/tracelens_arch_benchmark.py
@@ -41,7 +41,11 @@ check_gpu_idle = None  # type: ignore[assignment,misc]
 
 
 def _get_collect_arch_jsons():
-    """Return TraceLens' arch-JSON collector, importing lazily post-install."""
+    """Return TraceLens' arch-JSON collector, importing lazily post-install.
+
+    Returns:
+        The collector callable, or ``None`` when TraceLens is not installed.
+    """
     global _collect_arch_jsons
     if _collect_arch_jsons is None:
         try:
@@ -55,7 +59,12 @@ def _get_collect_arch_jsons():
 
 
 def _get_check_gpu_idle():
-    """Return TraceLens' check_gpu_idle, importing lazily post-install."""
+    """Return TraceLens' ``check_gpu_idle``, importing lazily post-install.
+
+    Returns:
+        The ``check_gpu_idle`` callable, or ``None`` when TraceLens is not
+        installed.
+    """
     global check_gpu_idle
     if check_gpu_idle is None:
         try:
@@ -90,7 +99,12 @@ def normalize_platform(platform: str) -> str:
 
 
 def list_candidate_physical_gpus() -> list[int]:
-    """Return physical GPU ids currently visible to this process."""
+    """List the physical GPU ids currently visible to this process.
+
+    Returns:
+        Physical GPU ids derived from ``*_VISIBLE_DEVICES`` or torch, or an
+        empty list when none are visible.
+    """
     for var in _VISIBLE_DEVICE_VARS:
         val = os.environ.get(var, "").strip()
         if not val:
@@ -117,7 +131,15 @@ def list_candidate_physical_gpus() -> list[int]:
 def single_physical_gpu_env(
     physical_id: int, *, base_env: dict[str, str] | None = None
 ) -> dict[str, str]:
-    """Return a subprocess env that exposes exactly one physical GPU."""
+    """Build a subprocess env that exposes exactly one physical GPU.
+
+    Args:
+        physical_id: The physical GPU id to expose.
+        base_env: Base environment to copy; defaults to ``os.environ``.
+
+    Returns:
+        An environment dict with the visibility vars pinned to ``physical_id``.
+    """
     env = dict(base_env if base_env is not None else os.environ)
     value = str(physical_id)
     for var in _VISIBLE_DEVICE_VARS:
@@ -128,7 +150,19 @@ def single_physical_gpu_env(
 def select_idle_gpu(
     *, log: Callable[[str], None] | None = None, util_threshold: int = 5
 ) -> int:
-    """Pick an unoccupied GPU for the arch microbenchmark subprocess."""
+    """Pick an unoccupied GPU for the arch microbenchmark subprocess.
+
+    Args:
+        log: Optional logging callable for selection diagnostics.
+        util_threshold: Max utilization percent to consider a GPU idle.
+
+    Returns:
+        The physical id of the selected idle GPU.
+
+    Raises:
+        RuntimeError: If TraceLens is missing, no GPUs are found, or none are
+            idle.
+    """
     check_idle = _get_check_gpu_idle()
     if check_idle is None:
         raise RuntimeError("TraceLens is not installed; cannot check GPU idle state")
@@ -161,7 +195,14 @@ def select_idle_gpu(
 
 
 def resolve_arch_json_path(platform: str) -> Path | None:
-    """Return the bundled arch JSON path for ``platform``, if present."""
+    """Resolve the bundled arch JSON path for a platform.
+
+    Args:
+        platform: Platform/architecture name.
+
+    Returns:
+        The bundled arch JSON path, or ``None`` when none matches.
+    """
     collect = _get_collect_arch_jsons()
     if collect is None:
         return None
@@ -206,10 +247,21 @@ def _sanitize_measured_arch_spec(
     (FP8/INT8/MX unsupported on the stack, or a bench that was skipped) and a
     ``0`` bandwidth when the HBM sweep failed. Roofline consumes
     ``max_achievable_tflops[<spec>]`` as a divisor and ``mem_bw_gbps`` as the
-    memory ceiling, so a ``0`` would divide-by-zero or yield garbage. Keep only
+    memory ceiling, so a     ``0`` would divide-by-zero or yield garbage. Keep only
     positive MAF values (roofline's lookup then returns ``None`` and skips that
-    dtype) and hard-fail when the spec is unusable. Returns True if ``payload``
-    was modified (caller persists it).
+    dtype) and hard-fail when the spec is unusable.
+
+    Args:
+        payload: The measured arch spec dict (mutated in place).
+        platform: Platform/architecture name for logging.
+        out_path: Path the spec will be written to (used in error messages).
+        log: Logging callable for diagnostics.
+
+    Returns:
+        ``True`` if ``payload`` was modified (the caller persists it).
+
+    Raises:
+        RuntimeError: If the spec has no usable MAF values or bandwidth.
     """
     maf = payload.get("max_achievable_tflops")
     if not isinstance(maf, dict) or not maf:
@@ -280,6 +332,22 @@ def populate_gpu_arch_json(
       returned and the internal extension supplies MAF at report time.
     - When it is False (open-source path) a bundled spec short-circuits, and
       a missing spec triggers the TraceLens microbenchmark on an idle GPU.
+
+    Args:
+        tracelens_root: Root of the TraceLens checkout.
+        platform: Target platform/architecture name.
+        internal_extension_enabled: Whether the internal extension backfills
+            MAF (skips the microbenchmark when ``True``).
+        log: Logging callable for diagnostics.
+        run_command: Callable that runs the microbenchmark subprocess.
+        timeout_s: Microbenchmark timeout in seconds.
+        device: Logical device index for the microbenchmark.
+
+    Returns:
+        The arch JSON path, or ``None`` when MAF is supplied at report time.
+
+    Raises:
+        RuntimeError: If the platform is empty or the microbenchmark fails.
     """
     if internal_extension_enabled:
         existing = resolve_arch_json_path(platform)

--- a/kernel-agent/tools/tracelens_skill_runner.py
+++ b/kernel-agent/tools/tracelens_skill_runner.py
@@ -319,8 +319,15 @@ def _iter_message_text(message: Any) -> Iterable[str]:
 
 
 def _cap_str(value: str, limit: int = _TRANSCRIPT_FIELD_MAX_CHARS) -> str:
-    """Truncate a transcript string to ``limit`` chars with a clip marker so a
-    reader can tell the field was bounded (#266)."""
+    """Truncate a transcript string, appending a clip marker when bounded.
+
+    Args:
+        value: The string to truncate.
+        limit: Maximum length before truncation.
+
+    Returns:
+        The original string, or a truncated copy with a clip marker (#266).
+    """
     if len(value) <= limit:
         return value
     return value[:limit] + f"... [truncated {len(value) - limit} chars]"
@@ -334,7 +341,15 @@ def _json_safe(value: Any, *, cap: bool = True) -> Any:
     write infallible so a serialization edge case never aborts a TraceLens
     run (#266). When ``cap`` is set every string (at any nesting depth) is
     bounded to ``_TRANSCRIPT_FIELD_MAX_CHARS`` so a megabyte tool_result cannot
-    bloat the transcript."""
+    bloat the transcript.
+
+    Args:
+        value: The value to coerce.
+        cap: When ``True``, bound every nested string to the field max.
+
+    Returns:
+        A JSON-serializable representation of ``value``.
+    """
     if isinstance(value, str):
         return _cap_str(value) if cap else value
     if isinstance(value, dict):
@@ -356,7 +371,14 @@ def _serialize_sdk_block(block: Any) -> dict[str, Any]:
     union of fields those types expose, rather than importing the SDK's
     concrete block classes. This mirrors
     ``ClaudeBackend._iter_blocks`` so the runner stays decoupled from
-    claude-agent-sdk internals."""
+    claude-agent-sdk internals.
+
+    Args:
+        block: An SDK content block (or a plain dict).
+
+    Returns:
+        A JSON-safe record describing the block.
+    """
     if isinstance(block, dict):
         record = _json_safe(block)
         if isinstance(record, dict):
@@ -403,7 +425,15 @@ def _serialize_sdk_message(message: Any, *, seq: int) -> dict[str, Any]:
     The record carries the message class name (``AssistantMessage`` /
     ``ResultMessage`` / ...), its content blocks, and — when present on a
     terminal ``ResultMessage`` — the consolidated ``result`` text and the
-    Anthropic ``usage`` dict (token accounting)."""
+    Anthropic ``usage`` dict (token accounting).
+
+    Args:
+        message: An SDK stream message.
+        seq: The message sequence number within the stream.
+
+    Returns:
+        A JSON-safe transcript record for the message.
+    """
     record: dict[str, Any] = {
         "seq": seq,
         "ts": datetime.now(timezone.utc).isoformat(),
@@ -694,7 +724,18 @@ def _parse_marker_attrs(blob: str) -> dict[str, str]:
 def _extract_between(
     text: str, start_marker: str, end_markers: tuple[str, ...],
 ) -> str:
-    """Return the substring between ``start_marker`` and the earliest ``end_markers`` (tail if none; empty if start absent)."""
+    """Extract the substring between a start marker and the earliest end marker.
+
+    Args:
+        text: The text to search.
+        start_marker: Marker that begins the region.
+        end_markers: Candidate markers that end the region; the earliest match
+            wins.
+
+    Returns:
+        The trimmed substring, the tail when no end marker is found, or an
+        empty string when the start marker is absent.
+    """
     start = text.find(start_marker)
     if start == -1:
         return ""
@@ -706,7 +747,15 @@ def _extract_between(
 
 
 def _extract_pitem_prose(body: str) -> dict[str, Any]:
-    """Extract Identification / Reasoning / Resolution / Impact-estimate fields from a P-item body (all default empty/0.0)."""
+    """Extract prose and impact fields from a P-item body.
+
+    Args:
+        body: The Markdown body of a single P-item.
+
+    Returns:
+        A dict with ``identification``, ``reasoning_for_slowdown``,
+        ``resolution``, and impact estimates (defaulting to empty / 0.0).
+    """
     identification = _extract_between(
         body, _IDENTIFICATION_LABEL,
         (_DATA_LABEL, _REASONING_LABEL, _RESOLUTION_LABEL, _IMPACT_LABEL),
@@ -729,7 +778,15 @@ def _extract_pitem_prose(body: str) -> dict[str, Any]:
 
 
 def _extract_pitem_categories(text: str) -> list[dict[str, Any]]:
-    """Return per-P-item metadata (``category``/``low``/``mid``/``high``), in priority order, from p_item markers."""
+    """Extract per-P-item category and impact metadata in priority order.
+
+    Args:
+        text: The full report text containing ``p_item`` markers.
+
+    Returns:
+        A list of dicts with ``category`` and ``impact_score*`` fields, one
+        per P-item marker.
+    """
 
     items: list[dict[str, Any]] = []
     for match in _PITEM_MARKER_RE.finditer(text):
@@ -775,7 +832,17 @@ def _split_data_blocks(text: str) -> list[tuple[int, str, str]]:
 
 
 def _extract_data_table(body: str) -> list[list[str]]:
-    """Pull the 9-column markdown table that follows ``**Data:**`` (raw header + data cells; ends at blank line or next ``**Field:**``)."""
+    """Pull the 9-column markdown table that follows a ``**Data:**`` marker.
+
+    The table includes the raw header and data cells and ends at a blank line
+    or the next ``**Field:**`` marker.
+
+    Args:
+        body: The P-item body text to scan.
+
+    Returns:
+        The table rows as lists of cell strings.
+    """
 
     marker = body.find("**Data:**")
     if marker < 0:
@@ -921,7 +988,17 @@ _IDLE_PCT_TABLE_RE = re.compile(
 
 
 def extract_idle_pct_from_analysis_md(md_path: Path) -> float | None:
-    """Extract ``Idle %`` from the Executive Summary table in ``analysis.md`` (§1/§2 idle-gate); ``None`` on missing/unparseable so callers skip the gate gracefully."""
+    """Extract ``Idle %`` from an ``analysis.md`` Executive Summary table.
+
+    Used by the §1/§2 idle gate.
+
+    Args:
+        md_path: Path to the ``analysis.md`` report.
+
+    Returns:
+        The idle percentage, or ``None`` when missing/unparseable so callers
+        skip the gate gracefully.
+    """
     try:
         text = md_path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
@@ -939,7 +1016,14 @@ def extract_idle_pct_from_analysis_md(md_path: Path) -> float | None:
 
 
 def _efficiency_sort_key(candidate: dict[str, Any]) -> float:
-    """Per-row sort key for the ``Lower Efficiency`` budget filter (§2); rows with no efficiency (0.0) sort last."""
+    """Compute the per-row sort key for the ``Lower Efficiency`` filter (§2).
+
+    Args:
+        candidate: A candidate row carrying ``efficiency_percent``.
+
+    Returns:
+        The efficiency value, or ``inf`` so rows with no efficiency sort last.
+    """
     eff = candidate.get("efficiency_percent")
     try:
         value = float(eff)
@@ -951,7 +1035,19 @@ def _efficiency_sort_key(candidate: dict[str, Any]) -> float:
 
 
 def parse_analysis_md(md_path: Path, top_k: int = 10) -> list[dict[str, Any]]:
-    """Parse the TraceLens ``analysis.md`` final report into hot-kernels in §2 priority order (P-item, then lower efficiency within); empty/missing → []."""
+    """Parse a TraceLens ``analysis.md`` report into hot-kernel rows.
+
+    Rows are returned in §2 priority order (P-item, then lower efficiency
+    within each item).
+
+    Args:
+        md_path: Path to the ``analysis.md`` report.
+        top_k: Maximum number of hot-kernel rows to return.
+
+    Returns:
+        The hot-kernel rows, or an empty list when the report is missing or
+        unparseable.
+    """
 
     if not md_path.exists():
         return []
@@ -1039,7 +1135,17 @@ _LAUNCHER_PATH_PLACEHOLDERS: frozenset[str] = frozenset({
 
 
 def _parse_launcher_path(kernel_path: str) -> tuple[str, int | None, str | None]:
-    """Parse a TraceLens kernel-path to ``(path, line, function_name)`` (accepts ``<path>(<line>): <func>``/``<path>#L<line>``/bare; placeholders → ``("", None, None)``)."""
+    """Parse a TraceLens kernel-path into its components.
+
+    Accepts ``<path>(<line>): <func>``, ``<path>#L<line>``, or a bare path.
+
+    Args:
+        kernel_path: The kernel-path string to parse.
+
+    Returns:
+        A ``(path, line, function_name)`` tuple; placeholders and empty input
+        return ``("", None, None)``.
+    """
     if not kernel_path:
         return "", None, None
     text = kernel_path.strip()
@@ -1083,7 +1189,13 @@ _FRAMEWORK_SOURCE_ROOTS_ENV = "HYPERLOOM_FRAMEWORK_SOURCE_ROOTS"
 
 
 def _env_framework_source_roots() -> dict[str, tuple[str, ...]]:
-    """Parse ``$HYPERLOOM_FRAMEWORK_SOURCE_ROOTS`` (comma-separated ``pkg=/abs/parent``) into ``{pkg: (root,...)}``; unparseable entries skipped."""
+    """Parse ``$HYPERLOOM_FRAMEWORK_SOURCE_ROOTS`` into a package-root map.
+
+    The variable is a comma-separated list of ``pkg=/abs/parent`` entries.
+
+    Returns:
+        A ``{pkg: (root, ...)}`` mapping; unparseable entries are skipped.
+    """
     raw = os.environ.get(_FRAMEWORK_SOURCE_ROOTS_ENV, "").strip()
     if not raw:
         return {}
@@ -1101,7 +1213,14 @@ def _env_framework_source_roots() -> dict[str, tuple[str, ...]]:
 
 
 def _package_root_parent(pkg: str) -> str | None:
-    """Return the directory containing ``pkg/`` on the live ``sys.path`` via find_spec; ``None`` if not importable."""
+    """Find the directory containing a package on the live ``sys.path``.
+
+    Args:
+        pkg: The importable package name.
+
+    Returns:
+        The directory containing ``pkg/``, or ``None`` when not importable.
+    """
     try:
         spec = importlib.util.find_spec(pkg)
     except (ImportError, ValueError):
@@ -1121,7 +1240,16 @@ def _package_root_parent(pkg: str) -> str | None:
 def _resolve_launcher_to_abs_source(
     kernel_path: str,
 ) -> tuple[str, int | None, str | None] | None:
-    """Resolve a TraceLens launcher-path to an absolute file; ``(abs_file, line, function_name)`` only when the file exists, else ``None`` (conservative miss → caller's grep locator)."""
+    """Resolve a TraceLens launcher-path to an absolute source file.
+
+    Args:
+        kernel_path: The TraceLens launcher-path to resolve.
+
+    Returns:
+        An ``(abs_file, line, function_name)`` tuple only when the file
+        exists, else ``None`` (a conservative miss defers to the caller's grep
+        locator).
+    """
     raw_path, line, func = _parse_launcher_path(kernel_path)
     if not raw_path:
         return None
@@ -1157,7 +1285,16 @@ def _resolve_launcher_to_abs_source(
 
 
 def _function_line_from_ast(path: Path, function_name: str) -> int | None:
-    """Return the lineno of the first (Async)FunctionDef in ``path`` named ``function_name``; ``None`` if unreadable/unparseable/absent."""
+    """Find the line number of a named function definition via AST.
+
+    Args:
+        path: The source file to parse.
+        function_name: The function name to locate.
+
+    Returns:
+        The first matching ``def``/``async def`` line, or ``None`` when the
+        file is unreadable, unparseable, or the function is absent.
+    """
     try:
         tree = ast.parse(path.read_text(encoding="utf-8"))
     except (OSError, SyntaxError, UnicodeDecodeError):
@@ -1173,7 +1310,19 @@ def _resolve_source_target(
     *,
     source_root: Path | None,
 ) -> dict[str, Any] | None:
-    """Resolve a candidate's launcher path to a ``(source_path, definition_line, function_name)`` triple; ``None`` when unparseable. AST line overrides the reported call-site line when resolvable."""
+    """Resolve a candidate's launcher path to a source-target triple.
+
+    The AST-derived definition line overrides the reported call-site line when
+    resolvable.
+
+    Args:
+        candidate: The candidate dict carrying launcher/source paths.
+        source_root: Optional root to resolve relative paths against.
+
+    Returns:
+        A ``(source_path, definition_line, function_name)`` dict, or ``None``
+        when the path is unparseable.
+    """
     # Prefer verbatim tracelens_launcher_path so AST resolution survives _finalize_candidates'
     # source_file overwrite; fall back to source_file / kernel_path for non-TraceLens candidates.
     kernel_path = str(
@@ -1220,6 +1369,12 @@ def _is_native_source(path: str) -> bool:
     keying a task_group on that line splits one device kernel across
     groups. Callers therefore drop the line/function key components for
     these files.
+
+    Args:
+        path: The source file path to classify.
+
+    Returns:
+        ``True`` for C/C++/HIP/CUDA source files.
     """
     return str(path).lower().endswith(_NATIVE_SOURCE_SUFFIXES)
 
@@ -1231,7 +1386,14 @@ def _normalize_operation_key(operation: str) -> str:
     SAME kernel profiled at different dtypes/shapes — e.g.
     ``rmsnorm_kernel<bf16>`` vs ``rmsnorm_kernel<fp16>`` — groups together,
     while DISTINCT kernels (different base names) stay separate (the Q1
-    invariant). Returns the original string when stripping leaves nothing.
+    invariant).
+
+    Args:
+        operation: The TraceLens operation name.
+
+    Returns:
+        The canonicalized operation name, or the original string when
+        stripping leaves nothing.
     """
     s = str(operation).strip()
     if "<" not in s:
@@ -1255,7 +1417,24 @@ def aggregate_by_source_function(
     *,
     source_root: Path | str | None = None,
 ) -> list[dict[str, Any]]:
-    """Group TraceLens candidates into per-kernel ``task_group`` dicts, sorted by aggregate time (desc). Native (.cu/.hip/.cpp) key on ``(source_path, function)`` only (collapse #420 over-split instantiations); Python key on ``(operation, path, line, function)`` since one caller frame can launch distinct kernels (Q1). Each group carries task_group_id/source_path/definition_line/function_name/kernel_ids/primary_kernel_id/rows/aggregate_*. Unparseable candidates left out for legacy per-kernel dispatch."""
+    """Group TraceLens candidates into per-kernel ``task_group`` dicts.
+
+    Groups are sorted by aggregate time (descending). Native (.cu/.hip/.cpp)
+    candidates key on ``(source_path, function)`` only (collapsing #420
+    over-split instantiations); Python candidates key on
+    ``(operation, path, line, function)`` since one caller frame can launch
+    distinct kernels (Q1). Each group carries ``task_group_id``,
+    ``source_path``, ``definition_line``, ``function_name``, ``kernel_ids``,
+    ``primary_kernel_id``, ``rows``, and ``aggregate_*`` fields.
+
+    Args:
+        candidates: The TraceLens candidate rows to group.
+        source_root: Optional root to resolve relative source paths against.
+
+    Returns:
+        The task-group dicts. Unparseable candidates are left out for legacy
+        per-kernel dispatch.
+    """
     if not candidates:
         return []
     root: Path | None = None

--- a/quantization_agent/driver/assessment.py
+++ b/quantization_agent/driver/assessment.py
@@ -168,7 +168,17 @@ def _classify_eval_outcome(
     *,
     acceptable_eval_gap: float | None,
 ) -> OutcomeId | None:
-    """Map eval-phase artifacts → outcome. ``None`` means 'eval not exercised'."""
+    """Map eval-phase artifacts to an outcome.
+
+    Args:
+        art: Collected artifacts for the attempt.
+        acceptable_eval_gap: Maximum tolerated relative accuracy gap, if
+            configured.
+
+    Returns:
+        The matching eval :class:`OutcomeId`, or ``None`` when eval was
+        not exercised this attempt.
+    """
 
     if art.eval_skipped_reason:
         reason = art.eval_skipped_reason.lower()
@@ -202,10 +212,16 @@ def _classify_sdk_phase_error(
     sdk_error: str,
     phase: str | None,
 ) -> OutcomeId | None:
-    """Map ``sdk_error`` text under a known phase to a phase-specific outcome.
+    """Map an SDK error under a known phase to a phase-specific outcome.
 
-    Returns ``None`` if the message doesn't look phase-specific; the caller
-    then falls through to bootstrap-level patterns.
+    Args:
+        sdk_error: Raw SDK error text.
+        phase: The phase that was executing when the error occurred.
+
+    Returns:
+        The matching :class:`OutcomeId`, or ``None`` if the message is not
+        phase-specific (the caller then falls through to bootstrap-level
+        patterns).
     """
 
     msg = sdk_error.lower()
@@ -238,10 +254,16 @@ def _classify_phase_artifact_gap(
     art: CollectedArtifacts,
     phase: str | None,
 ) -> OutcomeId | None:
-    """Disk-evidence gaps that depend on which phase last wrote ``last_phase.txt``.
+    """Detect disk-evidence gaps relative to the last-written phase.
 
-    Returns ``None`` if nothing is amiss at this phase boundary — the caller
-    then continues to MUST-have / validator / eval checks.
+    Args:
+        art: Collected artifacts for the attempt.
+        phase: The phase that last wrote ``last_phase.txt``.
+
+    Returns:
+        The matching :class:`OutcomeId`, or ``None`` if nothing is amiss
+        at this phase boundary (the caller then continues to MUST-have /
+        validator / eval checks).
     """
 
     if phase == "intake" and not art.model_analysis_present:
@@ -293,11 +315,20 @@ def classify_attempt(
 ) -> OutcomeId | None:
     """Classify a single attempt's workspace state.
 
-    Returns ``None`` for clean success, an ``OutcomeId`` otherwise. The retry
-    loop assembles attempts and derives the final ``Assessment``.
+    The retry loop assembles per-attempt outcomes and derives the final
+    ``Assessment``.
 
-    ``artifacts`` may be supplied if the caller already scanned the workspace
-    (saves a duplicate disk pass).
+    Args:
+        workspace: Attempt workspace directory to inspect.
+        sdk_error: Raw SDK error text, if the attempt raised one.
+        last_phase: Phase that last executed (overrides the on-disk marker).
+        acceptable_eval_gap: Maximum tolerated relative accuracy gap.
+        artifacts: Pre-scanned artifacts; supply to avoid a duplicate disk
+            pass.
+
+    Returns:
+        ``None`` for a clean success, otherwise the classified
+        :class:`OutcomeId`.
     """
 
     art = artifacts if artifacts is not None else collect_artifacts(Path(workspace))
@@ -385,6 +416,15 @@ def build_assessment(
     * ``final`` = last attempt's outcome.
     * ``recovered`` = True iff len(attempts) > 1 AND final ∈ SUCCESS_TAGS.
     * ``eval_gap`` = ``relative_gap`` from the latest ``eval_report.json``.
+
+    Args:
+        attempts: Per-attempt outcomes in chronological order.
+        workspace: Workspace directory used to collect artifacts.
+        artifacts: Pre-scanned artifacts; supply to avoid a disk pass.
+        notes: Extra human-readable notes to attach to the assessment.
+
+    Returns:
+        The assembled :class:`Assessment`.
     """
 
     if not attempts:
@@ -414,8 +454,15 @@ def build_assessment(
 def derive_status(assessment: Assessment, artifacts: CollectedArtifacts) -> str:
     """Map an ``Assessment`` to a public status string per design §5.4.
 
-    Returns ``"success"`` / ``"partial"`` / ``"failed"``. Consumed by
+    Consumed by
     :class:`quantization_agent.driver.retry.QuantSkillRunResult`.
+
+    Args:
+        assessment: The assembled assessment to map.
+        artifacts: Collected artifacts used for status demotion checks.
+
+    Returns:
+        One of ``"success"``, ``"partial"``, or ``"failed"``.
     """
 
     final = assessment.final

--- a/quantization_agent/driver/eval.py
+++ b/quantization_agent/driver/eval.py
@@ -65,7 +65,18 @@ def resolve_threshold(
     *,
     acceptable_eval_gap: float | None,
 ) -> tuple[float, str]:
-    """Return ``(threshold, source)`` per §3.1 priority chain."""
+    """Resolve the eval-gap threshold per the §3.1 priority chain.
+
+    Args:
+        workspace: Workspace directory that may hold a threshold override
+            file.
+        acceptable_eval_gap: Explicit threshold argument; takes precedence
+            when provided.
+
+    Returns:
+        A ``(threshold, source)`` tuple where ``source`` is ``"arg"``,
+        ``"file"``, or ``"default"``.
+    """
 
     if acceptable_eval_gap is not None:
         return float(acceptable_eval_gap), "arg"

--- a/quantization_agent/driver/outcomes.py
+++ b/quantization_agent/driver/outcomes.py
@@ -21,7 +21,11 @@ except ImportError:  # Python 3.10 fallback — mirror 3.11 StrEnum semantics
 
     class StrEnum(str, Enum):
         def __str__(self) -> str:
-            """Return the enum's string value (mirrors 3.11 ``StrEnum``)."""
+            """Return the enum's string value (mirrors 3.11 ``StrEnum``).
+
+            Returns:
+                The member's underlying string value.
+            """
             return str(self.value)
 
 

--- a/quantization_agent/driver/result_collector.py
+++ b/quantization_agent/driver/result_collector.py
@@ -172,9 +172,17 @@ def _read_json(path: Path) -> tuple[dict | None, str | None]:
 def _resolve_quantized_dir(workspace: Path) -> tuple[Path | None, bool, str | None]:
     """Read ``run_manifest.yaml`` and pull ``outputs.quantized_model_dir``.
 
-    Returns ``(path, manifest_present, parse_error)``. PyYAML is imported
-    lazily so the agent stays installable without it — falling back to the
-    ``nice_to_have_skipped`` (#20) outcome in that case.
+    PyYAML is imported lazily so the agent stays installable without it —
+    falling back to the ``nice_to_have_skipped`` (#20) outcome in that case.
+
+    Args:
+        workspace: Workspace directory containing ``run_manifest.yaml``.
+
+    Returns:
+        A ``(path, manifest_present, parse_error)`` tuple. ``path`` is the
+        resolved quantized-model directory (or ``None``), ``manifest_present``
+        indicates the manifest file existed, and ``parse_error`` carries a
+        reason string when parsing failed.
     """
 
     manifest = workspace / "run_manifest.yaml"
@@ -244,6 +252,12 @@ def _scan_hypothesis_attempts(workspace: Path) -> tuple[int, ...]:
     The classifier uses these to decide if SKILL.md actually diagnosed a fix
     before the retry was attempted (precondition for incrementing the
     retry counter — see §A.10).
+
+    Args:
+        workspace: Workspace directory to scan.
+
+    Returns:
+        The sorted attempt numbers ``N`` found on disk (empty if none).
     """
 
     pattern = re.compile(r"^fix_hypothesis_attempt_(\d+)\.md$")

--- a/quantization_agent/driver/retry.py
+++ b/quantization_agent/driver/retry.py
@@ -167,6 +167,14 @@ def _has_fix_hypothesis(workspace: Path, attempt_number: int) -> bool:
     Per §A.10, before re-running quark-torch-ptq SKILL.md must drop a concrete fix
     plan at ``fix_hypothesis_attempt_<next>.md``. Absence is the gate that
     prevents blind retries.
+
+    Args:
+        workspace: Workspace directory to inspect.
+        attempt_number: The current attempt number; the next attempt's
+            hypothesis file is ``attempt_number + 1``.
+
+    Returns:
+        ``True`` if the next attempt's fix-hypothesis file exists.
     """
 
     return (workspace / f"fix_hypothesis_attempt_{attempt_number + 1}.md").is_file()
@@ -200,7 +208,20 @@ def _decide_next_step(
     max_requantize_attempts: int,
     counter: int,
 ) -> _RetryDecision:
-    """Decide whether to retry, accept, or stop after one attempt."""
+    """Decide whether to retry, accept, or stop after one attempt.
+
+    Args:
+        outcome: The classified outcome of the just-finished attempt.
+        workspace: Attempt workspace directory.
+        attempt_number: Zero-based index of the attempt just completed.
+        interactive: Whether operator prompts are allowed.
+        max_requantize_attempts: Cap on requantize retries.
+        counter: Current value of the persisted requantize counter.
+
+    Returns:
+        A :class:`_RetryDecision` describing whether to retry, promote, or
+        terminate, plus a debugging note.
+    """
 
     if outcome is None or outcome in SUCCESS_TAGS:
         return _RetryDecision(retry=False, note="")
@@ -269,11 +290,25 @@ async def quantize_via_prompt(
 ) -> QuantSkillRunResult:
     """Run the quantization-agent against ``prompt`` and return a result.
 
-    All inputs except ``prompt`` and ``workspace`` are optional. ``quark_root``
-    falls back to ``$QUARK_ROOT`` then to a hard error (mapped to
-    ``quark_root_missing`` at the assessment level). The threshold resolves
-    per ``_eval.resolve_threshold``; the interactive flag per
-    ``_resolve_interactive``.
+    ``quark_root`` falls back to ``$QUARK_ROOT`` then to a hard error
+    (mapped to ``quark_root_missing`` at the assessment level). The
+    threshold resolves per ``_eval.resolve_threshold``; the interactive
+    flag per ``_resolve_interactive``.
+
+    Args:
+        prompt: The quantization instruction prompt.
+        workspace: Directory for attempt artifacts (created if needed).
+        quark_root: Quark checkout root; falls back to ``$QUARK_ROOT``.
+        interactive: Force interactive operator prompts; auto-resolved
+            when ``None``.
+        acceptable_eval_gap: Maximum tolerated relative accuracy gap.
+        max_requantize_attempts: Cap on requantize retries.
+        model: Optional model identifier passed to the runner.
+        runner_fn: Override for the single-attempt runner (testing hook).
+        log: Optional line-logging callback.
+
+    Returns:
+        The assembled :class:`QuantSkillRunResult`.
     """
 
     workspace_path = Path(workspace).resolve()
@@ -377,6 +412,14 @@ def _build_failed_bootstrap_result(
     note: str,
 ) -> QuantSkillRunResult:
     """Fast-path failure that bypasses the SDK (used for bootstrap errors).
+
+    Args:
+        workspace: Workspace directory for the (failed) attempt.
+        outcome: The bootstrap-level outcome to record.
+        note: Human-readable note attached to the assessment.
+
+    Returns:
+        A well-formed failed :class:`QuantSkillRunResult`.
 
     Produces a well-formed ``QuantSkillRunResult`` so callers can branch on
     ``status`` / ``assessment.final`` without special-casing pre-flight

--- a/quantization_agent/driver/runner.py
+++ b/quantization_agent/driver/runner.py
@@ -94,6 +94,13 @@ def resolve_skill_path(package_root: Path | None = None) -> Path:
     The SKILL is the runtime contract loaded into every attempt; resolution
     is centralized here so callers (including the CLI smoke test) don't
     hardcode the layout.
+
+    Args:
+        package_root: Override for the package root; defaults to the
+            parent of this module's directory.
+
+    Returns:
+        The path to ``SKILL.md`` under the package root.
     """
 
     # __file__ is .../quantization_agent/driver/runner.py — SKILL.md lives one
@@ -122,6 +129,20 @@ def build_attempt_prompt(
     prior outcome ID + the fix-hypothesis file SKILL.md wrote at the end of
     the previous attempt, so the LLM can target the diagnosed cause rather
     than re-running the same plan blindly.
+
+    Args:
+        user_prompt: The verbatim user instruction to embed.
+        skill_path: Path to ``SKILL.md`` (the runtime contract).
+        workspace: Directory where the attempt writes artifacts.
+        quark_root: Read-only Quark project root.
+        attempt_number: 1-based attempt index.
+        acceptable_eval_gap: Caller-supplied eval-gap threshold, if any.
+        interactive: Interactivity mode (``None`` = auto).
+        previous_outcome: Prior attempt's outcome ID, for retry context.
+        fix_hypothesis_path: Path to the prior fix-hypothesis file, if any.
+
+    Returns:
+        The fully-rendered prompt string.
     """
 
     interactive_str = (
@@ -191,6 +212,25 @@ async def run_one_attempt(
     and returned via ``AttemptResult.sdk_error`` rather than propagated, so
     the retry loop can read the workspace state — which often contains valid
     artifacts even when the SDK aborted late.
+
+    Args:
+        user_prompt: The verbatim user instruction.
+        workspace: Directory for attempt artifacts (created if needed).
+        quark_root: Read-only Quark project root.
+        attempt_number: 1-based attempt index.
+        acceptable_eval_gap: Caller-supplied eval-gap threshold, if any.
+        interactive: Interactivity mode (``None`` = auto).
+        previous_outcome: Prior attempt's outcome ID, for retry context.
+        skill_path: Override for the ``SKILL.md`` path.
+        model: Optional model identifier.
+        max_turns: Maximum SDK turns for the session.
+        allowed_tools: Optional explicit tool allowlist.
+        sdk_query_factory: Override for the SDK query callable (testing).
+        sdk_options_cls: Override for the SDK options class (testing).
+        log: Optional line-logging callback.
+
+    Returns:
+        The :class:`AttemptResult` for the session.
     """
 
     workspace = Path(workspace)

--- a/robustness-agent/src/robustness_agent/config.py
+++ b/robustness-agent/src/robustness_agent/config.py
@@ -476,6 +476,9 @@ def _discover_workload_uid() -> str:
 
     Lets a RayJob sandbox opt into hierarchy-based pod discovery; single-node
     runs leave every key unset and fall back to ``list_session_pods``.
+
+    Returns:
+        The first non-empty workload-uid env value, or ``""`` if none set.
     """
     for key in _WORKLOAD_UID_ENV_KEYS:
         value = (os.environ.get(key) or "").strip()

--- a/robustness-agent/src/robustness_agent/decision/action_ladder.py
+++ b/robustness-agent/src/robustness_agent/decision/action_ladder.py
@@ -406,8 +406,17 @@ _LADDER_KEY_SEP: str = "\x1f"  # ASCII unit separator — safe inside JSON strin
 def _encode_last_emitted(
     last_emitted: dict[tuple[str, ...], int],
 ) -> dict[str, int]:
-    """Serialise a tuple-keyed cooldown dict to a JSON-safe dict (tuple
-    components joined with ``_LADDER_KEY_SEP`` so decode recovers them)."""
+    """Serialise a tuple-keyed cooldown dict to a JSON-safe dict.
+
+    Tuple components are joined with ``_LADDER_KEY_SEP`` so the decoder can
+    recover them.
+
+    Args:
+        last_emitted: Cooldown map keyed by tuple of string components.
+
+    Returns:
+        A string-keyed dict safe for JSON serialization.
+    """
     out: dict[str, int] = {}
     for key, tick in last_emitted.items():
         try:

--- a/robustness-agent/src/robustness_agent/finalize/postmortem.py
+++ b/robustness-agent/src/robustness_agent/finalize/postmortem.py
@@ -585,7 +585,14 @@ def finalize_session(
 ) -> bool:
     """Convenience wrapper for non-reactor callers (e.g. post-hoc re-runs).
 
-    Returns the :meth:`PostmortemFinalizer.finalize` boolean.
+    Args:
+        session_dir: Session directory to finalize.
+        session_id: Identifier of the session.
+        stop_reason: Reason recorded for finalization.
+        config: Optional finalizer configuration.
+
+    Returns:
+        The :meth:`PostmortemFinalizer.finalize` boolean.
     """
     finalizer = PostmortemFinalizer(
         session_dir=session_dir,
@@ -602,8 +609,16 @@ def finalize_session(
 def _pick_flashpoint(
     findings: list[dict[str, Any]],
 ) -> dict[str, Any] | None:
-    """First HIGH-severity finding, ordered by ``tick_index`` then
-    ``timestamp_unix`` (tie-break). ``None`` if nothing crossed HIGH."""
+    """Pick the earliest HIGH-severity finding as the flashpoint.
+
+    Ordered by ``tick_index`` then ``timestamp_unix`` (tie-break).
+
+    Args:
+        findings: Candidate finding dicts.
+
+    Returns:
+        The first HIGH-severity finding, or ``None`` if none crossed HIGH.
+    """
     high = [
         f for f in findings
         if isinstance(f, dict) and str(f.get("severity")) == "high"
@@ -624,9 +639,19 @@ def _normalise_task_entry(
     result_path: Path,
     payload: dict[str, Any],
 ) -> dict[str, Any]:
-    """Project an executor ``result.json`` into the trace shape, capturing
-    the union of action-specific fields (e.g. ``output_throughput`` vs
-    ``gain_pct``) so dashboards need not re-read each file."""
+    """Project an executor ``result.json`` into the trace entry shape.
+
+    Captures the union of action-specific fields (e.g. ``output_throughput``
+    vs ``gain_pct``) so dashboards need not re-read each file.
+
+    Args:
+        task_dir: The task's workspace directory.
+        result_path: Path to the task's ``result.json``.
+        payload: Parsed result payload.
+
+    Returns:
+        A normalized trace entry dict.
+    """
     entry: dict[str, Any] = {
         "task_id": task_dir.name,
         "workspace": str(task_dir),

--- a/robustness-agent/src/robustness_agent/main.py
+++ b/robustness-agent/src/robustness_agent/main.py
@@ -37,9 +37,15 @@ def _setup_logging() -> None:
 
 
 async def _run_reactor_mode(config: Config) -> None:
-    """Standalone reactor loop for dev / debugging; polls sources at
-    ``standalone_tick_interval_s`` and writes findings to disk. (Production
-    drives the same reactor via ``runtime.cli tick`` in a subprocess.)"""
+    """Run the standalone reactor loop for dev / debugging.
+
+    Polls sources at ``standalone_tick_interval_s`` and writes findings to
+    disk. (Production drives the same reactor via ``runtime.cli tick`` in a
+    subprocess.)
+
+    Args:
+        config: The resolved agent configuration.
+    """
     log = logging.getLogger("robustness_agent")
     bundle = build_reactor_components(config)
 

--- a/robustness-agent/src/robustness_agent/role/prompt_inputs.py
+++ b/robustness-agent/src/robustness_agent/role/prompt_inputs.py
@@ -353,6 +353,12 @@ def _count_optimization_stack(head: str) -> int:
 
     ``SharedState._format_optimization_stack`` emits ``"(none)"`` (empty) or a
     Python list repr (e.g. ``['baseline:v1', 'integrate:v2']``).
+
+    Args:
+        head: The rendered ``optimization_stack`` head value.
+
+    Returns:
+        The number of stack entries (``0`` when empty/unparseable).
     """
     if not head or head == "(none)":
         return 0
@@ -372,7 +378,12 @@ def _parse_time_budget_into(snapshot: SharedStateSnapshot, body: str) -> None:
     """Decode the ``=== Time budget ===`` section in place onto ``snapshot``.
 
     The Coordinator emits one body line below the header; an absent section
-    leaves defaults so BudgetMonitor / deadline_imminent signals short-circuit.
+    leaves defaults so BudgetMonitor / deadline_imminent signals
+    short-circuit.
+
+    Args:
+        snapshot: Snapshot mutated in place with parsed budget fields.
+        body: The time-budget section body text.
     """
     if not body:
         return
@@ -413,6 +424,12 @@ def _split_double_space(value: str) -> str:
 
     ``to_prompt_summary`` joins two scalars with two spaces
     (``baseline_tput=...  baseline_acc=...``); cut at that boundary.
+
+    Args:
+        value: The raw scalar text possibly containing a trailing neighbour.
+
+    Returns:
+        The value trimmed at the first double-space boundary.
     """
     return value.split("  ", 1)[0].strip()
 

--- a/robustness-agent/src/robustness_agent/role/reactor.py
+++ b/robustness-agent/src/robustness_agent/role/reactor.py
@@ -167,9 +167,17 @@ class Reactor:
         return validated_intents
 
     def _resolve_authoritative_tick(self, ctx: ReactorContext) -> int:
-        """Pick the most reliable tick index: prefer the Coordinator's
-        session-wide ``ctx.shared_state.tick``, else the in-memory counter
-        (tests / first tick before the prompt is written).
+        """Pick the most reliable tick index for this reactor pass.
+
+        Prefers the Coordinator's session-wide ``ctx.shared_state.tick``,
+        else the in-memory counter (tests / first tick before the prompt is
+        written).
+
+        Args:
+            ctx: Reactor context for the current tick.
+
+        Returns:
+            The resolved authoritative tick index.
         """
         shared_tick = getattr(ctx.shared_state, "tick", 0) or 0
         if shared_tick > 0:

--- a/robustness-agent/src/robustness_agent/signals/budget.py
+++ b/robustness-agent/src/robustness_agent/signals/budget.py
@@ -204,7 +204,18 @@ def _burn_no_gain_symptom(
 def _strategy_drift_symptom(
     snap: SharedStateSnapshot, *, burn_pct: float, cfg: BudgetConfig,
 ) -> Symptom:
-    """H2 early warning: 50% burnt and nothing to ship; MEDIUM (diagnose only)."""
+    """H2 early-warning symptom: budget half-burnt with nothing to ship.
+
+    MEDIUM severity (diagnose only).
+
+    Args:
+        snap: Current shared-state snapshot.
+        burn_pct: Fraction of the wall-clock budget consumed.
+        cfg: Budget configuration thresholds.
+
+    Returns:
+        The constructed :class:`Symptom`.
+    """
     return Symptom(
         name="budget_strategy_drift",
         severity=SymptomSeverity.MEDIUM,
@@ -238,7 +249,19 @@ def _deadline_warning_symptom(
     validated: float,
     cfg: BudgetConfig,
 ) -> Symptom:
-    """H1 absolute-time warning (<30 min): MEDIUM with validated gain, HIGH without."""
+    """H1 absolute-time warning symptom (deadline approaching).
+
+    MEDIUM severity when validated gain exists, HIGH without.
+
+    Args:
+        snap: Current shared-state snapshot.
+        remaining: Minutes remaining in the budget.
+        validated: Cumulative validated gain percentage.
+        cfg: Budget configuration thresholds.
+
+    Returns:
+        The constructed :class:`Symptom`.
+    """
     if validated < cfg.productive_gain_pct:
         severity = SymptomSeverity.HIGH
         tail = "validated_gain still 0; wind the session down now"
@@ -277,7 +300,18 @@ def _deadline_warning_symptom(
 def _hard_cutoff_symptom(
     snap: SharedStateSnapshot, *, remaining: float, cfg: BudgetConfig,
 ) -> Symptom:
-    """H1 absolute-time emergency cut (<=5 min): always HIGH + delegate(report)."""
+    """H1 absolute-time emergency-cutoff symptom (deadline imminent).
+
+    Always HIGH severity and suggests delegating to the final report.
+
+    Args:
+        snap: Current shared-state snapshot.
+        remaining: Minutes remaining in the budget.
+        cfg: Budget configuration thresholds.
+
+    Returns:
+        The constructed :class:`Symptom`.
+    """
     return Symptom(
         name="deadline_hard_cutoff",
         severity=SymptomSeverity.HIGH,

--- a/robustness-agent/src/robustness_agent/signals/critic_health.py
+++ b/robustness-agent/src/robustness_agent/signals/critic_health.py
@@ -156,7 +156,19 @@ def _unavailable_streak_symptoms(
     data: SourceData,
     cfg: CriticHealthConfig,
 ) -> list[Symptom]:
-    """Count consecutive ``critic_unavailable`` verdicts across coordinator_events + inbox."""
+    """Detect a streak of consecutive ``critic_unavailable`` verdicts.
+
+    Scans ``coordinator_events`` plus the reactor inbox for the trailing
+    run of unavailable review verdicts.
+
+    Args:
+        ctx: Reactor context (supplies the inbox).
+        data: Collected source data (coordinator events).
+        cfg: Critic-health configuration thresholds.
+
+    Returns:
+        A list with one :class:`Symptom` when the streak trips, else empty.
+    """
     rows: list[dict[str, Any]] = []
     for event in data.coordinator_events:
         if not isinstance(event, dict):
@@ -267,7 +279,15 @@ def _prune_stuck_symptoms(
 def _runtime_stuck_symptoms(
     data: SourceData, cfg: CriticHealthConfig,
 ) -> list[Symptom]:
-    """Collapse ``runtime.cli .* timed out`` log hits into a critic-specific symptom."""
+    """Collapse ``runtime.cli .* timed out`` log hits into one symptom.
+
+    Args:
+        data: Collected source data (logs).
+        cfg: Critic-health configuration thresholds.
+
+    Returns:
+        A list with one :class:`Symptom` when timeouts are found, else empty.
+    """
     errors = data.local_log_errors
     if not isinstance(errors, list) or not errors:
         return []

--- a/robustness-agent/src/robustness_agent/signals/decision_audit.py
+++ b/robustness-agent/src/robustness_agent/signals/decision_audit.py
@@ -136,7 +136,17 @@ def _integrate_symptoms(
 
 
 def _g1_empty_patch_kept(entry: dict[str, Any]) -> list[Symptom]:
-    """G1: integrate KEEP/PARTIAL with patch_size_bytes == 0 — empty patch, so any gain is noise."""
+    """G1: flag a KEEP/PARTIAL integrate with an empty patch.
+
+    A ``patch_size_bytes == 0`` means no code changed, so any measured gain
+    is noise.
+
+    Args:
+        entry: A decision-audit ledger entry.
+
+    Returns:
+        A list with one :class:`Symptom` when the guard trips, else empty.
+    """
     patch_size = entry.get("patch_size_bytes")
     if not isinstance(patch_size, int) or patch_size > 0:
         return []
@@ -175,7 +185,17 @@ def _g1_empty_patch_kept(entry: dict[str, Any]) -> list[Symptom]:
 def _g2_decision_threshold_violated(
     entry: dict[str, Any], cfg: DecisionAuditConfig,
 ) -> list[Symptom]:
-    """G2: KEEP with gain_pct below ``min_keep_gain_pct`` (noise-floor); MEDIUM since the real fix is upstream's threshold."""
+    """G2: flag a KEEP whose gain is below the noise-floor threshold.
+
+    MEDIUM severity since the real fix is upstream's keep threshold.
+
+    Args:
+        entry: A decision-audit ledger entry.
+        cfg: Decision-audit configuration (supplies ``min_keep_gain_pct``).
+
+    Returns:
+        A list with one :class:`Symptom` when the guard trips, else empty.
+    """
     if entry.get("decision") != "KEEP":
         return []
     gain_pct = entry.get("gain_pct")
@@ -212,9 +232,19 @@ def _g2_decision_threshold_violated(
 def _g3_kernel_dispatch_bypassed(
     entry: dict[str, Any], cfg: DecisionAuditConfig,
 ) -> list[Symptom]:
-    """G3: KEEP'd patch likely never executed — ``dispatched_count == 0``, or absent
-    with ``|gain_pct| < dispatch_bypass_pre_post_epsilon_pct``. HIGH: a KEEP without
-    proof of execution is a false-positive in the optimization_stack.
+    """G3: flag a KEEP'd patch that likely never executed.
+
+    Trips when ``dispatched_count == 0``, or it is absent while
+    ``|gain_pct| < dispatch_bypass_pre_post_epsilon_pct``. HIGH severity: a
+    KEEP without proof of execution is a false-positive in the
+    optimization_stack.
+
+    Args:
+        entry: A decision-audit ledger entry.
+        cfg: Decision-audit configuration (dispatch-bypass epsilon).
+
+    Returns:
+        A list with one :class:`Symptom` when the guard trips, else empty.
     """
     if entry.get("decision") != "KEEP":
         return []
@@ -294,8 +324,18 @@ def _ci_metrics_symptoms(
 def _g4_negative_delta_kernel_kept(
     ci_metrics: dict[str, Any], ci_metrics_path: str,
 ) -> list[Symptom]:
-    """G4: kernels_optimized > 0 AND optimized_kernel_delta_pct <= 0 (net-negative).
-    HIGH because downstream aggregators treat kernels_optimized as a win count.
+    """G4: flag net-negative kernel changes counted as wins.
+
+    Trips when ``kernels_optimized > 0`` AND
+    ``optimized_kernel_delta_pct <= 0``. HIGH because downstream
+    aggregators treat ``kernels_optimized`` as a win count.
+
+    Args:
+        ci_metrics: Parsed ci_metrics document.
+        ci_metrics_path: Path of the ci_metrics file (recorded in evidence).
+
+    Returns:
+        A list with one :class:`Symptom` when the guard trips, else empty.
     """
     kernels_opt = ci_metrics.get("kernels_optimized")
     delta_pct = ci_metrics.get("optimized_kernel_delta_pct")
@@ -331,8 +371,18 @@ def _g4_negative_delta_kernel_kept(
 def _g5_baseline_zero_without_status(
     ci_metrics: dict[str, Any], ci_metrics_path: str,
 ) -> list[Symptom]:
-    """G5: any baseline-throughput field == 0 AND no ``status="baseline_failed"`` marker —
-    half-written ci_metrics that downstream mistakes for "no optimization space".
+    """G5: flag a zero baseline throughput lacking a failure marker.
+
+    Trips when any baseline-throughput field == 0 AND there is no
+    ``status="baseline_failed"`` marker — a half-written ci_metrics file
+    that downstream mistakes for "no optimization space".
+
+    Args:
+        ci_metrics: Parsed ci_metrics document.
+        ci_metrics_path: Path of the ci_metrics file (recorded in evidence).
+
+    Returns:
+        A list with one :class:`Symptom` when the guard trips, else empty.
     """
     if str(ci_metrics.get("status") or "") == "baseline_failed":
         return []
@@ -382,7 +432,18 @@ def _g5_baseline_zero_without_status(
 def _g6_schema_drift(
     ci_metrics: dict[str, Any], ci_metrics_path: str,
 ) -> list[Symptom]:
-    """G6: ci_metrics missing required schema fields OR using legacy names; MEDIUM (fix is in report_back)."""
+    """G6: flag ci_metrics schema drift.
+
+    Trips when required schema fields are missing OR legacy field names are
+    used. MEDIUM severity (the fix is in ``report_back``).
+
+    Args:
+        ci_metrics: Parsed ci_metrics document.
+        ci_metrics_path: Path of the ci_metrics file (recorded in evidence).
+
+    Returns:
+        A list with one :class:`Symptom` when the guard trips, else empty.
+    """
     keys = set(ci_metrics.keys())
     missing = _CI_METRICS_REQUIRED_FIELDS - keys
     legacy = keys & _CI_METRICS_LEGACY_FIELDS
@@ -421,7 +482,17 @@ def _oob_symptoms(
     entries: list[dict[str, Any]],
     cfg: DecisionAuditConfig,
 ) -> list[Symptom]:
-    """G7: OOB attempt advertises "expected speedup" but never measured; HIGH so downstream won't count it as kernels_optimized."""
+    """G7: flag OOB attempts advertising unmeasured "expected speedup".
+
+    HIGH severity so downstream won't count them as ``kernels_optimized``.
+
+    Args:
+        entries: OOB ``optimization_attempts.jsonl`` entries.
+        cfg: Decision-audit configuration.
+
+    Returns:
+        Symptoms for offending entries, possibly empty.
+    """
     out: list[Symptom] = []
     by_kernel: dict[str, dict[str, Any]] = {}
     for entry in entries:

--- a/robustness-agent/src/robustness_agent/signals/event.py
+++ b/robustness-agent/src/robustness_agent/signals/event.py
@@ -192,6 +192,13 @@ def _idempotency_replay_symptoms(
     Coordinator dedup keys only off ``idempotency_key``, so an LLM minting fresh keys
     per attempt with identical payload slips through. Fire when one action+payload hash
     carries ``>= idempotency_replay_threshold`` distinct keys within a tick.
+
+    Args:
+        ctx: Reactor context (supplies the inbox).
+        cfg: Event configuration (replay threshold).
+
+    Returns:
+        Symptoms for offending action+payload groups, possibly empty.
     """
     if not ctx.inbox:
         return []
@@ -260,9 +267,19 @@ def _recover_unsuccessful_symptoms(
     events: list[dict[str, Any]],
     cfg: EventConfig,
 ) -> list[Symptom]:
-    """Emit ``recover_unsuccessful`` (HIGH → delegate(report)) when the latest recover
-    hit ``state == "needs_review"`` — cleanup failed to free VRAM, terminal for this budget.
-    Inspects only the latest recover ``delegated_result``; earlier successes are not second-guessed.
+    """Emit ``recover_unsuccessful`` when the latest recover needs review.
+
+    Fires (HIGH → delegate(report)) when the latest recover hit
+    ``state == "needs_review"`` — cleanup failed to free VRAM, terminal for
+    this budget. Inspects only the latest recover ``delegated_result``;
+    earlier successes are not second-guessed.
+
+    Args:
+        events: Coordinator event dicts in chronological order.
+        cfg: Event configuration (recover lookback window).
+
+    Returns:
+        A list with one :class:`Symptom` when it fires, else empty.
     """
     head = events[-cfg.recover_lookback_events:] if events else []
     latest: dict[str, Any] | None = None
@@ -311,7 +328,17 @@ def _recover_unsuccessful_symptoms(
 
 
 def _is_recover_payload(payload: dict[str, Any]) -> bool:
-    """Best-effort check that a ``delegated_result`` came from ``recover`` (via ``kind`` or recover-only fields)."""
+    """Best-effort check that a ``delegated_result`` came from ``recover``.
+
+    Recognized via ``kind`` / ``action_name`` / ``family`` or recover-only
+    executor fields.
+
+    Args:
+        payload: A ``delegated_result`` payload.
+
+    Returns:
+        ``True`` if the payload appears to be from a recover action.
+    """
     if str(payload.get("kind") or "").strip() == "recover":
         return True
     if str(payload.get("action_name") or "").strip() == "recover":
@@ -373,7 +400,14 @@ def _normalise_events(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
 
 def _family_of(payload: dict[str, Any]) -> str:
-    """Best-effort family inference from a delegated_result payload; falls back to ``kind``."""
+    """Infer the action family from a ``delegated_result`` payload.
+
+    Args:
+        payload: A ``delegated_result`` payload.
+
+    Returns:
+        The family string, falling back to ``kind`` and then ``""``.
+    """
     family = payload.get("family")
     if isinstance(family, str) and family.strip():
         return family.strip()

--- a/robustness-agent/src/robustness_agent/signals/gpu_leak.py
+++ b/robustness-agent/src/robustness_agent/signals/gpu_leak.py
@@ -279,7 +279,16 @@ def evaluate_gpu_leak_signals(
     ctx: ReactorContext,
     data: SourceData,
 ) -> list[Symptom]:
-    """Module-level helper adapting the stateful detector to the ``(ctx, data)`` entry-point signature."""
+    """Adapt the stateful detector to the ``(ctx, data)`` entry point.
+
+    Args:
+        detector: The stateful GPU-leak detector instance.
+        ctx: Reactor context for the current tick.
+        data: Collected source data.
+
+    Returns:
+        The symptoms produced by the detector.
+    """
     return detector.evaluate(ctx, data)
 
 

--- a/robustness-agent/src/robustness_agent/signals/kernel_pipeline.py
+++ b/robustness-agent/src/robustness_agent/signals/kernel_pipeline.py
@@ -424,7 +424,18 @@ def evaluate_kernel_pipeline_signals(
     *,
     config: KernelPipelineConfig | None = None,
 ) -> list[Symptom]:
-    """Stateless slice of F (F2 / F4 / F5); F1 is stateful in :class:`RayPendingDetector`."""
+    """Evaluate the stateless kernel-pipeline signals (F2 / F4 / F5).
+
+    F1 is stateful and lives in :class:`RayPendingDetector`.
+
+    Args:
+        ctx: Reactor context for the current tick.
+        data: Collected source data.
+        config: Optional configuration; a default is used when ``None``.
+
+    Returns:
+        The kernel-pipeline symptoms, possibly empty.
+    """
     cfg = config or KernelPipelineConfig()
     out: list[Symptom] = []
     out.extend(_geak_budget_symptoms(data, cfg))

--- a/robustness-agent/src/robustness_agent/signals/local_health.py
+++ b/robustness-agent/src/robustness_agent/signals/local_health.py
@@ -270,8 +270,17 @@ def _disk_pressure_symptoms(
     data: SourceData,
     cfg: LocalHealthConfig,
 ) -> list[Symptom]:
-    """Emit ``disk_pressure`` for non-SHM mountpoints under capacity stress; SHM is handled
-    separately with stricter thresholds, so it's skipped here to avoid double-firing.
+    """Emit ``disk_pressure`` for non-SHM mountpoints under capacity stress.
+
+    SHM is handled separately with stricter thresholds, so it is skipped
+    here to avoid double-firing.
+
+    Args:
+        data: Collected source data (per-mountpoint disk stats).
+        cfg: Local-health configuration thresholds.
+
+    Returns:
+        Symptoms for stressed mountpoints, possibly empty.
     """
     if not isinstance(data.local_disk, dict) or not data.local_disk:
         return []
@@ -328,8 +337,18 @@ def _shm_pressure_symptoms(
     data: SourceData,
     cfg: LocalHealthConfig,
 ) -> list[Symptom]:
-    """Emit ``shm_pressure`` (stricter thresholds): SGLang/vLLM crash hard when /dev/shm fills,
-    surfaced at runtime before the next server start fails with ``shared memory allocation failed``.
+    """Emit ``shm_pressure`` (stricter thresholds) for SHM mountpoints.
+
+    SGLang/vLLM crash hard when /dev/shm fills; this surfaces the pressure
+    before the next server start fails with ``shared memory allocation
+    failed``.
+
+    Args:
+        data: Collected source data (per-mountpoint disk stats).
+        cfg: Local-health configuration thresholds.
+
+    Returns:
+        Symptoms for stressed SHM mountpoints, possibly empty.
     """
     if not isinstance(data.local_disk, dict) or not data.local_disk:
         return []
@@ -382,8 +401,17 @@ def _shm_pressure_symptoms(
 
 
 def _ray_head_dead_symptoms(data: SourceData) -> list[Symptom]:
-    """Emit ``ray_head_dead`` (HIGH) when ``data.local_ray`` reports ``healthy=False``;
-    silent when the probe slot is empty or healthy. Prompts Orchestration to prune kernel_opt.
+    """Emit ``ray_head_dead`` (HIGH) when the Ray head is unhealthy.
+
+    Fires when ``data.local_ray`` reports ``healthy=False``; silent when the
+    probe slot is empty or healthy. Prompts Orchestration to prune
+    kernel_opt.
+
+    Args:
+        data: Collected source data (Ray head probe).
+
+    Returns:
+        A list with one :class:`Symptom` when unhealthy, else empty.
     """
     ray_info = getattr(data, "local_ray", None)
     if not isinstance(ray_info, dict) or not ray_info:
@@ -416,8 +444,17 @@ def _fd_pressure_symptoms(
     data: SourceData,
     cfg: LocalHealthConfig,
 ) -> list[Symptom]:
-    """Emit ``fd_pressure`` from ``data.local_fd`` when Coordinator FD usage nears the limit;
-    leaked sockets hitting ``ulimit -n`` surface as agent_stall(kernel) whose real cause is here.
+    """Emit ``fd_pressure`` when Coordinator FD usage nears the limit.
+
+    Leaked sockets hitting ``ulimit -n`` surface as agent_stall(kernel)
+    whose real cause is here.
+
+    Args:
+        data: Collected source data (file-descriptor usage).
+        cfg: Local-health configuration thresholds.
+
+    Returns:
+        A list with one :class:`Symptom` when FD pressure trips, else empty.
     """
     fd_info = getattr(data, "local_fd", None)
     if not isinstance(fd_info, dict) or not fd_info:

--- a/robustness-agent/src/robustness_agent/signals/preflight.py
+++ b/robustness-agent/src/robustness_agent/signals/preflight.py
@@ -72,7 +72,15 @@ _PARAM_BILLIONS_RE: re.Pattern[str] = re.compile(
 
 
 def extract_params_billions(model_name: str) -> float | None:
-    """Best-effort parse of ``-<N>B`` from a model name (first match; ``None`` if absent)."""
+    """Best-effort parse of ``-<N>B`` parameter count from a model name.
+
+    Args:
+        model_name: The model name to parse.
+
+    Returns:
+        The parameter count in billions (first match), or ``None`` when
+        absent or unparseable.
+    """
     if not model_name:
         return None
     match = _PARAM_BILLIONS_RE.search(model_name)
@@ -103,8 +111,14 @@ def compute_headroom_gib(
 ) -> HeadroomBreakdown | None:
     """Project per-GPU HBM headroom from manifest metadata.
 
-    Returns ``None`` when a required field (model size, precision, gpu_type, ``tp``) is
-    unresolved; the C1 detector treats ``None`` as "skip — not enough data to judge".
+    Args:
+        manifest: Run manifest with model / workload / GPU metadata.
+        activation_buf_gib: Reserved activation buffer per GPU, in GiB.
+
+    Returns:
+        A :class:`HeadroomBreakdown`, or ``None`` when a required field
+        (model size, precision, gpu_type, ``tp``) is unresolved — the C1
+        detector treats ``None`` as "skip — not enough data to judge".
     """
     if not isinstance(manifest, dict) or not manifest:
         return None
@@ -162,7 +176,17 @@ def amdahl_e2e_ceiling(
     optimizable_pct: float,
     single_kernel_speedup: float,
 ) -> float:
-    """Amdahl's law best-case E2E speedup ratio (1.0 = none); caller converts via ``(ratio - 1.0) * 100``."""
+    """Compute Amdahl's-law best-case end-to-end speedup ratio.
+
+    The caller converts to a percentage via ``(ratio - 1.0) * 100``.
+
+    Args:
+        optimizable_pct: Percent of runtime that is optimizable (0-100).
+        single_kernel_speedup: Speedup factor for the optimizable portion.
+
+    Returns:
+        The best-case E2E speedup ratio (``1.0`` means no speedup).
+    """
     p = max(0.0, min(1.0, optimizable_pct / 100.0))
     s = max(1.0, float(single_kernel_speedup))
     serial = 1.0 - p
@@ -343,7 +367,16 @@ def _manifest_fingerprint(manifest: dict[str, Any]) -> tuple[Any, ...]:
 
 
 def _recommend_tp(breakdown: HeadroomBreakdown) -> int:
-    """Smallest power-of-two TP clearing ``required_gib`` (operator hint; assumes weights dominate KV)."""
+    """Recommend the smallest power-of-two TP that clears the HBM budget.
+
+    Operator hint only; assumes weights dominate KV and ignores KV scaling.
+
+    Args:
+        breakdown: The per-GPU headroom breakdown.
+
+    Returns:
+        A suggested tensor-parallel degree (power of two).
+    """
     if breakdown.hbm_gib <= 0 or breakdown.weights_gib <= 0:
         return 8
     # Weights shrink ~linearly with TP; ignore KV scaling for the hint.

--- a/robustness-agent/src/robustness_agent/signals/repeated_payload.py
+++ b/robustness-agent/src/robustness_agent/signals/repeated_payload.py
@@ -151,7 +151,16 @@ def evaluate_repeated_payload_signals(
 def _walk_streaks(
     events: list[dict[str, Any]],
 ) -> dict[str, list[dict[str, Any]]]:
-    """Group consecutive same-hash failures per family; a ``succeeded`` entry resets the streak."""
+    """Group consecutive same-hash failures per family.
+
+    A ``succeeded`` entry resets the streak for its family.
+
+    Args:
+        events: Time-ordered ``delegated_result`` rows.
+
+    Returns:
+        Mapping of family to its current run of same-hash failure events.
+    """
     by_family: dict[str, list[dict[str, Any]]] = {}
     current_hash: dict[str, str | None] = {}
     for ev in events:
@@ -183,7 +192,19 @@ def _gather_events(
     coord_events: list[dict[str, Any]],
     cfg: RepeatedPayloadConfig,
 ) -> list[dict[str, Any]]:
-    """Build a single time-ordered list of ``delegated_result`` rows, trimmed to ``lookback_events``."""
+    """Build a time-ordered list of ``delegated_result`` rows.
+
+    Unions inbox items and coordinator events, trimmed to
+    ``lookback_events``.
+
+    Args:
+        inbox: Reactor inbox items.
+        coord_events: Coordinator event dicts.
+        cfg: Repeated-payload configuration (lookback window).
+
+    Returns:
+        The merged, trimmed list of ``delegated_result`` rows.
+    """
     inbox_rows = [
         {
             "topic": item.topic,
@@ -277,9 +298,17 @@ def _hash_for(family: str, event: dict[str, Any]) -> str | None:
 
 
 def _normalise_extra_server_args_key(payload: dict[str, Any]) -> dict[str, Any]:
-    """Shallow copy with ``params.extra_server_args`` set from the compat
-    helper (originals not mutated). No-op when no extra-args key or canonical
-    already present; the shim's DeprecationWarning stays as the legacy audit channel.
+    """Normalise the legacy ``extra_sglang_args`` key to the canonical one.
+
+    Returns a shallow copy with ``params.extra_server_args`` populated from
+    the compat helper (originals not mutated). No-op when no extra-args key
+    exists or the canonical key is already present.
+
+    Args:
+        payload: The event payload to normalise.
+
+    Returns:
+        The (possibly copied) payload with a canonical extra-args key.
     """
     params = payload.get("params")
     if not isinstance(params, dict):
@@ -296,7 +325,16 @@ def _normalise_extra_server_args_key(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def _walk_path(payload: dict[str, Any], path: str) -> Any:
-    """Walk dotted ``a.b.c`` paths against nested dicts (non-dicts short-circuit to ``None``)."""
+    """Walk a dotted ``a.b.c`` path against nested dicts.
+
+    Args:
+        payload: The mapping to traverse.
+        path: Dot-separated key path.
+
+    Returns:
+        The value at the path, or ``None`` if any segment is missing or a
+        non-dict is encountered.
+    """
     cur: Any = payload
     for token in path.split("."):
         if not isinstance(cur, dict):

--- a/robustness-agent/src/robustness_agent/sources/base.py
+++ b/robustness-agent/src/robustness_agent/sources/base.py
@@ -97,7 +97,14 @@ class SourceData:
     degraded_reason: str | None = None
 
     def merge_from(self, other: "SourceData") -> None:
-        """Merge another snapshot in, preserving non-empty existing fields."""
+        """Merge another snapshot into this one in place.
+
+        Existing non-empty fields are preserved; only empty slots are
+        filled from ``other``.
+
+        Args:
+            other: The snapshot to merge fields from.
+        """
         for slot in (
             "session_pods",
             "session_events",

--- a/robustness-agent/src/robustness_agent/sources/cluster_decoder.py
+++ b/robustness-agent/src/robustness_agent/sources/cluster_decoder.py
@@ -134,6 +134,12 @@ def merge_gpu_snapshots(
 
     Later writes win on field clashes per (pod, gpu_id); distinct pods
     stay distinct so signal evidence keeps the GPU's namespace / name.
+
+    Args:
+        snapshots: Per-pod GPU snapshot mappings.
+
+    Returns:
+        A merged ``local_gpu`` mapping.
     """
 
     rows: list[dict[str, Any]] = []

--- a/robustness-agent/src/robustness_agent/sources/server_client.py
+++ b/robustness-agent/src/robustness_agent/sources/server_client.py
@@ -635,9 +635,18 @@ class RobustnessServerSource:
         """Fan out cluster pod metrics across the session's pods.
 
         Decodes each per-pod response into the LocalProbe ``local_gpu``
-        schema and merges them into one snapshot. A 5xx / transport
-        failure on any pod re-raises :class:`SourceUnavailable` so the
-        DegradeRouter degrades.
+        schema and merges them into one snapshot.
+
+        Args:
+            pods: Session pod rows to fetch metrics for.
+            window: Metrics time window to request.
+
+        Returns:
+            A merged ``local_gpu`` snapshot mapping (empty when no pods).
+
+        Raises:
+            SourceUnavailable: On a 5xx / transport failure for any pod, so
+                the DegradeRouter degrades.
         """
 
         refs = _unique_pod_refs(pods)
@@ -678,11 +687,17 @@ def _extract_session_id(ctx: Any) -> str:
 
 
 def _unique_pod_refs(pods: list[dict[str, Any]]) -> list[tuple[str, str]]:
-    """Distinct (namespace, name) tuples from session_pods.
+    """Return the distinct ``(namespace, name)`` tuples from session pods.
 
     Rows carry the pod under ``pod.namespace`` / ``pod.name``; a pod may
     recur across open/close cycles so we collapse to the unique set to
     avoid duplicating the cluster-metrics fan-out.
+
+    Args:
+        pods: Session pod rows.
+
+    Returns:
+        The unique ``(namespace, name)`` tuples in first-seen order.
     """
 
     seen: set[tuple[str, str]] = set()
@@ -711,6 +726,12 @@ def _extract_hierarchy_pods(
     Accepts ``pods`` (documented), ``children`` / ``items`` (mirrors),
     and a single ``pod`` (degraded response) so an upstream schema nudge
     does not silently disable multi-node fan-out.
+
+    Args:
+        hierarchy: The workload hierarchy response, if any.
+
+    Returns:
+        The extracted pod row dicts (empty when none found).
     """
 
     if not isinstance(hierarchy, dict):
@@ -734,6 +755,13 @@ def _merge_pods(
     Hierarchy rows are wrapped in the session-pod envelope
     (``{"pod": {...}}``) so downstream consumers see a uniform shape.
     Session entries win on conflicts (richer phase / role metadata).
+
+    Args:
+        session_pods: Pods reported by the session source.
+        extra_pods: Pods derived from the workload hierarchy.
+
+    Returns:
+        The merged, de-duplicated pod list.
     """
 
     out: list[dict[str, Any]] = list(session_pods or [])


### PR DESCRIPTION
## Summary
- Upgrades existing one-line / non-Google-style docstrings across the source packages to full Google style (adds `Args:`, `Returns:`, `Raises:`, etc. where applicable).
- Companion to #542 (which added docstrings to functions that had **none**). This PR converts the remaining ~1,341 source functions that *have* a docstring but lack Google-style sections.
- **Stacked on #542**: base branch is `docs/google-docstrings-sphinx` so this PR's diff shows only the upgrade commits. Will retarget to `main` automatically once #542 merges.

## Scope (source-only, no tests)
- critic-agent, quantization_agent, framework-agent, robustness-agent, ci, kernel-agent, inference_optimizer
- Work is landed incrementally, component by component.

## Test plan
- [ ] `pip install -r docs/requirements.txt && sphinx -b html docs docs/_build/html` builds with 0 warnings/errors
- [ ] No linter errors introduced
