### PR TITLE
ci: allow multimodal submit; swap daily pool M2.5 -> Llama-3.1-8B-Instruct, Kimi FP8; add ci tests

### DIFF
--- a/ci/build_candidates.py
+++ b/ci/build_candidates.py
@@ -318,9 +318,6 @@ def classify_candidate(
         return None
 
     pipeline_tag = (info.get("pipeline_tag") or "").strip()
-    if pipeline_tag and pipeline_tag != "text-generation":
-        log.info("skip %s: pipeline_tag=%s", repo_id, pipeline_tag)
-        return None
 
     try:
         config = hf.model_config(repo_id)

--- a/ci/candidates/inferencex_daily_fixed.json
+++ b/ci/candidates/inferencex_daily_fixed.json
@@ -11,11 +11,11 @@
     "matrix; the workflow forwards them to optimize_submit.py as",
     "--manual --framework --precision --tp --concurrency so per-model config",
     "is FIXED (no auto-detect). Precision is per-model NATIVE because MI300X",
-    "(gfx942) has no native FP4: FP8 for R1/GLM-4.7/Qwen3-Next/Qwen3.6/MiMo, INT4 for",
-    "Kimi, FP4 only for MXFP4-native gpt-oss. Qwen3.6 weights are BF16 (~67G, no",
+    "(gfx942) has no native FP4: FP8 for R1/GLM-4.7/Qwen3-Next/Qwen3.6/MiMo/Kimi,",
+    "BF16 for Llama-3.1-8B, FP4 only for MXFP4-native gpt-oss. Qwen3.6 weights are BF16 (~67G, no",
     "quantization_config); FP4 was a no-op — run dynamic FP8 on MI300X instead.",
     "tp8 everywhere except",
-    "MiniMax M2.5/M2.7 (tp4 - their FP8 block-128 weights are not divisible",
+    "MiniMax M2.7 (tp4 - its FP8 block-128 weights are not divisible",
     "by 8: 1536/8=192 is not a multiple of 128). Kimi & MiMo run on sglang",
     "(vLLM tp8 MLA assert / missing arch respectively).",
     "",
@@ -31,12 +31,11 @@
     "endpoint": "GET /api/playground/models?workspace=core42-hyperloom",
     "checked_at": "2026-06-13",
     "all_registered": false,
-    "note": "Original 8 rows are Ready in core42-hyperloom and pre-staged under /wekafs/models/<org>-<repo>, so SaFE register hits local_path mode (no re-download). Added GLM-4.7-FP8 and DeepSeek-V4-Flash on 2026-06-13 to make a 10-model daily pool. GLM-5 and GLM-5.1 were dropped 2026-06-05 (multi-node only; running single-node models here). Substitutions vs the original wishlist: MiniMax-M3 -> MiniMax-M2.5 (no official M3); MiMo-V2-PRO -> MiMo-V2.5-Pro (no MiMo-V2-PRO). Qwen3.6 repo is Qwen/Qwen3.6-35B-A3B (no -Instruct suffix).",
+    "note": "Original 8 rows are Ready in core42-hyperloom and pre-staged under /wekafs/models/<org>-<repo>, so SaFE register hits local_path mode (no re-download). Added GLM-4.7-FP8 and DeepSeek-V4-Flash on 2026-06-13 to make a 10-model daily pool. GLM-5 and GLM-5.1 were dropped 2026-06-05 (multi-node only; running single-node models here). Substitutions vs the original wishlist: MiniMax-M3 -> MiniMax-M2.5 (no official M3); MiMo-V2-PRO -> MiMo-V2.5-Pro (no MiMo-V2-PRO). Qwen3.6 repo is Qwen/Qwen3.6-35B-A3B (no -Instruct suffix). 2026-06-16: replaced MiniMax-M2.5 with meta-llama/Llama-3.1-8B-Instruct (most-downloaded Llama, ~6.44M dl; gated repo, needs HF_TOKEN); Kimi K2.6 switched from INT4 to FP8.",
     "playground_ids": {
       "deepseek-ai/DeepSeek-R1-0528": "deepseek-r1-0528-kmbd8",
       "moonshotai/Kimi-K2.6": "kimi-k2-6-k9cpr",
       "MiniMaxAI/MiniMax-M2.7": "minimax-m2.7-swn8g",
-      "MiniMaxAI/MiniMax-M2.5": "minimax-m2.5-d2kd2",
       "Qwen/Qwen3-Next-80B-A3B-Instruct": "qwen3-next-80b-a3b-instruct-fh9n7",
       "Qwen/Qwen3.6-35B-A3B": "qwen3-6-35b-a3b-8h5dl",
       "openai/gpt-oss-120b": "gpt-oss-120b-xhkql",
@@ -66,11 +65,11 @@
       "label": "Kimi K2.6",
       "repo_id": "moonshotai/Kimi-K2.6",
       "framework": "sglang",
-      "precision": "INT4",
+      "precision": "FP8",
       "tp": 8,
       "conc": 64,
       "registered": true,
-      "note": "INT4 compressed-tensors native. vLLM tp8 hits MLA num_head%16 assert; sglang handles tp8 cleanly. ~554G weights -> ~69G/GPU at tp8."
+      "note": "Run at FP8 (switched from INT4). vLLM tp8 hits MLA num_head%16 assert; sglang handles tp8 cleanly. sglang dynamic-quantizes to FP8 on MI300X; per-GPU memory rises vs the INT4 weights but stays within tp8 headroom."
     },
     {
       "pool_id": "inferencex-daily-fixed",
@@ -87,14 +86,14 @@
     {
       "pool_id": "inferencex-daily-fixed",
       "pool_index": 3,
-      "label": "MiniMax M2.5",
-      "repo_id": "MiniMaxAI/MiniMax-M2.5",
+      "label": "Llama 3.1 8B Instruct",
+      "repo_id": "meta-llama/Llama-3.1-8B-Instruct",
       "framework": "vllm",
-      "precision": "FP8",
-      "tp": 4,
+      "precision": "BF16",
+      "tp": 8,
       "conc": 64,
-      "registered": true,
-      "note": "FP8 block-128 native. Same tp8 192-not-div-128 crash as M2.7; tp4 OK (~54G/GPU). Kept original FP8 (not amd MXFP4 variant) per decision."
+      "registered": false,
+      "note": "Most-downloaded Llama on HF (~6.44M dl). Dense 8B, BF16-native (no quantization_config); MI300X has no native FP4, so run BF16. 32 attention heads / 8 KV heads divide by tp8 cleanly. Gated repo (gated=manual): SaFE register/download needs HF_TOKEN with the Llama license accepted; not pre-staged in core42-hyperloom yet. Replaces MiniMax-M2.5 in the daily pool."
     },
     {
       "pool_id": "inferencex-daily-fixed",

--- a/ci/conftest.py
+++ b/ci/conftest.py
@@ -1,0 +1,66 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Shared shims for the ci/ unit-test package.
+
+The unit-test CI image does not install ``requests``. Sibling suites
+(``inference_optimizer``) therefore drop a minimal ``requests`` stub into
+``sys.modules`` exposing only ``HTTPError`` / ``exceptions`` / ``utils``.
+The ci modules under test reference ``requests.get`` / ``requests.post`` /
+``requests.Session``, so augment whichever ``requests`` module is live (real
+or stub) *in place* before the ci tests import their targets: tests can then
+monkeypatch those attributes and client construction does not explode.
+No-op when the real ``requests`` package is installed.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+
+def _ensure_requests_attrs() -> None:
+    mod = sys.modules.get("requests")
+    if mod is None:
+        try:
+            import requests as mod  # type: ignore[no-redef]
+        except ModuleNotFoundError:
+            mod = types.ModuleType("requests")
+            sys.modules["requests"] = mod
+
+    if not hasattr(mod, "HTTPError"):
+        mod.HTTPError = type("HTTPError", (Exception,), {})
+    if not hasattr(mod, "exceptions"):
+        mod.exceptions = types.SimpleNamespace(RequestException=Exception)
+    if not hasattr(mod, "utils"):
+        mod.utils = types.SimpleNamespace(quote=lambda path, safe="": path)
+
+    def _no_network(*_a, **_k):
+        raise RuntimeError("requests stub: network disabled in unit tests")
+
+    for _name in ("get", "post", "put", "delete", "patch", "head", "request"):
+        if not hasattr(mod, _name):
+            setattr(mod, _name, _no_network)
+
+    if not hasattr(mod, "Session"):
+        class _Session:
+            def __init__(self) -> None:
+                self.headers: dict = {}
+                self.verify = True
+
+            def request(self, *_a, **_k):
+                raise RuntimeError(
+                    "requests stub: network disabled in unit tests")
+
+            def get(self, *a, **k):
+                return self.request("GET", *a, **k)
+
+            def post(self, *a, **k):
+                return self.request("POST", *a, **k)
+
+            def close(self) -> None:
+                pass
+
+        mod.Session = _Session
+
+
+_ensure_requests_attrs()

--- a/ci/optimize_submit.py
+++ b/ci/optimize_submit.py
@@ -383,8 +383,9 @@ class HuggingFaceClient:
         """Return top-N text-generation repos by downloads, optionally size-filtered.
 
         Pool-then-filter: the listing API matches on tags only, so re-validate
-        per-repo on pipeline_tag == "text-generation" AND a generative
-        architectures[0] suffix; either failing (or a gated 401) → skip.
+        per-repo on a generative architectures[0] suffix; failing that (or a
+        gated 401) → skip. The pipeline_tag != text-generation gate has been
+        removed so multimodal/other heads are allowed through.
         """
         pool_size = max(limit * 10, 100)
         listing = self._get(
@@ -403,12 +404,6 @@ class HuggingFaceClient:
                 info = self.model_info(repo)
             except Exception:
                 continue  # gated / network error
-
-            pipeline_tag = (info.get("pipeline_tag") or "").strip()
-            if pipeline_tag and pipeline_tag != "text-generation":
-                log.info("skip %s: pipeline_tag=%s (not text-generation)",
-                         repo, pipeline_tag)
-                continue
 
             if min_params_b > 0:
                 total = (info.get("safetensors") or {}).get("total", 0)
@@ -679,11 +674,6 @@ def auto_detect(hf: HuggingFaceClient, repo_id: str,
                   "suffix). Skipping — pass an actual causal-LM repo, or override "
                   "with --manual --framework vllm if you really want to try.",
                   repo_id, arch)
-        return None
-    pipeline_tag = (info.get("pipeline_tag") or "").strip()
-    if pipeline_tag and pipeline_tag != "text-generation":
-        log.error("[%s] pipeline_tag=%s is not 'text-generation' — skipping",
-                  repo_id, pipeline_tag)
         return None
 
     framework = detect_framework(config)

--- a/ci/test_ci_artifact_normalizer.py
+++ b/ci/test_ci_artifact_normalizer.py
@@ -1,0 +1,321 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for ci/artifact_normalizer.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_CI_DIR = Path(__file__).resolve().parent
+if str(_CI_DIR) not in sys.path:
+    sys.path.insert(0, str(_CI_DIR))
+
+import artifact_normalizer as an  # noqa: E402
+
+
+# ── small coercion helpers ──
+
+def test_read_json_none():
+    assert an._read_json(None, []) is None
+
+
+def test_read_json_ok(tmp_path: Path):
+    p = tmp_path / "a.json"
+    p.write_text(json.dumps({"x": 1}), encoding="utf-8")
+    assert an._read_json(p, []) == {"x": 1}
+
+
+def test_read_json_bad(tmp_path: Path):
+    p = tmp_path / "a.json"
+    p.write_text("{bad", encoding="utf-8")
+    warnings: list[str] = []
+    assert an._read_json(p, warnings) is None
+    assert warnings and "failed to parse" in warnings[0]
+
+
+def test_to_float_variants():
+    assert an._to_float(None) is None
+    assert an._to_float(5) == 5.0
+    assert an._to_float("1,024.5") == 1024.5
+    assert an._to_float("SKIPPED") is None
+    assert an._to_float("") is None
+    assert an._to_float("abc") is None
+
+
+def test_to_int_variants():
+    assert an._to_int("12.9") == 12
+    assert an._to_int(None) is None
+
+
+def test_first_of():
+    assert an._first_of({"a": None, "b": 2}, "a", "b") == 2
+    assert an._first_of({}, "a") is None
+
+
+def test_first_nested():
+    data = {"baseline": {"output_throughput_per_gpu": 3.0}}
+    assert an._first_nested(data, "missing", "baseline.output_throughput_per_gpu") == 3.0
+    assert an._first_nested({}, "a.b") is None
+
+
+def test_relative(tmp_path: Path):
+    root = tmp_path
+    inside = tmp_path / "a" / "b.txt"
+    assert an._relative(inside, root) == "a/b.txt"
+    assert an._relative(None, root) is None
+    # outside root -> absolute posix
+    outside = Path("/totally/other/x.txt")
+    assert an._relative(outside, root) == outside.as_posix()
+
+
+# ── find_artifact ──
+
+def test_find_artifact_by_tail(tmp_path: Path):
+    f = tmp_path / "hyperloom" / "ci_metrics.json"
+    f.parent.mkdir(parents=True)
+    f.write_text("{}", encoding="utf-8")
+    found = an.find_artifact(tmp_path, "ci_metrics.json")
+    assert found == f
+
+
+def test_find_artifact_missing_root(tmp_path: Path):
+    assert an.find_artifact(tmp_path / "nope", "x.json") is None
+
+
+def test_find_artifact_no_match(tmp_path: Path):
+    (tmp_path / "a.txt").write_text("x", encoding="utf-8")
+    assert an.find_artifact(tmp_path, "ci_metrics.json") is None
+
+
+# ── parse_env_file ──
+
+def test_parse_env_file(tmp_path: Path):
+    p = tmp_path / "run_context.env"
+    p.write_text("# comment\nFOO='bar'\nBAZ=\"qux\"\nNOEQ\n\n", encoding="utf-8")
+    assert an.parse_env_file(p) == {"FOO": "bar", "BAZ": "qux"}
+
+
+def test_parse_env_file_missing(tmp_path: Path):
+    assert an.parse_env_file(tmp_path / "nope.env") == {}
+    assert an.parse_env_file(None) == {}
+
+
+# ── parse_ci_metrics ──
+
+def test_parse_ci_metrics_flat():
+    data = {"baseline_throughput": "100", "optimized_throughput": "120",
+            "tp": "8", "conc": "64", "model": "m"}
+    m = an.parse_ci_metrics(data)
+    assert m["baseline_throughput"] == 100.0
+    assert m["optimized_throughput"] == 120.0
+    assert m["gain_pct"] == 20.0  # computed
+    assert m["tp"] == 8
+
+
+def test_parse_ci_metrics_ratio_gain():
+    data = {"best": {"speedup_vs_baseline": 1.10}}
+    m = an.parse_ci_metrics(data)
+    assert round(m["gain_pct"], 1) == 10.0
+
+
+def test_parse_ci_metrics_none():
+    m = an.parse_ci_metrics(None)
+    assert m["baseline_throughput"] is None
+    assert m["actions"] == []
+
+
+def test_parse_ci_metrics_explicit_gain():
+    m = an.parse_ci_metrics({"gain_pct": 7.5})
+    assert m["gain_pct"] == 7.5
+
+
+# ── parse_baseline_summary ──
+
+def test_parse_baseline_summary():
+    m = an.parse_baseline_summary({"baseline_tput_per_gpu": "50", "tp": "8"})
+    assert m["baseline_tput_per_gpu"] == 50.0
+    assert m["tp"] == 8
+
+
+def test_parse_baseline_summary_none():
+    assert an.parse_baseline_summary(None)["baseline_tput_per_gpu"] is None
+
+
+# ── parse_sweep_results ──
+
+def test_parse_sweep_results(tmp_path: Path):
+    p = tmp_path / "sweep_results.csv"
+    p.write_text(
+        "CONC,ISL,OSL,NUM_PROMPTS,output_throughput_tok_s,mean_tpot_ms,mean_ttft_ms\n"
+        "64,1024,1024,100,123.4,5.6,7.8\n"
+        "SKIPPED,1024,1024,100,,,\n",
+        encoding="utf-8",
+    )
+    pts = an.parse_sweep_results(p, [])
+    assert len(pts) == 2
+    assert pts[0]["status"] == "ok"
+    assert pts[1]["status"] == "skipped"
+
+
+def test_parse_sweep_results_missing(tmp_path: Path):
+    assert an.parse_sweep_results(tmp_path / "no.csv", []) == []
+    assert an.parse_sweep_results(None, []) == []
+
+
+# ── parse_kernel_candidates / results ──
+
+def test_parse_kernel_candidates():
+    data = [{"rank": "1", "name": "k", "gpu_pct": "10.5", "count": "3", "time_ms": "1.2"}, "bad"]
+    out = an.parse_kernel_candidates(data)
+    assert len(out) == 1
+    assert out[0]["rank"] == 1
+    assert out[0]["gpu_pct"] == 10.5
+
+
+def test_parse_kernel_candidates_non_list():
+    assert an.parse_kernel_candidates({"x": 1}) == []
+
+
+def test_parse_kernel_results():
+    data = {"kernels": [{"name": "k", "micro_speedup": "1.5"}, 5],
+            "summary": {"total": 1}}
+    kernels, summary = an.parse_kernel_results(data)
+    assert len(kernels) == 1
+    assert kernels[0]["micro_speedup"] == 1.5
+    assert summary == {"total": 1}
+
+
+def test_parse_kernel_results_none():
+    kernels, summary = an.parse_kernel_results(None)
+    assert kernels == []
+    assert summary == {}
+
+
+# ── classify_artifact ──
+
+def test_classify_artifact():
+    assert an.classify_artifact("x/ci_metrics.json") == "ci_metrics"
+    assert an.classify_artifact("session_breakdown_v2.json") == "session_breakdown"
+    assert an.classify_artifact("results/baseline_summary.json") == "baseline_summary"
+    assert an.classify_artifact("results/sweep_results.csv") == "sweep_results"
+    assert an.classify_artifact("kernel_candidates.json") == "kernel_candidates"
+    assert an.classify_artifact("kernel_opt/kernel_results.json") == "kernel_results"
+    assert an.classify_artifact("optimization_report.md") == "optimization_report"
+    assert an.classify_artifact("results/run_context.env") == "run_context"
+    assert an.classify_artifact("server.log") == "log"
+    assert an.classify_artifact("misc.bin") == "artifact"
+
+
+# ── build_artifact_index ──
+
+def test_build_artifact_index(tmp_path: Path):
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "ci_metrics.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "x.log").write_text("hello", encoding="utf-8")
+    idx = an.build_artifact_index(tmp_path)
+    kinds = {e["kind"] for e in idx}
+    assert "ci_metrics" in kinds and "log" in kinds
+    assert all("size_bytes" in e for e in idx)
+
+
+def test_build_artifact_index_missing(tmp_path: Path):
+    assert an.build_artifact_index(tmp_path / "nope") == []
+
+
+# ── normalize_task_result (end-to-end) ──
+
+def test_normalize_task_result_full(tmp_path: Path):
+    task_dir = tmp_path / "task1"
+    (task_dir / "hyperloom").mkdir(parents=True)
+    (task_dir / "hyperloom" / "ci_metrics.json").write_text(
+        json.dumps({"baseline_throughput": 100, "optimized_throughput": 130,
+                    "model": "org/m", "tp": 8}),
+        encoding="utf-8",
+    )
+    (task_dir / "results").mkdir()
+    (task_dir / "results" / "sweep_results.csv").write_text(
+        "CONC,ISL,OSL\n64,1024,1024\n", encoding="utf-8")
+    record = {"task_id": "task1", "model": "org/m", "display_name": "m",
+              "status": "submitted", "final_status": "Succeeded"}
+    result = an.normalize_task_result(task_dir, record, {"source": "test"})
+    assert result["schema_version"] == an.SCHEMA_VERSION
+    assert result["task"]["task_id"] == "task1"
+    assert result["metrics"]["gain_pct"] == 30.0
+    assert result["sweep_points"]
+    assert result["source_files"]["ci_metrics"] is not None
+
+
+def test_normalize_task_result_missing_dir(tmp_path: Path):
+    result = an.normalize_task_result(tmp_path / "nope", {"task_id": "t"}, None)
+    assert result["task"]["task_id"] == "t"
+    assert result["metrics"]["baseline_throughput"] is None
+    assert result["run"] == {}
+
+
+def test_normalize_task_result_session_breakdown_fallback(tmp_path: Path):
+    task_dir = tmp_path / "t"
+    task_dir.mkdir()
+    # No ci_metrics.json; only a session_breakdown variant via rglob fallback.
+    (task_dir / "session_breakdown_2026.json").write_text(
+        json.dumps({"baseline_throughput": 10, "optimized_throughput": 11}),
+        encoding="utf-8")
+    result = an.normalize_task_result(task_dir, {"task_id": "t"}, None)
+    assert result["source_files"]["session_breakdown"] is not None
+
+
+# ── collect_normalized_results ──
+
+def test_collect_normalized_results(tmp_path: Path):
+    artifacts = tmp_path / "artifacts"
+    manifests = tmp_path / "manifests"
+    (artifacts / "task1").mkdir(parents=True)
+    (artifacts / "task1" / "ci_metrics.json").write_text(
+        json.dumps({"baseline_throughput": 1, "optimized_throughput": 2}), encoding="utf-8")
+    manifests.mkdir()
+    (manifests / "submission_manifest.json").write_text(
+        json.dumps({"submitted_at": "now", "records": [{"task_id": "task1", "model": "m"}]}),
+        encoding="utf-8")
+    results = an.collect_normalized_results(artifacts, manifests, {"source": "ci"})
+    assert len(results) == 1
+    assert results[0]["task"]["task_id"] == "task1"
+
+
+def test_collect_normalized_results_no_manifests(tmp_path: Path):
+    (tmp_path / "m").mkdir()
+    assert an.collect_normalized_results(tmp_path / "a", tmp_path / "m", None) == []
+
+
+def test_collect_normalized_results_malformed_manifest(tmp_path: Path):
+    manifests = tmp_path / "m"
+    manifests.mkdir()
+    (manifests / "submission_manifest.json").write_text("{bad", encoding="utf-8")
+    assert an.collect_normalized_results(tmp_path / "a", manifests, None) == []
+
+
+# ── write_single_result / main ──
+
+def test_write_single_result(tmp_path: Path):
+    an.write_single_result({"a": 1}, tmp_path / "out")
+    assert (tmp_path / "out" / "normalized_result.json").exists()
+    assert (tmp_path / "out" / "normalized_results.json").exists()
+    assert (tmp_path / "out" / "normalized_results.ndjson").exists()
+
+
+def test_main_success(tmp_path: Path, monkeypatch, capsys):
+    task_dir = tmp_path / "task"
+    task_dir.mkdir()
+    (task_dir / "ci_metrics.json").write_text(
+        json.dumps({"baseline_throughput": 1, "optimized_throughput": 2}), encoding="utf-8")
+    out_dir = tmp_path / "out"
+    monkeypatch.setattr(sys, "argv", ["a.py", "--task-dir", str(task_dir),
+                                      "--out-dir", str(out_dir)])
+    assert an.main() == 0
+    assert (out_dir / "normalized_result.json").exists()
+
+
+def test_main_missing_task_dir(tmp_path: Path, monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["a.py", "--task-dir", str(tmp_path / "nope")])
+    assert an.main() == 2
+    assert "not found" in capsys.readouterr().err

--- a/ci/test_ci_build_rolling_pool.py
+++ b/ci/test_ci_build_rolling_pool.py
@@ -1,0 +1,113 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for ci/build_rolling_pool.py."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+
+_CI_DIR = Path(__file__).resolve().parent
+if str(_CI_DIR) not in sys.path:
+    sys.path.insert(0, str(_CI_DIR))
+
+import build_rolling_pool as brp  # noqa: E402
+
+
+def test_norm():
+    assert brp._norm("  Org/Model  ") == "org/model"
+    assert brp._norm(None) == ""
+
+
+def test_candidate_keys_full_and_basename():
+    keys = brp._candidate_keys("Org/Model-7B")
+    assert brp.slugify("Org/Model-7B") in keys
+    assert brp.slugify("Model-7B") in keys
+
+
+def test_pulse_model_keys_paginates(monkeypatch):
+    pages = [
+        {"results": [{"model_name": "Org/A"}, {"model_name": "Org/B"}],
+         "pagination": {"total": 3}},
+        {"results": [{"model_name": "Org/C"}], "pagination": {"total": 3}},
+    ]
+    calls = {"i": 0}
+
+    def fake_urlopen(url, timeout=0):
+        idx = calls["i"]
+        calls["i"] += 1
+        payload = pages[idx] if idx < len(pages) else {"results": []}
+        return io.BytesIO(json.dumps(payload).encode("utf-8"))
+
+    monkeypatch.setattr(brp.urllib.request, "urlopen", fake_urlopen)
+    keys = brp._pulse_model_keys()
+    assert brp.slugify("Org/A") in keys
+    assert brp.slugify("Org/C") in keys
+
+
+def test_pulse_model_keys_empty(monkeypatch):
+    monkeypatch.setattr(brp.urllib.request, "urlopen",
+                        lambda url, timeout=0: io.BytesIO(json.dumps({"results": []}).encode()))
+    assert brp._pulse_model_keys() == set()
+
+
+def test_pulse_model_keys_retries_then_succeeds(monkeypatch):
+    state = {"n": 0}
+
+    def flaky(url, timeout=0):
+        state["n"] += 1
+        if state["n"] == 1:
+            raise OSError("boom")
+        return io.BytesIO(json.dumps({"results": [{"model_name": "m"}],
+                                      "pagination": {"total": 1}}).encode())
+
+    monkeypatch.setattr(brp.urllib.request, "urlopen", flaky)
+    monkeypatch.setattr(brp.time, "sleep", lambda *_a, **_k: None)
+    keys = brp._pulse_model_keys()
+    assert brp.slugify("m") in keys
+
+
+def test_main_merges_dedups_and_writes(tmp_path: Path, monkeypatch, capsys):
+    prod = tmp_path / "prod.json"
+    newm = tmp_path / "new.json"
+    manual_out = tmp_path / "manual.json"
+    unrun_out = tmp_path / "unrun.json"
+
+    prod.write_text(json.dumps({
+        "policy": {"excluded_exact_ids": ["bad/excluded"],
+                   "exclusion_keywords": ["gpt-oss"]},
+        "candidates": [
+            {"repo_id": "org/keep", "params_b": 7, "downloads": 500},
+            {"repo_id": "org/gpt-oss-120b", "downloads": 999},   # keyword-excluded
+            {"repo_id": "bad/excluded", "downloads": 999},        # exact-excluded
+        ],
+    }), encoding="utf-8")
+    newm.write_text(json.dumps({"models": [
+        {"repo_id": "org/new1", "num_parameters": 7_000_000_000, "downloads": 1000},
+        {"repo_id": "org/keep", "downloads": 1},  # dup of production -> skipped
+    ]}), encoding="utf-8")
+
+    monkeypatch.setattr(brp, "PROD", prod)
+    monkeypatch.setattr(brp, "NEWM", newm)
+    monkeypatch.setattr(brp, "MANUAL_OUT", manual_out)
+    monkeypatch.setattr(brp, "UNRUN_OUT", unrun_out)
+    monkeypatch.setattr(brp, "MANUAL_N", 1)
+    # org/new1 already "run" via pulse -> excluded from unrun.
+    monkeypatch.setattr(brp, "_pulse_model_keys", lambda: {brp.slugify("new1")})
+
+    rc = brp.main()
+    assert rc == 0
+
+    merged = json.loads(prod.read_text(encoding="utf-8"))
+    repos = {c["repo_id"] for c in merged["candidates"]}
+    assert repos == {"org/keep", "org/new1"}  # excluded + dup gone
+
+    manual = json.loads(manual_out.read_text(encoding="utf-8"))
+    assert manual["count"] == 1  # MANUAL_N
+
+    unrun = json.loads(unrun_out.read_text(encoding="utf-8"))
+    unrun_repos = {c["repo_id"] for c in unrun["candidates"]}
+    # new1 is run (pulse) AND org/new1 may be in manual top-1; keep is in manual top-1
+    assert "org/new1" not in unrun_repos

--- a/ci/test_ci_build_summary.py
+++ b/ci/test_ci_build_summary.py
@@ -1,0 +1,175 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for ci/build_summary.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_CI_DIR = Path(__file__).resolve().parent
+if str(_CI_DIR) not in sys.path:
+    sys.path.insert(0, str(_CI_DIR))
+
+import build_summary as bs  # noqa: E402
+import inferenceX_parser as ix  # noqa: E402
+
+
+# ── formatting helpers ──
+
+def test_fmt_num():
+    assert bs.fmt_num(None) == "—"
+    assert bs.fmt_num(1.234) == "1.2"
+    assert bs.fmt_num("notnum") == "notnum"
+
+
+def test_fmt_pct():
+    assert bs.fmt_pct(None) == "—"
+    assert bs.fmt_pct(5.0) == "+5.00%"
+    assert bs.fmt_pct("x") == "x"
+
+
+def test_gain_medal():
+    assert bs.gain_medal(None) == ""
+    assert bs.gain_medal(60) == "🥇🥇🥇🥇"
+    assert bs.gain_medal(30) == "🥇🥇🥇"
+    assert bs.gain_medal(15) == "🥇🥇"
+    assert bs.gain_medal(5) == "🥇"
+    assert bs.gain_medal(0.5) == "🟢"
+    assert bs.gain_medal(0) == "➖"
+    assert bs.gain_medal(-1) == ""
+
+
+def test_vs_infx_decoration():
+    assert bs.vs_infx_decoration(None) == ""
+    assert bs.vs_infx_decoration(60) == "✅✅"
+    assert bs.vs_infx_decoration(5) == "✅"
+    assert bs.vs_infx_decoration(-1) == ""
+
+
+def test_status_icon():
+    assert bs.status_icon({"ci_success": True}) == "✅"
+    assert bs.status_icon({"final_status": "Failed"}) == "❌"
+    assert bs.status_icon({"baseline_tok_per_gpu": 1, "optimized_tok_per_gpu": 2}) == "✅"
+    assert bs.status_icon({"baseline_tok_per_gpu": 1}) == "🟡"
+    assert bs.status_icon({}) == "❌"
+
+
+def test_derive_params():
+    assert bs.derive_params("org/Model-14B-Instruct") == "14B"
+    assert bs.derive_params("org/Qwen-1.5B") == "1.5B"
+    assert bs.derive_params("org/no-params") is None
+    assert bs.derive_params(None) is None
+
+
+def test_short_model_name():
+    assert bs.short_model_name("org/Model") == "Model"
+    assert bs.short_model_name(None) == "—"
+
+
+def test_gain_sort_key():
+    assert bs.gain_sort_key({"ci_success": True, "gain_pct": 10}) == (0, -10.0)
+    assert bs.gain_sort_key({"ci_success": False}) == (1, 1.0)
+    assert bs.gain_sort_key({"ci_success": True, "gain_pct": "bad"}) == (0, 1.0)
+
+
+# ── load_hf_to_ifx_map ──
+
+def test_load_hf_to_ifx_map(tmp_path: Path):
+    p = tmp_path / "ifx.yaml"
+    p.write_text("models:\n  - hf_model: org/m\n    api_name: m-api\n  - hf_model: x\n",
+                 encoding="utf-8")
+    assert bs.load_hf_to_ifx_map(p) == {"org/m": "m-api"}
+
+
+def test_load_hf_to_ifx_map_missing(tmp_path: Path):
+    assert bs.load_hf_to_ifx_map(tmp_path / "no.yaml") == {}
+
+
+# ── fetch_inferenceX_ref ──
+
+def test_fetch_inferenceX_ref_no_mapping():
+    assert bs.fetch_inferenceX_ref("org/m", {}, "b200", 1024, 1024) is None
+
+
+def test_fetch_inferenceX_ref_match(monkeypatch):
+    monkeypatch.setattr(ix, "fetch_benchmarks", lambda name: [{
+        "hardware": "b200", "isl": 1024, "osl": 1024, "precision": "fp8",
+        "metrics": {"output_tput_per_gpu": 123}}])
+    ref = bs.fetch_inferenceX_ref("org/m", {"org/m": "m-api"}, "b200", 1024, 1024)
+    assert ref == 123
+
+
+def test_fetch_inferenceX_ref_api_error(monkeypatch):
+    def boom(name):
+        raise RuntimeError("down")
+    monkeypatch.setattr(ix, "fetch_benchmarks", boom)
+    assert bs.fetch_inferenceX_ref("org/m", {"org/m": "api"}, "b200", 1024, 1024) is None
+
+
+def test_fetch_inferenceX_ref_no_bench(monkeypatch):
+    monkeypatch.setattr(ix, "fetch_benchmarks", lambda name: [])
+    assert bs.fetch_inferenceX_ref("org/m", {"org/m": "api"}, "b200", 1024, 1024) is None
+
+
+# ── build_run_metadata ──
+
+def test_build_run_metadata(monkeypatch):
+    monkeypatch.setenv("GITHUB_RUN_ID", "42")
+    md = bs.build_run_metadata()
+    assert md["source"] == "hyperloom-ci"
+    assert md["github_run_id"] == "42"
+
+
+# ── collect_rows / render_markdown / main (end-to-end) ──
+
+def _make_artifacts(tmp_path: Path) -> tuple[Path, Path]:
+    artifacts = tmp_path / "artifacts"
+    manifests = tmp_path / "manifests"
+    (artifacts / "task1").mkdir(parents=True)
+    (artifacts / "task1" / "ci_metrics.json").write_text(json.dumps({
+        "baseline_throughput": 100, "optimized_throughput": 130,
+        "model": "org/m-7B", "framework": "sglang", "tp": 8}), encoding="utf-8")
+    manifests.mkdir()
+    (manifests / "submission_manifest.json").write_text(json.dumps({
+        "records": [{"task_id": "task1", "model": "org/m-7B", "final_status": "Succeeded"}]}),
+        encoding="utf-8")
+    return artifacts, manifests
+
+
+def test_collect_rows(tmp_path: Path, monkeypatch):
+    artifacts, manifests = _make_artifacts(tmp_path)
+    monkeypatch.setattr(bs, "fetch_inferenceX_ref", lambda *a, **k: 120.0)
+    rows, normalized = bs.collect_rows(artifacts, manifests, {}, "b200", 1024, 1024)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["model"] == "org/m-7B"
+    assert row["gain_pct"] == 30.0
+    assert row["inferenceX_tok_per_gpu"] == 120.0
+    assert row["vs_inferenceX_pct"] is not None
+    assert row["ci_success"] is True
+
+
+def test_render_markdown(tmp_path: Path, monkeypatch):
+    artifacts, manifests = _make_artifacts(tmp_path)
+    monkeypatch.setattr(bs, "fetch_inferenceX_ref", lambda *a, **k: None)
+    rows, _ = bs.collect_rows(artifacts, manifests, {}, "b200", 1024, 1024)
+    md = bs.render_markdown(rows, "b200", 1024, 1024)
+    assert "# Hyperloom CI Summary" in md
+    assert "`m-7B`" in md
+
+
+def test_main(tmp_path: Path, monkeypatch):
+    artifacts, manifests = _make_artifacts(tmp_path)
+    out_dir = tmp_path / "out"
+    monkeypatch.setattr(bs, "fetch_inferenceX_ref", lambda *a, **k: None)
+    monkeypatch.setattr(sys, "argv", [
+        "build_summary.py", "--artifacts-dir", str(artifacts),
+        "--manifests-dir", str(manifests), "--out-dir", str(out_dir),
+        "--ifx-models-yaml", str(tmp_path / "absent.yaml")])
+    assert bs.main() == 0
+    assert (out_dir / "ci_summary.md").exists()
+    assert (out_dir / "ci_summary.json").exists()
+    data = json.loads((out_dir / "ci_summary.json").read_text(encoding="utf-8"))
+    assert data["rows"]

--- a/ci/test_ci_generate_hf_matrix.py
+++ b/ci/test_ci_generate_hf_matrix.py
@@ -1,0 +1,585 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for ci/generate_hf_matrix.py."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_CI_DIR = Path(__file__).resolve().parent
+if str(_CI_DIR) not in sys.path:
+    sys.path.insert(0, str(_CI_DIR))
+
+import generate_hf_matrix as gm  # noqa: E402
+
+
+# ── pure helpers ──
+
+def test_slugify():
+    assert gm.slugify("Qwen/Qwen3-8B") == "qwen-qwen3-8b"
+    assert gm.slugify("a..b//c") == "a-b-c"
+    assert gm.slugify("???") == "model"
+
+
+def test_truthy():
+    for v in ("1", "true", "YES", "y", "on"):
+        assert gm._truthy(v) is True
+    for v in ("0", "", "no", None):
+        assert gm._truthy(v) is False
+
+
+def test_entry_repo_and_slug():
+    assert gm._entry_repo({"repo_id": "a/b"}) == "a/b"
+    assert gm._entry_repo({"model": "c/d"}) == "c/d"
+    assert gm._entry_repo("e/f") == "e/f"
+    assert gm._entry_repo({}) == ""
+    assert gm._entry_slug({"repo_id": "Org/M"}) == "org-m"
+
+
+def test_parse_explicit_models():
+    assert gm._parse_explicit_models("a b,c\nd") == ["a", "b", "c", "d"]
+    assert gm._parse_explicit_models("  ") == []
+
+
+# ── _filter_entries_by_explicit_models ──
+
+def test_filter_entries_by_explicit_models():
+    entries = [{"repo_id": "Org/A"}, {"repo_id": "Org/B"}]
+    out = gm._filter_entries_by_explicit_models(entries, ["org/b"])
+    assert out == [{"repo_id": "Org/B"}]
+
+
+def test_filter_entries_empty_repos_returns_all():
+    entries = [{"repo_id": "A"}]
+    assert gm._filter_entries_by_explicit_models(entries, []) == entries
+
+
+def test_filter_entries_missing_warns(capsys):
+    out = gm._filter_entries_by_explicit_models([{"repo_id": "A"}], ["a", "missing"])
+    assert len(out) == 1
+    assert "not present" in capsys.readouterr().err
+
+
+# ── _load_candidate_entries ──
+
+def test_load_candidate_entries(tmp_path: Path):
+    p = tmp_path / "c.json"
+    p.write_text(json.dumps({"pool_id": "pool1", "candidates": [
+        {"repo_id": "a"}, {"no_repo": 1}, {"repo_id": "b"}]}), encoding="utf-8")
+    out = gm._load_candidate_entries(p)
+    assert [e["repo_id"] for e in out] == ["a", "b"]
+    assert out[0]["pool_id"] == "pool1"
+    assert out[0]["pool_index"] == 0
+
+
+def test_load_candidate_entries_bad_file(tmp_path: Path, capsys):
+    p = tmp_path / "c.json"
+    p.write_text("{bad", encoding="utf-8")
+    assert gm._load_candidate_entries(p) == []
+
+
+# ── _resolve_batch_index ──
+
+def test_resolve_batch_index_explicit(monkeypatch):
+    monkeypatch.setenv("INPUT_BATCH_INDEX", "3")
+    assert gm._resolve_batch_index(100, 10) == 3
+
+
+def test_resolve_batch_index_explicit_invalid(monkeypatch):
+    monkeypatch.setenv("INPUT_BATCH_INDEX", "xx")
+    assert gm._resolve_batch_index(100, 10) == 0
+
+
+def test_resolve_batch_index_run_number(monkeypatch):
+    monkeypatch.delenv("INPUT_BATCH_INDEX", raising=False)
+    monkeypatch.delenv("GITHUB_EVENT_NAME", raising=False)
+    monkeypatch.setenv("GITHUB_RUN_NUMBER", "3")
+    # pool 100 / batch 10 => 10 batches; run 3 -> (3-1)%10 = 2
+    assert gm._resolve_batch_index(100, 10) == 2
+
+
+def test_resolve_batch_index_zero_batch(monkeypatch):
+    monkeypatch.delenv("INPUT_BATCH_INDEX", raising=False)
+    assert gm._resolve_batch_index(0, 0) == 0
+
+
+def test_resolve_batch_index_run_number_invalid(monkeypatch):
+    monkeypatch.delenv("INPUT_BATCH_INDEX", raising=False)
+    monkeypatch.delenv("GITHUB_EVENT_NAME", raising=False)
+    monkeypatch.setenv("GITHUB_RUN_NUMBER", "notint")
+    assert gm._resolve_batch_index(100, 10) == 0
+
+
+# ── cron rotation ──
+
+def test_cron_fire_counter_monotonic():
+    a = gm._cron_fire_counter(datetime(2026, 6, 15, 16, 0, tzinfo=timezone.utc))
+    b = gm._cron_fire_counter(datetime(2026, 6, 16, 4, 0, tzinfo=timezone.utc))
+    assert b > a
+
+
+def test_cron_fire_counter_before_first_fire():
+    # 02:00 UTC is before the 04:00 fire -> counted as prior day's last fire.
+    c = gm._cron_fire_counter(datetime(2026, 6, 15, 2, 0, tzinfo=timezone.utc))
+    assert isinstance(c, int)
+
+
+def test_cron_batch_index_anchor_is_zero(monkeypatch):
+    monkeypatch.setenv("INPUT_CRON_NOW", "2026-06-15T16:00:00+00:00")
+    assert gm._cron_batch_index(100, 10) == 0
+
+
+def test_cron_batch_index_advances(monkeypatch):
+    monkeypatch.setenv("INPUT_CRON_NOW", "2026-06-16T04:00:00Z")
+    # one fire after anchor -> batch 1
+    assert gm._cron_batch_index(100, 10) == 1
+
+
+def test_cron_batch_index_before_anchor_clamped(monkeypatch):
+    monkeypatch.setenv("INPUT_CRON_NOW", "2026-06-14T16:00:00+00:00")
+    assert gm._cron_batch_index(100, 10) == 0
+
+
+def test_cron_batch_index_bad_now(monkeypatch):
+    monkeypatch.setenv("INPUT_CRON_NOW", "not-a-date")
+    assert isinstance(gm._cron_batch_index(100, 10), int)
+
+
+# ── _slice_entries ──
+
+def test_slice_entries_no_batch(monkeypatch):
+    monkeypatch.delenv("INPUT_BATCH_SIZE", raising=False)
+    entries = [{"repo_id": str(i)} for i in range(5)]
+    assert gm._slice_entries(entries) == entries
+
+
+def test_slice_entries_batch(monkeypatch):
+    monkeypatch.setenv("INPUT_BATCH_SIZE", "2")
+    monkeypatch.setenv("INPUT_BATCH_INDEX", "1")
+    entries = [{"repo_id": str(i)} for i in range(5)]
+    out = gm._slice_entries(entries)
+    assert [e["repo_id"] for e in out] == ["2", "3"]
+    assert out[0]["_selected_batch_index"] == 1
+
+
+def test_slice_entries_manual_tail_wraps(monkeypatch):
+    monkeypatch.setenv("INPUT_BATCH_SIZE", "3")
+    monkeypatch.setenv("INPUT_BATCH_INDEX", "1")
+    monkeypatch.delenv("GITHUB_EVENT_NAME", raising=False)
+    entries = [{"repo_id": str(i)} for i in range(5)]
+    out = gm._slice_entries(entries)  # start=3, end=6 -> [3,4] + wrap [0]
+    assert [e["repo_id"] for e in out] == ["3", "4", "0"]
+
+
+def test_slice_entries_schedule_no_wrap(monkeypatch):
+    monkeypatch.setenv("INPUT_BATCH_SIZE", "3")
+    monkeypatch.setenv("INPUT_BATCH_INDEX", "1")
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "schedule")
+    entries = [{"repo_id": str(i)} for i in range(5)]
+    out = gm._slice_entries(entries)  # [3,4] only, no wrap
+    assert [e["repo_id"] for e in out] == ["3", "4"]
+
+
+def test_slice_entries_bad_batch_size(monkeypatch):
+    monkeypatch.setenv("INPUT_BATCH_SIZE", "abc")
+    entries = [{"repo_id": "a"}]
+    assert gm._slice_entries(entries) == entries
+
+
+# ── _slice_entries_with_active_refill ──
+
+def test_active_refill_no_batch(monkeypatch):
+    monkeypatch.delenv("INPUT_BATCH_SIZE", raising=False)
+    entries = [{"repo_id": "a"}, {"repo_id": "b"}]
+    out = gm._slice_entries_with_active_refill(entries, {gm.slugify("a")})
+    assert [e["repo_id"] for e in out] == ["b"]
+
+
+def test_active_refill_skips_active(monkeypatch):
+    monkeypatch.setenv("INPUT_BATCH_SIZE", "2")
+    monkeypatch.setenv("INPUT_BATCH_INDEX", "0")
+    entries = [{"repo_id": str(i)} for i in range(5)]
+    out = gm._slice_entries_with_active_refill(entries, {gm.slugify("0")})
+    # start 0, skip "0" -> picks "1","2"
+    assert [e["repo_id"] for e in out] == ["1", "2"]
+
+
+def test_active_refill_empty_pool(monkeypatch):
+    monkeypatch.setenv("INPUT_BATCH_SIZE", "2")
+    assert gm._slice_entries_with_active_refill([], set()) == []
+
+
+# ── _slice_from_candidates / _all_from_candidates ──
+
+def test_slice_from_candidates(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("INPUT_BATCH_SIZE", raising=False)
+    p = tmp_path / "c.json"
+    p.write_text(json.dumps({"candidates": [{"repo_id": "a"}, {"repo_id": "b"}]}), encoding="utf-8")
+    assert gm._slice_from_candidates(p) == ["a", "b"]
+
+
+def test_all_from_candidates(tmp_path: Path, capsys):
+    p = tmp_path / "c.json"
+    p.write_text(json.dumps({"candidates": [{"repo_id": "a"}]}), encoding="utf-8")
+    assert gm._all_from_candidates(p) == ["a"]
+
+
+# ── _matrix_entry ──
+
+def test_matrix_entry_string():
+    assert gm._matrix_entry("Org/M") == {"model": "Org/M", "key": "org-m"}
+
+
+def test_matrix_entry_dict_with_meta(monkeypatch):
+    monkeypatch.setenv("INPUT_BATCH_SIZE", "10")
+    entry = {"repo_id": "Org/M", "framework": "sglang", "tp": 8,
+             "_selected_batch_index": 2, "_selected_batch_size": 10}
+    out = gm._matrix_entry(entry)
+    assert out["model"] == "Org/M"
+    assert out["framework"] == "sglang"
+    assert out["batch_index"] == 2
+    assert out["batch_size"] == 10
+
+
+# ── collect_entries ──
+
+def test_collect_entries_explicit_only(monkeypatch):
+    monkeypatch.setenv("INPUT_MODELS", "a b")
+    monkeypatch.delenv("INPUT_CANDIDATES_FILE", raising=False)
+    monkeypatch.delenv("GITHUB_EVENT_NAME", raising=False)
+    assert gm.collect_entries() == ["a", "b"]
+
+
+def test_collect_entries_candidates_file(tmp_path: Path, monkeypatch):
+    p = tmp_path / "c.json"
+    p.write_text(json.dumps({"candidates": [{"repo_id": "a"}, {"repo_id": "b"}]}), encoding="utf-8")
+    monkeypatch.delenv("INPUT_MODELS", raising=False)
+    monkeypatch.setenv("INPUT_CANDIDATES_FILE", str(p))
+    monkeypatch.delenv("INPUT_BATCH_SIZE", raising=False)
+    monkeypatch.delenv("INPUT_EXCLUDE_LEADERBOARD", raising=False)
+    monkeypatch.delenv("INPUT_EXCLUDE_ACTIVE_WORKFLOWS", raising=False)
+    out = gm.collect_entries()
+    assert [gm._entry_repo(e) for e in out] == ["a", "b"]
+
+
+def test_collect_entries_candidates_file_missing(tmp_path: Path, monkeypatch, capsys):
+    monkeypatch.delenv("INPUT_MODELS", raising=False)
+    monkeypatch.setenv("INPUT_CANDIDATES_FILE", str(tmp_path / "nope.json"))
+    assert gm.collect_entries() == []
+    assert "not found" in capsys.readouterr().err
+
+
+def test_collect_entries_explicit_filter_candidates(tmp_path: Path, monkeypatch):
+    p = tmp_path / "c.json"
+    p.write_text(json.dumps({"candidates": [
+        {"repo_id": "Org/A", "framework": "sglang"}, {"repo_id": "Org/B"}]}), encoding="utf-8")
+    monkeypatch.setenv("INPUT_MODELS", "org/a")
+    monkeypatch.setenv("INPUT_CANDIDATES_FILE", str(p))
+    monkeypatch.delenv("INPUT_EXCLUDE_LEADERBOARD", raising=False)
+    monkeypatch.delenv("INPUT_EXCLUDE_ACTIVE_WORKFLOWS", raising=False)
+    out = gm.collect_entries()
+    assert [gm._entry_repo(e) for e in out] == ["Org/A"]
+
+
+def test_collect_repos(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("INPUT_MODELS", "x y")
+    monkeypatch.delenv("INPUT_CANDIDATES_FILE", raising=False)
+    monkeypatch.delenv("GITHUB_EVENT_NAME", raising=False)
+    assert gm.collect_repos() == ["x", "y"]
+
+
+# ── main ──
+
+def test_main_empty(monkeypatch, tmp_path: Path, capsys):
+    monkeypatch.delenv("INPUT_MODELS", raising=False)
+    monkeypatch.delenv("INPUT_CANDIDATES_FILE", raising=False)
+    monkeypatch.delenv("GITHUB_EVENT_NAME", raising=False)
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    monkeypatch.setattr(gm, "collect_entries", lambda: [])
+    assert gm.main() == 0
+    assert "empty matrix" in capsys.readouterr().err
+
+
+def test_main_writes_output(monkeypatch, tmp_path: Path):
+    out_file = tmp_path / "out.txt"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out_file))
+    monkeypatch.setattr(gm, "collect_entries", lambda: [{"repo_id": "Org/M"}])
+    assert gm.main() == 0
+    content = out_file.read_text(encoding="utf-8")
+    assert "matrix=" in content
+    assert "count=1" in content
+
+
+def test_main_stdout(monkeypatch, capsys):
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    monkeypatch.setattr(gm, "collect_entries", lambda: ["Org/M"])
+    assert gm.main() == 0
+    # last stdout line is the matrix json
+    out = capsys.readouterr().out.strip().splitlines()[-1]
+    assert json.loads(out)["include"][0]["model"] == "Org/M"
+
+
+# ── network functions (mocked urllib) ──
+
+class _FakeURLMap:
+    """Monkeypatch target: maps URL substring -> JSON/HTML payload."""
+
+    def __init__(self, routes: dict, html_routes: dict | None = None):
+        self.routes = routes
+        self.html_routes = html_routes or {}
+
+    def __call__(self, url_or_req, timeout=0):
+        url = getattr(url_or_req, "full_url", url_or_req)
+        for frag, payload in self.html_routes.items():
+            if frag in url:
+                return io.BytesIO(payload.encode("utf-8"))
+        for frag, payload in self.routes.items():
+            if frag in url:
+                return io.BytesIO(json.dumps(payload).encode("utf-8"))
+        return io.BytesIO(json.dumps({"results": []}).encode("utf-8"))
+
+
+def test_paginate_models(monkeypatch):
+    routes = {"/api/v1/leaderboard": {
+        "results": [{"model": "Org/A", "task_id": "t1"},
+                    {"model": "Org/B", "tasks": [{"task_id": "t2"}]}],
+        "pagination": {"has_more": False}}}
+    monkeypatch.setattr(gm.urllib.request, "urlopen", _FakeURLMap(routes))
+    models, tids = gm._paginate_models("/api/v1/leaderboard")
+    assert "org/a" in models and "org/b" in models
+    assert {"t1", "t2"} <= tids
+
+
+def test_paginate_models_error(monkeypatch):
+    def boom(url, timeout=0):
+        raise OSError("net")
+    monkeypatch.setattr(gm.urllib.request, "urlopen", boom)
+    try:
+        gm._paginate_models("/x")
+        assert False, "expected RuntimeError"
+    except RuntimeError:
+        pass
+
+
+def test_resolve_task_models(monkeypatch):
+    routes = {"/api/v1/tasks/t1": {"model": "Org/X"}}
+    monkeypatch.setattr(gm.urllib.request, "urlopen", _FakeURLMap(routes))
+    out = gm._resolve_task_models(["t1"], max_workers=2)
+    assert out == {"org/x"}
+
+
+def test_resolve_task_models_empty():
+    assert gm._resolve_task_models([]) == set()
+
+
+def test_dashboard_task_ids(monkeypatch):
+    html = '<a href="api/v1/tasks/abc">x</a> api/v1/tasks/def'
+    monkeypatch.setattr(gm.urllib.request, "urlopen",
+                        _FakeURLMap({}, html_routes={"/dashboard": html}))
+    tids = gm._dashboard_task_ids()
+    assert {"abc", "def"} <= tids
+
+
+def test_active_workflow_slugs_no_token(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+    assert gm._active_workflow_slugs() == set()
+
+
+def test_active_workflow_slugs(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "tok")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "o/r")
+    monkeypatch.setenv("GITHUB_RUN_ID", "999")
+    routes = {
+        "actions/runs": {"workflow_runs": [
+            {"id": 1, "name": "SaFE Optimize Submit", "jobs_url": "https://api.github.com/jobs1"},
+            {"id": 999, "name": "SaFE Optimize Submit", "jobs_url": "https://api.github.com/skip"},
+        ]},
+        "jobs1": {"jobs": [{"name": "optimize-org-m"}, {"name": "other"}]},
+    }
+    monkeypatch.setattr(gm.urllib.request, "urlopen", _FakeURLMap(routes))
+    slugs = gm._active_workflow_slugs()
+    assert "org-m" in slugs
+
+
+def test_leaderboard_models(monkeypatch):
+    routes = {
+        "/api/v1/leaderboard": {"results": [{"model": "Org/A", "task_id": "t1"}],
+                                "pagination": {"has_more": False}},
+        "/api/v1/tasks": {"results": [{"model": "Org/B", "task_id": "t2"}],
+                          "pagination": {"has_more": False}},
+    }
+    monkeypatch.setattr(gm.urllib.request, "urlopen",
+                        _FakeURLMap(routes, html_routes={"/dashboard": "no tasks here"}))
+    models = gm._leaderboard_models()
+    assert "org/a" in models and "org/b" in models
+
+
+def test_apply_exclusions(monkeypatch):
+    monkeypatch.delenv("INPUT_EXCLUDE_LEADERBOARD", raising=False)
+    monkeypatch.delenv("INPUT_EXCLUDE_ACTIVE_WORKFLOWS", raising=False)
+    assert gm._apply_exclusions(["a", "b"]) == ["a", "b"]
+
+
+def test_apply_exclusions_to_entries_with_leaderboard(monkeypatch):
+    monkeypatch.setenv("INPUT_EXCLUDE_LEADERBOARD", "1")
+    monkeypatch.delenv("INPUT_EXCLUDE_ACTIVE_WORKFLOWS", raising=False)
+    monkeypatch.setattr(gm, "_leaderboard_models", lambda: {"org/a"})
+    out = gm._apply_exclusions_to_entries([{"repo_id": "Org/A"}, {"repo_id": "Org/B"}])
+    assert [gm._entry_repo(e) for e in out] == ["Org/B"]
+
+
+def test_apply_exclusions_to_entries_with_active(monkeypatch):
+    monkeypatch.delenv("INPUT_EXCLUDE_LEADERBOARD", raising=False)
+    monkeypatch.setenv("INPUT_EXCLUDE_ACTIVE_WORKFLOWS", "1")
+    monkeypatch.setattr(gm, "_active_workflow_slugs", lambda: {gm.slugify("Org/A")})
+    out = gm._apply_exclusions_to_entries([{"repo_id": "Org/A"}, {"repo_id": "Org/B"}])
+    assert [gm._entry_repo(e) for e in out] == ["Org/B"]
+
+
+# ── extra branch coverage for generate_hf_matrix ──
+
+def test_resolve_batch_index_schedule(monkeypatch):
+    monkeypatch.delenv("INPUT_BATCH_INDEX", raising=False)
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "schedule")
+    monkeypatch.setenv("INPUT_CRON_NOW", "2026-06-16T04:00:00Z")
+    assert gm._resolve_batch_index(100, 10) == 1
+
+
+def test_cron_batch_index_uses_now_when_unset(monkeypatch):
+    monkeypatch.delenv("INPUT_CRON_NOW", raising=False)
+    assert isinstance(gm._cron_batch_index(100, 10), int)
+
+
+def test_matrix_entry_bad_batch_size(monkeypatch):
+    monkeypatch.delenv("INPUT_BATCH_SIZE", raising=False)
+    entry = {"repo_id": "Org/M", "_selected_batch_size": "bad"}
+    out = gm._matrix_entry(entry)
+    assert out["model"] == "Org/M"
+    assert "batch_size" not in out
+
+
+def test_collect_entries_relative_path(tmp_path: Path, monkeypatch):
+    (tmp_path / "rel.json").write_text(
+        json.dumps({"candidates": [{"repo_id": "a"}]}), encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("INPUT_MODELS", raising=False)
+    monkeypatch.setenv("INPUT_CANDIDATES_FILE", "rel.json")
+    monkeypatch.delenv("INPUT_BATCH_SIZE", raising=False)
+    monkeypatch.delenv("INPUT_EXCLUDE_LEADERBOARD", raising=False)
+    monkeypatch.delenv("INPUT_EXCLUDE_ACTIVE_WORKFLOWS", raising=False)
+    out = gm.collect_entries()
+    assert [gm._entry_repo(e) for e in out] == ["a"]
+
+
+def test_collect_entries_exclude_leaderboard(tmp_path: Path, monkeypatch):
+    p = tmp_path / "c.json"
+    p.write_text(json.dumps({"candidates": [{"repo_id": "Org/A"}, {"repo_id": "Org/B"}]}),
+                 encoding="utf-8")
+    monkeypatch.delenv("INPUT_MODELS", raising=False)
+    monkeypatch.setenv("INPUT_CANDIDATES_FILE", str(p))
+    monkeypatch.setenv("INPUT_EXCLUDE_LEADERBOARD", "1")
+    monkeypatch.delenv("INPUT_EXCLUDE_ACTIVE_WORKFLOWS", raising=False)
+    monkeypatch.delenv("INPUT_BATCH_SIZE", raising=False)
+    monkeypatch.setattr(gm, "_leaderboard_models", lambda: {"org/a"})
+    out = gm.collect_entries()
+    assert [gm._entry_repo(e) for e in out] == ["Org/B"]
+
+
+def test_collect_entries_exclude_active(tmp_path: Path, monkeypatch):
+    p = tmp_path / "c.json"
+    p.write_text(json.dumps({"candidates": [{"repo_id": "Org/A"}, {"repo_id": "Org/B"}]}),
+                 encoding="utf-8")
+    monkeypatch.delenv("INPUT_MODELS", raising=False)
+    monkeypatch.setenv("INPUT_CANDIDATES_FILE", str(p))
+    monkeypatch.delenv("INPUT_EXCLUDE_LEADERBOARD", raising=False)
+    monkeypatch.setenv("INPUT_EXCLUDE_ACTIVE_WORKFLOWS", "1")
+    monkeypatch.delenv("INPUT_BATCH_SIZE", raising=False)
+    monkeypatch.setattr(gm, "_active_workflow_slugs", lambda: {gm.slugify("Org/A")})
+    out = gm.collect_entries()
+    assert [gm._entry_repo(e) for e in out] == ["Org/B"]
+
+
+def test_collect_entries_hf_fallback(monkeypatch):
+    monkeypatch.delenv("INPUT_MODELS", raising=False)
+    monkeypatch.delenv("INPUT_CANDIDATES_FILE", raising=False)
+    monkeypatch.delenv("GITHUB_EVENT_NAME", raising=False)
+    monkeypatch.delenv("INPUT_EXCLUDE_LEADERBOARD", raising=False)
+    monkeypatch.delenv("INPUT_EXCLUDE_ACTIVE_WORKFLOWS", raising=False)
+
+    class FakeHF:
+        def __init__(self, *a, **k):
+            pass
+
+        def top_models(self, n, min_params_b=7):
+            return ["org/x", "org/y"]
+
+    monkeypatch.setattr(gm, "HuggingFaceClient", FakeHF)
+    assert gm.collect_entries() == ["org/x", "org/y"]
+
+
+def test_resolve_task_models_failure(monkeypatch, capsys):
+    def boom(url, timeout=0):
+        raise OSError("net")
+    monkeypatch.setattr(gm.urllib.request, "urlopen", boom)
+    assert gm._resolve_task_models(["t1"], max_workers=1) == set()
+
+
+def test_resolve_task_models_non_dict(monkeypatch):
+    monkeypatch.setattr(gm.urllib.request, "urlopen",
+                        _FakeURLMap({"/api/v1/tasks/t1": [1, 2, 3]}))
+    assert gm._resolve_task_models(["t1"], max_workers=1) == set()
+
+
+def test_dashboard_task_ids_error(monkeypatch):
+    def boom(url, timeout=0):
+        raise OSError("net")
+    monkeypatch.setattr(gm.urllib.request, "urlopen", boom)
+    assert gm._dashboard_task_ids() == set()
+
+
+def test_leaderboard_models_recovers_hidden(monkeypatch):
+    routes = {
+        "/api/v1/leaderboard": {"results": [{"model": "Org/A", "task_id": "t1"}],
+                                "pagination": {"has_more": False}},
+        "/api/v1/tasks/hidden1": {"model": "Org/Hidden"},
+        "/api/v1/tasks": {"results": [], "pagination": {"has_more": False}},
+    }
+    html = {"/dashboard": "api/v1/tasks/hidden1"}
+    monkeypatch.setattr(gm.urllib.request, "urlopen", _FakeURLMap(routes, html_routes=html))
+    models = gm._leaderboard_models()
+    assert "org/hidden" in models
+
+
+def test_active_workflow_slugs_error_branches(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "tok")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "o/r")
+    monkeypatch.delenv("GITHUB_RUN_ID", raising=False)
+
+    def boom(url_or_req, timeout=0):
+        raise OSError("net down")
+    monkeypatch.setattr(gm.urllib.request, "urlopen", boom)
+    assert gm._active_workflow_slugs() == set()
+
+
+def test_active_workflow_slugs_jobs_error(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "tok")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "o/r")
+    monkeypatch.delenv("GITHUB_RUN_ID", raising=False)
+
+    def selective(url_or_req, timeout=0):
+        url = getattr(url_or_req, "full_url", url_or_req)
+        if "actions/runs" in url:
+            payload = {"workflow_runs": [
+                {"id": 1, "name": "SaFE Optimize Submit", "jobs_url": "https://api.github.com/jobs1"},
+                {"id": 2, "name": "Other Workflow", "jobs_url": "https://x/jobs2"},
+                {"id": 3, "name": "SaFE Optimize Submit"},  # missing jobs_url
+            ]}
+            return io.BytesIO(json.dumps(payload).encode())
+        raise OSError("jobs listing failed")
+    monkeypatch.setattr(gm.urllib.request, "urlopen", selective)
+    assert gm._active_workflow_slugs() == set()

--- a/ci/test_ci_generate_matrix.py
+++ b/ci/test_ci_generate_matrix.py
@@ -1,0 +1,84 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for ci/generate_matrix.py (ci-config.yaml → GHA matrix)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_CI_DIR = Path(__file__).resolve().parent
+if str(_CI_DIR) not in sys.path:
+    sys.path.insert(0, str(_CI_DIR))
+
+import generate_matrix as gm  # noqa: E402
+
+
+def _write_config(tmp_path: Path, models: list[dict]) -> Path:
+    import yaml
+
+    p = tmp_path / "ci-config.yaml"
+    p.write_text(yaml.safe_dump({"models": models}), encoding="utf-8")
+    return p
+
+
+def test_entry_key_prefers_explicit_key():
+    assert gm._entry_key({"key": "k1", "inferenceX_key": "ifx"}) == "k1"
+
+
+def test_entry_key_falls_back_to_inferencex_key():
+    assert gm._entry_key({"inferenceX_key": "ifx"}) == "ifx"
+
+
+def test_generate_matrix_all_models(tmp_path: Path):
+    cfg = _write_config(tmp_path, [
+        {"inferenceX_key": "a"},
+        {"key": "b", "inferenceX_key": "ignored"},
+    ])
+    matrix = gm.generate_matrix(str(cfg))
+    assert matrix == {"include": [{"key": "a"}, {"key": "b"}]}
+
+
+def test_generate_matrix_selected_subset(tmp_path: Path):
+    cfg = _write_config(tmp_path, [
+        {"inferenceX_key": "a"},
+        {"inferenceX_key": "b"},
+        {"inferenceX_key": "c"},
+    ])
+    matrix = gm.generate_matrix(str(cfg), selected_models="a,c")
+    assert matrix == {"include": [{"key": "a"}, {"key": "c"}]}
+
+
+def test_generate_matrix_selected_with_whitespace(tmp_path: Path):
+    cfg = _write_config(tmp_path, [{"inferenceX_key": "a"}, {"inferenceX_key": "b"}])
+    matrix = gm.generate_matrix(str(cfg), selected_models="  a  ")
+    assert matrix == {"include": [{"key": "a"}]}
+
+
+def test_generate_matrix_empty_models(tmp_path: Path):
+    cfg = _write_config(tmp_path, [])
+    assert gm.generate_matrix(str(cfg)) == {"include": []}
+
+
+def test_main_writes_github_output(tmp_path: Path, monkeypatch, capsys):
+    _write_config(tmp_path, [{"inferenceX_key": "a"}])
+    out_file = tmp_path / "gh_out.txt"
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("INPUT_MODELS", "")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out_file))
+    gm.main()
+    written = out_file.read_text(encoding="utf-8")
+    assert written.startswith("matrix=")
+    payload = json.loads(written.split("matrix=", 1)[1])
+    assert payload == {"include": [{"key": "a"}]}
+
+
+def test_main_prints_when_no_github_output(tmp_path: Path, monkeypatch, capsys):
+    _write_config(tmp_path, [{"inferenceX_key": "z"}])
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("INPUT_MODELS", "")
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    gm.main()
+    stdout = capsys.readouterr().out
+    assert json.loads(stdout) == {"include": [{"key": "z"}]}

