### PR TITLE
fix(ci): keep optimize-submit workflow_dispatch under GitHub's 25-inp…

### DIFF
--- a/.github/workflows/optimize-gte100.yml
+++ b/.github/workflows/optimize-gte100.yml
@@ -113,11 +113,12 @@ jobs:
                   "exclude_active_workflows": "false",
                   "max_parallel": os.environ["MAX_PARALLEL"],
                   "submit_workspaces": os.environ["SUBMIT_WORKSPACES"],
-                  # max_hours=12h optimizer budget. wait timeout 780 (=13h) and
-                  # GitHub job timeout 840 (=14h) both sit above 12h so neither
-                  # the wait loop nor the job is killed before the optimizer ends.
+                  # max_hours=12h optimizer budget; wait timeout 780 (=13h) sits
+                  # above it. The GitHub job timeout is derived in optimize-submit
+                  # from max_hours (12*60+120 = 840m = 14h), so no separate
+                  # job_timeout_min input is needed (GitHub caps dispatch inputs
+                  # at 25).
                   "task_timeout_min": "780",
-                  "job_timeout_min": "840",
                   "max_hours": os.environ["MAX_HOURS"],
                   "all_artifacts": "true",
                   "dry_run": os.environ.get("DRY_RUN") or "false",

--- a/.github/workflows/optimize-gte100.yml
+++ b/.github/workflows/optimize-gte100.yml
@@ -113,12 +113,11 @@ jobs:
                   "exclude_active_workflows": "false",
                   "max_parallel": os.environ["MAX_PARALLEL"],
                   "submit_workspaces": os.environ["SUBMIT_WORKSPACES"],
-                  # max_hours=12h optimizer budget; wait timeout 780 (=13h) sits
-                  # above it. The GitHub job timeout is derived in optimize-submit
-                  # from max_hours (12*60+120 = 840m = 14h), so no separate
-                  # job_timeout_min input is needed (GitHub caps dispatch inputs
-                  # at 25).
-                  "task_timeout_min": "780",
+                  # max_hours=12h optimizer budget. optimize-submit derives the
+                  # per-task wait timeout (12h+30m = 750m) and the GitHub job
+                  # timeout (12h+60m = 780m) from max_hours in its prepare job,
+                  # so no task_timeout_min/job_timeout_min inputs are sent (GitHub
+                  # caps dispatch inputs at 25).
                   "max_hours": os.environ["MAX_HOURS"],
                   "all_artifacts": "true",
                   "dry_run": os.environ.get("DRY_RUN") or "false",

--- a/.github/workflows/optimize-submit.yml
+++ b/.github/workflows/optimize-submit.yml
@@ -183,10 +183,6 @@ on:
         description: 'Per-task wait timeout in minutes (default 420 = 7h)'
         required: false
         default: '420'
-      job_timeout_min:
-        description: 'GitHub job timeout in minutes for each optimize job (default 480 = 8h). Raise it when callers pass a larger max_hours so the wait/collect job is not killed mid-run.'
-        required: false
-        default: '480'
       max_hours:
         description: 'Per-task optimizer budget in hours (default 6)'
         required: false
@@ -262,11 +258,13 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.count != '0'
     runs-on: hyperloom-4hhzn
-    # Per-task wait timeout + buffer for register/wait/collect. Caller-tunable
-    # via the job_timeout_min input (default 480 = 8h); raise it when passing a
-    # larger max_hours so the wait/collect job is not killed mid-run. schedule
-    # has no inputs, so it falls back to the 480 default.
-    timeout-minutes: ${{ fromJson(github.event.inputs.job_timeout_min || '480') }}
+    # Per-task wait timeout + buffer for register/wait/collect. Tied to max_hours
+    # WITHOUT adding a workflow_dispatch input (GitHub caps inputs at 25) and
+    # WITHOUT arithmetic (unsupported in Actions expressions): long runs
+    # (max_hours>=12, e.g. the gte100 pool) get 840m (14h); everything else
+    # (schedule/6h and default) keeps the previous 480m (8h). schedule has no
+    # inputs so max_hours falls back to 6 -> 480.
+    timeout-minutes: ${{ fromJson(github.event.inputs.max_hours || '6') >= 12 && 840 || 480 }}
     strategy:
       fail-fast: false
       max-parallel: ${{ fromJson(github.event_name == 'schedule' && '240' || github.event.inputs.max_parallel || '240') }}

--- a/.github/workflows/optimize-submit.yml
+++ b/.github/workflows/optimize-submit.yml
@@ -52,6 +52,15 @@ on:
   schedule:
     - cron: '7 4,10,16,22 * * *'
   workflow_dispatch:
+    # ⚠️ HARD LIMIT: GitHub allows at most 25 top-level `inputs` for a
+    # workflow_dispatch event (raised from 10 on 2025-12-04). Exceeding it makes
+    # the workflow fail to parse, so EVERY dispatch (optimize-tiny,
+    # optimize-gte100, manual, API) returns HTTP 422 and no models are submitted.
+    # This block currently defines exactly 25 inputs — DO NOT add a 26th. To add
+    # a new knob, drop/merge an existing input first (e.g. derive it from another
+    # input as the job timeout is derived from max_hours below). Refs:
+    # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows
+    # https://github.blog/changelog/2025-12-04-actions-workflow-dispatch-workflows-now-support-25-inputs/
     inputs:
       # ── Model source (priority: models > candidates_file > legacy hf_top) ──────
       models:

--- a/.github/workflows/optimize-submit.yml
+++ b/.github/workflows/optimize-submit.yml
@@ -188,12 +188,8 @@ on:
         type: boolean
         required: false
         default: true
