### PR TITLE
feat(breakdown): restore /workspace session artifact packaging

### DIFF
--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -146,16 +146,19 @@ populate `session_breakdown.json` for downstream consumers
 | `SANDBOX_USER_ID` | Hosted SaFE / Claw user id, written to `session.sandbox_user_id`. Set by PrimusClaw; unset for local runs.                                            |
 | `HYPERLOOM_LANGFUSE_ENABLE` | Master switch (default **off**) for live Langfuse trace push. NOTE: when this flag is on in the environment / `.env`, `scripts/install.sh` auto-installs the optional `langfuse` SDK on demand (and skips it entirely when off), so no separate `pip install '...[trace]'` is required. When `1/true/yes/on` *and* the three `LANGFUSE_*` credentials are set, every in-process LLM call is mirrored into Langfuse while the run is live, and a session-end flush backfills the out-of-process children (geak / oob / robustness / specialist) and KEEP/REVERT decision Scores. The local `reports/trace/*.jsonl` ledger is always written regardless. If the SDK is unavailable, live push degrades to a no-op. **Correlation:** the Langfuse trace id and `session_id` grouping are derived from `claw_session_id` (env `CLAW_SESSION_ID`), falling back to the internal session id for standalone runs, so live push and the offline `backfill_langfuse` CLI collapse onto one trace per PrimusClaw session. **Span layout:** `trace → phase span (PRELUDE/EXPLORE/KERNEL/SWEEP/…) → agent span (component: orchestration/kernel/specialist/critic/geak/oob/…) → Generation`; each KEEP/REVERT/`gain_pct` Score attaches to the agent span that produced the decision (trace-level fallback when no matching span exists). **Receipt:** every session records a `langfuse` section in `session_breakdown.json` (and `reports/trace/langfuse_receipt.json`) noting whether the push was enabled (or the `disabled_reason`), the redacted connection config (host + key-presence booleans, never the keys), the derived `trace_id`/`session_id`, and how many generations/scores/spans were actually sent — so an operator can confirm post-hoc whether a run reached Langfuse. |
 
-#### Langfuse — security & known limitations
+#### Langfuse / artifact-package — security & known limitations
 
 * **Sensitive data surface.** When live push is on, `conversations.jsonl`
   (and Langfuse Generations) carry full prompt/response text. `redact_secrets`
   scrubs common token shapes (Bearer, `sk-`/`pk-`, GitHub tokens, some
   `KEY=value`) but is **not** a complete DLP filter — bare keys without a
-  recognizable prefix (e.g. raw AWS `AKIA…`) can slip through. If a session
-  may contain customer code / secrets, define an explicit retention +
-  access-control policy for the Langfuse project, and consider disabling live
-  push for those runs.
+  recognizable prefix (e.g. raw AWS `AKIA…`) can slip through. The artifact
+  packager also copies `reports/trace/*.jsonl` and, with the loose mode on by
+  default (`HYPERLOOM_SESSION_PACKAGE_LOOSE`), drops them under `/workspace`
+  for the Claw sync. If a session may contain customer code / secrets, define
+  an explicit retention + access-control policy for both the Langfuse project
+  and the `/workspace` package destination, and consider disabling live push
+  or loose packaging for those runs.
 * **`live push` + `backfill_langfuse` overlap.** Both derive the same
   `trace_id` from `claw_session_id`, so running the offline backfill *after* a
   live run re-emits the out-of-process children onto the same trace and can
@@ -163,6 +166,10 @@ populate `session_breakdown.json` for downstream consumers
   recovery tool only when live push did not run.
 * **`flush_session` is idempotent.** A second flush only re-writes the receipt
   (no re-emit), so a duplicated CLOSE step won't double-push.
+* **Package truncation.** The bundle caps at 5000 files / 256 MB. On a very
+  long session the cap can stop the bundle short; the `PACKAGE_MANIFEST` then
+  sets `truncated: true` and lists `dropped_files`, so consumers must not treat
+  a truncated package as complete.
 * **Generation duration is ~0.** Both live and backfill stamp a single
   timestamp (`end == start`), so Langfuse shows no meaningful per-Generation
   duration — counts/usage are accurate, latency is not captured.

--- a/inference_optimizer/breakdown/__init__.py
+++ b/inference_optimizer/breakdown/__init__.py
@@ -25,12 +25,14 @@ from .exporter import (
     write_minimal_final_report,
 )
 from .schema import SCHEMA_VERSION
