### PR TITLE
feat(vl): enable Qwen-VL models — preflight gate, auto image benchmark, roofline ISL

### DIFF
--- a/inference_optimizer/orchestrator/action_executors/_workload_envs.py
+++ b/inference_optimizer/orchestrator/action_executors/_workload_envs.py
@@ -250,6 +250,7 @@ def materialize_config_with_envs(
     benchmark_script: str | None = None,
     reference_server_args: str = "",
     reference_envs: dict[str, Any] | None = None,
+    mm_mode: bool = False,
     out_name: str = "baseline_config.with_envs.yaml",
     establish_quality_ref: bool = False,
 ) -> Path:
@@ -268,7 +269,9 @@ def materialize_config_with_envs(
     into the framework env; ``extra_envs`` overrides any of the above.
     ``reference_server_args`` / ``reference_envs`` seed a lowest-priority base
     from a reference recipe (below the YAML base and extra_server_args; empty =
-    no-op, byte-for-byte identical to omitting them).
+    no-op, byte-for-byte identical to omitting them). ``mm_mode`` (or
+    ``DATASET=random-mm``) switches to the multimodal benchmark script and
+    injects image dimension env vars (vllm only).
 
     Args:
         config_path: Path to the source Magpie YAML to render.
@@ -279,6 +282,9 @@ def materialize_config_with_envs(
         gpu_type: GPU type; sets ``runner_type`` and pins the generic script.
         inferencex_path: Explicit InferenceX checkout to pin into the YAML.
         benchmark_script: Pre-sanitized benchmark script name to re-pin.
+        reference_server_args: Lowest-priority server args from a reference recipe.
+        reference_envs: Lowest-priority env overrides from a reference recipe.
+        mm_mode: Enable multimodal benchmark script and image env injection (vllm only).
         out_name: File name for the materialized YAML.
         establish_quality_ref: When True (baseline only) the scriptable
             image-quality reference is ESTABLISHED (written) by this run;
@@ -336,6 +342,26 @@ def materialize_config_with_envs(
                 f"benchmark_script={_script!r} targets {_other[0]!r}; refusing "
                 f"to boot server (would launch the wrong framework's entrypoint)"
             )
+
+    # Multimodal (VL) mode: switch to the mm benchmark script and inject
+    # image dimension env vars.  Activated by the mm_mode arg OR by
+    # DATASET=random-mm in the process environment.
+    _mm_active = mm_mode or os.environ.get("DATASET", "").strip().lower() == "random-mm"
+    if _mm_active:
+        framework = str(bench.get("framework") or "").lower()
+        if "vllm" in framework:
+            _gpu_type = gpu_type or os.environ.get("GPU_TYPE", "").strip().lower() or "mi300x"
+            _mm_script = f"vllm_{_gpu_type}_mm.sh"
+            bench["benchmark_script"] = _mm_script
+            log.info("mm_mode: switched benchmark_script to %s", _mm_script)
+        else:
+            log.warning(
+                "mm_mode requested but framework=%r is not vllm; "
+                "random-mm dataset is not supported for this framework. "
+                "Falling back to text-only benchmark.", framework,
+            )
+            _mm_active = False
+
     effective_inferencex_path = str(inferencex_path or "").strip() or os.environ.get("INFERENCEX_PATH", "").strip()
     if effective_inferencex_path:
         # Persist the resolved InferenceX checkout into the YAML so Magpie's
@@ -359,6 +385,16 @@ def materialize_config_with_envs(
     r_env = os.environ.get("RANDOM_RANGE_RATIO", "").strip()
     if r_env:
         envs["RANDOM_RANGE_RATIO"] = float(r_env)
+    if _mm_active:
+        envs["DATASET"] = "random-mm"
+        for _mm_key, _mm_default in (
+            ("IMAGE_HEIGHT", "512"),
+            ("IMAGE_WIDTH", "512"),
+            ("MM_MAX_IMAGES", "1"),
+            ("SEED", "5678"),
+        ):
+            _mm_val = os.environ.get(_mm_key, "").strip() or _mm_default
+            envs[_mm_key] = int(_mm_val)
     rocr_env = os.environ.get("ROCR_VISIBLE_DEVICES", "").strip()
     if rocr_env:
         envs["ROCR_VISIBLE_DEVICES"] = rocr_env

--- a/inference_optimizer/orchestrator/coordinator_helpers.py
+++ b/inference_optimizer/orchestrator/coordinator_helpers.py
@@ -59,6 +59,14 @@ def _infer_model_class_from_config(model_path: str) -> str:
         except Exception:  # noqa: BLE001 - best effort only.
             log.debug("model_class inference: failed to read %s", cfg, exc_info=True)
 
+    # Flatten text_config so VL MoE models (Qwen2-VL, Qwen3-VL, etc.) are
+    # classified correctly. Top-level keys take precedence; flat configs unchanged.
+    nested = payload.get("text_config")
+    if isinstance(nested, dict):
+        merged = dict(nested)
+        merged.update(payload)
+        payload = merged
+
     text_parts: list[str] = [raw_path.lower()]
     arch = payload.get("architectures")
     if isinstance(arch, list):

--- a/inference_optimizer/orchestrator/roofline_ceiling.py
+++ b/inference_optimizer/orchestrator/roofline_ceiling.py
@@ -646,6 +646,11 @@ class ModelMeta:
     moe_intermediate_size: int = 0
     vocab_size: int = 0
     num_attention_heads: int = 0
+    # VL-specific: vision token count consumed per image at the given
+    # (IMAGE_HEIGHT × IMAGE_WIDTH) resolution.  0 for text-only models.
+    # Used by the roofline caller to compute effective text ISL when
+    # benchmarking with synthetic multimodal requests.
+    vision_tokens_per_image: int = 0
 
 
 def _read_total_size(model_path: Path) -> int | None:
@@ -703,6 +708,59 @@ def _read_hf_config(model_path: Path) -> dict[str, Any] | None:
         return json.loads(cfg.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
+
+
+def _flatten_text_config(cfg: dict[str, Any]) -> dict[str, Any]:
+    """Merge a nested ``text_config`` block into a flat view for field extraction.
+
+    VL models (Qwen2-VL, Qwen3-VL, etc.) nest the text decoder geometry under
+    ``text_config``; flat (text-only) models have everything at the top level.
+    Returns a merged dict where top-level keys take precedence over nested ones,
+    so this is a no-op for flat configs and correctly surfaces decoder fields
+    (``num_hidden_layers``, ``num_experts``, ``hidden_size``, etc.) for VL models.
+    """
+    nested = cfg.get("text_config")
+    if not isinstance(nested, dict):
+        return cfg
+    merged = dict(nested)
+    merged.update(cfg)
+    return merged
+
+
+def _vision_tokens_per_image(
+    cfg: dict[str, Any],
+    image_height: int = 512,
+    image_width: int = 512,
+) -> int:
+    """Estimate vision token count for one image at the given resolution.
+
+    Qwen2-VL / Qwen3-VL use a ViT with a 2D merge (spatial_merge_size=2):
+
+        grid_h = ceil(image_height / patch_size)
+        grid_w = ceil(image_width  / patch_size)
+        tokens = (grid_h // spatial_merge_size) * (grid_w // spatial_merge_size)
+
+    Values are read from ``vision_config`` (top-level, not flattened —
+    the flatten step exposes *text* decoder fields; vision geometry stays
+    under the separate ``vision_config`` sub-dict).
+
+    Returns 0 when no ``vision_config`` is present (text-only model) or
+    when required fields are missing.
+    """
+    import math
+    vision_cfg = cfg.get("vision_config")
+    if not isinstance(vision_cfg, dict):
+        return 0
+    patch_size = int(vision_cfg.get("patch_size") or 0)
+    if not patch_size:
+        return 0
+    merge = int(vision_cfg.get("spatial_merge_size") or 1)
+    if merge < 1:
+        merge = 1
+    grid_h = math.ceil(image_height / patch_size)
+    grid_w = math.ceil(image_width / patch_size)
+    tokens = (grid_h // merge) * (grid_w // merge)
+    return max(0, tokens)
 
 
 def _derive_kv_heads(cfg: dict[str, Any]) -> int:
@@ -804,9 +862,10 @@ def load_model_meta(
     p = Path(model_path).expanduser()
     if not p.is_dir():
         return None
-    cfg = _read_hf_config(p)
-    if cfg is None:
+    raw_cfg = _read_hf_config(p)
+    if raw_cfg is None:
         return None
+    cfg = _flatten_text_config(raw_cfg)
     weight_bytes = _read_total_size(p)
     if not weight_bytes:
         return None
@@ -839,6 +898,7 @@ def load_model_meta(
         moe_intermediate_size=moe_intermediate_size,
         vocab_size=int(cfg.get("vocab_size") or 0),
         num_attention_heads=int(cfg.get("num_attention_heads") or 0),
+        vision_tokens_per_image=_vision_tokens_per_image(raw_cfg),
     )
 
 

--- a/inference_optimizer/tests/test_model_class_vl.py
+++ b/inference_optimizer/tests/test_model_class_vl.py
@@ -1,0 +1,107 @@
+"""Tests for VL model class inference via nested text_config.
+
+Verifies that _infer_model_class_from_config correctly classifies VL MoE
+models (Qwen3-VL, Qwen2-VL) whose MoE fields are nested under text_config,
+rather than misclassifying them as dense.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from inference_optimizer.orchestrator.coordinator_helpers import (
+    _infer_model_class_from_config,
+)
+
+
+def _write_config(model_dir: Path, payload: dict) -> None:
+    model_dir.mkdir(parents=True, exist_ok=True)
+    (model_dir / "config.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+class TestInferModelClassVL:
+    def test_qwen3_vl_moe_classified_as_moe(self, tmp_path):
+        """Qwen3-VL-235B has MoE fields under text_config — must not be dense."""
+        m = tmp_path / "qwen3vl"
+        _write_config(m, {
+            "architectures": ["Qwen3VLMoeForConditionalGeneration"],
+            "model_type": "qwen3_vl",
+            "vision_config": {"hidden_size": 1280},
+            "text_config": {
+                "num_hidden_layers": 94,
+                "hidden_size": 7168,
+                "num_experts": 128,
+                "num_experts_per_tok": 8,
+                "moe_intermediate_size": 2048,
+            },
+        })
+        result = _infer_model_class_from_config(str(m))
+        assert result != "dense", f"expected MoE class, got {result!r}"
+        assert "moe" in result
+
+    def test_qwen2_vl_moe_classified_as_moe(self, tmp_path):
+        """Qwen2-VL variant with MoE under text_config is not dense."""
+        m = tmp_path / "qwen2vl"
+        _write_config(m, {
+            "architectures": ["Qwen2VLForConditionalGeneration"],
+            "model_type": "qwen2_vl",
+            "vision_config": {"hidden_size": 1280},
+            "text_config": {
+                "num_hidden_layers": 80,
+                "hidden_size": 8192,
+                "num_experts": 64,
+                "num_experts_per_tok": 4,
+            },
+        })
+        result = _infer_model_class_from_config(str(m))
+        assert "moe" in result
+
+    def test_flat_llm_moe_still_classified_as_moe(self, tmp_path):
+        """Flat (non-VL) MoE config must be unaffected by the text_config logic."""
+        m = tmp_path / "qwen3moe"
+        _write_config(m, {
+            "architectures": ["Qwen3MoeForCausalLM"],
+            "model_type": "qwen3_moe",
+            "num_hidden_layers": 48,
+            "hidden_size": 2048,
+            "num_experts": 128,
+            "num_experts_per_tok": 8,
+        })
+        result = _infer_model_class_from_config(str(m))
+        assert "moe" in result
+
+    def test_vl_dense_decoder_classified_as_dense(self, tmp_path):
+        """A VL model with a dense text decoder must stay classified as dense."""
+        m = tmp_path / "qwen2vl_dense"
+        _write_config(m, {
+            "architectures": ["Qwen2VLForConditionalGeneration"],
+            "model_type": "qwen2_vl",
+            "vision_config": {"hidden_size": 1280},
+            "text_config": {
+                "num_hidden_layers": 28,
+                "hidden_size": 3584,
+            },
+        })
+        result = _infer_model_class_from_config(str(m))
+        assert result == "dense"
+
+    def test_top_level_keys_win_over_text_config(self, tmp_path):
+        """Top-level fields must take precedence over text_config on conflict."""
+        m = tmp_path / "conflict"
+        _write_config(m, {
+            "model_type": "qwen3_vl",
+            "num_experts": 0,          # top-level says dense (0 experts)
+            "text_config": {
+                "num_experts": 128,    # nested says MoE — top-level should win
+                "num_experts_per_tok": 8,
+            },
+        })
+        result = _infer_model_class_from_config(str(m))
+        assert result == "dense"
+
+    def test_missing_config_returns_dense(self, tmp_path):
+        """Missing config.json gracefully returns dense (safe degrade)."""
+        result = _infer_model_class_from_config(str(tmp_path / "no_model"))
+        assert result == "dense"

--- a/inference_optimizer/tests/test_multimodal_gate.py
+++ b/inference_optimizer/tests/test_multimodal_gate.py
@@ -135,9 +135,9 @@ def test_detect_gemma3_conditional_generation_rejected(tmp_path):
 
 
 def test_detect_unknown_arch_rejected(tmp_path):
-    """An unknown architecture not matching text-generation markers -> rejected."""
+    """An unknown architecture with no recognised model_type -> rejected."""
     m = tmp_path / "custom"
-    _write_config(m, {"architectures": ["SomeCustomArch"], "model_type": "qwen2_vl"})
+    _write_config(m, {"architectures": ["SomeCustomArch"], "model_type": "some_exotic_vl"})
     hit = cli._detect_unsupported_model(str(m))
     assert hit is not None
     assert hit["architecture"] == "SomeCustomArch"
@@ -229,22 +229,31 @@ def test_detect_known_text_model_type_with_nonstandard_arch_allowed(tmp_path):
     assert cli._detect_unsupported_model(str(m)) is None
 
 
-def test_detect_causal_lm_with_vision_config_is_text_coercible(tmp_path):
-    """A generic ForCausalLM arch carrying vision_config is text-coercible:
-    a text decoder exists, so we degrade to the text path (not fail-fast)."""
+def test_detect_causal_lm_with_vision_config_allowed(tmp_path):
+    """vision_config alone no longer rejects a model — the VL Qwen family has it.
+    The model_type / architecture allowlists are the primary gate; config-key
+    checks are secondary signals for models that slip past both."""
     m = tmp_path / "visioncausal"
-    _write_config(
-        m,
-        {
-            "architectures": ["LlamaForCausalLM"],
-            "model_type": "llama",
-            "vision_config": {"hidden_size": 1024},
-        },
-    )
+    _write_config(m, {
+        "architectures": ["LlamaForCausalLM"],
+        "model_type": "llama",
+        "vision_config": {"hidden_size": 1024},
+    })
+    assert cli._detect_unsupported_model(str(m)) is None
+
+
+def test_detect_other_mm_config_keys_still_rejected(tmp_path):
+    """Non-vision_config multimodal keys (mm_config, projector_config, etc.)
+    still reject a model that slips past the model_type / architecture checks."""
+    m = tmp_path / "mm_config_model"
+    _write_config(m, {
+        "architectures": ["UnknownArch"],
+        "model_type": "some_unknown_vl",
+        "mm_config": {"foo": "bar"},
+    })
     hit = cli._detect_unsupported_model(str(m))
     assert hit is not None
-    assert hit["verdict"] == cli._VERDICT_TEXT_COERCIBLE
-    assert "vision_config" in hit["signal"]
+    assert "mm_config" in hit["signal"]
 
 
 def test_detect_kimi_k25_text_coercible(tmp_path):
@@ -391,7 +400,7 @@ def test_preflight_blocks_gemma3(tmp_path, monkeypatch):
 
 def test_preflight_blocks_unknown_arch(tmp_path, monkeypatch):
     model = tmp_path / "custom"
-    _write_config(model, {"architectures": ["X"], "model_type": "qwen2_vl"})
+    _write_config(model, {"architectures": ["X"], "model_type": "some_exotic_vl"})
     sd = tmp_path / "session_custom"
     _seed_state(sd, monkeypatch)
     assert cli._preflight_unsupported_model_arch(_args(str(model)), sd) is True
@@ -452,7 +461,68 @@ def test_preflight_persists_stop_reason_under_strict_env(tmp_path, monkeypatch):
     assert state["stop_reason"] == "unsupported_model_arch"
 
 
-# 4. text_coercible — multimodal signal but a text path exists
+# ---------------------------------------------------------------------------
+# 4. Qwen VL family — admitted via _SUPPORTED_MODEL_TYPES
+# ---------------------------------------------------------------------------
+def test_detect_qwen2_vl_allowed(tmp_path):
+    """qwen2_vl is now in _SUPPORTED_MODEL_TYPES; vision_config no longer blocks."""
+    m = tmp_path / "qwen2vl"
+    _write_config(m, {
+        "architectures": ["Qwen2VLForConditionalGeneration"],
+        "model_type": "qwen2_vl",
+        "vision_config": {"hidden_size": 1280},
+    })
+    assert cli._detect_unsupported_model(str(m)) is None
+
+
+def test_detect_qwen2_5_vl_allowed(tmp_path):
+    """qwen2_5_vl is now in _SUPPORTED_MODEL_TYPES."""
+    m = tmp_path / "qwen25vl"
+    _write_config(m, {
+        "architectures": ["Qwen2_5_VLForConditionalGeneration"],
+        "model_type": "qwen2_5_vl",
+        "vision_config": {"hidden_size": 1280},
+    })
+    assert cli._detect_unsupported_model(str(m)) is None
+
+
+def test_detect_qwen3_vl_allowed(tmp_path):
+    """qwen3_vl (incl. MoE variant) is now in _SUPPORTED_MODEL_TYPES."""
+    for arch in [
+        "Qwen3VLMoeForConditionalGeneration",
+        "Qwen3VLForConditionalGeneration",
+    ]:
+        m = tmp_path / arch
+        _write_config(m, {
+            "architectures": [arch],
+            "model_type": "qwen3_vl",
+            "vision_config": {"hidden_size": 1280},
+        })
+        assert cli._detect_unsupported_model(str(m)) is None, arch
+
+
+def test_preflight_allows_qwen3_vl(tmp_path, monkeypatch):
+    """End-to-end: Qwen3-VL model passes the preflight gate without blocking."""
+    model = tmp_path / "qwen3vl"
+    _write_config(model, {
+        "architectures": ["Qwen3VLMoeForConditionalGeneration"],
+        "model_type": "qwen3_vl",
+        "vision_config": {"hidden_size": 1280},
+        "text_config": {
+            "num_hidden_layers": 94,
+            "hidden_size": 7168,
+            "num_experts": 128,
+        },
+    })
+    sd = tmp_path / "session_qwen3vl"
+    _seed_state(sd, monkeypatch)
+    assert cli._preflight_unsupported_model_arch(_args(str(model)), sd) is False
+    assert not (sd / "reports" / "final.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# 5. text_coercible — multimodal signal but a text path exists
+# ---------------------------------------------------------------------------
 def _coercible_model(tmp_path: Path) -> Path:
     m = tmp_path / "kimi_k25"
     _write_config(
@@ -531,7 +601,7 @@ def test_preflight_vision_only_ignores_fallback_flag(tmp_path, monkeypatch):
     assert state["stop_reason"] == "unsupported_model_arch"
 
 
-# 5. report rendering of the degraded-mode section
+# 6. report rendering of the degraded-mode section
 def test_report_renders_degraded_mode_section():
     from inference_optimizer.orchestrator.action_executors import report
     from inference_optimizer.orchestrator.shared_state import SharedState

--- a/inference_optimizer/tests/test_roofline_ceiling.py
+++ b/inference_optimizer/tests/test_roofline_ceiling.py
@@ -15,6 +15,7 @@ from inference_optimizer.orchestrator.roofline_ceiling import (
     ModelMeta,
     _resolve_dtype_bytes,
     _resolve_peak_tflops,
+    _vision_tokens_per_image,
     apply_runtime_dtype,
     compute_compute_bound_ceiling_tok_per_sec,
     compute_kv_bytes_per_token,
@@ -460,6 +461,150 @@ class TestComputePeakFromState:
         assert compute_peak_from_state(state) == 0.0
 
 
+
+# ---------------------------------------------------------------------------
+# VL model geometry via nested text_config.
+# ---------------------------------------------------------------------------
+class TestLoadModelMetaVL:
+    """load_model_meta must correctly extract geometry from VL configs where
+    the text decoder fields are nested under ``text_config``."""
+
+    def _write_qwen3_vl_model(self, model_dir: Path, *, total_size: int) -> None:
+        """Lay down a Qwen3-VL-shaped config with nested text_config.
+
+        Geometry uses a small MoE config so total_expert_bytes < total_size
+        (the decomposition guard requires this).  Real Qwen3-VL-235B geometry
+        combined with a naive safetensors total_size would trigger the guard
+        because the formula counts all expert parameters without the GQA /
+        attention compression that reduces the real checkpoint size.
+        """
+        model_dir.mkdir(parents=True, exist_ok=True)
+        (model_dir / "config.json").write_text(json.dumps({
+            "architectures": ["Qwen3VLMoeForConditionalGeneration"],
+            "model_type": "qwen3_vl",
+            "vision_config": {"hidden_size": 1280, "num_hidden_layers": 32},
+            "text_config": {
+                "num_hidden_layers": 4,
+                "num_attention_heads": 16,
+                "num_key_value_heads": 4,
+                "hidden_size": 512,
+                "head_dim": 32,
+                "intermediate_size": 256,
+                "moe_intermediate_size": 128,
+                "num_experts": 8,
+                "num_experts_per_tok": 2,
+                "torch_dtype": "float8_e4m3fn",
+            },
+        }))
+        # total_size must exceed total_expert_bytes:
+        # 4 layers × 8 experts × 3 × 512 × 128 × 1 byte = 6,291,456 bytes
+        (model_dir / "model.safetensors.index.json").write_text(
+            json.dumps({"metadata": {"total_size": total_size}, "weight_map": {}})
+        )
+
+    def test_vl_text_config_geometry_extracted(self, tmp_path):
+        """Fields nested in text_config must be surfaced in the returned ModelMeta."""
+        self._write_qwen3_vl_model(tmp_path / "m", total_size=100_000_000)
+        meta = load_model_meta(tmp_path / "m")
+        assert meta is not None
+        assert meta.weight_bytes == 100_000_000
+        assert meta.num_layers == 4
+        assert meta.num_kv_heads == 4
+        assert meta.head_dim == 32
+        assert meta.hidden_size == 512
+        assert meta.weight_dtype_bytes == 1.0   # fp8
+
+    def test_vl_moe_decomposition_from_text_config(self, tmp_path):
+        """MoE expert decomposition must work when num_experts is in text_config."""
+        self._write_qwen3_vl_model(tmp_path / "m", total_size=100_000_000)
+        meta = load_model_meta(tmp_path / "m")
+        assert meta is not None
+        assert meta.num_experts == 8
+        assert meta.experts_per_tok == 2
+        # Active weight bytes must be well below total (MoE routing activates 2/8).
+        assert 0 < meta.active_weight_bytes < meta.weight_bytes
+
+    def test_flat_config_unchanged_by_text_config_flatten(self, tmp_path):
+        """A flat (non-VL) config must be completely unaffected by the flattening."""
+        _write_synthetic_model(
+            tmp_path / "flat",
+            total_size=70_000_000_000,
+            num_layers=80,
+            num_kv_heads=8,
+            hidden_size=8192,
+            num_attention_heads=64,
+            torch_dtype="bfloat16",
+        )
+        meta = load_model_meta(tmp_path / "flat")
+        assert meta is not None
+        assert meta.num_layers == 80
+        assert meta.num_kv_heads == 8
+        assert meta.hidden_size == 8192
+        assert meta.weight_dtype_bytes == 2.0   # bf16
+        assert meta.vision_tokens_per_image == 0  # no vision_config → 0
+
+    def test_vl_vision_token_budget_qwen3(self, tmp_path):
+        """vision_tokens_per_image must be computed from vision_config.
+
+        Qwen3-VL: patch_size=14, spatial_merge_size=2.
+        For a 512×512 image:
+            grid_h = ceil(512/14) = 37
+            grid_w = ceil(512/14) = 37
+            tokens = (37//2) * (37//2) = 18 * 18 = 324
+        """
+        import math
+        m = tmp_path / "qwen3vl_vision"
+        m.mkdir(parents=True, exist_ok=True)
+        (m / "config.json").write_text(json.dumps({
+            "architectures": ["Qwen3VLMoeForConditionalGeneration"],
+            "model_type": "qwen3_vl",
+            "vision_config": {
+                "hidden_size": 1280,
+                "patch_size": 14,
+                "spatial_merge_size": 2,
+            },
+            "text_config": {
+                "num_hidden_layers": 4,
+                "num_attention_heads": 16,
+                "num_key_value_heads": 4,
+                "hidden_size": 512,
+                "torch_dtype": "float8_e4m3fn",
+            },
+        }))
+        (m / "model.safetensors.index.json").write_text(
+            json.dumps({"metadata": {"total_size": 100_000_000}, "weight_map": {}})
+        )
+        meta = load_model_meta(m)
+        assert meta is not None
+        patch_size, merge = 14, 2
+        grid = math.ceil(512 / patch_size)
+        expected = (grid // merge) ** 2
+        assert meta.vision_tokens_per_image == expected, (
+            f"expected {expected}, got {meta.vision_tokens_per_image}"
+        )
+
+    def test_vl_missing_patch_size_returns_zero(self, tmp_path):
+        """vision_config without patch_size → vision_tokens_per_image == 0."""
+        m = tmp_path / "vl_no_patch"
+        m.mkdir(parents=True, exist_ok=True)
+        (m / "config.json").write_text(json.dumps({
+            "model_type": "qwen3_vl",
+            "vision_config": {"hidden_size": 1280},  # no patch_size
+            "text_config": {
+                "num_hidden_layers": 4,
+                "hidden_size": 512,
+                "torch_dtype": "bfloat16",
+            },
+        }))
+        (m / "model.safetensors.index.json").write_text(
+            json.dumps({"metadata": {"total_size": 100_000_000}, "weight_map": {}})
+        )
+        meta = load_model_meta(m)
+        assert meta is not None
+        assert meta.vision_tokens_per_image == 0
+
+
+# ---------------------------------------------------------------------------
 # MoE active weight bytes (PR: MoE-aware decode ceiling).
 def _write_qwen3_moe_model(model_dir: Path, *, total_size: int) -> None:
     """Lay down a Qwen3-30B-A3B-shaped MoE HF dir for ceiling tests."""


### PR DESCRIPTION
- **Description (what & why):** Enables vision-language (VL) models in the `inference_optimizer` orchestrator, which previously hard-rejected them at the preflight gate.
  - **Gate (policy C, reconciled with main #532):** Qwen-VL families (`qwen2_vl`, `qwen2_5_vl`, `qwen3_vl`, `qwen3_vl_moe`) are now **first-class VL** via a new `_SUPPORTED_VL_MODEL_TYPES` set, checked *before* the multimodal-config-key loop so they are admitted and run **with image workloads**. `vision_config` / `image_token_id` / `image_token_index` remain in `_UNSUPPORTED_CONFIG_KEYS` so every *other* VLM (Gemma4, Kimi, generic `ForCausalLM`+vision_config) keeps main #532's `text_coercible` degrade-to-text path. The denylist (Llava/Phi3V/…) still wins first → `vision_only` fail-fast. Adds a shared `_is_vl_model()` helper.
  - **Auto image-mode:** `materialize_config_with_envs` auto-detects VL models and switches to the Magpie `random-mm` script + injects image env vars (vllm only; sglang/atom stay text-only). An explicit `DATASET` env is honored as an opt-out. Previously `mm_mode` existed but had no caller. Coexists with main #532's new `FrameworkScriptMismatchError` guard (the auto-selected `vllm_*_mm.sh` shares the `vllm_` prefix, so it does not false-trip).
  - **Roofline:** the effective ISL now includes image vision tokens when image mode is active (`vision_tokens_per_image × MM_MAX_IMAGES`), so the ceiling reflects the true image+text input length. Kept atop main's new arm-aware `resolve_runtime_workload(state, *, arm=None)`.

  > **⚠️ Reviewer attention (@zgong, #532 author):** policy C promotes `qwen2_vl` / `qwen2_5_vl` from #532's deliberate `vision_only` block to first-class VL. Git auto-merged the unsupported-set change with **no conflict marker** — please confirm this reversal is intended. Documented in merge commit `4ef529b8`.

- **Merge status:** merged 116 commits of `origin/main` (incl. #532) into the branch; the VL gate was reconciled by hand (not git's silent auto-merge). `MERGEABLE`.

  **E2E evidence — re-validated POST-MERGE** (`Qwen3-VL-235B-A22B-Instruct-FP8`, 8× MI355X, TP8/EP8, `random-mm`):
  - All 5 checkpoints pass on the merged code (`34b6a40f`): gate admits as full VL (`degraded_mode: False`, not `text_coercible`); `vllm_mi355x_mm.sh` auto-selected with image envs; framework-mismatch guard does not false-trip; benchmark parses with non-null latency (`output_throughput=2307.7 tok/s/gpu`, `mean_ttft_ms=1367.2`, `mean_tpot_ms=22.4`, **input=1290 tok/req = 1024 text + 256 vision**); roofline effective ISL = 1024 + 256 = 1280.
  - Pre-merge run additionally showed the optimizer correctly flags `VLLM_ROCM_USE_AITER` as the top lever (+57–60% vs vLLM out-of-box).

  **Follow-ups (out of scope, noted intentionally):**
  1. Pre-quantized MoE dtype resolution: `quant_method` `quark`/`compressed-tensors` falls back to bf16 in `roofline_ceiling.load_model_meta`, collapsing the MoE roofline to dense for pre-quantized checkpoints. **Not VL-specific** (also affects e.g. `qwen3_5_moe`) — separate PR. BF16 VL MoE rooflines are correct.
  2. **EP-injection gap (surfaced by post-merge re-validation):** the roofline *profiler* sub-run rebuilds `EXTRA_VLLM_ARGS` to append `--profiler-config.*` and **drops** the injected `--enable-expert-parallel`, so its server hits the `block_n=128` FusedMoE error for 235B MoE. This is the EP-injection gap (tracked in #569), not the PR's roofline-ISL logic (verified correct directly). Fix direction: route EP via `extra_server_args` so the profiler's `merge_server_args` preserves it.
  3. Model-launch requirement (not a code change): Qwen3-VL-235B MoE at TP=8 needs `--enable-expert-parallel` (1536 experts / 8 = 192, not divisible by fp8 `block_n=128`). The orchestrator supplies this in `--explore`; baseline-only runs pass it via `EXTRA_VLLM_ARGS`.

- **Linked issue(s):** —

- **Tests:** **191** unit tests pass across `test_multimodal_gate`, `test_model_class_vl`, `test_workload_envs_vl` (new), `test_roofline_ceiling` — incl. a new policy-C coexistence regression (`test_policy_c_coexistence_qwen_vl_admitted_others_coerce`). Command: `python3 -m pytest inference_optimizer/tests/test_multimodal_gate.py inference_optimizer/tests/test_model_class_vl.py inference_optimizer/tests/test_workload_envs_vl.py inference_optimizer/tests/test_roofline_ceiling.py`. Full suite: 5132 passed (21 pre-existing env-dep failures in files identical to `origin/main`). Plus the post-merge real-config gate check + full e2e optimize run above.

- **Breaking changes:** No (behavior for non-VL and other-VLM models is preserved via policy C; Qwen-VL changes from rejected → supported).

---
**Related PR:** AMD-AGI/Magpie#44 (Magpie `random-mm` result-parsing fix) — required together; this Hyperloom change auto-selects the Magpie mm script that PR fixes.
