### PR TITLE
ci: route new architectures to sglang, rebalance MI300X TP, fix concurrency at 64

### DIFF
--- a/ci/optimize_submit.py
+++ b/ci/optimize_submit.py
@@ -95,14 +95,15 @@ DEFAULT_CONTEXT_RESERVE_TOKENS = 16
 MIN_MAX_POSITION_EMBEDDINGS = 2048
 
 # Hardware facts from AMD Instinct datasheets. tp_thresholds_b is CI policy:
-# MI300X baseline (32/128/256B) scaled by per-GPU HBM capacity.
+# MI300X baseline (80/128/256B): <=80B->TP1, <=128B->TP2, <=256B->TP4,
+# >256B->TP8. mi325x/mi355x stay scaled by per-GPU HBM capacity.
 GPU_PROFILES = {
     "mi300x": {
         "gpu_type": "MI300X",
         "llvm_target": "gfx942",
         "hbm_gb": 192,
         "hbm_bandwidth_tb_s": 5.3,
-        "tp_thresholds_b": (32, 128, 256),
+        "tp_thresholds_b": (80, 128, 256),
     },
     "mi325x": {
         "gpu_type": "MI325X",
@@ -293,6 +294,19 @@ SGLANG_ARCHS: set[str] = {
     "GPTBigCodeForCausalLM",
     "FalconForCausalLM",
     "ChatGLMModel",
+    # New architectures natively supported by sglang v0.5.11 (transformers 5.x)
+    # in the current sandbox image. Without these, detect_framework falls back
+    # to vLLM and the old proxy/vllm/vllm-openai-rocm:v0.19.0 image (transformers
+    # <5) crashes at baseline ("does not recognize this architecture" /
+    # "TokenizersBackend does not exist"). Verified against the failing models'
+    # config.architectures.
+    "Gemma4ForConditionalGeneration",            # gemma-4 (dense + A4B MoE)
+    "Qwen3_5ForConditionalGeneration",           # Qwen3.5 / Qwen3.6 dense
+    "Qwen3_5MoeForConditionalGeneration",        # Qwen3.5 / Qwen3.6 A3B MoE
+    "Mistral3ForConditionalGeneration",          # Mistral3 / Ministral3
+    "NemotronHForCausalLM",                      # Nemotron-H (nemotron_h)
+    "Glm4ForCausalLM",                           # GLM-4 (glm4) dense
+    "Glm4MoeForCausalLM",                        # GLM-4.5 / 4.6 (glm4_moe)
 }
 
 # Architectures that require vLLM (Lightning Attention, sparse, or special quant).
@@ -680,16 +694,19 @@ def detect_tp(params_b: float, precision: str = "BF16", gpu_type: str | None = N
 def detect_concurrency(tp: int, framework: str) -> int:
     """Pick a benchmark concurrency from tensor-parallel size and framework.
 
+    CI policy is now a single fixed concurrency of 64 across every framework
+    and TP size, so benchmark load stays directly comparable between models
+    regardless of how they are sharded or served. ``tp`` / ``framework`` are
+    kept for API compatibility.
+
     Args:
         tp (int): Tensor-parallel size.
         framework (str): Serving framework (``vllm`` / ``sglang``).
 
     Returns:
-        int: The chosen concurrency level.
+        int: The chosen concurrency level (always ``64``).
     """
-    if framework == "vllm":
-        return 64 if tp <= 4 else 16
-    return 64 if tp == 1 else 32 if tp <= 4 else 64
+    return 64
 
 
 def _sglang_image_for(repo_id: str = "") -> str:

--- a/ci/test_ci_detect_routing.py
+++ b/ci/test_ci_detect_routing.py
@@ -1,0 +1,99 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Regression tests for the CI auto-detection policy in optimize_submit.
+
+Guards three policy decisions that are easy to silently break:
+
+* ``detect_framework`` routes the new sglang-supported architectures
+  (gemma-4 / Qwen3.5 / Qwen3.6 / Mistral3 / Ministral3 / Nemotron-H / GLM-4.x)
+  to sglang instead of the old vLLM fallback image.
+* ``detect_tp`` uses the MI300X thresholds (80 / 128 / 256).
+* ``detect_concurrency`` is a fixed 64 across frameworks and TP sizes.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_CI_DIR = Path(__file__).resolve().parent
+if str(_CI_DIR) not in sys.path:
+    sys.path.insert(0, str(_CI_DIR))
+
+from optimize_submit import (  # noqa: E402
+    detect_concurrency,
+    detect_framework,
+    detect_tp,
+)
+
+# Architectures added so detect_framework stops routing them to the old
+# vLLM image (transformers <5) that crashes them at baseline.
+NEW_SGLANG_ARCHS = [
+    "Gemma4ForConditionalGeneration",
+    "Qwen3_5ForConditionalGeneration",
+    "Qwen3_5MoeForConditionalGeneration",
+    "Mistral3ForConditionalGeneration",
+    "NemotronHForCausalLM",
+    "Glm4ForCausalLM",
+    "Glm4MoeForCausalLM",
+]
+
+
+@pytest.mark.parametrize("arch", NEW_SGLANG_ARCHS)
+def test_new_architectures_route_to_sglang(arch: str) -> None:
+    assert detect_framework({"architectures": [arch]}) == "sglang"
+
+
+def test_vllm_required_arch_still_routes_to_vllm() -> None:
+    assert detect_framework({"architectures": ["MiniMaxText01ForCausalLM"]}) == "vllm"
+
+
+def test_unknown_arch_falls_back_to_vllm() -> None:
+    assert detect_framework({"architectures": ["TotallyUnknownForCausalLM"]}) == "vllm"
+
+
+@pytest.mark.parametrize("arch", NEW_SGLANG_ARCHS)
+def test_quantized_new_arch_still_routes_to_vllm(arch: str) -> None:
+    """Known limitation: the quant guard runs before the sglang allowlist, so a
+    quantized (awq/gptq/int4/fp4) variant of a new arch still goes to vLLM."""
+    config = {
+        "architectures": [arch],
+        "quantization_config": {"quant_method": "awq"},
+    }
+    assert detect_framework(config) == "vllm"
+
+
+@pytest.mark.parametrize(
+    "params_b,expected_tp",
+    [
+        (0, 1),
+        (7, 1),
+        (79, 1),
+        (80, 1),
+        (80.1, 2),
+        (128, 2),
+        (128.1, 4),
+        (256, 4),
+        (256.1, 8),
+        (671, 8),
+    ],
+)
+def test_detect_tp_mi300x_thresholds(params_b: float, expected_tp: int) -> None:
+    assert detect_tp(params_b, gpu_type="mi300x") == expected_tp
+
+
+@pytest.mark.parametrize(
+    "tp,framework",
+    [
+        (1, "sglang"),
+        (4, "sglang"),
+        (8, "sglang"),
+        (1, "vllm"),
+        (4, "vllm"),
+        (8, "vllm"),
+    ],
+)
+def test_detect_concurrency_is_fixed_64(tp: int, framework: str) -> None:
+    assert detect_concurrency(tp, framework) == 64


### PR DESCRIPTION
## Summary

Three CI policy changes in `ci/optimize_submit.py`:

### 1. Route new architectures to sglang (fixes baseline crashes)

A wave of new-architecture models (gemma-4, Qwen3.5/3.6, Mistral3/Ministral3,
Nemotron-H, GLM-4.x, etc.) were being routed to **vLLM** because their
architectures were not in `SGLANG_ARCHS`. They then ran on the old
`proxy/vllm/vllm-openai-rocm:v0.19.0` image (transformers `<5`), which crashes
at baseline server start:

- `Transformers does not recognize this architecture`
- `TokenizersBackend does not exist`

`sglang v0.5.11` (transformers 5.x, the current sandbox image) **natively
supports** these architectures — verified by loading/serving e.g.
`TeichAI/gemma-4-31B` and `dnotitia/DNA3.0-35B-A3B` on sglang. The failure was
purely the vLLM routing path, not the models themselves.

Added to `SGLANG_ARCHS` (each verified against the failing models'
`config.architectures`):

| Arch | Family |
|---|---|
| `Gemma4ForConditionalGeneration` | gemma-4 (dense + A4B MoE) |
| `Qwen3_5ForConditionalGeneration` | Qwen3.5 / Qwen3.6 dense |
| `Qwen3_5MoeForConditionalGeneration` | Qwen3.5 / Qwen3.6 A3B MoE |
| `Mistral3ForConditionalGeneration` | Mistral3 / Ministral3 |
| `NemotronHForCausalLM` | Nemotron-H |
| `Glm4ForCausalLM` | GLM-4 dense |
| `Glm4MoeForCausalLM` | GLM-4.5 / 4.6 |

This unblocks the ~55 new-arch models that were failing at baseline.

### 2. Rebalance MI300X TP thresholds

`detect_tp` MI300X thresholds changed to `(80, 128, 256)`:

| Params | TP |
|---|---|
| 0 – 80B | 1 |
| 80 – 128B | 2 |
| 128 – 256B | 4 |
| > 256B | 8 |

`mi325x` / `mi355x` profiles are unchanged.

### 3. Fix benchmark concurrency at 64

`detect_concurrency` now returns a single fixed `64` for every framework and
TP size, so benchmark load stays directly comparable across models regardless
of sharding / serving framework. (`tp` / `framework` args kept for API
compatibility.)

## Test plan

- [x] `python -m ruff check ci/optimize_submit.py` — passes
- [x] Verified `detect_framework` routes all 7 new archs to `sglang`
- [x] Verified `detect_tp` MI300X boundaries: 80→1, 80.1→2, 128→2, 128.1→4, 256→4, 256.1→8
- [x] Verified `detect_concurrency` returns 64 for vllm/sglang at TP 1/8
- [ ] Confirm new-arch models serve on sglang in a live optimize-submit batch
