### PR TITLE
Pin GEAK to v3.2.1 release

### DIFF
--- a/kernel-agent/SKILL.md
+++ b/kernel-agent/SKILL.md
@@ -78,7 +78,7 @@ bash "$REPO_ROOT/kernel-agent/scripts/install.sh"
   `TraceLens_generate_perf_report_pytorch_inference --help`
   (Hyperloom is inference-only since v0.4; the training-mode CLI is no
   longer accepted)
-- GEAK CLI from `GEAK_REF` (default `v3.2.0`) +
+- GEAK CLI from `GEAK_REF` (default `v3.2.1`) +
   `${HYPERLOOM_RUNTIME_DIR}/geak-config/local.yaml` (model resolution:
   `GEAK_MODEL_NAME` / `GEAK_API_KEY` / `GEAK_BASE_URL` from env, default
   `claude-opus-4-7`). Run-mode default for the generated yaml is
@@ -101,7 +101,7 @@ bash "$REPO_ROOT/kernel-agent/scripts/install.sh"
       environments.
     - `profiler-mcp` — unified profiling MCP (Metrix + rocprof-compute);
       produces `profile.json` per attempt. Metrix is no longer a separate
-      `metrix-mcp` folder in v3.2.0 — it is pulled in transitively via
+      `metrix-mcp` folder in v3.2.1 — it is pulled in transitively via
       `profiler-mcp/pyproject.toml` (`dependencies = ["metrix>=0.1.0"]`).
     - `cross-session-memory-mcp` — SQLite-backed cross-session memory
       retriever; points at `GEAK_MEMORY_STORE_PATH` (default
@@ -488,7 +488,7 @@ than a silent skip.
   runner SIGTERMs at 100%. `parallel_e2e_runner` will still extract whatever
   `optimization_report.md` / `optimized_versions/*` were on disk at SIGTERM
   time and promote the attempt to `partial` (see Proposal Rules).
-- **Why GEAK budget tracks $GEAK_RUN_MODE**: GEAK v3.2.0 yaml ships two
+- **Why GEAK budget tracks $GEAK_RUN_MODE**: GEAK v3.2.1 yaml ships two
   presets — `run.budgets.quick.total_s=3600` (1 h, 2 rounds) and
   `run.budgets.full.total_s=7200` (2 h, 5 rounds). GEAK's mini.py:435
   resolves mode by LLM-parsing the prompt-quoted budget: <120 min → quick,

--- a/kernel-agent/scripts/install.sh
+++ b/kernel-agent/scripts/install.sh
@@ -126,10 +126,10 @@ if [ -z "${SAFE_API_KEY:-}" ] || [ -z "${OPENAI_BASE_URL:-}" ] || [ -z "${CURSOR
 fi
 GEAK_REPO="${GEAK_REPO:-https://github.com/AMD-AGI/GEAK.git}"
 GEAK_ROOT="${GEAK_ROOT:-${_open_source_root}/GEAK}"
-# Pin GEAK to the v3.2.0 release, which carries the GEMM tuning entrypoint
+# Pin GEAK to the v3.2.1 release, which carries the GEMM tuning entrypoint
 # used by kernel-agent/tools/gemm_tuning.py (minisweagent.run.gemm_tuning).
 # Operators can override with GEAK_REF=<tag|branch|sha>.
-GEAK_REF="${GEAK_REF:-v3.2.0}"
+GEAK_REF="${GEAK_REF:-v3.2.1}"
 OOB_SRC="${OOB_SRC:-${HYPERLOOM_BUNDLE}/OOB}"
 OOB_ROOT="${OOB_ROOT:-${OOB_CLI_ROOT:-${_open_source_root}/OOB}}"
 GEAK_CONFIG="${GEAK_CONFIG:-${HYPERLOOM_RUNTIME_DIR}/geak-config/local.yaml}"
@@ -866,7 +866,7 @@ ensure_geak() {
       _PIP_CONSTRAINT_ARGS="--constraint ${GEAK_PIP_CONSTRAINT_FILE}"
     fi
     run python3 -m pip install ${_PIP_FLAGS} ${_PIP_CONSTRAINT_ARGS} "${GEAK_ROOT}"
-    # GEAK v3.2.0 ships 4 MCP tools under mcp_tools/; all are imported
+    # GEAK v3.2.1 ships 4 MCP tools under mcp_tools/; all are imported
     # by the bundled ``minisweagent`` at preprocess time:
     #   * rag-mcp                    — knowledge-base retrieval (tools.rag)
     #   * profiler-mcp               — Metrix-backed instrumented profiling

--- a/kernel-agent/tests/test_kernel_agent.py
+++ b/kernel-agent/tests/test_kernel_agent.py
@@ -251,7 +251,7 @@ class KernelAgentToolTests(unittest.TestCase):
             'python3 -m pip install ${_PIP_FLAGS} ${_PIP_CONSTRAINT_ARGS} "${GEAK_ROOT}"',
             install_text,
         )
-        # GEAK v3.2.0 ships 4 MCP tool folders (metrix-mcp removed; transitive via profiler-mcp).
+        # GEAK v3.2.1 ships 4 MCP tool folders (metrix-mcp removed; transitive via profiler-mcp).
         for _mcp in (
             "rag-mcp",
             "profiler-mcp",
@@ -259,7 +259,7 @@ class KernelAgentToolTests(unittest.TestCase):
             "automated-test-discovery",
         ):
             self.assertIn(_mcp, install_text)
-        # Pin the v3.2.0 install-loop ordering so re-adding metrix-mcp regresses this.
+        # Pin the v3.2.1 install-loop ordering so re-adding metrix-mcp regresses this.
         self.assertIn(
             "for _geak_mcp in rag-mcp profiler-mcp \\\n"
             "                    cross-session-memory-mcp automated-test-discovery; do",

--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -1606,7 +1606,7 @@ def build_prompt(
         "  or `rg ... <repo>`, NEVER `find /`.\n"
         "\n"
         "GOAL & TIME BUDGET:\n"
-        # GEAK v3.2.0 LLM-parses prompt for `--mode full` / `mode=quick` etc.
+        # GEAK v3.2.1 LLM-parses prompt for `--mode full` / `mode=quick` etc.
         # (prompts.py:73-76 trigger list). Emit the explicit token so the
         # parser locks in the right preset (yaml run.budgets.<mode>) instead
         # of leaking off other prompt phrases like "quick micro-benchmark".


### PR DESCRIPTION
## Summary
- Bump the `GEAK_REF` default in `kernel-agent/scripts/install.sh` from `v3.2.0` to the **v3.2.1** release tag (`c0a1f937ca74789ec54bde4daae17db684acb33a`), the latest stable GEAK release. Operators can still override with `GEAK_REF=<tag|branch|sha>`.
- Update the matching version references in `kernel-agent/SKILL.md`, the budget-mode comment in `kernel-agent/tools/kernel_optimization.py`, and the MCP-tool assertions in `kernel-agent/tests/test_kernel_agent.py`.
- The historical `v3.1.0 -> v3.2.0` changelog note in `install.sh` is intentionally left intact.

All bumped facts were verified against the GEAK `v3.2.1` tag: same 4 MCP tools (`rag-mcp`, `profiler-mcp`, `cross-session-memory-mcp`, `automated-test-discovery`), `metrix-mcp` folder still removed with metrix pulled transitively via `profiler-mcp` (`metrix>=0.1.0`), and budget presets unchanged (`quick.total_s=3600`, `full.total_s=7200`).

This is the **release-pin alternative** to #556 (track GEAK `main`). The two PRs are mutually exclusive — they edit the same `GEAK_REF` default with opposite philosophies (reproducible release pin vs. always-latest branch tracking). #556 / #555 are being closed in favor of this approach.

Closes #578

## Test plan
- [ ] `kernel-agent/tests/test_kernel_agent.py` version/MCP assertions pass (2 unrelated failures pre-exist on `main`: `test_default_backends_include_geak_without_benchmark`, `test_missing_trace_input_fails_with_status_and_log`)
- [ ] Run `kernel-agent/scripts/install.sh` and confirm GEAK clones at the `v3.2.1` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)