### PR TITLE
docs: upgrade existing docstrings to Google style (re-targeted onto main)

### DIFF
--- a/ci/artifact_normalizer.py
+++ b/ci/artifact_normalizer.py
@@ -93,8 +93,18 @@ def _first_of(data: dict[str, Any], *keys: str) -> Any | None:
 
 
 def _first_nested(data: dict[str, Any], *paths: str) -> Any | None:
-    """Return the first non-None value from dotted paths (compat across the
-    several flat and nested ci_metrics schemas agents have emitted)."""
+    """Return the first non-None value found among dotted paths.
+
+    Provides compatibility across the several flat and nested ci_metrics
+    schemas agents have emitted.
+
+    Args:
+        data: The mapping to traverse.
+        *paths: Dotted key paths, probed in order.
+
+    Returns:
+        The first resolved value, or ``None`` when no path resolves.
+    """
     for path in paths:
         cur: Any = data
         ok = True
@@ -528,8 +538,14 @@ def normalize_task_result(
 ) -> dict[str, Any]:
     """Normalize one task artifact directory.
 
-    ``manifest_record`` is caller-supplied task metadata; metrics are read
-    from files under ``task_dir``.
+    Args:
+        task_dir: Directory containing the task's collected artifacts.
+        manifest_record: Caller-supplied task metadata.
+        run: Optional run-level context merged into the result.
+
+    Returns:
+        The normalized result dict (schema-versioned) with metrics read from
+        files under ``task_dir``.
     """
     warnings: list[str] = []
 
@@ -605,6 +621,15 @@ def collect_normalized_results(
     """Normalize CI-collected artifacts using submission manifests.
 
     GitHub Actions adapter around ``normalize_task_result``.
+
+    Args:
+        artifacts_dir: Root directory of collected task artifacts.
+        manifests_dir: Directory tree holding ``submission_manifest.json``
+            files.
+        run: Optional run-level context merged into each result.
+
+    Returns:
+        One normalized result dict per task record across all manifests.
     """
     results: list[dict[str, Any]] = []
     manifest_files = sorted(manifests_dir.rglob("submission_manifest.json"))

--- a/ci/build_candidates.py
+++ b/ci/build_candidates.py
@@ -202,10 +202,16 @@ class HFClient:
         return r.json()
 
     def listing(self, limit: int) -> list[dict]:
-        """Top-N text-generation by downloads (raw HF API records).
+        """Return the top-N text-generation models by downloads.
 
-        HF caps one page at 1000 entries; follow the ``Link`` header cursor
-        until ``limit`` entries are fetched.
+        HF caps one page at 1000 entries; this follows the ``Link`` header
+        cursor until ``limit`` entries are fetched.
+
+        Args:
+            limit: Maximum number of model records to return.
+
+        Returns:
+            Raw HF API model records, up to ``limit``.
         """
         out: list[dict] = []
         page_limit = min(max(limit, 1), 1000)

--- a/ci/build_production_hf_pool.py
+++ b/ci/build_production_hf_pool.py
@@ -63,10 +63,16 @@ DEFAULT_AUTHOR_SLICES = [
 
 
 def _load_yaml_exclusions(path: Path) -> tuple[set[str], list[str]]:
-    """Read ``ci/inferenceX_models.yaml`` and return ``(exact_ids, keywords)``.
+    """Read ``ci/inferenceX_models.yaml`` and return its exclusions.
 
     Consumes ``models[].hf_model`` (exact lower-case match) and
     ``production_pool_exclusion_keywords`` (substring match).
+
+    Args:
+        path: Path to the InferenceX models YAML file.
+
+    Returns:
+        An ``(exact_ids, keywords)`` tuple; empty when the file is missing.
     """
     if not path.exists():
         return set(), []

--- a/ci/build_rolling_pool.py
+++ b/ci/build_rolling_pool.py
@@ -39,15 +39,40 @@ from generate_hf_matrix import slugify  # noqa: E402
 
 
 def _norm(repo: str | None) -> str:
+    """Normalize a repo id for case-insensitive comparison.
+
+    Args:
+        repo: Repo id, possibly ``None``.
+
+    Returns:
+        The trimmed, lower-cased repo id (empty string when ``repo`` is falsy).
+    """
     return (repo or "").strip().lower()
 
 
 def _candidate_keys(repo_id: str) -> set[str]:
+    """Build the set of slug keys a candidate may be matched by.
+
+    Args:
+        repo_id: Full Hugging Face repo id (``org/name``).
+
+    Returns:
+        Slugs for both the full repo id and its basename, since Pulse may store
+        either form as ``model_name``.
+    """
     repo_id = (repo_id or "").strip()
     return {slugify(repo_id), slugify(repo_id.split("/")[-1])}
 
 
 def _pulse_model_keys() -> set[str]:
+    """Fetch slug keys for every model already seen in Pulse breakdowns.
+
+    Pages through the Pulse session-breakdowns API (with retries) and collects
+    a slugified key per ``model_name``.
+
+    Returns:
+        The set of slugified model keys that have already been run.
+    """
     keys: set[str] = set()
     offset = 0
     limit = 200
@@ -79,6 +104,15 @@ def _pulse_model_keys() -> set[str]:
 
 
 def main() -> int:
+    """Merge the production and new-model pools and write the rolling outputs.
+
+    Reads the curated production corpus and the new-models list, applies the
+    production exclusion policy, de-duplicates by repo id, then writes the
+    merged pool, the reserved manual top-100, and the unrun subset.
+
+    Returns:
+        Process exit code (``0`` on success).
+    """
     prod = json.loads(PROD.read_text(encoding="utf-8"))
     newm = json.loads(NEWM.read_text(encoding="utf-8"))
 
@@ -90,6 +124,15 @@ def main() -> int:
     excl_kw = [k.lower() for k in policy.get("exclusion_keywords", [])]
 
     def excluded(repo: str) -> bool:
+        """Return whether a repo is filtered out by the exclusion policy.
+
+        Args:
+            repo: Candidate repo id.
+
+        Returns:
+            ``True`` when the repo is empty, exactly excluded, or matches an
+            exclusion keyword.
+        """
         k = _norm(repo)
         if not k:
             return True
@@ -146,6 +189,13 @@ def main() -> int:
     generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
 
     def dump(path: Path, cands: list[dict], note: str) -> None:
+        """Write a candidate pool to ``path`` as the standard corpus JSON.
+
+        Args:
+            path: Destination file; its stem is used as the ``pool_id``.
+            cands: Candidate records to serialize.
+            note: Human-readable description stored under the ``note`` key.
+        """
         path.write_text(json.dumps({
             "schema_version": "hyperloom.production_corpus.v1",
             "pool_id": path.stem,

--- a/ci/build_summary.py
+++ b/ci/build_summary.py
@@ -68,10 +68,19 @@ def fetch_inferenceX_ref(
     isl: int,
     osl: int,
 ) -> float | None:
-    """Look up InferenceX output_tput_per_gpu for repo_id on target_gpu.
+    """Look up the InferenceX reference throughput for a model.
 
-    Returns None when no comparison is available (unmapped repo, no benchmarks,
-    or no (hardware, ISL, OSL) match) — the column stays blank.
+    Args:
+        repo_id: HF repo id to look up.
+        hf_to_ifx: Mapping of HF repo ids to InferenceX api names.
+        target_gpu: GPU type to match.
+        isl: Input sequence length to match.
+        osl: Output sequence length to match.
+
+    Returns:
+        The ``output_tput_per_gpu`` reference value, or ``None`` when no
+        comparison is available (unmapped repo, no benchmarks, or no
+        (hardware, ISL, OSL) match).
     """
     api_name = hf_to_ifx.get(repo_id)
     if not api_name:

--- a/ci/claw_client.py
+++ b/ci/claw_client.py
@@ -232,6 +232,15 @@ class ClawClient:
         ))["data"]
 
     def download_file(self, session_id: str, file_path: str) -> bytes:
+        """Download a sandbox file and return its raw bytes.
+
+        Args:
+            session_id (str): Session id owning the file.
+            file_path (str): Path of the file within the sandbox.
+
+        Returns:
+            bytes: The file's contents.
+        """
         # Percent-encode the full path including any leading slash.
         encoded = quote(file_path, safe="")
         resp = self._session.get(

--- a/ci/generate_hf_matrix.py
+++ b/ci/generate_hf_matrix.py
@@ -363,6 +363,14 @@ def _filter_entries_by_explicit_models(
     Historically INPUT_MODELS returned bare repo strings and therefore lost
     framework / precision / tp / conc from candidates JSON. For manual reruns
     of a small subset from a fixed pool, keep the candidate dicts intact.
+
+    Args:
+        entries: Candidate entries (dicts or bare repo strings).
+        explicit_repos: Repo ids to keep; empty returns all entries.
+
+    Returns:
+        The matching entries in ``explicit_repos`` order; missing repos are
+        warned about and skipped.
     """
     if not explicit_repos:
         return entries
@@ -438,10 +446,17 @@ def _apply_exclusions(repos: list[str]) -> list[str]:
 
 
 def _load_candidate_entries(cands_path: Path) -> list[dict]:
-    """Load candidates.json and take an INPUT_BATCH_INDEX/INPUT_BATCH_SIZE slice.
+    """Load and normalize entries from a candidates JSON file.
 
-    BATCH_SIZE unset/0 returns all candidates. Slice order follows the JSON
-    (HF download rank) for deterministic batch dispatch.
+    Slice order follows the JSON (HF download rank) for deterministic batch
+    dispatch.
+
+    Args:
+        cands_path: Path to the candidates JSON file.
+
+    Returns:
+        Candidate entry dicts (with ``pool_id`` / ``pool_index`` filled in);
+        empty when the file cannot be read.
     """
     try:
         data = json.loads(cands_path.read_text(encoding="utf-8"))
@@ -513,6 +528,12 @@ def _cron_fire_counter(now_utc: datetime) -> int:
     Each scheduled cron fire (UTC 4/12/20) advances the counter by exactly one,
     so consecutive cron runs step through batch 0, 1, 2, ... in order (unlike a
     half-day slot, which collapsed the 12:00 and 20:00 fires onto one index).
+
+    Args:
+        now_utc: The UTC instant to map.
+
+    Returns:
+        A strictly increasing fire counter for the instant.
     """
     idx = bisect.bisect_right(_CRON_FIRE_HOURS_UTC, now_utc.hour) - 1
     if idx < 0:
@@ -537,6 +558,13 @@ def _cron_batch_index(pool_size: int, batch_size: int) -> int:
     instead of wrapping to the pool tail: a negative ``steps % batches`` would
     otherwise land on the last batch, silently skipping the not-run backlog the
     anchor is meant to drain first.
+
+    Args:
+        pool_size: Total number of candidate entries.
+        batch_size: Entries per batch.
+
+    Returns:
+        The 0-based batch index for the current scheduled fire.
     """
     batches = max((pool_size + batch_size - 1) // batch_size, 1)
     now_raw = (os.environ.get("INPUT_CRON_NOW") or "").strip()

--- a/ci/generate_hf_matrix.py
+++ b/ci/generate_hf_matrix.py
@@ -339,8 +339,18 @@ def _entry_slug(entry: dict | str) -> str:
 
 
 def _parse_explicit_models(value: str) -> list[str]:
-    # Whitespace OR comma separated, both supported (workflow_dispatch UI is
-    # space-friendly; downstream callers may comma-list).
+    """Split an explicit model list into individual repo ids.
+
+    Accepts whitespace- or comma-separated input so both the
+    ``workflow_dispatch`` UI (space-friendly) and programmatic callers
+    (comma-lists) work.
+
+    Args:
+        value: Raw model-list string.
+
+    Returns:
+        The non-empty repo ids in order.
+    """
     return [r for r in re.split(r"[\s,]+", value.strip()) if r]
 
 

--- a/ci/generate_hf_matrix.py
+++ b/ci/generate_hf_matrix.py
@@ -367,6 +367,14 @@ def _filter_entries_by_explicit_models(
     Historically INPUT_MODELS returned bare repo strings and therefore lost
     framework / precision / tp / conc from candidates JSON. For manual reruns
     of a small subset from a fixed pool, keep the candidate dicts intact.
+
+    Args:
+        entries: Candidate entries (dicts and/or repo id strings).
+        explicit_repos: Repo ids requested via ``INPUT_MODELS``.
+
+    Returns:
+        The matching candidate entries in ``explicit_repos`` order; all
+        ``entries`` when ``explicit_repos`` is empty.
     """
     if not explicit_repos:
         return entries
@@ -446,6 +454,13 @@ def _load_candidate_entries(cands_path: Path) -> list[dict]:
 
     BATCH_SIZE unset/0 returns all candidates. Slice order follows the JSON
     (HF download rank) for deterministic batch dispatch.
+
+    Args:
+        cands_path: Path to the candidates JSON file.
+
+    Returns:
+        The candidate dicts (each annotated with ``pool_id`` / ``pool_index``),
+        or ``[]`` when the file cannot be read.
     """
     try:
         data = json.loads(cands_path.read_text(encoding="utf-8"))
@@ -520,6 +535,12 @@ def _cron_fire_counter(now_utc: datetime) -> int:
     Each scheduled cron fire (UTC 4/16) advances the counter by exactly one,
     so consecutive cron runs step through batch 0, 1, 2, ... in order (unlike a
     half-day slot, which would collapse multiple fires onto one index).
+
+    Args:
+        now_utc: The UTC instant to map.
+
+    Returns:
+        A strictly increasing per-fire counter for ``now_utc``.
     """
     idx = bisect.bisect_right(_CRON_FIRE_HOURS_UTC, now_utc.hour) - 1
     if idx < 0:
@@ -544,6 +565,13 @@ def _cron_batch_index(pool_size: int, batch_size: int) -> int:
     instead of wrapping to the pool tail: a negative ``steps % batches`` would
     otherwise land on the last batch, silently skipping the not-run backlog the
     anchor is meant to drain first.
+
+    Args:
+        pool_size: Total number of candidate entries.
+        batch_size: Entries per batch.
+
+    Returns:
+        The 0-based batch index for the current scheduled fire.
     """
     batches = max((pool_size + batch_size - 1) // batch_size, 1)
     now_raw = (os.environ.get("INPUT_CRON_NOW") or "").strip()

--- a/ci/generate_matrix.py
+++ b/ci/generate_matrix.py
@@ -16,6 +16,17 @@ def _entry_key(m: dict) -> str:
 
 
 def generate_matrix(config_path: str = "ci-config.yaml", selected_models: str = "") -> dict:
+    """Build a GitHub Actions matrix from the CI config.
+
+    Args:
+        config_path: Path to ``ci-config.yaml``.
+        selected_models: Optional comma-separated list of model keys to
+            include; when empty, all configured models are used.
+
+    Returns:
+        A dict of the form ``{"include": [{"key": ...}, ...]}`` suitable for a
+        GitHub Actions matrix.
+    """
     # Force UTF-8: ci-config.yaml uses box-drawing chars (──); Windows cp1252 would raise UnicodeDecodeError.
     with open(config_path, encoding="utf-8") as f:
         config = yaml.safe_load(f)

--- a/ci/generate_matrix.py
+++ b/ci/generate_matrix.py
@@ -11,7 +11,14 @@ import yaml
 
 
 def _entry_key(m: dict) -> str:
-    """Effective matrix/filter key: explicit `key` field overrides `inferenceX_key`."""
+    """Return the effective matrix/filter key for a model entry.
+
+    Args:
+        m: A model config entry.
+
+    Returns:
+        The explicit ``key`` field when set, otherwise ``inferenceX_key``.
+    """
     return m.get("key") or m["inferenceX_key"]
 
 

--- a/ci/import_session_breakdown.py
+++ b/ci/import_session_breakdown.py
@@ -193,7 +193,17 @@ def derive_image(framework_name: str, session_image: Optional[str]) -> str:
 
 
 def derive_image_short(image: str) -> str:
-    """Strip version tag/digest, return the last 2 path components (or 1 if only one)."""
+    """Shorten a container image reference for display.
+
+    Strips the version tag/digest and keeps the last two path components
+    (or one when only one is present).
+
+    Args:
+        image: The full container image reference.
+
+    Returns:
+        The shortened image string, or ``"unknown"`` when empty.
+    """
     img = image.split("@")[0]            # strip digest
     img = img.split(":")[0]              # strip tag
     parts = [p for p in img.split("/") if p]
@@ -203,8 +213,18 @@ def derive_image_short(image: str) -> str:
 
 
 def derive_unique_key(model_name: str, image: str) -> str:
-    """BASE64("<model_name>+<image_short>"); matches the perf-runs API unique_key
-    contract so dev rows promote to prod without rekeying."""
+    """Build the perf-runs ``unique_key`` for a (model, image) pair.
+
+    Returns ``BASE64("<model_name>+<image_short>")``, matching the perf-runs
+    API contract so dev rows promote to prod without rekeying.
+
+    Args:
+        model_name: The model name.
+        image: The container image reference.
+
+    Returns:
+        The base64-encoded unique key.
+    """
     raw = f"{model_name}+{derive_image_short(image)}"
     return base64.b64encode(raw.encode("utf-8")).decode("ascii")
 
@@ -213,8 +233,15 @@ _STOP_REASON_FAILED_TOKENS = ("timeout", "killed", "error", "failed", "abort", "
 
 
 def derive_status(session: Dict) -> str:
-    """Map session.stop_reason to {success, running, failed}: empty=>running,
-    failure token=>failed, else success (report emitted = clean termination)."""
+    """Map ``session.stop_reason`` to a coarse status.
+
+    Args:
+        session: The session dict carrying ``stop_reason``.
+
+    Returns:
+        ``"running"`` (empty stop reason), ``"failed"`` (a failure token),
+        or ``"success"`` otherwise.
+    """
     stop = (session.get("stop_reason") or "").strip().lower()
     if not stop:
         return "running"
@@ -224,8 +251,17 @@ def derive_status(session: Dict) -> str:
 
 
 def detect_category(data: Dict) -> str:
-    """MoE if a kernel category/name or model name has MoE markers; VLM for
-    vision markers; else Dense."""
+    """Classify a session as MoE, VLM, or Dense.
+
+    MoE wins when a kernel category/name or the model name has MoE markers;
+    VLM for vision markers; otherwise Dense.
+
+    Args:
+        data: The session breakdown data dict.
+
+    Returns:
+        One of ``"MoE"``, ``"VLM"``, or ``"Dense"``.
+    """
     kernels = safe_get(data, "kernel_lifecycle", "detected", default=[]) or []
     if isinstance(kernels, list):
         for k in kernels:
@@ -271,9 +307,17 @@ def reshape_snapshot(snap: Optional[Dict]) -> Optional[Dict]:
 
 
 def extract_roofline(data: Dict) -> Optional[Dict]:
-    """Pass through the first roofline entry verbatim for full fidelity (every
-    nested field). Previously reshaped fields remain under entry.baseline.* /
-    entry.latest.* — nothing removed."""
+    """Return the first roofline entry verbatim for full fidelity.
+
+    Every nested field is preserved; previously reshaped fields remain under
+    ``entry.baseline.*`` / ``entry.latest.*``.
+
+    Args:
+        data: The session breakdown data dict.
+
+    Returns:
+        A deep copy of the first roofline entry, or ``None`` when absent.
+    """
     rl_list = safe_get(data, "roofline", default=[]) or []
     if isinstance(rl_list, list) and rl_list and isinstance(rl_list[0], dict):
         return copy.deepcopy(rl_list[0])
@@ -321,8 +365,18 @@ def compute_kernel_gain(attribution_src: Dict) -> Optional[float]:
 
 
 def compute_param_gain(attribution_src: Dict) -> Optional[float]:
-    """Param-attribution gain = params choice + sweep variant search (sweep is a
-    parameter-space search, so it belongs in the 'param' category)."""
+    """Compute the param-attribution gain.
+
+    Sums the params choice and sweep variant search (a sweep is a
+    parameter-space search, so it belongs in the 'param' category).
+
+    Args:
+        attribution_src: The ``attribution.source_breakdown`` sub-dict.
+
+    Returns:
+        The combined gain rounded to two decimals, or ``None`` when both
+        values are absent.
+    """
     params = attribution_src.get("params_pct_of_total")
     sweep = attribution_src.get("sweep_pct_of_total")
     if params is None and sweep is None:
@@ -380,8 +434,18 @@ def compute_oob_gain(attribution_src: Dict) -> Optional[float]:
 
 
 def compute_framework_gain(attribution: Dict) -> Optional[float]:
-    """Framework-source gain = SUM(delta_pct) over gain_per_stack_entry[] where
-    action='framework_pr'. None when absent so normalisation collapses it to 0.00."""
+    """Compute the framework-source gain.
+
+    Sums ``delta_pct`` over ``gain_per_stack_entry[]`` where
+    ``action == "framework_pr"``.
+
+    Args:
+        attribution: The ``attribution`` sub-dict.
+
+    Returns:
+        The summed gain rounded to two decimals, or ``None`` when absent so
+        normalisation collapses it to ``0.00``.
+    """
     entries = attribution.get("gain_per_stack_entry")
     if not isinstance(entries, list):
         return None
@@ -744,9 +808,20 @@ def format_duration_pretty(seconds: Optional[int]) -> str:
 
 
 def enrich_raw_data(original: Dict, row: Dict[str, Any], meta: Optional[Dict] = None) -> Dict:
-    """Build the JSON persisted into perf_runs.raw_data: deep-copy the original,
-    backfill session.image when missing, and add a top-level `_enrichment` block
-    of inferred/computed values (`meta` carries derivation provenance)."""
+    """Build the JSON persisted into ``perf_runs.raw_data``.
+
+    Deep-copies the original, backfills ``session.image`` /
+    ``session.session_duration_seconds`` / workload dims when missing, and
+    adds a top-level ``_enrichment`` block of inferred/computed values.
+
+    Args:
+        original: The original session breakdown JSON.
+        row: The derived perf-runs row supplying fallbacks.
+        meta: Optional derivation provenance recorded under ``_enrichment``.
+
+    Returns:
+        The enriched, deep-copied data dict.
+    """
     enriched = copy.deepcopy(original)
 
     session = enriched.get("session")
@@ -1080,7 +1155,18 @@ def _sql_jsonb_literal(obj: Any) -> str:
 
 
 def build_upsert_statement_inline(row: Dict[str, Any], table: str) -> str:
-    """Build one SQL statement with all values inlined (dollar-quoted)."""
+    """Build one upsert SQL statement with all values inlined.
+
+    String values are dollar-quoted so the statement can be piped over SSH
+    without a parameter protocol.
+
+    Args:
+        row: The perf-runs row to upsert.
+        table: Target table name (sanitized internally).
+
+    Returns:
+        The complete SQL upsert statement.
+    """
     table = safe_table(table)
     parts = (
         f"INSERT INTO {table} (\n"
@@ -1148,7 +1234,19 @@ def build_upsert_statement_inline(row: Dict[str, Any], table: str) -> str:
 
 
 def build_ssh_kubectl_psql(hop1: str, namespace: str, user: str, dbname: str) -> List[str]:
-    """Return argv to invoke psql on the master postgres pod via SSH+kubectl (stdin piped)."""
+    """Build the argv to run ``psql`` on the master Postgres pod over SSH.
+
+    The SQL is expected to be piped via stdin to the returned command.
+
+    Args:
+        hop1: SSH jump host (``user@host``) to reach the cluster.
+        namespace: Kubernetes namespace of the Postgres cluster.
+        user: Postgres user to connect as.
+        dbname: Target database name.
+
+    Returns:
+        The ``ssh`` argv list invoking ``kubectl exec ... psql``.
+    """
     remote_cmd = (
         f"kubectl exec -i -n {namespace} "
         f"$(kubectl get pod -n {namespace} "
@@ -1249,8 +1347,18 @@ def looks_like_session_breakdown(data: Any) -> bool:
 
 
 def looks_like_v1_flat_schema(data: Any) -> bool:
-    """Recognise the legacy 'V1 flat' layout: top-level dict with model,
-    framework, baseline_tput and best_tput (not nested under workload/baseline)."""
+    """Recognise the legacy "V1 flat" schema layout.
+
+    A V1 flat doc is a top-level dict with ``model``, ``framework``,
+    ``baseline_tput`` and ``best_tput`` (not nested under
+    ``workload`` / ``baseline``).
+
+    Args:
+        data: The parsed JSON value to inspect.
+
+    Returns:
+        ``True`` when the value matches the V1 flat schema.
+    """
     if not isinstance(data, dict):
         return False
     return (

--- a/ci/inferenceX_parser.py
+++ b/ci/inferenceX_parser.py
@@ -198,7 +198,17 @@ def synthesize_entry_from_ci_config(model_cfg: dict) -> dict:
 
 
 def parse_model_entry(entry: dict) -> dict:
-    """Extract structured config from an amd-master.yaml model entry."""
+    """Extract structured config from an amd-master.yaml model entry.
+
+    Supports both ``seq-len-configs`` (old) and
+    ``scenarios.fixed-seq-len`` (new) layouts.
+
+    Args:
+        entry: A single model entry from the InferenceX YAML.
+
+    Returns:
+        A structured config dict (model name, seq-len pairs, search space).
+    """
     # Support both seq-len-configs (old) and scenarios.fixed-seq-len (new).
     seq_configs = (
         entry.get("seq-len-configs")

--- a/ci/optimize_submit.py
+++ b/ci/optimize_submit.py
@@ -2284,7 +2284,24 @@ def _wait_for_nfs_session_delivery(
     grace_min: float | None = None,
     idle_min: float | None = None,
 ) -> str | None:
-    """After SaFE early terminal, wait while the NFS session is still active."""
+    """Wait for NFS session delivery after a SaFE early-terminal status.
+
+    Polls the session directory while it still appears active, up to the
+    grace/idle deadlines, so delivery-contract files have time to land.
+
+    Args:
+        rec: The submission record.
+        current_session_hints: Optional session-id hints to bias matching.
+        poll_s: Poll interval in seconds.
+        grace_min: Overall grace window in minutes; resolved from env when
+            ``None``.
+        idle_min: Idle window in minutes before giving up; resolved from env
+            when ``None``.
+
+    Returns:
+        The session directory to collect from, or ``None`` when none found
+        or grace is disabled.
+    """
     grace_min = _env_float("SAFE_OPTIMIZE_NFS_LIVE_GRACE_MIN", 180.0) \
         if grace_min is None else grace_min
     idle_min = _env_float("SAFE_OPTIMIZE_NFS_IDLE_GRACE_MIN", 20.0) \
@@ -2349,16 +2366,30 @@ def _wait_for_nfs_session_delivery(
 
 
 def _category_from_arch(arch: str | None) -> str:
-    """Coarse model-shape classification: "moe" if arch contains "moe", else
-    "dense"; "" when unknown so downstream JSON stays "n/a"."""
+    """Classify a model's coarse shape from its architecture name.
+
+    Args:
+        arch: The HF architecture name, if known.
+
+    Returns:
+        ``"moe"`` when the arch contains "moe", ``"dense"`` otherwise, or
+        ``""`` when unknown (so downstream JSON stays ``"n/a"``).
+    """
     if not arch:
         return ""
     return "moe" if "moe" in arch.lower() else "dense"
 
 
 def _sandbox_duration_seconds(last_task: dict) -> float | None:
-    """SaFE-side sandbox wallclock = finishedAt - startedAt (from the task API).
-    None when either field is missing/unparseable so we don't fabricate a duration."""
+    """Compute SaFE-side sandbox wallclock (``finishedAt - startedAt``).
+
+    Args:
+        last_task: The SaFE task payload carrying timestamp fields.
+
+    Returns:
+        The duration in seconds (rounded), or ``None`` when either field is
+        missing/unparseable so a duration is never fabricated.
+    """
     from datetime import datetime
     start = (last_task or {}).get("startedAt") or ""
     end = (last_task or {}).get("finishedAt") or ""
@@ -2380,6 +2411,12 @@ def _find_hyperloom_commit_sha(start: Path) -> str:
     First hit wins: (1) hyperloom_source_commit.txt written by the agent (depth
     varies by which fallback collected it), then (2) the CI runner env
     (HYPERLOOM_SOURCE_REF, else GITHUB_SHA).
+
+    Args:
+        start: A path inside the collected session tree to search from.
+
+    Returns:
+        The resolved SHA string, or ``""`` when none is found.
     """
     candidates = [
         start.parent / "hyperloom_source_commit.txt",
@@ -2407,13 +2444,17 @@ def _find_hyperloom_commit_sha(start: Path) -> str:
 
 
 def _backfill_ci_metrics_file(path: Path, rec: SubmissionRecord) -> None:
-    """Backfill task metadata (model, image, hyperloom_commit, category,
-    sandbox_duration_seconds) into ci_metrics.json / session_breakdown.json /
-    manifest.json so each artifact is self-describing.
+    """Backfill task metadata into a CI artifact so it is self-describing.
 
-    Writes the right shape per filename: ci_metrics.json → flat top-level;
-    session_breakdown.json → under session_meta; manifest.json → flat top-level
-    (V2 cli schema; category/duration are extra keys V2 ignores on re-read).
+    Adds model, image, hyperloom_commit, category, and
+    sandbox_duration_seconds. Writes the right shape per filename:
+    ci_metrics.json → flat top-level; session_breakdown.json → under
+    session_meta; manifest.json → flat top-level (V2 cli schema;
+    category/duration are extra keys V2 ignores on re-read).
+
+    Args:
+        path: The artifact file to backfill (no-op for other filenames).
+        rec: The submission record supplying the metadata.
     """
     if path.name not in ("ci_metrics.json", "session_breakdown.json", "manifest.json"):
         return

--- a/ci/optimize_submit.py
+++ b/ci/optimize_submit.py
@@ -145,6 +145,15 @@ def normalize_gpu_profile(gpu_type: str | None, *, warn: bool = True) -> str | N
 
 
 def canonical_gpu_type(gpu_type: str | None) -> str:
+    """Resolve a GPU type string to its canonical form.
+
+    Args:
+        gpu_type: Free-form GPU type/alias, or ``None``.
+
+    Returns:
+        The canonical GPU type from the matching profile, or the trimmed input
+        (falling back to ``DEFAULT_GPU_TYPE``) when no profile matches.
+    """
     profile_key = normalize_gpu_profile(gpu_type, warn=False)
     if profile_key:
         return str(GPU_PROFILES[profile_key]["gpu_type"])
@@ -288,6 +297,13 @@ def _proxy() -> str:
 
 
 def _default_sglang_image() -> str:
+    """Return the default SGLang server image.
+
+    Returns:
+        The pinned ``profilerfix`` SGLang image whose patched
+        libamdhip64/libroctracer let rocprofiler capture kernels under
+        ``HipGraphLaunch`` (issue #352).
+    """
     # profilerfix: patched libamdhip64/libroctracer so rocprofiler captures
     # kernels under HipGraphLaunch (issue #352). Pre-profilerfix image (revert):
     # lmsysorg/sglang:v0.5.11-rocm720-mi30x
@@ -295,6 +311,12 @@ def _default_sglang_image() -> str:
 
 
 def _default_vllm_image() -> str:
+    """Return the default vLLM server image.
+
+    Returns:
+        The proxy-qualified vLLM image (v0.19.0, one minor ahead of the
+        InferenceX baseline to avoid v0.20 breakage).
+    """
     # v0.19.0: one minor ahead of InferenceX baseline v0.17.0, avoiding v0.20 breakage.
     return f"{_proxy()}/vllm/vllm-openai-rocm:v0.19.0"
 
@@ -538,6 +560,19 @@ def context_too_short(
     osl: int,
     reserve_tokens: int = DEFAULT_CONTEXT_RESERVE_TOKENS,
 ) -> bool:
+    """Return whether the model context cannot fit the requested workload.
+
+    Args:
+        max_context_tokens: Model's maximum context length; ``<= 0`` means
+            unknown, in which case the check is skipped.
+        isl: Input sequence length.
+        osl: Output sequence length.
+        reserve_tokens: Headroom kept free beyond input + output.
+
+    Returns:
+        ``True`` when the context is known and smaller than
+        ``isl + osl + reserve_tokens``; otherwise ``False``.
+    """
     if max_context_tokens <= 0:
         return False
     return max_context_tokens < (isl + osl + reserve_tokens)
@@ -597,11 +632,35 @@ def _sglang_image_for(repo_id: str = "") -> str:
 
 
 def detect_image(framework: str, repo_id: str = "") -> str:
+    """Select the server image for a framework and model.
+
+    Args:
+        framework: Serving framework (``vllm`` / ``sglang``).
+        repo_id: Model repo id, used to honor per-model image overrides.
+
+    Returns:
+        The default vLLM image for ``vllm``; otherwise the SGLang image chosen
+        by :func:`_sglang_image_for`.
+    """
     return _default_vllm_image() if framework == "vllm" else _sglang_image_for(repo_id)
 
 
 def auto_detect(hf: HuggingFaceClient, repo_id: str,
                 gpu_type: str | None = None) -> DetectedConfig | None:
+    """Derive a benchmark configuration from a model's HF metadata.
+
+    Fetches model info and ``config.json`` and infers framework, precision,
+    tensor parallelism, concurrency, image, and context limits.
+
+    Args:
+        hf: Hugging Face client used to fetch metadata.
+        repo_id: Model repo id to inspect.
+        gpu_type: Target GPU type, used for TP/profile selection.
+
+    Returns:
+        A :class:`DetectedConfig`, or ``None`` when the HF metadata cannot be
+        fetched.
+    """
     log.info("[%s] fetching HF metadata", repo_id)
     try:
         info = hf.model_info(repo_id)
@@ -704,6 +763,21 @@ class SafeOptimizeClient:
 
     def _request(self, method: str, path: str, body: dict | None = None,
                  timeout: float | None = None) -> dict:
+        """Send an HTTP request to the SaFE API and return the parsed JSON.
+
+        Args:
+            method: HTTP method (e.g. ``GET``, ``POST``).
+            path: API path appended to ``base_url``.
+            body: Optional JSON request body.
+            timeout: Optional per-request timeout; falls back to the client
+                default.
+
+        Returns:
+            The decoded JSON response, or an empty dict when there is no body.
+
+        Raises:
+            RuntimeError: If the response status code is ``>= 400``.
+        """
         url = f"{self.base_url}/{path.lstrip('/')}"
         resp = self._sess.request(method, url, json=body,
                                   timeout=timeout or self.timeout)
@@ -837,6 +911,36 @@ class SafeOptimizeClient:
         target_gain: float | None = None,
         results_path: str | None = None,
     ) -> dict:
+        """Submit an optimization task to SaFE and return the API response.
+
+        Builds the task request body from the model and benchmark parameters,
+        choosing a target workspace (single or round-robin across the pool).
+
+        Args:
+            model_id: Registered SaFE model id.
+            display_name: Human-readable task name.
+            framework: Serving framework (``vllm`` / ``sglang``).
+            precision: Model precision (e.g. ``BF16``, ``FP8``).
+            tp: Tensor-parallel size.
+            concurrency: Benchmark concurrency level.
+            isl: Input sequence length.
+            osl: Output sequence length.
+            image: Server image to run, or ``None`` for the framework default.
+            mode: Submission mode (e.g. ``local``).
+            gpu_type: Target GPU type.
+            inferencex_path: Optional InferenceX checkout path.
+            oob_path: Optional out-of-box baseline path.
+            tracelens_root: Optional TraceLens root path.
+            prompt_prefix: Optional prompt prefix override.
+            prompt_suffix: Optional prompt suffix override.
+            kernel_backends: Optional list of kernel backends to enable.
+            max_hours: Optional wall-clock budget for the task.
+            target_gain: Optional target performance gain.
+            results_path: Optional path where results should be written.
+
+        Returns:
+            The decoded API response for the submitted task.
+        """
         # Pick the workspace: single submit_workspace, or round-robin across the
         # pool. Counter is per-instance, not thread-safe — fine since submit_task
         # runs serially (only wait_and_collect is parallel, after submit returns).
@@ -2261,6 +2365,15 @@ def _backfill_wekafs_in_place(rec: SubmissionRecord) -> int:
     n = 0
 
     def _session_has_matching_json(sess_path: str) -> bool:
+        """Return whether a session dir holds JSON matching the target model.
+
+        Args:
+            sess_path: Session directory to scan.
+
+        Returns:
+            ``True`` if any target JSON file under the known subdirs has a
+            model field matching ``rec``; otherwise ``False``.
+        """
         for sub in subdirs:
             base = os.path.join(sess_path, sub) if sub else sess_path
             if not os.path.isdir(base):
@@ -2279,6 +2392,15 @@ def _backfill_wekafs_in_place(rec: SubmissionRecord) -> int:
         return False
 
     def _backfill_files(sess_path: str) -> int:
+        """Backfill the model field into target JSON files in a session dir.
+
+        Args:
+            sess_path: Session directory whose target JSON files should be
+                updated.
+
+        Returns:
+            The number of files updated.
+        """
         updated = 0
         for sub in subdirs:
             base = os.path.join(sess_path, sub) if sub else sess_path

--- a/ci/optimize_submit.py
+++ b/ci/optimize_submit.py
@@ -127,7 +127,15 @@ _KERNEL_BACKEND_ALIASES = {
 
 
 def normalize_gpu_profile(gpu_type: str | None, *, warn: bool = True) -> str | None:
-    """Return the GPU profile key when ``gpu_type`` maps to a known CI profile."""
+    """Return the GPU profile key when ``gpu_type`` maps to a known CI profile.
+
+    Args:
+        gpu_type: Free-form GPU type/alias, or ``None``.
+        warn: When True, log a warning if no profile matches.
+
+    Returns:
+        The matching profile key, or ``None`` when no profile matches.
+    """
     raw = (gpu_type or "").strip()
     compact = re.sub(r"[^a-z0-9]", "", raw.lower())
     for key, profile in GPU_PROFILES.items():
@@ -166,8 +174,14 @@ _PROMPT_PREFIX_FILE = Path(__file__).resolve().parent / "prompt_prefix.txt"
 
 
 def _load_default_prompt_prefix() -> str:
-    """Resolve the default ``--prompt-prefix``: $SAFE_OPTIMIZE_PROMPT_PREFIX,
-    else ci/prompt_prefix.txt, else empty string."""
+    """Resolve the default ``--prompt-prefix`` value.
+
+    Resolution order: ``$SAFE_OPTIMIZE_PROMPT_PREFIX``, then
+    ``ci/prompt_prefix.txt``, then an empty string.
+
+    Returns:
+        The resolved prompt prefix text.
+    """
 
     env_value = os.environ.get("SAFE_OPTIMIZE_PROMPT_PREFIX", "")
     if env_value:
@@ -187,11 +201,18 @@ _MULTINODE_BNXT_TAR = "/wekafs/primus/data/libbnxt/libbnxt_re-234.0.154.0.tar.gz
 
 
 def _multinode_prompt_suffix(nodes: int, rayjob_image: str) -> str:
-    """RayJob topology block injected into the prompt when nodes > 1.
+    """Build the RayJob topology block injected into the prompt for multi-node.
 
     The SaFE tasks body has no node-count field, so multi-node is expressed the
     same way the Claw-direct CI does: tell the agent to fan out to an N-node
-    RayJob with the exact topology. Returns "" for single-node (unchanged path).
+    RayJob with the exact topology.
+
+    Args:
+        nodes: Number of nodes; values <= 1 yield no suffix.
+        rayjob_image: RayJob container image to reference in the block.
+
+    Returns:
+        The prompt suffix, or ``""`` for single-node runs.
     """
     if nodes <= 1:
         return ""
@@ -280,8 +301,15 @@ GENERATIVE_ARCH_SUFFIXES: tuple[str, ...] = (
 
 
 def is_generative_arch(arch: str) -> bool:
-    """True if the HF arch is causal-LM-style inference; False for empty/unknown
-    (better to skip than waste a sandbox slot)."""
+    """Report whether an HF architecture is causal-LM-style for inference.
+
+    Args:
+        arch: The HF architecture name.
+
+    Returns:
+        ``True`` for generative architectures; ``False`` for empty/unknown
+        (better to skip than waste a sandbox slot).
+    """
     if not arch:
         return False
     return any(arch.endswith(s) for s in GENERATIVE_ARCH_SUFFIXES)
@@ -385,6 +413,13 @@ class HuggingFaceClient:
         Pool-then-filter: the listing API matches on tags only, so re-validate
         per-repo on pipeline_tag == "text-generation" AND a generative
         architectures[0] suffix; either failing (or a gated 401) → skip.
+
+        Args:
+            limit: Maximum number of repos to return.
+            min_params_b: Minimum parameter count in billions (0 disables).
+
+        Returns:
+            Repo ids passing all gates, in download-rank order.
         """
         pool_size = max(limit * 10, 100)
         listing = self._get(
@@ -459,10 +494,19 @@ class DetectedConfig:
 
 
 def _quant_type(config: dict) -> str:
-    """Read the quantization tag from HF config.json (vendors disagree on the
-    field name). Priority: quant_algo (NVIDIA modelopt — quant_method there is
-    just the tool name) > quant_type > quantization_type > quant_method
-    (current de-facto standard) > method. First non-empty wins, lowercased."""
+    """Read the quantization tag from an HF ``config.json``.
+
+    Vendors disagree on the field name. Priority: ``quant_algo`` (NVIDIA
+    modelopt — ``quant_method`` there is just the tool name) > ``quant_type``
+    > ``quantization_type`` > ``quant_method`` (current de-facto standard) >
+    ``method``. First non-empty wins.
+
+    Args:
+        config: An HF ``config.json`` dict.
+
+    Returns:
+        The quantization tag lowercased, or ``""`` when none is present.
+    """
     quant = config.get("quantization_config") or {}
     raw = (
         quant.get("quant_algo")
@@ -545,7 +589,15 @@ def detect_param_count(hf_info: dict, config: dict) -> float:
 
 
 def detect_max_context_tokens(config: dict) -> int:
-    """Return the model context length from HF config.json when present."""
+    """Return the model context length from an HF ``config.json``.
+
+    Args:
+        config: An HF ``config.json`` dict.
+
+    Returns:
+        The smallest positive context-length field found, or ``0`` when none
+        is present.
+    """
     candidates = []
     for key in ("max_position_embeddings", "max_sequence_length", "n_positions", "seq_length"):
         value = config.get(key)
@@ -580,9 +632,17 @@ def context_too_short(
 
 def detect_tp(params_b: float, precision: str = "BF16",
               gpu_type: str | None = None) -> int:
-    """Pick tensor parallelism from param count and GPU profile. precision is
-    kept for API compatibility but unused — CI policy stays predictable across
-    precision variants of the same model family."""
+    """Pick tensor parallelism from param count and GPU profile.
+
+    Args:
+        params_b: Parameter count in billions.
+        precision: Kept for API compatibility but unused — CI policy stays
+            predictable across precision variants of the same model family.
+        gpu_type: GPU type used to select the threshold profile.
+
+    Returns:
+        The tensor-parallel size (1, 2, 4, or 8).
+    """
     if params_b <= 0:
         return 1
     profile_key = normalize_gpu_profile(gpu_type) or DEFAULT_GPU_PROFILE
@@ -624,6 +684,12 @@ def _sglang_image_for(repo_id: str = "") -> str:
     attention CUDA-graph-capture SIGABRT. Matched on the repo basename so it
     fires for the HF repo id (the /wekafs/<org>-<repo> local path is derived
     downstream from this same id).
+
+    Args:
+        repo_id: HF repo id used to detect per-model image needs.
+
+    Returns:
+        The SGLang image reference to use.
     """
     basename = (repo_id or "").split("/")[-1].lower()
     if "mimo-v2" in basename:

--- a/ci/optimize_submit.py
+++ b/ci/optimize_submit.py
@@ -853,8 +853,17 @@ class SafeOptimizeClient:
         return resp.json() if resp.content else {}
 
     def find_model(self, repo_id: str) -> dict | None:
-        """Look up an existing SaFE Model by HF source URL, scoped to
-        register_workspace (where the canonical Model CR + LocalPaths live)."""
+        """Look up an existing SaFE Model by HF source URL.
+
+        Scoped to ``register_workspace`` (where the canonical Model CR +
+        LocalPaths live).
+
+        Args:
+            repo_id: HF repo id to look up.
+
+        Returns:
+            The matching model record, or ``None`` when not found.
+        """
         hf_url = f"https://huggingface.co/{repo_id}".rstrip("/")
         from urllib.parse import quote
         try:
@@ -875,10 +884,18 @@ class SafeOptimizeClient:
     ) -> str:
         """Register a model record with SaFE so submit_task has a model_id.
 
-        local_path set → accessMode=local_path: SaFE skips its Download Job
-        (phase=Ready immediately) since files are already on disk (prewarm path).
-        local_path empty → accessMode=local: SaFE downloads from HF (slow
-        fallback when prewarm can't run).
+        ``local_path`` set → accessMode=local_path: SaFE skips its Download Job
+        (phase=Ready immediately) since files are already on disk (prewarm
+        path). ``local_path`` empty → accessMode=local: SaFE downloads from HF
+        (slow fallback when prewarm can't run).
+
+        Args:
+            repo_id: HF repo id to register.
+            hf_token: Optional HF token for gated downloads.
+            local_path: On-disk model path; enables local_path access mode.
+
+        Returns:
+            The registered model id.
         """
         if local_path:
             # local_path mode bypasses SaFE's HF metadata fetch, so we MUST
@@ -1113,11 +1130,20 @@ class SafeOptimizeClient:
     def wait_task_done(
         self, task_id: str, timeout_min: int = 480, poll_s: int = 60,
     ) -> tuple[str, dict]:
-        """Wait until the task reaches a terminal status. Returns (status, last_task).
+        """Wait until the task reaches a terminal status.
 
-        Prefer the Claw SSE stream (SaFE's task status lags Claw by minutes), and
-        fall back to SaFE polling when no clawSessionId exists or SSE fails.
-        Returns ('Timeout', {}) if neither sees a terminal status by the deadline.
+        Prefers the Claw SSE stream (SaFE's task status lags Claw by minutes),
+        and falls back to SaFE polling when no clawSessionId exists or SSE
+        fails.
+
+        Args:
+            task_id: The SaFE task id to wait on.
+            timeout_min: Overall deadline in minutes.
+            poll_s: Poll interval in seconds for the SaFE fallback.
+
+        Returns:
+            A ``(status, last_task)`` tuple; ``("Timeout", {})`` when no
+            terminal status is seen by the deadline.
         """
         log.info("[task %s] waiting for completion (timeout=%dm, poll=%ds)",
                  task_id, timeout_min, poll_s)
@@ -1266,8 +1292,15 @@ class SafeOptimizeClient:
         return "idle_timeout"
 
     def _claw_session_id_for(self, task_id: str) -> str | None:
-        """Resolve clawSessionId for a task (per-instance cached). None when
-        SaFE has no session attached (e.g. task failed before session creation)."""
+        """Resolve the clawSessionId for a task (per-instance cached).
+
+        Args:
+            task_id: The SaFE task id.
+
+        Returns:
+            The clawSessionId, or ``None`` when SaFE has no session attached
+            (e.g. the task failed before session creation).
+        """
         if not hasattr(self, "_claw_session_cache"):
             self._claw_session_cache = {}
         if task_id in self._claw_session_cache:
@@ -1285,9 +1318,15 @@ class SafeOptimizeClient:
     def list_artifacts(self, task_id: str) -> list[dict]:
         """List task artifacts via the SaFE standard endpoint.
 
-        Returns items shaped {path, size, lastModified, downloadPath}.
-        downloadPath is server-relative; download_artifact() uses it when present,
-        else builds the /artifacts/download?path= URL from path.
+        ``downloadPath`` is server-relative; ``download_artifact`` uses it when
+        present, else builds the ``/artifacts/download?path=`` URL from path.
+
+        Args:
+            task_id: The SaFE task id.
+
+        Returns:
+            Artifact items shaped ``{path, size, lastModified, downloadPath}``
+            (empty list on error).
         """
         try:
             data = self._request(
@@ -1303,8 +1342,19 @@ class SafeOptimizeClient:
         return items
 
     def download_artifact(self, task_id: str, path_or_item: "str | dict") -> bytes:
-        """Download a single task artifact. Accepts a string path or a
-        list_artifacts item dict; prefers the item's downloadPath when present."""
+        """Download a single task artifact.
+
+        Args:
+            task_id: The SaFE task id.
+            path_or_item: An artifact path string or a ``list_artifacts``
+                item dict; the item's ``downloadPath`` is preferred.
+
+        Returns:
+            The artifact bytes.
+
+        Raises:
+            RuntimeError: If the download responds with status ``>= 400``.
+        """
         if isinstance(path_or_item, dict):
             download_path = (path_or_item.get("downloadPath") or "").strip()
             if download_path:

--- a/ci/optimize_submit.py
+++ b/ci/optimize_submit.py
@@ -1704,8 +1704,19 @@ def _is_wanted_artifact(path: str, all_artifacts: bool) -> bool:
 
 
 def _safe_local_path(artifacts_dir: Path, task_id: str, remote_path: str) -> Path:
-    """Map a session-relative remote path to a local file path, stripping leading
-    slashes / '..' so we never escape the artifacts dir."""
+    """Map a session-relative remote path to a safe local file path.
+
+    Strips leading slashes and ``..`` segments so the result never escapes
+    the artifacts directory.
+
+    Args:
+        artifacts_dir: Root artifacts directory.
+        task_id: Task id used as a subdirectory.
+        remote_path: The session-relative remote path.
+
+    Returns:
+        The sanitized local path under ``artifacts_dir/task_id``.
+    """
     rel = remote_path.lstrip("/").replace("\\", "/")
     parts = [seg for seg in rel.split("/") if seg and seg != ".." and seg != "."]
     return artifacts_dir / task_id / Path(*parts) if parts else artifacts_dir / task_id / "artifact.bin"
@@ -1864,9 +1875,17 @@ def _json_has_any_number(value) -> bool:
 
 
 def _breakdown_has_basic_data(path: Path) -> bool:
-    """True when a session_breakdown JSON carries usable audit/perf payload. The
-    delivery contract is "has structured data", not "has positive gain" (aborted
-    runs may legitimately be zero)."""
+    """Report whether a session_breakdown JSON carries usable payload.
+
+    The delivery contract is "has structured data", not "has positive gain"
+    (aborted runs may legitimately be zero).
+
+    Args:
+        path: Path to the session_breakdown JSON file.
+
+    Returns:
+        ``True`` when the file parses and contains a known data key.
+    """
     try:
         with open(path, encoding="utf-8") as f:
             data = json.load(f)
@@ -2078,7 +2097,15 @@ def _record_has_task_window(rec: SubmissionRecord) -> bool:
 
 
 def _env_float(name: str, default: float) -> float:
-    """Read a float environment setting with a safe fallback."""
+    """Read a float environment setting with a safe fallback.
+
+    Args:
+        name: Environment variable name.
+        default: Value returned when unset or unparseable.
+
+    Returns:
+        The parsed float, or ``default`` on failure.
+    """
     raw = os.environ.get(name, "").strip()
     if not raw:
         return default
@@ -2090,7 +2117,14 @@ def _env_float(name: str, default: float) -> float:
 
 
 def _read_session_state(session_dir: str | Path) -> dict:
-    """Best-effort read of a session's state.json."""
+    """Best-effort read of a session's ``state.json``.
+
+    Args:
+        session_dir: The session directory to read from.
+
+    Returns:
+        The parsed state dict, or ``{}`` when missing or unreadable.
+    """
     path = Path(session_dir) / "state.json"
     if not path.is_file():
         return {}
@@ -2102,7 +2136,15 @@ def _read_session_state(session_dir: str | Path) -> dict:
 
 
 def _session_has_terminal_marker(session_dir: str | Path) -> bool:
-    """True when a session has reached a state where CI should collect now."""
+    """Report whether a session has reached a collectable terminal state.
+
+    Args:
+        session_dir: The session directory to inspect.
+
+    Returns:
+        ``True`` when a breakdown / complete marker or close-sequence flag
+        is present.
+    """
     root = Path(session_dir)
     if (root / "session_breakdown.json").is_file():
         return True
@@ -2120,6 +2162,13 @@ def _session_activity_mtime(session_dir: str | Path) -> float:
     ``state.json`` can be quiet while long Magpie subprocesses append logs or
     traces, so include the runtime subtrees CI relies on. The file cap avoids
     expensive walks for very large sessions.
+
+    Args:
+        session_dir: The session directory to scan.
+
+    Returns:
+        The newest relevant mtime as a Unix timestamp, or ``0.0`` when none
+        found.
     """
     root = Path(session_dir)
     mtimes: list[float] = []
@@ -2160,7 +2209,16 @@ def _find_nfs_state_session_dir(
     rec: SubmissionRecord,
     current_session_hints: set[str] | None = None,
 ) -> str | None:
-    """Locate the current NFS session using state.json, not breakdown files."""
+    """Locate the current NFS session using state.json, not breakdown files.
+
+    Args:
+        rec: The submission record (user / model / task window).
+        current_session_hints: Optional session-id hints to bias matching.
+
+    Returns:
+        The best-matching session directory path, or ``None`` when none
+        match.
+    """
     nfs_root = os.environ.get("NFS_ROOT", "/wekafs")
     users_root = Path(nfs_root) / "users"
     if not rec.safe_user_id or not users_root.is_dir():

--- a/ci/optimize_submit.py
+++ b/ci/optimize_submit.py
@@ -2563,6 +2563,12 @@ def _backfill_wekafs_in_place(rec: SubmissionRecord) -> int:
     match; only sessions modified in the last 24h. Updates ci_metrics.json,
     manifest.json, session_breakdown[_v2].json across subdirs via
     _backfill_ci_metrics_file. No-op when wekafs isn't mounted.
+
+    Args:
+        rec: The submission record supplying match keys and audit fields.
+
+    Returns:
+        The number of source files updated in place.
     """
     nfs_root = os.environ.get("NFS_ROOT", "/wekafs")
     users_root = os.path.join(nfs_root, "users")
@@ -2709,9 +2715,19 @@ def _backfill_wekafs_in_place(rec: SubmissionRecord) -> int:
 
 
 def _record_matches_session_dir(rec: SubmissionRecord, sess_name: str) -> bool:
-    """Conservative directory-name match for the /wekafs/users fallback. Prefer
-    the displayName slug; fall back to basename with strict-term guards to avoid
-    cross-wiring adjacent repos (Qwen2.5 vs -AWQ, Nano vs Super, bnb, etc.)."""
+    """Conservatively match a session directory name to a record.
+
+    Prefers the displayName slug; falls back to basename with strict-term
+    guards to avoid cross-wiring adjacent repos (Qwen2.5 vs -AWQ, Nano vs
+    Super, bnb, etc.).
+
+    Args:
+        rec: The submission record.
+        sess_name: The session directory basename.
+
+    Returns:
+        ``True`` when the directory name matches the record.
+    """
     sess_slug = _slug_token(sess_name)
     sess_norm = _norm_token(sess_name)
     display = rec.display_name or ""
@@ -2737,7 +2753,15 @@ def _record_matches_session_dir(rec: SubmissionRecord, sess_name: str) -> bool:
 
 
 def _record_model_field_matches(rec: SubmissionRecord, model_field: str) -> bool:
-    """Compare a JSON model field with a SubmissionRecord conservatively."""
+    """Conservatively compare a JSON ``model`` field with a record.
+
+    Args:
+        rec: The submission record.
+        model_field: The model identifier read from a JSON artifact.
+
+    Returns:
+        ``True`` when the field matches one of the record's model aliases.
+    """
     observed = _norm_token(str(model_field or ""))
     if not observed:
         return False
@@ -2879,8 +2903,17 @@ def _env_truthy(name: str) -> bool:
 
 
 def _copy_session_tree(src_dir: str, dst_dir: Path) -> int:
-    """Copy an entire persisted session directory into ``dst_dir`` (existing files
-    untouched). Returns the number of files copied."""
+    """Copy an entire persisted session directory into ``dst_dir``.
+
+    Existing files are left untouched; VCS / cache dirs are skipped.
+
+    Args:
+        src_dir: Source session directory to copy from.
+        dst_dir: Destination directory (created if needed).
+
+    Returns:
+        The number of files copied.
+    """
     copied = 0
     dst_dir.mkdir(parents=True, exist_ok=True)
     for root, dirnames, filenames in os.walk(src_dir):
@@ -2911,13 +2944,22 @@ def _nfs_fallback_collect(
     copy_full_session: bool = False,
     current_session_hints: set[str] | None = None,
 ) -> int:
-    """Scan NFS result directories for files matching this model, used when the
-    SaFE artifact API returns nothing (V2 writes under /wekafs/users/<uid>/...).
+    """Scan NFS result directories for files matching this model.
 
-    Two stages: A. legacy canonical CI dirs, matched by dir name; B. per-user
-    session dirs, matched by each ci_metrics.json's `model` field (more accurate
-    than dir-name fuzzy match). Mirrors ci/orchestrator.py's fallback.
-    Returns count of files copied.
+    Used when the SaFE artifact API returns nothing (V2 writes under
+    ``/wekafs/users/<uid>/...``). Two stages: A. legacy canonical CI dirs,
+    matched by dir name; B. per-user session dirs, matched by each
+    ci_metrics.json's ``model`` field (more accurate than dir-name fuzzy
+    match). Mirrors ci/orchestrator.py's fallback.
+
+    Args:
+        rec: The submission record.
+        artifacts_dir: Local root to copy collected artifacts into.
+        copy_full_session: When True, copy the entire session tree.
+        current_session_hints: Optional session-id hints to bias matching.
+
+    Returns:
+        The number of files copied.
     """
     current_session_hints = set(current_session_hints or set())
     nfs_root = os.environ.get("NFS_ROOT", "/wekafs")
@@ -3219,9 +3261,25 @@ def wait_and_collect_one(
     collect: bool,
     all_artifacts: bool,
 ) -> SubmissionRecord:
-    """Wait for one task to finish, then optionally download its artifacts:
-    (1) SaFE artifacts API, then (2) NFS fallback when session_breakdown.json
-    (the CI delivery contract) is still missing."""
+    """Wait for one task to finish, then optionally download its artifacts.
+
+    Collection tries (1) the SaFE artifacts API, then (2) the NFS fallback
+    when ``session_breakdown.json`` (the CI delivery contract) is still
+    missing.
+
+    Args:
+        safe: The SaFE optimize client.
+        rec: The submission record to update in place.
+        artifacts_dir: Local root for downloaded artifacts.
+        task_timeout_min: Per-task wait deadline in minutes.
+        poll_s: Poll interval in seconds.
+        collect: When False, skip artifact collection.
+        all_artifacts: When True, download every artifact, not just the
+            delivery-contract files.
+
+    Returns:
+        The updated submission record.
+    """
     if not rec.task_id:
         return rec  # nothing to wait for (skipped/failed during submit)
 

--- a/ci/optimize_submit.py
+++ b/ci/optimize_submit.py
@@ -127,7 +127,16 @@ _KERNEL_BACKEND_ALIASES = {
 
 
 def normalize_gpu_profile(gpu_type: str | None, *, warn: bool = True) -> str | None:
-    """Return the GPU profile key when ``gpu_type`` maps to a known CI profile."""
+    """Return the GPU profile key when ``gpu_type`` maps to a known CI profile.
+
+    Args:
+        gpu_type (str | None): Free-form GPU type/alias.
+        warn (bool): Log a warning when a non-empty ``gpu_type`` is unknown.
+
+    Returns:
+        str | None: The matching :data:`GPU_PROFILES` key, or ``None`` when no
+        profile matches.
+    """
     raw = (gpu_type or "").strip()
     compact = re.sub(r"[^a-z0-9]", "", raw.lower())
     for key, profile in GPU_PROFILES.items():
@@ -167,7 +176,11 @@ _PROMPT_PREFIX_FILE = Path(__file__).resolve().parent / "prompt_prefix.txt"
 
 def _load_default_prompt_prefix() -> str:
     """Resolve the default ``--prompt-prefix``: $SAFE_OPTIMIZE_PROMPT_PREFIX,
-    else ci/prompt_prefix.txt, else empty string."""
+    else ci/prompt_prefix.txt, else empty string.
+
+    Returns:
+        str: The resolved prompt prefix, or ``""`` when no source supplies one.
+    """
 
     env_value = os.environ.get("SAFE_OPTIMIZE_PROMPT_PREFIX", "")
     if env_value:
@@ -192,6 +205,13 @@ def _multinode_prompt_suffix(nodes: int, rayjob_image: str) -> str:
     The SaFE tasks body has no node-count field, so multi-node is expressed the
     same way the Claw-direct CI does: tell the agent to fan out to an N-node
     RayJob with the exact topology. Returns "" for single-node (unchanged path).
+
+    Args:
+        nodes (int): Node count for the run; ``<= 1`` produces no suffix.
+        rayjob_image (str): Container image to advertise for the RayJob.
+
+    Returns:
+        str: The multi-node topology prompt block, or ``""`` for single-node.
     """
     if nodes <= 1:
         return ""
@@ -281,7 +301,14 @@ GENERATIVE_ARCH_SUFFIXES: tuple[str, ...] = (
 
 def is_generative_arch(arch: str) -> bool:
     """True if the HF arch is causal-LM-style inference; False for empty/unknown
-    (better to skip than waste a sandbox slot)."""
+    (better to skip than waste a sandbox slot).
+
+    Args:
+        arch (str): HF ``architectures[0]`` class name.
+
+    Returns:
+        bool: True when ``arch`` ends with a known generative suffix.
+    """
     if not arch:
         return False
     return any(arch.endswith(s) for s in GENERATIVE_ARCH_SUFFIXES)
@@ -386,6 +413,14 @@ class HuggingFaceClient:
         per-repo on a generative architectures[0] suffix; failing that (or a
         gated 401) → skip. The pipeline_tag != text-generation gate has been
         removed so multimodal/other heads are allowed through.
+
+        Args:
+            limit (int): Maximum number of repos to return.
+            min_params_b (float): Minimum parameter count in billions; ``0``
+                disables the size filter.
+
+        Returns:
+            list[str]: Up to ``limit`` generative repo ids ordered by downloads.
         """
         pool_size = max(limit * 10, 100)
         listing = self._get(
@@ -457,7 +492,14 @@ def _quant_type(config: dict) -> str:
     """Read the quantization tag from HF config.json (vendors disagree on the
     field name). Priority: quant_algo (NVIDIA modelopt — quant_method there is
     just the tool name) > quant_type > quantization_type > quant_method
-    (current de-facto standard) > method. First non-empty wins, lowercased."""
+    (current de-facto standard) > method. First non-empty wins, lowercased.
+
+    Args:
+        config (dict): A HF ``config.json`` dict.
+
+    Returns:
+        str: The lowercased quantization tag, or ``""`` when none is present.
+    """
     quant = config.get("quantization_config") or {}
     raw = (
         quant.get("quant_algo")
@@ -540,7 +582,15 @@ def detect_param_count(hf_info: dict, config: dict) -> float:
 
 
 def detect_max_context_tokens(config: dict) -> int:
-    """Return the model context length from HF config.json when present."""
+    """Return the model context length from HF config.json when present.
+
+    Args:
+        config (dict): A HF ``config.json`` dict.
+
+    Returns:
+        int: The smallest positive context-length field found, or ``0`` when
+        none is present.
+    """
     candidates = []
     for key in ("max_position_embeddings", "max_sequence_length", "n_positions", "seq_length"):
         value = config.get(key)
@@ -577,7 +627,16 @@ def detect_tp(params_b: float, precision: str = "BF16",
               gpu_type: str | None = None) -> int:
     """Pick tensor parallelism from param count and GPU profile. precision is
     kept for API compatibility but unused — CI policy stays predictable across
-    precision variants of the same model family."""
+    precision variants of the same model family.
+
+    Args:
+        params_b (float): Parameter count in billions.
+        precision (str): Kept for API compatibility; unused.
+        gpu_type (str | None): GPU type used to select the profile thresholds.
+
+    Returns:
+        int: The tensor-parallel size (1, 2, 4, or 8).
+    """
     if params_b <= 0:
         return 1
     profile_key = normalize_gpu_profile(gpu_type) or DEFAULT_GPU_PROFILE
@@ -619,6 +678,13 @@ def _sglang_image_for(repo_id: str = "") -> str:
     attention CUDA-graph-capture SIGABRT. Matched on the repo basename so it
     fires for the HF repo id (the /wekafs/<org>-<repo> local path is derived
     downstream from this same id).
+
+    Args:
+        repo_id (str): Model repo id, matched on its basename for overrides.
+
+    Returns:
+        str: The MiMo-V2 sglang image for MiMo-V2.x repos, else the default
+        sglang image.
     """
     basename = (repo_id or "").split("/")[-1].lower()
     if "mimo-v2" in basename:
@@ -778,7 +844,15 @@ class SafeOptimizeClient:
 
     def find_model(self, repo_id: str) -> dict | None:
         """Look up an existing SaFE Model by HF source URL, scoped to
-        register_workspace (where the canonical Model CR + LocalPaths live)."""
+        register_workspace (where the canonical Model CR + LocalPaths live).
+
+        Args:
+            repo_id (str): HuggingFace repo id to match by source URL.
+
+        Returns:
+            dict | None: The matching SaFE model record, or ``None`` when none
+            matches or the listing fails.
+        """
         hf_url = f"https://huggingface.co/{repo_id}".rstrip("/")
         from urllib.parse import quote
         try:
@@ -803,6 +877,15 @@ class SafeOptimizeClient:
         (phase=Ready immediately) since files are already on disk (prewarm path).
         local_path empty → accessMode=local: SaFE downloads from HF (slow
         fallback when prewarm can't run).
+
+        Args:
+            repo_id (str): HuggingFace repo id to register.
+            hf_token (str): Optional HF token for gated downloads (local mode).
+            local_path (str): On-disk model path; when set, registers in
+                ``local_path`` mode and skips SaFE's Download Job.
+
+        Returns:
+            str: The registered SaFE model id (empty string when absent).
         """
         if local_path:
             # local_path mode bypasses SaFE's HF metadata fetch, so we MUST
@@ -1042,6 +1125,15 @@ class SafeOptimizeClient:
         Prefer the Claw SSE stream (SaFE's task status lags Claw by minutes), and
         fall back to SaFE polling when no clawSessionId exists or SSE fails.
         Returns ('Timeout', {}) if neither sees a terminal status by the deadline.
+
+        Args:
+            task_id (str): SaFE optimization task id to wait on.
+            timeout_min (int): Maximum minutes to wait for a terminal status.
+            poll_s (int): Seconds between SaFE status polls.
+
+        Returns:
+            tuple[str, dict]: ``(status, last_task)`` — the terminal status (or
+            ``"Timeout"``) and the last task record observed.
         """
         log.info("[task %s] waiting for completion (timeout=%dm, poll=%ds)",
                  task_id, timeout_min, poll_s)
@@ -1191,7 +1283,15 @@ class SafeOptimizeClient:
 
     def _claw_session_id_for(self, task_id: str) -> str | None:
         """Resolve clawSessionId for a task (per-instance cached). None when
-        SaFE has no session attached (e.g. task failed before session creation)."""
+        SaFE has no session attached (e.g. task failed before session creation).
+
+        Args:
+            task_id (str): SaFE optimization task id.
+
+        Returns:
+            str | None: The Claw session id, or ``None`` when none is attached
+            or the lookup fails.
+        """
         if not hasattr(self, "_claw_session_cache"):
             self._claw_session_cache = {}
         if task_id in self._claw_session_cache:
@@ -1212,6 +1312,13 @@ class SafeOptimizeClient:
         Returns items shaped {path, size, lastModified, downloadPath}.
         downloadPath is server-relative; download_artifact() uses it when present,
         else builds the /artifacts/download?path= URL from path.
+
+        Args:
+            task_id (str): SaFE optimization task id.
+
+        Returns:
+            list[dict]: Artifact item dicts, or ``[]`` on error / unexpected
+            shape.
         """
         try:
             data = self._request(
@@ -1228,7 +1335,19 @@ class SafeOptimizeClient:
 
     def download_artifact(self, task_id: str, path_or_item: "str | dict") -> bytes:
         """Download a single task artifact. Accepts a string path or a
-        list_artifacts item dict; prefers the item's downloadPath when present."""
+        list_artifacts item dict; prefers the item's downloadPath when present.
+
+        Args:
+            task_id (str): SaFE optimization task id.
+            path_or_item (str | dict): Artifact path string or a
+                :meth:`list_artifacts` item dict.
+
+        Returns:
+            bytes: The downloaded artifact content.
+
+        Raises:
+            RuntimeError: If the download response status is ``>= 400``.
+        """
         if isinstance(path_or_item, dict):
             download_path = (path_or_item.get("downloadPath") or "").strip()
             if download_path:
@@ -1579,7 +1698,16 @@ def _is_wanted_artifact(path: str, all_artifacts: bool) -> bool:
 
 def _safe_local_path(artifacts_dir: Path, task_id: str, remote_path: str) -> Path:
     """Map a session-relative remote path to a local file path, stripping leading
-    slashes / '..' so we never escape the artifacts dir."""
+    slashes / '..' so we never escape the artifacts dir.
+
+    Args:
+        artifacts_dir (Path): Local artifacts root.
+        task_id (str): SaFE task id used as the per-task subdirectory.
+        remote_path (str): Session-relative remote artifact path.
+
+    Returns:
+        Path: A safe local destination path under ``artifacts_dir/task_id``.
+    """
     rel = remote_path.lstrip("/").replace("\\", "/")
     parts = [seg for seg in rel.split("/") if seg and seg != ".." and seg != "."]
     return artifacts_dir / task_id / Path(*parts) if parts else artifacts_dir / task_id / "artifact.bin"
@@ -1740,7 +1868,15 @@ def _json_has_any_number(value) -> bool:
 def _breakdown_has_basic_data(path: Path) -> bool:
     """True when a session_breakdown JSON carries usable audit/perf payload. The
     delivery contract is "has structured data", not "has positive gain" (aborted
-    runs may legitimately be zero)."""
+    runs may legitimately be zero).
+
+    Args:
+        path (Path): Path to a ``session_breakdown`` JSON file.
+
+    Returns:
+        bool: True when the JSON is an object carrying a known audit/perf key or
+        any numeric value; False on read/parse error.
+    """
     try:
         with open(path, encoding="utf-8") as f:
             data = json.load(f)
@@ -1952,7 +2088,15 @@ def _record_has_task_window(rec: SubmissionRecord) -> bool:
 
 
 def _env_float(name: str, default: float) -> float:
-    """Read a float environment setting with a safe fallback."""
+    """Read a float environment setting with a safe fallback.
+
+    Args:
+        name (str): Environment variable name to read.
+        default (float): Fallback value when unset or non-float.
+
+    Returns:
+        float: The parsed value, or ``default``.
+    """
     raw = os.environ.get(name, "").strip()
     if not raw:
         return default
@@ -1964,7 +2108,15 @@ def _env_float(name: str, default: float) -> float:
 
 
 def _read_session_state(session_dir: str | Path) -> dict:
-    """Best-effort read of a session's state.json."""
+    """Best-effort read of a session's state.json.
+
+    Args:
+        session_dir (str | Path): Session directory containing ``state.json``.
+
+    Returns:
+        dict: The parsed state dict, or an empty dict when missing/unreadable
+        or not a JSON object.
+    """
     path = Path(session_dir) / "state.json"
     if not path.is_file():
         return {}
@@ -1976,7 +2128,15 @@ def _read_session_state(session_dir: str | Path) -> dict:
 
 
 def _session_has_terminal_marker(session_dir: str | Path) -> bool:
-    """True when a session has reached a state where CI should collect now."""
+    """True when a session has reached a state where CI should collect now.
+
+    Args:
+        session_dir (str | Path): Session directory to inspect.
+
+    Returns:
+        bool: True when a ``session_breakdown.json`` / ``complete`` marker
+        exists or ``state.json`` reports ``close_sequence_done``.
+    """
     root = Path(session_dir)
     if (root / "session_breakdown.json").is_file():
         return True
@@ -1994,6 +2154,12 @@ def _session_activity_mtime(session_dir: str | Path) -> float:
     ``state.json`` can be quiet while long Magpie subprocesses append logs or
     traces, so include the runtime subtrees CI relies on. The file cap avoids
     expensive walks for very large sessions.
+
+    Args:
+        session_dir (str | Path): Session directory to scan.
+
+    Returns:
+        float: The newest relevant file mtime, or ``0.0`` when nothing is found.
     """
     root = Path(session_dir)
     mtimes: list[float] = []
@@ -2034,7 +2200,18 @@ def _find_nfs_state_session_dir(
     rec: SubmissionRecord,
     current_session_hints: set[str] | None = None,
 ) -> str | None:
-    """Locate the current NFS session using state.json, not breakdown files."""
+    """Locate the current NFS session using state.json, not breakdown files.
+
+    Args:
+        rec (SubmissionRecord): Record providing user id, model names, and task
+            window for matching.
+        current_session_hints (set[str] | None): Optional session-timestamp
+            hints that, when present, must appear in the matched path.
+
+    Returns:
+        str | None: The best-matching session directory path, or ``None`` when
+        none matches.
+    """
     nfs_root = os.environ.get("NFS_ROOT", "/wekafs")
     users_root = Path(nfs_root) / "users"
     if not rec.safe_user_id or not users_root.is_dir():
@@ -2100,7 +2277,22 @@ def _wait_for_nfs_session_delivery(
     grace_min: float | None = None,
     idle_min: float | None = None,
 ) -> str | None:
-    """After SaFE early terminal, wait while the NFS session is still active."""
+    """After SaFE early terminal, wait while the NFS session is still active.
+
+    Args:
+        rec (SubmissionRecord): Record used to locate the NFS session.
+        current_session_hints (set[str] | None): Optional session-timestamp
+            hints to constrain the matched session.
+        poll_s (int): Seconds between activity polls.
+        grace_min (float | None): Max minutes to wait; ``None`` resolves from
+            ``$SAFE_OPTIMIZE_NFS_LIVE_GRACE_MIN``.
+        idle_min (float | None): Idle minutes that end the wait; ``None``
+            resolves from ``$SAFE_OPTIMIZE_NFS_IDLE_GRACE_MIN``.
+
+    Returns:
+        str | None: The session directory once delivery/idle settles, or
+        ``None`` when none is found or grace waiting is disabled.
+    """
     grace_min = _env_float("SAFE_OPTIMIZE_NFS_LIVE_GRACE_MIN", 180.0) \
         if grace_min is None else grace_min
     idle_min = _env_float("SAFE_OPTIMIZE_NFS_IDLE_GRACE_MIN", 20.0) \
@@ -2166,7 +2358,14 @@ def _wait_for_nfs_session_delivery(
 
 def _category_from_arch(arch: str | None) -> str:
     """Coarse model-shape classification: "moe" if arch contains "moe", else
-    "dense"; "" when unknown so downstream JSON stays "n/a"."""
+    "dense"; "" when unknown so downstream JSON stays "n/a".
+
+    Args:
+        arch (str | None): HF architecture class name.
+
+    Returns:
+        str: ``"moe"``, ``"dense"``, or ``""`` for empty/unknown input.
+    """
     if not arch:
         return ""
     return "moe" if "moe" in arch.lower() else "dense"
@@ -2174,7 +2373,15 @@ def _category_from_arch(arch: str | None) -> str:
 
 def _sandbox_duration_seconds(last_task: dict) -> float | None:
     """SaFE-side sandbox wallclock = finishedAt - startedAt (from the task API).
-    None when either field is missing/unparseable so we don't fabricate a duration."""
+    None when either field is missing/unparseable so we don't fabricate a duration.
+
+    Args:
+        last_task (dict): SaFE task record carrying ``startedAt``/``finishedAt``.
+
+    Returns:
+        float | None: Rounded duration in seconds, or ``None`` when either
+        timestamp is missing/unparseable or the delta is negative.
+    """
     from datetime import datetime
     start = (last_task or {}).get("startedAt") or ""
     end = (last_task or {}).get("finishedAt") or ""
@@ -2196,6 +2403,14 @@ def _find_hyperloom_commit_sha(start: Path) -> str:
     First hit wins: (1) hyperloom_source_commit.txt written by the agent (depth
     varies by which fallback collected it), then (2) the CI runner env
     (HYPERLOOM_SOURCE_REF, else GITHUB_SHA).
+
+    Args:
+        start (Path): A path near the artifact, used to derive sibling
+            ``hyperloom_source_commit.txt`` candidates.
+
+    Returns:
+        str: The resolved SHA-shaped commit string, or ``""`` when none is
+        found.
     """
     candidates = [
         start.parent / "hyperloom_source_commit.txt",
@@ -2230,6 +2445,11 @@ def _backfill_ci_metrics_file(path: Path, rec: SubmissionRecord) -> None:
     Writes the right shape per filename: ci_metrics.json → flat top-level;
     session_breakdown.json → under session_meta; manifest.json → flat top-level
     (V2 cli schema; category/duration are extra keys V2 ignores on re-read).
+
+    Args:
+        path (Path): Target JSON file (ci_metrics / session_breakdown /
+            manifest); other names and missing files are no-ops.
+        rec (SubmissionRecord): Record supplying the metadata to backfill.
     """
     if path.name not in ("ci_metrics.json", "session_breakdown.json", "manifest.json"):
         return
@@ -2338,6 +2558,14 @@ def _backfill_wekafs_in_place(rec: SubmissionRecord) -> int:
     match; only sessions modified in the last 24h. Updates ci_metrics.json,
     manifest.json, session_breakdown[_v2].json across subdirs via
     _backfill_ci_metrics_file. No-op when wekafs isn't mounted.
+
+    Args:
+        rec (SubmissionRecord): Record used to match sessions and supply the
+            metadata to backfill.
+
+    Returns:
+        int: Number of files updated; ``0`` when wekafs is unmounted or nothing
+        matched.
     """
     nfs_root = os.environ.get("NFS_ROOT", "/wekafs")
     users_root = os.path.join(nfs_root, "users")
@@ -2486,7 +2714,15 @@ def _backfill_wekafs_in_place(rec: SubmissionRecord) -> int:
 def _record_matches_session_dir(rec: SubmissionRecord, sess_name: str) -> bool:
     """Conservative directory-name match for the /wekafs/users fallback. Prefer
     the displayName slug; fall back to basename with strict-term guards to avoid
-    cross-wiring adjacent repos (Qwen2.5 vs -AWQ, Nano vs Super, bnb, etc.)."""
+    cross-wiring adjacent repos (Qwen2.5 vs -AWQ, Nano vs Super, bnb, etc.).
+
+    Args:
+        rec (SubmissionRecord): Record providing the model id / display name.
+        sess_name (str): Candidate session directory name.
+
+    Returns:
+        bool: True when ``sess_name`` conservatively matches the record.
+    """
     sess_slug = _slug_token(sess_name)
     sess_norm = _norm_token(sess_name)
     display = rec.display_name or ""
@@ -2512,7 +2748,16 @@ def _record_matches_session_dir(rec: SubmissionRecord, sess_name: str) -> bool:
 
 
 def _record_model_field_matches(rec: SubmissionRecord, model_field: str) -> bool:
-    """Compare a JSON model field with a SubmissionRecord conservatively."""
+    """Compare a JSON model field with a SubmissionRecord conservatively.
+
+    Args:
+        rec (SubmissionRecord): Record supplying the allowed model names.
+        model_field (str): The model id read from a result JSON.
+
+    Returns:
+        bool: True when ``model_field`` normalizes to one of the record's
+        allowed names.
+    """
     observed = _norm_token(str(model_field or ""))
     if not observed:
         return False
@@ -2655,7 +2900,15 @@ def _env_truthy(name: str) -> bool:
 
 def _copy_session_tree(src_dir: str, dst_dir: Path) -> int:
     """Copy an entire persisted session directory into ``dst_dir`` (existing files
-    untouched). Returns the number of files copied."""
+    untouched). Returns the number of files copied.
+
+    Args:
+        src_dir (str): Source session directory to copy from.
+        dst_dir (Path): Destination directory (created if absent).
+
+    Returns:
+        int: Number of files copied.
+    """
     copied = 0
     dst_dir.mkdir(parents=True, exist_ok=True)
     for root, dirnames, filenames in os.walk(src_dir):
@@ -2693,6 +2946,17 @@ def _nfs_fallback_collect(
     session dirs, matched by each ci_metrics.json's `model` field (more accurate
     than dir-name fuzzy match). Mirrors ci/orchestrator.py's fallback.
     Returns count of files copied.
+
+    Args:
+        rec (SubmissionRecord): Record used to match sessions and record
+            collected artifacts.
+        artifacts_dir (Path): Local artifacts root the files are copied into.
+        copy_full_session (bool): Also copy the full matched session tree.
+        current_session_hints (set[str] | None): Session-timestamp hints used to
+            scope the scan.
+
+    Returns:
+        int: Number of files copied.
     """
     current_session_hints = set(current_session_hints or set())
     nfs_root = os.environ.get("NFS_ROOT", "/wekafs")
@@ -2996,7 +3260,20 @@ def wait_and_collect_one(
 ) -> SubmissionRecord:
     """Wait for one task to finish, then optionally download its artifacts:
     (1) SaFE artifacts API, then (2) NFS fallback when session_breakdown.json
-    (the CI delivery contract) is still missing."""
+    (the CI delivery contract) is still missing.
+
+    Args:
+        safe (SafeOptimizeClient): Client used to poll and download artifacts.
+        rec (SubmissionRecord): Record to update with status and artifacts.
+        artifacts_dir (Path): Local artifacts root for this task.
+        task_timeout_min (int): Max minutes to wait for the task.
+        poll_s (int): Polling interval in seconds.
+        collect (bool): When False, skip artifact collection.
+        all_artifacts (bool): When True, download every artifact / full session.
+
+    Returns:
+        SubmissionRecord: The same ``rec``, mutated in place with results.
+    """
     if not rec.task_id:
         return rec  # nothing to wait for (skipped/failed during submit)
 

--- a/ci/orchestrator.py
+++ b/ci/orchestrator.py
@@ -74,9 +74,16 @@ def render_prompt(merged: dict, *, pr_mode: bool = False,
                   gh_token: str | None = None) -> str:
     """Render the agent prompt for the inference_optimizer skill.
 
-    pr_mode=False (default): prompt_template.md against /wekafs/HyperloomV2.
-    pr_mode=True: prompt_template_pr.md, agent git-clones PR head; requires
-    git_ref (PR head sha) and gh_token (clones AMD-AGI/Hyperloom).
+    Args:
+        merged: Merged model/run config (workload dims, benchmarks, image).
+        pr_mode: When False, use ``prompt_template.md`` against
+            ``/wekafs/HyperloomV2``; when True, use ``prompt_template_pr.md``
+            so the agent git-clones the PR head.
+        git_ref: PR head SHA; required when ``pr_mode`` is True.
+        gh_token: GitHub token used to clone AMD-AGI/Hyperloom in PR mode.
+
+    Returns:
+        The rendered prompt string.
     """
     isl, osl = merged["isl_osl_configs"][0]
     ifx_text = format_benchmark_for_prompt(
@@ -223,7 +230,17 @@ def run_model(
 ) -> dict:
     """Execute the full optimization flow for a single model.
 
-    pr_mode + git_ref + gh_token are forwarded to render_prompt. See its docstring.
+    Args:
+        claw: The Claw client used to launch and poll the sandbox.
+        merged: Merged model/run config.
+        nfs_base: NFS base path for result collection.
+        sandbox_timeout: Sandbox wait deadline in seconds.
+        pr_mode: Forwarded to :func:`render_prompt` (PR-CI mode).
+        git_ref: PR head SHA; forwarded to :func:`render_prompt`.
+        gh_token: GitHub token; forwarded to :func:`render_prompt`.
+
+    Returns:
+        A result dict describing the run outcome and collected artifacts.
     """
     model_name = merged["model_hf"].split("/")[-1]
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M")

--- a/ci/post_perf_runs.py
+++ b/ci/post_perf_runs.py
@@ -84,10 +84,18 @@ _CRASH_STOP_REASONS = {
 
 
 def is_complete_session(data: Dict[str, Any]) -> Tuple[bool, Optional[str]]:
-    """Reject incomplete or crashed sessions; returns (ok, reason_if_rejected).
+    """Validate that a session is complete and did not crash.
 
-    A 'good' session needs baseline + final throughput_tok_s_per_gpu > 0 and a
-    stop_reason not in _CRASH_STOP_REASONS ('signal'/'time_exhausted' are kept).
+    A "good" session needs baseline + final ``throughput_tok_s_per_gpu`` > 0
+    and a ``stop_reason`` not in ``_CRASH_STOP_REASONS``
+    (``signal`` / ``time_exhausted`` are kept).
+
+    Args:
+        data: The session breakdown data dict.
+
+    Returns:
+        An ``(ok, reason_if_rejected)`` tuple; ``reason`` is ``None`` when
+        accepted.
     """
     baseline = data.get("baseline") or {}
     final = data.get("final") or {}
@@ -113,9 +121,18 @@ def is_complete_session(data: Dict[str, Any]) -> Tuple[bool, Optional[str]]:
 # ---------------------------------------------------------------------------
 
 def build_body(path: Path) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
-    """Returns (body, error_msg); body is None on error.
+    """Build the perf_runs POST body from a breakdown file.
 
-    `body` is the JSON we POST, with keys matching the perf_runs DTO 1:1.
+    Accepts four layouts (strictest first): bare V2 breakdown, V2 wrapper
+    (``{source, data}``), legacy V1 flat schema, and the universal fallback.
+
+    Args:
+        path: Path to the session breakdown JSON file.
+
+    Returns:
+        A ``(body, error_msg)`` tuple; ``body`` is ``None`` on error and
+        ``error_msg`` carries the reason. The body keys match the perf_runs
+        DTO 1:1.
     """
     try:
         with path.open("r", encoding="utf-8") as f:

--- a/ci/pr_submitter.py
+++ b/ci/pr_submitter.py
@@ -574,6 +574,12 @@ def sync_fork_from_upstream(repo_dir: str, upstream_url: str,
 
     Merge (not rebase/reset) preserves the fork-only verify-pr/sync workflow
     files while keeping the base current.
+
+    Args:
+        repo_dir: Local clone directory of the fork.
+        upstream_url: Upstream repository URL to add as a remote.
+        branch: Branch to sync from upstream.
+        token: Optional auth token for the push back to the fork.
     """
     _run_git(["remote", "add", "upstream", upstream_url], repo_dir, check=False)
     _run_git(["fetch", "upstream", branch], repo_dir)

--- a/ci/prewarm_models.py
+++ b/ci/prewarm_models.py
@@ -118,10 +118,19 @@ def tmp_dir(target_root: Path, repo_id: str) -> Path:
 
 
 def is_complete(dest: Path, repo_id: str, hf_api: HfApi, token: str) -> bool:
-    """True iff dest/ has every file the HF repo claims, with non-zero size.
+    """Report whether a local copy fully mirrors the HF repo.
 
     One ``list_repo_files`` call; partial prior runs fail this because they
     miss a file or have a zero-sized one.
+
+    Args:
+        dest: Local destination directory.
+        repo_id: HF repo id to compare against.
+        hf_api: An :class:`HfApi` client.
+        token: HF token for gated repos.
+
+    Returns:
+        ``True`` iff ``dest`` has every claimed file with non-zero size.
     """
     if not dest.is_dir():
         return False
@@ -258,8 +267,19 @@ def _load_candidates(path: Path) -> list[str]:
 
 def _slice_repos(repos: list[str], batch_index: int | None,
                  batch_size: int | None) -> list[str]:
-    """Apply optional --batch-index / --batch-size slice (same semantics as
-    generate_hf_matrix.py, so prewarm + optimize target the same repos)."""
+    """Apply an optional ``--batch-index`` / ``--batch-size`` slice.
+
+    Uses the same semantics as ``generate_hf_matrix.py`` so prewarm and
+    optimize target the same repos.
+
+    Args:
+        repos: The full repo list.
+        batch_index: 0-based batch index (defaults to 0).
+        batch_size: Entries per batch; falsy returns all repos.
+
+    Returns:
+        The selected repo slice.
+    """
     if not batch_size:
         return repos
     bi = batch_index or 0

--- a/ci/progress.py
+++ b/ci/progress.py
@@ -45,7 +45,16 @@ def _load_json(path: Path) -> dict:
 
 
 def _summary_rows(summary_path: Path) -> list[dict]:
-    """Extract rows from a ci_summary.json; accepts `{"rows": [...]}`, `{"models": [...]}`, or a bare list."""
+    """Extract rows from a ci_summary.json file.
+
+    Accepts ``{"rows": [...]}``, ``{"models": [...]}``, or a bare list.
+
+    Args:
+        summary_path: Path to the ci_summary.json file.
+
+    Returns:
+        The extracted row dicts (empty when none found).
+    """
     data = _load_json(summary_path)
     if isinstance(data, list):
         return data
@@ -53,7 +62,16 @@ def _summary_rows(summary_path: Path) -> list[dict]:
 
 
 def _classify_status(row: dict) -> tuple[str, str | None]:
-    """Return (status, reason): completed (baseline+optimized), partial (one only), or failed (no usable data)."""
+    """Classify a summary row's completion status.
+
+    Args:
+        row: A ci_summary row dict.
+
+    Returns:
+        A ``(status, reason)`` tuple where status is ``"completed"``
+        (baseline + optimized + gain), ``"partial"`` (one data point), or
+        ``"failed"`` (no usable data); ``reason`` is ``None`` when completed.
+    """
     fs = row.get("final_status")
     submit = row.get("submit_status")
     has_opt = row.get("optimized_tok_per_gpu") is not None

--- a/ci/publish_results.py
+++ b/ci/publish_results.py
@@ -57,11 +57,18 @@ def load_results(path: Path) -> list[dict[str, Any]]:
 
 
 def _normalize_submitted_at(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Move ``run.submitted_at`` ISO strings to ``run.submitted_at_iso`` (set original to None).
+    """Move ``run.submitted_at`` ISO strings to ``run.submitted_at_iso``.
 
-    Required because the ingest path binds ``submitted_at`` (timestamptz) as a str and asyncpg
-    rejects it with HTTP 500. The sibling key preserves the value in the raw_result JSONB blob.
-    Drop once the ingest path accepts ISO strings directly.
+    Required because the ingest path binds ``submitted_at`` (timestamptz) as a
+    str and asyncpg rejects it with HTTP 500. The sibling key preserves the
+    value in the raw_result JSONB blob. Drop once the ingest path accepts ISO
+    strings directly.
+
+    Args:
+        results: Normalized result dicts to clean.
+
+    Returns:
+        New result dicts with ``submitted_at`` moved to ``submitted_at_iso``.
     """
     cleaned: list[dict[str, Any]] = []
     for r in results:
@@ -87,10 +94,22 @@ def publish(
     max_retries: int = 5,
     initial_backoff_s: float = 5.0,
 ) -> dict:
-    """POST results to /api/import with exponential-backoff retry.
+    """POST results to ``/api/import`` with exponential-backoff retry.
 
-    Retries cover intermittent service-side failures: PG pool drops after a pod crashloop
-    (HTTP 500, succeeds on retry once asyncpg reconnects) and liveness-probe restarts (5xx / refused).
+    Retries cover intermittent service-side failures: PG pool drops after a pod
+    crashloop (HTTP 500, succeeds on retry once asyncpg reconnects) and
+    liveness-probe restarts (5xx / refused).
+
+    Args:
+        results: Normalized result dicts to publish.
+        url: Base service URL (``/api/import`` is appended).
+        token: Optional bearer token.
+        timeout: Per-request timeout in seconds.
+        max_retries: Maximum retry attempts.
+        initial_backoff_s: Initial backoff delay in seconds.
+
+    Returns:
+        The decoded JSON response from the import endpoint.
     """
     import time
     import requests

--- a/ci/report_generator.py
+++ b/ci/report_generator.py
@@ -102,7 +102,18 @@ def _first_of(d: dict, *keys: str) -> Any | None:
 
 
 def _parse_metrics_from_report(content: str) -> dict:
-    """Fallback: extract baseline/optimized throughput from the optimization_report.md Executive Summary table (prefers total over per-GPU)."""
+    """Extract throughput metrics from an optimization report (fallback path).
+
+    Parses the ``optimization_report.md`` Executive Summary table, preferring
+    total over per-GPU figures.
+
+    Args:
+        content: The Markdown report contents.
+
+    Returns:
+        A dict with any of ``gain_pct``, ``baseline_throughput``, and
+        ``optimized_throughput`` that could be parsed.
+    """
     import re
 
     result: dict[str, Any] = {}

--- a/ci/transform_to_session_summary_v2.py
+++ b/ci/transform_to_session_summary_v2.py
@@ -82,9 +82,17 @@ def safe_get(d: Any, *keys: str, default: Any = None) -> Any:
 # ---------------------------------------------------------------------------
 
 def _patch_baseline(data: Dict) -> List[str]:
-    """Mirror `extra_server_args` / `extra_envs` onto `baseline` (which lacks
-    them) from baseline.invocation. Reads the legacy ``extra_sglang_args`` key
-    but always writes the canonical ``extra_server_args``.
+    """Mirror ``extra_server_args`` / ``extra_envs`` onto ``baseline``.
+
+    Fills the fields from ``baseline.invocation`` when ``baseline`` lacks
+    them. Reads the legacy ``extra_sglang_args`` key but always writes the
+    canonical ``extra_server_args``.
+
+    Args:
+        data: The session summary data dict (mutated in place).
+
+    Returns:
+        Human-readable notes describing each patch applied.
     """
     notes = []
     baseline = data.get("baseline")

--- a/critic-agent/runtime/decision_reviewer.py
+++ b/critic-agent/runtime/decision_reviewer.py
@@ -133,7 +133,17 @@ _APPROVE_REQUIRES_BY_CLASS: dict[str, tuple[str, ...]] = {
 
 
 def classify_proposal_action(action_name: str | None) -> str:
-    """Map ``action_name`` to a review class; unknown/missing → evidence_producer (cold-start safe)."""
+    """Map an action name to its review class.
+
+    Unknown or missing actions fall back to the evidence-producer class,
+    which is the cold-start-safe default.
+
+    Args:
+        action_name: The proposed action's name, if any.
+
+    Returns:
+        The review class constant for the action.
+    """
     if not isinstance(action_name, str):
         return ACTION_CLASS_EVIDENCE_PRODUCER
     name = action_name.strip()
@@ -162,8 +172,15 @@ def _discover_robustness_findings_path(session_id: str) -> Path | None:
     """Locate ``<session>.jsonl`` from the Robustness FindingSink.
 
     Resolution order: ``$CRITIC_ROBUSTNESS_FINDINGS_DIR`` (explicit override
-    dir) then ``$ROBUSTNESS_AGENT_SESSION_DIR`` (auto-discovery). Returns
-    ``None`` when neither env is set or the file does not exist.
+    dir) then ``$ROBUSTNESS_AGENT_SESSION_DIR`` (auto-discovery).
+
+    Args:
+        session_id: Session identifier used to build the ``<session>.jsonl``
+            filename (falls back to ``"default"`` when empty).
+
+    Returns:
+        Path to the findings file, or ``None`` when neither env var is set
+        or the file does not exist.
     """
     explicit = os.environ.get("CRITIC_ROBUSTNESS_FINDINGS_DIR", "").strip()
     if explicit:
@@ -188,7 +205,18 @@ def _load_robustness_priors(
     limit: int,
     min_severity: str,
 ) -> list[dict[str, Any]]:
-    """Tail the JSONL and return up to ``limit`` priors matching severity."""
+    """Tail the JSONL and return priors that meet the severity floor.
+
+    Args:
+        path: Path to the robustness findings JSONL file.
+        limit: Maximum number of priors to return.
+        min_severity: Minimum severity to include (``"high"``,
+            ``"medium"``, or ``"low"``).
+
+    Returns:
+        Up to ``limit`` prior records matching the severity filter; an
+        empty list if the file cannot be read.
+    """
     min_rank = _SEVERITY_RANK.get(min_severity, _SEVERITY_RANK["high"])
     try:
         text = path.read_text(encoding="utf-8")
@@ -756,6 +784,14 @@ class DecisionReviewer:
         With ``proposals``, ``approve_requires`` is the batch's strictest
         action class and ``proposal_action_classes`` carries the per-proposal
         bar; empty/None defaults to the strict ``patch_landing`` checklist.
+
+        Args:
+            proposals: Proposals in the bundle; when ``None`` or empty the
+                strict patch-landing checklist is used.
+
+        Returns:
+            A constraints payload with allowed verdicts, the approval
+            checklist, and (when proposals are given) per-proposal classes.
         """
         constraints: dict[str, Any] = {
             "allowed_verdicts": sorted(ALLOWED_VERDICTS),

--- a/framework-agent/src/framework_agent/decision.py
+++ b/framework-agent/src/framework_agent/decision.py
@@ -13,11 +13,21 @@ def winner_decision(
     accuracy: float | None,
     completed: str,
 ) -> tuple[bool, str]:
-    """Apply throughput / accuracy / completed gates, short-circuiting on first miss; returns ``(is_winner, reason)`` with ``reason`` always set for audit.
+    """Apply throughput / accuracy / completed gates for a candidate.
 
-    Gates: (1) throughput > 0 and ratio >= min_throughput_ratio;
-    (2) when baseline accuracy set, accuracy present and drop <=
-    max_accuracy_drop; (3) ``completed`` "K/N" must have K == N.
+    Short-circuits on the first failing gate: (1) throughput > 0 and ratio
+    >= ``min_throughput_ratio``; (2) when baseline accuracy is set, accuracy
+    present and drop <= ``max_accuracy_drop``; (3) ``completed`` "K/N" must
+    have K == N.
+
+    Args:
+        req: The explore request carrying baseline and thresholds.
+        throughput: Candidate throughput, or ``None`` if unmeasured.
+        accuracy: Candidate accuracy, or ``None`` if unmeasured.
+        completed: Benchmark completion marker in ``"K/N"`` form.
+
+    Returns:
+        A ``(is_winner, reason)`` tuple; ``reason`` is always set for audit.
     """
     if throughput is None or throughput <= 0:
         return False, "missing throughput"
@@ -52,7 +62,20 @@ def candidate_score(
     throughput: float | None,
     accuracy: float | None,
 ) -> float:
-    """Sortable ranking score = ``throughput_ratio - accuracy_drop_penalty`` (higher is better); missing throughput scores 0 so failed candidates sort to the tail."""
+    """Compute a sortable ranking score for a candidate.
+
+    The score is ``throughput_ratio - accuracy_drop_penalty`` (higher is
+    better); missing throughput scores ``0.0`` so failed candidates sort to
+    the tail.
+
+    Args:
+        req: The explore request carrying baseline and thresholds.
+        throughput: Candidate throughput, or ``None`` if unmeasured.
+        accuracy: Candidate accuracy, or ``None`` if unmeasured.
+
+    Returns:
+        The ranking score as a float.
+    """
     if throughput is None or throughput <= 0 or req.baseline.throughput <= 0:
         return 0.0
     ratio = throughput / req.baseline.throughput

--- a/framework-agent/src/framework_agent/explorer.py
+++ b/framework-agent/src/framework_agent/explorer.py
@@ -227,7 +227,23 @@ def _extract_changed_files(
 
 
 def _enrich_candidate_via_primus(req: ExploreRequest, candidate: Candidate) -> Candidate:
-    """Fetch pr_get + pr_files for PR-typed candidates (hard-fails on primus errors); branch / tag / commit refs returned unchanged."""
+    """Enrich a PR-typed candidate with metadata from Primus Cortex.
+
+    Fetches ``pr_get`` + ``pr_files`` for PR candidates; branch / tag /
+    commit refs are returned unchanged.
+
+    Args:
+        req: The explore request carrying the Primus Cortex config.
+        candidate: The candidate to enrich.
+
+    Returns:
+        The enriched candidate, or the original when enrichment does not
+        apply.
+
+    Raises:
+        primus_cortex.PrimusCortexError: If the repo URL is malformed or a
+            required Primus call fails.
+    """
     if req.primus_cortex is None:
         return candidate
     number = candidate.pr_number
@@ -263,7 +279,19 @@ def _enrich_candidate_via_primus(req: ExploreRequest, candidate: Candidate) -> C
 
 
 def _passes_filter(c: Candidate, f: PrFilter) -> tuple[bool, str]:
-    """Apply :class:`PrFilter` to one candidate: ``(True, '')`` on empty filter or pass, ``(False, reason)`` otherwise; metadata-dependent constraints fail when that metadata is missing (enrichment skipped)."""
+    """Apply a :class:`PrFilter` to one candidate.
+
+    Metadata-dependent constraints fail when the required metadata is
+    missing (e.g. enrichment was skipped).
+
+    Args:
+        c: The candidate to test.
+        f: The filter to apply.
+
+    Returns:
+        ``(True, "")`` on an empty filter or a pass, otherwise
+        ``(False, reason)`` describing the first failing constraint.
+    """
     if f.is_empty:
         return True, ""
 
@@ -321,7 +349,19 @@ def _passes_filter(c: Candidate, f: PrFilter) -> tuple[bool, str]:
 def _enumerate_with_skipped(
     req: ExploreRequest,
 ) -> tuple[list[Candidate], list[dict[str, str]]]:
-    """Return ``(kept, skipped)`` after enrichment + filtering: unions sources, enriches PR candidates via primus, then applies ``req.pr_filter``; explicit candidates bypass the filter (operator intent wins) but are still enriched."""
+    """Enumerate, enrich, and filter candidates.
+
+    Unions the configured sources, enriches PR candidates via Primus, then
+    applies ``req.pr_filter``. Explicit candidates bypass the filter
+    (operator intent wins) but are still enriched.
+
+    Args:
+        req: The explore request.
+
+    Returns:
+        A ``(kept, skipped)`` tuple where ``skipped`` entries carry the
+        ref, source, and skip reason.
+    """
     from .sources import enumerate_candidates as _enum_raw
 
     raw = _enum_raw(req)
@@ -398,10 +438,20 @@ def _prepare_candidate_workspace_with_artifacts(
     index: int,
     execute: bool,
 ) -> tuple[WorkspacePaths, dict[str, str]]:
-    """Drop audit material (``pr.patches`` / ``pr_files.json``) per candidate
-    regardless of execute mode, then delegate the worktree + venv step to
-    :mod:`isolation` when execute is True. Returns ``(WorkspacePaths,
-    artifact_paths)``.
+    """Prepare a candidate workspace and drop its audit artifacts.
+
+    Drops audit material (``pr.patches`` / ``pr_files.json``) for the
+    candidate regardless of execute mode, then delegates the worktree +
+    venv step to :mod:`isolation` when ``execute`` is True.
+
+    Args:
+        req: The explore request.
+        candidate: The candidate to prepare.
+        index: Zero-based candidate index (used in the directory name).
+        execute: Whether to materialize the worktree and venv.
+
+    Returns:
+        A ``(WorkspacePaths, artifact_paths)`` tuple.
     """
     candidate_dir = req.work_dir / "candidates" / f"{index:02d}_{candidate.slug}"
     candidate_dir.mkdir(parents=True, exist_ok=True)
@@ -415,9 +465,23 @@ def _prepare_candidate_workspace_with_artifacts(
 def _write_pr_artifacts(
     req: ExploreRequest, candidate: Candidate, candidate_dir: Path
 ) -> dict[str, str]:
-    """Drop ``pr.patches`` + ``pr_files.json`` per PR candidate. No-op when
-    primus_cortex is unconfigured or the candidate is not a PR ref;
-    hard-fails on network errors (CLI converts to exit code 2).
+    """Write ``pr.patches`` + ``pr_files.json`` for a PR candidate.
+
+    No-op when Primus Cortex is unconfigured or the candidate is not a PR
+    ref; hard-fails on network errors (the CLI converts these to exit
+    code 2).
+
+    Args:
+        req: The explore request carrying the Primus config and repo URL.
+        candidate: The candidate whose artifacts to write.
+        candidate_dir: Directory to write the artifacts into.
+
+    Returns:
+        A mapping of artifact names to written file paths (empty when the
+        candidate is not a PR or Primus is unconfigured).
+
+    Raises:
+        primus_cortex.PrimusCortexError: If the repo URL is malformed.
     """
     if req.primus_cortex is None:
         return {}
@@ -532,6 +596,15 @@ def _run_single_candidate(
     free beyond the workspace it owns. Concurrency safety: callers must
     ensure two candidates never share an ``index`` (slug collisions could
     overwrite material).
+
+    Args:
+        req: The explore request.
+        candidate: The candidate to run.
+        index: Unique candidate index (must be distinct across callers).
+        execute: When False, plan only; when True, build and benchmark.
+
+    Returns:
+        The :class:`CandidateResult` for the candidate.
     """
     workspace, artifact_paths = _prepare_candidate_workspace_with_artifacts(
         req, candidate, index=index, execute=execute,
@@ -610,10 +683,19 @@ async def _run_candidates_concurrent(
     *,
     execute: bool,
 ) -> list[CandidateResult]:
-    """Run candidates with ``asyncio.gather`` bounded by a ``build_concurrency``
-    semaphore. Each task wraps :func:`_run_single_candidate` in
+    """Run candidates concurrently, bounded by a ``build_concurrency`` semaphore.
+
+    Each task wraps :func:`_run_single_candidate` in
     :func:`asyncio.to_thread`; bench/accuracy stay inside the worker so two
     candidates only overlap when concurrency > 1 (the explicit user knob).
+
+    Args:
+        req: The explore request.
+        candidates: Candidates to run.
+        execute: Whether to build and benchmark (vs plan only).
+
+    Returns:
+        The per-candidate results in submission order.
     """
     semaphore = asyncio.Semaphore(max(1, req.build_concurrency))
 
@@ -713,6 +795,17 @@ def explore(req: ExploreRequest, *, execute: bool = False) -> dict[str, Any]:
 
     Disk preflight (execute=True and ``disk_min_free_gb != 0``) runs first;
     failure raises :class:`isolation.DiskPreflightError`.
+
+    Args:
+        req: The explore request driving the run.
+        execute: When False, plan only; when True, build and benchmark.
+
+    Returns:
+        A summary dict describing the run, candidates, winner, and KB
+        contribution.
+
+    Raises:
+        isolation.DiskPreflightError: If the disk preflight check fails.
     """
     log.info(
         "explore start framework=%s repo=%s work_dir=%s execute=%s "
@@ -819,8 +912,16 @@ def _contribute_findings_to_kb(
 
     Fires only when ``execute=True``, ``req.kb_domain`` is non-empty, and a
     ``winner`` exists. Best-effort: any KB write error is captured into the
-    returned ``kb_contribution`` metadata dict so the explore summary stays
-    usable even if the KB directory is read-only.
+    returned metadata dict so the explore summary stays usable even if the
+    KB directory is read-only.
+
+    Args:
+        req: The explore request (supplies KB domain and baseline).
+        winner: The winning candidate result, if any.
+        execute: Whether the run was in execute mode.
+
+    Returns:
+        A ``kb_contribution`` metadata dict with a ``status`` field.
     """
     if not execute or not req.kb_domain or winner is None:
         return {"status": "skipped", "reason": "execute+kb_domain+winner required"}

--- a/framework-agent/src/framework_agent/isolation.py
+++ b/framework-agent/src/framework_agent/isolation.py
@@ -124,7 +124,17 @@ def disk_preflight(
 
     Required = ``max(min_free_gb, n_candidates * per_candidate_gb)``. The
     work_dir is created when missing so :func:`shutil.disk_usage` doesn't
-    fail. Raises :class:`DiskPreflightError` on failure.
+    fail.
+
+    Args:
+        work_dir: Working directory whose mount is checked.
+        n_candidates: Number of candidates used to size the requirement.
+        min_free_gb: Floor on required free space; resolved from env when
+            ``None``.
+        per_candidate_gb: Estimated disk per candidate in GB.
+
+    Raises:
+        DiskPreflightError: If free space is below the computed requirement.
     """
     floor_gb = _resolve_min_free_gb(min_free_gb)
     required_gb = max(floor_gb, float(n_candidates) * per_candidate_gb)
@@ -247,9 +257,17 @@ def prepare_candidate_workspace(
 ) -> WorkspacePaths:
     """Materialise ``candidate_dir`` + (when execute) worktree + venv.
 
-    Returns :class:`WorkspacePaths`. ``execute=False`` /
-    ``prepare_candidate_env=False`` short-circuits before the git worktree
-    and venv steps so plan mode stays cheap.
+    ``execute=False`` / ``prepare_candidate_env=False`` short-circuits
+    before the git worktree and venv steps so plan mode stays cheap.
+
+    Args:
+        req: The explore request (work dir + env policy).
+        candidate: The candidate to prepare a workspace for.
+        index: Candidate index used in the directory name.
+        execute: Whether to materialize the worktree and venv.
+
+    Returns:
+        The :class:`WorkspacePaths` for the candidate.
     """
     candidate_dir = req.work_dir / "candidates" / f"{index:02d}_{candidate.slug}"
     worktree_dir = candidate_dir / "worktree"
@@ -310,6 +328,12 @@ def cleanup_workspace(
     but ``candidate_dir`` (and its ``pr.patches`` / ``pr_files.json`` audit
     artefacts) is kept so reviewers can still diff. Best-effort: cleanup
     errors are logged, never re-raised.
+
+    Args:
+        workspace: Paths for the candidate workspace to clean up.
+        is_winner: Whether this candidate is a winner (winners are kept).
+        keep_winner_only: When False, nothing is removed.
+        repo_dir: Mirror repo dir used to detach the worktree cleanly.
     """
     if not keep_winner_only or is_winner:
         return

--- a/framework-agent/src/framework_agent/kb.py
+++ b/framework-agent/src/framework_agent/kb.py
@@ -34,9 +34,14 @@ def path_for_framework(framework: str) -> Path:
     Returns ``<KB_ROOT>/framework_optimization/<framework_lower>/``; the name
     is lowercased and stripped (``"  Atom  "`` and ``"ATOM"`` resolve to
     ``"atom"``). The partition dir may not exist until
-    ``contribute_to_kb_for_framework`` creates it. Empty / whitespace-only
-    names resolve to the ``framework_optimization`` root (treat as "not
-    selected" and fall back to the ``framework`` domain bag).
+    ``contribute_to_kb_for_framework`` creates it.
+
+    Args:
+        framework: Framework name; empty / whitespace-only resolves to the
+            ``framework_optimization`` root (treated as "not selected").
+
+    Returns:
+        The KB partition path for the framework.
     """
     fw = (framework or "").strip().lower()
     root = _resolve_kb_root()
@@ -57,6 +62,15 @@ def contribute_to_kb_for_framework(
     :func:`path_for_framework`, for findings tied to a specific framework
     rather than a cross-framework domain. Partition dir is created lazily on
     first write.
+
+    Args:
+        framework: Framework whose partition to write to.
+        finding: The finding body (Markdown).
+        source: Provenance string recorded in the entry header.
+        session_id: Session identifier recorded in the entry header.
+
+    Returns:
+        Path to the ``empirical_kb.md`` file that was appended to.
     """
     fw_dir = path_for_framework(framework)
     fw_dir.mkdir(parents=True, exist_ok=True)
@@ -106,6 +120,9 @@ def _resolve_kb_root() -> Path:
 
     Order: (1) ``FRAMEWORK_AGENT_KB_DIR``; (2) ``${FRAMEWORK_AGENT_ROOT}/kb``;
     (3) ``${repo}/framework-agent/kb`` derived from this file's location.
+
+    Returns:
+        The resolved KB root path.
     """
     explicit = os.environ.get("FRAMEWORK_AGENT_KB_DIR", "").strip()
     if explicit:
@@ -338,6 +355,13 @@ def _synthesize_pure_python(domain: str, findings: list[Finding]) -> str:
 
     Layout: ``## Synthesised findings - <domain>``, one ``###`` section per
     finding, then ``## Aggregate metrics`` when metric keys repeat.
+
+    Args:
+        domain: Domain label for the digest header.
+        findings: Findings to render.
+
+    Returns:
+        The deterministic Markdown digest.
     """
     if not findings:
         return f"## Synthesised findings - {domain}\n\n_no findings_\n"
@@ -387,9 +411,22 @@ def _synthesize_via_llm(
     *,
     model: str,
 ) -> str:
-    """Distil findings via claude_agent_sdk. ImportError surfaces a
-    RuntimeError with install hint; network / SDK errors are not caught so
-    misconfiguration is loud.
+    """Distil findings via claude_agent_sdk.
+
+    Network / SDK errors are not caught so misconfiguration is loud.
+
+    Args:
+        domain: Domain label for the synthesis.
+        findings: Findings to summarize.
+        model: SDK model identifier to use.
+
+    Returns:
+        The LLM-synthesized Markdown, falling back to the pure-Python
+        digest when the SDK returns nothing.
+
+    Raises:
+        RuntimeError: If ``claude_agent_sdk`` is missing or lacks required
+            attributes.
     """
     try:
         import claude_agent_sdk as sdk  # type: ignore  # noqa: F401
@@ -431,6 +468,12 @@ def _iter_message_text(message) -> Iterable[str]:
 
     Accepts a plain string, ``.text``, or a ``.content`` list of blocks each
     with ``.text`` (SDK message shape varies across versions).
+
+    Args:
+        message: An SDK message object or string.
+
+    Yields:
+        Each non-empty text fragment found on the message.
     """
     if isinstance(message, str):
         yield message
@@ -457,6 +500,15 @@ def synthesize_findings(
 
     Default is pure-Python (deterministic, no SDK/network). ``with_llm=True``
     routes through a lazy-imported claude_agent_sdk.
+
+    Args:
+        domain: Domain label for the synthesis.
+        findings: Findings to distill.
+        with_llm: Whether to route through the LLM synthesizer.
+        model: SDK model identifier (used only when ``with_llm`` is True).
+
+    Returns:
+        The synthesized Markdown blob.
     """
     if not with_llm:
         return _synthesize_pure_python(domain, findings)
@@ -466,8 +518,13 @@ def synthesize_findings(
 def search_kb(query: str, *, domains: list[str] | None = None) -> list[KBFile]:
     """Case-insensitive substring search across all (or selected) domains.
 
-    Returns deduplicated KBFile records whose ``content`` contains ``query``;
-    order follows :func:`_prioritized_files` within each domain.
+    Args:
+        query: Substring to search for (matched case-insensitively).
+        domains: Domains to search; defaults to all known domains.
+
+    Returns:
+        Deduplicated :class:`KBFile` records whose ``content`` contains the
+        query, ordered per :func:`_prioritized_files` within each domain.
     """
     needle = query.lower()
     domains = domains or list_domains()

--- a/framework-agent/src/framework_agent/kb.py
+++ b/framework-agent/src/framework_agent/kb.py
@@ -411,6 +411,12 @@ def _synthesize_via_llm(
     import asyncio
 
     async def _drive() -> None:
+        """Stream the SDK query and accumulate text into ``chunks``.
+
+        Iterates the async generator returned by ``sdk.query`` and appends every
+        non-empty text fragment from each message to the enclosing ``chunks``
+        list.
+        """
         async for message in sdk.query(prompt=prompt, options=options):
             for text in _iter_message_text(message):
                 if text:

--- a/framework-agent/src/framework_agent/keywords.py
+++ b/framework-agent/src/framework_agent/keywords.py
@@ -50,6 +50,12 @@ def extract_keywords(description: str) -> list[str]:
 
     Whitelist hits first, then CamelCase identifiers; if nothing matched,
     fall back to the first five 3+ letter words so callers get some signal.
+
+    Args:
+        description: The gap description text to mine.
+
+    Returns:
+        A sorted, deduplicated list of keywords.
     """
     tokens = set(re.findall(r"[a-z][a-z0-9_]+", description.lower()))
     keywords = tokens & _TECHNICAL_TERMS
@@ -66,7 +72,13 @@ def score_title_against_keywords(title: str, keywords: Sequence[str]) -> int:
     """Count keywords overlapping the title's tokens, to rerank candidate PRs.
 
     Lowercase, snake_case-aware token split mirrors :func:`extract_keywords`.
-    Returns 0 for an empty title or empty keywords list.
+
+    Args:
+        title: The PR title to score.
+        keywords: Keywords to match against the title.
+
+    Returns:
+        The overlap count; ``0`` for an empty title or keyword list.
     """
     if not keywords or not title:
         return 0
@@ -130,10 +142,16 @@ def score_title_with_anti_signal(
 
     ``positive`` = keyword tokens in the title; ``anti`` = title tokens in the
     anti-set of any active gap keyword (only :data:`_ANTI_KEYWORDS` entries
-    activate). Default ``anti_penalty`` of 2.0 means one anti hit erases two
+    activate). A default ``anti_penalty`` of 2.0 means one anti hit erases two
     positive hits, so a wrong-axis PR ranks below any single correct-axis hit.
-    Clamped to 0.0 so callers can post-filter ``score == 0`` to drop
-    anti-heavy PRs.
+
+    Args:
+        title: The PR title to score.
+        keywords: Active gap keywords driving positive and anti matches.
+        anti_penalty: Weight applied per anti-signal hit.
+
+    Returns:
+        The clamped score (>= 0.0); callers can drop ``score == 0`` PRs.
     """
     if not keywords or not title:
         return 0.0

--- a/framework-agent/src/framework_agent/logging_setup.py
+++ b/framework-agent/src/framework_agent/logging_setup.py
@@ -118,6 +118,15 @@ def configure_logging(
 
     Idempotent: each call clears previously attached handlers so re-running
     does not stack duplicates.
+
+    Args:
+        level: Log level (name or int); resolved from env when ``None``.
+        json_output: Force JSON line output; resolved from env when ``None``.
+        log_file: Optional file path to also write logs to.
+        quiet_third_party: Raise noisy third-party loggers to WARNING.
+
+    Returns:
+        The configured root logger.
     """
     use_json = (
         json_output
@@ -199,8 +208,15 @@ def stage_log(
 ) -> Iterator[dict[str, Any]]:
     """Bracket a per-stage block with start/done/failed envelopes.
 
-    Yields a mutable dict so the caller can attach result metrics (e.g.
-    ``ctx["throughput"] = 1234.5``) before the ``done`` envelope fires.
+    Args:
+        logger: Logger to emit the stage envelopes on.
+        stage: Stage name included in each envelope.
+        candidate: Optional candidate ref for context.
+        **fields: Extra structured fields attached to the envelopes.
+
+    Yields:
+        A mutable dict so the caller can attach result metrics (e.g.
+        ``ctx["throughput"] = 1234.5``) before the ``done`` envelope fires.
     """
     started = time.monotonic()
     base: dict[str, Any] = {"stage": stage}

--- a/framework-agent/src/framework_agent/models.py
+++ b/framework-agent/src/framework_agent/models.py
@@ -310,7 +310,15 @@ def _parse_keywords(raw: Any) -> tuple[str, ...]:
 
     None/empty -> ``()`` (auto-extract from gap_description); string ->
     split on comma/whitespace; list/tuple -> trimmed non-empty items.
-    Anything else raises ``ValueError``.
+
+    Args:
+        raw: The raw ``keywords`` value to coerce.
+
+    Returns:
+        A tuple of trimmed keyword strings (empty when unset).
+
+    Raises:
+        ValueError: If ``raw`` is present but not a list/tuple/str.
     """
     if raw is None or raw == "":
         return ()

--- a/framework-agent/src/framework_agent/runtime/tools_api.py
+++ b/framework-agent/src/framework_agent/runtime/tools_api.py
@@ -63,14 +63,30 @@ def find_relevant_prs_smart(
     primus_label: str | None = None,
     include_github: bool = True,
 ) -> list[Candidate]:
-    """Discover candidate PRs across one or more repos (plain-arg version of
-    :func:`framework_agent.sources.enumerate_candidates`).
+    """Discover candidate PRs across one or more repos.
 
-    Each repo is queried via primus_cortex (hard-fail) when
-    ``primus_cortex_url`` is set; GitHub Search is a best-effort secondary
-    when ``include_github=True`` (returns ``[]``, never raises). Results are
-    de-duped by ``(repo_url, ref)`` so primus_cortex wins ties. Returns ``[]``
-    when ``repos`` is empty.
+    Plain-arg version of
+    :func:`framework_agent.sources.enumerate_candidates`. Each repo is
+    queried via primus_cortex (hard-fail) when ``primus_cortex_url`` is set;
+    GitHub Search is a best-effort secondary when ``include_github=True``
+    (returns ``[]``, never raises). Results are de-duped by
+    ``(repo_url, ref)`` so primus_cortex wins ties.
+
+    Args:
+        gap_description: Description used to drive GitHub search relevance.
+        repos: Repos to query; ``None``/empty yields ``[]``.
+        primus_cortex_url: Primus Cortex base URL; enables that source.
+        primus_timeout_sec: Per-request timeout for Primus calls.
+        limit_per_repo: Max candidates per repo per source.
+        primus_state: PR state filter for Primus (e.g. ``"open"``).
+        primus_label: Optional label filter for Primus.
+        include_github: Whether to also query GitHub search.
+
+    Returns:
+        De-duplicated candidate list across all repos and sources.
+
+    Raises:
+        PrimusCortexError: If a Primus query fails when configured.
     """
     if not repos:
         return []
@@ -118,11 +134,24 @@ def fetch_pr_audit_material(
     primus_cortex_url: str,
     primus_timeout_sec: float = 30.0,
 ) -> dict[str, str]:
-    """Download ``pr.patches`` (unified diff) and ``pr_files.json``
-    ({repo, number, files}) for a single PR under ``out_dir``.
+    """Download a PR's audit material (patches + files) under ``out_dir``.
 
-    Returns the absolute paths in a dict. Hard-fails (raises
-    ``PrimusCortexError``) on primus_cortex transport / parse errors.
+    Writes ``pr.patches`` (unified diff) and ``pr_files.json``
+    (``{repo, number, files}``).
+
+    Args:
+        repo_url: Repository URL the PR belongs to.
+        pr_number: PR number to fetch.
+        out_dir: Directory to write the artifacts into (created if needed).
+        primus_cortex_url: Primus Cortex base URL.
+        primus_timeout_sec: Per-request timeout for Primus calls.
+
+    Returns:
+        A dict of absolute artifact paths (``patches_path``,
+        ``files_json_path``).
+
+    Raises:
+        PrimusCortexError: On Primus transport / parse errors.
     """
     out = Path(out_dir).expanduser()
     out.mkdir(parents=True, exist_ok=True)
@@ -210,8 +239,22 @@ def evaluate_candidate_outcome(
 
     Gate logic matches the CLI's winner decision. Inputs accept a dict, a
     Path, or a string path; missing/invalid inputs yield a ``False`` verdict
-    with a reason rather than raising. Returns a dict with keys ``winner``,
-    ``reason``, ``throughput``, ``accuracy``, ``throughput_ratio``, ``completed``.
+    with a reason rather than raising.
+
+    Args:
+        benchmark: Benchmark data (dict, JSON path, or ``None``).
+        accuracy: Accuracy data (dict, JSON path, or ``None``).
+        baseline_throughput: Baseline throughput; must be positive.
+        baseline_accuracy: Baseline accuracy, if accuracy is gated.
+        min_throughput_ratio: Minimum throughput ratio to win.
+        max_accuracy_drop: Maximum tolerated accuracy drop.
+
+    Returns:
+        A dict with keys ``winner``, ``reason``, ``throughput``,
+        ``accuracy``, ``throughput_ratio``, and ``completed``.
+
+    Raises:
+        ValueError: If ``baseline_throughput`` is not a positive float.
     """
     if baseline_throughput is None or baseline_throughput <= 0:
         raise ValueError("baseline_throughput must be a positive float")

--- a/framework-agent/src/framework_agent/shell.py
+++ b/framework-agent/src/framework_agent/shell.py
@@ -74,8 +74,19 @@ def render_template(
     """Render known ``{var}`` placeholders, raise on unknown placeholders.
 
     Leaves JSON-style ``{...}`` braces that don't match the
-    ``[A-Za-z_][A-Za-z0-9_]*`` identifier pattern untouched. ``shell_quote=True``
-    wraps each value in :func:`shlex.quote` for shell-bound strings.
+    ``[A-Za-z_][A-Za-z0-9_]*`` identifier pattern untouched.
+
+    Args:
+        template: Template string with ``{var}`` placeholders.
+        variables: Mapping of placeholder names to replacement values.
+        shell_quote: When True, wrap each value in :func:`shlex.quote` for
+            shell-bound strings.
+
+    Returns:
+        The rendered string.
+
+    Raises:
+        ValueError: If any ``{identifier}`` placeholder is left unresolved.
     """
     rendered = template
     for key, value in variables.items():

--- a/framework-agent/src/framework_agent/sources/__init__.py
+++ b/framework-agent/src/framework_agent/sources/__init__.py
@@ -64,8 +64,15 @@ def _pr_to_candidate(
 ) -> Candidate:
     """Convert a GitHubPr (any backend) into a downstream Candidate.
 
-    ``score`` is the gap-relevance value from :func:`_rank_by_keyword_overlap`;
-    0.0 for paths that skip ranking (explicit refs, label-only listing).
+    Args:
+        pr: The source PR record.
+        repo_url: Repository URL the PR belongs to.
+        source: Source label recorded on the candidate (e.g. ``"github"``).
+        score: Gap-relevance value from :func:`_rank_by_keyword_overlap`;
+            ``0.0`` for paths that skip ranking.
+
+    Returns:
+        The downstream :class:`Candidate`.
     """
     return Candidate(
         ref=pr.ref,
@@ -168,6 +175,12 @@ def _resolve_keywords(request: ExploreRequest) -> list[str]:
     Priority: (1) ``request.keywords`` non-empty -> used verbatim (lowercased,
     bypasses extract_keywords); (2) ``gap_description`` -> auto-extract via
     :func:`extract_keywords`; (3) else ``[]`` (label-only path).
+
+    Args:
+        request: The explore request carrying keywords / gap description.
+
+    Returns:
+        The resolved keyword list (possibly empty).
     """
     if request.keywords:
         return [k.lower() for k in request.keywords if k.strip()]
@@ -183,8 +196,14 @@ def _rank_by_keyword_overlap(
 
     Uses :func:`score_title_with_anti_signal` so wrong-axis PRs (e.g.
     ``MegaMoE`` when gap calls for ``dense``) are demoted below correct-axis
-    PRs. Higher score first; ties preserve upstream order. Zero-score PRs drop
-    to the tail but are not filtered out. Anti-signal is gated per-gap-keyword.
+    PRs. Zero-score PRs drop to the tail but are not filtered out.
+
+    Args:
+        prs: PRs to rerank.
+        keywords: Active keywords driving the score.
+
+    Returns:
+        PRs sorted by descending score; ties preserve upstream order.
     """
     if not keywords:
         return list(prs)
@@ -196,12 +215,22 @@ def _rank_by_keyword_overlap(
 
 
 def _run_primus_cortex(request: ExploreRequest) -> list[Candidate]:
-    """Query primus-cortex with gap-aware ranking; hard-fail on transport errors.
+    """Query primus-cortex with gap-aware ranking.
 
     With non-empty keywords, prefer the free-text ``/v1/search/prs`` endpoint
     (over-fetch, then client-rerank by title overlap, trim to
     ``max_search_candidates``); fall back to ``list_perf_prs`` if search is
     unimplemented. With no keywords, use the cheap label-only path.
+
+    Args:
+        request: The explore request carrying the Primus config.
+
+    Returns:
+        Candidates from Primus Cortex, ranked when keywords are present.
+
+    Raises:
+        SourceConfigError: If ``primus_cortex`` is requested without config.
+        PrimusCortexError: On Primus transport errors.
     """
     cfg = request.primus_cortex
     if cfg is None:

--- a/framework-agent/src/framework_agent/sources/_shared.py
+++ b/framework-agent/src/framework_agent/sources/_shared.py
@@ -40,8 +40,16 @@ class GitHubPr:
 def _repo_slug(repo_url: str) -> str:
     """Parse ``owner/name`` from a GitHub-style git URL.
 
-    Accepts https (+/- .git) and ssh forms. Raises ValueError on a non-GitHub
-    or malformed URL.
+    Accepts https (+/- .git) and ssh forms.
+
+    Args:
+        repo_url: The repository URL to parse.
+
+    Returns:
+        The ``owner/name`` slug.
+
+    Raises:
+        ValueError: On a non-GitHub or malformed URL.
     """
     raw = repo_url.strip()
     if raw.endswith(".git"):

--- a/framework-agent/src/framework_agent/sources/primus_cortex.py
+++ b/framework-agent/src/framework_agent/sources/primus_cortex.py
@@ -242,10 +242,24 @@ def list_perf_prs(
     label: str | None = None,
     timeout_sec: float = 10.0,
 ) -> list[GitHubPr]:
-    """List PRs from primus-cortex; hard-fails on transport/parse errors.
+    """List PRs from primus-cortex.
 
     Returns :class:`GitHubPr` (same as the GitHub backend) so the dispatcher
     can union both sources without per-source branching.
+
+    Args:
+        repo_url: Repository URL to list PRs for.
+        base_url: Primus Cortex base URL.
+        limit: Maximum number of PRs to return.
+        state: PR state filter (e.g. ``"open"``).
+        label: Optional label filter.
+        timeout_sec: Per-request timeout.
+
+    Returns:
+        A list of :class:`GitHubPr` records.
+
+    Raises:
+        PrimusCortexError: On bad repo URL or transport/parse errors.
     """
     try:
         repo_slug = _repo_slug(repo_url)
@@ -353,6 +367,18 @@ def pr_patches(
     ``diff --git`` / ``--- a/`` / ``+++ b/`` headers per file so ``git apply``
     can consume it. Honours ``previous_path`` / ``status`` for renames+deletes;
     items missing ``patch`` (binary) emit only the file header.
+
+    Args:
+        repo_slug: ``owner/name`` repository slug.
+        number: PR number to fetch patches for.
+        base_url: Primus Cortex base URL.
+        timeout_sec: Per-request timeout.
+
+    Returns:
+        A unified-diff string suitable for ``git apply``.
+
+    Raises:
+        PrimusCortexError: On unexpected payload shapes or transport errors.
     """
     url = _build_url(base_url, f"/v1/repos/{repo_slug}/prs/{number}/patches")
     payload = _http_get_json(url, timeout_sec=timeout_sec)

--- a/inference_optimizer/baseline_comparison/target_analyzer.py
+++ b/inference_optimizer/baseline_comparison/target_analyzer.py
@@ -198,6 +198,14 @@ def _target_row_to_point(row: dict[str, Any]) -> BaselinePoint | None:
     present) is informational only and not folded into the point shape.
     """
     def _fnum(key: str) -> float:
+        """Read a float field from the enclosing ``row``.
+
+        Args:
+            key: Field name to look up.
+
+        Returns:
+            The value as a float, or ``0.0`` if missing or unparseable.
+        """
         try:
             return float(row.get(key))
         except (TypeError, ValueError):

--- a/inference_optimizer/baseline_comparison/target_analyzer.py
+++ b/inference_optimizer/baseline_comparison/target_analyzer.py
@@ -196,6 +196,13 @@ def _target_row_to_point(row: dict[str, Any]) -> BaselinePoint | None:
     Returns ``None`` when ``tput_per_gpu`` is missing or non-positive.
     ``tpot_ms`` is the per-output-token latency; ``interactivity`` (when
     present) is informational only and not folded into the point shape.
+
+    Args:
+        row: A single ``per_conc`` mapping from the competitor target data.
+
+    Returns:
+        A ``BaselinePoint`` built from the row, or ``None`` when the row has
+        no usable positive ``tput_per_gpu``.
     """
     def _fnum(key: str) -> float:
         """Read a float field from the enclosing ``row``.
@@ -253,6 +260,20 @@ def analyze(
     ``reason`` mirrors ``status`` with finer granularity:
     ``ok`` / ``model_mapping_miss`` / ``no_target_gpu_configured`` /
     ``no_competitor_target``.
+
+    Args:
+        session_dir: Session directory used to load competitor data and
+            persist the resulting summary.
+        model_path: Model path or name to map to a canonical display name.
+        compare_against_gpu: Target GPU to compare against; when empty the
+            analysis is skipped.
+        framework: Optional framework name recorded on the query.
+        precision: Optional precision label recorded on the query.
+        isl: Optional input sequence length recorded on the query.
+        osl: Optional output sequence length recorded on the query.
+
+    Returns:
+        The persisted ``BaselineSummary`` describing the comparison outcome.
     """
     from ..orchestrator import research_hints
 

--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -579,6 +579,14 @@ def _benchmark_report_candidates(root: Path) -> list[Path]:
 
 
 def _latest_benchmark_report(candidates: Iterable[Path]) -> Path | None:
+    """Return the most recently modified existing report among candidates.
+
+    Args:
+        candidates: Candidate report paths.
+
+    Returns:
+        The newest existing path by mtime, or ``None`` when none exist.
+    """
     reports = [p for p in candidates if p.exists()]
     if not reports:
         return None
@@ -669,6 +677,17 @@ def _close_phase_stop_reason(state: dict[str, Any]) -> tuple[str, str]:
 
 
 def _should_use_close_stop_reason(stop_reason: str, close_stop_reason: str) -> bool:
+    """Decide whether the CLOSE-phase stop reason should override the session's.
+
+    Args:
+        stop_reason: The session-level stop reason.
+        close_stop_reason: The CLOSE-phase stop reason.
+
+    Returns:
+        ``True`` when the close reason is more specific — i.e. it is set and the
+        session reason is empty, or the session merely timed out while the close
+        reason did not.
+    """
     if not close_stop_reason:
         return False
     if not stop_reason:
@@ -1521,6 +1540,17 @@ def collect_capability_summary(
     oob_invocations: list[dict[str, Any]],
     warnings: list[str],
 ) -> dict[str, Any]:
+    """Summarize kernel-optimization capability outcomes for the breakdown.
+
+    Args:
+        state: Session state mapping.
+        geak_invocations: GEAK backend invocation records.
+        oob_invocations: Out-of-box backend invocation records.
+        warnings: Mutable list that collected warnings are appended to.
+
+    Returns:
+        A capability-summary dict (per-kernel status, attempt and keep counts).
+    """
     # Integrate (e2e) outcome per kernel: a kernel-opt KEEP REVERTED at
     # integrate is not a real adoption, so don't inflate the geak/oob tally.
     integ = state.get("kernel_integrate_attempts") or {}
@@ -2716,6 +2746,15 @@ def collect_explore_search(
     state: dict[str, Any],
     warnings: list[str],
 ) -> dict[str, Any]:
+    """Collect the explore-phase search summary for the breakdown.
+
+    Args:
+        state: Session state mapping.
+        warnings: Mutable list that collected warnings are appended to.
+
+    Returns:
+        A dict summarizing the explore-phase search activity and outcomes.
+    """
     # Emit all three ledgers (unified explore + legacy params/backends) so
     # breakdown reprocesses both vintages; unused ones shape to empty shells.
     explore_ledger = _shape_ledger(state.get("explore_search"))
@@ -3379,6 +3418,21 @@ def collect_attribution(
     adopted_kernels: list[dict[str, Any]],
     warnings: list[str],
 ) -> dict[str, Any]:
+    """Attribute end-to-end gains to individual optimization-stack entries.
+
+    Prefers the authoritative ``gain_per_stack_entry`` ledger and falls back to
+    reconstructing attribution from the optimization stack.
+
+    Args:
+        state: Session state mapping.
+        geak_invocations: GEAK backend invocation records.
+        oob_invocations: Out-of-box backend invocation records.
+        adopted_kernels: Kernels adopted into the optimized stack.
+        warnings: Mutable list that collected warnings are appended to.
+
+    Returns:
+        An attribution dict mapping stack entries to their measured gains.
+    """
     # Prefer the authoritative ``gain_per_stack_entry`` ledger; else reconstruct from optimization_stack.
     state_entries = state.get("gain_per_stack_entry")
     state_provided = isinstance(state_entries, list) and len(state_entries) > 0
@@ -4192,6 +4246,15 @@ def collect_phase_segments(
     sub_events = [r for r in rows if not str(r.get("to_phase") or "")]
 
     def _unix(row: dict[str, Any]) -> float | None:
+        """Return a row's timestamp as a Unix epoch float.
+
+        Args:
+            row: Event row carrying ``ts_unix`` and/or ``ts``.
+
+        Returns:
+            The ``ts_unix`` value when numeric, else the parsed ISO ``ts``,
+            else ``None``.
+        """
         u = row.get("ts_unix")
         if isinstance(u, (int, float)):
             return float(u)
@@ -4679,6 +4742,11 @@ def _coerce_token(value: Any) -> int:
 
 
 def _empty_token_bucket() -> dict[str, int]:
+    """Return a fresh, zeroed token-rollup bucket.
+
+    Returns:
+        A dict with zeroed input/output/cache token totals and call count.
+    """
     return {
         "total_in": 0,
         "total_out": 0,
@@ -4689,6 +4757,12 @@ def _empty_token_bucket() -> dict[str, int]:
 
 
 def _fold_call_into_bucket(bucket: dict[str, int], call: dict[str, Any]) -> None:
+    """Add one call's token counts into a rollup bucket in place.
+
+    Args:
+        bucket: Token bucket to accumulate into (mutated).
+        call: Per-call record carrying token counters.
+    """
     bucket["total_in"] += _coerce_token(call.get(_TOKEN_IN_KEY))
     bucket["total_out"] += _coerce_token(call.get(_TOKEN_OUT_KEY))
     bucket["total_cache_creation"] += _coerce_token(

--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -41,7 +41,15 @@ _ENV_DENY_PATTERN = re.compile(
 
 
 def _filter_envs(envs: dict[str, Any] | None) -> dict[str, str]:
-    """Apply the allowlist + secret denylist; returns a fresh ``dict[str, str]`` (values stringified)."""
+    """Apply the allowlist + secret denylist; returns a fresh ``dict[str, str]`` (values stringified).
+
+    Args:
+        envs: Raw environment mapping to filter, or ``None``.
+
+    Returns:
+        A new dict containing only allowlisted, non-secret keys with
+        stringified values.
+    """
     if not isinstance(envs, dict):
         return {}
     out: dict[str, str] = {}
@@ -98,7 +106,14 @@ _SERVER_LOG_MAX_BYTES = 256 * 1024
 
 
 def _strip_log_prefix(line: str) -> str:
-    """Strip a leading ``[ts] LEVEL [src.py:NN]`` style prefix (incl. the process tag) from a log line."""
+    """Strip a leading ``[ts] LEVEL [src.py:NN]`` style prefix (incl. the process tag) from a log line.
+
+    Args:
+        line: A raw log line.
+
+    Returns:
+        The line with any leading log/timestamp prefix removed and trimmed.
+    """
     s = line
     s = _LOG_PREFIX_RE.sub("", s)
     s = _LOG_TIMESTAMP_RE.sub("", s)
@@ -132,6 +147,13 @@ def _load_yaml_dict_safe(config_yaml: Path) -> dict | None:
     """Parse ``config_yaml`` to its top-level dict, or ``None`` on miss/failure. Never raises.
 
     Shared by both yaml passes so the file is read at most once.
+
+    Args:
+        config_yaml: Path to the YAML config file.
+
+    Returns:
+        The parsed top-level dict, or ``None`` when PyYAML is unavailable,
+        the file cannot be read/parsed, or the root is not a mapping.
     """
     try:
         import yaml  # type: ignore[import-not-found]
@@ -148,7 +170,14 @@ def _load_yaml_dict_safe(config_yaml: Path) -> dict | None:
 
 
 def _yaml_cmd_from_dict(data: dict) -> str:
-    """Find a ``cmd`` / ``command`` / ``launch`` field (top-level or under ``benchmark``); ``""`` on miss."""
+    """Find a ``cmd`` / ``command`` / ``launch`` field (top-level or under ``benchmark``); ``""`` on miss.
+
+    Args:
+        data: Parsed YAML config dict.
+
+    Returns:
+        The first non-empty command string found, or ``""`` when none exists.
+    """
     for key in ("cmd", "command", "launch"):
         val = data.get(key)
         if isinstance(val, str) and val.strip():
@@ -167,6 +196,13 @@ def _yaml_benchmark_synthesis(data: dict) -> str:
 
     Returns ``""`` unless both ``benchmark.framework`` and
     ``benchmark.model`` are non-empty.
+
+    Args:
+        data: Parsed YAML config dict containing a ``benchmark`` mapping.
+
+    Returns:
+        A synthesized human-readable arg string, or ``""`` when the required
+        ``framework``/``model`` fields are missing.
     """
     bench = data.get("benchmark")
     if not isinstance(bench, dict):
@@ -213,6 +249,15 @@ def _extract_framework_args(
     priority order: ``log_non_default_args`` / ``log_args_line`` /
     ``log_python_cmd`` / ``yaml_cmd`` / ``yaml_benchmark`` (synthesized,
     not a literal cmdline) / ``unknown`` (empty args).
+
+    Args:
+        server_log: Path to the variant's server log, or ``None``.
+        config_yaml: Optional path to the variant config used as a fallback
+            source for the launch command.
+
+    Returns:
+        A ``(args_string, source)`` tuple; ``("", "unknown")`` when nothing
+        could be extracted.
     """
     chunk: str = ""
     if server_log is not None:
@@ -290,7 +335,15 @@ def _extract_framework_args(
 
 
 def _read_invocation_envs(config_path: Path | None) -> dict[str, str]:
-    """Read ``benchmark.envs`` (or top-level ``envs:``) from a variant config; allowlisted subset, never raises."""
+    """Read ``benchmark.envs`` (or top-level ``envs:``) from a variant config; allowlisted subset, never raises.
+
+    Args:
+        config_path: Path to the variant config YAML, or ``None``.
+
+    Returns:
+        The allowlisted, filtered environment mapping; empty when the file is
+        missing, unparseable, or has no envs.
+    """
     if config_path is None:
         return {}
     try:
@@ -511,6 +564,13 @@ def _benchmark_report_metrics(
 
     Priority: V2 nested (``throughput.*`` / ``latency.<m>.mean_ms``),
     pre-V2 flat top-level, then legacy ``result.<flat>``.
+
+    Args:
+        report: Parsed ``benchmark_report.json`` dict, or ``None``.
+
+    Returns:
+        A ``(output_throughput, ttft, tpot, e2el)`` tuple; each element is
+        ``None`` when the corresponding metric is absent.
     """
     if not isinstance(report, dict):
         return (None, None, None, None)
@@ -559,7 +619,14 @@ def _benchmark_report_metrics(
 
 
 def _benchmark_report_candidates(root: Path) -> list[Path]:
-    """Return benchmark reports under a task/workspace root (handles the several on-disk layouts used over time)."""
+    """Return benchmark reports under a task/workspace root (handles the several on-disk layouts used over time).
+
+    Args:
+        root: Task or workspace root directory to scan.
+
+    Returns:
+        Candidate ``benchmark_report.json`` paths (possibly empty).
+    """
     if not root.exists():
         return []
 
@@ -595,7 +662,14 @@ def _latest_benchmark_report(candidates: Iterable[Path]) -> Path | None:
 
 
 def _find_benchmark_report(workspace: Path | None) -> Path | None:
-    """Locate the most recent (by mtime) ``benchmark_report.json`` under a task workspace, else ``None``."""
+    """Locate the most recent (by mtime) ``benchmark_report.json`` under a task workspace, else ``None``.
+
+    Args:
+        workspace: Task workspace directory, or ``None``.
+
+    Returns:
+        The newest matching report path, or ``None`` when none exist.
+    """
     if workspace is None or not workspace.exists():
         return None
     return _latest_benchmark_report(_benchmark_report_candidates(workspace))
@@ -612,6 +686,15 @@ def _resolve_under_session(
     ``session_dir`` (container paths like ``/workspace/runs/...`` map to the
     wekafs ``<session_dir>/runs/...`` view). Returns the first existing
     path, else ``None``.
+
+    Args:
+        session_dir: Session root used to re-anchor container-rooted paths.
+        raw: The candidate path string, or ``None``.
+        anchors: Path segments to re-root under ``session_dir`` when the raw
+            path does not exist as-is.
+
+    Returns:
+        The first existing resolved path, or ``None``.
     """
     if not raw:
         return None
@@ -656,7 +739,15 @@ def _safe_get(d: Any, *keys: str, default: Any = None) -> Any:
 
 
 def _close_phase_stop_reason(state: dict[str, Any]) -> tuple[str, str]:
-    """Recover terminal reason/time from the CLOSE phase transition (next-best when ``state.stop_reason`` wasn't mirrored)."""
+    """Recover terminal reason/time from the CLOSE phase transition (next-best when ``state.stop_reason`` wasn't mirrored).
+
+    Args:
+        state: Session state mapping holding ``phase_history``.
+
+    Returns:
+        A ``(reason, timestamp)`` tuple from the CLOSE transition; both empty
+        when no CLOSE transition is recorded.
+    """
     history = state.get("phase_history") or []
     if not isinstance(history, list):
         return "", ""
@@ -1138,7 +1229,14 @@ def collect_final(
 
 
 def _find_latest_validate_stack_report(session_dir: Path) -> Path | None:
-    """Most-recent validate_stack benchmark_report.json (authoritative for the final stack's clock)."""
+    """Most-recent validate_stack benchmark_report.json (authoritative for the final stack's clock).
+
+    Args:
+        session_dir: Session root containing ``runs/validate_stack``.
+
+    Returns:
+        The newest validate_stack report path, or ``None`` when absent.
+    """
     root = session_dir / "runs" / "validate_stack"
     if not root.exists():
         return None
@@ -1153,7 +1251,15 @@ def _find_latest_validate_stack_report(session_dir: Path) -> Path | None:
 def _find_current_best_report(
     session_dir: Path, state: dict[str, Any],
 ) -> Path | None:
-    """Best-effort benchmark report for ``state.current_best`` (via workspace or action/variant/tput match)."""
+    """Best-effort benchmark report for ``state.current_best`` (via workspace or action/variant/tput match).
+
+    Args:
+        session_dir: Session root to search under.
+        state: Session state mapping holding ``current_best``.
+
+    Returns:
+        The matching benchmark report path, or ``None``.
+    """
     cb = state.get("current_best") or {}
     if not isinstance(cb, dict):
         return None
@@ -1168,7 +1274,15 @@ def _find_current_best_report(
 def _find_stack_top_report(
     session_dir: Path, state: dict[str, Any],
 ) -> Path | None:
-    """Last optimization_stack entry's benchmark_report.json (next-best when no validate_stack run exists)."""
+    """Last optimization_stack entry's benchmark_report.json (next-best when no validate_stack run exists).
+
+    Args:
+        session_dir: Session root to search under.
+        state: Session state mapping holding the optimization stack.
+
+    Returns:
+        The matching benchmark report path, or ``None``.
+    """
     cb = state.get("current_best") or {}
     stack = state.get("optimization_stack") or []
     if not stack and isinstance(cb, dict):
@@ -1193,7 +1307,16 @@ def _find_stack_top_report(
 def _find_matching_action_report(
     session_dir: Path, entry: dict[str, Any],
 ) -> Path | None:
-    """Match a report under ``runs/<action>/`` by variant name and tput (conservative; tput beats variant, latency-less reports skipped)."""
+    """Match a report under ``runs/<action>/`` by variant name and tput (conservative; tput beats variant, latency-less reports skipped).
+
+    Args:
+        session_dir: Session root to search under.
+        entry: Stack/current-best entry carrying ``action``, ``variant_name``
+            and ``tput`` used for matching.
+
+    Returns:
+        The highest-scoring matching report path, or ``None``.
+    """
     action = str(entry.get("action") or "").strip()
     if not action:
         return None
@@ -1234,7 +1357,18 @@ def _build_final_invocation(
     benchmark_report: Path | None,
     warnings: list[str],
 ) -> dict[str, Any]:
-    """Best-effort :class:`BenchmarkInvocation` for the final stack run (config = the launched ``*.with_envs.yaml`` sibling)."""
+    """Best-effort :class:`BenchmarkInvocation` for the final stack run (config = the launched ``*.with_envs.yaml`` sibling).
+
+    Args:
+        session_dir: Session root used to relativize discovered paths.
+        state: Session state mapping (reserved for future enrichment).
+        benchmark_report: The final stack's benchmark report path, or ``None``.
+        warnings: Accumulator appended to when arg extraction fails.
+
+    Returns:
+        A dict describing the final invocation (framework args, envs, config
+        and server-log paths).
+    """
     config_path: Path | None = None
     server_log_path: Path | None = None
     if benchmark_report is not None:
@@ -1281,7 +1415,14 @@ _AUDIT_ACTIONS = (
 
 
 def _parse_iso_unix(ts: Any) -> float | None:
-    """Best-effort ISO-8601 -> unix seconds. ``None`` on any failure."""
+    """Best-effort ISO-8601 -> unix seconds. ``None`` on any failure.
+
+    Args:
+        ts: Timestamp as an ISO-8601 string or numeric epoch seconds.
+
+    Returns:
+        Unix seconds as a float, or ``None`` when parsing fails.
+    """
     if ts is None:
         return None
     if isinstance(ts, (int, float)):
@@ -1303,6 +1444,13 @@ def _iso_z(ts: Any) -> str:
     The journal and ``state.phase_history`` use different suffixes;
     collapsing both keeps display and ``[entered_ts, exit_ts)`` matching
     consistent. Returns the input unchanged when empty/unparseable.
+
+    Args:
+        ts: Timestamp value to normalise.
+
+    Returns:
+        A canonical ``...Z`` UTC second-precision string, or the input
+        unchanged when empty or unparseable.
     """
     if ts is None:
         return ""
@@ -1322,7 +1470,15 @@ def _iso_z(ts: Any) -> str:
 def _load_optimization_journal(
     session_dir: Path | None, warnings: list[str],
 ) -> list[dict[str, Any]]:
-    """Read ``reports/optimization_journal.json`` entries (the canonical action ledger); ``[]`` on legacy sessions."""
+    """Read ``reports/optimization_journal.json`` entries (the canonical action ledger); ``[]`` on legacy sessions.
+
+    Args:
+        session_dir: Session root, or ``None``.
+        warnings: Accumulator appended to on read/parse failures.
+
+    Returns:
+        The journal ``entries`` list, or ``[]`` when missing.
+    """
     if session_dir is None:
         return []
     data = _load_json_safe(
@@ -1335,7 +1491,14 @@ def _load_optimization_journal(
 
 
 def _journal_entry_to_event(e: dict[str, Any]) -> dict[str, Any]:
-    """Map one optimization_journal entry to a phase_timeline event (keeps the declared ``phase`` for exact bucketing)."""
+    """Map one optimization_journal entry to a phase_timeline event (keeps the declared ``phase`` for exact bucketing).
+
+    Args:
+        e: A single optimization-journal entry dict.
+
+    Returns:
+        A normalized phase-timeline event dict.
+    """
     metric = e.get("throughput_after")
     metric_kind = "output_throughput" if metric is not None else None
     if metric is None and e.get("gain_pct") is not None:
@@ -1389,6 +1552,14 @@ def collect_phase_timeline(
     the journal copy winning, then sorted by ``ts``. Passing
     ``session_dir=None`` degrades gracefully to the audit-list scrape
     (used by unit fixtures that have no on-disk journal).
+
+    Args:
+        session_dir: Session root, or ``None`` to use only the audit lists.
+        state: Session state mapping holding the per-action attempt lists.
+        warnings: Accumulator appended to on journal read/parse failures.
+
+    Returns:
+        A de-duplicated, chronologically sorted list of timeline events.
     """
     events: list[dict[str, Any]] = []
 
@@ -1499,7 +1670,15 @@ def collect_phase_timeline(
 def _capability_for_action(
     state: dict[str, Any], action: str,
 ) -> dict[str, Any]:
-    """Per-action capability tally from ``<action>_attempts``, with an ``optimization_stack`` KEEP fallback for V1/partial state."""
+    """Per-action capability tally from ``<action>_attempts``, with an ``optimization_stack`` KEEP fallback for V1/partial state.
+
+    Args:
+        state: Session state mapping holding attempt lists and the stack.
+        action: Action name to tally.
+
+    Returns:
+        A dict with ``status``, ``attempts`` and ``keeps`` for the action.
+    """
     attempts_list = state.get(f"{action}_attempts") or []
     n_attempts = len(attempts_list) if isinstance(attempts_list, list) else 0
     n_keeps = sum(
@@ -1706,6 +1885,13 @@ def _specialist_capability_row(state: dict[str, Any]) -> dict[str, Any]:
 
     Headline counts aggregate all domains; ``by_specialist`` breaks them
     out per SpecialistDomain.key.
+
+    Args:
+        state: Session state mapping holding ``specialist_rounds``.
+
+    Returns:
+        A capability row with aggregate counts and a ``by_specialist``
+        per-domain breakdown.
     """
     rounds = state.get("specialist_rounds") or []
     if not isinstance(rounds, list) or not rounds:
@@ -1797,7 +1983,12 @@ def _specialist_capability_row(state: dict[str, Any]) -> dict[str, Any]:
 
 
 def _empty_by_specialist_capability() -> dict[str, dict[str, Any]]:
-    """Seed every catalogue domain with a not_attempted CapabilityEntry (stable shape, no KeyError-guarding)."""
+    """Seed every catalogue domain with a not_attempted CapabilityEntry (stable shape, no KeyError-guarding).
+
+    Returns:
+        A mapping of every catalogue domain to a zeroed, not_attempted
+        capability entry.
+    """
     return {
         d: {"status": "not_attempted", "attempts": 0, "keeps": 0, "tested": 0}
         for d in _SPECIALIST_DOMAIN_KEYS
@@ -1806,7 +1997,14 @@ def _empty_by_specialist_capability() -> dict[str, dict[str, Any]]:
 
 # §7 / §8 GEAK / OOB invocations
 def _kernel_agent_run_dirs(session_dir: Path) -> list[Path]:
-    """All ``<sd>/kernel-agent/runs/<sid>/`` dirs plus the two legacy layouts, so historical sessions still render."""
+    """All ``<sd>/kernel-agent/runs/<sid>/`` dirs plus the two legacy layouts, so historical sessions still render.
+
+    Args:
+        session_dir: Session root to scan for kernel-agent run dirs.
+
+    Returns:
+        The discovered run directories across canonical and legacy layouts.
+    """
     candidates: list[Path] = []
     # Canonical (current): <sd>/kernel-agent/runs/<sid>/
     new_root = session_dir / "kernel-agent" / "runs"
@@ -1925,6 +2123,13 @@ def _stamp_kernel_level_decisions(
     Reads kernel-level ``results/<kid>.json`` + ``verification/<kid>.json``;
     the best attempt is chosen by backend hint, else highest micro_speedup
     (ties: latest ts). Other attempts keep their per-attempt decision.
+
+    Args:
+        invocations: Attempt invocation dicts, mutated in place with the
+            stamped kernel-level decision and metadata.
+        run_dirs: Kernel-agent run directories to read results from.
+        session_dir: Session root used to relativize artifact paths.
+        warnings: Accumulator appended to on read/parse failures.
     """
     # Group by (run_id, kernel_id); same kid in different run_dirs is separate.
     groups: dict[tuple[str, str], list[dict[str, Any]]] = {}
@@ -2015,7 +2220,15 @@ def _shape_kernel_metadata(
     result: dict[str, Any],
     attempt: dict[str, Any],
 ) -> dict[str, Any]:
-    """Best-effort kernel metadata, preferring ``result['kernel_metadata']`` over the attempt's own."""
+    """Best-effort kernel metadata, preferring ``result['kernel_metadata']`` over the attempt's own.
+
+    Args:
+        result: The kernel-level result dict.
+        attempt: The attempt's own metadata used as a fallback.
+
+    Returns:
+        A normalized kernel-metadata dict.
+    """
     meta = result.get("kernel_metadata") if isinstance(result, dict) else None
     if isinstance(meta, dict) and meta:
         return {
@@ -2035,7 +2248,15 @@ def _shape_kernel_metadata(
 
 
 def _infer_run_dir_kernel_id(run_dir: Path) -> str:
-    """Recover the kernel id for a run dir whose attempts omit ``kernel_id``; only when the dir holds a single kid."""
+    """Recover the kernel id for a run dir whose attempts omit ``kernel_id``; only when the dir holds a single kid.
+
+    Args:
+        run_dir: Kernel-agent run directory to inspect.
+
+    Returns:
+        The single kernel id found under ``results``/``verification``, or
+        ``""`` when zero or multiple ids are present.
+    """
     kids: set[str] = set()
     for sub in ("results", "verification"):
         d = run_dir / sub
@@ -2051,7 +2272,16 @@ def collect_kernel_invocations(
     session_dir: Path,
     warnings: list[str],
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-    """Return ``(geak_invocations, oob_invocations)`` from each run dir's ``optimization_attempts.jsonl``, split by ``backend``."""
+    """Return ``(geak_invocations, oob_invocations)`` from each run dir's ``optimization_attempts.jsonl``, split by ``backend``.
+
+    Args:
+        session_dir: Session root to scan for kernel-agent run dirs.
+        warnings: Accumulator appended to on read/parse failures.
+
+    Returns:
+        A ``(geak_invocations, oob_invocations)`` tuple of attempt records,
+        each sorted by ``(kernel_id, ts)``.
+    """
     all_invocations: list[dict[str, Any]] = []
     run_dirs = _kernel_agent_run_dirs(session_dir)
     for run_dir in run_dirs:
@@ -2131,6 +2361,14 @@ def _read_kernel_candidates(
 
     Resolves via the orchestrator-recorded path, then the new and legacy
     on-disk layouts (glob fallbacks), then ``last_trace_analyze.hot_kernels_top15``.
+
+    Args:
+        session_dir: Session root to search for ``kernel_candidates.json``.
+        state: Session state mapping holding ``last_trace_analyze``.
+        warnings: Accumulator appended to on read/parse failures.
+
+    Returns:
+        The ``hot_kernels`` list, or ``[]`` when none can be resolved.
     """
     sk = state.get("last_trace_analyze") or {}
     raw_path = sk.get("candidates_path") if isinstance(sk, dict) else None
@@ -2180,7 +2418,14 @@ def _read_kernel_candidates(
 def _index_invocations_by_kernel(
     invs: list[dict[str, Any]],
 ) -> dict[str, dict[str, Any]]:
-    """Fold per-attempt invocations into a per-kernel ``{attempts, best_speedup, decision, last_status}`` summary."""
+    """Fold per-attempt invocations into a per-kernel ``{attempts, best_speedup, decision, last_status}`` summary.
+
+    Args:
+        invs: Per-attempt invocation records.
+
+    Returns:
+        A mapping of ``kernel_id`` to its aggregated summary.
+    """
     out: dict[str, dict[str, Any]] = {}
     for inv in invs:
         kid = str(inv.get("kernel_id") or "")
@@ -2219,6 +2464,17 @@ def _collect_detected_kernels(
     preferred, else ``benchmark_report.kernel_summary``),
     ``selected_for_optimization``, per-lane ``geak`` / ``oob`` summaries,
     ``adopted_by`` (from integrate KEEPs), and ``final_decision``.
+
+    Args:
+        session_dir: Session root to read candidate/profile data from.
+        state: Session state mapping.
+        geak: GEAK lane invocation records.
+        oob: Out-of-box lane invocation records.
+        warnings: Accumulator appended to on read/parse failures.
+        cap: Optional maximum number of kernel rows to return.
+
+    Returns:
+        The per-kernel lifecycle rows keyed by ``kernel_id``.
     """
     by_kid: dict[str, dict[str, Any]] = {}
 
@@ -2702,7 +2958,16 @@ def _shape_ledger(
 def _patch_winners_history(
     rows: list[Any], baseline_tput: float | None,
 ) -> list[dict[str, Any]]:
-    """Fix ``backend_winners_history`` data gaps: fall back to session ``baseline_tput`` for a 0 ``base_tput``, and compute missing per-winner ``gain_pct``."""
+    """Fix ``backend_winners_history`` data gaps: fall back to session ``baseline_tput`` for a 0 ``base_tput``, and compute missing per-winner ``gain_pct``.
+
+    Args:
+        rows: Raw ``backend_winners_history`` rows.
+        baseline_tput: Session baseline throughput used to backfill a missing
+            per-row ``base_tput``.
+
+    Returns:
+        New rows with backfilled ``base_tput`` and computed ``gain_pct``.
+    """
     out: list[dict[str, Any]] = []
     for r in rows:
         if not isinstance(r, dict):
@@ -2982,7 +3247,14 @@ def collect_critic_robustness(
 def _critic_kb_writes_summary(
     critic_iters: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    """Build ``critic_robustness.kb_writes_summary`` by counting each iteration's verdict into ``by_verdict``."""
+    """Build ``critic_robustness.kb_writes_summary`` by counting each iteration's verdict into ``by_verdict``.
+
+    Args:
+        critic_iters: Critic iteration records, each carrying a ``verdict``.
+
+    Returns:
+        A summary dict with ``total`` and per-verdict ``by_verdict`` counts.
+    """
     by_verdict: dict[str, int] = {}
     total = 0
     for entry in critic_iters:
@@ -3138,6 +3410,13 @@ def _collect_lane_timeline(
     One row per lane (capacity, live_holders, lease_expired_count). The
     per-tick holders timeline is deferred; the aggregates suffice for the
     ``benchmark_lane.peak ≤ 1`` invariant check.
+
+    Args:
+        session_dir: Session root holding ``storage/coordinator.db``.
+        warnings: Accumulator appended to on database read failures.
+
+    Returns:
+        One summary row per lane, or ``[]`` when the database is absent.
     """
     db_path = session_dir / "storage" / "coordinator.db"
     if not db_path.exists():
@@ -3281,6 +3560,12 @@ def _normalize_specialist_key(provenance: str) -> str:
     ``specialist:<domain>`` → bare ``<domain>``; ``legacy:<action>`` →
     ``legacy_<action>``; ``default_grid`` / ``llm_direct`` pass through;
     empty/unknown → ``"unknown"`` (so by_domain is never keyed by ``""``).
+
+    Args:
+        provenance: Raw provenance string to normalise.
+
+    Returns:
+        A stable specialist key, ``"unknown"`` when empty/unrecognized.
     """
     s = (provenance or "").strip()
     if not s:
@@ -3339,6 +3624,13 @@ def _promote_legacy_gain_entries(
     Recovers action/variant/ts/args from the parallel
     ``optimization_stack`` and computes ``delta_pct`` against the prior
     entry; ``None`` ledger entries stay ``None`` to keep index alignment.
+
+    Args:
+        state_entries: The legacy gain ledger (list of float or ``None``).
+        state: Session state mapping holding ``optimization_stack``.
+
+    Returns:
+        The gain ledger promoted to the V1 entry schema.
     """
     stack = state.get("optimization_stack") or []
     out: list[dict[str, Any]] = []
@@ -3380,6 +3672,13 @@ def collect_roofline(
 
     Returns ``[]`` when no snapshots exist or on parse failure
     (best-effort; errors recorded in ``warnings``).
+
+    Args:
+        state: Session state mapping holding ``roofline_snapshots``.
+        warnings: Accumulator appended to on parse failures.
+
+    Returns:
+        The roofline comparison rows, or ``[]`` when none/parse failed.
     """
     snapshots = state.get("roofline_snapshots")
     if not isinstance(snapshots, list) or not snapshots:
@@ -3557,6 +3856,15 @@ def _collect_phase_breakdown(
     Assigns each KEEP entry to the phase active at its acceptance
     timestamp (explore further splits by domain, kernel by kernel_id).
     Missing phase_history → everything lands under ``unattributed``.
+
+    Args:
+        state: Session state mapping holding ``phase_history`` and
+            ``explore_search``.
+        entries: Gain-ledger entries to attribute to phases.
+        warnings: Accumulator appended to on parse failures.
+
+    Returns:
+        A per-phase gain-attribution dict keyed by phase bucket.
     """
     # phase timeline lookup: for an entry ts, pick the latest row with ts_unix ≤ ts.
     history = state.get("phase_history") or []
@@ -3741,7 +4049,15 @@ def _reconstruct_gain_ledger(
     state: dict[str, Any],
     warnings: list[str],
 ) -> list[dict[str, Any]]:
-    """Approximate per-stack contribution (each entry's ``gain_pct`` as its delta) when Coordinator didn't record it; best-effort, see ``attribution.notes``."""
+    """Approximate per-stack contribution (each entry's ``gain_pct`` as its delta) when Coordinator didn't record it; best-effort, see ``attribution.notes``.
+
+    Args:
+        state: Session state mapping holding ``optimization_stack``.
+        warnings: Accumulator appended to on parse failures.
+
+    Returns:
+        A reconstructed gain ledger with cumulative/delta gains per entry.
+    """
     stack = state.get("optimization_stack") or []
     if not isinstance(stack, list):
         return []
@@ -3789,6 +4105,15 @@ def collect_roofline_progress(
     list-shaped key. Pure over ``state`` + ``manifest``. Output: ``trajectory[]``
     (baseline + KEEPs, ts-sorted), ceiling/target reference lines from the latest
     snapshot, headline current-best numbers, and a ``snapshots[]`` passthrough.
+
+    Args:
+        session_dir: Session root (reserved for path resolution).
+        state: Session state mapping holding snapshots and current-best.
+        manifest: Parsed session manifest dict.
+        warnings: Accumulator appended to on parse failures.
+
+    Returns:
+        The ``roofline_progress`` section dict.
     """
     # Trajectory: baseline + each KEEP.
     baseline_tput = _to_float(state.get("baseline_tput")) or 0.0
@@ -3948,6 +4273,13 @@ def collect_kernel_roofline(
     Missing file → ``{}`` (quiet); malformed → ``{}`` + warning; non-list
     ``kernels`` → ``[]``. Entries are type-coerced so upstream drift
     doesn't break consumers.
+
+    Args:
+        session_dir: Session root holding ``reports/kernel_roofline.json``.
+        warnings: Accumulator appended to on malformed input.
+
+    Returns:
+        The ``kernel_roofline`` section dict, or ``{}`` when absent/malformed.
     """
     path = session_dir / _KERNEL_ROOFLINE_REL_PATH
     if not path.exists():
@@ -4023,6 +4355,13 @@ def collect_kernel_optimization_summary(
     Missing → ``{}`` (quiet); malformed → ``{}`` + warning. Otherwise
     mirrored verbatim (producer additions ride through) apart from shape
     guards on the iterated containers + an added ``report_path``.
+
+    Args:
+        session_dir: Session root holding the summary file.
+        warnings: Accumulator appended to on malformed input.
+
+    Returns:
+        The kernel-optimization-summary section dict, or ``{}`` when absent.
     """
     path = session_dir / _KERNEL_OPT_SUMMARY_REL_PATH
     if not path.exists():
@@ -4086,6 +4425,13 @@ def collect_conc_sweep_summary(
     mirrored verbatim (only ``comparison`` shape-guarded) + ``report_path``.
     Do not synthesize the optional blocks the producer omits when
     ``status="skipped"``; pass through exactly what it wrote.
+
+    Args:
+        session_dir: Session root holding the conc-sweep summary file.
+        warnings: Accumulator appended to on malformed input.
+
+    Returns:
+        The conc-sweep-summary section dict, or ``{}`` when absent.
     """
     path = session_dir / _CONC_SWEEP_SUMMARY_REL_PATH
     if not path.exists():
@@ -4121,6 +4467,12 @@ def collect_optimization_stack(
 
     Each entry is stamped ``validated`` (within
     ``cumulative_gain_validated_stack_len``). Returns ``[]`` when absent.
+
+    Args:
+        state: Session state mapping holding ``optimization_stack``.
+
+    Returns:
+        The mirrored optimization-stack entries, or ``[]`` when absent.
     """
     stack = state.get("optimization_stack") or []
     if not isinstance(stack, list):
@@ -4142,7 +4494,15 @@ def collect_optimization_stack(
 def _normalize_optimization_stack_entry(
     raw: dict[str, Any], *, validated: bool,
 ) -> dict[str, Any]:
-    """Coerce one stack entry to the schema shape; unknown fields pass through verbatim (Inv-10.1 fact-layer compat)."""
+    """Coerce one stack entry to the schema shape; unknown fields pass through verbatim (Inv-10.1 fact-layer compat).
+
+    Args:
+        raw: A raw optimization-stack entry.
+        validated: Whether this entry falls within the validated stack prefix.
+
+    Returns:
+        The entry coerced to the schema shape with optional fields preserved.
+    """
     # Known fields — coerced types
     out: dict[str, Any] = {
         "action":                       str(raw.get("action") or ""),
@@ -4236,6 +4596,16 @@ def collect_phase_segments(
     own ``phase`` when present, else by the ``[entered_ts, exit_ts)``
     window. Empty when ``phase_history`` is missing (readers fall back to
     the flat ``phase_timeline``).
+
+    Args:
+        state: Session state mapping holding ``phase_history``.
+        phase_timeline: Flat action timeline whose events are attributed to
+            segments.
+        warnings: Accumulator appended to during attribution.
+
+    Returns:
+        The list of phase segments with folded events and actions; ``[]``
+        when ``phase_history`` is absent.
     """
     history = state.get("phase_history") or []
     if not isinstance(history, list) or not history:
@@ -4292,7 +4662,15 @@ def collect_phase_segments(
         })
 
     def _owner_by_window(ts: str) -> dict[str, Any] | None:
-        """Return the segment whose ``[entered_ts, exit_ts)`` ISO window holds ``ts`` (lexicographic compare)."""
+        """Return the segment whose ``[entered_ts, exit_ts)`` ISO window holds ``ts`` (lexicographic compare).
+
+        Args:
+            ts: ISO timestamp to locate.
+
+        Returns:
+            The owning segment, or the last segment when ``ts`` is empty or
+            unmatched; ``None`` when there are no segments.
+        """
         if not ts:
             return segments[-1] if segments else None
         for s in segments:
@@ -4369,7 +4747,17 @@ def collect_kb_provenance(
     manifest: dict[str, Any],
     warnings: list[str],
 ) -> dict[str, Any]:
-    """Collect the Cortex KB integration audit, merging SharedState warm-start fields, the NDJSON queue counts, and the audit-log status tail."""
+    """Collect the Cortex KB integration audit, merging SharedState warm-start fields, the NDJSON queue counts, and the audit-log status tail.
+
+    Args:
+        session_dir: Session root holding the Cortex queue/audit files.
+        state: Session state mapping holding warm-start fields.
+        manifest: Parsed session manifest dict.
+        warnings: Accumulator appended to with status signals and read errors.
+
+    Returns:
+        The KB-provenance audit section dict.
+    """
     from ..session_paths import (
         cortex_audit_jsonl as _audit_path,
         cortex_dead_letter_ndjson as _dl_path,
@@ -4506,7 +4894,17 @@ def _collect_flusher_status(
     pid_path: Path,
     warnings: list[str],
 ) -> dict[str, Any]:
-    """Merge the ``.kb_flusher_status.json`` boot marker with a live pid probe into one stable shape."""
+    """Merge the ``.kb_flusher_status.json`` boot marker with a live pid probe into one stable shape.
+
+    Args:
+        session_dir: Session root (reserved for path resolution).
+        status_path: Path to the flusher boot-status marker.
+        pid_path: Path to the flusher pid file.
+        warnings: Accumulator appended to on unreadable markers.
+
+    Returns:
+        A stable flusher-status dict including a live ``alive`` pid probe.
+    """
     base: dict[str, Any] = {
         "enabled":       False,
         "spawned":       False,
@@ -4557,7 +4955,15 @@ def _collect_flusher_status(
 
 # specialist_runs section
 def _coerce_round_id(value: Any) -> int | str:
-    """Normalise ``round_id`` to int when purely numeric, else keep the string (empty/None → 0). Never raises."""
+    """Normalise ``round_id`` to int when purely numeric, else keep the string (empty/None → 0). Never raises.
+
+    Args:
+        value: Raw round id value.
+
+    Returns:
+        An ``int`` for purely numeric input, ``0`` for empty/None, else the
+        stripped string.
+    """
     if value is None or value == "":
         return 0
     if isinstance(value, bool):
@@ -4584,6 +4990,16 @@ def collect_specialist_runs(
 
     ``include_transcripts`` inlines the transcript bytes under each ref's
     ``body`` (default False = path-only).
+
+    Args:
+        session_dir: Session root holding ``runs/specialist`` transcripts.
+        state: Session state mapping holding ``specialist_rounds``.
+        warnings: Accumulator appended to on read failures.
+        include_transcripts: When ``True``, inline transcript bytes under each
+            ref's ``body``.
+
+    Returns:
+        The ``specialist_runs`` section rows, or ``[]`` when none exist.
     """
     rounds = state.get("specialist_rounds") or []
     if not isinstance(rounds, list) or not rounds:
@@ -4695,7 +5111,15 @@ def _normalize_specialist_domain_breakdown(
 
 
 def _domain_for_task(round_entry: dict[str, Any], task_id: str) -> str:
-    """Best-effort domain for ``task_id`` within a round; "" when unmapped (older M5 rounds)."""
+    """Best-effort domain for ``task_id`` within a round; "" when unmapped (older M5 rounds).
+
+    Args:
+        round_entry: A single specialist round mapping.
+        task_id: Task id to resolve a domain for.
+
+    Returns:
+        The mapped domain, or ``""`` when it cannot be resolved.
+    """
     mapping = round_entry.get("task_domains")
     if isinstance(mapping, dict):
         v = mapping.get(task_id)
@@ -4732,6 +5156,12 @@ def _coerce_token(value: Any) -> int:
     The rollup sums tokens, so a missing counter contributes 0 here (the
     ``None``-vs-0 distinction matters only on the raw per-call rows, which
     we preserve verbatim in ``decision_trace.jsonl``).
+
+    Args:
+        value: Raw token-counter value.
+
+    Returns:
+        The value as an int, or ``0`` when ``None`` or unparseable.
     """
     if value is None:
         return 0
@@ -4781,6 +5211,13 @@ def _load_llm_calls(
     ``reports/trace/ext/*.jsonl`` shard written by out-of-process children.
     Best-effort: missing files / dirs yield ``[]``; malformed lines are
     skipped by :func:`_load_jsonl_safe`.
+
+    Args:
+        session_dir: Session root holding ``reports/trace``.
+        warnings: Accumulator appended to on scan/read failures.
+
+    Returns:
+        Every parsed LLM-call row across the ledger and ext shards.
     """
     trace_root = session_dir / "reports" / "trace"
     rows: list[dict[str, Any]] = list(
@@ -4806,6 +5243,13 @@ def _load_dispatch_history_all(
     Walks ``agents/orchestration/dynamic_actions/<dyn_id>/`` and stamps
     each row with its owning ``dyn_id`` so the join can key on it. Returns
     ``[]`` when the dynamic_actions tree is absent (no dynamic actions ran).
+
+    Args:
+        session_dir: Session root holding the dynamic-actions tree.
+        warnings: Accumulator appended to on scan/read failures.
+
+    Returns:
+        Every dispatch-history row stamped with its owning ``dyn_id``.
     """
     root = session_dir / "agents" / "orchestration" / "dynamic_actions"
     if not root.is_dir():
@@ -4835,6 +5279,12 @@ def _build_phase_windows(
     (real transitions). Used to backfill a call's / decision's phase from
     its ``ts`` when the producer didn't stamp one (out-of-process children,
     sub-agent runners). Empty when phase_history is missing.
+
+    Args:
+        state: Session state mapping holding ``phase_history``.
+
+    Returns:
+        A sorted list of ``(entered_unix, phase)`` window boundaries.
     """
     history = state.get("phase_history") or []
     if not isinstance(history, list):
@@ -4857,7 +5307,15 @@ def _build_phase_windows(
 
 
 def _phase_at(ts: Any, windows: list[tuple[float, str]]) -> str:
-    """Return the phase active at ``ts`` per ``windows`` (latest <= ts)."""
+    """Return the phase active at ``ts`` per ``windows`` (latest <= ts).
+
+    Args:
+        ts: Timestamp to resolve a phase for.
+        windows: Sorted ``(entered_unix, phase)`` boundaries.
+
+    Returns:
+        The phase active at ``ts``, or ``""`` when unresolved.
+    """
     unix = _parse_iso_unix(ts)
     if unix is None or not windows:
         return ""
@@ -4873,7 +5331,15 @@ def _phase_at(ts: Any, windows: list[tuple[float, str]]) -> str:
 def _decision_key(task_id: str, dyn_id: str) -> str | None:
     """Canonical join key for a decision / call: ``dyn_id`` wins over
     ``task_id`` (a dynamic_action dispatch owns both). ``None`` when
-    neither is present (the call can only be ts-window bucketed)."""
+    neither is present (the call can only be ts-window bucketed).
+
+    Args:
+        task_id: Task id, used when ``dyn_id`` is empty.
+        dyn_id: Dynamic-action id, preferred when present.
+
+    Returns:
+        A prefixed join key, or ``None`` when neither id is present.
+    """
     d = (dyn_id or "").strip()
     if d:
         return f"dyn:{d}"
@@ -4890,6 +5356,12 @@ def _token_convenience(bucket: dict[str, Any] | None) -> dict[str, int]:
     ``total_cache_creation`` / ``total_cache_read``) and the per-decision view
     (pre-summed ``total_cache``). ``total_in_out`` is prompt+completion only;
     ``grand_total`` folds in every cache token too.
+
+    Args:
+        bucket: A token bucket in either shape, or ``None``.
+
+    Returns:
+        A copy of the bucket with added ``total_in_out`` and ``grand_total``.
     """
     b = dict(bucket or {})
     ti = int(b.get("total_in", 0) or 0)
@@ -4925,6 +5397,14 @@ def collect_token_usage(
 
     Empty-but-valid (zeroed ``session_total``) when ``decision_trace`` is empty
     (e.g. a pre-trace session), so downstream readers never KeyError.
+
+    Args:
+        decision_trace: The decision-trace section holding the token rollup.
+        action_timeline: Visible action timeline rows to annotate with tokens.
+        warnings: Accumulator appended to on derivation issues.
+
+    Returns:
+        The ``token_usage`` section dict.
     """
     dt = decision_trace if isinstance(decision_trace, dict) else {}
     rollup = dt.get("token_rollup") or {}
@@ -5014,6 +5494,14 @@ def collect_langfuse(
     Either way credentials are redacted to host + presence booleans. Never
     raises: any failure degrades to a minimal ``config_only`` view so the
     breakdown still records whether the feature was even on.
+
+    Args:
+        session_dir: Session root holding the langfuse receipt/emitter state.
+        manifest: Parsed session manifest dict.
+        warnings: Accumulator appended to on read/receipt failures.
+
+    Returns:
+        The ``langfuse`` section dict (receipt, live, or config-only view).
     """
     from inference_optimizer.orchestrator.trace import langfuse_emitter as lfe
 
@@ -5086,6 +5574,15 @@ def collect_decision_trace(
     "unattributed_tokens": {...}}``. All-empty (zeroed rollup) when no
     trace files exist, so a session that ran before the trace subsystem
     landed degrades cleanly.
+
+    Args:
+        session_dir: Session root holding the trace files and journals.
+        state: Session state mapping used for phase-window backfill.
+        warnings: Accumulator appended to on read/write failures.
+
+    Returns:
+        A dict with ``decision_trace``, ``token_rollup`` and
+        ``unattributed_tokens`` keys.
     """
     calls = _load_llm_calls(session_dir, warnings)
     phase_windows = _build_phase_windows(state)
@@ -5238,6 +5735,11 @@ def _write_decision_trace_jsonl(
     the collector is the single producer, so a full rewrite is simpler than
     append + dedup and stays consistent with the latest join. Best-effort:
     OSError is recorded in ``warnings`` and swallowed.
+
+    Args:
+        session_dir: Session root holding ``reports/trace``.
+        decision_trace: The joined decision-trace rows to write.
+        warnings: Accumulator appended to on write failures.
     """
     target = session_dir / "reports" / "trace" / "decision_trace.jsonl"
     try:

--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -47,7 +47,16 @@ _ENV_DENY_PATTERN = re.compile(
 
 
 def _filter_envs(envs: dict[str, Any] | None) -> dict[str, str]:
-    """Apply the allowlist + secret denylist; returns a fresh ``dict[str, str]`` (values stringified)."""
+    """Apply the allowlist + secret denylist; returns a fresh ``dict[str, str]`` (values stringified).
+
+    Args:
+        envs (dict[str, Any] | None): Raw environment mapping to filter, or
+            ``None``.
+
+    Returns:
+        dict[str, str]: The allowlisted, secret-stripped subset with every
+        value coerced to ``str``. Empty when ``envs`` is not a dict.
+    """
     if not isinstance(envs, dict):
         return {}
     out: dict[str, str] = {}
@@ -104,7 +113,15 @@ _SERVER_LOG_MAX_BYTES = 256 * 1024
 
 
 def _strip_log_prefix(line: str) -> str:
-    """Strip a leading ``[ts] LEVEL [src.py:NN]`` style prefix (incl. the process tag) from a log line."""
+    """Strip a leading ``[ts] LEVEL [src.py:NN]`` style prefix (incl. the process tag) from a log line.
+
+    Args:
+        line (str): A single raw log line.
+
+    Returns:
+        str: The line with any recognized timestamp / level prefix removed
+        and surrounding whitespace stripped.
+    """
     s = line
     s = _LOG_PREFIX_RE.sub("", s)
     s = _LOG_TIMESTAMP_RE.sub("", s)
@@ -138,6 +155,14 @@ def _load_yaml_dict_safe(config_yaml: Path) -> dict | None:
     """Parse ``config_yaml`` to its top-level dict, or ``None`` on miss/failure. Never raises.
 
     Shared by both yaml passes so the file is read at most once.
+
+    Args:
+        config_yaml (Path): The YAML file to parse.
+
+    Returns:
+        dict | None: The decoded top-level mapping, or ``None`` when PyYAML is
+        unavailable, the file fails to read/parse, or the document is not a
+        dict.
     """
     try:
         import yaml  # type: ignore[import-not-found]
@@ -154,7 +179,15 @@ def _load_yaml_dict_safe(config_yaml: Path) -> dict | None:
 
 
 def _yaml_cmd_from_dict(data: dict) -> str:
-    """Find a ``cmd`` / ``command`` / ``launch`` field (top-level or under ``benchmark``); ``""`` on miss."""
+    """Find a ``cmd`` / ``command`` / ``launch`` field (top-level or under ``benchmark``); ``""`` on miss.
+
+    Args:
+        data (dict): The parsed YAML config mapping.
+
+    Returns:
+        str: The first non-empty command string found, or ``""`` when none of
+        the recognized fields hold one.
+    """
     for key in ("cmd", "command", "launch"):
         val = data.get(key)
         if isinstance(val, str) and val.strip():
@@ -173,6 +206,14 @@ def _yaml_benchmark_synthesis(data: dict) -> str:
 
     Returns ``""`` unless both ``benchmark.framework`` and
     ``benchmark.model`` are non-empty.
+
+    Args:
+        data (dict): The parsed YAML config mapping.
+
+    Returns:
+        str: A space-joined ``key=value`` summary (framework / model plus any
+        present precision / tp / gpu / envs), or ``""`` when framework or model
+        is missing.
     """
     bench = data.get("benchmark")
     if not isinstance(bench, dict):
@@ -219,6 +260,16 @@ def _extract_framework_args(
     priority order: ``log_non_default_args`` / ``log_args_line`` /
     ``log_python_cmd`` / ``yaml_cmd`` / ``yaml_benchmark`` (synthesized,
     not a literal cmdline) / ``unknown`` (empty args).
+
+    Args:
+        server_log (Path | None): The ``server.log`` to scan, or ``None``.
+        config_yaml (Path | None): The variant config YAML used as a fallback
+            source, or ``None``. Defaults to ``None``.
+
+    Returns:
+        tuple[str, str]: ``(args_string, source)`` — the extracted launch args
+        and a provenance label, with ``("", "unknown")`` when no source yields
+        anything.
     """
     chunk: str = ""
     if server_log is not None:
@@ -296,7 +347,16 @@ def _extract_framework_args(
 
 
 def _read_invocation_envs(config_path: Path | None) -> dict[str, str]:
-    """Read ``benchmark.envs`` (or top-level ``envs:``) from a variant config; allowlisted subset, never raises."""
+    """Read ``benchmark.envs`` (or top-level ``envs:``) from a variant config; allowlisted subset, never raises.
+
+    Args:
+        config_path (Path | None): The variant config YAML to read, or
+            ``None``.
+
+    Returns:
+        dict[str, str]: The allowlisted, secret-stripped env subset. Empty when
+        the path is missing, PyYAML is unavailable, or parsing fails.
+    """
     if config_path is None:
         return {}
     try:
@@ -517,6 +577,15 @@ def _benchmark_report_metrics(
 
     Priority: V2 nested (``throughput.*`` / ``latency.<m>.mean_ms``),
     pre-V2 flat top-level, then legacy ``result.<flat>``.
+
+    Args:
+        report (dict[str, Any] | None): A parsed ``benchmark_report.json``, or
+            ``None``.
+
+    Returns:
+        tuple[float | None, float | None, float | None, float | None]:
+        ``(output_throughput, ttft, tpot, e2el)`` with each element ``None``
+        when not present or not numeric.
     """
     if not isinstance(report, dict):
         return (None, None, None, None)
@@ -565,7 +634,15 @@ def _benchmark_report_metrics(
 
 
 def _benchmark_report_candidates(root: Path) -> list[Path]:
-    """Return benchmark reports under a task/workspace root (handles the several on-disk layouts used over time)."""
+    """Return benchmark reports under a task/workspace root (handles the several on-disk layouts used over time).
+
+    Args:
+        root (Path): The task or workspace directory to search.
+
+    Returns:
+        list[Path]: Candidate ``benchmark_report.json`` paths (direct and
+        glob-matched). Empty when ``root`` does not exist.
+    """
     if not root.exists():
         return []
 
@@ -601,7 +678,15 @@ def _latest_benchmark_report(candidates: Iterable[Path]) -> Path | None:
 
 
 def _find_benchmark_report(workspace: Path | None) -> Path | None:
-    """Locate the most recent (by mtime) ``benchmark_report.json`` under a task workspace, else ``None``."""
+    """Locate the most recent (by mtime) ``benchmark_report.json`` under a task workspace, else ``None``.
+
+    Args:
+        workspace (Path | None): The task workspace to search, or ``None``.
+
+    Returns:
+        Path | None: The newest matching report, or ``None`` when ``workspace``
+        is ``None`` / missing or no report exists.
+    """
     if workspace is None or not workspace.exists():
         return None
     return _latest_benchmark_report(_benchmark_report_candidates(workspace))
@@ -618,6 +703,18 @@ def _resolve_under_session(
     ``session_dir`` (container paths like ``/workspace/runs/...`` map to the
     wekafs ``<session_dir>/runs/...`` view). Returns the first existing
     path, else ``None``.
+
+    Args:
+        session_dir (Path): The on-disk session root to re-root under.
+        raw (str | None): The (possibly container-rooted) path to resolve, or
+            ``None``.
+        anchors (tuple[str, ...]): Path-segment names whose suffix is re-rooted
+            at ``session_dir``. Defaults to ``("runs", "kernel-agent",
+            "kernel-agent-workspace")``.
+
+    Returns:
+        Path | None: The first existing resolved path, or ``None`` when ``raw``
+        is empty / unusable or nothing resolves.
     """
     if not raw:
         return None
@@ -662,7 +759,15 @@ def _safe_get(d: Any, *keys: str, default: Any = None) -> Any:
 
 
 def _close_phase_stop_reason(state: dict[str, Any]) -> tuple[str, str]:
-    """Recover terminal reason/time from the CLOSE phase transition (next-best when ``state.stop_reason`` wasn't mirrored)."""
+    """Recover terminal reason/time from the CLOSE phase transition (next-best when ``state.stop_reason`` wasn't mirrored).
+
+    Args:
+        state (dict[str, Any]): Parsed ``state.json``.
+
+    Returns:
+        tuple[str, str]: ``(reason, ts)`` from the most recent CLOSE
+        transition, or ``("", "")`` when no such transition exists.
+    """
     history = state.get("phase_history") or []
     if not isinstance(history, list):
         return "", ""
@@ -1144,7 +1249,15 @@ def collect_final(
 
 
 def _find_latest_validate_stack_report(session_dir: Path) -> Path | None:
-    """Most-recent validate_stack benchmark_report.json (authoritative for the final stack's clock)."""
+    """Most-recent validate_stack benchmark_report.json (authoritative for the final stack's clock).
+
+    Args:
+        session_dir (Path): Absolute session root.
+
+    Returns:
+        Path | None: The newest ``benchmark_report.json`` under
+        ``runs/validate_stack/``, or ``None`` when none exist.
+    """
     root = session_dir / "runs" / "validate_stack"
     if not root.exists():
         return None
@@ -1159,7 +1272,16 @@ def _find_latest_validate_stack_report(session_dir: Path) -> Path | None:
 def _find_current_best_report(
     session_dir: Path, state: dict[str, Any],
 ) -> Path | None:
-    """Best-effort benchmark report for ``state.current_best`` (via workspace or action/variant/tput match)."""
+    """Best-effort benchmark report for ``state.current_best`` (via workspace or action/variant/tput match).
+
+    Args:
+        session_dir (Path): Absolute session root.
+        state (dict[str, Any]): Parsed ``state.json``.
+
+    Returns:
+        Path | None: The matched report, or ``None`` when ``current_best`` is
+        missing or no report resolves.
+    """
     cb = state.get("current_best") or {}
     if not isinstance(cb, dict):
         return None
@@ -1174,7 +1296,17 @@ def _find_current_best_report(
 def _find_stack_top_report(
     session_dir: Path, state: dict[str, Any],
 ) -> Path | None:
-    """Last optimization_stack entry's benchmark_report.json (next-best when no validate_stack run exists)."""
+    """Last optimization_stack entry's benchmark_report.json (next-best when no validate_stack run exists).
+
+    Args:
+        session_dir (Path): Absolute session root.
+        state (dict[str, Any]): Parsed ``state.json``.
+
+    Returns:
+        Path | None: The top stack entry's report (via workspace or
+        action/variant/tput match), or ``None`` when the stack is empty or
+        nothing resolves.
+    """
     cb = state.get("current_best") or {}
     stack = state.get("optimization_stack") or []
     if not stack and isinstance(cb, dict):
@@ -1199,7 +1331,17 @@ def _find_stack_top_report(
 def _find_matching_action_report(
     session_dir: Path, entry: dict[str, Any],
 ) -> Path | None:
-    """Match a report under ``runs/<action>/`` by variant name and tput (conservative; tput beats variant, latency-less reports skipped)."""
+    """Match a report under ``runs/<action>/`` by variant name and tput (conservative; tput beats variant, latency-less reports skipped).
+
+    Args:
+        session_dir (Path): Absolute session root.
+        entry (dict[str, Any]): A stack / current_best entry carrying
+            ``action``, ``variant_name``, and ``tput``.
+
+    Returns:
+        Path | None: The best-scoring matching report, or ``None`` when the
+        action is missing or no candidate matches.
+    """
     action = str(entry.get("action") or "").strip()
     if not action:
         return None
@@ -1240,7 +1382,20 @@ def _build_final_invocation(
     benchmark_report: Path | None,
     warnings: list[str],
 ) -> dict[str, Any]:
-    """Best-effort :class:`BenchmarkInvocation` for the final stack run (config = the launched ``*.with_envs.yaml`` sibling)."""
+    """Best-effort :class:`BenchmarkInvocation` for the final stack run (config = the launched ``*.with_envs.yaml`` sibling).
+
+    Args:
+        session_dir (Path): Absolute session root.
+        state (dict[str, Any]): Parsed ``state.json``.
+        benchmark_report (Path | None): The resolved final benchmark report
+            whose siblings supply the config / server log, or ``None``.
+        warnings (list[str]): Shared warnings list (mutated in place when args
+            extraction fails).
+
+    Returns:
+        dict[str, Any]: The invocation dict (framework args + source, extra
+        envs, and relative config / server-log paths).
+    """
     config_path: Path | None = None
     server_log_path: Path | None = None
     if benchmark_report is not None:
@@ -1287,7 +1442,15 @@ _AUDIT_ACTIONS = (
 
 
 def _parse_iso_unix(ts: Any) -> float | None:
-    """Best-effort ISO-8601 -> unix seconds. ``None`` on any failure."""
+    """Best-effort ISO-8601 -> unix seconds. ``None`` on any failure.
+
+    Args:
+        ts (Any): An ISO-8601 string or already-numeric timestamp.
+
+    Returns:
+        float | None: The timestamp in Unix seconds, or ``None`` when ``ts`` is
+        empty or unparseable.
+    """
     if ts is None:
         return None
     if isinstance(ts, (int, float)):
@@ -1309,6 +1472,13 @@ def _iso_z(ts: Any) -> str:
     The journal and ``state.phase_history`` use different suffixes;
     collapsing both keeps display and ``[entered_ts, exit_ts)`` matching
     consistent. Returns the input unchanged when empty/unparseable.
+
+    Args:
+        ts (Any): An ISO-8601 timestamp value (any suffix), or ``None``.
+
+    Returns:
+        str: The canonical ``...Z`` UTC string, ``""`` for empty input, or the
+        original string when it cannot be parsed.
     """
     if ts is None:
         return ""
@@ -1328,7 +1498,17 @@ def _iso_z(ts: Any) -> str:
 def _load_optimization_journal(
     session_dir: Path | None, warnings: list[str],
 ) -> list[dict[str, Any]]:
-    """Read ``reports/optimization_journal.json`` entries (the canonical action ledger); ``[]`` on legacy sessions."""
+    """Read ``reports/optimization_journal.json`` entries (the canonical action ledger); ``[]`` on legacy sessions.
+
+    Args:
+        session_dir (Path | None): Absolute session root, or ``None``.
+        warnings (list[str]): Shared warnings list (mutated in place on parse
+            failure).
+
+    Returns:
+        list[dict[str, Any]]: The journal ``entries`` list, or ``[]`` when the
+        file is missing / malformed or ``session_dir`` is ``None``.
+    """
     if session_dir is None:
         return []
     data = _load_json_safe(
@@ -1341,7 +1521,15 @@ def _load_optimization_journal(
 
 
 def _journal_entry_to_event(e: dict[str, Any]) -> dict[str, Any]:
-    """Map one optimization_journal entry to a phase_timeline event (keeps the declared ``phase`` for exact bucketing)."""
+    """Map one optimization_journal entry to a phase_timeline event (keeps the declared ``phase`` for exact bucketing).
+
+    Args:
+        e (dict[str, Any]): One ``optimization_journal.json`` entry.
+
+    Returns:
+        dict[str, Any]: The event row with normalized timestamp, resolved
+        action, metric / decision fields, and a threaded ``extras`` map.
+    """
     metric = e.get("throughput_after")
     metric_kind = "output_throughput" if metric is not None else None
     if metric is None and e.get("gain_pct") is not None:
@@ -1405,6 +1593,16 @@ def collect_phase_timeline(
     the journal copy winning, then sorted by ``ts``. Passing
     ``session_dir=None`` degrades gracefully to the audit-list scrape
     (used by unit fixtures that have no on-disk journal).
+
+    Args:
+        session_dir (Path | None): Absolute session root, or ``None`` to skip
+            the on-disk journal source.
+        state (dict[str, Any]): Parsed ``state.json``.
+        warnings (list[str]): Shared warnings list (mutated in place).
+
+    Returns:
+        list[dict[str, Any]]: The merged, de-duplicated, ts-sorted action
+        events.
     """
     events: list[dict[str, Any]] = []
 
@@ -1515,7 +1713,15 @@ def collect_phase_timeline(
 def _capability_for_action(
     state: dict[str, Any], action: str,
 ) -> dict[str, Any]:
-    """Per-action capability tally from ``<action>_attempts``, with an ``optimization_stack`` KEEP fallback for V1/partial state."""
+    """Per-action capability tally from ``<action>_attempts``, with an ``optimization_stack`` KEEP fallback for V1/partial state.
+
+    Args:
+        state (dict[str, Any]): Parsed ``state.json``.
+        action (str): The action label whose attempts / keeps are tallied.
+
+    Returns:
+        dict[str, Any]: ``{"status", "attempts", "keeps"}`` for the action.
+    """
     attempts_list = state.get(f"{action}_attempts") or []
     n_attempts = len(attempts_list) if isinstance(attempts_list, list) else 0
     n_keeps = sum(
@@ -1727,6 +1933,13 @@ def _specialist_capability_row(state: dict[str, Any]) -> dict[str, Any]:
 
     Headline counts aggregate all domains; ``by_specialist`` breaks them
     out per SpecialistDomain.key.
+
+    Args:
+        state (dict[str, Any]): Parsed ``state.json``.
+
+    Returns:
+        dict[str, Any]: The specialist capability row (aggregate status /
+        attempts / keeps / tested plus a ``by_specialist`` per-domain map).
     """
     rounds = state.get("specialist_rounds") or []
     if not isinstance(rounds, list) or not rounds:
@@ -1818,7 +2031,12 @@ def _specialist_capability_row(state: dict[str, Any]) -> dict[str, Any]:
 
 
 def _empty_by_specialist_capability() -> dict[str, dict[str, Any]]:
-    """Seed every catalogue domain with a not_attempted CapabilityEntry (stable shape, no KeyError-guarding)."""
+    """Seed every catalogue domain with a not_attempted CapabilityEntry (stable shape, no KeyError-guarding).
+
+    Returns:
+        dict[str, dict[str, Any]]: One zeroed, ``not_attempted`` capability
+        entry per catalogue specialist-domain key.
+    """
     return {
         d: {"status": "not_attempted", "attempts": 0, "keeps": 0, "tested": 0}
         for d in _SPECIALIST_DOMAIN_KEYS
@@ -1827,7 +2045,15 @@ def _empty_by_specialist_capability() -> dict[str, dict[str, Any]]:
 
 # §7 / §8 GEAK / OOB invocations
 def _kernel_agent_run_dirs(session_dir: Path) -> list[Path]:
-    """All ``<sd>/kernel-agent/runs/<sid>/`` dirs plus the two legacy layouts, so historical sessions still render."""
+    """All ``<sd>/kernel-agent/runs/<sid>/`` dirs plus the two legacy layouts, so historical sessions still render.
+
+    Args:
+        session_dir (Path): Absolute session root.
+
+    Returns:
+        list[Path]: Every kernel-agent run directory across the canonical and
+        two legacy layouts. Empty when none exist.
+    """
     candidates: list[Path] = []
     # Canonical (current): <sd>/kernel-agent/runs/<sid>/
     new_root = session_dir / "kernel-agent" / "runs"
@@ -1946,6 +2172,14 @@ def _stamp_kernel_level_decisions(
     Reads kernel-level ``results/<kid>.json`` + ``verification/<kid>.json``;
     the best attempt is chosen by backend hint, else highest micro_speedup
     (ties: latest ts). Other attempts keep their per-attempt decision.
+
+    Args:
+        invocations (list[dict[str, Any]]): All parsed per-attempt invocations
+            (mutated in place — the best attempt per kernel is stamped).
+        run_dirs (list[Path]): The kernel-agent run directories the
+            invocations came from.
+        session_dir (Path): Absolute session root.
+        warnings (list[str]): Shared warnings list (mutated in place).
     """
     # Group by (run_id, kernel_id); same kid in different run_dirs is separate.
     groups: dict[tuple[str, str], list[dict[str, Any]]] = {}
@@ -2036,7 +2270,18 @@ def _shape_kernel_metadata(
     result: dict[str, Any],
     attempt: dict[str, Any],
 ) -> dict[str, Any]:
-    """Best-effort kernel metadata, preferring ``result['kernel_metadata']`` over the attempt's own."""
+    """Best-effort kernel metadata, preferring ``result['kernel_metadata']`` over the attempt's own.
+
+    Args:
+        result (dict[str, Any]): The kernel-level ``results/<kid>.json`` dict
+            (may be empty).
+        attempt (dict[str, Any]): The per-attempt record used as a fallback
+            source.
+
+    Returns:
+        dict[str, Any]: Shaped kernel metadata (name, source file, shapes,
+        gpu_pct, arithmetic_intensity).
+    """
     meta = result.get("kernel_metadata") if isinstance(result, dict) else None
     if isinstance(meta, dict) and meta:
         return {
@@ -2056,7 +2301,15 @@ def _shape_kernel_metadata(
 
 
 def _infer_run_dir_kernel_id(run_dir: Path) -> str:
-    """Recover the kernel id for a run dir whose attempts omit ``kernel_id``; only when the dir holds a single kid."""
+    """Recover the kernel id for a run dir whose attempts omit ``kernel_id``; only when the dir holds a single kid.
+
+    Args:
+        run_dir (Path): A kernel-agent run directory.
+
+    Returns:
+        str: The single kernel id inferred from ``results`` / ``verification``
+        filenames, or ``""`` when zero or more than one is present.
+    """
     kids: set[str] = set()
     for sub in ("results", "verification"):
         d = run_dir / sub
@@ -2072,7 +2325,17 @@ def collect_kernel_invocations(
     session_dir: Path,
     warnings: list[str],
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
-    """Return ``(geak_invocations, oob_invocations, forge_invocations)`` from each run dir's ``optimization_attempts.jsonl``, split by ``backend`` into three independent lanes."""
+    """Return ``(geak_invocations, oob_invocations, forge_invocations)`` from each run dir's ``optimization_attempts.jsonl``, split by ``backend`` into three independent lanes.
+
+    Args:
+        session_dir (Path): Absolute session root.
+        warnings (list[str]): Shared warnings list (mutated in place).
+
+    Returns:
+        tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+        The ``(geak, oob, forge)`` invocation lanes, each sorted by
+        ``(kernel_id, ts)``.
+    """
     all_invocations: list[dict[str, Any]] = []
     run_dirs = _kernel_agent_run_dirs(session_dir)
     for run_dir in run_dirs:
@@ -2157,6 +2420,15 @@ def _read_kernel_candidates(
 
     Resolves via the orchestrator-recorded path, then the new and legacy
     on-disk layouts (glob fallbacks), then ``last_trace_analyze.hot_kernels_top15``.
+
+    Args:
+        session_dir (Path): Absolute session root.
+        state (dict[str, Any]): Parsed ``state.json``.
+        warnings (list[str]): Shared warnings list (mutated in place).
+
+    Returns:
+        list[dict[str, Any]]: The resolved ``hot_kernels`` list, or ``[]`` when
+        no source yields a non-empty list.
     """
     sk = state.get("last_trace_analyze") or {}
     raw_path = sk.get("candidates_path") if isinstance(sk, dict) else None
@@ -2206,7 +2478,14 @@ def _read_kernel_candidates(
 def _index_invocations_by_kernel(
     invs: list[dict[str, Any]],
 ) -> dict[str, dict[str, Any]]:
-    """Fold per-attempt invocations into a per-kernel ``{attempts, best_speedup, decision, last_status}`` summary."""
+    """Fold per-attempt invocations into a per-kernel ``{attempts, best_speedup, decision, last_status}`` summary.
+
+    Args:
+        invs (list[dict[str, Any]]): Per-attempt invocation records.
+
+    Returns:
+        dict[str, dict[str, Any]]: Per-kernel summary keyed by ``kernel_id``.
+    """
     out: dict[str, dict[str, Any]] = {}
     for inv in invs:
         kid = str(inv.get("kernel_id") or "")
@@ -2246,6 +2525,21 @@ def _collect_detected_kernels(
     preferred, else ``benchmark_report.kernel_summary``),
     ``selected_for_optimization``, per-lane ``geak`` / ``oob`` / ``forge``
     summaries, ``adopted_by`` (from integrate KEEPs), and ``final_decision``.
+
+    Args:
+        session_dir (Path): Absolute session root.
+        state (dict[str, Any]): Parsed ``state.json``.
+        geak (list[dict[str, Any]]): GEAK-lane invocations.
+        oob (list[dict[str, Any]]): OOB-lane invocations.
+        warnings (list[str]): Shared warnings list (mutated in place).
+        forge (list[dict[str, Any]] | None): Forge-lane invocations. Defaults
+            to ``None`` (treated as empty).
+        cap (int | None): Optional maximum number of rows to return (highest
+            GPU share first). Defaults to ``None`` (no cap).
+
+    Returns:
+        list[dict[str, Any]]: Per-kernel lifecycle rows sorted by descending
+        GPU share, truncated to ``cap`` when given.
     """
     forge = forge or []
     by_kid: dict[str, dict[str, Any]] = {}
@@ -2751,7 +3045,17 @@ def _shape_ledger(
 def _patch_winners_history(
     rows: list[Any], baseline_tput: float | None,
 ) -> list[dict[str, Any]]:
-    """Fix ``backend_winners_history`` data gaps: fall back to session ``baseline_tput`` for a 0 ``base_tput``, and compute missing per-winner ``gain_pct``."""
+    """Fix ``backend_winners_history`` data gaps: fall back to session ``baseline_tput`` for a 0 ``base_tput``, and compute missing per-winner ``gain_pct``.
+
+    Args:
+        rows (list[Any]): Raw ``backend_winners_history`` rows.
+        baseline_tput (float | None): Session baseline throughput used to
+            patch a zero / missing ``base_tput``.
+
+    Returns:
+        list[dict[str, Any]]: The patched rows with repaired ``base_tput`` and
+        back-filled per-winner ``gain_pct`` where derivable.
+    """
     out: list[dict[str, Any]] = []
     for r in rows:
         if not isinstance(r, dict):
@@ -2799,6 +3103,15 @@ def _shape_winners_history(
     ``_shape_ledger`` drops this history, so without re-emitting it the exported
     ``explore_search`` carries no ``fingerprint``→``provenance`` map and downstream
     consumers can't reconstruct ``phase_breakdown.explore.by_domain`` offline.
+
+    Args:
+        explore_search (dict[str, Any] | None): The ``explore_search`` ledger
+            from state, or ``None``.
+
+    Returns:
+        list[dict[str, Any]]: The shaped ``winners_history`` rows (round id,
+        variant, fingerprint, provenance, scope, gain, args/envs, ts). Empty
+        when no history is present.
     """
     if not isinstance(explore_search, dict):
         return []
@@ -3068,7 +3381,15 @@ def collect_critic_robustness(
 def _critic_kb_writes_summary(
     critic_iters: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    """Build ``critic_robustness.kb_writes_summary`` by counting each iteration's verdict into ``by_verdict``."""
+    """Build ``critic_robustness.kb_writes_summary`` by counting each iteration's verdict into ``by_verdict``.
+
+    Args:
+        critic_iters (list[dict[str, Any]]): The parsed critic-iteration rows.
+
+    Returns:
+        dict[str, Any]: ``{"total", "by_verdict"}`` where ``by_verdict`` counts
+        each non-empty, upper-cased verdict.
+    """
     by_verdict: dict[str, int] = {}
     total = 0
     for entry in critic_iters:
@@ -3224,6 +3545,15 @@ def _collect_lane_timeline(
     One row per lane (capacity, live_holders, lease_expired_count). The
     per-tick holders timeline is deferred; the aggregates suffice for the
     ``benchmark_lane.peak ≤ 1`` invariant check.
+
+    Args:
+        session_dir (Path): Absolute session root.
+        warnings (list[str]): Shared warnings list (mutated in place on DB
+            errors).
+
+    Returns:
+        list[dict[str, Any]]: One per-lane occupancy row plus a ``__total__``
+        aggregate row. Empty when the coordinator DB is absent / unreadable.
     """
     db_path = session_dir / "storage" / "coordinator.db"
     if not db_path.exists():
@@ -3367,6 +3697,12 @@ def _normalize_specialist_key(provenance: str) -> str:
     ``specialist:<domain>`` → bare ``<domain>``; ``legacy:<action>`` →
     ``legacy_<action>``; ``default_grid`` / ``llm_direct`` pass through;
     empty/unknown → ``"unknown"`` (so by_domain is never keyed by ``""``).
+
+    Args:
+        provenance (str): The raw provenance label.
+
+    Returns:
+        str: The normalized specialist key.
     """
     s = (provenance or "").strip()
     if not s:
@@ -3425,6 +3761,14 @@ def _promote_legacy_gain_entries(
     Recovers action/variant/ts/args from the parallel
     ``optimization_stack`` and computes ``delta_pct`` against the prior
     entry; ``None`` ledger entries stay ``None`` to keep index alignment.
+
+    Args:
+        state_entries (list[Any]): The legacy numeric gain ledger.
+        state (dict[str, Any]): Parsed ``state.json`` (supplies the parallel
+            ``optimization_stack``).
+
+    Returns:
+        list[dict[str, Any]]: The promoted V1 ``StackGainEntry`` rows.
     """
     stack = state.get("optimization_stack") or []
     out: list[dict[str, Any]] = []
@@ -3476,6 +3820,15 @@ def collect_roofline(
 
     Returns ``[]`` when no snapshots exist or on parse failure
     (best-effort; errors recorded in ``warnings``).
+
+    Args:
+        state (dict[str, Any]): Parsed ``state.json``.
+        warnings (list[str]): Shared warnings list (mutated in place on build
+            failure).
+
+    Returns:
+        list[dict[str, Any]]: A single-element comparison list (baseline /
+        latest / optional delta), or ``[]`` when no snapshots or on failure.
     """
     snapshots = state.get("roofline_snapshots")
     if not isinstance(snapshots, list) or not snapshots:
@@ -3661,6 +4014,18 @@ def _collect_phase_breakdown(
     Assigns each KEEP entry to the phase active at its acceptance
     timestamp (explore further splits by domain, kernel by kernel_id).
     Missing phase_history → everything lands under ``unattributed``.
+
+    Args:
+        state (dict[str, Any]): Parsed ``state.json``.
+        entries (list[dict[str, Any]]): The per-stack gain-ledger entries.
+        warnings (list[str]): Shared warnings list (mutated in place when
+            ``phase_history`` is empty).
+
+    Returns:
+        dict[str, Any]: Per-phase gain buckets (prelude / framework_pr /
+        explore / kernel / gemm_tuning / sweep / close, plus a conditional
+        ``unattributed``), each with a ``total_gain_pct`` and phase-specific
+        sub-breakdowns.
     """
     # phase timeline lookup: for an entry ts, pick the latest row with ts_unix ≤ ts.
     history = state.get("phase_history") or []
@@ -3845,7 +4210,18 @@ def _reconstruct_gain_ledger(
     state: dict[str, Any],
     warnings: list[str],
 ) -> list[dict[str, Any]]:
-    """Approximate per-stack contribution (each entry's ``gain_pct`` as its delta) when Coordinator didn't record it; best-effort, see ``attribution.notes``."""
+    """Approximate per-stack contribution (each entry's ``gain_pct`` as its delta) when Coordinator didn't record it; best-effort, see ``attribution.notes``.
+
+    Args:
+        state (dict[str, Any]): Parsed ``state.json``.
+        warnings (list[str]): Shared warnings list (kept for signature
+            symmetry; not mutated here).
+
+    Returns:
+        list[dict[str, Any]]: One reconstructed gain-ledger row per stack
+        entry, with cumulative gain and ``delta_pct``. Empty when there is no
+        ``optimization_stack``.
+    """
     stack = state.get("optimization_stack") or []
     if not isinstance(stack, list):
         return []
@@ -3902,6 +4278,18 @@ def collect_roofline_progress(
     list-shaped key. Pure over ``state`` + ``manifest``. Output: ``trajectory[]``
     (baseline + KEEPs, ts-sorted), ceiling/target reference lines from the latest
     snapshot, headline current-best numbers, and a ``snapshots[]`` passthrough.
+
+    Args:
+        session_dir (Path): Absolute session root (kept for a uniform collector
+            signature; the body is pure over state/manifest).
+        state (dict[str, Any]): Parsed ``state.json``.
+        manifest (dict[str, Any]): Parsed ``manifest.json``.
+        warnings (list[str]): Shared warnings list (mutated in place on a
+            trajectory / current-best mismatch).
+
+    Returns:
+        dict[str, Any]: The ``roofline_progress`` section (trajectory, ceiling
+        / target reference lines, headline numbers, and normalized snapshots).
     """
     # Trajectory: baseline + each KEEP.
     baseline_tput = _to_float(state.get("baseline_tput")) or 0.0
@@ -4061,6 +4449,15 @@ def collect_kernel_roofline(
     Missing file → ``{}`` (quiet); malformed → ``{}`` + warning; non-list
     ``kernels`` → ``[]``. Entries are type-coerced so upstream drift
     doesn't break consumers.
+
+    Args:
+        session_dir (Path): Absolute session root.
+        warnings (list[str]): Shared warnings list (mutated in place on
+            malformed input).
+
+    Returns:
+        dict[str, Any]: The ``kernel_roofline`` section, or ``{}`` when the
+        file is absent / not a JSON object.
     """
     path = session_dir / _KERNEL_ROOFLINE_REL_PATH
     if not path.exists():
@@ -4136,6 +4533,15 @@ def collect_kernel_optimization_summary(
     Missing → ``{}`` (quiet); malformed → ``{}`` + warning. Otherwise
     mirrored verbatim (producer additions ride through) apart from shape
     guards on the iterated containers + an added ``report_path``.
+
+    Args:
+        session_dir (Path): Absolute session root.
+        warnings (list[str]): Shared warnings list (mutated in place on
+            malformed input).
+
+    Returns:
+        dict[str, Any]: The mirrored summary section (with a ``report_path``),
+        or ``{}`` when the file is absent / not a JSON object.
     """
     path = session_dir / _KERNEL_OPT_SUMMARY_REL_PATH
     if not path.exists():
@@ -4199,6 +4605,16 @@ def collect_conc_sweep_summary(
     mirrored verbatim (only ``comparison`` shape-guarded) + ``report_path``.
     Do not synthesize the optional blocks the producer omits when
     ``status="skipped"``; pass through exactly what it wrote.
+
+    Args:
+        session_dir (Path): Absolute session root.
+        warnings (list[str]): Shared warnings list (mutated in place on
+            malformed input).
+
+    Returns:
+        dict[str, Any]: The mirrored conc-sweep summary (with a
+        ``report_path``), or ``{}`` when the file is absent / not a JSON
+        object.
     """
     path = session_dir / _CONC_SWEEP_SUMMARY_REL_PATH
     if not path.exists():
@@ -4234,6 +4650,13 @@ def collect_optimization_stack(
 
     Each entry is stamped ``validated`` (within
     ``cumulative_gain_validated_stack_len``). Returns ``[]`` when absent.
+
+    Args:
+        state (dict[str, Any]): Parsed ``state.json``.
+
+    Returns:
+        list[dict[str, Any]]: One normalized stack entry per KEEP (each flagged
+        ``validated``), or ``[]`` when the stack is absent.
     """
     stack = state.get("optimization_stack") or []
     if not isinstance(stack, list):
@@ -4255,7 +4678,17 @@ def collect_optimization_stack(
 def _normalize_optimization_stack_entry(
     raw: dict[str, Any], *, validated: bool,
 ) -> dict[str, Any]:
-    """Coerce one stack entry to the schema shape; unknown fields pass through verbatim (Inv-10.1 fact-layer compat)."""
+    """Coerce one stack entry to the schema shape; unknown fields pass through verbatim (Inv-10.1 fact-layer compat).
+
+    Args:
+        raw (dict[str, Any]): One raw ``optimization_stack`` entry.
+        validated (bool): Whether the entry falls within the validated stack
+            length.
+
+    Returns:
+        dict[str, Any]: The coerced stack entry with optional evidence fields
+        included only when present in ``raw``.
+    """
     # Known fields — coerced types
     out: dict[str, Any] = {
         "action":                       str(raw.get("action") or ""),
@@ -4349,6 +4782,18 @@ def collect_phase_segments(
     own ``phase`` when present, else by the ``[entered_ts, exit_ts)``
     window. Empty when ``phase_history`` is missing (readers fall back to
     the flat ``phase_timeline``).
+
+    Args:
+        state (dict[str, Any]): Parsed ``state.json``.
+        phase_timeline (list[dict[str, Any]]): The flat action timeline whose
+            events are attributed into segments.
+        warnings (list[str]): Shared warnings list (mutated in place when a
+            legacy plateau proxy fired).
+
+    Returns:
+        list[dict[str, Any]]: One segment per phase transition (with folded
+        sub-events and attributed actions). Empty when ``phase_history`` is
+        missing.
     """
     history = state.get("phase_history") or []
     if not isinstance(history, list) or not history:
@@ -4405,7 +4850,16 @@ def collect_phase_segments(
         })
 
     def _owner_by_window(ts: str) -> dict[str, Any] | None:
-        """Return the segment whose ``[entered_ts, exit_ts)`` ISO window holds ``ts`` (lexicographic compare)."""
+        """Return the segment whose ``[entered_ts, exit_ts)`` ISO window holds ``ts`` (lexicographic compare).
+
+        Args:
+            ts (str): An ISO-8601 timestamp.
+
+        Returns:
+            dict[str, Any] | None: The owning segment, the last segment when
+            ``ts`` is empty / past the end, or ``None`` when there are no
+            segments.
+        """
         if not ts:
             return segments[-1] if segments else None
         for s in segments:
@@ -4482,7 +4936,19 @@ def collect_kb_provenance(
     manifest: dict[str, Any],
     warnings: list[str],
 ) -> dict[str, Any]:
-    """Collect the Cortex KB integration audit, merging SharedState warm-start fields, the NDJSON queue counts, and the audit-log status tail."""
+    """Collect the Cortex KB integration audit, merging SharedState warm-start fields, the NDJSON queue counts, and the audit-log status tail.
+
+    Args:
+        session_dir (Path): Absolute session root.
+        state (dict[str, Any]): Parsed ``state.json``.
+        manifest (dict[str, Any]): Parsed ``manifest.json``.
+        warnings (list[str]): Shared warnings list (mutated in place; also used
+            to surface PR-monitor / flusher status markers).
+
+    Returns:
+        dict[str, Any]: The KB-provenance section (warm-start fields, queue
+        counts, audit-status tail, recipe-snapshot reads, and flusher status).
+    """
     from ..session_paths import (
         cortex_audit_jsonl as _audit_path,
         cortex_dead_letter_ndjson as _dl_path,
@@ -4644,7 +5110,19 @@ def _collect_flusher_status(
     pid_path: Path,
     warnings: list[str],
 ) -> dict[str, Any]:
-    """Merge the ``.kb_flusher_status.json`` boot marker with a live pid probe into one stable shape."""
+    """Merge the ``.kb_flusher_status.json`` boot marker with a live pid probe into one stable shape.
+
+    Args:
+        session_dir (Path): Absolute session root.
+        status_path (Path): The ``.kb_flusher_status.json`` boot marker path.
+        pid_path (Path): The flusher pid-file path used for the liveness probe.
+        warnings (list[str]): Shared warnings list (mutated in place when the
+            marker is unreadable).
+
+    Returns:
+        dict[str, Any]: The merged flusher-status dict (enabled / spawned /
+        alive / pid / config / reason).
+    """
     base: dict[str, Any] = {
         "enabled":       False,
         "spawned":       False,
@@ -4695,7 +5173,15 @@ def _collect_flusher_status(
 
 # specialist_runs section
 def _coerce_round_id(value: Any) -> int | str:
-    """Normalise ``round_id`` to int when purely numeric, else keep the string (empty/None → 0). Never raises."""
+    """Normalise ``round_id`` to int when purely numeric, else keep the string (empty/None → 0). Never raises.
+
+    Args:
+        value (Any): The raw ``round_id`` value.
+
+    Returns:
+        int | str: The integer round id when ``value`` is purely numeric,
+        ``0`` for empty / ``None``, else the original string.
+    """
     if value is None or value == "":
         return 0
     if isinstance(value, bool):
@@ -4722,6 +5208,18 @@ def collect_specialist_runs(
 
     ``include_transcripts`` inlines the transcript bytes under each ref's
     ``body`` (default False = path-only).
+
+    Args:
+        session_dir (Path): Absolute session root.
+        state (dict[str, Any]): Parsed ``state.json``.
+        warnings (list[str]): Shared warnings list (mutated in place on scan /
+            read failures).
+        include_transcripts (bool): When ``True``, inline each transcript's
+            bytes under its ``body``. Defaults to ``False`` (path-only).
+
+    Returns:
+        list[dict[str, Any]]: One shaped specialist-round row (with transcript
+        refs). Empty when no rounds exist.
     """
     rounds = state.get("specialist_rounds") or []
     if not isinstance(rounds, list) or not rounds:
@@ -4833,7 +5331,16 @@ def _normalize_specialist_domain_breakdown(
 
 
 def _domain_for_task(round_entry: dict[str, Any], task_id: str) -> str:
-    """Best-effort domain for ``task_id`` within a round; "" when unmapped (older M5 rounds)."""
+    """Best-effort domain for ``task_id`` within a round; "" when unmapped (older M5 rounds).
+
+    Args:
+        round_entry (dict[str, Any]): One specialist-round record.
+        task_id (str): The task id to resolve a domain for.
+
+    Returns:
+        str: The mapped domain, an unambiguous single tag/domain, or ``""``
+        when it cannot be determined.
+    """
     mapping = round_entry.get("task_domains")
     if isinstance(mapping, dict):
         v = mapping.get(task_id)
@@ -4870,6 +5377,13 @@ def _coerce_token(value: Any) -> int:
     The rollup sums tokens, so a missing counter contributes 0 here (the
     ``None``-vs-0 distinction matters only on the raw per-call rows, which
     we preserve verbatim in ``decision_trace.jsonl``).
+
+    Args:
+        value (Any): A raw token-counter value.
+
+    Returns:
+        int: The integer count, or ``0`` when ``value`` is ``None`` / not
+        numeric.
     """
     if value is None:
         return 0
@@ -4919,6 +5433,15 @@ def _load_llm_calls(
     ``reports/trace/ext/*.jsonl`` shard written by out-of-process children.
     Best-effort: missing files / dirs yield ``[]``; malformed lines are
     skipped by :func:`_load_jsonl_safe`.
+
+    Args:
+        session_dir (Path): Absolute session root.
+        warnings (list[str]): Shared warnings list (mutated in place on scan
+            failures).
+
+    Returns:
+        list[dict[str, Any]]: Every well-formed LLM-call row across the ledger
+        and ext shards. Empty when no trace files exist.
     """
     trace_root = session_dir / "reports" / "trace"
     rows: list[dict[str, Any]] = list(
@@ -4944,6 +5467,15 @@ def _load_dispatch_history_all(
     Walks ``agents/orchestration/dynamic_actions/<dyn_id>/`` and stamps
     each row with its owning ``dyn_id`` so the join can key on it. Returns
     ``[]`` when the dynamic_actions tree is absent (no dynamic actions ran).
+
+    Args:
+        session_dir (Path): Absolute session root.
+        warnings (list[str]): Shared warnings list (mutated in place on scan
+            failures).
+
+    Returns:
+        list[dict[str, Any]]: Every dispatch-history row, each stamped with its
+        owning ``dyn_id``. Empty when no dynamic actions ran.
     """
     root = session_dir / "agents" / "orchestration" / "dynamic_actions"
     if not root.is_dir():
@@ -4973,6 +5505,13 @@ def _build_phase_windows(
     (real transitions). Used to backfill a call's / decision's phase from
     its ``ts`` when the producer didn't stamp one (out-of-process children,
     sub-agent runners). Empty when phase_history is missing.
+
+    Args:
+        state (dict[str, Any]): Parsed ``state.json``.
+
+    Returns:
+        list[tuple[float, str]]: ``(entered_unix, phase)`` pairs sorted by
+        timestamp. Empty when ``phase_history`` is missing.
     """
     history = state.get("phase_history") or []
     if not isinstance(history, list):
@@ -4995,7 +5534,17 @@ def _build_phase_windows(
 
 
 def _phase_at(ts: Any, windows: list[tuple[float, str]]) -> str:
-    """Return the phase active at ``ts`` per ``windows`` (latest <= ts)."""
+    """Return the phase active at ``ts`` per ``windows`` (latest <= ts).
+
+    Args:
+        ts (Any): An ISO-8601 timestamp (or numeric Unix value).
+        windows (list[tuple[float, str]]): The ``(entered_unix, phase)``
+            timeline from :func:`_build_phase_windows`.
+
+    Returns:
+        str: The latest phase whose boundary is ``<= ts``, or ``""`` when ``ts``
+        is unparseable or the timeline is empty.
+    """
     unix = _parse_iso_unix(ts)
     if unix is None or not windows:
         return ""
@@ -5011,7 +5560,16 @@ def _phase_at(ts: Any, windows: list[tuple[float, str]]) -> str:
 def _decision_key(task_id: str, dyn_id: str) -> str | None:
     """Canonical join key for a decision / call: ``dyn_id`` wins over
     ``task_id`` (a dynamic_action dispatch owns both). ``None`` when
-    neither is present (the call can only be ts-window bucketed)."""
+    neither is present (the call can only be ts-window bucketed).
+
+    Args:
+        task_id (str): The call's / decision's task id.
+        dyn_id (str): The owning dynamic-action id.
+
+    Returns:
+        str | None: ``"dyn:<dyn_id>"`` when a dyn id is present, else
+        ``"task:<task_id>"``, else ``None``.
+    """
     d = (dyn_id or "").strip()
     if d:
         return f"dyn:{d}"
@@ -5028,6 +5586,14 @@ def _token_convenience(bucket: dict[str, Any] | None) -> dict[str, int]:
     ``total_cache_creation`` / ``total_cache_read``) and the per-decision view
     (pre-summed ``total_cache``). ``total_in_out`` is prompt+completion only;
     ``grand_total`` folds in every cache token too.
+
+    Args:
+        bucket (dict[str, Any] | None): A token bucket in either shape, or
+            ``None``.
+
+    Returns:
+        dict[str, int]: A copy of the bucket with added ``total_in_out`` and
+        ``grand_total`` figures.
     """
     b = dict(bucket or {})
     ti = int(b.get("total_in", 0) or 0)
@@ -5063,6 +5629,19 @@ def collect_token_usage(
 
     Empty-but-valid (zeroed ``session_total``) when ``decision_trace`` is empty
     (e.g. a pre-trace session), so downstream readers never KeyError.
+
+    Args:
+        decision_trace (dict[str, Any]): The output of
+            :func:`collect_decision_trace` (supplies the token rollup).
+        action_timeline (list[dict[str, Any]]): The visible action timeline to
+            annotate with joined token figures.
+        warnings (list[str]): Shared warnings list (kept for a uniform
+            collector signature; not mutated here).
+
+    Returns:
+        dict[str, Any]: The ``token_usage`` section (session total, per
+        component / phase, decision-attribution split, and the annotated
+        timeline).
     """
     dt = decision_trace if isinstance(decision_trace, dict) else {}
     rollup = dt.get("token_rollup") or {}
@@ -5152,6 +5731,17 @@ def collect_langfuse(
     Either way credentials are redacted to host + presence booleans. Never
     raises: any failure degrades to a minimal ``config_only`` view so the
     breakdown still records whether the feature was even on.
+
+    Args:
+        session_dir (Path): Absolute session root.
+        manifest (dict[str, Any]): Parsed ``manifest.json``.
+        warnings (list[str]): Shared warnings list (mutated in place on receipt
+            / emitter read failures).
+
+    Returns:
+        dict[str, Any]: The ``langfuse`` section, tagged with a
+        ``receipt_source`` of ``receipt_file`` / ``live_emitter`` /
+        ``config_only`` depending on which tier resolved.
     """
     from inference_optimizer.orchestrator.trace import langfuse_emitter as lfe
 
@@ -5207,6 +5797,13 @@ def _proposal_scores_by_variant(state: dict[str, Any]) -> dict[str, list[dict[st
     Returns ``{variant_name: [{rater, score, reason}, ...]}`` so a decision row
     can show who scored the proposal and how (the proposal_scorer signal that
     fed the KEEP/REVERT). Best-effort: shape drift yields an empty map.
+
+    Args:
+        state (dict[str, Any]): Parsed ``state.json``.
+
+    Returns:
+        dict[str, list[dict[str, Any]]]: Per-variant rater scores. Empty when
+        no ensemble scores are present.
     """
     out: dict[str, list[dict[str, Any]]] = {}
     rounds = state.get("specialist_rounds")
@@ -5256,6 +5853,15 @@ def collect_decision_trace(
     "unattributed_tokens": {...}}``. All-empty (zeroed rollup) when no
     trace files exist, so a session that ran before the trace subsystem
     landed degrades cleanly.
+
+    Args:
+        session_dir (Path): Absolute session root.
+        state (dict[str, Any]): Parsed ``state.json``.
+        warnings (list[str]): Shared warnings list (mutated in place).
+
+    Returns:
+        dict[str, Any]: ``{"decision_trace", "token_rollup",
+        "unattributed_tokens"}`` — the joined timeline plus token rollups.
     """
     calls = _load_llm_calls(session_dir, warnings)
     phase_windows = _build_phase_windows(state)
@@ -5438,6 +6044,13 @@ def _write_decision_trace_jsonl(
     the collector is the single producer, so a full rewrite is simpler than
     append + dedup and stays consistent with the latest join. Best-effort:
     OSError is recorded in ``warnings`` and swallowed.
+
+    Args:
+        session_dir (Path): Absolute session root.
+        decision_trace (list[dict[str, Any]]): The joined decision-trace rows
+            to write (one JSON object per line).
+        warnings (list[str]): Shared warnings list (mutated in place on write
+            failure).
     """
     target = session_dir / "reports" / "trace" / "decision_trace.jsonl"
     try:

--- a/inference_optimizer/breakdown/exporter.py
+++ b/inference_optimizer/breakdown/exporter.py
@@ -26,7 +26,16 @@ BREAKDOWN_FILENAME = "session_breakdown.json"
 
 
 def _load_state(session_dir: Path, warnings: list[str]) -> dict[str, Any]:
-    """Read ``state.json`` as a plain dict; empty dict + warning when missing."""
+    """Read ``state.json`` as a plain dict; empty dict + warning when missing.
+
+    Args:
+        session_dir: The hyperloom session directory.
+        warnings: Accumulator appended to when the file is missing or
+            unparseable.
+
+    Returns:
+        The parsed ``state.json`` contents, or an empty dict on any failure.
+    """
     state_path = session_dir / "state.json"
     if not state_path.exists():
         warnings.append(f"state.json missing at {state_path}")
@@ -314,7 +323,17 @@ def _safe_collect(
     *,
     default: Any = None,
 ):
-    """Run a collector with broad exception catching; failure → warning + ``default`` (a bug in one collector must not poison the export)."""
+    """Run a collector with broad exception catching; failure → warning + ``default`` (a bug in one collector must not poison the export).
+
+    Args:
+        name: Collector name used in the warning message.
+        fn: Zero-argument callable that runs the collector.
+        warnings: Accumulator appended to when the collector raises.
+        default: Value returned on failure; an empty dict when ``None``.
+
+    Returns:
+        The collector result, or ``default`` (or an empty dict) on failure.
+    """
     try:
         return fn()
     except Exception as exc:  # noqa: BLE001
@@ -335,6 +354,16 @@ def write_breakdown_json(
 
     ``output_path`` defaults to ``<session_dir>/session_breakdown.json``;
     ``include_transcripts`` is as in :func:`build`.
+
+    Args:
+        session_dir: The hyperloom session directory to build from.
+        output_path: Destination file; defaults to
+            ``<session_dir>/session_breakdown.json``.
+        include_transcripts: Whether to embed transcripts, as in
+            :func:`build`.
+
+    Returns:
+        The absolute path of the written breakdown file.
     """
     sd = Path(session_dir).resolve()
     target = Path(output_path).resolve() if output_path else sd / BREAKDOWN_FILENAME
@@ -376,6 +405,12 @@ def patch_breakdown_langfuse(session_dir: Path | str) -> bool:
     Best-effort and self-skipping: returns False (no-op) when no breakdown or
     no receipt exists yet, when live push was disabled, or on any error. Never
     raises -- it must not mask the session's stop_reason at shutdown.
+
+    Args:
+        session_dir: The hyperloom session directory holding the breakdown.
+
+    Returns:
+        ``True`` when the langfuse section was refreshed, ``False`` otherwise.
     """
     from ..orchestrator.trace.langfuse_emitter import read_receipt
 
@@ -443,6 +478,14 @@ def write_minimal_final_report(
 
     Stays minimal (one SharedState read) so it never raises or blocks
     shutdown. Idempotent: never overwrites an existing ``reports/final.md``.
+
+    Args:
+        session_dir: The hyperloom session directory.
+        output_path: Destination file; defaults to
+            ``<session_dir>/reports/final.md``.
+
+    Returns:
+        The path of the (existing or newly written) ``final.md`` file.
     """
     from ..orchestrator.shared_state import SharedState
     from ..session_paths import reports_dir

--- a/inference_optimizer/breakdown/exporter.py
+++ b/inference_optimizer/breakdown/exporter.py
@@ -31,6 +31,12 @@ def _phase_event_key(ev: dict[str, Any]) -> tuple[str, str, str]:
     ``(action, ts-to-second, change|task_id)`` with the timestamp canonicalised
     to ``...Z`` so a recorder fragment row and the collector's audit-list row
     for the same attempt collapse to one event.
+
+    Args:
+        ev: A phase-timeline event dict.
+
+    Returns:
+        The ``(action, ts-to-second, change|task_id)`` dedupe key.
     """
     return (
         str(ev.get("action") or ""),
@@ -51,6 +57,15 @@ def _merge_phase_timeline(
     the base and only append fragment rows whose dedupe key is missing (the
     crash-survivable audit rows the on-disk state may have lost). Result stays
     sorted by ``ts`` like the collector's own output.
+
+    Args:
+        fragment: The recorder ``phase_timeline`` fragment (may be any type).
+        collector_value: The collector-computed phase timeline used as the
+            base.
+
+    Returns:
+        The merged timeline (collector base plus missing fragment rows),
+        sorted by ``ts``.
     """
     base: list[dict[str, Any]] = (
         list(collector_value) if isinstance(collector_value, list) else []
@@ -139,6 +154,10 @@ def _attach_kernel_roofline(
     surfaced empty (roofline enrichment happens after discovery records). Pure
     best-effort: a missing/empty roofline table or kernel just leaves the
     journey untouched.
+
+    Args:
+        kernel_journey: The kernel-journey view mutated in place.
+        kernel_roofline: The per-kernel roofline table to merge from.
     """
     if not isinstance(kernel_journey, dict) or not isinstance(
         kernel_roofline, dict,
@@ -226,7 +245,17 @@ def build(
     schema_version = SCHEMA_VERSION_V3 if assembled else SCHEMA_VERSION
 
     def _pick(section: str, collector_value: Any) -> Any:
-        """Fragment value if recorded and non-empty, else the collector value."""
+        """Fragment value if recorded and non-empty, else the collector value.
+
+        Args:
+            section: The breakdown section name to look up in the recorder
+                fragments.
+            collector_value: The fallback collector-computed value.
+
+        Returns:
+            The recorder fragment value when present and non-empty, else
+            ``collector_value``.
+        """
         frag = assembled.get(section)
         if isinstance(frag, list) and frag:
             return frag
@@ -496,7 +525,16 @@ def _load_assembled(
 ) -> dict[str, Any]:
     """Assemble recorder fragments into ``{section: value}`` (empty on opt-out
     or when no fragments exist). Never raises — a recorder bug must not poison
-    the export; it just falls back to collectors."""
+    the export; it just falls back to collectors.
+
+    Args:
+        session_dir: The hyperloom session directory.
+        warnings: Accumulator appended to when assembly fails.
+
+    Returns:
+        The assembled ``{section: value}`` mapping, or an empty dict when the
+        recorder is disabled, no fragments exist, or assembly fails.
+    """
     disabled = os.environ.get(
         "INFERENCE_OPTIMIZER_BREAKDOWN_DISABLE_RECORDER", "",
     ).strip().lower() in ("1", "true", "yes")

--- a/inference_optimizer/breakdown/legacy_collectors.py
+++ b/inference_optimizer/breakdown/legacy_collectors.py
@@ -55,12 +55,30 @@ def is_legacy_session(state: dict[str, Any]) -> bool:
 
 
 def _phase_for_event(action: str, prev_phase: str) -> str:
+    """Determine the phase associated with an action event.
+
+    Args:
+        action: The action name from the event.
+        prev_phase: The phase carried over from the previous event.
+
+    Returns:
+        The mapped phase, the previous phase for phase-neutral actions,
+        or the default phase as a fallback.
+    """
     if action in _PHASE_NEUTRAL:
         return prev_phase or _DEFAULT_PHASE
     return _ACTION_PHASE.get(action, _DEFAULT_PHASE)
 
 
 def _stack_adoptions(state: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract timestamped optimization-stack adoption entries.
+
+    Args:
+        state: Session state mapping holding ``optimization_stack``.
+
+    Returns:
+        The stack entries that are dicts carrying a ``ts`` timestamp.
+    """
     stack = state.get("optimization_stack") or []
     out: list[dict[str, Any]] = []
     if isinstance(stack, list):

--- a/inference_optimizer/breakdown/legacy_collectors.py
+++ b/inference_optimizer/breakdown/legacy_collectors.py
@@ -49,7 +49,14 @@ _DEFAULT_PHASE = "EXPLORE"
 
 
 def is_legacy_session(state: dict[str, Any]) -> bool:
-    """A session is *legacy* when it never recorded ``phase_history``."""
+    """A session is *legacy* when it never recorded ``phase_history``.
+
+    Args:
+        state: Session state mapping to inspect.
+
+    Returns:
+        ``True`` when the session has no ``phase_history``, else ``False``.
+    """
     history = state.get("phase_history")
     return not (isinstance(history, list) and history)
 
@@ -99,6 +106,15 @@ def collect_phase_segments(
     consecutive same-phase events into segments matching the v2 collector
     wire shape; ``evidence.reconstructed_from == "legacy_audit_lists"``
     flags each as a derived view.
+
+    Args:
+        state: Session state mapping holding the optimization stack.
+        phase_timeline: Timestamped phase/action events to segment.
+        warnings: Mutable list to which any reconstruction warnings are
+            appended.
+
+    Returns:
+        The reconstructed ``phase_segments`` list in v2 collector shape.
     """
     events = [e for e in (phase_timeline or []) if isinstance(e, dict) and e.get("ts")]
     events.sort(key=lambda e: str(e.get("ts") or ""))

--- a/inference_optimizer/breakdown/recorder/assembler.py
+++ b/inference_optimizer/breakdown/recorder/assembler.py
@@ -22,18 +22,45 @@ from typing import Any
 
 
 def parts_dir(session_dir: Path | str) -> Path:
+    """Return the breakdown spool directory for ``session_dir``.
+
+    Args:
+        session_dir (Path | str): the session root directory.
+
+    Returns:
+        Path: the breakdown parts (spool) directory under the session.
+    """
     from ...session_paths import breakdown_parts_dir  # local: avoid import cycle
 
     return breakdown_parts_dir(Path(session_dir))
 
 
 def has_parts(session_dir: Path | str) -> bool:
-    """True iff at least one record fragment exists for this session."""
+    """True iff at least one record fragment exists for this session.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``True`` when the spool directory holds at least one ``*.json``
+        fragment.
+    """
     d = parts_dir(session_dir)
     return d.is_dir() and any(d.glob("*.json"))
 
 
 def _load(path: Path, warnings: list[str]) -> dict[str, Any] | None:
+    """Read and parse one fragment file, noting problems into ``warnings``.
+
+    Args:
+        path (Path): the fragment file to read.
+        warnings (list[str]): a list that parse/validation warnings are
+            appended to.
+
+    Returns:
+        dict[str, Any] | None: the parsed fragment record, or ``None`` when it
+            cannot be read or is not a JSON object.
+    """
     try:
         rec = json.loads(path.read_text(encoding="utf-8"))
     except Exception as exc:  # noqa: BLE001
@@ -53,6 +80,15 @@ def assemble_parts(
     """Return ``{section: list | dict}`` assembled from the spool directory.
 
     Empty mapping when no fragments exist (caller falls back to collectors).
+
+    Args:
+        session_dir: The session root directory.
+        warnings: Optional list to append parse/validation warnings to; a
+            fresh list is used when not provided.
+
+    Returns:
+        A ``{section: list | dict}`` mapping assembled from the spool
+        directory, or ``{}`` when no fragments exist.
     """
     warns = warnings if warnings is not None else []
     d = parts_dir(session_dir)
@@ -93,7 +129,11 @@ def assemble_parts(
 def _compose_versions(out: dict[str, Any]) -> None:
     """Fold the ``versions`` item substream into a top-level ``{tool: meta}``
     map (last write per tool wins; the substream is already deduped by tool key
-    at record time). No-op when nothing was recorded."""
+    at record time). No-op when nothing was recorded.
+
+    Args:
+        out: The assembled section mapping mutated in place.
+    """
     rows = out.get("versions")
     if not isinstance(rows, list):
         return
@@ -110,7 +150,11 @@ def _compose_critic_robustness(out: dict[str, Any]) -> None:
     """Fold the ``critic_iterations`` / ``robustness_signals`` item substreams
     into the ``critic_robustness`` singleton (shape mirrors
     ``collectors.collect_critic_robustness``). Pops the raw substreams so they
-    don't leak into the breakdown envelope."""
+    don't leak into the breakdown envelope.
+
+    Args:
+        out: The assembled section mapping mutated in place.
+    """
     critic_iters = out.pop("critic_iterations", None)
     rob_signals = out.pop("robustness_signals", None)
     if critic_iters is None and rob_signals is None:
@@ -133,6 +177,9 @@ def _compose_kernel_journey(out: dict[str, Any]) -> None:
     attempts -> e2e), then pop the raw substreams so they don't leak into the
     envelope. No-op (and ``kernel_journey`` stays absent) when no substream was
     recorded, preserving historical breakdowns byte-for-byte.
+
+    Args:
+        out: The assembled section mapping mutated in place.
     """
     discovery = out.pop("kernel_discovery", None)
     dispatch = out.pop("kernel_dispatch", None)
@@ -200,6 +247,15 @@ def _compose_kernel_journey(out: dict[str, Any]) -> None:
         })
 
     def _gpu(k: dict[str, Any]) -> float:
+        """Return a kernel's gpu_pct as a float (``-inf`` when absent/unparseable).
+
+        Args:
+            k: A kernel record mapping.
+
+        Returns:
+            The kernel's ``gpu_pct`` as a float, or ``-inf`` when absent or
+            unparseable.
+        """
         v = k.get("gpu_pct")
         try:
             return float(v) if v is not None else float("-inf")
@@ -219,6 +275,13 @@ def _best_micro_speedup(attempts: list[dict[str, Any]]) -> float | None:
     Surfaces the kernel-level achieved speedup at the journey-entry top level so
     the dashboard can correlate it with ``e2e.e2e_gain_pct`` without digging
     through the attempt ladder.
+
+    Args:
+        attempts: A kernel's backend attempt rows.
+
+    Returns:
+        The maximum ``micro_speedup`` across the attempts, or ``None`` when
+        none is present/parseable.
     """
     best: float | None = None
     for att in attempts:
@@ -240,7 +303,16 @@ def _kernel_outcome(
     e2e: dict[str, Any],
 ) -> str:
     """Coarse per-kernel outcome: adopted / reverted / attempted / dispatched /
-    skipped / discovered (in lifecycle-descending precedence)."""
+    skipped / discovered (in lifecycle-descending precedence).
+
+    Args:
+        dispatch: The kernel's dispatch row.
+        attempts: The kernel's backend attempt rows.
+        e2e: The kernel's end-to-end row.
+
+    Returns:
+        The coarse per-kernel outcome label.
+    """
     if e2e:
         decision = str(e2e.get("decision") or "").upper()
         if e2e.get("integrated") or decision in ("KEEP", "ADOPTED"):
@@ -255,7 +327,14 @@ def _kernel_outcome(
 
 
 def _kb_writes_summary(critic_iters: list[Any]) -> dict[str, Any]:
-    """Count each critic iteration's verdict (mirrors the collector)."""
+    """Count each critic iteration's verdict (mirrors the collector).
+
+    Args:
+        critic_iters: Critic iteration entries to tally by verdict.
+
+    Returns:
+        A summary ``{"total": int, "by_verdict": {verdict: count}}``.
+    """
     by_verdict: dict[str, int] = {}
     total = 0
     for entry in critic_iters:

--- a/inference_optimizer/breakdown/recorder/instrument.py
+++ b/inference_optimizer/breakdown/recorder/instrument.py
@@ -47,6 +47,12 @@ _FAILED_STATUSES = frozenset({"failed", "error", "crashed", "timeout"})
 
 
 def _now_iso_safe() -> str:
+    """Return the current UTC time as an ISO-8601 string (``""`` on failure).
+
+    Returns:
+        The current UTC time as a microsecond-precision ISO-8601 string, or
+        ``""`` if the clock read fails.
+    """
     from datetime import datetime, timezone
 
     try:
@@ -56,6 +62,15 @@ def _now_iso_safe() -> str:
 
 
 def _to_float(value: Any) -> float | None:
+    """Coerce a value to ``float``, rejecting bools and unparseable inputs.
+
+    Args:
+        value (Any): the value to coerce.
+
+    Returns:
+        float | None: the float value, or ``None`` when ``value`` is None, a
+            bool, or not parseable as a float.
+    """
     try:
         if value is None or isinstance(value, bool):
             return None
@@ -65,13 +80,31 @@ def _to_float(value: Any) -> float | None:
 
 
 def _recorder(session_dir: Path | str, producer: str):
+    """Return the process-cached recorder for ``session_dir`` and ``producer``.
+
+    Args:
+        session_dir (Path | str): the session directory backing the recorder.
+        producer (str): the breakdown producer label owning the fragments.
+
+    Returns:
+        The process-cached recorder for the ``(session_dir, producer)`` pair.
+    """
     from .recorder import get_recorder
 
     return get_recorder(session_dir, producer=producer)
 
 
 def _rel(path: Path, session_dir: Path | str) -> str:
-    """Render ``path`` relative to ``session_dir`` (falls back to str)."""
+    """Render ``path`` relative to ``session_dir`` (falls back to str).
+
+    Args:
+        path (Path): the path to render.
+        session_dir (Path | str): the session directory to relativize against.
+
+    Returns:
+        str: ``path`` relative to ``session_dir``, or the plain string form when
+            it is not under the session dir.
+    """
     try:
         return str(Path(path).relative_to(Path(session_dir)))
     except (ValueError, TypeError):
@@ -79,6 +112,15 @@ def _rel(path: Path, session_dir: Path | str) -> str:
 
 
 def _read_json(path: Path) -> dict[str, Any]:
+    """Read and parse a JSON object from ``path`` (``{}`` on any failure).
+
+    Args:
+        path (Path): the JSON file to read.
+
+    Returns:
+        dict[str, Any]: the parsed JSON object, or ``{}`` when the file is
+            missing, unreadable, invalid, or not a JSON object.
+    """
     import json
 
     try:
@@ -95,7 +137,17 @@ def record_phase_event(
     entry: dict[str, Any],
     producer: str = PRODUCER_COORDINATOR,
 ) -> None:
-    """Record one ``phase_timeline`` event from a ``record_action_attempt`` entry."""
+    """Record one ``phase_timeline`` event from a ``record_action_attempt`` entry.
+
+    Args:
+        session_dir (Path | str | None): the session directory; a falsy value is
+            a no-op.
+        action (str): the action name the event is keyed by.
+        entry (dict[str, Any]): the ``record_action_attempt`` entry to project
+            into a phase_timeline payload.
+        producer (str): the breakdown producer label (defaults to the
+            Coordinator).
+    """
     if not session_dir or not isinstance(entry, dict):
         return
     try:
@@ -132,6 +184,13 @@ def snapshot_state_sections(
     Singletons overwrite the producer's own file; event-stream items are keyed
     by a stable id so repeated snapshots are idempotent. Best-effort per
     section: one failing section never blocks the others.
+
+    Args:
+        session_dir (Path | str | None): the session directory; a falsy value is
+            a no-op.
+        state (Any): the live ``SharedState`` snapshotted into each section.
+        producer (str): the breakdown producer label (defaults to the
+            Coordinator).
     """
     if not session_dir or state is None:
         return
@@ -158,6 +217,12 @@ def snapshot_state_sections(
 
 
 def _snapshot_session(rec, st: Any) -> None:
+    """Snapshot the ``session`` singleton from ``st`` (no-op without a session id).
+
+    Args:
+        rec: the recorder used to write the singleton.
+        st (Any): the live ``SharedState`` to snapshot.
+    """
     session_id = str(getattr(st, "session_id", "") or "")
     if not session_id:
         return
@@ -174,6 +239,14 @@ def _snapshot_session(rec, st: Any) -> None:
 
 
 def _snapshot_workload(rec, st: Any) -> None:
+    """Snapshot the ``workload`` singleton from ``st``.
+
+    A no-op when neither a framework nor a model is set.
+
+    Args:
+        rec: the recorder used to write the singleton.
+        st (Any): the live ``SharedState`` to snapshot.
+    """
     framework = str(getattr(st, "framework", "") or "")
     model = str(getattr(st, "model_name", "") or getattr(st, "model_path", "") or "")
     if not framework and not model:
@@ -195,6 +268,14 @@ def _snapshot_workload(rec, st: Any) -> None:
 
 
 def _snapshot_final(rec, st: Any) -> None:
+    """Snapshot the ``final`` singleton (current best + cumulative gains) from ``st``.
+
+    A no-op when there is neither a current best nor an optimization stack.
+
+    Args:
+        rec: the recorder used to write the singleton.
+        st (Any): the live ``SharedState`` to snapshot.
+    """
     cb = getattr(st, "current_best", None) or {}
     stack = getattr(st, "optimization_stack", None) or []
     if not cb and not stack:
@@ -215,6 +296,15 @@ def _snapshot_final(rec, st: Any) -> None:
 
 
 def _snapshot_explore_search(rec, st: Any) -> None:
+    """Snapshot the ``explore_search`` singleton from ``st`` (no-op when empty).
+
+    Augments the base search dict with winner history, no-promote streak,
+    discovered flags, and synergy/backend-winner history pulled from ``st``.
+
+    Args:
+        rec: the recorder used to write the singleton.
+        st (Any): the live ``SharedState`` to snapshot.
+    """
     search = dict(getattr(st, "explore_search", None) or {})
     if not search:
         return
@@ -229,6 +319,12 @@ def _snapshot_explore_search(rec, st: Any) -> None:
 
 
 def _snapshot_sweep(rec, st: Any) -> None:
+    """Snapshot the ``sweep`` singleton from ``st.last_sweep`` (no-op when empty).
+
+    Args:
+        rec: the recorder used to write the singleton.
+        st (Any): the live ``SharedState`` to snapshot.
+    """
     last_sweep = dict(getattr(st, "last_sweep", None) or {})
     if not last_sweep:
         return
@@ -236,6 +332,15 @@ def _snapshot_sweep(rec, st: Any) -> None:
 
 
 def _snapshot_optimization_stack(rec, st: Any) -> None:
+    """Snapshot each ``optimization_stack`` entry from ``st`` as a keyed item.
+
+    Backfills a missing per-entry ``gain_pct`` from ``st.gain_per_stack_entry``
+    when available; each item is keyed by its stack index for idempotency.
+
+    Args:
+        rec: the recorder used to write the items.
+        st (Any): the live ``SharedState`` to snapshot.
+    """
     stack = getattr(st, "optimization_stack", None) or []
     gains = getattr(st, "gain_per_stack_entry", None) or []
     for i, entry in enumerate(stack):
@@ -248,6 +353,15 @@ def _snapshot_optimization_stack(rec, st: Any) -> None:
 
 
 def _snapshot_roofline(rec, st: Any) -> None:
+    """Snapshot each ``roofline`` snapshot from ``st`` as a keyed item.
+
+    Each item is keyed by its snapshot id (falling back to the list index) for
+    idempotency.
+
+    Args:
+        rec: the recorder used to write the items.
+        st (Any): the live ``SharedState`` to snapshot.
+    """
     snapshots = getattr(st, "roofline_snapshots", None) or []
     for idx, snap in enumerate(snapshots):
         if not isinstance(snap, dict):
@@ -264,6 +378,15 @@ def _best_attempt_id(
 
     Mirrors the collector's selection so the kernel-level decision lands on the
     same attempt the breakdown would attribute it to.
+
+    Args:
+        attempts (list[Any]): the per-backend attempt rows.
+        verification (dict[str, Any]): the verification block carrying the
+            ``best_attempt_id`` / ``best_backend`` hints.
+
+    Returns:
+        str: the adopted attempt id (verification hint, else highest speedup),
+            or ``""`` when there are no attempt rows.
     """
     rows = [a for a in attempts if isinstance(a, dict)]
     if not rows:
@@ -281,6 +404,15 @@ def _best_attempt_id(
             candidates = backend_rows
 
     def _spd(a: dict[str, Any]) -> float:
+        """Return an attempt's micro/plain speedup (``-inf`` when absent).
+
+        Args:
+            a: An attempt record mapping.
+
+        Returns:
+            The attempt's ``micro_speedup`` (or ``speedup``) as a float, or
+            ``-inf`` when neither is present.
+        """
         v = _to_float(a.get("micro_speedup") or a.get("speedup"))
         return v if v is not None else float("-inf")
 
@@ -289,6 +421,16 @@ def _best_attempt_id(
 
 
 def _invocation_section(backend: str) -> str | None:
+    """Map a kernel-agent backend to its invocation section name.
+
+    Args:
+        backend (str): the backend name (geak / forge / claude / codex / ...).
+
+    Returns:
+        str | None: the matching invocation section (``geak_invocations`` /
+            ``forge_invocations`` / ``oob_invocations``), or ``None`` when the
+            backend has no invocation lane.
+    """
     b = str(backend or "").lower()
     if b in _GEAK_BACKENDS:
         return "geak_invocations"
@@ -314,6 +456,14 @@ def record_kernel_invocations(
     gating: non_reusable_kernel / missing_source / kernel_agent_root_missing /
     ...), a single ``FAILED`` marker is recorded so the failure is never
     invisible in the geak/oob view.
+
+    Args:
+        session_dir (Path | str | None): the session directory; a falsy value is
+            a no-op.
+        result (dict[str, Any]): the in-process kernel-agent result carrying the
+            per-backend ``attempts`` ladder, verification, and proposal.
+        producer (str): the breakdown producer label (defaults to the
+            kernel-agent).
     """
     if not session_dir or not isinstance(result, dict):
         return
@@ -398,6 +548,16 @@ def record_kernel_invocations(
 
 
 def _to_bool(value: Any) -> bool | None:
+    """Coerce a loosely-typed truthy/falsy value to ``bool``.
+
+    Args:
+        value (Any): the value to interpret (a bool, or a string like
+            ``"true"`` / ``"failed"`` / ``"ok"``).
+
+    Returns:
+        bool | None: the interpreted boolean, or ``None`` when ``value`` is
+            None or not a recognized truthy/falsy token.
+    """
     if value is None:
         return None
     if isinstance(value, bool):
@@ -443,7 +603,15 @@ _TOOL_PROVENANCE: dict[str, dict[str, Any]] = {
 
 
 def _run_first_line(argv: list[str]) -> str:
-    """Run ``argv`` and return the trimmed first output line (never raises)."""
+    """Run ``argv`` and return the trimmed first output line (never raises).
+
+    Args:
+        argv (list[str]): the command argv to run.
+
+    Returns:
+        str: the trimmed first line of output (capped at 120 chars), or ``""``
+            on failure / non-zero exit.
+    """
     import subprocess  # local: keep module import cost off the common path
 
     try:
@@ -459,21 +627,44 @@ def _run_first_line(argv: list[str]) -> str:
 
 
 def _git_short_commit(root: Path) -> str:
-    """Best-effort ``git rev-parse --short HEAD`` for ``root`` (never raises)."""
+    """Best-effort ``git rev-parse --short HEAD`` for ``root`` (never raises).
+
+    Args:
+        root (Path): the repo root to inspect.
+
+    Returns:
+        str: the short commit hash, or ``""`` when it cannot be resolved.
+    """
     return _run_first_line(
         ["git", "-C", str(root), "rev-parse", "--short", "HEAD"],
     )
 
 
 def _git_describe(root: Path) -> str:
-    """Best-effort ``git describe --tags --always --dirty`` (never raises)."""
+    """Best-effort ``git describe --tags --always --dirty`` (never raises).
+
+    Args:
+        root (Path): the repo root to inspect.
+
+    Returns:
+        str: the ``git describe`` output, or ``""`` when it cannot be resolved.
+    """
     return _run_first_line(
         ["git", "-C", str(root), "describe", "--tags", "--always", "--dirty"],
     )
 
 
 def _dist_version(names: tuple[str, ...]) -> str:
-    """First resolvable ``importlib.metadata`` version among ``names`` ("" if none)."""
+    """First resolvable ``importlib.metadata`` version among ``names`` ("" if none).
+
+    Args:
+        names (tuple[str, ...]): candidate distribution names to resolve in
+            order.
+
+    Returns:
+        str: the first resolvable distribution version (rejecting a stale
+            ``0.0.0``), or ``""`` when none resolve.
+    """
     try:
         from importlib.metadata import version as _dist_ver
     except Exception:  # noqa: BLE001
@@ -490,7 +681,16 @@ def _dist_version(names: tuple[str, ...]) -> str:
 
 
 def _probe_tool_version(strategy: Any, root_dir: str) -> str:
-    """Resolve a tool's human version per its provenance ``strategy``."""
+    """Resolve a tool's human version per its provenance ``strategy``.
+
+    Args:
+        strategy (Any): the provenance strategy (``"git_describe"`` /
+            ``"git_short"`` / a ``("cmd", argv)`` or ``("dist", names)`` tuple).
+        root_dir (str): the tool install root for git-based strategies.
+
+    Returns:
+        str: the resolved version string, or ``""`` when it cannot be derived.
+    """
     try:
         if strategy == "git_describe":
             return _git_describe(Path(root_dir)) if root_dir else ""
@@ -522,6 +722,17 @@ def _tool_metadata(
     surfaced its own, else a cached per-tool probe (git describe / CLI
     ``--version`` / pip dist) following ``_TOOL_PROVENANCE``. All best-effort:
     nothing here ever raises into the optimizer.
+
+    Args:
+        tool (str): the external tool name (keys into ``_TOOL_PROVENANCE``).
+        root (str | None): an explicit install root, highest precedence.
+        root_env (str | None): a caller-supplied env var naming the root.
+        version (str | None): a caller-supplied version, preferred over the
+            probe.
+
+    Returns:
+        dict[str, Any]: the resolved ``{tool, root_dir, commit, version}``
+            metadata.
     """
     import os
 
@@ -558,7 +769,15 @@ def _tool_metadata(
 
 
 def _normalize_hot_kernel(k: dict[str, Any]) -> dict[str, Any]:
-    """Project a raw hot-kernel candidate onto the discovery shape."""
+    """Project a raw hot-kernel candidate onto the discovery shape.
+
+    Args:
+        k (dict[str, Any]): the raw hot-kernel candidate dict.
+
+    Returns:
+        dict[str, Any]: the candidate projected onto the normalized discovery
+            shape.
+    """
     return {
         "kernel_id":               str(k.get("kernel_id") or k.get("id") or ""),
         "name":                    str(k.get("name") or k.get("kernel_name") or ""),
@@ -604,6 +823,25 @@ def record_kernel_discovery(
     deterministic ``bypass`` route runs the same TraceLens toolchain, so its
     version provenance is still ``tracelens`` (passing ``tool="tracelens"``
     avoids minting an empty ``versions["bypass"]`` entry).
+
+    Args:
+        session_dir (Path | str | None): the session directory; a falsy value is
+            a no-op.
+        source (str): the discovery route label the dashboard groups by.
+        status (str): the discovery run status.
+        hot_kernels (list[Any] | None): the hot-kernel candidates the run
+            surfaced.
+        scan (dict[str, Any] | None): scan metadata (carries the
+            candidates/report path used as the idempotency key).
+        tool (str | None): the underlying tool whose version is recorded
+            (defaults to ``source``).
+        tool_root (str | None): an explicit tool install root.
+        tool_root_env (str | None): an env var naming the tool root.
+        tool_version (str | None): a caller-supplied tool version.
+        duration_sec (Any): the run duration in seconds.
+        error (str | None): an error string when the run failed.
+        producer (str): the breakdown producer label (defaults to the
+            kernel-agent).
     """
     if not session_dir:
         return
@@ -657,6 +895,17 @@ def record_tool_version(
     commit, version}`` via the tool provenance registry and spools it as one
     ``versions`` item; the assembler folds the substream into the top-level
     ``versions`` map. Best-effort: never raises into the optimizer.
+
+    Args:
+        session_dir (Path | str | None): the session directory; a falsy value is
+            a no-op.
+        tool (str): the external tool name; a falsy value is a no-op.
+        root (str | None): an explicit tool install root.
+        root_env (str | None): an env var naming the tool root.
+        version (str | None): a caller-supplied version, preferred over the
+            probe.
+        producer (str): the breakdown producer label (defaults to the
+            kernel-agent).
     """
     if not session_dir or not tool:
         return
@@ -687,6 +936,20 @@ def record_kernel_dispatch(
     Idempotent per ``kernel_id`` (last decision wins). ``dispatched`` is False
     for kernels gated out before any backend ran, with ``skip_reason`` holding
     the gate (non_reusable_kernel / missing_source / budget_exhausted / ...).
+
+    Args:
+        session_dir (Path | str | None): the session directory; a falsy value is
+            a no-op.
+        kernel_id (str): the kernel id the decision is keyed by; a falsy value
+            is a no-op.
+        dispatched (bool): whether the kernel was dispatched to a backend.
+        backends (list[str] | None): the backends the kernel was dispatched to.
+        skip_reason (str): the gate that blocked dispatch when ``dispatched`` is
+            False.
+        orchestration_commit (str): the orchestration commit at dispatch time.
+        task_group (str | None): the task group label.
+        producer (str): the breakdown producer label (defaults to the
+            kernel-agent).
     """
     if not session_dir or not kernel_id:
         return
@@ -719,6 +982,14 @@ def record_kernel_backend_result(
     ``run_id-backend``) so retries across runs are preserved rather than
     collapsed. Mirrors the attempt ladder in ``result['attempts']`` and carries
     the per-attempt timing + tool metadata when the kernel-agent surfaced them.
+
+    Args:
+        session_dir (Path | str | None): the session directory; a falsy value is
+            a no-op.
+        result (dict[str, Any]): the kernel-agent result carrying the
+            per-backend ``attempts`` ladder, verification, and metadata.
+        producer (str): the breakdown producer label (defaults to the
+            kernel-agent).
     """
     if not session_dir or not isinstance(result, dict):
         return
@@ -856,6 +1127,21 @@ def record_kernel_e2e(
 
     Idempotent per ``kernel_id``. ``e2e_gain_pct`` is the validated end-to-end
     gain at integrate (negative => regressed and reverted).
+
+    Args:
+        session_dir (Path | str | None): the session directory; a falsy value is
+            a no-op.
+        kernel_id (str): the kernel id the outcome is keyed by; a falsy value is
+            a no-op.
+        integrated (bool): whether the kernel change was integrated.
+        e2e_gain_pct (Any): the validated end-to-end gain percent at integrate.
+        validated (bool | None): whether the gain was validated.
+        decision (str): the integrate decision (KEEP / REVERT / ...).
+        patch_path (str | None): the applied patch path.
+        target_file (str | None): the integrated target file.
+        extra_server_args (str): extra server args carried by the change.
+        producer (str): the breakdown producer label (defaults to the
+            kernel-agent).
     """
     if not session_dir or not kernel_id:
         return
@@ -884,7 +1170,16 @@ def record_specialist_round(
     *,
     producer: str = PRODUCER_COORDINATOR,
 ) -> None:
-    """Record one ``specialist_runs`` round (idempotent by ``round_id``)."""
+    """Record one ``specialist_runs`` round (idempotent by ``round_id``).
+
+    Args:
+        session_dir (Path | str | None): the session directory; a falsy value is
+            a no-op.
+        entry (dict[str, Any]): the specialist round entry (keyed by
+            ``round_id``); an empty/non-dict value is a no-op.
+        producer (str): the breakdown producer label (defaults to the
+            Coordinator).
+    """
     if not session_dir or not isinstance(entry, dict) or not entry:
         return
     try:
@@ -917,6 +1212,20 @@ def record_critic_iteration(
     integration trace: whether the substrate assess / historical priors were
     used, the request, the response, and whether the final verdict referenced
     them. Omitted from the payload when empty so historical items are unchanged.
+
+    Args:
+        session_dir (Path | str | None): the session directory; a falsy value is
+            a no-op.
+        iter_n (int): the critic iteration number (idempotency key).
+        review (dict[str, Any] | None): the critic review payload.
+        emit (dict[str, Any] | None): the critic emit payload.
+        workdir (Path | str | None): the critic backend workdir holding the
+            per-iteration artifact files.
+        kb_assess (dict[str, Any] | None): the per-iteration substrate KB assess
+            trace; omitted when empty.
+        kb_priors (dict[str, Any] | None): the per-iteration historical KB
+            priors trace; omitted when empty.
+        producer (str): the breakdown producer label (defaults to ``critic``).
     """
     if not session_dir:
         return
@@ -957,6 +1266,15 @@ def record_robustness_signal(
     Reads ``signal.json`` / ``action.json`` from the just-written ``workdir``
     (idempotent on the workdir name) so the signal is captured before the
     robustness backend prunes old workdirs; payload mirrors the collector.
+
+    Args:
+        session_dir (Path | str | None): the session directory; a falsy value is
+            a no-op.
+        workdir (Path | str | None): the just-written robustness workdir holding
+            ``signal.json`` / ``action.json`` (idempotency key); a falsy value
+            is a no-op.
+        producer (str): the breakdown producer label (defaults to
+            ``robustness``).
     """
     if not session_dir or not workdir:
         return
@@ -984,7 +1302,16 @@ def record_singleton_section(
     *,
     producer: str,
 ) -> None:
-    """Record a producer-owned singleton section (report summaries, etc.)."""
+    """Record a producer-owned singleton section (report summaries, etc.).
+
+    Args:
+        session_dir (Path | str | None): the session directory; a falsy value is
+            a no-op.
+        section (str): the singleton section name to record.
+        payload (dict[str, Any]): the section payload; an empty/non-dict value
+            is a no-op.
+        producer (str): the breakdown producer label that owns the section.
+    """
     if not session_dir or not isinstance(payload, dict) or not payload:
         return
     try:

--- a/inference_optimizer/breakdown/recorder/recorder.py
+++ b/inference_optimizer/breakdown/recorder/recorder.py
@@ -34,11 +34,24 @@ _SANITIZE = re.compile(r"[^A-Za-z0-9._-]+")
 
 
 def _now_iso() -> str:
+    """Return the current UTC time as a microsecond-precision ISO-8601 string.
+
+    Returns:
+        The current UTC time formatted as an ISO-8601 string with microsecond
+        precision.
+    """
     return datetime.now(timezone.utc).isoformat(timespec="microseconds")
 
 
 def _slug(value: str) -> str:
-    """Filesystem-safe token; empty input collapses to ``unknown``."""
+    """Filesystem-safe token; empty input collapses to ``unknown``.
+
+    Args:
+        value: The raw string to sanitise into a filesystem-safe token.
+
+    Returns:
+        The sanitised token, or ``"unknown"`` when the input is empty.
+    """
     s = _SANITIZE.sub("-", str(value or "").strip())
     return s.strip("-.") or "unknown"
 
@@ -47,6 +60,14 @@ class Recorder:
     """Per-(session, producer) writer of breakdown record fragments."""
 
     def __init__(self, parts_dir: Path | str, *, producer: str) -> None:
+        """Initialize a recorder writing into ``parts_dir`` for ``producer``.
+
+        Args:
+            parts_dir (Path | str): the spool directory fragments are written
+                into.
+            producer (str): the producer label owning the written fragments
+                (sanitized into a filesystem-safe slug).
+        """
         self._dir = Path(parts_dir)
         self._producer = _slug(producer)
         self._seq = 0
@@ -54,13 +75,28 @@ class Recorder:
 
     @property
     def producer(self) -> str:
+        """Return the sanitized producer slug owning this recorder's fragments.
+
+        Returns:
+            The sanitized producer slug.
+        """
         return self._producer
 
     @property
     def parts_dir(self) -> Path:
+        """Return the spool directory fragments are written into.
+
+        Returns:
+            The spool directory path.
+        """
         return self._dir
 
     def _next_seq(self) -> int:
+        """Return the next monotonically increasing per-recorder sequence number.
+
+        Returns:
+            int: the next sequence number (thread-safe).
+        """
         with self._lock:
             self._seq += 1
             return self._seq
@@ -70,7 +106,16 @@ class Recorder:
         section: str,
         payload: Mapping[str, Any],
     ) -> Path:
-        """Write/overwrite this producer's single final blob for ``section``."""
+        """Write/overwrite this producer's single final blob for ``section``.
+
+        Args:
+            section: The breakdown section name (must be declared
+                ``singleton``-shaped).
+            payload: The final payload mapping for the section.
+
+        Returns:
+            The path of the written singleton fragment.
+        """
         self._check_shape(section, "singleton")
         filename = f"{_slug(section)}__{self._producer}.json"
         return self._write(section, "singleton", payload, filename=filename)
@@ -87,6 +132,16 @@ class Recorder:
         ``key`` (optional): a stable per-item identity. When given the fragment
         filename is derived from it, so re-recording the same key overwrites
         rather than duplicates (idempotent across retries / resume).
+
+        Args:
+            section: The breakdown section name (must be declared
+                ``item``-shaped).
+            payload: The event fragment payload mapping.
+            key: Optional stable per-item identity for idempotent rewrites;
+                when omitted a pid/sequence-unique filename is used.
+
+        Returns:
+            The path of the written item fragment.
         """
         self._check_shape(section, "item")
         if key:
@@ -101,6 +156,15 @@ class Recorder:
 
     @staticmethod
     def _check_shape(section: str, kind: str) -> None:
+        """Validate that ``section`` is used with its declared shape.
+
+        Args:
+            section: The breakdown section name being written.
+            kind: The shape being used (``"singleton"`` or ``"item"``).
+
+        Raises:
+            ValueError: If ``section`` is declared with a different shape.
+        """
         declared = SECTION_SHAPES.get(section)
         if declared is not None and declared != kind:
             raise ValueError(
@@ -116,6 +180,25 @@ class Recorder:
         *,
         filename: str,
     ) -> Path:
+        """Atomically write one fragment record to ``filename`` in the spool dir.
+
+        Wraps ``payload`` in the fragment envelope (section / kind / seq / ts /
+        producer) and writes it via a temp file plus ``os.replace`` so readers
+        never observe a partial write.
+
+        Args:
+            section (str): the breakdown section name.
+            kind (str): the fragment kind (``singleton`` or ``item``).
+            payload (Mapping[str, Any]): the record payload.
+            filename (str): the destination filename within the spool directory.
+
+        Returns:
+            Path: the path of the written fragment.
+
+        Raises:
+            Exception: re-raised if writing or replacing the file fails (the
+                temp file is removed first).
+        """
         self._dir.mkdir(parents=True, exist_ok=True)
         record = {
             "section":  section,
@@ -152,6 +235,15 @@ def get_recorder(session_dir: Path | str, *, producer: str) -> Recorder:
 
     Lets deep call sites obtain the writer without threading it through every
     function signature.
+
+    Args:
+        session_dir: The session directory whose breakdown parts dir backs the
+            recorder.
+        producer: The producer name owning the written fragments.
+
+    Returns:
+        The process-cached :class:`Recorder` for the
+        ``(session_dir, producer)`` pair.
     """
     from ...session_paths import breakdown_parts_dir  # local: avoid import cycle
 

--- a/inference_optimizer/breakdown/recorder/sections.py
+++ b/inference_optimizer/breakdown/recorder/sections.py
@@ -76,7 +76,15 @@ DERIVED_SECTIONS: frozenset[str] = frozenset({
 
 
 def section_shape(section: str) -> SectionShape | None:
-    """Return the declared shape for ``section`` (``None`` if unregistered)."""
+    """Return the declared shape for ``section`` (``None`` if unregistered).
+
+    Args:
+        section: The breakdown section name to look up.
+
+    Returns:
+        The declared section shape (``"item"`` / ``"singleton"``), or ``None``
+        when the section is not registered.
+    """
     return SECTION_SHAPES.get(section)
 
 

--- a/inference_optimizer/breakdown/reporters/_renderers/_invocation.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/_invocation.py
@@ -59,7 +59,17 @@ def render_invocation_block(
     invocation: Any,
     session_image: Any,
 ) -> str:
-    """Render an ``### Invocation`` markdown block, or "" when absent/empty."""
+    """Render an ``### Invocation`` markdown block, or "" when absent/empty.
+
+    Args:
+        invocation: Invocation record (dict) describing framework args,
+            environment overrides and config/log paths.
+        session_image: Container image associated with the session, if any.
+
+    Returns:
+        The rendered markdown block, or an empty string when the invocation
+        is missing or has nothing to show.
+    """
     if not isinstance(invocation, dict):
         return ""
     framework_args = str(invocation.get("framework_args") or "").strip()

--- a/inference_optimizer/breakdown/reporters/_renderers/data_provenance.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/data_provenance.py
@@ -14,7 +14,14 @@ from ..base import RenderedSection, md_table, register_renderer
 
 
 def _sources_summary(sources: list[dict[str, Any]]) -> str:
-    """Render a ``<found>/<total> probed`` summary, distinguishing required hits from optional."""
+    """Render a ``<found>/<total> probed`` summary, distinguishing required hits from optional.
+
+    Args:
+        sources: Probe records, each with ``found`` and ``required`` flags.
+
+    Returns:
+        A summary string of found/total counts, or ``"—"`` when empty.
+    """
     if not sources:
         return "—"
     total = len(sources)

--- a/inference_optimizer/breakdown/reporters/_renderers/invocations.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/invocations.py
@@ -19,7 +19,19 @@ def _render_pair(
     invocations_key: str,
     legacy_key: str,
 ) -> RenderedSection:
-    """Render either GEAK or OOB invocations (new ``invocations`` key, legacy fallback)."""
+    """Render either GEAK or OOB invocations (new ``invocations`` key, legacy fallback).
+
+    Args:
+        breakdown: The full ``session_breakdown.json`` dict.
+        section_id: Section identifier for the rendered block.
+        title: Human-readable section title.
+        invocations_key: Key under ``invocations`` to read records from.
+        legacy_key: Top-level fallback key for older breakdowns.
+
+    Returns:
+        The rendered section, or a skipped placeholder when no invocations
+        are present.
+    """
     raw = (
         (breakdown.get("invocations") or {}).get(invocations_key)
         or breakdown.get(legacy_key)

--- a/inference_optimizer/breakdown/reporters/_renderers/kernel_lifecycle.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/kernel_lifecycle.py
@@ -21,7 +21,15 @@ _MAX_NAME_LEN = 70
 
 
 def _short_name(name: str) -> str:
-    """Shorten a kernel name keeping head + tail (CK/ROCBLAS variants differ at the tail)."""
+    """Shorten a kernel name keeping head + tail (CK/ROCBLAS variants differ at the tail).
+
+    Args:
+        name: Full kernel name to shorten.
+
+    Returns:
+        The name unchanged when short enough, otherwise a head + tail
+        elision joined by ``"..."``.
+    """
     if not name:
         return ""
     if len(name) <= _MAX_NAME_LEN:

--- a/inference_optimizer/breakdown/reporters/base.py
+++ b/inference_optimizer/breakdown/reporters/base.py
@@ -64,7 +64,15 @@ REGISTRY: list[tuple[str, RendererFn]] = []
 
 
 def register_renderer(section_id: str) -> Callable[[RendererFn], RendererFn]:
-    """Decorator: register ``fn`` under ``section_id`` (re-registration replaces the prior entry)."""
+    """Decorator: register ``fn`` under ``section_id`` (re-registration replaces the prior entry).
+
+    Args:
+        section_id: Identifier under which the decorated renderer is stored.
+
+    Returns:
+        A decorator that registers the renderer function and returns it
+        unchanged.
+    """
 
     def _wrap(fn: RendererFn) -> RendererFn:
         """Register ``fn`` under ``section_id`` and return it unchanged.

--- a/inference_optimizer/breakdown/reporters/compose.py
+++ b/inference_optimizer/breakdown/reporters/compose.py
@@ -221,7 +221,14 @@ def _stitch(
 
 
 def _deterministic_exec_summary(g: GlobalFacts) -> str:
-    """Fallback exec summary when no LLM is configured / it failed; lists every data-quality flag."""
+    """Fallback exec summary when no LLM is configured / it failed; lists every data-quality flag.
+
+    Args:
+        g: Global facts used to populate the summary lines.
+
+    Returns:
+        The rendered executive-summary markdown block.
+    """
     out: list[str] = []
     out.append(f"- {g.headline} (stop_reason={g.stop_reason or 'unset'}, "
                f"elapsed={g.elapsed_minutes or 0:.0f}min, objective={g.objective}).")
@@ -249,7 +256,14 @@ def _deterministic_exec_summary(g: GlobalFacts) -> str:
 
 
 def _render_global_facts_block(g: GlobalFacts) -> str:
-    """Render :class:`GlobalFacts` as a compact key-value block for cross-checking the report."""
+    """Render :class:`GlobalFacts` as a compact key-value block for cross-checking the report.
+
+    Args:
+        g: Global facts to render as a key-value block.
+
+    Returns:
+        The rendered markdown key-value block.
+    """
     funnel = g.kernel_pipeline_funnel
     out: list[str] = []
     out.append(f"- **Headline**: {g.headline}")

--- a/inference_optimizer/breakdown/reporters/cross_section.py
+++ b/inference_optimizer/breakdown/reporters/cross_section.py
@@ -109,6 +109,13 @@ def _gain_attribution_lines(
 
     Priority: validated ``source_breakdown`` split, then single-entry
     ``final.action_path``, then best-effort ``optimization_stack``.
+
+    Args:
+        breakdown: The full ``session_breakdown.json`` dict.
+
+    Returns:
+        A tuple of the human-readable attribution lines and a label
+        describing the method used to derive them.
     """
     attribution = breakdown.get("attribution") or {}
     sb = attribution.get("source_breakdown") or {}
@@ -180,7 +187,15 @@ def _data_quality_flags(
     breakdown: dict[str, Any],
     rendered: list[RenderedSection],
 ) -> list[str]:
-    """Collect de-duplicated data-quality warnings from renderers + global cross-section checks."""
+    """Collect de-duplicated data-quality warnings from renderers + global cross-section checks.
+
+    Args:
+        breakdown: The full ``session_breakdown.json`` dict.
+        rendered: Rendered sections whose warnings are folded in.
+
+    Returns:
+        A de-duplicated list of data-quality flag strings.
+    """
     flags: list[str] = []
     seen: set[str] = set()
 

--- a/inference_optimizer/breakdown/reporters/llm_client.py
+++ b/inference_optimizer/breakdown/reporters/llm_client.py
@@ -63,6 +63,15 @@ class OpenAIHttpClient:
     timeout_sec: float = 60.0
 
     def complete(self, *, system: str, user: str) -> str:
+        """Issue a single chat-completion request and return the text.
+
+        Args:
+            system: System prompt content.
+            user: User prompt content.
+
+        Returns:
+            The content of the first choice's message.
+        """
         import httpx  # local import (see module docstring)
 
         url = self.base_url.rstrip("/") + "/chat/completions"

--- a/inference_optimizer/breakdown/reporters/llm_client.py
+++ b/inference_optimizer/breakdown/reporters/llm_client.py
@@ -170,6 +170,10 @@ def build_client_from_env() -> Any | None:
     ``HYPERLOOM_REPORT_MODEL``, ``HYPERLOOM_REPORT_MAX_TOKENS`` and the
     per-backend base-url/api-key vars; returns ``None``
     (deterministic-only) when required vars are missing.
+
+    Returns:
+        A configured backend client instance, or ``None`` when the backend
+        is disabled or required environment variables are missing.
     """
     backend = (os.environ.get("HYPERLOOM_REPORT_LLM_BACKEND") or "none").lower()
     if backend in ("", "none", "off", "disabled"):

--- a/inference_optimizer/breakdown/reporters/llm_prompt.py
+++ b/inference_optimizer/breakdown/reporters/llm_prompt.py
@@ -95,7 +95,15 @@ def build_user_prompt(
     rendered: list[RenderedSection],
     global_facts: GlobalFacts,
 ) -> str:
-    """Build the user-message JSON the LLM sees (string so the exact bytes are log-inspectable)."""
+    """Build the user-message JSON the LLM sees (string so the exact bytes are log-inspectable).
+
+    Args:
+        rendered: Rendered sections to include; skipped sections are withheld.
+        global_facts: Global facts block prepended to the prompt payload.
+
+    Returns:
+        A pretty-printed JSON string representing the user message.
+    """
     payload = {
         "global_facts": global_facts.as_prompt_dict(),
         # Skipped sections are withheld so the model can't "explain" a phantom section.
@@ -109,6 +117,13 @@ def parse_llm_response(raw: str) -> dict[str, Any]:
 
     Tolerates a code fence; on any failure returns empty fields so the
     deterministic-only output path stays usable.
+
+    Args:
+        raw: Raw text returned by the LLM, optionally wrapped in a code fence.
+
+    Returns:
+        A dict with ``executive_summary`` and ``section_narratives`` keys;
+        both empty when parsing fails.
     """
     text = (raw or "").strip()
     if text.startswith("```"):

--- a/inference_optimizer/breakdown/session_package.py
+++ b/inference_optimizer/breakdown/session_package.py
@@ -130,7 +130,11 @@ def _dest_root() -> Path:
 
 
 def _loose_enabled() -> bool:
-    """Whether to also drop loose (unzipped) copies. Defaults to True."""
+    """Whether to also drop loose (unzipped) copies. Defaults to True.
+
+    Returns:
+        ``True`` unless the env override disables loose copies.
+    """
     raw = (os.environ.get(ENV_PACKAGE_LOOSE) or "").strip().lower()
     return raw not in {"0", "false", "no", "off"}
 
@@ -149,6 +153,14 @@ def _copy_loose_tree(
     safe. A stale file from a previous, larger selection is left as-is;
     the per-run ``PACKAGE_MANIFEST`` is the source of truth for what this
     run actually included.
+
+    Args:
+        included: Tuples of ``(source path, relative path, size)`` to copy.
+        manifest: Manifest dict written alongside the copied files.
+        loose_dir: Destination root for the loose tree.
+
+    Returns:
+        The number of files successfully copied.
     """
     loose_dir.mkdir(parents=True, exist_ok=True)
     copied = 0
@@ -174,7 +186,14 @@ def _copy_loose_tree(
 
 def _iter_session_files(session_dir: Path) -> list[Path]:
     """All files under session_dir (one walk), so glob matching is a
-    single pass instead of N globs each re-walking the tree."""
+    single pass instead of N globs each re-walking the tree.
+
+    Args:
+        session_dir: Root directory to walk.
+
+    Returns:
+        Absolute paths of every file found under ``session_dir``.
+    """
     out: list[Path] = []
     for dp, _dn, fn in os.walk(session_dir):
         for f in fn:
@@ -188,6 +207,14 @@ def _select(session_dir: Path) -> tuple[list[Path], list[str]]:
     A glob is reported "unmatched" when it selected zero files — useful
     audit signal in the manifest (e.g. conc_sweep_summary absent because
     the sweep was skipped).
+
+    Args:
+        session_dir: Session directory whose files are matched against the
+            package globs.
+
+    Returns:
+        A tuple of the matched absolute paths and the patterns that matched
+        nothing.
     """
     all_files = _iter_session_files(session_dir)
     rels = {p: p.relative_to(session_dir).as_posix() for p in all_files}
@@ -220,6 +247,13 @@ def _glob_match(rel: str, pattern: str) -> bool:
       by replacing ``**`` with a sentinel that fnmatch's ``*`` covers.
     * otherwise → require the path to have the same number of segments,
       matching each segment with fnmatch so ``*`` stays within a segment.
+
+    Args:
+        rel: POSIX-style relative path to test.
+        pattern: Glob pattern, possibly containing ``**``.
+
+    Returns:
+        ``True`` when ``rel`` matches ``pattern``.
     """
     if "**" in pattern:
         # fnmatch's '*' already spans '/', so '**' == '*' for our purpose.

--- a/inference_optimizer/breakdown/session_package.py
+++ b/inference_optimizer/breakdown/session_package.py
@@ -119,6 +119,12 @@ _MAX_TOTAL_BYTES = 256 * 1024 * 1024  # 256 MB
 
 
 def _dest_root() -> Path:
+    """Resolve the destination root for session packages.
+
+    Returns:
+        The path from ``ENV_PACKAGE_DEST_ROOT`` when set, otherwise the
+        default destination root.
+    """
     override = (os.environ.get(ENV_PACKAGE_DEST_ROOT) or "").strip()
     return Path(override) if override else DEFAULT_DEST_ROOT
 
@@ -235,6 +241,19 @@ def _build_manifest(
     truncated: bool = False,
     dropped_files: list[str] | None = None,
 ) -> dict:
+    """Build the manifest dict describing a session package.
+
+    Args:
+        session_dir: Source session directory.
+        session_id: Identifier of the session.
+        included: ``(relative_path, size_bytes)`` pairs that were bundled.
+        missing_globs: Selection globs that matched no files.
+        truncated: Whether a size/count cap stopped the bundle short.
+        dropped_files: Files omitted due to truncation.
+
+    Returns:
+        A JSON-serializable manifest mapping.
+    """
     total = sum(sz for _, sz in included)
     return {
         "schema_version": PACKAGE_SCHEMA_VERSION,
@@ -254,6 +273,14 @@ def _build_manifest(
 
 
 def _manifest_text(manifest: dict) -> str:
+    """Render a manifest dict as a human-readable text summary.
+
+    Args:
+        manifest: Manifest mapping produced by :func:`_build_manifest`.
+
+    Returns:
+        A multi-line plain-text description of the package contents.
+    """
     lines = [
         "Hyperloom session artifact package",
         f"  session_id   : {manifest.get('session_id') or '?'}",

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -1524,6 +1524,19 @@ def _seed_shared_state(
     *,
     session_id: str,
 ) -> SharedState:
+    """Construct and persist the initial :class:`SharedState` for a run.
+
+    Seeds the state from parsed CLI args, clamping the research-lane
+    capacity to a safe range to protect quota and the PR-Monitor.
+
+    Args:
+        session_dir: Directory for the new session.
+        args: Parsed CLI arguments.
+        session_id: Identifier assigned to the session.
+
+    Returns:
+        The seeded :class:`SharedState` instance.
+    """
     # research_lane capacity is locked for the session; clamp to [0, ceiling] (2×GPU) to protect quota/PR-Monitor.
     from inference_optimizer.orchestrator.policy import (
         research_lane_ceiling,
@@ -3442,6 +3455,17 @@ def _export_workload_envs_for_optimize(
 
 
 async def _run_optimize(args: argparse.Namespace) -> int:
+    """Run the ``optimize`` subcommand end to end.
+
+    Resolves topology arguments (nodes, TP/EP, GPUs per node), runs
+    preflight, and drives the optimization session to completion.
+
+    Args:
+        args: Parsed CLI arguments for the ``optimize`` subcommand.
+
+    Returns:
+        Process exit code (``0`` on success).
+    """
     # Surface --nodes (CLI flag wins) before _preflight runs.
     nodes_resolved = max(1, int(args.nodes))
     tp_resolved = max(1, int(getattr(args, "tp", 1) or 1))
@@ -4324,6 +4348,11 @@ def _default_research_lane_capacity() -> int:
 
 
 def _build_parser() -> argparse.ArgumentParser:
+    """Build the top-level CLI argument parser and subcommands.
+
+    Returns:
+        The configured :class:`argparse.ArgumentParser`.
+    """
     from inference_optimizer.orchestrator.specialist_domains import (
         DEFAULT_SPECIALIST_MAX_TURNS as _DEFAULT_SPECIALIST_MAX_TURNS,
     )

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -124,7 +124,11 @@ class _RetiredFlag(argparse.Action):
 
 
 def _orchestration_rules_fragment_path() -> Path:
-    """Path to the rules-only ``orchestration.md`` fragment consumed by ``prompt_builder``."""
+    """Path to the rules-only ``orchestration.md`` fragment consumed by ``prompt_builder``.
+
+    Returns:
+        Path: The path to the ``orchestration.md`` system-prompt fragment.
+    """
     return asset_system_prompts_dir() / "orchestration.md"
 
 
@@ -161,7 +165,18 @@ def _build_orchestration_prompt(
     max_minutes: int,
     action_registry: ActionRegistry | None = None,
 ) -> str:
-    """Compose the Orchestration system prompt from typed inputs (``--orch-prompt`` overrides)."""
+    """Compose the Orchestration system prompt from typed inputs (``--orch-prompt`` overrides).
+
+    Args:
+        no_kernel: When True, kernel actions are excluded from the prompt.
+        framework: The target framework name.
+        objective: The run objective to summarise into the prompt.
+        max_minutes: The session time budget in minutes.
+        action_registry: Optional preloaded action registry; loaded if omitted.
+
+    Returns:
+        str: The composed orchestration system prompt.
+    """
     registry = action_registry or ActionRegistry().load()
     enabled = default_enabled_actions(no_kernel=no_kernel)
     kind, value = _objective_summary_for_prompt(objective)
@@ -225,6 +240,12 @@ def _gpu_runner_type(gpu_type: str) -> str:
 
     MI308X and MI325X share the gfx942 / CDNA3 die with MI300X and reuse
     the same Magpie benchmark scripts (sglang_mi300x.sh / vllm_mi300x.sh).
+
+    Args:
+        gpu_type: The resolved real GPU type (e.g. ``mi325x``).
+
+    Returns:
+        str: The Magpie runner label (``mi325x``/``mi308x`` map to ``mi300x``).
     """
     normalized = str(gpu_type or "").strip().lower()
     if normalized in ("mi325x", "mi308x"):
@@ -252,7 +273,12 @@ _CRITIC_AGENT_ROOT_ENV = "CRITIC_AGENT_ROOT"
 
 
 def _resolve_critic_agent_root() -> Path | None:
-    """Return the critic-agent skill root (``$CRITIC_AGENT_ROOT`` else sibling ``critic-agent/``), or ``None``."""
+    """Return the critic-agent skill root (``$CRITIC_AGENT_ROOT`` else sibling ``critic-agent/``), or ``None``.
+
+    Returns:
+        Path | None: The resolved critic-agent root containing
+        ``runtime/cli.py``, or ``None`` when it cannot be located.
+    """
     override = os.environ.get(_CRITIC_AGENT_ROOT_ENV, "").strip()
     if override:
         p = Path(override).expanduser()
@@ -263,7 +289,14 @@ def _resolve_critic_agent_root() -> Path | None:
 
 
 def _validate_critic_agent_runtime(root: Path) -> None:
-    """Fail fast (SystemExit) if ``python -m runtime.cli --help`` doesn't work."""
+    """Fail fast (SystemExit) if ``python -m runtime.cli --help`` doesn't work.
+
+    Args:
+        root: The critic-agent skill root to validate.
+
+    Raises:
+        SystemExit: With code 2 when the runtime cannot start or exits non-zero.
+    """
     cmd = [sys.executable, "-m", "runtime.cli", "--help"]
     try:
         proc = subprocess.run(
@@ -299,7 +332,12 @@ _ROBUSTNESS_AGENT_ROOT_ENV = "ROBUSTNESS_AGENT_ROOT"
 
 
 def _resolve_robustness_agent_root() -> Path | None:
-    """Return robustness-agent skill root (``$ROBUSTNESS_AGENT_ROOT`` else sibling), or ``None``."""
+    """Return robustness-agent skill root (``$ROBUSTNESS_AGENT_ROOT`` else sibling), or ``None``.
+
+    Returns:
+        Path | None: The resolved robustness-agent root containing the runtime
+        ``cli.py``, or ``None`` when it cannot be located.
+    """
     override = os.environ.get(_ROBUSTNESS_AGENT_ROOT_ENV, "").strip()
     if override:
         p = Path(override).expanduser()
@@ -362,6 +400,15 @@ def _apply_atom_auto_tighten(args: argparse.Namespace) -> list[str]:
 
     No auto-tightening is applied; kernel/framework/profile all work on atom. Multi-node TP wiring
     is unimplemented so ``--nodes>=2`` exits 2. Returns the list of auto-disabled flags (always empty).
+
+    Args:
+        args: Parsed CLI arguments (``nodes`` is consulted).
+
+    Returns:
+        list[str]: The auto-disabled flags (always empty).
+
+    Raises:
+        SystemExit: With code 2 when ``--nodes >= 2`` (atom is single-node).
     """
     auto_disabled: list[str] = []
     if int(getattr(args, "nodes", 1) or 1) >= 2:
@@ -393,6 +440,13 @@ def _resolve_gpu_type(
     Probe always wins on disagreement (wrong --gpu-type corrupts baseline+KB rows); user value kept
     only on probe failure. Returns ``(effective_gpu_type, warnings)``; warnings go to stderr to keep
     the ``HYPERLOOM_LAUNCH`` stdout sentinel clean.
+
+    Args:
+        user_specified: The user-provided ``--gpu-type`` hint.
+        probed: The hardware-probed GPU type.
+
+    Returns:
+        tuple[str, list[str]]: The effective GPU type and any warning strings.
     """
     warnings: list[str] = []
     if probed and user_specified and probed != user_specified:
@@ -420,6 +474,19 @@ def _emit_launch_info(
     """Print the machine-readable HYPERLOOM_LAUNCH stdout line; optionally JSON-dump to ``launch_info_file``.
 
     Returns the launch_info dict for callers/tests.
+
+    Args:
+        pid: The launched process id.
+        session_dir: The session directory.
+        session_id: The session id.
+        run_log: Path to the run log.
+        gpu_type: The resolved GPU type.
+        framework: The target framework.
+        model: The model path/id.
+        launch_info_file: Optional path to also JSON-dump the launch info to.
+
+    Returns:
+        dict[str, Any]: The launch info mapping.
     """
     launch_info: dict[str, Any] = {
         "event": "launch",
@@ -453,6 +520,15 @@ def _clean_stale_aiter_locks(
     Only deletes locks with mtime older than ``stale_minutes`` (default 5; above cold-start MoE build
     time, below the hang-suspicion cliff). Build dir resolution: caller arg → $INFERENCE_OPTIMIZER_AITER_JIT_DIR
     → dynamic <aiter>/jit/build → legacy fallbacks. Returns a stats dict; never raises (errors counted).
+
+    Args:
+        aiter_jit_dir: Optional explicit JIT build dir; resolved automatically
+            when ``None``.
+        stale_minutes: Minimum lock age (minutes) before deletion.
+
+    Returns:
+        dict[str, Any]: Stats with ``dir``, ``scanned``, ``deleted``,
+        ``skipped_fresh``, and ``errors`` counts.
     """
     stats: dict[str, Any] = {
         "dir": None,
@@ -530,7 +606,12 @@ def _clean_stale_aiter_locks(
 
 
 def _autodetect_gpu_type() -> str | None:
-    """Return mi300x|mi308x|mi325x|mi355x or None if undetectable (rocm-smi then torch gcnArchName, best-effort)."""
+    """Return mi300x|mi308x|mi325x|mi355x or None if undetectable (rocm-smi then torch gcnArchName, best-effort).
+
+    Returns:
+        str | None: The detected GPU runner label, or ``None`` when it cannot
+        be determined.
+    """
     import subprocess
     try:
         out = subprocess.run(
@@ -565,6 +646,13 @@ def _resolve_amd_gpu_type(explicit: str | None = None) -> str | None:
     callers gate AMD-specific behaviour on real hardware while still honouring
     a launcher/CI-supplied ``gpu_type`` even if ``rocm-smi``/torch probing is
     unavailable at the call site.
+
+    Args:
+        explicit: An explicit GPU type hint, consulted first.
+
+    Returns:
+        str | None: The resolved AMD GPU runner label, or ``None`` when not on
+        a recognised AMD GPU.
     """
     for cand in (explicit, os.environ.get("GPU_TYPE")):
         norm = str(cand or "").strip().lower()
@@ -587,6 +675,17 @@ def _resume_safe_flag(
 
     ``invert=True`` handles the ``--no-*`` pattern (args.no_X True == disable; manifest stores positive form).
     Lets robustness_monitor.sh resume preserve original intent without re-passing the flag.
+
+    Args:
+        args: Parsed CLI arguments.
+        arg_name: The attribute name on ``args`` to read.
+        manifest: The resume manifest, or ``None``.
+        manifest_key: The manifest key to fall back to.
+        default: The default returned when neither arg nor manifest applies.
+        invert: When True, treat the arg as a ``--no-*`` (disable) flag.
+
+    Returns:
+        bool: The resolved boolean value.
     """
     raw_arg = getattr(args, arg_name, None)
     if isinstance(raw_arg, bool) and raw_arg:
@@ -606,7 +705,18 @@ def _resume_safe_numeric(
     *,
     default: float,
 ) -> float:
-    """Float-valued analog of :func:`_resume_safe_flag`: explicit non-default arg → manifest → default."""
+    """Float-valued analog of :func:`_resume_safe_flag`: explicit non-default arg → manifest → default.
+
+    Args:
+        args: Parsed CLI arguments.
+        arg_name: The attribute name on ``args`` to read.
+        manifest: The resume manifest, or ``None``.
+        manifest_key: The manifest key to fall back to.
+        default: The default returned when neither arg nor manifest applies.
+
+    Returns:
+        float: The resolved numeric value.
+    """
     raw_arg = getattr(args, arg_name, None)
     if raw_arg is not None:
         try:
@@ -628,6 +738,14 @@ def _load_model_arch(workspace_root: Path, model_name: str) -> dict:
 
     Soft-degrades to ``{}`` (never blocks launch) on missing/unreadable/invalid file. Stale-file guard:
     require ``data["model_name"]`` basename to match launched ``--model`` basename, else WARN + ``{}``.
+
+    Args:
+        workspace_root: Directory containing ``model_arch.json``.
+        model_name: The launched model name used for the freshness check.
+
+    Returns:
+        dict: The parsed model-arch profile, or ``{}`` when absent, invalid,
+        or stale.
     """
     arch_path = workspace_root / "model_arch.json"
     try:
@@ -666,7 +784,14 @@ def _load_model_arch(workspace_root: Path, model_name: str) -> dict:
 
 
 def _load_model_config_dict(model_path: str) -> dict | None:
-    """Best-effort parse of ``<model_path>/config.json`` into a dict; returns ``None`` on any failure."""
+    """Best-effort parse of ``<model_path>/config.json`` into a dict; returns ``None`` on any failure.
+
+    Args:
+        model_path: Directory containing ``config.json``.
+
+    Returns:
+        dict | None: The parsed config dict, or ``None`` on any failure.
+    """
     if not model_path:
         return None
     cfg_path = Path(model_path) / "config.json"
@@ -691,7 +816,14 @@ def _load_model_config_dict(model_path: str) -> dict | None:
 
 
 def _config_architectures(config: dict) -> list[str]:
-    """Normalise ``config["architectures"]`` to a list of non-empty strings (scalar wrapped; absent -> [])."""
+    """Normalise ``config["architectures"]`` to a list of non-empty strings (scalar wrapped; absent -> []).
+
+    Args:
+        config: A model config dict.
+
+    Returns:
+        list[str]: The non-empty architecture strings.
+    """
     arches_raw = config.get("architectures")
     if isinstance(arches_raw, list):
         return [str(a).strip() for a in arches_raw if str(a or "").strip()]
@@ -704,6 +836,13 @@ def _load_model_config_tags(model_path: str) -> dict:
     """Best-effort loader for KB architecture-identity tags (``architectures`` + ``model_type``) from config.json.
 
     Soft-degrades to ``{}`` (never blocks launch); normalised fields are omitted when empty so callers can .get().
+
+    Args:
+        model_path: Directory containing ``config.json``.
+
+    Returns:
+        dict: KB architecture-identity tags (``architectures``, ``model_type``);
+        empty when the config is absent or has no identifiable fields.
     """
     data = _load_model_config_dict(model_path)
     if data is None:
@@ -824,7 +963,14 @@ _TEXT_COERCIBLE_MODEL_TYPES = frozenset({
 
 def _arch_is_supported_text_generation(arch: str) -> bool:
     """True when an architecture class name denotes a supported text-generation
-    (decoder-only causal LM) model."""
+    (decoder-only causal LM) model.
+
+    Args:
+        arch: An architecture class name from ``config.json``.
+
+    Returns:
+        bool: ``True`` when the name carries a supported text-generation marker.
+    """
     a = (arch or "").strip()
     if not a:
         return False
@@ -839,6 +985,14 @@ def _config_declares_text_decoder(config: dict, architectures: list[str], model_
     described under ``text_config`` / ``language_config``. Treat those nested
     text blocks as capability evidence instead of requiring a per-family
     allowlist entry.
+
+    Args:
+        config: The model config dict.
+        architectures: The normalised top-level architecture names.
+        model_type_l: The lower-cased top-level ``model_type``.
+
+    Returns:
+        bool: ``True`` when a usable text decoder is positively identified.
     """
     if model_type_l in _TEXT_COERCIBLE_MODEL_TYPES:
         return True
@@ -890,6 +1044,14 @@ def _detect_unsupported_model(model_path: str) -> dict | None:
       (e.g. Kimi-K2.6 / Qwen3.6 MoE, or a generic ``ForCausalLM`` arch that
       merely carries a ``vision_config``). Caller proceeds on the text path with
       a degraded-mode warning unless ``--allow-mm-text-fallback`` is off.
+
+    Args:
+        model_path: Directory containing the model's ``config.json``.
+
+    Returns:
+        dict | None: ``None`` for a plain (or unreadable) text-generation
+        model; otherwise a dict with ``architecture``, ``model_type``,
+        ``signal``, and ``verdict``.
     """
     config = _load_model_config_dict(model_path)
     if config is None:
@@ -1004,7 +1166,15 @@ _MAX_MODEL_LEN_HEADROOM = 4096
 
 
 def _load_model_max_position_embeddings(model_path: str) -> int | None:
-    """Best-effort read of max sequence length from config.json (first positive among known keys, incl. nested ``text_config``), or None."""
+    """Best-effort read of max sequence length from config.json (first positive among known keys, incl. nested ``text_config``), or None.
+
+    Args:
+        model_path: Directory containing ``config.json``.
+
+    Returns:
+        int | None: The first positive max-sequence-length value found, or
+        ``None`` when unavailable.
+    """
     if not model_path:
         return None
     cfg_path = Path(model_path) / "config.json"
@@ -1035,6 +1205,12 @@ def _model_has_dual_chunk_attention(model_path: str) -> bool:
     default aiter attention backend and demands ``dual_chunk_flash_attn``.
     Checks the top level and a nested ``text_config``. Soft-degrades to
     False on any missing / unreadable / invalid config.
+
+    Args:
+        model_path: Directory containing ``config.json``.
+
+    Returns:
+        bool: ``True`` when a ``dual_chunk_attention_config`` is present.
     """
     data = _load_model_config_dict(model_path)
     if data is None:
@@ -1059,6 +1235,12 @@ def _model_is_moe(model_path: str) -> bool:
     callers use this to switch to a ROCm-capable MoE runner. Checks the top
     level and a nested ``text_config``. Soft-degrades to False on any missing
     / unreadable / invalid config.
+
+    Args:
+        model_path: Directory containing ``config.json``.
+
+    Returns:
+        bool: ``True`` when the config carries Mixture-of-Experts markers.
     """
     data = _load_model_config_dict(model_path)
     if data is None:
@@ -1085,7 +1267,11 @@ def _model_is_moe(model_path: str) -> bool:
 
 
 def _context_headroom_tokens() -> int:
-    """Resolve the context headroom (tokens); env override, else default."""
+    """Resolve the context headroom (tokens); env override, else default.
+
+    Returns:
+        int: The non-negative context headroom in tokens.
+    """
     raw = os.environ.get(_CONTEXT_HEADROOM_ENV, "").strip()
     if not raw:
         return _CONTEXT_HEADROOM_DEFAULT
@@ -1097,7 +1283,16 @@ def _context_headroom_tokens() -> int:
 
 
 def _resolve_max_model_len(isl: int, osl: int, model_path: str) -> int:
-    """Resolve ``MAX_MODEL_LEN`` = ISL+OSL+headroom, clamped to ``max_position_embeddings`` (never stretch context)."""
+    """Resolve ``MAX_MODEL_LEN`` = ISL+OSL+headroom, clamped to ``max_position_embeddings`` (never stretch context).
+
+    Args:
+        isl: Input sequence length.
+        osl: Output sequence length.
+        model_path: Directory containing ``config.json`` for the clamp.
+
+    Returns:
+        int: The resolved max model length, clamped to the native window.
+    """
     desired = int(isl) + int(osl) + _MAX_MODEL_LEN_HEADROOM
     maxpos = _load_model_max_position_embeddings(model_path)
     if maxpos:
@@ -1110,6 +1305,14 @@ def _preflight_context_window(args: argparse.Namespace, session_dir: Path) -> bo
 
     Persists a stop reason and returns True (caller should exit) when the workload does NOT fit; False
     when it fits or the model's max length is unknown.
+
+    Args:
+        args: Parsed CLI arguments (``isl``, ``osl``, ``model``).
+        session_dir: The session directory for the persisted stop report.
+
+    Returns:
+        bool: ``True`` when the workload does not fit (caller should exit),
+        ``False`` otherwise.
     """
     isl = int(getattr(args, "isl", 0) or 0)
     osl = int(getattr(args, "osl", 0) or 0)
@@ -1206,6 +1409,13 @@ def _detect_amd_unsupported_quant(model_path: str) -> str | None:
     Reads both ``config.json:quantization_config`` (standard HF) and the
     separate ``hf_quant_config.json`` (NVIDIA ModelOpt). Returns None when the
     format is ROCm-runnable or absent.
+
+    Args:
+        model_path: Directory containing the model's config files.
+
+    Returns:
+        str | None: A human-readable reason when the quant format is
+        unsupported on ROCm, otherwise ``None``.
     """
     if not model_path:
         return None
@@ -1266,6 +1476,14 @@ def _detect_incompatible_model_config(
 
     A fully absent ``config.json`` is NOT blocked (kept soft-degrade): the
     upstream submission filter + downstream loader still apply.
+
+    Args:
+        model_path: Directory containing the model's ``config.json``.
+        gpu_type: Resolved GPU type used to gate AMD/ROCm-only checks.
+
+    Returns:
+        str | None: A human-readable incompatibility reason, or ``None`` when
+        no statically-knowable incompatibility is found.
     """
     if not model_path:
         return None
@@ -1357,7 +1575,13 @@ def _preflight_model_config_compat(
     or a RoPE block without any max-position field) so we persist a clear stop
     reason instead of booting a server that dies cryptically in engine init.
 
-    Returns True when incompatible (caller should exit); False otherwise.
+    Args:
+        args: Parsed CLI arguments (``model``, ``gpu_type``).
+        session_dir: Session directory for the persisted stop report.
+
+    Returns:
+        bool: ``True`` when incompatible (caller should exit), ``False``
+        otherwise.
     """
     model = str(getattr(args, "model", "") or "")
     detail = _detect_incompatible_model_config(
@@ -1424,6 +1648,14 @@ def _preflight_unsupported_model_arch(
       to fail-fast.
     * ``vision_only`` (true VLM / unclassifiable) → persists
       ``stop_reason=unsupported_model_arch`` and returns True (caller exits).
+
+    Args:
+        args: Parsed CLI arguments (``model``, ``allow_mm_text_fallback``).
+        session_dir: Session directory for the persisted stop report.
+
+    Returns:
+        bool: ``True`` when the model is unsupported (caller should exit),
+        ``False`` otherwise.
     """
     model = str(getattr(args, "model", "") or "")
     hit = _detect_unsupported_model(model)
@@ -1606,6 +1838,12 @@ def _seed_shared_state(
 
         Ladder: explicit CLI/$FRAMEWORK_VERSION → auto-detect package __version__ → "" (canonical_id
         substitutes unknown_version). Auto-detect runs only when both CLI and env are empty.
+
+        Args:
+            args_in: Parsed CLI arguments (``framework_version``, ``framework``).
+
+        Returns:
+            str: The resolved framework version, or an empty string when unknown.
         """
         explicit = (
             (getattr(args_in, "framework_version", None) or "").strip()
@@ -1739,7 +1977,15 @@ def _seed_shared_state(
 
 
 def _parse_conc_sweep_concs(args: argparse.Namespace) -> list[int]:
-    """Parse ``--conc-sweep-concs '1,2,4,8'`` into a list[int]; non-integers warned+dropped, empty -> 1..128 ladder."""
+    """Parse ``--conc-sweep-concs '1,2,4,8'`` into a list[int]; non-integers warned+dropped, empty -> 1..128 ladder.
+
+    Args:
+        args: Parsed CLI arguments carrying ``conc_sweep_concs``.
+
+    Returns:
+        list[int]: The parsed concurrency ladder, or the default
+        ``[1, 2, 4, 8, 16, 32, 64, 128]`` when empty.
+    """
     raw = str(getattr(args, "conc_sweep_concs", "") or "").strip()
     if not raw:
         return [1, 2, 4, 8, 16, 32, 64, 128]
@@ -1774,7 +2020,12 @@ def _snapshot_system_prompts(
     *,
     prompts: dict[str, str],
 ) -> None:
-    """Persist each agent's effective system prompt to ``agents/<role>/system_prompt.snapshot.md``."""
+    """Persist each agent's effective system prompt to ``agents/<role>/system_prompt.snapshot.md``.
+
+    Args:
+        session_dir: Session root directory for the snapshots.
+        prompts: Mapping of agent role to its effective system prompt.
+    """
     for role, body in prompts.items():
         target = agent_prompt_snapshot(session_dir, role)
         target.parent.mkdir(parents=True, exist_ok=True)
@@ -1862,6 +2113,10 @@ def _reconcile_crash_count(state: SharedState, session_dir: Path) -> None:
     """Reconcile persisted ``crash_count`` (state.json + final.json) up to the live in-memory value.
 
     Only ever raises the persisted value (max), never lowers it; best-effort, never fatal.
+
+    Args:
+        state: The live shared state carrying the in-memory ``crash_count``.
+        session_dir: Session directory holding ``state.json`` and the report.
     """
     live = int(getattr(state, "crash_count", 0) or 0)
 
@@ -1891,7 +2146,12 @@ def _reconcile_crash_count(state: SharedState, session_dir: Path) -> None:
 
 
 def _print_kernel_opt_summary_line(state: SharedState) -> None:
-    """One-line forensic readout of kernel_opt attempts at session end (matches the on-disk report; best-effort)."""
+    """One-line forensic readout of kernel_opt attempts at session end (matches the on-disk report; best-effort).
+
+    Args:
+        state: The shared state used to resolve the session directory and
+            build the kernel-optimization summary.
+    """
     try:
         from .orchestrator.kernel_attempt_summary import (
             build_kernel_optimization_summary,
@@ -1925,7 +2185,15 @@ def _print_kernel_opt_summary_line(state: SharedState) -> None:
 
 
 def _resolve_session_dir_for_summary(state: SharedState) -> Path | None:
-    """Best-effort session_dir lookup ($HYPERLOOM_SESSION_DIR) for the stdout kernel_opt line; ``None`` if unresolved."""
+    """Best-effort session_dir lookup ($HYPERLOOM_SESSION_DIR) for the stdout kernel_opt line; ``None`` if unresolved.
+
+    Args:
+        state: The shared state (reserved for future resolution heuristics).
+
+    Returns:
+        Path | None: The resolved session directory, or ``None`` when it
+        cannot be determined.
+    """
     env_sd = os.environ.get("HYPERLOOM_SESSION_DIR", "").strip()
     if env_sd:
         p = Path(env_sd).expanduser()
@@ -1935,7 +2203,14 @@ def _resolve_session_dir_for_summary(state: SharedState) -> Path | None:
 
 
 def _derive_anthropic_base_url(openai_base_url: str) -> str:
-    """Derive ``ANTHROPIC_BASE_URL`` from ``OPENAI_BASE_URL`` by stripping a trailing ``/v1`` (SDK re-appends it)."""
+    """Derive ``ANTHROPIC_BASE_URL`` from ``OPENAI_BASE_URL`` by stripping a trailing ``/v1`` (SDK re-appends it).
+
+    Args:
+        openai_base_url: The OpenAI-style base URL to transform.
+
+    Returns:
+        str: The derived Anthropic base URL.
+    """
     from urllib.parse import urlparse, urlunparse
 
     parsed = urlparse(openai_base_url)
@@ -1948,7 +2223,12 @@ def _derive_anthropic_base_url(openai_base_url: str) -> str:
 def _reset_claude_config_to_upstream(
     safe_key: str, anthropic_base_url: str
 ) -> None:
-    """Point ``~/.claude/config.json`` ``customApiUrl`` at the upstream gateway (stale 127.0.0.1:4002 would fail)."""
+    """Point ``~/.claude/config.json`` ``customApiUrl`` at the upstream gateway (stale 127.0.0.1:4002 would fail).
+
+    Args:
+        safe_key: SaFE API key to persist as ``primaryApiKey`` when provided.
+        anthropic_base_url: Upstream gateway URL to write as ``customApiUrl``.
+    """
     import json as _json
 
     if not anthropic_base_url:
@@ -2015,7 +2295,14 @@ def _validate_credentials() -> None:
 
 
 def _is_placeholder_tracelens_path(value: str) -> bool:
-    """Treat .env.template's bare ``\\`` and whitespace-only values as unset."""
+    """Treat .env.template's bare ``\\`` and whitespace-only values as unset.
+
+    Args:
+        value: The raw configuration value to inspect.
+
+    Returns:
+        bool: ``True`` when the value is a placeholder/unset, else ``False``.
+    """
     stripped = value.strip()
     return stripped in ("", "\\")
 
@@ -2143,6 +2430,13 @@ def _ensure_python_sdks(python_exe: str, pip_extra: list[str]) -> None:
 
     Avoids first-tick BackendError after baseline burns wall time; same-interpreter install avoids
     cross-interpreter install failures.
+
+    Args:
+        python_exe: Interpreter used to both probe and install the SDKs.
+        pip_extra: Extra arguments forwarded to ``pip install``.
+
+    Raises:
+        subprocess.CalledProcessError: If a required ``pip install`` fails.
     """
     candidates = (
         ("claude_agent_sdk", "claude-agent-sdk>=0.1.65"),
@@ -2314,7 +2608,13 @@ def _emit_preflight_diagnostics(
     anthropic_base_url: str | None,
     args: argparse.Namespace | None = None,
 ) -> None:
-    """One canonical, grep-friendly diagnostics block at the end of preflight."""
+    """One canonical, grep-friendly diagnostics block at the end of preflight.
+
+    Args:
+        magpie_python: Path to the Magpie Python interpreter.
+        anthropic_base_url: Resolved Anthropic gateway URL, or ``None``.
+        args: Parsed CLI arguments used to report KB/PR-monitor status.
+    """
     from .orchestrator.action_executors.baseline import (
         BASELINE_COLD_START_TIMEOUT_SEC,
         BASELINE_DEFAULT_TIMEOUT_SEC,
@@ -2379,7 +2679,15 @@ def _emit_preflight_diagnostics(
 
 
 def _print_cortex_kb_queue_status() -> None:
-    """Emit a one-line summary of the Cortex KB offline NDJSON queue (dead-letter = permanent-reject signal)."""
+    """Emit a one-line summary of the Cortex KB offline NDJSON queue (dead-letter = permanent-reject signal).
+
+    Reads the pending, dead-letter, and flushed NDJSON queues for the resolved
+    session and prints their row counts.
+
+    Note:
+        Side-effecting: writes a one-line status summary to stdout and returns
+        nothing.
+    """
     from .session_paths import (
         cortex_dead_letter_ndjson,
         cortex_flushed_ndjson,
@@ -2431,6 +2739,14 @@ def _probe_llm_catalog(
     """Probe ``<base_url>/models`` with retry (gateway flakes); return set of model ids or None.
 
     TLS verification is on by default; ``INFERENCE_OPTIMIZER_CATALOG_PROBE_INSECURE=1`` skips it (warns).
+
+    Args:
+        base_url: Gateway base URL whose ``/models`` endpoint is probed.
+        api_key: Bearer token sent in the ``Authorization`` header.
+
+    Returns:
+        set[str] | None: The set of model ids on success, or ``None`` when the
+        probe is skipped or exhausts its retries.
     """
     import time
 
@@ -2530,6 +2846,18 @@ def _validate_and_resolve_claude_model(
 
     Probes the gateway catalog (retries); falls back 4-7→4-6 with a WARN, else sys.exit(2). Returns the
     catalog id set on success (reused by the codex smoke-test).
+
+    Args:
+        args: Parsed CLI arguments; ``claude_model`` may be mutated in place.
+        resolved_urls: Optional ``(anthropic_url, openai_url)`` pair used to
+            derive the catalog probe base URL.
+
+    Returns:
+        set[str] | None: The gateway catalog id set on success.
+
+    Raises:
+        SystemExit: If the chosen model is disallowed, the catalog is
+            unreachable, or no acceptable model is present.
     """
     chosen = (args.claude_model or "").strip()
     if chosen not in _CLAUDE_ALLOWED_MODELS:
@@ -2591,7 +2919,13 @@ def _smoke_test_codex_model(
     args: argparse.Namespace,
     catalog_ids: set[str] | None,
 ) -> None:
-    """WARN-only catalog check for ``--codex-model`` (no hard gate); flags typos before Coordinator starts."""
+    """WARN-only catalog check for ``--codex-model`` (no hard gate); flags typos before Coordinator starts.
+
+    Args:
+        args: Parsed CLI arguments (``codex_model``, ``critic_backend``,
+            ``kernel_codex``, ``no_kernel``).
+        catalog_ids: Gateway catalog id set, or ``None`` when unavailable.
+    """
     if catalog_ids is None:
         return
     # Codex is needed by the Kernel agent (kernel-codex on) and the critic-agent review path.
@@ -2627,6 +2961,12 @@ def _inferencex_checkout_ok(path: Path | str) -> bool:
     ``git init`` that then failed to fetch/checkout. Magpie sources
     ``benchmarks/benchmark_lib.sh`` at runtime, so require that file to
     exist — a complete checkout always has it, a stub never does.
+
+    Args:
+        path: Candidate InferenceX checkout directory.
+
+    Returns:
+        bool: ``True`` when the checkout looks complete, else ``False``.
     """
     return (Path(path) / "benchmarks" / "benchmark_lib.sh").is_file()
 
@@ -2642,6 +2982,12 @@ def _clone_inferencex(dest: Path) -> str | None:
     On any failure the partial ``dest`` (e.g. a bare ``git init`` with no
     fetched tree) is removed so a later preflight's detection does not
     mistake the stub for a valid checkout and skip re-cloning.
+
+    Args:
+        dest: Destination directory for the InferenceX checkout.
+
+    Returns:
+        str | None: The checkout path on success, or ``None`` on failure.
     """
     repo = os.environ.get("INFERENCEX_REPO") or _INFERENCEX_REPO_DEFAULT
     ref = os.environ.get("INFERENCEX_REF") or _INFERENCEX_REF_DEFAULT
@@ -2683,6 +3029,13 @@ def _preflight(
     Credentials fallback → auth aliases → SDK install → ANTHROPIC_BASE_URL resolve + ~/.claude reset →
     ROCm hygiene → ray/Magpie/InferenceX install → CLI presence checks → diagnostics. Returns
     ``(anthropic_base_url, openai_base_url)`` or ``None`` when ``OPENAI_BASE_URL`` is missing.
+
+    Args:
+        args: Parsed CLI arguments, or ``None`` when run outside a command.
+
+    Returns:
+        tuple[str, str] | None: ``(anthropic_base_url, openai_base_url)`` on
+        success, or ``None`` when ``OPENAI_BASE_URL`` is missing.
     """
     _load_dotenv_fallback()
     _load_kernel_agent_env_fallback()
@@ -2897,6 +3250,9 @@ def _run_ir3_preflight(args: argparse.Namespace) -> None:
 
     Mutates args: ``cortex_enabled``/``pr_monitor_enabled`` plus
     ``kb_degraded_reason``/``pr_degraded_reason`` (None|"explicit_flag"|"ir3_auto").
+
+    Args:
+        args: Parsed CLI arguments; reachability fields are mutated in place.
     """
     explicit_kb = bool(getattr(args, "degraded_kb", False))
     explicit_pr = bool(getattr(args, "degraded_pr", False))
@@ -2973,7 +3329,17 @@ _VALID_CRITIC_BACKENDS = ("mock", "agent")
 
 
 def _resolve_critic_choice(args: argparse.Namespace) -> str:
-    """Resolve the active critic backend choice (arg → DEFAULT_CRITIC_BACKEND); hard-fails on invalid."""
+    """Resolve the active critic backend choice (arg → DEFAULT_CRITIC_BACKEND); hard-fails on invalid.
+
+    Args:
+        args: Parsed CLI arguments carrying ``critic_backend``.
+
+    Returns:
+        str: The resolved critic backend name.
+
+    Raises:
+        SystemExit: If the resolved backend is not a valid choice.
+    """
     chosen = args.critic_backend
     if chosen is None:
         chosen = DEFAULT_CRITIC_BACKEND
@@ -3001,6 +3367,15 @@ def _resolve_robustness_choice(args: argparse.Namespace) -> str:
     Multi-node policy: on ``nodes>=2`` the agent's LocalProbe targets sandbox-local resources that live in
     separate pods (HIGH false positives). Keep ``agent`` only when a robustness-server is configured; else
     auto-downgrade to ``mock`` (explicit --robustness-agent gets a WARN).
+
+    Args:
+        args: Parsed CLI arguments (``robustness_backend``, ``nodes``).
+
+    Returns:
+        str: The resolved robustness backend name.
+
+    Raises:
+        SystemExit: If the resolved backend is not a valid choice.
     """
     chosen = getattr(args, "robustness_backend", None)
     explicit = chosen is not None
@@ -3037,7 +3412,11 @@ def _resolve_robustness_choice(args: argparse.Namespace) -> str:
 
 
 def _reset_state_file(session_dir: Path) -> None:
-    """Back up ``state.json`` to ``state.json.preReset.<unix_ts>`` and start fresh (Cortex KB untouched)."""
+    """Back up ``state.json`` to ``state.json.preReset.<unix_ts>`` and start fresh (Cortex KB untouched).
+
+    Args:
+        session_dir: Session directory holding the ``state.json`` to reset.
+    """
     state_path = session_dir / "state.json"
     if not state_path.exists():
         return
@@ -3069,6 +3448,11 @@ def _gc_old_profile_traces(
 
     Never blocks startup (errors swallowed). Env knobs: HYPERLOOM_MN_TRACE_RETENTION_DAYS,
     HYPERLOOM_MN_TRACE_GC_DISABLE.
+
+    Args:
+        root: Trace-root directory to scan; defaults to the multi-node root.
+        retention_days: Age threshold in days before a trace dir is removed.
+        keep: Name of a trace dir to always preserve.
     """
     if os.environ.get("HYPERLOOM_MN_TRACE_GC_DISABLE", "").strip() in (
         "1", "true", "yes",
@@ -3251,6 +3635,10 @@ def _replay_kernel_patches_for_multi_node(args: argparse.Namespace) -> None:
     """Replay every applied kernel-agent patch (manifest status=applied + multinode block) onto RayJob pods.
 
     Idempotent ``apply-patch`` fan-out, run only when ``--nodes>=2``. Best-effort: per-patch failures warn.
+
+    Args:
+        args: Parsed CLI arguments carrying ``nodes`` (replay is a no-op for
+            single-node runs).
     """
     nodes = max(1, int(getattr(args, "nodes", 1) or 1))
     if nodes < 2:
@@ -3352,6 +3740,14 @@ async def _run_quantization_prelude(args: argparse.Namespace) -> None:
         The skip is made **detectable** so a launcher / UI never mistakes the
         run for quantized: a ``QUANTIZATION_SKIPPED:`` marker line on stdout
         plus the ``$HYPERLOOM_QUANTIZATION_SKIPPED`` env var (set to the reason).
+
+    Args:
+        args: Parsed CLI arguments (``quantize``, ``quantize_scheme``,
+            ``model``, ``resume``); ``model`` is rewritten on success.
+
+    Raises:
+        SystemExit: With code 3 when an explicitly requested quantization
+            fails or is blocked.
     """
     # Free-text --quantize wins; otherwise resolve the structured
     # --quantize-scheme enum (the UI/backend path) to a prompt.
@@ -3444,7 +3840,16 @@ def _export_workload_envs_for_optimize(
     ep_resolved: int,
     argv: list[str] | None = None,
 ) -> None:
-    """Mirror explicit workload CLI flags (--tp/--conc/--ep) into env so executors' Magpie YAMLs honor them."""
+    """Mirror explicit workload CLI flags (--tp/--conc/--ep) into env so executors' Magpie YAMLs honor them.
+
+    Args:
+        args: Parsed CLI arguments (reads ``conc``).
+        nodes_resolved: Resolved node count (>=2 forces all exports).
+        tp_resolved: Resolved tensor-parallel size exported as ``$TP``.
+        ep_resolved: Resolved expert-parallel size exported as ``$EP``.
+        argv: Argument vector to scan for explicit flags; defaults to
+            ``sys.argv[1:]``.
+    """
     argv = list(sys.argv[1:] if argv is None else argv)
     if nodes_resolved >= 2 or _argv_has_option(argv, "--tp"):
         os.environ["TP"] = str(tp_resolved)
@@ -4336,7 +4741,11 @@ async def _run_optimize(args: argparse.Namespace) -> int:
 
 
 def _default_research_lane_capacity() -> int:
-    """Default ``--research-lane-capacity``: $INFERENCE_OPTIMIZER_RESEARCH_LANE_CAPACITY else the GPU ceiling (2×GPU)."""
+    """Default ``--research-lane-capacity``: $INFERENCE_OPTIMIZER_RESEARCH_LANE_CAPACITY else the GPU ceiling (2×GPU).
+
+    Returns:
+        int: The resolved default research-lane capacity.
+    """
     env = os.environ.get("INFERENCE_OPTIMIZER_RESEARCH_LANE_CAPACITY")
     if env:
         try:

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -131,7 +131,11 @@ class _RetiredFlag(argparse.Action):
 
 
 def _orchestration_rules_fragment_path() -> Path:
-    """Path to the rules-only ``orchestration.md`` fragment consumed by ``prompt_builder``."""
+    """Path to the rules-only ``orchestration.md`` fragment consumed by ``prompt_builder``.
+
+    Returns:
+        Path: The path to the bundled ``orchestration.md`` fragment.
+    """
     return asset_system_prompts_dir() / "orchestration.md"
 
 
@@ -170,7 +174,21 @@ def _build_orchestration_prompt(
     no_framework: bool = False,
     action_registry: ActionRegistry | None = None,
 ) -> str:
-    """Compose the Orchestration system prompt from typed inputs (``--orch-prompt`` overrides)."""
+    """Compose the Orchestration system prompt from typed inputs (``--orch-prompt`` overrides).
+
+    Args:
+        no_kernel (bool): When ``True`` the kernel actions are disabled.
+        framework (str): The serving framework name (e.g. ``sglang``).
+        objective (Objective): The run objective summarised into the prompt.
+        max_minutes (int): The wall-clock budget in minutes.
+        no_explore (bool): When ``True`` the EXPLORE phase is disabled.
+        no_framework (bool): When ``True`` the FRAMEWORK_PR phase is disabled.
+        action_registry (ActionRegistry | None): The action registry to use;
+            a fresh loaded registry is built when ``None``.
+
+    Returns:
+        str: The composed Orchestration system prompt.
+    """
     registry = action_registry or ActionRegistry().load()
     enabled = default_enabled_actions(no_kernel=no_kernel, no_explore=no_explore)
     kind, value = _objective_summary_for_prompt(objective)
@@ -236,6 +254,13 @@ def _gpu_runner_type(gpu_type: str) -> str:
 
     MI308X and MI325X share the gfx942 / CDNA3 die with MI300X and reuse
     the same Magpie benchmark scripts (sglang_mi300x.sh / vllm_mi300x.sh).
+
+    Args:
+        gpu_type (str): The resolved real GPU type (e.g. ``mi325x``).
+
+    Returns:
+        str: The Magpie runner label (``mi325x`` / ``mi308x`` collapse to
+            ``mi300x``).
     """
     normalized = str(gpu_type or "").strip().lower()
     if normalized in ("mi325x", "mi308x"):
@@ -263,7 +288,12 @@ _CRITIC_AGENT_ROOT_ENV = "CRITIC_AGENT_ROOT"
 
 
 def _resolve_critic_agent_root() -> Path | None:
-    """Return the critic-agent skill root (``$CRITIC_AGENT_ROOT`` else sibling ``critic-agent/``), or ``None``."""
+    """Return the critic-agent skill root (``$CRITIC_AGENT_ROOT`` else sibling ``critic-agent/``), or ``None``.
+
+    Returns:
+        Path | None: The validated critic-agent root, or ``None`` when no
+            candidate contains ``runtime/cli.py``.
+    """
     override = os.environ.get(_CRITIC_AGENT_ROOT_ENV, "").strip()
     if override:
         p = Path(override).expanduser()
@@ -274,7 +304,15 @@ def _resolve_critic_agent_root() -> Path | None:
 
 
 def _validate_critic_agent_runtime(root: Path) -> None:
-    """Fail fast (SystemExit) if ``python -m runtime.cli --help`` doesn't work."""
+    """Fail fast (SystemExit) if ``python -m runtime.cli --help`` doesn't work.
+
+    Args:
+        root (Path): The critic-agent skill root to validate.
+
+    Raises:
+        SystemExit: With code 2 when the runtime cannot start or exits
+            non-zero.
+    """
     cmd = [sys.executable, "-m", "runtime.cli", "--help"]
     try:
         proc = subprocess.run(
@@ -310,7 +348,12 @@ _ROBUSTNESS_AGENT_ROOT_ENV = "ROBUSTNESS_AGENT_ROOT"
 
 
 def _resolve_robustness_agent_root() -> Path | None:
-    """Return robustness-agent skill root (``$ROBUSTNESS_AGENT_ROOT`` else sibling), or ``None``."""
+    """Return robustness-agent skill root (``$ROBUSTNESS_AGENT_ROOT`` else sibling), or ``None``.
+
+    Returns:
+        Path | None: The validated robustness-agent root, or ``None`` when no
+            candidate contains the expected ``runtime/cli.py`` module.
+    """
     override = os.environ.get(_ROBUSTNESS_AGENT_ROOT_ENV, "").strip()
     if override:
         p = Path(override).expanduser()
@@ -373,6 +416,15 @@ def _apply_atom_auto_tighten(args: argparse.Namespace) -> list[str]:
 
     No auto-tightening is applied; kernel/framework/profile all work on atom. Multi-node TP wiring
     is unimplemented so ``--nodes>=2`` exits 2. Returns the list of auto-disabled flags (always empty).
+
+    Args:
+        args (argparse.Namespace): The parsed CLI namespace (reads ``nodes``).
+
+    Returns:
+        list[str]: The auto-disabled flags (always empty).
+
+    Raises:
+        SystemExit: With code 2 when ``--nodes >= 2`` (unsupported on atom).
     """
     auto_disabled: list[str] = []
     if int(getattr(args, "nodes", 1) or 1) >= 2:
@@ -404,6 +456,14 @@ def _resolve_gpu_type(
     Probe always wins on disagreement (wrong --gpu-type corrupts baseline+KB rows); user value kept
     only on probe failure. Returns ``(effective_gpu_type, warnings)``; warnings go to stderr to keep
     the ``HYPERLOOM_LAUNCH`` stdout sentinel clean.
+
+    Args:
+        user_specified (str): The user-supplied ``--gpu-type`` hint.
+        probed (str): The hardware-probed GPU type.
+
+    Returns:
+        tuple[str, list[str]]: ``(effective_gpu_type, warnings)`` — the probe
+            wins on disagreement; ``warnings`` carries any stderr notes.
     """
     warnings: list[str] = []
     if probed and user_specified and probed != user_specified:
@@ -431,6 +491,21 @@ def _emit_launch_info(
     """Print the machine-readable HYPERLOOM_LAUNCH stdout line; optionally JSON-dump to ``launch_info_file``.
 
     Returns the launch_info dict for callers/tests.
+
+    Args:
+        pid (int): The launched process id.
+        session_dir (Path): The session root directory.
+        session_id (str): The session identifier.
+        run_log (str): The run-log path string.
+        gpu_type (str): The resolved GPU type.
+        framework (str): The serving framework name.
+        model (str): The model name / path.
+        launch_info_file (str | None): Optional path to JSON-dump the launch
+            info; skipped when ``None``.
+
+    Returns:
+        dict[str, Any]: The launch-info dict that was printed (and optionally
+            written).
     """
     launch_info: dict[str, Any] = {
         "event": "launch",
@@ -464,6 +539,16 @@ def _clean_stale_aiter_locks(
     Only deletes locks with mtime older than ``stale_minutes`` (default 5; above cold-start MoE build
     time, below the hang-suspicion cliff). Build dir resolution: caller arg → $INFERENCE_OPTIMIZER_AITER_JIT_DIR
     → dynamic <aiter>/jit/build → legacy fallbacks. Returns a stats dict; never raises (errors counted).
+
+    Args:
+        aiter_jit_dir (Path | None): Explicit JIT build dir; when ``None`` it
+            is resolved from env / installed aiter / legacy fallbacks.
+        stale_minutes (int): Minimum lock age in minutes before deletion
+            (default 5).
+
+    Returns:
+        dict[str, Any]: A stats dict (``dir``, ``scanned``, ``deleted``,
+            ``skipped_fresh``, ``errors``).
     """
     stats: dict[str, Any] = {
         "dir": None,
@@ -541,7 +626,11 @@ def _clean_stale_aiter_locks(
 
 
 def _autodetect_gpu_type() -> str | None:
-    """Return mi300x|mi308x|mi325x|mi355x or None if undetectable (rocm-smi then torch gcnArchName, best-effort)."""
+    """Return mi300x|mi308x|mi325x|mi355x or None if undetectable (rocm-smi then torch gcnArchName, best-effort).
+
+    Returns:
+        str | None: The detected GPU type, or ``None`` when undetectable.
+    """
     import subprocess
     try:
         out = subprocess.run(
@@ -576,6 +665,14 @@ def _resolve_amd_gpu_type(explicit: str | None = None) -> str | None:
     callers gate AMD-specific behaviour on real hardware while still honouring
     a launcher/CI-supplied ``gpu_type`` even if ``rocm-smi``/torch probing is
     unavailable at the call site.
+
+    Args:
+        explicit (str | None): An explicit GPU-type hint that takes priority
+            over the ``GPU_TYPE`` env and autodetect.
+
+    Returns:
+        str | None: The resolved AMD runner type, or ``None`` when not on a
+            known AMD GPU.
     """
     for cand in (explicit, os.environ.get("GPU_TYPE")):
         norm = str(cand or "").strip().lower()
@@ -598,6 +695,19 @@ def _resume_safe_flag(
 
     ``invert=True`` handles the ``--no-*`` pattern (args.no_X True == disable; manifest stores positive form).
     Lets robustness_monitor.sh resume preserve original intent without re-passing the flag.
+
+    Args:
+        args (argparse.Namespace): The parsed CLI namespace.
+        arg_name (str): The attribute name to read from ``args``.
+        manifest (dict | None): The resume manifest, or ``None``.
+        manifest_key (str): The manifest key holding the persisted value.
+        default (bool): The fallback value when neither arg nor manifest
+            supplies one.
+        invert (bool): When ``True`` apply the ``--no-*`` inversion to the
+            explicit arg.
+
+    Returns:
+        bool: The resolved boolean flag value.
     """
     raw_arg = getattr(args, arg_name, None)
     if isinstance(raw_arg, bool) and raw_arg:
@@ -617,7 +727,18 @@ def _resume_safe_numeric(
     *,
     default: float,
 ) -> float:
-    """Float-valued analog of :func:`_resume_safe_flag`: explicit non-default arg → manifest → default."""
+    """Float-valued analog of :func:`_resume_safe_flag`: explicit non-default arg → manifest → default.
+
+    Args:
+        args (argparse.Namespace): The parsed CLI namespace.
+        arg_name (str): The attribute name to read from ``args``.
+        manifest (dict | None): The resume manifest, or ``None``.
+        manifest_key (str): The manifest key holding the persisted value.
+        default (float): The fallback value when neither source supplies one.
+
+    Returns:
+        float: The resolved numeric value.
+    """
     raw_arg = getattr(args, arg_name, None)
     if raw_arg is not None:
         try:
@@ -639,6 +760,15 @@ def _load_model_arch(workspace_root: Path, model_name: str) -> dict:
 
     Soft-degrades to ``{}`` (never blocks launch) on missing/unreadable/invalid file. Stale-file guard:
     require ``data["model_name"]`` basename to match launched ``--model`` basename, else WARN + ``{}``.
+
+    Args:
+        workspace_root (Path): Directory containing ``model_arch.json``.
+        model_name (str): The launched model name, used for the stale-file
+            freshness check.
+
+    Returns:
+        dict: The advisory architecture profile, or ``{}`` when missing,
+            unreadable, invalid, or stale.
     """
     arch_path = workspace_root / "model_arch.json"
     try:
@@ -680,6 +810,13 @@ def _load_model_config_tags(model_path: str) -> dict:
     """Best-effort loader for KB architecture-identity tags (``architectures`` + ``model_type``) from config.json.
 
     Soft-degrades to ``{}`` (never blocks launch); normalised fields are omitted when empty so callers can .get().
+
+    Args:
+        model_path (str): The local model directory containing ``config.json``.
+
+    Returns:
+        dict: Architecture-identity tags (``architectures`` / ``model_type``);
+            empty fields are omitted, ``{}`` when the config is unreadable.
     """
     data = _load_model_config_dict(model_path)
     if data is None:
@@ -806,7 +943,15 @@ _TEXT_COERCIBLE_MODEL_TYPES = frozenset({
 
 def _arch_is_supported_text_generation(arch: str) -> bool:
     """True when an architecture class name denotes a supported text-generation
-    (decoder-only causal LM) model."""
+    (decoder-only causal LM) model.
+
+    Args:
+        arch (str): The architecture class name to test.
+
+    Returns:
+        bool: ``True`` when ``arch`` contains a supported text-generation
+            marker.
+    """
     a = (arch or "").strip()
     if not a:
         return False
@@ -821,6 +966,15 @@ def _config_declares_text_decoder(config: dict, architectures: list[str], model_
     described under ``text_config`` / ``language_config``. Treat those nested
     text blocks as capability evidence instead of requiring a per-family
     allowlist entry.
+
+    Args:
+        config (dict): The decoded model ``config.json`` mapping.
+        architectures (list[str]): The top-level architecture class names.
+        model_type_l (str): The lowercased top-level ``model_type``.
+
+    Returns:
+        bool: ``True`` when the config positively identifies a usable text
+            decoder.
     """
     if model_type_l in _TEXT_COERCIBLE_MODEL_TYPES:
         return True
@@ -872,6 +1026,15 @@ def _detect_unsupported_model(model_path: str) -> dict | None:
       (e.g. Kimi-K2.6 / Qwen3.6 MoE, or a generic ``ForCausalLM`` arch that
       merely carries a ``vision_config``). Caller proceeds on the text path with
       a degraded-mode warning unless ``--allow-mm-text-fallback`` is off.
+
+    Args:
+        model_path (str): The local model directory containing ``config.json``.
+
+    Returns:
+        dict | None: ``None`` for a plain text-generation model (or an
+            unreadable config), otherwise a dict with ``architecture``,
+            ``model_type``, ``signal``, and ``verdict``
+            (``vision_only`` / ``text_coercible``).
     """
     config = _load_model_config_dict(model_path)
     if config is None:
@@ -986,7 +1149,15 @@ _MAX_MODEL_LEN_HEADROOM = 4096
 
 
 def _load_model_max_position_embeddings(model_path: str) -> int | None:
-    """Best-effort read of max sequence length from config.json (first positive among known keys, incl. nested ``text_config``), or None."""
+    """Best-effort read of max sequence length from config.json (first positive among known keys, incl. nested ``text_config``), or None.
+
+    Args:
+        model_path (str): The local model directory containing ``config.json``.
+
+    Returns:
+        int | None: The first positive max-sequence-length value found, or
+            ``None`` when unavailable.
+    """
     if not model_path:
         return None
     cfg_path = Path(model_path) / "config.json"
@@ -1017,6 +1188,12 @@ def _model_has_dual_chunk_attention(model_path: str) -> bool:
     default aiter attention backend and demands ``dual_chunk_flash_attn``.
     Checks the top level and a nested ``text_config``. Soft-degrades to
     False on any missing / unreadable / invalid config.
+
+    Args:
+        model_path (str): The local model directory containing ``config.json``.
+
+    Returns:
+        bool: ``True`` when a ``dual_chunk_attention_config`` block is present.
     """
     data = _load_model_config_dict(model_path)
     if data is None:
@@ -1041,6 +1218,12 @@ def _model_is_moe(model_path: str) -> bool:
     callers use this to switch to a ROCm-capable MoE runner. Checks the top
     level and a nested ``text_config``. Soft-degrades to False on any missing
     / unreadable / invalid config.
+
+    Args:
+        model_path (str): The local model directory containing ``config.json``.
+
+    Returns:
+        bool: ``True`` when the config carries a Mixture-of-Experts signal.
     """
     data = _load_model_config_dict(model_path)
     if data is None:
@@ -1067,7 +1250,12 @@ def _model_is_moe(model_path: str) -> bool:
 
 
 def _context_headroom_tokens() -> int:
-    """Resolve the context headroom (tokens); env override, else default."""
+    """Resolve the context headroom (tokens); env override, else default.
+
+    Returns:
+        int: The configured context headroom in tokens (falls back to the
+            default for unset / invalid / negative env values).
+    """
     raw = os.environ.get(_CONTEXT_HEADROOM_ENV, "").strip()
     if not raw:
         return _CONTEXT_HEADROOM_DEFAULT
@@ -1079,7 +1267,17 @@ def _context_headroom_tokens() -> int:
 
 
 def _resolve_max_model_len(isl: int, osl: int, model_path: str) -> int:
-    """Resolve ``MAX_MODEL_LEN`` = ISL+OSL+headroom, clamped to ``max_position_embeddings`` (never stretch context)."""
+    """Resolve ``MAX_MODEL_LEN`` = ISL+OSL+headroom, clamped to ``max_position_embeddings`` (never stretch context).
+
+    Args:
+        isl (int): Input sequence length.
+        osl (int): Output sequence length.
+        model_path (str): The local model directory containing ``config.json``.
+
+    Returns:
+        int: The resolved ``MAX_MODEL_LEN``, clamped to the model's native
+            max-position window when known.
+    """
     desired = int(isl) + int(osl) + _MAX_MODEL_LEN_HEADROOM
     maxpos = _load_model_max_position_embeddings(model_path)
     if maxpos:
@@ -1092,6 +1290,15 @@ def _preflight_context_window(args: argparse.Namespace, session_dir: Path) -> bo
 
     Persists a stop reason and returns True (caller should exit) when the workload does NOT fit; False
     when it fits or the model's max length is unknown.
+
+    Args:
+        args (argparse.Namespace): The parsed CLI namespace (reads
+            ``isl`` / ``osl`` / ``model``).
+        session_dir (Path): The session root directory for the stop report.
+
+    Returns:
+        bool: ``True`` when the workload does not fit (caller should exit),
+            ``False`` when it fits or the max length is unknown.
     """
     isl = int(getattr(args, "isl", 0) or 0)
     osl = int(getattr(args, "osl", 0) or 0)
@@ -1231,6 +1438,14 @@ def _detect_amd_unsupported_quant(model_path: str) -> str | None:
     Reads both ``config.json:quantization_config`` (standard HF) and the
     separate ``hf_quant_config.json`` (NVIDIA ModelOpt). Returns None when the
     format is ROCm-runnable or absent.
+
+    Args:
+        model_path (str): The local model directory containing the quant
+            config files.
+
+    Returns:
+        str | None: A human-readable reason when the quant format is
+            unsupported on ROCm, else ``None``.
     """
     if not model_path:
         return None
@@ -1280,6 +1495,13 @@ def _detect_phi3_rope_scaling_incompatible(data: dict) -> str | None:
     dict, but transformers folds the top-level rope_theta into rope_scaling at
     load, yielding 4 keys and a ValueError. This is hardware-agnostic and the
     su/longrope type triggers it; yarn (the non-longrope path) is left alone.
+
+    Args:
+        data (dict): The decoded model ``config.json`` mapping.
+
+    Returns:
+        str | None: A human-readable reason when the Phi-3 rope_scaling config
+            would crash validation, else ``None``.
     """
     model_type = str(data.get("model_type") or "").strip().lower()
     arches = {a.lower() for a in _config_architectures(data)}
@@ -1312,6 +1534,13 @@ def _detect_gemma2_missing_hidden_act(data: dict) -> str | None:
 
     sglang's gemma2 runtime reads config.hidden_act unconditionally; configs
     that only ship hidden_activation crash with AttributeError in engine init.
+
+    Args:
+        data (dict): The decoded model ``config.json`` mapping.
+
+    Returns:
+        str | None: A human-readable reason when a Gemma2 config omits
+            ``hidden_act``, else ``None``.
     """
     model_type = str(data.get("model_type") or "").strip().lower()
     arches = {a.lower() for a in _config_architectures(data)}
@@ -1351,6 +1580,13 @@ def _detect_unrecognized_architecture(data: dict) -> str | None:
 
     Hardware-agnostic: the ModelConfig pydantic validation rejects the unknown
     model_type with a ValidationError in engine init on any GPU vendor.
+
+    Args:
+        data (dict): The decoded model ``config.json`` mapping.
+
+    Returns:
+        str | None: A human-readable reason when the architecture is
+            unrecognized by Transformers/sglang/vLLM, else ``None``.
     """
     scopes = [(data, False)]
     nested = data.get("text_config")
@@ -1388,7 +1624,15 @@ _SAFETENSORS_HEADER_LIMIT = 64 * 1024 * 1024
 
 
 def _read_safetensors_header(path: Path) -> dict | None:
-    """Read only the safetensors JSON header; never materialize tensor data."""
+    """Read only the safetensors JSON header; never materialize tensor data.
+
+    Args:
+        path (Path): The ``*.safetensors`` shard to inspect.
+
+    Returns:
+        dict | None: The parsed JSON header, or ``None`` when it cannot be
+            read / parsed within the header size limit.
+    """
     try:
         with path.open("rb") as f:
             raw_len = f.read(8)
@@ -1410,6 +1654,16 @@ def _detect_vocab_weight_shape_mismatch(model_path: str, data: dict) -> str | No
     data) of ``*.safetensors`` shards. Legacy ``*.bin``/``pytorch_model.bin``
     checkpoints are not inspected; truncated/corrupt headers are skipped
     silently (return None) and left to the downstream loader.
+
+    Args:
+        model_path (str): The local model directory holding the safetensors
+            shards.
+        data (dict): The decoded model ``config.json`` mapping (supplies
+            ``vocab_size``).
+
+    Returns:
+        str | None: A human-readable reason when a vocab dimension disagrees
+            with ``config.json``, else ``None``.
     """
     expected = data.get("vocab_size")
     nested = data.get("text_config")
@@ -1452,6 +1706,15 @@ def _detect_missing_tokenizer_files(model_path: str, data: dict) -> str | None:
 
     Conservative: only fires when NONE of the known tokenizer files exist AND
     the config carries no custom AutoTokenizer (auto_map) that could supply one.
+
+    Args:
+        model_path (str): The local model directory to inspect.
+        data (dict): The decoded model ``config.json`` mapping (checked for a
+            custom ``auto_map`` AutoTokenizer).
+
+    Returns:
+        str | None: A human-readable reason when no tokenizer artifacts are
+            present, else ``None``.
     """
     auto_map = data.get("auto_map")
     if isinstance(auto_map, dict) and auto_map.get("AutoTokenizer"):
@@ -1486,6 +1749,15 @@ def _detect_incompatible_model_config(
 
     A fully absent ``config.json`` is NOT blocked (kept soft-degrade): the
     upstream submission filter + downstream loader still apply.
+
+    Args:
+        model_path (str): The local model directory containing ``config.json``.
+        gpu_type (str | None): Optional GPU type; AMD-only checks fire when it
+            resolves to a known AMD runner.
+
+    Returns:
+        str | None: A human-readable reason when a statically-knowable config
+            incompatibility is detected, else ``None``.
     """
     if not model_path:
         return None
@@ -1600,6 +1872,15 @@ def _preflight_model_config_compat(
     reason instead of booting a server that dies cryptically in engine init.
 
     Returns True when incompatible (caller should exit); False otherwise.
+
+    Args:
+        args (argparse.Namespace): The parsed CLI namespace (reads ``model``
+            and ``gpu_type``).
+        session_dir (Path): The session root directory for the stop report.
+
+    Returns:
+        bool: ``True`` when the config is incompatible (caller should exit),
+            ``False`` otherwise.
     """
     model = str(getattr(args, "model", "") or "")
     detail = _detect_incompatible_model_config(
@@ -1666,6 +1947,16 @@ def _preflight_unsupported_model_arch(
       to fail-fast.
     * ``vision_only`` (true VLM / unclassifiable) → persists
       ``stop_reason=unsupported_model_arch`` and returns True (caller exits).
+
+    Args:
+        args (argparse.Namespace): The parsed CLI namespace (reads ``model``
+            and ``allow_mm_text_fallback``).
+        session_dir (Path): The session root directory for any stop report /
+            degraded-mode marker.
+
+    Returns:
+        bool: ``True`` when the model is vision-only (caller should exit),
+            ``False`` for plain text or coercible-with-fallback models.
     """
     model = str(getattr(args, "model", "") or "")
     hit = _detect_unsupported_model(model)
@@ -1848,6 +2139,13 @@ def _seed_shared_state(
 
         Ladder: explicit CLI/$FRAMEWORK_VERSION → auto-detect package __version__ → "" (canonical_id
         substitutes unknown_version). Auto-detect runs only when both CLI and env are empty.
+
+        Args:
+            args_in (Any): The parsed CLI namespace (reads ``framework_version``
+                and ``framework``).
+
+        Returns:
+            str: The resolved framework version, or ``""`` when unknown.
         """
         explicit = (
             (getattr(args_in, "framework_version", None) or "").strip()
@@ -1981,7 +2279,16 @@ def _seed_shared_state(
 
 
 def _parse_conc_sweep_concs(args: argparse.Namespace) -> list[int]:
-    """Parse ``--conc-sweep-concs '1,2,4,8'`` into a list[int]; non-integers warned+dropped, empty -> 1..128 ladder."""
+    """Parse ``--conc-sweep-concs '1,2,4,8'`` into a list[int]; non-integers warned+dropped, empty -> 1..128 ladder.
+
+    Args:
+        args (argparse.Namespace): The parsed CLI namespace (reads
+            ``conc_sweep_concs``).
+
+    Returns:
+        list[int]: The parsed concurrency ladder, falling back to the default
+            ``[1, 2, 4, 8, 16, 32, 64, 128]`` when empty.
+    """
     raw = str(getattr(args, "conc_sweep_concs", "") or "").strip()
     if not raw:
         return [1, 2, 4, 8, 16, 32, 64, 128]
@@ -2016,7 +2323,13 @@ def _snapshot_system_prompts(
     *,
     prompts: dict[str, str],
 ) -> None:
-    """Persist each agent's effective system prompt to ``agents/<role>/system_prompt.snapshot.md``."""
+    """Persist each agent's effective system prompt to ``agents/<role>/system_prompt.snapshot.md``.
+
+    Args:
+        session_dir (Path): The session root directory.
+        prompts (dict[str, str]): Mapping of agent role to effective system
+            prompt body.
+    """
     for role, body in prompts.items():
         target = agent_prompt_snapshot(session_dir, role)
         target.parent.mkdir(parents=True, exist_ok=True)
@@ -2058,6 +2371,14 @@ def _read_failure_summary(session_dir: Path) -> dict | None:
     Best-effort: returns ``None`` when the file is missing/unreadable or the
     block is absent (e.g. non-failure runs). Used to surface the real terminal
     root cause in the end-of-run summary on ``baseline_failed`` (#465).
+
+    Args:
+        session_dir (Path): The session root directory holding
+            ``reports/final.json``.
+
+    Returns:
+        dict | None: The ``failure_summary`` block, or ``None`` when missing /
+            unreadable / absent.
     """
     try:
         from .session_paths import reports_dir
@@ -2142,6 +2463,12 @@ def _reconcile_crash_count(state: SharedState, session_dir: Path) -> None:
     """Reconcile persisted ``crash_count`` (state.json + final.json) up to the live in-memory value.
 
     Only ever raises the persisted value (max), never lowers it; best-effort, never fatal.
+
+    Args:
+        state (SharedState): The live state carrying the authoritative
+            in-memory ``crash_count``.
+        session_dir (Path): The session root directory holding ``state.json``
+            and ``reports/final.json``.
     """
     live = int(getattr(state, "crash_count", 0) or 0)
 
@@ -2171,7 +2498,12 @@ def _reconcile_crash_count(state: SharedState, session_dir: Path) -> None:
 
 
 def _print_kernel_opt_summary_line(state: SharedState) -> None:
-    """One-line forensic readout of kernel_opt attempts at session end (matches the on-disk report; best-effort)."""
+    """One-line forensic readout of kernel_opt attempts at session end (matches the on-disk report; best-effort).
+
+    Args:
+        state (SharedState): The final shared state used to build the
+            kernel-optimization summary.
+    """
     try:
         from .orchestrator.kernel_attempt_summary import (
             build_kernel_optimization_summary,
@@ -2205,7 +2537,16 @@ def _print_kernel_opt_summary_line(state: SharedState) -> None:
 
 
 def _resolve_session_dir_for_summary(state: SharedState) -> Path | None:
-    """Best-effort session_dir lookup ($HYPERLOOM_SESSION_DIR) for the stdout kernel_opt line; ``None`` if unresolved."""
+    """Best-effort session_dir lookup ($HYPERLOOM_SESSION_DIR) for the stdout kernel_opt line; ``None`` if unresolved.
+
+    Args:
+        state (SharedState): The final shared state (accepted for call-site
+            parity; resolution is env-based).
+
+    Returns:
+        Path | None: The resolved session directory, or ``None`` when
+            unresolved.
+    """
     env_sd = os.environ.get("HYPERLOOM_SESSION_DIR", "").strip()
     if env_sd:
         p = Path(env_sd).expanduser()
@@ -2221,7 +2562,14 @@ _STALE_PROXY_HOSTPORT = "127.0.0.1:4002"
 
 
 def _is_stale_proxy_url(url: str | None) -> bool:
-    """Return True for a leftover legacy auth-proxy URL (``127.0.0.1:4002``)."""
+    """Return True for a leftover legacy auth-proxy URL (``127.0.0.1:4002``).
+
+    Args:
+        url (str | None): The URL to test.
+
+    Returns:
+        bool: ``True`` when the URL pins the stale legacy proxy host:port.
+    """
     return _STALE_PROXY_HOSTPORT in str(url or "")
 
 
@@ -2245,6 +2593,13 @@ def _sync_geak_config_base_url(geak_config_path: str, base_url: str) -> bool:
     Best-effort: returns ``False`` (never raises) when the path is empty, the
     file is missing/unreadable/unwritable, it has no ``base_url:`` line, or it
     is already in sync. Returns ``True`` only when a rewrite was applied.
+
+    Args:
+        geak_config_path (str): Path to the GEAK litellm yaml config.
+        base_url (str): The endpoint to write into the ``base_url:`` line.
+
+    Returns:
+        bool: ``True`` when a rewrite was applied, ``False`` otherwise.
     """
     if not geak_config_path or not base_url:
         return False
@@ -2274,7 +2629,14 @@ def _sync_geak_config_base_url(geak_config_path: str, base_url: str) -> bool:
 
 
 def _derive_anthropic_base_url(openai_base_url: str) -> str:
-    """Derive ``ANTHROPIC_BASE_URL`` from ``OPENAI_BASE_URL`` by stripping a trailing ``/v1`` (SDK re-appends it)."""
+    """Derive ``ANTHROPIC_BASE_URL`` from ``OPENAI_BASE_URL`` by stripping a trailing ``/v1`` (SDK re-appends it).
+
+    Args:
+        openai_base_url (str): The ``OPENAI_BASE_URL`` value.
+
+    Returns:
+        str: The derived Anthropic base URL with a trailing ``/v1`` removed.
+    """
     from urllib.parse import urlparse, urlunparse
 
     parsed = urlparse(openai_base_url)
@@ -2287,7 +2649,13 @@ def _derive_anthropic_base_url(openai_base_url: str) -> str:
 def _reset_claude_config_to_upstream(
     safe_key: str, anthropic_base_url: str
 ) -> None:
-    """Point ``~/.claude/config.json`` ``customApiUrl`` at the upstream gateway (stale 127.0.0.1:4002 would fail)."""
+    """Point ``~/.claude/config.json`` ``customApiUrl`` at the upstream gateway (stale 127.0.0.1:4002 would fail).
+
+    Args:
+        safe_key (str): The primary API key to write; blank leaves any
+            existing key untouched.
+        anthropic_base_url (str): The upstream gateway URL; blank is a no-op.
+    """
     import json as _json
 
     if not anthropic_base_url:
@@ -2354,7 +2722,15 @@ def _validate_credentials() -> None:
 
 
 def _is_placeholder_tracelens_path(value: str) -> bool:
-    """Treat .env.template's bare ``\\`` and whitespace-only values as unset."""
+    """Treat .env.template's bare ``\\`` and whitespace-only values as unset.
+
+    Args:
+        value (str): The candidate TraceLens path value.
+
+    Returns:
+        bool: ``True`` when the value is blank or the bare backslash
+            placeholder.
+    """
     stripped = value.strip()
     return stripped in ("", "\\")
 
@@ -2482,6 +2858,12 @@ def _ensure_python_sdks(python_exe: str, pip_extra: list[str]) -> None:
 
     Avoids first-tick BackendError after baseline burns wall time; same-interpreter install avoids
     cross-interpreter install failures.
+
+    Args:
+        python_exe (str): The interpreter that will import the SDKs (and run
+            the probe / install).
+        pip_extra (list[str]): Extra arguments threaded into the ``pip
+            install`` invocation (e.g. index flags).
     """
     candidates = (
         ("claude_agent_sdk", "claude-agent-sdk>=0.1.65"),
@@ -2653,7 +3035,15 @@ def _emit_preflight_diagnostics(
     anthropic_base_url: str | None,
     args: argparse.Namespace | None = None,
 ) -> None:
-    """One canonical, grep-friendly diagnostics block at the end of preflight."""
+    """One canonical, grep-friendly diagnostics block at the end of preflight.
+
+    Args:
+        magpie_python (str): The Magpie interpreter path to report.
+        anthropic_base_url (str | None): The resolved Anthropic base URL, or
+            ``None`` when unset.
+        args (argparse.Namespace | None): Parsed CLI args; when present, KB /
+            PR-monitor status lines are added.
+    """
     from .orchestrator.action_executors.baseline import (
         BASELINE_COLD_START_TIMEOUT_SEC,
         BASELINE_DEFAULT_TIMEOUT_SEC,
@@ -2742,7 +3132,12 @@ def _emit_preflight_diagnostics(
 
 
 def _print_cortex_kb_queue_status() -> None:
-    """Emit a one-line summary of the Cortex KB offline NDJSON queue (dead-letter = permanent-reject signal)."""
+    """Emit a one-line summary of the Cortex KB offline NDJSON queue (dead-letter = permanent-reject signal).
+
+    Note:
+        Side-effecting: writes the queue status summary to stdout and returns
+        nothing.
+    """
     from .session_paths import (
         cortex_dead_letter_ndjson,
         cortex_flushed_ndjson,
@@ -2794,6 +3189,15 @@ def _probe_llm_catalog(
     """Probe ``<base_url>/models`` with retry (gateway flakes); return set of model ids or None.
 
     TLS verification is on by default; ``INFERENCE_OPTIMIZER_CATALOG_PROBE_INSECURE=1`` skips it (warns).
+
+    Args:
+        base_url (str): The gateway base URL; ``""`` returns ``None``.
+        api_key (str): Optional bearer key sent in the ``Authorization``
+            header.
+
+    Returns:
+        set[str] | None: The set of model ids from ``<base_url>/models``, or
+            ``None`` when the probe is skipped or exhausts its retries.
     """
     import time
 
@@ -2893,6 +3297,20 @@ def _validate_and_resolve_claude_model(
 
     Probes the gateway catalog (retries); falls back 4-7→4-6 with a WARN, else sys.exit(2). Returns the
     catalog id set on success (reused by the codex smoke-test).
+
+    Args:
+        args (argparse.Namespace): The parsed CLI namespace; ``claude_model``
+            may be mutated to the fallback model.
+        resolved_urls (tuple[str, str] | None): Optional
+            ``(anthropic_base_url, openai_base_url)`` used to resolve the probe
+            base URL when env is unset.
+
+    Returns:
+        set[str] | None: The gateway catalog id set on success.
+
+    Raises:
+        SystemExit: With code 2 when the model is disallowed, the catalog is
+            unreachable, or no acceptable model is present.
     """
     chosen = (args.claude_model or "").strip()
     # #340: non-AMD deployments (Vultr / TensorWave / self-hosted gateways)
@@ -2987,7 +3405,15 @@ def _smoke_test_codex_model(
     args: argparse.Namespace,
     catalog_ids: set[str] | None,
 ) -> None:
-    """WARN-only catalog check for ``--codex-model`` (no hard gate); flags typos before Coordinator starts."""
+    """WARN-only catalog check for ``--codex-model`` (no hard gate); flags typos before Coordinator starts.
+
+    Args:
+        args (argparse.Namespace): The parsed CLI namespace (reads
+            ``codex_model`` / ``critic_backend`` / ``kernel_codex`` /
+            ``no_kernel``).
+        catalog_ids (set[str] | None): The gateway catalog id set; ``None``
+            skips the check.
+    """
     if catalog_ids is None:
         return
     # Codex is needed by the Kernel agent (kernel-codex on) and the critic-agent review path.
@@ -3023,6 +3449,13 @@ def _inferencex_checkout_ok(path: Path | str) -> bool:
     ``git init`` that then failed to fetch/checkout. Magpie sources
     ``benchmarks/benchmark_lib.sh`` at runtime, so require that file to
     exist — a complete checkout always has it, a stub never does.
+
+    Args:
+        path (Path | str): The candidate InferenceX checkout directory.
+
+    Returns:
+        bool: ``True`` when the checkout contains
+            ``benchmarks/benchmark_lib.sh``.
     """
     return (Path(path) / "benchmarks" / "benchmark_lib.sh").is_file()
 
@@ -3038,6 +3471,13 @@ def _clone_inferencex(dest: Path) -> str | None:
     On any failure the partial ``dest`` (e.g. a bare ``git init`` with no
     fetched tree) is removed so a later preflight's detection does not
     mistake the stub for a valid checkout and skip re-cloning.
+
+    Args:
+        dest (Path): The writable destination directory for the checkout.
+
+    Returns:
+        str | None: The checkout path string on success, or ``None`` on
+            failure.
     """
     repo = os.environ.get("INFERENCEX_REPO") or _INFERENCEX_REPO_DEFAULT
     ref = os.environ.get("INFERENCEX_REF") or _INFERENCEX_REF_DEFAULT
@@ -3079,6 +3519,14 @@ def _preflight(
     Credentials fallback → auth aliases → SDK install → ANTHROPIC_BASE_URL resolve + ~/.claude reset →
     ROCm hygiene → ray/Magpie/InferenceX install → CLI presence checks → diagnostics. Returns
     ``(anthropic_base_url, openai_base_url)`` or ``None`` when ``OPENAI_BASE_URL`` is missing.
+
+    Args:
+        args (argparse.Namespace | None): Parsed CLI args, used for the
+            diagnostics block; optional.
+
+    Returns:
+        tuple[str, str] | None: ``(anthropic_base_url, openai_base_url)``, or
+            ``None`` when ``OPENAI_BASE_URL`` is missing.
     """
     _load_dotenv_fallback()
     _load_kernel_agent_env_fallback()
@@ -3325,6 +3773,10 @@ def _run_ir3_preflight(args: argparse.Namespace) -> None:
 
     Mutates args: ``cortex_enabled``/``pr_monitor_enabled`` plus
     ``kb_degraded_reason``/``pr_degraded_reason`` (None|"explicit_flag"|"ir3_auto").
+
+    Args:
+        args (argparse.Namespace): The parsed CLI namespace; mutated in place
+            with the resolved KB / PR-monitor enable flags and reasons.
     """
     explicit_kb = bool(getattr(args, "degraded_kb", False))
     explicit_pr = bool(getattr(args, "degraded_pr", False))
@@ -3401,7 +3853,18 @@ _VALID_CRITIC_BACKENDS = ("mock", "agent")
 
 
 def _resolve_critic_choice(args: argparse.Namespace) -> str:
-    """Resolve the active critic backend choice (arg → DEFAULT_CRITIC_BACKEND); hard-fails on invalid."""
+    """Resolve the active critic backend choice (arg → DEFAULT_CRITIC_BACKEND); hard-fails on invalid.
+
+    Args:
+        args (argparse.Namespace): The parsed CLI namespace (reads
+            ``critic_backend``).
+
+    Returns:
+        str: The resolved critic backend (one of ``_VALID_CRITIC_BACKENDS``).
+
+    Raises:
+        SystemExit: With code 2 when the chosen backend is invalid.
+    """
     chosen = args.critic_backend
     if chosen is None:
         chosen = DEFAULT_CRITIC_BACKEND
@@ -3429,6 +3892,17 @@ def _resolve_robustness_choice(args: argparse.Namespace) -> str:
     Multi-node policy: on ``nodes>=2`` the agent's LocalProbe targets sandbox-local resources that live in
     separate pods (HIGH false positives). Keep ``agent`` only when a robustness-server is configured; else
     auto-downgrade to ``mock`` (explicit --robustness-agent gets a WARN).
+
+    Args:
+        args (argparse.Namespace): The parsed CLI namespace (reads
+            ``robustness_backend`` / ``nodes`` and server config).
+
+    Returns:
+        str: The resolved robustness backend (one of
+            ``_VALID_ROBUSTNESS_BACKENDS``).
+
+    Raises:
+        SystemExit: With code 2 when the chosen backend is invalid.
     """
     chosen = getattr(args, "robustness_backend", None)
     explicit = chosen is not None
@@ -3465,7 +3939,11 @@ def _resolve_robustness_choice(args: argparse.Namespace) -> str:
 
 
 def _reset_state_file(session_dir: Path) -> None:
-    """Back up ``state.json`` to ``state.json.preReset.<unix_ts>`` and start fresh (Cortex KB untouched)."""
+    """Back up ``state.json`` to ``state.json.preReset.<unix_ts>`` and start fresh (Cortex KB untouched).
+
+    Args:
+        session_dir (Path): The session root directory holding ``state.json``.
+    """
     state_path = session_dir / "state.json"
     if not state_path.exists():
         return
@@ -3497,6 +3975,13 @@ def _gc_old_profile_traces(
 
     Never blocks startup (errors swallowed). Env knobs: HYPERLOOM_MN_TRACE_RETENTION_DAYS,
     HYPERLOOM_MN_TRACE_GC_DISABLE.
+
+    Args:
+        root (str | None): The trace-root directory to scan; defaults to the
+            multi-node profile-trace root.
+        retention_days (int): Age threshold in days before a trace dir is
+            removed (env-overridable).
+        keep (str | None): A directory name to always preserve (name-matched).
     """
     if os.environ.get("HYPERLOOM_MN_TRACE_GC_DISABLE", "").strip() in (
         "1", "true", "yes",
@@ -3548,7 +4033,18 @@ def _gc_old_profile_traces(
 
 
 def _resolve_mn_backend(args: argparse.Namespace) -> str:
-    """Multi-node backend selector: --mn-backend > $INFERENCE_OPTIMIZER_MN_BACKEND > rayjob."""
+    """Multi-node backend selector: --mn-backend > $INFERENCE_OPTIMIZER_MN_BACKEND > rayjob.
+
+    Args:
+        args (argparse.Namespace): The parsed CLI namespace (reads
+            ``mn_backend``).
+
+    Returns:
+        str: The resolved multi-node backend (``rayjob`` or ``dynamo``).
+
+    Raises:
+        SystemExit: With code 2 when the resolved backend is invalid.
+    """
     backend = (
         (getattr(args, "mn_backend", None) or "").strip()
         or os.environ.get("INFERENCE_OPTIMIZER_MN_BACKEND", "").strip()
@@ -3573,6 +4069,13 @@ def _provision_multi_node_dynamo_stack(args: argparse.Namespace) -> None:
     to launch ``dynamo.sglang``/``dynamo.vllm``. Benchmarks target the Dynamo
     frontend (:8000) via ``state.service_url`` — picked up automatically by
     ``_multi_node_env.benchmark_env_for_subprocess``.
+
+    Args:
+        args (argparse.Namespace): The parsed CLI namespace (reads ``nodes``,
+            ``rayjob_image``, ``rayjob_gpus_per_node``, and PD flags).
+
+    Raises:
+        SystemExit: With code 2 when a required Dynamo image is not resolvable.
     """
     nodes = max(1, int(args.nodes))
     from .multi_node.cli import cmd_create_dynamo, _load_state
@@ -3802,6 +4305,10 @@ def _replay_kernel_patches_for_multi_node(args: argparse.Namespace) -> None:
     """Replay every applied kernel-agent patch (manifest status=applied + multinode block) onto RayJob pods.
 
     Idempotent ``apply-patch`` fan-out, run only when ``--nodes>=2``. Best-effort: per-patch failures warn.
+
+    Args:
+        args: Parsed CLI arguments; reads ``nodes`` and resolves the session
+            workspace to locate applied-patch manifests.
     """
     nodes = max(1, int(getattr(args, "nodes", 1) or 1))
     if nodes < 2:
@@ -3903,6 +4410,11 @@ async def _run_quantization_prelude(args: argparse.Namespace) -> None:
         The skip is made **detectable** so a launcher / UI never mistakes the
         run for quantized: a ``QUANTIZATION_SKIPPED:`` marker line on stdout
         plus the ``$HYPERLOOM_QUANTIZATION_SKIPPED`` env var (set to the reason).
+
+    Args:
+        args: Parsed CLI arguments; reads ``quantize`` / ``quantize_scheme`` /
+            ``gpu_type`` / ``resume`` and rewrites ``args.model`` in place to
+            the exported quantized model path on success.
     """
     # Free-text --quantize wins; otherwise resolve the structured
     # --quantize-scheme enum (the UI/backend path) to a prompt.
@@ -3995,7 +4507,17 @@ def _export_workload_envs_for_optimize(
     ep_resolved: int,
     argv: list[str] | None = None,
 ) -> None:
-    """Mirror explicit workload CLI flags (--tp/--conc/--ep) into env so executors' Magpie YAMLs honor them."""
+    """Mirror explicit workload CLI flags (--tp/--conc/--ep) into env so executors' Magpie YAMLs honor them.
+
+    Args:
+        args (argparse.Namespace): The parsed CLI namespace (reads ``conc``).
+        nodes_resolved (int): The resolved node count; ``>= 2`` forces export
+            of all three knobs regardless of whether they were passed.
+        tp_resolved (int): The resolved tensor-parallel size to export as ``TP``.
+        ep_resolved (int): The resolved expert-parallel size to export as ``EP``.
+        argv (list[str] | None): The argument vector to inspect for explicit
+            flags; defaults to ``sys.argv[1:]`` when ``None``.
+    """
     argv = list(sys.argv[1:] if argv is None else argv)
     if nodes_resolved >= 2 or _argv_has_option(argv, "--tp"):
         os.environ["TP"] = str(tp_resolved)
@@ -4909,7 +5431,12 @@ async def _run_optimize(args: argparse.Namespace) -> int:
 
 
 def _default_research_lane_capacity() -> int:
-    """Default ``--research-lane-capacity``: $INFERENCE_OPTIMIZER_RESEARCH_LANE_CAPACITY else the GPU ceiling (2×GPU)."""
+    """Default ``--research-lane-capacity``: $INFERENCE_OPTIMIZER_RESEARCH_LANE_CAPACITY else the GPU ceiling (2×GPU).
+
+    Returns:
+        int: The resolved research-lane capacity (env value when set and
+            parseable, otherwise the policy GPU ceiling).
+    """
     env = os.environ.get("INFERENCE_OPTIMIZER_RESEARCH_LANE_CAPACITY")
     if env:
         try:
@@ -6171,6 +6698,14 @@ def _session_recovery_status(session_dir: Path) -> dict[str, Any]:
     Pure read of state.json / session_breakdown.json / langfuse_receipt.json.
     Returns flags used by :func:`_run_recover_session` to decide whether the
     session still needs a (re)build + Langfuse push.
+
+    Args:
+        session_dir (Path): The session directory to inspect.
+
+    Returns:
+        dict[str, Any]: A status mapping with ``close_done``,
+            ``breakdown_exists``, ``breakdown_recorded``, ``counts_final``,
+            and ``looks_complete`` flags.
     """
     import json
 
@@ -6210,6 +6745,14 @@ def _run_recover_session(args: argparse.Namespace) -> int:
     receipt into the breakdown, and attaches the full breakdown JSON to the
     session's trace. Idempotent across processes (guarded by the persisted
     Langfuse receipt), so re-running is safe.
+
+    Args:
+        args (argparse.Namespace): The parsed CLI namespace (reads
+            ``session_dir``, ``force``, and ``backfill_trace``).
+
+    Returns:
+        int: The process exit code (``0`` on success, ``2`` when the session
+            dir is missing, ``1`` on breakdown rebuild failure).
     """
     session_dir = args.session_dir.resolve()
     if not session_dir.is_dir():

--- a/inference_optimizer/cli_backends.py
+++ b/inference_optimizer/cli_backends.py
@@ -46,6 +46,26 @@ def _build_backends(
     ``critic_agent_root``). ``robustness_choice`` ∈ {``mock``, ``agent``}:
     mock is the heartbeat-only backend; ``agent`` is
     :class:`RobustnessAgentBackend` (requires ``robustness_agent_root``).
+
+    Args:
+        claude_model: Claude model id for orchestration/kernel backends.
+        codex_model: Codex model id for the kernel/critic backends.
+        kernel_codex: When True, use the Codex backend for kernel work.
+        critic_choice: ``mock`` or ``agent``.
+        session_dir: The current session directory.
+        critic_agent_root: Critic-agent runtime root (required for ``agent``).
+        critic_kb_mode: KB mode passed to the critic-agent backend.
+        robustness_choice: ``mock`` or ``agent``.
+        robustness_agent_root: Robustness-agent root (required for ``agent``).
+        robustness_options: Optional ``request.options`` overrides.
+        no_kernel: When True, omit the kernel backend.
+
+    Returns:
+        dict[str, Any]: Per-role backend instances keyed by role name.
+
+    Raises:
+        ValueError: If a choice is not in ``{'mock','agent'}`` or an ``agent``
+            choice is missing its required root.
     """
     if critic_choice not in ("mock", "agent"):
         raise ValueError(
@@ -135,6 +155,14 @@ def _build_proposal_scorer(
     ``session_dir`` is forwarded so the scorer can append its per-model
     token usage to the full-trace ledger (component=proposal_scorer); when
     omitted the scorer simply skips trace writes.
+
+    Args:
+        args: Parsed CLI arguments (scoring opt-out, model list).
+        session_dir: Optional session directory for token-usage tracing.
+
+    Returns:
+        ProposalScorer | None: The configured scorer, or ``None`` when
+        scoring is disabled or the model list resolves empty.
     """
     if getattr(args, "no_proposal_scoring", False):
         return None
@@ -158,6 +186,12 @@ def _robustness_server_configured(args: argparse.Namespace) -> bool:
     ``enable_cluster_pod_metrics`` and the sandbox-local LocalProbe false
     positives are silenced. Configured = ``--robustness-server-url`` or
     ``ROBUSTNESS_SERVER_URL`` is set.
+
+    Args:
+        args: Parsed CLI arguments (``robustness_server_url``).
+
+    Returns:
+        bool: ``True`` if a robustness-server endpoint is configured.
     """
     url = (getattr(args, "robustness_server_url", None) or "").strip()
     if url:
@@ -188,6 +222,12 @@ def _build_robustness_options(args: argparse.Namespace) -> dict[str, Any]:
     forward a workload_uid hint, disable the 127.0.0.1:8888 auto-probe,
     and lift the ``no_levers_found`` floor to 60 min. Single-node
     semantics stay untouched.
+
+    Args:
+        args: Parsed CLI arguments (robustness flags, node count).
+
+    Returns:
+        dict[str, Any]: The non-default ``request.options`` overrides.
     """
     options: dict[str, Any] = {}
     server_url = getattr(args, "robustness_server_url", None)

--- a/inference_optimizer/cli_backends.py
+++ b/inference_optimizer/cli_backends.py
@@ -47,6 +47,30 @@ def _build_backends(
     ``critic_agent_root``). ``robustness_choice`` ∈ {``mock``, ``agent``}:
     mock is the heartbeat-only backend; ``agent`` is
     :class:`RobustnessAgentBackend` (requires ``robustness_agent_root``).
+
+    Args:
+        claude_model: Claude model id for the orchestration / kernel backends.
+        codex_model: Codex model id for the kernel / critic backends.
+        kernel_codex: Use a Codex backend for the kernel role when ``True``.
+        critic_choice: Critic backend selector (``mock`` or ``agent``).
+        session_dir: Session directory passed to agent backends.
+        critic_agent_root: Critic-agent root, required when
+            ``critic_choice='agent'``.
+        critic_kb_mode: Knowledge-base mode for the critic agent.
+        cortex_kb_url: Optional Cortex KB URL for the critic agent.
+        robustness_choice: Robustness backend selector (``mock`` or ``agent``).
+        robustness_agent_root: Robustness-agent root, required when
+            ``robustness_choice='agent'``.
+        robustness_options: Optional ``request.options`` overrides for the
+            robustness agent.
+        no_kernel: Skip building the kernel backend when ``True``.
+
+    Returns:
+        A mapping of role name to its constructed backend.
+
+    Raises:
+        ValueError: If ``critic_choice`` / ``robustness_choice`` is invalid, or
+            an ``agent`` choice is missing its required agent root.
     """
     if critic_choice not in ("mock", "agent"):
         raise ValueError(
@@ -137,6 +161,15 @@ def _build_proposal_scorer(
     ``session_dir`` is forwarded so the scorer can append its per-model
     token usage to the full-trace ledger (component=proposal_scorer); when
     omitted the scorer simply skips trace writes.
+
+    Args:
+        args: Parsed CLI args (``no_proposal_scoring`` /
+            ``proposal_scorer_models``).
+        session_dir: Optional session directory for token-usage trace writes.
+
+    Returns:
+        A configured :class:`ProposalScorer`, or ``None`` when scoring is
+        disabled or no models resolve.
     """
     if getattr(args, "no_proposal_scoring", False):
         return None
@@ -160,6 +193,13 @@ def _robustness_server_configured(args: argparse.Namespace) -> bool:
     ``enable_cluster_pod_metrics`` and the sandbox-local LocalProbe false
     positives are silenced. Configured = ``--robustness-server-url`` or
     ``ROBUSTNESS_SERVER_URL`` is set.
+
+    Args:
+        args: Parsed CLI args carrying ``robustness_server_url``.
+
+    Returns:
+        ``True`` when a robustness-server endpoint is configured via flag or
+        environment.
     """
     url = (getattr(args, "robustness_server_url", None) or "").strip()
     if url:
@@ -196,6 +236,13 @@ def _build_robustness_options(args: argparse.Namespace) -> dict[str, Any]:
     otherwise trip the same false ``local_server_unreachable``), while the
     rest of LocalProbe keeps running. All other single-node semantics stay
     untouched.
+
+    Args:
+        args: Parsed CLI args carrying the robustness-related flags.
+
+    Returns:
+        The non-default ``request.options`` overrides derived from the flags
+        (and multi-node policy); keys the operator did not set are omitted.
     """
     options: dict[str, Any] = {}
     server_url = getattr(args, "robustness_server_url", None)

--- a/inference_optimizer/cli_executors.py
+++ b/inference_optimizer/cli_executors.py
@@ -92,6 +92,15 @@ def _build_specialist_executor(
     SpecialistRunner). Production uses the subprocess dispatcher (claude in a
     per-task worktree); --specialist-dispatch-mode / missing claude falls back
     to the in-process ClaudeBackend.
+
+    Args:
+        args: Parsed CLI arguments (specialist model, turns, dispatch mode).
+        session_dir: The current session directory.
+        knowledge_plane: The live KnowledgePlane used to wire MCP config.
+
+    Returns:
+        Callable[[Any], Awaitable[dict]]: An async executor that runs a
+        specialist and returns a result envelope dict.
     """
     import shutil
 
@@ -186,7 +195,15 @@ def _build_specialist_executor(
     async def _executor(ctx: Any) -> dict:
         """Adapter SubAgentRunner.run_task -> SpecialistRunner.run. Always
         returns a dict (even on failure); runner_status preserves the
-        SpecialistRunResult distinctions for breakdown analytics."""
+        SpecialistRunResult distinctions for breakdown analytics.
+
+        Args:
+            ctx: The action context passed by ``SubAgentRunner.run_task``.
+
+        Returns:
+            dict: A result envelope with runner status, task/domain ids,
+            transcript paths, and any allocated GPU ids.
+        """
         run_result = await runner.run(ctx)
         return {
             "runner_status": run_result.status,
@@ -220,6 +237,13 @@ def _register_executors(
     _REAL_EXECUTORS_FULL set, kernel-owned no-ops (skipped when no_kernel),
     the always-wired Coordinator-internal executors, and the optional
     specialist executor.
+
+    Args:
+        coordinator: The live Coordinator to register executors on.
+        no_kernel: When True, skip wiring the kernel-owned no-op executors.
+        compare_against_gpu: Optional GPU type for the target-analysis executor.
+        session_dir: Optional session directory passed to executors.
+        specialist_executor: Optional specialist executor to register.
     """
     for kind, fn in _REAL_EXECUTORS_FULL.items():
         coordinator.sub.register_executor(kind, fn)

--- a/inference_optimizer/cli_executors.py
+++ b/inference_optimizer/cli_executors.py
@@ -42,6 +42,14 @@ log = logging.getLogger(__name__)
 
 
 async def _noop_prep(ctx) -> dict:
+    """No-op preparation executor used as a stub.
+
+    Args:
+        ctx: Action context (only ``ctx.task.kind`` is read).
+
+    Returns:
+        A success result envelope tagged as a noop stub.
+    """
     return {"status": "succeeded", "kind": ctx.task.kind, "note": "noop-stub"}
 
 
@@ -153,6 +161,14 @@ def _build_specialist_executor(
         )
     else:
         def _backend_factory(domain: Any) -> Any:
+            """Build an in-process Claude backend for a specialist domain.
+
+            Args:
+                domain: The specialist domain requesting a backend.
+
+            Returns:
+                A configured :class:`ClaudeBackend` instance.
+            """
             # in-process Claude path (fallback).
             return ClaudeBackend(
                 model=claude_model, max_turns_default=max_turns,

--- a/inference_optimizer/cli_kb.py
+++ b/inference_optimizer/cli_kb.py
@@ -33,6 +33,12 @@ def _resolve_local_kb_root(args: argparse.Namespace) -> Path:
     """Resolve the local recipe-snapshot KB root: ``--local-kb-root`` ->
     ``$HYPERLOOM_LOCAL_KB_ROOT`` -> ``workspace_root()/kb``. Not created here
     (LocalRecipeStore creates it lazily on first write).
+
+    Args:
+        args: Parsed CLI arguments; ``local_kb_root`` is consulted first.
+
+    Returns:
+        Path: The resolved local KB root directory.
     """
     explicit = (
         getattr(args, "local_kb_root", None)
@@ -49,6 +55,12 @@ def _build_recipe_kb_dispatcher(
     """Build the local-write / remote-read RecipeKB dispatcher. Local store
     always wired; remote half enabled only when not --degraded-kb and a URL
     resolves (foreground 2s + 1-retry; no hard-coded default endpoint).
+
+    Args:
+        args: Parsed CLI arguments (``degraded_kb``, ``cortex_kb_url``, etc.).
+
+    Returns:
+        Any: A configured ``RecipeKB`` dispatcher (optionally gbrain-mirroring).
     """
     from .recipe_kb import LocalRecipeStore, RecipeKB, RemoteRecipeClient
 
@@ -141,6 +153,15 @@ def _bootstrap_cortex_kb(
     """Boot the recipe-snapshot KB integration, run the T0 anchor, and return
     the dispatcher. KB unavailability never aborts the launch
     (fail_fast=False); a hard T0 failure warns and continues warm-start-empty.
+
+    Args:
+        args: Parsed CLI arguments.
+        session_dir: The current session directory.
+        manifest: The session manifest dict (model, framework, fingerprint).
+        resume: Whether this launch is resuming an existing session.
+
+    Returns:
+        Any: The configured ``RecipeKB`` dispatcher.
     """
     kb = _build_recipe_kb_dispatcher(args)
 
@@ -211,6 +232,15 @@ def _bootstrap_knowledge_plane(
     """Construct the :class:`KnowledgePlane` facade. Wires the optional PR
     Monitor REST client (KB reads go through RecipeKB, so cortex_kb=None here).
     Both backends fail-soft; --degraded-pr yields a disabled PRMonitorClient.
+
+    Args:
+        args: Parsed CLI arguments (PR Monitor enablement, URLs, window).
+        cortex_client: Optional cortex client; unused (KB reads go via RecipeKB).
+        session_dir: Optional session directory; when set a status marker is
+            written for breakdown warnings.
+
+    Returns:
+        KnowledgePlane: The wired KnowledgePlane facade.
     """
     from .orchestrator.knowledge_plane import (
         KnowledgePlane,

--- a/inference_optimizer/cli_kb.py
+++ b/inference_optimizer/cli_kb.py
@@ -77,6 +77,11 @@ def _attach_recipe_audit_hook(kb: Any, session_dir: Path | None) -> None:
     audit_path = recipe_snapshot_audit_jsonl(Path(session_dir))
 
     def _hook(event: dict[str, Any]) -> None:
+        """Append a timestamped recipe-snapshot read event to the audit log.
+
+        Args:
+            event (dict[str, Any]): The remote-read trace event to record.
+        """
         try:
             audit_path.parent.mkdir(parents=True, exist_ok=True)
             row = {

--- a/inference_optimizer/launcher/preflight_optimizer.py
+++ b/inference_optimizer/launcher/preflight_optimizer.py
@@ -24,6 +24,14 @@ STALE_PROCESS_PATTERNS = (
 
 
 def _read_cmdline(pid: str) -> str:
+    """Read and decode the ``/proc/<pid>/cmdline`` for the given pid.
+
+    Args:
+        pid: The process id (as a string) whose command line to read.
+
+    Returns:
+        The space-joined command line, or ``""`` when it cannot be read.
+    """
     try:
         raw = pathlib.Path("/proc", pid, "cmdline").read_bytes()
     except OSError:
@@ -32,6 +40,12 @@ def _read_cmdline(pid: str) -> str:
 
 
 def _print_torch_visibility() -> bool:
+    """Print torch CUDA visibility and report whether a device is usable.
+
+    Returns:
+        ``True`` when torch imports and reports at least one available CUDA
+        device, ``False`` otherwise (including on import failure).
+    """
     try:
         import torch  # type: ignore[import-not-found]
     except Exception as exc:
@@ -46,6 +60,7 @@ def _print_torch_visibility() -> bool:
 
 
 def _print_rocm_snapshot() -> None:
+    """Print a ``rocm-smi`` memory-use snapshot (best-effort, never raises)."""
     rocm_smi = shutil.which("rocm-smi")
     if not rocm_smi:
         print("rocm_smi=missing")
@@ -72,6 +87,12 @@ def _print_rocm_snapshot() -> None:
 
 
 def _find_stale_processes() -> list[tuple[str, str]]:
+    """Scan ``/proc`` for running processes matching known stale patterns.
+
+    Returns:
+        A list of ``(pid, cmdline)`` tuples for processes (other than this one)
+        whose command line matches one of :data:`STALE_PROCESS_PATTERNS`.
+    """
     matches: list[tuple[str, str]] = []
     for pid in filter(str.isdigit, os.listdir("/proc")):
         if int(pid) == os.getpid():
@@ -83,6 +104,14 @@ def _find_stale_processes() -> list[tuple[str, str]]:
 
 
 def main() -> int:
+    """Run launcher preflight checks and return a process exit code.
+
+    Validates the model path, prints torch/ROCm visibility, and reports any
+    stale optimizer/server processes.
+
+    Returns:
+        ``0`` when every check passes, otherwise ``2``.
+    """
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("model_path", help="Model directory to optimize.")
     args = parser.parse_args()

--- a/inference_optimizer/launcher/read_optimizer_state.py
+++ b/inference_optimizer/launcher/read_optimizer_state.py
@@ -26,10 +26,28 @@ SUMMARY_KEYS = (
 
 
 def _load_json(path: pathlib.Path) -> dict[str, Any]:
+    """Load and parse a JSON file into a dict.
+
+    Args:
+        path: The JSON file to read.
+
+    Returns:
+        The parsed JSON object as a dict.
+    """
     return json.loads(path.read_text())
 
 
 def _format_lifecycle_event(event: dict[str, Any]) -> str:
+    """Render a single lifecycle event as a one-line human-readable summary.
+
+    Args:
+        event: A lifecycle event dict (seq, label, phase, status, optional
+            duration_s, detail, and artifacts).
+
+    Returns:
+        A formatted single-line string describing the event, including any
+        artifacts when present.
+    """
     duration = f" {event['duration_s']}s" if event.get("duration_s") is not None else ""
     detail = f" [{event['detail']}]" if event.get("detail") else ""
     artifacts = " ".join(
@@ -45,6 +63,15 @@ def _format_lifecycle_event(event: dict[str, Any]) -> str:
 
 
 def main() -> int:
+    """Print a concise optimizer state and recent lifecycle summary.
+
+    Reads ``state.json`` (and optional ``manifest.json``) from the session
+    directory and prints the summary keys, phase, and the most recent
+    lifecycle events.
+
+    Returns:
+        ``0`` on success, or ``2`` when ``state.json`` is missing.
+    """
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("session_dir", help="Optimizer session directory.")
     parser.add_argument(

--- a/inference_optimizer/manifest.py
+++ b/inference_optimizer/manifest.py
@@ -81,6 +81,10 @@ def _detect_stack_fingerprint() -> dict[str, str]:
     """Best-effort ``stack_fingerprint`` (KB_design §3.6.5.1). Per component,
     first non-empty wins: env var -> /opt/rocm marker (rocm only) -> package
     __version__/__commit__. Missing components map to ``"unknown"``.
+
+    Returns:
+        Mapping of component name to detected version/commit (``"unknown"``
+        when not found).
     """
     out: dict[str, str] = {}
     for component, env_vars in _STACK_FINGERPRINT_ENVS.items():
@@ -172,7 +176,15 @@ def _git_remote_at(path: Path) -> str:
 
 
 def _path_is_relative_to(path: Path, root: Path) -> bool:
-    """Return True when ``path`` is inside ``root`` after best-effort resolution."""
+    """Return True when ``path`` is inside ``root`` after best-effort resolution.
+
+    Args:
+        path: The path to test.
+        root: The root directory ``path`` may be nested under.
+
+    Returns:
+        True when ``path`` is provably inside ``root``.
+    """
     try:
         path.resolve(strict=False).relative_to(root.resolve(strict=False))
         return True
@@ -192,6 +204,10 @@ def _warn_if_dependency_escapes_user_data(env_var: str, raw: str) -> None:
     """Warn when a dependency checkout points at a pod-local, non-persistent
     path (erased on pod recycle); a shared checkout outside USER_DATA_PATH is
     legitimate and does not warn.
+
+    Args:
+        env_var: Name of the env var holding the dependency checkout path.
+        raw: The raw checkout path value.
     """
     user_data = (os.environ.get(_paths.ENV_USER_DATA_PATH) or "").strip()
     if not user_data:
@@ -251,6 +267,9 @@ def _describe_dep(env_var: str) -> dict[str, str]:
 def _build_dependencies() -> dict[str, dict[str, str]]:
     """Provenance (path/commit/remote) for the Magpie / InferenceX trees this
     session executes against, so debuggers can answer "which upstream?" later.
+
+    Returns:
+        Mapping of dependency name to its ``{path, commit, remote}`` block.
     """
     return {
         "magpie":     _describe_dep("MAGPIE_DIR"),
@@ -261,6 +280,9 @@ def _build_dependencies() -> dict[str, dict[str, str]]:
 def _detect_image() -> str | None:
     """Best-effort container image detection: env vars -> known mount points
     -> cgroup probe. Returns None when nothing matches (never raises).
+
+    Returns:
+        The detected container image string, or ``None`` when none matches.
     """
     for var in ("HYPERLOOM_IMAGE", "CONTAINER_IMAGE", "IMAGE"):
         val = (os.environ.get(var) or "").strip()
@@ -315,7 +337,14 @@ def _objective_summary(args: argparse.Namespace) -> dict[str, Any]:
 
 def build_session_id(model_name: str = "") -> str:
     """Derive an internal session_id label for manifest / SharedState / report
-    metadata (not used for path computation)."""
+    metadata (not used for path computation).
+
+    Args:
+        model_name: Model name used as the id stem; defaults to ``session``.
+
+    Returns:
+        The derived internal session-id label.
+    """
     stem = (model_name or "session").strip().replace("/", "_") or "session"
     return f"{stem}_{_utc_now_compact()}_{uuid.uuid4().hex[:8]}"
 
@@ -433,7 +462,16 @@ def write_manifest(
     session_id: str | None = None,
 ) -> dict[str, Any]:
     """Atomically write ``manifest.json`` under session_dir; returns the
-    manifest dict."""
+    manifest dict.
+
+    Args:
+        session_dir: Session directory to write the manifest into.
+        args: Parsed CLI args overriding env-based defaults, or ``None``.
+        session_id: Explicit session-id label, or ``None`` to derive one.
+
+    Returns:
+        The manifest dict that was written.
+    """
     sd = Path(session_dir)
     manifest = build_manifest(sd, args=args, session_id=session_id)
     target = manifest_path(sd)
@@ -452,7 +490,17 @@ def write_manifest(
 def load_manifest(session_dir: Path) -> dict[str, Any]:
     """Read ``manifest.json`` for an existing session. Raises
     ``FileNotFoundError`` if missing (the signal ``--resume`` uses to refuse a
-    fresh sandbox)."""
+    fresh sandbox).
+
+    Args:
+        session_dir: Session directory to read the manifest from.
+
+    Returns:
+        The parsed manifest dict.
+
+    Raises:
+        FileNotFoundError: If ``manifest.json`` does not exist.
+    """
     p = manifest_path(Path(session_dir))
     if not p.exists():
         raise FileNotFoundError(

--- a/inference_optimizer/model_config_utils.py
+++ b/inference_optimizer/model_config_utils.py
@@ -15,7 +15,16 @@ from pathlib import Path
 
 
 def _load_model_config_dict(model_path: str) -> dict | None:
-    """Best-effort parse of ``<model_path>/config.json`` into a dict; returns ``None`` on any failure."""
+    """Best-effort parse of ``<model_path>/config.json`` into a dict; returns ``None`` on any failure.
+
+    Args:
+        model_path: Filesystem path to the model directory.
+
+    Returns:
+        The parsed ``config.json`` dict, or ``None`` when the path is empty,
+        the file is missing/unreadable, the JSON is invalid, or it is not a
+        dict.
+    """
     if not model_path:
         return None
     cfg_path = Path(model_path) / "config.json"
@@ -40,7 +49,15 @@ def _load_model_config_dict(model_path: str) -> dict | None:
 
 
 def _config_architectures(config: dict) -> list[str]:
-    """Normalise ``config["architectures"]`` to a list of non-empty strings (scalar wrapped; absent -> [])."""
+    """Normalise ``config["architectures"]`` to a list of non-empty strings (scalar wrapped; absent -> []).
+
+    Args:
+        config: A parsed model config dict.
+
+    Returns:
+        The non-empty architecture strings; a lone scalar is wrapped and a
+        missing key yields ``[]``.
+    """
     arches_raw = config.get("architectures")
     if isinstance(arches_raw, list):
         return [str(a).strip() for a in arches_raw if str(a or "").strip()]
@@ -72,6 +89,12 @@ def _path_looks_like_gemma2(model_path: str) -> bool:
     Word-boundary match on the directory name (gemma2 / gemma-2 / gemma_2),
     so a not-yet-materialized Hub-id style path still gets the workaround
     without false-positives on names like notgemma2 / gemma25.
+
+    Args:
+        model_path: Filesystem or Hub-id style path to the model.
+
+    Returns:
+        ``True`` when the path's final component looks like a Gemma2 name.
     """
     if not model_path:
         return False
@@ -79,7 +102,15 @@ def _path_looks_like_gemma2(model_path: str) -> bool:
 
 
 def _config_gemma2_scopes(data: dict) -> list[dict]:
-    """Return [top-level, text_config?] scopes for Gemma2 inspection."""
+    """Return [top-level, text_config?] scopes for Gemma2 inspection.
+
+    Args:
+        data: A parsed model config dict.
+
+    Returns:
+        The top-level config plus its nested ``text_config`` when that is a
+        dict.
+    """
     scopes = [data]
     nested = data.get("text_config")
     if isinstance(nested, dict):
@@ -88,7 +119,15 @@ def _config_gemma2_scopes(data: dict) -> list[dict]:
 
 
 def _config_is_gemma2(data: dict) -> bool:
-    """True when a parsed config dict declares Gemma2 (top level or text_config)."""
+    """True when a parsed config dict declares Gemma2 (top level or text_config).
+
+    Args:
+        data: A parsed model config dict.
+
+    Returns:
+        ``True`` when any scope declares the Gemma2 ``model_type`` or
+        architecture.
+    """
     for cfg in _config_gemma2_scopes(data):
         if str(cfg.get("model_type") or "").strip().lower() == GEMMA2_MODEL_TYPE:
             return True
@@ -103,6 +142,13 @@ def _config_has_model_identity(data: dict) -> bool:
     Used to decide whether a non-Gemma2 verdict is trustworthy: a config that
     clearly identifies another model (e.g. llama) must NOT fall back to the path
     heuristic, while an empty/residual config (``{}``, no model_type) should.
+
+    Args:
+        data: A parsed model config dict.
+
+    Returns:
+        ``True`` when any scope carries a non-empty ``model_type`` or
+        ``architectures``.
     """
     for cfg in _config_gemma2_scopes(data):
         if str(cfg.get("model_type") or "").strip():
@@ -118,6 +164,13 @@ def _model_is_gemma2(model_path: str) -> bool:
     Falls back to a path heuristic when config.json is missing/unreadable OR
     present-but-unidentifiable (empty dict / no model_type/architectures). A
     config that clearly identifies a non-Gemma2 model is trusted as-is.
+
+    Args:
+        model_path: Filesystem path to the model directory.
+
+    Returns:
+        ``True`` when the model is detected as Gemma2 via config.json or the
+        path heuristic.
     """
     data = _load_model_config_dict(model_path)
     if data is not None:

--- a/inference_optimizer/multi_node/_internal/dynamo_support.py
+++ b/inference_optimizer/multi_node/_internal/dynamo_support.py
@@ -23,14 +23,29 @@ _FRONTEND_PODID_HINTS = ("frontend",)
 def _service_roles_for(pd_mode: str) -> list[str]:
     """Positional serviceRoles list for the deployment topology (matches
     ``build_dynamo_workload_body``): PD -> [frontend, prefill, decode];
-    aggregated -> [frontend, worker]."""
+    aggregated -> [frontend, worker].
+
+    Args:
+        pd_mode: Deployment topology mode (``"disaggregated"`` or
+            ``"aggregated"``).
+
+    Returns:
+        The positional service roles for the topology.
+    """
     if (pd_mode or "").lower() == "disaggregated":
         return ["frontend", "prefill", "decode"]
     return ["frontend", "worker"]
 
 
 def _parse_role_index(pod_id: str) -> int | None:
-    """Parse the slot index from a DGD pod name ``<wid>-role<N>-<hash>``."""
+    """Parse the slot index from a DGD pod name ``<wid>-role<N>-<hash>``.
+
+    Args:
+        pod_id: The DGD pod name.
+
+    Returns:
+        The parsed role slot index, or ``None`` when the pattern is absent.
+    """
     import re
     m = re.search(r"-role(\d+)-", pod_id)
     return int(m.group(1)) if m else None
@@ -49,7 +64,16 @@ def _classify_pod_role(
          ``-role<N>-`` suffix in the pod name (SaFE keeps role0/role1/role2
          deployment names). This is the robust path for the observed
          ``<wid>-role<N>-<hash>`` naming.
-    Returns None for an unclassifiable pod.
+
+    Args:
+        pod_id: The DGD pod name.
+        resource_id: SaFE-provided resource id (fallback slot index when an
+            integer).
+        service_roles: Positional service roles to map a slot index onto.
+
+    Returns:
+        The classified role (``frontend`` / ``prefill`` / ``decode`` /
+        ``worker``), or ``None`` for an unclassifiable pod.
     """
     pl = pod_id.lower()
     if "prefill" in pl:
@@ -81,6 +105,14 @@ def discover_role_pods(
     ``{"frontend": [...], "prefill": [...], "decode": [...], "worker": [...]}``;
     each entry is ``{"podId", "podIP", "lwsIndex"}`` for pods with a non-empty
     ``podIP``, sorted by LWS ordinal (leader = 0) for deterministic rank order.
+
+    Args:
+        workload: A SaFE GetWorkloadResponse mapping with a ``pods`` list.
+        pd_mode: Deployment topology selecting the positional service roles.
+
+    Returns:
+        A mapping of role to its list of ``{"podId", "podIP", "lwsIndex"}``
+        entries, sorted by LWS ordinal then pod id.
     """
     service_roles = _service_roles_for(pd_mode)
     groups: dict[str, list[dict[str, Any]]] = {
@@ -120,6 +152,12 @@ def discover_role_pods(
 def discover_worker_pods(workload: dict[str, Any]) -> list[dict[str, Any]]:
     """Return the aggregated worker pods — convenience wrapper over
     :func:`discover_role_pods` for the non-PD path. Frontend pods are excluded.
+
+    Args:
+        workload: A SaFE GetWorkloadResponse mapping with a ``pods`` list.
+
+    Returns:
+        The aggregated worker pod entries.
     """
     return discover_role_pods(workload, pd_mode="aggregated")["worker"]
 
@@ -129,6 +167,12 @@ def _parse_lws_ordinal(pod_id: str) -> int | None:
 
     LWS pods are named ``<group>-<ordinal>`` (leader = 0). KubeRay-style random
     suffixes (``-x6fkf``) are non-numeric and return None.
+
+    Args:
+        pod_id: The LWS pod name.
+
+    Returns:
+        The trailing ordinal as an int, or ``None`` when it is non-numeric.
     """
     tail = pod_id.rsplit("-", 1)[-1] if "-" in pod_id else ""
     return int(tail) if tail.isdigit() else None
@@ -145,6 +189,16 @@ def frontend_service_url(
 
     Prefers the live SaFE service info (clusterIp / dns) when present; falls
     back to the conventional ``http://<wid>.<workspace>.svc.cluster.local:<port>``.
+
+    Args:
+        workload_id: The Dynamo workload id.
+        workspace: The Kubernetes namespace / workspace name.
+        service_info: Optional live SaFE service info (internalDomain / dns /
+            clusterIp / port).
+        port: Default frontend HTTP port used when none is in ``service_info``.
+
+    Returns:
+        The resolved frontend base URL.
     """
     if service_info:
         # Prefer the ready-made internalDomain ("<wid>.<ns>.svc.cluster.local:8000").
@@ -180,6 +234,16 @@ def disagg_flags(mode: str, kv_transfer_backend: str, *,
     server matches the native deploy path. ``dynamo.sglang`` parses these via
     argparse (it does NOT read SGLANG_DISAGGREGATION_* env), so they must be on
     the command line.
+
+    Args:
+        mode: Disaggregation mode (``"prefill"`` or ``"decode"``); any other
+            value yields an empty string.
+        kv_transfer_backend: Optional KV transfer backend name.
+        bootstrap_port: sglang PD bootstrap rendezvous port.
+
+    Returns:
+        The space-joined sglang PD disaggregation flags, or ``""`` when
+        ``mode`` is neither prefill nor decode.
     """
     m = (mode or "").strip().lower()
     if m not in ("prefill", "decode"):
@@ -215,6 +279,25 @@ def build_node_launch_args(
     its node-rank from ``$LWS_WORKER_INDEX`` pod-side, so the controller does
     not encode the rank here. ``disagg_mode`` (prefill/decode) folds the sglang
     PD flags into the launched command for that group.
+
+    Args:
+        framework: Framework name (``"sglang"`` or ``"vllm"``).
+        model: Model path passed to the launcher.
+        tp: Tensor-parallel size.
+        nnodes: Number of nodes in the group.
+        ep: Expert-parallel size (only emitted when > 1).
+        dist_init_port: torch.distributed rendezvous port.
+        pid_file: Pod-side server pid file path.
+        log_file: Pod-side server log file path.
+        extra_args: Extra args string folded into ``--extra-args``.
+        health_port: Leader local readiness probe port.
+        health_wait_sec: Seconds to wait for local ``/health`` (0 = skip).
+        kill_only: When ``True``, build a kill-only argv that frees the GPU.
+        disagg_mode: PD disaggregation mode folded into ``extra_args``.
+        kv_transfer_backend: KV transfer backend for PD disaggregation.
+
+    Returns:
+        The shell-quoted argv string for ``launch_dynamo_node.py``.
     """
     parts = ["--framework", framework]
     if kill_only:

--- a/inference_optimizer/multi_node/_internal/ray_dashboard.py
+++ b/inference_optimizer/multi_node/_internal/ray_dashboard.py
@@ -28,7 +28,14 @@ _HTTPX_TIMEOUT = httpx.Timeout(connect=10.0, read=30.0, write=30.0, pool=30.0)
 
 
 def _wrap_for_dash(body: str) -> str:
-    """Base64-wrap a bash body so it survives /bin/sh (dash), which Ray Dashboard uses to run entrypoints."""
+    """Base64-wrap a bash body so it survives /bin/sh (dash), which Ray Dashboard uses to run entrypoints.
+
+    Args:
+        body: The bash script body to wrap.
+
+    Returns:
+        str: A shell command that decodes and runs ``body`` under bash.
+    """
     import base64 as _b64
     encoded = _b64.b64encode(body.encode()).decode()
     return f'echo {encoded} | base64 -d | bash'
@@ -131,7 +138,19 @@ class RayDashboardClient:
             raise RayDashboardError(resp.status_code, resp.text, endpoint=endpoint) from e
 
     def submit_job(self, entrypoint: str, *, runtime_env: dict | None = None) -> str:
-        """POST /api/jobs/; returns the ``submission_id`` immediately (entrypoint runs async, poll :meth:`get_job`)."""
+        """POST /api/jobs/; returns the ``submission_id`` immediately (entrypoint runs async, poll :meth:`get_job`).
+
+        Args:
+            entrypoint: The shell entrypoint to run on the cluster.
+            runtime_env: Optional Ray runtime environment payload.
+
+        Returns:
+            str: The dashboard ``submission_id`` (or ``job_id``) for polling.
+
+        Raises:
+            ValueError: If ``entrypoint`` is empty.
+            RayDashboardError: On a non-200 status or a response missing an id.
+        """
         if not entrypoint:
             raise ValueError("entrypoint is empty")
         # Wrap for dash compatibility (Ray Dashboard uses /bin/sh).
@@ -150,7 +169,18 @@ class RayDashboardClient:
         return sub
 
     def get_job(self, submission_id: str) -> dict:
-        """GET /api/jobs/{submission_id}; response carries ``status`` (PENDING/RUNNING/SUCCEEDED/FAILED/STOPPED) + ``message``."""
+        """GET /api/jobs/{submission_id}; response carries ``status`` (PENDING/RUNNING/SUCCEEDED/FAILED/STOPPED) + ``message``.
+
+        Args:
+            submission_id: The dashboard submission id to query.
+
+        Returns:
+            dict: The decoded job status payload.
+
+        Raises:
+            ValueError: If ``submission_id`` is empty.
+            RayDashboardError: On any non-200 status.
+        """
         if not submission_id:
             raise ValueError("submission_id is empty")
         endpoint = f"GET /api/jobs/{submission_id}"

--- a/inference_optimizer/multi_node/_internal/safe_client.py
+++ b/inference_optimizer/multi_node/_internal/safe_client.py
@@ -32,6 +32,13 @@ class SafeApiError(RuntimeError):
     """
 
     def __init__(self, status: int | None, body: str, *, endpoint: str) -> None:
+        """Initialize the SaFE error with response context.
+
+        Args:
+            status: HTTP status code, or ``None`` if unavailable.
+            body: Raw response body (truncated in the message).
+            endpoint: The SaFE endpoint that produced the error.
+        """
         # Truncate body to keep the agent's stderr legible.
         snippet = body[:500] + ("..." if len(body) > 500 else "")
         super().__init__(f"SaFE {endpoint} -> status={status} body={snippet}")

--- a/inference_optimizer/multi_node/_internal/safe_client.py
+++ b/inference_optimizer/multi_node/_internal/safe_client.py
@@ -140,7 +140,17 @@ class SafeClient:
             raise SafeApiError(resp.status_code, resp.text, endpoint=endpoint) from e
 
     def create_workload(self, body: dict) -> str:
-        """POST /api/v1/workloads; returns the workload_id (non-2xx raises :class:`SafeApiError`)."""
+        """POST /api/v1/workloads; returns the workload_id (non-2xx raises :class:`SafeApiError`).
+
+        Args:
+            body: The CreateWorkloadRequest body to submit.
+
+        Returns:
+            str: The created workload id.
+
+        Raises:
+            SafeApiError: On any non-2xx status or a response missing an id.
+        """
         endpoint = "POST /api/v1/workloads"
         resp = self._client.post(self._url("/api/v1/workloads"), json=body)
         if not (200 <= resp.status_code < 300):
@@ -202,7 +212,14 @@ class SafeClient:
         return data
 
     def stop_workload(self, workload_id: str) -> None:
-        """POST /api/v1/workloads/{workload_id}/stop; idempotent (404/409 treated as success)."""
+        """POST /api/v1/workloads/{workload_id}/stop; idempotent (404/409 treated as success).
+
+        Args:
+            workload_id: The workload id to stop.
+
+        Raises:
+            SafeApiError: On any status other than 200/204/404/409.
+        """
         endpoint = f"POST /api/v1/workloads/{workload_id}/stop"
         resp = self._client.post(self._url(f"/api/v1/workloads/{workload_id}/stop"))
         if resp.status_code in (200, 204, 404, 409):
@@ -212,7 +229,14 @@ class SafeClient:
         raise SafeApiError(resp.status_code, resp.text, endpoint=endpoint)
 
     def delete_workload(self, workload_id: str) -> None:
-        """DELETE /api/v1/workloads/{workload_id}; idempotent (404 treated as success)."""
+        """DELETE /api/v1/workloads/{workload_id}; idempotent (404 treated as success).
+
+        Args:
+            workload_id: The workload id to delete.
+
+        Raises:
+            SafeApiError: On any status other than 200/204/404.
+        """
         endpoint = f"DELETE /api/v1/workloads/{workload_id}"
         resp = self._client.delete(self._url(f"/api/v1/workloads/{workload_id}"))
         if resp.status_code in (200, 204, 404):
@@ -223,7 +247,14 @@ class SafeClient:
 
 
 def from_env() -> SafeClient:
-    """Construct a SafeClient from SAFE_API_URL + SAFE_API_KEY env vars; clean RuntimeError when missing."""
+    """Construct a SafeClient from SAFE_API_URL + SAFE_API_KEY env vars; clean RuntimeError when missing.
+
+    Returns:
+        SafeClient: A client configured from the environment.
+
+    Raises:
+        RuntimeError: If ``SAFE_API_URL`` or ``SAFE_API_KEY`` is missing.
+    """
     base = (os.environ.get("SAFE_API_URL") or "").strip()
     key = (os.environ.get("SAFE_API_KEY") or "").strip()
     missing = [name for name, val in (("SAFE_API_URL", base), ("SAFE_API_KEY", key)) if not val]

--- a/inference_optimizer/multi_node/_internal/ssh_client.py
+++ b/inference_optimizer/multi_node/_internal/ssh_client.py
@@ -55,6 +55,15 @@ def generate_session_keypair(dest_dir: Path) -> tuple[Path, str]:
     Returns ``(private_key_path, public_key_str)``. Idempotent: if the key
     already exists it is reused (so retries of ``create-dynamo`` keep the same
     authorized key that the running pods already trust).
+
+    Args:
+        dest_dir: Directory to create (or reuse) the keypair under.
+
+    Returns:
+        A ``(private_key_path, public_key_str)`` tuple.
+
+    Raises:
+        RuntimeError: If ``ssh-keygen`` exits non-zero.
     """
     dest_dir.mkdir(parents=True, exist_ok=True)
     priv = dest_dir / "mn_id_ed25519"
@@ -99,6 +108,17 @@ def ssh_run(
     ``command`` is run via ``bash -lc`` on the remote so login-shell PATH and
     the framework venv resolve. Does not raise on non-zero exit — the caller
     inspects ``.returncode`` / ``.stdout`` / ``.stderr``.
+
+    Args:
+        host: The target host/IP.
+        command: The shell command to run remotely.
+        key_path: Path to the private SSH key.
+        port: The remote sshd port.
+        user: The remote login user.
+        timeout: Subprocess timeout in seconds.
+
+    Returns:
+        The completed SSH subprocess (not raised on non-zero exit).
     """
     argv = [
         "ssh",
@@ -136,6 +156,21 @@ def ssh_run_script(
     the SSH-launched framework child. A bare ``ssh host cmd`` does NOT forward
     the controller's environment, and these keys are not in the pod's container
     env, so they must be injected explicitly here.
+
+    Args:
+        host: The target host/IP.
+        script_text: The script body to ship and run.
+        interpreter: Interpreter used to run the script (e.g. ``python3``).
+        script_args: Arguments appended verbatim after the script path.
+        key_path: Path to the private SSH key.
+        port: The remote sshd port.
+        user: The remote login user.
+        timeout: Subprocess timeout in seconds.
+        remote_path: Destination path for the decoded script on the pod.
+        env: Optional ``KEY=VAL`` assignments prepended before the interpreter.
+
+    Returns:
+        The completed SSH subprocess.
     """
     enc = base64.b64encode(script_text.encode("utf-8")).decode("ascii")
     env_prefix = ""
@@ -168,6 +203,18 @@ def ssh_run_bash_with_env(
     ``export`` lines and the whole script is piped over SSH **stdin** — so
     secrets never appear in argv or on the pod's disk. Used by the OOB pod
     install (needs OOB_API_KEY / OOB_BASE_URL).
+
+    Args:
+        host: The target host/IP.
+        script_text: The script body run via ``bash -s``.
+        env: Environment variables exported before the script, or ``None``.
+        key_path: Path to the private SSH key.
+        port: The remote sshd port.
+        user: The remote login user.
+        timeout: Subprocess timeout in seconds.
+
+    Returns:
+        The completed SSH subprocess.
     """
     prologue = "\n".join(
         f"export {k}={shlex.quote(str(v))}" for k, v in (env or {}).items()
@@ -190,7 +237,19 @@ def probe_ssh(
     user: str = "root",
     timeout: int = 20,
 ) -> bool:
-    """Return True iff a trivial SSH command succeeds (pod reachable + key OK)."""
+    """Return True iff a trivial SSH command succeeds (pod reachable + key OK).
+
+    Args:
+        host: The target host/IP.
+        key_path: Path to the private SSH key.
+        port: The remote sshd port.
+        user: The remote login user.
+        timeout: Subprocess timeout in seconds.
+
+    Returns:
+        ``True`` when a trivial probe command succeeds (pod reachable and key
+        accepted), ``False`` otherwise (including on timeout).
+    """
     try:
         cp = ssh_run(host, "echo mn_ssh_ok", key_path=key_path, port=port,
                      user=user, timeout=timeout)

--- a/inference_optimizer/multi_node/_internal/workload_spec.py
+++ b/inference_optimizer/multi_node/_internal/workload_spec.py
@@ -107,7 +107,31 @@ def build_rayjob_workload_body(
     extra_env: dict[str, str] | None = None,
     extra_labels: dict[str, str] | None = None,
 ) -> dict[str, Any]:
-    """Build a SaFE CreateWorkloadRequest body for a multi-node RayJob (resource quantities as K8s-notation strings; json.dumps-safe)."""
+    """Build a SaFE CreateWorkloadRequest body for a multi-node RayJob (resource quantities as K8s-notation strings; json.dumps-safe).
+
+    Args:
+        workspace: SaFE workspace id the workload belongs to.
+        display_name: Human-readable name for the workload.
+        image: Container image used for both head and worker roles.
+        nodes: Total node count; head is 1 and workers are ``nodes - 1``.
+        gpus_per_node: GPUs requested per node.
+        cpus_per_node: CPUs requested per node.
+        mem_gi_per_node: Memory in GiB requested per node.
+        ephemeral_gi_per_node: Ephemeral storage in GiB requested per node.
+        description: Optional workload description.
+        owner_id: Optional owner id to attach to the workload.
+        session_id: Optional session id injected as ``primus-claw/session-id``
+            for Brain correlation.
+        extra_env: Optional user environment variables (reserved keys stripped).
+        extra_labels: Optional user labels (Brain-managed prefixes stripped).
+
+    Returns:
+        dict[str, Any]: A json.dumps-safe CreateWorkloadRequest body.
+
+    Raises:
+        ValueError: If ``nodes`` or ``gpus_per_node`` is below 1, or if
+            ``workspace``, ``display_name``, or ``image`` is empty.
+    """
     if nodes < 1:
         raise ValueError(f"nodes must be >= 1, got {nodes}")
     if gpus_per_node < 1:

--- a/inference_optimizer/multi_node/_internal/workload_spec.py
+++ b/inference_optimizer/multi_node/_internal/workload_spec.py
@@ -297,6 +297,46 @@ def build_dynamo_workload_body(
     ``entryPoints`` are base64-encoded per the SaFE contract (the apiserver
     stores them verbatim; the dispatcher decodes/append/re-encodes the
     launcher payload).
+
+    Args:
+        workspace: SaFE workspace id the workload belongs to.
+        display_name: Human-readable name for the workload.
+        image: Container image used for the frontend and worker roles.
+        nodes: Total node count for the aggregated worker role.
+        gpus_per_node: GPUs requested per GPU pod.
+        cpus_per_node: CPUs requested per GPU pod.
+        mem_gi_per_node: Memory in GiB requested per GPU pod.
+        ephemeral_gi_per_node: Ephemeral storage in GiB requested per GPU pod.
+        ssh_authorized_key: Public key injected as ``MN_SSH_AUTHORIZED_KEY``
+            for the idle-pod control plane.
+        backend_framework: Dynamo backend (``sglang`` / ``vllm`` / ``trtllm``).
+        kv_transfer_backend: KV transfer backend (``nixl`` / ``mori`` /
+            ``mooncake``).
+        ssh_port: SSH port exported as ``MN_SSH_PORT``.
+        shared_mem_gi: Shared memory in GiB requested per GPU pod.
+        rdma_resource: RDMA resource quantity for multinode / PD roles.
+        frontend_cpu: CPUs requested for the frontend pod.
+        frontend_mem_gi: Memory in GiB for the frontend pod.
+        frontend_port: Frontend HTTP port (benchmark target).
+        pd_mode: ``aggregated`` or ``disaggregated`` prefill/decode topology.
+        pd_prefill_nodes: Prefill group node count (disaggregated).
+        pd_decode_nodes: Decode group node count (disaggregated).
+        pd_prefill_tp: Prefill group tensor-parallel size (disaggregated).
+        pd_decode_tp: Decode group tensor-parallel size (disaggregated).
+        description: Optional workload description.
+        owner_id: Optional owner id to attach to the workload.
+        session_id: Optional session id injected as ``primus-claw/session-id``.
+        extra_env: Optional user environment variables (reserved keys stripped).
+        extra_labels: Optional user labels (Brain-managed prefixes stripped).
+
+    Returns:
+        A json.dumps-safe CreateWorkloadRequest body for the Dynamo deployment.
+
+    Raises:
+        ValueError: If ``nodes`` / ``gpus_per_node`` is below 1; if
+            ``workspace`` / ``display_name`` / ``image`` / ``ssh_authorized_key``
+            is empty; or if ``backend_framework`` / ``kv_transfer_backend`` is
+            not a supported enum value.
     """
     if nodes < 1:
         raise ValueError(f"nodes must be >= 1, got {nodes}")
@@ -333,7 +373,15 @@ def build_dynamo_workload_body(
 
     def _gpu_resource(replica: int, *, multinode: bool) -> dict[str, Any]:
         """One GPU pod slot (worker / prefill / decode). RDMA only when the
-        role spans nodes (a single-node role has no cross-node NCCL/KV)."""
+        role spans nodes (a single-node role has no cross-node NCCL/KV).
+
+        Args:
+            replica: The replica count for this pod role.
+            multinode: Whether the role spans nodes (adds ``rdmaResource``).
+
+        Returns:
+            The resource dict for one GPU pod slot.
+        """
         res: dict[str, Any] = {
             "replica": replica,
             "cpu": str(cpus_per_node),

--- a/inference_optimizer/multi_node/cli.py
+++ b/inference_optimizer/multi_node/cli.py
@@ -42,7 +42,11 @@ _DEFAULT_JIT_POLL_TIMEOUT_S = 1800
 
 
 def _resolve_poll_timeout_s() -> int:
-    """Poll budget (seconds): ``HYPERLOOM_MN_POLL_TIMEOUT_S`` env else ``_DEFAULT_POLL_TIMEOUT_S``."""
+    """Poll budget (seconds): ``HYPERLOOM_MN_POLL_TIMEOUT_S`` env else ``_DEFAULT_POLL_TIMEOUT_S``.
+
+    Returns:
+        int: The poll budget in seconds (at least 1).
+    """
     raw = (os.environ.get("HYPERLOOM_MN_POLL_TIMEOUT_S") or "").strip()
     if raw:
         try:
@@ -87,7 +91,14 @@ _TERMINAL_OK_STATUSES = {"SUCCEEDED"}
 
 
 def _normalize_extra_args(s: str | None) -> str:
-    """Normalize ``--extra-args`` whitespace for equality (order-preserving; argv order matters)."""
+    """Normalize ``--extra-args`` whitespace for equality (order-preserving; argv order matters).
+
+    Args:
+        s: The raw extra-args string, or ``None``.
+
+    Returns:
+        str: The whitespace-collapsed string.
+    """
     return " ".join((s or "").split())
 
 # Exit codes — part of the CLI's contract with the agent; keep stable.
@@ -154,7 +165,13 @@ def _checkpoint_create_rayjob_state(
     workspace: str,
     args: argparse.Namespace,
 ) -> None:
-    """Persist ``rayjob_id`` as soon as SaFE returns it, so a concurrent ``create-rayjob`` doesn't leak a second RayJob."""
+    """Persist ``rayjob_id`` as soon as SaFE returns it, so a concurrent ``create-rayjob`` doesn't leak a second RayJob.
+
+    Args:
+        wid: The workload id returned by SaFE.
+        workspace: The SaFE workspace the workload belongs to.
+        args: Parsed ``create-rayjob`` arguments (node/GPU counts, image).
+    """
     prev = _load_state()
     old = (prev.get("rayjob_id") or "").strip()
     state: dict[str, Any] = dict(prev)
@@ -196,6 +213,16 @@ def _write_rayjob_meta(
 
     Skipped when ``session_id`` is empty (it's the filename). Best-effort:
     filesystem errors are logged at WARN and swallowed.
+
+    Args:
+        wid: The RayJob workload id.
+        workspace: The SaFE workspace.
+        session_id: The sandbox session id (also the meta filename); empty
+            skips the write.
+        owner_id: Optional owner id.
+        display_name: Human-readable workload name.
+        nodes: Total node count.
+        gpus_per_node: GPUs requested per node.
     """
     if not session_id:
         return
@@ -272,7 +299,14 @@ def _b64(s: str) -> str:
 
 
 def _wrap_for_dash(body: str) -> str:
-    """Base64-wrap a bash entrypoint so it survives Ray Dashboard exec under /bin/sh (dash rejects ``set -o pipefail``)."""
+    """Base64-wrap a bash entrypoint so it survives Ray Dashboard exec under /bin/sh (dash rejects ``set -o pipefail``).
+
+    Args:
+        body: The bash entrypoint body to wrap.
+
+    Returns:
+        str: A shell command that decodes and runs ``body`` under bash.
+    """
     enc = _b64(body)
     return f"echo {enc} | base64 -d | bash"
 
@@ -303,7 +337,12 @@ def _parse_kv_list(values: list[str] | None) -> dict[str, str]:
 
 
 def _credential_fanout() -> dict[str, str]:
-    """Return the *_API_KEY / *_BASE_URL env to inject into the RayJob (keys fall back to SAFE_API_KEY per ADDENDUM-13)."""
+    """Return the *_API_KEY / *_BASE_URL env to inject into the RayJob (keys fall back to SAFE_API_KEY per ADDENDUM-13).
+
+    Returns:
+        dict[str, str]: The credential env vars present in the sandbox,
+        keyed by name.
+    """
     safe_key = os.environ.get("SAFE_API_KEY", "").strip()
     out: dict[str, str] = {}
     for name in (
@@ -362,6 +401,29 @@ def _short_poll(
     post-create 404 lag). Terminal failure raises
     :class:`WorkloadTerminalFailure` (exit 2); timeout raises
     :class:`TransientFailure` (exit 1, safe to rerun).
+
+    Args:
+        label: Human-readable label used in log lines and errors.
+        fetch: Callable returning ``(state_obj, summary_str)`` per poll.
+        is_ok: Predicate that returns True when the state is terminal-OK.
+        is_fail: Predicate that returns True when the state is terminal-fail.
+        interval_s: Seconds to sleep between polls.
+        timeout_s: Maximum seconds to poll before raising.
+        failure_diag: Optional callable mapping a failed state to a
+            ``(diag, snapshot)`` pair.
+        quiet_fetch_error_grace_s: Seconds during which a quiet fetch error
+            logs at INFO rather than WARN.
+        is_quiet_fetch_error: Optional predicate classifying an exception as
+            an expected quiet fetch error.
+
+    Returns:
+        Any: The first state object that satisfies ``is_ok``.
+
+    Raises:
+        WorkloadTerminalFailure: When ``is_fail`` matches and ``failure_diag``
+            is provided.
+        RuntimeError: When ``is_fail`` matches without a ``failure_diag``.
+        TransientFailure: When the timeout elapses before a terminal state.
     """
     started = time.monotonic()
     attempt = 0
@@ -415,7 +477,15 @@ def _short_poll(
 
 
 def _summarize_workload_failure(workload: dict[str, Any]) -> tuple[str, dict[str, Any]]:
-    """Build a one-line diagnostic + JSON-safe snapshot (phase/message/per-pod status/dispatch) from a SaFE GetWorkloadResponse."""
+    """Build a one-line diagnostic + JSON-safe snapshot (phase/message/per-pod status/dispatch) from a SaFE GetWorkloadResponse.
+
+    Args:
+        workload: A SaFE GetWorkloadResponse dict.
+
+    Returns:
+        tuple[str, dict[str, Any]]: The one-line diagnostic and a JSON-safe
+        failure snapshot.
+    """
     phase = str(workload.get("phase") or "?")
     msg = str(workload.get("message") or "").strip()
     queue = workload.get("queuePosition")
@@ -472,6 +542,12 @@ def _find_head_pod_ip(workload: dict) -> str:
 
     Priority: a ``podId`` containing ``-head-``, then ``resourceId == 0``,
     then the first pod with a ``podIP`` (the submitter pod isn't the head).
+
+    Args:
+        workload: A SaFE GetWorkloadResponse dict.
+
+    Returns:
+        str: The head pod IP, or an empty string when none is found.
     """
     pods = workload.get("pods") or []
     if not pods:
@@ -678,6 +754,13 @@ def cmd_bootstrap(args: argparse.Namespace) -> int:
 
     Streams the sandbox-side ``scripts/bootstrap.sh`` into the head pod via a
     heredoc entrypoint (``--script PATH`` overrides with a pod-visible script).
+
+    Args:
+        args: Parsed ``bootstrap`` arguments (script override, force,
+            print_logs, polling).
+
+    Returns:
+        int: ``0`` on success.
     """
     state = _require_state("rayjob_id", "head_pod_ip")
     head_ip = state["head_pod_ip"]
@@ -792,7 +875,17 @@ _SCRIPTS_DIR = Path(__file__).parent / "scripts"
 
 
 def _read_pod_script(name: str) -> str:
-    """Read a pod-side script from ``multi_node/scripts/`` (embedded into the dashboard entrypoint at submit time)."""
+    """Read a pod-side script from ``multi_node/scripts/`` (embedded into the dashboard entrypoint at submit time).
+
+    Args:
+        name: The script filename under ``multi_node/scripts/``.
+
+    Returns:
+        str: The script's text contents.
+
+    Raises:
+        RuntimeError: If the script file is missing.
+    """
     p = _SCRIPTS_DIR / name
     if not p.is_file():
         raise RuntimeError(
@@ -807,7 +900,20 @@ def _build_restart_entrypoint(
     pid_file: str,
     log_file: str,
 ) -> str:
-    """Compose the single-node restart entrypoint (heredoc kill_server.sh + launch_server.sh; IR-5 PID-file kill)."""
+    """Compose the single-node restart entrypoint (heredoc kill_server.sh + launch_server.sh; IR-5 PID-file kill).
+
+    Args:
+        args: Parsed ``restart-server`` arguments (framework, model, tp,
+            extra_args, health flag).
+        pid_file: Head-pod PID file path.
+        log_file: Head-pod server log path.
+
+    Returns:
+        str: The composed Ray Dashboard entrypoint shell command.
+
+    Raises:
+        RuntimeError: If ``args.framework`` is not sglang or vllm.
+    """
     framework = args.framework.lower()
     if framework not in ("sglang", "vllm"):
         raise RuntimeError(f"unsupported framework: {args.framework!r} (use sglang or vllm)")
@@ -912,7 +1018,15 @@ def _exec_kill_submission(
 
 
 def _build_multinode_kill_entrypoint(pid_dir: str, grace_sec: int = 5) -> str:
-    """Compose the head-pod entrypoint that kills every rank's server via heredoc-embedded kill_multinode.py (fans out via ray actors)."""
+    """Compose the head-pod entrypoint that kills every rank's server via heredoc-embedded kill_multinode.py (fans out via ray actors).
+
+    Args:
+        pid_dir: Directory of per-rank PID files to sweep.
+        grace_sec: Seconds between SIGTERM and SIGKILL.
+
+    Returns:
+        str: The composed Ray Dashboard entrypoint shell command.
+    """
     py = _read_pod_script("kill_multinode.py")
     return (
         f"{_MN_ENTRYPOINT_PREAMBLE}"
@@ -924,7 +1038,14 @@ def _build_multinode_kill_entrypoint(pid_dir: str, grace_sec: int = 5) -> str:
 
 
 def _extract_launcher_summary(launch_logs: str) -> dict:
-    """Parse the JSON summary launch_multinode.py writes to stdout (the last balanced ``{...}`` in the interleaved logs); ``{}`` on failure."""
+    """Parse the JSON summary launch_multinode.py writes to stdout (the last balanced ``{...}`` in the interleaved logs); ``{}`` on failure.
+
+    Args:
+        launch_logs: The interleaved launcher logs.
+
+    Returns:
+        dict: The parsed launcher summary, or ``{}`` if none could be found.
+    """
     if not launch_logs:
         return {}
     text = launch_logs.rstrip()
@@ -961,6 +1082,16 @@ def _build_multinode_launch_entrypoint(
 
     Killed ranks MUST be cleared before this runs (sequenced by
     cmd_restart_server) or rank 0's old process still holds :8888.
+
+    Args:
+        args: Parsed ``restart-server`` arguments (framework, model, tp, ep,
+            PD knobs, health flag, extra_args).
+        nnodes: Total node count for the launch.
+        pid_dir: Directory the per-rank PID files are written to.
+        log_dir: Directory the per-rank logs are written to.
+
+    Returns:
+        str: The composed Ray Dashboard entrypoint shell command.
     """
     py = _read_pod_script("launch_multinode.py")
     wait_flag = "--no-wait-health" if args.no_wait_health else ""
@@ -1036,7 +1167,18 @@ def _build_multinode_router_entrypoint(
     pid_dir: str,
     log_dir: str,
 ) -> str:
-    """Compose the head-pod entrypoint that detaches the PD router (rank 0 only, binds 8888) via heredoc-embedded launch_router.py."""
+    """Compose the head-pod entrypoint that detaches the PD router (rank 0 only, binds 8888) via heredoc-embedded launch_router.py.
+
+    Args:
+        args: Parsed ``restart-server`` arguments (framework, router override).
+        prefill_url: Internal prefill group URL.
+        decode_url: Internal decode group URL.
+        pid_dir: Directory the router PID file is written to.
+        log_dir: Directory the router log is written to.
+
+    Returns:
+        str: The composed Ray Dashboard entrypoint shell command.
+    """
     py = _read_pod_script("launch_router.py")
     public_port = 8888
     pid_file = f"{pid_dir.rstrip('/')}/router.pid"
@@ -1065,7 +1207,18 @@ def _build_multinode_apply_patch_entrypoint(
     kernel_id: str,
     timeout_sec: int,
 ) -> str:
-    """Compose the head-pod entrypoint that fans out a kernel patch to every pod via heredoc-embedded kernel_patch_multinode.py."""
+    """Compose the head-pod entrypoint that fans out a kernel patch to every pod via heredoc-embedded kernel_patch_multinode.py.
+
+    Args:
+        target_path: Absolute file path on each pod to overwrite.
+        patch_b64: Base64-encoded new file contents.
+        backup_dir: Directory on each pod where the original is saved.
+        kernel_id: Optional id used to construct the backup filename.
+        timeout_sec: Per-actor timeout in seconds.
+
+    Returns:
+        str: The composed Ray Dashboard entrypoint shell command.
+    """
     py = _read_pod_script("kernel_patch_multinode.py")
     return (
         f"{_MN_ENTRYPOINT_PREAMBLE}"
@@ -1086,7 +1239,16 @@ def _build_multinode_revert_patch_entrypoint(
     backup_map_json: str,
     timeout_sec: int,
 ) -> str:
-    """Compose the head-pod entrypoint that fans out a revert via heredoc-embedded kernel_patch_multinode.py (``backup_map_json`` from the matching apply)."""
+    """Compose the head-pod entrypoint that fans out a revert via heredoc-embedded kernel_patch_multinode.py (``backup_map_json`` from the matching apply).
+
+    Args:
+        target_path: Absolute file path on each pod to restore.
+        backup_map_json: JSON ``{hostname: backup_path}`` from the matching apply.
+        timeout_sec: Per-actor timeout in seconds.
+
+    Returns:
+        str: The composed Ray Dashboard entrypoint shell command.
+    """
     py = _read_pod_script("kernel_patch_multinode.py")
     return (
         f"{_MN_ENTRYPOINT_PREAMBLE}"
@@ -1108,6 +1270,13 @@ def _build_multinode_apply_tracelens_patch_entrypoint(
 
     Forwards only ``$TRACELENS_ROOT`` (patches are read on the pods'
     wekafs mount); the in-pod script is idempotent.
+
+    Args:
+        tracelens_root: Path to the TraceLens checkout visible from every pod.
+        sglang_version_pin: Optional advisory version pin; omitted when empty.
+
+    Returns:
+        str: The composed Ray Dashboard entrypoint shell command.
     """
     py = _read_pod_script("apply_tracelens_patch_multinode.py")
     pin_arg = ""
@@ -1131,7 +1300,18 @@ def _build_multinode_kernel_bench_entrypoint(
     result_glob: str,
     timeout_sec: int,
 ) -> str:
-    """Compose the head-pod entrypoint running a kernel micro-benchmark on a single GPU node via heredoc-embedded kernel_bench_multinode.py."""
+    """Compose the head-pod entrypoint running a kernel micro-benchmark on a single GPU node via heredoc-embedded kernel_bench_multinode.py.
+
+    Args:
+        workspace: Absolute dir on the pod used as CWD for the bench.
+        bench_command: Shell command run via ``bash -lc``.
+        files_b64_json: JSON ``{rel_path: base64_content}`` of files to stage.
+        result_glob: Glob (relative to workspace) of artifacts to read back.
+        timeout_sec: Hard timeout for the bench command.
+
+    Returns:
+        str: The composed Ray Dashboard entrypoint shell command.
+    """
     py = _read_pod_script("kernel_bench_multinode.py")
     return (
         f"{_MN_ENTRYPOINT_PREAMBLE}"
@@ -1148,7 +1328,15 @@ def _build_multinode_kernel_bench_entrypoint(
 
 
 def _extract_pod_json(logs: str) -> dict | None:
-    """Parse the last top-level JSON document from an interleaved Ray Dashboard job_logs blob (the in-pod scripts emit one)."""
+    """Parse the last top-level JSON document from an interleaved Ray Dashboard job_logs blob (the in-pod scripts emit one).
+
+    Args:
+        logs: The interleaved dashboard job logs.
+
+    Returns:
+        dict | None: The parsed JSON document, or ``None`` if none is found
+        or it does not parse.
+    """
     if not logs:
         return None
     text = logs.rstrip()
@@ -1192,7 +1380,19 @@ def _submit_and_collect_pod_json(
     poll_interval: int,
     poll_timeout: int,
 ) -> tuple[int, dict | None, str]:
-    """Submit ``entrypoint``, poll to terminal, parse the per-pod JSON, and return ``(returncode, parsed_or_None, logs)``."""
+    """Submit ``entrypoint``, poll to terminal, parse the per-pod JSON, and return ``(returncode, parsed_or_None, logs)``.
+
+    Args:
+        head_ip: IP of the Ray head pod's dashboard.
+        entrypoint: The entrypoint shell command to submit.
+        label: Human-readable label used in log lines and polling.
+        poll_interval: Seconds between polls.
+        poll_timeout: Maximum seconds to poll.
+
+    Returns:
+        tuple[int, dict | None, str]: The exit code, parsed per-pod JSON (or
+        ``None``), and the raw dashboard logs.
+    """
     with ray_dashboard.RayDashboardClient(head_ip) as ray:
         sub_id = ray.submit_job(_wrap_for_dash(entrypoint))
         info(f"{label} submission_id={sub_id}")
@@ -1230,7 +1430,16 @@ def _submit_and_collect_pod_json(
 
 # Subcommand: apply-patch / revert-patch / kernel-bench (multi-node only)
 def cmd_apply_patch(args: argparse.Namespace) -> int:
-    """Fan out a kernel patch to every pod via kernel_patch_multinode.py apply; multi-node only. Re-prints its JSON verbatim."""
+    """Fan out a kernel patch to every pod via kernel_patch_multinode.py apply; multi-node only. Re-prints its JSON verbatim.
+
+    Args:
+        args: Parsed ``apply-patch`` arguments (patch file, target, backup
+            dir, kernel id, polling).
+
+    Returns:
+        int: A process exit code (``EXIT_OK``/``EXIT_TRANSIENT``/
+        ``EXIT_CONFIG_ERROR``).
+    """
     state = _load_state()
     head_ip = (state.get("head_pod_ip") or "").strip()
     if not head_ip:
@@ -1271,7 +1480,15 @@ def cmd_apply_patch(args: argparse.Namespace) -> int:
 
 
 def cmd_revert_patch(args: argparse.Namespace) -> int:
-    """Fan out a kernel patch revert; ``--backup-map-json`` is the per-host map from the matching apply-patch (pass through unchanged)."""
+    """Fan out a kernel patch revert; ``--backup-map-json`` is the per-host map from the matching apply-patch (pass through unchanged).
+
+    Args:
+        args: Parsed ``revert-patch`` arguments (target, backup map, polling).
+
+    Returns:
+        int: A process exit code (``EXIT_OK``/``EXIT_TRANSIENT``/
+        ``EXIT_CONFIG_ERROR``).
+    """
     state = _load_state()
     head_ip = (state.get("head_pod_ip") or "").strip()
     if not head_ip:
@@ -1314,6 +1531,14 @@ def cmd_apply_tracelens_patch(args: argparse.Namespace) -> int:
     Needed because the sandbox can't ``import sglang`` to run the local
     patcher. Idempotent (already-patched pods return ``status=skipped``).
     Re-prints the script's JSON (``status`` + ``per_pod``) verbatim.
+
+    Args:
+        args: Parsed ``apply-tracelens-patch`` arguments (tracelens root,
+            version pin, polling).
+
+    Returns:
+        int: ``EXIT_OK`` when applied/skipped, otherwise ``EXIT_TRANSIENT`` /
+        ``EXIT_CONFIG_ERROR``.
     """
     state = _load_state()
     head_ip = (state.get("head_pod_ip") or "").strip()
@@ -1362,7 +1587,16 @@ def cmd_apply_tracelens_patch(args: argparse.Namespace) -> int:
 
 
 def cmd_kernel_bench(args: argparse.Namespace) -> int:
-    """Run a kernel micro-benchmark on a GPU-bearing pod (stages ``--workspace`` files, runs ``--bench-command``, reads back ``--result-glob``)."""
+    """Run a kernel micro-benchmark on a GPU-bearing pod (stages ``--workspace`` files, runs ``--bench-command``, reads back ``--result-glob``).
+
+    Args:
+        args: Parsed ``kernel-bench`` arguments (workspace, command, staged
+            files, result glob, polling).
+
+    Returns:
+        int: A process exit code (``EXIT_OK``/``EXIT_TRANSIENT``/
+        ``EXIT_CONFIG_ERROR``).
+    """
     state = _load_state()
     head_ip = (state.get("head_pod_ip") or "").strip()
     if not head_ip:
@@ -1405,6 +1639,14 @@ def cmd_restart_server(args: argparse.Namespace) -> int:
     Picks a path from state.json's ``nodes``: single-pod runs
     kill/launch_server.sh on the head pod; multi-pod fans
     kill/launch_multinode.py out across every node via ray actors.
+
+    Args:
+        args: Parsed ``restart-server`` arguments (framework, model, tp, ep,
+            PD knobs, pid/log files, polling).
+
+    Returns:
+        int: ``0`` on success; ``1`` on a terminal launch/router failure;
+        ``2`` for unsupported single-node PD.
     """
     state = _require_state("head_pod_ip")
     head_ip = state["head_pod_ip"]
@@ -2051,7 +2293,14 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
-    """CLI entrypoint with stable exit codes: 0 ok, 1 transient (retryable), 2 terminal workload failure (do not retry), 3 config error, 130 SIGINT."""
+    """CLI entrypoint with stable exit codes: 0 ok, 1 transient (retryable), 2 terminal workload failure (do not retry), 3 config error, 130 SIGINT.
+
+    Args:
+        argv: Optional argument vector; defaults to ``sys.argv`` when ``None``.
+
+    Returns:
+        int: The process exit code per the codes described above.
+    """
     parser = build_parser()
     args = parser.parse_args(argv)
     try:

--- a/inference_optimizer/multi_node/cli.py
+++ b/inference_optimizer/multi_node/cli.py
@@ -43,7 +43,12 @@ _DEFAULT_JIT_POLL_TIMEOUT_S = 1800
 
 
 def _resolve_poll_timeout_s() -> int:
-    """Poll budget (seconds): ``HYPERLOOM_MN_POLL_TIMEOUT_S`` env else ``_DEFAULT_POLL_TIMEOUT_S``."""
+    """Poll budget (seconds): ``HYPERLOOM_MN_POLL_TIMEOUT_S`` env else ``_DEFAULT_POLL_TIMEOUT_S``.
+
+    Returns:
+        int: The poll timeout in seconds (at least 1); falls back to the
+        default when the env var is unset or invalid.
+    """
     raw = (os.environ.get("HYPERLOOM_MN_POLL_TIMEOUT_S") or "").strip()
     if raw:
         try:
@@ -88,7 +93,15 @@ _TERMINAL_OK_STATUSES = {"SUCCEEDED"}
 
 
 def _normalize_extra_args(s: str | None) -> str:
-    """Normalize ``--extra-args`` whitespace for equality (order-preserving; argv order matters)."""
+    """Normalize ``--extra-args`` whitespace for equality (order-preserving; argv order matters).
+
+    Args:
+        s (str | None): The raw extra-args string, or ``None``.
+
+    Returns:
+        str: The string with runs of whitespace collapsed to single spaces
+        (token order preserved). Empty for ``None``.
+    """
     return " ".join((s or "").split())
 
 # Exit codes — part of the CLI's contract with the agent; keep stable.
@@ -155,7 +168,14 @@ def _checkpoint_create_rayjob_state(
     workspace: str,
     args: argparse.Namespace,
 ) -> None:
-    """Persist ``rayjob_id`` as soon as SaFE returns it, so a concurrent ``create-rayjob`` doesn't leak a second RayJob."""
+    """Persist ``rayjob_id`` as soon as SaFE returns it, so a concurrent ``create-rayjob`` doesn't leak a second RayJob.
+
+    Args:
+        wid (str): The SaFE workload id to checkpoint.
+        workspace (str): The SaFE workspace the workload belongs to.
+        args (argparse.Namespace): Parsed ``create-rayjob`` args (supplies
+            ``nodes`` / ``gpus_per_node`` / ``image``).
+    """
     prev = _load_state()
     old = (prev.get("rayjob_id") or "").strip()
     state: dict[str, Any] = dict(prev)
@@ -197,6 +217,16 @@ def _write_rayjob_meta(
 
     Skipped when ``session_id`` is empty (it's the filename). Best-effort:
     filesystem errors are logged at WARN and swallowed.
+
+    Args:
+        wid (str): The SaFE workload (RayJob) id.
+        workspace (str): The SaFE workspace.
+        session_id (str | None): The sandbox session id (used as the filename);
+            the write is skipped when empty.
+        owner_id (str | None): The owning sandbox workload id, if any.
+        display_name (str): Human-readable RayJob name.
+        nodes (int): Node count.
+        gpus_per_node (int): GPUs per pod.
     """
     if not session_id:
         return
@@ -273,7 +303,15 @@ def _b64(s: str) -> str:
 
 
 def _wrap_for_dash(body: str) -> str:
-    """Base64-wrap a bash entrypoint so it survives Ray Dashboard exec under /bin/sh (dash rejects ``set -o pipefail``)."""
+    """Base64-wrap a bash entrypoint so it survives Ray Dashboard exec under /bin/sh (dash rejects ``set -o pipefail``).
+
+    Args:
+        body (str): The bash entrypoint body to wrap.
+
+    Returns:
+        str: A ``echo <b64> | base64 -d | bash`` command that decodes and runs
+        ``body`` under bash.
+    """
     enc = _b64(body)
     return f"echo {enc} | base64 -d | bash"
 
@@ -304,7 +342,12 @@ def _parse_kv_list(values: list[str] | None) -> dict[str, str]:
 
 
 def _credential_fanout() -> dict[str, str]:
-    """Return the *_API_KEY / *_BASE_URL env to inject into the RayJob (keys fall back to SAFE_API_KEY per ADDENDUM-13)."""
+    """Return the *_API_KEY / *_BASE_URL env to inject into the RayJob (keys fall back to SAFE_API_KEY per ADDENDUM-13).
+
+    Returns:
+        dict[str, str]: The present credential / base-URL env vars, with API
+        keys defaulting to ``SAFE_API_KEY`` when their own var is unset.
+    """
     safe_key = os.environ.get("SAFE_API_KEY", "").strip()
     out: dict[str, str] = {}
     for name in (
@@ -363,6 +406,29 @@ def _short_poll(
     post-create 404 lag). Terminal failure raises
     :class:`WorkloadTerminalFailure` (exit 2); timeout raises
     :class:`TransientFailure` (exit 1, safe to rerun).
+
+    Args:
+        label (str): Human-readable label used in log lines.
+        fetch (callable): Returns ``(state_obj, summary_str)`` each poll.
+        is_ok (callable): Predicate marking a successful terminal state.
+        is_fail (callable): Predicate marking a terminal failure state.
+        interval_s (int): Seconds to sleep between polls.
+        timeout_s (int): Total poll budget before giving up.
+        failure_diag (callable | None): Optional ``state_obj -> (diag,
+            snapshot)`` used to enrich a terminal failure. Defaults to ``None``.
+        quiet_fetch_error_grace_s (float): Window during which a quiet fetch
+            error is logged at INFO rather than WARN. Defaults to ``0.0``.
+        is_quiet_fetch_error (Callable[[BaseException], bool] | None): Predicate
+            classifying a fetch exception as quiet. Defaults to ``None``.
+
+    Returns:
+        Any: The ``state_obj`` once ``is_ok`` is satisfied.
+
+    Raises:
+        WorkloadTerminalFailure: When ``is_fail`` matches and a
+            ``failure_diag`` is supplied.
+        RuntimeError: When ``is_fail`` matches without a ``failure_diag``.
+        TransientFailure: When the poll budget elapses before a terminal state.
     """
     started = time.monotonic()
     attempt = 0
@@ -416,7 +482,15 @@ def _short_poll(
 
 
 def _summarize_workload_failure(workload: dict[str, Any]) -> tuple[str, dict[str, Any]]:
-    """Build a one-line diagnostic + JSON-safe snapshot (phase/message/per-pod status/dispatch) from a SaFE GetWorkloadResponse."""
+    """Build a one-line diagnostic + JSON-safe snapshot (phase/message/per-pod status/dispatch) from a SaFE GetWorkloadResponse.
+
+    Args:
+        workload (dict[str, Any]): A SaFE ``GetWorkloadResponse`` dict.
+
+    Returns:
+        tuple[str, dict[str, Any]]: ``(diag, snapshot)`` — a one-line human
+        diagnostic and a JSON-safe structured failure snapshot.
+    """
     phase = str(workload.get("phase") or "?")
     msg = str(workload.get("message") or "").strip()
     queue = workload.get("queuePosition")
@@ -473,6 +547,12 @@ def _find_head_pod_ip(workload: dict) -> str:
 
     Priority: a ``podId`` containing ``-head-``, then ``resourceId == 0``,
     then the first pod with a ``podIP`` (the submitter pod isn't the head).
+
+    Args:
+        workload (dict): A SaFE ``GetWorkloadResponse`` dict.
+
+    Returns:
+        str: The resolved head pod IP, or ``""`` when no pod carries one.
     """
     pods = workload.get("pods") or []
     if not pods:
@@ -692,6 +772,15 @@ def cmd_create_dynamo(args: argparse.Namespace) -> int:
     workload body), creates/reuses the workload, waits for Running, then
     discovers the worker pod IPs and the frontend service URL into the state
     file so restart-server can SSH-fan-out the inference server.
+
+    Args:
+        args (argparse.Namespace): Parsed ``create-dynamo`` arguments.
+
+    Returns:
+        int: ``0`` on success.
+
+    Raises:
+        RuntimeError: If no workspace can be resolved.
     """
     extra_env = _parse_kv_list(args.extra_env)
     extra_labels = _parse_kv_list(args.extra_label)
@@ -789,6 +878,11 @@ def cmd_create_dynamo(args: argparse.Namespace) -> int:
             info("--no-wait set; not polling for Running")
         else:
             def _fetch():
+                """Fetch the workload and summarize its phase.
+
+                Returns:
+                    tuple: ``(workload_dict, summary_str)`` for the poll loop.
+                """
                 wl = safe.get_workload(wid)
                 return wl, f"phase={wl.get('phase', '?')}"
 
@@ -866,7 +960,15 @@ def cmd_create_dynamo(args: argparse.Namespace) -> int:
 
 
 def _dynamo_require_state() -> dict[str, Any]:
-    """Load dynamo state; require an ssh key + at least one GPU pod IP."""
+    """Load dynamo state; require an ssh key + at least one GPU pod IP.
+
+    Returns:
+        dict[str, Any]: The loaded dynamo state.
+
+    Raises:
+        RuntimeError: If the state backend is not ``dynamo``, no GPU pod IPs
+            are recorded, or the ssh key path is missing.
+    """
     state = _load_state()
     if state.get("backend") != "dynamo":
         raise RuntimeError("state backend is not 'dynamo'; run create-dynamo first")
@@ -895,7 +997,13 @@ _FORWARD_ENV_PREFIXES = ("MORI_", "SGLANG_MORI_", "SGLANG_DISAGGREGATION_")
 
 
 def _collect_forward_env() -> dict[str, str]:
-    """Read prompt-provided tuning vars from os.environ for SSH forwarding."""
+    """Read prompt-provided tuning vars from os.environ for SSH forwarding.
+
+    Returns:
+        dict[str, str]: Prefix-matched tuning vars, the translated torch
+        profiler dir, and any explicit per-variant overrides (which win on
+        key collisions).
+    """
     fwd = {
         k: v
         for k, v in os.environ.items()
@@ -941,6 +1049,18 @@ def _dynamo_fanout_launch(
     Returns ``(rc, per_pod_results)``. rc != 0 if any pod's launcher exits
     non-zero. The SAME launch_args go to every pod in the group — each
     self-determines its node-rank from $LWS_WORKER_INDEX pod-side.
+
+    Args:
+        state (dict[str, Any]): The dynamo state (ssh key / port).
+        launch_args (str): The launcher argv string sent to every pod.
+        worker_ips (list[str]): The pod IPs to SSH into.
+        label (str): Human-readable label used in log lines.
+        poll_timeout (int): Per-pod SSH timeout in seconds.
+        print_logs (bool): When ``True``, print each pod's stdout / stderr.
+
+    Returns:
+        tuple[int, list[dict]]: ``(rc, per_pod_results)`` where ``rc`` is
+        non-zero if any pod's launcher failed.
     """
     script = _read_pod_script("launch_dynamo_node.py")
     key_path = state["ssh_key_path"]
@@ -982,6 +1102,16 @@ def _dynamo_restart_server(args: argparse.Namespace) -> int:
     pod's own $LWS_WORKER_INDEX). The launcher detaches immediately, so this
     returns once every rank has SPAWNED — readiness (MoE cold start) is polled
     sandbox-side against the frontend service_url, never blocked here.
+
+    Args:
+        args (argparse.Namespace): Parsed ``restart-server`` arguments.
+
+    Returns:
+        int: ``0`` when every launcher spawned, ``1`` when at least one failed.
+
+    Raises:
+        RuntimeError: For an unsupported framework, or when PD disaggregation
+            is requested on a non-sglang framework.
     """
     state = _dynamo_require_state()
     framework = (args.framework or state.get("framework") or "sglang").lower()
@@ -1100,7 +1230,15 @@ def _dynamo_restart_server(args: argparse.Namespace) -> int:
 
 
 def _dynamo_all_gpu_ips(state: dict[str, Any]) -> list[str]:
-    """Every GPU pod IP to act on: PD => prefill+decode, else worker."""
+    """Every GPU pod IP to act on: PD => prefill+decode, else worker.
+
+    Args:
+        state (dict[str, Any]): The dynamo state.
+
+    Returns:
+        list[str]: The GPU pod IPs (prefill + decode when disaggregated, else
+        worker).
+    """
     pd = (state.get("pd_mode") or "aggregated").lower()
     if pd == "disaggregated":
         return list(state.get("prefill_pod_ips") or []) + list(state.get("decode_pod_ips") or [])
@@ -1108,7 +1246,14 @@ def _dynamo_all_gpu_ips(state: dict[str, Any]) -> list[str]:
 
 
 def _dynamo_kill_inference(args: argparse.Namespace) -> int:
-    """Dynamo kill: SSH fan-out launch_dynamo_node.py --kill-only to every GPU pod."""
+    """Dynamo kill: SSH fan-out launch_dynamo_node.py --kill-only to every GPU pod.
+
+    Args:
+        args (argparse.Namespace): Parsed ``kill-inference`` arguments.
+
+    Returns:
+        int: ``0`` when every pod's kill succeeded, ``1`` otherwise.
+    """
     state = _dynamo_require_state()
     framework = (
         state.get("last_restart_framework") or state.get("framework") or "sglang"
@@ -1140,6 +1285,16 @@ def _dynamo_ssh_node_op(
 
     Returns ``(parsed_json_or_None, transport)`` where transport carries the
     ssh rc / stderr for diagnostics.
+
+    Args:
+        state (dict[str, Any]): The dynamo state (ssh key / port).
+        ip (str): The pod IP to SSH into.
+        op_args (str): The ``kernel_node_ops.py`` subcommand argv string.
+        timeout (int): SSH timeout in seconds.
+
+    Returns:
+        tuple[dict | None, dict]: ``(parsed_json_or_None, transport)`` where
+        ``transport`` carries the ssh rc / stderr.
     """
     script = _read_pod_script("kernel_node_ops.py")
     key = state["ssh_key_path"]
@@ -1166,6 +1321,13 @@ def _dynamo_apply_tracelens_patch(args: argparse.Namespace) -> int:
     by TraceLens identically — only the dispatch differs. Idempotent: the
     in-pod script sentinel-greps and returns status=skipped on already-patched
     pods, so it is safe to call on every restart_server_for_round.
+
+    Args:
+        args (argparse.Namespace): Parsed ``apply-tracelens-patch`` arguments.
+
+    Returns:
+        int: ``0`` when every pod applied / skipped, ``1`` on any failure, or
+        ``EXIT_CONFIG_ERROR`` when the tracelens root / GPU pods are missing.
     """
     state = _dynamo_require_state()
     tracelens_root = (
@@ -1238,6 +1400,13 @@ def _dynamo_apply_patch(args: argparse.Namespace) -> int:
     Emits the SAME JSON shape as kernel_patch_multinode.py (command/status/
     per_node/failures), with ``per_node[].host`` keyed by the pod IP so the
     sandbox builds an IP->backup_path revert map.
+
+    Args:
+        args (argparse.Namespace): Parsed ``apply-patch`` arguments.
+
+    Returns:
+        int: ``0`` when every pod applied the patch, ``1`` on any failure, or
+        ``EXIT_CONFIG_ERROR`` when the patch file is missing.
     """
     state = _dynamo_require_state()
     patch_path = Path(args.patch_file)
@@ -1273,7 +1442,15 @@ def _dynamo_apply_patch(args: argparse.Namespace) -> int:
 
 
 def _dynamo_revert_patch(args: argparse.Namespace) -> int:
-    """Dynamo revert-patch: SSH each pod in the IP->backup_path map + restore."""
+    """Dynamo revert-patch: SSH each pod in the IP->backup_path map + restore.
+
+    Args:
+        args (argparse.Namespace): Parsed ``revert-patch`` arguments.
+
+    Returns:
+        int: ``0`` when every pod reverted, ``1`` on any failure, or
+        ``EXIT_CONFIG_ERROR`` when the backup map is missing / invalid.
+    """
     state = _dynamo_require_state()
     try:
         backup_map = json.loads(args.backup_map_json or "{}")
@@ -1306,7 +1483,16 @@ def _dynamo_revert_patch(args: argparse.Namespace) -> int:
 
 
 def _dynamo_kernel_bench(args: argparse.Namespace) -> int:
-    """Dynamo kernel-bench: run the micro-benchmark on ONE GPU pod over SSH."""
+    """Dynamo kernel-bench: run the micro-benchmark on ONE GPU pod over SSH.
+
+    Args:
+        args (argparse.Namespace): Parsed ``kernel-bench`` arguments.
+
+    Returns:
+        int: ``0`` when the bench succeeded, ``1`` when it failed, or
+        ``EXIT_CONFIG_ERROR`` / ``EXIT_TRANSIENT`` on missing GPU pods / no
+        pod JSON.
+    """
     state = _dynamo_require_state()
     gpu_ips = _dynamo_all_gpu_ips(state)
     if not gpu_ips:
@@ -1347,6 +1533,12 @@ def _resolve_geak_src(explicit: str | None) -> str:
     Resolution: --geak-src > $HYPERLOOM_GEAK_SRC > $HYPERLOOM_ROOT/geak >
     $USER_DATA_PATH/runtime/geak. Must be a path both sandbox and pod see
     (under $USER_DATA_PATH).
+
+    Args:
+        explicit (str | None): The ``--geak-src`` flag value, or ``None``.
+
+    Returns:
+        str: The resolved GEAK source dir, or ``""`` when no source resolves.
     """
     if explicit and explicit.strip():
         return explicit.strip()
@@ -1368,6 +1560,13 @@ def cmd_install_geak(args: argparse.Namespace) -> int:
     pip-installs the shared-FS GEAK checkout into each pod's framework venv so
     the kernel-agent SSH placement (run_geak_over_ssh) finds ``geak`` on PATH.
     Dynamo-only (kernel-agent on RayJob uses the Ray runtime, not this).
+
+    Args:
+        args (argparse.Namespace): Parsed ``install-geak`` arguments.
+
+    Returns:
+        int: ``0`` when every pod installed / skipped, non-zero on any failure
+        (or ``EXIT_CONFIG_ERROR`` when the GEAK source can't be resolved).
     """
     state = _dynamo_require_state()
     geak_src = _resolve_geak_src(getattr(args, "geak_src", None))
@@ -1415,6 +1614,13 @@ def cmd_install_oob(args: argparse.Namespace) -> int:
     OOB python CLI installs from the shared-NFS ``$OOB_SRC`` checkout; the npm
     CLIs (claude/codex/@cursor-sdk) install per pod. Credentials are forwarded
     over SSH stdin (never argv). Dynamo-only.
+
+    Args:
+        args (argparse.Namespace): Parsed ``install-oob`` arguments.
+
+    Returns:
+        int: ``0`` when every pod installed / skipped, non-zero on any failure
+        (or ``EXIT_CONFIG_ERROR`` when the OOB source is missing).
     """
     state = _dynamo_require_state()
     oob_src = (getattr(args, "oob_src", None) or os.environ.get("OOB_SRC", "")).strip()
@@ -1470,6 +1676,10 @@ def install_geak_on_pods_best_effort() -> int:
     No-op (returns 0) for non-dynamo state. Failures are logged but do not
     abort provisioning — the kernel phase will surface a clear pod-side
     ``geak CLI not found`` error if install genuinely failed.
+
+    Returns:
+        int: The install return code, or ``0`` for non-dynamo state / on a
+        swallowed error.
     """
     if _load_state().get("backend") != "dynamo":
         return 0
@@ -1489,6 +1699,10 @@ def install_oob_on_pods_best_effort() -> int:
     """Best-effort OOB install on the Dynamo GPU pods (provisioner hook).
 
     No-op (0) for non-dynamo. Failures are logged but never abort provisioning.
+
+    Returns:
+        int: The install return code, or ``0`` for non-dynamo state / on a
+        swallowed error.
     """
     if _load_state().get("backend") != "dynamo":
         return 0
@@ -1509,6 +1723,10 @@ def install_kernel_tools_on_pods_best_effort() -> int:
 
     No-op for non-dynamo. Returns non-zero only if a sub-install reported a
     hard failure (best-effort; provisioning continues regardless).
+
+    Returns:
+        int: Non-zero if either sub-install reported a hard failure, else
+        ``0``.
     """
     rc_geak = install_geak_on_pods_best_effort()
     rc_oob = install_oob_on_pods_best_effort()
@@ -1522,6 +1740,12 @@ def cmd_bootstrap(args: argparse.Namespace) -> int:
 
     Streams the sandbox-side ``scripts/bootstrap.sh`` into the head pod via a
     heredoc entrypoint (``--script PATH`` overrides with a pod-visible script).
+
+    Args:
+        args (argparse.Namespace): Parsed ``bootstrap`` arguments.
+
+    Returns:
+        int: ``0`` on success.
     """
     state = _require_state("rayjob_id", "head_pod_ip")
     head_ip = state["head_pod_ip"]
@@ -1636,7 +1860,17 @@ _SCRIPTS_DIR = Path(__file__).parent / "scripts"
 
 
 def _read_pod_script(name: str) -> str:
-    """Read a pod-side script from ``multi_node/scripts/`` (embedded into the dashboard entrypoint at submit time)."""
+    """Read a pod-side script from ``multi_node/scripts/`` (embedded into the dashboard entrypoint at submit time).
+
+    Args:
+        name (str): The script filename under ``multi_node/scripts/``.
+
+    Returns:
+        str: The script's text contents.
+
+    Raises:
+        RuntimeError: If the named script is missing.
+    """
     p = _SCRIPTS_DIR / name
     if not p.is_file():
         raise RuntimeError(
@@ -1651,7 +1885,19 @@ def _build_restart_entrypoint(
     pid_file: str,
     log_file: str,
 ) -> str:
-    """Compose the single-node restart entrypoint (heredoc kill_server.sh + launch_server.sh; IR-5 PID-file kill)."""
+    """Compose the single-node restart entrypoint (heredoc kill_server.sh + launch_server.sh; IR-5 PID-file kill).
+
+    Args:
+        args (argparse.Namespace): Parsed ``restart-server`` arguments.
+        pid_file (str): PID-file path the kill / launch scripts use.
+        log_file (str): Server log path on the head pod.
+
+    Returns:
+        str: The composed Ray Dashboard entrypoint shell command.
+
+    Raises:
+        RuntimeError: For an unsupported framework.
+    """
     framework = args.framework.lower()
     if framework not in ("sglang", "vllm"):
         raise RuntimeError(f"unsupported framework: {args.framework!r} (use sglang or vllm)")
@@ -1756,7 +2002,15 @@ def _exec_kill_submission(
 
 
 def _build_multinode_kill_entrypoint(pid_dir: str, grace_sec: int = 5) -> str:
-    """Compose the head-pod entrypoint that kills every rank's server via heredoc-embedded kill_multinode.py (fans out via ray actors)."""
+    """Compose the head-pod entrypoint that kills every rank's server via heredoc-embedded kill_multinode.py (fans out via ray actors).
+
+    Args:
+        pid_dir (str): Directory of per-rank PID files.
+        grace_sec (int): Grace period before a hard kill. Defaults to ``5``.
+
+    Returns:
+        str: The composed Ray Dashboard entrypoint shell command.
+    """
     py = _read_pod_script("kill_multinode.py")
     return (
         f"{_MN_ENTRYPOINT_PREAMBLE}"
@@ -1768,7 +2022,14 @@ def _build_multinode_kill_entrypoint(pid_dir: str, grace_sec: int = 5) -> str:
 
 
 def _extract_launcher_summary(launch_logs: str) -> dict:
-    """Parse the JSON summary launch_multinode.py writes to stdout (the last balanced ``{...}`` in the interleaved logs); ``{}`` on failure."""
+    """Parse the JSON summary launch_multinode.py writes to stdout (the last balanced ``{...}`` in the interleaved logs); ``{}`` on failure.
+
+    Args:
+        launch_logs (str): The interleaved launcher stdout / logs.
+
+    Returns:
+        dict: The parsed summary object, or ``{}`` when none can be parsed.
+    """
     if not launch_logs:
         return {}
     text = launch_logs.rstrip()
@@ -1805,6 +2066,15 @@ def _build_multinode_launch_entrypoint(
 
     Killed ranks MUST be cleared before this runs (sequenced by
     cmd_restart_server) or rank 0's old process still holds :8888.
+
+    Args:
+        args (argparse.Namespace): Parsed ``restart-server`` arguments.
+        nnodes (int): Number of nodes (ranks) to launch.
+        pid_dir (str): Directory for per-rank PID files.
+        log_dir (str): Directory for per-rank logs.
+
+    Returns:
+        str: The composed Ray Dashboard entrypoint shell command.
     """
     py = _read_pod_script("launch_multinode.py")
     wait_flag = "--no-wait-health" if args.no_wait_health else ""
@@ -1880,7 +2150,18 @@ def _build_multinode_router_entrypoint(
     pid_dir: str,
     log_dir: str,
 ) -> str:
-    """Compose the head-pod entrypoint that detaches the PD router (rank 0 only, binds 8888) via heredoc-embedded launch_router.py."""
+    """Compose the head-pod entrypoint that detaches the PD router (rank 0 only, binds 8888) via heredoc-embedded launch_router.py.
+
+    Args:
+        args (argparse.Namespace): Parsed ``restart-server`` arguments.
+        prefill_url (str): The prefill group's server URL.
+        decode_url (str): The decode group's server URL.
+        pid_dir (str): Directory for the router PID file.
+        log_dir (str): Directory for the router log.
+
+    Returns:
+        str: The composed Ray Dashboard entrypoint shell command.
+    """
     py = _read_pod_script("launch_router.py")
     public_port = 8888
     pid_file = f"{pid_dir.rstrip('/')}/router.pid"
@@ -1909,7 +2190,18 @@ def _build_multinode_apply_patch_entrypoint(
     kernel_id: str,
     timeout_sec: int,
 ) -> str:
-    """Compose the head-pod entrypoint that fans out a kernel patch to every pod via heredoc-embedded kernel_patch_multinode.py."""
+    """Compose the head-pod entrypoint that fans out a kernel patch to every pod via heredoc-embedded kernel_patch_multinode.py.
+
+    Args:
+        target_path (str): The pod-side file path to patch.
+        patch_b64 (str): Base64-encoded unified diff to apply.
+        backup_dir (str): Directory where pre-patch backups are written.
+        kernel_id (str): Identifier tying the patch to a kernel.
+        timeout_sec (int): Per-pod apply timeout in seconds.
+
+    Returns:
+        str: The composed Ray Dashboard entrypoint shell command.
+    """
     py = _read_pod_script("kernel_patch_multinode.py")
     return (
         f"{_MN_ENTRYPOINT_PREAMBLE}"
@@ -1930,7 +2222,17 @@ def _build_multinode_revert_patch_entrypoint(
     backup_map_json: str,
     timeout_sec: int,
 ) -> str:
-    """Compose the head-pod entrypoint that fans out a revert via heredoc-embedded kernel_patch_multinode.py (``backup_map_json`` from the matching apply)."""
+    """Compose the head-pod entrypoint that fans out a revert via heredoc-embedded kernel_patch_multinode.py (``backup_map_json`` from the matching apply).
+
+    Args:
+        target_path (str): The pod-side file path to revert.
+        backup_map_json (str): JSON map of per-pod backups from the matching
+            apply.
+        timeout_sec (int): Per-pod revert timeout in seconds.
+
+    Returns:
+        str: The composed Ray Dashboard entrypoint shell command.
+    """
     py = _read_pod_script("kernel_patch_multinode.py")
     return (
         f"{_MN_ENTRYPOINT_PREAMBLE}"
@@ -1952,6 +2254,15 @@ def _build_multinode_apply_tracelens_patch_entrypoint(
 
     Forwards only ``$TRACELENS_ROOT`` (patches are read on the pods'
     wekafs mount); the in-pod script is idempotent.
+
+    Args:
+        tracelens_root (str): Pod-visible TraceLens root forwarded as
+            ``--tracelens-root``.
+        sglang_version_pin (str): Optional SGLang version pin; omitted from the
+            command when empty.
+
+    Returns:
+        str: The composed Ray Dashboard entrypoint shell command.
     """
     py = _read_pod_script("apply_tracelens_patch_multinode.py")
     pin_arg = ""
@@ -1975,7 +2286,18 @@ def _build_multinode_kernel_bench_entrypoint(
     result_glob: str,
     timeout_sec: int,
 ) -> str:
-    """Compose the head-pod entrypoint running a kernel micro-benchmark on a single GPU node via heredoc-embedded kernel_bench_multinode.py."""
+    """Compose the head-pod entrypoint running a kernel micro-benchmark on a single GPU node via heredoc-embedded kernel_bench_multinode.py.
+
+    Args:
+        workspace (str): Pod-side workspace dir for the benchmark.
+        bench_command (str): The benchmark command to run.
+        files_b64_json (str): JSON map of base64-encoded files to materialize.
+        result_glob (str): Glob matching the result files to collect.
+        timeout_sec (int): Benchmark timeout in seconds.
+
+    Returns:
+        str: The composed Ray Dashboard entrypoint shell command.
+    """
     py = _read_pod_script("kernel_bench_multinode.py")
     return (
         f"{_MN_ENTRYPOINT_PREAMBLE}"
@@ -1992,7 +2314,15 @@ def _build_multinode_kernel_bench_entrypoint(
 
 
 def _extract_pod_json(logs: str) -> dict | None:
-    """Parse the last top-level JSON document from an interleaved Ray Dashboard job_logs blob (the in-pod scripts emit one)."""
+    """Parse the last top-level JSON document from an interleaved Ray Dashboard job_logs blob (the in-pod scripts emit one).
+
+    Args:
+        logs (str): The interleaved Ray Dashboard ``job_logs`` text.
+
+    Returns:
+        dict | None: The parsed JSON object, or ``None`` when none can be
+        parsed.
+    """
     if not logs:
         return None
     text = logs.rstrip()
@@ -2036,7 +2366,19 @@ def _submit_and_collect_pod_json(
     poll_interval: int,
     poll_timeout: int,
 ) -> tuple[int, dict | None, str]:
-    """Submit ``entrypoint``, poll to terminal, parse the per-pod JSON, and return ``(returncode, parsed_or_None, logs)``."""
+    """Submit ``entrypoint``, poll to terminal, parse the per-pod JSON, and return ``(returncode, parsed_or_None, logs)``.
+
+    Args:
+        head_ip (str): IP of the Ray head pod's dashboard.
+        entrypoint (str): The entrypoint shell command to submit.
+        label (str): Human-readable label used in log lines and polling.
+        poll_interval (int): Seconds between status polls.
+        poll_timeout (int): Overall poll budget in seconds.
+
+    Returns:
+        tuple[int, dict | None, str]: The job return code, the parsed per-pod
+        JSON (or ``None``), and the raw logs.
+    """
     with ray_dashboard.RayDashboardClient(head_ip) as ray:
         sub_id = ray.submit_job(_wrap_for_dash(entrypoint))
         info(f"{label} submission_id={sub_id}")
@@ -2087,6 +2429,16 @@ def cmd_apply_patch(args: argparse.Namespace) -> int:
     Stdout: the same JSON document kernel_patch_multinode.py emits,
     re-printed verbatim so sandbox-side callers (apply_kernel_patch.py
     multi-node dispatch) can parse it deterministically.
+
+    Args:
+        args (argparse.Namespace): Parsed ``apply-patch`` arguments
+            (``patch_file``, ``target_path``, ``kernel_id``, ``backup_dir``,
+            ``timeout_sec``, poll knobs).
+
+    Returns:
+        int: ``EXIT_OK`` on a successful fan-out, ``EXIT_CONFIG_ERROR`` for
+        missing state / unreadable patch, ``EXIT_TRANSIENT`` when the JSON
+        can't be parsed or the fan-out failed.
     """
     if _load_state().get("backend") == "dynamo":
         return _dynamo_apply_patch(args)
@@ -2134,6 +2486,15 @@ def cmd_revert_patch(args: argparse.Namespace) -> int:
     received it. ``--backup-map-json`` is the per-host map returned by
     the matching ``apply-patch`` call; callers MUST pass it through
     unchanged so the right backups are read on each pod.
+
+    Args:
+        args (argparse.Namespace): Parsed ``revert-patch`` arguments
+            (``target_path``, ``backup_map_json``, ``timeout_sec``, poll
+            knobs).
+
+    Returns:
+        int: ``EXIT_OK`` on success, ``EXIT_CONFIG_ERROR`` for missing state /
+        invalid backup map, ``EXIT_TRANSIENT`` when the JSON can't be parsed.
     """
     if _load_state().get("backend") == "dynamo":
         return _dynamo_revert_patch(args)
@@ -2179,6 +2540,15 @@ def cmd_apply_tracelens_patch(args: argparse.Namespace) -> int:
     Needed because the sandbox can't ``import sglang`` to run the local
     patcher. Idempotent (already-patched pods return ``status=skipped``).
     Re-prints the script's JSON (``status`` + ``per_pod``) verbatim.
+
+    Args:
+        args (argparse.Namespace): Parsed ``apply-tracelens-patch`` arguments
+            (``tracelens_root``, ``sglang_version_pin``, poll knobs).
+
+    Returns:
+        int: ``EXIT_OK`` when the patch was applied or skipped,
+        ``EXIT_CONFIG_ERROR`` for missing state / TraceLens root,
+        ``EXIT_TRANSIENT`` otherwise.
     """
     if _load_state().get("backend") == "dynamo":
         return _dynamo_apply_tracelens_patch(args)
@@ -2239,6 +2609,16 @@ def cmd_kernel_bench(args: argparse.Namespace) -> int:
     The sandbox calls this when ``is_multi_node()`` is True and the
     kernel-agent micro-benchmark step would otherwise try to compile +
     run on the sandbox (which lacks GPUs in multi-node mode).
+
+    Args:
+        args (argparse.Namespace): Parsed ``kernel-bench`` arguments
+            (``workspace``, ``bench_command``, ``files_b64_json``,
+            ``result_glob``, ``timeout_sec``, poll knobs).
+
+    Returns:
+        int: ``EXIT_OK`` on a successful benchmark, ``EXIT_CONFIG_ERROR`` for
+        missing state / invalid files JSON, ``EXIT_TRANSIENT`` when the JSON
+        can't be parsed.
     """
     if _load_state().get("backend") == "dynamo":
         return _dynamo_kernel_bench(args)
@@ -2296,6 +2676,15 @@ def cmd_restart_server(args: argparse.Namespace) -> int:
     Dynamo backend (state.backend == 'dynamo') routes to the SSH fan-out path
     instead of the Ray Dashboard; the RayJob path below is byte-for-byte
     unchanged for non-dynamo state.
+
+    Args:
+        args (argparse.Namespace): Parsed ``restart-server`` arguments
+            (``framework``, ``model``, ``tp``, ``ep``, PD knobs, ``pid_file``,
+            ``log_file``, poll knobs).
+
+    Returns:
+        int: ``EXIT_OK`` once the server is healthy, ``EXIT_CONFIG_ERROR`` for
+        missing state, or a transient exit code on launch / poll failure.
     """
     if _load_state().get("backend") == "dynamo":
         return _dynamo_restart_server(args)
@@ -3048,7 +3437,16 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
-    """CLI entrypoint with stable exit codes: 0 ok, 1 transient (retryable), 2 terminal workload failure (do not retry), 3 config error, 130 SIGINT."""
+    """CLI entrypoint with stable exit codes: 0 ok, 1 transient (retryable), 2 terminal workload failure (do not retry), 3 config error, 130 SIGINT.
+
+    Args:
+        argv (list[str] | None): Argument vector to parse; ``None`` uses
+            ``sys.argv``.
+
+    Returns:
+        int: The process exit code mapped from the subcommand result or the
+        caught exception type.
+    """
     parser = build_parser()
     args = parser.parse_args(argv)
     try:

--- a/inference_optimizer/multi_node/scripts/apply_tracelens_patch_multinode.py
+++ b/inference_optimizer/multi_node/scripts/apply_tracelens_patch_multinode.py
@@ -56,14 +56,26 @@ _GIT_TIMEOUT_SEC = 30
 
 
 def _log(msg: str) -> None:
-    """Stderr-only timestamped log line (stdout is reserved for the final JSON)."""
+    """Stderr-only timestamped log line (stdout is reserved for the final JSON).
+
+    Args:
+        msg: The message text to emit.
+    """
     ts = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime())
     sys.stderr.write(f"[tracelens_patch_multinode {ts}] {msg}\n")
     sys.stderr.flush()
 
 
 def _versioned_patches_subdir_name(version: str) -> str | None:
-    """``0.5.11`` -> ``sglang_0_5_11`` (tolerates ``-rc1`` / ``+local`` suffixes)."""
+    """``0.5.11`` -> ``sglang_0_5_11`` (tolerates ``-rc1`` / ``+local`` suffixes).
+
+    Args:
+        version: The sglang version string to convert.
+
+    Returns:
+        str | None: The versioned subdir name, or ``None`` if ``version`` is
+        empty or not a dotted numeric form.
+    """
     text = (version or "").strip()
     if not text:
         return None
@@ -75,7 +87,16 @@ def _versioned_patches_subdir_name(version: str) -> str | None:
 
 
 def _resolve_sglang_install(sglang_module_path: Path) -> tuple[Path, int] | None:
-    """Decide ``(apply_root, -p<N> strip)`` from any sglang anchor (wheel/editable/namespace-dir layouts); ``None`` if unrecognised."""
+    """Decide ``(apply_root, -p<N> strip)`` from any sglang anchor (wheel/editable/namespace-dir layouts); ``None`` if unrecognised.
+
+    Args:
+        sglang_module_path: A path anchored in the sglang install (module
+            file, submodule file, or namespace dir).
+
+    Returns:
+        tuple[Path, int] | None: The ``(apply_root, strip_level)`` pair, or
+        ``None`` if the layout is not recognised.
+    """
     resolved = sglang_module_path.resolve()
     # Pass 1: walk up to the ``sglang/`` package dir (the one with a ``srt/`` subdir).
     pkg_dir: Path | None = None
@@ -123,7 +144,15 @@ def _all_markers_present(path: Path, markers: tuple[str, ...]) -> bool:
 
 
 def _run_git(args: tuple[str, ...], cwd: Path) -> tuple[int, str, str]:
-    """Run ``git <args>``; return ``(rc, stdout, stderr)`` (never raises on non-zero exit)."""
+    """Run ``git <args>``; return ``(rc, stdout, stderr)`` (never raises on non-zero exit).
+
+    Args:
+        args: The git subcommand and arguments (without the leading ``git``).
+        cwd: Working directory to run git in.
+
+    Returns:
+        tuple[int, str, str]: The ``(returncode, stdout, stderr)`` triple.
+    """
     proc = subprocess.run(  # noqa: S603
         ["git", *args],
         cwd=str(cwd),
@@ -141,7 +170,19 @@ def _apply_on_pod(
     tracelens_internal_root: str,
     sglang_version_pin: str | None,
 ) -> dict[str, Any]:
-    """Apply (or verify) the TraceLens SGLang patch set on this pod; never raises (failures become ``status=failed``)."""
+    """Apply (or verify) the TraceLens SGLang patch set on this pod; never raises (failures become ``status=failed``).
+
+    Args:
+        tracelens_root: Path to the public TraceLens checkout on the pod.
+        tracelens_internal_root: Path to the TraceLens-internal checkout
+            (reserved; not consumed by current patch logic).
+        sglang_version_pin: Optional advisory version pin, logged on mismatch.
+
+    Returns:
+        dict[str, Any]: The per-pod summary with ``status`` (``applied``,
+        ``skipped``, or ``failed``), resolved version, applied patches, and
+        elapsed time.
+    """
     host = socket.gethostname()
     started = time.time()
     result: dict[str, Any] = {

--- a/inference_optimizer/multi_node/scripts/kernel_bench_multinode.py
+++ b/inference_optimizer/multi_node/scripts/kernel_bench_multinode.py
@@ -63,7 +63,18 @@ def _tail_bytes(s: str | None, limit: int) -> str:
 
 
 def _stage_files(workspace: Path, files_b64: dict[str, str]) -> list[str]:
-    """Decode each ``{relative_path: base64_content}`` into the workspace (rejecting ``/`` or ``..`` paths)."""
+    """Decode each ``{relative_path: base64_content}`` into the workspace (rejecting ``/`` or ``..`` paths).
+
+    Args:
+        workspace: Directory the files are decoded into.
+        files_b64: Mapping of relative path to base64-encoded content.
+
+    Returns:
+        list[str]: The absolute paths of the files written.
+
+    Raises:
+        ValueError: If a staging path is absolute or contains ``..``.
+    """
     staged: list[str] = []
     for rel, b64 in (files_b64 or {}).items():
         if rel.startswith("/") or ".." in Path(rel).parts:
@@ -84,7 +95,22 @@ def _bench_remote(
     result_glob: str,
     timeout_sec: int,
 ) -> dict:
-    """Run a kernel micro-benchmark on this (head) pod; the caller already pinned us to a GPU node."""
+    """Run a kernel micro-benchmark on this (head) pod; the caller already pinned us to a GPU node.
+
+    Args:
+        workspace: Absolute directory used as CWD for the bench command.
+        bench_command: Shell command run via ``bash -lc``.
+        files_b64_json: JSON ``{rel_path: base64_content}`` of files to stage.
+        result_glob: Glob (relative to workspace) of artifacts to read back.
+        timeout_sec: Hard timeout for the bench command.
+
+    Returns:
+        dict: Per-host result with return code, elapsed time, stdout/stderr
+        tails, staged files, and read-back artifacts.
+
+    Raises:
+        ValueError: If ``files_b64_json`` is not valid JSON.
+    """
     host = socket.gethostname()
     ws = Path(workspace)
     ws.mkdir(parents=True, exist_ok=True)
@@ -154,7 +180,14 @@ def _bench_remote(
 
 
 def _pick_gpu_node() -> str:
-    """Return the head-pod node id (GPU-bearing, co-located with the caller); fall back to any alive GPU node."""
+    """Return the head-pod node id (GPU-bearing, co-located with the caller); fall back to any alive GPU node.
+
+    Returns:
+        str: The Ray ``NodeID`` to pin the bench actor to.
+
+    Raises:
+        RuntimeError: If there are no alive nodes, or none with a GPU.
+    """
     nodes = [n for n in ray.nodes() if n.get("Alive")]
     if not nodes:
         raise RuntimeError("no alive Ray nodes for kernel bench")

--- a/inference_optimizer/multi_node/scripts/kernel_node_ops.py
+++ b/inference_optimizer/multi_node/scripts/kernel_node_ops.py
@@ -40,11 +40,30 @@ _STREAM_TAIL_BYTES = 32 * 1024
 
 
 def _safe_name(value: str) -> str:
+    """Sanitize a string into a filesystem-safe filename token.
+
+    Args:
+        value (str): the raw string to sanitize.
+
+    Returns:
+        str: the sanitized token (alphanumerics and ``._-`` kept, others
+            replaced with ``_``), truncated to 80 chars and defaulting to
+            ``"patch"`` when empty.
+    """
     cleaned = "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in value)
     return cleaned[:80] or "patch"
 
 
 def _atomic_write_bytes(target: Path, data: bytes) -> None:
+    """Atomically write ``data`` to ``target`` via a temp file and ``os.replace``.
+
+    Args:
+        target (Path): the destination file path (parent dirs are created).
+        data (bytes): the bytes to write.
+
+    Raises:
+        Exception: re-raised if writing fails (the temp file is removed first).
+    """
     target.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_str = tempfile.mkstemp(
         prefix=f".{target.name}.", suffix=".tmp", dir=str(target.parent),
@@ -64,6 +83,16 @@ def _atomic_write_bytes(target: Path, data: bytes) -> None:
 
 
 def _emit(payload: dict) -> int:
+    """Print ``payload`` as JSON to stdout and return a process exit code.
+
+    Args:
+        payload (dict): the result document to emit (its ``status`` selects the
+            exit code).
+
+    Returns:
+        int: ``0`` when ``status`` is a success state (``ok`` / ``restored`` /
+            ``noop_missing_backup``), else ``1``.
+    """
     sys.stdout.write(json.dumps(payload, indent=2) + "\n")
     sys.stdout.flush()
     return 0 if str(payload.get("status", "")).lower() in ("ok", "restored",
@@ -71,6 +100,19 @@ def _emit(payload: dict) -> int:
 
 
 def _do_apply(a: argparse.Namespace) -> int:
+    """Back up the target, write the base64 patch, and compile-check .py targets.
+
+    Backs up ``--target-path`` into ``--backup-dir``, atomically writes the
+    decoded ``--patch-b64``, and for ``.py`` targets runs ``py_compile`` with
+    auto-revert on syntax error. Emits a JSON result document on stdout.
+
+    Args:
+        a (argparse.Namespace): parsed ``apply`` arguments (``target_path``,
+            ``patch_b64``, ``backup_dir``, ``kernel_id``).
+
+    Returns:
+        int: the process exit code from emitting the result (``0`` on success).
+    """
     host = socket.gethostname()
     target = Path(a.target_path)
     if not target.is_file():
@@ -105,6 +147,18 @@ def _do_apply(a: argparse.Namespace) -> int:
 
 
 def _do_revert(a: argparse.Namespace) -> int:
+    """Restore the target file from its backup copy.
+
+    Emits a JSON result document on stdout (``noop_missing_backup`` when the
+    backup is absent, ``restored`` on success).
+
+    Args:
+        a (argparse.Namespace): parsed ``revert`` arguments (``target_path``,
+            ``backup_path``).
+
+    Returns:
+        int: the process exit code from emitting the result.
+    """
     host = socket.gethostname()
     target = Path(a.target_path)
     backup = Path(a.backup_path)
@@ -118,6 +172,22 @@ def _do_revert(a: argparse.Namespace) -> int:
 
 
 def _do_bench(a: argparse.Namespace) -> int:
+    """Stage files into the workspace, run the bench command, read back artifacts.
+
+    Decodes ``--files-b64-json`` into ``--workspace`` (rejecting absolute or
+    ``..`` paths), runs ``--bench-command`` under bash with a timeout, then
+    collects ``--result-glob`` artifacts (skipping oversized ones). Emits a JSON
+    result document on stdout.
+
+    Args:
+        a (argparse.Namespace): parsed ``bench`` arguments (``workspace``,
+            ``bench_command``, ``files_b64_json``, ``result_glob``,
+            ``timeout_sec``).
+
+    Returns:
+        int: the process exit code from emitting the result (``0`` when the
+            bench command exited zero).
+    """
     host = socket.gethostname()
     ws = Path(a.workspace)
     ws.mkdir(parents=True, exist_ok=True)
@@ -186,6 +256,12 @@ def _do_bench(a: argparse.Namespace) -> int:
 
 
 def main() -> int:
+    """Parse the subcommand and dispatch to apply / revert / bench.
+
+    Returns:
+        int: the subcommand's exit code, or ``2`` when no known subcommand
+            matched (after printing help to stderr).
+    """
     p = argparse.ArgumentParser(prog="kernel_node_ops.py")
     sub = p.add_subparsers(dest="command", required=True)
 

--- a/inference_optimizer/multi_node/scripts/kernel_patch_multinode.py
+++ b/inference_optimizer/multi_node/scripts/kernel_patch_multinode.py
@@ -30,7 +30,11 @@ from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 
 def _log(msg: str) -> None:
-    """Stderr-only timestamped log line (stdout is reserved for the final JSON)."""
+    """Stderr-only timestamped log line (stdout is reserved for the final JSON).
+
+    Args:
+        msg: The message text to emit.
+    """
     ts = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime())
     sys.stderr.write(f"[kernel_patch_multinode {ts}] {msg}\n")
     sys.stderr.flush()
@@ -84,7 +88,23 @@ def _apply_remote(
     backup_dir: str,
     kernel_id: str,
 ) -> dict:
-    """Apply a single patch on this pod; raises on any error (surfaced via ``ray.get``)."""
+    """Apply a single patch on this pod; raises on any error (surfaced via ``ray.get``).
+
+    Args:
+        target_path: Absolute path of the file to overwrite on the pod.
+        patch_b64: Base64-encoded new file contents.
+        backup_dir: Directory where the pre-patch original is saved.
+        kernel_id: Optional id used to construct the backup filename.
+
+    Returns:
+        dict: Per-host result with the target path, backup path, byte count,
+        and compile status.
+
+    Raises:
+        FileNotFoundError: If ``target_path`` does not exist on the pod.
+        ValueError: If ``patch_b64`` is not valid base64, or if a ``.py``
+            target fails to compile (it is auto-reverted first).
+    """
     host = socket.gethostname()
     target = Path(target_path)
     if not target.is_file():
@@ -127,7 +147,16 @@ def _revert_remote(
     target_path: str,
     backup_path: str,
 ) -> dict:
-    """Restore ``target_path`` from ``backup_path`` on this pod; noop when the backup is missing."""
+    """Restore ``target_path`` from ``backup_path`` on this pod; noop when the backup is missing.
+
+    Args:
+        target_path: Absolute path of the file to restore on the pod.
+        backup_path: Path of the saved pre-patch backup.
+
+    Returns:
+        dict: Per-host result with ``status`` of ``restored`` or
+        ``noop_missing_backup``.
+    """
     host = socket.gethostname()
     target = Path(target_path)
     backup = Path(backup_path)

--- a/inference_optimizer/multi_node/scripts/kill_multinode.py
+++ b/inference_optimizer/multi_node/scripts/kill_multinode.py
@@ -39,6 +39,14 @@ def _kill_remote(pid_dir: str, grace_sec: int) -> dict:
 
     One sweep covers both colocated and PD-disaggregated modes (unused
     patterns are no-ops).
+
+    Args:
+        pid_dir: Directory containing the PID files to sweep.
+        grace_sec: Seconds to wait between SIGTERM and SIGKILL.
+
+    Returns:
+        dict: Summary with ``killed``, ``stale``, and ``missing`` lists keyed
+        by PID-file name.
     """
     summary: dict[str, list] = {"killed": [], "stale": [], "missing": []}
     p = Path(pid_dir)

--- a/inference_optimizer/multi_node/scripts/launch_dynamo_node.py
+++ b/inference_optimizer/multi_node/scripts/launch_dynamo_node.py
@@ -52,6 +52,11 @@ _DEFAULT_DYN_SYSTEM_PORT = 9090
 
 
 def _log(msg: str) -> None:
+    """Write a timestamped launcher log line to stderr.
+
+    Args:
+        msg: The message to log.
+    """
     ts = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime())
     sys.stderr.write(f"[launch_dynamo_node {ts}] {msg}\n")
     sys.stderr.flush()
@@ -84,6 +89,10 @@ def _recover_container_env() -> dict[str, str]:
     (``NATS_SERVER`` / ``DYN_*``) live only in the container's pid1 env. We
     read ``/proc/1/environ`` (same uid — we SSH as root, pid1 is root) and
     overlay the relevant keys onto ``os.environ``.
+
+    Returns:
+        The current environment merged with pid1's recovered keys, with
+        ``/opt/venv/bin`` ensured at the front of ``PATH``.
     """
     env = dict(os.environ)
     try:
@@ -124,6 +133,12 @@ def _resolve_pod_ip(env: dict[str, str]) -> str:
     Resolution order: ``$POD_IP`` (downward API) -> egress-route probe ->
     hostname lookup. Falls back to ``127.0.0.1`` only if every method yields a
     loopback / fails (single-pod aggregated runs still work in that case).
+
+    Args:
+        env: The (recovered) environment, consulted for ``$POD_IP``.
+
+    Returns:
+        The pod's routable IP, or ``127.0.0.1`` when none can be resolved.
     """
     import socket
 
@@ -157,6 +172,9 @@ def _kill_prior(pid_file: Path) -> None:
 
     IR-5: never ``pkill -f`` — only the PID we launched. Missing / stale PID
     files are a no-op so callers can use this idempotently before launch.
+
+    Args:
+        pid_file: Path to the pid file recording the prior server's PID.
     """
     if not pid_file.is_file():
         return
@@ -195,7 +213,16 @@ def _kill_prior(pid_file: Path) -> None:
 
 
 def _build_sglang_cmd(a: argparse.Namespace, node_rank: int, leader: str) -> list[str]:
-    """dynamo.sglang multi-node command for this pod's rank."""
+    """dynamo.sglang multi-node command for this pod's rank.
+
+    Args:
+        a: Parsed launcher arguments.
+        node_rank: This pod's node rank.
+        leader: torch.distributed rendezvous leader address.
+
+    Returns:
+        The ``dynamo.sglang`` command argv for this pod's rank.
+    """
     cmd = [
         "python3", "-m", "dynamo.sglang",
         "--model-path", a.model,
@@ -221,7 +248,14 @@ def _build_sglang_cmd(a: argparse.Namespace, node_rank: int, leader: str) -> lis
 
 
 def _build_vllm_cmd(a: argparse.Namespace) -> list[str]:
-    """dynamo.vllm command (rank 0 only; workers just join the ray cluster)."""
+    """dynamo.vllm command (rank 0 only; workers just join the ray cluster).
+
+    Args:
+        a: Parsed launcher arguments.
+
+    Returns:
+        The ``dynamo.vllm`` command argv for rank 0.
+    """
     cmd = [
         "python3", "-m", "dynamo.vllm",
         "--model", a.model,
@@ -240,6 +274,19 @@ def _detach_launch(cmd: list[str], log_file: Path, pid_file: Path,
 
     Reparents the server under init so it survives the SSH session closing,
     and fails fast (with a log tail) if the child dies within 0.5s.
+
+    Args:
+        cmd: The server command argv to launch.
+        log_file: Path the detached server's stdout/stderr is written to.
+        pid_file: Path the launched PID is recorded in.
+        env: Environment for the launched process.
+
+    Returns:
+        The PID of the launched server.
+
+    Raises:
+        RuntimeError: If the detach spawn fails or the child exits within
+            0.5s of launch.
     """
     log_file.parent.mkdir(parents=True, exist_ok=True)
     pid_file.parent.mkdir(parents=True, exist_ok=True)
@@ -287,6 +334,11 @@ def _ray_start(role: str, leader: str, env: dict[str, str]) -> None:
     rank 0 -> ``ray start --head``; workers -> ``ray start --address``. vllm
     on rank 0 then discovers the workers via the GCS
     (``--distributed-executor-backend ray``).
+
+    Args:
+        role: ``"head"`` for rank 0, otherwise a worker that joins the leader.
+        leader: Leader address workers connect to.
+        env: Environment for the ``ray start`` subprocess.
     """
     if role == "head":
         ray_cmd = f"ray start --head --port {_RAY_GCS_PORT} --disable-usage-stats"
@@ -300,7 +352,17 @@ def _ray_start(role: str, leader: str, env: dict[str, str]) -> None:
 
 
 def _wait_health(port: int, timeout_s: int, pid: int | None) -> bool:
-    """Poll http://127.0.0.1:<port>/health until 200 or the pid dies."""
+    """Poll http://127.0.0.1:<port>/health until 200 or the pid dies.
+
+    Args:
+        port: Local health endpoint port to poll.
+        timeout_s: Maximum seconds to wait for a healthy response.
+        pid: Optional server PID; polling stops early if the process dies.
+
+    Returns:
+        ``True`` when the endpoint returned a 2xx status before the timeout,
+        else ``False``.
+    """
     import urllib.error
     import urllib.request
     started = time.monotonic()
@@ -326,6 +388,17 @@ def _wait_health(port: int, timeout_s: int, pid: int | None) -> bool:
 
 
 def main() -> int:
+    """Launch (or kill) this pod's Dynamo multi-node server rank.
+
+    Recovers the container env, resolves this pod's rank and rendezvous
+    leader, kills any prior server, then launches ``dynamo.sglang`` /
+    ``dynamo.vllm`` for this rank (optionally waiting for leader readiness).
+    With ``--kill-only`` it just tears down the prior server and exits.
+
+    Returns:
+        ``0`` on success, or ``2`` when required ``--model`` / ``--tp`` args
+        are missing.
+    """
     p = argparse.ArgumentParser(prog="launch_dynamo_node.py")
     p.add_argument("--framework", required=True, choices=("sglang", "vllm"))
     p.add_argument("--model", default="")

--- a/inference_optimizer/multi_node/scripts/launch_multinode.py
+++ b/inference_optimizer/multi_node/scripts/launch_multinode.py
@@ -42,7 +42,14 @@ _DEFAULT_DIST_INIT_PORT = 29500
 
 
 def _pd_decode_dist_init_port(prefill_dist_init_port: int) -> int:
-    """Derive the decode rendezvous port as ``prefill + 1`` so an override shifts both endpoints in lock-step."""
+    """Derive the decode rendezvous port as ``prefill + 1`` so an override shifts both endpoints in lock-step.
+
+    Args:
+        prefill_dist_init_port: The prefill group's rendezvous port.
+
+    Returns:
+        int: The decode group's rendezvous port.
+    """
     return prefill_dist_init_port + 1
 # sglang PD bootstrap (KV transfer rendezvous) port; override via --pd-bootstrap-port.
 _PD_DEFAULT_BOOTSTRAP_PORT = 8998
@@ -53,7 +60,11 @@ _HEALTH_PROBE_TIMEOUT_SEC = int(os.environ.get('SGLANG_HEALTH_PROBE_TIMEOUT_SEC'
 
 
 def _log(msg: str) -> None:
-    """Stderr line with timestamp (no logging module to avoid handler surprises as a dashboard entry-point)."""
+    """Stderr line with timestamp (no logging module to avoid handler surprises as a dashboard entry-point).
+
+    Args:
+        msg: The message text to emit.
+    """
     ts = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime())
     sys.stderr.write(f"[launch_multinode {ts}] {msg}\n")
     sys.stderr.flush()
@@ -92,7 +103,15 @@ def _wait_for_nodes(target_n: int, timeout_s: int) -> list[dict]:
 
 
 def _pick_head_first(nodes: list[dict]) -> list[dict]:
-    """Reorder so the local (driver) node is rank 0 and the rest follow in NodeManagerAddress order."""
+    """Reorder so the local (driver) node is rank 0 and the rest follow in NodeManagerAddress order.
+
+    Args:
+        nodes: The alive GPU node rows from ``ray.nodes()``.
+
+    Returns:
+        list[dict]: The nodes reordered with the local node first, or all
+        nodes sorted by address when the driver is not on a GPU node.
+    """
     local_addr = ray.util.get_node_ip_address()
     local = [n for n in nodes if n.get("NodeManagerAddress") == local_addr]
     others = sorted(
@@ -125,8 +144,25 @@ def _build_sglang_cmd(
 
     Only rank 0 gets ``--host``/``--port`` (workers serve no HTTP).
     ``--trust-remote-code`` is default-on (custom modeling.py models need
-    it). ``ep > 1`` emits ``--expert-parallel-size N`` for true expert
+    it).     ``ep > 1`` emits ``--expert-parallel-size N`` for true expert
     parallelism (the older ``--enable-ep-moe`` pair was removed upstream).
+
+    Args:
+        model: Model path passed to the launcher.
+        tp: Tensor-parallel size.
+        nnodes: Total node count for this server group.
+        node_rank: This node's rank within the group.
+        dist_init_addr: Collective rendezvous ``host:port``.
+        extra_args: Extra args appended verbatim to the launcher.
+        ep: Expert-parallel size; ``> 1`` enables expert parallelism.
+        pd_role: PD disaggregation role (``prefill``/``decode``) or empty.
+        pd_port: HTTP port bound by rank 0.
+        pd_transfer_backend: KV-transfer backend for PD mode.
+        pd_ib_device: IB/RoCE device list for PD KV transfer.
+        pd_bootstrap_port: sglang PD bootstrap rendezvous port.
+
+    Returns:
+        list[str]: The sglang launch argv.
     """
     cmd = [
         "python3", "-m", "sglang.launch_server",
@@ -172,6 +208,20 @@ def _build_vllm_cmd(
 
     ``--tensor-parallel-size`` = total cluster GPUs; ``ep > 1`` adds
     ``--enable-expert-parallel`` (vllm infers ep_size = tp_size).
+
+    Args:
+        model: Model path passed to ``vllm serve``.
+        tp: Tensor-parallel size (total cluster GPUs).
+        extra_args: Extra args appended verbatim to the launcher.
+        ep: Expert-parallel size; ``> 1`` enables expert parallelism.
+        pd_role: PD disaggregation role (``prefill``/``decode``) or empty.
+        pd_port: HTTP port bound by the server.
+        pd_transfer_backend: KV connector name for PD mode.
+        pd_kv_rank: This group's KV rank in PD mode.
+        pd_kv_parallel_size: Total KV parallel size in PD mode.
+
+    Returns:
+        list[str]: The vLLM launch argv.
     """
     cmd = [
         "vllm", "serve", model,
@@ -203,7 +253,12 @@ def _build_vllm_cmd(
 
 
 def _probe_mec_firmware_lt_177() -> bool:
-    """Return True iff rocm-smi reports MEC firmware < 177 (gate for the HSA_NO_SCRATCH_RECLAIM workaround); False on any failure."""
+    """Return True iff rocm-smi reports MEC firmware < 177 (gate for the HSA_NO_SCRATCH_RECLAIM workaround); False on any failure.
+
+    Returns:
+        bool: ``True`` if MEC firmware is below 177; ``False`` on any probe
+        failure or higher firmware.
+    """
     try:
         proc = subprocess.run(
             ["rocm-smi", "--showfw"],
@@ -232,6 +287,9 @@ def _subprocess_env() -> dict[str, str]:
     Sets the MI300X tuning trio (SGLANG_USE_AITER / SGLANG_AITER_MLA_PERSIST,
     and HSA_NO_SCRATCH_RECLAIM when MEC firmware < 177) without clobbering
     caller-set values.
+
+    Returns:
+        dict[str, str]: The environment mapping for the launcher subprocess.
     """
     env = dict(os.environ)
     # Strip Ray's empty *_VISIBLE_DEVICES mask (num_gpus=0 actors) so the
@@ -261,7 +319,22 @@ def _detach_framework_launch(
     sub_env: dict[str, str],
     node_rank: int,
 ) -> int:
-    """Start ``cmd`` detached from the Ray worker via bash+nohup+setsid (reparents under init, PYTHONUNBUFFERED logs, fails fast with log tail)."""
+    """Start ``cmd`` detached from the Ray worker via bash+nohup+setsid (reparents under init, PYTHONUNBUFFERED logs, fails fast with log tail).
+
+    Args:
+        cmd: The framework launcher argv.
+        log_file: Path the launcher's stdout/stderr is appended to.
+        pid_file: Path the spawned launcher PID is written to.
+        sub_env: Environment passed to the spawn shell.
+        node_rank: This node's rank, used in log/error messages.
+
+    Returns:
+        int: The PID of the detached framework process.
+
+    Raises:
+        RuntimeError: If the spawn shell fails, the PID file is missing or
+            invalid, or the process exits within 0.5s of launch.
+    """
     sub_env = dict(sub_env)
     sub_env.setdefault("PYTHONUNBUFFERED", "1")
     log_q = shlex.quote(str(log_file))
@@ -344,6 +417,36 @@ def _spawn_remote(
 
     ``torch_profiler_dir`` (if set) is exported as
     ``SGLANG_TORCH_PROFILER_DIR`` for shared-path traces.
+
+    Args:
+        framework: ``sglang`` or ``vllm``.
+        model: Model path passed to the launcher.
+        tp: Tensor-parallel size.
+        nnodes: Total node count for this server group.
+        node_rank: This node's rank within the group.
+        head_ip: Rendezvous head IP.
+        dist_init_port: Collective rendezvous port.
+        pid_dir: Directory the PID file is written to.
+        log_dir: Directory the log file is written to.
+        extra_args: Extra args appended verbatim to the launcher.
+        torch_profiler_dir: Optional shared dir exported as
+            ``SGLANG_TORCH_PROFILER_DIR``.
+        ep: Expert-parallel size.
+        pd_role: PD disaggregation role (``prefill``/``decode``) or empty.
+        pd_port: HTTP port bound in PD mode.
+        pd_transfer_backend: KV-transfer backend for PD mode.
+        pd_ib_device: IB/RoCE device list for PD KV transfer.
+        pd_bootstrap_port: sglang PD bootstrap rendezvous port.
+        pd_kv_rank: vLLM KV rank for PD mode.
+        pd_kv_parallel_size: vLLM total KV parallel size for PD mode.
+        pid_file_name: Optional role-tagged PID file name.
+
+    Returns:
+        int: The spawned framework PID, or ``0`` for a no-op vLLM worker rank.
+
+    Raises:
+        RuntimeError: If ``framework`` is unsupported, or the detached launch
+            fails.
     """
     Path(pid_dir).mkdir(parents=True, exist_ok=True)
     Path(log_dir).mkdir(parents=True, exist_ok=True)
@@ -462,7 +565,15 @@ _FATAL_SCAN_TAIL_BYTES = 256 * 1024
 
 
 def _scan_rank0_log_for_fatal(log_dir: str) -> str | None:
-    """Scan rank_0.log tail for a fatal traceback / framework error; returns the matched line or ``None``."""
+    """Scan rank_0.log tail for a fatal traceback / framework error; returns the matched line or ``None``.
+
+    Args:
+        log_dir: Directory containing ``rank_0.log``.
+
+    Returns:
+        str | None: The first matched fatal line, or ``None`` if none found
+        or the log cannot be read.
+    """
     try:
         lf = Path(log_dir) / "rank_0.log"
         if not lf.is_file():
@@ -492,7 +603,18 @@ def _wait_health(
     rank0_pid: int | None = None,
     log_dir: str | None = None,
 ) -> bool:
-    """Poll rank-0 ``/health``; True on first 200, False on timeout / rank-0 death / fatal ``rank_0.log`` error."""
+    """Poll rank-0 ``/health``; True on first 200, False on timeout / rank-0 death / fatal ``rank_0.log`` error.
+
+    Args:
+        timeout_s: Maximum seconds to poll before giving up.
+        rank0_pid: Optional rank-0 PID; the wait aborts early if it dies.
+        log_dir: Optional directory whose ``rank_0.log`` is scanned for fatal
+            errors to abort early.
+
+    Returns:
+        bool: ``True`` on a first healthy response; ``False`` on timeout,
+        confirmed rank-0 death, or a fatal log error.
+    """
     import urllib.request
     import urllib.error
     started = time.monotonic()
@@ -546,7 +668,12 @@ def _emit_rank0_log_tail(log_dir: Path) -> None:
 
 
 def _log_rank0_post_spawn(log_dir: Path, rank0_pid: int | None) -> None:
-    """Emit rank-0 diagnostics after a short settle (a ``rank_0.log`` tail for early weight-load exits)."""
+    """Emit rank-0 diagnostics after a short settle (a ``rank_0.log`` tail for early weight-load exits).
+
+    Args:
+        log_dir: Directory containing ``rank_0.log``.
+        rank0_pid: The rank-0 PID to probe, or ``None`` to skip.
+    """
     if rank0_pid is None or rank0_pid <= 0:
         return
     time.sleep(3)

--- a/inference_optimizer/multi_node/scripts/launch_router.py
+++ b/inference_optimizer/multi_node/scripts/launch_router.py
@@ -29,7 +29,11 @@ _DEFAULT_LOG_FILE = "/tmp/multi_node_logs/router.log"
 
 
 def _log(msg: str) -> None:
-    """Stderr line with timestamp."""
+    """Stderr line with timestamp.
+
+    Args:
+        msg: The message text to emit.
+    """
     ts = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime())
     sys.stderr.write(f"[launch_router {ts}] {msg}\n")
     sys.stderr.flush()
@@ -40,7 +44,16 @@ def _build_sglang_router_cmd(
     decode_url: str,
     public_port: int,
 ) -> list[str]:
-    """Compose the sglang_router PD-disaggregation launch command (one prefill + one decode group)."""
+    """Compose the sglang_router PD-disaggregation launch command (one prefill + one decode group).
+
+    Args:
+        prefill_url: Internal prefill group HTTP endpoint.
+        decode_url: Internal decode group HTTP endpoint.
+        public_port: Port the router binds for the client.
+
+    Returns:
+        list[str]: The argv for launching the sglang router.
+    """
     return [
         "python3", "-m", "sglang_router.launch_router",
         "--pd-disaggregation",
@@ -57,7 +70,18 @@ def _build_vllm_router_cmd(
     public_port: int,
     override_cmd: str = "",
 ) -> list[str]:
-    """Compose the vllm router/proxy launch command; ``--vllm-router-cmd`` overrides it ({prefill}/{decode}/{port} placeholders)."""
+    """Compose the vllm router/proxy launch command; ``--vllm-router-cmd`` overrides it ({prefill}/{decode}/{port} placeholders).
+
+    Args:
+        prefill_url: Internal prefill group HTTP endpoint.
+        decode_url: Internal decode group HTTP endpoint.
+        public_port: Port the router binds for the client.
+        override_cmd: Optional full command template; supports ``{prefill}``,
+            ``{decode}``, and ``{port}`` placeholders.
+
+    Returns:
+        list[str]: The argv for launching the vllm router/proxy.
+    """
     if override_cmd:
         rendered = (
             override_cmd
@@ -80,7 +104,20 @@ def _detach_router(
     log_file: Path,
     pid_file: Path,
 ) -> int:
-    """Run ``cmd`` detached via bash+nohup+setsid so it survives the dashboard job exit and dies cleanly under kill_multinode."""
+    """Run ``cmd`` detached via bash+nohup+setsid so it survives the dashboard job exit and dies cleanly under kill_multinode.
+
+    Args:
+        cmd: The router argv to launch.
+        log_file: Path the router's stdout/stderr is appended to.
+        pid_file: Path the spawned router PID is written to.
+
+    Returns:
+        int: The PID of the detached router process.
+
+    Raises:
+        RuntimeError: If the spawn shell fails, the PID file is missing or
+            invalid, or the router is not alive 0.5s after launch.
+    """
     log_file.parent.mkdir(parents=True, exist_ok=True)
     pid_file.parent.mkdir(parents=True, exist_ok=True)
     log_q = shlex.quote(str(log_file))

--- a/inference_optimizer/orchestrator/action_executors/_canonical_fingerprint.py
+++ b/inference_optimizer/orchestrator/action_executors/_canonical_fingerprint.py
@@ -38,6 +38,13 @@ def canonical_fingerprint(
     inputs (lossless legacy → ledger merge); kept separate so call-sites depend
     on the legacy canonical identity. Normalization: args ``shlex.split`` →
     sorted tokens; envs ``(str(k), str(v))`` sorted by key; 16-char SHA-1.
+
+    Args:
+        extra_args: Extra server-arg string for the variant, or None.
+        extra_envs: Mapping of extra environment variables, or None.
+
+    Returns:
+        The 16-character SHA-1 fingerprint hex digest.
     """
     args_text = str(extra_args or "")
     try:
@@ -70,6 +77,16 @@ def workload_signature(
     cross-workload resume can warn when an old KEEP came from a different
     (CONC, ISL, OSL, precision, TP). Not part of the fingerprint hash today.
     Args default to the corresponding process env vars when omitted.
+
+    Args:
+        conc: Concurrency; defaults to the ``CONC`` env var.
+        isl: Input sequence length; defaults to the ``ISL`` env var.
+        osl: Output sequence length; defaults to the ``OSL`` env var.
+        precision: Workload precision; defaults to the ``PRECISION`` env var.
+        tp: Tensor-parallel size; defaults to the ``TP`` env var.
+
+    Returns:
+        The 12-character SHA-1 digest of the workload contract.
     """
     fields = {
         "conc": str(conc if conc is not None else os.environ.get("CONC", "")).strip(),

--- a/inference_optimizer/orchestrator/action_executors/_canonical_fingerprint.py
+++ b/inference_optimizer/orchestrator/action_executors/_canonical_fingerprint.py
@@ -37,6 +37,13 @@ def canonical_fingerprint(
     Single source of truth for the content hash; ``_grid_runner.variant_fingerprint``
     delegates here for the legacy import path. Normalization: args ``shlex.split``
     → sorted tokens; envs ``(str(k), str(v))`` sorted by key; 16-char SHA-1.
+
+    Args:
+        extra_args: The variant's extra server args string, or ``None``.
+        extra_envs: The variant's extra env mapping, or ``None``.
+
+    Returns:
+        The canonical 16-char SHA-1 content fingerprint for the variant.
     """
     args_text = str(extra_args or "")
     try:
@@ -69,6 +76,16 @@ def workload_signature(
     cross-workload resume can warn when an old KEEP came from a different
     (CONC, ISL, OSL, precision, TP). Not part of the fingerprint hash today.
     Args default to the corresponding process env vars when omitted.
+
+    Args:
+        conc: Concurrency; defaults to ``$CONC`` when omitted.
+        isl: Input sequence length; defaults to ``$ISL`` when omitted.
+        osl: Output sequence length; defaults to ``$OSL`` when omitted.
+        precision: Precision tag; defaults to ``$PRECISION`` when omitted.
+        tp: Tensor-parallel size; defaults to ``$TP`` when omitted.
+
+    Returns:
+        A stable 12-char SHA-1 digest of the workload contract.
     """
     fields = {
         "conc": str(conc if conc is not None else os.environ.get("CONC", "")).strip(),

--- a/inference_optimizer/orchestrator/action_executors/_explore_roofline_filter.py
+++ b/inference_optimizer/orchestrator/action_executors/_explore_roofline_filter.py
@@ -75,6 +75,13 @@ def categorize_variant(
     """Return the set of roofline directions a variant's flags target.
 
     An empty set means the variant is uncategorized (no advisory).
+
+    Args:
+        extra_args: Extra server-arg string for the variant, or None.
+        extra_envs: Mapping of extra environment variables, or None.
+
+    Returns:
+        Frozenset of roofline direction names the variant targets.
     """
     cats: set[str] = set()
     args = (extra_args or "").strip()

--- a/inference_optimizer/orchestrator/action_executors/_framework_gap_composer.py
+++ b/inference_optimizer/orchestrator/action_executors/_framework_gap_composer.py
@@ -54,6 +54,12 @@ def _extract_bottleneck_from_breakdown(breakdown_path: str | Path | None) -> str
     sorted-by-time list or dict with ``top_kernels``). Best-effort: returns ""
     when the path is empty/unreadable or no kernel matches
     :data:`_OP_TO_KEYWORD`, and the caller falls back to manifest-only gap.
+
+    Args:
+        breakdown_path: Path to the kernel breakdown JSON, or None.
+
+    Returns:
+        One canonical bottleneck keyword, or "" when none is found.
     """
     if not breakdown_path:
         return ""
@@ -101,6 +107,12 @@ def _normalize_model_class(model_class: str) -> str:
 
     Same canonicalisation rule (lowercase, -/+/space → _) every other
     ``model_class`` consumer uses, keeping the gap token grep-friendly.
+
+    Args:
+        model_class: Raw model-class label.
+
+    Returns:
+        The canonical lowercase token, or "" when the input is empty.
     """
     raw = (model_class or "").strip().lower()
     if not raw:
@@ -113,6 +125,13 @@ def _model_class_to_search_token(model_class: str) -> str:
 
     fa's anti-correlation table activates on ``dense`` / ``moe``, so the gap
     must carry one of those rather than granular IO labels (``moe_mla`` ...).
+
+    Args:
+        model_class: Raw model-class label.
+
+    Returns:
+        An fa-friendly architectural token (``moe`` / ``dense`` / canonical
+        token), or "" when the input is empty.
     """
     mc = _normalize_model_class(model_class)
     if not mc:
@@ -140,9 +159,21 @@ def compose_gap(
     ``profile_kernel_breakdown_path`` (when present) adds a bottleneck keyword.
     ``tried_refs`` is accepted for forward-compat but currently unused.
 
-    Returns ``(gap_description, keywords)``: a free-text gap phrase for
-    fa's PR search, and a lowercased/deduped/sorted explicit keyword list
-    (non-empty when any of framework/gpu_type/model_class/bottleneck is known).
+    Args:
+        framework: Inference framework name.
+        gpu_type: Target GPU type.
+        model_class: Model-class label (canonicalised to a search token).
+        precision: Workload precision.
+        profile_kernel_breakdown_path: Optional path to the kernel breakdown
+            JSON used to derive a bottleneck keyword.
+        tried_refs: Previously tried PR refs; accepted for forward-compat but
+            currently unused.
+
+    Returns:
+        A ``(gap_description, keywords)`` tuple: a free-text gap phrase for
+        fa's PR search, and a lowercased/deduped/sorted explicit keyword list
+        (non-empty when any of framework/gpu_type/model_class/bottleneck is
+        known).
     """
     fw = (framework or "").strip().lower()
     gpu = (gpu_type or "").strip().lower()

--- a/inference_optimizer/orchestrator/action_executors/_grid_runner.py
+++ b/inference_optimizer/orchestrator/action_executors/_grid_runner.py
@@ -53,6 +53,13 @@ def variant_fingerprint(
 
     Name and note are NOT inputs — variants with identical content but
     different names collapse to the same fingerprint.
+
+    Args:
+        extra_server_args: The variant's server-args string, or ``None``.
+        extra_envs: The variant's env overrides, or ``None``.
+
+    Returns:
+        A 16-char SHA-1 prefix fingerprint of the normalized content.
     """
     args_text = str(extra_server_args or "")
     try:
@@ -79,6 +86,10 @@ def _resolve_magpie_python() -> str:
     Magpie venv) as unconditional last resort. A stale ``$MAGPIE_PYTHON``
     resolved before Magpie was pip-installed (e.g. ``/usr/bin/python3``) is
     validated and skipped to avoid ``ModuleNotFoundError`` at benchmark time.
+
+    Returns:
+        Path to a Python interpreter that can import Magpie, falling back to
+        the canonical ``/opt/venv/bin/python``.
     """
     def _can_import_magpie(py: str) -> bool:
         """Whether an interpreter can import Magpie and its ``yaml`` dep.
@@ -136,6 +147,9 @@ def _resolve_session_dir() -> Path:
     Reads :func:`inference_optimizer.paths.session_dir` (honors
     ``$USER_DATA_PATH``, else ``/workspace/hyperloom``). Used by fallback
     paths when ``ctx.extra["workspace"]`` was not pre-mkdir'd.
+
+    Returns:
+        The resolved active session directory.
     """
     from ...paths import session_dir as _sd
     return _sd()
@@ -219,6 +233,13 @@ def annotate_multi_node_cuda_graph_max_bs(
     cross-node decode tick), but the variant is kept in the grid and surfaced
     as an advisory rather than auto-dropped. Returns ``[]`` outside multi-node
     mode, when ``$CONC`` is unset/non-positive, or when no variant matches.
+
+    Args:
+        grid: The variants to inspect for a low ``--cuda-graph-max-bs``.
+
+    Returns:
+        A list of advisory note dicts (``name``/``source``/``reason``), or
+        ``[]`` when nothing applies.
     """
     from ._multi_node_env import is_multi_node
     if not is_multi_node():
@@ -291,6 +312,12 @@ def _probe_server_help_text(framework: str) -> str:
     fall through to NOT filtering. Empty results are NOT cached. The broad
     ``except`` is deliberate: this probe is a perf optimisation only and must
     never crash the optimizer.
+
+    Args:
+        framework: The framework name (``sglang`` / ``vllm`` / ``atom``).
+
+    Returns:
+        The ``--help`` text, or ``""`` on any failure or unknown framework.
     """
     fw = (framework or "").strip().lower()
     if fw in _HELP_TEXT_CACHE:
@@ -316,6 +343,9 @@ def _probe_sglang_help_text() -> str:
 
     Kept so tests that monkey-patch this exact name still work; new call
     sites should use ``_probe_server_help_text("sglang")``.
+
+    Returns:
+        The SGLang ``--help`` text, or ``""`` on failure.
     """
     return _probe_server_help_text("sglang")
 
@@ -327,6 +357,12 @@ def _detect_model_class(model_path: str) -> tuple[bool, bool]:
     variant before a 10-min doomed sglang restart. Misclassifications cost at
     most one restart. MLA: DeepSeek (V2/V3/R1), GLM-5, Kimi-K2; MoE: MLA set +
     Qwen3-MoE.
+
+    Args:
+        model_path: The model path/name to classify.
+
+    Returns:
+        A ``(is_mla_model, is_moe_model)`` tuple of detection flags.
     """
     p = model_path.lower()
     mla_keys = ("glm-5", "glm5", "deepseek", "kimi-k2", "kimi_k2", "kimi")
@@ -348,6 +384,13 @@ def apply_compatibility_filter(
     model class (MLA / MoE flags dropped when ``$MODEL_PATH`` lacks the family
     keyword), and sglang version (flags absent from ``launch_server --help``
     dropped). Returns the ``(kept, dropped)`` shape of ``apply_user_skip_list``.
+
+    Args:
+        grid: The candidate variants to filter.
+
+    Returns:
+        A ``(kept, dropped)`` tuple where ``dropped`` entries are
+        ``{"name", "source", "reason"}`` dicts (source=``"compatibility_filter"``).
     """
     model_path = os.environ.get("MODEL_PATH", "")
     if model_path:
@@ -409,6 +452,13 @@ def apply_user_skip_list(
 
     Returns ``(kept, dropped)`` where each dropped entry is
     ``{"name", "reason", "source"}`` with source=``"user_skip"``.
+
+    Args:
+        grid: The candidate variants to filter.
+        skip_spec: Comma/space-separated name or glob patterns to drop.
+
+    Returns:
+        A ``(kept, dropped)`` tuple of variants and drop-reason dicts.
     """
     patterns = _parse_skip_spec(skip_spec)
     if not patterns:
@@ -511,6 +561,12 @@ def coerce_extra_envs(value: Any) -> dict[str, str]:
     ``"FOO=1 BAR=2"`` string, and ``["FOO=1", "BAR=2"]`` token list — so
     downstream ``.items()`` callers never crash on a non-dict. Unknown shapes
     coerce to an empty dict.
+
+    Args:
+        value: The raw ``extra_envs`` value (dict, string, or list/tuple).
+
+    Returns:
+        A normalized ``dict[str, str]`` of environment overrides.
     """
     if isinstance(value, dict):
         return {str(k): str(v) for k, v in value.items() if k is not None}
@@ -675,6 +731,15 @@ def sanitize_script_name(value: Any) -> str | None:
 
     Must be a bare ``*.sh`` name (no slashes / ``..``). Empty/``None`` →
     ``None``; anything resembling shell injection raises ``ValueError``.
+
+    Args:
+        value: The Orchestration-supplied benchmark script name.
+
+    Returns:
+        The validated script name, or ``None`` when empty/``None``.
+
+    Raises:
+        ValueError: If ``value`` is not a bare ``*.sh`` file name.
     """
     if value is None:
         return None
@@ -695,6 +760,15 @@ def sanitize_result_dir(value: Any) -> str | None:
     Lands in a shell ``cd`` / ``mkdir`` via ``$RESULT_DIR``, so reject any
     character that could escape into a different shell word. Empty/``None`` →
     ``None``.
+
+    Args:
+        value: The Orchestration-supplied result directory path.
+
+    Returns:
+        The validated directory string, or ``None`` when empty/``None``.
+
+    Raises:
+        ValueError: If ``value`` contains whitespace or shell metacharacters.
     """
     if value is None:
         return None
@@ -735,6 +809,12 @@ def merge_server_args(*parts: str | None) -> str:
     Only removes empty chunks; does NOT de-duplicate option names, because
     repeated flags are how later args override base args (e.g. ``--block-size
     1`` then ``--block-size 256``).
+
+    Args:
+        *parts: Server-arg strings (or ``None``) in override order.
+
+    Returns:
+        The non-empty parts joined by single spaces.
     """
     return " ".join(str(p).strip() for p in parts if str(p or "").strip())
 
@@ -758,6 +838,9 @@ def resolve_sglang_watchdog_timeout() -> int:
     :data:`DEFAULT_SGLANG_WATCHDOG_TIMEOUT_SEC` when the env var is unset,
     empty, non-integer, or non-positive. A malformed value logs a warning
     and uses the default rather than crashing the YAML materialization.
+
+    Returns:
+        The resolved watchdog timeout in seconds.
     """
     raw = os.environ.get(SGLANG_WATCHDOG_TIMEOUT_ENV, "").strip()
     if not raw:
@@ -790,6 +873,13 @@ def inject_sglang_watchdog_timeout(
     (empty/unknown is treated as sglang) or the flag is already present.
     Otherwise appends the value from :func:`resolve_sglang_watchdog_timeout`;
     no other flag is touched.
+
+    Args:
+        server_args: The existing server-args string, or ``None``.
+        framework: The backend framework name.
+
+    Returns:
+        The server-args string, with the watchdog flag appended when applicable.
     """
     args = str(server_args or "").strip()
     if server_args_env_name(framework) != "EXTRA_SGLANG_ARGS":
@@ -824,6 +914,13 @@ def _resolve_nonneg_int_env(name: str, default: int) -> int:
 
     A blank/non-integer/negative value logs a warning and falls back to the
     default rather than crashing the YAML materialization.
+
+    Args:
+        name: The environment variable name to read.
+        default: The fallback value when unset/invalid.
+
+    Returns:
+        The parsed non-negative integer, or ``default``.
     """
     raw = os.environ.get(name, "").strip()
     if not raw:
@@ -850,6 +947,13 @@ def resolve_sglang_context_cap(isl: int, osl: int) -> int:
     operator-tunable via ``$SGLANG_CONTEXT_HEADROOM_TOKENS`` /
     ``$SGLANG_CONTEXT_FLOOR_TOKENS``). Caller clamps to the model's native
     window before injecting.
+
+    Args:
+        isl: Input sequence length in tokens.
+        osl: Output sequence length in tokens.
+
+    Returns:
+        The resolved context-length cap in tokens.
     """
     headroom = _resolve_nonneg_int_env(
         SGLANG_CONTEXT_HEADROOM_ENV, DEFAULT_SGLANG_CONTEXT_HEADROOM_TOKENS,
@@ -874,6 +978,16 @@ def inject_sglang_context_length(
     model's ``max_position_embeddings`` cannot be read. Otherwise appends
     ``min(max_pos, cap)`` from :func:`resolve_sglang_context_cap`; only this
     flag is added.
+
+    Args:
+        server_args: The existing server-args string, or ``None``.
+        framework: The backend framework name.
+        model_path: The model path used to read ``max_position_embeddings``.
+        isl: Input sequence length in tokens.
+        osl: Output sequence length in tokens.
+
+    Returns:
+        The server-args string, with ``--context-length`` appended when applicable.
     """
     args = str(server_args or "").strip()
     if server_args_env_name(framework) != "EXTRA_SGLANG_ARGS":
@@ -903,6 +1017,12 @@ def _resolve_dual_chunk_backend(gpu_type: str | None = None) -> str:
     (e.g. operator override), return the canonical backend and let sglang
     raise the clear error rather than silently injecting triton which
     sglang also rejects.  Override via ``$HYPERLOOM_DUAL_CHUNK_BACKEND``.
+
+    Args:
+        gpu_type: Optional caller-known GPU type (currently advisory).
+
+    Returns:
+        The dual-chunk attention backend name to inject.
     """
     override = os.environ.get("HYPERLOOM_DUAL_CHUNK_BACKEND", "").strip()
     if override:
@@ -929,6 +1049,15 @@ def inject_sglang_attention_backend(
     Returns ``server_args`` unchanged when: framework is not sglang, an
     ``--attention-backend`` is already pinned (operator wins), or the model
     config has no dual-chunk block (fail-safe: inject nothing).
+
+    Args:
+        server_args: The existing server-args string, or ``None``.
+        framework: The backend framework name.
+        model_path: The model path used to detect dual-chunk attention.
+        gpu_type: Optional caller-known GPU type, preferred over autodetect.
+
+    Returns:
+        The server-args string, with ``--attention-backend`` appended when applicable.
     """
     args = str(server_args or "").strip()
     if server_args_env_name(framework) != "EXTRA_SGLANG_ARGS":
@@ -984,6 +1113,15 @@ def inject_sglang_moe_runner_backend(
     inject nothing). Otherwise appends the backend from
     ``$HYPERLOOM_SGLANG_MOE_RUNNER_BACKEND`` (default ``triton``); only this
     flag is added.
+
+    Args:
+        server_args: The existing server-args string, or ``None``.
+        framework: The backend framework name.
+        model_path: The model path used to detect a MoE model.
+        gpu_type: Optional caller-known GPU type, preferred over autodetect.
+
+    Returns:
+        The server-args string, with ``--moe-runner-backend`` appended when applicable.
     """
     args = str(server_args or "").strip()
     if server_args_env_name(framework) != "EXTRA_SGLANG_ARGS":
@@ -1022,6 +1160,15 @@ def apply_runtime_benchmark_overrides(
     ``benchmark_script`` (must be pre-sanitized via :func:`sanitize_script_name`)
     force-selects a specific Magpie script, applied AFTER the
     ``gpu_type``-derived generic script so the operator pick wins.
+
+    Args:
+        bench: The benchmark YAML dict to mutate in place.
+        model_path: Optional model path override.
+        gpu_type: Optional GPU/runner type override.
+        benchmark_script: Optional pre-sanitized Magpie script name to force.
+
+    Returns:
+        The mutated ``envs`` sub-dict of ``bench``.
     """
     if model_path:
         bench["model"] = str(model_path)
@@ -1090,6 +1237,18 @@ def _build_variant_yaml(
     overrides the legacy hardcoded ``benchmark.model``; ``gpu_type`` pins the
     generic ``{framework}_{gpu_type}.sh``; ``benchmark_script`` (pre-sanitized)
     force-pins a script, applied last so the operator pick wins.
+
+    Args:
+        base_yaml_path: Path to the base Magpie YAML to clone.
+        base_extra_args: Server args common to every variant.
+        variant: The variant whose flags/envs are layered on top.
+        output_subdir: Directory the per-variant ``config.yaml`` is written to.
+        model_path: Optional model path override.
+        gpu_type: Optional GPU/runner type override.
+        benchmark_script: Optional pre-sanitized Magpie script name to force.
+
+    Returns:
+        Path to the materialized per-variant ``config.yaml``.
     """
     with base_yaml_path.open(encoding="utf-8") as f:
         cfg = yaml.safe_load(f)
@@ -1147,6 +1306,11 @@ def _kill_stale_servers() -> None:
     hangs ~5 min on zmq / shared-mem conflicts. Called before every Magpie
     invocation. Uses /proc scan (not pgrep) to avoid clashing with test
     subprocess mocks. No-op in multi-node mode (servers live in RayJob pods).
+
+    Note:
+        Side-effecting and best-effort: it sends signals to matching processes
+        and unlinks stale shared-memory segments, swallowing errors. Returns
+        nothing.
     """
     from ._multi_node_env import is_multi_node
     if is_multi_node():
@@ -1268,6 +1432,18 @@ def _run_magpie(
     land in the per-task workspace, not ``/workspace/``. ``soft_deadline_sec``
     is the Fix-E overtime cap: the tree is reaped and a sentinel
     ``OVERTIME_KILL_RETURNCODE`` returned instead of raising ``TimeoutExpired``.
+
+    Args:
+        magpie_python: Path to the Python interpreter that runs Magpie.
+        config_path: Path to the materialized benchmark YAML.
+        output_dir: Directory for the run's outputs (default ``$RESULT_DIR``).
+        timeout_sec: Hard subprocess timeout in seconds.
+        cwd: Working directory for the Magpie subprocess.
+        result_dir: Optional pre-sanitized override for ``$RESULT_DIR``.
+        soft_deadline_sec: Optional overtime soft cap in seconds.
+
+    Returns:
+        A ``(returncode, stdout, stderr)`` tuple from the Magpie subprocess.
     """
     # Pre-clean lingering servers + shared memory (skip under pytest).
     if not os.environ.get("PYTEST_CURRENT_TEST"):
@@ -1344,6 +1520,24 @@ async def run_grid(
     that hardcode ``--result-dir /workspace/`` (see SKILL.md "Magpie leak-path
     salvage"). ``soft_deadline_sec`` (Fix E): reap a variant once wall-clock
     exceeds it, marking it ``killed_overtime=True``; None/0 disables (legacy).
+
+    Args:
+        base_yaml_path: Path to the base Magpie YAML cloned per variant.
+        base_extra_args: Server args common to every variant.
+        grid: The variants to execute, in order.
+        output_root: Root directory under which each variant's outputs land.
+        magpie_python: Optional interpreter override; resolved when unset.
+        cwd: Working directory for each Magpie subprocess.
+        variant_timeout_sec: Hard per-variant subprocess timeout in seconds.
+        keep_going_on_failure: Whether to continue after a variant fails.
+        model_path: Optional model path forwarded to each YAML render.
+        gpu_type: Optional GPU/runner type forwarded to each YAML render.
+        benchmark_script: Optional pre-sanitized Magpie script name to force.
+        result_dir: Optional pre-sanitized override for ``$RESULT_DIR``.
+        soft_deadline_sec: Optional per-variant overtime soft cap in seconds.
+
+    Returns:
+        The per-variant :class:`VariantResult` list for every attempt.
     """
     if not magpie_python:
         magpie_python = _resolve_magpie_python()
@@ -1748,6 +1942,15 @@ def pick_winners(
     falls back to ``MULTI_NODE_DEFAULT_KEEP_THRESHOLD_PCT`` (2.0%, the empirical
     cross-node noise floor) in multi-node mode, else
     ``SINGLE_NODE_DEFAULT_KEEP_THRESHOLD_PCT`` (1.0%).
+
+    Args:
+        results: The per-variant results to filter.
+        baseline_tput: The baseline output throughput to beat.
+        keep_threshold_pct: Explicit win margin percent; resolved by mode
+            when ``None``.
+
+    Returns:
+        The succeeded variants whose throughput clears the cutoff.
     """
     if keep_threshold_pct is None:
         from ._multi_node_env import is_multi_node
@@ -1793,6 +1996,13 @@ def _write_variant_abort_marker(
     "untested". This marker lets final-report / post-mortem tools count failed
     variants and find an explicit reason even after the log rotated. Failure
     to write it is non-fatal (log and continue).
+
+    Args:
+        slot: The variant slot directory to write the marker into.
+        variant_name: The aborted variant's name.
+        error_class: Short failure-classification tag.
+        error_summary: Human-readable error summary (truncated to 2000 chars).
+        extra_args: The variant's server args, recorded for post-mortem.
     """
     try:
         slot.mkdir(parents=True, exist_ok=True)

--- a/inference_optimizer/orchestrator/action_executors/_grid_runner.py
+++ b/inference_optimizer/orchestrator/action_executors/_grid_runner.py
@@ -81,6 +81,17 @@ def _resolve_magpie_python() -> str:
     validated and skipped to avoid ``ModuleNotFoundError`` at benchmark time.
     """
     def _can_import_magpie(py: str) -> bool:
+        """Whether an interpreter can import Magpie and its ``yaml`` dep.
+
+        Probes both ``Magpie`` and ``yaml`` so interpreters that resolve
+        Magpie via a ``.pth`` but lack PyYAML are rejected.
+
+        Args:
+            py: Path to the candidate Python interpreter.
+
+        Returns:
+            ``True`` if both imports succeed in the interpreter.
+        """
         # Probe Magpie AND its top-level runtime dep ``yaml``: an editable
         # install puts Magpie on sys.path via a .pth regardless of whether
         # the interpreter has PyYAML, so ``import Magpie`` alone can succeed
@@ -454,6 +465,16 @@ class GridVariant:
         *,
         extra_sglang_args: str | None = None,
     ) -> None:
+        """Initialize a grid variant descriptor.
+
+        Args:
+            name: Variant name.
+            extra_server_args: Extra server CLI args for this variant.
+            extra_envs: Extra environment variables for this variant.
+            note: Optional reason/category note.
+            extra_sglang_args: Deprecated alias for ``extra_server_args``;
+                routed into the canonical attribute with a warning.
+        """
         # Back-compat alias for the historical ``extra_sglang_args`` kwarg;
         # routed into the canonical attribute with a DeprecationWarning.
         if extra_sglang_args is not None:

--- a/inference_optimizer/orchestrator/action_executors/_grid_runner.py
+++ b/inference_optimizer/orchestrator/action_executors/_grid_runner.py
@@ -53,6 +53,13 @@ def variant_fingerprint(
     Name and note are NOT inputs — variants with identical content but
     different names collapse to the same fingerprint. Delegates to
     :func:`canonical_fingerprint` so the two never drift.
+
+    Args:
+        extra_server_args (str | None): Backend server args for the variant.
+        extra_envs (dict[str, Any] | None): Per-variant environment overrides.
+
+    Returns:
+        str: The 16-char content fingerprint of the pair.
     """
     return canonical_fingerprint(extra_server_args, extra_envs)
 
@@ -65,6 +72,10 @@ def _resolve_magpie_python() -> str:
     Magpie venv) as unconditional last resort. A stale ``$MAGPIE_PYTHON``
     resolved before Magpie was pip-installed (e.g. ``/usr/bin/python3``) is
     validated and skipped to avoid ``ModuleNotFoundError`` at benchmark time.
+
+    Returns:
+        str: Path to a Python interpreter that can import Magpie, falling back
+        to ``/opt/venv/bin/python``.
     """
     def _can_import_magpie(py: str) -> bool:
         """Whether an interpreter can import Magpie and its ``yaml`` dep.
@@ -122,6 +133,9 @@ def _resolve_session_dir() -> Path:
     Reads :func:`inference_optimizer.paths.session_dir` (honors
     ``$USER_DATA_PATH``, else ``/workspace/hyperloom``). Used by fallback
     paths when ``ctx.extra["workspace"]`` was not pre-mkdir'd.
+
+    Returns:
+        Path: The resolved active session directory.
     """
     from ...paths import session_dir as _sd
     return _sd()
@@ -205,6 +219,13 @@ def annotate_multi_node_cuda_graph_max_bs(
     cross-node decode tick), but the variant is kept in the grid and surfaced
     as an advisory rather than auto-dropped. Returns ``[]`` outside multi-node
     mode, when ``$CONC`` is unset/non-positive, or when no variant matches.
+
+    Args:
+        grid (list[GridVariant]): The candidate variants to inspect.
+
+    Returns:
+        list[dict]: Advisory note dicts (``name``/``source``/``reason``) for the
+        matching variants; empty outside multi-node mode or on no match.
     """
     from ._multi_node_env import is_multi_node
     if not is_multi_node():
@@ -276,6 +297,15 @@ def _mn_priority_index(
     variant's ``note`` (falling back to ``name`` when ``note`` is empty).
     Untagged variants return ``len(priority_tags)`` so a stable sort sinks them
     to the end while preserving their relative order.
+
+    Args:
+        variant (GridVariant): The variant to rank.
+        priority_tags (tuple[str, ...] | list[str]): Ordered category tags;
+            lower index == higher priority.
+
+    Returns:
+        int: The index of the first matching tag, or ``len(priority_tags)`` when
+        none match.
     """
     haystack = (variant.note or variant.name or "")
     for idx, tag in enumerate(priority_tags):
@@ -296,6 +326,15 @@ def reorder_grid_for_multi_node(
     multi-node mode variants are stably sorted by ``_mn_priority_index`` so
     tagged variants surface ahead of untagged ones and a ``--max-hours`` cut
     still benches the strong candidates.
+
+    Args:
+        grid (list[GridVariant]): The variants to reorder.
+        priority_tags (tuple[str, ...] | list[str]): Ordered category tags used
+            to rank variants.
+
+    Returns:
+        list[GridVariant]: ``grid`` unchanged in single-node mode, else a stably
+        sorted copy with higher-priority variants first.
     """
     from ._multi_node_env import is_multi_node
     if not is_multi_node():
@@ -318,6 +357,14 @@ def apply_multi_node_invalid_variants(
     in multi-node mode (cuda-graph cache misses every cross-node decode tick),
     so it is dropped from the explore grid here (the advisory-only counterpart
     is ``annotate_multi_node_cuda_graph_max_bs``).
+
+    Args:
+        grid (list[GridVariant]): The candidate variants to filter.
+
+    Returns:
+        tuple[list[GridVariant], list[dict]]: ``(kept, dropped)`` where dropped
+        entries carry ``name``/``source``/``reason``; ``(grid, [])`` outside
+        multi-node mode.
     """
     from ._multi_node_env import is_multi_node
     if not is_multi_node():
@@ -390,6 +437,13 @@ def _probe_server_help_text(framework: str) -> str:
     fall through to NOT filtering. Empty results are NOT cached. The broad
     ``except`` is deliberate: this probe is a perf optimisation only and must
     never crash the optimizer.
+
+    Args:
+        framework (str): Framework name; matched case-insensitively.
+
+    Returns:
+        str: The combined stdout+stderr ``--help`` text, or ``""`` on any
+        failure or unknown framework.
     """
     fw = (framework or "").strip().lower()
     if fw in _HELP_TEXT_CACHE:
@@ -415,6 +469,9 @@ def _probe_sglang_help_text() -> str:
 
     Kept so tests that monkey-patch this exact name still work; new call
     sites should use ``_probe_server_help_text("sglang")``.
+
+    Returns:
+        str: The sglang ``--help`` text, or ``""`` on failure.
     """
     return _probe_server_help_text("sglang")
 
@@ -426,6 +483,13 @@ def _detect_model_class(model_path: str) -> tuple[bool, bool]:
     variant before a 10-min doomed sglang restart. Misclassifications cost at
     most one restart. MLA: DeepSeek (V2/V3/R1), GLM-5, Kimi-K2; MoE: MLA set +
     Qwen3-MoE.
+
+    Args:
+        model_path (str): Model path/identifier; matched as a lowercased
+            substring.
+
+    Returns:
+        tuple[bool, bool]: ``(is_mla_model, is_moe_model)``.
     """
     p = model_path.lower()
     mla_keys = ("glm-5", "glm5", "deepseek", "kimi-k2", "kimi_k2", "kimi")
@@ -447,6 +511,13 @@ def apply_compatibility_filter(
     model class (MLA / MoE flags dropped when ``$MODEL_PATH`` lacks the family
     keyword), and sglang version (flags absent from ``launch_server --help``
     dropped). Returns the ``(kept, dropped)`` shape of ``apply_user_skip_list``.
+
+    Args:
+        grid (list[GridVariant]): The candidate variants to filter.
+
+    Returns:
+        tuple[list[GridVariant], list[dict]]: ``(kept, dropped)`` where dropped
+        entries carry ``name``/``source``/``reason``.
     """
     model_path = os.environ.get("MODEL_PATH", "")
     if model_path:
@@ -508,6 +579,15 @@ def apply_user_skip_list(
 
     Returns ``(kept, dropped)`` where each dropped entry is
     ``{"name", "reason", "source"}`` with source=``"user_skip"``.
+
+    Args:
+        grid (list[GridVariant]): The candidate variants to filter.
+        skip_spec (str): Comma/whitespace skip patterns (exact or fnmatch glob)
+            matched against ``GridVariant.name``.
+
+    Returns:
+        tuple[list[GridVariant], list[dict]]: ``(kept, dropped)`` where dropped
+        entries carry ``name``/``source``/``reason``.
     """
     patterns = _parse_skip_spec(skip_spec)
     if not patterns:
@@ -610,6 +690,13 @@ def coerce_extra_envs(value: Any) -> dict[str, str]:
     ``"FOO=1 BAR=2"`` string, and ``["FOO=1", "BAR=2"]`` token list — so
     downstream ``.items()`` callers never crash on a non-dict. Unknown shapes
     coerce to an empty dict.
+
+    Args:
+        value (Any): The Orchestration-supplied ``extra_envs`` in any of the
+            accepted shapes (dict, shell-style string, or token list).
+
+    Returns:
+        dict[str, str]: The normalized env mapping; empty for unknown shapes.
     """
     if isinstance(value, dict):
         return {str(k): str(v) for k, v in value.items() if k is not None}
@@ -785,6 +872,16 @@ def sanitize_script_name(value: Any) -> str | None:
 
     Must be a bare ``*.sh`` name (no slashes / ``..``). Empty/``None`` →
     ``None``; anything resembling shell injection raises ``ValueError``.
+
+    Args:
+        value (Any): Candidate script name; coerced to a stripped string.
+
+    Returns:
+        str | None: The validated bare ``*.sh`` name, or ``None`` for empty
+        input.
+
+    Raises:
+        ValueError: When ``value`` is not a bare ``*.sh`` file name.
     """
     if value is None:
         return None
@@ -805,6 +902,15 @@ def sanitize_result_dir(value: Any) -> str | None:
     Lands in a shell ``cd`` / ``mkdir`` via ``$RESULT_DIR``, so reject any
     character that could escape into a different shell word. Empty/``None`` →
     ``None``.
+
+    Args:
+        value (Any): Candidate directory; coerced to a stripped string.
+
+    Returns:
+        str | None: The validated path, or ``None`` for empty input.
+
+    Raises:
+        ValueError: When ``value`` contains whitespace or shell metacharacters.
     """
     if value is None:
         return None
@@ -845,6 +951,13 @@ def merge_server_args(*parts: str | None) -> str:
     Only removes empty chunks; does NOT de-duplicate option names, because
     repeated flags are how later args override base args (e.g. ``--block-size
     1`` then ``--block-size 256``).
+
+    Args:
+        *parts (str | None): Server-arg chunks to merge, in override order;
+            empty/``None`` chunks are dropped.
+
+    Returns:
+        str: The space-joined non-empty chunks.
     """
     return " ".join(str(p).strip() for p in parts if str(p or "").strip())
 
@@ -909,6 +1022,15 @@ def dedup_vllm_server_args(
     is empty, it carries a space/JSON-valued flag (see
     :data:`_SPACE_VALUE_FLAGS` / :data:`_MULTI_VALUE_FLAGS`), or it cannot be
     shell-parsed.
+
+    Args:
+        server_args (str | None): The server-arg string to dedupe.
+        framework (str | None): Framework name; matched case-insensitively
+            (sglang is a no-op).
+
+    Returns:
+        str: The deduped server-arg string, or the input unchanged when no
+        dedupe applies.
     """
     args = str(server_args or "").strip()
     if not args:
@@ -973,6 +1095,13 @@ def _shell_safe_dedupe(args: str) -> str:
     a space/JSON value (which the unquoted ``$EXTRA_*_ARGS`` expansion in the
     Magpie scripts cannot safely round-trip anyway), the string is returned
     unchanged to avoid mangling it.
+
+    Args:
+        args (str): The server-arg string to dedupe.
+
+    Returns:
+        str: The last-wins deduped string, or the input unchanged when it
+        carries a space/JSON-valued flag.
     """
     if not args.strip():
         return ""
@@ -1031,6 +1160,9 @@ def resolve_sglang_watchdog_timeout() -> int:
     :data:`DEFAULT_SGLANG_WATCHDOG_TIMEOUT_SEC` when the env var is unset,
     empty, non-integer, or non-positive. A malformed value logs a warning
     and uses the default rather than crashing the YAML materialization.
+
+    Returns:
+        int: The resolved watchdog timeout in seconds.
     """
     raw = os.environ.get(SGLANG_WATCHDOG_TIMEOUT_ENV, "").strip()
     if not raw:
@@ -1063,6 +1195,14 @@ def inject_sglang_watchdog_timeout(
     (empty/unknown is treated as sglang) or the flag is already present.
     Otherwise appends the value from :func:`resolve_sglang_watchdog_timeout`;
     no other flag is touched.
+
+    Args:
+        server_args (str | None): The server-arg string to augment.
+        framework (str | None): Framework name; empty/unknown treated as sglang.
+
+    Returns:
+        str: ``server_args`` with ``--watchdog-timeout`` appended, or unchanged
+        for non-sglang frameworks or when the flag is already present.
     """
     args = str(server_args or "").strip()
     if server_args_env_name(framework) != "EXTRA_SGLANG_ARGS":
@@ -1097,6 +1237,13 @@ def _resolve_nonneg_int_env(name: str, default: int) -> int:
 
     A blank/non-integer/negative value logs a warning and falls back to the
     default rather than crashing the YAML materialization.
+
+    Args:
+        name (str): Environment variable name to read.
+        default (int): Fallback value when unset/invalid.
+
+    Returns:
+        int: The parsed non-negative integer, or ``default``.
     """
     raw = os.environ.get(name, "").strip()
     if not raw:
@@ -1123,6 +1270,13 @@ def resolve_sglang_context_cap(isl: int, osl: int) -> int:
     operator-tunable via ``$SGLANG_CONTEXT_HEADROOM_TOKENS`` /
     ``$SGLANG_CONTEXT_FLOOR_TOKENS``). Caller clamps to the model's native
     window before injecting.
+
+    Args:
+        isl (int): Input sequence length.
+        osl (int): Output sequence length.
+
+    Returns:
+        int: ``max(isl + osl + headroom, floor)``.
     """
     headroom = _resolve_nonneg_int_env(
         SGLANG_CONTEXT_HEADROOM_ENV, DEFAULT_SGLANG_CONTEXT_HEADROOM_TOKENS,
@@ -1147,6 +1301,19 @@ def inject_sglang_context_length(
     model's ``max_position_embeddings`` cannot be read. Otherwise appends
     ``min(max_pos, cap)`` from :func:`resolve_sglang_context_cap`; only this
     flag is added.
+
+    Args:
+        server_args (str | None): The server-arg string to augment.
+        framework (str | None): Framework name; empty/unknown treated as sglang.
+        model_path (str | None): Model path used to read
+            ``max_position_embeddings``.
+        isl (int): Input sequence length.
+        osl (int): Output sequence length.
+
+    Returns:
+        str: ``server_args`` with ``--context-length`` appended, or unchanged
+        for non-sglang frameworks, when the flag is present, or when the model
+        window cannot be read.
     """
     args = str(server_args or "").strip()
     if server_args_env_name(framework) != "EXTRA_SGLANG_ARGS":
@@ -1176,6 +1343,14 @@ def _resolve_dual_chunk_backend(gpu_type: str | None = None) -> str:
     (e.g. operator override), return the canonical backend and let sglang
     raise the clear error rather than silently injecting triton which
     sglang also rejects.  Override via ``$HYPERLOOM_DUAL_CHUNK_BACKEND``.
+
+    Args:
+        gpu_type (str | None): Caller-known GPU type; accepted for parity but
+            the canonical backend is returned regardless.
+
+    Returns:
+        str: ``$HYPERLOOM_DUAL_CHUNK_BACKEND`` when set, else
+        ``dual_chunk_flash_attn``.
     """
     override = os.environ.get("HYPERLOOM_DUAL_CHUNK_BACKEND", "").strip()
     if override:
@@ -1202,6 +1377,18 @@ def inject_sglang_attention_backend(
     Returns ``server_args`` unchanged when: framework is not sglang, an
     ``--attention-backend`` is already pinned (operator wins), or the model
     config has no dual-chunk block (fail-safe: inject nothing).
+
+    Args:
+        server_args (str | None): The server-arg string to augment.
+        framework (str | None): Framework name; empty/unknown treated as sglang.
+        model_path (str | None): Model path checked for a dual-chunk config.
+        gpu_type (str | None): Caller-known GPU type; takes precedence over
+            autodetect.
+
+    Returns:
+        str: ``server_args`` with ``--attention-backend`` appended, or unchanged
+        for non-sglang frameworks, when already pinned, or for non-dual-chunk
+        models.
     """
     args = str(server_args or "").strip()
     if server_args_env_name(framework) != "EXTRA_SGLANG_ARGS":
@@ -1257,6 +1444,17 @@ def inject_sglang_moe_runner_backend(
     inject nothing). Otherwise appends the backend from
     ``$HYPERLOOM_SGLANG_MOE_RUNNER_BACKEND`` (default ``triton``); only this
     flag is added.
+
+    Args:
+        server_args (str | None): The server-arg string to augment.
+        framework (str | None): Framework name; empty/unknown treated as sglang.
+        model_path (str | None): Model path checked for Mixture-of-Experts.
+        gpu_type (str | None): Caller-known GPU type; used to gate AMD/ROCm.
+
+    Returns:
+        str: ``server_args`` with ``--moe-runner-backend`` appended, or unchanged
+        for non-sglang frameworks, when already pinned, off AMD/ROCm, or for
+        non-MoE models.
     """
     args = str(server_args or "").strip()
     if server_args_env_name(framework) != "EXTRA_SGLANG_ARGS":
@@ -1295,6 +1493,17 @@ def apply_runtime_benchmark_overrides(
     ``benchmark_script`` (must be pre-sanitized via :func:`sanitize_script_name`)
     force-selects a specific Magpie script, applied AFTER the
     ``gpu_type``-derived generic script so the operator pick wins.
+
+    Args:
+        bench (dict[str, Any]): The Magpie ``benchmark`` config to mutate.
+        model_path (str | None): Overrides ``benchmark.model`` when set.
+        gpu_type (str | None): Pins ``runner_type`` and the generic
+            ``{framework}_{gpu_type}.sh`` script.
+        benchmark_script (str | None): Pre-sanitized script name that
+            force-selects a Magpie script (applied last).
+
+    Returns:
+        dict[str, Any]: The mutated ``benchmark["envs"]`` mapping.
     """
     if model_path:
         bench["model"] = str(model_path)
@@ -1366,6 +1575,21 @@ def _build_variant_yaml(
     force-pins a script, applied last so the operator pick wins.
     ``server_lifecycle`` (``{cleanup, pid_dir, port}``) enables Magpie's
     persistent-server reuse so a paired round can re-attach to a hot server.
+
+    Args:
+        base_yaml_path (Path): Path to the base Magpie YAML to template from.
+        base_extra_args (str): Server args merged ahead of the variant's args.
+        variant (GridVariant): The variant whose flags/envs are applied.
+        output_subdir (Path): Directory the per-variant ``config.yaml`` is
+            written into.
+        model_path (str | None): Overrides ``benchmark.model`` when set.
+        gpu_type (str | None): Pins the generic ``{framework}_{gpu_type}.sh``.
+        benchmark_script (str | None): Pre-sanitized script name (applied last).
+        server_lifecycle (dict[str, Any] | None): ``{cleanup, pid_dir, port}``
+            enabling persistent-server reuse.
+
+    Returns:
+        Path: Path to the materialized per-variant ``config.yaml``.
     """
     with base_yaml_path.open(encoding="utf-8") as f:
         cfg = yaml.safe_load(f)
@@ -1432,6 +1656,11 @@ def _kill_stale_servers() -> None:
     hangs ~5 min on zmq / shared-mem conflicts. Called before every Magpie
     invocation. Uses /proc scan (not pgrep) to avoid clashing with test
     subprocess mocks. No-op in multi-node mode (servers live in RayJob pods).
+
+    Note:
+        Side-effecting and best-effort: it sends signals to matching processes
+        and unlinks stale shared-memory segments, swallowing errors. Returns
+        nothing.
     """
     from ._multi_node_env import is_multi_node
     if is_multi_node():
@@ -1553,6 +1782,20 @@ def _run_magpie(
     land in the per-task workspace, not ``/workspace/``. ``soft_deadline_sec``
     is the Fix-E overtime cap: the tree is reaped and a sentinel
     ``OVERTIME_KILL_RETURNCODE`` returned instead of raising ``TimeoutExpired``.
+
+    Args:
+        magpie_python (str): Python interpreter used to launch Magpie.
+        config_path (Path): Path to the per-variant Magpie config YAML.
+        output_dir (Path): Per-task output/workspace directory.
+        timeout_sec (int): Hard subprocess timeout in seconds.
+        cwd (str): Working directory for the Magpie subprocess.
+        result_dir (str | None): Pre-sanitized ``$RESULT_DIR`` override;
+            defaults to ``output_dir``.
+        soft_deadline_sec (float | None): Overtime soft deadline; reaps the tree
+            and returns ``OVERTIME_KILL_RETURNCODE``.
+
+    Returns:
+        tuple[int, str, str]: ``(returncode, stdout, stderr)``.
     """
     # Pre-clean lingering servers + shared memory (skip under pytest).
     if not os.environ.get("PYTEST_CURRENT_TEST"):
@@ -1633,6 +1876,27 @@ async def run_grid(
     ``server_lifecycle`` (``{cleanup, pid_dir, port}``) enables Magpie's
     persistent-server reuse so a paired warm round can re-attach to a hot
     server; None keeps the legacy boot-per-variant behaviour.
+
+    Args:
+        base_yaml_path (Path): Base Magpie YAML templated per variant.
+        base_extra_args (str): Server args merged ahead of each variant's args.
+        grid (list[GridVariant]): Variants to run, in order.
+        output_root (Path): Root directory for per-variant slots.
+        magpie_python (str | None): Python interpreter; auto-resolved when None.
+        cwd (str): Working directory for Magpie subprocesses.
+        variant_timeout_sec (int): Per-variant hard timeout in seconds.
+        keep_going_on_failure (bool): Continue the grid after a variant failure.
+        model_path (str | None): Forwarded to each variant's YAML render.
+        gpu_type (str | None): Forwarded to each variant's YAML render.
+        benchmark_script (str | None): Pre-sanitized Magpie script override.
+        result_dir (str | None): Pre-sanitized ``$RESULT_DIR`` override.
+        soft_deadline_sec (float | None): Overtime soft deadline per variant;
+            None/0 disables.
+        server_lifecycle (dict[str, Any] | None): ``{cleanup, pid_dir, port}``
+            enabling persistent-server reuse.
+
+    Returns:
+        list[VariantResult]: Per-variant results for every attempt, in order.
     """
     if not magpie_python:
         magpie_python = _resolve_magpie_python()
@@ -2060,6 +2324,16 @@ def pick_winners(
     falls back to ``MULTI_NODE_DEFAULT_KEEP_THRESHOLD_PCT`` (2.0%, the empirical
     cross-node noise floor) in multi-node mode, else
     ``SINGLE_NODE_DEFAULT_KEEP_THRESHOLD_PCT`` (1.0%).
+
+    Args:
+        results (list[VariantResult]): All variant results to filter.
+        baseline_tput (float): Baseline throughput the winners must beat.
+        keep_threshold_pct (float | None): Required percent improvement over
+            baseline; ``None`` resolves to the multi/single-node default.
+
+    Returns:
+        list[VariantResult]: Succeeded variants whose output throughput exceeds
+        the baseline-plus-threshold cutoff.
     """
     if keep_threshold_pct is None:
         from ._multi_node_env import is_multi_node
@@ -2105,6 +2379,13 @@ def _write_variant_abort_marker(
     "untested". This marker lets final-report / post-mortem tools count failed
     variants and find an explicit reason even after the log rotated. Failure
     to write it is non-fatal (log and continue).
+
+    Args:
+        slot (Path): Variant slot directory the marker is written into.
+        variant_name (str): Name of the aborted variant.
+        error_class (str): Short failure-classification tag.
+        error_summary (str): Error detail (truncated to 2000 chars).
+        extra_args (str): The variant's server args, recorded for context.
     """
     try:
         slot.mkdir(parents=True, exist_ok=True)

--- a/inference_optimizer/orchestrator/action_executors/_inferencex_patcher.py
+++ b/inference_optimizer/orchestrator/action_executors/_inferencex_patcher.py
@@ -69,6 +69,13 @@ def _discover_inferencex_roots(
     unpatched. Patches ALL discovered roots (deduped by resolved path):
     ``inferencex_path`` arg, ``$INFERENCEX_PATH``, ``$MAGPIE_DIR/InferenceX``.
     Returns ``[]`` when none resolve (callers fail-soft).
+
+    Args:
+        inferencex_path: Caller-provided override root to include in the scan.
+
+    Returns:
+        A deduped list of resolved InferenceX checkout directories, or ``[]``
+        when none resolve.
     """
     roots: list[Path] = []
     seen: set[Path] = set()
@@ -108,6 +115,13 @@ def _resolve_benchmark_lib_paths(
 ) -> list[Path]:
     """Return every existing ``<root>/benchmarks/benchmark_lib.sh`` to patch
     (one per :func:`_discover_inferencex_roots` root). ``[]`` = skip patching.
+
+    Args:
+        inferencex_path: Caller-provided override root to include in the scan.
+
+    Returns:
+        A list of existing ``benchmark_lib.sh`` paths, or ``[]`` when none
+        exist.
     """
     out: list[Path] = []
     for root in _discover_inferencex_roots(inferencex_path):
@@ -142,6 +156,12 @@ def _file_lock(lock_path: str) -> Iterator[None]:
 
     Falls through without exclusion if the lock file can't be opened; the
     atomic-replace path still guarantees no torn writes (idempotent).
+
+    Args:
+        lock_path: Filesystem path of the lock file to acquire exclusively.
+
+    Yields:
+        Control while the exclusive lock is held; the lock is released on exit.
     """
     try:
         fp = open(lock_path, "w")
@@ -258,6 +278,14 @@ def ensure_benchmark_lib_patched(
     Returns ``True`` when patched at exit, ``False`` (non-fatal) when the file
     is missing or the legacy line is absent. Concurrency-safe (flock +
     atomic rename; already-patched fast-path skips the lock).
+
+    Args:
+        inferencex_path: Caller-provided override root; defaults to env-based
+            discovery when ``None``.
+
+    Returns:
+        True when at least one discovered ``benchmark_lib.sh`` is patched (or
+        already patched), False when none could be patched.
     """
     sources = _resolve_benchmark_lib_paths(inferencex_path)
     if not sources:
@@ -301,6 +329,13 @@ def _resolve_benchmark_serving_paths(
     ``<root>/utils/bench_serving/benchmark_serving.py`` to patch (one per
     :func:`_discover_inferencex_roots` root, including Magpie's bundled copy
     per the #210 fix). Independent of the benchmark_lib.sh resolver.
+
+    Args:
+        inferencex_path: Caller-provided override root to include in the scan.
+
+    Returns:
+        A list of existing ``benchmark_serving.py`` paths, or ``[]`` when none
+        exist.
     """
     out: list[Path] = []
     for root in _discover_inferencex_roots(inferencex_path):
@@ -347,6 +382,13 @@ def _is_benchmark_serving_patched(src: Path) -> bool:
 def _apply_benchmark_serving_patch_atomic(src: Path) -> bool:
     """Rewrite the hardcoded ``extra_body=`` line to consult
     ``PROFILE_EXTRA_BODY`` first, via temp-file + atomic rename.
+
+    Args:
+        src: The ``benchmark_serving.py`` file to patch in place.
+
+    Returns:
+        True when the patched bytes were written, False when the legacy line
+        is missing or any IO step fails.
     """
     try:
         original = src.read_text(encoding="utf-8")
@@ -418,6 +460,14 @@ def ensure_benchmark_serving_patched(
     Returns ``True`` when patched at exit, ``False`` (non-fatal) when missing.
     Concurrency-safe; independent lock file from
     :func:`ensure_benchmark_lib_patched` so the two patches don't serialize.
+
+    Args:
+        inferencex_path: Caller-provided override root; defaults to env-based
+            discovery when ``None``.
+
+    Returns:
+        True when at least one discovered ``benchmark_serving.py`` is patched
+        (or already patched), False when none could be patched.
     """
     sources = _resolve_benchmark_serving_paths(inferencex_path)
     if not sources:

--- a/inference_optimizer/orchestrator/action_executors/_magpie_patcher.py
+++ b/inference_optimizer/orchestrator/action_executors/_magpie_patcher.py
@@ -145,6 +145,14 @@ def _resolve_benchmarker_path(magpie_dir: Path | str | None) -> Path | None:
 
     Returns ``None`` when unconfigured or missing on disk (callers skip
     patching).
+
+    Args:
+        magpie_dir: Magpie root override; falls back to ``$MAGPIE_DIR`` when
+            falsy.
+
+    Returns:
+        The resolved ``benchmarker.py`` path, or ``None`` when unconfigured or
+        absent on disk.
     """
     root: Path | None = None
     if magpie_dir:
@@ -162,7 +170,16 @@ def _resolve_benchmarker_path(magpie_dir: Path | str | None) -> Path | None:
 def _resolve_sglang_mi300x_script_path(
     magpie_dir: Path | str | None,
 ) -> Path | None:
-    """Resolve Magpie's generic SGLang MI300X benchmark script when present."""
+    """Resolve Magpie's generic SGLang MI300X benchmark script when present.
+
+    Args:
+        magpie_dir: Magpie root override; falls back to ``$MAGPIE_DIR`` when
+            falsy.
+
+    Returns:
+        The resolved ``sglang_mi300x.sh`` path, or ``None`` when unconfigured
+        or absent on disk.
+    """
     root: Path | None = None
     if magpie_dir:
         root = Path(magpie_dir)
@@ -182,6 +199,12 @@ def _file_lock(lock_path: str) -> Iterator[None]:
 
     Falls through without exclusion if the lock file can't be opened; the
     atomic-replace still guarantees no torn writes (idempotent).
+
+    Args:
+        lock_path: Filesystem path of the lock file to acquire exclusively.
+
+    Yields:
+        Control while the exclusive lock is held; the lock is released on exit.
     """
     try:
         fp = open(lock_path, "w")  # noqa: SIM115 — kept open across yield
@@ -227,6 +250,13 @@ def _extract_prepare_region(text: str) -> str:
     Scopes inline-atomic detection to one method body (header down to the next
     line indented at/below the header column) so an unrelated ``os.replace``
     can't masquerade as a fixed copy loop.
+
+    Args:
+        text: The full ``benchmarker.py`` source text to slice.
+
+    Returns:
+        The source slice covering the ``_prepare_benchmark_scripts`` method
+        body, or ``""`` when the header is absent.
     """
     start = text.find(_PREPARE_METHOD_MARKER)
     if start == -1:
@@ -251,6 +281,13 @@ def _upstream_is_already_atomic(text: str) -> bool:
     redundant). Either signal suffices: ``_copy_benchmark_script_atomic``
     present, or an inline ``tempfile.mkstemp(`` + ``os.replace(`` in the
     ``_prepare_benchmark_scripts`` body.
+
+    Args:
+        text: The full ``benchmarker.py`` source text to inspect.
+
+    Returns:
+        True when the cloned Magpie already copies scripts atomically (making
+        the #C1 patch redundant), False otherwise.
     """
     if _UPSTREAM_ATOMIC_HELPER in text:
         return True
@@ -344,12 +381,27 @@ def _apply_patch_atomic_reason(src: Path) -> str:
 
 def _apply_patch_atomic(src: Path) -> bool:
     """Bool wrapper over :func:`_apply_patch_atomic_reason`: True when the
-    atomic-copy race is closed (applied / already-patched / upstream-atomic)."""
+    atomic-copy race is closed (applied / already-patched / upstream-atomic).
+
+    Args:
+        src: The ``benchmarker.py`` file to patch in place.
+
+    Returns:
+        True when the atomic-copy race is closed, False on a genuine failure.
+    """
     return _apply_patch_atomic_reason(src) not in _ATOMIC_REASONS_GENUINE_FAILURE
 
 
 def _is_remote_trust_patched(src: Path) -> bool:
-    """Return whether the SGLang remote-client trust gate is already present."""
+    """Return whether the SGLang remote-client trust gate is already present.
+
+    Args:
+        src: The ``sglang_mi300x.sh`` file to inspect.
+
+    Returns:
+        True iff the remote-trust sentinel is present, False on a miss or read
+        error.
+    """
     try:
         return _REMOTE_TRUST_SENTINEL in src.read_text(encoding="utf-8")
     except OSError as e:
@@ -358,7 +410,16 @@ def _is_remote_trust_patched(src: Path) -> bool:
 
 
 def _apply_remote_trust_patch_atomic(src: Path) -> bool:
-    """Patch ``sglang_mi300x.sh`` so remote clients can pass trust mode."""
+    """Patch ``sglang_mi300x.sh`` so remote clients can pass trust mode.
+
+    Args:
+        src: The ``sglang_mi300x.sh`` file to patch in place.
+
+    Returns:
+        True when the trust gate is present after the call (already patched or
+        freshly written), False when the legacy block is missing or any IO
+        step fails.
+    """
     try:
         original = src.read_text(encoding="utf-8")
     except OSError as e:
@@ -439,7 +500,12 @@ class MagpiePatchStatus:
     def atomic_genuine_failure(self) -> bool:
         """True when ``atomic_ok`` is False for a real reason (unrecognized
         shape / I/O error) — i.e. the script-tearing race is NOT mitigated, as
-        opposed to a benign no-op. A strict install should fail-loud on this."""
+        opposed to a benign no-op. A strict install should fail-loud on this.
+
+        Returns:
+            True when the atomic-copy patch failed for a genuine reason
+            (unrecognized shape / I/O error), False for a benign no-op.
+        """
         return self.atomic_reason in _ATOMIC_REASONS_GENUINE_FAILURE
 
 
@@ -451,6 +517,14 @@ def magpie_scripts_patch_status(
     This keeps a drift in the optional SGLang remote-client trust patch from
     being reported as a generic atomic-copy failure. The bool-valued
     ``ensure_magpie_atomic_scripts_patch`` wrapper remains for compatibility.
+
+    Args:
+        magpie_dir: Magpie root override; falls back to ``$MAGPIE_DIR`` when
+            falsy.
+
+    Returns:
+        A ``MagpiePatchStatus`` carrying the atomic-copy and remote-trust
+        outcomes plus the classified ``atomic_reason``.
     """
     src = _resolve_benchmarker_path(magpie_dir)
     if src is None:
@@ -515,6 +589,14 @@ def ensure_magpie_atomic_scripts_patch(
     without the atomic race being open, so it is intentionally NOT folded in
     here; callers that need both must use :func:`magpie_scripts_patch_status`
     and check ``remote_trust_ok`` / ``ok`` (install.sh does this).
+
+    Args:
+        magpie_dir: Magpie root override; falls back to ``$MAGPIE_DIR`` when
+            falsy.
+
+    Returns:
+        True when the atomic-copy race is closed, False when the file is
+        missing or neither the legacy block nor an atomic impl is found.
     """
     return magpie_scripts_patch_status(magpie_dir).atomic_ok
 

--- a/inference_optimizer/orchestrator/action_executors/_magpie_patcher.py
+++ b/inference_optimizer/orchestrator/action_executors/_magpie_patcher.py
@@ -427,6 +427,12 @@ class MagpiePatchStatus:
 
     @property
     def ok(self) -> bool:
+        """Whether the patch result is fully successful.
+
+        Returns:
+            ``True`` only when both the atomic write and remote-trust
+            checks succeeded.
+        """
         return self.atomic_ok and self.remote_trust_ok
 
     @property

--- a/inference_optimizer/orchestrator/action_executors/_multi_node_env.py
+++ b/inference_optimizer/orchestrator/action_executors/_multi_node_env.py
@@ -64,6 +64,9 @@ def is_multi_node() -> bool:
     State file wins over env so ``--resume`` works (manifest.json doesn't
     persist ``nodes``): ``/tmp/multi_node_state.json`` ``nodes`` >= 2 wins;
     else fall back to ``$INFERENCE_OPTIMIZER_NODES``.
+
+    Returns:
+        True when operating on a >=2-node RayJob cluster, else False.
     """
     state = _read_state()
     try:
@@ -102,6 +105,9 @@ def rayjob_id_from_state() -> str:
     Reads the ``$MULTI_NODE_STATE_FILE`` checkpoint. Used to scope per-RayJob
     shared artefacts when ``$HYPERLOOM_MN_PROFILE_TRACE_DIR`` was not exported
     in-process.
+
+    Returns:
+        The SaFE-allocated RayJob workload id, or ``""`` if absent.
     """
     return str(_read_state().get("rayjob_id") or "").strip()
 
@@ -123,6 +129,10 @@ def magpie_remote_env() -> dict[str, str]:
     "BENCHMARK_BASE_URL": "<service_url>"}`` so Magpie skips its local server
     launch and points ``benchmark_serving`` at the head pod. Multi-node without
     a state file: ``{}`` + WARN (the local-launch failure surfaces clearly).
+
+    Returns:
+        Env vars to inject into the Magpie subprocess, or ``{}`` for the
+        single-node path or when no service URL is available.
     """
     if not is_multi_node():
         return {}
@@ -165,6 +175,12 @@ def log_mn_banner(
     Multi-node prints ``[MN component=<name> nodes=N head=<ip>
     service_url=<url> key=value ...]``; ``**extra`` keys are appended for
     round-specific context (e.g. ``trace_dir=`` / ``variant=``).
+
+    Args:
+        component: Name of the component emitting the banner.
+        target_log: Logger the banner line is written to.
+        **extra: Round-specific key/value context appended to the banner;
+            keys with empty or None values are skipped.
     """
     if not is_multi_node():
         return

--- a/inference_optimizer/orchestrator/action_executors/_multi_node_env.py
+++ b/inference_optimizer/orchestrator/action_executors/_multi_node_env.py
@@ -107,6 +107,10 @@ def dynamo_ssh_env_from_state() -> dict[str, str]:
     Returns ``{}`` for the RayJob backend and single-node so the Ray placement
     path (``ray_gcs_address_from_state`` / ``RAY_ADDRESS``) is left untouched —
     this is the isolation seam that keeps the SSH path Dynamo-only.
+
+    Returns:
+        A ``{KERNEL_AGENT_GPU_PLACEMENT, MN_SSH_HOST/PORT/KEY}`` mapping for the
+        Dynamo backend when a GPU pod IP and ssh key are known, else ``{}``.
     """
     state = _read_state()
     if state.get("backend") != "dynamo":

--- a/inference_optimizer/orchestrator/action_executors/_multi_node_server_lifecycle.py
+++ b/inference_optimizer/orchestrator/action_executors/_multi_node_server_lifecycle.py
@@ -50,6 +50,12 @@ def _merge_sglang_defaults(extra_args: str) -> str:
 
     Mirrors ``sglang_mi300x.sh:74-79``; a caller's explicit value for a flag
     wins and that default is dropped.
+
+    Args:
+        extra_args: The caller's existing server-arg string.
+
+    Returns:
+        The merged server-arg string with missing defaults appended.
     """
     user = (extra_args or "").strip()
     parts = [user] if user else []
@@ -94,6 +100,24 @@ def _resolve_pd_args(
     Resolution per field: explicit kwarg > ``state["last_restart_pd_*"]`` >
     ``$PD_*`` env > defaults (mode=colocated, prefill/decode TP=tp). Validates
     ``pd_mode`` and disaggregated prefill/decode TP.
+
+    Args:
+        pd_mode: Prefill/decode mode (``colocated`` or ``disaggregated``).
+        pd_prefill_nodes: Node count for the prefill group.
+        pd_decode_nodes: Node count for the decode group.
+        pd_prefill_tp: Tensor-parallel size for the prefill group.
+        pd_decode_tp: Tensor-parallel size for the decode group.
+        pd_transfer_backend: KV transfer backend name.
+        pd_ib_device: InfiniBand device name.
+        tp_int: Resolved overall tensor-parallel size used as a TP default.
+
+    Returns:
+        A flat dict of resolved PD values for the multi_node CLI Namespace.
+
+    Raises:
+        ServerRestartFailed: If ``pd_mode`` is unsupported, the cluster has
+            fewer than 2 nodes for disaggregated mode, the prefill/decode node
+            split is invalid, or the prefill/decode TP values are non-positive.
     """
     state = _read_state()
     mode = (
@@ -202,8 +226,19 @@ def _resolve_round_args(
 
     Resolution per field: explicit kwarg > ``state["last_restart_*"]`` >
     ``$FRAMEWORK`` / ``$MODEL_PATH`` / ``$TP`` / ``$EP`` env > defaults (ep=1).
-    Raises :class:`ServerRestartFailed` if model/tp are empty, framework is
-    unsupported, or ``ep > tp``.
+
+    Args:
+        framework: Inference framework override (``sglang`` or ``vllm``).
+        model_path: Model path/id override.
+        tp: Tensor-parallel size override.
+        ep: Expert-parallel size override (defaults to 1).
+
+    Returns:
+        A ``(framework, model, tp, ep)`` tuple of resolved restart args.
+
+    Raises:
+        ServerRestartFailed: If model/tp are empty, the framework is
+            unsupported, or ``ep > tp``.
     """
     state = _read_state()
     fw = (framework or state.get("last_restart_framework")
@@ -274,7 +309,29 @@ async def restart_server_for_round(
     this invocation so a fresh kill+launch runs — required after kernel-agent
     fans patched source so sglang re-imports the new modules.
 
-    Raises :class:`ServerRestartFailed` on any failure (callers let it bubble).
+    Args:
+        extra_server_args: Extra framework server args for this round.
+        torch_profiler_dir: Per-round profiler trace dir; exported via
+            ``HYPERLOOM_MN_PROFILE_TRACE_DIR`` and restored afterward.
+        framework: Inference framework override.
+        model_path: Model path/id override.
+        tp: Tensor-parallel size override.
+        ep: Expert-parallel size override.
+        pd_mode: Prefill/decode mode override.
+        pd_prefill_nodes: Node count for the prefill group.
+        pd_decode_nodes: Node count for the decode group.
+        pd_prefill_tp: Tensor-parallel size for the prefill group.
+        pd_decode_tp: Tensor-parallel size for the decode group.
+        pd_transfer_backend: KV transfer backend name.
+        pd_ib_device: InfiniBand device name.
+        health_timeout_s: Timeout for the post-launch /health poll.
+        poll_interval_s: Poll interval passed to the restart driver.
+        force_full_restart: When True, force a fresh kill+launch instead of
+            resuming a running server.
+
+    Raises:
+        ServerRestartFailed: On any restart or post-launch /health failure
+            (callers let it bubble).
     """
     global _LAST_ROUND_TRACE_DIR
 
@@ -488,6 +545,14 @@ async def _wait_for_server_health_async(
 
     Reads ``service_url`` from ``state.json``; rewrites a ClusterIP DNS URL to
     ``head_pod_ip`` when available so the sandbox can reach it directly.
+
+    Args:
+        timeout_s: Maximum seconds to wait for a 200 from /health.
+        poll_every_s: Seconds between successive /health polls.
+
+    Raises:
+        ServerRestartFailed: If /health does not return 200 within
+            ``timeout_s``.
     """
     import time as _time
     import re as _re

--- a/inference_optimizer/orchestrator/action_executors/_multi_node_server_lifecycle.py
+++ b/inference_optimizer/orchestrator/action_executors/_multi_node_server_lifecycle.py
@@ -590,7 +590,14 @@ DEFAULT_DYN_SYSTEM_PORT = 9090
 
 
 def _dynamo_gpu_pod_ips(state: dict | None = None) -> list[str]:
-    """Return the dynamo GPU worker pod IPs (prefill + decode + worker)."""
+    """Return the dynamo GPU worker pod IPs (prefill + decode + worker).
+
+    Args:
+        state: Pre-read state mapping, or ``None`` to read ``state.json``.
+
+    Returns:
+        The deduplicated prefill + decode + worker pod IPs, in that order.
+    """
     st = state if state is not None else (_read_state() or {})
     ips: list[str] = []
     seen: set[str] = set()
@@ -622,6 +629,11 @@ async def trigger_dynamo_engine_profile(
     JSON payload to ``start_profile`` (e.g. the optimizer-computed
     ``PROFILE_EXTRA_BODY`` carrying start_step / num_steps); ignored for
     stop.
+
+    Args:
+        action: ``"start"`` or ``"stop"`` — selects the engine profile route.
+        body: Optional JSON payload forwarded to ``start_profile``; ignored
+            for ``stop``.
     """
     if not is_multi_node():
         return

--- a/inference_optimizer/orchestrator/action_executors/_robustness_pulse.py
+++ b/inference_optimizer/orchestrator/action_executors/_robustness_pulse.py
@@ -31,6 +31,14 @@ _OFF_VALUES = frozenset({"0", "false", "no", "off", ""})
 
 
 def _enabled() -> bool:
+    """Whether the robustness pulse should run.
+
+    Disabled under pytest (the pulse spawns a real subprocess that
+    bypasses test mocks) and via ``HYPERLOOM_GRID_ROBUSTNESS_PULSE``.
+
+    Returns:
+        ``True`` if the pulse is enabled in the current environment.
+    """
     # Disable inside pytest — the pulse spawns a real subprocess that bypasses
     # test mocks. Mirrors ``_run_magpie``'s guard.
     if os.environ.get("PYTEST_CURRENT_TEST"):

--- a/inference_optimizer/orchestrator/action_executors/_server_lifecycle.py
+++ b/inference_optimizer/orchestrator/action_executors/_server_lifecycle.py
@@ -57,6 +57,14 @@ def resolve_lifecycle_params(materialized_config_path: Path) -> dict[str, Any]:
     ``port`` (int) and ``reason`` (str, populated when ineligible).
     Reuse is single-node only, requires a Magpie built-in script, and is
     incompatible with torch_profiler.
+
+    Args:
+        materialized_config_path: Path to the materialized benchmark YAML to
+            inspect.
+
+    Returns:
+        A dict with ``eligible`` (bool), ``framework`` (str), ``port`` (int)
+        and ``reason`` (str, populated when ineligible).
     """
     info: dict[str, Any] = {
         "eligible": False,
@@ -111,6 +119,13 @@ def inject_lifecycle(
 
     Both rounds share ``pid_dir`` + ``port`` so round 2 re-attaches; only
     ``cleanup`` differs (round 1 persists, round 2 tears down).
+
+    Args:
+        bench: The benchmark config dict to mutate in place.
+        cleanup: Whether this round tears the server down (``False`` for round
+            1, ``True`` for round 2).
+        pid_dir: Shared directory for the server pid/meta files.
+        port: HTTP port pinned for the persistent server.
     """
     ready_timeout = int(os.environ.get(
         "INFERENCE_OPTIMIZER_BASELINE_SERVER_READY_SEC",
@@ -135,6 +150,11 @@ def teardown_lifecycle_server(
 
     Idempotent and never raises (safe in ``finally``); a no-op on the happy
     path, real work only on abnormal paths.
+
+    Args:
+        pid_dir: Directory holding the server pid/meta files.
+        framework: Framework name used to key the pid/meta filenames.
+        port: HTTP port used to key the pid/meta filenames.
     """
     base = Path(pid_dir)
     tag = f"{framework}_{port}"

--- a/inference_optimizer/orchestrator/action_executors/_server_patcher.py
+++ b/inference_optimizer/orchestrator/action_executors/_server_patcher.py
@@ -65,6 +65,13 @@ def _load_sglang_supported_versions_from_manifest(
 
     Returns ``None`` when no manifest exists (the common case today; a
     forward-compatible hook), or a frozenset of versions (empty = reject all).
+
+    Args:
+        patches_dir: SGLang patches directory that may ship the manifest.
+
+    Returns:
+        A frozenset of supported version strings, or ``None`` when no manifest
+        exists or it could not be read.
     """
     for name in _SGLANG_SUPPORTED_VERSIONS_MANIFEST_NAMES:
         manifest = patches_dir / name
@@ -101,6 +108,14 @@ def _sglang_version_accepted(
     ``$HYPERLOOM_SGLANG_PATCH_ALLOWED_MINORS`` (minor prefixes, ``0.5`` matches
     ``0.5.9`` not ``0.50.0``) > TraceLens ``SUPPORTED_VERSIONS`` manifest in
     ``patches_dir`` > :data:`_SGLANG_DEFAULT_ALLOWED_MINORS`.
+
+    Args:
+        version: The SGLang version string to test.
+        patches_dir: Optional patches directory consulted for the TraceLens
+            ``SUPPORTED_VERSIONS`` manifest.
+
+    Returns:
+        True iff ``version`` is accepted by the resolved allowlist.
     """
     text = (version or "").strip()
     if not text:
@@ -138,7 +153,15 @@ _PATCH_TREE_REL = ("examples", "custom_workflows", "inference_analysis")
 def _versioned_patches_subdir_name(version: str) -> str | None:
     """Map ``sglang.__version__`` to the per-version patch subdir name (e.g.
     ``0.5.11`` -> ``sglang_0_5_11``). Returns ``None`` when ``version`` has no
-    dotted numeric head."""
+    dotted numeric head.
+
+    Args:
+        version: The ``sglang.__version__`` string to map.
+
+    Returns:
+        The per-version patch subdir name, or ``None`` when ``version`` has no
+        dotted numeric head.
+    """
     text = (version or "").strip()
     if not text:
         return None
@@ -165,6 +188,13 @@ def _resolve_sglang_patches_dir(
     Requires the per-version subdir layout (``sglang_0_5_11/``, ...); the flat
     v0.3 layout is unsupported. Returns the subdir when it exists and has at
     least one ``*.patch``, else ``None`` (caller fail-softs).
+
+    Args:
+        patches_root: Root directory holding the per-version patch subdirs.
+        version: The running ``sglang`` version string.
+
+    Returns:
+        The resolved patches subdir, or ``None`` when it is missing or empty.
     """
     subdir_name = _versioned_patches_subdir_name(version)
     if subdir_name is None:
@@ -186,6 +216,14 @@ def ensure_vllm_patched_for_tracelens(
 
     Returns ``True`` when patched at exit, ``False`` on any fail-soft outcome
     (callers MUST then skip the TraceLens-only profiler flags).
+
+    Args:
+        tracelens_root: TraceLens checkout root; falls back to
+            ``$TRACELENS_ROOT`` when ``None``.
+
+    Returns:
+        True if the vLLM install is in patched state at exit, False on any
+        fail-soft outcome.
     """
     plan = _discover_vllm_plan(tracelens_root)
     if plan is None:
@@ -240,7 +278,16 @@ class _PatchPlan:
 
 def _resolve_tracelens_root(arg: Path | str | None) -> Path | None:
     """Resolve TRACELENS_ROOT from arg → env → None; fail-soft when unset or
-    missing on disk."""
+    missing on disk.
+
+    Args:
+        arg: Explicit TraceLens root override, or ``None`` to read
+            ``$TRACELENS_ROOT``.
+
+    Returns:
+        The resolved TraceLens root directory, or ``None`` when unset or
+        missing on disk.
+    """
     if arg:
         root = Path(arg)
     else:
@@ -462,6 +509,13 @@ def _resolve_sglang_apply_root(sglang_module: Path) -> tuple[Path, int] | None:
     Editable (``<repo>/python/sglang/``): ``(repo_root, 1)``. Wheel
     (``site-packages/sglang/`` with no ``python/`` parent):
     ``(<site-packages>/sglang, 3)``. Anything else: ``None`` (fail-soft).
+
+    Args:
+        sglang_module: Resolved path to the imported ``sglang`` package file.
+
+    Returns:
+        An ``(apply_root, strip_count)`` tuple, or ``None`` when the install
+        layout is unrecognized.
     """
     if sglang_module.parent.parent.name == "python":
         return sglang_module.parent.parent.parent, 1
@@ -500,7 +554,15 @@ def _ensure_patched(plan: _PatchPlan) -> bool:
 
 def _is_patched(plan: _PatchPlan) -> bool:
     """True iff the sentinel file (and every extra_sentinel) exists with all of
-    its marker substrings present. The all-of-N rule lowers false positives."""
+    its marker substrings present. The all-of-N rule lowers false positives.
+
+    Args:
+        plan: The resolved patch plan whose sentinels are inspected.
+
+    Returns:
+        True when every sentinel file exists with all required markers, False
+        otherwise (including on read error).
+    """
     try:
         if not plan.sentinel_file.exists():
             return False
@@ -523,7 +585,14 @@ def _is_patched(plan: _PatchPlan) -> bool:
 @contextmanager
 def _file_lock(path: str) -> Iterator[None]:
     """Best-effort cross-process exclusion; proceeds unsynchronized if ``/tmp``
-    is read-only (the second patcher re-checks the sentinel and short-circuits)."""
+    is read-only (the second patcher re-checks the sentinel and short-circuits).
+
+    Args:
+        path: Filesystem path of the lock file to acquire exclusively.
+
+    Yields:
+        Control while the exclusive lock is held; the lock is released on exit.
+    """
     try:
         fp = open(path, "w")
     except OSError as e:
@@ -549,6 +618,13 @@ def _apply_atomic(plan: _PatchPlan) -> bool:
     ``git apply --check`` every patch first (any failure → apply none); then
     apply one at a time, reverse-applying the already-applied ones if a later
     patch fails.
+
+    Args:
+        plan: The resolved patch plan to apply as a transaction.
+
+    Returns:
+        True when every patch is applied (or already applied), False on any
+        precheck/apply failure (with already-applied patches rolled back).
     """
     git = shutil.which("git")
     if git is None:
@@ -678,6 +754,15 @@ def _patch_dry_run(
     Fuzzy fallback (zero side effects) when ``git apply --check`` rejects a
     patch for minor context drift. ``strip`` matches git apply's ``-p<N>``.
     See :data:`_FUZZ`.
+
+    Args:
+        patch_bin: Path to the ``patch`` executable.
+        patch_file: The patch file to dry-run.
+        cwd: Working directory the patch is tested relative to.
+        strip: The ``-p<N>`` strip count.
+
+    Returns:
+        True iff the dry-run exits with return code 0.
     """
     try:
         with patch_file.open("rb") as fh:

--- a/inference_optimizer/orchestrator/action_executors/_server_patcher.py
+++ b/inference_optimizer/orchestrator/action_executors/_server_patcher.py
@@ -761,6 +761,13 @@ def _rollback_applied(
     Used both when a later patch fails mid-transaction and when the post-apply
     sentinel check rejects an otherwise-clean apply, so ``_apply_atomic`` never
     leaves the framework tree modified while returning ``False``.
+
+    Args:
+        applied: The ``(patch, mode)`` pairs already applied, in apply order.
+        plan: The resolved patch plan (provides ``apply_root`` / strip).
+        git: Path to the ``git`` executable.
+        patch_bin: Path to the ``patch`` executable, or ``None``.
+        strip_arg: The ``-p<N>`` strip argument string.
     """
     for prev, prev_mode in reversed(applied):
         if prev_mode == "git":
@@ -834,6 +841,15 @@ def _patch_reverse_dry_run(
     Symmetric counterpart to :func:`_patch_dry_run` for detecting patches
     that were previously applied via fuzzy ``patch`` (where ``git apply -R
     --check`` would fail due to fuzz-shifted hunks).
+
+    Args:
+        patch_bin: Path to the ``patch`` executable.
+        patch_file: The patch file to reverse dry-run.
+        cwd: Working directory the patch is tested relative to.
+        strip: The ``-p<N>`` strip count.
+
+    Returns:
+        True iff the reverse dry-run exits with return code 0.
     """
     try:
         with patch_file.open("rb") as fh:

--- a/inference_optimizer/orchestrator/action_executors/_subprocess_kill.py
+++ b/inference_optimizer/orchestrator/action_executors/_subprocess_kill.py
@@ -201,6 +201,12 @@ class _StreamCapture:
     """Capture child output while mirroring each line to the parent stream."""
 
     def __init__(self, proc: subprocess.Popen, *, text: bool) -> None:
+        """Set up capture/mirror threads for a child's stdout and stderr.
+
+        Args:
+            proc: The child process whose pipes should be captured.
+            text: Whether the pipes are in text (``str``) or bytes mode.
+        """
         self._text = text
         self._stdout_chunks: list[str | bytes] = []
         self._stderr_chunks: list[str | bytes] = []
@@ -219,10 +225,20 @@ class _StreamCapture:
             ))
 
     def start(self) -> None:
+        """Start the capture threads."""
         for thread in self._threads:
             thread.start()
 
     def finish(self, timeout: float = 2.0) -> tuple[str | bytes, str | bytes]:
+        """Join the capture threads and return the captured output.
+
+        Args:
+            timeout: Per-thread join timeout in seconds.
+
+        Returns:
+            A ``(stdout, stderr)`` tuple of the captured streams (``str`` or
+            ``bytes`` depending on the capture mode).
+        """
         for thread in self._threads:
             thread.join(timeout=timeout)
         empty: str | bytes = "" if self._text else b""
@@ -232,9 +248,24 @@ class _StreamCapture:
         )
 
     def _join(self, chunks: list[str | bytes]) -> str | bytes:
+        """Concatenate captured chunks using the appropriate empty separator.
+
+        Args:
+            chunks: Captured stdout or stderr chunks.
+
+        Returns:
+            The joined ``str`` or ``bytes`` output.
+        """
         return "".join(chunks) if self._text else b"".join(chunks)  # type: ignore[arg-type,return-value]
 
     def _pump(self, pipe, chunks: list[str | bytes], mirror) -> None:
+        """Read a pipe line-by-line, capturing and mirroring each line.
+
+        Args:
+            pipe: The child pipe to read from.
+            chunks: List that read chunks are appended to.
+            mirror: Parent stream the chunks are echoed to.
+        """
         try:
             while True:
                 chunk = pipe.readline()
@@ -249,6 +280,12 @@ class _StreamCapture:
                 pass
 
     def _mirror(self, chunk: str | bytes, mirror) -> None:
+        """Echo a captured chunk to the parent stream, ignoring errors.
+
+        Args:
+            chunk: The captured ``str``/``bytes`` chunk.
+            mirror: Parent stream to write to.
+        """
         try:
             if isinstance(chunk, bytes):
                 stream = getattr(mirror, "buffer", mirror)
@@ -466,6 +503,13 @@ class _ServerDeadDetected(Exception):
     def __init__(
         self, *, marker: str, grace_sec: float, elapsed_sec: float,
     ) -> None:
+        """Build the error message describing the hung-after-death condition.
+
+        Args:
+            marker: Log marker that indicated the server init died.
+            grace_sec: Grace period the parent was allowed after the marker.
+            elapsed_sec: Actual wall-clock elapsed at trip time.
+        """
         super().__init__(
             f"server init died (marker={marker!r}) and parent hung past "
             f"grace {grace_sec:.1f}s (elapsed={elapsed_sec:.1f}s)"

--- a/inference_optimizer/orchestrator/action_executors/_subprocess_kill.py
+++ b/inference_optimizer/orchestrator/action_executors/_subprocess_kill.py
@@ -33,6 +33,10 @@ _TERM_GRACE_SECONDS = 5.0
 def new_session_kwargs() -> dict:
     """``Popen`` kwargs so the child gets its own POSIX session (killable via
     ``os.killpg``). Returns ``{}`` on non-POSIX.
+
+    Returns:
+        A kwargs dict to splat into ``Popen``; ``{"start_new_session": True}``
+        on POSIX, otherwise an empty dict.
     """
     if os.name == "posix":
         return {"start_new_session": True}
@@ -44,6 +48,13 @@ def _process_group_alive(pgid: int) -> bool:
 
     ``killpg(pgid, 0)`` raises ``ProcessLookupError`` once the group is empty;
     any other ``OSError`` (e.g. sandbox ``EPERM``) is treated as "still alive".
+
+    Args:
+        pgid: The POSIX process-group id to probe.
+
+    Returns:
+        True if the group still has at least one member (or liveness is
+        indeterminate), False once the group is empty or on non-POSIX.
     """
     if os.name != "posix":
         return False
@@ -88,6 +99,12 @@ def kill_my_spawned_server(
     warning on unexpected signalling failure). Requires the child to have been
     launched with :func:`new_session_kwargs` so its pgid is distinct from
     Hyperloom's own; asserted defensively below.
+
+    Args:
+        proc: The spawned process whose tree should be reaped; ``None`` is a
+            no-op.
+        grace_seconds: Seconds to wait after SIGTERM before SIGKILLing
+            survivors.
     """
     if proc is None:
         return
@@ -306,6 +323,13 @@ def _server_log_shows_death(path: str) -> bool:
 
     Best-effort and never raises: a missing / unreadable log (server hasn't
     written yet) reads as "not dead" so a slow cold start is never misjudged.
+
+    Args:
+        path: Filesystem path to the server's ``server.log``.
+
+    Returns:
+        True if the log tail contains a terminal engine/worker-init marker,
+        False otherwise (including when the log is missing or unreadable).
     """
     try:
         with open(path, "rb") as fh:
@@ -330,6 +354,15 @@ def server_log_death_excerpt(path: str, *, max_chars: int = 1200) -> str | None:
     excerpt keeps a couple of lines of context around the marker so the
     operator-facing ``error`` field is actionable. Best-effort: a missing /
     unreadable log reads as "no marker" (returns ``None``).
+
+    Args:
+        path: Filesystem path to the server's ``server.log``.
+        max_chars: Maximum length of the returned excerpt; the tail is kept
+            when the excerpt is longer.
+
+    Returns:
+        A short multi-line excerpt around the first terminal init marker, or
+        ``None`` when no fatal marker is present.
     """
     try:
         with open(path, "rb") as fh:
@@ -385,6 +418,30 @@ def run_with_session_kill(
     ``returncode = SERVER_DEAD_RETURNCODE`` is returned (does NOT raise). This
     turns a crashed-but-hung server (parent never exits, ``/health`` polled
     forever) into a fast fail instead of a ~2h hard-timeout stall.
+
+    Args:
+        cmd: The command and arguments to execute.
+        env: Optional environment mapping for the child process.
+        cwd: Optional working directory for the child process.
+        timeout: Hard timeout in seconds; ``TimeoutExpired`` is re-raised on
+            elapse, as with ``subprocess.run``.
+        text: Whether to capture stdout/stderr as ``str`` (vs ``bytes``).
+        soft_deadline_sec: Optional deadline firing before ``timeout``; on
+            elapse the tree is reaped and ``OVERTIME_KILL_RETURNCODE`` is
+            returned without raising.
+        server_log_path: Optional path to the spawned server's ``server.log``
+            to enable the server-liveness watchdog.
+        server_dead_grace_sec: Grace period a terminal init marker must persist
+            before the watchdog reaps the tree; defaults to the
+            ``INFERENCE_OPTIMIZER_SERVER_DEAD_GRACE_SEC`` env value or 120s.
+
+    Returns:
+        A ``CompletedProcess`` carrying the child's returncode (or one of the
+        sentinel returncodes when a soft deadline or the watchdog fired) plus
+        its captured stdout/stderr.
+
+    Raises:
+        subprocess.TimeoutExpired: When the hard ``timeout`` elapses.
     """
     if server_dead_grace_sec is None:
         try:
@@ -542,6 +599,28 @@ def _communicate_with_soft_deadline(
 
     The ``hard_timeout`` is always honoured so a stuck child can't dodge the
     gates.
+
+    Args:
+        proc: The running child process to wait on.
+        hard_timeout: Hard timeout in seconds; always enforced.
+        soft_deadline_sec: Optional soft deadline that trips before the hard
+            timeout.
+        server_log_path: Optional path to the server's ``server.log`` enabling
+            the liveness watchdog.
+        server_dead_grace_sec: Grace period a terminal init marker must persist
+            before the watchdog trips.
+        capture: Optional stream capture whose threads are joined to assemble
+            the returned output.
+
+    Returns:
+        A ``(stdout, stderr)`` tuple (``str`` or ``bytes`` per the capture
+        mode).
+
+    Raises:
+        _SoftDeadlineExceeded: When the soft deadline elapses.
+        _ServerDeadDetected: When a terminal init marker persists past the
+            grace window.
+        subprocess.TimeoutExpired: When the hard timeout elapses.
     """
     watchdog_active = bool(server_log_path) and (
         server_dead_grace_sec is not None and float(server_dead_grace_sec) > 0.0

--- a/inference_optimizer/orchestrator/action_executors/_workload_envs.py
+++ b/inference_optimizer/orchestrator/action_executors/_workload_envs.py
@@ -62,6 +62,9 @@ def _visible_gpu_count() -> int:
     tests happy), falls back to ``rocm-smi --showid``. Returns 0 on every
     failure so callers skip the clamp. Override via
     ``$INFERENCE_OPTIMIZER_VISIBLE_GPU_COUNT``.
+
+    Returns:
+        The number of visible GPUs, or 0 when none/unknown.
     """
     override = os.environ.get("INFERENCE_OPTIMIZER_VISIBLE_GPU_COUNT", "").strip()
     if override:
@@ -107,6 +110,9 @@ def _tracelens_patch_enabled() -> bool:
     Set ``HYPERLOOM_ENABLE_PATCH=0`` to disable runtime patching of vLLM /
     SGLang (keeps today's safe behaviour, no TraceLens-only flags injected).
     Default on because the patches are backward-compatible.
+
+    Returns:
+        True when runtime patching is enabled (default), else False.
     """
     return os.environ.get("HYPERLOOM_ENABLE_PATCH", "1").strip() != "0"
 
@@ -156,7 +162,23 @@ def materialize_config_with_envs(
     ``$INFERENCEX_PATH`` for existing callers). ``extra_server_args`` routes
     into the framework env; ``extra_envs`` overrides any of the above.
 
-    Returns the materialized YAML path (stable file name across calls).
+    Args:
+        config_path: Path to the source Magpie YAML to render.
+        output_dir: Directory the materialized YAML is written into.
+        extra_server_args: Extra framework server args merged into the env.
+        extra_envs: Overrides applied last over any computed env values.
+        model_path: Model path/id; overrides ``benchmark.model`` when set.
+        gpu_type: GPU type; sets ``runner_type`` and pins the generic script.
+        inferencex_path: Explicit InferenceX checkout to pin into the YAML.
+        benchmark_script: Pre-sanitized benchmark script name to re-pin.
+        out_name: File name for the materialized YAML.
+
+    Returns:
+        The materialized YAML path (stable file name across calls).
+
+    Raises:
+        FrameworkScriptMismatchError: If ``benchmark_script`` targets a
+            different known framework than the run's framework.
     """
     server_args = (extra_server_args or "").strip()
     with config_path.open(encoding="utf-8") as f:

--- a/inference_optimizer/orchestrator/action_executors/baseline.py
+++ b/inference_optimizer/orchestrator/action_executors/baseline.py
@@ -139,6 +139,12 @@ def _path_fstype(path: str) -> str:
     Picks the longest mountpoint that is a prefix of the resolved path.
     Returns ``""`` when it cannot be determined (non-Linux, unreadable
     ``/proc/mounts``, ...), which callers treat as "assume local".
+
+    Args:
+        path: The filesystem path to classify.
+
+    Returns:
+        The filesystem type string, or ``""`` when it cannot be determined.
     """
     try:
         rp = os.path.realpath(path)
@@ -172,7 +178,14 @@ def _path_fstype(path: str) -> str:
 
 
 def _is_network_fs(path: str) -> bool:
-    """True when ``path`` is backed by a revocable network filesystem."""
+    """True when ``path`` is backed by a revocable network filesystem.
+
+    Args:
+        path: The filesystem path to classify.
+
+    Returns:
+        True when ``path`` is backed by a known network filesystem type.
+    """
     return _path_fstype(path).lower() in _NETWORK_FS_TYPES
 
 
@@ -188,6 +201,12 @@ def _mirror_lock(lock_path: str) -> Iterator[None]:
     wait for the winner and then overwrite a consistent tree. Degrades to no
     exclusion when ``fcntl`` is unavailable (non-Linux) or the lock file
     cannot be opened — the unique staging dir still prevents torn copies.
+
+    Args:
+        lock_path: Filesystem path of the lock file to acquire exclusively.
+
+    Yields:
+        Control while the exclusive lock is held; the lock is released on exit.
     """
     try:
         import fcntl
@@ -238,6 +257,15 @@ def _ensure_local_inferencex(src: str, *, mirror_key: str = "") -> str:
     materialized YAML first) patches the LOCAL mirror in place — the mirror
     therefore ends up carrying the NUM_PROMPTS / PROFILE_EXTRA_BODY patches,
     and Magpie ``cd``-s into the patched local copy.
+
+    Args:
+        src: The InferenceX checkout path to mirror.
+        mirror_key: Optional caller-supplied key (e.g. task output dir) that
+            isolates concurrent tasks sharing the same source checkout.
+
+    Returns:
+        A local-disk mirror path, or ``src`` unchanged when relocation is
+        disabled, unnecessary, or fails.
     """
     src = str(src)
     if os.environ.get(
@@ -325,6 +353,10 @@ def _resolve_aiter_jit_dir_dynamic() -> list[str]:
     pre-built ``.so``); the legacy fixed ``jit/build`` list mis-reports
     every wheel install as COLD. Returns an ordered candidate list
     (``jit`` preferred over ``jit/build``); empty if aiter not found.
+
+    Returns:
+        An ordered list of candidate ``jit`` directory paths, or ``[]`` when
+        aiter is not importable.
     """
     try:
         spec = importlib.util.find_spec("aiter")
@@ -458,6 +490,13 @@ class BaselineExecutor:
 
         Order: ``task.params['output_dir']`` → ``ctx.extra['workspace']``
         → ``runs_dir(...)`` (direct-instantiation fallback for tests).
+
+        Args:
+            ctx: The runner context carrying task params and ``extra``.
+            action: The action name used to build the fallback runs dir.
+
+        Returns:
+            The resolved per-task workspace directory.
         """
         params = ctx.task.params or {}
         if params.get("output_dir"):
@@ -474,6 +513,12 @@ class BaselineExecutor:
         when the aiter jit probe reports COLD (env-overridable via
         ``INFERENCE_OPTIMIZER_COLD_START_TIMEOUT_SEC``) → warm default.
         Every path emits one log line for greppability.
+
+        Args:
+            params: The task params, optionally carrying ``timeout_sec``.
+
+        Returns:
+            The resolved subprocess timeout in seconds.
         """
         explicit = params.get("timeout_sec")
         if explicit:
@@ -524,6 +569,14 @@ class BaselineExecutor:
 
         ProfileExecutor uses this to patch/validate the InferenceX checkout
         named by the rendered YAML. No-op default keeps baseline unchanged.
+
+        Args:
+            config_path: The materialized Magpie YAML config path.
+            output_dir: The per-task output directory.
+
+        Returns:
+            ``None`` to proceed with the launch, or a failure result dict to
+            short-circuit (subclasses only).
         """
         return None
 
@@ -777,6 +830,12 @@ class BaselineExecutor:
 
         Returns a dict with ``eligible`` (bool), ``framework`` (str),
         ``port`` (int) and ``reason`` (str, populated when ineligible).
+
+        Args:
+            materialized_config_path: The materialized YAML config to inspect.
+
+        Returns:
+            A dict with ``eligible``, ``framework``, ``port`` and ``reason``.
         """
         info: dict[str, Any] = {
             "eligible": False,
@@ -836,6 +895,16 @@ class BaselineExecutor:
 
         Both rounds share ``pid_dir`` + ``port`` so round 2 re-attaches;
         only ``cleanup`` differs (round 1 persists, round 2 tears down).
+
+        Args:
+            base_config_path: The base materialized YAML to extend.
+            dest_dir: Directory the per-round YAML is written into.
+            cleanup: Whether this round tears down the persistent server.
+            pid_dir: Shared directory keying the persistent server pid/meta.
+            port: HTTP port pinned for the persistent server.
+
+        Returns:
+            The path to the rendered per-round lifecycle YAML.
         """
         with Path(base_config_path).open(encoding="utf-8") as f:
             cfg = yaml.safe_load(f) or {}
@@ -866,6 +935,11 @@ class BaselineExecutor:
         """Best-effort teardown of a persistent server left by the
         double-run rounds. Idempotent and never raises (safe in finally);
         a no-op on the happy path, real work only on abnormal paths.
+
+        Args:
+            pid_dir: Directory holding the persistent server pid/meta files.
+            framework: Framework name used to key the pid/meta filenames.
+            port: HTTP port used to key the pid/meta filenames.
         """
         base = Path(pid_dir)
         tag = f"{framework}_{port}"
@@ -923,6 +997,22 @@ class BaselineExecutor:
 
         Single-round core extracted from ``__call__`` so the cold-start
         guard can invoke it twice. ``output_dir`` is the per-round slot.
+
+        Args:
+            config_path: The materialized Magpie YAML config to run.
+            output_dir: The per-round output directory.
+            timeout_sec: Hard subprocess timeout in seconds.
+            override_result_dir: Optional ``$RESULT_DIR`` override, or ``None``.
+            resolved_model: The resolved model path (may be empty).
+            materialized_config_path: The canonical materialized config path
+                surfaced in the result for downstream reuse.
+            inferencex_path: The InferenceX checkout path Magpie should use.
+            params: The task params forwarded to server restart logic.
+            ctx: The runner context (carries ``extra`` flags).
+
+        Returns:
+            A result dict (``status="succeeded"`` with measurements, or
+            ``status="failed"`` with an ``error_class``).
         """
         cmd = [
             self.magpie_python, "-m", "Magpie", "-v", "benchmark",

--- a/inference_optimizer/orchestrator/action_executors/baseline.py
+++ b/inference_optimizer/orchestrator/action_executors/baseline.py
@@ -759,6 +759,13 @@ class BaselineExecutor:
 
     @staticmethod
     def _double_run_enabled() -> bool:
+        """Whether baseline double-run is enabled.
+
+        Controlled by ``INFERENCE_OPTIMIZER_BASELINE_DOUBLE_RUN``.
+
+        Returns:
+            ``True`` unless the env var is set to a falsey value.
+        """
         return os.environ.get(
             "INFERENCE_OPTIMIZER_BASELINE_DOUBLE_RUN", "1",
         ).strip().lower() not in ("0", "false", "no", "")

--- a/inference_optimizer/orchestrator/action_executors/baseline.py
+++ b/inference_optimizer/orchestrator/action_executors/baseline.py
@@ -121,6 +121,13 @@ def _is_cuda_graph_capture_failure(*texts: str) -> bool:
     carry neither OOM nor a compile/lowering error, both unrecoverable by
     disabling cuda-graph. Strong wins on a line that also matches weak, so the
     compile/OOM whole-blob gate never demotes a genuine stream-capture failure.
+
+    Args:
+        *texts: Log / stdout / stderr blobs to scan for cuda-graph markers.
+
+    Returns:
+        ``True`` when a cuda-graph capture failure recoverable by disabling
+        cuda-graph capture is detected, else ``False``.
     """
     lines = "\n".join(t for t in texts if t).splitlines()
     lowered = [ln.lower() for ln in lines]
@@ -152,7 +159,16 @@ _DISABLE_CUDA_GRAPH_FLAGS = {
 
 
 def _disable_cuda_graph_flag(framework: str) -> str:
-    """Return the framework-correct flag that disables cuda-graph capture."""
+    """Return the framework-correct flag that disables cuda-graph capture.
+
+    Args:
+        framework: Framework name (e.g. ``"sglang"`` or ``"vllm"``); matched
+            case-insensitively.
+
+    Returns:
+        The disable-cuda-graph flag for ``framework``, defaulting to
+        ``--disable-cuda-graph`` for unknown frameworks.
+    """
     return _DISABLE_CUDA_GRAPH_FLAGS.get(
         (framework or "").strip().lower(), "--disable-cuda-graph",
     )
@@ -163,6 +179,14 @@ def _with_cuda_graph_disabled(extra_server_args: str, framework: str) -> str:
 
     Token-level dedup so a longer flag (e.g. ``--disable-cuda-graph-extra``)
     is not mistaken for an existing ``--disable-cuda-graph``.
+
+    Args:
+        extra_server_args: Existing extra server args string (may be empty).
+        framework: Framework name used to pick the correct disable flag.
+
+    Returns:
+        ``extra_server_args`` with the framework-correct disable-cuda-graph
+        flag appended once; unchanged when the flag is already present.
     """
     flag = _disable_cuda_graph_flag(framework)
     if flag in (extra_server_args or "").split():
@@ -174,7 +198,16 @@ def _classify_subprocess_error(
     elapsed_sec: float, stderr_tail: str,
 ) -> str:
     """Return 'fast_exit_arg_error' when the subprocess died fast on an arg
-    validation error, else 'subprocess_nonzero'."""
+    validation error, else 'subprocess_nonzero'.
+
+    Args:
+        elapsed_sec: Subprocess wall-clock runtime in seconds.
+        stderr_tail: Tail of the subprocess stderr used for marker matching.
+
+    Returns:
+        ``"fast_exit_arg_error"`` for a fast exit caused by argument
+        validation, else ``"subprocess_nonzero"``.
+    """
     if elapsed_sec >= FAST_EXIT_THRESHOLD_SEC:
         return "subprocess_nonzero"
     tail = stderr_tail.lower()
@@ -242,6 +275,13 @@ def _path_fstype(path: str) -> str:
     Picks the longest mountpoint that is a prefix of the resolved path.
     Returns ``""`` when it cannot be determined (non-Linux, unreadable
     ``/proc/mounts``, ...), which callers treat as "assume local".
+
+    Args:
+        path: Filesystem path whose backing mount type is resolved.
+
+    Returns:
+        The filesystem type backing ``path``, or ``""`` when it cannot be
+        determined.
     """
     try:
         rp = os.path.realpath(path)
@@ -275,7 +315,14 @@ def _path_fstype(path: str) -> str:
 
 
 def _is_network_fs(path: str) -> bool:
-    """True when ``path`` is backed by a revocable network filesystem."""
+    """True when ``path`` is backed by a revocable network filesystem.
+
+    Args:
+        path: Filesystem path to classify.
+
+    Returns:
+        ``True`` when ``path`` lives on a known network filesystem type.
+    """
     return _path_fstype(path).lower() in _NETWORK_FS_TYPES
 
 
@@ -291,6 +338,13 @@ def _mirror_lock(lock_path: str) -> Iterator[None]:
     wait for the winner and then overwrite a consistent tree. Degrades to no
     exclusion when ``fcntl`` is unavailable (non-Linux) or the lock file
     cannot be opened — the unique staging dir still prevents torn copies.
+
+    Args:
+        lock_path: Path to the lock file used for cross-process exclusion.
+
+    Yields:
+        None: Control is yielded to the caller while the lock is held (or
+        immediately, when no exclusion could be acquired).
     """
     try:
         import fcntl
@@ -341,6 +395,15 @@ def _ensure_local_inferencex(src: str, *, mirror_key: str = "") -> str:
     materialized YAML first) patches the LOCAL mirror in place — the mirror
     therefore ends up carrying the NUM_PROMPTS / PROFILE_EXTRA_BODY patches,
     and Magpie ``cd``-s into the patched local copy.
+
+    Args:
+        src: Source InferenceX checkout path (typically on a network mount).
+        mirror_key: Optional key isolating concurrent tasks that share the
+            same source checkout; folded into the mirror destination name.
+
+    Returns:
+        A local-disk mirror path when relocation succeeds, otherwise ``src``
+        unchanged (relocation disabled, already local, or copy failed).
     """
     src = str(src)
     if os.environ.get(
@@ -428,6 +491,10 @@ def _resolve_aiter_jit_dir_dynamic() -> list[str]:
     pre-built ``.so``); the legacy fixed ``jit/build`` list mis-reports
     every wheel install as COLD. Returns an ordered candidate list
     (``jit`` preferred over ``jit/build``); empty if aiter not found.
+
+    Returns:
+        An ordered list of candidate aiter ``jit/`` directory paths, or an
+        empty list when aiter cannot be located.
     """
     try:
         spec = importlib.util.find_spec("aiter")
@@ -566,6 +633,13 @@ class BaselineExecutor:
 
         Order: ``task.params['output_dir']`` → ``ctx.extra['workspace']``
         → ``runs_dir(...)`` (direct-instantiation fallback for tests).
+
+        Args:
+            ctx: Runner context carrying ``task.params`` and ``extra``.
+            action: Action name used when falling back to ``runs_dir(...)``.
+
+        Returns:
+            The resolved per-task workspace directory.
         """
         params = ctx.task.params or {}
         if params.get("output_dir"):
@@ -581,6 +655,13 @@ class BaselineExecutor:
         Used to keep the flag armed when the framework is unknown (cannot pick
         a safe disable-cuda-graph flag), so the one-shot is not wasted.
         Best-effort: missing/unreadable state reads as not armed.
+
+        Args:
+            shared_state: Optional live SharedState; falls back to
+                ``self.shared_state`` and then a loaded session state.
+
+        Returns:
+            ``True`` when the one-shot eager-fallback flag is currently armed.
         """
         try:
             state = shared_state or self.shared_state
@@ -600,6 +681,14 @@ class BaselineExecutor:
 
         Returns True (and clears the flag) when a prior baseline armed it.
         Best-effort: missing/unreadable state reads as no fallback.
+
+        Args:
+            shared_state: Optional live SharedState; falls back to
+                ``self.shared_state`` and then a loaded session state.
+
+        Returns:
+            ``True`` when the flag was armed (and is now cleared), else
+            ``False``.
         """
         try:
             state = shared_state or self.shared_state
@@ -625,6 +714,13 @@ class BaselineExecutor:
         when the aiter jit probe reports COLD (env-overridable via
         ``INFERENCE_OPTIMIZER_COLD_START_TIMEOUT_SEC``) → warm default.
         Every path emits one log line for greppability.
+
+        Args:
+            params: Task params; an explicit ``timeout_sec`` overrides the
+                probe-based selection.
+
+        Returns:
+            The subprocess timeout in seconds for this baseline launch.
         """
         explicit = params.get("timeout_sec")
         if explicit:
@@ -675,6 +771,14 @@ class BaselineExecutor:
 
         ProfileExecutor uses this to patch/validate the InferenceX checkout
         named by the rendered YAML. No-op default keeps baseline unchanged.
+
+        Args:
+            config_path: The materialized Magpie YAML config path.
+            output_dir: The per-task workspace directory.
+
+        Returns:
+            An early-return result dict to short-circuit the launch, or
+            ``None`` to proceed with the baseline run.
         """
         return None
 
@@ -961,7 +1065,15 @@ class BaselineExecutor:
     def _resolve_lifecycle_params(
         self, materialized_config_path: Path,
     ) -> dict[str, Any]:
-        """Inspect the materialized YAML for server_lifecycle eligibility."""
+        """Inspect the materialized YAML for server_lifecycle eligibility.
+
+        Args:
+            materialized_config_path: The materialized Magpie YAML config path.
+
+        Returns:
+            Lifecycle params including eligibility, framework, port and the
+            reason a run is ineligible.
+        """
         return _lifecycle.resolve_lifecycle_params(materialized_config_path)
 
     def _write_lifecycle_config(
@@ -977,6 +1089,17 @@ class BaselineExecutor:
 
         Both rounds share ``pid_dir`` + ``port`` so round 2 re-attaches;
         only ``cleanup`` differs (round 1 persists, round 2 tears down).
+
+        Args:
+            base_config_path: Source materialized YAML to clone and patch.
+            dest_dir: Directory the per-round YAML is written into.
+            cleanup: Whether the server should be torn down after the round.
+            pid_dir: Shared pid/metadata directory keying the persistent
+                server across both rounds.
+            port: Server port shared across both rounds.
+
+        Returns:
+            Path to the written per-round lifecycle YAML.
         """
         with Path(base_config_path).open(encoding="utf-8") as f:
             cfg = yaml.safe_load(f) or {}
@@ -992,7 +1115,16 @@ class BaselineExecutor:
 
     @staticmethod
     def _port_healthy(port: int, timeout: float = 3.0) -> bool:
-        """Return True when localhost:{port}/health responds HTTP 200."""
+        """Return True when localhost:{port}/health responds HTTP 200.
+
+        Args:
+            port: Local server port to probe.
+            timeout: Per-request timeout in seconds.
+
+        Returns:
+            ``True`` when the health endpoint responds HTTP 200, else
+            ``False``.
+        """
         import urllib.request
         try:
             r = urllib.request.urlopen(
@@ -1013,6 +1145,11 @@ class BaselineExecutor:
         calls _kill_stale_servers() to reap the orphan listener. Stale
         pid/json files are always unlinked (without sending signals to
         potentially-recycled PIDs). Never raises.
+
+        Args:
+            pid_dir: Directory holding the server pid/metadata files.
+            framework: Framework name used to build the server tag.
+            port: Server port used to build the server tag.
         """
         base = Path(pid_dir)
         tag = f"{framework}_{port}"
@@ -1056,6 +1193,11 @@ class BaselineExecutor:
     ) -> None:
         """Best-effort teardown of a persistent server left by the
         double-run rounds. Idempotent and never raises (safe in finally).
+
+        Args:
+            pid_dir: Directory holding the server pid/metadata files.
+            framework: Framework name used to build the server tag.
+            port: Server port used to build the server tag.
         """
         _lifecycle.teardown_lifecycle_server(
             pid_dir=pid_dir, framework=framework, port=port,
@@ -1079,6 +1221,28 @@ class BaselineExecutor:
 
         Single-round core extracted from ``__call__`` so the cold-start
         guard can invoke it twice. ``output_dir`` is the per-round slot.
+
+        Args:
+            config_path: The materialized Magpie YAML config for this round.
+            output_dir: The per-round workspace slot.
+            timeout_sec: Subprocess timeout in seconds.
+            override_result_dir: Optional ``$RESULT_DIR`` override for the
+                benchmark wrapper.
+            resolved_model: Resolved model path for the run.
+            materialized_config_path: The canonical materialized YAML, echoed
+                into the result for downstream reuse.
+            inferencex_path: Task-local InferenceX checkout path pinned via
+                ``MAGPIE_INFERENCEX_PATH``.
+            effective_extra_server_args: Extra server args passed to the
+                multi-node restart helper.
+            params: Task params for this launch.
+            ctx: Runner context carrying ``extra`` (e.g. multi-node round
+                state).
+
+        Returns:
+            A result dict: ``status="succeeded"`` with measurements on
+            success, or ``status="failed"`` with an ``error_class`` on
+            failure.
         """
         cmd = [
             self.magpie_python, "-m", "Magpie", "-v", "benchmark",

--- a/inference_optimizer/orchestrator/action_executors/benchmark_result.py
+++ b/inference_optimizer/orchestrator/action_executors/benchmark_result.py
@@ -173,6 +173,14 @@ def _rescue_candidate_paths(
     When ``subprocess_started_unix`` is given, candidates older than it
     (minus :data:`_MTIME_GATE_SLACK_SEC`) are dropped as stale prior-run
     leaks. Never raises: per-candidate I/O errors are swallowed.
+
+    Args:
+        workspace: The per-task workspace; in-workspace files are skipped.
+        subprocess_started_unix: Optional launch time used to drop stale
+            prior-run leaks.
+
+    Returns:
+        Absolute paths to fresh, out-of-workspace Magpie leak destinations.
     """
     candidates: list[Path] = []
     seen: set[Path] = set()
@@ -247,6 +255,14 @@ def _materialize_rescue_into_workspace(
     self-contained. Returns the destination on success, or ``None`` on I/O
     error (caller falls back to the leak path) or when the source already
     lives inside the workspace.
+
+    Args:
+        rescue_path: The leaked InferenceX result file to copy in.
+        workspace: The per-task workspace to copy the result into.
+
+    Returns:
+        The in-workspace destination path on success, or ``None`` on I/O error
+        or when the source already lives inside the workspace.
     """
     try:
         rescue_resolved = rescue_path.resolve()
@@ -277,6 +293,13 @@ def _resolve_leak_roots(leak_root: Path | None) -> tuple[Path, ...]:
     Order: explicit ``leak_root`` kwarg (tests) →
     ``$INFERENCE_OPTIMIZER_LEAK_ROOTS`` (colon-separated) →
     :data:`_DEFAULT_LEAK_ARTIFACT_ROOT` (``/workspace``).
+
+    Args:
+        leak_root: Optional explicit root override (used by tests); when
+            ``None`` the env var or default is used.
+
+    Returns:
+        A tuple of directory roots to scan for wrapper-side leak files.
     """
     if leak_root is not None:
         return (leak_root,)
@@ -303,6 +326,17 @@ def harvest_leaked_artifacts(
     ``shutil.copy2``-s each match (source never moved). Returns
     ``(leak_path, copy_path)`` tuples for audit; never raises (per-artifact
     errors are isolated).
+
+    Args:
+        destination: Directory the harvested artifacts are copied into.
+        subprocess_started_unix: Optional launch time used to skip stale
+            prior-run leaks.
+        leak_root: Optional explicit root override forwarded to
+            :func:`_resolve_leak_roots`.
+        extra_globs: Additional filename globs to harvest beyond the defaults.
+
+    Returns:
+        A list of ``(leak_path, copy_path)`` tuples for the artifacts copied.
     """
     harvested: list[tuple[Path, Path]] = []
     leak_roots = _resolve_leak_roots(leak_root)
@@ -440,6 +474,17 @@ def extract_benchmark_measurement(
     ``subprocess_started_unix`` enables an opt-in salvage pass over the
     Magpie leak destinations (see :func:`_rescue_candidate_paths`) when the
     in-workspace search fails; only leaks written after this run are adopted.
+
+    Args:
+        report: The Magpie ``benchmark_report.json`` mapping, or ``None``.
+        workspace: Optional task workspace scanned for raw InferenceX results
+            and (as a fallback) salvageable leaks.
+        subprocess_started_unix: Optional launch time enabling the mtime-gated
+            leak salvage pass.
+
+    Returns:
+        A normalized measurement dict (including ``valid_measurement`` and any
+        ``nonfatal_warnings``).
     """
     report = report or {}
     throughput = report.get("throughput") or {}
@@ -533,6 +578,11 @@ def _derive_tpot_if_missing(
     Best-effort: only derives when end-to-end and TTFT latencies are
     available and an output sequence length greater than 1 can be
     resolved from the report. Leaves the field untouched otherwise.
+
+    Args:
+        measurement: The measurement dict to fill in place.
+        report: The Magpie report mapping used to resolve the output sequence
+            length, or ``None``.
     """
     if measurement.get("tpot_mean_ms") is not None:
         return
@@ -547,7 +597,14 @@ def _derive_tpot_if_missing(
 
 
 def _resolve_osl(report: dict[str, Any] | None) -> int | None:
-    """Pull the output sequence length from common report locations."""
+    """Pull the output sequence length from common report locations.
+
+    Args:
+        report: The Magpie report mapping to search, or ``None``.
+
+    Returns:
+        The first positive output sequence length found, or ``None``.
+    """
     if not isinstance(report, dict):
         return None
     candidates: list[Any] = [report.get("osl"), report.get("output_len")]

--- a/inference_optimizer/orchestrator/action_executors/benchmark_result.py
+++ b/inference_optimizer/orchestrator/action_executors/benchmark_result.py
@@ -744,7 +744,14 @@ def _find_server_logs(slot: Path) -> list[Path]:
         return []
 
     def _size(path: Path) -> int:
-        """Best-effort byte size used to rank candidate logs (0 on error)."""
+        """Best-effort byte size used to rank candidate logs (0 on error).
+
+        Args:
+            path: The log file whose byte size to read.
+
+        Returns:
+            The file size in bytes, or ``0`` on stat error.
+        """
         try:
             return path.stat().st_size
         except OSError:

--- a/inference_optimizer/orchestrator/action_executors/conc_sweep.py
+++ b/inference_optimizer/orchestrator/action_executors/conc_sweep.py
@@ -33,6 +33,15 @@ class ConcSweepExecutor:
     """ActionRunner for ``conc_sweep``. See module docstring."""
 
     async def __call__(self, ctx) -> dict[str, Any]:
+        """Run the concurrency sweep action for the given context.
+
+        Args:
+            ctx: Action context; ``ctx.extra['session_dir']`` is required.
+
+        Returns:
+            A result dict with a ``status`` field (and error metadata on
+            failure, such as a missing ``session_dir``).
+        """
         extra = getattr(ctx, "extra", None) or {}
         session_dir_str = str(extra.get("session_dir") or "").strip()
         if not session_dir_str:

--- a/inference_optimizer/orchestrator/action_executors/explore.py
+++ b/inference_optimizer/orchestrator/action_executors/explore.py
@@ -123,6 +123,12 @@ def _coerce_args_str(value: Any) -> str:
     ``vllm serve ... $EXTRA_VLLM_ARGS`` splices verbatim, so the server rejects
     it as ``unrecognized arguments`` and every server-arg variant aborts.
     Lists/tuples are space-joined into individual tokens.
+
+    Args:
+        value: The raw payload value (string, list/tuple, or None).
+
+    Returns:
+        The coerced shell-arg string ("" when ``value`` is None).
     """
     if value is None:
         return ""
@@ -150,6 +156,12 @@ def _grid_variants_from_payload(payload: list[Any]) -> list[GridVariant]:
 
     Unknown keys ignored; unstamped ``provenance`` defaults to
     ``'default_grid'`` (keeps seed grids distinct from ``'llm_direct'``).
+
+    Args:
+        payload: List of variant dicts from the LLM/specialist grid.
+
+    Returns:
+        The parsed ``GridVariant`` objects (entries without a name skipped).
     """
     out: list[GridVariant] = []
     for raw in payload or []:
@@ -207,6 +219,15 @@ def _atom_default_grid(
     ``apply_compatibility_filter`` is the second-line drop for flags not in
     ``atom --help``. Variant names are ``atom_``-prefixed for cross-session
     disambiguation.
+
+    Args:
+        model_class: Model-class label that gates which variants are emitted.
+        conc: Live concurrency used to bracket cudagraph capture sizes.
+        isl: Input sequence length (reserved for future gating).
+        osl: Output sequence length (reserved for future gating).
+
+    Returns:
+        The curated list of atom ``GridVariant`` seeds.
     """
     mc_l = (model_class or "").strip().lower()
     is_moe = "moe" in mc_l
@@ -287,6 +308,16 @@ def _default_grid_for_framework(
 
     Atom returns a curated seed grid; sglang / vllm / unknown return ``[]``
     ("no programmatic seed") and rely on LLM-emitted ``default_grid`` variants.
+
+    Args:
+        framework: Inference framework name to dispatch on.
+        model_class: Model-class label forwarded to the seed grid builder.
+        conc: Live concurrency forwarded to the seed grid builder.
+        isl: Input sequence length forwarded to the seed grid builder.
+        osl: Output sequence length forwarded to the seed grid builder.
+
+    Returns:
+        The framework's default ``GridVariant`` seeds, or ``[]`` when none.
     """
     fw = (framework or "").strip().lower()
     if fw == "atom":

--- a/inference_optimizer/orchestrator/action_executors/explore.py
+++ b/inference_optimizer/orchestrator/action_executors/explore.py
@@ -767,6 +767,19 @@ class ExploreExecutor:
         gain_unlockable = {"REVERT", "KEEP_UNSTABLE", "no_promote"}
 
         def _is_blocked(entry: Any) -> bool:
+            """Whether a tested-ledger entry should still be skipped this round.
+
+            KEEP'd and infra-failed entries stay blocked; gain-unlockable
+            outcomes (REVERT / KEEP_UNSTABLE / no_promote) unblock once the
+            current KEEP bar drops to or below their prior measured gain.
+
+            Args:
+                entry (Any): A ``tested`` ledger entry (expected dict).
+
+            Returns:
+                bool: ``True`` when the variant should remain skipped, ``False``
+                when it may be re-tested this round.
+            """
             if not isinstance(entry, dict):
                 return True
             if str(entry.get("outcome") or "") in gain_unlockable:

--- a/inference_optimizer/orchestrator/action_executors/framework_pr.py
+++ b/inference_optimizer/orchestrator/action_executors/framework_pr.py
@@ -103,7 +103,15 @@ DEFAULT_DIFF_FETCH_TIMEOUT_SEC: float = 30.0
 # resets HEAD to the pre-apply sha so a failed REJECT can't clobber prior KEEPs.
 def _git_head_sha(framework_root: Path) -> tuple[str | None, str]:
     """``git rev-parse HEAD`` in ``framework_root``; ``(sha, stderr)``,
-    sha None on failure."""
+    sha None on failure.
+
+    Args:
+        framework_root: The git checkout to read HEAD from.
+
+    Returns:
+        A ``(sha, stderr)`` tuple; ``sha`` is ``None`` on failure with the
+        error text in ``stderr``.
+    """
     cmd = ["git", "-C", str(framework_root), "rev-parse", "HEAD"]
     try:
         cp = subprocess.run(
@@ -119,7 +127,16 @@ def _git_head_sha(framework_root: Path) -> tuple[str | None, str]:
 def _git_reset_hard(framework_root: Path, sha: str) -> tuple[bool, str]:
     """Revert ``framework_root`` to ``sha``: ``git reset --hard`` +
     ``git clean -fd`` (discards untracked files the candidate added) so a
-    failed candidate can't leak state into the next candidate's baseline."""
+    failed candidate can't leak state into the next candidate's baseline.
+
+    Args:
+        framework_root: The git checkout to reset.
+        sha: The commit sha to reset ``--hard`` to.
+
+    Returns:
+        A ``(ok, stderr)`` tuple; ``ok`` is False on failure with the error
+        text in ``stderr``.
+    """
     cmd = ["git", "-C", str(framework_root), "reset", "--hard", sha]
     try:
         cp = subprocess.run(
@@ -147,7 +164,16 @@ def _git_commit_keep(
     """``git add -A && git commit`` with a forced hyperloom identity (``-c``,
     Magpie clones may lack user.email), returning the new HEAD sha. ``add -A``
     (not ``commit -am``) so add-only PRs' new files land in the KEEP commit
-    instead of polluting the next candidate's baseline."""
+    instead of polluting the next candidate's baseline.
+
+    Args:
+        framework_root: The git checkout to commit into.
+        message: The commit message for the KEEP commit.
+
+    Returns:
+        A ``(new_sha, stderr)`` tuple; ``new_sha`` is ``None`` on failure with
+        the error text in ``stderr``.
+    """
     add = ["git", "-C", str(framework_root), "add", "-A"]
     try:
         cp_add = subprocess.run(
@@ -180,7 +206,15 @@ def _git_commit_keep(
 
 def _candidate_slug(candidate: dict[str, Any]) -> str:
     """Filesystem-safe candidate id (variant names + paths). Prefer
-    ``repo/pr_number``."""
+    ``repo/pr_number``.
+
+    Args:
+        candidate: The PR metadata row.
+
+    Returns:
+        A filesystem-safe slug derived from the candidate's repo / pr_number
+        / ref.
+    """
     repo = str(candidate.get("repo") or "").replace("/", "-")
     pr = candidate.get("pr_number")
     if repo and pr not in (None, "", 0):
@@ -196,7 +230,17 @@ def _fetch_diff_to_path(
 ) -> tuple[bool, str]:
     """Curl ``diff_url`` into ``dest`` (.patch path); returns ``(ok, stderr)``.
     Uses curl (not aiohttp) for consistent HTTPS_PROXY behaviour in
-    restricted-network sessions."""
+    restricted-network sessions.
+
+    Args:
+        diff_url: The unified-diff URL to download.
+        dest: Destination ``.patch`` path to write.
+        timeout_sec: Per-request curl timeout in seconds.
+
+    Returns:
+        A ``(ok, stderr)`` tuple; ``ok`` is False on failure with the error
+        text in ``stderr``.
+    """
     dest.parent.mkdir(parents=True, exist_ok=True)
     cmd = [
         "curl", "-fsSL", "--retry", "2", "--max-time",
@@ -244,7 +288,14 @@ def _run_git(
 
 def _normalize_repo_id(url_or_slug: str) -> str:
     """Reduce a repo URL / slug to a canonical lowercase ``owner/name`` token.
-    Tolerates https, ssh, and bare ``Owner/Name`` forms."""
+    Tolerates https, ssh, and bare ``Owner/Name`` forms.
+
+    Args:
+        url_or_slug: A repo URL or slug in any supported form.
+
+    Returns:
+        The canonical lowercase ``owner/name`` token, or ``""`` when empty.
+    """
     s = (url_or_slug or "").strip().lower()
     if not s:
         return ""
@@ -270,7 +321,16 @@ def _candidate_is_same_repo(
     resolve the wrong ref).
 
     Fails OPEN when inconclusive (no candidate repo, unreadable / non-GitHub
-    origin); only fires when both sides yield differing ``owner/name`` tokens."""
+    origin); only fires when both sides yield differing ``owner/name`` tokens.
+
+    Args:
+        candidate: The PR metadata row (carries the candidate repo).
+        framework_root: The live framework checkout whose origin is compared.
+
+    Returns:
+        True unless the candidate is positively proven to live in a different
+        repo than ``framework_root``'s origin.
+    """
     cand_repo = _normalize_repo_id(
         str(candidate.get("repo") or candidate.get("discovered_repo_url") or "")
     )
@@ -307,6 +367,16 @@ def _materialize_pr_diff_via_worktree(
 
     Head ref order: ``candidate.head_sha`` → ``candidate.ref`` →
     ``refs/pull/<pr_number>/head``.
+
+    Args:
+        framework_root: The live framework checkout to fetch the PR head into.
+        candidate: The PR metadata row (head_sha / ref / pr_number).
+        dest: Destination ``.patch`` path the net diff is written to.
+        timeout_sec: Per-git-operation timeout in seconds.
+
+    Returns:
+        A ``(ok, err)`` tuple; ``ok`` is False on failure with the error text
+        in ``err``.
     """
     dest.parent.mkdir(parents=True, exist_ok=True)
     root = str(framework_root)
@@ -858,6 +928,14 @@ class FrameworkPrExecutor:
 
         Best-effort: candidates lacking both ``pr_url`` and ``head_sha``
         (no dedup key) are skipped; write errors are logged + swallowed.
+
+        Args:
+            candidate: The PR metadata row (provides the dedup key).
+            outcome: The outcome label to record (e.g. integrated / reverted).
+            tps_delta_pct: The measured throughput delta percentage.
+            patch_path: Path to the applied patch (for provenance).
+            extra: The runner ``extra`` mapping (provides the shared state /
+                session id).
         """
         pr_url = str(candidate.get("pr_url") or "").strip()
         pr_sha = str(candidate.get("head_sha") or "").strip()
@@ -900,6 +978,15 @@ class FrameworkPrExecutor:
         <pre_apply_sha>`` (prior KEEPs are committed past that sha, so they
         survive). Returns the patches reverted (full ``applied`` on success,
         empty on failure) for telemetry / schema compat.
+
+        Args:
+            framework_root: The git checkout to reset, or ``None`` (no-op).
+            applied: The patches applied this candidate.
+            pre_apply_sha: The HEAD sha captured before this candidate applied.
+
+        Returns:
+            The reverted patches (full ``applied`` on success, ``[]`` on
+            failure or no-op).
         """
         if framework_root is None or not applied:
             return []
@@ -919,7 +1006,17 @@ class FrameworkPrExecutor:
         slug: str,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         """Run a 1-variant Magpie bench under the patched server + accuracy
-        gate. Mirrors :meth:`IntegratePatchExecutor._bench_patch`."""
+        gate. Mirrors :meth:`IntegratePatchExecutor._bench_patch`.
+
+        Args:
+            params: The task params (config / model / bench knobs).
+            output_root: The per-task workspace root for the bench.
+            slug: The candidate slug used to name the variant.
+
+        Returns:
+            A ``(bench, gate_evidence)`` tuple: the bench result dict and a
+            dict carrying the ``accuracy_pass`` verdict.
+        """
         config_path = Path(
             params.get("config_path")
             or self.default_config_path

--- a/inference_optimizer/orchestrator/action_executors/integrate_patch.py
+++ b/inference_optimizer/orchestrator/action_executors/integrate_patch.py
@@ -105,6 +105,13 @@ def _resolve_framework_root(explicit: str | None) -> Path | None:
 
     Precedence: explicit param → first existing
     ``resolve_source_file_allowlist()`` entry. None when nothing resolves.
+
+    Args:
+        explicit: Explicit framework-root override, or ``None`` to use the
+            allowlist.
+
+    Returns:
+        The resolved framework source root, or ``None`` when nothing resolves.
     """
     if explicit:
         p = Path(explicit)
@@ -139,7 +146,18 @@ def _run_git_apply(
     framework_root: Path, patch_path: Path, *, p_level: int,
     three_way: bool, check_only: bool,
 ) -> tuple[bool, str]:
-    """Single ``git apply`` invocation at an explicit strip level."""
+    """Single ``git apply`` invocation at an explicit strip level.
+
+    Args:
+        framework_root: The git checkout to apply into.
+        patch_path: The patch file to apply.
+        p_level: The ``-p<N>`` strip level.
+        three_way: Whether to pass ``-3`` for a three-way merge.
+        check_only: Whether to pass ``--check`` (dry run, no mutation).
+
+    Returns:
+        A ``(ok, stderr)`` tuple; ``ok`` is True on a zero return code.
+    """
     cmd = ["git", "-C", str(framework_root), "apply", f"-p{p_level}"]
     if three_way:
         cmd.append("-3")
@@ -167,6 +185,14 @@ def _preflight_missing_targets(
     Defense-in-depth: ``specialist_patch_safety`` already drops these at
     authoring time, but patches supplied directly via ``params.patches``
     bypass that gate.
+
+    Args:
+        framework_root: The git checkout the patches target.
+        patch_paths: The patch files to preflight.
+
+    Returns:
+        A list of per-patch records (``patch`` + ``missing_targets``) for
+        patches whose targets are absent at every strip level.
     """
     records: list[dict[str, Any]] = []
     for patch in patch_paths:
@@ -183,7 +209,17 @@ def _preflight_missing_targets(
 def _detect_p_level(
     framework_root: Path, patch_path: Path, *, three_way: bool,
 ) -> int | None:
-    """Return the first ``-p`` level whose ``--check`` applies cleanly."""
+    """Return the first ``-p`` level whose ``--check`` applies cleanly.
+
+    Args:
+        framework_root: The git checkout to test against.
+        patch_path: The patch file to probe.
+        three_way: Whether to probe with ``-3``.
+
+    Returns:
+        The first ``-p<N>`` level that applies cleanly, or ``None`` when none
+        do.
+    """
     for lvl in _P_LEVELS:
         ok, _ = _run_git_apply(
             framework_root, patch_path, p_level=lvl,
@@ -200,7 +236,18 @@ def _git_apply(
 ) -> tuple[bool, str]:
     """Run ``git apply [-3] -p<auto> [--check] <patch>`` inside
     ``framework_root``, auto-detecting the strip level. Returns
-    ``(ok, stderr)``."""
+    ``(ok, stderr)``.
+
+    Args:
+        framework_root: The git checkout to apply into.
+        patch_path: The patch file to apply.
+        three_way: Whether to pass ``-3`` for a three-way merge.
+        check_only: Whether to only check (dry run) rather than mutate.
+
+    Returns:
+        A ``(ok, stderr)`` tuple; ``ok`` is True when the apply (or check)
+        succeeds.
+    """
     lvl = _detect_p_level(framework_root, patch_path, three_way=three_way)
     if lvl is None:
         # Surface a representative error at the git-native default level.
@@ -221,7 +268,16 @@ def _git_apply_reverse(
 ) -> tuple[bool, str]:
     """Reverse-apply ``patch_path`` (``git apply -R -p<auto>``) as the REVERT
     path; caller falls back to ``git checkout`` on failure. Auto-detects the
-    same strip level the forward apply used via ``-R --check``."""
+    same strip level the forward apply used via ``-R --check``.
+
+    Args:
+        framework_root: The git checkout to reverse-apply into.
+        patch_path: The patch file to reverse-apply.
+
+    Returns:
+        A ``(ok, stderr)`` tuple; ``ok`` is True when the reverse apply
+        succeeds.
+    """
     for lvl in _P_LEVELS:
         check = [
             "git", "-C", str(framework_root), "apply", "-R", f"-p{lvl}",
@@ -286,6 +342,15 @@ def _resolve_patch_paths(
     Order: ``params.patches`` → ``specialist_done.patches_written`` →
     filesystem scan of ``specialist_workspace/{worktree/,}patches/``.
     Entries normalised to absolute Paths; missing ones logged + dropped.
+
+    Args:
+        specialist_workspace: The specialist task workspace to resolve
+            relative paths / scan for patches.
+        explicit_patches: Explicit patch paths from params, or ``None``.
+        done_payload: The parsed ``specialist_done.json`` payload, or ``None``.
+
+    Returns:
+        The resolved, existing patch files as absolute Paths.
     """
     candidates: list[str] = []
     if explicit_patches:
@@ -719,6 +784,13 @@ class IntegratePatchExecutor:
         """Return the first proposal whose provenance starts with
         ``specialist:serving:framework_pr`` (F2-5); ``None`` otherwise so
         the KB writeback hook no-ops for legacy / kernel outputs.
+
+        Args:
+            done_payload: The parsed ``specialist_done.json`` payload, or
+                ``None``.
+
+        Returns:
+            The matching framework_pr proposal dict, or ``None`` when absent.
         """
         if not isinstance(done_payload, dict):
             return None
@@ -746,6 +818,14 @@ class IntegratePatchExecutor:
 
         No-op for other provenance or when both dedup keys (``fa_pr_url`` /
         ``fa_pr_sha``) are missing. Write errors are logged + swallowed.
+
+        Args:
+            done_payload: The parsed ``specialist_done.json`` payload, or
+                ``None``.
+            outcome: The outcome label to record (e.g. integrated / reverted).
+            tps_delta_pct: The measured throughput delta percentage.
+            extra: The runner ``extra`` mapping (provides shared state /
+                session id).
         """
         proposal = self._find_framework_pr_proposal(done_payload)
         if proposal is None:
@@ -793,7 +873,16 @@ class IntegratePatchExecutor:
         self, framework_root: Path | None, applied: list[Path],
     ) -> list[Path]:
         """Reverse-apply the applied patches (best-effort); returns those
-        actually reverted."""
+        actually reverted.
+
+        Args:
+            framework_root: The git checkout to revert in, or ``None`` (no-op).
+            applied: The patches that were applied this run.
+
+        Returns:
+            The patches actually reverted (may be the full ``applied`` list
+            when the checkout fallback fires).
+        """
         reverted: list[Path] = []
         if framework_root is None or not applied:
             return reverted
@@ -831,6 +920,17 @@ class IntegratePatchExecutor:
 
         Returns ``(bench_result_dict, gate_evidence)`` where gate_evidence
         carries ``accuracy_pass`` (True / False / None).
+
+        Args:
+            params: The task params (config / model / bench knobs).
+            output_root: The per-task workspace root for the bench.
+            config_changes_applied: Env overrides layered onto the variant.
+            specialist_task_id: The originating specialist task id (names the
+                variant).
+
+        Returns:
+            A ``(bench_result_dict, gate_evidence)`` tuple where
+            ``gate_evidence`` carries ``accuracy_pass`` (True / False / None).
         """
         config_path = Path(
             params.get("config_path")

--- a/inference_optimizer/orchestrator/action_executors/integrate_patch.py
+++ b/inference_optimizer/orchestrator/action_executors/integrate_patch.py
@@ -335,7 +335,16 @@ _PATCH_DEV_NULL = "/dev/null"
 
 
 def _strip_path_prefix(path: str, level: int) -> str:
-    """Drop ``level`` leading path components (mimics ``git apply -p<level>``)."""
+    """Drop ``level`` leading path components (mimics ``git apply -p<level>``).
+
+    Args:
+        path: The diff-header path to strip.
+        level: The number of leading components to drop (``<= 0`` is a no-op).
+
+    Returns:
+        The path with ``level`` leading components removed (or the basename
+        when there are not enough components).
+    """
     if level <= 0:
         return path
     parts = path.split("/")
@@ -349,6 +358,13 @@ def _commit_strip_level(
 
     The patch has already been applied, so modify/create targets exist in the
     tree; the level that maximises those hits is the one the forward apply used.
+
+    Args:
+        framework_root: The git checkout the patch was applied into.
+        pairs: ``(old_path, new_path)`` header pairs from the patch.
+
+    Returns:
+        The ``-p`` strip level resolving the most targets to existing files.
     """
     best_lvl, best_hits = 1, -1
     for lvl in _P_LEVELS:
@@ -378,6 +394,14 @@ def _patch_touched_paths(
     commit. Only paths that exist post-apply are emitted (pure deletions, the
     rare KEEP shape, are skipped) so the subsequent ``git add`` pathspec can
     never miss and silently stage nothing for the whole set.
+
+    Args:
+        framework_root: The git checkout the patches were applied into.
+        patches: The applied patch files to inspect.
+
+    Returns:
+        The repo-relative paths the patches modified/created that exist
+        post-apply.
     """
     out: list[str] = []
     for patch in patches:
@@ -418,6 +442,15 @@ def _git_commit_kept(
     dirty framework tree is not folded into the win commit. Best-effort: a
     commit failure (e.g. nothing staged) is non-fatal — the KEEP still stands in
     the working tree exactly as before.
+
+    Args:
+        framework_root: The git checkout to commit in.
+        message: The commit message for the KEEP.
+        paths: The repo-relative patch-touched paths to stage and commit.
+
+    Returns:
+        A ``(ok, note)`` tuple; ``ok`` is ``True`` on a successful commit or a
+        benign no-op (nothing to commit), and ``note`` carries any detail.
     """
     if not paths:
         return True, "no patch-touched paths to commit"

--- a/inference_optimizer/orchestrator/action_executors/profile.py
+++ b/inference_optimizer/orchestrator/action_executors/profile.py
@@ -67,7 +67,14 @@ _PROFILE_UNSAFE_VALUE_FLAGS = frozenset({
 
 
 def _sanitize_profile_server_args(args: str) -> str:
-    """Drop server flags known to conflict with profiler/shape discovery."""
+    """Drop server flags known to conflict with profiler/shape discovery.
+
+    Args:
+        args: Raw server-args string to sanitize.
+
+    Returns:
+        The args string with profiler-unsafe flags (and their values) removed.
+    """
     raw = str(args or "").strip()
     if not raw:
         return ""
@@ -98,6 +105,17 @@ def _trace_contains(path: Path, substring: str, max_bytes: int | None = None) ->
 
     Confirmation pass when :func:`_sample_trace_text` finds zero
     occurrences. Returns ``False`` on any IO/decode error (never raises).
+
+    Args:
+        path: The gzipped trace file to scan.
+        substring: The marker substring to search for.
+        max_bytes: Maximum decompressed bytes to read; defaults to the
+            ``INFERENCE_OPTIMIZER_TRACE_CONFIRM_BYTES`` env value or
+            :data:`_TRACE_CONFIRM_BYTES`.
+
+    Returns:
+        True if ``substring`` is found within ``max_bytes``, False otherwise
+        (including on any IO/decode error).
     """
     if not substring:
         return False
@@ -134,7 +152,14 @@ def _trace_contains(path: Path, substring: str, max_bytes: int | None = None) ->
 def _sample_trace_text(path: Path) -> str | None:
     """Read up to ``_TRACE_INSPECT_BYTES`` of decompressed text from a
     gzipped trace. Returns ``None`` (debug-logged) on IO/decode error so the
-    check is skipped rather than failing the profile path."""
+    check is skipped rather than failing the profile path.
+
+    Args:
+        path: The gzipped trace file to sample.
+
+    Returns:
+        The decompressed leading text, or ``None`` on IO/decode error.
+    """
     try:
         with gzip.open(path, "rt", encoding="utf-8", errors="replace") as fh:
             return fh.read(_TRACE_INSPECT_BYTES)
@@ -148,7 +173,16 @@ def _sample_trace_text(path: Path) -> str | None:
 
 def _count_substring_occurrences(text: str, substring: str) -> int:
     """Count non-overlapping ``substring`` occurrences as a cheap
-    lower-bound event count (avoids full JSON parsing)."""
+    lower-bound event count (avoids full JSON parsing).
+
+    Args:
+        text: The text to scan.
+        substring: The substring to count.
+
+    Returns:
+        The number of non-overlapping occurrences (0 when ``substring`` is
+        empty).
+    """
     if not substring:
         return 0
     return text.count(substring)
@@ -180,6 +214,17 @@ def _validate_trace_structure(
     Read-only; each check warns independently so partial signals stay actionable.
 
     Returns a structured ``trace_health`` dict (#431): ``per_kernel_attribution_degraded`` (no execute_*/user_annotation events -> cuda-graph folds per-kernel time, 0 hot kernels -> triggers eager re-profile), ``capture_traces_present``, and ``issues`` (logged warning strings).
+
+    Args:
+        trace_dir: The profile workspace trace directory to inspect.
+        framework: The framework name (e.g. ``"sglang"``) gating
+            framework-specific checks.
+        expected_pieces: Expected split-piece count (reserved for future
+            checks).
+
+    Returns:
+        A ``trace_health`` dict with ``issues``,
+        ``per_kernel_attribution_degraded``, and ``capture_traces_present``.
     """
     issues: list[str] = []
     per_kernel_attribution_degraded = False
@@ -359,7 +404,14 @@ PROFILE_DEFAULT_TIMEOUT_SEC = 14400    # 4 h wall cap; Qwen3-32B TP=1 profile ne
 
 def _trace_files_for_dir(trace_dir: Path) -> list[Path]:
     """Return ``*.trace.json.gz`` files under ``trace_dir`` (recursive,
-    stable order)."""
+    stable order).
+
+    Args:
+        trace_dir: The directory to scan recursively.
+
+    Returns:
+        Sorted ``*.trace.json.gz`` paths found under ``trace_dir``.
+    """
     return sorted(trace_dir.rglob("*.trace.json.gz"))
 
 
@@ -369,6 +421,13 @@ def _preferred_main_trace_path(trace_dir: Path, trace_files: list[Path]) -> Path
     Prefer the ``merged-*`` trace (the large annotated trace the splitter
     wants); otherwise pass the trace dir so kernel-agent picks its own order
     rather than pinning a tiny single-rank slice.
+
+    Args:
+        trace_dir: The trace directory, returned as the fallback path.
+        trace_files: Candidate trace files discovered under ``trace_dir``.
+
+    Returns:
+        The preferred ``merged-*`` trace path, else ``trace_dir`` itself.
     """
     merged = sorted(p for p in trace_files if p.name.startswith("merged-"))
     return merged[0] if merged else trace_dir
@@ -413,6 +472,9 @@ def _default_profile_config() -> Path:
     wrapper script from the YAML's ``benchmark.framework`` (not $FRAMEWORK);
     falling through to the sglang yaml on FRAMEWORK=atom would launch the
     wrong wrapper.
+
+    Returns:
+        The path to the framework-specific profile YAML config.
     """
     fw = os.environ.get("FRAMEWORK", "sglang").strip().lower()
     if fw == "atom":
@@ -481,6 +543,13 @@ class ProfileExecutor(BaselineExecutor):
            last-resort so concurrent sandboxes never share a dir.
 
         The resolved dir is mkdir'd best-effort.
+
+        Args:
+            ctx: Action context (unused beyond multi-node detection).
+
+        Returns:
+            The resolved shared torch-trace base dir, or ``""`` when not
+            running multi-node.
         """
         from ._multi_node_env import is_multi_node, rayjob_id_from_state
         if not is_multi_node():
@@ -516,6 +585,14 @@ class ProfileExecutor(BaselineExecutor):
         `benchmark.inferencex_path` to its own sibling checkout); patch the
         path resolved from the materialized YAML so NUM_PROMPTS /
         PROFILE_EXTRA_BODY aren't applied to a different checkout.
+
+        Args:
+            config_path: The materialized profile YAML config to read.
+            output_dir: The run output directory (unused here).
+
+        Returns:
+            ``None`` when the InferenceX checkout is patched correctly,
+            otherwise a failure result dict describing the patch gap.
         """
         try:
             cfg = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}

--- a/inference_optimizer/orchestrator/action_executors/profile.py
+++ b/inference_optimizer/orchestrator/action_executors/profile.py
@@ -580,6 +580,18 @@ class ProfileExecutor(BaselineExecutor):
         return None
 
     async def __call__(self, ctx) -> dict[str, Any]:
+        """Run the profiling action for the given context.
+
+        Launches a profiling run (sglang/vllm or the Magpie atom path),
+        merging the current-best server args with caller params, and
+        returns the captured trace artifacts.
+
+        Args:
+            ctx: Action context carrying the task and its parameters.
+
+        Returns:
+            A result dict describing the profiling outcome and artifacts.
+        """
         # atom: the Magpie atom wrapper bridges PROFILE=1 to atom's
         # --torch-profiler-dir; atom writes standard *.pt.trace.json.gz that
         # _candidate_trace_dirs + TraceLens consume unchanged, so the executor

--- a/inference_optimizer/orchestrator/action_executors/profile.py
+++ b/inference_optimizer/orchestrator/action_executors/profile.py
@@ -816,6 +816,12 @@ class ProfileExecutor(BaselineExecutor):
         _prof_started = {"v": False}
 
         async def _bounded_profile_window() -> None:
+            """Run a warmup-then-bounded engine profiling window.
+
+            Sleeps for the warmup period, starts engine profiling, holds it
+            open for the configured window, then stops it; updates the shared
+            ``_prof_started`` flag around the active window.
+            """
             await _asyncio.sleep(warmup_s)
             await trigger_dynamo_engine_profile("start", prof_body)
             _prof_started["v"] = True
@@ -870,6 +876,15 @@ class ProfileExecutor(BaselineExecutor):
                     # untouched — it never produces a competing CPU-only
                     # batch.
                     def _safe_size(p: Path) -> int:
+                        """Return ``p``'s size in bytes, or 0 on stat() failure.
+
+                        Args:
+                            p (Path): Path to stat.
+
+                        Returns:
+                            int: The file size in bytes, or ``0`` if ``stat()``
+                            fails.
+                        """
                         try:
                             return p.stat().st_size
                         except OSError:

--- a/inference_optimizer/orchestrator/action_executors/recover.py
+++ b/inference_optimizer/orchestrator/action_executors/recover.py
@@ -347,6 +347,9 @@ class RecoverExecutor:
 
         Returns one record per signalled PID (cmdline at discovery + final
         signal name ``"TERM"`` / ``"KILL"``).
+
+        Returns:
+            One record per signalled PID, or ``[]`` when none were stale.
         """
         candidates = self._discover_stale_pids()
         if not candidates:
@@ -369,7 +372,12 @@ class RecoverExecutor:
 
     def _discover_stale_pids(self) -> list[dict[str, Any]]:
         """Run ``pgrep -a -f -- <pattern>`` per owner pattern (matches the
-        full cmdline) and return unique PID records, excluding our own PID."""
+        full cmdline) and return unique PID records, excluding our own PID.
+
+        Returns:
+            Unique PID records matching the owner patterns, or ``[]`` when
+            ``pgrep`` is unavailable or nothing matched.
+        """
         if not shutil.which("pgrep"):
             log.warning("recover_executor: pgrep not on PATH; skipping kill stage")
             return []

--- a/inference_optimizer/orchestrator/action_executors/recover.py
+++ b/inference_optimizer/orchestrator/action_executors/recover.py
@@ -141,6 +141,10 @@ def _is_multi_node_sandbox() -> bool:
 
     Single-node (``is_multi_node() == False``) is unaffected — the sandbox
     IS the GPU pod, so local rocm-smi / gpureset are meaningful.
+
+    Returns:
+        ``True`` when running in multi-node mode (nodes >= 2); ``False`` for
+        single-node or when the mode cannot be determined.
     """
     try:
         from ._multi_node_env import is_multi_node

--- a/inference_optimizer/orchestrator/action_executors/report.py
+++ b/inference_optimizer/orchestrator/action_executors/report.py
@@ -31,7 +31,16 @@ log = logging.getLogger(__name__)
 
 def _safe_call(state: Any, method: str, default: Any) -> Any:
     """Call a zero-arg SharedState helper, returning ``default`` when absent
-    or raising."""
+    or raising.
+
+    Args:
+        state: The object the helper is looked up on.
+        method: Name of the zero-arg method to call.
+        default: Value returned when the method is missing or raises.
+
+    Returns:
+        The method's result, or ``default`` when it is absent or raises.
+    """
     fn = getattr(state, method, None)
     if not callable(fn):
         return default
@@ -223,6 +232,13 @@ def _format_degraded_mode_section(summary: dict[str, Any]) -> list[str]:
 
     Empty when the run was not degraded. Lists each recorded model warning so
     the reader knows benchmark numbers reflect the text decoder alone.
+
+    Args:
+        summary: The summary payload built by :func:`_build_summary_dict`.
+
+    Returns:
+        Markdown lines for the degraded-mode section, or ``[]`` when the run
+        was not degraded.
     """
     warnings = summary.get("model_warnings") or []
     if not summary.get("degraded_mode") and not warnings:
@@ -247,7 +263,15 @@ def _format_degraded_mode_section(summary: dict[str, Any]) -> list[str]:
 
 def _format_completeness_annotations(summary: dict[str, Any]) -> list[str]:
     """Render honesty annotations for work left unfinished (unvalidated
-    KEEPs, untried hot kernels, KEEPs awaiting integrate)."""
+    KEEPs, untried hot kernels, KEEPs awaiting integrate).
+
+    Args:
+        summary: The summary payload built by :func:`_build_summary_dict`.
+
+    Returns:
+        Markdown lines for the completeness annotations, or ``[]`` when nothing
+        is outstanding.
+    """
     unvalidated = bool(summary.get("has_unvalidated_keeps"))
     untried = list(summary.get("untried_hot_reusable_kernels") or [])
     pending_keeps = list(summary.get("pending_keep_kernels") or [])
@@ -279,6 +303,13 @@ def _format_steward_section(summary: dict[str, Any]) -> list[str]:
 
     Steward was retired in P3_17; kept for back-compat with older state.json
     carrying a populated ``last_remaining_gaps_assessment``.
+
+    Args:
+        summary: The summary payload built by :func:`_build_summary_dict`.
+
+    Returns:
+        Markdown lines for the steward assessment section, or ``[]`` when no
+        assessment/history is present.
     """
     assessment = summary.get("remaining_gaps_assessment") or {}
     history = summary.get("remaining_gaps_assessments_history") or []
@@ -315,6 +346,13 @@ def _extract_executive_summary(analysis_md_path: str) -> str:
     """Extract the ``## Executive Summary`` block (up to the next level-2
     heading) from analysis.md. Best-effort: returns a marker string when the
     file is missing / unparseable rather than crashing the report.
+
+    Args:
+        analysis_md_path: Filesystem path to the analysis.md file.
+
+    Returns:
+        The extracted Executive Summary block (capped to ~2KB), or a marker
+        string when the path is empty, unreadable, or lacks the block.
     """
     if not analysis_md_path:
         return "(no analysis.md path recorded)"
@@ -356,6 +394,12 @@ def _format_roofline_comparison_section(cmp: dict[str, Any]) -> list[str]:
     Two modes: ``single_snapshot`` (only the PRELUDE bootstrap ran; one
     Executive Summary + Base metric table) and ``before_after`` (a watermark
     refresh produced a distinct snapshot; two summaries + Base/Opt/Δ table).
+
+    Args:
+        cmp: The roofline-comparison dict built from snapshot history.
+
+    Returns:
+        Markdown lines for the Roofline Comparison section.
     """
     from ..roofline_snapshot import format_roofline_metrics_table
 
@@ -467,6 +511,12 @@ def _format_external_baseline_section(ext: dict[str, Any]) -> list[str]:
     gap %, no "should reach" wording) so it never reads as an implicit KPI.
     Heading varies by ``ext['reason']``: ``ok`` (full reference-best),
     ``no_target_gpu_configured`` ("(not requested)"), else "(advisory)".
+
+    Args:
+        ext: The external-baseline dict from :func:`_load_external_baseline`.
+
+    Returns:
+        Markdown lines for the advisory external-baseline section.
     """
     lines: list[str] = []
     status = str(ext.get("status") or "unknown")
@@ -554,7 +604,15 @@ def _format_external_baseline_section(ext: dict[str, Any]) -> list[str]:
 def _load_external_baseline(session_dir: Path) -> dict[str, Any] | None:
     """Best-effort load of ``target_analysis/target_baseline.json``; ``None``
     when missing / unreadable (errors swallowed so a corrupt JSON never
-    breaks report generation)."""
+    breaks report generation).
+
+    Args:
+        session_dir: The session directory holding the target-analysis JSON.
+
+    Returns:
+        The parsed external-baseline mapping, or ``None`` when missing or
+        unreadable.
+    """
     try:
         from ...session_paths import target_baseline_json
         path = target_baseline_json(session_dir)
@@ -579,6 +637,14 @@ def _write_kernel_opt_summary(
     Best-effort (failure logged, returns ``None`` so the final.json write
     still happens). Aggregates ``kernel_opt_attempts`` with per-kernel
     ``results/<kid>.json`` for the "why no optimized kernel?" view.
+
+    Args:
+        state: The session's shared state.
+        session_dir: The session directory used to locate per-kernel results.
+        output_dir: The reports output directory to write the summary into.
+
+    Returns:
+        The written summary path, or ``None`` on failure.
     """
     try:
         from ..kernel_attempt_summary import build_kernel_optimization_summary
@@ -598,7 +664,15 @@ def _write_kernel_opt_summary(
 def _read_conc_sweep_pointer(session_dir: Path) -> dict[str, Any] | None:
     """Build the small ``conc_sweep_summary`` pointer for ``final.json``
     (report_path + status + summary); ``None`` when conc_sweep wrote no
-    summary."""
+    summary.
+
+    Args:
+        session_dir: The session directory holding the conc-sweep summary.
+
+    Returns:
+        A compact pointer dict for ``final.json``, or ``None`` when no
+        conc-sweep summary exists or it is unreadable.
+    """
     from ...session_paths import reports_dir as _reports_dir
     json_path = _reports_dir(session_dir) / "conc_sweep_summary.json"
     if not json_path.exists():
@@ -624,7 +698,15 @@ def _read_conc_sweep_pointer(session_dir: Path) -> dict[str, Any] | None:
 
 
 def _read_ko_summary_totals(path: Path) -> dict[str, int]:
-    """Re-read totals so the final.json pointer doesn't drift from disk."""
+    """Re-read totals so the final.json pointer doesn't drift from disk.
+
+    Args:
+        path: Path to the kernel-optimization summary JSON.
+
+    Returns:
+        A mapping of total counts read from disk, or ``{}`` on any read/parse
+        error.
+    """
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
         totals = data.get("totals") or {}
@@ -803,6 +885,13 @@ class ReportExecutor:
         Order: ``ctx.extra['session_dir']`` → ``task.params['session_dir']``
         → :func:`paths.session_dir` (only if it exists with ``state.json``)
         → None (runner returns failed).
+
+        Args:
+            ctx: Action context carrying ``extra`` / task params.
+
+        Returns:
+            The resolved session directory, or ``None`` when it cannot be
+            resolved.
         """
         extra = getattr(ctx, "extra", None) or {}
         if extra.get("session_dir"):
@@ -818,7 +907,15 @@ class ReportExecutor:
 
     def _maybe_publish_results(self, session_dir: Path, state: SharedState) -> dict[str, Any]:
         """Best-effort publish hook for code-driven optimizer runs (opt-in
-        unless the results service URL is configured)."""
+        unless the results service URL is configured).
+
+        Args:
+            session_dir: The session directory to publish artifacts from.
+            state: The session's shared state (model/session identifiers).
+
+        Returns:
+            A dict describing whether publishing ran and its outcome.
+        """
         service_url = os.environ.get("HYPERLOOM_RESULTS_SERVICE_URL", "")
         auto_publish = os.environ.get("HYPERLOOM_RESULTS_AUTO_PUBLISH", "").lower()
         if not service_url and auto_publish not in {"1", "true", "yes"}:

--- a/inference_optimizer/orchestrator/action_executors/report.py
+++ b/inference_optimizer/orchestrator/action_executors/report.py
@@ -705,6 +705,16 @@ class ReportExecutor:
         self.max_highlights = int(max_highlights)
 
     async def __call__(self, ctx) -> dict[str, Any]:
+        """Run the report-generation action for the given context.
+
+        Args:
+            ctx: Action context; used to resolve the session directory
+                and report parameters.
+
+        Returns:
+            A result dict with a ``status`` field, failing when the
+            session directory cannot be resolved.
+        """
         session_dir = self._resolve_session_dir(ctx)
         if session_dir is None:
             return {"status": "failed",

--- a/inference_optimizer/orchestrator/action_executors/report.py
+++ b/inference_optimizer/orchestrator/action_executors/report.py
@@ -60,7 +60,14 @@ _BENIGN_FAILURE_PATTERNS: tuple[str, ...] = (
 
 
 def _is_benign_failure_text(text: str) -> bool:
-    """Return True when ``text`` matches a known-benign upstream WARN pattern."""
+    """Return True when ``text`` matches a known-benign upstream WARN pattern.
+
+    Args:
+        text: The candidate error/warning text to test.
+
+    Returns:
+        ``True`` when ``text`` contains any known-benign upstream WARN pattern.
+    """
     blob = str(text or "")
     return any(pat in blob for pat in _BENIGN_FAILURE_PATTERNS)
 
@@ -73,6 +80,13 @@ def _highlight_is_benign(highlight: dict[str, Any]) -> bool:
     a highlight whose summary describes a real fault (e.g. ``EngineCore failed
     to start``) is never suppressed even if its payload also references a benign
     file (#465).
+
+    Args:
+        highlight: A highlight record whose one-line ``summary`` is judged.
+
+    Returns:
+        ``True`` when the highlight's ``summary`` is only a benign upstream
+        WARN.
     """
     return _is_benign_failure_text(str(highlight.get("summary", "")))
 
@@ -83,6 +97,13 @@ def _partition_benign_lines(text: str) -> tuple[list[str], list[str]]:
     Drops only the lines matching a benign upstream WARN pattern and preserves
     every other line, so a mixed blob (benign WARN + real HIP OOM) keeps its
     real root cause instead of being wiped wholesale (#465).
+
+    Args:
+        text: The raw error blob to partition line-by-line.
+
+    Returns:
+        A ``(kept_lines, suppressed_benign_lines)`` tuple; suppressed lines are
+        stripped and truncated to 200 characters.
     """
     kept: list[str] = []
     suppressed: list[str] = []
@@ -101,6 +122,13 @@ def _classify_root_cause_type(error_class: str, error_text: str) -> str:
 
     Returns one of ``oom`` / ``benchmark_timeout`` / ``engine_core_init`` /
     ``worker_crash`` / ``unknown`` for the dashboard / ops contract.
+
+    Args:
+        error_class: The attempt's recorded error class.
+        error_text: The attempt's error message / excerpt.
+
+    Returns:
+        The coarse root-cause enum string for the dashboard / ops contract.
     """
     blob = f"{error_class} {error_text}".lower()
     if "out of memory" in blob or "hip oom" in blob:
@@ -125,6 +153,12 @@ def _pick_failure_headline(text: str) -> str:
 
     Prefers terminal fault lines (OOM / FATAL / engine-core markers) over the
     last line, so the headline points at the real root cause.
+
+    Args:
+        text: The server.log excerpt to scan.
+
+    Returns:
+        The most informative single line, or ``""`` when ``text`` is empty.
     """
     lines = [ln.strip() for ln in str(text or "").splitlines() if ln.strip()]
     if not lines:
@@ -147,6 +181,13 @@ def _last_failed_baseline_attempt(state: SharedState) -> dict[str, Any] | None:
     by ``record_action_attempt``) and falls back to the matching
     ``last_action_failures`` row. Both are persisted in ``state.json`` — there
     is no on-disk ``runs/baseline/<task_id>/result.json`` to scan.
+
+    Args:
+        state: The session's shared state to read attempt records from.
+
+    Returns:
+        The most recent failed baseline attempt record, or ``None`` when none
+        is found.
     """
     attempts = getattr(state, "baseline_attempts", None) or []
     failed = [
@@ -169,6 +210,13 @@ def _resolve_attempt_server_log(attempt: dict[str, Any]) -> Path | None:
     The audit row stores the ``benchmark_*`` workspace; ``server.log`` is
     written one level up (``output_dir/server.log``). Also honours an explicit
     ``stderr_log_path`` when present.
+
+    Args:
+        attempt: A baseline attempt audit record.
+
+    Returns:
+        The path to an existing ``server.log``, or ``None`` when none of the
+        candidates exist.
     """
     candidates: list[Path] = []
     workspace = attempt.get("workspace")
@@ -203,6 +251,15 @@ def _build_failure_summary(
     Best-effort: only fires for ``baseline_failed`` and returns ``None`` on any
     error so the report still writes. ``session_dir`` is used only to render a
     session-relative ``server_log`` path.
+
+    Args:
+        state: The session's shared state.
+        session_dir: Session root used only to render a session-relative
+            ``server_log`` path; ``None`` leaves the path absolute.
+
+    Returns:
+        A compact ``failure_summary`` dict, or ``None`` when the stop reason is
+        not ``baseline_failed``, no failed attempt exists, or any error occurs.
     """
     if str(getattr(state, "stop_reason", "") or "") != "baseline_failed":
         return None

--- a/inference_optimizer/orchestrator/action_executors/roofline.py
+++ b/inference_optimizer/orchestrator/action_executors/roofline.py
@@ -62,9 +62,13 @@ def _extract_steady_state_retry_mode(
 ) -> "tuple[str, dict[str, Any]] | None":
     """Inspect a failed trace_analyze result for a steady-state recovery hint.
 
-    Returns ``(mode, warning_dict)`` when a recovery warning carries an
-    alternate in ``non_empty_modes`` / ``available_modes`` (first one picked,
-    splitter-sorted); ``None`` otherwise (caller falls to ``_failed()``).
+    Args:
+        ta_result: The failed trace_analyze result to inspect for warnings.
+
+    Returns:
+        ``(mode, warning_dict)`` when a recovery warning carries an alternate
+        in ``non_empty_modes`` / ``available_modes`` (first one picked,
+        splitter-sorted); ``None`` otherwise (caller falls to ``_failed()``).
     """
     if not isinstance(ta_result, dict):
         return None
@@ -93,7 +97,14 @@ def _extract_steady_state_retry_mode(
 
 def _extract_trace_path(profile_result: dict[str, Any]) -> str:
     """Pick the trace path like Coordinator's ``_promote_to_shared_state``:
-    prefer ``main_trace_path`` (merged), else ``trace_files[0]``."""
+    prefer ``main_trace_path`` (merged), else ``trace_files[0]``.
+
+    Args:
+        profile_result: The profile sub-step result to read the trace from.
+
+    Returns:
+        The resolved trace path, or an empty string if none is present.
+    """
     if not isinstance(profile_result, dict):
         return ""
     direct = profile_result.get("main_trace_path")
@@ -117,6 +128,15 @@ def _failed(
 
     ``phase`` names the failed sub-step (profile / profile_no_trace /
     trace_analyze); ``sub_result`` is pruned to known keys for audit.
+
+    Args:
+        phase: Name of the failed sub-step.
+        error: Human-readable error message.
+        sub_result: The failed sub-step's result, pruned to known keys for
+            audit when provided.
+
+    Returns:
+        The canonical failure result dict.
     """
     out: dict[str, Any] = {
         "status": "failed",
@@ -492,6 +512,12 @@ class RooflineExecutor:
         Bypasses SubAgentRunner's child Task creation (avoids double task
         accounting); the child carries kind="profile" + same params and
         inherits the lease (no profile_lane re-acquire).
+
+        Args:
+            parent_ctx: The parent runner context to derive the child from.
+
+        Returns:
+            A child ``RunnerContext`` for the profile sub-step.
         """
         from ..task_registry import Task
         parent_task = parent_ctx.task
@@ -514,7 +540,14 @@ class RooflineExecutor:
 
 
 def make_roofline_executor(*, shared_state: Any) -> RooflineExecutor:
-    """Production factory used by `cli._register_executors`."""
+    """Production factory used by `cli._register_executors`.
+
+    Args:
+        shared_state: The SharedState instance the executor will mutate.
+
+    Returns:
+        A configured ``RooflineExecutor``.
+    """
     return RooflineExecutor(shared_state=shared_state)
 
 

--- a/inference_optimizer/orchestrator/action_executors/roofline.py
+++ b/inference_optimizer/orchestrator/action_executors/roofline.py
@@ -166,6 +166,17 @@ class RooflineExecutor:
         self.shared_state = shared_state
 
     async def __call__(self, ctx: RunnerContext) -> dict[str, Any]:
+        """Run the roofline action for the given context.
+
+        Performs a profile sub-step and feeds the resulting trace into
+        TraceLens analysis to produce a roofline characterization.
+
+        Args:
+            ctx: Runner context carrying the task and session metadata.
+
+        Returns:
+            A result dict describing the roofline outcome and artifacts.
+        """
         # atom: the profile sub-step produces *.pt.trace.json.gz that
         # TraceLens consumes unchanged, so this falls through to the
         # sglang/vllm path. Lazy imports keep shell-out/yaml off module load.

--- a/inference_optimizer/orchestrator/action_executors/sweep.py
+++ b/inference_optimizer/orchestrator/action_executors/sweep.py
@@ -56,7 +56,14 @@ DEFAULT_NUM_PROMPTS_FACTOR = 5
 
 def _coerce_int(value: Any) -> int:
     """Best-effort int coercion that never raises; non-numeric / None
-    collapse to 0 so an unset ``max_model_len`` disables filtering."""
+    collapse to 0 so an unset ``max_model_len`` disables filtering.
+
+    Args:
+        value: The value to coerce to an int.
+
+    Returns:
+        The parsed integer, or 0 when ``value`` is empty/non-numeric.
+    """
     if value is None or value == "":
         return 0
     try:
@@ -78,8 +85,19 @@ def _build_grid(
 
     Combos with ``ISL + OSL`` over a positive ``max_model_len`` are dropped
     up front (the server would reject every request), avoiding a wasted
-    launch. Returns ``(runnable_variants, skipped_records)`` so dropped
-    combos stay visible in the result.
+    launch.
+
+    Args:
+        conc_values: Concurrency values to fan out.
+        isl_osl_configs: ``"ISL:OSL"`` strings to fan out.
+        num_prompts_factor: Multiplier deriving ``NUM_PROMPTS`` from concurrency.
+        base_extra_args: Server args applied to every variant.
+        max_model_len: When positive, drops combos whose ``ISL + OSL`` exceeds
+            it.
+
+    Returns:
+        A ``(runnable_variants, skipped_records)`` tuple so dropped combos
+        stay visible in the result.
     """
     out: list[GridVariant] = []
     skipped: list[dict[str, Any]] = []

--- a/inference_optimizer/orchestrator/action_executors/sweep.py
+++ b/inference_optimizer/orchestrator/action_executors/sweep.py
@@ -189,6 +189,17 @@ class SweepExecutor:
         default_num_prompts_factor: int = DEFAULT_NUM_PROMPTS_FACTOR,
         variant_timeout_sec: int = 2400,
     ):
+        """Initialize the sweep executor with default sweep parameters.
+
+        Args:
+            default_config_path: Benchmark config path; ``None`` resolves
+                from ``$FRAMEWORK`` at call time.
+            session_dir: Default session directory for outputs.
+            default_conc_values: Default concurrency values to sweep.
+            default_isl_osl_configs: Default input/output length configs.
+            default_num_prompts_factor: Multiplier for prompt count.
+            variant_timeout_sec: Per-variant timeout in seconds.
+        """
         # None = resolve at call time from $FRAMEWORK; explicit fixture wins.
         self.default_config_path = (
             Path(default_config_path) if default_config_path else None

--- a/inference_optimizer/orchestrator/action_executors/target_analysis.py
+++ b/inference_optimizer/orchestrator/action_executors/target_analysis.py
@@ -93,7 +93,14 @@ class TargetAnalysisExecutor:
     def _resolve_session_dir(self, ctx: RunnerContext) -> Path | None:
         """Resolve session_dir: ``ctx.extra["session_dir"]`` >
         ``task.params["session_dir"]`` > constructor arg >
-        ``paths.session_dir()``; ``None`` when nothing resolves."""
+        ``paths.session_dir()``; ``None`` when nothing resolves.
+
+        Args:
+            ctx: The runner context carrying ``task.params`` and ``extra``.
+
+        Returns:
+            The resolved session directory, or ``None`` when nothing resolves.
+        """
         extra = getattr(ctx, "extra", None) or {}
         cand = extra.get("session_dir")
         if cand:
@@ -202,7 +209,17 @@ class TargetAnalysisExecutor:
         session_dir: Path,
     ) -> dict[str, Any]:
         """Build the small bus-friendly result payload (pointer + status;
-        the heavy JSON stays on disk)."""
+        the heavy JSON stays on disk).
+
+        Args:
+            ctx: The runner context (supplies ``task.kind``).
+            summary: The baseline comparison summary object.
+            session_dir: Session directory the report artefacts live under.
+
+        Returns:
+            The bus-friendly result dict with status, pointers, and best-point
+            metrics when available.
+        """
         from ...session_paths import target_analysis_report_md, target_baseline_json
         json_path = target_baseline_json(session_dir)
         md_path = target_analysis_report_md(session_dir)

--- a/inference_optimizer/orchestrator/action_registry.py
+++ b/inference_optimizer/orchestrator/action_registry.py
@@ -100,7 +100,14 @@ _DEFAULT_VERDICT_CLASS_FALLBACK: str = "exploration"
 
 
 def default_verdict_class_for(action_name: str) -> str:
-    """Look up the default ``verdict_class``; falls back to ``"exploration"``."""
+    """Look up the default ``verdict_class``; falls back to ``"exploration"``.
+
+    Args:
+        action_name: The action name to look up.
+
+    Returns:
+        The mapped verdict class, or ``"exploration"`` when unmapped.
+    """
     return _DEFAULT_VERDICT_CLASS.get(
         action_name, _DEFAULT_VERDICT_CLASS_FALLBACK,
     )

--- a/inference_optimizer/orchestrator/backends/base.py
+++ b/inference_optimizer/orchestrator/backends/base.py
@@ -24,6 +24,15 @@ def parse_call_timeout_env(env_name: str, *, default: float) -> float:
 
     Returns ``default`` (logging a WARNING) when the env var is unset, empty,
     or not a positive finite float — a malformed knob must not be fatal.
+
+    Args:
+        env_name: Name of the environment variable holding the timeout seconds.
+        default: Fallback timeout in seconds used when the env var is missing
+            or malformed.
+
+    Returns:
+        The parsed positive finite timeout in seconds, or ``default`` on any
+        miss or parse error.
     """
     raw = os.environ.get(env_name)
     if raw is None or not raw.strip():

--- a/inference_optimizer/orchestrator/backends/base.py
+++ b/inference_optimizer/orchestrator/backends/base.py
@@ -85,10 +85,29 @@ class RetryPolicy:
 
         Malformed values fall back to the dataclass default for that field.
         ``<prefix>_ATTEMPTS=1`` (or ``0``) disables retry.
+
+        Args:
+            prefix: The environment-variable prefix to read the policy fields
+                from.
+
+        Returns:
+            A :class:`RetryPolicy` populated from the environment, with
+            per-field fallback to the dataclass defaults.
         """
         d = cls()
 
         def _num(suffix: str, default: float, *, cast: Callable[[float], Any]):
+            """Read ``<prefix>_<suffix>`` as a number, falling back to ``default``.
+
+            Args:
+                suffix: The env-var suffix appended to ``prefix``.
+                default: Fallback returned when the var is unset or invalid.
+                cast: Callable applied to the parsed float for the final value.
+
+            Returns:
+                The cast parsed value, or ``default`` when missing, non-finite,
+                negative, or unparseable.
+            """
             raw = os.environ.get(f"{prefix}_{suffix}")
             if raw is None or not raw.strip():
                 return default
@@ -111,7 +130,15 @@ class RetryPolicy:
         )
 
     def delay_for(self, attempt: int) -> float:
-        """Backoff delay (seconds) before retry ``attempt`` (1-based prior attempt)."""
+        """Backoff delay (seconds) before retry ``attempt`` (1-based prior attempt).
+
+        Args:
+            attempt: The 1-based number of the prior attempt that just failed.
+
+        Returns:
+            The backoff delay in seconds (capped at ``max_delay_s`` plus
+            optional jitter).
+        """
         raw = self.base_delay_s * (self.multiplier ** max(0, attempt - 1))
         capped = min(self.max_delay_s, raw)
         if self.jitter_s > 0:
@@ -131,6 +158,21 @@ async def retry_with_backoff(
 
     Re-raises the last exception once ``policy.max_attempts`` is exhausted. The
     ``sleep`` seam keeps tests deterministic (inject a no-op / fake clock).
+
+    Args:
+        fn: The zero-arg awaitable factory to invoke each attempt.
+        policy: The retry policy bounding attempts and backoff delay.
+        retry_on: The exception types that trigger a retry.
+        sleep: Awaitable sleep used between attempts (injectable for tests).
+        on_retry: Optional callback ``(attempt, exc, delay)`` invoked before
+            each retry; its own exceptions are swallowed.
+
+    Returns:
+        The successful result of ``fn()``.
+
+    Raises:
+        BaseException: Re-raises the last exception from ``fn()`` once
+            ``policy.max_attempts`` is exhausted.
     """
     attempt = 0
     while True:

--- a/inference_optimizer/orchestrator/backends/claude.py
+++ b/inference_optimizer/orchestrator/backends/claude.py
@@ -84,6 +84,14 @@ def _import_sdk() -> tuple[Any, Any, Any]:
     """Return ``(query, ClaudeAgentOptions, sdk_module)`` or raise.
 
     Only ``claude_agent_sdk`` is supported (``claude_code_sdk`` deprecated).
+
+    Returns:
+        A tuple of the SDK ``query`` callable, the ``ClaudeAgentOptions``
+        class, and the imported SDK module.
+
+    Raises:
+        BackendError: If ``claude_agent_sdk`` is not installed or is missing
+            the required ``query`` / ``ClaudeAgentOptions`` attributes.
     """
     try:
         sdk = importlib.import_module("claude_agent_sdk")
@@ -383,6 +391,10 @@ class ClaudeBackend:
 
         ``None`` detaches it. Best-effort: a build failure is recorded as a
         soft warning and leaves the backend usable without the pull tools.
+
+        Args:
+            provider: The context provider to back the pull tools, or ``None``
+                to detach the context-tools server.
         """
         if provider is None:
             self._context_server_config = None
@@ -416,7 +428,12 @@ class ClaudeBackend:
 
     @property
     def conversation_session_id(self) -> str | None:
-        """Current SDK session token (conversational mode), or None."""
+        """Current SDK session token (conversational mode), or None.
+
+        Returns:
+            The captured SDK session id in conversational mode, otherwise
+            ``None``.
+        """
         return self._session_id if self.conversational else None
 
     def _build_options(
@@ -485,6 +502,16 @@ class ClaudeBackend:
 
         Older SDK builds lack ``resume``; fall back to a stateless turn
         (with a one-time warning) rather than crashing the reactor.
+
+        Args:
+            kwargs: Keyword arguments to pass to the SDK options constructor.
+
+        Returns:
+            A constructed SDK options instance.
+
+        Raises:
+            TypeError: If the constructor rejects a keyword other than
+                ``resume``.
         """
         try:
             return self.sdk_options_cls(**kwargs)
@@ -518,6 +545,15 @@ class ClaudeBackend:
 
         `usage` (cache_creation/read_input_tokens) measures prompt-cache
         effectiveness against the SECTION-A/B stable-prefix design (§5.1, §8.8).
+
+        Args:
+            prompt: The composed prompt to stream to the SDK.
+            options: The SDK options object configuring this turn.
+
+        Returns:
+            A tuple ``(intents, raw_text, tool_block_count, usage, session_id)``
+            where ``usage`` is the latest cumulative usage dict and
+            ``session_id`` is the SDK session token (or ``None``).
         """
         intents: list[Intent] = []
         text_chunks: list[str] = []

--- a/inference_optimizer/orchestrator/backends/claude.py
+++ b/inference_optimizer/orchestrator/backends/claude.py
@@ -238,6 +238,20 @@ class ClaudeBackend:
         max_turns: int = 1,
         allow_no_intent: bool = False,
     ) -> BackendTurnResult:
+        """Run a single backend turn against Claude and parse the result.
+
+        Args:
+            prompt: User prompt for this turn.
+            system_prompt: Optional system prompt override.
+            tools: Tool names to enable for the turn.
+            max_turns: Maximum agent turns; falls back to the backend
+                default when falsy.
+            allow_no_intent: When ``True``, relax the guard that requires
+                an ``emit_intent`` (e.g. for summary/checkpoint turns).
+
+        Returns:
+            The parsed :class:`BackendTurnResult` for the turn.
+        """
         # ``allow_no_intent`` (plan Step 4): a summary/checkpoint turn asks
         # for plain-text instead of emit_intent, so relax the no-intent guard.
         full_prompt = self._compose_prompt(prompt)
@@ -386,6 +400,11 @@ class ClaudeBackend:
 
     @property
     def has_context_tools(self) -> bool:
+        """Whether the context-tools MCP server is configured.
+
+        Returns:
+            ``True`` if a context-server config was set up successfully.
+        """
         return self._context_server_config is not None
 
     def reset_conversation(self) -> None:

--- a/inference_optimizer/orchestrator/backends/claude.py
+++ b/inference_optimizer/orchestrator/backends/claude.py
@@ -289,12 +289,27 @@ class ClaudeBackend:
         # Bounded retry/backoff (R6) absorbs transient stalls / blips across a
         # multi-day run; a per-attempt wall-clock cap still bounds each try.
         async def _one_attempt() -> tuple[Any, ...]:
+            """Run one bounded SDK invocation under the per-attempt timeout.
+
+            Returns:
+                The collected ``_invoke_and_collect`` result tuple.
+
+            Raises:
+                asyncio.TimeoutError: If the attempt exceeds ``call_timeout_s``.
+            """
             return await asyncio.wait_for(
                 self._invoke_and_collect(full_prompt, options),
                 timeout=self.call_timeout_s,
             )
 
         def _note_retry(attempt: int, exc: BaseException, delay: float) -> None:
+            """Record a transient-failure retry warning into the call log.
+
+            Args:
+                attempt: The 1-based attempt number that failed.
+                exc: The transient exception raised by the attempt.
+                delay: Seconds to wait before the next retry.
+            """
             self.calls.append({
                 "warn": (
                     f"claude SDK transient failure (attempt {attempt}): {exc!r}; "

--- a/inference_optimizer/orchestrator/backends/codex.py
+++ b/inference_optimizer/orchestrator/backends/codex.py
@@ -284,6 +284,13 @@ class CodexBackend:
 
         Mirrors ``ClaudeBackend._safe_int`` so both backends report
         identically-shaped token counts on metadata.
+
+        Args:
+            value: A raw usage counter of any type to coerce to an integer.
+
+        Returns:
+            The integer value, or ``0`` when ``value`` is ``None`` or not
+            coercible.
         """
         try:
             return int(value or 0)

--- a/inference_optimizer/orchestrator/backends/critic_agent.py
+++ b/inference_optimizer/orchestrator/backends/critic_agent.py
@@ -104,7 +104,15 @@ _BARE_JSON_RE = re.compile(r"(\{[^{}]*\"review_verdicts\"[\s\S]*\})", re.DOTALL)
 
 
 def _extract_review_json(text: str) -> dict[str, Any] | None:
-    """Pull the first valid review JSON out of a model reply, or ``None``."""
+    """Pull the first valid review JSON out of a model reply, or ``None``.
+
+    Args:
+        text: The raw model reply that may contain a review JSON object.
+
+    Returns:
+        The first dict containing a ``"review_verdicts"`` key, or ``None`` when
+        no parseable review object is found.
+    """
     if not text:
         return None
     for m in _FENCED_JSON_RE.finditer(text):
@@ -150,7 +158,16 @@ fake that writes the desired ``judge_bundle.json`` / ``emit.json`` to
 
 def _assistant_message_with_tool_calls(msg: Any) -> dict[str, Any]:
     """Re-serialize an OpenAI assistant message that issued tool_calls
-    (minimal dict shape, pydantic v1/v2 compatible)."""
+    (minimal dict shape, pydantic v1/v2 compatible).
+
+    Args:
+        msg: The OpenAI assistant message object carrying ``content`` and
+            ``tool_calls``.
+
+    Returns:
+        A minimal assistant-message dict with role, content, and a normalized
+        ``tool_calls`` list suitable for re-sending to the API.
+    """
     return {
         "role": "assistant",
         "content": getattr(msg, "content", None),
@@ -222,7 +239,16 @@ def _default_runtime_caller(call: RuntimeCall) -> None:
 
 # Cross-domain enrichment helper for cross-domain (scope=domains) proposals.
 def _proposal_scope_literal(proposal: dict[str, Any]) -> str:
-    """Read the ``scope`` dial off a proposal (top-level or nested ``params``)."""
+    """Read the ``scope`` dial off a proposal (top-level or nested ``params``).
+
+    Args:
+        proposal: A proposal dict that may carry ``scope`` at the top level or
+            under ``params``.
+
+    Returns:
+        The stripped scope string, or an empty string when absent or the
+        proposal is not a dict.
+    """
     if not isinstance(proposal, dict):
         return ""
     top = proposal.get("scope")
@@ -238,7 +264,13 @@ def _proposal_scope_literal(proposal: dict[str, Any]) -> str:
 
 def _maybe_inject_cross_domain_constraints(judge_bundle: dict[str, Any]) -> None:
     """Set ``review_constraints.cross_domain`` + rule descriptors when any
-    proposal is cross-domain (unified ``scope == 'domains'`` dial). Idempotent."""
+    proposal is cross-domain (unified ``scope == 'domains'`` dial). Idempotent.
+
+    Args:
+        judge_bundle: The judge bundle to enrich in place; its
+            ``review_constraints`` are updated when a cross-domain proposal is
+            present.
+    """
     proposals = judge_bundle.get("proposals") or []
     if not isinstance(proposals, list):
         return
@@ -740,6 +772,10 @@ class CriticAgentBackend:
         manifest.json (model / framework / gpu_type / model_path / tp /
         workload / precision); empty values dropped. Any read error logs a
         WARNING and returns ``{}``.
+
+        Returns:
+            A context dict built from the manifest's non-empty fields, or an
+            empty dict when the manifest is missing or unreadable.
         """
         path = manifest_path(self.session_dir)
         try:
@@ -908,6 +944,16 @@ class CriticAgentBackend:
         web_search / web_fetch up to ``self._web_tool_max_turns`` before a
         final text-only reply. Returns ``(text, finish_reason)``; tool-exec
         failures are reported back to the model, never raised.
+
+        Args:
+            messages: The running chat-completions message list; tool-use turns
+                are appended in place.
+
+        Returns:
+            A tuple of the final reply text and the final finish reason.
+
+        Raises:
+            BackendError: If any Codex chat-completions API call fails.
         """
         tools = self._web_tool_schemas
         max_turns = self._web_tool_max_turns if tools else 0
@@ -982,6 +1028,11 @@ class CriticAgentBackend:
         OpenAI reports ``prompt_tokens`` / ``completion_tokens``; map them
         onto the canonical in/out counters. Missing / bad values contribute
         0 so a single malformed response never corrupts the running sum.
+
+        Args:
+            acc: The running accumulator with ``input_tokens`` /
+                ``output_tokens`` keys, updated in place.
+            usage: An OpenAI usage object (or ``None``) to fold into ``acc``.
         """
         if usage is None:
             return
@@ -1003,6 +1054,10 @@ class CriticAgentBackend:
         ``component=critic``. tick/phase are unknown to the critic backend
         (it runs as its own reactor) — the collector backfills from the ts
         window. Best-effort: never raises into the review path.
+
+        Args:
+            usage_acc: Accumulated token counts with ``input_tokens`` /
+                ``output_tokens`` keys for this reasoning loop.
         """
         try:
             record = LLMCallRecord(
@@ -1035,6 +1090,12 @@ class CriticAgentBackend:
         (it runs as its own reactor); the collector backfills from the ts
         window. Best-effort: never raises into the review path. No-op when
         both prompt and reply are empty.
+
+        Args:
+            system_prompt: Optional system prompt prepended to the recorded
+                prompt.
+            user_prompt: The judge-bundle user prompt the critic reasoned over.
+            response: The model's externally-visible reply text.
         """
         try:
             prompt = (

--- a/inference_optimizer/orchestrator/backends/mcp_context_tools.py
+++ b/inference_optimizer/orchestrator/backends/mcp_context_tools.py
@@ -72,29 +72,53 @@ class ContextProvider:
 
     # Projections backed by SharedState.to_*_summary.
     def mission_status(self) -> str:
-        """Return the mission-status summary projection."""
+        """Return the mission-status summary projection.
+
+        Returns:
+            The mission-status summary string.
+        """
         return self._safe(self.shared_state.to_mission_summary, "mission_status")
 
     def shared_state_summary(self) -> str:
-        """Return the prompt-oriented shared-state summary projection."""
+        """Return the prompt-oriented shared-state summary projection.
+
+        Returns:
+            The shared-state summary string.
+        """
         return self._safe(self.shared_state.to_prompt_summary, "shared_state")
 
     def gaps(self) -> str:
-        """Return the open-gaps summary projection."""
+        """Return the open-gaps summary projection.
+
+        Returns:
+            The open-gaps summary string.
+        """
         return self._safe(self.shared_state.to_gaps_summary, "gaps")
 
     def warm_start(self) -> str:
-        """Return the warm-start summary projection."""
+        """Return the warm-start summary projection.
+
+        Returns:
+            The warm-start summary string.
+        """
         return self._safe(self.shared_state.to_warm_start_summary, "warm_start")
 
     def proposal_scores(self) -> str:
-        """Return the proposal-scores summary projection."""
+        """Return the proposal-scores summary projection.
+
+        Returns:
+            The proposal-scores summary string.
+        """
         return self._safe(
             self.shared_state.to_proposal_scores_summary, "proposal_scores"
         )
 
     def intervention_mix(self) -> str:
-        """Return the intervention-mix summary projection."""
+        """Return the intervention-mix summary projection.
+
+        Returns:
+            The intervention-mix summary string.
+        """
         return self._safe(
             self.shared_state.to_intervention_mix_summary, "intervention_mix"
         )
@@ -326,7 +350,16 @@ def _resolve_sdk(sdk_module: Any | None) -> Any | None:
 def _make_handler(
     provider: ContextProvider, method_name: str,
 ) -> Callable[[dict[str, Any]], Any]:
-    """Build an async MCP handler returning the provider method's string."""
+    """Build an async MCP handler returning the provider method's string.
+
+    Args:
+        provider: The context provider whose method backs the handler.
+        method_name: Name of the provider method to invoke per tool call.
+
+    Returns:
+        An async MCP handler callable that invokes the bound method and wraps
+        its result.
+    """
 
     async def _handler(args: dict[str, Any]) -> dict[str, Any]:
         """Invoke the bound provider method and wrap its string result.
@@ -381,6 +414,18 @@ def build_context_tools_server(
     Returns the SDK ``McpSdkServerConfig`` for
     :class:`ClaudeAgentOptions.mcp_servers`, or ``None`` if the SDK lacks
     in-process MCP helpers (handled gracefully by the caller).
+
+    Args:
+        provider: The context provider backing every tool handler.
+        sdk_module: Explicit SDK module to use, or ``None`` to import the real
+            one.
+        tool_factory: Override for the SDK ``tool`` decorator factory (tests).
+        server_factory: Override for the SDK ``create_sdk_mcp_server`` factory
+            (tests).
+
+    Returns:
+        The constructed in-process MCP server config, or ``None`` when the SDK
+        lacks the required in-process MCP helpers.
     """
     sdk = _resolve_sdk(sdk_module)
     if tool_factory is None:

--- a/inference_optimizer/orchestrator/backends/mcp_context_tools.py
+++ b/inference_optimizer/orchestrator/backends/mcp_context_tools.py
@@ -22,6 +22,14 @@ MCP_SERVER_NAME = "inference_optimizer_context"
 
 
 def _qualified(tool_name: str) -> str:
+    """Return the fully-qualified MCP tool name.
+
+    Args:
+        tool_name: Bare tool name.
+
+    Returns:
+        The name prefixed with ``mcp__<server>__``.
+    """
     return f"mcp__{MCP_SERVER_NAME}__{tool_name}"
 
 
@@ -45,6 +53,16 @@ class ContextProvider:
     action_runner: Callable[[str, dict[str, Any]], str] | None = None
 
     def _safe(self, fn: Callable[[], str], label: str) -> str:
+        """Invoke a projection callable, never letting it crash the reactor.
+
+        Args:
+            fn: Zero-argument projection returning a summary string.
+            label: Short name used in log and fallback messages.
+
+        Returns:
+            The projection output, or a short error/empty marker string when
+            ``fn`` raises or returns nothing usable.
+        """
         try:
             out = fn()
         except Exception as exc:  # noqa: BLE001 — never crash a pull
@@ -54,28 +72,43 @@ class ContextProvider:
 
     # Projections backed by SharedState.to_*_summary.
     def mission_status(self) -> str:
+        """Return the mission-status summary projection."""
         return self._safe(self.shared_state.to_mission_summary, "mission_status")
 
     def shared_state_summary(self) -> str:
+        """Return the prompt-oriented shared-state summary projection."""
         return self._safe(self.shared_state.to_prompt_summary, "shared_state")
 
     def gaps(self) -> str:
+        """Return the open-gaps summary projection."""
         return self._safe(self.shared_state.to_gaps_summary, "gaps")
 
     def warm_start(self) -> str:
+        """Return the warm-start summary projection."""
         return self._safe(self.shared_state.to_warm_start_summary, "warm_start")
 
     def proposal_scores(self) -> str:
+        """Return the proposal-scores summary projection."""
         return self._safe(
             self.shared_state.to_proposal_scores_summary, "proposal_scores"
         )
 
     def intervention_mix(self) -> str:
+        """Return the intervention-mix summary projection."""
         return self._safe(
             self.shared_state.to_intervention_mix_summary, "intervention_mix"
         )
 
     def why_denied(self, top_k: int = 6) -> str:
+        """Return a summary of recent policy denials.
+
+        Args:
+            top_k: Maximum number of denial entries to include.
+
+        Returns:
+            The denial summary from the denial reader when wired, otherwise the
+            shared-state policy-denial projection.
+        """
         if self.denial_reader is not None:
             return self._safe(lambda: self.denial_reader(top_k), "why_denied")
         return self._safe(
@@ -84,16 +117,38 @@ class ContextProvider:
         )
 
     def analysis_md(self) -> str:
+        """Return the current ``analysis.md`` contents.
+
+        Returns:
+            The analysis text, or a not-wired marker when no reader is bound.
+        """
         if self.analysis_reader is None:
             return "(analysis.md reader not wired)"
         return self._safe(self.analysis_reader, "analysis_md")
 
     def inbox(self, since_seq: int = 0) -> str:
+        """Return inbox messages newer than a sequence number.
+
+        Args:
+            since_seq: Only messages with a sequence greater than this are
+                returned.
+
+        Returns:
+            The inbox text, or a not-wired marker when no reader is bound.
+        """
         if self.inbox_reader is None:
             return "(inbox reader not wired)"
         return self._safe(lambda: self.inbox_reader(since_seq), "inbox")
 
     def recent_outcomes(self, top_k: int = 8) -> str:
+        """Return a summary of recent action outcomes.
+
+        Args:
+            top_k: Maximum number of recent outcomes to include.
+
+        Returns:
+            The outcomes summary, or a not-wired marker when no reader is bound.
+        """
         if self.recent_outcomes_reader is None:
             return "(recent outcomes reader not wired)"
         return self._safe(
@@ -103,6 +158,16 @@ class ContextProvider:
     def run_action_now(
         self, action_name: str = "", params: dict[str, Any] | None = None,
     ) -> str:
+        """Run a whitelisted lane-light action inline.
+
+        Args:
+            action_name: Name of the action to run.
+            params: Optional action parameters.
+
+        Returns:
+            The action result string, or a not-wired marker when no action
+            runner is bound.
+        """
         if self.action_runner is None:
             return "(run_action_now not wired)"
         return self._safe(
@@ -240,6 +305,16 @@ CONTEXT_TOOL_QUALIFIED_NAMES: tuple[str, ...] = tuple(
 
 
 def _resolve_sdk(sdk_module: Any | None) -> Any | None:
+    """Resolve the Claude Agent SDK module.
+
+    Args:
+        sdk_module: Explicit module to use (for tests), or ``None`` to import
+            the real SDK.
+
+    Returns:
+        The provided or imported SDK module, or ``None`` when it is not
+        installed.
+    """
     if sdk_module is not None:
         return sdk_module
     try:
@@ -254,6 +329,15 @@ def _make_handler(
     """Build an async MCP handler returning the provider method's string."""
 
     async def _handler(args: dict[str, Any]) -> dict[str, Any]:
+        """Invoke the bound provider method and wrap its string result.
+
+        Args:
+            args: Tool call arguments; recognized keys (``top_k``,
+                ``since_seq``, ``action_name``, ``params``) are forwarded.
+
+        Returns:
+            An MCP tool result dict carrying the provider method's output.
+        """
         method = getattr(provider, method_name)
         kwargs: dict[str, Any] = {}
         if isinstance(args, dict):

--- a/inference_optimizer/orchestrator/backends/mcp_context_tools.py
+++ b/inference_optimizer/orchestrator/backends/mcp_context_tools.py
@@ -72,29 +72,53 @@ class ContextProvider:
 
     # Projections backed by SharedState.to_*_summary.
     def mission_status(self) -> str:
-        """Return the mission-status summary projection."""
+        """Return the mission-status summary projection.
+
+        Returns:
+            The mission-status summary string.
+        """
         return self._safe(self.shared_state.to_mission_summary, "mission_status")
 
     def shared_state_summary(self) -> str:
-        """Return the prompt-oriented shared-state summary projection."""
+        """Return the prompt-oriented shared-state summary projection.
+
+        Returns:
+            The prompt-oriented shared-state summary string.
+        """
         return self._safe(self.shared_state.to_prompt_summary, "shared_state")
 
     def gaps(self) -> str:
-        """Return the open-gaps summary projection."""
+        """Return the open-gaps summary projection.
+
+        Returns:
+            The open-gaps summary string.
+        """
         return self._safe(self.shared_state.to_gaps_summary, "gaps")
 
     def warm_start(self) -> str:
-        """Return the warm-start summary projection."""
+        """Return the warm-start summary projection.
+
+        Returns:
+            The warm-start summary string.
+        """
         return self._safe(self.shared_state.to_warm_start_summary, "warm_start")
 
     def proposal_scores(self) -> str:
-        """Return the proposal-scores summary projection."""
+        """Return the proposal-scores summary projection.
+
+        Returns:
+            The proposal-scores summary string.
+        """
         return self._safe(
             self.shared_state.to_proposal_scores_summary, "proposal_scores"
         )
 
     def intervention_mix(self) -> str:
-        """Return the intervention-mix summary projection."""
+        """Return the intervention-mix summary projection.
+
+        Returns:
+            The intervention-mix summary string.
+        """
         return self._safe(
             self.shared_state.to_intervention_mix_summary, "intervention_mix"
         )
@@ -326,7 +350,16 @@ def _resolve_sdk(sdk_module: Any | None) -> Any | None:
 def _make_handler(
     provider: ContextProvider, method_name: str,
 ) -> Callable[[dict[str, Any]], Any]:
-    """Build an async MCP handler returning the provider method's string."""
+    """Build an async MCP handler returning the provider method's string.
+
+    Args:
+        provider: The bound context provider.
+        method_name: Name of the provider method the handler invokes.
+
+    Returns:
+        An async MCP handler that wraps the provider method's output in an
+        MCP tool result dict.
+    """
 
     async def _handler(args: dict[str, Any]) -> dict[str, Any]:
         """Invoke the bound provider method and wrap its string result.
@@ -381,6 +414,16 @@ def build_context_tools_server(
     Returns the SDK ``McpSdkServerConfig`` for
     :class:`ClaudeAgentOptions.mcp_servers`, or ``None`` if the SDK lacks
     in-process MCP helpers (handled gracefully by the caller).
+
+    Args:
+        provider: The context provider backing every tool handler.
+        sdk_module: Explicit SDK module (for tests), or ``None`` to import it.
+        tool_factory: Override for the SDK ``tool`` decorator factory.
+        server_factory: Override for the SDK ``create_sdk_mcp_server`` factory.
+
+    Returns:
+        The SDK ``McpSdkServerConfig``, or ``None`` when the SDK lacks
+        in-process MCP helpers.
     """
     sdk = _resolve_sdk(sdk_module)
     if tool_factory is None:

--- a/inference_optimizer/orchestrator/backends/mcp_emit_intent.py
+++ b/inference_optimizer/orchestrator/backends/mcp_emit_intent.py
@@ -117,7 +117,15 @@ def validate_emit_intent_input(payload: dict[str, Any]) -> None:
 
 
 async def _emit_intent_handler(args: dict[str, Any]) -> dict[str, Any]:
-    """Default handler — validate then ack; errors return is_error=True."""
+    """Default handler — validate then ack; errors return is_error=True.
+
+    Args:
+        args: The raw ``emit_intent`` tool input to validate.
+
+    Returns:
+        An MCP tool result dict acknowledging success, or carrying the
+        validation error with ``is_error=True``.
+    """
     try:
         validate_emit_intent_input(args)
     except IntentValidationError as exc:
@@ -161,6 +169,19 @@ def build_emit_intent_server(
     :class:`ClaudeAgentOptions.mcp_servers`, or ``None`` if the SDK lacks
     in-process MCP helpers. ``tool_factory`` / ``server_factory`` /
     ``handler`` are test seams.
+
+    Args:
+        sdk_module: Explicit SDK module to use, or ``None`` to import the real
+            one.
+        tool_factory: Override for the SDK ``tool`` decorator factory (tests).
+        server_factory: Override for the SDK ``create_sdk_mcp_server`` factory
+            (tests).
+        handler: Override for the tool handler; defaults to
+            :func:`_emit_intent_handler`.
+
+    Returns:
+        The constructed in-process MCP server config, or ``None`` when the SDK
+        lacks the required in-process MCP helpers.
     """
     sdk = _resolve_sdk(sdk_module)
     handler = handler or _emit_intent_handler

--- a/inference_optimizer/orchestrator/backends/robustness_agent.py
+++ b/inference_optimizer/orchestrator/backends/robustness_agent.py
@@ -43,6 +43,14 @@ def _default_runtime_caller(call: RuntimeCall) -> None:
 
     Sets ``PYTHONPATH=<root>/src`` + ``cwd=<root>`` so the package resolves
     without a pip-install (matching the critic-agent convention).
+
+    Args:
+        call: The invocation descriptor with phase, request / output paths,
+            working directory, and subprocess env.
+
+    Raises:
+        BackendError: If the phase is not ``tick``, the subprocess times out,
+            cannot start, or exits non-zero.
     """
     if call.phase != "tick":
         raise BackendError(
@@ -324,7 +332,12 @@ class RobustnessAgentBackend:
 
     def _build_runtime_env(self) -> dict[str, str]:
         """Build subprocess env with ``<root>/src`` prepended to PYTHONPATH
-        (preserving any existing value) so the CLI module resolves."""
+        (preserving any existing value) so the CLI module resolves.
+
+        Returns:
+            A copy of the current environment with ``PYTHONPATH`` and the
+            robustness session-dir hint applied.
+        """
         env = dict(os.environ)
         src = str(self.robustness_agent_root / "src")
         existing = env.get("PYTHONPATH", "").strip()

--- a/inference_optimizer/orchestrator/conc_sweep.py
+++ b/inference_optimizer/orchestrator/conc_sweep.py
@@ -55,7 +55,14 @@ DEFAULT_TOTAL_BUDGET_SEC = 9000
 
 
 def _has_optimization(state: SharedState) -> tuple[bool, str, dict[str, str]]:
-    """Return ``(has_opt, args, envs)`` from ``state.current_best`` (either non-empty side counts as optimized)."""
+    """Return ``(has_opt, args, envs)`` from ``state.current_best`` (either non-empty side counts as optimized).
+
+    Args:
+        state: Shared run state whose ``current_best`` is inspected.
+
+    Returns:
+        A tuple of ``(has_optimization, extra_server_args, extra_envs)``.
+    """
     cb = state.current_best or {}
     args = str(cb.get("extra_server_args") or "").strip()
     envs_raw = cb.get("extra_envs") or {}
@@ -72,7 +79,19 @@ def _build_grid(
     optimized_args: str,
     optimized_envs: dict[str, str],
 ) -> list[GridVariant]:
-    """Two-arm grid: ``baseline`` × ``optimized`` crossed with every requested CONC."""
+    """Two-arm grid: ``baseline`` × ``optimized`` crossed with every requested CONC.
+
+    Args:
+        concs: Concurrency values to sweep.
+        isl: Input sequence length.
+        osl: Output sequence length.
+        num_prompts_factor: Multiplier applied to each CONC for NUM_PROMPTS.
+        optimized_args: Extra server args for the optimized arm.
+        optimized_envs: Extra environment variables for the optimized arm.
+
+    Returns:
+        The list of grid variants spanning both arms and all concurrencies.
+    """
     arms: list[tuple[str, str, dict[str, str]]] = [
         ("baseline",  "",              {}),
         ("optimized", optimized_args,  dict(optimized_envs)),
@@ -98,7 +117,14 @@ def _build_grid(
 
 
 def _budget_skip_result(variant: GridVariant) -> VariantResult:
-    """Synthetic VariantResult for a budget-exhausted variant; ``skipped`` status distinguishes "out of time" from "Magpie crashed"."""
+    """Synthetic VariantResult for a budget-exhausted variant; ``skipped`` status distinguishes "out of time" from "Magpie crashed".
+
+    Args:
+        variant: The grid variant that did not get to run.
+
+    Returns:
+        A ``VariantResult`` marked ``skipped`` with a budget-exhausted error.
+    """
     return VariantResult(
         name=variant.name,
         extra_server_args=variant.extra_server_args,
@@ -114,7 +140,15 @@ def _budget_skip_result(variant: GridVariant) -> VariantResult:
 
 
 def _point_from_variant(v: VariantResult, *, arm: str) -> dict[str, Any]:
-    """Flatten a ``VariantResult`` into one row of the curve."""
+    """Flatten a ``VariantResult`` into one row of the curve.
+
+    Args:
+        v: The variant result to flatten.
+        arm: The arm label (e.g. ``baseline`` or ``optimized``) for the row.
+
+    Returns:
+        A dict of the variant's metrics keyed for the curve row.
+    """
     envs = v.extra_envs or {}
     try:
         conc = int(envs.get("CONC", "0"))
@@ -145,7 +179,12 @@ def _build_comparison(
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     """Pair points by CONC, compute per-conc speedup, and aggregate.
 
-    Returns ``(per_conc_rows, summary_dict)``.
+    Args:
+        baseline_points: Curve rows for the baseline arm.
+        optimized_points: Curve rows for the optimized arm.
+
+    Returns:
+        A tuple of ``(per_conc_rows, summary_dict)``.
     """
     by_conc_b = {p["conc"]: p for p in baseline_points}
     by_conc_o = {p["conc"]: p for p in optimized_points}
@@ -214,7 +253,12 @@ def _build_comparison(
 
 
 def _write_csv(csv_path: Path, points: list[dict[str, Any]]) -> None:
-    """One row per (arm, conc) — flat columns for spreadsheet pivots."""
+    """One row per (arm, conc) — flat columns for spreadsheet pivots.
+
+    Args:
+        csv_path: Destination CSV path (parent dirs are created).
+        points: Curve rows to write, one per (arm, conc).
+    """
     columns = [
         "arm", "conc", "status",
         "output_throughput", "request_throughput", "total_token_throughput",
@@ -238,7 +282,20 @@ def _build_roofline_ceiling(
     baseline_points: list[dict[str, Any]],
     optimized_points: list[dict[str, Any]],
 ) -> dict[str, Any] | None:
-    """Per-conc decode roofline alongside the measured curves (T_cmp once, T_mem per CONC; MBU% = measured/T_peak×100). ``None`` when model meta / GPU spec is unavailable."""
+    """Per-conc decode roofline alongside the measured curves (T_cmp once, T_mem per CONC; MBU% = measured/T_peak×100). ``None`` when model meta / GPU spec is unavailable.
+
+    Args:
+        state: Shared run state providing model path, precision, GPU type, TP.
+        concs: Concurrency values to compute ceilings for.
+        isl: Input sequence length.
+        osl: Output sequence length.
+        baseline_points: Measured baseline curve rows (for MBU%).
+        optimized_points: Measured optimized curve rows (for MBU%).
+
+    Returns:
+        A roofline ceiling payload dict, or ``None`` when model meta or GPU
+        spec is unavailable.
+    """
     model_path = str(getattr(state, "model_path", "") or "")
     precision = str(getattr(state, "precision", "") or "") or "bf16"
     meta = load_model_meta(model_path, precision_hint=precision)
@@ -348,7 +405,15 @@ def _build_roofline_ceiling(
 
 
 def _skip(reason: str, **extras: Any) -> dict[str, Any]:
-    """Build a non-fatal skip envelope. Reason is operator-readable."""
+    """Build a non-fatal skip envelope. Reason is operator-readable.
+
+    Args:
+        reason: Operator-readable reason for skipping.
+        **extras: Additional key/value fields to merge into the envelope.
+
+    Returns:
+        A skip-status payload dict.
+    """
     payload: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "status":         "skipped",
@@ -368,7 +433,20 @@ async def run_conc_sweep(
     num_prompts_factor: int = DEFAULT_NUM_PROMPTS_FACTOR,
     write_reports: bool = True,
 ) -> dict[str, Any]:
-    """Run the full conc-sweep post-hook end-to-end (always returns a dict; never raises; no files written when skipped)."""
+    """Run the full conc-sweep post-hook end-to-end (always returns a dict; never raises; no files written when skipped).
+
+    Args:
+        state: Shared run state (baseline, current_best, workload shape).
+        session_dir: Session directory for workspace and report outputs.
+        concs: Concurrency ladder to sweep; ``None`` uses the default ladder.
+        variant_timeout_sec: Per-variant timeout in seconds.
+        total_budget_sec: Total wall-clock budget in seconds; ``<=0`` disables.
+        num_prompts_factor: Multiplier applied to each CONC for NUM_PROMPTS.
+        write_reports: When ``True``, write the JSON/CSV reports to disk.
+
+    Returns:
+        The sweep payload dict (a skip envelope when prerequisites are unmet).
+    """
     session_dir = Path(session_dir)
     # ``None`` → default ladder; an explicit empty list short-circuits via ``empty_conc_list`` below.
     concs = list(concs) if concs is not None else list(DEFAULT_CONCS)
@@ -551,7 +629,14 @@ async def run_conc_sweep(
 
 
 def format_summary_line(payload: dict[str, Any]) -> str:
-    """One-line stdout summary for ``_print_final_summary``."""
+    """One-line stdout summary for ``_print_final_summary``.
+
+    Args:
+        payload: The conc-sweep result payload to summarize.
+
+    Returns:
+        A single formatted summary line.
+    """
     status = payload.get("status", "?")
     if status == "skipped":
         return f"  conc_sweep           : skipped ({payload.get('skip_reason', '?')})"

--- a/inference_optimizer/orchestrator/conc_sweep.py
+++ b/inference_optimizer/orchestrator/conc_sweep.py
@@ -297,6 +297,15 @@ def _build_roofline_ceiling(
             t_peak = t_mem
 
         def _mbu_pct(measured: Any) -> float | None:
+            """Express a measured throughput as a percent of peak.
+
+            Args:
+                measured: Measured throughput value.
+
+            Returns:
+                The ratio to ``t_peak`` as a percentage, or ``None`` when
+                inputs are non-positive or invalid.
+            """
             if not isinstance(measured, (int, float)) or measured <= 0:
                 return None
             if t_peak <= 0:

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -1067,12 +1067,24 @@ class Coordinator:
             )
 
     def _kernel_enabled(self) -> bool:
+        """Whether the kernel role is registered and enabled.
+
+        Returns:
+            ``True`` if the kernel role exists and the persisted
+            ``kernel_enabled`` flag is set.
+        """
         # Mirror persisted kernel_enabled flag; --no-kernel removes the kernel role.
         return "kernel" in self.role_registry and bool(
             getattr(self.shared_state, "kernel_enabled", True)
         )
 
     def _explore_enabled(self) -> bool:
+        """Whether the EXPLORE phase is enabled for this run.
+
+        Returns:
+            ``True`` unless ``--no-explore`` disabled it (collapsing to
+            KERNEL/SWEEP).
+        """
         # Mirror persisted explore_enabled flag; --no-explore collapses to KERNEL/SWEEP. EXPLORE is a phase, not a role.
         return bool(getattr(self.shared_state, "explore_enabled", True))
 
@@ -4335,6 +4347,15 @@ class Coordinator:
         return "\n".join(sections)
 
     async def _load_system_prompt(self, agent_name: str) -> str:
+        """Load the system prompt for an agent, honoring overrides.
+
+        Args:
+            agent_name: Name of the agent/role whose prompt to load.
+
+        Returns:
+            The override prompt if configured, the role's prompt file
+            contents, or a placeholder string when none exists.
+        """
         # Demo/test override via self.system_prompt_overrides[agent_name].
         override = getattr(self, "system_prompt_overrides", {}).get(agent_name)
         if override is not None:
@@ -6606,6 +6627,15 @@ class Coordinator:
         ))
 
     async def _handle_force_dispatch(self, source: str, intent: Intent) -> None:
+        """Handle a ``force_dispatch`` intent by emitting an event.
+
+        Currently a P0-3 stub: it broadcasts a ``force_dispatch`` event;
+        real dispatcher reordering arrives in P0-5 with the priority queue.
+
+        Args:
+            source: Identifier of the intent's originating agent.
+            intent: The ``force_dispatch`` intent carrying ``task_id``.
+        """
         # P0-3 stub: emit an event; real dispatcher reordering lands in P0-5 with the priority queue.
         await self.bus.append_and_seq(Message.new(
             source, "*", "event",

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -118,7 +118,15 @@ _OUTCOME_STATUS_KEYS: tuple[str, ...] = ("status", "verdict", "outcome")
 
 
 def _first_present(d: dict[str, Any], keys: tuple[str, ...]) -> Any | None:
-    """Return ``d[k]`` for the first ``k`` in ``keys`` present + non-None."""
+    """Return ``d[k]`` for the first ``k`` in ``keys`` present + non-None.
+
+    Args:
+        d: Mapping to look up; a non-dict yields ``None``.
+        keys: Candidate keys probed in order.
+
+    Returns:
+        The first non-None value found, or ``None`` if none match.
+    """
     if not isinstance(d, dict):
         return None
     for k in keys:
@@ -129,7 +137,14 @@ def _first_present(d: dict[str, Any], keys: tuple[str, ...]) -> Any | None:
 
 
 def _format_inbox_event(m: "Message") -> str:
-    """Render one inbox ``Message`` as a compact, high-signal line (Path A/A1)."""
+    """Render one inbox ``Message`` as a compact, high-signal line (Path A/A1).
+
+    Args:
+        m: The inbox message to render.
+
+    Returns:
+        A single-line, topic-aware summary of the message.
+    """
     topic = (m.topic or "").strip()
     payload = m.payload if isinstance(m.payload, dict) else {}
     # DESIGN §13.1: canonical inbox header ordering downstream parsers anchor on.
@@ -224,7 +239,14 @@ _LIFECYCLE_PATH_KEYS: tuple[str, ...] = (
 def _lifecycle_paths(payload: Any) -> dict[str, str]:
     """Extract present, non-empty path-like fields from a kernel handler
     payload or result dict (#266). Best-effort: a non-dict argument yields
-    an empty mapping so callers never have to guard the type."""
+    an empty mapping so callers never have to guard the type.
+
+    Args:
+        payload: Kernel handler payload or result; non-dicts are tolerated.
+
+    Returns:
+        Mapping of recognised path-like keys to their non-empty string values.
+    """
     if not isinstance(payload, dict):
         return {}
     out: dict[str, str] = {}
@@ -497,7 +519,11 @@ class Coordinator:
 
     # Context-pull tools (plan Step 2)
     def _orchestration_conversational(self) -> bool:
-        """True when the orchestration backend runs in persistent-conversation mode (plan Step 1)."""
+        """True when the orchestration backend runs in persistent-conversation mode (plan Step 1).
+
+        Returns:
+            ``True`` if the orchestration backend is conversational.
+        """
         backend = self.backends.get("orchestration")
         return bool(getattr(backend, "conversational", False))
 
@@ -513,7 +539,12 @@ class Coordinator:
         self._orchestration_seeded = False
 
     def _conversation_progress_signal(self) -> dict[str, Any]:
-        """Compute the no-progress circuit-breaker signal (plan Step 6)."""
+        """Compute the no-progress circuit-breaker signal (plan Step 6).
+
+        Returns:
+            Mapping with ``ticks_without_progress``, ``threshold``,
+            ``severity`` ("ok"/"high") and ``last_progress_tick``.
+        """
         state = self.shared_state
         cur_tick = int(getattr(state, "tick", 0) or 0)
         try:
@@ -572,6 +603,14 @@ class Coordinator:
         """Compact the orchestration conversation into durable memory (plan Step 4).
 
         Returns True when a checkpoint was taken. Best-effort.
+
+        Args:
+            tick: Current coordinator tick number.
+            phase_changed: Whether the phase changed since the last checkpoint,
+                which biases the policy toward checkpointing.
+
+        Returns:
+            ``True`` when a checkpoint was taken, ``False`` otherwise.
         """
         if not self._checkpoint_enabled:
             return False
@@ -679,7 +718,15 @@ class Coordinator:
             log.exception("Coordinator: failed to attach orchestration context tools")
 
     def _context_inbox_reader(self, since_seq: int = 0) -> str:
-        """Synchronous projection of the orchestration inbox tail (sync SQLite path)."""
+        """Synchronous projection of the orchestration inbox tail (sync SQLite path).
+
+        Args:
+            since_seq: Only events with a sequence greater than this are read.
+
+        Returns:
+            Newline-joined rendering of the last inbox events, or a placeholder
+            string when none are available.
+        """
         try:
             rows = self.bus.db.fetchall_sync(
                 "SELECT * FROM events WHERE seq > ? AND "
@@ -696,7 +743,15 @@ class Coordinator:
         return "\n".join(lines)
 
     def _context_recent_outcomes_reader(self, top_k: int = 8) -> str:
-        """Synchronous projection of recent action outcomes (Path A / A2)."""
+        """Synchronous projection of recent action outcomes (Path A / A2).
+
+        Args:
+            top_k: Number of recent outcomes to include (clamped to 1..50).
+
+        Returns:
+            Newline-joined, chronologically ordered rendering of recent
+            outcomes, or a placeholder string when none exist.
+        """
         try:
             k = max(1, min(int(top_k or 8), 50))
         except (TypeError, ValueError):
@@ -725,7 +780,11 @@ class Coordinator:
     })
 
     def _inline_action_whitelist(self) -> frozenset[str]:
-        """Derive the set of actions safe to run inline (A3): lane-light, registered executor, not in _INLINE_ACTION_DENY. PolicyGate remains the real security boundary."""
+        """Derive the set of actions safe to run inline (A3): lane-light, registered executor, not in _INLINE_ACTION_DENY. PolicyGate remains the real security boundary.
+
+        Returns:
+            Frozen set of inline-eligible action names.
+        """
         reg = getattr(self, "action_registry", None)
         if reg is None:
             return frozenset()
@@ -750,7 +809,16 @@ class Coordinator:
     def _run_action_now_sync(
         self, action_name: str, params: dict[str, Any] | None = None,
     ) -> str:
-        """Bridge callable for the ``run_action_now`` context tool (A3): marshals the executor coroutine onto the Coordinator loop and blocks with a timeout."""
+        """Bridge callable for the ``run_action_now`` context tool (A3): marshals the executor coroutine onto the Coordinator loop and blocks with a timeout.
+
+        Args:
+            action_name: Name of the action to run inline.
+            params: Action parameters; ``None`` is treated as empty.
+
+        Returns:
+            A human-readable status string describing the inline run outcome
+            (completion, denial, timeout or error).
+        """
         if not self._inline_fast_actions_enabled:
             return (
                 "(run_action_now disabled: set "
@@ -804,7 +872,16 @@ class Coordinator:
     async def _run_action_now(
         self, action_name: str, params: dict[str, Any],
     ) -> str:
-        """Coordinator-loop coroutine that runs a whitelisted action inline through PolicyGate + SubAgentRunner, publishing a delegated_result for audit/inbox parity."""
+        """Coordinator-loop coroutine that runs a whitelisted action inline through PolicyGate + SubAgentRunner, publishing a delegated_result for audit/inbox parity.
+
+        Args:
+            action_name: Name of the action to run inline.
+            params: Action parameters.
+
+        Returns:
+            A human-readable status string describing the run outcome or a
+            policy/sequence denial.
+        """
         from .message_bus import Message
         # PolicyGate parity (R1): validate synthetic delegate intent so phase/role/paths/red-line gates apply.
         intent = Intent(
@@ -873,7 +950,12 @@ class Coordinator:
         return f"inline run complete: {rendered}"
 
     def _context_analysis_reader(self) -> str:
-        """Return the latest TraceLens analysis.md snapshot text."""
+        """Return the latest TraceLens analysis.md snapshot text.
+
+        Returns:
+            The analysis.md content, or a placeholder/error string when no
+            snapshot is available or the recorded path is unreadable.
+        """
         try:
             blob = self.shared_state._format_analysis_md_full()
             if blob and blob.strip():
@@ -893,7 +975,12 @@ class Coordinator:
 
     # Resume
     def _detect_resume_state(self) -> dict[str, Any]:
-        """Synchronously inspect persistence to determine if this is a resume (non-blocking)."""
+        """Synchronously inspect persistence to determine if this is a resume (non-blocking).
+
+        Returns:
+            Mapping with ``is_resume``, ``event_count``, ``state_json_present``
+            and ``rebuilt`` (set later by :meth:`replay_for_resume`).
+        """
         ev_count = self.bus.db.fetchone_sync("SELECT COUNT(*) AS c FROM events")
         events_present = (int(ev_count["c"]) if ev_count else 0) > 0
         state_path = SharedState.state_path(self.session_dir)
@@ -905,7 +992,13 @@ class Coordinator:
         }
 
     async def replay_for_resume(self) -> dict[str, Any]:
-        """Walk the event log to reconstruct ``CoordinatorState.pending_proposals``. Idempotent; a proposal is undecided when no review_verdict targets it."""
+        """Walk the event log to reconstruct ``CoordinatorState.pending_proposals``. Idempotent; a proposal is undecided when no review_verdict targets it.
+
+        Returns:
+            Mapping summarising the resume replay: ``is_resume``,
+            ``event_count``, ``state_json_present``, ``pending_restored`` and
+            ``verdicts_seen``.
+        """
         proposal_msgs = await self.bus.tail(topic="proposal", n=10_000)
         verdicts = await self.bus.tail(topic="review_verdict", n=10_000)
 
@@ -949,7 +1042,11 @@ class Coordinator:
 
     @property
     def resumed_from(self) -> dict[str, Any]:
-        """Read-only snapshot of resume detection (set by ``__init__``)."""
+        """Read-only snapshot of resume detection (set by ``__init__``).
+
+        Returns:
+            A copy of the resume-detection mapping.
+        """
         return dict(self._resumed_from)
 
     # Lifecycle
@@ -1182,7 +1279,12 @@ class Coordinator:
             log.exception("Coordinator: _on_phase_entered hook failed")
 
     async def _on_phase_entered(self, *, from_phase: str, to_phase: str) -> None:
-        """Fire per-phase entry side effects (pure dispatcher; hooks catch + log internally). CLOSE runs the 5-step sequencer (KB_design §3.2 §5.5 + KB_gaps/Gap-06; sets close_sequence_done)."""
+        """Fire per-phase entry side effects (pure dispatcher; hooks catch + log internally). CLOSE runs the 5-step sequencer (KB_design §3.2 §5.5 + KB_gaps/Gap-06; sets close_sequence_done).
+
+        Args:
+            from_phase: The phase being left.
+            to_phase: The phase just entered, used to dispatch the hook.
+        """
         # Orchestration checkpoint at the phase seam (plan Step 4); runs before per-phase side effects.
         try:
             await self._maybe_checkpoint_orchestration(
@@ -1205,7 +1307,11 @@ class Coordinator:
             await self._on_enter_close(from_phase=from_phase)
 
     async def _on_enter_explore(self, *, from_phase: str) -> None:
-        """Warm ``KnowledgePlane.pr_feed`` across specialist domains (best-effort) on EXPLORE entry. Roofline lives in PRELUDE, not here."""
+        """Warm ``KnowledgePlane.pr_feed`` across specialist domains (best-effort) on EXPLORE entry. Roofline lives in PRELUDE, not here.
+
+        Args:
+            from_phase: The phase being left, used only for logging.
+        """
         plane = self.knowledge_plane
         if plane is None:
             return
@@ -1223,7 +1329,11 @@ class Coordinator:
             )
 
     async def _on_enter_framework_pr(self, *, from_phase: str) -> None:
-        """FRAMEWORK_PR entry hook: trigger the per-batch pump once on entry (best-effort; later batches driven from the main tick)."""
+        """FRAMEWORK_PR entry hook: trigger the per-batch pump once on entry (best-effort; later batches driven from the main tick).
+
+        Args:
+            from_phase: The phase being left, used only for logging.
+        """
         log.info(
             "FRAMEWORK_PR entry (from=%s): pumping initial batch",
             from_phase or "<unknown>",
@@ -1331,7 +1441,11 @@ class Coordinator:
                 )
 
     async def _framework_pr_authoring_inflight(self) -> bool:
-        """True while a FRAMEWORK_PR-authored patch is still in flight (specialist/integrate_patch task or pending integrate_patch proposal); pump waits before advancing."""
+        """True while a FRAMEWORK_PR-authored patch is still in flight (specialist/integrate_patch task or pending integrate_patch proposal); pump waits before advancing.
+
+        Returns:
+            ``True`` if an authored patch is still being processed.
+        """
         try:
             queued = await self.tasks.queued()
             running = await self.tasks.running()
@@ -1352,7 +1466,12 @@ class Coordinator:
     async def _enqueue_framework_pr_authoring_specialist(
         self, candidate: dict[str, Any],
     ) -> None:
-        """Dispatch a write-capable specialist seeded with ``candidate`` (Inv-5.1: flows through autosubmit → Critic → integrate_patch → bench → KEEP/REVERT)."""
+        """Dispatch a write-capable specialist seeded with ``candidate`` (Inv-5.1: flows through autosubmit → Critic → integrate_patch → bench → KEEP/REVERT).
+
+        Args:
+            candidate: Discovered upstream PR candidate used to seed the
+                authoring specialist (title, urls, gap and batch ids).
+        """
         state = self.shared_state
         cand_id = str(
             candidate.get("candidate_id")
@@ -1437,7 +1556,12 @@ class Coordinator:
         )
 
     def _select_next_framework_pr_candidate(self) -> dict[str, Any] | None:
-        """Return the next unprocessed candidate in the latest batch (processed = has progress entry)."""
+        """Return the next unprocessed candidate in the latest batch (processed = has progress entry).
+
+        Returns:
+            The next candidate dict, or ``None`` when the latest batch is empty
+            or fully processed.
+        """
         state = self.shared_state
         batches = getattr(state, "framework_pr_batches", None) or []
         if not batches:
@@ -1467,7 +1591,12 @@ class Coordinator:
         return None
 
     def _framework_pr_known_candidate_ids(self) -> set[str]:
-        """All candidate ids already discovered into any prior batch (dedup for new batches)."""
+        """All candidate ids already discovered into any prior batch (dedup for new batches).
+
+        Returns:
+            Set of candidate ids seen across all batches plus PR ids already
+            mined by the research scout.
+        """
         state = self.shared_state
         ids: set[str] = set()
         batches = getattr(state, "framework_pr_batches", None) or []
@@ -1495,7 +1624,11 @@ class Coordinator:
         return ids
 
     def _framework_pr_tried_refs(self) -> list[str]:
-        """Refs already discovered this phase (fed to compose_gap to bias away from prior PR categories)."""
+        """Refs already discovered this phase (fed to compose_gap to bias away from prior PR categories).
+
+        Returns:
+            List of already-discovered candidate refs.
+        """
         refs: list[str] = []
         for cid in self._framework_pr_known_candidate_ids():
             if cid:
@@ -1503,7 +1636,14 @@ class Coordinator:
         return refs
 
     def _framework_pr_discover_repo_urls(self, framework: str) -> list[str]:
-        """Repo URLs to query for the FRAMEWORK_PR batch: framework's own repo + pr_intel_specialist cross-repo set, dedup preserving order."""
+        """Repo URLs to query for the FRAMEWORK_PR batch: framework's own repo + pr_intel_specialist cross-repo set, dedup preserving order.
+
+        Args:
+            framework: Framework name whose repo seeds the query set.
+
+        Returns:
+            Ordered, de-duplicated list of repo URLs to query.
+        """
         from . import framework_agent_client as _fa_client
 
         urls: list[str] = []
@@ -1544,7 +1684,12 @@ class Coordinator:
     def _record_framework_pr_phase_done(
         self, *, reason: str, failure_count: int,
     ) -> None:
-        """Append a framework_pr_phase_done row to phase_history describing why the pump gave up."""
+        """Append a framework_pr_phase_done row to phase_history describing why the pump gave up.
+
+        Args:
+            reason: Human-readable reason the phase finished.
+            failure_count: Number of consecutive discover failures recorded.
+        """
         state = self.shared_state
         try:
             history = getattr(state, "phase_history", None)
@@ -1563,7 +1708,12 @@ class Coordinator:
             pass
 
     async def _discover_next_framework_pr_batch(self) -> bool:
-        """Call ``fa phase-discover`` and append a batch to SharedState. Returns True iff a non-empty batch was appended; transient failures return False (see DISCOVER_FAILURE_RETRY_LIMIT)."""
+        """Call ``fa phase-discover`` and append a batch to SharedState. Returns True iff a non-empty batch was appended; transient failures return False (see DISCOVER_FAILURE_RETRY_LIMIT).
+
+        Returns:
+            ``True`` when a non-empty batch was appended, ``False`` on a
+            transient failure or empty payload.
+        """
         from . import framework_agent_client as _fa_client
 
         state = self.shared_state
@@ -1802,7 +1952,12 @@ class Coordinator:
     _CRITIC_PRIORS_OUTCOME_TAIL: int = 5
 
     def _collect_framework_pr_priors(self) -> dict[str, Any]:
-        """Return compact session-local priors for the Critic gate (recent_decisions + recent_outcomes); best-effort."""
+        """Return compact session-local priors for the Critic gate (recent_decisions + recent_outcomes); best-effort.
+
+        Returns:
+            Mapping with ``recent_decisions`` and ``recent_outcomes`` lists,
+            each bounded to a short tail.
+        """
         state = self.shared_state
         decisions: list[dict[str, Any]] = []
         try:
@@ -1842,6 +1997,13 @@ class Coordinator:
 
         Returns {"verdict": "approve"|"reject"|"abstain", "rationale": str}. abstain is the safe degraded
         path (treated as approve by caller); decisions cached in framework_pr_critic_decisions for resume.
+
+        Args:
+            candidate: The discovered PR candidate to review.
+
+        Returns:
+            Mapping with ``verdict`` ("approve"/"reject"/"abstain") and a
+            ``rationale`` string.
         """
         state = self.shared_state
         cand_id = str(
@@ -1952,7 +2114,11 @@ class Coordinator:
         return verdict_row
 
     async def _on_enter_kernel(self, *, from_phase: str) -> None:
-        """Run deterministic KERNEL-entry setup before LLM kernel work (FP8 GEMM tuning gate)."""
+        """Run deterministic KERNEL-entry setup before LLM kernel work (FP8 GEMM tuning gate).
+
+        Args:
+            from_phase: The phase being left, used for logging.
+        """
         if not self._kernel_enabled():
             # Should not happen — --no-kernel routes EXPLORE → SWEEP.
             log.info(
@@ -2152,7 +2318,11 @@ class Coordinator:
     _ROOFLINE_WATERMARK_RATIO: float = 1.10   # 10% step over last roofline
 
     def _current_tput_from_validated_gain(self) -> float:
-        """Project current tput from ``baseline_tput * (1 + cumulative_gain_validated/100)``; 0.0 when baseline unknown (watermark not-yet-armed)."""
+        """Project current tput from ``baseline_tput * (1 + cumulative_gain_validated/100)``; 0.0 when baseline unknown (watermark not-yet-armed).
+
+        Returns:
+            Projected throughput, or ``0.0`` when the baseline is unknown.
+        """
         state = self.shared_state
         try:
             base = float(state.baseline_tput or 0.0)
@@ -2167,7 +2337,11 @@ class Coordinator:
         return base * (1.0 + gain / 100.0)
 
     def _needs_roofline_for_watermark(self) -> bool:
-        """True iff projected tput crossed the 10% watermark over ``last_roofline_tput`` (bootstrap guard: False until PRELUDE roofline ran; re-arm guard: False while auto_roofline_pending_task_id is in-flight)."""
+        """True iff projected tput crossed the 10% watermark over ``last_roofline_tput`` (bootstrap guard: False until PRELUDE roofline ran; re-arm guard: False while auto_roofline_pending_task_id is in-flight).
+
+        Returns:
+            ``True`` when a fresh roofline is warranted by the watermark.
+        """
         state = self.shared_state
         try:
             last_rl = float(state.last_roofline_tput or 0.0)
@@ -2198,7 +2372,14 @@ class Coordinator:
     async def _maybe_enqueue_watermark_roofline(
         self, *, reason: str,
     ) -> bool:
-        """Enqueue a fresh roofline if the watermark crossed; idempotency-keyed via ``reason``, stamps auto_roofline_pending_task_id. Returns True when enqueued."""
+        """Enqueue a fresh roofline if the watermark crossed; idempotency-keyed via ``reason``, stamps auto_roofline_pending_task_id. Returns True when enqueued.
+
+        Args:
+            reason: Tag used for idempotency keying and logging.
+
+        Returns:
+            ``True`` when a roofline task was enqueued, ``False`` otherwise.
+        """
         if not self._needs_roofline_for_watermark():
             return False
         try:
@@ -2220,13 +2401,25 @@ class Coordinator:
         return True
 
     def _internal_analysis_kind(self) -> str:
-        """Pick the kind for the next Coordinator-internal analysis task: roofline (composite) when enable_roofline else profile. Both absent from PHASE_LLM_PROPOSABLE_ACTIONS (PolicyGate R1 denies LLM proposals)."""
+        """Pick the kind for the next Coordinator-internal analysis task: roofline (composite) when enable_roofline else profile. Both absent from PHASE_LLM_PROPOSABLE_ACTIONS (PolicyGate R1 denies LLM proposals).
+
+        Returns:
+            ``"roofline"`` when roofline is enabled, else ``"profile"``.
+        """
         return "roofline" if bool(
             getattr(self.shared_state, "enable_roofline", True),
         ) else "profile"
 
     def _registry_lanes_ttl(self, kind: str) -> tuple[list[str], int]:
-        """Resolve ``(requires_lanes, lease_ttl_sec)`` from the ActionRegistry; lanes filtered to KNOWN_LANES, returns ([], 0) for unknown actions."""
+        """Resolve ``(requires_lanes, lease_ttl_sec)`` from the ActionRegistry; lanes filtered to KNOWN_LANES, returns ([], 0) for unknown actions.
+
+        Args:
+            kind: Action name to look up in the registry.
+
+        Returns:
+            Tuple of (required lane names, lease TTL seconds); ``([], 0)`` for
+            unknown actions.
+        """
         reg = getattr(self, "action_registry", None)
         if reg is None:
             return [], 0
@@ -2240,7 +2433,11 @@ class Coordinator:
         return lanes, int(getattr(meta, "lease_ttl_sec", 0) or 0)
 
     def _warm_recipe_proven_items(self) -> list[dict[str, str]]:
-        """Summarise warm-start ``what_worked`` items the scout can skip ({name, source}); fail-soft."""
+        """Summarise warm-start ``what_worked`` items the scout can skip ({name, source}); fail-soft.
+
+        Returns:
+            List of ``{"name", "source"}`` dicts for proven warm-start items.
+        """
         state = self.shared_state
         warm = getattr(state, "warm_start_recipe", None) or {}
         if not isinstance(warm, dict) or not warm:
@@ -2261,7 +2458,11 @@ class Coordinator:
         return out
 
     def _inject_warm_recipe_history_into_ledger(self) -> int:
-        """GAP 1 — pre-fill ``explore_search.rejected`` with the warm recipe's ``what_failed`` rows (fingerprinted so the dedup gate denies re-tests). Idempotent via warm_history_injected; returns rows added."""
+        """GAP 1 — pre-fill ``explore_search.rejected`` with the warm recipe's ``what_failed`` rows (fingerprinted so the dedup gate denies re-tests). Idempotent via warm_history_injected; returns rows added.
+
+        Returns:
+            Number of rejected rows injected into the ledger.
+        """
         state = self.shared_state
         if getattr(state, "warm_history_injected", False):
             return 0
@@ -2341,6 +2542,13 @@ class Coordinator:
 
         Skips on --no-warm-replay/resume/low-confidence/empty best_config; otherwise mints an internal
         task running the baseline workload contract with the KB config applied. Idempotent via warm-replay-prelude.
+
+        Args:
+            baseline_tput: Measured baseline throughput used as the replay
+                anchor.
+
+        Returns:
+            The enqueued ``Task``, or ``None`` when the replay is skipped.
         """
         state = self.shared_state
         if not getattr(self, "_warm_replay_enabled", True):
@@ -2482,7 +2690,12 @@ class Coordinator:
     def _promote_warm_replay(
         self, result: dict, *, task: "Task | None" = None,
     ) -> None:
-        """GAP 1 — interpret a ``replay_warm_recipe`` result: any measured uplift pushes warm config onto optimization_stack + current_best; failures set status and never propagate."""
+        """GAP 1 — interpret a ``replay_warm_recipe`` result: any measured uplift pushes warm config onto optimization_stack + current_best; failures set status and never propagate.
+
+        Args:
+            result: The ``replay_warm_recipe`` task result payload.
+            task: The originating replay task, when available.
+        """
         state = self.shared_state
         outcome = dict(state.warm_replay_outcome or {})
         expected_gain = float(outcome.get("expected_gain_pct") or 0.0)
@@ -2650,7 +2863,12 @@ class Coordinator:
         *,
         baseline_tput: float | None = None,
     ) -> None:
-        """Enqueue the PRELUDE-bootstrap roofline/profile task after baseline; skipped while warm-replay is in_flight (GPU/port contention)."""
+        """Enqueue the PRELUDE-bootstrap roofline/profile task after baseline; skipped while warm-replay is in_flight (GPU/port contention).
+
+        Args:
+            baseline_tput: Measured baseline throughput; ``None`` reads it from
+                shared state.
+        """
         state = self.shared_state
         if _phase_state.warm_replay_in_flight(state):
             log.info(
@@ -2684,7 +2902,14 @@ class Coordinator:
             )
 
     async def _enqueue_internal_analysis_task(self, *, reason: str) -> Task:
-        """Build + enqueue a Coordinator-internal analysis task (roofline or profile). Kind-agnostic idempotency key internal-analysis-<reason>; omits baseline_config_path so ProfileExecutor enables torch_profiler."""
+        """Build + enqueue a Coordinator-internal analysis task (roofline or profile). Kind-agnostic idempotency key internal-analysis-<reason>; omits baseline_config_path so ProfileExecutor enables torch_profiler.
+
+        Args:
+            reason: Tag used for idempotency keying and base-args selection.
+
+        Returns:
+            The enqueued (or pre-existing idempotent) analysis ``Task``.
+        """
         state = self.shared_state
         kind = self._internal_analysis_kind()
         params: dict[str, Any] = {
@@ -2731,7 +2956,11 @@ class Coordinator:
         return task
 
     def _record_phase_entry_evidence(self, **kvs: Any) -> None:
-        """Merge ``kvs`` into the latest phase_history row's evidence dict (Gap-04; no-op when empty)."""
+        """Merge ``kvs`` into the latest phase_history row's evidence dict (Gap-04; no-op when empty).
+
+        Args:
+            **kvs: Evidence key/value pairs merged into the latest phase row.
+        """
         history = self.shared_state.phase_history or []
         if not history:
             return
@@ -2792,7 +3021,11 @@ class Coordinator:
             )
 
     async def _on_enter_sweep(self, *, from_phase: str) -> None:
-        """Auto-enqueue a ``sweep`` task on SWEEP entry (§3.2 §5.4). Idempotent via internal-sweep-phase_entry (Inv-2.1); PolicyGate's sweep_phase_singleton then denies LLM-emitted sweep (OOM race)."""
+        """Auto-enqueue a ``sweep`` task on SWEEP entry (§3.2 §5.4). Idempotent via internal-sweep-phase_entry (Inv-2.1); PolicyGate's sweep_phase_singleton then denies LLM-emitted sweep (OOM race).
+
+        Args:
+            from_phase: The phase being left, used for logging.
+        """
         state = self.shared_state
         # Bug #7 fix: drain pending KEEP integrates from prior KERNEL so sweep measures full current_best.
         if getattr(state, "has_keep_pending_integrate", False):
@@ -2830,7 +3063,14 @@ class Coordinator:
     async def _enqueue_internal_conc_sweep_task(
         self, *, reason: str,
     ) -> Task | None:
-        """Build + enqueue a Coordinator-internal ``conc_sweep`` task (caller checks conc_sweep_enabled). Idempotency key + PolicyGate singleton ensure ≤1 per SWEEP; returns None on error."""
+        """Build + enqueue a Coordinator-internal ``conc_sweep`` task (caller checks conc_sweep_enabled). Idempotency key + PolicyGate singleton ensure ≤1 per SWEEP; returns None on error.
+
+        Args:
+            reason: Tag used for idempotency keying and logging.
+
+        Returns:
+            The enqueued ``conc_sweep`` task, or ``None`` on error.
+        """
         state = self.shared_state
         params: dict[str, Any] = {
             "source": "coordinator_internal",
@@ -2871,7 +3111,14 @@ class Coordinator:
     async def _enqueue_internal_sweep_task(
         self, *, reason: str,
     ) -> Task:
-        """Build + enqueue a Coordinator-internal ``sweep`` task. Grid priority: warm_start_recipe.sweep_grid then SKILL.md defaults. Idempotency key internal-sweep-<reason>."""
+        """Build + enqueue a Coordinator-internal ``sweep`` task. Grid priority: warm_start_recipe.sweep_grid then SKILL.md defaults. Idempotency key internal-sweep-<reason>.
+
+        Args:
+            reason: Tag used for idempotency keying and logging.
+
+        Returns:
+            The enqueued (or pre-existing idempotent) ``sweep`` task.
+        """
         state = self.shared_state
         grid_params = self._build_sweep_params_from_recipe(state)
         params: dict[str, Any] = {
@@ -2908,7 +3155,15 @@ class Coordinator:
 
     @staticmethod
     def _build_sweep_params_from_recipe(state: SharedState) -> dict[str, Any]:
-        """Pick a sweep grid (§3.14 R-13): warm_start_recipe.sweep_grid takes precedence over SKILL.md defaults; per-field fallback. Returns source/conc_values/isl_osl_configs/num_prompts_factor."""
+        """Pick a sweep grid (§3.14 R-13): warm_start_recipe.sweep_grid takes precedence over SKILL.md defaults; per-field fallback. Returns source/conc_values/isl_osl_configs/num_prompts_factor.
+
+        Args:
+            state: Session shared state holding any warm-start recipe grid.
+
+        Returns:
+            Mapping with ``source``, ``conc_values``, ``isl_osl_configs`` and
+            ``num_prompts_factor``.
+        """
         from .action_executors.sweep import (
             DEFAULT_CONC_VALUES,
             DEFAULT_ISL_OSL,
@@ -3012,7 +3267,11 @@ class Coordinator:
     CLOSE_NDJSON_DRAIN_TIMEOUT_SEC: float = 60.0
 
     def _derive_close_stop_reason(self) -> str:
-        """Best-effort ``stop_reason`` for a CLOSE reached blank: recover from the newest CLOSE-bound phase_history row, else time_exhausted."""
+        """Best-effort ``stop_reason`` for a CLOSE reached blank: recover from the newest CLOSE-bound phase_history row, else time_exhausted.
+
+        Returns:
+            The recovered stop reason, or ``"time_exhausted"`` as a fallback.
+        """
         history = self.shared_state.phase_history or []
         for row in reversed(history):
             if not isinstance(row, dict):
@@ -3028,7 +3287,11 @@ class Coordinator:
         return "time_exhausted"
 
     async def _on_enter_close(self, *, from_phase: str) -> None:
-        """CLOSE 5-step sequencer (fixed order): report → session_breakdown → fact_finalize → ndjson_drain (no-op) → mark close_sequence_done + stop_reason. Best-effort steps; final done step always runs."""
+        """CLOSE 5-step sequencer (fixed order): report → session_breakdown → fact_finalize → ndjson_drain (no-op) → mark close_sequence_done + stop_reason. Best-effort steps; final done step always runs.
+
+        Args:
+            from_phase: The phase being left, used for logging.
+        """
         log.info("CLOSE entered (from=%s); starting 5-step close sequence",
                  from_phase or "<unknown>")
         await self._record_close_step("sequencer_started", status="running")
@@ -3218,6 +3481,12 @@ class Coordinator:
         """Build + enqueue a Coordinator-internal ``report`` task (idempotency_key internal-report-<reason>).
 
         Reuses closing_report_task_id when set so the wall-clock + CLOSE-sequencer paths don't race.
+
+        Args:
+            reason: Tag used for idempotency keying and logging.
+
+        Returns:
+            The enqueued (or reused) ``report`` task.
         """
         existing_id = (self.shared_state.closing_report_task_id or "").strip()
         if existing_id:
@@ -3267,7 +3536,16 @@ class Coordinator:
     async def _enqueue_internal_research_scout_task(
         self, *, reason: str, round_id: int,
     ) -> "Task | None":
-        """Enqueue a Coordinator-owned read-only research-scout specialist task; idempotency keyed by round, returns None on existing/failure (fail-soft)."""
+        """Enqueue a Coordinator-owned read-only research-scout specialist task; idempotency keyed by round, returns None on existing/failure (fail-soft).
+
+        Args:
+            reason: Tag used for idempotency keying and logging.
+            round_id: EXPLORE round number, part of the idempotency key.
+
+        Returns:
+            The dispatched scout ``Task``, or ``None`` when disabled, already
+            existing, or on failure.
+        """
         if not bool(getattr(self.shared_state, "research_scout_enabled", True)):
             return None
         idempotency_key = f"internal-research-scout-round{int(round_id)}"
@@ -3362,7 +3640,11 @@ class Coordinator:
             log.exception("research-scout: EXPLORE re-dispatch failed")
 
     def _harvest_research_scout(self, done_payload: dict[str, Any]) -> None:
-        """Persist scout output (hints, competitor target, gap seeds, dedup); all steps fail-soft."""
+        """Persist scout output (hints, competitor target, gap seeds, dedup); all steps fail-soft.
+
+        Args:
+            done_payload: The research-scout task's completion payload.
+        """
         from . import research_hints as _research_hints
 
         block = done_payload.get("research")
@@ -3435,7 +3717,14 @@ class Coordinator:
     async def _enqueue_internal_session_breakdown_task(
         self, *, reason: str,
     ) -> Task:
-        """Build + enqueue a Coordinator-internal ``session_breakdown`` task; same idempotency contract as the report helper."""
+        """Build + enqueue a Coordinator-internal ``session_breakdown`` task; same idempotency contract as the report helper.
+
+        Args:
+            reason: Tag used for idempotency keying and logging.
+
+        Returns:
+            The enqueued (or pre-existing idempotent) ``session_breakdown`` task.
+        """
         params: dict[str, Any] = {
             "source":      "coordinator_internal",
             "reason":      str(reason),
@@ -3503,7 +3792,14 @@ class Coordinator:
         task_id: str = "",
         detail: str = "",
     ) -> None:
-        """Append one row to ``phase_history[-1].evidence.close_steps`` (best-effort, per-step persist)."""
+        """Append one row to ``phase_history[-1].evidence.close_steps`` (best-effort, per-step persist).
+
+        Args:
+            step: Name of the CLOSE sequencer step.
+            status: Step status (e.g. "running", "done", "failed", "skipped").
+            task_id: Associated task id, when applicable.
+            detail: Optional free-form detail recorded with the step.
+        """
         history = self.shared_state.phase_history or []
         if not history:
             return
@@ -3543,14 +3839,22 @@ class Coordinator:
         await self.replay_for_resume()
 
     async def _pump_framework_pr_phase_safely(self, *, caller: str) -> None:
-        """Best-effort FRAMEWORK_PR pump wrapper shared by tick and run."""
+        """Best-effort FRAMEWORK_PR pump wrapper shared by tick and run.
+
+        Args:
+            caller: Name of the calling context, used for logging.
+        """
         try:
             await self._pump_framework_pr_phase()
         except Exception:  # noqa: BLE001 — defensive
             log.exception("FRAMEWORK_PR pump (%s) failed", caller)
 
     async def tick(self, n: int = 1) -> None:
-        """Run exactly ``n`` reactor passes for every agent (P0-3/P0-5/P1-4 tests); dispatcher pumps at pass end, lazy resume replay on tick 1."""
+        """Run exactly ``n`` reactor passes for every agent (P0-3/P0-5/P1-4 tests); dispatcher pumps at pass end, lazy resume replay on tick 1.
+
+        Args:
+            n: Number of reactor passes to run.
+        """
         await self._replay_resume_if_needed()
         for _ in range(n):
             self.shared_state.increment_tick()
@@ -3570,7 +3874,14 @@ class Coordinator:
         tick: int | None = None,
         agent: str = "",
     ) -> None:
-        """Record a Coordinator-side exception without killing the session."""
+        """Record a Coordinator-side exception without killing the session.
+
+        Args:
+            stage: Pipeline stage where the exception occurred.
+            exc: The caught exception.
+            tick: Tick number to record; ``None`` reads the current tick.
+            agent: Agent name associated with the exception, if any.
+        """
         try:
             self.shared_state.record_tick_exception(
                 tick=int(tick if tick is not None else self.shared_state.tick or 0),
@@ -3600,7 +3911,24 @@ class Coordinator:
         crash_emergency_threshold: int = 25,
         closing_grace_sec: float | None = None,
     ) -> str:
-        """Run reactor + dispatcher until a stop condition fires (DESIGN §9.1, priority order): signal, target_reached, time_exhausted (via closing phase), emergency, custom, max_ticks. Sets + saves + returns shared_state.stop_reason."""
+        """Run reactor + dispatcher until a stop condition fires (DESIGN §9.1, priority order): signal, target_reached, time_exhausted (via closing phase), emergency, custom, max_ticks. Sets + saves + returns shared_state.stop_reason.
+
+        Args:
+            objective: Optimization objective; ``None`` uses a
+                :class:`TimeOnlyObjective`.
+            max_minutes: Wall-clock budget in minutes; ``None`` for unbounded.
+            tick_interval_sec: Sleep between ticks.
+            max_ticks: Hard cap on ticks; ``None`` for unbounded.
+            stop_when: Optional custom stop predicate.
+            install_signal_handlers: Whether to install SIGINT/SIGTERM handlers.
+            crash_emergency_threshold: Crash count that triggers an emergency
+                stop.
+            closing_grace_sec: Grace period for the closing phase; ``None``
+                derives it from ``max_minutes``.
+
+        Returns:
+            The final ``shared_state.stop_reason``.
+        """
         objective = objective or TimeOnlyObjective()
         # Stash so _compose_prompt can update target_gap_pct.
         self._current_objective = objective
@@ -3781,7 +4109,14 @@ class Coordinator:
         return self.shared_state.stop_reason
 
     async def _enter_closing_phase(self, *, grace_sec: float) -> float:
-        """Enter report-flush phase after the wall-clock deadline (enqueue deterministic report task)."""
+        """Enter report-flush phase after the wall-clock deadline (enqueue deterministic report task).
+
+        Args:
+            grace_sec: Grace window in seconds for the closing phase.
+
+        Returns:
+            The monotonic deadline by which the closing phase should complete.
+        """
         closing_started = time.time()
         closing_deadline = time.monotonic() + float(grace_sec)
         self.shared_state.closing_phase = True
@@ -3949,6 +4284,10 @@ class Coordinator:
         Wrapped in a broad ``try`` so any unexpected error in trace
         assembly degrades to a logged warning rather than breaking the
         tick loop.
+
+        Args:
+            agent_name: Reactor role name, used as both component and role.
+            result: The backend turn result carrying token metadata.
         """
         try:
             metadata = result.metadata or {}
@@ -3991,6 +4330,10 @@ class Coordinator:
 
         Best-effort: any failure degrades to a logged warning rather than
         breaking the tick loop.
+
+        Args:
+            agent_name: Reactor role name, used as both component and role.
+            result: The backend turn result carrying prompt/response metadata.
         """
         try:
             metadata = result.metadata or {}
@@ -4018,7 +4361,12 @@ class Coordinator:
     async def _track_backend_error_streak(
         self, agent_name: str, exc: BackendError,
     ) -> None:
-        """Increment the per-agent ``BackendError`` streak; emit one backend_unhealthy event on crossing the threshold (re-arms only after a successful turn)."""
+        """Increment the per-agent ``BackendError`` streak; emit one backend_unhealthy event on crossing the threshold (re-arms only after a successful turn).
+
+        Args:
+            agent_name: Agent whose error streak is incremented.
+            exc: The backend error that occurred.
+        """
         new_value = self._backend_error_streak.get(agent_name, 0) + 1
         self._backend_error_streak[agent_name] = new_value
         threshold = self._backend_error_streak_threshold
@@ -4046,7 +4394,12 @@ class Coordinator:
             )
 
     async def _scan_stale_specialists(self) -> list[dict[str, Any]]:
-        """Return specialist task rows running longer than ``_specialist_stale_sec`` (v0.8 §3.3 §4.4); never raises, returns [] on failure."""
+        """Return specialist task rows running longer than ``_specialist_stale_sec`` (v0.8 §3.3 §4.4); never raises, returns [] on failure.
+
+        Returns:
+            List of ``{task_id, kind, running_seconds}`` dicts for stale
+            specialist tasks; empty on failure or when none are stale.
+        """
         try:
             running = await self.tasks.running()
         except Exception:  # noqa: BLE001 — defensive
@@ -4073,7 +4426,14 @@ class Coordinator:
         return stale
 
     async def _compose_prompt(self, agent_name: str) -> str:
-        """v0.6 §8.3 prompt: SharedState summary + inbox tail (with canonical msg_id per inbox row)."""
+        """v0.6 §8.3 prompt: SharedState summary + inbox tail (with canonical msg_id per inbox row).
+
+        Args:
+            agent_name: Role name whose prompt is being composed.
+
+        Returns:
+            The fully assembled prompt string for the agent.
+        """
         sections: list[str] = []
 
         # 0. SESSION_DIR contract — literal path for every agent (pairs with PolicyGate path containment).
@@ -4368,7 +4728,12 @@ class Coordinator:
 
     # Execution order guard
     def _target_analysis_baseline_exists(self) -> bool:
-        """True iff target_analysis produced ``target_baseline.json`` (file existence is a sufficient gate signal)."""
+        """True iff target_analysis produced ``target_baseline.json`` (file existence is a sufficient gate signal).
+
+        Returns:
+            ``True`` when the target baseline artifact exists (or when the
+            helper is unavailable, treated as done).
+        """
         try:
             from ..session_paths import target_baseline_json
             return target_baseline_json(self.session_dir).exists()
@@ -4376,7 +4741,11 @@ class Coordinator:
             return True
 
     def _kernel_opt_keep_pending(self) -> str:
-        """Return the next kernel_id awaiting integrate, or "" if none (delegates to SharedState.next_pending_keep_kernel_id)."""
+        """Return the next kernel_id awaiting integrate, or "" if none (delegates to SharedState.next_pending_keep_kernel_id).
+
+        Returns:
+            The next pending KEEP kernel id, or an empty string if none.
+        """
         return self.shared_state.next_pending_keep_kernel_id()
 
     def _sequence_denial_for_action(
@@ -4384,7 +4753,16 @@ class Coordinator:
         action_name: str,
         proposed_params: dict[str, Any] | None = None,
     ) -> PolicyDenied | None:
-        """Reject orchestration action/delegate attempts before baseline. Only invariant: nothing runs until baseline_tput > 0 (a data-dependency). proposed_params kept for signature compat."""
+        """Reject orchestration action/delegate attempts before baseline. Only invariant: nothing runs until baseline_tput > 0 (a data-dependency). proposed_params kept for signature compat.
+
+        Args:
+            action_name: Name of the proposed/delegated action.
+            proposed_params: Action params, kept for signature compatibility.
+
+        Returns:
+            A :class:`PolicyDenied` when the action is sequenced before
+            baseline, otherwise ``None``.
+        """
         action = str(action_name or "").strip()
         sequence_actions = {
             "target_analysis",
@@ -4409,7 +4787,16 @@ class Coordinator:
     def _sequence_denial_for_request(
         self, target_agent: str, kind: str,
     ) -> PolicyDenied | None:
-        """Reject kernel requests that skip the baseline prerequisite (invariant: nothing kernel-side runs before baseline_tput > 0)."""
+        """Reject kernel requests that skip the baseline prerequisite (invariant: nothing kernel-side runs before baseline_tput > 0).
+
+        Args:
+            target_agent: Target agent of the request (only "kernel" is gated).
+            kind: Kernel request kind.
+
+        Returns:
+            A :class:`PolicyDenied` when the request precedes baseline,
+            otherwise ``None``.
+        """
         target = str(target_agent or "").strip()
         req_kind = str(kind or "").strip()
         if target != "kernel" or self.shared_state.stop_reason:
@@ -4600,7 +4987,14 @@ class Coordinator:
         self.state.pending_proposals[msg.msg_id] = pending
 
     def _resolve_issue_canonical(self, pending: PendingProposal) -> str:
-        """Find the issue_node canonical_id this proposal addresses. Priority: payload gap_canonical_id → params gap_canonical_id → _gap_anchor_canonical_id (Gap-09)."""
+        """Find the issue_node canonical_id this proposal addresses. Priority: payload gap_canonical_id → params gap_canonical_id → _gap_anchor_canonical_id (Gap-09).
+
+        Args:
+            pending: The pending proposal whose gap anchor is resolved.
+
+        Returns:
+            The resolved issue-node canonical id.
+        """
         payload = pending.payload or {}
         explicit_top = str(payload.get("gap_canonical_id") or "").strip()
         if explicit_top:
@@ -4613,7 +5007,12 @@ class Coordinator:
         return self._gap_anchor_canonical_id()
 
     def _workload_canonical_id(self) -> str:
-        """Canonical 5-tuple recipe id for the current workload. MUST match cortex_t0.run_t0_anchor's derivation so warm-start and KEEP/REVERT/CLOSE writes target the same row."""
+        """Canonical 5-tuple recipe id for the current workload. MUST match cortex_t0.run_t0_anchor's derivation so warm-start and KEEP/REVERT/CLOSE writes target the same row.
+
+        Returns:
+            The canonical recipe id derived from model/hardware/framework/
+            framework_version/precision.
+        """
         ss = self.shared_state
         workload = ss.model_name or "unknown_model"
         hw = ss.gpu_type or "unknown_gpu"
@@ -4631,7 +5030,11 @@ class Coordinator:
         )
 
     def _gap_anchor_canonical_id(self) -> str:
-        """M1 gap anchor: delegates to _workload_canonical_id so anchor and write target never diverge."""
+        """M1 gap anchor: delegates to _workload_canonical_id so anchor and write target never diverge.
+
+        Returns:
+            The workload canonical id used as the gap anchor.
+        """
         return self._workload_canonical_id()
 
     def _kb_amend_recipe(
@@ -4642,7 +5045,15 @@ class Coordinator:
         recipe_overrides: dict[str, Any] | None = None,
         provenance_details: dict[str, Any] | None = None,
     ) -> None:
-        """Read-modify-write helper for the v2 recipe-snapshot KB: load live row, append lesson/pitfall, merge recipe_overrides (unset fields preserved), write back. Best-effort; lesson/pitfall appended without dedup (commit 4d)."""
+        """Read-modify-write helper for the v2 recipe-snapshot KB: load live row, append lesson/pitfall, merge recipe_overrides (unset fields preserved), write back. Best-effort; lesson/pitfall appended without dedup (commit 4d).
+
+        Args:
+            append_lesson: Optional lesson dict to append.
+            append_pitfall: Optional pitfall dict to append.
+            recipe_overrides: Field overrides merged into the recipe; unset
+                fields are preserved from the live row.
+            provenance_details: Optional provenance metadata for the write.
+        """
         if self.cortex_kb is None:
             return
         try:
@@ -4763,7 +5174,13 @@ class Coordinator:
             )
 
     async def _handle_review_verdict(self, source: str, intent: Intent) -> None:
-        """Apply a Critic ``review_verdict`` to its target proposal; legacy verdict_map collapsed (approve > reject > needs_review)."""
+        """Apply a Critic ``review_verdict`` to its target proposal; legacy verdict_map collapsed (approve > reject > needs_review).
+
+        Args:
+            source: Agent name issuing the verdict.
+            intent: The ``review_verdict`` intent carrying the target and
+                verdict payload.
+        """
         target = intent.payload["target_proposal_msg_id"]
         pending = self.state.pending_proposals.get(target)
         verdict_map = intent.payload.get("verdict_map")
@@ -4805,7 +5222,14 @@ class Coordinator:
         verdict: str,
         reasoning: str,
     ) -> None:
-        """Legacy v0.6 single-verdict handler (approve materialises proposal as-is); mirrors integrate_patch/specialist verdicts onto specialist_patch_verdicts for PolicyGate."""
+        """Legacy v0.6 single-verdict handler (approve materialises proposal as-is); mirrors integrate_patch/specialist verdicts onto specialist_patch_verdicts for PolicyGate.
+
+        Args:
+            source: Agent name issuing the verdict.
+            pending: The pending proposal being decided.
+            verdict: The collapsed verdict ("approve"/"reject"/"needs_review").
+            reasoning: Free-form rationale recorded with the verdict.
+        """
         pending.decided = True
         pending.verdict = verdict
         await self.bus.append_and_seq(Message.new(
@@ -4847,7 +5271,12 @@ class Coordinator:
             await self._materialize_approved_proposal(pending)
 
     def _inject_explore_runtime_params(self, params: dict) -> None:
-        """Inject explore-task operational knobs from SharedState into ``params`` (single source of truth for both propose/Critic and direct-delegate paths). setdefault preserves LLM overrides. Knobs: baseline_runtime_sec + explore_overtime_kill_ratio (Fix E soft_deadline), variant_timeout_sec, variant_timeout_safety_margin, roofline_saturation_snapshot (advisory)."""
+        """Inject explore-task operational knobs from SharedState into ``params`` (single source of truth for both propose/Critic and direct-delegate paths). setdefault preserves LLM overrides. Knobs: baseline_runtime_sec + explore_overtime_kill_ratio (Fix E soft_deadline), variant_timeout_sec, variant_timeout_safety_margin, roofline_saturation_snapshot (advisory).
+
+        Args:
+            params: Explore-task params mutated in place with operational
+                knobs (existing keys are preserved).
+        """
         br = float(getattr(self.shared_state, "baseline_runtime_sec", 0.0) or 0.0)
         if br > 0:
             params.setdefault("baseline_runtime_sec", br)
@@ -4886,7 +5315,13 @@ class Coordinator:
         *,
         approved_variant_names: set[str] | None = None,
     ) -> None:
-        """Promote an approved proposal into a TaskRegistry entry. Grid executors get current best tput as base_tput (DESIGN §16); approved_variant_names filters the explore grid (None keeps full)."""
+        """Promote an approved proposal into a TaskRegistry entry. Grid executors get current best tput as base_tput (DESIGN §16); approved_variant_names filters the explore grid (None keeps full).
+
+        Args:
+            pending: The approved proposal to materialize into a task.
+            approved_variant_names: Optional set of explore variant names to
+                keep; ``None`` keeps the full grid.
+        """
         params = dict(pending.payload.get("params") or {})
         # Filter the grid to the Critic-approved subset.
         if (
@@ -5133,7 +5568,13 @@ class Coordinator:
     def _record_framework_pr_authored_outcome(
         self, *, task: "Task", result: Any,
     ) -> None:
-        """Bridge an authored-patch ``integrate_patch`` outcome into the FRAMEWORK_PR progress ledger (else the gain is invisible). Attributed to the latest batch; only kept/reverted rows."""
+        """Bridge an authored-patch ``integrate_patch`` outcome into the FRAMEWORK_PR progress ledger (else the gain is invisible). Attributed to the latest batch; only kept/reverted rows.
+
+        Args:
+            task: The integrate_patch task carrying authoring provenance.
+            result: The task result whose ``status`` (kept/reverted) and gain
+                are recorded.
+        """
         res = getattr(result, "result", None)
         if not isinstance(res, dict):
             return
@@ -5203,7 +5644,14 @@ class Coordinator:
         normal ``_handle_delegate`` path (warm + idempotency + TaskRegistry +
         lease + reap), preserving the low-cost wide-net recon the retired
         dynamic_specialist channel provided. Per-task idempotency keys derive
-        from the wave key; non-dict / empty-description entries are skipped."""
+        from the wave key; non-dict / empty-description entries are skipped.
+
+        Args:
+            source: Agent name issuing the wave delegate.
+            intent: The originating delegate intent.
+            params: Delegate params carrying the ``tasks`` list plus shared
+                fields applied to every fanned task.
+        """
         tasks = params.get("tasks") or []
         shared = {k: v for k, v in params.items() if k != "tasks"}
         base_key = str(intent.payload.get("idempotency_key") or "").strip()
@@ -5252,7 +5700,15 @@ class Coordinator:
         (timeout / crash / stale-heartbeat, per ``classify_specialist_failure``)
         are retried, capped at :data:`SPECIALIST_AUTO_RETRY_MAX`; the failure
         reason is injected into the retry prompt. Disabled when
-        ``INFERENCE_OPTIMIZER_SPECIALIST_AUTO_RETRY`` is set to ``0``."""
+        ``INFERENCE_OPTIMIZER_SPECIALIST_AUTO_RETRY`` is set to ``0``.
+
+        Args:
+            task: The failed specialist task.
+            result: The sub-agent result classified for retry eligibility.
+
+        Returns:
+            ``True`` when a retry was scheduled, ``False`` otherwise.
+        """
         flag = os.environ.get(
             "INFERENCE_OPTIMIZER_SPECIALIST_AUTO_RETRY", "1",
         ).strip().lower()
@@ -5333,7 +5789,12 @@ class Coordinator:
 
     # specialist pre-dispatch warmup
     async def _warm_specialist_params(self, params: dict[str, Any]) -> None:
-        """Fill specialist task params with KnowledgePlane data before enqueue (mutates in place); all best-effort, missing fields stay empty."""
+        """Fill specialist task params with KnowledgePlane data before enqueue (mutates in place); all best-effort, missing fields stay empty.
+
+        Args:
+            params: Specialist task params mutated in place with KnowledgePlane
+                context.
+        """
         state = self.shared_state
         plane = self.knowledge_plane
 
@@ -5530,7 +5991,14 @@ class Coordinator:
 
     @staticmethod
     def _pr_summary_to_dict(pr: Any) -> dict[str, Any]:
-        """Flatten a PRSummary into the dict SpecialistPromptBuilder expects."""
+        """Flatten a PRSummary into the dict SpecialistPromptBuilder expects.
+
+        Args:
+            pr: A PRSummary-like object with repo/number/title/url/etc.
+
+        Returns:
+            A flat dict of the PR's summary fields.
+        """
         return {
             "repo":   str(getattr(pr, "repo", "")),
             "number": int(getattr(pr, "number", 0) or 0),
@@ -5543,7 +6011,11 @@ class Coordinator:
 
     # gaps[] ledger refresh
     async def _refresh_gaps(self, *, reason: str) -> None:
-        """Refresh :attr:`SharedState.gaps` from observable signals (Coordinator is sole writer, Inv-1). Additive upsert deduped by canonical_id; best-effort."""
+        """Refresh :attr:`SharedState.gaps` from observable signals (Coordinator is sole writer, Inv-1). Additive upsert deduped by canonical_id; best-effort.
+
+        Args:
+            reason: Tag used for logging the refresh trigger.
+        """
         state = self.shared_state
         try:
             for entry in self._extract_gaps_from_baseline():
@@ -5582,7 +6054,11 @@ class Coordinator:
         )
 
     def _extract_gaps_from_baseline(self) -> list[dict[str, Any]]:
-        """Derive initial gap rows from the baseline snapshot (throughput_below_target, baseline_unstable); reuse the M1 anchor canonical_id so traverse rows align."""
+        """Derive initial gap rows from the baseline snapshot (throughput_below_target, baseline_unstable); reuse the M1 anchor canonical_id so traverse rows align.
+
+        Returns:
+            List of gap row dicts derived from the baseline snapshot.
+        """
         state = self.shared_state
         gaps: list[dict[str, Any]] = []
         if state.baseline_tput <= 0:
@@ -5623,7 +6099,11 @@ class Coordinator:
         return gaps
 
     def _extract_gaps_from_attempts(self) -> list[dict[str, Any]]:
-        """Derive gaps from rolling failures + winners history (recurring (action, error_class) + explore plateau)."""
+        """Derive gaps from rolling failures + winners history (recurring (action, error_class) + explore plateau).
+
+        Returns:
+            List of gap row dicts derived from recent attempts.
+        """
         state = self.shared_state
         anchor = self._gap_anchor_canonical_id()
         gaps: list[dict[str, Any]] = []
@@ -5683,7 +6163,14 @@ class Coordinator:
 
     @staticmethod
     def _gap_layer_for_action(action: str) -> tuple[str, str]:
-        """Map an action name → (layer, domain_hint) for gap rows (fallback ("framework", "serving_specialist"))."""
+        """Map an action name → (layer, domain_hint) for gap rows (fallback ("framework", "serving_specialist")).
+
+        Args:
+            action: The action name to classify.
+
+        Returns:
+            Tuple of (layer, domain_hint) for the action.
+        """
         a = str(action or "").strip().lower()
         if a in {"kernel_opt", "integrate", "trace_analyze", "run_gemm_tuning", "run_optimization"}:
             return ("kernel", "kernel_switch_specialist")
@@ -5698,7 +6185,13 @@ class Coordinator:
     def _record_explore_round_gaps(
         self, *, task: "Task | None", result: dict[str, Any],
     ) -> None:
-        """Append per-variant KEEP/REVERT outcomes to the matching gap (or the anchor gap as fallback)."""
+        """Append per-variant KEEP/REVERT outcomes to the matching gap (or the anchor gap as fallback).
+
+        Args:
+            task: The explore task whose params carry the gap canonical id;
+                ``None`` is a no-op.
+            result: The explore result carrying ``per_variant_outcomes``.
+        """
         if task is None:
             return
         per_variant = result.get("per_variant_outcomes")
@@ -5734,7 +6227,12 @@ class Coordinator:
     async def _handle_specialist_done(
         self, source: str, intent: Intent,
     ) -> None:
-        """Handle a ``specialist_done`` intent (source ``specialist:<task_id>`` per Inv-5.3 / R3); bookkeeping in _record_specialist_result."""
+        """Handle a ``specialist_done`` intent (source ``specialist:<task_id>`` per Inv-5.3 / R3); bookkeeping in _record_specialist_result.
+
+        Args:
+            source: The ``specialist:<task_id>`` source agent string.
+            intent: The ``specialist_done`` intent payload.
+        """
         payload = dict(intent.payload or {})
         task_id = self._task_id_from_specialist_source(source)
         task: Task | None = None
@@ -5758,7 +6256,15 @@ class Coordinator:
 
     @staticmethod
     def _task_id_from_specialist_source(source: str) -> str:
-        """Extract the task_id from a ``specialist:<task_id>`` source ("" when prefix is absent)."""
+        """Extract the task_id from a ``specialist:<task_id>`` source ("" when prefix is absent).
+
+        Args:
+            source: The source agent string to parse.
+
+        Returns:
+            The extracted task id, or an empty string when the prefix is
+            absent.
+        """
         if not source:
             return ""
         if source.startswith(SPECIALIST_FROM_AGENT_PREFIX):
@@ -5772,7 +6278,13 @@ class Coordinator:
         done_payload: dict[str, Any],
         source: str,
     ) -> None:
-        """Common bookkeeping for any specialist task termination (dispatcher loop + intent routing); idempotent on round_id, failures logged not raised."""
+        """Common bookkeeping for any specialist task termination (dispatcher loop + intent routing); idempotent on round_id, failures logged not raised.
+
+        Args:
+            task: The terminated specialist task.
+            done_payload: The specialist's completion payload.
+            source: The source agent string for the result.
+        """
         domain = str(done_payload.get("domain") or "").strip()
         proposals = done_payload.get("proposal_set") or []
         if not isinstance(proposals, list):
@@ -5907,7 +6419,12 @@ class Coordinator:
             )
 
     def _plateau_advisory_block(self) -> str:
-        """Render the plateau-judgment advisory block (EXPLORE/KERNEL/FRAMEWORK_PR; advisory, never gates). Returns "" when no plateau signal is active."""
+        """Render the plateau-judgment advisory block (EXPLORE/KERNEL/FRAMEWORK_PR; advisory, never gates). Returns "" when no plateau signal is active.
+
+        Returns:
+            The advisory block text, or an empty string when no plateau signal
+            is active.
+        """
         state = self.shared_state
         phase = (getattr(state, "phase", "") or "").strip().upper()
         overrides = getattr(state, "plateau_overrides", None) or {}
@@ -6003,7 +6520,12 @@ class Coordinator:
         return "\n".join(lines)
 
     def _target_gap_advisory_block(self) -> str:
-        """Build the advisory "External target gap" prompt block (current-best vs competitor target; never gates)."""
+        """Build the advisory "External target gap" prompt block (current-best vs competitor target; never gates).
+
+        Returns:
+            The gap-summary block text, or an empty string when advisory is
+            disabled or no target/current-best is available.
+        """
         state = self.shared_state
         if not bool(getattr(state, "target_advisory_enabled", True)):
             return ""
@@ -6034,7 +6556,11 @@ class Coordinator:
         return _research_hints.full_gap_summary(gap)
 
     def _current_primary_gap(self) -> str | None:
-        """Resolve the dominant external gap direction ('latency'/'throughput') from the competitor target, or None when advisory is off / no target. Fail-soft."""
+        """Resolve the dominant external gap direction ('latency'/'throughput') from the competitor target, or None when advisory is off / no target. Fail-soft.
+
+        Returns:
+            The primary gap direction string, or ``None`` when unavailable.
+        """
         state = self.shared_state
         if not bool(getattr(state, "target_advisory_enabled", True)):
             return None
@@ -6075,7 +6601,14 @@ class Coordinator:
     def _recent_proposed_variants(
         self, *, max_rounds: int = 2,
     ) -> list[dict[str, Any]]:
-        """Collect proposal_set rows from the most recent specialist rounds (deduped by name; fail-soft)."""
+        """Collect proposal_set rows from the most recent specialist rounds (deduped by name; fail-soft).
+
+        Args:
+            max_rounds: Number of most-recent specialist rounds to scan.
+
+        Returns:
+            De-duplicated list of proposed variant dicts.
+        """
         rounds = [
             r for r in (getattr(self.shared_state, "specialist_rounds", []) or [])
             if isinstance(r, dict) and isinstance(r.get("proposal_set"), list)
@@ -6093,7 +6626,12 @@ class Coordinator:
         return out
 
     def _priors_match_advisory_block(self) -> str:
-        """Flag recently proposed variants aligning with proven priors / dominant external gap (advisory ordering, fail-soft)."""
+        """Flag recently proposed variants aligning with proven priors / dominant external gap (advisory ordering, fail-soft).
+
+        Returns:
+            The priors-match advisory text, or an empty string when there are
+            no recent variants or on failure.
+        """
         try:
             from . import research_hints as _research_hints
 
@@ -6111,7 +6649,13 @@ class Coordinator:
     async def _maybe_autosubmit_specialist_patches(
         self, *, task: "Task", done_payload: dict[str, Any],
     ) -> None:
-        """B3: auto-surface a specialist's source patches to the Critic via a synthetic integrate_patch proposal; idempotent per specialist."""
+        """B3: auto-surface a specialist's source patches to the Critic via a synthetic integrate_patch proposal; idempotent per specialist.
+
+        Args:
+            task: The completed specialist task.
+            done_payload: The specialist's completion payload carrying
+                ``patches_written``.
+        """
         patches = done_payload.get("patches_written") or []
         if not isinstance(patches, list) or not patches:
             return
@@ -6210,7 +6754,16 @@ class Coordinator:
         done_payload: dict[str, Any],
         source: str,
     ) -> dict[str, Any]:
-        """Translate a specialist done payload into a SharedState.specialist_rounds[] row; round_id defaults to task_id for idempotent overwrite (M5)."""
+        """Translate a specialist done payload into a SharedState.specialist_rounds[] row; round_id defaults to task_id for idempotent overwrite (M5).
+
+        Args:
+            task: The completed specialist task.
+            done_payload: The specialist's completion payload.
+            source: The source agent string for the round.
+
+        Returns:
+            A specialist-round entry dict ready to persist.
+        """
         proposals = done_payload.get("proposal_set") or []
         if not isinstance(proposals, list):
             proposals = []
@@ -6270,6 +6823,13 @@ class Coordinator:
 
         Best-effort by design: operator-facing logging must never break the
         orchestration loop, so any failure is swallowed at debug level.
+
+        Args:
+            step: Lifecycle step name.
+            status: Event status (e.g. "START", "END", "ERROR").
+            artifacts: Optional map of produced artifact names to paths.
+            detail: Optional free-form detail string.
+            duration_s: Optional step duration in seconds.
         """
         try:
             self.shared_state.record_lifecycle_event(
@@ -6530,7 +7090,16 @@ class Coordinator:
                 )
 
     def _cached_kernel_request(self, kind: str, payload: dict[str, Any]) -> dict[str, Any] | None:
-        """Return a cached programmatic_handler result if applicable (cache key last_trace_analyze)."""
+        """Return a cached programmatic_handler result if applicable (cache key last_trace_analyze).
+
+        Args:
+            kind: Kernel request kind; only ``trace_analyze`` is cacheable.
+            payload: Request payload carrying the trace input.
+
+        Returns:
+            The cached result dict, or ``None`` when there is no usable cache
+            hit.
+        """
         if kind != "trace_analyze":
             return None
         cached = self.shared_state.last_trace_analyze or {}
@@ -6644,7 +7213,12 @@ class Coordinator:
         ))
 
     async def _handle_escalate_strategy_change(self, source: str, intent: Intent) -> None:
-        """Process ``escalate_strategy_change`` (KB_design §3.8 §7.3 + §3.13 M7 §5.3); broadcasts strategy_change, acts on closed-vocab hints, drops unknown (Inv-8.2)."""
+        """Process ``escalate_strategy_change`` (KB_design §3.8 §7.3 + §3.13 M7 §5.3); broadcasts strategy_change, acts on closed-vocab hints, drops unknown (Inv-8.2).
+
+        Args:
+            source: Agent issuing the escalation.
+            intent: The ``escalate_strategy_change`` intent carrying the hint.
+        """
         payload = dict(intent.payload or {})
         # Always emit the broadcast first (back-compat with legacy contract tests).
         await self.bus.append_and_seq(Message.new(
@@ -6827,7 +7401,11 @@ class Coordinator:
             await self.cursors.advance(agent_name, seq=top.seq, msg_id=top.msg_id)
 
     def _record_kernel_opt_partial(self, result: dict[str, Any]) -> None:
-        """Streaming callback for ``_run_optimization_batch`` sub-attempts: write each per-kernel entry to kernel_opt_attempts immediately so the next-tick prompt is accurate mid-batch."""
+        """Streaming callback for ``_run_optimization_batch`` sub-attempts: write each per-kernel entry to kernel_opt_attempts immediately so the next-tick prompt is accurate mid-batch.
+
+        Args:
+            result: A per-kernel sub-attempt result to record.
+        """
         try:
             self.shared_state.record_kernel_opt(result)
             self.shared_state.save(self.session_dir)
@@ -6963,7 +7541,12 @@ class Coordinator:
     def _record_intervention_for_task(
         self, task: "Task", result: Any,
     ) -> None:
-        """PR-A8: log a completed task's change_type into SharedState.intervention_mix (explore → config; integrate_patch → code_patch_attempt or code_patch when kept). Best-effort."""
+        """PR-A8: log a completed task's change_type into SharedState.intervention_mix (explore → config; integrate_patch → code_patch_attempt or code_patch when kept). Best-effort.
+
+        Args:
+            task: The completed task whose change type is recorded.
+            result: The task result payload; non-dicts are ignored.
+        """
         if not isinstance(result, dict):
             return
         kind = (task.kind or "").strip()
@@ -7012,7 +7595,12 @@ class Coordinator:
     async def _handle_unpromotable_result(
         self, task: Task, result: dict[str, Any] | None,
     ) -> None:
-        """Record a failed / unpromotable task result into SharedState: append to last_action_failures (+ a failed attempts row for _AUDIT_ACTIONS); keep baseline failure_streak/stop_reason logic intact."""
+        """Record a failed / unpromotable task result into SharedState: append to last_action_failures (+ a failed attempts row for _AUDIT_ACTIONS); keep baseline failure_streak/stop_reason logic intact.
+
+        Args:
+            task: The failed or unpromotable task.
+            result: The task result payload; ``None`` is treated as empty.
+        """
         result_payload = result or {}
         any_changed = False
         # Per-action audit (failed attempt) for the 6 in-scope kinds.
@@ -7351,7 +7939,16 @@ class Coordinator:
         holders: dict[str, int],
         capacities: dict[str, int],
     ) -> bool:
-        """Local-view headroom hint for the concurrent dispatcher (authoritative gate is try_acquire_many)."""
+        """Local-view headroom hint for the concurrent dispatcher (authoritative gate is try_acquire_many).
+
+        Args:
+            expanded_lanes: Lane names the task requires (already expanded).
+            holders: Map of lane name to current holder count.
+            capacities: Map of lane name to capacity.
+
+        Returns:
+            ``True`` when every required lane has local headroom.
+        """
         for lane in expanded_lanes:
             cap = int(capacities.get(lane, 1))
             used = int(holders.get(lane, 0))
@@ -7364,6 +7961,9 @@ class Coordinator:
         """Return the hyperloom-local session id used as source_session_id on KB fact writes.
 
         NOT a KB-side session id; prefers cortex_session_id, falls back to session_dir.name.
+
+        Returns:
+            The hyperloom-local session id string.
         """
         return (
             str(getattr(self.shared_state, "cortex_session_id", "") or "")
@@ -7377,7 +7977,13 @@ class Coordinator:
         result: Any,
         kept: bool,
     ) -> None:
-        """Per-task fact-write entry point (per_variant for explore grids, else per-task); best-effort, never raises."""
+        """Per-task fact-write entry point (per_variant for explore grids, else per-task); best-effort, never raises.
+
+        Args:
+            task: The terminated task.
+            result: The task result (object or dict) to translate into facts.
+            kept: Whether the task's change was kept.
+        """
         result_dict = result.result if hasattr(result, "result") else (result or {})
         if not isinstance(result_dict, dict):
             result_dict = {}
@@ -7420,7 +8026,11 @@ class Coordinator:
     # Fact-write surface — journal + direct KB lesson/pitfall/recipe writes (the fact side of KB integration).
     PITFALL_REGRESS_THRESHOLD_PCT: float = -5.0  # gain_pct ≤ this → pitfall
     def _ensure_journal(self) -> Journal:
-        """Lazy-instantiate the per-session :class:`Journal` (load_or_create reads an existing file on resume)."""
+        """Lazy-instantiate the per-session :class:`Journal` (load_or_create reads an existing file on resume).
+
+        Returns:
+            The per-session :class:`Journal` instance.
+        """
         existing = getattr(self, "_journal", None)
         if existing is None:
             ss = self.shared_state
@@ -7444,7 +8054,14 @@ class Coordinator:
     def _pitfall_severity_for(
         self, result_dict: dict[str, Any] | None,
     ) -> str | None:
-        """Decide whether a failed result warrants a pitfall row (Threshold-B): crash/oom/hang → SEVERITY_CRASH; gain_pct ≤ -5% → SEVERITY_REGRESS; else None."""
+        """Decide whether a failed result warrants a pitfall row (Threshold-B): crash/oom/hang → SEVERITY_CRASH; gain_pct ≤ -5% → SEVERITY_REGRESS; else None.
+
+        Args:
+            result_dict: The task result payload; non-dicts yield ``None``.
+
+        Returns:
+            The pitfall severity tag, or ``None`` when no pitfall is warranted.
+        """
         if not isinstance(result_dict, dict):
             return None
         error_class = str(result_dict.get("error_class") or "").lower()
@@ -7478,7 +8095,14 @@ class Coordinator:
         result_dict: dict[str, Any],
         kept: bool,
     ) -> None:
-        """Per-task fact write — one journal row + maybe one KB fact (source_session_id is hyperloom-local)."""
+        """Per-task fact write — one journal row + maybe one KB fact (source_session_id is hyperloom-local).
+
+        Args:
+            task: The terminated task.
+            source_session_id: Hyperloom-local session id stamped on writes.
+            result_dict: The task result payload.
+            kept: Whether the task's change was kept.
+        """
         journal = self._ensure_journal()
         gain_raw = result_dict.get("gain_pct")
         try:
@@ -7582,7 +8206,17 @@ class Coordinator:
         gain_pct: float | None = None,  # kept for backward call-signature compat
         severity: str | None = None,
     ) -> str:
-        """Build the lesson statement / pitfall description hashed into the KB canonical_id; MUST exclude volatile fields (e.g. gain_pct) so N sessions merge instead of producing N rows. Identity = framework + change + model/hw."""
+        """Build the lesson statement / pitfall description hashed into the KB canonical_id; MUST exclude volatile fields (e.g. gain_pct) so N sessions merge instead of producing N rows. Identity = framework + change + model/hw.
+
+        Args:
+            change: Human-readable change summary.
+            kind: Statement kind ("lesson" or "pitfall").
+            gain_pct: Kept for call-signature compatibility; not hashed in.
+            severity: Pitfall severity tag (used only for pitfalls).
+
+        Returns:
+            The lesson/pitfall statement string.
+        """
         framework = str(getattr(self.shared_state, "framework", "") or "").strip()
         fw_tag = f"[{framework or '?'}] "
         model = self.shared_state.model_name or "?"
@@ -7602,7 +8236,18 @@ class Coordinator:
         measured_at: str,
         throughput_before: float | None = None,
     ) -> dict[str, Any]:
-        """GAP 3 — structured ``measured_impact`` payload (dict not legacy string so consumers parse without regex); stack_depth = stack length before this lesson lands."""
+        """GAP 3 — structured ``measured_impact`` payload (dict not legacy string so consumers parse without regex); stack_depth = stack length before this lesson lands.
+
+        Args:
+            gain_pct: Measured gain percentage, if any.
+            throughput_after: Throughput after the change, if any.
+            stack_depth: Optimization-stack length before this lesson lands.
+            measured_at: ISO timestamp of the measurement.
+            throughput_before: Throughput before the change, if any.
+
+        Returns:
+            A compact ``measured_impact`` dict with None fields stripped.
+        """
         out: dict[str, Any] = {
             "gain_pct": float(gain_pct) if gain_pct is not None else None,
             "stack_depth_at_apply": int(stack_depth),
@@ -7622,7 +8267,13 @@ class Coordinator:
         source_session_id: str,
         variant_outcome: dict[str, Any],
     ) -> None:
-        """Per-variant fact write — mirror of _record_fact_per_task for explore per-variant decisions."""
+        """Per-variant fact write — mirror of _record_fact_per_task for explore per-variant decisions.
+
+        Args:
+            task: The explore task being recorded.
+            source_session_id: Hyperloom-local session id stamped on writes.
+            variant_outcome: One per-variant outcome dict from the result.
+        """
         journal = self._ensure_journal()
         outcome_raw = str(variant_outcome.get("outcome") or "")
         if outcome_raw == "KEEP":
@@ -7749,7 +8400,11 @@ class Coordinator:
             )
 
     def _collect_workload_tags(self) -> dict[str, Any]:
-        """Return the workload-shape KB tag dict for the current session (GAP 5); shared by recipe attrs + lesson/pitfall writes so the warm-start reader filters symmetrically."""
+        """Return the workload-shape KB tag dict for the current session (GAP 5); shared by recipe attrs + lesson/pitfall writes so the warm-start reader filters symmetrically.
+
+        Returns:
+            Mapping of workload-shape KB tags for the current session.
+        """
         ss = self.shared_state
         out: dict[str, Any] = {}
         framework = str(getattr(ss, "framework", "") or "").strip()
@@ -7826,7 +8481,11 @@ class Coordinator:
         return out
 
     def _build_kernel_optimizations_from_state(self) -> list[dict[str, Any]]:
-        """Collect KEEP'd kernel optimizations + their E2E verdict by joining kernel_opt_attempts (micro) and kernel_integrate_attempts (E2E) on kernel_id; non-integrated KEEPs surface integrated=False. Returns KernelOptimization-shaped dicts."""
+        """Collect KEEP'd kernel optimizations + their E2E verdict by joining kernel_opt_attempts (micro) and kernel_integrate_attempts (E2E) on kernel_id; non-integrated KEEPs surface integrated=False. Returns KernelOptimization-shaped dicts.
+
+        Returns:
+            List of KernelOptimization-shaped dicts for KEEP'd kernels.
+        """
         ss = self.shared_state
         opt_attempts = getattr(ss, "kernel_opt_attempts", {}) or {}
         integ_attempts = getattr(ss, "kernel_integrate_attempts", {}) or {}
@@ -7894,7 +8553,12 @@ class Coordinator:
     def _collect_attempt_provenance(
         self,
     ) -> tuple[dict[str, str], dict[str, str], list[dict[str, Any]]]:
-        """Map proven optimizations to their research-hint origin from the gaps[] attempts ledger; returns (kept_sources by name/kernel, kept_by_gap by canonical_id, reverted_rows). Fail-soft."""
+        """Map proven optimizations to their research-hint origin from the gaps[] attempts ledger; returns (kept_sources by name/kernel, kept_by_gap by canonical_id, reverted_rows). Fail-soft.
+
+        Returns:
+            Tuple of (kept_sources by name/kernel, kept_by_gap by canonical_id,
+            reverted_rows list).
+        """
         kept_sources: dict[str, str] = {}
         kept_by_gap: dict[str, str] = {}
         reverted_rows: list[dict[str, Any]] = []
@@ -7929,7 +8593,11 @@ class Coordinator:
         return kept_sources, kept_by_gap, reverted_rows
 
     def _build_recipe_attrs_from_state(self) -> dict[str, Any]:
-        """Materialise the recipe-shaped view of :class:`SharedState` (kg-usage-guide §7.4; defensive getattr)."""
+        """Materialise the recipe-shaped view of :class:`SharedState` (kg-usage-guide §7.4; defensive getattr).
+
+        Returns:
+            A recipe-shaped attrs dict derived from the current shared state.
+        """
         ss = self.shared_state
         current_best = getattr(ss, "current_best", {}) or {}
         opt_stack = getattr(ss, "optimization_stack", []) or []
@@ -8191,7 +8859,15 @@ class Coordinator:
         self, task_kind: str, best_tput: float, bv: dict[str, Any],
         *, gap_canonical_id: str = "",
     ) -> None:
-        """Update SharedState.current_best + recompute cumulative_gain; gap_canonical_id (when known) is stamped onto the stack entry so provenance resolves by gap id not name."""
+        """Update SharedState.current_best + recompute cumulative_gain; gap_canonical_id (when known) is stamped onto the stack entry so provenance resolves by gap id not name.
+
+        Args:
+            task_kind: The action kind that produced the winning variant.
+            best_tput: The winning throughput to promote.
+            bv: The best-variant payload (args, envs, metrics, workspace).
+            gap_canonical_id: Optional gap id stamped onto the stack entry for
+                provenance.
+        """
         previous = self.shared_state.current_best or {}
         if not self.shared_state.optimization_stack:
             self.shared_state.seed_stack_from_current_best()
@@ -8279,7 +8955,13 @@ class Coordinator:
         *,
         task: "Task | None" = None,
     ) -> None:
-        """Lift specific action-result fields into the persistent SharedState (baseline/profile/roofline/grid)."""
+        """Lift specific action-result fields into the persistent SharedState (baseline/profile/roofline/grid).
+
+        Args:
+            task_kind: The action kind whose result is being promoted.
+            result: The action result payload; non-dicts are ignored.
+            task: The originating task, when available.
+        """
         if not isinstance(result, dict):
             return
         changed = False

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -140,7 +140,16 @@ _OUTCOME_STATUS_KEYS: tuple[str, ...] = ("status", "verdict", "outcome")
 
 
 def _first_present(d: dict[str, Any], keys: tuple[str, ...]) -> Any | None:
-    """Return ``d[k]`` for the first ``k`` in ``keys`` present + non-None."""
+    """Return ``d[k]`` for the first ``k`` in ``keys`` present + non-None.
+
+    Args:
+        d: Mapping to look up; a non-dict argument yields ``None``.
+        keys: Candidate keys checked in order; the first whose value is
+            non-None wins.
+
+    Returns:
+        The first present, non-None value, or ``None`` if none match.
+    """
     if not isinstance(d, dict):
         return None
     for k in keys:
@@ -151,7 +160,16 @@ def _first_present(d: dict[str, Any], keys: tuple[str, ...]) -> Any | None:
 
 
 def _format_inbox_event(m: "Message") -> str:
-    """Render one inbox ``Message`` as a compact, high-signal line (Path A/A1)."""
+    """Render one inbox ``Message`` as a compact, high-signal line (Path A/A1).
+
+    Args:
+        m: The inbox message to render; its topic selects a per-topic
+            formatting branch (delegated_result, policy_denial, review_verdict,
+            observation) with a generic fallback.
+
+    Returns:
+        A single-line string summarising the message header and payload.
+    """
     topic = (m.topic or "").strip()
     payload = m.payload if isinstance(m.payload, dict) else {}
     # DESIGN §13.1: canonical inbox header ordering downstream parsers anchor on.
@@ -246,7 +264,15 @@ _LIFECYCLE_PATH_KEYS: tuple[str, ...] = (
 def _lifecycle_paths(payload: Any) -> dict[str, str]:
     """Extract present, non-empty path-like fields from a kernel handler
     payload or result dict (#266). Best-effort: a non-dict argument yields
-    an empty mapping so callers never have to guard the type."""
+    an empty mapping so callers never have to guard the type.
+
+    Args:
+        payload: A kernel handler payload or result; non-dict inputs are
+            tolerated and produce an empty mapping.
+
+    Returns:
+        Mapping of recognised path-like key to its non-empty string value.
+    """
     if not isinstance(payload, dict):
         return {}
     out: dict[str, str] = {}
@@ -585,7 +611,12 @@ class Coordinator:
 
     # Context-pull tools (plan Step 2)
     def _orchestration_conversational(self) -> bool:
-        """True when the orchestration backend runs in persistent-conversation mode (plan Step 1)."""
+        """True when the orchestration backend runs in persistent-conversation mode (plan Step 1).
+
+        Returns:
+            ``True`` if the orchestration backend exposes a truthy
+            ``conversational`` attribute, else ``False``.
+        """
         backend = self.backends.get("orchestration")
         return bool(getattr(backend, "conversational", False))
 
@@ -601,7 +632,14 @@ class Coordinator:
         self._orchestration_seeded = False
 
     def _conversation_progress_signal(self) -> dict[str, Any]:
-        """Compute the no-progress circuit-breaker signal (plan Step 6)."""
+        """Compute the no-progress circuit-breaker signal (plan Step 6).
+
+        Returns:
+            A dict with ``ticks_without_progress``, ``threshold``,
+            ``severity`` ("ok" or "high"), and ``last_progress_tick``;
+            progress is detected from stack growth, validated gain,
+            current-best signature, or phase change.
+        """
         state = self.shared_state
         cur_tick = int(getattr(state, "tick", 0) or 0)
         try:
@@ -665,6 +703,14 @@ class Coordinator:
         unbounded. Best-effort — every step is independently guarded so one
         failure never aborts the run loop. Returns a summary dict when it ran,
         else ``None``.
+
+        Args:
+            tick: The current coordinator tick; maintenance only runs when it
+                is positive and a multiple of the configured cadence.
+
+        Returns:
+            A summary dict of work performed (leases reaped, tasks reclaimed,
+            rows pruned, disk status) when the cadence fired, else ``None``.
         """
         every = int(getattr(self, "_maintenance_every_ticks", 0) or 0)
         if every <= 0 or tick <= 0 or (tick % every) != 0:
@@ -787,6 +833,17 @@ class Coordinator:
         Returns True when a checkpoint was taken. Best-effort. ``force`` bypasses
         the throttle policy (used by the R6 cycle-boundary soft restart) but
         still requires a seeded conversational backend.
+
+        Args:
+            tick: The current coordinator tick, recorded on the checkpoint
+                tracker and emitted in the observation.
+            phase_changed: Whether the phase changed this tick; influences the
+                throttle policy's decision to checkpoint.
+            force: Bypass the throttle policy and checkpoint regardless of
+                cadence (still requires a seeded conversational backend).
+
+        Returns:
+            ``True`` if a checkpoint was taken, else ``False``.
         """
         if not self._checkpoint_enabled:
             return False
@@ -894,7 +951,16 @@ class Coordinator:
             log.exception("Coordinator: failed to attach orchestration context tools")
 
     def _context_inbox_reader(self, since_seq: int = 0) -> str:
-        """Synchronous projection of the orchestration inbox tail (sync SQLite path)."""
+        """Synchronous projection of the orchestration inbox tail (sync SQLite path).
+
+        Args:
+            since_seq: Only events with a sequence number greater than this are
+                included; defaults to ``0`` (all events).
+
+        Returns:
+            A newline-joined rendering of the last 40 matching inbox events, or
+            a placeholder string when none are available.
+        """
         try:
             rows = self.bus.db.fetchall_sync(
                 "SELECT * FROM events WHERE seq > ? AND "
@@ -911,7 +977,16 @@ class Coordinator:
         return "\n".join(lines)
 
     def _context_recent_outcomes_reader(self, top_k: int = 8) -> str:
-        """Synchronous projection of recent action outcomes (Path A / A2)."""
+        """Synchronous projection of recent action outcomes (Path A / A2).
+
+        Args:
+            top_k: Number of recent outcome events to project; clamped to the
+                range 1..50 (defaults to 8).
+
+        Returns:
+            A newline-joined, chronological (newest-last) rendering of recent
+            delegated_result/review_verdict events, or a placeholder string.
+        """
         try:
             k = max(1, min(int(top_k or 8), 50))
         except (TypeError, ValueError):
@@ -940,7 +1015,12 @@ class Coordinator:
     })
 
     def _inline_action_whitelist(self) -> frozenset[str]:
-        """Derive the set of actions safe to run inline (A3): lane-light, registered executor, not in _INLINE_ACTION_DENY. PolicyGate remains the real security boundary."""
+        """Derive the set of actions safe to run inline (A3): lane-light, registered executor, not in _INLINE_ACTION_DENY. PolicyGate remains the real security boundary.
+
+        Returns:
+            A frozenset of action names eligible for inline execution; empty
+            when no action registry is loaded.
+        """
         reg = getattr(self, "action_registry", None)
         if reg is None:
             return frozenset()
@@ -965,7 +1045,17 @@ class Coordinator:
     def _run_action_now_sync(
         self, action_name: str, params: dict[str, Any] | None = None,
     ) -> str:
-        """Bridge callable for the ``run_action_now`` context tool (A3): marshals the executor coroutine onto the Coordinator loop and blocks with a timeout."""
+        """Bridge callable for the ``run_action_now`` context tool (A3): marshals the executor coroutine onto the Coordinator loop and blocks with a timeout.
+
+        Args:
+            action_name: Name of the action to run inline; must be
+                inline-eligible per :meth:`_inline_action_whitelist`.
+            params: Optional parameter mapping forwarded to the executor.
+
+        Returns:
+            A human-readable status string describing the inline run outcome,
+            disablement, ineligibility, timeout, or error.
+        """
         if not self._inline_fast_actions_enabled:
             return (
                 "(run_action_now disabled: set "
@@ -1019,7 +1109,16 @@ class Coordinator:
     async def _run_action_now(
         self, action_name: str, params: dict[str, Any],
     ) -> str:
-        """Coordinator-loop coroutine that runs a whitelisted action inline through PolicyGate + SubAgentRunner, publishing a delegated_result for audit/inbox parity."""
+        """Coordinator-loop coroutine that runs a whitelisted action inline through PolicyGate + SubAgentRunner, publishing a delegated_result for audit/inbox parity.
+
+        Args:
+            action_name: Name of the action to execute.
+            params: Parameter mapping forwarded to the task/executor.
+
+        Returns:
+            A status string: a policy/sequence denial message, an
+            already-in-flight notice, or the rendered delegated_result line.
+        """
         from .message_bus import Message
         # PolicyGate parity (R1): validate synthetic delegate intent so phase/role/paths/red-line gates apply.
         intent = Intent(
@@ -1088,7 +1187,12 @@ class Coordinator:
         return f"inline run complete: {rendered}"
 
     def _context_analysis_reader(self) -> str:
-        """Return the latest TraceLens analysis.md snapshot text."""
+        """Return the latest TraceLens analysis.md snapshot text.
+
+        Returns:
+            The formatted analysis.md snapshot, the text read from the recorded
+            ``analysis_md_path``, or a placeholder when none is available.
+        """
         try:
             blob = self.shared_state._format_analysis_md_full()
             if blob and blob.strip():
@@ -1108,7 +1212,12 @@ class Coordinator:
 
     # Resume
     def _detect_resume_state(self) -> dict[str, Any]:
-        """Synchronously inspect persistence to determine if this is a resume (non-blocking)."""
+        """Synchronously inspect persistence to determine if this is a resume (non-blocking).
+
+        Returns:
+            A dict with ``is_resume``, ``event_count``, ``state_json_present``
+            and ``rebuilt`` (the last set later by :meth:`replay_for_resume`).
+        """
         ev_count = self.bus.db.fetchone_sync("SELECT COUNT(*) AS c FROM events")
         events_present = (int(ev_count["c"]) if ev_count else 0) > 0
         state_path = SharedState.state_path(self.session_dir)
@@ -1120,7 +1229,13 @@ class Coordinator:
         }
 
     async def replay_for_resume(self) -> dict[str, Any]:
-        """Walk the event log to reconstruct ``CoordinatorState.pending_proposals``. Idempotent; a proposal is undecided when no review_verdict targets it."""
+        """Walk the event log to reconstruct ``CoordinatorState.pending_proposals``. Idempotent; a proposal is undecided when no review_verdict targets it.
+
+        Returns:
+            A dict summarising the replay: ``is_resume``, ``event_count``,
+            ``state_json_present``, ``pending_restored`` (count rebuilt) and
+            ``verdicts_seen``.
+        """
         proposal_msgs = await self.bus.tail(topic="proposal", n=10_000)
         verdicts = await self.bus.tail(topic="review_verdict", n=10_000)
 
@@ -1164,7 +1279,12 @@ class Coordinator:
 
     @property
     def resumed_from(self) -> dict[str, Any]:
-        """Read-only snapshot of resume detection (set by ``__init__``)."""
+        """Read-only snapshot of resume detection (set by ``__init__``).
+
+        Returns:
+            A copy of the resume-detection dict so callers cannot mutate
+            internal state.
+        """
         return dict(self._resumed_from)
 
     # Lifecycle
@@ -1441,6 +1561,11 @@ class Coordinator:
         so the new cycle gets a fresh budget / plateau evaluation. The explore
         ledger is preserved; its already-KEEP entries stay blocked while
         sub-threshold ones may unblock as the KEEP bar decays.
+
+        Args:
+            evidence: The loopback evidence dict from ``compute_next_phase``;
+                may carry ``no_gain_cycle_streak_effective`` which is persisted
+                onto the new cycle.
         """
         state = self.shared_state
         prior_cycle = int(getattr(state, "macro_cycle", 0) or 0)
@@ -1500,6 +1625,14 @@ class Coordinator:
 
         Best-effort: every step is independently guarded so one failure never
         aborts the run loop. Returns a summary dict when it ran, else ``None``.
+
+        Args:
+            prior_cycle: The macro-cycle number that just finished.
+            new_cycle: The macro-cycle number being entered.
+
+        Returns:
+            A summary dict of the restart steps performed, or ``None`` when the
+            soft restart is disabled.
         """
         if not getattr(self, "_cycle_soft_restart", False):
             return None
@@ -1595,7 +1728,13 @@ class Coordinator:
         _kill_stale_servers()
 
     async def _on_phase_entered(self, *, from_phase: str, to_phase: str) -> None:
-        """Fire per-phase entry side effects (pure dispatcher; hooks catch + log internally). CLOSE runs the 5-step sequencer (KB_design §3.2 §5.5 + KB_gaps/Gap-06; sets close_sequence_done)."""
+        """Fire per-phase entry side effects (pure dispatcher; hooks catch + log internally). CLOSE runs the 5-step sequencer (KB_design §3.2 §5.5 + KB_gaps/Gap-06; sets close_sequence_done).
+
+        Args:
+            from_phase: The phase being left.
+            to_phase: The phase being entered; selects which per-phase entry
+                hook fires.
+        """
         # Orchestration checkpoint at the phase seam (plan Step 4); runs before per-phase side effects.
         try:
             await self._maybe_checkpoint_orchestration(
@@ -1618,7 +1757,12 @@ class Coordinator:
             await self._on_enter_close(from_phase=from_phase)
 
     async def _on_enter_explore(self, *, from_phase: str) -> None:
-        """Warm ``KnowledgePlane.pr_feed`` across specialist domains (best-effort) on EXPLORE entry. Roofline lives in PRELUDE, not here (except the R3 per-cycle reprofile below)."""
+        """Warm ``KnowledgePlane.pr_feed`` across specialist domains (best-effort) on EXPLORE entry. Roofline lives in PRELUDE, not here (except the R3 per-cycle reprofile below).
+
+        Args:
+            from_phase: The phase being left; a SWEEP origin in cyclic mode
+                triggers the R3 per-cycle forced reprofile.
+        """
         # R3: at the start of each macro-cycle (cyclic loopback SWEEP→EXPLORE),
         # force a fresh roofline/profile so the new cycle re-targets the current
         # bottleneck instead of reusing the prior cycle's stale picture. The
@@ -1659,7 +1803,11 @@ class Coordinator:
             )
 
     async def _on_enter_framework_pr(self, *, from_phase: str) -> None:
-        """FRAMEWORK_PR entry hook: trigger the per-batch pump once on entry (best-effort; later batches driven from the main tick)."""
+        """FRAMEWORK_PR entry hook: trigger the per-batch pump once on entry (best-effort; later batches driven from the main tick).
+
+        Args:
+            from_phase: The phase being left, used only for logging.
+        """
         log.info(
             "FRAMEWORK_PR entry (from=%s): pumping initial batch",
             from_phase or "<unknown>",
@@ -1775,7 +1923,13 @@ class Coordinator:
                 )
 
     async def _framework_pr_authoring_inflight(self) -> bool:
-        """True while a FRAMEWORK_PR-authored patch is still in flight (specialist/integrate_patch task or pending integrate_patch proposal); pump waits before advancing."""
+        """True while a FRAMEWORK_PR-authored patch is still in flight (specialist/integrate_patch task or pending integrate_patch proposal); pump waits before advancing.
+
+        Returns:
+            ``True`` if a specialist/integrate_patch task is queued or running,
+            or an integrate_patch proposal is pending Critic review; else
+            ``False``.
+        """
         try:
             queued = await self.tasks.queued()
             running = await self.tasks.running()
@@ -1796,7 +1950,13 @@ class Coordinator:
     async def _enqueue_framework_pr_authoring_specialist(
         self, candidate: dict[str, Any],
     ) -> None:
-        """Dispatch a write-capable specialist seeded with ``candidate`` (Inv-5.1: flows through autosubmit → Critic → integrate_patch → bench → KEEP/REVERT)."""
+        """Dispatch a write-capable specialist seeded with ``candidate`` (Inv-5.1: flows through autosubmit → Critic → integrate_patch → bench → KEEP/REVERT).
+
+        Args:
+            candidate: The discovered FRAMEWORK_PR candidate (PR url, title,
+                diff url, batch/candidate ids) used to seed the specialist's
+                authoring task and provenance markers.
+        """
         state = self.shared_state
         cand_id = str(
             candidate.get("candidate_id")
@@ -1881,7 +2041,12 @@ class Coordinator:
         )
 
     def _select_next_framework_pr_candidate(self) -> dict[str, Any] | None:
-        """Return the next unprocessed candidate in the latest batch (processed = has progress entry)."""
+        """Return the next unprocessed candidate in the latest batch (processed = has progress entry).
+
+        Returns:
+            The next candidate dict not yet recorded in the phase progress, or
+            ``None`` when no batch exists or all are processed.
+        """
         state = self.shared_state
         batches = getattr(state, "framework_pr_batches", None) or []
         if not batches:
@@ -1911,7 +2076,12 @@ class Coordinator:
         return None
 
     def _framework_pr_known_candidate_ids(self) -> set[str]:
-        """All candidate ids already discovered into any prior batch (dedup for new batches)."""
+        """All candidate ids already discovered into any prior batch (dedup for new batches).
+
+        Returns:
+            A set of candidate ids drawn from every prior batch plus PR ids the
+            research scout has already mined.
+        """
         state = self.shared_state
         ids: set[str] = set()
         batches = getattr(state, "framework_pr_batches", None) or []
@@ -1939,7 +2109,11 @@ class Coordinator:
         return ids
 
     def _framework_pr_tried_refs(self) -> list[str]:
-        """Refs already discovered this phase (fed to compose_gap to bias away from prior PR categories)."""
+        """Refs already discovered this phase (fed to compose_gap to bias away from prior PR categories).
+
+        Returns:
+            A list of already-known candidate id refs.
+        """
         refs: list[str] = []
         for cid in self._framework_pr_known_candidate_ids():
             if cid:
@@ -1947,7 +2121,14 @@ class Coordinator:
         return refs
 
     def _framework_pr_discover_repo_urls(self, framework: str) -> list[str]:
-        """Repo URLs to query for the FRAMEWORK_PR batch: framework's own repo + pr_intel_specialist cross-repo set, dedup preserving order."""
+        """Repo URLs to query for the FRAMEWORK_PR batch: framework's own repo + pr_intel_specialist cross-repo set, dedup preserving order.
+
+        Args:
+            framework: The framework name whose own repo seeds the query.
+
+        Returns:
+            An order-preserving, deduped list of repo URLs to query.
+        """
         from . import framework_agent_client as _fa_client
 
         urls: list[str] = []
@@ -1988,7 +2169,12 @@ class Coordinator:
     def _record_framework_pr_phase_done(
         self, *, reason: str, failure_count: int,
     ) -> None:
-        """Append a framework_pr_phase_done row to phase_history describing why the pump gave up."""
+        """Append a framework_pr_phase_done row to phase_history describing why the pump gave up.
+
+        Args:
+            reason: Human-readable reason the phase ended.
+            failure_count: Number of consecutive discover failures recorded.
+        """
         state = self.shared_state
         try:
             history = getattr(state, "phase_history", None)
@@ -2007,7 +2193,13 @@ class Coordinator:
             pass
 
     async def _discover_next_framework_pr_batch(self) -> bool:
-        """Call ``fa phase-discover`` and append a batch to SharedState. Returns True iff a non-empty batch was appended; transient failures return False (see DISCOVER_FAILURE_RETRY_LIMIT)."""
+        """Call ``fa phase-discover`` and append a batch to SharedState. Returns True iff a non-empty batch was appended; transient failures return False (see DISCOVER_FAILURE_RETRY_LIMIT).
+
+        Returns:
+            ``True`` if a non-empty, deduped batch of new candidates was
+            appended to SharedState; ``False`` on transient failure or when no
+            new candidates were found.
+        """
         from . import framework_agent_client as _fa_client
 
         state = self.shared_state
@@ -2246,7 +2438,13 @@ class Coordinator:
     _CRITIC_PRIORS_OUTCOME_TAIL: int = 5
 
     def _collect_framework_pr_priors(self) -> dict[str, Any]:
-        """Return compact session-local priors for the Critic gate (recent_decisions + recent_outcomes); best-effort."""
+        """Return compact session-local priors for the Critic gate (recent_decisions + recent_outcomes); best-effort.
+
+        Returns:
+            A dict with ``recent_decisions`` (recent critic verdicts) and
+            ``recent_outcomes`` (recent terminal apply/bench results), each
+            bounded to a short tail.
+        """
         state = self.shared_state
         decisions: list[dict[str, Any]] = []
         try:
@@ -2286,6 +2484,14 @@ class Coordinator:
 
         Returns {"verdict": "approve"|"reject"|"abstain", "rationale": str}. abstain is the safe degraded
         path (treated as approve by caller); decisions cached in framework_pr_critic_decisions for resume.
+
+        Args:
+            candidate: The discovered PR candidate to review.
+
+        Returns:
+            A dict with ``verdict`` (one of "approve", "reject", "abstain") and
+            ``rationale``; abstain is the safe degraded path treated as approve
+            by the caller.
         """
         state = self.shared_state
         cand_id = str(
@@ -2396,7 +2602,11 @@ class Coordinator:
         return verdict_row
 
     async def _on_enter_kernel(self, *, from_phase: str) -> None:
-        """Run deterministic KERNEL-entry setup before LLM kernel work (FP8 GEMM tuning gate)."""
+        """Run deterministic KERNEL-entry setup before LLM kernel work (FP8 GEMM tuning gate).
+
+        Args:
+            from_phase: The phase being left, used only for logging.
+        """
         if not self._kernel_enabled():
             # Should not happen — --no-kernel routes EXPLORE → SWEEP.
             log.info(
@@ -2596,7 +2806,12 @@ class Coordinator:
     _ROOFLINE_WATERMARK_RATIO: float = 1.10   # 10% step over last roofline
 
     def _current_tput_from_validated_gain(self) -> float:
-        """Project current tput from ``baseline_tput * (1 + cumulative_gain_validated/100)``; 0.0 when baseline unknown (watermark not-yet-armed)."""
+        """Project current tput from ``baseline_tput * (1 + cumulative_gain_validated/100)``; 0.0 when baseline unknown (watermark not-yet-armed).
+
+        Returns:
+            The projected current throughput, or ``0.0`` when the baseline is
+            unknown.
+        """
         state = self.shared_state
         try:
             base = float(state.baseline_tput or 0.0)
@@ -2611,7 +2826,13 @@ class Coordinator:
         return base * (1.0 + gain / 100.0)
 
     def _needs_roofline_for_watermark(self) -> bool:
-        """True iff projected tput crossed the 10% watermark over ``last_roofline_tput`` (bootstrap guard: False until PRELUDE roofline ran; re-arm guard: False while auto_roofline_pending_task_id is in-flight)."""
+        """True iff projected tput crossed the 10% watermark over ``last_roofline_tput`` (bootstrap guard: False until PRELUDE roofline ran; re-arm guard: False while auto_roofline_pending_task_id is in-flight).
+
+        Returns:
+            ``True`` when a fresh roofline is warranted because projected tput
+            crossed the watermark ratio; ``False`` otherwise (including the
+            bootstrap and in-flight re-arm guards).
+        """
         state = self.shared_state
         try:
             last_rl = float(state.last_roofline_tput or 0.0)
@@ -2642,7 +2863,14 @@ class Coordinator:
     async def _maybe_enqueue_watermark_roofline(
         self, *, reason: str,
     ) -> bool:
-        """Enqueue a fresh roofline if the watermark crossed; idempotency-keyed via ``reason``, stamps auto_roofline_pending_task_id. Returns True when enqueued."""
+        """Enqueue a fresh roofline if the watermark crossed; idempotency-keyed via ``reason``, stamps auto_roofline_pending_task_id. Returns True when enqueued.
+
+        Args:
+            reason: Tag used in the task's idempotency key and logging.
+
+        Returns:
+            ``True`` if a roofline task was enqueued, else ``False``.
+        """
         if not self._needs_roofline_for_watermark():
             return False
         try:
@@ -2664,13 +2892,25 @@ class Coordinator:
         return True
 
     def _internal_analysis_kind(self) -> str:
-        """Pick the kind for the next Coordinator-internal analysis task: roofline (composite) when enable_roofline else profile. Both absent from PHASE_LLM_PROPOSABLE_ACTIONS (PolicyGate R1 denies LLM proposals)."""
+        """Pick the kind for the next Coordinator-internal analysis task: roofline (composite) when enable_roofline else profile. Both absent from PHASE_LLM_PROPOSABLE_ACTIONS (PolicyGate R1 denies LLM proposals).
+
+        Returns:
+            ``"roofline"`` when roofline is enabled, else ``"profile"``.
+        """
         return "roofline" if bool(
             getattr(self.shared_state, "enable_roofline", True),
         ) else "profile"
 
     def _registry_lanes_ttl(self, kind: str) -> tuple[list[str], int]:
-        """Resolve ``(requires_lanes, lease_ttl_sec)`` from the ActionRegistry; lanes filtered to KNOWN_LANES, returns ([], 0) for unknown actions."""
+        """Resolve ``(requires_lanes, lease_ttl_sec)`` from the ActionRegistry; lanes filtered to KNOWN_LANES, returns ([], 0) for unknown actions.
+
+        Args:
+            kind: The action name to resolve.
+
+        Returns:
+            A ``(requires_lanes, lease_ttl_sec)`` tuple; ``([], 0)`` when the
+            action is unknown or no registry is loaded.
+        """
         reg = getattr(self, "action_registry", None)
         if reg is None:
             return [], 0
@@ -2684,7 +2924,12 @@ class Coordinator:
         return lanes, int(getattr(meta, "lease_ttl_sec", 0) or 0)
 
     def _warm_recipe_proven_items(self) -> list[dict[str, str]]:
-        """Summarise warm-start ``what_worked`` items the scout can skip ({name, source}); fail-soft."""
+        """Summarise warm-start ``what_worked`` items the scout can skip ({name, source}); fail-soft.
+
+        Returns:
+            A list of ``{"name", "source"}`` dicts for proven warm-start items;
+            empty when no warm recipe is present.
+        """
         state = self.shared_state
         warm = getattr(state, "warm_start_recipe", None) or {}
         if not isinstance(warm, dict) or not warm:
@@ -2705,7 +2950,11 @@ class Coordinator:
         return out
 
     def _inject_warm_recipe_history_into_ledger(self) -> int:
-        """GAP 1 — pre-fill ``explore_search.rejected`` with the warm recipe's ``what_failed`` rows (fingerprinted so the dedup gate denies re-tests). Idempotent via warm_history_injected; returns rows added."""
+        """GAP 1 — pre-fill ``explore_search.rejected`` with the warm recipe's ``what_failed`` rows (fingerprinted so the dedup gate denies re-tests). Idempotent via warm_history_injected; returns rows added.
+
+        Returns:
+            The number of new rejected rows injected into the explore ledger.
+        """
         state = self.shared_state
         if getattr(state, "warm_history_injected", False):
             return 0
@@ -2785,6 +3034,14 @@ class Coordinator:
 
         Skips on --no-warm-replay/resume/low-confidence/empty best_config; otherwise mints an internal
         task running the baseline workload contract with the KB config applied. Idempotent via warm-replay-prelude.
+
+        Args:
+            baseline_tput: The baseline throughput captured at enqueue time,
+                carried forward as the replay's comparison anchor.
+
+        Returns:
+            The created (or existing) ``replay_warm_recipe`` task, or ``None``
+            when the replay is skipped.
         """
         state = self.shared_state
         if not getattr(self, "_warm_replay_enabled", True):
@@ -2926,7 +3183,14 @@ class Coordinator:
     def _promote_warm_replay(
         self, result: dict, *, task: "Task | None" = None,
     ) -> None:
-        """GAP 1 — interpret a ``replay_warm_recipe`` result: any measured uplift pushes warm config onto optimization_stack + current_best; failures set status and never propagate."""
+        """GAP 1 — interpret a ``replay_warm_recipe`` result: any measured uplift pushes warm config onto optimization_stack + current_best; failures set status and never propagate.
+
+        Args:
+            result: The ``replay_warm_recipe`` task result dict (status,
+                throughput, workspace, etc.).
+            task: The originating task, used to recover the warm args/envs and
+                the baseline anchor; may be ``None`` (degraded path).
+        """
         state = self.shared_state
         outcome = dict(state.warm_replay_outcome or {})
         expected_gain = float(outcome.get("expected_gain_pct") or 0.0)
@@ -3114,7 +3378,12 @@ class Coordinator:
         *,
         baseline_tput: float | None = None,
     ) -> None:
-        """Enqueue the PRELUDE-bootstrap roofline/profile task after baseline; skipped while warm-replay is in_flight (GPU/port contention)."""
+        """Enqueue the PRELUDE-bootstrap roofline/profile task after baseline; skipped while warm-replay is in_flight (GPU/port contention).
+
+        Args:
+            baseline_tput: The baseline throughput; ``None`` reads it from
+                SharedState. A non-positive value short-circuits the enqueue.
+        """
         state = self.shared_state
         if _phase_state.warm_replay_in_flight(state):
             log.info(
@@ -3154,12 +3423,23 @@ class Coordinator:
 
         Without this, a later macro-cycle's sweep/roofline/profile would dedupe
         to the first cycle's already-succeeded task and never re-run.
+
+        Returns:
+            ``"-c<cycle>"`` for macro-cycle > 0, else an empty string.
         """
         cycle = int(getattr(self.shared_state, "macro_cycle", 0) or 0)
         return f"-c{cycle}" if cycle > 0 else ""
 
     async def _enqueue_internal_analysis_task(self, *, reason: str) -> Task:
-        """Build + enqueue a Coordinator-internal analysis task (roofline or profile). Kind-agnostic idempotency key internal-analysis-<reason>; omits baseline_config_path so ProfileExecutor enables torch_profiler."""
+        """Build + enqueue a Coordinator-internal analysis task (roofline or profile). Kind-agnostic idempotency key internal-analysis-<reason>; omits baseline_config_path so ProfileExecutor enables torch_profiler.
+
+        Args:
+            reason: Tag distinguishing the enqueue site; used in the
+                idempotency key and to select baseline vs current-best args.
+
+        Returns:
+            The created (or existing idempotent) analysis :class:`Task`.
+        """
         state = self.shared_state
         kind = self._internal_analysis_kind()
         params: dict[str, Any] = {
@@ -3206,7 +3486,12 @@ class Coordinator:
         return task
 
     def _record_phase_entry_evidence(self, **kvs: Any) -> None:
-        """Merge ``kvs`` into the latest phase_history row's evidence dict (Gap-04; no-op when empty)."""
+        """Merge ``kvs`` into the latest phase_history row's evidence dict (Gap-04; no-op when empty).
+
+        Args:
+            **kvs: Arbitrary key/value pairs merged into the latest
+                phase_history row's evidence dict.
+        """
         history = self.shared_state.phase_history or []
         if not history:
             return
@@ -3275,7 +3560,12 @@ class Coordinator:
             )
 
     def _positive_needs_review_integrates(self) -> list[dict[str, Any]]:
-        """Return positive NEEDS_REVIEW integrate entries eligible for stack validation."""
+        """Return positive NEEDS_REVIEW integrate entries eligible for stack validation.
+
+        Returns:
+            Integrate-attempt entries with a positive best gain that are not
+            yet stack-resolved or in progress, sorted by gain descending.
+        """
         out: list[dict[str, Any]] = []
         stack_resolved_ids = self._stack_resolved_kernel_ids()
         for entry in (self.shared_state.kernel_integrate_attempts or {}).values():
@@ -3304,7 +3594,11 @@ class Coordinator:
         return out
 
     def _stack_resolved_kernel_ids(self) -> set[str]:
-        """Kernel ids already covered by a kept stack validation."""
+        """Kernel ids already covered by a kept stack validation.
+
+        Returns:
+            The set of kernel ids resolved by kept ``integrate`` stack entries.
+        """
         resolved: set[str] = set()
         for item in self.shared_state.optimization_stack or []:
             if not isinstance(item, dict):
@@ -3325,7 +3619,13 @@ class Coordinator:
         entries: list[dict[str, Any]],
         result: dict[str, Any],
     ) -> None:
-        """Mark component NEEDS_REVIEW entries as handled by a kept stack."""
+        """Mark component NEEDS_REVIEW entries as handled by a kept stack.
+
+        Args:
+            entries: The component integrate entries that formed the stack.
+            result: The stack-validation result; only a ``KEEP`` decision with
+                a stack kernel id triggers marking.
+        """
         stack_id = str(result.get("kernel_id") or "")
         decision = str(result.get("decision") or "").upper()
         if decision != "KEEP" or not stack_id:
@@ -3359,7 +3659,14 @@ class Coordinator:
     def _stack_component_identities(
         self, entries: list[dict[str, Any]],
     ) -> set[tuple[str, str, str]]:
-        """Return (kernel_id, patch_path, target_file) tuples for stack members."""
+        """Return (kernel_id, patch_path, target_file) tuples for stack members.
+
+        Args:
+            entries: The stack component integrate entries.
+
+        Returns:
+            A set of ``(kernel_id, patch_path, target_file)`` identity tuples.
+        """
         return {
             (
                 str(entry.get("kernel_id") or ""),
@@ -3375,7 +3682,12 @@ class Coordinator:
         entries: list[dict[str, Any]],
         stack_id: str,
     ) -> None:
-        """Persist an in-flight stack guard before applying patches."""
+        """Persist an in-flight stack guard before applying patches.
+
+        Args:
+            entries: The component integrate entries to guard.
+            stack_id: The combined stack kernel id stamped onto each entry.
+        """
         now = datetime.now(timezone.utc).isoformat()
         wanted = self._stack_component_identities(entries)
         for entry in (self.shared_state.kernel_integrate_attempts or {}).values():
@@ -3395,7 +3707,12 @@ class Coordinator:
     def _clear_stack_validation_in_progress(
         self, entries: list[dict[str, Any]],
     ) -> None:
-        """Clear the in-flight stack guard for component integrate entries."""
+        """Clear the in-flight stack guard for component integrate entries.
+
+        Args:
+            entries: The component integrate entries whose in-progress guard
+                should be cleared.
+        """
         wanted = self._stack_component_identities(entries)
         for entry in (self.shared_state.kernel_integrate_attempts or {}).values():
             if not isinstance(entry, dict):
@@ -3415,7 +3732,12 @@ class Coordinator:
         self.shared_state.pending_stack_validation_apply_results = []
 
     async def _recover_interrupted_stack_validation(self) -> bool:
-        """Resume or abort a stack validation interrupted by crash."""
+        """Resume or abort a stack validation interrupted by crash.
+
+        Returns:
+            ``True`` if an interrupted stack validation was finalized or rolled
+            back, ``False`` when there was nothing to recover.
+        """
         from .kernel_request_handlers import _maybe_revert_kernel_patch
 
         pending = self.shared_state.pending_stack_validation_result
@@ -3457,7 +3779,16 @@ class Coordinator:
         *,
         stack_id: str = "",
     ) -> list[dict[str, Any]]:
-        """Rebuild component integrate ledger rows for a stack id."""
+        """Rebuild component integrate ledger rows for a stack id.
+
+        Args:
+            kernel_ids: The component kernel ids to recover.
+            stack_id: Fallback ``+``-joined stack id parsed for component ids
+                when ``kernel_ids`` is empty.
+
+        Returns:
+            The matching integrate-attempt entries, sorted by kernel id.
+        """
         wanted_ids = {str(kid) for kid in kernel_ids if str(kid)}
         if not wanted_ids and stack_id:
             wanted_ids = {kid for kid in stack_id.split("+") if kid}
@@ -3476,7 +3807,13 @@ class Coordinator:
         stack: list[dict[str, Any]],
         result: dict[str, Any],
     ) -> None:
-        """Record stack validation, promote KEEP, and clear recovery checkpoints."""
+        """Record stack validation, promote KEEP, and clear recovery checkpoints.
+
+        Args:
+            stack: The component integrate entries that formed the stack.
+            result: The stack-validation result; a ``KEEP`` decision promotes
+                the stack and marks entries resolved.
+        """
         self.shared_state.record_kernel_integrate_result(result)
         decision = str(result.get("decision") or "").upper()
         if decision == "KEEP":
@@ -3528,7 +3865,16 @@ class Coordinator:
     async def _run_kernel_stack_validation_e2e(
         self, entries: list[dict[str, Any]],
     ) -> dict[str, Any]:
-        """Apply multiple kernel patches, run one E2E benchmark, then keep or revert the stack."""
+        """Apply multiple kernel patches, run one E2E benchmark, then keep or revert the stack.
+
+        Args:
+            entries: The component integrate entries whose patches are applied
+                together for the combined benchmark.
+
+        Returns:
+            A result dict with the KEEP/REVERT decision, measured throughput,
+            incremental gain, apply/revert sub-results and stack metadata.
+        """
         from .action_executors.baseline import BaselineExecutor
         from .action_executors.benchmark_result import is_valid_measurement
         from .kernel_request_handlers import (
@@ -3676,7 +4022,11 @@ class Coordinator:
             }
 
     async def _on_enter_sweep(self, *, from_phase: str) -> None:
-        """Auto-enqueue a ``sweep`` task on SWEEP entry (§3.2 §5.4). Idempotent via internal-sweep-phase_entry (Inv-2.1); PolicyGate's sweep_phase_singleton then denies LLM-emitted sweep (OOM race)."""
+        """Auto-enqueue a ``sweep`` task on SWEEP entry (§3.2 §5.4). Idempotent via internal-sweep-phase_entry (Inv-2.1); PolicyGate's sweep_phase_singleton then denies LLM-emitted sweep (OOM race).
+
+        Args:
+            from_phase: The phase being left, used only for logging.
+        """
         state = self.shared_state
         # Bug #7 fix: drain pending KEEP integrates from prior KERNEL so sweep measures full current_best.
         if getattr(state, "has_keep_pending_integrate", False):
@@ -3717,7 +4067,15 @@ class Coordinator:
     async def _enqueue_internal_conc_sweep_task(
         self, *, reason: str,
     ) -> Task | None:
-        """Build + enqueue a Coordinator-internal ``conc_sweep`` task (caller checks conc_sweep_enabled). Idempotency key + PolicyGate singleton ensure ≤1 per SWEEP; returns None on error."""
+        """Build + enqueue a Coordinator-internal ``conc_sweep`` task (caller checks conc_sweep_enabled). Idempotency key + PolicyGate singleton ensure ≤1 per SWEEP; returns None on error.
+
+        Args:
+            reason: Tag used in the task's idempotency key and logging.
+
+        Returns:
+            The created (or existing) ``conc_sweep`` task, or ``None`` on
+            enqueue error.
+        """
         state = self.shared_state
         params: dict[str, Any] = {
             "source": "coordinator_internal",
@@ -3758,7 +4116,14 @@ class Coordinator:
     async def _enqueue_internal_sweep_task(
         self, *, reason: str,
     ) -> Task:
-        """Build + enqueue a Coordinator-internal ``sweep`` task. Grid priority: warm_start_recipe.sweep_grid then SKILL.md defaults. Idempotency key internal-sweep-<reason>."""
+        """Build + enqueue a Coordinator-internal ``sweep`` task. Grid priority: warm_start_recipe.sweep_grid then SKILL.md defaults. Idempotency key internal-sweep-<reason>.
+
+        Args:
+            reason: Tag used in the task's idempotency key and logging.
+
+        Returns:
+            The created (or existing idempotent) ``sweep`` :class:`Task`.
+        """
         state = self.shared_state
         grid_params = self._build_sweep_params_from_recipe(state)
         params: dict[str, Any] = {
@@ -3795,7 +4160,17 @@ class Coordinator:
 
     @staticmethod
     def _build_sweep_params_from_recipe(state: SharedState) -> dict[str, Any]:
-        """Pick a sweep grid (§3.14 R-13): warm_start_recipe.sweep_grid takes precedence over SKILL.md defaults; per-field fallback. Returns source/conc_values/isl_osl_configs/num_prompts_factor."""
+        """Pick a sweep grid (§3.14 R-13): warm_start_recipe.sweep_grid takes precedence over SKILL.md defaults; per-field fallback. Returns source/conc_values/isl_osl_configs/num_prompts_factor.
+
+        Args:
+            state: The session SharedState whose ``warm_start_recipe`` may carry
+                a ``sweep_grid`` override.
+
+        Returns:
+            A dict with ``source`` (``"cortex_recipe"`` or
+            ``"skill_md_default"``), ``conc_values``, ``isl_osl_configs`` and
+            ``num_prompts_factor``.
+        """
         from .action_executors.sweep import (
             DEFAULT_CONC_VALUES,
             DEFAULT_ISL_OSL,
@@ -3899,7 +4274,12 @@ class Coordinator:
     CLOSE_NDJSON_DRAIN_TIMEOUT_SEC: float = 60.0
 
     def _derive_close_stop_reason(self) -> str:
-        """Best-effort ``stop_reason`` for a CLOSE reached blank: recover from the newest CLOSE-bound phase_history row, else time_exhausted."""
+        """Best-effort ``stop_reason`` for a CLOSE reached blank: recover from the newest CLOSE-bound phase_history row, else time_exhausted.
+
+        Returns:
+            A valid stop reason recovered from the newest CLOSE-bound
+            phase_history row, or ``"time_exhausted"`` as the fallback.
+        """
         history = self.shared_state.phase_history or []
         for row in reversed(history):
             if not isinstance(row, dict):
@@ -3915,7 +4295,11 @@ class Coordinator:
         return "time_exhausted"
 
     async def _on_enter_close(self, *, from_phase: str) -> None:
-        """CLOSE 5-step sequencer (fixed order): report → session_breakdown → fact_finalize → ndjson_drain (no-op) → mark close_sequence_done + stop_reason. Best-effort steps; final done step always runs."""
+        """CLOSE 5-step sequencer (fixed order): report → session_breakdown → fact_finalize → ndjson_drain (no-op) → mark close_sequence_done + stop_reason. Best-effort steps; final done step always runs.
+
+        Args:
+            from_phase: The phase being left, used only for logging.
+        """
         log.info("CLOSE entered (from=%s); starting 5-step close sequence",
                  from_phase or "<unknown>")
         await self._record_close_step("sequencer_started", status="running")
@@ -4112,6 +4496,12 @@ class Coordinator:
         """Build + enqueue a Coordinator-internal ``report`` task (idempotency_key internal-report-<reason>).
 
         Reuses closing_report_task_id when set so the wall-clock + CLOSE-sequencer paths don't race.
+
+        Args:
+            reason: Tag used in the task's idempotency key and logging.
+
+        Returns:
+            The created or reused ``report`` :class:`Task`.
         """
         existing_id = (self.shared_state.closing_report_task_id or "").strip()
         if existing_id:
@@ -4161,7 +4551,17 @@ class Coordinator:
     async def _enqueue_internal_research_scout_task(
         self, *, reason: str, round_id: int,
     ) -> "Task | None":
-        """Enqueue a Coordinator-owned read-only research-scout specialist task; idempotency keyed by round, returns None on existing/failure (fail-soft)."""
+        """Enqueue a Coordinator-owned read-only research-scout specialist task; idempotency keyed by round, returns None on existing/failure (fail-soft).
+
+        Args:
+            reason: Tag distinguishing the enqueue site, recorded on the task.
+            round_id: The EXPLORE round (or 0 for PRELUDE) scoping the
+                idempotency key.
+
+        Returns:
+            The created (or existing) specialist :class:`Task`, or ``None`` when
+            the scout is disabled or enqueue fails.
+        """
         if not bool(getattr(self.shared_state, "research_scout_enabled", True)):
             return None
         idempotency_key = f"internal-research-scout-round{int(round_id)}"
@@ -4269,6 +4669,11 @@ class Coordinator:
         self-throttles by zeroing the per-anchor counter on dispatch. Routes
         through ``_handle_intent`` exactly as an LLM delegate would; at most one
         forced dispatch per tick.
+
+        Note:
+            Side-effecting: may dispatch a domain specialist via
+            ``_handle_intent`` and mutate per-anchor throttle counters on
+            ``shared_state``. Returns nothing.
         """
         state = self.shared_state
         if str(getattr(state, "phase", "") or "").upper() != "EXPLORE":
@@ -4421,7 +4826,12 @@ class Coordinator:
             )
 
     def _harvest_research_scout(self, done_payload: dict[str, Any]) -> None:
-        """Persist scout output (hints, competitor target, gap seeds, dedup); all steps fail-soft."""
+        """Persist scout output (hints, competitor target, gap seeds, dedup); all steps fail-soft.
+
+        Args:
+            done_payload: The completed research-scout task payload; its
+                ``research`` block carries hints, competitor target and PR ids.
+        """
         from . import research_hints as _research_hints
 
         block = done_payload.get("research")
@@ -4494,7 +4904,15 @@ class Coordinator:
     async def _enqueue_internal_session_breakdown_task(
         self, *, reason: str,
     ) -> Task:
-        """Build + enqueue a Coordinator-internal ``session_breakdown`` task; same idempotency contract as the report helper."""
+        """Build + enqueue a Coordinator-internal ``session_breakdown`` task; same idempotency contract as the report helper.
+
+        Args:
+            reason: Tag used in the task's idempotency key and logging.
+
+        Returns:
+            The created (or existing idempotent) ``session_breakdown``
+            :class:`Task`.
+        """
         params: dict[str, Any] = {
             "source":      "coordinator_internal",
             "reason":      str(reason),
@@ -4562,7 +4980,15 @@ class Coordinator:
         task_id: str = "",
         detail: str = "",
     ) -> None:
-        """Append one row to ``phase_history[-1].evidence.close_steps`` (best-effort, per-step persist)."""
+        """Append one row to ``phase_history[-1].evidence.close_steps`` (best-effort, per-step persist).
+
+        Args:
+            step: The close-step name.
+            status: The step's status (e.g. "running", "done", "failed",
+                "skipped").
+            task_id: Optional task id associated with the step.
+            detail: Optional free-text detail recorded on the row.
+        """
         history = self.shared_state.phase_history or []
         if not history:
             return
@@ -4602,14 +5028,23 @@ class Coordinator:
         await self.replay_for_resume()
 
     async def _pump_framework_pr_phase_safely(self, *, caller: str) -> None:
-        """Best-effort FRAMEWORK_PR pump wrapper shared by tick and run."""
+        """Best-effort FRAMEWORK_PR pump wrapper shared by tick and run.
+
+        Args:
+            caller: Label identifying the caller ("tick" / "run"), used only in
+                the failure log.
+        """
         try:
             await self._pump_framework_pr_phase()
         except Exception:  # noqa: BLE001 — defensive
             log.exception("FRAMEWORK_PR pump (%s) failed", caller)
 
     async def tick(self, n: int = 1) -> None:
-        """Run exactly ``n`` reactor passes for every agent (P0-3/P0-5/P1-4 tests); dispatcher pumps at pass end, lazy resume replay on tick 1."""
+        """Run exactly ``n`` reactor passes for every agent (P0-3/P0-5/P1-4 tests); dispatcher pumps at pass end, lazy resume replay on tick 1.
+
+        Args:
+            n: Number of full reactor+dispatcher passes to run (default 1).
+        """
         await self._replay_resume_if_needed()
         for _ in range(n):
             self.shared_state.increment_tick()
@@ -4629,7 +5064,15 @@ class Coordinator:
         tick: int | None = None,
         agent: str = "",
     ) -> None:
-        """Record a Coordinator-side exception without killing the session."""
+        """Record a Coordinator-side exception without killing the session.
+
+        Args:
+            stage: The pipeline stage where the exception occurred.
+            exc: The caught exception, recorded with type/message/traceback.
+            tick: Optional tick number; defaults to the current SharedState
+                tick when ``None``.
+            agent: Optional agent role associated with the failure.
+        """
         try:
             self.shared_state.record_tick_exception(
                 tick=int(tick if tick is not None else self.shared_state.tick or 0),
@@ -4659,7 +5102,27 @@ class Coordinator:
         crash_emergency_threshold: int = 25,
         closing_grace_sec: float | None = None,
     ) -> str:
-        """Run reactor + dispatcher until a stop condition fires (DESIGN §9.1, priority order): signal, target_reached, time_exhausted (via closing phase), emergency, custom, max_ticks. Sets + saves + returns shared_state.stop_reason."""
+        """Run reactor + dispatcher until a stop condition fires (DESIGN §9.1, priority order): signal, target_reached, time_exhausted (via closing phase), emergency, custom, max_ticks. Sets + saves + returns shared_state.stop_reason.
+
+        Args:
+            objective: Stop objective; ``None`` uses a :class:`TimeOnlyObjective`.
+            max_minutes: Wall-clock budget in minutes; ``None``/falsy runs
+                unbounded (capped at the container lifetime).
+            tick_interval_sec: Sleep between ticks; ``0.0`` keeps tests fast.
+            max_ticks: Optional hard cap on the number of ticks.
+            stop_when: Optional custom predicate (sync or async) evaluated each
+                tick; a truthy result stops the run.
+            install_signal_handlers: Whether to install SIGINT/SIGTERM handlers
+                that set the stop event.
+            crash_emergency_threshold: Recent-crash count within the emergency
+                window that triggers an emergency stop.
+            closing_grace_sec: Grace window for the closing report phase;
+                ``None`` derives a default from ``max_minutes``.
+
+        Returns:
+            The persisted ``shared_state.stop_reason`` describing why the run
+            stopped.
+        """
         objective = objective or TimeOnlyObjective()
         # Stash so _compose_prompt can update target_gap_pct.
         self._current_objective = objective
@@ -4852,7 +5315,15 @@ class Coordinator:
         return self.shared_state.stop_reason
 
     async def _enter_closing_phase(self, *, grace_sec: float) -> float:
-        """Enter report-flush phase after the wall-clock deadline (enqueue deterministic report task)."""
+        """Enter report-flush phase after the wall-clock deadline (enqueue deterministic report task).
+
+        Args:
+            grace_sec: Seconds the closing phase may run before the report task
+                is abandoned.
+
+        Returns:
+            The monotonic deadline by which the closing phase must complete.
+        """
         closing_started = time.time()
         closing_deadline = time.monotonic() + float(grace_sec)
         self.shared_state.closing_phase = True
@@ -5020,6 +5491,11 @@ class Coordinator:
         Wrapped in a broad ``try`` so any unexpected error in trace
         assembly degrades to a logged warning rather than breaking the
         tick loop.
+
+        Args:
+            agent_name: The reactor role; doubles as trace component and role.
+            result: The backend turn result whose metadata carries token
+                counters.
         """
         try:
             metadata = result.metadata or {}
@@ -5062,6 +5538,11 @@ class Coordinator:
 
         Best-effort: any failure degrades to a logged warning rather than
         breaking the tick loop.
+
+        Args:
+            agent_name: The reactor role; doubles as trace component and role.
+            result: The backend turn result whose metadata carries the redacted
+                prompt/response text.
         """
         try:
             metadata = result.metadata or {}
@@ -5089,7 +5570,12 @@ class Coordinator:
     async def _track_backend_error_streak(
         self, agent_name: str, exc: BackendError,
     ) -> None:
-        """Increment the per-agent ``BackendError`` streak; emit one backend_unhealthy event on crossing the threshold (re-arms only after a successful turn)."""
+        """Increment the per-agent ``BackendError`` streak; emit one backend_unhealthy event on crossing the threshold (re-arms only after a successful turn).
+
+        Args:
+            agent_name: The agent role whose error streak is incremented.
+            exc: The backend error; its repr is included in the emitted event.
+        """
         new_value = self._backend_error_streak.get(agent_name, 0) + 1
         self._backend_error_streak[agent_name] = new_value
         threshold = self._backend_error_streak_threshold
@@ -5117,7 +5603,12 @@ class Coordinator:
             )
 
     async def _scan_stale_specialists(self) -> list[dict[str, Any]]:
-        """Return specialist task rows running longer than ``_specialist_stale_sec`` (v0.8 §3.3 §4.4); never raises, returns [] on failure."""
+        """Return specialist task rows running longer than ``_specialist_stale_sec`` (v0.8 §3.3 §4.4); never raises, returns [] on failure.
+
+        Returns:
+            A list of stale specialist task row dicts; empty on failure or when
+            none are stale.
+        """
         try:
             running = await self.tasks.running()
         except Exception:  # noqa: BLE001 — defensive
@@ -5144,7 +5635,15 @@ class Coordinator:
         return stale
 
     async def _compose_prompt(self, agent_name: str) -> str:
-        """v0.6 §8.3 prompt: SharedState summary + inbox tail (with canonical msg_id per inbox row)."""
+        """v0.6 §8.3 prompt: SharedState summary + inbox tail (with canonical msg_id per inbox row).
+
+        Args:
+            agent_name: The agent role to compose the per-tick prompt for;
+                selects which advisory/telemetry sections are included.
+
+        Returns:
+            The assembled prompt string for this agent's reactor turn.
+        """
         sections: list[str] = []
 
         # 0. SESSION_DIR contract — literal path for every agent (pairs with PolicyGate path containment).
@@ -5475,7 +5974,12 @@ class Coordinator:
 
     # Execution order guard
     def _target_analysis_baseline_exists(self) -> bool:
-        """True iff target_analysis produced ``target_baseline.json`` (file existence is a sufficient gate signal)."""
+        """True iff target_analysis produced ``target_baseline.json`` (file existence is a sufficient gate signal).
+
+        Returns:
+            ``True`` when the target baseline file exists (or the helper is
+            unavailable, treated as done); ``False`` otherwise.
+        """
         try:
             from ..session_paths import target_baseline_json
             return target_baseline_json(self.session_dir).exists()
@@ -5483,7 +5987,11 @@ class Coordinator:
             return True
 
     def _kernel_opt_keep_pending(self) -> str:
-        """Return the next kernel_id awaiting integrate, or "" if none (delegates to SharedState.next_pending_keep_kernel_id)."""
+        """Return the next kernel_id awaiting integrate, or "" if none (delegates to SharedState.next_pending_keep_kernel_id).
+
+        Returns:
+            The next kernel id pending integrate, or ``""`` when none.
+        """
         return self.shared_state.next_pending_keep_kernel_id()
 
     def _sequence_denial_for_action(
@@ -5491,7 +5999,17 @@ class Coordinator:
         action_name: str,
         proposed_params: dict[str, Any] | None = None,
     ) -> PolicyDenied | None:
-        """Reject orchestration action/delegate attempts before baseline. Only invariant: nothing runs until baseline_tput > 0 (a data-dependency). proposed_params kept for signature compat."""
+        """Reject orchestration action/delegate attempts before baseline. Only invariant: nothing runs until baseline_tput > 0 (a data-dependency). proposed_params kept for signature compat.
+
+        Args:
+            action_name: The proposed/delegated action name.
+            proposed_params: Optional action params; kept for signature
+                compatibility and not currently inspected.
+
+        Returns:
+            A :class:`PolicyDenied` when the action must wait for baseline, else
+            ``None``.
+        """
         action = str(action_name or "").strip()
         sequence_actions = {
             "target_analysis",
@@ -5516,7 +6034,18 @@ class Coordinator:
     def _sequence_denial_for_request(
         self, target_agent: str, kind: str,
     ) -> PolicyDenied | None:
-        """Reject kernel requests that skip the baseline prerequisite (invariant: nothing kernel-side runs before baseline_tput > 0)."""
+        """Reject kernel requests that skip the baseline prerequisite (invariant: nothing kernel-side runs before baseline_tput > 0).
+
+        Args:
+            target_agent: The request's target agent; only ``"kernel"`` is
+                gated.
+            kind: The kernel request kind; ``trace_analyze`` and unknown kinds
+                are exempt.
+
+        Returns:
+            A :class:`PolicyDenied` when the kernel request must wait for
+            baseline, else ``None``.
+        """
         target = str(target_agent or "").strip()
         req_kind = str(kind or "").strip()
         if target != "kernel" or self.shared_state.stop_reason:
@@ -5707,7 +6236,15 @@ class Coordinator:
         self.state.pending_proposals[msg.msg_id] = pending
 
     def _resolve_issue_canonical(self, pending: PendingProposal) -> str:
-        """Find the issue_node canonical_id this proposal addresses. Priority: payload gap_canonical_id → params gap_canonical_id → _gap_anchor_canonical_id (Gap-09)."""
+        """Find the issue_node canonical_id this proposal addresses. Priority: payload gap_canonical_id → params gap_canonical_id → _gap_anchor_canonical_id (Gap-09).
+
+        Args:
+            pending: The pending proposal whose payload/params are searched for
+                a gap canonical id.
+
+        Returns:
+            The resolved gap canonical id, falling back to the workload anchor.
+        """
         payload = pending.payload or {}
         explicit_top = str(payload.get("gap_canonical_id") or "").strip()
         if explicit_top:
@@ -5720,7 +6257,12 @@ class Coordinator:
         return self._gap_anchor_canonical_id()
 
     def _workload_canonical_id(self) -> str:
-        """Canonical 5-tuple recipe id for the current workload. MUST match cortex_t0.run_t0_anchor's derivation so warm-start and KEEP/REVERT/CLOSE writes target the same row."""
+        """Canonical 5-tuple recipe id for the current workload. MUST match cortex_t0.run_t0_anchor's derivation so warm-start and KEEP/REVERT/CLOSE writes target the same row.
+
+        Returns:
+            The canonical recipe id derived from model, hardware, framework,
+            framework version and precision.
+        """
         ss = self.shared_state
         workload = ss.model_name or "unknown_model"
         hw = ss.gpu_type or "unknown_gpu"
@@ -5738,7 +6280,11 @@ class Coordinator:
         )
 
     def _gap_anchor_canonical_id(self) -> str:
-        """M1 gap anchor: delegates to _workload_canonical_id so anchor and write target never diverge."""
+        """M1 gap anchor: delegates to _workload_canonical_id so anchor and write target never diverge.
+
+        Returns:
+            The workload canonical recipe id used as the gap anchor.
+        """
         return self._workload_canonical_id()
 
     def _kb_amend_recipe(
@@ -5749,7 +6295,16 @@ class Coordinator:
         recipe_overrides: dict[str, Any] | None = None,
         provenance_details: dict[str, Any] | None = None,
     ) -> None:
-        """Read-modify-write helper for the v2 recipe-snapshot KB: load live row, append lesson/pitfall, merge recipe_overrides (unset fields preserved), write back. Best-effort; lesson/pitfall appended without dedup (commit 4d)."""
+        """Read-modify-write helper for the v2 recipe-snapshot KB: load live row, append lesson/pitfall, merge recipe_overrides (unset fields preserved), write back. Best-effort; lesson/pitfall appended without dedup (commit 4d).
+
+        Args:
+            append_lesson: Optional lesson dict appended to the recipe.
+            append_pitfall: Optional pitfall dict appended to the recipe.
+            recipe_overrides: Optional recipe field overrides merged in (unset
+                fields preserved).
+            provenance_details: Optional provenance metadata recorded with the
+                amendment.
+        """
         if self.cortex_kb is None:
             return
         try:
@@ -5870,7 +6425,13 @@ class Coordinator:
             )
 
     async def _handle_review_verdict(self, source: str, intent: Intent) -> None:
-        """Apply a Critic ``review_verdict`` to its target proposal; legacy verdict_map collapsed (approve > reject > needs_review)."""
+        """Apply a Critic ``review_verdict`` to its target proposal; legacy verdict_map collapsed (approve > reject > needs_review).
+
+        Args:
+            source: The agent (Critic) emitting the verdict.
+            intent: The REVIEW_VERDICT intent; payload carries
+                ``target_proposal_msg_id`` and ``verdict``/``verdict_map``.
+        """
         target = intent.payload["target_proposal_msg_id"]
         pending = self.state.pending_proposals.get(target)
         verdict_map = intent.payload.get("verdict_map")
@@ -5912,7 +6473,14 @@ class Coordinator:
         verdict: str,
         reasoning: str,
     ) -> None:
-        """Legacy v0.6 single-verdict handler (approve materialises proposal as-is); mirrors integrate_patch/specialist verdicts onto specialist_patch_verdicts for PolicyGate."""
+        """Legacy v0.6 single-verdict handler (approve materialises proposal as-is); mirrors integrate_patch/specialist verdicts onto specialist_patch_verdicts for PolicyGate.
+
+        Args:
+            source: The agent emitting the verdict.
+            pending: The pending proposal the verdict targets.
+            verdict: The collapsed verdict (approve / reject / needs_review).
+            reasoning: Free-text reasoning recorded with the verdict.
+        """
         pending.decided = True
         pending.verdict = verdict
         await self.bus.append_and_seq(Message.new(
@@ -5954,7 +6522,12 @@ class Coordinator:
             await self._materialize_approved_proposal(pending)
 
     def _inject_explore_runtime_params(self, params: dict) -> None:
-        """Inject explore-task operational knobs from SharedState into ``params`` (single source of truth for both propose/Critic and direct-delegate paths). setdefault preserves LLM overrides. Knobs: baseline_runtime_sec + explore_overtime_kill_ratio (Fix E soft_deadline), variant_timeout_sec, variant_timeout_safety_margin, roofline_saturation_snapshot (advisory)."""
+        """Inject explore-task operational knobs from SharedState into ``params`` (single source of truth for both propose/Critic and direct-delegate paths). setdefault preserves LLM overrides. Knobs: baseline_runtime_sec + explore_overtime_kill_ratio (Fix E soft_deadline), variant_timeout_sec, variant_timeout_safety_margin, roofline_saturation_snapshot (advisory).
+
+        Args:
+            params: The explore-task params dict mutated in place; existing keys
+                are preserved (``setdefault``).
+        """
         br = float(getattr(self.shared_state, "baseline_runtime_sec", 0.0) or 0.0)
         if br > 0:
             params.setdefault("baseline_runtime_sec", br)
@@ -5998,6 +6571,10 @@ class Coordinator:
         curve as macro-cycles accrue. Returns ``None`` off cyclic mode so short /
         non-cyclic runs fall back to the executor's fixed default (no regression);
         first cycle (N=1) reproduces that same default value anyway.
+
+        Returns:
+            The decayed per-cycle KEEP threshold percentage, or ``None`` off
+            cyclic mode (keep executor defaults).
         """
         if not _phase_state.is_cyclic_phases_enabled():
             return None
@@ -6013,7 +6590,13 @@ class Coordinator:
         *,
         approved_variant_names: set[str] | None = None,
     ) -> None:
-        """Promote an approved proposal into a TaskRegistry entry. Grid executors get current best tput as base_tput (DESIGN §16); approved_variant_names filters the explore grid (None keeps full)."""
+        """Promote an approved proposal into a TaskRegistry entry. Grid executors get current best tput as base_tput (DESIGN §16); approved_variant_names filters the explore grid (None keeps full).
+
+        Args:
+            pending: The approved proposal to materialise into a task.
+            approved_variant_names: When set, restricts an explore grid to these
+                Critic-approved variant names; ``None`` keeps the full grid.
+        """
         params = dict(pending.payload.get("params") or {})
         # Filter the grid to the Critic-approved subset.
         if (
@@ -6264,7 +6847,14 @@ class Coordinator:
     def _record_framework_pr_authored_outcome(
         self, *, task: "Task", result: Any,
     ) -> None:
-        """Bridge an authored-patch ``integrate_patch`` outcome into the FRAMEWORK_PR progress ledger (else the gain is invisible). Attributed to the latest batch; only kept/reverted rows."""
+        """Bridge an authored-patch ``integrate_patch`` outcome into the FRAMEWORK_PR progress ledger (else the gain is invisible). Attributed to the latest batch; only kept/reverted rows.
+
+        Args:
+            task: The integrate_patch task carrying the FRAMEWORK_PR authoring
+                provenance markers.
+            result: The task result; only ``kept``/``reverted`` statuses are
+                recorded.
+        """
         res = getattr(result, "result", None)
         if not isinstance(res, dict):
             return
@@ -6334,7 +6924,13 @@ class Coordinator:
         normal ``_handle_delegate`` path (warm + idempotency + TaskRegistry +
         lease + reap), preserving the low-cost wide-net recon the retired
         dynamic_specialist channel provided. Per-task idempotency keys derive
-        from the wave key; non-dict / empty-description entries are skipped."""
+        from the wave key; non-dict / empty-description entries are skipped.
+
+        Args:
+            source: The agent issuing the wave delegate.
+            intent: The originating specialist DELEGATE intent.
+            params: The delegate params carrying the ``tasks`` list to fan out.
+        """
         tasks = params.get("tasks") or []
         shared = {k: v for k, v in params.items() if k != "tasks"}
         base_key = str(intent.payload.get("idempotency_key") or "").strip()
@@ -6383,7 +6979,17 @@ class Coordinator:
         (timeout / crash / stale-heartbeat, per ``classify_specialist_failure``)
         are retried, capped at :data:`SPECIALIST_AUTO_RETRY_MAX`; the failure
         reason is injected into the retry prompt. Disabled when
-        ``INFERENCE_OPTIMIZER_SPECIALIST_AUTO_RETRY`` is set to ``0``."""
+        ``INFERENCE_OPTIMIZER_SPECIALIST_AUTO_RETRY`` is set to ``0``.
+
+        Args:
+            task: The specialist task whose attempt just failed.
+            result: The sub-agent result classified for infra-failure
+                eligibility.
+
+        Returns:
+            ``True`` when a retry was scheduled (caller must skip this
+            attempt's bookkeeping); ``False`` otherwise.
+        """
         flag = os.environ.get(
             "INFERENCE_OPTIMIZER_SPECIALIST_AUTO_RETRY", "1",
         ).strip().lower()
@@ -6464,7 +7070,12 @@ class Coordinator:
 
     # specialist pre-dispatch warmup
     async def _warm_specialist_params(self, params: dict[str, Any]) -> None:
-        """Fill specialist task params with KnowledgePlane data before enqueue (mutates in place); all best-effort, missing fields stay empty."""
+        """Fill specialist task params with KnowledgePlane data before enqueue (mutates in place); all best-effort, missing fields stay empty.
+
+        Args:
+            params: The specialist task params dict mutated in place with PR
+                feed, warm-start, hardware/workload and gap/roofline context.
+        """
         state = self.shared_state
         plane = self.knowledge_plane
 
@@ -6661,7 +7272,15 @@ class Coordinator:
 
     @staticmethod
     def _pr_summary_to_dict(pr: Any) -> dict[str, Any]:
-        """Flatten a PRSummary into the dict SpecialistPromptBuilder expects."""
+        """Flatten a PRSummary into the dict SpecialistPromptBuilder expects.
+
+        Args:
+            pr: A PRSummary-like object exposing repo/number/title/url/state/
+                labels/author attributes.
+
+        Returns:
+            A flat dict of the PR's summary fields.
+        """
         return {
             "repo":   str(getattr(pr, "repo", "")),
             "number": int(getattr(pr, "number", 0) or 0),
@@ -6674,7 +7293,11 @@ class Coordinator:
 
     # gaps[] ledger refresh
     async def _refresh_gaps(self, *, reason: str) -> None:
-        """Refresh :attr:`SharedState.gaps` from observable signals (Coordinator is sole writer, Inv-1). Additive upsert deduped by canonical_id; best-effort."""
+        """Refresh :attr:`SharedState.gaps` from observable signals (Coordinator is sole writer, Inv-1). Additive upsert deduped by canonical_id; best-effort.
+
+        Args:
+            reason: Tag describing the refresh trigger, used only in logging.
+        """
         state = self.shared_state
         try:
             for entry in self._extract_gaps_from_baseline():
@@ -6713,7 +7336,12 @@ class Coordinator:
         )
 
     def _extract_gaps_from_baseline(self) -> list[dict[str, Any]]:
-        """Derive initial gap rows from the baseline snapshot (throughput_below_target, baseline_unstable); reuse the M1 anchor canonical_id so traverse rows align."""
+        """Derive initial gap rows from the baseline snapshot (throughput_below_target, baseline_unstable); reuse the M1 anchor canonical_id so traverse rows align.
+
+        Returns:
+            A list of gap row dicts derived from the baseline; empty when no
+            baseline throughput is recorded.
+        """
         state = self.shared_state
         gaps: list[dict[str, Any]] = []
         if state.baseline_tput <= 0:
@@ -6754,7 +7382,12 @@ class Coordinator:
         return gaps
 
     def _extract_gaps_from_attempts(self) -> list[dict[str, Any]]:
-        """Derive gaps from rolling failures + winners history (recurring (action, error_class) + explore plateau)."""
+        """Derive gaps from rolling failures + winners history (recurring (action, error_class) + explore plateau).
+
+        Returns:
+            A list of gap row dicts derived from recurring action failures and
+            an explore-plateau signal.
+        """
         state = self.shared_state
         anchor = self._gap_anchor_canonical_id()
         gaps: list[dict[str, Any]] = []
@@ -6814,7 +7447,14 @@ class Coordinator:
 
     @staticmethod
     def _gap_layer_for_action(action: str) -> tuple[str, str]:
-        """Map an action name → (layer, domain_hint) for gap rows (fallback ("framework", "serving_specialist"))."""
+        """Map an action name → (layer, domain_hint) for gap rows (fallback ("framework", "serving_specialist")).
+
+        Args:
+            action: The action name to classify.
+
+        Returns:
+            A ``(layer, domain_hint)`` tuple for the action.
+        """
         a = str(action or "").strip().lower()
         if a in {"kernel_opt", "integrate", "trace_analyze", "run_gemm_tuning", "run_optimization"}:
             return ("kernel", "kernel_switch_specialist")
@@ -6829,7 +7469,14 @@ class Coordinator:
     def _record_explore_round_gaps(
         self, *, task: "Task | None", result: dict[str, Any],
     ) -> None:
-        """Append per-variant KEEP/REVERT outcomes to the matching gap (or the anchor gap as fallback)."""
+        """Append per-variant KEEP/REVERT outcomes to the matching gap (or the anchor gap as fallback).
+
+        Args:
+            task: The explore task whose params carry the gap canonical id;
+                ``None`` is a no-op.
+            result: The explore result; its ``per_variant_outcomes`` drive the
+                appended gap attempts.
+        """
         if task is None:
             return
         per_variant = result.get("per_variant_outcomes")
@@ -6865,7 +7512,12 @@ class Coordinator:
     async def _handle_specialist_done(
         self, source: str, intent: Intent,
     ) -> None:
-        """Handle a ``specialist_done`` intent (source ``specialist:<task_id>`` per Inv-5.3 / R3); bookkeeping in _record_specialist_result."""
+        """Handle a ``specialist_done`` intent (source ``specialist:<task_id>`` per Inv-5.3 / R3); bookkeeping in _record_specialist_result.
+
+        Args:
+            source: The emitting agent, expected as ``specialist:<task_id>``.
+            intent: The SPECIALIST_DONE intent carrying the done payload.
+        """
         payload = dict(intent.payload or {})
         task_id = self._task_id_from_specialist_source(source)
         task: Task | None = None
@@ -6889,7 +7541,14 @@ class Coordinator:
 
     @staticmethod
     def _task_id_from_specialist_source(source: str) -> str:
-        """Extract the task_id from a ``specialist:<task_id>`` source ("" when prefix is absent)."""
+        """Extract the task_id from a ``specialist:<task_id>`` source ("" when prefix is absent).
+
+        Args:
+            source: The from-agent string to parse.
+
+        Returns:
+            The task id when the specialist prefix is present, else ``""``.
+        """
         if not source:
             return ""
         if source.startswith(SPECIALIST_FROM_AGENT_PREFIX):
@@ -6933,6 +7592,13 @@ class Coordinator:
         on the same content collapses to the same row (no double-bench),
         and its per-variant KEEP/REVERT gain gate is the safety net
         (no critic dependency).
+
+        Args:
+            task: The completed specialist task whose id seeds the explore
+                idempotency key.
+            domain: The specialist domain, stamped onto variant provenance.
+            proposals: The specialist ``proposal_set`` entries materialised into
+                the explore grid (capped at ``_MN_AUTO_EXPLORE_GRID_CAP``).
         """
         from .action_executors._multi_node_env import is_multi_node
         if not is_multi_node() or not proposals:
@@ -7010,7 +7676,14 @@ class Coordinator:
         done_payload: dict[str, Any],
         source: str,
     ) -> None:
-        """Common bookkeeping for any specialist task termination (dispatcher loop + intent routing); idempotent on round_id, failures logged not raised."""
+        """Common bookkeeping for any specialist task termination (dispatcher loop + intent routing); idempotent on round_id, failures logged not raised.
+
+        Args:
+            task: The terminated specialist task.
+            done_payload: The specialist's done payload (proposal_set, domain,
+                summary, etc.).
+            source: The emitting agent string (``specialist:<task_id>``).
+        """
         domain = str(done_payload.get("domain") or "").strip()
         proposals = done_payload.get("proposal_set") or []
         if not isinstance(proposals, list):
@@ -7197,6 +7870,10 @@ class Coordinator:
         mode (default) it deterministically advances EXPLORE → KERNEL via
         ``explore_no_more_leverage`` (a non-terminal lever switch); the rendered
         footer states which regime is active.
+
+        Returns:
+            The rendered plateau advisory text, or ``""`` when no plateau
+            signal is active for the current phase.
         """
         state = self.shared_state
         phase = (getattr(state, "phase", "") or "").strip().upper()
@@ -7307,7 +7984,12 @@ class Coordinator:
 
     def _dominant_roofline_direction(self) -> tuple[str, float]:
         """Return ``(direction, pct)`` for the most-saturated roofline direction
-        in the latest snapshot; ``("", 0.0)`` when no snapshot is available."""
+        in the latest snapshot; ``("", 0.0)`` when no snapshot is available.
+
+        Returns:
+            A ``(direction, pct)`` tuple for the dominant roofline direction, or
+            ``("", 0.0)`` when no snapshot exists.
+        """
         from .roofline_snapshot import dominant_direction
         snaps = getattr(self.shared_state, "roofline_snapshots", None) or []
         if not snaps or not isinstance(snaps[-1], dict):
@@ -7321,6 +8003,10 @@ class Coordinator:
         ``pending_bottleneck_switch``. Names the bottleneck we plateaued on, the
         current dominant roofline direction, and a suggested specialist domain so
         Orchestration redirects the new cycle's dispatch. Advisory, never gates.
+
+        Returns:
+            The rendered bottleneck-redirect advisory text, or ``""`` when not
+            applicable.
         """
         state = self.shared_state
         if not _phase_state.is_cyclic_phases_enabled():
@@ -7370,6 +8056,10 @@ class Coordinator:
         stack-stable thresholds and lists prior sub-threshold variants whose
         measured gain now meets the decayed bar (unblocked for re-test) plus a
         few still below it (reference only). Advisory; never gates dispatch.
+
+        Returns:
+            The rendered acceptance-threshold advisory text, or ``""`` when not
+            applicable (non-cyclic mode or first cycle).
         """
         state = self.shared_state
         keep = self._decaying_keep_threshold_pct()
@@ -7422,7 +8112,12 @@ class Coordinator:
         return "\n".join(lines)
 
     def _target_gap_advisory_block(self) -> str:
-        """Build the advisory "External target gap" prompt block (current-best vs competitor target; never gates)."""
+        """Build the advisory "External target gap" prompt block (current-best vs competitor target; never gates).
+
+        Returns:
+            The rendered external-target-gap advisory text, or ``""`` when
+            disabled or no competitor target/current-best is available.
+        """
         state = self.shared_state
         if not bool(getattr(state, "target_advisory_enabled", True)):
             return ""
@@ -7453,7 +8148,12 @@ class Coordinator:
         return _research_hints.full_gap_summary(gap)
 
     def _current_primary_gap(self) -> str | None:
-        """Resolve the dominant external gap direction ('latency'/'throughput') from the competitor target, or None when advisory is off / no target. Fail-soft."""
+        """Resolve the dominant external gap direction ('latency'/'throughput') from the competitor target, or None when advisory is off / no target. Fail-soft.
+
+        Returns:
+            The primary gap direction string, or ``None`` when the advisory is
+            off, no target exists, or analysis fails.
+        """
         state = self.shared_state
         if not bool(getattr(state, "target_advisory_enabled", True)):
             return None
@@ -7494,7 +8194,15 @@ class Coordinator:
     def _recent_proposed_variants(
         self, *, max_rounds: int = 2,
     ) -> list[dict[str, Any]]:
-        """Collect proposal_set rows from the most recent specialist rounds (deduped by name; fail-soft)."""
+        """Collect proposal_set rows from the most recent specialist rounds (deduped by name; fail-soft).
+
+        Args:
+            max_rounds: Number of most-recent specialist rounds to scan
+                (default 2).
+
+        Returns:
+            A name-deduped list of proposal variant dicts.
+        """
         rounds = [
             r for r in (getattr(self.shared_state, "specialist_rounds", []) or [])
             if isinstance(r, dict) and isinstance(r.get("proposal_set"), list)
@@ -7512,7 +8220,12 @@ class Coordinator:
         return out
 
     def _priors_match_advisory_block(self) -> str:
-        """Flag recently proposed variants aligning with proven priors / dominant external gap (advisory ordering, fail-soft)."""
+        """Flag recently proposed variants aligning with proven priors / dominant external gap (advisory ordering, fail-soft).
+
+        Returns:
+            The rendered priors-match advisory text, or ``""`` when there are no
+            recent variants or rendering fails.
+        """
         try:
             from . import research_hints as _research_hints
 
@@ -7530,7 +8243,14 @@ class Coordinator:
     async def _maybe_autosubmit_specialist_patches(
         self, *, task: "Task", done_payload: dict[str, Any],
     ) -> None:
-        """B3: auto-surface a specialist's source patches to the Critic via a synthetic integrate_patch proposal; idempotent per specialist."""
+        """B3: auto-surface a specialist's source patches to the Critic via a synthetic integrate_patch proposal; idempotent per specialist.
+
+        Args:
+            task: The completed specialist task whose worktree patches are
+                surfaced.
+            done_payload: The specialist done payload carrying
+                ``patches_written`` and proposal metadata.
+        """
         patches = done_payload.get("patches_written") or []
         if not isinstance(patches, list) or not patches:
             return
@@ -7629,7 +8349,18 @@ class Coordinator:
         done_payload: dict[str, Any],
         source: str,
     ) -> dict[str, Any]:
-        """Translate a specialist done payload into a SharedState.specialist_rounds[] row; round_id defaults to task_id for idempotent overwrite (M5)."""
+        """Translate a specialist done payload into a SharedState.specialist_rounds[] row; round_id defaults to task_id for idempotent overwrite (M5).
+
+        Args:
+            task: The completed specialist task.
+            done_payload: The specialist done payload (proposal_set, domain,
+                tags, summary, etc.).
+            source: The emitting agent string, recorded on the row.
+
+        Returns:
+            A specialist-round row dict suitable for
+            ``SharedState.record_specialist_round``.
+        """
         proposals = done_payload.get("proposal_set") or []
         if not isinstance(proposals, list):
             proposals = []
@@ -7689,6 +8420,13 @@ class Coordinator:
 
         Best-effort by design: operator-facing logging must never break the
         orchestration loop, so any failure is swallowed at debug level.
+
+        Args:
+            step: The machine step name (resolved to a human label downstream).
+            status: The lifecycle status (e.g. START / END / ERROR / ENTER).
+            artifacts: Optional mapping of produced artifact paths.
+            detail: Optional free-text detail.
+            duration_s: Optional elapsed seconds for the step.
         """
         try:
             self.shared_state.record_lifecycle_event(
@@ -7952,7 +8690,16 @@ class Coordinator:
                 )
 
     def _cached_kernel_request(self, kind: str, payload: dict[str, Any]) -> dict[str, Any] | None:
-        """Return a cached programmatic_handler result if applicable (cache key last_trace_analyze)."""
+        """Return a cached programmatic_handler result if applicable (cache key last_trace_analyze).
+
+        Args:
+            kind: The kernel request kind; only ``trace_analyze`` is cacheable.
+            payload: The merged request payload; its ``trace_input`` /
+                ``trace_dir`` must match the cached entry for a hit.
+
+        Returns:
+            A synthesized cached result dict on a cache hit, else ``None``.
+        """
         if kind != "trace_analyze":
             return None
         cached = self.shared_state.last_trace_analyze or {}
@@ -8066,7 +8813,13 @@ class Coordinator:
         ))
 
     async def _handle_escalate_strategy_change(self, source: str, intent: Intent) -> None:
-        """Process ``escalate_strategy_change`` (KB_design §3.8 §7.3 + §3.13 M7 §5.3); broadcasts strategy_change, acts on closed-vocab hints, drops unknown (Inv-8.2)."""
+        """Process ``escalate_strategy_change`` (KB_design §3.8 §7.3 + §3.13 M7 §5.3); broadcasts strategy_change, acts on closed-vocab hints, drops unknown (Inv-8.2).
+
+        Args:
+            source: The agent issuing the escalation.
+            intent: The ESCALATE_STRATEGY_CHANGE intent; ``payload`` may carry a
+                closed-vocab ``next_action_hint``.
+        """
         payload = dict(intent.payload or {})
         # Always emit the broadcast first (back-compat with legacy contract tests).
         await self.bus.append_and_seq(Message.new(
@@ -8307,7 +9060,11 @@ class Coordinator:
             self._auto_integrate_dispatched.add(kid)
 
     def _record_kernel_opt_partial(self, result: dict[str, Any]) -> None:
-        """Streaming callback for ``_run_optimization_batch`` sub-attempts: write each per-kernel entry to kernel_opt_attempts immediately so the next-tick prompt is accurate mid-batch."""
+        """Streaming callback for ``_run_optimization_batch`` sub-attempts: write each per-kernel entry to kernel_opt_attempts immediately so the next-tick prompt is accurate mid-batch.
+
+        Args:
+            result: One sub-attempt's per-kernel result dict.
+        """
         try:
             self.shared_state.record_kernel_opt(result)
             self.shared_state.save(self.session_dir)
@@ -8456,7 +9213,12 @@ class Coordinator:
     def _record_intervention_for_task(
         self, task: "Task", result: Any,
     ) -> None:
-        """PR-A8: log a completed task's change_type into SharedState.intervention_mix (explore → config; integrate_patch → code_patch_attempt or code_patch when kept). Best-effort."""
+        """PR-A8: log a completed task's change_type into SharedState.intervention_mix (explore → config; integrate_patch → code_patch_attempt or code_patch when kept). Best-effort.
+
+        Args:
+            task: The completed task whose kind selects the intervention class.
+            result: The task result dict; non-dict results are ignored.
+        """
         if not isinstance(result, dict):
             return
         kind = (task.kind or "").strip()
@@ -8505,7 +9267,13 @@ class Coordinator:
     async def _handle_unpromotable_result(
         self, task: Task, result: dict[str, Any] | None,
     ) -> None:
-        """Record a failed / unpromotable task result into SharedState: append to last_action_failures (+ a failed attempts row for _AUDIT_ACTIONS); keep baseline failure_streak/stop_reason logic intact."""
+        """Record a failed / unpromotable task result into SharedState: append to last_action_failures (+ a failed attempts row for _AUDIT_ACTIONS); keep baseline failure_streak/stop_reason logic intact.
+
+        Args:
+            task: The failed/unpromotable task.
+            result: The task result payload; ``None`` is treated as an empty
+                result.
+        """
         result_payload = result or {}
         any_changed = False
         # Per-action audit (failed attempt) for the 6 in-scope kinds.
@@ -8660,6 +9428,14 @@ class Coordinator:
         (possibly empty). Pure dispatch — per-task completion bookkeeping is
         handled by :meth:`_reap_dispatched_task`. Mirrors the prior capacity /
         GPU-specialist-lease logic exactly. Inv-7.3: lease bound to task_id.
+
+        Args:
+            exclude_ids: Task ids already dispatched this pump pass; skipped so
+                a task is never dispatched twice.
+
+        Returns:
+            The ``(task, asyncio_task, gpu_lease)`` tuples spawned this pass
+            (possibly empty).
         """
         queued = await self.tasks.queued()
         if not queued:
@@ -8773,6 +9549,11 @@ class Coordinator:
         shared-state promotion, fact-write, explore-gap refresh). The
         single-element loop preserves the original body unchanged — ``continue``
         acts as an early return for this task.
+
+        Args:
+            task: The finished dispatched task.
+            maybe_result: The task's result, or the exception it raised.
+            gpu_lease: The GPU specialist lease to release, or ``None``.
         """
         for (task, _, gpu_lease), maybe_result in zip(
             [(task, None, gpu_lease)], [maybe_result],
@@ -8942,7 +9723,17 @@ class Coordinator:
         holders: dict[str, int],
         capacities: dict[str, int],
     ) -> bool:
-        """Local-view headroom hint for the concurrent dispatcher (authoritative gate is try_acquire_many)."""
+        """Local-view headroom hint for the concurrent dispatcher (authoritative gate is try_acquire_many).
+
+        Args:
+            expanded_lanes: The fully-expanded lanes the task requires.
+            holders: Current per-lane holder counts (local view).
+            capacities: Per-lane capacities.
+
+        Returns:
+            ``True`` when every requested lane has local headroom, else
+            ``False``.
+        """
         for lane in expanded_lanes:
             cap = int(capacities.get(lane, 1))
             used = int(holders.get(lane, 0))
@@ -8955,6 +9746,10 @@ class Coordinator:
         """Return the hyperloom-local session id used as source_session_id on KB fact writes.
 
         NOT a KB-side session id; prefers cortex_session_id, falls back to session_dir.name.
+
+        Returns:
+            The hyperloom-local session id (cortex_session_id when set, else
+            ``session_dir.name``).
         """
         return (
             str(getattr(self.shared_state, "cortex_session_id", "") or "")
@@ -8968,7 +9763,13 @@ class Coordinator:
         result: Any,
         kept: bool,
     ) -> None:
-        """Per-task fact-write entry point (per_variant for explore grids, else per-task); best-effort, never raises."""
+        """Per-task fact-write entry point (per_variant for explore grids, else per-task); best-effort, never raises.
+
+        Args:
+            task: The completed task being recorded.
+            result: The task's :class:`SubAgentResult` (or result dict).
+            kept: Whether the task's result was KEEP-promoted.
+        """
         result_dict = result.result if hasattr(result, "result") else (result or {})
         if not isinstance(result_dict, dict):
             result_dict = {}
@@ -9011,7 +9812,12 @@ class Coordinator:
     # Fact-write surface — journal + direct KB lesson/pitfall/recipe writes (the fact side of KB integration).
     PITFALL_REGRESS_THRESHOLD_PCT: float = -5.0  # gain_pct ≤ this → pitfall
     def _ensure_journal(self) -> Journal:
-        """Lazy-instantiate the per-session :class:`Journal` (load_or_create reads an existing file on resume)."""
+        """Lazy-instantiate the per-session :class:`Journal` (load_or_create reads an existing file on resume).
+
+        Returns:
+            The per-session :class:`Journal` instance (created on first call,
+            with the baseline backfilled on subsequent calls).
+        """
         existing = getattr(self, "_journal", None)
         if existing is None:
             ss = self.shared_state
@@ -9035,7 +9841,15 @@ class Coordinator:
     def _pitfall_severity_for(
         self, result_dict: dict[str, Any] | None,
     ) -> str | None:
-        """Decide whether a failed result warrants a pitfall row (Threshold-B): crash/oom/hang → SEVERITY_CRASH; gain_pct ≤ -5% → SEVERITY_REGRESS; else None."""
+        """Decide whether a failed result warrants a pitfall row (Threshold-B): crash/oom/hang → SEVERITY_CRASH; gain_pct ≤ -5% → SEVERITY_REGRESS; else None.
+
+        Args:
+            result_dict: The failed task's result dict; non-dict yields ``None``.
+
+        Returns:
+            The pitfall severity (``SEVERITY_CRASH`` / ``SEVERITY_REGRESS``), or
+            ``None`` when no pitfall is warranted.
+        """
         if not isinstance(result_dict, dict):
             return None
         error_class = str(result_dict.get("error_class") or "").lower()
@@ -9069,7 +9883,16 @@ class Coordinator:
         result_dict: dict[str, Any],
         kept: bool,
     ) -> None:
-        """Per-task fact write — one journal row + maybe one KB fact (source_session_id is hyperloom-local)."""
+        """Per-task fact write — one journal row + maybe one KB fact (source_session_id is hyperloom-local).
+
+        Args:
+            task: The completed task being recorded.
+            source_session_id: The hyperloom-local session id stamped on the
+                fact provenance.
+            result_dict: The task result dict.
+            kept: Whether the result was KEEP-promoted (KEEP → lesson, else
+                pitfall/REVERT).
+        """
         journal = self._ensure_journal()
         gain_raw = result_dict.get("gain_pct")
         try:
@@ -9173,7 +9996,19 @@ class Coordinator:
         gain_pct: float | None = None,  # kept for backward call-signature compat
         severity: str | None = None,
     ) -> str:
-        """Build the lesson statement / pitfall description hashed into the KB canonical_id; MUST exclude volatile fields (e.g. gain_pct) so N sessions merge instead of producing N rows. Identity = framework + change + model/hw."""
+        """Build the lesson statement / pitfall description hashed into the KB canonical_id; MUST exclude volatile fields (e.g. gain_pct) so N sessions merge instead of producing N rows. Identity = framework + change + model/hw.
+
+        Args:
+            change: The summarized change description.
+            kind: ``"lesson"`` or ``"pitfall"`` — selects the rendered form.
+            gain_pct: Kept for backward call-signature compat; intentionally not
+                included in the statement.
+            severity: The pitfall severity, rendered only when ``kind`` is
+                ``"pitfall"``.
+
+        Returns:
+            The identity-stable statement / description string.
+        """
         framework = str(getattr(self.shared_state, "framework", "") or "").strip()
         fw_tag = f"[{framework or '?'}] "
         model = self.shared_state.model_name or "?"
@@ -9193,7 +10028,18 @@ class Coordinator:
         measured_at: str,
         throughput_before: float | None = None,
     ) -> dict[str, Any]:
-        """GAP 3 — structured ``measured_impact`` payload (dict not legacy string so consumers parse without regex); stack_depth = stack length before this lesson lands."""
+        """GAP 3 — structured ``measured_impact`` payload (dict not legacy string so consumers parse without regex); stack_depth = stack length before this lesson lands.
+
+        Args:
+            gain_pct: The measured gain percent, or ``None``.
+            throughput_after: Throughput after the change, or ``None``.
+            stack_depth: Optimization-stack length before this lesson lands.
+            measured_at: ISO timestamp of the measurement.
+            throughput_before: Throughput before the change, or ``None``.
+
+        Returns:
+            A compact ``measured_impact`` dict with ``None`` fields stripped.
+        """
         out: dict[str, Any] = {
             "gain_pct": float(gain_pct) if gain_pct is not None else None,
             "stack_depth_at_apply": int(stack_depth),
@@ -9213,7 +10059,15 @@ class Coordinator:
         source_session_id: str,
         variant_outcome: dict[str, Any],
     ) -> None:
-        """Per-variant fact write — mirror of _record_fact_per_task for explore per-variant decisions."""
+        """Per-variant fact write — mirror of _record_fact_per_task for explore per-variant decisions.
+
+        Args:
+            task: The completed explore task.
+            source_session_id: The hyperloom-local session id stamped on the
+                fact provenance.
+            variant_outcome: One per-variant outcome row (name, outcome,
+                metrics).
+        """
         journal = self._ensure_journal()
         outcome_raw = str(variant_outcome.get("outcome") or "")
         if outcome_raw == "KEEP":
@@ -9355,7 +10209,13 @@ class Coordinator:
             )
 
     def _collect_workload_tags(self) -> dict[str, Any]:
-        """Return the workload-shape KB tag dict for the current session (GAP 5); shared by recipe attrs + lesson/pitfall writes so the warm-start reader filters symmetrically."""
+        """Return the workload-shape KB tag dict for the current session (GAP 5); shared by recipe attrs + lesson/pitfall writes so the warm-start reader filters symmetrically.
+
+        Returns:
+            A dict of workload-shape KB tags (framework, model, parallelism,
+            runtime versions, baseline workload extras) with empty values
+            omitted.
+        """
         ss = self.shared_state
         out: dict[str, Any] = {}
         framework = str(getattr(ss, "framework", "") or "").strip()
@@ -9432,7 +10292,12 @@ class Coordinator:
         return out
 
     def _build_kernel_optimizations_from_state(self) -> list[dict[str, Any]]:
-        """Collect KEEP'd kernel optimizations + their E2E verdict by joining kernel_opt_attempts (micro) and kernel_integrate_attempts (E2E) on kernel_id; non-integrated KEEPs surface integrated=False. Returns KernelOptimization-shaped dicts."""
+        """Collect KEEP'd kernel optimizations + their E2E verdict by joining kernel_opt_attempts (micro) and kernel_integrate_attempts (E2E) on kernel_id; non-integrated KEEPs surface integrated=False. Returns KernelOptimization-shaped dicts.
+
+        Returns:
+            A list of KernelOptimization-shaped dicts for each KEEP'd kernel,
+            joined with its E2E integrate verdict where available.
+        """
         ss = self.shared_state
         opt_attempts = getattr(ss, "kernel_opt_attempts", {}) or {}
         integ_attempts = getattr(ss, "kernel_integrate_attempts", {}) or {}
@@ -9500,7 +10365,13 @@ class Coordinator:
     def _collect_attempt_provenance(
         self,
     ) -> tuple[dict[str, str], dict[str, str], list[dict[str, Any]]]:
-        """Map proven optimizations to their research-hint origin from the gaps[] attempts ledger; returns (kept_sources by name/kernel, kept_by_gap by canonical_id, reverted_rows). Fail-soft."""
+        """Map proven optimizations to their research-hint origin from the gaps[] attempts ledger; returns (kept_sources by name/kernel, kept_by_gap by canonical_id, reverted_rows). Fail-soft.
+
+        Returns:
+            A ``(kept_sources, kept_by_gap, reverted_rows)`` tuple: KEEP'd
+            provenance keyed by variant/kernel name, KEEP'd provenance keyed by
+            gap canonical_id, and reverted-attempt rows.
+        """
         kept_sources: dict[str, str] = {}
         kept_by_gap: dict[str, str] = {}
         reverted_rows: list[dict[str, Any]] = []
@@ -9535,7 +10406,13 @@ class Coordinator:
         return kept_sources, kept_by_gap, reverted_rows
 
     def _build_recipe_attrs_from_state(self) -> dict[str, Any]:
-        """Materialise the recipe-shaped view of :class:`SharedState` (kg-usage-guide §7.4; defensive getattr)."""
+        """Materialise the recipe-shaped view of :class:`SharedState` (kg-usage-guide §7.4; defensive getattr).
+
+        Returns:
+            A recipe-shaped attrs dict (best_config, what_worked, what_failed,
+            kernel_optimizations, workload tags, session row) for KB recipe
+            writes.
+        """
         ss = self.shared_state
         current_best = getattr(ss, "current_best", {}) or {}
         opt_stack = getattr(ss, "optimization_stack", []) or []
@@ -9797,7 +10674,16 @@ class Coordinator:
         self, task_kind: str, best_tput: float, bv: dict[str, Any],
         *, gap_canonical_id: str = "",
     ) -> None:
-        """Update SharedState.current_best + recompute cumulative_gain; gap_canonical_id (when known) is stamped onto the stack entry so provenance resolves by gap id not name."""
+        """Update SharedState.current_best + recompute cumulative_gain; gap_canonical_id (when known) is stamped onto the stack entry so provenance resolves by gap id not name.
+
+        Args:
+            task_kind: The action kind that produced the winner (stamped on the
+                stack entry / current_best).
+            best_tput: The winning variant's measured throughput.
+            bv: The winning variant dict (args, envs, metrics, provenance).
+            gap_canonical_id: When known, stamped onto the stack entry so
+                provenance resolves by gap id rather than name.
+        """
         previous = self.shared_state.current_best or {}
         if not self.shared_state.optimization_stack:
             self.shared_state.seed_stack_from_current_best()
@@ -9924,7 +10810,14 @@ class Coordinator:
         *,
         task: "Task | None" = None,
     ) -> None:
-        """Lift specific action-result fields into the persistent SharedState (baseline/profile/roofline/grid)."""
+        """Lift specific action-result fields into the persistent SharedState (baseline/profile/roofline/grid).
+
+        Args:
+            task_kind: The settled task's kind, selecting the promote branch.
+            result: The task result dict; non-dict results are ignored.
+            task: The originating task, used for audit fingerprints and
+                pending-roofline gating.
+        """
         if not isinstance(result, dict):
             return
         changed = False

--- a/inference_optimizer/orchestrator/coordinator_helpers.py
+++ b/inference_optimizer/orchestrator/coordinator_helpers.py
@@ -18,7 +18,16 @@ log = logging.getLogger(__name__)
 
 
 def _infer_model_class_from_config(model_path: str) -> str:
-    """Infer a deterministic model_class from local model metadata."""
+    """Infer a deterministic model_class from local model metadata.
+
+    Args:
+        model_path: Local filesystem path to the model directory containing
+            ``config.json``.
+
+    Returns:
+        One of ``moe_mla_nsa`` / ``moe_mla`` / ``moe_swa`` / ``dense`` derived
+        from the model's architecture and config.
+    """
     import json
     raw_path = (model_path or "").strip()
     payload: dict[str, Any] = {}
@@ -124,6 +133,15 @@ def effective_closing_grace_sec(
 
     Explicit ``closing_grace_sec`` (including ``0`` to disable) wins;
     otherwise default to ``min(120, max_minutes * 60 * 0.02)``.
+
+    Args:
+        max_minutes: Total session budget in minutes, used to derive the
+            default grace window.
+        closing_grace_sec: Explicit grace window in seconds, or ``None`` to use
+            the derived default.
+
+    Returns:
+        The closing-phase grace window in seconds.
     """
     if closing_grace_sec is not None:
         return float(closing_grace_sec)
@@ -134,6 +152,13 @@ def _parse_iso_unix(ts: str) -> float:
     """Parse an ISO 8601 UTC timestamp into unix seconds; ``0.0`` on failure.
 
     Naive timestamps are treated as UTC. Never raises.
+
+    Args:
+        ts: An ISO 8601 timestamp string (``Z`` suffix accepted).
+
+    Returns:
+        The timestamp as unix epoch seconds, or ``0.0`` when empty or
+        unparseable.
     """
     s = (ts or "").strip()
     if not s:
@@ -154,6 +179,14 @@ def _summarize_failed_variants(
 
     Returns ``[{name, error_class, error_excerpt, extra_server_args}, ...]``
     (excerpt capped at 400 chars, at most ``max_entries`` rows).
+
+    Args:
+        all_results: The grid_runner result rows to scan (non-list inputs
+            yield an empty list).
+        max_entries: Maximum number of failed rows to include.
+
+    Returns:
+        A compact list of failed-variant dicts.
     """
     if not isinstance(all_results, list):
         return []
@@ -181,6 +214,13 @@ def _parse_baseline_workload_extra(yaml_path: str) -> dict[str, Any]:
     Reads workload-shape fields outside ``_collect_workload_tags`` from
     ``benchmark.envs`` extra-args blobs and top-level ``benchmark`` fields.
     Defensive — parse errors return ``{}``.
+
+    Args:
+        yaml_path: Path to the baseline-materialized Magpie YAML file.
+
+    Returns:
+        A dict of extracted workload-tag fields, or ``{}`` on any read/parse
+        error.
     """
     import yaml as _yaml
     try:
@@ -240,6 +280,12 @@ def _baseline_params_fingerprint(params: dict[str, Any] | None) -> dict[str, Any
     Missing keys recorded as ``None``; ``extra_envs`` normalized to a sorted
     list of stringified ``[key, value]`` pairs so ordering doesn't affect
     equality.
+
+    Args:
+        params: The baseline action params to fingerprint, or ``None``.
+
+    Returns:
+        A fingerprint dict keyed by the baseline-determining params.
     """
     params = params or {}
     out: dict[str, Any] = {}
@@ -259,7 +305,12 @@ def _baseline_params_fingerprint(params: dict[str, Any] | None) -> dict[str, Any
 
 
 def _resolve_roofline_watermark_ratio() -> float:
-    """Resolve the roofline watermark ratio from ``$HYPERLOOM_ROOFLINE_WATERMARK_RATIO`` (fallback 1.10)."""
+    """Resolve the roofline watermark ratio from ``$HYPERLOOM_ROOFLINE_WATERMARK_RATIO`` (fallback 1.10).
+
+    Returns:
+        The configured ratio when it parses to a float greater than 1.0,
+        otherwise the default ``1.10``.
+    """
     raw = (os.environ.get(_ROOFLINE_WATERMARK_RATIO_ENV) or "").strip()
     if not raw:
         return _DEFAULT_ROOFLINE_WATERMARK_RATIO
@@ -281,6 +332,15 @@ def _merge_cumulative_extra_sglang_args(
 
     Prefer the full stack and dedupe, since joining ``base + candidate``
     when both are full stacks duplicates flags.
+
+    Args:
+        base_args: The baseline launch args string.
+        candidate_args: The candidate's launch args string.
+        full_args: The full cumulative stack args string, preferred when
+            present and distinct from the candidate.
+
+    Returns:
+        The merged, deduplicated launch args string.
     """
     base = str(base_args or "").strip()
     candidate = str(candidate_args or "").strip()
@@ -303,6 +363,12 @@ def _dedupe_extra_server_args(args_str: str) -> str:
     Keep each flag once with its last value (first-seen order preserved),
     since argparse ``action="store"`` only honors the last value. Flags in
     ``_MULTI_VALUE_SGLANG_FLAGS`` keep their multi-value runs.
+
+    Args:
+        args_str: The space-separated launch args string to deduplicate.
+
+    Returns:
+        The deduplicated launch args string, or ``""`` when input is empty.
     """
     if not args_str:
         return ""

--- a/inference_optimizer/orchestrator/coordinator_helpers.py
+++ b/inference_optimizer/orchestrator/coordinator_helpers.py
@@ -44,6 +44,16 @@ def _infer_model_class_from_config(model_path: str) -> str:
     text = " ".join(text_parts)
 
     def _positive_int(*keys: str) -> bool:
+        """Whether any of the given payload keys holds a positive integer.
+
+        Booleans are explicitly ignored (they are not treated as ints).
+
+        Args:
+            *keys: Payload keys to check.
+
+        Returns:
+            ``True`` if at least one key parses to an integer > 0.
+        """
         for key in keys:
             val = payload.get(key)
             if isinstance(val, bool):

--- a/inference_optimizer/orchestrator/coordinator_helpers.py
+++ b/inference_optimizer/orchestrator/coordinator_helpers.py
@@ -18,7 +18,16 @@ log = logging.getLogger(__name__)
 
 
 def _infer_model_class_from_config(model_path: str) -> str:
-    """Infer a deterministic model_class from local model metadata."""
+    """Infer a deterministic model_class from local model metadata.
+
+    Args:
+        model_path: Local model directory path; its ``config.json`` is read
+            when present.
+
+    Returns:
+        A model-class label: ``moe_mla_nsa``, ``moe_mla``, ``moe_swa`` or
+        ``dense``.
+    """
     import json
     raw_path = (model_path or "").strip()
     payload: dict[str, Any] = {}
@@ -124,6 +133,14 @@ def effective_closing_grace_sec(
 
     Explicit ``closing_grace_sec`` (including ``0`` to disable) wins;
     otherwise default to ``min(120, max_minutes * 60 * 0.02)``.
+
+    Args:
+        max_minutes: The wall-clock budget in minutes (used for the default).
+        closing_grace_sec: Explicit grace window in seconds; when not
+            ``None`` it is used verbatim.
+
+    Returns:
+        The closing-phase grace window in seconds.
     """
     if closing_grace_sec is not None:
         return float(closing_grace_sec)
@@ -134,6 +151,12 @@ def _parse_iso_unix(ts: str) -> float:
     """Parse an ISO 8601 UTC timestamp into unix seconds; ``0.0`` on failure.
 
     Naive timestamps are treated as UTC. Never raises.
+
+    Args:
+        ts: ISO 8601 timestamp string (``Z`` suffix accepted).
+
+    Returns:
+        The timestamp in unix seconds, or ``0.0`` when empty/unparseable.
     """
     s = (ts or "").strip()
     if not s:
@@ -154,6 +177,13 @@ def _summarize_failed_variants(
 
     Returns ``[{name, error_class, error_excerpt, extra_server_args}, ...]``
     (excerpt capped at 400 chars, at most ``max_entries`` rows).
+
+    Args:
+        all_results: Grid-runner result rows; non-list inputs yield ``[]``.
+        max_entries: Maximum number of failed rows to include.
+
+    Returns:
+        A compact list of failed-variant projections.
     """
     if not isinstance(all_results, list):
         return []
@@ -181,6 +211,12 @@ def _parse_baseline_workload_extra(yaml_path: str) -> dict[str, Any]:
     Reads workload-shape fields outside ``_collect_workload_tags`` from
     ``benchmark.envs`` extra-args blobs and top-level ``benchmark`` fields.
     Defensive — parse errors return ``{}``.
+
+    Args:
+        yaml_path: Path to the baseline-materialized Magpie YAML.
+
+    Returns:
+        The extracted workload-tag fields, or ``{}`` on parse error.
     """
     import yaml as _yaml
     try:
@@ -240,6 +276,12 @@ def _baseline_params_fingerprint(params: dict[str, Any] | None) -> dict[str, Any
     Missing keys recorded as ``None``; ``extra_envs`` normalized to a sorted
     list of stringified ``[key, value]`` pairs so ordering doesn't affect
     equality.
+
+    Args:
+        params: Task params to project (``None`` treated as empty).
+
+    Returns:
+        A fingerprint dict over the baseline-determining keys.
     """
     params = params or {}
     out: dict[str, Any] = {}
@@ -259,7 +301,12 @@ def _baseline_params_fingerprint(params: dict[str, Any] | None) -> dict[str, Any
 
 
 def _resolve_roofline_watermark_ratio() -> float:
-    """Resolve the roofline watermark ratio from ``$HYPERLOOM_ROOFLINE_WATERMARK_RATIO`` (fallback 1.10)."""
+    """Resolve the roofline watermark ratio from ``$HYPERLOOM_ROOFLINE_WATERMARK_RATIO`` (fallback 1.10).
+
+    Returns:
+        The watermark ratio (> 1.0), falling back to ``1.10`` when unset,
+        unparseable, or not greater than 1.0.
+    """
     raw = (os.environ.get(_ROOFLINE_WATERMARK_RATIO_ENV) or "").strip()
     if not raw:
         return _DEFAULT_ROOFLINE_WATERMARK_RATIO
@@ -281,6 +328,14 @@ def _merge_cumulative_extra_sglang_args(
 
     Prefer the full stack and dedupe, since joining ``base + candidate``
     when both are full stacks duplicates flags.
+
+    Args:
+        base_args: The baseline extra-args string.
+        candidate_args: The candidate extra-args string for the KEEP.
+        full_args: The full cumulative stack, preferred when present.
+
+    Returns:
+        The deduped cumulative launch-args string.
     """
     base = str(base_args or "").strip()
     candidate = str(candidate_args or "").strip()
@@ -312,6 +367,13 @@ def _dedupe_extra_server_args(args_str: str) -> str:
     ``_MULTI_VALUE_SGLANG_FLAGS`` keep their multi-value runs. Args with
     JSON/space-valued flags are left untouched because downstream launch
     scripts expand them unquoted.
+
+    Args:
+        args_str: The extra server-args string to dedupe.
+
+    Returns:
+        The deduped args string, or the input unchanged when it contains a
+        JSON/space-valued flag; ``""`` for empty input.
     """
     if not args_str:
         return ""

--- a/inference_optimizer/orchestrator/cortex_t0.py
+++ b/inference_optimizer/orchestrator/cortex_t0.py
@@ -59,6 +59,13 @@ def _build_warm_prefer(shared_state: Any, framework_version: str) -> dict[str, A
     Only non-empty values are included; the dispatcher skips absent
     fields. ``quant_scheme`` / ``workload_mode`` ride on the per-baseline
     ``baseline_workload_extra`` map when present.
+
+    Args:
+        shared_state: The live SharedState carrying workload knobs.
+        framework_version: The resolved framework version, included when set.
+
+    Returns:
+        The ``prefer`` similarity-hint dict (non-empty fields only).
     """
     prefer: dict[str, Any] = {}
     for attr in _PREFER_NUMERIC_ATTRS:
@@ -84,6 +91,12 @@ def _remote_is_gbrain(kb: Any) -> bool:
     adapter; otherwise the source is the cortex kb-service (or local-only
     fallback, which we still label ``cortex-kb`` since that is the
     configured remote contract).
+
+    Args:
+        kb: The recipe-KB dispatcher whose active remote is inspected.
+
+    Returns:
+        ``True`` when the active remote is the gbrain adapter.
     """
     remote = getattr(kb, "remote", None)
     return type(remote).__name__ == "GbrainRemoteRecipeClient"
@@ -96,6 +109,13 @@ def _recipe_is_actionable(row: Mapping[str, Any]) -> bool:
     tags but no champion / experiential lists) is NOT actionable: treating
     it as a confident hit would let warm-replay apply an empty config and
     starve the specialist prompt of real priors.
+
+    Args:
+        row: A warm recipe row to inspect.
+
+    Returns:
+        ``True`` when the row carries a usable config, positive throughput, or
+        any experiential list worth replaying.
     """
     if not isinstance(row, Mapping):
         return False
@@ -133,6 +153,19 @@ def _build_warm_start_context(
     ready-to-replay champion plus the experiential lists, so consumers
     (warm-replay / specialist prompt / ledger) never parse the raw
     recipe shape.
+
+    Args:
+        status: The warm-start status (``hit`` / ``seed_only`` / ``miss`` /
+            ``error``).
+        tier: The match tier (e.g. ``exact`` / ``relative`` / ``seed_only``).
+        confidence: The match confidence score.
+        canonical_id: The recipe's canonical id.
+        source: The serving source label (e.g. ``gbrain`` / ``cortex-kb``).
+        recipe: The matched recipe row, or ``None``.
+
+    Returns:
+        The model-facing WarmStartContext dict; replay/prior fields are only
+        populated for a ``hit``.
     """
     ctx: dict[str, Any] = {
         "status": status,
@@ -195,6 +228,28 @@ def run_t0_anchor(
 
     Mutates ``shared_state`` in place (warm_start_* fields) and persists when
     ``save_state=True``. ``session_dir`` is required. Returns a :class:`T0Result`.
+
+    Args:
+        kb: The recipe-KB dispatcher used for the read-modify-write anchor.
+        shared_state: The live SharedState, mutated in place with warm-start
+            results.
+        workload: The model/workload identifier.
+        hw: The hardware/GPU identifier.
+        image_digest: Optional container image digest stamped as a trace tag.
+        stack_fingerprint: Optional stack-version fingerprint mapping.
+        extra_attrs: Optional extra identity/trace attributes (model_class,
+            framework, session ids).
+        resume: When ``True``, re-anchor even if already anchored.
+        fail_fast: Reserved flag for fail-fast behavior.
+        on_status: Optional status-line callback; defaults to INFO logging.
+        session_dir: The session directory (required).
+        save_state: When ``True``, persist the mutated SharedState.
+
+    Returns:
+        A :class:`T0Result` describing the anchor outcome.
+
+    Raises:
+        ValueError: If ``session_dir`` is ``None``.
     """
     emit = on_status or _default_status_emitter
     if session_dir is None:

--- a/inference_optimizer/orchestrator/db_maintenance.py
+++ b/inference_optimizer/orchestrator/db_maintenance.py
@@ -44,6 +44,11 @@ class RetentionResult:
 
     @property
     def total(self) -> int:
+        """Total rows deleted across the events and tasks retention passes.
+
+        Returns:
+            The sum of ``events_deleted`` and ``tasks_deleted``.
+        """
         return self.events_deleted + self.tasks_deleted
 
 
@@ -51,7 +56,15 @@ async def _min_processed_seq(cursors: CursorStore) -> int | None:
     """Lowest ``last_processed_seq`` across all agent cursors.
 
     ``None`` when no cursor exists yet (nothing is safe to prune — every event
-    may still need replay)."""
+    may still need replay).
+
+    Args:
+        cursors: Cursor store holding each agent's processing watermark.
+
+    Returns:
+        The minimum ``last_processed_seq`` across all cursors, or ``None`` when
+        no cursor exists yet.
+    """
     states = await cursors.all()
     if not states:
         return None
@@ -67,6 +80,15 @@ async def prune_events(
     """Delete fully-processed events below the resume anchor + recent margin.
 
     Returns the number of rows deleted.
+
+    Args:
+        db: Open SQLite connection to prune the ``events`` table on.
+        cursors: Cursor store used to compute the resume anchor watermark.
+        keep_recent: Minimum number of most-recent events to retain regardless
+            of the cursor watermark.
+
+    Returns:
+        The number of event rows deleted.
     """
     min_cursor = await _min_processed_seq(cursors)
     if min_cursor is None or min_cursor <= 0:
@@ -94,6 +116,13 @@ async def prune_tasks(
 
     Never touches queued/running/failed/needs_manual_review rows. Returns the
     number of rows deleted.
+
+    Args:
+        db: Open SQLite connection to prune the ``tasks`` table on.
+        keep_done: Minimum number of most-recent done tasks to retain.
+
+    Returns:
+        The number of task rows deleted.
     """
     keep_done = max(0, int(keep_done))
     placeholders = ",".join("?" * len(_PRUNABLE_TASK_STATES))
@@ -117,7 +146,17 @@ async def run_db_retention(
     events_keep_recent: int = DEFAULT_EVENTS_KEEP_RECENT,
     tasks_keep_done: int = DEFAULT_TASKS_KEEP_DONE,
 ) -> RetentionResult:
-    """Run all DB retention passes; safe to call periodically from the reaper."""
+    """Run all DB retention passes; safe to call periodically from the reaper.
+
+    Args:
+        db: Open SQLite connection to run retention on.
+        cursors: Cursor store used to compute the event prune watermark.
+        events_keep_recent: Minimum number of most-recent events to retain.
+        tasks_keep_done: Minimum number of most-recent done tasks to retain.
+
+    Returns:
+        A :class:`RetentionResult` with the per-table deletion counts.
+    """
     events_deleted = await prune_events(
         db, cursors, keep_recent=events_keep_recent,
     )

--- a/inference_optimizer/orchestrator/framework_agent_client.py
+++ b/inference_optimizer/orchestrator/framework_agent_client.py
@@ -43,7 +43,14 @@ except ImportError:  # pragma: no cover — exercised only in IO-only test envs
     }
 
     def repo_url_for_framework(framework: str) -> str:
-        """Return the canonical GitHub repo URL for ``framework`` ("" if unknown)."""
+        """Return the canonical GitHub repo URL for ``framework`` ("" if unknown).
+
+        Args:
+            framework: The framework name (case-insensitive).
+
+        Returns:
+            The repo URL, or ``""`` when the framework is unknown.
+        """
         return _FRAMEWORK_TO_REPO_URL.get(
             (framework or "").strip().lower(), "",
         )
@@ -54,6 +61,10 @@ def _resolve_fa_binary() -> str | None:
 
     Resolution order: ``$FA_BIN``; ``shutil.which('fa')``;
     ``$FRAMEWORK_AGENT_ROOT/scripts/fa``.
+
+    Returns:
+        The absolute path to the ``fa`` binary, or ``None`` when it cannot be
+        located.
     """
     explicit = (os.environ.get("FA_BIN") or "").strip()
     if explicit and Path(explicit).exists():
@@ -80,7 +91,18 @@ def _run_fa_subcommand_sync(
     request_path: Path,
     timeout_sec: float,
 ) -> "tuple[int, str, str]":
-    """Sync helper: run ``fa <subcommand> --request <path> --out -``. Never raises."""
+    """Sync helper: run ``fa <subcommand> --request <path> --out -``. Never raises.
+
+    Args:
+        fa_bin: Path to the ``fa`` binary.
+        subcommand: The ``fa`` subcommand to run.
+        request_path: Path to the request JSON file.
+        timeout_sec: Subprocess wall-clock timeout in seconds.
+
+    Returns:
+        A ``(returncode, stdout, stderr)`` tuple; failures map to ``127``
+        (missing binary) or ``124`` (timeout).
+    """
     cmd = [fa_bin, subcommand, "--request", str(request_path), "--out", "-"]
     try:
         cp = subprocess.run(
@@ -109,6 +131,19 @@ async def _invoke_fa_phase(
     Writes ``request`` as temp JSON, runs the subcommand, returns parsed
     JSON. Raises :class:`RuntimeError` on missing binary / non-zero exit /
     parse failure.
+
+    Args:
+        subcommand: The ``fa phase-*`` subcommand to run.
+        request: The request payload serialized to temp JSON.
+        session_dir: The session directory under which the temp request lives.
+        timeout_sec: Subprocess wall-clock timeout in seconds.
+
+    Returns:
+        The parsed JSON payload returned by the subcommand.
+
+    Raises:
+        RuntimeError: If the ``fa`` binary is missing, the subcommand exits
+            non-zero, or its output is not valid JSON.
     """
     fa_bin = _resolve_fa_binary()
     if not fa_bin:
@@ -163,6 +198,23 @@ async def phase_discover(
     (fa skips its own ``extract_keywords``); empty/``None`` keeps the legacy
     behaviour. Returns the ``fa phase-discover`` payload
     ``{batch_id, framework, repo_url, candidates: [...]}``.
+
+    Args:
+        model: The model identifier.
+        framework: The target framework (defaults to ``sglang`` when empty).
+        gpu_type: The target GPU type.
+        gaps: The performance gaps driving discovery.
+        session_dir: The session directory for temp request staging.
+        repo_url: Optional explicit repo URL; resolved from ``framework`` when
+            empty.
+        keywords: Optional verbatim AND-search keywords; ``None``/empty keeps
+            the legacy keyword extraction.
+        max_candidates: Maximum number of candidate PRs to request.
+        batch_id: Optional batch identifier.
+        timeout_sec: Subprocess wall-clock timeout in seconds.
+
+    Returns:
+        The ``fa phase-discover`` payload dict.
     """
     resolved_repo_url = (repo_url or repo_url_for_framework(framework)).strip()
     request = {

--- a/inference_optimizer/orchestrator/framework_paths.py
+++ b/inference_optimizer/orchestrator/framework_paths.py
@@ -325,6 +325,10 @@ def resolve_atom_arg_utils_path() -> tuple[Path, str]:
 
     Returns ``(Path, str)`` where the str is the file path on success or a
     diagnostic message on failure.
+
+    Returns:
+        A ``(Path, str)`` tuple of the resolved path and either the file path
+        (on success) or a diagnostic message (on failure).
     """
     override = os.environ.get("INFERENCE_OPTIMIZER_ATOM_ARG_UTILS", "").strip()
     if override:
@@ -377,6 +381,12 @@ def summarise_framework_root_discovery(roots: str) -> str:
     Input is the colon-separated string from
     ``probe_framework_source_roots_for_env``; emitted in ``_FRAMEWORK_BUCKETS``
     order for stable output.
+
+    Args:
+        roots: Colon-separated source roots to summarise.
+
+    Returns:
+        A one-line ``fw=ok``/``fw=missing`` summary in bucket order.
     """
     parts: list[str] = []
     items = [p.strip().lower() for p in (roots or "").split(":") if p.strip()]

--- a/inference_optimizer/orchestrator/gpu_pool.py
+++ b/inference_optimizer/orchestrator/gpu_pool.py
@@ -20,7 +20,12 @@ DEFAULT_GPU_LEASE_TTL_SEC = 1800
 
 
 def _now_iso() -> str:
-    """Return the current UTC time as a microsecond ISO-8601 string."""
+    """Return the current UTC time as a microsecond ISO-8601 string.
+
+    Returns:
+        The current UTC time formatted as an ISO-8601 string with microsecond
+        precision.
+    """
     return datetime.now(timezone.utc).isoformat(timespec="microseconds")
 
 
@@ -53,6 +58,13 @@ def resolve_gpu_specialist_devices(capacity: int) -> list[int]:
 
     ``INFERENCE_OPTIMIZER_GPU_SPECIALIST_DEVICES`` may name an explicit pool;
     absent → ``range(capacity)``. Capacity zero disables dispatch.
+
+    Args:
+        capacity: Maximum number of GPU ids to return; zero or negative
+            disables dispatch.
+
+    Returns:
+        GPU ids available to specialists, capped at ``capacity``.
     """
     cap = max(0, int(capacity or 0))
     if cap <= 0:
@@ -95,7 +107,11 @@ class SpecialistGpuPool:
 
     @property
     def capacity(self) -> int:
-        """Return the number of GPUs the pool manages."""
+        """Return the number of GPUs the pool manages.
+
+        Returns:
+            The count of GPU ids managed by this pool.
+        """
         return len(self.gpu_ids)
 
     async def try_acquire(
@@ -106,7 +122,18 @@ class SpecialistGpuPool:
         task_id: str,
         ttl_sec: int = DEFAULT_GPU_LEASE_TTL_SEC,
     ) -> GpuLease | None:
-        """Acquire ``count`` GPU ids or return ``None`` if the pool is full."""
+        """Acquire ``count`` GPU ids or return ``None`` if the pool is full.
+
+        Args:
+            count: Number of GPU ids to acquire.
+            holder_id: Identifier of the lease holder.
+            task_id: Identifier of the task requesting the GPUs.
+            ttl_sec: Lease time-to-live in seconds before the lease expires.
+
+        Returns:
+            A ``GpuLease`` over the acquired GPU ids, or ``None`` when the
+            request cannot be satisfied (invalid count or too few free GPUs).
+        """
         n = int(count or 0)
         if n <= 0 or n > self.capacity:
             return None

--- a/inference_optimizer/orchestrator/gpu_pool.py
+++ b/inference_optimizer/orchestrator/gpu_pool.py
@@ -20,10 +20,20 @@ DEFAULT_GPU_LEASE_TTL_SEC = 1800
 
 
 def _now_iso() -> str:
+    """Return the current UTC time as a microsecond ISO-8601 string."""
     return datetime.now(timezone.utc).isoformat(timespec="microseconds")
 
 
 def _parse_gpu_list(raw: str) -> list[int]:
+    """Parse a comma/semicolon-separated GPU id list.
+
+    Args:
+        raw: Raw string of GPU ids (``,`` or ``;`` separated).
+
+    Returns:
+        Unique non-negative GPU ids in first-seen order; malformed entries are
+        skipped.
+    """
     out: list[int] = []
     for part in (raw or "").replace(";", ",").split(","):
         p = part.strip()
@@ -73,11 +83,19 @@ class SpecialistGpuPool:
         *,
         gpu_ids: list[int] | tuple[int, ...],
     ):
+        """Initialize the pool over a fixed set of GPU ids.
+
+        Args:
+            db: SQLite connection backing the lease table.
+            gpu_ids: GPU ids managed by this pool; duplicates and negatives are
+                dropped.
+        """
         self.db = db
         self.gpu_ids = tuple(dict.fromkeys(int(g) for g in gpu_ids if int(g) >= 0))
 
     @property
     def capacity(self) -> int:
+        """Return the number of GPUs the pool manages."""
         return len(self.gpu_ids)
 
     async def try_acquire(
@@ -133,6 +151,11 @@ class SpecialistGpuPool:
         )
 
     async def release(self, lease: GpuLease | None) -> None:
+        """Release the GPUs held by a lease.
+
+        Args:
+            lease: The lease to release; ``None`` or an empty lease is a no-op.
+        """
         if lease is None or not lease.gpu_ids:
             return
         placeholders = ",".join("?" * len(lease.gpu_ids))
@@ -145,6 +168,11 @@ class SpecialistGpuPool:
             )
 
     async def heartbeat(self, lease: GpuLease | None) -> None:
+        """Refresh the heartbeat timestamp for a lease's GPUs.
+
+        Args:
+            lease: The lease to refresh; ``None`` or an empty lease is a no-op.
+        """
         if lease is None or not lease.gpu_ids:
             return
         now_iso = _now_iso()

--- a/inference_optimizer/orchestrator/gpu_pool.py
+++ b/inference_optimizer/orchestrator/gpu_pool.py
@@ -20,7 +20,12 @@ DEFAULT_GPU_LEASE_TTL_SEC = 1800
 
 
 def _now_iso() -> str:
-    """Return the current UTC time as a microsecond ISO-8601 string."""
+    """Return the current UTC time as a microsecond ISO-8601 string.
+
+    Returns:
+        The current UTC time formatted as a microsecond-precision ISO-8601
+        string.
+    """
     return datetime.now(timezone.utc).isoformat(timespec="microseconds")
 
 
@@ -53,6 +58,15 @@ def resolve_gpu_specialist_devices(capacity: int) -> list[int]:
 
     ``INFERENCE_OPTIMIZER_GPU_SPECIALIST_DEVICES`` may name an explicit pool;
     absent → ``range(capacity)``. Capacity zero disables dispatch.
+
+    Args:
+        capacity: Maximum number of GPU ids to make available; values ``<= 0``
+            disable dispatch.
+
+    Returns:
+        The GPU ids available to specialists (explicit pool capped to
+        ``capacity``, else ``range(capacity)``); ``[]`` when capacity is
+        non-positive.
     """
     cap = max(0, int(capacity or 0))
     if cap <= 0:
@@ -95,7 +109,11 @@ class SpecialistGpuPool:
 
     @property
     def capacity(self) -> int:
-        """Return the number of GPUs the pool manages."""
+        """Return the number of GPUs the pool manages.
+
+        Returns:
+            The count of GPU ids managed by this pool.
+        """
         return len(self.gpu_ids)
 
     async def try_acquire(
@@ -106,7 +124,18 @@ class SpecialistGpuPool:
         task_id: str,
         ttl_sec: int = DEFAULT_GPU_LEASE_TTL_SEC,
     ) -> GpuLease | None:
-        """Acquire ``count`` GPU ids or return ``None`` if the pool is full."""
+        """Acquire ``count`` GPU ids or return ``None`` if the pool is full.
+
+        Args:
+            count: Number of GPU ids to acquire.
+            holder_id: Identifier of the lease holder.
+            task_id: Identifier of the task the lease is for.
+            ttl_sec: Lease time-to-live in seconds.
+
+        Returns:
+            A :class:`GpuLease` for the acquired GPUs, or ``None`` when the
+            request is invalid or insufficient GPUs are free.
+        """
         n = int(count or 0)
         if n <= 0 or n > self.capacity:
             return None
@@ -191,7 +220,11 @@ class SpecialistGpuPool:
         ``try_acquire`` already clears expired rows opportunistically, but a
         multi-day run may go long stretches without an acquire (e.g. an idle
         EXPLORE phase), leaking capacity. The reaper tick calls this so stale
-        leases never pin a GPU id indefinitely."""
+        leases never pin a GPU id indefinitely.
+
+        Returns:
+            The number of expired lease rows deleted.
+        """
         now_iso = _now_iso()
         async with self.db.transaction() as cur:
             cur.execute(

--- a/inference_optimizer/orchestrator/kernel_attempt_summary.py
+++ b/inference_optimizer/orchestrator/kernel_attempt_summary.py
@@ -553,6 +553,16 @@ def _render_unattempted_row(
     reason_code: str,
     reason_detail: str,
 ) -> dict[str, Any]:
+    """Build a summary row for a kernel that was not attempted.
+
+    Args:
+        top_entry: The kernel's roofline/top-list entry.
+        reason_code: Machine-readable reason the kernel was skipped.
+        reason_detail: Human-readable explanation of the skip.
+
+    Returns:
+        A row dict tagged with the unattempted category and reason.
+    """
     return {
         "kernel_id": str(top_entry.get("kernel_id") or ""),
         "kernel_name": str(top_entry.get("name") or ""),
@@ -580,6 +590,22 @@ def _render_attempted_row(
     session_dir: Path,
     last_kernel_opt: dict[str, Any] | None,
 ) -> dict[str, Any]:
+    """Build a summary row for a kernel that was attempted.
+
+    Loads the backend ladder and kernel result, then assembles a row
+    capturing the attempt outcome and verification details.
+
+    Args:
+        top_entry: The kernel's roofline/top-list entry.
+        attempt: The recorded attempt metadata.
+        category: Outcome category for the row.
+        results_dir: Directory holding per-kernel result artifacts.
+        session_dir: Session directory for the run.
+        last_kernel_opt: Most recent kernel-optimization record, if any.
+
+    Returns:
+        A row dict describing the attempt and its results.
+    """
     kid = str(top_entry.get("kernel_id") or attempt.get("kernel_id") or "")
     ladder, ladder_unavailable = _load_backend_ladder(results_dir, kid)
     kernel_result, _ = _load_kernel_result(results_dir, kid)
@@ -814,6 +840,14 @@ def _find_highest_impact_missed(
 
 
 def _to_float(v: Any) -> float | None:
+    """Coerce a value to a 4-decimal float, or ``None`` on failure.
+
+    Args:
+        v: Arbitrary value to convert.
+
+    Returns:
+        The rounded float, or ``None`` if it cannot be parsed.
+    """
     if v is None:
         return None
     try:

--- a/inference_optimizer/orchestrator/kernel_attempt_summary.py
+++ b/inference_optimizer/orchestrator/kernel_attempt_summary.py
@@ -66,6 +66,12 @@ def _is_real_artifact_path(path: str) -> bool:
 
     Excludes stdout/stderr/log dumps kernel-agent writes on early-failure
     paths and stuffs into ``optimized_path``.
+
+    Args:
+        path: Candidate artifact path string.
+
+    Returns:
+        True when the path looks like a real kernel artifact.
     """
     if not path:
         return False
@@ -105,6 +111,12 @@ def _classify_attempt_failure(
 
     Priority: timeout → preprocess → compile → correctness → agent_error →
     unknown. ``succeeded`` attempts get ``("", "")``.
+
+    Args:
+        attempt: One attempt record dict.
+
+    Returns:
+        An ``(error_class, error_message)`` tuple.
     """
     status = str(attempt.get("status") or "").strip().lower()
     if status == "succeeded":
@@ -174,6 +186,13 @@ def _backend_results_dir(session_dir: Path, session_id: str) -> Path | None:
 
     ``key`` lookup order: ``session_dir.name``, then ``state.session_id``,
     then a lone subdir under ``kernel-agent/runs/`` (migrated-key recovery).
+
+    Args:
+        session_dir: Session directory root.
+        session_id: State session id used as a fallback lookup key.
+
+    Returns:
+        The results directory path, or ``None`` when none is found.
     """
     runs_root = Path(session_dir) / "kernel-agent" / "runs"
     if not runs_root.is_dir():
@@ -199,6 +218,13 @@ def _load_kernel_result(
 
     Returns ``(payload_dict_or_None, unavailable_reason)``; reused by ladder
     harvesting and verification passthrough.
+
+    Args:
+        results_dir: Directory holding ``<kid>.json`` result files, or ``None``.
+        kernel_id: Kernel id whose result is loaded.
+
+    Returns:
+        A ``(payload_or_None, unavailable_reason)`` tuple.
     """
     if results_dir is None:
         return None, "kernel_agent_results_dir_missing"
@@ -227,6 +253,13 @@ def _load_backend_ladder(
       ``kernel_agent_results_dir_missing``,
       ``kernel_agent_result_file_missing``, ``parse_error``,
       ``no_attempts_recorded``.
+
+    Args:
+        results_dir: Directory holding ``<kid>.json`` result files, or ``None``.
+        kernel_id: Kernel id whose ladder is parsed.
+
+    Returns:
+        A ``(ladder, unavailable_reason)`` tuple.
     """
     data, reason = _load_kernel_result(results_dir, kernel_id)
     if data is None:
@@ -262,7 +295,15 @@ def _load_backend_ladder(
 
 
 def _relative_to_session(p: Path, session_dir: Path) -> str:
-    """Render ``p`` as a path relative to ``session_dir`` when possible."""
+    """Render ``p`` as a path relative to ``session_dir`` when possible.
+
+    Args:
+        p: The path to render.
+        session_dir: Session directory to make ``p`` relative to.
+
+    Returns:
+        The relative path string, or the absolute string when not nested.
+    """
     try:
         return str(p.relative_to(session_dir))
     except ValueError:
@@ -277,7 +318,17 @@ def _classify_attempted(
     rejected_ids: set[str],
     kernel_id: str,
 ) -> str:
-    """Decide the category for a kernel that has an attempts ledger row."""
+    """Decide the category for a kernel that has an attempts ledger row.
+
+    Args:
+        entry: The kernel's attempts ledger row.
+        integrated_ids: Kernel ids already integrated.
+        rejected_ids: Kernel ids that were rejected.
+        kernel_id: The kernel id being classified.
+
+    Returns:
+        The outcome category constant.
+    """
     last_decision = str(entry.get("last_decision") or "").upper()
     if kernel_id in integrated_ids:
         return CATEGORY_INTEGRATED
@@ -293,6 +344,12 @@ def _unattempted_reason(top_entry: dict[str, Any]) -> tuple[str, str]:
 
     Order matters: ``no_source_file`` first since source-file resolve is the
     dispatcher's first gate.
+
+    Args:
+        top_entry: The kernel's top-list/roofline entry.
+
+    Returns:
+        A ``(reason_code, human_detail)`` tuple.
     """
     source = str(top_entry.get("source_file") or "").strip()
     reusable = bool(top_entry.get("reusable_native_kernel"))
@@ -332,7 +389,17 @@ def _summary_one_line(
     backend_ladder: list[dict[str, Any]],
     artifact_error: str,
 ) -> str:
-    """One-line natural-language summary, deterministic, never LLM."""
+    """One-line natural-language summary, deterministic, never LLM.
+
+    Args:
+        category: The kernel outcome category.
+        entry: The kernel's attempt ledger row.
+        backend_ladder: Per-backend attempt rows.
+        artifact_error: Verification error detail, when any.
+
+    Returns:
+        A one-line summary string (``""`` for unknown categories).
+    """
     if category == CATEGORY_INTEGRATED:
         micro = entry.get("last_micro_speedup") or 0.0
         return f"integrated into optimization_stack; micro_speedup={micro:.3f}x"
@@ -378,6 +445,14 @@ def build_kernel_optimization_summary(
     top15 with the per-kernel kernel-agent ``results/<kid>.json`` files.
     Returns a JSON-ready dict for atomic write to
     ``<session_dir>/reports/kernel_optimization_summary.json``.
+
+    Args:
+        state: The session ``SharedState`` instance.
+        session_dir: Session directory (path or string).
+        schema_version: Schema version stamped onto the output.
+
+    Returns:
+        A JSON-ready summary dict.
     """
     sd_path = Path(session_dir)
     session_id = str(getattr(state, "session_id", "") or "")
@@ -701,6 +776,12 @@ def _aggregate_failure_reasons(by_kernel: list[dict[str, Any]]) -> dict[str, int
     Priority: ``error_class``-derived buckets trump legacy structural buckets
     so root causes don't get buried in ``other``; falls back to structural
     classification when no ladder attempt carries an error_class.
+
+    Args:
+        by_kernel: The per-kernel summary rows.
+
+    Returns:
+        Mapping of failure-mode bucket to count.
     """
     breakdown: dict[str, int] = {
         # Legacy structural buckets (kept for back-compat)
@@ -763,7 +844,17 @@ def _build_top_takeaways(
     rejection_breakdown: dict[str, int],
     failure_reason_breakdown: dict[str, int],
 ) -> list[str]:
-    """Deterministic 2-4 sentence summary, no LLM."""
+    """Deterministic 2-4 sentence summary, no LLM.
+
+    Args:
+        counts: Per-category totals.
+        by_kernel: The per-kernel summary rows.
+        rejection_breakdown: Counts of rejection reasons.
+        failure_reason_breakdown: Counts of failure modes.
+
+    Returns:
+        A list of takeaway sentences.
+    """
     out: list[str] = []
     attempted = counts.get("attempted", 0)
     integrated = counts.get("integrated", 0)
@@ -824,6 +915,12 @@ def _find_highest_impact_missed(
 
     "Missed" = ``ATTEMPTED_REJECTED`` OR ``UNATTEMPTED``; ``INTEGRATED`` /
     ``KEEP_PENDING`` are excluded.
+
+    Args:
+        by_kernel: The per-kernel summary rows.
+
+    Returns:
+        The highest-``gpu_pct`` missed row, or ``None`` when none qualify.
     """
     best: dict[str, Any] | None = None
     best_gpu = -1.0

--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -83,7 +83,12 @@ _COMPILE_GENERATED_NAME_MARKERS = (
 # Shape sources trusted for kernel-opt dispatch (``torch_trace`` from TraceLens; ``tuning_csv`` reserved for a profiled sweep).
 _ALLOWED_SHAPE_PROVENANCE = frozenset({"torch_trace", "tuning_csv"})
 def _reusable_source_roots() -> tuple[str, ...]:
-    """Framework install roots for patchability checks (from :func:`framework_paths.resolve_patch_target_roots`; emits a lower-case variant per root for case-insensitive matching)."""
+    """Framework install roots for patchability checks (from :func:`framework_paths.resolve_patch_target_roots`; emits a lower-case variant per root for case-insensitive matching).
+
+    Returns:
+        The de-duplicated framework install roots (each with a lower-case
+        variant), including FlyDSL checkout roots.
+    """
     from .framework_paths import resolve_patch_target_roots
 
     roots = resolve_patch_target_roots()
@@ -118,7 +123,11 @@ _DEFAULT_GEMM_TUNING_TIMEOUT_SEC = 3 * 60 * 60
 
 @functools.lru_cache(maxsize=1)
 def _default_geak_budget_minutes() -> float:
-    """Default per-GEAK-attempt budget tracking ``$GEAK_RUN_MODE`` (quick→70, full→130). PR #301: mirrors kernel-agent tool defaults."""
+    """Default per-GEAK-attempt budget tracking ``$GEAK_RUN_MODE`` (quick→70, full→130). PR #301: mirrors kernel-agent tool defaults.
+
+    Returns:
+        The default per-attempt GEAK budget in minutes.
+    """
     raw = (os.environ.get("GEAK_RUN_MODE") or "").strip().lower()
     return 70.0 if raw == "quick" else 130.0
 
@@ -129,6 +138,10 @@ def _visible_gpu_count() -> int | None:
     Returns ``None`` when torch can't tell us (missing / driver-init
     failure) so callers can distinguish "no GPUs" (``0``) from "unknown"
     and pick the right fallback. Works for both ROCm and CUDA backends.
+
+    Returns:
+        The visible GPU count, or ``None`` when torch is unavailable or
+        driver init fails.
     """
     try:
         import torch  # local import: torch driver init can be expensive
@@ -142,6 +155,9 @@ def _per_task_gpus() -> int:
 
     Floors at 1 so a missing / invalid env never zero-divides or stalls
     the batch fanout.
+
+    Returns:
+        The per-attempt GPU reservation, always ``>= 1``.
     """
     try:
         per_task = int(os.environ.get("KERNEL_AGENT_NUM_GPUS", "0") or 0)
@@ -201,6 +217,13 @@ def _should_parallelize_backends(payload: dict, num_candidates: int) -> bool:
     Operators / tests can force the decision via payload
     ``parallel_backends`` or env ``KERNEL_OPT_PARALLEL_BACKENDS``
     (truthy ``1/true/yes/on`` enables, anything else disables).
+
+    Args:
+        payload: Request payload; ``parallel_backends`` may force the choice.
+        num_candidates: Number of kernel candidates in this request.
+
+    Returns:
+        ``True`` to race GEAK against the OOB ladder, else ``False``.
     """
     override = payload.get("parallel_backends")
     if override is None:
@@ -662,7 +685,14 @@ def _validate_reusable_native_kernel(payload: dict) -> HandlerResult | None:
 
 
 def _allow_empty_kernel_shape(payload: dict) -> bool:
-    """Escape hatch (default off) via ``payload['allow_empty_kernel_shape']`` or ``HYPERLOOM_ALLOW_EMPTY_KERNEL_SHAPE=1``."""
+    """Escape hatch (default off) via ``payload['allow_empty_kernel_shape']`` or ``HYPERLOOM_ALLOW_EMPTY_KERNEL_SHAPE=1``.
+
+    Args:
+        payload: Request payload that may carry ``allow_empty_kernel_shape``.
+
+    Returns:
+        ``True`` when empty kernel shapes are explicitly permitted.
+    """
     if bool(payload.get("allow_empty_kernel_shape")):
         return True
     return str(
@@ -673,7 +703,16 @@ def _allow_empty_kernel_shape(payload: dict) -> bool:
 def _validate_kernel_shape_and_paths(
     payload: dict, *, session_dir: Path,
 ) -> HandlerResult | None:
-    """Reject a kernel-opt dispatch with no trace-anchored shape or a missing source/workspace path (would burn budget with no anchor; guides back to ``trace_analyze``)."""
+    """Reject a kernel-opt dispatch with no trace-anchored shape or a missing source/workspace path (would burn budget with no anchor; guides back to ``trace_analyze``).
+
+    Args:
+        payload: Kernel-opt dispatch payload to validate.
+        session_dir: Session directory used as the default workspace path.
+
+    Returns:
+        A failure ``HandlerResult`` describing the rejection, or ``None`` when
+        the dispatch is valid.
+    """
     # ``dry_run`` exercises the plumbing without a backend, so no GPU budget and fake fixture paths need not exist.
     if bool(payload.get("dry_run")):
         return None
@@ -894,6 +933,13 @@ def _fill_integrate_defaults_from_state(
     Runs before the ``base_tput > 0`` hard-check in ``integrate_handler`` for
     bare ``{"kernel_id": ...}`` payloads. Always returns a shallow copy; never
     raises on a missing snapshot.
+
+    Args:
+        payload: The integrate request payload.
+        session_dir: Session directory to load SharedState from.
+
+    Returns:
+        A shallow copy of ``payload`` with defaults filled from state.
     """
     from .shared_state import SharedState
 
@@ -925,7 +971,17 @@ def _fill_integrate_defaults_from_state(
 
 
 def _resolve_integrate_payload(payload: dict, *, session_dir: Path) -> tuple[dict, HandlerResult | None]:
-    """Fill integrate inputs from SharedState when Orchestration sends only kernel_id (artifact in ``last_kernel_opt``, source in ``last_trace_analyze``)."""
+    """Fill integrate inputs from SharedState when Orchestration sends only kernel_id (artifact in ``last_kernel_opt``, source in ``last_trace_analyze``).
+
+    Args:
+        payload: The integrate request payload.
+        session_dir: Session directory to load SharedState from.
+
+    Returns:
+        A tuple of ``(resolved_payload, error_result)`` where ``error_result``
+        is a failure ``HandlerResult`` when required inputs are missing, else
+        ``None``.
+    """
     from .shared_state import SharedState
 
     resolved = dict(payload)
@@ -992,7 +1048,15 @@ def _resolve_integrate_payload(payload: dict, *, session_dir: Path) -> tuple[dic
 
 
 async def _run_subprocess(cmd: list[str], *, timeout_sec: int) -> tuple[int, str, str]:
-    """asyncio-friendly wrapper around blocking subprocess.run (keeps the reactor responsive)."""
+    """asyncio-friendly wrapper around blocking subprocess.run (keeps the reactor responsive).
+
+    Args:
+        cmd: The command and arguments to run.
+        timeout_sec: Per-run timeout in seconds.
+
+    Returns:
+        A tuple of ``(returncode, stdout, stderr)``.
+    """
     def _run() -> subprocess.CompletedProcess[str]:
         """Run the command synchronously in a worker thread.
 
@@ -1094,7 +1158,21 @@ def _write_gemm_tuning_benchmark_script(
     isl: int,
     osl: int,
 ) -> Path:
-    """Create an isolated benchmark wrapper for GEAK GEMM tuning (distinct port + no global ``pgrep sglang`` cleanup, so it can't kill the main optimizer's server)."""
+    """Create an isolated benchmark wrapper for GEAK GEMM tuning (distinct port + no global ``pgrep sglang`` cleanup, so it can't kill the main optimizer's server).
+
+    Args:
+        workspace: Directory to write the benchmark script into.
+        model_path: Path to the model under test.
+        framework: Serving framework (e.g. ``sglang``).
+        gpu_type: GPU type used to select the benchmark runner.
+        tp: Tensor-parallel degree.
+        conc: Concurrency.
+        isl: Input sequence length.
+        osl: Output sequence length.
+
+    Returns:
+        The path to the written, executable benchmark script.
+    """
     inferencex_path = os.environ.get("INFERENCEX_PATH") or "/hyperloom/InferenceX"
     runner = f"{inferencex_path}/benchmarks/{framework}_{gpu_type}.sh"
     path = workspace / "geak_gemm_benchmark.sh"
@@ -1128,7 +1206,15 @@ exec {shlex.quote(runner)}
 async def run_gemm_tuning_handler(
     payload: dict, *, session_dir: Path,
 ) -> HandlerResult:
-    """Run GEAK's FP8 block-scale GEMM tuning workflow (separate from ``run_optimization``; tunes GEMM dispatch before source-level rewrites)."""
+    """Run GEAK's FP8 block-scale GEMM tuning workflow (separate from ``run_optimization``; tunes GEMM dispatch before source-level rewrites).
+
+    Args:
+        payload: The GEMM-tuning request payload.
+        session_dir: Session directory for workspace and state.
+
+    Returns:
+        A ``HandlerResult`` describing the tuning outcome.
+    """
     from .shared_state import SharedState
 
     state = SharedState.load_or_init(session_dir)
@@ -1386,7 +1472,16 @@ async def trace_analyze_handler(
 def _validate_trace_analyze_inputs(
     payload: dict, *, session_dir: Path,
 ) -> HandlerResult | None:
-    """Confirm the run_optimization payload references a valid trace_analyze."""
+    """Confirm the run_optimization payload references a valid trace_analyze.
+
+    Args:
+        payload: The run_optimization request payload.
+        session_dir: Session directory to load SharedState from.
+
+    Returns:
+        A failure ``HandlerResult`` when no valid trace_analyze is referenced,
+        else ``None``.
+    """
     candidates_path = str(payload.get("candidates_path") or "").strip()
     if candidates_path and not Path(candidates_path).exists():
         return {
@@ -1439,6 +1534,15 @@ async def run_optimization_handler(
     With candidate metadata, upgrades single-kernel requests into a concurrent
     batch over all reusable native kernels. ``record_partial`` (optional) streams
     each batch sub-result into SharedState before gather wait-all returns.
+
+    Args:
+        payload: The run_optimization request payload.
+        session_dir: Session directory for workspace and state.
+        record_partial: Optional callback streaming each batch sub-result into
+            SharedState before the gather wait-all returns.
+
+    Returns:
+        A ``HandlerResult`` describing the optimization outcome.
     """
     data_guard = _validate_trace_analyze_inputs(payload, session_dir=session_dir)
     if data_guard is not None:
@@ -1563,7 +1667,14 @@ def _backend_order(payload: dict) -> list[str]:
 
 
 def _in_flight_kernel_ids(session_dir: Path) -> set[str]:
-    """Scan the kernel-agent run dir for ``state=running`` status files, so :func:`_batch_kernel_candidates` skips kernels still in flight from a prior batch."""
+    """Scan the kernel-agent run dir for ``state=running`` status files, so :func:`_batch_kernel_candidates` skips kernels still in flight from a prior batch.
+
+    Args:
+        session_dir: Session directory whose kernel-agent run dir is scanned.
+
+    Returns:
+        The set of kernel ids currently in flight.
+    """
     in_flight: set[str] = set()
     sid = session_dir.name
     status_dir = session_dir / "kernel-agent" / "runs" / sid / "status" / "kernel_optimization"
@@ -1589,7 +1700,14 @@ def _in_flight_kernel_ids(session_dir: Path) -> set[str]:
 
 
 def _normalize_kernel_id(value: str) -> str:
-    """Fold hallucinated ``kn``/``rn`` prefixes onto the real ``k`` numbering (mirrors ``kernel_optimization._normalize_kernel_id``)."""
+    """Fold hallucinated ``kn``/``rn`` prefixes onto the real ``k`` numbering (mirrors ``kernel_optimization._normalize_kernel_id``).
+
+    Args:
+        value: The raw kernel id to normalize.
+
+    Returns:
+        The normalized kernel id.
+    """
     s = str(value or "").strip().lower()
     for prefix in ("kn", "rn"):
         if s.startswith(prefix) and s[len(prefix):].isdigit():
@@ -1600,7 +1718,16 @@ def _normalize_kernel_id(value: str) -> str:
 def _reconcile_kernel_id(
     requested: Any, candidates: list[dict[str, Any]],
 ) -> str:
-    """Resolve the LLM kernel_id to a real candidate id (exact kernel_id/name, then normalized; only a missing id falls back to the first candidate)."""
+    """Resolve the LLM kernel_id to a real candidate id (exact kernel_id/name, then normalized; only a missing id falls back to the first candidate).
+
+    Args:
+        requested: The (possibly hallucinated) kernel id from the LLM.
+        candidates: The real candidate dicts to reconcile against.
+
+    Returns:
+        The reconciled candidate id (the first candidate's id when
+        ``requested`` is empty; ``requested`` unchanged when no match).
+    """
     req = str(requested or "")
     if req:
         for cand in candidates:
@@ -1624,7 +1751,15 @@ def _reconcile_kernel_id(
 def _resolve_candidate_id(
     requested: Any, candidates: list[dict[str, Any]],
 ) -> str:
-    """Return the canonical ``k00x`` id for ``requested`` or ``""`` (like ``find_candidate`` but with no first-candidate fallback; a pure hallucination returns ``""``)."""
+    """Return the canonical ``k00x`` id for ``requested`` or ``""`` (like ``find_candidate`` but with no first-candidate fallback; a pure hallucination returns ``""``).
+
+    Args:
+        requested: The (possibly hallucinated) kernel id to canonicalize.
+        candidates: The real candidate dicts to match against.
+
+    Returns:
+        The canonical candidate id, or ``""`` when no match is found.
+    """
     req = str(requested or "")
     if not req:
         return ""
@@ -1648,7 +1783,15 @@ def _resolve_candidate_id(
 
 
 def _all_kernel_candidates(payload: dict) -> list[dict[str, Any]]:
-    """Load every candidate (``hot_kernels`` ∪ ``skipped_kernels``) so id canonicalization resolves even when hot_kernels is empty."""
+    """Load every candidate (``hot_kernels`` ∪ ``skipped_kernels``) so id canonicalization resolves even when hot_kernels is empty.
+
+    Args:
+        payload: Request payload carrying ``candidates_path``.
+
+    Returns:
+        Every candidate dict from the artifact, or an empty list when the
+        artifact is missing or unreadable.
+    """
     candidates_path = payload.get("candidates_path")
     if not candidates_path:
         return []
@@ -1740,7 +1883,15 @@ def _batch_kernel_candidates(
             )
 
     def _is_live(kid: str, current_source: str = "") -> bool:
-        """A kernel_id is live (batch-eligible) iff NOT rejected, NOT in-flight, and < max_attempts recorded against the CURRENT source_file (PR-K per-source counting)."""
+        """A kernel_id is live (batch-eligible) iff NOT rejected, NOT in-flight, and < max_attempts recorded against the CURRENT source_file (PR-K per-source counting).
+
+        Args:
+            kid: The kernel id to test.
+            current_source: The current source file for per-source counting.
+
+        Returns:
+            ``True`` when the kernel is batch-eligible, else ``False``.
+        """
         if kid in rejected_kernel_ids:
             return False
         if kid in in_flight:
@@ -1860,6 +2011,13 @@ def _kernel_result_rank(result: HandlerResult | None) -> tuple[int, float]:
     integrate-ready patch); among equals, higher ``micro_speedup`` wins.
     Mirrors the max-key in :func:`_run_optimization_batch` so the ladder,
     the GEAK-vs-OOB race, and the batch all agree on "best".
+
+    Args:
+        result: A kernel-opt attempt result, or ``None``.
+
+    Returns:
+        A ``(keep, micro_speedup)`` sort key; KEEP verdicts rank above
+        non-KEEP, and higher ``micro_speedup`` breaks ties.
     """
     if not isinstance(result, dict):
         return (0, 0.0)
@@ -1887,6 +2045,18 @@ async def _run_backend_ladder(
     attempt log. Stops at the first KEEP so a clean GEAK KEEP still
     short-circuits *its own* ladder and OOB fallbacks (claude -> codex ->
     cursor) only fire when an earlier backend misses a KEEP.
+
+    Args:
+        base_payload: The base request payload shared by every backend.
+        candidate: The kernel candidate to optimize.
+        kernel_id: The kernel id being optimized.
+        backends: The ordered backends to try.
+        session_dir: Session directory for workspace and state.
+
+    Returns:
+        A tuple of ``(best, attempts)`` where ``best`` is the strongest
+        result by ``_kernel_result_rank`` and ``attempts`` is the ordered
+        per-backend attempt log.
     """
     attempts: list[dict[str, Any]] = []
     best: HandlerResult | None = None
@@ -1936,6 +2106,15 @@ async def _run_kernel_backend_sequence(
       first KEEP when there are spare GPUs to let OOB chase a higher
       speedup. Falls back to sequential when GEAK or every OOB backend is
       absent from the ladder (nothing to race).
+
+    Args:
+        base_payload: The base request payload shared by every backend.
+        candidate: The kernel candidate to optimize.
+        session_dir: Session directory for workspace and state.
+        parallel_backends: When ``True``, race GEAK against the OOB ladder.
+
+    Returns:
+        The strongest ``HandlerResult`` across the backends tried.
     """
     kernel_id = str(candidate.get("kernel_id") or base_payload.get("kernel_id") or "")
     order = _backend_order(base_payload)
@@ -1988,7 +2167,18 @@ async def _run_optimization_batch(
     session_dir: Path,
     record_partial: Callable[[dict], None] | None = None,
 ) -> HandlerResult:
-    """Fan ``run_optimization`` out across reusable native kernels (``record_partial`` streams each sub-attempt into SharedState before gather wait-all unblocks)."""
+    """Fan ``run_optimization`` out across reusable native kernels (``record_partial`` streams each sub-attempt into SharedState before gather wait-all unblocks).
+
+    Args:
+        payload: The run_optimization request payload.
+        candidates: The reusable native kernels to fan out across.
+        session_dir: Session directory for workspace and state.
+        record_partial: Optional callback streaming each sub-attempt into
+            SharedState before the gather wait-all unblocks.
+
+    Returns:
+        The strongest ``HandlerResult`` augmented with batch metadata.
+    """
     max_parallel = int(
         payload.get("max_parallel")
         or os.environ.get("KERNEL_OPT_MAX_PARALLEL")
@@ -2092,6 +2282,13 @@ async def _run_optimization_single(
     """Run Hyperloom/kernel-agent's kernel_optimization.py on one kernel.
 
     Required payload: ``kernel_id``. Returns the tool's JSON output verbatim.
+
+    Args:
+        payload: The single-kernel request payload (requires ``kernel_id``).
+        session_dir: Session directory for workspace and state.
+
+    Returns:
+        The kernel_optimization tool's JSON output as a ``HandlerResult``.
     """
     kernel_id = payload.get("kernel_id")
     if not kernel_id:
@@ -2217,6 +2414,10 @@ def _trace_kernel_attempt_usage(
 
     Best-effort end to end: any read/parse/append failure is logged at debug
     and swallowed so kernel optimization never breaks on a trace write.
+
+    Args:
+        result: A kernel_optimization result whose ``attempts`` are mined.
+        session_dir: Session directory the ``llm_calls.jsonl`` rows append to.
     """
     if not isinstance(result, dict):
         return
@@ -2264,7 +2465,17 @@ def _trace_kernel_attempt_usage(
 
 
 def _shape_tool_result(rc: int, stdout: str, stderr: str) -> HandlerResult:
-    """Wrap a kernel-agent tool's exit + stdout into our schema (prefer the tool's own JSON, synthesize only on parse failure)."""
+    """Wrap a kernel-agent tool's exit + stdout into our schema (prefer the tool's own JSON, synthesize only on parse failure).
+
+    Args:
+        rc: The tool's process return code.
+        stdout: The tool's captured standard output.
+        stderr: The tool's captured standard error.
+
+    Returns:
+        The tool's own JSON result (status filled from ``rc`` if absent), or a
+        synthesized failure result when stdout has no parseable JSON.
+    """
     parsed = _parse_tool_stdout(stdout)
     if parsed:
         # Trust the tool's own status; otherwise infer from rc.
@@ -2320,7 +2531,15 @@ def _parse_tool_stdout(stdout: str) -> dict[str, Any]:
 
 # ---------------------------------------------------------------------------
 def _lookup_kernel_roofline_name(session_dir: Path, kernel_id: str) -> str:
-    """Resolve the TraceLens/device kernel name for a roofline sidecar row."""
+    """Resolve the TraceLens/device kernel name for a roofline sidecar row.
+
+    Args:
+        session_dir: Session directory holding the roofline sidecar.
+        kernel_id: The kernel id to look up.
+
+    Returns:
+        The matched kernel name, or ``""`` when the sidecar/row is absent.
+    """
     sidecar_path = session_dir / "reports" / "kernel_roofline.json"
     try:
         payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
@@ -2345,7 +2564,17 @@ def _record_after_kernel_opt_rocprof_status(
     txt_path: str = "",
     log: Any = None,
 ) -> None:
-    """Best-effort sidecar status update for skipped/failed after-opt rocprof."""
+    """Best-effort sidecar status update for skipped/failed after-opt rocprof.
+
+    Args:
+        session_dir: Session directory holding the roofline sidecar.
+        kernel_id: The kernel id whose sidecar row is updated.
+        status: The rocprof status to record.
+        reason: Optional human-readable reason for the status.
+        json_path: Optional path to the rocprof JSON artifact.
+        txt_path: Optional path to the rocprof text artifact.
+        log: Optional logger for warnings on failure.
+    """
     try:
         ko_tool = _kernel_agent_tool_path("kernel_optimization.py")
         ko_dir = ko_tool.parent
@@ -2415,6 +2644,14 @@ async def _run_after_kernel_opt_rocprof(
     calls ``_update_kernel_roofline_sidecar`` with ``phase='after_kernel_opt'``.
 
     Always returns a small status dict; never raises.
+
+    Args:
+        kernel_id: The kernel id that was just integrated.
+        session_dir: Session directory for state and artifacts.
+        log: Logger for status/warning messages.
+
+    Returns:
+        A small status dict describing the rocprof outcome.
     """
     rocprof_env = os.environ.get("HYPERLOOM_ROCPROF_ROOFLINE", "1").strip().lower()
     if rocprof_env in {"0", "false", "no", "off"}:
@@ -2621,6 +2858,16 @@ async def integrate_handler(
     kernel_id, config_path, extra_server_args, keep_threshold_pct (1.0),
     budget_minutes (20). Returns ``{status, decision, base_tput, new_tput,
     gain_pct, kernel_id, patch_path, report_path, workspace}``.
+
+    Args:
+        payload: The integrate request payload (requires ``base_tput``).
+        session_dir: Session directory for workspace and state.
+
+    Returns:
+        A ``HandlerResult`` with the KEEP/REVERT decision and re-baseline
+        metrics (``status``, ``decision``, ``base_tput``, ``new_tput``,
+        ``gain_pct``, ``kernel_id``, ``patch_path``, ``report_path``,
+        ``workspace``).
     """
     from .action_executors.baseline import BaselineExecutor
     from .action_executors.benchmark_result import is_valid_measurement

--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -2369,6 +2369,14 @@ def _record_after_kernel_opt_rocprof_status(
 
 
 def _rocprof_timeout_sec() -> int:
+    """Resolve the rocprof roofline subprocess timeout in seconds.
+
+    Reads ``HYPERLOOM_ROCPROF_ROOFLINE_TIMEOUT_SEC`` and clamps it to a
+    minimum of 60 seconds.
+
+    Returns:
+        The timeout in seconds (defaults to 1800).
+    """
     try:
         return max(60, int(os.environ.get("HYPERLOOM_ROCPROF_ROOFLINE_TIMEOUT_SEC", "1800")))
     except (TypeError, ValueError):
@@ -2376,6 +2384,17 @@ def _rocprof_timeout_sec() -> int:
 
 
 def _rocprof_profile_command(test_command: str) -> str:
+    """Rewrite a test command to run in rocprof profiling mode.
+
+    Swaps a ``--correctness`` flag for ``--profile`` only when the command
+    targets a recognized unittest harness; otherwise returns it unchanged.
+
+    Args:
+        test_command: The original kernel test command.
+
+    Returns:
+        The (possibly rewritten) command string.
+    """
     if "--correctness" not in test_command:
         return test_command
     if "/unittest/harness_" not in test_command and " harness_" not in test_command:
@@ -2536,6 +2555,20 @@ def _schedule_after_kernel_opt_rocprof(
     session_dir: Path,
     log: logging.Logger,
 ) -> dict[str, Any]:
+    """Schedule a background rocprof roofline run after a kernel integrate.
+
+    Honors ``HYPERLOOM_ROCPROF_ROOFLINE`` to disable profiling; otherwise
+    records a ``scheduled`` status and launches the run as a tracked
+    background task.
+
+    Args:
+        kernel_id: Identifier of the integrated kernel.
+        session_dir: Session directory for status sidecars.
+        log: Logger for status and error reporting.
+
+    Returns:
+        A status dict indicating whether the run was scheduled or skipped.
+    """
     rocprof_env = os.environ.get("HYPERLOOM_ROCPROF_ROOFLINE", "1").strip().lower()
     if rocprof_env in {"0", "false", "no", "off"}:
         _record_after_kernel_opt_rocprof_status(
@@ -2562,6 +2595,11 @@ def _schedule_after_kernel_opt_rocprof(
     _BACKGROUND_ROCPROF_TASKS.add(task)
 
     def _done(done_task: asyncio.Task[Any]) -> None:
+        """Completion callback that drops the task and logs failures.
+
+        Args:
+            done_task: The finished background rocprof task.
+        """
         _BACKGROUND_ROCPROF_TASKS.discard(done_task)
         try:
             done_task.result()
@@ -2664,6 +2702,11 @@ async def integrate_handler(
         os.environ["AITER_REBUILD"] = "1"
 
     def _restore_aiter_rebuild_env() -> None:
+        """Restore the ``AITER_REBUILD`` env var to its prior value.
+
+        No-op unless a forced rebuild was applied for this re-baseline;
+        otherwise pops or restores the original value (GH #458).
+        """
         if not force_aiter_rebuild:
             return
         if _prev_aiter_rebuild is None:

--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -2643,7 +2643,12 @@ def _parse_tool_stdout(stdout: str) -> dict[str, Any]:
 def _record_kernel_roofline_sidecar(session_dir: Path) -> None:
     """Transcribe ``reports/kernel_roofline.json`` (written by the external
     kernel-agent tool) into the breakdown recorder as a ``kernel_roofline``
-    singleton. Best-effort; never raises."""
+    singleton. Best-effort; never raises.
+
+    Args:
+        session_dir: Session directory holding the ``reports/kernel_roofline.json``
+            sidecar to transcribe.
+    """
     try:
         sidecar_path = Path(session_dir) / "reports" / "kernel_roofline.json"
         if not sidecar_path.is_file():

--- a/inference_optimizer/orchestrator/knowledge_plane.py
+++ b/inference_optimizer/orchestrator/knowledge_plane.py
@@ -51,7 +51,11 @@ _DOMAIN_REPOS_FILENAME: str = "_domain_repos.yaml"
 
 
 def _domain_repos_path() -> Path:
-    """Where ``_domain_repos.yaml`` lives (centralised for test monkeypatching)."""
+    """Where ``_domain_repos.yaml`` lives (centralised for test monkeypatching).
+
+    Returns:
+        The path to the ``_domain_repos.yaml`` config file.
+    """
     return asset_actions_dir() / "_meta" / _DOMAIN_REPOS_FILENAME
 
 
@@ -60,6 +64,14 @@ def load_domain_repos(path: Path | None = None) -> dict[str, DomainRepos]:
 
     Returns ``{domain_key: DomainRepos}``; missing/malformed yaml returns an
     empty dict + warning log ("no PR feed for any domain").
+
+    Args:
+        path: Optional explicit config path; defaults to
+            :func:`_domain_repos_path`.
+
+    Returns:
+        A ``{domain_key: DomainRepos}`` mapping, or ``{}`` when the config is
+        missing or unparseable.
     """
     target = path or _domain_repos_path()
     if not target.exists():
@@ -215,6 +227,9 @@ class KnowledgePlane:
 
         Returns ``""`` when PR Monitor is disabled so the runner can elide
         the ``mcp__pr_monitor__*`` tool block.
+
+        Returns:
+            The PR Monitor MCP URL, or ``""`` when PR Monitor is disabled.
         """
         if not self.pr_monitor_enabled:
             return ""
@@ -232,6 +247,16 @@ class KnowledgePlane:
         Called once per EXPLORE phase entry (KB_design §3.6 §5.2). Returns a
         ``{domain: (prs, warnings)}`` map; aggregated warnings stashed on
         :attr:`last_warnings`. Fail-soft.
+
+        Args:
+            window_days: PR lookback window override, or ``None`` for the
+                configured default.
+            per_repo_limit: Max PRs per repo override, or ``None`` for the
+                configured default.
+            total_budget_sec: Total wall-clock budget for the batch warm.
+
+        Returns:
+            A ``{domain: (prs, warnings)}`` map across every known domain.
         """
         out: dict[str, tuple[list[PRSummary], list[str]]] = {}
         all_warnings: list[str] = []
@@ -267,6 +292,19 @@ class KnowledgePlane:
         Failure semantics: disabled → ``["pr_monitor:disabled"]``; unknown
         domain → ``["pr_monitor:unknown_domain:<d>"]``; per-repo failures
         fold into ``warnings`` while reachable repos still surface.
+
+        Args:
+            domain: The specialist domain key to warm.
+            extra_keywords: Additional keywords appended to the domain
+                defaults.
+            window_days: PR lookback window override, or ``None`` for the
+                configured default.
+            per_repo_limit: Max PRs per repo override, or ``None`` for the
+                configured default.
+            total_budget_sec: Total wall-clock budget for the warm.
+
+        Returns:
+            A ``(prs, warnings)`` tuple for the domain.
         """
         warnings: list[str] = []
         if not self.pr_monitor_enabled:

--- a/inference_optimizer/orchestrator/knowledge_plane.py
+++ b/inference_optimizer/orchestrator/knowledge_plane.py
@@ -188,6 +188,14 @@ class KnowledgePlane:
 
     @property
     def cortex_enabled(self) -> bool:
+        """Whether Cortex is enabled (always ``False``).
+
+        Backwards-compatible shim; the knowledge plane no longer wires
+        Cortex.
+
+        Returns:
+            ``False``.
+        """
         # Backwards-compatible shim; KnowledgePlane no longer wires Cortex.
         return False
 

--- a/inference_optimizer/orchestrator/objective.py
+++ b/inference_optimizer/orchestrator/objective.py
@@ -142,6 +142,15 @@ class TargetGainObjective(Objective):
         return state.cumulative_gain >= self.target_gain_pct
 
     def pressure_input(self, state: "SharedState") -> float:
+        """Compute normalized progress toward the gain target.
+
+        Args:
+            state: Current shared state.
+
+        Returns:
+            Progress in ``[0.0, 1.0]``; stays ``0.0`` until the baseline
+            throughput has been measured.
+        """
         # Stays 0 until baseline finishes.
         if state.baseline_tput <= 0:
             return 0.0

--- a/inference_optimizer/orchestrator/objective.py
+++ b/inference_optimizer/orchestrator/objective.py
@@ -70,7 +70,14 @@ class Objective(ABC):
 
     @abstractmethod
     def pressure_input(self, state: "SharedState") -> float:
-        """Feed to scheduler.pressure() (§12): 0.0 = relaxed, 1.0 = max urgency."""
+        """Feed to scheduler.pressure() (§12): 0.0 = relaxed, 1.0 = max urgency.
+
+        Args:
+            state: Current shared optimization state to evaluate.
+
+        Returns:
+            Urgency in the range 0.0 (relaxed) → 1.0 (maximum urgency).
+        """
 
     @abstractmethod
     def describe(self) -> str:
@@ -455,7 +462,21 @@ class TimeOnlyObjective(Objective):
 
 # ---------------------------------------------------------------------------
 def build_objective(env: dict[str, Any]) -> Objective:
-    """Factory (DESIGN §11.3): requires MAX_HOURS; at most one of TARGET_GAIN_PCT / TARGET_TPUT_PER_GPU / TARGET_DIR (none → TimeOnly)."""
+    """Factory (DESIGN §11.3): requires MAX_HOURS; at most one of TARGET_GAIN_PCT / TARGET_TPUT_PER_GPU / TARGET_DIR (none → TimeOnly).
+
+    Args:
+        env: Environment mapping; must contain ``MAX_HOURS`` and may contain at
+            most one of ``TARGET_GAIN_PCT``, ``TARGET_TPUT_PER_GPU``, or
+            ``TARGET_DIR``.
+
+    Returns:
+        The objective matching the supplied target, or a ``TimeOnlyObjective``
+        when no target is given.
+
+    Raises:
+        ObjectiveError: If ``MAX_HOURS`` is missing, non-numeric, or
+            non-positive, or if more than one ``TARGET_*`` key is supplied.
+    """
     if "MAX_HOURS" not in env:
         raise ObjectiveError("build_objective: MAX_HOURS is required")
     try:

--- a/inference_optimizer/orchestrator/optimization_journal.py
+++ b/inference_optimizer/orchestrator/optimization_journal.py
@@ -48,6 +48,13 @@ def _optional_int(value: Any) -> int | None:
     written before D1 has no ``tick`` key, and a corrupted value must not
     crash :meth:`JournalEntry.from_dict` (the journal is a best-effort
     audit artifact loaded on resume).
+
+    Args:
+        value: The value to coerce to an int.
+
+    Returns:
+        The coerced int, or ``None`` when the value is absent or not
+        convertible.
     """
     if value is None:
         return None
@@ -118,7 +125,12 @@ class JournalEntry:
         )
 
     def dedupe_key(self) -> tuple[str, int, str, str, str, str, str]:
-        """Dedup tuple for resume replay (includes variant_name + task_id so same-tick siblings don't collide)."""
+        """Dedup tuple for resume replay (includes variant_name + task_id so same-tick siblings don't collide).
+
+        Returns:
+            A tuple of ``(phase, iter, kind, change, outcome, variant_name,
+            task_id)`` uniquely identifying this decision for dedup.
+        """
         return (
             self.phase, self.iter, self.kind, self.change,
             self.outcome, self.variant_name, self.task_id,
@@ -151,7 +163,20 @@ class Journal:
         framework: str = "",
         baseline_throughput: float = 0.0,
     ) -> Journal:
-        """Return the existing journal if on disk, else mint a new one (on-disk header fields win only when the caller leaves them empty)."""
+        """Return the existing journal if on disk, else mint a new one (on-disk header fields win only when the caller leaves them empty).
+
+        Args:
+            session_dir: The session directory whose ``reports/`` holds the
+                journal file.
+            session_id: Session identifier used when minting a new journal.
+            model: Model identifier used when minting a new journal.
+            hardware: Hardware identifier used when minting a new journal.
+            framework: Optional framework identifier for a new journal.
+            baseline_throughput: Optional baseline throughput for a new journal.
+
+        Returns:
+            The loaded or newly created ``Journal`` instance.
+        """
         path = cls._journal_path(session_dir)
         if path.exists():
             try:
@@ -200,7 +225,15 @@ class Journal:
 
     # Mutation
     def append_entry(self, entry: JournalEntry) -> bool:
-        """Append a decision row and flush; ``False`` on duplicate dedupe_key (resume replay safety)."""
+        """Append a decision row and flush; ``False`` on duplicate dedupe_key (resume replay safety).
+
+        Args:
+            entry: The decision row to append; its ``ts`` is stamped when empty.
+
+        Returns:
+            ``True`` when the entry was appended and flushed, ``False`` when a
+            row with the same dedupe key already exists.
+        """
         if not entry.ts:
             entry.ts = _now_iso()
         key = entry.dedupe_key()
@@ -217,7 +250,14 @@ class Journal:
         final_throughput: float | None = None,
         total_gain_pct: float | None = None,
     ) -> None:
-        """Update top-level summary fields and flush (called once at CLOSE; partial finalize allowed)."""
+        """Update top-level summary fields and flush (called once at CLOSE; partial finalize allowed).
+
+        Args:
+            final_throughput: Final measured throughput; left unchanged when
+                ``None``.
+            total_gain_pct: Total gain percentage over baseline; left unchanged
+                when ``None``.
+        """
         if final_throughput is not None:
             self.final_throughput = float(final_throughput)
         if total_gain_pct is not None:
@@ -225,7 +265,12 @@ class Journal:
         self._flush()
 
     def update_baseline(self, baseline_throughput: float) -> None:
-        """Late-binding setter for the baseline measurement (no-op on non-positive, to avoid erasing a real value with a stale 0)."""
+        """Late-binding setter for the baseline measurement (no-op on non-positive, to avoid erasing a real value with a stale 0).
+
+        Args:
+            baseline_throughput: The measured baseline throughput; ignored when
+                non-positive.
+        """
         if baseline_throughput and baseline_throughput > 0:
             self.baseline_throughput = float(baseline_throughput)
             self._flush()
@@ -277,7 +322,14 @@ def _now_iso() -> str:
 
 
 def _variant_args(variant: dict[str, Any]) -> str:
-    """Read a variant's server-arg string, canonical (``extra_server_args``) first with a legacy ``extra_sglang_args`` fallback."""
+    """Read a variant's server-arg string, canonical (``extra_server_args``) first with a legacy ``extra_sglang_args`` fallback.
+
+    Args:
+        variant: The variant dict to read server args from.
+
+    Returns:
+        The server-arg string, or an empty string when neither key is present.
+    """
     return str(
         variant.get("extra_server_args")
         or variant.get("extra_sglang_args")
@@ -286,7 +338,16 @@ def _variant_args(variant: dict[str, Any]) -> str:
 
 
 def classify_change_kind(task_kind: str, variant: dict[str, Any] | None = None) -> str:
-    """Map a task / variant to a ``KIND_*`` value (priority: env-only > kernel_file > integrate > backend > param)."""
+    """Map a task / variant to a ``KIND_*`` value (priority: env-only > kernel_file > integrate > backend > param).
+
+    Args:
+        task_kind: The task kind to classify.
+        variant: Optional variant dict inspected for server args and envs when
+            the task kind alone is not decisive.
+
+    Returns:
+        The matching ``KIND_*`` constant.
+    """
     kind = (task_kind or "").lower()
     if kind in ("kernel_opt", "deep_kernel_analysis", "operator_tuning"):
         return KIND_KERNEL_FILE
@@ -312,7 +373,18 @@ def summarize_change(
     variant: dict[str, Any] | None = None,
     result_dict: dict[str, Any] | None = None,
 ) -> str:
-    """Human-readable one-line description used as the ``change`` field (falls back to task kind)."""
+    """Human-readable one-line description used as the ``change`` field (falls back to task kind).
+
+    Args:
+        task_kind: The task kind, used as a fallback label.
+        variant: Optional variant dict whose server args, envs, or name supply
+            the description.
+        result_dict: Optional result dict mined for identifiers (kernel id,
+            patch path, PR url) when no variant detail is available.
+
+    Returns:
+        A one-line human-readable description of the change.
+    """
     if isinstance(variant, dict):
         name = str(variant.get("name") or "").strip()
         args = _variant_args(variant).strip()

--- a/inference_optimizer/orchestrator/optimization_journal.py
+++ b/inference_optimizer/orchestrator/optimization_journal.py
@@ -406,6 +406,13 @@ def operation_kind_for(action: str, kind: str = "") -> str:
     ``kernel_integrate``; ``baseline`` / ``profile`` / ``roofline`` / ``sweep``.
     Prefers the fine change-kind, falling back to the action when the kind is
     absent or ``other``.
+
+    Args:
+        action: The action name, used as the fallback label.
+        kind: The fine change-kind; preferred when present and not ``other``.
+
+    Returns:
+        The stable ``operation_kind`` label.
     """
     k = (kind or "").lower()
     if k and k != KIND_OTHER:
@@ -424,6 +431,12 @@ def proposer_for(provenance: str) -> str:
     ``specialist:<domain>`` is kept verbatim (so a trace can filter on the exact
     specialist); ``llm_direct`` / ``legacy:*`` / empty collapse to
     ``orchestration``; ``default_grid`` becomes ``grid``.
+
+    Args:
+        provenance: The explore provenance label to map.
+
+    Returns:
+        The stable proposer/component name.
     """
     p = (provenance or "").strip()
     if not p or p == "llm_direct" or p.startswith("legacy:"):

--- a/inference_optimizer/orchestrator/orchestration_memory.py
+++ b/inference_optimizer/orchestrator/orchestration_memory.py
@@ -29,6 +29,7 @@ _MEMORY_KEYS: tuple[str, ...] = (
 
 
 def _now_iso() -> str:
+    """Return the current UTC time as a second-resolution ISO-8601 string."""
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
 
 
@@ -50,6 +51,18 @@ class CheckpointPolicy:
         chars_since_last: int,
         phase_changed: bool,
     ) -> bool:
+        """Decide whether a checkpoint is due under this policy.
+
+        Args:
+            ticks_since_last: Ticks elapsed since the last checkpoint.
+            minutes_since_last: Minutes elapsed since the last checkpoint.
+            chars_since_last: Characters accumulated since the last checkpoint.
+            phase_changed: Whether a phase boundary was just crossed.
+
+        Returns:
+            ``True`` when any enabled trigger (phase boundary, tick, time, or
+            char budget) is met.
+        """
         if phase_changed and self.on_phase_boundary:
             return True
         if self.every_ticks > 0 and ticks_since_last >= self.every_ticks:
@@ -118,6 +131,16 @@ def parse_checkpoint_reply(raw_text: str) -> dict[str, Any]:
 
 
 def _extract_json_object(text: str) -> dict[str, Any] | None:
+    """Extract the first JSON object embedded in free-form text.
+
+    Args:
+        text: Text that may contain a fenced ```json``` block or a bare
+            ``{ ... }`` span.
+
+    Returns:
+        The parsed JSON object, or ``None`` when none is found or it does not
+        parse to a dict.
+    """
     if not text:
         return None
     # Prefer a fenced ```json ... ``` block.
@@ -184,6 +207,12 @@ def render_memory_for_seed(memory: dict[str, Any]) -> str:
         lines.append(f"current_plan: {plan}")
 
     def _block(label: str, key: str) -> None:
+        """Append a labeled bullet block for a memory list field.
+
+        Args:
+            label: Section heading to render.
+            key: Memory key whose list items are rendered as bullets.
+        """
         items = memory.get(key) or []
         if items:
             lines.append(f"{label}:")
@@ -212,9 +241,21 @@ class CheckpointTracker:
     last_phase: str = ""
 
     def chars_add(self, n: int) -> None:
+        """Accumulate characters produced since the last checkpoint.
+
+        Args:
+            n: Number of characters to add (negatives are clamped to 0).
+        """
         self.chars_since_last += max(0, int(n))
 
     def reset(self, *, tick: int, minute_mark: float, phase: str) -> None:
+        """Reset the tracker after a checkpoint lands.
+
+        Args:
+            tick: Current tick to record as the last checkpoint tick.
+            minute_mark: Current minute mark to record.
+            phase: Current phase to record.
+        """
         self.last_tick = int(tick)
         self.last_minute_mark = float(minute_mark)
         self.chars_since_last = 0

--- a/inference_optimizer/orchestrator/orchestration_memory.py
+++ b/inference_optimizer/orchestrator/orchestration_memory.py
@@ -29,7 +29,12 @@ _MEMORY_KEYS: tuple[str, ...] = (
 
 
 def _now_iso() -> str:
-    """Return the current UTC time as a second-resolution ISO-8601 string."""
+    """Return the current UTC time as a second-resolution ISO-8601 string.
+
+    Returns:
+        The current UTC time formatted as an ISO-8601 string with second
+        precision.
+    """
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
 
 
@@ -106,6 +111,14 @@ def parse_checkpoint_reply(raw_text: str) -> dict[str, Any]:
     Tolerant: accepts a fenced ```json block or bare object; missing keys
     default to empty. Never raises — malformed replies yield a best-effort
     dict (with a ``parse_error`` marker).
+
+    Args:
+        raw_text: The agent's raw checkpoint reply text.
+
+    Returns:
+        A memory-schema dict with ``current_plan`` plus the ``hypotheses``,
+        ``tried_and_why``, ``pending``, and ``learnings`` lists; includes a
+        ``parse_error`` marker when no JSON object could be extracted.
     """
     obj = _extract_json_object(raw_text)
     if obj is None:
@@ -172,6 +185,17 @@ def build_memory_record(
 
     ``learnings`` accumulate across checkpoints (deduped, capped) so durable
     lessons survive a later checkpoint that forgets to repeat them.
+
+    Args:
+        parsed: Parsed checkpoint reply (see ``parse_checkpoint_reply``).
+        seq: Conversation sequence number recorded with the checkpoint.
+        tick: Coordinator tick recorded with the checkpoint.
+        previous: Prior memory record, used to accumulate learnings and the
+            checkpoint count.
+
+    Returns:
+        The new ``orchestration_memory`` record with accumulated learnings and
+        updated checkpoint bookkeeping.
     """
     prev = previous or {}
     learnings = list(prev.get("learnings") or [])
@@ -198,6 +222,13 @@ def render_memory_for_seed(memory: dict[str, Any]) -> str:
 
     Used for compaction re-seed and resume rebuild. Returns "" when memory
     is empty (fresh session).
+
+    Args:
+        memory: An ``orchestration_memory`` record to render.
+
+    Returns:
+        A prompt-ready text block summarizing the recovered working memory, or
+        an empty string when ``memory`` is empty.
     """
     if not memory:
         return ""

--- a/inference_optimizer/orchestrator/orchestration_memory.py
+++ b/inference_optimizer/orchestrator/orchestration_memory.py
@@ -29,7 +29,11 @@ _MEMORY_KEYS: tuple[str, ...] = (
 
 
 def _now_iso() -> str:
-    """Return the current UTC time as a second-resolution ISO-8601 string."""
+    """Return the current UTC time as a second-resolution ISO-8601 string.
+
+    Returns:
+        The current UTC time formatted as a second-resolution ISO-8601 string.
+    """
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
 
 
@@ -106,6 +110,14 @@ def parse_checkpoint_reply(raw_text: str) -> dict[str, Any]:
     Tolerant: accepts a fenced ```json block or bare object; missing keys
     default to empty. Never raises — malformed replies yield a best-effort
     dict (with a ``parse_error`` marker).
+
+    Args:
+        raw_text: The agent's raw checkpoint reply text.
+
+    Returns:
+        The parsed memory dict (``current_plan`` / ``hypotheses`` /
+        ``tried_and_why`` / ``pending`` / ``learnings``), with a
+        ``parse_error`` marker when no JSON object was found.
     """
     obj = _extract_json_object(raw_text)
     if obj is None:
@@ -172,6 +184,16 @@ def build_memory_record(
 
     ``learnings`` accumulate across checkpoints (deduped, capped) so durable
     lessons survive a later checkpoint that forgets to repeat them.
+
+    Args:
+        parsed: The parsed checkpoint reply from :func:`parse_checkpoint_reply`.
+        seq: The checkpoint sequence number.
+        tick: The current tick.
+        previous: The prior persisted memory record, or ``None``.
+
+    Returns:
+        The persisted ``orchestration_memory`` record with accumulated,
+        deduped, capped ``learnings`` and checkpoint bookkeeping.
     """
     prev = previous or {}
     learnings = list(prev.get("learnings") or [])
@@ -198,6 +220,12 @@ def render_memory_for_seed(memory: dict[str, Any]) -> str:
 
     Used for compaction re-seed and resume rebuild. Returns "" when memory
     is empty (fresh session).
+
+    Args:
+        memory: An ``orchestration_memory`` record.
+
+    Returns:
+        The rendered prompt text, or ``""`` when ``memory`` is empty.
     """
     if not memory:
         return ""

--- a/inference_optimizer/orchestrator/phase_state.py
+++ b/inference_optimizer/orchestrator/phase_state.py
@@ -839,6 +839,19 @@ def exit_terminal_prelude(state: Any) -> tuple[str, dict[str, Any]] | None:
 
 
 def abort_prelude(state: Any) -> tuple[str, dict[str, Any]] | None:
+    """Detect a PRELUDE-aborting stop reason on the state.
+
+    Recognizes terminal stop reasons (e.g. ``cortex_t0_failed``,
+    ``time_exhausted_during_prelude``) so phase history captures the
+    boundary.
+
+    Args:
+        state: Object exposing a ``stop_reason`` attribute.
+
+    Returns:
+        A ``(reason, metadata)`` tuple when an abort reason is present,
+        otherwise ``None``.
+    """
     # Treat cortex_t0_failed / time_exhausted_during_prelude etc. as a PRELUDE
     # abort so phase_history captures the boundary.
     sr = (getattr(state, "stop_reason", "") or "").strip()

--- a/inference_optimizer/orchestrator/phase_state.py
+++ b/inference_optimizer/orchestrator/phase_state.py
@@ -39,7 +39,14 @@ PHASE_INDEX: dict[str, int] = {name: i for i, name in enumerate(PHASE_NAMES)}
 
 
 def phase_index(phase: str) -> int:
-    """Return monotonic index of ``phase`` (Inv-2.1 check); unknown → -1."""
+    """Return monotonic index of ``phase`` (Inv-2.1 check); unknown → -1.
+
+    Args:
+        phase: Phase name to look up (case-insensitive).
+
+    Returns:
+        The phase's monotonic index, or ``-1`` when unknown.
+    """
     return PHASE_INDEX.get((phase or "").strip().upper(), -1)
 
 
@@ -81,7 +88,16 @@ PHASE_ALLOWED_ACTIONS: dict[str, frozenset[str]] = {
 
 
 def is_action_allowed_in_phase(action_name: str, phase: str) -> bool:
-    """Return True iff ``action_name`` is in the phase allowlist (R1; unknown phase → deny)."""
+    """Return True iff ``action_name`` is in the phase allowlist (R1; unknown phase → deny).
+
+    Args:
+        action_name: Candidate action name.
+        phase: Phase to check against (case-insensitive).
+
+    Returns:
+        ``True`` when the action is allowed in the phase, ``False`` otherwise
+        (including for unknown phases).
+    """
     allowed = PHASE_ALLOWED_ACTIONS.get((phase or "").strip().upper())
     if allowed is None:
         return False
@@ -89,7 +105,14 @@ def is_action_allowed_in_phase(action_name: str, phase: str) -> bool:
 
 
 def allowed_actions_for(phase: str) -> tuple[str, ...]:
-    """Return ``PHASE_ALLOWED_ACTIONS[phase]`` as a sorted tuple (deterministic)."""
+    """Return ``PHASE_ALLOWED_ACTIONS[phase]`` as a sorted tuple (deterministic).
+
+    Args:
+        phase: Phase whose allowed actions are returned (case-insensitive).
+
+    Returns:
+        The phase's allowed action names sorted for deterministic ordering.
+    """
     return tuple(sorted(PHASE_ALLOWED_ACTIONS.get((phase or "").strip().upper(), frozenset())))
 
 
@@ -102,7 +125,16 @@ PHASE_LLM_PROPOSABLE_ACTIONS: dict[str, frozenset[str]] = {
 
 
 def is_action_llm_proposable_in_phase(action_name: str, phase: str) -> bool:
-    """Return True iff ``action_name`` is LLM-proposable in ``phase`` (unknown → deny)."""
+    """Return True iff ``action_name`` is LLM-proposable in ``phase`` (unknown → deny).
+
+    Args:
+        action_name: Candidate action name.
+        phase: Phase to check against (case-insensitive).
+
+    Returns:
+        ``True`` when the action is LLM-proposable in the phase, ``False``
+        otherwise (including for unknown phases).
+    """
     proposable = PHASE_LLM_PROPOSABLE_ACTIONS.get((phase or "").strip().upper())
     if proposable is None:
         return False
@@ -110,7 +142,16 @@ def is_action_llm_proposable_in_phase(action_name: str, phase: str) -> bool:
 
 
 def llm_proposable_actions_for(phase: str) -> tuple[str, ...]:
-    """Return ``PHASE_LLM_PROPOSABLE_ACTIONS[phase]`` sorted (deterministic)."""
+    """Return ``PHASE_LLM_PROPOSABLE_ACTIONS[phase]`` sorted (deterministic).
+
+    Args:
+        phase: Phase whose LLM-proposable actions are returned
+            (case-insensitive).
+
+    Returns:
+        The phase's LLM-proposable action names sorted for deterministic
+        ordering.
+    """
     return tuple(sorted(
         PHASE_LLM_PROPOSABLE_ACTIONS.get((phase or "").strip().upper(), frozenset())
     ))
@@ -129,7 +170,12 @@ _INTERLEAVE_KERNEL_EXTRAS: frozenset[str] = frozenset({
 
 
 def is_phase_interleave_enabled() -> bool:
-    """Return True when EXPLORE↔KERNEL interleave is enabled (default ON, P3_18; env is rollback knob)."""
+    """Return True when EXPLORE↔KERNEL interleave is enabled (default ON, P3_18; env is rollback knob).
+
+    Returns:
+        ``True`` unless the interleave env var is set to a falsey value
+        (``0``/``false``/``no``/``off``).
+    """
     raw = (os.environ.get(PHASE_INTERLEAVE_ENV) or "").strip().lower()
     return raw not in {"0", "false", "no", "off"}
 
@@ -137,7 +183,17 @@ def is_phase_interleave_enabled() -> bool:
 def llm_proposable_actions_for_with_interleave(
     phase: str, *, interleave: bool | None = None,
 ) -> frozenset[str]:
-    """Return the active LLM-proposable set for ``phase`` (when interleave on, EXPLORE adds kernel-owned names, KERNEL adds the explore triple)."""
+    """Return the active LLM-proposable set for ``phase`` (when interleave on, EXPLORE adds kernel-owned names, KERNEL adds the explore triple).
+
+    Args:
+        phase: Phase whose proposable set is returned (case-insensitive).
+        interleave: Force interleave on/off; defaults to
+            :func:`is_phase_interleave_enabled` when ``None``.
+
+    Returns:
+        The proposable action set for the phase, widened by interleave extras
+        when interleave is active.
+    """
     key = (phase or "").strip().upper()
     base = PHASE_LLM_PROPOSABLE_ACTIONS.get(key, frozenset())
     if interleave is None:
@@ -155,7 +211,18 @@ def is_action_llm_proposable_in_phase_with_interleave(
     action_name: str, phase: str, *, interleave: bool | None = None,
 ) -> bool:
     """Mirror of :func:`is_action_llm_proposable_in_phase` honoring the
-    interleave flag."""
+    interleave flag.
+
+    Args:
+        action_name: Candidate action name.
+        phase: Phase to check against (case-insensitive).
+        interleave: Force interleave on/off; defaults to
+            :func:`is_phase_interleave_enabled` when ``None``.
+
+    Returns:
+        ``True`` when the action is LLM-proposable in the phase under the
+        resolved interleave mode.
+    """
     proposable = llm_proposable_actions_for_with_interleave(
         phase, interleave=interleave,
     )
@@ -370,7 +437,15 @@ def is_pause_specialist_hint(hint: str) -> bool:
 
 
 def is_valid_escalate_hint(hint: str) -> bool:
-    """Return True for any hint Coordinator should act on (closed vocab + ``pause_specialist_<domain>``)."""
+    """Return True for any hint Coordinator should act on (closed vocab + ``pause_specialist_<domain>``).
+
+    Args:
+        hint: Candidate escalate hint string.
+
+    Returns:
+        ``True`` when the hint is in the closed vocabulary or is a valid
+        ``pause_specialist_<domain>`` directive.
+    """
     return (hint or "").strip() in ESCALATE_HINT_VOCAB or is_pause_specialist_hint(hint)
 
 
@@ -381,7 +456,18 @@ def apply_escalate_budget_bump(
     delta: float = ESCALATE_HINT_BUDGET_BUMP_DELTA,
     cap: float = ESCALATE_HINT_BUDGET_BUMP_CAP,
 ) -> dict[str, float]:
-    """Return a budget map with ``phase`` raised by ``delta`` (capped at 80%)."""
+    """Return a budget map with ``phase`` raised by ``delta`` (capped at 80%).
+
+    Args:
+        current_budget_pct: Existing ``phase -> pct`` map, or ``None``.
+        phase: Phase whose budget is raised; unknown phases are a no-op.
+        delta: Percentage-point increase to apply.
+        cap: Absolute ceiling for the resulting budget fraction.
+
+    Returns:
+        A new budget map with the phase's budget raised by ``delta`` and
+        clamped to ``[0.0, cap]``.
+    """
     phase_key = (phase or "").strip().upper()
     if phase_key not in PHASE_NAMES:
         return dict(current_budget_pct or {})
@@ -395,7 +481,15 @@ def apply_escalate_budget_bump(
 def normalize_budget_pct(
     budget: dict[str, float] | None,
 ) -> dict[str, float]:
-    """Return a sanitized ``phase -> pct`` mapping (budgets are upper bounds, not renormalized to 1.0)."""
+    """Return a sanitized ``phase -> pct`` mapping (budgets are upper bounds, not renormalized to 1.0).
+
+    Args:
+        budget: Candidate ``phase -> pct`` map, or ``None`` for defaults.
+
+    Returns:
+        A copy of the default budget map with valid overrides applied; unknown
+        phases and out-of-range values are dropped.
+    """
     out = dict(DEFAULT_PHASE_BUDGET_PCT)
     if not budget:
         return out
@@ -415,7 +509,15 @@ def normalize_budget_pct(
 
 # Pure judgment helpers (used by Coordinator at each tick end)
 def _now_unix(state: Any) -> float:
-    """Resolve the "now" timestamp; tests can inject ``state._now_unix``."""
+    """Resolve the "now" timestamp; tests can inject ``state._now_unix``.
+
+    Args:
+        state: Frozen SharedState view; may expose a callable ``_now_unix``.
+
+    Returns:
+        The current Unix timestamp in seconds, from the injected hook when
+        present otherwise from ``time.time()``.
+    """
     if hasattr(state, "_now_unix") and callable(state._now_unix):
         return float(state._now_unix())  # type: ignore[attr-defined]
     import time as _time
@@ -442,7 +544,14 @@ def _phase_started_unix(state: Any) -> float:
 
 
 def _pending_escalate_hint(state: Any) -> str:
-    """Return a pending escalate hint to act on this tick (unknown hints → empty)."""
+    """Return a pending escalate hint to act on this tick (unknown hints → empty).
+
+    Args:
+        state: Frozen SharedState view exposing ``pending_escalate_hint``.
+
+    Returns:
+        The pending hint when it is recognized, else an empty string.
+    """
     raw = str(getattr(state, "pending_escalate_hint", "") or "").strip()
     if not raw:
         return ""
@@ -497,7 +606,18 @@ def phase_budget_remaining_seconds(
     budget_pct: dict[str, float] | None = None,
     now_unix: float | None = None,
 ) -> float | None:
-    """Return seconds remaining in the current phase's budget (``None`` when ``max_minutes`` 0 = unlimited)."""
+    """Return seconds remaining in the current phase's budget (``None`` when ``max_minutes`` 0 = unlimited).
+
+    Args:
+        state: Frozen SharedState view exposing phase and budget fields.
+        budget_pct: Override ``phase -> pct`` map; defaults to the state's
+            ``phase_budget_pct`` when ``None``.
+        now_unix: Override for the current time in seconds.
+
+    Returns:
+        Non-negative seconds remaining in the current phase's budget, or
+        ``None`` when the session is unlimited or the phase has no budget.
+    """
     mm = _max_minutes(state)
     if mm <= 0:
         return None
@@ -513,7 +633,17 @@ def phase_budget_remaining_seconds(
 def session_remaining_seconds(
     state: Any, *, now_unix: float | None = None,
 ) -> float | None:
-    """Total wall-clock seconds remaining for the session (``None`` when ``max_minutes`` 0 or ``start_ts`` unparseable)."""
+    """Total wall-clock seconds remaining for the session (``None`` when ``max_minutes`` 0 or ``start_ts`` unparseable).
+
+    Args:
+        state: Frozen SharedState view exposing ``max_minutes`` and
+            ``start_ts``.
+        now_unix: Override for the current time in seconds.
+
+    Returns:
+        Non-negative wall-clock seconds remaining, or ``None`` when the session
+        is unlimited or ``start_ts`` cannot be parsed.
+    """
     mm = _max_minutes(state)
     if mm <= 0:
         return None
@@ -550,6 +680,20 @@ def should_force_exit_explore(
     CLOSE-buffer (the "reserve 3h for a separate KERNEL phase" rationale no
     longer applies because kernel work runs inside EXPLORE). Explicit
     non-default thresholds from the caller always win.
+
+    Args:
+        state: Frozen SharedState view.
+        hours_remaining_threshold: Session-remaining hours below which the gate
+            fires; non-positive disables this check.
+        budget_pct_threshold: Phase-budget remaining fraction below which the
+            gate fires; non-positive disables this check.
+        budget_pct: Override ``phase -> pct`` map for budget computation.
+        now_unix: Override for the current time in seconds.
+
+    Returns:
+        A tuple ``(fired, evidence)`` where ``fired`` is ``True`` when the
+        force-exit gate triggers and ``evidence`` records the thresholds and
+        which checks fired.
     """
     if is_phase_interleave_enabled():
         if float(hours_remaining_threshold) == DEFAULT_EXPLORE_FORCE_EXIT_HOURS_REMAINING:
@@ -616,6 +760,20 @@ def compute_plateau_explore(
 
     Trigger (AND, KB_design §3.8 §5.1): recent_keep_gain < threshold AND
     recent_empty_streak >= empty_streak_threshold.
+
+    Args:
+        state: Frozen SharedState view exposing ``explore_search`` and
+            ``specialist_rounds``.
+        lookback: Number of recent winners to sum keep-gain over; non-positive
+            disables the judgment.
+        keep_gain_threshold_pct: Keep-gain threshold below which the gain leg
+            of the trigger is satisfied.
+        empty_streak_threshold: Trailing empty-round count required for the
+            streak leg of the trigger.
+
+    Returns:
+        A tuple ``(triggered, evidence)`` where ``evidence`` records the
+        observed keep-gain, empty streak, and the thresholds used.
     """
     if lookback <= 0:
         return False, {"reason": "lookback_disabled"}
@@ -708,6 +866,19 @@ def compute_plateau_kernel(
 
     Trigger (OR, KB_design §3.8 §5.2 — weaker than explore's AND): revert_streak
     >= threshold OR recent_keep_gain < keep_gain_threshold_pct.
+
+    Args:
+        state: Frozen SharedState view exposing ``kernel_integrate_attempts``.
+        lookback: Number of most-recent integrate attempts to consider;
+            non-positive disables the judgment.
+        revert_streak_threshold: Trailing REVERT/NEEDS_REVIEW count that
+            triggers the streak leg; non-positive disables the judgment.
+        keep_gain_threshold_pct: Keep-gain threshold below which the gain leg
+            triggers.
+
+    Returns:
+        A tuple ``(triggered, evidence)`` where ``evidence`` records the revert
+        streak, summed keep-gain, and the thresholds used.
     """
     lookback = int(lookback or 0)
     revert_streak_threshold = int(revert_streak_threshold or 0)
@@ -780,6 +951,14 @@ def _global_terminal(state: Any) -> tuple[str, dict[str, Any]] | None:
     """Return ``(stop_reason, evidence)`` for a phase-orthogonal stop.
 
     Priority: 1. ``skip_to_close`` → ``robustness_escalated``; 2. Coordinator ``stop_reason``.
+
+    Args:
+        state: Frozen SharedState view exposing ``pending_escalate_hint`` and
+            ``stop_reason``.
+
+    Returns:
+        A ``(stop_reason, evidence)`` tuple when a terminal stop applies, else
+        ``None``.
     """
     hint = _pending_escalate_hint(state)
     if hint == ESCALATE_HINT_SKIP_TO_CLOSE:
@@ -799,7 +978,14 @@ def _global_terminal(state: Any) -> tuple[str, dict[str, Any]] | None:
 
 # per-phase judgments
 def warm_replay_in_flight(state: Any) -> bool:
-    """True while the PRELUDE warm-recipe replay task has not finished (PRELUDE must not exit until False — GPU contention)."""
+    """True while the PRELUDE warm-recipe replay task has not finished (PRELUDE must not exit until False — GPU contention).
+
+    Args:
+        state: Frozen SharedState view exposing ``warm_replay_outcome``.
+
+    Returns:
+        ``True`` while the warm-replay outcome status is ``in_flight``.
+    """
     outcome = getattr(state, "warm_replay_outcome", None) or {}
     if not isinstance(outcome, dict):
         return False
@@ -807,7 +993,16 @@ def warm_replay_in_flight(state: Any) -> bool:
 
 
 def exit_normal_prelude(state: Any) -> tuple[str, dict[str, Any]] | None:
-    """``baseline_tput > 0`` and warm-replay settled → ``prelude_done`` (else ``None``)."""
+    """``baseline_tput > 0`` and warm-replay settled → ``prelude_done`` (else ``None``).
+
+    Args:
+        state: Frozen SharedState view exposing ``baseline_tput`` and
+            warm-replay status.
+
+    Returns:
+        ``("prelude_done", evidence)`` once the baseline is measured and
+        warm-replay has settled, else ``None``.
+    """
     if warm_replay_in_flight(state):
         return None
     try:
@@ -874,6 +1069,18 @@ def exit_normal_explore(
     Priority: 0. HARD force-exit (IR-6, overrides plateau); 1. ``skip_to_kernel``
     → ``plateau_explore``; 2. ``skip_to_sweep`` → ``no_more_leverage`` (non-terminal);
     3. phase budget exhausted.
+
+    Args:
+        state: Frozen SharedState view.
+        budget_pct: Override ``phase -> pct`` map for budget computation.
+        now_unix: Override for the current time in seconds.
+        force_exit_hours_remaining: Session-remaining hours threshold for the
+            IR-6 force-exit gate.
+        force_exit_budget_pct: Phase-budget remaining fraction threshold for the
+            IR-6 force-exit gate.
+
+    Returns:
+        A ``(reason, evidence)`` tuple when EXPLORE should exit, else ``None``.
     """
     forced, force_ev = should_force_exit_explore(
         state,
@@ -919,6 +1126,14 @@ def exit_normal_kernel(
 
     Priority: 1. ``skip_to_close`` defers to global terminal; 2. ``skip_to_sweep``
     → ``no_more_leverage``; 3. phase budget exhausted.
+
+    Args:
+        state: Frozen SharedState view.
+        budget_pct: Override ``phase -> pct`` map for budget computation.
+        now_unix: Override for the current time in seconds.
+
+    Returns:
+        A ``(reason, evidence)`` tuple when KERNEL should exit, else ``None``.
     """
     if _pending_escalate_hint(state) == ESCALATE_HINT_SKIP_TO_SWEEP:
         return "no_more_leverage", {
@@ -947,6 +1162,15 @@ def exit_normal_sweep(
     """SWEEP normal exit: sweep_done OR conc_sweep_done OR budget exhausted.
 
     Bug #12: conc_sweep completion emits an exit so a singleton-blocked sweep doesn't idle.
+
+    Args:
+        state: Frozen SharedState view exposing ``last_sweep`` and
+            ``last_conc_sweep``.
+        budget_pct: Override ``phase -> pct`` map for budget computation.
+        now_unix: Override for the current time in seconds.
+
+    Returns:
+        A ``(reason, evidence)`` tuple when SWEEP should exit, else ``None``.
     """
     last_sweep = getattr(state, "last_sweep", None) or {}
     if isinstance(last_sweep, dict):
@@ -971,7 +1195,15 @@ def exit_normal_sweep(
 # Transition decision (the only function the Coordinator calls each tick)
 def _resolve_plateau_overrides(state: Any) -> dict[str, Any]:
     """Pull operator-tuned plateau thresholds off
-    :attr:`SharedState.plateau_overrides` (empty → library defaults)."""
+    :attr:`SharedState.plateau_overrides` (empty → library defaults).
+
+    Args:
+        state: Frozen SharedState view exposing ``plateau_overrides``.
+
+    Returns:
+        A copy of the operator-tuned override map, or an empty dict when none
+        are set.
+    """
     overrides = getattr(state, "plateau_overrides", None) or {}
     return dict(overrides) if isinstance(overrides, dict) else {}
 
@@ -980,7 +1212,16 @@ def _framework_pr_batch_is_complete(
     batch: dict[str, Any],
     progress_by_batch: dict[str, int],
 ) -> bool:
-    """A FRAMEWORK_PR batch is complete iff every candidate has a terminal-status row in ``framework_pr_phase_progress`` (guards the plateau judge)."""
+    """A FRAMEWORK_PR batch is complete iff every candidate has a terminal-status row in ``framework_pr_phase_progress`` (guards the plateau judge).
+
+    Args:
+        batch: A FRAMEWORK_PR batch record with a ``candidates`` list.
+        progress_by_batch: Map of ``batch_id`` to processed-candidate count.
+
+    Returns:
+        ``True`` when every candidate in the batch has a progress row (or the
+        batch has no candidates).
+    """
     candidates = batch.get("candidates") or []
     if not isinstance(candidates, list) or not candidates:
         return True
@@ -1002,6 +1243,18 @@ def compute_plateau_framework_pr(
 
     Triggers when the last ``lookback`` fully-processed batches each carry
     ``max_gain_pct_observed_in_batch < keep_gain_threshold_pct``. Advisory-only.
+
+    Args:
+        state: Frozen SharedState view exposing ``framework_pr_batches`` and
+            ``framework_pr_phase_progress``.
+        lookback: Number of trailing complete batches to inspect; non-positive
+            disables the judgment.
+        keep_gain_threshold_pct: Max-gain threshold each batch must fall below
+            for the plateau to trigger.
+
+    Returns:
+        A tuple ``(triggered, evidence)`` where ``evidence`` records the
+        lookback, threshold, and the observed per-batch max gains.
     """
     batches = getattr(state, "framework_pr_batches", None) or []
     lookback_int = int(lookback or 0)
@@ -1051,7 +1304,15 @@ def compute_plateau_framework_pr(
 
 
 def _framework_pr_pending_candidate_count(state: Any) -> int:
-    """Count candidates discovered into a batch but missing a progress row."""
+    """Count candidates discovered into a batch but missing a progress row.
+
+    Args:
+        state: Frozen SharedState view exposing ``framework_pr_batches`` and
+            ``framework_pr_phase_progress``.
+
+    Returns:
+        The number of discovered candidates that lack a progress row.
+    """
     batches = getattr(state, "framework_pr_batches", None) or []
     if not isinstance(batches, list) or not batches:
         return 0
@@ -1088,6 +1349,19 @@ def exit_normal_framework_pr(
 
     Priority: 0. HARD force-exit when remaining < ratio*max_hours →
     ``framework_pr_force_exit_low_budget``; 1. ``framework_pr_phase_done``; else ``None``.
+
+    Args:
+        state: Frozen SharedState view; may expose ``remaining_minutes`` and
+            ``framework_pr_phase_done``.
+        max_hours: Total session budget in hours; enables the force-exit gate
+            when positive.
+        now_unix: Override for the current time in seconds.
+        force_exit_hours_remaining_ratio: Fraction of ``max_hours`` below which
+            the force-exit gate fires.
+
+    Returns:
+        A ``(reason, evidence)`` tuple when FRAMEWORK_PR should exit, else
+        ``None``.
     """
     if max_hours and max_hours > 0:
         remaining_min_fn = getattr(state, "remaining_minutes", None)
@@ -1123,7 +1397,15 @@ def exit_normal_framework_pr(
 
 def _post_prelude_target(*, explore_enabled: bool, kernel_enabled: bool) -> str:
     """First active phase after PRELUDE / FRAMEWORK_PR: EXPLORE, else KERNEL,
-    else SWEEP (``--no-explore`` / ``--no-kernel`` collapse the chain)."""
+    else SWEEP (``--no-explore`` / ``--no-kernel`` collapse the chain).
+
+    Args:
+        explore_enabled: Whether the EXPLORE phase is enabled.
+        kernel_enabled: Whether the KERNEL phase is enabled.
+
+    Returns:
+        The first active phase name given the enabled flags.
+    """
     if explore_enabled:
         return PHASE_EXPLORE
     if kernel_enabled:
@@ -1144,6 +1426,20 @@ def compute_next_phase(
     """Return ``(next_phase, reason, evidence)`` or ``None``.
 
     Priority (Inv-8.2 + §3.8 §7.1): global terminal first, then abort > exit_terminal > exit_normal.
+
+    Args:
+        state: Frozen SharedState view exposing the current ``phase``.
+        kernel_enabled: Whether the KERNEL phase is enabled.
+        budget_pct: Override ``phase -> pct`` map for budget computation.
+        now_unix: Override for the current time in seconds.
+        framework_phase_enabled: Whether the FRAMEWORK_PR phase runs after
+            PRELUDE.
+        explore_enabled: Whether the EXPLORE phase is enabled.
+        max_hours: Total session budget in hours (FRAMEWORK_PR force-exit gate).
+
+    Returns:
+        A ``(next_phase, reason, evidence)`` tuple when a transition is due,
+        else ``None``.
     """
     current = (getattr(state, "phase", "") or "").strip().upper() or PHASE_PRELUDE
     overrides = _resolve_plateau_overrides(state)
@@ -1253,7 +1549,19 @@ def make_history_row(
     ts: str,
     ts_unix: float,
 ) -> dict[str, Any]:
-    """Construct a canonical phase_history row (Inv-2.2 + KB_design §3.2 §6); ``reason`` unvalidated for resume tools."""
+    """Construct a canonical phase_history row (Inv-2.2 + KB_design §3.2 §6); ``reason`` unvalidated for resume tools.
+
+    Args:
+        from_phase: Phase being left.
+        to_phase: Phase being entered.
+        reason: Transition reason (left unvalidated for resume tools).
+        evidence: Optional evidence dict recorded with the row.
+        ts: ISO timestamp of the transition.
+        ts_unix: Unix timestamp of the transition.
+
+    Returns:
+        A canonical phase-history row dict.
+    """
     return {
         "from_phase": (from_phase or "").strip().upper(),
         "to_phase":   (to_phase or "").strip().upper(),
@@ -1332,6 +1640,13 @@ def lifecycle_label(name: str) -> str:
     Falls back to the phase-label table, then to the verbatim name, so an
     unmapped step still produces a sensible event rather than an empty
     label.
+
+    Args:
+        name: A step or phase name to label.
+
+    Returns:
+        The human-friendly label, falling back to the verbatim name when
+        unmapped.
     """
     key = (name or "").strip()
     if key in LIFECYCLE_STEP_LABELS:
@@ -1361,6 +1676,21 @@ def make_lifecycle_event(
     that want the strict check go through :data:`LIFECYCLE_STATUSES`.
     Empty / ``None`` artifact values are dropped so the rendered event only
     advertises paths that actually exist.
+
+    Args:
+        step: Machine step / handler name.
+        status: Lifecycle status (START/END/ERROR/ENTER); not hard-validated.
+        phase: Coordinator phase active when the event fired.
+        label: Human-friendly label; defaults to ``lifecycle_label(step)`` when
+            ``None``.
+        artifacts: Optional map of artifact name to path; empty values dropped.
+        detail: Free-form detail string.
+        duration_s: Optional duration in seconds; omitted when unparseable.
+        seq: Monotonic sequence number for the event.
+        ts: ISO timestamp of the event.
+
+    Returns:
+        A canonical lifecycle event row dict.
     """
     event: dict[str, Any] = {
         "seq":    int(seq),

--- a/inference_optimizer/orchestrator/phase_state.py
+++ b/inference_optimizer/orchestrator/phase_state.py
@@ -40,7 +40,14 @@ PHASE_INDEX: dict[str, int] = {name: i for i, name in enumerate(PHASE_NAMES)}
 
 
 def phase_index(phase: str) -> int:
-    """Return monotonic index of ``phase`` (Inv-2.1 check); unknown → -1."""
+    """Return monotonic index of ``phase`` (Inv-2.1 check); unknown → -1.
+
+    Args:
+        phase (str): Phase name; stripped and upper-cased before lookup.
+
+    Returns:
+        int: The phase's position in :data:`PHASE_NAMES`, or ``-1`` when unknown.
+    """
     return PHASE_INDEX.get((phase or "").strip().upper(), -1)
 
 
@@ -82,7 +89,16 @@ PHASE_ALLOWED_ACTIONS: dict[str, frozenset[str]] = {
 
 
 def is_action_allowed_in_phase(action_name: str, phase: str) -> bool:
-    """Return True iff ``action_name`` is in the phase allowlist (R1; unknown phase → deny)."""
+    """Return True iff ``action_name`` is in the phase allowlist (R1; unknown phase → deny).
+
+    Args:
+        action_name (str): Candidate action name; stripped before comparison.
+        phase (str): Phase name; stripped and upper-cased before lookup.
+
+    Returns:
+        bool: True when ``action_name`` is allowed in ``phase``; False for an
+        unknown phase or a non-member action.
+    """
     allowed = PHASE_ALLOWED_ACTIONS.get((phase or "").strip().upper())
     if allowed is None:
         return False
@@ -90,7 +106,15 @@ def is_action_allowed_in_phase(action_name: str, phase: str) -> bool:
 
 
 def allowed_actions_for(phase: str) -> tuple[str, ...]:
-    """Return ``PHASE_ALLOWED_ACTIONS[phase]`` as a sorted tuple (deterministic)."""
+    """Return ``PHASE_ALLOWED_ACTIONS[phase]`` as a sorted tuple (deterministic).
+
+    Args:
+        phase (str): Phase name; stripped and upper-cased before lookup.
+
+    Returns:
+        tuple[str, ...]: The phase's allowed actions sorted ascending, or an
+        empty tuple for an unknown phase.
+    """
     return tuple(sorted(PHASE_ALLOWED_ACTIONS.get((phase or "").strip().upper(), frozenset())))
 
 
@@ -103,7 +127,16 @@ PHASE_LLM_PROPOSABLE_ACTIONS: dict[str, frozenset[str]] = {
 
 
 def is_action_llm_proposable_in_phase(action_name: str, phase: str) -> bool:
-    """Return True iff ``action_name`` is LLM-proposable in ``phase`` (unknown → deny)."""
+    """Return True iff ``action_name`` is LLM-proposable in ``phase`` (unknown → deny).
+
+    Args:
+        action_name (str): Candidate action name; stripped before comparison.
+        phase (str): Phase name; stripped and upper-cased before lookup.
+
+    Returns:
+        bool: True when ``action_name`` is LLM-proposable in ``phase``; False
+        for an unknown phase or a non-member action.
+    """
     proposable = PHASE_LLM_PROPOSABLE_ACTIONS.get((phase or "").strip().upper())
     if proposable is None:
         return False
@@ -111,7 +144,15 @@ def is_action_llm_proposable_in_phase(action_name: str, phase: str) -> bool:
 
 
 def llm_proposable_actions_for(phase: str) -> tuple[str, ...]:
-    """Return ``PHASE_LLM_PROPOSABLE_ACTIONS[phase]`` sorted (deterministic)."""
+    """Return ``PHASE_LLM_PROPOSABLE_ACTIONS[phase]`` sorted (deterministic).
+
+    Args:
+        phase (str): Phase name; stripped and upper-cased before lookup.
+
+    Returns:
+        tuple[str, ...]: The phase's LLM-proposable actions sorted ascending,
+        or an empty tuple for an unknown phase.
+    """
     return tuple(sorted(
         PHASE_LLM_PROPOSABLE_ACTIONS.get((phase or "").strip().upper(), frozenset())
     ))
@@ -129,7 +170,12 @@ _INTERLEAVE_KERNEL_EXTRAS: frozenset[str] = frozenset({
 })
 
 def is_phase_interleave_enabled() -> bool:
-    """Return True when EXPLORE↔KERNEL interleave is enabled (default OFF; env opt-in knob)."""
+    """Return True when EXPLORE↔KERNEL interleave is enabled (default OFF; env opt-in knob).
+
+    Returns:
+        bool: True when ``$INFERENCE_OPTIMIZER_PHASE_INTERLEAVE`` is one of
+        ``1``/``true``/``yes``/``on`` (case-insensitive); False otherwise.
+    """
     raw = (os.environ.get(PHASE_INTERLEAVE_ENV) or "").strip().lower()
     return raw in {"1", "true", "yes", "on"}
 
@@ -148,6 +194,16 @@ def llm_proposable_actions_for_with_interleave(
     disabled the EXPLORE phase. ``specialist`` / ``integrate_patch`` stay
     available because KERNEL legitimately uses them (specialist research +
     patch integration).
+
+    Args:
+        phase (str): Phase name; stripped and upper-cased before lookup.
+        interleave (bool | None): Force interleave on/off; ``None`` resolves it
+            from :func:`is_phase_interleave_enabled`.
+        explore_enabled (bool): When False (``--no-explore``), strip ``explore``
+            from the KERNEL interleave extras.
+
+    Returns:
+        frozenset[str]: The active LLM-proposable action set for ``phase``.
     """
     key = (phase or "").strip().upper()
     base = PHASE_LLM_PROPOSABLE_ACTIONS.get(key, frozenset())
@@ -173,7 +229,20 @@ def is_action_llm_proposable_in_phase_with_interleave(
     explore_enabled: bool = True,
 ) -> bool:
     """Mirror of :func:`is_action_llm_proposable_in_phase` honoring the
-    interleave flag (and the ``--no-explore`` KERNEL grey-channel strip)."""
+    interleave flag (and the ``--no-explore`` KERNEL grey-channel strip).
+
+    Args:
+        action_name (str): Candidate action name; stripped before comparison.
+        phase (str): Phase name; stripped and upper-cased before lookup.
+        interleave (bool | None): Force interleave on/off; ``None`` resolves it
+            from :func:`is_phase_interleave_enabled`.
+        explore_enabled (bool): When False, strip ``explore`` from the KERNEL
+            interleave extras.
+
+    Returns:
+        bool: True when ``action_name`` is in the active interleave-aware
+        proposable set for ``phase``.
+    """
     proposable = llm_proposable_actions_for_with_interleave(
         phase, interleave=interleave, explore_enabled=explore_enabled,
     )
@@ -425,6 +494,10 @@ def is_cyclic_phases_enabled() -> bool:
     when enabled, the macro-cycle behaviour additionally requires a
     long/unbounded budget (see :func:`is_long_run`) so short bounded runs never
     loop in practice.
+
+    Returns:
+        bool: True unless ``$INFERENCE_OPTIMIZER_CYCLIC_PHASES`` is set to a
+        falsy value (``0``/``false``/``no``/``off``).
     """
     return os.environ.get(PHASE_CYCLIC_ENV, "").strip().lower() not in {
         "0", "false", "no", "off",
@@ -449,6 +522,13 @@ def is_long_run(state: Any) -> bool:
     runs longer than :data:`DEFAULT_LONGRUN_THRESHOLD_MINUTES` are "long".
     Everything ``≤ 24h`` is a short bounded run and must behave like the legacy
     monotonic chain.
+
+    Args:
+        state (Any): Frozen SharedState view exposing ``max_minutes``.
+
+    Returns:
+        bool: True for unbounded runs (``max_minutes`` == 0) or bounded runs
+        longer than :data:`DEFAULT_LONGRUN_THRESHOLD_MINUTES`.
     """
     mm = _max_minutes(state)
     if mm <= 0:
@@ -457,6 +537,16 @@ def is_long_run(state: Any) -> bool:
 
 
 def _cumulative_gain_validated(state: Any) -> float:
+    """Return ``state.cumulative_gain_validated``, defensively coerced to float.
+
+    Args:
+        state (Any): Frozen SharedState view exposing
+            ``cumulative_gain_validated``.
+
+    Returns:
+        float: The validated cumulative gain, or ``0.0`` when missing or
+        non-numeric.
+    """
     try:
         return float(getattr(state, "cumulative_gain_validated", 0.0) or 0.0)
     except (TypeError, ValueError):
@@ -481,6 +571,23 @@ def should_reloop_to_explore(
     Loops back iff cyclic mode is on AND below the macro-cycle safety cap AND
     the run has not globally converged (R7: ``no_gain_cycles`` consecutive
     no-gain cycles) AND enough session budget remains to use a fresh cycle.
+
+    Args:
+        state (Any): Frozen SharedState view.
+        now_unix (float | None): Override for the current time; defaults to
+            wall-clock resolution when None.
+        max_cycles (int): Safety ceiling on macro-cycles.
+        min_remaining_sec (float): Minimum session seconds that must remain to
+            justify opening a new cycle.
+        no_gain_cycles (int): Consecutive no-gain cycles that mark global
+            convergence (R7).
+        min_gain_pct (float | None): Per-cycle gain bar; ``None`` uses the
+            decaying KEEP threshold for the cycle.
+
+    Returns:
+        tuple[bool, dict[str, Any]]: ``(reloop, evidence)`` — whether to open a
+        new macro-cycle, and the evidence map (including the effective no-gain
+        streak and any ``reloop_blocked`` reason).
     """
     cycle = int(getattr(state, "macro_cycle", 0) or 0)
     evidence: dict[str, Any] = {"cyclic": is_cyclic_phases_enabled(), "macro_cycle": cycle}
@@ -584,7 +691,15 @@ def is_pause_specialist_hint(hint: str) -> bool:
 
 
 def is_valid_escalate_hint(hint: str) -> bool:
-    """Return True for any hint Coordinator should act on (closed vocab + ``pause_specialist_<domain>``)."""
+    """Return True for any hint Coordinator should act on (closed vocab + ``pause_specialist_<domain>``).
+
+    Args:
+        hint (str): Candidate escalate hint string; stripped before comparison.
+
+    Returns:
+        bool: True when ``hint`` is in :data:`ESCALATE_HINT_VOCAB` or is a
+        structural ``pause_specialist_<domain>`` directive.
+    """
     return (hint or "").strip() in ESCALATE_HINT_VOCAB or is_pause_specialist_hint(hint)
 
 
@@ -595,7 +710,20 @@ def apply_escalate_budget_bump(
     delta: float = ESCALATE_HINT_BUDGET_BUMP_DELTA,
     cap: float = ESCALATE_HINT_BUDGET_BUMP_CAP,
 ) -> dict[str, float]:
-    """Return a budget map with ``phase`` raised by ``delta`` (capped at 80%)."""
+    """Return a budget map with ``phase`` raised by ``delta`` (capped at 80%).
+
+    Args:
+        current_budget_pct (dict[str, float] | None): Existing ``phase -> pct``
+            map; ``None`` starts from the defaults.
+        phase (str): Phase to raise; stripped and upper-cased. An unknown phase
+            returns the input map unchanged.
+        delta (float): Percentage-point increment to apply.
+        cap (float): Absolute ceiling for the resulting fraction.
+
+    Returns:
+        dict[str, float]: A normalized budget map with ``phase`` bumped by
+        ``delta`` and clamped to ``[0.0, cap]``.
+    """
     phase_key = (phase or "").strip().upper()
     if phase_key not in PHASE_NAMES:
         return dict(current_budget_pct or {})
@@ -609,7 +737,16 @@ def apply_escalate_budget_bump(
 def normalize_budget_pct(
     budget: dict[str, float] | None,
 ) -> dict[str, float]:
-    """Return a sanitized ``phase -> pct`` mapping (budgets are upper bounds, not renormalized to 1.0)."""
+    """Return a sanitized ``phase -> pct`` mapping (budgets are upper bounds, not renormalized to 1.0).
+
+    Args:
+        budget (dict[str, float] | None): Raw ``phase -> pct`` overrides;
+            unknown phases and out-of-range / unparseable values are dropped.
+
+    Returns:
+        dict[str, float]: The defaults overlaid with the valid overrides (each
+        in the ``(0.0, 1.0]`` range).
+    """
     out = dict(DEFAULT_PHASE_BUDGET_PCT)
     if not budget:
         return out
@@ -629,7 +766,15 @@ def normalize_budget_pct(
 
 # Pure judgment helpers (used by Coordinator at each tick end)
 def _now_unix(state: Any) -> float:
-    """Resolve the "now" timestamp; tests can inject ``state._now_unix``."""
+    """Resolve the "now" timestamp; tests can inject ``state._now_unix``.
+
+    Args:
+        state (Any): Frozen SharedState view; may expose a callable
+            ``_now_unix`` override for tests.
+
+    Returns:
+        float: Current time in seconds since the epoch.
+    """
     if hasattr(state, "_now_unix") and callable(state._now_unix):
         return float(state._now_unix())  # type: ignore[attr-defined]
     import time as _time
@@ -656,7 +801,14 @@ def _phase_started_unix(state: Any) -> float:
 
 
 def _pending_escalate_hint(state: Any) -> str:
-    """Return a pending escalate hint to act on this tick (unknown hints → empty)."""
+    """Return a pending escalate hint to act on this tick (unknown hints → empty).
+
+    Args:
+        state (Any): Frozen SharedState view exposing ``pending_escalate_hint``.
+
+    Returns:
+        str: The pending hint when it is a recognized escalate hint, else ``""``.
+    """
     raw = str(getattr(state, "pending_escalate_hint", "") or "").strip()
     if not raw:
         return ""
@@ -735,7 +887,19 @@ def phase_budget_remaining_seconds(
     budget_pct: dict[str, float] | None = None,
     now_unix: float | None = None,
 ) -> float | None:
-    """Return seconds remaining in the current phase's budget (``None`` when budget window 0 = unlimited)."""
+    """Return seconds remaining in the current phase's budget (``None`` when budget window 0 = unlimited).
+
+    Args:
+        state (Any): Frozen SharedState view.
+        budget_pct (dict[str, float] | None): Phase-budget overrides; defaults
+            to ``state.phase_budget_pct`` when None.
+        now_unix (float | None): Override for the current time.
+
+    Returns:
+        float | None: Non-negative seconds left in the current phase's budget,
+        or ``None`` when the budget window is unlimited or the phase has no
+        allocated fraction.
+    """
     mm = _budget_minutes(state)
     if mm <= 0:
         return None
@@ -748,7 +912,15 @@ def phase_budget_remaining_seconds(
 
 
 def effective_max_minutes(state: Any) -> float:
-    """Session minutes for deadline/cap math; unbounded runs use the 14-day ceiling."""
+    """Session minutes for deadline/cap math; unbounded runs use the 14-day ceiling.
+
+    Args:
+        state (Any): Frozen SharedState view exposing ``max_minutes``.
+
+    Returns:
+        float: ``max_minutes`` when positive, else
+        :data:`DEFAULT_LONGRUN_MAX_MINUTES` (the unbounded-run ceiling).
+    """
     mm = _max_minutes(state)
     return mm if mm > 0 else float(DEFAULT_LONGRUN_MAX_MINUTES)
 
@@ -785,7 +957,18 @@ def phase_cap_exceeded(
     budget_pct: dict[str, float] | None = None,
     now_unix: float | None = None,
 ) -> bool:
-    """True when time spent in the current phase has reached its absolute cap."""
+    """True when time spent in the current phase has reached its absolute cap.
+
+    Args:
+        state (Any): Frozen SharedState view.
+        budget_pct (dict[str, float] | None): Phase-budget overrides; defaults
+            to ``state.phase_budget_pct`` when None.
+        now_unix (float | None): Override for the current time.
+
+    Returns:
+        bool: True when phase-elapsed time has reached the absolute cap; False
+        when no cap applies.
+    """
     cap = phase_cap_seconds(state, budget_pct=budget_pct)
     if cap is None:
         return False
@@ -796,7 +979,18 @@ def phase_cap_exceeded(
 def session_remaining_seconds(
     state: Any, *, now_unix: float | None = None,
 ) -> float | None:
-    """Total wall-clock seconds remaining for the session (``None`` when ``max_minutes`` 0 or ``start_ts`` unparseable)."""
+    """Total wall-clock seconds remaining for the session (``None`` when ``max_minutes`` 0 or ``start_ts`` unparseable).
+
+    Args:
+        state (Any): Frozen SharedState view exposing ``max_minutes`` and
+            ``start_ts``.
+        now_unix (float | None): Accepted for signature parity; the deadline is
+            computed against the current UTC time.
+
+    Returns:
+        float | None: Non-negative seconds left in the session, or ``None``
+        when ``max_minutes`` is 0 or ``start_ts`` is missing/unparseable.
+    """
     mm = _max_minutes(state)
     if mm <= 0:
         return None
@@ -833,6 +1027,20 @@ def should_force_exit_explore(
     CLOSE-buffer (the "reserve 3h for a separate KERNEL phase" rationale no
     longer applies because kernel work runs inside EXPLORE). Explicit
     non-default thresholds from the caller always win.
+
+    Args:
+        state (Any): Frozen SharedState view.
+        hours_remaining_threshold (float): Session-hours-remaining gate;
+            non-positive disables it.
+        budget_pct_threshold (float): Phase-budget-fraction gate; non-positive
+            disables it.
+        budget_pct (dict[str, float] | None): Phase-budget overrides; defaults
+            to ``state.phase_budget_pct`` when None.
+        now_unix (float | None): Override for the current time.
+
+    Returns:
+        tuple[bool, dict[str, Any]]: ``(fired, evidence)`` — whether HARD
+        force-exit fires, and the evidence map recording which gate(s) fired.
     """
     if is_phase_interleave_enabled():
         if float(hours_remaining_threshold) == DEFAULT_EXPLORE_FORCE_EXIT_HOURS_REMAINING:
@@ -900,6 +1108,20 @@ def compute_plateau_explore(
 
     Trigger (AND, KB_design §3.8 §5.1): recent_keep_gain < threshold AND
     recent_empty_streak >= empty_streak_threshold.
+
+    Args:
+        state (Any): Frozen SharedState view exposing ``explore_search`` and
+            ``specialist_rounds``.
+        lookback (int): Window of recent winners to sum for keep-gain;
+            non-positive disables the judgment.
+        keep_gain_threshold_pct (float): Keep-gain floor below which the gain
+            arm trips.
+        empty_streak_threshold (int): Trailing empty specialist-round count that
+            trips the streak arm.
+
+    Returns:
+        tuple[bool, dict[str, Any]]: ``(triggered, evidence)`` — whether the
+        plateau fired, and the supporting evidence map.
     """
     if lookback <= 0:
         return False, {"reason": "lookback_disabled"}
@@ -992,6 +1214,20 @@ def compute_plateau_kernel(
 
     Trigger (OR, KB_design §3.8 §5.2 — weaker than explore's AND): revert_streak
     >= threshold OR recent_keep_gain < keep_gain_threshold_pct.
+
+    Args:
+        state (Any): Frozen SharedState view exposing
+            ``kernel_integrate_attempts``.
+        lookback (int): Window of recent integrate attempts to inspect;
+            non-positive disables the judgment.
+        revert_streak_threshold (int): Trailing REVERT/NEEDS_REVIEW streak that
+            trips the streak arm; non-positive disables the judgment.
+        keep_gain_threshold_pct (float): Keep-gain floor below which the gain
+            arm trips.
+
+    Returns:
+        tuple[bool, dict[str, Any]]: ``(triggered, evidence)`` — whether the
+        plateau fired, and the supporting evidence map.
     """
     lookback = int(lookback or 0)
     revert_streak_threshold = int(revert_streak_threshold or 0)
@@ -1064,6 +1300,14 @@ def _global_terminal(state: Any) -> tuple[str, dict[str, Any]] | None:
     """Return ``(stop_reason, evidence)`` for a phase-orthogonal stop.
 
     Priority: 1. ``skip_to_close`` → ``robustness_escalated``; 2. Coordinator ``stop_reason``.
+
+    Args:
+        state (Any): Frozen SharedState view exposing ``stop_reason`` and any
+            pending escalate hint.
+
+    Returns:
+        tuple[str, dict[str, Any]] | None: ``(stop_reason, evidence)`` for a
+        phase-orthogonal stop, or ``None`` when none applies.
     """
     hint = _pending_escalate_hint(state)
     if hint == ESCALATE_HINT_SKIP_TO_CLOSE:
@@ -1083,7 +1327,14 @@ def _global_terminal(state: Any) -> tuple[str, dict[str, Any]] | None:
 
 # per-phase judgments
 def warm_replay_in_flight(state: Any) -> bool:
-    """True while the PRELUDE warm-recipe replay task has not finished (PRELUDE must not exit until False — GPU contention)."""
+    """True while the PRELUDE warm-recipe replay task has not finished (PRELUDE must not exit until False — GPU contention).
+
+    Args:
+        state (Any): Frozen SharedState view exposing ``warm_replay_outcome``.
+
+    Returns:
+        bool: True when the warm-replay outcome status is ``in_flight``.
+    """
     outcome = getattr(state, "warm_replay_outcome", None) or {}
     if not isinstance(outcome, dict):
         return False
@@ -1091,7 +1342,16 @@ def warm_replay_in_flight(state: Any) -> bool:
 
 
 def exit_normal_prelude(state: Any) -> tuple[str, dict[str, Any]] | None:
-    """``baseline_tput > 0`` and warm-replay settled → ``prelude_done`` (else ``None``)."""
+    """``baseline_tput > 0`` and warm-replay settled → ``prelude_done`` (else ``None``).
+
+    Args:
+        state (Any): Frozen SharedState view exposing ``baseline_tput`` and the
+            warm-replay outcome.
+
+    Returns:
+        tuple[str, dict[str, Any]] | None: ``("prelude_done", evidence)`` when
+        the baseline succeeded and warm-replay has settled, else ``None``.
+    """
     if warm_replay_in_flight(state):
         return None
     try:
@@ -1159,6 +1419,20 @@ def exit_normal_explore(
     → ``plateau_explore``; 2. ``skip_to_sweep`` / detected plateau →
     ``explore_no_more_leverage`` (non-terminal; routes to KERNEL to switch
     lever); 3. phase budget exhausted.
+
+    Args:
+        state (Any): Frozen SharedState view.
+        budget_pct (dict[str, float] | None): Phase-budget overrides; defaults
+            to ``state.phase_budget_pct`` when None.
+        now_unix (float | None): Override for the current time.
+        force_exit_hours_remaining (float): Session-hours-remaining force-exit
+            threshold.
+        force_exit_budget_pct (float): Phase-budget-fraction force-exit
+            threshold.
+
+    Returns:
+        tuple[str, dict[str, Any]] | None: ``(reason, evidence)`` for the EXPLORE
+        exit, or ``None`` when EXPLORE should continue.
     """
     forced, force_ev = should_force_exit_explore(
         state,
@@ -1220,6 +1494,16 @@ def exit_normal_kernel(
 
     Priority: 1. ``skip_to_close`` defers to global terminal; 2. ``skip_to_sweep``
     → ``kernel_no_more_leverage`` (non-terminal); 3. phase budget exhausted.
+
+    Args:
+        state (Any): Frozen SharedState view.
+        budget_pct (dict[str, float] | None): Phase-budget overrides; defaults
+            to ``state.phase_budget_pct`` when None.
+        now_unix (float | None): Override for the current time.
+
+    Returns:
+        tuple[str, dict[str, Any]] | None: ``(reason, evidence)`` for the KERNEL
+        exit, or ``None`` when KERNEL should continue.
     """
     if _pending_escalate_hint(state) == ESCALATE_HINT_SKIP_TO_SWEEP:
         return "kernel_no_more_leverage", {
@@ -1253,6 +1537,17 @@ def exit_normal_sweep(
     """SWEEP normal exit: sweep_done OR conc_sweep_done OR budget exhausted.
 
     Bug #12: conc_sweep completion emits an exit so a singleton-blocked sweep doesn't idle.
+
+    Args:
+        state (Any): Frozen SharedState view exposing ``last_sweep`` and
+            ``last_conc_sweep``.
+        budget_pct (dict[str, float] | None): Phase-budget overrides; defaults
+            to ``state.phase_budget_pct`` when None.
+        now_unix (float | None): Override for the current time.
+
+    Returns:
+        tuple[str, dict[str, Any]] | None: ``(reason, evidence)`` for the SWEEP
+        exit, or ``None`` when SWEEP should continue.
     """
     last_sweep = getattr(state, "last_sweep", None) or {}
     if isinstance(last_sweep, dict):
@@ -1281,7 +1576,15 @@ def exit_normal_sweep(
 # Transition decision (the only function the Coordinator calls each tick)
 def _resolve_plateau_overrides(state: Any) -> dict[str, Any]:
     """Pull operator-tuned plateau thresholds off
-    :attr:`SharedState.plateau_overrides` (empty → library defaults)."""
+    :attr:`SharedState.plateau_overrides` (empty → library defaults).
+
+    Args:
+        state (Any): Frozen SharedState view exposing ``plateau_overrides``.
+
+    Returns:
+        dict[str, Any]: A copy of the overrides mapping, or an empty dict when
+        unset or non-dict.
+    """
     overrides = getattr(state, "plateau_overrides", None) or {}
     return dict(overrides) if isinstance(overrides, dict) else {}
 
@@ -1290,7 +1593,18 @@ def _framework_pr_batch_is_complete(
     batch: dict[str, Any],
     progress_by_batch: dict[str, int],
 ) -> bool:
-    """A FRAMEWORK_PR batch is complete iff every candidate has a terminal-status row in ``framework_pr_phase_progress`` (guards the plateau judge)."""
+    """A FRAMEWORK_PR batch is complete iff every candidate has a terminal-status row in ``framework_pr_phase_progress`` (guards the plateau judge).
+
+    Args:
+        batch (dict[str, Any]): A FRAMEWORK_PR batch carrying ``candidates`` and
+            ``batch_id``.
+        progress_by_batch (dict[str, int]): Per-batch count of recorded progress
+            rows, keyed by batch id.
+
+    Returns:
+        bool: True when every candidate in the batch has a progress row (or the
+        batch has no candidates).
+    """
     candidates = batch.get("candidates") or []
     if not isinstance(candidates, list) or not candidates:
         return True
@@ -1312,6 +1626,18 @@ def compute_plateau_framework_pr(
 
     Triggers when the last ``lookback`` fully-processed batches each carry
     ``max_gain_pct_observed_in_batch < keep_gain_threshold_pct``. Advisory-only.
+
+    Args:
+        state (Any): Frozen SharedState view exposing ``framework_pr_batches``
+            and ``framework_pr_phase_progress``.
+        lookback (int): Number of fully-processed trailing batches to inspect;
+            non-positive disables the judgment.
+        keep_gain_threshold_pct (float): Per-batch max-gain floor each batch
+            must fall below to trip the plateau.
+
+    Returns:
+        tuple[bool, dict[str, Any]]: ``(triggered, evidence)`` — whether the
+        plateau fired, and the supporting evidence map.
     """
     batches = getattr(state, "framework_pr_batches", None) or []
     lookback_int = int(lookback or 0)
@@ -1361,7 +1687,15 @@ def compute_plateau_framework_pr(
 
 
 def _framework_pr_pending_candidate_count(state: Any) -> int:
-    """Count candidates discovered into a batch but missing a progress row."""
+    """Count candidates discovered into a batch but missing a progress row.
+
+    Args:
+        state (Any): Frozen SharedState view exposing ``framework_pr_batches``
+            and ``framework_pr_phase_progress``.
+
+    Returns:
+        int: Total candidates across all batches that lack a progress row.
+    """
     batches = getattr(state, "framework_pr_batches", None) or []
     if not isinstance(batches, list) or not batches:
         return 0
@@ -1398,6 +1732,19 @@ def exit_normal_framework_pr(
 
     Priority: 0. HARD force-exit when remaining < ratio*max_hours →
     ``framework_pr_force_exit_low_budget``; 1. ``framework_pr_phase_done``; else ``None``.
+
+    Args:
+        state (Any): Frozen SharedState view; may expose a ``remaining_minutes``
+            callable and ``framework_pr_phase_done`` flag.
+        max_hours (float | None): Session wall-clock budget in hours; enables
+            the force-exit gate when positive.
+        now_unix (float | None): Override for the current time.
+        force_exit_hours_remaining_ratio (float): Fraction of ``max_hours``
+            below which the force-exit gate fires.
+
+    Returns:
+        tuple[str, dict[str, Any]] | None: ``(reason, evidence)`` for the
+        FRAMEWORK_PR exit, or ``None`` when the phase should continue.
     """
     if max_hours and max_hours > 0:
         remaining_min_fn = getattr(state, "remaining_minutes", None)
@@ -1433,7 +1780,16 @@ def exit_normal_framework_pr(
 
 def _post_prelude_target(*, explore_enabled: bool, kernel_enabled: bool) -> str:
     """First active phase after PRELUDE / FRAMEWORK_PR: EXPLORE, else KERNEL,
-    else SWEEP (``--no-explore`` / ``--no-kernel`` collapse the chain)."""
+    else SWEEP (``--no-explore`` / ``--no-kernel`` collapse the chain).
+
+    Args:
+        explore_enabled (bool): Whether the EXPLORE phase is enabled.
+        kernel_enabled (bool): Whether the KERNEL phase is enabled.
+
+    Returns:
+        str: ``PHASE_EXPLORE``, ``PHASE_KERNEL``, or ``PHASE_SWEEP`` depending on
+        which phases are enabled.
+    """
     if explore_enabled:
         return PHASE_EXPLORE
     if kernel_enabled:
@@ -1454,6 +1810,22 @@ def compute_next_phase(
     """Return ``(next_phase, reason, evidence)`` or ``None``.
 
     Priority (Inv-8.2 + §3.8 §7.1): global terminal first, then abort > exit_terminal > exit_normal.
+
+    Args:
+        state (Any): Frozen SharedState view exposing the current ``phase``.
+        kernel_enabled (bool): Whether the KERNEL phase is enabled.
+        budget_pct (dict[str, float] | None): Phase-budget overrides; defaults
+            to ``state.phase_budget_pct`` when None.
+        now_unix (float | None): Override for the current time.
+        framework_phase_enabled (bool): Whether the FRAMEWORK_PR phase runs
+            after PRELUDE.
+        explore_enabled (bool): Whether the EXPLORE phase is enabled.
+        max_hours (float | None): Session wall-clock budget in hours (used by
+            the FRAMEWORK_PR force-exit gate).
+
+    Returns:
+        tuple[str, str, dict[str, Any]] | None: ``(next_phase, reason,
+        evidence)`` when a transition fires, else ``None``.
     """
     current = (getattr(state, "phase", "") or "").strip().upper() or PHASE_PRELUDE
     overrides = _resolve_plateau_overrides(state)
@@ -1592,6 +1964,20 @@ def make_history_row(
 
     ``cycle`` stamps the R1 macro-cycle this transition belongs to (0 for the
     first pass / legacy non-cyclic runs).
+
+    Args:
+        from_phase (str): Source phase name; normalized to upper-case.
+        to_phase (str): Destination phase name; normalized to upper-case.
+        reason (str): Transition reason; stripped, left unvalidated for resume
+            tools.
+        evidence (dict[str, Any] | None): Supporting evidence; copied (``None``
+            → empty dict).
+        ts (str): ISO timestamp string for the transition.
+        ts_unix (float): Unix timestamp for the transition.
+        cycle (int): R1 macro-cycle index this transition belongs to.
+
+    Returns:
+        dict[str, Any]: The canonical phase_history row.
     """
     return {
         "from_phase": (from_phase or "").strip().upper(),
@@ -1672,6 +2058,13 @@ def lifecycle_label(name: str) -> str:
     Falls back to the phase-label table, then to the verbatim name, so an
     unmapped step still produces a sensible event rather than an empty
     label.
+
+    Args:
+        name (str): A coordinator step or phase name; stripped before lookup.
+
+    Returns:
+        str: The mapped step label, else the mapped phase label, else the
+        verbatim ``name``.
     """
     key = (name or "").strip()
     if key in LIFECYCLE_STEP_LABELS:
@@ -1701,6 +2094,23 @@ def make_lifecycle_event(
     that want the strict check go through :data:`LIFECYCLE_STATUSES`.
     Empty / ``None`` artifact values are dropped so the rendered event only
     advertises paths that actually exist.
+
+    Args:
+        step (str): Machine step/handler name.
+        status (str): Event status (e.g. START/END/ENTER); not hard-validated.
+        phase (str): Active coordinator phase; normalized to upper-case.
+        label (str | None): Human-friendly label; resolved via
+            :func:`lifecycle_label` when None.
+        artifacts (dict[str, str] | None): Artifact paths; empty/None values are
+            dropped.
+        detail (str): Free-form detail string; stripped.
+        duration_s (float | None): Optional duration in seconds; omitted when
+            unparseable.
+        seq (int): Monotonic sequence number for the event.
+        ts (str): ISO timestamp string for the event.
+
+    Returns:
+        dict[str, Any]: The canonical lifecycle event row.
     """
     event: dict[str, Any] = {
         "seq":    int(seq),

--- a/inference_optimizer/orchestrator/policy.py
+++ b/inference_optimizer/orchestrator/policy.py
@@ -43,7 +43,14 @@ if TYPE_CHECKING:  # pragma: no cover — type-only
 
 
 def _value_is_present(value: Any) -> bool:
-    """Present iff a non-empty string OR non-empty container; ``None`` / whitespace count as absent."""
+    """Present iff a non-empty string OR non-empty container; ``None`` / whitespace count as absent.
+
+    Args:
+        value: The value to test for presence.
+
+    Returns:
+        True when the value is considered present.
+    """
     if value is None:
         return False
     if isinstance(value, str):
@@ -54,7 +61,15 @@ def _value_is_present(value: Any) -> bool:
 
 
 def _delegate_field_present(payload: dict[str, Any], field_name: str) -> bool:
-    """True iff ``field_name`` is present at the top of ``payload`` OR nested under ``payload["params"]`` (robustness uses params)."""
+    """True iff ``field_name`` is present at the top of ``payload`` OR nested under ``payload["params"]`` (robustness uses params).
+
+    Args:
+        payload: The intent payload dict to inspect.
+        field_name: The field name to look for.
+
+    Returns:
+        True when the field is present at the top level or under ``params``.
+    """
     if _value_is_present(payload.get(field_name)):
         return True
     nested = payload.get("params")
@@ -128,7 +143,11 @@ RESEARCH_LANE_CEILING_FALLBACK: int = 2
 
 
 def detect_gpu_count() -> int:
-    """Best-effort visible-GPU count: env masks first, then ``rocm-smi``; 0 when nothing can be probed."""
+    """Best-effort visible-GPU count: env masks first, then ``rocm-smi``; 0 when nothing can be probed.
+
+    Returns:
+        The visible GPU count, or 0 when nothing can be probed.
+    """
     for env_name in ("HIP_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES"):
         raw = os.environ.get(env_name)
         if raw is None:
@@ -163,7 +182,11 @@ def detect_gpu_count() -> int:
 
 
 def research_lane_ceiling() -> int:
-    """Dynamic ceiling on concurrent research-lane specialists (``2 × GPU``; falls back to :data:`RESEARCH_LANE_CEILING_FALLBACK`)."""
+    """Dynamic ceiling on concurrent research-lane specialists (``2 × GPU``; falls back to :data:`RESEARCH_LANE_CEILING_FALLBACK`).
+
+    Returns:
+        The research-lane concurrency ceiling.
+    """
     gpus = detect_gpu_count()
     if gpus > 0:
         return 2 * gpus
@@ -171,7 +194,15 @@ def research_lane_ceiling() -> int:
 
 
 def gpu_specialist_ceiling(shared_state: Any | None = None) -> int:
-    """Configured GPU specialist capacity (separate from serving lanes; 0 disables ``needs_gpu=true`` dispatch)."""
+    """Configured GPU specialist capacity (separate from serving lanes; 0 disables ``needs_gpu=true`` dispatch).
+
+    Args:
+        shared_state: Session state carrying the configured capacity, or
+            ``None`` to read from the environment.
+
+    Returns:
+        The configured GPU specialist capacity (>= 0).
+    """
     if shared_state is not None:
         try:
             return max(0, int(
@@ -360,7 +391,11 @@ SOURCE_LIKE_FIELDS: frozenset[str] = frozenset({"source_file"})
 
 # Multi-node profile trace dirs live outside session_dir but must be referenceable by trace_dir / main_trace_path / trace_input (runtime-resolved).
 def _trace_path_allowlist() -> tuple[str, ...]:
-    """Multi-node profile trace path-prefix allowlist (runtime-resolved; trailing ``/`` is load-bearing for the startswith check)."""
+    """Multi-node profile trace path-prefix allowlist (runtime-resolved; trailing ``/`` is load-bearing for the startswith check).
+
+    Returns:
+        A one-tuple of the allowed trace-root path prefix.
+    """
     from ..paths import mn_profile_trace_root
     root = str(mn_profile_trace_root()).rstrip("/") + "/"
     return (root,)
@@ -492,7 +527,15 @@ class PolicyGate:
 
     # Public API
     def validate_intent(self, from_agent: str, intent: Intent) -> None:
-        """Raise :class:`PolicyDenied` if the intent is not allowed (cheapest checks first: role → allowed_intents → structural → cross-source)."""
+        """Raise :class:`PolicyDenied` if the intent is not allowed (cheapest checks first: role → allowed_intents → structural → cross-source).
+
+        Args:
+            from_agent: Identity of the emitting agent.
+            intent: The parsed intent to validate.
+
+        Raises:
+            PolicyDenied: If the intent is not permitted for the agent.
+        """
         # specialist sub-agents emit under an ephemeral ``specialist:<task_id>`` identity routed to a synthetic role.
         if from_agent.startswith(SPECIALIST_FROM_AGENT_PREFIX):
             self._validate_specialist_intent(from_agent, intent)
@@ -544,7 +587,15 @@ class PolicyGate:
     def _closing_phase_denial(
         self, source: str, intent: Intent,
     ) -> PolicyDenied | None:
-        """During closing phase, allow only harmless intents and ``report`` proposals."""
+        """During closing phase, allow only harmless intents and ``report`` proposals.
+
+        Args:
+            source: Identity of the emitting agent.
+            intent: The parsed intent under evaluation.
+
+        Returns:
+            A :class:`PolicyDenied` to raise, or ``None`` when allowed.
+        """
         state = self.shared_state
         if state is None or not getattr(state, "closing_phase", False):
             return None
@@ -569,7 +620,14 @@ class PolicyGate:
         )
 
     def allowed_tools_for_agent(self, agent_name: str) -> list[str]:
-        """Return the Claude tool list a reactor may use (Codex → []; Claude → emit_intent; orchestration also gets context-pull tools + sandboxed Read)."""
+        """Return the Claude tool list a reactor may use (Codex → []; Claude → emit_intent; orchestration also gets context-pull tools + sandboxed Read).
+
+        Args:
+            agent_name: Identity of the reactor agent.
+
+        Returns:
+            The list of tool names the agent may use.
+        """
         role = self.role_registry.get(agent_name)
         if role is None:
             return []
@@ -583,7 +641,14 @@ class PolicyGate:
         return tools
 
     def allowed_tools_for_action(self, action_name: str) -> list[str]:
-        """Per-action tool intersection; action's declared ``allowed_tools`` or the default ``["emit_intent"]``."""
+        """Per-action tool intersection; action's declared ``allowed_tools`` or the default ``["emit_intent"]``.
+
+        Args:
+            action_name: The action to resolve tools for.
+
+        Returns:
+            The list of allowed tool names for the action.
+        """
         if self.action_registry is None:
             return ["emit_intent"]
         meta = self.action_registry.get(action_name)
@@ -992,7 +1057,17 @@ class PolicyGate:
         *,
         intent_kind: str,
     ) -> None:
-        """Reject an action the LLM cannot propose in the current phase (``strict_phase`` True raises, False warns; no-op when phase missing)."""
+        """Reject an action the LLM cannot propose in the current phase (``strict_phase`` True raises, False warns; no-op when phase missing).
+
+        Args:
+            role: The resolved role of the emitting agent.
+            action_name: The action being validated.
+            intent_kind: The intent kind (e.g. ``"delegate"``).
+
+        Raises:
+            PolicyDenied: If the action is not proposable in the phase and
+                ``strict_phase`` is enabled.
+        """
         if action_name in COORDINATOR_INTERNAL_ACTIONS:
             raise PolicyDenied(
                 f"action {action_name!r} is Coordinator-managed and not "
@@ -1060,7 +1135,15 @@ class PolicyGate:
         *,
         intent_kind: str,
     ) -> None:
-        """Reject GEMM tuning for non-FP8 sessions (it drives FP8 block-scale GEMM dispatch; the handler repeats the check)."""
+        """Reject GEMM tuning for non-FP8 sessions (it drives FP8 block-scale GEMM dispatch; the handler repeats the check).
+
+        Args:
+            action_name: The action being validated.
+            intent_kind: The intent kind (e.g. ``"delegate"``).
+
+        Raises:
+            PolicyDenied: If the action is FP8-only but the session is not FP8.
+        """
         if not action_name or action_name not in FP8_ONLY_ACTIONS:
             return
         state = self.shared_state
@@ -1087,7 +1170,15 @@ class PolicyGate:
         *,
         intent_kind: str,
     ) -> None:
-        """Reject any intent whose ``action_name`` / ``request.kind`` equals a Cortex KB write tool name (defense in depth; KB_design §3.11 §4.4 / Inv-11.3)."""
+        """Reject any intent whose ``action_name`` / ``request.kind`` equals a Cortex KB write tool name (defense in depth; KB_design §3.11 §4.4 / Inv-11.3).
+
+        Args:
+            action_name: The action / request kind being validated.
+            intent_kind: The intent kind (e.g. ``"delegate"``).
+
+        Raises:
+            PolicyDenied: If the name collides with a KB write tool.
+        """
         if not action_name:
             return
         if action_name not in KB_WRITE_TOOL_NAMES:
@@ -1113,7 +1204,16 @@ class PolicyGate:
         *,
         intent_kind: str,
     ) -> None:
-        """Reject an external tool name not on the caller's role whitelist (KB/PR/Web tools are specialist-only; KB_design §3.11 §4.5)."""
+        """Reject an external tool name not on the caller's role whitelist (KB/PR/Web tools are specialist-only; KB_design §3.11 §4.5).
+
+        Args:
+            role_name: The emitting role name.
+            action_name: The action / tool name being validated.
+            intent_kind: The intent kind (e.g. ``"delegate"``).
+
+        Raises:
+            PolicyDenied: If the tool is not whitelisted for the role.
+        """
         if not action_name:
             return
         # Skip KB write names (R4 owns them) so a write attempt yields ``kb_write_unauthorized``, not the less-specific R5 code.
@@ -1144,7 +1244,17 @@ class PolicyGate:
         source_role: str,
         phase: str | None = None,
     ) -> None:
-        """Raise :class:`PolicyDenied` if ``tool_name`` is not allowed for ``source_role`` (pure, Inv-11.1; ``phase`` no longer gates)."""
+        """Raise :class:`PolicyDenied` if ``tool_name`` is not allowed for ``source_role`` (pure, Inv-11.1; ``phase`` no longer gates).
+
+        Args:
+            tool_name: The canonical tool name being invoked.
+            source_role: The role invoking the tool.
+            phase: Current phase; retained for compatibility (no longer gates).
+
+        Raises:
+            PolicyDenied: If the tool is empty, a KB write, or not whitelisted
+                for the role.
+        """
         tool_name = (tool_name or "").strip()
         if not tool_name:
             raise PolicyDenied(
@@ -1184,7 +1294,15 @@ class PolicyGate:
     def _validate_sweep_singleton(
         self, payload: dict[str, Any], *, intent_kind: str,
     ) -> None:
-        """Enforce one sweep per SWEEP phase (Inv-9.4): deny agent sweeps once the auto-enqueued sweep landed (concurrent sweeps crash both vllm engines). Escape: ``params.bypass_sweep_singleton=True``."""
+        """Enforce one sweep per SWEEP phase (Inv-9.4): deny agent sweeps once the auto-enqueued sweep landed (concurrent sweeps crash both vllm engines). Escape: ``params.bypass_sweep_singleton=True``.
+
+        Args:
+            payload: The delegate/propose payload (may carry the bypass flag).
+            intent_kind: The intent kind (e.g. ``"delegate"``).
+
+        Raises:
+            PolicyDenied: If an auto-enqueued sweep already exists this phase.
+        """
         params = payload.get("params") or {}
         if isinstance(params, dict) and params.get("bypass_sweep_singleton"):
             return
@@ -1228,7 +1346,15 @@ class PolicyGate:
     def _validate_conc_sweep_singleton(
         self, payload: dict[str, Any], *, intent_kind: str,
     ) -> None:
-        """Enforce one conc_sweep per SWEEP phase (Bug #11); re-proposals burn GPU for no new data. Escape: ``params.bypass_conc_sweep_singleton=True``."""
+        """Enforce one conc_sweep per SWEEP phase (Bug #11); re-proposals burn GPU for no new data. Escape: ``params.bypass_conc_sweep_singleton=True``.
+
+        Args:
+            payload: The delegate/propose payload (may carry the bypass flag).
+            intent_kind: The intent kind (e.g. ``"delegate"``).
+
+        Raises:
+            PolicyDenied: If an auto-enqueued conc_sweep already exists this phase.
+        """
         params = payload.get("params") or {}
         if isinstance(params, dict) and params.get("bypass_conc_sweep_singleton"):
             return
@@ -1268,7 +1394,14 @@ class PolicyGate:
     def _validate_integrate_patch_critic_gate(
         self, payload: dict[str, Any],
     ) -> None:
-        """PR-A7: enforce ``integrate_patch_requires_critic_verdict`` (needs specialist_task_id + permissive verdict, unless ``params.bypass_critic=True``)."""
+        """PR-A7: enforce ``integrate_patch_requires_critic_verdict`` (needs specialist_task_id + permissive verdict, unless ``params.bypass_critic=True``).
+
+        Args:
+            payload: The integrate_patch delegate payload.
+
+        Raises:
+            PolicyDenied: If params are malformed or the critic gate is unmet.
+        """
         params = payload.get("params") or {}
         if not isinstance(params, dict):
             raise PolicyDenied(
@@ -1335,7 +1468,15 @@ class PolicyGate:
     def _validate_specialist_dispatch(
         self, role: "AgentRole", payload: dict[str, Any],
     ) -> None:
-        """Enforce the specialist-delegate contract (Inv-11.2): orchestration-only, tags ∈ vocab, gap_canonical_id required, max_turns ≤ cap."""
+        """Enforce the specialist-delegate contract (Inv-11.2): orchestration-only, tags ∈ vocab, gap_canonical_id required, max_turns ≤ cap.
+
+        Args:
+            role: The resolved role of the emitting agent.
+            payload: The specialist delegate payload.
+
+        Raises:
+            PolicyDenied: If any part of the specialist-dispatch contract fails.
+        """
         if role.name not in SPECIALIST_DISPATCH_SOURCE_ALLOWLIST:
             raise PolicyDenied(
                 f"role={role.name!r} cannot dispatch specialists "
@@ -1514,7 +1655,14 @@ class PolicyGate:
         validates only structural shape: a single ``task_description`` or a
         ``tasks=[...]`` wave (bounded by SPECIALIST_FREEFORM_WAVE_MAX), each
         with a non-empty, length-bounded description that survives the
-        red-line tripwire."""
+        red-line tripwire.
+
+        Args:
+            params: The freeform specialist delegate params.
+
+        Raises:
+            PolicyDenied: If the wave or task descriptions are malformed.
+        """
         wave = params.get("tasks")
         if wave is not None:
             if not isinstance(wave, list) or not wave:
@@ -1559,7 +1707,15 @@ class PolicyGate:
     @staticmethod
     def _check_freeform_task_description(desc: str, *, where: str) -> None:
         """Per-task structural checks for a free-form ``task_description``:
-        non-empty, length-bounded, and clear of the red-line tripwire."""
+        non-empty, length-bounded, and clear of the red-line tripwire.
+
+        Args:
+            desc: The task description to check.
+            where: Label identifying the task position, used in error messages.
+
+        Raises:
+            PolicyDenied: If the description is empty, too long, or tripwired.
+        """
         if not desc:
             raise PolicyDenied(
                 f"delegate{{action='specialist',scope='freeform'}}: "
@@ -1595,7 +1751,16 @@ class PolicyGate:
     def _validate_specialist_intent(
         self, from_agent: str, intent: Intent,
     ) -> None:
-        """Validate any intent emitted under a ``specialist:<task_id>`` identity (Inv-5.2: only SEND_MESSAGE, ALERT, and one SPECIALIST_DONE)."""
+        """Validate any intent emitted under a ``specialist:<task_id>`` identity (Inv-5.2: only SEND_MESSAGE, ALERT, and one SPECIALIST_DONE).
+
+        Args:
+            from_agent: The ``specialist:<task_id>`` emitting identity.
+            intent: The parsed intent to validate.
+
+        Raises:
+            PolicyDenied: If the task id is missing or the intent type is
+                not permitted for a specialist.
+        """
         task_id = from_agent.removeprefix(SPECIALIST_FROM_AGENT_PREFIX).strip()
         if not task_id:
             raise PolicyDenied(
@@ -1631,7 +1796,15 @@ class PolicyGate:
     def _validate_specialist_done_payload(
         self, task_id: str, payload: dict[str, Any],
     ) -> None:
-        """Per-field R3 structural checks for the ``specialist_done`` payload (gap_canonical_id, domain ∈ keys, proposal_set, empty+reason, summary ≤4096, confidence ∈ [0,1])."""
+        """Per-field R3 structural checks for the ``specialist_done`` payload (gap_canonical_id, domain ∈ keys, proposal_set, empty+reason, summary ≤4096, confidence ∈ [0,1]).
+
+        Args:
+            task_id: The specialist task id (for error context).
+            payload: The specialist_done payload to validate.
+
+        Raises:
+            PolicyDenied: If any required field is missing or malformed.
+        """
         gap = str(payload.get("gap_canonical_id") or "").strip()
         if not gap:
             raise PolicyDenied(
@@ -1806,14 +1979,31 @@ class PolicyGate:
         return any(s.startswith(p) for p in resolve_source_file_allowlist())
 
     def _path_in_trace_allowlist(self, value: str) -> bool:
-        """Match a value against runtime-resolved trace path prefixes (multi-node shared profile dir outside session_dir)."""
+        """Match a value against runtime-resolved trace path prefixes (multi-node shared profile dir outside session_dir).
+
+        Args:
+            value: The path string to test.
+
+        Returns:
+            True when ``value`` starts with an allowed trace path prefix.
+        """
         s = str(value)
         return any(s.startswith(p) for p in _trace_path_allowlist())
 
     def _validate_payload_paths(
         self, role: "AgentRole", intent_type: IntentType, payload: dict[str, Any],
     ) -> None:
-        """Walk payload (recursively); reject path-like values escaping session_dir. No-op when session_dir is None or strict_paths is False."""
+        """Walk payload (recursively); reject path-like values escaping session_dir. No-op when session_dir is None or strict_paths is False.
+
+        Args:
+            role: The resolved role of the emitting agent.
+            intent_type: The intent type being validated.
+            payload: The intent payload to walk.
+
+        Raises:
+            PolicyDenied: If a path-like value escapes session_dir and its
+                applicable allowlists.
+        """
         if self.session_dir is None or not self.strict_paths:
             return
 

--- a/inference_optimizer/orchestrator/policy.py
+++ b/inference_optimizer/orchestrator/policy.py
@@ -473,6 +473,12 @@ class PolicyGate:
     strict_phase: bool = False
 
     def __post_init__(self) -> None:  # noqa: D401 — dataclass hook
+        """Apply environment overrides for strict-mode flags.
+
+        Lets ``INFERENCE_OPTIMIZER_STRICT_PATHS`` and
+        ``INFERENCE_OPTIMIZER_STRICT_PHASE`` enable strict behavior
+        without threading a constructor argument through every caller.
+        """
         # Allow env to enable strict mode without threading a constructor arg through every caller.
         import os as _os
         if not self.strict_paths and _os.environ.get(
@@ -1874,6 +1880,18 @@ class PolicyGate:
     def _validate_robustness_only(
         self, role: "AgentRole", intent_type: IntentType, payload: dict[str, Any]
     ) -> None:
+        """Enforce that only allowed roles emit robustness-only intents.
+
+        Args:
+            role: The agent role attempting to emit the intent.
+            intent_type: The intent being validated.
+            payload: The intent payload (checked for required fields).
+
+        Raises:
+            PolicyDenied: If the role is not permitted to emit the intent,
+                or a required payload field (e.g. ``family`` for
+                ``PRUNE_BRANCH``) is missing.
+        """
         # Per-intent source override takes precedence; default is robustness-only.
         allowed_sources = _ROBUSTNESS_ONLY_INTENT_SOURCES.get(
             intent_type, ROBUSTNESS_ONLY_SOURCE_ALLOWLIST,

--- a/inference_optimizer/orchestrator/policy.py
+++ b/inference_optimizer/orchestrator/policy.py
@@ -46,7 +46,16 @@ if TYPE_CHECKING:  # pragma: no cover — type-only
 
 
 def _value_is_present(value: Any) -> bool:
-    """Present iff a non-empty string OR non-empty container; ``None`` / whitespace count as absent."""
+    """Present iff a non-empty string OR non-empty container; ``None`` / whitespace count as absent.
+
+    Args:
+        value (Any): the value to test for presence; strings are checked for
+            non-whitespace content and dict/list/tuple/set for non-empty length.
+
+    Returns:
+        bool: True when the value is considered present, False otherwise
+            (``None`` and whitespace-only strings count as absent).
+    """
     if value is None:
         return False
     if isinstance(value, str):
@@ -57,7 +66,17 @@ def _value_is_present(value: Any) -> bool:
 
 
 def _delegate_field_present(payload: dict[str, Any], field_name: str) -> bool:
-    """True iff ``field_name`` is present at the top of ``payload`` OR nested under ``payload["params"]`` (robustness uses params)."""
+    """True iff ``field_name`` is present at the top of ``payload`` OR nested under ``payload["params"]`` (robustness uses params).
+
+    Args:
+        payload (dict[str, Any]): the intent payload dict to inspect.
+        field_name (str): the field name to look for at the top level or nested
+            under ``payload["params"]``.
+
+    Returns:
+        bool: True when the field is present (non-empty) at either location,
+            else False.
+    """
     if _value_is_present(payload.get(field_name)):
         return True
     nested = payload.get("params")
@@ -131,7 +150,13 @@ RESEARCH_LANE_CEILING_FALLBACK: int = 2
 
 
 def detect_gpu_count() -> int:
-    """Best-effort visible-GPU count: env masks first, then ``rocm-smi``; 0 when nothing can be probed."""
+    """Best-effort visible-GPU count: env masks first, then ``rocm-smi``; 0 when nothing can be probed.
+
+    Returns:
+        int: the number of visible GPUs derived from ``HIP_VISIBLE_DEVICES`` /
+            ``CUDA_VISIBLE_DEVICES`` env masks, else the count parsed from
+            ``rocm-smi``; 0 when nothing can be probed.
+    """
     for env_name in ("HIP_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES"):
         raw = os.environ.get(env_name)
         if raw is None:
@@ -166,7 +191,12 @@ def detect_gpu_count() -> int:
 
 
 def research_lane_ceiling() -> int:
-    """Dynamic ceiling on concurrent research-lane specialists (``2 × GPU``; falls back to :data:`RESEARCH_LANE_CEILING_FALLBACK`)."""
+    """Dynamic ceiling on concurrent research-lane specialists (``2 × GPU``; falls back to :data:`RESEARCH_LANE_CEILING_FALLBACK`).
+
+    Returns:
+        int: twice the detected GPU count, or
+            :data:`RESEARCH_LANE_CEILING_FALLBACK` when no GPUs can be probed.
+    """
     gpus = detect_gpu_count()
     if gpus > 0:
         return 2 * gpus
@@ -174,7 +204,18 @@ def research_lane_ceiling() -> int:
 
 
 def gpu_specialist_ceiling(shared_state: Any | None = None) -> int:
-    """Configured GPU specialist capacity (separate from serving lanes; 0 disables ``needs_gpu=true`` dispatch)."""
+    """Configured GPU specialist capacity (separate from serving lanes; 0 disables ``needs_gpu=true`` dispatch).
+
+    Args:
+        shared_state (Any | None): optional SharedState whose
+            ``gpu_specialist_capacity`` is read first; when ``None`` the value
+            comes from the ``INFERENCE_OPTIMIZER_GPU_SPECIALIST_CAPACITY`` env
+            var.
+
+    Returns:
+        int: the configured GPU specialist capacity (0 when unset or
+            unparseable).
+    """
     if shared_state is not None:
         try:
             return max(0, int(
@@ -363,7 +404,13 @@ SOURCE_LIKE_FIELDS: frozenset[str] = frozenset({"source_file"})
 
 # Multi-node profile trace dirs live outside session_dir but must be referenceable by trace_dir / main_trace_path / trace_input (runtime-resolved).
 def _trace_path_allowlist() -> tuple[str, ...]:
-    """Multi-node profile trace path-prefix allowlist (runtime-resolved; trailing ``/`` is load-bearing for the startswith check)."""
+    """Multi-node profile trace path-prefix allowlist (runtime-resolved; trailing ``/`` is load-bearing for the startswith check).
+
+    Returns:
+        tuple[str, ...]: a single-element tuple holding the multi-node profile
+            trace root with a trailing ``/`` so prefix ``startswith`` checks are
+            path-boundary safe.
+    """
     from ..paths import mn_profile_trace_root
     root = str(mn_profile_trace_root()).rstrip("/") + "/"
     return (root,)
@@ -510,7 +557,18 @@ class PolicyGate:
 
     # Public API
     def validate_intent(self, from_agent: str, intent: Intent) -> None:
-        """Raise :class:`PolicyDenied` if the intent is not allowed (cheapest checks first: role → allowed_intents → structural → cross-source)."""
+        """Raise :class:`PolicyDenied` if the intent is not allowed (cheapest checks first: role → allowed_intents → structural → cross-source).
+
+        Args:
+            from_agent (str): the identity of the emitting agent; a
+                ``specialist:<task_id>`` prefix routes to the specialist
+                validators.
+            intent (Intent): the parsed intent to validate.
+
+        Raises:
+            PolicyDenied: when the intent is not permitted; the ``rule``
+                attribute identifies which guard fired.
+        """
         # specialist sub-agents emit under an ephemeral ``specialist:<task_id>`` identity routed to a synthetic role.
         if from_agent.startswith(SPECIALIST_FROM_AGENT_PREFIX):
             self._validate_specialist_intent(from_agent, intent)
@@ -562,7 +620,17 @@ class PolicyGate:
     def _closing_phase_denial(
         self, source: str, intent: Intent,
     ) -> PolicyDenied | None:
-        """During closing phase, allow only harmless intents and ``report`` proposals."""
+        """During closing phase, allow only harmless intents and ``report`` proposals.
+
+        Args:
+            source (str): the identity of the emitting agent.
+            intent (Intent): the intent being evaluated.
+
+        Returns:
+            PolicyDenied | None: ``None`` when the intent is permitted (or no
+                closing phase is active); otherwise a :class:`PolicyDenied`
+                describing the wind-down rejection.
+        """
         state = self.shared_state
         if state is None or not getattr(state, "closing_phase", False):
             return None
@@ -587,7 +655,16 @@ class PolicyGate:
         )
 
     def allowed_tools_for_agent(self, agent_name: str) -> list[str]:
-        """Return the Claude tool list a reactor may use (Codex → []; Claude → emit_intent; orchestration also gets context-pull tools + sandboxed Read)."""
+        """Return the Claude tool list a reactor may use (Codex → []; Claude → emit_intent; orchestration also gets context-pull tools + sandboxed Read).
+
+        Args:
+            agent_name (str): the name of the agent whose tool list is
+                requested.
+
+        Returns:
+            list[str]: the allowed tool names (empty for unknown or no-tool
+                roles).
+        """
         role = self.role_registry.get(agent_name)
         if role is None:
             return []
@@ -601,7 +678,16 @@ class PolicyGate:
         return tools
 
     def allowed_tools_for_action(self, action_name: str) -> list[str]:
-        """Per-action tool intersection; action's declared ``allowed_tools`` or the default ``["emit_intent"]``."""
+        """Per-action tool intersection; action's declared ``allowed_tools`` or the default ``["emit_intent"]``.
+
+        Args:
+            action_name (str): the action whose allowed tools are requested.
+
+        Returns:
+            list[str]: the action's declared ``allowed_tools``, or
+                ``["emit_intent"]`` when no registry is wired or the action is
+                unknown.
+        """
         if self.action_registry is None:
             return ["emit_intent"]
         meta = self.action_registry.get(action_name)
@@ -1021,7 +1107,21 @@ class PolicyGate:
         *,
         intent_kind: str,
     ) -> None:
-        """Reject an action the LLM cannot propose in the current phase (``strict_phase`` True raises, False warns; no-op when phase missing)."""
+        """Reject an action the LLM cannot propose in the current phase (``strict_phase`` True raises, False warns; no-op when phase missing).
+
+        Args:
+            role (AgentRole): the resolved role of the emitting agent.
+            action_name (str): the action name being checked against the phase
+                contract.
+            intent_kind (str): the channel the action arrived on (``delegate`` /
+                ``propose_action`` / ``request``), used in audit and error
+                messages.
+
+        Raises:
+            PolicyDenied: when the action is Coordinator-managed, ``explore`` is
+                disabled for the run, or (under ``strict_phase``) the action is
+                not LLM-proposable in the current phase.
+        """
         if action_name in COORDINATOR_INTERNAL_ACTIONS:
             raise PolicyDenied(
                 f"action {action_name!r} is Coordinator-managed and not "
@@ -1115,7 +1215,17 @@ class PolicyGate:
         *,
         intent_kind: str,
     ) -> None:
-        """Reject GEMM tuning for non-FP8 sessions (it drives FP8 block-scale GEMM dispatch; the handler repeats the check)."""
+        """Reject GEMM tuning for non-FP8 sessions (it drives FP8 block-scale GEMM dispatch; the handler repeats the check).
+
+        Args:
+            action_name (str): the action name being checked.
+            intent_kind (str): the channel the action arrived on, used in the
+                error hint.
+
+        Raises:
+            PolicyDenied: when an FP8-only action is requested but the session
+                precision is not ``fp8``.
+        """
         if not action_name or action_name not in FP8_ONLY_ACTIONS:
             return
         state = self.shared_state
@@ -1142,7 +1252,17 @@ class PolicyGate:
         *,
         intent_kind: str,
     ) -> None:
-        """Reject any intent whose ``action_name`` / ``request.kind`` equals a Cortex KB write tool name (defense in depth; KB_design §3.11 §4.4 / Inv-11.3)."""
+        """Reject any intent whose ``action_name`` / ``request.kind`` equals a Cortex KB write tool name (defense in depth; KB_design §3.11 §4.4 / Inv-11.3).
+
+        Args:
+            action_name (str): the action name (or REQUEST ``kind``) being
+                checked.
+            intent_kind (str): the channel the action arrived on, used in the
+                error message.
+
+        Raises:
+            PolicyDenied: when the name targets a KB write surface.
+        """
         if not action_name:
             return
         if action_name not in KB_WRITE_TOOL_NAMES:
@@ -1168,7 +1288,19 @@ class PolicyGate:
         *,
         intent_kind: str,
     ) -> None:
-        """Reject an external tool name not on the caller's role whitelist (KB/PR/Web tools are specialist-only; KB_design §3.11 §4.5)."""
+        """Reject an external tool name not on the caller's role whitelist (KB/PR/Web tools are specialist-only; KB_design §3.11 §4.5).
+
+        Args:
+            role_name (str): the name of the emitting role.
+            action_name (str): the action name (or REQUEST ``kind``) being
+                checked.
+            intent_kind (str): the channel the action arrived on, used in the
+                error message.
+
+        Raises:
+            PolicyDenied: when the name is a known external tool not whitelisted
+                for the role.
+        """
         if not action_name:
             return
         # Skip KB write names (R4 owns them) so a write attempt yields ``kb_write_unauthorized``, not the less-specific R5 code.
@@ -1199,7 +1331,18 @@ class PolicyGate:
         source_role: str,
         phase: str | None = None,
     ) -> None:
-        """Raise :class:`PolicyDenied` if ``tool_name`` is not allowed for ``source_role`` (pure, Inv-11.1; ``phase`` no longer gates)."""
+        """Raise :class:`PolicyDenied` if ``tool_name`` is not allowed for ``source_role`` (pure, Inv-11.1; ``phase`` no longer gates).
+
+        Args:
+            tool_name (str): the canonical tool name to validate.
+            source_role (str): the role attempting to invoke the tool.
+            phase (str | None): the current phase; retained for signature
+                compatibility but no longer used to gate.
+
+        Raises:
+            PolicyDenied: when ``tool_name`` is empty, a KB write surface, or a
+                known external tool not whitelisted for ``source_role``.
+        """
         tool_name = (tool_name or "").strip()
         if not tool_name:
             raise PolicyDenied(
@@ -1239,7 +1382,19 @@ class PolicyGate:
     def _validate_sweep_singleton(
         self, payload: dict[str, Any], *, intent_kind: str,
     ) -> None:
-        """Enforce one sweep per SWEEP phase (Inv-9.4): deny agent sweeps once the auto-enqueued sweep landed (concurrent sweeps crash both vllm engines). Escape: ``params.bypass_sweep_singleton=True``."""
+        """Enforce one sweep per SWEEP phase (Inv-9.4): deny agent sweeps once the auto-enqueued sweep landed (concurrent sweeps crash both vllm engines). Escape: ``params.bypass_sweep_singleton=True``.
+
+        Args:
+            payload (dict[str, Any]): the intent payload;
+                ``params.bypass_sweep_singleton`` opts out of the singleton
+                guard.
+            intent_kind (str): the channel the action arrived on, used in the
+                error hint.
+
+        Raises:
+            PolicyDenied: when the SWEEP phase already carries an auto-enqueued
+                sweep task and no bypass flag is set.
+        """
         params = payload.get("params") or {}
         if isinstance(params, dict) and params.get("bypass_sweep_singleton"):
             return
@@ -1283,7 +1438,19 @@ class PolicyGate:
     def _validate_conc_sweep_singleton(
         self, payload: dict[str, Any], *, intent_kind: str,
     ) -> None:
-        """Enforce one conc_sweep per SWEEP phase (Bug #11); re-proposals burn GPU for no new data. Escape: ``params.bypass_conc_sweep_singleton=True``."""
+        """Enforce one conc_sweep per SWEEP phase (Bug #11); re-proposals burn GPU for no new data. Escape: ``params.bypass_conc_sweep_singleton=True``.
+
+        Args:
+            payload (dict[str, Any]): the intent payload;
+                ``params.bypass_conc_sweep_singleton`` opts out of the singleton
+                guard.
+            intent_kind (str): the channel the action arrived on, used in the
+                error hint.
+
+        Raises:
+            PolicyDenied: when the SWEEP phase already carries an auto-enqueued
+                conc_sweep task and no bypass flag is set.
+        """
         params = payload.get("params") or {}
         if isinstance(params, dict) and params.get("bypass_conc_sweep_singleton"):
             return
@@ -1323,7 +1490,19 @@ class PolicyGate:
     def _validate_integrate_patch_critic_gate(
         self, payload: dict[str, Any],
     ) -> None:
-        """PR-A7: enforce ``integrate_patch_requires_critic_verdict`` (needs specialist_task_id + permissive verdict, unless ``params.bypass_critic=True``)."""
+        """PR-A7: enforce ``integrate_patch_requires_critic_verdict`` (needs specialist_task_id + permissive verdict, unless ``params.bypass_critic=True``).
+
+        Args:
+            payload (dict[str, Any]): the integrate_patch intent payload
+                carrying ``params`` with ``specialist_task_id`` and optional
+                ``bypass_critic``.
+
+        Raises:
+            PolicyDenied: when ``params`` is malformed, ``specialist_task_id``
+                is missing, no Critic verdict is on record, or the verdict is
+                not in :data:`INTEGRATE_PATCH_PERMISSIVE_VERDICTS` (and no
+                bypass).
+        """
         params = payload.get("params") or {}
         if not isinstance(params, dict):
             raise PolicyDenied(
@@ -1390,7 +1569,18 @@ class PolicyGate:
     def _validate_specialist_dispatch(
         self, role: "AgentRole", payload: dict[str, Any],
     ) -> None:
-        """Enforce the specialist-delegate contract (Inv-11.2): orchestration-only, tags ∈ vocab, gap_canonical_id required, max_turns ≤ cap."""
+        """Enforce the specialist-delegate contract (Inv-11.2): orchestration-only, tags ∈ vocab, gap_canonical_id required, max_turns ≤ cap.
+
+        Args:
+            role (AgentRole): the resolved role of the emitting agent.
+            payload (dict[str, Any]): the delegate intent payload carrying
+                ``params`` (tags, scope, gap_canonical_id, max_turns, ...).
+
+        Raises:
+            PolicyDenied: when the role may not dispatch, params are malformed,
+                tags are unknown, the scope is invalid, the gap id is missing,
+                or max_turns is out of range.
+        """
         if role.name not in SPECIALIST_DISPATCH_SOURCE_ALLOWLIST:
             raise PolicyDenied(
                 f"role={role.name!r} cannot dispatch specialists "
@@ -1551,6 +1741,14 @@ class PolicyGate:
         ``needs_gpu``) and later becomes a GPU-needing queued task that can stall
         forever when the pool is disabled (``--gpu-specialist-capacity 0``)
         rather than being rejected at the policy layer.
+
+        Args:
+            params (dict[str, Any]): the specialist dispatch ``params`` carrying
+                ``needs_gpu`` and optional ``gpu_count``.
+
+        Raises:
+            PolicyDenied: when ``gpu_count`` is invalid, the GPU specialist pool
+                is disabled, or the request exceeds the pool ceiling.
         """
         needs_gpu_raw = params.get("needs_gpu", False)
         if isinstance(needs_gpu_raw, str):
@@ -1614,6 +1812,15 @@ class PolicyGate:
         least-attempted, then the oldest (most-stalled) gap. Mutates ``params``
         in place and returns the chosen canonical id (``""`` when nothing
         matches, leaving the caller's required-gap rejection intact).
+
+        Args:
+            params (dict[str, Any]): the dispatch ``params``; mutated in place
+                with the chosen ``gap_canonical_id`` when a match is found.
+            tags (list[str]): the knowledge-domain tags used to build the anchor
+                candidate set.
+
+        Returns:
+            str: the chosen canonical gap id, or ``""`` when no gap matches.
         """
         state = getattr(self, "shared_state", None)
         gaps = list(getattr(state, "gaps", None) or []) if state is not None else []
@@ -1643,6 +1850,16 @@ class PolicyGate:
         severity_rank = {"high": 3, "medium": 2, "low": 1}
 
         def _selection_key(g: dict[str, Any]) -> tuple[int, int, str]:
+            """Sort key ranking gaps by actionability for autofill.
+
+            Args:
+                g (dict[str, Any]): a gaps[] ledger entry.
+
+            Returns:
+                tuple[int, int, str]: ``(-severity_rank, attempt_count,
+                first_seen_ts)`` so the highest-severity, least-attempted,
+                oldest gap sorts first.
+            """
             sev = severity_rank.get(str(g.get("severity") or "").lower(), 0)
             attempts = len(g.get("attempts") or [])
             first_seen = str(g.get("first_seen_ts") or "")
@@ -1672,7 +1889,17 @@ class PolicyGate:
         validates only structural shape: a single ``task_description`` or a
         ``tasks=[...]`` wave (bounded by SPECIALIST_FREEFORM_WAVE_MAX), each
         with a non-empty, length-bounded description that survives the
-        red-line tripwire."""
+        red-line tripwire.
+
+        Args:
+            params (dict[str, Any]): the freeform dispatch ``params`` carrying a
+                single ``task_description`` or a ``tasks`` wave.
+
+        Raises:
+            PolicyDenied: when the GPU request fails, the wave is malformed or
+                too large, or a task description is empty / too long / trips the
+                red-line tripwire.
+        """
         # Freeform skips the domain-anchored max_turns gate by design (it
         # carries no domain/gap), but a GPU request must still clear the same
         # pool ceiling as a domain specialist — otherwise scope='freeform'
@@ -1722,7 +1949,17 @@ class PolicyGate:
     @staticmethod
     def _check_freeform_task_description(desc: str, *, where: str) -> None:
         """Per-task structural checks for a free-form ``task_description``:
-        non-empty, length-bounded, and clear of the red-line tripwire."""
+        non-empty, length-bounded, and clear of the red-line tripwire.
+
+        Args:
+            desc (str): the freeform task description to validate.
+            where (str): a label identifying the source location, used in error
+                messages.
+
+        Raises:
+            PolicyDenied: when ``desc`` is empty, exceeds the length cap, or
+                matches a red-line pattern.
+        """
         if not desc:
             raise PolicyDenied(
                 f"delegate{{action='specialist',scope='freeform'}}: "
@@ -1758,7 +1995,17 @@ class PolicyGate:
     def _validate_specialist_intent(
         self, from_agent: str, intent: Intent,
     ) -> None:
-        """Validate any intent emitted under a ``specialist:<task_id>`` identity (Inv-5.2: only SEND_MESSAGE, ALERT, and one SPECIALIST_DONE)."""
+        """Validate any intent emitted under a ``specialist:<task_id>`` identity (Inv-5.2: only SEND_MESSAGE, ALERT, and one SPECIALIST_DONE).
+
+        Args:
+            from_agent (str): the ``specialist:<task_id>`` identity of the
+                emitter.
+            intent (Intent): the intent emitted under that identity.
+
+        Raises:
+            PolicyDenied: when the task_id suffix is missing or the intent type
+                is not one a specialist may emit.
+        """
         task_id = from_agent.removeprefix(SPECIALIST_FROM_AGENT_PREFIX).strip()
         if not task_id:
             raise PolicyDenied(
@@ -1794,7 +2041,18 @@ class PolicyGate:
     def _validate_specialist_done_payload(
         self, task_id: str, payload: dict[str, Any],
     ) -> None:
-        """Per-field R3 structural checks for the ``specialist_done`` payload (gap_canonical_id, domain ∈ keys, proposal_set, empty+reason, summary ≤4096, confidence ∈ [0,1])."""
+        """Per-field R3 structural checks for the ``specialist_done`` payload (gap_canonical_id, domain ∈ keys, proposal_set, empty+reason, summary ≤4096, confidence ∈ [0,1]).
+
+        Args:
+            task_id (str): the specialist task id taken from the emitting
+                identity.
+            payload (dict[str, Any]): the specialist_done payload to validate.
+
+        Raises:
+            PolicyDenied: when any required field is missing or malformed (gap
+                id, domain, proposal_set, empty+reason, summary length, or
+                confidence range).
+        """
         gap = str(payload.get("gap_canonical_id") or "").strip()
         if not gap:
             raise PolicyDenied(
@@ -1969,14 +2227,34 @@ class PolicyGate:
         return any(s.startswith(p) for p in resolve_source_file_allowlist())
 
     def _path_in_trace_allowlist(self, value: str) -> bool:
-        """Match a value against runtime-resolved trace path prefixes (multi-node shared profile dir outside session_dir)."""
+        """Match a value against runtime-resolved trace path prefixes (multi-node shared profile dir outside session_dir).
+
+        Args:
+            value (str): the path string to test.
+
+        Returns:
+            bool: True when ``value`` starts with any runtime-resolved trace
+                path prefix, else False.
+        """
         s = str(value)
         return any(s.startswith(p) for p in _trace_path_allowlist())
 
     def _validate_payload_paths(
         self, role: "AgentRole", intent_type: IntentType, payload: dict[str, Any],
     ) -> None:
-        """Walk payload (recursively); reject path-like values escaping session_dir. No-op when session_dir is None or strict_paths is False."""
+        """Walk payload (recursively); reject path-like values escaping session_dir. No-op when session_dir is None or strict_paths is False.
+
+        Args:
+            role (AgentRole): the resolved role of the emitting agent, used in
+                error messages.
+            intent_type (IntentType): the intent type, used in error messages.
+            payload (dict[str, Any]): the intent payload to walk for path-like
+                fields.
+
+        Raises:
+            PolicyDenied: when a path-like value escapes session_dir and its
+                applicable allowlists.
+        """
         if self.session_dir is None or not self.strict_paths:
             return
 

--- a/inference_optimizer/orchestrator/pr_monitor.py
+++ b/inference_optimizer/orchestrator/pr_monitor.py
@@ -155,6 +155,17 @@ class PRMonitorClient:
         """GET ``base_url + path`` with ``params``; parsed JSON or raises.
 
         Response size capped at 4 MiB as defense-in-depth.
+
+        Args:
+            path: The endpoint path appended to ``base_url``.
+            params: Optional query parameters (empty/``None`` values dropped).
+
+        Returns:
+            The parsed JSON response.
+
+        Raises:
+            PRMonitorError: If the client is disabled, the request fails, or
+                the response is not valid JSON.
         """
         if not self.enabled:
             raise PRMonitorError("PR Monitor client disabled (--degraded-pr)")
@@ -214,6 +225,9 @@ class PRMonitorClient:
 
         Accepts either the array or ``{"items": [...]}`` shape and either
         ``repo_name``/``name`` field; skips ``is_active=False`` entries.
+
+        Returns:
+            The active repo names, or ``[]`` on failure.
         """
         try:
             data = self._get_json("/repos")
@@ -249,6 +263,15 @@ class PRMonitorClient:
 
         Returns :class:`PRSummary` list (empty on failure). Cached by
         rendered URL to avoid re-hitting the network within a tick.
+
+        Args:
+            repo: Canonical ``owner/name`` repo identifier.
+            state: PR state filter (``all`` / ``open`` / ``closed``).
+            since: Optional ISO lower bound on ``updated_at``.
+            limit: Maximum number of PRs to fetch.
+
+        Returns:
+            The PR summaries, or ``[]`` on failure.
         """
         params = {
             "state": state,
@@ -346,7 +369,19 @@ class PRMonitorClient:
         total_budget_sec: float = DEFAULT_PR_FEED_TOTAL_BUDGET_SEC,
         now: datetime | None = None,
     ) -> tuple[list[PRSummary], list[str]]:
-        """Return ``(prs, warnings)`` for the union of ``repos``."""
+        """Return ``(prs, warnings)`` for the union of ``repos``.
+
+        Args:
+            repos: The repos to fetch and union.
+            keywords: Optional keyword filter applied to each PR.
+            window_days: Lookback window in days for the ``since`` bound.
+            per_repo_limit: Maximum PRs fetched per repo.
+            total_budget_sec: Total wall-clock budget across all repos.
+            now: Optional reference time (for tests); defaults to current UTC.
+
+        Returns:
+            A ``(prs, warnings)`` tuple; PRs are sorted newest-first.
+        """
         out: list[PRSummary] = []
         warns: list[str] = []
         if not self.enabled:
@@ -399,6 +434,18 @@ class PRMonitorClient:
         """Same as :meth:`list_prs` but re-raises :class:`PRMonitorError`.
 
         Lets :meth:`pr_feed_warm` distinguish empty-window from fetch-failed.
+
+        Args:
+            repo: Canonical ``owner/name`` repo identifier.
+            state: PR state filter (``all`` / ``open`` / ``closed``).
+            since: Optional ISO lower bound on ``updated_at``.
+            limit: Maximum number of PRs to fetch.
+
+        Returns:
+            The PR summaries for the repo.
+
+        Raises:
+            PRMonitorError: If the underlying HTTP fetch fails.
         """
         params: dict[str, Any] = {
             "state": state,
@@ -457,7 +504,16 @@ class PRMonitorClient:
 
 
 def _matches_keywords(pr: PRSummary, keywords_lower: list[str]) -> bool:
-    """Return True iff ``pr`` (title + labels + body snippet) mentions any keyword."""
+    """Return True iff ``pr`` (title + labels + body snippet) mentions any keyword.
+
+    Args:
+        pr: The PR summary to test.
+        keywords_lower: Lowercased keywords to match (empty matches all).
+
+    Returns:
+        ``True`` when any keyword appears in the PR's title, labels, or body
+        snippet (or when no keywords are given).
+    """
     if not keywords_lower:
         return True
     haystack = " ".join([

--- a/inference_optimizer/orchestrator/proposal_scorer.py
+++ b/inference_optimizer/orchestrator/proposal_scorer.py
@@ -95,6 +95,15 @@ def _extract_scores_json(text: str) -> dict[str, Any] | None:
 
 
 def _clip(value: Any, *, limit: int = _MAX_FIELD_CHARS) -> str:
+    """Stringify a value and truncate it to a maximum length.
+
+    Args:
+        value: Value to stringify (``None`` becomes an empty string).
+        limit: Maximum number of characters to keep.
+
+    Returns:
+        The string, suffixed with an ellipsis if it was truncated.
+    """
     s = "" if value is None else str(value)
     return s if len(s) <= limit else (s[:limit] + "…")
 
@@ -161,6 +170,13 @@ class ProposalScorer:
     _client: Any = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
+        """Normalize the model list and optionally eager-build the client.
+
+        Strips and de-blanks the configured model names. If a
+        ``client_factory`` is provided the client is built immediately;
+        otherwise it is constructed lazily on first use so an
+        unconfigured environment degrades per-call rather than at boot.
+        """
         self.models = tuple(
             m for m in (str(x).strip() for x in (self.models or ())) if m
         )
@@ -171,6 +187,15 @@ class ProposalScorer:
         self._client = None
 
     def _ensure_client(self) -> Any:
+        """Return the cached client, constructing one on first use.
+
+        Returns:
+            The OpenAI-compatible async client.
+
+        Raises:
+            RuntimeError: If the ``openai`` SDK is missing or no API key
+                is configured in the environment.
+        """
         if self._client is not None:
             return self._client
         try:

--- a/inference_optimizer/orchestrator/proposal_scorer.py
+++ b/inference_optimizer/orchestrator/proposal_scorer.py
@@ -71,7 +71,14 @@ _BARE_JSON_RE = re.compile(r"(\{.*?\"scores\".*\})", re.DOTALL)
 
 
 def _extract_scores_json(text: str) -> dict[str, Any] | None:
-    """Pull the first valid ``{"scores": {...}}`` object out of a reply."""
+    """Pull the first valid ``{"scores": {...}}`` object out of a reply.
+
+    Args:
+        text: Raw model reply that may contain a fenced or bare JSON object.
+
+    Returns:
+        The parsed ``{"scores": {...}}`` dict, or ``None`` if none was found.
+    """
     if not text:
         return None
     for m in _FENCED_JSON_RE.finditer(text):
@@ -109,7 +116,15 @@ def _clip(value: Any, *, limit: int = _MAX_FIELD_CHARS) -> str:
 
 
 def _coerce_score(raw: Any) -> float | None:
-    """Coerce a model-emitted score into a clamped [0, 10] float."""
+    """Coerce a model-emitted score into a clamped [0, 10] float.
+
+    Args:
+        raw: Raw score value emitted by a model.
+
+    Returns:
+        The score clamped to ``[0, 10]``, or ``None`` if it could not be
+        coerced to a finite number.
+    """
     try:
         val = float(raw)
     except (TypeError, ValueError):
@@ -122,7 +137,16 @@ def _coerce_score(raw: Any) -> float | None:
 def _normalise_model_scores(
     parsed: dict[str, Any], *, proposal_names: list[str],
 ) -> dict[str, dict[str, Any]]:
-    """Project parsed ``{"scores": {...}}`` onto known names (drop unknowns, clamp [0,10], truncate reasons)."""
+    """Project parsed ``{"scores": {...}}`` onto known names (drop unknowns, clamp [0,10], truncate reasons).
+
+    Args:
+        parsed: A parsed ``{"scores": {...}}`` dict from a model reply.
+        proposal_names: Names of the proposals that were actually scored;
+            scores for any other name are discarded.
+
+    Returns:
+        A mapping of proposal name to its clamped score and truncated reason.
+    """
     out: dict[str, dict[str, Any]] = {}
     scores = parsed.get("scores")
     if not isinstance(scores, dict):
@@ -227,7 +251,15 @@ class ProposalScorer:
     def _build_prompt(
         self, *, gap: dict[str, Any], proposals: list[dict[str, Any]],
     ) -> str:
-        """Build ONE group-scoring prompt covering every proposal."""
+        """Build ONE group-scoring prompt covering every proposal.
+
+        Args:
+            gap: The gap being addressed (domain, symptom, evidence, etc.).
+            proposals: Candidate variants to embed in the prompt.
+
+        Returns:
+            The assembled prompt text describing the gap and proposals.
+        """
         lines: list[str] = ["=== Gap ==="]
         lines.append(f"domain: {_clip(gap.get('domain'), limit=80)}")
         lines.append(
@@ -262,7 +294,20 @@ class ProposalScorer:
     async def _score_one_model(
         self, model: str, prompt: str, proposal_names: list[str],
     ) -> dict[str, dict[str, Any]]:
-        """Score every proposal with a single model (raises on failure; caller records the per-model error)."""
+        """Score every proposal with a single model (raises on failure; caller records the per-model error).
+
+        Args:
+            model: The model slug to score with.
+            prompt: The base scoring prompt (instructions are appended).
+            proposal_names: Names of the proposals being scored.
+
+        Returns:
+            A mapping of proposal name to its normalised score and reason.
+
+        Raises:
+            RuntimeError: If the call times out or the reply has no
+                parseable scores JSON.
+        """
         client = self._ensure_client()
         full_prompt = f"{prompt}\n\n{_SCORING_INSTRUCTIONS}"
         messages = [{"role": "user", "content": full_prompt}]
@@ -301,6 +346,10 @@ class ProposalScorer:
         phase are unknown here (the scorer runs off the dispatch path) — the
         collector backfills phase from the ts window. Best-effort: never
         raises into the scoring path.
+
+        Args:
+            model: The model slug whose usage is being recorded.
+            usage: The OpenAI usage object from the response, or ``None``.
         """
         if self.session_dir is None:
             return
@@ -339,6 +388,11 @@ class ProposalScorer:
         unknown here (the scorer runs off the dispatch path); the collector
         backfills phase from the ts window. Best-effort: never raises into
         the scoring path.
+
+        Args:
+            model: The model slug whose conversation is being recorded.
+            prompt: The full (redacted) scoring prompt sent to the model.
+            response: The model's reply text.
         """
         if self.session_dir is None:
             return
@@ -363,7 +417,16 @@ class ProposalScorer:
     async def score(
         self, *, gap: dict[str, Any], proposals: list[dict[str, Any]],
     ) -> dict[str, Any]:
-        """Score ``proposals`` against ``gap`` with every configured model (per-model failures land in ``errors``, never raised)."""
+        """Score ``proposals`` against ``gap`` with every configured model (per-model failures land in ``errors``, never raised).
+
+        Args:
+            gap: The gap the proposals are meant to address.
+            proposals: Candidate variants to score (non-dict entries ignored).
+
+        Returns:
+            A dict with the scoring ``scale``, per-model ``models`` scores,
+            and per-model ``errors``.
+        """
         proposals = [p for p in (proposals or []) if isinstance(p, dict)]
         if not proposals or not self.models:
             return {"scale": "0-10", "models": {}, "errors": {}}

--- a/inference_optimizer/orchestrator/quantization_request_handlers.py
+++ b/inference_optimizer/orchestrator/quantization_request_handlers.py
@@ -34,6 +34,17 @@ async def run_quantization_prelude_async(
     Awaits the async ``quantize_via_prompt`` directly (the caller already
     runs inside ``asyncio.run``). Raises ``SystemExit(3)`` when no usable
     quantized model was produced.
+
+    Args:
+        prompt: User-provided quantization instructions (e.g. scheme text).
+        source_model: Path to the model to quantize.
+        workspace: Working directory; the quantized model is exported under it.
+
+    Returns:
+        The path to the exported quantized model directory.
+
+    Raises:
+        SystemExit: If quantization failed or produced no usable model.
     """
     # quantization_agent is a top-level package (sibling of inference_optimizer);
     # imported lazily so this module loads even where its deps are absent.
@@ -98,6 +109,14 @@ def run_quantization_prelude(
     DO NOT call from within a running event loop — the cli prelude awaits
     :func:`run_quantization_prelude_async` directly because ``_run_optimize``
     already runs under ``asyncio.run``.
+
+    Args:
+        prompt: User-provided quantization instructions (e.g. scheme text).
+        source_model: Path to the model to quantize.
+        workspace: Working directory; the quantized model is exported under it.
+
+    Returns:
+        The path to the exported quantized model directory.
     """
     return asyncio.run(
         run_quantization_prelude_async(

--- a/inference_optimizer/orchestrator/quantization_schemes.py
+++ b/inference_optimizer/orchestrator/quantization_schemes.py
@@ -49,6 +49,12 @@ def supported_schemes(gpu_type: str | None) -> list[str]:
 
     MI355X gets the full set; every other (DCGPU) target drops the
     ``mxfp4`` / ``mxfp4_fp8`` MI355X-only schemes.
+
+    Args:
+        gpu_type: The target GPU type, or ``None``/empty for non-MI355X.
+
+    Returns:
+        The list of schemes selectable on the given GPU type.
     """
     if (gpu_type or "").strip().lower() == "mi355x":
         return list(SUPPORTED_SCHEMES)
@@ -64,6 +70,15 @@ def validate_scheme(scheme: str | None, gpu_type: str | None) -> None:
     (the real GPU is resolved later via the rocm-smi probe) the hardware
     constraint is not enforced here — the constraint check needs a concrete
     target to act on.
+
+    Args:
+        scheme: The requested quantization scheme, or the ``none`` sentinel.
+        gpu_type: The target GPU type used to enforce hardware constraints.
+
+    Raises:
+        ValueError: If ``scheme`` is not a known supported scheme.
+        SchemeNotSupportedError: If an MI355X-only scheme is requested on a
+            known non-MI355X target.
     """
     if not scheme or scheme == NO_QUANTIZATION:
         return
@@ -106,7 +121,14 @@ class QuantizationConfig:
 
 
 def _join_clauses(items: Sequence[str]) -> str:
-    """Join clauses as ``a``, ``a and b``, or ``a, b and c``."""
+    """Join clauses as ``a``, ``a and b``, or ``a, b and c``.
+
+    Args:
+        items: The clause strings to join.
+
+    Returns:
+        The natural-language conjunction, or ``""`` when ``items`` is empty.
+    """
     items = list(items)
     if not items:
         return ""
@@ -202,6 +224,15 @@ def build_quantization_prompt(
     (no hard-coded defaults). ``model_path`` / ``skill_path`` / ``gpu_type``
     populate the intro line; the inference_optimizer prelude leaves them unset
     because its adapter folds the source model + export dir into the prompt.
+
+    Args:
+        cfg: The structured quantization config to render.
+        model_path: Optional source model path for the intro line.
+        gpu_type: Optional target GPU type for the intro line.
+        skill_path: Optional skill path referenced in the intro line.
+
+    Returns:
+        The composed natural-language quantization prompt.
     """
     paragraphs: list[str] = []
 
@@ -232,6 +263,16 @@ def resolve_scheme_prompt(scheme: str | None) -> str | None:
     Quark's intake + plan skill supplies those. Per-layer overrides and the
     other §4 knobs travel through :func:`build_quantization_prompt` with a fully
     populated :class:`QuantizationConfig` (the structured UI path).
+
+    Args:
+        scheme: The global scheme enum, or the ``none`` sentinel.
+
+    Returns:
+        The rendered ``--quantize`` prompt, or ``None`` when ``scheme`` is
+        falsy or ``"none"``.
+
+    Raises:
+        ValueError: If ``scheme`` is a non-empty unknown scheme.
     """
     if not scheme or scheme == NO_QUANTIZATION:
         return None

--- a/inference_optimizer/orchestrator/quantization_schemes.py
+++ b/inference_optimizer/orchestrator/quantization_schemes.py
@@ -116,6 +116,15 @@ def _join_clauses(items: Sequence[str]) -> str:
 
 
 def _strategy_paragraph(cfg: QuantizationConfig) -> str:
+    """Render the quantization-strategy paragraph for a prompt.
+
+    Args:
+        cfg: Quantization configuration to describe.
+
+    Returns:
+        A prose paragraph covering the global scheme, layer overrides,
+        kv-cache handling, exclusions, and output directory.
+    """
     sentences = [f"Apply {cfg.global_scheme} as the global quantization scheme."]
     if cfg.layer_overrides:
         clauses = [
@@ -136,6 +145,15 @@ def _strategy_paragraph(cfg: QuantizationConfig) -> str:
 
 
 def _calibration_paragraph(cfg: QuantizationConfig) -> str | None:
+    """Render the calibration paragraph, composing only set fields.
+
+    Args:
+        cfg: Quantization configuration to describe.
+
+    Returns:
+        A calibration paragraph, or ``None`` when no calibration fields
+        are configured.
+    """
     if cfg.calib_dataset is None and cfg.num_calib_data is None and cfg.seq_len is None:
         return None
     # Compose only the parts that were set, e.g. "Calibrate with the pileval
@@ -151,6 +169,15 @@ def _calibration_paragraph(cfg: QuantizationConfig) -> str | None:
 
 
 def _evaluation_paragraph(cfg: QuantizationConfig) -> str | None:
+    """Render the evaluation paragraph describing the accuracy budget.
+
+    Args:
+        cfg: Quantization configuration to describe.
+
+    Returns:
+        An evaluation paragraph, or ``None`` when no acceptable eval gap
+        is configured.
+    """
     if cfg.acceptable_eval_gap is None:
         return None
     pct = f"{cfg.acceptable_eval_gap * 100:g}"

--- a/inference_optimizer/orchestrator/research_hints.py
+++ b/inference_optimizer/orchestrator/research_hints.py
@@ -74,6 +74,14 @@ def load_hints(session_dir: Path) -> list[dict[str, Any]]:
 
 
 def _render_md(hints: list[dict[str, Any]]) -> str:
+    """Render research hints as a Markdown document.
+
+    Args:
+        hints: Normalized hint records.
+
+    Returns:
+        Markdown text, with a placeholder note when there are no hints.
+    """
     lines = ["# Research Hints", ""]
     if not hints:
         lines += [
@@ -97,6 +105,12 @@ def _render_md(hints: list[dict[str, Any]]) -> str:
 
 
 def _atomic_write(path: Path, text: str) -> None:
+    """Write text to a file atomically via a temp file and rename.
+
+    Args:
+        path: Destination file path.
+        text: Text content to write.
+    """
     tmp = path.with_suffix(path.suffix + ".tmp")
     tmp.write_text(text, encoding="utf-8")
     os.replace(tmp, path)
@@ -112,6 +126,12 @@ def write_hints_skeleton(session_dir: Path) -> None:
 
 
 def _persist(session_dir: Path, hints: list[dict[str, Any]]) -> None:
+    """Persist hints to the session's JSON and Markdown artifacts.
+
+    Args:
+        session_dir: Session directory to write into.
+        hints: Hint records to serialize.
+    """
     sd = Path(session_dir)
     sd.mkdir(parents=True, exist_ok=True)
     try:
@@ -317,6 +337,14 @@ def full_gap_summary(
 
 
 def _to_num(value: Any) -> float | None:
+    """Coerce a value to ``float``, returning ``None`` on failure.
+
+    Args:
+        value: Arbitrary value to convert.
+
+    Returns:
+        The float value, or ``None`` if it cannot be parsed.
+    """
     try:
         return float(value)
     except (TypeError, ValueError):
@@ -338,6 +366,17 @@ _STOPWORDS: frozenset[str] = frozenset({
 
 
 def _tokens(text: str) -> set[str]:
+    """Tokenize text into a set of lowercase content words.
+
+    Splits on non-alphanumeric characters and drops short tokens and
+    stopwords so the remaining set is useful for overlap matching.
+
+    Args:
+        text: Free-form text to tokenize.
+
+    Returns:
+        Set of distinct content tokens (length >= 3, non-stopword).
+    """
     out: set[str] = set()
     for raw in re.split(r"[^a-z0-9]+", str(text).lower()):
         tok = raw.strip()

--- a/inference_optimizer/orchestrator/research_hints.py
+++ b/inference_optimizer/orchestrator/research_hints.py
@@ -24,7 +24,14 @@ _HINT_FIELDS = ("what", "expected_impact", "accuracy_risk", "source",
 
 
 def _coerce_hint(raw: Any) -> dict[str, Any] | None:
-    """Normalize one incoming hint; return ``None`` when it has no source."""
+    """Normalize one incoming hint; return ``None`` when it has no source.
+
+    Args:
+        raw: A raw incoming hint value.
+
+    Returns:
+        The normalized hint dict, or ``None`` when it lacks a source/claim.
+    """
     if not isinstance(raw, dict):
         return None
     source = str(raw.get("source") or "").strip()
@@ -48,12 +55,26 @@ def _coerce_hint(raw: Any) -> dict[str, Any] | None:
 
 
 def _hint_key(hint: dict[str, Any]) -> str:
-    """Dedup key for append-merge: claim + source (case-insensitive)."""
+    """Dedup key for append-merge: claim + source (case-insensitive).
+
+    Args:
+        hint: A normalized hint dict.
+
+    Returns:
+        The case-insensitive dedup key string.
+    """
     return f"{hint['what'].lower()}::{hint['source'].lower()}"
 
 
 def load_hints(session_dir: Path) -> list[dict[str, Any]]:
-    """Return the structured hints written so far (empty on miss/parse error)."""
+    """Return the structured hints written so far (empty on miss/parse error).
+
+    Args:
+        session_dir: Session directory to read hints from.
+
+    Returns:
+        The list of normalized hint dicts (empty on miss/parse error).
+    """
     path = session_paths.research_hints_json(session_dir)
     try:
         if not path.exists():
@@ -117,7 +138,11 @@ def _atomic_write(path: Path, text: str) -> None:
 
 
 def write_hints_skeleton(session_dir: Path) -> None:
-    """Ensure both hint artifacts exist before the scout returns (PRELUDE invariant; preserves prior hints)."""
+    """Ensure both hint artifacts exist before the scout returns (PRELUDE invariant; preserves prior hints).
+
+    Args:
+        session_dir: Session directory whose hint artifacts are ensured.
+    """
     md_path = session_paths.research_hints_md(session_dir)
     if md_path.exists():
         return
@@ -147,7 +172,15 @@ def _persist(session_dir: Path, hints: list[dict[str, Any]]) -> None:
 def append_hints(
     session_dir: Path, incoming: list[Any],
 ) -> tuple[int, int]:
-    """Append-merge ``incoming`` scout hints; returns ``(added, dropped)`` (dropped = missing-source rejects; duplicates not re-added)."""
+    """Append-merge ``incoming`` scout hints; returns ``(added, dropped)`` (dropped = missing-source rejects; duplicates not re-added).
+
+    Args:
+        session_dir: Session directory to merge hints into.
+        incoming: Raw incoming hint values from the scout.
+
+    Returns:
+        A ``(added, dropped)`` tuple of counts.
+    """
     existing = load_hints(session_dir)
     seen = {_hint_key(h) for h in existing}
     added = 0
@@ -168,7 +201,14 @@ def append_hints(
 
 
 def _coerce_per_conc(raw: Any) -> dict[str, Any] | None:
-    """Drop a per-concurrency target row that lacks a source."""
+    """Drop a per-concurrency target row that lacks a source.
+
+    Args:
+        raw: A raw per-concurrency target row value.
+
+    Returns:
+        The normalized row dict, or ``None`` when it lacks a source.
+    """
     if not isinstance(raw, dict):
         return None
     if not str(raw.get("source") or "").strip():
@@ -183,7 +223,15 @@ def _coerce_per_conc(raw: Any) -> dict[str, Any] | None:
 def write_competitor_target(
     session_dir: Path, target: Any,
 ) -> bool:
-    """Persist ``competitor_target.json`` after dropping sourceless rows; ``True`` when ≥1 sourced row was written."""
+    """Persist ``competitor_target.json`` after dropping sourceless rows; ``True`` when ≥1 sourced row was written.
+
+    Args:
+        session_dir: Session directory to write the target into.
+        target: The competitor target payload.
+
+    Returns:
+        True when at least one sourced row was written, else False.
+    """
     if not isinstance(target, dict):
         return False
     per_conc_in = target.get("per_conc") or []
@@ -212,7 +260,14 @@ def write_competitor_target(
 
 
 def load_competitor_target(session_dir: Path) -> dict[str, Any] | None:
-    """Read ``competitor_target.json`` keeping only sourced per-conc rows; ``None`` when absent/malformed/sourceless. Fail-soft."""
+    """Read ``competitor_target.json`` keeping only sourced per-conc rows; ``None`` when absent/malformed/sourceless. Fail-soft.
+
+    Args:
+        session_dir: Session directory to read the target from.
+
+    Returns:
+        The competitor target dict, or ``None`` when absent/malformed/sourceless.
+    """
     path = session_paths.competitor_target_json(session_dir)
     try:
         if not path.exists():
@@ -242,7 +297,15 @@ def load_competitor_target(session_dir: Path) -> dict[str, Any] | None:
 def _match_target_row(
     target: dict[str, Any], conc: int | None,
 ) -> dict[str, Any] | None:
-    """Pick the per-conc target row nearest ``conc`` (highest-throughput row when conc unknown)."""
+    """Pick the per-conc target row nearest ``conc`` (highest-throughput row when conc unknown).
+
+    Args:
+        target: A competitor target dict carrying ``per_conc`` rows.
+        conc: The concurrency to match, or ``None``.
+
+    Returns:
+        The best-matching per-conc row, or ``None`` when there are no rows.
+    """
     rows = target.get("per_conc") or []
     if not rows:
         return None
@@ -266,7 +329,17 @@ def gap_analysis(
     our_tpot_ms: float | None,
     conc: int | None = None,
 ) -> dict[str, Any] | None:
-    """Compute advisory throughput/latency gaps against a competitor row; ``None`` when no comparable row. ``primary_gap`` is "latency" when TPOT ratio outweighs throughput gap."""
+    """Compute advisory throughput/latency gaps against a competitor row; ``None`` when no comparable row. ``primary_gap`` is "latency" when TPOT ratio outweighs throughput gap.
+
+    Args:
+        target: A competitor target dict, or ``None``.
+        our_tput_per_gpu: Our achieved throughput per GPU, when known.
+        our_tpot_ms: Our achieved TPOT in milliseconds, when known.
+        conc: Concurrency to match the target row against.
+
+    Returns:
+        A gap-analysis dict, or ``None`` when no comparable row exists.
+    """
     if not target:
         return None
     row = _match_target_row(target, conc)
@@ -311,7 +384,15 @@ def full_gap_summary(
     *,
     tpot_ratio_threshold: float = 1.3,
 ) -> str:
-    """Render an advisory "External target gap" block (empty when no gap; advisory only, never gates)."""
+    """Render an advisory "External target gap" block (empty when no gap; advisory only, never gates).
+
+    Args:
+        gap: A gap-analysis dict, or ``None``.
+        tpot_ratio_threshold: TPOT ratio above which latency is called out.
+
+    Returns:
+        The advisory block text, or ``""`` when there is no gap.
+    """
     if not gap:
         return ""
     lines = ["External target gap (advisory) — competitor numbers are "
@@ -391,7 +472,16 @@ def match_variants_to_priors(
     *,
     primary_gap: str | None = None,
 ) -> dict[str, dict[str, Any]]:
-    """Annotate which variants align with proven priors (advisory; informs ordering only). Returns ``{name: {hints, latency_aligned}}`` for variants matching a hint or a dominant latency gap."""
+    """Annotate which variants align with proven priors (advisory; informs ordering only). Returns ``{name: {hints, latency_aligned}}`` for variants matching a hint or a dominant latency gap.
+
+    Args:
+        variants: Candidate variant dicts to annotate.
+        hints: Normalized prior hint dicts.
+        primary_gap: The dominant external gap (e.g. ``"latency"``), when known.
+
+    Returns:
+        Mapping of variant name to its match info dict.
+    """
     out: dict[str, dict[str, Any]] = {}
     latency_dominant = str(primary_gap or "").strip().lower() == "latency"
     hint_tokens: list[tuple[str, set[str]]] = []
@@ -442,7 +532,17 @@ def priors_match_summary(
     primary_gap: str | None = None,
     max_rows: int = 12,
 ) -> str:
-    """Render an advisory block flagging variants that match priors (empty when none; advisory ordering only)."""
+    """Render an advisory block flagging variants that match priors (empty when none; advisory ordering only).
+
+    Args:
+        variants: Candidate variant dicts to check.
+        hints: Normalized prior hint dicts.
+        primary_gap: The dominant external gap, when known.
+        max_rows: Maximum number of variant rows to render.
+
+    Returns:
+        The advisory block text, or ``""`` when no variants match.
+    """
     matches = match_variants_to_priors(
         variants, hints, primary_gap=primary_gap,
     )
@@ -468,7 +568,15 @@ def priors_match_summary(
 def summarise_for_prompt(
     session_dir: Path, *, max_entries: int = 8,
 ) -> str:
-    """Compact advisory block of proven priors for the orchestration prompt (empty when none; advisory only)."""
+    """Compact advisory block of proven priors for the orchestration prompt (empty when none; advisory only).
+
+    Args:
+        session_dir: Session directory to load hints from.
+        max_entries: Maximum number of hint entries to render inline.
+
+    Returns:
+        The advisory prompt block text, or ``""`` when there are no hints.
+    """
     hints = load_hints(session_dir)
     if not hints:
         return ""

--- a/inference_optimizer/orchestrator/resource_lock.py
+++ b/inference_optimizer/orchestrator/resource_lock.py
@@ -59,7 +59,18 @@ def _now_iso() -> str:
 
 
 def _expand_lanes(lanes: list[str]) -> list[str]:
-    """Expand requested lanes by transitive conflicts; sorted deterministically."""
+    """Expand requested lanes by transitive conflicts; sorted deterministically.
+
+    Args:
+        lanes: Requested lane names to expand.
+
+    Returns:
+        The requested lanes plus their conflicting lanes, sorted for
+        deterministic ordering.
+
+    Raises:
+        ValueError: If any requested lane is not a known lane.
+    """
     out: set[str] = set()
     for lane in lanes:
         if lane not in KNOWN_LANES:
@@ -138,6 +149,21 @@ class SqliteLeaseBackend:
 
         Same-holder retries are idempotent; raises :class:`LaneFull` (at cap)
         or :class:`LaneBusy` (different-holder conflict). Inv-7.1: serving lanes default capacity 1.
+
+        Args:
+            lanes: Lanes to acquire; transitive conflicts are co-acquired.
+            holder_id: Identifier of the lease holder.
+            task_id: Identifier of the task acquiring the lanes.
+            action: Action label recorded with the lease.
+            ttl_sec: Lease time-to-live in seconds.
+
+        Returns:
+            The acquired ``Lease`` covering the expanded set of lanes.
+
+        Raises:
+            ValueError: If ``lanes`` is empty.
+            LaneFull: If a lane is at (or disabled by) its capacity cap.
+            LaneBusy: If a capacity-1 lane is held by a different holder.
         """
         if not lanes:
             raise ValueError("acquire_many called with no lanes")
@@ -264,7 +290,16 @@ class SqliteLeaseBackend:
         )
 
     async def heartbeat(self, lease: Lease, *, ttl_sec: int) -> None:
-        """Refresh ``expires_at`` for every lane this holder owns (keyed on ``(lane, holder_id)`` PK)."""
+        """Refresh ``expires_at`` for every lane this holder owns (keyed on ``(lane, holder_id)`` PK).
+
+        Args:
+            lease: The lease whose lanes should be refreshed.
+            ttl_sec: New lifetime in seconds from now.
+
+        Raises:
+            StaleLeaseError: If the number of rows updated does not match the
+                lease's lane count (the lease no longer belongs to us).
+        """
         new_expires_iso = datetime.fromtimestamp(
             time.time() + ttl_sec, tz=timezone.utc
         ).isoformat()
@@ -306,7 +341,11 @@ class SqliteLeaseBackend:
     async def reap_expired(self) -> list[dict]:
         """Sweep expired rows; emits one ``lease_expired`` event per stale
         (lane, holder_id) row. Reaps only TTL-fired holders, leaving live
-        holders on a multi-holder lane untouched."""
+        holders on a multi-holder lane untouched.
+
+        Returns:
+            The reaped lease rows as dicts, one per deleted (lane, holder_id).
+        """
         now_iso_str = _now_iso()
         reaped: list[dict] = []
         async with self.db.transaction() as cur:
@@ -448,6 +487,14 @@ class ResourceLockManager:
 
         Returns the :class:`Lease` on success, ``None`` when any lane is
         busy or full (both LaneBusy and LaneFull map to None; retry next tick).
+
+        Args:
+            lanes: Lanes to acquire.
+            **kwargs: Forwarded to :meth:`acquire_many` (``holder_id`` /
+                ``task_id`` / ``action`` / ``ttl_sec``).
+
+        Returns:
+            The acquired ``Lease``, or ``None`` when any lane is busy or full.
         """
         try:
             return await self.acquire_many(lanes, **kwargs)

--- a/inference_optimizer/orchestrator/roofline_ceiling.py
+++ b/inference_optimizer/orchestrator/roofline_ceiling.py
@@ -98,6 +98,13 @@ def _parse_server_arg(args: str, flag: str) -> str:
     Tolerant of both ``--quantization fp8`` and ``--quantization=fp8``.
     When the flag appears multiple times, the last value wins so an
     optimized overlay can override the baseline args.
+
+    Args:
+        args: The server-args string to scan.
+        flag: The flag whose value to extract (e.g. ``--quantization``).
+
+    Returns:
+        The last value following the flag, or ``""`` when absent.
     """
     if not args:
         return ""
@@ -137,7 +144,14 @@ class RuntimeWorkload:
 
 
 def _read_baseline_yaml_benchmark(state: Any) -> dict[str, Any]:
-    """Read ``benchmark`` from the materialized baseline yaml."""
+    """Read ``benchmark`` from the materialized baseline yaml.
+
+    Args:
+        state: Shared run state carrying ``last_baseline`` provenance.
+
+    Returns:
+        The ``benchmark`` mapping, or ``{}`` when unreadable.
+    """
     last_bl = getattr(state, "last_baseline", None) or {}
     if not isinstance(last_bl, dict):
         return {}
@@ -214,6 +228,12 @@ def _read_baseline_yaml_server_args(state: Any) -> str:
     yaml), so a baseline-only run with ``--quantization fp8`` in the yaml
     would otherwise be invisible to dtype resolution. Returns ``""`` when
     the file / fields are unreadable.
+
+    Args:
+        state: Shared run state carrying ``last_baseline`` provenance.
+
+    Returns:
+        The assembled baseline server args, or ``""`` when unreadable.
     """
     return _server_args_from_envs(
         _benchmark_envs(_read_baseline_yaml_benchmark(state))
@@ -221,7 +241,14 @@ def _read_baseline_yaml_server_args(state: Any) -> str:
 
 
 def _server_args_env_override(entry: Any) -> str:
-    """Return framework server args pinned via ``extra_envs``."""
+    """Return framework server args pinned via ``extra_envs``.
+
+    Args:
+        entry: A state entry that may carry an ``extra_envs`` mapping.
+
+    Returns:
+        The server args assembled from ``extra_envs``, or ``""``.
+    """
     if not isinstance(entry, dict):
         return ""
     envs = entry.get("extra_envs") or {}
@@ -231,7 +258,14 @@ def _server_args_env_override(entry: Any) -> str:
 
 
 def _server_args_payload(entry: Any) -> str:
-    """Return framework-neutral overlay server args from an entry."""
+    """Return framework-neutral overlay server args from an entry.
+
+    Args:
+        entry: A state entry that may carry overlay server-arg keys.
+
+    Returns:
+        The first non-empty overlay server-args string, or ``""``.
+    """
     if not isinstance(entry, dict):
         return ""
     for key in ("candidate_extra_server_args", "extra_server_args", "extra_args"):
@@ -242,7 +276,14 @@ def _server_args_payload(entry: Any) -> str:
 
 
 def _server_args_from(entry: Any) -> str:
-    """Extract the final server-args string from one state entry."""
+    """Extract the final server-args string from one state entry.
+
+    Args:
+        entry: A state entry to read server args from.
+
+    Returns:
+        The env-override args if present, else the overlay payload args.
+    """
     return _server_args_env_override(entry) or _server_args_payload(entry)
 
 
@@ -250,9 +291,16 @@ def _achieved_arm_source(state: Any) -> str:
     """Which arm the roofline ``achieved`` throughput comes from.
 
     Mirrors the snapshot writer (``current_best.tput > 0`` ⇒ optimized,
-    else baseline) so the ceiling's dtype is resolved from the SAME run
+    else baseline) so the ceiling's dtype is resolved     from the SAME run
     its measured throughput came from. Returns ``"current_best"`` or
     ``"baseline"``.
+
+    Args:
+        state: Shared run state carrying ``current_best``.
+
+    Returns:
+        ``"current_best"`` when the optimized arm has positive throughput,
+        otherwise ``"baseline"``.
     """
     cb = getattr(state, "current_best", None)
     if isinstance(cb, dict):
@@ -271,6 +319,14 @@ def _collect_runtime_server_args(state: Any, *, arm: str | None = None) -> str:
     measured throughput comes from the optimized arm. ``arm`` pins the
     source explicitly ("baseline" never overlays current_best), so a
     baseline snapshot's ceiling precision stays anchored to baseline.
+
+    Args:
+        state: Shared run state to read baseline / current_best args from.
+        arm: Pins the source arm; ``None`` infers it via
+            ``_achieved_arm_source``.
+
+    Returns:
+        The server-args string for the selected arm.
     """
     base_args = (
         _read_baseline_yaml_server_args(state)
@@ -288,7 +344,15 @@ def _collect_runtime_server_args(state: Any, *, arm: str | None = None) -> str:
 
 
 def _runtime_gpu_type(state: Any, benchmark: dict[str, Any]) -> str:
-    """Resolve real hardware for roofline; runner_type is only script routing."""
+    """Resolve real hardware for roofline; runner_type is only script routing.
+
+    Args:
+        state: Shared run state carrying ``gpu_type``.
+        benchmark: Benchmark record (fallback ``runner_type``).
+
+    Returns:
+        The resolved GPU type string, or ``""`` when unknown.
+    """
     return str(
         getattr(state, "gpu_type", "")
         or os.environ.get("TARGET_GPU_TYPE", "")
@@ -306,6 +370,13 @@ def resolve_runtime_workload(
     yaml. ``arm`` only pins which arm's server args feed precision
     resolution; ``"baseline"`` keeps the ceiling's dtype anchored to
     baseline even after current_best is promoted.
+
+    Args:
+        state: Shared run state to resolve workload fields from.
+        arm: Pins which arm's server args feed precision resolution.
+
+    Returns:
+        The resolved ``RuntimeWorkload``.
     """
     benchmark = _read_baseline_yaml_benchmark(state)
     envs = _benchmark_envs(benchmark)
@@ -385,6 +456,14 @@ def resolve_runtime_dtype(
     float32 checkpoints to fp16, never keep 4B at runtime, and never go
     sub-bf16 without an explicit quantization signal. Activation dtype
     follows ``--dtype`` when present, else bf16, also floored at 2B.
+
+    Args:
+        state: Shared run state to read the runtime server args from.
+        meta: Model metadata (its on-disk weight dtype is a fallback signal).
+        arm: Pins which arm's server args feed precision resolution.
+
+    Returns:
+        The resolved ``RuntimeDtype`` provenance.
     """
     runtime = resolve_runtime_workload(state, arm=arm)
     args = runtime.server_args
@@ -439,7 +518,14 @@ def resolve_runtime_dtype(
 
 
 def _compute_tag_for_bytes(weight_bytes: float) -> str:
-    """Map weight bytes-per-element to a HW_SPECS compute precision key."""
+    """Map weight bytes-per-element to a HW_SPECS compute precision key.
+
+    Args:
+        weight_bytes: Weight bytes-per-element.
+
+    Returns:
+        The matching precision key (``fp4`` / ``fp8`` / ``bf16`` / ``fp32``).
+    """
     if weight_bytes <= 0.5:
         return "fp4"
     if weight_bytes <= 1.0:
@@ -457,6 +543,14 @@ def apply_runtime_dtype(meta: "ModelMeta", rt: RuntimeDtype) -> "ModelMeta":
     per-token weight IO must scale by ``runtime_bpe / checkpoint_bpe``.
     No-op (scale == 1.0) when the checkpoint already matches runtime
     (pre-quantized MoE fp8), so it is safe to call unconditionally.
+
+    Args:
+        meta: Model metadata whose weight byte fields are rescaled.
+        rt: Resolved runtime dtype carrying the runtime weight bytes.
+
+    Returns:
+        A new ``ModelMeta`` rescaled to the runtime weight dtype (or ``meta``
+        unchanged for non-dataclass test doubles).
     """
     import dataclasses as _dc
 
@@ -478,7 +572,15 @@ def apply_runtime_dtype(meta: "ModelMeta", rt: RuntimeDtype) -> "ModelMeta":
 
 
 def _resolve_peak_tflops(gpu_type: str | None, precision_tag: str | None) -> float:
-    """``(gpu, precision)`` → vendor dense peak TFLOPS; 0.0 on miss (safe-degrade signal → T_cmp unavailable, fall back to T_mem)."""
+    """``(gpu, precision)`` → vendor dense peak TFLOPS; 0.0 on miss (safe-degrade signal → T_cmp unavailable, fall back to T_mem).
+
+    Args:
+        gpu_type: GPU type key (matched case-insensitively).
+        precision_tag: Precision key to look up.
+
+    Returns:
+        The vendor dense peak TFLOPS, or ``0.0`` on miss.
+    """
     spec = HW_SPECS.get((gpu_type or "").strip().lower())
     if spec is None:
         return 0.0
@@ -514,7 +616,14 @@ class ModelMeta:
 
 
 def _read_total_size(model_path: Path) -> int | None:
-    """Read ``metadata.total_size`` (bytes) from the safetensors index (byte-exact)."""
+    """Read ``metadata.total_size`` (bytes) from the safetensors index (byte-exact).
+
+    Args:
+        model_path: Local HF model directory.
+
+    Returns:
+        The total weight size in bytes, or ``None`` when unavailable.
+    """
     idx = model_path / "model.safetensors.index.json"
     if idx.is_file():
         try:
@@ -531,7 +640,15 @@ def _read_total_size(model_path: Path) -> int | None:
 
 
 def _sum_weight_file_sizes(model_path: Path, pattern: str) -> int | None:
-    """Fallback weight size from local weight shards matching ``pattern``."""
+    """Fallback weight size from local weight shards matching ``pattern``.
+
+    Args:
+        model_path: Local HF model directory.
+        pattern: Glob pattern for weight shards (e.g. ``*.safetensors``).
+
+    Returns:
+        The summed shard size in bytes, or ``None`` when zero/unreadable.
+    """
     try:
         total = sum(
             p.stat().st_size
@@ -563,7 +680,14 @@ def _read_hf_config(model_path: Path) -> dict[str, Any] | None:
 
 
 def _derive_kv_heads(cfg: dict[str, Any]) -> int:
-    """GQA-aware: ``num_key_value_heads`` if present, else ``num_attention_heads``."""
+    """GQA-aware: ``num_key_value_heads`` if present, else ``num_attention_heads``.
+
+    Args:
+        cfg: Parsed HF ``config.json``.
+
+    Returns:
+        The number of KV heads, or ``0`` when neither field is present.
+    """
     kv = cfg.get("num_key_value_heads")
     if kv is None:
         kv = cfg.get("num_attention_heads")
@@ -571,7 +695,14 @@ def _derive_kv_heads(cfg: dict[str, Any]) -> int:
 
 
 def _derive_head_dim(cfg: dict[str, Any]) -> int:
-    """``head_dim`` directly, or ``hidden_size / num_attention_heads``."""
+    """``head_dim`` directly, or ``hidden_size / num_attention_heads``.
+
+    Args:
+        cfg: Parsed HF ``config.json``.
+
+    Returns:
+        The per-head dimension, or ``0`` when it cannot be derived.
+    """
     head_dim = cfg.get("head_dim")
     if head_dim:
         return int(head_dim)
@@ -588,7 +719,16 @@ def _compute_active_weight_bytes(
     weight_bytes: int,
     dtype_bytes: float,
 ) -> int:
-    """MoE-aware estimate of weight bytes fetched per token (geometry-based, avoids the ~10× over-count from the safetensors total; safe-degrades to ``weight_bytes``)."""
+    """MoE-aware estimate of weight bytes fetched per token (geometry-based, avoids the ~10× over-count from the safetensors total; safe-degrades to ``weight_bytes``).
+
+    Args:
+        cfg: Parsed HF ``config.json``.
+        weight_bytes: Total weight bytes (the safe-degrade fallback).
+        dtype_bytes: Weight bytes-per-element.
+
+    Returns:
+        The estimated per-token active weight bytes.
+    """
     active, _total_expert, _ne, _ept = _compute_expert_decomposition(
         cfg, weight_bytes=weight_bytes, dtype_bytes=dtype_bytes,
     )
@@ -601,7 +741,17 @@ def _compute_expert_decomposition(
     weight_bytes: int,
     dtype_bytes: float,
 ) -> tuple[int, int, int, int]:
-    """MoE decomposition for the batch-aware roofline; returns ``(active_weight_bytes, total_expert_bytes, num_experts, experts_per_tok)``. Safe-degrades to ``(weight_bytes, 0, 0, 0)``. Handles num_experts / n_routed_experts / num_local_experts aliases."""
+    """MoE decomposition for the batch-aware roofline; returns ``(active_weight_bytes, total_expert_bytes, num_experts, experts_per_tok)``. Safe-degrades to ``(weight_bytes, 0, 0, 0)``. Handles num_experts / n_routed_experts / num_local_experts aliases.
+
+    Args:
+        cfg: Parsed HF ``config.json``.
+        weight_bytes: Total weight bytes (the safe-degrade fallback).
+        dtype_bytes: Weight bytes-per-element.
+
+    Returns:
+        A tuple of ``(active_weight_bytes, total_expert_bytes, num_experts,
+        experts_per_tok)``, degrading to ``(weight_bytes, 0, 0, 0)``.
+    """
     num_experts = int(
         cfg.get("num_experts")
         or cfg.get("n_routed_experts")  # DeepSeek V3 alias
@@ -643,7 +793,16 @@ def load_model_meta(
     *,
     precision_hint: str = "",
 ) -> ModelMeta | None:
-    """Read ``weight_bytes`` + KV-cache shape from a local HF model dir (``None`` when unreadable). Weight-dtype priority: quantization_config.quant_method > torch_dtype > dtype > precision_hint."""
+    """Read ``weight_bytes`` + KV-cache shape from a local HF model dir (``None`` when unreadable). Weight-dtype priority: quantization_config.quant_method > torch_dtype > dtype > precision_hint.
+
+    Args:
+        model_path: Local HF model directory.
+        precision_hint: Fallback precision tag when config lacks a dtype.
+
+    Returns:
+        The populated ``ModelMeta``, or ``None`` when the dir/config/weights
+        are unreadable.
+    """
     if not model_path:
         return None
     p = Path(model_path).expanduser()
@@ -700,7 +859,17 @@ def compute_kv_bytes_per_token(
     head_dim: int,
     kv_dtype_bytes: float,
 ) -> int:
-    """KV cache footprint per generated token, summed over all layers (the ``2`` covers K + V)."""
+    """KV cache footprint per generated token, summed over all layers (the ``2`` covers K + V).
+
+    Args:
+        num_layers: Number of transformer layers.
+        num_kv_heads: Number of KV heads.
+        head_dim: Per-head dimension.
+        kv_dtype_bytes: Bytes per KV element.
+
+    Returns:
+        The KV-cache bytes per generated token.
+    """
     return int(2 * num_layers * num_kv_heads * head_dim * kv_dtype_bytes)
 
 
@@ -721,7 +890,28 @@ def compute_theoretical_peak_output_tok_per_sec(
     experts_per_tok: int = 0,
     expert_weight_bytes: int = 0,
 ) -> float:
-    """Decode-only memory-bound ceiling for ``output_throughput`` (returns 0.0, never raises, on unknown gpu_type / degenerate divisor). ``active_weight_bytes`` shrinks per-token IO for MoE."""
+    """Decode-only memory-bound ceiling for ``output_throughput`` (returns 0.0, never raises, on unknown gpu_type / degenerate divisor). ``active_weight_bytes`` shrinks per-token IO for MoE.
+
+    Args:
+        gpu_type: GPU type key for the HBM bandwidth lookup.
+        num_gpus: Number of GPUs (tensor-parallel degree).
+        weight_bytes: Total weight bytes.
+        num_layers: Number of transformer layers.
+        num_kv_heads: Number of KV heads.
+        head_dim: Per-head dimension.
+        kv_dtype_bytes: Bytes per KV element.
+        isl: Input sequence length.
+        osl: Output sequence length.
+        concurrency: Decode batch size (floored at 1).
+        active_weight_bytes: Per-token active weight bytes for MoE (0 = dense).
+        num_experts: Total experts (0 = dense).
+        experts_per_tok: Experts activated per token.
+        expert_weight_bytes: Total expert weight bytes.
+
+    Returns:
+        The memory-bound decode throughput ceiling, or ``0.0`` on unknown
+        GPU type or a degenerate divisor.
+    """
     spec = HW_SPECS.get((gpu_type or "").strip().lower())
     if spec is None:
         return 0.0
@@ -776,6 +966,18 @@ def compute_compute_bound_ceiling_tok_per_sec(
         T_cmp = (F_peak * G * dtype_bytes) / (2 * active_weight_bytes_B1)
 
     Divisor uses ``active_weight_bytes`` at B=1 (NOT batch-saturated). Returns 0.0 on missing input (degrade to T_mem).
+
+    Args:
+        gpu_type: GPU type key for the peak TFLOPS lookup.
+        num_gpus: Number of GPUs (tensor-parallel degree).
+        precision_tag: Precision key for the peak TFLOPS lookup.
+        active_weight_bytes: Per-token active weight bytes at B=1.
+        weight_bytes: Total weight bytes (fallback when active is missing).
+        weight_dtype_bytes: Weight bytes-per-element.
+
+    Returns:
+        The compute-bound decode throughput ceiling, or ``0.0`` on missing
+        input.
     """
     peak_tflops = _resolve_peak_tflops(gpu_type, precision_tag)
     if peak_tflops <= 0 or weight_dtype_bytes <= 0:
@@ -796,7 +998,14 @@ def compute_compute_bound_ceiling_tok_per_sec(
 
 
 def _read_baseline_yaml_conc(state: Any) -> int:
-    """Read ``benchmark.envs.CONC`` from the materialized baseline yaml (ground-truth concurrency; ``0`` when unreadable)."""
+    """Read ``benchmark.envs.CONC`` from the materialized baseline yaml (ground-truth concurrency; ``0`` when unreadable).
+
+    Args:
+        state: Shared run state carrying ``last_baseline`` provenance.
+
+    Returns:
+        The baseline concurrency, or ``0`` when unreadable.
+    """
     return _env_int(
         _benchmark_envs(_read_baseline_yaml_benchmark(state)),
         "CONC",
@@ -804,7 +1013,14 @@ def _read_baseline_yaml_conc(state: Any) -> int:
 
 
 def _resolve_effective_concurrency(state: Any) -> int:
-    """Resolve the concurrency the actual benchmark ran with (returns int >= 1; on-disk baseline yaml CONC wins, since ``state.conc`` can stay stale and under-count the ceiling 8x)."""
+    """Resolve the concurrency the actual benchmark ran with (returns int >= 1; on-disk baseline yaml CONC wins, since ``state.conc`` can stay stale and under-count the ceiling 8x).
+
+    Args:
+        state: Shared run state (baseline yaml CONC preferred over ``conc``).
+
+    Returns:
+        The effective concurrency, always ``>= 1``.
+    """
     yaml_conc = _read_baseline_yaml_conc(state)
     if yaml_conc > 0:
         return yaml_conc
@@ -841,7 +1057,16 @@ def _activation_kv_dtype_bytes(meta: ModelMeta) -> float:
 def compute_roofline_breakdown_from_state(
     state: Any, *, arm: str | None = None,
 ) -> RooflineBreakdown:
-    """Primary decode ceiling + T_mem/T_cmp side projections. Prefers the bottom-up PerfModel (``compute_roofline_from_perfmodel``) when model config is complete, else the legacy top-down aggregate. Never raises; returns ``_EMPTY_BREAKDOWN`` on missing fields. ``arm`` pins precision to a specific arm ("baseline" anchors the ceiling dtype to baseline)."""
+    """Primary decode ceiling + T_mem/T_cmp side projections. Prefers the bottom-up PerfModel (``compute_roofline_from_perfmodel``) when model config is complete, else the legacy top-down aggregate. Never raises; returns ``_EMPTY_BREAKDOWN`` on missing fields. ``arm`` pins precision to a specific arm ("baseline" anchors the ceiling dtype to baseline).
+
+    Args:
+        state: Shared run state to resolve the workload and dtype from.
+        arm: Pins precision to a specific arm; ``None`` infers it.
+
+    Returns:
+        The decode ``RooflineBreakdown`` (``_EMPTY_BREAKDOWN`` on missing
+        fields).
+    """
     runtime = resolve_runtime_workload(state, arm=arm)
     meta = load_model_meta(
         runtime.model_path,
@@ -922,7 +1147,15 @@ def compute_roofline_breakdown_from_state(
 
 
 def compute_peak_from_state(state: Any, *, arm: str | None = None) -> float:
-    """Convenience scalar wrapper for ``T_peak`` only (kept for backward compat; prefer ``compute_roofline_breakdown_from_state``). ``arm`` pins precision to a specific arm."""
+    """Convenience scalar wrapper for ``T_peak`` only (kept for backward compat; prefer ``compute_roofline_breakdown_from_state``). ``arm`` pins precision to a specific arm.
+
+    Args:
+        state: Shared run state to compute the ceiling from.
+        arm: Pins precision to a specific arm; ``None`` infers it.
+
+    Returns:
+        The peak decode throughput (``peak_tok_per_sec``).
+    """
     return compute_roofline_breakdown_from_state(state, arm=arm).peak_tok_per_sec
 
 
@@ -932,6 +1165,12 @@ def read_baseline_server_args(state: Any) -> str:
     Stable entry point for callers (e.g. Coordinator profile injection) that
     must read baseline's own flags without depending on the private
     ``_read_baseline_yaml_server_args`` helper.
+
+    Args:
+        state: Shared run state carrying ``last_baseline`` provenance.
+
+    Returns:
+        The baseline arm's runtime server args, or ``""`` when unreadable.
     """
     return _read_baseline_yaml_server_args(state)
 
@@ -983,7 +1222,15 @@ HW_SPECS_ACHIEVABLE: dict[str, dict[str, Any]] = {
 
 
 def _resolve_achievable_tflops(gpu_type: str | None, precision_tag: str | None) -> float:
-    """Max-achievable TFLOPS from ``HW_SPECS_ACHIEVABLE``; 0.0 on miss."""
+    """Max-achievable TFLOPS from ``HW_SPECS_ACHIEVABLE``; 0.0 on miss.
+
+    Args:
+        gpu_type: GPU type key (matched case-insensitively).
+        precision_tag: Precision key to look up.
+
+    Returns:
+        The max-achievable TFLOPS, or ``0.0`` on miss.
+    """
     spec = HW_SPECS_ACHIEVABLE.get((gpu_type or "").strip().lower())
     if spec is None:
         return 0.0
@@ -1004,6 +1251,15 @@ def _fused_moe_flops(M: int, K: int, N: int, topk: int) -> float:
       gate+up : 2 * M * K * N * topk * 2
       down    : 2 * M * K * N * topk
       aggregation: M * K * (2 * topk - 1)
+
+    Args:
+        M: Number of tokens (batch * seq).
+        K: Hidden size.
+        N: Per-expert FFN intermediate size.
+        topk: Experts activated per token.
+
+    Returns:
+        Total FLOPs for the gated SwiGLU MoE forward.
     """
     return 2.0 * M * K * N * topk * 2 + 2.0 * M * K * N * topk + M * K * (2 * topk - 1)
 
@@ -1024,6 +1280,18 @@ def _fused_moe_bytes(
     act_bpe defaults to weight_bpe when not provided. For FP8/FP4-weight
     models pass act_bpe=2.0 (bf16 activations) to match TraceLens semantics
     where input_bpe != weight_bpe.
+
+    Args:
+        M: Number of tokens (batch * seq).
+        K: Hidden size.
+        N: Per-expert FFN intermediate size.
+        num_experts: Total experts.
+        topk: Experts activated per token.
+        weight_bpe: Weight bytes-per-element.
+        act_bpe: Activation bytes-per-element; defaults to ``weight_bpe``.
+
+    Returns:
+        Total HBM bytes for the gated SwiGLU MoE forward.
     """
     if act_bpe is None:
         act_bpe = weight_bpe
@@ -1077,6 +1345,14 @@ def _gemm_flops(M: int, N: int, K: int) -> float:
     Mirrors TraceLens.PerfModel.perf_model.GEMM.flops_func (no bias path
     needed here since LLM linear layers are weight-only without bias in
     the roofline model).
+
+    Args:
+        M: Rows of the output (tokens).
+        N: Output features.
+        K: Inner/contraction dimension.
+
+    Returns:
+        Total FLOPs for the matrix multiply.
     """
     return 2.0 * M * N * K
 
@@ -1090,6 +1366,16 @@ def _gemm_bytes(
     (input activation), bpe_mat2=weight_bpe (weight), bpe_output=act_bpe (output).
     act_bpe defaults to weight_bpe; for FP8/FP4-weight models pass act_bpe=2.0
     (bf16 activations) to correctly separate activation from weight bytes.
+
+    Args:
+        M: Rows of the output (tokens).
+        N: Output features.
+        K: Inner/contraction dimension.
+        weight_bpe: Weight bytes-per-element.
+        act_bpe: Activation bytes-per-element; defaults to ``weight_bpe``.
+
+    Returns:
+        Total HBM bytes for the matrix multiply.
     """
     a = act_bpe if act_bpe is not None else weight_bpe
     return M * K * a + K * N * weight_bpe + M * N * a
@@ -1106,6 +1392,19 @@ def _sdpa_flops(
       PV    : B * H_Q * 2 * N_Q * d_h_v * N_KV
     Softmax FLOPs omitted (dominated by matmuls).
     Causal masking halves the work when N_Q == N_KV (prefill only).
+
+    Args:
+        B: Batch size.
+        N_Q: Query sequence length.
+        H_Q: Number of query heads.
+        N_KV: Key/value sequence length.
+        H_KV: Number of KV heads.
+        d_h_qk: Per-head dimension for Q/K.
+        d_h_v: Per-head dimension for V.
+        causal: Whether causal masking applies.
+
+    Returns:
+        Total FLOPs for scaled dot-product attention.
     """
     flops_qk = B * H_Q * (2.0 * N_Q * N_KV * d_h_qk)
     flops_pv = B * H_Q * (2.0 * N_Q * d_h_v * N_KV)
@@ -1124,6 +1423,20 @@ def _sdpa_bytes(
     Mirrors TraceLens.PerfModel.perf_model.SDPA.bytes_func.
     causal is accepted for API symmetry but does not change the I/O volume
     (KV is always fully read even under causal masking at the HBM level).
+
+    Args:
+        B: Batch size.
+        N_Q: Query sequence length.
+        H_Q: Number of query heads.
+        N_KV: Key/value sequence length.
+        H_KV: Number of KV heads.
+        d_h_qk: Per-head dimension for Q/K.
+        d_h_v: Per-head dimension for V.
+        causal: Accepted for API symmetry; does not change I/O volume.
+        bpe: Bytes per element for the tensors.
+
+    Returns:
+        Total HBM bytes for scaled dot-product attention.
     """
     elems = (
         B * N_Q * H_Q * d_h_qk    # Q read
@@ -1160,6 +1473,19 @@ def compute_roofline_from_perfmodel(
     The GEMM / SDPA formulas are inlined here (no TraceLens import) and
     maintained independently.  They match TraceLens PerfModel exactly
     (verified by the PoC in roofline_perfmodel_poc.py: deviation < 1.6%).
+
+    Args:
+        meta: Model metadata; complete config required (else ``None``).
+        gpu_type: GPU type key for the achievable-spec lookup.
+        concurrency: Decode batch size.
+        isl: Input sequence length.
+        osl: Output sequence length.
+        num_gpus: Number of GPUs (tensor-parallel degree).
+        precision_tag: Precision key for the achievable TFLOPS lookup.
+
+    Returns:
+        The per-op ``PerfModelBreakdown``, or ``None`` when model metadata is
+        incomplete or the GPU is unsupported.
     """
     if meta is None:
         return None
@@ -1354,6 +1680,14 @@ def compute_roofline_breakdown_from_state_v2(
     the GPU or model config is unsupported).  Its ``decode_tok_per_s`` equals
     ``breakdown.peak_tok_per_sec`` for supported configs. ``arm`` pins precision
     to a specific arm ("baseline" anchors the ceiling dtype to baseline).
+
+    Args:
+        state: Shared run state to compute the breakdowns from.
+        arm: Pins precision to a specific arm; ``None`` infers it.
+
+    Returns:
+        A tuple of ``(RooflineBreakdown, PerfModelBreakdown | None)``; the
+        second element is ``None`` when the GPU/model config is unsupported.
     """
     legacy = compute_roofline_breakdown_from_state(state, arm=arm)
     runtime = resolve_runtime_workload(state, arm=arm)

--- a/inference_optimizer/orchestrator/roofline_ceiling.py
+++ b/inference_optimizer/orchestrator/roofline_ceiling.py
@@ -156,11 +156,29 @@ def _read_baseline_yaml_benchmark(state: Any) -> dict[str, Any]:
 
 
 def _benchmark_envs(benchmark: dict[str, Any]) -> dict[str, Any]:
+    """Return the ``envs`` mapping from a benchmark record.
+
+    Args:
+        benchmark: Benchmark record.
+
+    Returns:
+        The ``envs`` dict, or ``{}`` when absent or not a dict.
+    """
     envs = benchmark.get("envs") or {}
     return envs if isinstance(envs, dict) else {}
 
 
 def _env_int(envs: dict[str, Any], key: str) -> int:
+    """Read a positive integer from an env mapping.
+
+    Args:
+        envs: Environment mapping.
+        key: Key to read.
+
+    Returns:
+        The parsed positive integer, or ``0`` when missing, non-positive, or
+        unparseable.
+    """
     raw = envs.get(key)
     if raw is None:
         return 0
@@ -172,6 +190,14 @@ def _env_int(envs: dict[str, Any], key: str) -> int:
 
 
 def _server_args_from_envs(envs: dict[str, Any]) -> str:
+    """Assemble server CLI args from recognized env keys.
+
+    Args:
+        envs: Environment mapping.
+
+    Returns:
+        A space-joined string of the non-empty server-arg env values.
+    """
     parts = [
         str(envs[k]).strip()
         for k in _RUNTIME_SERVER_ARG_ENV_KEYS
@@ -285,6 +311,15 @@ def resolve_runtime_workload(
     envs = _benchmark_envs(benchmark)
 
     def _state_int(name: str) -> int:
+        """Read a positive integer attribute from ``state``.
+
+        Args:
+            name: Attribute name to read.
+
+        Returns:
+            The positive integer value, or ``0`` when missing, non-positive, or
+            unparseable.
+        """
         try:
             parsed = int(getattr(state, name, 0) or 0)
             return parsed if parsed > 0 else 0
@@ -792,6 +827,14 @@ _EMPTY_BREAKDOWN = RooflineBreakdown(0.0, 0.0, 0.0, "unknown")
 
 
 def _activation_kv_dtype_bytes(meta: ModelMeta) -> float:
+    """Return the per-element byte size for activation/KV tensors.
+
+    Args:
+        meta: Model metadata.
+
+    Returns:
+        The dtype byte width used for activation and KV-cache sizing.
+    """
     return max(float(meta.weight_dtype_bytes or 2.0), 2.0)
 
 
@@ -1175,11 +1218,33 @@ def compute_roofline_from_perfmodel(
         linears.append(("lm_head", hidden, vocab, 1))
 
     def _roofline_time(fl: float, by: float) -> tuple[float, str, float, float]:
+        """Roofline time for one op given its FLOPs and byte traffic.
+
+        Args:
+            fl: Floating-point operations for the op.
+            by: Bytes moved for the op.
+
+        Returns:
+            A tuple ``(time, bound_kind, t_mem, t_cmp)`` where ``time`` is the
+            roofline max of compute and memory time and ``bound_kind`` is
+            ``"compute"`` or ``"memory"``.
+        """
         t_cmp = fl / f_peak if f_peak > 0 else 1e30
         t_mem = by / bw_bps if bw_bps > 0 else 1e30
         return max(t_cmp, t_mem), "compute" if t_cmp >= t_mem else "memory", t_mem, t_cmp
 
     def _forward(batch: int, s_q: int, s_kv: int) -> tuple[float, float, float, list[OpBreakdown]]:
+        """Roofline-model one forward pass for the given shapes.
+
+        Args:
+            batch: Batch size (concurrency).
+            s_q: Query sequence length.
+            s_kv: Key/value sequence length.
+
+        Returns:
+            A tuple ``(total_time, total_mem_time, total_cmp_time, ops)`` where
+            ``ops`` is the per-op breakdown list.
+        """
         total_t = 0.0
         total_mem_t = 0.0
         total_cmp_t = 0.0

--- a/inference_optimizer/orchestrator/roofline_snapshot.py
+++ b/inference_optimizer/orchestrator/roofline_snapshot.py
@@ -129,7 +129,14 @@ SATURATION_ADVISORY_THRESHOLD_PCT: float = 80.0
 
 
 def derive_saturation_per_direction(analysis_md_text: str) -> dict[str, float]:
-    """Return ``{direction: saturation_pct}`` for the four canonical directions (F3-4 Roofline-v2; missing/unparseable degrades to ``0.0``)."""
+    """Return ``{direction: saturation_pct}`` for the four canonical directions (F3-4 Roofline-v2; missing/unparseable degrades to ``0.0``).
+
+    Args:
+        analysis_md_text: The TraceLens ``analysis.md`` text to parse.
+
+    Returns:
+        A mapping of each canonical direction to its saturation percent.
+    """
     out: dict[str, float] = {k: 0.0 for k in _SATURATION_LABEL_MAP}
     if not analysis_md_text:
         return out
@@ -222,7 +229,16 @@ def _compute_within_and_gap(
     peak: float,
     achieved: float,
 ) -> tuple[float | None, float | None]:
-    """Return ``(within_roofline_pct, gap_to_roofline_pct)``; both ``None`` when either input is non-positive."""
+    """Return ``(within_roofline_pct, gap_to_roofline_pct)``; both ``None`` when either input is non-positive.
+
+    Args:
+        peak: The theoretical peak throughput.
+        achieved: The achieved throughput.
+
+    Returns:
+        A tuple of ``(within_roofline_pct, gap_to_roofline_pct)``, both
+        ``None`` when either input is non-positive.
+    """
     if peak <= 0 or achieved <= 0:
         return None, None
     within = round(achieved / peak * 100.0, 2)
@@ -243,6 +259,20 @@ def build_roofline_snapshot(
     """Materialise one side (baseline or latest) of the comparison.
 
     ``theoretical_peak_tok_per_sec`` is the primary decode roofline ceiling (from ``roofline_ceiling.compute_roofline_breakdown_from_state``); mem/cmp sides + ``roofline_bound_kind`` persist which side dominated, and ``achieved_tok_per_sec`` is the snapshot-time ``output_throughput``. All default to 0/"unknown" so legacy callers yield ``None`` in derived pct fields.
+
+    Args:
+        snapshot_id: Monotonic snapshot id, or ``None`` for offline callers.
+        ts: ISO timestamp for the snapshot.
+        analysis_md_path: Path to the TraceLens ``analysis.md`` (empty skips
+            workload/kernel enrichment).
+        theoretical_peak_tok_per_sec: Primary decode roofline ceiling.
+        achieved_tok_per_sec: Snapshot-time achieved output throughput.
+        mem_ceiling_tok_per_sec: Memory-bound ceiling side.
+        cmp_ceiling_tok_per_sec: Compute-bound ceiling side.
+        bound_kind: Which side dominated (e.g. ``memory`` / ``compute``).
+
+    Returns:
+        The snapshot dict for one side of the comparison.
     """
     within, gap = _compute_within_and_gap(
         peak=theoretical_peak_tok_per_sec,
@@ -338,6 +368,12 @@ def build_roofline_comparison_from_history(
 
     Append-only: ``snapshots[0]`` is baseline, ``snapshots[-1]`` the latest refresh.
     Same snapshot_id → single_snapshot mode; distinct ids → before_after with ``delta``. ``None`` when history empty.
+
+    Args:
+        snapshots: The append-only snapshot history, or ``None``.
+
+    Returns:
+        The ``roofline_comparison`` block, or ``None`` when history is empty.
     """
     snapshots = list(snapshots or [])
     if not snapshots:
@@ -496,7 +532,14 @@ def _fmt_pct_cell(v: float | None) -> str:
 
 
 def format_roofline_metrics_table(cmp: dict[str, Any]) -> list[str]:
-    """Render the compact Base / Opt / Δ markdown table (session-constant ceiling rendered once above the Base/Opt columns)."""
+    """Render the compact Base / Opt / Δ markdown table (session-constant ceiling rendered once above the Base/Opt columns).
+
+    Args:
+        cmp: The ``roofline_comparison`` block to render.
+
+    Returns:
+        The markdown table as a list of lines.
+    """
 
     def cell(v: float | None) -> str:
         """Format a percentage value for a table cell.

--- a/inference_optimizer/orchestrator/roofline_snapshot.py
+++ b/inference_optimizer/orchestrator/roofline_snapshot.py
@@ -193,7 +193,16 @@ def _compute_within_and_gap(
     peak: float,
     achieved: float,
 ) -> tuple[float | None, float | None]:
-    """Return ``(within_roofline_pct, gap_to_roofline_pct)``; both ``None`` when either input is non-positive."""
+    """Return ``(within_roofline_pct, gap_to_roofline_pct)``; both ``None`` when either input is non-positive.
+
+    Args:
+        peak: The theoretical peak throughput (tok/s).
+        achieved: The achieved throughput (tok/s).
+
+    Returns:
+        A ``(within_roofline_pct, gap_to_roofline_pct)`` tuple, both ``None``
+        when either input is non-positive.
+    """
     if peak <= 0 or achieved <= 0:
         return None, None
     within = round(achieved / peak * 100.0, 2)
@@ -214,6 +223,22 @@ def build_roofline_snapshot(
     """Materialise one side (baseline or latest) of the comparison.
 
     ``theoretical_peak_tok_per_sec`` is the primary decode roofline ceiling (from ``roofline_ceiling.compute_roofline_breakdown_from_state``); mem/cmp sides + ``roofline_bound_kind`` persist which side dominated, and ``achieved_tok_per_sec`` is the snapshot-time ``output_throughput``. All default to 0/"unknown" so legacy callers yield ``None`` in derived pct fields.
+
+    Args:
+        snapshot_id: The snapshot identifier, or ``None``.
+        ts: The capture timestamp string.
+        analysis_md_path: Path to the TraceLens ``analysis.md``; when empty the
+            workload/top-kernel fields are left unset.
+        theoretical_peak_tok_per_sec: Primary decode roofline ceiling (tok/s).
+        achieved_tok_per_sec: Snapshot-time ``output_throughput`` (tok/s).
+        mem_ceiling_tok_per_sec: Memory-side roofline ceiling (tok/s).
+        cmp_ceiling_tok_per_sec: Compute-side roofline ceiling (tok/s).
+        bound_kind: Which side dominated (e.g. ``memory`` / ``compute``).
+
+    Returns:
+        A snapshot dict with the ceiling, achieved throughput, derived
+        within/gap percentages, and workload/top-kernel fields parsed from the
+        analysis.md when available.
     """
     within, gap = _compute_within_and_gap(
         peak=theoretical_peak_tok_per_sec,
@@ -309,6 +334,14 @@ def build_roofline_comparison_from_history(
 
     Append-only: ``snapshots[0]`` is baseline, ``snapshots[-1]`` the latest refresh.
     Same snapshot_id → single_snapshot mode; distinct ids → before_after with ``delta``. ``None`` when history empty.
+
+    Args:
+        snapshots: The append-only snapshot history, or ``None``.
+
+    Returns:
+        The ``roofline_comparison`` block (``mode`` / ``baseline`` / ``latest``
+        and, in before_after mode, a ``delta``), or ``None`` when the history
+        is empty.
     """
     snapshots = list(snapshots or [])
     if not snapshots:
@@ -399,7 +432,16 @@ def _fmt_pct_cell(v: float | None) -> str:
 
 
 def format_roofline_metrics_table(cmp: dict[str, Any]) -> list[str]:
-    """Render the compact Base / Opt / Δ markdown table (session-constant ceiling rendered once above the Base/Opt columns)."""
+    """Render the compact Base / Opt / Δ markdown table (session-constant ceiling rendered once above the Base/Opt columns).
+
+    Args:
+        cmp: The roofline-comparison dict built by
+            :func:`build_roofline_comparison_from_history`.
+
+    Returns:
+        The markdown table lines; ``single_snapshot`` mode renders a single
+        Metric/Value table while ``before_after`` renders Base/Opt/Δ columns.
+    """
 
     def cell(v: float | None) -> str:
         """Format a percentage value for a table cell.
@@ -525,6 +567,13 @@ def dominant_direction(snapshot: dict[str, Any] | None) -> tuple[str, float]:
 
     Reads compute/idle/comm percentages and folds a ``memory`` bound kind in as
     a tie-breaker; returns ``("", 0.0)`` when no usable numbers are present.
+
+    Args:
+        snapshot: A single roofline snapshot dict, or ``None``.
+
+    Returns:
+        A ``(direction, pct)`` tuple for the most-saturated direction, or
+        ``("", 0.0)`` when no usable numbers are present.
     """
     if not isinstance(snapshot, dict):
         return "", 0.0
@@ -558,6 +607,16 @@ def build_profiler_digest(
     previous snapshot, the hottest kernels, a suggested specialist lever for the
     dominant direction, and the reusable native kernel ids. Returns ``""`` when
     no profiler data is available; never raises.
+
+    Args:
+        snapshots: The roofline snapshot history, or ``None``.
+        trace_analyze: The latest ``trace_analyze`` payload (hot kernels +
+            reusable kernel ids), or ``None``.
+        top_n: Maximum number of hot kernels to surface.
+
+    Returns:
+        The rendered profiler block, or ``""`` when no profiler data is
+        available.
     """
     try:
         snaps = [s for s in (snapshots or []) if isinstance(s, dict)]
@@ -567,6 +626,14 @@ def build_profiler_digest(
         latest = snaps[-1] if snaps else {}
 
         def _pct(v: Any) -> str:
+            """Format a value as a one-decimal percentage, or ``—`` when not numeric.
+
+            Args:
+                v (Any): The candidate percentage value.
+
+            Returns:
+                str: The formatted percentage, or ``"—"`` when not numeric.
+            """
             return f"{float(v):.1f}%" if isinstance(v, (int, float)) else "—"
 
         bound_kind = str(latest.get("roofline_bound_kind") or "").strip() or "unknown"

--- a/inference_optimizer/orchestrator/shared_state.py
+++ b/inference_optimizer/orchestrator/shared_state.py
@@ -72,7 +72,15 @@ _MODEL_ARCH_STRUCTURED_FIELDS: tuple[tuple[str, str], ...] = (
 
 
 def render_model_arch_compact(arch: dict | None) -> str:
-    """Render the advisory ``model_arch`` profile as a single compact line (``""`` when empty/not a dict)."""
+    """Render the advisory ``model_arch`` profile as a single compact line (``""`` when empty/not a dict).
+
+    Args:
+        arch: The ``model_arch`` profile dict, or ``None``.
+
+    Returns:
+        A single ``key=value; ...`` line summarizing the architecture, or an
+        empty string when ``arch`` is empty or not a dict.
+    """
     if not isinstance(arch, dict) or not arch:
         return ""
     parts: list[str] = []
@@ -148,7 +156,15 @@ _PHASE4_LEGACY_KEY_RENAMES: dict[str, str] = {
 
 
 def _migrate_legacy_extra_sglang_args_keys(obj: Any) -> int:
-    """Recursively rewrite legacy ``extra_sglang_args`` field names in-place; returns count rewritten (canonical kept when both present)."""
+    """Recursively rewrite legacy ``extra_sglang_args`` field names in-place; returns count rewritten (canonical kept when both present).
+
+    Args:
+        obj: An arbitrary JSON-like structure (dict/list/scalar) mutated in
+            place.
+
+    Returns:
+        The number of legacy keys rewritten or removed across the structure.
+    """
     migrated = 0
     if isinstance(obj, dict):
         for legacy_key, canonical_key in _PHASE4_LEGACY_KEY_RENAMES.items():
@@ -703,7 +719,19 @@ class SharedState:
         params_winner_history: Any,
         synergy_attempted: Any,
     ) -> dict[str, Any]:
-        """Shape the unified ``explore_search`` ledger at load time; folds live history so resume preserves cross-round aggregation."""
+        """Shape the unified ``explore_search`` ledger at load time; folds live history so resume preserves cross-round aggregation.
+
+        Args:
+            existing: The existing ``explore_search`` dict, or any non-dict
+                (treated as empty).
+            backend_winners_history: Live backend winners history to fold in.
+            params_winner_history: Live params winner history to fold in.
+            synergy_attempted: Synergy-attempted markers to fold in.
+
+        Returns:
+            The shaped ``explore_search`` ledger dict with defaults and folded
+            winners history.
+        """
         from .action_executors._grid_runner import variant_fingerprint as _fp
 
         existing = existing if isinstance(existing, dict) else {}
@@ -932,7 +960,19 @@ class SharedState:
         *,
         strict: bool | None = None,
     ) -> str:
-        """Validated writer for :attr:`stop_reason` (Inv-8.3 closed vocab): values outside ``STOP_REASON_VOCAB`` map to ``"unknown"`` (lenient) or raise (``strict=True``, default env ``INFERENCE_OPTIMIZER_STRICT_STOP_REASON``). Returns value written."""
+        """Validated writer for :attr:`stop_reason` (Inv-8.3 closed vocab): values outside ``STOP_REASON_VOCAB`` map to ``"unknown"`` (lenient) or raise (``strict=True``, default env ``INFERENCE_OPTIMIZER_STRICT_STOP_REASON``). Returns value written.
+
+        Args:
+            value: Candidate stop-reason string.
+            strict: When ``True`` raise on an unknown value; ``None`` reads the
+                ``INFERENCE_OPTIMIZER_STRICT_STOP_REASON`` env flag.
+
+        Returns:
+            The value actually written (the input, ``""``, or ``"unknown"``).
+
+        Raises:
+            ValueError: If the value is unknown and strict mode is active.
+        """
         from .phase_state import STOP_REASON_VOCAB, is_valid_stop_reason
         text = str(value or "").strip()
         if not text:
@@ -964,7 +1004,14 @@ class SharedState:
 
     # escalate hint plumbing
     def set_pending_escalate_hint(self, hint: str) -> str:
-        """Stash the LLM-supplied hint for the next phase compute pass; unknown hints dropped (Inv-8.2: closed vocab). Returns value written."""
+        """Stash the LLM-supplied hint for the next phase compute pass; unknown hints dropped (Inv-8.2: closed vocab). Returns value written.
+
+        Args:
+            hint: Candidate escalate hint.
+
+        Returns:
+            The hint actually stored, or ``""`` when it was unknown and dropped.
+        """
         from .phase_state import is_valid_escalate_hint
         text = str(hint or "").strip()
         if text and not is_valid_escalate_hint(text):
@@ -973,7 +1020,11 @@ class SharedState:
         return text
 
     def consume_pending_escalate_hint(self) -> str:
-        """Pop the pending hint (recording consumption in audit fields) so the next tick doesn't re-trigger; returns cleared hint."""
+        """Pop the pending hint (recording consumption in audit fields) so the next tick doesn't re-trigger; returns cleared hint.
+
+        Returns:
+            The consumed hint, or ``""`` when none was pending.
+        """
         hint = (self.pending_escalate_hint or "").strip()
         if not hint:
             return ""
@@ -992,7 +1043,18 @@ class SharedState:
         ts: str | None = None,
         ts_unix: float | None = None,
     ) -> dict[str, Any]:
-        """Append a phase_history row and atomically update ``phase`` fields; ``phase``/``phase_history`` are CORE_STATE_FIELDS so LLM update_state is rejected. Returns the inserted row."""
+        """Append a phase_history row and atomically update ``phase`` fields; ``phase``/``phase_history`` are CORE_STATE_FIELDS so LLM update_state is rejected. Returns the inserted row.
+
+        Args:
+            to_phase: Phase being entered.
+            reason: Transition reason recorded in the row.
+            evidence: Optional evidence dict recorded with the row.
+            ts: Optional ISO timestamp; defaults to now.
+            ts_unix: Optional Unix timestamp; defaults to now.
+
+        Returns:
+            The inserted phase-history row.
+        """
         from datetime import datetime as _dt, timezone as _tz
         import time as _time
         # Lazy import to avoid an import-time cycle.
@@ -1046,6 +1108,19 @@ class SharedState:
         Coordinator-only writer (``policy.CORE_STATE_FIELDS`` guards
         ``lifecycle`` so an LLM ``update_state`` cannot forge events).
         Returns the inserted row.
+
+        Args:
+            step: Machine step / handler name.
+            status: Lifecycle status (START/END/ERROR/ENTER).
+            phase: Phase the event belongs to; defaults to the current phase.
+            label: Human-friendly label; defaults to the step's mapped label.
+            artifacts: Optional map of artifact name to path.
+            detail: Free-form detail string.
+            duration_s: Optional duration in seconds.
+            ts: Optional ISO timestamp; defaults to now.
+
+        Returns:
+            The inserted lifecycle event row.
         """
         # Lazy import to avoid an import-time cycle with the orchestrator
         # package (phase_state imports nothing from SharedState).
@@ -1121,7 +1196,19 @@ class SharedState:
         traceback_text: str,
         agent: str = "",
     ) -> dict[str, Any]:
-        """Persist a compact Coordinator exception summary for postmortems."""
+        """Persist a compact Coordinator exception summary for postmortems.
+
+        Args:
+            tick: Coordinator tick the exception fired on.
+            stage: Pipeline stage where the exception occurred.
+            exc_type: Exception class name.
+            message: Exception message (truncated).
+            traceback_text: Formatted traceback (truncated).
+            agent: Optional agent name associated with the exception.
+
+        Returns:
+            The recorded exception summary entry.
+        """
         entry = {
             "tick": int(tick or 0),
             "ts": _now_iso(),
@@ -1135,7 +1222,15 @@ class SharedState:
         return entry
 
     def apply_changes(self, changes: dict[str, Any], *, allow_core: bool) -> dict[str, Any]:
-        """Merge a non-empty changes dict into this state; does NOT re-validate the role/source allowlist (PolicyGate filters upstream). Returns fields actually written."""
+        """Merge a non-empty changes dict into this state; does NOT re-validate the role/source allowlist (PolicyGate filters upstream). Returns fields actually written.
+
+        Args:
+            changes: Field-name to value map to merge into the state.
+            allow_core: Whether core fields may be written (enforced upstream).
+
+        Returns:
+            The subset of changes actually applied (unknown fields skipped).
+        """
         if not changes:
             return {}
         applied: dict[str, Any] = {}
@@ -1371,7 +1466,12 @@ class SharedState:
         return entry
 
     def record_kernel_opt(self, result: dict[str, Any]) -> None:
-        """Capture kernel_optimization_handler result for the next Orch turn; empty kernel_id no-op, non-KEEP can't overwrite a pending KEEP, retires kernel_id (r24 guard) after >= max_partial PARTIALs (INFERENCE_OPTIMIZER_KERNEL_OPT_MAX_PARTIAL)."""
+        """Capture kernel_optimization_handler result for the next Orch turn; empty kernel_id no-op, non-KEEP can't overwrite a pending KEEP, retires kernel_id (r24 guard) after >= max_partial PARTIALs (INFERENCE_OPTIMIZER_KERNEL_OPT_MAX_PARTIAL).
+
+        Args:
+            result: The kernel-optimization handler result dict; an empty or
+                kernel-id-less result is a no-op.
+        """
         if not isinstance(result, dict):
             return
         kernel_id = str(result.get("kernel_id") or "")
@@ -1548,7 +1648,12 @@ class SharedState:
         }
 
     def _source_files_in_optimization_stack(self) -> set[str]:
-        """source_file paths already touched by an integrate entry; enforces "same source_file, only strongest KEEP integrated" (apply_kernel_patch is a whole-file overwrite)."""
+        """source_file paths already touched by an integrate entry; enforces "same source_file, only strongest KEEP integrated" (apply_kernel_patch is a whole-file overwrite).
+
+        Returns:
+            The set of source-file paths that appear on an ``integrate`` entry
+            of :attr:`optimization_stack`.
+        """
         sources: set[str] = set()
         for e in (self.optimization_stack or []):
             if not isinstance(e, dict) or e.get("action") != "integrate":
@@ -1559,7 +1664,12 @@ class SharedState:
         return sources
 
     def next_pending_keep_kernel_id(self) -> str:
-        """Return next KEEP kernel_id awaiting integrate ("" if drained); excludes integrated/rejected/same-file-conflict KEEPs, picks highest ``last_micro_speedup`` first."""
+        """Return next KEEP kernel_id awaiting integrate ("" if drained); excludes integrated/rejected/same-file-conflict KEEPs, picks highest ``last_micro_speedup`` first.
+
+        Returns:
+            The strongest pending KEEP kernel id, or ``""`` when the queue is
+            drained.
+        """
         integrated_ids = self._kernel_ids_in_optimization_stack()
         integrated_sources = self._source_files_in_optimization_stack()
         rejected = set(self.rejected_kernel_ids or [])
@@ -1587,7 +1697,11 @@ class SharedState:
         return best_kid
 
     def pending_keep_kernel_ids(self) -> list[str]:
-        """All KEEP kernel_ids awaiting integrate, sorted strongest-first; surfaced in the prompt so the LLM doesn't propose ``report`` before draining them."""
+        """All KEEP kernel_ids awaiting integrate, sorted strongest-first; surfaced in the prompt so the LLM doesn't propose ``report`` before draining them.
+
+        Returns:
+            Pending KEEP kernel ids sorted strongest-first, one per source file.
+        """
         integrated_ids = self._kernel_ids_in_optimization_stack()
         integrated_sources = self._source_files_in_optimization_stack()
         rejected = set(self.rejected_kernel_ids or [])
@@ -1645,7 +1759,18 @@ class SharedState:
         min_gpu_pct: float | None = None,
         top_n: int | None = None,
     ) -> list[str]:
-        """Hot kernels still owing a ``kernel_opt`` attempt (reusable, gpu_pct >= min_gpu_pct, untouched); capped to top_n by gpu_pct, one kernel_id per task_group."""
+        """Hot kernels still owing a ``kernel_opt`` attempt (reusable, gpu_pct >= min_gpu_pct, untouched); capped to top_n by gpu_pct, one kernel_id per task_group.
+
+        Args:
+            min_gpu_pct: Minimum GPU share to consider; defaults to the
+                ``HYPERLOOM_KERNEL_OPT_MIN_GPU_PCT`` env value.
+            top_n: Maximum number of kernels to return; defaults to the
+                ``HYPERLOOM_KERNEL_OPT_GATE_TOP_N`` env value.
+
+        Returns:
+            Kernel ids that still owe a ``kernel_opt`` attempt, one per task
+            group, capped to ``top_n``.
+        """
         info = self.last_trace_analyze or {}
         hot = info.get("hot_kernels_top15") or info.get("hot_kernels") or []
         task_groups = info.get("task_groups") or []
@@ -1731,7 +1856,15 @@ class SharedState:
     # Per-action audit (kernel parity for non-kernel actions)
     @staticmethod
     def _truncate_excerpt(value: Any, *, limit: int = 800) -> str | None:
-        """Coerce ``value`` to str and trim to ``limit`` chars; None for falsy inputs (renderer shows ``err=(none)``)."""
+        """Coerce ``value`` to str and trim to ``limit`` chars; None for falsy inputs (renderer shows ``err=(none)``).
+
+        Args:
+            value: Value to coerce and truncate.
+            limit: Maximum length of the returned string.
+
+        Returns:
+            The truncated string, or ``None`` for falsy inputs.
+        """
         if value is None:
             return None
         text = str(value)
@@ -1743,7 +1876,15 @@ class SharedState:
 
     @staticmethod
     def _stderr_tail(value: Any, *, limit: int = 1000) -> str | None:
-        """Pull the last ``limit`` chars from a subprocess error blob (stderr's actionable signal is at the end)."""
+        """Pull the last ``limit`` chars from a subprocess error blob (stderr's actionable signal is at the end).
+
+        Args:
+            value: Error blob to tail.
+            limit: Maximum number of trailing characters to keep.
+
+        Returns:
+            The trailing slice of the text, or ``None`` for falsy inputs.
+        """
         if value is None:
             return None
         text = str(value)
@@ -1762,7 +1903,22 @@ class SharedState:
         extras: dict[str, Any] | None = None,
         max_history: int = _DEFAULT_ATTEMPTS_HISTORY,
     ) -> dict[str, Any] | None:
-        """Append one attempt to ``<action>_attempts`` and refresh ``last_<action>``. Entry schema {ts, task_id, status, decision, key_metric, key_metric_kind, workspace, error_class, error_excerpt, stderr_tail, raw_result_path, reported_success, extras}. Returns the entry, or None when ``action`` not in the audit set (kernel-owned actions use bespoke recorders). Does NOT call :meth:`save`."""
+        """Append one attempt to ``<action>_attempts`` and refresh ``last_<action>``. Entry schema {ts, task_id, status, decision, key_metric, key_metric_kind, workspace, error_class, error_excerpt, stderr_tail, raw_result_path, reported_success, extras}. Returns the entry, or None when ``action`` not in the audit set (kernel-owned actions use bespoke recorders). Does NOT call :meth:`save`.
+
+        Args:
+            action: Audited action name; must be in the audit set.
+            task_id: Task identifier for the attempt.
+            status: Attempt status string.
+            decision: Decision string for the attempt.
+            result: The action result dict mined for the key metric and error
+                fields; ``None`` treated as empty.
+            extras: Optional extra fields stored on the entry.
+            max_history: Maximum number of attempt rows to retain.
+
+        Returns:
+            The recorded attempt entry, or ``None`` when ``action`` is not an
+            audited action.
+        """
         if action not in _AUDIT_ACTIONS:
             return None
         attempts_attr = f"{action}_attempts"
@@ -1832,7 +1988,18 @@ class SharedState:
         result: dict[str, Any] | None,
         max_history: int = _DEFAULT_LAST_FAILURES,
     ) -> dict[str, Any]:
-        """Append one rich failure record to :attr:`last_action_failures` for self-correction; invoked for EVERY unpromotable task kind, unlike :meth:`record_action_attempt`."""
+        """Append one rich failure record to :attr:`last_action_failures` for self-correction; invoked for EVERY unpromotable task kind, unlike :meth:`record_action_attempt`.
+
+        Args:
+            action: The failing action name.
+            task_id: Task identifier for the failure.
+            result: The action result dict mined for error fields; ``None``
+                treated as empty.
+            max_history: Maximum number of failure rows to retain.
+
+        Returns:
+            The recorded failure entry.
+        """
         result = result or {}
         error_class = result.get("error_class")
         error_class_str = str(error_class) if error_class else None
@@ -1874,6 +2041,9 @@ class SharedState:
         Prefers ``baseline_tput``; falls back to ``last_baseline``'s
         ``tput``/``output_throughput`` so a state that lost ``baseline_tput``
         still stamps an achieved value (avoids an empty within/gap pct).
+
+        Returns:
+            The resolved baseline throughput, or ``0.0`` when none is available.
         """
         if isinstance(self.baseline_tput, (int, float)) and self.baseline_tput > 0:
             return float(self.baseline_tput)
@@ -1890,6 +2060,10 @@ class SharedState:
         Reads ``current_best``'s ``tput``/``output_throughput`` so a
         current_best-tagged snapshot keeps its arm even when ``tput`` is
         momentarily absent (avoids silently downgrading to the baseline arm).
+
+        Returns:
+            The resolved current-best throughput, or ``0.0`` when none is
+            available.
         """
         cb = self.current_best if isinstance(self.current_best, dict) else {}
         for key in ("tput", "output_throughput"):
@@ -1903,7 +2077,12 @@ class SharedState:
         payload: dict[str, Any],
         result: dict[str, Any],
     ) -> None:
-        """Write the canonical 11-field ``last_trace_analyze`` dict (single writer). ``roofline_snapshot_id`` increments monotonically; PR #321 retired ``last_trace_analyze_baseline`` (roofline_snapshots feeds report.py Roofline Comparison)."""
+        """Write the canonical 11-field ``last_trace_analyze`` dict (single writer). ``roofline_snapshot_id`` increments monotonically; PR #321 retired ``last_trace_analyze_baseline`` (roofline_snapshots feeds report.py Roofline Comparison).
+
+        Args:
+            payload: The trace-analyze request payload.
+            result: The trace-analyze result dict; non-dicts are a no-op.
+        """
         if not isinstance(result, dict):
             return
         trace_input = (
@@ -2244,7 +2423,11 @@ class SharedState:
         }
 
     def record_conc_sweep(self, result: dict[str, Any]) -> None:
-        """Record conc_sweep task completion (mirrors record_sweep). Bug #12: status lets exit_normal_sweep return conc_sweep_done so SWEEP→CLOSE fires on conc_sweep alone."""
+        """Record conc_sweep task completion (mirrors record_sweep). Bug #12: status lets exit_normal_sweep return conc_sweep_done so SWEEP→CLOSE fires on conc_sweep alone.
+
+        Args:
+            result: The conc_sweep result dict; non-dicts are a no-op.
+        """
         if not isinstance(result, dict):
             return
         self.last_conc_sweep = {
@@ -2259,7 +2442,11 @@ class SharedState:
 
     # specialist round bookkeeping
     def record_specialist_round(self, entry: dict[str, Any]) -> None:
-        """Append one round summary to ``specialist_rounds``; idempotent on ``round_id`` (re-record overwrites)."""
+        """Append one round summary to ``specialist_rounds``; idempotent on ``round_id`` (re-record overwrites).
+
+        Args:
+            entry: The round summary dict; empty or non-dict is a no-op.
+        """
         if not isinstance(entry, dict) or not entry:
             return
         round_id = str(entry.get("round_id") or "").strip()
@@ -2276,7 +2463,16 @@ class SharedState:
     def bump_specialist_domain_empty_streak(
         self, domain: str, *, empty: bool,
     ) -> int:
-        """Increment/reset the per-domain empty-proposal streak; returns new value (escalation threshold lives in ``KB_design §3.9``, not here)."""
+        """Increment/reset the per-domain empty-proposal streak; returns new value (escalation threshold lives in ``KB_design §3.9``, not here).
+
+        Args:
+            domain: The specialist domain; blank maps to ``"unknown"``.
+            empty: Whether the latest round was empty (increment) or not
+                (reset).
+
+        Returns:
+            The new streak count for the domain.
+        """
         d = str(domain or "").strip() or "unknown"
         if empty:
             self.specialist_domain_empty_streak[d] = int(
@@ -2288,7 +2484,14 @@ class SharedState:
 
     # gaps ledger helpers
     def find_gap(self, canonical_id: str) -> dict[str, Any] | None:
-        """Return the gap entry matching ``canonical_id`` (or ``None``)."""
+        """Return the gap entry matching ``canonical_id`` (or ``None``).
+
+        Args:
+            canonical_id: The gap's canonical identifier.
+
+        Returns:
+            The matching gap entry, or ``None`` when not found.
+        """
         if not canonical_id:
             return None
         cid = str(canonical_id)
@@ -2298,7 +2501,15 @@ class SharedState:
         return None
 
     def upsert_gap(self, entry: dict[str, Any]) -> dict[str, Any]:
-        """Insert or update one gap row, keyed by ``canonical_id``. Coordinator-only writer (Inv-1 single-writer + CORE_STATE_FIELDS lock). Returns the merged entry."""
+        """Insert or update one gap row, keyed by ``canonical_id``. Coordinator-only writer (Inv-1 single-writer + CORE_STATE_FIELDS lock). Returns the merged entry.
+
+        Args:
+            entry: The gap row to insert or merge; must carry a non-empty
+                ``canonical_id``.
+
+        Returns:
+            The merged gap entry, or ``{}`` when the input is invalid.
+        """
         if not isinstance(entry, dict):
             return {}
         cid = str(entry.get("canonical_id") or "").strip()
@@ -2369,7 +2580,15 @@ class SharedState:
         canonical_id: str,
         attempt: dict[str, Any],
     ) -> dict[str, Any] | None:
-        """Append one attempt row to an existing gap; returns the gap or ``None`` when unknown (caller may ``upsert_gap`` instead)."""
+        """Append one attempt row to an existing gap; returns the gap or ``None`` when unknown (caller may ``upsert_gap`` instead).
+
+        Args:
+            canonical_id: The gap's canonical identifier.
+            attempt: The attempt row to append (timestamped when absent).
+
+        Returns:
+            The updated gap entry, or ``None`` when the gap is unknown.
+        """
         gap = self.find_gap(canonical_id)
         if gap is None:
             return None
@@ -2382,7 +2601,12 @@ class SharedState:
         return gap
 
     def replace_gaps(self, entries: list[dict[str, Any]]) -> None:
-        """Bulk-replace ``gaps`` with a fresh dedup'd list (discards stale rows wholesale); idempotent."""
+        """Bulk-replace ``gaps`` with a fresh dedup'd list (discards stale rows wholesale); idempotent.
+
+        Args:
+            entries: The replacement gap rows; non-lists are a no-op and rows
+                without a ``canonical_id`` are dropped.
+        """
         if not isinstance(entries, list):
             return
         dedup: dict[str, dict[str, Any]] = {}
@@ -2417,7 +2641,15 @@ class SharedState:
         task_id: str = "",
         delta_pct: float | None = None,
     ) -> None:
-        """Append one intervention entry and update config-only counters. consecutive-config counter advances on ``"config"``, resets on ``"code_patch"``; ``"code_patch_attempt"`` is telemetry-only."""
+        """Append one intervention entry and update config-only counters. consecutive-config counter advances on ``"config"``, resets on ``"code_patch"``; ``"code_patch_attempt"`` is telemetry-only.
+
+        Args:
+            change_type: Intervention change type (e.g. ``config`` /
+                ``code_patch``).
+            action: The action associated with the intervention.
+            task_id: Optional task identifier.
+            delta_pct: Optional measured delta percentage.
+        """
         ct = str(change_type or "").strip().lower()
         entry = {
             "change_type": ct,
@@ -2435,7 +2667,15 @@ class SharedState:
             self.consecutive_config_only_rounds = 0
 
     def get_intervention_mix(self, *, recent_window: int = 5) -> dict[str, Any]:
-        """Summarise the intervention-mix ledger as derived counts (config vs code_patch totals, recent window, consecutive_config_only, config_heavy). Read-only; unknown change_types ignored in tallies but break the trailing config-only run."""
+        """Summarise the intervention-mix ledger as derived counts (config vs code_patch totals, recent window, consecutive_config_only, config_heavy). Read-only; unknown change_types ignored in tallies but break the trailing config-only run.
+
+        Args:
+            recent_window: Number of most-recent entries to tally for the recent
+                window counts.
+
+        Returns:
+            A summary dict of derived intervention counts and flags.
+        """
         ledger = [e for e in (self.intervention_mix or []) if isinstance(e, dict)]
 
         def _ct(entry: dict[str, Any]) -> str:
@@ -2483,7 +2723,14 @@ class SharedState:
         }
 
     def bump_specialist_dispatched(self, n: int = 1) -> int:
-        """Increment the per-EXPLORE specialist dispatch counter; returns post-increment value."""
+        """Increment the per-EXPLORE specialist dispatch counter; returns post-increment value.
+
+        Args:
+            n: Amount to add to the dispatch counter.
+
+        Returns:
+            The post-increment dispatch count.
+        """
         self.explore_specialist_dispatched_count = (
             int(self.explore_specialist_dispatched_count or 0) + int(n)
         )
@@ -2494,12 +2741,27 @@ class SharedState:
         self.explore_specialist_dispatched_count = 0
 
     def bump_research_scout_runs(self, n: int = 1) -> int:
-        """Increment the research-scout dispatch counter; return new total."""
+        """Increment the research-scout dispatch counter; return new total.
+
+        Args:
+            n: Amount to add to the research-scout run counter.
+
+        Returns:
+            The new research-scout run total.
+        """
         self.research_scout_runs = int(self.research_scout_runs or 0) + int(n)
         return self.research_scout_runs
 
     def register_seen_pr_ids(self, pr_ids: Any) -> int:
-        """Add PR ids to the shared seen-set (scout + FRAMEWORK_PR dedup); returns count newly added."""
+        """Add PR ids to the shared seen-set (scout + FRAMEWORK_PR dedup); returns count newly added.
+
+        Args:
+            pr_ids: Iterable of PR ids to register; blanks and duplicates are
+                skipped.
+
+        Returns:
+            The number of PR ids newly added to the seen set.
+        """
         seen = set(self.research_scout_seen_pr_ids or [])
         added = 0
         for raw in pr_ids or []:
@@ -2512,7 +2774,14 @@ class SharedState:
         return added
 
     def has_seen_pr_id(self, pr_id: Any) -> bool:
-        """True iff ``pr_id`` was already surfaced by scout / FRAMEWORK_PR."""
+        """True iff ``pr_id`` was already surfaced by scout / FRAMEWORK_PR.
+
+        Args:
+            pr_id: The PR id to check.
+
+        Returns:
+            ``True`` when the PR id is in the seen set.
+        """
         pid = str(pr_id or "").strip()
         return bool(pid) and pid in set(self.research_scout_seen_pr_ids or [])
 
@@ -2522,14 +2791,23 @@ class SharedState:
         self.params_no_promote_streak = 0
 
     def note_explore_outcome(self, *, promoted: bool) -> None:
-        """Update the legacy plateau proxy after one explore task (KEEP resets, no-promote increments)."""
+        """Update the legacy plateau proxy after one explore task (KEEP resets, no-promote increments).
+
+        Args:
+            promoted: Whether the explore task promoted a variant; ``True``
+                resets the proxy, ``False`` increments it.
+        """
         if promoted:
             self.reset_explore_plateau_proxy()
         else:
             self.params_no_promote_streak += 1
 
     def to_intervention_mix_summary(self) -> str:
-        """Render the intervention ledger as neutral telemetry (one-line counts summary; ``""`` when empty). No directive emitted — config-vs-patch is the LLM's choice."""
+        """Render the intervention ledger as neutral telemetry (one-line counts summary; ``""`` when empty). No directive emitted — config-vs-patch is the LLM's choice.
+
+        Returns:
+            A one-line counts summary, or ``""`` when the ledger is empty.
+        """
         mix = self.intervention_mix or []
         if not mix:
             return ""
@@ -2558,7 +2836,13 @@ class SharedState:
     def record_specialist_patch_verdict(
         self, specialist_task_id: str, verdict: str,
     ) -> None:
-        """Record the Critic verdict for a specialist worktree patch; idempotent (later verdict overwrites), empty ``verdict`` clears the entry to force re-review."""
+        """Record the Critic verdict for a specialist worktree patch; idempotent (later verdict overwrites), empty ``verdict`` clears the entry to force re-review.
+
+        Args:
+            specialist_task_id: The specialist task identifier; blank is a
+                no-op.
+            verdict: The Critic verdict; an empty string clears the entry.
+        """
         sid = str(specialist_task_id or "").strip()
         if not sid:
             return
@@ -2571,7 +2855,14 @@ class SharedState:
     def get_specialist_patch_verdict(
         self, specialist_task_id: str,
     ) -> str:
-        """Return the patch verdict, or empty when no Critic decision exists."""
+        """Return the patch verdict, or empty when no Critic decision exists.
+
+        Args:
+            specialist_task_id: The specialist task identifier.
+
+        Returns:
+            The recorded verdict, or ``""`` when none exists.
+        """
         sid = str(specialist_task_id or "").strip()
         if not sid:
             return ""
@@ -2588,7 +2879,11 @@ class SharedState:
             self.last_specialist = dict(snapshot)
 
     def apply_explore_search_update(self, update: dict[str, Any]) -> None:
-        """Merge an ExploreExecutor search update into persistent state (v0.8 M3); executor never writes ``accepted`` directly — :meth:`record_explore_accepted` is the single writer for that bucket."""
+        """Merge an ExploreExecutor search update into persistent state (v0.8 M3); executor never writes ``accepted`` directly — :meth:`record_explore_accepted` is the single writer for that bucket.
+
+        Args:
+            update: The executor search-update dict; non-dicts are a no-op.
+        """
         if not isinstance(update, dict):
             return
         prior = self.explore_search if isinstance(self.explore_search, dict) else {}
@@ -2633,7 +2928,11 @@ class SharedState:
         self.explore_search = merged
 
     def record_explore_accepted(self, variant: dict[str, Any]) -> None:
-        """Append one promoted variant to ``explore_search.accepted``; dedupes by ``fingerprint`` and removes any matching ``rejected`` entry so a variant isn't in both buckets."""
+        """Append one promoted variant to ``explore_search.accepted``; dedupes by ``fingerprint`` and removes any matching ``rejected`` entry so a variant isn't in both buckets.
+
+        Args:
+            variant: The promoted variant dict; empty or non-dict is a no-op.
+        """
         if not isinstance(variant, dict) or not variant:
             return
         from .action_executors._canonical_fingerprint import canonical_fingerprint
@@ -2696,7 +2995,15 @@ class SharedState:
         param_flags: list[str] | None = None,
         source_path: str = "",
     ) -> None:
-        """Persist the AST-discovered flag list for a framework; the prompt surfaces the union so the LLM synthesizes new GridVariants beyond DEFAULT_*_GRID. Idempotent per-framework."""
+        """Persist the AST-discovered flag list for a framework; the prompt surfaces the union so the LLM synthesizes new GridVariants beyond DEFAULT_*_GRID. Idempotent per-framework.
+
+        Args:
+            framework: Framework name; blank maps to ``"unknown"``.
+            backend_flags: Discovered backend flags; left unchanged when
+                ``None``.
+            param_flags: Discovered param flags; left unchanged when ``None``.
+            source_path: Optional path the flags were discovered from.
+        """
         fw = (framework or "").strip().lower() or "unknown"
         entry = dict(self.discovered_flags.get(fw) or {})
         if backend_flags is not None:
@@ -2727,7 +3034,19 @@ class SharedState:
         extra_server_args: str = "",
         ts: str | None = None,
     ) -> float | None:
-        """Mirror an optimization_stack append into gain_per_stack_entry; computes ``(new_tput-baseline_tput)/baseline_tput*100`` and appends. Returns gain_pct (None when baseline_tput is 0 or new_tput non-positive)."""
+        """Mirror an optimization_stack append into gain_per_stack_entry; computes ``(new_tput-baseline_tput)/baseline_tput*100`` and appends. Returns gain_pct (None when baseline_tput is 0 or new_tput non-positive).
+
+        Args:
+            action: The stack action being mirrored.
+            variant_name: Optional variant name for the entry.
+            new_tput: The new throughput used to compute the gain.
+            extra_server_args: Optional server-arg string for the entry.
+            ts: Optional ISO timestamp.
+
+        Returns:
+            The computed gain percentage, or ``None`` when the baseline or new
+            throughput is non-positive.
+        """
         try:
             base = float(self.baseline_tput or 0.0)
         except (TypeError, ValueError):
@@ -2769,7 +3088,15 @@ class SharedState:
 
     # Time-budget helpers (consumed by Coordinator._compose_prompt)
     def elapsed_minutes(self, *, now: datetime | None = None) -> float:
-        """Wall-clock minutes since ``start_ts`` (0.0 when empty/unparseable)."""
+        """Wall-clock minutes since ``start_ts`` (0.0 when empty/unparseable).
+
+        Args:
+            now: Override for the current time; defaults to ``datetime.now``.
+
+        Returns:
+            Non-negative minutes elapsed since ``start_ts``, or ``0.0`` when it
+            is unset or unparseable.
+        """
         if not self.start_ts:
             return 0.0
         try:
@@ -2785,17 +3112,37 @@ class SharedState:
         return max(0.0, delta)
 
     def remaining_minutes(self, *, now: datetime | None = None) -> float | None:
-        """Minutes left in the wall-clock budget; ``None`` when ``max_minutes`` unset (unbounded), else clamped at 0."""
+        """Minutes left in the wall-clock budget; ``None`` when ``max_minutes`` unset (unbounded), else clamped at 0.
+
+        Args:
+            now: Override for the current time; defaults to ``datetime.now``.
+
+        Returns:
+            Minutes remaining in the budget, or ``None`` when the session is
+            unbounded.
+        """
         if not self.max_minutes:
             return None
         return max(0.0, float(self.max_minutes) - self.elapsed_minutes(now=now))
 
     def optimization_stack_has_unvalidated_keeps(self) -> bool:
-        """True iff a new KEEP landed since the last inline stack rebench (purely a stack-length check vs ``cumulative_gain_validated_stack_len``)."""
+        """True iff a new KEEP landed since the last inline stack rebench (purely a stack-length check vs ``cumulative_gain_validated_stack_len``).
+
+        Returns:
+            ``True`` when the optimization stack has grown since the last
+            validated rebench.
+        """
         return len(self.optimization_stack) > int(self.cumulative_gain_validated_stack_len)
 
     def to_mission_summary(self, *, now: datetime | None = None) -> str:
-        """Mission-progress block printed at the top of every tick (outcome-shaped state: raw/validated gain, time vs budget, stack staleness); distinct from :meth:`to_prompt_summary`."""
+        """Mission-progress block printed at the top of every tick (outcome-shaped state: raw/validated gain, time vs budget, stack staleness); distinct from :meth:`to_prompt_summary`.
+
+        Args:
+            now: Override for the current time used in elapsed/remaining math.
+
+        Returns:
+            A multi-line mission-progress summary block.
+        """
         elapsed = self.elapsed_minutes(now=now)
         remaining = self.remaining_minutes(now=now)
         budget_line = (
@@ -2853,7 +3200,16 @@ class SharedState:
         budget_pct: dict[str, float] | None = None,
         now_unix: float | None = None,
     ) -> str:
-        """Render the per-tick ``=== Phase ===`` block (v0.8 §3.3); compact (≤5 lines). EXPLORE adds a ``force_exit`` line showing runway before the hard force-exit gate."""
+        """Render the per-tick ``=== Phase ===`` block (v0.8 §3.3); compact (≤5 lines). EXPLORE adds a ``force_exit`` line showing runway before the hard force-exit gate.
+
+        Args:
+            budget_pct: Override ``phase -> pct`` map; defaults to the state's
+                ``phase_budget_pct``.
+            now_unix: Override for the current time in seconds.
+
+        Returns:
+            The rendered phase-status block as a multi-line string.
+        """
         from .phase_state import (
             DEFAULT_EXPLORE_FORCE_EXIT_BUDGET_PCT,
             DEFAULT_EXPLORE_FORCE_EXIT_HOURS_REMAINING,
@@ -2940,7 +3296,17 @@ class SharedState:
         budget_pct: dict[str, float] | None = None,
         now_unix: float | None = None,
     ) -> str:
-        """Render the per-phase budget telemetry block for Robustness (one ``phase: elapsed=Xs cap=Ys (Z%)`` line per phase) so it can spot budget overruns."""
+        """Render the per-phase budget telemetry block for Robustness (one ``phase: elapsed=Xs cap=Ys (Z%)`` line per phase) so it can spot budget overruns.
+
+        Args:
+            budget_pct: Override ``phase -> pct`` map; defaults to the state's
+                ``phase_budget_pct``.
+            now_unix: Override for the current time in seconds.
+
+        Returns:
+            One telemetry line per phase, or a placeholder when no phase history
+            exists yet.
+        """
         from .phase_state import (
             DEFAULT_PHASE_BUDGET_PCT,
             PHASE_NAMES,
@@ -2988,7 +3354,15 @@ class SharedState:
         return "\n".join(lines) or "(no phase history yet)"
 
     def to_warm_start_summary(self, *, max_lines: int = 12) -> str:
-        """Render T0 warm-start snapshot for the ``=== Warm start ===`` prompt section (v0.8 §3.3 §4.1); empty when no recipe/pitfalls. Capped; full JSON at runtime/cortex/.kb_warm.json / .kb_pitfalls.json."""
+        """Render T0 warm-start snapshot for the ``=== Warm start ===`` prompt section (v0.8 §3.3 §4.1); empty when no recipe/pitfalls. Capped; full JSON at runtime/cortex/.kb_warm.json / .kb_pitfalls.json.
+
+        Args:
+            max_lines: Maximum number of lines to render before truncating.
+
+        Returns:
+            The rendered warm-start block, or ``""`` when no recipe or pitfalls
+            exist.
+        """
         recipe = self.warm_start_recipe or {}
         pitfalls = self.warm_start_pitfalls or []
         if not recipe and not pitfalls:
@@ -3031,7 +3405,14 @@ class SharedState:
         return "\n".join(out)
 
     def to_gaps_summary(self, *, max_entries: int = 10) -> str:
-        """Render :attr:`gaps` for prompt injection (KB_design §3.3/§3.5); empty when no gaps. Capped at ``max_entries`` newest rows."""
+        """Render :attr:`gaps` for prompt injection (KB_design §3.3/§3.5); empty when no gaps. Capped at ``max_entries`` newest rows.
+
+        Args:
+            max_entries: Maximum number of newest gap rows to render.
+
+        Returns:
+            The rendered gaps block, or ``""`` when there are no gaps.
+        """
         if not self.gaps:
             return ""
         # Newest first by last_updated_ts (deterministic fallback to first_seen_ts/insertion).
@@ -3074,7 +3455,15 @@ class SharedState:
         return "\n".join(rows)
 
     def to_proposal_scores_summary(self, *, max_rounds: int = 2) -> str:
-        """Render advisory multi-model proposal scores for Orchestration. NO mean/sorting (Inv-9.1: no system-side scoreboard); rater identities anonymized to avoid brand bias. Empty when no recent round carries scores."""
+        """Render advisory multi-model proposal scores for Orchestration. NO mean/sorting (Inv-9.1: no system-side scoreboard); rater identities anonymized to avoid brand bias. Empty when no recent round carries scores.
+
+        Args:
+            max_rounds: Maximum number of most-recent scored rounds to render.
+
+        Returns:
+            The rendered advisory scores block, or ``""`` when no recent round
+            carries scores.
+        """
         rounds = [
             r for r in (self.specialist_rounds or [])
             if isinstance(r, dict)
@@ -3263,7 +3652,12 @@ class SharedState:
         )
 
     def _format_attempts_history(self) -> str:
-        """One-line summary across the audit actions (``baseline:total(s<succ>,f<fail>) ...``) so the LLM gauges reliability without 6x20 rows."""
+        """One-line summary across the audit actions (``baseline:total(s<succ>,f<fail>) ...``) so the LLM gauges reliability without 6x20 rows.
+
+        Returns:
+            A one-line per-action attempt summary, or a placeholder when no
+            attempts are recorded.
+        """
         parts: list[str] = []
         for action in sorted(_AUDIT_ACTIONS):
             attempts_attr = f"{action}_attempts"
@@ -3283,7 +3677,12 @@ class SharedState:
         return " ".join(parts) if parts else "(no attempts recorded)"
 
     def _format_last_action_failures(self) -> str:
-        """Render up to the 3 most-recent global failures (rich-context companion to crash_count/baseline_failure_streak); full list on disk."""
+        """Render up to the 3 most-recent global failures (rich-context companion to crash_count/baseline_failure_streak); full list on disk.
+
+        Returns:
+            A compact render of the recent failures, or ``"(none)"`` when there
+            are none.
+        """
         if not self.last_action_failures:
             return "(none)"
         rows: list[str] = []
@@ -3343,7 +3742,15 @@ class SharedState:
 
     @staticmethod
     def _format_variant_line(entry: dict[str, Any]) -> str:
-        """One-line render of a search variant for prompt blocks."""
+        """One-line render of a search variant for prompt blocks.
+
+        Args:
+            entry: The variant dict to render.
+
+        Returns:
+            A single formatted line summarizing the variant's name, gain,
+            throughput, args, and envs.
+        """
         name = str(entry.get("name") or "?")
         gain = entry.get("gain_pct")
         tput = entry.get("tput") or entry.get("output_throughput")
@@ -3370,7 +3777,16 @@ class SharedState:
     def _enrich_with_tested_gain(
         entry: dict[str, Any], tested: dict[str, Any],
     ) -> dict[str, Any]:
-        """Backfill ``gain_pct``/``tput`` from the matching ``tested[fp]`` at render time (some accepted entries don't persist gain_pct; avoids a second writer)."""
+        """Backfill ``gain_pct``/``tput`` from the matching ``tested[fp]`` at render time (some accepted entries don't persist gain_pct; avoids a second writer).
+
+        Args:
+            entry: The variant entry to enrich.
+            tested: The ``tested`` ledger keyed by fingerprint.
+
+        Returns:
+            The entry (or a copy) with ``gain_pct``/``tput`` backfilled from the
+            matching tested snapshot when available.
+        """
         if (
             entry.get("gain_pct") is not None
             and entry.get("tput") is not None
@@ -3394,7 +3810,12 @@ class SharedState:
         return out
 
     def _format_backend_winners_history(self) -> str:
-        """Multi-line render of the explore-round winners history (last 5 rounds: per-winner gain_pct/tput/flags); older rounds collapse to an elision line."""
+        """Multi-line render of the explore-round winners history (last 5 rounds: per-winner gain_pct/tput/flags); older rounds collapse to an elision line.
+
+        Returns:
+            A multi-line winners-history render, or a placeholder when no
+            explore rounds have completed.
+        """
         if not self.backend_winners_history:
             return "(no explore rounds completed)"
         last = self.backend_winners_history[-5:]
@@ -3440,7 +3861,14 @@ class SharedState:
 
     @staticmethod
     def _format_search_state(search: dict[str, Any] | None) -> str:
-        """Multi-line render of a ``*_search`` dedup ledger; each entry surfaces real ``gain_pct``. Counts on the head line; bodies show last 5 per bucket (only the prompt body is truncated)."""
+        """Multi-line render of a ``*_search`` dedup ledger; each entry surfaces real ``gain_pct``. Counts on the head line; bodies show last 5 per bucket (only the prompt body is truncated).
+
+        Args:
+            search: The ``*_search`` ledger dict, or ``None``.
+
+        Returns:
+            A multi-line render of the ledger, or ``"(none)"`` when empty.
+        """
         if not search:
             return "(none)"
         accepted = list(search.get("accepted") or [])
@@ -3490,14 +3918,26 @@ class SharedState:
 
     @staticmethod
     def _strip_base64_data_urls(text: str) -> str:
-        """Drop base64 image payloads before prompt injection (in-memory only; on-disk file intact). Delegates to ``inference_optimizer.tracelens_md``."""
+        """Drop base64 image payloads before prompt injection (in-memory only; on-disk file intact). Delegates to ``inference_optimizer.tracelens_md``.
+
+        Args:
+            text: The text to strip base64 data URLs from.
+
+        Returns:
+            The text with base64 image payloads removed.
+        """
         if not text:
             return text or ""
         from inference_optimizer.tracelens_md import strip_base64_data_urls
         return strip_base64_data_urls(text)
 
     def _format_analysis_md_full(self) -> str:
-        """Inject TraceLens analysis.md verbatim (Roofline composite design §6.1: no truncation/interpretation) between ``=== TraceLens Analysis ... ===`` bookends; header carries snapshot id + gain. Empty cache → one-line hint to propose ``roofline``."""
+        """Inject TraceLens analysis.md verbatim (Roofline composite design §6.1: no truncation/interpretation) between ``=== TraceLens Analysis ... ===`` bookends; header carries snapshot id + gain. Empty cache → one-line hint to propose ``roofline``.
+
+        Returns:
+            The bookended analysis.md block, or a one-line hint when no
+            TraceLens snapshot is cached.
+        """
         cached = self.last_trace_analyze or {}
         md_text = cached.get("analysis_md_text") or ""
         if not md_text:

--- a/inference_optimizer/orchestrator/shared_state.py
+++ b/inference_optimizer/orchestrator/shared_state.py
@@ -560,6 +560,19 @@ class SharedState:
 
     @classmethod
     def from_dict(cls, raw: dict[str, Any]) -> "SharedState":
+        """Construct a :class:`SharedState` from a raw mapping, migrating it.
+
+        Acts as the unified migration entry point: an absent
+        ``schema_version`` is treated as 1, legacy keys are renamed to
+        their canonical form, and unknown keys are dropped. The operation
+        is idempotent and short-circuits when already at the latest schema.
+
+        Args:
+            raw: Decoded state mapping (e.g. from JSON on disk).
+
+        Returns:
+            A fully-populated, migrated :class:`SharedState` instance.
+        """
         # Unified migration entry point; absent schema_version treated as 1. Idempotent (latest version short-circuits).
         incoming_version = int(raw.get("schema_version") or 1)
         needs_migration = incoming_version < LATEST_STATE_SCHEMA_VERSION
@@ -2426,6 +2439,14 @@ class SharedState:
         ledger = [e for e in (self.intervention_mix or []) if isinstance(e, dict)]
 
         def _ct(entry: dict[str, Any]) -> str:
+            """Return an entry's normalized ``change_type`` string.
+
+            Args:
+                entry: A single intervention-mix ledger entry.
+
+            Returns:
+                The lowercased, stripped change type (empty if absent).
+            """
             return str(entry.get("change_type") or "").strip().lower()
 
         total_config = sum(1 for e in ledger if _ct(e) == "config")
@@ -3506,6 +3527,11 @@ class SharedState:
         )
 
     def _format_last_trace_analyze(self) -> str:
+        """Render the most recent trace-analyze blob for the prompt.
+
+        Returns:
+            A formatted summary of ``last_trace_analyze``.
+        """
         return self._format_trace_analyze_blob(self.last_trace_analyze)
 
     def _format_trace_analyze_blob(self, blob: dict[str, Any] | None) -> str:

--- a/inference_optimizer/orchestrator/shared_state.py
+++ b/inference_optimizer/orchestrator/shared_state.py
@@ -77,7 +77,17 @@ _MODEL_ARCH_STRUCTURED_FIELDS: tuple[tuple[str, str], ...] = (
 
 
 def render_model_arch_compact(arch: dict | None) -> str:
-    """Render the advisory ``model_arch`` profile as a single compact line (``""`` when empty/not a dict)."""
+    """Render the advisory ``model_arch`` profile as a single compact line (``""`` when empty/not a dict).
+
+    Args:
+        arch (dict | None): The advisory architecture profile mapping
+            (structured keys plus an optional free-text ``notes`` field).
+
+    Returns:
+        str: A ``"; "``-joined ``label=value`` line over the recognized
+            structured fields (plus ``notes`` when present), or ``""`` when
+            ``arch`` is empty or not a dict.
+    """
     if not isinstance(arch, dict) or not arch:
         return ""
     parts: list[str] = []
@@ -172,6 +182,15 @@ def _cap_tested_ledger(tested: dict[str, Any]) -> dict[str, Any]:
     order, so retaining the last ``_EXPLORE_TESTED_CAP`` keys evicts the oldest
     rejections first. Dropping a stale rejection only risks one re-exploration,
     which the round-level dedup still catches in-session.
+
+    Args:
+        tested (dict[str, Any]): The explore_search negative ledger keyed by
+            canonical fingerprint.
+
+    Returns:
+        dict[str, Any]: The ledger trimmed to the most recent
+            ``_EXPLORE_TESTED_CAP`` keys, or an empty dict when ``tested`` is
+            not a dict.
     """
     if not isinstance(tested, dict) or len(tested) <= _EXPLORE_TESTED_CAP:
         return tested if isinstance(tested, dict) else {}
@@ -189,6 +208,18 @@ def _stamp_cycle_on_tested(
     ``cycle`` / ``bottleneck`` values are preserved so an entry stays attributed
     to the cycle + bottleneck that first rejected it, enabling per-cycle /
     per-bottleneck bucketing of veto fingerprints across bottleneck shifts.
+
+    Args:
+        tested (dict[str, Any]): The negative ledger keyed by fingerprint;
+            entry dict values are stamped in place.
+        cycle (int): The macro-cycle to attribute newly-stamped entries to.
+        bottleneck (str): The live bottleneck label to stamp; blank values
+            skip the bottleneck stamp.
+
+    Returns:
+        dict[str, Any]: The same ``tested`` mapping with ``cycle`` /
+            ``bottleneck`` stamped on entries lacking them, or an empty dict
+            when ``tested`` is not a dict.
     """
     if not isinstance(tested, dict):
         return {}
@@ -205,7 +236,20 @@ def _stamp_cycle_on_tested(
 def _stamp_cycle_on_rejected(
     rejected: list[Any], cycle: int, bottleneck: str = "",
 ) -> list[Any]:
-    """Bucket rejected entries by macro-cycle + bottleneck (R3)."""
+    """Bucket rejected entries by macro-cycle + bottleneck (R3).
+
+    Args:
+        rejected (list[Any]): The rejected-entries list; dict items are
+            stamped in place.
+        cycle (int): The macro-cycle to attribute newly-stamped entries to.
+        bottleneck (str): The live bottleneck label to stamp; blank values
+            skip the bottleneck stamp.
+
+    Returns:
+        list[Any]: The same ``rejected`` list with ``cycle`` /
+            ``bottleneck`` stamped on entries lacking them, or an empty list
+            when ``rejected`` is not a list.
+    """
     if not isinstance(rejected, list):
         return []
     bn = (bottleneck or "").strip()
@@ -218,7 +262,16 @@ def _stamp_cycle_on_rejected(
     return rejected
 
 def _migrate_legacy_extra_sglang_args_keys(obj: Any) -> int:
-    """Recursively rewrite legacy ``extra_sglang_args`` field names in-place; returns count rewritten (canonical kept when both present)."""
+    """Recursively rewrite legacy ``extra_sglang_args`` field names in-place; returns count rewritten (canonical kept when both present).
+
+    Args:
+        obj (Any): An arbitrarily nested structure (dict / list / scalar);
+            dicts and lists are walked recursively and mutated in place.
+
+    Returns:
+        int: The number of legacy keys rewritten or dropped across the whole
+            structure.
+    """
     migrated = 0
     if isinstance(obj, dict):
         for legacy_key, canonical_key in _PHASE4_LEGACY_KEY_RENAMES.items():
@@ -824,7 +877,22 @@ class SharedState:
         params_winner_history: Any,
         synergy_attempted: Any,
     ) -> dict[str, Any]:
-        """Shape the unified ``explore_search`` ledger at load time; folds live history so resume preserves cross-round aggregation."""
+        """Shape the unified ``explore_search`` ledger at load time; folds live history so resume preserves cross-round aggregation.
+
+        Args:
+            existing (Any): The persisted ``explore_search`` dict (or any
+                value; non-dicts are treated as empty).
+            backend_winners_history (Any): Legacy backend-winners rows folded
+                into the unified ``winners_history``.
+            params_winner_history (Any): Legacy params-winner rows folded into
+                the unified ``winners_history``.
+            synergy_attempted (Any): Legacy synergy combos folded (deduped)
+                into ``synergy_attempted``.
+
+        Returns:
+            dict[str, Any]: The normalized ``explore_search`` ledger with all
+                required keys defaulted and live history folded in.
+        """
         from .action_executors._grid_runner import variant_fingerprint as _fp
 
         existing = existing if isinstance(existing, dict) else {}
@@ -1061,7 +1129,23 @@ class SharedState:
         *,
         strict: bool | None = None,
     ) -> str:
-        """Validated writer for :attr:`stop_reason` (Inv-8.3 closed vocab): values outside ``STOP_REASON_VOCAB`` map to ``"unknown"`` (lenient) or raise (``strict=True``, default env ``INFERENCE_OPTIMIZER_STRICT_STOP_REASON``). Returns value written."""
+        """Validated writer for :attr:`stop_reason` (Inv-8.3 closed vocab): values outside ``STOP_REASON_VOCAB`` map to ``"unknown"`` (lenient) or raise (``strict=True``, default env ``INFERENCE_OPTIMIZER_STRICT_STOP_REASON``). Returns value written.
+
+        Args:
+            value (str): The proposed stop reason; blank clears
+                :attr:`stop_reason`.
+            strict (bool | None): When ``True`` an out-of-vocab value raises;
+                when ``None`` the mode is read from
+                ``INFERENCE_OPTIMIZER_STRICT_STOP_REASON``.
+
+        Returns:
+            str: The value actually written (``""``, the validated reason, or
+                ``"unknown"`` in lenient mode).
+
+        Raises:
+            ValueError: When ``strict`` is enabled and ``value`` is not in
+                ``STOP_REASON_VOCAB``.
+        """
         from .phase_state import STOP_REASON_VOCAB, is_valid_stop_reason
         text = str(value or "").strip()
         if not text:
@@ -1093,7 +1177,15 @@ class SharedState:
 
     # escalate hint plumbing
     def set_pending_escalate_hint(self, hint: str) -> str:
-        """Stash the LLM-supplied hint for the next phase compute pass; unknown hints dropped (Inv-8.2: closed vocab). Returns value written."""
+        """Stash the LLM-supplied hint for the next phase compute pass; unknown hints dropped (Inv-8.2: closed vocab). Returns value written.
+
+        Args:
+            hint (str): The proposed escalate hint; values outside the closed
+                vocab (and blanks) are dropped.
+
+        Returns:
+            str: The hint actually stored (``""`` when dropped or blank).
+        """
         from .phase_state import is_valid_escalate_hint
         text = str(hint or "").strip()
         if text and not is_valid_escalate_hint(text):
@@ -1102,7 +1194,11 @@ class SharedState:
         return text
 
     def consume_pending_escalate_hint(self) -> str:
-        """Pop the pending hint (recording consumption in audit fields) so the next tick doesn't re-trigger; returns cleared hint."""
+        """Pop the pending hint (recording consumption in audit fields) so the next tick doesn't re-trigger; returns cleared hint.
+
+        Returns:
+            str: The consumed hint (``""`` when none was pending).
+        """
         hint = (self.pending_escalate_hint or "").strip()
         if not hint:
             return ""
@@ -1121,7 +1217,20 @@ class SharedState:
         ts: str | None = None,
         ts_unix: float | None = None,
     ) -> dict[str, Any]:
-        """Append a phase_history row and atomically update ``phase`` fields; ``phase``/``phase_history`` are CORE_STATE_FIELDS so LLM update_state is rejected. Returns the inserted row."""
+        """Append a phase_history row and atomically update ``phase`` fields; ``phase``/``phase_history`` are CORE_STATE_FIELDS so LLM update_state is rejected. Returns the inserted row.
+
+        Args:
+            to_phase (str): The phase being entered.
+            reason (str): The transition reason (from ``PHASE_EXIT_REASONS``).
+            evidence (dict[str, Any] | None): Optional structured evidence
+                attached to the history row.
+            ts (str | None): Optional ISO timestamp; defaults to now (UTC).
+            ts_unix (float | None): Optional Unix epoch matching ``ts``;
+                defaults to the current time.
+
+        Returns:
+            dict[str, Any]: The inserted phase_history row.
+        """
         from datetime import datetime as _dt, timezone as _tz
         import time as _time
         # Lazy import to avoid an import-time cycle.
@@ -1153,6 +1262,10 @@ class SharedState:
 
         Single accessor so the R3 redirect logic and prompt advisory read the
         same value (latest = ``roofline_snapshots[-1]``).
+
+        Returns:
+            str: The latest snapshot's ``top_bottleneck``, or ``""`` when no
+                snapshot exists.
         """
         snaps = self.roofline_snapshots if isinstance(self.roofline_snapshots, list) else []
         if not snaps:
@@ -1168,6 +1281,10 @@ class SharedState:
         Called when a cyclic EXPLORE plateau winds the cycle down. Records the
         bottleneck we plateaued on so the redirect advisory can steer specialists
         away from it; falls back to the live top bottleneck when not supplied.
+
+        Args:
+            prev_bottleneck (str): The bottleneck plateaued on; when blank the
+                live top bottleneck is used instead.
         """
         self.pending_bottleneck_switch = True
         pb = (prev_bottleneck or "").strip() or self.current_top_bottleneck()
@@ -1185,6 +1302,13 @@ class SharedState:
         Returns True when the flag was cleared. A fresh roofline whose top
         bottleneck differs from the plateaued one means the redirect succeeded,
         so the orchestration prompt should stop nagging.
+
+        Args:
+            new_top_bottleneck (str): The current live top bottleneck.
+
+        Returns:
+            bool: ``True`` when a pending switch was cleared, ``False``
+                otherwise.
         """
         if not bool(getattr(self, "pending_bottleneck_switch", False)):
             return False
@@ -1222,6 +1346,23 @@ class SharedState:
         Coordinator-only writer (``policy.CORE_STATE_FIELDS`` guards
         ``lifecycle`` so an LLM ``update_state`` cannot forge events).
         Returns the inserted row.
+
+        Args:
+            step (str): The machine step/handler name (e.g. ``trace_analyze``).
+            status (str): The boundary status (e.g. ``START`` / ``END`` /
+                ``ERROR``).
+            phase (str | None): The owning phase; defaults to the current
+                coordinator phase.
+            label (str | None): Human-friendly step name; defaults to the
+                mapping in ``phase_state.LIFECYCLE_STEP_LABELS``.
+            artifacts (dict[str, str] | None): Optional produced-artifact
+                path map recorded on the event.
+            detail (str): Optional free-text detail.
+            duration_s (float | None): Optional step duration in seconds.
+            ts (str | None): Optional ISO timestamp; defaults to now (UTC).
+
+        Returns:
+            dict[str, Any]: The inserted lifecycle event row.
         """
         # Lazy import to avoid an import-time cycle with the orchestrator
         # package (phase_state imports nothing from SharedState).
@@ -1321,7 +1462,21 @@ class SharedState:
         traceback_text: str,
         agent: str = "",
     ) -> dict[str, Any]:
-        """Persist a compact Coordinator exception summary for postmortems."""
+        """Persist a compact Coordinator exception summary for postmortems.
+
+        Args:
+            tick (int): The Coordinator tick at which the exception fired.
+            stage (str): The tick-loop stage that raised.
+            exc_type (str): The exception class name.
+            message (str): The exception message (truncated to 1000 chars).
+            traceback_text (str): The formatted traceback (truncated to
+                12000 chars).
+            agent (str): Optional agent identifier associated with the stage.
+
+        Returns:
+            dict[str, Any]: The recorded exception summary now stored in
+                :attr:`last_tick_exception`.
+        """
         entry = {
             "tick": int(tick or 0),
             "ts": _now_iso(),
@@ -1335,7 +1490,18 @@ class SharedState:
         return entry
 
     def apply_changes(self, changes: dict[str, Any], *, allow_core: bool) -> dict[str, Any]:
-        """Merge a non-empty changes dict into this state; does NOT re-validate the role/source allowlist (PolicyGate filters upstream). Returns fields actually written."""
+        """Merge a non-empty changes dict into this state; does NOT re-validate the role/source allowlist (PolicyGate filters upstream). Returns fields actually written.
+
+        Args:
+            changes (dict[str, Any]): Field-name -> value mapping to apply;
+                keys not matching a dataclass field are ignored.
+            allow_core (bool): Whether core fields may be written (enforced by
+                PolicyGate upstream; accepted here for call-site parity).
+
+        Returns:
+            dict[str, Any]: The subset of ``changes`` actually written to
+                dataclass fields.
+        """
         if not changes:
             return {}
         applied: dict[str, Any] = {}
@@ -1592,7 +1758,12 @@ class SharedState:
         return entry
 
     def record_kernel_opt(self, result: dict[str, Any]) -> None:
-        """Capture kernel_optimization_handler result for the next Orch turn; empty kernel_id no-op, non-KEEP can't overwrite a pending KEEP, retires kernel_id (r24 guard) after >= max_partial PARTIALs (INFERENCE_OPTIMIZER_KERNEL_OPT_MAX_PARTIAL)."""
+        """Capture kernel_optimization_handler result for the next Orch turn; empty kernel_id no-op, non-KEEP can't overwrite a pending KEEP, retires kernel_id (r24 guard) after >= max_partial PARTIALs (INFERENCE_OPTIMIZER_KERNEL_OPT_MAX_PARTIAL).
+
+        Args:
+            result (dict[str, Any]): The kernel_optimization_handler result
+                envelope; non-dicts and empty ``kernel_id`` are no-ops.
+        """
         if not isinstance(result, dict):
             return
         # Author-time breakdown capture: record geak/oob invocations (incl.
@@ -1821,7 +1992,13 @@ class SharedState:
         }
 
     def _source_files_in_optimization_stack(self) -> set[str]:
-        """source_file paths already touched by an integrate entry; enforces "same source_file, only strongest KEEP integrated" (apply_kernel_patch is a whole-file overwrite)."""
+        """source_file paths already touched by an integrate entry; enforces "same source_file, only strongest KEEP integrated" (apply_kernel_patch is a whole-file overwrite).
+
+        Returns:
+            set[str]: The set of ``target_file`` / ``source_file`` paths
+                referenced by ``integrate`` entries of
+                :attr:`optimization_stack`.
+        """
         sources: set[str] = set()
         for e in (self.optimization_stack or []):
             if not isinstance(e, dict) or e.get("action") != "integrate":
@@ -1832,7 +2009,12 @@ class SharedState:
         return sources
 
     def _kernel_ids_with_integrate_attempts(self) -> set[str]:
-        """kernel_ids that already received an E2E integrate verdict."""
+        """kernel_ids that already received an E2E integrate verdict.
+
+        Returns:
+            set[str]: The set of ``kernel_id`` values recorded in
+                :attr:`kernel_integrate_attempts`.
+        """
         ids: set[str] = set()
         for entry in (self.kernel_integrate_attempts or {}).values():
             if not isinstance(entry, dict):
@@ -1843,7 +2025,16 @@ class SharedState:
         return ids
 
     def _kernel_trace_impact_pct(self, kernel_id: str) -> float:
-        """Return TraceLens gpu_pct for a kernel_id; unknown kernels sort last."""
+        """Return TraceLens gpu_pct for a kernel_id; unknown kernels sort last.
+
+        Args:
+            kernel_id (str): The kernel identifier to look up in the latest
+                trace-analyze ``hot_kernels_top15``.
+
+        Returns:
+            float: The kernel's ``gpu_pct`` impact, or ``0.0`` when blank,
+                unknown, or unparseable.
+        """
         kid = str(kernel_id or "").strip()
         if not kid:
             return 0.0
@@ -1865,6 +2056,10 @@ class SharedState:
         Ordering favors trace impact (``gpu_pct``) over kernel micro speedup:
         E2E validation should test the highest-impact hot kernel first, not
         merely the patch with the largest isolated microbenchmark win.
+
+        Returns:
+            str: The highest-impact pending KEEP ``kernel_id``, or ``""``
+                when the queue is drained.
         """
         pending = self.pending_keep_kernel_ids()
         return pending[0] if pending else ""
@@ -1876,6 +2071,10 @@ class SharedState:
         ``NEEDS_REVIEW``) are excluded so a noisy near-threshold result does not
         automatically rerun the same patch up to the historical max-attempt cap.
         Positive ``NEEDS_REVIEW`` rows are handled by stack validation instead.
+
+        Returns:
+            list[str]: Pending KEEP ``kernel_id`` values sorted impact-first
+                (trace ``gpu_pct``, then micro speedup), one per source file.
         """
         integrated_ids = self._kernel_ids_in_optimization_stack()
         integrated_sources = self._source_files_in_optimization_stack()
@@ -1935,7 +2134,18 @@ class SharedState:
         min_gpu_pct: float | None = None,
         top_n: int | None = None,
     ) -> list[str]:
-        """Hot kernels still owing a ``kernel_opt`` attempt (reusable, gpu_pct >= min_gpu_pct, untouched); capped to top_n by gpu_pct, one kernel_id per task_group."""
+        """Hot kernels still owing a ``kernel_opt`` attempt (reusable, gpu_pct >= min_gpu_pct, untouched); capped to top_n by gpu_pct, one kernel_id per task_group.
+
+        Args:
+            min_gpu_pct (float | None): Minimum GPU-share threshold; when
+                ``None`` it is read from ``HYPERLOOM_KERNEL_OPT_MIN_GPU_PCT``.
+            top_n (int | None): Cap on enforced kernels by gpu_pct; when
+                ``None`` it is read from ``HYPERLOOM_KERNEL_OPT_GATE_TOP_N``.
+
+        Returns:
+            list[str]: The untried hot-reusable ``kernel_id`` values (one per
+                task_group), sorted strongest-first.
+        """
         info = self.last_trace_analyze or {}
         hot = info.get("hot_kernels_top15") or info.get("hot_kernels") or []
         task_groups = info.get("task_groups") or []
@@ -2021,7 +2231,16 @@ class SharedState:
     # Per-action audit (kernel parity for non-kernel actions)
     @staticmethod
     def _truncate_excerpt(value: Any, *, limit: int = 800) -> str | None:
-        """Coerce ``value`` to str and trim to ``limit`` chars; None for falsy inputs (renderer shows ``err=(none)``)."""
+        """Coerce ``value`` to str and trim to ``limit`` chars; None for falsy inputs (renderer shows ``err=(none)``).
+
+        Args:
+            value (Any): The value to coerce to a string excerpt.
+            limit (int): Maximum retained length in characters (default 800).
+
+        Returns:
+            str | None: The trimmed string, or ``None`` when ``value`` is
+                falsy.
+        """
         if value is None:
             return None
         text = str(value)
@@ -2033,7 +2252,17 @@ class SharedState:
 
     @staticmethod
     def _stderr_tail(value: Any, *, limit: int = 1000) -> str | None:
-        """Pull the last ``limit`` chars from a subprocess error blob (stderr's actionable signal is at the end)."""
+        """Pull the last ``limit`` chars from a subprocess error blob (stderr's actionable signal is at the end).
+
+        Args:
+            value (Any): The error blob to coerce and tail.
+            limit (int): Maximum retained trailing length in characters
+                (default 1000).
+
+        Returns:
+            str | None: The trailing slice of the string, or ``None`` when
+                ``value`` is falsy.
+        """
         if value is None:
             return None
         text = str(value)
@@ -2052,7 +2281,24 @@ class SharedState:
         extras: dict[str, Any] | None = None,
         max_history: int = _DEFAULT_ATTEMPTS_HISTORY,
     ) -> dict[str, Any] | None:
-        """Append one attempt to ``<action>_attempts`` and refresh ``last_<action>``. Entry schema {ts, task_id, status, decision, key_metric, key_metric_kind, workspace, error_class, error_excerpt, stderr_tail, raw_result_path, reported_success, extras}. Returns the entry, or None when ``action`` not in the audit set (kernel-owned actions use bespoke recorders). Does NOT call :meth:`save`."""
+        """Append one attempt to ``<action>_attempts`` and refresh ``last_<action>``. Entry schema {ts, task_id, status, decision, key_metric, key_metric_kind, workspace, error_class, error_excerpt, stderr_tail, raw_result_path, reported_success, extras}. Returns the entry, or None when ``action`` not in the audit set (kernel-owned actions use bespoke recorders). Does NOT call :meth:`save`.
+
+        Args:
+            action (str): The audited action name (must be in
+                ``_AUDIT_ACTIONS``).
+            task_id (str): The task id this attempt belongs to.
+            status (str): The task status string.
+            decision (str): The promotion decision string.
+            result (dict[str, Any] | None): The action result envelope;
+                ``None`` treated as empty.
+            extras (dict[str, Any] | None): Optional extra fields recorded on
+                the entry.
+            max_history (int): Cap on retained ``<action>_attempts`` entries.
+
+        Returns:
+            dict[str, Any] | None: The recorded attempt entry, or ``None``
+                when ``action`` is not audited.
+        """
         if action not in _AUDIT_ACTIONS:
             return None
         attempts_attr = f"{action}_attempts"
@@ -2130,7 +2376,19 @@ class SharedState:
         result: dict[str, Any] | None,
         max_history: int = _DEFAULT_LAST_FAILURES,
     ) -> dict[str, Any]:
-        """Append one rich failure record to :attr:`last_action_failures` for self-correction; invoked for EVERY unpromotable task kind, unlike :meth:`record_action_attempt`."""
+        """Append one rich failure record to :attr:`last_action_failures` for self-correction; invoked for EVERY unpromotable task kind, unlike :meth:`record_action_attempt`.
+
+        Args:
+            action (str): The failed action name.
+            task_id (str): The task id that failed.
+            result (dict[str, Any] | None): The failure result envelope;
+                ``None`` treated as empty.
+            max_history (int): Cap on retained ``last_action_failures``
+                entries.
+
+        Returns:
+            dict[str, Any]: The recorded failure entry.
+        """
         result = result or {}
         error_class = result.get("error_class")
         error_class_str = str(error_class) if error_class else None
@@ -2172,6 +2430,10 @@ class SharedState:
         Prefers ``baseline_tput``; falls back to ``last_baseline``'s
         ``tput``/``output_throughput`` so a state that lost ``baseline_tput``
         still stamps an achieved value (avoids an empty within/gap pct).
+
+        Returns:
+            float: The resolved baseline throughput, or ``0.0`` when none is
+                available.
         """
         if isinstance(self.baseline_tput, (int, float)) and self.baseline_tput > 0:
             return float(self.baseline_tput)
@@ -2188,6 +2450,10 @@ class SharedState:
         Reads ``current_best``'s ``tput``/``output_throughput`` so a
         current_best-tagged snapshot keeps its arm even when ``tput`` is
         momentarily absent (avoids silently downgrading to the baseline arm).
+
+        Returns:
+            float: The resolved current_best throughput, or ``0.0`` when none
+                is available.
         """
         cb = self.current_best if isinstance(self.current_best, dict) else {}
         for key in ("tput", "output_throughput"):
@@ -2201,7 +2467,14 @@ class SharedState:
         payload: dict[str, Any],
         result: dict[str, Any],
     ) -> None:
-        """Write the canonical 11-field ``last_trace_analyze`` dict (single writer). ``roofline_snapshot_id`` increments monotonically; PR #321 retired ``last_trace_analyze_baseline`` (roofline_snapshots feeds report.py Roofline Comparison)."""
+        """Write the canonical 11-field ``last_trace_analyze`` dict (single writer). ``roofline_snapshot_id`` increments monotonically; PR #321 retired ``last_trace_analyze_baseline`` (roofline_snapshots feeds report.py Roofline Comparison).
+
+        Args:
+            payload (dict[str, Any]): The trace_analyze task payload (supplies
+                ``trace_input`` / ``trace_dir`` and optional ``roofline_arm``).
+            result (dict[str, Any]): The trace_analyze result envelope; a
+                non-dict result is a no-op.
+        """
         if not isinstance(result, dict):
             return
         trace_input = (
@@ -2548,7 +2821,12 @@ class SharedState:
         }
 
     def record_conc_sweep(self, result: dict[str, Any]) -> None:
-        """Record conc_sweep task completion (mirrors record_sweep). Bug #12: status lets exit_normal_sweep return conc_sweep_done so SWEEP→CLOSE fires on conc_sweep alone."""
+        """Record conc_sweep task completion (mirrors record_sweep). Bug #12: status lets exit_normal_sweep return conc_sweep_done so SWEEP→CLOSE fires on conc_sweep alone.
+
+        Args:
+            result (dict[str, Any]): The conc_sweep result envelope; a
+                non-dict result is a no-op.
+        """
         if not isinstance(result, dict):
             return
         self.last_conc_sweep = {
@@ -2563,7 +2841,12 @@ class SharedState:
 
     # specialist round bookkeeping
     def record_specialist_round(self, entry: dict[str, Any]) -> None:
-        """Append one round summary to ``specialist_rounds``; idempotent on ``round_id`` (re-record overwrites)."""
+        """Append one round summary to ``specialist_rounds``; idempotent on ``round_id`` (re-record overwrites).
+
+        Args:
+            entry (dict[str, Any]): The round summary; an empty / non-dict
+                value is a no-op. A blank ``round_id`` always appends.
+        """
         if not isinstance(entry, dict) or not entry:
             return
         round_id = str(entry.get("round_id") or "").strip()
@@ -2597,7 +2880,17 @@ class SharedState:
     def bump_specialist_domain_empty_streak(
         self, domain: str, *, empty: bool,
     ) -> int:
-        """Increment/reset the per-domain empty-proposal streak; returns new value (escalation threshold lives in ``KB_design §3.9``, not here)."""
+        """Increment/reset the per-domain empty-proposal streak; returns new value (escalation threshold lives in ``KB_design §3.9``, not here).
+
+        Args:
+            domain (str): The specialist domain; blank normalizes to
+                ``"unknown"``.
+            empty (bool): ``True`` to increment the streak, ``False`` to reset
+                it to zero.
+
+        Returns:
+            int: The post-update streak value for the domain.
+        """
         d = str(domain or "").strip() or "unknown"
         if empty:
             self.specialist_domain_empty_streak[d] = int(
@@ -2624,7 +2917,15 @@ class SharedState:
 
     @staticmethod
     def _anchor_for(domain_or_anchor: str) -> str:
-        """Resolve a domain key or raw tag to its canonical kb_anchor."""
+        """Resolve a domain key or raw tag to its canonical kb_anchor.
+
+        Args:
+            domain_or_anchor (str): A domain key, raw tag, or anchor string.
+
+        Returns:
+            str: The canonical kb_anchor, falling back to the trimmed input
+                when no mapping resolves (``""`` for blank input).
+        """
         from .specialist_domains import domain_for_tag, get_domain
 
         s = str(domain_or_anchor or "").strip()
@@ -2639,13 +2940,23 @@ class SharedState:
         return s
 
     def note_specialist_dispatched(self, domain_or_anchor: str) -> None:
-        """Reset ``rounds_since_last_specialist`` for the dispatched anchor."""
+        """Reset ``rounds_since_last_specialist`` for the dispatched anchor.
+
+        Args:
+            domain_or_anchor (str): The dispatched domain / anchor whose
+                counter should be reset.
+        """
         anchor = self._anchor_for(domain_or_anchor)
         if anchor:
             self.rounds_since_last_specialist[anchor] = 0
 
     def note_domain_keep(self, domain_or_anchor: str) -> None:
-        """Reset ``rounds_since_last_keep`` for the anchor that just KEPT."""
+        """Reset ``rounds_since_last_keep`` for the anchor that just KEPT.
+
+        Args:
+            domain_or_anchor (str): The domain / anchor whose KEEP counter
+                should be reset.
+        """
         anchor = self._anchor_for(domain_or_anchor)
         if anchor:
             self.rounds_since_last_keep[anchor] = 0
@@ -2656,7 +2967,18 @@ class SharedState:
         """Return anchors whose ``rounds_since_last_specialist`` ≥
         ``specialist_threshold`` OR ``rounds_since_last_keep`` ≥
         ``keep_threshold`` (point 1 lower-bound; point 2 hard-trigger reads
-        this). Deterministically ordered by widest gap first."""
+        this). Deterministically ordered by widest gap first.
+
+        Args:
+            specialist_threshold (int): Rounds-since-last-specialist value at
+                or above which an anchor counts as stalled.
+            keep_threshold (int): Rounds-since-last-keep value at or above
+                which an anchor counts as stalled.
+
+        Returns:
+            list[str]: Stalled anchors ordered by widest gap first, then by
+                anchor name.
+        """
         anchors = (
             set(self.rounds_since_last_specialist)
             | set(self.rounds_since_last_keep)
@@ -2674,7 +2996,15 @@ class SharedState:
         """Return the canonical_id of the most actionable open gap whose
         ``domain_hint`` resolves to ``anchor`` (or ``""`` when none). Selection:
         highest severity, then least-attempted, then oldest (point 2 reads this
-        to force-dispatch a stalled domain that still has pending work)."""
+        to force-dispatch a stalled domain that still has pending work).
+
+        Args:
+            anchor (str): The domain / anchor to match gaps against.
+
+        Returns:
+            str: The ``canonical_id`` of the most actionable matching gap, or
+                ``""`` when none match.
+        """
         target = self._anchor_for(anchor)
         if not target:
             return ""
@@ -2699,7 +3029,15 @@ class SharedState:
 
     # gaps ledger helpers
     def find_gap(self, canonical_id: str) -> dict[str, Any] | None:
-        """Return the gap entry matching ``canonical_id`` (or ``None``)."""
+        """Return the gap entry matching ``canonical_id`` (or ``None``).
+
+        Args:
+            canonical_id (str): The gap's canonical identifier.
+
+        Returns:
+            dict[str, Any] | None: The matching gap row, or ``None`` when the
+                id is blank or not present.
+        """
         if not canonical_id:
             return None
         cid = str(canonical_id)
@@ -2709,7 +3047,16 @@ class SharedState:
         return None
 
     def upsert_gap(self, entry: dict[str, Any]) -> dict[str, Any]:
-        """Insert or update one gap row, keyed by ``canonical_id``. Coordinator-only writer (Inv-1 single-writer + CORE_STATE_FIELDS lock). Returns the merged entry."""
+        """Insert or update one gap row, keyed by ``canonical_id``. Coordinator-only writer (Inv-1 single-writer + CORE_STATE_FIELDS lock). Returns the merged entry.
+
+        Args:
+            entry (dict[str, Any]): The gap row to upsert; must carry a
+                non-empty ``canonical_id`` (else a no-op returning ``{}``).
+
+        Returns:
+            dict[str, Any]: The inserted-or-merged gap row, or ``{}`` when the
+                entry is invalid.
+        """
         if not isinstance(entry, dict):
             return {}
         cid = str(entry.get("canonical_id") or "").strip()
@@ -2780,7 +3127,17 @@ class SharedState:
         canonical_id: str,
         attempt: dict[str, Any],
     ) -> dict[str, Any] | None:
-        """Append one attempt row to an existing gap; returns the gap or ``None`` when unknown (caller may ``upsert_gap`` instead)."""
+        """Append one attempt row to an existing gap; returns the gap or ``None`` when unknown (caller may ``upsert_gap`` instead).
+
+        Args:
+            canonical_id (str): The gap's canonical identifier.
+            attempt (dict[str, Any]): The attempt row to append (a ``ts`` is
+                stamped when absent).
+
+        Returns:
+            dict[str, Any] | None: The updated gap row, or ``None`` when no
+                gap matches ``canonical_id``.
+        """
         gap = self.find_gap(canonical_id)
         if gap is None:
             return None
@@ -2793,7 +3150,13 @@ class SharedState:
         return gap
 
     def replace_gaps(self, entries: list[dict[str, Any]]) -> None:
-        """Bulk-replace ``gaps`` with a fresh dedup'd list (discards stale rows wholesale); idempotent."""
+        """Bulk-replace ``gaps`` with a fresh dedup'd list (discards stale rows wholesale); idempotent.
+
+        Args:
+            entries (list[dict[str, Any]]): The replacement gap rows; deduped
+                by ``canonical_id``, per-gap attempts and the list are capped.
+                A non-list value is a no-op.
+        """
         if not isinstance(entries, list):
             return
         dedup: dict[str, dict[str, Any]] = {}
@@ -2828,7 +3191,16 @@ class SharedState:
         task_id: str = "",
         delta_pct: float | None = None,
     ) -> None:
-        """Append one intervention entry and update config-only counters. consecutive-config counter advances on ``"config"``, resets on ``"code_patch"``; ``"code_patch_attempt"`` is telemetry-only."""
+        """Append one intervention entry and update config-only counters. consecutive-config counter advances on ``"config"``, resets on ``"code_patch"``; ``"code_patch_attempt"`` is telemetry-only.
+
+        Args:
+            change_type (str): The intervention kind (e.g. ``config`` /
+                ``code_patch`` / ``code_patch_attempt``).
+            action (str): The action name driving the intervention.
+            task_id (str): The originating task id.
+            delta_pct (float | None): Optional measured gain delta for the
+                intervention.
+        """
         ct = str(change_type or "").strip().lower()
         entry = {
             "change_type": ct,
@@ -2848,7 +3220,17 @@ class SharedState:
             self.consecutive_config_only_rounds = 0
 
     def get_intervention_mix(self, *, recent_window: int = 5) -> dict[str, Any]:
-        """Summarise the intervention-mix ledger as derived counts (config vs code_patch totals, recent window, consecutive_config_only, config_heavy). Read-only; unknown change_types ignored in tallies but break the trailing config-only run."""
+        """Summarise the intervention-mix ledger as derived counts (config vs code_patch totals, recent window, consecutive_config_only, config_heavy). Read-only; unknown change_types ignored in tallies but break the trailing config-only run.
+
+        Args:
+            recent_window (int): Size of the trailing window for the
+                ``recent_*`` tallies; non-positive uses the full ledger.
+
+        Returns:
+            dict[str, Any]: Derived totals (total/recent config and
+                code_patch counts, ``consecutive_config_only``,
+                ``config_heavy``).
+        """
         ledger = [e for e in (self.intervention_mix or []) if isinstance(e, dict)]
 
         def _ct(entry: dict[str, Any]) -> str:
@@ -2896,7 +3278,14 @@ class SharedState:
         }
 
     def bump_specialist_dispatched(self, n: int = 1) -> int:
-        """Increment the per-EXPLORE specialist dispatch counter; returns post-increment value."""
+        """Increment the per-EXPLORE specialist dispatch counter; returns post-increment value.
+
+        Args:
+            n (int): Amount to add to the dispatch counter (default 1).
+
+        Returns:
+            int: The post-increment dispatch count.
+        """
         self.explore_specialist_dispatched_count = (
             int(self.explore_specialist_dispatched_count or 0) + int(n)
         )
@@ -2907,12 +3296,27 @@ class SharedState:
         self.explore_specialist_dispatched_count = 0
 
     def bump_research_scout_runs(self, n: int = 1) -> int:
-        """Increment the research-scout dispatch counter; return new total."""
+        """Increment the research-scout dispatch counter; return new total.
+
+        Args:
+            n (int): Amount to add to the scout-run counter (default 1).
+
+        Returns:
+            int: The post-increment scout-run total.
+        """
         self.research_scout_runs = int(self.research_scout_runs or 0) + int(n)
         return self.research_scout_runs
 
     def register_seen_pr_ids(self, pr_ids: Any) -> int:
-        """Add PR ids to the shared seen-set (scout + FRAMEWORK_PR dedup); returns count newly added."""
+        """Add PR ids to the shared seen-set (scout + FRAMEWORK_PR dedup); returns count newly added.
+
+        Args:
+            pr_ids (Any): An iterable of PR id values; blanks and duplicates
+                are skipped.
+
+        Returns:
+            int: The number of PR ids newly added to the seen-set.
+        """
         seen = set(self.research_scout_seen_pr_ids or [])
         added = 0
         for raw in pr_ids or []:
@@ -2930,7 +3334,14 @@ class SharedState:
         return added
 
     def has_seen_pr_id(self, pr_id: Any) -> bool:
-        """True iff ``pr_id`` was already surfaced by scout / FRAMEWORK_PR."""
+        """True iff ``pr_id`` was already surfaced by scout / FRAMEWORK_PR.
+
+        Args:
+            pr_id (Any): The PR id to check.
+
+        Returns:
+            bool: ``True`` when the id is non-blank and already seen.
+        """
         pid = str(pr_id or "").strip()
         return bool(pid) and pid in set(self.research_scout_seen_pr_ids or [])
 
@@ -2940,14 +3351,25 @@ class SharedState:
         self.params_no_promote_streak = 0
 
     def note_explore_outcome(self, *, promoted: bool) -> None:
-        """Update the legacy plateau proxy after one explore task (KEEP resets, no-promote increments)."""
+        """Update the legacy plateau proxy after one explore task (KEEP resets, no-promote increments).
+
+        Args:
+            promoted (bool): ``True`` when the explore task produced a KEEP
+                (resets the proxy); ``False`` increments the no-promote
+                streak.
+        """
         if promoted:
             self.reset_explore_plateau_proxy()
         else:
             self.params_no_promote_streak += 1
 
     def to_intervention_mix_summary(self) -> str:
-        """Render the intervention ledger as neutral telemetry (one-line counts summary; ``""`` when empty). No directive emitted — config-vs-patch is the LLM's choice."""
+        """Render the intervention ledger as neutral telemetry (one-line counts summary; ``""`` when empty). No directive emitted — config-vs-patch is the LLM's choice.
+
+        Returns:
+            str: A single-line counts summary, or ``""`` when the ledger is
+                empty.
+        """
         mix = self.intervention_mix or []
         if not mix:
             return ""
@@ -2976,7 +3398,14 @@ class SharedState:
     def record_specialist_patch_verdict(
         self, specialist_task_id: str, verdict: str,
     ) -> None:
-        """Record the Critic verdict for a specialist worktree patch; idempotent (later verdict overwrites), empty ``verdict`` clears the entry to force re-review."""
+        """Record the Critic verdict for a specialist worktree patch; idempotent (later verdict overwrites), empty ``verdict`` clears the entry to force re-review.
+
+        Args:
+            specialist_task_id (str): The specialist task id; blank is a
+                no-op.
+            verdict (str): The Critic verdict; blank clears the recorded
+                verdict to force re-review.
+        """
         sid = str(specialist_task_id or "").strip()
         if not sid:
             return
@@ -2989,7 +3418,15 @@ class SharedState:
     def get_specialist_patch_verdict(
         self, specialist_task_id: str,
     ) -> str:
-        """Return the patch verdict, or empty when no Critic decision exists."""
+        """Return the patch verdict, or empty when no Critic decision exists.
+
+        Args:
+            specialist_task_id (str): The specialist task id.
+
+        Returns:
+            str: The recorded verdict, or ``""`` when none exists or the id
+                is blank.
+        """
         sid = str(specialist_task_id or "").strip()
         if not sid:
             return ""
@@ -3006,7 +3443,13 @@ class SharedState:
             self.last_specialist = dict(snapshot)
 
     def apply_explore_search_update(self, update: dict[str, Any]) -> None:
-        """Merge an ExploreExecutor search update into persistent state (v0.8 M3); executor never writes ``accepted`` directly — :meth:`record_explore_accepted` is the single writer for that bucket."""
+        """Merge an ExploreExecutor search update into persistent state (v0.8 M3); executor never writes ``accepted`` directly — :meth:`record_explore_accepted` is the single writer for that bucket.
+
+        Args:
+            update (dict[str, Any]): The executor's explore-search update
+                (tested / rejected / name_index / history fields); a non-dict
+                value is a no-op.
+        """
         if not isinstance(update, dict):
             return
         prior = self.explore_search if isinstance(self.explore_search, dict) else {}
@@ -3063,7 +3506,12 @@ class SharedState:
         self.explore_search = merged
 
     def record_explore_accepted(self, variant: dict[str, Any]) -> None:
-        """Append one promoted variant to ``explore_search.accepted``; dedupes by ``fingerprint`` and removes any matching ``rejected`` entry so a variant isn't in both buckets."""
+        """Append one promoted variant to ``explore_search.accepted``; dedupes by ``fingerprint`` and removes any matching ``rejected`` entry so a variant isn't in both buckets.
+
+        Args:
+            variant (dict[str, Any]): The promoted variant to record; an
+                empty / non-dict value is a no-op.
+        """
         if not isinstance(variant, dict) or not variant:
             return
         from .action_executors._canonical_fingerprint import canonical_fingerprint
@@ -3129,7 +3577,17 @@ class SharedState:
         param_flags: list[str] | None = None,
         source_path: str = "",
     ) -> None:
-        """Persist the AST-discovered flag list for a framework; the prompt surfaces the union so the LLM synthesizes new GridVariants beyond DEFAULT_*_GRID. Idempotent per-framework."""
+        """Persist the AST-discovered flag list for a framework; the prompt surfaces the union so the LLM synthesizes new GridVariants beyond DEFAULT_*_GRID. Idempotent per-framework.
+
+        Args:
+            framework (str): The framework key; blank normalizes to
+                ``"unknown"``.
+            backend_flags (list[str] | None): Discovered backend flags;
+                ``None`` leaves the existing list untouched.
+            param_flags (list[str] | None): Discovered parameter flags;
+                ``None`` leaves the existing list untouched.
+            source_path (str): Optional path to the scanned source file.
+        """
         fw = (framework or "").strip().lower() or "unknown"
         entry = dict(self.discovered_flags.get(fw) or {})
         if backend_flags is not None:
@@ -3160,7 +3618,19 @@ class SharedState:
         extra_server_args: str = "",
         ts: str | None = None,
     ) -> float | None:
-        """Mirror an optimization_stack append into gain_per_stack_entry; computes ``(new_tput-baseline_tput)/baseline_tput*100`` and appends. Returns gain_pct (None when baseline_tput is 0 or new_tput non-positive)."""
+        """Mirror an optimization_stack append into gain_per_stack_entry; computes ``(new_tput-baseline_tput)/baseline_tput*100`` and appends. Returns gain_pct (None when baseline_tput is 0 or new_tput non-positive).
+
+        Args:
+            action (str): The action that produced the stack entry.
+            variant_name (str | None): The variant name, when applicable.
+            new_tput (float): The measured throughput for the entry.
+            extra_server_args (str): The extra server args for the entry.
+            ts (str | None): Optional ISO timestamp for the entry.
+
+        Returns:
+            float | None: The computed incremental gain pct, or ``None`` when
+                ``baseline_tput`` is 0 or ``new_tput`` is non-positive.
+        """
         try:
             base = float(self.baseline_tput or 0.0)
         except (TypeError, ValueError):
@@ -3202,7 +3672,16 @@ class SharedState:
 
     # Time-budget helpers (consumed by Coordinator._compose_prompt)
     def elapsed_minutes(self, *, now: datetime | None = None) -> float:
-        """Wall-clock minutes since ``start_ts`` (0.0 when empty/unparseable)."""
+        """Wall-clock minutes since ``start_ts`` (0.0 when empty/unparseable).
+
+        Args:
+            now (datetime | None): Reference time; defaults to the current UTC
+                time.
+
+        Returns:
+            float: Minutes elapsed since ``start_ts`` (clamped at 0.0; 0.0
+                when ``start_ts`` is empty or unparseable).
+        """
         if not self.start_ts:
             return 0.0
         try:
@@ -3218,17 +3697,39 @@ class SharedState:
         return max(0.0, delta)
 
     def remaining_minutes(self, *, now: datetime | None = None) -> float | None:
-        """Minutes left in the wall-clock budget; ``None`` when ``max_minutes`` unset (unbounded), else clamped at 0."""
+        """Minutes left in the wall-clock budget; ``None`` when ``max_minutes`` unset (unbounded), else clamped at 0.
+
+        Args:
+            now (datetime | None): Reference time; defaults to the current UTC
+                time.
+
+        Returns:
+            float | None: Minutes remaining in the budget (clamped at 0.0), or
+                ``None`` when ``max_minutes`` is unset.
+        """
         if not self.max_minutes:
             return None
         return max(0.0, float(self.max_minutes) - self.elapsed_minutes(now=now))
 
     def optimization_stack_has_unvalidated_keeps(self) -> bool:
-        """True iff a new KEEP landed since the last inline stack rebench (purely a stack-length check vs ``cumulative_gain_validated_stack_len``)."""
+        """True iff a new KEEP landed since the last inline stack rebench (purely a stack-length check vs ``cumulative_gain_validated_stack_len``).
+
+        Returns:
+            bool: ``True`` when ``optimization_stack`` is longer than
+                ``cumulative_gain_validated_stack_len``.
+        """
         return len(self.optimization_stack) > int(self.cumulative_gain_validated_stack_len)
 
     def to_mission_summary(self, *, now: datetime | None = None) -> str:
-        """Mission-progress block printed at the top of every tick (outcome-shaped state: raw/validated gain, time vs budget, stack staleness); distinct from :meth:`to_prompt_summary`."""
+        """Mission-progress block printed at the top of every tick (outcome-shaped state: raw/validated gain, time vs budget, stack staleness); distinct from :meth:`to_prompt_summary`.
+
+        Args:
+            now (datetime | None): Reference time for elapsed / remaining
+                calculations; defaults to the current UTC time.
+
+        Returns:
+            str: The multi-line mission-progress block.
+        """
         elapsed = self.elapsed_minutes(now=now)
         remaining = self.remaining_minutes(now=now)
         budget_line = (
@@ -3286,7 +3787,16 @@ class SharedState:
         budget_pct: dict[str, float] | None = None,
         now_unix: float | None = None,
     ) -> str:
-        """Render the per-tick ``=== Phase ===`` block (v0.8 §3.3); compact (≤5 lines). EXPLORE adds a ``force_exit`` line showing runway before the hard force-exit gate."""
+        """Render the per-tick ``=== Phase ===`` block (v0.8 §3.3); compact (≤5 lines). EXPLORE adds a ``force_exit`` line showing runway before the hard force-exit gate.
+
+        Args:
+            budget_pct (dict[str, float] | None): Per-phase budget fractions;
+                defaults to :attr:`phase_budget_pct`.
+            now_unix (float | None): Reference Unix time; defaults to now.
+
+        Returns:
+            str: The compact ``=== Phase ===`` block.
+        """
         from .phase_state import (
             DEFAULT_EXPLORE_FORCE_EXIT_BUDGET_PCT,
             DEFAULT_EXPLORE_FORCE_EXIT_HOURS_REMAINING,
@@ -3375,7 +3885,17 @@ class SharedState:
         budget_pct: dict[str, float] | None = None,
         now_unix: float | None = None,
     ) -> str:
-        """Render the per-phase budget telemetry block for Robustness (one ``phase: elapsed=Xs cap=Ys (Z%)`` line per phase) so it can spot budget overruns."""
+        """Render the per-phase budget telemetry block for Robustness (one ``phase: elapsed=Xs cap=Ys (Z%)`` line per phase) so it can spot budget overruns.
+
+        Args:
+            budget_pct (dict[str, float] | None): Per-phase budget fractions;
+                defaults to :attr:`phase_budget_pct`.
+            now_unix (float | None): Reference Unix time; defaults to now.
+
+        Returns:
+            str: One telemetry line per phase, or ``"(no phase history yet)"``
+                when no history exists.
+        """
         from .phase_state import (
             DEFAULT_PHASE_BUDGET_PCT,
             PHASE_NAMES,
@@ -3423,7 +3943,15 @@ class SharedState:
         return "\n".join(lines) or "(no phase history yet)"
 
     def to_warm_start_summary(self, *, max_lines: int = 12) -> str:
-        """Render T0 warm-start snapshot for the ``=== Warm start ===`` prompt section (v0.8 §3.3 §4.1); empty when no recipe/pitfalls. Capped; full JSON at runtime/cortex/.kb_warm.json / .kb_pitfalls.json."""
+        """Render T0 warm-start snapshot for the ``=== Warm start ===`` prompt section (v0.8 §3.3 §4.1); empty when no recipe/pitfalls. Capped; full JSON at runtime/cortex/.kb_warm.json / .kb_pitfalls.json.
+
+        Args:
+            max_lines (int): Cap on rendered lines before truncation.
+
+        Returns:
+            str: The warm-start summary block, or ``""`` when no recipe /
+                pitfalls are present.
+        """
         recipe = self.warm_start_recipe or {}
         pitfalls = self.warm_start_pitfalls or []
         if not recipe and not pitfalls:
@@ -3466,7 +3994,14 @@ class SharedState:
         return "\n".join(out)
 
     def to_gaps_summary(self, *, max_entries: int = 10) -> str:
-        """Render :attr:`gaps` for prompt injection (KB_design §3.3/§3.5); empty when no gaps. Capped at ``max_entries`` newest rows."""
+        """Render :attr:`gaps` for prompt injection (KB_design §3.3/§3.5); empty when no gaps. Capped at ``max_entries`` newest rows.
+
+        Args:
+            max_entries (int): Maximum number of newest gap rows to render.
+
+        Returns:
+            str: The rendered gaps block, or ``""`` when no gaps exist.
+        """
         if not self.gaps:
             return ""
         # Newest first by last_updated_ts (deterministic fallback to first_seen_ts/insertion).
@@ -3509,7 +4044,16 @@ class SharedState:
         return "\n".join(rows)
 
     def to_proposal_scores_summary(self, *, max_rounds: int = 2) -> str:
-        """Render advisory multi-model proposal scores for Orchestration. NO mean/sorting (Inv-9.1: no system-side scoreboard); rater identities anonymized to avoid brand bias. Empty when no recent round carries scores."""
+        """Render advisory multi-model proposal scores for Orchestration. NO mean/sorting (Inv-9.1: no system-side scoreboard); rater identities anonymized to avoid brand bias. Empty when no recent round carries scores.
+
+        Args:
+            max_rounds (int): Maximum number of recent scored rounds to
+                render.
+
+        Returns:
+            str: The anonymized proposal-scores block, or ``""`` when no
+                recent round carries scores.
+        """
         rounds = [
             r for r in (self.specialist_rounds or [])
             if isinstance(r, dict)
@@ -3699,7 +4243,12 @@ class SharedState:
         )
 
     def _format_attempts_history(self) -> str:
-        """One-line summary across the audit actions (``baseline:total(s<succ>,f<fail>) ...``) so the LLM gauges reliability without 6x20 rows."""
+        """One-line summary across the audit actions (``baseline:total(s<succ>,f<fail>) ...``) so the LLM gauges reliability without 6x20 rows.
+
+        Returns:
+            str: A per-action totals summary, or ``"(no attempts recorded)"``
+                when no attempts exist.
+        """
         parts: list[str] = []
         for action in sorted(_AUDIT_ACTIONS):
             attempts_attr = f"{action}_attempts"
@@ -3719,7 +4268,12 @@ class SharedState:
         return " ".join(parts) if parts else "(no attempts recorded)"
 
     def _format_last_action_failures(self) -> str:
-        """Render up to the 3 most-recent global failures (rich-context companion to crash_count/baseline_failure_streak); full list on disk."""
+        """Render up to the 3 most-recent global failures (rich-context companion to crash_count/baseline_failure_streak); full list on disk.
+
+        Returns:
+            str: A pipe-joined render of the last 3 failures (with an
+                ``[+N earlier]`` suffix when more exist), or ``"(none)"``.
+        """
         if not self.last_action_failures:
             return "(none)"
         rows: list[str] = []
@@ -3779,7 +4333,15 @@ class SharedState:
 
     @staticmethod
     def _format_variant_line(entry: dict[str, Any]) -> str:
-        """One-line render of a search variant for prompt blocks."""
+        """One-line render of a search variant for prompt blocks.
+
+        Args:
+            entry (dict[str, Any]): A search-variant entry (name, gain_pct,
+                tput, extra args / envs).
+
+        Returns:
+            str: A single fixed-width line summarizing the variant.
+        """
         name = str(entry.get("name") or "?")
         gain = entry.get("gain_pct")
         tput = entry.get("tput") or entry.get("output_throughput")
@@ -3806,7 +4368,17 @@ class SharedState:
     def _enrich_with_tested_gain(
         entry: dict[str, Any], tested: dict[str, Any],
     ) -> dict[str, Any]:
-        """Backfill ``gain_pct``/``tput`` from the matching ``tested[fp]`` at render time (some accepted entries don't persist gain_pct; avoids a second writer)."""
+        """Backfill ``gain_pct``/``tput`` from the matching ``tested[fp]`` at render time (some accepted entries don't persist gain_pct; avoids a second writer).
+
+        Args:
+            entry (dict[str, Any]): The accepted-variant entry to enrich.
+            tested (dict[str, Any]): The negative ledger keyed by fingerprint,
+                used to backfill missing gain / tput.
+
+        Returns:
+            dict[str, Any]: ``entry`` itself when already complete, otherwise
+                a copy with ``gain_pct`` / ``tput`` backfilled where possible.
+        """
         if (
             entry.get("gain_pct") is not None
             and entry.get("tput") is not None
@@ -3830,7 +4402,12 @@ class SharedState:
         return out
 
     def _format_backend_winners_history(self) -> str:
-        """Multi-line render of the explore-round winners history (last 5 rounds: per-winner gain_pct/tput/flags); older rounds collapse to an elision line."""
+        """Multi-line render of the explore-round winners history (last 5 rounds: per-winner gain_pct/tput/flags); older rounds collapse to an elision line.
+
+        Returns:
+            str: The multi-line winners-history render, or
+                ``"(no explore rounds completed)"`` when empty.
+        """
         if not self.backend_winners_history:
             return "(no explore rounds completed)"
         last = self.backend_winners_history[-5:]
@@ -3876,7 +4453,14 @@ class SharedState:
 
     @staticmethod
     def _format_search_state(search: dict[str, Any] | None) -> str:
-        """Multi-line render of a ``*_search`` dedup ledger; each entry surfaces real ``gain_pct``. Counts on the head line; bodies show last 5 per bucket (only the prompt body is truncated)."""
+        """Multi-line render of a ``*_search`` dedup ledger; each entry surfaces real ``gain_pct``. Counts on the head line; bodies show last 5 per bucket (only the prompt body is truncated).
+
+        Args:
+            search (dict[str, Any] | None): The search ledger to render.
+
+        Returns:
+            str: The multi-line ledger render, or ``"(none)"`` when empty.
+        """
         if not search:
             return "(none)"
         accepted = list(search.get("accepted") or [])
@@ -3926,14 +4510,27 @@ class SharedState:
 
     @staticmethod
     def _strip_base64_data_urls(text: str) -> str:
-        """Drop base64 image payloads before prompt injection (in-memory only; on-disk file intact). Delegates to ``inference_optimizer.tracelens_md``."""
+        """Drop base64 image payloads before prompt injection (in-memory only; on-disk file intact). Delegates to ``inference_optimizer.tracelens_md``.
+
+        Args:
+            text (str): The markdown text to scrub of base64 data URLs.
+
+        Returns:
+            str: The text with base64 data URLs stripped (``""`` for falsy
+                input).
+        """
         if not text:
             return text or ""
         from inference_optimizer.tracelens_md import strip_base64_data_urls
         return strip_base64_data_urls(text)
 
     def _format_analysis_md_full(self) -> str:
-        """Inject TraceLens analysis.md verbatim (Roofline composite design §6.1: no truncation/interpretation) between ``=== TraceLens Analysis ... ===`` bookends; header carries snapshot id + gain. Empty cache → one-line hint to propose ``roofline``."""
+        """Inject TraceLens analysis.md verbatim (Roofline composite design §6.1: no truncation/interpretation) between ``=== TraceLens Analysis ... ===`` bookends; header carries snapshot id + gain. Empty cache → one-line hint to propose ``roofline``.
+
+        Returns:
+            str: The verbatim analysis.md wrapped in bookends, or a one-line
+                hint when no TraceLens snapshot is cached.
+        """
         cached = self.last_trace_analyze or {}
         md_text = cached.get("analysis_md_text") or ""
         if not md_text:
@@ -3974,7 +4571,12 @@ class SharedState:
         )
 
     def _format_profiler_digest(self) -> str:
-        """Compact bottleneck-focused profiler block (saturation mix + cross-snapshot delta + hot kernels + lever); ``(none)`` until a snapshot lands."""
+        """Compact bottleneck-focused profiler block (saturation mix + cross-snapshot delta + hot kernels + lever); ``(none)`` until a snapshot lands.
+
+        Returns:
+            str: The profiler digest block, or ``"(none)"`` until a roofline
+                snapshot lands.
+        """
         from .roofline_snapshot import build_profiler_digest
         digest = build_profiler_digest(
             self.roofline_snapshots, self.last_trace_analyze,

--- a/inference_optimizer/orchestrator/specialist_bench.py
+++ b/inference_optimizer/orchestrator/specialist_bench.py
@@ -91,10 +91,27 @@ MAX_BENCH_WALL_CLOCK_SEC: float = 60.0
 
 
 def _error(reason: str, **extra: Any) -> dict[str, Any]:
+    """Build a failure result envelope.
+
+    Args:
+        reason: Human-readable failure reason.
+        **extra: Additional fields to merge into the envelope.
+
+    Returns:
+        Dict with ``ok=False`` plus the reason and any extra fields.
+    """
     return {"ok": False, "reason": reason, **extra}
 
 
 def _ok(payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Build a success result envelope.
+
+    Args:
+        payload: Optional fields to merge into the envelope.
+
+    Returns:
+        Dict with ``ok=True`` plus any payload fields.
+    """
     out: dict[str, Any] = {"ok": True}
     if payload:
         out.update(payload)

--- a/inference_optimizer/orchestrator/specialist_bench.py
+++ b/inference_optimizer/orchestrator/specialist_bench.py
@@ -131,6 +131,17 @@ async def run_bench(
     Output lands under ``worktree/scratch/bench/<bench_id>/<call_id>/`` and is
     destroyed with the worktree. ``bench_dir_root`` overrides script discovery
     for tests.
+
+    Args:
+        bench_id: Registered micro-bench identifier to run.
+        worktree: Worktree the bench runs inside.
+        call_id: Unique call id used to scope the output directory.
+        params: Optional bench parameters passed via env JSON.
+        bench_dir_root: Override for bench-script discovery (tests).
+
+    Returns:
+        A result dict with ``ok`` plus bench output, or an error dict when the
+        bench is disabled/unknown/missing or the run fails or times out.
     """
     if not BENCH_TOOL_ENABLED:
         return _error(
@@ -206,7 +217,16 @@ _PATCH_PATH_RE = re.compile(r"^(?:---|\+\+\+) (?:a|b)/(?P<path>.+)$", re.M)
 def apply_patch_in_worktree(
     worktree: Path, patch_text: str,
 ) -> dict[str, Any]:
-    """Try ``git apply`` inside the worktree (self-check); not committed."""
+    """Try ``git apply`` inside the worktree (self-check); not committed.
+
+    Args:
+        worktree: Worktree the patch is applied inside.
+        patch_text: The unified-diff text to apply.
+
+    Returns:
+        A result dict with ``applied`` on success, or an error dict for an
+        empty patch, missing worktree, path escape, or git-apply failure.
+    """
     if not patch_text or not patch_text.strip():
         return _error("empty_patch")
     worktree = Path(worktree)
@@ -260,6 +280,13 @@ def capture_worktree_cumulative_diff(worktree: Path) -> str | None:
     * ``<diff>`` — uncommitted-change diff.
     * ``None``   — git failure / not a repo; callers skip the
                    cumulative-diff check rather than aborting.
+
+    Args:
+        worktree: Worktree to capture the cumulative diff from.
+
+    Returns:
+        The ``git diff HEAD`` output, ``""`` for a clean worktree, or ``None``
+        on git failure / not a repo.
     """
     worktree = Path(worktree)
     if not worktree.is_dir():
@@ -277,7 +304,11 @@ def capture_worktree_cumulative_diff(worktree: Path) -> str | None:
 
 
 def reset_worktree(worktree: Path) -> None:
-    """Discard uncommitted changes + untracked files in ``worktree``."""
+    """Discard uncommitted changes + untracked files in ``worktree``.
+
+    Args:
+        worktree: Worktree to hard-reset and clean.
+    """
     worktree = Path(worktree)
     if not worktree.is_dir():
         return

--- a/inference_optimizer/orchestrator/specialist_domains.py
+++ b/inference_optimizer/orchestrator/specialist_domains.py
@@ -207,7 +207,15 @@ _ANCHOR_TO_DOMAIN: dict[str, "SpecialistDomain"] = _anchor_to_domain_map()
 
 def domain_for_tag(tag: str) -> "SpecialistDomain | None":
     """Return a representative catalogue entry for a knowledge-domain
-    tag (matched first by ``kb_anchor``, then by ``key``)."""
+    tag (matched first by ``kb_anchor``, then by ``key``).
+
+    Args:
+        tag: The knowledge-domain tag to look up.
+
+    Returns:
+        The matching catalogue entry, or ``None`` when the tag is empty or
+        unknown.
+    """
     t = (tag or "").strip()
     if not t:
         return None
@@ -223,6 +231,12 @@ def normalize_dispatch_tags(params: dict) -> list[str]:
     Reads ``params.tags``; falls back to the ``params.domain`` alias (mapped
     to its ``kb_anchor`` when it names a catalogue entry, else verbatim) when
     absent. Order-preserving dedup; empty entries dropped.
+
+    Args:
+        params: The dispatch payload (reads ``tags`` then ``domain``).
+
+    Returns:
+        The resolved, order-preserving deduped tag list.
     """
     raw = params.get("tags")
     tags: list[str] = []

--- a/inference_optimizer/orchestrator/specialist_domains.py
+++ b/inference_optimizer/orchestrator/specialist_domains.py
@@ -160,6 +160,14 @@ EXTRA_KNOWLEDGE_DOMAIN_TAGS: tuple[str, ...] = ()
 
 
 def _derive_knowledge_domain_tags() -> tuple[str, ...]:
+    """Collect the distinct knowledge-domain tags from the catalogue.
+
+    Combines the ``kb_anchor`` of each specialist domain with any extra
+    standalone tags, preserving first-seen order and dropping blanks.
+
+    Returns:
+        Ordered tuple of unique knowledge-domain tags.
+    """
     seen: dict[str, None] = {}
     for d in SPECIALIST_DOMAINS:
         anchor = (d.kb_anchor or "").strip()
@@ -179,6 +187,13 @@ KNOWLEDGE_DOMAIN_TAG_SET: frozenset[str] = frozenset(KNOWLEDGE_DOMAIN_TAGS)
 # Map each knowledge-domain tag back to a representative catalogue entry.
 # The first catalogue entry that owns the anchor wins.
 def _anchor_to_domain_map() -> dict[str, "SpecialistDomain"]:
+    """Build a map from KB anchor to its representative domain entry.
+
+    The first catalogue entry that owns a given anchor wins.
+
+    Returns:
+        Mapping of ``kb_anchor`` to the owning :class:`SpecialistDomain`.
+    """
     out: dict[str, SpecialistDomain] = {}
     for d in SPECIALIST_DOMAINS:
         anchor = (d.kb_anchor or "").strip()

--- a/inference_optimizer/orchestrator/specialist_mcp_config.py
+++ b/inference_optimizer/orchestrator/specialist_mcp_config.py
@@ -33,13 +33,15 @@ def write_specialist_mcp_config(
     Returns ``None`` when no MCP server is wireable (caller leaves
     ``--mcp-config`` off). Idempotent.
 
-    Parameters
-    ----------
-    session_dir
-        Session root; file lands at
-        ``<session_dir>/runtime/<SPECIALIST_MCP_CONFIG_FILENAME>``.
-    pr_monitor_mcp_url
-        ``KnowledgePlane.specialist_mcp_url()`` — empty means disabled.
+    Args:
+        session_dir: Session root; the file lands at
+            ``<session_dir>/runtime/<SPECIALIST_MCP_CONFIG_FILENAME>``.
+        pr_monitor_mcp_url: ``KnowledgePlane.specialist_mcp_url()``; empty
+            means disabled.
+
+    Returns:
+        The written config file path, or ``None`` when no MCP server is
+        wireable.
     """
     servers: dict[str, dict[str, Any]] = {}
     pr_url = (pr_monitor_mcp_url or "").strip()

--- a/inference_optimizer/orchestrator/specialist_patch_safety.py
+++ b/inference_optimizer/orchestrator/specialist_patch_safety.py
@@ -83,7 +83,15 @@ _DEV_NULL = "/dev/null"
 
 
 def _strip_path_prefix(path: str, level: int) -> str:
-    """Strip ``level`` leading path components, mimicking ``git apply -p<level>``."""
+    """Strip ``level`` leading path components, mimicking ``git apply -p<level>``.
+
+    Args:
+        path: The diff header path to strip.
+        level: Number of leading components to drop (``<= 0`` is a no-op).
+
+    Returns:
+        The path with ``level`` leading components removed (basename floor).
+    """
     if level <= 0:
         return path
     parts = path.split("/")
@@ -98,6 +106,12 @@ def patch_file_targets(patch_text: str) -> list[tuple[str, str]]:
     Paths are the raw ``--- ``/``+++ `` tokens (may carry an ``a/``/``b/``
     prefix, a deep absolute prefix, or the ``/dev/null`` sentinel for a
     created/deleted file). Trailing ``\\t<timestamp>`` is stripped.
+
+    Args:
+        patch_text: The unified-diff text to scan.
+
+    Returns:
+        The list of ``(old_path, new_path)`` header pairs.
     """
     pairs: list[tuple[str, str]] = []
     lines = (patch_text or "").splitlines()
@@ -131,6 +145,14 @@ def patch_targets_missing(
     (e.g. patching a CUDA-only file on a ROCm build). Pure file *creations*
     (pre-image ``/dev/null``) are exempt. The returned paths are the raw
     pre-image tokens, suitable for an advisory back to the specialist.
+
+    Args:
+        patch_text: The unified-diff text to scan.
+        root: Framework source-tree root the targets are probed against.
+        strip_levels: ``-p`` strip levels to try when resolving each path.
+
+    Returns:
+        The raw pre-image token paths absent from ``root`` at every level.
     """
     missing: list[str] = []
     for old, _new in patch_file_targets(patch_text):
@@ -204,7 +226,12 @@ CROSS_DOMAIN_RULES: tuple[CrossDomainRule, ...] = (
 
 
 def cross_domain_rule_descriptors() -> list[dict[str, str]]:
-    """Return the cross-domain rules as the dict shape the Critic bundle uses."""
+    """Return the cross-domain rules as the dict shape the Critic bundle uses.
+
+    Returns:
+        One dict per cross-domain rule with ``rule_id`` / ``description`` /
+        ``failure_verdict`` / ``failure_reason_code`` keys.
+    """
     return [
         {
             "rule_id": r.rule_id,
@@ -217,7 +244,14 @@ def cross_domain_rule_descriptors() -> list[dict[str, str]]:
 
 
 def numeric_claims(text: str) -> list[str]:
-    """Return numeric-speedup claim substrings found in ``text``."""
+    """Return numeric-speedup claim substrings found in ``text``.
+
+    Args:
+        text: The free-text argument/summary to scan.
+
+    Returns:
+        The matched numeric-claim substrings (may be empty).
+    """
     hits: list[str] = []
     for pattern in _NUMERIC_CLAIM_PATTERNS:
         for match in pattern.finditer(text or ""):
@@ -226,12 +260,26 @@ def numeric_claims(text: str) -> list[str]:
 
 
 def is_unified_diff(text: str) -> bool:
-    """True iff ``text`` carries at least one unified-diff hunk header."""
+    """True iff ``text`` carries at least one unified-diff hunk header.
+
+    Args:
+        text: The candidate diff text.
+
+    Returns:
+        True when at least one ``@@`` hunk header is present.
+    """
     return bool(_UNIFIED_DIFF_HUNK_RE.search(text or ""))
 
 
 def normalise_diff_for_compare(text: str) -> str:
-    """Strip git-only metadata + trailing whitespace for semantic comparison."""
+    """Strip git-only metadata + trailing whitespace for semantic comparison.
+
+    Args:
+        text: The diff text to normalise.
+
+    Returns:
+        The normalised diff body (git-only lines and blank lines dropped).
+    """
     body = text or ""
     for pat in _DIFF_NORMALISE_DROP_LINES:
         body = pat.sub("", body)
@@ -241,7 +289,15 @@ def normalise_diff_for_compare(text: str) -> str:
 
 
 def patch_escapes_tree(patch_text: str) -> str | None:
-    """Return the first offending path that escapes the tree, else ``None``."""
+    """Return the first offending path that escapes the tree, else ``None``.
+
+    Args:
+        patch_text: The unified-diff text to scan.
+
+    Returns:
+        The first absolute or ``..``-containing path, or ``None`` when none
+        escape the tree.
+    """
     for hit in _PATCH_PATH_RE.finditer(patch_text or ""):
         cand = hit.group("path").strip()
         if cand.startswith("/") or ".." in Path(cand).parts:
@@ -274,6 +330,9 @@ class PatchGroundingResult:
         never apply, so it is dropped before it wastes an ``integrate_patch``
         benchmark slot (unlike ``stale``, which is kept because integrate's
         ``-p`` auto-detect / 3-way merge may still salvage it).
+
+        Returns:
+            True for structural-failure verdicts that should drop the patch.
         """
         return self.verdict in (
             GROUND_NOT_DIFF, GROUND_PATH_ESCAPE, GROUND_MISSING_TARGET,
@@ -292,6 +351,15 @@ def ground_patch_text(
     ``git apply --check`` grounding runs only when ``base_checkout`` is a real
     git checkout; otherwise the result is ``GROUND_UNCHECKED`` (advisory, never
     drops the patch) so a missing base never produces a false negative.
+
+    Args:
+        patch_text: The unified-diff text to validate and ground.
+        base_checkout: Clean git checkout to ground against, or ``None`` to
+            skip the ``git apply --check`` step.
+        git_timeout_sec: Timeout for the ``git apply --check`` subprocess.
+
+    Returns:
+        The :class:`PatchGroundingResult` with the verdict and detail.
     """
     if not is_unified_diff(patch_text):
         return PatchGroundingResult(GROUND_NOT_DIFF, "no unified-diff hunk header")
@@ -339,7 +407,11 @@ class PatchSafetyReport:
     forbidden_fields: list[str] = field(default_factory=list)
 
     def notes(self) -> list[str]:
-        """Render audit notes for SpecialistRunResult / session_breakdown."""
+        """Render audit notes for SpecialistRunResult / session_breakdown.
+
+        Returns:
+            Human-readable audit note strings for the recorded findings.
+        """
         out: list[str] = []
         if self.dropped:
             out.append(
@@ -374,6 +446,13 @@ def scan_quantitative_claims(payload: dict[str, Any]) -> tuple[list[str], list[s
     Forbidden quantitative fields are a hard signal; numeric claims in the
     summary / qualitative argument are advisory warnings (the Coordinator's
     measured gain is the truth, not the claim).
+
+    Args:
+        payload: The specialist_done payload to scan.
+
+    Returns:
+        A ``(forbidden_fields_present, numeric_warning_strings)`` tuple, each
+        de-duped with order preserved.
     """
     forbidden = sorted(set((payload or {}).keys()) & FORBIDDEN_PROPOSAL_FIELDS)
     warnings: list[str] = []
@@ -405,8 +484,15 @@ def vet_patches(
 ) -> tuple[list[str], list[dict[str, str]], dict[str, str]]:
     """Ground each patch file; drop clear garbage (non-diff / path escape).
 
-    Returns ``(kept_paths, dropped_records, grounding_by_path)``. Stale-but-valid
-    patches are kept (integrate_patch + Critic adjudicate) with a grounding note.
+    Stale-but-valid patches are kept (integrate_patch + Critic adjudicate)
+    with a grounding note.
+
+    Args:
+        patch_paths: File paths of the candidate patches to vet.
+        base_checkout: Clean git checkout to ground against, or ``None``.
+
+    Returns:
+        A ``(kept_paths, dropped_records, grounding_by_path)`` tuple.
     """
     kept: list[str] = []
     dropped: list[dict[str, str]] = []

--- a/inference_optimizer/orchestrator/specialist_profile.py
+++ b/inference_optimizer/orchestrator/specialist_profile.py
@@ -60,10 +60,20 @@ class SpecialistProfile:
 
     @property
     def is_freeform(self) -> bool:
+        """Whether this profile uses the free-form (unscoped) scope.
+
+        Returns:
+            ``True`` if the scope is free-form.
+        """
         return self.scope == SCOPE_FREEFORM
 
     @property
     def is_cross_domain(self) -> bool:
+        """Whether this profile spans multiple knowledge domains.
+
+        Returns:
+            ``True`` if the scope is the multi-domain scope.
+        """
         return self.scope == SCOPE_DOMAINS
 
     @property
@@ -75,6 +85,18 @@ class SpecialistProfile:
 
 
 def _coerce_bool(value: Any, default: bool) -> bool:
+    """Coerce a loosely-typed value to a boolean.
+
+    Accepts native bools, numbers, and common truthy/falsey strings
+    (``"true"``/``"yes"``/``"on"`` and their negatives).
+
+    Args:
+        value: Value to interpret.
+        default: Fallback returned when ``value`` is ``None`` or unrecognized.
+
+    Returns:
+        The interpreted boolean, or ``default`` when undecidable.
+    """
     if value is None:
         return default
     if isinstance(value, bool):

--- a/inference_optimizer/orchestrator/specialist_profile.py
+++ b/inference_optimizer/orchestrator/specialist_profile.py
@@ -80,7 +80,11 @@ class SpecialistProfile:
     def grants_bench_tool(self) -> bool:
         """True iff this dispatch may use the in-loop ``run_bench`` tool. Only
         patch-authoring specialists with ``bench=True`` qualify (bench has no
-        meaning for read-only research)."""
+        meaning for read-only research).
+
+        Returns:
+            True when the dispatch is patch-authoring with bench enabled.
+        """
         return self.mode == MODE_PATCH and self.bench
 
 
@@ -117,6 +121,13 @@ def resolve_specialist_profile(params: dict[str, Any] | None) -> SpecialistProfi
     Unknown / missing values fall back to the legacy-compatible defaults so the
     resolver never raises; PolicyGate is the place that *rejects* malformed
     dispatches, this helper only normalises for the runtime.
+
+    Args:
+        params: The dispatch params (reads ``scope`` / ``mode`` / ``bench`` /
+            ``lane``), or ``None``.
+
+    Returns:
+        The normalised :class:`SpecialistProfile`.
     """
     p = params or {}
 

--- a/inference_optimizer/orchestrator/specialist_profile.py
+++ b/inference_optimizer/orchestrator/specialist_profile.py
@@ -83,7 +83,11 @@ class SpecialistProfile:
     def grants_bench_tool(self) -> bool:
         """True iff this dispatch may use the in-loop ``run_bench`` tool. Only
         patch-authoring specialists with ``bench=True`` qualify (bench has no
-        meaning for read-only research)."""
+        meaning for read-only research).
+
+        Returns:
+            ``True`` when the profile is patch-mode with ``bench=True``.
+        """
         return self.mode == MODE_PATCH and self.bench
 
 
@@ -121,6 +125,13 @@ def _infer_scope(p: dict[str, Any]) -> str:
     specialist; one with no anchor at all is treated as ``freeform`` so a bare
     dispatch defaults to the cheap read-only lane instead of the expensive
     patch/GPU lane.
+
+    Args:
+        p: The dispatch params to inspect for domain/tag anchors.
+
+    Returns:
+        ``SCOPE_DOMAINS`` for two-or-more tags, ``SCOPE_DOMAIN`` for one, or
+        ``SCOPE_FREEFORM`` when no anchor is present.
     """
     # Local import avoids a module-load cycle (specialist_domains is heavier).
     from .specialist_domains import normalize_dispatch_tags
@@ -144,6 +155,14 @@ def resolve_specialist_profile(params: dict[str, Any] | None) -> SpecialistProfi
     domain/tag anchor: anchored dispatches resolve to ``domain``/``domains``
     (legacy patch/GPU default preserved), while a truly bare dispatch resolves
     to ``freeform`` → ``research`` → ``cpu`` (safe & cheap first).
+
+    Args:
+        params: The dispatch params carrying ``scope`` / ``mode`` / ``bench`` /
+            ``lane``, or ``None``.
+
+    Returns:
+        The resolved :class:`SpecialistProfile` with legacy-compatible
+        fallbacks applied.
     """
     p = params or {}
 

--- a/inference_optimizer/orchestrator/specialist_runner.py
+++ b/inference_optimizer/orchestrator/specialist_runner.py
@@ -59,7 +59,15 @@ log = logging.getLogger(__name__)
 def _extra_focus_tags(
     params: dict[str, Any], domain: "SpecialistDomain",
 ) -> tuple[str, ...]:
-    """Knowledge-domain tags beyond the primary domain's anchor (anchor dropped to avoid double-rendering)."""
+    """Knowledge-domain tags beyond the primary domain's anchor (anchor dropped to avoid double-rendering).
+
+    Args:
+        params: The dispatch params carrying the tag list.
+        domain: The primary specialist domain whose anchor is excluded.
+
+    Returns:
+        The extra focus tags, excluding the primary domain's anchor.
+    """
     tags = normalize_dispatch_tags(params)
     primary_anchor = (domain.kb_anchor or "").strip()
     return tuple(t for t in tags if t and t != primary_anchor)
@@ -212,6 +220,13 @@ def classify_specialist_failure(
     / crash); ``empty_synthesised`` means it exited cleanly without a usable
     ``specialist_done`` (genuine empty, max-turns, or a config error encoded in
     ``error``).
+
+    Args:
+        runner_status: The :class:`SpecialistRunResult` status string.
+        error: The associated error string (drives sub-classification).
+
+    Returns:
+        A ``(failure_type, retry_eligible)`` tuple.
     """
     status = (runner_status or "").strip().lower()
     err = (error or "").strip().lower()
@@ -245,6 +260,15 @@ def build_empty_specialist_done(
 
     Satisfies PolicyGate R3 schema (``empty=true``, ``proposal_set=[]``,
     non-empty summary).
+
+    Args:
+        gap_canonical_id: Canonical id of the gap the specialist addressed.
+        domain: The specialist domain key.
+        reason: Why the specialist exited empty (becomes summary/reason).
+        confidence: Confidence score, clamped to ``[0.0, 1.0]``.
+
+    Returns:
+        The canonical empty ``specialist_done`` payload dict.
     """
     return {
         "gap_canonical_id": gap_canonical_id,
@@ -282,6 +306,19 @@ class SpecialistRunner:
         Exactly one of ``backend_factory`` (in-process, tests) /
         ``subprocess_config`` (PR-A2 ``claude`` subprocess, production) must
         be supplied. ``knowledge_plane`` gates ``mcp__pr_monitor__*`` tools.
+
+        Args:
+            backend_factory: In-process backend factory (tests path).
+            subprocess_config: Subprocess spawn config (production path).
+            session_dir: Session output directory.
+            default_tools: Default tool whitelist for specialists.
+            default_max_turns: Default per-task max turn budget.
+            per_turn_max_seconds: Per-turn wall-clock soft limit.
+            knowledge_plane: KnowledgePlane gating ``mcp__pr_monitor__*`` tools.
+
+        Raises:
+            ValueError: If neither or both of ``backend_factory`` and
+                ``subprocess_config`` are supplied.
         """
         if backend_factory is None and subprocess_config is None:
             raise ValueError(
@@ -319,6 +356,14 @@ class SpecialistRunner:
         ``Task.allowed_tools``; grants the worktree-scoped ``run_bench`` tool
         only to bench-enabled specialists (``grant_bench`` and the bench tool
         globally enabled); enforces :data:`SPECIALIST_TOOL_DENYLIST` last.
+
+        Args:
+            task_allowed_tools: Narrower per-task tool whitelist override.
+            grant_bench: When True (and bench globally enabled), grant the
+                worktree-scoped ``run_bench`` tool.
+
+        Returns:
+            The resolved per-task tool whitelist.
         """
         tools = (
             list(task_allowed_tools)
@@ -363,6 +408,14 @@ class SpecialistRunner:
 
         Never raises a Backend error past the boundary — every failure ends
         with a valid specialist_done payload (Inv-5.3 single exit).
+
+        Args:
+            ctx: The runner context for this specialist task.
+            prompt_inputs: Pre-built prompt inputs; built from ``ctx`` when
+                omitted.
+
+        Returns:
+            The :class:`SpecialistRunResult` for the task.
         """
         prep = await self._prepare(ctx, prompt_inputs=prompt_inputs)
         if prep.early_return is not None:
@@ -565,6 +618,11 @@ class SpecialistRunner:
         No-op when ``self.session_dir`` is unset (some test harnesses run
         the runner without a session dir) or the backend reported no token
         counters. Wrapped broadly so a trace failure never aborts the run.
+
+        Args:
+            task_id: The specialist task id.
+            turn: The turn index being traced.
+            metadata: Backend turn metadata carrying token counters.
         """
         if self.session_dir is None:
             return
@@ -605,6 +663,11 @@ class SpecialistRunner:
         """Append one ``conversations.jsonl`` row for an in-process specialist
         turn. Persists the full (redacted) prompt + completion the backend put
         on ``metadata``. No-op without a session dir; best-effort otherwise.
+
+        Args:
+            task_id: The specialist task id.
+            turn: The turn index being recorded.
+            metadata: Backend turn metadata carrying the prompt + response.
         """
         if self.session_dir is None:
             return
@@ -636,7 +699,15 @@ class SpecialistRunner:
         self, ctx: RunnerContext, prep: "_PreparedRun",
     ) -> SpecialistRunResult:
         """Drive ``Backend.run`` one turn at a time until a specialist_done
-        intent shows up."""
+        intent shows up.
+
+        Args:
+            ctx: The runner context for this specialist task.
+            prep: The prepared-run state (domain, gap, workspace, prompts).
+
+        Returns:
+            The :class:`SpecialistRunResult` for the task.
+        """
         assert self.backend_factory is not None  # narrowed by run()
         domain = prep.domain
         gap = prep.gap
@@ -1077,9 +1148,16 @@ class SpecialistRunner:
     ) -> tuple[Path | None, Path | None, str]:
         """Provision a per-task git worktree when in subprocess mode.
 
-        Returns ``(worktree_dir, worktree_base, error)``; empty/None in
-        in-process mode or on git failure. Best-effort: the specialist still
-        dispatches without isolation and the reason lands in ``notes``.
+        Best-effort: the specialist still dispatches without isolation and the
+        reason lands in ``notes``.
+
+        Args:
+            ctx: The runner context for this specialist task.
+            workspace: The task workspace the worktree is created under.
+
+        Returns:
+            A ``(worktree_dir, worktree_base, error)`` tuple; ``worktree_dir``
+            is ``None`` in in-process/readonly mode or on git failure.
         """
         if self.subprocess_config is None or workspace is None:
             return None, None, ""

--- a/inference_optimizer/orchestrator/specialist_runner.py
+++ b/inference_optimizer/orchestrator/specialist_runner.py
@@ -976,6 +976,14 @@ class SpecialistRunner:
         search_bases = [b for b in (prep.worktree, workspace) if b is not None]
 
         def _resolve_existing_patch(p: Any) -> str | None:
+            """Resolve a claimed patch path against known search bases.
+
+            Args:
+                p: Patch path (absolute or relative to a search base).
+
+            Returns:
+                The first existing file path as a string, or ``None``.
+            """
             raw = Path(str(p))
             candidates = [raw] if raw.is_absolute() else []
             for base in search_bases:
@@ -1122,8 +1130,18 @@ class SpecialistRunner:
 
     # Workspace file protocol
     def _resolve_workspace(self, ctx: RunnerContext) -> Path | None:
-        # Prefer the SubAgentRunner-premkdir'd workspace, else
-        # ``runs/specialist/<task_id>/``.
+        """Resolve (and create) the workspace directory for a run.
+
+        Prefers a pre-created workspace supplied on the context's ``extra``
+        mapping, otherwise falls back to ``runs/specialist/<task_id>/``
+        under the session directory.
+
+        Args:
+            ctx: Runner context for the current dispatch.
+
+        Returns:
+            The workspace path, or ``None`` if no session directory is set.
+        """
         extra = getattr(ctx, "extra", None) or {}
         ws = extra.get("workspace")
         if ws:

--- a/inference_optimizer/orchestrator/specialist_subprocess.py
+++ b/inference_optimizer/orchestrator/specialist_subprocess.py
@@ -139,6 +139,12 @@ def _pick_worktree_base(roots: tuple[str, ...]) -> Path | None:
 
     Falls back to None when none exist — the runner then runs the
     specialist without an isolated worktree.
+
+    Args:
+        roots: Candidate root paths to probe for a ``.git`` marker.
+
+    Returns:
+        The first git-checkout root, or ``None`` when none qualify.
     """
     for r in roots:
         p = Path(r)
@@ -159,6 +165,15 @@ def _setup_worktree(
 
     Best-effort: on git error returns ``(None, err)`` so the caller can
     proceed without isolation (PR-A2 default) or hard-fail.
+
+    Args:
+        base: Git checkout the worktree is branched off of.
+        worktree_path: Destination path for the new worktree.
+        branch: Branch name to create for the worktree.
+
+    Returns:
+        A ``(worktree_path, "")`` tuple on success, or ``(None, error)`` on
+        git failure.
     """
     if worktree_path.exists():
         # Resume / retry: reuse an existing worktree (stale ones are rare).
@@ -191,6 +206,10 @@ def _teardown_worktree(base: Path | None, worktree_path: Path) -> None:
 
     Called only on the REVERT / synth-empty path; the KEEP path leaves the
     worktree in place so ``integrate_patch`` can pull patches out of it.
+
+    Args:
+        base: Git checkout the worktree was created from, or ``None``.
+        worktree_path: Path of the worktree to remove.
     """
     if not worktree_path.exists():
         return

--- a/inference_optimizer/orchestrator/sub_agent_runner.py
+++ b/inference_optimizer/orchestrator/sub_agent_runner.py
@@ -116,6 +116,13 @@ class SubAgentRunner:
 
         Returns the path (stashed on ``RunnerContext.extra``) or None when
         the task kind is not a known runs/ action.
+
+        Args:
+            task: The task whose workspace directory should be pre-created.
+
+        Returns:
+            The created workspace path, or ``None`` when there is no session
+            dir or the task kind is not a known runs/ action.
         """
         if self.session_dir is None:
             return None
@@ -139,6 +146,16 @@ class SubAgentRunner:
         Bug-fix N34: a long-running task's row can vanish before its terminal
         transition; swallowing TaskNotFound keeps the pipeline running.
         Returns True on success, False on the swallowed-TaskNotFound branch.
+
+        Args:
+            task_id: The task to transition.
+            new_state: The target state.
+            evidence: Optional evidence dict recorded with the transition.
+            context: Short label describing the transition call site.
+
+        Returns:
+            ``True`` on success, ``False`` on the swallowed-``TaskNotFound``
+            branch.
         """
         try:
             await self.tasks.transition(task_id, new_state, evidence=evidence or {})
@@ -165,6 +182,16 @@ class SubAgentRunner:
         Always transitions to ``running`` first (state machine constraint).
         With ``prebound_lease`` the runner skips its own acquire but still
         owns the release in its finally block.
+
+        Args:
+            task: The task to execute.
+            prebound_lease: Optional already-acquired lease; when given, the
+                runner skips its own acquire but still releases it.
+            extra_context: Optional extra values merged into the
+                :class:`RunnerContext`.
+
+        Returns:
+            The :class:`SubAgentResult` capturing terminal state and payload.
         """
         # queued → running first (state machine constraint).
         await self._transition_resilient(

--- a/inference_optimizer/orchestrator/system_prompts/critic_prompt_builder.py
+++ b/inference_optimizer/orchestrator/system_prompts/critic_prompt_builder.py
@@ -99,7 +99,11 @@ def _section_run_context(
 
 def _section_phase_review_contract() -> list[str]:
     """Static phase-aware verdict contract (v0.8 §3.3 §4.3); mirrors
-    ``phase_state.PHASE_LLM_PROPOSABLE_ACTIONS`` (PolicyGate R1)."""
+    ``phase_state.PHASE_LLM_PROPOSABLE_ACTIONS`` (PolicyGate R1).
+
+    Returns:
+        The rendered phase-review-contract lines.
+    """
     from ..phase_state import (
         PHASE_NAMES,
         is_phase_interleave_enabled,
@@ -333,20 +337,20 @@ def build_critic_prompt(
 ) -> str:
     """Compose the Critic system prompt (deterministic for given inputs).
 
-    Parameters
-    ----------
-    action_registry:
-        Pre-loaded ``ActionRegistry`` (caller calls ``.load()``).
-    enabled_actions:
-        Action names enabled for this run (same set as orchestration).
-    framework:
-        ``sglang`` / ``vllm`` / ``atom`` — printed in RUN CONTEXT verbatim.
-    kernel_enabled:
-        ``None`` derives from whether any KERNEL_OWNED action is enabled.
-    max_minutes:
-        Wall-clock budget for the run.
-    rules_fragment_path:
-        Path to ``critic.md`` rules fragment.
+    Args:
+        action_registry: Pre-loaded ``ActionRegistry`` (caller calls
+            ``.load()``).
+        enabled_actions: Action names enabled for this run (same set as
+            orchestration).
+        framework: ``sglang`` / ``vllm`` / ``atom`` — printed in RUN CONTEXT
+            verbatim.
+        kernel_enabled: ``None`` derives from whether any KERNEL_OWNED action
+            is enabled.
+        max_minutes: Wall-clock budget for the run.
+        rules_fragment_path: Path to the ``critic.md`` rules fragment.
+
+    Returns:
+        The composed Critic system prompt string.
     """
     actions = _filter_actions(action_registry, enabled_actions)
     if kernel_enabled is None:

--- a/inference_optimizer/orchestrator/system_prompts/prompt_builder.py
+++ b/inference_optimizer/orchestrator/system_prompts/prompt_builder.py
@@ -135,7 +135,14 @@ def _section_session_context(
 
 def _section_phase_semantics(*, kernel_enabled: bool) -> list[str]:
     """Render the per-phase allowed-action contract (current phase injected
-    dynamically by the Coordinator)."""
+    dynamically by the Coordinator).
+
+    Args:
+        kernel_enabled: Whether kernel-owned actions are enabled.
+
+    Returns:
+        The rendered phase-contract lines.
+    """
     from ..phase_state import (
         PHASE_NAMES,
         is_phase_interleave_enabled,
@@ -227,7 +234,15 @@ def _filter_actions(
 
 
 def _phase_eta_summary(actions: list[ActionMetadata]) -> list[tuple[str, float, list[str]]]:
-    """Group actions by phase in _PHASE_ORDER; return (phase, eta_min_sum, names)."""
+    """Group actions by phase in _PHASE_ORDER; return (phase, eta_min_sum, names).
+
+    Args:
+        actions: The action metadata to group.
+
+    Returns:
+        Per-phase ``(phase, eta_min_sum, action_names)`` tuples ordered by
+        ``_PHASE_ORDER`` with any unranked phases appended.
+    """
     bucket: dict[str, list[ActionMetadata]] = {}
     for a in actions:
         bucket.setdefault(a.pipeline_phase, []).append(a)
@@ -366,7 +381,14 @@ def _format_emit_hint(meta: ActionMetadata) -> str:
 
 
 def _format_grid_injection_hint(name: str) -> str | None:
-    """Return a per-action one-liner showing how to override grid, or None."""
+    """Return a per-action one-liner showing how to override grid, or None.
+
+    Args:
+        name: The action name to render a grid-injection hint for.
+
+    Returns:
+        The grid-injection hint line, or ``None`` when the action has none.
+    """
     if name == "explore":
         return (
             "GRID INPUT (v0.8 M3, REQUIRED): emit "
@@ -770,15 +792,23 @@ def build_orchestration_prompt(
 ) -> str:
     """Compose the Orchestration system prompt (deterministic for given inputs).
 
-    Parameters
-    ----------
-    action_registry: pre-loaded ``ActionRegistry`` (caller calls ``.load()``).
-    enabled_actions: enabled action names; final ordering is by pipeline_phase.
-    framework: ``sglang`` / ``vllm`` — printed in SESSION CONTEXT.
-    kernel_enabled: explicit override; ``None`` derives from KERNEL_OWNED actions.
-    objective_kind / objective_value: :mod:`objective` strings, printed verbatim.
-    max_minutes: wall-clock budget for the run.
-    rules_fragment_path: path to ``orchestration.md``; placeholder if unreadable.
+    Args:
+        action_registry: Pre-loaded ``ActionRegistry`` (caller calls ``.load()``).
+        enabled_actions: Enabled action names; final ordering is by
+            pipeline_phase.
+        framework: ``sglang`` / ``vllm`` — printed in SESSION CONTEXT.
+        kernel_enabled: Explicit override; ``None`` derives from KERNEL_OWNED
+            actions.
+        objective_kind: :mod:`objective` kind string, printed verbatim.
+        objective_value: :mod:`objective` value, printed verbatim.
+        max_minutes: Wall-clock budget for the run.
+        rules_fragment_path: Path to ``orchestration.md``; placeholder if
+            unreadable.
+        framework_source_roots: Framework source roots printed in SESSION
+            CONTEXT.
+
+    Returns:
+        The composed Orchestration system prompt string.
     """
     actions = _filter_actions(action_registry, enabled_actions)
     if kernel_enabled is None:

--- a/inference_optimizer/orchestrator/system_prompts/prompt_builder.py
+++ b/inference_optimizer/orchestrator/system_prompts/prompt_builder.py
@@ -152,6 +152,14 @@ def _section_phase_semantics(
     ``--no-framework`` keep their row in the 6-phase chain but are annotated
     ``(DISABLED: --no-xxx — phase skipped)`` so Orchestration plans against the
     phases the run will actually enter.
+
+    Args:
+        kernel_enabled: Whether kernel-owned actions are enabled.
+        explore_enabled: Whether the EXPLORE phase is enabled.
+        framework_phase_enabled: Whether the FRAMEWORK_PR phase is enabled.
+
+    Returns:
+        Markdown lines for the phase-contract section.
     """
     from ..phase_state import (
         PHASE_NAMES,
@@ -263,7 +271,15 @@ def _filter_actions(
 
 
 def _phase_eta_summary(actions: list[ActionMetadata]) -> list[tuple[str, float, list[str]]]:
-    """Group actions by phase in _PHASE_ORDER; return (phase, eta_min_sum, names)."""
+    """Group actions by phase in _PHASE_ORDER; return (phase, eta_min_sum, names).
+
+    Args:
+        actions: The enabled actions to group by pipeline phase.
+
+    Returns:
+        A list of ``(phase, eta_min_sum, names)`` tuples ordered by
+        ``_PHASE_ORDER`` with unknown phases appended last.
+    """
     bucket: dict[str, list[ActionMetadata]] = {}
     for a in actions:
         bucket.setdefault(a.pipeline_phase, []).append(a)
@@ -402,7 +418,15 @@ def _format_emit_hint(meta: ActionMetadata) -> str:
 
 
 def _format_grid_injection_hint(name: str) -> str | None:
-    """Return a per-action one-liner showing how to override grid, or None."""
+    """Return a per-action one-liner showing how to override grid, or None.
+
+    Args:
+        name: The action name to render a grid-injection hint for.
+
+    Returns:
+        The grid-injection hint string for ``explore`` / ``sweep``, or ``None``
+        for any other action.
+    """
     if name == "explore":
         return (
             "GRID INPUT (v0.8 M3, REQUIRED): emit "
@@ -808,20 +832,29 @@ def build_orchestration_prompt(
 ) -> str:
     """Compose the Orchestration system prompt (deterministic for given inputs).
 
-    Parameters
-    ----------
-    action_registry: pre-loaded ``ActionRegistry`` (caller calls ``.load()``).
-    enabled_actions: enabled action names; final ordering is by pipeline_phase.
-    framework: ``sglang`` / ``vllm`` — printed in SESSION CONTEXT.
-    kernel_enabled: explicit override; ``None`` derives from KERNEL_OWNED actions.
-    explore_enabled: when False (``--no-explore``) the EXPLORE phase is skipped;
-        the prompt annotates it as DISABLED so Orchestration's plan matches the
-        real phase chain.
-    framework_phase_enabled: when False (``--no-framework``) the FRAMEWORK_PR
-        phase is skipped; annotated DISABLED in the prompt.
-    objective_kind / objective_value: :mod:`objective` strings, printed verbatim.
-    max_minutes: wall-clock budget for the run.
-    rules_fragment_path: path to ``orchestration.md``; placeholder if unreadable.
+    Args:
+        action_registry: pre-loaded ``ActionRegistry`` (caller calls
+            ``.load()``).
+        enabled_actions: enabled action names; final ordering is by
+            pipeline_phase.
+        framework: ``sglang`` / ``vllm`` — printed in SESSION CONTEXT.
+        kernel_enabled: explicit override; ``None`` derives from KERNEL_OWNED
+            actions.
+        explore_enabled: when False (``--no-explore``) the EXPLORE phase is
+            skipped; the prompt annotates it as DISABLED so Orchestration's plan
+            matches the real phase chain.
+        framework_phase_enabled: when False (``--no-framework``) the
+            FRAMEWORK_PR phase is skipped; annotated DISABLED in the prompt.
+        objective_kind: :mod:`objective` kind string, printed verbatim.
+        objective_value: :mod:`objective` target value, printed verbatim.
+        max_minutes: wall-clock budget for the run.
+        rules_fragment_path: path to ``orchestration.md``; placeholder if
+            unreadable.
+        framework_source_roots: optional framework source roots passed through
+            to the session-context section.
+
+    Returns:
+        The composed Orchestration system prompt text.
     """
     actions = _filter_actions(action_registry, enabled_actions)
     if kernel_enabled is None:

--- a/inference_optimizer/orchestrator/system_prompts/specialist_prompt_builder.py
+++ b/inference_optimizer/orchestrator/system_prompts/specialist_prompt_builder.py
@@ -39,7 +39,14 @@ from inference_optimizer.orchestrator.policy import (
 
 def _is_atom(inp: SpecialistPromptInputs) -> bool:
     """True when ``_focus_*`` blocks should use atom-flavoured hints
-    (empty framework falls back to the canonical sglang/vllm block)."""
+    (empty framework falls back to the canonical sglang/vllm block).
+
+    Args:
+        inp: The specialist prompt inputs.
+
+    Returns:
+        True when the framework is ``atom``.
+    """
     return (inp.framework or "").strip().lower() == "atom"
 
 
@@ -631,7 +638,14 @@ def _auto_retry_note_block(inp: SpecialistPromptInputs) -> list[str]:
     """Heads-up block when this dispatch is a bounded auto-retry of a prior
     transient (timeout / crash / stale-heartbeat) attempt. Advisory only —
     the mandate is unchanged; the note nudges the specialist to scope its work
-    so it finishes within budget this time."""
+    so it finishes within budget this time.
+
+    Args:
+        inp: The specialist prompt inputs (reads ``auto_retry_reason``).
+
+    Returns:
+        The rendered auto-retry notice lines.
+    """
     reason = inp.auto_retry_reason.strip()
     return [
         "",
@@ -651,7 +665,15 @@ def _auto_retry_note_block(inp: SpecialistPromptInputs) -> list[str]:
 def _bench_block(inp: SpecialistPromptInputs) -> list[str]:
     """In-loop micro-bench mandate appended for bench-enabled specialists
     (``mode=patch`` & ``bench=true``). Lists the whitelisted ``bench_id``s and
-    the worktree-scoped contract; the ``run_bench`` tool executes them."""
+    the worktree-scoped contract; the ``run_bench`` tool executes them.
+
+    Args:
+        inp: The specialist prompt inputs.
+
+    Returns:
+        The rendered micro-bench mandate lines, or ``[]`` when no benches are
+        registered.
+    """
     from ..specialist_bench import BENCH_REGISTRY, MAX_BENCH_WALL_CLOCK_SEC
     if not BENCH_REGISTRY:
         return []
@@ -683,7 +705,14 @@ def _freeform_block(inp: SpecialistPromptInputs) -> list[str]:
     """Free-form mandate appended when ``scope == 'freeform'`` (absorbed from
     the retired dynamic_specialist wave channel). The specialist is NOT bound
     to the domain catalogue — the Orchestration ``task_description`` is the
-    whole mandate. The single deliverable is still ONE ``specialist_done``."""
+    whole mandate. The single deliverable is still ONE ``specialist_done``.
+
+    Args:
+        inp: The specialist prompt inputs (reads ``task_description``).
+
+    Returns:
+        The rendered free-form mandate lines.
+    """
     desc = (inp.task_description or "").strip() or "(no task description provided)"
     return [
         "",
@@ -709,7 +738,15 @@ def _cross_domain_block(inp: SpecialistPromptInputs) -> list[str]:
     """Cross-domain mandate appended when ``scope == 'domains'`` (absorbed
     from the retired dynamic_action channel). The single deliverable is still
     ONE ``specialist_done``; the difference is the patch may span every domain
-    in scope and the Critic will hold it to the cross-domain rules."""
+    in scope and the Critic will hold it to the cross-domain rules.
+
+    Args:
+        inp: The specialist prompt inputs (reads ``extra_focus_tags`` /
+            ``domain``).
+
+    Returns:
+        The rendered cross-domain mandate lines.
+    """
     tags = ", ".join(inp.extra_focus_tags) if inp.extra_focus_tags else inp.domain.key
     return [
         "",
@@ -829,7 +866,14 @@ def _section_gap(inp: SpecialistPromptInputs) -> list[str]:
 # Section 4 — optional KB context
 def _is_cold_start(inp: SpecialistPromptInputs) -> bool:
     """Issue-J: all prior sources empty, so inject a cold-start directive
-    instead of letting specialists return an empty proposal_set."""
+    instead of letting specialists return an empty proposal_set.
+
+    Args:
+        inp: The specialist prompt inputs.
+
+    Returns:
+        True when every prior KB/PR/research source is empty.
+    """
     return (
         not inp.kb_subgraph
         and not inp.warm_start_recipe
@@ -920,7 +964,14 @@ def _section_kb_subgraph(inp: SpecialistPromptInputs) -> list[str]:
 # Section 4a — Roofline / TraceLens evidence
 def _section_roofline_evidence(inp: SpecialistPromptInputs) -> list[str]:
     """Render the ROOFLINE EVIDENCE section from ``inp.roofline_evidence``;
-    empty evidence renders a heading + ``(none)`` placeholder."""
+    empty evidence renders a heading + ``(none)`` placeholder.
+
+    Args:
+        inp: The specialist prompt inputs (reads ``roofline_evidence``).
+
+    Returns:
+        The rendered roofline-evidence section lines.
+    """
     rows = ["## 4a. ROOFLINE EVIDENCE", ""]
     ev = inp.roofline_evidence or {}
     if not isinstance(ev, dict) or not ev:
@@ -1074,7 +1125,14 @@ def _section_recipe(inp: SpecialistPromptInputs) -> list[str]:
 # Section 5b — Related lessons (positive priors from prior KEEPs)
 def _section_lessons(inp: SpecialistPromptInputs) -> list[str]:
     """Render KB ``kind=lesson`` points from prior KEEPs, compactly
-    (statement + measured_impact)."""
+    (statement + measured_impact).
+
+    Args:
+        inp: The specialist prompt inputs (reads ``warm_start_lessons``).
+
+    Returns:
+        The rendered related-lessons section lines.
+    """
     rows = ["## 5b. RELATED LESSONS (prior KEEPs on this model+hw)", ""]
     if not inp.warm_start_lessons:
         rows.append(_NONE_PLACEHOLDER)
@@ -1117,7 +1175,16 @@ def _format_version_note(
 ) -> str:
     """GAP 8 — render a ``[from sglang@X.Y, you're on A.B]`` annotation when
     the lesson's framework_version differs; empty when either side is
-    unknown or they match."""
+    unknown or they match.
+
+    Args:
+        inp: The specialist prompt inputs (reads ``framework`` /
+            ``framework_version``).
+        lesson_attrs: The lesson's attrs (reads ``framework_version``).
+
+    Returns:
+        The version-mismatch annotation, or "" when unknown or matching.
+    """
     lesson_fv = str(lesson_attrs.get("framework_version") or "").strip()
     current_fv = (inp.framework_version or "").strip()
     if not lesson_fv or not current_fv:
@@ -1130,7 +1197,14 @@ def _format_version_note(
 
 def _render_measured_impact(raw: Any) -> str:
     """Back-compat renderer for ``attrs.measured_impact`` (dict, legacy
-    string, or other)."""
+    string, or other).
+
+    Args:
+        raw: The ``measured_impact`` value (dict, string, None, or other).
+
+    Returns:
+        A compact human-readable impact string ("" when ``raw`` is None).
+    """
     if isinstance(raw, dict):
         parts: list[str] = []
         gain = raw.get("gain_pct")
@@ -1156,7 +1230,14 @@ def _render_measured_impact(raw: Any) -> str:
 # Section 5c — Known pitfalls (anti-priors from prior REVERTs)
 def _section_pitfalls(inp: SpecialistPromptInputs) -> list[str]:
     """Render KB ``kind=pitfall`` points from prior REVERTs (description +
-    severity); framed as forbidden paths, not suggestions."""
+    severity); framed as forbidden paths, not suggestions.
+
+    Args:
+        inp: The specialist prompt inputs (reads ``warm_start_pitfalls``).
+
+    Returns:
+        The rendered known-pitfalls section lines.
+    """
     rows = ["## 5c. KNOWN PITFALLS (do NOT repeat — prior REVERTs)", ""]
     if not inp.warm_start_pitfalls:
         rows.append(_NONE_PLACEHOLDER)

--- a/inference_optimizer/orchestrator/system_prompts/specialist_prompt_builder.py
+++ b/inference_optimizer/orchestrator/system_prompts/specialist_prompt_builder.py
@@ -379,6 +379,15 @@ def _focus_pr_intel_specialist(inp: SpecialistPromptInputs) -> list[str]:
 def _focus_research_scout_specialist(
     inp: SpecialistPromptInputs,
 ) -> list[str]:
+    """Build the focus section for the research-scout specialist prompt.
+
+    Args:
+        inp: Assembled prompt inputs for the current dispatch.
+
+    Returns:
+        Prompt lines highlighting already-proven priors and steering the
+        scout toward net-new findings.
+    """
     proven_lines: list[str] = []
     if inp.already_proven:
         proven_lines.append(
@@ -832,6 +841,16 @@ def _is_cold_start(inp: SpecialistPromptInputs) -> bool:
 
 
 def _section_kb_subgraph(inp: SpecialistPromptInputs) -> list[str]:
+    """Build the advisory KB-context section of the specialist prompt.
+
+    Falls back to research hints when the structured KB subgraph is empty.
+
+    Args:
+        inp: Assembled prompt inputs for the current dispatch.
+
+    Returns:
+        Prompt lines rendering the KB subgraph (or hint-based fallback).
+    """
     rows = ["## 4. KB CONTEXT (optional, advisory)", ""]
     cold = _is_cold_start(inp)
     if not inp.kb_subgraph:

--- a/inference_optimizer/orchestrator/task_registry.py
+++ b/inference_optimizer/orchestrator/task_registry.py
@@ -158,7 +158,22 @@ class TaskRegistry:
         lease_ttl_sec: int = 0,
         task_id: str | None = None,
     ) -> tuple[Task, bool]:
-        """Insert a new task row OR return the existing one keyed by idempotency_key. Returns ``(task, was_existing)``."""
+        """Insert a new task row OR return the existing one keyed by idempotency_key. Returns ``(task, was_existing)``.
+
+        Args:
+            kind: Task kind tag.
+            params: Task parameters serialised into the row.
+            idempotency_key: Key used to detect and return an existing task.
+            requires_lanes: Lanes the task must hold while running.
+            allowed_tools: Tools the task is permitted to use.
+            side_effects: Declared side effects of the task.
+            lease_ttl_sec: Lease time-to-live in seconds.
+            task_id: Optional explicit task id; generated when omitted.
+
+        Returns:
+            A tuple ``(task, was_existing)`` where ``was_existing`` is ``True``
+            when a task with the same idempotency key already existed.
+        """
         existing = await self.db.fetchone(
             "SELECT * FROM tasks WHERE idempotency_key=?", (idempotency_key,)
         )
@@ -220,7 +235,21 @@ class TaskRegistry:
         lease_ttl_sec: int = 0,
         task_id: str | None = None,
     ) -> Task:
-        """Thin wrapper around :meth:`create_or_return_existing` for callers that don't need ``was_existing``."""
+        """Thin wrapper around :meth:`create_or_return_existing` for callers that don't need ``was_existing``.
+
+        Args:
+            kind: Task kind tag.
+            params: Task parameters serialised into the row.
+            idempotency_key: Key used to detect and return an existing task.
+            requires_lanes: Lanes the task must hold while running.
+            allowed_tools: Tools the task is permitted to use.
+            side_effects: Declared side effects of the task.
+            lease_ttl_sec: Lease time-to-live in seconds.
+            task_id: Optional explicit task id; generated when omitted.
+
+        Returns:
+            The created or pre-existing ``Task``.
+        """
         task, _was_existing = await self.create_or_return_existing(
             kind=kind,
             params=params,
@@ -352,7 +381,14 @@ class TaskRegistry:
         return [Task.from_row(r) for r in rows]
 
     async def cancel_family(self, family_kinds: list[str]) -> list[str]:
-        """Bulk-cancel queued tasks of the given kinds (Robustness prune_branch); returns cancelled task_ids."""
+        """Bulk-cancel queued tasks of the given kinds (Robustness prune_branch); returns cancelled task_ids.
+
+        Args:
+            family_kinds: Task kinds whose queued tasks should be cancelled.
+
+        Returns:
+            The task ids that were cancelled (empty when none matched).
+        """
         if not family_kinds:
             return []
         cancelled: list[str] = []

--- a/inference_optimizer/orchestrator/task_registry.py
+++ b/inference_optimizer/orchestrator/task_registry.py
@@ -396,6 +396,15 @@ class TaskRegistry:
 
         Idempotent: a second call finds the rows already ``failed`` and is a
         no-op. Returns the reclaimed task_ids.
+
+        Args:
+            now_unix: Reference unix time for lease-age comparison; defaults to
+                the current time.
+            reason: Reason label recorded in the transition history evidence.
+
+        Returns:
+            The task ids whose expired running lease was reclaimed to
+            ``failed`` (empty when none expired).
         """
         import time as _time
 

--- a/inference_optimizer/orchestrator/trace/conversation_trace.py
+++ b/inference_optimizer/orchestrator/trace/conversation_trace.py
@@ -103,10 +103,23 @@ def redact_secrets(text: str) -> str:
 
 
 def _now_iso() -> str:
+    """Return the current UTC time as a microsecond-precision ISO string.
+
+    Returns:
+        ISO 8601 timestamp in UTC.
+    """
     return datetime.now(timezone.utc).isoformat(timespec="microseconds")
 
 
 def _coerce_optional_str(value: Any) -> str | None:
+    """Coerce a value to a non-empty stripped string or ``None``.
+
+    Args:
+        value: Arbitrary value to normalize.
+
+    Returns:
+        The stripped string, or ``None`` if it is empty or ``None``.
+    """
     if value is None:
         return None
     s = str(value).strip()
@@ -114,6 +127,14 @@ def _coerce_optional_str(value: Any) -> str | None:
 
 
 def _coerce_optional_int(value: Any) -> int | None:
+    """Coerce a value to ``int`` or ``None`` if it cannot be parsed.
+
+    Args:
+        value: Arbitrary value to convert.
+
+    Returns:
+        The integer value, or ``None`` on failure.
+    """
     if value is None:
         return None
     try:

--- a/inference_optimizer/orchestrator/trace/conversation_trace.py
+++ b/inference_optimizer/orchestrator/trace/conversation_trace.py
@@ -93,6 +93,12 @@ def redact_secrets(text: str) -> str:
     redacted line still reads sensibly, only the secret material is
     replaced with ``[REDACTED]``. Returns ``text`` unchanged when it
     carries no recognizable secret shape.
+
+    Args:
+        text: Raw text that may embed secret values.
+
+    Returns:
+        The text with recognizable secret values replaced by ``[REDACTED]``.
     """
     if not text:
         return text
@@ -144,7 +150,14 @@ def _coerce_optional_int(value: Any) -> int | None:
 
 
 def _coerce_text(value: Any) -> str:
-    """Normalize a prompt / response field to a (possibly empty) string."""
+    """Normalize a prompt / response field to a (possibly empty) string.
+
+    Args:
+        value: Arbitrary prompt/response value.
+
+    Returns:
+        The value as a string, or ``""`` when ``None``.
+    """
     if value is None:
         return ""
     return value if isinstance(value, str) else str(value)
@@ -173,7 +186,11 @@ class ConversationRecord:
 
     def to_row(self) -> dict[str, Any]:
         """Serialize to the on-disk row dict, stamping ``ts`` and redacting
-        the prompt / response text."""
+        the prompt / response text.
+
+        Returns:
+            The on-disk conversation row dict.
+        """
         return {
             "session_id": str(self.session_id),
             "ts": _now_iso(),
@@ -191,7 +208,15 @@ class ConversationRecord:
 
 
 def _validate_row(row: dict[str, Any]) -> None:
-    """Fail fast if ``row`` deviates from the closed schema."""
+    """Fail fast if ``row`` deviates from the closed schema.
+
+    Args:
+        row: A serialized conversation row dict.
+
+    Raises:
+        ConversationRowError: If the row has extra/missing fields, an empty
+            ``session_id``, or an unknown ``component``.
+    """
     keys = set(row.keys())
     extra = sorted(keys - _ROW_FIELDS)
     missing = sorted(_ROW_FIELDS - keys)
@@ -229,6 +254,15 @@ def append_conversation(
 
     A schema violation (:class:`ConversationRowError`) is *not* swallowed:
     that is a programming error at the call site and must surface in tests.
+
+    Args:
+        session_dir: Session directory used to resolve the ledger path.
+        record: The conversation record to serialize and append.
+        target: Optional override destination (e.g. an ext shard path);
+            defaults to the session's conversations ledger.
+
+    Raises:
+        ConversationRowError: If the serialized row violates the schema.
     """
     row = record.to_row()
     _validate_row(row)

--- a/inference_optimizer/orchestrator/trace/langfuse_emitter.py
+++ b/inference_optimizer/orchestrator/trace/langfuse_emitter.py
@@ -78,7 +78,11 @@ def _receipt_path(session_dir: Path) -> Path:
 
 
 def _sdk_available() -> bool:
-    """Whether the optional ``langfuse`` SDK can be imported (no side effects)."""
+    """Whether the optional ``langfuse`` SDK can be imported (no side effects).
+
+    Returns:
+        True when the ``langfuse`` SDK is importable.
+    """
     import importlib.util
 
     try:
@@ -93,6 +97,12 @@ def _to_ns(dt: Any) -> int | None:
     v4's OTEL-based SDK wants integer ns for ``end_time``; v2/v3 accepted a
     ``datetime``. Returns None for a None/zero input so callers can omit the
     kwarg entirely. Best-effort: an unparseable value yields None.
+
+    Args:
+        dt: A ``datetime`` (or other value) to convert.
+
+    Returns:
+        Integer nanoseconds since epoch, or ``None`` when not convertible.
     """
     if dt is None:
         return None
@@ -115,6 +125,13 @@ def _start_obs(parent: Any, **kwargs: Any) -> Any:
     TypeError, retry without it. This keeps backdated timestamps where the
     SDK supports them and degrades to "start = now" only on the SDKs that
     require it, instead of unconditionally dropping the timestamp.
+
+    Args:
+        parent: The client or span to create the observation under.
+        **kwargs: Observation kwargs forwarded to ``start_observation``.
+
+    Returns:
+        The created observation object.
     """
     try:
         return parent.start_observation(**kwargs)
@@ -132,6 +149,12 @@ def _end_time_wants_int(obs: Any) -> bool:
     OTEL span, so a "try datetime then retry int" pattern double-ends the
     span and emits a noisy "Calling end() on an ended span" warning.
     Falls back to datetime (False) when the annotation can't be read.
+
+    Args:
+        obs: The observation whose ``end`` signature is inspected.
+
+    Returns:
+        True when ``end(end_time=...)`` expects integer nanoseconds.
     """
     try:
         import inspect
@@ -150,6 +173,10 @@ def _end_obs(obs: Any, end_dt: Any) -> None:
     Picks the right ``end_time`` type up front (see :func:`_end_time_wants_int`)
     so the span is never ended twice. Falls back to a bare ``end()`` if the
     typed call is rejected, so a signature change can't strand an open span.
+
+    Args:
+        obs: The observation to end (no-op when ``None``).
+        end_dt: The end ``datetime``, or ``None`` for a bare ``end()``.
     """
     if obs is None:
         return
@@ -178,6 +205,12 @@ def _otel_attr_value(v: Any) -> Any:
     the SDK log ``Invalid type ... for attribute`` and drop it. So: skip
     ``None``, pass scalars through, and JSON-stringify everything else
     (e.g. the ``workload`` dict) so it still lands on the trace as text.
+
+    Args:
+        v: The metadata value to coerce.
+
+    Returns:
+        An OTEL-acceptable scalar/string, or ``None`` to skip the attribute.
     """
     if v is None:
         return None
@@ -205,6 +238,12 @@ def _set_trace_attrs(
     attributes directly on the underlying span (``langfuse.trace.name``,
     ``session.id``, ``langfuse.trace.metadata.*``). Best-effort: a missing
     API on either side just means the trace label isn't set, never a raise.
+
+    Args:
+        span: The root span whose trace attributes are stamped.
+        name: Trace name to set, when provided.
+        session_id: Langfuse session id to set, when provided.
+        metadata: Trace-level metadata to stamp, when provided.
     """
     try:
         span.update_trace(name=name, session_id=session_id, metadata=metadata)
@@ -352,6 +391,9 @@ class LangfuseEmitter:
         Records ``_disabled_reason`` (``disabled`` / ``no_credentials`` /
         ``sdk_missing`` / ``init_failed``) so the receipt can explain *why*
         nothing was pushed. Correlation is already resolved in ``__init__``.
+
+        Returns:
+            True when all gates pass and the client was built, else False.
         """
         if not langfuse_live_enabled():
             self._disabled_reason = "disabled"
@@ -389,7 +431,11 @@ class LangfuseEmitter:
 
     @property
     def enabled(self) -> bool:
-        """Whether live push to Langfuse is enabled for this session."""
+        """Whether live push to Langfuse is enabled for this session.
+
+        Returns:
+            True when live push is enabled.
+        """
         return self._enabled
 
     # -- span hierarchy (trace -> phase -> agent -> generation) ---------
@@ -402,7 +448,14 @@ class LangfuseEmitter:
         return str(self._manifest.get("model_name") or self._session_label or "hyperloom")
 
     def _ensure_root(self, start: Any) -> Any:
-        """Lazily open the root span and stamp trace-level attrs once."""
+        """Lazily open the root span and stamp trace-level attrs once.
+
+        Args:
+            start: Span start time.
+
+        Returns:
+            The cached or newly opened root span.
+        """
         if self._root_span is None:
             self._root_span = _start_obs(
                 self._client,
@@ -446,7 +499,16 @@ class LangfuseEmitter:
 
     def _ensure_agent_span(self, phase: str, agent: str, start: Any) -> Any:
         """Get-or-create the per-(phase, agent) span. This is the 'which agent
-        did what' layer; Generations and decision Scores attach here."""
+        did what' layer; Generations and decision Scores attach here.
+
+        Args:
+            phase: Phase name.
+            agent: Agent/component name.
+            start: Span start time.
+
+        Returns:
+            The cached or newly opened agent span.
+        """
         key = (phase, agent)
         span = self._agent_spans.get(key)
         if span is None:
@@ -462,7 +524,11 @@ class LangfuseEmitter:
 
     # -- live ingest ----------------------------------------------------
     def record_llm_call(self, row: dict[str, Any]) -> None:
-        """Buffer a token row; emit the Generation if its text half is in."""
+        """Buffer a token row; emit the Generation if its text half is in.
+
+        Args:
+            row: The token (``llm_calls``) trace row.
+        """
         if not self._enabled:
             return
         try:
@@ -471,7 +537,11 @@ class LangfuseEmitter:
             log.debug("langfuse: record_llm_call failed", exc_info=True)
 
     def record_conversation(self, row: dict[str, Any]) -> None:
-        """Buffer a conversation row; emit the Generation if its tokens are in."""
+        """Buffer a conversation row; emit the Generation if its tokens are in.
+
+        Args:
+            row: The conversation trace row.
+        """
         if not self._enabled:
             return
         try:
@@ -505,7 +575,12 @@ class LangfuseEmitter:
         token_row: dict[str, Any] | None,
         conv_row: dict[str, Any] | None,
     ) -> None:
-        """Emit one Generation, nested under its phase -> agent span."""
+        """Emit one Generation, nested under its phase -> agent span.
+
+        Args:
+            token_row: The token half of the call, or ``None``.
+            conv_row: The conversation (text) half of the call, or ``None``.
+        """
         base = token_row or conv_row or {}
         phase = lfmap.phase_of(base)
         agent = lfmap.agent_of(base)
@@ -685,6 +760,9 @@ class LangfuseEmitter:
         is True once :meth:`flush_session` has run (so the out-of-process ext
         shards and decision scores are reflected); before that it reports the
         in-process running totals.
+
+        Returns:
+            A redacted receipt dict mirroring the breakdown ``langfuse`` section.
         """
         creds = langfuse_credentials()
         config = {
@@ -737,7 +815,14 @@ _REGISTRY_LOCK = threading.Lock()
 
 
 def get_emitter(session_dir: Path) -> LangfuseEmitter:
-    """Return the per-session emitter, building it once (cached by session)."""
+    """Return the per-session emitter, building it once (cached by session).
+
+    Args:
+        session_dir: Session directory keying the emitter.
+
+    Returns:
+        The cached or newly built :class:`LangfuseEmitter`.
+    """
     key = str(Path(session_dir).resolve())
     with _REGISTRY_LOCK:
         emitter = _REGISTRY.get(key)
@@ -748,7 +833,11 @@ def get_emitter(session_dir: Path) -> LangfuseEmitter:
 
 
 def flush_session(session_dir: Path) -> None:
-    """Module-level convenience: flush the emitter for ``session_dir``."""
+    """Module-level convenience: flush the emitter for ``session_dir``.
+
+    Args:
+        session_dir: Session directory whose emitter is flushed.
+    """
     get_emitter(session_dir).flush_session()
 
 
@@ -759,6 +848,12 @@ def read_receipt(session_dir: Path) -> dict[str, Any] | None:
     collector, since its counts are final) or ``None`` if no receipt was
     written -- e.g. the breakdown is being assembled before ``flush_session``
     ran, or live push never happened.
+
+    Args:
+        session_dir: Session directory whose receipt is read.
+
+    Returns:
+        The receipt dict, or ``None`` when no receipt was written.
     """
     import json
 

--- a/inference_optimizer/orchestrator/trace/langfuse_emitter.py
+++ b/inference_optimizer/orchestrator/trace/langfuse_emitter.py
@@ -54,10 +54,26 @@ log = logging.getLogger(__name__)
 
 
 def _manifest_path(session_dir: Path) -> Path:
+    """Return the path to a session's ``manifest.json``.
+
+    Args:
+        session_dir: Session directory.
+
+    Returns:
+        The manifest file path.
+    """
     return session_dir / "manifest.json"
 
 
 def _receipt_path(session_dir: Path) -> Path:
+    """Return the path to a session's Langfuse receipt file.
+
+    Args:
+        session_dir: Session directory.
+
+    Returns:
+        The ``langfuse_receipt.json`` path under the trace directory.
+    """
     return trace_dir(session_dir) / "langfuse_receipt.json"
 
 
@@ -220,6 +236,15 @@ def _set_trace_attrs(
 
 
 def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Load a JSONL file into a list of dict records.
+
+    Args:
+        path: Path to the ``.jsonl`` file.
+
+    Returns:
+        The dict records; missing files, unreadable files, and malformed lines
+        yield (or are skipped to) an empty/partial list.
+    """
     import json
 
     out: list[dict[str, Any]] = []
@@ -243,6 +268,15 @@ def _load_jsonl(path: Path) -> list[dict[str, Any]]:
 
 
 def _load_json(path: Path) -> dict[str, Any]:
+    """Load a JSON object file.
+
+    Args:
+        path: Path to the JSON file.
+
+    Returns:
+        The parsed object, or ``{}`` when the file is missing, unreadable, or
+        not a JSON object.
+    """
     import json
 
     if not path.exists():
@@ -264,6 +298,15 @@ class LangfuseEmitter:
     """
 
     def __init__(self, session_dir: Path) -> None:
+        """Initialize the per-session emitter.
+
+        Resolves the manifest and correlation labels unconditionally (even when
+        the live push is disabled) so the receipt always reports the right trace
+        and correlation ids.
+
+        Args:
+            session_dir: Session directory whose traces are emitted.
+        """
         self.session_dir = Path(session_dir)
         self._lock = threading.Lock()
         # pair_key -> partial generation parts ({"llm": row} / {"conv": row}).
@@ -346,10 +389,16 @@ class LangfuseEmitter:
 
     @property
     def enabled(self) -> bool:
+        """Whether live push to Langfuse is enabled for this session."""
         return self._enabled
 
     # -- span hierarchy (trace -> phase -> agent -> generation) ---------
     def _trace_name(self) -> str:
+        """Return the human-readable trace name.
+
+        Returns:
+            The model name, else the session label, else ``"hyperloom"``.
+        """
         return str(self._manifest.get("model_name") or self._session_label or "hyperloom")
 
     def _ensure_root(self, start: Any) -> Any:
@@ -374,6 +423,15 @@ class LangfuseEmitter:
         return self._root_span
 
     def _ensure_phase_span(self, phase: str, start: Any) -> Any:
+        """Get-or-create the span for a phase under the trace root.
+
+        Args:
+            phase: Phase name.
+            start: Span start time.
+
+        Returns:
+            The cached or newly opened phase span.
+        """
         span = self._phase_spans.get(phase)
         if span is None:
             root = self._ensure_root(start)
@@ -422,6 +480,12 @@ class LangfuseEmitter:
             log.debug("langfuse: record_conversation failed", exc_info=True)
 
     def _buffer(self, row: dict[str, Any], *, half: str) -> None:
+        """Buffer one half of a generation and emit once both halves arrive.
+
+        Args:
+            row: The token (``llm``) or conversation (``conv``) row.
+            half: Which half this row represents (``"llm"`` or ``"conv"``).
+        """
         key = lfmap.pair_key(row)
         emit_parts: dict[str, dict[str, Any]] | None = None
         with self._lock:
@@ -521,6 +585,11 @@ class LangfuseEmitter:
 
     @staticmethod
     def _safe_end(span: Any) -> None:
+        """End a span, swallowing any errors.
+
+        Args:
+            span: The span object to end.
+        """
         try:
             span.end()
         except Exception:  # noqa: BLE001
@@ -572,6 +641,13 @@ class LangfuseEmitter:
     def _create_score(
         self, score: dict[str, Any], *, phase: str, agent: str,
     ) -> None:
+        """Attach a Langfuse Score to the owning agent span or the trace.
+
+        Args:
+            score: Score payload (``name``, ``value``, ``data_type``, ...).
+            phase: Phase that owns the decision, used to locate the span.
+            agent: Agent/component that owns the decision.
+        """
         span = self._agent_spans.get((phase, agent))
         try:
             if span is not None and hasattr(span, "score"):

--- a/inference_optimizer/orchestrator/trace/langfuse_emitter.py
+++ b/inference_optimizer/orchestrator/trace/langfuse_emitter.py
@@ -79,7 +79,11 @@ def _receipt_path(session_dir: Path) -> Path:
 
 
 def _sdk_available() -> bool:
-    """Whether the optional ``langfuse`` SDK can be imported (no side effects)."""
+    """Whether the optional ``langfuse`` SDK can be imported (no side effects).
+
+    Returns:
+        True when the ``langfuse`` SDK can be located, False otherwise.
+    """
     import importlib.util
 
     try:
@@ -94,6 +98,13 @@ def _to_ns(dt: Any) -> int | None:
     v4's OTEL-based SDK wants integer ns for ``end_time``; v2/v3 accepted a
     ``datetime``. Returns None for a None/zero input so callers can omit the
     kwarg entirely. Best-effort: an unparseable value yields None.
+
+    Args:
+        dt: the datetime to convert (any other type yields ``None``).
+
+    Returns:
+        Integer nanoseconds since the epoch, or ``None`` for a ``None`` /
+        non-datetime / unparseable input.
     """
     if dt is None:
         return None
@@ -116,6 +127,14 @@ def _start_obs(parent: Any, **kwargs: Any) -> Any:
     TypeError, retry without it. This keeps backdated timestamps where the
     SDK supports them and degrades to "start = now" only on the SDKs that
     require it, instead of unconditionally dropping the timestamp.
+
+    Args:
+        parent: the parent observation (or client) to create the child on.
+        **kwargs: the keyword arguments forwarded to ``start_observation``;
+            ``start_time`` is dropped on a retry if the SDK rejects it.
+
+    Returns:
+        The newly started observation.
     """
     try:
         return parent.start_observation(**kwargs)
@@ -133,6 +152,13 @@ def _end_time_wants_int(obs: Any) -> bool:
     OTEL span, so a "try datetime then retry int" pattern double-ends the
     span and emits a noisy "Calling end() on an ended span" warning.
     Falls back to datetime (False) when the annotation can't be read.
+
+    Args:
+        obs: the observation whose ``end`` signature is inspected.
+
+    Returns:
+        True when the SDK's ``end(end_time=...)`` wants integer ns (v4), False
+        when it wants a datetime (v2/v3) or the annotation can't be read.
     """
     try:
         import inspect
@@ -151,6 +177,10 @@ def _end_obs(obs: Any, end_dt: Any) -> None:
     Picks the right ``end_time`` type up front (see :func:`_end_time_wants_int`)
     so the span is never ended twice. Falls back to a bare ``end()`` if the
     typed call is rejected, so a signature change can't strand an open span.
+
+    Args:
+        obs: the observation to end (``None`` is a no-op).
+        end_dt: the end time as a datetime; ``None`` ends with no explicit time.
     """
     if obs is None:
         return
@@ -179,6 +209,13 @@ def _otel_attr_value(v: Any) -> Any:
     the SDK log ``Invalid type ... for attribute`` and drop it. So: skip
     ``None``, pass scalars through, and JSON-stringify everything else
     (e.g. the ``workload`` dict) so it still lands on the trace as text.
+
+    Args:
+        v: the metadata value to coerce.
+
+    Returns:
+        The value unchanged when it is a str/bool/int/float, a JSON string for
+        any other non-``None`` value, or ``None`` to skip ``None`` inputs.
     """
     if v is None:
         return None
@@ -206,6 +243,12 @@ def _set_trace_attrs(
     attributes directly on the underlying span (``langfuse.trace.name``,
     ``session.id``, ``langfuse.trace.metadata.*``). Best-effort: a missing
     API on either side just means the trace label isn't set, never a raise.
+
+    Args:
+        span: the span/observation whose trace-level attributes are stamped.
+        name: optional trace name.
+        session_id: optional session id to group the trace.
+        metadata: optional trace-level metadata mapping.
     """
     try:
         span.update_trace(name=name, session_id=session_id, metadata=metadata)
@@ -356,6 +399,10 @@ class LangfuseEmitter:
         Records ``_disabled_reason`` (``disabled`` / ``no_credentials`` /
         ``sdk_missing`` / ``init_failed``) so the receipt can explain *why*
         nothing was pushed. Correlation is already resolved in ``__init__``.
+
+        Returns:
+            bool: True when all three gates pass and the SDK client was built;
+                False (a no-op emitter) otherwise.
         """
         if not langfuse_live_enabled():
             self._disabled_reason = "disabled"
@@ -393,7 +440,11 @@ class LangfuseEmitter:
 
     @property
     def enabled(self) -> bool:
-        """Whether live push to Langfuse is enabled for this session."""
+        """Whether live push to Langfuse is enabled for this session.
+
+        Returns:
+            bool: True when live push is enabled for this session.
+        """
         return self._enabled
 
     # -- span hierarchy (trace -> phase -> agent -> generation) ---------
@@ -406,7 +457,14 @@ class LangfuseEmitter:
         return str(self._manifest.get("model_name") or self._session_label or "hyperloom")
 
     def _ensure_root(self, start: Any) -> Any:
-        """Lazily open the root span and stamp trace-level attrs once."""
+        """Lazily open the root span and stamp trace-level attrs once.
+
+        Args:
+            start: the start time for the root span.
+
+        Returns:
+            The cached or newly opened root span.
+        """
         if self._root_span is None:
             self._root_span = _start_obs(
                 self._client,
@@ -450,7 +508,16 @@ class LangfuseEmitter:
 
     def _ensure_agent_span(self, phase: str, agent: str, start: Any) -> Any:
         """Get-or-create the per-(phase, agent) span. This is the 'which agent
-        did what' layer; Generations and decision Scores attach here."""
+        did what' layer; Generations and decision Scores attach here.
+
+        Args:
+            phase: Phase name.
+            agent: Agent name.
+            start: Span start time.
+
+        Returns:
+            The cached or newly opened (phase, agent) span.
+        """
         key = (phase, agent)
         span = self._agent_spans.get(key)
         if span is None:
@@ -466,7 +533,11 @@ class LangfuseEmitter:
 
     # -- live ingest ----------------------------------------------------
     def record_llm_call(self, row: dict[str, Any]) -> None:
-        """Buffer a token row; emit the Generation if its text half is in."""
+        """Buffer a token row; emit the Generation if its text half is in.
+
+        Args:
+            row: the token (``llm``) row to buffer.
+        """
         if not self._enabled:
             return
         try:
@@ -475,7 +546,11 @@ class LangfuseEmitter:
             log.debug("langfuse: record_llm_call failed", exc_info=True)
 
     def record_conversation(self, row: dict[str, Any]) -> None:
-        """Buffer a conversation row; emit the Generation if its tokens are in."""
+        """Buffer a conversation row; emit the Generation if its tokens are in.
+
+        Args:
+            row: the conversation (``conv``) row to buffer.
+        """
         if not self._enabled:
             return
         try:
@@ -557,7 +632,13 @@ class LangfuseEmitter:
         token_row: dict[str, Any] | None,
         conv_row: dict[str, Any] | None,
     ) -> None:
-        """Emit one Generation, nested under its phase -> agent span."""
+        """Emit one Generation, nested under its phase -> agent span.
+
+        Args:
+            token_row: the token-half row, or ``None`` when only text is in.
+            conv_row: the conversation-half row, or ``None`` when only tokens
+                are in.
+        """
         base = token_row or conv_row or {}
         phase = lfmap.phase_of(base)
         agent = lfmap.agent_of(base)
@@ -636,6 +717,10 @@ class LangfuseEmitter:
         live spans (the normal order: write file -> flush -> patch langfuse ->
         record here). Idempotent (a second call is a no-op) and best-effort:
         any send failure is swallowed and never breaks shutdown.
+
+        Args:
+            breakdown: the complete ``session_breakdown.json`` document to
+                attach; a non-dict or empty value is a no-op.
         """
         if not self._enabled or not isinstance(breakdown, dict) or not breakdown:
             return
@@ -795,6 +880,14 @@ class LangfuseEmitter:
         ``grid`` to ``orchestration`` (grid proposals are orchestration-driven),
         so the per-decision score still lands under a real agent span instead of
         always falling back to the trace level.
+
+        Args:
+            proposer: the resolved proposer label from the decision metadata.
+
+        Returns:
+            str: the span-attachable agent name (``specialist`` / ``orchestration``
+                for the collapsed aliases, else the proposer or the unknown-agent
+                fallback).
         """
         p = (proposer or "").strip()
         if p.startswith("specialist:"):
@@ -812,6 +905,15 @@ class LangfuseEmitter:
         operation_kind + proposer + effect in metadata so dashboards/Langfuse can
         filter steps directly. Returns the span, or ``None`` when no parent is
         open or the SDK rejects the call (best-effort; never raises).
+
+        Args:
+            drow: the decision_trace row carrying the ``decision`` payload.
+            phase: the phase that owns the decision (used to locate the parent).
+            agent: the agent that owns the decision (used to locate the parent).
+
+        Returns:
+            The opened ``optimization_step`` span, or ``None`` when no parent is
+            open or the SDK rejects the call.
         """
         parent = (
             self._agent_spans.get((phase, agent))
@@ -898,6 +1000,11 @@ class LangfuseEmitter:
         is True once :meth:`flush_session` has run (so the out-of-process ext
         shards and decision scores are reflected); before that it reports the
         in-process running totals.
+
+        Returns:
+            dict[str, Any]: a redacted receipt dict (enabled flag, disabled
+                reason, config, trace/session ids, correlation key, and push
+                counts) mirroring the ``langfuse`` breakdown section.
         """
         creds = langfuse_credentials()
         config = {
@@ -950,7 +1057,14 @@ _REGISTRY_LOCK = threading.Lock()
 
 
 def get_emitter(session_dir: Path) -> LangfuseEmitter:
-    """Return the per-session emitter, building it once (cached by session)."""
+    """Return the per-session emitter, building it once (cached by session).
+
+    Args:
+        session_dir: Session directory the emitter is keyed by.
+
+    Returns:
+        LangfuseEmitter: the cached or newly built emitter for the session.
+    """
     key = str(Path(session_dir).resolve())
     with _REGISTRY_LOCK:
         emitter = _REGISTRY.get(key)
@@ -961,12 +1075,24 @@ def get_emitter(session_dir: Path) -> LangfuseEmitter:
 
 
 def flush_session(session_dir: Path) -> None:
-    """Module-level convenience: flush the emitter for ``session_dir``."""
+    """Module-level convenience: flush the emitter for ``session_dir``.
+
+    Args:
+        session_dir: Session directory whose emitter is flushed.
+    """
     get_emitter(session_dir).flush_session()
 
 
 def _read_breakdown_file(session_dir: Path) -> dict[str, Any]:
-    """Load the written ``session_breakdown.json`` for ``session_dir`` ({} if absent)."""
+    """Load the written ``session_breakdown.json`` for ``session_dir`` ({} if absent).
+
+    Args:
+        session_dir: Session directory whose breakdown file is read.
+
+    Returns:
+        dict[str, Any]: the parsed breakdown object, or ``{}`` when the file is
+            missing, unreadable, or not a JSON object.
+    """
     import json
 
     from ...breakdown import BREAKDOWN_FILENAME
@@ -991,6 +1117,10 @@ def record_session_breakdown(
     the attached document is the complete, post-flush form). Reads the file
     from disk when ``breakdown`` is not supplied. No-op when live push is
     disabled; best-effort (never raises).
+
+    Args:
+        session_dir: Session directory whose trace the breakdown attaches to.
+        breakdown: the breakdown document; read from disk when ``None``.
     """
     if breakdown is None:
         breakdown = _read_breakdown_file(Path(session_dir))
@@ -1004,6 +1134,13 @@ def read_receipt(session_dir: Path) -> dict[str, Any] | None:
     collector, since its counts are final) or ``None`` if no receipt was
     written -- e.g. the breakdown is being assembled before ``flush_session``
     ran, or live push never happened.
+
+    Args:
+        session_dir: Session directory whose persisted receipt is read.
+
+    Returns:
+        dict[str, Any] | None: the post-flush receipt dict, or ``None`` when no
+            receipt was written or it is unreadable.
     """
     import json
 

--- a/inference_optimizer/orchestrator/trace/langfuse_mapping.py
+++ b/inference_optimizer/orchestrator/trace/langfuse_mapping.py
@@ -38,6 +38,13 @@ def correlation_seed(manifest: dict[str, Any], fallback: str) -> str:
     and any future claw-side upload -- collapses onto the same Langfuse trace
     / session view. Falls back to the internal session id (e.g. the session
     dir name) for standalone/local runs where no claw id exists.
+
+    Args:
+        manifest: Session manifest dict carrying id fields.
+        fallback: Seed used when no id is present in the manifest.
+
+    Returns:
+        The chosen correlation seed string.
     """
     claw = str(manifest.get("claw_session_id") or "").strip()
     if claw:
@@ -52,6 +59,13 @@ def langfuse_session_id(manifest: dict[str, Any], fallback: str) -> str:
     Same precedence as :func:`correlation_seed` (claw id wins) -- this is the
     human-facing session grouping in the Langfuse UI, whereas the trace_id is
     its hashed form.
+
+    Args:
+        manifest: Session manifest dict carrying id fields.
+        fallback: Seed used when no id is present in the manifest.
+
+    Returns:
+        The Langfuse session grouping id.
     """
     return correlation_seed(manifest, fallback)
 
@@ -63,17 +77,37 @@ def agent_of(row: dict[str, Any]) -> str:
     specialist / critic / geak / oob / robustness / proposal_scorer /
     tracelens / breakdown); it is the "which agent did this" axis used for the
     per-agent span layer.
+
+    Args:
+        row: A trace row dict.
+
+    Returns:
+        The producing agent name, or ``UNKNOWN_AGENT`` when absent.
     """
     return str(row.get("component") or row.get("role") or UNKNOWN_AGENT)
 
 
 def phase_of(row: dict[str, Any]) -> str:
-    """The phase a row belongs to (``(unphased)`` when absent)."""
+    """The phase a row belongs to (``(unphased)`` when absent).
+
+    Args:
+        row: A trace row dict.
+
+    Returns:
+        The phase name, or ``UNPHASED`` when absent.
+    """
     return str(row.get("phase") or UNPHASED)
 
 
 def span_key(row: dict[str, Any]) -> tuple[str, str]:
-    """(phase, agent) key identifying which agent-span a Generation nests in."""
+    """(phase, agent) key identifying which agent-span a Generation nests in.
+
+    Args:
+        row: A trace row dict.
+
+    Returns:
+        A ``(phase, agent)`` tuple.
+    """
     return (phase_of(row), agent_of(row))
 
 
@@ -83,6 +117,12 @@ def derive_trace_id(seed: str) -> str:
     Langfuse trace ids must be 32-char lowercase hex; deriving from the
     session id keeps re-runs / live+backfill of the same session writing to
     one trace instead of duplicating it.
+
+    Args:
+        seed: Session id or any seed string to hash.
+
+    Returns:
+        A 32-char lowercase hex trace id.
     """
     return hashlib.sha256(str(seed).encode("utf-8")).hexdigest()[:32]
 
@@ -92,6 +132,12 @@ def parse_ts(ts: str | None) -> datetime | None:
 
     Returns ``None`` for missing / unparseable input so callers can fall
     back to a span/trace-level time without crashing.
+
+    Args:
+        ts: Timestamp string in ISO+offset or ``...Z`` form, or ``None``.
+
+    Returns:
+        The parsed ``datetime``, or ``None`` when missing/unparseable.
     """
     if not ts:
         return None
@@ -107,6 +153,12 @@ def utc_second_key(ts: str | None) -> str:
     ``llm_calls.jsonl`` and ``conversations.jsonl`` stamp their own ``ts`` a
     few milliseconds apart for the same logical call, so pairing is done at
     whole-second resolution.
+
+    Args:
+        ts: Timestamp string, or ``None``.
+
+    Returns:
+        The UTC second key string, or ``""`` when unparseable.
     """
     dt = parse_ts(ts)
     if dt is None:
@@ -128,6 +180,12 @@ def pair_key(row: dict[str, Any]) -> tuple:
     ``asyncio.gather``, so multiple rows land in the same second with
     otherwise identical keys. Older rows that predate any field carry
     ``None``, so the key degrades gracefully to the previous behaviour.
+
+    Args:
+        row: A token or conversation trace row dict.
+
+    Returns:
+        A tuple join key pairing the row across streams.
     """
     return (
         str(row.get("component") or ""),
@@ -147,6 +205,12 @@ def usage_details(row: dict[str, Any]) -> dict[str, int]:
     Drops ``None`` counters (so an unreported counter is absent rather than
     a misleading zero) and maps our canonical names onto the short Langfuse
     keys.
+
+    Args:
+        row: A token trace row dict.
+
+    Returns:
+        Mapping of Langfuse usage key to integer count (``None`` dropped).
     """
     raw = {
         "input": row.get("input_tokens"),
@@ -158,14 +222,30 @@ def usage_details(row: dict[str, Any]) -> dict[str, int]:
 
 
 def generation_name(row: dict[str, Any]) -> str:
-    """Human-friendly Generation name: component, falling back to role."""
+    """Human-friendly Generation name: component, falling back to role.
+
+    Args:
+        row: A token trace row dict.
+
+    Returns:
+        The Generation display name.
+    """
     return str(row.get("component") or row.get("role") or "llm_call")
 
 
 def generation_metadata(
     row: dict[str, Any], *, phase: str, has_text: bool,
 ) -> dict[str, Any]:
-    """Assemble the per-Generation metadata block (join keys + flags)."""
+    """Assemble the per-Generation metadata block (join keys + flags).
+
+    Args:
+        row: A token trace row dict.
+        phase: Phase name to stamp onto the metadata.
+        has_text: Whether a paired conversation text was found.
+
+    Returns:
+        The per-Generation metadata dict.
+    """
     return {
         "phase": phase,
         "tick": row.get("tick"),
@@ -179,7 +259,14 @@ def generation_metadata(
 
 
 def trace_metadata(manifest: dict[str, Any]) -> dict[str, Any]:
-    """Assemble the trace-level metadata block from ``manifest.json``."""
+    """Assemble the trace-level metadata block from ``manifest.json``.
+
+    Args:
+        manifest: Parsed ``manifest.json`` dict.
+
+    Returns:
+        The trace-level metadata dict.
+    """
     workload = manifest.get("workload") or {}
     return {
         "model_name": manifest.get("model_name"),
@@ -204,6 +291,12 @@ def decision_to_scores(decision_row: dict[str, Any]) -> list[dict[str, Any]]:
     carries a measured gain. Each returned dict is transport-agnostic
     (``name`` / ``value`` / ``data_type`` / ``comment`` / ``metadata``) so the
     caller can hand it to the SDK or a REST body unchanged.
+
+    Args:
+        decision_row: One ``decision_trace.jsonl`` row dict.
+
+    Returns:
+        A list of transport-agnostic Score dicts (one or two entries).
     """
     dec = decision_row.get("decision") or {}
     meta = {

--- a/inference_optimizer/orchestrator/trace/llm_trace.py
+++ b/inference_optimizer/orchestrator/trace/llm_trace.py
@@ -88,6 +88,11 @@ class LLMTraceRowError(ValueError):
 
 
 def _now_iso() -> str:
+    """Return the current UTC time as a microsecond-precision ISO string.
+
+    Returns:
+        ISO 8601 timestamp in UTC.
+    """
     return datetime.now(timezone.utc).isoformat(timespec="microseconds")
 
 
@@ -206,6 +211,14 @@ class LLMCallRecord:
 
 
 def _coerce_optional_str(value: Any) -> str | None:
+    """Coerce a value to a non-empty stripped string or ``None``.
+
+    Args:
+        value: Arbitrary value to normalize.
+
+    Returns:
+        The stripped string, or ``None`` if it is empty or ``None``.
+    """
     if value is None:
         return None
     s = str(value).strip()

--- a/inference_optimizer/orchestrator/trace/llm_trace.py
+++ b/inference_optimizer/orchestrator/trace/llm_trace.py
@@ -147,6 +147,9 @@ class LLMCallRecord:
         Normalizes the identity fields to ``str`` and the four token
         counters via :func:`_coerce_optional_int` so a stray float / numpy
         scalar from an SDK ``usage`` object never lands raw in the ledger.
+
+        Returns:
+            The on-disk LLM-call row dict.
         """
         return {
             "session_id": str(self.session_id),
@@ -191,6 +194,20 @@ class LLMCallRecord:
         orchestration/kernel, A2 dynamic_action, A3 specialist fallback).
         Missing token keys degrade to ``None`` rather than ``0`` so the
         collector can distinguish "unreported" from "reported zero".
+
+        Args:
+            session_id: Cross-process aggregation primary key.
+            component: Producer label; must be in :data:`VALID_COMPONENTS`.
+            metadata: Backend turn metadata carrying model + token counters.
+            role: Reactor role name, when known.
+            task_id: Decision-association task id, when known.
+            dyn_id: Dynamic-action id, when known.
+            tick: Timeline tick, when known.
+            phase: Phase name, when known.
+            turn: Multi-turn sub-agent sequence index, when known.
+
+        Returns:
+            A populated :class:`LLMCallRecord`.
         """
         md = metadata or {}
         return cls(
@@ -231,6 +248,12 @@ def _coerce_optional_int(value: Any) -> int | None:
     Unlike the backends' ``_safe_int`` (which floors to 0), this keeps
     ``None`` distinct from ``0``: a backend that does not report a counter
     must not be indistinguishable from one that genuinely spent zero.
+
+    Args:
+        value: Arbitrary token / index value.
+
+    Returns:
+        The integer value, or ``None`` on a miss or bad type.
     """
     if value is None:
         return None
@@ -241,7 +264,15 @@ def _coerce_optional_int(value: Any) -> int | None:
 
 
 def _validate_row(row: dict[str, Any]) -> None:
-    """Fail fast if ``row`` deviates from the closed schema."""
+    """Fail fast if ``row`` deviates from the closed schema.
+
+    Args:
+        row: A serialized LLM-call row dict.
+
+    Raises:
+        LLMTraceRowError: If the row has extra/missing fields, an empty
+            ``session_id``, or an unknown ``component``.
+    """
     keys = set(row.keys())
     extra = sorted(keys - _ROW_FIELDS)
     missing = sorted(_ROW_FIELDS - keys)
@@ -286,6 +317,15 @@ def append_llm_call(
     :class:`LLMTraceRowError` (schema violation) is *not* swallowed: a
     malformed row is a programming error at the call site, not a runtime
     disk condition, and must surface in tests.
+
+    Args:
+        session_dir: Session directory used to resolve the ledger path.
+        record: The LLM-call record to serialize and append.
+        target: Optional override destination (e.g. an ext shard path);
+            defaults to the session's ``llm_calls.jsonl``.
+
+    Raises:
+        LLMTraceRowError: If the serialized row violates the closed schema.
     """
     row = record.to_row()
     _validate_row(row)
@@ -313,7 +353,11 @@ def append_llm_call(
 
 
 def row_field_set() -> frozenset[str]:
-    """Public accessor for the closed row schema (used by the collector)."""
+    """Public accessor for the closed row schema (used by the collector).
+
+    Returns:
+        The frozenset of canonical row field names.
+    """
     return _ROW_FIELDS
 
 

--- a/inference_optimizer/orchestrator/trace/parse_usage.py
+++ b/inference_optimizer/orchestrator/trace/parse_usage.py
@@ -71,6 +71,12 @@ def normalize_usage(usage: dict[str, Any] | None) -> dict[str, int | None] | Non
     recognized counters (so a stray ``{}`` or an unrelated dict doesn't
     masquerade as a real measurement). Unknown keys are dropped; absent
     counters become ``None``.
+
+    Args:
+        usage: Arbitrary usage dict, or ``None``.
+
+    Returns:
+        The canonical four-key token dict, or ``None`` when nothing usable.
     """
     if not isinstance(usage, dict) or not usage:
         return None
@@ -100,6 +106,12 @@ def parse_claude_stream_json_usage(
     onto a different terminal message still works). Malformed lines are
     skipped. Returns ``None`` if the file is missing or no ``usage`` is
     found.
+
+    Args:
+        log_path: Path to the Claude CLI ``stream-json`` log.
+
+    Returns:
+        The canonical token dict, or ``None`` when no usage was found.
     """
     path = Path(log_path)
     last_usage: dict[str, Any] | None = None
@@ -161,6 +173,12 @@ def parse_claude_stream_json_response(
     Tolerant by contract: a missing file, malformed lines, or a stream with
     no recoverable text returns ``None`` so the best-effort trace path
     degrades to "no response captured" instead of raising.
+
+    Args:
+        log_path: Path to the Claude CLI ``stream-json`` log.
+
+    Returns:
+        The recovered response text, or ``None`` when none could be read.
     """
     path = Path(log_path)
     result_text: str | None = None
@@ -222,6 +240,12 @@ def parse_oob_json_usage(stdout: str) -> dict[str, int | None] | None:
 
     OpenAI-style OOB has no prompt-cache split, so ``cache_*`` stay
     ``None``. Returns ``None`` when nothing parseable is found.
+
+    Args:
+        stdout: Captured ``oob run --json`` stdout text.
+
+    Returns:
+        The canonical token dict, or ``None`` when nothing parseable.
     """
     if not stdout or not stdout.strip():
         return None
@@ -264,6 +288,12 @@ def parse_geak_usage(
 
     No prompt-cache split, so ``cache_*`` stay ``None``. Returns ``None``
     when nothing parseable is found.
+
+    Args:
+        payload: A parsed litellm response dict, a JSON string, or ``None``.
+
+    Returns:
+        The canonical token dict, or ``None`` when nothing parseable.
     """
     obj: Any = payload
     if isinstance(payload, str):
@@ -292,6 +322,13 @@ def _find_usage_in_obj(obj: Any, _depth: int = 0) -> dict[str, Any] | None:
     keys, then recurses one extra level into nested dicts. Bounded depth
     keeps this cheap and avoids pathological deep structures; out-of-process
     envelopes nest ``usage`` at most a couple of levels down in practice.
+
+    Args:
+        obj: Arbitrary parsed JSON value to search.
+        _depth: Internal recursion depth guard.
+
+    Returns:
+        The first ``usage``/``token_usage`` dict found, or ``None``.
     """
     if _depth > 4 or not isinstance(obj, dict):
         return None

--- a/inference_optimizer/orchestrator/trace/parse_usage.py
+++ b/inference_optimizer/orchestrator/trace/parse_usage.py
@@ -48,6 +48,14 @@ _TOKEN_KEYS: tuple[str, ...] = (
 
 
 def _coerce_optional_int(value: Any) -> int | None:
+    """Coerce a value to ``int`` or ``None`` if it cannot be parsed.
+
+    Args:
+        value: Arbitrary value to convert.
+
+    Returns:
+        The integer value, or ``None`` on failure.
+    """
     if value is None:
         return None
     try:

--- a/inference_optimizer/orchestrator/trace/trace_env.py
+++ b/inference_optimizer/orchestrator/trace/trace_env.py
@@ -33,6 +33,13 @@ def env_flag(name: str, default: bool = False) -> bool:
 
     Accepts ``1/true/yes/on`` (True) and ``0/false/no/off`` (False),
     case-insensitive. An unset or unrecognized value returns ``default``.
+
+    Args:
+        name: Environment variable name to read.
+        default: Value returned when the var is unset or unrecognized.
+
+    Returns:
+        The parsed boolean, or ``default`` when not recognized.
     """
     raw = os.environ.get(name)
     if raw is None:
@@ -46,7 +53,11 @@ def env_flag(name: str, default: bool = False) -> bool:
 
 
 def langfuse_live_enabled() -> bool:
-    """Report whether the live-Langfuse master switch is on (default off)."""
+    """Report whether the live-Langfuse master switch is on (default off).
+
+    Returns:
+        True when the master switch env var is enabled.
+    """
     return env_flag(ENV_LANGFUSE_ENABLE, default=False)
 
 
@@ -55,6 +66,9 @@ def langfuse_credentials() -> dict[str, str]:
 
     Missing / blank vars are omitted; callers treat an incomplete set as
     "not configured" and degrade to a no-op.
+
+    Returns:
+        Mapping of env var name to stripped value for each set variable.
     """
     out: dict[str, str] = {}
     for key in (ENV_LANGFUSE_HOST, ENV_LANGFUSE_PUBLIC_KEY, ENV_LANGFUSE_SECRET_KEY):
@@ -65,7 +79,11 @@ def langfuse_credentials() -> dict[str, str]:
 
 
 def langfuse_credentials_complete() -> bool:
-    """True iff all three Langfuse connection vars are present and non-empty."""
+    """True iff all three Langfuse connection vars are present and non-empty.
+
+    Returns:
+        True when all three connection vars are set and non-empty.
+    """
     return len(langfuse_credentials()) == 3
 
 

--- a/inference_optimizer/orchestrator/trajectory_reviewer.py
+++ b/inference_optimizer/orchestrator/trajectory_reviewer.py
@@ -32,7 +32,16 @@ _EXHAUSTED_MAX_GAIN_PCT: float = 1.0
 
 
 def _load_journal_entries(session_dir: Path, shared_state: Any) -> list[Any]:
-    """Return journal entries (empty on miss); header fields are read-only here."""
+    """Return journal entries (empty on miss); header fields are read-only here.
+
+    Args:
+        session_dir: The session directory holding the optimization journal.
+        shared_state: The session's shared state, read for journal header
+            fields.
+
+    Returns:
+        The journal entries, or ``[]`` when the journal cannot be loaded.
+    """
     try:
         journal = Journal.load_or_create(
             session_dir,
@@ -46,7 +55,15 @@ def _load_journal_entries(session_dir: Path, shared_state: Any) -> list[Any]:
 
 
 def _exhausted_clusters(entries: list[Any]) -> list[dict[str, Any]]:
-    """Group repeated REVERT / no_promote attempts by (kind, change); dead ends first."""
+    """Group repeated REVERT / no_promote attempts by (kind, change); dead ends first.
+
+    Args:
+        entries: The optimization journal entries to cluster.
+
+    Returns:
+        Exhausted-cluster dicts (``kind`` / ``change`` / ``count`` /
+        ``max_gain``) sorted by attempt count descending.
+    """
     clusters: dict[tuple[str, str], dict[str, Any]] = {}
     for e in entries:
         outcome = getattr(e, "outcome", "")
@@ -72,7 +89,16 @@ def _exhausted_clusters(entries: list[Any]) -> list[dict[str, Any]]:
 
 
 def _stalled_cycle_count(shared_state: Any) -> int:
-    """Consecutive most-recent macro-cycles that produced no explore winner."""
+    """Consecutive most-recent macro-cycles that produced no explore winner.
+
+    Args:
+        shared_state: The session's shared state, read for explore winners
+            history and the current macro cycle.
+
+    Returns:
+        The count of consecutive most-recent macro-cycles with no explore
+        winner.
+    """
     search = getattr(shared_state, "explore_search", None) or {}
     wh = search.get("winners_history") if isinstance(search, dict) else None
     cycles_with_winner = {
@@ -99,6 +125,15 @@ def build_trajectory_digest(
     Deterministic aggregation only (no model call). Surfaces stall depth,
     exhausted directions to avoid, and the dominant roofline bottleneck with a
     suggested specialist lever to redirect exploration.
+
+    Args:
+        session_dir: The session directory holding the optimization journal.
+        shared_state: The session's shared state.
+        max_directions: Maximum number of exhausted directions to list.
+
+    Returns:
+        The advisory trajectory-review block, or ``""`` when there is nothing
+        to report.
     """
     try:
         entries = _load_journal_entries(Path(session_dir), shared_state)

--- a/inference_optimizer/paths.py
+++ b/inference_optimizer/paths.py
@@ -89,6 +89,9 @@ def workspace_root() -> Path:
     ``DEFAULT_SESSION_DIR``), regardless of layout mode. Workspace-shared
     artefacts (runtime/, logs/) live here. Falling back to the default emits
     one loud warning so a misconfigured launcher is visible.
+
+    Returns:
+        The workspace root path.
     """
     global _WARNED_NO_USER_DATA
     user_data = os.environ.get(ENV_USER_DATA_PATH)
@@ -110,7 +113,11 @@ def workspace_root() -> Path:
 
 def _layout_mode() -> str:
     """Effective layout mode: ``flat`` or ``per_model_ts`` (default), pinnable
-    via the env override."""
+    via the env override.
+
+    Returns:
+        Either ``"flat"`` or ``"per_model_ts"``.
+    """
     raw = (os.environ.get(ENV_SESSION_LAYOUT) or "").strip().lower()
     if raw in ("flat", "per_model_ts"):
         return raw
@@ -119,7 +126,14 @@ def _layout_mode() -> str:
 
 def _sanitize_model_basename(model_name: str | os.PathLike[str]) -> str:
     """Reduce ``model_name`` (path, HF id, or Path) to a filename-safe
-    basename (trailing path component). Empty/all-invalid -> ``"session"``."""
+    basename (trailing path component). Empty/all-invalid -> ``"session"``.
+
+    Args:
+        model_name: Model path, HF id, or Path to reduce to a basename.
+
+    Returns:
+        A filename-safe basename, or ``"session"`` when empty/all-invalid.
+    """
     stem = ("" if model_name is None else str(model_name)).strip()
     if not stem:
         return "session"
@@ -135,6 +149,9 @@ def session_dir() -> Path:
     ``$INFERENCE_OPTIMIZER_CURRENT_SESSION_DIR`` (pin from make_session_dir,
     inherited by subprocesses) -> ``$USER_DATA_PATH`` (flat layout) ->
     ``DEFAULT_SESSION_DIR``.
+
+    Returns:
+        The absolute session directory for the current run.
     """
     pinned = os.environ.get(ENV_CURRENT_SESSION_DIR)
     if pinned:
@@ -149,6 +166,13 @@ def find_latest_per_session_dir(
     ``--resume`` without ``--resume-from``). Selects by the
     ``%Y%m%dT%H%M%SZ`` timestamp in the directory name (lex sort), not mtime.
     Returns None when no matching subdir exists.
+
+    Args:
+        model_name: Restrict the scan to one model's subtree, or ``None`` to
+            scan every model basename.
+
+    Returns:
+        The latest per-session directory, or ``None`` when none match.
     """
     ws = workspace_root()
     if not ws.is_dir():
@@ -184,6 +208,13 @@ def make_session_dir(model_name: str | os.PathLike[str] | None = None) -> Path:
     is ``<workspace_root>/<model>/<UTC_ts>/`` and is pinned via
     ``$INFERENCE_OPTIMIZER_CURRENT_SESSION_DIR``; otherwise it is
     workspace_root (flat layout). Idempotent.
+
+    Args:
+        model_name: Model name selecting the per-model subtree, or ``None``
+            for the flat layout.
+
+    Returns:
+        The created (and pinned) session directory.
     """
     ws = workspace_root()
     ws.mkdir(parents=True, exist_ok=True)
@@ -282,7 +313,15 @@ def asset_kernel_opt_dir() -> Path:
 
 def agent_session_dir(session_dir: Path, agent_name: str) -> Path:
     """Per-agent inbox/outbox dir under the session (created by
-    make_session_dir; this only computes the path)."""
+    make_session_dir; this only computes the path).
+
+    Args:
+        session_dir: The session directory root.
+        agent_name: The agent name subdirectory.
+
+    Returns:
+        ``<session_dir>/agents/<agent_name>``.
+    """
     return Path(session_dir) / "agents" / agent_name
 
 
@@ -293,6 +332,12 @@ def runtime_dir(session_dir: Path | None = None) -> Path:
     """``<workspace_root>/runtime/`` — workspace-shared writable runtime
     (kernel-agent env file, GEAK litellm config). Survives across sessions;
     the ``session_dir`` param is ignored (back-compat).
+
+    Args:
+        session_dir: Ignored; accepted for back-compat.
+
+    Returns:
+        ``<workspace_root>/runtime``.
     """
     return workspace_root() / "runtime"
 
@@ -303,6 +348,9 @@ def open_source_root() -> Path:
     ``${TMPDIR:-/tmp}/hyperloom/open-source-repos``. Decoupled from
     ``$USER_DATA_PATH`` so a shared workspace root never collocates concurrent
     pods' checkouts.
+
+    Returns:
+        The pod-local open-source repos root path.
     """
     override = os.environ.get("HYPERLOOM_OPEN_SOURCE_ROOT")
     if override:
@@ -315,6 +363,12 @@ def magpie_dir(session_dir: Path | None = None) -> Path:
     """``<open_source_root>/Magpie/`` — Magpie clone (pod-local; ``$MAGPIE_DIR``
     overrides). Aligned with install.sh so script and runtime resolve the same
     checkout. ``session_dir`` param ignored (back-compat).
+
+    Args:
+        session_dir: Ignored; accepted for back-compat.
+
+    Returns:
+        The Magpie checkout path.
     """
     override = os.environ.get("MAGPIE_DIR")
     if override:
@@ -326,13 +380,26 @@ def kernel_agent_runs_root(session_dir: Path) -> Path:
     """``<sd>/kernel-agent/`` — kernel-agent CLI tool output root (one
     ``runs/<session_id>/`` per invocation). Distinct from the kernel_id-keyed
     ``<sd>/kernel-agent-workspace/``.
+
+    Args:
+        session_dir: The session directory root.
+
+    Returns:
+        ``<session_dir>/kernel-agent``.
     """
     return Path(session_dir) / "kernel-agent"
 
 
 def optimizer_runs_dir(session_dir: Path) -> Path:
     """``<sd>/optimizer_runs/`` — launcher stdout / PID / robustness monitor
-    logs."""
+    logs.
+
+    Args:
+        session_dir: The session directory root.
+
+    Returns:
+        ``<session_dir>/optimizer_runs``.
+    """
     return Path(session_dir) / "optimizer_runs"
 
 
@@ -341,6 +408,9 @@ def mn_profile_trace_root() -> Path:
     root (``<rayjob_id>/torch_trace/`` per provision). Multi-node operators
     MUST set ``$USER_DATA_PATH`` to a cluster-shared path or the sandbox never
     sees pod-side trace files. Single-node never reads this.
+
+    Returns:
+        ``<workspace_root>/profile-traces``.
     """
     return workspace_root() / "profile-traces"
 

--- a/inference_optimizer/protocol/intent.py
+++ b/inference_optimizer/protocol/intent.py
@@ -256,6 +256,14 @@ def _validate_review_verdict_payload(
 
     PolicyGate handles content validation (verdict vocab, variant_name vs
     grid); this only guarantees at-most-one-present for downstream callers.
+
+    Args:
+        payload: The REVIEW_VERDICT intent payload to validate.
+        index: Position of the intent in the envelope (for error messages).
+
+    Raises:
+        IntentValidationError: If neither or both of ``verdict`` and
+            ``verdict_map`` are present, or ``verdict_map`` is malformed.
     """
     has_single = "verdict" in payload
     has_map = "verdict_map" in payload

--- a/inference_optimizer/recipe_kb/composite_remote.py
+++ b/inference_optimizer/recipe_kb/composite_remote.py
@@ -99,6 +99,14 @@ def _precedence_key(row: dict[str, Any]) -> tuple[int, float, int, float]:
 
 
 def _is_empty(value: Any) -> bool:
+    """Return whether a value counts as empty for back-fill purposes.
+
+    Args:
+        value: Value to test.
+
+    Returns:
+        ``True`` for ``None``, empty containers/strings, and numeric zero.
+    """
     if value is None:
         return True
     if isinstance(value, (str, list, dict, tuple)) and len(value) == 0:
@@ -197,6 +205,14 @@ class CompositeRemoteRecipeClient:
     returns_arbor_shape = True
 
     def __init__(self, sources: Iterable[Any], *, names: list[str] | None = None) -> None:
+        """Initialize the composite over an ordered list of sub-remotes.
+
+        Args:
+            sources: Sub-remote clients, in precedence order; ``None`` entries
+                are dropped.
+            names: Optional display names parallel to ``sources``; defaults to
+                each source's ``_name`` or class name.
+        """
         self._sources = [s for s in sources if s is not None]
         self._names = names or [
             getattr(s, "_name", None) or type(s).__name__ for s in self._sources
@@ -208,6 +224,12 @@ class CompositeRemoteRecipeClient:
         return any(getattr(s, "enabled", False) for s in self._sources)
 
     def _active(self) -> list[tuple[str, Any]]:
+        """Return ``(name, source)`` pairs for the enabled sub-remotes.
+
+        Returns:
+            The enabled sources paired with their display names, in precedence
+            order.
+        """
         return [
             (self._names[i], s)
             for i, s in enumerate(self._sources)
@@ -234,6 +256,15 @@ class CompositeRemoteRecipeClient:
         return out
 
     def _merged_search(self, *, per_source_limit: int, kwargs: dict[str, Any]) -> list[dict[str, Any]]:
+        """Fan out a search to all active sources and merge by canonical id.
+
+        Args:
+            per_source_limit: Row limit applied to each sub-remote.
+            kwargs: Search keyword arguments forwarded to each source.
+
+        Returns:
+            Field-merged rows, one per canonical id, sorted by precedence.
+        """
         sub_kwargs = dict(kwargs)
         sub_kwargs["limit"] = per_source_limit
         grouped: dict[str, list[dict[str, Any]]] = {}
@@ -259,6 +290,20 @@ class CompositeRemoteRecipeClient:
         limit: int = 50,
         prefer: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
+        """Search all active sources and return merged, ranked rows.
+
+        Args:
+            label_match: Exact label filters (the 5-tuple identity labels).
+            metric_filters: ``{metric: {min, max}}`` filters.
+            updated_since: Lower bound on ``updated_at``.
+            order_by: Ordering directive forwarded to sub-remotes.
+            limit: Maximum number of merged rows to return.
+            prefer: Workload-similarity hints (accepted for parity; rerank is
+                applied by the dispatcher).
+
+        Returns:
+            Up to ``limit`` merged recipe rows.
+        """
         # Main's dispatcher passes workload-similarity hints through this
         # parameter. Sub-remotes accept it for interface parity while the
         # dispatcher performs the actual client-side rerank.
@@ -299,6 +344,14 @@ class CompositeRemoteRecipeClient:
     # are only hit by direct callers). Delegate to the first capable source.
     # ------------------------------------------------------------------
     def list_recent(self, *, limit: int = 50) -> list[dict[str, Any]]:
+        """Return the most recent merged recipes across all sources.
+
+        Args:
+            limit: Maximum number of rows to return.
+
+        Returns:
+            Up to ``limit`` merged recipe rows ordered most-recent first.
+        """
         return self._merged_search(
             per_source_limit=max(int(limit), _FETCH_FLOOR),
             kwargs={"label_match": None, "limit": limit, "metric_filters": None,
@@ -306,19 +359,47 @@ class CompositeRemoteRecipeClient:
         )[: int(limit)]
 
     def _first_active(self) -> Any | None:
+        """Return the first enabled sub-remote, or ``None`` if none are active."""
         for _name, source in self._active():
             return source
         return None
 
     def list_attempts(self, *, canonical_id: str, limit: int = 100) -> list[dict[str, Any]]:
+        """Return attempt rows for a recipe from the first active source.
+
+        Args:
+            canonical_id: Canonical recipe id.
+            limit: Maximum number of attempts.
+
+        Returns:
+            Attempt rows from the first active source, or ``[]`` when none are
+            active.
+        """
         src = self._first_active()
         return src.list_attempts(canonical_id=canonical_id, limit=limit) if src else []
 
     def list_session_attempts(self, *, session_id: str, limit: int = 500) -> list[dict[str, Any]]:
+        """Return attempt rows for a session from the first active source.
+
+        Args:
+            session_id: Session identifier.
+            limit: Maximum number of attempts.
+
+        Returns:
+            Session attempt rows, or ``[]`` when no source is active.
+        """
         src = self._first_active()
         return src.list_session_attempts(session_id=session_id, limit=limit) if src else []
 
     def session_summary(self, *, session_id: str) -> dict[str, Any] | None:
+        """Return a session summary from the first active source.
+
+        Args:
+            session_id: Session identifier.
+
+        Returns:
+            The session summary, or ``None`` when no source is active.
+        """
         src = self._first_active()
         return src.session_summary(session_id=session_id) if src else None
 
@@ -333,6 +414,7 @@ class CompositeRemoteRecipeClient:
         return False
 
     def close(self) -> None:
+        """Close all sub-remotes, ignoring individual close failures."""
         for source in self._sources:
             try:
                 source.close()

--- a/inference_optimizer/recipe_kb/composite_remote.py
+++ b/inference_optimizer/recipe_kb/composite_remote.py
@@ -69,7 +69,14 @@ _FETCH_FLOOR = 25
 
 def _richness(row: dict[str, Any]) -> int:
     """Count populated 'rich' fields — a tie-breaker that favours the row
-    carrying actual warm-start payload over a sparse stub."""
+    carrying actual warm-start payload over a sparse stub.
+
+    Args:
+        row: An arbor-shaped recipe row.
+
+    Returns:
+        The count of populated rich fields (0-5).
+    """
     score = 0
     if row.get("best_config"):
         score += 1
@@ -85,7 +92,15 @@ def _richness(row: dict[str, Any]) -> int:
 
 
 def _precedence_key(row: dict[str, Any]) -> tuple[int, float, int, float]:
-    """Higher tuple = preferred base. authority → confidence → richness → tput."""
+    """Higher tuple = preferred base. authority → confidence → richness → tput.
+
+    Args:
+        row: An arbor-shaped recipe row.
+
+    Returns:
+        A sortable precedence tuple ``(authority_rank, confidence, richness,
+        throughput)``; higher sorts first.
+    """
     authority = str(row.get("authority") or "")
     try:
         confidence = float(row.get("confidence") or 0.0)
@@ -117,7 +132,14 @@ def _is_empty(value: Any) -> bool:
 
 
 def _dedup_preserve(items: Iterable[Any]) -> list[Any]:
-    """Order-preserving dedup of a small sequence."""
+    """Order-preserving dedup of a small sequence.
+
+    Args:
+        items: The sequence to deduplicate.
+
+    Returns:
+        A list with duplicates removed, preserving first-seen order.
+    """
     out: list[Any] = []
     for it in items:
         if it not in out:
@@ -135,6 +157,12 @@ def _union_lists(
     is the ordered, de-duplicated list of ``_source`` tags that contributed at
     least one element to the union (for field-level provenance).
 
+    Args:
+        rows: The rows whose ``field`` lists are unioned.
+        field: The list field name to union across rows.
+
+    Returns:
+        A tuple of the merged item list and the ordered contributor sources.
     """
     out: list[Any] = []
     seen: set[str] = set()
@@ -161,6 +189,13 @@ def _merge_group(rows: list[dict[str, Any]]) -> dict[str, Any]:
     surviving value came from — scalar fields map to the single winning/
     back-filling source, list fields to the ordered set of contributors. This
     is what lets the KB-eval layer attribute an outcome to gbrain vs cortex.
+
+    Args:
+        rows: All rows sharing one canonical id.
+
+    Returns:
+        The merged row with unioned list fields, back-filled scalars, and
+        ``_sources`` / ``_field_sources`` provenance markers.
     """
     ordered = sorted(rows, key=_precedence_key, reverse=True)
     base = dict(ordered[0])
@@ -220,7 +255,11 @@ class CompositeRemoteRecipeClient:
 
     @property
     def enabled(self) -> bool:
-        """Enabled iff at least one sub-remote is enabled."""
+        """Enabled iff at least one sub-remote is enabled.
+
+        Returns:
+            ``True`` when any sub-remote reports ``enabled``.
+        """
         return any(getattr(s, "enabled", False) for s in self._sources)
 
     def _active(self) -> list[tuple[str, Any]]:
@@ -237,7 +276,17 @@ class CompositeRemoteRecipeClient:
         ]
 
     def _fan_out_search(self, *, name: str, source: Any, kwargs: dict[str, Any]) -> list[dict[str, Any]]:
-        """Run one source's search, tag + normalize each row. Best-effort."""
+        """Run one source's search, tag + normalize each row. Best-effort.
+
+        Args:
+            name: Display name of the source (used as the ``_source`` tag).
+            source: The sub-remote client to query.
+            kwargs: Search keyword arguments forwarded to the source.
+
+        Returns:
+            The source's arbor-normalized rows tagged with ``_source``, or
+            ``[]`` when the source is disabled or raises.
+        """
         try:
             rows = source.search(**kwargs)
         except RemoteRecipeClientError as exc:
@@ -324,7 +373,16 @@ class CompositeRemoteRecipeClient:
         canonical_id: str,
         version: int | None = None,
     ) -> dict[str, Any] | None:
-        """Exact-cid read: search every source by the 5-tuple labels, merge top."""
+        """Exact-cid read: search every source by the 5-tuple labels, merge top.
+
+        Args:
+            canonical_id: The canonical recipe id to look up.
+            version: Accepted for interface parity; not used for selection.
+
+        Returns:
+            The merged row matching ``canonical_id``, the top merged row when
+            no exact match, or ``None`` when nothing is found.
+        """
         try:
             labels = _labels_from_canonical_id(canonical_id)
         except InvalidCanonicalIdError as exc:
@@ -359,7 +417,11 @@ class CompositeRemoteRecipeClient:
         )[: int(limit)]
 
     def _first_active(self) -> Any | None:
-        """Return the first enabled sub-remote, or ``None`` if none are active."""
+        """Return the first enabled sub-remote, or ``None`` if none are active.
+
+        Returns:
+            The first active sub-remote, or ``None`` when none are enabled.
+        """
         for _name, source in self._active():
             return source
         return None
@@ -404,7 +466,11 @@ class CompositeRemoteRecipeClient:
         return src.session_summary(session_id=session_id) if src else None
 
     def health(self) -> bool:
-        """Healthy iff any active source is healthy."""
+        """Healthy iff any active source is healthy.
+
+        Returns:
+            ``True`` when any active sub-remote's health probe succeeds.
+        """
         for _name, source in self._active():
             try:
                 if source.health():

--- a/inference_optimizer/recipe_kb/composite_remote.py
+++ b/inference_optimizer/recipe_kb/composite_remote.py
@@ -69,7 +69,14 @@ _FETCH_FLOOR = 25
 
 def _richness(row: dict[str, Any]) -> int:
     """Count populated 'rich' fields — a tie-breaker that favours the row
-    carrying actual warm-start payload over a sparse stub."""
+    carrying actual warm-start payload over a sparse stub.
+
+    Args:
+        row: Arbor-shaped recipe row to score.
+
+    Returns:
+        The count of populated 'rich' fields on ``row``.
+    """
     score = 0
     if row.get("best_config"):
         score += 1
@@ -85,7 +92,15 @@ def _richness(row: dict[str, Any]) -> int:
 
 
 def _precedence_key(row: dict[str, Any]) -> tuple[int, float, int, float]:
-    """Higher tuple = preferred base. authority → confidence → richness → tput."""
+    """Higher tuple = preferred base. authority → confidence → richness → tput.
+
+    Args:
+        row: Arbor-shaped recipe row to rank.
+
+    Returns:
+        A precedence tuple ``(authority_rank, confidence, richness,
+        throughput)`` where a higher tuple is preferred.
+    """
     authority = str(row.get("authority") or "")
     try:
         confidence = float(row.get("confidence") or 0.0)
@@ -117,7 +132,14 @@ def _is_empty(value: Any) -> bool:
 
 
 def _dedup_preserve(items: Iterable[Any]) -> list[Any]:
-    """Order-preserving dedup of a small sequence."""
+    """Order-preserving dedup of a small sequence.
+
+    Args:
+        items: Sequence to deduplicate.
+
+    Returns:
+        The deduplicated items, preserving first-seen order.
+    """
     out: list[Any] = []
     for it in items:
         if it not in out:
@@ -135,6 +157,14 @@ def _union_lists(
     is the ordered, de-duplicated list of ``_source`` tags that contributed at
     least one element to the union (for field-level provenance).
 
+    Args:
+        rows: Rows sharing one canonical id, in precedence order.
+        field: Name of the list-valued field to union.
+
+    Returns:
+        A ``(merged_items, contributor_sources)`` tuple where
+        ``contributor_sources`` is the ordered, de-duplicated list of
+        ``_source`` tags that contributed at least one element.
     """
     out: list[Any] = []
     seen: set[str] = set()
@@ -161,6 +191,13 @@ def _merge_group(rows: list[dict[str, Any]]) -> dict[str, Any]:
     surviving value came from — scalar fields map to the single winning/
     back-filling source, list fields to the ordered set of contributors. This
     is what lets the KB-eval layer attribute an outcome to gbrain vs cortex.
+
+    Args:
+        rows: All rows sharing one canonical id.
+
+    Returns:
+        A single merged arbor row with unioned list fields, back-filled
+        scalars, and ``_sources`` / ``_field_sources`` provenance markers.
     """
     ordered = sorted(rows, key=_precedence_key, reverse=True)
     base = dict(ordered[0])
@@ -220,7 +257,11 @@ class CompositeRemoteRecipeClient:
 
     @property
     def enabled(self) -> bool:
-        """Enabled iff at least one sub-remote is enabled."""
+        """Enabled iff at least one sub-remote is enabled.
+
+        Returns:
+            ``True`` when at least one sub-remote reports enabled.
+        """
         return any(getattr(s, "enabled", False) for s in self._sources)
 
     def _active(self) -> list[tuple[str, Any]]:
@@ -237,7 +278,17 @@ class CompositeRemoteRecipeClient:
         ]
 
     def _fan_out_search(self, *, name: str, source: Any, kwargs: dict[str, Any]) -> list[dict[str, Any]]:
-        """Run one source's search, tag + normalize each row. Best-effort."""
+        """Run one source's search, tag + normalize each row. Best-effort.
+
+        Args:
+            name: Display name of the sub-remote (used for tagging and logs).
+            source: The sub-remote client to query.
+            kwargs: Search keyword arguments forwarded to ``source.search``.
+
+        Returns:
+            Arbor-normalized rows tagged with their ``_source``, or an empty
+            list when the source is skipped on error.
+        """
         try:
             rows = source.search(**kwargs)
         except RemoteRecipeClientError as exc:
@@ -324,7 +375,16 @@ class CompositeRemoteRecipeClient:
         canonical_id: str,
         version: int | None = None,
     ) -> dict[str, Any] | None:
-        """Exact-cid read: search every source by the 5-tuple labels, merge top."""
+        """Exact-cid read: search every source by the 5-tuple labels, merge top.
+
+        Args:
+            canonical_id: Canonical recipe id to resolve.
+            version: Optional version (accepted for parity; not used to filter).
+
+        Returns:
+            The merged row matching ``canonical_id``, the top merged row when
+            no exact match is found, or ``None`` when nothing is available.
+        """
         try:
             labels = _labels_from_canonical_id(canonical_id)
         except InvalidCanonicalIdError as exc:
@@ -359,7 +419,11 @@ class CompositeRemoteRecipeClient:
         )[: int(limit)]
 
     def _first_active(self) -> Any | None:
-        """Return the first enabled sub-remote, or ``None`` if none are active."""
+        """Return the first enabled sub-remote, or ``None`` if none are active.
+
+        Returns:
+            The first enabled sub-remote, or ``None`` when none are active.
+        """
         for _name, source in self._active():
             return source
         return None
@@ -404,7 +468,11 @@ class CompositeRemoteRecipeClient:
         return src.session_summary(session_id=session_id) if src else None
 
     def health(self) -> bool:
-        """Healthy iff any active source is healthy."""
+        """Healthy iff any active source is healthy.
+
+        Returns:
+            ``True`` when at least one active source reports healthy.
+        """
         for _name, source in self._active():
             try:
                 if source.health():

--- a/inference_optimizer/recipe_kb/dispatcher.py
+++ b/inference_optimizer/recipe_kb/dispatcher.py
@@ -261,7 +261,15 @@ _PREFER_STRING_KEYS: tuple[str, ...] = (
 
 
 def _prefer_score(row: dict[str, Any], prefer: dict[str, Any]) -> int:
-    """Count how many ``prefer`` fields the (flat arbor) row matches."""
+    """Count how many ``prefer`` fields the (flat arbor) row matches.
+
+    Args:
+        row: A flat arbor recipe row.
+        prefer: Workload-similarity hints to compare against the row.
+
+    Returns:
+        The count of matching numeric and string preference fields.
+    """
     if not isinstance(row, dict):
         return 0
     score = 0
@@ -294,6 +302,14 @@ def _rerank_by_prefer(
 
     No-op when ``prefer`` is empty. Never drops rows; only reorders so a
     closer-workload recipe surfaces first.
+
+    Args:
+        rows: The flat arbor rows to reorder.
+        prefer: Workload-similarity hints, or ``None`` to leave order intact.
+
+    Returns:
+        The rows reordered by descending preference score (or unchanged when
+        ``prefer`` is empty).
     """
     if not prefer:
         return rows
@@ -373,6 +389,12 @@ class RecipeKB:
         :func:`_v2_to_arbor` keeps an idempotency guard so a row that is
         already in flat arbor shape (e.g. a mis-built adapter) passes
         through untouched rather than being silently emptied.
+
+        Args:
+            row: The remote row in the unified nested KB-interface envelope.
+
+        Returns:
+            The row projected into the flat arbor shape callers expect.
         """
         return _v2_to_arbor(row)
 
@@ -687,6 +709,18 @@ class RecipeKB:
 
         ``prefer`` only reorders; the ``required`` filter
         (``label_match`` / ``metric_filters``) decides membership.
+
+        Args:
+            label_match: Identity labels deciding membership.
+            metric_filters: ``{metric: {min, max}}`` bounds deciding membership.
+            updated_since: Lower bound on ``updated_at``.
+            order_by: Ordering directive forwarded to the store.
+            limit: Maximum number of rows to return.
+            prefer: Workload-similarity hints used only to rerank results.
+
+        Returns:
+            The matching recipe rows (remote-first, local fall-through),
+            reranked by ``prefer``.
         """
         if self._remote_active():
             try:

--- a/inference_optimizer/recipe_kb/gbrain_ingest.py
+++ b/inference_optimizer/recipe_kb/gbrain_ingest.py
@@ -79,6 +79,12 @@ def _scalar(value: Any) -> str:
     ``type``. Everything else is JSON double-quoted (valid YAML) so the
     parser never reinterprets a number-ish / bool-ish / underscore-
     separated token — e.g. ``0_5_11`` must not become octal ``329``.
+
+    Args:
+        value: The scalar value to render.
+
+    Returns:
+        A YAML-safe token: bare for safe identifiers, JSON-quoted otherwise.
     """
     if value is None:
         return "null"
@@ -93,7 +99,15 @@ def _scalar(value: Any) -> str:
 
 
 def _emit_yaml(obj: Mapping[str, Any], indent: int = 0) -> str:
-    """Minimal recursive YAML emitter for scalars / nested dicts / scalar lists."""
+    """Minimal recursive YAML emitter for scalars / nested dicts / scalar lists.
+
+    Args:
+        obj: The mapping to render as YAML.
+        indent: Current indentation depth (two spaces per level).
+
+    Returns:
+        The rendered YAML text.
+    """
     pad = "  " * indent
     lines: list[str] = []
     for key, val in obj.items():
@@ -143,6 +157,12 @@ def _best_config_split(best_config: Mapping[str, Any]) -> tuple[str, dict[str, s
     Reads the args via the compat helper (canonical with read-only legacy
     fallback). For envs, a nested map wins; otherwise the remaining scalar
     sibling keys (minus non-env metadata) are taken as flat envs.
+
+    Args:
+        best_config: The champion config dict in either nested or flat shape.
+
+    Returns:
+        A tuple of the launch-args string and the env-var dict.
     """
     args = read_extra_server_args(dict(best_config)).strip()
     nested = best_config.get("extra_envs")
@@ -161,7 +181,15 @@ def _best_config_split(best_config: Mapping[str, Any]) -> tuple[str, dict[str, s
 
 
 def _has_shareable_signal(recipe: Mapping[str, Any]) -> bool:
-    """Return True when a seed-only recipe carries reusable prior signal."""
+    """Return True when a seed-only recipe carries reusable prior signal.
+
+    Args:
+        recipe: The recipe dict to inspect.
+
+    Returns:
+        ``True`` when the recipe has a positive-throughput session, any
+        negative-knowledge list, or architecture/model-class hints.
+    """
     for s in (recipe.get("sessions") or []):
         if not isinstance(s, Mapping):
             continue
@@ -186,6 +214,13 @@ def recipe_to_page(recipe: Mapping[str, Any]) -> tuple[str, str] | None:
     even pure seed-only anchors are mirrored so future gbrain reads can hit the
     5-tuple (tier=seed_only); set RECIPE_KB_MIRROR_REQUIRE_SIGNAL=1 to restore
     the old stricter gate (best_config OR reusable prior).
+
+    Args:
+        recipe: The v2 recipe dict to convert.
+
+    Returns:
+        A ``(slug, content)`` page tuple, or ``None`` when the recipe lacks a
+        canonical id (or fails the strict mirror gate).
     """
     best_config = recipe.get("best_config") if isinstance(recipe.get("best_config"), Mapping) else {}
     canonical = str(recipe.get("canonical_id") or "").strip()
@@ -265,7 +300,17 @@ def ingest_local_to_gbrain(
     mcp: _GbrainMcp | None,
     dry_run: bool,
 ) -> dict[str, int]:
-    """Ingest a list of v2 recipe dicts into gbrain. Returns counters."""
+    """Ingest a list of v2 recipe dicts into gbrain. Returns counters.
+
+    Args:
+        recipes: The v2 recipe dicts to ingest.
+        mcp: The gbrain MCP client, or ``None`` to skip the actual writes.
+        dry_run: When ``True``, count rows as ingested without writing.
+
+    Returns:
+        A counters dict with ``total`` / ``ingested`` / ``skipped_*`` /
+        ``errors`` tallies.
+    """
     stats = {
         "total": len(recipes),
         "ingested": 0,
@@ -302,6 +347,13 @@ def mirror_recipe(recipe: Mapping[str, Any], mcp: _GbrainMcp | None) -> bool:
     ``canonical_id``, strict-gate rejection, no mcp) or on a transport
     error. Never raises — the local write is authoritative and a gbrain
     hiccup must not affect it.
+
+    Args:
+        recipe: The recipe dict to mirror.
+        mcp: The gbrain MCP client, or ``None`` to skip mirroring.
+
+    Returns:
+        ``True`` when a page was written, ``False`` when skipped or on error.
     """
     if mcp is None:
         return False
@@ -318,7 +370,12 @@ def mirror_recipe(recipe: Mapping[str, Any], mcp: _GbrainMcp | None) -> bool:
 
 
 def build_mirror_mcp_from_env() -> _GbrainMcp | None:
-    """Build a write-side gbrain MCP client from env (background timeout)."""
+    """Build a write-side gbrain MCP client from env (background timeout).
+
+    Returns:
+        A configured :class:`_GbrainMcp`, or ``None`` when ``GBRAIN_BASE_URL``
+        / ``GBRAIN_TOKEN`` are not set.
+    """
     base_url = (os.environ.get("GBRAIN_BASE_URL", "") or "").strip()
     token = (os.environ.get("GBRAIN_TOKEN", "") or "").strip()
     if not base_url or not token:

--- a/inference_optimizer/recipe_kb/gbrain_ingest.py
+++ b/inference_optimizer/recipe_kb/gbrain_ingest.py
@@ -57,6 +57,17 @@ _TAG_CLEAN = str.maketrans({" ": "-", "\t": "-", "/": "-"})
 
 
 def _tag_value(value: Any) -> str:
+    """Normalize a value into a slug-style tag token.
+
+    Lowercases the value and replaces whitespace and slashes with
+    hyphens, trimming leading/trailing hyphens.
+
+    Args:
+        value: Arbitrary value to slugify.
+
+    Returns:
+        The tag slug, or ``"unknown"`` when the value is empty.
+    """
     return str(value or "").strip().lower().translate(_TAG_CLEAN).strip("-") or "unknown"
 
 
@@ -330,10 +341,27 @@ class GbrainMirroringRecipeKB:
     """
 
     def __init__(self, inner: Any, mcp: _GbrainMcp | None) -> None:
+        """Wrap an inner dispatcher with a gbrain mirroring side-effect.
+
+        Args:
+            inner: The wrapped recipe dispatcher to delegate to.
+            mcp: Optional gbrain MCP client used for mirroring writes.
+        """
         self._inner = inner
         self._mcp = mcp
 
     def put_recipe(self, **kwargs: Any) -> Any:
+        """Write a recipe locally, then best-effort mirror it to gbrain.
+
+        The local write is authoritative; mirroring failures are logged
+        and swallowed so they never block the local result.
+
+        Args:
+            **kwargs: Recipe fields forwarded to the inner dispatcher.
+
+        Returns:
+            The result of the wrapped ``put_recipe`` call.
+        """
         result = self._inner.put_recipe(**kwargs)
         try:
             mirror_recipe(kwargs, self._mcp)
@@ -342,12 +370,29 @@ class GbrainMirroringRecipeKB:
         return result
 
     def __getattr__(self, name: str) -> Any:
+        """Delegate all other attribute access to the wrapped dispatcher.
+
+        Args:
+            name: Attribute name to resolve on the inner dispatcher.
+
+        Returns:
+            The corresponding attribute from the wrapped dispatcher.
+        """
         # Delegate everything else (get_recipe / search / append_attempt /
         # local / remote / ...) to the wrapped dispatcher.
         return getattr(self._inner, name)
 
 
 def main(argv: list[str] | None = None) -> int:
+    """CLI entry point to bulk-ingest local recipes into gbrain.
+
+    Args:
+        argv: Optional argument vector; defaults to ``sys.argv`` when
+            ``None``.
+
+    Returns:
+        Process exit code (``0`` on success, non-zero on usage errors).
+    """
     ap = argparse.ArgumentParser(description="Bulk-ingest local recipe snapshots into gbrain.")
     ap.add_argument("--local-kb-root", default=os.environ.get("HYPERLOOM_LOCAL_KB_ROOT", ""),
                     help="LocalRecipeStore root (default: $HYPERLOOM_LOCAL_KB_ROOT)")

--- a/inference_optimizer/recipe_kb/gbrain_remote_client.py
+++ b/inference_optimizer/recipe_kb/gbrain_remote_client.py
@@ -78,6 +78,13 @@ class GbrainRemoteError(RemoteRecipeClientError):
     """
 
     def __init__(self, message: str, *, category: str = "transport", **kwargs: Any) -> None:
+        """Initialize the error.
+
+        Args:
+            message: Human-readable error message.
+            category: Error category (defaults to ``transport``).
+            **kwargs: Additional fields forwarded to the base exception.
+        """
         super().__init__(message, category=category, **kwargs)
 
 
@@ -85,11 +92,32 @@ class _GbrainMcp:
     """Minimal JSON-RPC-over-HTTP MCP client (list_pages / get_page)."""
 
     def __init__(self, base_url: str, token: str, timeout_sec: float) -> None:
+        """Initialize the MCP client.
+
+        Args:
+            base_url: Base URL of the gbrain MCP endpoint.
+            token: Bearer token for authorization.
+            timeout_sec: Per-request timeout in seconds (floored at 0.5).
+        """
         self._base = base_url.rstrip("/")
         self._token = token
         self._timeout = max(0.5, float(timeout_sec))
 
     def call(self, tool: str, arguments: dict[str, Any]) -> Any:
+        """Invoke an MCP tool over JSON-RPC and return its decoded result.
+
+        Args:
+            tool: MCP tool name to call.
+            arguments: Tool arguments.
+
+        Returns:
+            The decoded tool result: parsed JSON content when present, else the
+            raw content text, else the result object.
+
+        Raises:
+            GbrainRemoteError: On transport failures, malformed envelopes, or
+                JSON-RPC / tool-level errors.
+        """
         envelope = {
             "jsonrpc": "2.0", "id": "1", "method": "tools/call",
             "params": {"name": tool, "arguments": arguments},
@@ -140,6 +168,14 @@ class _GbrainMcp:
 
 
 def _as_float(value: Any) -> float:
+    """Coerce a value to float, defaulting to ``0.0`` on failure.
+
+    Args:
+        value: Value to convert.
+
+    Returns:
+        The parsed float, or ``0.0`` when conversion fails.
+    """
     try:
         return float(value)
     except (TypeError, ValueError):
@@ -318,6 +354,15 @@ class GbrainRemoteRecipeClient:
         enabled: bool = True,
         timeout_sec: float | None = None,
     ) -> None:
+        """Initialize the gbrain-backed recipe client.
+
+        Args:
+            base_url: Base URL of the gbrain endpoint.
+            token: Bearer token for authorization.
+            enabled: Whether the client is active (also requires a URL/token).
+            timeout_sec: Per-request timeout; defaults to the foreground HTTP
+                budget when ``None``.
+        """
         self.base_url = (base_url or "").strip()
         self.token = (token or "").strip()
         # Foreground-friendly default: gbrain is a read side-channel, so
@@ -334,9 +379,16 @@ class GbrainRemoteRecipeClient:
 
     # -- lifecycle ---------------------------------------------------------
     def close(self) -> None:  # symmetry with RemoteRecipeClient
+        """Release the underlying MCP client."""
         self._mcp = None
 
     def health(self) -> bool:
+        """Probe gbrain reachability with a tiny ``list_pages`` call.
+
+        Returns:
+            ``True`` if the probe succeeds; ``False`` when disabled or the
+            probe errors.
+        """
         if not self.enabled or self._mcp is None:
             return False
         try:
@@ -348,6 +400,12 @@ class GbrainRemoteRecipeClient:
 
     # -- internal scan -----------------------------------------------------
     def _scan_cache_ttl(self) -> float:
+        """Return the recipe-scan cache TTL in seconds.
+
+        Returns:
+            The value from ``GBRAIN_RECIPE_SCAN_TTL_SEC`` when valid, otherwise
+            the default TTL.
+        """
         raw = os.environ.get("GBRAIN_RECIPE_SCAN_TTL_SEC", "").strip()
         if raw:
             try:
@@ -457,10 +515,28 @@ class GbrainRemoteRecipeClient:
         return rows[0] if rows else None
 
     def get_history(self, *, canonical_id: str, limit: int = 100) -> list[dict[str, Any]]:
+        """Return the version history for a recipe.
+
+        Args:
+            canonical_id: Canonical recipe id.
+            limit: Maximum number of history entries.
+
+        Returns:
+            Always ``[]`` — gbrain does not retain a versioned recipe archive
+            (provided for interface parity).
+        """
         # gbrain does not retain a versioned recipe archive.
         return []
 
     def list_recent(self, *, limit: int = 50) -> list[dict[str, Any]]:
+        """Return the most recently updated recipes.
+
+        Args:
+            limit: Maximum number of recipes to return.
+
+        Returns:
+            Recent recipe rows, or ``[]`` when the client is disabled.
+        """
         if not self.enabled:
             return []
         return self._scan_recipes(limit=limit)
@@ -497,14 +573,41 @@ class GbrainRemoteRecipeClient:
         return rows[: int(limit)] if limit and limit > 0 else rows
 
     def list_attempts(self, *, canonical_id: str, limit: int = 100) -> list[dict[str, Any]]:
+        """Return attempt rows for a recipe.
+
+        Args:
+            canonical_id: Canonical recipe id.
+            limit: Maximum number of attempts.
+
+        Returns:
+            Always ``[]`` — attempt rows live in the local store, so the
+            dispatcher falls through to local on gbrain absence.
+        """
         # Attempt rows live on local store under this design; gbrain
         # absence falls the dispatcher through to local.
         return []
 
     def list_session_attempts(self, *, session_id: str, limit: int = 200) -> list[dict[str, Any]]:
+        """Return attempt rows for a session.
+
+        Args:
+            session_id: Session identifier.
+            limit: Maximum number of attempts.
+
+        Returns:
+            Always ``[]`` — session attempts are served from the local store.
+        """
         return []
 
     def session_summary(self, *, session_id: str) -> dict[str, Any] | None:
+        """Return a session summary.
+
+        Args:
+            session_id: Session identifier.
+
+        Returns:
+            Always ``None`` — gbrain does not serve session summaries.
+        """
         return None
 
 

--- a/inference_optimizer/recipe_kb/gbrain_remote_client.py
+++ b/inference_optimizer/recipe_kb/gbrain_remote_client.py
@@ -191,6 +191,12 @@ def _json_list(value: Any) -> list[Any]:
     only renders scalar lists. Tolerates an already-decoded list (in case
     a future page stores them natively) and degrades to ``[]`` on absence
     or malformed content so a bad page never breaks warm-start.
+
+    Args:
+        value: A list, a JSON-encoded list string, or anything else.
+
+    Returns:
+        The decoded list, or ``[]`` when the value is absent or malformed.
     """
     if isinstance(value, list):
         return value
@@ -216,6 +222,13 @@ def _best_config_from_attrs(attrs: Mapping[str, Any]) -> dict[str, Any]:
     be invisible to the consumer's nested ``best_config["extra_envs"]``
     read and the high-confidence warm recipe would be skipped as
     ``best_config_empty``.
+
+    Args:
+        attrs: The flat gbrain recipe page attrs mapping.
+
+    Returns:
+        The canonical ``best_config`` dict with launch args under the
+        canonical key and the env map nested under ``extra_envs``.
     """
     out: dict[str, Any] = {}
     args = str(attrs.get("best_config_args") or "").strip()
@@ -239,6 +252,13 @@ def _page_to_recipe(frontmatter: Mapping[str, Any]) -> dict[str, Any] | None:
 
     Returns ``None`` when the page lacks the minimum identity (model /
     hardware) needed to build a canonical id.
+
+    Args:
+        frontmatter: The gbrain recipe page frontmatter mapping.
+
+    Returns:
+        The nested KB-interface recipe envelope, or ``None`` when the page
+        lacks the model/hardware identity needed for a canonical id.
     """
     attrs = frontmatter.get("attrs") if isinstance(frontmatter.get("attrs"), Mapping) else {}
     model = str(attrs.get("model") or "").strip()
@@ -301,6 +321,15 @@ def _labels_match(recipe: Mapping[str, Any], label_match: Mapping[str, Any]) -> 
     :func:`_page_to_recipe`); the caller's ``label_match`` may be a raw or
     slugged value, so we re-run it through ``canonical_labels`` to make
     the comparison slug-normalized (``Qwen/Qwen3`` vs ``qwen3`` converge).
+
+    Args:
+        recipe: The candidate recipe carrying slugged ``labels``.
+        label_match: The constraining labels (raw or slugged); empty matches
+            everything.
+
+    Returns:
+        ``True`` when every constrained label equals the recipe's slugged
+        value.
     """
     if not label_match:
         return True
@@ -415,7 +444,15 @@ class GbrainRemoteRecipeClient:
         return _SCAN_CACHE_TTL_SEC
 
     def _get_page_recipe(self, slug: str) -> dict[str, Any] | None:
-        """Fetch one gbrain recipe page by slug and project it."""
+        """Fetch one gbrain recipe page by slug and project it.
+
+        Args:
+            slug: The gbrain page slug to fetch.
+
+        Returns:
+            The projected recipe envelope, or ``None`` when disabled, missing,
+            or lacking frontmatter.
+        """
         if not self.enabled or self._mcp is None:
             return None
         page = self._mcp.call("get_page", {"slug": slug})
@@ -432,6 +469,13 @@ class GbrainRemoteRecipeClient:
         early when many pages share the same ``updated_at``, hiding older
         recipes from client-side search. Dedup by slug across page boundaries
         and return newest-first to preserve the previous caller contract.
+
+        Args:
+            limit: Maximum number of recipes to return (capped at the internal
+                scan cap).
+
+        Returns:
+            Newest-first projected recipe dicts, or ``[]`` when disabled.
         """
         if not self.enabled or self._mcp is None:
             return []
@@ -486,6 +530,17 @@ class GbrainRemoteRecipeClient:
 
         gbrain keeps no per-version archive, so ``version`` is accepted
         for interface parity but only ``version in (None, 1)`` can match.
+
+        Args:
+            canonical_id: The canonical recipe id to look up.
+            version: Optional version; only ``None`` or ``1`` can match.
+
+        Returns:
+            The matching recipe envelope, or ``None`` on miss / disabled /
+            non-matching version.
+
+        Raises:
+            ValueError: If ``canonical_id`` is empty.
         """
         if not self.enabled:
             return None
@@ -557,6 +612,19 @@ class GbrainRemoteRecipeClient:
         unified KB-interface signature; the dispatcher applies the
         client-side rerank over the normalized rows, so this adapter
         only honours the ``required`` (``label_match`` / metric) filter.
+
+        Args:
+            label_match: Identity labels to filter on (empty matches all).
+            metric_filters: ``{metric: {min, max}}`` bounds to apply.
+            updated_since: Keep only rows with ``updated_at`` at or after this.
+            order_by: Ordering key; ASC variants reverse the default newest-
+                first order.
+            limit: Maximum number of rows to return.
+            prefer: Accepted for signature parity; ignored here (rerank lives
+                in the dispatcher).
+
+        Returns:
+            The filtered, ordered recipe rows, or ``[]`` when disabled.
         """
         del prefer  # client-side rerank lives in RecipeKB
         if not self.enabled:
@@ -617,6 +685,13 @@ def _passes_metric_filters(recipe: Mapping[str, Any], metric_filters: Mapping[st
     The recipe is the nested KB-interface envelope, so throughput lives
     under ``metrics.throughput`` / ``body.best_throughput``. We accept
     both the ``throughput`` and the ``best_throughput`` filter aliases.
+
+    Args:
+        recipe: The nested KB-interface recipe envelope.
+        metric_filters: ``{metric: {min, max}}`` bounds to apply.
+
+    Returns:
+        ``True`` when the recipe satisfies every metric bound.
     """
     metrics = recipe.get("metrics") if isinstance(recipe.get("metrics"), Mapping) else {}
     body = recipe.get("body") if isinstance(recipe.get("body"), Mapping) else {}
@@ -642,6 +717,10 @@ def build_gbrain_remote_from_env() -> GbrainRemoteRecipeClient | None:
 
     Returns ``None`` when the env is not configured so the caller can
     fall back to local-only or the cortex remote.
+
+    Returns:
+        A configured :class:`GbrainRemoteRecipeClient`, or ``None`` when the
+        base URL / token env vars are not set.
     """
     base_url = (os.environ.get("GBRAIN_BASE_URL", "") or "").strip()
     token = (os.environ.get("GBRAIN_TOKEN", "") or "").strip()

--- a/inference_optimizer/recipe_kb/local_store.py
+++ b/inference_optimizer/recipe_kb/local_store.py
@@ -438,6 +438,10 @@ class LocalRecipeStore:
           rather than indexing it);
         * the ``history`` subdir (six levels deep, the recipe.json
           presence check naturally rules it out).
+
+        Yields:
+            Each recipe directory at the documented 5-level depth that holds a
+            live ``recipe.json``.
         """
         if not self.root.is_dir():
             return
@@ -466,6 +470,10 @@ class LocalRecipeStore:
         against a cid that doesn't (yet) have a parent recipe row
         are still discoverable. Mirrors the central server contract
         that attempts have no FK to the parent recipe.
+
+        Yields:
+            Each canonical-id directory at the 5-level depth holding either a
+            ``recipe.json`` or an ``attempts.ndjson`` (deduplicated).
         """
         if not self.root.is_dir():
             return

--- a/inference_optimizer/recipe_kb/remote_client.py
+++ b/inference_optimizer/recipe_kb/remote_client.py
@@ -592,6 +592,18 @@ class RemoteRecipeClient:
         server-side prefer ranking, so the dispatcher applies a
         client-side rerank over the returned rows; this client only
         forwards the ``required`` filter.
+
+        Args:
+            label_match: Identity labels to filter on.
+            metric_filters: ``{metric: {min, max}}`` bounds to apply.
+            updated_since: Lower bound on ``updated_at``.
+            order_by: Ordering directive forwarded to the server.
+            limit: Maximum number of rows to request.
+            prefer: Accepted for signature parity; ignored here (rerank lives
+                in the dispatcher).
+
+        Returns:
+            The matching recipe rows, or ``[]`` when the client is disabled.
         """
         del prefer  # client-side rerank lives in RecipeKB
         if not self.enabled:

--- a/inference_optimizer/recipe_snapshot_constants.py
+++ b/inference_optimizer/recipe_snapshot_constants.py
@@ -194,6 +194,13 @@ def _slug(value: str, default: str) -> str:
     Slugged for lookup stability (``--model /path/Qwen3`` and ``qwen3`` must
     converge) and filesystem safety in the local KB store. ``/`` resolves to
     the basename first (HF paths collapse to the stem).
+
+    Args:
+        value: The raw value to slugify.
+        default: Fallback slug returned when ``value`` is empty.
+
+    Returns:
+        The slugified value, or ``default`` when empty.
     """
     raw = (value or "").strip()
     if not raw:
@@ -221,6 +228,16 @@ def recipe_canonical_id(
     useful before all components are known. Keyword-only to prevent
     positional re-ordering; missing components fall back to ``DEFAULT_*_SLUG``
     so the id is always well-formed (6 colon-separated segments).
+
+    Args:
+        model: The model identifier.
+        hardware: The hardware/GPU identifier.
+        framework: The serving framework name.
+        framework_version: The framework version.
+        precision: The precision/quantization scheme.
+
+    Returns:
+        The six-segment colon-separated canonical id.
     """
     return (
         f"inference:"
@@ -243,6 +260,16 @@ def canonical_labels(
     """Return the five-key ``labels`` dict mirroring the canonical id, so
     ``/recipes/search`` can ``label_match`` by individual dimension. Slug
     values match :func:`recipe_canonical_id`.
+
+    Args:
+        model: The model identifier.
+        hardware: The hardware/GPU identifier.
+        framework: The serving framework name.
+        framework_version: The framework version.
+        precision: The precision/quantization scheme.
+
+    Returns:
+        The five-key labels dict mirroring the canonical id.
     """
     return {
         F_LABEL_MODEL:             _slug(model,             DEFAULT_MODEL_SLUG),
@@ -268,6 +295,12 @@ def detect_framework_version(framework: str) -> str:
     top-level package and reading ``__version__``. Failures degrade to
     :data:`DEFAULT_FRAMEWORK_VERSION_SLUG` (the optimizer must boot without
     the framework importable).
+
+    Args:
+        framework: The serving framework name to probe.
+
+    Returns:
+        The detected version slug, or the default on any failure.
     """
     fw_slug = _slug(framework, "")
     if not fw_slug:
@@ -296,6 +329,13 @@ def format_recipe_path(template: str, canonical_id: str) -> str:
     """Substitute ``{canonical_id}`` into a path template without
     percent-encoding (server treats canonical_id as ``:path``-typed, so HF
     stems like ``Qwen/Qwen3-30B-A3B`` must reach it verbatim).
+
+    Args:
+        template: The path template containing ``{canonical_id}``.
+        canonical_id: The canonical id to substitute verbatim.
+
+    Returns:
+        The template with ``{canonical_id}`` replaced.
     """
     return template.replace("{canonical_id}", canonical_id)
 

--- a/inference_optimizer/scripts/backfill_langfuse.py
+++ b/inference_optimizer/scripts/backfill_langfuse.py
@@ -93,6 +93,15 @@ UNPHASED = lfmap.UNPHASED
 # IO helpers
 # ---------------------------------------------------------------------------
 def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Load a JSONL file into a list of dict records.
+
+    Args:
+        path: Path to the ``.jsonl`` file.
+
+    Returns:
+        The dict records; a missing file yields ``[]`` and malformed lines are
+        skipped.
+    """
     out: list[dict[str, Any]] = []
     if not path.exists():
         return out
@@ -110,6 +119,15 @@ def _load_jsonl(path: Path) -> list[dict[str, Any]]:
 
 
 def _load_json(path: Path) -> dict[str, Any]:
+    """Load a JSON object file.
+
+    Args:
+        path: Path to the JSON file.
+
+    Returns:
+        The parsed object, or ``{}`` when the file is missing, unreadable, or
+        not a JSON object.
+    """
     if not path.exists():
         return {}
     try:
@@ -185,6 +203,15 @@ def build_plan(session_dir: Path) -> dict[str, Any]:
 
 
 def _time_bounds(gens: list[dict]) -> tuple[datetime | None, datetime | None]:
+    """Return the earliest and latest timestamps across generations.
+
+    Args:
+        gens: Generation rows each carrying a ``ts`` field.
+
+    Returns:
+        A ``(min, max)`` datetime tuple, or ``(None, None)`` when no row has a
+        parseable timestamp.
+    """
     times = [lfmap.parse_ts(g["ts"]) for g in gens]
     times = [t for t in times if t is not None]
     if not times:
@@ -195,6 +222,14 @@ def _time_bounds(gens: list[dict]) -> tuple[datetime | None, datetime | None]:
 def _phase_time_bounds(
     agents: "OrderedDict[str, list[dict]]",
 ) -> tuple[datetime | None, datetime | None]:
+    """Return the time bounds across all agents in a phase.
+
+    Args:
+        agents: Mapping of agent name to its generation rows.
+
+    Returns:
+        A ``(min, max)`` datetime tuple over every generation in the phase.
+    """
     flat = [g for gens in agents.values() for g in gens]
     return _time_bounds(flat)
 
@@ -203,6 +238,11 @@ def _phase_time_bounds(
 # Dry-run printer
 # ---------------------------------------------------------------------------
 def print_plan(plan: dict[str, Any]) -> None:
+    """Print a human-readable dry-run summary of a backfill plan.
+
+    Args:
+        plan: The plan dict produced by the plan builder.
+    """
     s = plan["stats"]
     print(f"Trace: {plan['name']}  (session_id={plan['session_id']})")
     print(f"  claw_session_id = {plan.get('claw_session_id') or '(none)'}  "
@@ -242,6 +282,18 @@ def print_plan(plan: dict[str, Any]) -> None:
 # Real ingest (needs the langfuse SDK)
 # ---------------------------------------------------------------------------
 def ingest(plan: dict[str, Any]) -> int:
+    """Emit a backfill plan to Langfuse as a full trace tree.
+
+    Recreates the trace -> phase -> agent -> generation hierarchy from a
+    completed session and attaches decision scores to the owning agent spans.
+
+    Args:
+        plan: The backfill plan produced by the plan builder.
+
+    Returns:
+        Process exit code: ``0`` on success, ``3`` when the Langfuse SDK is not
+        importable.
+    """
     try:
         from langfuse import get_client  # type: ignore
     except Exception as exc:  # noqa: BLE001
@@ -348,6 +400,11 @@ def ingest(plan: dict[str, Any]) -> int:
 # CLI
 # ---------------------------------------------------------------------------
 def _build_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser.
+
+    Returns:
+        The configured :class:`argparse.ArgumentParser`.
+    """
     p = argparse.ArgumentParser(
         prog="backfill_langfuse",
         description=__doc__,
@@ -362,6 +419,14 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: build and (optionally) emit a backfill plan.
+
+    Args:
+        argv: Argument list to parse; defaults to ``sys.argv`` when ``None``.
+
+    Returns:
+        Process exit code from the plan/ingest path.
+    """
     args = _build_parser().parse_args(argv)
     logging.basicConfig(
         level=(logging.DEBUG if args.verbose >= 2

--- a/inference_optimizer/scripts/backfill_langfuse.py
+++ b/inference_optimizer/scripts/backfill_langfuse.py
@@ -141,7 +141,15 @@ def _load_json(path: Path) -> dict[str, Any]:
 # Plan building (pure -- no SDK, dry-run friendly)
 # ---------------------------------------------------------------------------
 def build_plan(session_dir: Path) -> dict[str, Any]:
-    """Parse the trace files into a Langfuse-shaped plan dict (pure)."""
+    """Parse the trace files into a Langfuse-shaped plan dict (pure).
+
+    Args:
+        session_dir: The session directory holding trace and manifest files.
+
+    Returns:
+        A Langfuse-shaped plan dict with trace seed, session id, and phase
+        hierarchy.
+    """
     tdir = session_dir / TRACE_SUBDIR
     llm = _load_jsonl(tdir / LLM_CALLS)
     conv = _load_jsonl(tdir / CONVERSATIONS)

--- a/inference_optimizer/scripts/backfill_langfuse.py
+++ b/inference_optimizer/scripts/backfill_langfuse.py
@@ -412,6 +412,17 @@ def ingest(plan: dict[str, Any]) -> int:
     # orchestration); normalise it back to a span-attachable agent so the score
     # still lands under a real agent span. operation_kind rides in score metadata.
     def _span_agent_for(proposer: str) -> str:
+        """Normalize a resolved proposer name to a span-attachable agent name.
+
+        Args:
+            proposer: The resolved proposer (e.g. ``specialist:<domain>`` /
+                ``grid`` / ``orchestration``).
+
+        Returns:
+            The agent name to attach the score under (``specialist`` for any
+            ``specialist:*``, ``orchestration`` for ``grid``, else the proposer
+            or the unknown-agent fallback).
+        """
         p = (proposer or "").strip()
         if p.startswith("specialist:"):
             return "specialist"

--- a/inference_optimizer/scripts/roofline_sweep.py
+++ b/inference_optimizer/scripts/roofline_sweep.py
@@ -60,6 +60,17 @@ class LaunchTemplate:
 
 
 def load_session_state(session_dir: Path) -> dict[str, Any]:
+    """Load a session's ``state.json``.
+
+    Args:
+        session_dir: Hyperloom session directory.
+
+    Returns:
+        The parsed state mapping.
+
+    Raises:
+        SystemExit: If ``state.json`` is missing.
+    """
     state_path = session_dir / "state.json"
     if not state_path.is_file():
         raise SystemExit(f"state.json not found at {state_path}")
@@ -108,6 +119,18 @@ class SglangServer:
         gpu_id: int,
         ready_timeout_sec: int = 900,
     ) -> None:
+        """Initialize the sglang server wrapper.
+
+        Args:
+            model_path: Path to the model to serve.
+            tp: Tensor-parallel size.
+            port: Port to bind the server on.
+            extra_args: Extra server CLI args (space-separated).
+            extra_envs: Extra environment variables for the server process.
+            log_path: File to capture server stdout/stderr.
+            gpu_id: Physical GPU id to pin via ``ROCR_VISIBLE_DEVICES``.
+            ready_timeout_sec: Max seconds to wait for the server to be ready.
+        """
         self.model_path = model_path
         self.tp = tp
         self.port = port
@@ -119,6 +142,14 @@ class SglangServer:
         self.proc: subprocess.Popen | None = None
 
     def __enter__(self) -> "SglangServer":
+        """Launch the server process and block until it is ready.
+
+        Returns:
+            This server instance.
+
+        Raises:
+            RuntimeError: If the server dies or never becomes ready.
+        """
         cmd = [
             sys.executable, "-m", "sglang.launch_server",
             f"--model-path={self.model_path}",
@@ -156,6 +187,12 @@ class SglangServer:
         return self
 
     def _wait_ready(self) -> None:
+        """Poll the health endpoint until the server is ready or times out.
+
+        Raises:
+            RuntimeError: If the server process dies or does not become ready
+                within ``ready_timeout_sec``.
+        """
         import urllib.request
         deadline = time.time() + self.ready_timeout_sec
         url = f"http://127.0.0.1:{self.port}/health_generate"
@@ -177,6 +214,11 @@ class SglangServer:
         )
 
     def __exit__(self, *_exc: Any) -> None:
+        """Terminate the server process group on context exit.
+
+        Args:
+            *_exc: Exception info from the ``with`` block (unused).
+        """
         if self.proc is None:
             return
         try:
@@ -192,6 +234,7 @@ class SglangServer:
 
     @property
     def base_url(self) -> str:
+        """Return the server's local base URL."""
         return f"http://127.0.0.1:{self.port}"
 
 
@@ -248,6 +291,22 @@ def compute_ceiling(
     *, model_meta: Any, gpu_type: str, num_gpus: int,
     conc: int, isl: int, osl: int,
 ) -> float:
+    """Compute the theoretical peak output throughput for one concurrency.
+
+    Thin wrapper over :func:`compute_theoretical_peak_output_tok_per_sec` that
+    unpacks the model metadata fields.
+
+    Args:
+        model_meta: Loaded model metadata (weights, layers, KV shape, ...).
+        gpu_type: GPU type key into the hardware specs.
+        num_gpus: Number of GPUs (tensor-parallel size).
+        conc: Concurrency level.
+        isl: Input sequence length.
+        osl: Output sequence length.
+
+    Returns:
+        The theoretical peak output tokens/second.
+    """
     return compute_theoretical_peak_output_tok_per_sec(
         gpu_type=gpu_type,
         num_gpus=num_gpus,
@@ -275,6 +334,27 @@ def sweep_one_template(
     concs: list[int], dataset: str, num_prompts_factor: int,
     output_dir: Path,
 ) -> list[dict[str, Any]]:
+    """Sweep a launch template across all concurrencies on one reused server.
+
+    Args:
+        tmpl: Launch template (baseline or optimized).
+        model_path: Path to the model to serve.
+        model_meta: Loaded model metadata used for ceiling computation.
+        gpu_type: GPU type key.
+        tp: Tensor-parallel size.
+        gpu_id: Physical GPU id to pin.
+        port: Server port.
+        isl: Input sequence length.
+        osl: Output sequence length.
+        concs: Concurrency levels to benchmark.
+        dataset: Benchmark dataset name.
+        num_prompts_factor: ``num_prompts = max(conc * factor, 16)``.
+        output_dir: Directory for server/bench logs.
+
+    Returns:
+        One result row per concurrency with measured throughput, ceiling, MBU,
+        and status.
+    """
     rows: list[dict[str, Any]] = []
     server_log = output_dir / f"server_{tmpl.label}.log"
     bench_out_dir = output_dir / f"bench_{tmpl.label}"
@@ -326,6 +406,12 @@ def sweep_one_template(
 # Output: csv + svg
 # ---------------------------------------------------------------------------
 def write_csv(rows: list[dict[str, Any]], csv_path: Path) -> None:
+    """Write sweep result rows to a CSV file.
+
+    Args:
+        rows: Result rows from :func:`sweep_one_template`.
+        csv_path: Destination CSV path (parents created as needed).
+    """
     csv_path.parent.mkdir(parents=True, exist_ok=True)
     fields = ["conc", "config", "measured_tps", "ceiling_tps", "target_70_tps", "mbu_pct", "status"]
     with csv_path.open("w", newline="", encoding="utf-8") as f:
@@ -340,12 +426,33 @@ def plot_svg(
     model_label: str, gpu_label: str, tp: int, isl: int, osl: int,
     target_ratio: float = 0.70,
 ) -> None:
+    """Render the dual-panel throughput/MBU roofline chart as SVG.
+
+    Args:
+        rows: Sweep result rows.
+        svg_path: Destination SVG path.
+        model_label: Model name shown in the title.
+        gpu_label: GPU label shown in the title.
+        tp: Tensor-parallel size shown in the title.
+        isl: Input sequence length shown in the title.
+        osl: Output sequence length shown in the title.
+        target_ratio: Roofline fraction drawn as the target line.
+    """
     import matplotlib
     matplotlib.use("Agg")
     import matplotlib.pyplot as plt
 
     concs = sorted({r["conc"] for r in rows})
     def _series(label: str, key: str) -> list[float | None]:
+        """Return per-concurrency values for one config/metric.
+
+        Args:
+            label: Config label (``baseline`` / ``optimized``).
+            key: Metric key to extract from each row.
+
+        Returns:
+            A list aligned with ``concs``; ``None`` where a value is missing.
+        """
         out: list[float | None] = []
         for c in concs:
             row = next((r for r in rows if r["conc"] == c and r["config"] == label), None)
@@ -429,6 +536,14 @@ def plot_svg(
 # CLI
 # ---------------------------------------------------------------------------
 def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for the roofline concurrency sweep.
+
+    Args:
+        argv: Argument list to parse; defaults to ``sys.argv`` when ``None``.
+
+    Returns:
+        Process exit code (``0`` on success).
+    """
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     ap.add_argument("--session-dir", required=True, type=Path,
                     help="Hyperloom session directory (contains state.json)")

--- a/inference_optimizer/scripts/roofline_sweep.py
+++ b/inference_optimizer/scripts/roofline_sweep.py
@@ -84,6 +84,16 @@ def extract_templates(state: dict[str, Any]) -> tuple[LaunchTemplate, LaunchTemp
     state.current_best.extra_server_args + extra_envs. The optimized
     template is the hard KPI of this sweep — when empty, the caller
     should refuse to run.
+
+    Args:
+        state: Parsed ``state.json`` contents.
+
+    Returns:
+        A ``(baseline, optimized)`` tuple of launch templates.
+
+    Raises:
+        SystemExit: If ``current_best`` has neither extra server args nor
+            extra envs.
     """
     cb = state.get("current_best") or {}
     opt_args = (cb.get("extra_server_args") or "").strip()
@@ -234,7 +244,11 @@ class SglangServer:
 
     @property
     def base_url(self) -> str:
-        """Return the server's local base URL."""
+        """Return the server's local base URL.
+
+        Returns:
+            The ``http://127.0.0.1:<port>`` base URL.
+        """
         return f"http://127.0.0.1:{self.port}"
 
 
@@ -248,6 +262,21 @@ def run_bench(
     """Invoke ``sglang.bench_serving`` once; return parsed metrics dict.
 
     Returns ``{}`` on subprocess failure (caller can mark as OOM/ERROR).
+
+    Args:
+        base_url: The server base URL to benchmark against.
+        model_path: The served model path.
+        conc: Maximum concurrency for the run.
+        isl: Random input sequence length.
+        osl: Random output sequence length.
+        num_prompts: Number of prompts to send.
+        dataset: Dataset name passed to ``bench_serving``.
+        output_dir: Directory for the bench output file.
+        port: Server port (used for logging/output naming).
+
+    Returns:
+        The parsed metrics dict, or ``{}`` on subprocess failure or missing
+        output.
     """
     output_dir.mkdir(parents=True, exist_ok=True)
     out_file = output_dir / f"bench_conc{conc}.jsonl"

--- a/inference_optimizer/scripts/roofline_sweep.py
+++ b/inference_optimizer/scripts/roofline_sweep.py
@@ -84,6 +84,16 @@ def extract_templates(state: dict[str, Any]) -> tuple[LaunchTemplate, LaunchTemp
     state.current_best.extra_server_args + extra_envs. The optimized
     template is the hard KPI of this sweep — when empty, the caller
     should refuse to run.
+
+    Args:
+        state: The parsed session ``state.json`` mapping.
+
+    Returns:
+        The ``(baseline, optimized)`` launch templates.
+
+    Raises:
+        SystemExit: If ``current_best`` carries neither extra args nor envs
+            (the session accepted no optimization).
     """
     cb = state.get("current_best") or {}
     opt_args = (cb.get("extra_server_args") or "").strip()
@@ -234,7 +244,11 @@ class SglangServer:
 
     @property
     def base_url(self) -> str:
-        """Return the server's local base URL."""
+        """Return the server's local base URL.
+
+        Returns:
+            The ``http://127.0.0.1:<port>`` base URL for this server.
+        """
         return f"http://127.0.0.1:{self.port}"
 
 
@@ -248,6 +262,21 @@ def run_bench(
     """Invoke ``sglang.bench_serving`` once; return parsed metrics dict.
 
     Returns ``{}`` on subprocess failure (caller can mark as OOM/ERROR).
+
+    Args:
+        base_url: Base URL of the running sglang server.
+        model_path: Path to the served model.
+        conc: Max concurrency for the benchmark.
+        isl: Input sequence length.
+        osl: Output sequence length.
+        num_prompts: Number of prompts to send.
+        dataset: Benchmark dataset name.
+        output_dir: Directory for the per-conc ``bench_conc<N>.jsonl`` output.
+        port: Server port (informational).
+
+    Returns:
+        The parsed metrics dict from the last bench line, or ``{}`` on
+        subprocess failure or unreadable/empty output.
     """
     output_dir.mkdir(parents=True, exist_ok=True)
     out_file = output_dir / f"bench_conc{conc}.jsonl"

--- a/inference_optimizer/session_paths.py
+++ b/inference_optimizer/session_paths.py
@@ -69,6 +69,9 @@ def _runs_actions() -> frozenset[str]:
     """Action names that own a ``runs/<kind>/<task_id>/`` workspace, from
     action metadata. Lazy + cached; falls back to ``_RUNS_ACTIONS_FALLBACK``
     when the registry can't load.
+
+    Returns:
+        The set of action names that own a runs-workspace.
     """
     try:
         from .orchestrator.action_registry import ActionRegistry  # local: avoid import-time cycle
@@ -149,6 +152,14 @@ def kernel_workspace(session_dir: Path, kernel_id: str) -> Path:
     GEAK/OOB candidates, and the chosen patch for one kernel. Keyed by
     ``kernel_id`` and survives across tasks (vs the per-invocation
     :func:`kernel_agent_runs_dir`).
+
+    Args:
+        session_dir: The session root directory.
+        kernel_id: Kernel id keying the workspace; blank falls back to
+            ``"unknown"``.
+
+    Returns:
+        ``<session_dir>/kernel-agent-workspace/<kernel_id>``.
     """
     kid = str(kernel_id or "").strip() or "unknown"
     return Path(session_dir) / "kernel-agent-workspace" / kid
@@ -159,6 +170,14 @@ def kernel_agent_runs_dir(session_dir: Path, session_id: str) -> Path:
     kernel-agent output (logs, status JSON, optimization_attempts.jsonl,
     TraceLens analysis). Keyed by tool-invocation session id (vs the
     kernel_id-keyed :func:`kernel_workspace`).
+
+    Args:
+        session_dir: The session root directory.
+        session_id: Tool-invocation session id; blank falls back to
+            ``"unknown"``.
+
+    Returns:
+        ``<session_dir>/kernel-agent/runs/<session_id>``.
     """
     sid = str(session_id or "").strip() or "unknown"
     return Path(session_dir) / "kernel-agent" / "runs" / sid
@@ -167,6 +186,14 @@ def kernel_agent_runs_dir(session_dir: Path, session_id: str) -> Path:
 def patches_dir(session_dir: Path, kernel_id: str) -> Path:
     """``<sd>/patches/<kernel_id>/`` — KEEP-promoted on-disk changes: the
     original source backup + applied patch (REVERT restores from backup).
+
+    Args:
+        session_dir: The session root directory.
+        kernel_id: Kernel id keying the patch dir; blank falls back to
+            ``"unknown"``.
+
+    Returns:
+        ``<session_dir>/patches/<kernel_id>``.
     """
     kid = str(kernel_id or "").strip() or "unknown"
     return Path(session_dir) / "patches" / kid
@@ -213,7 +240,14 @@ def report_file(session_dir: Path, ts: str, suffix: str = "md") -> Path:
 # All trace writers are best-effort and swallow OSError; these helpers only
 # compute paths (callers mkdir the parent before writing).
 def trace_dir(session_dir: Path) -> Path:
-    """``<sd>/reports/trace/`` — root of the unified token+decision trace."""
+    """``<sd>/reports/trace/`` — root of the unified token+decision trace.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/reports/trace``.
+    """
     return reports_dir(session_dir) / "trace"
 
 
@@ -224,13 +258,26 @@ def llm_calls_path(session_dir: Path) -> Path:
 
     Out-of-process children write to :func:`ext_trace_path` instead; the
     collector merges both streams.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/reports/trace/llm_calls.jsonl``.
     """
     return trace_dir(session_dir) / "llm_calls.jsonl"
 
 
 def trace_ext_dir(session_dir: Path) -> Path:
     """``<sd>/reports/trace/ext/`` — parent of every out-of-process child's
-    own ``<component>-<pid>.jsonl`` shard."""
+    own ``<component>-<pid>.jsonl`` shard.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/reports/trace/ext``.
+    """
     return trace_dir(session_dir) / "ext"
 
 
@@ -241,6 +288,14 @@ def ext_trace_path(session_dir: Path, component: str, pid: int) -> Path:
     CLI / tracelens) writes its own shard so concurrent children never
     contend on a shared file; the collector globs ``ext/*.jsonl`` and merges.
     The ``pid`` keeps shards disjoint across re-spawns of the same component.
+
+    Args:
+        session_dir: The session root directory.
+        component: Producer component name; blank falls back to ``"unknown"``.
+        pid: Process id of the producing child.
+
+    Returns:
+        ``<session_dir>/reports/trace/ext/<component>-<pid>.jsonl``.
     """
     comp = str(component or "").strip() or "unknown"
     return trace_ext_dir(session_dir) / f"{comp}-{int(pid)}.jsonl"
@@ -248,7 +303,14 @@ def ext_trace_path(session_dir: Path, component: str, pid: int) -> Path:
 
 def decision_trace_path(session_dir: Path) -> Path:
     """``<sd>/reports/trace/decision_trace.jsonl`` — collector output joining
-    every decision to its LLM token spend along the phase→tick timeline."""
+    every decision to its LLM token spend along the phase→tick timeline.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/reports/trace/decision_trace.jsonl``.
+    """
     return trace_dir(session_dir) / "decision_trace.jsonl"
 
 
@@ -262,25 +324,52 @@ def conversations_path(session_dir: Path) -> Path:
     can be replayed or exported (e.g. to Langfuse) after the fact. Both share
     the same ``session_id`` / ``component`` / ``tick`` / ``phase`` join keys
     so the two streams line up against ``decision_trace``.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/reports/trace/conversations.jsonl``.
     """
     return trace_dir(session_dir) / "conversations.jsonl"
 
 
 def research_hints_md(session_dir: Path) -> Path:
     """``<sd>/research_hints.md`` — human-readable proven-prior hints
-    collected by the research scout."""
+    collected by the research scout.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/research_hints.md``.
+    """
     return Path(session_dir) / "research_hints.md"
 
 
 def research_hints_json(session_dir: Path) -> Path:
     """``<sd>/research_hints.json`` — structured mirror of the research
-    hints (machine-readable; advisory gap-scoring reads this)."""
+    hints (machine-readable; advisory gap-scoring reads this).
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/research_hints.json``.
+    """
     return Path(session_dir) / "research_hints.json"
 
 
 def competitor_target_json(session_dir: Path) -> Path:
     """``<sd>/competitor_target.json`` — LLM-authored competitor target
-    numbers (each per-concurrency entry carries its own source)."""
+    numbers (each per-concurrency entry carries its own source).
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/competitor_target.json``.
+    """
     return Path(session_dir) / "competitor_target.json"
 
 
@@ -314,6 +403,12 @@ def optimizer_runs_dir(session_dir: Path) -> Path:
     """``<sd>/optimizer_runs/`` — launcher artefacts (run_<tag>.log / .pid /
     robustness_monitor_*.log). Under $USER_DATA_PATH so one override moves
     the whole run tail.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/optimizer_runs``.
     """
     return Path(session_dir) / "optimizer_runs"
 
@@ -426,6 +521,12 @@ def agent_prompt_snapshot(session_dir: Path, role: str) -> Path:
 def target_analysis_dir(session_dir: Path) -> Path:
     """``<sd>/target_analysis/`` — external baseline artefacts. Owner:
     TargetAnalysisExecutor; reader: ReportExecutor.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/target_analysis``.
     """
     return Path(session_dir) / "target_analysis"
 
@@ -479,6 +580,12 @@ def cortex_dir(session_dir: Path) -> Path:
 def cortex_sid_file(session_dir: Path) -> Path:
     """``<sd>/runtime/cortex/.kb_sid`` — Cortex session id from T0 ``session
     begin`` (resume reuses it). Absent => --degraded-kb or T0 not yet run.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/runtime/cortex/.kb_sid``.
     """
     return cortex_dir(session_dir) / ".kb_sid"
 
@@ -517,6 +624,12 @@ def cortex_pending_ndjson(session_dir: Path) -> Path:
     """``<sd>/runtime/cortex/.kb_pending.ndjson`` — append-only async write
     queue for T2/T3 ops. Consumed by the cortex_kb_flusher daemon; drained at
     T4 before ``session commit``.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/runtime/cortex/.kb_pending.ndjson``.
     """
     return cortex_dir(session_dir) / ".kb_pending.ndjson"
 
@@ -555,6 +668,12 @@ def cortex_dead_letter_ndjson(session_dir: Path) -> Path:
 def cortex_audit_jsonl(session_dir: Path) -> Path:
     """``<sd>/runtime/cortex/.kb_audit.jsonl`` — append-only audit of every
     direct Cortex CLI invocation. Source of truth for breakdown.kb_provenance.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/runtime/cortex/.kb_audit.jsonl``.
     """
     return cortex_dir(session_dir) / ".kb_audit.jsonl"
 
@@ -579,6 +698,12 @@ def recipe_snapshot_dir(session_dir: Path) -> Path:
 def recipe_snapshot_audit_jsonl(session_dir: Path) -> Path:
     """``<sd>/runtime/recipe_snapshot/.audit.jsonl`` — append-only audit of
     every recipe-snapshot remote READ call (writes are local-only and skip it).
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/runtime/recipe_snapshot/.audit.jsonl``.
     """
     return recipe_snapshot_dir(session_dir) / ".audit.jsonl"
 
@@ -588,6 +713,12 @@ def pr_monitor_status_json(session_dir: Path) -> Path:
     reachability snapshot; breakdown reads it for pr_monitor:* warnings.
 
     Schema: ``{enabled, url, reachable, mcp_url, window_days, status_text}``.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/runtime/cortex/.pr_monitor_status.json``.
     """
     return cortex_dir(session_dir) / ".pr_monitor_status.json"
 
@@ -614,6 +745,12 @@ def cortex_flusher_status_json(session_dir: Path) -> Path:
 
     Schema: ``{enabled, spawned, pid, cmd, cortex_kb_url, interval_sec,
     batch_size, reason, ts}``.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/runtime/cortex/.kb_flusher_status.json``.
     """
     return cortex_dir(session_dir) / ".kb_flusher_status.json"
 

--- a/inference_optimizer/session_paths.py
+++ b/inference_optimizer/session_paths.py
@@ -205,6 +205,12 @@ def breakdown_parts_dir(session_dir: Path) -> Path:
     fragments. Each owner writes its own files here (atomic + uniquely named);
     the exporter assembles them into ``session_breakdown.json``. Single-owner
     per section, so there is no cross-producer write contention.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/runtime/breakdown/parts``.
     """
     return Path(session_dir) / "runtime" / "breakdown" / "parts"
 

--- a/inference_optimizer/storage/connection.py
+++ b/inference_optimizer/storage/connection.py
@@ -156,7 +156,12 @@ class SqliteConnection:
 
     @contextlib.contextmanager
     def transaction_sync(self) -> Iterator[sqlite3.Cursor]:
-        """Synchronous BEGIN IMMEDIATE -> COMMIT/ROLLBACK."""
+        """Synchronous BEGIN IMMEDIATE -> COMMIT/ROLLBACK.
+
+        Yields:
+            An open cursor inside the immediate write transaction; the
+            transaction commits on clean exit and rolls back on exception.
+        """
         with self._sync_lock:
             cur = self._conn.cursor()
             try:
@@ -233,6 +238,10 @@ class SqliteConnection:
             async with conn.transaction() as cur:
                 cur.execute("INSERT INTO events (...) VALUES (...)", row)
                 cur.execute("UPDATE cursors SET ...", row2)
+
+        Yields:
+            An open cursor inside the immediate write transaction; the
+            transaction commits on clean exit and rolls back on exception.
         """
         await self._async_lock.acquire()
         try:

--- a/inference_optimizer/storage/schema.py
+++ b/inference_optimizer/storage/schema.py
@@ -139,6 +139,13 @@ def _migrate_leases_v1_to_v2(cur: sqlite3.Cursor) -> bool:
     ``(lane, holder_id)``). Returns True when a migration ran, False when
     already migrated / unknown shape. Snapshots rows, recreates the table,
     re-inserts; runs inside the caller's BEGIN IMMEDIATE.
+
+    Args:
+        cur: Open SQLite cursor within the caller's transaction.
+
+    Returns:
+        ``True`` when a migration ran, ``False`` when already migrated or the
+        table has an unknown shape.
     """
     try:
         cur.execute("PRAGMA table_info(leases)")
@@ -193,7 +200,11 @@ def _migrate_leases_v1_to_v2(cur: sqlite3.Cursor) -> bool:
 
 def _seed_default_lane_capacity(cur: sqlite3.Cursor) -> None:
     """Idempotently insert default capacity rows; existing rows are left
-    alone so a resume preserves the operator's choice."""
+    alone so a resume preserves the operator's choice.
+
+    Args:
+        cur: Open SQLite cursor within the caller's transaction.
+    """
     for lane, capacity in DEFAULT_LANE_CAPACITIES.items():
         cur.execute(
             "INSERT OR IGNORE INTO lane_capacity(lane, capacity) "
@@ -265,6 +276,12 @@ def ensure_schema(conn: sqlite3.Connection) -> int:
     """Idempotently create all tables, run the leases PK migration, seed
     lane_capacity defaults, and record the schema version. Single
     transaction so readers never see an intermediate schema.
+
+    Args:
+        conn: Open database connection.
+
+    Returns:
+        The current (max) recorded schema version.
     """
     cur = conn.cursor()
     try:

--- a/kernel-agent/tools/_collective_names.py
+++ b/kernel-agent/tools/_collective_names.py
@@ -27,7 +27,14 @@ _CAMEL_BOUNDARY = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
 
 
 def _normalise_kernel_name(name: str) -> str:
-    """Lowercase + underscore-delimit *name* so substring tests are stable."""
+    """Lowercase and underscore-delimit a name so substring tests are stable.
+
+    Args:
+        name: The raw kernel name.
+
+    Returns:
+        The normalized name, or an empty string if ``name`` is falsy.
+    """
     if not name:
         return ""
     s = _CAMEL_BOUNDARY.sub("_", str(name))
@@ -37,7 +44,16 @@ def _normalise_kernel_name(name: str) -> str:
 
 
 def kernel_name_implies_multigpu(name: str) -> bool:
-    """Return True iff *name* matches a known collective-op pattern (leaf-name only)."""
+    """Report whether a kernel name implies a multi-GPU collective op.
+
+    Matching uses the leaf name only against known collective-op patterns.
+
+    Args:
+        name: The kernel name to test.
+
+    Returns:
+        ``True`` if the name matches a known collective-op pattern.
+    """
     norm = _normalise_kernel_name(name)
     if not norm:
         return False

--- a/kernel-agent/tools/_paths.py
+++ b/kernel-agent/tools/_paths.py
@@ -21,7 +21,14 @@ _WARNED_NO_USER_DATA = False
 
 
 def workspace_root() -> str:
-    """Return ``$USER_DATA_PATH`` if set, else ``DEFAULT_WORKSPACE_ROOT`` (warns once)."""
+    """Resolve the workspace root for kernel-agent tool outputs.
+
+    Returns ``$USER_DATA_PATH`` when set; otherwise falls back to
+    ``DEFAULT_WORKSPACE_ROOT`` and logs a one-time misconfiguration warning.
+
+    Returns:
+        The resolved workspace root path.
+    """
     global _WARNED_NO_USER_DATA
     user_data = os.environ.get(ENV_USER_DATA_PATH)
     if user_data:

--- a/kernel-agent/tools/_payload_aliases.py
+++ b/kernel-agent/tools/_payload_aliases.py
@@ -40,10 +40,17 @@ def _coerce_str(value: Any) -> str:
 
 
 def read_extra_server_args(payload: dict, *, default: str = "") -> str:
-    """Read ``extra_server_args`` with a read-only fallback to legacy ``extra_sglang_args``.
+    """Read ``extra_server_args`` with a fallback to legacy ``extra_sglang_args``.
 
-    Canonical wins silently; legacy-only emits one DeprecationWarning; neither
-    returns ``default``.
+    The canonical key wins silently; a legacy-only payload emits one
+    ``DeprecationWarning``; if neither key is present, ``default`` is returned.
+
+    Args:
+        payload: The payload dict to read from.
+        default: Value returned when neither key is present.
+
+    Returns:
+        The coerced string value for the server args.
     """
     if CANONICAL_KEY in payload:
         return _coerce_str(payload[CANONICAL_KEY])

--- a/kernel-agent/tools/apply_kernel_patch.py
+++ b/kernel-agent/tools/apply_kernel_patch.py
@@ -99,7 +99,12 @@ _MN_STATE_FILE = Path(_MN_STATE_FILE_DEFAULT)
 
 
 def _is_multi_node() -> bool:
-    """True iff a multi-node RayJob is active (nodes >= 2); missing/unreadable → False."""
+    """Report whether a multi-node RayJob is active.
+
+    Returns:
+        ``True`` when the state file reports ``nodes >= 2``; ``False`` when the
+        state file is missing or unreadable.
+    """
     state_path = _mn_state_path()
     try:
         if not state_path.is_file():
@@ -118,10 +123,21 @@ def _dispatch_multinode_apply(
     backup_dir_on_pod: str,
     timeout_sec: int = 180,
 ) -> dict[str, Any]:
-    """Fan the patch out to every pod (head + workers); return parsed JSON.
+    """Fan a patch out to every pod (head + workers).
 
-    Raises RuntimeError on subprocess failure / non-JSON / pod status != ok so
-    the caller can roll back the sandbox-local copy.
+    Args:
+        target_file: The file to patch on each pod.
+        patch_path: Path to the patch file to apply.
+        kernel_id: Identifier of the kernel being patched.
+        backup_dir_on_pod: Directory on each pod to store backups.
+        timeout_sec: Subprocess timeout in seconds.
+
+    Returns:
+        The parsed JSON result from the multi-node dispatch.
+
+    Raises:
+        RuntimeError: On subprocess failure, non-JSON output, or a pod status
+            other than ``ok`` (so the caller can roll back the local copy).
     """
     cmd = [
         sys.executable, "-m", "inference_optimizer.multi_node",
@@ -162,7 +178,18 @@ def _dispatch_multinode_revert(
     backup_map: dict[str, str],
     timeout_sec: int = 120,
 ) -> dict[str, Any]:
-    """Restore the original file on every pod that received the apply (best-effort)."""
+    """Restore the original file on every pod that received the apply.
+
+    Best-effort: failures are reported in the result rather than raised.
+
+    Args:
+        target_path: The patched file path to restore on each pod.
+        backup_map: Mapping of pod identifier to its backup path.
+        timeout_sec: Subprocess timeout in seconds.
+
+    Returns:
+        The parsed JSON result, or an empty dict when output is not JSON.
+    """
     cmd = [
         sys.executable, "-m", "inference_optimizer.multi_node",
         "revert-patch",
@@ -439,12 +466,24 @@ _AITER_CSRC_MARKER = "/aiter/csrc/"
 
 
 def _target_is_in_aiter_csrc(target_file: Path) -> bool:
-    """Return True iff ``target_file`` resides under any ``aiter/csrc/`` tree."""
+    """Report whether a file resides under an ``aiter/csrc/`` tree.
+
+    Args:
+        target_file: The file path to test.
+
+    Returns:
+        ``True`` if the path is under an ``aiter/csrc/`` directory.
+    """
     return _AITER_CSRC_MARKER in str(target_file).replace(os.sep, "/")
 
 
 def _aiter_jit_build_dir() -> Path | None:
-    """Return ``<aiter>/jit/build`` for the importable aiter, or ``None`` if absent."""
+    """Locate the importable aiter package's ``jit/build`` directory.
+
+    Returns:
+        The ``<aiter>/jit/build`` path, or ``None`` when aiter is not
+        importable.
+    """
     try:
         spec = importlib.util.find_spec("aiter")
     except (ImportError, ValueError):
@@ -461,9 +500,16 @@ def _invalidate_aiter_jit_build(
     *,
     jit_build_dir_override: Path | None = None,
 ) -> dict[str, Any]:
-    """Move aiter ``jit/build/`` aside so a post-rebuild first import re-JITs.
+    """Move aiter ``jit/build/`` aside so a post-rebuild import re-JITs.
 
-    Returns status ok / skipped / failed; ``jit_build_dir_override`` is test-only.
+    Args:
+        target_file: The file being patched (gates the operation).
+        backup_dir: Directory to move the ``jit/build`` tree into.
+        jit_build_dir_override: Test-only override for the jit/build location.
+
+    Returns:
+        A status dict with ``status`` of ``ok``, ``skipped``, or ``failed``
+        and supporting fields.
     """
     if not _target_is_in_aiter_csrc(target_file):
         return {"status": "skipped", "reason": "target not under aiter/csrc/"}
@@ -508,7 +554,17 @@ def _invalidate_aiter_jit_build(
 
 
 def _restore_aiter_jit_build(jit_build_backup: dict[str, Any]) -> dict[str, Any]:
-    """Reverse of :func:`_invalidate_aiter_jit_build`: restore the backup, removing any regenerated dir first."""
+    """Restore an aiter ``jit/build`` backup, reversing the invalidation.
+
+    Any regenerated ``jit/build`` directory is removed first.
+
+    Args:
+        jit_build_backup: The backup record returned by
+            :func:`_invalidate_aiter_jit_build`.
+
+    Returns:
+        A status dict with ``status`` of ``ok``, ``skipped``, or ``failed``.
+    """
     if not isinstance(jit_build_backup, dict) or jit_build_backup.get("status") != "ok":
         return {"status": "skipped", "reason": "no backup recorded"}
     src = Path(jit_build_backup.get("src", ""))
@@ -578,7 +634,7 @@ _MD_NAME_RE = re.compile(r"""(?m)^\s*MD_NAME\s*=\s*["']([^"']+)["']""")
 
 
 def _target_is_in_aiter_cpp_itfs(target_file: Path) -> bool:
-    """True iff ``target_file`` lives under any ``aiter/csrc/cpp_itfs/`` tree.
+    """Report whether a file lives under an ``aiter/csrc/cpp_itfs/`` tree.
 
     Strict subset of :func:`_target_is_in_aiter_csrc`: these are the
     runtime-compiled kernels whose served ``.so`` lives in
@@ -586,6 +642,12 @@ def _target_is_in_aiter_cpp_itfs(target_file: Path) -> bool:
     statically-linked wheel. Matches both the editable checkout
     (``/sgl-workspace/aiter/csrc/cpp_itfs/...``) and the dist-packages
     layout (``.../aiter/csrc/cpp_itfs/...``).
+
+    Args:
+        target_file: The file path to test.
+
+    Returns:
+        ``True`` if the path is under an ``aiter/csrc/cpp_itfs/`` directory.
     """
     return _AITER_CPP_ITFS_MARKER in str(target_file).replace(os.sep, "/")
 
@@ -597,6 +659,9 @@ def _aiter_cpp_itfs_build_dir() -> Path:
     ``$AITER_ROOT_DIR`` defaulting to ``$HOME/.aiter``. Honouring both env
     vars keeps non-default deployments + unit tests correct without importing
     aiter into this standalone tool.
+
+    Returns:
+        The resolved cpp_itfs ``build`` directory path.
     """
     root = os.environ.get("AITER_ROOT_DIR", "").strip()
     if not root:
@@ -606,16 +671,21 @@ def _aiter_cpp_itfs_build_dir() -> Path:
 
 
 def _cpp_itfs_module_names(target_file: Path) -> list[str]:
-    """Best-effort ``MD_NAME`` prefix(es) for the cpp_itfs module(s) the
-    patched source feeds.
+    """Collect ``MD_NAME`` prefixes for the cpp_itfs module(s) a source feeds.
 
     The cpp_itfs ``.py`` driver next to the patched source declares
     ``MD_NAME = "pa_ragged"`` (etc.), which becomes the
     ``<md_name>_<hash>`` runtime-cache folder prefix. A single shared
     ``.cuh`` (e.g. ``pa_kernels.cuh``) is pulled into several drivers in the
     same directory, so we collect EVERY ``MD_NAME`` declared in the target's
-    directory. An empty result tells the caller to fall back to clearing the
-    whole cpp_itfs build root.
+    directory.
+
+    Args:
+        target_file: The patched source file whose directory is scanned.
+
+    Returns:
+        The discovered ``MD_NAME`` prefixes. An empty list tells the caller to
+        fall back to clearing the whole cpp_itfs build root.
     """
     names: set[str] = set()
     search_dir = target_file.parent
@@ -651,6 +721,14 @@ def _invalidate_aiter_cpp_itfs_cache(
     The record always carries ``is_cpp_itfs`` + ``build_dir`` +
     ``module_names`` + ``invalidated_unix`` (even when nothing was cached
     yet) so integrate can later verify a fresh rebuild actually landed.
+
+    Args:
+        target_file: The file being patched (gates the operation).
+        backup_dir: Directory to move affected cache dirs into.
+        build_dir_override: Test-only override for the cpp_itfs build root.
+
+    Returns:
+        A status dict recording what was moved and the invalidation metadata.
 
     Returns one of ``ok`` / ``skipped`` / ``failed`` mirroring
     :func:`_invalidate_aiter_jit_build`. ``build_dir_override`` is a
@@ -733,6 +811,13 @@ def _restore_aiter_cpp_itfs_cache(cache_backup: dict[str, Any]) -> dict[str, Any
     Moves each backed-up cache dir back to its original location, removing
     any dir the re-baseline server regenerated there first so the pre-patch
     runtime cache is restored bit-for-bit.
+
+    Args:
+        cache_backup: The backup record from
+            :func:`_invalidate_aiter_cpp_itfs_cache`.
+
+    Returns:
+        A status dict with ``status`` of ``ok``, ``skipped``, or ``failed``.
     """
     if not isinstance(cache_backup, dict) or cache_backup.get("status") != "ok":
         return {"status": "skipped", "reason": "no cpp_itfs cache backup recorded"}
@@ -776,9 +861,14 @@ def verify_cpp_itfs_rebuilt(cache_backup: dict[str, Any]) -> dict[str, Any]:
     measured gain is meaningless -- the integrate KEEP/REVERT gate uses this
     to flag/abort instead of scoring a stale binary (GH #458 point 2).
 
-    Returns ``{"verified": bool, ...}``. ``verified`` is True for
-    non-cpp_itfs targets so the caller's gate is a strict no-op off the
-    cpp_itfs path.
+    Args:
+        cache_backup: The invalidation record from
+            :func:`_invalidate_aiter_cpp_itfs_cache`.
+
+    Returns:
+        A dict ``{"verified": bool, ...}``. ``verified`` is ``True`` for
+        non-cpp_itfs targets so the caller's gate is a strict no-op off the
+        cpp_itfs path.
     """
     if not isinstance(cache_backup, dict) or not cache_backup.get("is_cpp_itfs"):
         return {"verified": True, "status": "skipped", "reason": "non-cpp_itfs target"}

--- a/kernel-agent/tools/backends/forge_submit.py
+++ b/kernel-agent/tools/backends/forge_submit.py
@@ -38,6 +38,10 @@ def _ensure_forge_on_path() -> str:
     `src/`, or the package dir itself) and prepend it to sys.path. When the
     env var is unset, do nothing and rely on an installed `kernel_agents`
     (e.g. `pip install -e`). Returns the path inserted, or "".
+
+    Returns:
+        str: the path prepended to ``sys.path``, or ``""`` when ``$FORGE_PATH``
+            is unset or no ``kernel_agents`` package can be located.
     """
     root = (os.environ.get("FORGE_PATH")
             or os.environ.get("KERNEL_FORGE_ROOT")
@@ -69,7 +73,17 @@ _SOURCE_TYPE_TO_FELLOW = {
 
 
 def _run(cmd: list[str], cwd: str | None = None, timeout: int = 120) -> subprocess.CompletedProcess:
-    """Run a subprocess, capturing text output (never raises on non-zero)."""
+    """Run a subprocess, capturing text output (never raises on non-zero).
+
+    Args:
+        cmd (list[str]): the command argv to execute.
+        cwd (str | None): optional working directory for the subprocess.
+        timeout (int): subprocess timeout in seconds.
+
+    Returns:
+        subprocess.CompletedProcess: the completed process with captured text
+            stdout/stderr.
+    """
     return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, timeout=timeout)
 
 
@@ -77,6 +91,13 @@ def _resolve_gpu_target(candidate: dict) -> str:
     """Resolve the gfx target: env GPU_TARGET -> candidate platform -> probe.
 
     Never hard-codes; falls back to rocminfo when nothing else is available.
+
+    Args:
+        candidate (dict): the kernel candidate; its ``platform`` / ``arch``
+            fields hint the target when no env override is set.
+
+    Returns:
+        str: the resolved gfx target string (falls back to ``"gfx942"``).
     """
     env_target = (os.environ.get("GPU_TARGET") or os.environ.get("GPU_TYPE") or "").strip()
     if env_target:
@@ -96,12 +117,30 @@ def _resolve_gpu_target(candidate: dict) -> str:
 
 
 def _fellow_for_source_type(source_type: str) -> str | None:
-    """Map source_type to a Forge fellow (stage 1: triton only). None if unsupported."""
+    """Map source_type to a Forge fellow (stage 1: triton only). None if unsupported.
+
+    Args:
+        source_type (str): the candidate source type (e.g. ``triton`` /
+            ``python``).
+
+    Returns:
+        str | None: the mapped Forge fellow name, or ``None`` when the source
+            type is unsupported.
+    """
     return _SOURCE_TYPE_TO_FELLOW.get((source_type or "").strip().lower())
 
 
 def _git_toplevel(path: str) -> str:
-    """Return the git repo root containing `path`, or '' if not a git repo."""
+    """Return the git repo root containing `path`, or '' if not a git repo.
+
+    Args:
+        path (str): a path inside the candidate repo; its parent is probed with
+            ``git rev-parse --show-toplevel``.
+
+    Returns:
+        str: the git repo top-level directory, or ``""`` when ``path`` is not in
+            a git repo.
+    """
     try:
         proc = _run(["git", "-C", str(Path(path).parent), "rev-parse", "--show-toplevel"], timeout=30)
         if proc.returncode == 0:
@@ -117,6 +156,13 @@ def _default_branch(repo: str) -> str:
     Used to auto-recover a repo stranded on a leftover ``forge/`` temp branch by
     a hard-killed prior run. Prefers the remote's advertised default, then falls
     back to common local branch names.
+
+    Args:
+        repo (str): the git repo root to inspect.
+
+    Returns:
+        str: the default branch name (remote-advertised, else ``main`` /
+            ``master``), or ``""`` when none can be resolved.
     """
     p = _run(["git", "-C", repo, "symbolic-ref", "--short",
               "refs/remotes/origin/HEAD"], timeout=30)
@@ -138,6 +184,19 @@ def _prepare_worktree(source_file: str, kernel_repo: str, output_dir: Path,
     repo is not a clean git checkout / source_file is not tracked (forge then
     skips, never mutating the live repo). base_commit is the commit the worktree
     was created at (HEAD); export diffs the best state against it.
+
+    Args:
+        source_file (str): the kernel source file to optimize.
+        kernel_repo (str): the kernel repo root (falls back to the git toplevel
+            of ``source_file`` when empty).
+        output_dir (Path): the run output dir; the worktree is created at
+            ``output_dir/worktree``.
+        branch (str): the temp branch name to create the worktree on.
+
+    Returns:
+        tuple[str, str, str] | None: ``(worktree_dir, worktree_kernel_file,
+            base_commit)``, or ``None`` when the repo is not a clean git
+            checkout or ``source_file`` is not tracked.
     """
     repo = kernel_repo or _git_toplevel(source_file)
     if not repo or not (Path(repo) / ".git").exists():
@@ -180,6 +239,10 @@ def _editable_roots() -> list[str]:
       1. Path-string .pth files that contain absolute paths in quotes.
       2. Setuptools-style .pth files that ``import __editable___<pkg>_finder``;
          the finder .py has a ``MAPPING`` dict mapping package names to paths.
+
+    Returns:
+        list[str]: the sorted absolute filesystem roots that editable-finder
+            installs map into.
     """
     import re
     import site
@@ -257,6 +320,13 @@ def _needs_inplace(kernel_repo: str) -> bool:
 
     In that case forge must edit the live repo in place (the finder imports the
     live path; a worktree copy would be invisible -> the loop would no-op).
+
+    Args:
+        kernel_repo (str): the kernel repo root to test.
+
+    Returns:
+        bool: True when ``kernel_repo`` is, contains, or sits under an
+            editable-finder root (forge must edit in place); False otherwise.
     """
     if not kernel_repo:
         return False
@@ -275,6 +345,14 @@ def _acquire_repo_lock(repo: str) -> int | None:
     cross-contaminated measurements). The lock serializes them; a caller that
     cannot get it must skip in-place (fall through to the next backend). Returns
     the held fd (release with _release_repo_lock) or None when already held.
+
+    Args:
+        repo (str): the live repo root to lock.
+
+    Returns:
+        int | None: the held lock file descriptor (release via
+            :func:`_release_repo_lock`), or ``None`` when the lock is already
+            held or cannot be opened.
     """
     try:
         fd = os.open(os.path.join(repo, ".git", "forge_inplace.lock"),
@@ -290,7 +368,12 @@ def _acquire_repo_lock(repo: str) -> int | None:
 
 
 def _release_repo_lock(fd: int | None) -> None:
-    """Release + close the in-place repo lock (best-effort)."""
+    """Release + close the in-place repo lock (best-effort).
+
+    Args:
+        fd (int | None): the lock file descriptor returned by
+            :func:`_acquire_repo_lock`; ``None`` is a no-op.
+    """
     if fd is None:
         return
     try:
@@ -319,6 +402,17 @@ def _prepare_inplace(source_file: str, kernel_repo: str, branch: str) -> tuple[s
       - dirty working trees are allowed: restore only touches the source_file
         (per-file write-back, no ``reset --hard``), so other uncommitted changes
         in the repo are never destroyed.
+
+    Args:
+        source_file (str): the kernel source file to edit in place.
+        kernel_repo (str): the kernel repo root (falls back to the git toplevel
+            of ``source_file`` when empty).
+        branch (str): the temp branch name to create for the forge loop.
+
+    Returns:
+        tuple[str, str, dict] | None: ``(workspace=repo, kernel_file=source_file,
+            restore_info)``, or ``None`` when the repo is not a usable git
+            checkout (or another in-place run holds the lock).
     """
     repo = kernel_repo or _git_toplevel(source_file)
     if not repo or not (Path(repo) / ".git").exists():
@@ -336,6 +430,11 @@ def _prepare_inplace(source_file: str, kernel_repo: str, branch: str) -> tuple[s
         return None  # another forge in-place run holds this repo; skip cleanly
 
     def _skip() -> None:
+        """Release the repo lock and bail out of in-place preparation.
+
+        Returns:
+            ``None`` (the sentinel callers return to signal a clean skip).
+        """
         _release_repo_lock(lock_fd)
         return None
 
@@ -424,6 +523,11 @@ def _restore_inplace(restore: dict) -> None:
     dirty content snapshotted at prepare time), so checking files out of it
     restores precisely what was there before forge ran. Untracked files (build
     artifacts) are never touched (no ``reset --hard``).
+
+    Args:
+        restore (dict): the restore info dict produced by
+            :func:`_prepare_inplace` (repo, orig_branch/head, base_commit,
+            source_file, backup bytes, lock fd, ...).
     """
     if not restore:
         return
@@ -471,7 +575,15 @@ def _restore_inplace(restore: dict) -> None:
 
 
 def _remove_worktree(kernel_repo: str, source_file: str, wt: str, branch: str) -> None:
-    """Tear down the worktree + temp branch; live repo untouched (W3)."""
+    """Tear down the worktree + temp branch; live repo untouched (W3).
+
+    Args:
+        kernel_repo (str): the kernel repo root (falls back to the git toplevel
+            of ``source_file`` when empty).
+        source_file (str): the kernel source file (used to resolve the repo).
+        wt (str): the worktree directory to remove.
+        branch (str): the temp branch to delete.
+    """
     repo = kernel_repo or _git_toplevel(source_file)
     if not repo:
         return
@@ -549,7 +661,16 @@ main()
 
 
 def _build_driver_adapter(test_command: str, worktree: str, output_dir: Path) -> str:
-    """Write the driver-adapter script and return its path."""
+    """Write the driver-adapter script and return its path.
+
+    Args:
+        test_command (str): the Hyperloom harness/test command to wrap.
+        worktree (str): the worktree directory forced onto sys.path/cwd.
+        output_dir (Path): the run output dir the adapter is written under.
+
+    Returns:
+        str: the path to the written, executable driver-adapter script.
+    """
     adapter = output_dir / "forge_driver_adapter.py"
     adapter.write_text(_ADAPTER_TEMPLATE.format(test_command=test_command, worktree=worktree))
     adapter.chmod(0o755)
@@ -757,6 +878,20 @@ def _autogen_forge_driver(candidate: dict, worktree_kernel: str, output_dir: Pat
       - gemm / matmul    -> imports the kernel by FILE path (worktree-safe) +
         torch.matmul golden.
     Returns the driver path, or None when the op has no usable template.
+
+    Args:
+        candidate (dict): the kernel candidate; ``operation`` / ``name`` select
+            the op template.
+        worktree_kernel (str): the worktree kernel file path (substituted into
+            file-import templates).
+        output_dir (Path): the run output dir the driver is written under.
+        inplace (bool): whether forge is running in in-place mode (required for
+            the package-import moe template).
+
+    Returns:
+        str | None: the path to the written driver script, or ``None`` when the
+            op has no usable template (or moe is requested outside in-place
+            mode).
     """
     op = str(candidate.get("operation") or "").lower()
     hint = (op + " " + str(candidate.get("name") or "") + " " + worktree_kernel).lower()
@@ -785,6 +920,13 @@ def _tensor_dim_lists(candidate: dict) -> list[list[int]]:
     falls back to its tiny default shape (M=512) — which benches a memory-bound
     regime and yields a near-1.0x speedup instead of the real prefill gain. Parse
     both forms here.
+
+    Args:
+        candidate (dict): the kernel candidate carrying ``input_shapes`` in the
+            integer-list or dtype-tagged-string form.
+
+    Returns:
+        list[list[int]]: one integer dim list per parsed tensor shape.
     """
     out: list[list[int]] = []
     for e in candidate.get("input_shapes") or []:
@@ -811,6 +953,13 @@ def _gemm_dims(shapes: list[list[int]]) -> dict:
     Picks the first pair of 2D tensors whose inner dims agree (A[1]==B[0]); falls
     back to M/K from a single 2D tensor. Dims that cannot be derived are omitted
     so the driver keeps its own default for them.
+
+    Args:
+        shapes (list[list[int]]): per-tensor integer dim lists.
+
+    Returns:
+        dict: the derived ``{M, N, K}`` dims (partial when only a single 2D
+            tensor is available; empty when none can be derived).
     """
     twod = [s for s in shapes if len(s) == 2]
     for a in twod:
@@ -829,6 +978,13 @@ def _moe_dims(shapes: list[list[int]]) -> dict:
     [E,*,K] (3D), and topk ids/weights [M,t] (2D, small second dim). w2 is
     [E,K,N] (dim1==K) -> N=dim2; else w1 [E,2N,K] (dim2==K) -> N=dim1//2.
     Only confidently derived dims are returned; the rest fall back to defaults.
+
+    Args:
+        shapes (list[list[int]]): per-tensor integer dim lists.
+
+    Returns:
+        dict: the confidently derived subset of ``{M, N, K, E, TOPK}``; the rest
+            fall back to driver defaults.
     """
     twod = [s for s in shapes if len(s) == 2]
     threed = [s for s in shapes if len(s) == 3]
@@ -869,6 +1025,14 @@ def _shapes_from_candidate(candidate: dict) -> dict:
     omitted and the driver keeps its built-in default (safe degradation).
 
     With a single shape, minimal == primary and the sweep degenerates (Y3).
+
+    Args:
+        candidate (dict): the kernel candidate carrying ``operation`` / ``name``
+            and ``input_shapes``.
+
+    Returns:
+        dict: a shapes dict with ``primary`` / ``minimal`` named-dim mappings
+            and a ``validation`` list for the driver.
     """
     op = (str(candidate.get("operation") or "") + " " + str(candidate.get("name") or "")).lower()
     dims = _tensor_dim_lists(candidate)
@@ -896,6 +1060,15 @@ def _write_report(output_dir: Path, baseline_ms: float | None, best_ms: float | 
     kernel strictly faster than baseline (improved=True). Otherwise emits no
     speedup and [correctness] fail, so build_verification never KEEPs a kernel
     that wasn't really optimized/validated.
+
+    Args:
+        output_dir (Path): the run output dir the report is written under.
+        baseline_ms (float | None): the baseline wall time in ms.
+        best_ms (float | None): the best-kept wall time in ms.
+        improved (bool): whether a validated, strictly-faster kernel was kept.
+
+    Returns:
+        Path: the path to the written ``optimization_report.md``.
     """
     lines = ["# Forge optimization report", ""]
     if improved and baseline_ms and best_ms and best_ms > 0:
@@ -931,6 +1104,21 @@ def _export_best_artifacts(workspace: str, base_commit: str, worktree_kernel_fil
         base_commit``) so a multi-file change can be applied at integration time.
 
     Returns (primary_artifact_path, changed_relpaths).
+
+    Args:
+        workspace (str): the worktree/live-repo workspace holding the best-kept
+            state.
+        base_commit (str): the pre-forge baseline commit to diff against.
+        worktree_kernel_file (str): the primary kernel file to copy as the
+            drop-in replacement artifact.
+        source_file (str): the original kernel source file (its suffix names the
+            artifact).
+        output_dir (Path): the run output dir artifacts are written under.
+
+    Returns:
+        tuple[str, list[str]]: ``(primary_artifact_path, changed_relpaths)`` —
+            the exported primary kernel path and every repo-relative file
+            changed since ``base_commit``.
     """
     dst_dir = output_dir / "optimized_versions"
     dst_dir.mkdir(parents=True, exist_ok=True)
@@ -975,7 +1163,20 @@ def _export_best_artifacts(workspace: str, base_commit: str, worktree_kernel_fil
 
 def _normalized(returncode: int, stdout: str, stderr: str, elapsed_s: float,
                 gpu_ids: str = "") -> dict:
-    """Shape the result like oob_submit/geak_submit return dicts."""
+    """Shape the result like oob_submit/geak_submit return dicts.
+
+    Args:
+        returncode (int): the process return code.
+        stdout (str): captured stdout.
+        stderr (str): captured stderr.
+        elapsed_s (float): wall time elapsed in seconds.
+        gpu_ids (str): GPU id string; defaults to the visible-device env vars
+            when empty.
+
+    Returns:
+        dict: the normalized result dict (returncode, stdout/stderr tails,
+            gpu_ids, elapsed_s, cmd).
+    """
     return {
         "returncode": returncode,
         "stdout_tail": (stdout or "")[-4000:],
@@ -998,6 +1199,28 @@ def submit(source_file: str, prompt_file: Path, output_dir: Path,
     Stage 1 runs the loop in-process inside a git worktree (Ray wrapping is a
     follow-up to match OOB GPU leasing). Returns a normalized result dict and
     writes optimized_versions/ + optimization_report.md under output_dir.
+
+    Args:
+        source_file (str): the kernel source file to optimize.
+        prompt_file (Path): the Hyperloom-rendered prompt reused as the Forge
+            program text.
+        output_dir (Path): the run output dir for artifacts and logs.
+        test_command (str): optional Hyperloom harness/test command; when empty
+            a Forge-native driver is auto-generated.
+        source_type (str): the kernel source type (stage 1 supports triton).
+        candidate (dict | None): the kernel candidate metadata (operation,
+            input_shapes, platform, targets, ...).
+        num_gpus (int): the number of GPUs to lease for the run.
+        timeout_s (int): the overall run budget in seconds (drives the per-iter
+            Forge budget).
+        prefer_ray (bool): whether to prefer Ray wrapping (stage 1 runs
+            in-process).
+        kernel_repo (str): the kernel repo root (falls back to the git toplevel
+            of ``source_file`` when empty).
+
+    Returns:
+        dict: a normalized result dict (also carrying ``cli_workspace`` /
+            ``output_dir`` so the report scan finds the emitted artifacts).
     """
     started = time.time()
     candidate = candidate or {}
@@ -1138,6 +1361,24 @@ def submit(source_file: str, prompt_file: Path, output_dir: Path,
         )
 
         async def _logged_agent_fn(kernel_path: str, history: str) -> str:
+            """Run the Forge agent with per-call timeout, retries, and logging.
+
+            Wraps ``raw_agent_fn`` so each call is bounded by
+            ``agent_timeout_s`` and retried up to ``agent_retries`` times on
+            timeouts or transient SDK errors, appending an outcome line to the
+            forge loop log on every attempt.
+
+            Args:
+                kernel_path (str): Path to the kernel the agent edits.
+                history (str): Iteration history passed through to the agent.
+
+            Returns:
+                str: The agent's result string on success.
+
+            Raises:
+                Exception: The last timeout/transient error when all attempts
+                    are exhausted (or a non-transient error immediately).
+            """
             import asyncio as _aio
             import traceback as _tb
             last_exc: Exception | None = None

--- a/kernel-agent/tools/backends/geak_submit.py
+++ b/kernel-agent/tools/backends/geak_submit.py
@@ -136,6 +136,24 @@ def run_via_ray(prompt_file: Path, output_dir: Path, kernel_path: str,
     @ray.remote(num_gpus=num_gpus)
     def _task(prompt_file_str: str, output_dir_str: str, kernel_path: str,
               cost_limit, timeout_s: int, kernel_repo: str, test_command: str) -> dict:
+        """Run one GEAK CLI attempt inside a Ray worker.
+
+        Self-contained because Ray workers do not inherit the driver's
+        ``sys.path``; all imports and GPU-visibility remapping happen here.
+
+        Args:
+            prompt_file_str: Path to the prompt file.
+            output_dir_str: Output directory for this attempt.
+            kernel_path: Path to the kernel under optimization.
+            cost_limit: Optional cost ceiling for the GEAK run.
+            timeout_s: Per-attempt timeout in seconds.
+            kernel_repo: Kernel repository identifier.
+            test_command: Command used to validate the kernel.
+
+        Returns:
+            A result dict with ``returncode``, ``stdout_tail``,
+            ``stderr_tail``, ``gpu_ids``, ``elapsed_s``, and ``cmd``.
+        """
         # Self-contained: Ray workers lack the driver's sys.path.
         import os as _os, shutil as _shutil, subprocess as _sp, time as _t
         import re as _re
@@ -245,6 +263,25 @@ def run_via_ray(prompt_file: Path, output_dir: Path, kernel_path: str,
 def run_via_cli(prompt_file: Path, output_dir: Path, kernel_path: str,
                 cost_limit: float | None, timeout_s: int,
                 kernel_repo: str = "", test_command: str = "") -> dict:
+    """Run one GEAK CLI attempt in a subprocess (non-Ray path).
+
+    Builds a child environment with ROCR→logical GPU remapping and per-attempt
+    compile caches, then runs the GEAK CLI under a timeout.
+
+    Args:
+        prompt_file: Path to the prompt file.
+        output_dir: Output directory for this attempt.
+        kernel_path: Path to the kernel under optimization.
+        cost_limit: Optional cost ceiling for the GEAK run.
+        timeout_s: Per-attempt timeout in seconds.
+        kernel_repo: Kernel repository identifier.
+        test_command: Command used to validate the kernel.
+
+    Returns:
+        A result dict with ``returncode``, ``stdout_tail``, ``stderr_tail``,
+        ``gpu_ids``, ``elapsed_s``, and ``cmd``. Timeouts return code ``124``
+        and input errors return code ``2``.
+    """
     # Child env with ROCR→logical GPU mapping; avoids leaking GPU vars to later steps.
     child_env = os.environ.copy()
     rocr_raw = child_env.get("ROCR_VISIBLE_DEVICES", "")

--- a/kernel-agent/tools/backends/oob_submit.py
+++ b/kernel-agent/tools/backends/oob_submit.py
@@ -227,6 +227,26 @@ def run_via_ray(agent: str, prompt_file: Path, output_dir: Path, source_file: st
     def _task(agent: str, prompt_file_str: str, output_dir_str: str,
               source_file: str, max_turns: int, timeout_s: int,
               extra_files: list[str], system_prompt: str) -> dict:
+        """Run one out-of-box (OOB) agent attempt inside a Ray worker.
+
+        Self-contained because Ray workers do not inherit the driver's
+        ``sys.path``; GPU visibility and compile caches are set up here.
+
+        Args:
+            agent: Agent identifier to run.
+            prompt_file_str: Path to the prompt file.
+            output_dir_str: Output directory for this attempt.
+            source_file: Path to the kernel source file.
+            max_turns: Maximum agent turns.
+            timeout_s: Per-attempt timeout in seconds.
+            extra_files: Additional files to make available to the agent.
+            system_prompt: System prompt text for the run.
+
+        Returns:
+            A result dict with ``returncode``, ``stdout``/``stdout_tail``,
+            ``stderr_tail``, ``gpu_ids``, ``elapsed_s``, and ``cmd`` (return
+            code ``127`` when the ``oob`` CLI is missing on the worker).
+        """
         # Self-contained: workers don't share the driver sys.path.
         import os as _os, shutil as _shutil, subprocess as _sp, time as _t
         if not _shutil.which("oob"):

--- a/kernel-agent/tools/backends/oob_submit.py
+++ b/kernel-agent/tools/backends/oob_submit.py
@@ -133,7 +133,18 @@ def _build_cmd(agent: str, prompt_file: Path, output_dir: Path,
 
 
 def _parse_oob_init(stdout: str) -> dict[str, str]:
-    """Extract cwd / session_id / thread_id from oob run --json output (trailing summary, else ndjson init)."""
+    """Extract workspace and session identifiers from ``oob run`` JSON output.
+
+    Prefers the trailing oob-run JSON summary, falling back to the ndjson init
+    record.
+
+    Args:
+        stdout: The captured stdout from ``oob run --json``.
+
+    Returns:
+        A dict with ``cli_workspace``, ``session_id``, and ``thread_id`` keys
+        (empty strings when not found).
+    """
     info = {"cli_workspace": "", "session_id": "", "thread_id": ""}
     if not stdout:
         return info

--- a/kernel-agent/tools/backends/ray_runtime.py
+++ b/kernel-agent/tools/backends/ray_runtime.py
@@ -37,6 +37,12 @@ def _fd_limit_warn(msg: str) -> None:
 
 
 def _min_nofile_target() -> int:
+    """Return the target soft RLIMIT_NOFILE value.
+
+    Returns:
+        The positive integer from ``RAY_MIN_NOFILE`` when set, otherwise
+        ``DEFAULT_MIN_NOFILE``.
+    """
     raw = os.environ.get("RAY_MIN_NOFILE", "").strip()
     if raw.isdigit() and int(raw) > 0:
         return int(raw)
@@ -313,6 +319,7 @@ def quiet_ray_init(num_gpus: Optional[int] = None, log_path: Optional[Path] = No
     runtime_env = safe_runtime_env()
 
     def _init() -> None:
+        """Call ``ray.init`` with stdout suppressed and standard options."""
         buf = io.StringIO()
         with contextlib.redirect_stdout(buf):
             ray.init(

--- a/kernel-agent/tools/backends/ray_runtime.py
+++ b/kernel-agent/tools/backends/ray_runtime.py
@@ -27,11 +27,13 @@ DEFAULT_MIN_NOFILE = 65536
 
 
 def _fd_limit_warn(msg: str) -> None:
-    """Single indirection for fd-limit warnings.
+    """Emit an fd-limit warning to stderr with a stable prefix.
 
     Kept as a module function so tests can capture it and so every warning
-    carries the same prefix. Goes to stderr; callers that own a log_path
-    also get a line in the Ray lifecycle log.
+    carries the same prefix.
+
+    Args:
+        msg: The warning message body.
     """
     print(f"[kernel-agent WARN] {msg}", file=sys.stderr)
 
@@ -52,8 +54,7 @@ def _min_nofile_target() -> int:
 def ensure_fd_limit(
     min_soft: Optional[int] = None, log_path: Optional[Path] = None,
 ) -> Tuple[int, int]:
-    """Raise this process's RLIMIT_NOFILE soft limit before Ray spawns the
-    raylet (issue #433).
+    """Raise this process's RLIMIT_NOFILE soft limit before Ray starts.
 
     The child ``ray start`` process inherits this process's limits, so the
     raylet's open-files ceiling is whatever we set here. We raise the soft
@@ -61,9 +62,15 @@ def ensure_fd_limit(
     cap needs no privileges; lifting the hard cap does (CAP_SYS_RESOURCE),
     so when the hard cap is itself below ``min_soft`` we raise soft as high
     as allowed and warn — only ``docker run --ulimit nofile=...`` at
-    container launch can lift the hard cap in an unprivileged container.
+    container launch can lift the hard cap in an unprivileged container
+    (issue #433).
 
-    Returns the ``(soft, hard)`` limit in effect after the call.
+    Args:
+        min_soft: Target soft limit; defaults to the configured target.
+        log_path: Optional path to append a lifecycle log line.
+
+    Returns:
+        The ``(soft, hard)`` limit in effect after the call.
     """
     if min_soft is None:
         min_soft = _min_nofile_target()
@@ -127,6 +134,13 @@ def isolated_compile_cache_env(output_dir, base_env: Optional[dict] = None) -> d
     ``AITER_ROOT_DIR`` only steers aiter's cpp_itfs ``BUILD_DIR`` -- sources
     and configs resolve off the package dir -- so redirecting it is
     compile-safe.
+
+    Args:
+        output_dir: The per-attempt output directory caches are nested under.
+        base_env: Base environment to copy; defaults to ``os.environ``.
+
+    Returns:
+        An environment dict with per-attempt cache directories set.
     """
     env = dict(os.environ if base_env is None else base_env)
     base = os.path.join(str(output_dir), ".cache")
@@ -163,7 +177,15 @@ def ray_status_ok() -> bool:
 def ensure_ray_cluster(num_gpus: Optional[int] = None, log_path: Optional[Path] = None) -> bool:
     """Ensure a Ray cluster is reachable, starting a head node if needed.
 
-    Returns True if this call started Ray, False if already running; raises on failure.
+    Args:
+        num_gpus: Optional GPU count to pass to ``ray start --head``.
+        log_path: Optional path to append ``ray start`` output.
+
+    Returns:
+        ``True`` if this call started Ray, ``False`` if it was already running.
+
+    Raises:
+        RuntimeError: If starting the Ray head node fails.
     """
     if ray_status_ok():
         return False
@@ -210,14 +232,36 @@ def stop_ray_if_owned(started: bool, log_path: Optional[Path] = None) -> None:
 
 
 def _is_ray_version_mismatch(text: str) -> bool:
-    """True when Ray refused the job due to a cluster started under a different Python/Ray (issue #432); matches the stable ``Version mismatch`` banner."""
+    """Detect Ray's version-mismatch banner in captured output.
+
+    Indicates the cluster was started under a different Python/Ray than this
+    process (issue #432).
+
+    Args:
+        text: The captured error or output text.
+
+    Returns:
+        ``True`` if the text contains the stable version-mismatch banner.
+    """
     return "version mismatch" in (text or "").lower()
 
 
 def force_restart_local_cluster(
     num_gpus: Optional[int] = None, log_path: Optional[Path] = None,
 ) -> None:
-    """Tear down any reachable Ray cluster and start a fresh local head under THIS interpreter. Recovers from a stale/foreign cluster (issue #432) whose version mismatch otherwise mislabels as a "compile failed" REVERT; also clears raylet zombies. Raises RuntimeError if the fresh head fails to start."""
+    """Tear down any reachable Ray cluster and start a fresh local head.
+
+    The fresh head runs under this interpreter, recovering from a
+    stale/foreign cluster (issue #432) whose version mismatch otherwise
+    mislabels as a "compile failed" REVERT; this also clears raylet zombies.
+
+    Args:
+        num_gpus: Optional GPU count for the fresh head node.
+        log_path: Optional path to append restart output.
+
+    Raises:
+        RuntimeError: If the fresh head node fails to start.
+    """
     # issue #433: raise the open-files limit before the fresh raylet starts
     # so it inherits a high enough ceiling (the container default 1024 makes
     # the raylet abort on startup / linger as a zombie).
@@ -312,6 +356,10 @@ def quiet_ray_init(num_gpus: Optional[int] = None, log_path: Optional[Path] = No
     once. ``num_gpus`` / ``log_path`` are threaded through to the restart so
     the new head matches the requested GPU count and the action is audited
     in ``ray_lifecycle.log``.
+
+    Args:
+        num_gpus: Optional GPU count forwarded to a restart, if needed.
+        log_path: Optional path to audit Ray lifecycle actions.
     """
     import contextlib
     import io

--- a/kernel-agent/tools/backends/ssh_runtime.py
+++ b/kernel-agent/tools/backends/ssh_runtime.py
@@ -56,12 +56,20 @@ def ssh_placement_active() -> bool:
     """True only when the orchestrator opted this run into SSH GPU placement.
 
     The single switch that isolates the Dynamo SSH path from every other run.
+
+    Returns:
+        ``True`` when ``KERNEL_AGENT_GPU_PLACEMENT`` is set to ``ssh``.
     """
     return os.environ.get("KERNEL_AGENT_GPU_PLACEMENT", "").strip().lower() == "ssh"
 
 
 def ssh_target() -> tuple[str, int, str]:
-    """Resolve (host, port, key_path) for the GPU pod from MN_SSH_* env."""
+    """Resolve (host, port, key_path) for the GPU pod from MN_SSH_* env.
+
+    Returns:
+        A ``(host, port, key_path)`` tuple read from ``MN_SSH_HOST`` /
+        ``MN_SSH_PORT`` / ``MN_SSH_KEY``.
+    """
     host = os.environ.get("MN_SSH_HOST", "").strip()
     port = int(os.environ.get("MN_SSH_PORT", str(DEFAULT_SSH_PORT)) or DEFAULT_SSH_PORT)
     key = os.environ.get("MN_SSH_KEY", "").strip()
@@ -73,6 +81,10 @@ def _env_prologue() -> str:
 
     Values are shell-quoted; nothing reaches argv. Mirrors
     ``safe_runtime_env``'s allowlist + credential aliasing.
+
+    Returns:
+        Newline-joined ``export K=V`` lines for the allowlisted GEAK env,
+        including a ``PATH`` export leading with ``/opt/venv/bin``.
     """
     env = safe_runtime_env().get("env_vars", {})
     lines = [
@@ -161,7 +173,15 @@ except subprocess.TimeoutExpired:
 
 
 def _extract_last_json(text: str) -> dict | None:
-    """Parse the last top-level JSON object from the pod's stdout."""
+    """Parse the last top-level JSON object from the pod's stdout.
+
+    Args:
+        text: The pod's stdout to scan.
+
+    Returns:
+        The last top-level JSON object as a dict, or ``None`` when none is
+        found or it fails to parse.
+    """
     if not text:
         return None
     s = text.rstrip()
@@ -184,7 +204,11 @@ def _extract_last_json(text: str) -> dict | None:
 
 
 def _ssh_unconfigured() -> dict | None:
-    """Return an error dict if MN_SSH_HOST/KEY are missing, else None."""
+    """Return an error dict if MN_SSH_HOST/KEY are missing, else None.
+
+    Returns:
+        A result-shaped error dict when SSH is unconfigured, else ``None``.
+    """
     host, _port, key = ssh_target()
     if not host or not key:
         return {
@@ -203,6 +227,16 @@ def _run_pod_runner_over_ssh(
 
     Env (creds) is piped via SSH stdin (never argv/disk). Returns
     ``(parsed_json_or_None, completed_proc_or_None, host)``.
+
+    Args:
+        runner_name: Short name for the runner (used in temp paths / heredoc).
+        runner_py: The self-contained pod runner Python source.
+        runner_args: CLI args passed to the pod runner.
+        timeout_s: Runner budget in seconds (SSH timeout adds a buffer).
+
+    Returns:
+        A ``(parsed_json_or_None, completed_proc_or_None, host)`` tuple; the
+        proc is ``None`` when the SSH call itself timed out.
     """
     host, port, key = ssh_target()
     quoted_args = " ".join(shlex.quote(x) for x in runner_args)
@@ -233,6 +267,20 @@ def run_geak_over_ssh(
 ) -> dict:
     """Run GEAK on a Dynamo GPU pod over SSH (no Ray). Returns the same dict
     shape as ``run_via_cli`` / ``run_via_ray`` so callers are placement-blind.
+
+    Args:
+        prompt_file: Path to the GEAK prompt (on the shared mount).
+        output_dir: Output directory for GEAK artifacts (shared mount).
+        kernel_path: Optional kernel source path passed to GEAK.
+        cost_limit: Optional cost cap forwarded to GEAK.
+        num_gpus: Number of GPUs to expose to the pod runner.
+        timeout_s: GEAK budget in seconds.
+        kernel_repo: Optional kernel repo path passed to GEAK.
+        test_command: Optional test command passed to GEAK.
+
+    Returns:
+        The GEAK result dict (``returncode`` / ``stdout_tail`` /
+        ``stderr_tail`` / ``gpu_ids`` / ``elapsed_s`` / ``cmd``).
     """
     unconfigured = _ssh_unconfigured()
     if unconfigured is not None:
@@ -346,6 +394,22 @@ def run_oob_over_ssh(
     Returns the same dict shape as oob_submit.run_via_ray, INCLUDING the full
     ``stdout`` (read back from the shared-FS log the pod runner wrote) so the
     caller's ``_parse_oob_init`` recovers the workspace.
+
+    Args:
+        agent: OOB agent name (e.g. ``claude`` / ``codex`` / ``cursor``).
+        prompt_file: Path to the prompt file (shared mount).
+        output_dir: Output directory for the run (shared mount).
+        source_file: Optional source file passed to the agent.
+        max_turns: Maximum agent turns.
+        num_gpus: Number of GPUs to expose to the pod runner.
+        timeout_s: Agent budget in seconds.
+        extra_files: Optional extra files passed to the agent.
+        kernel_repo: Optional kernel repo path (accepted for parity).
+        system_prompt_text: Optional system prompt written to a shared-FS file.
+
+    Returns:
+        The OOB result dict, including the full ``stdout`` recovered from the
+        shared-FS log.
     """
     unconfigured = _ssh_unconfigured()
     if unconfigured is not None:

--- a/kernel-agent/tools/geak_prompt_patcher.py
+++ b/kernel-agent/tools/geak_prompt_patcher.py
@@ -39,10 +39,14 @@ _DEFAULT_REL_PATH = Path("minisweagent/config/mini_kernel_strategy_list.yaml")
 
 
 def _locate_yaml() -> Path | None:
-    """Return the bundled GEAK strategy YAML path.
+    """Locate the bundled GEAK strategy YAML.
 
-    Resolves ``$HYPERLOOM_GEAK_PROMPT_YAML`` (test override) then the
-    minisweagent package; ``None`` when the package isn't importable.
+    Resolves ``$HYPERLOOM_GEAK_PROMPT_YAML`` (test override) first, then the
+    ``minisweagent`` package location.
+
+    Returns:
+        The YAML path, or ``None`` when the override file is missing or the
+        package isn't importable.
     """
     override = os.environ.get("HYPERLOOM_GEAK_PROMPT_YAML", "").strip()
     if override:
@@ -60,7 +64,12 @@ def _locate_yaml() -> Path | None:
 
 
 def _atomic_write(target: Path, content: str) -> None:
-    """Write ``content`` to ``target`` atomically via tempfile + replace."""
+    """Write content to a file atomically via a tempfile and replace.
+
+    Args:
+        target: Destination file path.
+        content: Text to write.
+    """
     with tempfile.NamedTemporaryFile(
         "w", dir=str(target.parent), delete=False, encoding="utf-8",
     ) as tmp:
@@ -74,7 +83,15 @@ def _atomic_write(target: Path, content: str) -> None:
 
 
 def ensure_geak_prompt_patched() -> tuple[bool, str]:
-    """Patch the bundled YAML in-place; idempotent and fail-soft. Returns ``(ok, message)``."""
+    """Patch the bundled GEAK strategy YAML in place.
+
+    The operation is idempotent and fail-soft: it skips when already patched,
+    when the package is absent, or when upstream wording has drifted.
+
+    Returns:
+        A ``(ok, message)`` tuple where ``ok`` indicates success and
+        ``message`` is a human-readable status.
+    """
     yaml_path = _locate_yaml()
     if yaml_path is None:
         return False, "minisweagent not installed (skip)"
@@ -100,7 +117,14 @@ def ensure_geak_prompt_patched() -> tuple[bool, str]:
 
 
 def main() -> int:
-    """CLI entry for install.sh; exits 0 unless ``$HYPERLOOM_GEAK_PROMPT_PATCH_REQUIRED == 1``."""
+    """Run the patcher as a CLI entry point for ``install.sh``.
+
+    Exits 0 unless the patch fails and
+    ``$HYPERLOOM_GEAK_PROMPT_PATCH_REQUIRED == 1``.
+
+    Returns:
+        Process exit code (0 on success or soft-skip, 1 on required failure).
+    """
     ok, msg = ensure_geak_prompt_patched()
     status = "OK" if ok else "WARN"
     print(f"[geak-prompt-patcher] {status}: {msg}")

--- a/kernel-agent/tools/harness_generator.py
+++ b/kernel-agent/tools/harness_generator.py
@@ -167,7 +167,15 @@ class BenchmarkAnalyzer:
     def classify_functions(
         self, decorated: dict[str, FuncInfo]
     ) -> tuple[FuncInfo | None, FuncInfo | None]:
-        """Classify decorated functions into (reference, kernel); either can be None."""
+        """Classify decorated functions into a reference/kernel pair.
+
+        Args:
+            decorated: Mapping of function name to its :class:`FuncInfo`.
+
+        Returns:
+            A ``(reference, kernel)`` tuple; either element may be ``None``
+            when no suitable candidate is found.
+        """
         ref_candidates: list[FuncInfo] = []
         kernel_candidates: list[FuncInfo] = []
 
@@ -218,7 +226,14 @@ class BenchmarkAnalyzer:
         return ref, kernel
 
     def get_test_function(self, decorated: dict[str, FuncInfo]) -> FuncInfo | None:
-        """Find the main test/benchmark orchestrator function."""
+        """Find the main test/benchmark orchestrator function.
+
+        Args:
+            decorated: Mapping of function name to its :class:`FuncInfo`.
+
+        Returns:
+            The orchestrator :class:`FuncInfo`, or ``None`` if none is found.
+        """
         # Prefer a @benchmark-decorated function; else a top-level test_*/bench_* caller.
         for fi in decorated.values():
             if fi.decorator == "benchmark":
@@ -373,7 +388,14 @@ class BenchmarkAnalyzer:
 # Config builder — from TraceLens input_shapes
 
 def _build_configs(candidate: dict) -> tuple[str, str, str]:
-    """Build (ALL_CONFIGS, cfg unpack, config_str) code from candidate shapes."""
+    """Build harness config code from a candidate's trace shapes.
+
+    Args:
+        candidate: Candidate dict carrying ``input_shapes`` from TraceLens.
+
+    Returns:
+        A tuple of ``(ALL_CONFIGS, cfg unpack, config_str)`` code fragments.
+    """
     input_shapes = candidate.get("input_shapes") or []
     if not input_shapes:
         return _default_configs()
@@ -507,7 +529,20 @@ def _generate_setup_inputs(
     ref_func: FuncInfo | None,
     kernel_func: FuncInfo | None,
 ) -> str:
-    """Generate the setup_inputs(cfg) body, creating inputs only for args the test actually passes."""
+    """Generate the ``setup_inputs(cfg)`` body for the harness.
+
+    Inputs are created only for args the test actually passes.
+
+    Args:
+        analyzer: The benchmark analyzer for the source module.
+        test_func: The orchestrator test function, if any.
+        cfg_unpack: The config-unpack code line (e.g. ``M, N = cfg``).
+        ref_func: The reference function, if any.
+        kernel_func: The kernel function, if any.
+
+    Returns:
+        The generated ``setup_inputs`` body as source text.
+    """
     dim_vars = cfg_unpack.replace(" = cfg", "").split(", ")
     dim_vars = [v.strip() for v in dim_vars if v.strip() != "dtype"]
 
@@ -567,7 +602,17 @@ def _generate_setup_inputs(
 def _match_call_args_to_params(
     call: CallInfo, params: list[str]
 ) -> list[tuple[str, str | None]]:
-    """Match call args to params, returning [(param, call_value_or_None), ...] (positional + tensor kwargs)."""
+    """Match a call's args to a function's parameters.
+
+    Handles positional args and tensor keyword args.
+
+    Args:
+        call: The call-site info to match.
+        params: The target function's parameter names.
+
+    Returns:
+        A list of ``(param, call_value_or_None)`` tuples.
+    """
     result: list[tuple[str, str | None]] = []
 
     # Positional args are always required.
@@ -675,7 +720,18 @@ def _generate_run_func_body(
     test_func: FuncInfo | None,
     target_func: FuncInfo,
 ) -> str:
-    """Generate a body that calls target_func with inputs dict values; missing params use defaults."""
+    """Generate a run-function body that calls the target function.
+
+    Arguments are pulled from the inputs dict; missing params use defaults.
+
+    Args:
+        analyzer: The benchmark analyzer for the source module.
+        test_func: The orchestrator test function, if any.
+        target_func: The function the generated body should call.
+
+    Returns:
+        The generated run-function body as source text.
+    """
     call = None
     if test_func:
         call = analyzer.extract_call_to(test_func, target_func.name)

--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -1883,11 +1883,22 @@ def _try_generate_harness(
 
 
 def _rocprof_roofline_enabled() -> bool:
+    """Return whether rocprof roofline profiling is enabled.
+
+    Returns:
+        ``True`` unless ``HYPERLOOM_ROCPROF_ROOFLINE`` is set to a falsy value.
+    """
     value = os.environ.get("HYPERLOOM_ROCPROF_ROOFLINE", "1").strip().lower()
     return value not in {"0", "false", "no", "off"}
 
 
 def _rocprof_timeout_sec() -> int:
+    """Return the per-kernel rocprof roofline timeout in seconds.
+
+    Returns:
+        The value from ``HYPERLOOM_ROCPROF_ROOFLINE_TIMEOUT_SEC`` (floored at
+        60s), or ``1800`` when unset or invalid.
+    """
     try:
         return max(60, int(os.environ.get("HYPERLOOM_ROCPROF_ROOFLINE_TIMEOUT_SEC", "1800")))
     except ValueError:
@@ -1895,6 +1906,17 @@ def _rocprof_timeout_sec() -> int:
 
 
 def _rocprof_workdir(candidate: dict[str, Any], source_file: str, out_dir: Path) -> Path:
+    """Choose a working directory for the rocprof profiling run.
+
+    Args:
+        candidate: Candidate metadata containing ``kernel_repo``.
+        source_file: Path to the kernel source file.
+        out_dir: Fallback directory when no candidate path resolves.
+
+    Returns:
+        The first existing directory derived from the candidate/source paths,
+        else ``out_dir``.
+    """
     for raw in (candidate.get("kernel_repo"), source_file):
         if not raw:
             continue
@@ -1907,6 +1929,15 @@ def _rocprof_workdir(candidate: dict[str, Any], source_file: str, out_dir: Path)
 
 
 def _rocprof_profile_command(test_command: str) -> str:
+    """Convert a harness correctness command into a profiling command.
+
+    Args:
+        test_command: Original harness test command.
+
+    Returns:
+        The command with a single ``--correctness`` swapped for ``--profile``
+        when it targets a generated harness; otherwise the command unchanged.
+    """
     if "--correctness" not in test_command:
         return test_command
     if "/unittest/harness_" not in test_command and " harness_" not in test_command:
@@ -1915,6 +1946,15 @@ def _rocprof_profile_command(test_command: str) -> str:
 
 
 def _compact_rocprof_prompt(payload: dict[str, Any]) -> str:
+    """Render a compact roofline-evidence addendum for the agent prompt.
+
+    Args:
+        payload: Structured rocprof roofline payload.
+
+    Returns:
+        A Markdown snippet summarizing up to three kernels' roofline signals,
+        or an empty string when there are no results.
+    """
     rows = payload.get("results") if isinstance(payload, dict) else []
     if not isinstance(rows, list) or not rows:
         return ""
@@ -1950,6 +1990,23 @@ def _run_rocprof_roofline(
     prompt_file: Path,
     log_path: Path | None,
 ) -> dict[str, Any]:
+    """Run rocprof roofline before GEAK and append evidence to the prompt.
+
+    Profiles the kernel via the ``rocprof_roofline.py`` helper, writes the
+    JSON/text artifacts, and appends a compact evidence section to the prompt.
+
+    Args:
+        test_command: Harness command used to exercise the kernel.
+        candidate: Candidate kernel metadata.
+        source_file: Path to the kernel source file.
+        out_dir: Output directory for this attempt.
+        prompt_file: Prompt file to append roofline evidence to.
+        log_path: Optional log file for progress messages.
+
+    Returns:
+        A status dict with the run outcome and artifact paths (``status`` is
+        ``skipped``/``failed``/``ok``).
+    """
     roof_dir = out_dir / "rocprof_roofline"
     roof_dir.mkdir(parents=True, exist_ok=True)
     out_json = roof_dir / "before.json"
@@ -2013,6 +2070,15 @@ def _run_rocprof_roofline(
 
 
 def _rocprof_kernel_matches(row: dict[str, Any], target_kernel: str) -> bool:
+    """Return whether a roofline result row matches the target kernel.
+
+    Args:
+        row: Result row with ``matched_kernel_name`` / ``name`` fields.
+        target_kernel: Kernel name to match; empty matches any row.
+
+    Returns:
+        ``True`` if the row corresponds to ``target_kernel``.
+    """
     if not target_kernel:
         return True
     target = target_kernel.strip()
@@ -2024,6 +2090,17 @@ def _rocprof_kernel_matches(row: dict[str, Any], target_kernel: str) -> bool:
 
 
 def _rocprof_sidecar_from_payload(payload: dict[str, Any], txt_path: str, json_path: str) -> dict[str, Any]:
+    """Project a roofline payload into a sidecar record for one kernel.
+
+    Args:
+        payload: Structured rocprof roofline payload.
+        txt_path: Path to the text report, recorded on the result.
+        json_path: Path to the JSON report, recorded on the result.
+
+    Returns:
+        A roofline record for the matched (or first) kernel, or a
+        skipped/failed status record when no match is found.
+    """
     rows = payload.get("results") if isinstance(payload, dict) else []
     if not isinstance(rows, list) or not rows:
         return {
@@ -2065,6 +2142,15 @@ def _rocprof_sidecar_from_payload(payload: dict[str, Any], txt_path: str, json_p
 
 
 def _rocprof_phase_has_measurement(phase_data: dict[str, Any]) -> bool:
+    """Return whether a roofline phase contains real numeric measurements.
+
+    Args:
+        phase_data: A before/after roofline phase record.
+
+    Returns:
+        ``True`` only when the phase did not fail/skip and carries at least one
+        numeric roofline metric (metadata alone does not count).
+    """
     status = str(phase_data.get("status") or "").lower()
     if status in {"failed", "skipped"}:
         return False
@@ -2230,6 +2316,15 @@ def _restore_env(previous: dict[str, str | None]) -> None:
 
 
 def _oob_output_dir(session_id: str, prompt_file: Path) -> Path:
+    """Return the per-attempt output directory for an OOB run.
+
+    Args:
+        session_id: Session identifier for the run.
+        prompt_file: Prompt file whose stem scopes the attempt directory.
+
+    Returns:
+        The created ``.../oob/<session_id>/<prompt_stem>`` directory.
+    """
     # Per-attempt, mirroring _geak_output_dir. A session-level dir would let
     # concurrent OOB attempts share artifacts AND the per-attempt compile
     # caches (isolated_compile_cache_env keys off output_dir), reintroducing
@@ -3216,6 +3311,20 @@ def _select_source_artifact(
 
 
 def build_verification(args: argparse.Namespace, attempts: list[dict[str, Any]], benchmark_available: bool) -> dict[str, Any]:
+    """Summarize attempt results into a verification record.
+
+    Selects the best usable attempt (by extracted speedup, falling back to the
+    first usable one) and reports whether a real speedup was measured.
+
+    Args:
+        args: Parsed CLI arguments for the run.
+        attempts: Per-attempt result records.
+        benchmark_available: Whether a benchmark/harness was available to
+            measure speedups.
+
+    Returns:
+        A verification dict describing the best attempt and measured speedup.
+    """
     # Usable = completed cleanly OR killed-but-left-artifacts (status=partial).
     usable = [a for a in attempts if a.get("status") in {"completed", "partial"}]
     best = None

--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -155,6 +155,12 @@ def resolve_candidates_path(run_dir: Path) -> Path:
     Falls back to the flat path (which ``load_candidates`` will surface as a
     clean ``FileNotFoundError``) when nothing matches, preserving the
     "no fabricated target" failure mode for genuinely missing analyses.
+
+    Args:
+        run_dir: The ``runs/<session_id>/`` root for the session.
+
+    Returns:
+        The resolved ``kernel_candidates.json`` path (possibly non-existent).
     """
     flat = run_dir / "kernel_candidates.json"
     if flat.is_file():
@@ -176,7 +182,15 @@ def resolve_candidates_path(run_dir: Path) -> Path:
 def load_candidates(path: Path) -> list[dict[str, Any]]:
     """Load kernel candidates from JSON, normalizing legacy shapes.
 
-    Per Hyperloom#314 returns the union of ``hot_kernels`` (routable) + ``skipped_kernels`` so id lookup still resolves non-routable kernels; legacy flat-list / ``kernel_candidates`` shapes respected.
+    Per Hyperloom#314 returns the union of ``hot_kernels`` (routable) +
+    ``skipped_kernels`` so id lookup still resolves non-routable kernels;
+    legacy flat-list / ``kernel_candidates`` shapes are respected.
+
+    Args:
+        path: Path to the ``kernel_candidates.json`` file.
+
+    Returns:
+        The list of candidate dicts, with trace-report paths backfilled.
     """
     payload = json.loads(path.read_text(encoding="utf-8"))
     if isinstance(payload, list):
@@ -212,7 +226,17 @@ def load_candidates(path: Path) -> list[dict[str, Any]]:
 
 
 def _normalize_kernel_id(value: str) -> str:
-    """Fold hallucinated ``kn``/``rn`` prefixes onto the real ``k`` numbering, lower-cased, for tolerant comparison."""
+    """Normalize a kernel id for tolerant comparison.
+
+    Folds hallucinated ``kn``/``rn`` prefixes onto the real ``k`` numbering and
+    lower-cases the value.
+
+    Args:
+        value: The raw kernel id.
+
+    Returns:
+        The normalized kernel id.
+    """
     s = value.strip().lower()
     for prefix in ("kn", "rn"):
         if s.startswith(prefix) and s[len(prefix):].isdigit():
@@ -223,7 +247,19 @@ def _normalize_kernel_id(value: str) -> str:
 def find_candidate(
     candidates: list[dict[str, Any]], kernel_id: str
 ) -> dict[str, Any] | None:
-    """Resolve a candidate by exact ``kernel_id``, then unique routable ``name``, then normalized id (``kn``/``rn``→``k``); ``None`` if nothing matches (caller skips gracefully)."""
+    """Resolve a candidate by id with progressively looser matching.
+
+    Tries exact ``kernel_id`` first, then a unique routable ``name`` match,
+    then a normalized id (``kn``/``rn`` → ``k``).
+
+    Args:
+        candidates: The candidate dicts to search.
+        kernel_id: The kernel id (or name) to resolve.
+
+    Returns:
+        The matching candidate, or ``None`` when nothing matches (the caller
+        skips gracefully).
+    """
     for candidate in candidates:
         if candidate.get("kernel_id") == kernel_id:
             return candidate
@@ -299,6 +335,15 @@ def _resolve_source_file(
     kernel, e.g. DeepSeek-R1 routed an MHA rewrite at ``fused_moe.py``); a
     differing LLM path emits a ``[source-override]`` warning. Falls back to the
     LLM path when the candidate has no source_file.
+
+    Args:
+        llm_source: The LLM-supplied ``--source-file`` path.
+        candidate: The TraceLens candidate dict (source of truth).
+        kernel_id: The kernel id, used in log messages.
+        log_path: Optional path to append override/fallback notes.
+
+    Returns:
+        The effective source file path to use.
     """
     cand_source = str((candidate or {}).get("source_file") or "").strip()
     llm = str(llm_source or "").strip()
@@ -398,6 +443,13 @@ def _match_benchmark_for_kernel(
     kernel-name regex hoists that family's bench files to the front (earlier
     patterns win). No match preserves the original order. Prevents picking an
     off-topic benchmark (e.g. fmha → test_pa.py stalling GEAK Step-5).
+
+    Args:
+        kernel_name: The kernel name to match patterns against.
+        bench_files: Candidate benchmark file paths.
+
+    Returns:
+        The benchmark paths reordered so the matching family comes first.
     """
     existing = [p for p in (bench_files or []) if isinstance(p, str) and p]
     if not existing:
@@ -434,8 +486,11 @@ def _profile_timeout_sec() -> int:
 
     Injected as a ``timeout <N>`` prefix on the test_command so a default-matrix
     benchmark (e.g. aiter test_pa.py) can't stall Step 5 for hours; SIGTERM at N
-    surfaces as a normal profiling failure. Default 600s, override via
-    ``KERNEL_OPT_PROFILE_TIMEOUT_SEC``, floored at 1.
+    surfaces as a normal profiling failure.
+
+    Returns:
+        The timeout in seconds: 600 by default, overridable via
+        ``KERNEL_OPT_PROFILE_TIMEOUT_SEC``, floored at 1.
     """
     try:
         value = int(os.environ.get("KERNEL_OPT_PROFILE_TIMEOUT_SEC", "600"))
@@ -701,7 +756,15 @@ def _env_target_platform() -> str:
 
 
 def _format_shapes_for_case(shapes: Any) -> str:
-    """Render a candidate row's ``shapes`` field as one comma-joined line."""
+    """Render a candidate row's ``shapes`` field as a comma-joined line.
+
+    Args:
+        shapes: A shapes value (string, list, or list of ``{call_num, shape}``
+            dicts).
+
+    Returns:
+        The rendered single-line shapes string, or empty when none.
+    """
     if not shapes:
         return ""
     if isinstance(shapes, str):
@@ -732,6 +795,13 @@ def _build_captured_shapes_block(candidate: dict[str, Any]) -> str:
     speedup will not translate to an end-to-end gain. Generic: applies to any
     candidate carrying captured shapes; returns ``""`` when none exist so the
     prompt stays byte-identical to legacy in that case.
+
+    Args:
+        candidate: The kernel candidate dict, possibly carrying captured
+            shapes.
+
+    Returns:
+        The captured-shapes prompt block, or ``""`` when no shapes exist.
     """
     shapes = candidate.get("shapes") or candidate.get("kernel_shapes")
     rendered = _format_shapes_for_case(shapes)
@@ -754,7 +824,18 @@ def _build_captured_shapes_block(candidate: dict[str, Any]) -> str:
 def _build_benchmark_cases_block(candidate: dict[str, Any]) -> str:
     """Render the multi-row benchmark cases section for a task_group.
 
-    Falls back to :func:`_build_captured_shapes_block` when ``candidate["task_group"]`` is absent/empty so captured shapes still reach GEAK. With a task_group, emits one bullet per TraceLens row (sorted by aggregate time desc) surfacing operation/args/aggregate_time_ms/percent_e2e/count/per_call_ms/flops_per_byte/efficiency/bound (bound + per_call_ms drive backend dispatch).
+    Falls back to :func:`_build_captured_shapes_block` when
+    ``candidate["task_group"]`` is absent/empty so captured shapes still reach
+    GEAK. With a task_group, emits one bullet per TraceLens row (sorted by
+    aggregate time descending) surfacing operation, args, aggregate time,
+    percent E2E, count, per-call ms, flops/byte, efficiency, and bound (bound +
+    per-call ms drive backend dispatch).
+
+    Args:
+        candidate: The kernel candidate dict, optionally with a ``task_group``.
+
+    Returns:
+        The rendered benchmark-cases prompt block.
     """
     group = candidate.get("task_group")
     rows = group.get("rows") if isinstance(group, dict) else None
@@ -910,7 +991,14 @@ _PRIORITY_BULLETS: dict[str, list[str]] = {
 
 
 def _classify_bound(bound_type: str) -> str:
-    """Map TraceLens ``bound`` strings to one of ``memory`` / ``compute`` / ``unknown``."""
+    """Classify a TraceLens ``bound`` string into a coarse bucket.
+
+    Args:
+        bound_type: The TraceLens bound description.
+
+    Returns:
+        One of ``"memory"``, ``"compute"``, or ``"unknown"``.
+    """
     text = (bound_type or "").lower()
     if "memory" in text or "bandwidth" in text or "hbm" in text:
         return "memory"
@@ -920,9 +1008,16 @@ def _classify_bound(bound_type: str) -> str:
 
 
 def _build_priority_block(candidate: dict[str, Any]) -> str:
-    """Render the bound-keyed optimization priority list (uses the primary row's bound for a task_group).
+    """Render the bound-keyed optimization priority list.
 
-    Empty string when ``bound_type`` is missing and no ``task_group`` is attached.
+    Uses the primary row's bound when the candidate carries a ``task_group``.
+
+    Args:
+        candidate: The kernel candidate dict.
+
+    Returns:
+        The priority-list prompt block, or ``""`` when ``bound_type`` is
+        missing and no ``task_group`` is attached.
     """
     group = candidate.get("task_group")
     bound_type = str(candidate.get("bound_type") or "").strip()
@@ -1002,6 +1097,13 @@ def _build_hypothesis_block(candidate: dict[str, Any]) -> str:
     every P-item's prose under a ``### P{rank}`` header; otherwise a single block.
     The reasoning/resolution prose is labelled a hypothesis to validate (it is
     itself LLM-generated); the numeric impact range is roofline arithmetic.
+
+    Args:
+        candidate: The kernel candidate dict, optionally with a ``task_group``
+            carrying P-item prose.
+
+    Returns:
+        The hypothesis prompt block, or ``""`` when no prose is present.
     """
     # Multi-P-item case (Q2): render every P-item's prose so GEAK sees all framings.
     group = candidate.get("task_group")
@@ -1650,7 +1752,17 @@ def _backends_module_dir() -> Path:
 
 
 def _import_backend(name: str):
-    """Dynamically load kernel-agent/tools/backends/<name>.py (dir added to sys.path so submodules cross-import)."""
+    """Dynamically import a per-backend submitter module.
+
+    The ``backends`` directory is added to ``sys.path`` so its submodules can
+    cross-import each other.
+
+    Args:
+        name: The backend module name (without ``.py``).
+
+    Returns:
+        The imported backend module.
+    """
     backends_dir = _backends_module_dir()
     if str(backends_dir) not in sys.path:
         sys.path.insert(0, str(backends_dir))
@@ -1659,7 +1771,14 @@ def _import_backend(name: str):
 
 
 def _kernel_agent_root() -> Path:
-    """Output root for kernel-agent tools at ``$USER_DATA_PATH/kernel-agent`` (via workspace_root, which warns once when unset)."""
+    """Resolve the kernel-agent tools output root.
+
+    Uses :func:`workspace_root` (which warns once when ``$USER_DATA_PATH`` is
+    unset).
+
+    Returns:
+        The ``$USER_DATA_PATH/kernel-agent`` output root path.
+    """
     return Path(workspace_root()) / "kernel-agent"
 
 
@@ -1731,7 +1850,18 @@ _DEFAULT_GEAK_FALLBACK_TIMEOUT_SEC = 3600
 
 
 def _ensure_yaml_env_timeout(text: str, *, timeout: int = _DEFAULT_GEAK_FALLBACK_TIMEOUT_SEC) -> str:
-    """Inject ``env.timeout`` (default 3600s) if absent; mini-swe-agent defaults to 30s and would kill the test command."""
+    """Ensure the GEAK YAML carries a sufficient ``env.timeout``.
+
+    Injects or raises ``env.timeout`` (default 3600s) because mini-swe-agent
+    defaults to 30s and would kill the test command.
+
+    Args:
+        text: The original GEAK YAML config text.
+        timeout: Desired timeout in seconds (floored at 60).
+
+    Returns:
+        The YAML text with ``env.timeout`` set to at least ``timeout``.
+    """
     timeout = max(60, int(timeout))
     has_env = re.search(r"^env\s*:\s*(?:#.*)?$", text, flags=re.MULTILINE)
     if has_env:
@@ -2196,6 +2326,17 @@ def _update_kernel_roofline_sidecar(
     Even when ``_run_rocprof_roofline`` skipped (e.g. no ``test_command``)
     or failed, we still write a tagged entry so the dashboard can distinguish
     "considered but skipped/failed" from "not yet evaluated" (``null``).
+
+    Args:
+        workspace_path: Workspace root containing ``reports/``.
+        kernel_id: The kernel id whose sidecar entry is updated.
+        rocprof_json_path: Path to the rocprof JSON artifact, if any.
+        rocprof_txt_path: Path to the rocprof text report, if any.
+        log_path: Optional path to append diagnostics.
+        rocprof_status: Status tag to record when no JSON is available.
+        rocprof_reason: Reason tag to record when no JSON is available.
+        phase: Which sub-key to write (``before_kernel_opt`` or
+            ``after_kernel_opt``).
     """
     sidecar_path = Path(workspace_path) / "reports" / "kernel_roofline.json"
     if not sidecar_path.is_file():
@@ -2356,7 +2497,14 @@ def _mirror_path_link(run_dir: Path, mirror: Path) -> None:
 
 
 def _git_checkout_fallback(kernel_repo: str, log_path: Path) -> None:
-    """Best-effort `git checkout -- .` to undo rogue agent writes under the kernel repo. Idempotent."""
+    """Run a best-effort ``git checkout -- .`` to undo rogue agent writes.
+
+    Idempotent and safe to call when the repo has no changes.
+
+    Args:
+        kernel_repo: Path to the kernel repo to clean.
+        log_path: Path to append checkout diagnostics.
+    """
     if not kernel_repo:
         return
     git_dir = Path(kernel_repo) / ".git"
@@ -2847,7 +2995,16 @@ _AUTH_RETRY_THRESHOLD = 3
 
 
 def _count_auth_failures(text: str) -> int:
-    """Count distinct inner-LLM auth-failure markers in *text* (distinguishes a transient 401 from an unrecoverable loop)."""
+    """Count inner-LLM auth-failure markers in captured text.
+
+    Distinguishes a transient 401 from an unrecoverable loop.
+
+    Args:
+        text: The captured backend output to scan.
+
+    Returns:
+        The number of auth-failure markers found.
+    """
     if not text:
         return 0
     total = 0
@@ -2857,7 +3014,17 @@ def _count_auth_failures(text: str) -> int:
 
 
 def _extract_speedup_from_report(report_path: str | Path) -> float | None:
-    """Best-effort scan of an OOB optimization_report.md for a speedup figure (median-of-top-3; None if absent)."""
+    """Scan an OOB ``optimization_report.md`` for a speedup figure.
+
+    Uses a median-of-top-3 to dodge cherry-picked best-shape numbers.
+
+    Args:
+        report_path: Path to the optimization report.
+
+    Returns:
+        The estimated speedup, or ``None`` when the report is missing or no
+        plausible figure is found.
+    """
     if not report_path:
         return None
     p = Path(report_path)
@@ -2963,6 +3130,10 @@ def _trust_geak_correctness() -> bool:
     GEAK's save_and_test only checks compile + import, not numerical output, so without this
     every GEAK KEEP would degrade to NEEDS_REVIEW; integrate's E2E magpie benchmark is the
     ground-truth check. Set ``HYPERLOOM_TRUST_GEAK_CORRECTNESS=0`` to restore the conservative behaviour.
+
+    Returns:
+        ``True`` when GEAK correctness should be trusted (the default),
+        ``False`` when the env var disables it.
     """
     raw = os.environ.get("HYPERLOOM_TRUST_GEAK_CORRECTNESS", "").strip().lower()
     if raw in {"0", "false", "no", "off"}:
@@ -3122,9 +3293,17 @@ def _extract_source_block(text_path: Path, target_suffix: str, output_path: Path
 
 
 def _geak_best_worktree(best_patch_path: str) -> Path | None:
-    """Map a GEAK best-patch file path to the ``worktrees/slot_<M>`` it edited (shares ``parallel_<M>``'s suffix).
+    """Map a GEAK best-patch path to the ``worktrees/slot_<M>`` it edited.
 
-    Lets callers pick up the real source file instead of scraping a diff; ``None`` on layout mismatch.
+    The slot shares the ``parallel_<M>`` suffix, letting callers pick up the
+    real source file instead of scraping a diff.
+
+    Args:
+        best_patch_path: Path to the GEAK best-patch file.
+
+    Returns:
+        The corresponding ``worktrees/slot_<M>`` path, or ``None`` on layout
+        mismatch.
     """
     if not best_patch_path:
         return None
@@ -3147,10 +3326,18 @@ def _worktree_source_paths(
     source_file: str,
     kernel_repo: str,
 ) -> list[Path]:
-    """Return existing files under ``worktree`` mirroring ``source_file``.
+    """Find existing files under a worktree mirroring a source file.
 
-    Tries source_file relative to kernel_repo first, then a basename rglob within
-    the worktree. Empty list when nothing matches.
+    Tries ``source_file`` relative to ``kernel_repo`` first, then a basename
+    rglob within the worktree.
+
+    Args:
+        worktree: The worktree directory to search.
+        source_file: The source file path to mirror.
+        kernel_repo: The kernel repo root used for relative resolution.
+
+    Returns:
+        Matching paths under the worktree, or an empty list when none match.
     """
     if not worktree.is_dir() or not source_file:
         return []

--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -810,7 +810,14 @@ _SHAPE_ARG_RE = re.compile(
 
 
 def _split_shape_fragments(shape_text: Any) -> list[str]:
-    """Split TraceLens ``Args`` text into per-argument shape fragments."""
+    """Split TraceLens ``Args`` text into per-argument shape fragments.
+
+    Args:
+        shape_text: The raw TraceLens ``Args`` text (any type; coerced to str).
+
+    Returns:
+        The non-empty per-argument shape fragments.
+    """
     text = str(shape_text or "").strip()
     if not text:
         return []
@@ -822,7 +829,16 @@ def _split_shape_fragments(shape_text: Any) -> list[str]:
 
 
 def _parse_shape_arg(raw: Any, *, index: int) -> dict[str, Any]:
-    """Parse one shape fragment such as ``(15360,8,768) bf16``."""
+    """Parse one shape fragment such as ``(15360,8,768) bf16``.
+
+    Args:
+        raw: The raw shape fragment text (any type; coerced to str).
+        index: The argument index recorded on the parsed result.
+
+    Returns:
+        A dict with ``index`` / ``raw`` and, when parseable, ``shape`` (dims)
+        and ``dtype``.
+    """
     text = str(raw or "").strip()
     out: dict[str, Any] = {"index": index, "raw": text}
     match = _SHAPE_ARG_RE.match(text)
@@ -852,7 +868,17 @@ def _shape_case_from_value(
     call_count: Any = None,
     primary: bool = False,
 ) -> dict[str, Any]:
-    """Build one structured benchmark shape case from TraceLens shape data."""
+    """Build one structured benchmark shape case from TraceLens shape data.
+
+    Args:
+        value: The shape data (dict, list/tuple, or scalar) to convert.
+        call_count: Fallback call count when the value carries none.
+        primary: Whether this case is the primary benchmark case.
+
+    Returns:
+        A shape-case dict with ``primary`` / ``call_count`` / ``raw`` / ``args``
+        keys.
+    """
     if isinstance(value, dict):
         structured_args = value.get("args")
         raw_shape = value.get("shape") or value.get("Args") or value.get("args") or ""
@@ -896,7 +922,15 @@ def _shape_case_from_value(
 
 
 def _safe_float(value: Any, default: float = 0.0) -> float:
-    """Coerce a TraceLens numeric field, returning ``default`` on drift."""
+    """Coerce a TraceLens numeric field, returning ``default`` on drift.
+
+    Args:
+        value: The value to coerce to ``float``.
+        default: Fallback returned when ``value`` cannot be parsed.
+
+    Returns:
+        The parsed float, or ``default`` on any failure.
+    """
     try:
         return float(value)
     except (TypeError, ValueError):
@@ -904,7 +938,16 @@ def _safe_float(value: Any, default: float = 0.0) -> float:
 
 
 def _structured_benchmark_shape_cases(candidate: dict[str, Any]) -> dict[str, Any]:
-    """Expose primary/supplementary serving shapes in machine-readable form."""
+    """Expose primary/supplementary serving shapes in machine-readable form.
+
+    Args:
+        candidate: The kernel candidate dict, possibly carrying a
+            ``task_group`` or ``input_shapes``.
+
+    Returns:
+        A dict with ``primary_shape`` and ``supplementary_shapes``, or ``{}``
+        when no usable shapes are present.
+    """
     group = candidate.get("task_group")
     rows = group.get("rows") if isinstance(group, dict) else None
     cases: list[dict[str, Any]] = []

--- a/kernel-agent/tools/parallel_e2e_runner.py
+++ b/kernel-agent/tools/parallel_e2e_runner.py
@@ -266,6 +266,24 @@ def run_one_attempt(
     harness_path: str,
     num_gpus: int = 1,
 ) -> dict[str, Any]:
+    """Run a single backend/replica kernel-optimization attempt.
+
+    Args:
+        backend: Backend name to run (e.g. ``geak`` / ``oob``).
+        replica: Replica index within the backend's parallel fan-out.
+        gpu_id: Logical GPU id assigned to this attempt (informational; Ray
+            sets the visible-device env vars in workers).
+        args: Parsed CLI arguments for the run.
+        run_dir: Per-run output directory.
+        env: Base environment to extend for the child process.
+        kernel_id: Identifier of the kernel being optimized.
+        source_file: Path to the kernel source file.
+        harness_path: Path to the benchmark/validation harness.
+        num_gpus: Number of GPUs allotted to this attempt.
+
+    Returns:
+        A result dict describing the attempt's outcome and artifact paths.
+    """
     # Do NOT set HIP/ROCR/CUDA_VISIBLE_DEVICES here; Ray assigns them in workers.
     local_env = {
         **env,

--- a/kernel-agent/tools/rocprof_roofline.py
+++ b/kernel-agent/tools/rocprof_roofline.py
@@ -499,7 +499,15 @@ def _kernel_name_matches(row: dict[str, Any], target_kernel: str) -> bool:
 
 
 def _project_payload_to_row(payload: dict[str, Any], target_kernel: str = "") -> dict[str, Any]:
-    """Project the row that matches ``target_kernel`` into ``kernel_roofline.json``."""
+    """Project the matching result row into a ``kernel_roofline.json`` row.
+
+    Args:
+        payload: The rocprof roofline payload with a ``results`` list.
+        target_kernel: Kernel name to match; empty selects the first row.
+
+    Returns:
+        The projected roofline row, or a status dict when no row matches.
+    """
     rows = payload.get("results") if isinstance(payload, dict) else None
     if not isinstance(rows, list) or not rows:
         return {"status": payload.get("status", "failed") if isinstance(payload, dict) else "failed"}
@@ -537,10 +545,19 @@ def _generate_harness_for_candidate(
     out_dir: Path,
     log_fn: Any,
 ) -> tuple[str, str | None]:
-    """Best-effort harness generation for a TraceLens hot-kernel candidate.
+    """Generate a benchmark harness for a TraceLens hot-kernel candidate.
 
-    Returns ``(test_command, error)``. ``test_command`` is empty when no
-    benchmark file resolves; the caller should mark the row as skipped.
+    Best-effort: returns an empty command rather than raising when no
+    benchmark file resolves.
+
+    Args:
+        candidate: The hot-kernel candidate metadata.
+        out_dir: Directory to write the generated harness into.
+        log_fn: Logging callable for progress/diagnostics.
+
+    Returns:
+        A ``(test_command, error)`` tuple. ``test_command`` is empty when no
+        benchmark file resolves and ``error`` names the reason.
     """
     bench_files = candidate.get("benchmark_files") or []
     if not isinstance(bench_files, list) or not bench_files:
@@ -626,7 +643,17 @@ def enrich_kernel_roofline_sidecar(
       this row was considered (vs. silently ``null``).
     * Per-kernel rocprof timeout / failure marks the row ``status='failed'``
       but never aborts enrichment of remaining rows.
-    * Returns a small summary suitable for caller logging.
+
+    Args:
+        sidecar_path: Path to the ``kernel_roofline.json`` sidecar to update.
+        candidates_path: Path to the candidates JSON to read kernels from.
+        workdir: Optional working directory for profiling.
+        timeout_sec_per_kernel: Per-kernel rocprof timeout in seconds.
+        log_fn: Optional logging callable.
+
+    Returns:
+        A summary dict with ``matched``, ``skipped``, ``failed``, and ``rows``
+        counts suitable for caller logging.
     """
     sidecar_p = Path(sidecar_path).expanduser()
     cand_p = Path(candidates_path).expanduser()

--- a/kernel-agent/tools/rocprof_roofline.py
+++ b/kernel-agent/tools/rocprof_roofline.py
@@ -29,6 +29,14 @@ SATURATION_PCT = 60.0
 
 
 def _safe_float(value: str) -> float | None:
+    """Parse a string to float, returning ``None`` on failure.
+
+    Args:
+        value: String to convert.
+
+    Returns:
+        The parsed float, or ``None`` when ``value`` is not numeric.
+    """
     try:
         return float(value)
     except (TypeError, ValueError):
@@ -36,6 +44,14 @@ def _safe_float(value: str) -> float | None:
 
 
 def _bound_type(bound: str) -> str:
+    """Classify a roofline bound description into a short category.
+
+    Args:
+        bound: Free-form bound text (e.g. ``"memory-bound ..."``).
+
+    Returns:
+        One of ``"memory"``, ``"compute"``, ``"latency"``, or ``"unknown"``.
+    """
     lower = (bound or "").lower()
     if lower.startswith("memory-bound"):
         return "memory"
@@ -47,6 +63,14 @@ def _bound_type(bound: str) -> str:
 
 
 def _resolve_rocprof_compute() -> str | None:
+    """Locate the ``rocprof-compute`` executable.
+
+    Checks the ``HYPERLOOM_ROCPROF_COMPUTE_PATH`` / ``ROCPROF_COMPUTE_PATH``
+    environment variables, then ``PATH``, then the default ROCm install path.
+
+    Returns:
+        The resolved executable path, or ``None`` when not found.
+    """
     configured = (
         os.environ.get("HYPERLOOM_ROCPROF_COMPUTE_PATH", "").strip()
         or os.environ.get("ROCPROF_COMPUTE_PATH", "").strip()
@@ -65,6 +89,12 @@ def _resolve_rocprof_compute() -> str | None:
 
 
 def _check_rocprof_compute() -> str | None:
+    """Verify ``rocprof-compute`` runs and report its version.
+
+    Returns:
+        The detected version string (``"unknown"`` if unparsable), or ``None``
+        when the tool is missing or ``--version`` fails.
+    """
     tool = _resolve_rocprof_compute()
     if not tool:
         return None
@@ -85,10 +115,22 @@ class RocprofRooflineAnalyzer:
     """Small parser around rocprof-compute section 4 roofline output."""
 
     def __init__(self, output_path: str | Path | None = None):
+        """Initialize the analyzer.
+
+        Args:
+            output_path: Directory for rocprof-compute output; a temporary
+                directory is created when omitted.
+        """
         self.output_path = Path(output_path or tempfile.mkdtemp(prefix="rocprof_roofline_")).resolve()
         self.content = ""
 
     def parse_roofline_blocks(self) -> list[tuple[str, dict[str, tuple[float, float, str]]]]:
+        """Parse section 4.1 roofline rate metrics from the analyze output.
+
+        Returns:
+            A list of ``(kernel_name, rates)`` tuples, where ``rates`` maps a
+            metric name to ``(actual, peak, unit)``.
+        """
         blocks: list[tuple[str, dict[str, tuple[float, float, str]]]] = []
         current_name = "Unknown"
         rates: dict[str, tuple[float, float, str]] = {}
@@ -125,6 +167,13 @@ class RocprofRooflineAnalyzer:
         return blocks
 
     def parse_roofline_ai(self) -> list[dict[str, tuple[float, str]]]:
+        """Parse section 4.2 roofline AI plot points from the analyze output.
+
+        Returns:
+            A per-kernel list of metric maps, each mapping an AI/performance
+            metric name to ``(value, unit)`` (performance is normalized to
+            TFLOPS).
+        """
         out: list[dict[str, tuple[float, str]]] = []
         metrics: dict[str, tuple[float, str]] = {}
         in_section = False
@@ -160,6 +209,11 @@ class RocprofRooflineAnalyzer:
         return out
 
     def parse_real_hbm_peak(self) -> float | None:
+        """Extract the measured (real) HBM peak bandwidth from the output.
+
+        Returns:
+            The real HBM peak bandwidth in GB/s, or ``None`` when not present.
+        """
         for line in self.content.splitlines():
             if "│" in line and "17.1.5" in line:
                 parts = [p.strip() for p in line.split("│")]
@@ -182,6 +236,20 @@ class RocprofRooflineAnalyzer:
         ai_metrics: dict[str, tuple[float, str]],
         real_hbm_peak: float | None,
     ) -> dict[str, Any]:
+        """Compute roofline efficiency and bottleneck classification.
+
+        Args:
+            rates: Section 4.1 rate metrics mapping name to
+                ``(actual, peak, unit)``.
+            ai_metrics: Section 4.2 AI metrics mapping name to ``(value, unit)``.
+            real_hbm_peak: Measured HBM peak bandwidth, or ``None`` to fall
+                back to the empirical peak.
+
+        Returns:
+            A dict of derived metrics including the bound description and type,
+            compute/bandwidth utilization, arithmetic intensity, and roofline
+            efficiency against both empirical and real peaks.
+        """
         hbm_actual = hbm_emp_peak = None
         if "HBM Bandwidth" in rates:
             hbm_actual, hbm_emp_peak, _ = rates["HBM Bandwidth"]
@@ -250,6 +318,12 @@ class RocprofRooflineAnalyzer:
         }
 
     def analyze_structured(self) -> dict[str, Any]:
+        """Parse the analyze output into a structured per-kernel result.
+
+        Returns:
+            A dict with ``schema_version``, ``source``, ``real_hbm_peak``, and
+            a ``results`` list of per-kernel roofline records.
+        """
         blocks = self.parse_roofline_blocks()
         ai_list = self.parse_roofline_ai()
         real_hbm_peak = self.parse_real_hbm_peak()
@@ -282,6 +356,22 @@ class RocprofRooflineAnalyzer:
         analyze_blocks: str = "0 1 2 4 7 10 11 16 17",
         timeout_sec: int = 21600,
     ) -> tuple[bool, str | None]:
+        """Profile and analyze a command with rocprof-compute.
+
+        Runs ``rocprof-compute profile`` followed by ``analyze``, storing the
+        analyze text on ``self.content``.
+
+        Args:
+            workdir: Working directory in which to run the command.
+            cmd: Benchmark command to profile.
+            target_kernel: Optional kernel name filter.
+            analyze_blocks: Space-separated analyze block ids to request.
+            timeout_sec: Timeout applied to each subprocess.
+
+        Returns:
+            A ``(success, error)`` tuple; ``error`` carries the captured output
+            on failure and is ``None`` on success.
+        """
         tool = _resolve_rocprof_compute()
         if tool is None:
             return False, "rocprof-compute is not installed or not on PATH"
@@ -324,6 +414,15 @@ class RocprofRooflineAnalyzer:
 
 
 def recommended_actions(bound_type: str) -> list[str]:
+    """Return suggested optimization actions for a bottleneck type.
+
+    Args:
+        bound_type: Bottleneck category (``memory`` / ``compute`` / ``latency``).
+
+    Returns:
+        A list of human-readable optimization suggestions (empty for unknown
+        types).
+    """
     if bound_type == "memory":
         return ["Improve memory coalescing/locality", "Increase arithmetic intensity", "Use LDS/cache tiling when applicable"]
     if bound_type == "compute":
@@ -334,6 +433,14 @@ def recommended_actions(bound_type: str) -> list[str]:
 
 
 def build_text_report(payload: dict[str, Any]) -> str:
+    """Render a structured roofline payload into a human-readable report.
+
+    Args:
+        payload: Structured payload from :meth:`RocprofRooflineAnalyzer.analyze_structured`.
+
+    Returns:
+        A multi-line text report summarizing each kernel's roofline metrics.
+    """
     lines = ["Below is the rocprof-compute roofline information of the kernel:"]
     for row in payload.get("results", []):
         roof = row.get("rocprof_roofline") or {}
@@ -357,6 +464,12 @@ def build_text_report(payload: dict[str, Any]) -> str:
 
 
 def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
+    """Write JSON to ``path`` atomically via a temp file and rename.
+
+    Args:
+        path: Destination file path.
+        data: JSON-serializable data to write.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.NamedTemporaryFile("w", dir=str(path.parent), delete=False) as tmp:
         json.dump(data, tmp, indent=2, sort_keys=True)
@@ -366,6 +479,15 @@ def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
 
 
 def _kernel_name_matches(row: dict[str, Any], target_kernel: str) -> bool:
+    """Return whether a result row matches the target kernel name.
+
+    Args:
+        row: A result row with ``matched_kernel_name`` / ``name`` fields.
+        target_kernel: Kernel name to match; an empty value matches any row.
+
+    Returns:
+        ``True`` if the row corresponds to ``target_kernel``.
+    """
     if not target_kernel:
         return True
     target = target_kernel.strip()
@@ -464,6 +586,16 @@ def _generate_harness_for_candidate(
 
 
 def _profile_workdir(candidate: dict[str, Any], fallback: Path) -> Path:
+    """Pick a working directory for profiling a candidate kernel.
+
+    Args:
+        candidate: Candidate metadata with ``kernel_repo`` / ``source_file``.
+        fallback: Directory to use when no candidate path resolves.
+
+    Returns:
+        The first existing directory derived from the candidate paths, else
+        ``fallback``.
+    """
     for raw in (candidate.get("kernel_repo"), candidate.get("source_file")):
         if not raw:
             continue
@@ -529,6 +661,11 @@ def enrich_kernel_roofline_sidecar(
     fallback_workdir = Path(workdir).expanduser() if workdir else sidecar_p.parent
 
     def _log(msg: str) -> None:
+        """Forward a message to ``log_fn`` if one was provided.
+
+        Args:
+            msg: Message to log; sink errors are swallowed.
+        """
         if callable(log_fn):
             try:
                 log_fn(msg)
@@ -653,6 +790,14 @@ def enrich_kernel_roofline_sidecar(
 
 
 def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: profile a command and write roofline JSON/text.
+
+    Args:
+        argv: Argument list to parse; defaults to ``sys.argv`` when ``None``.
+
+    Returns:
+        Process exit code: ``0`` on success, ``1`` when profiling fails.
+    """
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--workdir", required=True)
     parser.add_argument("--cmd", required=True)

--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -2273,7 +2273,16 @@ _RANK_PCT_KEYS = (
 
 
 def _coerce_float(value: Any) -> float | None:
-    """Parse a CSV/JSON cell to float (strips ``%`` / commas); ``None`` if not numeric."""
+    """Parse a CSV/JSON cell into a float.
+
+    Strips a trailing ``%`` and comma thousands separators.
+
+    Args:
+        value: The raw cell value.
+
+    Returns:
+        The parsed float, or ``None`` when not numeric.
+    """
     if isinstance(value, bool):
         return None
     if isinstance(value, (int, float)):
@@ -2322,6 +2331,12 @@ def _clean_category_label(raw: str) -> str:
     The real ``ops_summary.csv`` stores the category as a Python list-repr
     string, e.g. ``['MoE_fused']`` or ``['GEMM', 'Reduce']`` — return the first
     element (``MoE_fused`` / ``GEMM``). Plain labels pass through unchanged.
+
+    Args:
+        raw: The raw category cell value.
+
+    Returns:
+        The bare category label.
     """
     s = str(raw or "").strip()
     if s.startswith("[") and s.endswith("]"):
@@ -2337,7 +2352,14 @@ def _clean_category_label(raw: str) -> str:
 
 
 def _record_gpu_us(low: dict[str, Any]) -> float | None:
-    """Best-effort GPU time in microseconds from a per-op ranking record."""
+    """Extract GPU time in microseconds from a per-op ranking record.
+
+    Args:
+        low: A per-op ranking record with lower-cased keys.
+
+    Returns:
+        The GPU time in microseconds, or ``None`` when no time field resolves.
+    """
     for k in _RANK_TIME_MS_KEYS:
         if k in low:
             val = _coerce_float(low[k])
@@ -2470,9 +2492,16 @@ def load_ops_ranking(
 
     Returns ``[{name, category, gpu_us, gpu_pct}]`` from the first sidecar that
     yields rows (ops_summary.csv / unified_perf_summary.csv /
-    priority_data.json, under the output dir or its ``perf_report_csvs/``);
-    ``[]`` when none is present/parseable. Used only by the ``other``-bucket
-    recovery fallback — the contracted candidate source remains analysis.md.
+    priority_data.json, under the output dir or its ``perf_report_csvs/``).
+    Used only by the ``other``-bucket recovery fallback — the contracted
+    candidate source remains analysis.md.
+
+    Args:
+        skill_output_dir: The TraceLens skill output directory to scan.
+
+    Returns:
+        A list of ``{name, category, gpu_us, gpu_pct}`` rows, or ``[]`` when no
+        sidecar is present or parseable.
     """
     if not skill_output_dir:
         return []
@@ -2545,10 +2574,19 @@ def recover_other_bucket_candidates(
     the recovery net does not route non-patchable kernels to GEAK.
 
     Fires for ops that are (a) absent from ``existing_candidates`` by name and
-    (b) at or above ``min_gpu_pct`` of total GPU time (env
-    ``HYPERLOOM_OTHER_BUCKET_MIN_GPU_PCT``, default 10%). Returns ``[]`` when no
-    sidecar is available or nothing qualifies, so analysis.md stays the primary
-    source.
+    (b) at or above ``min_gpu_pct`` of total GPU time.
+
+    Args:
+        skill_output_dir: The TraceLens skill output directory to scan.
+        existing_candidates: Candidates already extracted from analysis.md.
+        top_k: Maximum number of recovered candidates to return.
+        min_gpu_pct: Minimum GPU-time percentage to qualify; defaults to the
+            ``HYPERLOOM_OTHER_BUCKET_MIN_GPU_PCT`` env value (10%).
+        log: Optional logging callable for diagnostics.
+
+    Returns:
+        The recovered candidate dicts, or ``[]`` when no sidecar is available
+        or nothing qualifies (so analysis.md stays primary).
     """
     ranking = load_ops_ranking(skill_output_dir)
     if not ranking:
@@ -2628,9 +2666,21 @@ def _finalize_candidates(
     top: list[dict[str, Any]], *, total_dur: float | None = None,
     perf_report_csv_dir: Path | str | None = None,
 ) -> list[dict[str, Any]]:
-    """Shared post-processing for parsed candidate rows (source resolution / pybind upgrade / backend recommend / notes); mutates ``top`` in place.
+    """Apply shared post-processing to parsed candidate rows.
 
-    When ``perf_report_csv_dir`` is given, populates each item's ``tracelens_category`` from the CSV.
+    Resolves source files, promotes pybind/launcher shims, recommends
+    backends, classifies patchability, and attaches notes; mutates ``top`` in
+    place.
+
+    Args:
+        top: The parsed candidate rows to finalize (mutated in place).
+        total_dur: Total GPU duration for percentage computation; summed from
+            ``top`` when omitted.
+        perf_report_csv_dir: Optional CSV directory used to populate each
+            item's ``tracelens_category``.
+
+    Returns:
+        The finalized candidate list (the same ``top`` object).
     """
     op_cat_map = (
         load_op_category_map(perf_report_csv_dir)
@@ -2724,9 +2774,16 @@ def _finalize_candidates(
 
 
 def recommend_backends(candidate: dict[str, Any]) -> list[str]:
-    """Recommend a backend ladder (GEAK first, then claude/codex) for a reusable native kernel.
+    """Recommend a backend ladder for a reusable native kernel.
 
-    Returns ``[]`` for unresolved source, non-reusable, vendor-binary, or runtime-generated kernels.
+    Orders GEAK first, then claude/codex.
+
+    Args:
+        candidate: The hot-kernel candidate dict.
+
+    Returns:
+        The recommended backend names, or ``[]`` for unresolved source,
+        non-reusable, vendor-binary, or runtime-generated kernels.
     """
     source_type = candidate.get("source_type")
     if not candidate.get("source_file"):
@@ -2965,7 +3022,22 @@ def build_kernel_roofline_payload(
     roofline_json_path: str,
     candidates: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    """Build the per-kernel roofline sidecar (a view over candidates + optional --roofline-json; missing counters stay null)."""
+    """Build the per-kernel roofline sidecar payload.
+
+    A view over the candidates plus an optional ``--roofline-json``; missing
+    counters stay null.
+
+    Args:
+        trace_input: The trace input path recorded in the payload.
+        trace_input_type: Whether ``trace_input`` is a file or capture dir.
+        analysis_md_path: Path to the source analysis report.
+        kernel_candidates_path: Path to the candidates JSON.
+        roofline_json_path: Optional path to an external roofline JSON.
+        candidates: The finalized hot-kernel candidate rows.
+
+    Returns:
+        The kernel-roofline sidecar payload dict.
+    """
     rows = [
         _kernel_roofline_row(candidate)
         for candidate in candidates
@@ -2988,6 +3060,12 @@ def kernel_roofline_path_for_run(run_dir: Path) -> Path:
 
     PR-C layout is ``.../runs/<session_id>/<ts>_<run_id>/``; the pre-PR-C
     ``.../runs/<session_id>/`` layout is still handled by the fallback branch.
+
+    Args:
+        run_dir: The ``runs/<session_id>/`` root for the session.
+
+    Returns:
+        The stable session-level kernel roofline report path.
     """
     try:
         # PR-C layout: .../runs/<session_id>/<ts>_<run_id>/
@@ -3108,7 +3186,15 @@ _FLYDSL_BUFFER_LOAD_MARKERS = (
 
 
 def _resolve_flydsl_source_fallback() -> str:
-    """Resolve the real FlyDSL MoE kernel source ($DSL2_ROOT/kernels/moe_gemm_2stage.py) for synthetic PR #668 pseudo-ops; first existing path or ""."""
+    """Resolve the real FlyDSL MoE kernel source for synthetic pseudo-ops.
+
+    Used for PR #668 pseudo-ops, looking for
+    ``$DSL2_ROOT/kernels/moe_gemm_2stage.py`` and known fallback roots.
+
+    Returns:
+        The first existing FlyDSL MoE kernel source path, or ``""`` when none
+        exists.
+    """
     roots = [
         os.environ.get("DSL2_ROOT", "").strip(),
         os.environ.get("FLYDSL_ROOT", "").strip(),
@@ -3127,7 +3213,18 @@ def _resolve_flydsl_source_fallback() -> str:
 def _flydsl_kernel_params(
     source_file: str, target_platform: str,
 ) -> dict[str, Any]:
-    """Return FlyDSL-specific kernel_params (target arch, JIT cache state, smem/buffer-load usage); best-effort, never raises."""
+    """Build FlyDSL-specific kernel params.
+
+    Captures target arch, JIT cache state, and smem/buffer-load usage;
+    best-effort and never raises.
+
+    Args:
+        source_file: The FlyDSL kernel source path.
+        target_platform: The target GPU platform name.
+
+    Returns:
+        The FlyDSL kernel-params dict (possibly partial).
+    """
     params: dict[str, Any] = {}
     arch = _FLYDSL_TARGET_ARCH_BY_PLATFORM.get(
         (target_platform or "").strip().lower(),
@@ -3227,10 +3324,18 @@ def build_task_groups(
     *,
     source_root: Path | str | None = None,
 ) -> list[dict[str, Any]]:
-    """Aggregate reusable candidates by AST-resolved source function (wrapper over aggregate_by_source_function).
+    """Aggregate reusable candidates by AST-resolved source function.
 
-    Only reusable_native_kernel candidates are grouped. Returns ``[]`` when none carries a
-    parseable launcher path, so callers fall through to per-kernel dispatch.
+    A wrapper over :func:`aggregate_by_source_function`; only
+    ``reusable_native_kernel`` candidates are grouped.
+
+    Args:
+        candidates: The hot-kernel candidate rows.
+        source_root: Optional root to resolve relative source paths against.
+
+    Returns:
+        The task-group dicts, or ``[]`` when none carries a parseable launcher
+        path (callers fall through to per-kernel dispatch).
     """
     reusable = [c for c in candidates if isinstance(c, dict) and c.get("reusable_native_kernel")]
     if not reusable:
@@ -3247,7 +3352,22 @@ def build_audit_summary(
     task_groups: list[dict[str, Any]] | None = None,
     trace_health_warnings: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
-    """Build the ``tracelens/summary.json`` payload, splitting candidates into routable ``tasks`` and ``skipped`` (each with ``skip_reason``), preserving priority order. Pure function."""
+    """Build the ``tracelens/summary.json`` payload.
+
+    Splits candidates into routable ``tasks`` and ``skipped`` (each with a
+    ``skip_reason``), preserving priority order. Pure function.
+
+    Args:
+        candidates: The hot-kernel candidate rows.
+        trace_input: The trace input path recorded in the summary.
+        framework: Optional framework name recorded in the summary.
+        target_platform: Optional target platform recorded in the summary.
+        task_groups: Optional task-group projections to include.
+        trace_health_warnings: Optional trace-health warnings to include.
+
+    Returns:
+        The ``summary.json`` payload dict.
+    """
     tasks: list[dict[str, Any]] = []
     skipped: list[dict[str, Any]] = []
     for cand in candidates:
@@ -3321,8 +3441,24 @@ def write_reports(
 ) -> dict[str, str]:
     """Write Hyperloom-owned sidecar JSONs and surface the upstream ``analysis.md``.
 
-    ``analysis.md`` is owned by the TraceLens SDK orchestrator and not copied/aliased (#203).
-    Raises ``RuntimeError`` rather than fabricating a report when the orchestrator didn't produce it.
+    ``analysis.md`` is owned by the TraceLens SDK orchestrator and not
+    copied/aliased (#203).
+
+    Args:
+        run_dir: The per-run output directory to write sidecars into.
+        trace_input_type: Whether the trace input is a file or capture dir.
+        trace_files: The resolved trace files for the manifest.
+        candidates: The finalized hot-kernel candidate rows.
+        args: Parsed CLI args carrying model/framework/platform settings.
+        existing_report_path: Optional pre-existing report path to surface.
+        trace_health_warnings: Optional trace-health warnings to record.
+
+    Returns:
+        A mapping of report name to its written/surfaced path.
+
+    Raises:
+        RuntimeError: When the orchestrator did not produce ``analysis.md``
+            (rather than fabricating a report).
     """
     tracelens_dir = run_dir / "tracelens"
     (tracelens_dir / "system_findings").mkdir(parents=True, exist_ok=True)
@@ -3474,6 +3610,9 @@ def _default_workspace_path() -> str:
 
     Fallback order: ``$USER_DATA_PATH``, then legacy ``$WORKSPACE_PATH``, then
     ``_paths.workspace_root()`` (which warns once when ``$USER_DATA_PATH`` is unset).
+
+    Returns:
+        The resolved default workspace path.
     """
     user_data = os.environ.get("USER_DATA_PATH")
     if user_data:

--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -1572,7 +1572,19 @@ def _known_harness_files(name: str, source_file: str) -> list[Path]:
 
 
 def find_benchmark_files(name: str, repo_root: str, source_file: str = "") -> list[str]:
-    """Find test/benchmark files matching the kernel keywords under *repo_root*'s known subdirs (absolute paths)."""
+    """Find test/benchmark files matching a kernel under a repo's subdirs.
+
+    Searches ``repo_root``'s known benchmark/test subdirectories for the
+    kernel keywords, returning absolute paths.
+
+    Args:
+        name: Kernel symbol/name.
+        repo_root: Repo root to search; empty returns only curated harnesses.
+        source_file: Resolved source-file path, used to derive extra keywords.
+
+    Returns:
+        Up to ten matching harness paths, with multi-GPU tests demoted.
+    """
     known = _known_harness_files(name, source_file)
     if not repo_root:
         return [str(p) for p in known[:10]]
@@ -1724,9 +1736,18 @@ def upgrade_aiter_compile_ops_launcher(
 ) -> str:
     """Promote an aiter ``@compile_ops`` Python wrapper to the device ``.cu``.
 
-    Promotes when source_file is a ``.py`` under ``aiter/ops/``, kernel_name matches a
-    :data:`_AITER_COMPILE_OPS_PROMOTIONS` pattern, and the ``.cu`` exists under kernel_repo
-    (or :data:`_AITER_FALLBACK_REPO`). Otherwise returns source_file unchanged.
+    Promotes when source_file is a ``.py`` under ``aiter/ops/``, kernel_name
+    matches a :data:`_AITER_COMPILE_OPS_PROMOTIONS` pattern, and the ``.cu``
+    exists under kernel_repo (or :data:`_AITER_FALLBACK_REPO`).
+
+    Args:
+        source_file: The candidate's resolved source path.
+        kernel_name: The kernel name used for pattern matching.
+        kernel_repo: The resolved kernel repo root.
+
+    Returns:
+        The promoted device ``.cu`` path, or ``source_file`` unchanged when no
+        promotion applies.
     """
     if not source_file or not kernel_name:
         return source_file
@@ -1772,10 +1793,20 @@ def upgrade_aiter_compile_ops_launcher(
 
 def upgrade_pybind_shim_source(source_file: str, kernel_name: str,
                                kernel_repo: str) -> str:
-    """If `source_file` is a tiny pybind11 shim, find the real device .cu/.cuh implementing `kernel_name`.
+    """Promote a tiny pybind11 shim to the real device source.
 
-    Prefers a same-stem file under csrc/py_itfs_cu|kernels|include, then greps the symbol.
-    Returns `source_file` unchanged if no better target is found.
+    When ``source_file`` is a pybind11 shim, finds the ``.cu``/``.cuh``
+    implementing ``kernel_name``, preferring a same-stem file under
+    ``csrc/py_itfs_cu|kernels|include`` before grepping the symbol.
+
+    Args:
+        source_file: The candidate's resolved source path.
+        kernel_name: The kernel name used to locate the device source.
+        kernel_repo: The resolved kernel repo root.
+
+    Returns:
+        The real device source path, or ``source_file`` unchanged when no
+        better target is found.
     """
     if not _is_pybind_shim(source_file):
         return source_file
@@ -1882,7 +1913,14 @@ def _shape_call_entries(shapes: Any, call_num: Any = None) -> list[dict[str, Any
 def derive_kernel_category(candidate: dict[str, Any]) -> str:
     """Map a candidate to its GEAK-facing kernel category (#125).
 
-    Priority: explicit TraceLens category (normalized), then a kernel-name heuristic, then ``unknown``.
+    Priority: explicit TraceLens category (normalized), then a kernel-name
+    heuristic, then ``unknown``.
+
+    Args:
+        candidate: The hot-kernel candidate dict.
+
+    Returns:
+        The GEAK-facing kernel category string.
     """
     cat = (candidate.get("tracelens_category") or "").strip()
     if cat:
@@ -2003,7 +2041,16 @@ def analyze_trace_files(trace_files: list[Path], top_k: int) -> list[dict[str, A
 def load_op_category_map(
     perf_report_csv_dir: Path | str,
 ) -> dict[str, str]:
-    """Read ``{name: raw TraceLens op category}`` from unified_perf_summary.csv (first non-empty per name; ``{}`` when absent)."""
+    """Read a ``{name: raw op category}`` map from the unified perf summary.
+
+    Args:
+        perf_report_csv_dir: Directory containing
+            ``unified_perf_summary.csv``.
+
+    Returns:
+        A mapping of kernel name to its first non-empty TraceLens op category,
+        or ``{}`` when the CSV is absent or unreadable.
+    """
     csv_path = Path(perf_report_csv_dir) / "unified_perf_summary.csv"
     if not csv_path.is_file():
         return {}
@@ -2065,7 +2112,15 @@ _TRACE_DTYPE_SUFFIX = {
 
 
 def _format_trace_shape(dims: Any, dtype: Any) -> str | None:
-    """Render one operand as ``(d0,d1,...) <dtype>`` (matching TraceLens shape strings); ``None`` for scalar/empty operands."""
+    """Render one operand as a TraceLens-style ``(d0,d1,...) <dtype>`` string.
+
+    Args:
+        dims: The operand dimensions (list/tuple of ints).
+        dtype: The operand dtype token.
+
+    Returns:
+        The formatted shape string, or ``None`` for scalar/empty operands.
+    """
     if not isinstance(dims, (list, tuple)) or not dims:
         return None
     try:
@@ -2085,8 +2140,15 @@ def resolve_fused_moe_shapes_from_csv(
     Reads each per-shape row whose op name embeds ``invoke_fused_moe_kernel`` and
     parses its ``Input Dims`` / ``Input type`` tuple-of-tuples into TraceLens-style
     shape strings (e.g. ``(15360,2048) bf16``), deduped across rows in first-seen
-    order. Returns ``[]`` when the sidecar is absent or carries no fused-MoE rows
-    (so callers leave the candidate's empty ``shapes`` untouched).
+    order.
+
+    Args:
+        perf_report_csv_dir: Directory containing ``ops_unique_args.csv``.
+
+    Returns:
+        The recovered operand shape strings, or ``[]`` when the sidecar is
+        absent or carries no fused-MoE rows (callers then leave the
+        candidate's empty ``shapes`` untouched).
     """
     if not perf_report_csv_dir:
         return []
@@ -2122,7 +2184,16 @@ def resolve_fused_moe_shapes_from_csv(
 
 
 def _is_fused_moe_candidate(item: dict[str, Any]) -> bool:
-    """True for the Triton fused-MoE expert-kernel candidate (by op name or moe_fused category)."""
+    """Detect the Triton fused-MoE expert-kernel candidate.
+
+    Matches by op name or the ``moe_fused`` category.
+
+    Args:
+        item: The candidate dict to test.
+
+    Returns:
+        ``True`` when the candidate is the fused-MoE expert kernel.
+    """
     name = str(item.get("name") or "").lower()
     if _FUSED_MOE_KERNEL_MARKER in name:
         return True

--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -2054,10 +2054,27 @@ def _coerce_float(value: Any) -> float | None:
 
 
 def _lower_keyed(row: dict) -> dict[str, Any]:
+    """Return a copy of ``row`` with keys trimmed and lower-cased.
+
+    Args:
+        row: Source mapping (e.g. a CSV/JSON record).
+
+    Returns:
+        A new dict keyed by the normalized column names.
+    """
     return {str(k).strip().lower(): v for k, v in row.items()}
 
 
 def _first_present(low: dict[str, Any], keys: tuple[str, ...]) -> str:
+    """Return the first non-empty value among candidate keys.
+
+    Args:
+        low: Lower-keyed record to read from.
+        keys: Candidate keys, in priority order.
+
+    Returns:
+        The first present, non-empty value as a stripped string, or ``""``.
+    """
     for k in keys:
         v = low.get(k)
         if v is not None and str(v).strip():
@@ -2101,6 +2118,14 @@ def _record_gpu_us(low: dict[str, Any]) -> float | None:
 
 
 def _record_gpu_pct(low: dict[str, Any]) -> float | None:
+    """Extract the GPU-time percentage from a per-op ranking record.
+
+    Args:
+        low: Lower-keyed ranking record.
+
+    Returns:
+        The GPU-time percentage, or ``None`` when no recognized key parses.
+    """
     for k in _RANK_PCT_KEYS:
         if k in low:
             val = _coerce_float(low[k])
@@ -2110,6 +2135,15 @@ def _record_gpu_pct(low: dict[str, Any]) -> float | None:
 
 
 def _ranking_record(raw: dict) -> dict[str, Any] | None:
+    """Normalize a raw ranking row into a standard candidate record.
+
+    Args:
+        raw: Raw CSV/JSON ranking row.
+
+    Returns:
+        A dict with ``name``, ``category``, ``gpu_us``, and ``gpu_pct``, or
+        ``None`` when the row has no usable op name.
+    """
     low = _lower_keyed(raw)
     name = _first_present(low, _RANK_NAME_KEYS)
     if not name:
@@ -2123,6 +2157,15 @@ def _ranking_record(raw: dict) -> dict[str, Any] | None:
 
 
 def _load_ops_ranking_csv(path: Path) -> list[dict[str, Any]]:
+    """Load per-op ranking records from a CSV sidecar.
+
+    Args:
+        path: Path to the CSV file.
+
+    Returns:
+        Normalized ranking records, or ``[]`` when the file is missing or
+        cannot be read.
+    """
     if not path.is_file():
         return []
     out: list[dict[str, Any]] = []
@@ -2138,6 +2181,17 @@ def _load_ops_ranking_csv(path: Path) -> list[dict[str, Any]]:
 
 
 def _iter_json_ranking_records(data: Any) -> list[dict]:
+    """Extract the list of ranking record dicts from parsed JSON.
+
+    Accepts either a top-level list or a dict containing the records under one
+    of several known keys.
+
+    Args:
+        data: Parsed JSON value.
+
+    Returns:
+        The list of dict records, or ``[]`` when none are found.
+    """
     if isinstance(data, list):
         return [r for r in data if isinstance(r, dict)]
     if isinstance(data, dict):
@@ -2152,6 +2206,15 @@ def _iter_json_ranking_records(data: Any) -> list[dict]:
 
 
 def _load_ops_ranking_json(path: Path) -> list[dict[str, Any]]:
+    """Load per-op ranking records from a JSON sidecar.
+
+    Args:
+        path: Path to the JSON file.
+
+    Returns:
+        Normalized ranking records, or ``[]`` when the file is missing or
+        cannot be parsed.
+    """
     if not path.is_file():
         return []
     try:
@@ -2192,6 +2255,12 @@ def load_ops_ranking(
 
 
 def _resolve_other_bucket_min_gpu_pct() -> float:
+    """Return the minimum GPU-time percentage for other-bucket recovery.
+
+    Returns:
+        The value from ``HYPERLOOM_OTHER_BUCKET_MIN_GPU_PCT`` when set to a
+        valid non-negative number, otherwise the default threshold.
+    """
     raw = os.environ.get(_OTHER_BUCKET_MIN_GPU_PCT_ENV, "").strip()
     if raw:
         val = _coerce_float(raw)
@@ -2201,6 +2270,15 @@ def _resolve_other_bucket_min_gpu_pct() -> float:
 
 
 def _is_other_like_category(category: str) -> bool:
+    """Return whether a category counts as the ``other`` bucket.
+
+    Args:
+        category: Raw or upstream category label.
+
+    Returns:
+        ``True`` if the label (or its normalized upstream form) is an
+        other-like category.
+    """
     raw_l = str(category or "").strip().lower()
     if raw_l in _OTHER_LIKE_CATEGORIES:
         return True
@@ -2254,6 +2332,15 @@ def recover_other_bucket_candidates(
     ) or 0.0
 
     def _pct(rec: dict[str, Any]) -> float | None:
+        """Return a record's GPU-time percentage.
+
+        Args:
+            rec: A ranking record.
+
+        Returns:
+            The explicit ``gpu_pct`` when present, else the share of
+            ``total_us`` derived from ``gpu_us``, else ``None``.
+        """
         if rec.get("gpu_pct") is not None:
             return float(rec["gpu_pct"])
         if total_us > 0 and rec.get("gpu_us") is not None:
@@ -2453,6 +2540,18 @@ def run_command(
     timeout_s: int,
     env: dict[str, str] | None = None,
 ) -> int:
+    """Run a subprocess, tee its output to a log, and return the exit code.
+
+    Args:
+        cmd: Command and arguments to execute.
+        cwd: Working directory, or ``None`` to inherit the current one.
+        log_path: Log file the command line and output are appended to.
+        timeout_s: Subprocess timeout in seconds.
+        env: Optional environment for the child process.
+
+    Returns:
+        The process return code.
+    """
     append_log(log_path, f"$ {' '.join(cmd)}")
     proc = subprocess.run(
         cmd,

--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -71,6 +71,9 @@ def _resolve_idle_pct_threshold() -> float:
     Relaxed from the docx §2 ~20% target to 80% because real SGLang inference traces
     sit structurally at ~50-60% idle (host scheduling + JIT/launch overhead), which the
     20% gate over-suppressed. Pin via ``HYPERLOOM_TRACELENS_IDLE_PCT_THRESHOLD``.
+
+    Returns:
+        The idle-percent gate threshold.
     """
     raw = os.environ.get(HIGH_IDLE_PCT_THRESHOLD_ENV, "").strip()
     if not raw:
@@ -90,6 +93,9 @@ def _resolve_arch_benchmark_timeout_s() -> int:
     Configured via ``TRACELENS_ARCH_BENCHMARK_TIMEOUT_SEC``. Empty, non-numeric,
     or out-of-range values fall back to the 600s floor rather than crashing the
     pipeline with a ``ValueError`` before the microbenchmark runs.
+
+    Returns:
+        The arch microbenchmark timeout in seconds (at least the 600s floor).
     """
     raw = os.environ.get(ARCH_BENCHMARK_TIMEOUT_ENV, "").strip()
     if not raw:
@@ -104,7 +110,18 @@ def _resolve_arch_benchmark_timeout_s() -> int:
 def _build_high_idle_warning(
     *, idle_pct: float, threshold_pct: float, report_path: Path,
 ) -> dict[str, Any]:
-    """Build the ``trace_health_warnings[]`` entry for a high-idle trace (consumed by trace_analyze_handler T4 to route to param optimization)."""
+    """Build the ``trace_health_warnings[]`` entry for a high-idle trace.
+
+    Consumed by ``trace_analyze_handler`` T4 to route to param optimization.
+
+    Args:
+        idle_pct: The measured GPU idle percentage.
+        threshold_pct: The idle-gate threshold that was exceeded.
+        report_path: Path to the source report, recorded in the entry.
+
+    Returns:
+        The structured ``high_gpu_idle_pct`` warning entry.
+    """
     return {
         "code": "high_gpu_idle_pct",
         "severity": "warning",
@@ -178,6 +195,17 @@ def _check_selected_chunk_has_gpu_events(
     returns ``None`` when the chunk carries real GPU work, else a ``steady_state_chunk_empty``
     warning the caller appends and raises on. A data-validity gate, not a reorder — falling
     back to another mode is the operator's call (never a silent swap).
+
+    Args:
+        split_dir: Directory holding the splitter's ``execution_details.csv``.
+        selected_chunk: The chunk file selected by the steady-state mode.
+        mode: The requested ``--steady-state-mode``.
+        available_modes: Mapping of mode to its ``(label, chunks)`` for
+            surfacing non-empty alternatives.
+
+    Returns:
+        ``None`` when the chunk has real GPU work, else a
+        ``steady_state_chunk_empty`` warning dict.
     """
     details_path = split_dir / "execution_details.csv"
     if not details_path.is_file():
@@ -305,7 +333,17 @@ def _resolve_min_busy_ratio() -> float:
 
 
 def _busy_ratio(num_events: float, busy_us: float, dur_us: float) -> float | None:
-    """Return ``busy_us / dur_us`` or ``None`` when undefined (caller defers to N25)."""
+    """Compute the clamped busy ratio for a chunk.
+
+    Args:
+        num_events: GPU event count for the chunk.
+        busy_us: GPU busy duration in microseconds.
+        dur_us: Total chunk duration in microseconds.
+
+    Returns:
+        ``busy_us / dur_us`` clamped to ``[0, 1]``, or ``None`` when undefined
+        (the caller defers to the N25 structural gate).
+    """
     if dur_us <= 0.0 or num_events <= 0:
         return None
     return max(0.0, min(1.0, busy_us / dur_us))
@@ -320,9 +358,19 @@ def _check_selected_chunk_has_gpu_events_quality(
 ) -> "dict[str, Any] | None":
     """Quality gate complementing N25's structural gate.
 
-    ``None`` when the chunk is acceptable (busy_ratio >= threshold), no alternate is
-    materially better, or the CSV/row is absent. Otherwise a ``steady_state_chunk_low_quality``
-    warning (same shape as N25 for the N26 retry path). See the module-level N36 comment.
+    See the module-level N36 comment for the gate's rationale.
+
+    Args:
+        split_dir: Directory holding the splitter's ``execution_details.csv``.
+        selected_chunk: The chunk file selected by the steady-state mode.
+        mode: The requested ``--steady-state-mode``.
+        available_modes: Mapping of mode to its ``(label, chunks)`` for
+            evaluating better alternatives.
+
+    Returns:
+        ``None`` when the chunk is acceptable (busy_ratio >= threshold), no
+        alternate is materially better, or the CSV/row is absent. Otherwise a
+        ``steady_state_chunk_low_quality`` warning dict (same shape as N25).
     """
     details_path = split_dir / "execution_details.csv"
     if not details_path.is_file():
@@ -605,9 +653,17 @@ def open_json(path: Path) -> dict[str, Any]:
 
 
 def count_gpu_kernel_events(trace_file: Path, max_events: int = 1_000_000) -> int:
-    """Count GPU kernel events in a torch_profiler trace (pre-flight check for CPU-only traces).
+    """Count GPU kernel events in a torch_profiler trace.
 
-    Counts only real GPU kernels via :func:`is_kernel_event`, not host-side wrappers.
+    Used as a pre-flight check for CPU-only traces. Counts only real GPU
+    kernels via :func:`is_kernel_event`, not host-side wrappers.
+
+    Args:
+        trace_file: Path to the torch_profiler trace (JSON or ``.gz``).
+        max_events: Early-exit cap on the number of events counted.
+
+    Returns:
+        The GPU kernel event count, or 0 when the trace is unreadable.
     """
     try:
         payload = open_json(trace_file)
@@ -626,7 +682,17 @@ def count_gpu_kernel_events(trace_file: Path, max_events: int = 1_000_000) -> in
 
 
 def _trace_input_sort_key(path: Path) -> tuple[int, str]:
-    """Prefer the merged annotated trace over rank/phase shards during directory discovery (TraceLens splitter needs the large trace)."""
+    """Compute the discovery sort key for a trace input path.
+
+    Prefers the merged annotated trace over rank/phase shards (the TraceLens
+    splitter needs the large trace).
+
+    Args:
+        path: The trace file path to rank.
+
+    Returns:
+        A ``(priority, name)`` sort key (lower priority sorts first).
+    """
     name = path.name
     if name.startswith("merged-"):
         return (0, name)
@@ -677,7 +743,17 @@ def discover_trace_inputs(trace_input: Path) -> tuple[str, list[Path]]:
 
 
 def is_kernel_event(event: dict[str, Any]) -> bool:
-    """Strict GPU-kernel filter: only ``cat == 'kernel'`` events (excludes host-side sync/launch wrappers that would eclipse real kernels)."""
+    """Apply a strict GPU-kernel filter to a trace event.
+
+    Only ``cat == 'kernel'`` events qualify, excluding host-side sync/launch
+    wrappers that would eclipse real kernels.
+
+    Args:
+        event: A single trace event dict.
+
+    Returns:
+        ``True`` if the event is a real GPU kernel.
+    """
     cat = str(event.get("cat") or event.get("category") or "").lower()
     if cat != "kernel":
         return False
@@ -741,7 +817,16 @@ _FLYDSL_SCAN_BYTES = 4096
 
 
 def _looks_like_flydsl_source(source_file: str) -> bool:
-    """Return True when ``source_file`` is a FlyDSL kernel source (content-sniff first 4 KiB for FlyDSL markers)."""
+    """Detect whether a source file is a FlyDSL kernel source.
+
+    Content-sniffs the first 4 KiB for FlyDSL markers.
+
+    Args:
+        source_file: Path to the candidate ``.py`` source.
+
+    Returns:
+        ``True`` when FlyDSL markers are found in the file head.
+    """
     if not source_file or not source_file.endswith(".py"):
         return False
     try:
@@ -808,7 +893,15 @@ _COMPILE_GENERATED_NAME_MARKERS = (
 )
 @functools.lru_cache(maxsize=1)
 def _framework_patch_roots() -> tuple[str, ...]:
-    """Framework install roots (from framework_paths.resolve_patch_target_roots); also emits a lower-case variant of each (``/app/ATOM/atom/`` -> ``/app/atom/atom/``) for case-insensitive matching."""
+    """Resolve framework install roots for patch-target matching.
+
+    Roots come from ``framework_paths.resolve_patch_target_roots``; a
+    lower-case variant of each (e.g. ``/app/ATOM/atom/`` ->
+    ``/app/atom/atom/``) is also emitted for case-insensitive matching.
+
+    Returns:
+        The framework install roots, including lower-case variants.
+    """
     try:
         if _resolve_patch_target_roots is None:
             raise ImportError
@@ -830,9 +923,14 @@ def _framework_patch_roots() -> tuple[str, ...]:
 
 @functools.lru_cache(maxsize=1)
 def _aiter_csrc_root() -> str:
-    """aiter's own device-source root (e.g. ``.../aiter_meta/csrc/``),
-    resolved from the installed package. Empty when aiter is not importable.
-    Cached once per process."""
+    """Resolve aiter's own device-source root from the installed package.
+
+    Cached once per process.
+
+    Returns:
+        The aiter csrc root (e.g. ``.../aiter_meta/csrc/``), or ``""`` when
+        aiter is not importable.
+    """
     if _aiter_jit_core is None:
         return ""
     raw = (getattr(_aiter_jit_core, "AITER_CSRC_DIR", "") or "").replace(os.sep, "/")
@@ -840,7 +938,13 @@ def _aiter_csrc_root() -> str:
 
 
 def _flydsl_reusable_roots() -> tuple[str, ...]:
-    """FlyDSL checkout root(s) for PR #668 moe_flydsl pseudo-ops, lower-cased ($DSL2_ROOT/$FLYDSL_ROOT take precedence over the WekaFS default)."""
+    """Resolve FlyDSL checkout root(s) for PR #668 moe_flydsl pseudo-ops.
+
+    ``$DSL2_ROOT`` / ``$FLYDSL_ROOT`` take precedence over the WekaFS default.
+
+    Returns:
+        The lower-cased FlyDSL checkout roots.
+    """
     out: list[str] = []
     for env_key in ("DSL2_ROOT", "FLYDSL_ROOT"):
         val = (os.environ.get(env_key, "") or "").strip()
@@ -921,13 +1025,30 @@ def is_torch_dispatch_shim_source(source_file: str) -> bool:
     tensor op to a vendor backend and hold no rewritable device kernel, so a
     symbol attributed here must be treated as a non-reusable dispatch stub
     (same handling as ``@compile_ops`` JIT stubs in ``aiter/ops/moe_op.py``).
+
+    Args:
+        source_file: The resolved source-file path.
+
+    Returns:
+        ``True`` when the file is a known torch-dispatch interception shim.
     """
     posix = str(source_file or "").replace("\\", "/")
     return any(posix.endswith(suffix) for suffix in _TORCH_DISPATCH_SHIM_SOURCES)
 
 
 def is_runtime_generated_kernel(name: str, source_file: str) -> bool:
-    """Return True for torch.compile / Inductor / cache-generated kernels (not portable across serving runs)."""
+    """Detect torch.compile / Inductor / cache-generated kernels.
+
+    These are not portable across serving runs.
+
+    Args:
+        name: The kernel symbol/name.
+        source_file: The resolved source-file path.
+
+    Returns:
+        ``True`` for a runtime-generated kernel that is not a stable in-repo
+        Triton source.
+    """
     lower_name = (name or "").lower()
     lower_file = (source_file or "").lower()
     if any(marker in lower_file for marker in _RUNTIME_GENERATED_SOURCE_MARKERS):
@@ -941,9 +1062,16 @@ def is_runtime_generated_kernel(name: str, source_file: str) -> bool:
 def classify_patchability(candidate: dict[str, Any]) -> tuple[bool, str]:
     """Return ``(reusable, skip_reason)`` for a hot-kernel candidate.
 
-    Single source of truth for the kernel-opt routing gate; ``skip_reason`` is empty
-    when reusable, else a short audit explanation. Also rejects vendor/collective/native-op
-    name markers (:data:`_NON_PATCHABLE_NAME_MARKERS`) and library-less ``aten::*`` ops.
+    Single source of truth for the kernel-opt routing gate. Also rejects
+    vendor/collective/native-op name markers
+    (:data:`_NON_PATCHABLE_NAME_MARKERS`) and library-less ``aten::*`` ops.
+
+    Args:
+        candidate: The hot-kernel candidate dict.
+
+    Returns:
+        A ``(reusable, skip_reason)`` tuple; ``skip_reason`` is empty when
+        reusable, else a short audit explanation.
     """
     source_file = str(candidate.get("source_file") or "")
     name = str(candidate.get("name") or "")
@@ -1025,7 +1153,19 @@ _VENDOR_KEYWORD_NAMES = (
 
 
 def is_vendor_dispatch_wrapper(name: str, source_file: str) -> bool:
-    """Heuristic: True when source_file is a thin dispatch wrapper around a precompiled vendor binary (.so/.co); nothing to rewrite."""
+    """Detect a thin dispatch wrapper around a precompiled vendor binary.
+
+    Uses a small file size plus content signatures so that real small kernels
+    survive (conservative).
+
+    Args:
+        name: The kernel symbol/name.
+        source_file: The resolved source-file path.
+
+    Returns:
+        ``True`` when the source is a dispatch wrapper around a ``.so``/``.co``
+        with nothing to rewrite.
+    """
     nm = (name or "").lower()
     if any(kw in nm for kw in _VENDOR_KEYWORD_NAMES):
         return True
@@ -1249,6 +1389,13 @@ def _compound_subwindow_keywords(name: str) -> list[str]:
     shorter trailing windows (longest first, most specific) so the embedded
     function symbol (e.g. ``invoke_fused_moe_kernel``) still resolves. The
     namespace/profiler prefix and a trailing numeric id are stripped first.
+
+    Args:
+        name: The compound/profiler-wrapped symbol name.
+
+    Returns:
+        Progressively shorter trailing snake_case windows (longest first),
+        capped at six.
     """
     cleaned = _strip_template_args(name.strip())
     if "::" in cleaned:
@@ -1275,7 +1422,15 @@ def _file_defines_symbol(path: Path, keyword: str) -> bool:
     Distinguishes a kernel's definition site (``def invoke_fused_moe_kernel``,
     a Triton ``@triton.jit`` function, or a C/HIP ``__global__``) from a file
     that only calls/wraps it (e.g. sglang's ``kernel_shape_profiler.py`` dispatch
-    shim). Best-effort: returns False on read errors.
+    shim).
+
+    Args:
+        path: The source file to inspect.
+        keyword: The symbol name to look for a definition of.
+
+    Returns:
+        ``True`` when the file defines the symbol; ``False`` on read errors or
+        when it only mentions it.
     """
     kw = re.escape(keyword)
     try:
@@ -1291,7 +1446,15 @@ def _file_defines_symbol(path: Path, keyword: str) -> bool:
 
 
 def _prefer_symbol_definition(keyword: str, hits: list[Path]) -> list[Path]:
-    """Rank definition sites of ``keyword`` ahead of mere mentions."""
+    """Rank definition sites of a symbol ahead of mere mentions.
+
+    Args:
+        keyword: The symbol name to prefer definitions of.
+        hits: Candidate source paths to rank.
+
+    Returns:
+        The ranked paths, preferring files that define ``keyword``.
+    """
     definers = [h for h in hits if _file_defines_symbol(h, keyword)]
     return _rank_paths(definers) if definers else _rank_paths(hits)
 

--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -1250,6 +1250,13 @@ def _normalize_profiler_op_name(name: str) -> str:
     leading C++ return-type token, a trailing ``(... Op)`` annotation, and a
     trailing ``.kd`` HSA code-object suffix. Already-clean names (e.g.
     ``sglang_profiler::...`` or ``aten::mm``) pass through unchanged.
+
+    Args:
+        name: The raw TraceLens op symbol to normalize.
+
+    Returns:
+        The normalized op symbol with capture wrappers, leading return-type
+        tokens, trailing op annotations and ``.kd`` suffixes removed.
     """
     s = (name or "").strip()
     if not s:
@@ -1398,6 +1405,16 @@ def _rank_paths(paths: list[Path], keyword: str = "") -> list[Path]:
     kw_lower = keyword.lower()
 
     def score(path: Path) -> tuple[int, int, int, int]:
+        """Relevance sort key for a candidate source path (lower sorts first).
+
+        Args:
+            path (Path): A candidate source path to rank.
+
+        Returns:
+            tuple[int, int, int, int]: ``(name_match, kind_score, ext_score,
+            depth_penalty)`` so keyword-stem matches, impl source kinds,
+            implementation extensions, and shallower paths rank ahead.
+        """
         s = str(path)
         depth_penalty = s.count("/")
         kind_score = 0
@@ -1915,7 +1932,16 @@ _SGL_KERNEL_DEVICE_PROMOTIONS: tuple[tuple[str, tuple[str, ...]], ...] = (
 
 
 def upgrade_sgl_kernel_launcher(source_file: str, kernel_name: str) -> str:
-    """Promote known sgl-kernel Python launchers to reusable HIP source."""
+    """Promote known sgl-kernel Python launchers to reusable HIP source.
+
+    Args:
+        source_file: The candidate's resolved source path.
+        kernel_name: The kernel name used for pattern matching.
+
+    Returns:
+        The promoted reusable HIP source path, or ``source_file`` unchanged
+        when no promotion applies.
+    """
     if not source_file or not kernel_name:
         return source_file
     source_posix = source_file.replace(os.sep, "/")
@@ -3009,7 +3035,17 @@ def _category_analysis_command(
     tier: str,
     output_dir: Path,
 ) -> list[str] | None:
-    """Return the TraceLens category-analysis command for one manifest category."""
+    """Return the TraceLens category-analysis command for one manifest category.
+
+    Args:
+        cat_name: The manifest category name (e.g. ``sdpa_fwd`` / ``norm_bwd``).
+        tier: The category tier; only ``compute_kernel`` produces a command.
+        output_dir: The analysis output directory passed to the tool.
+
+    Returns:
+        The TraceLens command argv for the category, or ``None`` when the
+        category is skipped or unroutable.
+    """
     if tier != "compute_kernel":
         return None
     if cat_name in _SKIP_DETERMINISTIC_CATEGORIES:
@@ -3051,7 +3087,15 @@ def _category_analysis_command(
 def _raise_on_failed_deterministic_pipeline(
     det_rc: int,
 ) -> None:
-    """Fail deterministic route on any TraceLens deterministic toolchain error."""
+    """Fail deterministic route on any TraceLens deterministic toolchain error.
+
+    Args:
+        det_rc: Return code from the deterministic TraceLens pipeline.
+
+    Raises:
+        RuntimeError: When ``det_rc`` is non-zero, to avoid returning partial
+            ``hot_kernels[]``.
+    """
     if det_rc == 0:
         return
     raise RuntimeError(
@@ -3077,6 +3121,20 @@ def _run_deterministic_tracelens_steps(
 
     Invokes the CLI tools as subprocesses so they run in the TraceLens
     package environment. Returns 0 on success.
+
+    Args:
+        trace_path: Path to the trace fed into the pipeline.
+        output_dir: Directory the pipeline writes its artifacts into.
+        tl_root: TraceLens package root used as the subprocess cwd.
+        platform: GPU arch platform string passed to the tools.
+        analysis_mode: The analysis mode selector.
+        framework: The serving framework name.
+        capture_folder: Optional TraceLens capture folder.
+        log_path: Log file the subprocess output is appended to.
+        budget_minutes: Time budget used to derive the subprocess timeout.
+
+    Returns:
+        ``0`` on success, else the first non-zero subprocess return code.
     """
     timeout_s = max(120, int(budget_minutes * 60))
 
@@ -3163,7 +3221,16 @@ def _run_deterministic_tracelens_steps(
 
 
 def _extract_idle_pct_from_gpu_timeline(output_dir: Path) -> float | None:
-    """Read GPU idle percentage directly from gpu_timeline.csv."""
+    """Read GPU idle percentage directly from gpu_timeline.csv.
+
+    Args:
+        output_dir: The analysis output directory holding
+            ``perf_report_csvs/gpu_timeline.csv``.
+
+    Returns:
+        The GPU idle percentage, or ``None`` when the CSV is absent or has no
+        idle-time row.
+    """
     csv_path = output_dir / "perf_report_csvs" / "gpu_timeline.csv"
     if not csv_path.exists():
         return None
@@ -3180,7 +3247,16 @@ def _extract_idle_pct_from_gpu_timeline(output_dir: Path) -> float | None:
 
 
 def _extract_total_time_us_from_gpu_timeline(output_dir: Path) -> float | None:
-    """Read the trace total_time from gpu_timeline.csv (ms -> us)."""
+    """Read the trace total_time from gpu_timeline.csv (ms -> us).
+
+    Args:
+        output_dir: The analysis output directory holding
+            ``perf_report_csvs/gpu_timeline.csv``.
+
+    Returns:
+        The trace total time in microseconds, or ``None`` when the CSV is
+        absent or has no total-time row.
+    """
     csv_path = output_dir / "perf_report_csvs" / "gpu_timeline.csv"
     if not csv_path.exists():
         return None
@@ -3209,6 +3285,15 @@ def _match_op_by_time(
     Returns an empty dict when no candidate is within
     ``_MATCH_OP_MAX_DELTA_MS`` milliseconds, preventing silent
     mis-association of launcher paths and shapes.
+
+    Args:
+        ops: Operation rows from a ``*_metrics.json`` file.
+        name: The operation name to match.
+        time_ms: The operation time in milliseconds to match against.
+
+    Returns:
+        The best-matching operation row, or ``{}`` when none is within
+        ``_MATCH_OP_MAX_DELTA_MS``.
     """
     best: dict[str, Any] = {}
     best_delta = float("inf")
@@ -3228,7 +3313,14 @@ def _match_op_by_time(
 
 
 def _resolve_source_file_from_kernel_path(kernel_path: str) -> str:
-    """Resolve a TraceLens launcher path to an existing absolute source file."""
+    """Resolve a TraceLens launcher path to an existing absolute source file.
+
+    Args:
+        kernel_path: The TraceLens launcher path (possibly relative).
+
+    Returns:
+        The resolved absolute source-file path, or ``""`` when none exists.
+    """
     raw_path, _, _ = _parse_launcher_path(kernel_path)
     if not raw_path:
         return ""
@@ -3267,6 +3359,21 @@ def deterministic_extract_hot_kernels(
 
     Each candidate maps to the same schema that ``_finalize_candidates``
     expects downstream (name, duration_us, efficiency_percent, etc.).
+
+    Args:
+        output_dir: The deterministic-pipeline output directory.
+        top_k: Maximum number of candidates to return.
+        log_path: Optional log file for skip/parse diagnostics.
+        fail_on_corrupt_priority: When ``True``, raise instead of returning
+            ``[]`` on a corrupt ``priority_data.json``.
+
+    Returns:
+        The hot-kernel candidate dicts, sorted by GPU time and truncated to
+        ``top_k``; ``[]`` when no priority data is available.
+
+    Raises:
+        RuntimeError: When ``priority_data.json`` cannot be parsed and
+            ``fail_on_corrupt_priority`` is ``True``.
     """
     priority_path = output_dir / "priority_data.json"
     if not priority_path.exists():
@@ -3474,6 +3581,14 @@ def generate_minimal_analysis_md(
     Deterministic hot-kernel extraction uses structured ``*_metrics.json`` and
     ``priority_data.json`` directly. This Markdown report is intentionally not
     the parser contract used by the LLM-agent route.
+
+    Args:
+        output_dir: Directory the ``analysis.md`` report is written into.
+        candidates: The finalized hot-kernel candidates to tabulate.
+        idle_pct: Optional GPU idle percentage to include in the summary.
+
+    Returns:
+        The path to the written ``analysis.md``.
     """
     report_path = output_dir / "analysis.md"
     lines: list[str] = []
@@ -3517,6 +3632,16 @@ def generate_minimal_analysis_md(
     # LLM-written recommendations — here we expose only the underlying numbers.
     if gpu_rows:
         def _timeline_pct(row_type: str) -> float | None:
+            """Return the GPU-timeline percentage for a given row type.
+
+            Args:
+                row_type (str): The timeline row ``type`` to match (e.g.
+                    ``idle_time``).
+
+            Returns:
+                float | None: The row's ``percent`` value, or ``None`` when the
+                row is absent or its percent is unparseable.
+            """
             for row in gpu_rows:
                 if (row.get("type") or "").strip().lower() == row_type:
                     try:

--- a/kernel-agent/tools/tracelens_arch_benchmark.py
+++ b/kernel-agent/tools/tracelens_arch_benchmark.py
@@ -78,6 +78,14 @@ _VISIBLE_DEVICE_VARS = (
 
 
 def normalize_platform(platform: str) -> str:
+    """Normalize a platform/arch name to its canonical upper-case form.
+
+    Args:
+        platform: Platform or architecture name.
+
+    Returns:
+        The trimmed, upper-cased platform name.
+    """
     return (platform or "").strip().upper()
 
 
@@ -168,6 +176,15 @@ def resolve_arch_json_path(platform: str) -> Path | None:
 
 
 def default_arch_output_path(tracelens_root: Path, platform: str) -> Path:
+    """Return the default arch-spec JSON path for a platform.
+
+    Args:
+        tracelens_root: Root of the TraceLens checkout.
+        platform: Platform/architecture name.
+
+    Returns:
+        The conventional ``.../arch/<PLATFORM>.json`` path.
+    """
     canonical = normalize_platform(platform)
     return (
         tracelens_root

--- a/kernel-agent/tools/tracelens_arch_benchmark.py
+++ b/kernel-agent/tools/tracelens_arch_benchmark.py
@@ -41,7 +41,11 @@ check_gpu_idle = None  # type: ignore[assignment,misc]
 
 
 def _get_collect_arch_jsons():
-    """Return TraceLens' arch-JSON collector, importing lazily post-install."""
+    """Return TraceLens' arch-JSON collector, importing lazily post-install.
+
+    Returns:
+        The collector callable, or ``None`` when TraceLens is not installed.
+    """
     global _collect_arch_jsons
     if _collect_arch_jsons is None:
         try:
@@ -55,7 +59,12 @@ def _get_collect_arch_jsons():
 
 
 def _get_check_gpu_idle():
-    """Return TraceLens' check_gpu_idle, importing lazily post-install."""
+    """Return TraceLens' ``check_gpu_idle``, importing lazily post-install.
+
+    Returns:
+        The ``check_gpu_idle`` callable, or ``None`` when TraceLens is not
+        installed.
+    """
     global check_gpu_idle
     if check_gpu_idle is None:
         try:
@@ -90,7 +99,12 @@ def normalize_platform(platform: str) -> str:
 
 
 def list_candidate_physical_gpus() -> list[int]:
-    """Return physical GPU ids currently visible to this process."""
+    """List the physical GPU ids currently visible to this process.
+
+    Returns:
+        Physical GPU ids derived from ``*_VISIBLE_DEVICES`` or torch, or an
+        empty list when none are visible.
+    """
     for var in _VISIBLE_DEVICE_VARS:
         val = os.environ.get(var, "").strip()
         if not val:
@@ -117,7 +131,15 @@ def list_candidate_physical_gpus() -> list[int]:
 def single_physical_gpu_env(
     physical_id: int, *, base_env: dict[str, str] | None = None
 ) -> dict[str, str]:
-    """Return a subprocess env that exposes exactly one physical GPU."""
+    """Build a subprocess env that exposes exactly one physical GPU.
+
+    Args:
+        physical_id: The physical GPU id to expose.
+        base_env: Base environment to copy; defaults to ``os.environ``.
+
+    Returns:
+        An environment dict with the visibility vars pinned to ``physical_id``.
+    """
     env = dict(base_env if base_env is not None else os.environ)
     value = str(physical_id)
     for var in _VISIBLE_DEVICE_VARS:
@@ -128,7 +150,19 @@ def single_physical_gpu_env(
 def select_idle_gpu(
     *, log: Callable[[str], None] | None = None, util_threshold: int = 5
 ) -> int:
-    """Pick an unoccupied GPU for the arch microbenchmark subprocess."""
+    """Pick an unoccupied GPU for the arch microbenchmark subprocess.
+
+    Args:
+        log: Optional logging callable for selection diagnostics.
+        util_threshold: Max utilization percent to consider a GPU idle.
+
+    Returns:
+        The physical id of the selected idle GPU.
+
+    Raises:
+        RuntimeError: If TraceLens is missing, no GPUs are found, or none are
+            idle.
+    """
     check_idle = _get_check_gpu_idle()
     if check_idle is None:
         raise RuntimeError("TraceLens is not installed; cannot check GPU idle state")
@@ -161,7 +195,14 @@ def select_idle_gpu(
 
 
 def resolve_arch_json_path(platform: str) -> Path | None:
-    """Return the bundled arch JSON path for ``platform``, if present."""
+    """Resolve the bundled arch JSON path for a platform.
+
+    Args:
+        platform: Platform/architecture name.
+
+    Returns:
+        The bundled arch JSON path, or ``None`` when none matches.
+    """
     collect = _get_collect_arch_jsons()
     if collect is None:
         return None
@@ -206,10 +247,21 @@ def _sanitize_measured_arch_spec(
     (FP8/INT8/MX unsupported on the stack, or a bench that was skipped) and a
     ``0`` bandwidth when the HBM sweep failed. Roofline consumes
     ``max_achievable_tflops[<spec>]`` as a divisor and ``mem_bw_gbps`` as the
-    memory ceiling, so a ``0`` would divide-by-zero or yield garbage. Keep only
+    memory ceiling, so a     ``0`` would divide-by-zero or yield garbage. Keep only
     positive MAF values (roofline's lookup then returns ``None`` and skips that
-    dtype) and hard-fail when the spec is unusable. Returns True if ``payload``
-    was modified (caller persists it).
+    dtype) and hard-fail when the spec is unusable.
+
+    Args:
+        payload: The measured arch spec dict (mutated in place).
+        platform: Platform/architecture name for logging.
+        out_path: Path the spec will be written to (used in error messages).
+        log: Logging callable for diagnostics.
+
+    Returns:
+        ``True`` if ``payload`` was modified (the caller persists it).
+
+    Raises:
+        RuntimeError: If the spec has no usable MAF values or bandwidth.
     """
     maf = payload.get("max_achievable_tflops")
     if not isinstance(maf, dict) or not maf:
@@ -280,6 +332,22 @@ def populate_gpu_arch_json(
       returned and the internal extension supplies MAF at report time.
     - When it is False (open-source path) a bundled spec short-circuits, and
       a missing spec triggers the TraceLens microbenchmark on an idle GPU.
+
+    Args:
+        tracelens_root: Root of the TraceLens checkout.
+        platform: Target platform/architecture name.
+        internal_extension_enabled: Whether the internal extension backfills
+            MAF (skips the microbenchmark when ``True``).
+        log: Logging callable for diagnostics.
+        run_command: Callable that runs the microbenchmark subprocess.
+        timeout_s: Microbenchmark timeout in seconds.
+        device: Logical device index for the microbenchmark.
+
+    Returns:
+        The arch JSON path, or ``None`` when MAF is supplied at report time.
+
+    Raises:
+        RuntimeError: If the platform is empty or the microbenchmark fails.
     """
     if internal_extension_enabled:
         existing = resolve_arch_json_path(platform)

--- a/kernel-agent/tools/tracelens_skill_runner.py
+++ b/kernel-agent/tools/tracelens_skill_runner.py
@@ -319,8 +319,15 @@ def _iter_message_text(message: Any) -> Iterable[str]:
 
 
 def _cap_str(value: str, limit: int = _TRANSCRIPT_FIELD_MAX_CHARS) -> str:
-    """Truncate a transcript string to ``limit`` chars with a clip marker so a
-    reader can tell the field was bounded (#266)."""
+    """Truncate a transcript string, appending a clip marker when bounded.
+
+    Args:
+        value: The string to truncate.
+        limit: Maximum length before truncation.
+
+    Returns:
+        The original string, or a truncated copy with a clip marker (#266).
+    """
     if len(value) <= limit:
         return value
     return value[:limit] + f"... [truncated {len(value) - limit} chars]"
@@ -334,7 +341,15 @@ def _json_safe(value: Any, *, cap: bool = True) -> Any:
     write infallible so a serialization edge case never aborts a TraceLens
     run (#266). When ``cap`` is set every string (at any nesting depth) is
     bounded to ``_TRANSCRIPT_FIELD_MAX_CHARS`` so a megabyte tool_result cannot
-    bloat the transcript."""
+    bloat the transcript.
+
+    Args:
+        value: The value to coerce.
+        cap: When ``True``, bound every nested string to the field max.
+
+    Returns:
+        A JSON-serializable representation of ``value``.
+    """
     if isinstance(value, str):
         return _cap_str(value) if cap else value
     if isinstance(value, dict):
@@ -356,7 +371,14 @@ def _serialize_sdk_block(block: Any) -> dict[str, Any]:
     union of fields those types expose, rather than importing the SDK's
     concrete block classes. This mirrors
     ``ClaudeBackend._iter_blocks`` so the runner stays decoupled from
-    claude-agent-sdk internals."""
+    claude-agent-sdk internals.
+
+    Args:
+        block: An SDK content block (or a plain dict).
+
+    Returns:
+        A JSON-safe record describing the block.
+    """
     if isinstance(block, dict):
         record = _json_safe(block)
         if isinstance(record, dict):
@@ -403,7 +425,15 @@ def _serialize_sdk_message(message: Any, *, seq: int) -> dict[str, Any]:
     The record carries the message class name (``AssistantMessage`` /
     ``ResultMessage`` / ...), its content blocks, and — when present on a
     terminal ``ResultMessage`` — the consolidated ``result`` text and the
-    Anthropic ``usage`` dict (token accounting)."""
+    Anthropic ``usage`` dict (token accounting).
+
+    Args:
+        message: An SDK stream message.
+        seq: The message sequence number within the stream.
+
+    Returns:
+        A JSON-safe transcript record for the message.
+    """
     record: dict[str, Any] = {
         "seq": seq,
         "ts": datetime.now(timezone.utc).isoformat(),
@@ -694,7 +724,18 @@ def _parse_marker_attrs(blob: str) -> dict[str, str]:
 def _extract_between(
     text: str, start_marker: str, end_markers: tuple[str, ...],
 ) -> str:
-    """Return the substring between ``start_marker`` and the earliest ``end_markers`` (tail if none; empty if start absent)."""
+    """Extract the substring between a start marker and the earliest end marker.
+
+    Args:
+        text: The text to search.
+        start_marker: Marker that begins the region.
+        end_markers: Candidate markers that end the region; the earliest match
+            wins.
+
+    Returns:
+        The trimmed substring, the tail when no end marker is found, or an
+        empty string when the start marker is absent.
+    """
     start = text.find(start_marker)
     if start == -1:
         return ""
@@ -706,7 +747,15 @@ def _extract_between(
 
 
 def _extract_pitem_prose(body: str) -> dict[str, Any]:
-    """Extract Identification / Reasoning / Resolution / Impact-estimate fields from a P-item body (all default empty/0.0)."""
+    """Extract prose and impact fields from a P-item body.
+
+    Args:
+        body: The Markdown body of a single P-item.
+
+    Returns:
+        A dict with ``identification``, ``reasoning_for_slowdown``,
+        ``resolution``, and impact estimates (defaulting to empty / 0.0).
+    """
     identification = _extract_between(
         body, _IDENTIFICATION_LABEL,
         (_DATA_LABEL, _REASONING_LABEL, _RESOLUTION_LABEL, _IMPACT_LABEL),
@@ -729,7 +778,15 @@ def _extract_pitem_prose(body: str) -> dict[str, Any]:
 
 
 def _extract_pitem_categories(text: str) -> list[dict[str, Any]]:
-    """Return per-P-item metadata (``category``/``low``/``mid``/``high``), in priority order, from p_item markers."""
+    """Extract per-P-item category and impact metadata in priority order.
+
+    Args:
+        text: The full report text containing ``p_item`` markers.
+
+    Returns:
+        A list of dicts with ``category`` and ``impact_score*`` fields, one
+        per P-item marker.
+    """
 
     items: list[dict[str, Any]] = []
     for match in _PITEM_MARKER_RE.finditer(text):
@@ -775,7 +832,17 @@ def _split_data_blocks(text: str) -> list[tuple[int, str, str]]:
 
 
 def _extract_data_table(body: str) -> list[list[str]]:
-    """Pull the 9-column markdown table that follows ``**Data:**`` (raw header + data cells; ends at blank line or next ``**Field:**``)."""
+    """Pull the 9-column markdown table that follows a ``**Data:**`` marker.
+
+    The table includes the raw header and data cells and ends at a blank line
+    or the next ``**Field:**`` marker.
+
+    Args:
+        body: The P-item body text to scan.
+
+    Returns:
+        The table rows as lists of cell strings.
+    """
 
     marker = body.find("**Data:**")
     if marker < 0:
@@ -921,7 +988,17 @@ _IDLE_PCT_TABLE_RE = re.compile(
 
 
 def extract_idle_pct_from_analysis_md(md_path: Path) -> float | None:
-    """Extract ``Idle %`` from the Executive Summary table in ``analysis.md`` (§1/§2 idle-gate); ``None`` on missing/unparseable so callers skip the gate gracefully."""
+    """Extract ``Idle %`` from an ``analysis.md`` Executive Summary table.
+
+    Used by the §1/§2 idle gate.
+
+    Args:
+        md_path: Path to the ``analysis.md`` report.
+
+    Returns:
+        The idle percentage, or ``None`` when missing/unparseable so callers
+        skip the gate gracefully.
+    """
     try:
         text = md_path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
@@ -939,7 +1016,14 @@ def extract_idle_pct_from_analysis_md(md_path: Path) -> float | None:
 
 
 def _efficiency_sort_key(candidate: dict[str, Any]) -> float:
-    """Per-row sort key for the ``Lower Efficiency`` budget filter (§2); rows with no efficiency (0.0) sort last."""
+    """Compute the per-row sort key for the ``Lower Efficiency`` filter (§2).
+
+    Args:
+        candidate: A candidate row carrying ``efficiency_percent``.
+
+    Returns:
+        The efficiency value, or ``inf`` so rows with no efficiency sort last.
+    """
     eff = candidate.get("efficiency_percent")
     try:
         value = float(eff)
@@ -951,7 +1035,19 @@ def _efficiency_sort_key(candidate: dict[str, Any]) -> float:
 
 
 def parse_analysis_md(md_path: Path, top_k: int = 10) -> list[dict[str, Any]]:
-    """Parse the TraceLens ``analysis.md`` final report into hot-kernels in §2 priority order (P-item, then lower efficiency within); empty/missing → []."""
+    """Parse a TraceLens ``analysis.md`` report into hot-kernel rows.
+
+    Rows are returned in §2 priority order (P-item, then lower efficiency
+    within each item).
+
+    Args:
+        md_path: Path to the ``analysis.md`` report.
+        top_k: Maximum number of hot-kernel rows to return.
+
+    Returns:
+        The hot-kernel rows, or an empty list when the report is missing or
+        unparseable.
+    """
 
     if not md_path.exists():
         return []
@@ -1039,7 +1135,17 @@ _LAUNCHER_PATH_PLACEHOLDERS: frozenset[str] = frozenset({
 
 
 def _parse_launcher_path(kernel_path: str) -> tuple[str, int | None, str | None]:
-    """Parse a TraceLens kernel-path to ``(path, line, function_name)`` (accepts ``<path>(<line>): <func>``/``<path>#L<line>``/bare; placeholders → ``("", None, None)``)."""
+    """Parse a TraceLens kernel-path into its components.
+
+    Accepts ``<path>(<line>): <func>``, ``<path>#L<line>``, or a bare path.
+
+    Args:
+        kernel_path: The kernel-path string to parse.
+
+    Returns:
+        A ``(path, line, function_name)`` tuple; placeholders and empty input
+        return ``("", None, None)``.
+    """
     if not kernel_path:
         return "", None, None
     text = kernel_path.strip()
@@ -1083,7 +1189,13 @@ _FRAMEWORK_SOURCE_ROOTS_ENV = "HYPERLOOM_FRAMEWORK_SOURCE_ROOTS"
 
 
 def _env_framework_source_roots() -> dict[str, tuple[str, ...]]:
-    """Parse ``$HYPERLOOM_FRAMEWORK_SOURCE_ROOTS`` (comma-separated ``pkg=/abs/parent``) into ``{pkg: (root,...)}``; unparseable entries skipped."""
+    """Parse ``$HYPERLOOM_FRAMEWORK_SOURCE_ROOTS`` into a package-root map.
+
+    The variable is a comma-separated list of ``pkg=/abs/parent`` entries.
+
+    Returns:
+        A ``{pkg: (root, ...)}`` mapping; unparseable entries are skipped.
+    """
     raw = os.environ.get(_FRAMEWORK_SOURCE_ROOTS_ENV, "").strip()
     if not raw:
         return {}
@@ -1101,7 +1213,14 @@ def _env_framework_source_roots() -> dict[str, tuple[str, ...]]:
 
 
 def _package_root_parent(pkg: str) -> str | None:
-    """Return the directory containing ``pkg/`` on the live ``sys.path`` via find_spec; ``None`` if not importable."""
+    """Find the directory containing a package on the live ``sys.path``.
+
+    Args:
+        pkg: The importable package name.
+
+    Returns:
+        The directory containing ``pkg/``, or ``None`` when not importable.
+    """
     try:
         spec = importlib.util.find_spec(pkg)
     except (ImportError, ValueError):
@@ -1121,7 +1240,16 @@ def _package_root_parent(pkg: str) -> str | None:
 def _resolve_launcher_to_abs_source(
     kernel_path: str,
 ) -> tuple[str, int | None, str | None] | None:
-    """Resolve a TraceLens launcher-path to an absolute file; ``(abs_file, line, function_name)`` only when the file exists, else ``None`` (conservative miss → caller's grep locator)."""
+    """Resolve a TraceLens launcher-path to an absolute source file.
+
+    Args:
+        kernel_path: The TraceLens launcher-path to resolve.
+
+    Returns:
+        An ``(abs_file, line, function_name)`` tuple only when the file
+        exists, else ``None`` (a conservative miss defers to the caller's grep
+        locator).
+    """
     raw_path, line, func = _parse_launcher_path(kernel_path)
     if not raw_path:
         return None
@@ -1157,7 +1285,16 @@ def _resolve_launcher_to_abs_source(
 
 
 def _function_line_from_ast(path: Path, function_name: str) -> int | None:
-    """Return the lineno of the first (Async)FunctionDef in ``path`` named ``function_name``; ``None`` if unreadable/unparseable/absent."""
+    """Find the line number of a named function definition via AST.
+
+    Args:
+        path: The source file to parse.
+        function_name: The function name to locate.
+
+    Returns:
+        The first matching ``def``/``async def`` line, or ``None`` when the
+        file is unreadable, unparseable, or the function is absent.
+    """
     try:
         tree = ast.parse(path.read_text(encoding="utf-8"))
     except (OSError, SyntaxError, UnicodeDecodeError):
@@ -1173,7 +1310,19 @@ def _resolve_source_target(
     *,
     source_root: Path | None,
 ) -> dict[str, Any] | None:
-    """Resolve a candidate's launcher path to a ``(source_path, definition_line, function_name)`` triple; ``None`` when unparseable. AST line overrides the reported call-site line when resolvable."""
+    """Resolve a candidate's launcher path to a source-target triple.
+
+    The AST-derived definition line overrides the reported call-site line when
+    resolvable.
+
+    Args:
+        candidate: The candidate dict carrying launcher/source paths.
+        source_root: Optional root to resolve relative paths against.
+
+    Returns:
+        A ``(source_path, definition_line, function_name)`` dict, or ``None``
+        when the path is unparseable.
+    """
     # Prefer verbatim tracelens_launcher_path so AST resolution survives _finalize_candidates'
     # source_file overwrite; fall back to source_file / kernel_path for non-TraceLens candidates.
     kernel_path = str(
@@ -1220,6 +1369,12 @@ def _is_native_source(path: str) -> bool:
     keying a task_group on that line splits one device kernel across
     groups. Callers therefore drop the line/function key components for
     these files.
+
+    Args:
+        path: The source file path to classify.
+
+    Returns:
+        ``True`` for C/C++/HIP/CUDA source files.
     """
     return str(path).lower().endswith(_NATIVE_SOURCE_SUFFIXES)
 
@@ -1231,7 +1386,14 @@ def _normalize_operation_key(operation: str) -> str:
     SAME kernel profiled at different dtypes/shapes — e.g.
     ``rmsnorm_kernel<bf16>`` vs ``rmsnorm_kernel<fp16>`` — groups together,
     while DISTINCT kernels (different base names) stay separate (the Q1
-    invariant). Returns the original string when stripping leaves nothing.
+    invariant).
+
+    Args:
+        operation: The TraceLens operation name.
+
+    Returns:
+        The canonicalized operation name, or the original string when
+        stripping leaves nothing.
     """
     s = str(operation).strip()
     if "<" not in s:
@@ -1255,7 +1417,24 @@ def aggregate_by_source_function(
     *,
     source_root: Path | str | None = None,
 ) -> list[dict[str, Any]]:
-    """Group TraceLens candidates into per-kernel ``task_group`` dicts, sorted by aggregate time (desc). Native (.cu/.hip/.cpp) key on ``(source_path, function)`` only (collapse #420 over-split instantiations); Python key on ``(operation, path, line, function)`` since one caller frame can launch distinct kernels (Q1). Each group carries task_group_id/source_path/definition_line/function_name/kernel_ids/primary_kernel_id/rows/aggregate_*. Unparseable candidates left out for legacy per-kernel dispatch."""
+    """Group TraceLens candidates into per-kernel ``task_group`` dicts.
+
+    Groups are sorted by aggregate time (descending). Native (.cu/.hip/.cpp)
+    candidates key on ``(source_path, function)`` only (collapsing #420
+    over-split instantiations); Python candidates key on
+    ``(operation, path, line, function)`` since one caller frame can launch
+    distinct kernels (Q1). Each group carries ``task_group_id``,
+    ``source_path``, ``definition_line``, ``function_name``, ``kernel_ids``,
+    ``primary_kernel_id``, ``rows``, and ``aggregate_*`` fields.
+
+    Args:
+        candidates: The TraceLens candidate rows to group.
+        source_root: Optional root to resolve relative source paths against.
+
+    Returns:
+        The task-group dicts. Unparseable candidates are left out for legacy
+        per-kernel dispatch.
+    """
     if not candidates:
         return []
     root: Path | None = None

--- a/quantization_agent/cli.py
+++ b/quantization_agent/cli.py
@@ -35,6 +35,18 @@ from .driver.runner import DEFAULT_MODEL
 
 
 def _interactive_value(raw: str) -> bool | None:
+    """Parse the ``--interactive`` flag into a tri-state value.
+
+    Args:
+        raw: Raw flag value supplied on the command line.
+
+    Returns:
+        ``None`` for ``auto`` (tty auto-detection), ``True`` for the on-style
+        values, and ``False`` for the off-style values.
+
+    Raises:
+        argparse.ArgumentTypeError: If ``raw`` is not a recognized value.
+    """
     raw = raw.strip().lower()
     if raw in ("auto", "", "default"):
         return None
@@ -48,6 +60,14 @@ def _interactive_value(raw: str) -> bool | None:
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Build the argument parser and parse the CLI arguments.
+
+    Args:
+        argv: Argument list to parse; defaults to ``sys.argv`` when ``None``.
+
+    Returns:
+        The populated :class:`argparse.Namespace`.
+    """
     p = argparse.ArgumentParser(
         prog="quantization_agent",
         description="Drive the AMD Quark PTQ skill chain from a natural-language prompt.",
@@ -104,7 +124,21 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 async def _run(args: argparse.Namespace) -> int:
+    """Run one quantization request and print a JSON summary.
+
+    Args:
+        args: Parsed CLI arguments.
+
+    Returns:
+        Process exit code: ``0`` on success or partial success, ``1`` when the
+        resulting model is unusable.
+    """
     def log(line: str) -> None:
+        """Write a line to stderr when verbose output is enabled.
+
+        Args:
+            line: Text to emit.
+        """
         if args.verbose:
             print(line, file=sys.stderr, flush=True)
 
@@ -134,6 +168,14 @@ async def _run(args: argparse.Namespace) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for the quantization agent.
+
+    Args:
+        argv: Argument list to parse; defaults to ``sys.argv`` when ``None``.
+
+    Returns:
+        The process exit code produced by :func:`_run`.
+    """
     args = _parse_args(argv)
     return asyncio.run(_run(args))
 

--- a/quantization_agent/driver/assessment.py
+++ b/quantization_agent/driver/assessment.py
@@ -168,7 +168,17 @@ def _classify_eval_outcome(
     *,
     acceptable_eval_gap: float | None,
 ) -> OutcomeId | None:
-    """Map eval-phase artifacts → outcome. ``None`` means 'eval not exercised'."""
+    """Map eval-phase artifacts to an outcome.
+
+    Args:
+        art: Collected artifacts for the attempt.
+        acceptable_eval_gap: Maximum tolerated relative accuracy gap, if
+            configured.
+
+    Returns:
+        The matching eval :class:`OutcomeId`, or ``None`` when eval was
+        not exercised this attempt.
+    """
 
     if art.eval_skipped_reason:
         reason = art.eval_skipped_reason.lower()
@@ -202,10 +212,16 @@ def _classify_sdk_phase_error(
     sdk_error: str,
     phase: str | None,
 ) -> OutcomeId | None:
-    """Map ``sdk_error`` text under a known phase to a phase-specific outcome.
+    """Map an SDK error under a known phase to a phase-specific outcome.
 
-    Returns ``None`` if the message doesn't look phase-specific; the caller
-    then falls through to bootstrap-level patterns.
+    Args:
+        sdk_error: Raw SDK error text.
+        phase: The phase that was executing when the error occurred.
+
+    Returns:
+        The matching :class:`OutcomeId`, or ``None`` if the message is not
+        phase-specific (the caller then falls through to bootstrap-level
+        patterns).
     """
 
     msg = sdk_error.lower()
@@ -238,10 +254,16 @@ def _classify_phase_artifact_gap(
     art: CollectedArtifacts,
     phase: str | None,
 ) -> OutcomeId | None:
-    """Disk-evidence gaps that depend on which phase last wrote ``last_phase.txt``.
+    """Detect disk-evidence gaps relative to the last-written phase.
 
-    Returns ``None`` if nothing is amiss at this phase boundary — the caller
-    then continues to MUST-have / validator / eval checks.
+    Args:
+        art: Collected artifacts for the attempt.
+        phase: The phase that last wrote ``last_phase.txt``.
+
+    Returns:
+        The matching :class:`OutcomeId`, or ``None`` if nothing is amiss
+        at this phase boundary (the caller then continues to MUST-have /
+        validator / eval checks).
     """
 
     if phase == "intake" and not art.model_analysis_present:
@@ -293,11 +315,20 @@ def classify_attempt(
 ) -> OutcomeId | None:
     """Classify a single attempt's workspace state.
 
-    Returns ``None`` for clean success, an ``OutcomeId`` otherwise. The retry
-    loop assembles attempts and derives the final ``Assessment``.
+    The retry loop assembles per-attempt outcomes and derives the final
+    ``Assessment``.
 
-    ``artifacts`` may be supplied if the caller already scanned the workspace
-    (saves a duplicate disk pass).
+    Args:
+        workspace: Attempt workspace directory to inspect.
+        sdk_error: Raw SDK error text, if the attempt raised one.
+        last_phase: Phase that last executed (overrides the on-disk marker).
+        acceptable_eval_gap: Maximum tolerated relative accuracy gap.
+        artifacts: Pre-scanned artifacts; supply to avoid a duplicate disk
+            pass.
+
+    Returns:
+        ``None`` for a clean success, otherwise the classified
+        :class:`OutcomeId`.
     """
 
     art = artifacts if artifacts is not None else collect_artifacts(Path(workspace))
@@ -385,6 +416,15 @@ def build_assessment(
     * ``final`` = last attempt's outcome.
     * ``recovered`` = True iff len(attempts) > 1 AND final ∈ SUCCESS_TAGS.
     * ``eval_gap`` = ``relative_gap`` from the latest ``eval_report.json``.
+
+    Args:
+        attempts: Per-attempt outcomes in chronological order.
+        workspace: Workspace directory used to collect artifacts.
+        artifacts: Pre-scanned artifacts; supply to avoid a disk pass.
+        notes: Extra human-readable notes to attach to the assessment.
+
+    Returns:
+        The assembled :class:`Assessment`.
     """
 
     if not attempts:
@@ -414,8 +454,15 @@ def build_assessment(
 def derive_status(assessment: Assessment, artifacts: CollectedArtifacts) -> str:
     """Map an ``Assessment`` to a public status string per design §5.4.
 
-    Returns ``"success"`` / ``"partial"`` / ``"failed"``. Consumed by
+    Consumed by
     :class:`quantization_agent.driver.retry.QuantSkillRunResult`.
+
+    Args:
+        assessment: The assembled assessment to map.
+        artifacts: Collected artifacts used for status demotion checks.
+
+    Returns:
+        One of ``"success"``, ``"partial"``, or ``"failed"``.
     """
 
     final = assessment.final

--- a/quantization_agent/driver/assessment.py
+++ b/quantization_agent/driver/assessment.py
@@ -80,6 +80,12 @@ class Assessment:
     notes: tuple[str, ...] = field(default_factory=tuple)
 
     def to_dict(self) -> dict:
+        """Serialize the assessment to a JSON-friendly dictionary.
+
+        Returns:
+            A dict with the final outcome, per-attempt outcomes, recovery flag,
+            evaluation gap, and notes, using enum *values* for outcome ids.
+        """
         return {
             "final": self.final.value if self.final is not None else None,
             "attempts": [a.value if a is not None else None for a in self.attempts],
@@ -120,6 +126,15 @@ _QUANTIZED_LOAD_PATTERNS = (
 
 
 def _contains_any(haystack: str, needles: tuple[str, ...]) -> bool:
+    """Return whether any needle substring appears in ``haystack``.
+
+    Args:
+        haystack: String to search within.
+        needles: Candidate substrings to look for.
+
+    Returns:
+        ``True`` if at least one needle is found, otherwise ``False``.
+    """
     for n in needles:
         if n in haystack:
             return True
@@ -127,6 +142,15 @@ def _contains_any(haystack: str, needles: tuple[str, ...]) -> bool:
 
 
 def _parse_blocked_outcome(text: str | None) -> OutcomeId | None:
+    """Extract an explicit ``BLOCKED`` outcome id from agent output text.
+
+    Args:
+        text: Free-form text that may contain a ``BLOCKED`` outcome marker.
+
+    Returns:
+        The matching :class:`OutcomeId`, or ``None`` when no valid marker is
+        present.
+    """
     if not text:
         return None
     m = _BLOCKED_OUTCOME_RE.search(text)
@@ -234,6 +258,15 @@ def _classify_phase_artifact_gap(
 
 
 def _classify_bootstrap_sdk_error(sdk_error: str) -> OutcomeId | None:
+    """Classify a bootstrap-phase SDK error message into an outcome.
+
+    Args:
+        sdk_error: Raw error text raised before the skill chain started.
+
+    Returns:
+        The matching bootstrap :class:`OutcomeId` (e.g. missing Quark root,
+        unwritable workspace, runtime error), or ``None`` if unrecognized.
+    """
     msg = sdk_error.lower()
     if "quark_root" in msg or ("quark root" in msg and ("missing" in msg or "not found" in msg)):
         return OutcomeId.quark_root_missing

--- a/quantization_agent/driver/eval.py
+++ b/quantization_agent/driver/eval.py
@@ -88,6 +88,18 @@ def decide(
     workspace: Path,
     acceptable_eval_gap: float | None,
 ) -> EvalDecision:
+    """Decide whether an evaluation report passes the quality gap threshold.
+
+    Args:
+        eval_report: Parsed evaluation report, or ``None`` when absent.
+        workspace: Run workspace, used to resolve a per-run gap threshold file.
+        acceptable_eval_gap: Explicit maximum relative gap; falls back to the
+            workspace threshold or the default when ``None``.
+
+    Returns:
+        An :class:`EvalDecision` describing the status (``missing``,
+        ``within``, or ``exceeded``), the relative gap, and the threshold used.
+    """
     threshold, source = resolve_threshold(
         workspace, acceptable_eval_gap=acceptable_eval_gap
     )

--- a/quantization_agent/driver/eval.py
+++ b/quantization_agent/driver/eval.py
@@ -65,7 +65,18 @@ def resolve_threshold(
     *,
     acceptable_eval_gap: float | None,
 ) -> tuple[float, str]:
-    """Return ``(threshold, source)`` per §3.1 priority chain."""
+    """Resolve the eval-gap threshold per the §3.1 priority chain.
+
+    Args:
+        workspace: Workspace directory that may hold a threshold override
+            file.
+        acceptable_eval_gap: Explicit threshold argument; takes precedence
+            when provided.
+
+    Returns:
+        A ``(threshold, source)`` tuple where ``source`` is ``"arg"``,
+        ``"file"``, or ``"default"``.
+    """
 
     if acceptable_eval_gap is not None:
         return float(acceptable_eval_gap), "arg"

--- a/quantization_agent/driver/outcomes.py
+++ b/quantization_agent/driver/outcomes.py
@@ -21,6 +21,7 @@ except ImportError:  # Python 3.10 fallback — mirror 3.11 StrEnum semantics
 
     class StrEnum(str, Enum):
         def __str__(self) -> str:
+            """Return the enum's string value (mirrors 3.11 ``StrEnum``)."""
             return str(self.value)
 
 

--- a/quantization_agent/driver/outcomes.py
+++ b/quantization_agent/driver/outcomes.py
@@ -21,7 +21,11 @@ except ImportError:  # Python 3.10 fallback — mirror 3.11 StrEnum semantics
 
     class StrEnum(str, Enum):
         def __str__(self) -> str:
-            """Return the enum's string value (mirrors 3.11 ``StrEnum``)."""
+            """Return the enum's string value (mirrors 3.11 ``StrEnum``).
+
+            Returns:
+                The member's underlying string value.
+            """
             return str(self.value)
 
 

--- a/quantization_agent/driver/outcomes.py
+++ b/quantization_agent/driver/outcomes.py
@@ -21,7 +21,11 @@ except ImportError:  # Python 3.10 fallback — mirror 3.11 StrEnum semantics
 
     class StrEnum(str, Enum):
         def __str__(self) -> str:
-            """Return the enum's string value (mirrors 3.11 ``StrEnum``)."""
+            """Return the enum's string value (mirrors 3.11 ``StrEnum``).
+
+            Returns:
+                The enum member's string value.
+            """
             return str(self.value)
 
 

--- a/quantization_agent/driver/result_collector.py
+++ b/quantization_agent/driver/result_collector.py
@@ -107,6 +107,15 @@ _STEP_LINE_RE = re.compile(
 
 
 def _parse_validation_report(text: str) -> ValidationSteps:
+    """Parse the validator's Markdown report into per-step statuses.
+
+    Args:
+        text: Contents of ``validation_report.md``.
+
+    Returns:
+        A :class:`ValidationSteps` with the auxiliary, MD5, config, and fuzzy
+        step statuses (``ok`` / ``FAIL`` / ``skipped`` / ``None`` if absent).
+    """
     by_num: dict[str, str] = {}
     for m in _STEP_LINE_RE.finditer(text):
         # Normalize to lower-case "ok"/"fail"/"skipped" for downstream compares.
@@ -123,6 +132,14 @@ def _parse_validation_report(text: str) -> ValidationSteps:
 
 
 def _read_text(path: Path) -> str | None:
+    """Read a UTF-8 text file, returning ``None`` if it cannot be read.
+
+    Args:
+        path: File to read.
+
+    Returns:
+        The file contents, or ``None`` when the file is missing or unreadable.
+    """
     try:
         return path.read_text(encoding="utf-8")
     except FileNotFoundError:
@@ -132,6 +149,17 @@ def _read_text(path: Path) -> str | None:
 
 
 def _read_json(path: Path) -> tuple[dict | None, str | None]:
+    """Read and parse a JSON file.
+
+    Args:
+        path: File to read.
+
+    Returns:
+        A ``(data, error)`` tuple. On success ``data`` is the parsed object and
+        ``error`` is ``None``; on a decode failure ``data`` is ``None`` and
+        ``error`` is a human-readable message. A missing file yields
+        ``(None, None)``.
+    """
     raw = _read_text(path)
     if raw is None:
         return None, None
@@ -179,6 +207,15 @@ def _resolve_quantized_dir(workspace: Path) -> tuple[Path | None, bool, str | No
 
 
 def _has_any(directory: Path, names: Iterable[str]) -> bool:
+    """Return whether any of the named files exists in ``directory``.
+
+    Args:
+        directory: Directory to check.
+        names: Candidate file names.
+
+    Returns:
+        ``True`` if at least one named file exists, otherwise ``False``.
+    """
     for name in names:
         if (directory / name).is_file():
             return True
@@ -186,6 +223,15 @@ def _has_any(directory: Path, names: Iterable[str]) -> bool:
 
 
 def _has_glob(directory: Path, patterns: Iterable[str]) -> bool:
+    """Return whether any glob pattern matches a file in ``directory``.
+
+    Args:
+        directory: Directory to search.
+        patterns: Glob patterns to test.
+
+    Returns:
+        ``True`` if at least one pattern matches an entry, otherwise ``False``.
+    """
     for pat in patterns:
         for _ in directory.glob(pat):
             return True
@@ -213,6 +259,15 @@ def _scan_hypothesis_attempts(workspace: Path) -> tuple[int, ...]:
 
 
 def _strict_validation_enabled(env: dict[str, str] | None = None) -> bool:
+    """Return whether strict validation mode is enabled.
+
+    Args:
+        env: Environment mapping to read from; defaults to ``os.environ``.
+
+    Returns:
+        ``True`` unless ``STRICT_VALIDATION_ENV`` is explicitly set to a
+        falsy value (``0``, ``false``, ``no``, or empty).
+    """
     raw = (env if env is not None else os.environ).get(STRICT_VALIDATION_ENV, "1")
     return raw.strip().lower() not in ("0", "false", "no", "")
 
@@ -226,6 +281,21 @@ def collect_artifacts(
     *,
     env: dict[str, str] | None = None,
 ) -> CollectedArtifacts:
+    """Scan a run workspace and summarize the on-disk artifacts.
+
+    Inspects the run manifest, quantized model directory, validation report,
+    eval report, and retry/hypothesis markers to build the evidence record the
+    outcome classifier consumes.
+
+    Args:
+        workspace: Per-run workspace directory to inspect.
+        env: Environment mapping used for feature flags; defaults to
+            ``os.environ``.
+
+    Returns:
+        A :class:`CollectedArtifacts` describing which expected outputs are
+        present and any parse errors encountered.
+    """
     workspace = Path(workspace)
 
     qdir, manifest_present, manifest_err = _resolve_quantized_dir(workspace)

--- a/quantization_agent/driver/result_collector.py
+++ b/quantization_agent/driver/result_collector.py
@@ -172,9 +172,17 @@ def _read_json(path: Path) -> tuple[dict | None, str | None]:
 def _resolve_quantized_dir(workspace: Path) -> tuple[Path | None, bool, str | None]:
     """Read ``run_manifest.yaml`` and pull ``outputs.quantized_model_dir``.
 
-    Returns ``(path, manifest_present, parse_error)``. PyYAML is imported
-    lazily so the agent stays installable without it — falling back to the
-    ``nice_to_have_skipped`` (#20) outcome in that case.
+    PyYAML is imported lazily so the agent stays installable without it —
+    falling back to the ``nice_to_have_skipped`` (#20) outcome in that case.
+
+    Args:
+        workspace: Workspace directory containing ``run_manifest.yaml``.
+
+    Returns:
+        A ``(path, manifest_present, parse_error)`` tuple. ``path`` is the
+        resolved quantized-model directory (or ``None``), ``manifest_present``
+        indicates the manifest file existed, and ``parse_error`` carries a
+        reason string when parsing failed.
     """
 
     manifest = workspace / "run_manifest.yaml"
@@ -244,6 +252,12 @@ def _scan_hypothesis_attempts(workspace: Path) -> tuple[int, ...]:
     The classifier uses these to decide if SKILL.md actually diagnosed a fix
     before the retry was attempted (precondition for incrementing the
     retry counter — see §A.10).
+
+    Args:
+        workspace: Workspace directory to scan.
+
+    Returns:
+        The sorted attempt numbers ``N`` found on disk (empty if none).
     """
 
     pattern = re.compile(r"^fix_hypothesis_attempt_(\d+)\.md$")

--- a/quantization_agent/driver/retry.py
+++ b/quantization_agent/driver/retry.py
@@ -167,6 +167,14 @@ def _has_fix_hypothesis(workspace: Path, attempt_number: int) -> bool:
     Per §A.10, before re-running quark-torch-ptq SKILL.md must drop a concrete fix
     plan at ``fix_hypothesis_attempt_<next>.md``. Absence is the gate that
     prevents blind retries.
+
+    Args:
+        workspace: Workspace directory to inspect.
+        attempt_number: The current attempt number; the next attempt's
+            hypothesis file is ``attempt_number + 1``.
+
+    Returns:
+        ``True`` if the next attempt's fix-hypothesis file exists.
     """
 
     return (workspace / f"fix_hypothesis_attempt_{attempt_number + 1}.md").is_file()
@@ -200,7 +208,20 @@ def _decide_next_step(
     max_requantize_attempts: int,
     counter: int,
 ) -> _RetryDecision:
-    """Decide whether to retry, accept, or stop after one attempt."""
+    """Decide whether to retry, accept, or stop after one attempt.
+
+    Args:
+        outcome: The classified outcome of the just-finished attempt.
+        workspace: Attempt workspace directory.
+        attempt_number: Zero-based index of the attempt just completed.
+        interactive: Whether operator prompts are allowed.
+        max_requantize_attempts: Cap on requantize retries.
+        counter: Current value of the persisted requantize counter.
+
+    Returns:
+        A :class:`_RetryDecision` describing whether to retry, promote, or
+        terminate, plus a debugging note.
+    """
 
     if outcome is None or outcome in SUCCESS_TAGS:
         return _RetryDecision(retry=False, note="")
@@ -269,11 +290,25 @@ async def quantize_via_prompt(
 ) -> QuantSkillRunResult:
     """Run the quantization-agent against ``prompt`` and return a result.
 
-    All inputs except ``prompt`` and ``workspace`` are optional. ``quark_root``
-    falls back to ``$QUARK_ROOT`` then to a hard error (mapped to
-    ``quark_root_missing`` at the assessment level). The threshold resolves
-    per ``_eval.resolve_threshold``; the interactive flag per
-    ``_resolve_interactive``.
+    ``quark_root`` falls back to ``$QUARK_ROOT`` then to a hard error
+    (mapped to ``quark_root_missing`` at the assessment level). The
+    threshold resolves per ``_eval.resolve_threshold``; the interactive
+    flag per ``_resolve_interactive``.
+
+    Args:
+        prompt: The quantization instruction prompt.
+        workspace: Directory for attempt artifacts (created if needed).
+        quark_root: Quark checkout root; falls back to ``$QUARK_ROOT``.
+        interactive: Force interactive operator prompts; auto-resolved
+            when ``None``.
+        acceptable_eval_gap: Maximum tolerated relative accuracy gap.
+        max_requantize_attempts: Cap on requantize retries.
+        model: Optional model identifier passed to the runner.
+        runner_fn: Override for the single-attempt runner (testing hook).
+        log: Optional line-logging callback.
+
+    Returns:
+        The assembled :class:`QuantSkillRunResult`.
     """
 
     workspace_path = Path(workspace).resolve()
@@ -377,6 +412,14 @@ def _build_failed_bootstrap_result(
     note: str,
 ) -> QuantSkillRunResult:
     """Fast-path failure that bypasses the SDK (used for bootstrap errors).
+
+    Args:
+        workspace: Workspace directory for the (failed) attempt.
+        outcome: The bootstrap-level outcome to record.
+        note: Human-readable note attached to the assessment.
+
+    Returns:
+        A well-formed failed :class:`QuantSkillRunResult`.
 
     Produces a well-formed ``QuantSkillRunResult`` so callers can branch on
     ``status`` / ``assessment.final`` without special-casing pre-flight

--- a/quantization_agent/driver/retry.py
+++ b/quantization_agent/driver/retry.py
@@ -82,6 +82,15 @@ class QuantSkillRunResult:
 # ─────────────────────────────────────────────────────────────────────────────
 
 def _read_counter(workspace: Path) -> int:
+    """Read the persisted requantize-attempt counter.
+
+    Args:
+        workspace: Run workspace holding the counter file.
+
+    Returns:
+        The current counter value, or ``0`` when the file is absent or
+        unreadable.
+    """
     f = workspace / _COUNTER_FILE
     if not f.is_file():
         return 0
@@ -92,6 +101,14 @@ def _read_counter(workspace: Path) -> int:
 
 
 def _bump_counter(workspace: Path) -> int:
+    """Increment and persist the requantize-attempt counter.
+
+    Args:
+        workspace: Run workspace holding the counter file.
+
+    Returns:
+        The new counter value after incrementing.
+    """
     n = _read_counter(workspace) + 1
     (workspace / _COUNTER_FILE).write_text(str(n), encoding="utf-8")
     return n
@@ -102,6 +119,15 @@ def _bump_counter(workspace: Path) -> int:
 # ─────────────────────────────────────────────────────────────────────────────
 
 def _resolve_interactive(interactive: bool | None) -> bool:
+    """Resolve the effective interactive mode.
+
+    Args:
+        interactive: Explicit mode, or ``None`` to auto-detect from the tty.
+
+    Returns:
+        The explicit value when provided, otherwise ``True`` only when both
+        stdin and stderr are attached to a tty.
+    """
     if interactive is not None:
         return interactive
     # Auto: only enable if stdin is a tty AND stderr is a tty (we use stderr
@@ -114,6 +140,15 @@ def _resolve_interactive(interactive: bool | None) -> bool:
 
 
 def _ask_operator(message: str) -> bool:
+    """Prompt the operator on stderr for a yes/no decision.
+
+    Args:
+        message: Question to display.
+
+    Returns:
+        ``True`` if the operator answers ``y``/``yes``; ``False`` otherwise,
+        including on EOF or interrupt.
+    """
     print(message, file=sys.stderr, flush=True)
     try:
         line = sys.stdin.readline()
@@ -364,6 +399,15 @@ def _build_failed_bootstrap_result(
 # Convenience sync wrapper for the CLI smoke path. The library entry remains
 # async to compose cleanly with the orchestrator's asyncio loop.
 def quantize_via_prompt_sync(prompt: str, **kwargs: Any) -> QuantSkillRunResult:
+    """Synchronous wrapper around :func:`quantize_via_prompt`.
+
+    Args:
+        prompt: Natural-language quantization request.
+        **kwargs: Keyword arguments forwarded to :func:`quantize_via_prompt`.
+
+    Returns:
+        The :class:`QuantSkillRunResult` produced by the async entry point.
+    """
     return asyncio.run(quantize_via_prompt(prompt, **kwargs))
 
 

--- a/quantization_agent/driver/runner.py
+++ b/quantization_agent/driver/runner.py
@@ -45,6 +45,15 @@ class AttemptResult:
 
 
 def _import_sdk() -> tuple[Any, Any]:
+    """Import the Claude Agent SDK and return its query primitives.
+
+    Returns:
+        A ``(query, ClaudeAgentOptions)`` tuple from ``claude_agent_sdk``.
+
+    Raises:
+        RuntimeError: If the SDK is not installed or is missing the required
+            ``query`` / ``ClaudeAgentOptions`` attributes.
+    """
     try:
         import claude_agent_sdk as sdk  # type: ignore[import-not-found]
     except ImportError as exc:  # pragma: no cover - exercised via injection seams in tests
@@ -57,6 +66,17 @@ def _import_sdk() -> tuple[Any, Any]:
 
 
 def _iter_message_text(message: Any) -> Iterable[str]:
+    """Yield text fragments from a Claude Agent SDK message.
+
+    Handles the varying SDK message shapes: ``.content`` blocks exposing
+    ``.text`` (object or dict) and a top-level ``.result`` string.
+
+    Args:
+        message: An SDK message object.
+
+    Yields:
+        Each non-empty text fragment found on the message.
+    """
     for block in list(getattr(message, "content", None) or []):
         text = getattr(block, "text", None)
         if isinstance(text, str) and text:

--- a/quantization_agent/driver/runner.py
+++ b/quantization_agent/driver/runner.py
@@ -94,6 +94,13 @@ def resolve_skill_path(package_root: Path | None = None) -> Path:
     The SKILL is the runtime contract loaded into every attempt; resolution
     is centralized here so callers (including the CLI smoke test) don't
     hardcode the layout.
+
+    Args:
+        package_root: Override for the package root; defaults to the
+            parent of this module's directory.
+
+    Returns:
+        The path to ``SKILL.md`` under the package root.
     """
 
     # __file__ is .../quantization_agent/driver/runner.py — SKILL.md lives one
@@ -122,6 +129,20 @@ def build_attempt_prompt(
     prior outcome ID + the fix-hypothesis file SKILL.md wrote at the end of
     the previous attempt, so the LLM can target the diagnosed cause rather
     than re-running the same plan blindly.
+
+    Args:
+        user_prompt: The verbatim user instruction to embed.
+        skill_path: Path to ``SKILL.md`` (the runtime contract).
+        workspace: Directory where the attempt writes artifacts.
+        quark_root: Read-only Quark project root.
+        attempt_number: 1-based attempt index.
+        acceptable_eval_gap: Caller-supplied eval-gap threshold, if any.
+        interactive: Interactivity mode (``None`` = auto).
+        previous_outcome: Prior attempt's outcome ID, for retry context.
+        fix_hypothesis_path: Path to the prior fix-hypothesis file, if any.
+
+    Returns:
+        The fully-rendered prompt string.
     """
 
     interactive_str = (
@@ -191,6 +212,25 @@ async def run_one_attempt(
     and returned via ``AttemptResult.sdk_error`` rather than propagated, so
     the retry loop can read the workspace state — which often contains valid
     artifacts even when the SDK aborted late.
+
+    Args:
+        user_prompt: The verbatim user instruction.
+        workspace: Directory for attempt artifacts (created if needed).
+        quark_root: Read-only Quark project root.
+        attempt_number: 1-based attempt index.
+        acceptable_eval_gap: Caller-supplied eval-gap threshold, if any.
+        interactive: Interactivity mode (``None`` = auto).
+        previous_outcome: Prior attempt's outcome ID, for retry context.
+        skill_path: Override for the ``SKILL.md`` path.
+        model: Optional model identifier.
+        max_turns: Maximum SDK turns for the session.
+        allowed_tools: Optional explicit tool allowlist.
+        sdk_query_factory: Override for the SDK query callable (testing).
+        sdk_options_cls: Override for the SDK options class (testing).
+        log: Optional line-logging callback.
+
+    Returns:
+        The :class:`AttemptResult` for the session.
     """
 
     workspace = Path(workspace)

--- a/robustness-agent/src/robustness_agent/config.py
+++ b/robustness-agent/src/robustness_agent/config.py
@@ -485,6 +485,17 @@ def _discover_workload_uid() -> str:
 
 
 def _env_bool(name: str, default: bool) -> bool:
+    """Read a boolean configuration value from the environment.
+
+    Args:
+        name: Name of the environment variable to read.
+        default: Value to return when the variable is unset.
+
+    Returns:
+        ``True`` when the variable is set to one of ``1``, ``true``, ``yes``,
+        or ``on`` (case-insensitive); ``False`` for any other set value; and
+        ``default`` when the variable is unset.
+    """
     raw = os.environ.get(name)
     if raw is None:
         return default
@@ -492,6 +503,17 @@ def _env_bool(name: str, default: bool) -> bool:
 
 
 def _env_int(name: str, default: int) -> int:
+    """Read an integer configuration value from the environment.
+
+    Args:
+        name: Name of the environment variable to read.
+        default: Value to return when the variable is unset, empty, or not a
+            valid integer.
+
+    Returns:
+        The parsed integer, or ``default`` when the variable is missing or
+        cannot be parsed.
+    """
     raw = (os.environ.get(name) or "").strip()
     if not raw:
         return default

--- a/robustness-agent/src/robustness_agent/config.py
+++ b/robustness-agent/src/robustness_agent/config.py
@@ -476,6 +476,9 @@ def _discover_workload_uid() -> str:
 
     Lets a RayJob sandbox opt into hierarchy-based pod discovery; single-node
     runs leave every key unset and fall back to ``list_session_pods``.
+
+    Returns:
+        The first non-empty workload-uid env value, or ``""`` if none set.
     """
     for key in _WORKLOAD_UID_ENV_KEYS:
         value = (os.environ.get(key) or "").strip()

--- a/robustness-agent/src/robustness_agent/decision/action_ladder.py
+++ b/robustness-agent/src/robustness_agent/decision/action_ladder.py
@@ -406,8 +406,17 @@ _LADDER_KEY_SEP: str = "\x1f"  # ASCII unit separator — safe inside JSON strin
 def _encode_last_emitted(
     last_emitted: dict[tuple[str, ...], int],
 ) -> dict[str, int]:
-    """Serialise a tuple-keyed cooldown dict to a JSON-safe dict (tuple
-    components joined with ``_LADDER_KEY_SEP`` so decode recovers them)."""
+    """Serialise a tuple-keyed cooldown dict to a JSON-safe dict.
+
+    Tuple components are joined with ``_LADDER_KEY_SEP`` so the decoder can
+    recover them.
+
+    Args:
+        last_emitted: Cooldown map keyed by tuple of string components.
+
+    Returns:
+        A string-keyed dict safe for JSON serialization.
+    """
     out: dict[str, int] = {}
     for key, tick in last_emitted.items():
         try:

--- a/robustness-agent/src/robustness_agent/factory.py
+++ b/robustness-agent/src/robustness_agent/factory.py
@@ -490,6 +490,16 @@ class _QuietFallback:
     reason: str
 
     async def fetch(self, ctx: Any) -> SourceData:  # noqa: ARG002 - protocol
+        """Return empty source data describing the disabled local probe.
+
+        Args:
+            ctx: Fetch context supplied by the source protocol; unused because
+                this fallback never collects data.
+
+        Returns:
+            A :class:`SourceData` with no signals, annotated with a
+            ``degraded_reason`` explaining that the local probe is disabled.
+        """
         return SourceData(
             degraded_reason=f"local-probe disabled: {self.reason}",
             sources_used=[self.name],

--- a/robustness-agent/src/robustness_agent/finalize/postmortem.py
+++ b/robustness-agent/src/robustness_agent/finalize/postmortem.py
@@ -585,7 +585,14 @@ def finalize_session(
 ) -> bool:
     """Convenience wrapper for non-reactor callers (e.g. post-hoc re-runs).
 
-    Returns the :meth:`PostmortemFinalizer.finalize` boolean.
+    Args:
+        session_dir: Session directory to finalize.
+        session_id: Identifier of the session.
+        stop_reason: Reason recorded for finalization.
+        config: Optional finalizer configuration.
+
+    Returns:
+        The :meth:`PostmortemFinalizer.finalize` boolean.
     """
     finalizer = PostmortemFinalizer(
         session_dir=session_dir,
@@ -602,8 +609,16 @@ def finalize_session(
 def _pick_flashpoint(
     findings: list[dict[str, Any]],
 ) -> dict[str, Any] | None:
-    """First HIGH-severity finding, ordered by ``tick_index`` then
-    ``timestamp_unix`` (tie-break). ``None`` if nothing crossed HIGH."""
+    """Pick the earliest HIGH-severity finding as the flashpoint.
+
+    Ordered by ``tick_index`` then ``timestamp_unix`` (tie-break).
+
+    Args:
+        findings: Candidate finding dicts.
+
+    Returns:
+        The first HIGH-severity finding, or ``None`` if none crossed HIGH.
+    """
     high = [
         f for f in findings
         if isinstance(f, dict) and str(f.get("severity")) == "high"
@@ -624,9 +639,19 @@ def _normalise_task_entry(
     result_path: Path,
     payload: dict[str, Any],
 ) -> dict[str, Any]:
-    """Project an executor ``result.json`` into the trace shape, capturing
-    the union of action-specific fields (e.g. ``output_throughput`` vs
-    ``gain_pct``) so dashboards need not re-read each file."""
+    """Project an executor ``result.json`` into the trace entry shape.
+
+    Captures the union of action-specific fields (e.g. ``output_throughput``
+    vs ``gain_pct``) so dashboards need not re-read each file.
+
+    Args:
+        task_dir: The task's workspace directory.
+        result_path: Path to the task's ``result.json``.
+        payload: Parsed result payload.
+
+    Returns:
+        A normalized trace entry dict.
+    """
     entry: dict[str, Any] = {
         "task_id": task_dir.name,
         "workspace": str(task_dir),

--- a/robustness-agent/src/robustness_agent/main.py
+++ b/robustness-agent/src/robustness_agent/main.py
@@ -37,9 +37,15 @@ def _setup_logging() -> None:
 
 
 async def _run_reactor_mode(config: Config) -> None:
-    """Standalone reactor loop for dev / debugging; polls sources at
-    ``standalone_tick_interval_s`` and writes findings to disk. (Production
-    drives the same reactor via ``runtime.cli tick`` in a subprocess.)"""
+    """Run the standalone reactor loop for dev / debugging.
+
+    Polls sources at ``standalone_tick_interval_s`` and writes findings to
+    disk. (Production drives the same reactor via ``runtime.cli tick`` in a
+    subprocess.)
+
+    Args:
+        config: The resolved agent configuration.
+    """
     log = logging.getLogger("robustness_agent")
     bundle = build_reactor_components(config)
 

--- a/robustness-agent/src/robustness_agent/role/prompt_inputs.py
+++ b/robustness-agent/src/robustness_agent/role/prompt_inputs.py
@@ -353,6 +353,12 @@ def _count_optimization_stack(head: str) -> int:
 
     ``SharedState._format_optimization_stack`` emits ``"(none)"`` (empty) or a
     Python list repr (e.g. ``['baseline:v1', 'integrate:v2']``).
+
+    Args:
+        head: The rendered ``optimization_stack`` head value.
+
+    Returns:
+        The number of stack entries (``0`` when empty/unparseable).
     """
     if not head or head == "(none)":
         return 0
@@ -372,7 +378,12 @@ def _parse_time_budget_into(snapshot: SharedStateSnapshot, body: str) -> None:
     """Decode the ``=== Time budget ===`` section in place onto ``snapshot``.
 
     The Coordinator emits one body line below the header; an absent section
-    leaves defaults so BudgetMonitor / deadline_imminent signals short-circuit.
+    leaves defaults so BudgetMonitor / deadline_imminent signals
+    short-circuit.
+
+    Args:
+        snapshot: Snapshot mutated in place with parsed budget fields.
+        body: The time-budget section body text.
     """
     if not body:
         return
@@ -413,6 +424,12 @@ def _split_double_space(value: str) -> str:
 
     ``to_prompt_summary`` joins two scalars with two spaces
     (``baseline_tput=...  baseline_acc=...``); cut at that boundary.
+
+    Args:
+        value: The raw scalar text possibly containing a trailing neighbour.
+
+    Returns:
+        The value trimmed at the first double-space boundary.
     """
     return value.split("  ", 1)[0].strip()
 

--- a/robustness-agent/src/robustness_agent/role/reactor.py
+++ b/robustness-agent/src/robustness_agent/role/reactor.py
@@ -167,9 +167,17 @@ class Reactor:
         return validated_intents
 
     def _resolve_authoritative_tick(self, ctx: ReactorContext) -> int:
-        """Pick the most reliable tick index: prefer the Coordinator's
-        session-wide ``ctx.shared_state.tick``, else the in-memory counter
-        (tests / first tick before the prompt is written).
+        """Pick the most reliable tick index for this reactor pass.
+
+        Prefers the Coordinator's session-wide ``ctx.shared_state.tick``,
+        else the in-memory counter (tests / first tick before the prompt is
+        written).
+
+        Args:
+            ctx: Reactor context for the current tick.
+
+        Returns:
+            The resolved authoritative tick index.
         """
         shared_tick = getattr(ctx.shared_state, "tick", 0) or 0
         if shared_tick > 0:

--- a/robustness-agent/src/robustness_agent/signals/budget.py
+++ b/robustness-agent/src/robustness_agent/signals/budget.py
@@ -204,7 +204,18 @@ def _burn_no_gain_symptom(
 def _strategy_drift_symptom(
     snap: SharedStateSnapshot, *, burn_pct: float, cfg: BudgetConfig,
 ) -> Symptom:
-    """H2 early warning: 50% burnt and nothing to ship; MEDIUM (diagnose only)."""
+    """H2 early-warning symptom: budget half-burnt with nothing to ship.
+
+    MEDIUM severity (diagnose only).
+
+    Args:
+        snap: Current shared-state snapshot.
+        burn_pct: Fraction of the wall-clock budget consumed.
+        cfg: Budget configuration thresholds.
+
+    Returns:
+        The constructed :class:`Symptom`.
+    """
     return Symptom(
         name="budget_strategy_drift",
         severity=SymptomSeverity.MEDIUM,
@@ -238,7 +249,19 @@ def _deadline_warning_symptom(
     validated: float,
     cfg: BudgetConfig,
 ) -> Symptom:
-    """H1 absolute-time warning (<30 min): MEDIUM with validated gain, HIGH without."""
+    """H1 absolute-time warning symptom (deadline approaching).
+
+    MEDIUM severity when validated gain exists, HIGH without.
+
+    Args:
+        snap: Current shared-state snapshot.
+        remaining: Minutes remaining in the budget.
+        validated: Cumulative validated gain percentage.
+        cfg: Budget configuration thresholds.
+
+    Returns:
+        The constructed :class:`Symptom`.
+    """
     if validated < cfg.productive_gain_pct:
         severity = SymptomSeverity.HIGH
         tail = "validated_gain still 0; wind the session down now"
@@ -277,7 +300,18 @@ def _deadline_warning_symptom(
 def _hard_cutoff_symptom(
     snap: SharedStateSnapshot, *, remaining: float, cfg: BudgetConfig,
 ) -> Symptom:
-    """H1 absolute-time emergency cut (<=5 min): always HIGH + delegate(report)."""
+    """H1 absolute-time emergency-cutoff symptom (deadline imminent).
+
+    Always HIGH severity and suggests delegating to the final report.
+
+    Args:
+        snap: Current shared-state snapshot.
+        remaining: Minutes remaining in the budget.
+        cfg: Budget configuration thresholds.
+
+    Returns:
+        The constructed :class:`Symptom`.
+    """
     return Symptom(
         name="deadline_hard_cutoff",
         severity=SymptomSeverity.HIGH,

--- a/robustness-agent/src/robustness_agent/signals/critic_health.py
+++ b/robustness-agent/src/robustness_agent/signals/critic_health.py
@@ -156,7 +156,19 @@ def _unavailable_streak_symptoms(
     data: SourceData,
     cfg: CriticHealthConfig,
 ) -> list[Symptom]:
-    """Count consecutive ``critic_unavailable`` verdicts across coordinator_events + inbox."""
+    """Detect a streak of consecutive ``critic_unavailable`` verdicts.
+
+    Scans ``coordinator_events`` plus the reactor inbox for the trailing
+    run of unavailable review verdicts.
+
+    Args:
+        ctx: Reactor context (supplies the inbox).
+        data: Collected source data (coordinator events).
+        cfg: Critic-health configuration thresholds.
+
+    Returns:
+        A list with one :class:`Symptom` when the streak trips, else empty.
+    """
     rows: list[dict[str, Any]] = []
     for event in data.coordinator_events:
         if not isinstance(event, dict):
@@ -267,7 +279,15 @@ def _prune_stuck_symptoms(
 def _runtime_stuck_symptoms(
     data: SourceData, cfg: CriticHealthConfig,
 ) -> list[Symptom]:
-    """Collapse ``runtime.cli .* timed out`` log hits into a critic-specific symptom."""
+    """Collapse ``runtime.cli .* timed out`` log hits into one symptom.
+
+    Args:
+        data: Collected source data (logs).
+        cfg: Critic-health configuration thresholds.
+
+    Returns:
+        A list with one :class:`Symptom` when timeouts are found, else empty.
+    """
     errors = data.local_log_errors
     if not isinstance(errors, list) or not errors:
         return []

--- a/robustness-agent/src/robustness_agent/signals/decision_audit.py
+++ b/robustness-agent/src/robustness_agent/signals/decision_audit.py
@@ -136,7 +136,17 @@ def _integrate_symptoms(
 
 
 def _g1_empty_patch_kept(entry: dict[str, Any]) -> list[Symptom]:
-    """G1: integrate KEEP/PARTIAL with patch_size_bytes == 0 — empty patch, so any gain is noise."""
+    """G1: flag a KEEP/PARTIAL integrate with an empty patch.
+
+    A ``patch_size_bytes == 0`` means no code changed, so any measured gain
+    is noise.
+
+    Args:
+        entry: A decision-audit ledger entry.
+
+    Returns:
+        A list with one :class:`Symptom` when the guard trips, else empty.
+    """
     patch_size = entry.get("patch_size_bytes")
     if not isinstance(patch_size, int) or patch_size > 0:
         return []
@@ -175,7 +185,17 @@ def _g1_empty_patch_kept(entry: dict[str, Any]) -> list[Symptom]:
 def _g2_decision_threshold_violated(
     entry: dict[str, Any], cfg: DecisionAuditConfig,
 ) -> list[Symptom]:
-    """G2: KEEP with gain_pct below ``min_keep_gain_pct`` (noise-floor); MEDIUM since the real fix is upstream's threshold."""
+    """G2: flag a KEEP whose gain is below the noise-floor threshold.
+
+    MEDIUM severity since the real fix is upstream's keep threshold.
+
+    Args:
+        entry: A decision-audit ledger entry.
+        cfg: Decision-audit configuration (supplies ``min_keep_gain_pct``).
+
+    Returns:
+        A list with one :class:`Symptom` when the guard trips, else empty.
+    """
     if entry.get("decision") != "KEEP":
         return []
     gain_pct = entry.get("gain_pct")
@@ -212,9 +232,19 @@ def _g2_decision_threshold_violated(
 def _g3_kernel_dispatch_bypassed(
     entry: dict[str, Any], cfg: DecisionAuditConfig,
 ) -> list[Symptom]:
-    """G3: KEEP'd patch likely never executed — ``dispatched_count == 0``, or absent
-    with ``|gain_pct| < dispatch_bypass_pre_post_epsilon_pct``. HIGH: a KEEP without
-    proof of execution is a false-positive in the optimization_stack.
+    """G3: flag a KEEP'd patch that likely never executed.
+
+    Trips when ``dispatched_count == 0``, or it is absent while
+    ``|gain_pct| < dispatch_bypass_pre_post_epsilon_pct``. HIGH severity: a
+    KEEP without proof of execution is a false-positive in the
+    optimization_stack.
+
+    Args:
+        entry: A decision-audit ledger entry.
+        cfg: Decision-audit configuration (dispatch-bypass epsilon).
+
+    Returns:
+        A list with one :class:`Symptom` when the guard trips, else empty.
     """
     if entry.get("decision") != "KEEP":
         return []
@@ -294,8 +324,18 @@ def _ci_metrics_symptoms(
 def _g4_negative_delta_kernel_kept(
     ci_metrics: dict[str, Any], ci_metrics_path: str,
 ) -> list[Symptom]:
-    """G4: kernels_optimized > 0 AND optimized_kernel_delta_pct <= 0 (net-negative).
-    HIGH because downstream aggregators treat kernels_optimized as a win count.
+    """G4: flag net-negative kernel changes counted as wins.
+
+    Trips when ``kernels_optimized > 0`` AND
+    ``optimized_kernel_delta_pct <= 0``. HIGH because downstream
+    aggregators treat ``kernels_optimized`` as a win count.
+
+    Args:
+        ci_metrics: Parsed ci_metrics document.
+        ci_metrics_path: Path of the ci_metrics file (recorded in evidence).
+
+    Returns:
+        A list with one :class:`Symptom` when the guard trips, else empty.
     """
     kernels_opt = ci_metrics.get("kernels_optimized")
     delta_pct = ci_metrics.get("optimized_kernel_delta_pct")
@@ -331,8 +371,18 @@ def _g4_negative_delta_kernel_kept(
 def _g5_baseline_zero_without_status(
     ci_metrics: dict[str, Any], ci_metrics_path: str,
 ) -> list[Symptom]:
-    """G5: any baseline-throughput field == 0 AND no ``status="baseline_failed"`` marker —
-    half-written ci_metrics that downstream mistakes for "no optimization space".
+    """G5: flag a zero baseline throughput lacking a failure marker.
+
+    Trips when any baseline-throughput field == 0 AND there is no
+    ``status="baseline_failed"`` marker — a half-written ci_metrics file
+    that downstream mistakes for "no optimization space".
+
+    Args:
+        ci_metrics: Parsed ci_metrics document.
+        ci_metrics_path: Path of the ci_metrics file (recorded in evidence).
+
+    Returns:
+        A list with one :class:`Symptom` when the guard trips, else empty.
     """
     if str(ci_metrics.get("status") or "") == "baseline_failed":
         return []
@@ -382,7 +432,18 @@ def _g5_baseline_zero_without_status(
 def _g6_schema_drift(
     ci_metrics: dict[str, Any], ci_metrics_path: str,
 ) -> list[Symptom]:
-    """G6: ci_metrics missing required schema fields OR using legacy names; MEDIUM (fix is in report_back)."""
+    """G6: flag ci_metrics schema drift.
+
+    Trips when required schema fields are missing OR legacy field names are
+    used. MEDIUM severity (the fix is in ``report_back``).
+
+    Args:
+        ci_metrics: Parsed ci_metrics document.
+        ci_metrics_path: Path of the ci_metrics file (recorded in evidence).
+
+    Returns:
+        A list with one :class:`Symptom` when the guard trips, else empty.
+    """
     keys = set(ci_metrics.keys())
     missing = _CI_METRICS_REQUIRED_FIELDS - keys
     legacy = keys & _CI_METRICS_LEGACY_FIELDS
@@ -421,7 +482,17 @@ def _oob_symptoms(
     entries: list[dict[str, Any]],
     cfg: DecisionAuditConfig,
 ) -> list[Symptom]:
-    """G7: OOB attempt advertises "expected speedup" but never measured; HIGH so downstream won't count it as kernels_optimized."""
+    """G7: flag OOB attempts advertising unmeasured "expected speedup".
+
+    HIGH severity so downstream won't count them as ``kernels_optimized``.
+
+    Args:
+        entries: OOB ``optimization_attempts.jsonl`` entries.
+        cfg: Decision-audit configuration.
+
+    Returns:
+        Symptoms for offending entries, possibly empty.
+    """
     out: list[Symptom] = []
     by_kernel: dict[str, dict[str, Any]] = {}
     for entry in entries:

--- a/robustness-agent/src/robustness_agent/signals/event.py
+++ b/robustness-agent/src/robustness_agent/signals/event.py
@@ -192,6 +192,13 @@ def _idempotency_replay_symptoms(
     Coordinator dedup keys only off ``idempotency_key``, so an LLM minting fresh keys
     per attempt with identical payload slips through. Fire when one action+payload hash
     carries ``>= idempotency_replay_threshold`` distinct keys within a tick.
+
+    Args:
+        ctx: Reactor context (supplies the inbox).
+        cfg: Event configuration (replay threshold).
+
+    Returns:
+        Symptoms for offending action+payload groups, possibly empty.
     """
     if not ctx.inbox:
         return []
@@ -260,9 +267,19 @@ def _recover_unsuccessful_symptoms(
     events: list[dict[str, Any]],
     cfg: EventConfig,
 ) -> list[Symptom]:
-    """Emit ``recover_unsuccessful`` (HIGH → delegate(report)) when the latest recover
-    hit ``state == "needs_review"`` — cleanup failed to free VRAM, terminal for this budget.
-    Inspects only the latest recover ``delegated_result``; earlier successes are not second-guessed.
+    """Emit ``recover_unsuccessful`` when the latest recover needs review.
+
+    Fires (HIGH → delegate(report)) when the latest recover hit
+    ``state == "needs_review"`` — cleanup failed to free VRAM, terminal for
+    this budget. Inspects only the latest recover ``delegated_result``;
+    earlier successes are not second-guessed.
+
+    Args:
+        events: Coordinator event dicts in chronological order.
+        cfg: Event configuration (recover lookback window).
+
+    Returns:
+        A list with one :class:`Symptom` when it fires, else empty.
     """
     head = events[-cfg.recover_lookback_events:] if events else []
     latest: dict[str, Any] | None = None
@@ -311,7 +328,17 @@ def _recover_unsuccessful_symptoms(
 
 
 def _is_recover_payload(payload: dict[str, Any]) -> bool:
-    """Best-effort check that a ``delegated_result`` came from ``recover`` (via ``kind`` or recover-only fields)."""
+    """Best-effort check that a ``delegated_result`` came from ``recover``.
+
+    Recognized via ``kind`` / ``action_name`` / ``family`` or recover-only
+    executor fields.
+
+    Args:
+        payload: A ``delegated_result`` payload.
+
+    Returns:
+        ``True`` if the payload appears to be from a recover action.
+    """
     if str(payload.get("kind") or "").strip() == "recover":
         return True
     if str(payload.get("action_name") or "").strip() == "recover":
@@ -373,7 +400,14 @@ def _normalise_events(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
 
 def _family_of(payload: dict[str, Any]) -> str:
-    """Best-effort family inference from a delegated_result payload; falls back to ``kind``."""
+    """Infer the action family from a ``delegated_result`` payload.
+
+    Args:
+        payload: A ``delegated_result`` payload.
+
+    Returns:
+        The family string, falling back to ``kind`` and then ``""``.
+    """
     family = payload.get("family")
     if isinstance(family, str) and family.strip():
         return family.strip()

--- a/robustness-agent/src/robustness_agent/signals/gpu_leak.py
+++ b/robustness-agent/src/robustness_agent/signals/gpu_leak.py
@@ -279,7 +279,16 @@ def evaluate_gpu_leak_signals(
     ctx: ReactorContext,
     data: SourceData,
 ) -> list[Symptom]:
-    """Module-level helper adapting the stateful detector to the ``(ctx, data)`` entry-point signature."""
+    """Adapt the stateful detector to the ``(ctx, data)`` entry point.
+
+    Args:
+        detector: The stateful GPU-leak detector instance.
+        ctx: Reactor context for the current tick.
+        data: Collected source data.
+
+    Returns:
+        The symptoms produced by the detector.
+    """
     return detector.evaluate(ctx, data)
 
 

--- a/robustness-agent/src/robustness_agent/signals/kernel_pipeline.py
+++ b/robustness-agent/src/robustness_agent/signals/kernel_pipeline.py
@@ -424,7 +424,18 @@ def evaluate_kernel_pipeline_signals(
     *,
     config: KernelPipelineConfig | None = None,
 ) -> list[Symptom]:
-    """Stateless slice of F (F2 / F4 / F5); F1 is stateful in :class:`RayPendingDetector`."""
+    """Evaluate the stateless kernel-pipeline signals (F2 / F4 / F5).
+
+    F1 is stateful and lives in :class:`RayPendingDetector`.
+
+    Args:
+        ctx: Reactor context for the current tick.
+        data: Collected source data.
+        config: Optional configuration; a default is used when ``None``.
+
+    Returns:
+        The kernel-pipeline symptoms, possibly empty.
+    """
     cfg = config or KernelPipelineConfig()
     out: list[Symptom] = []
     out.extend(_geak_budget_symptoms(data, cfg))

--- a/robustness-agent/src/robustness_agent/signals/local_health.py
+++ b/robustness-agent/src/robustness_agent/signals/local_health.py
@@ -270,8 +270,17 @@ def _disk_pressure_symptoms(
     data: SourceData,
     cfg: LocalHealthConfig,
 ) -> list[Symptom]:
-    """Emit ``disk_pressure`` for non-SHM mountpoints under capacity stress; SHM is handled
-    separately with stricter thresholds, so it's skipped here to avoid double-firing.
+    """Emit ``disk_pressure`` for non-SHM mountpoints under capacity stress.
+
+    SHM is handled separately with stricter thresholds, so it is skipped
+    here to avoid double-firing.
+
+    Args:
+        data: Collected source data (per-mountpoint disk stats).
+        cfg: Local-health configuration thresholds.
+
+    Returns:
+        Symptoms for stressed mountpoints, possibly empty.
     """
     if not isinstance(data.local_disk, dict) or not data.local_disk:
         return []
@@ -328,8 +337,18 @@ def _shm_pressure_symptoms(
     data: SourceData,
     cfg: LocalHealthConfig,
 ) -> list[Symptom]:
-    """Emit ``shm_pressure`` (stricter thresholds): SGLang/vLLM crash hard when /dev/shm fills,
-    surfaced at runtime before the next server start fails with ``shared memory allocation failed``.
+    """Emit ``shm_pressure`` (stricter thresholds) for SHM mountpoints.
+
+    SGLang/vLLM crash hard when /dev/shm fills; this surfaces the pressure
+    before the next server start fails with ``shared memory allocation
+    failed``.
+
+    Args:
+        data: Collected source data (per-mountpoint disk stats).
+        cfg: Local-health configuration thresholds.
+
+    Returns:
+        Symptoms for stressed SHM mountpoints, possibly empty.
     """
     if not isinstance(data.local_disk, dict) or not data.local_disk:
         return []
@@ -382,8 +401,17 @@ def _shm_pressure_symptoms(
 
 
 def _ray_head_dead_symptoms(data: SourceData) -> list[Symptom]:
-    """Emit ``ray_head_dead`` (HIGH) when ``data.local_ray`` reports ``healthy=False``;
-    silent when the probe slot is empty or healthy. Prompts Orchestration to prune kernel_opt.
+    """Emit ``ray_head_dead`` (HIGH) when the Ray head is unhealthy.
+
+    Fires when ``data.local_ray`` reports ``healthy=False``; silent when the
+    probe slot is empty or healthy. Prompts Orchestration to prune
+    kernel_opt.
+
+    Args:
+        data: Collected source data (Ray head probe).
+
+    Returns:
+        A list with one :class:`Symptom` when unhealthy, else empty.
     """
     ray_info = getattr(data, "local_ray", None)
     if not isinstance(ray_info, dict) or not ray_info:
@@ -416,8 +444,17 @@ def _fd_pressure_symptoms(
     data: SourceData,
     cfg: LocalHealthConfig,
 ) -> list[Symptom]:
-    """Emit ``fd_pressure`` from ``data.local_fd`` when Coordinator FD usage nears the limit;
-    leaked sockets hitting ``ulimit -n`` surface as agent_stall(kernel) whose real cause is here.
+    """Emit ``fd_pressure`` when Coordinator FD usage nears the limit.
+
+    Leaked sockets hitting ``ulimit -n`` surface as agent_stall(kernel)
+    whose real cause is here.
+
+    Args:
+        data: Collected source data (file-descriptor usage).
+        cfg: Local-health configuration thresholds.
+
+    Returns:
+        A list with one :class:`Symptom` when FD pressure trips, else empty.
     """
     fd_info = getattr(data, "local_fd", None)
     if not isinstance(fd_info, dict) or not fd_info:

--- a/robustness-agent/src/robustness_agent/signals/preflight.py
+++ b/robustness-agent/src/robustness_agent/signals/preflight.py
@@ -72,7 +72,15 @@ _PARAM_BILLIONS_RE: re.Pattern[str] = re.compile(
 
 
 def extract_params_billions(model_name: str) -> float | None:
-    """Best-effort parse of ``-<N>B`` from a model name (first match; ``None`` if absent)."""
+    """Best-effort parse of ``-<N>B`` parameter count from a model name.
+
+    Args:
+        model_name: The model name to parse.
+
+    Returns:
+        The parameter count in billions (first match), or ``None`` when
+        absent or unparseable.
+    """
     if not model_name:
         return None
     match = _PARAM_BILLIONS_RE.search(model_name)
@@ -103,8 +111,14 @@ def compute_headroom_gib(
 ) -> HeadroomBreakdown | None:
     """Project per-GPU HBM headroom from manifest metadata.
 
-    Returns ``None`` when a required field (model size, precision, gpu_type, ``tp``) is
-    unresolved; the C1 detector treats ``None`` as "skip — not enough data to judge".
+    Args:
+        manifest: Run manifest with model / workload / GPU metadata.
+        activation_buf_gib: Reserved activation buffer per GPU, in GiB.
+
+    Returns:
+        A :class:`HeadroomBreakdown`, or ``None`` when a required field
+        (model size, precision, gpu_type, ``tp``) is unresolved — the C1
+        detector treats ``None`` as "skip — not enough data to judge".
     """
     if not isinstance(manifest, dict) or not manifest:
         return None
@@ -162,7 +176,17 @@ def amdahl_e2e_ceiling(
     optimizable_pct: float,
     single_kernel_speedup: float,
 ) -> float:
-    """Amdahl's law best-case E2E speedup ratio (1.0 = none); caller converts via ``(ratio - 1.0) * 100``."""
+    """Compute Amdahl's-law best-case end-to-end speedup ratio.
+
+    The caller converts to a percentage via ``(ratio - 1.0) * 100``.
+
+    Args:
+        optimizable_pct: Percent of runtime that is optimizable (0-100).
+        single_kernel_speedup: Speedup factor for the optimizable portion.
+
+    Returns:
+        The best-case E2E speedup ratio (``1.0`` means no speedup).
+    """
     p = max(0.0, min(1.0, optimizable_pct / 100.0))
     s = max(1.0, float(single_kernel_speedup))
     serial = 1.0 - p
@@ -343,7 +367,16 @@ def _manifest_fingerprint(manifest: dict[str, Any]) -> tuple[Any, ...]:
 
 
 def _recommend_tp(breakdown: HeadroomBreakdown) -> int:
-    """Smallest power-of-two TP clearing ``required_gib`` (operator hint; assumes weights dominate KV)."""
+    """Recommend the smallest power-of-two TP that clears the HBM budget.
+
+    Operator hint only; assumes weights dominate KV and ignores KV scaling.
+
+    Args:
+        breakdown: The per-GPU headroom breakdown.
+
+    Returns:
+        A suggested tensor-parallel degree (power of two).
+    """
     if breakdown.hbm_gib <= 0 or breakdown.weights_gib <= 0:
         return 8
     # Weights shrink ~linearly with TP; ignore KV scaling for the hint.

--- a/robustness-agent/src/robustness_agent/signals/repeated_payload.py
+++ b/robustness-agent/src/robustness_agent/signals/repeated_payload.py
@@ -151,7 +151,16 @@ def evaluate_repeated_payload_signals(
 def _walk_streaks(
     events: list[dict[str, Any]],
 ) -> dict[str, list[dict[str, Any]]]:
-    """Group consecutive same-hash failures per family; a ``succeeded`` entry resets the streak."""
+    """Group consecutive same-hash failures per family.
+
+    A ``succeeded`` entry resets the streak for its family.
+
+    Args:
+        events: Time-ordered ``delegated_result`` rows.
+
+    Returns:
+        Mapping of family to its current run of same-hash failure events.
+    """
     by_family: dict[str, list[dict[str, Any]]] = {}
     current_hash: dict[str, str | None] = {}
     for ev in events:
@@ -183,7 +192,19 @@ def _gather_events(
     coord_events: list[dict[str, Any]],
     cfg: RepeatedPayloadConfig,
 ) -> list[dict[str, Any]]:
-    """Build a single time-ordered list of ``delegated_result`` rows, trimmed to ``lookback_events``."""
+    """Build a time-ordered list of ``delegated_result`` rows.
+
+    Unions inbox items and coordinator events, trimmed to
+    ``lookback_events``.
+
+    Args:
+        inbox: Reactor inbox items.
+        coord_events: Coordinator event dicts.
+        cfg: Repeated-payload configuration (lookback window).
+
+    Returns:
+        The merged, trimmed list of ``delegated_result`` rows.
+    """
     inbox_rows = [
         {
             "topic": item.topic,
@@ -277,9 +298,17 @@ def _hash_for(family: str, event: dict[str, Any]) -> str | None:
 
 
 def _normalise_extra_server_args_key(payload: dict[str, Any]) -> dict[str, Any]:
-    """Shallow copy with ``params.extra_server_args`` set from the compat
-    helper (originals not mutated). No-op when no extra-args key or canonical
-    already present; the shim's DeprecationWarning stays as the legacy audit channel.
+    """Normalise the legacy ``extra_sglang_args`` key to the canonical one.
+
+    Returns a shallow copy with ``params.extra_server_args`` populated from
+    the compat helper (originals not mutated). No-op when no extra-args key
+    exists or the canonical key is already present.
+
+    Args:
+        payload: The event payload to normalise.
+
+    Returns:
+        The (possibly copied) payload with a canonical extra-args key.
     """
     params = payload.get("params")
     if not isinstance(params, dict):
@@ -296,7 +325,16 @@ def _normalise_extra_server_args_key(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def _walk_path(payload: dict[str, Any], path: str) -> Any:
-    """Walk dotted ``a.b.c`` paths against nested dicts (non-dicts short-circuit to ``None``)."""
+    """Walk a dotted ``a.b.c`` path against nested dicts.
+
+    Args:
+        payload: The mapping to traverse.
+        path: Dot-separated key path.
+
+    Returns:
+        The value at the path, or ``None`` if any segment is missing or a
+        non-dict is encountered.
+    """
     cur: Any = payload
     for token in path.split("."):
         if not isinstance(cur, dict):

--- a/robustness-agent/src/robustness_agent/signals/repeated_payload.py
+++ b/robustness-agent/src/robustness_agent/signals/repeated_payload.py
@@ -298,7 +298,7 @@ def _hash_for(family: str, event: dict[str, Any]) -> str | None:
 
 
 def _normalise_extra_server_args_key(payload: dict[str, Any]) -> dict[str, Any]:
-    """Normalise the legacy ``extra_sglang_args`` key to the canonical one.
+    """Normalise the legacy SGLang extra-args key to the canonical one.
 
     Returns a shallow copy with ``params.extra_server_args`` populated from
     the compat helper (originals not mutated). No-op when no extra-args key

--- a/robustness-agent/src/robustness_agent/sources/base.py
+++ b/robustness-agent/src/robustness_agent/sources/base.py
@@ -97,7 +97,14 @@ class SourceData:
     degraded_reason: str | None = None
 
     def merge_from(self, other: "SourceData") -> None:
-        """Merge another snapshot in, preserving non-empty existing fields."""
+        """Merge another snapshot into this one in place.
+
+        Existing non-empty fields are preserved; only empty slots are
+        filled from ``other``.
+
+        Args:
+            other: The snapshot to merge fields from.
+        """
         for slot in (
             "session_pods",
             "session_events",

--- a/robustness-agent/src/robustness_agent/sources/cluster_decoder.py
+++ b/robustness-agent/src/robustness_agent/sources/cluster_decoder.py
@@ -134,6 +134,12 @@ def merge_gpu_snapshots(
 
     Later writes win on field clashes per (pod, gpu_id); distinct pods
     stay distinct so signal evidence keeps the GPU's namespace / name.
+
+    Args:
+        snapshots: Per-pod GPU snapshot mappings.
+
+    Returns:
+        A merged ``local_gpu`` mapping.
     """
 
     rows: list[dict[str, Any]] = []

--- a/robustness-agent/src/robustness_agent/sources/server_client.py
+++ b/robustness-agent/src/robustness_agent/sources/server_client.py
@@ -635,9 +635,18 @@ class RobustnessServerSource:
         """Fan out cluster pod metrics across the session's pods.
 
         Decodes each per-pod response into the LocalProbe ``local_gpu``
-        schema and merges them into one snapshot. A 5xx / transport
-        failure on any pod re-raises :class:`SourceUnavailable` so the
-        DegradeRouter degrades.
+        schema and merges them into one snapshot.
+
+        Args:
+            pods: Session pod rows to fetch metrics for.
+            window: Metrics time window to request.
+
+        Returns:
+            A merged ``local_gpu`` snapshot mapping (empty when no pods).
+
+        Raises:
+            SourceUnavailable: On a 5xx / transport failure for any pod, so
+                the DegradeRouter degrades.
         """
 
         refs = _unique_pod_refs(pods)
@@ -678,11 +687,17 @@ def _extract_session_id(ctx: Any) -> str:
 
 
 def _unique_pod_refs(pods: list[dict[str, Any]]) -> list[tuple[str, str]]:
-    """Distinct (namespace, name) tuples from session_pods.
+    """Return the distinct ``(namespace, name)`` tuples from session pods.
 
     Rows carry the pod under ``pod.namespace`` / ``pod.name``; a pod may
     recur across open/close cycles so we collapse to the unique set to
     avoid duplicating the cluster-metrics fan-out.
+
+    Args:
+        pods: Session pod rows.
+
+    Returns:
+        The unique ``(namespace, name)`` tuples in first-seen order.
     """
 
     seen: set[tuple[str, str]] = set()
@@ -711,6 +726,12 @@ def _extract_hierarchy_pods(
     Accepts ``pods`` (documented), ``children`` / ``items`` (mirrors),
     and a single ``pod`` (degraded response) so an upstream schema nudge
     does not silently disable multi-node fan-out.
+
+    Args:
+        hierarchy: The workload hierarchy response, if any.
+
+    Returns:
+        The extracted pod row dicts (empty when none found).
     """
 
     if not isinstance(hierarchy, dict):
@@ -734,6 +755,13 @@ def _merge_pods(
     Hierarchy rows are wrapped in the session-pod envelope
     (``{"pod": {...}}``) so downstream consumers see a uniform shape.
     Session entries win on conflicts (richer phase / role metadata).
+
+    Args:
+        session_pods: Pods reported by the session source.
+        extra_pods: Pods derived from the workload hierarchy.
+
+    Returns:
+        The merged, de-duplicated pod list.
     """
 
     out: list[dict[str, Any]] = list(session_pods or [])


### PR DESCRIPTION
## Summary

Re-targets the Google-style docstring **upgrade** work (originally PR #543) directly onto current `main`.

PR #542 (add missing docstrings + Sphinx) merged into `main`, but #543 was stacked on #542's feature branch and merged *into that branch* rather than `main`, so its ~1,500 docstring upgrades never reached `main`. This PR brings them in.

- Merges the `docs/google-docstrings-upgrade` work onto current `main`.
- On the 25 files that conflicted with post-#542 PRs, the **main side was kept** (current code + newer prose) to avoid regressing recent changes; those files are re-upgraded directly on top of current code in follow-up commits.
- `ci/pr_submitter.py` stays deleted (removed on `main` after #543 was cut).
- Net effect so far: source non-Google-style docstrings reduced from 1,590 to 786; remaining are largely functions added by the 63 PRs merged after #542, addressed incrementally in this PR.

## Test plan

- [ ] `python -m compileall` clean across all packages
- [ ] `check_docstrings.py` reports 0 non-Google in source
- [ ] Sphinx HTML build succeeds with no warnings
- [ ] Linters clean on changed files
