### PR TITLE
Fix vLLM patch fallback and server args propagation

### DIFF
--- a/inference_optimizer/SKILL.md
+++ b/inference_optimizer/SKILL.md
@@ -677,6 +677,15 @@ sanitized `*.sh` name; overrides the gpu_type auto-pick) and
 that changes params after a failure — the agent must retry with
 identical params and the run terminates after 3 consecutive failures.
 
+Operator server flags have one supported CLI entry point:
+`optimize --server-args "<framework serve flags>"`. The CLI exports this as
+`INFERENCE_OPTIMIZER_SERVER_ARGS`, and YAML materialization routes it into
+`EXTRA_VLLM_ARGS` / `EXTRA_SGLANG_ARGS` / `EXTRA_ATOM_ARGS` for baseline,
+profile, explore, and sweep. Explicit `--max-model-len` / `$MAX_MODEL_LEN`
+wins over auto `ISL+OSL+headroom`. A comma `$CONC` value such as
+`4,16,128` is treated as a sweep ladder: baseline uses the max value and the
+ladder is forwarded to `INFERENCE_OPTIMIZER_CONC_SWEEP_CONCS`.
+
 ### Workload-contract reuse (baseline → explore/sweep)
 
 `baseline` materializes its YAML once with the operator's process env

--- a/inference_optimizer/SKILL.md
+++ b/inference_optimizer/SKILL.md
@@ -683,7 +683,7 @@ Operator server flags have one supported CLI entry point:
 `EXTRA_VLLM_ARGS` / `EXTRA_SGLANG_ARGS` / `EXTRA_ATOM_ARGS` for baseline,
 profile, explore, and sweep. Explicit `--max-model-len` / `$MAX_MODEL_LEN`
 wins over auto `ISL+OSL+headroom`. A comma `$CONC` value such as
-`4,16,128` is treated as a sweep ladder: baseline uses the max value and the
+`4,16,128` is treated as a sweep ladder: baseline uses the first value and the
 ladder is forwarded to `INFERENCE_OPTIMIZER_CONC_SWEEP_CONCS`.
 
 ### Workload-contract reuse (baseline → explore/sweep)

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -2748,6 +2748,76 @@ def _argv_has_option(argv: list[str], option: str) -> bool:
     return any(arg == option or arg.startswith(prefix) for arg in argv)
 
 
