### PR TITLE
Support flat OOB source installs

### DIFF
--- a/inference_optimizer/SKILL.md
+++ b/inference_optimizer/SKILL.md
@@ -53,7 +53,7 @@ $USER_DATA_PATH/                          # workspace_root — set by operator /
 #   ${TMPDIR:-/tmp}/hyperloom/open-source-repos/{Magpie,TraceLens,GEAK,InferenceX}/
 #   TraceLens-internal is present only when TRACELENS_INTERNAL_ROOT is set
 #   OOB is NOT cloned: copied from $OOB_SRC (default $HYPERLOOM_BUNDLE/OOB)
-#   into open-source-repos/OOB/oob_cli
+#   into open-source-repos/OOB
 ├── logs/                                 # workspace-shared launcher stdout
 └── <model_basename>/                     # e.g. DeepSeek-R1-0528, deepseek-ai-DeepSeek-V3
     └── <UTC_YYYYMMDDTHHMMSSZ>/           # session_dir — manifest.json, state.json, runs/, …
@@ -338,7 +338,7 @@ of `inference_optimizer/install.sh`):
 | TraceLens public (editable install) | `ensure_tracelens` (`pip install -e` at `$TRACELENS_ROOT`; skills, patches, CLI, analysis orchestrator) |
 | TraceLens-internal (editable install, **optional**) | `ensure_tracelens` (`pip install -e` at `$TRACELENS_INTERNAL_ROOT` only when set; mirrors read-only checkout to `${HYPERLOOM_ROOT}/TraceLens-internal`; rehydration module). Unset => open-source-only. |
 | GEAK CLI + `${HYPERLOOM_RUNTIME_DIR}/geak-config/local.yaml` | `ensure_geak` |
