### PR TITLE
fix(kernel-agent): default GEAK model to claude-opus-4-8

### DIFF
--- a/kernel-agent/scripts/install.sh
+++ b/kernel-agent/scripts/install.sh
@@ -170,7 +170,7 @@ GEAK_CONFIG="${GEAK_CONFIG:-${HYPERLOOM_RUNTIME_DIR}/geak-config/local.yaml}"
 # Anthropic /v1/messages transformer.  Without this, GEAK gets
 # Primus.00009 / NotFound on the same key+URL that works through
 # /chat/completions.
-GEAK_MODEL_NAME_RAW="${GEAK_MODEL_NAME:-claude-opus-4-7}"
+GEAK_MODEL_NAME_RAW="${GEAK_MODEL_NAME:-claude-opus-4-8}"
 case "${GEAK_MODEL_NAME_RAW}" in
   openai/*|anthropic/*|gpt-*|o1-*|o3-*|o4-*)
     GEAK_MODEL_NAME_VAL="${GEAK_MODEL_NAME_RAW}"


### PR DESCRIPTION
## Summary

- Bumps the GEAK default model id from `claude-opus-4-7` to `claude-opus-4-8` in `kernel-agent/scripts/install.sh`.
- The Primus-Safe / VertexGenAI proxy no longer serves `claude-opus-4-7` (live deployment is `claude-opus-4-8@default`); GEAK runs were failing instantly with an upstream `BadRequest` / `INVALID_ARGUMENT` and producing no patch.
- One-line change. The `GEAK_MODEL_NAME` env override is unchanged for operators who need a different id.

Closes #698

## Test plan

- [ ] Run one GEAK kernel-optimization with the new default and confirm the `400 BadRequest (Received Model Group=claude-opus-4-7)` no longer occurs.
- [ ] Confirm the generated `$GEAK_CONFIG` `local.yaml` shows `model_name: openai/claude-opus-4-8`.

## Out of scope

`claude-opus-4-7` remains the default in ~15 other places across the repo (framework-agent, quantization_agent, robustness-agent, inference_optimizer, `_meta/*.yaml`). If 4.7 is deprecated proxy-side those will break too; tracked separately, not part of this minimal fix.