### PR TITLE
chore: pin GEAK to v3.2.2 release tag

### DIFF
--- a/kernel-agent/scripts/install.sh
+++ b/kernel-agent/scripts/install.sh
@@ -126,10 +126,15 @@ if [ -z "${SAFE_API_KEY:-}" ] || [ -z "${OPENAI_BASE_URL:-}" ] || [ -z "${CURSOR
 fi
 GEAK_REPO="${GEAK_REPO:-https://github.com/AMD-AGI/GEAK.git}"
 GEAK_ROOT="${GEAK_ROOT:-${_open_source_root}/GEAK}"
-# Pin GEAK to the v3.2.1 release, which carries the GEMM tuning entrypoint
-# used by kernel-agent/tools/gemm_tuning.py (minisweagent.run.gemm_tuning).
-# Operators can override with GEAK_REF=<tag|branch|sha>.
-GEAK_REF="${GEAK_REF:-v3.2.1}"
+# Pin GEAK to the v3.2.2 release (commit d3f94cbe, cut from the
+# chore/subagent-docs-upstream-resource branch / PR #290). It carries the
+# GEMM tuning entrypoint used by kernel-agent/tools/gemm_tuning.py
+# (minisweagent.run.gemm_tuning) plus the upstreamed subagent docs/resources.
+# A tag is a permanent ref: it stays reachable regardless of how PR #290 is
+# merged to main (merge/squash/rebase) or whether the source branch is later
+# deleted, unlike a branch-HEAD SHA. Operators can override with
+# GEAK_REF=<tag|branch|sha>; bump to the next patch tag if the branch advances.
+GEAK_REF="${GEAK_REF:-v3.2.2}"
 OOB_SRC="${OOB_SRC:-${HYPERLOOM_BUNDLE}/OOB}"
 OOB_ROOT="${OOB_ROOT:-${OOB_CLI_ROOT:-${_open_source_root}/OOB}}"
 GEAK_CONFIG="${GEAK_CONFIG:-${HYPERLOOM_RUNTIME_DIR}/geak-config/local.yaml}"


### PR DESCRIPTION
## Summary
- Repoint `GEAK_REF` in `kernel-agent/scripts/install.sh` from the `v3.2.1` tag to the new [`v3.2.2`](https://github.com/AMD-AGI/GEAK/releases/tag/v3.2.2) release tag (commit `d3f94cbe`).
- `v3.2.2` was cut from the HEAD of GEAK's [`chore/subagent-docs-upstream-resource`](https://github.com/AMD-AGI/GEAK/tree/chore/subagent-docs-upstream-resource) branch (GEAK PR #290).

## Why a tag (not a branch or branch-HEAD SHA)
GEAK PR #290 is still in review. We want Hyperloom to consume that branch's content now, durably:
- A **tag** is a permanent ref. It keeps its target commit reachable regardless of how PR #290 eventually merges to main (merge commit / squash / rebase) or whether the source branch is later deleted. GEAK allows squash merges and does not auto-delete branches, but a branch-HEAD SHA would still become unreachable (and GC-eligible) after a squash merge + manual branch cleanup.
- A **branch name** pin would drift as the branch moves and break outright on branch deletion.
- A **branch-HEAD SHA** is reproducible but hostage to the branch's continued existence.
- Using a tag also matches the prior convention (Hyperloom previously pinned `GEAK_REF=v3.2.1`).

## Notes
- `GEAK_REF` in `kernel-agent/scripts/install.sh` is the single source of truth; `inference_optimizer/scripts/install.sh` only references it in comments.
- The clone logic handles tags natively via `git clone --depth 1 --branch "$GEAK_REF"` (kernel-agent/scripts/install.sh#L847).
- If review on PR #290 adds commits, cut `v3.2.3` from the updated HEAD and bump this pin.
- Operators can still override with `GEAK_REF=<tag|branch|sha>`.

## Test plan
- [ ] Run `kernel-agent/scripts/install.sh` and confirm GEAK clones at the `v3.2.2` tag (commit `d3f94cbe`)
- [ ] Confirm `gemm_tuning.py` entrypoint still resolves against the new checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
