### PR TITLE
feat(breakdown): record forge as its own SBD lane (geak/oob/forge)

### DIFF
--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -1555,6 +1555,7 @@ def collect_capability_summary(
     geak_invocations: list[dict[str, Any]],
     oob_invocations: list[dict[str, Any]],
     warnings: list[str],
+    forge_invocations: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Summarize kernel-optimization capability outcomes for the breakdown.
 
@@ -1563,10 +1564,12 @@ def collect_capability_summary(
         geak_invocations: GEAK backend invocation records.
         oob_invocations: Out-of-box backend invocation records.
         warnings: Mutable list that collected warnings are appended to.
+        forge_invocations: Forge backend invocation records (own lane).
 
     Returns:
         A capability-summary dict (per-kernel status, attempt and keep counts).
     """
+    forge_invocations = forge_invocations or []
     # Integrate (e2e) outcome per kernel: a kernel-opt KEEP REVERTED at
     # integrate is not a real adoption, so don't inflate the geak/oob tally.
     integ = state.get("kernel_integrate_attempts") or {}
@@ -1630,6 +1633,7 @@ def collect_capability_summary(
 
     geak_cap = _from_invocations(geak_invocations)
     oob_cap = _from_invocations(oob_invocations)
+    forge_cap = _from_invocations(forge_invocations)
 
     # Legacy capability rows for archived (pre-merge) sessions; current
     # sessions leave these not_attempted and carry activity under ``explore``.
@@ -1707,6 +1711,7 @@ def collect_capability_summary(
     return {
         "geak":           geak_cap,
         "oob":            oob_cap,
+        "forge":          forge_cap,
         # primary post-merge row; backends/params/validate_stack are compat rows.
         "explore":        explore,
         "backends":       backends,
@@ -2066,8 +2071,8 @@ def _infer_run_dir_kernel_id(run_dir: Path) -> str:
 def collect_kernel_invocations(
     session_dir: Path,
     warnings: list[str],
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-    """Return ``(geak_invocations, oob_invocations)`` from each run dir's ``optimization_attempts.jsonl``, split by ``backend``."""
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    """Return ``(geak_invocations, oob_invocations, forge_invocations)`` from each run dir's ``optimization_attempts.jsonl``, split by ``backend`` into three independent lanes."""
     all_invocations: list[dict[str, Any]] = []
     run_dirs = _kernel_agent_run_dirs(session_dir)
     for run_dir in run_dirs:
@@ -2102,17 +2107,22 @@ def collect_kernel_invocations(
 
     geak: list[dict[str, Any]] = []
     oob: list[dict[str, Any]] = []
+    forge: list[dict[str, Any]] = []
     for inv in all_invocations:
         backend = inv.get("backend") or ""
         if backend == "geak":
             geak.append(inv)
+        elif backend == "forge":
+            forge.append(inv)
         elif backend in ("claude", "codex"):
             oob.append(inv)
         else:
+            # Unknown / legacy backends fall back to the oob lane (forge keeps
+            # its own lane above so it is never mislabeled as oob).
             oob.append(inv)
-    geak.sort(key=lambda e: (e.get("kernel_id") or "", e.get("ts") or ""))
-    oob.sort(key=lambda e: (e.get("kernel_id") or "", e.get("ts") or ""))
-    return geak, oob
+    for lane in (geak, oob, forge):
+        lane.sort(key=lambda e: (e.get("kernel_id") or "", e.get("ts") or ""))
+    return geak, oob, forge
 
 
 # §9 Kernel lifecycle
@@ -2227,15 +2237,17 @@ def _collect_detected_kernels(
     oob: list[dict[str, Any]],
     warnings: list[str],
     *,
+    forge: list[dict[str, Any]] | None = None,
     cap: int | None = None,
 ) -> list[dict[str, Any]]:
     """Build the canonical per-kernel lifecycle row, keyed by ``kernel_id``.
 
     Merges static profile fields (from ``kernel_candidates.json``,
     preferred, else ``benchmark_report.kernel_summary``),
-    ``selected_for_optimization``, per-lane ``geak`` / ``oob`` summaries,
-    ``adopted_by`` (from integrate KEEPs), and ``final_decision``.
+    ``selected_for_optimization``, per-lane ``geak`` / ``oob`` / ``forge``
+    summaries, ``adopted_by`` (from integrate KEEPs), and ``final_decision``.
     """
+    forge = forge or []
     by_kid: dict[str, dict[str, Any]] = {}
 
     # 1) candidates.json (preferred: has call_count / duration_us).
@@ -2354,6 +2366,7 @@ def _collect_detected_kernels(
     }
     geak_idx = _index_invocations_by_kernel(geak)
     oob_idx = _index_invocations_by_kernel(oob)
+    forge_idx = _index_invocations_by_kernel(forge)
 
     integ = state.get("kernel_integrate_attempts") or {}
     adopted_kids: set[str] = set()
@@ -2381,24 +2394,23 @@ def _collect_detected_kernels(
         entry["selected_for_optimization"] = kid in selected_ids
         entry["geak"] = geak_idx.get(kid)  # None if lane never touched this kid
         entry["oob"] = oob_idx.get(kid)
+        entry["forge"] = forge_idx.get(kid)
         # e2e (integrate) gain so the table shows why a micro-KEPT kernel reverted.
         if kid in integ_gain_by_kid:
             entry["integrate_gain_pct"] = integ_gain_by_kid[kid]
         if kid in adopted_kids:
-            # Disambiguate which lane's patch was kept.
-            g_kept = bool(entry["geak"] and entry["geak"]["decision"] in ("KEEP", "PARTIAL"))
-            o_kept = bool(entry["oob"] and entry["oob"]["decision"] in ("KEEP", "PARTIAL"))
-            if g_kept and not o_kept:
-                entry["adopted_by"] = "geak"
-            elif o_kept and not g_kept:
-                entry["adopted_by"] = "oob"
-            elif g_kept and o_kept:
-                # Prefer the lane with higher micro-speedup.
-                g_spd = (entry["geak"] or {}).get("best_speedup") or 0.0
-                o_spd = (entry["oob"] or {}).get("best_speedup") or 0.0
-                entry["adopted_by"] = "geak" if g_spd >= o_spd else "oob"
+            # Disambiguate which lane's patch was kept. With three lanes, pick
+            # the KEPT lane with the highest micro-speedup; fall back to
+            # 'kernel_agent' when integrate KEPT but no single lane shows a KEEP.
+            kept_lanes: list[tuple[str, float]] = []
+            for lane in ("geak", "oob", "forge"):
+                row = entry.get(lane)
+                if row and row.get("decision") in ("KEEP", "PARTIAL"):
+                    kept_lanes.append((lane, row.get("best_speedup") or 0.0))
+            if kept_lanes:
+                entry["adopted_by"] = max(kept_lanes, key=lambda t: t[1])[0]
             else:
-                # Integrate KEEP but neither lane KEPT: record 'kernel_agent', don't guess.
+                # Integrate KEEP but no lane KEPT: record 'kernel_agent', don't guess.
                 entry["adopted_by"] = "kernel_agent"
             entry["final_decision"] = "kept"
         elif kid in reverted_kids:
@@ -2407,7 +2419,7 @@ def _collect_detected_kernels(
         elif kid in rejected_kids:
             entry["adopted_by"] = None
             entry["final_decision"] = "rejected"
-        elif entry["geak"] or entry["oob"]:
+        elif entry["geak"] or entry["oob"] or entry["forge"]:
             entry["adopted_by"] = None
             entry["final_decision"] = "attempted"
         else:
@@ -2461,10 +2473,11 @@ def _collect_optimized_kernels(
     geak: list[dict[str, Any]],
     oob: list[dict[str, Any]],
     state: dict[str, Any],
+    forge: list[dict[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
     """Fold per-attempt invocations into per-kernel optimization summaries.
 
-    Aggregates both lanes' attempts per kernel (counts, best micro-speedup,
+    Aggregates all lanes' attempts per kernel (counts, best micro-speedup,
     best artifact, decision history) and cross-references
     ``state.kernel_opt_attempts`` to recover decisions whose on-disk
     verification was rotated away.
@@ -2473,13 +2486,14 @@ def _collect_optimized_kernels(
         geak (list[dict[str, Any]]): GEAK-lane invocations.
         oob (list[dict[str, Any]]): OOB-lane invocations.
         state (dict[str, Any]): Parsed ``state.json``.
+        forge (list[dict[str, Any]] | None): Forge-lane invocations.
 
     Returns:
         list[dict[str, Any]]: Per-kernel optimization summaries sorted by
         ``kernel_id``.
     """
     by_kid: dict[str, dict[str, Any]] = {}
-    for invs in (geak, oob):
+    for invs in (geak, oob, forge or []):
         for inv in invs:
             kid = inv.get("kernel_id") or ""
             if not kid:
@@ -2621,6 +2635,7 @@ def collect_kernel_lifecycle(
     geak: list[dict[str, Any]],
     oob: list[dict[str, Any]],
     warnings: list[str],
+    forge: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Collect the §9 kernel-lifecycle section.
 
@@ -2633,15 +2648,17 @@ def collect_kernel_lifecycle(
         geak (list[dict[str, Any]]): GEAK-lane invocations.
         oob (list[dict[str, Any]]): OOB-lane invocations.
         warnings (list[str]): Shared warnings list (mutated in place).
+        forge (list[dict[str, Any]] | None): Forge-lane invocations (own lane).
 
     Returns:
         dict[str, Any]: ``{"detected", "recommended", "optimized", "adopted",
         "rejected"}`` lists.
     """
+    forge = forge or []
     return {
-        "detected":    _collect_detected_kernels(session_dir, state, geak, oob, warnings),
+        "detected":    _collect_detected_kernels(session_dir, state, geak, oob, warnings, forge=forge),
         "recommended": _collect_recommended_kernels(state),
-        "optimized":   _collect_optimized_kernels(geak, oob, state),
+        "optimized":   _collect_optimized_kernels(geak, oob, state, forge),
         "adopted":     _collect_adopted_kernels(state),
         "rejected":    _collect_rejected_kernels(state),
     }
@@ -3496,6 +3513,7 @@ def collect_attribution(
     oob_invocations: list[dict[str, Any]],
     adopted_kernels: list[dict[str, Any]],
     warnings: list[str],
+    forge_invocations: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Attribute end-to-end gains to individual optimization-stack entries.
 
@@ -3508,10 +3526,12 @@ def collect_attribution(
         oob_invocations: Out-of-box backend invocation records.
         adopted_kernels: Kernels adopted into the optimized stack.
         warnings: Mutable list that collected warnings are appended to.
+        forge_invocations: Forge backend invocation records (own lane).
 
     Returns:
         An attribution dict mapping stack entries to their measured gains.
     """
+    forge_invocations = forge_invocations or []
     # Prefer the authoritative ``gain_per_stack_entry`` ledger; else reconstruct from optimization_stack.
     state_entries = state.get("gain_per_stack_entry")
     state_provided = isinstance(state_entries, list) and len(state_entries) > 0
@@ -3569,20 +3589,24 @@ def collect_attribution(
         fam = _action_family(str(e.get("action") or ""))
         family_totals[fam] = family_totals.get(fam, 0.0) + max(delta, 0.0)
 
-    # Split "kernel" between GEAK / OOB based on adopted KEEP entries' backend
+    # Split "kernel" between GEAK / OOB / Forge based on adopted KEEP entries' backend
     geak_kept_kids = {inv.get("kernel_id") for inv in geak_invocations if inv.get("decision") == "KEEP"}
     oob_kept_kids  = {inv.get("kernel_id") for inv in oob_invocations  if inv.get("decision") == "KEEP"}
+    forge_kept_kids = {inv.get("kernel_id") for inv in forge_invocations if inv.get("decision") == "KEEP"}
     kernel_total = family_totals.get("kernel", 0.0)
     geak_total = 0.0
     oob_total = 0.0
+    forge_total = 0.0
     for k in adopted_kernels:
         kid = k.get("kernel_id")
         gain = _to_float(k.get("e2e_gain_pct")) or 0.0
         if kid in geak_kept_kids:
             geak_total += gain
+        elif kid in forge_kept_kids:
+            forge_total += gain
         elif kid in oob_kept_kids:
             oob_total += gain
-    if geak_total + oob_total == 0.0 and kernel_total > 0.0:
+    if geak_total + oob_total + forge_total == 0.0 and kernel_total > 0.0:
         # Default all-OOB when no KEEP'd adopt entry is on disk.
         oob_total = kernel_total
 
@@ -3609,6 +3633,7 @@ def collect_attribution(
         "source_breakdown": {
             "geak_pct_of_total":     round(geak_total, 2),
             "oob_pct_of_total":      round(oob_total, 2),
+            "forge_pct_of_total":    round(forge_total, 2),
             # primary row.
             "explore_pct_of_total":  round(family_totals.get("explore", 0.0), 2),
             # FRAMEWORK_PR row; always emitted (0.0 when disabled/empty).

--- a/inference_optimizer/breakdown/exporter.py
+++ b/inference_optimizer/breakdown/exporter.py
@@ -259,22 +259,25 @@ def build(
                                        ),
                                        warnings,
                                        default=[])
-    geak_c, oob_c = _safe_collect(
+    geak_c, oob_c, forge_c = _safe_collect(
         "invocations",
         lambda: collectors.collect_kernel_invocations(sd, warnings),
         warnings,
-        default=([], []),
+        default=([], [], []),
     )
     geak_invocations = _pick("geak_invocations", geak_c)
     oob_invocations = _pick("oob_invocations", oob_c)
+    forge_invocations = _pick("forge_invocations", forge_c)
     capability_summary = _safe_collect("capability_summary",
                                         lambda: collectors.collect_capability_summary(
                                             state, geak_invocations, oob_invocations, warnings,
+                                            forge_invocations,
                                         ),
                                         warnings)
     kernel_lifecycle   = _safe_collect("kernel_lifecycle",
                                         lambda: collectors.collect_kernel_lifecycle(
                                             sd, state, geak_invocations, oob_invocations, warnings,
+                                            forge_invocations,
                                         ),
                                         warnings)
     explore_search     = _pick("explore_search", _safe_collect("explore_search",
@@ -294,6 +297,7 @@ def build(
                                             state, geak_invocations, oob_invocations,
                                             kernel_lifecycle.get("adopted") or [],
                                             warnings,
+                                            forge_invocations,
                                         ),
                                         warnings)
     kb_provenance      = _pick("kb_provenance", _safe_collect("kb_provenance",
@@ -423,6 +427,7 @@ def build(
         "capability_summary":  capability_summary,
         "geak_invocations":    geak_invocations,
         "oob_invocations":     oob_invocations,
+        "forge_invocations":   forge_invocations,
         "kernel_lifecycle":    kernel_lifecycle,
         "param_search":        explore_search,
         # v2-native name for the merged ledger; mirrors ``param_search``.

--- a/inference_optimizer/breakdown/recorder/instrument.py
+++ b/inference_optimizer/breakdown/recorder/instrument.py
@@ -34,10 +34,14 @@ log = logging.getLogger(__name__)
 PRODUCER_COORDINATOR = "coordinator"
 PRODUCER_KERNEL_AGENT = "kernel-agent"
 
-# kernel-agent backend -> invocation section. geak is its own lane; the
-# out-of-band LLM backends (claude/codex) share the oob lane.
+# kernel-agent backend -> invocation section. Three independent lanes: geak,
+# the out-of-band LLM backends (claude/codex) on the oob lane, and forge
+# (Kernel-Forge autonomous loop) on its own lane. forge is NOT folded into oob
+# — it is a distinct backend, so it gets a distinct ``forge_invocations``
+# section (and a distinct capability/attribution row downstream).
 _GEAK_BACKENDS = frozenset({"geak"})
 _OOB_BACKENDS = frozenset({"claude", "codex"})
+_FORGE_BACKENDS = frozenset({"forge"})
 
 _FAILED_STATUSES = frozenset({"failed", "error", "crashed", "timeout"})
 
@@ -288,6 +292,8 @@ def _invocation_section(backend: str) -> str | None:
     b = str(backend or "").lower()
     if b in _GEAK_BACKENDS:
         return "geak_invocations"
+    if b in _FORGE_BACKENDS:
+        return "forge_invocations"
     if b in _OOB_BACKENDS:
         return "oob_invocations"
     return None
@@ -424,6 +430,10 @@ _TOOL_PROVENANCE: dict[str, dict[str, Any]] = {
     "geak":         {"root_env": "GEAK_ROOT",                 "version": "git_short"},
     "mini":         {"root_env": "GEAK_ROOT",                 "version": "git_short"},
     "geak-gaagent": {"root_env": "GEAK_ROOT",                 "version": "git_short"},
+    # forge (Kernel-Forge autonomous loop) is its own backend; it locates its
+    # repo via $FORGE_PATH (forge_submit also accepts $KERNEL_FORGE_ROOT /
+    # $KERNEL_FORGE_PATH, but root resolution here pins the primary env var).
+    "forge":        {"root_env": "FORGE_PATH",               "version": "git_short"},
     "claude":       {"root_env": "",                          "version": ("cmd", ("claude", "--version"))},
     "codex":        {"root_env": "",                          "version": ("cmd", ("codex", "--version"))},
     "oob":          {"root_env": "",                          "version": ("dist", ("oob-mcp-server",))},

--- a/inference_optimizer/breakdown/recorder/sections.py
+++ b/inference_optimizer/breakdown/recorder/sections.py
@@ -31,6 +31,7 @@ SECTION_SHAPES: dict[str, SectionShape] = {
     "phase_timeline":              "item",
     "geak_invocations":            "item",
     "oob_invocations":             "item",
+    "forge_invocations":           "item",
     "kernel_lifecycle":            "singleton",
     "explore_search":              "singleton",
     "sweep":                       "singleton",

--- a/inference_optimizer/breakdown/schema.py
+++ b/inference_optimizer/breakdown/schema.py
@@ -1731,6 +1731,8 @@ class SessionBreakdown(TypedDict, total=False):
         capability_summary (CapabilitySummary): Per-capability roll-up.
         geak_invocations (list[Invocation]): GEAK backend invocations.
         oob_invocations (list[Invocation]): Out-of-box backend invocations.
+        forge_invocations (list[Invocation]): Forge (Kernel-Forge) backend
+            invocations — its own lane, NOT folded into ``oob_invocations``.
         kernel_lifecycle (KernelLifecycle): Kernels grouped by lifecycle stage.
         param_search (ParamSearch): v1-reader compat alias for ``explore_search``.
         explore_search (ParamSearch): Merged explore-search ledger.
@@ -1766,6 +1768,7 @@ class SessionBreakdown(TypedDict, total=False):
     capability_summary: CapabilitySummary
     geak_invocations: list[Invocation]
     oob_invocations: list[Invocation]
+    forge_invocations: list[Invocation]
     kernel_lifecycle: KernelLifecycle
     # explore_search is the native merged ledger; param_search is a v1 alias.
     param_search: ParamSearch

--- a/inference_optimizer/tests/test_breakdown_smoke.py
+++ b/inference_optimizer/tests/test_breakdown_smoke.py
@@ -276,6 +276,7 @@ def test_envelope(fixture_session: Path) -> None:
     for key in (
         "session", "workload", "baseline", "final", "phase_timeline",
         "capability_summary", "geak_invocations", "oob_invocations",
+        "forge_invocations",
         "kernel_lifecycle", "param_search", "sweep", "critic_robustness",
         "telemetry", "attribution", "warnings", "source_files",
     ):

--- a/inference_optimizer/tests/test_forge_lane.py
+++ b/inference_optimizer/tests/test_forge_lane.py
@@ -1,0 +1,68 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""forge is an independent third lane (geak / oob / forge).
+
+These tests pin the contract that forge is NOT folded into the oob lane: it
+gets its own ``forge_invocations`` section, its own capability-summary row, its
+own attribution bucket, and its own ``adopted_by`` value — everywhere the
+breakdown splits invocations by lane.
+"""
+from __future__ import annotations
+
+from inference_optimizer.breakdown import collectors
+from inference_optimizer.breakdown.recorder import instrument
+
+
+def test_invocation_section_forge_is_own_lane() -> None:
+    assert instrument._invocation_section("geak") == "geak_invocations"
+    assert instrument._invocation_section("forge") == "forge_invocations"
+    # claude/codex stay on oob; forge is never routed there.
+    assert instrument._invocation_section("claude") == "oob_invocations"
+    assert instrument._invocation_section("codex") == "oob_invocations"
+
+
+def test_capability_summary_has_distinct_forge_row() -> None:
+    forge_invs = [{"kernel_id": "k1", "decision": "KEEP", "micro_speedup": 1.4}]
+    cap = collectors.collect_capability_summary(
+        {}, [], [], [], forge_invocations=forge_invs,
+    )
+    # forge gets its own row with its own KEEP tally.
+    assert cap["forge"]["attempts"] == 1
+    assert cap["forge"]["keeps"] == 1
+    assert cap["forge"]["status"] == "kept"
+    # oob stays empty — forge was not folded into it.
+    assert cap["oob"]["attempts"] == 0
+    assert cap["oob"]["keeps"] == 0
+
+
+def test_optimized_kernels_includes_forge_attempts() -> None:
+    forge_invs = [{
+        "kernel_id": "k1", "backend": "forge", "decision": "KEEP",
+        "micro_speedup": 1.6, "attempt_id": "a1", "ts": "2026-06-16T00:00:00Z",
+    }]
+    rows = collectors._collect_optimized_kernels([], [], {}, forge_invs)
+    by_kid = {r["kernel_id"]: r for r in rows}
+    assert "k1" in by_kid
+    assert by_kid["k1"]["backend"] == "forge"
+    assert by_kid["k1"]["best_micro_speedup"] == 1.6
+    assert by_kid["k1"]["successful_attempts"] == 1
+
+
+def test_attribution_splits_kernel_gain_to_forge() -> None:
+    state = {"gain_per_stack_entry": [{"action": "kernel_opt", "delta_pct": 10.0}]}
+    forge_invs = [{"kernel_id": "k1", "decision": "KEEP"}]
+    adopted = [{"kernel_id": "k1", "e2e_gain_pct": 10.0}]
+    out = collectors.collect_attribution(
+        state, [], [], adopted, [], forge_invocations=forge_invs,
+    )
+    sb = out["source_breakdown"]
+    # The adopted kernel's gain is attributed to forge, not oob.
+    assert sb["forge_pct_of_total"] == 10.0
+    assert sb["oob_pct_of_total"] == 0.0
+
+
+def test_attribution_backward_compatible_without_forge() -> None:
+    # Legacy 5-arg call (no forge) still works and never errors.
+    out = collectors.collect_attribution({}, [], [], [], [])
+    assert "source_breakdown" in out
+    assert out["source_breakdown"]["forge_pct_of_total"] == 0.0

--- a/inference_optimizer/tests/test_kernel_journey.py
+++ b/inference_optimizer/tests/test_kernel_journey.py
@@ -190,6 +190,33 @@ def test_versions_map_composed_at_top_level(tmp_path: Path) -> None:
     assert "tool" not in out["kernel_journey"]["kernels"][0]["backend_attempts"][0]
 
 
+def test_forge_backend_mints_versions_entry(tmp_path: Path) -> None:
+    # forge is its own backend (NOT folded into oob): a forge attempt keeps
+    # backend="forge" in the journey and mints a distinct versions["forge"]
+    # provenance entry (via _TOOL_PROVENANCE), so A8b can group by forge version.
+    sha = _init_git_repo(tmp_path)
+    instrument.record_kernel_discovery(
+        tmp_path, source="tracelens", status="success",
+        hot_kernels=[{"kernel_id": "k1", "name": "moe", "gpu_pct": 10.0}],
+        scan={},
+    )
+    instrument.record_kernel_backend_result(tmp_path, {
+        "kernel_id": "k1", "run_id": "r1", "attempts": [
+            {"attempt_id": "a1", "backend": "forge", "status": "completed",
+             "metadata": {"root_dir": str(tmp_path)}},
+        ],
+    })
+    out = assemble_parts(tmp_path)
+    # The attempt keeps its own backend label in the journey.
+    atts = out["kernel_journey"]["kernels"][0]["backend_attempts"]
+    assert atts[0]["backend"] == "forge"
+    # Distinct provenance entry, NOT merged into oob.
+    versions = out["versions"]
+    assert versions["forge"]["tool"] == "forge"
+    assert versions["forge"]["version"] == sha
+    assert "oob" not in versions
+
+
 def test_discovery_run_carries_duration(tmp_path: Path) -> None:
     instrument.record_kernel_discovery(
         tmp_path, source="tracelens", status="success",
@@ -243,6 +270,11 @@ def test_tool_version_probe_git_strategies(tmp_path: Path) -> None:
     # tracelens -> git describe (--always falls back to the short sha here).
     meta_tl = instrument._tool_metadata("tracelens", root=str(tmp_path))
     assert meta_tl["version"]  # non-empty describe output
+    # forge -> git short SHA (own backend, $FORGE_PATH-rooted); same strategy
+    # as geak so a real session mints a populated versions["forge"].
+    meta_forge = instrument._tool_metadata("forge", root=str(tmp_path))
+    assert meta_forge["commit"] == sha
+    assert meta_forge["version"] == sha
     # A caller-supplied version always wins over the probe.
     meta_explicit = instrument._tool_metadata(
         "geak", root=str(tmp_path), version="v9.9",


### PR DESCRIPTION
## Summary

`forge` (Kernel-Forge autonomous loop) is a distinct kernel-agent backend, **not** an out-of-band LLM agent. This makes it a first-class **third lane** in the session breakdown end to end, instead of being dropped by the recorder or silently folded into `oob` by the collector catch-all.

- **recorder** (`instrument.py`): route `forge` → `forge_invocations` (new `_FORGE_BACKENDS`), register the section in `sections.py`, and add `forge` to `_TOOL_PROVENANCE` (`$FORGE_PATH`, git short SHA) so a real session mints a populated `versions["forge"]`.
- **schema/exporter**: emit a top-level `forge_invocations` list parallel to `geak_invocations` / `oob_invocations`.
- **collectors**: `collect_kernel_invocations` now returns `(geak, oob, forge)`; add a `forge` capability row, a per-kernel `forge` summary + `adopted_by` resolution across three lanes, and a `forge_pct_of_total` attribution row.

`oob` semantics are unchanged (claude/codex stay on the oob lane); unknown/legacy backends still fall back to `oob` so `forge` is never mislabeled. `backend_attempts[].backend="forge"` in `kernel_journey` is unchanged (it already carried forge verbatim).

Context: the default kernel ladder is now `forge` + `geak` (oob defaults empty), so "geak vs forge" is the new normal. pulse-service already lanes `forge` separately (`LANES=(geak, oob, forge)`); this aligns the Hyperloom producer side.

## Test plan

- [x] `test_kernel_journey.py`: forge mints a distinct `versions["forge"]`; forge provenance probe (git short) hits.
- [x] `test_forge_lane.py`: forge invocations land in their own lane (not oob), capability/optimized/attribution rows carry forge.
- [x] `test_breakdown_smoke.py`: top-level `forge_invocations` present.
