### PR TITLE
feat(forge): kernel_kind routing + honest compile-only skip + aiter op_test harness fixes

### DIFF
--- a/kernel-agent/tools/backends/forge_submit.py
+++ b/kernel-agent/tools/backends/forge_submit.py
@@ -574,6 +574,12 @@ def main():
             print(f"wall_ms: {{m.group(1)}}")
         else:
             us = re.findall(r"avg:\\s*([0-9.]+)\\s*us/iter", out)
+            if not us:
+                # aiter test_common perftest also logs "<label> avg: <N> us"
+                # (no "/iter" suffix) and "us: <N>" — match those too so aiter
+                # op_tests yield a baseline instead of None.
+                us = (re.findall(r"avg:\\s*([0-9.]+)\\s*us\\b", out)
+                      or re.findall(r"\\bus:\\s*([0-9.]+)", out))
             if us:
                 # min across measured shapes = the kernel's best timing.
                 print(f"wall_ms: {{min(float(u) for u in us) / 1000.0:.6f}}")
@@ -595,13 +601,23 @@ def main():
     # "no metric found" -> the iteration fails (never a fabricated pass).
     snr = re.search(r"snr\\s*[:=]\\s*([-0-9.]+)\\s*db", low)
     m = re.search(r"allclose\\s*[:=]\\s*(true|false)", low)
-    if any(k in low for k in ("mismatch", "not close", "correctness failed", "validation failed")):
+    # aiter test_common.checkAllclose logs "[checkAllclose ... passed~]" on
+    # success and "... failed!" on mismatch — neither emits a Forge-contract
+    # "allclose:" line, so translate it explicitly (root cause of attention/
+    # aiter kernels reporting NO CORRECTNESS METRIC and failing Stage 1).
+    aiter_pass = ("checkallclose" in low and "passed" in low and "failed" not in low)
+    aiter_fail = ("checkallclose" in low and "failed" in low)
+    if any(k in low for k in ("mismatch", "not close", "correctness failed", "validation failed")) or aiter_fail:
         print("allclose: False")
     elif m:
         print(f"allclose: {{'True' if m.group(1) == 'true' else 'False'}}")
     elif snr:
         print(f"SNR: {{snr.group(1)}} dB")
-    elif any(k in low for k in ("correctness passed", "all tests passed", "test passed", "ok")):
+    elif aiter_pass:
+        print("allclose: True")
+    elif any(k in low for k in ("correctness passed", "all tests passed", "test passed")):
+        # NOTE: bare "ok" was removed here — it false-matched on substrings like
+        # "tokens", "block", etc. and fabricated passes. Require explicit phrases.
         print("allclose: True")
     else:
         # No correctness signal at all -> do NOT fabricate a pass.
@@ -1411,6 +1427,19 @@ def _apply_fellow_env(env: dict) -> None:
         env.setdefault("KERNELFORGE_GBRAIN_ENABLED", "true")
         env.setdefault("GBRAIN_BASE_URL", _gbrain_url)
         env.setdefault("GBRAIN_TOKEN", _gbrain_token)
+    else:
+        # Observability (F1): gbrain kernel KB stays disabled whenever either
+        # GBRAIN_BASE_URL or GBRAIN_TOKEN is absent — most commonly because a
+        # local-only / --degraded-kb setup_env.sh `unset` them as a
+        # belt-and-suspenders. Without this line the forge loop silently runs
+        # with NO cross-KB kernel knowledge, which is easy to miss. Surface it
+        # so operators can tell whether forge had gbrain available.
+        import sys as _sys
+        _sys.stderr.write(
+            "[forge_submit] gbrain KB disabled (forge runs without cross-KB "
+            f"knowledge): GBRAIN_BASE_URL={'set' if _gbrain_url else 'MISSING'} "
+            f"GBRAIN_TOKEN={'set' if _gbrain_token else 'MISSING'}\n"
+        )
 
     # Auth fallback: if no ANTHROPIC_API_KEY is exported, seed it from the claude
     # CLI's validated config.json primaryApiKey so the streaming transport
