### PR TITLE
feat(breakdown): mirror manifest + session breakdown to claw sync root

### DIFF
--- a/inference_optimizer/breakdown/claw_mirror.py
+++ b/inference_optimizer/breakdown/claw_mirror.py
@@ -1,34 +1,53 @@
-"""Mirror ``session_breakdown.json`` into the claw-synced subtree.
+"""Mirror session artifacts into claw-synced storage.
 
-Hyperloom's canonical write lands in ``<session_dir>/`` which under the
-default ``per_model_ts`` layout is ``<workspace>/<model>/<ts>/``. The
-claw sandbox checkpoint sync only watches the ``hyperloom/`` subtree
-under ``$USER_DATA_PATH``, so without an explicit mirror the canonical
-artifact is lost the moment the sandbox is reaped.
+Hyperloom's canonical write lands in ``session_dir`` which, under the
+default ``per_model_ts`` layout, is ``<USER_DATA_PATH>/<model>/<ts>/``.
+In a Primus-Claw sandbox the brain only uploads ``/workspace`` to object
+storage (``syncWorkspaceToS3`` walks ``/workspace`` and maps a file at
+``/workspace/<rel>`` to the S3 key
+``users/<user_id>/sessions/<claw_session_id>/<rel>``), and the session
+collector reads the breakdown straight from the deterministic ROOT key
+``users/<uid>/sessions/<csid>/{manifest,session_breakdown}.json``.
 
