### PR TITLE
feat(profile): profile-scoped OSL control + serialization-safe capture cap (#571, #570)

### DIFF
--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -79,7 +79,7 @@ read them when invoked standalone.
 | `CONC`            | `8`         | Benchmark concurrency.                                               |
 | `ISL`             | `256`       | Input sequence length.                                               |
 | `OSL`             | `256`       | Output sequence length.                                              |
-| `PROFILE_OSL`     | unset (reuse `OSL`) | Profiling-phase output sequence length (set by `--profile-osl`). When set, overrides `OSL` for the roofline/profile server **only** so its torch-profiler trace stays serializable; baseline/optimize phases still run at `OSL`. |
+| `PROFILE_OSL`     | unset → `min(OSL, 1024)` | Profiling-phase output sequence length (set by `--profile-osl`). Overrides `OSL` for the roofline/profile server **only** so its torch-profiler trace stays serializable; baseline/optimize phases still run at `OSL`. When unset, the profile phase uses `min(OSL, 1024)` and is auto-lowered further if needed to keep the capture window within the serialization cap. |
 | `MAX_MODEL_LEN`   | `8192`      | Server-side max sequence length.                                     |
 | `PRECISION`       | `bf16`      | Model precision (`bf16`, `fp8`, `mxfp4`, ...).                       |
 | `RANDOM_RANGE_RATIO` | unset    | Optional Magpie random-range jitter.                                 |

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -79,6 +79,7 @@ read them when invoked standalone.
 | `CONC`            | `8`         | Benchmark concurrency.                                               |
 | `ISL`             | `256`       | Input sequence length.                                               |
 | `OSL`             | `256`       | Output sequence length.                                              |
+| `PROFILE_OSL`     | unset (reuse `OSL`) | Profiling-phase output sequence length (set by `--profile-osl`). When set, overrides `OSL` for the roofline/profile server **only** so its torch-profiler trace stays serializable; baseline/optimize phases still run at `OSL`. |
 | `MAX_MODEL_LEN`   | `8192`      | Server-side max sequence length.                                     |
 | `PRECISION`       | `bf16`      | Model precision (`bf16`, `fp8`, `mxfp4`, ...).                       |
 | `RANDOM_RANGE_RATIO` | unset    | Optional Magpie random-range jitter.                                 |

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -3082,6 +3082,15 @@ async def _run_optimize(args: argparse.Namespace) -> int:
             if val:
                 os.environ[env_name] = str(val)
                 print(f"  re-exported {env_name:<14s}: {val}")
+        # Profile-scoped OSL: an explicit --profile-osl on this resume wins;
+        # otherwise re-export the value persisted from the original run so the
+        # profile phase doesn't silently revert to its default (and re-trigger
+        # the oversized-trace / EngineCore-timeout failure this guards against).
+        _resume_profile_osl = getattr(args, "profile_osl", None) or getattr(state, "profile_osl", 0)
+        if _resume_profile_osl:
+            os.environ["PROFILE_OSL"] = str(int(_resume_profile_osl))
+            state.profile_osl = int(_resume_profile_osl)
+            print(f"  re-exported PROFILE_OSL   : {int(_resume_profile_osl)}")
         if state.precision:
             os.environ["PRECISION"] = state.precision
             print(f"  re-exported PRECISION     : {state.precision}")
@@ -4097,10 +4106,12 @@ def _build_parser() -> argparse.ArgumentParser:
             else None
         ),
         help=(
-            "Profiling-phase output sequence length (issue #571). When set, it "
-            "overrides --osl for the roofline/profile server ONLY, so its "
-            "torch-profiler trace stays serializable; baseline/optimize phases "
-            "still run at --osl. Default $PROFILE_OSL or unset (reuse --osl)."
+            "Profiling-phase output sequence length. When set, it overrides "
+            "--osl for the roofline/profile server ONLY, so its torch-profiler "
+            "trace stays serializable; baseline/optimize phases still run at "
+            "--osl. Default $PROFILE_OSL; when unset the profile phase uses "
+            "min(--osl, 1024) and is auto-lowered further if needed to keep the "
+            "capture window within the serialization cap."
         ),
     )
     opt.add_argument(

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -3269,6 +3269,11 @@ async def _run_optimize(args: argparse.Namespace) -> int:
         os.environ["MAX_MODEL_LEN"] = str(max_model_len)
         os.environ["ISL"] = str(args.isl)
         os.environ["OSL"] = str(args.osl)
+        # Profile-scoped OSL (issue #571): exported only when explicitly set, so
+        # the profile/roofline materializer can decouple its OSL from the served
+        # workload. Unset leaves the profile phase on the global --osl.
+        if getattr(args, "profile_osl", None) is not None:
+            os.environ["PROFILE_OSL"] = str(args.profile_osl)
         os.environ["PRECISION"] = args.precision
         # Mirror resolved framework_version into env (explicit > auto-detect > unset; see _resolve_framework_version).
         _fw_version_for_env = (getattr(args, "framework_version", None) or "").strip() or (
@@ -4082,6 +4087,22 @@ def _build_parser() -> argparse.ArgumentParser:
                       help="Input sequence length (default $ISL or 256)")
     opt.add_argument("--osl", type=int, default=int(os.environ.get("OSL", "256")),
                       help="Output sequence length (default $OSL or 256)")
+    opt.add_argument(
+        "--profile-osl",
+        dest="profile_osl",
+        type=int,
+        default=(
+            int(os.environ["PROFILE_OSL"])
+            if os.environ.get("PROFILE_OSL", "").strip().isdigit()
+            else None
+        ),
+        help=(
+            "Profiling-phase output sequence length (issue #571). When set, it "
+            "overrides --osl for the roofline/profile server ONLY, so its "
+            "torch-profiler trace stays serializable; baseline/optimize phases "
+            "still run at --osl. Default $PROFILE_OSL or unset (reuse --osl)."
+        ),
+    )
     opt.add_argument(
         "--reference-script",
         dest="reference_script",

--- a/inference_optimizer/cli_bootstrap.py
+++ b/inference_optimizer/cli_bootstrap.py
@@ -209,6 +209,8 @@ def _seed_shared_state(
         conc=_int_env_or_arg("conc", "CONC"),
         isl=_int_env_or_arg("isl", "ISL"),
         osl=_int_env_or_arg("osl", "OSL"),
+        # Persist the explicit profile OSL so a fresh-shell resume keeps it.
+        profile_osl=_int_env_or_arg("profile_osl", "PROFILE_OSL"),
         max_model_len=_int_env_or_arg("max_model_len", "MAX_MODEL_LEN"),
         kernel_enabled=not getattr(args, "no_kernel", False),
         continue_kernel_after_gemm=bool(

--- a/inference_optimizer/orchestrator/action_executors/_workload_envs.py
+++ b/inference_optimizer/orchestrator/action_executors/_workload_envs.py
@@ -348,6 +348,17 @@ def materialize_config_with_envs(
             r_val = float(envs.get("RANDOM_RANGE_RATIO", 1.0))
         except (TypeError, ValueError):
             r_val = 1.0
+        # Profile-scoped OSL control (issue #571): the profile/roofline phase
+        # may run a lighter OSL than the served workload so its torch-profiler
+        # trace stays serializable (#570). When PROFILE_OSL is set it overrides
+        # the profile server's OSL (and feeds the steady-state window math
+        # below); when unset this is byte-for-byte the previous behavior (the
+        # profile reuses the global OSL). Scoped to is_profile so baseline /
+        # optimize configs are never affected.
+        _profile_osl_raw = os.environ.get("PROFILE_OSL", "").strip()
+        if _profile_osl_raw.isdigit() and int(_profile_osl_raw) > 0:
+            osl_val = int(_profile_osl_raw)
+            envs["OSL"] = osl_val
         safe_conc = max(conc_val, 1)
         safe_osl = max(osl_val, 1)
         max_iters = min(1024, max(256, (osl_val * 16) // safe_conc))

--- a/inference_optimizer/orchestrator/action_executors/_workload_envs.py
+++ b/inference_optimizer/orchestrator/action_executors/_workload_envs.py
@@ -19,6 +19,7 @@ Used by ``baseline.py`` (materializes once, surfaces the path) and the
 from __future__ import annotations
 
 import logging
+import math
 import os
 import re
 import shutil
@@ -47,6 +48,17 @@ from ...model_config_utils import _load_model_config_dict, _model_is_gemma2
 log = logging.getLogger(__name__)
 
 _MOE_RUNNER_BACKEND_RE = re.compile(r"(?:^|\s)--moe-runner-backend(?:[=\s]+)\S+")
+
+# Profile-phase capture defaults (issue #571 / #570). Trace size scales with
+# captured decode steps; an oversized capture serializes too slowly and kills
+# the engine (EngineCore RPC timeout). 128 captured steps was measured
+# serialization-safe (~160 MB/rank, ~29s) on a large TP=8 MoE, so smaller
+# models stay within budget. Tunable via HYPERLOOM_PROFILE_MAX_STEPS_CAP.
+_DEFAULT_PROFILE_MAX_STEPS = 128
+# Default profile OSL ceiling when --profile-osl / PROFILE_OSL is unset: the
+# profile reuses min(served OSL, this) so its trace stays light without
+# distorting the served workload more than necessary.
+_PROFILE_DEFAULT_OSL = 1024
 
 
 def _remove_moe_runner_backend_arg(args: str) -> str:
@@ -335,10 +347,13 @@ def materialize_config_with_envs(
     conc_val = int(envs.get("CONC") or 8)
 
     # Steady-state window for profiling configs (detected by PROFILE env or
-    # ``profiler.torch_profiler.enabled``). Formulas match the TraceLens
-    # profiling skill (RANDOM_RANGE_RATIO defaults to 1.0):
-    #   max_iters   = min(1024, max(256, OSL * 16 / CONC))
-    #   delay_iters = OSL * (R + 1) * 3 - max_iters / 2
+    # ``profiler.torch_profiler.enabled``). The captured-step count is capped at
+    # a serialization-safe budget; the profile OSL is resolved (and lowered if
+    # needed) so the steady-state floor fits that cap (RANDOM_RANGE_RATIO
+    # defaults to 1.0):
+    #   max_iters    = HYPERLOOM_PROFILE_MAX_STEPS_CAP (default 128)
+    #   steady_floor = ceil(OSL * (1 + R) / (2 * CONC))   # must be <= max_iters
+    #   delay_iters  = OSL * (R + 1) * 3 - max_iters / 2
     is_profile = str(envs.get("PROFILE", "")).strip() == "1" or (
         bench.get("profiler", {}).get("torch_profiler", {}).get("enabled") is True
     )
@@ -348,29 +363,82 @@ def materialize_config_with_envs(
             r_val = float(envs.get("RANDOM_RANGE_RATIO", 1.0))
         except (TypeError, ValueError):
             r_val = 1.0
-        # Profile-scoped OSL control (issue #571): the profile/roofline phase
-        # may run a lighter OSL than the served workload so its torch-profiler
-        # trace stays serializable (#570). When PROFILE_OSL is set it overrides
-        # the profile server's OSL (and feeds the steady-state window math
-        # below); when unset this is byte-for-byte the previous behavior (the
-        # profile reuses the global OSL). Scoped to is_profile so baseline /
-        # optimize configs are never affected.
-        _profile_osl_raw = os.environ.get("PROFILE_OSL", "").strip()
-        if _profile_osl_raw.isdigit() and int(_profile_osl_raw) > 0:
-            osl_val = int(_profile_osl_raw)
-            envs["OSL"] = osl_val
         safe_conc = max(conc_val, 1)
+        # --- Profile capture window cap (issue #571 / #570) ----------------
+        # Cap captured decode steps at a serialization-safe default so the
+        # torch-profiler trace can be written without starving the engine RPC
+        # (the EngineCore timeout crash). Operator-tunable.
+        try:
+            cap = int(
+                os.environ.get("HYPERLOOM_PROFILE_MAX_STEPS_CAP", "").strip()
+                or _DEFAULT_PROFILE_MAX_STEPS
+            )
+        except (TypeError, ValueError):
+            cap = _DEFAULT_PROFILE_MAX_STEPS
+        if cap < 1:
+            cap = _DEFAULT_PROFILE_MAX_STEPS
+
+        # --- Resolve the profile-scoped OSL --------------------------------
+        # The profile/roofline phase may run a lighter OSL than the served
+        # workload so its trace stays serializable; baseline/optimize keep the
+        # global OSL. PROFILE_OSL (via --profile-osl) is an explicit operator
+        # choice and is honored as-is; otherwise default to
+        # min(served OSL, _PROFILE_DEFAULT_OSL). Scoped to is_profile so
+        # baseline/optimize configs are never affected.
+        _profile_osl_raw = os.environ.get("PROFILE_OSL", "").strip()
+        profile_osl_explicit = _profile_osl_raw.isdigit() and int(_profile_osl_raw) > 0
+        if profile_osl_explicit:
+            osl_val = int(_profile_osl_raw)
+        else:
+            osl_val = min(osl_val, _PROFILE_DEFAULT_OSL)
         safe_osl = max(osl_val, 1)
-        max_iters = min(1024, max(256, (osl_val * 16) // safe_conc))
+
+        # Steady-state floor: minimum captured decode steps for the splitter to
+        # isolate a steady-state window (mirrors TraceLens
+        # find_steady_state_window). The capture must be >= this or the splitter
+        # reports trace_split_no_steady_state.
+        steady_floor = math.ceil(safe_osl * (1.0 + r_val) / (2.0 * safe_conc))
+        if steady_floor > cap:
+            if profile_osl_explicit:
+                # Honor the operator's explicit OSL; warn that the window may
+                # not contain a steady-state segment at this OSL + cap.
+                log.warning(
+                    "PROFILE_OSL=%d needs %d captured steps to reach steady "
+                    "state, above the profile cap of %d; the trace may lack a "
+                    "steady-state window (trace_split_no_steady_state). Lower "
+                    "--profile-osl or raise HYPERLOOM_PROFILE_MAX_STEPS_CAP.",
+                    osl_val, steady_floor, cap,
+                )
+            else:
+                # Auto path: lower the profile OSL so the floor fits the cap
+                # (largest OSL whose steady floor stays <= cap).
+                fitted_osl = max(1, int(cap * 2 * safe_conc / (1.0 + r_val)))
+                log.warning(
+                    "profile OSL %d would need %d captured steps to reach "
+                    "steady state (> cap %d); lowering profile OSL to %d so the "
+                    "capture stays serializable. Baseline/optimize unaffected.",
+                    osl_val, steady_floor, cap, fitted_osl,
+                )
+                osl_val = fitted_osl
+                safe_osl = max(osl_val, 1)
+                steady_floor = math.ceil(safe_osl * (1.0 + r_val) / (2.0 * safe_conc))
+
+        # Profile server runs at the resolved (possibly reduced) profile OSL,
+        # decoupled from the served --osl.
+        envs["OSL"] = osl_val
+
+        # Capture up to the cap (>= steady_floor in the auto path). delay_iters
+        # keeps the established warmup formula.
+        max_iters = cap
         delay_iters = int(osl_val * (r_val + 1) * 3 - max_iters / 2)
         # Clamp >= 0 (tiny OSL / huge R can produce a negative delay).
         if delay_iters < 0:
             delay_iters = 0
-        # Operator override for a small eager FlyDSL profile: the default
-        # >=256-step capture is unsavable in eager mode for a 30B MoE, but
-        # eager is the only mode recording the flydsl_moe frames PR#668 keys
-        # on. Set HYPERLOOM_PROFILE_MAX_ITERS small (e.g. 8) with the eager
-        # profile patch.
+        # Operator hard-override of captured steps for a small eager FlyDSL
+        # profile (e.g. 8), which is unsavable in eager mode at the default
+        # capture but is the only mode recording the flydsl_moe frames PR#668
+        # keys on. Honored verbatim; warn when outside the safe band rather
+        # than silently clamping.
         _ovr = os.environ.get("HYPERLOOM_PROFILE_MAX_ITERS", "").strip()
         if _ovr.isdigit() and int(_ovr) > 0:
             max_iters = int(_ovr)
@@ -380,6 +448,20 @@ def materialize_config_with_envs(
                 delay_iters = 8
             if delay_iters < 0:
                 delay_iters = 0
+            if max_iters < steady_floor:
+                log.warning(
+                    "HYPERLOOM_PROFILE_MAX_ITERS=%d is below the steady-state "
+                    "floor of %d; the trace may lack a steady-state window "
+                    "(trace_split_no_steady_state).",
+                    max_iters, steady_floor,
+                )
+            elif max_iters > cap:
+                log.warning(
+                    "HYPERLOOM_PROFILE_MAX_ITERS=%d exceeds the serialization-"
+                    "safe cap of %d; the trace may be too large to serialize "
+                    "(EngineCore RPC timeout).",
+                    max_iters, cap,
+                )
         # TraceLens #194 §2: NUM_PROMPTS must let the engine reach
         # ``delay_iters + max_iters`` decode steps before running out of
         # prompts (N prompts ≈ N * OSL / CONC iters; invert + 2x buffer).

--- a/inference_optimizer/orchestrator/shared_state.py
+++ b/inference_optimizer/orchestrator/shared_state.py
@@ -446,6 +446,10 @@ class SharedState:
     conc: int = 0
     isl: int = 0
     osl: int = 0
+    # Profile-phase output length (from --profile-osl). 0 = unset (profile
+    # defaults to min(osl, 1024)). Persisted so a fresh-shell resume keeps the
+    # operator's explicit profile OSL instead of reverting to the default.
+    profile_osl: int = 0
     max_model_len: int = 0
     kernel_enabled: bool = True
     # When False (``--no-explore``) EXPLORE is skipped: PRELUDE/FRAMEWORK_PR route to KERNEL (or SWEEP).

--- a/inference_optimizer/tests/golden/coordinator_behavior_golden.json
+++ b/inference_optimizer/tests/golden/coordinator_behavior_golden.json
@@ -317,6 +317,7 @@
     "policy_denial_streak": {},
     "precision": "",
     "profile_attempts": [],
+    "profile_osl": 0,
     "pruned_families": [],
     "recipe_sediment_enabled": true,
     "reference_envs": {},

--- a/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -425,7 +425,11 @@ def test_materialize_profile_window_vllm_skill_formula_default_R(
     tmp_path,
     monkeypatch,
 ):
-    """vLLM: OSL=1024, CONC=32, R unset → max=512, delay=5888 per skill."""
+    """vLLM: OSL=1024, CONC=32, R unset → capture capped at 128, delay=6080.
+
+    Capture is the serialization-safe cap (default 128); delay keeps the
+    warmup formula OSL*(R+1)*3 - max_iters/2 = 1024*2*3 - 64 = 6080.
+    """
     import yaml
 
     _clear_workload_env(monkeypatch)
@@ -433,15 +437,15 @@ def test_materialize_profile_window_vllm_skill_formula_default_R(
     out = _materialize_config_with_envs(src, tmp_path)
     rendered = yaml.safe_load(out.read_text())
     extra = rendered["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
-    assert "--profiler-config.delay_iterations 5888" in extra, extra
-    assert "--profiler-config.max_iterations 512" in extra, extra
+    assert "--profiler-config.delay_iterations 6080" in extra, extra
+    assert "--profiler-config.max_iterations 128" in extra, extra
 
 
 def test_materialize_profile_window_vllm_skill_formula_explicit_R(
     tmp_path,
     monkeypatch,
 ):
-    """vLLM: explicit R=0.5 must shrink delay (skill: 3*OSL*(R+1) term)."""
+    """vLLM: explicit R=0.5 must shrink delay (warmup: 3*OSL*(R+1) term)."""
     import yaml
 
     _clear_workload_env(monkeypatch)
@@ -450,10 +454,10 @@ def test_materialize_profile_window_vllm_skill_formula_explicit_R(
     out = _materialize_config_with_envs(src, tmp_path)
     rendered = yaml.safe_load(out.read_text())
     envs = rendered["benchmark"]["envs"]
-    # R=0.5: delay = 1024 * 1.5 * 3 - 512/2 = 4608 - 256 = 4352; max=512.
+    # R=0.5: max capped at 128; delay = 1024 * 1.5 * 3 - 128/2 = 4608 - 64 = 4544.
     extra = envs["EXTRA_VLLM_ARGS"]
-    assert "--profiler-config.delay_iterations 4352" in extra, extra
-    assert "--profiler-config.max_iterations 512" in extra, extra
+    assert "--profiler-config.delay_iterations 4544" in extra, extra
+    assert "--profiler-config.max_iterations 128" in extra, extra
     # And R must round-trip into the YAML as a float, not stringified-int.
     assert envs["RANDOM_RANGE_RATIO"] == 0.5
 
@@ -471,8 +475,9 @@ def test_materialize_profile_window_sglang_skill_formula(
     out = _materialize_config_with_envs(src, tmp_path)
     rendered = yaml.safe_load(out.read_text())
     body = json.loads(rendered["benchmark"]["envs"]["PROFILE_EXTRA_BODY"])
-    assert body["start_step"] == 5888
-    assert body["num_steps"] == 512
+    # max capped at 128; delay = 1024 * 2 * 3 - 128/2 = 6080.
+    assert body["start_step"] == 6080
+    assert body["num_steps"] == 128
 
 
 def test_materialize_persists_inferencex_path_for_magpie(
@@ -494,7 +499,8 @@ def test_materialize_profile_window_clamps_to_skill_floor(
     tmp_path,
     monkeypatch,
 ):
-    """Skill: max_iters floors at 256 (OSL=256, CONC=64 ⇒ 16*OSL/CONC=64, so the floor kicks in)."""
+    """Capture is always the serialization cap (default 128), even for a small
+    OSL whose steady floor is far below it (OSL=256, CONC=64 ⇒ floor=4)."""
     import yaml
 
     _clear_workload_env(monkeypatch)
@@ -502,7 +508,7 @@ def test_materialize_profile_window_clamps_to_skill_floor(
     out = _materialize_config_with_envs(src, tmp_path)
     rendered = yaml.safe_load(out.read_text())
     extra = rendered["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
-    assert "--profiler-config.max_iterations 256" in extra, extra
+    assert "--profiler-config.max_iterations 128" in extra, extra
 
 
 # Regression #194 §2: NUM_PROMPTS must be sized to cover the steady-state window (profile mode force-overrides any caller-supplied value).
@@ -510,30 +516,30 @@ def test_materialize_profile_num_prompts_covers_steady_state_window(
     tmp_path,
     monkeypatch,
 ):
-    """OSL=1024 / CONC=32 / R=1 → delay+max = 6400 iters ⇒ NUM_PROMPTS=400."""
+    """OSL=1024 / CONC=32 / R=1 → delay+max = 6208 iters ⇒ NUM_PROMPTS=388."""
     import yaml
 
     _clear_workload_env(monkeypatch)
     src = _profile_yaml(tmp_path, "vllm", {"CONC": 32, "ISL": 256, "OSL": 1024})
     out = _materialize_config_with_envs(src, tmp_path)
     envs = yaml.safe_load(out.read_text())["benchmark"]["envs"]
-    # delay=5888, max=512 → required=6400; 6400*32/1024 = 200; *2 = 400.
-    assert envs["NUM_PROMPTS"] == 400, envs.get("NUM_PROMPTS")
+    # delay=6080, max=128 → required=6208; floor(6208*32/1024)=194; *2 = 388.
+    assert envs["NUM_PROMPTS"] == 388, envs.get("NUM_PROMPTS")
 
 
 def test_materialize_profile_num_prompts_floors_at_conc_for_tiny_osl(
     tmp_path,
     monkeypatch,
 ):
-    """Tiny OSL with skill floor max_iters=256 still produces a sane NUM_PROMPTS."""
+    """Tiny OSL with the capped capture still produces a sane NUM_PROMPTS."""
     import yaml
 
     _clear_workload_env(monkeypatch)
     src = _profile_yaml(tmp_path, "vllm", {"CONC": 32, "ISL": 64, "OSL": 64})
     out = _materialize_config_with_envs(src, tmp_path)
     envs = yaml.safe_load(out.read_text())["benchmark"]["envs"]
-    # max=256, delay=64*2*3-128=256, required=512; 512*32/64=256; *2=512.
-    assert envs["NUM_PROMPTS"] == 512, envs.get("NUM_PROMPTS")
+    # max=128, delay=64*2*3-64=320, required=448; 448*32/64=224; *2=448.
+    assert envs["NUM_PROMPTS"] == 448, envs.get("NUM_PROMPTS")
 
 
 def test_materialize_profile_force_overrides_user_num_prompts(
@@ -554,8 +560,8 @@ def test_materialize_profile_force_overrides_user_num_prompts(
     )
     out = _materialize_config_with_envs(src, tmp_path)
     envs = yaml.safe_load(out.read_text())["benchmark"]["envs"]
-    # Hyperloom-computed 400 must win over the caller's 32.
-    assert envs["NUM_PROMPTS"] == 400, envs.get("NUM_PROMPTS")
+    # Hyperloom-computed 388 must win over the caller's 32.
+    assert envs["NUM_PROMPTS"] == 388, envs.get("NUM_PROMPTS")
 
 
 def test_materialize_non_profile_keeps_legacy_seq_cost_factor(
@@ -625,8 +631,8 @@ def test_materialize_profile_vllm_injects_tracelens_flags_when_patched(
     src = _profile_yaml(tmp_path, "vllm", {"CONC": 32, "ISL": 256, "OSL": 1024})
     out = _materialize_config_with_envs(src, tmp_path)
     extra = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
-    assert "--profiler-config.delay_iterations 5888" in extra, extra
-    assert "--profiler-config.max_iterations 512" in extra, extra
+    assert "--profiler-config.delay_iterations 6080" in extra, extra
+    assert "--profiler-config.max_iterations 128" in extra, extra
     assert "--profiler-config.capture_torch_profiler_dir " in extra, extra
     assert "--profiler-config.detailed_trace_annotation True" in extra, extra
     # Per-framework dispatch: the SGLang patcher must NOT run for a vLLM YAML.
@@ -648,7 +654,7 @@ def test_materialize_profile_vllm_omits_tracelens_flags_when_patch_fails(
     out = _materialize_config_with_envs(src, tmp_path)
     envs = yaml.safe_load(out.read_text())["benchmark"]["envs"]
     extra = envs["EXTRA_VLLM_ARGS"]
-    assert "--profiler-config.delay_iterations 5888" in extra, extra
+    assert "--profiler-config.delay_iterations 6080" in extra, extra
     assert "capture_torch_profiler_dir" not in extra, extra
     assert "detailed_trace_annotation" not in extra, extra
     assert envs["HYPERLOOM_TRACELENS_PATCH_STATUS"] == "unavailable"
@@ -711,7 +717,7 @@ def test_materialize_profile_kill_switch_skips_patcher_entirely(
     out = _materialize_config_with_envs(src, tmp_path)
     extra = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
     # Safe §1 flags still present.
-    assert "--profiler-config.delay_iterations 5888" in extra, extra
+    assert "--profiler-config.delay_iterations 6080" in extra, extra
     # TraceLens-only flags absent.
     assert "capture_torch_profiler_dir" not in extra, extra
     assert "detailed_trace_annotation" not in extra, extra

--- a/inference_optimizer/tests/test_shared_state_persistence.py
+++ b/inference_optimizer/tests/test_shared_state_persistence.py
@@ -73,6 +73,17 @@ def test_save_load_round_trip(tmp_path):
     assert s2.current_best == {"action": "backends", "tput": 2010.0}
 
 
+def test_profile_osl_round_trip(tmp_path):
+    # The explicit profile OSL must survive save/load so a fresh-shell resume
+    # keeps it instead of reverting to the default.
+    s = SharedState(session_id="abc", osl=8192, profile_osl=512)
+    s.save(tmp_path)
+    s2 = SharedState.load_or_init(tmp_path)
+    assert s2.profile_osl == 512
+    # Default stays 0 (= unset → profile uses min(osl, 1024)).
+    assert SharedState(session_id="x").profile_osl == 0
+
+
 def test_tick_exception_round_trip(tmp_path):
     s = SharedState(session_id="abc")
     entry = s.record_tick_exception(

--- a/inference_optimizer/tests/test_workload_envs_branches_unit.py
+++ b/inference_optimizer/tests/test_workload_envs_branches_unit.py
@@ -31,6 +31,8 @@ def _clear_env(monkeypatch):
         "INFERENCEX_PATH",
         "HYPERLOOM_PROFILE_MAX_ITERS",
         "HYPERLOOM_PROFILE_DELAY_ITERS",
+        "HYPERLOOM_PROFILE_MAX_STEPS_CAP",
+        "PROFILE_OSL",
         "INFERENCE_OPTIMIZER_VISIBLE_GPU_COUNT",
         "INFERENCE_OPTIMIZER_DISABLE_TP_CLAMP",
     ):
@@ -235,3 +237,79 @@ def test_profile_sglang_bad_extra_body(monkeypatch, tmp_path):
     bench = _materialize(src, tmp_path / "out")
     body = bench["envs"]["PROFILE_EXTRA_BODY"]
     assert "start_step" in body and "num_steps" in body
+
+
+# ---- profile capture cap + profile-scoped OSL (issue #571 / #570) ---------
+def _profile_num_steps(bench) -> int:
+    """Captured-step count the sglang profile path writes into PROFILE_EXTRA_BODY."""
+    import json
+
+    return int(json.loads(bench["envs"]["PROFILE_EXTRA_BODY"])["num_steps"])
+
+
+def test_profile_default_caps_steps_and_osl(monkeypatch, tmp_path):
+    # No PROFILE_OSL: capture is capped at the default 128 and the profile OSL
+    # defaults to min(served OSL, 1024) without touching the served value.
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_DISABLE_TP_CLAMP", "1")
+    monkeypatch.setenv("OSL", "8192")
+    monkeypatch.setenv("CONC", "64")
+    src = _write(tmp_path / "cfg.yaml", envs={"PROFILE": "1"})
+    bench = _materialize(src, tmp_path / "out")
+    assert bench["envs"]["OSL"] == 1024  # min(8192, 1024)
+    assert _profile_num_steps(bench) == 128  # default cap
+
+
+def test_profile_explicit_profile_osl_honored(monkeypatch, tmp_path):
+    # --profile-osl / PROFILE_OSL overrides the profile OSL verbatim.
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_DISABLE_TP_CLAMP", "1")
+    monkeypatch.setenv("OSL", "8192")
+    monkeypatch.setenv("CONC", "64")
+    monkeypatch.setenv("PROFILE_OSL", "512")
+    src = _write(tmp_path / "cfg.yaml", envs={"PROFILE": "1"})
+    bench = _materialize(src, tmp_path / "out")
+    assert bench["envs"]["OSL"] == 512
+    assert _profile_num_steps(bench) == 128
+
+
+def test_profile_steps_cap_env_override(monkeypatch, tmp_path):
+    # Operators can raise the serialization cap.
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_DISABLE_TP_CLAMP", "1")
+    monkeypatch.setenv("OSL", "1024")
+    monkeypatch.setenv("CONC", "64")
+    monkeypatch.setenv("HYPERLOOM_PROFILE_MAX_STEPS_CAP", "256")
+    src = _write(tmp_path / "cfg.yaml", envs={"PROFILE": "1"})
+    bench = _materialize(src, tmp_path / "out")
+    assert _profile_num_steps(bench) == 256
+
+
+def test_profile_high_osl_low_conc_auto_lowers_osl(monkeypatch, tmp_path, caplog):
+    # Low CONC pushes the steady-state floor above the cap at OSL=1024, so the
+    # auto path lowers the profile OSL until the floor fits the 128-step cap.
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_DISABLE_TP_CLAMP", "1")
+    monkeypatch.setenv("OSL", "8192")
+    monkeypatch.setenv("CONC", "4")
+    src = _write(tmp_path / "cfg.yaml", envs={"PROFILE": "1"})
+    with caplog.at_level("WARNING"):
+        bench = _materialize(src, tmp_path / "out")
+    # fitted = int(128 * 2 * 4 / (1 + 1)) = 512; floor(512, conc=4) = 128 <= 128.
+    assert bench["envs"]["OSL"] == 512
+    assert _profile_num_steps(bench) == 128
+    assert any("lowering profile OSL" in r.message for r in caplog.records)
+
+
+def test_profile_manual_max_iters_below_floor_warns(monkeypatch, tmp_path, caplog):
+    # An explicit too-small capture is honored but warned about (steady-state).
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_DISABLE_TP_CLAMP", "1")
+    monkeypatch.setenv("OSL", "1024")
+    monkeypatch.setenv("CONC", "8")
+    monkeypatch.setenv("HYPERLOOM_PROFILE_MAX_ITERS", "8")
+    src = _write(tmp_path / "cfg.yaml", envs={"PROFILE": "1"})
+    with caplog.at_level("WARNING"):
+        bench = _materialize(src, tmp_path / "out")
+    assert _profile_num_steps(bench) == 8  # honored verbatim
+    assert any("below the steady-state floor" in r.message for r in caplog.records)

--- a/inference_optimizer/tests/test_workload_envs_branches_unit.py
+++ b/inference_optimizer/tests/test_workload_envs_branches_unit.py
@@ -313,3 +313,33 @@ def test_profile_manual_max_iters_below_floor_warns(monkeypatch, tmp_path, caplo
         bench = _materialize(src, tmp_path / "out")
     assert _profile_num_steps(bench) == 8  # honored verbatim
     assert any("below the steady-state floor" in r.message for r in caplog.records)
+
+
+def test_profile_explicit_osl_over_cap_warns_not_lowered(monkeypatch, tmp_path, caplog):
+    # Explicit PROFILE_OSL whose steady floor exceeds the cap is honored as-is
+    # (operator choice), but a warning is emitted.
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_DISABLE_TP_CLAMP", "1")
+    monkeypatch.setenv("OSL", "1024")
+    monkeypatch.setenv("CONC", "4")
+    monkeypatch.setenv("PROFILE_OSL", "8192")
+    src = _write(tmp_path / "cfg.yaml", envs={"PROFILE": "1"})
+    with caplog.at_level("WARNING"):
+        bench = _materialize(src, tmp_path / "out")
+    assert bench["envs"]["OSL"] == 8192  # not auto-lowered
+    assert _profile_num_steps(bench) == 128
+    assert any("above the profile cap" in r.message for r in caplog.records)
+
+
+def test_profile_manual_max_iters_above_cap_warns(monkeypatch, tmp_path, caplog):
+    # An explicit too-large capture is honored but warned about (serialization).
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_DISABLE_TP_CLAMP", "1")
+    monkeypatch.setenv("OSL", "256")
+    monkeypatch.setenv("CONC", "64")
+    monkeypatch.setenv("HYPERLOOM_PROFILE_MAX_ITERS", "2000")
+    src = _write(tmp_path / "cfg.yaml", envs={"PROFILE": "1"})
+    with caplog.at_level("WARNING"):
+        bench = _materialize(src, tmp_path / "out")
+    assert _profile_num_steps(bench) == 2000  # honored verbatim
+    assert any("exceeds the serialization-safe cap" in r.message for r in caplog.records)


### PR DESCRIPTION
The roofline/profile phase reused the served --osl, so on long-decode workloads its torch-profiler trace grew huge and crashed the engine (EngineCore RPC timeout). There was also no supported way to make profiling lighter than the served workload.

This PR:

Adds --profile-osl / PROFILE_OSL to set the profile phase's output length independently of --osl. Baseline/optimize still run at --osl.
Caps captured decode steps at a serialization-safe default of 128 (tunable via HYPERLOOM_PROFILE_MAX_STEPS_CAP).
Defaults the profile OSL to min(served OSL, 1024) when --profile-osl is unset.
Auto-lowers the profile OSL when the steady-state floor would exceed the cap, so the capture still contains a steady-state window.
Warns (never silently clamps) when an explicit HYPERLOOM_PROFILE_MAX_ITERS is below the steady-state floor or above the cap.
All profile logic is scoped to the profile phase; baseline/optimize are unaffected.