@@ -1424,6 +1453,27 @@ def _apply_fellow_env(env: dict) -> None:
                 env["ANTHROPIC_API_KEY"] = _key
         except Exception:  # noqa: S110
             pass  # best-effort: missing/unreadable config is not fatal
+
+
+def _driver_is_compile_only(driver_path: str) -> bool:
+    """True when the driver only compile-checks (emits no real correctness/timing).
+
+    The auto-generated HIP/CK compile-only driver verifies ``hipcc -c`` succeeds
+    and prints ``compile_only: True`` plus a synthesized ``wall_ms`` derived from
+    object-file size -- neither is a real correctness or performance signal.
+    Driving a KEEP decision off it produces fake successes/failures, so callers
+    use this to skip forge for such kernels.
+
+    Match ONLY the definite ``compile_only: True`` sentinel the compile-only
+    template emits -- a looser substring (e.g. ``"compile-only"``) would also
+    match a real harness that merely mentions the word in a comment/docstring and
+    silently skip a kernel that has valid correctness+timing.
+    """
+    try:
+        txt = Path(driver_path).read_text(errors="replace")
+    except OSError:
+        return False
+    return "compile_only: True" in txt
 
 
 def _baseline_correctness_ok(driver: str, workspace: str, gpu_target: str,
@@ -1465,9 +1515,13 @@ def _baseline_correctness_ok(driver: str, workspace: str, gpu_target: str,
     negative = any(k in out for k in (
         "correctness failed", "allclose: false", "error:", "traceback",
         "no metric in harness output", "keyerror", "correctness: failed"))
+    # NOTE: a compile-only driver (correctness UNVERIFIED + synthesized wall_ms)
+    # is NOT a positive baseline signal -- driving a KEEP decision off a kernel
+    # that was never numerically validated produces fake successes. Those drivers
+    # are filtered separately (see _driver_is_compile_only) and never reach here
+    # as a pass.
     positive = ("snr:" in out) or any(k in out for k in (
-        "allclose: true", "all correctness checks passed", "correctness passed",
-        "compile_only: true"))
+        "allclose: true", "all correctness checks passed", "correctness passed"))
     if proc.returncode == 0 and positive and not negative:
         return True, "baseline correctness ok"
     return False, f"baseline correctness not confirmed (rc={proc.returncode})"
