### PR TITLE
fix: filter daily incompatible model submissions

### DIFF
--- a/ci/filter_candidates.py
+++ b/ci/filter_candidates.py
@@ -84,7 +84,9 @@ def classify_local(repo):
     mdir = os.path.join(MODELS_DIR, slug(repo))
     cfg_path = os.path.join(mdir, "config.json")
     if not os.path.isfile(cfg_path):
-        return None  # no local cache -> judged only by the HF gated check
+        # Some non-LLM repos (for example FLUX Diffusers pipelines) have no
+        # root config.json, so still apply repo-id-only compatibility gates.
+        return model_compat.unrunnable_reason(None, repo=repo)
     try:
         cfg = json.load(open(cfg_path))
     except Exception:

--- a/ci/model_compat.py
+++ b/ci/model_compat.py
@@ -102,6 +102,12 @@ def is_mi300x(gpu_type):
 _MI300X_BLOCK_RE = re.compile(r"deepseek[-_]?v4(?![0-9])|glm[-_]?5(?![0-9])", re.I)
 _MI300X_ALLOW_RE = re.compile(r"deepseek[-_]?v4[-_]?flash", re.I)
 
+# Non-LLM model families that can appear in broad HF pools but cannot be served
+# by Hyperloom's text-generation benchmark path. Some of these repos (for
+# example FLUX.1-dev) do not have a HF ``config.json`` at the repo root, so keep
+# this repo-name gate outside the config-only rules.
+_NON_LLM_RE = re.compile(r"(^|[/_-])flux(\.|[/_-]|$)|stable[-_]?diffusion|diffusion", re.I)
+
 
 def mi300x_blocked_model(repo):
     """Return the matched model token when ``repo`` is one we never run on
@@ -112,6 +118,14 @@ def mi300x_blocked_model(repo):
     if _MI300X_ALLOW_RE.search(name):
         return ""
     m = _MI300X_BLOCK_RE.search(name)
+    return m.group(0) if m else ""
+
+
+def non_llm_repo(repo):
+    """Return the matched token when ``repo`` is a known non-text-generation
+    family (Diffusers/image-generation), else ``""``.
+    """
+    m = _NON_LLM_RE.search(str(repo or ""))
     return m.group(0) if m else ""
 
 
@@ -183,6 +197,12 @@ def unrunnable_reason(config, repo="", model_dir=None, whitelist=None, gpu_type=
     """
     if whitelist and repo and repo in whitelist:
         return None  # curated/whitelisted repo -> never filtered
+    blocked_non_llm = non_llm_repo(repo)
+    if blocked_non_llm:
+        return (
+            "non_text_generation",
+            f"{blocked_non_llm} is a Diffusers/image-generation model, not a decoder-only causal LM",
+        )
     if not isinstance(config, dict):
         return None
     archs = config.get("architectures") or []

--- a/ci/model_compat.py
+++ b/ci/model_compat.py
@@ -105,8 +105,16 @@ _MI300X_ALLOW_RE = re.compile(r"deepseek[-_]?v4[-_]?flash", re.I)
 # Non-LLM model families that can appear in broad HF pools but cannot be served
 # by Hyperloom's text-generation benchmark path. Some of these repos (for
 # example FLUX.1-dev) do not have a HF ``config.json`` at the repo root, so keep
-# this repo-name gate outside the config-only rules.
-_NON_LLM_RE = re.compile(r"(^|[/_-])flux(\.|[/_-]|$)|stable[-_]?diffusion|diffusion", re.I)
+# this repo-name gate outside the config-only rules. Keep the patterns
+# family/token-scoped: a broad ``diffusion`` substring would also match possible
+# text-generation research repos whose config is otherwise runnable.
+_NON_LLM_RE = re.compile(
+    r"(^|[/_-])flux(\.|[/_-]|$)"
+    r"|(^|[/_-])stable[-_]?diffusion([/_-]|$)"
+    r"|(^|[/_-])diffusers([/_-]|$)"
+    r"|(^|[/_-])diffusion[-_]?pipeline([/_-]|$)",
+    re.I,
+)
 
 
 def mi300x_blocked_model(repo):

