### PR TITLE
feat(gemm-tuning): emit phase_timeline event for adopted GEMM tuning

### DIFF
--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -53,6 +53,8 @@ _CRASH_EMERGENCY_WINDOW_SEC: float = 24.0 * 3600.0
 _BASELINE_MAX_TOTAL_FAILURES: int = 3
 from . import phase_state as _phase_state
 from .optimization_journal import (
+    KIND_GEMM_TUNING,
+    OUTCOME_KEEP,
     Journal,
     JournalEntry,
     classify_change_kind,
@@ -3528,6 +3530,65 @@ class Coordinator:
             self._promote_gemm_tuning_keep(result)
         self.shared_state.save(self.session_dir)
 
+    def _journal_gemm_tuning_keep(
+        self,
+        entry: dict[str, Any],
+        *,
+        task_id: str = "",
+    ) -> None:
+        """Mirror an adopted GEMM-tuning stack entry as an optimization_journal KEEP row.
+
+        GEMM-tuning adoptions previously landed only in ``optimization_stack``
+        / ``roofline_progress.trajectory`` and never as a ``phase_timeline``
+        event. As a result the run's serving throughput was invisible to the
+        timeline (and to downstream throughput-attempt series that read the
+        flat phase_timeline). Emitting a KEEP journal row — carrying the
+        end-to-end ``throughput_after`` plus the originating ``task_id`` for
+        token attribution — closes that gap so the GEMM tuning point shows up
+        alongside every other attempt. Best-effort: journaling failures never
+        abort the run.
+
+        Args:
+            entry: The ``optimization_stack`` entry just appended for this
+                GEMM-tuning adoption (carries variant_name / tput / gain_pct /
+                backend / tuned_file / ts).
+            task_id: Originating task id used to join per-step token spend.
+        """
+        try:
+            journal = self._ensure_journal()
+            variant_name = str(entry.get("variant_name") or "gemm_tuning")
+            backend = str(entry.get("backend") or "").strip().lower()
+            try:
+                tput = float(entry["tput"]) if entry.get("tput") is not None else None
+            except (TypeError, ValueError):
+                tput = None
+            try:
+                gain_pct = float(entry["gain_pct"]) if entry.get("gain_pct") is not None else None
+            except (TypeError, ValueError):
+                gain_pct = None
+            metrics: dict[str, Any] = {}
+            if entry.get("tuned_file"):
+                metrics["tuned_file"] = str(entry.get("tuned_file"))
+            journal.append_entry(
+                JournalEntry(
+                    phase=self._journal_entry_phase(),
+                    iter=int(self.shared_state.tick or 0),
+                    kind=KIND_GEMM_TUNING,
+                    change=variant_name,
+                    outcome=OUTCOME_KEEP,
+                    gain_pct=gain_pct,
+                    throughput_after=tput,
+                    task_id=str(task_id or ""),
+                    variant_name=variant_name,
+                    ts=str(entry.get("ts") or ""),
+                    provenance=f"gemm_tuning:{backend}" if backend else "gemm_tuning",
+                    tick=int(self.shared_state.tick or 0),
+                    metrics=metrics,
+                )
+            )
+        except Exception:  # noqa: BLE001 — journaling is best-effort
+            log.exception("gemm_tuning journal append failed")
+
     def _promote_gemm_tuning_keep(self, result: dict[str, Any]) -> None:
         """Promote a successful GEMM tuning run into the main gain ledger.
 
@@ -3613,6 +3674,9 @@ class Coordinator:
                 variant_name=variant_name,
                 new_tput=tuned_tput,
                 ts=ts,
+            )
+            self._journal_gemm_tuning_keep(
+                entry, task_id=str(result.get("task_id") or ""),
             )
         self.shared_state.current_best = {
             "action": "gemm_tuning",
@@ -3757,6 +3821,9 @@ class Coordinator:
                     variant_name=f"forge_{tuner_name}",
                     new_tput=new_tput,
                     ts=ts,
+                )
+                self._journal_gemm_tuning_keep(
+                    entry, task_id=f"gemm_tune_e2e_{tuner_name}",
                 )
             else:
                 reverted.append({**cand, "reason": f"decision={decision}, gain={gain_pct:.2f}%"})

--- a/inference_optimizer/orchestrator/optimization_journal.py
+++ b/inference_optimizer/orchestrator/optimization_journal.py
@@ -38,6 +38,7 @@ KIND_KERNEL_FILE: str = "kernel_file"  # kernel-opt patch on a specific file
 KIND_INTEGRATE: str = "integrate"  # framework PR / patch integration
 KIND_BASELINE: str = "baseline"
 KIND_PROFILE: str = "profile"
+KIND_GEMM_TUNING: str = "gemm_tuning"  # adopted GEMM-tuning run (GEAK / forge)
 KIND_OTHER: str = "other"
 
 
@@ -498,6 +499,7 @@ __all__ = [
     "KIND_BACKEND",
     "KIND_BASELINE",
     "KIND_ENV",
+    "KIND_GEMM_TUNING",
     "KIND_INTEGRATE",
     "KIND_KERNEL_FILE",
     "KIND_OTHER",

--- a/inference_optimizer/tests/test_coordinator_gemm_promote_units.py
+++ b/inference_optimizer/tests/test_coordinator_gemm_promote_units.py
@@ -9,6 +9,7 @@ forge results on the per-tuner E2E path while GEAK results promote inline.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -17,6 +18,14 @@ import inference_optimizer.orchestrator.action_executors.explore as explore_mod
 import inference_optimizer.orchestrator.kernel_request_handlers as krh_mod
 from inference_optimizer.orchestrator.coordinator import Coordinator
 from inference_optimizer.orchestrator.shared_state import SharedState
+
+
+def _journal_entries(session_dir: Path) -> list[dict]:
+    """Read the optimization_journal entries written under ``session_dir``."""
+    path = session_dir / "reports" / "optimization_journal.json"
+    if not path.exists():
+        return []
+    return list(json.loads(path.read_text(encoding="utf-8")).get("entries") or [])
 
 
 def _make_integrate(responses):
@@ -111,6 +120,30 @@ class TestPromoteGemmTuningKeep:
         assert stack[0]["variant_name"] == "a8w8_blockscale_tuned_gemm"
         envs = coord.shared_state.current_best["extra_envs"]
         assert envs["AITER_CONFIG_GEMM_A8W8_BLOCKSCALE"] == "/tuned/gemm.csv"
+
+    def test_geak_keep_writes_gemm_tuning_journal_event(self, tmp_path):
+        # The adopted GEMM-tuning run must surface as a phase_timeline event:
+        # a KIND_GEMM_TUNING KEEP journal row carrying the serving throughput
+        # and the originating task_id (for token attribution).
+        coord = _coord(tmp_path, baseline_tput=200.0)
+        coord._promote_gemm_tuning_keep(
+            {
+                "status": "ok",
+                "decision": "KEEP",
+                "best_speedup": 1.1,
+                "backend": "geak",
+                "tuned_file": "/tuned/gemm.csv",
+                "task_id": "kernel_entry_gemm_tuning",
+            }
+        )
+        rows = [e for e in _journal_entries(tmp_path) if e.get("kind") == "gemm_tuning"]
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["outcome"] == "KEEP"
+        assert row["variant_name"] == "a8w8_blockscale_tuned_gemm"
+        assert row["throughput_after"] == pytest.approx(220.0)
+        assert row["task_id"] == "kernel_entry_gemm_tuning"
+        assert row["provenance"] == "gemm_tuning:geak"
 
     def test_forge_keep_dedupes_same_tuned_file(self, tmp_path):
         coord = _coord(tmp_path, baseline_tput=100.0)
@@ -239,6 +272,14 @@ class TestValidateForgeGemmTuningE2E:
         assert fake.calls[1]["base_tput"] == pytest.approx(120.0)
 
         assert len(coord.shared_state.optimization_stack) == 2
+        # Each kept tuner also lands as a gemm_tuning KEEP journal event with
+        # its serving throughput + per-tuner task_id.
+        gj = [e for e in _journal_entries(tmp_path) if e.get("kind") == "gemm_tuning"]
+        assert [e["throughput_after"] for e in gj] == pytest.approx([120.0, 132.0])
+        assert {e["task_id"] for e in gj} == {
+            "gemm_tune_e2e_fmoe_ck",
+            "gemm_tune_e2e_dense_gemm",
+        }
         cb = coord.shared_state.current_best
         assert cb["engine"] == "forge"
         assert cb["tput"] == pytest.approx(132.0)


### PR DESCRIPTION
Adopted GEMM-tuning runs previously landed only in optimization_stack / roofline_progress.trajectory and never as a phase_timeline event, so their serving throughput was invisible to the optimization timeline and to the throughput-attempts series (which reads the flat phase_timeline). Mirror each KEEP into an optimization_journal row (KIND_GEMM_TUNING) carrying throughput_after + task_id, so the GEMM tuning point shows up alongside every other attempt and gets token attribution.

- Description: what and why
- Linked issue(s): close/fix refs
- Tests: added/updated? commands run?
- Breaking changes: yes/no (details if yes)
