### PR TITLE
Emit session breakdown to Langfuse on pre-flight fail-fast

### DIFF
--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -3220,6 +3220,16 @@ async def _run_optimize(args: argparse.Namespace) -> int:
         # published for the robustness monitor.
         session_lock = _acquire_session_lock_or_exit(session_dir)
         manifest = write_manifest(session_dir, args=args)
+        # One-shot Langfuse startup marker: ties the WekaFS user dir + session
+        # dir to code_revision/dependency commits the moment the session is
+        # created, so a run that aborts in pre-flight or is killed before a
+        # breakdown still leaves a correlatable trace. Best-effort, never fatal.
+        try:
+            from .orchestrator.trace.langfuse_emitter import record_session_start
+
+            record_session_start(session_dir)
+        except Exception:  # noqa: BLE001 — startup marker must never break launch
+            log.debug("langfuse record_session_start failed (non-fatal)", exc_info=True)
         print(f"Session dir     : {session_dir}")
         print(f"Session id      : {manifest['session_id']}  (manifest label only)")
         _print_session_skeleton(session_dir)

--- a/inference_optimizer/cli_model_gate.py
+++ b/inference_optimizer/cli_model_gate.py
@@ -1246,6 +1246,44 @@ def _resolve_max_model_len(isl: int, osl: int, model_path: str) -> int:
         return min(desired, maxpos)
     return desired
 
