### PR TITLE
Fix cu-mapping resolver so HL dispatches aiter MoE kernels to GEAK

### DIFF
--- a/kernel-agent/tools/data/op_to_source.json
+++ b/kernel-agent/tools/data/op_to_source.json
@@ -1879,5 +1879,21 @@
       }
     },
     "sglang": {}
+  },
+  "aiter::fmoe_g1u1": {
+    "kind": "single",
+    "patchable": true,
+    "python_launcher_path": [
+      "aiter/fused_moe.py(367): fused_moestage"
+    ],
+    "sglang": {
+      "aiter::fmoe_bf16_pertokenFp8_g1u1_vs_silu_1tg_ps_32x256": {
+        "kernel_kind": "aiter_asm_kernel",
+        "kernel_source_line": "5",
+        "kernel_source_path": "/sgl-workspace/aiter/csrc/py_itfs_cu/asm_fmoe.cu",
+        "patchable": true
+      }
+    },
+    "vllm": {}
   }
 }

--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -180,19 +180,95 @@ class OpResolution:
         self.stamp_onto(item)
 
 
+def _normalize_op_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    """Bridge the data schema (nested ``{fw:{device_kernel:{kernel_source_path}}}``)
+    to the schema the resolver consumes (``status``/``abs_path``/``routes``).
+
+    The committed ``op_to_source.json`` stores each op's editable source NESTED as
+    ``sglang``/``vllm`` -> ``{<device_kernel_name>: {kernel_source_path, patchable}}``,
+    but :class:`OpResolver` only emits sources when ``status == "resolved"`` and
+    reads ``abs_path`` / ``abs_path_sglang`` / ``abs_path_vllm`` (single) or
+    ``routes[].match`` + per-route ``abs_path`` (dispatch). Without this bridge every
+    op resolves to ``status=None`` / empty sources (the cu_mapping WIP schema-mismatch
+    bug). This converts in-place, idempotently:
+      * 1 device-kernel across fw containers  -> single entry with abs_path_{sglang,vllm}
+      * >1 distinct device-kernels            -> dispatch entry with routes[].match
+    Already-normalized entries (those carrying ``status``/``abs_path``/``routes``) pass through.
+    """
+    if not isinstance(entry, dict):
+        return entry
+    # Already in resolver schema -> leave as-is.
+    if entry.get("status") or entry.get("routes") or entry.get("abs_path") \
+            or entry.get("abs_path_sglang") or entry.get("abs_path_vllm"):
+        return entry
+    # Collect (device_kernel_name, source_path, framework, patchable) from nested fw maps.
+    leaves: list[tuple[str, str, str, Any]] = []
+    for fw in ("sglang", "vllm"):
+        fw_map = entry.get(fw)
+        if not isinstance(fw_map, dict):
+            continue
+        for dk_name, leaf in fw_map.items():
+            if not isinstance(leaf, dict):
+                continue
+            path = leaf.get("kernel_source_path") or leaf.get("abs_path")
+            if path:
+                leaves.append((str(dk_name), str(path), fw, leaf.get("patchable")))
+    if not leaves:
+        return entry  # no editable source recorded -> leave unresolved (no-kernel/triton/etc.)
+    out = dict(entry)
+    distinct_kernels = {dk for dk, _p, _fw, _pa in leaves}
+    if len(distinct_kernels) <= 1:
+        # Single editable source — resolve directly, split by container so
+        # _select_paths picks whichever .cu is actually present on disk.
+        out["kind"] = "single"
+        out["status"] = _ROUTABLE_STATUS
+        out.setdefault("framework", "aiter")
+        sgl = [p for _dk, p, fw, _pa in leaves if fw == "sglang"]
+        vll = [p for _dk, p, fw, _pa in leaves if fw == "vllm"]
+        if sgl:
+            out["abs_path_sglang"] = sgl
+        if vll:
+            out["abs_path_vllm"] = vll
+        if not sgl and not vll:
+            out["abs_path"] = [p for _dk, p, _fw, _pa in leaves]
+        out["patchable"] = any(bool(pa) for _dk, _p, _fw, pa in leaves) or entry.get("patchable")
+    else:
+        # Multiple device kernels -> dispatch by device_kernel_name glob.
+        out["kind"] = "dispatch"
+        routes = []
+        for dk, p, fw, pa in leaves:
+            routes.append({
+                "match": dk,
+                "status": _ROUTABLE_STATUS,
+                ("abs_path_sglang" if fw == "sglang" else "abs_path_vllm" if fw == "vllm" else "abs_path"): [p],
+                "patchable": pa,
+                "framework": "aiter",
+            })
+        out["routes"] = routes
+        out["default"] = {"status": "unresolved"}
+    return out
+
+
 @lru_cache(maxsize=1)
 def load_mapping() -> dict[str, Any]:
     """Load and cache the vendored ground-truth ``data/op_to_source.json``.
 
     Returns:
         The parsed mapping (op name -> entry), or ``{}`` if unreadable.
+
+    Each entry is passed through :func:`_normalize_op_entry` so the committed
+    nested ``{fw:{device_kernel:{kernel_source_path}}}`` data is bridged to the
+    resolver's ``status``/``abs_path``/``routes`` schema (fixes the cu_mapping
+    schema-mismatch where every op resolved to empty).
     """
     try:
         with open(_OP_TO_SOURCE_JSON, encoding="utf-8") as fh:
             data = json.load(fh)
     except (OSError, ValueError):
         return {}
-    return data if isinstance(data, dict) else {}
+    if not isinstance(data, dict):
+        return {}
+    return {op: _normalize_op_entry(entry) for op, entry in data.items()}
 
 
 def _as_path_list(value: Any) -> list[str]:

