### PR TITLE
feat(breakdown): emit replay_warm_recipe as its own source_breakdown family

### DIFF
--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -3788,8 +3788,8 @@ def _action_family(action: str) -> str:
 
     Returns:
         str: One of ``kernel`` / ``backends`` / ``params`` / ``validate`` /
-        ``sweep`` / ``explore`` / ``framework_pr`` / ``gemm_tuning``, or
-        ``"other"`` when unrecognized.
+        ``sweep`` / ``explore`` / ``replay_warm_recipe`` / ``framework_pr`` /
+        ``gemm_tuning``, or ``"other"`` when unrecognized.
     """
     s = (action or "").lower()
     if s.startswith("kernel_opt") or s == "integrate":
@@ -3806,6 +3806,12 @@ def _action_family(action: str) -> str:
     # merged explore family subsuming the legacy backends + params buckets.
     if s == "explore":
         return "explore"
+    # REPLAY_WARM_RECIPE: warm-recipe / cortex best_config replay (a prep action).
+    # Its own headline row so its gain reconciles against validated_total_pct
+    # instead of vanishing into the non-emitted ``other`` family. The label may
+    # carry a tier suffix (``replay_warm_recipe:exact``), so match the base token.
+    if s.split(":", 1)[0] == "replay_warm_recipe":
+        return "replay_warm_recipe"
     # FRAMEWORK_PR: own headline row so per-source totals reconcile against
     # validated_total_pct (else these KEEPs fell into ``other`` and vanished).
     if s == "framework_pr":
@@ -3999,6 +4005,9 @@ def collect_attribution(
         "explore": 0.0,
         # FRAMEWORK_PR family, kept apart from ``other`` for a dedicated row.
         "framework_pr": 0.0,
+        # REPLAY_WARM_RECIPE family: warm-recipe replay, kept apart from ``other``
+        # so its gain gets a dedicated headline row.
+        "replay_warm_recipe": 0.0,
         # GEMM_TUNING family, kept apart from ``kernel`` (deterministic tuner vs rewrite).
         "gemm_tuning": 0.0,
         # PerfSkills/GEAK-e2e family: whole-pipeline KERNEL-phase optimizer.
@@ -4060,6 +4069,11 @@ def collect_attribution(
             "forge_pct_of_total": round(forge_total, 2),
             # primary row.
             "explore_pct_of_total": round(family_totals.get("explore", 0.0), 2),
+            # REPLAY_WARM_RECIPE row; always emitted (0.0 when no warm-recipe
+            # replay was reproduced/adopted this session).
+            "replay_warm_recipe_pct_of_total": round(
+                family_totals.get("replay_warm_recipe", 0.0), 2
+            ),
             # FRAMEWORK_PR row; always emitted (0.0 when disabled/empty).
             "framework_pr_pct_of_total": round(family_totals.get("framework_pr", 0.0), 2),
             # GEMM_TUNING row; always emitted (0.0 when non-FP8/skipped/no KEEP).

--- a/inference_optimizer/breakdown/reporters/_renderers/attribution.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/attribution.py
@@ -40,6 +40,7 @@ def render(breakdown: dict[str, Any]) -> RenderedSection:
     rows = [
         # explore subsumes the old backends+params split; legacy rows kept for archived reports.
         ["explore", sb.get("explore_pct_of_total"), sb.get("explore_share_pct")],
+        ["replay_warm_recipe", sb.get("replay_warm_recipe_pct_of_total"), sb.get("replay_warm_recipe_share_pct")],
         ["backends", sb.get("backends_pct_of_total"), sb.get("backends_share_pct")],
         ["params", sb.get("params_pct_of_total"), sb.get("params_share_pct")],
         ["sweep", sb.get("sweep_pct_of_total"), sb.get("sweep_share_pct")],

--- a/inference_optimizer/breakdown/reporters/cross_section.py
+++ b/inference_optimizer/breakdown/reporters/cross_section.py
@@ -122,6 +122,7 @@ def _gain_attribution_lines(
         "backends": _to_float(sb.get("backends_pct_of_total")),
         "params": _to_float(sb.get("params_pct_of_total")),
         "explore": _to_float(sb.get("explore_pct_of_total")),
+        "replay_warm_recipe": _to_float(sb.get("replay_warm_recipe_pct_of_total")),
         "geak": _to_float(sb.get("geak_pct_of_total")),
         "oob": _to_float(sb.get("oob_pct_of_total")),
         "sweep": _to_float(sb.get("sweep_pct_of_total")),

--- a/inference_optimizer/breakdown/schema.py
+++ b/inference_optimizer/breakdown/schema.py
@@ -1124,6 +1124,8 @@ class SourceBreakdown(TypedDict, total=False):
         geak_pct_of_total (float): Gain share from GEAK kernel rewrites.
         oob_pct_of_total (float): Gain share from out-of-box backends.
         explore_pct_of_total (float): Gain share from the primary explore family.
+        replay_warm_recipe_pct_of_total (float): Gain share from warm-recipe
+            replay (cortex best_config replay); 0.0 when none was adopted.
         framework_pr_pct_of_total (float): Gain share from FRAMEWORK_PR bake-ins.
         gemm_tuning_pct_of_total (float): Gain share from the FP8 GEMM tuner
             (0.0 on non-FP8 workloads or when the tuner produced no KEEP).
@@ -1137,6 +1139,10 @@ class SourceBreakdown(TypedDict, total=False):
     oob_pct_of_total: float
     # primary explore family bucket.
     explore_pct_of_total: float
+    # REPLAY_WARM_RECIPE (warm-recipe / cortex best_config replay) contribution,
+    # bucketed separately so its gain reconciles against validated_total_pct
+    # instead of vanishing into the non-emitted ``other`` family.
+    replay_warm_recipe_pct_of_total: float
     # FRAMEWORK_PR phase contribution (upstream-PR bake-ins), bucketed
     # separately so per-source totals reconcile against validated_total_pct.
     framework_pr_pct_of_total: float

--- a/inference_optimizer/tests/test_breakdown_smoke.py
+++ b/inference_optimizer/tests/test_breakdown_smoke.py
@@ -1137,6 +1137,85 @@ def test_attribution_gemm_tuning_pct_emitted_even_when_zero(
     assert sb["gemm_tuning_pct_of_total"] == 0.0
 
 
+# A1.0e: replay_warm_recipe surfaces in source_breakdown
+# Regression: replay_warm_recipe KEEPs used to fall into ``"other"`` (which is
+# never emitted), so a pure warm-recipe-replay session showed a validated_total
+# with no per-source split to back it. It now gets its own headline row.
+def test_attribution_replay_warm_recipe_surfaces_in_source_breakdown(
+    tmp_path: Path,
+) -> None:
+    """A ``replay_warm_recipe`` KEEP contributes to
+    ``replay_warm_recipe_pct_of_total`` instead of being lost to ``other``."""
+    sd = _attribution_fixture(
+        tmp_path,
+        {
+            "cumulative_gain_validated": 19.0,
+            "optimization_stack": [
+                {
+                    "action": "replay_warm_recipe",
+                    "variant_name": "warm_replay",
+                    "gain_pct": 19.0,
+                },
+            ],
+            "gain_per_stack_entry": [
+                {
+                    "action": "replay_warm_recipe",
+                    "variant_name": "warm_replay",
+                    "stack_len_before": 0,
+                    "stack_len_after": 1,
+                    "cum_gain_before": 0.0,
+                    "cum_gain_after": 19.0,
+                    "delta_pct": 19.0,
+                    "ts": "2026-06-01T11:00:00+00:00",
+                },
+            ],
+        },
+    )
+    sb = build(sd)["attribution"]["source_breakdown"]
+    assert sb["replay_warm_recipe_pct_of_total"] == pytest.approx(19.0)
+    # Per-source rows reconcile to validated_total (no "other" black-hole).
+    summed = (
+        sb["geak_pct_of_total"]
+        + sb["oob_pct_of_total"]
+        + sb["explore_pct_of_total"]
+        + sb["replay_warm_recipe_pct_of_total"]
+        + sb["sweep_pct_of_total"]
+        + sb["framework_pr_pct_of_total"]
+        + sb["gemm_tuning_pct_of_total"]
+    )
+    assert summed == pytest.approx(sb["validated_total_pct"], abs=0.05)
+
+
+def test_attribution_replay_warm_recipe_pct_emitted_even_when_zero(
+    tmp_path: Path,
+) -> None:
+    """Always emit ``replay_warm_recipe_pct_of_total`` (default 0.0)."""
+    sd = _attribution_fixture(
+        tmp_path,
+        {
+            "cumulative_gain_validated": 5.0,
+            "optimization_stack": [
+                {"action": "params", "variant_name": "p1", "gain_pct": 5.0},
+            ],
+            "gain_per_stack_entry": [
+                {
+                    "action": "params",
+                    "variant_name": "p1",
+                    "stack_len_before": 0,
+                    "stack_len_after": 1,
+                    "cum_gain_before": 0.0,
+                    "cum_gain_after": 5.0,
+                    "delta_pct": 5.0,
+                    "ts": "2026-06-01T11:00:00+00:00",
+                },
+            ],
+        },
+    )
+    sb = build(sd)["attribution"]["source_breakdown"]
+    assert "replay_warm_recipe_pct_of_total" in sb
+    assert sb["replay_warm_recipe_pct_of_total"] == 0.0
+
+
 def test_attribution_phase_breakdown_gemm_tuning_by_tuned_file(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- `replay_warm_recipe` gain was bucketed into the non-emitted `other` family in `collect_attribution`, so a pure warm-recipe-replay session reported a `validated_total_pct` with **no per-source row to back it** — the gain silently vanished from `source_breakdown` (per-source rows no longer reconcile against the validated total).
- Map the action to its own `replay_warm_recipe` family and emit `replay_warm_recipe_pct_of_total`, so per-source rows reconcile against `validated_total_pct` again.
- Surface the new row in the attribution renderer, the cross-section reporter, and the `SourceBreakdown` schema.

## Why
On the leaderboard, replay is in fact the dominant gain source (most sessions are replay-dominated), but it was invisible in "gain share by source" because it had no `*_pct_of_total` key. This makes warm-recipe replay a first-class source at the collection layer. New sessions get the key directly; the Pulse console already backfills historical rows from the gain ledger (separate change on `pulse-internal` main).

## Test plan
- [x] `test_breakdown_smoke.py` — added `test_attribution_replay_warm_recipe_surfaces_in_source_breakdown` (per-source rows reconcile to `validated_total_pct`) and `test_attribution_replay_warm_recipe_pct_emitted_even_when_zero`.
- [x] Full breakdown + reporter + warm-replay suites pass (164 tests).

Made with [Cursor](https://cursor.com)