### PR TITLE
Modified op source paths for vLLM v21 and SGLang 0.5.12

### DIFF
--- a/kernel-agent/tools/data/op_to_source.json
+++ b/kernel-agent/tools/data/op_to_source.json
@@ -113,18 +113,17 @@
     "patchable": true,
     "vllm": {
       "void vllm::moe::moe_align_block_size_kernel<int>(int const*, int*, int*, int*, int*, int, int, int, int, unsigned long, ": {
-        "kernel_source_path": "",
-        "kernel_source_line": "",
-        "kernel_kind": "vllm_hip",
-        "patchable": true,
-        "note": "vLLM csrc is still not shipped in the container, not editable inside the container."
+        "kernel_source_path": "/usr/local/lib/python3.12/dist-packages/aiter_meta/csrc/kernels/moe_align_block_size_kernels.cu",
+        "kernel_source_line": "39",
+        "kernel_kind": "aiter_hip",
+        "patchable": true
       },
       "void vllm::moe::count_and_sort_expert_tokens_kernel<int>(int const*, int*, int*, int*, unsigned long, int, int, int, boo": {
         "kernel_source_path": "",
         "kernel_source_line": "",
         "kernel_kind": "vllm_hip",
-        "patchable": true,
-        "note": "vLLM csrc is still not shipped in the container, not editable inside the container."
+        "patchable": false,
+        "note": "Source not shipped in vLLM 0.21.0 aiter_meta/csrc (only compiled into _moe_C.abi3.so); not editable inside the container."
       }
     },
     "sglang": {}
@@ -362,8 +361,8 @@
     "patchable": true,
     "vllm": {
       "vllm::initializeScale(float*, int, float) [clone .kd]": {
-        "kernel_source_path": "/usr/local/lib/python3.12/dist-packages/aiter_meta/csrc/include/quant_common.cuh",
-        "kernel_source_line": "56",
+        "kernel_source_path": "/usr/local/lib/python3.12/dist-packages/aiter_meta/csrc/kernels/quant_kernels.cu",
+        "kernel_source_line": "135",
         "kernel_kind": "aiter_hip",
         "patchable": true
       },


### PR DESCRIPTION

- Description: what and why: This pull request updates the `op_to_source.json` mapping to improve accuracy and reflect the current state of shipped source files for vLLM and aiter_meta kernels. The main changes involve correcting source file paths, line numbers, and patchability information for specific kernels.

- Linked issue(s): close/fix refs: NA
- Tests: Not needed
- Breaking changes: No, just modifies the kernel source paths passed to GEAK
