### PR TITLE
fix(proposal-scorer): stream LLM calls to satisfy Primus-Safe proxy

### DIFF
--- a/inference_optimizer/orchestrator/proposal_scorer.py
+++ b/inference_optimizer/orchestrator/proposal_scorer.py
@@ -311,29 +311,37 @@ class ProposalScorer:
         full_prompt = f"{prompt}\n\n{_SCORING_INSTRUCTIONS}"
         messages = [{"role": "user", "content": full_prompt}]
         _t0 = time.perf_counter()
+
         # The Primus-Safe/Vertex proxy rejects non-streaming predictions with an
         # opaque 400 INVALID_ARGUMENT; only streamed requests are accepted. Stream
         # and accumulate the deltas, pulling usage from the final chunk.
-        text_parts: list[str] = []
-        usage = None
-        try:
-            stream = await asyncio.wait_for(
-                client.chat.completions.create(
-                    model=model,
-                    messages=messages,
-                    max_completion_tokens=self.max_completion_tokens,
-                    stream=True,
-                    stream_options={"include_usage": True},
-                ),
-                timeout=self.call_timeout_s,
+        #
+        # The deadline must cover BOTH stream creation and the chunk-consumption
+        # loop: a proxy can establish the stream and then stall mid-body, so a
+        # timeout around creation alone would let this hang indefinitely. We wrap
+        # the whole read in a single ``asyncio.wait_for`` (``asyncio.timeout`` is
+        # 3.11+, and this project still targets 3.10).
+        async def _read_stream() -> tuple[list[str], Any]:
+            parts: list[str] = []
+            usage_obj = None
+            stream = await client.chat.completions.create(
+                model=model,
+                messages=messages,
+                max_completion_tokens=self.max_completion_tokens,
+                stream=True,
+                stream_options={"include_usage": True},
             )
             async for chunk in stream:
                 if getattr(chunk, "usage", None) is not None:
-                    usage = chunk.usage
+                    usage_obj = chunk.usage
                 if chunk.choices:
                     delta = chunk.choices[0].delta
                     if delta is not None and delta.content:
-                        text_parts.append(delta.content)
+                        parts.append(delta.content)
+            return parts, usage_obj
+
+        try:
+            text_parts, usage = await asyncio.wait_for(_read_stream(), timeout=self.call_timeout_s)
         except asyncio.TimeoutError as exc:
             raise RuntimeError(f"timed out after {self.call_timeout_s:.0f}s") from exc
         latency_ms = int((time.perf_counter() - _t0) * 1000)
@@ -351,7 +359,12 @@ class ProposalScorer:
         # Persist the full (redacted) prompt + reply so the
         # scorer's conversation lines up with its token row.
         self._record_scorer_conversation(
-            model, full_prompt, text, task_id=task_id, tick=tick, phase=phase,
+            model,
+            full_prompt,
+            text,
+            task_id=task_id,
+            tick=tick,
+            phase=phase,
         )
         parsed = _extract_scores_json(text)
         if parsed is None:
@@ -359,9 +372,14 @@ class ProposalScorer:
         return _normalise_model_scores(parsed, proposal_names=proposal_names)
 
     def _trace_scorer_llm_call(
-        self, model: str, usage: Any, *,
-        latency_ms: int | None = None, task_id: str | None = None,
-        tick: int | None = None, phase: str | None = None,
+        self,
+        model: str,
+        usage: Any,
+        *,
+        latency_ms: int | None = None,
+        task_id: str | None = None,
+        tick: int | None = None,
+        phase: str | None = None,
     ) -> None:
         """Append one ``llm_calls.jsonl`` row for a proposal-scoring call.
 

--- a/inference_optimizer/orchestrator/proposal_scorer.py
+++ b/inference_optimizer/orchestrator/proposal_scorer.py
@@ -311,15 +311,29 @@ class ProposalScorer:
         full_prompt = f"{prompt}\n\n{_SCORING_INSTRUCTIONS}"
         messages = [{"role": "user", "content": full_prompt}]
         _t0 = time.perf_counter()
+        # The Primus-Safe/Vertex proxy rejects non-streaming predictions with an
+        # opaque 400 INVALID_ARGUMENT; only streamed requests are accepted. Stream
+        # and accumulate the deltas, pulling usage from the final chunk.
+        text_parts: list[str] = []
+        usage = None
         try:
-            resp = await asyncio.wait_for(
+            stream = await asyncio.wait_for(
                 client.chat.completions.create(
                     model=model,
                     messages=messages,
                     max_completion_tokens=self.max_completion_tokens,
+                    stream=True,
+                    stream_options={"include_usage": True},
                 ),
                 timeout=self.call_timeout_s,
             )
+            async for chunk in stream:
+                if getattr(chunk, "usage", None) is not None:
+                    usage = chunk.usage
+                if chunk.choices:
+                    delta = chunk.choices[0].delta
+                    if delta is not None and delta.content:
+                        text_parts.append(delta.content)
         except asyncio.TimeoutError as exc:
             raise RuntimeError(f"timed out after {self.call_timeout_s:.0f}s") from exc
         latency_ms = int((time.perf_counter() - _t0) * 1000)
@@ -327,13 +341,13 @@ class ProposalScorer:
         # no-op when ``session_dir`` is unset).
         self._trace_scorer_llm_call(
             model,
-            getattr(resp, "usage", None),
+            usage,
             latency_ms=latency_ms,
             task_id=task_id,
             tick=tick,
             phase=phase,
         )
-        text = resp.choices[0].message.content or ""
+        text = "".join(text_parts)
         # Persist the full (redacted) prompt + reply so the
         # scorer's conversation lines up with its token row.
         self._record_scorer_conversation(

--- a/inference_optimizer/tests/test_proposal_scorer.py
+++ b/inference_optimizer/tests/test_proposal_scorer.py
@@ -32,19 +32,40 @@ class _FakeUsage:
 
 
 @dataclass
-class _FakeMessage:
-    content: str
+class _FakeDelta:
+    content: str | None
 
 
 @dataclass
-class _FakeChoice:
-    message: _FakeMessage
+class _FakeStreamChoice:
+    delta: _FakeDelta
 
 
 @dataclass
-class _FakeResp:
-    choices: list[_FakeChoice]
+class _FakeChunk:
+    choices: list[_FakeStreamChoice]
     usage: _FakeUsage | None = None
+
+
+class _FakeStream:
+    """Async iterator emulating an OpenAI streaming response: content deltas
+    followed by a final usage-only chunk (``include_usage``)."""
+
+    def __init__(self, text: str, usage: _FakeUsage):
+        self._chunks = [
+            _FakeChunk(choices=[_FakeStreamChoice(_FakeDelta(text))]),
+            _FakeChunk(choices=[], usage=usage),
+        ]
+
+    def __aiter__(self):
+        self._it = iter(self._chunks)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._it)
+        except StopIteration:
+            raise StopAsyncIteration
 
 
 class _FakeCompletions:
@@ -54,14 +75,15 @@ class _FakeCompletions:
         self._behaviour = behaviour
         self.calls: list[dict[str, Any]] = []
 
-    async def create(self, *, model: str, messages, max_completion_tokens):
-        self.calls.append({"model": model, "messages": messages})
+    async def create(self, *, model: str, messages, max_completion_tokens,
+                     stream=False, stream_options=None):
+        self.calls.append({"model": model, "messages": messages, "stream": stream})
         result = self._behaviour.get(model)
         if isinstance(result, BaseException):
             raise result
-        return _FakeResp(
-            choices=[_FakeChoice(_FakeMessage(result or ""))],
-            usage=_FakeUsage(prompt_tokens=120, completion_tokens=30),
+        return _FakeStream(
+            result or "",
+            _FakeUsage(prompt_tokens=120, completion_tokens=30),
         )
 
 

--- a/inference_optimizer/tests/test_proposal_scorer.py
+++ b/inference_optimizer/tests/test_proposal_scorer.py
@@ -4,9 +4,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -75,8 +77,7 @@ class _FakeCompletions:
         self._behaviour = behaviour
         self.calls: list[dict[str, Any]] = []
 
-    async def create(self, *, model: str, messages, max_completion_tokens,
-                     stream=False, stream_options=None):
+    async def create(self, *, model: str, messages, max_completion_tokens, stream=False, stream_options=None):
         self.calls.append({"model": model, "messages": messages, "stream": stream})
         result = self._behaviour.get(model)
         if isinstance(result, BaseException):
@@ -548,4 +549,109 @@ async def test_resume_idempotent_on_round_id(tmp_path):
             source=f"{SPECIALIST_FROM_AGENT_PREFIX}t1",
         )
     assert len(c.shared_state.specialist_rounds) == 1
-    assert "ensemble_scores" in c.shared_state.specialist_rounds[0]
+
+
+# ---------------------------------------------------------------------------
+# Streaming behaviour: the Primus-Safe proxy requires stream=True, and the
+# per-call deadline must cover the full stream body (not just creation).
+# ---------------------------------------------------------------------------
+
+
+class _ScriptedStream:
+    """Async iterator yielding a caller-supplied list of chunks. If
+    ``stall`` is set, it hangs forever after the scripted chunks instead of
+    stopping — emulating a proxy that opens the stream then stalls mid-body."""
+
+    def __init__(self, chunks: list[Any], *, stall: bool = False):
+        self._chunks = chunks
+        self._stall = stall
+
+    def __aiter__(self):
+        self._it = iter(self._chunks)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._it)
+        except StopIteration:
+            if self._stall:
+                await asyncio.sleep(3600)  # never completes within the deadline
+            raise StopAsyncIteration
+
+
+class _ScriptedCompletions:
+    def __init__(self, chunks: list[Any], *, stall: bool = False):
+        self._chunks = chunks
+        self._stall = stall
+        self.calls: list[dict[str, Any]] = []
+
+    async def create(self, *, model, messages, max_completion_tokens, stream=False, stream_options=None):
+        self.calls.append({"stream": stream, "stream_options": stream_options})
+        return _ScriptedStream(self._chunks, stall=self._stall)
+
+
+class _ScriptedClient:
+    def __init__(self, chunks: list[Any], *, stall: bool = False):
+        self.chat = SimpleNamespace(completions=_ScriptedCompletions(chunks, stall=stall))
+
+
+def _content_chunk(text: str) -> _FakeChunk:
+    return _FakeChunk(choices=[_FakeStreamChoice(_FakeDelta(text))])
+
+
+def _usage_chunk(usage: _FakeUsage) -> _FakeChunk:
+    return _FakeChunk(choices=[], usage=usage)
+
+
+def _scripted_scorer(chunks: list[Any], *, stall: bool = False, call_timeout_s: float = 30.0):
+    client = _ScriptedClient(chunks, stall=stall)
+    return ProposalScorer(
+        models=("m",),
+        client_factory=lambda: client,
+        call_timeout_s=call_timeout_s,
+    ), client
+
+
+@pytest.mark.asyncio
+async def test_stream_flag_is_passed():
+    chunks = [_content_chunk(_scores_json(("p", 5, "ok"))), _usage_chunk(_FakeUsage(10, 20))]
+    scorer, client = _scripted_scorer(chunks)
+    await scorer._score_one_model("m", "prompt", ["p"])
+    call = client.chat.completions.calls[0]
+    assert call["stream"] is True
+    assert call["stream_options"] == {"include_usage": True}
+
+
+@pytest.mark.asyncio
+async def test_multiple_content_chunks_are_accumulated():
+    # Split a valid scores JSON across several content deltas.
+    body = _scores_json(("p", 7, "good"))
+    third = len(body) // 3
+    chunks = [
+        _content_chunk(body[:third]),
+        _content_chunk(body[third : 2 * third]),
+        _content_chunk(body[2 * third :]),
+        _usage_chunk(_FakeUsage(11, 22)),
+    ]
+    scorer, _ = _scripted_scorer(chunks)
+    out = await scorer._score_one_model("m", "prompt", ["p"])
+    assert out["p"]["score"] == 7.0
+
+
+@pytest.mark.asyncio
+async def test_stalled_stream_body_times_out():
+    # One content chunk, then the stream stalls forever: the deadline must
+    # cover the consumption loop, not just stream creation.
+    chunks = [_content_chunk('{"scores": {')]
+    scorer, _ = _scripted_scorer(chunks, stall=True, call_timeout_s=0.05)
+    with pytest.raises(RuntimeError, match="timed out"):
+        await scorer._score_one_model("m", "prompt", ["p"])
+
+
+@pytest.mark.asyncio
+async def test_missing_usage_chunk_degrades_cleanly():
+    # No usage-bearing chunk at all: scoring still succeeds.
+    chunks = [_content_chunk(_scores_json(("p", 4, "fine")))]
+    scorer, _ = _scripted_scorer(chunks)
+    out = await scorer._score_one_model("m", "prompt", ["p"])
+    assert out["p"]["score"] == 4.0

--- a/inference_optimizer/tests/test_proposal_scorer_coverage_unit.py
+++ b/inference_optimizer/tests/test_proposal_scorer_coverage_unit.py
@@ -94,23 +94,37 @@ class _FakeCompletions:
         self._b = behaviour
         self.calls = []
 
-    async def create(self, *, model, messages, max_completion_tokens):
+    async def create(self, *, model, messages, max_completion_tokens,
+                     stream=False, stream_options=None):
         self.calls.append(model)
         r = self._b.get(model)
         if isinstance(r, BaseException):
             raise r
 
-        class _Msg:
-            content = r or ""
+        text = r or ""
+
+        class _Delta:
+            content = text
 
         class _Choice:
-            message = _Msg()
+            delta = _Delta()
 
-        class _Resp:
+        class _Chunk:
             choices = [_Choice()]
             usage = None
 
-        return _Resp()
+        class _Stream:
+            def __aiter__(self):
+                self._done = False
+                return self
+
+            async def __anext__(self):
+                if self._done:
+                    raise StopAsyncIteration
+                self._done = True
+                return _Chunk()
+
+        return _Stream()
 
 
 class _FakeClient:


### PR DESCRIPTION
## Summary

- Fixes ProposalScorer's 100% failure rate against the Primus-Safe / VertexGenAI proxy.
- The proxy rejects **non-streaming** Claude predictions with an opaque `400 BadRequest / INVALID_ARGUMENT`; only `stream:true` requests return 200. ProposalScorer's `chat.completions.create` was non-streaming, so every panel model (`claude-opus-4-8`, `Kimi-K2.6`, `gemini-3.1-pro`) failed.
- Streams the request, accumulates `delta.content`, and reads usage from the final `include_usage` chunk.

Proof-of-fix for #709. The same root cause also affects **GEAK** (litellm path), addressed separately.

## Root cause (reproduced against the live proxy)

| chat/completions variant | Result |
|---|---|
| `max_tokens=16384` / `max_completion_tokens=4096` / no cap / small cap | **400** |
| **same + `stream:true`** | **200** |
| `/v1/messages` native, non-streaming | 400 |

`stream:true` is the only field that yields 200 — independent of model id (this is why PR #699's `4-7`->`4-8` bump didn't fix it) and token cap.

## Test plan

- [x] Unit tests updated to emulate streaming responses; `test_proposal_scorer.py` + `test_proposal_scorer_coverage_unit.py` pass (32 passed).
- [x] Streaming pattern verified end-to-end against the live proxy (full text accumulated, usage captured from final chunk).
- [ ] Observe a live optimizer run and confirm `ProposalScorer: model=... failed: BadRequestError` warnings stop.

## Note

`asyncio.wait_for` now wraps stream creation rather than the full body read; the per-call timeout still applies to connect/first-chunk. Acceptable for this fix; a full-read deadline can be added later if needed.