### PR TITLE
Fix kernel-opt dispatch false failures: candidates retry (#600) + empty-queue skip (#598)

### DIFF
--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -4598,6 +4598,7 @@ def collect_kernel_optimization_summary(
         "rejection_breakdown",
         "unattempted_reason_breakdown",
         "failure_reason_breakdown",
+        "dispatch_skip_reason",
         "field_glossary",
     ):
         val = out.get(key)

--- a/inference_optimizer/breakdown/schema.py
+++ b/inference_optimizer/breakdown/schema.py
@@ -1597,6 +1597,7 @@ class KernelOptimizationSummary(TypedDict, total=False):
     rejection_breakdown: dict[str, int]
     unattempted_reason_breakdown: dict[str, int]
     failure_reason_breakdown: dict[str, int]
+    dispatch_skip_reason: dict[str, Any]  # {} or {reason, kernels_considered, message, ts} when a dispatch found no eligible kernels
     field_glossary: dict[str, str]  # {field_name: explanation} for tooltips
     top_takeaways: list[str]  # 2-4 deterministic (non-LLM) sentences
     by_kernel: list[dict[str, Any]]  # one row per top kernel, sorted gpu_pct desc; shape per §A1.4

--- a/inference_optimizer/orchestrator/kernel_attempt_summary.py
+++ b/inference_optimizer/orchestrator/kernel_attempt_summary.py
@@ -594,6 +594,10 @@ def build_kernel_optimization_summary(
         "rejection_breakdown": rejection_breakdown,
         "unattempted_reason_breakdown": unattempted_breakdown,
         "failure_reason_breakdown": failure_reason_breakdown,
+        # Honest, non-failure breadcrumb for a kernel-opt dispatch that found no
+        # eligible kernels (empty batch, no named kernel) and was skipped wholesale.
+        # Empty {} when no such skip occurred.
+        "dispatch_skip_reason": dict(getattr(state, "last_kernel_opt_dispatch_skip", {}) or {}),
         "field_glossary": FIELD_GLOSSARY,
         "by_kernel": by_kernel,
         "top_takeaways": top_takeaways,

--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -1888,6 +1888,37 @@ async def trace_analyze_handler(
     return result
 
 
+def _exists_with_retry(
+    path: str | Path,
+    *,
+    attempts: int = 5,
+    delay_sec: float = 0.5,
+) -> bool:
+    """Check ``path`` existence, retrying briefly to absorb storage latency.
+
+    On shared/network filesystems (e.g. wekafs) a file that was just written can
+    take a moment to become visible to another client, so a single
+    :meth:`Path.exists` immediately after the write may spuriously report
+    missing. Retry a handful of times with a short pause before giving up.
+
+    Args:
+        path: Filesystem path to check.
+        attempts: Total number of existence checks to perform (>= 1).
+        delay_sec: Seconds to sleep between checks.
+
+    Returns:
+        ``True`` as soon as the path is visible, else ``False`` after all
+        attempts are exhausted.
+    """
+    target = Path(path)
+    for attempt in range(max(1, attempts)):
+        if target.exists():
+            return True
+        if attempt < attempts - 1:
+            time.sleep(delay_sec)
+    return False
+
+
 def _validate_trace_analyze_inputs(
     payload: dict,
     *,
@@ -1904,7 +1935,7 @@ def _validate_trace_analyze_inputs(
         else ``None``.
     """
     candidates_path = str(payload.get("candidates_path") or "").strip()
-    if candidates_path and not Path(candidates_path).exists():
+    if candidates_path and not _exists_with_retry(candidates_path):
         return {
             "status": "failed",
             "error_class": "missing_candidates_artifact",

--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -4320,6 +4320,23 @@ def record_kernel_opt(state, result: dict[str, Any]) -> None:
 
     if not isinstance(result, dict):
         return
+    # Capture an empty-queue skip (no eligible kernels, no named kernel) as a
+    # non-failure breadcrumb. The result carries no kernel_id, so the per-kernel
+    # bookkeeping below early-returns and the skip is otherwise invisible in the
+    # breakdown (no backend, no kernel_id). Stash it so the summary can surface
+    # it honestly.
+    if (
+        str(result.get("status") or "").lower() == "skipped"
+        and str(result.get("reason") or "") == "no_eligible_kernels"
+    ):
+        from .shared_state import _now_iso
+
+        state.last_kernel_opt_dispatch_skip = {
+            "reason": "no_eligible_kernels",
+            "kernels_considered": int(result.get("kernels_considered") or 0),
+            "message": str(result.get("message") or ""),
+            "ts": _now_iso(),
+        }
     # Author-time breakdown capture: record geak/oob invocations (incl.
     # backend + pre-dispatch failures) before the metadata-less early
     # return so no failed attempt becomes invisible in the geak/oob view.

--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -2014,6 +2014,25 @@ async def run_optimization_handler(
             )
             if canon:
                 single_payload["kernel_id"] = canon
+            elif not _names_specific_kernel(single_payload):
+                # Empty eligible queue and the request named no specific target
+                # (e.g. the post-GEMM auto pass dispatches a batch with no id).
+                # All candidates are already tried/rejected, below the size
+                # cutoff, or not reusable. Finish cleanly instead of falling
+                # into the single-kernel path, which would surface
+                # "missing 'kernel_id'" and mis-report an empty work queue as a
+                # GEAK failure. A "skipped" status (no error_class / REVERT
+                # decision) is not counted as a failure by the breakdown
+                # recorder.
+                return {
+                    "status": "skipped",
+                    "reason": "no_eligible_kernels",
+                    "kernels_considered": len(_all_kernel_candidates(payload)),
+                    "message": (
+                        "no eligible kernels to optimize (all candidates already "
+                        "tried/rejected, below the size cutoff, or not reusable)"
+                    ),
+                }
         single_payload["_single_kernel"] = True
         return await _run_optimization_single(single_payload, session_dir=session_dir)
     return await _run_optimization_batch(
@@ -2278,6 +2297,29 @@ def _resolve_candidate_id(
         if _normalize_kernel_id(str(cand.get("kernel_id") or "")) == target:
             return str(cand.get("kernel_id") or "")
     return ""
+
+
+def _names_specific_kernel(payload: dict) -> bool:
+    """Return ``True`` when the payload targets one specific kernel/source.
+
+    A specific target is an explicit ``kernel_id``, a ``source_file`` to
+    optimize, or an inline ``candidate`` dict. The post-GEMM auto pass dispatches
+    a batch with none of these, which is the empty-work-queue case that should be
+    skipped cleanly rather than routed into the single-kernel path.
+
+    Args:
+        payload: The run_optimization request payload.
+
+    Returns:
+        ``True`` if the request names a specific kernel/source, else ``False``.
+    """
+    if str(payload.get("kernel_id") or "").strip():
+        return True
+    if str(payload.get("source_file") or "").strip():
+        return True
+    if isinstance(payload.get("candidate"), dict):
+        return True
+    return False
 
 
 def _all_kernel_candidates(payload: dict) -> list[dict[str, Any]]:

--- a/inference_optimizer/orchestrator/shared_state.py
+++ b/inference_optimizer/orchestrator/shared_state.py
@@ -583,6 +583,11 @@ class SharedState:
     last_conc_sweep: dict[str, Any] = field(default_factory=dict)
     # Most recent run_optimization_done so Orch doesn't re-dispatch the same kernel_id every tick.
     last_kernel_opt: dict[str, Any] = field(default_factory=dict)
+    # Most recent run_optimization dispatch skipped with no eligible kernels
+    # (empty batch, no named kernel). Recorded honestly as a non-failure so the
+    # breakdown can surface it; it is otherwise invisible in sbd (the result has
+    # no backend and no kernel_id).
+    last_kernel_opt_dispatch_skip: dict[str, Any] = field(default_factory=dict)
     # Per-action audit (kernel parity): each ``last_<action>`` is the most recent attempt snapshot; ``<action>_attempts`` is a capped list.
     last_baseline: dict[str, Any] = field(default_factory=dict)
     last_profile: dict[str, Any] = field(default_factory=dict)

--- a/inference_optimizer/tests/golden/coordinator_behavior_golden.json
+++ b/inference_optimizer/tests/golden/coordinator_behavior_golden.json
@@ -254,6 +254,7 @@
     "last_explore": {},
     "last_gemm_tuning": {},
     "last_kernel_opt": {},
+    "last_kernel_opt_dispatch_skip": {},
     "last_profile": {},
     "last_profile_args": "",
     "last_profile_status": "",

--- a/inference_optimizer/tests/test_kernel_attempt_summary.py
+++ b/inference_optimizer/tests/test_kernel_attempt_summary.py
@@ -368,6 +368,27 @@ def test_glossary_present_and_documents_efficiency_pct(tmp_path: Path) -> None:
     assert "backend_ladder" in out["field_glossary"]
 
 
+def test_dispatch_skip_reason_surfaced_when_present(tmp_path: Path) -> None:
+    """A no_eligible_kernels dispatch skip rides through to the summary."""
+    state = _make_state(top15=[_top15_entry("k001")])
+    state.last_kernel_opt_dispatch_skip = {
+        "reason": "no_eligible_kernels",
+        "kernels_considered": 5,
+        "message": "no eligible kernels to optimize (...)",
+        "ts": "2026-06-22T00:00:00+00:00",
+    }
+    out = build_kernel_optimization_summary(state, tmp_path)
+    assert out["dispatch_skip_reason"]["reason"] == "no_eligible_kernels"
+    assert out["dispatch_skip_reason"]["kernels_considered"] == 5
+
+
+def test_dispatch_skip_reason_empty_by_default(tmp_path: Path) -> None:
+    """No dispatch skip => empty dict, never a failure marker."""
+    state = _make_state(top15=[_top15_entry("k001")])
+    out = build_kernel_optimization_summary(state, tmp_path)
+    assert out["dispatch_skip_reason"] == {}
+
+
 def test_zero_attempts_session_does_not_crash(tmp_path: Path) -> None:
     state = _make_state(top15=[])
     out = build_kernel_optimization_summary(state, tmp_path)

--- a/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -2538,6 +2538,37 @@ async def test_run_optimization_handler_missing_kernel_id(session_dir):
 
 
 @pytest.mark.asyncio
+async def test_run_optimization_handler_empty_queue_skips_cleanly(session_dir, tmp_path):
+    # Empty eligible queue (all candidates non-reusable) with no specific kernel
+    # named (the post-GEMM auto pass shape) must finish as a clean skip, not a
+    # "missing 'kernel_id'" GEAK failure.
+    candidates_path = _write_candidates_json(
+        tmp_path,
+        {
+            "hot_kernels": [
+                {
+                    "kernel_id": "k001",
+                    "name": "fused_moe",
+                    "source_file": "/sgl-workspace/aiter/moe.py",
+                    "reusable_native_kernel": False,
+                    "duration_us": 100.0,
+                    "gpu_pct": 12.0,
+                },
+            ],
+        },
+    )
+    assert krh._batch_kernel_candidates({"candidates_path": str(candidates_path)}) == []
+    res = await krh.run_optimization_handler(
+        {"candidates_path": str(candidates_path), "session_id": session_dir.name},
+        session_dir=session_dir,
+    )
+    assert res["status"] == "skipped"
+    assert res["reason"] == "no_eligible_kernels"
+    assert res.get("error_class") is None
+    assert res["kernels_considered"] == 1
+
+
+@pytest.mark.asyncio
 async def test_run_optimization_handler_dry_run(session_dir):
     payload = {
         "kernel_id": "fake_kernel_1",

--- a/inference_optimizer/tests/test_shared_state_kernel_opt.py
+++ b/inference_optimizer/tests/test_shared_state_kernel_opt.py
@@ -70,6 +70,32 @@ def test_record_kernel_opt_empty_kernel_id_noop_on_blank_state(state: SharedStat
     assert state.kernel_opt_attempts == {}
 
 
+def test_record_kernel_opt_no_eligible_kernels_skip_is_captured(state: SharedState):
+    """An empty-queue skip is stashed as a non-failure breadcrumb."""
+    state.record_kernel_opt(
+        {
+            "status": "skipped",
+            "reason": "no_eligible_kernels",
+            "kernels_considered": 7,
+            "message": "no eligible kernels to optimize (...)",
+        }
+    )
+    skip = state.last_kernel_opt_dispatch_skip
+    assert skip["reason"] == "no_eligible_kernels"
+    assert skip["kernels_considered"] == 7
+    assert skip["ts"]
+    # A non-failure skip must not pollute the per-kernel ledgers or last_kernel_opt.
+    assert state.last_kernel_opt == {}
+    assert state.kernel_opt_attempts == {}
+    assert state.rejected_kernel_ids == []
+
+
+def test_record_kernel_opt_plain_failure_does_not_set_dispatch_skip(state: SharedState):
+    """A regular failure (no no_eligible_kernels reason) leaves dispatch-skip empty."""
+    state.record_kernel_opt({"status": "failed", "error": "missing 'kernel_id' in payload"})
+    assert state.last_kernel_opt_dispatch_skip == {}
+
+
 # Invariant 2: KEEP wins; non-KEEP never overwrites a pending KEEP
 def test_record_kernel_opt_keep_survives_later_revert(state: SharedState):
     """A later REVERT on a different kernel must not displace an un-integrated KEEP."""


### PR DESCRIPTION
## Summary

Two related kernel-optimization dispatch bugs from the GEAK-dispatch cohort review, plus a breakdown-visibility follow-up. Both wasted runs / distorted GEAK metrics by reporting a non-failure as a failure.

### #600 — Candidates artifact checked before it is visible on shared storage
`_validate_trace_analyze_inputs` checked `Path(candidates_path).exists()` exactly once. On shared/network storage (wekafs) a just-written file can take a moment to become visible, so a valid run was rejected with `missing_candidates_artifact`.

- Add `_exists_with_retry` (5 tries, 0.5s apart) and use it in `_validate_trace_analyze_inputs`, absorbing the brief write-to-visible delay before declaring the file missing.

### #598 — Empty kernel-candidate queue reported as a GEAK failure
After GEMM tuning, `_run_kernel_opt_after_gemm` dispatches a batch with no kernel id. When no eligible kernel remains (all candidates already tried/rejected, below the size cutoff, or not reusable), the request fell into the single-kernel path and returned `{status: failed, error: "missing 'kernel_id' in payload"}` — recorded as a GEAK failure even though GEAK never ran (the dominant "GEAK failure" in the cohort).

- `run_optimization_handler`: when the candidate batch is empty **and** the request named no specific kernel (no `kernel_id` / `source_file` / `candidate`), return `{status: "skipped", reason: "no_eligible_kernels"}` instead of continuing into the single-kernel path. A `skipped` status carries no `error_class` / REVERT decision, so the breakdown recorder never counts it as a failure.
- Add `_names_specific_kernel` helper.

This fixes the root cause at the source rather than relying on the #616 breakdown guard, which only suppresses the mis-attribution while the result still has no backend stamped (a fragile, "backend happens to be empty" coincidence).

### Breakdown visibility for the skip
After #616 stopped fabricating a GEAK invocation for unattributable failures, the empty-queue case became invisible in the session breakdown: no backend (dropped from `geak_invocations`) and no `kernel_id` (skips the `kernel_journey` lanes). To keep the event auditable without re-inflating any failure tally:

- `SharedState.last_kernel_opt_dispatch_skip` captures the skip in `record_kernel_opt` (before the empty-kernel_id early return).
- `build_kernel_optimization_summary` emits a top-level `dispatch_skip_reason` (`{}` when absent), which rides through `collect_kernel_optimization_summary` into `session_breakdown.json` (also mirrored in `state.json` / `reports/kernel_optimization_summary.json`).

## Notes / scope
- Real backend failures are unaffected — they still record into `geak_invocations` / `kernel_journey` / state as before.
- A separate, pre-existing #616 blind spot remains out of scope: pre-dispatch failures with **no backend AND no kernel_id** (e.g. `missing_trace_analyze`) are still dropped from sbd; their journey-lane fallback never fires without a kernel_id. Can be a follow-up.

## Test plan
- [x] `test_profile_and_kernel_handlers.py` + `test_geak_dispatch_routing.py` (142 passed) — incl. new `test_run_optimization_handler_empty_queue_skips_cleanly` and the preserved `missing_kernel_id` (source_file) path.
- [x] `test_shared_state_kernel_opt.py` + `test_kernel_attempt_summary.py` (62 passed) — incl. new skip-capture and `dispatch_skip_reason` passthrough tests.
- [x] `test_breakdown_smoke.py` + `test_reporters_smoke.py` (no regressions).

Made with [Cursor](https://cursor.com)