-      task_timeout_min:
-        description: 'Per-task wait timeout in minutes (default 420 = 7h)'
-        required: false
-        default: '420'
       max_hours:
-        description: 'Per-task optimizer budget in hours (default 6)'
+        description: 'Per-task optimizer budget in hours (default 6). The per-task wait timeout (max_hours+30m) and the GitHub job timeout (max_hours+60m) are derived from this in the prepare job.'
         required: false
         default: '6'
       all_artifacts:
@@ -220,6 +216,11 @@ jobs:
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       count:  ${{ steps.matrix.outputs.count }}
+      # Per-task wait timeout (max_hours + 30m) and GitHub job timeout
+      # (max_hours + 60m), computed here since Actions expressions can't do
+      # arithmetic. Both in minutes.
+      task_timeout: ${{ steps.jobtimeout.outputs.task_timeout }}
+      job_timeout:  ${{ steps.jobtimeout.outputs.job_timeout }}
     env:
       HF_TOKEN:              ${{ secrets.HF_TOKEN }}
       HF_TOKEN_2:            ${{ secrets.HF_TOKEN_2 }}
@@ -260,6 +261,22 @@ jobs:
         id: matrix
         working-directory: ci
         run: python3 generate_hf_matrix.py
+      - name: Compute optimize timeouts
+        id: jobtimeout
+        # Both timeouts derive from max_hours (Actions expressions can't do
+        # arithmetic, so compute in Python). Ascending so each layer has a 30m
+        # buffer over the one below: optimizer budget (max_hours) < task wait
+        # (max_hours + 30m) < GitHub job (max_hours + 60m). schedule has no
+        # inputs -> max_hours falls back to 6 -> task=390, job=420.
+        env:
+          INPUT_MAX_HOURS: ${{ github.event.inputs.max_hours }}
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import os
+          mh = float(os.environ.get("INPUT_MAX_HOURS") or 6)
+          print(f"task_timeout={int(mh * 60 + 30)}")
+          print(f"job_timeout={int(mh * 60 + 60)}")
+          PY
 
   # ── Stage 2: per-model optimization (parallel) ──────────────────────────────
   optimize:
@@ -267,13 +284,10 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.count != '0'
     runs-on: hyperloom-4hhzn
-    # Per-task wait timeout + buffer for register/wait/collect. Tied to max_hours
-    # WITHOUT adding a workflow_dispatch input (GitHub caps inputs at 25) and
-    # WITHOUT arithmetic (unsupported in Actions expressions): long runs
-    # (max_hours>=12, e.g. the gte100 pool) get 840m (14h); everything else
-    # (schedule/6h and default) keeps the previous 480m (8h). schedule has no
-    # inputs so max_hours falls back to 6 -> 480.
-    timeout-minutes: ${{ fromJson(github.event.inputs.max_hours || '6') >= 12 && 840 || 480 }}
+    # GitHub job timeout = max_hours + 1h (computed in the prepare job since
+    # Actions expressions can't do arithmetic). Covers register + wait + collect
+    # for the per-task optimizer budget. schedule/6h -> 420m; gte100/12h -> 780m.
+    timeout-minutes: ${{ fromJson(needs.prepare.outputs.job_timeout) }}
     strategy:
       fail-fast: false
       max-parallel: ${{ fromJson(github.event_name == 'schedule' && '240' || github.event.inputs.max_parallel || '240') }}
@@ -344,7 +358,7 @@ jobs:
           SAFE_OPTIMIZE_SUBMIT_WORKSPACES: ${{ github.event_name == 'schedule' && 'core42-hyperloom' || github.event.inputs.submit_workspaces || 'core42-hyperloom' }}
           INPUT_WAIT:             ${{ github.event.inputs.wait_for_completion }}
           INPUT_COLLECT:          ${{ github.event.inputs.collect_artifacts }}
-          INPUT_TASK_TIMEOUT_MIN: ${{ github.event.inputs.task_timeout_min }}
+          INPUT_TASK_TIMEOUT_MIN: ${{ needs.prepare.outputs.task_timeout }}
           INPUT_MAX_HOURS:        ${{ github.event.inputs.max_hours }}
           # Cron rotates through the production pool — operators can't go
           # back and re-fetch sandbox state after the fact, so force

--- a/.github/workflows/optimize-tiny.yml
+++ b/.github/workflows/optimize-tiny.yml
@@ -132,7 +132,8 @@ jobs:
                   "exclude_active_workflows": "true",
                   "max_parallel": "240",
                   "submit_workspaces": os.environ["SUBMIT_WORKSPACES"],
-                  "task_timeout_min": "420",
+                  # task wait + job timeout are derived from max_hours in
+                  # optimize-submit's prepare job (max_hours+30m / +60m).
                   "max_hours": "6",
                   "all_artifacts": "true",
                   "dry_run": os.environ.get("DRY_RUN") or "false",


### PR DESCRIPTION
…ut cap

Adding the job_timeout_min input pushed optimize-submit to 26 workflow_dispatch inputs, exceeding GitHub's hard limit of 25. The workflow then failed to parse, so every dispatch (optimize-tiny, optimize-gte100, manual) returned HTTP 422 and no models were submitted via those paths.

Drop the job_timeout_min input and derive the optimize job timeout from the existing max_hours input instead (max_hours>=12 -> 840m, else 480m; no arithmetic since Actions expressions don't support it). Remove job_timeout_min from the optimize-gte100 dispatch payload accordingly.

- Description: what and why
- Linked issue(s): close/fix refs
- Tests: added/updated? commands run?
- Breaking changes: yes/no (details if yes)
