### PR TITLE
feat(session-breakdown): proposer attribution + operation_kind across timeline & trace

### DIFF
--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -19,6 +19,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
+from ..orchestrator.optimization_journal import (
+    classify_change_kind,
+    operation_kind_for,
+    proposer_for,
+)
+
 log = logging.getLogger(__name__)
 
 
@@ -1348,6 +1354,19 @@ def _journal_entry_to_event(e: dict[str, Any]) -> dict[str, Any]:
         action = kind
     else:
         action = change or kind or "other"
+    provenance = str(e.get("provenance") or "")
+    extras = {k: v for k, v in (
+        ("variant_name", e.get("variant_name")),
+        ("reason", e.get("reason")),
+        # Proposer attribution + stable filter label, threaded so the timeline
+        # answers "what / how / who" for each step.
+        ("provenance", provenance),
+        ("proposer", proposer_for(provenance) if provenance else ""),
+        ("scope", str(e.get("scope") or "")),
+        ("fingerprint", str(e.get("fingerprint") or "")),
+        ("operation_kind", operation_kind_for(action, kind)),
+        ("metrics", e.get("metrics") if isinstance(e.get("metrics"), dict) else None),
+    ) if v}
     return {
         "ts":              _iso_z(e.get("ts")),
         "action":          action,
@@ -1361,10 +1380,7 @@ def _journal_entry_to_event(e: dict[str, Any]) -> dict[str, Any]:
         "error_class":     e.get("error_class"),
         "phase":           str(e.get("phase") or ""),
         "change":          change,
-        "extras":          {k: v for k, v in (
-            ("variant_name", e.get("variant_name")),
-            ("reason", e.get("reason")),
-        ) if v},
+        "extras":          extras,
     }
 
 