--- a/ci/test_model_compat.py
+++ b/ci/test_model_compat.py
@@ -22,6 +22,7 @@ if str(_CI_DIR) not in sys.path:
     sys.path.insert(0, str(_CI_DIR))
 
 import model_compat  # noqa: E402
+import filter_candidates  # noqa: E402
 
 
 # ── unrunnable_reason: per-rule hits ────────────────────────────────────────
@@ -49,6 +50,23 @@ def test_multimodal_by_vision_config():
 
 def test_non_llm_diffusers_repo_filtered_without_config():
     assert _reason(None, repo="black-forest-labs/FLUX.1-dev") == "non_text_generation"
+
+
+def test_filter_candidates_repo_gate_without_config(tmp_path, monkeypatch):
+    monkeypatch.setattr(filter_candidates, "MODELS_DIR", str(tmp_path))
+    (tmp_path / "black-forest-labs-FLUX.1-dev").mkdir()
+
+    r = filter_candidates.classify_local("black-forest-labs/FLUX.1-dev")
+
+    assert r is not None
+    assert r[0] == "non_text_generation"
+
+
+def test_diffusion_substring_text_repo_is_kept():
+    assert _reason({"architectures": ["LlamaForCausalLM"],
+                    "model_type": "llama",
+                    "max_position_embeddings": 8192},
+                   repo="org/diffusion-language-model") is None
 
 
 def test_bare_for_conditional_generation_without_vision_is_kept():

--- a/ci/test_model_compat.py
+++ b/ci/test_model_compat.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import sys
 import urllib.error
 from pathlib import Path
@@ -54,12 +55,124 @@ def test_non_llm_diffusers_repo_filtered_without_config():
 
 def test_filter_candidates_repo_gate_without_config(tmp_path, monkeypatch):
     monkeypatch.setattr(filter_candidates, "MODELS_DIR", str(tmp_path))
-    (tmp_path / "black-forest-labs-FLUX.1-dev").mkdir()
 
     r = filter_candidates.classify_local("black-forest-labs/FLUX.1-dev")
 
     assert r is not None
     assert r[0] == "non_text_generation"
