### PR TITLE
ci: alternate HF tokens with 429 backoff to cut rate-limit failures

### DIFF
--- a/.github/workflows/inference-optimization-daily.yml
+++ b/.github/workflows/inference-optimization-daily.yml
@@ -91,6 +91,7 @@ jobs:
       count:  ${{ steps.matrix.outputs.count }}
     env:
       HF_TOKEN:              ${{ secrets.HF_TOKEN }}
+      HF_TOKEN_2:            ${{ secrets.HF_TOKEN_2 }}
       INPUT_MODELS:          ${{ github.event.inputs.models }}
       # Always read the fixed candidates JSON (both schedule and dispatch) so
       # the daily corpus is reproducible and editable in one place.
@@ -139,6 +140,7 @@ jobs:
       SAFE_BASE_URL:                    ${{ secrets.SAFE_BASE_URL }}
       HARBOR_PREFIX:                    ${{ secrets.HARBOR_PREFIX }}
       HF_TOKEN:                         ${{ secrets.HF_TOKEN }}
+      HF_TOKEN_2:                       ${{ secrets.HF_TOKEN_2 }}
       SAFE_OPTIMIZE_REGISTER_WORKSPACE: ${{ secrets.SAFE_OPTIMIZE_REGISTER_WORKSPACE }}
       SAFE_OPTIMIZE_SUBMIT_WORKSPACE:   ${{ secrets.SAFE_OPTIMIZE_SUBMIT_WORKSPACE }}
       SAFE_OPTIMIZE_VOLUME:             ${{ secrets.SAFE_OPTIMIZE_VOLUME }}
@@ -158,6 +160,7 @@ jobs:
         continue-on-error: true
         env:
           HF_TOKEN:   ${{ secrets.HF_TOKEN }}
+          HF_TOKEN_2: ${{ secrets.HF_TOKEN_2 }}
           MODEL_REPO: ${{ matrix.model }}
         run: |
           set -euo pipefail

--- a/.github/workflows/optimize-submit.yml
+++ b/.github/workflows/optimize-submit.yml
@@ -207,6 +207,7 @@ jobs:
       count:  ${{ steps.matrix.outputs.count }}
     env:
       HF_TOKEN:              ${{ secrets.HF_TOKEN }}
+      HF_TOKEN_2:            ${{ secrets.HF_TOKEN_2 }}
       INPUT_MODELS:          ${{ github.event.inputs.models }}
       # Rolling cron cycles the downloads>100 pool (every size), ordered with
       # not-yet-run models first so the front-anchored window picks them up
@@ -263,6 +264,7 @@ jobs:
       SAFE_BASE_URL:                    ${{ secrets.SAFE_BASE_URL }}
       HARBOR_PREFIX:                    ${{ secrets.HARBOR_PREFIX }}
       HF_TOKEN:                         ${{ secrets.HF_TOKEN }}
+      HF_TOKEN_2:                       ${{ secrets.HF_TOKEN_2 }}
       SAFE_OPTIMIZE_REGISTER_WORKSPACE: ${{ secrets.SAFE_OPTIMIZE_REGISTER_WORKSPACE }}
       SAFE_OPTIMIZE_SUBMIT_WORKSPACE:   ${{ secrets.SAFE_OPTIMIZE_SUBMIT_WORKSPACE }}
       SAFE_OPTIMIZE_VOLUME:             ${{ secrets.SAFE_OPTIMIZE_VOLUME }}
@@ -284,6 +286,7 @@ jobs:
         continue-on-error: true
         env:
           HF_TOKEN:   ${{ secrets.HF_TOKEN }}
+          HF_TOKEN_2: ${{ secrets.HF_TOKEN_2 }}
           MODEL_REPO: ${{ matrix.model }}
         run: |
           set -euo pipefail

--- a/ci/generate_hf_matrix.py
+++ b/ci/generate_hf_matrix.py
@@ -770,7 +770,11 @@ def collect_entries() -> list[dict | str]:
 
     hf_top = int(os.environ.get("INPUT_HF_TOP") or "5")
     min_params = float(os.environ.get("INPUT_MIN_PARAMS") or "7")
-    hf = HuggingFaceClient(os.environ.get("HF_TOKEN", ""))
+    hf = HuggingFaceClient(
+        os.environ.get("HF_TOKEN", ""),
+        tokens=[os.environ.get("HF_TOKEN_2", "")],
+        seed=os.environ.get("GITHUB_RUN_ID", ""),
+    )
     print(f"fetching HF top-{hf_top} (>={min_params}B)...", file=sys.stderr)
     return _apply_exclusions(hf.top_models(hf_top, min_params_b=min_params))
 

