### PR TITLE
Restore optimize-submit schedule and align 6h task budget with tiny.

### DIFF
--- a/.github/workflows/optimize-submit.yml
+++ b/.github/workflows/optimize-submit.yml
@@ -34,20 +34,21 @@ name: SaFE Optimize Submit
 #   • Quick HF top-N probe   : `-f hf_top=10 -f min_params=7`
 
 on:
-  # Rolling downloads>100 pool: 240 models TWICE a day, firing at UTC
-  # 04:00 / 16:00 (Beijing 12:00 / 00:00). Each fire submits the
-  # NEXT sequential 240-model slice of the rotate pool, now hosted off-repo at
+  # Rolling downloads>100 pool: 240 models every 6 hours, firing at UTC
+  # 16:00 / 22:00 / 04:00 / 10:00 (Beijing 00:00 / 06:00 / 12:00 / 18:00).
+  # Each fire submits the NEXT sequential 240-model slice of the rotate pool,
+  # now hosted off-repo at
   # $WEKAFS_CHENYI_DIR/ci-candidates/hf_downloads_gt100_rotate.json
   # (a date-less symlink that always points at the latest filtered pool;
   # ordered not-run first; the 449 >12B multimodal models are front-loaded),
   # stepping batch 0,1,2,... and wrapping at the pool end. Both
-  # exclude_leaderboard and exclude_active are OFF on schedule: slices are
-  # disjoint, so the whole pool keeps cycling (re-running finished models too).
+  # exclude_leaderboard is OFF on schedule so the whole pool keeps cycling
+  # (re-running finished models too). exclude_active is ON to skip models
+  # already queued/running in other SaFE Optimize Submit runs.
   # The tail batch is short (not head-wrapped) so consecutive fires never
   # double-submit the head models. Manual workflow_dispatch is unaffected.
-  # PAUSED 2026-06-19: scheduled auto-run disabled on request. Uncomment to resume.
-  # schedule:
-  #   - cron: '0 4,16 * * *'
+  schedule:
+    - cron: '0 4,10,16,22 * * *'
   workflow_dispatch:
     inputs:
       # ── Model source (priority: models > candidates_file > legacy hf_top) ──────
@@ -76,7 +77,7 @@ on:
         description: 'Exclude models already queued/running in active optimize-submit workflow runs.'
         type: boolean
         required: false
-        default: false
+        default: true
       min_params:
         description: 'Min parameter count in Billions (e.g. 7 for >=7B). 0 to skip filter.'
         required: false
@@ -177,13 +178,13 @@ on:
         required: false
         default: true
       task_timeout_min:
-        description: 'Per-task wait timeout in minutes (default 720 = 12h)'
+        description: 'Per-task wait timeout in minutes (default 420 = 7h)'
         required: false
-        default: '720'
+        default: '420'
       max_hours:
-        description: 'Per-task optimizer budget in hours (default 12)'
+        description: 'Per-task optimizer budget in hours (default 6)'
         required: false
-        default: '12'
+        default: '6'
       all_artifacts:
         description: 'Download every artifact (default off — only optimization_report + ci_metrics)'
         type: boolean
@@ -229,13 +230,12 @@ jobs:
       INPUT_BATCH_SIZE:      ${{ github.event_name == 'schedule' && '240' || github.event.inputs.batch_size }}
       INPUT_HF_TOP:          ${{ github.event.inputs.hf_top }}
       INPUT_MIN_PARAMS:      ${{ github.event.inputs.min_params }}
-      # Schedule does NOT exclude leaderboard-known models, and does NOT exclude
-      # active workflows: the sequential batches are disjoint slices, so each
-      # cron submits its own slice. Keeping both exclusions off means the whole
-      # downloads>100 pool keeps cycling (re-running finished models too) and the
-      # clean batch boundaries are preserved.
+      # Schedule does NOT exclude leaderboard-known models so the pool keeps
+      # cycling. Active-workflow exclusion is ON (same as optimize-tiny) so
+      # cron skips models already queued/running elsewhere; active-refill keeps
+      # batch size at 240.
       INPUT_EXCLUDE_LEADERBOARD:      ${{ github.event_name == 'schedule' && 'false' || github.event.inputs.exclude_leaderboard }}