-| Node.js/npm + OOB CLI + claude/codex npm CLIs + `@cursor/sdk` global install + `~/.claude/config.json` + `~/.codex/auth.json` | `ensure_node` + `ensure_oob` (mirrors `${HYPERLOOM_BUNDLE}/OOB` → `${HYPERLOOM_ROOT}/OOB/oob_cli`) |
+| Node.js/npm + OOB CLI + claude/codex npm CLIs + `@cursor/sdk` global install + `~/.claude/config.json` + `~/.codex/auth.json` | `ensure_node` + `ensure_oob` (mirrors `${HYPERLOOM_BUNDLE}/OOB` → `${HYPERLOOM_ROOT}/OOB`) |
 | `CURSOR_API_KEY` / `CURSOR_DEFAULT_MODEL` exported to `kernel-agent.env.sh` if set in env (cursor backend uses Cursor's own gateway). When `CURSOR_API_KEY` is unset, `cursor` is auto-skipped from default backend selection (`choose_backends` / `recommend_backends` / batch fallback ladder / `parallel_e2e_runner --backends` default); explicit user-supplied backends are still honored. | `write_env_file` |
 
 `${KERNEL_AGENT_ENV:-${USER_DATA_PATH:-/workspace/hyperloom}/runtime/kernel-agent.env.sh}` is

--- a/inference_optimizer/multi_node/scripts/install_oob_node.sh
+++ b/inference_optimizer/multi_node/scripts/install_oob_node.sh
@@ -21,8 +21,6 @@ OOB_INSTALL_SRC=""
 if [ -n "$OOB_SRC" ] && [ -d "$OOB_SRC" ]; then
   if [ -f "$OOB_SRC/pyproject.toml" ]; then
     OOB_INSTALL_SRC="$OOB_SRC"
-  elif [ -f "$OOB_SRC/oob_cli/pyproject.toml" ]; then
-    OOB_INSTALL_SRC="$OOB_SRC/oob_cli"
   fi
 fi
 

--- a/inference_optimizer/multi_node/scripts/install_oob_node.sh
+++ b/inference_optimizer/multi_node/scripts/install_oob_node.sh
@@ -17,6 +17,14 @@ set -uo pipefail
 OOB_SRC="${OOB_SRC:-}"
 PIP="/opt/venv/bin/pip"
 command -v "$PIP" >/dev/null 2>&1 || PIP="python3 -m pip"
+OOB_INSTALL_SRC=""
+if [ -n "$OOB_SRC" ] && [ -d "$OOB_SRC" ]; then
+  if [ -f "$OOB_SRC/pyproject.toml" ]; then
+    OOB_INSTALL_SRC="$OOB_SRC"
+  elif [ -f "$OOB_SRC/oob_cli/pyproject.toml" ]; then
+    OOB_INSTALL_SRC="$OOB_SRC/oob_cli"
+  fi
+fi
 
 # 1. Node.js / npm (NodeSource apt) — needed for claude/codex/@cursor CLIs.
 if ! command -v node >/dev/null 2>&1 || ! npm --version >/dev/null 2>&1; then
@@ -30,10 +38,10 @@ fi
 
 # 2. oob python CLI from the shared OOB_SRC checkout (no copy: NFS is shared).
 if ! command -v oob >/dev/null 2>&1; then
-  if [ -n "$OOB_SRC" ] && [ -d "$OOB_SRC" ]; then
-    [ -f "$OOB_SRC/requirements.txt" ] && \
-      $PIP install -q --no-cache-dir --break-system-packages -r "$OOB_SRC/requirements.txt" >/tmp/mn_oob_pip.log 2>&1 || true
-    $PIP install -q --no-cache-dir --break-system-packages "$OOB_SRC" >>/tmp/mn_oob_pip.log 2>&1 || true
+  if [ -n "$OOB_INSTALL_SRC" ]; then
+    [ -f "$OOB_INSTALL_SRC/requirements.txt" ] && \
+      $PIP install -q --no-cache-dir --break-system-packages -r "$OOB_INSTALL_SRC/requirements.txt" >/tmp/mn_oob_pip.log 2>&1 || true
+    $PIP install -q --no-cache-dir --break-system-packages "$OOB_INSTALL_SRC" >>/tmp/mn_oob_pip.log 2>&1 || true
   fi
 fi
 

--- a/inference_optimizer/tests/test_multi_node_scripts.py
+++ b/inference_optimizer/tests/test_multi_node_scripts.py
@@ -86,12 +86,13 @@ def test_kill_remote_missing_pid_dir():
     assert out == {"killed": [], "stale": [], "missing": []}
 
 
-def test_install_oob_node_accepts_wrapped_oob_src():
+def test_install_oob_node_uses_flat_oob_src():
     text = (
         _repo_root() / "multi_node" / "scripts" / "install_oob_node.sh"
     ).read_text(encoding="utf-8")
-    assert 'elif [ -f "$OOB_SRC/oob_cli/pyproject.toml" ]; then' in text
-    assert 'OOB_INSTALL_SRC="$OOB_SRC/oob_cli"' in text
+    assert 'if [ -f "$OOB_SRC/pyproject.toml" ]; then' in text
+    assert 'OOB_INSTALL_SRC="$OOB_SRC"' in text
+    assert '$OOB_SRC/oob_cli/pyproject.toml' not in text
     assert '$PIP install -q --no-cache-dir --break-system-packages "$OOB_INSTALL_SRC"' in text
 
 

--- a/inference_optimizer/tests/test_multi_node_scripts.py
+++ b/inference_optimizer/tests/test_multi_node_scripts.py
@@ -86,6 +86,15 @@ def test_kill_remote_missing_pid_dir():
     assert out == {"killed": [], "stale": [], "missing": []}
 
 
+def test_install_oob_node_accepts_wrapped_oob_src():
+    text = (
+        _repo_root() / "multi_node" / "scripts" / "install_oob_node.sh"
+    ).read_text(encoding="utf-8")
+    assert 'elif [ -f "$OOB_SRC/oob_cli/pyproject.toml" ]; then' in text
+    assert 'OOB_INSTALL_SRC="$OOB_SRC/oob_cli"' in text
+    assert '$PIP install -q --no-cache-dir --break-system-packages "$OOB_INSTALL_SRC"' in text
+
+
 def test_kill_remote_non_digit_pid_file_removed(tmp_path):
     km = _load_script_module("km_test_nondigit", "kill_multinode.py")
     d = tmp_path / "pids"

--- a/kernel-agent/SKILL.md
+++ b/kernel-agent/SKILL.md
@@ -364,7 +364,7 @@ repeat the manual install above.
 When `$TRACELENS_ROOT` or `$TRACELENS_INTERNAL_ROOT` is on a read-only mount,
 `ensure_tracelens` uses `$TRACELENS_ROOT` for the public checkout and mirrors
 the internal checkout to `$TRACELENS_MIRROR_DIR` when needed (parallel to
-`${GEAK_ROOT}` / `${OOB_CLI_ROOT}`) via `cp -r`, runs `pip install -e` against
+`${GEAK_ROOT}` / `${OOB_ROOT}`) via `cp -r`, runs `pip install -e` against
 the writable mirror, and `write_env_file` re-exports the resolved root so
 subsequent CLI subprocesses inherit the mirror. Treat these mirrors as
 installer-owned state; do not clone, clean, or edit them by hand.

