### PR TITLE
kernel_journey fidelity: pre-dispatch failures, roofline, timing/speedup, and tool versions

### DIFF
--- a/inference_optimizer/breakdown/exporter.py
+++ b/inference_optimizer/breakdown/exporter.py
@@ -61,6 +61,71 @@ def _load_manifest(session_dir: Path, warnings: list[str]) -> dict[str, Any]:
         return {}
 
 
+_ROOFLINE_NUMERIC_FIELDS = (
+    "arithmetic_intensity",
+    "flops_per_byte",
+    "efficiency_percent",
+)
+
+
+def _attach_kernel_roofline(
+    kernel_journey: dict[str, Any],
+    kernel_roofline: dict[str, Any],
+) -> None:
+    """Merge per-kernel roofline metrics into the ``kernel_journey`` view.
+
+    For every journey entry with a matching ``kernel_roofline`` kernel (by
+    ``kernel_id``, falling back to ``name``), attach the full roofline entry
+    under ``roofline`` and backfill the discovery numeric fields that discovery
+    surfaced empty (roofline enrichment happens after discovery records). Pure
+    best-effort: a missing/empty roofline table or kernel just leaves the
+    journey untouched.
+    """
+    if not isinstance(kernel_journey, dict) or not isinstance(
+        kernel_roofline, dict,
+    ):
+        return
+    kernels = kernel_journey.get("kernels")
+    roofline_kernels = kernel_roofline.get("kernels")
+    if not isinstance(kernels, list) or not isinstance(roofline_kernels, list):
+        return
+
+    by_kid: dict[str, dict[str, Any]] = {}
+    by_name: dict[str, dict[str, Any]] = {}
+    for rk in roofline_kernels:
+        if not isinstance(rk, dict):
+            continue
+        kid = str(rk.get("kernel_id") or "")
+        name = str(rk.get("name") or "")
+        if kid:
+            by_kid.setdefault(kid, rk)
+        if name:
+            by_name.setdefault(name, rk)
+
+    for entry in kernels:
+        if not isinstance(entry, dict):
+            continue
+        rk = by_kid.get(str(entry.get("kernel_id") or "")) or by_name.get(
+            str(entry.get("name") or ""),
+        )
+        if not rk:
+            continue
+        entry["roofline"] = dict(rk)
+        # Promote bound_type onto the entry header when discovery left it blank.
+        if not str(entry.get("bound_type") or "") and rk.get("bound_type"):
+            entry["bound_type"] = rk.get("bound_type")
+        disc = entry.get("discovery")
+        if not isinstance(disc, dict):
+            continue
+        if not str(disc.get("bound_type") or "") and rk.get("bound_type"):
+            disc["bound_type"] = rk.get("bound_type")
+        for field in _ROOFLINE_NUMERIC_FIELDS:
+            if disc.get(field) in (None, 0, 0.0) and rk.get(field) not in (
+                None, 0, 0.0,
+            ):
+                disc[field] = rk.get(field)
+
+
 def build(
     session_dir: Path | str,
     *,
@@ -266,6 +331,11 @@ def build(
     # predate the substreams, so v1/v2 readers that don't know it just ignore
     # it and historical breakdowns stay byte-for-byte identical.
     kernel_journey     = _pick("kernel_journey", {})
+    # Attach a copy of the per-kernel roofline metrics onto each journey entry
+    # and backfill discovery numeric fields that discovery couldn't surface
+    # (arithmetic_intensity / bound_type / efficiency) since roofline is
+    # enriched after discovery. Best-effort; never raises.
+    _attach_kernel_roofline(kernel_journey, kernel_roofline)
 
     source_files = collectors.collect_source_files(
         sd,

--- a/inference_optimizer/breakdown/exporter.py
+++ b/inference_optimizer/breakdown/exporter.py
@@ -330,6 +330,9 @@ def build(
     # Pure recorder section (no collector fallback): empty {} on sessions that
     # predate the substreams, so v1/v2 readers that don't know it just ignore
     # it and historical breakdowns stay byte-for-byte identical.
+    # Authoritative external-tool versions, folded into a {tool: meta} map by
+    # the recorder assembler. Pure recorder section (no collector fallback).
+    versions           = _pick("versions", {})
     kernel_journey     = _pick("kernel_journey", {})
     # Attach a copy of the per-kernel roofline metrics onto each journey entry
     # and backfill discovery numeric fields that discovery couldn't surface
@@ -404,6 +407,11 @@ def build(
         # attempts -> e2e), composed from the recorder substreams. Additive,
         # optional; empty {} on sessions that predate the substreams.
         "kernel_journey":      kernel_journey,
+        # Authoritative external-tool versions, one object per tool
+        # (geak / tracelens / claude / codex / ...), keyed by tool name. Each
+        # carries ``{tool, root_dir, commit, version}``. Empty {} on sessions
+        # that predate the recorder.
+        "versions":            versions,
 
         "warnings":            warnings,
         "source_files":        source_files,

--- a/inference_optimizer/breakdown/recorder/__init__.py
+++ b/inference_optimizer/breakdown/recorder/__init__.py
@@ -36,6 +36,7 @@ from .instrument import (
     record_robustness_signal,
     record_singleton_section,
     record_specialist_round,
+    record_tool_version,
     snapshot_state_sections,
 )
 from .recorder import Recorder, get_recorder
@@ -66,6 +67,7 @@ __all__ = [
     "record_robustness_signal",
     "record_singleton_section",
     "record_specialist_round",
+    "record_tool_version",
     "section_shape",
     "snapshot_state_sections",
 ]

--- a/inference_optimizer/breakdown/recorder/assembler.py
+++ b/inference_optimizer/breakdown/recorder/assembler.py
@@ -86,7 +86,24 @@ def assemble_parts(
 
     _compose_critic_robustness(out)
     _compose_kernel_journey(out)
+    _compose_versions(out)
     return out
+
+
+def _compose_versions(out: dict[str, Any]) -> None:
+    """Fold the ``versions`` item substream into a top-level ``{tool: meta}``
+    map (last write per tool wins; the substream is already deduped by tool key
+    at record time). No-op when nothing was recorded."""
+    rows = out.get("versions")
+    if not isinstance(rows, list):
+        return
+    merged: dict[str, Any] = {}
+    for r in rows:
+        if isinstance(r, dict):
+            tool = str(r.get("tool") or "").lower()
+            if tool:
+                merged[tool] = r
+    out["versions"] = merged
 
 
 def _compose_critic_robustness(out: dict[str, Any]) -> None:

--- a/inference_optimizer/breakdown/recorder/assembler.py
+++ b/inference_optimizer/breakdown/recorder/assembler.py
@@ -174,6 +174,7 @@ def _compose_kernel_journey(out: dict[str, Any]) -> None:
             "gpu_pct":          disc.get("gpu_pct"),
             "bound_type":       str(disc.get("bound_type") or ""),
             "source_file":      disc.get("source_file"),
+            "micro_speedup":    _best_micro_speedup(atts),
             "discovery":        disc,
             "dispatch":         disp,
             "backend_attempts": atts,
@@ -193,6 +194,27 @@ def _compose_kernel_journey(out: dict[str, Any]) -> None:
         "discovery_runs": discovery_runs,
         "kernels":        kernels,
     }
+
+
+def _best_micro_speedup(attempts: list[dict[str, Any]]) -> float | None:
+    """Best (max) micro_speedup across a kernel's attempts, or None.
+
+    Surfaces the kernel-level achieved speedup at the journey-entry top level so
+    the dashboard can correlate it with ``e2e.e2e_gain_pct`` without digging
+    through the attempt ladder.
+    """
+    best: float | None = None
+    for att in attempts:
+        if not isinstance(att, dict):
+            continue
+        v = att.get("micro_speedup")
+        try:
+            f = float(v) if v is not None else None
+        except (TypeError, ValueError):
+            f = None
+        if f is not None and (best is None or f > best):
+            best = f
+    return best
 
 
 def _kernel_outcome(

--- a/inference_optimizer/breakdown/recorder/instrument.py
+++ b/inference_optimizer/breakdown/recorder/instrument.py
@@ -485,6 +485,7 @@ def record_kernel_discovery(
     tool_root: str | None = None,
     tool_root_env: str | None = None,
     tool_version: str | None = None,
+    duration_sec: Any = None,
     error: str | None = None,
     producer: str = PRODUCER_KERNEL_AGENT,
 ) -> None:
@@ -510,6 +511,7 @@ def record_kernel_discovery(
             "source":           str(source or ""),
             "status":           str(status or ""),
             "ts":               _now_iso_safe(),
+            "duration_sec":     _to_float(duration_sec),
             "tool":             meta,
             "scan":             scan,
             "hot_kernel_count": len(kernels),
@@ -586,6 +588,14 @@ def record_kernel_backend_result(
         attempts = attempts if isinstance(attempts, list) else []
         result_meta = result.get("metadata") if isinstance(
             result.get("metadata"), dict) else {}
+        # The kernel-level micro_speedup is derived (best across attempts) and
+        # lives in ``verification`` -- the raw per-attempt dict carries none. We
+        # stamp it onto the adopted (best) attempt so the journey can correlate
+        # achieved speedup with the e2e gain.
+        verification = result.get("verification") if isinstance(
+            result.get("verification"), dict) else {}
+        best_attempt_id = _best_attempt_id(attempts, verification)
+        kernel_micro_speedup = _to_float(verification.get("micro_speedup"))
         recorded_any = False
         for att in attempts:
             if not isinstance(att, dict):
@@ -595,23 +605,30 @@ def record_kernel_backend_result(
             optimized = att.get("optimized_path") or att.get("optimized_file")
             att_meta = att.get("metadata") if isinstance(
                 att.get("metadata"), dict) else {}
+            micro_speedup = _to_float(
+                att.get("micro_speedup") or att.get("speedup"))
+            if (micro_speedup is None and kernel_micro_speedup is not None
+                    and attempt_id and attempt_id == best_attempt_id):
+                micro_speedup = kernel_micro_speedup
             payload = {
                 "kernel_id":          kid,
                 "attempt_id":         attempt_id,
                 "run_id":             run_id,
                 "backend":            backend,
                 "model":              att.get("model"),
-                "ts":                 str(att.get("ts") or att.get("started_at") or ""),
+                "ts":                 str(att.get("ts") or att.get("started_at")
+                                          or att.get("created_at") or ""),
                 "status":             str(att.get("status") or "").lower(),
                 "decision":           str(att.get("decision") or "").upper(),
-                "micro_speedup":      _to_float(
-                    att.get("micro_speedup") or att.get("speedup")),
+                "micro_speedup":      micro_speedup,
                 "compile_passed":     _to_bool(att.get("compile_passed")),
                 "correctness_passed": _to_bool(att.get("correctness_passed")),
                 "optimized_files":    [str(optimized)] if optimized else [],
                 "error":              att.get("error") or att.get("error_message"),
+                "error_class":        str(att.get("error_type") or "") or None,
                 "duration_sec":       _to_float(
-                    att.get("duration_sec") or att.get("elapsed_sec")),
+                    att.get("duration_sec") or att.get("elapsed_sec")
+                    or att.get("elapsed_s")),
                 "tool": _tool_metadata(
                     backend or "kernel_agent",
                     root=str(att_meta.get("root_dir") or result_meta.get("root_dir") or "")

--- a/inference_optimizer/breakdown/recorder/instrument.py
+++ b/inference_optimizer/breakdown/recorder/instrument.py
@@ -466,6 +466,8 @@ def _normalize_hot_kernel(k: dict[str, Any]) -> dict[str, Any]:
         "time_ms":                 _to_float(k.get("time_ms") or k.get("duration_ms")),
         "bound_type":              str(k.get("bound_type") or k.get("bottleneck") or ""),
         "arithmetic_intensity":    _to_float(k.get("arithmetic_intensity")),
+        "flops_per_byte":          _to_float(k.get("flops_per_byte")),
+        "efficiency_percent":      _to_float(k.get("efficiency_percent")),
         "reusable_native_kernel":  bool(k.get("reusable_native_kernel") or False),
         "source_file":             k.get("source_file"),
         "recommended_backends":    list(k.get("recommended_backends") or []),
@@ -584,6 +586,7 @@ def record_kernel_backend_result(
         attempts = attempts if isinstance(attempts, list) else []
         result_meta = result.get("metadata") if isinstance(
             result.get("metadata"), dict) else {}
+        recorded_any = False
         for att in attempts:
             if not isinstance(att, dict):
                 continue
@@ -619,6 +622,55 @@ def record_kernel_backend_result(
             }
             key = attempt_id or (f"{run_id}-{backend}" if run_id else None)
             rec.record_item("kernel_backend_result", payload, key=key)
+            recorded_any = True
+
+        if recorded_any or not kid:
+            return
+
+        # No per-backend attempts: capture a pre-dispatch / infra failure as a
+        # synthetic FAILED attempt so kernel_journey shows the failure too
+        # (mirrors record_kernel_invocations' pre-dispatch marker; without this
+        # the kernel looks merely "dispatched" with an empty attempt ladder).
+        status = str(result.get("status") or "").lower()
+        err_class = str(result.get("error_class") or "")
+        decision = str(
+            (result.get("proposal") or {}).get("decision") or "").upper()
+        failed = status in _FAILED_STATUSES or (
+            decision == "REVERT" and bool(err_class)
+        )
+        if not failed:
+            return
+        backend = str(result.get("backend") or "").lower() or "geak"
+        payload = {
+            "kernel_id":            kid,
+            "attempt_id":           "",
+            "run_id":               run_id,
+            "backend":              backend,
+            "model":                None,
+            "ts":                   _now_iso_safe(),
+            "status":               status or "failed",
+            "decision":             "FAILED",
+            "micro_speedup":        None,
+            "compile_passed":       None,
+            "correctness_passed":   None,
+            "optimized_files":      [],
+            "error":                result.get("error") or err_class or None,
+            "error_class":          err_class or None,
+            "duration_sec":         None,
+            # Distinguishes a pre-dispatch gating failure (no backend ran) from
+            # a backend that ran and failed.
+            "pre_dispatch_failure": True,
+            "tool": _tool_metadata(
+                backend,
+                root=str(result_meta.get("root_dir") or "") or None,
+                root_env="HYPERLOOM_KERNEL_AGENT_ROOT",
+                version=str(result_meta.get("version") or ""),
+            ),
+        }
+        rec.record_item(
+            "kernel_backend_result", payload,
+            key=f"{kid}-predispatch",
+        )
     except Exception:  # noqa: BLE001
         log.debug("record_kernel_backend_result failed", exc_info=True)
 

--- a/inference_optimizer/breakdown/recorder/instrument.py
+++ b/inference_optimizer/breakdown/recorder/instrument.py
@@ -404,23 +404,97 @@ def _to_bool(value: Any) -> bool | None:
     return None
 
 
-# Cache of resolved tool metadata, keyed by the resolved root dir. The git
-# probe is a one-shot per root: it never re-runs in the hot path.
+# Cache of resolved tool metadata, keyed by ``tool:root_dir``. The git/CLI/pip
+# probes are a one-shot per key: they never re-run in the hot path.
 _TOOL_META_CACHE: dict[str, dict[str, Any]] = {}
 
+# Per-tool "authoritative version" recipe. ``root_env`` holds the install root
+# (used for the commit probe and the git-based version strategies). ``version``
+# picks how the human version is derived:
+#   * "git_describe" -> ``git describe --tags --always --dirty`` of the root
+#   * "git_short"    -> ``git rev-parse --short HEAD`` of the root (== commit)
+#   * ("cmd", argv)  -> first line of ``argv --version`` style CLI output
+#   * ("dist", names)-> importlib.metadata version of the first matching dist
+# Notes (verified on-cluster): GEAK's version is its git SHA, NOT the pip
+# ``mini-swe-agent`` (that's the upstream core); InferenceX is git-only (no pip
+# package); TraceLens reads best as ``git describe``; OOB sub-agents report via
+# their npm CLIs (codex/claude), and the OOB harness itself via ``oob-mcp-server``.
+_TOOL_PROVENANCE: dict[str, dict[str, Any]] = {
+    "tracelens":    {"root_env": "TRACELENS_ROOT",            "version": "git_describe"},
+    "geak":         {"root_env": "GEAK_ROOT",                 "version": "git_short"},
+    "mini":         {"root_env": "GEAK_ROOT",                 "version": "git_short"},
+    "geak-gaagent": {"root_env": "GEAK_ROOT",                 "version": "git_short"},
+    "claude":       {"root_env": "",                          "version": ("cmd", ("claude", "--version"))},
+    "codex":        {"root_env": "",                          "version": ("cmd", ("codex", "--version"))},
+    "oob":          {"root_env": "",                          "version": ("dist", ("oob-mcp-server",))},
+    "inferencex":   {"root_env": "INFERENCEX_PATH",           "version": "git_short"},
+    "kernel_agent": {"root_env": "HYPERLOOM_KERNEL_AGENT_ROOT", "version": "git_short"},
+}
 
-def _git_short_commit(root: Path) -> str:
-    """Best-effort ``git rev-parse --short HEAD`` for ``root`` (never raises)."""
+
+def _run_first_line(argv: list[str]) -> str:
+    """Run ``argv`` and return the trimmed first output line (never raises)."""
     import subprocess  # local: keep module import cost off the common path
 
     try:
         out = subprocess.run(
-            ["git", "-C", str(root), "rev-parse", "--short", "HEAD"],
-            capture_output=True, text=True, timeout=3, check=False,
+            argv, capture_output=True, text=True, timeout=3, check=False,
         )
-        return out.stdout.strip() if out.returncode == 0 else ""
     except Exception:  # noqa: BLE001
         return ""
+    if out.returncode != 0:
+        return ""
+    text = (out.stdout or "").strip() or (out.stderr or "").strip()
+    return text.splitlines()[0].strip()[:120] if text else ""
+
+
+def _git_short_commit(root: Path) -> str:
+    """Best-effort ``git rev-parse --short HEAD`` for ``root`` (never raises)."""
+    return _run_first_line(
+        ["git", "-C", str(root), "rev-parse", "--short", "HEAD"],
+    )
+
+
+def _git_describe(root: Path) -> str:
+    """Best-effort ``git describe --tags --always --dirty`` (never raises)."""
+    return _run_first_line(
+        ["git", "-C", str(root), "describe", "--tags", "--always", "--dirty"],
+    )
+
+
+def _dist_version(names: tuple[str, ...]) -> str:
+    """First resolvable ``importlib.metadata`` version among ``names`` ("" if none)."""
+    try:
+        from importlib.metadata import version as _dist_ver
+    except Exception:  # noqa: BLE001
+        return ""
+    for name in names:
+        try:
+            v = str(_dist_ver(name) or "").strip()
+        except Exception:  # noqa: BLE001
+            continue
+        # Stale ``UNKNOWN.egg-info`` can masquerade as 0.0.0; reject it.
+        if v and v != "0.0.0":
+            return v
+    return ""
+
+
+def _probe_tool_version(strategy: Any, root_dir: str) -> str:
+    """Resolve a tool's human version per its provenance ``strategy``."""
+    try:
+        if strategy == "git_describe":
+            return _git_describe(Path(root_dir)) if root_dir else ""
+        if strategy == "git_short":
+            return _git_short_commit(Path(root_dir)) if root_dir else ""
+        if isinstance(strategy, tuple) and len(strategy) == 2:
+            kind, arg = strategy
+            if kind == "cmd":
+                return _run_first_line(list(arg))
+            if kind == "dist":
+                return _dist_version(tuple(arg))
+    except Exception:  # noqa: BLE001
+        return ""
+    return ""
 
 
 def _tool_metadata(
@@ -432,15 +506,23 @@ def _tool_metadata(
 ) -> dict[str, Any]:
     """Resolve ``{tool, root_dir, commit, version}`` for an external tool.
 
-    ``root`` (explicit) wins over ``root_env`` (an env var holding the path).
-    The commit is a cached ``git rev-parse`` of the root; ``version`` is passed
-    through verbatim when the tool already surfaced its own. All best-effort:
-    a missing root just yields empty strings.
+    Root resolution: explicit ``root`` > caller ``root_env`` > the tool's
+    registered ``root_env``. ``commit`` is a cached ``git rev-parse`` of the
+    root. ``version`` is the caller-supplied value when the tool already
+    surfaced its own, else a cached per-tool probe (git describe / CLI
+    ``--version`` / pip dist) following ``_TOOL_PROVENANCE``. All best-effort:
+    nothing here ever raises into the optimizer.
     """
     import os
 
-    root_dir = str(root or (os.environ.get(root_env or "") or "")).strip()
-    cache_key = f"{tool}:{root_dir}"
+    key = str(tool or "").lower()
+    hint = _TOOL_PROVENANCE.get(key, {})
+    root_dir = str(
+        root
+        or os.environ.get(root_env or "", "")
+        or os.environ.get(str(hint.get("root_env") or ""), "")
+    ).strip()
+    cache_key = f"{key}:{root_dir}"
     cached = _TOOL_META_CACHE.get(cache_key)
     if cached is None:
         commit = ""
@@ -450,10 +532,18 @@ def _tool_metadata(
                     commit = _git_short_commit(Path(root_dir))
             except Exception:  # noqa: BLE001
                 commit = ""
-        cached = {"tool": tool, "root_dir": root_dir, "commit": commit}
+        probed = _probe_tool_version(hint.get("version"), root_dir) if hint else ""
+        cached = {
+            "tool": tool, "root_dir": root_dir,
+            "commit": commit, "_probed_version": probed,
+        }
         _TOOL_META_CACHE[cache_key] = cached
-    meta = dict(cached)
-    meta["version"] = str(version or "")
+    meta = {
+        "tool":     cached["tool"],
+        "root_dir": cached["root_dir"],
+        "commit":   cached["commit"],
+    }
+    meta["version"] = str(version or "") or str(cached.get("_probed_version") or "")
     return meta
 
 
@@ -629,12 +719,15 @@ def record_kernel_backend_result(
                 "duration_sec":       _to_float(
                     att.get("duration_sec") or att.get("elapsed_sec")
                     or att.get("elapsed_s")),
+                # Root/version resolved per-backend by the tool registry:
+                # geak -> $GEAK_ROOT git SHA, claude/codex -> CLI --version. An
+                # explicit root/version the backend surfaced still wins.
                 "tool": _tool_metadata(
                     backend or "kernel_agent",
                     root=str(att_meta.get("root_dir") or result_meta.get("root_dir") or "")
                     or None,
-                    root_env="HYPERLOOM_KERNEL_AGENT_ROOT",
-                    version=str(att_meta.get("version") or result_meta.get("version") or ""),
+                    version=str(att_meta.get("version") or result_meta.get("version") or "")
+                    or None,
                 ),
             }
             key = attempt_id or (f"{run_id}-{backend}" if run_id else None)
@@ -680,8 +773,7 @@ def record_kernel_backend_result(
             "tool": _tool_metadata(
                 backend,
                 root=str(result_meta.get("root_dir") or "") or None,
-                root_env="HYPERLOOM_KERNEL_AGENT_ROOT",
-                version=str(result_meta.get("version") or ""),
+                version=str(result_meta.get("version") or "") or None,
             ),
         }
         rec.record_item(

--- a/inference_optimizer/breakdown/recorder/instrument.py
+++ b/inference_optimizer/breakdown/recorder/instrument.py
@@ -594,15 +594,11 @@ def record_kernel_discovery(
             if isinstance(k, dict)
         ]
         scan = dict(scan or {})
-        meta = _tool_metadata(
-            source, root=tool_root, root_env=tool_root_env, version=tool_version,
-        )
         payload = {
             "source":           str(source or ""),
             "status":           str(status or ""),
             "ts":               _now_iso_safe(),
             "duration_sec":     _to_float(duration_sec),
-            "tool":             meta,
             "scan":             scan,
             "hot_kernel_count": len(kernels),
             "hot_kernels":      kernels,
@@ -615,8 +611,43 @@ def record_kernel_discovery(
         _recorder(session_dir, producer).record_item(
             "kernel_discovery", payload, key=key,
         )
+        # The discovery tool's authoritative version lands in the top-level
+        # ``versions`` map (keyed by tool name), not inline per run.
+        record_tool_version(
+            session_dir, tool=source, root=tool_root,
+            root_env=tool_root_env, version=tool_version, producer=producer,
+        )
     except Exception:  # noqa: BLE001
         log.debug("record_kernel_discovery failed", exc_info=True)
+
+
+def record_tool_version(
+    session_dir: Path | str | None,
+    *,
+    tool: str,
+    root: str | None = None,
+    root_env: str | None = None,
+    version: str | None = None,
+    producer: str = PRODUCER_KERNEL_AGENT,
+) -> None:
+    """Record one external tool's authoritative version into ``versions``.
+
+    Idempotent per tool name (last write wins). Resolves ``{tool, root_dir,
+    commit, version}`` via the tool provenance registry and spools it as one
+    ``versions`` item; the assembler folds the substream into the top-level
+    ``versions`` map. Best-effort: never raises into the optimizer.
+    """
+    if not session_dir or not tool:
+        return
+    try:
+        meta = _tool_metadata(
+            tool, root=root, root_env=root_env, version=version,
+        )
+        _recorder(session_dir, producer).record_item(
+            "versions", meta, key=str(tool).lower(),
+        )
+    except Exception:  # noqa: BLE001
+        log.debug("record_tool_version failed", exc_info=True)
 
 
 def record_kernel_dispatch(
@@ -719,20 +750,22 @@ def record_kernel_backend_result(
                 "duration_sec":       _to_float(
                     att.get("duration_sec") or att.get("elapsed_sec")
                     or att.get("elapsed_s")),
-                # Root/version resolved per-backend by the tool registry:
-                # geak -> $GEAK_ROOT git SHA, claude/codex -> CLI --version. An
-                # explicit root/version the backend surfaced still wins.
-                "tool": _tool_metadata(
-                    backend or "kernel_agent",
-                    root=str(att_meta.get("root_dir") or result_meta.get("root_dir") or "")
-                    or None,
-                    version=str(att_meta.get("version") or result_meta.get("version") or "")
-                    or None,
-                ),
             }
             key = attempt_id or (f"{run_id}-{backend}" if run_id else None)
             rec.record_item("kernel_backend_result", payload, key=key)
             recorded_any = True
+            # The backend's authoritative version lands in the top-level
+            # ``versions`` map (keyed by backend name), not inline per attempt.
+            # geak -> $GEAK_ROOT git SHA, claude/codex -> CLI --version.
+            if backend:
+                record_tool_version(
+                    session_dir, tool=backend,
+                    root=str(att_meta.get("root_dir")
+                             or result_meta.get("root_dir") or "") or None,
+                    version=str(att_meta.get("version")
+                                or result_meta.get("version") or "") or None,
+                    producer=producer,
+                )
 
         if recorded_any or not kid:
             return
@@ -770,15 +803,16 @@ def record_kernel_backend_result(
             # Distinguishes a pre-dispatch gating failure (no backend ran) from
             # a backend that ran and failed.
             "pre_dispatch_failure": True,
-            "tool": _tool_metadata(
-                backend,
-                root=str(result_meta.get("root_dir") or "") or None,
-                version=str(result_meta.get("version") or "") or None,
-            ),
         }
         rec.record_item(
             "kernel_backend_result", payload,
             key=f"{kid}-predispatch",
+        )
+        record_tool_version(
+            session_dir, tool=backend,
+            root=str(result_meta.get("root_dir") or "") or None,
+            version=str(result_meta.get("version") or "") or None,
+            producer=producer,
         )
     except Exception:  # noqa: BLE001
         log.debug("record_kernel_backend_result failed", exc_info=True)
@@ -940,5 +974,6 @@ __all__ = [
     "record_robustness_signal",
     "record_singleton_section",
     "record_specialist_round",
+    "record_tool_version",
     "snapshot_state_sections",
 ]

--- a/inference_optimizer/breakdown/recorder/sections.py
+++ b/inference_optimizer/breakdown/recorder/sections.py
@@ -57,6 +57,10 @@ SECTION_SHAPES: dict[str, SectionShape] = {
     "kernel_dispatch":             "item",  # one per kernel: dispatched? which backends?
     "kernel_backend_result":       "item",  # one per backend attempt (geak/oob)
     "kernel_e2e":                  "item",  # one per kernel: e2e integrate gain
+    # Authoritative external-tool versions (geak/tracelens/claude/codex/...),
+    # one item per tool (idempotent by tool name); folded into the top-level
+    # ``versions`` map at assembly.
+    "versions":                    "item",
 }
 
 # Sections computed at finalize from in-memory state, never written as

--- a/inference_optimizer/breakdown/schema.py
+++ b/inference_optimizer/breakdown/schema.py
@@ -524,13 +524,21 @@ class KernelToolMetadata(TypedDict, total=False):
 
 
 class DiscoveredHotKernel(TypedDict, total=False):
-    """One hot kernel surfaced by a discovery run (projected onto the journey)."""
+    """One hot kernel surfaced by a discovery run (projected onto the journey).
+
+    The roofline numeric fields (``arithmetic_intensity`` / ``flops_per_byte``
+    / ``efficiency_percent``) are backfilled at export from ``kernel_roofline``
+    when discovery surfaced them empty (roofline enrichment runs after the
+    discovery record is written).
+    """
     kernel_id: str
     name: str
     gpu_pct: float | None
     time_ms: float | None
     bound_type: str
     arithmetic_intensity: float | None
+    flops_per_byte: float | None
+    efficiency_percent: float | None
     reusable_native_kernel: bool
     source_file: str | None
     recommended_backends: list[str]
@@ -599,7 +607,11 @@ class KernelBackendAttempt(TypedDict, total=False):
         correctness_passed (bool | None): Whether correctness passed, or None.
         optimized_files (list[str]): Optimized artifact paths.
         error (str | None): Failure text, or None.
+        error_class (str | None): Failure classification (pre-dispatch markers).
         duration_sec (float | None): Wall-clock seconds the attempt ran, or None.
+        pre_dispatch_failure (bool): True for a synthetic marker recorded when a
+            backend failed before running any real attempt (e.g. geak rejecting
+            an empty/non-reusable kernel shape).
         tool (KernelToolMetadata): Provenance of the backend tool.
     """
     kernel_id: str
@@ -615,7 +627,9 @@ class KernelBackendAttempt(TypedDict, total=False):
     correctness_passed: bool | None
     optimized_files: list[str]
     error: str | None
+    error_class: str | None
     duration_sec: float | None
+    pre_dispatch_failure: bool
     tool: KernelToolMetadata
 
 
@@ -658,6 +672,9 @@ class KernelJourneyEntry(TypedDict, total=False):
         dispatch (KernelDispatch): Stage-2 dispatch decision.
         backend_attempts (list[KernelBackendAttempt]): Stage-3 backend attempts.
         e2e (KernelE2E): Stage-4 end-to-end integrate outcome.
+        roofline (dict[str, Any]): A copy of the matching ``kernel_roofline``
+            entry (arithmetic intensity / efficiency / bound type / rocprof
+            roofline), attached at export. Absent when no roofline ran.
         outcome (str): Coarse rollup (``adopted`` / ``reverted`` / ``attempted``
             / ``dispatched`` / ``skipped`` / ``discovered``).
     """
@@ -670,6 +687,7 @@ class KernelJourneyEntry(TypedDict, total=False):
     dispatch: KernelDispatch
     backend_attempts: list[KernelBackendAttempt]
     e2e: KernelE2E
+    roofline: dict[str, Any]
     outcome: str
 
 

--- a/inference_optimizer/breakdown/schema.py
+++ b/inference_optimizer/breakdown/schema.py
@@ -554,18 +554,19 @@ class KernelDiscoveryRun(TypedDict, total=False):
         ts (str): ISO UTC timestamp of the run.
         duration_sec (float | None): Wall-clock seconds the discovery run took
             (source efficiency), or None.
-        tool (KernelToolMetadata): Provenance of the discovery tool.
         scan (dict[str, Any]): Scan inputs/outputs (``splitter_mode`` /
             ``trace_dir`` / ``candidates_path`` / ``trace_report_path``).
         hot_kernel_count (int): Number of hot kernels surfaced.
         hot_kernels (list[DiscoveredHotKernel]): The surfaced hot kernels.
         error (str | None): Failure text, or None on success.
+
+    The discovery tool's authoritative version is not inlined here; it lives in
+    the top-level ``versions`` map keyed by ``source``.
     """
     source: str
     status: str
     ts: str
     duration_sec: float | None
-    tool: KernelToolMetadata
     scan: dict[str, Any]
     hot_kernel_count: int
     hot_kernels: list[DiscoveredHotKernel]
@@ -615,7 +616,9 @@ class KernelBackendAttempt(TypedDict, total=False):
         pre_dispatch_failure (bool): True for a synthetic marker recorded when a
             backend failed before running any real attempt (e.g. geak rejecting
             an empty/non-reusable kernel shape).
-        tool (KernelToolMetadata): Provenance of the backend tool.
+
+    The backend tool's authoritative version is not inlined here; it lives in
+    the top-level ``versions`` map keyed by ``backend``.
     """
     kernel_id: str
     attempt_id: str
@@ -633,7 +636,6 @@ class KernelBackendAttempt(TypedDict, total=False):
     error_class: str | None
     duration_sec: float | None
     pre_dispatch_failure: bool
-    tool: KernelToolMetadata
 
 
 class KernelE2E(TypedDict, total=False):
@@ -1782,6 +1784,11 @@ class SessionBreakdown(TypedDict, total=False):
     # substreams; empty {} on sessions that predate it, so v1/v2 readers that
     # don't know it simply ignore it.
     kernel_journey: KernelJourney
+    # Authoritative external-tool versions, one ``KernelToolMetadata`` object
+    # per tool (geak / tracelens / claude / codex / ...), keyed by tool name.
+    # Additive optional section recorded at author time; empty {} on sessions
+    # that predate the recorder.
+    versions: dict[str, KernelToolMetadata]
 
     warnings: list[str]
     source_files: SourceFiles

--- a/inference_optimizer/breakdown/schema.py
+++ b/inference_optimizer/breakdown/schema.py
@@ -552,6 +552,8 @@ class KernelDiscoveryRun(TypedDict, total=False):
         source (str): Discovery source (``tracelens`` / ``roofline`` / ...).
         status (str): Run status (``success`` / ``failed``).
         ts (str): ISO UTC timestamp of the run.
+        duration_sec (float | None): Wall-clock seconds the discovery run took
+            (source efficiency), or None.
         tool (KernelToolMetadata): Provenance of the discovery tool.
         scan (dict[str, Any]): Scan inputs/outputs (``splitter_mode`` /
             ``trace_dir`` / ``candidates_path`` / ``trace_report_path``).
@@ -562,6 +564,7 @@ class KernelDiscoveryRun(TypedDict, total=False):
     source: str
     status: str
     ts: str
+    duration_sec: float | None
     tool: KernelToolMetadata
     scan: dict[str, Any]
     hot_kernel_count: int
@@ -668,6 +671,9 @@ class KernelJourneyEntry(TypedDict, total=False):
         gpu_pct (float | None): Share of total GPU time (from discovery), or None.
         bound_type (str): Bottleneck class (from discovery).
         source_file (str | None): Source file (from discovery), or None.
+        micro_speedup (float | None): Best achieved micro-benchmark speedup
+            across attempts (kernel-level), or None. Pair with
+            ``e2e.e2e_gain_pct`` for the speedup-vs-e2e correlation.
         discovery (DiscoveredHotKernel): Stage-1 discovery snapshot.
         dispatch (KernelDispatch): Stage-2 dispatch decision.
         backend_attempts (list[KernelBackendAttempt]): Stage-3 backend attempts.
@@ -683,6 +689,7 @@ class KernelJourneyEntry(TypedDict, total=False):
     gpu_pct: float | None
     bound_type: str
     source_file: str | None
+    micro_speedup: float | None
     discovery: DiscoveredHotKernel
     dispatch: KernelDispatch
     backend_attempts: list[KernelBackendAttempt]

--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -1325,7 +1325,9 @@ async def trace_analyze_handler(
         cmd += ["--dry-run"]
     timeout_sec = int(payload.get("budget_minutes", 60)) * 60
 
+    _disc_started = time.monotonic()
     rc, stdout, stderr = await _run_subprocess(cmd, timeout_sec=timeout_sec)
+    _disc_duration_sec = round(time.monotonic() - _disc_started, 3)
     result = _shape_tool_result(rc, stdout, stderr)
     artifacts = result.get("artifact_paths") if isinstance(result, dict) else None
     if isinstance(artifacts, dict) and artifacts.get("kernel_candidates"):
@@ -1400,6 +1402,7 @@ async def trace_analyze_handler(
                 },
                 tool_root=str(HYPERLOOM_KERNEL_AGENT_ROOT or "") or None,
                 tool_root_env=_KERNEL_AGENT_ROOT_ENV,
+                duration_sec=_disc_duration_sec,
                 error=(str(result.get("error") or "") or None
                        if str(result.get("status") or "") == "failed" else None),
             )

--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -1400,8 +1400,9 @@ async def trace_analyze_handler(
                     "candidates_path":    str(result.get("candidates_path") or ""),
                     "trace_report_path":  str(result.get("trace_report_path") or ""),
                 },
-                tool_root=str(HYPERLOOM_KERNEL_AGENT_ROOT or "") or None,
-                tool_root_env=_KERNEL_AGENT_ROOT_ENV,
+                # tracelens version/commit is read from $TRACELENS_ROOT (its
+                # own checkout), resolved by the recorder's tool registry; we
+                # don't pin it to the kernel-agent root here.
                 duration_sec=_disc_duration_sec,
                 error=(str(result.get("error") or "") or None
                        if str(result.get("status") or "") == "failed" else None),

--- a/inference_optimizer/orchestrator/shared_state.py
+++ b/inference_optimizer/orchestrator/shared_state.py
@@ -1423,7 +1423,23 @@ class SharedState:
                     _sel = result.get("selected_backends") or result.get("backends")
                     if isinstance(_sel, list):
                         _backends = [str(b).lower() for b in _sel if b]
-                _dispatched = bool(_attempts)
+                # A backend that failed before dispatching attempts (e.g. geak
+                # rejecting an empty/non-reusable kernel shape) still counts as
+                # dispatched: the backend was invoked. Mirror the failure-detect
+                # used by record_kernel_backend_result so the synthetic FAILED
+                # attempt and the dispatch flag stay consistent.
+                _status = str(result.get("status") or "").lower()
+                _err_class = str(result.get("error_class") or "")
+                _decision = str(
+                    (result.get("proposal") or {}).get("decision") or "").upper()
+                _failed_predispatch = (not _attempts) and (
+                    _status in {"failed", "error", "crashed", "timeout"}
+                    or (_decision == "REVERT" and bool(_err_class))
+                )
+                if _failed_predispatch and not _backends:
+                    _b = str(result.get("backend") or "").lower() or "geak"
+                    _backends = [_b]
+                _dispatched = bool(_attempts) or _failed_predispatch
                 instrument.record_kernel_dispatch(
                     sdir,
                     kernel_id=_kid,

--- a/inference_optimizer/tests/test_kernel_journey.py
+++ b/inference_optimizer/tests/test_kernel_journey.py
@@ -167,6 +167,29 @@ def test_backend_attempt_maps_kernel_agent_field_names(tmp_path: Path) -> None:
     assert entry["micro_speedup"] == 1.42
 
 
+def test_versions_map_composed_at_top_level(tmp_path: Path) -> None:
+    # Discovery + backend recording feed the top-level versions map (one object
+    # per tool, keyed by tool name), and no longer inline `tool` per element.
+    instrument.record_kernel_discovery(
+        tmp_path, source="tracelens", status="success",
+        hot_kernels=[{"kernel_id": "k1", "name": "moe", "gpu_pct": 10.0}],
+        scan={},
+    )
+    instrument.record_kernel_backend_result(tmp_path, {
+        "kernel_id": "k1", "run_id": "r1", "attempts": [
+            {"attempt_id": "a1", "backend": "geak", "status": "completed"},
+        ],
+    })
+    out = assemble_parts(tmp_path)
+    versions = out["versions"]
+    assert isinstance(versions, dict)
+    assert set(versions) >= {"tracelens", "geak"}
+    assert versions["geak"]["tool"] == "geak"
+    # Inline tool metadata is gone from the per-element shapes.
+    assert "tool" not in out["kernel_journey"]["discovery_runs"][0]
+    assert "tool" not in out["kernel_journey"]["kernels"][0]["backend_attempts"][0]
+
+
 def test_discovery_run_carries_duration(tmp_path: Path) -> None:
     instrument.record_kernel_discovery(
         tmp_path, source="tracelens", status="success",

--- a/inference_optimizer/tests/test_kernel_journey.py
+++ b/inference_optimizer/tests/test_kernel_journey.py
@@ -10,12 +10,28 @@ substream was recorded.
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 from inference_optimizer.breakdown.recorder import (
     assemble_parts,
     instrument,
 )
+
+
+def _init_git_repo(path: Path) -> str:
+    for argv in (
+        ["git", "init", "-q"],
+        ["git", "config", "user.email", "t@t"],
+        ["git", "config", "user.name", "t"],
+        ["git", "commit", "--allow-empty", "-q", "-m", "init"],
+    ):
+        subprocess.run(argv, cwd=path, check=True, capture_output=True)
+    out = subprocess.run(
+        ["git", "-C", str(path), "rev-parse", "--short", "HEAD"],
+        check=True, capture_output=True, text=True,
+    )
+    return out.stdout.strip()
 
 
 def test_kernel_journey_absent_without_substreams(tmp_path: Path) -> None:
@@ -159,6 +175,32 @@ def test_discovery_run_carries_duration(tmp_path: Path) -> None:
     )
     out = assemble_parts(tmp_path)
     assert out["kernel_journey"]["discovery_runs"][0]["duration_sec"] == 4.2
+
+
+def test_tool_version_probe_git_strategies(tmp_path: Path) -> None:
+    sha = _init_git_repo(tmp_path)
+    # geak -> git short SHA (NOT pip mini-swe-agent); commit == version.
+    meta = instrument._tool_metadata("geak", root=str(tmp_path))
+    assert meta["commit"] == sha
+    assert meta["version"] == sha
+    # tracelens -> git describe (--always falls back to the short sha here).
+    meta_tl = instrument._tool_metadata("tracelens", root=str(tmp_path))
+    assert meta_tl["version"]  # non-empty describe output
+    # A caller-supplied version always wins over the probe.
+    meta_explicit = instrument._tool_metadata(
+        "geak", root=str(tmp_path), version="v9.9",
+    )
+    assert meta_explicit["version"] == "v9.9"
+
+
+def test_tool_version_probe_cmd_and_dist() -> None:
+    # CLI strategy: python3 --version is always available in CI.
+    assert instrument._probe_tool_version(
+        ("cmd", ("python3", "--version")), "",
+    ).lower().startswith("python")
+    # dist strategy resolves an installed package and rejects bogus 0.0.0.
+    assert instrument._dist_version(("pytest",))
+    assert instrument._dist_version(("definitely-not-a-real-dist-xyz",)) == ""
 
 
 def test_attach_kernel_roofline_enriches_journey() -> None:

--- a/inference_optimizer/tests/test_kernel_journey.py
+++ b/inference_optimizer/tests/test_kernel_journey.py
@@ -103,3 +103,56 @@ def test_kernel_backend_result_keeps_retries_across_runs(tmp_path: Path) -> None
     out = assemble_parts(tmp_path)
     attempts = out["kernel_journey"]["kernels"][0]["backend_attempts"]
     assert len(attempts) == 2
+
+
+def test_kernel_backend_result_records_pre_dispatch_failure(tmp_path: Path) -> None:
+    # Backend failed before running any attempt (empty attempts + failed status)
+    # -> a synthetic FAILED marker so the failure is visible in kernel_journey.
+    instrument.record_kernel_backend_result(tmp_path, {
+        "kernel_id": "k001", "run_id": "r1", "attempts": [],
+        "status": "failed", "error_class": "non_reusable_kernel",
+        "error": "empty kernel shape", "backend": "geak",
+    })
+    out = assemble_parts(tmp_path)
+    attempts = out["kernel_journey"]["kernels"][0]["backend_attempts"]
+    assert len(attempts) == 1
+    att = attempts[0]
+    assert att["decision"] == "FAILED"
+    assert att["pre_dispatch_failure"] is True
+    assert att["error_class"] == "non_reusable_kernel"
+    assert att["backend"] == "geak"
+    # With an attempt present the kernel reads as "attempted", not "skipped".
+    assert out["kernel_journey"]["kernels"][0]["outcome"] == "attempted"
+
+
+def test_attach_kernel_roofline_enriches_journey() -> None:
+    from inference_optimizer.breakdown.exporter import _attach_kernel_roofline
+
+    kernel_journey = {
+        "discovery_runs": [],
+        "kernels": [{
+            "kernel_id": "k001", "name": "moe", "gpu_pct": 42.0,
+            "bound_type": "",
+            "discovery": {
+                "kernel_id": "k001", "bound_type": "",
+                "arithmetic_intensity": None, "efficiency_percent": None,
+            },
+            "backend_attempts": [],
+        }],
+    }
+    kernel_roofline = {
+        "kernels": [{
+            "kernel_id": "k001", "name": "moe", "bound_type": "memory",
+            "arithmetic_intensity": 3.5, "flops_per_byte": 2.1,
+            "efficiency_percent": 61.0, "rocprof_roofline": {"foo": "bar"},
+        }],
+    }
+    _attach_kernel_roofline(kernel_journey, kernel_roofline)
+    entry = kernel_journey["kernels"][0]
+    assert entry["roofline"]["arithmetic_intensity"] == 3.5
+    assert entry["roofline"]["rocprof_roofline"] == {"foo": "bar"}
+    # Header + discovery numeric fields backfilled from roofline.
+    assert entry["bound_type"] == "memory"
+    assert entry["discovery"]["bound_type"] == "memory"
+    assert entry["discovery"]["arithmetic_intensity"] == 3.5
+    assert entry["discovery"]["efficiency_percent"] == 61.0

--- a/inference_optimizer/tests/test_kernel_journey.py
+++ b/inference_optimizer/tests/test_kernel_journey.py
@@ -125,6 +125,42 @@ def test_kernel_backend_result_records_pre_dispatch_failure(tmp_path: Path) -> N
     assert out["kernel_journey"]["kernels"][0]["outcome"] == "attempted"
 
 
+def test_backend_attempt_maps_kernel_agent_field_names(tmp_path: Path) -> None:
+    # kernel-agent emits elapsed_s / created_at / error_type and keeps the
+    # achieved speedup at the kernel level in verification (best attempt). The
+    # recorder must map those onto the journey attempt + entry.
+    instrument.record_kernel_backend_result(tmp_path, {
+        "kernel_id": "k001", "run_id": "r1",
+        "verification": {"micro_speedup": 1.42, "best_attempt_id": "a1"},
+        "attempts": [
+            {"attempt_id": "a1", "backend": "geak", "status": "completed",
+             "elapsed_s": 87.5, "created_at": "2026-06-12T00:00:00Z"},
+            {"attempt_id": "a2", "backend": "claude", "status": "timeout",
+             "error_type": "timeout", "elapsed_s": 12.0},
+        ],
+    })
+    out = assemble_parts(tmp_path)
+    entry = out["kernel_journey"]["kernels"][0]
+    a1, a2 = entry["backend_attempts"]
+    assert a1["duration_sec"] == 87.5
+    assert a1["ts"] == "2026-06-12T00:00:00Z"
+    # kernel-level best speedup stamped onto the adopted attempt.
+    assert a1["micro_speedup"] == 1.42
+    assert a2["error_class"] == "timeout"
+    # Entry exposes the best achieved speedup for the e2e correlation.
+    assert entry["micro_speedup"] == 1.42
+
+
+def test_discovery_run_carries_duration(tmp_path: Path) -> None:
+    instrument.record_kernel_discovery(
+        tmp_path, source="tracelens", status="success",
+        hot_kernels=[{"kernel_id": "k1", "name": "moe", "gpu_pct": 10.0}],
+        scan={}, duration_sec=4.2,
+    )
+    out = assemble_parts(tmp_path)
+    assert out["kernel_journey"]["discovery_runs"][0]["duration_sec"] == 4.2
+
+
 def test_attach_kernel_roofline_enriches_journey() -> None:
     from inference_optimizer.breakdown.exporter import _attach_kernel_roofline
 


### PR DESCRIPTION
## Summary

Follow-up fixes on top of the `kernel_journey` section to close data-fidelity gaps needed by the Kernel Overview dashboard. All changes are additive (recorder/instrument + exporter only); no existing section or collector is touched.

### 1. Capture pre-dispatch backend failures
When a backend fails before running any attempt (e.g. geak rejecting an empty / non-reusable kernel shape), `backend_attempts` was empty and the failure was invisible. We now record a synthetic `FAILED` attempt (`pre_dispatch_failure=true`, with `error_class`) and mark the kernel `dispatched=true` (the backend was invoked), so the funnel shows the loss instead of hiding it.

### 2. Attach roofline data to each kernel
Each `kernel_journey.kernels[]` entry now carries a copy of its matching `kernel_roofline` entry under `roofline`, and the discovery numeric fields (`arithmetic_intensity` / `efficiency_percent` / `flops_per_byte` / `bound_type`) are backfilled from roofline (discovery records before roofline enrichment runs, so they were empty).

### 3. Fill timing + speedup fields
- Map the kernel-agent attempt field names that were silently dropped due to a key mismatch: `elapsed_s` -> `duration_sec`, `created_at` -> `ts`, `error_type` -> `error_class`.
- Surface the kernel-level best `micro_speedup` (from `verification`) onto the adopted attempt and at the journey-entry top level, so it can be correlated with `e2e.e2e_gain_pct`.
- Record discovery-run wall-clock `duration_sec` (source efficiency).

### 4. Authoritative tool versions in a top-level `versions` map
Resolve each external tool's authoritative version via a per-tool provenance registry (verified on-cluster) and store them in a new top-level `versions` object, one object per tool keyed by name (`{tool, root_dir, commit, version}`):
- `geak`: git short SHA of `$GEAK_ROOT` (NOT the upstream pip `mini-swe-agent`)
- `tracelens`: `git describe --tags --always --dirty` of `$TRACELENS_ROOT`
- `claude` / `codex`: CLI `--version`
- `oob`: pip dist `oob-mcp-server` (rejecting stale `0.0.0`)
- `inferencex` / `kernel_agent`: git short SHA

Versions are no longer inlined per discovery_run / backend attempt; consumers resolve a version via the element's `source` / `backend` name against the `versions` map. All probes are cached per tool+root, 3s timeout, best-effort (never raise into the optimizer).

## Schema changes
- `KernelJourneyEntry`: add `micro_speedup`, `roofline`.
- `KernelBackendAttempt`: add `error_class`, `pre_dispatch_failure`; drop inline `tool`.
- `KernelDiscoveryRun`: add `duration_sec`; drop inline `tool`.
- `DiscoveredHotKernel`: add `flops_per_byte`, `efficiency_percent`.
- `SessionBreakdown`: add top-level `versions: dict[str, KernelToolMetadata]`.

## Notes
- Effective only for newly-run sessions (recorder is author-time); historical breakdowns are not backfilled.
- `bypass` discovery source is not wired yet: there is currently no non-tracelens discovery code path to hook; needs the bypass path identified before a `source="bypass"` record can be added.

## Test plan
- [x] `inference_optimizer/tests/test_kernel_journey.py` (10 tests): full lifecycle compose, pre-dispatch failure marker, roofline enrichment, kernel-agent field-name mapping, discovery duration, version probe (git/CLI/pip strategies), and top-level versions map composition.
