### PR TITLE
fix(breakdown): perfskills accepted_kernels backfill + geak_v4 provenance

### DIFF
--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -6370,6 +6370,88 @@ def _write_decision_trace_jsonl(
         warnings.append(f"decision_trace: failed to write {target}: {exc!r}")
 
 
+def _perfskills_accepted_kernels_from_journey(
+    result: dict[str, Any],
+    warnings: list[str],
+) -> list[dict[str, Any]]:
+    """Derive the accepted (KEEP/integrated) kernels from ``kernel_journey.json``.
+
+    GEAK-e2e's ``result.json`` carries the aggregate win but can ship an empty
+    ``accepted_kernels`` (e.g. a recovered/intermediate flush after a budget
+    SIGTERM). The sibling ``kernel_journey.json`` still records the per-kernel
+    end-to-end outcome, so this reads it and projects each kernel whose ``e2e``
+    sub-object was integrated (or decided ``KEEP``/``ADOPTED``) into a compact
+    accepted-kernel descriptor. Best-effort: a missing/partial file yields ``[]``
+    and never raises.
+
+    Args:
+        result (dict[str, Any]): The normalized ``result.json`` (carries
+            ``kernel_journey_path`` / ``eval_dir`` used to locate the journey).
+        warnings (list[str]): Shared warnings list (mutated in place).
+
+    Returns:
+        list[dict[str, Any]]: The accepted-kernel descriptors, or ``[]`` when the
+            journey is absent, unreadable, or holds no integrated kernel.
+    """
+    kj_path = str(result.get("kernel_journey_path") or "")
+    if not kj_path:
+        eval_dir = str(result.get("eval_dir") or "")
+        if eval_dir:
+            kj_path = str(Path(eval_dir) / "kernel_journey.json")
+    if not kj_path:
+        return []
+    try:
+        if not Path(kj_path).is_file():
+            return []
+        journey = json.loads(Path(kj_path).read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        warnings.append(f"perfskills: kernel_journey read failed for backfill: {exc}")
+        return []
+    if not isinstance(journey, dict):
+        return []
+
+    accepted: list[dict[str, Any]] = []
+    for k in journey.get("kernels") or []:
+        if not isinstance(k, dict):
+            continue
+        e2e = k.get("e2e")
+        if not isinstance(e2e, dict):
+            continue
+        decision = str(e2e.get("decision") or "").strip().upper()
+        integrated = e2e.get("integrated") is True
+        if not (integrated or decision in ("KEEP", "ADOPTED")):
+            continue
+        kid = str(k.get("kernel_id") or "")
+        if not kid:
+            continue
+        br = k.get("backend_result") if isinstance(k.get("backend_result"), dict) else {}
+        verification = br.get("verification") if isinstance(br.get("verification"), dict) else {}
+        dispatch = k.get("dispatch") if isinstance(k.get("dispatch"), dict) else {}
+        backend = str(
+            verification.get("best_backend")
+            or (dispatch.get("backends") or [None])[0]
+            or ""
+        )
+        accepted.append(
+            {
+                "kernel_id": kid,
+                "name": str(k.get("name") or kid),
+                "gpu_pct": _to_float(k.get("gpu_pct")),
+                "micro_speedup": _to_float(
+                    k.get("micro_speedup") or verification.get("micro_speedup")
+                ),
+                "e2e_gain_pct": _to_float(e2e.get("e2e_gain_pct")),
+                "validated": e2e.get("validated") if isinstance(e2e.get("validated"), bool) else None,
+                "decision": decision or "KEEP",
+                "backend": backend,
+                "target_file": e2e.get("target_file"),
+                "extra_server_args": str(e2e.get("extra_server_args") or ""),
+                "source": "kernel_journey_backfill",
+            }
+        )
+    return accepted
+
+
 def collect_perfskills(
     session_dir: Path,
     state: dict[str, Any],
@@ -6449,6 +6531,20 @@ def collect_perfskills(
     if not isinstance(accepted_heads, list):
         accepted_heads = []
 
+    # Back-fill per-kernel attribution when ``result.json`` shipped the aggregate
+    # win but an empty ``accepted_kernels`` (e.g. a recovered/intermediate flush
+    # after a budget SIGTERM). The sibling ``kernel_journey.json`` still records
+    # the integrated/KEEP kernels, so derive them here to keep the perfskills
+    # section's ``accepted_kernels`` / ``kernels_optimized`` consistent with the
+    # assembled ``kernel_journey``. Only fires on a successful run with an empty
+    # list; a producer-populated list is always preserved verbatim.
+    accepted_kernels_source = "result" if accepted_kernels else None
+    if not accepted_kernels and status == "ok":
+        backfilled = _perfskills_accepted_kernels_from_journey(result, warnings)
+        if backfilled:
+            accepted_kernels = backfilled
+            accepted_kernels_source = "kernel_journey_backfill"
+
     section: dict[str, Any] = {
         "engaged": True,
         "status": status,
@@ -6469,6 +6565,10 @@ def collect_perfskills(
         "output_parity": result.get("output_parity"),
         # What the optimizer actually changed (per-kernel / head / config).
         "accepted_kernels": accepted_kernels,
+        # Provenance of ``accepted_kernels``: ``result`` (producer-populated),
+        # ``kernel_journey_backfill`` (derived from the journey on an empty
+        # result list), or ``None`` (no accepted kernels at all).
+        "accepted_kernels_source": accepted_kernels_source,
         "accepted_heads": accepted_heads,
         "kernels_optimized": len(accepted_kernels),
         "accepted_config": dict(result.get("accepted_config") or {}),

--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -6432,6 +6432,12 @@ def _perfskills_accepted_kernels_from_journey(
             or (dispatch.get("backends") or [None])[0]
             or ""
         )
+        # The GEAK-e2e pipeline's GEAK is the distinct ``geak_v4`` variant; the
+        # raw kernel_journey.json labels it plainly ``geak``. Relabel so the
+        # backfilled attribution matches the assembled kernel_journey / versions
+        # map (which the coordinator records under ``geak_v4``).
+        if backend.lower() == "geak":
+            backend = "geak_v4"
         accepted.append(
             {
                 "kernel_id": kid,

--- a/inference_optimizer/breakdown/recorder/instrument.py
+++ b/inference_optimizer/breakdown/recorder/instrument.py
@@ -597,6 +597,9 @@ _TOOL_META_CACHE: dict[str, dict[str, Any]] = {}
 _TOOL_PROVENANCE: dict[str, dict[str, Any]] = {
     "tracelens": {"root_env": "TRACELENS_ROOT", "version": "git_describe"},
     "geak": {"root_env": "GEAK_ROOT", "version": "git_short"},
+    # GEAK-e2e (PerfSkills) variant; distinct provenance from the generic geak
+    # backend but resolved the same way (its repo SHA under $GEAK_ROOT).
+    "geak_v4": {"root_env": "GEAK_ROOT", "version": "git_short"},
     "mini": {"root_env": "GEAK_ROOT", "version": "git_short"},
     "geak-gaagent": {"root_env": "GEAK_ROOT", "version": "git_short"},
     # forge (Kernel-Forge autonomous loop) is its own backend; it locates its

--- a/inference_optimizer/breakdown/schema.py
+++ b/inference_optimizer/breakdown/schema.py
@@ -915,6 +915,10 @@ class Perfskills(TypedDict, total=False):
         tpot_mean_ms (float | None): Median TPOT (ms).
         output_parity (str | None): Output-parity verdict.
         accepted_kernels (list[Any]): Per-kernel changes the e2e accepted.
+        accepted_kernels_source (str | None): Provenance of ``accepted_kernels``
+            -- ``result`` (producer-populated), ``kernel_journey_backfill``
+            (derived from ``kernel_journey.json`` when the result list was
+            empty), or ``None`` (no accepted kernels).
         accepted_heads (list[Any]): Per-head changes the e2e accepted.
         kernels_optimized (int): ``len(accepted_kernels)``.
         accepted_config (dict[str, Any]): Accepted serving config.
@@ -943,6 +947,7 @@ class Perfskills(TypedDict, total=False):
     tpot_mean_ms: float | None
     output_parity: str | None
     accepted_kernels: list[Any]
+    accepted_kernels_source: str | None
     accepted_heads: list[Any]
     kernels_optimized: int
     accepted_config: dict[str, Any]

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -147,6 +147,69 @@ _OUTCOME_TPUT_KEYS: tuple[str, ...] = (
 )
 _OUTCOME_STATUS_KEYS: tuple[str, ...] = ("status", "verdict", "outcome")
 
+# The GEAK used by the GEAK-e2e (PerfSkills) whole-pipeline optimizer is a
+# distinct variant from the kernel-agent's generic per-kernel ``geak`` backend.
+# Its kernel_journey.json labels everything plainly ``geak`` (versions key,
+# dispatch backends, attempt backend, verification.best_backend), which would
+# collide with — and be indistinguishable from — the generic ``geak`` lane in
+# ``session_breakdown.json`` (the ``versions`` map is keyed by tool name, last
+# write wins). We relabel it to ``geak_v4`` on the way into the breakdown so SBD
+# and trace keep the two provenances separate. The raw interface file is left
+# untouched.
+PERFSKILLS_GEAK_BACKEND: str = "geak_v4"
+
+
+def _relabel_perfskills_geak_journey(journey: dict[str, Any]) -> None:
+    """Relabel the PerfSkills GEAK-e2e ``geak`` provenance to ``geak_v4`` in place.
+
+    Rewrites every ``geak`` token the GEAK-e2e ``kernel_journey.json`` carries
+    (the ``versions`` key, each kernel's ``dispatch.backends`` and
+    ``backend_result`` attempt/verification backends, and the discovery
+    ``recommended_backends``) to :data:`PERFSKILLS_GEAK_BACKEND`, so the
+    assembled breakdown never conflates it with the kernel-agent's generic
+    ``geak`` lane. Best-effort and structure-preserving: unknown shapes are
+    skipped, non-``geak`` tokens are left untouched.
+
+    Args:
+        journey (dict[str, Any]): the parsed GEAK-e2e ``kernel_journey.json``
+            (mutated in place).
+    """
+    def _swap(name: Any) -> Any:
+        return PERFSKILLS_GEAK_BACKEND if str(name or "").lower() == "geak" else name
+
+    def _swap_list(values: Any) -> list[Any]:
+        return [_swap(v) for v in values] if isinstance(values, list) else values
+
+    # Top-level ``versions`` map: re-key geak -> geak_v4 and fix its ``tool``.
+    versions = journey.get("versions")
+    if isinstance(versions, dict) and "geak" in versions:
+        meta = versions.pop("geak")
+        if isinstance(meta, dict):
+            meta["tool"] = PERFSKILLS_GEAK_BACKEND
+        versions[PERFSKILLS_GEAK_BACKEND] = meta
+
+    for run in journey.get("discovery_runs") or []:
+        if not isinstance(run, dict):
+            continue
+        for hk in run.get("hot_kernels") or []:
+            if isinstance(hk, dict) and "recommended_backends" in hk:
+                hk["recommended_backends"] = _swap_list(hk.get("recommended_backends"))
+
+    for k in journey.get("kernels") or []:
+        if not isinstance(k, dict):
+            continue
+        disp = k.get("dispatch")
+        if isinstance(disp, dict) and "backends" in disp:
+            disp["backends"] = _swap_list(disp.get("backends"))
+        br = k.get("backend_result")
+        if isinstance(br, dict):
+            for att in br.get("attempts") or []:
+                if isinstance(att, dict) and "backend" in att:
+                    att["backend"] = _swap(att.get("backend"))
+            verification = br.get("verification")
+            if isinstance(verification, dict) and "best_backend" in verification:
+                verification["best_backend"] = _swap(verification.get("best_backend"))
+
 
 def _first_present(d: dict[str, Any], keys: tuple[str, ...]) -> Any | None:
     """Return ``d[k]`` for the first ``k`` in ``keys`` present + non-None.
@@ -3988,6 +4051,12 @@ class Coordinator:
         if not isinstance(journey, dict):
             return
 
+        # The GEAK-e2e pipeline's GEAK is a distinct variant ("geak_v4") from
+        # the kernel-agent's generic ``geak`` backend. Relabel it before replay
+        # so SBD/trace (versions map, kernel_journey backend lanes) never
+        # conflate the two provenances. See ``_relabel_perfskills_geak_journey``.
+        _relabel_perfskills_geak_journey(journey)
+
         from ..breakdown.recorder import instrument
 
         sdir = self.session_dir
@@ -3995,8 +4064,9 @@ class Coordinator:
         # Stage 1: replay GEAK-e2e's discovery substream (schema §3) so the
         # assembler backfills each kernel's discovery-sourced fields
         # (name/gpu_pct/bound_type/source_file). GEAK-e2e profiles via rocprofv3,
-        # not tracelens, so the route is ``bypass``; ``tool="geak"`` keeps the
-        # version provenance under geak instead of minting an empty bypass entry.
+        # not tracelens, so the route is ``bypass``; ``tool=geak_v4`` keeps the
+        # version provenance under the GEAK-e2e variant instead of minting an
+        # empty bypass entry (and apart from the generic ``geak`` lane).
         for run in (journey.get("discovery_runs") or []):
             if not isinstance(run, dict):
                 continue
@@ -4007,7 +4077,7 @@ class Coordinator:
                     status=str(run.get("status") or "success"),
                     hot_kernels=list(run.get("hot_kernels") or []),
                     scan=run.get("scan") if isinstance(run.get("scan"), dict) else None,
-                    tool="geak",
+                    tool=PERFSKILLS_GEAK_BACKEND,
                 )
             except Exception:  # noqa: BLE001
                 log.debug("perfskills kernel_journey discovery replay failed",

--- a/inference_optimizer/tests/test_kernel_journey.py
+++ b/inference_optimizer/tests/test_kernel_journey.py
@@ -296,6 +296,75 @@ def test_forge_backend_mints_versions_entry(tmp_path: Path) -> None:
     assert "oob" not in versions
 
 
+def test_relabel_perfskills_geak_journey_rewrites_all_geak_tokens() -> None:
+    # The GEAK-e2e pipeline's GEAK must be relabeled to geak_v4 everywhere it
+    # appears in the interface file, so SBD never conflates it with the generic
+    # kernel-agent ``geak`` lane. Non-geak tokens (claude) are untouched.
+    from inference_optimizer.orchestrator.coordinator import (
+        _relabel_perfskills_geak_journey,
+    )
+
+    journey = {
+        "versions": {"geak": {"tool": "geak", "version": "909bc2da"}},
+        "discovery_runs": [
+            {
+                "source": "bypass",
+                "hot_kernels": [
+                    {"kernel_id": "k1", "recommended_backends": ["geak"]},
+                ],
+            }
+        ],
+        "kernels": [
+            {
+                "kernel_id": "k1",
+                "dispatch": {"dispatched": True, "backends": ["geak"]},
+                "backend_result": {
+                    "attempts": [
+                        {"backend": "geak", "status": "succeeded"},
+                        {"backend": "claude", "status": "failed"},
+                    ],
+                    "verification": {"best_backend": "geak"},
+                },
+            }
+        ],
+    }
+    _relabel_perfskills_geak_journey(journey)
+
+    versions = journey["versions"]
+    assert "geak" not in versions
+    assert versions["geak_v4"]["tool"] == "geak_v4"
+    assert versions["geak_v4"]["version"] == "909bc2da"
+    assert journey["discovery_runs"][0]["hot_kernels"][0]["recommended_backends"] == ["geak_v4"]
+    k = journey["kernels"][0]
+    assert k["dispatch"]["backends"] == ["geak_v4"]
+    assert [a["backend"] for a in k["backend_result"]["attempts"]] == ["geak_v4", "claude"]
+    assert k["backend_result"]["verification"]["best_backend"] == "geak_v4"
+
+
+def test_relabel_perfskills_geak_journey_noop_without_geak() -> None:
+    from inference_optimizer.orchestrator.coordinator import (
+        _relabel_perfskills_geak_journey,
+    )
+
+    journey = {
+        "versions": {"tracelens": {"tool": "tracelens"}},
+        "kernels": [{"kernel_id": "k1", "dispatch": {"backends": ["forge"]}}],
+    }
+    _relabel_perfskills_geak_journey(journey)
+    assert set(journey["versions"]) == {"tracelens"}
+    assert journey["kernels"][0]["dispatch"]["backends"] == ["forge"]
+
+
+def test_geak_v4_provenance_resolves_like_geak(tmp_path: Path) -> None:
+    # geak_v4 is registered with the same git-SHA provenance as geak so a real
+    # session mints a populated versions["geak_v4"] entry distinct from geak.
+    sha = _init_git_repo(tmp_path)
+    meta = instrument._tool_metadata("geak_v4", root=str(tmp_path))
+    assert meta["tool"] == "geak_v4"
+    assert meta["commit"] == sha
+    assert meta["version"] == sha
+
+
 def test_discovery_run_carries_duration(tmp_path: Path) -> None:
     instrument.record_kernel_discovery(
         tmp_path,

--- a/inference_optimizer/tests/test_perfskills_breakdown_unit.py
+++ b/inference_optimizer/tests/test_perfskills_breakdown_unit.py
@@ -100,6 +100,153 @@ def test_collect_perfskills_full_success_maps_fields(tmp_path: Path) -> None:
     assert out["eval_dir"] == "runs/perfskills/eval"
 
 
+def _write_kernel_journey(eval_dir: Path) -> Path:
+    """Write a minimal kernel_journey.json with one integrated KEEP kernel."""
+    eval_dir.mkdir(parents=True, exist_ok=True)
+    kj = {
+        "schema_version": 1,
+        "kernels": [
+            {
+                "kernel_id": "fused_moe_kernel_gptq_awq",
+                "name": "fused_moe_kernel_gptq_awq",
+                "gpu_pct": 50.64,
+                "micro_speedup": 1.5902,
+                "dispatch": {"dispatched": True, "backends": ["geak"]},
+                "backend_result": {
+                    "verification": {"micro_speedup": 1.5902, "best_backend": "geak"},
+                },
+                "e2e": {
+                    "kernel_id": "fused_moe_kernel_gptq_awq",
+                    "integrated": True,
+                    "e2e_gain_pct": 16.049,
+                    "validated": True,
+                    "decision": "KEEP",
+                    "target_file": "config/integrate_moe_tuned/E=384.json",
+                    "extra_server_args": "--max-num-batched-tokens 16384",
+                },
+            },
+            {
+                # Cut-off kernel: dispatched but no e2e → must NOT be accepted.
+                "kernel_id": "fwd_grouped_kernel_stage1",
+                "name": "fwd_grouped_kernel_stage1",
+                "gpu_pct": 15.55,
+                "dispatch": {"dispatched": True, "backends": ["geak"]},
+                "backend_result": {"attempts": [], "verification": {}},
+            },
+        ],
+    }
+    path = eval_dir / "kernel_journey.json"
+    path.write_text(json.dumps(kj), encoding="utf-8")
+    return path
+
+
+def test_collect_perfskills_backfills_accepted_kernels_from_journey(tmp_path: Path) -> None:
+    # result.json shipped the aggregate win but an empty accepted_kernels (a
+    # recovered/intermediate flush). The sibling kernel_journey.json holds the
+    # integrated KEEP kernel, so the collector must back-fill it.
+    eval_dir = tmp_path / "perfskills" / "eval"
+    _write_kernel_journey(eval_dir)
+    state = {
+        "kernel_optimizer": "perfskills",
+        "perfskills_result": {
+            "status": "ok",
+            "baseline_throughput_tok_s": 461.314,
+            "final_throughput_tok_s": 535.352,
+            "throughput_speedup": 1.1605,
+            "accepted_kernels": [],
+            "recovered_from_disk": True,
+            "eval_dir": str(eval_dir),
+        },
+    }
+    warnings: list[str] = []
+    out = collect_perfskills(tmp_path, state, warnings)
+
+    assert out["kernels_optimized"] == 1
+    assert out["accepted_kernels_source"] == "kernel_journey_backfill"
+    only = out["accepted_kernels"][0]
+    assert only["kernel_id"] == "fused_moe_kernel_gptq_awq"
+    assert only["decision"] == "KEEP"
+    assert only["backend"] == "geak"
+    assert only["e2e_gain_pct"] == 16.049
+    assert only["micro_speedup"] == 1.5902
+    assert only["source"] == "kernel_journey_backfill"
+
+
+def test_collect_perfskills_backfill_via_explicit_journey_path(tmp_path: Path) -> None:
+    # kernel_journey_path takes precedence over deriving it from eval_dir.
+    eval_dir = tmp_path / "perfskills" / "eval"
+    kj_path = _write_kernel_journey(eval_dir)
+    state = {
+        "kernel_optimizer": "perfskills",
+        "perfskills_result": {
+            "status": "ok",
+            "throughput_speedup": 1.16,
+            "accepted_kernels": [],
+            "kernel_journey_path": str(kj_path),
+        },
+    }
+    out = collect_perfskills(tmp_path, state, [])
+    assert out["kernels_optimized"] == 1
+    assert out["accepted_kernels_source"] == "kernel_journey_backfill"
+
+
+def test_collect_perfskills_does_not_overwrite_populated_kernels(tmp_path: Path) -> None:
+    # A producer-populated accepted_kernels list must be preserved verbatim and
+    # marked as sourced from the result, never replaced by the journey.
+    eval_dir = tmp_path / "perfskills" / "eval"
+    _write_kernel_journey(eval_dir)
+    state = {
+        "kernel_optimizer": "perfskills",
+        "perfskills_result": {
+            "status": "ok",
+            "throughput_speedup": 1.16,
+            "accepted_kernels": ["rmsnorm"],
+            "eval_dir": str(eval_dir),
+        },
+    }
+    out = collect_perfskills(tmp_path, state, [])
+    assert out["accepted_kernels"] == ["rmsnorm"]
+    assert out["accepted_kernels_source"] == "result"
+    assert out["kernels_optimized"] == 1
+
+
+def test_collect_perfskills_no_backfill_on_failure(tmp_path: Path) -> None:
+    # A non-ok run must not back-fill (the e2e never landed a real win).
+    eval_dir = tmp_path / "perfskills" / "eval"
+    _write_kernel_journey(eval_dir)
+    state = {
+        "kernel_optimizer": "perfskills",
+        "perfskills_result": {
+            "status": "error",
+            "error_class": "timeout",
+            "accepted_kernels": [],
+            "eval_dir": str(eval_dir),
+        },
+    }
+    out = collect_perfskills(tmp_path, state, [])
+    assert out["accepted_kernels"] == []
+    assert out["accepted_kernels_source"] is None
+    assert out["kernels_optimized"] == 0
+
+
+def test_collect_perfskills_backfill_missing_journey_is_noop(tmp_path: Path) -> None:
+    # ok run but no kernel_journey.json on disk → empty list, no crash.
+    eval_dir = tmp_path / "perfskills" / "eval"
+    eval_dir.mkdir(parents=True, exist_ok=True)
+    state = {
+        "kernel_optimizer": "perfskills",
+        "perfskills_result": {
+            "status": "ok",
+            "throughput_speedup": 1.16,
+            "accepted_kernels": [],
+            "eval_dir": str(eval_dir),
+        },
+    }
+    out = collect_perfskills(tmp_path, state, [])
+    assert out["accepted_kernels"] == []
+    assert out["accepted_kernels_source"] is None
+
+
 def test_collect_perfskills_speedup_only_gain_and_bad_kernels(tmp_path: Path) -> None:
     state = {
         "kernel_optimizer": "perfskills",

--- a/inference_optimizer/tests/test_perfskills_breakdown_unit.py
+++ b/inference_optimizer/tests/test_perfskills_breakdown_unit.py
@@ -166,7 +166,8 @@ def test_collect_perfskills_backfills_accepted_kernels_from_journey(tmp_path: Pa
     only = out["accepted_kernels"][0]
     assert only["kernel_id"] == "fused_moe_kernel_gptq_awq"
     assert only["decision"] == "KEEP"
-    assert only["backend"] == "geak"
+    # The GEAK-e2e GEAK is relabeled to the distinct geak_v4 variant.
+    assert only["backend"] == "geak_v4"
     assert only["e2e_gain_pct"] == 16.049
     assert only["micro_speedup"] == 1.5902
     assert only["source"] == "kernel_journey_backfill"


### PR DESCRIPTION
Two related fixes that make the PerfSkills/GEAK-e2e KERNEL phase faithfully represented in `session_breakdown.json` (and therefore the langfuse trace, which attaches the full breakdown).

## 1. Back-fill `perfskills.accepted_kernels` from `kernel_journey`

When GEAK-e2e ships an aggregate win in `result.json` but an **empty `accepted_kernels`** (e.g. a recovered/intermediate flush after a budget SIGTERM, `result_source: disk_intermediate_win`), the `perfskills` section reported `kernels_optimized: 0` / `accepted_kernels: []` even though the assembled `kernel_journey` clearly showed an integrated `KEEP` kernel — the "which kernel earned the gain" attribution was silently lost.

`collect_perfskills` now derives the accepted kernels from the sibling `kernel_journey.json` (kernels whose `e2e` was `integrated` / `KEEP` / `ADOPTED`) whenever a **successful** run shipped an empty list. A producer-populated list is always preserved verbatim. New `accepted_kernels_source` field records provenance (`result` | `kernel_journey_backfill` | `None`). Because the fix is in the collector, re-exporting historical recovered sessions picks it up immediately.

## 2. Label the GEAK-e2e GEAK as `geak_v4` (distinct from generic `geak`)

The GEAK-e2e pipeline uses a distinct GEAK variant from the kernel-agent's generic per-kernel `geak` backend, but its `kernel_journey.json` labels everything plainly `geak`. In SBD the `versions` map is keyed by tool name (last write wins), so the two provenances **collided and were indistinguishable** in SBD and trace.

We now relabel the GEAK-e2e provenance to `geak_v4` on the way into the breakdown (coordinator replay + the accepted_kernels backfill), and register `geak_v4` in the recorder's tool-provenance registry so it resolves its repo SHA like `geak`. Raw interface files are untouched.

### Validated on a real recovered session
`moonshotai-Kimi-K2.6 / 20260620T152724Z` (recovered_intermediate):
- Before → `kernels_optimized: 0`, `versions.geak` (collided with generic geak lane).
- After → `kernels_optimized: 1` recovering `fused_moe_kernel_gptq_awq` (KEEP, +16.05% e2e, **geak_v4**, micro_speedup 1.59); `versions.geak_v4` distinct, no plain `geak`.

## Changes
- `breakdown/collectors.py`: `_perfskills_accepted_kernels_from_journey()` + backfill wiring + `accepted_kernels_source` + geak_v4 relabel of the backfilled backend.
- `breakdown/schema.py`: declare `accepted_kernels_source` on `Perfskills`.
- `orchestrator/coordinator.py`: `_relabel_perfskills_geak_journey()` + wire into `_record_perfskills_kernel_journey` (discovery tool `geak_v4`).
- `breakdown/recorder/instrument.py`: register `geak_v4` in `_TOOL_PROVENANCE`.
- `tests/`: backfill cases + relabel cases + geak_v4 provenance.

## Test plan
- [x] `pytest test_perfskills_breakdown_unit.py test_kernel_journey.py test_breakdown_smoke.py test_breakdown_exporter_unit.py test_coordinator_runtime.py` (223 passed)
- [x] Manual end-to-end validation on the real Kimi-K2.6 recovered session

## Notes / follow-ups (out of scope)
- Producer-side `kernel_id` inconsistency in `kernel_journey.json` discovery vs `kernels[]` (leading underscore `_fwd_grouped_kernel_stage1` vs `fwd_grouped_kernel_stage1`) splits one kernel into two journey entries — a GEAK-e2e `build_kernel_journey` normalization fix, left separate.
- `capability_summary` still has a fixed `geak` lane (no `geak_v4` lane); the perfskills capability/attribution is already tracked under its own `perfskills` family, so this is left as an optional follow-up rather than a schema change.
- Empty trace on this session was due to langfuse being disabled at run time, not a code gap (the emitter already attaches the full breakdown).