+
+
+def test_filter_candidates_classify_local_config_and_bad_json(tmp_path, monkeypatch):
+    monkeypatch.setattr(filter_candidates, "MODELS_DIR", str(tmp_path))
+    short_dir = tmp_path / "org-short"
+    short_dir.mkdir()
+    (short_dir / "config.json").write_text(
+        json.dumps({
+            "architectures": ["LlamaForCausalLM"],
+            "max_position_embeddings": 2048,
+        }),
+        encoding="utf-8",
+    )
+    bad_dir = tmp_path / "org-bad-json"
+    bad_dir.mkdir()
+    (bad_dir / "config.json").write_text("{", encoding="utf-8")
+
+    assert filter_candidates.classify_local("org/short")[0] == "short_ctx"
+    assert filter_candidates.classify_local("org/bad-json") is None
+
+
+def test_filter_candidates_tokens_slug_and_gated_cache(tmp_path, monkeypatch):
+    monkeypatch.setenv("HF_TOKENS", "hf_a, hf_b")
+    monkeypatch.setenv("HF_TOKEN", "hf_b")
+    monkeypatch.setenv("HF_TOKEN_2", "hf_c")
+    monkeypatch.setattr(
+        filter_candidates,
+        "GATED_CACHE",
+        str(tmp_path / "gated_cache.tsv"),
+    )
+    (tmp_path / "gated_cache.tsv").write_text(
+        "cached/repo\tgated\nmalformed\n",
+        encoding="utf-8",
+    )
+
+    assert filter_candidates.hf_tokens() == ["hf_a", "hf_b", "hf_c"]
+    assert filter_candidates.slug("org/model") == "org-model"
+    assert filter_candidates.load_gated_cache() == {"cached/repo": "gated"}
+
+
+def test_filter_candidates_gated_check_all_appends_uncached(tmp_path, monkeypatch):
+    cache_path = tmp_path / "gated_cache.tsv"
+    cache_path.write_text("cached/repo\tok\n", encoding="utf-8")
+    monkeypatch.setattr(filter_candidates, "GATED_CACHE", str(cache_path))
+    monkeypatch.setattr(
+        filter_candidates,
+        "hf_gated",
+        lambda repo: "gated" if repo == "new/gated" else None,
+    )
+    monkeypatch.setattr(filter_candidates.time, "sleep", lambda _seconds: None)
+
+    cache = filter_candidates.gated_check_all(["cached/repo", "new/gated", "new/ok"])
+
+    assert cache == {
+        "cached/repo": "ok",
+        "new/gated": "gated",
+        "new/ok": "ok",
+    }
+    assert "new/gated\tgated" in cache_path.read_text(encoding="utf-8")
+
+
+def test_filter_candidates_main_filters_local_and_gated(tmp_path, monkeypatch):
+    models_dir = tmp_path / "models"
+    out_dir = tmp_path / "out"
+    pool_path = tmp_path / "daily.json"
+    pool_path.write_text(
+        json.dumps({
+            "candidates": [
+                {"repo_id": "black-forest-labs/FLUX.1-dev"},
+                {"repo_id": "org/ok"},
+                {"repo_id": "org/gated"},
+                {"repo_id": "org/whitelist"},
+            ]
+        }),
+        encoding="utf-8",
+    )
+    ok_dir = models_dir / "org-ok"
+    ok_dir.mkdir(parents=True)
+    (ok_dir / "config.json").write_text(
+        json.dumps({
+            "architectures": ["LlamaForCausalLM"],
+            "max_position_embeddings": 8192,
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(filter_candidates, "MODELS_DIR", str(models_dir))
+    monkeypatch.setattr(filter_candidates, "OUT_DIR", str(out_dir))
+    monkeypatch.setattr(
+        filter_candidates,
+        "GATED_CACHE",
+        str(out_dir / "gated_cache.tsv"),
+    )
+    monkeypatch.setattr(
+        filter_candidates.model_compat,
+        "load_whitelist",
+        lambda: {"org/whitelist"},
+    )
+    monkeypatch.setattr(
+        filter_candidates,
+        "gated_check_all",
+        lambda repos: {"org/ok": "ok", "org/gated": "gated"},
+    )
+
+    filter_candidates.main([str(pool_path)])
+
+    filtered = json.loads((out_dir / "daily_filtered.json").read_text(encoding="utf-8"))
+    assert [c["repo_id"] for c in filtered["candidates"]] == [
+        "org/ok",
+        "org/whitelist",
+    ]
+    report = (out_dir / "pool_filter_report.tsv").read_text(encoding="utf-8")
+    assert "black-forest-labs/FLUX.1-dev\tnon_text_generation" in report
+    assert "org/gated\tgated\tHF API" in report
 
 
 def test_diffusion_substring_text_repo_is_kept():

--- a/ci/test_model_compat.py
+++ b/ci/test_model_compat.py
@@ -47,6 +47,10 @@ def test_multimodal_by_vision_config():
                     "max_position_embeddings": 4096}) == "multimodal"
 
 
+def test_non_llm_diffusers_repo_filtered_without_config():
+    assert _reason(None, repo="black-forest-labs/FLUX.1-dev") == "non_text_generation"
+
+
 def test_bare_for_conditional_generation_without_vision_is_kept():
     # Text-only MoE that merely use the *ForConditionalGeneration suffix
     # (no vision_config) must NOT be filtered as multimodal.

--- a/inference_optimizer/cli_model_gate.py
+++ b/inference_optimizer/cli_model_gate.py
@@ -278,13 +278,22 @@ _UNRECOGNIZED_ARCHITECTURES = frozenset({
     "deepseekv4forcausallm", "glm4moeliteforcausallm",
     "mimov2flashforcausallm", "glmmoedsaforcausallm",
 })
-# ministral3 only fails inside a Mistral3 multimodal wrapper (Surpem-Supertron2
-# server.log: vLLM registry raises KeyError('ministral3') for text_config.
-# model_type). A bare top-level ministral3 is left to the framework to judge, so
-# this is checked only against the nested text_config scope.
-_NESTED_ONLY_UNRECOGNIZED_MODEL_TYPES = frozenset({"ministral3"})
+# Some model_type values only appear inside nested decoder configs carried by a
+# wrapper. A bare top-level type is left to the framework unless we have a direct
+# repro, so these are checked only against the nested text_config scope.
+#
+# ministral3: Mistral3 multimodal wrapper (Surpem-Supertron2 server.log: vLLM
+# registry raises KeyError('ministral3') for text_config.model_type).
+# qwen3_5_moe_text: Qwen3.6 text decoder wrapper; vLLM/Transformers rejects it
+# with "model type `qwen3_5_moe_text` but Transformers does not recognize this
+# architecture".
+_NESTED_ONLY_UNRECOGNIZED_MODEL_TYPES = frozenset({
+    "ministral3",
+    "qwen3_5_moe_text",
+})
 
 _PHI3_ROPE_TYPES = frozenset({"su", "longrope"})
+_STRICT_BOOL_CONFIG_KEYS = ("use_cache",)
 
 # ``_GEMMA2_ARCHITECTURES`` is imported from model_config_utils (single source
 # of truth) at module top.
@@ -892,6 +901,59 @@ def _detect_gemma2_missing_hidden_act(data: dict) -> str | None:
         "in engine init."
     )
 
