### PR TITLE
feat(breakdown): agent & KB decision timelines (langfuse-recoverable)

### DIFF
--- a/inference_optimizer/breakdown/__init__.py
+++ b/inference_optimizer/breakdown/__init__.py
@@ -21,6 +21,11 @@ from .agent_timeline import (
     build_agent_timeline,
     enrich_breakdown_with_langfuse_timeline,
 )
+from .kb_timeline import (
+    KB_TIMELINE_SCHEMA,
+    build_kb_timeline,
+    enrich_breakdown_with_langfuse_kb_timeline,
+)
 from .exporter import (
     BREAKDOWN_FILENAME,
     EXPORTER_VERSION,
@@ -36,9 +41,12 @@ __all__ = [
     "AGENT_TIMELINE_SCHEMA",
     "BREAKDOWN_FILENAME",
     "EXPORTER_VERSION",
+    "KB_TIMELINE_SCHEMA",
     "SCHEMA_VERSION",
     "build",
     "build_agent_timeline",
+    "build_kb_timeline",
+    "enrich_breakdown_with_langfuse_kb_timeline",
     "enrich_breakdown_with_langfuse_timeline",
     "package_session_artifacts",
     "patch_breakdown_langfuse",

--- a/inference_optimizer/breakdown/__init__.py
+++ b/inference_optimizer/breakdown/__init__.py
@@ -16,6 +16,11 @@ Public surface:
 
 from __future__ import annotations
 
+from .agent_timeline import (
+    AGENT_TIMELINE_SCHEMA,
+    build_agent_timeline,
+    enrich_breakdown_with_langfuse_timeline,
+)
 from .exporter import (
     BREAKDOWN_FILENAME,
     EXPORTER_VERSION,
@@ -28,10 +33,13 @@ from .schema import SCHEMA_VERSION
 from .session_package import package_session_artifacts
 
 __all__ = [
+    "AGENT_TIMELINE_SCHEMA",
     "BREAKDOWN_FILENAME",
     "EXPORTER_VERSION",
     "SCHEMA_VERSION",
     "build",
+    "build_agent_timeline",
+    "enrich_breakdown_with_langfuse_timeline",
     "package_session_artifacts",
     "patch_breakdown_langfuse",
     "write_breakdown_json",

--- a/inference_optimizer/breakdown/agent_timeline.py
+++ b/inference_optimizer/breakdown/agent_timeline.py
@@ -27,6 +27,7 @@ The same builder serves both paths:
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from pathlib import PurePosixPath
 from typing import Any
 
 #: Wire-shape version of the ``agent_timeline`` section.
@@ -311,8 +312,10 @@ def _trace_seed_from_breakdown(breakdown: dict[str, Any]) -> tuple[str | None, s
     """Extract an explicit trace id and a correlation seed from a breakdown.
 
     Prefers the trace id recorded in the ``langfuse`` push receipt; otherwise
-    falls back to ``session.claw_session_id`` (then ``session.session_id``) as
-    the seed the writer hashed into the trace id.
+    falls back to the same seed chain the writer hashed into the trace id —
+    ``session.claw_session_id`` -> ``session.session_id`` -> the
+    ``session.session_dir`` basename (the writer's ``correlation_seed``
+    final fallback is the session-dir name).
 
     Args:
         breakdown: A ``session_breakdown.json`` dict.
@@ -324,7 +327,28 @@ def _trace_seed_from_breakdown(breakdown: dict[str, Any]) -> tuple[str | None, s
     trace_id = lf.get("trace_id") if isinstance(lf, dict) else None
     session = breakdown.get("session") if isinstance(breakdown.get("session"), dict) else {}
     seed = _first(session, "claw_session_id", "session_id")
+    if not seed:
+        session_dir = session.get("session_dir")
+        if session_dir:
+            seed = PurePosixPath(str(session_dir).rstrip("/")).name or None
     return (str(trace_id).strip() if trace_id else None), (str(seed).strip() if seed else None)
+
+
+def _has_populated_timeline(breakdown: dict[str, Any], key: str) -> bool:
+    """Whether ``breakdown[key]`` already holds a timeline with events.
+
+    Guards the upload-time enrich path from clobbering a good locally-built
+    timeline with a ``degraded`` empty one when Langfuse recovery fails.
+
+    Args:
+        breakdown: The breakdown dict.
+        key: Timeline section key (e.g. ``"agent_timeline"``).
+
+    Returns:
+        True when a non-empty events list is already present.
+    """
+    existing = breakdown.get(key)
+    return isinstance(existing, dict) and bool(existing.get("events"))
 
 
 def empty_timeline(*, source: str = "langfuse", reason: str = "") -> dict[str, Any]:
@@ -382,6 +406,15 @@ def enrich_breakdown_with_langfuse_timeline(
     # (and avoids any import cycle at module load).
     from ..orchestrator.trace.langfuse_reader import fetch_session_breakdown, resolve_trace_id
 
+    # Fill-if-missing. The exporter already builds a local ``agent_timeline``
+    # that is consistent with *this file's own* decision sections, so never
+    # overwrite a populated one — a Langfuse re-derive could be stale (the
+    # trace snapshot predates a later on-disk refresh) or empty. Only
+    # (re)derive from Langfuse when the section is absent or has no events
+    # (e.g. an older breakdown produced before local population existed).
+    if _has_populated_timeline(breakdown, "agent_timeline"):
+        return breakdown
+
     bd_trace_id, bd_seed = _trace_seed_from_breakdown(breakdown)
     resolved = resolve_trace_id(trace_id=trace_id or bd_trace_id, seed=seed or bd_seed)
     if not resolved:
@@ -392,9 +425,7 @@ def enrich_breakdown_with_langfuse_timeline(
         trace_id=resolved, credentials=credentials, timeout=timeout
     )
     if source_breakdown is None:
-        breakdown["agent_timeline"] = empty_timeline(
-            reason=f"could not fetch trace {resolved} from langfuse"
-        )
+        breakdown["agent_timeline"] = empty_timeline(reason=f"could not fetch trace {resolved} from langfuse")
         return breakdown
 
     breakdown["agent_timeline"] = build_agent_timeline(

--- a/inference_optimizer/breakdown/agent_timeline.py
+++ b/inference_optimizer/breakdown/agent_timeline.py
@@ -1,0 +1,411 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Build the unified three-actor ``agent_timeline`` section.
+
+Merges the three decision histories that already live in a
+``session_breakdown.json`` onto a single chronological axis:
+
+* **orchestrator** decisions  ← ``decision_trace.decision_trace[]``
+* **specialist** proposals    ← ``specialist_runs[]``
+* **critic** reviews          ← ``critic_robustness.critic_iterations[]``
+
+Each source record is normalised to a flat :class:`TimelineEvent`
+(``ts / actor / kind / title / detail / source``) and the merged list is
+sorted by ``(ts, seq)``. The builder is a **pure projection**: it never
+touches the network or disk, tolerates missing/partial sections (marking the
+result ``degraded`` with a warning), and keeps original fields verbatim under
+``detail`` so no information is lost.
+
+The same builder serves both paths:
+
+* **local** — called with the breakdown dict produced in-session;
+* **langfuse** — called with the breakdown recovered from a trace's root
+  output (see :mod:`inference_optimizer.orchestrator.trace.langfuse_reader`),
+  which is how the upload path enriches the SBD without a live session dir.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+#: Wire-shape version of the ``agent_timeline`` section.
+AGENT_TIMELINE_SCHEMA = "hyperloom.agent_timeline.v1"
+
+# Far-future sentinel so events without a parseable timestamp sort last
+# (stable, after every real event) instead of crashing the sort.
+_TS_MAX = datetime(9999, 12, 31, tzinfo=timezone.utc)
+
+
+def _parse_ts(value: Any) -> datetime | None:
+    """Best-effort parse of an ISO-8601 timestamp into an aware ``datetime``.
+
+    Accepts the trailing-``Z`` form and explicit offsets; naive timestamps are
+    assumed UTC. Returns ``None`` for anything unparseable so the caller can
+    fall back to the sequence index.
+
+    Args:
+        value: Candidate timestamp (typically a string).
+
+    Returns:
+        An aware ``datetime`` in UTC, or ``None`` when not parseable.
+    """
+    if not isinstance(value, str) or not value.strip():
+        return None
+    raw = value.strip().replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _first(mapping: dict[str, Any], *keys: str) -> Any:
+    """Return the first non-``None`` value among ``keys`` (schema drift guard).
+
+    Args:
+        mapping: Source dict.
+        *keys: Candidate keys, tried in order.
+
+    Returns:
+        The first present, non-``None`` value, else ``None``.
+    """
+    for key in keys:
+        val = mapping.get(key)
+        if val is not None:
+            return val
+    return None
+
+
+def _orchestrator_events(breakdown: dict[str, Any], warnings: list[str]) -> list[dict[str, Any]]:
+    """Project ``decision_trace.decision_trace[]`` into orchestrator events.
+
+    Args:
+        breakdown: The full breakdown dict.
+        warnings: Mutable list to append non-fatal notes to.
+
+    Returns:
+        A list of partial :class:`TimelineEvent` dicts (``seq`` not yet set).
+    """
+    section = breakdown.get("decision_trace")
+    if not isinstance(section, dict):
+        warnings.append("decision_trace section missing or not an object")
+        return []
+    rows = section.get("decision_trace")
+    if not isinstance(rows, list):
+        warnings.append("decision_trace.decision_trace[] missing or not a list")
+        return []
+
+    events: list[dict[str, Any]] = []
+    for idx, row in enumerate(rows):
+        if not isinstance(row, dict):
+            continue
+        dec = row.get("decision") if isinstance(row.get("decision"), dict) else {}
+        outcome = dec.get("outcome")
+        change = _first(dec, "change", "event", "verdict") or ""
+        title = " ".join(p for p in (str(outcome or "").strip(), str(change).strip()) if p)
+        events.append(
+            {
+                "ts": row.get("ts"),
+                "actor": "orchestrator",
+                "kind": "decision",
+                "phase": row.get("phase"),
+                "tick": row.get("tick"),
+                "title": title or "decision",
+                "detail": {
+                    "outcome": outcome,
+                    "change": change or None,
+                    "component": dec.get("component"),
+                    "operation_kind": dec.get("operation_kind"),
+                    "kind": dec.get("kind"),
+                    "gain_pct": dec.get("gain_pct"),
+                    "task_id": _first(dec, "task_id", "dyn_id"),
+                    "variant_name": dec.get("variant_name"),
+                    "provenance": dec.get("provenance"),
+                    "tokens": row.get("tokens"),
+                },
+                "source": {"section": "decision_trace.decision_trace", "index": idx},
+            }
+        )
+    return events
+
+
+def _specialist_events(breakdown: dict[str, Any], warnings: list[str]) -> list[dict[str, Any]]:
+    """Project ``specialist_runs[]`` into specialist proposal events.
+
+    Defensive about schema drift: production runs carry per-run fields
+    (``domain`` / ``confidence`` / ``new_findings`` / ``ensemble_scores``)
+    beyond the documented :class:`SpecialistRound`, so every field is read with
+    fallbacks and kept verbatim under ``detail``.
+
+    Args:
+        breakdown: The full breakdown dict.
+        warnings: Mutable list to append non-fatal notes to.
+
+    Returns:
+        A list of partial :class:`TimelineEvent` dicts (``seq`` not yet set).
+    """
+    rows = breakdown.get("specialist_runs")
+    if not isinstance(rows, list):
+        warnings.append("specialist_runs[] missing or not a list")
+        return []
+
+    events: list[dict[str, Any]] = []
+    for idx, row in enumerate(rows):
+        if not isinstance(row, dict):
+            continue
+        domains = row.get("domains") if isinstance(row.get("domains"), list) else None
+        domain = _first(row, "domain") or (domains[0] if domains else None)
+        domain_label = domain or (", ".join(str(d) for d in domains) if domains else "specialist")
+        confidence = _first(row, "confidence", "confidence_avg")
+        title = str(domain_label)
+        if confidence is not None:
+            title = f"{title} (conf {confidence})"
+        events.append(
+            {
+                "ts": _first(row, "completed_at", "dispatched_at"),
+                "actor": "specialist",
+                "kind": "proposal",
+                "phase": row.get("phase"),
+                "tick": row.get("tick"),
+                "title": title,
+                "detail": {
+                    "round_id": row.get("round_id"),
+                    "domain": domain,
+                    "domains": domains,
+                    "confidence": confidence,
+                    "empty": row.get("empty"),
+                    "gap_canonical_id": row.get("gap_canonical_id"),
+                    "ensemble_scores": row.get("ensemble_scores"),
+                    "new_findings": row.get("new_findings"),
+                    "proposals_total": row.get("proposals_total"),
+                    "proposals_kept": row.get("proposals_kept"),
+                    "proposals_rejected": row.get("proposals_rejected"),
+                    "summary": row.get("summary"),
+                },
+                "source": {"section": "specialist_runs", "index": idx},
+            }
+        )
+    return events
+
+
+def _critic_events(breakdown: dict[str, Any], warnings: list[str]) -> list[dict[str, Any]]:
+    """Project ``critic_robustness.critic_iterations[]`` into critic events.
+
+    Args:
+        breakdown: The full breakdown dict.
+        warnings: Mutable list to append non-fatal notes to.
+
+    Returns:
+        A list of partial :class:`TimelineEvent` dicts (``seq`` not yet set).
+    """
+    section = breakdown.get("critic_robustness")
+    if not isinstance(section, dict):
+        warnings.append("critic_robustness section missing or not an object")
+        return []
+    rows = section.get("critic_iterations")
+    if not isinstance(rows, list):
+        warnings.append("critic_robustness.critic_iterations[] missing or not a list")
+        return []
+
+    events: list[dict[str, Any]] = []
+    for idx, row in enumerate(rows):
+        if not isinstance(row, dict):
+            continue
+        verdict = row.get("verdict")
+        topic = row.get("topic")
+        title = f"verdict {verdict}" if verdict else "review"
+        if topic:
+            title = f"{title}: {topic}"
+        events.append(
+            {
+                "ts": row.get("ts"),
+                "actor": "critic",
+                "kind": "review",
+                "phase": row.get("phase"),
+                "tick": row.get("tick"),
+                "title": title,
+                "detail": {
+                    "iter": row.get("iter"),
+                    "verdict": verdict,
+                    "topic": topic,
+                    "summary": row.get("summary"),
+                    "kb_assess": row.get("kb_assess"),
+                    "kb_priors": row.get("kb_priors"),
+                },
+                "source": {"section": "critic_robustness.critic_iterations", "index": idx},
+            }
+        )
+    return events
+
+
+def build_agent_timeline(
+    breakdown: dict[str, Any],
+    *,
+    source: str = "local",
+    trace_id: str | None = None,
+) -> dict[str, Any]:
+    """Merge the three decision histories into one sorted ``agent_timeline``.
+
+    Pulls orchestrator decisions, specialist proposals, and critic reviews out
+    of ``breakdown`` (see module docstring for the exact source sections),
+    normalises each to a :class:`TimelineEvent`, and returns them sorted by
+    ``(ts, seq)``. Never raises on partial input — missing sections add a
+    warning and set ``degraded``.
+
+    Args:
+        breakdown: A ``session_breakdown.json`` dict (built locally or
+            recovered from a Langfuse trace's root output).
+        source: Provenance label stamped onto the result
+            (``"local"`` or ``"langfuse"``).
+        trace_id: Langfuse trace id to record (and stamp onto every event's
+            ``source``) when the breakdown was fetched from a trace.
+
+    Returns:
+        An ``agent_timeline`` dict matching
+        :class:`inference_optimizer.breakdown.schema.AgentTimeline`.
+    """
+    warnings: list[str] = []
+    raw = (
+        _orchestrator_events(breakdown, warnings)
+        + _specialist_events(breakdown, warnings)
+        + _critic_events(breakdown, warnings)
+    )
+
+    # Stable sort: timestamp first (unparseable -> last), original build order
+    # as the tiebreaker so same-second events keep a deterministic sequence.
+    indexed = list(enumerate(raw))
+    indexed.sort(key=lambda pair: (_parse_ts(pair[1].get("ts")) or _TS_MAX, pair[0]))
+
+    events: list[dict[str, Any]] = []
+    for seq, (_, ev) in enumerate(indexed):
+        ev["seq"] = seq
+        if trace_id:
+            ev["source"]["trace_id"] = trace_id
+        events.append(ev)
+
+    counts = {
+        "orchestrator": sum(1 for e in events if e["actor"] == "orchestrator"),
+        "specialist": sum(1 for e in events if e["actor"] == "specialist"),
+        "critic": sum(1 for e in events if e["actor"] == "critic"),
+    }
+    degraded = bool(warnings) or not events
+
+    timeline: dict[str, Any] = {
+        "schema": AGENT_TIMELINE_SCHEMA,
+        "source": source,
+        "fetched_at_utc": datetime.now(timezone.utc).isoformat(),
+        "events": events,
+        "counts": counts,
+        "degraded": degraded,
+        "warnings": warnings,
+    }
+    if trace_id:
+        timeline["trace_id"] = trace_id
+    return timeline
+
+
+def _trace_seed_from_breakdown(breakdown: dict[str, Any]) -> tuple[str | None, str | None]:
+    """Extract an explicit trace id and a correlation seed from a breakdown.
+
+    Prefers the trace id recorded in the ``langfuse`` push receipt; otherwise
+    falls back to ``session.claw_session_id`` (then ``session.session_id``) as
+    the seed the writer hashed into the trace id.
+
+    Args:
+        breakdown: A ``session_breakdown.json`` dict.
+
+    Returns:
+        A ``(trace_id, seed)`` tuple; either element may be ``None``.
+    """
+    lf = breakdown.get("langfuse")
+    trace_id = lf.get("trace_id") if isinstance(lf, dict) else None
+    session = breakdown.get("session") if isinstance(breakdown.get("session"), dict) else {}
+    seed = _first(session, "claw_session_id", "session_id")
+    return (str(trace_id).strip() if trace_id else None), (str(seed).strip() if seed else None)
+
+
+def empty_timeline(*, source: str = "langfuse", reason: str = "") -> dict[str, Any]:
+    """Return a well-formed but empty, ``degraded`` ``agent_timeline``.
+
+    Used when the source breakdown could not be recovered from Langfuse, so the
+    field is always present and self-describing rather than silently absent.
+
+    Args:
+        source: Provenance label to stamp.
+        reason: Human-readable warning explaining why it is empty.
+
+    Returns:
+        An ``agent_timeline`` dict with no events and ``degraded=True``.
+    """
+    return {
+        "schema": AGENT_TIMELINE_SCHEMA,
+        "source": source,
+        "fetched_at_utc": datetime.now(timezone.utc).isoformat(),
+        "events": [],
+        "counts": {"orchestrator": 0, "specialist": 0, "critic": 0},
+        "degraded": True,
+        "warnings": [reason] if reason else ["no events recovered"],
+    }
+
+
+def enrich_breakdown_with_langfuse_timeline(
+    breakdown: dict[str, Any],
+    *,
+    trace_id: str | None = None,
+    seed: str | None = None,
+    credentials: dict[str, str] | None = None,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """Fetch the trace's breakdown from Langfuse, build, and inject the timeline.
+
+    This is the upload-path entry point (the "trigger in the SBD upload
+    interface"): it reads the three decision histories back from the session's
+    Langfuse trace and writes the merged ``agent_timeline`` onto ``breakdown``
+    **in place** (also returned for convenience). Best-effort — on any failure
+    it injects a ``degraded`` empty timeline so the field always exists.
+
+    Args:
+        breakdown: The ``session_breakdown.json`` dict to enrich in place.
+        trace_id: Explicit trace id; defaults to one resolved from
+            ``breakdown.langfuse.trace_id`` / ``session.claw_session_id``.
+        seed: Explicit correlation seed override.
+        credentials: Optional explicit Langfuse credentials override.
+        timeout: Per-request timeout in seconds.
+
+    Returns:
+        The same ``breakdown`` dict, with ``breakdown["agent_timeline"]`` set.
+    """
+    # Lazy import: keeps the pure builder importable without the trace package
+    # (and avoids any import cycle at module load).
+    from ..orchestrator.trace.langfuse_reader import fetch_session_breakdown, resolve_trace_id
+
+    bd_trace_id, bd_seed = _trace_seed_from_breakdown(breakdown)
+    resolved = resolve_trace_id(trace_id=trace_id or bd_trace_id, seed=seed or bd_seed)
+    if not resolved:
+        breakdown["agent_timeline"] = empty_timeline(reason="no trace_id / correlation seed on breakdown")
+        return breakdown
+
+    source_breakdown = fetch_session_breakdown(
+        trace_id=resolved, credentials=credentials, timeout=timeout
+    )
+    if source_breakdown is None:
+        breakdown["agent_timeline"] = empty_timeline(
+            reason=f"could not fetch trace {resolved} from langfuse"
+        )
+        return breakdown
+
+    breakdown["agent_timeline"] = build_agent_timeline(
+        source_breakdown, source="langfuse", trace_id=resolved
+    )
+    return breakdown
+
+
+__all__ = [
+    "AGENT_TIMELINE_SCHEMA",
+    "build_agent_timeline",
+    "empty_timeline",
+    "enrich_breakdown_with_langfuse_timeline",
+]

--- a/inference_optimizer/breakdown/exporter.py
+++ b/inference_optimizer/breakdown/exporter.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from . import collectors
 from .agent_timeline import build_agent_timeline
+from .kb_timeline import build_kb_timeline
 from .schema import SCHEMA_VERSION, SCHEMA_VERSION_V3
 
 log = logging.getLogger(__name__)
@@ -531,6 +532,25 @@ def build(
         default={},
     )
 
+    # KB read/use decision timeline (recipe reads + warm-start/replay + critic
+    # KB assess/priors), built locally from the KB sections so the field is
+    # present in every produced breakdown. The Langfuse path
+    # (``enrich_breakdown_with_langfuse_kb_timeline``) can later re-derive it
+    # with full span granularity for a downstream consumer holding only a
+    # trace id.
+    kb_timeline = _safe_collect(
+        "kb_timeline",
+        lambda: build_kb_timeline(
+            {
+                "kb_provenance": kb_provenance,
+                "critic_robustness": critic_robustness,
+            },
+            source="local",
+        ),
+        warnings,
+        default={},
+    )
+
     source_files = collectors.collect_source_files(
         sd,
         baseline.get("benchmark_report_path"),
@@ -606,6 +626,10 @@ def build(
         # timeline, merged onto one ``ts`` axis. Additive optional section;
         # older readers ignore it.
         "agent_timeline": agent_timeline,
+        # KB read/use decision timeline (recipe reads + warm-start/replay +
+        # critic KB assess/priors), merged onto one ``ts`` axis. Additive
+        # optional section; older readers ignore it.
+        "kb_timeline": kb_timeline,
         "warnings": warnings,
         "source_files": source_files,
     }

--- a/inference_optimizer/breakdown/exporter.py
+++ b/inference_optimizer/breakdown/exporter.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any
 
 from . import collectors
+from .agent_timeline import build_agent_timeline
 from .schema import SCHEMA_VERSION, SCHEMA_VERSION_V3
 
 log = logging.getLogger(__name__)
@@ -509,6 +510,27 @@ def build(
     # enriched after discovery. Best-effort; never raises.
     _attach_kernel_roofline(kernel_journey, kernel_roofline)
 
+    # Unified three-actor timeline (specialist proposals + orchestrator
+    # decisions + critic reviews) merged onto one ``ts`` axis. Built locally
+    # from the sections just collected so the field is present in *every*
+    # produced breakdown. This is byte-for-byte the same data the Langfuse
+    # trace carries (the writer attaches this very breakdown as the trace
+    # output), so a downstream consumer reading ``agent_timeline`` from the SBD
+    # or re-deriving it from Langfuse gets identical content.
+    agent_timeline = _safe_collect(
+        "agent_timeline",
+        lambda: build_agent_timeline(
+            {
+                "decision_trace": decision_trace,
+                "specialist_runs": specialist_runs,
+                "critic_robustness": critic_robustness,
+            },
+            source="local",
+        ),
+        warnings,
+        default={},
+    )
+
     source_files = collectors.collect_source_files(
         sd,
         baseline.get("benchmark_report_path"),
@@ -580,6 +602,10 @@ def build(
         # carries ``{tool, root_dir, commit, version}``. Empty {} on sessions
         # that predate the recorder.
         "versions": versions,
+        # Unified specialist-proposal + orchestrator-decision + critic-review
+        # timeline, merged onto one ``ts`` axis. Additive optional section;
+        # older readers ignore it.
+        "agent_timeline": agent_timeline,
         "warnings": warnings,
         "source_files": source_files,
     }

--- a/inference_optimizer/breakdown/kb_timeline.py
+++ b/inference_optimizer/breakdown/kb_timeline.py
@@ -1,0 +1,466 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Build the knowledge-base decision timeline (``kb_timeline``).
+
+Merges the KB **read/use** decisions that a session made onto one
+chronological axis:
+
+* ``recipe_read``   — recipe lookups / canonical-id matches
+* ``warm_start``    — T0 warm-start recipe selection
+* ``warm_replay``   — warm-recipe replay accept / reject / promote
+* ``critic_assess`` — critic ``/assess`` substrate reads (per review)
+* ``critic_priors`` — critic historical-prior reads (per review)
+
+Write-side KB activity (committing lessons/pitfalls back to the recipe KB,
+critic ``commit-review`` upserts) is **intentionally excluded**: it is
+session-close bookkeeping rather than a decision, and is not timestamped
+anywhere (neither locally nor in Langfuse).
+
+Two input shapes are supported, mirroring the ``agent_timeline`` pattern:
+
+* **breakdown sections** (local build / trace ``output``): recipe reads from
+  ``kb_provenance.recipe_snapshot_reads.tail`` and critic reads from
+  ``critic_robustness.critic_iterations[].kb_assess`` / ``kb_priors``;
+* **Langfuse observations** (spans): the per-event ``kb:recipe_snapshot:*`` /
+  ``kb_assess:iter_N`` / ``kb_priors:iter_N`` spans, which carry the *full*
+  read history (the breakdown ``tail`` is capped). When ``observations`` is
+  given it is preferred for these categories.
+
+``warm_start`` / ``warm_replay`` always come from ``kb_provenance`` (they have
+no per-event span).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+#: Wire-shape version of the ``kb_timeline`` section.
+KB_TIMELINE_SCHEMA = "hyperloom.kb_timeline.v1"
+
+_TS_MAX = datetime(9999, 12, 31, tzinfo=timezone.utc)
+
+
+def _parse_ts(value: Any) -> datetime | None:
+    """Best-effort parse of an ISO-8601 timestamp into an aware ``datetime``.
+
+    Args:
+        value: Candidate timestamp (string).
+
+    Returns:
+        An aware UTC ``datetime``, or ``None`` when not parseable.
+    """
+    if not isinstance(value, str) or not value.strip():
+        return None
+    raw = value.strip().replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _first(mapping: dict[str, Any], *keys: str) -> Any:
+    """Return the first non-``None`` value among ``keys``.
+
+    Args:
+        mapping: Source dict.
+        *keys: Candidate keys, tried in order.
+
+    Returns:
+        The first present, non-``None`` value, else ``None``.
+    """
+    for key in keys:
+        val = mapping.get(key)
+        if val is not None:
+            return val
+    return None
+
+
+def _warm_events(kbp: dict[str, Any]) -> list[dict[str, Any]]:
+    """Project warm-start + warm-replay decisions from ``kb_provenance``.
+
+    Args:
+        kbp: The ``kb_provenance`` section dict.
+
+    Returns:
+        Zero to two partial KB timeline events (``seq`` not yet set).
+    """
+    events: list[dict[str, Any]] = []
+    warm_ts = kbp.get("warm_start_ts")
+
+    seen = kbp.get("warm_start_recipe_seen")
+    if seen is not None or warm_ts:
+        tier = kbp.get("warm_start_recipe_tier")
+        title = f"warm-start: recipe tier {tier}" if seen else "warm-start: no recipe matched"
+        events.append(
+            {
+                "ts": warm_ts,
+                "category": "warm_start",
+                "title": title,
+                "detail": {
+                    "recipe_seen": seen,
+                    "tier": tier,
+                    "pitfall_count": kbp.get("warm_start_pitfall_count"),
+                    "lesson_count": kbp.get("warm_start_lesson_count"),
+                    "warm_history_injected": kbp.get("warm_history_injected"),
+                    "cortex_session_id": kbp.get("cortex_session_id"),
+                },
+                "source": {"section": "kb_provenance"},
+            }
+        )
+
+    replay = kbp.get("warm_replay") if isinstance(kbp.get("warm_replay"), dict) else {}
+    if kbp.get("warm_replay_attempted") or replay:
+        status = replay.get("status")
+        events.append(
+            {
+                # warm_replay carries no own ts; anchor near warm-start.
+                "ts": replay.get("ts") or warm_ts,
+                "category": "warm_replay",
+                "title": f"warm-replay: {status or 'attempted'}",
+                "detail": {
+                    "status": status,
+                    "expected_gain_pct": replay.get("expected_gain_pct"),
+                    "actual_gain_pct": replay.get("actual_gain_pct"),
+                    "warm_recipe_tier": replay.get("warm_recipe_tier"),
+                    "warm_recipe_conf": replay.get("warm_recipe_conf"),
+                    "replay_task_id": replay.get("replay_task_id"),
+                    "reason": replay.get("reason"),
+                    "attempted": kbp.get("warm_replay_attempted"),
+                },
+                "source": {"section": "kb_provenance.warm_replay"},
+            }
+        )
+    return events
+
+
+def _recipe_read_event(row: dict[str, Any], idx: int) -> dict[str, Any]:
+    """Project one recipe-snapshot read row into a ``recipe_read`` event.
+
+    Args:
+        row: One ``recipe_snapshot_reads.tail[]`` audit row.
+        idx: Index of the row (for provenance).
+
+    Returns:
+        A partial KB timeline event (``seq`` not yet set).
+    """
+    method = row.get("method")
+    resolution = row.get("resolution")
+    hit = row.get("hit")
+    request = row.get("request") if isinstance(row.get("request"), dict) else {}
+    result = row.get("result") if isinstance(row.get("result"), dict) else {}
+    return {
+        "ts": row.get("ts"),
+        "category": "recipe_read",
+        "title": f"recipe {method or 'read'}: {resolution or '?'} ({'hit' if hit else 'miss'})",
+        "detail": {
+            "method": method,
+            "remote": row.get("remote"),
+            "resolution": resolution,
+            "hit": hit,
+            "candidates": row.get("candidates"),
+            "canonical_id": request.get("canonical_id") if request else result.get("canonical_id"),
+            "result": result or None,
+        },
+        "source": {"section": "kb_provenance.recipe_snapshot_reads.tail", "index": idx},
+    }
+
+
+def _critic_kb_events(iterations: list[Any], warnings: list[str]) -> list[dict[str, Any]]:
+    """Project ``critic_iterations[].kb_assess`` / ``kb_priors`` into events.
+
+    Args:
+        iterations: The ``critic_robustness.critic_iterations`` list.
+        warnings: Mutable list to append non-fatal notes to.
+
+    Returns:
+        Partial ``critic_assess`` / ``critic_priors`` events (``seq`` unset).
+    """
+    events: list[dict[str, Any]] = []
+    for idx, it in enumerate(iterations):
+        if not isinstance(it, dict):
+            continue
+        ts = it.get("ts")
+        itr = it.get("iter")
+        assess = it.get("kb_assess") if isinstance(it.get("kb_assess"), dict) else None
+        if assess and assess.get("configured"):
+            ref = assess.get("referenced_in_verdict")
+            events.append(
+                {
+                    "ts": ts,
+                    "category": "critic_assess",
+                    "title": f"kb_assess iter {itr}: {'used' if ref else 'not used'}",
+                    "detail": {
+                        "iter": itr,
+                        "mode": assess.get("mode"),
+                        "verdict_count": assess.get("verdict_count"),
+                        "referenced_in_verdict": ref,
+                        "skipped_reason": assess.get("skipped_reason"),
+                    },
+                    "source": {"section": "critic_robustness.critic_iterations", "index": idx},
+                }
+            )
+        priors = it.get("kb_priors") if isinstance(it.get("kb_priors"), dict) else None
+        if priors and priors.get("configured"):
+            ref = priors.get("referenced_in_verdict")
+            events.append(
+                {
+                    "ts": ts,
+                    "category": "critic_priors",
+                    "title": f"kb_priors iter {itr}: {'used' if ref else 'not used'}",
+                    "detail": {
+                        "iter": itr,
+                        "mode": priors.get("mode"),
+                        "prior_count": priors.get("prior_count"),
+                        "referenced_in_verdict": ref,
+                        "skipped_reason": priors.get("skipped_reason"),
+                    },
+                    "source": {"section": "critic_robustness.critic_iterations", "index": idx},
+                }
+            )
+    return events
+
+
+def _obs_ts(obs: dict[str, Any]) -> Any:
+    """Read an observation's start timestamp (camelCase or snake_case)."""
+    return _first(obs, "startTime", "start_time", "timestamp", "ts")
+
+
+def _events_from_observations(observations: list[Any], warnings: list[str]) -> list[dict[str, Any]]:
+    """Project Langfuse KB spans into recipe_read / critic_assess / critic_priors.
+
+    Recognises the three KB span name patterns emitted by the writer:
+    ``kb:recipe_snapshot:{method}`` / ``kb_assess:iter_N`` / ``kb_priors:iter_N``.
+
+    Args:
+        observations: List of Langfuse observation dicts for the trace.
+        warnings: Mutable list to append non-fatal notes to.
+
+    Returns:
+        Partial KB timeline events (``seq`` not yet set).
+    """
+    events: list[dict[str, Any]] = []
+    for idx, obs in enumerate(observations):
+        if not isinstance(obs, dict):
+            continue
+        name = str(obs.get("name") or "")
+        meta = obs.get("metadata") if isinstance(obs.get("metadata"), dict) else {}
+        oid = obs.get("id")
+        ts = _obs_ts(obs)
+        if name.startswith("kb:recipe_snapshot:"):
+            method = name.split(":", 2)[-1]
+            events.append(
+                {
+                    "ts": ts,
+                    "category": "recipe_read",
+                    "title": f"recipe {method}: {meta.get('resolution') or '?'} "
+                    f"({'hit' if meta.get('hit') else 'miss'})",
+                    "detail": {
+                        "method": meta.get("method") or method,
+                        "remote": meta.get("remote"),
+                        "resolution": meta.get("resolution"),
+                        "hit": meta.get("hit"),
+                    },
+                    "source": {"span": name, "observation_id": oid},
+                }
+            )
+        elif name.startswith("kb_assess:iter"):
+            ref = meta.get("referenced_in_verdict")
+            events.append(
+                {
+                    "ts": ts,
+                    "category": "critic_assess",
+                    "title": f"kb_assess {name.split(':', 1)[-1]}: {'used' if ref else 'not used'}",
+                    "detail": {
+                        "iter": meta.get("iter"),
+                        "mode": meta.get("mode"),
+                        "verdict_count": meta.get("verdict_count"),
+                        "referenced_in_verdict": ref,
+                    },
+                    "source": {"span": name, "observation_id": oid},
+                }
+            )
+        elif name.startswith("kb_priors:iter"):
+            ref = meta.get("referenced_in_verdict")
+            events.append(
+                {
+                    "ts": ts,
+                    "category": "critic_priors",
+                    "title": f"kb_priors {name.split(':', 1)[-1]}: {'used' if ref else 'not used'}",
+                    "detail": {
+                        "iter": meta.get("iter"),
+                        "prior_count": meta.get("prior_count"),
+                        "referenced_in_verdict": ref,
+                    },
+                    "source": {"span": name, "observation_id": oid},
+                }
+            )
+    return events
+
+
+_CATEGORIES = ("recipe_read", "warm_start", "warm_replay", "critic_assess", "critic_priors")
+
+
+def build_kb_timeline(
+    breakdown: dict[str, Any],
+    *,
+    observations: list[Any] | None = None,
+    source: str = "local",
+    trace_id: str | None = None,
+) -> dict[str, Any]:
+    """Merge KB read/use decisions into one sorted ``kb_timeline``.
+
+    Pulls warm-start / warm-replay from ``breakdown.kb_provenance`` and recipe
+    reads + critic assess/priors from either Langfuse ``observations`` (when
+    given — full span granularity) or the breakdown sections
+    (``recipe_snapshot_reads.tail`` + ``critic_iterations``). Never raises on
+    partial input — missing sources add a warning and set ``degraded``.
+
+    Args:
+        breakdown: A ``session_breakdown.json`` dict.
+        observations: Optional Langfuse observation (span) list; preferred for
+            ``recipe_read`` / ``critic_assess`` / ``critic_priors`` when given.
+        source: Provenance label (``"local"`` / ``"langfuse"``).
+        trace_id: Langfuse trace id to record (and stamp onto each event).
+
+    Returns:
+        A ``kb_timeline`` dict matching
+        :class:`inference_optimizer.breakdown.schema.KBTimeline`.
+    """
+    warnings: list[str] = []
+    raw: list[dict[str, Any]] = []
+
+    kbp = breakdown.get("kb_provenance")
+    if isinstance(kbp, dict):
+        raw.extend(_warm_events(kbp))
+    else:
+        warnings.append("kb_provenance section missing or not an object")
+        kbp = {}
+
+    if observations:
+        # Span path: recipe reads + critic assess/priors come from spans (full).
+        # An empty/None list falls through to the breakdown sections so a
+        # transient observation-fetch miss doesn't drop data that's in output.
+        raw.extend(_events_from_observations(observations, warnings))
+    else:
+        # Breakdown path: recipe reads from the (capped) audit tail.
+        reads = (kbp.get("recipe_snapshot_reads") or {}).get("tail") if isinstance(kbp, dict) else None
+        if isinstance(reads, list):
+            raw.extend(_recipe_read_event(r, i) for i, r in enumerate(reads) if isinstance(r, dict))
+        else:
+            warnings.append("kb_provenance.recipe_snapshot_reads.tail missing")
+        critic = breakdown.get("critic_robustness")
+        iterations = critic.get("critic_iterations") if isinstance(critic, dict) else None
+        if isinstance(iterations, list):
+            raw.extend(_critic_kb_events(iterations, warnings))
+        else:
+            warnings.append("critic_robustness.critic_iterations missing")
+
+    indexed = list(enumerate(raw))
+    indexed.sort(key=lambda pair: (_parse_ts(pair[1].get("ts")) or _TS_MAX, pair[0]))
+
+    events: list[dict[str, Any]] = []
+    for seq, (_, ev) in enumerate(indexed):
+        ev["seq"] = seq
+        if trace_id:
+            ev["source"]["trace_id"] = trace_id
+        events.append(ev)
+
+    counts = {cat: sum(1 for e in events if e["category"] == cat) for cat in _CATEGORIES}
+    degraded = bool(warnings) or not events
+
+    timeline: dict[str, Any] = {
+        "schema": KB_TIMELINE_SCHEMA,
+        "source": source,
+        "fetched_at_utc": datetime.now(timezone.utc).isoformat(),
+        "events": events,
+        "counts": counts,
+        "degraded": degraded,
+        "warnings": warnings,
+    }
+    if trace_id:
+        timeline["trace_id"] = trace_id
+    return timeline
+
+
+def empty_kb_timeline(*, source: str = "langfuse", reason: str = "") -> dict[str, Any]:
+    """Return a well-formed but empty, ``degraded`` ``kb_timeline``.
+
+    Args:
+        source: Provenance label to stamp.
+        reason: Human-readable warning explaining why it is empty.
+
+    Returns:
+        A ``kb_timeline`` dict with no events and ``degraded=True``.
+    """
+    return {
+        "schema": KB_TIMELINE_SCHEMA,
+        "source": source,
+        "fetched_at_utc": datetime.now(timezone.utc).isoformat(),
+        "events": [],
+        "counts": {cat: 0 for cat in _CATEGORIES},
+        "degraded": True,
+        "warnings": [reason] if reason else ["no events recovered"],
+    }
+
+
+def enrich_breakdown_with_langfuse_kb_timeline(
+    breakdown: dict[str, Any],
+    *,
+    trace_id: str | None = None,
+    seed: str | None = None,
+    credentials: dict[str, str] | None = None,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """Fetch trace output + observations from Langfuse and inject ``kb_timeline``.
+
+    Recovers the breakdown (for warm-start / warm-replay) and the KB spans (for
+    full recipe-read / critic-assess / critic-priors granularity) from the
+    session's Langfuse trace, builds the merged timeline, and writes it onto
+    ``breakdown`` in place. Best-effort — injects a ``degraded`` empty timeline
+    on any failure.
+
+    Args:
+        breakdown: The ``session_breakdown.json`` dict to enrich in place.
+        trace_id: Explicit trace id (defaults to one resolved from the breakdown).
+        seed: Explicit correlation seed override.
+        credentials: Optional explicit Langfuse credentials override.
+        timeout: Per-request timeout in seconds.
+
+    Returns:
+        The same ``breakdown`` dict, with ``breakdown["kb_timeline"]`` set.
+    """
+    from ..orchestrator.trace.langfuse_reader import (
+        fetch_observations,
+        fetch_session_breakdown,
+        resolve_trace_id,
+    )
+    from .agent_timeline import _trace_seed_from_breakdown
+
+    bd_trace_id, bd_seed = _trace_seed_from_breakdown(breakdown)
+    resolved = resolve_trace_id(trace_id=trace_id or bd_trace_id, seed=seed or bd_seed)
+    if not resolved:
+        breakdown["kb_timeline"] = empty_kb_timeline(reason="no trace_id / correlation seed on breakdown")
+        return breakdown
+
+    source_breakdown = fetch_session_breakdown(trace_id=resolved, credentials=credentials, timeout=timeout)
+    if source_breakdown is None:
+        breakdown["kb_timeline"] = empty_kb_timeline(reason=f"could not fetch trace {resolved} from langfuse")
+        return breakdown
+
+    observations = fetch_observations(resolved, credentials=credentials, timeout=timeout)
+    breakdown["kb_timeline"] = build_kb_timeline(
+        source_breakdown, observations=observations, source="langfuse", trace_id=resolved
+    )
+    return breakdown
+
+
+__all__ = [
+    "KB_TIMELINE_SCHEMA",
+    "build_kb_timeline",
+    "empty_kb_timeline",
+    "enrich_breakdown_with_langfuse_kb_timeline",
+]

--- a/inference_optimizer/breakdown/kb_timeline.py
+++ b/inference_optimizer/breakdown/kb_timeline.py
@@ -169,16 +169,25 @@ def _recipe_read_event(row: dict[str, Any], idx: int) -> dict[str, Any]:
     }
 
 
-def _critic_kb_events(iterations: list[Any], warnings: list[str]) -> list[dict[str, Any]]:
+def _critic_kb_events(
+    iterations: list[Any],
+    warnings: list[str],
+    *,
+    categories: set[str] | None = None,
+) -> list[dict[str, Any]]:
     """Project ``critic_iterations[].kb_assess`` / ``kb_priors`` into events.
 
     Args:
         iterations: The ``critic_robustness.critic_iterations`` list.
         warnings: Mutable list to append non-fatal notes to.
+        categories: When given, only emit events for these categories
+            (``critic_assess`` / ``critic_priors``); ``None`` emits both.
 
     Returns:
         Partial ``critic_assess`` / ``critic_priors`` events (``seq`` unset).
     """
+    want_assess = categories is None or "critic_assess" in categories
+    want_priors = categories is None or "critic_priors" in categories
     events: list[dict[str, Any]] = []
     for idx, it in enumerate(iterations):
         if not isinstance(it, dict):
@@ -186,7 +195,7 @@ def _critic_kb_events(iterations: list[Any], warnings: list[str]) -> list[dict[s
         ts = it.get("ts")
         itr = it.get("iter")
         assess = it.get("kb_assess") if isinstance(it.get("kb_assess"), dict) else None
-        if assess and assess.get("configured"):
+        if want_assess and assess and assess.get("configured"):
             ref = assess.get("referenced_in_verdict")
             events.append(
                 {
@@ -204,7 +213,7 @@ def _critic_kb_events(iterations: list[Any], warnings: list[str]) -> list[dict[s
                 }
             )
         priors = it.get("kb_priors") if isinstance(it.get("kb_priors"), dict) else None
-        if priors and priors.get("configured"):
+        if want_priors and priors and priors.get("configured"):
             ref = priors.get("referenced_in_verdict")
             events.append(
                 {
@@ -301,6 +310,48 @@ def _events_from_observations(observations: list[Any], warnings: list[str]) -> l
     return events
 
 
+def _recipe_reads_from_breakdown(kbp: dict[str, Any], warnings: list[str]) -> list[dict[str, Any]]:
+    """Project ``kb_provenance.recipe_snapshot_reads.tail`` into recipe events.
+
+    Args:
+        kbp: The ``kb_provenance`` section dict.
+        warnings: Mutable list to append non-fatal notes to.
+
+    Returns:
+        Partial ``recipe_read`` events (``seq`` not yet set).
+    """
+    reads = (kbp.get("recipe_snapshot_reads") or {}).get("tail") if isinstance(kbp, dict) else None
+    if isinstance(reads, list):
+        return [_recipe_read_event(r, i) for i, r in enumerate(reads) if isinstance(r, dict)]
+    warnings.append("kb_provenance.recipe_snapshot_reads.tail missing")
+    return []
+
+
+def _critic_from_breakdown(
+    breakdown: dict[str, Any],
+    warnings: list[str],
+    *,
+    categories: set[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Project ``critic_robustness.critic_iterations`` KB reads into events.
+
+    Args:
+        breakdown: The full breakdown dict.
+        warnings: Mutable list to append non-fatal notes to.
+        categories: Restrict to these categories (``critic_assess`` /
+            ``critic_priors``); ``None`` emits both.
+
+    Returns:
+        Partial ``critic_assess`` / ``critic_priors`` events (``seq`` unset).
+    """
+    critic = breakdown.get("critic_robustness")
+    iterations = critic.get("critic_iterations") if isinstance(critic, dict) else None
+    if isinstance(iterations, list):
+        return _critic_kb_events(iterations, warnings, categories=categories)
+    warnings.append("critic_robustness.critic_iterations missing")
+    return []
+
+
 _CATEGORIES = ("recipe_read", "warm_start", "warm_replay", "critic_assess", "critic_priors")
 
 
@@ -341,23 +392,25 @@ def build_kb_timeline(
         kbp = {}
 
     if observations:
-        # Span path: recipe reads + critic assess/priors come from spans (full).
-        # An empty/None list falls through to the breakdown sections so a
-        # transient observation-fetch miss doesn't drop data that's in output.
-        raw.extend(_events_from_observations(observations, warnings))
+        # Span path: prefer KB spans (full history vs the capped audit tail).
+        # But the observation list is the trace's *full* span set and may carry
+        # only LLM spans with no KB spans, so fall back to the breakdown
+        # sections per-category when that category has no spans (and an
+        # empty/None list falls through entirely below).
+        span_events = _events_from_observations(observations, warnings)
+        raw.extend(span_events)
+        span_cats = {e["category"] for e in span_events}
+        if "recipe_read" not in span_cats:
+            raw.extend(_recipe_reads_from_breakdown(kbp, warnings))
+        # Gate the two critic categories independently: a trace with only
+        # kb_assess spans must still recover kb_priors from the breakdown.
+        missing_critic = {"critic_assess", "critic_priors"} - span_cats
+        if missing_critic:
+            raw.extend(_critic_from_breakdown(breakdown, warnings, categories=missing_critic))
     else:
-        # Breakdown path: recipe reads from the (capped) audit tail.
-        reads = (kbp.get("recipe_snapshot_reads") or {}).get("tail") if isinstance(kbp, dict) else None
-        if isinstance(reads, list):
-            raw.extend(_recipe_read_event(r, i) for i, r in enumerate(reads) if isinstance(r, dict))
-        else:
-            warnings.append("kb_provenance.recipe_snapshot_reads.tail missing")
-        critic = breakdown.get("critic_robustness")
-        iterations = critic.get("critic_iterations") if isinstance(critic, dict) else None
-        if isinstance(iterations, list):
-            raw.extend(_critic_kb_events(iterations, warnings))
-        else:
-            warnings.append("critic_robustness.critic_iterations missing")
+        # Breakdown path: recipe reads from the (capped) audit tail + critic.
+        raw.extend(_recipe_reads_from_breakdown(kbp, warnings))
+        raw.extend(_critic_from_breakdown(breakdown, warnings))
 
     indexed = list(enumerate(raw))
     indexed.sort(key=lambda pair: (_parse_ts(pair[1].get("ts")) or _TS_MAX, pair[0]))
@@ -438,7 +491,14 @@ def enrich_breakdown_with_langfuse_kb_timeline(
         fetch_session_breakdown,
         resolve_trace_id,
     )
-    from .agent_timeline import _trace_seed_from_breakdown
+    from .agent_timeline import _has_populated_timeline, _trace_seed_from_breakdown
+
+    # Fill-if-missing: the exporter already builds a local ``kb_timeline``
+    # consistent with this file's own KB sections, so never overwrite a
+    # populated one (a Langfuse re-derive could be stale or empty). Only
+    # (re)derive when the section is absent or has no events.
+    if _has_populated_timeline(breakdown, "kb_timeline"):
+        return breakdown
 
     bd_trace_id, bd_seed = _trace_seed_from_breakdown(breakdown)
     resolved = resolve_trace_id(trace_id=trace_id or bd_trace_id, seed=seed or bd_seed)

--- a/inference_optimizer/breakdown/schema.py
+++ b/inference_optimizer/breakdown/schema.py
@@ -1853,6 +1853,71 @@ class AgentTimeline(TypedDict, total=False):
     warnings: list[str]
 
 
+class KBTimelineEvent(TypedDict, total=False):
+    """One chronological event on the knowledge-base decision timeline.
+
+    Normalises a single KB read/use decision (recipe lookup, warm-start,
+    warm-replay, or a critic KB assess/priors read) to a flat shape so the
+    scattered KB decision sources can be merged on one time axis. **Write-side
+    KB activity is intentionally excluded** (it is session-close bookkeeping,
+    not a decision, and is not timestamped anywhere).
+
+    Attributes:
+        ts (str): ISO UTC timestamp (primary sort key).
+        seq (int): Monotonic fallback ordering index, assigned at build time.
+        category (str): ``recipe_read`` / ``warm_start`` / ``warm_replay`` /
+            ``critic_assess`` / ``critic_priors``.
+        title (str): One-line human summary.
+        detail (dict[str, Any]): Category-specific payload (original fields kept
+            verbatim — method/resolution/hit for reads, tier/confidence for
+            warm-start, status/gain for replay, verdict_count/prior_count and
+            ``referenced_in_verdict`` for critic reads).
+        source (dict[str, Any]): Provenance pointer (``{section, index}`` or
+            ``{span, observation_id}``, plus ``trace_id`` on the Langfuse path).
+    """
+
+    ts: str
+    seq: int
+    category: str
+    title: str
+    detail: dict[str, Any]
+    source: dict[str, Any]
+
+
+class KBTimeline(TypedDict, total=False):
+    """Unified, time-ordered timeline of knowledge-base read/use decisions.
+
+    Additive optional top-level section (older readers ignore it). Built by
+    :func:`inference_optimizer.breakdown.kb_timeline.build_kb_timeline` by
+    merging recipe lookups (``kb_provenance.recipe_snapshot_reads`` /
+    ``kb:recipe_snapshot`` spans), warm-start + warm-replay
+    (``kb_provenance``), and the critic's KB assess/priors reads
+    (``critic_robustness.critic_iterations`` / ``kb_assess`` / ``kb_priors``
+    spans) onto one ``ts`` axis. Write-side KB activity is out of scope.
+
+    Attributes:
+        schema (str): Timeline schema id (``hyperloom.kb_timeline.v1``).
+        source (str): ``local`` (built from the breakdown payload) or
+            ``langfuse`` (recovered from a trace's output + observations).
+        trace_id (str): Langfuse trace id (when ``source == "langfuse"``).
+        fetched_at_utc (str): ISO UTC timestamp the timeline was assembled.
+        events (list[KBTimelineEvent]): Events sorted by ``(ts, seq)``.
+        counts (dict[str, int]): Per-category event counts.
+        degraded (bool): True when one or more source sections were missing /
+            empty / unparseable (still emitted, just partial).
+        warnings (list[str]): Non-fatal notes raised while assembling.
+    """
+
+    schema: str
+    source: str
+    trace_id: str
+    fetched_at_utc: str
+    events: list[KBTimelineEvent]
+    counts: dict[str, int]
+    degraded: bool
+    warnings: list[str]
+
+
 class SessionBreakdown(TypedDict, total=False):
     """Top-level wire shape of ``session_breakdown.json``.
 
@@ -1970,6 +2035,11 @@ class SessionBreakdown(TypedDict, total=False):
     # upload path, recovered from the Langfuse trace. Additive optional
     # section; empty {} on sessions that predate it, so older readers ignore it.
     agent_timeline: AgentTimeline
+    # Knowledge-base decision timeline (recipe lookups + warm-start/replay +
+    # critic KB assess/priors reads) merged onto one ``ts`` axis. Write-side KB
+    # activity is intentionally excluded. Built by
+    # ``breakdown.kb_timeline.build_kb_timeline``. Additive optional section.
+    kb_timeline: KBTimeline
 
     warnings: list[str]
     source_files: SourceFiles
@@ -2010,6 +2080,8 @@ __all__ = [
     "Invocation",
     "KBProvenance",
     "KBQueueStats",
+    "KBTimeline",
+    "KBTimelineEvent",
     "LaneTimelineEntry",
     "KernelLifecycle",
     "KernelMetadata",

--- a/inference_optimizer/breakdown/schema.py
+++ b/inference_optimizer/breakdown/schema.py
@@ -1779,6 +1779,80 @@ class LangfusePush(TypedDict, total=False):
     receipt_source: str
 
 
+class TimelineEvent(TypedDict, total=False):
+    """One chronological event on the unified three-actor ``agent_timeline``.
+
+    A flat, transport-agnostic projection of one source record (an
+    orchestrator decision, a specialist proposal round, or a critic review)
+    normalised to a common shape so the three histories can be merged and
+    sorted on a single time axis.
+
+    Attributes:
+        ts (str): ISO UTC timestamp used as the primary sort key
+            (``decision.ts`` / ``specialist_run.completed_at`` /
+            ``critic_iteration.ts``).
+        seq (int): Monotonic fallback ordering index, assigned at build time
+            (stable tiebreaker when two events share a ``ts`` or one is missing).
+        actor (str): ``orchestrator`` / ``specialist`` / ``critic``.
+        kind (str): ``decision`` / ``proposal`` / ``review``.
+        phase (str): Phase active at the event (orchestrator decisions only).
+        tick (int | None): Orchestrator tick, when the source carried one.
+        title (str): One-line human summary (e.g. ``KEEP target_analysis``).
+        detail (dict[str, Any]): Actor-specific payload (original fields kept
+            verbatim — outcome/gain for decisions, domain/findings for
+            proposals, verdict/topic for reviews).
+        source (dict[str, Any]): Provenance pointer
+            (``{section, index}`` and, when fetched from Langfuse, ``trace_id``).
+    """
+
+    ts: str
+    seq: int
+    actor: str
+    kind: str
+    phase: str
+    tick: int | None
+    title: str
+    detail: dict[str, Any]
+    source: dict[str, Any]
+
+
+class AgentTimeline(TypedDict, total=False):
+    """Unified, time-ordered timeline of specialist proposals, orchestrator
+    decisions, and critic reviews.
+
+    Additive optional top-level section: a v1/v2/v3 reader that doesn't know
+    about it simply ignores it. Assembled (by
+    :func:`inference_optimizer.breakdown.agent_timeline.build_agent_timeline`)
+    by merging ``decision_trace.decision_trace`` (orchestrator),
+    ``specialist_runs`` (specialist), and
+    ``critic_robustness.critic_iterations`` (critic) onto one ``ts`` axis.
+
+    Attributes:
+        schema (str): Timeline schema id (``hyperloom.agent_timeline.v1``).
+        source (str): Where the source sections came from
+            (``langfuse`` when fetched back from a trace, ``local`` when built
+            straight from the breakdown payload).
+        trace_id (str): Langfuse trace id the data was recovered from (when
+            ``source == "langfuse"``).
+        fetched_at_utc (str): ISO UTC timestamp the timeline was assembled.
+        events (list[TimelineEvent]): Events sorted by ``(ts, seq)``.
+        counts (dict[str, int]): Per-actor event counts
+            (``{"orchestrator": n, "specialist": n, "critic": n}``).
+        degraded (bool): True when one or more source sections were missing /
+            empty / unparseable (the timeline is still emitted, just partial).
+        warnings (list[str]): Non-fatal notes raised while assembling.
+    """
+
+    schema: str
+    source: str
+    trace_id: str
+    fetched_at_utc: str
+    events: list[TimelineEvent]
+    counts: dict[str, int]
+    degraded: bool
+    warnings: list[str]
+
+
 class SessionBreakdown(TypedDict, total=False):
     """Top-level wire shape of ``session_breakdown.json``.
 
@@ -1890,6 +1964,12 @@ class SessionBreakdown(TypedDict, total=False):
     # Additive optional section recorded at author time; empty {} on sessions
     # that predate the recorder.
     versions: dict[str, KernelToolMetadata]
+    # Unified three-actor decision timeline (specialist proposals +
+    # orchestrator decisions + critic reviews) merged onto one ``ts`` axis.
+    # Built by ``breakdown.agent_timeline.build_agent_timeline`` and, on the
+    # upload path, recovered from the Langfuse trace. Additive optional
+    # section; empty {} on sessions that predate it, so older readers ignore it.
+    agent_timeline: AgentTimeline
 
     warnings: list[str]
     source_files: SourceFiles
@@ -1899,6 +1979,7 @@ __all__ = [
     "SCHEMA_VERSION",
     "SCHEMA_VERSION_V3",
     "AdoptedKernel",
+    "AgentTimeline",
     "Attribution",
     "Baseline",
     "BaselineAttemptSummary",
@@ -1956,6 +2037,7 @@ __all__ = [
     "Sweep",
     "SweepPoint",
     "Telemetry",
+    "TimelineEvent",
     "TokenBucket",
     "TokenRollup",
     "TokenUsage",

--- a/inference_optimizer/orchestrator/trace/langfuse_reader.py
+++ b/inference_optimizer/orchestrator/trace/langfuse_reader.py
@@ -36,6 +36,7 @@ from .trace_env import langfuse_credentials
 log = logging.getLogger(__name__)
 
 _TRACE_API_PATH = "/api/public/traces/"
+_OBSERVATIONS_API_PATH = "/api/public/observations"
 
 
 def resolve_trace_id(*, trace_id: str | None = None, seed: str | None = None) -> str | None:
@@ -74,6 +75,31 @@ def _credentials(creds: dict[str, str] | None) -> dict[str, str] | None:
     return {"host": host, "public_key": public_key, "secret_key": secret_key}
 
 
+def _get_json(url: str, creds: dict[str, str], timeout: float) -> Any | None:
+    """GET a Langfuse public-API URL with Basic auth and parse the JSON body.
+
+    Args:
+        url: Fully-qualified request URL.
+        creds: A complete ``{host, public_key, secret_key}`` set.
+        timeout: Per-request timeout in seconds.
+
+    Returns:
+        The parsed JSON (dict/list), or ``None`` on any failure.
+    """
+    token = base64.b64encode(f"{creds['public_key']}:{creds['secret_key']}".encode()).decode()
+    req = urllib.request.Request(url, headers={"Authorization": f"Basic {token}"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (trusted host)
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        log.warning("langfuse_reader: HTTP %s GET %s", exc.code, url)
+    except (urllib.error.URLError, TimeoutError) as exc:
+        log.warning("langfuse_reader: network error GET %s: %s", url, exc)
+    except (ValueError, json.JSONDecodeError) as exc:
+        log.warning("langfuse_reader: unparseable body GET %s: %s", url, exc)
+    return None
+
+
 def fetch_trace(
     trace_id: str,
     *,
@@ -96,21 +122,61 @@ def fetch_trace(
     if creds is None:
         log.warning("langfuse_reader: credentials incomplete; cannot fetch trace %s", trace_id)
         return None
+    result = _get_json(f"{creds['host']}{_TRACE_API_PATH}{trace_id}", creds, timeout)
+    return result if isinstance(result, dict) else None
 
-    url = f"{creds['host']}{_TRACE_API_PATH}{trace_id}"
-    token = base64.b64encode(f"{creds['public_key']}:{creds['secret_key']}".encode()).decode()
-    req = urllib.request.Request(url, headers={"Authorization": f"Basic {token}"})
-    try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (trusted host)
-            body = resp.read().decode("utf-8")
-        return json.loads(body)
-    except urllib.error.HTTPError as exc:
-        log.warning("langfuse_reader: HTTP %s fetching trace %s", exc.code, trace_id)
-    except (urllib.error.URLError, TimeoutError) as exc:
-        log.warning("langfuse_reader: network error fetching trace %s: %s", trace_id, exc)
-    except (ValueError, json.JSONDecodeError) as exc:
-        log.warning("langfuse_reader: unparseable trace body for %s: %s", trace_id, exc)
-    return None
+
+def fetch_observations(
+    trace_id: str,
+    *,
+    name_prefix: str | None = None,
+    credentials: dict[str, str] | None = None,
+    timeout: float = 30.0,
+    max_pages: int = 20,
+) -> list[dict[str, Any]]:
+    """Fetch a trace's observations (spans/generations) from the public API.
+
+    Paginates ``GET /api/public/observations?traceId=...`` and returns the flat
+    list. The per-event KB granularity (recipe-snapshot reads, per-iter
+    ``kb_assess`` / ``kb_priors``) lives in **observations**, not the trace
+    ``output``, so the KB-timeline langfuse path needs this.
+
+    Args:
+        trace_id: The trace id whose observations to fetch.
+        name_prefix: When set, keep only observations whose ``name`` starts with
+            this prefix (client-side filter, e.g. ``"kb:recipe_snapshot"``).
+        credentials: Optional explicit credentials override.
+        timeout: Per-request timeout in seconds.
+        max_pages: Safety cap on pagination.
+
+    Returns:
+        A list of observation dicts (possibly empty); never raises.
+    """
+    creds = _credentials(credentials)
+    if creds is None:
+        log.warning("langfuse_reader: credentials incomplete; cannot fetch observations for %s", trace_id)
+        return []
+
+    out: list[dict[str, Any]] = []
+    page = 1
+    while page <= max_pages:
+        url = f"{creds['host']}{_OBSERVATIONS_API_PATH}?traceId={trace_id}&page={page}&limit=100"
+        payload = _get_json(url, creds, timeout)
+        if not isinstance(payload, dict):
+            break
+        rows = payload.get("data")
+        if not isinstance(rows, list) or not rows:
+            break
+        out.extend(r for r in rows if isinstance(r, dict))
+        meta = payload.get("meta") if isinstance(payload.get("meta"), dict) else {}
+        total_pages = meta.get("totalPages")
+        if not isinstance(total_pages, int) or page >= total_pages:
+            break
+        page += 1
+
+    if name_prefix:
+        out = [o for o in out if str(o.get("name") or "").startswith(name_prefix)]
+    return out
 
 
 def _extract_output(trace: dict[str, Any]) -> dict[str, Any] | None:
@@ -172,6 +238,7 @@ def fetch_session_breakdown(
 
 
 __all__ = [
+    "fetch_observations",
     "fetch_session_breakdown",
     "fetch_trace",
     "resolve_trace_id",

--- a/inference_optimizer/orchestrator/trace/langfuse_reader.py
+++ b/inference_optimizer/orchestrator/trace/langfuse_reader.py
@@ -1,0 +1,178 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Read a session's ``session_breakdown`` back out of a Langfuse trace.
+
+The write side (:mod:`langfuse_emitter`) attaches the full
+``session_breakdown.json`` as the **root output** of each session's trace via
+``record_session_breakdown``. This module is the symmetric **read** side: given
+a trace id (or a correlation seed such as the ``claw_session_id``), it fetches
+the trace and returns that breakdown dict — which the upload path then feeds to
+:func:`inference_optimizer.breakdown.agent_timeline.build_agent_timeline` to
+produce the ``agent_timeline`` section.
+
+Design notes:
+
+* **Read-only, best-effort.** Every failure degrades to ``None`` (with a
+  logged reason); nothing here raises into the upload path.
+* **No new dependency.** The Langfuse public REST API is called with the
+  stdlib (``urllib``) and HTTP Basic auth (``public_key`` : ``secret_key``).
+  When the ``langfuse`` SDK happens to be installed it is used as a fallback.
+* **Trace id derivation** reuses :func:`langfuse_mapping.derive_trace_id` so a
+  reader and the writer always agree on the id for a given session.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import urllib.error
+import urllib.request
+from typing import Any
+
+from .langfuse_mapping import derive_trace_id
+from .trace_env import langfuse_credentials
+
+log = logging.getLogger(__name__)
+
+_TRACE_API_PATH = "/api/public/traces/"
+
+
+def resolve_trace_id(*, trace_id: str | None = None, seed: str | None = None) -> str | None:
+    """Resolve the Langfuse trace id from an explicit id or a correlation seed.
+
+    Args:
+        trace_id: An explicit 32-char trace id (returned as-is when given).
+        seed: A correlation seed (typically ``claw_session_id`` or the internal
+            session id); hashed via :func:`derive_trace_id`.
+
+    Returns:
+        The resolved trace id, or ``None`` when neither input was usable.
+    """
+    if trace_id and trace_id.strip():
+        return trace_id.strip()
+    if seed and str(seed).strip():
+        return derive_trace_id(str(seed).strip())
+    return None
+
+
+def _credentials(creds: dict[str, str] | None) -> dict[str, str] | None:
+    """Return a complete ``{host, public_key, secret_key}`` set or ``None``.
+
+    Args:
+        creds: Optional explicit override; falls back to env-derived creds.
+
+    Returns:
+        A dict with all three keys present, or ``None`` when incomplete.
+    """
+    src = creds or langfuse_credentials()
+    host = (src.get("LANGFUSE_HOST") or src.get("host") or "").strip().rstrip("/")
+    public_key = (src.get("LANGFUSE_PUBLIC_KEY") or src.get("public_key") or "").strip()
+    secret_key = (src.get("LANGFUSE_SECRET_KEY") or src.get("secret_key") or "").strip()
+    if not (host and public_key and secret_key):
+        return None
+    return {"host": host, "public_key": public_key, "secret_key": secret_key}
+
+
+def fetch_trace(
+    trace_id: str,
+    *,
+    credentials: dict[str, str] | None = None,
+    timeout: float = 30.0,
+) -> dict[str, Any] | None:
+    """Fetch one trace (with its details) from the Langfuse public REST API.
+
+    Args:
+        trace_id: The trace id to fetch.
+        credentials: Optional explicit ``{host, public_key, secret_key}`` (or
+            the ``LANGFUSE_*`` env-key form); defaults to env-derived creds.
+        timeout: Per-request timeout in seconds.
+
+    Returns:
+        The parsed trace JSON dict, or ``None`` on any failure (missing creds,
+        network error, non-2xx, unparseable body).
+    """
+    creds = _credentials(credentials)
+    if creds is None:
+        log.warning("langfuse_reader: credentials incomplete; cannot fetch trace %s", trace_id)
+        return None
+
+    url = f"{creds['host']}{_TRACE_API_PATH}{trace_id}"
+    token = base64.b64encode(f"{creds['public_key']}:{creds['secret_key']}".encode()).decode()
+    req = urllib.request.Request(url, headers={"Authorization": f"Basic {token}"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (trusted host)
+            body = resp.read().decode("utf-8")
+        return json.loads(body)
+    except urllib.error.HTTPError as exc:
+        log.warning("langfuse_reader: HTTP %s fetching trace %s", exc.code, trace_id)
+    except (urllib.error.URLError, TimeoutError) as exc:
+        log.warning("langfuse_reader: network error fetching trace %s: %s", trace_id, exc)
+    except (ValueError, json.JSONDecodeError) as exc:
+        log.warning("langfuse_reader: unparseable trace body for %s: %s", trace_id, exc)
+    return None
+
+
+def _extract_output(trace: dict[str, Any]) -> dict[str, Any] | None:
+    """Pull the breakdown dict out of a fetched trace's ``output``.
+
+    The Langfuse SDK / API can store ``output`` either as a dict or as a
+    JSON-encoded string; both are handled.
+
+    Args:
+        trace: A fetched trace JSON dict.
+
+    Returns:
+        The breakdown dict, or ``None`` when ``output`` is absent / not an object.
+    """
+    output = trace.get("output")
+    if isinstance(output, str):
+        try:
+            output = json.loads(output)
+        except (ValueError, json.JSONDecodeError):
+            return None
+    if isinstance(output, dict):
+        return output
+    return None
+
+
+def fetch_session_breakdown(
+    *,
+    trace_id: str | None = None,
+    seed: str | None = None,
+    credentials: dict[str, str] | None = None,
+    timeout: float = 30.0,
+) -> dict[str, Any] | None:
+    """Recover the ``session_breakdown`` dict attached to a session's trace.
+
+    Resolves the trace id (explicit or derived from ``seed``), fetches the
+    trace, and returns its root ``output`` (the breakdown the writer attached).
+
+    Args:
+        trace_id: Explicit trace id; takes precedence over ``seed``.
+        seed: Correlation seed (e.g. ``claw_session_id``) when ``trace_id`` is
+            unknown.
+        credentials: Optional explicit credentials override.
+        timeout: Per-request timeout in seconds.
+
+    Returns:
+        The recovered breakdown dict, or ``None`` on any failure.
+    """
+    resolved = resolve_trace_id(trace_id=trace_id, seed=seed)
+    if not resolved:
+        log.warning("langfuse_reader: no trace_id and no usable seed; cannot fetch breakdown")
+        return None
+    trace = fetch_trace(resolved, credentials=credentials, timeout=timeout)
+    if trace is None:
+        return None
+    breakdown = _extract_output(trace)
+    if breakdown is None:
+        log.warning("langfuse_reader: trace %s has no usable output (breakdown)", resolved)
+    return breakdown
+
+
+__all__ = [
+    "fetch_session_breakdown",
+    "fetch_trace",
+    "resolve_trace_id",
+]

--- a/inference_optimizer/orchestrator/trace/langfuse_reader.py
+++ b/inference_optimizer/orchestrator/trace/langfuse_reader.py
@@ -157,10 +157,15 @@ def fetch_observations(
         log.warning("langfuse_reader: credentials incomplete; cannot fetch observations for %s", trace_id)
         return []
 
+    limit = 100
     out: list[dict[str, Any]] = []
     page = 1
-    while page <= max_pages:
-        url = f"{creds['host']}{_OBSERVATIONS_API_PATH}?traceId={trace_id}&page={page}&limit=100"
+    truncated = False
+    while True:
+        if page > max_pages:
+            truncated = True
+            break
+        url = f"{creds['host']}{_OBSERVATIONS_API_PATH}?traceId={trace_id}&page={page}&limit={limit}"
         payload = _get_json(url, creds, timeout)
         if not isinstance(payload, dict):
             break
@@ -170,36 +175,104 @@ def fetch_observations(
         out.extend(r for r in rows if isinstance(r, dict))
         meta = payload.get("meta") if isinstance(payload.get("meta"), dict) else {}
         total_pages = meta.get("totalPages")
-        if not isinstance(total_pages, int) or page >= total_pages:
+        if isinstance(total_pages, int):
+            if page >= total_pages:
+                break
+        elif len(rows) < limit:
+            # No usable totalPages: a short page means we've reached the end.
             break
         page += 1
+
+    if truncated:
+        log.warning(
+            "langfuse_reader: observation pagination for %s hit max_pages=%d (>%d rows); "
+            "results may be truncated",
+            trace_id,
+            max_pages,
+            max_pages * limit,
+        )
 
     if name_prefix:
         out = [o for o in out if str(o.get("name") or "").startswith(name_prefix)]
     return out
 
 
-def _extract_output(trace: dict[str, Any]) -> dict[str, Any] | None:
-    """Pull the breakdown dict out of a fetched trace's ``output``.
-
-    The Langfuse SDK / API can store ``output`` either as a dict or as a
-    JSON-encoded string; both are handled.
+def _coerce_output(output: Any) -> dict[str, Any] | None:
+    """Coerce an ``output`` value (dict or JSON-encoded string) to a dict.
 
     Args:
-        trace: A fetched trace JSON dict.
+        output: The raw ``output`` value from a trace or observation.
 
     Returns:
-        The breakdown dict, or ``None`` when ``output`` is absent / not an object.
+        The dict form, or ``None`` when absent / not an object.
     """
-    output = trace.get("output")
     if isinstance(output, str):
         try:
             output = json.loads(output)
         except (ValueError, json.JSONDecodeError):
             return None
-    if isinstance(output, dict):
-        return output
+    return output if isinstance(output, dict) else None
+
+
+def _breakdown_from_observations(observations: list[Any]) -> dict[str, Any] | None:
+    """Find the ``session_breakdown`` observation and return its ``output``.
+
+    ``record_session_breakdown`` attaches the full breakdown as the ``output``
+    of a ``session_breakdown`` span observation (not the trace root output), so
+    that is the authoritative place to recover it from.
+
+    Args:
+        observations: A list of observation dicts.
+
+    Returns:
+        The breakdown dict, or ``None`` when no usable observation is found.
+    """
+    for obs in observations:
+        if isinstance(obs, dict) and obs.get("name") == "session_breakdown":
+            bd = _coerce_output(obs.get("output"))
+            if bd is not None:
+                return bd
     return None
+
+
+def _extract_breakdown(
+    trace: dict[str, Any],
+    trace_id: str,
+    *,
+    credentials: dict[str, str] | None,
+    timeout: float,
+) -> dict[str, Any] | None:
+    """Recover the breakdown from a fetched trace, trying every known location.
+
+    Order: the ``session_breakdown`` span among the trace's embedded
+    ``observations`` (where the writer puts it) -> the trace root ``output``
+    (fast path, in case a future writer sets it) -> a dedicated observations
+    fetch for the ``session_breakdown`` span.
+
+    Args:
+        trace: The fetched trace JSON dict.
+        trace_id: The trace id (for the fallback observations fetch).
+        credentials: Optional explicit credentials override.
+        timeout: Per-request timeout in seconds.
+
+    Returns:
+        The breakdown dict, or ``None`` when not recoverable.
+    """
+    embedded = trace.get("observations")
+    if isinstance(embedded, list):
+        bd = _breakdown_from_observations(embedded)
+        if bd is not None:
+            return bd
+
+    bd = _coerce_output(trace.get("output"))
+    if bd is not None:
+        return bd
+
+    # Embedded observations were absent or only IDs: fetch them explicitly.
+    obs = fetch_observations(
+        trace_id, name_prefix="session_breakdown", credentials=credentials, timeout=timeout
+    )
+    return _breakdown_from_observations(obs)
 
 
 def fetch_session_breakdown(
@@ -231,9 +304,9 @@ def fetch_session_breakdown(
     trace = fetch_trace(resolved, credentials=credentials, timeout=timeout)
     if trace is None:
         return None
-    breakdown = _extract_output(trace)
+    breakdown = _extract_breakdown(trace, resolved, credentials=credentials, timeout=timeout)
     if breakdown is None:
-        log.warning("langfuse_reader: trace %s has no usable output (breakdown)", resolved)
+        log.warning("langfuse_reader: trace %s has no recoverable session_breakdown", resolved)
     return breakdown
 
 

--- a/inference_optimizer/tests/test_agent_timeline.py
+++ b/inference_optimizer/tests/test_agent_timeline.py
@@ -155,17 +155,49 @@ def test_empty_timeline_is_well_formed():
     assert tl["warnings"] == ["boom"]
 
 
+def test_trace_seed_falls_back_to_session_dir_basename():
+    from inference_optimizer.breakdown.agent_timeline import _trace_seed_from_breakdown
+
+    # No claw/session id -> match the writer's correlation_seed fallback
+    # (the session-dir basename).
+    bd = {"session": {"session_dir": "/data/model/20260617_073000/"}}
+    tid, seed = _trace_seed_from_breakdown(bd)
+    assert tid is None
+    assert seed == "20260617_073000"
+
+
 def test_resolve_trace_id_prefers_explicit_then_seed():
     assert langfuse_reader.resolve_trace_id(trace_id="  fixed  ") == "fixed"
     assert langfuse_reader.resolve_trace_id(seed="claw-xyz") == derive_trace_id("claw-xyz")
     assert langfuse_reader.resolve_trace_id() is None
 
 
-def test_extract_output_handles_dict_and_json_string():
-    assert langfuse_reader._extract_output({"output": {"a": 1}}) == {"a": 1}
-    assert langfuse_reader._extract_output({"output": json.dumps({"a": 1})}) == {"a": 1}
-    assert langfuse_reader._extract_output({"output": "not json"}) is None
-    assert langfuse_reader._extract_output({}) is None
+def test_coerce_output_handles_dict_and_json_string():
+    assert langfuse_reader._coerce_output({"a": 1}) == {"a": 1}
+    assert langfuse_reader._coerce_output(json.dumps({"a": 1})) == {"a": 1}
+    assert langfuse_reader._coerce_output("not json") is None
+    assert langfuse_reader._coerce_output(None) is None
+
+
+def test_breakdown_recovered_from_session_breakdown_observation():
+    # The writer attaches the breakdown as a `session_breakdown` span output,
+    # not the trace root output, so recovery must look there.
+    obs = [
+        {"name": "kernel", "output": {"unrelated": 1}},
+        {"name": "session_breakdown", "output": {"schema_version": "v3", "ok": True}},
+    ]
+    assert langfuse_reader._breakdown_from_observations(obs) == {"schema_version": "v3", "ok": True}
+    assert langfuse_reader._breakdown_from_observations([{"name": "kernel"}]) is None
+
+
+def test_fetch_session_breakdown_reads_embedded_observation(monkeypatch):
+    trace = {
+        "output": None,
+        "observations": [{"name": "session_breakdown", "output": {"schema_version": "v3"}}],
+    }
+    monkeypatch.setattr(langfuse_reader, "fetch_trace", lambda *a, **kw: trace)
+    bd = langfuse_reader.fetch_session_breakdown(trace_id="t1")
+    assert bd == {"schema_version": "v3"}
 
 
 def test_enrich_injects_built_timeline_when_fetch_succeeds(monkeypatch):
@@ -200,3 +232,30 @@ def test_enrich_injects_degraded_timeline_when_fetch_fails(monkeypatch):
 def test_enrich_handles_no_trace_seed():
     out = enrich_breakdown_with_langfuse_timeline({})
     assert out["agent_timeline"]["degraded"] is True
+
+
+def test_enrich_keeps_populated_local_timeline_on_fetch_failure(monkeypatch):
+    # A failed Langfuse re-derive must not clobber an already-populated
+    # (locally built) timeline with a degraded empty one.
+    local = build_agent_timeline(_full_breakdown(), source="local")
+    target = {"session": {"claw_session_id": "claw-xyz"}, "agent_timeline": local}
+    monkeypatch.setattr(
+        "inference_optimizer.orchestrator.trace.langfuse_reader.fetch_session_breakdown",
+        lambda **kw: None,
+    )
+    out = enrich_breakdown_with_langfuse_timeline(target)
+    assert out["agent_timeline"] is local
+    assert out["agent_timeline"]["counts"] == {"orchestrator": 1, "specialist": 1, "critic": 1}
+
+
+def test_enrich_success_does_not_downgrade_populated_local_timeline(monkeypatch):
+    # Successful fetch but the recovered breakdown has no decision sources ->
+    # the built langfuse timeline is empty; keep the populated local one.
+    local = build_agent_timeline(_full_breakdown(), source="local")
+    target = {"session": {"claw_session_id": "claw-xyz"}, "agent_timeline": local}
+    monkeypatch.setattr(
+        "inference_optimizer.orchestrator.trace.langfuse_reader.fetch_session_breakdown",
+        lambda **kw: {},  # recovered, but empty -> no events
+    )
+    out = enrich_breakdown_with_langfuse_timeline(target)
+    assert out["agent_timeline"] is local

--- a/inference_optimizer/tests/test_agent_timeline.py
+++ b/inference_optimizer/tests/test_agent_timeline.py
@@ -1,0 +1,202 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit coverage for the unified ``agent_timeline`` builder and Langfuse reader.
+
+The builder is a pure projection that merges the three decision histories that
+already live in a breakdown (``decision_trace`` / ``specialist_runs`` /
+``critic_robustness``) onto one ``ts`` axis. These tests pin:
+
+* the merge picks all three actors and sorts by timestamp (unparseable last);
+* per-actor field projection (outcome/gain, domain/findings, verdict/topic),
+  including specialist schema drift (``domain`` vs ``domains``);
+* partial / missing sections degrade gracefully (warning + ``degraded``);
+* the Langfuse reader resolves trace ids, extracts the breakdown from a
+  trace ``output`` (dict or JSON-string), and the upload-path bridge injects a
+  ``degraded`` empty timeline when the trace cannot be fetched.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from inference_optimizer.breakdown.agent_timeline import (
+    AGENT_TIMELINE_SCHEMA,
+    build_agent_timeline,
+    empty_timeline,
+    enrich_breakdown_with_langfuse_timeline,
+)
+from inference_optimizer.orchestrator.trace import langfuse_reader
+from inference_optimizer.orchestrator.trace.langfuse_mapping import derive_trace_id
+
+
+def _full_breakdown() -> dict:
+    """A breakdown carrying one event of each actor at known timestamps."""
+    return {
+        "session": {"claw_session_id": "claw-xyz"},
+        "decision_trace": {
+            "decision_trace": [
+                {
+                    "ts": "2026-06-17T07:35:59Z",
+                    "phase": "PRELUDE",
+                    "tick": 1,
+                    "tokens": {"total": 100},
+                    "decision": {
+                        "outcome": "KEEP",
+                        "change": "target_analysis",
+                        "component": "orchestration",
+                        "operation_kind": "other",
+                        "gain_pct": None,
+                        "task_id": "t-1",
+                    },
+                }
+            ]
+        },
+        "specialist_runs": [
+            {
+                "completed_at": "2026-06-17T07:52:07.359619+00:00",
+                "domain": "research_scout_specialist",
+                "confidence": 0.6,
+                "new_findings": ["DENSE Qwen2.5-1.5B; NO MoE"],
+                "gap_canonical_id": "gap.research_scout.round0",
+            }
+        ],
+        "critic_robustness": {
+            "critic_iterations": [
+                {
+                    "iter": 0,
+                    "ts": "2026-06-17T08:00:00Z",
+                    "verdict": "approve",
+                    "topic": "kernel_opt:k001",
+                    "summary": "looks good",
+                }
+            ]
+        },
+    }
+
+
+def test_merge_orders_by_timestamp_and_counts_actors():
+    tl = build_agent_timeline(_full_breakdown())
+    assert tl["schema"] == AGENT_TIMELINE_SCHEMA
+    assert tl["source"] == "local"
+    assert tl["degraded"] is False
+    actors = [e["actor"] for e in tl["events"]]
+    # 07:35 orchestrator -> 07:52 specialist -> 08:00 critic
+    assert actors == ["orchestrator", "specialist", "critic"]
+    assert [e["seq"] for e in tl["events"]] == [0, 1, 2]
+    assert tl["counts"] == {"orchestrator": 1, "specialist": 1, "critic": 1}
+
+
+def test_actor_field_projection():
+    tl = build_agent_timeline(_full_breakdown())
+    by_actor = {e["actor"]: e for e in tl["events"]}
+
+    orch = by_actor["orchestrator"]
+    assert orch["kind"] == "decision"
+    assert orch["title"] == "KEEP target_analysis"
+    assert orch["detail"]["outcome"] == "KEEP"
+    assert orch["detail"]["tokens"] == {"total": 100}
+    assert orch["source"] == {"section": "decision_trace.decision_trace", "index": 0}
+
+    spec = by_actor["specialist"]
+    assert spec["kind"] == "proposal"
+    assert spec["title"] == "research_scout_specialist (conf 0.6)"
+    assert spec["detail"]["new_findings"] == ["DENSE Qwen2.5-1.5B; NO MoE"]
+
+    crit = by_actor["critic"]
+    assert crit["kind"] == "review"
+    assert crit["title"] == "verdict approve: kernel_opt:k001"
+    assert crit["detail"]["verdict"] == "approve"
+
+
+def test_specialist_domains_list_fallback():
+    bd = {"specialist_runs": [{"completed_at": "2026-06-17T07:00:00Z", "domains": ["a", "b"]}]}
+    tl = build_agent_timeline(bd)
+    ev = tl["events"][0]
+    assert ev["detail"]["domain"] == "a"
+    assert ev["detail"]["domains"] == ["a", "b"]
+    assert ev["title"] == "a"
+
+
+def test_unparseable_timestamp_sorts_last_without_crashing():
+    bd = {
+        "critic_robustness": {
+            "critic_iterations": [
+                {"iter": 1, "ts": "not-a-date", "verdict": "reject"},
+                {"iter": 0, "ts": "2026-06-17T07:00:00Z", "verdict": "approve"},
+            ]
+        }
+    }
+    tl = build_agent_timeline(bd)
+    assert [e["detail"]["iter"] for e in tl["events"]] == [0, 1]
+
+
+def test_missing_sections_degrade_with_warnings():
+    tl = build_agent_timeline({})
+    assert tl["events"] == []
+    assert tl["degraded"] is True
+    assert len(tl["warnings"]) == 3  # one per missing section
+    assert tl["counts"] == {"orchestrator": 0, "specialist": 0, "critic": 0}
+
+
+def test_langfuse_source_stamps_trace_id_on_events():
+    tl = build_agent_timeline(_full_breakdown(), source="langfuse", trace_id="abc123")
+    assert tl["source"] == "langfuse"
+    assert tl["trace_id"] == "abc123"
+    assert all(e["source"]["trace_id"] == "abc123" for e in tl["events"])
+
+
+def test_empty_timeline_is_well_formed():
+    tl = empty_timeline(reason="boom")
+    assert tl["schema"] == AGENT_TIMELINE_SCHEMA
+    assert tl["events"] == []
+    assert tl["degraded"] is True
+    assert tl["warnings"] == ["boom"]
+
+
+def test_resolve_trace_id_prefers_explicit_then_seed():
+    assert langfuse_reader.resolve_trace_id(trace_id="  fixed  ") == "fixed"
+    assert langfuse_reader.resolve_trace_id(seed="claw-xyz") == derive_trace_id("claw-xyz")
+    assert langfuse_reader.resolve_trace_id() is None
+
+
+def test_extract_output_handles_dict_and_json_string():
+    assert langfuse_reader._extract_output({"output": {"a": 1}}) == {"a": 1}
+    assert langfuse_reader._extract_output({"output": json.dumps({"a": 1})}) == {"a": 1}
+    assert langfuse_reader._extract_output({"output": "not json"}) is None
+    assert langfuse_reader._extract_output({}) is None
+
+
+def test_enrich_injects_built_timeline_when_fetch_succeeds(monkeypatch):
+    target = {"session": {"claw_session_id": "claw-xyz"}}
+
+    def fake_fetch(*, trace_id, credentials=None, timeout=30.0):
+        assert trace_id == derive_trace_id("claw-xyz")
+        return _full_breakdown()
+
+    monkeypatch.setattr(
+        "inference_optimizer.orchestrator.trace.langfuse_reader.fetch_session_breakdown",
+        fake_fetch,
+    )
+    out = enrich_breakdown_with_langfuse_timeline(target)
+    tl = out["agent_timeline"]
+    assert tl["source"] == "langfuse"
+    assert tl["trace_id"] == derive_trace_id("claw-xyz")
+    assert tl["counts"] == {"orchestrator": 1, "specialist": 1, "critic": 1}
+
+
+def test_enrich_injects_degraded_timeline_when_fetch_fails(monkeypatch):
+    monkeypatch.setattr(
+        "inference_optimizer.orchestrator.trace.langfuse_reader.fetch_session_breakdown",
+        lambda **kw: None,
+    )
+    out = enrich_breakdown_with_langfuse_timeline({"session": {"claw_session_id": "claw-xyz"}})
+    tl = out["agent_timeline"]
+    assert tl["degraded"] is True
+    assert tl["events"] == []
+
+
+def test_enrich_handles_no_trace_seed():
+    out = enrich_breakdown_with_langfuse_timeline({})
+    assert out["agent_timeline"]["degraded"] is True

--- a/inference_optimizer/tests/test_kb_timeline.py
+++ b/inference_optimizer/tests/test_kb_timeline.py
@@ -1,0 +1,198 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit coverage for the KB decision timeline builder and observation reader.
+
+``kb_timeline`` merges KB *read/use* decisions onto one ``ts`` axis:
+recipe-snapshot reads, warm-start, warm-replay, and the critic's per-iteration
+``kb_assess`` / ``kb_priors`` reads. Write-side KB activity is out of scope.
+These tests pin:
+
+* the breakdown path (warm-start/replay from ``kb_provenance`` + recipe reads
+  from the audit tail + critic assess/priors) merges and sorts by ``ts``;
+* the Langfuse observation path projects ``kb:recipe_snapshot`` /
+  ``kb_assess:iter_N`` / ``kb_priors:iter_N`` spans and is preferred when given;
+* partial / missing sources degrade gracefully;
+* ``fetch_observations`` paginates and filters by name prefix;
+* the upload-path bridge injects a ``degraded`` empty timeline on fetch failure.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from inference_optimizer.breakdown.kb_timeline import (
+    KB_TIMELINE_SCHEMA,
+    build_kb_timeline,
+    empty_kb_timeline,
+    enrich_breakdown_with_langfuse_kb_timeline,
+)
+from inference_optimizer.orchestrator.trace import langfuse_reader
+from inference_optimizer.orchestrator.trace.langfuse_mapping import derive_trace_id
+
+
+def _breakdown() -> dict:
+    """A breakdown with warm-start/replay + one recipe read + critic KB reads."""
+    return {
+        "session": {"claw_session_id": "claw-xyz"},
+        "kb_provenance": {
+            "cortex_session_id": "cortex-1",
+            "warm_start_ts": "2026-06-17T07:30:00Z",
+            "warm_start_recipe_seen": True,
+            "warm_start_recipe_tier": "exact",
+            "warm_start_pitfall_count": 2,
+            "warm_start_lesson_count": 0,
+            "warm_history_injected": True,
+            "warm_replay_attempted": True,
+            "warm_replay": {"status": "promoted", "actual_gain_pct": 12.0, "reason": "ok"},
+            "recipe_snapshot_reads": {
+                "count": 1,
+                "hits": 1,
+                "tail": [
+                    {
+                        "ts": "2026-06-17T07:31:00Z",
+                        "method": "get_recipe",
+                        "remote": "gbrain",
+                        "resolution": "remote",
+                        "hit": True,
+                        "request": {"canonical_id": "cid-1"},
+                        "result": {"canonical_id": "cid-1"},
+                    }
+                ],
+            },
+        },
+        "critic_robustness": {
+            "critic_iterations": [
+                {
+                    "iter": 5,
+                    "ts": "2026-06-17T08:00:00Z",
+                    "kb_assess": {"configured": True, "mode": "injected", "verdict_count": 1, "referenced_in_verdict": True},
+                    "kb_priors": {"configured": True, "mode": "per_proposal", "prior_count": 3, "referenced_in_verdict": False},
+                }
+            ]
+        },
+    }
+
+
+def test_breakdown_path_merges_and_sorts():
+    tl = build_kb_timeline(_breakdown())
+    assert tl["schema"] == KB_TIMELINE_SCHEMA
+    assert tl["source"] == "local"
+    # 07:30 warm_start, 07:30 warm_replay (anchored), 07:31 recipe_read, 08:00 critic x2
+    cats = [e["category"] for e in tl["events"]]
+    assert cats[0] == "warm_start"
+    assert "recipe_read" in cats
+    assert cats[-2:] == ["critic_assess", "critic_priors"]
+    assert tl["counts"] == {
+        "recipe_read": 1,
+        "warm_start": 1,
+        "warm_replay": 1,
+        "critic_assess": 1,
+        "critic_priors": 1,
+    }
+    assert tl["degraded"] is False
+    assert [e["seq"] for e in tl["events"]] == list(range(len(tl["events"])))
+
+
+def test_recipe_read_detail_fields():
+    tl = build_kb_timeline(_breakdown())
+    read = next(e for e in tl["events"] if e["category"] == "recipe_read")
+    assert read["detail"]["remote"] == "gbrain"
+    assert read["detail"]["resolution"] == "remote"
+    assert read["detail"]["hit"] is True
+    assert read["detail"]["canonical_id"] == "cid-1"
+    assert read["source"] == {"section": "kb_provenance.recipe_snapshot_reads.tail", "index": 0}
+
+
+def test_critic_kb_use_flag_in_title():
+    tl = build_kb_timeline(_breakdown())
+    assess = next(e for e in tl["events"] if e["category"] == "critic_assess")
+    priors = next(e for e in tl["events"] if e["category"] == "critic_priors")
+    assert "used" in assess["title"]          # referenced_in_verdict True
+    assert "not used" in priors["title"]       # referenced_in_verdict False
+
+
+def test_observations_path_preferred_for_reads():
+    observations = [
+        {
+            "id": "o1",
+            "name": "kb:recipe_snapshot:search",
+            "startTime": "2026-06-17T07:31:00Z",
+            "metadata": {"method": "search", "remote": "cortex", "resolution": "remote", "hit": False},
+        },
+        {
+            "id": "o2",
+            "name": "kb_assess:iter_7",
+            "startTime": "2026-06-17T07:45:00Z",
+            "metadata": {"iter": 7, "verdict_count": 2, "referenced_in_verdict": True},
+        },
+        {"id": "o3", "name": "kernel", "startTime": "2026-06-17T07:50:00Z", "metadata": {}},
+    ]
+    tl = build_kb_timeline(_breakdown(), observations=observations, source="langfuse", trace_id="t1")
+    cats = sorted(e["category"] for e in tl["events"])
+    # warm_start + warm_replay (from kbp) + recipe_read + critic_assess (from spans);
+    # the breakdown tail/critic_iterations are NOT used when observations given.
+    assert cats == ["critic_assess", "recipe_read", "warm_replay", "warm_start"]
+    read = next(e for e in tl["events"] if e["category"] == "recipe_read")
+    assert read["source"] == {"span": "kb:recipe_snapshot:search", "observation_id": "o1", "trace_id": "t1"}
+    assert tl["trace_id"] == "t1"
+
+
+def test_missing_sections_degrade():
+    tl = build_kb_timeline({})
+    assert tl["events"] == []
+    assert tl["degraded"] is True
+    assert tl["warnings"]
+    assert tl["counts"] == {c: 0 for c in ("recipe_read", "warm_start", "warm_replay", "critic_assess", "critic_priors")}
+
+
+def test_empty_kb_timeline_well_formed():
+    tl = empty_kb_timeline(reason="boom")
+    assert tl["schema"] == KB_TIMELINE_SCHEMA
+    assert tl["events"] == []
+    assert tl["degraded"] is True
+    assert tl["warnings"] == ["boom"]
+
+
+def test_fetch_observations_paginates_and_filters(monkeypatch):
+    pages = {
+        1: {"data": [{"name": "kb:recipe_snapshot:get_recipe", "id": "a"}, {"name": "kernel", "id": "b"}], "meta": {"totalPages": 2}},
+        2: {"data": [{"name": "kb_assess:iter_1", "id": "c"}], "meta": {"totalPages": 2}},
+    }
+
+    def fake_get_json(url, creds, timeout):
+        page = 2 if "page=2" in url else 1
+        return pages[page]
+
+    monkeypatch.setattr(langfuse_reader, "_get_json", fake_get_json)
+    creds = {"host": "https://h", "public_key": "pk", "secret_key": "sk"}
+    allobs = langfuse_reader.fetch_observations("t1", credentials=creds)
+    assert [o["id"] for o in allobs] == ["a", "b", "c"]
+    kb_only = langfuse_reader.fetch_observations("t1", name_prefix="kb:recipe_snapshot", credentials=creds)
+    assert [o["id"] for o in kb_only] == ["a"]
+
+
+def test_enrich_injects_timeline_on_success(monkeypatch):
+    bd = {"session": {"claw_session_id": "claw-xyz"}}
+    monkeypatch.setattr(
+        "inference_optimizer.orchestrator.trace.langfuse_reader.fetch_session_breakdown",
+        lambda **kw: _breakdown(),
+    )
+    monkeypatch.setattr(
+        "inference_optimizer.orchestrator.trace.langfuse_reader.fetch_observations",
+        lambda *a, **kw: [],
+    )
+    out = enrich_breakdown_with_langfuse_kb_timeline(bd)
+    tl = out["kb_timeline"]
+    assert tl["source"] == "langfuse"
+    assert tl["trace_id"] == derive_trace_id("claw-xyz")
+    assert tl["counts"]["warm_start"] == 1
+
+
+def test_enrich_injects_degraded_on_fetch_failure(monkeypatch):
+    monkeypatch.setattr(
+        "inference_optimizer.orchestrator.trace.langfuse_reader.fetch_session_breakdown",
+        lambda **kw: None,
+    )
+    out = enrich_breakdown_with_langfuse_kb_timeline({"session": {"claw_session_id": "claw-xyz"}})
+    assert out["kb_timeline"]["degraded"] is True
+    assert out["kb_timeline"]["events"] == []

--- a/inference_optimizer/tests/test_kb_timeline.py
+++ b/inference_optimizer/tests/test_kb_timeline.py
@@ -111,7 +111,9 @@ def test_critic_kb_use_flag_in_title():
     assert "not used" in priors["title"]       # referenced_in_verdict False
 
 
-def test_observations_path_preferred_for_reads():
+def test_observations_path_preferred_when_spans_cover_all_categories():
+    # When the spans cover recipe + both critic categories, the breakdown
+    # tail / critic_iterations are NOT used (spans are authoritative).
     observations = [
         {
             "id": "o1",
@@ -125,16 +127,78 @@ def test_observations_path_preferred_for_reads():
             "startTime": "2026-06-17T07:45:00Z",
             "metadata": {"iter": 7, "verdict_count": 2, "referenced_in_verdict": True},
         },
-        {"id": "o3", "name": "kernel", "startTime": "2026-06-17T07:50:00Z", "metadata": {}},
+        {
+            "id": "o3",
+            "name": "kb_priors:iter_7",
+            "startTime": "2026-06-17T07:45:01Z",
+            "metadata": {"iter": 7, "prior_count": 4, "referenced_in_verdict": False},
+        },
+        {"id": "o4", "name": "kernel", "startTime": "2026-06-17T07:50:00Z", "metadata": {}},
     ]
     tl = build_kb_timeline(_breakdown(), observations=observations, source="langfuse", trace_id="t1")
     cats = sorted(e["category"] for e in tl["events"])
-    # warm_start + warm_replay (from kbp) + recipe_read + critic_assess (from spans);
-    # the breakdown tail/critic_iterations are NOT used when observations given.
-    assert cats == ["critic_assess", "recipe_read", "warm_replay", "warm_start"]
+    assert cats == ["critic_assess", "critic_priors", "recipe_read", "warm_replay", "warm_start"]
     read = next(e for e in tl["events"] if e["category"] == "recipe_read")
     assert read["source"] == {"span": "kb:recipe_snapshot:search", "observation_id": "o1", "trace_id": "t1"}
+    # critic_priors came from the span (iter 7), not the breakdown (iter 5).
+    priors = next(e for e in tl["events"] if e["category"] == "critic_priors")
+    assert priors["source"]["observation_id"] == "o3"
     assert tl["trace_id"] == "t1"
+
+
+def test_observations_without_kb_spans_fall_back_to_breakdown():
+    # A trace with only LLM spans (no KB spans) must NOT skip the breakdown's
+    # recipe_snapshot_reads.tail / critic_iterations sources.
+    observations = [
+        {"id": "k1", "name": "kernel", "startTime": "2026-06-17T07:40:00Z", "metadata": {}},
+        {"id": "o1", "name": "orchestration", "startTime": "2026-06-17T07:41:00Z", "metadata": {}},
+    ]
+    tl = build_kb_timeline(_breakdown(), observations=observations, source="langfuse", trace_id="t1")
+    # recipe_read (from tail) and critic_assess/priors (from critic_iterations) recovered
+    assert tl["counts"]["recipe_read"] == 1
+    assert tl["counts"]["critic_assess"] == 1
+    assert tl["counts"]["critic_priors"] == 1
+    read = next(e for e in tl["events"] if e["category"] == "recipe_read")
+    assert read["source"]["section"] == "kb_provenance.recipe_snapshot_reads.tail"
+
+
+def test_only_assess_span_still_recovers_priors_from_breakdown():
+    # A trace with only a kb_assess span must still recover kb_priors from the
+    # breakdown critic_iterations (independent per-category fallback).
+    observations = [
+        {
+            "id": "a1",
+            "name": "kb_assess:iter_7",
+            "startTime": "2026-06-17T07:45:00Z",
+            "metadata": {"iter": 7, "verdict_count": 1, "referenced_in_verdict": True},
+        }
+    ]
+    tl = build_kb_timeline(_breakdown(), observations=observations, source="langfuse", trace_id="t1")
+    assert tl["counts"]["critic_assess"] == 1   # from span (iter 7)
+    assert tl["counts"]["critic_priors"] == 1   # recovered from breakdown (iter 5)
+    assert tl["counts"]["recipe_read"] == 1     # no recipe span -> breakdown tail
+    priors = next(e for e in tl["events"] if e["category"] == "critic_priors")
+    assert priors["source"]["section"] == "critic_robustness.critic_iterations"
+
+
+def test_fetch_observations_stops_on_short_page_without_meta(monkeypatch):
+    monkeypatch.setattr(
+        langfuse_reader, "_get_json", lambda url, creds, timeout: {"data": [{"id": "x", "name": "kernel"}]}
+    )
+    creds = {"host": "https://h", "public_key": "pk", "secret_key": "sk"}
+    obs = langfuse_reader.fetch_observations("t1", credentials=creds)
+    assert [o["id"] for o in obs] == ["x"]
+
+
+def test_enrich_keeps_populated_local_kb_timeline_on_fetch_failure(monkeypatch):
+    local = build_kb_timeline(_breakdown(), source="local")
+    target = {"session": {"claw_session_id": "claw-xyz"}, "kb_timeline": local}
+    monkeypatch.setattr(
+        "inference_optimizer.orchestrator.trace.langfuse_reader.fetch_session_breakdown",
+        lambda **kw: None,
+    )
+    out = enrich_breakdown_with_langfuse_kb_timeline(target)
+    assert out["kb_timeline"] is local
 
 
 def test_missing_sections_degrade():


### PR DESCRIPTION
## Summary

Adds two new additive `session_breakdown.json` sections that merge a session's scattered decision records into single, chronologically-sorted event streams a downstream consumer can read directly:

- **`agent_timeline`** — specialist proposals + orchestrator decisions + critic reviews, merged onto one `ts` axis (from `decision_trace` / `specialist_runs` / `critic_robustness`).
- **`kb_timeline`** — KB *read/use* decisions: recipe-snapshot reads, warm-start, warm-replay, and the critic's per-iteration `kb_assess` / `kb_priors`. KB *writes* are intentionally out of scope (session-close bookkeeping, not a steering decision, and not timestamped anywhere — including Langfuse).

Both fields are populated **locally in `exporter.build()`** so they are present in every produced breakdown and consistent with the file's own sections. A symmetric **Langfuse read path** (`langfuse_reader`) can re-derive them from a trace for a consumer that only holds a `trace_id`:

- `fetch_session_breakdown` recovers the breakdown from the `session_breakdown` observation output (where `record_session_breakdown` attaches it), with trace-root-output / dedicated-fetch fallbacks.
- `fetch_observations` (paginated) recovers the per-event KB spans (`kb:recipe_snapshot:*`, `kb_assess:iter_N`, `kb_priors:iter_N`).
- The enrich bridges are **fill-if-missing**: they never overwrite the consistent local timeline; they only (re)derive when the section is absent/empty.

The trace id is derived with the same `derive_trace_id(correlation_seed)` chain the writer uses (`claw_session_id` → `session_id` → session-dir basename). No new runtime dependency (stdlib `urllib` + Basic auth); credentials read from the standard `LANGFUSE_*` env vars; everything is best-effort and never breaks the breakdown/upload path.

This work was reviewed with Bugbot over three rounds; all findings were fixed (observation-output recovery, robust pagination, per-category KB fallback, fill-if-missing enrich, seed fallback).

## Changes

- `breakdown/schema.py`: `TimelineEvent` / `AgentTimeline` / `KBTimelineEvent` / `KBTimeline` TypedDicts + `agent_timeline` / `kb_timeline` fields on `SessionBreakdown`.
- `breakdown/agent_timeline.py`, `breakdown/kb_timeline.py`: pure builders + Langfuse enrich bridges.
- `orchestrator/trace/langfuse_reader.py`: new read side (`fetch_trace` / `fetch_observations` / `fetch_session_breakdown` / `resolve_trace_id`).
- `breakdown/exporter.py` + `breakdown/__init__.py`: wire local population + exports.
- `ci/enrich_agent_timeline.py`: optional upload-time enrichment CLI.

## Test plan

- [x] New unit suites green: `test_agent_timeline.py`, `test_kb_timeline.py` (builders: projection/sort/degrade; reader: resolve/observation-recovery/pagination; enrich: fill-if-missing / fetch-failure).
- [x] Breakdown regression suites green (`test_breakdown_smoke.py`, `test_breakdown_exporter_unit.py`, `test_breakdown_langfuse.py`); `build()` emits both `agent_timeline` and `kb_timeline`.
- [ ] (reviewer) End-to-end Langfuse fetch against a real session in an environment with `LANGFUSE_*` set.

Made with [Cursor](https://cursor.com)