### PR TITLE
[fix] bound detokenizer-stall to fast-fail hung servers

### DIFF
--- a/inference_optimizer/orchestrator/action_executors/_grid_runner.py
+++ b/inference_optimizer/orchestrator/action_executors/_grid_runner.py
@@ -27,6 +27,7 @@ import yaml
 from ._canonical_fingerprint import canonical_fingerprint
 from ._robustness_pulse import pulse as _robustness_pulse
 from ._subprocess_kill import (
+    DETOKENIZER_STALL_RETURNCODE,
     OVERTIME_KILL_RETURNCODE,
     SERVER_DEAD_RETURNCODE,
     run_with_session_kill,
@@ -2274,6 +2275,62 @@ async def run_grid(
                     error_class="server_init_dead",
                     note=variant.note,
                     nonfatal_warnings=[f"harvested_leaked_artifact:{src}" for src, _ in sd_harvested],
+                )
+            )
+            await _pulse_after_variant(i)
+            if not keep_going_on_failure:
+                break
+            continue
+
+        # Detokenizer-stall watchdog fired: this variant's server came up
+        # healthy (ready marker logged) but then went completely silent — a hung
+        # engine / wedged detokenizer. The clock runs from the ready marker, so
+        # a long cold start does not trip it. Fast-prune the variant with a
+        # distinct ``error_class`` so the ExploreExecutor drops it and the round
+        # proceeds, instead of burning the full ~2h hard timeout on a server
+        # that will never return tokens. Harvest leaks for RCA.
+        if rc == DETOKENIZER_STALL_RETURNCODE:
+            variant_runtime_sec = round(
+                max(0.0, time.time() - variant_started_unix),
+                2,
+            )
+            ds_candidates = sorted(slot.glob("benchmark_*"))
+            ds_destination = ds_candidates[-1] if ds_candidates else slot
+            ds_harvested = harvest_leaked_artifacts(
+                ds_destination,
+                subprocess_started_unix=variant_started_unix,
+            )
+            log.warning(
+                "grid_runner: variant %d/%d name=%s aborted: detokenizer_stall "
+                "(server ready but log went silent) after %.1fs",
+                i + 1,
+                len(grid),
+                variant.name,
+                variant_runtime_sec,
+            )
+            _write_variant_abort_marker(
+                slot,
+                variant_name=variant.name,
+                error_class="detokenizer_stall",
+                error_summary=(
+                    "server reported ready but emitted no log output (hung "
+                    "engine / detokenizer stall); reaped by the "
+                    "detokenizer-stall watchdog"
+                ),
+                extra_args=variant.extra_server_args,
+            )
+            results.append(
+                VariantResult(
+                    name=variant.name,
+                    extra_server_args=variant.extra_server_args,
+                    extra_envs=dict(variant.extra_envs),
+                    status="failed",
+                    returncode=rc,
+                    runtime_sec=variant_runtime_sec,
+                    error="detokenizer_stall: server ready but log went silent",
+                    error_class="detokenizer_stall",
+                    note=variant.note,
+                    nonfatal_warnings=[f"harvested_leaked_artifact:{src}" for src, _ in ds_harvested],
                 )
             )
             await _pulse_after_variant(i)