+from .session_package import package_session_artifacts
 
 __all__ = [
     "BREAKDOWN_FILENAME",
     "EXPORTER_VERSION",
     "SCHEMA_VERSION",
     "build",
+    "package_session_artifacts",
     "patch_breakdown_langfuse",
     "write_breakdown_json",
     "write_minimal_final_report",

--- a/inference_optimizer/breakdown/session_package.py
+++ b/inference_optimizer/breakdown/session_package.py
@@ -1,0 +1,469 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Bundle a session's *consumer-facing* artifacts into a single zip under
+``/workspace`` so the Claw sandbox sync picks it up (and ships it to S3 /
+the wekafs persist base).
+
+Why this exists
+---------------
+Hyperloom writes all products under ``session_dir`` (``$USER_DATA_PATH``),
+which production launchers frequently point at a wekafs path *outside*
+``/workspace``. Claw only syncs ``/workspace``, so those products never
+reach Claw storage and the ``/v1/sessions/<sid>/files`` endpoint can't
+serve them. Rather than move the whole (multi-hundred-MB) session tree,
+this module copies just the small set of result/report/analysis files
+(KB–MB total) into one zip placed *inside* ``/workspace``, where Claw's
+sync is guaranteed to see it. By default it ALSO drops the same files
+*loose* (uncompressed, original relative tree) directly under the dest
+root itself (e.g. ``/workspace/session_breakdown.json``,
+``/workspace/reports/final.json``), so a consumer can fetch a single
+file without unzipping (disable via ``HYPERLOOM_SESSION_PACKAGE_LOOSE=0``).
+
+A processing log (``PACKAGE_MANIFEST.json`` + ``PACKAGE_MANIFEST.txt``)
+recording exactly which files were included / missing is written into
+the zip itself, so a consumer can audit the bundle without the source
+session dir.
+
+Contract
+--------
+* Best-effort: never raises. On any failure returns ``None`` and logs;
+  the caller MUST treat the canonical per-file writes as the source of
+  truth and never let a packaging failure mask the real ``stop_reason``.
+* Selection is a glob spec (:data:`PACKAGE_GLOBS`) resolved against the
+  session dir. ``runs/`` trace blobs and per-turn agent dumps are never
+  matched — only the curated result/report set.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import logging
+import os
+import shutil
+import tempfile
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+# Default destination root. Claw mounts the synced workspace at
+# ``/workspace`` REGARDLESS of where ``$USER_DATA_PATH`` points, so the
+# bundle must be anchored here (not at ``workspace_root()`` which follows
+# ``$USER_DATA_PATH`` to wekafs). Overridable via env for non-Claw envs
+# and tests.
+ENV_PACKAGE_DEST_ROOT = "HYPERLOOM_SESSION_PACKAGE_DEST"
+DEFAULT_DEST_ROOT = Path("/workspace")
+
+# In addition to the zip, also lay the same curated files down *loose*
+# (uncompressed, keeping their relative tree) directly under the dest
+# root, so a consumer can fetch a single file (e.g.
+# /v1/sessions/<sid>/files/<rel>) without unzipping. Set to
+# "0"/"false"/"no" to write only the zip.
+ENV_PACKAGE_LOOSE = "HYPERLOOM_SESSION_PACKAGE_LOOSE"
+
+#: Subdir under the dest root where bundles land.
+PACKAGE_SUBDIR = "hyperloom-session-packages"
+
+MANIFEST_JSON_NAME = "PACKAGE_MANIFEST.json"
+MANIFEST_TXT_NAME = "PACKAGE_MANIFEST.txt"
+PACKAGE_SCHEMA_VERSION = 1
+
+# Curated artifact selection, relative to session_dir. Glob patterns are
+# matched against POSIX-style relative paths. ``**`` spans directories.
+# Keep this list in sync with the "necessary products" audit; the goal is
+# results / reports / analysis only — never the bulky ``runs/`` traces,
+# profile blobs, or per-turn agent ``request.json`` dumps.
+PACKAGE_GLOBS: tuple[str, ...] = (
+    # ── top-level core ────────────────────────────────────────────────
+    "session_breakdown.json",
+    "state.json",
+    "manifest.json",
+    # ── reports/ ──────────────────────────────────────────────────────
+    "reports/final.json",
+    "reports/final.md",
+    "reports/optimization_journal.json",
+    "reports/kernel_optimization_summary.json",
+    "reports/kernel_roofline.json",
+    "reports/conc_sweep_summary.json",
+    "reports/trace/*.jsonl",
+    # ── target analysis ───────────────────────────────────────────────
+    "target_analysis/target_baseline.json",
+    "target_analysis/target_analysis_report.md",
+    # ── coordinator DB ────────────────────────────────────────────────
+    "storage/coordinator.db",
+    # ── TraceLens analysis/report family (dynamic <ts>/<tl-id> subdirs) ─
+    "kernel-agent/runs/**/tracelens/analysis.md",
+    "kernel-agent/runs/**/tracelens/tracelens_report.json",
+    "kernel-agent/runs/**/tracelens/summary.json",
+    "kernel-agent/runs/**/tracelens/priority_data.json",
+    "kernel-agent/runs/**/kernel_candidates.json",
+    "kernel-agent/runs/**/trace_input_manifest.json",
+    "kernel-agent/runs/**/tracelens/category_findings/*.md",
+    "kernel-agent/runs/**/tracelens/system_findings/*.md",
+    "kernel-agent/runs/**/tracelens/perf_report_csvs/*.csv",
+    # ── per-run benchmark reports (small JSON/txt; NOT the trace blobs) ─
+    "runs/**/benchmark_report.json",
+    "runs/**/summary.txt",
+    "runs/**/inferencex_result.json",
+    "runs/gemm_tuning/**/final_report.json",
+    "runs/gemm_tuning/**/best_results.json",
+    "runs/specialist/**/specialist_done.json",
+    "runs/recover/**/result.json",
+)
+
+# Hard safety caps so a pathological session can't blow up the bundle.
+_MAX_FILES = 5000
+_MAX_TOTAL_BYTES = 256 * 1024 * 1024  # 256 MB
+
+
+def _dest_root() -> Path:
+    """Resolve the destination root for session packages.
+
+    Returns:
+        The path from ``ENV_PACKAGE_DEST_ROOT`` when set, otherwise the
+        default destination root.
+    """
+    override = (os.environ.get(ENV_PACKAGE_DEST_ROOT) or "").strip()
+    return Path(override) if override else DEFAULT_DEST_ROOT
+
+
+def _loose_enabled() -> bool:
+    """Whether to also drop loose (unzipped) copies. Defaults to True.
+
+    Returns:
+        ``True`` unless the env override disables loose copies.
+    """
+    raw = (os.environ.get(ENV_PACKAGE_LOOSE) or "").strip().lower()
+    return raw not in {"0", "false", "no", "off"}
+
+
+def _copy_loose_tree(
+    included: list[tuple[Path, str, int]],
+    manifest: dict,
+    loose_dir: Path,
+) -> int:
+    """Copy each included file into ``loose_dir`` preserving its relative
+    tree, plus the two manifest files. Best-effort, per-file isolated:
+    one unreadable file never aborts the rest. Returns the count copied.
+
+    Files are overwritten in place (no wholesale wipe of ``loose_dir``):
+    the dest is the shared ``/workspace`` root, so deleting it is never
+    safe. A stale file from a previous, larger selection is left as-is;
+    the per-run ``PACKAGE_MANIFEST`` is the source of truth for what this
+    run actually included.
+
+    Args:
+        included: Tuples of ``(source path, relative path, size)`` to copy.
+        manifest: Manifest dict written alongside the copied files.
+        loose_dir: Destination root for the loose tree.
+
+    Returns:
+        The number of files successfully copied.
+    """
+    loose_dir.mkdir(parents=True, exist_ok=True)
+    copied = 0
+    for src, rel, _sz in included:
+        dst = loose_dir / rel
+        try:
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dst)
+            copied += 1
+        except OSError:
+            log.warning("session package: failed to copy loose file %s", rel)
+    try:
+        (loose_dir / MANIFEST_JSON_NAME).write_text(
+            json.dumps(manifest, indent=2),
+            encoding="utf-8",
+        )
+        (loose_dir / MANIFEST_TXT_NAME).write_text(
+            _manifest_text(manifest),
+            encoding="utf-8",
+        )
+    except OSError:
+        log.warning("session package: failed to write loose manifest")
+    return copied
+
+
+def _iter_session_files(session_dir: Path) -> list[Path]:
+    """All files under session_dir (one walk), so glob matching is a
+    single pass instead of N globs each re-walking the tree.
+
+    Args:
+        session_dir: Root directory to walk.
+
+    Returns:
+        Absolute paths of every file found under ``session_dir``.
+    """
+    out: list[Path] = []
+    for dp, _dn, fn in os.walk(session_dir):
+        for f in fn:
+            out.append(Path(dp) / f)
+    return out
+
+
+def _select(session_dir: Path) -> tuple[list[Path], list[str]]:
+    """Return (matched absolute paths, unmatched globs).
+
+    A glob is reported "unmatched" when it selected zero files — useful
+    audit signal in the manifest (e.g. conc_sweep_summary absent because
+    the sweep was skipped).
+
+    Args:
+        session_dir: Session directory whose files are matched against the
+            package globs.
+
+    Returns:
+        A tuple of the matched absolute paths and the patterns that matched
+        nothing.
+    """
+    all_files = _iter_session_files(session_dir)
+    rels = {p: p.relative_to(session_dir).as_posix() for p in all_files}
+
+    matched: list[Path] = []
+    seen: set[Path] = set()
+    unmatched_globs: list[str] = []
+    for pattern in PACKAGE_GLOBS:
+        hit = False
+        for p, rel in rels.items():
+            if _glob_match(rel, pattern):
+                hit = True
+                if p not in seen:
+                    seen.add(p)
+                    matched.append(p)
+        if not hit:
+            unmatched_globs.append(pattern)
+    matched.sort(key=lambda p: rels[p])
+    return matched, unmatched_globs
+
+
+def _glob_match(rel: str, pattern: str) -> bool:
+    """fnmatch with ``**`` spanning ``/``.
+
+    ``fnmatch`` treats ``*`` as spanning ``/`` too, which is too loose
+    for single-segment patterns like ``reports/trace/*.jsonl``. Handle
+    the two cases explicitly:
+
+    * pattern contains ``**`` → collapse to a permissive regex-ish match
+      by replacing ``**`` with a sentinel that fnmatch's ``*`` covers.
+    * otherwise → require the path to have the same number of segments,
+      matching each segment with fnmatch so ``*`` stays within a segment.
+
+    Args:
+        rel: POSIX-style relative path to test.
+        pattern: Glob pattern, possibly containing ``**``.
+
+    Returns:
+        ``True`` when ``rel`` matches ``pattern``.
+    """
+    if "**" in pattern:
+        # fnmatch's '*' already spans '/', so '**' == '*' for our purpose.
+        collapsed = pattern.replace("**/", "*/").replace("**", "*")
+        return fnmatch.fnmatch(rel, collapsed) or fnmatch.fnmatch(rel, pattern.replace("**", "*"))
+    pat_parts = pattern.split("/")
+    rel_parts = rel.split("/")
+    if len(pat_parts) != len(rel_parts):
+        return False
+    return all(fnmatch.fnmatch(rp, pp) for rp, pp in zip(rel_parts, pat_parts))
+
+
+def _build_manifest(
+    session_dir: Path,
+    session_id: str,
+    included: list[tuple[str, int]],
+    missing_globs: list[str],
+    *,
+    truncated: bool = False,
+    dropped_files: list[str] | None = None,
+) -> dict:
+    """Build the manifest dict describing a session package.
+
+    Args:
+        session_dir: Source session directory.
+        session_id: Identifier of the session.
+        included: ``(relative_path, size_bytes)`` pairs that were bundled.
+        missing_globs: Selection globs that matched no files.
+        truncated: Whether a size/count cap stopped the bundle short.
+        dropped_files: Files omitted due to truncation.
+
+    Returns:
+        A JSON-serializable manifest mapping.
+    """
+    total = sum(sz for _, sz in included)
+    return {
+        "schema_version": PACKAGE_SCHEMA_VERSION,
+        "packaged_at_utc": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "session_id": session_id,
+        "session_dir": str(session_dir),
+        "included_count": len(included),
+        "included_total_bytes": total,
+        "included_files": [{"path": rel, "bytes": sz} for rel, sz in included],
+        "unmatched_globs": missing_globs,
+        "selection_globs": list(PACKAGE_GLOBS),
+        # True when a size/count cap stopped the bundle short -- a consumer
+        # MUST treat the package as incomplete and consult dropped_files.
+        "truncated": truncated,
+        "dropped_files": list(dropped_files or []),
+    }
+
+
+def _manifest_text(manifest: dict) -> str:
+    """Render a manifest dict as a human-readable text summary.
+
+    Args:
+        manifest: Manifest mapping produced by :func:`_build_manifest`.
+
+    Returns:
+        A multi-line plain-text description of the package contents.
+    """
+    lines = [
+        "Hyperloom session artifact package",
+        f"  session_id   : {manifest.get('session_id') or '?'}",
+        f"  packaged_at  : {manifest.get('packaged_at_utc')}",
+        f"  source dir   : {manifest.get('session_dir')}",
+        f"  files        : {manifest.get('included_count')}",
+        f"  total bytes  : {manifest.get('included_total_bytes')}",
+        f"  truncated    : {manifest.get('truncated')}",
+        "",
+        "Included files:",
+    ]
+    for entry in manifest.get("included_files") or []:
+        lines.append(f"  + {entry['path']}  ({entry['bytes']} B)")
+    dropped = manifest.get("dropped_files") or []
+    if dropped:
+        lines.append("")
+        lines.append("DROPPED (bundle hit size/count cap — package is INCOMPLETE):")
+        for d in dropped:
+            lines.append(f"  ! {d}")
+    missing = manifest.get("unmatched_globs") or []
+    if missing:
+        lines.append("")
+        lines.append("Selection patterns that matched nothing (informational):")
+        for g in missing:
+            lines.append(f"  - {g}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def package_session_artifacts(
+    session_dir: Path | str,
+    *,
+    session_id: str = "",
+    dest_root: Path | str | None = None,
+) -> Path | None:
+    """Bundle curated artifacts of ``session_dir`` into one zip under the
+    dest root (default ``/workspace/<PACKAGE_SUBDIR>/``).
+
+    Args:
+        session_dir: hyperloom session directory (the products live here).
+        session_id: used for the zip filename + manifest. Falls back to
+            the session dir basename when empty.
+        dest_root: override the destination root (defaults to
+            ``$HYPERLOOM_SESSION_PACKAGE_DEST`` or ``/workspace``).
+
+    Returns:
+        Absolute path to the written zip, or ``None`` on any failure /
+        no files matched. Never raises.
+    """
+    try:
+        sd = Path(session_dir).resolve()
+        if not sd.is_dir():
+            log.warning("session package skipped: session_dir not a dir: %s", sd)
+            return None
+
+        sid = (session_id or "").strip() or sd.name
+        matched, missing_globs = _select(sd)
+        if not matched:
+            log.warning("session package skipped: no artifacts matched in %s", sd)
+            return None
+
+        # Apply safety caps. If we hit a cap, record what got dropped and
+        # flag the manifest as truncated so a consumer never mistakes a
+        # partial bundle for a complete one (a long session can hit the cap
+        # before, say, conversations.jsonl is reached).
+        included: list[tuple[Path, str, int]] = []
+        total = 0
+        truncated = False
+        dropped: list[str] = []
+        for i, p in enumerate(matched):
+            try:
+                sz = p.stat().st_size
+            except OSError:
+                continue
+            if len(included) >= _MAX_FILES or total + sz > _MAX_TOTAL_BYTES:
+                truncated = True
+                dropped = [q.relative_to(sd).as_posix() for q in matched[i:]]
+                log.warning(
+                    "session package: hit size/count cap, TRUNCATING bundle "
+                    "(included=%d, bytes=%d, dropped=%d). Manifest flagged "
+                    "truncated=true.",
+                    len(included),
+                    total,
+                    len(dropped),
+                )
+                break
+            included.append((p, p.relative_to(sd).as_posix(), sz))
+            total += sz
+
+        manifest = _build_manifest(
+            sd,
+            sid,
+            [(rel, sz) for _, rel, sz in included],
+            missing_globs,
+            truncated=truncated,
+            dropped_files=dropped,
+        )
+
+        root = Path(dest_root).resolve() if dest_root else _dest_root()
+        out_dir = root / PACKAGE_SUBDIR
+        out_dir.mkdir(parents=True, exist_ok=True)
+        target = out_dir / f"{sid}.zip"
+
+        # Atomic write: build into a temp zip in the same dir, then replace.
+        fd, tmp = tempfile.mkstemp(prefix=f".{sid}.", suffix=".zip.tmp", dir=str(out_dir))
+        os.close(fd)
+        tmp_path = Path(tmp)
+        try:
+            with zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_DEFLATED) as zf:
+                for p, rel, _sz in included:
+                    try:
+                        zf.write(p, arcname=rel)
+                    except OSError:
+                        log.warning("session package: failed to add %s", rel)
+                zf.writestr(MANIFEST_JSON_NAME, json.dumps(manifest, indent=2))
+                zf.writestr(MANIFEST_TXT_NAME, _manifest_text(manifest))
+            os.replace(tmp_path, target)
+        except Exception:
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+            raise
+
+        log.info(
+            "session package: wrote %s (%d files, %d bytes pre-zip)",
+            target,
+            len(included),
+            total,
+        )
+
+        # Also lay the same files down loose (uncompressed, original tree)
+        # directly under the dest root (e.g. ``/workspace/``) so a consumer
+        # can grab one file without unzip. NOT under the package subdir —
+        # straight at the root, preserving each file's relative path.
+        if _loose_enabled():
+            try:
+                copied = _copy_loose_tree(included, manifest, root)
+                log.info(
+                    "session package: copied %d loose files into %s",
+                    copied,
+                    root,
+                )
+            except Exception:  # noqa: BLE001 — loose copy must not mask the zip
+                log.exception("session package: loose copy failed (non-fatal)")
+
+        return target
+    except Exception:  # noqa: BLE001 — never let packaging mask stop_reason
+        log.exception("session package failed (non-fatal)")
+        return None

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -3656,6 +3656,27 @@ async def _run_optimize(args: argparse.Namespace) -> int:
             except Exception:  # noqa: BLE001
                 log.debug("langfuse flush_session failed (non-fatal)", exc_info=True)
 