+def _emit_breakdown_to_langfuse(session_dir: Path) -> None:
+    """Best-effort: push the just-written ``session_breakdown.json`` to Langfuse.
+
+    The pre-flight gates below fail-fast *before* ``coordinator.run()``'s
+    ``finally`` — the one place a normal session flushes Langfuse and attaches
+    the breakdown document. Without this, an early-aborted session writes
+    ``session_breakdown.json`` to disk (so the on-disk collector path still
+    forwards it downstream) but never emits the trace/observation to Langfuse,
+    leaving the session absent from Langfuse entirely. Mirror ``cli``'s
+    end-of-session order (flush -> patch -> record) so the attached document
+    carries the post-flush receipt counts.
+
+    No-op unless ``HYPERLOOM_LANGFUSE_ENABLE`` + the ``LANGFUSE_*`` connection
+    vars are set; never raises (a Langfuse outage must not mask the stop
+    reason). Call only *after* ``write_breakdown_json`` has run.
+
+    Args:
+        session_dir (Path): The session root directory whose breakdown is
+            pushed to Langfuse.
+    """
+    try:
+        from .breakdown import patch_breakdown_langfuse
+        from .orchestrator.trace.langfuse_emitter import (
+            flush_session,
+            record_session_breakdown,
+        )
+
+        flush_session(session_dir)
+        patch_breakdown_langfuse(session_dir)
+        record_session_breakdown(session_dir)
+    except Exception as exc:  # noqa: BLE001 — best-effort; never mask the reason
+        print(
+            f"WARNING: failed to emit session_breakdown to Langfuse on "
+            f"fail-fast: {exc!r}",
+            file=sys.stderr,
+        )
+
+
 def _preflight_context_window(args: argparse.Namespace, session_dir: Path) -> bool:
     """Fail fast when ``max_position_embeddings < ISL+OSL+headroom`` (no --context-length stretch by policy).
 
@@ -1320,6 +1358,10 @@ def _preflight_context_window(args: argparse.Namespace, session_dir: Path) -> bo
             f"fail-fast: {exc!r}",
             file=sys.stderr,
         )
+    # Langfuse parity: this gate exits before coordinator.run()'s finally, so
+    # push the breakdown to Langfuse here too (else the session is on disk for
+    # the collector but missing from Langfuse).
+    _emit_breakdown_to_langfuse(session_dir)
     print(f"ERROR: {reason}", file=sys.stderr)
     return True
 
@@ -1389,6 +1431,10 @@ def _preflight_model_config_compat(
             f"fail-fast: {exc!r}",
             file=sys.stderr,
         )
+    # Langfuse parity: this gate exits before coordinator.run()'s finally, so
+    # push the breakdown to Langfuse here too (else the session is on disk for
+    # the collector but missing from Langfuse).
+    _emit_breakdown_to_langfuse(session_dir)
     print(f"ERROR: {reason}", file=sys.stderr)
     return True
 
@@ -1507,5 +1553,9 @@ def _preflight_unsupported_model_arch(
             f"model fail-fast: {exc!r}",
             file=sys.stderr,
         )
+    # Langfuse parity: this gate exits before coordinator.run()'s finally, so
+    # push the breakdown to Langfuse here too (else the session is on disk for
+    # the collector but missing from Langfuse).
+    _emit_breakdown_to_langfuse(session_dir)
     print(f"ERROR: {reason}", file=sys.stderr)
     return True

--- a/inference_optimizer/orchestrator/trace/langfuse_emitter.py
+++ b/inference_optimizer/orchestrator/trace/langfuse_emitter.py
@@ -384,6 +384,7 @@ class LangfuseEmitter:
             "generations_paired": 0,  # of which had both token + text halves
             "generations_text_only": 0,
             "generations_token_only": 0,
+            "session_start_recorded": 0,  # 1 once the startup marker was sent
             "scores_sent": 0,  # decision Scores created (span + trace)
             "spans_opened": 0,  # phase + agent spans created
             "ext_shards_read": 0,  # out-of-process ext/*.jsonl files swept
@@ -731,6 +732,73 @@ class LangfuseEmitter:
                 self._counts["errors"] += 1
                 log.debug("langfuse: client.flush failed", exc_info=True)
             self._flushed = True
+            self._write_receipt()
+
+    def record_session_start(self) -> None:
+        """Emit a one-shot ``session_start`` marker the moment a session begins.
+
+        Attached directly to the session's ``trace_id`` (independent of the
+        lazy root span and of any LLM traffic), so a run that aborts in
+        pre-flight or is killed before producing a breakdown still leaves a
+        Langfuse trace tying the WekaFS user dir + session dir to its
+        ``code_revision`` and dependency commits. Idempotent (cross-process via
+        the persisted receipt) and best-effort (never raises).
+        """
+        if not self._enabled:
+            return
+        if self._counts.get("session_start_recorded"):
+            return
+        # Cross-process guard mirrors record_session_breakdown: a prior process
+        # (original run or a `recover-session`) may have already marked start.
+        persisted = read_receipt(self.session_dir) or {}
+        if (persisted.get("counts") or {}).get("session_start_recorded"):
+            self._counts["session_start_recorded"] = 1
+            return
+        import os
+
+        payload = lfmap.session_start_payload(
+            self._manifest,
+            user_data_path=(os.environ.get("USER_DATA_PATH") or "").strip() or None,
+            env=os.environ,
+        )
+        try:
+            obs = _start_obs(
+                self._client,
+                name="session_start",
+                as_type="span",
+                trace_context={"trace_id": self._trace_id},
+                input=None,
+                output=payload,
+                metadata={
+                    "claw_session_id": payload.get("claw_session_id"),
+                    "sandbox_user_id": payload.get("sandbox_user_id"),
+                    "code_revision": payload.get("code_revision"),
+                    "session_dir": payload.get("session_dir"),
+                    "user_data_path": payload.get("user_data_path"),
+                    "host": payload.get("host"),
+                    "image": payload.get("image"),
+                },
+            )
+            # Stamp trace name/session_id so the trace is grouped and visible
+            # from the very first observation, even with no LLM calls.
+            _set_trace_attrs(
+                obs,
+                name=self._trace_name(),
+                session_id=self._session_label,
+                metadata=lfmap.trace_metadata(self._manifest),
+            )
+            _end_obs(obs, None)
+            self._counts["session_start_recorded"] = 1
+        except Exception:  # noqa: BLE001
+            self._counts["errors"] += 1
+            log.debug("langfuse: record_session_start failed", exc_info=True)
+        finally:
+            try:
+                self._client.flush()
+            except Exception:  # noqa: BLE001
+                self._counts["errors"] += 1
+                log.debug("langfuse: flush after session_start failed", exc_info=True)
+            # Persist the flag so a later process (recovery) skips re-emitting.
             self._write_receipt()
 
     def record_session_breakdown(self, breakdown: dict[str, Any]) -> None:
@@ -1191,6 +1259,19 @@ def get_emitter(session_dir: Path) -> LangfuseEmitter:
             emitter = LangfuseEmitter(Path(session_dir))
             _REGISTRY[key] = emitter
         return emitter
+
+
+def record_session_start(session_dir: Path) -> None:
+    """Module-level convenience: emit the startup marker for ``session_dir``.
+
+    Call once right after ``manifest.json`` is written, before any heavy
+    bring-up / pre-flight, so the session's Langfuse trace exists from the
+    start. No-op when live push is disabled; best-effort (never raises).
+
+    Args:
+        session_dir: Session directory whose startup marker is emitted.
+    """
+    get_emitter(session_dir).record_session_start()
 
 
 def flush_session(session_dir: Path) -> None:

--- a/inference_optimizer/orchestrator/trace/langfuse_emitter.py
+++ b/inference_optimizer/orchestrator/trace/langfuse_emitter.py
@@ -47,6 +47,7 @@ from .trace_env import (
     ENV_LANGFUSE_HOST,
     ENV_LANGFUSE_PUBLIC_KEY,
     ENV_LANGFUSE_SECRET_KEY,
+    apply_flush_defaults,
     langfuse_credentials,
     langfuse_credentials_complete,
     langfuse_live_enabled,
@@ -431,6 +432,10 @@ class LangfuseEmitter:
             )
             return False
         try:
+            # Tighten the SDK auto-flush cadence before the singleton is built
+            # so a session killed before cli.finally still lands its latest
+            # observations (marking where the run died).
+            apply_flush_defaults()
             creds = langfuse_credentials()
             self._client = get_client()
             log.info(

--- a/inference_optimizer/orchestrator/trace/langfuse_mapping.py
+++ b/inference_optimizer/orchestrator/trace/langfuse_mapping.py
@@ -23,11 +23,34 @@ it only reshapes dicts and parses timestamps.
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
 UNPHASED = "(unphased)"
 UNKNOWN_AGENT = "(unknown)"
+
+# Env-var name fragments whose *value* is redacted before the environment
+# snapshot is attached to the session_start marker. The key name is kept (so
+# you still see the variable existed), but the secret value never leaves the
+# sandbox. Matched case-insensitively as a substring.
+_SENSITIVE_ENV_MARKERS: tuple[str, ...] = (
+    "SECRET",
+    "TOKEN",
+    "PASSWORD",
+    "PASSWD",
+    "PASSPHRASE",
+    "CREDENTIAL",
+    "PRIVATE_KEY",
+    "PRIVATEKEY",
+    "API_KEY",
+    "APIKEY",
+    "ACCESS_KEY",
+    "SECRET_KEY",
+    "AUTH",
+    "SIGNATURE",
+)
+_REDACTED = "***redacted***"
 
 
 def correlation_seed(manifest: dict[str, Any], fallback: str) -> str:
@@ -311,6 +334,62 @@ def trace_metadata(manifest: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def redact_env(environ: Mapping[str, str]) -> dict[str, str]:
+    """Snapshot the process environment with secret values redacted.
+
+    Keeps every variable name (so debuggers can see what was set) but replaces
+    the value of anything whose name looks like a credential (see
+    :data:`_SENSITIVE_ENV_MARKERS`) with a placeholder, so the session_start
+    marker never ships secrets to Langfuse.
+
+    Args:
+        environ: The process environment mapping (e.g. ``os.environ``).
+
+    Returns:
+        A plain dict copy with sensitive values redacted.
+    """
+    out: dict[str, str] = {}
+    for key, value in environ.items():
+        upper = key.upper()
+        if any(marker in upper for marker in _SENSITIVE_ENV_MARKERS):
+            out[key] = _REDACTED
+        else:
+            out[key] = value
+    return out
+
+
+def session_start_payload(
+    manifest: dict[str, Any],
+    *,
+    user_data_path: str | None = None,
+    env: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Assemble the one-shot session-start document.
+
+    Carries the *entire* ``manifest.json`` (identity, provenance, workload,
+    dependency commits, stack fingerprint, host/image/pid, ...) plus the
+    WekaFS user-data root and a redacted environment snapshot, so a run that
+    aborts in pre-flight or is killed before producing a breakdown still leaves
+    a fully self-describing Langfuse trace.
+
+    Args:
+        manifest: Parsed ``manifest.json`` dict (copied verbatim into the
+            payload).
+        user_data_path: WekaFS user-data root (the ``USER_DATA_PATH`` env),
+            passed in by the caller so this stays free of env coupling.
+        env: Process environment to snapshot; redacted via :func:`redact_env`.
+            Omitted from the payload when ``None``.
+
+    Returns:
+        JSON-serializable startup document.
+    """
+    payload: dict[str, Any] = dict(manifest or {})
+    payload["user_data_path"] = user_data_path or None
+    if env is not None:
+        payload["env"] = redact_env(env)
+    return payload
+
+
 def decision_to_scores(decision_row: dict[str, Any]) -> list[dict[str, Any]]:
     """Project one ``decision_trace.jsonl`` row onto zero or more Score dicts.
 
@@ -437,6 +516,8 @@ __all__ = [
     "pair_key",
     "parse_ts",
     "phase_of",
+    "redact_env",
+    "session_start_payload",
     "span_key",
     "trace_metadata",
     "usage_details",

--- a/inference_optimizer/orchestrator/trace/trace_env.py
+++ b/inference_optimizer/orchestrator/trace/trace_env.py
@@ -24,6 +24,18 @@ ENV_LANGFUSE_HOST = "LANGFUSE_HOST"
 ENV_LANGFUSE_PUBLIC_KEY = "LANGFUSE_PUBLIC_KEY"
 ENV_LANGFUSE_SECRET_KEY = "LANGFUSE_SECRET_KEY"
 
+# SDK batch-flush cadence (official langfuse SDK variable names). The SDK
+# background thread already auto-flushes, but its stock 5s interval means a
+# session that is hard-killed before ``cli.finally`` loses up to the last 5s of
+# observations. Hyperloom sessions run for hours and can be preempted, so we
+# tighten the interval to 1s by default: whatever is in the queue lands within
+# ~1s, and the last observation that made it to Langfuse marks where the run
+# died. ``flush_at`` is left at the SDK default (512) so steady-state traffic
+# still batches normally and we do not issue one HTTP request per observation.
+ENV_LANGFUSE_FLUSH_INTERVAL = "LANGFUSE_FLUSH_INTERVAL"
+ENV_LANGFUSE_FLUSH_AT = "LANGFUSE_FLUSH_AT"
+_DEFAULT_FLUSH_INTERVAL = "1"
+
 _TRUE_TOKENS: frozenset[str] = frozenset({"1", "true", "yes", "on"})
 _FALSE_TOKENS: frozenset[str] = frozenset({"0", "false", "no", "off"})
 
@@ -87,11 +99,25 @@ def langfuse_credentials_complete() -> bool:
     return len(langfuse_credentials()) == 3
 
 
+def apply_flush_defaults() -> None:
+    """Seed the SDK's auto-flush cadence before the client is built.
+
+    Must run before the first ``get_client()`` call, since the langfuse SDK
+    reads ``LANGFUSE_FLUSH_INTERVAL`` / ``LANGFUSE_FLUSH_AT`` only when it lazily
+    constructs the singleton client. Uses ``setdefault`` so an operator-supplied
+    value always wins; we only supply a tighter default when nothing is set.
+    """
+    os.environ.setdefault(ENV_LANGFUSE_FLUSH_INTERVAL, _DEFAULT_FLUSH_INTERVAL)
+
+
 __all__ = [
     "ENV_LANGFUSE_ENABLE",
+    "ENV_LANGFUSE_FLUSH_AT",
+    "ENV_LANGFUSE_FLUSH_INTERVAL",
     "ENV_LANGFUSE_HOST",
     "ENV_LANGFUSE_PUBLIC_KEY",
     "ENV_LANGFUSE_SECRET_KEY",
+    "apply_flush_defaults",
     "env_flag",
     "langfuse_credentials",
     "langfuse_credentials_complete",

--- a/inference_optimizer/tests/test_langfuse_emitter.py
+++ b/inference_optimizer/tests/test_langfuse_emitter.py
@@ -214,6 +214,35 @@ def test_all_gates_pass_enables(tmp_path, monkeypatch):
     assert em._session_label == "claw-XYZ"
 
 
+def test_enabling_seeds_default_flush_interval(tmp_path, monkeypatch):
+    # When the operator has not pinned a flush cadence, building the client
+    # tightens the SDK auto-flush interval so a killed run still lands its
+    # latest observations.
+    _enable_env(monkeypatch)
+    monkeypatch.delenv("LANGFUSE_FLUSH_INTERVAL", raising=False)
+    monkeypatch.delenv("LANGFUSE_FLUSH_AT", raising=False)
+    client = _FakeClient()
+    _install_fake_sdk(monkeypatch, client)
+    em = lfe.LangfuseEmitter(tmp_path / "SID")
+    assert em.enabled is True
+    import os
+
+    assert os.environ["LANGFUSE_FLUSH_INTERVAL"] == "1"
+    # flush_at is intentionally left to the SDK default (no per-event HTTP).
+    assert "LANGFUSE_FLUSH_AT" not in os.environ
+
+
+def test_operator_flush_interval_is_respected(tmp_path, monkeypatch):
+    _enable_env(monkeypatch)
+    monkeypatch.setenv("LANGFUSE_FLUSH_INTERVAL", "10")
+    client = _FakeClient()
+    _install_fake_sdk(monkeypatch, client)
+    lfe.LangfuseEmitter(tmp_path / "SID")
+    import os
+
+    assert os.environ["LANGFUSE_FLUSH_INTERVAL"] == "10"
+
+
 def test_trace_id_falls_back_to_internal_id_without_claw(tmp_path, monkeypatch):
     _enable_env(monkeypatch)
     client = _FakeClient()

--- a/inference_optimizer/tests/test_langfuse_emitter.py
+++ b/inference_optimizer/tests/test_langfuse_emitter.py
@@ -243,6 +243,109 @@ def test_operator_flush_interval_is_respected(tmp_path, monkeypatch):
     assert os.environ["LANGFUSE_FLUSH_INTERVAL"] == "10"
 
 
+def test_session_start_emits_marker_with_provenance(tmp_path, monkeypatch):
+    _enable_env(monkeypatch)
+    monkeypatch.setenv("USER_DATA_PATH", "/weka/users/alice")
+    client = _FakeClient()
+    _install_fake_sdk(monkeypatch, client)
+    monkeypatch.setenv("HYPERLOOM_CUSTOM_FLAG", "on")
+    monkeypatch.setenv("MY_API_TOKEN", "super-secret-value")
+    sd = tmp_path / "SID"
+    sd.mkdir(parents=True, exist_ok=True)
+    (sd / "manifest.json").write_text(
+        json.dumps(
+            {
+                "session_id": "SID",
+                "model_name": "TestModel",
+                "claw_session_id": "claw-XYZ",
+                "sandbox_user_id": "alice",
+                "code_revision": "abc1234",
+                "session_dir": str(sd),
+                "host": "node-7",
+                "image": "registry/hyperloom:tag",
+                "pid": 4242,
+                "stack_fingerprint": {"rocm": "6.2", "vllm": "0.6"},
+                "workload": {"isl": 128, "osl": 256},
+                "dependencies": {"magpie": {"path": "/weka/magpie", "commit": "deadbee"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    em = lfe.LangfuseEmitter(sd)
+    em.record_session_start()
+
+    marker = client.span_named("session_start")
+    assert marker is not None
+    out = marker.kwargs.get("output") or {}
+    # The full manifest is carried verbatim.
+    assert out["claw_session_id"] == "claw-XYZ"
+    assert out["sandbox_user_id"] == "alice"
+    assert out["code_revision"] == "abc1234"
+    assert out["session_dir"] == str(sd)
+    assert out["host"] == "node-7"
+    assert out["image"] == "registry/hyperloom:tag"
+    assert out["pid"] == 4242
+    assert out["stack_fingerprint"] == {"rocm": "6.2", "vllm": "0.6"}
+    assert out["workload"] == {"isl": 128, "osl": 256}
+    assert out["dependencies"]["magpie"]["commit"] == "deadbee"
+    assert out["user_data_path"] == "/weka/users/alice"
+    # Environment snapshot is attached, with secret-looking values redacted.
+    env = out["env"]
+    assert env["HYPERLOOM_CUSTOM_FLAG"] == "on"
+    assert env["USER_DATA_PATH"] == "/weka/users/alice"
+    assert env["MY_API_TOKEN"] == "***redacted***"
+    assert env["LANGFUSE_SECRET_KEY"] == "***redacted***"
+    # Scalar correlation keys also land on the observation metadata.
+    meta = marker.kwargs.get("metadata") or {}
+    assert meta["code_revision"] == "abc1234"
+    assert meta["user_data_path"] == "/weka/users/alice"
+    # Trace is grouped on the claw session id from the first observation.
+    assert marker.trace_update is not None
+    assert marker.trace_update["session_id"] == "claw-XYZ"
+    assert client.flushed >= 1
+
+
+def test_redact_env_keeps_names_redacts_secret_values():
+    snap = lfmap.redact_env(
+        {
+            "PATH": "/usr/bin",
+            "HF_TOKEN": "hf_xxx",
+            "AWS_SECRET_ACCESS_KEY": "abc",
+            "DB_PASSWORD": "pw",
+            "PLAIN": "value",
+        }
+    )
+    assert snap["PATH"] == "/usr/bin"
+    assert snap["PLAIN"] == "value"
+    assert snap["HF_TOKEN"] == "***redacted***"
+    assert snap["AWS_SECRET_ACCESS_KEY"] == "***redacted***"
+    assert snap["DB_PASSWORD"] == "***redacted***"
+
+
+def test_session_start_is_idempotent(tmp_path, monkeypatch):
+    _enable_env(monkeypatch)
+    client = _FakeClient()
+    _install_fake_sdk(monkeypatch, client)
+    sd = tmp_path / "SID"
+    _write_manifest(sd, claw_session_id="claw-XYZ")
+    em = lfe.LangfuseEmitter(sd)
+    em.record_session_start()
+    em.record_session_start()
+    assert len([s for s in client.spans if s.kwargs.get("name") == "session_start"]) == 1
+
+
+def test_session_start_noop_when_disabled(tmp_path, monkeypatch):
+    monkeypatch.delenv("HYPERLOOM_LANGFUSE_ENABLE", raising=False)
+    client = _FakeClient()
+    _install_fake_sdk(monkeypatch, client)
+    sd = tmp_path / "SID"
+    _write_manifest(sd)
+    em = lfe.LangfuseEmitter(sd)
+    assert em.enabled is False
+    em.record_session_start()
+    assert client.span_named("session_start") is None
+
+
 def test_trace_id_falls_back_to_internal_id_without_claw(tmp_path, monkeypatch):
     _enable_env(monkeypatch)
     client = _FakeClient()

--- a/inference_optimizer/tests/test_model_config_compat_preflight.py
+++ b/inference_optimizer/tests/test_model_config_compat_preflight.py
@@ -976,6 +976,107 @@ def test_gguf_with_pytorch_model_bin_not_blocked(tmp_path):
     assert cli._detect_incompatible_model_config(str(m)) is None
 
 
+# ---------------------------------------------------------------------------
+# Langfuse parity on fail-fast — the pre-flight gates exit before
+# coordinator.run()'s finally (the normal Langfuse flush point), so each must
+# push the breakdown to Langfuse itself or early-aborted sessions land on disk
+# (collector) but never in Langfuse.
+# ---------------------------------------------------------------------------
+def _spy_langfuse_emit(monkeypatch) -> dict[str, list]:
+    calls: dict[str, list] = {"flush": [], "patch": [], "record": []}
+    from inference_optimizer import breakdown as bd
+    from inference_optimizer.orchestrator.trace import langfuse_emitter as lfe
+
+    monkeypatch.setattr(
+        lfe, "flush_session", lambda sd: calls["flush"].append(Path(sd))
+    )
+    monkeypatch.setattr(
+        bd, "patch_breakdown_langfuse", lambda sd: calls["patch"].append(Path(sd))
+    )
+    monkeypatch.setattr(
+        lfe,
+        "record_session_breakdown",
+        lambda sd, *a, **k: calls["record"].append(Path(sd)),
+    )
+    return calls
+
+
+def test_model_config_fail_fast_emits_to_langfuse(tmp_path, monkeypatch):
+    model = tmp_path / "bad_lf"
+    _write_config(model, model_type="x", rope_scaling={"factor": 2.0})
+    sd = tmp_path / "session_lf"
+    _seed_state(sd, monkeypatch)
+    calls = _spy_langfuse_emit(monkeypatch)
+
+    assert cli._preflight_model_config_compat(_args(str(model)), sd) is True
+    # written to disk AND pushed to Langfuse in flush -> patch -> record order.
+    assert (sd / "session_breakdown.json").exists()
+    assert calls["flush"] == [sd]
+    assert calls["patch"] == [sd]
+    assert calls["record"] == [sd]
+
+
+def test_unsupported_model_fail_fast_emits_to_langfuse(tmp_path, monkeypatch):
+    model = tmp_path / "vlm_lf"
+    _write_config(
+        model,
+        model_type="llava",
+        architectures=["LlavaForConditionalGeneration"],
+        max_position_embeddings=4096,
+    )
+    sd = tmp_path / "session_vlm_lf"
+    _seed_state(sd, monkeypatch)
+    calls = _spy_langfuse_emit(monkeypatch)
+
+    assert cli._preflight_unsupported_model_arch(_args(str(model)), sd) is True
+    assert calls["record"] == [sd]
+
+
+def test_context_window_fail_fast_emits_to_langfuse(tmp_path, monkeypatch):
+    model = tmp_path / "ctx_lf"
+    _write_config(model, model_type="llama", max_position_embeddings=128)
+    sd = tmp_path / "session_ctx_lf"
+    _seed_state(sd, monkeypatch)
+    calls = _spy_langfuse_emit(monkeypatch)
+
+    # ISL+OSL (1024+1024) + headroom >> 128 -> fail fast.
+    assert cli._preflight_context_window(_args(str(model)), sd) is True
+    assert calls["record"] == [sd]
+
+
+def test_emit_to_langfuse_is_best_effort(tmp_path, monkeypatch):
+    # A Langfuse outage must never turn a clean fail-fast into a crash, nor
+    # mask the persisted stop reason.
+    model = tmp_path / "bad_raise"
+    _write_config(model, model_type="x", rope_scaling={"factor": 2.0})
+    sd = tmp_path / "session_raise"
+    _seed_state(sd, monkeypatch)
+
+    from inference_optimizer.orchestrator.trace import langfuse_emitter as lfe
+
+    def _boom(*a, **k):
+        raise RuntimeError("langfuse down")
+
+    monkeypatch.setattr(lfe, "flush_session", _boom)
+
+    assert cli._preflight_model_config_compat(_args(str(model)), sd) is True
+    state = json.loads((sd / "state.json").read_text())
+    assert state["stop_reason"] == "model_config_incompatible"
+
+
+def test_healthy_model_does_not_emit_to_langfuse(tmp_path, monkeypatch):
+    # A passing pre-flight must not touch Langfuse — the normal end-of-session
+    # path owns that for runs that actually start.
+    model = tmp_path / "good_lf"
+    _write_config(model, model_type="llama", max_position_embeddings=8192)
+    sd = tmp_path / "session_good_lf"
+    _seed_state(sd, monkeypatch)
+    calls = _spy_langfuse_emit(monkeypatch)
+
+    assert cli._preflight_model_config_compat(_args(str(model)), sd) is False
+    assert calls["record"] == []
+
+
 def test_declared_standard_quant_with_scales_index_not_blocked(tmp_path):
     # AWQ/GPTQ/compressed-tensors legitimately ship '.scales'/'.biases' tensors;
     # a declared supported quant_method must NOT be misread as MLX (the weight-


### PR DESCRIPTION
The unsupported-model / model-config-compat / context-window pre-flight gates exit before coordinator.run()'s finally, which is the one place a normal session flushes Langfuse and attaches the session_breakdown document. As a result an early-aborted session wrote session_breakdown.json to disk (so the on-disk collector path forwarded it downstream) but never emitted the trace/observation to Langfuse, leaving those sessions absent from Langfuse entirely.

Add a best-effort _emit_breakdown_to_langfuse() helper (flush -> patch -> record, mirroring cli's end-of-session order) and call it in all three gates right after write_breakdown_json. No-op unless HYPERLOOM_LANGFUSE_ENABLE
+ LANGFUSE_* are set; never raises so a Langfuse outage cannot mask the persisted stop reason.

- Description: what and why
- Linked issue(s): close/fix refs
- Tests: added/updated? commands run?
- Breaking changes: yes/no (details if yes)