--- a/ci/optimize_submit.py
+++ b/ci/optimize_submit.py
@@ -386,21 +386,49 @@ class HuggingFaceClient:
 
     BASE = "https://huggingface.co"
 
-    def __init__(self, token: str = "", timeout: int = 15):
+    def __init__(self, token: str = "", timeout: int = 15, tokens: list[str] | None = None, seed: str = ""):
         """Initialise the HF client session.
 
+        Supports a *pool* of HuggingFace tokens. Requests start on a token chosen
+        by hashing ``seed`` (so parallel CI jobs spread their first hit across the
+        pool) and, on HTTP 429 (Too Many Requests), transparently rotate to the
+        next token with exponential backoff before retrying. This mitigates the
+        bursty rate-limiting that hits the resolve/config.json endpoint when many
+        optimize jobs fan out at once.
+
         Args:
-            token (str): Optional HuggingFace token for gated-model access.
+            token (str): Primary HuggingFace token for gated-model access.
             timeout (int): Per-request timeout in seconds.
+            tokens (list[str] | None): Additional tokens to alternate with.
+            seed (str): Per-job string used to pick the starting token.
         """
         self.timeout = timeout
+        pool: list[str] = []
+        for t in [token, *(tokens or [])]:
+            if t and t not in pool:
+                pool.append(t)
+        self._tokens = pool
+        if pool:
+            self._idx = (hash(seed) % len(pool)) if seed else 0
+        else:
+            self._idx = 0
         self._sess = requests.Session()
         self._sess.headers["User-Agent"] = "hyperloom-optimize-submit/1.0"
-        if token:
-            self._sess.headers["Authorization"] = f"Bearer {token}"
+        self._apply_token()
+
+    def _apply_token(self) -> None:
+        """Set the Authorization header to the currently-selected token."""
+        if self._tokens:
+            tok = self._tokens[self._idx % len(self._tokens)]
+            self._sess.headers["Authorization"] = f"Bearer {tok}"
+        else:
+            self._sess.headers.pop("Authorization", None)
 
     def _get(self, path: str) -> dict | list:
         """GET a HuggingFace API path and return the parsed JSON body.
+
+        On HTTP 429 the client rotates to the next token in the pool and retries
+        with exponential backoff (capped at 30s); other errors raise immediately.
 
         Args:
             path (str): Path appended to the HF base URL.
@@ -411,9 +439,24 @@ class HuggingFaceClient:
         Raises:
             requests.HTTPError: If the response status indicates an error.
         """
-        resp = self._sess.get(f"{self.BASE}{path}", timeout=self.timeout)
-        resp.raise_for_status()
-        return resp.json()
+        attempts = max(4, len(self._tokens) * 2)
+        last_exc: Exception | None = None
+        for i in range(attempts):
+            resp = self._sess.get(f"{self.BASE}{path}", timeout=self.timeout)
+            if resp.status_code == 429:
+                last_exc = requests.HTTPError(
+                    f"429 Client Error: Too Many Requests for url: {self.BASE}{path}", response=resp
+                )
+                if len(self._tokens) > 1:
+                    self._idx += 1
+                    self._apply_token()
+                time.sleep(min(2 ** i, 30))
+                continue
+            resp.raise_for_status()
+            return resp.json()
+        if last_exc is not None:
+            raise last_exc
+        raise requests.HTTPError(f"exhausted retries for url: {self.BASE}{path}")
 
     def model_info(self, repo_id: str) -> dict:
         """Fetch a repo's model metadata from the HF API.
@@ -3898,6 +3941,11 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--hf-token", default=os.environ.get("HF_TOKEN", ""), help="HuggingFace token (or set $HF_TOKEN)"
     )
+    parser.add_argument(
+        "--hf-token-2",
+        default=os.environ.get("HF_TOKEN_2", ""),
+        help="Secondary HuggingFace token to alternate with on 429 (or set $HF_TOKEN_2)",
+    )
 
     # Production-pool audit metadata: copied into submission_manifest.json (does
     # not affect submission) to trace which pool entry a task reran.
@@ -4060,7 +4108,10 @@ def main() -> int:
             "fallback to be deployed; will 400 on submit_task otherwise"
         )
 
-    hf = HuggingFaceClient(args.hf_token)
+    hf_seed = ",".join(getattr(args, "model", None) or []) or os.environ.get("GITHUB_RUN_ID", "")
+    hf = HuggingFaceClient(args.hf_token, tokens=[args.hf_token_2], seed=hf_seed)
+    if args.hf_token_2:
+        log.info("HF token pool: 2 tokens (alternate on 429)")
     # Dry-run never hits SaFE, so a placeholder token is fine.
     safe = SafeOptimizeClient(
         base_url,

--- a/ci/prewarm_models.py
+++ b/ci/prewarm_models.py
@@ -168,7 +168,7 @@ def _dir_stats(p: Path) -> tuple[int, float]:
     return n, total / 1e9
 
 
-def download_one(repo_id: str, target_root: Path, hf_token: str, inner_workers: int = 4) -> dict:
+def download_one(repo_id: str, target_root: Path, hf_token, inner_workers: int = 4) -> dict:
     """Download a single HF repo to <target_root>/<slug>/.
 
     Skips already-complete destinations, downloads into a temporary ``.part``
