### PR TITLE
fix(inference): prevent duplicate optimizer corrupting a session (#592)

### DIFF
--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -179,6 +179,7 @@ from .orchestrator.system_prompts.prompt_builder import (
     build_orchestration_prompt,
     default_enabled_actions,
 )
+from .session_lock import SessionAlreadyRunning, SessionLock
 from .paths import (
     DEFAULT_SESSION_DIR,
     ENV_USER_DATA_PATH,
@@ -586,6 +587,42 @@ def _emit_launch_info(
         path.write_text(json.dumps(launch_info, indent=2))
         print(f"Launch info file: {path}")
     return launch_info
+
+
+# Exit code for "another optimizer already owns this session" (issue #592).
+# Distinct from the generic config/usage failures (``2``) so the robustness
+# monitor can tell a refused duplicate launch from a real misconfiguration.
+SESSION_BUSY_EXIT_CODE = 3
+
+
+def _acquire_session_lock_or_exit(session_dir: Path) -> SessionLock:
+    """Take the single-optimizer session lock or exit ``SESSION_BUSY_EXIT_CODE``.
+
+    Guards both fresh ``optimize`` and ``--resume`` against a second optimizer
+    attaching to the same ``session_dir`` (issue #592). When a live optimizer
+    already owns the session this refuses to run *before* any ``state.json`` /
+    lease mutation, so a misfiring robustness monitor can never corrupt the
+    shared session.
+
+    Args:
+        session_dir (Path): The resolved session root directory.
+
+    Returns:
+        SessionLock: The acquired lock; the caller must keep it referenced for
+            the optimizer's lifetime.
+    """
+    lock = SessionLock(session_dir)
+    try:
+        return lock.acquire()
+    except SessionAlreadyRunning as exc:
+        print(
+            f"ERROR: {exc}. Refusing to start a second optimizer on the same "
+            f"session (would corrupt shared leases / state.json). If the owner "
+            f"is truly dead, wait for the OS to drop the lock or remove "
+            f"{lock.path} before retrying.",
+            file=sys.stderr,
+        )
+        sys.exit(SESSION_BUSY_EXIT_CODE)
 
 
 def _clean_stale_aiter_locks(
@@ -2905,6 +2942,11 @@ async def _run_optimize(args: argparse.Namespace) -> int:
         for sub in __import__("inference_optimizer.paths", fromlist=["_SESSION_SKELETON"])._SESSION_SKELETON:
             (session_dir / sub).mkdir(parents=True, exist_ok=True)
 
+        # Single-optimizer guard (issue #592): take the session lock before any
+        # state.json / lease access so a misfiring monitor cannot attach a
+        # second optimizer to this session. Held for the whole run.
+        session_lock = _acquire_session_lock_or_exit(session_dir)
+
         try:
             manifest = load_manifest(session_dir)
         except FileNotFoundError as exc:
@@ -3171,6 +3213,11 @@ async def _run_optimize(args: argparse.Namespace) -> int:
 
         # session_dir defaults to <workspace_root>/<model>/<UTC ts>/ (INFERENCE_OPTIMIZER_SESSION_LAYOUT=flat for legacy).
         session_dir = make_session_dir(model_name=args.model)
+        # Single-optimizer guard (issue #592): a fresh per-session dir is
+        # normally uncontended, but take the lock here too so the contract
+        # ("one optimizer owns a session") holds uniformly and the owner pid is
+        # published for the robustness monitor.
+        session_lock = _acquire_session_lock_or_exit(session_dir)
         manifest = write_manifest(session_dir, args=args)
         print(f"Session dir     : {session_dir}")
         print(f"Session id      : {manifest['session_id']}  (manifest label only)")
@@ -3547,6 +3594,10 @@ async def _run_optimize(args: argparse.Namespace) -> int:
         )
     finally:
         await coordinator.stop()
+        # Drop the single-optimizer session lock (issue #592) once the
+        # coordinator has released its leases. The OS would drop it on process
+        # exit anyway; this just frees it promptly for an intentional resume.
+        session_lock.release()
         # End-of-session safety net: always materialize session_breakdown.json (best-effort; never mask stop_reason).
         # Skip when the CLOSE sequencer already wrote it (close_sequence_done is locked in CORE_STATE_FIELDS).
         sequencer_done = getattr(

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -613,7 +613,7 @@ def _acquire_session_lock_or_exit(session_dir: Path) -> SessionLock:
     """
     lock = SessionLock(session_dir)
     try:
-        return lock.acquire()
+        lock.acquire()
     except SessionAlreadyRunning as exc:
         print(
             f"ERROR: {exc}. Refusing to start a second optimizer on the same "
@@ -623,6 +623,7 @@ def _acquire_session_lock_or_exit(session_dir: Path) -> SessionLock:
             file=sys.stderr,
         )
         sys.exit(SESSION_BUSY_EXIT_CODE)
+    return lock
 
 
 def _clean_stale_aiter_locks(

--- a/inference_optimizer/launcher/robustness_monitor.sh.example
+++ b/inference_optimizer/launcher/robustness_monitor.sh.example
@@ -5,10 +5,22 @@
 #
 # Polls ``$INFERENCE_OPTIMIZER_SESSION_DIR/state.json`` every 300s. On a
 # terminal session (any ``stop_reason`` in ``STOP_REASON_VOCAB``, ``phase=CLOSE``,
-# or ``reports/final.md`` present), exits 0 without resuming. If the optimizer
-# process has disappeared from ``/proc`` *without* a terminal marker (unexpected
-# crash), re-launches the same session only via
-# ``optimize --resume --resume-from "$session_dir"`` and updates ``$PID_FILE``.
+# or ``reports/final.md`` present), exits 0 without resuming. Otherwise it only
+# re-launches the session via ``optimize --resume --resume-from "$session_dir"``
+# when the optimizer is judged dead by a ROBUST, multi-signal liveness check
+# (issue #592). The session is considered ALIVE when ANY of the following hold:
+#   * the optimizer owner pid published in ``$session_dir/runtime/optimizer.lock``
+#     is still in ``/proc`` (authoritative — survives the wrapper pid exiting);
+#   * the ``$PID_FILE`` pid is still in ``/proc`` (legacy wrapper signal);
+#   * ``state.json`` was modified within ``STATE_FRESH_SEC`` (recent heartbeat);
+#   * a non-expired lease in ``$session_dir/storage/coordinator.db`` is owned by
+#     a pid that is still in ``/proc``.
+# To kill the original cold-start race, resume is additionally gated by a
+# ``STARTUP_GRACE_SEC`` warm-up window (covers the slow ~90s serving cold-start)
+# and requires ``DEAD_CONFIRMATIONS`` consecutive dead observations before
+# firing. The optimizer itself also holds an exclusive lock on
+# ``optimizer.lock``, so even a misfired resume cannot attach a second optimizer
+# to the same session (it exits with code 3 instead of corrupting state).
 # Logs the resume invocation to ``$REPO_ROOT/optimizer_runs/resume_<ts>.log``.
 #
 # Required env (caller MUST export):
@@ -31,6 +43,18 @@
 #   LAUNCH_INFO_WAIT_SEC               60    seconds to poll for LAUNCH_INFO_FILE
 #                                            before failing (covers the monitor
 #                                            racing ahead of the optimizer write)
+#   STARTUP_GRACE_SEC                  180   warm-up window (from monitor start)
+#                                            during which a not-yet-alive session
+#                                            is NEVER resumed; covers the slow
+#                                            serving cold-start (issue #592)
+#   STATE_FRESH_SEC                    600   state.json mtime within this many
+#                                            seconds counts as a live heartbeat
+#   DEAD_CONFIRMATIONS                 2     consecutive dead observations
+#                                            required before firing a resume
+#   RECHECK_INTERVAL_SEC               30    poll interval while inside the
+#                                            grace window or confirming death
+#   POLL_INTERVAL_SEC                  300   poll interval once the session is
+#                                            confirmed alive / after a resume
 #   MAGPIE_PYTHON                      /opt/venv/bin/python
 #                                            interpreter forwarded to the
 #                                            resume launch
@@ -158,6 +182,116 @@ raise SystemExit(1)
 PY
 }
 
+# Tunables (validated to non-negative integers; malformed values degrade to the
+# documented default instead of crashing under ``set -u``).
+_validate_int() {
+  # $1 = value, $2 = default; echoes a base-10 integer.
+  local val="$1" def="$2"
+  if [[ "$val" =~ ^[0-9]+$ ]]; then
+    printf '%s' "$((10#$val))"
+  else
+    printf '%s' "$def"
+  fi
+}
+STARTUP_GRACE_SEC="$(_validate_int "${STARTUP_GRACE_SEC:-180}" 180)"
+STATE_FRESH_SEC="$(_validate_int "${STATE_FRESH_SEC:-600}" 600)"
+DEAD_CONFIRMATIONS="$(_validate_int "${DEAD_CONFIRMATIONS:-2}" 2)"
+RECHECK_INTERVAL_SEC="$(_validate_int "${RECHECK_INTERVAL_SEC:-30}" 30)"
+POLL_INTERVAL_SEC="$(_validate_int "${POLL_INTERVAL_SEC:-300}" 300)"
+# At least one confirmation, else a single transient miss would resume.
+[ "$DEAD_CONFIRMATIONS" -lt 1 ] && DEAD_CONFIRMATIONS=1
+
+# Robust, multi-signal liveness probe (issue #592). Exit 0 = ALIVE (do not
+# resume), exit 1 = no live signal. ``wrapper_pid`` is the legacy $PID_FILE pid.
+is_session_alive() {
+  STATE_FRESH_SEC="$STATE_FRESH_SEC" python3 - "$session_dir" "${1:-}" <<'PY'
+import json
+import os
+import pathlib
+import sys
+import time
+
+
+def pid_alive(pid):
+    try:
+        pid = int(pid)
+    except (TypeError, ValueError):
+        return False
+    # Monitor host is Linux; /proc is the source of truth used elsewhere here.
+    return pid > 0 and os.path.isdir(f"/proc/{pid}")
+
+
+sd = pathlib.Path(sys.argv[1])
+wrapper_pid = sys.argv[2] if len(sys.argv) > 2 else ""
+
+# 1) Authoritative owner pid published by the optimizer's session lock.
+lock_path = sd / "runtime" / "optimizer.lock"
+try:
+    owner = json.loads(lock_path.read_text())
+    if pid_alive(owner.get("pid")):
+        print("owner_pid", file=sys.stderr)
+        raise SystemExit(0)
+except SystemExit:
+    raise
+except Exception:
+    pass
+
+# 2) Legacy wrapper pid from $PID_FILE.
+if pid_alive(wrapper_pid):
+    print("wrapper_pid", file=sys.stderr)
+    raise SystemExit(0)
+
+# 3) Recent state.json heartbeat (Coordinator rewrites it every tick).
+try:
+    fresh = int(os.environ.get("STATE_FRESH_SEC", "600"))
+except ValueError:
+    fresh = 600
+state_path = sd / "state.json"
+try:
+    age = time.time() - state_path.stat().st_mtime
+    if age <= fresh:
+        print(f"state_mtime_age={int(age)}s", file=sys.stderr)
+        raise SystemExit(0)
+except SystemExit:
+    raise
+except FileNotFoundError:
+    pass
+except Exception:
+    pass
+
+# 4) A non-expired lease owned by a live pid in coordinator.db.
+db_path = sd / "storage" / "coordinator.db"
+if db_path.is_file():
+    try:
+        import sqlite3
+        from datetime import datetime, timezone
+
+        now = datetime.now(timezone.utc)
+        con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5)
+        try:
+            rows = con.execute("SELECT pid, expires_at FROM leases").fetchall()
+        finally:
+            con.close()
+        for pid, expires_at in rows:
+            try:
+                exp = datetime.fromisoformat(expires_at)
+            except (TypeError, ValueError):
+                continue
+            if exp > now and pid_alive(pid):
+                print(f"live_lease_pid={pid}", file=sys.stderr)
+                raise SystemExit(0)
+    except SystemExit:
+        raise
+    except Exception:
+        pass
+
+raise SystemExit(1)
+PY
+}
+
+monitor_start="$(date +%s)"
+dead_streak=0
+
 while [ "$(date +%s)" -lt "$deadline" ]; do
   pid=""
   [ -f "$PID_FILE" ] && read -r pid < "$PID_FILE" || true
@@ -167,10 +301,30 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     exit 0
   fi
 
-  if [ -n "$pid" ] && [ -d "/proc/$pid" ]; then
-    sleep 300
+  if is_session_alive "$pid"; then
+    dead_streak=0
+    sleep "$POLL_INTERVAL_SEC"
     continue
   fi
+
+  # No live signal. Never resume inside the cold-start warm-up window — a fresh
+  # launch legitimately has no owner pid / heartbeat / lease yet (issue #592).
+  if [ "$(( $(date +%s) - monitor_start ))" -lt "$STARTUP_GRACE_SEC" ]; then
+    echo "[robustness] no live signal but within startup grace (${STARTUP_GRACE_SEC}s); not resuming $(date -Is)"
+    dead_streak=0
+    sleep "$RECHECK_INTERVAL_SEC"
+    continue
+  fi
+
+  # Require consecutive dead observations so a single transient miss (slow
+  # state.json write, brief /proc race) does not trigger a spurious resume.
+  dead_streak=$(( dead_streak + 1 ))
+  if [ "$dead_streak" -lt "$DEAD_CONFIRMATIONS" ]; then
+    echo "[robustness] dead signal ${dead_streak}/${DEAD_CONFIRMATIONS}; re-checking $(date -Is)"
+    sleep "$RECHECK_INTERVAL_SEC"
+    continue
+  fi
+  dead_streak=0
 
   echo "[robustness] optimizer stopped (no terminal marker); resuming $(date -Is)"
   # Resume logs land next to the pidfile (its dir is guaranteed to exist —
@@ -195,5 +349,9 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
   else
     echo "[robustness] WARN: could not resolve resumed optimizer pid; see $resume_log"
   fi
-  sleep 300
+  # Give the just-resumed optimizer its own cold-start grace window before the
+  # next liveness check, so we never stack a second resume on top of it.
+  monitor_start="$(date +%s)"
+  dead_streak=0
+  sleep "$POLL_INTERVAL_SEC"
 done

--- a/inference_optimizer/session_lock.py
+++ b/inference_optimizer/session_lock.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 
 import errno
 import json
-import logging
 import os
 import socket
 from contextlib import suppress
@@ -44,9 +43,6 @@ try:  # POSIX runtime (Linux): authoritative flock-based exclusion.
     import fcntl
 except ImportError:  # pragma: no cover - non-POSIX dev hosts (e.g. Windows).
     fcntl = None  # type: ignore[assignment]
-
-
-log = logging.getLogger(__name__)
 
 
 def _now_iso() -> str:
@@ -158,7 +154,8 @@ class SessionLock:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         # os.open returns a non-inheritable fd by default (PEP 446), so spawned
         # serving subprocesses never keep the lock alive past the optimizer.
-        fd = os.open(self.path, os.O_RDWR | os.O_CREAT, 0o644)
+        # 0o600: owner-only (the lock body carries pid/host metadata).
+        fd = os.open(self.path, os.O_RDWR | os.O_CREAT, 0o600)
         if fcntl is not None:
             try:
                 fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)

--- a/inference_optimizer/session_lock.py
+++ b/inference_optimizer/session_lock.py
@@ -1,0 +1,249 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Single-optimizer session lock (issue #592).
+
+A long ``inference_optimizer optimize`` run is guarded by a robustness monitor
+that re-launches the optimizer via ``--resume`` if it judges the process dead.
+During the slow serving cold-start that liveness check can misfire and spawn a
+**second** optimizer on the same ``session_dir``; the two then contend for the
+shared ``coordinator.db`` leases and both write ``state.json``, corrupting the
+session.
+
+This module is the authoritative backstop: whichever optimizer owns a session
+holds an exclusive advisory lock (``flock`` on POSIX) on
+``<session_dir>/runtime/optimizer.lock`` for its whole lifetime. A second
+optimizer fails to acquire the lock and must refuse to run *before* touching
+``state.json`` or any lease. The kernel drops the lock automatically when the
+holder exits or crashes, so there is no stale-lock recovery to get wrong.
+
+The lock file body is a small JSON document (``pid`` / ``hostname`` /
+``started_at`` / ``heartbeat_at``) so the monitor can read the *authoritative*
+owner pid instead of trusting a wrapper pidfile.
+
+The lock file is intentionally never unlinked on release: unlinking a flock'd
+path races a concurrent acquirer (it would flock a now-unlinked inode while a
+newcomer creates and flocks a fresh file). A stale body is harmless — the next
+acquirer flocks the same inode and overwrites it.
+"""
+
+from __future__ import annotations
+
+import errno
+import json
+import logging
+import os
+import socket
+from contextlib import suppress
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from . import session_paths
+
+try:  # POSIX runtime (Linux): authoritative flock-based exclusion.
+    import fcntl
+except ImportError:  # pragma: no cover - non-POSIX dev hosts (e.g. Windows).
+    fcntl = None  # type: ignore[assignment]
+
+
+log = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    """Return the current UTC time as a second-precision ISO-8601 string."""
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _pid_alive(pid: int | None) -> bool:
+    """Best-effort liveness probe for ``pid`` (used only on the fcntl-less path).
+
+    Args:
+        pid (int | None): Candidate owner pid; ``None`` / non-positive → dead.
+
+    Returns:
+        bool: ``True`` when the pid appears to reference a live process.
+    """
+    if not pid or pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Exists but owned by another user — treat as alive.
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def read_owner(session_dir: Path) -> dict[str, Any] | None:
+    """Read the lock file's owner metadata without acquiring the lock.
+
+    Args:
+        session_dir (Path): The session root directory.
+
+    Returns:
+        dict | None: The parsed owner document, or ``None`` when the lock file
+            is absent / empty / malformed.
+    """
+    path = session_paths.optimizer_lock_path(session_dir)
+    try:
+        raw = path.read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeDecodeError):
+        return None
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+class SessionAlreadyRunning(RuntimeError):
+    """Raised when another live optimizer already owns the session."""
+
+    def __init__(self, session_dir: Path, owner: dict[str, Any] | None):
+        """Capture the contended session and the current owner metadata.
+
+        Args:
+            session_dir (Path): The session whose lock could not be acquired.
+            owner (dict | None): The existing owner document, if readable.
+        """
+        self.session_dir = Path(session_dir)
+        self.owner = owner or {}
+        who = ""
+        if owner:
+            who = (
+                f" (held by pid={owner.get('pid')} "
+                f"host={owner.get('hostname')} "
+                f"since={owner.get('started_at')})"
+            )
+        super().__init__(
+            f"another optimizer is already running for session "
+            f"{self.session_dir}{who}"
+        )
+
+
+class SessionLock:
+    """Exclusive, crash-safe, single-optimizer-per-session lock.
+
+    Acquire once at optimizer startup (both fresh ``optimize`` and
+    ``--resume``); hold for the whole run. Use as a context manager or call
+    :meth:`acquire` / :meth:`release` explicitly.
+    """
+
+    def __init__(self, session_dir: Path):
+        """Bind the lock to a session directory (does not acquire yet).
+
+        Args:
+            session_dir (Path): The session root directory to guard.
+        """
+        self.session_dir = Path(session_dir)
+        self.path = session_paths.optimizer_lock_path(self.session_dir)
+        self._fd: int | None = None
+        self._started_at: str = ""
+
+    def acquire(self) -> SessionLock:
+        """Acquire the session lock or raise :class:`SessionAlreadyRunning`.
+
+        Returns:
+            SessionLock: ``self`` once the lock is held.
+
+        Raises:
+            SessionAlreadyRunning: When a live optimizer already owns the
+                session.
+        """
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        # os.open returns a non-inheritable fd by default (PEP 446), so spawned
+        # serving subprocesses never keep the lock alive past the optimizer.
+        fd = os.open(self.path, os.O_RDWR | os.O_CREAT, 0o644)
+        if fcntl is not None:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError as exc:
+                owner = self._read_owner_fd(fd)
+                os.close(fd)
+                if exc.errno in (errno.EACCES, errno.EAGAIN, errno.EWOULDBLOCK):
+                    raise SessionAlreadyRunning(self.session_dir, owner) from exc
+                raise
+        else:  # pragma: no cover - non-POSIX fallback (no real exclusion).
+            owner = self._read_owner_fd(fd)
+            owner_pid = owner.get("pid") if owner else None
+            if owner and owner_pid != os.getpid() and _pid_alive(owner_pid):
+                os.close(fd)
+                raise SessionAlreadyRunning(self.session_dir, owner)
+        self._fd = fd
+        self._write_owner(self._now_owner(started_at=_now_iso()))
+        return self
+
+    def heartbeat(self) -> None:
+        """Refresh ``heartbeat_at`` in the lock body (best-effort, never raises)."""
+        if self._fd is None:
+            return
+        with suppress(OSError):
+            self._write_owner(self._now_owner(started_at=self._started_at))
+
+    def release(self) -> None:
+        """Release the lock and close the fd. The file body is left in place."""
+        if self._fd is None:
+            return
+        if fcntl is not None:
+            with suppress(OSError):
+                fcntl.flock(self._fd, fcntl.LOCK_UN)
+        with suppress(OSError):
+            os.close(self._fd)
+        self._fd = None
+
+    def _now_owner(self, *, started_at: str) -> dict[str, Any]:
+        """Build the owner document written into the lock body."""
+        now = _now_iso()
+        self._started_at = started_at or now
+        return {
+            "pid": os.getpid(),
+            "hostname": socket.gethostname(),
+            "started_at": self._started_at,
+            "heartbeat_at": now,
+        }
+
+    def _write_owner(self, owner: dict[str, Any]) -> None:
+        """Atomically rewrite the lock body (truncate + write while holding it)."""
+        assert self._fd is not None
+        blob = json.dumps(owner).encode("utf-8")
+        os.lseek(self._fd, 0, os.SEEK_SET)
+        os.ftruncate(self._fd, 0)
+        os.write(self._fd, blob)
+        with suppress(OSError):
+            os.fsync(self._fd)
+
+    @staticmethod
+    def _read_owner_fd(fd: int) -> dict[str, Any] | None:
+        """Read + parse the owner JSON from an already-open fd (no lock needed)."""
+        try:
+            os.lseek(fd, 0, os.SEEK_SET)
+            raw = os.read(fd, 65536).decode("utf-8", "replace").strip()
+        except OSError:
+            return None
+        if not raw:
+            return None
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+        return data if isinstance(data, dict) else None
+
+    def __enter__(self) -> SessionLock:
+        """Context-manager entry: acquire the lock."""
+        return self.acquire()
+
+    def __exit__(self, *exc: object) -> None:
+        """Context-manager exit: release the lock."""
+        self.release()
+
+    def __del__(self) -> None:
+        """Release on GC so a returning caller drops the lock promptly."""
+        self.release()
+
+
+__all__ = ["SessionAlreadyRunning", "SessionLock", "read_owner"]

--- a/inference_optimizer/session_paths.py
+++ b/inference_optimizer/session_paths.py
@@ -38,6 +38,23 @@ def state_path(session_dir: Path) -> Path:
     return Path(session_dir) / "state.json"
 
 
+def optimizer_lock_path(session_dir: Path) -> Path:
+    """Compute ``<sd>/runtime/optimizer.lock`` — the single-optimizer session lock.
+
+    A live ``optimize`` process holds an exclusive advisory lock on this file
+    for its whole lifetime and writes its owner metadata (pid / host /
+    heartbeat) into it. A second optimizer attaching to the same session must
+    fail fast instead of clobbering ``state.json`` / ``coordinator.db`` leases.
+
+    Args:
+        session_dir (Path): The session root directory.
+
+    Returns:
+        Path: The absolute path to ``<session_dir>/runtime/optimizer.lock``.
+    """
+    return Path(session_dir) / "runtime" / "optimizer.lock"
+
+
 # Per-task workspaces under runs/<action>/<task_id>/.
 # Which actions own a runs/ workspace is derived from the ActionRegistry's
 # ``pipeline_phase`` field; these are the phases whose executors write there.

--- a/inference_optimizer/tests/test_robustness_monitor.py
+++ b/inference_optimizer/tests/test_robustness_monitor.py
@@ -15,6 +15,8 @@ import subprocess
 import time
 from pathlib import Path
 
+import pytest
+
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 MONITOR = REPO_ROOT / "inference_optimizer" / "launcher" / "robustness_monitor.sh.example"
@@ -28,7 +30,15 @@ _MONITOR_VARS = (
     "REPO_ROOT",
     "MAX_HOURS",
     "MAGPIE_PYTHON",
+    "STARTUP_GRACE_SEC",
+    "STATE_FRESH_SEC",
+    "DEAD_CONFIRMATIONS",
+    "RECHECK_INTERVAL_SEC",
+    "POLL_INTERVAL_SEC",
 )
+
+# The multi-signal liveness probe reads ``/proc`` (the monitor host is Linux).
+_HAS_PROC = os.path.isdir("/proc")
 
 
 def _clean_env() -> dict[str, str]:
@@ -36,6 +46,26 @@ def _clean_env() -> dict[str, str]:
     for var in _MONITOR_VARS:
         env.pop(var, None)
     return env
+
+
+def _run_monitor_briefly(env, *, seconds=3.0):
+    """Start the monitor, let it poll for ``seconds``, then stop and capture output."""
+    proc = subprocess.Popen(
+        ["bash", str(MONITOR)],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    time.sleep(seconds)
+    proc.terminate()
+    try:
+        out, err = proc.communicate(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        out, err = proc.communicate()
+    return out, err
 
 
 def test_monitor_waits_for_delayed_launch_info(tmp_path):
@@ -219,3 +249,100 @@ def test_monitor_resume_is_pinned_to_resolved_session_dir():
     """Crash recovery must never use bare --resume, which auto-picks the latest session."""
     text = MONITOR.read_text(encoding="utf-8")
     assert '--resume --resume-from "$session_dir"' in text
+
+
+# --- Issue #592: robust liveness + cold-start grace (no spurious resume) -----
+
+
+@pytest.mark.skipif(not _HAS_PROC, reason="liveness probe reads /proc (Linux)")
+def test_monitor_does_not_resume_during_startup_grace(tmp_path):
+    """Within the cold-start grace window a not-yet-alive session is never resumed."""
+    sess = tmp_path / "sess"
+    sess.mkdir(parents=True)
+    pidfile = tmp_path / "pid"
+    pidfile.write_text("999999\n", encoding="utf-8")  # dead pid
+
+    env = _clean_env()
+    env.update(
+        {
+            "PID_FILE": str(pidfile),
+            "REPO_ROOT": str(tmp_path),
+            "INFERENCE_OPTIMIZER_SESSION_DIR": str(sess),
+            "MAX_HOURS": "1",
+            "STARTUP_GRACE_SEC": "3600",  # never leave grace during the test
+            "RECHECK_INTERVAL_SEC": "1",
+        }
+    )
+
+    out, err = _run_monitor_briefly(env, seconds=3.0)
+    combined = out + err
+    assert "within startup grace" in combined, combined
+    assert "resuming" not in combined, combined
+
+
+@pytest.mark.skipif(not _HAS_PROC, reason="liveness probe reads /proc (Linux)")
+def test_monitor_does_not_resume_when_owner_pid_alive(tmp_path):
+    """An alive owner pid in optimizer.lock keeps the monitor from resuming (past grace)."""
+    sess = tmp_path / "sess"
+    (sess / "runtime").mkdir(parents=True)
+    pidfile = tmp_path / "pid"
+    pidfile.write_text("999999\n", encoding="utf-8")  # wrapper pid is dead
+
+    live = subprocess.Popen(["sleep", "30"])
+    try:
+        (sess / "runtime" / "optimizer.lock").write_text(
+            json.dumps(
+                {
+                    "pid": live.pid,
+                    "hostname": "x",
+                    "started_at": "t",
+                    "heartbeat_at": "t",
+                }
+            ),
+            encoding="utf-8",
+        )
+        env = _clean_env()
+        env.update(
+            {
+                "PID_FILE": str(pidfile),
+                "REPO_ROOT": str(tmp_path),
+                "INFERENCE_OPTIMIZER_SESSION_DIR": str(sess),
+                "MAX_HOURS": "1",
+                "STARTUP_GRACE_SEC": "0",  # past grace immediately
+                "RECHECK_INTERVAL_SEC": "1",
+                "POLL_INTERVAL_SEC": "1",
+            }
+        )
+        out, err = _run_monitor_briefly(env, seconds=3.0)
+        combined = out + err
+        assert "resuming" not in combined, combined
+    finally:
+        live.terminate()
+        live.wait(timeout=10)
+
+
+@pytest.mark.skipif(not _HAS_PROC, reason="liveness probe reads /proc (Linux)")
+def test_monitor_requires_consecutive_dead_confirmations(tmp_path):
+    """A single dead observation does not resume; the streak must reach DEAD_CONFIRMATIONS."""
+    sess = tmp_path / "sess"
+    sess.mkdir(parents=True)
+    pidfile = tmp_path / "pid"
+    pidfile.write_text("999999\n", encoding="utf-8")  # dead
+
+    env = _clean_env()
+    env.update(
+        {
+            "PID_FILE": str(pidfile),
+            "REPO_ROOT": str(tmp_path),
+            "INFERENCE_OPTIMIZER_SESSION_DIR": str(sess),
+            "MAX_HOURS": "1",
+            "STARTUP_GRACE_SEC": "0",
+            "DEAD_CONFIRMATIONS": "5",
+            "RECHECK_INTERVAL_SEC": "1",
+        }
+    )
+    # ~2.5s with a 1s recheck => a couple of confirmations, well short of 5.
+    out, err = _run_monitor_briefly(env, seconds=2.5)
+    combined = out + err
+    assert "dead signal 1/5" in combined, combined
+    assert "resuming" not in combined, combined

--- a/inference_optimizer/tests/test_robustness_monitor.py
+++ b/inference_optimizer/tests/test_robustness_monitor.py
@@ -277,7 +277,9 @@ def test_monitor_does_not_resume_during_startup_grace(tmp_path):
     out, err = _run_monitor_briefly(env, seconds=3.0)
     combined = out + err
     assert "within startup grace" in combined, combined
-    assert "resuming" not in combined, combined
+    # The grace line itself ends with "not resuming"; assert the real resume
+    # action marker is absent rather than the bare word "resuming".
+    assert "optimizer stopped (no terminal marker)" not in combined, combined
 
 
 @pytest.mark.skipif(not _HAS_PROC, reason="liveness probe reads /proc (Linux)")
@@ -315,7 +317,7 @@ def test_monitor_does_not_resume_when_owner_pid_alive(tmp_path):
         )
         out, err = _run_monitor_briefly(env, seconds=3.0)
         combined = out + err
-        assert "resuming" not in combined, combined
+        assert "optimizer stopped (no terminal marker)" not in combined, combined
     finally:
         live.terminate()
         live.wait(timeout=10)
@@ -345,4 +347,4 @@ def test_monitor_requires_consecutive_dead_confirmations(tmp_path):
     out, err = _run_monitor_briefly(env, seconds=2.5)
     combined = out + err
     assert "dead signal 1/5" in combined, combined
-    assert "resuming" not in combined, combined
+    assert "optimizer stopped (no terminal marker)" not in combined, combined

--- a/inference_optimizer/tests/test_session_lock.py
+++ b/inference_optimizer/tests/test_session_lock.py
@@ -1,0 +1,130 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Tests for the single-optimizer session lock (issue #592).
+
+The lock guarantees that a second ``optimize`` / ``--resume`` attaching to the
+same ``session_dir`` cannot run, so a misfiring robustness monitor can never
+spawn a duplicate optimizer that corrupts the shared leases / ``state.json``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+from inference_optimizer import session_lock, session_paths
+from inference_optimizer.session_lock import (
+    SessionAlreadyRunning,
+    SessionLock,
+)
+
+
+def test_lock_path_under_runtime(tmp_path):
+    """The lock lives at ``<session_dir>/runtime/optimizer.lock``."""
+    assert (
+        session_paths.optimizer_lock_path(tmp_path)
+        == tmp_path / "runtime" / "optimizer.lock"
+    )
+
+
+def test_acquire_writes_owner_metadata(tmp_path):
+    """Acquiring publishes the owner pid so the monitor can read it back."""
+    lock = SessionLock(tmp_path)
+    lock.acquire()
+    try:
+        owner = session_lock.read_owner(tmp_path)
+        assert owner is not None
+        assert owner["pid"] == os.getpid()
+        assert owner["started_at"]
+        assert owner["heartbeat_at"]
+    finally:
+        lock.release()
+
+
+def test_read_owner_missing_is_none(tmp_path):
+    """No lock file yet -> ``read_owner`` returns ``None`` (not an error)."""
+    assert session_lock.read_owner(tmp_path) is None
+
+
+def test_release_allows_reacquire(tmp_path):
+    """After release the same session can be locked again."""
+    first = SessionLock(tmp_path)
+    first.acquire()
+    first.release()
+    second = SessionLock(tmp_path)
+    second.acquire()  # must not raise
+    second.release()
+
+
+@pytest.mark.skipif(
+    session_lock.fcntl is None,
+    reason="flock-based mutual exclusion requires POSIX fcntl",
+)
+def test_second_holder_rejected(tmp_path):
+    """A second live holder of the same session is refused (flock backstop)."""
+    held = SessionLock(tmp_path)
+    held.acquire()
+    try:
+        with pytest.raises(SessionAlreadyRunning) as exc:
+            SessionLock(tmp_path).acquire()
+        # The error surfaces the contended session for the operator.
+        assert exc.value.session_dir == tmp_path
+    finally:
+        held.release()
+
+
+def test_context_manager_releases(tmp_path):
+    """The context manager acquires on enter and releases on exit."""
+    with SessionLock(tmp_path):
+        owner = session_lock.read_owner(tmp_path)
+        assert owner is not None and owner["pid"] == os.getpid()
+    # Released: a fresh acquire succeeds immediately.
+    again = SessionLock(tmp_path)
+    again.acquire()
+    again.release()
+
+
+def test_pid_fallback_rejects_live_owner(tmp_path, monkeypatch):
+    """Without fcntl, a lock owned by a *different* live pid is still refused.
+
+    Exercises the non-POSIX fallback path explicitly (the CI host is POSIX, so
+    fcntl is force-disabled here) using a separate live child process as owner.
+    """
+    monkeypatch.setattr(session_lock, "fcntl", None)
+    live = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        lock_path = session_paths.optimizer_lock_path(tmp_path)
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(
+            '{"pid": %d, "hostname": "x", "started_at": "t", '
+            '"heartbeat_at": "t"}' % (live.pid),
+            encoding="utf-8",
+        )
+        with pytest.raises(SessionAlreadyRunning):
+            SessionLock(tmp_path).acquire()
+    finally:
+        live.terminate()
+        live.wait(timeout=10)
+
+
+def test_pid_fallback_takes_over_dead_owner(tmp_path, monkeypatch):
+    """Without fcntl, a lock owned by a dead pid is taken over (not refused)."""
+    monkeypatch.setattr(session_lock, "fcntl", None)
+    lock_path = session_paths.optimizer_lock_path(tmp_path)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    # A pid that is essentially guaranteed to be dead.
+    lock_path.write_text(
+        '{"pid": 2147480000, "hostname": "x", '
+        '"started_at": "t", "heartbeat_at": "t"}',
+        encoding="utf-8",
+    )
+    lock = SessionLock(tmp_path)
+    lock.acquire()  # must not raise — stale owner is taken over
+    try:
+        owner = session_lock.read_owner(tmp_path)
+        assert owner is not None and owner["pid"] == os.getpid()
+    finally:
+        lock.release()


### PR DESCRIPTION
## Summary

Fixes #592 — the robustness monitor spawned a duplicate `--resume` optimizer that corrupted the shared session.

During the slow serving cold-start the monitor's liveness check could misfire shortly after a fresh launch and start a **second** optimizer on the same `session_dir`. The two optimizers then contended for the same `coordinator.db` leases and both wrote `state.json`, clobbering each other.

Two complementary layers:

- **Layer A — single-optimizer session lock (root-cause backstop).** The optimizer now holds an exclusive, crash-safe `flock` on `<session_dir>/runtime/optimizer.lock` for its whole lifetime, taken in both the fresh `optimize` and `--resume` paths *before* any `state.json` / lease access. A second optimizer fails to acquire it and exits with code **3** instead of corrupting the session. The lock body publishes the authoritative owner pid for the monitor. The OS drops the lock on exit/crash, so there is no stale-lock recovery; the file is intentionally never unlinked (avoids the flock-unlink race).
- **Layer B — robust monitor liveness (fewer misfires).** The monitor's liveness check is now multi-signal: owner pid from the lock, legacy wrapper pid, fresh `state.json` mtime, or a live `coordinator.db` lease pid. Resume is additionally gated by a `STARTUP_GRACE_SEC` warm-up window (covers the ~90s cold-start) and `DEAD_CONFIRMATIONS` consecutive dead observations. A resume resets the grace window so it never stacks a second resume.

## Changes

- `inference_optimizer/session_lock.py` (new) — `SessionLock` / `SessionAlreadyRunning` / `read_owner`.
- `inference_optimizer/session_paths.py` — `optimizer_lock_path()` helper.
- `inference_optimizer/cli.py` — acquire the lock in both fresh and `--resume` paths; release on run end; exit code `3` when a session is already owned.
- `inference_optimizer/launcher/robustness_monitor.sh.example` — multi-signal `is_session_alive`, startup grace, consecutive-dead confirmation, configurable intervals.
- Tests: `tests/test_session_lock.py` (new) and new cases in `tests/test_robustness_monitor.py`.

## New / tunable env (monitor)

| Var | Default | Purpose |
| --- | --- | --- |
| `STARTUP_GRACE_SEC` | 180 | warm-up window during which a not-yet-alive session is never resumed |
| `STATE_FRESH_SEC` | 600 | `state.json` mtime within this counts as a live heartbeat |
| `DEAD_CONFIRMATIONS` | 2 | consecutive dead observations required before resuming |
| `RECHECK_INTERVAL_SEC` | 30 | poll interval while in grace / confirming death |
| `POLL_INTERVAL_SEC` | 300 | poll interval once alive / after a resume |

## Test plan

- [x] `ruff check` clean on all changed files.
- [x] `pytest inference_optimizer/tests/test_session_lock.py` — owner metadata, re-acquire after release, second-holder rejection (flock), pid-fallback live-reject / dead-takeover.
- [x] Monitor grace + consecutive-dead-streak paths validated against real `bash` (never spurious-resume).
- [ ] CI on Linux runs the `/proc`-gated monitor liveness tests end to end.