@@ -1666,9 +1720,26 @@ def submit(source_file: str, prompt_file: Path, output_dir: Path,
     if (source_type or "").strip().lower() in ("", "unknown") and \
             str(source_file).lower().endswith((".cu", ".cuh", ".hip")):
         source_type = "hip_cpp"
+    # Curated kernel_kind (from op_to_source) refines the fellow choice: an aiter
+    # CK attention/gemm .cu (e.g. mha_batch_prefill) arrives as hip_cpp by
+    # extension, but its real impl is a Composable-Kernel template the ck-fellow
+    # knows how to tune (tile/warp/pipeline/LDS), not generic HIP. aiter_asm is a
+    # prebuilt assembly compute-core the agent cannot rewrite -> skip cleanly.
+    kernel_kind = str((candidate or {}).get("kernel_kind") or "").strip().lower()
+    if kernel_kind == "aiter_asm":
+        return _normalized(
+            2, "",
+            "forge: aiter_asm prebuilt assembly compute-core (.co) is not "
+            "editable from source; skipping (no rewritable kernel, no tuner)",
+            time.time() - started)
     fellow = _fellow_for_source_type(source_type)
-    log.info("forge dispatch: source_file=%s source_type=%s fellow=%s op=%s",
-             source_file, source_type, fellow, (candidate or {}).get("operation", ""))
+    if kernel_kind == "aiter_ck" and fellow in ("hip-fellow", None):
+        ck_fellow = _fellow_for_source_type("ck")
+        if ck_fellow is not None:
+            fellow = ck_fellow
+    log.info("forge dispatch: source_file=%s source_type=%s kernel_kind=%s fellow=%s op=%s",
+             source_file, source_type, kernel_kind or "-", fellow,
+             (candidate or {}).get("operation", ""))
     if fellow is None:
         return _normalized(2, "", f"forge stage-1 supports triton only; got source_type={source_type}",
                            time.time() - started)
@@ -1749,6 +1820,29 @@ def submit(source_file: str, prompt_file: Path, output_dir: Path,
                         f"({gate_detail}); not spinning the agent on an "
                         "unverifiable harness",
                         time.time() - started)
+        # Compile-only drivers cannot produce a real correctness/timing signal,
+        # so any KEEP they yield is based on synthesized metrics. Skip forge for
+        # such kernels (they fall through to the next ladder backend / are
+        # reported non-optimizable) unless explicitly allowed via
+        # FORGE_ALLOW_COMPILE_ONLY=1. This removes the structural "fake success /
+        # fake failure" on compiled attention where no real harness exists.
+        if (os.environ.get("FORGE_ALLOW_COMPILE_ONLY", "0").strip().lower()
+                not in ("1", "true", "yes") and _driver_is_compile_only(driver)):
+            # Observability: this is a deliberate global default-behavior change
+            # (compile-only kernels used to "attempt" forge), so log the skip so
+            # session stats / RCA can see why forge attempt counts dropped.
+            log.warning(
+                "forge skipped (compile-only, no real harness): source_file=%s "
+                "source_type=%s kernel_kind=%s op=%s -- falling through to next "
+                "backend (set FORGE_ALLOW_COMPILE_ONLY=1 to override)",
+                source_file, source_type, kernel_kind or "-",
+                (candidate or {}).get("operation", ""))
+            return _normalized(
+                2, "",
+                "forge skipped: only a compile-only driver is available (no real "
+                "correctness/timing harness); not driving a KEEP decision off "
+                "synthesized metrics (set FORGE_ALLOW_COMPILE_ONLY=1 to override)",
+                time.time() - started)
         # GPU_TARGET is passed to Kernel-Forge's MCP server tools (build/bench/pmc)
         # via the forge-loop child env (_run_loop_via_cli sets env["GPU_TARGET"]),
         # so it is NOT written to the parent os.environ -- that would leak to the
@@ -1758,6 +1852,21 @@ def submit(source_file: str, prompt_file: Path, output_dir: Path,
         experiments_dir = output_dir / "forge_experiments"
         experiments_dir.mkdir(parents=True, exist_ok=True)
         max_iters = int(os.environ.get("FORGE_MAX_ITERS", "8"))
+        # F3 (kernel-priority budgeting): compiled/ASM fellows (aiter / ck / hip
+        # / hipblaslt / flydsl) optimize a precompiled kernel whose compute core
+        # the agent cannot rewrite — it can only tweak host-side params (e.g.
+        # partition size), so their KEEP rate is structurally low (~2% vs the
+        # triton-fellow's much higher rate) with a micro-speedup ceiling ~1.6x.
+        # Cap their iteration budget so forge doesn't burn the full budget
+        # reverting on a kernel it cannot meaningfully change; triton-fellow
+        # (rewritable source, high yield) keeps the full budget. Configurable
+        # via FORGE_COMPILED_MAX_ITERS; set it >= FORGE_MAX_ITERS to disable.
+        if fellow != "triton-fellow":
+            _compiled_cap = int(os.environ.get("FORGE_COMPILED_MAX_ITERS", "3"))
+            if _compiled_cap < max_iters:
+                log.info("forge: capping compiled/ASM fellow %s iters %d -> %d "
+                         "(low-yield kernel, see F3)", fellow, max_iters, _compiled_cap)
+                max_iters = _compiled_cap
         snr_threshold = float((candidate.get("targets") or {}).get("snr_db", 30.0))
 
         # Run the loop in an isolated, hard-killable subprocess (like GEAK) so a

--- a/kernel-agent/tools/harness_generator.py
+++ b/kernel-agent/tools/harness_generator.py
@@ -109,7 +109,15 @@ class BenchmarkAnalyzer:
             if isinstance(node, (ast.Import, ast.ImportFrom)):
                 start = node.lineno - 1
                 end = node.end_lineno or node.lineno
-                import_lines.append("\n".join(self.lines[start:end]))
+                block = "\n".join(self.lines[start:end])
+                # ast.walk also yields imports nested inside functions / classes /
+                # try blocks, which keep their source indentation. Emitted verbatim
+                # at the harness module top level they raise "unexpected indent" and
+                # break static_check (the whole harness is then unusable). Dedent
+                # each block so a function-local ``    import math`` becomes a valid
+                # top-level ``import math``; module-level imports (no indent) are
+                # unchanged.
+                import_lines.append(textwrap.dedent(block))
         return import_lines
 
     def get_decorated_functions(self) -> dict[str, FuncInfo]:
@@ -1153,10 +1161,18 @@ def _try_generate_aiter_harness(
     imports = analyzer.get_imports()
     if not any("aiter" in imp for imp in imports):
         return None
-    bench_fns = [fi for fi in decorated.values() if fi.decorator == "benchmark"]
+    # Recognize both aiter perf decorators. Many aiter op_tests time the op with
+    # @perftest rather than @benchmark (e.g. test_batch_prefill.py), so matching
+    # only @benchmark misses them and forces the weaker generic path. A bare
+    # passthrough wrapper (e.g. @perftest def profile_func(target_func, *args,
+    # **kwargs)) carries no mappable shape params and is filtered by the kwargs
+    # guard below, so widening to @perftest only adds real benchmark fns.
+    bench_fns = [fi for fi in decorated.values()
+                 if fi.decorator in ("benchmark", "perftest")]
     if not bench_fns:
         return None
-    # Pick the first @benchmark fn that times an op (run_perftest / aiter.<op>).
+    # Pick the first perf fn that actually times an op (run_perftest / aiter.<op>);
+    # this also skips passthrough wrappers whose body just forwards to target_func.
     test_fn = next(
         (fi for fi in bench_fns
          if "run_perftest" in fi.source or "aiter." in fi.source),

--- a/kernel-agent/tools/test_harness_generator.py
+++ b/kernel-agent/tools/test_harness_generator.py
@@ -66,6 +66,57 @@ def test_get_imports():
     assert any("import torch" in i for i in imports)
 
 
+def test_get_imports_dedents_function_local():
+    """Regression: ast.walk yields imports nested inside functions with their
+    source indentation; emitted verbatim at the harness module top they raise
+    'unexpected indent'. get_imports must dedent them to valid top-level imports.
+    """
+    import ast as _ast
+
+    src = (
+        "import torch\n"
+        "def f():\n"
+        "    import math\n"
+        "    return math.pi\n"
+    )
+    a = hg.BenchmarkAnalyzer(src)
+    imports = a.get_imports()
+    assert "import math" in imports, imports
+    # Joined imports must form valid top-level Python (no IndentationError).
+    _ast.parse("\n".join(imports))
+
+
+def test_aiter_harness_recognizes_perftest(tmp_path):
+    """Regression: aiter op_tests that time the op with @perftest (not
+    @benchmark) must be picked up by the aiter idiom path and emit a valid
+    harness (previously they fell through to the weaker generic path)."""
+    import ast as _ast
+
+    src = (
+        "import torch\n"
+        "import aiter\n"
+        "from aiter.test_common import perftest, run_perftest\n"
+        "@perftest\n"
+        "def bench_op(m, n, k, dtype):\n"
+        "    x = torch.randn(m, k, dtype=dtype)\n"
+        "    return run_perftest(aiter.gemm, x)\n"
+    )
+    bench = tmp_path / "test_op.py"
+    bench.write_text(src, encoding="utf-8")
+    a = hg.BenchmarkAnalyzer(src)
+    out = hg._try_generate_aiter_harness(
+        analyzer=a,
+        decorated=a.get_decorated_functions(),
+        candidate={"input_shapes": {"M": 64, "N": 64, "K": 64}, "precision": "bf16"},
+        source_file=str(bench),
+        benchmark_path=bench,
+        out_dir=tmp_path,
+        log=lambda _m: None,
+    )
+    assert out is not None
+    _ast.parse(Path(out.harness_path).read_text(encoding="utf-8"))
+
+
 def test_get_decorated_functions():
     a = hg.BenchmarkAnalyzer(BENCH_SRC)
     dec = a.get_decorated_functions()

--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -142,6 +142,13 @@ class OpResolution:
     fanout: list["OpResolution"] = field(default_factory=list)
     resolution_method: str = "op_to_source"
     target_index: int = 0
+    # Per-source curated metadata (aligned with ``sources``): the JSON
+    # ``kernel_kind`` (``aiter_ck`` / ``aiter_asm`` / ``triton`` / ...) and the
+    # optional ``prebuilt_binary`` (a hand-written ``.co`` the ``.cu`` dispatcher
+    # loads). Routing reads these to send ASM compute-cores to skip and CK
+    # templates to the ck-fellow instead of the generic hip-fellow.
+    kernel_kinds: list[str] = field(default_factory=list)
+    prebuilt_binaries: list[str] = field(default_factory=list)
 
     @property
     def primary_source(self) -> str:
@@ -149,6 +156,20 @@ class OpResolution:
         if 0 <= self.target_index < len(self.sources):
             return self.sources[self.target_index]
         return self.sources[0] if self.sources else ""
+
+    @property
+    def primary_kernel_kind(self) -> str:
+        """The curated ``kernel_kind`` for :attr:`primary_source` (or ``""``)."""
+        if 0 <= self.target_index < len(self.kernel_kinds):
+            return self.kernel_kinds[self.target_index]
+        return self.kernel_kinds[0] if self.kernel_kinds else ""
+
+    @property
+    def primary_prebuilt_binary(self) -> str:
+        """The curated ``prebuilt_binary`` for :attr:`primary_source` (or ``""``)."""
+        if 0 <= self.target_index < len(self.prebuilt_binaries):
+            return self.prebuilt_binaries[self.target_index]
+        return self.prebuilt_binaries[0] if self.prebuilt_binaries else ""
 
     @property
     def is_routable(self) -> bool:
@@ -205,6 +226,16 @@ class OpResolution:
         if launcher and launcher != self.primary_source:
             item["launcher_source_file"] = launcher
             item["source_promoted_from_launcher"] = True
+        # Curated routing metadata for the optimization backends: kernel_kind
+        # distinguishes editable CK templates (aiter_ck) from non-editable
+        # prebuilt assembly compute-cores (aiter_asm), and prebuilt_binary names
+        # the .co the .cu dispatcher loads (present only for the asm path).
+        kk = self.primary_kernel_kind
+        if kk:
+            item["kernel_kind"] = kk
+        pb = self.primary_prebuilt_binary
+        if pb:
+            item["prebuilt_binary"] = pb
         self.stamp_onto(item)
 
 
@@ -319,9 +350,16 @@ class OpResolver:
         return self._single(op_name, entry, framework)
 
     @staticmethod
-    def _container_sources(container: dict[str, Any] | None) -> list[str]:
-        """Editable, patchable source paths for one container (dedup, order-preserving)."""
-        out: list[str] = []
+    def _container_source_meta(
+        container: dict[str, Any] | None,
+    ) -> list[tuple[str, str, str]]:
+        """Editable patchable ``(abs_path, kernel_kind, prebuilt_binary)`` for one container.
+
+        Dedups by path (first occurrence wins, order-preserving) so the per-source
+        ``kernel_kind`` / ``prebuilt_binary`` stay aligned with the path list.
+        """
+        out: list[tuple[str, str, str]] = []
+        seen: set[str] = set()
         for info in (container or {}).values():
             if not isinstance(info, dict) or not info.get("patchable"):
                 continue
@@ -329,12 +367,25 @@ class OpResolver:
             if not _is_editable_source(path, info.get("kernel_kind")):
                 continue
             abs_path = _absolutize_source(str(path))
-            if abs_path not in out:
-                out.append(abs_path)
+            if abs_path in seen:
+                continue
+            seen.add(abs_path)
+            out.append((
+                abs_path,
+                str(info.get("kernel_kind") or ""),
+                str(info.get("prebuilt_binary") or ""),
+            ))
         return out
 
-    def _select_sources(self, entry: dict[str, Any], framework: str | None) -> list[str]:
-        """Pick the editable source list, routing to the installed container.
+    @classmethod
+    def _container_sources(cls, container: dict[str, Any] | None) -> list[str]:
+        """Editable, patchable source paths for one container (dedup, order-preserving)."""
+        return [m[0] for m in cls._container_source_meta(container)]
+
+    def _select_source_meta(
+        self, entry: dict[str, Any], framework: str | None,
+    ) -> list[tuple[str, str, str]]:
+        """Pick the editable ``(path, kernel_kind, prebuilt_binary)`` list per container.
 
         When both containers carry editable sources, prefer whichever is present
         on disk; otherwise honor the ``framework`` hint (only ``vllm``/``sglang``
@@ -346,12 +397,12 @@ class OpResolver:
             except OSError:
                 return False
 
-        sgl = self._container_sources(entry.get("sglang"))
-        vll = self._container_sources(entry.get("vllm"))
+        sgl = self._container_source_meta(entry.get("sglang"))
+        vll = self._container_source_meta(entry.get("vllm"))
         if not (sgl or vll):
             return []
-        sgl_present = any(present(p) for p in sgl)
-        vll_present = any(present(p) for p in vll)
+        sgl_present = any(present(m[0]) for m in sgl)
+        vll_present = any(present(m[0]) for m in vll)
         if sgl_present and not vll_present:
             return sgl
         if vll_present and not sgl_present:
@@ -363,15 +414,22 @@ class OpResolver:
             return sgl
         return sgl or vll
 
+    def _select_sources(self, entry: dict[str, Any], framework: str | None) -> list[str]:
+        """Pick the editable source paths, routing to the installed container."""
+        return [m[0] for m in self._select_source_meta(entry, framework)]
+
     def _single(
         self, op_name: str, entry: dict[str, Any], framework: str | None,
     ) -> OpResolution:
         """Resolve a ``single`` entry to its editable source(s)."""
-        sources = self._select_sources(entry, framework)
+        meta = self._select_source_meta(entry, framework)
+        sources = [m[0] for m in meta]
         if sources:
             return OpResolution(
                 op_name=op_name, kind="single", status=_ROUTABLE_STATUS,
                 patchable=True, framework=framework, sources=sources,
+                kernel_kinds=[m[1] for m in meta],
+                prebuilt_binaries=[m[2] for m in meta],
             )
         return OpResolution(
             op_name=op_name, kind="single", status="non_rewritable",
@@ -416,6 +474,8 @@ class OpResolver:
                             op_name=op_name, kind="dispatch", status=_ROUTABLE_STATUS,
                             patchable=True, framework=framework,
                             sources=[_absolutize_source(str(path))], matched_route=kname,
+                            kernel_kinds=[str(info.get("kernel_kind") or "")],
+                            prebuilt_binaries=[str(info.get("prebuilt_binary") or "")],
                         )
                     return OpResolution(
                         op_name=op_name, kind="dispatch", status="non_rewritable",
@@ -431,13 +491,14 @@ class OpResolver:
         self, op_name: str, entry: dict[str, Any], framework: str | None,
     ) -> OpResolution:
         """Resolve a ``composite`` entry into a fan-out over its editable kernels."""
-        sources = self._select_sources(entry, framework)
+        meta = self._select_source_meta(entry, framework)
         fanout = [
             OpResolution(
                 op_name=op_name, kind="composite", status=_ROUTABLE_STATUS,
                 patchable=True, framework=framework, sources=[src],
+                kernel_kinds=[kind_], prebuilt_binaries=[pb],
             )
-            for src in sources
+            for src, kind_, pb in meta
         ]
         return OpResolution(
             op_name=op_name,
@@ -1555,6 +1616,19 @@ def classify_patchability(candidate: dict[str, Any]) -> tuple[bool, str]:
     if candidate.get("source_resolution_method") == "op_to_source":
         patchable = candidate.get("op_to_source_patchable")
         if patchable is True and source_file:
+            # aiter_asm compute-cores are hand-written assembly: the curated .cu
+            # is only a dispatcher that loads a prebuilt .co (no .s source is
+            # shipped), so the GPU compute core is not editable from source. An
+            # LLM/GEAK rewrite of the dispatcher cannot change the math and
+            # historically just burns the budget failing correctness. There is no
+            # aiter attention/asm deterministic tuner either, so skip with a clear
+            # reason and let the optimizer spend the budget on rewritable kernels.
+            if str(candidate.get("kernel_kind") or "").strip().lower() == "aiter_asm":
+                return False, (
+                    "op_to_source: aiter_asm prebuilt assembly compute-core "
+                    "(.co loaded by the .cu dispatcher; no editable .s source) "
+                    "-- not rewritable, no deterministic tuner available"
+                )
             return True, ""
         if patchable is False:
             reason = (


### PR DESCRIPTION
## Summary
Make forge optimize compiled aiter kernels by their curated `kernel_kind` instead of treating every `.cu` the same, and stop forge from driving KEEP decisions off synthesized (compile-only) metrics. Also fixes two harness-generator bugs that blocked aiter op_test harnesses.

- **tracelens**: stamp `kernel_kind`/`prebuilt_binary` onto candidates; skip `aiter_asm` prebuilt-assembly compute-cores (not editable from source, no deterministic tuner) instead of spinning the budget reverting on them.
- **forge_submit**: route an `aiter_ck` `.cu` to `ck-fellow` (not the generic `hip-fellow`); compile-only drivers no longer count as a baseline pass and are skipped (`FORGE_ALLOW_COMPILE_ONLY=1` to override) so a KEEP is never based on fake `wall_ms`; retains the aiter contract translation (`checkAllclose` -> SNR/allclose) and `FORGE_COMPILED_MAX_ITERS` budgeting.
- **harness_generator**: dedent imports captured by `ast.walk` so a function-local `import math` no longer breaks the generated harness with an "unexpected indent" SyntaxError; recognize `@perftest` (not only `@benchmark`) so aiter op_tests such as `test_batch_prefill.py` use the aiter-idiom harness path.
- **tests**: regressions for the dedent fix and the `@perftest` harness path.

> Note: a companion KernelForge change (forge-loop fellow-prompt loading + REFERENCE-ONLY framing) is submitted as a separate PR in AMD-AGI/KernelForge.

## Test plan
- [x] Unit: `kernel-agent/tools/test_harness_generator.py` (77 passed, incl. 2 new regressions); consolidated 138 passed; KernelForge 96 passed. Only 3 pre-existing failures unrelated to this change.
- [x] e2e (5 models): Llama-3.1-8B / Qwen2.5-7B / 14B harnesses now `passed static_check` (previously failed `unexpected indent (line 41)`); Qwen3-30B-A3B MoE triton kernel KEPT at ~1.48x (`fellow=triton-fellow`); compiled attention honestly skips when no correctness oracle exists.

Made with [Cursor](https://cursor.com)