@@ -190,7 +190,16 @@ def download_one(repo_id: str, target_root: Path, hf_token: str, inner_workers: 
     tmp = tmp_dir(target_root, repo_id)
     hf_api = HfApi()
 
-    if is_complete(dest, repo_id, hf_api, hf_token):
+    # Token pool: accept either a single token (str) or a list. Start on a
+    # token chosen by hashing the repo id so parallel prewarm jobs spread
+    # across the pool, then rotate on 429.
+    tokens = [t for t in (hf_token if isinstance(hf_token, (list, tuple)) else [hf_token]) if t]
+    tok_idx = (hash(repo_id) % len(tokens)) if tokens else 0
+
+    def _cur_token():
+        return tokens[tok_idx % len(tokens)] if tokens else None
+
+    if is_complete(dest, repo_id, hf_api, _cur_token()):
         n, gb = _dir_stats(dest)
         return {"status": "SKIP", "size_gb": gb, "n_files": n, "elapsed_s": 0, "reason": "already complete"}
 
@@ -200,49 +209,70 @@ def download_one(repo_id: str, target_root: Path, hf_token: str, inner_workers: 
         shutil.rmtree(tmp, ignore_errors=True)
     tmp.mkdir(parents=True, exist_ok=True)
 
-    try:
-        snapshot_download(
-            repo_id,
-            local_dir=str(tmp),
-            local_dir_use_symlinks=False,
-            token=hf_token or None,
-            max_workers=inner_workers,
-            allow_patterns=None,
-            ignore_patterns=[
-                "*.h5",
-                "*.msgpack",
-                "*.onnx",
-                "*.tflite",
-                "consolidated.*",  # legacy llama-cpp dumps
-            ],
-            tqdm_class=None,
-        )
-    except RepositoryNotFoundError:
+    attempts = max(4, len(tokens) * 2)
+    last_429 = None
+    for attempt in range(attempts):
+        try:
+            snapshot_download(
+                repo_id,
+                local_dir=str(tmp),
+                local_dir_use_symlinks=False,
+                token=_cur_token(),
+                max_workers=inner_workers,
+                allow_patterns=None,
+                ignore_patterns=[
+                    "*.h5",
+                    "*.msgpack",
+                    "*.onnx",
+                    "*.tflite",
+                    "consolidated.*",  # legacy llama-cpp dumps
+                ],
+                tqdm_class=None,
+            )
+            break
+        except RepositoryNotFoundError:
+            shutil.rmtree(tmp, ignore_errors=True)
+            return {
+                "status": "FAIL",
+                "size_gb": 0,
+                "n_files": 0,
+                "elapsed_s": time.time() - start,
+                "reason": "repo not found (gated or deleted)",
+            }
+        except HfHubHTTPError as e:
+            status_code = getattr(getattr(e, "response", None), "status_code", None)
+            if status_code == 429 or "429" in str(e):
+                last_429 = e
+                if len(tokens) > 1:
+                    tok_idx += 1
+                    log.warning("[%s] HF 429 — rotating token and retrying (attempt %d)", repo_id, attempt + 1)
+                time.sleep(min(2 ** attempt, 30))
+                continue
+            shutil.rmtree(tmp, ignore_errors=True)
+            return {
+                "status": "FAIL",
+                "size_gb": 0,
+                "n_files": 0,
+                "elapsed_s": time.time() - start,
+                "reason": f"HF HTTP error: {e}"[:200],
+            }
+        except Exception as e:
+            shutil.rmtree(tmp, ignore_errors=True)
+            return {
+                "status": "FAIL",
+                "size_gb": 0,
+                "n_files": 0,
+                "elapsed_s": time.time() - start,
+                "reason": f"{type(e).__name__}: {e}"[:200],
+            }
+    else:
         shutil.rmtree(tmp, ignore_errors=True)
         return {
             "status": "FAIL",
             "size_gb": 0,
             "n_files": 0,
             "elapsed_s": time.time() - start,
-            "reason": "repo not found (gated or deleted)",
-        }
-    except HfHubHTTPError as e:
-        shutil.rmtree(tmp, ignore_errors=True)
-        return {
-            "status": "FAIL",
-            "size_gb": 0,
-            "n_files": 0,
-            "elapsed_s": time.time() - start,
-            "reason": f"HF HTTP error: {e}"[:200],
-        }
-    except Exception as e:
-        shutil.rmtree(tmp, ignore_errors=True)
-        return {
-            "status": "FAIL",
-            "size_gb": 0,
-            "n_files": 0,
-            "elapsed_s": time.time() - start,
-            "reason": f"{type(e).__name__}: {e}"[:200],
+            "reason": f"HF 429 rate-limited after {attempts} attempts: {last_429}"[:200],
         }
 
     # Atomic-ish swap; clear any partial dest first.
@@ -420,9 +450,11 @@ def main() -> int:
         force=True,
     )
 
-    hf_token = os.environ.get("HF_TOKEN", "")
-    if not hf_token:
+    hf_tokens = [t for t in (os.environ.get("HF_TOKEN", ""), os.environ.get("HF_TOKEN_2", "")) if t]
+    if not hf_tokens:
         log.warning("HF_TOKEN unset — gated repos will fail with 401/403")
+    elif len(hf_tokens) > 1:
+        log.info("HF token pool: %d tokens (alternate on 429)", len(hf_tokens))
 
     repos = load_repos(args)
     if args.exclude_done and args.already_done.exists():
@@ -455,7 +487,7 @@ def main() -> int:
         max_workers=args.concurrency,
         thread_name_prefix="prewarm",
     ) as ex:
-        future_to_repo = {ex.submit(download_one, r, args.target_root, hf_token, args.inner_workers): r for r in repos}
+        future_to_repo = {ex.submit(download_one, r, args.target_root, hf_tokens, args.inner_workers): r for r in repos}
         for done_count, fut in enumerate(concurrent.futures.as_completed(future_to_repo), 1):
             repo = future_to_repo[fut]
             try:


### PR DESCRIPTION
## Summary
- Adds a HuggingFace **token pool** (`HF_TOKEN` + new `HF_TOKEN_2`) so the optimize-submit pipeline spreads HF traffic across two tokens and **transparently rotates on HTTP 429** with exponential backoff (cap 30s).
- Directly targets the bursty `429 Too Many Requests` failures on `/resolve/main/config.json` that dominate large parallel batches (≈25% of today's optimize-job failures, 81/320).

## Changes
- `ci/optimize_submit.py` — `HuggingFaceClient` now takes a token pool, picks the starting token by hashing a per-job seed (model id) so parallel jobs don't all hit the same token first, and rotates token + backoff on 429 in `_get`. New `--hf-token-2` / `$HF_TOKEN_2`.
- `ci/prewarm_models.py` — `download_one` gets the same multi-token rotation/backoff around `snapshot_download`, starting token chosen per repo id.
- `ci/generate_hf_matrix.py` — matrix-filtering client uses both tokens.
- `.github/workflows/optimize-submit.yml` & `inference-optimization-daily.yml` — inject `HF_TOKEN_2` into the prepare / optimize / prewarm steps.

> Requires repo secret **`HF_TOKEN_2`** (already added). The second token's account has also been granted/requested access to the gated repos so either token can read them.

## Test plan
- [x] `python -m pytest ci/test_ci_detect_routing.py` — 32 passed
- [x] Syntax check on all three edited scripts
- [x] Unit test of rotation: seed-based start token, rotates to the other token on 429, retries succeed
- [ ] Observe next scheduled batch: HF-429 failure count should drop vs. today's baseline (81)