+        # Safety-net artifact package -> /workspace. The CLOSE phase
+        # sequencer normally packages at step 2.6, but the wall-clock
+        # deadline path (_enter_closing_phase) and crash paths leave
+        # close_sequence_done False and never run the sequencer, so the
+        # bundle would be missing without this. Best-effort: failures
+        # must not mask stop_reason. Runs after the SBD/final.md +
+        # Langfuse flush above so the freshest products are bundled.
+        try:
+            from .breakdown import package_session_artifacts
+
+            pkg_path = package_session_artifacts(
+                session_dir,
+                session_id=str(
+                    getattr(coordinator.shared_state, "session_id", "") or "",
+                ),
+            )
+            if pkg_path is not None:
+                print(f"Artifact package  : {pkg_path}")
+        except Exception:  # noqa: BLE001
+            log.exception("session artifact package failed (non-fatal)")
+
     _reconcile_crash_count(coordinator.shared_state, session_dir)
     # NOTE: conc_sweep is now a SWEEP-phase action auto-enqueued by the Coordinator, not a post-hook here.
 
@@ -5212,6 +5233,16 @@ def _run_recover_session(args: argparse.Namespace) -> int:
             print(f"  trace backfill    : rc={rc}")
         except Exception:  # noqa: BLE001
             log.exception("recover-session: trace backfill failed (non-fatal)")