@@ -2671,15 +2687,31 @@ def _shape_ledger(
         """
         if not isinstance(e, dict):
             return {}
-        return {
+        args = str(e.get("extra_server_args") or "")
+        envs = dict(e.get("extra_envs") or {})
+        provenance = str(e.get("provenance") or "")
+        # Classify the variant into a stable operation_kind (backend/param/env)
+        # so the ledger can be filtered the same way as the timeline / trace.
+        change_kind = classify_change_kind(
+            "explore", {"extra_server_args": args, "extra_envs": envs},
+        )
+        shaped = {
             "name":              str(e.get("name") or ""),
             "fingerprint":       str(e.get("fingerprint") or ""),
-            "extra_server_args": str(e.get("extra_server_args") or ""),
-            "extra_envs":        dict(e.get("extra_envs") or {}),
+            "extra_server_args": args,
+            "extra_envs":        envs,
             "output_throughput": _to_float(e.get("output_throughput") or e.get("tput")),
             "gain_pct":          _to_float(e.get("gain_pct")),
             "ts":                str(e.get("ts") or ""),
+            "operation_kind":    operation_kind_for("explore", change_kind),
         }
+        if provenance:
+            shaped["provenance"] = provenance
+            shaped["proposer"] = proposer_for(provenance)
+        scope = str(e.get("scope") or "")
+        if scope:
+            shaped["scope"] = scope
+        return shaped
 
     accepted = [_shape_entry(e) for e in ledger.get("accepted") or []]
     rejected = [_shape_entry(e) for e in ledger.get("rejected") or []]
@@ -5144,6 +5176,38 @@ def collect_langfuse(
     }
 
 
+def _proposal_scores_by_variant(state: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
+    """Index ``specialist_rounds[].ensemble_scores`` by variant name.
+
+    Returns ``{variant_name: [{rater, score, reason}, ...]}`` so a decision row
+    can show who scored the proposal and how (the proposal_scorer signal that
+    fed the KEEP/REVERT). Best-effort: shape drift yields an empty map.
+    """
+    out: dict[str, list[dict[str, Any]]] = {}
+    rounds = state.get("specialist_rounds")
+    if not isinstance(rounds, list):
+        return out
+    for r in rounds:
+        if not isinstance(r, dict):
+            continue
+        ens = r.get("ensemble_scores")
+        models = ens.get("models") if isinstance(ens, dict) else None
+        if not isinstance(models, dict):
+            continue
+        for slug, per_model in models.items():
+            if not isinstance(per_model, dict):
+                continue
+            for name, cell in per_model.items():
+                if not isinstance(cell, dict) or cell.get("score") is None:
+                    continue
+                out.setdefault(str(name), []).append({
+                    "rater": str(slug),
+                    "score": _to_float(cell.get("score")),
+                    "reason": str(cell.get("reason") or ""),
+                })
+    return out
+
+
 def collect_decision_trace(
     session_dir: Path,
     state: dict[str, Any],
@@ -5170,6 +5234,7 @@ def collect_decision_trace(
     """
     calls = _load_llm_calls(session_dir, warnings)
     phase_windows = _build_phase_windows(state)
+    scores_by_variant = _proposal_scores_by_variant(state)
 
     # ── Index calls by decision key; orphans (no key) go to a ts list ──
     calls_by_key: dict[str, list[dict[str, Any]]] = {}
@@ -5192,19 +5257,47 @@ def collect_decision_trace(
         key = _decision_key(task_id, "")
         ts = _iso_z(e.get("ts"))
         phase = str(e.get("phase") or "").strip() or _phase_at(ts, phase_windows)
+        provenance = str(e.get("provenance") or "")
+        change_kind = str(e.get("kind") or "")
+        # ``component`` is now the real proposer (specialist:<domain> / grid /
+        # orchestration) derived from provenance, not a hard-coded constant, so
+        # the decision timeline answers "who proposed this".
+        decision: dict[str, Any] = {
+            "component": proposer_for(provenance) if provenance else "orchestration",
+            "change": str(e.get("change") or ""),
+            "outcome": str(e.get("outcome") or ""),
+            "gain_pct": _to_float(e.get("gain_pct")),
+            "task_id": task_id,
+            "operation_kind": operation_kind_for("", change_kind),
+        }
+        if change_kind:
+            decision["kind"] = change_kind
+        if provenance:
+            decision["provenance"] = provenance
+        scope = str(e.get("scope") or "")
+        if scope:
+            decision["scope"] = scope
+        fingerprint = str(e.get("fingerprint") or "")
+        if fingerprint:
+            decision["fingerprint"] = fingerprint
+        detail_metrics = e.get("metrics")
+        if isinstance(detail_metrics, dict) and detail_metrics:
+            decision["metrics"] = detail_metrics
+        variant_name = str(e.get("variant_name") or "")
+        if variant_name:
+            decision["variant_name"] = variant_name
+            # Attach the proposal_scorer signal (who rated this proposal, how)
+            # so the decision step answers "was it scored, by whom, how high".
+            scored = scores_by_variant.get(variant_name)
+            if scored:
+                decision["proposal_scores"] = scored
         decisions.append({
             "kind": "keep_revert",
             "key": key,
             "phase": phase,
             "tick": e.get("tick"),
             "ts": ts,
-            "decision": {
-                "component": "orchestration",
-                "change": str(e.get("change") or ""),
-                "outcome": str(e.get("outcome") or ""),
-                "gain_pct": _to_float(e.get("gain_pct")),
-                "task_id": task_id,
-            },
+            "decision": decision,
         })
     for row in _load_dispatch_history_all(session_dir, warnings):
         dyn_id = str(row.get("dyn_id") or "")
@@ -5219,6 +5312,7 @@ def collect_decision_trace(
             "ts": ts,
             "decision": {
                 "component": "dynamic_action",
+                "operation_kind": "dynamic_action",
                 "event": str(row.get("event") or ""),
                 "dyn_id": dyn_id,
                 "verdict": row.get("verdict"),

--- a/inference_optimizer/breakdown/schema.py
+++ b/inference_optimizer/breakdown/schema.py
@@ -255,7 +255,13 @@ class PhaseEvent(TypedDict, total=False):
         key_metric_kind (str | None): Type/label of the key metric, or None.
         workspace (str | None): Benchmark workspace path, or None.
         error_class (str | None): Error classification on failure, or None.
-        extras (dict[str, Any]): Action-specific extra fields.
+        extras (dict[str, Any]): Action-specific extra fields. For journal-sourced
+            events this carries proposer attribution and a filter label:
+            ``provenance`` (raw explore label), ``proposer`` (resolved component:
+            ``specialist:<domain>`` / ``grid`` / ``orchestration``), ``scope``,
+            ``fingerprint``, ``operation_kind`` (``backend`` / ``param`` / ``env``
+            / ``kernel_opt`` / ``kernel_integrate`` / ``baseline`` / ...), and
+            ``metrics`` (per-variant measurement detail).
     """
     ts: str
     action: str                   # baseline / profile / backends / params / sweep / validate_stack / kernel_opt / trace_analyze / integrate
@@ -735,6 +741,13 @@ class ParamSearchEntry(TypedDict, total=False):
         gain_pct (float | None): Gain percent vs current best, or None.
         ts (str): ISO UTC timestamp of evaluation.
         status (str): Outcome (``accepted`` / ``rejected`` / ``tested``).
+        operation_kind (str): Filter label for the variant's change type
+            (``backend`` / ``param`` / ``env``).
+        provenance (str): Raw explore proposer label (``llm_direct`` /
+            ``default_grid`` / ``specialist:<domain>``).
+        proposer (str): Resolved proposer/component (``specialist:<domain>`` /
+            ``grid`` / ``orchestration``).
+        scope (str): Specialist dial (``domain`` / ``domains`` / ``freeform``).
     """
     name: str
     fingerprint: str
@@ -744,6 +757,10 @@ class ParamSearchEntry(TypedDict, total=False):
     gain_pct: float | None
     ts: str
     status: str                   # accepted / rejected / tested
+    operation_kind: str           # backend / param / env
+    provenance: str
+    proposer: str
+    scope: str
 
 
 class ParamSearchLedger(TypedDict, total=False):
@@ -1371,6 +1388,10 @@ class OptimizationStackEntry(TypedDict, total=False):
     fingerprint: str
     provenance: str
     task_id: str
+    # filter label for the kind of optimization (backend / param / env on
+    # explore KEEPs); specialist dial.
+    operation_kind: str
+    scope: str
 
 
 # Kernel Roofline — hot-kernel table for the dashboard, mirroring
@@ -1476,7 +1497,12 @@ class DecisionTraceEntry(TypedDict, total=False):
     phase: str                             # phase active at the decision (declared or ts-window backfill)
     tick: int | None                       # orchestrator tick (None when the producer didn't stamp one)
     ts: str                                # ISO ...Z of the decision
-    decision: dict[str, Any]               # {component, change/event/verdict, outcome, gain_pct, task_id/dyn_id}
+    # ``decision`` now carries proposer attribution + a filter label:
+    # {component (resolved proposer: specialist:<domain> / grid / orchestration),
+    #  operation_kind (backend / param / env / kernel_opt / kernel_integrate / ...),
+    #  change/event/verdict, outcome, gain_pct, task_id/dyn_id,
+    #  kind, provenance, scope, fingerprint, metrics}
+    decision: dict[str, Any]
     tokens: DecisionTokens
 
 

--- a/inference_optimizer/orchestrator/action_executors/explore.py
+++ b/inference_optimizer/orchestrator/action_executors/explore.py
@@ -1020,6 +1020,7 @@ class ExploreExecutor:
                         "round_id": round_id,
                         "ts": _now_iso(),
                         "provenance": provenance,
+                        "scope": scope,
                         "workload_signature": ws_sig,
                         "framework": framework,
                         "workspace": r.workspace,
@@ -1279,8 +1280,18 @@ class ExploreExecutor:
                 "outcome":      outcome,
                 "fingerprint":  fp_key,
                 "provenance":   str(te.get("provenance") or ""),
+                "scope":        str(te.get("scope") or ""),
                 "metrics":      metrics,
                 "reason":       reasons_by_fp.get(fp_key, ""),
+                # Carry the variant knobs so the journal can classify the change
+                # kind (backend / param / env) at decision-write time -- without
+                # this dict ``classify_change_kind`` always falls back to OTHER.
+                "variant": {
+                    "name":              str(te.get("name") or ""),
+                    "extra_server_args": str(te.get("extra_server_args") or ""),
+                    "extra_envs":        dict(te.get("extra_envs") or {}),
+                    "note":              str(te.get("note") or ""),
+                },
             })
         for sd in skipped_dup:
             per_variant_outcomes.append({

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -41,6 +41,7 @@ from .optimization_journal import (
     OUTCOME_NO_PROMOTE,
     OUTCOME_REVERT,
     classify_change_kind,
+    operation_kind_for,
     summarize_change,
 )
 from ..paths import db_path_for
@@ -8301,6 +8302,17 @@ class Coordinator:
         if outcome == OUTCOME_REVERT:
             error_class = (str(variant_outcome.get("error_class") or "") or None)
             reason = (str(variant_outcome.get("reason") or "") or None)
+        # Proposer attribution + per-variant measurement detail, carried from the
+        # explore executor's per_variant_outcomes so the decision row records who
+        # proposed the change and how it measured (beyond headline gain/tput).
+        detail_metrics = {
+            k: metrics[k]
+            for k in (
+                "runtime_sec", "wall_clock_ratio_vs_baseline",
+                "stack_rebench_tput", "estimated_output_throughput",
+            )
+            if isinstance(metrics, dict) and metrics.get(k) is not None
+        }
         journal.append_entry(JournalEntry(
             phase=self._journal_entry_phase(),
             iter=int(self.shared_state.tick or 0),
@@ -8313,6 +8325,10 @@ class Coordinator:
             reason=reason,
             task_id=task.task_id,
             variant_name=variant_name,
+            provenance=str(variant_outcome.get("provenance") or ""),
+            scope=str(variant_outcome.get("scope") or ""),
+            fingerprint=str(variant_outcome.get("fingerprint") or ""),
+            metrics=detail_metrics,
             tick=int(self.shared_state.tick or 0),
         ))
 
@@ -8903,6 +8919,23 @@ class Coordinator:
                     stack_entry["fingerprint"] = fp_val
                 if prov_val:
                     stack_entry["provenance"] = prov_val
+                # Stable filter label for "what kind of optimization" (backend /
+                # param / env), so the stack can be sliced like the timeline.
+                _stack_envs = (
+                    dict(bv.get("extra_envs") or {}) if isinstance(bv, dict) else {}
+                )
+                stack_entry["operation_kind"] = operation_kind_for(
+                    task_kind,
+                    classify_change_kind(
+                        task_kind,
+                        {"extra_server_args": candidate_args, "extra_envs": _stack_envs},
+                    ),
+                )
+                _stack_scope = (
+                    str(bv.get("scope") or "").strip() if isinstance(bv, dict) else ""
+                )
+                if _stack_scope:
+                    stack_entry["scope"] = _stack_scope
                 self.shared_state.optimization_stack.append(stack_entry)
                 # Mirror append into gain_per_stack_entry so the two parallel lists stay index-aligned.
                 self.shared_state.append_stack_gain_entry(

--- a/inference_optimizer/orchestrator/optimization_journal.py
+++ b/inference_optimizer/orchestrator/optimization_journal.py
@@ -73,6 +73,18 @@ class JournalEntry:
     task_id:           str = ""
     variant_name:      str = ""
     ts:                str = ""
+    # Proposer attribution (who proposed this change). ``provenance`` is the raw
+    # explore label (``llm_direct`` / ``default_grid`` / ``specialist:<domain>``);
+    # ``scope`` is the orthogonal specialist dial (domain / domains / freeform);
+    # ``fingerprint`` is the variant join key into ``explore_search``. All empty
+    # on non-explore rows and on legacy journals (stripped by ``to_dict``).
+    provenance:        str = ""
+    scope:             str = ""
+    fingerprint:       str = ""
+    # Per-variant measurement detail beyond the headline gain/throughput
+    # (runtime_sec / wall_clock_ratio_vs_baseline / stack_rebench_tput /
+    # estimated_output_throughput). Empty dict stripped by ``to_dict``.
+    metrics:           dict[str, Any] = field(default_factory=dict)
     # Full-trace D1: orchestrator tick at the moment of decision. Lets the
     # decision-trace collector join this KEEP/REVERT row to the LLM calls
     # recorded for the same tick. Defaults to ``None`` (not 0) so older
@@ -89,7 +101,12 @@ class JournalEntry:
                 removed.
         """
         raw = dataclasses.asdict(self)
-        return {k: v for k, v in raw.items() if v is not None and v != ""}
+        # Strip None, empty strings, and empty containers ({} / []) so the file
+        # stays compact and byte-diffable (an unset ``metrics`` dict vanishes).
+        return {
+            k: v for k, v in raw.items()
+            if v is not None and v != "" and v != {} and v != []
+        }
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> JournalEntry:
@@ -114,6 +131,10 @@ class JournalEntry:
             task_id=str(d.get("task_id", "")),
             variant_name=str(d.get("variant_name", "")),
             ts=str(d.get("ts", "")),
+            provenance=str(d.get("provenance", "")),
+            scope=str(d.get("scope", "")),
+            fingerprint=str(d.get("fingerprint", "")),
+            metrics=dict(d.get("metrics") or {}),
             tick=_optional_int(d.get("tick")),
         )
 
@@ -305,6 +326,50 @@ def classify_change_kind(task_kind: str, variant: dict[str, Any] | None = None) 
         if args:
             return KIND_PARAM
     return KIND_OTHER
+
+
+# operation_kind: a single stable, filterable label for "what this step did".
+# Reuses the change-kind vocabulary but renames the two kernel kinds to the
+# action names dashboards/traces filter on, and falls back to the raw action
+# for non-explore steps (baseline / profile / roofline / sweep / framework_pr).
+_OP_KIND_RENAME: dict[str, str] = {
+    KIND_KERNEL_FILE: "kernel_opt",
+    KIND_INTEGRATE:   "kernel_integrate",
+}
+
+
+def operation_kind_for(action: str, kind: str = "") -> str:
+    """Map an (action, change-kind) pair to a stable ``operation_kind`` label.
+
+    Examples: explore ``backend`` / ``param`` / ``env``; kernel ``kernel_opt`` /
+    ``kernel_integrate``; ``baseline`` / ``profile`` / ``roofline`` / ``sweep``.
+    Prefers the fine change-kind, falling back to the action when the kind is
+    absent or ``other``.
+    """
+    k = (kind or "").lower()
+    if k and k != KIND_OTHER:
+        return _OP_KIND_RENAME.get(k, k)
+    a = (action or "").lower()
+    if a in ("kernel_opt", "deep_kernel_analysis", "operator_tuning"):
+        return "kernel_opt"
+    if a == "integrate":
+        return "kernel_integrate"
+    return a or KIND_OTHER
+
+
+def proposer_for(provenance: str) -> str:
+    """Map an explore ``provenance`` label to a stable proposer/component name.
+
+    ``specialist:<domain>`` is kept verbatim (so a trace can filter on the exact
+    specialist); ``llm_direct`` / ``legacy:*`` / empty collapse to
+    ``orchestration``; ``default_grid`` becomes ``grid``.
+    """
+    p = (provenance or "").strip()
+    if not p or p == "llm_direct" or p.startswith("legacy:"):
+        return "orchestration"
+    if p == "default_grid":
+        return "grid"
+    return p
 
 
 def summarize_change(

--- a/inference_optimizer/orchestrator/trace/langfuse_emitter.py
+++ b/inference_optimizer/orchestrator/trace/langfuse_emitter.py
@@ -770,23 +770,98 @@ class LangfuseEmitter:
         missing), it falls back to a trace-level score.
         """
         for drow in _load_jsonl(decision_trace_path(self.session_dir)):
-            for score in lfmap.decision_to_scores(drow):
-                meta = score.get("metadata") or {}
-                phase = str(meta.get("phase") or lfmap.UNPHASED)
-                agent = str(meta.get("component") or lfmap.UNKNOWN_AGENT)
-                self._create_score(score, phase=phase, agent=agent)
+            scores = lfmap.decision_to_scores(drow)
+            if not scores:
+                continue
+            meta0 = scores[0].get("metadata") or {}
+            phase = str(meta0.get("phase") or lfmap.UNPHASED)
+            agent = self._span_agent_for(str(meta0.get("component") or ""))
+            # Per-decision span carrying ``operation_kind`` (+ proposer / effect)
+            # so the trace can be filtered by "what this step did". Scores attach
+            # to this step span when it opens, else to the owning agent span.
+            step_span = self._open_decision_span(drow, phase, agent)
+            for score in scores:
+                self._create_score(
+                    score, phase=phase, agent=agent, span=step_span,
+                )
+            if step_span is not None:
+                self._safe_end(step_span)
+
+    @staticmethod
+    def _span_agent_for(proposer: str) -> str:
+        """Map a resolved proposer back to a span-attachable agent name.
+
+        ``specialist:<domain>`` collapses to the ``specialist`` agent span and
+        ``grid`` to ``orchestration`` (grid proposals are orchestration-driven),
+        so the per-decision score still lands under a real agent span instead of
+        always falling back to the trace level.
+        """
+        p = (proposer or "").strip()
+        if p.startswith("specialist:"):
+            return "specialist"
+        if p == "grid":
+            return "orchestration"
+        return p or lfmap.UNKNOWN_AGENT
+
+    def _open_decision_span(
+        self, drow: dict[str, Any], phase: str, agent: str,
+    ) -> Any:
+        """Open an ``optimization_step:<operation_kind>`` span for one decision.
+
+        Parented to the owning agent span (then phase span, then root). Carries
+        operation_kind + proposer + effect in metadata so dashboards/Langfuse can
+        filter steps directly. Returns the span, or ``None`` when no parent is
+        open or the SDK rejects the call (best-effort; never raises).
+        """
+        parent = (
+            self._agent_spans.get((phase, agent))
+            or self._phase_spans.get(phase)
+            or self._root_span
+        )
+        if parent is None:
+            return None
+        dec = drow.get("decision") or {}
+        op_kind = str(dec.get("operation_kind") or "decision")
+        md = {
+            "operation_kind": op_kind,
+            "proposer": dec.get("component"),
+            "provenance": dec.get("provenance"),
+            "scope": dec.get("scope"),
+            "change": dec.get("change"),
+            "outcome": dec.get("outcome"),
+            "gain_pct": dec.get("gain_pct"),
+            "variant_name": dec.get("variant_name"),
+            "fingerprint": dec.get("fingerprint"),
+            "task_id": dec.get("task_id"),
+            "phase": phase,
+            "tick": drow.get("tick"),
+            "metrics": dec.get("metrics"),
+            "proposal_scores": dec.get("proposal_scores"),
+        }
+        md = {k: v for k, v in md.items() if v is not None}
+        try:
+            return _start_obs(
+                parent, name=f"optimization_step:{op_kind}",
+                as_type="span", metadata=md,
+            )
+        except Exception:  # noqa: BLE001
+            log.debug("langfuse: open decision span failed", exc_info=True)
+            return None
 
     def _create_score(
         self, score: dict[str, Any], *, phase: str, agent: str,
+        span: Any = None,
     ) -> None:
-        """Attach a Langfuse Score to the owning agent span or the trace.
+        """Attach a Langfuse Score to a step span / agent span / the trace.
 
         Args:
             score: Score payload (``name``, ``value``, ``data_type``, ...).
             phase: Phase that owns the decision, used to locate the span.
             agent: Agent/component that owns the decision.
+            span: Optional pre-opened step span; preferred over the agent span.
         """
-        span = self._agent_spans.get((phase, agent))
+        if span is None:
+            span = self._agent_spans.get((phase, agent))
         try:
             if span is not None and hasattr(span, "score"):
                 span.score(

--- a/inference_optimizer/orchestrator/trace/langfuse_mapping.py
+++ b/inference_optimizer/orchestrator/trace/langfuse_mapping.py
@@ -212,7 +212,19 @@ def decision_to_scores(decision_row: dict[str, Any]) -> list[dict[str, Any]]:
         "change": dec.get("change"),
         "component": dec.get("component"),
         "task_id": dec.get("task_id"),
+        # Proposer attribution + filter label so a trace can be sliced by
+        # "what this step did" (operation_kind) and "who proposed it".
+        "operation_kind": dec.get("operation_kind"),
+        "proposer": dec.get("component"),
+        "provenance": dec.get("provenance"),
+        "scope": dec.get("scope"),
+        "variant_name": dec.get("variant_name"),
+        "fingerprint": dec.get("fingerprint"),
+        "metrics": dec.get("metrics"),
+        "proposal_scores": dec.get("proposal_scores"),
     }
+    # Drop keys the decision didn't carry so the score metadata stays compact.
+    meta = {k: v for k, v in meta.items() if v is not None}
     comment = str(dec.get("change") or "")
     scores: list[dict[str, Any]] = [{
         "name": "decision_outcome",

--- a/inference_optimizer/scripts/backfill_langfuse.py
+++ b/inference_optimizer/scripts/backfill_langfuse.py
@@ -400,11 +400,22 @@ def ingest(plan: dict[str, Any]) -> int:
         _end_obs(ra_span, (max(ra_times) if ra_times else None) or trace_start)
 
     # Decision scores -> the owning agent span (trace-level fallback).
+    # ``component`` is the resolved proposer (specialist:<domain> / grid /
+    # orchestration); normalise it back to a span-attachable agent so the score
+    # still lands under a real agent span. operation_kind rides in score metadata.
+    def _span_agent_for(proposer: str) -> str:
+        p = (proposer or "").strip()
+        if p.startswith("specialist:"):
+            return "specialist"
+        if p == "grid":
+            return "orchestration"
+        return p or lfmap.UNKNOWN_AGENT
+
     for i, drow in enumerate(plan["decisions"]):
         for score in lfmap.decision_to_scores(drow):
             meta = score.get("metadata") or {}
             phase = str(meta.get("phase") or lfmap.UNPHASED)
-            agent = str(meta.get("component") or lfmap.UNKNOWN_AGENT)
+            agent = _span_agent_for(str(meta.get("component") or ""))
             span = agent_spans.get((phase, agent))
             try:
                 if span is not None and hasattr(span, "score"):

--- a/inference_optimizer/tests/test_langfuse_emitter.py
+++ b/inference_optimizer/tests/test_langfuse_emitter.py
@@ -488,32 +488,41 @@ def test_flush_creates_decision_scores(tmp_path, monkeypatch):
     dtrace.write_text(
         json.dumps({
             "decision": {"change": "tp_sweep", "component": "kernel",
+                         "operation_kind": "kernel_opt",
                          "outcome": "KEEP", "gain_pct": 12.5, "task_id": "k1"},
             "phase": "KERNEL", "tick": 5, "ts": "2026-06-09T16:00:00Z",
         }) + "\n"
         + json.dumps({
-            "decision": {"change": "radix", "component": "orchestration",
+            "decision": {"change": "radix", "component": "grid",
+                         "operation_kind": "param", "provenance": "default_grid",
                          "outcome": "REVERT", "gain_pct": None, "task_id": "t2"},
             "phase": "EXPLORE", "tick": 6, "ts": "2026-06-09T16:05:00Z",
         }) + "\n",
         encoding="utf-8",
     )
     em = lfe.LangfuseEmitter(sd)
-    # Create an agent span for (KERNEL, kernel) so its decision attaches there;
-    # the (EXPLORE, orchestration) decision has no span -> trace-level fallback.
+    # Create an agent span for (KERNEL, kernel) so its step span parents there.
     em.record_llm_call(_llm_row(phase="KERNEL", component="kernel", role="kernel"))
     em.record_conversation(_conv_row(phase="KERNEL", component="kernel", role="kernel"))
     em.flush_session()
 
+    # Each decision now opens an ``optimization_step:<operation_kind>`` span,
+    # tagged with operation_kind in metadata, and its scores attach to it.
+    kernel_step = client.span_named("optimization_step:kernel_opt")
+    param_step = client.span_named("optimization_step:param")
+    assert kernel_step is not None
+    assert kernel_step.kwargs["metadata"]["operation_kind"] == "kernel_opt"
+    assert param_step is not None
+    assert param_step.kwargs["metadata"]["operation_kind"] == "param"
+    assert param_step.kwargs["metadata"]["provenance"] == "default_grid"
+
+    # KERNEL KEEP w/ gain -> decision_outcome + gain_pct; EXPLORE REVERT -> 1.
     span_score_names = sorted(s["name"] for s in client.observation_scores)
-    trace_score_names = sorted(s["name"] for s in client.scores)
-    # KERNEL/kernel KEEP w/ gain -> 2 span-level scores.
-    assert span_score_names == ["decision_outcome", "gain_pct"]
-    # EXPLORE/orchestration REVERT w/o gain -> 1 trace-level fallback score.
-    assert trace_score_names == ["decision_outcome"]
+    assert span_score_names == ["decision_outcome", "decision_outcome", "gain_pct"]
     gain = [s for s in client.observation_scores if s["name"] == "gain_pct"][0]
     assert gain["value"] == 12.5
     assert gain["data_type"] == "NUMERIC"
+    assert gain["metadata"]["operation_kind"] == "kernel_opt"
 
 
 # ---------------------------------------------------------------------------

--- a/inference_optimizer/tests/test_optimization_journal.py
+++ b/inference_optimizer/tests/test_optimization_journal.py
@@ -265,3 +265,50 @@ def test_summarize_change_prefers_variant_args_and_envs():
 def test_summarize_change_falls_back_to_task_kind():
     assert summarize_change("baseline") == "baseline"
     assert summarize_change("") == "(unknown)"
+
+
+def test_operation_kind_for_maps_kind_and_action():
+    from inference_optimizer.orchestrator.optimization_journal import (
+        operation_kind_for,
+    )
+    # Explore sub-kinds pass through.
+    assert operation_kind_for("explore", "backend") == "backend"
+    assert operation_kind_for("explore", "param") == "param"
+    assert operation_kind_for("explore", "env") == "env"
+    # Kernel kinds rename to the action labels dashboards filter on.
+    assert operation_kind_for("kernel_opt", "kernel_file") == "kernel_opt"
+    assert operation_kind_for("integrate", "integrate") == "kernel_integrate"
+    # No / other kind falls back to the action.
+    assert operation_kind_for("roofline", "") == "roofline"
+    assert operation_kind_for("sweep", "other") == "sweep"
+    assert operation_kind_for("", "") == "other"
+
+
+def test_proposer_for_resolves_provenance():
+    from inference_optimizer.orchestrator.optimization_journal import proposer_for
+    assert proposer_for("specialist:serving_specialist") == "specialist:serving_specialist"
+    assert proposer_for("llm_direct") == "orchestration"
+    assert proposer_for("default_grid") == "grid"
+    assert proposer_for("legacy:backends") == "orchestration"
+    assert proposer_for("") == "orchestration"
+
+
+def test_journal_entry_roundtrips_proposer_and_metrics():
+    from inference_optimizer.orchestrator.optimization_journal import JournalEntry
+    e = JournalEntry(
+        phase="EXPLORE", iter=1, kind="backend", change="x", outcome="KEEP",
+        provenance="specialist:serving_specialist", scope="domain",
+        fingerprint="fp123", metrics={"runtime_sec": 42.0},
+    )
+    d = e.to_dict()
+    assert d["provenance"] == "specialist:serving_specialist"
+    assert d["scope"] == "domain"
+    assert d["fingerprint"] == "fp123"
+    assert d["metrics"] == {"runtime_sec": 42.0}
+    back = JournalEntry.from_dict(d)
+    assert back.provenance == "specialist:serving_specialist"
+    assert back.metrics == {"runtime_sec": 42.0}
+    # Empty metrics dict is stripped from the serialized form.
+    assert "metrics" not in JournalEntry(
+        phase="P", iter=0, kind="baseline", change="b", outcome="KEEP",
+    ).to_dict()

--- a/inference_optimizer/tests/test_optimization_timeline_attribution.py
+++ b/inference_optimizer/tests/test_optimization_timeline_attribution.py
@@ -1,0 +1,108 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Tests for proposer / operation_kind / per-variant attribution in the
+optimization timeline (phase_timeline + decision_trace).
+
+Verifies the augmentation that threads "who proposed", "what kind of change"
+(operation_kind), and "how it measured" (per-variant metrics + proposal scores)
+from the explore executor through the journal into the breakdown timeline.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from inference_optimizer.breakdown import collectors
+
+
+def test_journal_event_carries_proposer_and_operation_kind() -> None:
+    from inference_optimizer.breakdown.collectors import _journal_entry_to_event
+
+    ev = _journal_entry_to_event({
+        "ts": "2026-06-12T00:00:01Z",
+        "kind": "backend",
+        "change": "--attention-backend AITER",
+        "outcome": "KEEP",
+        "phase": "EXPLORE",
+        "gain_pct": 4.2,
+        "variant_name": "v01",
+        "provenance": "specialist:serving_specialist",
+        "scope": "domain",
+        "fingerprint": "fp1",
+        "metrics": {"runtime_sec": 30.0},
+    })
+    extras = ev["extras"]
+    assert extras["operation_kind"] == "backend"
+    assert extras["provenance"] == "specialist:serving_specialist"
+    assert extras["proposer"] == "specialist:serving_specialist"
+    assert extras["scope"] == "domain"
+    assert extras["fingerprint"] == "fp1"
+    assert extras["metrics"] == {"runtime_sec": 30.0}
+
+
+def test_decision_trace_resolves_proposer_kind_and_scores(tmp_path: Path) -> None:
+    (tmp_path / "reports").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "reports" / "optimization_journal.json").write_text(
+        json.dumps({"entries": [
+            {"ts": "2026-06-12T00:00:01Z", "kind": "backend",
+             "change": "--attention-backend AITER", "outcome": "KEEP",
+             "phase": "EXPLORE", "gain_pct": 4.2, "task_id": "t1",
+             "variant_name": "v01", "provenance": "specialist:serving_specialist",
+             "scope": "domain", "fingerprint": "fp1",
+             "metrics": {"runtime_sec": 30.0, "wall_clock_ratio_vs_baseline": 1.1}},
+            {"ts": "2026-06-12T00:00:05Z", "kind": "param",
+             "change": "--max-num-batched-tokens 8192", "outcome": "REVERT",
+             "phase": "EXPLORE", "task_id": "t2", "variant_name": "v02",
+             "provenance": "default_grid"},
+        ]}),
+        encoding="utf-8",
+    )
+    state = {
+        "specialist_rounds": [{
+            "round_id": "r1", "domain": "serving",
+            "ensemble_scores": {"scale": "0-10", "models": {
+                "modelA": {"v01": {"score": 8.5, "reason": "strong"}},
+                "modelB": {"v01": {"score": 7.0, "reason": "ok"}},
+            }},
+        }],
+    }
+    out = collectors.collect_decision_trace(tmp_path, state, [])
+    rows = out["decision_trace"]
+    by_task = {r["decision"].get("task_id"): r["decision"] for r in rows}
+
+    keep = by_task["t1"]
+    assert keep["component"] == "specialist:serving_specialist"  # resolved proposer
+    assert keep["operation_kind"] == "backend"
+    assert keep["provenance"] == "specialist:serving_specialist"
+    assert keep["scope"] == "domain"
+    assert keep["fingerprint"] == "fp1"
+    assert keep["metrics"]["runtime_sec"] == 30.0
+    # proposal_scorer signal joined by variant_name.
+    raters = {s["rater"] for s in keep["proposal_scores"]}
+    assert raters == {"modelA", "modelB"}
+
+    revert = by_task["t2"]
+    assert revert["component"] == "grid"  # default_grid -> grid
+    assert revert["operation_kind"] == "param"
+
+
+def test_shape_ledger_entry_tags_operation_kind_and_proposer() -> None:
+    from inference_optimizer.breakdown.collectors import _shape_ledger
+
+    ledger = {
+        "schema_version": 1,
+        "tested": {
+            "fpA": {"name": "v01", "fingerprint": "fpA",
+                    "extra_server_args": "--attention-backend AITER",
+                    "gain_pct": 3.0, "provenance": "specialist:serving",
+                    "scope": "domain"},
+        },
+        "accepted": [], "rejected": [],
+    }
+    shaped = _shape_ledger(ledger)
+    entry = shaped["top_by_gain"][0]
+    assert entry["operation_kind"] == "backend"
+    assert entry["provenance"] == "specialist:serving"
+    assert entry["proposer"] == "specialist:serving"
+    assert entry["scope"] == "domain"


### PR DESCRIPTION
## Summary

Thread **"who proposed / what kind / how it measured"** from the explore executor through the optimization journal into both the `session_breakdown.json` timeline and the Langfuse trace, and add a single filterable `operation_kind` label everywhere.

- **explore executor**: `per_variant_outcomes` now carries the variant knobs (so the journal can classify `backend` / `param` / `env` instead of collapsing to `other`) plus `scope`.
- **journal**: `JournalEntry` gains `provenance` / `scope` / `fingerprint` / `metrics`; the coordinator threads them on the per-variant KEEP/REVERT append and stamps `operation_kind` / `scope` on explore `optimization_stack` entries.
- **breakdown collectors**: `decision_trace[].decision.component` is now the resolved **proposer** (`specialist:<domain>` / `grid` / `orchestration`) instead of a hard-coded constant, alongside `operation_kind`, `kind`, `provenance`, `scope`, `fingerprint`, per-variant `metrics`, and the joined `proposal_scores` (proposal_scorer signal joined by variant name). `phase_timeline` events and the `explore_search` ledger carry the same attribution + `operation_kind` filter label.
- **trace (Langfuse)**: each decision now opens an `optimization_step:<operation_kind>` span tagged with `operation_kind` + proposer + effect in metadata, so traces can be filtered directly by step type; decision scores re-resolve `specialist`/`grid` back to a real agent span (instead of always falling back to trace level). Mirrored in the `backfill_langfuse.py` recovery path.
- **schema** docstrings + field additions for `PhaseEvent.extras`, `DecisionTraceEntry`, `ParamSearchEntry`, `OptimizationStackEntry`.

### operation_kind taxonomy
`backend` / `param` / `env` (explore) · `kernel_opt` / `kernel_integrate` · `baseline` / `profile` / `roofline` / `sweep` · `dynamic_action`.

## Test plan

- [x] `test_optimization_journal.py` — `operation_kind_for`, `proposer_for`, `JournalEntry` round-trip of new fields (provenance/scope/fingerprint/metrics, empty dict stripping).
- [x] `test_optimization_timeline_attribution.py` (new) — `_journal_entry_to_event` extras, `collect_decision_trace` proposer/operation_kind/proposal_scores join, `_shape_ledger` operation_kind + proposer tagging.
- [x] `test_langfuse_emitter.py` — updated for per-decision `optimization_step` spans with `operation_kind` metadata.
- [x] Full related suite green (only unrelated `markdownify` import failure in a critic-agent test).

Made with [Cursor](https://cursor.com)