### PR TITLE
feat(breakdown): surface model_info in session_breakdown.json

### DIFF
--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -958,6 +958,32 @@ def collect_workload(
     }
 
 
+# §2b Model basics
+def collect_model_info(
+    state: dict[str, Any],
+    warnings: list[str],
+) -> dict[str, Any]:
+    """Collect the §2b ``model_info`` section (state.model_info passthrough).
+
+    The summary is computed once at launch (``cli_bootstrap`` →
+    ``summarize_model_config``) and persisted on ``state.model_info``, so the
+    breakdown just mirrors it verbatim. Returns ``{}`` when the field is absent
+    (sessions whose state predates it) or empty (non-transformers models such
+    as diffusion checkpoints, where the config.json could not be parsed); the
+    frontend treats an empty object as "model info unavailable".
+
+    Args:
+        state (dict[str, Any]): Parsed ``state.json``.
+        warnings (list[str]): Shared warnings list (unused here but kept for a
+            uniform collector signature).
+
+    Returns:
+        dict[str, Any]: The model_info object, or ``{}`` when unavailable.
+    """
+    info = state.get("model_info")
+    return dict(info) if isinstance(info, dict) else {}
+
+
 # §3 Baseline
 def collect_baseline(
     session_dir: Path,
@@ -6643,4 +6669,5 @@ __all__ = [
     "collect_telemetry",
     "collect_token_usage",
     "collect_workload",
+    "collect_model_info",
 ]

--- a/inference_optimizer/breakdown/exporter.py
+++ b/inference_optimizer/breakdown/exporter.py
@@ -287,6 +287,12 @@ def build(
     workload = _pick(
         "workload", _safe_collect("workload", lambda: collectors.collect_workload(state, manifest, warnings), warnings)
     )
+    # §2b model basics — verbatim mirror of ``state.model_info`` (computed once
+    # at launch). Empty {} on non-transformers models / pre-field sessions.
+    model_info = _pick(
+        "model_info",
+        _safe_collect("model_info", lambda: collectors.collect_model_info(state, warnings), warnings, default={}),
+    )
     baseline = _pick(
         "baseline", _safe_collect("baseline", lambda: collectors.collect_baseline(sd, state, warnings), warnings)
     )
@@ -554,6 +560,9 @@ def build(
         # §1b enrichment; always present from the exporter (no longer CI-only).
         "session_meta": session_meta,
         "workload": workload,
+        # §2b structural model summary (state.model_info mirror). Additive
+        # optional; empty {} on non-transformers models / pre-field sessions.
+        "model_info": model_info,
         "baseline": baseline,
         "final": final,
         "phase_timeline": phase_timeline,

--- a/inference_optimizer/breakdown/schema.py
+++ b/inference_optimizer/breakdown/schema.py
@@ -125,6 +125,63 @@ class Workload(TypedDict, total=False):
     objective: WorkloadObjective
 
 
+# §2b Model basics — architecture/scale summary parsed from the served model's
+# ``config.json`` (see ``model_config_utils.summarize_model_config``). Empty
+# ``{}`` on non-transformers models (e.g. diffusion) and on sessions whose
+# state predates the field. Mirrored verbatim from ``state.model_info``.
+class ModelInfo(TypedDict, total=False):
+    """Structural summary of the served model (architecture / scale / attention).
+
+    Best-effort parse of the model's ``config.json``; every field is
+    optional-by-convention so consumers must null-check. ``{}`` when the model
+    is not a transformers checkpoint (diffusion etc.) or the session predates
+    the field.
+
+    Attributes:
+        model_family (str): Base family with generation (``llama3`` / ``qwen3`` /
+            ``deepseek_v3``).
+        model_type (str): HuggingFace ``model_type`` (``qwen2`` / ``llama``).
+        architectures (list[str]): Architecture class names
+            (``["Qwen3ForCausalLM"]``).
+        attention_type (str): Inferred attention variant (``MHA`` / ``GQA`` /
+            ``MQA`` / ``MLA``).
+        is_moe (bool): Whether the model is a Mixture-of-Experts model.
+        num_hidden_layers (int): Number of transformer layers.
+        hidden_size (int): Model hidden dimension.
+        intermediate_size (int): FFN intermediate dimension.
+        num_attention_heads (int): Number of attention heads.
+        num_key_value_heads (int): Number of KV heads (GQA groups).
+        head_dim (int): Per-head dimension.
+        max_position_embeddings (int): Native context length.
+        vocab_size (int): Vocabulary size.
+        torch_dtype (str): Declared weight dtype (``bfloat16`` / ...).
+        kv_cache_dtype (str): KV cache dtype when declared.
+        quantization (str): Weight quant method (``fp8`` / ...); '' when
+            unquantized.
+        num_experts (int): Expert count (MoE only).
+        num_experts_per_tok (int): Activated experts per token (MoE only).
+    """
+
+    model_family: str
+    model_type: str
+    architectures: list[str]
+    attention_type: str
+    is_moe: bool
+    num_hidden_layers: int
+    hidden_size: int
+    intermediate_size: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int
+    max_position_embeddings: int
+    vocab_size: int
+    torch_dtype: str
+    kv_cache_dtype: str
+    quantization: str
+    num_experts: int
+    num_experts_per_tok: int
+
+
 # §3 Baseline
 class BaselineAttemptSummary(TypedDict, total=False):
     """One recorded attempt to establish the baseline measurement.
@@ -1984,6 +2041,9 @@ class SessionBreakdown(TypedDict, total=False):
         exporter_version (str): Version of the exporter that produced the file.
         session (SessionMeta): Session identity, timing, and host context.
         workload (Workload): Model/framework/serving configuration.
+        model_info (ModelInfo): Structural summary of the served model
+            (architecture / scale / attention), parsed from its config.json.
+            Empty {} on non-transformers models or pre-field sessions.
         baseline (Baseline): Pre-optimization reference performance.
         final (Final): Final validated optimization state.
         phase_timeline (list[PhaseEvent]): Flat per-action timeline (v1-reader compat).
@@ -2022,6 +2082,11 @@ class SessionBreakdown(TypedDict, total=False):
 
     session: SessionMeta
     workload: Workload
+    # Structural model summary parsed from config.json (state.model_info
+    # mirror). Additive optional section: empty {} on non-transformers models
+    # (diffusion etc.) and on sessions whose state predates the field, so
+    # v1/v2 readers that don't know it simply ignore it.
+    model_info: ModelInfo
     baseline: Baseline
     final: Final
     # flat per-action timeline (v1 compat); ``phase_segments`` is the boundary view.
@@ -2125,6 +2190,7 @@ __all__ = [
     "LangfuseConfig",
     "LangfusePush",
     "LangfusePushCounts",
+    "ModelInfo",
     "Final",
     "GpuMonitorAggregate",
     "Invocation",


### PR DESCRIPTION
## Summary
- Adds a new top-level `model_info` section to `session_breakdown.json`, mirroring `state.model_info` (the architecture / scale / attention summary parsed from the served model's `config.json` at launch).
- Lets downstream consumers display model basics (family, attention type, dense/MoE, layers, hidden size, context length, etc.) without re-reading `state.json`.

## Changes
- `breakdown/schema.py`: new `ModelInfo` TypedDict (§2b) + `model_info` field on `SessionBreakdown` (added to `__all__`).
- `breakdown/collectors.py`: new `collect_model_info(state, warnings)` — verbatim `state.model_info` passthrough; returns `{}` when the field is absent or empty.
- `breakdown/exporter.py`: wires `model_info` into the assembled breakdown dict (after `workload`).

## Behavior / compatibility
- Additive + optional. Empty `{}` on:
  - non-transformers models (e.g. diffusion / FLUX where `config.json` can't be parsed), and
  - sessions whose `state.json` predates the `model_info` field.
- v1/v2 readers that don't know the field simply ignore it; historical breakdowns are otherwise unchanged.
- No pulse-side changes needed: the pulse detail API already passes `raw_data` through wholesale, so new sessions surface `data.model_info` automatically.

## Test plan
- [x] Existing `test_breakdown_exporter_unit.py` + `test_breakdown_smoke.py` — 125 passed.
- [x] End-to-end smoke `exporter.build` on temp sessions:
  - GQA model → full `model_info` emitted at top level.
  - empty `model_info` (`{}`) → passes through as `{}` (diffusion-style fallback).
  - legacy session (no `model_info` key) → `{}`.

Made with [Cursor](https://cursor.com)