--- a/inference_optimizer/orchestrator/action_executors/_subprocess_kill.py
+++ b/inference_optimizer/orchestrator/action_executors/_subprocess_kill.py
@@ -219,6 +219,56 @@ _SERVER_DEAD_MARKERS: tuple[str, ...] = (
 _SERVER_DEAD_GRACE_SEC_DEFAULT: float = 120.0
 
 
+# Sentinel ``returncode`` when the detokenizer-stall watchdog reaps a child
+# because the inference server came up healthy (``/health`` 200, startup
+# complete) but then produced NO generation progress — the classic
+# "detokenizer / output processor stall" where the engine accepts the request
+# and the benchmark client blocks forever waiting for tokens that never
+# detokenize. The ``_SERVER_DEAD_MARKERS`` watchdog can't catch this (the
+# server never crashes — it logs a clean startup and then goes quiet), so
+# without this gate a stalled variant burns the full ~2h hard ``timeout``
+# before failing, wasting the explore budget. Distinct from the other
+# sentinels so callers can label it ``error_class="detokenizer_stall"`` and
+# fast-prune the offending variant.
+DETOKENIZER_STALL_RETURNCODE: int = -911
+
+# Server-ready markers: their appearance in ``server.log`` means the HTTP/API
+# server has finished startup and is accepting traffic. Only AFTER one of these
+# is observed does the detokenizer-stall clock start — a model still loading
+# weights is "slow", not "stalled", and must never trip this gate. Covers both
+# the uvicorn frontend (vLLM and sglang both serve via uvicorn) and sglang's
+# own ready banner.
+_SERVER_READY_MARKERS: tuple[str, ...] = (
+    "Application startup complete",          # uvicorn (vLLM + sglang frontends)
+    "Uvicorn running on",                    # uvicorn bind line
+    "The server is fired up and ready to roll",  # sglang ready banner
+)
+
+# Generation-progress markers: the periodic decode-throughput lines (same ones
+# ``benchmark_result.py`` parses). Reported by the scanner for diagnostics, but
+# the stall gate itself keys on RAW LOG ACTIVITY (any new bytes), not these
+# markers — see :func:`_communicate_with_soft_deadline`. Keying on "is the
+# server still writing ANYTHING" rather than "is it decoding" is deliberate: a
+# huge model can sit between ready and its first token for many minutes while
+# aiter/torch.compile JITs the first request, emitting compile logs the whole
+# time. Those keep the clock alive; only a server that goes COMPLETELY silent
+# after ready (a true hung engine / detokenizer wedge) trips the gate.
+_SERVER_PROGRESS_MARKERS: tuple[str, ...] = (
+    "gen throughput (token/s):",   # sglang
+    "Avg generation throughput:",  # vLLM
+)
+
+# Default grace: how long after the server reports ready it may emit NO log
+# output at all before the watchdog declares a hang / detokenizer stall.
+# Measured from the ready marker, so the (arbitrarily long) cold start — weight
+# load + CUDA-graph capture, all of which precede "ready" — is never counted.
+# Set generous (30 min) so a quiet post-ready first-request JIT/compile on a
+# very large model is not mistaken for a stall, yet still far below the ~2h hard
+# timeout. ``<= 0`` disables the gate. Overridable via
+# ``INFERENCE_OPTIMIZER_DETOK_STALL_GRACE_SEC``.
+_DETOK_STALL_GRACE_SEC_DEFAULT: float = 1800.0
+
+
 class _StreamCapture:
     """Capture child output while mirroring each line to the parent stream."""
 
@@ -394,6 +444,49 @@ def server_log_death_excerpt(path: str, *, max_chars: int = 1200) -> str | None:
     return None
 
 
+def _scan_server_log_increment(
+    path: str, from_offset: int
+) -> tuple[int, bool, bool]:
+    """Incrementally scan the bytes appended to ``server.log`` since
+    ``from_offset`` for ready / generation-progress markers.
+
+    Reading only the NEW tail (not the whole file) keeps the per-poll cost flat
+    and — crucially — makes "progress" mean *fresh* progress: a throughput line
+    written ten minutes ago that still sits in the file is read exactly once,
+    so a wedged server that stops appending lines correctly reads as "no new
+    progress" on subsequent polls. Handles truncation/rotation (size shrank
+    below the offset) by rescanning from the start. Best-effort: a missing /
+    unreadable log reads as "no new markers" and leaves the offset unchanged so
+    a slow cold start is never misjudged.
+
+    Args:
+        path: Filesystem path to the server's ``server.log``.
+        from_offset: Byte offset already consumed by a prior scan.
+
+    Returns:
+        ``(new_offset, saw_ready, saw_progress)`` — the advanced offset plus
+        whether a ready / progress marker appeared in the newly read bytes.
+    """
+    try:
+        size = os.path.getsize(path)
+    except OSError:
+        return from_offset, False, False
+    start = from_offset
+    if size < start:  # truncated / rotated — rescan from the top.
+        start = 0
+    if size <= start:  # nothing new appended.
+        return start, False, False
+    try:
+        with open(path, "rb") as fh:
+            fh.seek(start)
+            chunk = fh.read().decode("utf-8", "ignore")
+    except (OSError, ValueError):
+        return from_offset, False, False
+    saw_ready = any(marker in chunk for marker in _SERVER_READY_MARKERS)
+    saw_progress = any(marker in chunk for marker in _SERVER_PROGRESS_MARKERS)
+    return size, saw_ready, saw_progress
+
+
 def run_with_session_kill(
     cmd: list[str],
     *,
@@ -404,6 +497,7 @@ def run_with_session_kill(
     soft_deadline_sec: float | None = None,
     server_log_path: str | None = None,
     server_dead_grace_sec: float | None = None,
+    detok_stall_grace_sec: float | None = None,
 ) -> subprocess.CompletedProcess:
     """``subprocess.run``-compatible call that ALSO tears down the entire
     descendant tree on every exit path.
@@ -429,6 +523,19 @@ def run_with_session_kill(
     turns a crashed-but-hung server (parent never exits, ``/health`` polled
     forever) into a fast fail instead of a ~2h hard-timeout stall.
 
+    ``server_log_path`` (detokenizer-stall watchdog): when set, ``server.log``
+    is ALSO watched for the ready-then-silent pattern — the server logs a clean
+    startup (``/health`` 200) and then stops writing to the log entirely for
+    ``detok_stall_grace_sec`` (default
+    ``INFERENCE_OPTIMIZER_DETOK_STALL_GRACE_SEC`` or 1800s). The clock is
+    measured from the ready marker, so the cold start (weight load + CUDA-graph
+    capture, all before "ready") is never counted, and ANY new log line —
+    decode throughput or a slow first-request JIT/compile — resets it. On trip
+    the tree is reaped and a ``CompletedProcess`` with
+    ``returncode = DETOKENIZER_STALL_RETURNCODE`` is returned (does NOT raise),
+    so a variant whose engine hangs fails in minutes instead of burning the
+    full hard timeout.
+
     Args:
         cmd: The command and arguments to execute.
         env: Optional environment mapping for the child process.
@@ -440,10 +547,14 @@ def run_with_session_kill(
             elapse the tree is reaped and ``OVERTIME_KILL_RETURNCODE`` is
             returned without raising.
         server_log_path: Optional path to the spawned server's ``server.log``
-            to enable the server-liveness watchdog.
+            to enable the server-liveness + detokenizer-stall watchdogs.
         server_dead_grace_sec: Grace period a terminal init marker must persist
             before the watchdog reaps the tree; defaults to the
             ``INFERENCE_OPTIMIZER_SERVER_DEAD_GRACE_SEC`` env value or 120s.
+        detok_stall_grace_sec: Grace period a ready server may produce no
+            generation progress before the stall watchdog reaps the tree;
+            defaults to the ``INFERENCE_OPTIMIZER_DETOK_STALL_GRACE_SEC`` env
+            value or 600s. ``≤ 0`` disables the stall gate.
 
     Returns:
         A ``CompletedProcess`` carrying the child's returncode (or one of the
@@ -463,6 +574,16 @@ def run_with_session_kill(
             )
         except (TypeError, ValueError):
             server_dead_grace_sec = _SERVER_DEAD_GRACE_SEC_DEFAULT
+    if detok_stall_grace_sec is None:
+        try:
+            detok_stall_grace_sec = float(
+                os.environ.get(
+                    "INFERENCE_OPTIMIZER_DETOK_STALL_GRACE_SEC",
+                    _DETOK_STALL_GRACE_SEC_DEFAULT,
+                )
+            )
+        except (TypeError, ValueError):
+            detok_stall_grace_sec = _DETOK_STALL_GRACE_SEC_DEFAULT
     proc: subprocess.Popen | None = None
     capture: _StreamCapture | None = None
     try:
@@ -484,6 +605,7 @@ def run_with_session_kill(
                 soft_deadline_sec=soft_deadline_sec,
                 server_log_path=server_log_path,
                 server_dead_grace_sec=server_dead_grace_sec,
+                detok_stall_grace_sec=detok_stall_grace_sec,
                 capture=capture,
             )
         except subprocess.TimeoutExpired:
@@ -509,6 +631,25 @@ def run_with_session_kill(
             return subprocess.CompletedProcess(
                 args=cmd,
                 returncode=SERVER_DEAD_RETURNCODE,
+                stdout=stdout if stdout is not None else ("" if text else b""),
+                stderr=stderr if stderr is not None else ("" if text else b""),
+            )
+        except _ServerStalledDetected as exc:
+            kill_my_spawned_server(proc)
+            stdout, stderr = (
+                capture.finish(timeout=2.0) if capture is not None else ("" if text else b"", "" if text else b"")
+            )
+            log.warning(
+                "_subprocess_kill: detokenizer-stall watchdog reaped tree — "
+                "server reported ready but emitted no log output (grace=%.1fs, "
+                "elapsed=%.1fs); returncode=%d.",
+                exc.grace_sec,
+                exc.elapsed_sec,
+                DETOKENIZER_STALL_RETURNCODE,
+            )
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=DETOKENIZER_STALL_RETURNCODE,
                 stdout=stdout if stdout is not None else ("" if text else b""),
                 stderr=stderr if stderr is not None else ("" if text else b""),
             )
@@ -587,6 +728,35 @@ class _ServerDeadDetected(Exception):
         self.elapsed_sec = float(elapsed_sec)
 
 
+class _ServerStalledDetected(Exception):
+    """Internal sentinel: the detokenizer-stall watchdog saw the server report
+    ready and then produce no generation progress for the grace window. Never
+    bubbles past :func:`run_with_session_kill` (converted to a
+    ``CompletedProcess`` carrying ``DETOKENIZER_STALL_RETURNCODE``).
+    """
+
+    def __init__(
+        self,
+        *,
+        grace_sec: float,
+        elapsed_sec: float,
+    ) -> None:
+        """Build the error message describing the ready-but-no-progress stall.
+
+        Args:
+            grace_sec: How long the ready server was allowed to produce no
+                generation progress before the watchdog tripped.
+            elapsed_sec: Actual wall-clock elapsed at trip time.
+        """
+        super().__init__(
+            f"server reported ready but emitted no log output for "
+            f"{grace_sec:.1f}s (hung engine / detokenizer stall; "
+            f"elapsed={elapsed_sec:.1f}s)"
+        )
+        self.grace_sec = float(grace_sec)
+        self.elapsed_sec = float(elapsed_sec)
+
+
 def _communicate_with_soft_deadline(
     proc: subprocess.Popen,
     *,
@@ -594,6 +764,7 @@ def _communicate_with_soft_deadline(
     soft_deadline_sec: float | None,
     server_log_path: str | None = None,
     server_dead_grace_sec: float | None = None,
+    detok_stall_grace_sec: float | None = None,
     capture: _StreamCapture | None = None,
 ) -> tuple[str | bytes, str | bytes]:
     """``proc.communicate`` shim enforcing the soft deadline + server watchdog.
@@ -603,10 +774,14 @@ def _communicate_with_soft_deadline(
     polls in 0.5s slices, enforcing:
 
     * ``soft_deadline_sec`` — raise :class:`_SoftDeadlineExceeded` once passed;
-    * ``server_log_path`` watchdog — once a terminal init marker
+    * ``server_log_path`` death watchdog — once a terminal init marker
       (:data:`_SERVER_DEAD_MARKERS`) is observed AND it persists for
       ``server_dead_grace_sec`` without the child exiting on its own, raise
       :class:`_ServerDeadDetected`.
+    * ``server_log_path`` detokenizer-stall watchdog — once a ready marker
+      (:data:`_SERVER_READY_MARKERS`) is observed, require the log to keep
+      growing; if NO new bytes are appended for ``detok_stall_grace_sec``
+      (a hung engine / detokenizer wedge), raise :class:`_ServerStalledDetected`.
 
     The ``hard_timeout`` is always honoured so a stuck child can't dodge the
     gates.
@@ -617,9 +792,12 @@ def _communicate_with_soft_deadline(
         soft_deadline_sec: Optional soft deadline that trips before the hard
             timeout.
         server_log_path: Optional path to the server's ``server.log`` enabling
-            the liveness watchdog.
+            the liveness + stall watchdogs.
         server_dead_grace_sec: Grace period a terminal init marker must persist
-            before the watchdog trips.
+            before the death watchdog trips.
+        detok_stall_grace_sec: Grace period a ready server may emit no log
+            output at all before the stall watchdog trips. ``None`` / ≤ 0
+            disables the stall gate.
         capture: Optional stream capture whose threads are joined to assemble
             the returned output.
 
@@ -631,23 +809,37 @@ def _communicate_with_soft_deadline(
         _SoftDeadlineExceeded: When the soft deadline elapses.
         _ServerDeadDetected: When a terminal init marker persists past the
             grace window.
+        _ServerStalledDetected: When a ready server produces no generation
+            progress past the stall grace window.
         subprocess.TimeoutExpired: When the hard timeout elapses.
     """
     watchdog_active = bool(server_log_path) and (
         server_dead_grace_sec is not None and float(server_dead_grace_sec) > 0.0
     )
+    stall_active = bool(server_log_path) and (
+        detok_stall_grace_sec is not None and float(detok_stall_grace_sec) > 0.0
+    )
     soft_active = soft_deadline_sec is not None and float(soft_deadline_sec) > 0.0
-    if capture is None and not soft_active and not watchdog_active:
+    if capture is None and not soft_active and not watchdog_active and not stall_active:
         return proc.communicate(timeout=hard_timeout)
-    if capture is not None and not soft_active and not watchdog_active:
+    if capture is not None and not soft_active and not watchdog_active and not stall_active:
         proc.wait(timeout=hard_timeout)
         return capture.finish()
 
     deadline_sec = float(soft_deadline_sec) if soft_active else None
     grace_sec = float(server_dead_grace_sec) if watchdog_active else None
+    stall_grace_sec = float(detok_stall_grace_sec) if stall_active else None
     poll_interval = 0.5
     start = time.monotonic()
     dead_marker_since: float | None = None
+    # Detokenizer-stall watchdog state: byte offset consumed from server.log,
+    # whether a ready marker has been seen, and the last time the log showed
+    # ANY new output (seeded to the ready time so the silence clock starts the
+    # moment the server is ready). Cold-start logging before "ready" is ignored
+    # because the gate only arms once ``server_ready_since`` is set.
+    stall_log_offset = 0
+    server_ready_since: float | None = None
+    last_activity_at: float | None = None
     while True:
         elapsed = time.monotonic() - start
         if soft_active and deadline_sec is not None:
@@ -668,6 +860,30 @@ def _communicate_with_soft_deadline(
                     )
             else:
                 dead_marker_since = None
+        if stall_active and stall_grace_sec is not None:
+            prev_offset = stall_log_offset
+            stall_log_offset, saw_ready, _saw_progress = _scan_server_log_increment(
+                server_log_path,  # type: ignore[arg-type]
+                stall_log_offset,
+            )
+            now = time.monotonic()
+            if saw_ready and server_ready_since is None:
+                server_ready_since = now
+                last_activity_at = now  # start the silence clock at ready
+            # ANY new bytes in server.log count as liveness — decode throughput,
+            # but also cold-path / JIT / compile logs that a huge model emits
+            # between ready and its first token. Only total silence trips the
+            # gate, so a slow-but-logging first request is never killed.
+            if stall_log_offset > prev_offset:
+                last_activity_at = now
+            # Armed only once the server is ready; pre-ready weight loading is
+            # slow, not stalled, and must never trip this gate.
+            if server_ready_since is not None and last_activity_at is not None:
+                if now - last_activity_at >= stall_grace_sec:
+                    raise _ServerStalledDetected(
+                        grace_sec=stall_grace_sec,
+                        elapsed_sec=elapsed,
+                    )
         # Slice bounded by every active remaining window so the right gate
         # fires first; the child can still finish inside any slice.
         slice_sec = poll_interval
@@ -690,6 +906,7 @@ def _communicate_with_soft_deadline(
 
 
 __all__ = [
+    "DETOKENIZER_STALL_RETURNCODE",
     "OVERTIME_KILL_RETURNCODE",
     "SERVER_DEAD_RETURNCODE",
     "kill_my_spawned_server",

--- a/inference_optimizer/orchestrator/action_executors/baseline.py
+++ b/inference_optimizer/orchestrator/action_executors/baseline.py
@@ -46,6 +46,7 @@ from ._grid_runner import (
     sanitize_script_name,
 )
 from ._subprocess_kill import (
+    DETOKENIZER_STALL_RETURNCODE,
     SERVER_DEAD_RETURNCODE,
     run_with_session_kill,
     server_log_death_excerpt,
@@ -1536,6 +1537,40 @@ class BaselineExecutor:
         proc_returncode = proc.returncode
         proc_stdout = proc.stdout
         proc_stderr = proc.stderr
+
+        # Detokenizer-stall watchdog reap: the server came up healthy (ready
+        # marker logged) but then went completely silent for the stall grace
+        # window — a hung engine / wedged detokenizer. The clock runs from the
+        # ready marker, so a long cold start never trips it. Short-circuit here:
+        # a stall reap leaves no benchmark_* workspace, so without this it would
+        # misclassify as ``no_workspace``. Distinct ``error_class`` lets the
+        # coordinator fast-fail this baseline / variant instead of burning the
+        # full hard timeout. Harvest whatever the wrapper wrote first.
+        if proc_returncode == DETOKENIZER_STALL_RETURNCODE:
+            stall_candidates = sorted(output_dir.glob("benchmark_*"))
+            stall_destination = stall_candidates[-1] if stall_candidates else output_dir
+            stall_harvested = harvest_leaked_artifacts(
+                stall_destination,
+                subprocess_started_unix=subprocess_started_unix,
+            )
+            log.warning(
+                "baseline_executor: detokenizer-stall watchdog reaped run "
+                "(server ready but log went silent); error_class=detokenizer_stall."
+            )
+            return {
+                "status": "failed",
+                "error_class": "detokenizer_stall",
+                "returncode": proc_returncode,
+                "error": (
+                    "server reported ready but emitted no log output (hung "
+                    "engine / detokenizer stall); reaped by the "
+                    "detokenizer-stall watchdog. See server.log."
+                ),
+                "subprocess_runtime_sec": round(subprocess_runtime_sec, 2),
+                "output_dir": str(output_dir),
+                "harvested_artifacts": [str(dst) for _, dst in stall_harvested],
+                "nonfatal_warnings": [f"harvested_leaked_artifact:{src}" for src, _ in stall_harvested],
+            }
 
         # #524: when the inference server's engine/worker bootstrap dies (e.g.
         # vLLM ``RuntimeError: Engine core initialization failed``), the real

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -10353,7 +10353,11 @@ class Coordinator:
         if not isinstance(result_dict, dict):
             return None
         error_class = str(result_dict.get("error_class") or "").lower()
-        if error_class in ("crash", "oom", "hang"):
+        # ``detokenizer_stall`` is a hang in all but name (server ready, no
+        # generation progress); record it as a crash-severity pitfall so the
+        # offending variant config is remembered and not re-proposed, instead
+        # of burning explore budget on the same stall again.
+        if error_class in ("crash", "oom", "hang", "detokenizer_stall"):
             return _SEVERITY_CRASH
         status = str(result_dict.get("status") or "").lower()
         if status in ("crash", "oom", "hang"):

--- a/inference_optimizer/tests/test_kill_spawned_server.py
+++ b/inference_optimizer/tests/test_kill_spawned_server.py
@@ -18,8 +18,10 @@ from pathlib import Path
 import pytest
 
 from inference_optimizer.orchestrator.action_executors._subprocess_kill import (
+    DETOKENIZER_STALL_RETURNCODE,
     OVERTIME_KILL_RETURNCODE,
     SERVER_DEAD_RETURNCODE,
+    _scan_server_log_increment,
     _server_log_shows_death,
     kill_my_spawned_server,
     new_session_kwargs,
@@ -391,3 +393,124 @@ def test_run_with_session_kill_watchdog_ignores_healthy_server(tmp_path):
     )
     assert cp.returncode == 0
     assert "ok" in (cp.stdout or "")
+
+
+# ── Detokenizer-stall watchdog ──
+def test_scan_server_log_increment_detects_ready_and_progress(tmp_path):
+    """The incremental scanner advances its offset and flags ready/progress
+    markers only in the newly appended bytes."""
+    log_path = tmp_path / "server.log"
+    log_path.write_text("INFO loading weights\nApplication startup complete\n")
+    off, ready, prog = _scan_server_log_increment(str(log_path), 0)
+    assert ready is True and prog is False and off == log_path.stat().st_size
+    # Re-scan from the advanced offset: nothing new, no re-trigger.
+    off2, ready2, prog2 = _scan_server_log_increment(str(log_path), off)
+    assert ready2 is False and prog2 is False and off2 == off
+    # Append a vLLM throughput line; only the new bytes are scanned.
+    with log_path.open("a") as f:
+        f.write("Avg generation throughput: 123.4 tokens/s, Running: 8\n")
+    off3, ready3, prog3 = _scan_server_log_increment(str(log_path), off2)
+    assert prog3 is True and ready3 is False and off3 == log_path.stat().st_size
+
+
+def test_run_with_session_kill_detok_stall_reaps_ready_but_silent_server(tmp_path):
+    """A server that reports ready then produces no generation progress is
+    reaped with ``DETOKENIZER_STALL_RETURNCODE`` well before the hard timeout."""
+    log_path = tmp_path / "server.log"
+    script = (
+        "import sys, time\n"
+        "open(sys.argv[1], 'w').write('Application startup complete\\n')\n"
+        "time.sleep(60)\n"  # ready, then silent — detokenizer stall
+    )
+    start = time.monotonic()
+    cp = run_with_session_kill(
+        [sys.executable, "-c", script, str(log_path)],
+        timeout=60,
+        server_log_path=str(log_path),
+        detok_stall_grace_sec=1.0,
+    )
+    elapsed = time.monotonic() - start
+    assert cp.returncode == DETOKENIZER_STALL_RETURNCODE
+    assert elapsed < 15.0, f"stall watchdog took {elapsed:.2f}s (expected fast)"
+
+
+def test_run_with_session_kill_detok_stall_not_armed_before_ready(tmp_path):
+    """A server still loading weights (no ready marker) must NOT trip the stall
+    gate even past the grace window — slow is not stalled."""
+    log_path = tmp_path / "server.log"
+    script = (
+        "import sys, time\n"
+        "open(sys.argv[1], 'w').write('INFO loading weights shard 1/8\\n')\n"
+        "time.sleep(2)\n"
+        "raise SystemExit(0)\n"
+    )
+    cp = run_with_session_kill(
+        [sys.executable, "-c", script, str(log_path)],
+        timeout=30,
+        server_log_path=str(log_path),
+        detok_stall_grace_sec=0.5,
+    )
+    assert cp.returncode == 0
+
+
+def test_run_with_session_kill_detok_stall_progress_keeps_it_alive(tmp_path):
+    """Continued generation-progress lines reset the stall clock so a healthy
+    (if slow) run finishes with its own returncode."""
+    log_path = tmp_path / "server.log"
+    script = (
+        "import sys, time\n"
+        "f = open(sys.argv[1], 'w')\n"
+        "f.write('Application startup complete\\n'); f.flush()\n"
+        "for _ in range(6):\n"
+        "    time.sleep(0.3)\n"
+        "    f.write('gen throughput (token/s): 250.0, #queue-req: 0\\n'); f.flush()\n"
+        "raise SystemExit(0)\n"
+    )
+    cp = run_with_session_kill(
+        [sys.executable, "-c", script, str(log_path)],
+        timeout=30,
+        server_log_path=str(log_path),
+        detok_stall_grace_sec=1.0,
+    )
+    assert cp.returncode == 0
+
+
+def test_run_with_session_kill_detok_stall_compile_logs_keep_it_alive(tmp_path):
+    """A long, quiet first-request JIT/compile after ready must NOT trip the
+    gate: ANY new log line (not just throughput) is liveness, so a huge model
+    that logs compile progress between ready and its first token survives."""
+    log_path = tmp_path / "server.log"
+    script = (
+        "import sys, time\n"
+        "f = open(sys.argv[1], 'w')\n"
+        "f.write('The server is fired up and ready to roll\\n'); f.flush()\n"
+        "for i in range(6):\n"  # non-throughput compile chatter, no tokens yet
+        "    time.sleep(0.3)\n"
+        "    f.write('aiter: JIT compiling kernel %d/6\\n' % i); f.flush()\n"
+        "raise SystemExit(0)\n"
+    )
+    cp = run_with_session_kill(
+        [sys.executable, "-c", script, str(log_path)],
+        timeout=30,
+        server_log_path=str(log_path),
+        detok_stall_grace_sec=1.0,
+    )
+    assert cp.returncode == 0
+
+
+def test_run_with_session_kill_detok_stall_disabled_when_grace_nonpositive(tmp_path):
+    """``detok_stall_grace_sec <= 0`` disables the gate entirely."""
+    log_path = tmp_path / "server.log"
+    script = (
+        "import sys, time\n"
+        "open(sys.argv[1], 'w').write('Application startup complete\\n')\n"
+        "time.sleep(1)\n"
+        "raise SystemExit(0)\n"
+    )
+    cp = run_with_session_kill(
+        [sys.executable, "-c", script, str(log_path)],
+        timeout=30,
+        server_log_path=str(log_path),
+        detok_stall_grace_sec=0.0,
+    )
+    assert cp.returncode == 0


### PR DESCRIPTION
After a server reports ready, a wedged engine / detokenizer would keep the benchmark client blocked until the full ~2h hard timeout, burning explore budget and surfacing only a generic timeout error_class.

Add a detokenizer-stall watchdog in the shared run_with_session_kill choke point so both the baseline warmup and the explore variant grid benefit:

- Watch server.log for a ready marker, then require the log to keep growing; total silence for the grace window (default 1800s, env-tunable, measured from ready so cold start is never counted) reaps the tree with a new DETOKENIZER_STALL_RETURNCODE. Any new log line (decode throughput or a slow first-request JIT/compile) resets the clock, so slow-but-alive servers are never killed.
- Map the sentinel to error_class="detokenizer_stall" in BaselineExecutor and fast-prune the offending variant in the grid runner.
- Record detokenizer_stall as a crash-severity pitfall so the bad config is remembered and not re-proposed.