--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -14,6 +14,7 @@ import asyncio
 import csv
 import fnmatch
 import functools
+import glob
 import gzip
 import json
 import os
@@ -86,6 +87,11 @@ _OP_TO_SOURCE_JSON = Path(__file__).resolve().parent / "data" / "op_to_source.js
 
 # Statuses that mean "we have an editable device source to optimize".
 _ROUTABLE_STATUS = "resolved"
+
+# TraceLens may annotate a candidate op name with the steady-state phase it was
+# observed in, e.g. ``aiter::fmoe_g1u1 (prefill)``. The mapping is keyed by the
+# bare op name, so strip a trailing phase tag before the (exact) dict lookup.
+_PHASE_SUFFIX_RE = re.compile(r"\s*\((?:prefill|decode|prefilldecode|mixed)\)\s*$")
 
 
 @dataclass
@@ -238,7 +244,12 @@ def _normalize_op_entry(entry: dict[str, Any]) -> dict[str, Any]:
         routes = []
         for dk, p, fw, pa in leaves:
             routes.append({
-                "match": dk,
+                # Escape + strip so the device-kernel name matches as a literal:
+                # fnmatch treats [ ] ? * as metachars (would silently break or
+                # over-broaden self-matching for templated kernels), and the
+                # resolver strip()s the lookup name (so trailing whitespace in
+                # the stored name must be stripped here too).
+                "match": glob.escape(dk.strip()),
                 "status": _ROUTABLE_STATUS,
                 ("abs_path_sglang" if fw == "sglang" else "abs_path_vllm" if fw == "vllm" else "abs_path"): [p],
                 "patchable": pa,
@@ -303,6 +314,7 @@ class OpResolver:
         device_kernel_name: str | None = None,
     ) -> OpResolution | None:
         """Resolve ``op_name`` to an :class:`OpResolution`, or ``None`` on a dict miss."""
+        op_name = _PHASE_SUFFIX_RE.sub("", op_name)
         entry = self.mapping.get(op_name)
         if entry is None:
             return None


### PR DESCRIPTION
## Summary
Makes the cu-mapping (`op_to_source.json`) resolver actually resolve aiter kernels to their editable `.cu`, so HL's patchability gate stops dropping every aiter op and the HL→TraceLens→GEAK loop reaches GEAK. Stacked on `cu_mapping_test` (Tharun's cu-resolve WIP); this PR is the 2 fix commits on top.

Root cause: the committed `op_to_source.json` stores each op's source NESTED as `{sglang,vllm}->{device_kernel:{kernel_source_path}}`, but `OpResolver` only emits sources when `status=="resolved"` and reads `abs_path`/`abs_path_{sglang,vllm}` (single) or `routes[].match` (dispatch). With no bridge, every op resolved to empty → HL's filter (`parallel_e2e_runner.py:248`, `source_file && Path(...).exists()`) rejected all aiter kernels → GEAK dispatched nothing.

## Changes (`kernel-agent/tools/tracelens_analysis.py` + `data/op_to_source.json`)
- **Normalizer** (`_normalize_op_entry` in `load_mapping()`): bridges the nested data schema → resolver schema for all 104 ops (single vs dispatch by distinct device kernel). Idempotent; single chokepoint every consumer goes through.
- **`aiter::fmoe_g1u1` entry**: the 42.36% GLM-4.7-FP8 MoE kernel (pertoken route → `asm_fmoe.cu`), previously absent.
- **Robustness (general, not model-specific):**
  - `match = glob.escape(dk.strip())` for auto-generated dispatch routes — 24 device-kernel names contain fnmatch metachars `[ ] ? *` that would silently fail self-match or over-match; strip also fixes a trailing-space name the resolver strips on lookup.
  - Strip a trailing ` (prefill|decode|prefilldecode|mixed)` phase suffix before the exact `mapping.get()` lookup — TraceLens annotates candidate names with the phase, which otherwise caused a nondeterministic miss → kernel skipped.
  - Removed a stray `@lru_cache` on `_normalize_op_entry` (unhashable dict arg).

## Verification
On the existing GLM-4.7-FP8 roofline trace (no re-serve):
- `hot_kernels` 0 → 5; `5/5` survive HL's patchable filter.
- `aiter::fmoe_g1u1` @ 42.36% resolves to `/sgl-workspace/aiter/csrc/py_itfs_cu/asm_fmoe.cu` (`op_to_source_status=resolved`), with faithful traced geometry (w1 `(161,512,5120) fp8`, w2 `(161,5120,256) fp8`).
- Unit: 78/78 dispatch routes self-resolve; synthetic `kernel[2]` metachar resolves; phase-suffixed `aiter::fmoe_g1u1 (prefill)`/`(decode)` resolve; whole table 92/104 resolved.
- End-to-end: full `tracelens_analysis` through the LLM orchestrator passes; HL then dispatches GEAK on the fmoe kernel, and GEAK autonomously builds its harness on the exact traced shapes `(7680,5120,256,161,9,32)` (`harness_shapes_source=user_task:production`) — not synthetic.

## Test plan
- [ ] `tracelens_analysis` on a GLM-4.7-FP8 trace yields `hot_kernels>0` with aiter MoE resolved to a real `.cu`
- [ ] resolver unit checks: dispatch self-resolve, metachar route, phase-suffix lookup
- [ ] HL kernel-opt dispatches GEAK (`kernel_attempts>0`) on the resolved kernel

🤖 Generated with [Claude Code](https://claude.com/claude-code)