+
+def _detect_diffusers_pipeline_model(model_path: str) -> str | None:
+    """Return a reason when the directory is a Diffusers pipeline, not an LLM.
+
+    Diffusers repos such as FLUX.1-dev ship ``model_index.json`` at the root and
+    no causal-LM ``config.json``. Without this guard they can reach baseline and
+    fail only after server health checks time out.
+    """
+    idx = Path(model_path) / "model_index.json"
+    if not idx.is_file():
+        return None
+    try:
+        data = json.loads(idx.read_text(encoding="utf-8", errors="replace"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    class_name = str(data.get("_class_name") or "").strip()
+    if class_name.endswith("Pipeline") or class_name in {
+        "FluxPipeline",
+        "StableDiffusionPipeline",
+        "DiffusionPipeline",
+    }:
+        return (
+            f"model_index.json declares Diffusers pipeline '{class_name or '?'}', "
+            "not a decoder-only causal LM; Hyperloom text-generation benchmarks "
+            "cannot serve this model."
+        )
+    return None
+
+
+def _detect_null_strict_bool_config(data: dict) -> str | None:
+    """Return a reason for config fields that strict HF validators require bool.
+
+    Some checkpoints serialize ``use_cache: null``. The loader path then fails
+    before useful work with ``StrictDataclassFieldValidationError: field
+    'use_cache' expected bool, got NoneType``.
+    """
+    scopes = [("config", data)]
+    nested = data.get("text_config")
+    if isinstance(nested, dict):
+        scopes.append(("text_config", nested))
+    for scope_name, scope in scopes:
+        for key in _STRICT_BOOL_CONFIG_KEYS:
+            if key in scope and scope.get(key) is None:
+                return (
+                    f"{scope_name}.{key} is null, but HuggingFace/vLLM strict "
+                    "config validation expects a bool and raises "
+                    "StrictDataclassFieldValidationError before server init."
+                )
+    return None
+
+
 # Local tokenizer artifacts sglang/HF need to build a real tokenizer. A
 # checkpoint shipping only weights + config (no tokenizer) loads a degraded
 # fallback whose warmup encodes an empty prompt → empty (M=0) batch → aiter
@@ -1144,6 +1206,9 @@ def _detect_incompatible_model_config(
     """
     if not model_path:
         return None
+    pipeline_reason = _detect_diffusers_pipeline_model(model_path)
+    if pipeline_reason is not None:
+        return pipeline_reason
     cfg_path = Path(model_path) / "config.json"
     if not cfg_path.is_file():
         return None
@@ -1178,6 +1243,9 @@ def _detect_incompatible_model_config(
     nested = data.get("text_config")
     if isinstance(nested, dict):
         scopes.append(nested)
+    null_bool_reason = _detect_null_strict_bool_config(data)
+    if null_bool_reason is not None:
+        return null_bool_reason
     has_rope = any(
         s.get(k) for s in scopes for k in _ROPE_CONFIG_KEYS
     )

--- a/inference_optimizer/cli_model_gate.py
+++ b/inference_optimizer/cli_model_gate.py
@@ -1014,6 +1014,22 @@ _VOCAB_WEIGHT_NAMES = (
     "word_embeddings.weight",
     "lm_head.weight",
 )
+_FULL_BASE_WEIGHT_NAMES = (
+    "model.embed_tokens.weight",
+    "embed_tokens.weight",
+    "transformer.wte.weight",
+    "wte.weight",
+    "word_embeddings.weight",
+    "lm_head.weight",
+)
+_PEFT_ADAPTER_WEIGHT_MARKERS = (
+    ".lora_A.",
+    ".lora_B.",
+    ".lora_embedding_A",
+    ".lora_embedding_B",
+    ".modules_to_save.",
+    ".base_layer.",
+)
 _SAFETENSORS_HEADER_LIMIT = 64 * 1024 * 1024
 
 
@@ -1108,6 +1124,58 @@ def _detect_vocab_weight_shape_mismatch(model_path: str, data: dict) -> str | No
                     f"weight loading will fail."
                 )
     return None
+
+
+def _detect_peft_adapter_only_checkpoint(model_path: str, data: dict) -> str | None:
+    """Return a reason when a checkpoint looks like an unmerged PEFT adapter.
+
+    Some repos ship ``config.json`` plus LoRA/PEFT adapter tensors but not the
+    corresponding base-model weights. The default vLLM/sglang loaders then try
+    to resolve base tensors such as ``base_model.model.lm_head.base_layer.weight``
+    and fail during engine init. Keep this conservative: only block when the
+    safetensors index explicitly carries adapter-shaped tensor names and lacks
+    normal base embedding / LM-head weights.
+    """
+    mdir = Path(model_path)
+    idx = mdir / "model.safetensors.index.json"
+    if not idx.is_file():
+        return None
+    try:
+        weight_map = (json.loads(idx.read_text(encoding="utf-8")) or {}).get(
+            "weight_map",
+        ) or {}
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(weight_map, dict) or not weight_map:
+        return None
+
+    keys = {str(k) for k in weight_map}
+    has_adapter_tensors = any(
+        marker in key for key in keys for marker in _PEFT_ADAPTER_WEIGHT_MARKERS
+    )
+    has_adapter_manifest = (
+        (mdir / "adapter_config.json").is_file()
+        or any("adapter" in str(v).lower() for v in weight_map.values())
+    )
+    if not has_adapter_tensors and not has_adapter_manifest:
+        return None
+
+    has_base_weights = any(
+        key.endswith(suffix)
+        for key in keys
+        for suffix in _FULL_BASE_WEIGHT_NAMES
+    )
+    if has_base_weights:
+        return None
+
+    return (
+        "checkpoint appears to be an unmerged PEFT/LoRA adapter: "
+        "model.safetensors.index.json contains adapter/base_layer tensor names "
+        "but no full base embedding or lm_head weights. The default "
+        "vLLM/sglang loader cannot reconstruct missing base tensors such as "
+        "base_model.model.lm_head.base_layer.weight; merge the adapter into the "
+        "base model before running Hyperloom."
+    )
 
 
 def _detect_missing_tokenizer_files(model_path: str, data: dict) -> str | None:
@@ -1281,6 +1349,9 @@ def _detect_incompatible_model_config(
     private_quant_reason = _detect_private_quant(model_path, data)
     if private_quant_reason is not None:
         return private_quant_reason
+    peft_adapter_reason = _detect_peft_adapter_only_checkpoint(model_path, data)
+    if peft_adapter_reason is not None:
+        return peft_adapter_reason
     vocab_shape_reason = _detect_vocab_weight_shape_mismatch(model_path, data)
     if vocab_shape_reason is not None:
         return vocab_shape_reason

--- a/inference_optimizer/tests/test_model_config_compat_preflight.py
+++ b/inference_optimizer/tests/test_model_config_compat_preflight.py
@@ -66,6 +66,52 @@ def test_detect_healthy_config_returns_none(tmp_path):
     assert cli._detect_incompatible_model_config(str(m)) is None
 
 
+def test_detect_diffusers_pipeline_blocks_without_config_json(tmp_path):
+    m = tmp_path / "flux"
+    m.mkdir()
+    (m / "model_index.json").write_text(
+        json.dumps({"_class_name": "FluxPipeline"}),
+        encoding="utf-8",
+    )
+
+    reason = cli._detect_incompatible_model_config(str(m))
+
+    assert reason is not None
+    assert "Diffusers pipeline" in reason
+    assert "causal LM" in reason
+
+
+def test_detect_null_use_cache_blocks_strict_config_validation(tmp_path):
+    m = tmp_path / "null_use_cache"
+    _write_config(
+        m,
+        model_type="qwen2",
+        max_position_embeddings=4096,
+        use_cache=None,
+    )
+
+    reason = cli._detect_incompatible_model_config(str(m))
+
+    assert reason is not None
+    assert "use_cache" in reason
+    assert "StrictDataclassFieldValidationError" in reason
+
+
+def test_detect_null_use_cache_in_text_config_blocks(tmp_path):
+    m = tmp_path / "nested_null_use_cache"
+    _write_config(
+        m,
+        model_type="wrapper",
+        max_position_embeddings=4096,
+        text_config={"model_type": "qwen2", "use_cache": None},
+    )
+
+    reason = cli._detect_incompatible_model_config(str(m))
+
+    assert reason is not None
+    assert "text_config.use_cache" in reason
+
+
 def test_detect_rope_with_maxpos_ok(tmp_path):
     m = tmp_path / "rope_ok"
     _write_config(
@@ -297,6 +343,38 @@ def test_detect_pure_nested_ministral3_blocked(tmp_path):
     )
     reason = cli._detect_incompatible_model_config(str(m))
     assert reason is not None and "ministral3" in reason
+
+
+def test_detect_nested_qwen3_5_moe_text_unrecognized_blocked(tmp_path):
+    # Qwen3.6 wrapper exposes text_config.model_type=qwen3_5_moe_text; vLLM/
+    # Transformers rejects that nested type during ModelConfig validation.
+    m = tmp_path / "wrapper_nested_qwen3_5_moe_text"
+    _write_config(
+        m,
+        model_type="qwen3_5_moe",
+        architectures=["Qwen3_5MoeForConditionalGeneration"],
+        text_config={
+            "model_type": "qwen3_5_moe_text",
+            "max_position_embeddings": 262144,
+            "vocab_size": 151936,
+        },
+    )
+    reason = cli._detect_incompatible_model_config(str(m))
+    assert reason is not None and "qwen3_5_moe_text" in reason
+
+
+def test_detect_top_level_qwen3_5_moe_not_blocked(tmp_path):
+    # Bare top-level qwen3_5_moe remains in the text-coercible runtime path; only
+    # the nested text_config subtype has a confirmed registry failure.
+    m = tmp_path / "bare_qwen3_5_moe"
+    _write_config(
+        m,
+        model_type="qwen3_5_moe",
+        architectures=["Qwen3_5MoeForConditionalGeneration"],
+        max_position_embeddings=262144,
+        vocab_size=151936,
+    )
+    assert cli._detect_incompatible_model_config(str(m)) is None
 
 
 def test_detect_top_level_ministral3_not_blocked(tmp_path):

--- a/inference_optimizer/tests/test_model_config_compat_preflight.py
+++ b/inference_optimizer/tests/test_model_config_compat_preflight.py
@@ -1071,6 +1071,48 @@ def test_private_quant_gguf_only_blocks(tmp_path):
     assert reason is not None and "GGUF" in reason
 
 
+def test_peft_adapter_only_checkpoint_blocks(tmp_path):
+    m = tmp_path / "adapter_only"
+    _write_config(m, model_type="qwen2", max_position_embeddings=32768)
+    (m / "adapter_config.json").write_text(
+        json.dumps({"peft_type": "LORA", "base_model_name_or_path": "Qwen/Qwen2-7B"}),
+        encoding="utf-8",
+    )
+    (m / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {
+            "base_model.model.lm_head.lora_A.default.weight": "adapter_model.safetensors",
+            "base_model.model.lm_head.lora_B.default.weight": "adapter_model.safetensors",
+            "base_model.model.layers.0.self_attn.q_proj.lora_A.default.weight": (
+                "adapter_model.safetensors"
+            ),
+        }}),
+        encoding="utf-8",
+    )
+
+    reason = cli._detect_incompatible_model_config(str(m))
+
+    assert reason is not None
+    assert "PEFT/LoRA adapter" in reason
+    assert "base_model.model.lm_head.base_layer.weight" in reason
+
+
+def test_merged_peft_like_checkpoint_with_base_weights_not_blocked(tmp_path):
+    m = tmp_path / "merged_adapter"
+    _write_config(m, model_type="qwen2", max_position_embeddings=32768)
+    (m / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {
+            "model.embed_tokens.weight": "model-00001.safetensors",
+            "lm_head.weight": "model-00001.safetensors",
+            "base_model.model.layers.0.self_attn.q_proj.lora_A.default.weight": (
+                "model-00001.safetensors"
+            ),
+        }}),
+        encoding="utf-8",
+    )
+
+    assert cli._detect_incompatible_model_config(str(m)) is None
+
+
 def test_standard_quant_fp8_not_blocked(tmp_path):
     m = tmp_path / "fp8"
     _write_config(


### PR DESCRIPTION
## Summary
1. Adds CI-side filtering for non-text-generation Diffusers/image-generation repos such as FLUX, so broad daily model pools do not submit image pipelines to Hyperloom's causal-LM benchmark path.
2. Adds runtime preflight for Diffusers model_index.json repositories that have no causal-LM config.json, preventing baseline/server health-check timeouts on non-LLM models.
3. Adds runtime preflight for strict bool config fields serialized as null, currently use_cache: null, because HF/vLLM strict config validation fails before useful work.
4. Extends nested decoder config detection to reject text_config.model_type=qwen3_5_moe_text, while keeping bare top-level qwen3_5_moe eligible until there is a direct runtime repro.
5. Adds targeted CI/runtime tests covering the new filters and the non-blocked top-level Qwen3.5 MoE case.

## Test plan
- python -m py_compile ci/model_compat.py inference_optimizer/cli_model_gate.py
- python -c "import sys, types, pytest; m=types.ModuleType('fcntl'); m.LOCK_EX=2; m.LOCK_UN=8; m.LOCK_NB=4; m.flock=lambda *a, **k: None; sys.modules['fcntl']=m; raise SystemExit(pytest.main(['ci/test_model_compat.py','inference_optimizer/tests/test_model_config_compat_preflight.py']))"

## Notes
- The direct Windows pytest command still fails during collection because this repo imports fcntl; the second command injects an in-memory shim and passes 149 targeted tests.