-      INPUT_EXCLUDE_ACTIVE_WORKFLOWS: ${{ github.event_name == 'schedule' && 'false' || github.event.inputs.exclude_active_workflows }}
+      INPUT_EXCLUDE_ACTIVE_WORKFLOWS: ${{ github.event_name == 'schedule' && 'true' || github.event.inputs.exclude_active_workflows }}
       GITHUB_TOKEN:          ${{ github.token }}
       GITHUB_RUN_NUMBER:     ${{ github.run_number }}
     steps:
@@ -256,8 +256,8 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.count != '0'
     runs-on: hyperloom-4hhzn
-    # 12h per-task wait timeout + buffer for register/wait/collect.
-    timeout-minutes: 780
+    # 7h per-task wait timeout + buffer for register/wait/collect.
+    timeout-minutes: 480
     strategy:
       fail-fast: false
       max-parallel: ${{ fromJson(github.event_name == 'schedule' && '240' || github.event.inputs.max_parallel || '240') }}
@@ -375,7 +375,7 @@ jobs:
           # Code-level contract: do not rely on natural-language prompt text
           # for these two critical values. SaFE consumes them and renders the
           # generated prompt tail consistently with the CI prefix.
-          ARGS+=(--max-hours "${INPUT_MAX_HOURS:-12}")
+          ARGS+=(--max-hours "${INPUT_MAX_HOURS:-6}")
           # Hard guarantee: SaFE promptPrefix MUST be non-empty. Workflow
           # input is only populated on workflow_dispatch — for schedule
           # trigger we fall back to ci/prompt_prefix.txt (single source of
@@ -434,7 +434,7 @@ jobs:
           if [ -n "${MATRIX_SOURCE_TASK_ID:-}" ]; then
             ARGS+=(--pool-source-task-id "${MATRIX_SOURCE_TASK_ID}")
           fi
-          ARGS+=(--task-timeout-min "${INPUT_TASK_TIMEOUT_MIN:-720}")
+          ARGS+=(--task-timeout-min "${INPUT_TASK_TIMEOUT_MIN:-420}")
           ARGS+=(--output-dir "${OUTPUT_DIR}")
           ARGS+=(--artifacts-dir "${ARTIFACTS_DIR}")
           python3 optimize_submit.py "${ARGS[@]}"

--- a/ci/optimize_submit.py
+++ b/ci/optimize_submit.py
@@ -88,7 +88,7 @@ DEFAULT_PROXY = "harbor.core42.primus-safe.amd.com/proxy"
 DEFAULT_GPU_TYPE = "MI300X"
 DEFAULT_GPU_PROFILE = "mi300x"
 DEFAULT_KERNEL_BACKENDS = ["GEAK", "Claude Code", "Codex"]
-DEFAULT_MAX_HOURS = 12.0
+DEFAULT_MAX_HOURS = 6.0
 DEFAULT_TARGET_GAIN = 500.0
 DEFAULT_RESULTS_PATH = "$RESULT_DIR"
 DEFAULT_CONTEXT_RESERVE_TOKENS = 16
@@ -4078,7 +4078,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--max-hours",
         type=float,
         default=float(os.environ.get("SAFE_OPTIMIZE_MAX_HOURS", DEFAULT_MAX_HOURS)),
-        help="Max hours passed to the Hyperloom optimizer prompt (default: 12).",
+        help="Max hours passed to the Hyperloom optimizer prompt (default: 6).",
     )
     parser.add_argument(
         "--target-gain",
@@ -4160,7 +4160,7 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Local directory where per-task artifacts land (default: ./task-artifacts)",
     )
     parser.add_argument(
-        "--task-timeout-min", type=int, default=720, help="Per-task wait timeout in minutes (default: 720 = 12h)"
+        "--task-timeout-min", type=int, default=420, help="Per-task wait timeout in minutes (default: 420 = 7h)"
     )
     parser.add_argument(
         "--poll-interval-s", type=int, default=60, help="How often to poll task status, seconds (default: 60)"


### PR DESCRIPTION
Re-enable 6-hour cron, set 6h/420min timeouts, and skip models already queued in other SaFE Optimize Submit runs.

- Description: what and why
- Linked issue(s): close/fix refs
- Tests: added/updated? commands run?
- Breaking changes: yes/no (details if yes)
