### PR TITLE
Track GEAK main branch instead of pinned commit

### DIFF
--- a/kernel-agent/SKILL.md
+++ b/kernel-agent/SKILL.md
@@ -78,7 +78,7 @@ bash "$REPO_ROOT/kernel-agent/scripts/install.sh"
   `TraceLens_generate_perf_report_pytorch_inference --help`
   (Hyperloom is inference-only since v0.4; the training-mode CLI is no
   longer accepted)
-- GEAK CLI from `GEAK_REF` (default `v3.2.0`) +
+- GEAK CLI from `GEAK_REF` (default `main`) +
   `${HYPERLOOM_RUNTIME_DIR}/geak-config/local.yaml` (model resolution:
   `GEAK_MODEL_NAME` / `GEAK_API_KEY` / `GEAK_BASE_URL` from env, default
   `claude-opus-4-7`). Run-mode default for the generated yaml is

--- a/kernel-agent/scripts/install.sh
+++ b/kernel-agent/scripts/install.sh
@@ -126,15 +126,11 @@ if [ -z "${SAFE_API_KEY:-}" ] || [ -z "${OPENAI_BASE_URL:-}" ] || [ -z "${CURSOR
 fi
 GEAK_REPO="${GEAK_REPO:-https://github.com/AMD-AGI/GEAK.git}"
 GEAK_ROOT="${GEAK_ROOT:-${_open_source_root}/GEAK}"
-# Pin GEAK to the save-and-test-diff-fallthrough fix tip
-# (https://github.com/AMD-AGI/GEAK/pull/244, not yet released as a tag).
-# We pin to the *commit SHA* of the branch tip, NOT the branch name, so a
-# future force-push / rebase upstream cannot silently change what every
-# fresh install gets.
-# TODO(post-GEAK-PR-244): once PR #244 lands and ships in a new GEAK tag,
-# revert this pin to the tag (e.g. v3.2.1) for stronger discoverability.
-# Operators can override with GEAK_REF=<tag|branch|sha>.
-GEAK_REF="${GEAK_REF:-ec61bdbdb151904ec187a8d89518afb969c53737}"
+# Track the GEAK `main` branch so fresh installs pick up the latest upstream
+# tip at install time. Note: tracking a branch (rather than a pinned commit
+# SHA) is not reproducible -- a force-push / rebase upstream changes what an
+# install gets. Operators can pin a specific ref with GEAK_REF=<tag|branch|sha>.
+GEAK_REF="${GEAK_REF:-main}"
 OOB_SRC="${OOB_SRC:-${HYPERLOOM_BUNDLE}/OOB}"
 OOB_ROOT="${OOB_ROOT:-${OOB_CLI_ROOT:-${_open_source_root}/OOB}}"
 GEAK_CONFIG="${GEAK_CONFIG:-${HYPERLOOM_RUNTIME_DIR}/geak-config/local.yaml}"


### PR DESCRIPTION
## Summary
- Change `GEAK_REF` default in `kernel-agent/scripts/install.sh` from the PR #244 commit SHA (`ec61bdbd...`) to the `main` branch, so fresh installs pick up the latest upstream GEAK tip at install time.
- Update the surrounding comment to note the reproducibility trade-off (branch tracking is not reproducible; operators can still pin with `GEAK_REF=<tag|branch|sha>`).
- Update `kernel-agent/SKILL.md` to reflect the new default (`main`, was the stale `v3.2.0`).

The existing install logic already handles a branch ref: a non-SHA `GEAK_REF` falls to the `git clone --depth 1 --branch "$GEAK_REF"` path, so no clone-logic change is needed.

Closes #555

## Test plan
- [ ] `kernel-agent/tests/test_kernel_agent.py` still passes (asserts the `GEAK_REF="${GEAK_REF:-` override pattern, not the exact value)
- [ ] Run `kernel-agent/scripts/install.sh` and confirm GEAK clones at `main` HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)