### PR TITLE
fix(report): surface real baseline_failed root cause, not benign WARN (#465)

### DIFF
--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -1810,17 +1810,42 @@ def _default_target_summary(args: argparse.Namespace) -> str:
     return f"Optimize {Path(args.model).name} for up to {args.max_hours}h (no target)."
 
 
-def _print_final_summary(state: SharedState, stop_reason: str) -> None:
+def _read_failure_summary(session_dir: Path) -> dict | None:
+    """Read ``reports/final.json``'s ``failure_summary`` block, if present.
+
+    Best-effort: returns ``None`` when the file is missing/unreadable or the
+    block is absent (e.g. non-failure runs). Used to surface the real terminal
+    root cause in the end-of-run summary on ``baseline_failed`` (#465).
+    """
+    try:
+        from .session_paths import reports_dir
+        final_json = reports_dir(session_dir) / "final.json"
+        data = json.loads(final_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+    fs = data.get("failure_summary") if isinstance(data, dict) else None
+    return fs if isinstance(fs, dict) else None
+
+
+def _print_final_summary(
+    state: SharedState,
+    stop_reason: str,
+    session_dir: Path | None = None,
+) -> None:
     """Print the end-of-run summary block to stdout.
 
     Reports the stop reason, session id, model, baseline throughput, the
     per-round (informational) cumulative gain, the validated cumulative gain
     (with a staleness warning when the optimization stack grew after the last
     validation), the current best config, pruned families, and crash count.
+    On ``baseline_failed`` it also surfaces the real terminal root cause from
+    ``reports/final.json`` instead of a benign upstream WARN (#465).
 
     Args:
         state (SharedState): The final shared state after the run completes.
         stop_reason (str): Why the run stopped (e.g. ``"target_reached"``).
+        session_dir (Path | None): Session root, used to read the
+            ``failure_summary`` block on failure runs.
 
     Returns:
         None
@@ -1831,6 +1856,19 @@ def _print_final_summary(state: SharedState, stop_reason: str) -> None:
     print(f"  session_id           : {state.session_id}")
     print(f"  model                : {state.model_name}")
     print(f"  baseline_tput        : {state.baseline_tput:.1f} tok/s/GPU")
+    if session_dir is not None and stop_reason == "baseline_failed":
+        failure_summary = _read_failure_summary(session_dir)
+        if failure_summary and failure_summary.get("root_cause"):
+            print(
+                f"  root_cause           : "
+                f"[{failure_summary.get('root_cause_type', 'unknown')}] "
+                f"{failure_summary.get('root_cause')}"
+            )
+            if failure_summary.get("server_log"):
+                print(
+                    f"  server_log           : "
+                    f"{failure_summary.get('server_log')}"
+                )
     print(
         f"  cumulative_gain      : {state.cumulative_gain:.2f}% "
         f"(per-round sum — informational)"
@@ -4326,7 +4364,7 @@ async def _run_optimize(args: argparse.Namespace) -> int:
     _reconcile_crash_count(coordinator.shared_state, session_dir)
     # NOTE: conc_sweep is now a SWEEP-phase action auto-enqueued by the Coordinator, not a post-hook here.
 
-    _print_final_summary(coordinator.shared_state, stop_reason)
+    _print_final_summary(coordinator.shared_state, stop_reason, session_dir)
     return 0 if stop_reason in (
         "target_reached",
         "no_more_leverage",

--- a/inference_optimizer/orchestrator/action_executors/report.py
+++ b/inference_optimizer/orchestrator/action_executors/report.py
@@ -41,12 +41,195 @@ def _safe_call(state: Any, method: str, default: Any) -> Any:
         return default
 
 
+# Benign upstream WARN fragments that must never be promoted as the
+# ``baseline_failed`` headline: they do not correlate with the terminal
+# failure (the model still resolves / runs). Suppression is Hyperloom-side
+# only — the full text still appears in the per-attempt logs. See issue #465.
+_BENIGN_FAILURE_PATTERNS: tuple[str, ...] = (
+    "modeling_cohere2.py",
+)
+
+
+def _is_benign_failure_text(text: str) -> bool:
+    """Return True when ``text`` matches a known-benign upstream WARN pattern."""
+    blob = str(text or "")
+    return any(pat in blob for pat in _BENIGN_FAILURE_PATTERNS)
+
+
+def _highlight_is_benign(highlight: dict[str, Any]) -> bool:
+    """Return True when a highlight record only carries a benign upstream WARN.
+
+    Checks the one-line ``summary`` plus the stringy ``payload`` values so a
+    WARN buried in the event payload is suppressed too.
+    """
+    if _is_benign_failure_text(str(highlight.get("summary", ""))):
+        return True
+    payload = highlight.get("payload")
+    if isinstance(payload, dict):
+        for value in payload.values():
+            if isinstance(value, str) and _is_benign_failure_text(value):
+                return True
+    return False
+
+
+def _classify_root_cause_type(error_class: str, error_text: str) -> str:
+    """Map a baseline attempt's ``error_class`` + message to a coarse enum.
+
+    Returns one of ``oom`` / ``benchmark_timeout`` / ``engine_core_init`` /
+    ``worker_crash`` / ``unknown`` for the dashboard / ops contract.
+    """
+    blob = f"{error_class} {error_text}".lower()
+    if "out of memory" in blob or "hip oom" in blob:
+        return "oom"
+    if error_class == "timeout" or "benchmark exceeded" in blob:
+        return "benchmark_timeout"
+    if (
+        error_class == "server_init_dead"
+        or "engine core" in blob
+        or "enginecore" in blob
+        or "workerproc" in blob
+        or "engine process failed" in blob
+    ):
+        return "engine_core_init"
+    if error_class == "subprocess_nonzero" or "nccl" in blob or "worker" in blob:
+        return "worker_crash"
+    return "unknown"
+
+
+def _pick_failure_headline(text: str) -> str:
+    """Pick the most informative single line out of a server.log excerpt.
+
+    Prefers terminal fault lines (OOM / FATAL / engine-core markers) over the
+    last line, so the headline points at the real root cause.
+    """
+    lines = [ln.strip() for ln in str(text or "").splitlines() if ln.strip()]
+    if not lines:
+        return ""
+    priority = (
+        "out of memory", "fatal", "runtimeerror", "nccl",
+        "engine core", "enginecore", "workerproc", "error:",
+    )
+    for keyword in priority:
+        for ln in lines:
+            if keyword in ln.lower():
+                return ln
+    return lines[-1]
+
+
+def _build_failure_summary(
+    session_dir: Path, state: SharedState,
+) -> dict[str, Any] | None:
+    """Surface the real terminal error on ``baseline_failed`` (issue #465).
+
+    Reads the most recent ``runs/baseline/<task_id>/result.json`` whose
+    ``status == "failed"`` and lifts its ``error`` / ``error_class`` into a
+    compact ``failure_summary`` block. When that error is missing or matches a
+    benign WARN, falls back to scanning the attempt's ``server.log`` for the
+    terminal engine/worker marker via :func:`server_log_death_excerpt`.
+
+    Best-effort: only fires for ``baseline_failed`` and returns ``None`` on any
+    error so the report still writes.
+    """
+    if str(getattr(state, "stop_reason", "") or "") != "baseline_failed":
+        return None
+    try:
+        from ...session_paths import runs_root as _runs_root
+        baseline_root = _runs_root(session_dir) / "baseline"
+        if not baseline_root.is_dir():
+            return None
+        attempts: list[tuple[float, Path, dict[str, Any]]] = []
+        for task_dir in baseline_root.iterdir():
+            if not task_dir.is_dir():
+                continue
+            result_path = task_dir / "result.json"
+            if not result_path.is_file():
+                continue
+            try:
+                payload = json.loads(result_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not isinstance(payload, dict):
+                continue
+            if str(payload.get("status")) != "failed":
+                continue
+            try:
+                mtime = result_path.stat().st_mtime
+            except OSError:
+                mtime = 0.0
+            attempts.append((mtime, task_dir, payload))
+        if not attempts:
+            return None
+        attempts.sort(key=lambda item: item[0])
+        _, last_dir, payload = attempts[-1]
+    except Exception:  # noqa: BLE001 — report must never crash on the summary
+        log.warning(
+            "report_executor: failed to build failure_summary", exc_info=True,
+        )
+        return None
+
+    error_class = str(payload.get("error_class") or "unknown")
+    error_text = str(payload.get("error") or "").strip()
+    suppressed: list[str] = []
+    if error_text and _is_benign_failure_text(error_text):
+        suppressed.append(error_text.splitlines()[0][:200])
+        error_text = ""  # force fallback to the server.log terminal marker
+
+    # Locate this attempt's server.log (written at ``output_dir/server.log``).
+    server_log_abs: Path | None = None
+    out_dir = payload.get("output_dir")
+    candidates = [last_dir / "server.log"]
+    if out_dir:
+        candidates.insert(0, Path(str(out_dir)) / "server.log")
+    for cand in candidates:
+        try:
+            if cand.is_file():
+                server_log_abs = cand
+                break
+        except OSError:
+            continue
+
+    # Fallback / enrichment: pull the terminal marker from server.log when the
+    # result carried no error or only the benign WARN.
+    if not error_text and server_log_abs is not None:
+        try:
+            from ._subprocess_kill import server_log_death_excerpt
+            excerpt = server_log_death_excerpt(str(server_log_abs))
+        except Exception:  # noqa: BLE001
+            excerpt = None
+        if excerpt:
+            error_text = excerpt.strip()
+            if error_class == "unknown":
+                error_class = "server_init_dead"
+
+    root_cause = _pick_failure_headline(error_text) or (
+        "(no terminal error captured; see server.log)"
+    )
+    server_log_rel: str | None = None
+    if server_log_abs is not None:
+        try:
+            server_log_rel = server_log_abs.relative_to(session_dir).as_posix()
+        except ValueError:
+            server_log_rel = str(server_log_abs)
+
+    summary: dict[str, Any] = {
+        "root_cause": root_cause[:500],
+        "root_cause_type": _classify_root_cause_type(error_class, error_text),
+        "error_class": error_class,
+        "last_attempt_id": last_dir.name,
+        "server_log": server_log_rel,
+    }
+    if suppressed:
+        summary["suppressed_benign"] = suppressed
+    return summary
+
+
 def _build_summary_dict(
     state: SharedState,
     ev_counts: dict[str, int],
     highlights: list[dict],
     *,
     external_baseline: dict[str, Any] | None = None,
+    session_dir: Path | None = None,
 ) -> dict[str, Any]:
     """Assemble the machine-readable session summary dict.
 
@@ -56,6 +239,8 @@ def _build_summary_dict(
         highlights (list[dict]): Top-N highlighted decisions/verdicts.
         external_baseline (dict[str, Any] | None): Optional external
             baseline comparison block to embed.
+        session_dir (Path | None): Session root; when provided, a
+            ``failure_summary`` block is added on ``baseline_failed`` (#465).
 
     Returns:
         dict[str, Any]: The summary payload written to ``final.json``,
@@ -111,6 +296,12 @@ def _build_summary_dict(
     )
     if cmp:
         summary["roofline_comparison"] = cmp
+    # Real terminal root cause on baseline_failed (#465): promote the last
+    # failed baseline attempt's engine/worker fault over benign upstream WARNs.
+    if session_dir is not None:
+        failure_summary = _build_failure_summary(session_dir, state)
+        if failure_summary:
+            summary["failure_summary"] = failure_summary
     return summary
 
 
@@ -134,6 +325,17 @@ def _format_md(summary: dict[str, Any]) -> str:
     stop_detail = str(summary.get("stop_detail") or "").strip()
     if stop_detail:
         lines.append(f"- **Stop detail**: {stop_detail}")
+    failure_summary = summary.get("failure_summary")
+    if isinstance(failure_summary, dict) and failure_summary.get("root_cause"):
+        lines.append(
+            f"- **Root cause**: "
+            f"`{failure_summary.get('root_cause_type', 'unknown')}` — "
+            f"{failure_summary.get('root_cause')}"
+        )
+        if failure_summary.get("server_log"):
+            lines.append(
+                f"- **Server log**: `{failure_summary.get('server_log')}`"
+            )
     if summary.get("degraded_mode"):
         lines.append(
             "- **⚠ Degraded mode**: ran on the TEXT path only "
@@ -740,7 +942,13 @@ class ReportExecutor:
             highlights: list[dict] = []
             for m in ev_rows:
                 if m.topic in highlight_topics:
-                    highlights.append(_highlight(m.payload or {}, m.topic, m.from_agent))
+                    h = _highlight(m.payload or {}, m.topic, m.from_agent)
+                    # Suppress benign upstream WARNs so they never become the
+                    # top-level highlight on a failure (#465); the full text
+                    # still lives in the per-attempt logs.
+                    if _highlight_is_benign(h):
+                        continue
+                    highlights.append(h)
         finally:
             db.close()
 
@@ -751,6 +959,7 @@ class ReportExecutor:
             dict(ev_counts),
             highlights,
             external_baseline=external_baseline,
+            session_dir=session_dir,
         )
 
         # Kernel-optimization forensic summary in a separate file (pointer

--- a/inference_optimizer/orchestrator/action_executors/report.py
+++ b/inference_optimizer/orchestrator/action_executors/report.py
@@ -57,19 +57,34 @@ def _is_benign_failure_text(text: str) -> bool:
 
 
 def _highlight_is_benign(highlight: dict[str, Any]) -> bool:
-    """Return True when a highlight record only carries a benign upstream WARN.
+    """Return True when a highlight's *headline* is only a benign upstream WARN.
 
-    Checks the one-line ``summary`` plus the stringy ``payload`` values so a
-    WARN buried in the event payload is suppressed too.
+    Judges the one-line ``summary`` (the text that would surface as the
+    headline) exclusively. Payload-buried mentions are intentionally ignored so
+    a highlight whose summary describes a real fault (e.g. ``EngineCore failed
+    to start``) is never suppressed even if its payload also references a benign
+    file (#465).
     """
-    if _is_benign_failure_text(str(highlight.get("summary", ""))):
-        return True
-    payload = highlight.get("payload")
-    if isinstance(payload, dict):
-        for value in payload.values():
-            if isinstance(value, str) and _is_benign_failure_text(value):
-                return True
-    return False
+    return _is_benign_failure_text(str(highlight.get("summary", "")))
+
+
+def _partition_benign_lines(text: str) -> tuple[list[str], list[str]]:
+    """Split an error blob into ``(kept_lines, suppressed_benign_lines)``.
+
+    Drops only the lines matching a benign upstream WARN pattern and preserves
+    every other line, so a mixed blob (benign WARN + real HIP OOM) keeps its
+    real root cause instead of being wiped wholesale (#465).
+    """
+    kept: list[str] = []
+    suppressed: list[str] = []
+    for line in str(text or "").splitlines():
+        if _is_benign_failure_text(line):
+            stripped = line.strip()
+            if stripped:
+                suppressed.append(stripped[:200])
+        else:
+            kept.append(line)
+    return kept, suppressed
 
 
 def _classify_root_cause_type(error_class: str, error_text: str) -> str:
@@ -116,111 +131,128 @@ def _pick_failure_headline(text: str) -> str:
     return lines[-1]
 
 
+def _last_failed_baseline_attempt(state: SharedState) -> dict[str, Any] | None:
+    """Return the most recent *failed* baseline attempt record, or ``None``.
+
+    Prefers ``SharedState.baseline_attempts`` (the per-action audit log written
+    by ``record_action_attempt``) and falls back to the matching
+    ``last_action_failures`` row. Both are persisted in ``state.json`` — there
+    is no on-disk ``runs/baseline/<task_id>/result.json`` to scan.
+    """
+    attempts = getattr(state, "baseline_attempts", None) or []
+    failed = [
+        a for a in attempts
+        if isinstance(a, dict) and str(a.get("status")) == "failed"
+    ]
+    if failed:
+        return failed[-1]
+    failures = getattr(state, "last_action_failures", None) or []
+    baseline_failures = [
+        f for f in failures
+        if isinstance(f, dict) and str(f.get("action")) == "baseline"
+    ]
+    return baseline_failures[-1] if baseline_failures else None
+
+
+def _resolve_attempt_server_log(attempt: dict[str, Any]) -> Path | None:
+    """Best-effort path to a baseline attempt's ``server.log``.
+
+    The audit row stores the ``benchmark_*`` workspace; ``server.log`` is
+    written one level up (``output_dir/server.log``). Also honours an explicit
+    ``stderr_log_path`` when present.
+    """
+    candidates: list[Path] = []
+    workspace = attempt.get("workspace")
+    if workspace:
+        ws = Path(str(workspace))
+        candidates.append(ws.parent / "server.log")
+        candidates.append(ws / "server.log")
+    stderr_log = attempt.get("stderr_log_path")
+    if stderr_log:
+        candidates.append(Path(str(stderr_log)))
+    for cand in candidates:
+        try:
+            if cand.is_file():
+                return cand
+        except OSError:
+            continue
+    return None
+
+
 def _build_failure_summary(
-    session_dir: Path, state: SharedState,
+    state: SharedState, session_dir: Path | None = None,
 ) -> dict[str, Any] | None:
     """Surface the real terminal error on ``baseline_failed`` (issue #465).
 
-    Reads the most recent ``runs/baseline/<task_id>/result.json`` whose
-    ``status == "failed"`` and lifts its ``error`` / ``error_class`` into a
-    compact ``failure_summary`` block. When that error is missing or matches a
-    benign WARN, falls back to scanning the attempt's ``server.log`` for the
-    terminal engine/worker marker via :func:`server_log_death_excerpt`.
+    Sources the last *failed* baseline attempt from ``SharedState`` (see
+    :func:`_last_failed_baseline_attempt`) and lifts its ``error_excerpt`` /
+    ``error_class`` into a compact ``failure_summary``. Only benign upstream
+    WARN *lines* are stripped (the real error text is kept); when nothing
+    actionable remains, falls back to the attempt workspace's ``server.log``
+    terminal marker via :func:`server_log_death_excerpt`.
 
     Best-effort: only fires for ``baseline_failed`` and returns ``None`` on any
-    error so the report still writes.
+    error so the report still writes. ``session_dir`` is used only to render a
+    session-relative ``server_log`` path.
     """
     if str(getattr(state, "stop_reason", "") or "") != "baseline_failed":
         return None
     try:
-        from ...session_paths import runs_root as _runs_root
-        baseline_root = _runs_root(session_dir) / "baseline"
-        if not baseline_root.is_dir():
+        attempt = _last_failed_baseline_attempt(state)
+        if attempt is None:
             return None
-        attempts: list[tuple[float, Path, dict[str, Any]]] = []
-        for task_dir in baseline_root.iterdir():
-            if not task_dir.is_dir():
-                continue
-            result_path = task_dir / "result.json"
-            if not result_path.is_file():
-                continue
+
+        error_class = str(attempt.get("error_class") or "unknown")
+        raw_error = str(attempt.get("error_excerpt") or "")
+        kept_lines, suppressed = _partition_benign_lines(raw_error)
+        error_text = "\n".join(kept_lines).strip()
+
+        server_log_abs = _resolve_attempt_server_log(attempt)
+        # Only the benign WARN (or nothing) survived → dig the real terminal
+        # marker out of server.log when one is available.
+        if not error_text and server_log_abs is not None:
             try:
-                payload = json.loads(result_path.read_text(encoding="utf-8"))
-            except (OSError, json.JSONDecodeError):
-                continue
-            if not isinstance(payload, dict):
-                continue
-            if str(payload.get("status")) != "failed":
-                continue
-            try:
-                mtime = result_path.stat().st_mtime
-            except OSError:
-                mtime = 0.0
-            attempts.append((mtime, task_dir, payload))
-        if not attempts:
-            return None
-        attempts.sort(key=lambda item: item[0])
-        _, last_dir, payload = attempts[-1]
+                from ._subprocess_kill import server_log_death_excerpt
+                excerpt = server_log_death_excerpt(str(server_log_abs))
+            except Exception:  # noqa: BLE001
+                excerpt = None
+            if excerpt:
+                error_text = excerpt.strip()
+                if error_class in ("", "unknown"):
+                    error_class = "server_init_dead"
+        if not error_text:
+            error_text = "(no terminal error captured; see logs)"
+
+        root_cause = _pick_failure_headline(error_text)
+        server_log_rel: str | None = None
+        if server_log_abs is not None:
+            if session_dir is not None:
+                try:
+                    server_log_rel = server_log_abs.relative_to(
+                        session_dir
+                    ).as_posix()
+                except ValueError:
+                    server_log_rel = str(server_log_abs)
+            else:
+                server_log_rel = str(server_log_abs)
+
+        summary: dict[str, Any] = {
+            "root_cause": root_cause[:500],
+            "root_cause_type": _classify_root_cause_type(
+                error_class, error_text
+            ),
+            "error_class": error_class,
+            "last_attempt_id": str(attempt.get("task_id") or ""),
+            "server_log": server_log_rel,
+        }
+        if suppressed:
+            summary["suppressed_benign"] = suppressed[:5]
+        return summary
     except Exception:  # noqa: BLE001 — report must never crash on the summary
         log.warning(
             "report_executor: failed to build failure_summary", exc_info=True,
         )
         return None
-
-    error_class = str(payload.get("error_class") or "unknown")
-    error_text = str(payload.get("error") or "").strip()
-    suppressed: list[str] = []
-    if error_text and _is_benign_failure_text(error_text):
-        suppressed.append(error_text.splitlines()[0][:200])
-        error_text = ""  # force fallback to the server.log terminal marker
-
-    # Locate this attempt's server.log (written at ``output_dir/server.log``).
-    server_log_abs: Path | None = None
-    out_dir = payload.get("output_dir")
-    candidates = [last_dir / "server.log"]
-    if out_dir:
-        candidates.insert(0, Path(str(out_dir)) / "server.log")
-    for cand in candidates:
-        try:
-            if cand.is_file():
-                server_log_abs = cand
-                break
-        except OSError:
-            continue
-
-    # Fallback / enrichment: pull the terminal marker from server.log when the
-    # result carried no error or only the benign WARN.
-    if not error_text and server_log_abs is not None:
-        try:
-            from ._subprocess_kill import server_log_death_excerpt
-            excerpt = server_log_death_excerpt(str(server_log_abs))
-        except Exception:  # noqa: BLE001
-            excerpt = None
-        if excerpt:
-            error_text = excerpt.strip()
-            if error_class == "unknown":
-                error_class = "server_init_dead"
-
-    root_cause = _pick_failure_headline(error_text) or (
-        "(no terminal error captured; see server.log)"
-    )
-    server_log_rel: str | None = None
-    if server_log_abs is not None:
-        try:
-            server_log_rel = server_log_abs.relative_to(session_dir).as_posix()
-        except ValueError:
-            server_log_rel = str(server_log_abs)
-
-    summary: dict[str, Any] = {
-        "root_cause": root_cause[:500],
-        "root_cause_type": _classify_root_cause_type(error_class, error_text),
-        "error_class": error_class,
-        "last_attempt_id": last_dir.name,
-        "server_log": server_log_rel,
-    }
-    if suppressed:
-        summary["suppressed_benign"] = suppressed
-    return summary
 
 
 def _build_summary_dict(
@@ -298,10 +330,11 @@ def _build_summary_dict(
         summary["roofline_comparison"] = cmp
     # Real terminal root cause on baseline_failed (#465): promote the last
     # failed baseline attempt's engine/worker fault over benign upstream WARNs.
-    if session_dir is not None:
-        failure_summary = _build_failure_summary(session_dir, state)
-        if failure_summary:
-            summary["failure_summary"] = failure_summary
+    # Sourced from SharedState (not the filesystem); session_dir only renders a
+    # relative server.log path.
+    failure_summary = _build_failure_summary(state, session_dir)
+    if failure_summary:
+        summary["failure_summary"] = failure_summary
     return summary
 
 
@@ -932,6 +965,11 @@ class ReportExecutor:
         )
 
         state = SharedState.load_or_init(session_dir)
+        # Only demote benign upstream WARNs from highlights on a baseline
+        # failure (#465); other runs keep every highlight untouched.
+        suppress_benign_highlights = (
+            str(getattr(state, "stop_reason", "") or "") == "baseline_failed"
+        )
 
         # Pull bus stats over a fresh connection (SQLite WAL shares cleanly).
         db = SqliteConnection(db_path_for(session_dir))
@@ -943,10 +981,10 @@ class ReportExecutor:
             for m in ev_rows:
                 if m.topic in highlight_topics:
                     h = _highlight(m.payload or {}, m.topic, m.from_agent)
-                    # Suppress benign upstream WARNs so they never become the
-                    # top-level highlight on a failure (#465); the full text
-                    # still lives in the per-attempt logs.
-                    if _highlight_is_benign(h):
+                    # On baseline_failed, suppress benign upstream WARN
+                    # headlines so they never become the top-level highlight
+                    # (#465); the full text still lives in the per-attempt logs.
+                    if suppress_benign_highlights and _highlight_is_benign(h):
                         continue
                     highlights.append(h)
         finally:

--- a/inference_optimizer/tests/test_baseline_failure_summary.py
+++ b/inference_optimizer/tests/test_baseline_failure_summary.py
@@ -1,0 +1,220 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""``baseline_failed`` root-cause surfacing tests (issue #465).
+
+On ``baseline_failed`` the top-level ``final.json`` / report must headline the
+real terminal engine/worker fault from the last failed baseline attempt, not a
+benign upstream WARN (e.g. transformers' ``modeling_cohere2.py`` ENOENT).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from inference_optimizer.orchestrator.action_executors.report import (
+    _build_summary_dict,
+    _classify_root_cause_type,
+    _format_md,
+    _highlight_is_benign,
+    _is_benign_failure_text,
+)
+
+_BENIGN_WARN = (
+    "[WARN] Error: [Errno 2] No such file or directory: "
+    "'/app/.../transformers/models/cohere2/modeling_cohere2.py'"
+)
+
+_SERVER_LOG_OOM = (
+    "non-default args: {'tensor_parallel_size': 8}\n"
+    "[aiter] import [module_aiter_core] ...\n"
+    "[2] [FATAL ERROR]: HIP failure: 'out of memory' "
+    "(in ncclCommInitRank during init_model_parallel)\n"
+    "RuntimeError: NCCL error: unhandled cuda error\n"
+    "EngineCore failed to start.\n"
+)
+
+
+def _mock_state(*, stop_reason: str = "baseline_failed") -> SimpleNamespace:
+    """Minimal SharedState-shaped object for ``_build_summary_dict``."""
+    return SimpleNamespace(
+        session_id="sid",
+        model_name="command-a-plus-05-2026-fp8",
+        model_path="/tmp/model",
+        model_class="moe",
+        stop_reason=stop_reason,
+        baseline_tput=0.0,
+        baseline_accuracy=0.0,
+        last_remaining_gaps_assessment={},
+        remaining_gaps_assessments=[],
+        current_best={},
+        cumulative_gain=0.0,
+        cumulative_gain_validated=0.0,
+        cumulative_gain_validated_ts="",
+        cumulative_gain_validated_stack_len=0,
+        optimization_stack=[],
+        crash_count=2,
+        pruned_families=[],
+        max_minutes=720,
+        roofline_snapshots=[],
+    )
+
+
+def _write_baseline_attempt(
+    session_dir: Path,
+    task_id: str,
+    *,
+    error_class: str,
+    error: str,
+    server_log: str | None = None,
+) -> Path:
+    """Materialise ``runs/baseline/<task_id>/result.json`` (+ optional log)."""
+    task_dir = session_dir / "runs" / "baseline" / task_id
+    task_dir.mkdir(parents=True, exist_ok=True)
+    payload: dict[str, Any] = {
+        "status": "failed",
+        "error_class": error_class,
+        "error": error,
+        "output_dir": str(task_dir),
+    }
+    (task_dir / "result.json").write_text(
+        json.dumps(payload), encoding="utf-8",
+    )
+    if server_log is not None:
+        (task_dir / "server.log").write_text(server_log, encoding="utf-8")
+    return task_dir
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+def test_is_benign_failure_text():
+    assert _is_benign_failure_text(_BENIGN_WARN)
+    assert not _is_benign_failure_text("HIP out of memory during ncclCommInitRank")
+
+
+def test_highlight_is_benign_checks_summary_and_payload():
+    assert _highlight_is_benign({"summary": _BENIGN_WARN, "payload": {}})
+    assert _highlight_is_benign(
+        {"summary": "sev=high", "payload": {"detail": _BENIGN_WARN}}
+    )
+    assert not _highlight_is_benign(
+        {"summary": "sev=high EngineCore failed", "payload": {"x": 1}}
+    )
+
+
+def test_classify_root_cause_type():
+    assert _classify_root_cause_type("server_init_dead", "HIP out of memory") == "oom"
+    assert _classify_root_cause_type("timeout", "baseline benchmark exceeded 600s") == "benchmark_timeout"
+    assert _classify_root_cause_type("server_init_dead", "EngineCore failed to start") == "engine_core_init"
+    assert _classify_root_cause_type("subprocess_nonzero", "boom") == "worker_crash"
+    assert _classify_root_cause_type("unknown", "") == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# failure_summary from result.json
+# ---------------------------------------------------------------------------
+def test_failure_summary_from_result_error(tmp_path):
+    """A server_init_dead attempt's excerpt becomes the headline root cause."""
+    _write_baseline_attempt(
+        tmp_path, "attempt1",
+        error_class="server_init_dead",
+        error=_SERVER_LOG_OOM,
+    )
+    state = _mock_state()
+    summary = _build_summary_dict(
+        state, ev_counts={}, highlights=[], session_dir=tmp_path,
+    )
+    fs = summary["failure_summary"]
+    assert fs["root_cause_type"] == "oom"
+    assert "out of memory" in fs["root_cause"].lower()
+    assert fs["last_attempt_id"] == "attempt1"
+
+
+def test_failure_summary_suppresses_benign_warn_and_falls_back_to_log(tmp_path):
+    """Benign WARN in result.error → fall back to server.log terminal marker."""
+    _write_baseline_attempt(
+        tmp_path, "attempt2",
+        error_class="unknown",
+        error=_BENIGN_WARN,
+        server_log=_SERVER_LOG_OOM,
+    )
+    state = _mock_state()
+    summary = _build_summary_dict(
+        state, ev_counts={}, highlights=[], session_dir=tmp_path,
+    )
+    fs = summary["failure_summary"]
+    assert fs["root_cause_type"] == "oom"
+    assert "out of memory" in fs["root_cause"].lower()
+    assert "modeling_cohere2.py" not in fs["root_cause"]
+    assert fs["suppressed_benign"]
+    assert fs["server_log"].endswith("server.log")
+
+
+def test_failure_summary_picks_latest_failed_attempt(tmp_path):
+    """Most recent failed attempt wins when several are present."""
+    import os
+    import time
+
+    first = _write_baseline_attempt(
+        tmp_path, "attempt_old",
+        error_class="timeout",
+        error="baseline benchmark exceeded 600s",
+    )
+    time.sleep(0.01)
+    _write_baseline_attempt(
+        tmp_path, "attempt_new",
+        error_class="server_init_dead",
+        error=_SERVER_LOG_OOM,
+    )
+    # Make the ordering deterministic regardless of FS mtime granularity.
+    old = time.time() - 100
+    os.utime(first / "result.json", (old, old))
+
+    state = _mock_state()
+    summary = _build_summary_dict(
+        state, ev_counts={}, highlights=[], session_dir=tmp_path,
+    )
+    assert summary["failure_summary"]["last_attempt_id"] == "attempt_new"
+
+
+def test_failure_summary_absent_when_not_baseline_failed(tmp_path):
+    """Non-failure stop reasons never attach a failure_summary."""
+    _write_baseline_attempt(
+        tmp_path, "attempt1",
+        error_class="server_init_dead",
+        error=_SERVER_LOG_OOM,
+    )
+    state = _mock_state(stop_reason="time_exhausted")
+    summary = _build_summary_dict(
+        state, ev_counts={}, highlights=[], session_dir=tmp_path,
+    )
+    assert "failure_summary" not in summary
+
+
+def test_failure_summary_absent_without_session_dir(tmp_path):
+    """Back-compat: no session_dir → no failure_summary (legacy callers)."""
+    state = _mock_state()
+    summary = _build_summary_dict(state, ev_counts={}, highlights=[])
+    assert "failure_summary" not in summary
+
+
+# ---------------------------------------------------------------------------
+# markdown rendering
+# ---------------------------------------------------------------------------
+def test_format_md_surfaces_root_cause(tmp_path):
+    _write_baseline_attempt(
+        tmp_path, "attempt1",
+        error_class="server_init_dead",
+        error=_SERVER_LOG_OOM,
+    )
+    state = _mock_state()
+    summary = _build_summary_dict(
+        state, ev_counts={}, highlights=[], session_dir=tmp_path,
+    )
+    md = _format_md(summary)
+    assert "Root cause" in md
+    assert "oom" in md
+    assert "modeling_cohere2.py" not in md

--- a/inference_optimizer/tests/test_baseline_failure_summary.py
+++ b/inference_optimizer/tests/test_baseline_failure_summary.py
@@ -5,22 +5,26 @@
 On ``baseline_failed`` the top-level ``final.json`` / report must headline the
 real terminal engine/worker fault from the last failed baseline attempt, not a
 benign upstream WARN (e.g. transformers' ``modeling_cohere2.py`` ENOENT).
+
+These exercise the real persistence path: a failed baseline result is recorded
+into ``SharedState`` via :meth:`SharedState.record_action_attempt` /
+:meth:`SharedState.record_action_failure` (exactly as the Coordinator does in
+``_handle_unpromotable_result``), and the report layer reads it back from state
+— there is no on-disk ``runs/baseline/<task_id>/result.json``.
 """
 
 from __future__ import annotations
 
-import json
-from pathlib import Path
-from types import SimpleNamespace
-from typing import Any
-
 from inference_optimizer.orchestrator.action_executors.report import (
+    _build_failure_summary,
     _build_summary_dict,
     _classify_root_cause_type,
     _format_md,
     _highlight_is_benign,
     _is_benign_failure_text,
+    _partition_benign_lines,
 )
+from inference_optimizer.orchestrator.shared_state import SharedState
 
 _BENIGN_WARN = (
     "[WARN] Error: [Errno 2] No such file or directory: "
@@ -36,55 +40,45 @@ _SERVER_LOG_OOM = (
     "EngineCore failed to start.\n"
 )
 
-
-def _mock_state(*, stop_reason: str = "baseline_failed") -> SimpleNamespace:
-    """Minimal SharedState-shaped object for ``_build_summary_dict``."""
-    return SimpleNamespace(
-        session_id="sid",
-        model_name="command-a-plus-05-2026-fp8",
-        model_path="/tmp/model",
-        model_class="moe",
-        stop_reason=stop_reason,
-        baseline_tput=0.0,
-        baseline_accuracy=0.0,
-        last_remaining_gaps_assessment={},
-        remaining_gaps_assessments=[],
-        current_best={},
-        cumulative_gain=0.0,
-        cumulative_gain_validated=0.0,
-        cumulative_gain_validated_ts="",
-        cumulative_gain_validated_stack_len=0,
-        optimization_stack=[],
-        crash_count=2,
-        pruned_families=[],
-        max_minutes=720,
-        roofline_snapshots=[],
-    )
+# A subprocess_nonzero stderr tail that mixes the benign WARN with the real
+# fault on separate lines (the #465 reproduction).
+_MIXED_STDERR = (
+    f"{_BENIGN_WARN}\n"
+    "Loading safetensors checkpoint shards: 100% complete\n"
+    "[2] [FATAL ERROR]: HIP failure: 'out of memory' during ncclCommInitRank\n"
+)
 
 
-def _write_baseline_attempt(
-    session_dir: Path,
-    task_id: str,
+def _failed_state(
     *,
     error_class: str,
     error: str,
-    server_log: str | None = None,
-) -> Path:
-    """Materialise ``runs/baseline/<task_id>/result.json`` (+ optional log)."""
-    task_dir = session_dir / "runs" / "baseline" / task_id
-    task_dir.mkdir(parents=True, exist_ok=True)
-    payload: dict[str, Any] = {
+    workspace: str | None = None,
+    task_id: str = "baseline-1",
+    stop_reason: str = "baseline_failed",
+) -> SharedState:
+    """Build a SharedState carrying one failed baseline attempt, like the
+    Coordinator's ``_handle_unpromotable_result`` does."""
+    state = SharedState()
+    state.set_stop_reason(stop_reason)
+    result = {
         "status": "failed",
         "error_class": error_class,
         "error": error,
-        "output_dir": str(task_dir),
     }
-    (task_dir / "result.json").write_text(
-        json.dumps(payload), encoding="utf-8",
+    if workspace is not None:
+        result["workspace"] = workspace
+    state.record_action_attempt(
+        action="baseline",
+        task_id=task_id,
+        status="failed",
+        decision="no_promote",
+        result=result,
     )
-    if server_log is not None:
-        (task_dir / "server.log").write_text(server_log, encoding="utf-8")
-    return task_dir
+    state.record_action_failure(
+        action="baseline", task_id=task_id, result=result,
+    )
+    return state
 
 
 # ---------------------------------------------------------------------------
@@ -95,14 +89,21 @@ def test_is_benign_failure_text():
     assert not _is_benign_failure_text("HIP out of memory during ncclCommInitRank")
 
 
-def test_highlight_is_benign_checks_summary_and_payload():
+def test_highlight_is_benign_uses_summary_only():
+    # Benign headline → suppressed.
     assert _highlight_is_benign({"summary": _BENIGN_WARN, "payload": {}})
-    assert _highlight_is_benign(
-        {"summary": "sev=high", "payload": {"detail": _BENIGN_WARN}}
-    )
+    # Real fault headline is kept even when payload mentions the benign file.
     assert not _highlight_is_benign(
-        {"summary": "sev=high EngineCore failed", "payload": {"x": 1}}
+        {"summary": "sev=high EngineCore failed", "payload": {"f": _BENIGN_WARN}}
     )
+
+
+def test_partition_benign_lines_keeps_real_lines():
+    kept, suppressed = _partition_benign_lines(_MIXED_STDERR)
+    joined = "\n".join(kept)
+    assert "out of memory" in joined.lower()
+    assert "modeling_cohere2.py" not in joined
+    assert suppressed and "modeling_cohere2.py" in suppressed[0]
 
 
 def test_classify_root_cause_type():
@@ -114,106 +115,109 @@ def test_classify_root_cause_type():
 
 
 # ---------------------------------------------------------------------------
-# failure_summary from result.json
+# failure_summary sourced from SharedState
 # ---------------------------------------------------------------------------
-def test_failure_summary_from_result_error(tmp_path):
-    """A server_init_dead attempt's excerpt becomes the headline root cause."""
-    _write_baseline_attempt(
-        tmp_path, "attempt1",
-        error_class="server_init_dead",
-        error=_SERVER_LOG_OOM,
-    )
-    state = _mock_state()
-    summary = _build_summary_dict(
-        state, ev_counts={}, highlights=[], session_dir=tmp_path,
-    )
-    fs = summary["failure_summary"]
+def test_failure_summary_from_server_init_dead_attempt():
+    state = _failed_state(error_class="server_init_dead", error=_SERVER_LOG_OOM)
+    fs = _build_failure_summary(state)
+    assert fs is not None
     assert fs["root_cause_type"] == "oom"
     assert "out of memory" in fs["root_cause"].lower()
-    assert fs["last_attempt_id"] == "attempt1"
+    assert fs["last_attempt_id"] == "baseline-1"
 
 
-def test_failure_summary_suppresses_benign_warn_and_falls_back_to_log(tmp_path):
-    """Benign WARN in result.error → fall back to server.log terminal marker."""
-    _write_baseline_attempt(
-        tmp_path, "attempt2",
-        error_class="unknown",
-        error=_BENIGN_WARN,
-        server_log=_SERVER_LOG_OOM,
-    )
-    state = _mock_state()
-    summary = _build_summary_dict(
-        state, ev_counts={}, highlights=[], session_dir=tmp_path,
-    )
-    fs = summary["failure_summary"]
+def test_failure_summary_mixed_error_keeps_real_root_cause():
+    """A benign WARN mixed with a real fault must NOT wipe the real root cause."""
+    state = _failed_state(error_class="subprocess_nonzero", error=_MIXED_STDERR)
+    fs = _build_failure_summary(state)
+    assert fs is not None
     assert fs["root_cause_type"] == "oom"
     assert "out of memory" in fs["root_cause"].lower()
     assert "modeling_cohere2.py" not in fs["root_cause"]
     assert fs["suppressed_benign"]
+
+
+def test_failure_summary_pure_benign_falls_back_to_server_log(tmp_path):
+    """When the only recorded error is the benign WARN, fall back to the
+    attempt's server.log terminal marker."""
+    workspace = tmp_path / "runs" / "baseline" / "baseline-1" / "benchmark_vllm_x"
+    workspace.mkdir(parents=True)
+    (workspace.parent / "server.log").write_text(_SERVER_LOG_OOM, encoding="utf-8")
+    state = _failed_state(
+        error_class="unknown", error=_BENIGN_WARN, workspace=str(workspace),
+    )
+    fs = _build_failure_summary(state, tmp_path)
+    assert fs is not None
+    assert fs["root_cause_type"] == "oom"
+    assert "out of memory" in fs["root_cause"].lower()
+    assert fs["suppressed_benign"]
     assert fs["server_log"].endswith("server.log")
+    # server.log path is rendered session-relative when session_dir is given.
+    assert not fs["server_log"].startswith(str(tmp_path))
 
 
-def test_failure_summary_picks_latest_failed_attempt(tmp_path):
-    """Most recent failed attempt wins when several are present."""
-    import os
-    import time
-
-    first = _write_baseline_attempt(
-        tmp_path, "attempt_old",
-        error_class="timeout",
-        error="baseline benchmark exceeded 600s",
+def test_failure_summary_picks_latest_failed_attempt():
+    state = _failed_state(
+        error_class="timeout", error="baseline benchmark exceeded 600s",
+        task_id="attempt-old",
     )
-    time.sleep(0.01)
-    _write_baseline_attempt(
-        tmp_path, "attempt_new",
-        error_class="server_init_dead",
-        error=_SERVER_LOG_OOM,
+    # A later, more severe attempt.
+    state.record_action_attempt(
+        action="baseline", task_id="attempt-new", status="failed",
+        decision="no_promote",
+        result={"status": "failed", "error_class": "server_init_dead",
+                "error": _SERVER_LOG_OOM},
     )
-    # Make the ordering deterministic regardless of FS mtime granularity.
-    old = time.time() - 100
-    os.utime(first / "result.json", (old, old))
+    fs = _build_failure_summary(state)
+    assert fs is not None
+    assert fs["last_attempt_id"] == "attempt-new"
+    assert fs["root_cause_type"] == "oom"
 
-    state = _mock_state()
-    summary = _build_summary_dict(
-        state, ev_counts={}, highlights=[], session_dir=tmp_path,
+
+def test_failure_summary_falls_back_to_last_action_failures():
+    """When no baseline audit row exists, use the global failure log row."""
+    state = SharedState()
+    state.set_stop_reason("baseline_failed")
+    state.record_action_failure(
+        action="baseline", task_id="b1",
+        result={"status": "failed", "error_class": "server_init_dead",
+                "error": _SERVER_LOG_OOM},
     )
-    assert summary["failure_summary"]["last_attempt_id"] == "attempt_new"
+    assert not state.baseline_attempts
+    fs = _build_failure_summary(state)
+    assert fs is not None
+    assert fs["root_cause_type"] == "oom"
+    assert fs["last_attempt_id"] == "b1"
 
 
-def test_failure_summary_absent_when_not_baseline_failed(tmp_path):
-    """Non-failure stop reasons never attach a failure_summary."""
-    _write_baseline_attempt(
-        tmp_path, "attempt1",
-        error_class="server_init_dead",
-        error=_SERVER_LOG_OOM,
+def test_failure_summary_absent_when_not_baseline_failed():
+    state = _failed_state(
+        error_class="server_init_dead", error=_SERVER_LOG_OOM,
+        stop_reason="time_exhausted",
     )
-    state = _mock_state(stop_reason="time_exhausted")
-    summary = _build_summary_dict(
-        state, ev_counts={}, highlights=[], session_dir=tmp_path,
-    )
-    assert "failure_summary" not in summary
-
-
-def test_failure_summary_absent_without_session_dir(tmp_path):
-    """Back-compat: no session_dir → no failure_summary (legacy callers)."""
-    state = _mock_state()
+    assert _build_failure_summary(state) is None
     summary = _build_summary_dict(state, ev_counts={}, highlights=[])
     assert "failure_summary" not in summary
 
 
+def test_failure_summary_absent_when_no_failed_attempt():
+    state = SharedState()
+    state.set_stop_reason("baseline_failed")
+    assert _build_failure_summary(state) is None
+
+
 # ---------------------------------------------------------------------------
-# markdown rendering
+# wiring through _build_summary_dict / _format_md
 # ---------------------------------------------------------------------------
-def test_format_md_surfaces_root_cause(tmp_path):
-    _write_baseline_attempt(
-        tmp_path, "attempt1",
-        error_class="server_init_dead",
-        error=_SERVER_LOG_OOM,
-    )
-    state = _mock_state()
-    summary = _build_summary_dict(
-        state, ev_counts={}, highlights=[], session_dir=tmp_path,
-    )
+def test_build_summary_dict_attaches_failure_summary():
+    state = _failed_state(error_class="server_init_dead", error=_SERVER_LOG_OOM)
+    summary = _build_summary_dict(state, ev_counts={}, highlights=[])
+    assert summary["failure_summary"]["root_cause_type"] == "oom"
+
+
+def test_format_md_surfaces_root_cause():
+    state = _failed_state(error_class="server_init_dead", error=_SERVER_LOG_OOM)
+    summary = _build_summary_dict(state, ev_counts={}, highlights=[])
     md = _format_md(summary)
     assert "Root cause" in md
     assert "oom" in md


### PR DESCRIPTION
## Summary

Fixes #465.

On `baseline_failed`, the end-of-run summary (`final.json`, the Markdown report, and the stdout block) headlined a **benign upstream WARN** — e.g. transformers' `modeling_cohere2.py` `[Errno 2] No such file or directory` — instead of the **real terminal engine/worker fault** (OOM during `ncclCommInitRank`, `EngineCore failed to start`, etc.). Operators saw a misleading top-level error and had to dig through `server.log` to find the actual cause.

This PR surfaces the real root cause and demotes the benign WARN.

## Changes

- **`report.py` — `failure_summary` block**: on `baseline_failed`, read the most recent failed `runs/baseline/<task_id>/result.json` and lift its `error` / `error_class` into a compact `failure_summary`. When that error is missing or matches a known-benign WARN, fall back to scanning the attempt's `server.log` terminal marker via `server_log_death_excerpt`. Adds a coarse `root_cause_type` classifier (`oom` / `benchmark_timeout` / `engine_core_init` / `worker_crash` / `unknown`), plus `last_attempt_id`, `server_log` (session-relative), and `suppressed_benign`.
- **`report.py` — highlight denylist**: benign upstream WARNs are filtered out of event highlights so they can never become the top-level highlight. Full text still lives in the per-attempt logs.
- **`_format_md`**: render a `Root cause` + `Server log` line on failure runs.
- **`cli.py` — `_print_final_summary`**: reads `failure_summary` from `final.json` and prints `root_cause` / `server_log` on `baseline_failed`.

All new behaviour is gated on `stop_reason == "baseline_failed"` and is best-effort (never raises), so success/other-stop runs and legacy callers are unaffected.

## Test plan

- [x] New unit tests in `inference_optimizer/tests/test_baseline_failure_summary.py` (9 cases): result-error path, benign-WARN suppression + `server.log` fallback, latest-attempt selection, gating on stop reason / `session_dir`, classifier, highlight denylist, and Markdown rendering.
- [x] Existing `test_roofline_comparison_pipeline.py` (32 cases) still pass — `_build_summary_dict` signature change is backward compatible.
- [ ] CI on Linux (local Windows cannot import the package due to the Unix-only `fcntl` dependency in the import chain; tests were run locally with an `fcntl` stub).
