### PR TITLE
fix(inference): correct GEAK dispatch attribution

### DIFF
--- a/inference_optimizer/breakdown/recorder/instrument.py
+++ b/inference_optimizer/breakdown/recorder/instrument.py
@@ -528,12 +528,21 @@ def record_kernel_invocations(
         if not failed:
             return
         backend = str(result.get("backend") or "").lower()
-        section = _invocation_section(backend) or "geak_invocations"
+        section = _invocation_section(backend)
+        if section is None:
+            # The optimizer that ran could not be determined (a genuine
+            # pre-dispatch / gating failure where no backend subprocess
+            # launched, or an ambiguous multi-backend value). Do NOT fabricate a
+            # GEAK invocation — that contaminates GEAK's success/failure tally
+            # with failures it never owned. The failure stays visible via the
+            # kernel_dispatch / kernel_backend_result journey lanes. See
+            # Hyperloom#602.
+            return
         payload = {
             "kernel_id": kid,
             "attempt_id": "",
             "run_id": run_id,
-            "backend": backend or "geak",
+            "backend": backend,
             "decision": "FAILED",
             "status": status or "failed",
             "error": result.get("error") or err_class or None,
@@ -1079,7 +1088,11 @@ def record_kernel_backend_result(
         failed = status in _FAILED_STATUSES or (decision == "REVERT" and bool(err_class))
         if not failed:
             return
-        backend = str(result.get("backend") or "").lower() or "geak"
+        # Never default an unattributable failure to GEAK; a genuine pre-dispatch
+        # gating failure (no backend launched) is recorded honestly as
+        # "unknown" so the kernel_journey timeline does not inflate GEAK's
+        # failure count with attempts it never owned. See Hyperloom#602.
+        backend = str(result.get("backend") or "").lower() or "unknown"
         payload = {
             "kernel_id": kid,
             "attempt_id": "",
@@ -1105,13 +1118,14 @@ def record_kernel_backend_result(
             payload,
             key=f"{kid}-predispatch",
         )
-        record_tool_version(
-            session_dir,
-            tool=backend,
-            root=str(result_meta.get("root_dir") or "") or None,
-            version=str(result_meta.get("version") or "") or None,
-            producer=producer,
-        )
+        if backend != "unknown":
+            record_tool_version(
+                session_dir,
+                tool=backend,
+                root=str(result_meta.get("root_dir") or "") or None,
+                version=str(result_meta.get("version") or "") or None,
+                producer=producer,
+            )
     except Exception:  # noqa: BLE001
         log.debug("record_kernel_backend_result failed", exc_info=True)
 

--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -128,6 +128,11 @@ _DEFAULT_KERNEL_BACKEND_ORDER = ("forge", "geak")
 # Soft cap on concurrent kernel-backend coroutines (legacy MI300X 8-GPU fallback; pin with KERNEL_OPT_MAX_PARALLEL).
 _DEFAULT_KERNEL_BATCH_PARALLEL = 8
 _DEFAULT_OOB_BUDGET_MINUTES = 60.0
+# Minimum wall-clock a fallback backend needs to do anything useful (and still
+# salvage partial artifacts). When less than this remains in the per-kernel
+# ladder budget, the ladder stops instead of launching a backend it cannot
+# finish. Mirrors the +180s wrapper grace. See Hyperloom#602.
+_KERNEL_LADDER_MIN_BACKEND_SEC = 180
 _DEFAULT_GEMM_TUNING_TIMEOUT_SEC = 3 * 60 * 60
 
 
@@ -1660,6 +1665,38 @@ def _optimization_wrapper_timeout_sec(payload: dict) -> int:
     return int(_optimization_budget_minutes(payload) * 60) + 180
 
 
+def _kernel_ladder_budget_sec(payload: dict) -> int:
+    """Total wall-clock budget for one kernel's whole backend ladder.
+
+    The ladder runs its backends sequentially (forge -> geak -> oob fallbacks),
+    each as a subprocess with its own timeout. Without a shared ceiling a
+    backend that hangs to its hard timeout followed by a fallback running its
+    full budget could roughly double a kernel's wall clock and overshoot the
+    KERNEL-phase budget cap (which is only re-checked between orchestration
+    turns, never mid-``run_optimization``). This budget bounds the whole ladder
+    so a fallback only runs within the time left and an exhausted budget exits
+    the ladder cleanly. See Hyperloom#602.
+
+    Priority: payload ``kernel_budget_min`` > env
+    ``KERNEL_OPT_KERNEL_BUDGET_MIN`` > the single-backend wall-clock budget from
+    :func:`_optimization_budget_minutes` (the ladder shares roughly one
+    backend's budget). A +180s grace mirrors the per-subprocess wrapper so the
+    first backend is never capped below its own timeout.
+
+    Args:
+        payload (dict): Request payload carrying optional ``kernel_budget_min``.
+
+    Returns:
+        int: The per-kernel ladder budget in seconds.
+    """
+    minutes = (
+        payload.get("kernel_budget_min")
+        or os.environ.get("KERNEL_OPT_KERNEL_BUDGET_MIN")
+        or _optimization_budget_minutes(payload)
+    )
+    return int(float(minutes) * 60) + 180
+
+
 def _backend_order(payload: dict) -> list[str]:
     """Resolve the ordered list of optimization backends to try.
 
@@ -2087,6 +2124,7 @@ async def _run_backend_ladder(
     backends: list[str],
     *,
     session_dir: Path,
+    deadline: float | None = None,
 ) -> tuple[HandlerResult | None, list[dict[str, Any]]]:
     """Run ``backends`` as a sequential break-on-KEEP ladder.
 
@@ -2096,12 +2134,21 @@ async def _run_backend_ladder(
     short-circuits *its own* ladder and OOB fallbacks (claude -> codex ->
     cursor) only fire when an earlier backend misses a KEEP.
 
+    When ``deadline`` (a :func:`time.monotonic` timestamp) is given, the ladder
+    enforces the per-kernel budget: each backend's subprocess timeout is capped
+    to the time left, and once less than :data:`_KERNEL_LADDER_MIN_BACKEND_SEC`
+    remains the ladder stops rather than launching a fallback it cannot finish.
+    This keeps a backend that hangs to its hard timeout from letting the
+    fallback overshoot the budget. See Hyperloom#602.
+
     Args:
         base_payload: The base request payload shared by every backend.
         candidate: The kernel candidate to optimize.
         kernel_id: The kernel id being optimized.
         backends: The ordered backends to try.
         session_dir: Session directory for workspace and state.
+        deadline: Optional ``time.monotonic`` deadline bounding the whole
+            ladder; ``None`` disables the per-kernel budget cap.
 
     Returns:
         A tuple of ``(best, attempts)`` where ``best`` is the strongest
@@ -2110,14 +2157,33 @@ async def _run_backend_ladder(
     """
     attempts: list[dict[str, Any]] = []
     best: HandlerResult | None = None
-    for backend in backends:
+    for idx, backend in enumerate(backends):
+        timeout_override: int | None = None
+        if deadline is not None:
+            remaining = deadline - time.monotonic()
+            if remaining <= _KERNEL_LADDER_MIN_BACKEND_SEC:
+                # Not enough of the per-kernel budget left to run another
+                # backend usefully; stop instead of overshooting it. #602
+                log.info(
+                    "kernel %s: per-kernel ladder budget exhausted (%.0fs left); "
+                    "skipping remaining backends %s",
+                    kernel_id,
+                    remaining,
+                    backends[idx:],
+                )
+                break
+            timeout_override = int(remaining)
         child = dict(base_payload)
         child["_single_kernel"] = True
         child["kernel_id"] = kernel_id
         child["backends"] = backend
         child["candidate"] = candidate
         child.setdefault("source_file", candidate.get("source_file"))
-        result = await _run_optimization_single(child, session_dir=session_dir)
+        result = await _run_optimization_single(
+            child,
+            session_dir=session_dir,
+            timeout_override_sec=timeout_override,
+        )
         attempts.append(
             {
                 "backend": backend,
@@ -2171,6 +2237,12 @@ async def _run_kernel_backend_sequence(
     kernel_id = str(candidate.get("kernel_id") or base_payload.get("kernel_id") or "")
     order = _backend_order(base_payload)
 
+    # Bound the whole ladder (all backends for this kernel) to one wall-clock
+    # budget so a backend that hangs to its hard timeout cannot let the
+    # fallback double the kernel's wall clock and overshoot the KERNEL-phase
+    # cap. Each ladder call caps its backends to the time left. See #602.
+    ladder_deadline = time.monotonic() + _kernel_ladder_budget_sec(base_payload)
+
     # Forge edits the live repo in-place (temp branch + per-file restore) and
     # must NOT race with other backends that read/write the same repo. Run it
     # sequentially first; if it KEEPs, short-circuit. Otherwise continue with
@@ -2188,6 +2260,7 @@ async def _run_kernel_backend_sequence(
             kernel_id,
             forge_group,
             session_dir=session_dir,
+            deadline=ladder_deadline,
         )
         if forge_best and _kernel_result_rank(forge_best)[0] > 0:
             best = forge_best
@@ -2206,6 +2279,7 @@ async def _run_kernel_backend_sequence(
                 kernel_id,
                 geak_group,
                 session_dir=session_dir,
+                deadline=ladder_deadline,
             ),
             _run_backend_ladder(
                 base_payload,
@@ -2213,6 +2287,7 @@ async def _run_kernel_backend_sequence(
                 kernel_id,
                 oob_group,
                 session_dir=session_dir,
+                deadline=ladder_deadline,
             ),
         )
         attempts = forge_attempts + geak_attempts + oob_attempts
@@ -2228,6 +2303,7 @@ async def _run_kernel_backend_sequence(
             kernel_id,
             remaining,
             session_dir=session_dir,
+            deadline=ladder_deadline,
         )
         attempts = forge_attempts + attempts
         if best is None and forge_best is not None:
@@ -2369,10 +2445,35 @@ async def _run_optimization_batch(
     return out
 
 
+def _backends_cli_arg(value: Any) -> str:
+    """Normalize a payload ``backends`` field into a bare ``--backends`` value.
+
+    The orchestration payload may carry ``backends`` as a bare string
+    (``"geak"``), a comma-joined string (``"geak,claude"``), or a JSON list
+    (``["geak"]``) when an upstream request serializes it as an array. A list
+    MUST be comma-joined into bare names, never ``str()``-ed into the repr of a
+    list (``"['geak']"``) — the kernel-agent's ``parse_backends`` validator
+    correctly rejects that opaque token and the dispatch fails with the
+    self-contradictory "unsupported backend(s): ['geak']". See Hyperloom#601.
+
+    Args:
+        value: The raw ``payload["backends"]`` value (str / list / tuple / None).
+
+    Returns:
+        A bare, comma-joined backend string (possibly empty).
+    """
+    if value is None:
+        return ""
+    if isinstance(value, (list, tuple)):
+        return ",".join(str(b).strip() for b in value if str(b).strip())
+    return str(value).strip()
+
+
 async def _run_optimization_single(
     payload: dict,
     *,
     session_dir: Path,
+    timeout_override_sec: int | None = None,
 ) -> HandlerResult:
     """Run Hyperloom/kernel-agent's kernel_optimization.py on one kernel.
 
@@ -2422,8 +2523,9 @@ async def _run_optimization_single(
         "--workspace-path",
         workspace_path,
     ]
-    if payload.get("backends"):
-        cmd += ["--backends", str(payload["backends"])]
+    backends_arg = _backends_cli_arg(payload.get("backends"))
+    if backends_arg:
+        cmd += ["--backends", backends_arg]
     if payload.get("source_file"):
         cmd += ["--source-file", str(payload["source_file"])]
     if target_platform:
@@ -2460,13 +2562,17 @@ async def _run_optimization_single(
     if payload.get("dry_run"):
         cmd += ["--dry-run"]
     geak_budget_min = _geak_budget_minutes(payload)
-    backend = str(payload.get("backends") or "").strip().lower()
+    backend = backends_arg.lower()
     if backend == "geak" or not backend:
         cmd += ["--geak-budget-min", str(geak_budget_min)]
     if payload.get("budget_minutes") is not None:
         cmd += ["--budget-minutes", str(payload["budget_minutes"])]
     # Allow the tool to handle its own backend timeout and salvage partial artifacts.
     timeout_sec = _optimization_wrapper_timeout_sec(payload)
+    if timeout_override_sec is not None:
+        # The backend ladder caps each subprocess to the time left in the
+        # per-kernel budget so a fallback never overshoots it. See Hyperloom#602.
+        timeout_sec = max(1, min(timeout_sec, int(timeout_override_sec)))
 
     from .action_executors._multi_node_env import is_multi_node
 
@@ -2477,14 +2583,38 @@ async def _run_optimization_single(
 
         await asyncio.to_thread(kill_inference_for_kernel_agent_best_effort)
 
-    rc, stdout, stderr = await _run_subprocess(cmd, timeout_sec=timeout_sec)
-    result = _shape_tool_result(rc, stdout, stderr)
+    try:
+        rc, stdout, stderr = await _run_subprocess(cmd, timeout_sec=timeout_sec)
+        result = _shape_tool_result(rc, stdout, stderr)
+    except subprocess.TimeoutExpired as exc:
+        # The kernel-agent subprocess overran the hard outer timeout. Shape a
+        # failed result here instead of letting TimeoutExpired propagate to the
+        # batch wrapper — that wrapper produces a backend-less result, so the
+        # failure was silently bucketed as a GEAK invocation even when a
+        # different optimizer (e.g. claude) actually ran. See Hyperloom#602.
+        cmd_repr = " ".join(str(c) for c in (getattr(exc, "cmd", None) or cmd))
+        result = {
+            "status": "failed",
+            "error_class": "subprocess_timeout",
+            "error": f"TimeoutExpired after {timeout_sec}s: {cmd_repr[:1500]}",
+        }
     # Stamp source_file / kernel_id from the payload onto the result so the multi-KEEP integrate queue can group same-file KEEPs (the tool may omit them on timeout/crash).
     if isinstance(result, dict):
         if not result.get("kernel_id") and payload.get("kernel_id"):
             result["kernel_id"] = str(payload["kernel_id"])
         if not result.get("source_file") and payload.get("source_file"):
             result["source_file"] = str(payload["source_file"])
+        # Attribute a result that carries no per-backend attempt ladder
+        # (pre-dispatch / infra / timeout) to the backend that actually ran, so
+        # downstream recorders never fall back to a silent GEAK default. Only
+        # when this run dispatched a single, unambiguous backend. See #602.
+        if (
+            backend
+            and "," not in backend
+            and not result.get("backend")
+            and not result.get("attempts")
+        ):
+            result["backend"] = backend
     # Full-trace: mine each geak/oob attempt's stdout log for token usage and
     # append an ``llm_calls.jsonl`` row. Best-effort; a no-op when the backend
     # emits no usage block (claude/codex/cursor account spend elsewhere).
@@ -3688,7 +3818,11 @@ def record_kernel_opt(state, result: dict[str, Any]) -> None:
                 or (_decision == "REVERT" and bool(_err_class))
             )
             if _failed_predispatch and not _backends:
-                _b = str(result.get("backend") or "").lower() or "geak"
+                # Never default an unattributable failure to GEAK — the backend
+                # that ran is stamped on the result upstream when known; only a
+                # genuine pre-dispatch gating failure (no backend launched)
+                # falls through, and "unknown" reflects that honestly. #602
+                _b = str(result.get("backend") or "").lower() or "unknown"
                 _backends = [_b]
             _dispatched = bool(_attempts) or _failed_predispatch
             instrument.record_kernel_dispatch(

--- a/inference_optimizer/tests/test_decision_framework.py
+++ b/inference_optimizer/tests/test_decision_framework.py
@@ -465,7 +465,7 @@ async def test_run_optimization_handler_batches_reusable_kernels_with_backend_fa
     )
     calls: list[tuple[str, str]] = []
 
-    async def fake_single(payload, *, session_dir):
+    async def fake_single(payload, *, session_dir, timeout_override_sec=None):
         kernel_id = payload["kernel_id"]
         backend = payload["backends"]
         calls.append((kernel_id, backend))

--- a/inference_optimizer/tests/test_geak_dispatch_routing.py
+++ b/inference_optimizer/tests/test_geak_dispatch_routing.py
@@ -1,0 +1,217 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""GEAK-dispatch correctness regressions (Hyperloom#601, #602).
+
+* #601 — a ``backends`` payload supplied as a JSON list (``["geak"]``) must be
+  serialized into a bare ``--backends geak`` token, never ``str(["geak"])`` →
+  ``"['geak']"`` (which the kernel-agent validator rightly rejects).
+* #602 — a non-GEAK attempt (e.g. a Claude subprocess that times out) must not
+  be silently bucketed under the GEAK invocation lane; the backend that ran is
+  stamped on the result and an unattributable failure never defaults to GEAK.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from inference_optimizer.breakdown.recorder import assemble_parts
+from inference_optimizer.breakdown.recorder import instrument
+from inference_optimizer.orchestrator import kernel_request_handlers as krh
+
+
+# --------------------------------------------------------------------------- #
+# #601 — --backends serialization
+# --------------------------------------------------------------------------- #
+def test_backends_cli_arg_list_is_comma_joined_bare_names():
+    assert krh._backends_cli_arg(["geak"]) == "geak"
+    assert krh._backends_cli_arg(["geak", "claude"]) == "geak,claude"
+    assert krh._backends_cli_arg("geak") == "geak"
+    assert krh._backends_cli_arg("geak,claude") == "geak,claude"
+    assert krh._backends_cli_arg(None) == ""
+    # The repr of a list must never be what reaches --backends.
+    assert krh._backends_cli_arg(["geak"]) != "['geak']"
+
+
+def _bypass_single_kernel_guards(monkeypatch):
+    """Disable the pre-dispatch validators so a unit test reaches cmd-building."""
+    monkeypatch.setattr(krh, "_validate_reusable_native_kernel", lambda payload: None)
+    monkeypatch.setattr(
+        krh,
+        "_validate_kernel_shape_and_paths",
+        lambda payload, *, session_dir: None,
+    )
+    monkeypatch.setattr(krh, "_kernel_agent_root_error", lambda: "")
+
+
+@pytest.mark.asyncio
+async def test_run_optimization_single_serializes_list_backends(tmp_path: Path, monkeypatch):
+    # Hyperloom#601 repro: a list backends payload must hit the subprocess as a
+    # bare "geak" token, not the repr "['geak']".
+    _bypass_single_kernel_guards(monkeypatch)
+    captured: dict[str, list[str]] = {}
+
+    async def _fake_run_subprocess(cmd, *, timeout_sec):
+        captured["cmd"] = list(cmd)
+        return 0, '{"status": "ok", "kernel_id": "k001"}', ""
+
+    monkeypatch.setattr(krh, "_run_subprocess", _fake_run_subprocess)
+
+    payload = {"kernel_id": "k001", "backends": ["geak"], "_single_kernel": True}
+    await krh._run_optimization_single(payload, session_dir=tmp_path)
+
+    cmd = captured["cmd"]
+    assert "--backends" in cmd
+    val = cmd[cmd.index("--backends") + 1]
+    assert val == "geak"
+    assert val != "['geak']"
+
+
+# --------------------------------------------------------------------------- #
+# #602 — timeout backend attribution
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_timeout_result_is_attributed_to_dispatched_backend(tmp_path: Path, monkeypatch):
+    # Hyperloom#602 repro: a claude subprocess that overruns the outer timeout
+    # must be shaped into a failed result that carries backend="claude" (not
+    # left backend-less for the GEAK fallback to claim).
+    _bypass_single_kernel_guards(monkeypatch)
+
+    async def _fake_timeout(cmd, *, timeout_sec):
+        raise subprocess.TimeoutExpired(cmd=list(cmd), timeout=timeout_sec)
+
+    monkeypatch.setattr(krh, "_run_subprocess", _fake_timeout)
+
+    payload = {"kernel_id": "k008", "backends": "claude", "_single_kernel": True}
+    result = await krh._run_optimization_single(payload, session_dir=tmp_path)
+
+    assert isinstance(result, dict)
+    assert result["status"] == "failed"
+    assert result["error_class"] == "subprocess_timeout"
+    assert result["backend"] == "claude"
+
+
+def test_record_kernel_invocations_claude_timeout_routes_to_oob(tmp_path: Path):
+    # A backend-stamped (claude) no-attempts failure lands on the oob lane,
+    # never the geak lane. Hyperloom#602.
+    result = {
+        "kernel_id": "k008",
+        "status": "failed",
+        "error_class": "subprocess_timeout",
+        "error": "TimeoutExpired ... --backends claude",
+        "backend": "claude",
+        "attempts": [],
+    }
+    instrument.record_kernel_invocations(tmp_path, result)
+    sections = assemble_parts(tmp_path)
+    assert sections.get("oob_invocations"), "claude failure must be on the oob lane"
+    assert not sections.get("geak_invocations"), "must NOT contaminate the geak lane"
+
+
+def test_record_kernel_invocations_unknown_backend_is_not_geak(tmp_path: Path):
+    # A genuine pre-dispatch failure with no resolvable backend must NOT be
+    # fabricated as a GEAK invocation. Hyperloom#602.
+    result = {
+        "kernel_id": "k001",
+        "status": "failed",
+        "error_class": "kernel_agent_root_missing",
+        "error": "kernel-agent root missing",
+        "attempts": [],
+    }
+    instrument.record_kernel_invocations(tmp_path, result)
+    sections = assemble_parts(tmp_path)
+    assert not sections.get("geak_invocations"), "unknown backend must not default to geak"
+    assert not sections.get("oob_invocations")
+    assert not sections.get("forge_invocations")
+
+
+def test_record_kernel_invocations_geak_still_records(tmp_path: Path):
+    # A real GEAK pre-dispatch failure still records on the geak lane.
+    result = {
+        "kernel_id": "k001",
+        "status": "failed",
+        "error_class": "non_reusable_kernel",
+        "error": "non reusable",
+        "backend": "geak",
+        "attempts": [],
+    }
+    instrument.record_kernel_invocations(tmp_path, result)
+    sections = assemble_parts(tmp_path)
+    assert sections.get("geak_invocations"), "geak failure must record on the geak lane"
+
+
+# --------------------------------------------------------------------------- #
+# #602 — per-kernel ladder budget (option 1)
+# --------------------------------------------------------------------------- #
+def test_kernel_ladder_budget_sec_priority(monkeypatch):
+    monkeypatch.delenv("KERNEL_OPT_KERNEL_BUDGET_MIN", raising=False)
+    # payload override wins.
+    assert krh._kernel_ladder_budget_sec({"kernel_budget_min": 10}) == 10 * 60 + 180
+    # env is next in priority.
+    monkeypatch.setenv("KERNEL_OPT_KERNEL_BUDGET_MIN", "5")
+    assert krh._kernel_ladder_budget_sec({}) == 5 * 60 + 180
+
+
+@pytest.mark.asyncio
+async def test_ladder_continues_to_fallback_after_timeout(tmp_path: Path, monkeypatch):
+    # Option A: a timed-out backend (failed, not KEEP) does not abort the
+    # ladder — the next backend still runs (within budget). Hyperloom#602.
+    calls: list[str] = []
+
+    async def _fake_single(payload, *, session_dir, timeout_override_sec=None):
+        calls.append(payload["backends"])
+        return {"status": "failed", "backend": payload["backends"], "error_class": "subprocess_timeout"}
+
+    monkeypatch.setattr(krh, "_run_optimization_single", _fake_single)
+    deadline = time.monotonic() + 10_000  # plenty of budget left
+    best, attempts = await krh._run_backend_ladder(
+        {}, {"kernel_id": "k1", "source_file": "x"}, "k1", ["forge", "geak"],
+        session_dir=tmp_path, deadline=deadline,
+    )
+    assert calls == ["forge", "geak"], "fallback must run after a forge timeout"
+    assert len(attempts) == 2
+
+
+@pytest.mark.asyncio
+async def test_ladder_caps_backend_timeout_to_remaining_budget(tmp_path: Path, monkeypatch):
+    # Each backend's subprocess timeout is capped to the time left in the
+    # per-kernel budget. Hyperloom#602.
+    seen: list[int | None] = []
+
+    async def _fake_single(payload, *, session_dir, timeout_override_sec=None):
+        seen.append(timeout_override_sec)
+        return {"status": "failed", "backend": payload["backends"]}
+
+    monkeypatch.setattr(krh, "_run_optimization_single", _fake_single)
+    deadline = time.monotonic() + 300  # ~5 min left
+    await krh._run_backend_ladder(
+        {}, {"kernel_id": "k1"}, "k1", ["forge"],
+        session_dir=tmp_path, deadline=deadline,
+    )
+    assert seen[0] is not None
+    assert 250 <= seen[0] <= 300
+
+
+@pytest.mark.asyncio
+async def test_ladder_skips_backends_when_budget_exhausted(tmp_path: Path, monkeypatch):
+    # When the per-kernel budget is already spent (e.g. forge hung to its hard
+    # timeout), the remaining backends are skipped rather than overshooting the
+    # budget. Hyperloom#602.
+    calls: list[str] = []
+
+    async def _fake_single(payload, *, session_dir, timeout_override_sec=None):
+        calls.append(payload["backends"])
+        return {"status": "failed", "backend": payload["backends"]}
+
+    monkeypatch.setattr(krh, "_run_optimization_single", _fake_single)
+    deadline = time.monotonic() - 1  # budget already exhausted
+    best, attempts = await krh._run_backend_ladder(
+        {}, {"kernel_id": "k1"}, "k1", ["geak"],
+        session_dir=tmp_path, deadline=deadline,
+    )
+    assert calls == [], "no backend should run once the budget is exhausted"
+    assert best is None
+    assert attempts == []

--- a/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -3007,7 +3007,7 @@ async def test_backend_ladder_prefers_keep_over_higher_micro_non_keep(
     """
     calls: list[str] = []
 
-    async def fake_single(child, *, session_dir):
+    async def fake_single(child, *, session_dir, timeout_override_sec=None):
         backend = child["backends"]
         calls.append(backend)
         if backend == "geak":
@@ -3069,7 +3069,7 @@ async def test_backend_ladder_breaks_on_first_keep(session_dir):
     """When GEAK already KEEPs, the ladder short-circuits (no Claude/Codex)."""
     calls: list[str] = []
 
-    async def fake_single(child, *, session_dir):
+    async def fake_single(child, *, session_dir, timeout_override_sec=None):
         backend = child["backends"]
         calls.append(backend)
         if backend == "geak":
@@ -3103,7 +3103,7 @@ async def test_backend_ladder_falls_back_to_highest_micro_when_no_keep(
 ):
     """If NO backend KEEPs, the ladder picks the highest-micro non-KEEP."""
 
-    async def fake_single(child, *, session_dir):
+    async def fake_single(child, *, session_dir, timeout_override_sec=None):
         backend = child["backends"]
         if backend == "geak":
             return {
@@ -3148,7 +3148,7 @@ async def test_backend_sequence_parallel_runs_oob_even_when_geak_keeps(session_d
     rewrite than GEAK's first KEEP."""
     calls: list[str] = []
 
-    async def fake_single(child, *, session_dir):
+    async def fake_single(child, *, session_dir, timeout_override_sec=None):
         backend = child["backends"]
         calls.append(backend)
         if backend == "geak":
@@ -3199,7 +3199,7 @@ async def test_backend_sequence_parallel_keeps_geak_when_oob_lower(session_dir):
     """GPU-rich mode races both, but if GEAK is the strongest it still
     wins the best-selection contest."""
 
-    async def fake_single(child, *, session_dir):
+    async def fake_single(child, *, session_dir, timeout_override_sec=None):
         backend = child["backends"]
         if backend == "geak":
             return {
@@ -3243,7 +3243,7 @@ async def test_backend_sequence_parallel_oob_ladder_still_falls_back(session_dir
     GEAK, with the strongest overall result selected."""
     calls: list[str] = []
 
-    async def fake_single(child, *, session_dir):
+    async def fake_single(child, *, session_dir, timeout_override_sec=None):
         backend = child["backends"]
         calls.append(backend)
         if backend == "geak":
@@ -3293,7 +3293,7 @@ async def test_backend_sequence_parallel_noop_without_geak(session_dir):
     still short-circuits on the first KEEP."""
     calls: list[str] = []
 
-    async def fake_single(child, *, session_dir):
+    async def fake_single(child, *, session_dir, timeout_override_sec=None):
         backend = child["backends"]
         calls.append(backend)
         return {
@@ -3326,7 +3326,7 @@ async def test_backend_sequence_forge_keep_short_circuits(session_dir):
     """
     calls: list[str] = []
 
-    async def fake_single(child, *, session_dir):
+    async def fake_single(child, *, session_dir, timeout_override_sec=None):
         backend = child["backends"]
         calls.append(backend)
         if backend == "forge":

--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -550,7 +550,16 @@ def parse_backends(backends: str) -> list[str]:
         ValueError: When any backend is outside the allowed set
             (``geak``, ``claude``, ``codex``, ``cursor``).
     """
-    parsed = [b.strip().lower() for b in backends.split(",") if b.strip()]
+    raw = str(backends or "").strip()
+    # Defense-in-depth (Hyperloom#601): an upstream dispatch slip can hand us
+    # the repr() of a Python list (e.g. "['geak']" or "['geak', 'claude']")
+    # instead of a bare comma-joined string. Recover the inner tokens so a
+    # serialization mistake at the call site does not reject an otherwise-valid
+    # backend with the self-contradictory "unsupported backend(s): ['geak']".
+    # Genuinely-invalid names inside the list are still rejected below.
+    if raw.startswith("[") and raw.endswith("]"):
+        raw = raw[1:-1].replace("'", "").replace('"', "")
+    parsed = [b.strip().lower() for b in raw.split(",") if b.strip()]
     # `forge` is the Kernel-Forge autonomous-loop backend; it is first in the
     # default ladder (choose_backends) and falls through to geak/claude/codex
     # when it skips a non-triton candidate or misses a KEEP. See

--- a/kernel-agent/tools/test_forge_submit.py
+++ b/kernel-agent/tools/test_forge_submit.py
@@ -33,6 +33,22 @@ def test_parse_backends_still_rejects_unknown():
         ko.parse_backends("forge,bogus")
 
 
+def test_parse_backends_tolerates_stringified_list():
+    # Hyperloom#601: an upstream dispatch slip can hand the repr() of a Python
+    # list to --backends ("['geak']") instead of a bare name. parse_backends
+    # must recover the inner token rather than rejecting a valid backend.
+    assert ko.parse_backends("['geak']") == ["geak"]
+    assert ko.parse_backends('["geak"]') == ["geak"]
+    assert ko.parse_backends("['geak', 'claude']") == ["geak", "claude"]
+
+
+def test_parse_backends_stringified_list_still_rejects_unknown():
+    # The recovery must not weaken validation: a genuinely-unknown name inside
+    # a stringified list is still rejected.
+    with pytest.raises(ValueError):
+        ko.parse_backends("['bogus']")
+
+
 def test_resolve_gpu_target_env_wins(monkeypatch):
     monkeypatch.setenv("GPU_TARGET", "gfx950")
     assert forge_submit._resolve_gpu_target({"platform": "mi300x"}) == "gfx950"


### PR DESCRIPTION
## Summary
- Fix #601 by normalizing `backends` payloads before building `--backends`, with defense-in-depth parsing for stringified backend lists.
- Fix #602 by preserving the actual dispatched backend on timeout/pre-dispatch failures and stopping unattributable failures from defaulting into GEAK metrics.
- Add a per-kernel backend-ladder budget so fallback execution stays within one kernel budget when an earlier backend hangs.

## Test plan
- [x] `python -m pytest inference_optimizer/tests/test_geak_dispatch_routing.py -q`
- [x] `python -m pytest inference_optimizer/tests/test_decision_framework.py inference_optimizer/tests/test_profile_and_kernel_handlers.py -q`
- [x] `python -m pytest inference_optimizer/tests/test_kernel_journey.py inference_optimizer/tests/test_forge_lane.py inference_optimizer/tests/test_kernel_shape_validation.py inference_optimizer/tests/test_breakdown_smoke.py inference_optimizer/tests/test_geak_dispatch_routing.py kernel-agent/tools/test_forge_submit.py -q`

Fixes #601.
Fixes #602.

Made with [Cursor](https://cursor.com)