### PR TITLE
fix(tracelens): faithful GEAK harnesses — real per-arg dtypes + tolerate remapped analysis.md columns

### DIFF
--- a/kernel-agent/tools/test_faithful_dtypes.py
+++ b/kernel-agent/tools/test_faithful_dtypes.py
@@ -1,0 +1,56 @@
+"""Faithful per-arg dtype propagation.
+
+TraceLens records each kernel arg's dtype INLINE in the analysis.md ``Args``
+column ("(64,5120) bf16"). HL parsed the shape but left ``input_dtypes`` empty,
+so the GEAK harness could not allocate correct-dtype tensors (fp8 weight vs bf16
+activation). These tests verify HL now surfaces the real, ordered per-arg dtypes.
+"""
+import sys
+from argparse import Namespace
+
+sys.argv = ["x"]
+import tracelens_analysis as tla
+
+
+def test_split_shape_dtype():
+    assert tla._split_shape_dtype("(64,5120) bf16") == ("(64,5120)", "bf16")
+    assert tla._split_shape_dtype("(161,512,5120) fp8") == ("(161,512,5120)", "fp8")
+    assert tla._split_shape_dtype("()") == ("()", "")          # scalar, arity kept
+    assert tla._split_shape_dtype("(64,9) int") == ("(64,9)", "int")
+    assert tla._split_shape_dtype("(1792,) bf16") == ("(1792,)", "bf16")
+    assert tla._split_shape_dtype({"shape": "(8,8) fp16"}) == ("(8,8)", "fp16")
+
+
+def test_dtypes_from_shapes_aligned():
+    shapes = ["(64,5120) bf16", "(161,512,5120) fp8", "()", "(64,9) int"]
+    assert tla._dtypes_from_shapes(shapes) == ["bf16", "fp8", "", "int"]
+
+
+def test_dtypes_from_shapes_none_present():
+    # no dtype on any entry -> [] (preserves prior empty-default behaviour)
+    assert tla._dtypes_from_shapes(["(1,2)", "(3,4)"]) == []
+    assert tla._dtypes_from_shapes([]) == []
+
+
+def _args():
+    return Namespace(framework="sglang", model_name="glm", target_platform="MI300X",
+                     analysis_mode="inference", runtime_env="local")
+
+
+def test_enrich_populates_input_dtypes_from_inline_shapes():
+    cand = {"name": "fused_moe",
+            "shapes": ["(64,5120) bf16", "(161,512,5120) fp8", "(64,9) int"]}
+    tla.enrich_candidates_with_runtime_metadata([cand], _args())
+    assert cand["input_dtypes"] == ["bf16", "fp8", "int"]
+
+
+def test_enrich_preserves_explicit_dtypes():
+    cand = {"name": "x", "shapes": ["(1,2) bf16"], "input_dtypes": ["fp16"]}
+    tla.enrich_candidates_with_runtime_metadata([cand], _args())
+    assert cand["input_dtypes"] == ["fp16"]
+
+
+def test_enrich_no_dtype_stays_empty():
+    cand = {"name": "y", "shapes": ["(1,2)", "(3,4)"]}
+    tla.enrich_candidates_with_runtime_metadata([cand], _args())
+    assert cand["input_dtypes"] == []

--- a/kernel-agent/tools/test_faithful_dtypes.py
+++ b/kernel-agent/tools/test_faithful_dtypes.py
@@ -54,3 +54,56 @@ def test_enrich_no_dtype_stays_empty():
     cand = {"name": "y", "shapes": ["(1,2)", "(3,4)"]}
     tla.enrich_candidates_with_runtime_metadata([cand], _args())
     assert cand["input_dtypes"] == []
