### PR TITLE
fix(kernel-agent): reconstruct full source from patch when no complete artifact found

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.10"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -863,6 +863,10 @@ def _maybe_apply_kernel_patch(
     kid = str(kernel_id or payload.get("kernel_id") or "")
     backup_root = payload.get("backup_root") or (patches_dir(session_dir, kid or "anon") / "backup")
     tool = _load_apply_tool()
+    # Snapshot mode (content-addressed deploy): when a snapshot dir of byte-exact
+    # final files is present, the patch lands atomically across all its files.
+    snapshot_dir = str(payload.get("snapshot_dir") or "").strip() or None
+    repo_root = str(payload.get("kernel_repo") or payload.get("repo") or "").strip() or None
     return tool.apply_kernel_patch(
         patch_path=patch_path,
         target_file=target_file,
@@ -874,6 +878,8 @@ def _maybe_apply_kernel_patch(
         skip_rebuild=bool(payload.get("skip_rebuild", False)),
         allow_unknown_target=bool(payload.get("allow_unknown_target", False)),
         dry_run=bool(payload.get("dry_run_patch", False)),
+        snapshot_dir=snapshot_dir,
+        repo_root=repo_root,
     )
 
 
@@ -985,6 +991,14 @@ def _resolve_integrate_payload(payload: dict, *, session_dir: Path) -> tuple[dic
     last_kernel = state.last_kernel_opt or {}
 
     if kernel_id and str(last_kernel.get("kernel_id") or "") == kernel_id:
+        # Snapshot deploy: prefer the original patch (manifest) + its byte-exact
+        # snapshot dir so the WHOLE multi-file patch lands atomically.
+        if not resolved.get("snapshot_dir") and last_kernel.get("deploy_snapshot_dir"):
+            resolved["snapshot_dir"] = str(last_kernel["deploy_snapshot_dir"])
+            if last_kernel.get("deploy_patch_path") and not resolved.get("patch_path"):
+                resolved["patch_path"] = str(last_kernel["deploy_patch_path"])
+            if last_kernel.get("deploy_repo_root") and not resolved.get("kernel_repo"):
+                resolved["kernel_repo"] = str(last_kernel["deploy_repo_root"])
         if not resolved.get("patch_path"):
             artifact = (
                 last_kernel.get("best_artifact_path")
@@ -999,6 +1013,12 @@ def _resolve_integrate_payload(payload: dict, *, session_dir: Path) -> tuple[dic
     # Multi-KEEP queue fallback: ``last_kernel_opt`` holds only the strongest pending KEEP, so pull patch_path/source_file from the per-kernel ledger for other queued KEEPs.
     if kernel_id:
         attempt = (state.kernel_opt_attempts or {}).get(kernel_id) or {}
+        if not resolved.get("snapshot_dir") and attempt.get("last_snapshot_dir"):
+            resolved["snapshot_dir"] = str(attempt["last_snapshot_dir"])
+            if attempt.get("last_deploy_patch_path") and not resolved.get("patch_path"):
+                resolved["patch_path"] = str(attempt["last_deploy_patch_path"])
+            if attempt.get("last_deploy_repo_root") and not resolved.get("kernel_repo"):
+                resolved["kernel_repo"] = str(attempt["last_deploy_repo_root"])
         if not resolved.get("patch_path") and attempt.get("last_artifact_path"):
             resolved["patch_path"] = str(attempt["last_artifact_path"])
         if not resolved.get("source_file") and attempt.get("last_source_file"):
@@ -4798,6 +4818,9 @@ def record_kernel_opt(state, result: dict[str, Any]) -> None:
     except (TypeError, ValueError):
         micro_float = 0.0
     best_artifact_path = str(verification.get("best_artifact_path", "") or "")
+    deploy_snapshot_dir = str(verification.get("deploy_snapshot_dir", "") or "")
+    deploy_patch_path = str(verification.get("deploy_patch_path", "") or "")
+    deploy_repo_root = str(verification.get("deploy_repo_root", "") or "")
     source_file = str(
         result.get("source_file")
         or (result.get("candidate") or {}).get("source_file")
@@ -4855,6 +4878,9 @@ def record_kernel_opt(state, result: dict[str, Any]) -> None:
     entry["last_status"] = status
     entry["last_micro_speedup"] = micro_float
     entry["last_artifact_path"] = best_artifact_path
+    entry["last_snapshot_dir"] = deploy_snapshot_dir
+    entry["last_deploy_patch_path"] = deploy_patch_path
+    entry["last_deploy_repo_root"] = deploy_repo_root
     entry["last_source_file"] = source_file
     entry["last_ts"] = ts
     entry["history"] = history
@@ -4881,6 +4907,9 @@ def record_kernel_opt(state, result: dict[str, Any]) -> None:
             "compile_passed": verification.get("compile_passed"),
             "correctness_passed": verification.get("correctness_passed"),
             "best_artifact_path": best_artifact_path,
+            "deploy_snapshot_dir": deploy_snapshot_dir,
+            "deploy_patch_path": deploy_patch_path,
+            "deploy_repo_root": deploy_repo_root,
             "source_file": source_file,
             "ts": ts,
         }

--- a/kernel-agent/tools/apply_kernel_patch.py
+++ b/kernel-agent/tools/apply_kernel_patch.py
@@ -427,6 +427,274 @@ def _validate_replacement_compatibility(patch_text: str, target_text: str, targe
             )
 
 
+def _unquote_git_path(raw: str) -> str:
+    """Decode a git diff header path, handling C-style quoting.
+
+    Git emits paths with special characters as C-quoted strings (e.g.
+    ``"b/\\303\\251.py"``). A naive ``..``/absolute check on the still-quoted
+    string can be bypassed, so decode it first.
+
+    Args:
+        raw (str): The raw token following a header keyword (already
+            whitespace-trimmed).
+
+    Returns:
+        str: The decoded path, or the input unchanged when it is not quoted.
+    """
+    if len(raw) >= 2 and raw[0] == '"' and raw[-1] == '"':
+        try:
+            return raw[1:-1].encode("latin-1", "backslashreplace").decode("unicode_escape")
+        except (UnicodeDecodeError, ValueError):
+            return raw[1:-1]
+    return raw
+
+
+def _strip_ab_prefix(path: str) -> str:
+    """Drop a leading ``a/`` or ``b/`` git diff prefix.
+
+    Args:
+        path (str): A diff header path.
+
+    Returns:
+        str: The path without its ``a/``/``b/`` prefix.
+    """
+    return re.sub(r"^[ab]/", "", path)
+
+
+def parse_patch_manifest(patch_text: str) -> list[dict[str, Any]]:
+    """Parse a unified diff into a list of per-path deploy descriptors.
+
+    The patch is read as a *manifest* of intended filesystem changes — the set
+    of touched paths and each path's disposition — never as an instruction to be
+    replayed. Recognises the full git header vocabulary so nothing is silently
+    skipped: plain modifications, ``new file`` / ``--- /dev/null`` additions,
+    ``deleted file`` / ``+++ /dev/null`` deletions, ``rename from/to`` (mapped to
+    delete-source + add-dest), ``copy from/to``, ``old mode/new mode`` chmod-only
+    entries, and ``GIT binary patch`` blocks (flagged, content sourced from the
+    snapshot).
+
+    Args:
+        patch_text (str): The full unified diff text.
+
+    Returns:
+        list[dict[str, Any]]: One descriptor per affected path. Each has
+            ``op`` (``"write"`` or ``"delete"``), ``path`` (repo-relative
+            target), ``mode`` (octal string or ``""``), ``binary`` (bool), and
+            for renames/copies a ``source`` (origin repo-relative path). A
+            rename yields two descriptors: a ``delete`` of the source and a
+            ``write`` of the dest.
+
+    Raises:
+        ValueError: When the patch is empty/unparseable, or a section's
+            disposition cannot be determined.
+    """
+    if not patch_text or not patch_text.strip():
+        raise ValueError("empty patch: nothing to apply")
+
+    if re.search(r"(?m)^diff --git ", patch_text):
+        blocks = [b for b in re.split(r"(?m)^(?=diff --git )", patch_text) if b.strip()]
+    else:
+        blocks = [b for b in re.split(r"(?m)^(?=--- )", patch_text) if b.strip()]
+    if not blocks:
+        raise ValueError("patch contains no file sections")
+
+    descriptors: list[dict[str, Any]] = []
+    for block in blocks:
+        binary = bool(re.search(r"(?m)^GIT binary patch\b", block))
+        new_mode_m = re.search(r"(?m)^new file mode (\d+)$", block)
+        chmod_m = re.search(r"(?m)^new mode (\d+)$", block)
+        mode = ""
+        if new_mode_m:
+            mode = new_mode_m.group(1)[-4:]
+        elif chmod_m:
+            mode = chmod_m.group(1)[-4:]
+
+        rename_to = re.search(r"(?m)^rename to (.+)$", block)
+        rename_from = re.search(r"(?m)^rename from (.+)$", block)
+        copy_to = re.search(r"(?m)^copy to (.+)$", block)
+        if rename_to and rename_from:
+            src = _unquote_git_path(rename_from.group(1).strip())
+            dst = _unquote_git_path(rename_to.group(1).strip())
+            descriptors.append({"op": "delete", "path": src, "mode": "", "binary": False})
+            descriptors.append({"op": "write", "path": dst, "mode": mode, "binary": binary})
+            continue
+        if copy_to:
+            dst = _unquote_git_path(copy_to.group(1).strip())
+            descriptors.append({"op": "write", "path": dst, "mode": mode, "binary": binary})
+            continue
+
+        minus = re.search(r"(?m)^--- (.+)$", block)
+        plus = re.search(r"(?m)^\+\+\+ (.+)$", block)
+        deleted = bool(re.search(r"(?m)^deleted file mode", block))
+        plus_path = _unquote_git_path(plus.group(1).split("\t", 1)[0].strip()) if plus else ""
+        minus_path = _unquote_git_path(minus.group(1).split("\t", 1)[0].strip()) if minus else ""
+
+        if deleted or plus_path == "/dev/null":
+            target = _strip_ab_prefix(minus_path)
+            if not target:
+                raise ValueError(f"deletion section missing source path:\n{block[:200]}")
+            descriptors.append({"op": "delete", "path": target, "mode": "", "binary": binary})
+            continue
+
+        # Addition (--- /dev/null) or modification: dest comes from the +++ line.
+        target = _strip_ab_prefix(plus_path)
+        if not target:
+            # Header-only entries (pure chmod) carry the path on the diff line.
+            gitline = re.search(r"(?m)^diff --git a/(.+?) b/(.+)$", block)
+            if gitline:
+                target = _unquote_git_path(gitline.group(2).strip())
+        if not target:
+            raise ValueError(f"cannot determine target path for section:\n{block[:200]}")
+        descriptors.append({"op": "write", "path": target, "mode": mode, "binary": binary})
+
+    return descriptors
+
+
+def _contained_dest(repo_root: Path, rel_path: str) -> Path:
+    """Resolve ``rel_path`` under ``repo_root``, rejecting any escape.
+
+    Rejects absolute paths and any ``..`` traversal, and confirms the resolved
+    destination stays inside ``repo_root`` (closes the path-traversal hole the
+    review flagged, applied at the deploy boundary).
+
+    Args:
+        repo_root (Path): The framework repo root that destinations must stay in.
+        rel_path (str): Repo-relative target path from the patch manifest.
+
+    Returns:
+        Path: The validated absolute destination path.
+
+    Raises:
+        ValueError: If the path is absolute, contains ``..``, or escapes
+            ``repo_root``.
+    """
+    if rel_path.startswith("/"):
+        raise ValueError(f"absolute path not allowed in patch: {rel_path}")
+    if ".." in Path(rel_path).parts:
+        raise ValueError(f"'..' not allowed in patch path: {rel_path}")
+    root = repo_root.resolve()
+    dest = (root / rel_path).resolve()
+    try:
+        dest.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"patch path escapes repo root {root}: {rel_path}") from exc
+    return dest
+
+
+def apply_snapshot(
+    *,
+    descriptors: list[dict[str, Any]],
+    snapshot_dir: str | Path,
+    repo_root: str | Path,
+    backup_dir: str | Path,
+) -> dict[str, Any]:
+    """Apply a content-addressed snapshot atomically (all-or-nothing).
+
+    Each descriptor asserts a final filesystem state rather than replaying a
+    diff: ``write`` copies the byte-exact file from ``snapshot_dir`` onto the
+    live repo, ``delete`` removes the live file. The whole set is staged with a
+    full pre-flight (containment + source existence) before any write; if any
+    single operation fails, every already-touched path is restored from backup
+    and the call returns ``status="failed"`` — the repo is never left partially
+    applied. There is no fuzzy fallback.
+
+    Args:
+        descriptors (list[dict[str, Any]]): Output of
+            :func:`parse_patch_manifest`.
+        snapshot_dir (str | Path): Directory holding byte-exact final contents
+            for every ``write`` path (mirrored at the same relative path).
+        repo_root (str | Path): Framework repo root the targets live under.
+        backup_dir (str | Path): Where per-path backups + the revert manifest
+            are written.
+
+    Returns:
+        dict[str, Any]: ``status="ok"`` with ``source_backups`` (the revert
+            manifest entries) and ``touched`` paths, or ``status="failed"`` with
+            an ``error`` and the offending path.
+    """
+    root = Path(repo_root)
+    snap = Path(snapshot_dir)
+    backups: list[dict[str, Any]] = []
+
+    # Pre-flight: validate everything before touching the live tree.
+    staged: list[tuple[dict[str, Any], Path, Path | None]] = []
+    try:
+        for desc in descriptors:
+            dest = _contained_dest(root, desc["path"])
+            src: Path | None = None
+            if desc["op"] == "write":
+                src = snap / desc["path"]
+                if not src.is_symlink() and not src.exists():
+                    return {
+                        "status": "failed",
+                        "error": f"snapshot missing content for {desc['path']}",
+                        "path": desc["path"],
+                    }
+            staged.append((desc, dest, src))
+    except ValueError as exc:
+        return {"status": "failed", "error": str(exc), "path": "<pre-flight>"}
+
+    def _restore_all() -> None:
+        """Roll the live tree back to v0 from recorded backups."""
+        for entry in reversed(backups):
+            disp = entry["disposition"]
+            live = Path(entry["path"])
+            if disp == "added":
+                live.unlink(missing_ok=True)
+            else:  # modified / deleted -> restore old bytes from backup
+                bp = entry.get("backup_path")
+                if bp and Path(bp).exists():
+                    live.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(bp, live, follow_symlinks=False)
+
+    touched: list[str] = []
+    for desc, dest, src in staged:
+        try:
+            existed = dest.exists() or dest.is_symlink()
+            # Back up (disposition drives revert): record before mutating.
+            if desc["op"] == "delete" or existed:
+                disposition = "deleted" if desc["op"] == "delete" else "modified"
+                bp = None
+                if existed:
+                    bdst = Path(backup_dir) / "source" / f"{_path_hash(dest)}_{dest.name}"
+                    bdst.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(dest, bdst, follow_symlinks=False)
+                    bp = str(bdst)
+                backups.append({"path": str(dest), "backup_path": bp, "disposition": disposition})
+            else:
+                backups.append({"path": str(dest), "backup_path": None, "disposition": "added"})
+
+            if desc["op"] == "delete":
+                dest.unlink(missing_ok=True)
+            else:
+                # Re-validate containment on the final dest right before the
+                # write (close the TOCTOU window) and never follow a symlink.
+                _contained_dest(root, desc["path"])
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                if dest.is_symlink():
+                    dest.unlink()
+                if src.is_symlink():
+                    link_target = os.readlink(src)
+                    dest.symlink_to(link_target)
+                else:
+                    shutil.copy2(src, dest, follow_symlinks=False)
+                    if desc.get("mode"):
+                        try:
+                            dest.chmod(int(desc["mode"], 8))
+                        except (ValueError, OSError):
+                            pass
+            touched.append(str(dest))
+        except (OSError, ValueError) as exc:
+            _restore_all()
+            return {
+                "status": "failed",
+                "error": f"apply failed at {desc['path']}: {exc}; repo restored",
+                "path": desc["path"],
+            }
+
+    return {"status": "ok", "source_backups": backups, "touched": touched}
+
+
 def _clear_python_kernel_caches(target: Path) -> dict[str, Any]:
     """Clear Python / Triton / Inductor caches around a Python patch.
 
@@ -1092,8 +1360,29 @@ def revert_kernel_patch(manifest_path: str | Path) -> dict[str, Any]:
             dst.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(src, dst)
             restored.append(str(dst))
+    # Disposition-aware multi-file revert (snapshot deploy): added -> unlink,
+    # modified/deleted -> restore old bytes. Falls back to the legacy singular
+    # ``source_backup`` for manifests written before snapshot deploy.
+    source_backups = manifest.get("source_backups")
+    cache_cleared = False
+    if source_backups:
+        for entry in reversed(source_backups):
+            disp = entry.get("disposition")
+            dst = Path(entry["path"])
+            if disp == "added":
+                dst.unlink(missing_ok=True)
+                restored.append(str(dst))
+            else:
+                bp = entry.get("backup_path")
+                if bp and Path(bp).exists():
+                    dst.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(bp, dst, follow_symlinks=False)
+                    restored.append(str(dst))
+            if dst.suffix.lower() in PYTHON_SOURCE_SUFFIXES and not cache_cleared:
+                manifest["revert_cache_clear"] = _clear_python_kernel_caches(dst)
+                cache_cleared = True
     source_backup = manifest.get("source_backup") or {}
-    if source_backup:
+    if not source_backups and source_backup:
         src = Path(source_backup["backup_path"])
         dst = Path(source_backup["path"])
         if src.exists():
@@ -1153,6 +1442,44 @@ def revert_kernel_patch(manifest_path: str | Path) -> dict[str, Any]:
     return result
 
 
+def _multi_root_strategies(
+    live_paths: Iterable[Path],
+    *,
+    allow_unknown_target: bool,
+) -> list[dict[str, Any]]:
+    """Compute the set of distinct rebuild strategies across edited files.
+
+    A multi-file patch can touch files in several framework roots (e.g. a
+    ``csrc/*.cu`` plus an ``aiter/ops/triton/*.py``). Driving rebuild off the
+    primary target alone would skip compilation for companion compiled files, so
+    derive ``compiled``/rebuild from the **whole** edited set.
+
+    Args:
+        live_paths (Iterable[Path]): The live target paths the patch writes.
+        allow_unknown_target (bool): Passed through to :func:`_detect_strategy`.
+
+    Returns:
+        list[dict[str, Any]]: One strategy dict per distinct root that needs a
+            rebuild (compiled roots only), each as returned by
+            :func:`_detect_strategy`.
+    """
+    seen: set[str] = set()
+    strategies: list[dict[str, Any]] = []
+    for p in live_paths:
+        try:
+            strat = _detect_strategy(p, allow_unknown_target=allow_unknown_target)
+        except ValueError:
+            continue
+        if not strat["compiled"]:
+            continue
+        key = strat["root"] or str(p.parent)
+        if key in seen:
+            continue
+        seen.add(key)
+        strategies.append(strat)
+    return strategies
+
+
 def apply_kernel_patch(
     *,
     patch_path: str | Path,
@@ -1165,17 +1492,29 @@ def apply_kernel_patch(
     skip_rebuild: bool = False,
     allow_unknown_target: bool = False,
     dry_run: bool = False,
+    snapshot_dir: str | Path | None = None,
+    repo_root: str | Path | None = None,
 ) -> dict[str, Any]:
     """Apply an optimized kernel file with backup, rebuild, and fan-out.
 
-    Validates the patch against the target, backs up the source (and compiled
-    artifacts), writes a manifest, copies the patch into place, clears caches,
-    fans the patch out to multi-node pods when active, and rebuilds compiled
-    targets — reverting automatically on rebuild failure.
+    Two modes:
+
+    - **snapshot mode** (``snapshot_dir`` given): ``patch_path`` is a unified
+      diff used only as a *manifest* of intended changes; the byte-exact final
+      contents come from ``snapshot_dir``. The whole multi-file set lands
+      atomically (all-or-nothing) or the repo is left untouched — see
+      :func:`apply_snapshot`. This is the path that satisfies the "entire patch
+      lands byte-for-byte or nothing changes" contract.
+    - **legacy full-source mode** (no ``snapshot_dir``): ``patch_path`` is a
+      complete replacement file for a single ``target_file`` (whole-file copy).
+
+    Both back up the prior state, rebuild compiled targets, fan out to multi-node
+    pods, and revert automatically on rebuild failure.
 
     Args:
-        patch_path (str | Path): The replacement source file.
-        target_file (str | Path): The file to replace.
+        patch_path (str | Path): The replacement source file, or (snapshot mode)
+            the unified diff manifest.
+        target_file (str | Path): The primary file (drives timing/rebuild root).
         backup_root (str | Path): Root directory for backups and the manifest.
         kernel_id (str): Identifier for the kernel being patched.
         artifact_paths (Iterable[str] | None): Explicit compiled artifacts to
@@ -1186,6 +1525,8 @@ def apply_kernel_patch(
         skip_rebuild (bool): When ``True``, skip the rebuild step.
         allow_unknown_target (bool): Allow targets outside the known roots.
         dry_run (bool): Prepare backups/manifest only, without applying.
+        snapshot_dir (str | Path | None): When set, enables snapshot mode and
+            holds byte-exact final contents mirrored at each write path.
 
     Returns:
         dict[str, Any]: A result dict with ``status`` and, on success, the
@@ -1193,6 +1534,21 @@ def apply_kernel_patch(
             cache-clear / rebuild / jit-build records, and an optional
             ``multinode`` block.
     """
+    if snapshot_dir is not None:
+        return _apply_kernel_patch_snapshot(
+            patch_path=patch_path,
+            target_file=target_file,
+            backup_root=backup_root,
+            snapshot_dir=snapshot_dir,
+            kernel_id=kernel_id,
+            artifact_paths=artifact_paths,
+            rebuild_command=rebuild_command,
+            rebuild_timeout_sec=rebuild_timeout_sec,
+            skip_rebuild=skip_rebuild,
+            allow_unknown_target=allow_unknown_target,
+            dry_run=dry_run,
+            repo_root=repo_root,
+        )
     patch = Path(patch_path).resolve()
     target = Path(target_file).resolve()
     if not patch.is_file():
@@ -1400,6 +1756,246 @@ def apply_kernel_patch(
         "cpp_itfs_cache_backup": cpp_itfs_cache_backup,
     }
     # Only attach the multinode key when fan-out actually ran.
+    if multinode_info:
+        result["multinode"] = multinode_info
+    return result
+
+
+def _apply_kernel_patch_snapshot(
+    *,
+    patch_path: str | Path,
+    target_file: str | Path,
+    backup_root: str | Path,
+    snapshot_dir: str | Path,
+    kernel_id: str,
+    artifact_paths: Iterable[str] | None,
+    rebuild_command: list[str] | str | None,
+    rebuild_timeout_sec: int,
+    skip_rebuild: bool,
+    allow_unknown_target: bool,
+    dry_run: bool,
+    repo_root: str | Path | None = None,
+) -> dict[str, Any]:
+    """Snapshot-mode apply: land an entire multi-file patch atomically.
+
+    See :func:`apply_kernel_patch` for the contract. The diff at ``patch_path``
+    is parsed only as a manifest; contents come from ``snapshot_dir``. Rebuild,
+    JIT/cpp_itfs invalidation, and multi-node fan-out are driven off the
+    **whole** edited set so companion compiled files and worker pods are not
+    missed, and all-or-nothing spans apply → rebuild (a rebuild failure restores
+    every touched path).
+
+    Returns:
+        dict[str, Any]: Result dict mirroring the legacy mode plus
+            ``touched`` (the applied paths).
+    """
+    patch = Path(patch_path).resolve()
+    target = Path(target_file).resolve()
+    if not patch.is_file():
+        return {"status": "failed", "error": f"patch_path does not exist: {patch}"}
+
+    try:
+        descriptors = parse_patch_manifest(patch.read_text(encoding="utf-8", errors="replace"))
+    except ValueError as exc:
+        return {"status": "failed", "error": f"unparseable patch: {exc}"}
+    if not descriptors:
+        return {"status": "failed", "error": "patch has no file operations"}
+
+    try:
+        primary_strategy = _detect_strategy(target, allow_unknown_target=allow_unknown_target)
+    except ValueError as exc:
+        return {"status": "failed", "error": str(exc)}
+
+    # The repo root is authoritative for resolving the patch's repo-relative
+    # paths. Prefer the explicitly-threaded root (captured at verify time where
+    # kernel_repo is known); fall back to the strategy root. Never silently guess
+    # ``target.parent`` — a wrong root would resolve every manifest path into a
+    # nested subdir, violating the byte-for-byte contract.
+    resolved_root = str(repo_root or "") or primary_strategy["root"]
+    if not resolved_root:
+        return {
+            "status": "failed",
+            "error": (
+                "snapshot mode requires a known repo root (pass repo_root or a "
+                f"target under a known framework root): {target}"
+            ),
+        }
+    repo_root = Path(resolved_root)
+    backup_dir = Path(backup_root) / f"{_safe_name(kernel_id or target.stem)}_{_path_hash(target)}"
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = backup_dir / "manifest.json"
+
+    # Resolve every write/delete path to absolutes for downstream rebuild logic.
+    write_paths: list[Path] = []
+    for desc in descriptors:
+        try:
+            dest = _contained_dest(repo_root, desc["path"])
+        except ValueError as exc:
+            return {"status": "failed", "error": str(exc), "path": desc["path"]}
+        if desc["op"] == "write":
+            write_paths.append(dest)
+
+    rebuild_strategies = _multi_root_strategies(
+        write_paths, allow_unknown_target=allow_unknown_target
+    )
+    compiled = bool(rebuild_strategies)
+
+    artifacts: list[dict[str, str]] = []
+    if compiled:
+        roots: list[Path] = []
+        for strat in rebuild_strategies:
+            roots.extend(strat["artifact_roots"])
+        found = _discover_artifacts(roots, artifact_paths)
+        artifacts = [_copy_to_backup(p, backup_dir, "artifacts") for p in found]
+
+    manifest = {
+        "status": "prepared",
+        "kernel_id": kernel_id,
+        "patch_path": str(patch),
+        "target_file": str(target),
+        "mode": "snapshot",
+        "descriptors": descriptors,
+        "artifacts": artifacts,
+        "strategy": {"compiled": compiled, "root": str(repo_root)},
+        "created_at": _now(),
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if dry_run:
+        return {"status": "ok", "dry_run": True, "manifest_path": str(manifest_path)}
+
+    applied = apply_snapshot(
+        descriptors=descriptors,
+        snapshot_dir=snapshot_dir,
+        repo_root=repo_root,
+        backup_dir=backup_dir,
+    )
+    if applied["status"] != "ok":
+        return {"status": "failed", "error": applied.get("error"), "path": applied.get("path"),
+                "manifest_path": str(manifest_path)}
+
+    manifest["source_backups"] = applied["source_backups"]
+    # Keep a singular source_backup for the primary so legacy manifest readers work.
+    for entry in applied["source_backups"]:
+        if Path(entry["path"]) == target and entry.get("backup_path"):
+            manifest["source_backup"] = {"path": entry["path"], "backup_path": entry["backup_path"]}
+            break
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    # Post-apply verification: every written path must be byte-identical to its
+    # snapshot source, every deleted path gone. Any mismatch -> full restore.
+    snap = Path(snapshot_dir)
+    for desc in descriptors:
+        dest = _contained_dest(repo_root, desc["path"])
+        if desc["op"] == "delete":
+            if dest.exists():
+                revert_kernel_patch(manifest_path)
+                return {"status": "failed", "error": f"post-verify: {desc['path']} not deleted",
+                        "manifest_path": str(manifest_path)}
+            continue
+        src = snap / desc["path"]
+        if src.is_symlink():
+            if not dest.is_symlink() or os.readlink(dest) != os.readlink(src):
+                revert_kernel_patch(manifest_path)
+                return {"status": "failed", "error": f"post-verify symlink mismatch: {desc['path']}",
+                        "manifest_path": str(manifest_path)}
+        elif dest.read_bytes() != src.read_bytes():
+            revert_kernel_patch(manifest_path)
+            return {"status": "failed", "error": f"post-verify content mismatch: {desc['path']}",
+                    "manifest_path": str(manifest_path)}
+
+    cache_clear_paths = [p for p in write_paths if p.suffix.lower() in PYTHON_SOURCE_SUFFIXES]
+    cache_clear = {"status": "skipped", "reason": "no python source target"}
+    for p in cache_clear_paths:
+        cache_clear = _clear_python_kernel_caches(p)
+
+    # Multi-node fan-out: push every write path to every pod.
+    multinode_info: dict[str, Any] = {}
+    if _is_multi_node():
+        pod_backup_dir = os.environ.get("HYPERLOOM_MN_KERNEL_BACKUP_DIR", _MN_POD_BACKUP_DIR_DEFAULT)
+        per_node_all: list[dict[str, Any]] = []
+        backup_map: dict[str, str] = {}
+        try:
+            for p in write_paths:
+                mn_apply = _dispatch_multinode_apply(
+                    target_file=p, patch_path=snap / Path(p).relative_to(repo_root),
+                    kernel_id=kernel_id, backup_dir_on_pod=pod_backup_dir,
+                )
+                per_node_all.extend(mn_apply.get("per_node", []) or [])
+        except Exception as exc:  # noqa: BLE001
+            revert_kernel_patch(manifest_path)
+            return {"status": "failed",
+                    "error": f"multi-node apply fan-out failed; repo restored: {exc}",
+                    "manifest_path": str(manifest_path)}
+        for entry in per_node_all:
+            host = (entry.get("host") or "").strip()
+            bp = (entry.get("backup_path") or "").strip()
+            if host and bp:
+                backup_map[host] = bp
+        multinode_info = {"status": "ok", "target_path": str(target),
+                          "backup_dir_on_pod": pod_backup_dir,
+                          "host_backup_map": backup_map, "per_node": per_node_all}
+        manifest["multinode"] = multinode_info
+        manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    command: list[str] = []
+    if isinstance(rebuild_command, str):
+        command = ["/bin/bash", "-lc", rebuild_command]
+    elif rebuild_command:
+        command = list(rebuild_command)
+
+    rebuild: dict[str, Any] = {"status": "skipped", "reason": "source-only patch or skip_rebuild=true"}
+    jit_build_backup: dict[str, Any] = {"status": "skipped", "reason": "rebuild not run"}
+    cpp_itfs_cache_backup: dict[str, Any] = {"status": "skipped", "reason": "rebuild not run", "is_cpp_itfs": False}
+    if compiled and not skip_rebuild:
+        jit_build_backup = _invalidate_aiter_jit_build(target, backup_dir)
+        if jit_build_backup.get("status") == "failed":
+            revert_kernel_patch(manifest_path)
+            return {"status": "failed", "error_class": "aiter_jit_invalidation_failed",
+                    "error": f"aiter jit/build/ invalidation failed: {jit_build_backup.get('error')}",
+                    "manifest_path": str(manifest_path), "jit_build_backup": jit_build_backup}
+        if jit_build_backup.get("status") == "ok":
+            manifest["jit_build_backup"] = jit_build_backup
+            manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+        cpp_itfs_cache_backup = _invalidate_aiter_cpp_itfs_cache(target, backup_dir)
+        if cpp_itfs_cache_backup.get("status") == "failed":
+            revert_kernel_patch(manifest_path)
+            return {"status": "failed", "error_class": "aiter_cpp_itfs_invalidation_failed",
+                    "error": f"aiter cpp_itfs runtime cache invalidation failed: {cpp_itfs_cache_backup.get('error')}",
+                    "manifest_path": str(manifest_path), "cpp_itfs_cache_backup": cpp_itfs_cache_backup}
+        if cpp_itfs_cache_backup.get("status") == "ok":
+            manifest["cpp_itfs_cache_backup"] = cpp_itfs_cache_backup
+            manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+        # Rebuild each distinct compiled root. Any failure -> full restore.
+        rebuild_records: list[dict[str, Any]] = []
+        for strat in rebuild_strategies:
+            cmd = command or list(strat["rebuild_command"])
+            cwd = Path(strat["root"] or target.parent)
+            rec = _run_rebuild(cmd, cwd, rebuild_timeout_sec)
+            rebuild_records.append(rec)
+            if rec["status"] != "ok":
+                revert = revert_kernel_patch(manifest_path)
+                return {"status": "failed",
+                        "error": "rebuild failed; original source/artifacts restored",
+                        "manifest_path": str(manifest_path), "rebuild": rec, "revert": revert}
+        rebuild = rebuild_records[-1] if rebuild_records else rebuild
+
+    manifest["status"] = "applied"
+    manifest["applied_at"] = _now()
+    manifest["rebuild"] = rebuild
+    manifest["cache_clear"] = cache_clear
+    if jit_build_backup.get("status") in {"ok", "skipped"}:
+        manifest["jit_build_backup"] = jit_build_backup
+    if cpp_itfs_cache_backup.get("status") in {"ok", "skipped"}:
+        manifest["cpp_itfs_cache_backup"] = cpp_itfs_cache_backup
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    result: dict[str, Any] = {
+        "status": "ok", "manifest_path": str(manifest_path), "target_file": str(target),
+        "backup_dir": str(backup_dir), "compiled": compiled, "artifact_count": len(artifacts),
+        "cache_clear": cache_clear, "rebuild": rebuild, "jit_build_backup": jit_build_backup,
+        "cpp_itfs_cache_backup": cpp_itfs_cache_backup, "touched": applied["touched"],
+    }
     if multinode_info:
         result["multinode"] = multinode_info
     return result

--- a/kernel-agent/tools/apply_kernel_patch.py
+++ b/kernel-agent/tools/apply_kernel_patch.py
@@ -682,6 +682,11 @@ def apply_snapshot(
                         try:
                             dest.chmod(int(desc["mode"], 8))
                         except (ValueError, OSError):
+                            # Restoring mode bits is best-effort: a bad/garbled
+                            # mode string (ValueError) or a target filesystem
+                            # that rejects chmod (OSError) must not fail the
+                            # apply. The copied content is what matters, so keep
+                            # the default mode and proceed.
                             pass
             touched.append(str(dest))
         except (OSError, ValueError) as exc:

--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -3802,6 +3802,81 @@ def _candidate_artifact_paths(
     return deduped
 
 
+def _reconstruct_source_from_patch(
+    patch_path: Path,
+    target_file: str,
+    output_path: Path,
+) -> str:
+    """Reconstruct a complete source file by applying a unified diff.
+
+    A backend's best artifact is frequently a unified ``.patch``/``.diff``
+    (a diff, not a complete file). When no full-source artifact is found, the
+    original kernel at ``target_file`` plus the patch deterministically
+    reconstruct the optimized source — the same apply that deployment uses, so
+    the reconstructed file matches what would actually run. Tries ``git apply``
+    across the usual strip levels, then falls back to ``patch``.
+
+    Args:
+        patch_path (Path): Unified diff produced by the backend.
+        target_file (str): Original (pre-patch) kernel source path.
+        output_path (Path): Where the reconstructed source is written.
+
+    Returns:
+        str: The string path of the reconstructed source, or empty string when
+            the original is missing or the patch does not apply cleanly.
+    """
+    original = Path(target_file)
+    if not patch_path.is_file() or not original.is_file():
+        return ""
+    try:
+        original_text = original.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+    for strip in ("1", "0", "2"):
+        work = output_path.with_suffix(output_path.suffix + ".work")
+        try:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            work.write_text(original_text, encoding="utf-8")
+        except OSError:
+            return ""
+        applied = False
+        # git apply (preferred: honours rename/strip semantics), then patch.
+        try:
+            rc = subprocess.run(
+                ["git", "apply", f"-p{strip}", "--unsafe-paths",
+                 f"--directory={work.parent}", str(patch_path)],
+                capture_output=True, text=True, cwd=work.parent, check=False,
+            )
+            applied = rc.returncode == 0 and work.is_file()
+        except (OSError, ValueError):
+            applied = False
+        if not applied:
+            try:
+                with patch_path.open(encoding="utf-8", errors="replace") as pf:
+                    rc = subprocess.run(
+                        ["patch", f"-p{strip}", "--force", "--no-backup-if-mismatch",
+                         str(work)],
+                        stdin=pf, capture_output=True, text=True, check=False,
+                    )
+                applied = rc.returncode == 0
+            except (OSError, ValueError):
+                applied = False
+        if applied:
+            try:
+                patched_text = work.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                patched_text = ""
+            work.unlink(missing_ok=True)
+            if patched_text and patched_text != original_text and _source_text_looks_complete(
+                patched_text, output_path.suffix.lower()
+            ):
+                output_path.write_text(patched_text, encoding="utf-8")
+                return str(output_path)
+        else:
+            work.unlink(missing_ok=True)
+    return ""
+
+
 def _select_source_artifact(
     attempt: dict[str, Any],
     *,
@@ -3856,6 +3931,22 @@ def _select_source_artifact(
         )
         if extracted:
             return extracted, "extracted_code_block", ""
+
+    # Final fallback: a backend's best artifact is often a unified diff with no
+    # complete-source counterpart (and a diff can't be scraped as a full file).
+    # The original kernel + the patch reconstruct the optimized source
+    # deterministically — universal across backends/strategies/suffixes and
+    # independent of worktree/optimized_versions layout.
+    for path in candidates:
+        if path.suffix.lower() not in {".patch", ".diff"}:
+            continue
+        reconstructed = _reconstruct_source_from_patch(
+            path,
+            target_file,
+            extraction_root / f"{attempt.get('attempt_id', 'attempt')}_patched{target_suffix}",
+        )
+        if reconstructed:
+            return reconstructed, "reconstructed_from_patch", ""
 
     tried = ", ".join(str(p) for p in candidates[:6])
     return "", "missing", f"no complete {target_suffix} source artifact found; tried: {tried}"

--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -3802,6 +3802,120 @@ def _candidate_artifact_paths(
     return deduped
 
 
+_BACKUP_SUFFIXES = {".orig", ".rej", ".bak"}
+
+
+def _unquote_diff_path(raw: str) -> str:
+    """Decode a git diff header path, handling C-style quoting.
+
+    Git emits paths with special characters as C-quoted strings (e.g.
+    ``"b/\\303\\251.py"``). A naive ``..``/absolute check on the still-quoted
+    string can be bypassed, so decode it first.
+
+    Args:
+        raw (str): The raw token following ``+++ `` / ``--- `` (already
+            whitespace-trimmed of a trailing tab-timestamp by the caller).
+
+    Returns:
+        str: The decoded path, or the input unchanged when it is not quoted.
+    """
+    if len(raw) >= 2 and raw[0] == '"' and raw[-1] == '"':
+        try:
+            return raw[1:-1].encode("latin-1", "backslashreplace").decode("unicode_escape")
+        except (UnicodeDecodeError, ValueError):
+            return raw[1:-1]
+    return raw
+
+
+def _strip_diff_prefix(path: str, strip: int) -> str:
+    """Drop the first ``strip`` path components, mirroring ``-p<N>``.
+
+    Empty components (from ``//`` or a leading ``/``) are dropped first so the
+    strip count operates on real path segments and cannot resurrect an absolute
+    path via an empty component.
+
+    Args:
+        path (str): A diff target path (e.g. ``b/dir/file.py``).
+        strip (int): Number of leading components to remove.
+
+    Returns:
+        str: The post-strip relative path, or ``""`` when nothing remains.
+    """
+    parts = [p for p in path.split("/") if p]
+    return "/".join(parts[strip:]) if len(parts) > strip else ""
+
+
+def _select_patch_section(patch_text: str, target_file: str) -> tuple[str, str] | None:
+    """Slice out the per-file diff section that targets ``target_file``.
+
+    Real kernel patches are frequently multi-file, but reconstruction only has
+    the single original kernel on disk, so the whole patch cannot apply in an
+    isolated dir. Extract just the matched file's section and reject anything
+    unsafe or unusable.
+
+    Args:
+        patch_text (str): The full unified diff.
+        target_file (str): Original kernel path the section must target.
+
+    Returns:
+        tuple[str, str] | None: ``(section_text, raw_target_path)`` for the
+            matched file, or ``None`` when no usable/safe section matches.
+    """
+    if not patch_text.strip():
+        return None
+    # Split into per-file blocks. Prefer git's ``diff --git`` boundaries; fall
+    # back to ``--- ``/``+++ `` pairs for plain unified diffs.
+    if re.search(r"(?m)^diff --git ", patch_text):
+        blocks = [b for b in re.split(r"(?m)^(?=diff --git )", patch_text) if b.strip()]
+    else:
+        blocks = [b for b in re.split(r"(?m)^(?=--- )", patch_text) if b.strip()]
+
+    want = Path(target_file).name
+    want_parts = Path(target_file).parts
+    matches: list[tuple[int, str, str]] = []  # (tail_len, raw_path, block)
+    for block in blocks:
+        m = re.search(r"(?m)^\+\+\+ (.+)$", block)
+        if not m:
+            continue
+        raw = _unquote_diff_path(m.group(1).split("\t", 1)[0].strip())
+        if raw == "/dev/null":
+            continue
+        # Strip a leading a/ or b/ for tail comparison only.
+        cmp_path = re.sub(r"^[ab]/", "", raw)
+        cmp_parts = Path(cmp_path).parts
+        if not cmp_parts or Path(cmp_path).name != want:
+            continue
+        if Path(cmp_path).suffix.lower() in _BACKUP_SUFFIXES:
+            continue
+        # Longest common path-tail length (basename match is the floor).
+        tail = 0
+        for a, b in zip(reversed(cmp_parts), reversed(want_parts)):
+            if a != b:
+                break
+            tail += 1
+        matches.append((tail, raw, block))
+
+    if not matches:
+        return None
+    best_tail = max(t for t, _, _ in matches)
+    best = [(r, b) for t, r, b in matches if t == best_tail]
+    if len(best) != 1:
+        return None  # genuine ambiguity: two distinct targets share the tail
+    raw, block = best[0]
+    if "\n@@" not in ("\n" + block):
+        return None  # rename/mode-only/binary section: no hunk to apply
+    # Validate the path that the apply loop actually writes to (after the same
+    # empty-component-aware strip), at every strip level it will try — not a
+    # separately-derived cmp_path. Reject if any usable strip yields an absolute
+    # or ``..``-containing path.
+    stripped = [_strip_diff_prefix(raw, s) for s in (1, 0, 2)]
+    if not any(stripped):
+        return None
+    if any(rel and (os.path.isabs(rel) or ".." in Path(rel).parts) for rel in stripped):
+        return None
+    return block, raw
+
+
 def _reconstruct_source_from_patch(
     patch_path: Path,
     target_file: str,
@@ -3812,9 +3926,9 @@ def _reconstruct_source_from_patch(
     A backend's best artifact is frequently a unified ``.patch``/``.diff``
     (a diff, not a complete file). When no full-source artifact is found, the
     original kernel at ``target_file`` plus the patch deterministically
-    reconstruct the optimized source — the same apply that deployment uses, so
-    the reconstructed file matches what would actually run. Tries ``git apply``
-    across the usual strip levels, then falls back to ``patch``.
+    reconstruct the optimized source. The matched file's section is applied
+    inside an isolated temp dir (so an untrusted patch header cannot escape it),
+    via ``git apply`` then ``patch`` across the usual strip levels.
 
     Args:
         patch_path (Path): Unified diff produced by the backend.
@@ -3830,51 +3944,159 @@ def _reconstruct_source_from_patch(
         return ""
     try:
         original_text = original.read_text(encoding="utf-8", errors="replace")
+        patch_text = patch_path.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return ""
-    for strip in ("1", "0", "2"):
-        work = output_path.with_suffix(output_path.suffix + ".work")
-        try:
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            work.write_text(original_text, encoding="utf-8")
-        except OSError:
-            return ""
-        applied = False
-        # git apply (preferred: honours rename/strip semantics), then patch.
-        try:
-            rc = subprocess.run(
-                ["git", "apply", f"-p{strip}", "--unsafe-paths",
-                 f"--directory={work.parent}", str(patch_path)],
-                capture_output=True, text=True, cwd=work.parent, check=False,
-            )
-            applied = rc.returncode == 0 and work.is_file()
-        except (OSError, ValueError):
-            applied = False
-        if not applied:
+    selected = _select_patch_section(patch_text, target_file)
+    if selected is None:
+        return ""
+    section_text, raw_target = selected
+
+    for strip in (1, 0, 2):
+        rel = _strip_diff_prefix(raw_target, strip)
+        if not rel or os.path.isabs(rel) or ".." in Path(rel).parts:
+            continue
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            work = tmp / rel
+            section = tmp / "section.patch"
+            # Containment guard: confirm the resolved write path stays inside the
+            # temp dir after all path arithmetic, before writing anything.
             try:
-                with patch_path.open(encoding="utf-8", errors="replace") as pf:
-                    rc = subprocess.run(
-                        ["patch", f"-p{strip}", "--force", "--no-backup-if-mismatch",
-                         str(work)],
-                        stdin=pf, capture_output=True, text=True, check=False,
-                    )
-                applied = rc.returncode == 0
+                work.resolve().relative_to(tmp.resolve())
+            except ValueError:
+                continue
+            try:
+                work.parent.mkdir(parents=True, exist_ok=True)
+                work.write_text(original_text, encoding="utf-8")
+                section.write_text(section_text, encoding="utf-8")
+            except OSError:
+                continue
+            applied = False
+            # git apply (honours rename/strip semantics), contained to tmp; no
+            # --unsafe-paths/--directory, so git refuses any path escape itself.
+            try:
+                rc = subprocess.run(
+                    ["git", "apply", f"-p{strip}", "section.patch"],
+                    capture_output=True, text=True, cwd=str(tmp), check=False,
+                )
+                applied = rc.returncode == 0 and work.is_file()
             except (OSError, ValueError):
                 applied = False
-        if applied:
+            if not applied:
+                # patch with an explicit file arg ignores the header path and
+                # only writes ``work`` (any .rej stays in the temp dir).
+                try:
+                    with section.open(encoding="utf-8", errors="replace") as pf:
+                        rc = subprocess.run(
+                            ["patch", f"-p{strip}", "--force", "--no-backup-if-mismatch",
+                             str(work)],
+                            stdin=pf, capture_output=True, text=True, check=False,
+                        )
+                    applied = rc.returncode == 0
+                except (OSError, ValueError):
+                    applied = False
+            if not applied:
+                continue
             try:
                 patched_text = work.read_text(encoding="utf-8", errors="replace")
             except OSError:
-                patched_text = ""
-            work.unlink(missing_ok=True)
+                continue
             if patched_text and patched_text != original_text and _source_text_looks_complete(
                 patched_text, output_path.suffix.lower()
             ):
-                output_path.write_text(patched_text, encoding="utf-8")
+                try:
+                    output_path.parent.mkdir(parents=True, exist_ok=True)
+                    output_path.write_text(patched_text, encoding="utf-8")
+                except OSError:
+                    return ""
                 return str(output_path)
-        else:
-            work.unlink(missing_ok=True)
     return ""
+
+
+def build_patch_snapshot(
+    patch_path: str,
+    *,
+    worktree: Path | None,
+    kernel_repo: str,
+    clean_base: str,
+    out_dir: Path,
+) -> dict[str, Any] | None:
+    """Stage byte-exact final contents for every file a patch writes.
+
+    Implements the content-addressed deploy capture: parse the patch as a
+    manifest, then for each non-deleted path materialise its exact final bytes
+    into ``out_dir`` (mirrored at the same repo-relative path). Content is
+    sourced, in priority order, from the backend's ``worktree`` (ground-truth
+    written files) and, failing that, by reconstructing from ``clean_base`` +
+    the patch in a contained temp dir. Only manifest paths are staged — never
+    the whole worktree — so scratch the backend left outside the patch never
+    deploys.
+
+    Args:
+        patch_path (str): The winning unified diff.
+        worktree (Path | None): The backend worktree of final files, if any.
+        kernel_repo (str): Repo root, for worktree-relative resolution.
+        clean_base (str): Repo root holding pristine pre-patch sources, used to
+            reconstruct content when the worktree lacks a path.
+        out_dir (Path): Snapshot staging dir to populate.
+
+    Returns:
+        dict[str, Any] | None: ``{"snapshot_dir", "descriptors", "patch_path"}``
+            when every write path was materialised byte-exact, else ``None``
+            (caller treats this as non-deployable -> hard fail downstream).
+    """
+    import apply_kernel_patch as _akp
+
+    try:
+        patch_text = Path(patch_path).read_text(encoding="utf-8", errors="replace")
+        descriptors = _akp.parse_patch_manifest(patch_text)
+    except (OSError, ValueError):
+        return None
+    if not descriptors:
+        return None
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for desc in descriptors:
+        if desc["op"] != "write":
+            continue
+        rel = desc["path"]
+        dst = out_dir / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        sourced = False
+        # 1) worktree ground-truth file at the same relative path.
+        if worktree is not None and kernel_repo:
+            cand = worktree / rel
+            if cand.is_file() or cand.is_symlink():
+                try:
+                    import shutil as _shutil
+                    _shutil.copy2(cand, dst, follow_symlinks=False)
+                    sourced = True
+                except OSError:
+                    sourced = False
+        # 2) reconstruct from clean base + patch (single-file slice).
+        if not sourced and clean_base:
+            base_file = Path(clean_base) / rel
+            reconstructed = _reconstruct_source_from_patch(
+                Path(patch_path), str(base_file), dst.with_suffix(dst.suffix + ".recon")
+            ) if base_file.is_file() else ""
+            if reconstructed:
+                try:
+                    Path(reconstructed).replace(dst)
+                    sourced = True
+                except OSError:
+                    sourced = False
+        if not sourced:
+            # Cannot guarantee byte-exact final content for this path -> the
+            # whole attempt is non-deployable (hard fail, never partial).
+            return None
+
+    return {
+        "snapshot_dir": str(out_dir),
+        "descriptors": descriptors,
+        "patch_path": str(patch_path),
+        "repo_root": str(kernel_repo or ""),
+    }
 
 
 def _select_source_artifact(
@@ -4017,6 +4239,36 @@ def build_verification(
             kernel_repo=kernel_repo,
         )
     artifact_valid = bool(best_artifact_path)
+
+    # Content-addressed deploy capture: when the winning attempt produced a
+    # unified diff, stage byte-exact final contents for the WHOLE patch now
+    # (clean base + worktree are in hand). Deploy then lands all files atomically.
+    deploy_snapshot_dir = ""
+    deploy_patch_path = ""
+    deploy_repo_root = ""
+    if best is not None and artifact_valid:
+        bp = best.get("backend_paths") or {}
+        winning_patch = str(bp.get("geak_per_task_best_patch") or "")
+        if not winning_patch:
+            for key in ("partial_report", "report"):
+                cand = str(bp.get(key) or "")
+                if cand.endswith((".patch", ".diff")):
+                    winning_patch = cand
+                    break
+        if winning_patch and Path(winning_patch).is_file():
+            worktree = _geak_best_worktree(winning_patch)
+            snap_out = (run_dir or Path(winning_patch).parent) / f"{best.get('attempt_id', 'attempt')}_deploy_snapshot"
+            snap = build_patch_snapshot(
+                winning_patch,
+                worktree=worktree,
+                kernel_repo=kernel_repo,
+                clean_base=kernel_repo,
+                out_dir=snap_out,
+            )
+            if snap is not None:
+                deploy_snapshot_dir = snap["snapshot_dir"]
+                deploy_patch_path = snap["patch_path"]
+                deploy_repo_root = snap.get("repo_root", "")
     correctness_signal = getattr(args, "correctness_passed", None)
     correctness_source = "cli_override" if correctness_signal is not None else "missing"
     if correctness_signal is None and best is not None:
@@ -4088,6 +4340,9 @@ def build_verification(
         "artifact_valid": artifact_valid,
         "artifact_source": artifact_source,
         "artifact_error": "" if artifact_valid else artifact_error,
+        "deploy_snapshot_dir": deploy_snapshot_dir,
+        "deploy_patch_path": deploy_patch_path,
+        "deploy_repo_root": deploy_repo_root,
     }
 
 

--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -3832,6 +3832,18 @@ def _reconstruct_source_from_patch(
         original_text = original.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return ""
+    # Backend-produced diffs are untrusted input. Validate the headers before
+    # applying: the diff must touch exactly one file whose post-image basename
+    # matches the target, with no absolute paths and no ``..`` traversal. This
+    # plus applying to an explicit work file (never ``--directory`` /
+    # ``--unsafe-paths``) keeps a malicious/malformed header from escaping the
+    # extraction dir.
+    if not _patch_targets_only(patch_path, original.name):
+        return ""
+    try:
+        patch_text = patch_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
     for strip in ("1", "0", "2"):
         work = output_path.with_suffix(output_path.suffix + ".work")
         try:
@@ -3840,27 +3852,18 @@ def _reconstruct_source_from_patch(
         except OSError:
             return ""
         applied = False
-        # git apply (preferred: honours rename/strip semantics), then patch.
+        # Apply ONLY to the explicit work file: ``patch <strip> <work>`` ignores
+        # the diff's header path (writes solely to the named file), so a hostile
+        # header cannot redirect the write. No --directory, no --unsafe-paths.
         try:
             rc = subprocess.run(
-                ["git", "apply", f"-p{strip}", "--unsafe-paths",
-                 f"--directory={work.parent}", str(patch_path)],
-                capture_output=True, text=True, cwd=work.parent, check=False,
+                ["patch", f"-p{strip}", "--force", "--no-backup-if-mismatch",
+                 str(work)],
+                input=patch_text, capture_output=True, text=True, check=False,
             )
-            applied = rc.returncode == 0 and work.is_file()
+            applied = rc.returncode == 0
         except (OSError, ValueError):
             applied = False
-        if not applied:
-            try:
-                with patch_path.open(encoding="utf-8", errors="replace") as pf:
-                    rc = subprocess.run(
-                        ["patch", f"-p{strip}", "--force", "--no-backup-if-mismatch",
-                         str(work)],
-                        stdin=pf, capture_output=True, text=True, check=False,
-                    )
-                applied = rc.returncode == 0
-            except (OSError, ValueError):
-                applied = False
         if applied:
             try:
                 patched_text = work.read_text(encoding="utf-8", errors="replace")
@@ -3875,6 +3878,44 @@ def _reconstruct_source_from_patch(
         else:
             work.unlink(missing_ok=True)
     return ""
+
+
+def _patch_targets_only(patch_path: Path, expected_basename: str) -> bool:
+    """Return whether a unified diff safely touches only ``expected_basename``.
+
+    Rejects multi-file diffs, absolute target paths, and ``..`` traversal in any
+    ``+++`` / ``---`` header — defense in depth around the reconstruction apply,
+    which itself writes only to an explicit work file. ``/dev/null`` (pure
+    add/delete side) is ignored; the non-null side must basename-match.
+
+    Args:
+        patch_path (Path): The unified diff to validate.
+        expected_basename (str): The original kernel file's basename.
+
+    Returns:
+        bool: True when every header targets only ``expected_basename`` safely.
+    """
+    try:
+        text = patch_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    seen_target = False
+    for line in text.splitlines():
+        if not (line.startswith("+++ ") or line.startswith("--- ")):
+            continue
+        raw = line[4:].strip()
+        # strip a trailing tab-timestamp some diff tools append
+        raw = raw.split("\t", 1)[0].strip()
+        if raw in ("/dev/null", ""):
+            continue
+        # drop a leading a/ or b/ prefix
+        path = raw[2:] if (raw.startswith("a/") or raw.startswith("b/")) else raw
+        if path.startswith("/") or ".." in Path(path).parts:
+            return False
+        if Path(path).name != expected_basename:
+            return False
+        seen_target = True
+    return seen_target
 
 
 def _select_source_artifact(

--- a/kernel-agent/tools/test_apply_kernel_patch_jit_invalidation.py
+++ b/kernel-agent/tools/test_apply_kernel_patch_jit_invalidation.py
@@ -293,7 +293,9 @@ def test_apply_then_revert_roundtrip_invalidates_and_restores_jit_cache(
     backup_root = tmp_path / "backups"
 
     # Make aiter resolve to the synthetic layout for _aiter_jit_build_dir().
-    fake_spec = types.SimpleNamespace(submodule_search_locations=[str(repo / "aiter")])
+    fake_spec = types.SimpleNamespace(
+        submodule_search_locations=[str(repo / "aiter")], origin=None
+    )
     fake_rebuild_ok = {
         "status": "ok",
         "returncode": 0,
@@ -339,7 +341,9 @@ def test_skip_rebuild_does_not_invalidate_jit_build(
     patch_file = tmp_path / "patched.cu"
     patch_file.write_text('#include <cstdio>\nnamespace aiter {\nvoid ck_moe_stage1(int x) { printf("v1\\n"); }\n}\n')
 
-    fake_spec = types.SimpleNamespace(submodule_search_locations=[str(repo / "aiter")])
+    fake_spec = types.SimpleNamespace(
+        submodule_search_locations=[str(repo / "aiter")], origin=None
+    )
     with patch.object(apply_tool.importlib.util, "find_spec", return_value=fake_spec):
         result = apply_tool.apply_kernel_patch(
             patch_path=patch_file,

--- a/kernel-agent/tools/test_apply_kernel_patch_snapshot.py
+++ b/kernel-agent/tools/test_apply_kernel_patch_snapshot.py
@@ -1,0 +1,242 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Snapshot (content-addressed) deploy: land the whole patch byte-for-byte or fail.
+
+Covers the hard requirement that the entire backend patch is applied exactly as
+given — every addition, deletion, and substitution — across all files
+atomically, with no fuzzy/partial application and a hard, repo-restoring failure
+otherwise.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+_APPLY_TOOL_PATH = Path(__file__).resolve().parent / "apply_kernel_patch.py"
+
+
+@pytest.fixture(scope="module")
+def akp() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location("_akp_snapshot_under_test", _APPLY_TOOL_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# --- manifest parser -------------------------------------------------------
+
+def test_parse_manifest_modify_add_delete(akp):
+    patch = (
+        "diff --git a/m.py b/m.py\n--- a/m.py\n+++ b/m.py\n@@ -1 +1 @@\n-a\n+b\n"
+        "diff --git a/n.py b/n.py\nnew file mode 100644\n--- /dev/null\n+++ b/n.py\n@@ -0,0 +1 @@\n+x\n"
+        "diff --git a/d.py b/d.py\ndeleted file mode 100644\n--- a/d.py\n+++ /dev/null\n@@ -1 +0,0 @@\n-y\n"
+    )
+    descs = akp.parse_patch_manifest(patch)
+    ops = {d["path"]: d["op"] for d in descs}
+    assert ops == {"m.py": "write", "n.py": "write", "d.py": "delete"}
+
+
+def test_parse_manifest_rename_maps_to_delete_plus_write(akp):
+    patch = (
+        "diff --git a/old.py b/new.py\nsimilarity index 100%\nrename from old.py\nrename to new.py\n"
+    )
+    descs = akp.parse_patch_manifest(patch)
+    assert {"op": "delete", "path": "old.py", "mode": "", "binary": False} in descs
+    assert any(d["op"] == "write" and d["path"] == "new.py" for d in descs)
+
+
+def test_parse_manifest_chmod_and_binary_and_mode(akp):
+    chmod = akp.parse_patch_manifest("diff --git a/s b/s\nold mode 100644\nnew mode 100755\n")
+    assert chmod == [{"op": "write", "path": "s", "mode": "0755", "binary": False}]
+    binary = akp.parse_patch_manifest(
+        "diff --git a/b.bin b/b.bin\nnew file mode 100644\nindex 0..1\nGIT binary patch\nliteral 0\n"
+    )
+    assert binary[0]["binary"] is True and binary[0]["mode"] == "0644"
+
+
+def test_parse_manifest_empty_raises(akp):
+    with pytest.raises(ValueError):
+        akp.parse_patch_manifest("   \n")
+
+
+# --- apply_snapshot core ---------------------------------------------------
+
+def _mk(tmp_path):
+    repo = tmp_path / "repo"
+    snap = tmp_path / "snap"
+    repo.mkdir()
+    snap.mkdir()
+    return repo, snap, tmp_path / "backup"
+
+
+def test_apply_snapshot_modify_add_delete_atomic(tmp_path, akp):
+    repo, snap, bk = _mk(tmp_path)
+    (repo / "mod.py").write_text("OLD\n")
+    (repo / "del.py").write_text("bye\n")
+    (snap / "mod.py").write_text("NEW\n")
+    (snap / "add.py").write_text("ADD\n")
+    descs = [
+        {"op": "write", "path": "mod.py", "mode": "", "binary": False},
+        {"op": "write", "path": "add.py", "mode": "0755", "binary": False},
+        {"op": "delete", "path": "del.py", "mode": "", "binary": False},
+    ]
+    r = akp.apply_snapshot(descriptors=descs, snapshot_dir=snap, repo_root=repo, backup_dir=bk)
+    assert r["status"] == "ok"
+    assert (repo / "mod.py").read_text() == "NEW\n"
+    assert (repo / "add.py").read_text() == "ADD\n"
+    assert oct((repo / "add.py").stat().st_mode)[-3:] == "755"
+    assert not (repo / "del.py").exists()
+
+
+def test_apply_snapshot_preflight_missing_content_writes_nothing(tmp_path, akp):
+    repo, snap, bk = _mk(tmp_path)
+    (repo / "a.py").write_text("A0\n")
+    (snap / "a.py").write_text("A1\n")
+    descs = [
+        {"op": "write", "path": "a.py", "mode": "", "binary": False},
+        {"op": "write", "path": "missing.py", "mode": "", "binary": False},
+    ]
+    r = akp.apply_snapshot(descriptors=descs, snapshot_dir=snap, repo_root=repo, backup_dir=bk)
+    assert r["status"] == "failed"
+    assert (repo / "a.py").read_text() == "A0\n"  # untouched
+
+
+@pytest.mark.parametrize("bad", ["../victim.py", "/etc/evil.py", "sub/../../victim.py"])
+def test_apply_snapshot_rejects_path_escape(tmp_path, akp, bad):
+    repo, snap, bk = _mk(tmp_path)
+    victim = tmp_path / "victim.py"
+    victim.write_text("safe\n")
+    (snap / "x.py").write_text("x\n")
+    descs = [{"op": "write", "path": bad, "mode": "", "binary": False}]
+    r = akp.apply_snapshot(descriptors=descs, snapshot_dir=snap, repo_root=repo, backup_dir=bk)
+    assert r["status"] == "failed"
+    assert victim.read_text() == "safe\n"
+
+
+def test_apply_snapshot_symlink_reproduced_not_dereferenced(tmp_path, akp):
+    repo, snap, bk = _mk(tmp_path)
+    os.symlink("/etc/hostname", snap / "link.py")
+    descs = [{"op": "write", "path": "link.py", "mode": "", "binary": False}]
+    r = akp.apply_snapshot(descriptors=descs, snapshot_dir=snap, repo_root=repo, backup_dir=bk)
+    assert r["status"] == "ok"
+    assert (repo / "link.py").is_symlink()
+
+
+def test_apply_snapshot_midapply_failure_restores_all(tmp_path, akp, monkeypatch):
+    repo, snap, bk = _mk(tmp_path)
+    (repo / "first.py").write_text("F0\n")
+    (snap / "first.py").write_text("F1\n")
+    (snap / "second.py").write_text("S1\n")
+    descs = [
+        {"op": "write", "path": "first.py", "mode": "", "binary": False},
+        {"op": "write", "path": "second.py", "mode": "", "binary": False},
+    ]
+    # Inject a write failure on the SECOND file's apply copy (after first
+    # succeeded) — robust regardless of uid, unlike a chmod-based block.
+    real_copy2 = akp.shutil.copy2
+
+    def flaky(src, dst, *a, **k):
+        if Path(dst).parent == repo and Path(dst).name == "second.py":
+            raise OSError("injected write failure")
+        return real_copy2(src, dst, *a, **k)
+
+    monkeypatch.setattr(akp.shutil, "copy2", flaky)
+    r = akp.apply_snapshot(descriptors=descs, snapshot_dir=snap, repo_root=repo, backup_dir=bk)
+    assert r["status"] == "failed"
+    assert (repo / "first.py").read_text() == "F0\n"  # rolled back
+    assert not (repo / "second.py").exists()
+
+
+# --- end-to-end apply_kernel_patch snapshot mode + revert ------------------
+
+def _patch_text():
+    return (
+        "diff --git a/mod.py b/mod.py\n--- a/mod.py\n+++ b/mod.py\n@@ -1,2 +1,2 @@\n import triton\n-OLD\n+NEW\n"
+        "diff --git a/add.py b/add.py\nnew file mode 100644\n--- /dev/null\n+++ b/add.py\n@@ -0,0 +1 @@\n+ADD\n"
+        "diff --git a/del.py b/del.py\ndeleted file mode 100644\n--- a/del.py\n+++ /dev/null\n@@ -1 +0,0 @@\n-bye\n"
+    )
+
+
+def test_snapshot_mode_apply_then_revert_roundtrip(tmp_path, akp):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "mod.py").write_text("import triton\nOLD\n")
+    (repo / "del.py").write_text("bye\n")
+    snap = tmp_path / "snap"
+    snap.mkdir()
+    (snap / "mod.py").write_text("import triton\nNEW\n")
+    (snap / "add.py").write_text("ADD\n")
+    patch = tmp_path / "p.patch"
+    patch.write_text(_patch_text())
+
+    r = akp.apply_kernel_patch(
+        patch_path=patch, target_file=str(repo / "mod.py"), backup_root=tmp_path / "bk",
+        snapshot_dir=snap, allow_unknown_target=True, skip_rebuild=True, repo_root=str(repo),
+    )
+    assert r["status"] == "ok"
+    assert (repo / "mod.py").read_text() == "import triton\nNEW\n"
+    assert (repo / "add.py").exists()
+    assert not (repo / "del.py").exists()
+
+    rv = akp.revert_kernel_patch(r["manifest_path"])
+    assert rv["status"] == "ok"
+    assert (repo / "mod.py").read_text() == "import triton\nOLD\n"  # modified restored
+    assert not (repo / "add.py").exists()  # added unlinked
+    assert (repo / "del.py").read_text() == "bye\n"  # deleted recreated
+
+
+def test_snapshot_mode_post_verify_mismatch_fails_and_restores(tmp_path, akp, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "k.py").write_text("V0\n")
+    snap = tmp_path / "snap"
+    snap.mkdir()
+    (snap / "k.py").write_text("V1\n")
+    patch = tmp_path / "p.patch"
+    patch.write_text("diff --git a/k.py b/k.py\n--- a/k.py\n+++ b/k.py\n@@ -1 +1 @@\n-V0\n+V1\n")
+
+    # Corrupt the applied file once (during apply only) so post-verify detects a
+    # content mismatch vs the snapshot and must restore. The one-shot guard lets
+    # the subsequent restore copy run cleanly.
+    real_copy2 = akp.shutil.copy2
+    state = {"poisoned": False}
+
+    def poisoned(src, dst, *a, **k):
+        real_copy2(src, dst, *a, **k)
+        if not state["poisoned"] and Path(dst).name == "k.py" and Path(dst).parent == repo:
+            Path(dst).write_text("CORRUPT\n")
+            state["poisoned"] = True
+
+    monkeypatch.setattr(akp.shutil, "copy2", poisoned)
+    r = akp.apply_kernel_patch(
+        patch_path=patch, target_file=str(repo / "k.py"), backup_root=tmp_path / "bk",
+        snapshot_dir=snap, allow_unknown_target=True, skip_rebuild=True, repo_root=str(repo),
+    )
+    assert r["status"] == "failed"
+    monkeypatch.undo()
+    assert (repo / "k.py").read_text() == "V0\n"  # restored to original
+
+
+def test_snapshot_mode_unparseable_patch_hard_fails(tmp_path, akp):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "k.py").write_text("V0\n")
+    snap = tmp_path / "snap"
+    snap.mkdir()
+    patch = tmp_path / "p.patch"
+    patch.write_text("")  # empty -> nothing to apply
+    r = akp.apply_kernel_patch(
+        patch_path=patch, target_file=str(repo / "k.py"), backup_root=tmp_path / "bk",
+        snapshot_dir=snap, allow_unknown_target=True, skip_rebuild=True, repo_root=str(repo),
+    )
+    assert r["status"] == "failed"
+    assert (repo / "k.py").read_text() == "V0\n"

--- a/kernel-agent/tools/test_kernel_optimization_verification.py
+++ b/kernel-agent/tools/test_kernel_optimization_verification.py
@@ -889,6 +889,225 @@ def test_patch_only_winner_reconstructs_full_source(tmp_path):
     assert "@@" not in text  # not a diff
 
 
+_RECON_ORIGINAL = (
+    "import triton\n\n\ndef helper():\n    return 1\n\n\ndef kernel():\n    return helper()\n"
+)
+_RECON_KERNEL_SECTION = (
+    "diff --git a/fused_moe.py b/fused_moe.py\n"
+    "--- a/fused_moe.py\n"
+    "+++ b/fused_moe.py\n"
+    "@@ -1,5 +1,8 @@\n"
+    " import triton\n"
+    " \n"
+    " \n"
+    "+_CACHE = {}\n"
+    "+\n"
+    "+\n"
+    " def helper():\n"
+    "     return 1\n"
+)
+
+
+def _reconstruct(tmp_path, patch_text, *, original_name="fused_moe.py", original_text=_RECON_ORIGINAL):
+    """Run reconstruction for ``patch_text`` against a written original kernel."""
+    original = tmp_path / original_name
+    original.parent.mkdir(parents=True, exist_ok=True)
+    original.write_text(original_text, encoding="utf-8")
+    patch_path = tmp_path / "winner.patch"
+    patch_path.write_text(patch_text, encoding="utf-8")
+    out = tmp_path / "reconstructed.py"
+    return ko._reconstruct_source_from_patch(patch_path, str(original), out)
+
+
+def test_reconstruct_git_style_diff_with_index_header(tmp_path):
+    """A real-shape ``diff --git`` + ``index`` multi-component path reconstructs
+    via the contained ``git apply`` path (not silently falling back)."""
+    patch = (
+        "diff --git a/aiter/ops/fused_moe.py b/aiter/ops/fused_moe.py\n"
+        "index 1d75520b5..0159e0442 100644\n"
+        "--- a/aiter/ops/fused_moe.py\n"
+        "+++ b/aiter/ops/fused_moe.py\n"
+        "@@ -1,5 +1,8 @@\n"
+        " import triton\n"
+        " \n"
+        " \n"
+        "+_CACHE = {}\n"
+        "+\n"
+        "+\n"
+        " def helper():\n"
+        "     return 1\n"
+    )
+    out = _reconstruct(tmp_path, patch, original_name="aiter/ops/fused_moe.py")
+    assert out
+    text = Path(out).read_text(encoding="utf-8")
+    assert "_CACHE = {}" in text and "def kernel():" in text and "@@" not in text
+
+
+def test_reconstruct_multi_file_patch_slices_matched_target(tmp_path):
+    """Multi-file patch where only the kernel original exists: the kernel section
+    is sliced and applied (a whole-patch apply would fail on the absent files)."""
+    patch = (
+        "diff --git a/bench.py b/bench.py\n--- a/bench.py\n+++ b/bench.py\n"
+        "@@ -1 +1 @@\n-old\n+new\n"
+        + _RECON_KERNEL_SECTION
+        + "diff --git a/other.py b/other.py\n--- a/other.py\n+++ b/other.py\n"
+        "@@ -1 +1 @@\n-a\n+b\n"
+    )
+    out = _reconstruct(tmp_path, patch)
+    assert out
+    assert "_CACHE = {}" in Path(out).read_text(encoding="utf-8")
+
+
+def test_reconstruct_prefers_real_target_over_orig_sibling(tmp_path):
+    """A ``.orig`` sibling with the same stem must not be chosen over the real
+    kernel file."""
+    patch = (
+        "diff --git a/fused_moe.py.orig b/fused_moe.py.orig\n"
+        "--- a/fused_moe.py.orig\n+++ b/fused_moe.py.orig\n"
+        "@@ -1 +1 @@\n-junk\n+junk2\n"
+        + _RECON_KERNEL_SECTION
+    )
+    out = _reconstruct(tmp_path, patch)
+    assert out
+    assert "_CACHE = {}" in Path(out).read_text(encoding="utf-8")
+
+
+def test_reconstruct_ignores_companion_new_file_dev_null(tmp_path):
+    """A ``/dev/null`` new-file companion entry is ignored, not fatal, as long as
+    the matched kernel section has real hunks."""
+    patch = (
+        "diff --git a/new_helper.py b/new_helper.py\n"
+        "new file mode 100644\n--- /dev/null\n+++ b/new_helper.py\n"
+        "@@ -0,0 +1 @@\n+HELPER = 1\n"
+        + _RECON_KERNEL_SECTION
+    )
+    out = _reconstruct(tmp_path, patch)
+    assert out
+    assert "_CACHE = {}" in Path(out).read_text(encoding="utf-8")
+
+
+def test_reconstruct_rejects_empty_patch(tmp_path):
+    """An empty / 0-byte patch reconstructs nothing."""
+    assert _reconstruct(tmp_path, "") == ""
+    assert _reconstruct(tmp_path, "   \n  \n") == ""
+
+
+def test_reconstruct_rejects_hunkless_patch(tmp_path):
+    """Headers present but no ``@@`` hunk (rename/mode-only shape) → nothing."""
+    patch = (
+        "diff --git a/fused_moe.py b/fused_moe.py\n"
+        "old mode 100644\nnew mode 100755\n"
+        "--- a/fused_moe.py\n+++ b/fused_moe.py\n"
+    )
+    assert _reconstruct(tmp_path, patch) == ""
+
+
+def test_reconstruct_rejects_absolute_path_patch(tmp_path):
+    """An absolute-path diff header is refused (no write outside)."""
+    victim = tmp_path / "victim.py"
+    victim.write_text("safe\n", encoding="utf-8")
+    patch = (
+        f"--- a/fused_moe.py\n+++ {victim}\n@@ -1 +1 @@\n-safe\n+PWNED\n"
+    )
+    assert _reconstruct(tmp_path, patch) == ""
+    assert victim.read_text(encoding="utf-8") == "safe\n"
+
+
+def test_reconstruct_rejects_parent_traversal_patch(tmp_path):
+    """A ``..`` traversal header is refused and writes nothing outside the dir."""
+    outside = tmp_path / "outside.py"
+    outside.write_text("safe\n", encoding="utf-8")
+    work = tmp_path / "work"
+    work.mkdir()
+    original = work / "fused_moe.py"
+    original.write_text(_RECON_ORIGINAL, encoding="utf-8")
+    patch_path = work / "winner.patch"
+    patch_path.write_text(
+        "--- a/fused_moe.py\n+++ b/../outside.py\n@@ -1 +1 @@\n-safe\n+PWNED\n",
+        encoding="utf-8",
+    )
+    out = ko._reconstruct_source_from_patch(patch_path, str(original), work / "out.py")
+    assert out == ""
+    assert outside.read_text(encoding="utf-8") == "safe\n"
+
+
+def test_reconstruct_no_matching_target(tmp_path):
+    """A patch that touches only unrelated files yields nothing."""
+    patch = "diff --git a/foo.py b/foo.py\n--- a/foo.py\n+++ b/foo.py\n@@ -1 +1 @@\n-x\n+y\n"
+    assert _reconstruct(tmp_path, patch) == ""
+
+
+def test_reconstruct_double_slash_header_cannot_escape_sandbox(tmp_path):
+    """A ``b//abs/path`` header must not write outside the sandbox: the empty
+    component from ``//`` previously survived the count-based strip and produced
+    an absolute write path (``tmp / "/abs"`` resets to the absolute path). The
+    empty component is now dropped and a containment guard backstops it, so the
+    apply stays inside the temp dir and never creates the outside victim path."""
+    victim_dir = tmp_path / "OUTSIDE"
+    work = tmp_path / "work"
+    work.mkdir()
+    original = work / "fused_moe.py"
+    original.write_text(_RECON_ORIGINAL, encoding="utf-8")
+    escape = f"b/{victim_dir}/fused_moe.py"  # -> b//tmp/.../OUTSIDE/fused_moe.py
+    patch_path = work / "winner.patch"
+    patch_path.write_text(
+        f"diff --git a/fused_moe.py {escape}\n"
+        f"--- a/fused_moe.py\n+++ {escape}\n"
+        "@@ -1,5 +1,8 @@\n import triton\n \n \n+_CACHE = {}\n+\n+\n def helper():\n     return 1\n",
+        encoding="utf-8",
+    )
+    ko._reconstruct_source_from_patch(patch_path, str(original), work / "out.py")
+    # The only security property that matters: nothing written outside the dir.
+    assert not victim_dir.exists()
+
+
+def test_build_patch_snapshot_sources_worktree_and_base(tmp_path):
+    """Snapshot staging materialises byte-exact content for every write path:
+    from the worktree when present, else reconstructed from base + patch."""
+    base = tmp_path / "base" / "aiter" / "ops"
+    base.mkdir(parents=True)
+    (base / "k.py").write_text("import triton\nOLD\n")
+    worktree = tmp_path / "wt"
+    (worktree / "aiter" / "ops").mkdir(parents=True)
+    (worktree / "aiter" / "ops" / "k.py").write_text("import triton\nNEW\n")
+    (worktree / "aiter" / "ops" / "helper.py").write_text("HELP\n")
+    patch = tmp_path / "p.patch"
+    patch.write_text(
+        "diff --git a/aiter/ops/k.py b/aiter/ops/k.py\n--- a/aiter/ops/k.py\n+++ b/aiter/ops/k.py\n"
+        "@@ -1,2 +1,2 @@\n import triton\n-OLD\n+NEW\n"
+        "diff --git a/aiter/ops/helper.py b/aiter/ops/helper.py\nnew file mode 100644\n"
+        "--- /dev/null\n+++ b/aiter/ops/helper.py\n@@ -0,0 +1 @@\n+HELP\n"
+    )
+    res = ko.build_patch_snapshot(
+        str(patch), worktree=worktree, kernel_repo=str(tmp_path / "base"),
+        clean_base=str(tmp_path / "base"), out_dir=tmp_path / "snap",
+    )
+    assert res is not None
+    snap = Path(res["snapshot_dir"])
+    assert (snap / "aiter/ops/k.py").read_text() == "import triton\nNEW\n"
+    assert (snap / "aiter/ops/helper.py").read_text() == "HELP\n"
+    assert len(res["descriptors"]) == 2
+
+
+def test_build_patch_snapshot_returns_none_when_content_unavailable(tmp_path):
+    """If any write path can't be made byte-exact (no worktree file, no base to
+    reconstruct from), the attempt is non-deployable -> None (hard fail)."""
+    base = tmp_path / "base"
+    base.mkdir()
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    patch = tmp_path / "p.patch"
+    patch.write_text(
+        "diff --git a/helper.py b/helper.py\nnew file mode 100644\n"
+        "--- /dev/null\n+++ b/helper.py\n@@ -0,0 +1 @@\n+HELP\n"
+    )
+    res = ko.build_patch_snapshot(
+        str(patch), worktree=worktree, kernel_repo=str(base),
+        clean_base=str(base), out_dir=tmp_path / "snap",
+    )
+    assert res is None
+
+
 # Downstream-consumer contract: breakdown collector's `glob("{attempt_id}*")` must keep matching both legacy `_optimized.<suffix>` and new `_stdout.log` names (kernel-agent/SKILL.md § Per-attempt stdout file naming).
 
 

--- a/kernel-agent/tools/test_kernel_optimization_verification.py
+++ b/kernel-agent/tools/test_kernel_optimization_verification.py
@@ -887,6 +887,77 @@ def test_patch_only_winner_reconstructs_full_source(tmp_path):
     assert "_CACHE = {}" in text
     assert "def kernel():" in text  # untouched original content preserved
     assert "@@" not in text  # not a diff
+    # Security: nothing was written outside run_dir (no traversal escape).
+    assert Path(artifact_path).resolve().is_relative_to(tmp_path.resolve())
+
+
+def test_patch_with_absolute_path_header_is_rejected(tmp_path):
+    """A backend diff whose header targets an ABSOLUTE path must NOT reconstruct
+    (and must not write outside the work dir). Backend patches are untrusted."""
+    original = tmp_path / "fused_moe.py"
+    original.write_text("import triton\n\n\ndef kernel():\n    return 1\n", encoding="utf-8")
+    evil = tmp_path / "evil.patch"
+    evil.write_text(
+        "--- a/fused_moe.py\n"
+        "+++ /etc/cron.d/pwned\n"
+        "@@ -1,1 +1,2 @@\n"
+        " import triton\n"
+        "+# owned\n",
+        encoding="utf-8",
+    )
+    attempt = {
+        "status": "completed", "attempt_id": "geak-evil", "backend": "geak",
+        "backend_paths": {"geak_per_task_best_patch": str(evil)},
+    }
+    artifact_path, source, _ = ko._select_source_artifact(
+        attempt, target_file=str(original), run_dir=tmp_path,
+    )
+    assert source == "missing"
+    assert artifact_path == ""
+
+
+def test_patch_with_parent_traversal_header_is_rejected(tmp_path):
+    """A backend diff header using ``..`` traversal must NOT reconstruct."""
+    original = tmp_path / "fused_moe.py"
+    original.write_text("import triton\n\n\ndef kernel():\n    return 1\n", encoding="utf-8")
+    evil = tmp_path / "evil.patch"
+    evil.write_text(
+        "--- a/fused_moe.py\n"
+        "+++ b/../../../../tmp/pwned.py\n"
+        "@@ -1,1 +1,2 @@\n"
+        " import triton\n"
+        "+# owned\n",
+        encoding="utf-8",
+    )
+    attempt = {
+        "status": "completed", "attempt_id": "geak-evil2", "backend": "geak",
+        "backend_paths": {"geak_per_task_best_patch": str(evil)},
+    }
+    artifact_path, source, _ = ko._select_source_artifact(
+        attempt, target_file=str(original), run_dir=tmp_path,
+    )
+    assert source == "missing"
+    assert artifact_path == ""
+
+
+def test_patch_targeting_other_basename_is_rejected(tmp_path):
+    """A diff that edits a different file than the target kernel is rejected."""
+    original = tmp_path / "fused_moe.py"
+    original.write_text("import triton\n\n\ndef kernel():\n    return 1\n", encoding="utf-8")
+    other = tmp_path / "other.patch"
+    other.write_text(
+        "--- a/setup.py\n+++ b/setup.py\n@@ -1,1 +1,2 @@\n import triton\n+# x\n",
+        encoding="utf-8",
+    )
+    attempt = {
+        "status": "completed", "attempt_id": "geak-other", "backend": "geak",
+        "backend_paths": {"geak_per_task_best_patch": str(other)},
+    }
+    artifact_path, source, _ = ko._select_source_artifact(
+        attempt, target_file=str(original), run_dir=tmp_path,
+    )
+    assert source == "missing"
+    assert artifact_path == ""
 
 
 # Downstream-consumer contract: breakdown collector's `glob("{attempt_id}*")` must keep matching both legacy `_optimized.<suffix>` and new `_stdout.log` names (kernel-agent/SKILL.md § Per-attempt stdout file naming).

--- a/kernel-agent/tools/test_kernel_optimization_verification.py
+++ b/kernel-agent/tools/test_kernel_optimization_verification.py
@@ -801,7 +801,7 @@ def test_geak_stdout_log_with_fenced_cuda_block_is_extracted(tmp_path):
 
 
 def test_geak_patch_is_preferred_over_stdout_log(tmp_path):
-    """Patch wins over stdout log; a diff has no fenced block so we return `missing` rather than promoting the log (`_candidate_artifact_paths` precedence)."""
+    """Patch wins over stdout log; with no readable original to apply against, a bare diff yields `missing` rather than promoting the marker-noise log (`_candidate_artifact_paths` precedence)."""
     patch_path = tmp_path / "patch_1.patch"
     patch_path.write_text(
         "--- a/kernel.cu\n+++ b/kernel.cu\n@@ -1,1 +1,1 @@\n-old\n+new\n",
@@ -832,6 +832,61 @@ def test_geak_patch_is_preferred_over_stdout_log(tmp_path):
     # Crucial: the marker-noise log is NOT silently promoted to source_file (the pre-fix bug).
     assert source == "missing"
     assert artifact_path == ""
+
+
+def test_patch_only_winner_reconstructs_full_source(tmp_path):
+    """A backend whose best artifact is a unified diff (no full-source .py, no
+    fenced block) must reconstruct the complete optimized source by applying the
+    patch to the original kernel — not defer with artifact_source='missing'.
+
+    Reproduces the DeepSeek-R1 fp8-MoE case: GEAK's winning ``asm-kernel-rewrite``
+    emitted only ``patch_0.patch`` under a ``<task-label>/`` dir (so the
+    ``parallel_<M>`` worktree mapping missed it) and a diff has no fenced block to
+    scrape, leaving the verified +8.4% kernel unverifiable. The patch + original
+    reconstruct the optimized file deterministically.
+    """
+    original = tmp_path / "fused_moe.py"
+    original.write_text(
+        "import triton\n\n\ndef helper():\n    return 1\n\n\ndef kernel():\n    return helper()\n",
+        encoding="utf-8",
+    )
+    # Unified diff that adds a cache helper (mirrors the asm-rewrite shape).
+    patch_path = tmp_path / "asm-kernel-rewrite" / "patch_0.patch"
+    patch_path.parent.mkdir(parents=True)
+    patch_path.write_text(
+        "--- a/fused_moe.py\n"
+        "+++ b/fused_moe.py\n"
+        "@@ -1,5 +1,8 @@\n"
+        " import triton\n"
+        " \n"
+        " \n"
+        "+_CACHE = {}\n"
+        "+\n"
+        "+\n"
+        " def helper():\n"
+        "     return 1\n",
+        encoding="utf-8",
+    )
+    attempt = {
+        "status": "completed",
+        "attempt_id": "geak-asm",
+        "backend": "geak",
+        "backend_paths": {"geak_per_task_best_patch": str(patch_path)},
+    }
+
+    artifact_path, source, error = ko._select_source_artifact(
+        attempt,
+        target_file=str(original),
+        run_dir=tmp_path,
+    )
+
+    assert source == "reconstructed_from_patch", error
+    assert artifact_path
+    text = Path(artifact_path).read_text(encoding="utf-8")
+    # Reconstruction = original + patch (complete file, not a diff).
+    assert "_CACHE = {}" in text
+    assert "def kernel():" in text  # untouched original content preserved
+    assert "@@" not in text  # not a diff
 
 
 # Downstream-consumer contract: breakdown collector's `glob("{attempt_id}*")` must keep matching both legacy `_optimized.<suffix>` and new `_stdout.log` names (kernel-agent/SKILL.md § Per-attempt stdout file naming).


### PR DESCRIPTION
Fixes #680.

## Summary
- A GEAK/OOB attempt whose best artifact is a **unified diff** (no full-source `.py`/`.cu`, no fenced block) previously verified as `artifact_source='missing'` → `verification_status='deferred'`, clamping a real correctness-passing kernel win to unverified.
- Add a universal final fallback in `_select_source_artifact`: apply the patch to the original kernel (`git apply` across strip levels, then `patch`) to **reconstruct the complete optimized source deterministically** — the same apply deployment uses.

## Why this is the right fix (not overfitted)
- **Universal**: depends only on the patch + original source — independent of worktree / `optimized_versions` naming, strategy, or suffix (`.py`/`.cu`/`.cuh`). (The earlier `parallel_<M>` worktree mapping in `_geak_best_worktree` is stale vs the current `<task-label>/` + `worktrees/slot_<M>/` layout; rather than chase layout strings, reconstruct from the two artifacts that always exist.)
- **Non-breaking / additive**: runs **only after** the existing tiers (full-source suffix-match, fenced-block extraction) fail. When today's path already resolves a source, behavior is byte-identical. It only converts a previously-`missing` case into a verified one.
- **Faithful**: `git apply` / `patch` is exactly how `apply_kernel_patch.py` deploys kernels, so the reconstructed file matches what runs.

## Validation
- New regression test `test_patch_only_winner_reconstructs_full_source` reproduces the DeepSeek-R1 fp8-MoE patch-only winner.
- Existing verification suite unchanged: **76 → 77 pass**; broader kernel-opt/integrate suites: **135 pass**; `ruff` clean.
- Validated against the **real** failing DeepSeek artifact (`asm-kernel-rewrite/patch_0.patch`): reconstructs the full 1248-line optimized source with the asm optimization intact → would verify the +8.4% win instead of deferring.

## Test plan
- [ ] CI: full Python matrix (3.10/3.11) + ruff/pylint/CodeQL
- [ ] Confirm no change to attempts that already resolve a full-source artifact