--- a/ci/test_ci_inferencex_parser.py
+++ b/ci/test_ci_inferencex_parser.py
@@ -1,0 +1,251 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for ci/inferenceX_parser.py."""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+_CI_DIR = Path(__file__).resolve().parent
+if str(_CI_DIR) not in sys.path:
+    sys.path.insert(0, str(_CI_DIR))
+
+import inferenceX_parser as ix  # noqa: E402
+
+
+# ── _unmangle_msys_path / get_nfs_root / resolve_var ──
+
+def test_unmangle_msys_path():
+    mangled = r"C:/Program Files/Git/wekafs/models/x"
+    assert ix._unmangle_msys_path(mangled) == "/wekafs/models/x"
+
+
+def test_unmangle_msys_path_noop():
+    assert ix._unmangle_msys_path("/wekafs/models/x") == "/wekafs/models/x"
+
+
+def test_get_nfs_root_default(monkeypatch):
+    monkeypatch.delenv("NFS_ROOT", raising=False)
+    assert ix.get_nfs_root() == "/wekafs"
+
+
+def test_get_nfs_root_env(monkeypatch):
+    monkeypatch.setenv("NFS_ROOT", "/custom")
+    assert ix.get_nfs_root() == "/custom"
+
+
+def test_resolve_var_basic():
+    assert ix.resolve_var("a/${X}/b", {"X": "mid"}) == "a/mid/b"
+
+
+def test_resolve_var_unset_keeps_placeholder():
+    assert ix.resolve_var("${MISSING}", {}) == "${MISSING}"
+
+
+def test_resolve_var_non_string():
+    assert ix.resolve_var(123) == 123
+
+
+# ── synthesize_entry_from_ci_config / parse_model_entry ──
+
+def test_synthesize_and_parse_roundtrip():
+    cfg = {"model_hf": "org/m", "image": "img:1", "framework": "vllm",
+           "precision": "fp8", "conc": 128, "tp": 4, "ep": 2,
+           "isl_osl_configs": [[1024, 2048]], "key": "abc-def"}
+    entry = ix.synthesize_entry_from_ci_config(cfg)
+    assert entry["model"] == "org/m"
+    assert entry["model-prefix"] == "abc"
+    parsed = ix.parse_model_entry(entry)
+    assert parsed["model_hf"] == "org/m"
+    assert parsed["tp"] == 4
+    assert parsed["conc_end"] == 128
+    assert parsed["isl_osl_configs"] == [(1024, 2048)]
+
+
+def test_synthesize_defaults():
+    entry = ix.synthesize_entry_from_ci_config({})
+    assert entry["runner"] == "mi300x"
+    assert entry["scenarios"]["fixed-seq-len"][0]["isl"] == 1024
+
+
+def test_parse_model_entry_legacy_seq_len_configs():
+    entry = {"model": "m", "seq-len-configs": [
+        {"isl": 512, "osl": 512, "search-space": [{"tp": 2, "conc-end": 32}]}]}
+    parsed = ix.parse_model_entry(entry)
+    assert parsed["tp"] == 2
+    assert parsed["isl_osl_configs"] == [(512, 512)]
+
+
+def test_parse_model_entry_empty():
+    parsed = ix.parse_model_entry({})
+    assert parsed["tp"] == 8
+    assert parsed["isl_osl_configs"] == []
+
+
+# ── find_benchmark ──
+
+def _bench(hw="b200", isl=1024, osl=1024, prec="fp8", out_tput=100, **kw):
+    b = {"hardware": hw, "isl": isl, "osl": osl, "precision": prec,
+         "metrics": {"output_tput_per_gpu": out_tput}}
+    b.update(kw)
+    return b
+
+
+def test_find_benchmark_basic_best_tput():
+    benches = [_bench(out_tput=100), _bench(out_tput=200)]
+    assert ix.find_benchmark(benches, "b200", 1024, 1024)["metrics"]["output_tput_per_gpu"] == 200
+
+
+def test_find_benchmark_no_match():
+    assert ix.find_benchmark([_bench(hw="h100")], "b200", 1024, 1024) is None
+
+
+def test_find_benchmark_precision_filter():
+    benches = [_bench(prec="fp8"), _bench(prec="bf16", out_tput=999)]
+    got = ix.find_benchmark(benches, "b200", 1024, 1024, precision="fp8")
+    assert got["precision"] == "fp8"
+
+
+def test_find_benchmark_image_tp_conc_preference():
+    benches = [
+        _bench(out_tput=300, image="other", decode_tp=2, conc=64),
+        _bench(out_tput=10, image="want-img", decode_tp=8, conc=32),
+    ]
+    got = ix.find_benchmark(benches, "b200", 1024, 1024, image="want-img", tp=8, conc=32)
+    assert got["image"] == "want-img"
+
+
+def test_find_benchmark_tput_per_gpu_fallback():
+    b = {"hardware": "b200", "isl": 1024, "osl": 1024, "precision": "fp8",
+         "metrics": {"tput_per_gpu": 55}}
+    assert ix.find_benchmark([b], "b200", 1024, 1024)["metrics"]["tput_per_gpu"] == 55
+
+
+# ── format_benchmark_for_prompt ──
+
+def test_format_benchmark_for_prompt_match():
+    text = ix.format_benchmark_for_prompt([_bench()], "b200", 1024, 1024, "fp8")
+    assert "Hardware: b200" in text
+    assert "Output Throughput/GPU" in text
+
+
+def test_format_benchmark_for_prompt_no_data():
+    text = ix.format_benchmark_for_prompt([], "b200", 1024, 1024, "fp8")
+    assert "No InferenceX data" in text
+
+
+# ── find_benchmark_script ──
+
+def test_find_benchmark_script_exact(tmp_path: Path):
+    sdir = tmp_path / "benchmarks" / "single_node"
+    sdir.mkdir(parents=True)
+    (sdir / "minimaxm25_fp8_mi355x.sh").write_text("#!/bin/sh", encoding="utf-8")
+    got = ix.find_benchmark_script(tmp_path, "minimaxm2.5-fp8-mi355x")
+    assert got == "benchmarks/single_node/minimaxm25_fp8_mi355x.sh"
+
+
+def test_find_benchmark_script_prefix(tmp_path: Path):
+    sdir = tmp_path / "benchmarks" / "single_node"
+    sdir.mkdir(parents=True)
+    (sdir / "qwen3_fp8_b200.sh").write_text("x", encoding="utf-8")
+    got = ix.find_benchmark_script(tmp_path, "qwen3-fp8-h100")
+    assert got == "benchmarks/single_node/qwen3_fp8_b200.sh"
+
+
+def test_find_benchmark_script_no_dir(tmp_path: Path):
+    assert ix.find_benchmark_script(tmp_path, "x") is None
+
+
+def test_find_benchmark_script_no_match(tmp_path: Path):
+    sdir = tmp_path / "benchmarks" / "single_node"
+    sdir.mkdir(parents=True)
+    (sdir / "zzz.sh").write_text("x", encoding="utf-8")
+    assert ix.find_benchmark_script(tmp_path, "qwen3-fp8-h100") is None
+
+
+# ── merge_model_config ──
+
+def test_merge_model_config(monkeypatch):
+    monkeypatch.setenv("NFS_ROOT", "/nfs")
+    ifx_entry = ix.synthesize_entry_from_ci_config({
+        "model_hf": "org/M", "image": "img:1", "framework": "sglang",
+        "precision": "fp8", "conc": 64, "isl_osl_configs": [[1024, 1024]]})
+    cfg = {"inferenceX_key": "k", "tp": 4}
+    merged = ix.merge_model_config(cfg, ifx_entry, {}, "harbor", [])
+    assert merged["model_hf"] == "org/M"
+    assert merged["model_path"] == "/nfs/models/org-M"
+    assert merged["sandbox_image"] == "harbor/img:1"
+    assert merged["tp"] == 4
+    assert merged["claw_plugin_id"] == 4
+    assert merged["inferencex_path"] == "/nfs/InferenceX"
+
+
+def test_merge_model_config_no_harbor_and_plugin_override(monkeypatch):
+    monkeypatch.setenv("NFS_ROOT", "/nfs")
+    ifx_entry = ix.synthesize_entry_from_ci_config({"model_hf": "m", "image": "img"})
+    merged = ix.merge_model_config({"claw_plugin_id": None}, ifx_entry, {}, "", [])
+    assert merged["sandbox_image"] == "img"
+    assert merged["claw_plugin_id"] is None
+
+
+# ── network functions (mocked) ──
+
+def test_get_latest_commit(monkeypatch):
+    def fake_run(cmd, **kw):
+        return types.SimpleNamespace(stdout="abc123\trefs/heads/main\n")
+    monkeypatch.setattr(ix.subprocess, "run", fake_run)
+    assert ix.get_latest_commit("url") == "abc123"
+
+
+def test_get_latest_commit_empty(monkeypatch):
+    monkeypatch.setattr(ix.subprocess, "run", lambda *a, **k: types.SimpleNamespace(stdout="  \n"))
+    assert ix.get_latest_commit("url") == ""
+
+
+def test_fetch_amd_master_yaml(monkeypatch, tmp_path: Path):
+    def fake_run(cmd, **kw):
+        # cmd: ["git","clone","--depth=1","--branch=main", url, tmpdir]
+        tmpdir = Path(cmd[-1])
+        cfgp = tmpdir / ".github" / "configs" / "amd-master.yaml"
+        cfgp.parent.mkdir(parents=True, exist_ok=True)
+        cfgp.write_text("models:\n  - model: x\n", encoding="utf-8")
+        return types.SimpleNamespace(returncode=0)
+    monkeypatch.setattr(ix.subprocess, "run", fake_run)
+    cfg = ix.fetch_amd_master_yaml("url")
+    assert cfg == {"models": [{"model": "x"}]}
+
+
+def test_find_benchmark_script_from_clone(monkeypatch):
+    def fake_run(cmd, **kw):
+        tmpdir = Path(cmd[-1])
+        sdir = tmpdir / "benchmarks" / "single_node"
+        sdir.mkdir(parents=True, exist_ok=True)
+        (sdir / "m_fp8.sh").write_text("x", encoding="utf-8")
+        return types.SimpleNamespace(returncode=0)
+    monkeypatch.setattr(ix.subprocess, "run", fake_run)
+    got = ix.find_benchmark_script_from_clone("url", "m-fp8")
+    assert got == "benchmarks/single_node/m_fp8.sh"
+
+
+def test_fetch_benchmarks_ok(monkeypatch):
+    class FakeResp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return [{"hardware": "b200"}]
+    monkeypatch.setattr(ix.requests, "get", lambda *a, **k: FakeResp())
+    assert ix.fetch_benchmarks("model") == [{"hardware": "b200"}]
+
+
+def test_fetch_benchmarks_api_error(monkeypatch):
+    class FakeResp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"error": "nope"}
+    monkeypatch.setattr(ix.requests, "get", lambda *a, **k: FakeResp())
+    assert ix.fetch_benchmarks("model") == []

--- a/ci/test_ci_progress.py
+++ b/ci/test_ci_progress.py
@@ -1,0 +1,261 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for ci/progress.py (promote / list-remaining / stats)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_CI_DIR = Path(__file__).resolve().parent
+if str(_CI_DIR) not in sys.path:
+    sys.path.insert(0, str(_CI_DIR))
+
+import progress  # noqa: E402
+
+
+# ── _load_json ──
+
+def test_load_json_missing_returns_empty(tmp_path: Path):
+    assert progress._load_json(tmp_path / "nope.json") == {}
+
+
+def test_load_json_valid(tmp_path: Path):
+    p = tmp_path / "a.json"
+    p.write_text(json.dumps({"x": 1}), encoding="utf-8")
+    assert progress._load_json(p) == {"x": 1}
+
+
+def test_load_json_invalid_returns_empty(tmp_path: Path, capsys):
+    p = tmp_path / "bad.json"
+    p.write_text("{not json", encoding="utf-8")
+    assert progress._load_json(p) == {}
+    assert "could not parse" in capsys.readouterr().err
+
+
+# ── _summary_rows ──
+
+def test_summary_rows_bare_list(tmp_path: Path):
+    p = tmp_path / "s.json"
+    p.write_text(json.dumps([{"model": "m"}]), encoding="utf-8")
+    assert progress._summary_rows(p) == [{"model": "m"}]
+
+
+def test_summary_rows_rows_key(tmp_path: Path):
+    p = tmp_path / "s.json"
+    p.write_text(json.dumps({"rows": [{"model": "a"}]}), encoding="utf-8")
+    assert progress._summary_rows(p) == [{"model": "a"}]
+
+
+def test_summary_rows_models_key(tmp_path: Path):
+    p = tmp_path / "s.json"
+    p.write_text(json.dumps({"models": [{"model": "b"}]}), encoding="utf-8")
+    assert progress._summary_rows(p) == [{"model": "b"}]
+
+
+# ── _classify_status ──
+
+def test_classify_completed():
+    row = {"baseline_tok_per_gpu": 1, "optimized_tok_per_gpu": 2, "gain_pct": 10}
+    assert progress._classify_status(row) == ("completed", None)
+
+
+def test_classify_partial():
+    status, reason = progress._classify_status({"optimized_tok_per_gpu": 2})
+    assert status == "partial"
+    assert "single-data point" in reason
+
+
+def test_classify_failed_final_status():
+    status, reason = progress._classify_status({"final_status": "Failed"})
+    assert status == "failed"
+    assert "final_status=Failed" in reason
+
+
+def test_classify_failed_submit_status():
+    status, reason = progress._classify_status({"submit_status": "error"})
+    assert status == "failed"
+    assert "submit_status=error" in reason
+
+
+def test_classify_failed_no_data():
+    assert progress._classify_status({}) == ("failed", "no data produced")
+
+
+# ── _row_to_entry ──
+
+def test_row_to_entry_full():
+    row = {
+        "model": "org/m", "framework": "sglang", "precision": "fp8", "tp": 8,
+        "params_b": 7, "gain_pct": 12.345, "vs_inferenceX_pct": 3.21,
+        "task_id": "t1", "baseline_tok_per_gpu": 1, "optimized_tok_per_gpu": 2,
+    }
+    e = progress._row_to_entry(row)
+    assert e["repo_id"] == "org/m"
+    assert e["status"] == "completed"
+    assert e["gain_pct"] == 12.35
+    assert e["vs_infx_pct"] == 3.21
+    assert e["task_id"] == "t1"
+
+
+def test_row_to_entry_failed_has_reason():
+    e = progress._row_to_entry({"model": "m"})
+    assert e["status"] == "failed"
+    assert "reason" in e
+
+
+# ── cmd_promote ──
+
+def _ns(**kw) -> argparse.Namespace:
+    return argparse.Namespace(**kw)
+
+
+def test_promote_empty_summary(tmp_path: Path):
+    s = tmp_path / "sum.json"
+    s.write_text(json.dumps([]), encoding="utf-8")
+    rc = progress.cmd_promote(
+        _ns(summary=str(s), already_done=str(tmp_path / "ad.json"), write=False))
+    assert rc == 1
+
+
+def test_promote_dry_run(tmp_path: Path, capsys):
+    s = tmp_path / "sum.json"
+    s.write_text(json.dumps([
+        {"model": "org/m1", "baseline_tok_per_gpu": 1, "optimized_tok_per_gpu": 2, "gain_pct": 5},
+    ]), encoding="utf-8")
+    ad = tmp_path / "ad.json"
+    rc = progress.cmd_promote(_ns(summary=str(s), already_done=str(ad), write=False))
+    assert rc == 0
+    assert "dry-run" in capsys.readouterr().out
+    assert not ad.exists()
+
+
+def test_promote_write_creates_file(tmp_path: Path):
+    s = tmp_path / "sum.json"
+    s.write_text(json.dumps([
+        {"model": "org/m1", "baseline_tok_per_gpu": 1, "optimized_tok_per_gpu": 2, "gain_pct": 5},
+        {"model": "org/m2"},
+    ]), encoding="utf-8")
+    ad = tmp_path / "sub" / "ad.json"
+    rc = progress.cmd_promote(_ns(summary=str(s), already_done=str(ad), write=True))
+    assert rc == 0
+    data = json.loads(ad.read_text(encoding="utf-8"))
+    assert data["_meta"]["count"] == 2
+    repos = {m["repo_id"] for m in data["models"]}
+    assert repos == {"org/m1", "org/m2"}
+
+
+def test_promote_upgrades_not_downgrades(tmp_path: Path):
+    ad = tmp_path / "ad.json"
+    ad.write_text(json.dumps({"models": [{"repo_id": "org/m", "status": "failed"}]}),
+                  encoding="utf-8")
+    s = tmp_path / "sum.json"
+    s.write_text(json.dumps([
+        {"model": "org/m", "baseline_tok_per_gpu": 1, "optimized_tok_per_gpu": 2, "gain_pct": 5},
+    ]), encoding="utf-8")
+    rc = progress.cmd_promote(_ns(summary=str(s), already_done=str(ad), write=True))
+    assert rc == 0
+    data = json.loads(ad.read_text(encoding="utf-8"))
+    assert data["models"][0]["status"] == "completed"
+
+
+def test_promote_nothing_to_do(tmp_path: Path, capsys):
+    ad = tmp_path / "ad.json"
+    ad.write_text(json.dumps({"models": [{"repo_id": "org/m", "status": "completed"}]}),
+                  encoding="utf-8")
+    s = tmp_path / "sum.json"
+    # Same completed status -> no upgrade, no new entry.
+    s.write_text(json.dumps([
+        {"model": "org/m", "baseline_tok_per_gpu": 1, "optimized_tok_per_gpu": 2, "gain_pct": 5},
+    ]), encoding="utf-8")
+    rc = progress.cmd_promote(_ns(summary=str(s), already_done=str(ad), write=True))
+    assert rc == 0
+    assert "nothing to promote" in capsys.readouterr().out
+
+
+def test_promote_many_new_entries_truncated(tmp_path: Path, capsys):
+    rows = [{"model": f"org/m{i}", "baseline_tok_per_gpu": 1,
+             "optimized_tok_per_gpu": 2, "gain_pct": 5} for i in range(20)]
+    s = tmp_path / "sum.json"
+    s.write_text(json.dumps(rows), encoding="utf-8")
+    rc = progress.cmd_promote(
+        _ns(summary=str(s), already_done=str(tmp_path / "ad.json"), write=False))
+    assert rc == 0
+    assert "and 5 more" in capsys.readouterr().out
+
+
+# ── cmd_list_remaining ──
+
+def test_list_remaining_empty_candidates(tmp_path: Path):
+    c = tmp_path / "c.json"
+    c.write_text(json.dumps({"candidates": []}), encoding="utf-8")
+    rc = progress.cmd_list_remaining(_ns(candidates=str(c), already_done=str(tmp_path / "ad.json")))
+    assert rc == 1
+
+
+def test_list_remaining_prints_unrun(tmp_path: Path, capsys):
+    c = tmp_path / "c.json"
+    c.write_text(json.dumps({"candidates": [{"repo_id": "a"}, {"repo_id": "b"}]}), encoding="utf-8")
+    ad = tmp_path / "ad.json"
+    ad.write_text(json.dumps({"models": [{"repo_id": "a"}]}), encoding="utf-8")
+    rc = progress.cmd_list_remaining(_ns(candidates=str(c), already_done=str(ad)))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "1 remaining of 2" in out
+    assert "b" in out
+
+
+# ── cmd_stats ──
+
+def test_stats_basic(tmp_path: Path, capsys):
+    ad = tmp_path / "ad.json"
+    ad.write_text(json.dumps({"models": [
+        {"repo_id": "a", "status": "completed", "framework": "sglang",
+         "precision": "fp8", "gain_pct": 10},
+        {"repo_id": "b", "status": "failed"},
+    ]}), encoding="utf-8")
+    rc = progress.cmd_stats(_ns(already_done=str(ad), candidates=None))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Total models: 2" in out
+    assert "With gain%" in out
+
+
+def test_stats_with_candidates(tmp_path: Path, capsys):
+    ad = tmp_path / "ad.json"
+    ad.write_text(json.dumps({"models": [{"repo_id": "a", "status": "completed"}]}),
+                  encoding="utf-8")
+    c = tmp_path / "c.json"
+    c.write_text(json.dumps({"candidates": [{"repo_id": "a"}, {"repo_id": "b"}]}), encoding="utf-8")
+    rc = progress.cmd_stats(_ns(already_done=str(ad), candidates=str(c)))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Pool size:    2" in out
+    assert "Remaining:    1" in out
+
+
+# ── main dispatch ──
+
+def test_main_promote(tmp_path: Path, monkeypatch):
+    s = tmp_path / "sum.json"
+    s.write_text(json.dumps([{"model": "org/m"}]), encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["progress.py", "promote", str(s),
+                                      "--already-done", str(tmp_path / "ad.json")])
+    assert progress.main() == 0
+
+
+def test_main_stats(tmp_path: Path, monkeypatch):
+    ad = tmp_path / "ad.json"
+    ad.write_text(json.dumps({"models": []}), encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["progress.py", "stats", "--already-done", str(ad)])
+    assert progress.main() == 0
+
+
+def test_main_list_remaining(tmp_path: Path, monkeypatch):
+    c = tmp_path / "c.json"
+    c.write_text(json.dumps({"candidates": [{"repo_id": "a"}]}), encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["progress.py", "list-remaining", str(c),
+                                      "--already-done", str(tmp_path / "ad.json")])
+    assert progress.main() == 0

--- a/ci/test_ci_report_generator.py
+++ b/ci/test_ci_report_generator.py
@@ -1,0 +1,231 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for ci/report_generator.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_CI_DIR = Path(__file__).resolve().parent
+if str(_CI_DIR) not in sys.path:
+    sys.path.insert(0, str(_CI_DIR))
+
+import report_generator as rg  # noqa: E402
+
+
+# ── _fmt_pct / _avg / _first_of ──
+
+def test_fmt_pct():
+    assert rg._fmt_pct(None) == "N/A"
+    assert rg._fmt_pct(0.0) == "--"
+    assert rg._fmt_pct(7.94) == "+7.9%"
+    assert rg._fmt_pct(-3.0) == "-3.0%"
+
+
+def test_avg():
+    assert rg._avg([1.0, 2.0, 3.0]) == 2.0
+    assert rg._avg([]) is None
+
+
+def test_first_of():
+    assert rg._first_of({"a": None, "b": 5}, "a", "b") == 5
+    assert rg._first_of({}, "x") is None
+
+
+# ── _parse_metrics_from_report ──
+
+def test_parse_metrics_from_report_gpu_row():
+    content = "Gain: **12.5%**\n| tok/s/GPU | ~100 | ~120 |\n"
+    out = rg._parse_metrics_from_report(content)
+    assert out["gain_pct"] == 12.5
+    assert out["baseline_throughput"] == 100.0
+    assert out["optimized_throughput"] == 120.0
+
+
+def test_parse_metrics_from_report_output_throughput_row():
+    content = "| Output Throughput (tok/s) | 200 | 240 |"
+    out = rg._parse_metrics_from_report(content)
+    assert out["baseline_throughput"] == 200.0
+    assert out["optimized_throughput"] == 240.0
+
+
+def test_parse_metrics_from_report_empty():
+    assert rg._parse_metrics_from_report("nothing here") == {}
+
+
+# ── _extract_metrics_via_llm ──
+
+def test_extract_metrics_via_llm_no_key(monkeypatch):
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+    assert rg._extract_metrics_via_llm("report") == {}
+
+
+def test_extract_metrics_via_llm_success(monkeypatch):
+    monkeypatch.setenv("LLM_API_KEY", "k")
+
+    class FakeResp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"choices": [{"message": {"content": json.dumps({
+                "baseline_throughput": 10, "optimized_throughput": 12,
+                "tok_per_gpu_baseline": 5, "tok_per_gpu_optimized": 6,
+                "gain_pct": 20})}}]}
+
+    import requests
+    monkeypatch.setattr(requests, "post", lambda *a, **k: FakeResp())
+    out = rg._extract_metrics_via_llm("report text")
+    assert out["gain_pct"] == 20
+    assert out["baseline_throughput"] == 10
+
+
+def test_extract_metrics_via_llm_fenced(monkeypatch):
+    monkeypatch.setenv("LLM_API_KEY", "k")
+
+    class FakeResp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            fenced = "```json\n" + json.dumps({"gain_pct": 3}) + "\n```"
+            return {"choices": [{"message": {"content": fenced}}]}
+
+    import requests
+    monkeypatch.setattr(requests, "post", lambda *a, **k: FakeResp())
+    assert rg._extract_metrics_via_llm("r")["gain_pct"] == 3
+
+
+def test_extract_metrics_via_llm_failure(monkeypatch):
+    monkeypatch.setenv("LLM_API_KEY", "k")
+    import requests
+
+    def boom(*a, **k):
+        raise RuntimeError("net down")
+
+    monkeypatch.setattr(requests, "post", boom)
+    assert rg._extract_metrics_via_llm("r") == {}
+
+
+# ── extract_optimization_data ──
+
+def test_extract_optimization_data_ci_metrics(tmp_path: Path):
+    (tmp_path / "ci_metrics.json").write_text(json.dumps({
+        "tok_per_gpu_baseline": 100, "tok_per_gpu_optimized": 130,
+        "actions_taken": ["a", "b"]}), encoding="utf-8")
+    data = rg.extract_optimization_data(str(tmp_path))
+    assert data["baseline_throughput"] == 100
+    assert data["optimized_throughput"] == 130
+    assert data["gain_pct"] == 30.0
+    assert data["actions"] == ["a", "b"]
+
+
+def test_extract_optimization_data_report_regex(tmp_path: Path):
+    (tmp_path / "optimization_report.md").write_text(
+        "Gain **10.0%**\n| tok/s/GPU | ~50 | ~55 |", encoding="utf-8")
+    data = rg.extract_optimization_data(str(tmp_path))
+    assert data["report_exists"] is True
+    assert data["baseline_throughput"] == 50.0
+    assert data["optimized_throughput"] == 55.0
+
+
+def test_extract_optimization_data_nested_schema(tmp_path: Path):
+    (tmp_path / "ci_metrics.json").write_text(json.dumps({
+        "baseline": {"tok_s_per_gpu": 100},
+        "optimized": {"tok_s_per_gpu": 110},
+        "improvement": {"output_throughput_pct": 10}}), encoding="utf-8")
+    data = rg.extract_optimization_data(str(tmp_path))
+    assert data["baseline_throughput"] == 100
+    assert data["optimized_throughput"] == 110
+    assert data["gain_pct"] == 10.0
+
+
+def test_extract_optimization_data_empty_dir(tmp_path: Path):
+    data = rg.extract_optimization_data(str(tmp_path))
+    assert data["baseline_throughput"] is None
+    assert data["report_exists"] is False
+
+
+def test_extract_optimization_data_bad_ci_metrics(tmp_path: Path):
+    (tmp_path / "ci_metrics.json").write_text("{bad", encoding="utf-8")
+    data = rg.extract_optimization_data(str(tmp_path))
+    assert data["baseline_throughput"] is None
+
+
+# ── build_model_result ──
+
+def test_build_model_result_basic(tmp_path: Path):
+    (tmp_path / "ci_metrics.json").write_text(json.dumps({
+        "tok_per_gpu_baseline": 100, "tok_per_gpu_optimized": 120}), encoding="utf-8")
+    result = rg.build_model_result("M", "k", "img:1", "fp8", "completed", "ts", str(tmp_path))
+    assert result["model"] == "M"
+    assert result["optimized_tok_per_gpu"] == 120
+
+
+def test_build_model_result_with_ifx_reference(tmp_path: Path):
+    (tmp_path / "ci_metrics.json").write_text(json.dumps({
+        "tok_per_gpu_baseline": 80, "tok_per_gpu_optimized": 100}), encoding="utf-8")
+    ifx = {"metrics": {"output_tput_per_gpu": 90}, "decode_tp": 8}
+    result = rg.build_model_result("M", "k", "img", "fp8", "completed", "ts",
+                                   str(tmp_path), ifx_reference=ifx)
+    assert result["inferenceX_tok_per_gpu"] == 90
+    assert result["vs_inferenceX_pct"] is not None
+
+
+def test_build_model_result_total_throughput_correction(tmp_path: Path):
+    # optimized is >3x ifx -> treated as total throughput, divided by TP.
+    (tmp_path / "ci_metrics.json").write_text(json.dumps({
+        "tok_per_gpu_baseline": 800, "tok_per_gpu_optimized": 1000}), encoding="utf-8")
+    ifx = {"metrics": {"output_tput_per_gpu": 100}, "decode_tp": 8}
+    result = rg.build_model_result("M", "k", "img", "fp8", "completed", "ts",
+                                   str(tmp_path), ifx_reference=ifx)
+    assert result["optimized_tok_per_gpu"] == 125.0  # 1000 / 8
+
+
+# ── report renderers ──
+
+def _results():
+    return [
+        {"model": "A", "precision": "fp8", "image": "img:1", "status": "completed",
+         "baseline_tok_per_gpu": 100, "optimized_tok_per_gpu": 120, "gain_pct": 20.0,
+         "vs_inferenceX_pct": 5.0, "inferenceX_tok_per_gpu": 114, "report_exists": True,
+         "actions": ["x"]},
+        {"model": "B", "precision": "bf16", "image": "img:2", "status": "failed",
+         "actions": []},
+        {"model": "C", "precision": "fp8", "image": "img:3", "status": "timeout"},
+    ]
+
+
+def test_generate_markdown_report():
+    md = rg.generate_markdown_report(_results(), "manual", "abcdef1234", "run42")
+    assert "# Inference Optimization CI Report" in md
+    assert "run42" in md
+    assert "abcdef1" in md  # 7-char commit
+
+
+def test_generate_json_summary():
+    summary = rg.generate_json_summary(_results(), "cron", "deadbeef", "run1")
+    assert summary["stats"]["total"] == 3
+    assert summary["stats"]["completed"] == 1
+    assert summary["stats"]["failed"] == 1
+    assert summary["stats"]["timeout"] == 1
+    assert summary["stats"]["avg_gain_pct"] == 20.0
+
+
+def test_generate_github_summary():
+    out = rg.generate_github_summary(_results(), "manual", "abcdef1234")
+    assert "Hyperloom Inference Optimization Results" in out
+    assert "## ✅ A (fp8)" in out
+    assert "Optimization Gain" in out
+
+
+def test_generate_github_summary_overall_table():
+    results = [
+        {"model": f"M{i}", "precision": "fp8", "image": "i", "status": "completed",
+         "baseline_tok_per_gpu": 10, "optimized_tok_per_gpu": 12, "gain_pct": 20.0}
+        for i in range(2)
+    ]
+    out = rg.generate_github_summary(results, "t", "c")
+    assert "Overall Summary" in out

--- a/ci/test_ci_transform_v2.py
+++ b/ci/test_ci_transform_v2.py
@@ -1,0 +1,278 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for ci/transform_to_session_summary_v2.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_CI_DIR = Path(__file__).resolve().parent
+if str(_CI_DIR) not in sys.path:
+    sys.path.insert(0, str(_CI_DIR))
+
+import transform_to_session_summary_v2 as tx  # noqa: E402
+
+
+# ── safe_get ──
+
+def test_safe_get_nested():
+    assert tx.safe_get({"a": {"b": 1}}, "a", "b") == 1
+
+
+def test_safe_get_missing_returns_default():
+    assert tx.safe_get({"a": {}}, "a", "b", default="x") == "x"
+
+
+def test_safe_get_non_dict_returns_default():
+    assert tx.safe_get({"a": 5}, "a", "b", default=None) is None
+
+
+def test_safe_get_none_value_returns_default():
+    assert tx.safe_get({"a": None}, "a", default="d") == "d"
+
+
+# ── _patch_baseline ──
+
+def test_patch_baseline_legacy_alias():
+    data = {"baseline": {"extra_sglang_args": "--foo"}}
+    notes = tx._patch_baseline(data)
+    assert data["baseline"]["extra_server_args"] == "--foo"
+    assert "extra_sglang_args" not in data["baseline"]
+    assert any("legacy" in n for n in notes)
+
+
+def test_patch_baseline_empty_default():
+    data = {"baseline": {}}
+    tx._patch_baseline(data)
+    assert data["baseline"]["extra_server_args"] == ""
+    assert data["baseline"]["extra_envs"] == {}
+
+
+def test_patch_baseline_envs_from_invocation():
+    data = {"baseline": {"extra_server_args": "x", "invocation": {"extra_envs": {"A": "1"}}}}
+    tx._patch_baseline(data)
+    assert data["baseline"]["extra_envs"] == {"A": "1"}
+
+
+def test_patch_baseline_no_baseline():
+    assert tx._patch_baseline({}) == []
+
+
+# ── _best_gain_for_phase ──
+
+def test_best_gain_from_param_search():
+    data = {"param_search": {"params": {"top_by_gain": [{"gain_pct": 12.5}]}}}
+    assert tx._best_gain_for_phase(data, "params") == 12.5
+
+
+def test_best_gain_from_phase_timeline():
+    data = {"phase_timeline": [
+        {"action": "sweep", "extras": {"best_gain_pct_vs_base": 3.0}},
+        {"action": "sweep", "extras": {"best_gain_pct_vs_base": 7.0}},
+    ]}
+    assert tx._best_gain_for_phase(data, "sweep") == 7.0
+
+
+def test_best_gain_none():
+    assert tx._best_gain_for_phase({}, "params") is None
+
+
+# ── _patch_capability_summary ──
+
+def test_patch_capability_summary_fills_phases():
+    data = {
+        "capability_summary": {"params": {}, "validate_stack": {"last_validated_gain_pct": 9.0}},
+        "param_search": {"params": {"top_by_gain": [{"gain_pct": 4.0}]}},
+    }
+    tx._patch_capability_summary(data)
+    assert data["capability_summary"]["params"]["best_gain_pct"] == 4.0
+    assert data["capability_summary"]["validate_stack"]["best_gain_pct"] == 9.0
+
+
+def test_patch_capability_summary_no_cs():
+    assert tx._patch_capability_summary({}) == []
+
+
+# ── _patch_phase_timeline ──
+
+def test_patch_phase_timeline_alias_added():
+    data = {"phase_timeline": [{"extras": {"candidate_extra_server_args": "--x"}}]}
+    tx._patch_phase_timeline(data)
+    assert data["phase_timeline"][0]["extras"]["best_extra_server_args"] == "--x"
+
+
+def test_patch_phase_timeline_legacy_candidate_key():
+    data = {"phase_timeline": [{"extras": {"candidate_extra_sglang_args": "--y"}}]}
+    tx._patch_phase_timeline(data)
+    assert data["phase_timeline"][0]["extras"]["best_extra_server_args"] == "--y"
+
+
+def test_patch_phase_timeline_no_pt():
+    assert tx._patch_phase_timeline({}) == []
+
+
+# ── _aggregate_backend ──
+
+def test_aggregate_backend_picks_best():
+    data = {"kernel_decision_path": [{
+        "kid": "k1",
+        "steps": [
+            {"backend": "geak", "speedup": 1.2, "outcome": "PARTIAL"},
+            {"backend": "geak", "speedup": 1.5, "decision": "KEEP"},
+            {"backend": "oob", "speedup": 9.0},
+        ],
+    }]}
+    agg = tx._aggregate_backend(data, "k1", "geak")
+    assert agg == {"decision": "KEEP", "best_speedup": 1.5}
+
+
+def test_aggregate_backend_no_path():
+    assert tx._aggregate_backend({}, "k1", "geak") == {"decision": None, "best_speedup": None}
+
+
+# ── _patch_detected_kernels ──
+
+def test_patch_detected_kernels_fills():
+    data = {
+        "kernel_lifecycle": {"detected": [{"kernel_id": "k1"}]},
+        "kernel_decision_path": [{"kid": "k1", "steps": [
+            {"backend": "geak", "speedup": 2.0, "decision": "KEEP"},
+        ]}],
+    }
+    tx._patch_detected_kernels(data)
+    k = data["kernel_lifecycle"]["detected"][0]
+    assert k["geak"]["decision"] == "KEEP"
+    assert k["oob"] == {"decision": None, "best_speedup": None}
+
+
+def test_patch_detected_kernels_no_detected():
+    assert tx._patch_detected_kernels({}) == []
+
+
+# ── is_already_v2 / transform ──
+
+def _v2_doc() -> dict:
+    return {
+        "baseline": {"extra_server_args": "", "extra_envs": {}},
+        "capability_summary": {p: {"best_gain_pct": 1.0}
+                               for p in ("params", "backends", "sweep", "geak", "oob")},
+        "phase_timeline": [],
+        "kernel_lifecycle": {"detected": []},
+    }
+
+
+def test_is_already_v2_true():
+    assert tx.is_already_v2(_v2_doc()) is True
+
+
+def test_is_already_v2_false_for_legacy():
+    assert tx.is_already_v2({"baseline": {}}) is False
+
+
+def test_transform_already_v2_passthrough():
+    out = tx.transform(_v2_doc())
+    assert out["source"] == "hyperloom_v2"
+    assert out["error"] is None
+
+
+def test_transform_legacy_applies_patches():
+    legacy = {"baseline": {}, "capability_summary": {"params": {}},
+              "phase_timeline": [{"extras": {"candidate_extra_server_args": "--z"}}],
+              "kernel_lifecycle": {"detected": [{"kernel_id": "k"}]}}
+    out = tx.transform(legacy)
+    assert out["source"] == "claw_legacy_phased"
+    assert "_v2_patches" in out["data"]
+    assert out["data"]["_v2_patches"]  # non-empty
+
+
+def test_transform_does_not_mutate_input():
+    legacy = {"baseline": {}}
+    tx.transform(legacy)
+    assert legacy == {"baseline": {}}
+
+
+# ── transform_file / _output_name_for / main ──
+
+def test_transform_file_default_suffix(tmp_path: Path):
+    p = tmp_path / "session_breakdown.json"
+    p.write_text(json.dumps({"baseline": {}}), encoding="utf-8")
+    out = tx.transform_file(p, None)
+    assert out == p.with_suffix(".v2.json")
+    assert out.exists()
+
+
+def test_transform_file_explicit_out(tmp_path: Path):
+    p = tmp_path / "in.json"
+    p.write_text(json.dumps({"baseline": {}}), encoding="utf-8")
+    target = tmp_path / "sub" / "out.json"
+    out = tx.transform_file(p, target)
+    assert out == target
+    assert json.loads(target.read_text())["source"] == "claw_legacy_phased"
+
+
+def test_transform_file_stdout(tmp_path: Path, capsys):
+    p = tmp_path / "in.json"
+    p.write_text(json.dumps({"baseline": {}}), encoding="utf-8")
+    out = tx.transform_file(p, Path("-"))
+    assert str(out) == "-"
+    assert "claw_legacy_phased" in capsys.readouterr().out
+
+
+def test_transform_file_non_object_raises(tmp_path: Path):
+    p = tmp_path / "in.json"
+    p.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    with pytest.raises(ValueError):
+        tx.transform_file(p, None)
+
+
+def test_output_name_for_session_id(tmp_path: Path):
+    f = tmp_path / "session_breakdown.json"
+    f.write_text(json.dumps({"session": {"session_id": "abc123"}}), encoding="utf-8")
+    assert tx._output_name_for(f, tmp_path) == Path("abc123.json")
+
+
+def test_output_name_for_fallback(tmp_path: Path):
+    f = tmp_path / "nested" / "session_breakdown.json"
+    f.parent.mkdir()
+    f.write_text(json.dumps({}), encoding="utf-8")
+    assert tx._output_name_for(f, tmp_path) == Path("nested/session_breakdown.json")
+
+
+def test_main_batch_mode(tmp_path: Path, monkeypatch, capsys):
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    (in_dir / "session_breakdown.json").write_text(json.dumps({"baseline": {}}), encoding="utf-8")
+    out_dir = tmp_path / "out"
+    monkeypatch.setattr(sys, "argv", ["t.py", "--in-dir", str(in_dir), "--out-dir", str(out_dir)])
+    tx.main()
+    produced = list(out_dir.rglob("*.json"))
+    assert produced
+
+
+def test_main_batch_no_files(tmp_path: Path, monkeypatch, capsys):
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    out_dir = tmp_path / "out"
+    monkeypatch.setattr(sys, "argv", ["t.py", "--in-dir", str(in_dir), "--out-dir", str(out_dir)])
+    tx.main()
+    assert "no input" in capsys.readouterr().err
+
+
+def test_main_single_file(tmp_path: Path, monkeypatch, capsys):
+    p = tmp_path / "session_breakdown.json"
+    p.write_text(json.dumps({"baseline": {}}), encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["t.py", str(p)])
+    tx.main()
+    assert p.with_suffix(".v2.json").exists()
+
+
+def test_main_single_file_error_reported(tmp_path: Path, monkeypatch, capsys):
+    p = tmp_path / "session_breakdown.json"
+    p.write_text("[1,2]", encoding="utf-8")  # not an object
+    monkeypatch.setattr(sys, "argv", ["t.py", str(p)])
+    tx.main()
+    assert "[err]" in capsys.readouterr().err

--- a/ci/test_claw_flow.py
+++ b/ci/test_claw_flow.py
@@ -10,6 +10,13 @@ import sys
 import threading
 import time
 
+import pytest
+
+# Live smoke test (run manually via main()); depends on the optional sseclient
+# package that the unit-test CI image does not install. Skip cleanly at
+# collection time instead of erroring out the whole pytest run.
+pytest.importorskip("sseclient")
+
 sys.path.insert(0, ".")
 from claw_client import ClawClient
 

--- a/ci/test_submit_body.py
+++ b/ci/test_submit_body.py
@@ -35,7 +35,12 @@ def _capture_body(client: SafeOptimizeClient) -> dict:
     """Call submit_task with minimal args and return the POST body."""
     captured: dict = {}
 
-    def fake_request(_method: str, _path: str, body: dict | None = None) -> dict:
+    def fake_request(
+        _method: str,
+        _path: str,
+        body: dict | None = None,
+        timeout: float | None = None,
+    ) -> dict:
         captured.update(body or {})
         return {"id": "task-123"}
 
@@ -69,7 +74,7 @@ def test_explicit_inferencex_path_forwarded():
     client = _make_client()
     captured: dict = {}
 
-    def fake_request(_method, _path, body=None):
+    def fake_request(_method, _path, body=None, timeout=None):
         captured.update(body or {})
         return {"id": "task-456"}
 
@@ -94,7 +99,7 @@ def test_empty_string_inferencex_path_stays_empty():
     client = _make_client()
     captured: dict = {}
 
-    def fake_request(_method, _path, body=None):
+    def fake_request(_method, _path, body=None, timeout=None):
         captured.update(body or {})
         return {"id": "task-789"}
 
@@ -119,7 +124,7 @@ def test_none_inferencex_path_becomes_empty():
     client = _make_client()
     captured: dict = {}
 
-    def fake_request(_method, _path, body=None):
+    def fake_request(_method, _path, body=None, timeout=None):
         captured.update(body or {})
         return {"id": "task-000"}
 

--- a/inference_optimizer/tests/test_no_legacy_writer_sites.py
+++ b/inference_optimizer/tests/test_no_legacy_writer_sites.py
@@ -62,6 +62,9 @@ ALLOWED_FILES: dict[str, str] = {
     # CI transform reads legacy-keyed session_breakdown.json artefacts.
     "ci/transform_to_session_summary_v2.py":
         "legacy session-breakdown JSON reader (operator-side back-compat)",
+    "ci/test_ci_transform_v2.py":
+        "unit tests assert the ci legacy reader migrates extra_sglang_args "
+        "-> extra_server_args",
 
     # Prompt / orientation text that names both keys explicitly so the
     # LLM and any human reader of the prompt knows the alias exists

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,8 +70,15 @@ testpaths = [
     "kernel-agent/tools/test_gemm_tuning.py",
     "kernel-agent/tools/test_rocprof_roofline.py",
     "kernel-agent/tools/test_harness_generator.py",
+    # ci/ inference-optimization pipeline: the genuine unit tests
+    # (test_submit_body.py + the new test_ci_*.py suites) were never
+    # collected before because ci/ was absent from testpaths. The two
+    # live smoke scripts (test_claw_flow.py / test_tool4.py) define only a
+    # module-level main()/run_test() and no ``test_`` functions, so pytest
+    # collects zero items from them and never hits their network calls.
+    "ci",
 ]
-pythonpath = [".", "robustness-agent/src", "critic-agent"]
+pythonpath = [".", "robustness-agent/src", "critic-agent", "ci"]
 markers = [
     "critic_agent_e2e: end-to-end tests that shell out to the real critic-agent runtime; skip with '-m \"not critic_agent_e2e\"' if critic-agent is not on disk.",
     "robustness_agent_e2e: end-to-end tests that shell out to the real robustness-agent runtime; skip with '-m \"not robustness_agent_e2e\"' if robustness-agent is not on disk.",
@@ -102,6 +109,7 @@ source = [
     "inference_optimizer",
     "robustness_agent",
     "kernel-agent/tools",
+    "ci",
 ]
 omit = [
     "*/tests/*",
@@ -176,6 +184,32 @@ omit = [
     "robustness-agent/src/robustness_agent/providers/hybrid.py",
     "robustness-agent/src/robustness_agent/providers/robust.py",
     "robustness-agent/src/robustness_agent/providers/local.py",
+    # ── ci/ inference-optimization pipeline ──
+    # The measured ci/ set is the library-shaped logic modules
+    # (generate_hf_matrix, generate_matrix, progress, build_rolling_pool,
+    # inferenceX_parser, artifact_normalizer, transform_to_session_summary_v2,
+    # build_summary, report_generator). Everything below is a SaFE/Claw/HF/
+    # GitHub network client or a subprocess-driven CLI driver — the same
+    # "subprocess plumbing dominated" reasoning that omits inference_optimizer
+    # cli.py and the kernel-agent tool CLIs. Each is exercised end-to-end by
+    # the live optimize-submit / optimize-tiny workflows, not unit tests.
+    "ci/optimize_submit.py",
+    "ci/tiny_submit.py",
+    "ci/orchestrator.py",
+    "ci/pipeline_run.py",
+    "ci/import_session_breakdown.py",
+    "ci/claw_client.py",
+    "ci/post_perf_runs.py",
+    "ci/prewarm_models.py",
+    "ci/send_webhook.py",
+    "ci/publish_results.py",
+    "ci/publish_artifacts.py",
+    "ci/download_ab_stitched_session_logs.py",
+    "ci/run_llm_batch.py",
+    "ci/build_candidates.py",
+    "ci/build_production_hf_pool.py",
+    # In-tree CLI test scripts / live smoke scripts (treated as test files).
+    "ci/test_*.py",
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
## Summary

- Allow multimodal models to be submitted: drop the `pipeline_tag != text-generation` skip in the CI submit path so image-text-to-text / any-to-any candidates are no longer filtered out.
- Update the fixed daily pool (`ci/candidates/inferencex_daily_fixed.json`):
  - Replace `MiniMaxAI/MiniMax-M2.5` with `meta-llama/Llama-3.1-8B-Instruct` (the most-downloaded Llama on Hugging Face, ~6.44M downloads). Dense 8B, BF16-native; runs on vLLM at tp8. This repo is **gated** (`gated=manual`), so register/download requires an `HF_TOKEN` with the Llama license accepted; its core42-hyperloom playground id mapping is removed since it is not pre-staged there yet.
  - Switch `Kimi K2.6` from INT4 to FP8 (sglang, tp8).
- Add CI unit-test coverage:
  - 9 new test modules under `ci/` (250 cases) for `generate_matrix`, `progress`, `transform_v2`, `artifact_normalizer`, `inferenceX_parser`, `build_rolling_pool`, `report_generator`, `build_summary`, and `generate_hf_matrix`, with all network and subprocess calls mocked.
  - Fix `test_submit_body.py` `fake_request` mocks that were missing the `timeout` argument, which made the suite hang on retry backoff.
  - Wire `ci/` into `pyproject` `testpaths` and coverage source (omitting network/subprocess drivers); the measured set reaches ~97% coverage.

## Model access check

`meta-llama/Llama-3.1-8B-Instruct` was verified against the Hugging Face API:
- Metadata: reachable, `pipeline_tag=text-generation`, downloads ~6,443,229, `gated=manual`.
- Anonymous file download (`resolve/main/config.json`): HTTP 401, confirming the repo is gated and needs an authorized `HF_TOKEN` at submit/download time.

## Test plan

- [x] `pytest ci/test_ci_*.py ci/test_submit_body.py` -> 250 passed locally.
- [x] `inferencex_daily_fixed.json` parses and still defines exactly 10 candidates.
- [ ] Trigger the daily pool and confirm the Llama-3.1-8B-Instruct row registers/downloads with the configured `HF_TOKEN`.