+
+
+# --- analysis_remapped.md parse tolerance (extra/inserted column) ---
+import tracelens_skill_runner as tlr  # noqa: E402
+
+
+_REMAP_TABLE = (
+    "<!-- impact-begin kind=p_item category=gemm mid=4.0 low=2.0 high=8.0 -->\n"
+    "\n## Detailed Analysis\n\n### Compute Kernel Insights\n\n"
+    "<!-- reasoning-candidate tier=compute rank=1 -->\n"
+    "#### 🔴 P1: Inserted Source Path column (Tensile)\n\n"
+    "**Identification:** stub\n**Data:**\n"
+    # NOTE: 'Source Path' INSERTED between 'Kernel Path' and 'Time (ms)'.
+    "| Operation | Args | Kernel Path | Source Path | Time (ms) | %E2E | Count | "
+    "FLOPS/Byte | Efficiency | Bound |\n"
+    "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |\n"
+    "| stub_op | (64,5120) bf16 | /x/k.cu | /x/launch.py | 1.0 | 5 | 10 | 1000 | "
+    "40% of 708 TFLOPS | compute-bound |\n"
+    "**Reasoning for Slowdown:** stub\n**Resolution:** stub\n"
+)
+
+
+def test_parse_tolerates_inserted_source_path_column(tmp_path):
+    md = tmp_path / "analysis_remapped.md"
+    md.write_text(_REMAP_TABLE, encoding="utf-8")
+    cands = tlr.parse_analysis_md(md, top_k=10)
+    assert len(cands) == 1
+    c = cands[0]
+    assert c["name"] == "stub_op"
+    # name-keyed read still maps the right cells despite the inserted column:
+    # the 'Kernel Path' cell is captured (under tracelens_launcher_path) and the
+    # Args shape parses — neither is corrupted by the extra 'Source Path' column.
+    assert c.get("tracelens_launcher_path") == "/x/k.cu"
+    assert c["shapes"] == ["(64,5120) bf16"]
+
+
+def test_parse_still_rejects_reordered_canonical_columns(tmp_path):
+    # Bound<->Efficiency swapped -> canonical relative order broken -> reject.
+    md = tmp_path / "analysis.md"
+    md.write_text(
+        "<!-- impact-begin kind=p_item category=gemm mid=4.0 low=2.0 high=8.0 -->\n"
+        "\n## Detailed Analysis\n\n### Compute Kernel Insights\n\n"
+        "<!-- reasoning-candidate tier=compute rank=1 -->\n"
+        "#### 🔴 P1: Reordered (Tensile)\n\n**Identification:** stub\n**Data:**\n"
+        "| Operation | Args | Kernel Path | Time (ms) | %E2E | Count | "
+        "FLOPS/Byte | Bound | Efficiency |\n"
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- |\n"
+        "| stub_op | (1,2) bf16 | — | 1.0 | 5 | 10 | 1000 | "
+        "compute-bound | 40% of 708 TFLOPS |\n"
+        "**Reasoning for Slowdown:** stub\n**Resolution:** stub\n",
+        encoding="utf-8",
+    )
+    assert tlr.parse_analysis_md(md, top_k=10) == []

