### PR TITLE
fix(inference-optimizer): preflight model gates + Gemma2 roofline shape-discovery workaround

### DIFF
--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -48,6 +48,7 @@ from .cli_backends import (  # noqa: F401 - re-exported for callers/tests
 from .orchestrator.backends import ClaudeBackend
 from .manifest import load_manifest, write_manifest
 from .model_config_utils import (  # noqa: F401 - re-exported for callers/tests
+    GEMMA2_ARCHITECTURES as _GEMMA2_ARCHITECTURES,
     _config_architectures,
     _load_model_config_dict,
     _model_is_gemma2,
@@ -1188,14 +1189,19 @@ _UNREGISTERED_CUSTOM_CONFIG_TYPES = frozenset({"kimi_k2"})
 # type mimo_v2_flash to instantiate a model of type ." + Unknown attention
 # backend TRITON) — the unrecognized arch leaves an empty model type.
 # deepseek_v4: confirmed from DeepSeek-V4-Flash server.log ModelConfig
-# validation failure. ministral3: vLLM registry raises KeyError('ministral3').
+# validation failure.
 _UNRECOGNIZED_MODEL_TYPES = frozenset({
-    "deepseek_v4", "glm4_moe_lite", "mimo_v2_flash", "ministral3",
+    "deepseek_v4", "glm4_moe_lite", "mimo_v2_flash",
 })
 _UNRECOGNIZED_ARCHITECTURES = frozenset({
     "deepseekv4forcausallm", "glm4moeliteforcausallm",
     "mimov2flashforcausallm",
 })
+# ministral3 only fails inside a Mistral3 multimodal wrapper (Surpem-Supertron2
+# server.log: vLLM registry raises KeyError('ministral3') for text_config.
+# model_type). A bare top-level ministral3 is left to the framework to judge, so
+# this is checked only against the nested text_config scope.
+_NESTED_ONLY_UNRECOGNIZED_MODEL_TYPES = frozenset({"ministral3"})
 
 # Phi-3 su/longrope rope_scaling: Phi3Config._rope_scaling_validation() requires
 # rope_scaling to be a dict of EXACTLY 3 keys (type/short_factor/long_factor).
@@ -1208,8 +1214,8 @@ _PHI3_ROPE_TYPES = frozenset({"su", "longrope"})
 # Gemma2 missing hidden_act: sglang's gemma2 runtime reads config.hidden_act
 # unconditionally. Some checkpoints ship only hidden_activation (the HF field
 # name), so config.hidden_act is absent and the model crashes with
-# AttributeError in engine init. Hardware-agnostic.
-_GEMMA2_ARCHITECTURES = frozenset({"gemma2forcausallm"})
+# AttributeError in engine init. Hardware-agnostic. ``_GEMMA2_ARCHITECTURES`` is
+# imported from model_config_utils (single source of truth) at module top.
 
 # Quantization formats with no ROCm/AMD runtime path. NVIDIA ModelOpt FP8/NVFP4
 # use vendor-specific scale packing (no sglang ROCm loader); bitsandbytes ships
@@ -1346,15 +1352,20 @@ def _detect_unrecognized_architecture(data: dict) -> str | None:
     Hardware-agnostic: the ModelConfig pydantic validation rejects the unknown
     model_type with a ValidationError in engine init on any GPU vendor.
     """
-    scopes = [data]
+    scopes = [(data, False)]
     nested = data.get("text_config")
     if isinstance(nested, dict):
-        scopes.append(nested)
-    for scope in scopes:
+        scopes.append((nested, True))
+    for scope, is_nested in scopes:
         model_type = str(scope.get("model_type") or "").strip().lower()
         arches = {a.lower() for a in _config_architectures(scope)}
+        unrecognized_types = _UNRECOGNIZED_MODEL_TYPES
+        if is_nested:
+            unrecognized_types = (
+                _UNRECOGNIZED_MODEL_TYPES | _NESTED_ONLY_UNRECOGNIZED_MODEL_TYPES
+            )
         if (
-            model_type in _UNRECOGNIZED_MODEL_TYPES
+            model_type in unrecognized_types
             or arches & _UNRECOGNIZED_ARCHITECTURES
         ):
             label = model_type or (next(iter(arches), "") if arches else "?")
@@ -1393,7 +1404,13 @@ def _read_safetensors_header(path: Path) -> dict | None:
 
 
 def _detect_vocab_weight_shape_mismatch(model_path: str, data: dict) -> str | None:
-    """Return a reason when config vocab_size disagrees with model weights."""
+    """Return a reason when config vocab_size disagrees with model weights.
+
+    Best-effort and safetensors-only: reads just the JSON header (never tensor
+    data) of ``*.safetensors`` shards. Legacy ``*.bin``/``pytorch_model.bin``
+    checkpoints are not inspected; truncated/corrupt headers are skipped
+    silently (return None) and left to the downstream loader.
+    """
     expected = data.get("vocab_size")
     nested = data.get("text_config")
     if not isinstance(expected, int) and isinstance(nested, dict):

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -17,6 +17,7 @@ import re
 import shlex
 import shutil
 import signal
+import struct
 import subprocess
 import sys
 import time
@@ -1094,6 +1095,32 @@ def _model_is_moe(model_path: str) -> bool:
     return False
 
 
+# Gemma2 forward builds ``normalizer = torch.tensor(...)`` (a host scalar) on
+# every call. The TraceLens kernel_shape_profiler patch activates inside the
+# CUDA-graph capture critical section, so that host construct runs during HIP
+# stream capture and raises ``hipErrorStreamCaptureUnsupported`` -> capture
+# fails -> roofline produces no ceiling. Callers skip shape-discovery for
+# Gemma2 to keep CUDA graph while avoiding the crash.
+_GEMMA2_ARCH_MARKERS = frozenset({"gemma2forcausallm"})
+
+
+def _model_is_gemma2(model_path: str) -> bool:
+    """Best-effort detect a Gemma2 model from config.json (top level or text_config)."""
+    data = _load_model_config_dict(model_path)
+    if data is None:
+        return False
+    candidates = [data]
+    nested = data.get("text_config")
+    if isinstance(nested, dict):
+        candidates.append(nested)
+    for cfg in candidates:
+        if str(cfg.get("model_type") or "").strip().lower() == "gemma2":
+            return True
+        if any(a.lower() in _GEMMA2_ARCH_MARKERS for a in _config_architectures(cfg)):
+            return True
+    return False
+
+
 def _context_headroom_tokens() -> int:
     """Resolve the context headroom (tokens); env override, else default."""
     raw = os.environ.get(_CONTEXT_HEADROOM_ENV, "").strip()
@@ -1216,9 +1243,14 @@ _UNREGISTERED_CUSTOM_CONFIG_TYPES = frozenset({"kimi_k2"})
 # mimo_v2_flash: confirmed from XiaomiMiMo-MiMo-V2-Flash server.log ("model of
 # type mimo_v2_flash to instantiate a model of type ." + Unknown attention
 # backend TRITON) — the unrecognized arch leaves an empty model type.
-_UNRECOGNIZED_MODEL_TYPES = frozenset({"glm4_moe_lite", "mimo_v2_flash"})
+# deepseek_v4: confirmed from DeepSeek-V4-Flash server.log ModelConfig
+# validation failure. ministral3: vLLM registry raises KeyError('ministral3').
+_UNRECOGNIZED_MODEL_TYPES = frozenset({
+    "deepseek_v4", "glm4_moe_lite", "mimo_v2_flash", "ministral3",
+})
 _UNRECOGNIZED_ARCHITECTURES = frozenset({
-    "glm4moeliteforcausallm", "mimov2flashforcausallm",
+    "deepseekv4forcausallm", "glm4moeliteforcausallm",
+    "mimov2flashforcausallm",
 })
 
 # Phi-3 su/longrope rope_scaling: Phi3Config._rope_scaling_validation() requires
@@ -1370,19 +1402,87 @@ def _detect_unrecognized_architecture(data: dict) -> str | None:
     Hardware-agnostic: the ModelConfig pydantic validation rejects the unknown
     model_type with a ValidationError in engine init on any GPU vendor.
     """
-    model_type = str(data.get("model_type") or "").strip().lower()
-    arches = {a.lower() for a in _config_architectures(data)}
-    if (
-        model_type in _UNRECOGNIZED_MODEL_TYPES
-        or arches & _UNRECOGNIZED_ARCHITECTURES
-    ):
-        label = model_type or (next(iter(arches), "") if arches else "?")
-        return (
-            f"model type '{label}' is not recognized by Transformers/sglang's "
-            f"ModelConfig; engine init raises a pydantic ValidationError "
-            f"('does not recognize this architecture'). Needs a framework "
-            f"upgrade or a registered architecture mapping."
-        )
+    scopes = [data]
+    nested = data.get("text_config")
+    if isinstance(nested, dict):
+        scopes.append(nested)
+    for scope in scopes:
+        model_type = str(scope.get("model_type") or "").strip().lower()
+        arches = {a.lower() for a in _config_architectures(scope)}
+        if (
+            model_type in _UNRECOGNIZED_MODEL_TYPES
+            or arches & _UNRECOGNIZED_ARCHITECTURES
+        ):
+            label = model_type or (next(iter(arches), "") if arches else "?")
+            return (
+                f"model type '{label}' is not recognized by Transformers/"
+                f"sglang/vLLM's ModelConfig or model registry; engine init "
+                f"raises a validation/registry error. Needs a framework "
+                f"upgrade or a registered architecture mapping."
+            )
+    return None
+
+
+_VOCAB_WEIGHT_NAMES = (
+    "embed_tokens.weight",
+    "wte.weight",
+    "word_embeddings.weight",
+    "lm_head.weight",
+)
+_SAFETENSORS_HEADER_LIMIT = 64 * 1024 * 1024
+
+
+def _read_safetensors_header(path: Path) -> dict | None:
+    """Read only the safetensors JSON header; never materialize tensor data."""
+    try:
+        with path.open("rb") as f:
+            raw_len = f.read(8)
+            if len(raw_len) != 8:
+                return None
+            header_len = struct.unpack("<Q", raw_len)[0]
+            if header_len <= 0 or header_len > _SAFETENSORS_HEADER_LIMIT:
+                return None
+            header = json.loads(f.read(header_len))
+    except (OSError, json.JSONDecodeError, ValueError, struct.error):
+        return None
+    return header if isinstance(header, dict) else None
+
+
+def _detect_vocab_weight_shape_mismatch(model_path: str, data: dict) -> str | None:
+    """Return a reason when config vocab_size disagrees with model weights."""
+    expected = data.get("vocab_size")
+    nested = data.get("text_config")
+    if not isinstance(expected, int) and isinstance(nested, dict):
+        expected = nested.get("vocab_size")
+    if isinstance(expected, bool) or not isinstance(expected, int) or expected <= 0:
+        return None
+
+    mdir = Path(model_path)
+    for st_path in sorted(mdir.glob("*.safetensors")):
+        header = _read_safetensors_header(st_path)
+        if not header:
+            continue
+        for name, meta in header.items():
+            if name == "__metadata__" or not isinstance(meta, dict):
+                continue
+            if not any(name.endswith(suffix) for suffix in _VOCAB_WEIGHT_NAMES):
+                continue
+            shape = meta.get("shape")
+            if not (
+                isinstance(shape, list)
+                and shape
+                and isinstance(shape[0], int)
+                and not isinstance(shape[0], bool)
+            ):
+                continue
+            actual = shape[0]
+            if actual != expected:
+                return (
+                    f"config.json vocab_size={expected} but {st_path.name}:"
+                    f"{name} has vocab dimension {actual}; sglang asserts "
+                    f"loaded_weight.shape[output_dim] matches org_vocab_size "
+                    f"during weight loading."
+                )
     return None
 
 
@@ -1492,6 +1592,9 @@ def _detect_incompatible_model_config(
     unrecognized_reason = _detect_unrecognized_architecture(data)
     if unrecognized_reason is not None:
         return unrecognized_reason
+    vocab_shape_reason = _detect_vocab_weight_shape_mismatch(model_path, data)
+    if vocab_shape_reason is not None:
+        return vocab_shape_reason
     # Missing tokenizer artifacts: hardware-agnostic; the degraded fallback
     # tokenizer's empty-prompt warmup triggers an aiter M=0 SIGFPE.
     tokenizer_reason = _detect_missing_tokenizer_files(model_path, data)

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -47,6 +47,11 @@ from .cli_backends import (  # noqa: F401 - re-exported for callers/tests
 )
 from .orchestrator.backends import ClaudeBackend
 from .manifest import load_manifest, write_manifest
+from .model_config_utils import (  # noqa: F401 - re-exported for callers/tests
+    _config_architectures,
+    _load_model_config_dict,
+    _model_is_gemma2,
+)
 from .orchestrator.action_registry import ActionRegistry
 from .orchestrator.coordinator import Coordinator
 from .orchestrator.proposal_scorer import DEFAULT_SCORER_MODELS
@@ -670,41 +675,6 @@ def _load_model_arch(workspace_root: Path, model_name: str) -> dict:
     return data
 
 
-def _load_model_config_dict(model_path: str) -> dict | None:
-    """Best-effort parse of ``<model_path>/config.json`` into a dict; returns ``None`` on any failure."""
-    if not model_path:
-        return None
-    cfg_path = Path(model_path) / "config.json"
-    try:
-        raw = cfg_path.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        return None
-    except OSError as exc:
-        logging.warning("model_config_unreadable: %s (%s)", cfg_path, exc)
-        return None
-    try:
-        data = json.loads(raw)
-    except (json.JSONDecodeError, ValueError) as exc:
-        logging.warning("model_config_invalid_json: %s (%s)", cfg_path, exc)
-        return None
-    if not isinstance(data, dict):
-        logging.warning(
-            "model_config_not_a_dict: %s (got %s)", cfg_path, type(data).__name__,
-        )
-        return None
-    return data
-
-
-def _config_architectures(config: dict) -> list[str]:
-    """Normalise ``config["architectures"]`` to a list of non-empty strings (scalar wrapped; absent -> [])."""
-    arches_raw = config.get("architectures")
-    if isinstance(arches_raw, list):
-        return [str(a).strip() for a in arches_raw if str(a or "").strip()]
-    if isinstance(arches_raw, str) and arches_raw.strip():
-        return [arches_raw.strip()]
-    return []
-
-
 def _load_model_config_tags(model_path: str) -> dict:
     """Best-effort loader for KB architecture-identity tags (``architectures`` + ``model_type``) from config.json.
 
@@ -1091,32 +1061,6 @@ def _model_is_moe(model_path: str) -> bool:
         if "moe" in str(cfg.get("model_type") or "").lower():
             return True
         if any("moe" in arch.lower() for arch in _config_architectures(cfg)):
-            return True
-    return False
-
-
-# Gemma2 forward builds ``normalizer = torch.tensor(...)`` (a host scalar) on
-# every call. The TraceLens kernel_shape_profiler patch activates inside the
-# CUDA-graph capture critical section, so that host construct runs during HIP
-# stream capture and raises ``hipErrorStreamCaptureUnsupported`` -> capture
-# fails -> roofline produces no ceiling. Callers skip shape-discovery for
-# Gemma2 to keep CUDA graph while avoiding the crash.
-_GEMMA2_ARCH_MARKERS = frozenset({"gemma2forcausallm"})
-
-
-def _model_is_gemma2(model_path: str) -> bool:
-    """Best-effort detect a Gemma2 model from config.json (top level or text_config)."""
-    data = _load_model_config_dict(model_path)
-    if data is None:
-        return False
-    candidates = [data]
-    nested = data.get("text_config")
-    if isinstance(nested, dict):
-        candidates.append(nested)
-    for cfg in candidates:
-        if str(cfg.get("model_type") or "").strip().lower() == "gemma2":
-            return True
-        if any(a.lower() in _GEMMA2_ARCH_MARKERS for a in _config_architectures(cfg)):
             return True
     return False
 

--- a/inference_optimizer/model_config_utils.py
+++ b/inference_optimizer/model_config_utils.py
@@ -54,21 +54,43 @@ def _config_architectures(config: dict) -> list[str]:
 # stream capture and raises ``hipErrorStreamCaptureUnsupported`` -> capture
 # fails -> roofline produces no ceiling. Callers skip shape-discovery for
 # Gemma2 to keep CUDA graph while avoiding the crash.
-_GEMMA2_ARCH_MARKERS = frozenset({"gemma2forcausallm"})
+# Single source of truth: ``cli`` reuses these for its preflight checks too.
+GEMMA2_MODEL_TYPE = "gemma2"
+GEMMA2_ARCHITECTURES = frozenset({"gemma2forcausallm"})
+
+
+def _path_looks_like_gemma2(model_path: str) -> bool:
+    """Heuristic Gemma2 detection from the path when config.json is absent.
+
+    Matches a ``gemma-2`` / ``gemma2`` directory name while excluding Gemma3, so
+    a not-yet-materialized Hub-id style path still gets the workaround.
+    """
+    if not model_path:
+        return False
+    compact = (
+        Path(model_path).name.lower()
+        .replace("-", "").replace("_", "").replace(".", "")
+    )
+    if "gemma3" in compact:
+        return False
+    return "gemma2" in compact
 
 
 def _model_is_gemma2(model_path: str) -> bool:
-    """Best-effort detect a Gemma2 model from config.json (top level or text_config)."""
+    """Best-effort detect a Gemma2 model from config.json (top level or text_config).
+
+    Falls back to a path heuristic when config.json is missing/unreadable.
+    """
     data = _load_model_config_dict(model_path)
     if data is None:
-        return False
+        return _path_looks_like_gemma2(model_path)
     candidates = [data]
     nested = data.get("text_config")
     if isinstance(nested, dict):
         candidates.append(nested)
     for cfg in candidates:
-        if str(cfg.get("model_type") or "").strip().lower() == "gemma2":
+        if str(cfg.get("model_type") or "").strip().lower() == GEMMA2_MODEL_TYPE:
             return True
-        if any(a.lower() in _GEMMA2_ARCH_MARKERS for a in _config_architectures(cfg)):
+        if any(a.lower() in GEMMA2_ARCHITECTURES for a in _config_architectures(cfg)):
             return True
     return False

--- a/inference_optimizer/model_config_utils.py
+++ b/inference_optimizer/model_config_utils.py
@@ -1,0 +1,74 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Shared model-config helpers (config.json parsing + arch/type detection).
+
+Leaf module: depends only on the standard library so both ``cli`` and the
+orchestrator executors can import it without a circular dependency.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+
+def _load_model_config_dict(model_path: str) -> dict | None:
+    """Best-effort parse of ``<model_path>/config.json`` into a dict; returns ``None`` on any failure."""
+    if not model_path:
+        return None
+    cfg_path = Path(model_path) / "config.json"
+    try:
+        raw = cfg_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        logging.warning("model_config_unreadable: %s (%s)", cfg_path, exc)
+        return None
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError) as exc:
+        logging.warning("model_config_invalid_json: %s (%s)", cfg_path, exc)
+        return None
+    if not isinstance(data, dict):
+        logging.warning(
+            "model_config_not_a_dict: %s (got %s)", cfg_path, type(data).__name__,
+        )
+        return None
+    return data
+
+
+def _config_architectures(config: dict) -> list[str]:
+    """Normalise ``config["architectures"]`` to a list of non-empty strings (scalar wrapped; absent -> [])."""
+    arches_raw = config.get("architectures")
+    if isinstance(arches_raw, list):
+        return [str(a).strip() for a in arches_raw if str(a or "").strip()]
+    if isinstance(arches_raw, str) and arches_raw.strip():
+        return [arches_raw.strip()]
+    return []
+
+
+# Gemma2 forward builds ``normalizer = torch.tensor(...)`` (a host scalar) on
+# every call. The TraceLens kernel_shape_profiler patch activates inside the
+# CUDA-graph capture critical section, so that host construct runs during HIP
+# stream capture and raises ``hipErrorStreamCaptureUnsupported`` -> capture
+# fails -> roofline produces no ceiling. Callers skip shape-discovery for
+# Gemma2 to keep CUDA graph while avoiding the crash.
+_GEMMA2_ARCH_MARKERS = frozenset({"gemma2forcausallm"})
+
+
+def _model_is_gemma2(model_path: str) -> bool:
+    """Best-effort detect a Gemma2 model from config.json (top level or text_config)."""
+    data = _load_model_config_dict(model_path)
+    if data is None:
+        return False
+    candidates = [data]
+    nested = data.get("text_config")
+    if isinstance(nested, dict):
+        candidates.append(nested)
+    for cfg in candidates:
+        if str(cfg.get("model_type") or "").strip().lower() == "gemma2":
+            return True
+        if any(a.lower() in _GEMMA2_ARCH_MARKERS for a in _config_architectures(cfg)):
+            return True
+    return False

--- a/inference_optimizer/model_config_utils.py
+++ b/inference_optimizer/model_config_utils.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from pathlib import Path
 
 
@@ -59,38 +60,69 @@ GEMMA2_MODEL_TYPE = "gemma2"
 GEMMA2_ARCHITECTURES = frozenset({"gemma2forcausallm"})
 
 
+# ``gemma`` then an optional single separator then ``2`` as a standalone token
+# (start/separator on the left, separator/end on the right). Matches gemma2 /
+# gemma-2 / gemma_2 but not gemma3, gemma25, or notgemma2.
+_GEMMA2_PATH_RE = re.compile(r"(?:^|[-_.])gemma[-_.]?2(?:[-_.]|$)")
+
+
 def _path_looks_like_gemma2(model_path: str) -> bool:
     """Heuristic Gemma2 detection from the path when config.json is absent.
 
-    Matches a ``gemma-2`` / ``gemma2`` directory name while excluding Gemma3, so
-    a not-yet-materialized Hub-id style path still gets the workaround.
+    Word-boundary match on the directory name (gemma2 / gemma-2 / gemma_2),
+    so a not-yet-materialized Hub-id style path still gets the workaround
+    without false-positives on names like notgemma2 / gemma25.
     """
     if not model_path:
         return False
-    compact = (
-        Path(model_path).name.lower()
-        .replace("-", "").replace("_", "").replace(".", "")
-    )
-    if "gemma3" in compact:
-        return False
-    return "gemma2" in compact
+    return _GEMMA2_PATH_RE.search(Path(model_path).name.lower()) is not None
 
 
-def _model_is_gemma2(model_path: str) -> bool:
-    """Best-effort detect a Gemma2 model from config.json (top level or text_config).
-
-    Falls back to a path heuristic when config.json is missing/unreadable.
-    """
-    data = _load_model_config_dict(model_path)
-    if data is None:
-        return _path_looks_like_gemma2(model_path)
-    candidates = [data]
+def _config_gemma2_scopes(data: dict) -> list[dict]:
+    """Return [top-level, text_config?] scopes for Gemma2 inspection."""
+    scopes = [data]
     nested = data.get("text_config")
     if isinstance(nested, dict):
-        candidates.append(nested)
-    for cfg in candidates:
+        scopes.append(nested)
+    return scopes
+
+
+def _config_is_gemma2(data: dict) -> bool:
+    """True when a parsed config dict declares Gemma2 (top level or text_config)."""
+    for cfg in _config_gemma2_scopes(data):
         if str(cfg.get("model_type") or "").strip().lower() == GEMMA2_MODEL_TYPE:
             return True
         if any(a.lower() in GEMMA2_ARCHITECTURES for a in _config_architectures(cfg)):
             return True
     return False
+
+
+def _config_has_model_identity(data: dict) -> bool:
+    """True when the config carries any recognizable model_type/architectures.
+
+    Used to decide whether a non-Gemma2 verdict is trustworthy: a config that
+    clearly identifies another model (e.g. llama) must NOT fall back to the path
+    heuristic, while an empty/residual config (``{}``, no model_type) should.
+    """
+    for cfg in _config_gemma2_scopes(data):
+        if str(cfg.get("model_type") or "").strip():
+            return True
+        if _config_architectures(cfg):
+            return True
+    return False
+
+
+def _model_is_gemma2(model_path: str) -> bool:
+    """Best-effort detect a Gemma2 model from config.json (top level or text_config).
+
+    Falls back to a path heuristic when config.json is missing/unreadable OR
+    present-but-unidentifiable (empty dict / no model_type/architectures). A
+    config that clearly identifies a non-Gemma2 model is trusted as-is.
+    """
+    data = _load_model_config_dict(model_path)
+    if data is not None:
+        if _config_is_gemma2(data):
+            return True
+        if _config_has_model_identity(data):
+            return False
+    return _path_looks_like_gemma2(model_path)

--- a/inference_optimizer/orchestrator/action_executors/_workload_envs.py
+++ b/inference_optimizer/orchestrator/action_executors/_workload_envs.py
@@ -374,8 +374,9 @@ def materialize_config_with_envs(
             # Gemma2 + shape-discovery crashes CUDA-graph capture (host
             # torch.tensor in forward during HIP stream capture). Disable
             # shape-discovery for Gemma2 so capture/roofline still run.
-            # Escape hatch HYPERLOOM_PROFILE_SHAPE_DISCOVERY_FORCE=1 keeps it on
-            # (for debugging the TraceLens root-cause fix).
+            # Escape hatch HYPERLOOM_PROFILE_SHAPE_DISCOVERY_FORCE=1 only skips
+            # the Gemma2 gate (for debugging the TraceLens root-cause fix); it
+            # does NOT override a global HYPERLOOM_PROFILE_SHAPE_DISCOVERY=0.
             _force_shape_disc = os.environ.get(
                 "HYPERLOOM_PROFILE_SHAPE_DISCOVERY_FORCE", "0",
             ).strip().lower() in {"1", "true", "yes", "on"}

--- a/inference_optimizer/orchestrator/action_executors/_workload_envs.py
+++ b/inference_optimizer/orchestrator/action_executors/_workload_envs.py
@@ -374,7 +374,7 @@ def materialize_config_with_envs(
             # torch.tensor in forward during HIP stream capture). Disable
             # shape-discovery for Gemma2 so capture/roofline still run.
             if _shape_disc:
-                from ...cli import _model_is_gemma2
+                from ...model_config_utils import _model_is_gemma2
                 if _model_is_gemma2(str(bench.get("model") or "")):
                     _shape_disc = False
                     log.info(

--- a/inference_optimizer/orchestrator/action_executors/_workload_envs.py
+++ b/inference_optimizer/orchestrator/action_executors/_workload_envs.py
@@ -370,6 +370,18 @@ def materialize_config_with_envs(
             _shape_disc = os.environ.get(
                 "HYPERLOOM_PROFILE_SHAPE_DISCOVERY", "1",
             ).strip().lower() not in {"0", "false", "no", "off"}
+            # Gemma2 + shape-discovery crashes CUDA-graph capture (host
+            # torch.tensor in forward during HIP stream capture). Disable
+            # shape-discovery for Gemma2 so capture/roofline still run.
+            if _shape_disc:
+                from ...cli import _model_is_gemma2
+                if _model_is_gemma2(str(bench.get("model") or "")):
+                    _shape_disc = False
+                    log.info(
+                        "Gemma2 roofline: disabling shape-discovery to avoid "
+                        "CUDA-graph capture crash (hipErrorStreamCapture"
+                        "Unsupported); CUDA graph + profiling kept.",
+                    )
             extra_body["shape_discovery"] = _shape_disc
             extra_body.setdefault("roofline_annotations", True)
             envs["PROFILE_EXTRA_BODY"] = _json.dumps(extra_body)

--- a/inference_optimizer/orchestrator/action_executors/_workload_envs.py
+++ b/inference_optimizer/orchestrator/action_executors/_workload_envs.py
@@ -40,6 +40,7 @@ from ._server_patcher import (
     ensure_sglang_patched_for_tracelens,
     ensure_vllm_patched_for_tracelens,
 )
+from ...model_config_utils import _load_model_config_dict, _model_is_gemma2
 
 log = logging.getLogger(__name__)
 
@@ -373,15 +374,27 @@ def materialize_config_with_envs(
             # Gemma2 + shape-discovery crashes CUDA-graph capture (host
             # torch.tensor in forward during HIP stream capture). Disable
             # shape-discovery for Gemma2 so capture/roofline still run.
-            if _shape_disc:
-                from ...model_config_utils import _model_is_gemma2
-                if _model_is_gemma2(str(bench.get("model") or "")):
+            # Escape hatch HYPERLOOM_PROFILE_SHAPE_DISCOVERY_FORCE=1 keeps it on
+            # (for debugging the TraceLens root-cause fix).
+            _force_shape_disc = os.environ.get(
+                "HYPERLOOM_PROFILE_SHAPE_DISCOVERY_FORCE", "0",
+            ).strip().lower() in {"1", "true", "yes", "on"}
+            if _shape_disc and not _force_shape_disc:
+                _model = str(bench.get("model") or "")
+                if _model_is_gemma2(_model):
                     _shape_disc = False
                     log.info(
                         "Gemma2 roofline: disabling shape-discovery to avoid "
                         "CUDA-graph capture crash (hipErrorStreamCapture"
-                        "Unsupported); CUDA graph + profiling kept.",
+                        "Unsupported); CUDA graph + profiling kept. Set "
+                        "HYPERLOOM_PROFILE_SHAPE_DISCOVERY_FORCE=1 to override.",
                     )
+                    if _load_model_config_dict(_model) is None:
+                        log.warning(
+                            "Gemma2 detected via path heuristic (no readable "
+                            "config.json at %r); shape-discovery skip may be "
+                            "imprecise.", _model,
+                        )
             extra_body["shape_discovery"] = _shape_disc
             extra_body.setdefault("roofline_annotations", True)
             envs["PROFILE_EXTRA_BODY"] = _json.dumps(extra_body)

--- a/inference_optimizer/tests/test_model_config_compat_preflight.py
+++ b/inference_optimizer/tests/test_model_config_compat_preflight.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import struct
 from pathlib import Path
 
 import pytest
@@ -146,6 +147,39 @@ def test_detect_mimo_v2_flash_unrecognized_blocked(tmp_path):
     )
     reason = cli._detect_incompatible_model_config(str(m))
     assert reason is not None and "not recognized" in reason
+
+
+def test_detect_deepseek_v4_unrecognized_blocked(tmp_path):
+    # DeepSeek-V4 currently fails sglang ModelConfig validation during server init.
+    m = tmp_path / "deepseek_v4"
+    _write_config(
+        m,
+        model_type="deepseek_v4",
+        architectures=["DeepseekV4ForCausalLM"],
+        max_position_embeddings=1048576,
+    )
+    reason = cli._detect_incompatible_model_config(str(m))
+    assert reason is not None and "not recognized" in reason
+
+
+def test_detect_nested_ministral3_unrecognized_blocked(tmp_path):
+    # Mistral3 wrapper exposes text_config.model_type=ministral3; vLLM raises KeyError.
+    m = tmp_path / "mistral3"
+    _write_config(
+        m,
+        model_type="mistral3",
+        architectures=["Mistral3ForConditionalGeneration"],
+        image_token_index=10,
+        text_config={
+            "model_type": "ministral3",
+            "max_position_embeddings": 393216,
+            "vocab_size": 131072,
+            "hidden_size": 5120,
+            "num_hidden_layers": 40,
+        },
+    )
+    reason = cli._detect_incompatible_model_config(str(m))
+    assert reason is not None and "ministral3" in reason
 
 
 def test_detect_glm4_moe_not_blocked(tmp_path):
@@ -458,6 +492,40 @@ def test_detect_amd_native_fp8_not_blocked(tmp_path):
         quantization_config={"quant_method": "fp8"},
     )
     assert cli._detect_incompatible_model_config(str(m), gpu_type="mi300x") is None
+
+
+def _write_safetensors_header(model_dir: Path, tensors: dict) -> None:
+    header = json.dumps(tensors).encode("utf-8")
+    with (model_dir / "model.safetensors").open("wb") as f:
+        f.write(struct.pack("<Q", len(header)))
+        f.write(header)
+
+
+def test_detect_vocab_shape_mismatch_blocks(tmp_path):
+    m = tmp_path / "qwen_vocab_mismatch"
+    _write_config(
+        m,
+        model_type="qwen2",
+        architectures=["Qwen2ForCausalLM"],
+        max_position_embeddings=4096,
+        vocab_size=152064,
+    )
+    _write_safetensors_header(m, {
+        "model.embed_tokens.weight": {
+            "dtype": "BF16",
+            "shape": [151936, 1536],
+            "data_offsets": [0, 0],
+        },
+        "lm_head.weight": {
+            "dtype": "BF16",
+            "shape": [151936, 1536],
+            "data_offsets": [0, 0],
+        },
+    })
+    reason = cli._detect_incompatible_model_config(str(m))
+    assert reason is not None
+    assert "vocab_size=152064" in reason
+    assert "151936" in reason
 
 
 def test_detect_unregistered_custom_config_blocks(tmp_path):

--- a/inference_optimizer/tests/test_model_config_compat_preflight.py
+++ b/inference_optimizer/tests/test_model_config_compat_preflight.py
@@ -182,6 +182,20 @@ def test_detect_nested_ministral3_unrecognized_blocked(tmp_path):
     assert reason is not None and "ministral3" in reason
 
 
+def test_detect_top_level_ministral3_not_blocked(tmp_path):
+    # A bare top-level model_type=ministral3 (no Mistral3 wrapper) is left to the
+    # framework; only the nested text_config form is a confirmed failure.
+    m = tmp_path / "bare_ministral3"
+    _write_config(
+        m,
+        model_type="ministral3",
+        architectures=["Ministral3ForCausalLM"],
+        max_position_embeddings=32768,
+        vocab_size=131072,
+    )
+    assert cli._detect_incompatible_model_config(str(m)) is None
+
+
 def test_detect_glm4_moe_not_blocked(tmp_path):
     # glm4_moe (GLM-4.5/4.6 mainline) is a supported arch; must NOT be blocked
     # by the unrecognized-arch rule (only glm4_moe_lite is unrecognized).
@@ -526,6 +540,39 @@ def test_detect_vocab_shape_mismatch_blocks(tmp_path):
     assert reason is not None
     assert "vocab_size=152064" in reason
     assert "151936" in reason
+
+
+def test_detect_vocab_shape_match_not_blocked(tmp_path):
+    # config vocab_size matches the weight output dim -> must NOT block.
+    m = tmp_path / "qwen_vocab_ok"
+    _write_config(
+        m,
+        model_type="qwen2",
+        architectures=["Qwen2ForCausalLM"],
+        max_position_embeddings=4096,
+        vocab_size=151936,
+    )
+    _write_safetensors_header(m, {
+        "model.embed_tokens.weight": {
+            "dtype": "BF16", "shape": [151936, 1536], "data_offsets": [0, 0],
+        },
+    })
+    assert cli._detect_incompatible_model_config(str(m)) is None
+
+
+def test_read_safetensors_header_parses_and_rejects(tmp_path):
+    # Valid header round-trips; truncated / oversized headers return None.
+    good = tmp_path / "model.safetensors"
+    _write_safetensors_header(tmp_path, {"x.weight": {"shape": [4, 4]}})
+    assert cli._read_safetensors_header(good) == {"x.weight": {"shape": [4, 4]}}
+
+    truncated = tmp_path / "trunc.safetensors"
+    truncated.write_bytes(struct.pack("<Q", 999) + b"{")  # claims 999, has 1
+    assert cli._read_safetensors_header(truncated) is None
+
+    short = tmp_path / "short.safetensors"
+    short.write_bytes(b"\x01\x02")  # < 8-byte length prefix
+    assert cli._read_safetensors_header(short) is None
 
 
 def test_detect_unregistered_custom_config_blocks(tmp_path):

--- a/inference_optimizer/tests/test_model_config_compat_preflight.py
+++ b/inference_optimizer/tests/test_model_config_compat_preflight.py
@@ -182,6 +182,25 @@ def test_detect_nested_ministral3_unrecognized_blocked(tmp_path):
     assert reason is not None and "ministral3" in reason
 
 
+def test_detect_pure_nested_ministral3_blocked(tmp_path):
+    # Parent model_type is NOT ministral3 (a generic wrapper); only the nested
+    # text_config carries ministral3. Verifies the nested-only gate in isolation
+    # from the parent scope.
+    m = tmp_path / "wrapper_nested_ministral3"
+    _write_config(
+        m,
+        model_type="some_wrapper",
+        architectures=["SomeWrapperForConditionalGeneration"],
+        text_config={
+            "model_type": "ministral3",
+            "max_position_embeddings": 32768,
+            "vocab_size": 131072,
+        },
+    )
+    reason = cli._detect_incompatible_model_config(str(m))
+    assert reason is not None and "ministral3" in reason
+
+
 def test_detect_top_level_ministral3_not_blocked(tmp_path):
     # A bare top-level model_type=ministral3 (no Mistral3 wrapper) is left to the
     # framework; only the nested text_config form is a confirmed failure.
@@ -573,6 +592,63 @@ def test_read_safetensors_header_parses_and_rejects(tmp_path):
     short = tmp_path / "short.safetensors"
     short.write_bytes(b"\x01\x02")  # < 8-byte length prefix
     assert cli._read_safetensors_header(short) is None
+
+
+# ---------------------------------------------------------------------------
+# Gemma2 detection helpers (model_config_utils)
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("gemma2", True),
+        ("gemma2-9b", True),
+        ("google-gemma-2-9b-it", True),
+        ("gemma_2_2b", True),
+        ("llama-gemma2-test", True),
+        ("gemma-3-12b", False),
+        ("gemma3-12b", False),
+        ("gemma25", False),
+        ("notgemma2", False),
+        ("mygemma2", False),
+        ("gemma12-model", False),
+        ("", False),
+    ],
+)
+def test_path_looks_like_gemma2(name, expected):
+    from inference_optimizer import model_config_utils as mcu
+    assert mcu._path_looks_like_gemma2(name) is expected
+
+
+def test_model_is_gemma2_falls_back_to_path_on_residual_config(tmp_path):
+    # config.json present but empty (no model_type/architectures) -> the path
+    # heuristic decides; a gemma-2 path is still detected.
+    from inference_optimizer import model_config_utils as mcu
+    m = tmp_path / "google-gemma-2-9b-it"
+    m.mkdir()
+    (m / "config.json").write_text("{}", encoding="utf-8")
+    assert mcu._model_is_gemma2(str(m)) is True
+
+
+def test_model_is_gemma2_trusts_identified_non_gemma_config(tmp_path):
+    # config clearly identifies llama; even a gemma-2 path must NOT override it.
+    from inference_optimizer import model_config_utils as mcu
+    m = tmp_path / "gemma-2-distill-llama"
+    m.mkdir()
+    (m / "config.json").write_text(json.dumps({
+        "model_type": "llama", "architectures": ["LlamaForCausalLM"],
+    }), encoding="utf-8")
+    assert mcu._model_is_gemma2(str(m)) is False
+
+
+def test_model_is_gemma2_detects_nested_text_config(tmp_path):
+    from inference_optimizer import model_config_utils as mcu
+    m = tmp_path / "wrapper"
+    m.mkdir()
+    (m / "config.json").write_text(json.dumps({
+        "model_type": "wrapper",
+        "text_config": {"model_type": "gemma2"},
+    }), encoding="utf-8")
+    assert mcu._model_is_gemma2(str(m)) is True
 
 
 def test_detect_unregistered_custom_config_blocks(tmp_path):

--- a/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -714,6 +714,69 @@ def test_materialize_profile_sglang_keeps_shape_discovery_for_non_gemma2(
     assert "--enable-shape-discovery-for-cuda-graph-profile" in extra, extra
 
 
+def test_materialize_profile_sglang_skips_shape_discovery_gemma2_by_path(
+    tmp_path, monkeypatch,
+):
+    """No config.json but a gemma-2 path -> heuristic skips shape-discovery."""
+    import yaml
+    _clear_workload_env(monkeypatch)
+    monkeypatch.delenv("HYPERLOOM_PROFILE_SHAPE_DISCOVERY_FORCE", raising=False)
+    _mock_patchers(monkeypatch, vllm=False, sglang=True)
+    # Path looks like Gemma2 but ships no config.json (not-yet-materialized).
+    model = "/wekafs/models/google-gemma-2-9b-it"
+    src = _profile_yaml_model(
+        tmp_path, "sglang", model, {"CONC": 32, "ISL": 256, "OSL": 1024},
+    )
+    out = _materialize_config_with_envs(src, tmp_path)
+    envs = yaml.safe_load(out.read_text())["benchmark"]["envs"]
+    assert "shape-discovery" not in envs.get("EXTRA_SGLANG_ARGS", ""), envs
+    assert json.loads(envs["PROFILE_EXTRA_BODY"])["shape_discovery"] is False
+
+
+def test_materialize_profile_sglang_no_config_non_gemma_keeps_shape_discovery(
+    tmp_path, monkeypatch,
+):
+    """No config.json and a non-Gemma2 path -> shape-discovery stays on."""
+    import yaml
+    _clear_workload_env(monkeypatch)
+    monkeypatch.delenv("HYPERLOOM_PROFILE_SHAPE_DISCOVERY_FORCE", raising=False)
+    _mock_patchers(monkeypatch, vllm=False, sglang=True)
+    model = "/wekafs/models/meta-llama-3-8b-instruct"
+    src = _profile_yaml_model(
+        tmp_path, "sglang", model, {"CONC": 32, "ISL": 256, "OSL": 1024},
+    )
+    out = _materialize_config_with_envs(src, tmp_path)
+    extra = yaml.safe_load(out.read_text())["benchmark"]["envs"].get(
+        "EXTRA_SGLANG_ARGS", "",
+    )
+    assert "--enable-shape-discovery-for-cuda-graph-profile" in extra, extra
+
+
+def test_materialize_profile_sglang_force_overrides_gemma2_gate(
+    tmp_path, monkeypatch,
+):
+    """HYPERLOOM_PROFILE_SHAPE_DISCOVERY_FORCE=1 keeps shape-discovery on for
+    Gemma2 (escape hatch for debugging the TraceLens root-cause fix)."""
+    import yaml
+    _clear_workload_env(monkeypatch)
+    monkeypatch.setenv("HYPERLOOM_PROFILE_SHAPE_DISCOVERY_FORCE", "1")
+    _mock_patchers(monkeypatch, vllm=False, sglang=True)
+    model = tmp_path / "gemma2_model"
+    model.mkdir()
+    (model / "config.json").write_text(json.dumps({
+        "model_type": "gemma2", "architectures": ["Gemma2ForCausalLM"],
+    }), encoding="utf-8")
+    src = _profile_yaml_model(
+        tmp_path, "sglang", str(model), {"CONC": 32, "ISL": 256, "OSL": 1024},
+    )
+    out = _materialize_config_with_envs(src, tmp_path)
+    envs = yaml.safe_load(out.read_text())["benchmark"]["envs"]
+    assert "--enable-shape-discovery-for-cuda-graph-profile" in envs.get(
+        "EXTRA_SGLANG_ARGS", "",
+    ), envs
+    assert json.loads(envs["PROFILE_EXTRA_BODY"])["shape_discovery"] is True
+
+
 def test_profile_executor_calls_benchmark_lib_patcher():
     """ProfileExecutor must patch the materialized InferenceX checkout before launching Magpie (else the computed profile window is stomped and the trace is empty)."""
     import inference_optimizer.orchestrator.action_executors.profile as profile_mod

--- a/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -675,7 +675,6 @@ def test_materialize_profile_sglang_skips_shape_discovery_for_gemma2(
 ):
     """Gemma2 + patched SGLang must NOT inject shape-discovery (it crashes
     CUDA-graph capture); --enable-profile-cuda-graph still applies."""
-    import json
     import yaml
     _clear_workload_env(monkeypatch)
     _mock_patchers(monkeypatch, vllm=False, sglang=True)
@@ -697,7 +696,6 @@ def test_materialize_profile_sglang_keeps_shape_discovery_for_non_gemma2(
     tmp_path, monkeypatch,
 ):
     """A non-Gemma2 model still gets shape-discovery when patched."""
-    import json
     import yaml
     _clear_workload_env(monkeypatch)
     _mock_patchers(monkeypatch, vllm=False, sglang=True)

--- a/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -655,6 +655,67 @@ def test_materialize_profile_sglang_does_not_duplicate_shape_discovery(
     assert extra.count("--enable-shape-discovery-for-cuda-graph-profile") == 1, extra
 
 
+def _profile_yaml_model(tmp_path, framework: str, model: str, envs: dict) -> Path:
+    """Like _profile_yaml but with an explicit model path (for Gemma2 gating)."""
+    import yaml as _yaml
+    src = tmp_path / f"src_{framework}_model.yaml"
+    src.write_text(_yaml.safe_dump({
+        "benchmark": {
+            "framework": framework,
+            "model": model,
+            "envs": {"PROFILE": "1", **envs},
+            "profiler": {"torch_profiler": {"enabled": True}},
+        },
+    }))
+    return src
+
+
+def test_materialize_profile_sglang_skips_shape_discovery_for_gemma2(
+    tmp_path, monkeypatch,
+):
+    """Gemma2 + patched SGLang must NOT inject shape-discovery (it crashes
+    CUDA-graph capture); --enable-profile-cuda-graph still applies."""
+    import json
+    import yaml
+    _clear_workload_env(monkeypatch)
+    _mock_patchers(monkeypatch, vllm=False, sglang=True)
+    model = tmp_path / "gemma2_model"
+    model.mkdir()
+    (model / "config.json").write_text(json.dumps({
+        "model_type": "gemma2", "architectures": ["Gemma2ForCausalLM"],
+    }), encoding="utf-8")
+    src = _profile_yaml_model(
+        tmp_path, "sglang", str(model), {"CONC": 32, "ISL": 256, "OSL": 1024},
+    )
+    out = _materialize_config_with_envs(src, tmp_path)
+    envs = yaml.safe_load(out.read_text())["benchmark"]["envs"]
+    assert "shape-discovery" not in envs.get("EXTRA_SGLANG_ARGS", ""), envs
+    assert json.loads(envs["PROFILE_EXTRA_BODY"])["shape_discovery"] is False
+
+
+def test_materialize_profile_sglang_keeps_shape_discovery_for_non_gemma2(
+    tmp_path, monkeypatch,
+):
+    """A non-Gemma2 model still gets shape-discovery when patched."""
+    import json
+    import yaml
+    _clear_workload_env(monkeypatch)
+    _mock_patchers(monkeypatch, vllm=False, sglang=True)
+    model = tmp_path / "llama_model"
+    model.mkdir()
+    (model / "config.json").write_text(json.dumps({
+        "model_type": "llama", "architectures": ["LlamaForCausalLM"],
+    }), encoding="utf-8")
+    src = _profile_yaml_model(
+        tmp_path, "sglang", str(model), {"CONC": 32, "ISL": 256, "OSL": 1024},
+    )
+    out = _materialize_config_with_envs(src, tmp_path)
+    extra = yaml.safe_load(out.read_text())["benchmark"]["envs"].get(
+        "EXTRA_SGLANG_ARGS", "",
+    )
+    assert "--enable-shape-discovery-for-cuda-graph-profile" in extra, extra
+
+
 def test_profile_executor_calls_benchmark_lib_patcher():
     """ProfileExecutor must patch the materialized InferenceX checkout before launching Magpie (else the computed profile window is stomped and the trace is empty)."""
     import inference_optimizer.orchestrator.action_executors.profile as profile_mod

--- a/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -752,6 +752,49 @@ def test_materialize_profile_sglang_no_config_non_gemma_keeps_shape_discovery(
     assert "--enable-shape-discovery-for-cuda-graph-profile" in extra, extra
 
 
+def test_materialize_profile_sglang_skips_shape_discovery_nested_gemma2(
+    tmp_path, monkeypatch,
+):
+    """Gemma2 declared only in text_config still trips the shape-discovery gate."""
+    import yaml
+    _clear_workload_env(monkeypatch)
+    monkeypatch.delenv("HYPERLOOM_PROFILE_SHAPE_DISCOVERY_FORCE", raising=False)
+    _mock_patchers(monkeypatch, vllm=False, sglang=True)
+    model = tmp_path / "wrapper_model"
+    model.mkdir()
+    (model / "config.json").write_text(json.dumps({
+        "model_type": "wrapper",
+        "text_config": {"model_type": "gemma2"},
+    }), encoding="utf-8")
+    src = _profile_yaml_model(
+        tmp_path, "sglang", str(model), {"CONC": 32, "ISL": 256, "OSL": 1024},
+    )
+    out = _materialize_config_with_envs(src, tmp_path)
+    envs = yaml.safe_load(out.read_text())["benchmark"]["envs"]
+    assert "shape-discovery" not in envs.get("EXTRA_SGLANG_ARGS", ""), envs
+    assert json.loads(envs["PROFILE_EXTRA_BODY"])["shape_discovery"] is False
+
+
+def test_materialize_profile_sglang_residual_config_gemma2_path(
+    tmp_path, monkeypatch,
+):
+    """Empty config.json + gemma-2 path -> heuristic still skips shape-discovery."""
+    import yaml
+    _clear_workload_env(monkeypatch)
+    monkeypatch.delenv("HYPERLOOM_PROFILE_SHAPE_DISCOVERY_FORCE", raising=False)
+    _mock_patchers(monkeypatch, vllm=False, sglang=True)
+    model = tmp_path / "google-gemma-2-9b-it"
+    model.mkdir()
+    (model / "config.json").write_text("{}", encoding="utf-8")
+    src = _profile_yaml_model(
+        tmp_path, "sglang", str(model), {"CONC": 32, "ISL": 256, "OSL": 1024},
+    )
+    out = _materialize_config_with_envs(src, tmp_path)
+    envs = yaml.safe_load(out.read_text())["benchmark"]["envs"]
+    assert "shape-discovery" not in envs.get("EXTRA_SGLANG_ARGS", ""), envs
+    assert json.loads(envs["PROFILE_EXTRA_BODY"])["shape_discovery"] is False
+
+
 def test_materialize_profile_sglang_force_overrides_gemma2_gate(
     tmp_path, monkeypatch,
 ):


### PR DESCRIPTION


Preflight (cli.py): fail fast on statically-detectable incompatible configs so they stop before the heavy server bring-up instead of crashing in engine init / baseline:
- unrecognized model types/arches now include deepseek_v4 and nested text_config.model_type=ministral3 (vLLM registry KeyError).
- new vocab-shape check: config.vocab_size vs safetensors embed/lm_head dim mismatch (sglang weight-load AssertionError).

Gemma2 roofline (_workload_envs.py): skip
--enable-shape-discovery-for-cuda-graph-profile for Gemma2. The TraceLens kernel_shape_profiler activates inside the CUDA-graph capture critical section; Gemma2 forward builds a host torch.tensor(normalizer) there, which raises hipErrorStreamCaptureUnsupported and aborts capture (roofline yields no ceiling, e2e gain stays 0). Verified locally: with shape-discovery the capture crashes on the 2nd bs; without it Gemma2 captures all 52 bs. CUDA graph + profiling are kept.

Adds regression tests for both.