--- a/kernel-agent/scripts/install.sh
+++ b/kernel-agent/scripts/install.sh
@@ -136,7 +136,7 @@ GEAK_ROOT="${GEAK_ROOT:-${_open_source_root}/GEAK}"
 # Operators can override with GEAK_REF=<tag|branch|sha>.
 GEAK_REF="${GEAK_REF:-ec61bdbdb151904ec187a8d89518afb969c53737}"
 OOB_SRC="${OOB_SRC:-${HYPERLOOM_BUNDLE}/OOB}"
-OOB_CLI_ROOT="${OOB_CLI_ROOT:-${_open_source_root}/OOB/oob_cli}"
+OOB_ROOT="${OOB_ROOT:-${OOB_CLI_ROOT:-${_open_source_root}/OOB}}"
 GEAK_CONFIG="${GEAK_CONFIG:-${HYPERLOOM_RUNTIME_DIR}/geak-config/local.yaml}"
 # GEAK talks to the AMD Primus-Safe LiteLLM-compatible /chat/completions
 # endpoint.  Force the LiteLLM provider prefix to `openai/` for bare Claude
@@ -796,7 +796,7 @@ ensure_tracelens() {
   # editable install in a subprocess on every trace_analyze request,
   # producing a tight failure loop. Detecting unwritable source up front
   # and mirroring to ${TRACELENS_MIRROR_DIR} (parallel to
-  # ${GEAK_ROOT} / ${OOB_CLI_ROOT}) lets both
+  # ${GEAK_ROOT} / ${OOB_ROOT}) lets both
   # the install-time and the runtime pip install land on a writable
   # filesystem. write_env_file() emits the resulting TRACELENS_INTERNAL_ROOT into
   # the pod-local kernel-agent env so subsequent CLI subprocesses inherit
@@ -1131,26 +1131,24 @@ ensure_oob() {
   log "ensuring OOB backend"
   local oob_install_src=""
   if [ "$DRY_RUN" -eq 0 ] && [ "$CHECK_ONLY" -eq 0 ]; then
-    mkdir -p "$(dirname "${OOB_CLI_ROOT}")"
+    mkdir -p "$(dirname "${OOB_ROOT}")"
   fi
   if ! command -v oob >/dev/null 2>&1; then
     if [ -d "$OOB_SRC" ]; then
       if [ -f "${OOB_SRC}/pyproject.toml" ]; then
         oob_install_src="$OOB_SRC"
-      elif [ -f "${OOB_SRC}/oob_cli/pyproject.toml" ]; then
-        oob_install_src="${OOB_SRC}/oob_cli"
       fi
       if [ -z "$oob_install_src" ]; then
-        warn "OOB source has no pyproject.toml at $OOB_SRC or $OOB_SRC/oob_cli"
+        warn "OOB source has no pyproject.toml at $OOB_SRC"
         return 0
       fi
-      if [ ! -d "${OOB_CLI_ROOT}" ]; then
-        run cp -r "$oob_install_src" "${OOB_CLI_ROOT}"
+      if [ ! -d "${OOB_ROOT}" ]; then
+        run cp -r "$oob_install_src" "${OOB_ROOT}"
       fi
-      if [ -f "${OOB_CLI_ROOT}/requirements.txt" ]; then
-        run python3 -m pip install -q --no-cache-dir --break-system-packages -r "${OOB_CLI_ROOT}/requirements.txt"
+      if [ -f "${OOB_ROOT}/requirements.txt" ]; then
+        run python3 -m pip install -q --no-cache-dir --break-system-packages -r "${OOB_ROOT}/requirements.txt"
       fi
-      run python3 -m pip install -q --no-cache-dir --break-system-packages "${OOB_CLI_ROOT}"
+      run python3 -m pip install -q --no-cache-dir --break-system-packages "${OOB_ROOT}"
     else
       warn "OOB source not found: $OOB_SRC"
     fi

--- a/kernel-agent/scripts/install.sh
+++ b/kernel-agent/scripts/install.sh
@@ -1140,15 +1140,19 @@ ensure_oob() {
       fi
       if [ -z "$oob_install_src" ]; then
         warn "OOB source has no pyproject.toml at $OOB_SRC"
-        return 0
+      else
+        if [ -d "${OOB_ROOT}" ] && [ ! -f "${OOB_ROOT}/pyproject.toml" ]; then
+          log "removing stale OOB install root without pyproject.toml: ${OOB_ROOT}"
+          run rm -rf "${OOB_ROOT}"
+        fi
+        if [ ! -d "${OOB_ROOT}" ]; then
+          run cp -r "$oob_install_src" "${OOB_ROOT}"
+        fi
+        if [ -f "${OOB_ROOT}/requirements.txt" ]; then
+          run python3 -m pip install -q --no-cache-dir --break-system-packages -r "${OOB_ROOT}/requirements.txt"
+        fi
+        run python3 -m pip install -q --no-cache-dir --break-system-packages "${OOB_ROOT}"
       fi
-      if [ ! -d "${OOB_ROOT}" ]; then
-        run cp -r "$oob_install_src" "${OOB_ROOT}"
-      fi
-      if [ -f "${OOB_ROOT}/requirements.txt" ]; then
-        run python3 -m pip install -q --no-cache-dir --break-system-packages -r "${OOB_ROOT}/requirements.txt"
-      fi
-      run python3 -m pip install -q --no-cache-dir --break-system-packages "${OOB_ROOT}"
     else
       warn "OOB source not found: $OOB_SRC"
     fi

--- a/kernel-agent/scripts/install.sh
+++ b/kernel-agent/scripts/install.sh
@@ -1129,13 +1129,23 @@ ensure_rag_index() {
 
 ensure_oob() {
   log "ensuring OOB backend"
+  local oob_install_src=""
   if [ "$DRY_RUN" -eq 0 ] && [ "$CHECK_ONLY" -eq 0 ]; then
     mkdir -p "$(dirname "${OOB_CLI_ROOT}")"
   fi
   if ! command -v oob >/dev/null 2>&1; then
     if [ -d "$OOB_SRC" ]; then
+      if [ -f "${OOB_SRC}/pyproject.toml" ]; then
+        oob_install_src="$OOB_SRC"
+      elif [ -f "${OOB_SRC}/oob_cli/pyproject.toml" ]; then
+        oob_install_src="${OOB_SRC}/oob_cli"
+      fi
+      if [ -z "$oob_install_src" ]; then
+        warn "OOB source has no pyproject.toml at $OOB_SRC or $OOB_SRC/oob_cli"
+        return 0
+      fi
       if [ ! -d "${OOB_CLI_ROOT}" ]; then
-        run cp -r "$OOB_SRC" "${OOB_CLI_ROOT}"
+        run cp -r "$oob_install_src" "${OOB_CLI_ROOT}"
       fi
       if [ -f "${OOB_CLI_ROOT}/requirements.txt" ]; then
         run python3 -m pip install -q --no-cache-dir --break-system-packages -r "${OOB_CLI_ROOT}/requirements.txt"

--- a/kernel-agent/tests/test_kernel_agent.py
+++ b/kernel-agent/tests/test_kernel_agent.py
@@ -233,6 +233,8 @@ class KernelAgentToolTests(unittest.TestCase):
         # implicitly move TraceLens/OOB via HYPERLOOM_ROOT.
         self.assertIn('GEAK_ROOT="${GEAK_ROOT:-${_open_source_root}/GEAK}"', install_text)
         self.assertIn('OOB_CLI_ROOT="${OOB_CLI_ROOT:-${_open_source_root}/OOB/oob_cli}"', install_text)
+        self.assertIn('elif [ -f "${OOB_SRC}/oob_cli/pyproject.toml" ]; then', install_text)
+        self.assertIn('oob_install_src="${OOB_SRC}/oob_cli"', install_text)
         # Override is read but never written into a generated env file.
         self.assertNotIn("export HYPERLOOM_OPEN_SOURCE_ROOT", install_text)
         # Assert the override pattern, not the exact pin, so ref bumps don't break this.

--- a/kernel-agent/tests/test_kernel_agent.py
+++ b/kernel-agent/tests/test_kernel_agent.py
@@ -234,7 +234,10 @@ class KernelAgentToolTests(unittest.TestCase):
         self.assertIn('GEAK_ROOT="${GEAK_ROOT:-${_open_source_root}/GEAK}"', install_text)
         self.assertIn('OOB_ROOT="${OOB_ROOT:-${OOB_CLI_ROOT:-${_open_source_root}/OOB}}"', install_text)
         self.assertIn('run cp -r "$oob_install_src" "${OOB_ROOT}"', install_text)
+        self.assertIn('removing stale OOB install root without pyproject.toml', install_text)
+        self.assertIn('run rm -rf "${OOB_ROOT}"', install_text)
         self.assertNotIn('${OOB_SRC}/oob_cli/pyproject.toml', install_text)
+        self.assertNotIn('warn "OOB source has no pyproject.toml at $OOB_SRC"\n        return 0', install_text)
         # Override is read but never written into a generated env file.
         self.assertNotIn("export HYPERLOOM_OPEN_SOURCE_ROOT", install_text)
         # Assert the override pattern, not the exact pin, so ref bumps don't break this.

--- a/kernel-agent/tests/test_kernel_agent.py
+++ b/kernel-agent/tests/test_kernel_agent.py
@@ -232,9 +232,9 @@ class KernelAgentToolTests(unittest.TestCase):
         # GEAK has a dedicated root so moving it to pod-local storage does not
         # implicitly move TraceLens/OOB via HYPERLOOM_ROOT.
         self.assertIn('GEAK_ROOT="${GEAK_ROOT:-${_open_source_root}/GEAK}"', install_text)
-        self.assertIn('OOB_CLI_ROOT="${OOB_CLI_ROOT:-${_open_source_root}/OOB/oob_cli}"', install_text)
-        self.assertIn('elif [ -f "${OOB_SRC}/oob_cli/pyproject.toml" ]; then', install_text)
-        self.assertIn('oob_install_src="${OOB_SRC}/oob_cli"', install_text)
+        self.assertIn('OOB_ROOT="${OOB_ROOT:-${OOB_CLI_ROOT:-${_open_source_root}/OOB}}"', install_text)
+        self.assertIn('run cp -r "$oob_install_src" "${OOB_ROOT}"', install_text)
+        self.assertNotIn('${OOB_SRC}/oob_cli/pyproject.toml', install_text)
         # Override is read but never written into a generated env file.
         self.assertNotIn("export HYPERLOOM_OPEN_SOURCE_ROOT", install_text)
         # Assert the override pattern, not the exact pin, so ref bumps don't break this.


### PR DESCRIPTION
## Summary
- Update Hyperloom's OOB install path to use the flat OOB source root by default, aligning OOB with GEAK/TraceLens/Magpie installs.
- Keep `OOB_CLI_ROOT` as a legacy override alias while defaulting to `${_open_source_root}/OOB`.
- Update multi-node OOB installation and docs/tests to match the flat OOB layout.

## Test plan
- `bash -n kernel-agent/scripts/install.sh`
- `bash -n inference_optimizer/multi_node/scripts/install_oob_node.sh`
- `python3 -m pytest kernel-agent/tests/test_kernel_agent.py inference_optimizer/tests/test_multi_node_scripts.py -q -p no:cacheprovider`
- `python3 -m pytest kernel-agent/tools/test_backend_submit_dispatch_gate.py kernel-agent/tools/test_geak_submit_imports.py -q -p no:cacheprovider`
- Simulated copying a flat OOB source into the target install root.


Made with [Cursor](https://cursor.com)