+
+    # 4) Re-package the artifact bundle so /workspace carries the recovered SBD.
+    try:
+        from .breakdown import package_session_artifacts
+
+        pkg_path = package_session_artifacts(session_dir)
+        if pkg_path is not None:
+            print(f"  artifact package  : {pkg_path}")
+    except Exception:  # noqa: BLE001
+        log.exception("recover-session: artifact package failed (non-fatal)")
 
     return 0
 

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -6235,6 +6235,42 @@ class Coordinator:
                 detail=repr(exc)[:240],
             )
 
+        # ---------------- Step 2.6: artifact package -> /workspace -------
+        # Bundle the curated result/report/analysis files (incl. the
+        # session_breakdown just written in step 2) into a single zip
+        # placed under ``/workspace`` so the Claw sandbox sync ships it
+        # to object storage even when ``$USER_DATA_PATH`` points at a
+        # wekafs path outside ``/workspace`` (the common production case).
+        # Best-effort: failures are recorded but never abort the close
+        # sequence. The zip carries its own PACKAGE_MANIFEST log of what
+        # went in / what was missing.
+        try:
+            from ..breakdown import package_session_artifacts
+
+            pkg_path = package_session_artifacts(
+                self.session_dir,
+                session_id=str(getattr(self.shared_state, "session_id", "") or ""),
+            )
+            if pkg_path is not None:
+                await self._record_close_step(
+                    "artifact_package",
+                    status="done",
+                    detail=str(pkg_path),
+                )
+            else:
+                await self._record_close_step(
+                    "artifact_package",
+                    status="skipped",
+                    detail="no artifacts matched or dest unwritable",
+                )
+        except Exception as exc:  # noqa: BLE001 — defensive
+            log.exception("CLOSE step 2.6 (artifact_package) failed")
+            await self._record_close_step(
+                "artifact_package",
+                status="failed",
+                detail=repr(exc)[:240],
+            )
+
         # ---------------- Step 4: fact finalize (Cortex commit) ----------
         # The canonical step-4 "Cortex session commit": writes
         # update_recipe + finalises the local journal (final_throughput /

