### PR TITLE
fix(ci): raise DEFAULT_TARGET_GAIN from 100% to 500%

### DIFF
--- a/ci/optimize_submit.py
+++ b/ci/optimize_submit.py
@@ -86,7 +86,7 @@ DEFAULT_GPU_TYPE = "MI300X"
 DEFAULT_GPU_PROFILE = "mi300x"
 DEFAULT_KERNEL_BACKENDS = ["GEAK", "Claude Code", "Codex"]
 DEFAULT_MAX_HOURS = 12.0
-DEFAULT_TARGET_GAIN = 100.0
+DEFAULT_TARGET_GAIN = 500.0
 DEFAULT_RESULTS_PATH = "$RESULT_DIR"
 DEFAULT_CONTEXT_RESERVE_TOKENS = 16
 # Models whose config.json ``max_position_embeddings`` is at or below this are
@@ -3929,7 +3929,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--target-gain",
         type=float,
         default=float(os.environ.get("SAFE_OPTIMIZE_TARGET_GAIN", DEFAULT_TARGET_GAIN)),
-        help="Target gain %% passed to the Hyperloom optimizer prompt (default: 30).",
+        help="Target gain %% passed to the Hyperloom optimizer prompt (default: 500).",
     )
     parser.add_argument(
         "--results-path",


### PR DESCRIPTION
## Summary

- Raise `DEFAULT_TARGET_GAIN` from 100% to 500% in `ci/optimize_submit.py`
- Fix stale help text that incorrectly stated default was 30%

## Background

Analysis of 10 recent sessions (Jun 18-19) showed all sessions stopping immediately after `warm_replay` in PRELUDE phase because the 100% gain target was too easy to reach — `warm_replay` alone delivers 130-360% gain by replaying KB recipes (torch.compile + CUDA graph + triton attention). This caused all sessions to skip explore/kernel/framework_pr/close phases entirely, wasting optimization potential (most sessions were only at 25-60% of roofline ceiling when stopped).

## Impact

With 500% target, sessions will continue into deeper optimization phases after warm_replay, exploring kernel rewrites, GEMM tuning, and framework PRs to push closer to the roofline ceiling.

## Test plan

- [ ] Verify next daily CI run sessions continue past PRELUDE phase
- [ ] Confirm sessions enter explore/kernel phases after warm_replay
- [ ] Monitor that sessions don't hit time_exhausted prematurely (max_hours=12-24h should be sufficient)


Made with [Cursor](https://cursor.com)