### PR TITLE
feat(breakdown): add top-level gemm_tuning section, engine-tagged

### DIFF
--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -4713,6 +4713,8 @@ def _normalize_optimization_stack_entry(
         "validated": bool(validated),
     }
     # gemm_tuning-specific evidence (optional).
+    if "engine" in raw:
+        out["engine"] = str(raw.get("engine") or "")
     if "tuned_file" in raw:
         out["tuned_file"] = str(raw.get("tuned_file") or "")
     if "final_report_path" in raw:
@@ -4730,6 +4732,133 @@ def _normalize_optimization_stack_entry(
     if "task_id" in raw:
         out["task_id"] = str(raw.get("task_id") or "")
     return out
+
+
+def collect_gemm_tuning(state: dict[str, Any]) -> dict[str, Any]:
+    """Build the top-level ``gemm_tuning`` section from session state; never raises.
+
+    Assembles one run per ``state.gemm_tuning_attempts[]`` entry (falling back
+    to ``last_gemm_tuning`` when the history is absent), tags each with its
+    tuning ``engine`` (``geak`` today, ``forge`` later), and cross-references
+    ``optimization_stack`` so a run whose ``tuned_file`` was kept is marked
+    ``adopted`` with the kept gain. Gain is mirrored here for the optimization
+    layer while ``attribution`` remains the authoritative roll-up.
+
+    Args:
+        state (dict[str, Any]): Parsed ``state.json``.
+
+    Returns:
+        dict[str, Any]: A ``GemmTuning`` envelope (``runs`` + adopted summary),
+        or ``{}`` when the session ran no GEMM tuning.
+    """
+    attempts = state.get("gemm_tuning_attempts")
+    if not isinstance(attempts, list) or not attempts:
+        last = state.get("last_gemm_tuning")
+        attempts = [last] if isinstance(last, dict) and last else []
+    if not attempts:
+        return {}
+
+    # tuned_file -> (gain_pct, validated) for KEEPs already in the stack.
+    adopted_gain: dict[str, dict[str, Any]] = {}
+    stack = state.get("optimization_stack")
+    validated_len = 0
+    try:
+        validated_len = int(state.get("cumulative_gain_validated_stack_len") or 0)
+    except (TypeError, ValueError):
+        validated_len = 0
+    if isinstance(stack, list):
+        for idx, item in enumerate(stack):
+            if not isinstance(item, dict) or item.get("action") != "gemm_tuning":
+                continue
+            tf = str(item.get("tuned_file") or "").strip()
+            if not tf:
+                continue
+            adopted_gain[tf] = {
+                "gain_pct": _to_float(item.get("gain_pct")),
+                "validated": idx < validated_len,
+                "engine": str(item.get("engine") or "geak"),
+            }
+
+    baseline_tput = _to_float(state.get("baseline_tput"))
+    knob_tp = state.get("tp")
+    knob_conc = state.get("conc")
+    knob_isl = state.get("isl")
+    knob_osl = state.get("osl")
+    gpu_type = str(state.get("gpu_type") or "").strip()
+    precision = str(state.get("precision") or "").strip()
+    framework = str(state.get("framework") or "").strip()
+
+    runs: list[dict[str, Any]] = []
+    for raw in attempts:
+        if not isinstance(raw, dict):
+            continue
+        engine = str(raw.get("engine") or "geak")
+        speedup = _to_float(raw.get("best_speedup"))
+        gain_pct: float | None = None
+        tuned_tput: float | None = None
+        if speedup is not None:
+            gain_pct = (speedup - 1.0) * 100.0
+            if baseline_tput is not None:
+                tuned_tput = baseline_tput * speedup
+        tuned_file = str(raw.get("tuned_file") or "").strip()
+        adopted = tuned_file in adopted_gain
+        # Prefer the kept gain (validated e2e) when this run was adopted.
+        if adopted and adopted_gain[tuned_file].get("gain_pct") is not None:
+            gain_pct = adopted_gain[tuned_file]["gain_pct"]
+
+        run: dict[str, Any] = {
+            "engine": engine,
+            "status": str(raw.get("status") or ""),
+            "decision": str(raw.get("decision") or ""),
+            "source": str(raw.get("source") or ""),
+            "ts": str(raw.get("ts") or ""),
+            "precision": str(raw.get("precision") or precision),
+            "framework": str(raw.get("framework") or framework),
+            "gpu_type": str(raw.get("gpu_type") or gpu_type),
+            "baseline_tput": baseline_tput,
+            "best_speedup": speedup,
+            "gain_pct": gain_pct,
+            "tuned_tput": tuned_tput,
+            "tuned_file": tuned_file,
+            "final_report_path": str(raw.get("final_report_path") or ""),
+            "workspace": str(raw.get("workspace") or ""),
+            "adopted": adopted,
+        }
+        for knob, val in (("tp", knob_tp), ("conc", knob_conc), ("isl", knob_isl), ("osl", knob_osl)):
+            raw_knob = raw.get(knob)
+            chosen = raw_knob if raw_knob not in (None, "") else val
+            if chosen not in (None, ""):
+                try:
+                    run[knob] = int(chosen)
+                except (TypeError, ValueError):
+                    pass
+        if raw.get("libtype"):
+            run["libtype"] = str(raw.get("libtype"))
+        if isinstance(raw.get("summary"), dict):
+            run["summary"] = raw["summary"]
+        if isinstance(raw.get("shapes"), list):
+            run["shapes"] = raw["shapes"]
+        runs.append(run)
+
+    if not runs:
+        return {}
+
+    adopted_engine = ""
+    adopted_tuned_file = ""
+    total_gain_pct = 0.0
+    for run in runs:
+        if run.get("adopted"):
+            adopted_engine = run.get("engine") or adopted_engine
+            adopted_tuned_file = run.get("tuned_file") or adopted_tuned_file
+            if isinstance(run.get("gain_pct"), (int, float)):
+                total_gain_pct += float(run["gain_pct"])
+
+    return {
+        "runs": runs,
+        "adopted_engine": adopted_engine,
+        "adopted_tuned_file": adopted_tuned_file,
+        "total_gain_pct": round(total_gain_pct, 2),
+    }
 
 
 def collect_source_files(

--- a/inference_optimizer/breakdown/exporter.py
+++ b/inference_optimizer/breakdown/exporter.py
@@ -400,6 +400,12 @@ def build(
         "optimization_stack",
         _safe_collect("optimization_stack", lambda: collectors.collect_optimization_stack(state), warnings, default=[]),
     )
+    # Fixed FP8 GEMM-tuning stage, engine-tagged (geak today, forge later);
+    # empty {} on non-fp8/sglang or pre-section sessions.
+    gemm_tuning = _pick(
+        "gemm_tuning",
+        _safe_collect("gemm_tuning", lambda: collectors.collect_gemm_tuning(state), warnings, default={}),
+    )
     # Hot-kernel roofline table (Dashboard §1) from ``<sd>/reports/kernel_roofline.json``.
     kernel_roofline = _pick(
         "kernel_roofline",
@@ -560,6 +566,10 @@ def build(
         "specialist_runs": specialist_runs,
         # Raw KEEP ledger passthrough mirroring ``state.optimization_stack[]``.
         "optimization_stack": optimization_stack,
+        # Fixed FP8 GEMM-tuning stage (KERNEL entry), engine-tagged (geak
+        # today, forge later). Gain mirrored here; ``attribution`` stays
+        # authoritative. Empty {} on non-fp8/sglang or pre-section sessions.
+        "gemm_tuning": gemm_tuning,
         # Hot-kernel roofline table (spec §1); empty → dashboard hides it.
         "kernel_roofline": kernel_roofline,
         # Kernel-agent attempt outcome summary (spec §A1); empty → hides Block 1.

--- a/inference_optimizer/breakdown/schema.py
+++ b/inference_optimizer/breakdown/schema.py
@@ -1428,7 +1428,7 @@ class OptimizationStackEntry(TypedDict, total=False):
 
     Always-present fields: ``action`` / ``variant_name`` /
     ``candidate_extra_server_args`` / ``extra_envs`` / ``tput`` / ``ts`` /
-    ``workspace``. GEMM-tuning entries add ``tuned_file`` /
+    ``workspace``. GEMM-tuning entries add ``engine`` / ``tuned_file`` /
     ``final_report_path`` / ``source``. Other optionals: ``gain_pct`` /
     ``kernel_id`` / ``fingerprint`` / ``provenance`` / ``task_id`` /
     ``validated`` (within the last full-stack rebench).
@@ -1443,6 +1443,8 @@ class OptimizationStackEntry(TypedDict, total=False):
     workspace: str | None
     validated: bool
     # gemm_tuning evidence
+    # Tuning engine provenance: "geak" today; a forge-backed tuner will set "forge".
+    engine: str
     tuned_file: str
     final_report_path: str
     source: str
@@ -1456,6 +1458,92 @@ class OptimizationStackEntry(TypedDict, total=False):
     # explore KEEPs); specialist dial.
     operation_kind: str
     scope: str
+
+
+# GEMM tuning — top-level section for the fixed FP8 block-scale GEMM tuning
+# stage that runs at KERNEL entry. A peer of the source-level kernel rewrite
+# lanes; engine-tagged so the GEAK tuner ("geak") and a future forge-backed
+# tuner ("forge") share one home. Gain is mirrored here (optimization-layer
+# convenience) while ``attribution`` stays the authoritative roll-up.
+class GemmTuningRun(TypedDict, total=False):
+    """One GEMM-tuning run, keyed by the produced ``tuned_file`` CSV.
+
+    A run is a config search over many GEMM shapes (not a single-kernel
+    rewrite); its artifact is a dispatch CSV consumed via the
+    ``AITER_CONFIG_GEMM_A8W8_BLOCKSCALE`` env, not a kernel patch.
+
+    Attributes:
+        engine (str): Tuning engine provenance — ``"geak"`` today; a
+            forge-backed tuner records ``"forge"``.
+        status (str): Tool status (``ok`` / ``complete`` / ``skipped`` / ...).
+        decision (str): ``KEEP`` / ``REVERT``.
+        source (str): What triggered the run (``kernel_entry_auto`` / ...).
+        ts (str): ISO UTC timestamp of the run record.
+        precision (str): Workload precision (``fp8``).
+        framework (str): Serving framework (``sglang``).
+        gpu_type (str): Target GPU (``mi355x`` / ...).
+        tp (int): Tensor-parallel degree (locked workload knob).
+        conc (int): Concurrency (locked workload knob).
+        isl (int): Input sequence length (locked workload knob).
+        osl (int): Output sequence length (locked workload knob).
+        libtype (str): Tuner library family (``ck`` / ``cktile`` / ``all``).
+        baseline_tput (float | None): Pre-tuning throughput reference.
+        best_speedup (float | None): Tuned / baseline throughput ratio.
+        gain_pct (float | None): ``(best_speedup - 1) * 100``; mirrors
+            the optimization-stack KEEP gain for this run.
+        tuned_tput (float | None): ``baseline_tput * best_speedup``.
+        tuned_file (str): Absolute path to the produced dispatch CSV.
+        final_report_path (str): Absolute path to ``final_report.json``.
+        workspace (str): Run workspace directory.
+        adopted (bool): Whether this run's ``tuned_file`` landed as a KEEP
+            in ``optimization_stack``.
+        summary (dict[str, Any]): Tool-reported summary passthrough.
+        shapes (list[dict[str, Any]]): Optional per-shape CSV rows
+            (``M`` / ``N`` / ``K`` / ``libtype`` / ``kernelId`` / ``splitK`` /
+            ``us`` / ``tflops``); empty until a producer emits them.
+    """
+
+    engine: str
+    status: str
+    decision: str
+    source: str
+    ts: str
+    precision: str
+    framework: str
+    gpu_type: str
+    tp: int
+    conc: int
+    isl: int
+    osl: int
+    libtype: str
+    baseline_tput: float | None
+    best_speedup: float | None
+    gain_pct: float | None
+    tuned_tput: float | None
+    tuned_file: str
+    final_report_path: str
+    workspace: str
+    adopted: bool
+    summary: dict[str, Any]
+    shapes: list[dict[str, Any]]
+
+
+class GemmTuning(TypedDict, total=False):
+    """Top-level GEMM-tuning section envelope.
+
+    Attributes:
+        runs (list[GemmTuningRun]): Every GEMM-tuning run this session
+            recorded, newest-last, across engines.
+        adopted_engine (str): Engine of the KEEP that won (``""`` if none).
+        adopted_tuned_file (str): ``tuned_file`` of the adopted KEEP.
+        total_gain_pct (float): Summed gain of adopted runs; mirrors
+            ``attribution.phase_breakdown.gemm_tuning`` for convenience.
+    """
+
+    runs: list[GemmTuningRun]
+    adopted_engine: str
+    adopted_tuned_file: str
+    total_gain_pct: float
 
 
 # Kernel Roofline — hot-kernel table for the dashboard, mirroring
@@ -1829,6 +1917,8 @@ class SessionBreakdown(TypedDict, total=False):
         kb_provenance (KBProvenance): Cortex KB integration audit.
         specialist_runs (list[SpecialistRound]): Specialist sub-agent dispatch records.
         optimization_stack (list[OptimizationStackEntry]): Raw KEEP ledger passthrough.
+        gemm_tuning (GemmTuning): Fixed FP8 GEMM-tuning stage, engine-tagged
+            (geak today, forge later); empty {} on non-fp8/sglang or old sessions.
         kernel_roofline (KernelRoofline): Hot-kernel table for the dashboard.
         roofline (list[dict[str, Any]]): Per-snapshot roofline comparison list for
             the markdown report's ``## Roofline`` section.
@@ -1869,6 +1959,11 @@ class SessionBreakdown(TypedDict, total=False):
     # Raw KEEP ledger passthrough mirroring ``state.optimization_stack[]``
     # with full per-entry evidence; the stack-derived sections summarise it.
     optimization_stack: list["OptimizationStackEntry"]
+    # Fixed FP8 block-scale GEMM-tuning stage (KERNEL entry). Engine-tagged
+    # (geak today, forge later) top-level section; gain mirrored here while
+    # ``attribution`` stays authoritative. Additive optional — empty {} on
+    # non-fp8/sglang sessions and on sessions that predate it.
+    gemm_tuning: GemmTuning
     # Hot-kernel table (spec §1), mirror of ``reports/kernel_roofline.json``.
     kernel_roofline: KernelRoofline
     # Kernel-agent attempt outcome summary (spec §A1); empty → dashboard hides Block 1.

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -2776,8 +2776,10 @@ class Coordinator:
             if isinstance(item, dict) and item.get("action") == "gemm_tuning"
         }
         ts = datetime.now(timezone.utc).isoformat()
+        engine = str(result.get("engine") or "geak")
         entry = {
             "action": "gemm_tuning",
+            "engine": engine,
             "variant_name": "a8w8_blockscale_tuned_gemm",
             "tuned_file": tuned_file,
             "final_report_path": final_report,
@@ -2798,6 +2800,7 @@ class Coordinator:
             )
         self.shared_state.current_best = {
             "action": "gemm_tuning",
+            "engine": engine,
             "tput": tuned_tput,
             "variant_name": "a8w8_blockscale_tuned_gemm",
             "tuned_file": tuned_file,

--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -1300,6 +1300,10 @@ async def run_gemm_tuning_handler(
 
     rc, stdout, stderr = await _run_subprocess(cmd, timeout_sec=_gemm_tuning_timeout_sec(payload))
     result = _shape_tool_result(rc, stdout, stderr)
+    # Tuning engine provenance: this handler drives GEAK's FP8 tuner. A future
+    # forge-backed tuner sets engine="forge" from its own handler; downstream
+    # consumers split tuning stats by this label without restructuring.
+    result.setdefault("engine", "geak")
     result.setdefault("workspace", str(workspace))
     result.setdefault("precision", precision)
     result.setdefault("framework", framework)

--- a/inference_optimizer/tests/test_breakdown_exporter_units.py
+++ b/inference_optimizer/tests/test_breakdown_exporter_units.py
@@ -134,3 +134,80 @@ class TestCollectSpecialistRuns:
         assert len(row["transcripts"]) == 1
         assert row["transcripts"][0]["task_id"] == "abc123"
         assert row["transcripts"][0]["domain"] == "communication"
+
+
+class TestCollectGemmTuning:
+    def test_empty_when_no_attempts(self):
+        assert col.collect_gemm_tuning({}) == {}
+
+    def test_adopted_run_takes_kept_gain_and_engine(self):
+        state = {
+            "baseline_tput": 1000.0,
+            "tp": 1,
+            "conc": 64,
+            "isl": 128,
+            "osl": 128,
+            "precision": "fp8",
+            "framework": "sglang",
+            "gpu_type": "mi355x",
+            "cumulative_gain_validated_stack_len": 1,
+            "gemm_tuning_attempts": [
+                {
+                    "engine": "geak",
+                    "status": "ok",
+                    "decision": "KEEP",
+                    "source": "kernel_entry_auto",
+                    "best_speedup": 1.28,
+                    "tuned_file": "/w/a8w8.csv",
+                    "final_report_path": "/w/final_report.json",
+                    "workspace": "/w",
+                    "ts": "2026-06-19T00:00:00Z",
+                    "summary": {"best_conc": 64},
+                },
+                {
+                    "engine": "geak",
+                    "status": "complete",
+                    "decision": "REVERT",
+                    "best_speedup": 0.98,
+                    "tuned_file": "/w2/a8w8.csv",
+                    "workspace": "/w2",
+                    "ts": "2026-06-19T00:05:00Z",
+                },
+            ],
+            "optimization_stack": [
+                {
+                    "action": "gemm_tuning",
+                    "engine": "geak",
+                    "tuned_file": "/w/a8w8.csv",
+                    "gain_pct": 28.0,
+                    "tput": 1280.0,
+                },
+            ],
+        }
+        out = col.collect_gemm_tuning(state)
+        assert len(out["runs"]) == 2
+        kept, reverted = out["runs"]
+        assert kept["engine"] == "geak"
+        assert kept["adopted"] is True
+        assert kept["gain_pct"] == 28.0
+        assert kept["tuned_tput"] == 1280.0
+        assert kept["conc"] == 64
+        assert kept["summary"] == {"best_conc": 64}
+        assert reverted["adopted"] is False
+        assert reverted["decision"] == "REVERT"
+        assert out["adopted_engine"] == "geak"
+        assert out["adopted_tuned_file"] == "/w/a8w8.csv"
+        assert out["total_gain_pct"] == 28.0
+
+    def test_engine_defaults_to_geak_and_falls_back_to_last(self):
+        state = {
+            "last_gemm_tuning": {
+                "status": "ok",
+                "decision": "KEEP",
+                "best_speedup": 1.1,
+                "tuned_file": "/w/a8w8.csv",
+            },
+        }
+        out = col.collect_gemm_tuning(state)
+        assert len(out["runs"]) == 1
+        assert out["runs"][0]["engine"] == "geak"


### PR DESCRIPTION
## Summary
- Promote the fixed FP8 block-scale GEMM tuning stage (runs at KERNEL entry) to a first-class top-level `gemm_tuning` section in `session_breakdown`, peer to the source-level kernel rewrite lanes instead of only living in `optimization_stack` + `attribution`.
- Tag every run with its tuning `engine` (`geak` today; a future forge-backed tuner sets `forge`) so both engines share one home and stats can be split by engine later without restructuring.
- Mirror optimization gain in the section (per-run `gain_pct` / `best_speedup` / `tuned_tput` + envelope `total_gain_pct`) while `attribution` stays the authoritative roll-up.

## Changes
- `schema.py`: add `GemmTuningRun` / `GemmTuning` TypedDicts and `SessionBreakdown.gemm_tuning`; add `engine` to `OptimizationStackEntry`.
- `collectors.py`: `collect_gemm_tuning(state)` builds runs from `gemm_tuning_attempts` (falls back to `last_gemm_tuning`) and cross-references `optimization_stack` to mark the adopted KEEP and reuse its validated gain.
- `exporter.py`: wire the section next to `optimization_stack`.
- `coordinator.py` / `kernel_request_handlers.py`: stamp `engine="geak"` on the GEMM tuning result, KEEP ledger entry, and `current_best`.

## Compatibility
- Additive optional section: empty `{}` on non-fp8/sglang and pre-section sessions; v1/v2 readers ignore it. No `schema_version` bump (consistent with other additive sections).

## Forge handoff
- A forge tuner only needs its own handler returning `engine="forge"`; the existing record/promote path and `collect_gemm_tuning` fold it into the same `runs[]` and mark `adopted` automatically. Per-shape detail can fill the reserved `shapes` field.

## Test plan
- [x] `pytest inference_optimizer/tests/test_breakdown_exporter_units.py` (new `TestCollectGemmTuning`)
- [x] `pytest inference_optimizer/tests/test_decision_framework.py -k gemm`
- [x] breakdown smoke suite

Made with [Cursor](https://cursor.com)