--- a/inference_optimizer/tests/test_close_phase_sequencer.py
+++ b/inference_optimizer/tests/test_close_phase_sequencer.py
@@ -314,14 +314,15 @@ async def test_close_sequencer_runs_all_steps_in_order_happy_path(
     await coord._on_enter_close(from_phase="SWEEP")
 
     rows = coord.shared_state.phase_history[-1]["evidence"]["close_steps"]
-    # Step sequence post T2/T3 retirement (cortex_commit removed) and post
-    # /workspace artifact-package removal (moving artifacts is now the
-    # collector's job, not the optimizer's).
+    # Step sequence post T2/T3 retirement (cortex_commit removed); the
+    # artifact_package bundle (step 2.6) sits between session_breakdown and
+    # fact_finalize.
     steps = [r["step"] for r in rows]
     assert steps == [
         "sequencer_started",
         "report",
         "session_breakdown",
+        "artifact_package",
         "fact_finalize",
         "ndjson_drain",
         "done",
@@ -331,6 +332,9 @@ async def test_close_sequencer_runs_all_steps_in_order_happy_path(
     by_step = {r["step"]: r for r in rows}
     assert by_step["report"]["status"] == "done"
     assert by_step["session_breakdown"]["status"] == "done"
+    # tmp_path session dir holds no curated artifacts, so packaging matches
+    # nothing and records "skipped" (best-effort; never blocks close).
+    assert by_step["artifact_package"]["status"] == "skipped"
     assert by_step["fact_finalize"]["status"] == "done"
     # ndjson_drain retired with the v1 cortex_kb_client; stub-emits "skipped".
     assert by_step["ndjson_drain"]["status"] == "skipped"

--- a/inference_optimizer/tests/test_session_package.py
+++ b/inference_optimizer/tests/test_session_package.py
@@ -1,0 +1,291 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Tests for breakdown.session_package.package_session_artifacts.
+
+Builds a synthetic session dir mixing curated artifacts with bulky
+``runs/`` traces + per-turn agent dumps, then asserts the zip contains
+exactly the curated set (plus the manifest log) and excludes the noise.
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from inference_optimizer.breakdown.session_package import (
+    ENV_PACKAGE_LOOSE,
+    MANIFEST_JSON_NAME,
+    MANIFEST_TXT_NAME,
+    PACKAGE_SUBDIR,
+    package_session_artifacts,
+)
+
+
+def _write(p: Path, content: str = "x") -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+
+
+def _build_session(sd: Path) -> None:
+    # curated (must be included)
+    _write(sd / "session_breakdown.json", '{"a":1}')
+    _write(sd / "state.json", "{}")
+    _write(sd / "manifest.json", "{}")
+    _write(sd / "reports" / "final.json", "{}")
+    _write(sd / "reports" / "final.md", "# final")
+    _write(sd / "reports" / "optimization_journal.json", "[]")
+    _write(sd / "reports" / "kernel_optimization_summary.json", "{}")
+    _write(sd / "reports" / "kernel_roofline.json", "{}")
+    _write(sd / "reports" / "trace" / "decision_trace.jsonl", "{}\n")
+    _write(sd / "reports" / "trace" / "llm_calls.jsonl", "{}\n")
+    _write(sd / "target_analysis" / "target_baseline.json", "{}")
+    _write(sd / "target_analysis" / "target_analysis_report.md", "# t")
+    _write(sd / "storage" / "coordinator.db", "sqlite")
+    # tracelens family under a dynamic <ts>/<tl-id> path
+    tl = sd / "kernel-agent" / "runs" / "20260609T010022Z" / "20260609T012416Z_tl-abc" / "tracelens"
+    _write(tl / "analysis.md", "# analysis")
+    _write(tl / "tracelens_report.json", "{}")
+    _write(tl / "summary.json", "{}")
+    _write(tl / "priority_data.json", "{}")
+    _write(tl.parent / "kernel_candidates.json", "[]")
+    _write(tl.parent / "trace_input_manifest.json", "{}")
+    _write(tl / "category_findings" / "gemm_findings.md", "# g")
+    _write(tl / "system_findings" / "cpu_idle_findings.md", "# c")
+    _write(tl / "perf_report_csvs" / "GEMM.csv", "a,b\n1,2\n")
+    # per-run reports (curated)
+    run = sd / "runs" / "baseline" / "abc" / "measure_round" / "benchmark_sglang_x"
+    _write(run / "benchmark_report.json", "{}")
+    _write(run / "summary.txt", "ok")
+    _write(run / "inferencex_result.json", "{}")
+    _write(sd / "runs" / "gemm_tuning" / "k" / "logs" / "final_report.json", "{}")
+    _write(sd / "runs" / "gemm_tuning" / "k" / "logs" / "best_results.json", "{}")
+    _write(sd / "runs" / "specialist" / "s1" / "specialist_done.json", "{}")
+    _write(sd / "runs" / "recover" / "r1" / "result.json", "{}")
+
+    # NOISE — must be excluded
+    _write(run / "torch_trace" / "x.trace.json.gz", "BLOB")
+    _write(tl / "trace_split" / "y.trace.json.gz", "BLOB")
+    _write(sd / "critic-workdir" / "000001" / "request.json", "{}")
+    _write(sd / "robustness-workdir" / "000001" / "request.json", "{}")
+    _write(sd / "hands.log", "log")
+    _write(sd / "runs" / "specialist" / "s1" / "prompt.md", "prompt")  # not in spec
+
+
+def _zip_names(zip_path: Path) -> set[str]:
+    with zipfile.ZipFile(zip_path) as zf:
+        return set(zf.namelist())
+
+
+def test_package_includes_curated_excludes_noise(tmp_path: Path) -> None:
+    sd = tmp_path / "session"
+    _build_session(sd)
+    dest = tmp_path / "workspace"
+
+    out = package_session_artifacts(sd, session_id="sid-123", dest_root=dest)
+    assert out is not None
+    assert out == dest / PACKAGE_SUBDIR / "sid-123.zip"
+    assert out.exists()
+
+    names = _zip_names(out)
+
+    # curated present
+    for rel in (
+        "session_breakdown.json",
+        "state.json",
+        "manifest.json",
+        "reports/final.json",
+        "reports/final.md",
+        "reports/optimization_journal.json",
+        "reports/kernel_optimization_summary.json",
+        "reports/kernel_roofline.json",
+        "reports/trace/decision_trace.jsonl",
+        "reports/trace/llm_calls.jsonl",
+        "target_analysis/target_baseline.json",
+        "target_analysis/target_analysis_report.md",
+        "storage/coordinator.db",
+        "kernel-agent/runs/20260609T010022Z/20260609T012416Z_tl-abc/tracelens/analysis.md",
+        "kernel-agent/runs/20260609T010022Z/20260609T012416Z_tl-abc/tracelens/tracelens_report.json",
+        "kernel-agent/runs/20260609T010022Z/20260609T012416Z_tl-abc/tracelens/summary.json",
+        "kernel-agent/runs/20260609T010022Z/20260609T012416Z_tl-abc/tracelens/priority_data.json",
+        "kernel-agent/runs/20260609T010022Z/20260609T012416Z_tl-abc/kernel_candidates.json",
+        "kernel-agent/runs/20260609T010022Z/20260609T012416Z_tl-abc/trace_input_manifest.json",
+        "kernel-agent/runs/20260609T010022Z/20260609T012416Z_tl-abc/tracelens/category_findings/gemm_findings.md",
+        "kernel-agent/runs/20260609T010022Z/20260609T012416Z_tl-abc/tracelens/system_findings/cpu_idle_findings.md",
+        "kernel-agent/runs/20260609T010022Z/20260609T012416Z_tl-abc/tracelens/perf_report_csvs/GEMM.csv",
+        "runs/baseline/abc/measure_round/benchmark_sglang_x/benchmark_report.json",
+        "runs/baseline/abc/measure_round/benchmark_sglang_x/summary.txt",
+        "runs/baseline/abc/measure_round/benchmark_sglang_x/inferencex_result.json",
+        "runs/gemm_tuning/k/logs/final_report.json",
+        "runs/gemm_tuning/k/logs/best_results.json",
+        "runs/specialist/s1/specialist_done.json",
+        "runs/recover/r1/result.json",
+    ):
+        assert rel in names, f"missing curated: {rel}"
+
+    # noise excluded
+    for rel in (
+        "runs/baseline/abc/measure_round/benchmark_sglang_x/torch_trace/x.trace.json.gz",
+        "kernel-agent/runs/20260609T010022Z/20260609T012416Z_tl-abc/tracelens/trace_split/y.trace.json.gz",
+        "critic-workdir/000001/request.json",
+        "robustness-workdir/000001/request.json",
+        "hands.log",
+        "runs/specialist/s1/prompt.md",
+    ):
+        assert rel not in names, f"noise leaked in: {rel}"
+
+    # manifest log present + inside the zip
+    assert MANIFEST_JSON_NAME in names
+    assert MANIFEST_TXT_NAME in names
+
+
+def test_manifest_records_included_and_missing(tmp_path: Path) -> None:
+    sd = tmp_path / "session"
+    _build_session(sd)
+    # remove one curated file so its glob shows up as unmatched
+    (sd / "reports" / "kernel_roofline.json").unlink()
+    dest = tmp_path / "workspace"
+
+    out = package_session_artifacts(sd, session_id="sid-x", dest_root=dest)
+    assert out is not None
+    with zipfile.ZipFile(out) as zf:
+        manifest = json.loads(zf.read(MANIFEST_JSON_NAME))
+
+    assert manifest["session_id"] == "sid-x"
+    assert manifest["included_count"] == len(manifest["included_files"])
+    incl_paths = {e["path"] for e in manifest["included_files"]}
+    assert "session_breakdown.json" in incl_paths
+    assert "reports/kernel_roofline.json" not in incl_paths
+    # the removed file's glob is reported as unmatched
+    assert "reports/kernel_roofline.json" in manifest["unmatched_globs"]
+    # conc_sweep_summary was never created → also unmatched (audit signal)
+    assert "reports/conc_sweep_summary.json" in manifest["unmatched_globs"]
+
+
+def test_empty_session_returns_none(tmp_path: Path) -> None:
+    sd = tmp_path / "session"
+    sd.mkdir()
+    (sd / "runs").mkdir()  # only noise-ish empty dirs
+    out = package_session_artifacts(sd, session_id="empty", dest_root=tmp_path / "ws")
+    assert out is None
+
+
+def test_missing_session_dir_returns_none(tmp_path: Path) -> None:
+    out = package_session_artifacts(
+        tmp_path / "does-not-exist",
+        session_id="x",
+        dest_root=tmp_path / "ws",
+    )
+    assert out is None
+
+
+def test_session_id_falls_back_to_dirname(tmp_path: Path) -> None:
+    sd = tmp_path / "Qwen_20260609T010022Z"
+    _write(sd / "session_breakdown.json", "{}")
+    out = package_session_artifacts(sd, dest_root=tmp_path / "ws")
+    assert out is not None
+    assert out.name == "Qwen_20260609T010022Z.zip"
+
+
+def test_atomic_no_tmp_left_behind(tmp_path: Path) -> None:
+    sd = tmp_path / "session"
+    _write(sd / "session_breakdown.json", "{}")
+    dest = tmp_path / "ws"
+    package_session_artifacts(sd, session_id="sid", dest_root=dest)
+    leftovers = list((dest / PACKAGE_SUBDIR).glob(".*tmp"))
+    assert leftovers == []
+
+
+def test_loose_files_dropped_at_dest_root(tmp_path: Path) -> None:
+    sd = tmp_path / "session"
+    _build_session(sd)
+    dest = tmp_path / "workspace"
+
+    out = package_session_artifacts(sd, session_id="sid-123", dest_root=dest)
+    assert out is not None
+    assert out.exists()  # zip still under the package subdir
+    assert out == dest / PACKAGE_SUBDIR / "sid-123.zip"
+
+    # loose files land DIRECTLY under the dest root (not under <sid>/),
+    # preserving each file's original relative path
+    for rel in (
+        "session_breakdown.json",
+        "state.json",
+        "reports/final.json",
+        "reports/trace/decision_trace.jsonl",
+        "kernel-agent/runs/20260609T010022Z/20260609T012416Z_tl-abc/tracelens/analysis.md",
+        "runs/baseline/abc/measure_round/benchmark_sglang_x/benchmark_report.json",
+    ):
+        assert (dest / rel).is_file(), f"missing loose file: {rel}"
+
+    # noise stays out of the loose tree too
+    assert not (dest / "hands.log").exists()
+    assert not (dest / "critic-workdir" / "000001" / "request.json").exists()
+
+    # manifest also written loose at the root
+    assert (dest / MANIFEST_JSON_NAME).is_file()
+    assert (dest / MANIFEST_TXT_NAME).is_file()
+
+    # loose content matches source byte-for-byte
+    assert (dest / "session_breakdown.json").read_text(encoding="utf-8") == '{"a":1}'
+
+
+def test_loose_can_be_disabled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_PACKAGE_LOOSE, "0")
+    sd = tmp_path / "session"
+    _build_session(sd)
+    dest = tmp_path / "workspace"
+
+    out = package_session_artifacts(sd, session_id="sid-123", dest_root=dest)
+    assert out is not None and out.exists()  # zip still written
+    assert not (dest / "session_breakdown.json").exists()  # no loose copies
+
+
+def test_truncation_is_flagged_in_manifest(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import inference_optimizer.breakdown.session_package as sp
+
+    # Force a tiny byte cap so the bundle truncates after the first file.
+    monkeypatch.setattr(sp, "_MAX_TOTAL_BYTES", 5)
+    sd = tmp_path / "session"
+    _build_session(sd)
+    dest = tmp_path / "workspace"
+
+    out = sp.package_session_artifacts(sd, session_id="sid-trunc", dest_root=dest)
+    assert out is not None
+    with zipfile.ZipFile(out) as zf:
+        manifest = json.loads(zf.read(MANIFEST_JSON_NAME))
+
+    assert manifest["truncated"] is True
+    assert len(manifest["dropped_files"]) > 0  # what got left out is recorded
+    # the dropped set and the included set are disjoint
+    incl = {e["path"] for e in manifest["included_files"]}
+    assert not (incl & set(manifest["dropped_files"]))
+
+
+def test_no_truncation_flag_when_under_cap(tmp_path: Path) -> None:
+    sd = tmp_path / "session"
+    _build_session(sd)
+    out = package_session_artifacts(sd, session_id="sid-ok", dest_root=tmp_path / "ws")
+    assert out is not None
+    with zipfile.ZipFile(out) as zf:
+        manifest = json.loads(zf.read(MANIFEST_JSON_NAME))
+    assert manifest["truncated"] is False
+    assert manifest["dropped_files"] == []
+
+
+def test_loose_does_not_wipe_dest_root(tmp_path: Path) -> None:
+    sd = tmp_path / "session"
+    _build_session(sd)
+    dest = tmp_path / "workspace"
+    dest.mkdir()
+    # a pre-existing unrelated file at the dest root must survive
+    keep = dest / "unrelated-other-session.txt"
+    keep.write_text("keep me", encoding="utf-8")
+
+    package_session_artifacts(sd, session_id="sid-123", dest_root=dest)
+
+    assert keep.is_file()  # loose copy must never blow away the root
+    assert keep.read_text(encoding="utf-8") == "keep me"
+    assert (dest / "session_breakdown.json").is_file()  # loose copy still landed


### PR DESCRIPTION
## Summary
- Re-enable `package_session_artifacts` and `breakdown/session_package.py`, which copies curated session reports into `/workspace` for Claw sync when `USER_DATA_PATH` points outside `/workspace`.
- Wire packaging back into the CLOSE sequencer (step 2.6), `cli.finally` safety net, and `recover-session`.
- Restore tests and configuration-reference notes for artifact-package behavior.

## Test plan
- [x] `pytest inference_optimizer/tests/test_session_package.py inference_optimizer/tests/test_close_phase_sequencer.py` (34 passed)


Made with [Cursor](https://cursor.com)