-This module exposes a single best-effort helper, kept off ``cli.py`` so
-the unit tests can exercise it without dragging in cli's full import
-graph (``orchestrator/action_executors`` pulls ``fcntl`` and friends
-that aren't available on every dev box).
+Two best-effort mirrors keep that pipeline whole (belt-and-suspenders):
 
-Contract:
+1. :func:`mirror_breakdown_to_claw_storage` — copies the breakdown into
+   ``<workspace_root>/hyperloom/<session_id>/`` (the original
+   ``$USER_DATA_PATH``-relative checkpoint-synced subtree). Kept for
+   backward-compat with consumers that watch that location.
+2. :func:`mirror_session_artifacts_to_claw_storage` — ADDITIONALLY copies
+   ``manifest.json`` + ``session_breakdown.json`` to the claw S3-sync ROOT
+   (``/workspace`` by default), so primus-claw uploads them to the exact
+   root key the collector's cheap MinIO-first lookup reads.
 
-* On success, returns the absolute mirror path.
-* On any failure (empty ``session_id``, missing source, unwritable
-  destination, etc.) returns ``None`` and logs — the caller MUST treat
-  the canonical write as the source of truth and never let a mirror
-  failure mask the real ``stop_reason``.
+Both are best-effort: the canonical weka write under ``session_dir`` is
+the source of truth, and a mirror failure MUST never mask the real
+``stop_reason`` (never raises).
 """
 
 from __future__ import annotations
 
 import logging
+import os
 import shutil
 from pathlib import Path
 
 from ..paths import workspace_root
 
 log = logging.getLogger(__name__)
+
+#: Env var primus-claw can set to point at the dir it syncs to the S3
+#: session-prefix root. Defaults to ``/workspace`` (the path the brain's
+#: ``syncWorkspaceToS3`` hard-codes).
+ENV_CLAW_WORKSPACE = "CLAW_WORKSPACE_PATH"
+ENV_CLAW_SESSION_ID = "CLAW_SESSION_ID"
+DEFAULT_CLAW_WORKSPACE = Path("/workspace")
+
+#: Artifacts mirrored to the sync root. ``manifest.json`` is required by the
+#: collector's MinIO-first locate (it keys on the manifest's
+#: ``claw_session_id`` and derives the weka dir from ``manifest.session_dir``);
+#: ``session_breakdown.json`` is the payload it forwards.
+_MIRRORED_NAMES: tuple[str, ...] = ("manifest.json", "session_breakdown.json")
 
 
 def mirror_breakdown_to_claw_storage(
@@ -38,7 +57,10 @@ def mirror_breakdown_to_claw_storage(
 ) -> Path | None:
     """Copy ``breakdown_path`` to ``<workspace_root>/hyperloom/<sid>/``.
 
-    See module docstring for the full contract. Never raises.
+    The original ``$USER_DATA_PATH``-relative checkpoint-synced mirror.
+    On success returns the absolute mirror path; on any failure (empty
+    ``session_id``, missing source, unwritable destination, etc.) returns
+    ``None`` and logs — never raises.
     """
     sid = (session_id or "").strip()
     if not sid:
@@ -53,3 +75,63 @@ def mirror_breakdown_to_claw_storage(
     except Exception:  # noqa: BLE001
         log.exception("session_breakdown claw-mirror failed (non-fatal)")
         return None
+
+
+def claw_sync_root() -> Path | None:
+    """Dir primus-claw uploads to the S3 session-prefix ROOT, or None.
+
+    None means we're not in a claw sandbox (no ``CLAW_SESSION_ID``) or the
+    configured root doesn't exist on disk -- the caller then skips the
+    root mirror.
+    """
+    if not (os.environ.get(ENV_CLAW_SESSION_ID) or "").strip():
+        return None
+    raw = (os.environ.get(ENV_CLAW_WORKSPACE) or "").strip()
+    root = Path(raw) if raw else DEFAULT_CLAW_WORKSPACE
+    return root if root.is_dir() else None
+
+
+def _copy_atomic(src: Path, dst: Path) -> None:
+    """Copy ``src`` onto ``dst`` via a same-dir temp + ``os.replace`` so a
+    concurrent S3 sync never sees a half-written file at the final name."""
+    tmp = dst.with_name(dst.name + ".tmp")
+    shutil.copy2(src, tmp)
+    os.replace(tmp, dst)
+
+
+def mirror_session_artifacts_to_claw_storage(
+    session_dir: Path | str,
+    *,
+    sync_root: Path | None = None,
+) -> list[Path]:
+    """Copy the session's breakdown + manifest to the claw S3-sync ROOT.
+
+    This is the redundant copy (in addition to
+    :func:`mirror_breakdown_to_claw_storage`) that lands the artifacts at
+    the deterministic root key the collector reads. See the module
+    docstring for the full contract. Never raises.
+
+    ``sync_root`` is resolved via :func:`claw_sync_root` when not given
+    (the production path); tests pass it explicitly.
+    """
+    root = sync_root if sync_root is not None else claw_sync_root()
+    if root is None:
+        return []
+    sd = Path(session_dir)
+    written: list[Path] = []
+    for name in _MIRRORED_NAMES:
+        src = sd / name
+        if not src.is_file():
+            continue
+        try:
+            dst = root / name
+            _copy_atomic(src, dst)
+            written.append(dst)
+        except Exception:  # noqa: BLE001 - mirror failure must stay non-fatal
+            log.exception("claw-mirror of %s failed (non-fatal)", name)
+    if written:
+        log.info(
+            "claw-mirrored %d artifact(s) to %s: %s",
+            len(written), root, ", ".join(p.name for p in written),
+        )
+    return written

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -5036,6 +5036,36 @@ async def _run_optimize(args: argparse.Namespace) -> int:
                 log.exception(
                     "emergency final report write failed (non-fatal)"
                 )
+        # Regardless of who wrote it (CLOSE sequencer or the safety-net
+        # above), mirror the breakdown to claw-synced storage. Two
+        # redundant best-effort copies, both non-fatal:
+        #   1. <workspace_root>/hyperloom/<sid>/ (the original
+        #      $USER_DATA_PATH-relative checkpoint-synced subtree);
+        #   2. the claw S3-sync ROOT (/workspace) with manifest.json +
+        #      session_breakdown.json, so the brain uploads them to the
+        #      deterministic root key the session collector reads
+        #      (users/<uid>/sessions/<csid>/...).
+        # The canonical weka write under session_dir stays the source of
+        # truth; a mirror failure MUST NOT mask the real stop_reason.
+        try:
+            from pathlib import Path as _Path
+            from .breakdown.claw_mirror import (
+                mirror_breakdown_to_claw_storage,
+                mirror_session_artifacts_to_claw_storage,
+            )
+            _sid = getattr(coordinator.shared_state, "session_id", "") or ""
+            mirror_breakdown_to_claw_storage(
+                _Path(session_dir) / "session_breakdown.json",
+                session_id=_sid,
+            )
+            mirrored = mirror_session_artifacts_to_claw_storage(session_dir)
+            if mirrored:
+                print(
+                    "Claw S3 mirror    : "
+                    + ", ".join(str(p) for p in mirrored)
+                )
+        except Exception:  # noqa: BLE001
+            log.exception("claw-mirror finalize failed (non-fatal)")
 
     _reconcile_crash_count(coordinator.shared_state, session_dir)
     # NOTE: conc_sweep used to run here as a post-hook. It is now a

--- a/inference_optimizer/tests/test_cli_breakdown_claw_mirror.py
+++ b/inference_optimizer/tests/test_cli_breakdown_claw_mirror.py
@@ -1,24 +1,21 @@
-"""Unit tests for ``breakdown.claw_mirror.mirror_breakdown_to_claw_storage``.
+"""Unit tests for ``breakdown.claw_mirror``.
 
-The hyperloom CLI writes ``session_breakdown.json`` into ``session_dir``
-(which under the default ``per_model_ts`` layout is
-``<workspace>/<model>/<ts>/``). The claw sandbox checkpoint sync only
-watches the ``hyperloom/`` subtree under ``$USER_DATA_PATH``; without
-the mirror tested here the canonical breakdown is lost when the sandbox
-is reaped, breaking ``claw-stats-service`` historical lookups.
+Hyperloom writes ``session_breakdown.json`` + ``manifest.json`` into
+``session_dir`` (which under the default ``per_model_ts`` layout is
+``<USER_DATA_PATH>/<model>/<ts>/``). Two best-effort mirrors keep the
+claw pipeline whole:
 
-The mirror lives in its own module (rather than as a private helper on
-``cli.py``) precisely so this test file can import it without dragging
-in cli's ``orchestrator/action_executors`` graph (which imports
-``fcntl`` and other POSIX-only modules).
+1. :func:`mirror_breakdown_to_claw_storage` copies the breakdown to
+   ``<workspace_root>/hyperloom/<sid>/`` (the original
+   ``$USER_DATA_PATH``-relative checkpoint-synced subtree).
+2. :func:`mirror_session_artifacts_to_claw_storage` ADDITIONALLY copies
+   ``manifest.json`` + ``session_breakdown.json`` to the claw S3-sync ROOT
+   (``/workspace``), so primus-claw uploads them to the deterministic root
+   key the collector reads
+   (``users/<uid>/sessions/<csid>/{manifest,session_breakdown}.json``).
 
-These tests exercise the mirror helper in isolation:
-
-* happy-path mirror lands at ``<workspace_root>/hyperloom/<sid>/...``;
-* empty ``session_id`` is a no-op (warns, returns ``None``);
-* unreadable source / unwritable dest is a no-op (logs, returns ``None``)
-  — the canonical write path is the source of truth and MUST NOT be
-  broken by mirror failures.
+The mirrors live in their own module so this file needn't drag in cli's
+``orchestrator/action_executors`` graph (which imports POSIX-only modules).
 """
 
 from __future__ import annotations
@@ -29,9 +26,18 @@ from pathlib import Path
 import pytest
 
 from inference_optimizer.breakdown.claw_mirror import (
+    ENV_CLAW_SESSION_ID,
+    ENV_CLAW_WORKSPACE,
+    claw_sync_root,
     mirror_breakdown_to_claw_storage,
+    mirror_session_artifacts_to_claw_storage,
 )
 from inference_optimizer.paths import ENV_USER_DATA_PATH
+
+
+# ---------------------------------------------------------------------------
+# 1. Original USER_DATA_PATH/hyperloom/<sid> mirror
+# ---------------------------------------------------------------------------
 
 
 @pytest.fixture
@@ -43,8 +49,6 @@ def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 
 def _make_breakdown(session_dir: Path, payload: dict | None = None) -> Path:
-    """Drop a minimal ``session_breakdown.json`` under a per-model-ts
-    subdir of the workspace, mimicking hyperloom's canonical layout."""
     session_dir.mkdir(parents=True, exist_ok=True)
     bp = session_dir / "session_breakdown.json"
     bp.write_text(
@@ -55,74 +59,127 @@ def _make_breakdown(session_dir: Path, payload: dict | None = None) -> Path:
 
 
 def test_mirrors_to_workspace_hyperloom_subtree(workspace: Path) -> None:
-    """Happy path: copy lands at ``hyperloom/<sid>/session_breakdown.json``
-    with identical bytes — that's the path the claw sync watches."""
     sid = "abc123"
     canonical = _make_breakdown(
         workspace / "Llama-3.1-8B" / "20260525T040000Z",
         payload={"schema_version": "1.1.0", "session": {"session_id": sid}},
     )
-
     mirror = mirror_breakdown_to_claw_storage(canonical, session_id=sid)
-
     expected = workspace / "hyperloom" / sid / "session_breakdown.json"
     assert mirror == expected
     assert mirror.is_file()
     assert mirror.read_bytes() == canonical.read_bytes()
 
 
-def test_empty_session_id_is_noop(
-    workspace: Path,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Empty/whitespace ``session_id`` would collapse the mirror dir into
-    ``hyperloom/`` itself, which is wrong; the helper must bail out and
-    leave the canonical file untouched."""
+def test_empty_session_id_is_noop(workspace: Path, caplog) -> None:
     canonical = _make_breakdown(workspace / "model" / "ts")
-
     with caplog.at_level("WARNING"):
         result = mirror_breakdown_to_claw_storage(canonical, session_id="")
-
     assert result is None
     assert not (workspace / "hyperloom").exists()
     assert any("empty session_id" in r.message for r in caplog.records)
 
 
-def test_missing_source_is_swallowed(
-    workspace: Path,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """If the canonical write didn't actually produce a file (caller
-    bug, disk full, etc.) the mirror must log + return ``None`` rather
-    than raise — the finally block in ``_run_optimize`` relies on this
-    to keep ``stop_reason`` propagation intact."""
+def test_missing_source_is_swallowed(workspace: Path, caplog) -> None:
     bogus = workspace / "model" / "ts" / "session_breakdown.json"
-
     with caplog.at_level("ERROR"):
         result = mirror_breakdown_to_claw_storage(bogus, session_id="sid42")
-
     assert result is None
     assert any("claw-mirror failed" in r.message for r in caplog.records)
 
 
 def test_overwrites_existing_mirror(workspace: Path) -> None:
-    """Repeat runs with the same session_id (e.g. ``--resume``) must
-    overwrite the previous mirror — otherwise downstream consumers
-    would see a stale early snapshot."""
     sid = "resumed-sid"
     canonical = _make_breakdown(
         workspace / "m" / "ts1",
         payload={"schema_version": "1.1.0", "session": {"tick": 1}},
     )
     mirror_breakdown_to_claw_storage(canonical, session_id=sid)
-
-    # Second run, same sid, fresher payload.
     canonical2 = _make_breakdown(
         workspace / "m" / "ts2",
         payload={"schema_version": "1.1.0", "session": {"tick": 99}},
     )
     mirror = mirror_breakdown_to_claw_storage(canonical2, session_id=sid)
-
     assert mirror is not None
     payload = json.loads(mirror.read_text(encoding="utf-8"))
     assert payload["session"]["tick"] == 99
+
+
+# ---------------------------------------------------------------------------
+# 2. Redundant claw S3-sync ROOT mirror (manifest + breakdown)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sandbox(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Path]:
+    """Simulate a claw sandbox: a ``/workspace`` sync root + a session dir
+    OUTSIDE it (mimicking USER_DATA_PATH on a separate wekafs mount)."""
+    sync_root = tmp_path / "workspace"
+    sync_root.mkdir()
+    session_dir = tmp_path / "wekafs" / "users" / "u1" / "model" / "ts"
+    session_dir.mkdir(parents=True)
+    monkeypatch.setenv(ENV_CLAW_SESSION_ID, "csid-1")
+    monkeypatch.setenv(ENV_CLAW_WORKSPACE, str(sync_root))
+    return {"sync_root": sync_root, "session_dir": session_dir}
+
+
+def _seed(session_dir: Path, *, breakdown: dict | None = None, manifest: dict | None = None) -> None:
+    if breakdown is not None:
+        (session_dir / "session_breakdown.json").write_text(
+            json.dumps(breakdown), encoding="utf-8"
+        )
+    if manifest is not None:
+        (session_dir / "manifest.json").write_text(
+            json.dumps(manifest), encoding="utf-8"
+        )
+
+
+def test_root_mirror_breakdown_and_manifest(sandbox) -> None:
+    sd, root = sandbox["session_dir"], sandbox["sync_root"]
+    _seed(
+        sd,
+        breakdown={"schema_version": "1.1.0", "session": {"session_id": "s"}},
+        manifest={"claw_session_id": "csid-1", "session_id": "s"},
+    )
+    written = mirror_session_artifacts_to_claw_storage(sd)
+    assert sorted(p.name for p in written) == ["manifest.json", "session_breakdown.json"]
+    assert (root / "session_breakdown.json").is_file()
+    assert (root / "manifest.json").is_file()
+    assert (root / "session_breakdown.json").read_bytes() == (
+        sd / "session_breakdown.json"
+    ).read_bytes()
+
+
+def test_root_mirror_noop_outside_claw_sandbox(sandbox, monkeypatch) -> None:
+    monkeypatch.delenv(ENV_CLAW_SESSION_ID, raising=False)
+    _seed(sandbox["session_dir"], breakdown={"x": 1}, manifest={"y": 2})
+    assert claw_sync_root() is None
+    assert mirror_session_artifacts_to_claw_storage(sandbox["session_dir"]) == []
+    assert not (sandbox["sync_root"] / "session_breakdown.json").exists()
+
+
+def test_root_mirror_noop_when_sync_root_missing(sandbox, monkeypatch) -> None:
+    monkeypatch.setenv(ENV_CLAW_WORKSPACE, str(sandbox["sync_root"] / "nope"))
+    _seed(sandbox["session_dir"], breakdown={"x": 1})
+    assert claw_sync_root() is None
+    assert mirror_session_artifacts_to_claw_storage(sandbox["session_dir"]) == []
+
+
+def test_root_mirror_skips_missing_source_files(sandbox) -> None:
+    _seed(sandbox["session_dir"], breakdown={"only": "breakdown"})
+    written = mirror_session_artifacts_to_claw_storage(sandbox["session_dir"])
+    assert [p.name for p in written] == ["session_breakdown.json"]
+
+
+def test_root_mirror_nothing_to_mirror_returns_empty(sandbox) -> None:
+    assert mirror_session_artifacts_to_claw_storage(sandbox["session_dir"]) == []
+
+
+def test_root_mirror_overwrites_with_freshest(sandbox) -> None:
+    sd, root = sandbox["session_dir"], sandbox["sync_root"]
+    _seed(sd, breakdown={"tick": 1})
+    mirror_session_artifacts_to_claw_storage(sd)
+    _seed(sd, breakdown={"tick": 99})
+    mirror_session_artifacts_to_claw_storage(sd)
+    payload = json.loads((root / "session_breakdown.json").read_text(encoding="utf-8"))
+    assert payload["tick"] == 99


### PR DESCRIPTION
## Summary

The session collector discovers a run's artifacts **MinIO-first**, under the key prefix that primus-claw syncs from its workspace root (typically `/workspace`). Previously hyperloom only mirrored `session_breakdown.json` into the `USER_DATA_PATH/hyperloom/<sid>` subtree, which is **not** part of the brain-synced workspace subtree. As a result the collector's MinIO-first lookup missed the artifacts and had to fall back to WekaFS.

This PR adds a redundant mirror so the breakdown artifacts reliably land in **both** places.

## Changes

- Keep the existing `mirror_breakdown_to_claw_storage()` copy into `USER_DATA_PATH/hyperloom/<sid>` (unchanged source-of-truth behaviour).
- Add `mirror_session_artifacts_to_claw_storage()` which copies **both** `manifest.json` and `session_breakdown.json` into the claw sync root (`CLAW_WORKSPACE_PATH`, default `/workspace`), so the snapshot the collector reads is complete and self-describing (the manifest carries `claw_session_id`).
- Invoke both mirrors from the CLI `finally` block so they run once at end-of-run regardless of how optimization exits.
- Mirroring is **best-effort and non-fatal**: WekaFS under `USER_DATA_PATH` remains the source of truth, and any copy failure is logged rather than raised.

## Test plan

- [x] `inference_optimizer/tests/test_cli_breakdown_claw_mirror.py` covers both mirrors: success, no-op outside the sandbox, missing files, and overwrite.
- [ ] End-to-end: run a hyperloom marathon and confirm the collector resolves the breakdown MinIO-first (no WekaFS fallback) and the global service shows the breakdown.

Made with [Cursor](https://cursor.com)