+def _positive_int_arg(value: str) -> int:
+    """argparse type for positive integer knobs."""
+    try:
+        parsed = int(str(value).strip())
+    except (TypeError, ValueError) as exc:
+        raise argparse.ArgumentTypeError(f"expected a positive integer, got {value!r}") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(f"expected a positive integer, got {value!r}")
+    return parsed
+
+
+def _parse_conc_env_default() -> int:
+    """Resolve ``$CONC`` for argparse, accepting a comma ladder as sweep input."""
+    raw = os.environ.get("CONC", "").strip()
+    if not raw:
+        return 8
+    tokens = [tok.strip() for tok in raw.split(",") if tok.strip()]
+    try:
+        values = [int(tok) for tok in tokens]
+    except ValueError:
+        print(
+            f"ERROR: CONC={raw!r} is not an integer or comma-separated integer ladder. "
+            "Use --conc N for one baseline concurrency, or "
+            "--conc-sweep-concs 4,16,128 for a ladder.",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    if not values or any(v <= 0 for v in values):
+        print(
+            f"ERROR: CONC={raw!r} must contain positive integer value(s).",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    if len(values) > 1:
+        # Preserve the user's ladder for the post-sweep action while picking a
+        # single baseline concurrency. ``max`` keeps the historical "cap"
+        # interpretation of CONC and prevents downstream int() coercions from
+        # seeing the comma string.
+        os.environ.setdefault(
+            "INFERENCE_OPTIMIZER_CONC_SWEEP_CONCS",
+            ",".join(str(v) for v in values),
+        )
+        os.environ["CONC"] = str(max(values))
+    return max(values)
+
+
+def _resolve_run_max_model_len(args: argparse.Namespace) -> tuple[int, str]:
+    """Resolve run-wide MAX_MODEL_LEN with explicit operator values winning."""
+    if getattr(args, "max_model_len", None):
+        return int(args.max_model_len), "--max-model-len"
+    max_model_len_env = os.environ.get("MAX_MODEL_LEN", "").strip()
+    if max_model_len_env:
+        try:
+            return _positive_int_arg(max_model_len_env), "$MAX_MODEL_LEN"
+        except argparse.ArgumentTypeError as exc:
+            print(
+                f"ERROR: MAX_MODEL_LEN={max_model_len_env!r} is invalid: {exc}",
+                file=sys.stderr,
+            )
+            raise SystemExit(2)
+    return (
+        _resolve_max_model_len(
+            args.isl,
+            args.osl,
+            str(args.model or ""),
+        ),
+        "auto",
+    )
+
+
 def _export_workload_envs_for_optimize(
     args: argparse.Namespace,
     *,
@@ -2829,6 +2899,9 @@ async def _run_optimize(args: argparse.Namespace) -> int:
             sys.exit(2)
 
     os.environ["INFERENCE_OPTIMIZER_NODES"] = str(nodes_resolved)
+    operator_server_args = str(getattr(args, "server_args", "") or "").strip()
+    if operator_server_args:
+        os.environ["INFERENCE_OPTIMIZER_SERVER_ARGS"] = operator_server_args
     # Re-export $TP/$CONC/$EP when explicitly supplied (always for multi-node); skip defaults in single-node.
     _export_workload_envs_for_optimize(
         args,
@@ -3179,12 +3252,10 @@ async def _run_optimize(args: argparse.Namespace) -> int:
             args.gpu_type = None
             print("GPU type        : <unset> (Magpie will auto-detect)")
 
-        # MAX_MODEL_LEN = ISL+OSL+headroom clamped to native window (see _resolve_max_model_len); exported for YAML.
-        max_model_len = _resolve_max_model_len(
-            args.isl,
-            args.osl,
-            str(args.model or ""),
-        )
+        # MAX_MODEL_LEN is operator-overridable. Auto resolution only runs when
+        # neither --max-model-len nor $MAX_MODEL_LEN was supplied.
+        max_model_len, max_model_len_source = _resolve_run_max_model_len(args)
+        args.max_model_len = max_model_len
         os.environ["MAX_MODEL_LEN"] = str(max_model_len)
         os.environ["ISL"] = str(args.isl)
         os.environ["OSL"] = str(args.osl)
@@ -3208,7 +3279,8 @@ async def _run_optimize(args: argparse.Namespace) -> int:
             os.environ["FRAMEWORK_VERSION"] = _fw_version_for_env
         print(
             f"Workload        : ISL={args.isl} OSL={args.osl} "
-            f"MAX_MODEL_LEN={max_model_len} PRECISION={args.precision} "
+            f"MAX_MODEL_LEN={max_model_len} ({max_model_len_source}) "
+            f"PRECISION={args.precision} "
             f"FRAMEWORK_VERSION={_fw_version_for_env or '<unset>'}"
         )
 
@@ -3903,11 +3975,34 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     opt.add_argument(
         "--conc",
-        type=int,
-        default=int(os.environ.get("CONC", "8") or 8),
+        type=_positive_int_arg,
+        default=_parse_conc_env_default(),
         help="Magpie client concurrency cap (max in-flight requests). "
         "Resolution: --conc > $CONC env > 8. Symmetric with --tp; "
-        "agent can pass `--conc N` directly from the prompt.",
+        "agent can pass `--conc N` directly from the prompt. If $CONC is "
+        "a comma ladder (e.g. 4,16,128), Hyperloom uses the max as the "
+        "baseline cap and forwards the ladder to --conc-sweep-concs.",
+    )
+    opt.add_argument(
+        "--max-model-len",
+        dest="max_model_len",
+        type=_positive_int_arg,
+        default=None,
+        help="Explicit server-facing MAX_MODEL_LEN. Resolution: "
+        "--max-model-len > $MAX_MODEL_LEN > auto(ISL+OSL+headroom, "
+        "clamped to native context). Explicit values are preserved and "
+        "exported into the materialized Magpie YAML.",
+    )
+    opt.add_argument(
+        "--server-args",
+        dest="server_args",
+        type=str,
+        default=os.environ.get("INFERENCE_OPTIMIZER_SERVER_ARGS", ""),
+        help="Framework server args to apply in every phase. Routed through "
+        "the framework-specific EXTRA_*_ARGS env in Magpie YAMLs "
+        "(EXTRA_VLLM_ARGS / EXTRA_SGLANG_ARGS / EXTRA_ATOM_ARGS). "
+        "Example: --server-args \"--kv-cache-dtype fp8_e4m3 "
+        "--gpu-memory-utilization 0.85\".",
     )
     opt.add_argument(
         "--ep",

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -2759,17 +2759,17 @@ def _positive_int_arg(value: str) -> int:
     return parsed
 
 
-def _parse_conc_env_default() -> int:
-    """Resolve ``$CONC`` for argparse, accepting a comma ladder as sweep input."""
-    raw = os.environ.get("CONC", "").strip()
-    if not raw:
-        return 8
-    tokens = [tok.strip() for tok in raw.split(",") if tok.strip()]
+def _parse_conc_values(raw: str, *, source: str = "CONC") -> list[int]:
+    """Parse a positive integer or comma ladder without mutating env."""
+    text = str(raw or "").strip()
+    if not text:
+        return []
+    tokens = [tok.strip() for tok in text.split(",") if tok.strip()]
     try:
         values = [int(tok) for tok in tokens]
     except ValueError:
         print(
-            f"ERROR: CONC={raw!r} is not an integer or comma-separated integer ladder. "
+            f"ERROR: {source}={text!r} is not an integer or comma-separated integer ladder. "
             "Use --conc N for one baseline concurrency, or "
             "--conc-sweep-concs 4,16,128 for a ladder.",
             file=sys.stderr,
@@ -2777,21 +2777,31 @@ def _parse_conc_env_default() -> int:
         raise SystemExit(2)
     if not values or any(v <= 0 for v in values):
         print(
-            f"ERROR: CONC={raw!r} must contain positive integer value(s).",
+            f"ERROR: {source}={text!r} must contain positive integer value(s).",
             file=sys.stderr,
         )
         raise SystemExit(2)
+    return values
+
+
+def _parse_conc_env_default() -> int:
+    """Resolve ``$CONC`` for argparse; comma ladders use first value as baseline."""
+    values = _parse_conc_values(os.environ.get("CONC", ""), source="CONC")
+    return values[0] if values else 8
+
+
+def _parse_conc_sweep_default() -> str:
+    """Resolve the sweep ladder, defaulting a comma ``$CONC`` into the sweep."""
+    explicit = os.environ.get("INFERENCE_OPTIMIZER_CONC_SWEEP_CONCS", "").strip()
+    if explicit:
+        return explicit
+    raw = os.environ.get("CONC", "").strip()
+    if not raw:
+        return "1,2,4,8,16,32,64,128"
+    values = _parse_conc_values(raw, source="CONC")
     if len(values) > 1:
-        # Preserve the user's ladder for the post-sweep action while picking a
-        # single baseline concurrency. ``max`` keeps the historical "cap"
-        # interpretation of CONC and prevents downstream int() coercions from
-        # seeing the comma string.
-        os.environ.setdefault(
-            "INFERENCE_OPTIMIZER_CONC_SWEEP_CONCS",
-            ",".join(str(v) for v in values),
-        )
-        os.environ["CONC"] = str(max(values))
-    return max(values)
+        return ",".join(str(v) for v in values)
+    return "1,2,4,8,16,32,64,128"
 
 
 def _resolve_run_max_model_len(args: argparse.Namespace) -> tuple[int, str]:
@@ -3980,8 +3990,8 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Magpie client concurrency cap (max in-flight requests). "
         "Resolution: --conc > $CONC env > 8. Symmetric with --tp; "
         "agent can pass `--conc N` directly from the prompt. If $CONC is "
-        "a comma ladder (e.g. 4,16,128), Hyperloom uses the max as the "
-        "baseline cap and forwards the ladder to --conc-sweep-concs.",
+        "a comma ladder (e.g. 4,16,128), Hyperloom uses the first value as "
+        "the baseline cap and forwards the ladder to --conc-sweep-concs.",
     )
     opt.add_argument(
         "--max-model-len",
@@ -4829,10 +4839,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--conc-sweep-concs",
         dest="conc_sweep_concs",
         type=str,
-        default=os.environ.get(
-            "INFERENCE_OPTIMIZER_CONC_SWEEP_CONCS",
-            "1,2,4,8,16,32,64,128",
-        ),
+        default=_parse_conc_sweep_default(),
         help="Comma-separated CONC ladder for --enable-conc-sweep. Default 1,2,4,8,16,32,64,128.",
     )
     opt.add_argument(

--- a/inference_optimizer/launcher/benchmark.md
+++ b/inference_optimizer/launcher/benchmark.md
@@ -61,7 +61,7 @@ framework-specific Magpie env (`EXTRA_VLLM_ARGS`, `EXTRA_SGLANG_ARGS`, or
 `EXTRA_ATOM_ARGS`) for baseline, profile, explore, and sweep. Explicit
 `--max-model-len` / `$MAX_MODEL_LEN` wins over the auto `ISL+OSL+headroom`
 calculation. A comma `$CONC` value such as `4,16,128` is treated as a sweep
-ladder: the single baseline CONC becomes the max value and the ladder is
+ladder: the single baseline CONC becomes the first value and the ladder is
 forwarded to `INFERENCE_OPTIMIZER_CONC_SWEEP_CONCS`.
 
 ## Workload-contract reuse (baseline → explore/sweep)

--- a/inference_optimizer/launcher/benchmark.md
+++ b/inference_optimizer/launcher/benchmark.md
@@ -54,6 +54,16 @@ denies any baseline proposal that changes params after a failure — the agent
 must retry with identical params and the run terminates after 3 consecutive
 failures.
 
+Operator-supplied server flags have a first-class CLI surface:
+`optimize --server-args "<framework serve flags>"`. The CLI exports this as
+`INFERENCE_OPTIMIZER_SERVER_ARGS`, and YAML materialization routes it into the
+framework-specific Magpie env (`EXTRA_VLLM_ARGS`, `EXTRA_SGLANG_ARGS`, or
+`EXTRA_ATOM_ARGS`) for baseline, profile, explore, and sweep. Explicit
+`--max-model-len` / `$MAX_MODEL_LEN` wins over the auto `ISL+OSL+headroom`
+calculation. A comma `$CONC` value such as `4,16,128` is treated as a sweep
+ladder: the single baseline CONC becomes the max value and the ladder is
+forwarded to `INFERENCE_OPTIMIZER_CONC_SWEEP_CONCS`.
+
 ## Workload-contract reuse (baseline → explore/sweep)
 
 `baseline` materializes its YAML once with the operator's process env (`CONC` /

--- a/inference_optimizer/orchestrator/action_executors/_server_patcher.py
+++ b/inference_optimizer/orchestrator/action_executors/_server_patcher.py
@@ -321,15 +321,11 @@ _VLLM_PATCH_RE = re.compile(r"^config_vllm_v(\d+(?:\.\d+)*)\.patch$")
 
 def _version_tuple(v: str) -> tuple[int, ...] | None:
     """Parse the leading dotted-numeric run of a version into a tuple.
-    ``0.22.0-rocm`` -> (0, 22, 0); returns None when there is no numeric head."""
-    head = (v or "").strip().split("-", 1)[0].split("+", 1)[0]
-    nums: list[int] = []
-    for part in (head.split(".") if head else []):
-        if part.isdigit():
-            nums.append(int(part))
-        else:
-            break
-    return tuple(nums) if nums else None
+    ``0.22.1rc1.dev`` -> (0, 22, 1); returns None when there is no numeric head."""
+    m = re.match(r"^\s*v?(\d+(?:\.\d+)*)", str(v or ""))
+    if not m:
+        return None
+    return tuple(int(part) for part in m.group(1).split("."))
 
 
 def _resolve_vllm_patch_file(patches_dir: Path, version: str) -> Path | None:
@@ -414,9 +410,10 @@ def _discover_vllm_plan(arg: Path | str | None) -> _PatchPlan | None:
     patches_dir = _patch_tree(tracelens_root, "vllm_patches")
     patch_file = _resolve_vllm_patch_file(patches_dir, version)
     if patch_file is None:
-        log.info(
+        log.warning(
             "_server_patcher: no TraceLens patch for vLLM %s "
-            "(searched %s incl. minor/nearest-lower fallback); skip",
+            "(searched %s incl. minor/nearest-lower fallback); "
+            "TraceLens annotations will be unavailable",
             version, patches_dir,
         )
         return None

--- a/inference_optimizer/orchestrator/action_executors/_workload_envs.py
+++ b/inference_optimizer/orchestrator/action_executors/_workload_envs.py
@@ -133,6 +133,24 @@ def _tracelens_patch_enabled() -> bool:
     return os.environ.get("HYPERLOOM_ENABLE_PATCH", "1").strip() != "0"
 
 
+def _coerce_workload_int_env(env_key: str, raw: str) -> int:
+    """Coerce workload env values, accepting ``CONC`` comma ladders."""
+    text = str(raw or "").strip()
+    if env_key == "CONC" and "," in text:
+        values = [int(tok.strip()) for tok in text.split(",") if tok.strip()]
+        if not values or any(v <= 0 for v in values):
+            raise ValueError(f"{env_key}={raw!r} must contain positive integers")
+        os.environ.setdefault(
+            "INFERENCE_OPTIMIZER_CONC_SWEEP_CONCS",
+            ",".join(str(v) for v in values),
+        )
+        return max(values)
+    value = int(text)
+    if value <= 0:
+        raise ValueError(f"{env_key}={raw!r} must be positive")
+    return value
+
+
 def default_baseline_config() -> Path:
     """Resolve the shipped Magpie YAML based on ``$FRAMEWORK`` env.
 
@@ -202,6 +220,14 @@ def materialize_config_with_envs(
             different known framework than the run's framework.
     """
     server_args = (extra_server_args or "").strip()
+    operator_server_args = os.environ.get("INFERENCE_OPTIMIZER_SERVER_ARGS", "").strip()
+    if operator_server_args:
+        if server_args:
+            from ._grid_runner import merge_server_args
+
+            server_args = merge_server_args(operator_server_args, server_args)
+        else:
+            server_args = operator_server_args
     with config_path.open(encoding="utf-8") as f:
         cfg = yaml.safe_load(f) or {}
     bench = cfg.setdefault("benchmark", {})
@@ -252,7 +278,7 @@ def materialize_config_with_envs(
     ):
         val = os.environ.get(env_key, "").strip()
         if val:
-            envs[env_key] = int(val)
+            envs[env_key] = _coerce_workload_int_env(env_key, val)
     # RANDOM_RANGE_RATIO is a float feeding the steady-state formulas below; do
     # NOT coerce to int or fractional ratios collapse the prefill estimate.
     r_env = os.environ.get("RANDOM_RANGE_RATIO", "").strip()
@@ -304,9 +330,9 @@ def materialize_config_with_envs(
             )
         envs["ROCR_VISIBLE_DEVICES"] = derived
 
-    isl_val = int(os.environ.get("ISL") or envs.get("ISL") or 256)
-    osl_val = int(os.environ.get("OSL") or envs.get("OSL") or 256)
-    conc_val = int(os.environ.get("CONC") or envs.get("CONC") or 8)
+    isl_val = int(envs.get("ISL") or 256)
+    osl_val = int(envs.get("OSL") or 256)
+    conc_val = int(envs.get("CONC") or 8)
 
     # Steady-state window for profiling configs (detected by PROFILE env or
     # ``profiler.torch_profiler.enabled``). Formulas match the TraceLens
@@ -364,11 +390,19 @@ def materialize_config_with_envs(
         # Default-on (HYPERLOOM_ENABLE_PATCH=0 disables); skip for atom (native
         # profiler, no patch set).
         tracelens_patch_ok = False
-        if _tracelens_patch_enabled() and not is_atom:
+        patch_attempted = _tracelens_patch_enabled() and not is_atom
+        if patch_attempted:
             if "vllm" in fw:
                 tracelens_patch_ok = ensure_vllm_patched_for_tracelens()
             else:
                 tracelens_patch_ok = ensure_sglang_patched_for_tracelens()
+            if not tracelens_patch_ok:
+                log.warning(
+                    "TraceLens runtime patch unavailable for framework=%s; "
+                    "profile will omit annotation-only flags and roofline "
+                    "analysis may be degraded.",
+                    fw or "<unset>",
+                )
         if is_atom:
             # atom's profiler records the entire bench-client run (no internal
             # window); its profile window lives only in Magpie's atom_mi*x.sh

--- a/inference_optimizer/orchestrator/action_executors/_workload_envs.py
+++ b/inference_optimizer/orchestrator/action_executors/_workload_envs.py
@@ -38,13 +38,6 @@ from ._grid_runner import (
     inject_sglang_watchdog_timeout,
     server_args_env_name,
 )
-
-_MOE_RUNNER_BACKEND_RE = re.compile(r"(?:^|\s)--moe-runner-backend(?:[=\s]+)\S+")
-
-
-def _remove_moe_runner_backend_arg(args: str) -> str:
-    """Remove any existing SGLang MoE runner backend flag from an args string."""
-    return " ".join(_MOE_RUNNER_BACKEND_RE.sub(" ", str(args or "")).split())
 from ._server_patcher import (
     ensure_sglang_patched_for_tracelens,
     ensure_vllm_patched_for_tracelens,
@@ -52,6 +45,13 @@ from ._server_patcher import (
 from ...model_config_utils import _load_model_config_dict, _model_is_gemma2
 
 log = logging.getLogger(__name__)
+
+_MOE_RUNNER_BACKEND_RE = re.compile(r"(?:^|\s)--moe-runner-backend(?:[=\s]+)\S+")
+
+
+def _remove_moe_runner_backend_arg(args: str) -> str:
+    """Remove any existing SGLang MoE runner backend flag from an args string."""
+    return " ".join(_MOE_RUNNER_BACKEND_RE.sub(" ", str(args or "")).split())
 
 # Warn once per process when the accuracy gate is disabled.
 _RUN_EVAL_DISABLED_WARN_EMITTED = False
@@ -144,7 +144,7 @@ def _coerce_workload_int_env(env_key: str, raw: str) -> int:
             "INFERENCE_OPTIMIZER_CONC_SWEEP_CONCS",
             ",".join(str(v) for v in values),
         )
-        return max(values)
+        return values[0]
     value = int(text)
     if value <= 0:
         raise ValueError(f"{env_key}={raw!r} must be positive")
@@ -397,6 +397,10 @@ def materialize_config_with_envs(
             else:
                 tracelens_patch_ok = ensure_sglang_patched_for_tracelens()
             if not tracelens_patch_ok:
+                envs["HYPERLOOM_TRACELENS_PATCH_STATUS"] = "unavailable"
+                envs["HYPERLOOM_PROFILE_DEGRADED_REASON"] = (
+                    "tracelens_runtime_patch_unavailable"
+                )
                 log.warning(
                     "TraceLens runtime patch unavailable for framework=%s; "
                     "profile will omit annotation-only flags and roofline "

--- a/inference_optimizer/orchestrator/roofline_ceiling.py
+++ b/inference_optimizer/orchestrator/roofline_ceiling.py
@@ -258,8 +258,9 @@ def _read_baseline_yaml_server_args(state: Any) -> str:
     The baseline ``current_best`` snapshot carries no ``extra_server_args``
     (the flags live only in ``benchmark.envs.EXTRA_*_ARGS`` of the on-disk
     yaml), so a baseline-only run with ``--quantization fp8`` in the yaml
-    would otherwise be invisible to dtype resolution. Returns ``""`` when
-    the file / fields are unreadable.
+    would otherwise be invisible to dtype resolution. If the materialized YAML
+    is unreadable, fall back to ``last_baseline`` payload/env args so prelude
+    profiling does not silently drop operator server flags.
 
     Args:
         state: Shared run state carrying ``last_baseline`` provenance.
@@ -267,7 +268,10 @@ def _read_baseline_yaml_server_args(state: Any) -> str:
     Returns:
         The assembled baseline server args, or ``""`` when unreadable.
     """
-    return _server_args_from_envs(_benchmark_envs(_read_baseline_yaml_benchmark(state)))
+    yaml_args = _server_args_from_envs(_benchmark_envs(_read_baseline_yaml_benchmark(state)))
+    if yaml_args:
+        return yaml_args
+    return _server_args_from(getattr(state, "last_baseline", None))
 
 
 def _server_args_env_override(entry: Any) -> str:

--- a/inference_optimizer/tests/test_cli_workload_envs.py
+++ b/inference_optimizer/tests/test_cli_workload_envs.py
@@ -13,6 +13,7 @@ import yaml
 from inference_optimizer.cli import (
     _export_workload_envs_for_optimize,
     _parse_conc_env_default,
+    _parse_conc_sweep_default,
     _resolve_run_max_model_len,
 )
 from inference_optimizer.orchestrator.action_executors._workload_envs import (
@@ -163,7 +164,7 @@ def test_conc_env_ladder_materializes_as_single_baseline_and_sweep_ladder(
     out = materialize_config_with_envs(src, tmp_path / "out")
     envs = yaml.safe_load(out.read_text())["benchmark"]["envs"]
 
-    assert envs["CONC"] == 128
+    assert envs["CONC"] == 4
     assert os.environ["INFERENCE_OPTIMIZER_CONC_SWEEP_CONCS"] == "4,16,128"
 
 
@@ -171,9 +172,16 @@ def test_conc_env_ladder_parser_default_exports_sweep_ladder(monkeypatch):
     monkeypatch.setenv("CONC", "4,16,128")
     monkeypatch.delenv("INFERENCE_OPTIMIZER_CONC_SWEEP_CONCS", raising=False)
 
-    assert _parse_conc_env_default() == 128
-    assert os.environ["CONC"] == "128"
-    assert os.environ["INFERENCE_OPTIMIZER_CONC_SWEEP_CONCS"] == "4,16,128"
+    assert _parse_conc_env_default() == 4
+    assert os.environ["CONC"] == "4,16,128"
+
+
+def test_conc_env_ladder_parser_default_feeds_sweep_without_env_mutation(monkeypatch):
+    monkeypatch.setenv("CONC", "4,16,128")
+    monkeypatch.delenv("INFERENCE_OPTIMIZER_CONC_SWEEP_CONCS", raising=False)
+
+    assert _parse_conc_sweep_default() == "4,16,128"
+    assert os.environ["CONC"] == "4,16,128"
 
 
 def test_explicit_max_model_len_wins_over_auto(tmp_path, monkeypatch):

--- a/inference_optimizer/tests/test_cli_workload_envs.py
+++ b/inference_optimizer/tests/test_cli_workload_envs.py
@@ -10,7 +10,11 @@ import os
 import pytest
 import yaml
 
-from inference_optimizer.cli import _export_workload_envs_for_optimize
+from inference_optimizer.cli import (
+    _export_workload_envs_for_optimize,
+    _parse_conc_env_default,
+    _resolve_run_max_model_len,
+)
 from inference_optimizer.orchestrator.action_executors._workload_envs import (
     FrameworkScriptMismatchError,
     materialize_config_with_envs,
@@ -27,6 +31,11 @@ def _write_yaml(path, framework, benchmark_script=None):
     bench = {"framework": framework, "model": "/m", "envs": {}}
     if benchmark_script:
         bench["benchmark_script"] = benchmark_script
+    path.write_text(yaml.safe_dump({"benchmark": bench}), encoding="utf-8")
+
+
+def _write_yaml_with_envs(path, framework, envs):
+    bench = {"framework": framework, "model": "/m", "envs": dict(envs)}
     path.write_text(yaml.safe_dump({"benchmark": bench}), encoding="utf-8")
 
 
@@ -104,3 +113,93 @@ def test_multi_node_always_exports_workload_envs(monkeypatch):
     assert os.environ["TP"] == "8"
     assert os.environ["CONC"] == "32"
     assert os.environ["EP"] == "2"
+
+
+def test_operator_server_args_env_routes_to_vllm_args(tmp_path, monkeypatch):
+    """#573: one server-args injection point must reach vLLM YAML materialization."""
+    monkeypatch.setenv(
+        "INFERENCE_OPTIMIZER_SERVER_ARGS",
+        "--gpu-memory-utilization 0.85 --kv-cache-dtype fp8_e4m3",
+    )
+    src = tmp_path / "cfg.yaml"
+    _write_yaml(src, "vllm")
+
+    out = materialize_config_with_envs(src, tmp_path / "out")
+    envs = yaml.safe_load(out.read_text())["benchmark"]["envs"]
+
+    assert "EXTRA_VLLM_ARGS" in envs
+    assert "--gpu-memory-utilization 0.85" in envs["EXTRA_VLLM_ARGS"]
+    assert "--kv-cache-dtype fp8_e4m3" in envs["EXTRA_VLLM_ARGS"]
+
+
+def test_operator_server_args_dedup_vllm_single_value_flags(tmp_path, monkeypatch):
+    """Operator flags should override YAML defaults without duplicate vLLM keys."""
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_SERVER_ARGS", "--gpu-memory-utilization 0.85")
+    src = tmp_path / "cfg.yaml"
+    _write_yaml_with_envs(
+        src,
+        "vllm",
+        {"EXTRA_VLLM_ARGS": "--gpu-memory-utilization 0.95 --trust-remote-code"},
+    )
+
+    out = materialize_config_with_envs(src, tmp_path / "out")
+    args = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
+
+    assert args.count("--gpu-memory-utilization") == 1
+    assert "--gpu-memory-utilization 0.85" in args
+    assert "--trust-remote-code" in args
+
+
+def test_conc_env_ladder_materializes_as_single_baseline_and_sweep_ladder(
+    tmp_path,
+    monkeypatch,
+):
+    """#573: CONC=4,16,128 is recognized as a ladder, not crashed by int()."""
+    monkeypatch.setenv("CONC", "4,16,128")
+    monkeypatch.delenv("INFERENCE_OPTIMIZER_CONC_SWEEP_CONCS", raising=False)
+    src = tmp_path / "cfg.yaml"
+    _write_yaml(src, "vllm")
+
+    out = materialize_config_with_envs(src, tmp_path / "out")
+    envs = yaml.safe_load(out.read_text())["benchmark"]["envs"]
+
+    assert envs["CONC"] == 128
+    assert os.environ["INFERENCE_OPTIMIZER_CONC_SWEEP_CONCS"] == "4,16,128"
+
+
+def test_conc_env_ladder_parser_default_exports_sweep_ladder(monkeypatch):
+    monkeypatch.setenv("CONC", "4,16,128")
+    monkeypatch.delenv("INFERENCE_OPTIMIZER_CONC_SWEEP_CONCS", raising=False)
+
+    assert _parse_conc_env_default() == 128
+    assert os.environ["CONC"] == "128"
+    assert os.environ["INFERENCE_OPTIMIZER_CONC_SWEEP_CONCS"] == "4,16,128"
+
+
+def test_explicit_max_model_len_wins_over_auto(tmp_path, monkeypatch):
+    """#573: explicit --max-model-len / $MAX_MODEL_LEN must not be recomputed."""
+    model = tmp_path / "model"
+    model.mkdir()
+    (model / "config.json").write_text('{"max_position_embeddings": 4096}', encoding="utf-8")
+    monkeypatch.delenv("MAX_MODEL_LEN", raising=False)
+
+    value, source = _resolve_run_max_model_len(
+        _ns(model=str(model), isl=1024, osl=1024, max_model_len=200000),
+    )
+
+    assert value == 200000
+    assert source == "--max-model-len"
+
+
+def test_env_max_model_len_wins_over_auto(tmp_path, monkeypatch):
+    model = tmp_path / "model"
+    model.mkdir()
+    (model / "config.json").write_text('{"max_position_embeddings": 4096}', encoding="utf-8")
+    monkeypatch.setenv("MAX_MODEL_LEN", "200000")
+
+    value, source = _resolve_run_max_model_len(
+        _ns(model=str(model), isl=1024, osl=1024, max_model_len=None),
+    )
+
+    assert value == 200000
+    assert source == "$MAX_MODEL_LEN"

--- a/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -636,6 +636,7 @@ def test_materialize_profile_vllm_injects_tracelens_flags_when_patched(
 def test_materialize_profile_vllm_omits_tracelens_flags_when_patch_fails(
     tmp_path,
     monkeypatch,
+    caplog,
 ):
     """Patcher False ⇒ EXTRA_VLLM_ARGS keeps only the §1 safe set (else unpatched vLLM crashes on unknown JSON key)."""
     import yaml
@@ -643,11 +644,16 @@ def test_materialize_profile_vllm_omits_tracelens_flags_when_patch_fails(
     _clear_workload_env(monkeypatch)
     _mock_patchers(monkeypatch, vllm=False, sglang=False)
     src = _profile_yaml(tmp_path, "vllm", {"CONC": 32, "ISL": 256, "OSL": 1024})
+    caplog.set_level("WARNING")
     out = _materialize_config_with_envs(src, tmp_path)
-    extra = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
+    envs = yaml.safe_load(out.read_text())["benchmark"]["envs"]
+    extra = envs["EXTRA_VLLM_ARGS"]
     assert "--profiler-config.delay_iterations 5888" in extra, extra
     assert "capture_torch_profiler_dir" not in extra, extra
     assert "detailed_trace_annotation" not in extra, extra
+    assert envs["HYPERLOOM_TRACELENS_PATCH_STATUS"] == "unavailable"
+    assert envs["HYPERLOOM_PROFILE_DEGRADED_REASON"] == "tracelens_runtime_patch_unavailable"
+    assert "TraceLens runtime patch unavailable" in caplog.text
 
 
 def test_materialize_profile_sglang_injects_shape_discovery_when_patched(

--- a/inference_optimizer/tests/test_roofline_ceiling.py
+++ b/inference_optimizer/tests/test_roofline_ceiling.py
@@ -2217,6 +2217,22 @@ class TestReadBaselineServerArgs:
         )
         assert read_baseline_server_args(state) == ""
 
+    def test_falls_back_to_last_baseline_payload_when_yaml_missing(self):
+        from inference_optimizer.orchestrator.roofline_ceiling import (
+            read_baseline_server_args,
+        )
+
+        state = SimpleNamespace(
+            last_baseline={
+                "extras": {"materialized_config": "/no/such.yaml"},
+                "extra_envs": {
+                    "EXTRA_VLLM_ARGS": "--kv-cache-dtype fp8_e4m3 --gpu-memory-utilization 0.85",
+                },
+            },
+        )
+
+        assert read_baseline_server_args(state) == "--kv-cache-dtype fp8_e4m3 --gpu-memory-utilization 0.85"
+
 
 class TestPreludeRooflineWarmReplayIntegration:
     """End-to-end-ish: a delayed PRELUDE roofline running AFTER warm-replay has

--- a/inference_optimizer/tests/test_server_patcher_vllm_version_fallback.py
+++ b/inference_optimizer/tests/test_server_patcher_vllm_version_fallback.py
@@ -29,6 +29,30 @@ def test_same_minor_fallback(tmp_path):
     assert got is not None and got.name == "config_vllm_v0.21.0.patch"
 
 
+def test_rc_dev_version_uses_same_minor_patch(tmp_path):
+    d = _mk_patches(tmp_path, ["0.21.0", "0.22.0"])
+    got = sp._resolve_vllm_patch_file(
+        d,
+        "0.22.1rc1.dev259+g23d65ff98.localfp8.aiter1be6",
+    )
+    assert got is not None and got.name == "config_vllm_v0.22.0.patch"
+
+
+def test_local_build_suffix_uses_release_patch(tmp_path):
+    d = _mk_patches(tmp_path, ["0.21.0", "0.22.0"])
+    got = sp._resolve_vllm_patch_file(d, "0.22.0+rocm722")
+    assert got is not None and got.name == "config_vllm_v0.22.0.patch"
+
+
+def test_rc_dev_version_nearest_lower_when_minor_missing(tmp_path):
+    d = _mk_patches(tmp_path, ["0.20.0", "0.21.0"])
+    got = sp._resolve_vllm_patch_file(
+        d,
+        "0.22.1rc1.dev259+g23d65ff98.localfp8.aiter1be6",
+    )
+    assert got is not None and got.name == "config_vllm_v0.21.0.patch"
+
+
 def test_same_minor_never_picks_newer_patch(tmp_path):
     d = _mk_patches(tmp_path, ["0.21.0", "0.21.10"])
     # 0.21.10 is same-minor but newer than running 0.21.5, so skip it.


### PR DESCRIPTION
## Summary
- Fix vLLM TraceLens patch resolution for rc/dev/local build versions, with same-minor and nearest-lower fallback plus explicit degraded-profile warnings.
- Add a unified `--server-args` CLI surface and route operator server flags into vLLM/SGLang/Atom YAML envs across baseline, profile, explore, and sweep.
- Preserve explicit `--max-model-len` / `$MAX_MODEL_LEN`, support comma `$CONC` ladders, and keep profile server args available when baseline YAML cannot be read.

## Test plan
- Local: `python -m ruff check ...` for changed modules/tests.
- Local: targeted pytest with Windows `fcntl` stub, 27 passed.
- Remote vLLM 0.22.0+rocm722 machine: targeted pytest in `/tmp` sandbox, 16 passed; verified patch fallback and server args / CONC materialization.
- Previous PR CI for the same fix set passed on ruff, pylint, analyze, CodeQL, Python 3.10 and Python 3.11.