### PR TITLE
feat(session-breakdown): record bypass discovery runs in kernel_journey

### DIFF
--- a/inference_optimizer/breakdown/recorder/instrument.py
+++ b/inference_optimizer/breakdown/recorder/instrument.py
@@ -572,6 +572,7 @@ def record_kernel_discovery(
     status: str,
     hot_kernels: list[Any] | None = None,
     scan: dict[str, Any] | None = None,
+    tool: str | None = None,
     tool_root: str | None = None,
     tool_root_env: str | None = None,
     tool_version: str | None = None,
@@ -581,10 +582,18 @@ def record_kernel_discovery(
 ) -> None:
     """Record one hot-kernel discovery run (stage 1 of ``kernel_journey``).
 
-    One item per discovery invocation (tracelens / roofline scan), keyed by the
-    candidates/report path so a re-run with the same artifact overwrites rather
-    than duplicates. Carries the tool metadata (root + commit + version) and the
-    full hot-kernel list the run surfaced.
+    One item per discovery invocation (tracelens / bypass / roofline scan),
+    keyed by the candidates/report path so a re-run with the same artifact
+    overwrites rather than duplicates. Carries the full hot-kernel list the run
+    surfaced.
+
+    ``source`` is the discovery *route* label the dashboard groups by
+    (``tracelens`` / ``bypass`` / ...). ``tool`` is the underlying tool whose
+    authoritative version lands in the top-level ``versions`` map; it defaults
+    to ``source`` but is decoupled because routes can share one toolchain — the
+    deterministic ``bypass`` route runs the same TraceLens toolchain, so its
+    version provenance is still ``tracelens`` (passing ``tool="tracelens"``
+    avoids minting an empty ``versions["bypass"]`` entry).
     """
     if not session_dir:
         return
@@ -612,9 +621,11 @@ def record_kernel_discovery(
             "kernel_discovery", payload, key=key,
         )
         # The discovery tool's authoritative version lands in the top-level
-        # ``versions`` map (keyed by tool name), not inline per run.
+        # ``versions`` map (keyed by tool name), not inline per run. The version
+        # provenance follows the underlying ``tool`` (defaults to ``source``),
+        # so route aliases like ``bypass`` reuse the real toolchain's version.
         record_tool_version(
-            session_dir, tool=source, root=tool_root,
+            session_dir, tool=(tool or source), root=tool_root,
             root_env=tool_root_env, version=tool_version, producer=producer,
         )
     except Exception:  # noqa: BLE001

--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -1399,14 +1399,28 @@ async def trace_analyze_handler(
             )
 
         # kernel_journey stage 1 (hot-kernel discovery): additive, best-effort.
-        # Records the tracelens run + its hot-kernel list + tool provenance so
+        # Records the discovery run + its hot-kernel list + tool provenance so
         # the journey can thread discovery -> dispatch -> backends -> e2e.
         try:
             from ..breakdown.recorder import instrument
             _hot = result.get("hot_kernels_top15") or result.get("hot_kernels") or []
+            # Discovery source = the route that actually ran. The tool reports
+            # the authoritative mode (``orchestrator_mode``); the deterministic
+            # (no-LLM) route is surfaced to the dashboard as ``bypass`` while the
+            # LLM route stays ``tracelens``. Fall back to the requested
+            # ``analysis_route`` when the tool didn't echo a mode (e.g. early
+            # failure). Both routes drive the same TraceLens toolchain, so the
+            # version provenance (``tool``) stays ``tracelens`` either way.
+            _orch_mode = str(result.get("orchestrator_mode") or "").strip().lower()
+            _is_bypass = (
+                _orch_mode == "deterministic"
+                or analysis_route == "deterministic"
+            )
+            _disc_source = "bypass" if _is_bypass else "tracelens"
             instrument.record_kernel_discovery(
                 session_dir,
-                source="tracelens",
+                source=_disc_source,
+                tool="tracelens",
                 status=str(result.get("status") or ""),
                 hot_kernels=_hot if isinstance(_hot, list) else [],
                 scan={
@@ -1414,6 +1428,7 @@ async def trace_analyze_handler(
                     "trace_dir":          str(trace_input),
                     "candidates_path":    str(result.get("candidates_path") or ""),
                     "trace_report_path":  str(result.get("trace_report_path") or ""),
+                    "analysis_route":     _disc_source,
                 },
                 # tracelens version/commit is read from $TRACELENS_ROOT (its
                 # own checkout), resolved by the recorder's tool registry; we

--- a/inference_optimizer/tests/test_kernel_journey.py
+++ b/inference_optimizer/tests/test_kernel_journey.py
@@ -200,6 +200,40 @@ def test_discovery_run_carries_duration(tmp_path: Path) -> None:
     assert out["kernel_journey"]["discovery_runs"][0]["duration_sec"] == 4.2
 
 
+def test_bypass_discovery_decouples_source_from_version_tool(tmp_path: Path) -> None:
+    # The deterministic (no-LLM) route surfaces as source="bypass" for the
+    # dashboard, but it runs the same TraceLens toolchain -> version provenance
+    # must stay under "tracelens" and NOT mint an empty versions["bypass"].
+    instrument.record_kernel_discovery(
+        tmp_path, source="bypass", tool="tracelens", status="success",
+        hot_kernels=[{"kernel_id": "k1", "name": "moe", "gpu_pct": 12.0}],
+        scan={"analysis_route": "bypass", "candidates_path": str(tmp_path / "c.json")},
+        duration_sec=1.5,
+    )
+    out = assemble_parts(tmp_path)
+    runs = out["kernel_journey"]["discovery_runs"]
+    assert len(runs) == 1
+    assert runs[0]["source"] == "bypass"
+    assert runs[0]["hot_kernel_count"] == 1
+    assert runs[0]["scan"]["analysis_route"] == "bypass"
+    # Version provenance follows the underlying tool, not the route alias.
+    versions = out["versions"]
+    assert "tracelens" in versions
+    assert "bypass" not in versions
+
+
+def test_discovery_tool_defaults_to_source(tmp_path: Path) -> None:
+    # Back-compat: callers that omit ``tool`` keep version provenance keyed by
+    # ``source`` (the historical behavior for the tracelens route).
+    instrument.record_kernel_discovery(
+        tmp_path, source="tracelens", status="success",
+        hot_kernels=[{"kernel_id": "k1", "name": "moe", "gpu_pct": 9.0}],
+        scan={},
+    )
+    out = assemble_parts(tmp_path)
+    assert "tracelens" in out["versions"]
+
+
 def test_tool_version_probe_git_strategies(tmp_path: Path) -> None:
     sha = _init_git_repo(tmp_path)
     # geak -> git short SHA (NOT pip mini-swe-agent); commit == version.

--- a/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -1182,6 +1182,178 @@ async def test_trace_analyze_handler_tolerates_non_string_analysis_route(session
 
 
 @pytest.mark.asyncio
+async def test_trace_analyze_handler_records_bypass_discovery_success(
+    session_dir, monkeypatch,
+):
+    """Deterministic route surfaces a kernel_journey discovery run labelled
+    source="bypass" (with the real hot kernels), while version provenance stays
+    under the tracelens toolchain (no junk versions["bypass"])."""
+    from inference_optimizer.breakdown.recorder import assemble_parts
+
+    fake_trace = session_dir / "fake_trace_dir"
+    fake_trace.mkdir()
+
+    captured: dict = {}
+
+    async def fake_run_subprocess(cmd, *, timeout_sec):
+        captured["cmd"] = list(cmd)
+        payload = {
+            "status": "ok",
+            "orchestrator_mode": "deterministic",
+            "hot_kernels": [
+                {"kernel_id": "k001", "name": "fused_moe", "gpu_pct": 42.0,
+                 "bottleneck": "memory", "reusable_native_kernel": True},
+                {"kernel_id": "k002", "name": "rms_norm", "gpu_pct": 7.5},
+            ],
+            "artifact_paths": {"kernel_candidates": "/tmp/kc.json"},
+        }
+        return 0, json.dumps(payload), ""
+
+    monkeypatch.setattr(krh, "_run_subprocess", fake_run_subprocess)
+    res = await krh.trace_analyze_handler(
+        {
+            "trace_input": str(fake_trace),
+            "session_id": session_dir.name,
+            "analysis_route": "deterministic",
+            "top_k": 5,
+        },
+        session_dir=session_dir,
+    )
+    assert res["status"] == "ok"
+    # The deterministic route flag is forwarded to the tool.
+    assert "--analysis-route" in captured["cmd"]
+    assert "deterministic" in captured["cmd"]
+
+    out = assemble_parts(session_dir)
+    runs = out["kernel_journey"]["discovery_runs"]
+    assert len(runs) == 1
+    run = runs[0]
+    assert run["source"] == "bypass"
+    assert run["status"] == "ok"
+    assert run["hot_kernel_count"] == 2
+    assert {k["name"] for k in run["hot_kernels"]} == {"fused_moe", "rms_norm"}
+    assert run["scan"]["analysis_route"] == "bypass"
+    # Underlying toolchain is still tracelens; no empty versions["bypass"].
+    assert "bypass" not in out.get("versions", {})
+
+
+@pytest.mark.asyncio
+async def test_trace_analyze_handler_records_bypass_discovery_failed(
+    session_dir, monkeypatch,
+):
+    """Fail-loud deterministic pipeline -> discovery run status=failed with the
+    error text and an empty hot-kernel list, still labelled source="bypass"."""
+    from inference_optimizer.breakdown.recorder import assemble_parts
+
+    fake_trace = session_dir / "fake_trace_dir"
+    fake_trace.mkdir()
+
+    async def fake_run_subprocess(cmd, *, timeout_sec):
+        payload = {
+            "status": "failed",
+            "orchestrator_mode": "deterministic",
+            "error": "deterministic: category script for gemm exited rc=1",
+            "hot_kernels": [],
+        }
+        return 1, json.dumps(payload), "boom"
+
+    monkeypatch.setattr(krh, "_run_subprocess", fake_run_subprocess)
+    res = await krh.trace_analyze_handler(
+        {
+            "trace_input": str(fake_trace),
+            "session_id": session_dir.name,
+            "analysis_route": "deterministic",
+        },
+        session_dir=session_dir,
+    )
+    assert res["status"] == "failed"
+
+    out = assemble_parts(session_dir)
+    run = out["kernel_journey"]["discovery_runs"][0]
+    assert run["source"] == "bypass"
+    assert run["status"] == "failed"
+    assert run["hot_kernel_count"] == 0
+    assert run["error"]
+
+
+@pytest.mark.asyncio
+async def test_trace_analyze_handler_records_bypass_discovery_high_idle_empty(
+    session_dir, monkeypatch,
+):
+    """High-idle gate suppresses hot kernels but the run still succeeds -> a
+    bypass discovery run with status=ok and hot_kernel_count=0."""
+    from inference_optimizer.breakdown.recorder import assemble_parts
+
+    fake_trace = session_dir / "fake_trace_dir"
+    fake_trace.mkdir()
+
+    async def fake_run_subprocess(cmd, *, timeout_sec):
+        payload = {
+            "status": "ok",
+            "orchestrator_mode": "deterministic",
+            "hot_kernels": [],
+            "trace_health_warnings": [
+                {"code": "high_gpu_idle", "severity": "warning"},
+            ],
+        }
+        return 0, json.dumps(payload), ""
+
+    monkeypatch.setattr(krh, "_run_subprocess", fake_run_subprocess)
+    res = await krh.trace_analyze_handler(
+        {
+            "trace_input": str(fake_trace),
+            "session_id": session_dir.name,
+            "analysis_route": "deterministic",
+        },
+        session_dir=session_dir,
+    )
+    assert res["status"] == "ok"
+
+    out = assemble_parts(session_dir)
+    run = out["kernel_journey"]["discovery_runs"][0]
+    assert run["source"] == "bypass"
+    assert run["status"] == "ok"
+    assert run["hot_kernel_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_trace_analyze_handler_agent_route_stays_tracelens(
+    session_dir, monkeypatch,
+):
+    """The LLM/agent route keeps source="tracelens" (regression guard for the
+    bypass relabel)."""
+    from inference_optimizer.breakdown.recorder import assemble_parts
+
+    fake_trace = session_dir / "fake_trace_dir"
+    fake_trace.mkdir()
+
+    async def fake_run_subprocess(cmd, *, timeout_sec):
+        payload = {
+            "status": "ok",
+            "orchestrator_mode": "claude_agent_sdk",
+            "hot_kernels": [
+                {"kernel_id": "k001", "name": "fused_moe", "gpu_pct": 30.0},
+            ],
+        }
+        return 0, json.dumps(payload), ""
+
+    monkeypatch.setattr(krh, "_run_subprocess", fake_run_subprocess)
+    await krh.trace_analyze_handler(
+        {
+            "trace_input": str(fake_trace),
+            "session_id": session_dir.name,
+            "analysis_route": "agent",
+        },
+        session_dir=session_dir,
+    )
+
+    out = assemble_parts(session_dir)
+    run = out["kernel_journey"]["discovery_runs"][0]
+    assert run["source"] == "tracelens"
+    assert run["scan"]["analysis_route"] == "tracelens"
+
+
+@pytest.mark.asyncio
 async def test_trace_analyze_handler_surfaces_candidates_path(session_dir, monkeypatch):
     captured: dict = {}
 


### PR DESCRIPTION
## Summary

Implements **B1** from the Kernel Overview design (`pulse docs/kernel-overview`): make the deterministic / **bypass** TraceLens route (`--analysis-route deterministic`, #558) show up in `session_breakdown.json`'s `kernel_journey.discovery_runs[]` with `source="bypass"`, so the dashboard's discovery-source comparison (tracelens vs bypass, view A2) finally has bypass rows.

### Root cause
The deterministic route from #558 already produces hot kernels through the **same** `trace_analyze` pipeline as the LLM route, and the orchestrator already records a stage-1 discovery run for every `trace_analyze`. But that recorder call was hard-coded to `source="tracelens"`, so bypass runs were mislabeled and the `bypass` series was always empty.

### Changes
- `orchestrator/kernel_request_handlers.py` (`trace_analyze_handler`): label the discovery run by the route that actually ran — prefer the tool's authoritative `orchestrator_mode` (`"deterministic"` → `"bypass"`), falling back to the requested `analysis_route`. Record the route into `scan.analysis_route` for provenance.
- `breakdown/recorder/instrument.py` (`record_kernel_discovery`): decouple the discovery **`source`** label (dashboard group-by) from the version-provenance **`tool`** key (new optional param, defaults to `source` for back-compat). The handler passes `tool="tracelens"` because bypass runs the same TraceLens toolchain — this avoids minting an empty `versions["bypass"]` entry.

Status / duration / hot-kernel field mapping are untouched, so bypass discovery rows are **structurally identical** to tracelens rows (design requirement) across all three states: success, fail-loud, and high-idle empty set.

### `discovery_runs[]` fields a bypass row carries (per `KernelDiscoveryRun`)
| field | value for bypass |
|---|---|
| `source` | `"bypass"` |
| `status` | tool status (`ok` on success / high-idle, `failed` on fail-loud) |
| `ts` | run timestamp |
| `duration_sec` | wall time of the trace_analyze subprocess |
| `scan` | `{splitter_mode, trace_dir, candidates_path, trace_report_path, analysis_route="bypass"}` |
| `hot_kernel_count` | len(hot_kernels) (0 on high-idle / failure) |
| `hot_kernels[]` | `DiscoveredHotKernel` rows (name, gpu_pct, time_ms, bound_type, efficiency_percent, source_file, recommended_backends, ...) |
| `error` | failure text on `status="failed"`, else null |

Tool version provenance lands in top-level `versions["tracelens"]` (not `versions["bypass"]`).

## Test plan
- [x] `inference_optimizer/tests/test_kernel_journey.py` — recorder-level: `source`/`tool` decoupling keeps version provenance under `tracelens` (no `versions["bypass"]`); `tool` defaults to `source` for back-compat. (Runs locally; 14 passed.)
- [x] `inference_optimizer/tests/test_profile_and_kernel_handlers.py` — handler-level: bypass success / fail-loud / high-idle-empty all record `source="bypass"`; agent route stays `source="tracelens"`. (Linux/CI — module imports `fcntl`, not collectable on Windows dev box.)