--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -1641,6 +1641,56 @@ def _shape_call_entries(shapes: Any, call_num: Any = None) -> list[dict[str, Any
     return entries
 
 
+# Recognized dtype tokens that appear as the suffix on a TraceLens ``Args`` /
+# metrics shape entry (e.g. ``(64,5120) bf16``). Permissive: anything after the
+# shape paren is treated as the dtype; this list is only used to recognise a
+# trailing dtype on a paren-less entry.
+_KNOWN_DTYPE_TOKENS = frozenset({
+    "bf16", "fp16", "fp32", "f32", "fp8", "f8", "fp8_e4m3", "fp8_e5m2",
+    "e4m3", "e5m2", "int8", "int4", "int32", "int64", "int", "uint8",
+    "bool", "float", "double", "half",
+})
+
+
+def _split_shape_dtype(entry: Any) -> tuple[str, str]:
+    """Split a TraceLens shape entry ``"(64,5120) bf16"`` into ``("(64,5120)", "bf16")``.
+
+    TraceLens records each kernel arg as ``<shape> [dtype]`` in the analysis.md
+    ``Args`` column (and category metrics ``args``); the dtype is inline. This
+    separates them so the per-arg dtype can be surfaced as a clean, positionally
+    aligned ``input_dtypes`` list (the field that was always defaulted to ``[]``).
+    Non-string / dict entries return ``(str(value), "")``. Empty scalar ``()`` is
+    preserved with an empty dtype so arity stays aligned with the call signature.
+    """
+    if isinstance(entry, dict):
+        entry = entry.get("shape", "")
+    s = str(entry).strip()
+    if not s:
+        return "", ""
+    if s.startswith("("):
+        close = s.find(")")
+        if close != -1:
+            return s[: close + 1].strip(), s[close + 1 :].strip()
+        return s, ""
+    parts = s.rsplit(" ", 1)
+    if len(parts) == 2 and parts[1].lower() in _KNOWN_DTYPE_TOKENS:
+        return parts[0].strip(), parts[1].strip()
+    return s, ""
+
+
+def _dtypes_from_shapes(shapes: Any) -> list[str]:
+    """Ordered per-arg dtype list parsed from a candidate's ``shapes`` strings.
+
+    Positionally aligned with the shapes (one entry per arg, ``""`` when no dtype
+    was captured). Returns ``[]`` when no dtype is present on any entry, so callers
+    keep the existing empty-default behaviour when TraceLens captured none.
+    """
+    if not isinstance(shapes, list):
+        return []
+    dtypes = [_split_shape_dtype(s)[1] for s in shapes]
+    return dtypes if any(dtypes) else []
+
+
 def derive_kernel_category(candidate: dict[str, Any]) -> str:
     """Map a candidate to its GEAK-facing kernel category (#125).
 
@@ -2322,7 +2372,14 @@ def enrich_candidates_with_runtime_metadata(
                 item.get("shapes", []) or [], item.get("call_count"),
             )
         item.setdefault("output_shapes", [])
-        item.setdefault("input_dtypes", item.get("dtypes", []) or [])
+        # Per-arg dtypes: TraceLens records them INLINE in each ``shapes`` string
+        # ("(64,5120) bf16"); surface them as a clean, positionally-aligned list so
+        # the GEAK harness allocates the correct-dtype tensors (fp8 weight vs bf16
+        # activation). Falls back to any explicit ``dtypes`` field, then ``[]``.
+        existing_dtypes = item.get("input_dtypes") or item.get("dtypes") or []
+        if not existing_dtypes:
+            existing_dtypes = _dtypes_from_shapes(item.get("shapes", []) or [])
+        item["input_dtypes"] = existing_dtypes
         item.setdefault("output_dtypes", [])
         item.setdefault("runtime_args", {})
         item.setdefault("env_vars", {})

--- a/kernel-agent/tools/tracelens_skill_runner.py
+++ b/kernel-agent/tools/tracelens_skill_runner.py
@@ -807,23 +807,36 @@ def parse_analysis_md(md_path: Path, top_k: int = 10) -> list[dict[str, Any]]:
         if not rows:
             continue
         header_row = [cell.strip().lower() for cell in rows[0]]
-        # Validate first 9 cells against the canonical schema; reject narrower/reordered headers (silent wrong-mapping would corrupt candidates).
+        # Validate by PRESENCE of every canonical column (matched by name anywhere
+        # in the header), not by fixed position. ``_row_to_candidate`` reads cells
+        # name-keyed (``dict(zip(headers, cells))`` -> ``record.get("kernel path")``),
+        # so any column ORDER works as long as every required name is present and
+        # the per-cell names stay aligned. This tolerates a remapped report that
+        # INSERTS or APPENDS extra columns (e.g. a ``Source Path`` column the
+        # path-resolution step adds) — TraceLens's own spec permits appended
+        # columns, and downstream consumers must not break when one is added.
+        # We normalize each header cell to its canonical name when it CONTAINS one
+        # (e.g. "kernel path (resolved)" -> "kernel path") so name-keyed lookup
+        # still hits; unknown extras (e.g. "source path") are kept verbatim.
         if len(header_row) < canonical_width:
             continue
-        header_prefix = header_row[:canonical_width]
-        if header_prefix != headers_canonical:
-            normalized: list[str] = []
-            for cell in header_prefix:
-                match = next(
-                    (canon for canon in headers_canonical if canon in cell),
-                    cell,
-                )
-                normalized.append(match)
-            if normalized != headers_canonical:
-                continue
-            header_prefix = normalized
-        # Splice normalized canonical names back into the full header (extras kept verbatim).
-        header_row = header_prefix + header_row[canonical_width:]
+        normalized_header: list[str] = []
+        for cell in header_row:
+            match = next(
+                (canon for canon in headers_canonical if canon == cell or canon in cell),
+                cell,
+            )
+            normalized_header.append(match)
+        # Accept EXTRA/INSERTED columns (e.g. a ``Source Path`` column the
+        # path-resolution remap appends) but still REJECT genuine REORDERING of the
+        # canonical columns — a swap (e.g. Bound<->Efficiency) is a corrupt report
+        # and must be skipped, not silently mis-read. So: every canonical column
+        # must be present AND the canonical columns must appear in their canonical
+        # relative order (extras may be interleaved anywhere).
+        canonical_in_header = [c for c in normalized_header if c in headers_canonical]
+        if canonical_in_header != headers_canonical:
+            continue
+        header_row = normalized_header
         # P-item meta by 1-based rank (P1 → pitems[0]); a missing entry => category unknown.
         pitem_meta = pitems[rank - 1] if rank - 1 < len(pitems) else {}
         category = pitem_meta.get("category", "")


### PR DESCRIPTION
Closes #609. Closes #611.

This PR makes HL→GEAK harnesses **faithful to the real served workload** via two related TraceLens-consumption fixes.

## Fix 1 — surface real per-arg dtypes (#609)
- TraceLens records per-arg dtypes inline in the analysis.md `Args` column, but `enrich_candidates_with_runtime_metadata` left `input_dtypes = []`, so the GEAK harness couldn't allocate correct-dtype tensors (fp8 weight vs bf16 activation) → speedup not a faithful E2E signal.
- Add `_split_shape_dtype` / `_dtypes_from_shapes`; populate `input_dtypes` from the shapes' inline dtype (preserve explicit; stay `[]` when none). Flows into `build_kernel_metadata` → GEAK prompt.

## Fix 2 — tolerate remapped analysis.md extra columns (#611)
- `parse_analysis_md` validated the table header positionally, so a remapped report that **inserts a `Source Path` column** made every row reject → **0 candidates silently** (all 5 sglang traces: analysis.md→10, remapped→0).
- Validate by **name presence + canonical relative order**: accept extra/inserted columns; still reject genuine reordering (Bound↔Efficiency swap) to keep the anti-mis-map guard.

## Scope
`kernel-agent/tools/tracelens_analysis.py` + `tracelens_skill_runner.py` + tests. No TraceLens-core or GEAK change.

## Verification
- [x] dtypes: 7 model traces, **67/67** candidates carry real per-arg dtypes (was 0); GLM-4.7 `[] → ['bf16','bf16']`, reaches `build_kernel_metadata`.
- [x] parse: `analysis_remapped.md` → **10 candidates for all 5 sglang models (was 0)**; original `analysis.md` unchanged; reorder-rejection preserved.
- [x] Unit: `test_faithful_dtypes.py` 8/8.
- [x] Regression: full `kernel-agent/tools` suite — **0 new failures** (8 pre-existing failures in `test_aiter_source_autoresolve.py` / `test_apply_kernel_patch_jit_invalidation.py` identical with/without this change).

## Notes
- Faithful **shapes+dtypes (Tier B)**; data-dependent kernels (MoE routing skew) → captured-tensor replay (Tier A) is future work.
- Optional follow-up on the remap side: append `Source Path` as a trailing column to also satisfy TraceLens's "append at end, don't reorder" contract.
