### PR TITLE
Filter incompatible model configs before runtime

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.10"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/ci/model_compat.py
+++ b/ci/model_compat.py
@@ -152,6 +152,7 @@ def non_llm_repo(repo):
 _UNSUPPORTED_REGISTRY_BY_MT = {
     "glm_moe_dsa":  "GLM glm_moe_dsa registry not supported on AMD/ROCm",
     "deepseek_v32": "DeepSeek V3.2 (deepseek_v32) missing AMD runtime path",
+    "gemma4":       "Gemma4 is not recognized by the current vLLM/Transformers runtime",
     "rwkv6qwen2":   "RWKV6/Qwen2 hybrid architecture is not supported by sglang/vLLM",
     # Qwen3.6 MoE: this model_type appears as text_config.model_type; the new
     # arch is not in the vLLM/Transformers registry, so the baseline server
@@ -161,6 +162,10 @@ _UNSUPPORTED_REGISTRY_BY_MT = {
 _UNSUPPORTED_REGISTRY_BY_ARCH = {
     "GlmMoeDsaForCausalLM":   "GLM glm_moe_dsa registry not supported on AMD/ROCm",
     "DeepseekV32ForCausalLM": "DeepSeek V3.2 (deepseek_v32) missing AMD runtime path",
+    "Gemma4ForCausalLM":      "Gemma4 is not recognized by the current vLLM/Transformers runtime",
+    "Gemma4ForConditionalGeneration": (
+        "Gemma4 is not recognized by the current vLLM/Transformers runtime"
+    ),
     "RWKV6Qwen2ForCausalLM":  "RWKV6/Qwen2 hybrid architecture is not supported by sglang/vLLM",
 }
 
@@ -261,6 +266,11 @@ def unrunnable_reason(config, repo="", model_dir=None, whitelist=None, gpu_type=
     # 6) NVIDIA ModelOpt FP8 (no ROCm loader)
     if str(qc.get("quant_method", "")).lower() == "modelopt" or "modelopt" in blob:
         return ("modelopt_fp8", "NVIDIA ModelOpt quant, no ROCm loader")
+    if isinstance(qc, dict) and "quant_method" in qc and not str(qc.get("quant_method") or "").strip():
+        return (
+            "quant_empty_method",
+            "quantization_config.quant_method is empty; runtime cannot select a quant loader",
+        )
 
     # 7) unsupported attention backend (FlashInfer)
     attn = str(config.get("attn_implementation",
@@ -295,6 +305,26 @@ def unrunnable_reason(config, repo="", model_dir=None, whitelist=None, gpu_type=
     # 11) missing tokenizer (only when weights are present locally)
     if model_dir and has_weights(model_dir) and not has_tokenizer(model_dir):
         return ("missing_tokenizer", "weights present but no tokenizer files")
+    if model_dir and has_weights(model_dir):
+        files = _listdir(model_dir)
+        if files is not None:
+            is_llama = mt == "llama" or arch == "LlamaForCausalLM"
+            has_custom_tokenizer = bool(
+                isinstance(config.get("auto_map"), dict)
+                and config["auto_map"].get("AutoTokenizer")
+            )
+            if (
+                is_llama
+                and not has_custom_tokenizer
+                and "tokenizer.model" in files
+                and "tokenizer_config.json" not in files
+                and "tokenizer.json" not in files
+            ):
+                return (
+                    "tokenizer_metadata_gap",
+                    "Llama tokenizer.model without tokenizer_config.json/tokenizer.json "
+                    "can fail local-path tokenizer resolution",
+                )
 
     return None
 

--- a/ci/test_model_compat.py
+++ b/ci/test_model_compat.py
@@ -258,6 +258,19 @@ def test_unsupported_arch_deepseek_v32_by_model_type():
                     "quantization_config": {"quant_method": "fp8"}}) == "unsupported_arch"
 
 
+def test_unsupported_arch_gemma4_by_model_type():
+    assert _reason({"architectures": ["Gemma4ForCausalLM"],
+                    "model_type": "gemma4",
+                    "max_position_embeddings": 32768}) == "unsupported_arch"
+
+
+def test_empty_quant_method_filtered():
+    assert _reason({"architectures": ["LlamaForCausalLM"],
+                    "model_type": "llama",
+                    "max_position_embeddings": 4096,
+                    "quantization_config": {"quant_method": ""}}) == "quant_empty_method"
+
+
 def test_unsupported_arch_qwen3_5_moe_text_via_text_config():
     # Qwen3.6 MoE carries qwen3_5_moe_text as text_config.model_type; top-level
     # model_type is qwen3_5_moe. The rule must catch it via text_config.
@@ -435,6 +448,23 @@ def test_tokenizer_present_is_kept(tmp_path):
     mdir = _mk_dir(tmp_path, ["config.json", "model.safetensors", "tokenizer.json"])
     assert _reason({"architectures": ["Qwen2ForCausalLM"],
                     "max_position_embeddings": 32768}, model_dir=mdir) is None
+
+
+def test_llama_sentencepiece_without_metadata_filtered(tmp_path):
+    mdir = _mk_dir(tmp_path, ["config.json", "pytorch_model.bin", "tokenizer.model"])
+    assert _reason({"architectures": ["LlamaForCausalLM"],
+                    "model_type": "llama",
+                    "max_position_embeddings": 4096}, model_dir=mdir) == "tokenizer_metadata_gap"
+
+
+def test_llama_sentencepiece_with_tokenizer_config_kept(tmp_path):
+    mdir = _mk_dir(
+        tmp_path,
+        ["config.json", "pytorch_model.bin", "tokenizer.model", "tokenizer_config.json"],
+    )
+    assert _reason({"architectures": ["LlamaForCausalLM"],
+                    "model_type": "llama",
+                    "max_position_embeddings": 4096}, model_dir=mdir) is None
 
 
 def test_no_weights_does_not_flag_missing_tokenizer(tmp_path):

--- a/inference_optimizer/cli_model_gate.py
+++ b/inference_optimizer/cli_model_gate.py
@@ -228,12 +228,6 @@ _VERDICT_VISION_ONLY = "vision_only"
 _TEXT_COERCIBLE_MODEL_TYPES = frozenset({
     "kimi_k25",
     "qwen3_5_moe",
-    # Gemma-4 ships a vision_config (Gemma4ForConditionalGeneration) but its
-    # text decoder (text_config / gemma4_text) is a standard dense causal LM
-    # that vLLM serves text-only (both Gemma4ForCausalLM and
-    # Gemma4ForConditionalGeneration are registered). Text benchmarks never
-    # exercise the vision tower, so route to the degraded text path.
-    "gemma4",
 })
 
 _MAXPOS_CONFIG_KEYS = (
@@ -272,10 +266,11 @@ _UNREGISTERED_CUSTOM_CONFIG_TYPES = frozenset({"kimi_k2"})
 # `glm_moe_dsa` but Transformers does not recognize this architecture" →
 # ModelConfig ValidationError in engine init).
 _UNRECOGNIZED_MODEL_TYPES = frozenset({
-    "deepseek_v4", "glm4_moe_lite", "mimo_v2_flash", "glm_moe_dsa",
+    "deepseek_v4", "gemma4", "glm4_moe_lite", "mimo_v2_flash", "glm_moe_dsa",
 })
 _UNRECOGNIZED_ARCHITECTURES = frozenset({
-    "deepseekv4forcausallm", "glm4moeliteforcausallm",
+    "deepseekv4forcausallm", "gemma4forcausallm",
+    "gemma4forconditionalgeneration", "glm4moeliteforcausallm",
     "mimov2flashforcausallm", "glmmoedsaforcausallm",
 })
 # Some model_type values only appear inside nested decoder configs carried by a
@@ -790,7 +785,14 @@ def _detect_private_quant(model_path: str, data: dict) -> str | None:
     qc = data.get("quantization_config")
     declared_supported = False
     if isinstance(qc, dict):
-        method = str(qc.get("quant_method") or "").strip().lower()
+        raw_method = qc.get("quant_method")
+        method = str(raw_method or "").strip().lower()
+        if "quant_method" in qc and not method:
+            return (
+                "quantization_config.quant_method is empty; sglang/vLLM treats "
+                "the checkpoint as quantized but cannot select a loader and "
+                "fails engine init with \"Unknown quantization method: ''\"."
+            )
         if method and method not in _SUPPORTED_QUANT_METHODS:
             return (
                 f"quantization_config.quant_method '{method}' is a private/"
@@ -1244,6 +1246,36 @@ def _detect_mistral_common_tokenizer_gap(model_path: str, data: dict) -> str | N
     )
 
 
+def _detect_llama_sentencepiece_metadata_gap(model_path: str, data: dict) -> str | None:
+    """Return a reason for Llama checkpoints with bare SentencePiece tokenizer.
+
+    Some local Llama fine-tunes ship ``tokenizer.model`` but omit
+    ``tokenizer_config.json`` / ``tokenizer.json``. SGLang first loads a generic
+    tokenizer backend, then retries the declared-class path with the local
+    absolute model path. The HF Hub validator rejects that path with
+    ``HFValidationError: Repo id must be in the form ...`` before serving starts.
+    """
+    model_type = str(data.get("model_type") or "").strip().lower()
+    arches = {str(a or "").strip() for a in _config_architectures(data)}
+    if model_type != "llama" and "LlamaForCausalLM" not in arches:
+        return None
+
+    auto_map = data.get("auto_map")
+    if isinstance(auto_map, dict) and auto_map.get("AutoTokenizer"):
+        return None
+
+    mdir = Path(model_path)
+    if not (mdir / "tokenizer.model").is_file():
+        return None
+    if (mdir / "tokenizer_config.json").is_file() or (mdir / "tokenizer.json").is_file():
+        return None
+    return (
+        "Llama checkpoint ships tokenizer.model but lacks tokenizer_config.json "
+        "or tokenizer.json; sglang falls back through a local-path tokenizer "
+        "resolution path that raises HFValidationError before server init."
+    )
+
+
 def _detect_incompatible_model_config(
     model_path: str, gpu_type: str | None = None,
 ) -> str | None:
@@ -1363,6 +1395,9 @@ def _detect_incompatible_model_config(
     mistral_tokenizer_reason = _detect_mistral_common_tokenizer_gap(model_path, data)
     if mistral_tokenizer_reason is not None:
         return mistral_tokenizer_reason
+    llama_tokenizer_reason = _detect_llama_sentencepiece_metadata_gap(model_path, data)
+    if llama_tokenizer_reason is not None:
+        return llama_tokenizer_reason
     # Custom AutoConfig with unregistered model_type: sglang/vLLM fall
     # back to PreTrainedConfig (no max_position_embeddings attr) → crash.
     auto_map = data.get("auto_map")

--- a/inference_optimizer/cli_model_gate.py
+++ b/inference_optimizer/cli_model_gate.py
@@ -498,6 +498,12 @@ def _detect_unsupported_model(model_path: str) -> dict | None:
         nested_model_type = str(nested.get("model_type") or "").strip()
         nested_model_type_l = nested_model_type.lower()
 
+    # Registry/config incompatibilities are handled by the model-config gate so
+    # they get the precise model_config_incompatible stop reason. Do not emit a
+    # misleading multimodal text-fallback warning for wrappers such as Gemma4.
+    if _detect_unrecognized_architecture(config) is not None:
+        return None
+
     # Hard denylist wins first: explicit VLM arch / model_type is vision_only
     # even if it also carries a ForCausalLM marker (e.g. Phi3VForCausalLM).
     for arch in architectures:

--- a/inference_optimizer/tests/test_model_config_compat_preflight.py
+++ b/inference_optimizer/tests/test_model_config_compat_preflight.py
@@ -276,6 +276,19 @@ def test_detect_glm_moe_dsa_unrecognized_blocked(tmp_path):
     assert reason is not None and "not recognized" in reason
 
 
+def test_detect_gemma4_unrecognized_blocked(tmp_path):
+    # google-gemma-4-26B-A4B-it: current vLLM/Transformers rejects model_type=gemma4.
+    m = tmp_path / "gemma4"
+    _write_config(
+        m,
+        model_type="gemma4",
+        architectures=["Gemma4ForCausalLM"],
+        max_position_embeddings=32768,
+    )
+    reason = cli._detect_incompatible_model_config(str(m))
+    assert reason is not None and "gemma4" in reason
+
+
 def test_detect_bailing_ling_left_to_runtime_scope(tmp_path):
     # #649 does not add Bailing filters; keep these out of the fail-fast gate.
     for model_type, arch in (
@@ -1048,6 +1061,19 @@ def test_private_quant_mxtq_blocks(tmp_path):
     assert reason is not None and "mxtq" in reason
 
 
+def test_private_quant_empty_method_blocks(tmp_path):
+    m = tmp_path / "empty_quant_method"
+    _write_config(
+        m,
+        model_type="llama",
+        architectures=["LlamaForCausalLM"],
+        max_position_embeddings=4096,
+        quantization_config={"quant_method": ""},
+    )
+    reason = cli._detect_incompatible_model_config(str(m))
+    assert reason is not None and "quant_method is empty" in reason
+
+
 def test_private_quant_mlx_weights_index_blocks(tmp_path):
     # JANG/MLX often declares no quant config; the tell is '.biases'/'.scales'.
     m = tmp_path / "mlx_weights"
@@ -1156,6 +1182,38 @@ def test_gguf_with_pytorch_model_bin_not_blocked(tmp_path):
     m = tmp_path / "gguf_plus_hf_bin"
     _write_config(m, model_type="qwen3", max_position_embeddings=32768)
     (m / "model.gguf").write_text("dummy", encoding="utf-8")
+    (m / "pytorch_model.bin").write_text("dummy", encoding="utf-8")
+    assert cli._detect_incompatible_model_config(str(m)) is None
+
+
+def test_llama_sentencepiece_without_metadata_blocks(tmp_path):
+    m = tmp_path / "llama_sentencepiece_gap"
+    _write_config(
+        m,
+        with_tokenizer=False,
+        model_type="llama",
+        architectures=["LlamaForCausalLM"],
+        max_position_embeddings=4096,
+    )
+    (m / "tokenizer.model").write_text("dummy", encoding="utf-8")
+    (m / "pytorch_model.bin").write_text("dummy", encoding="utf-8")
+    reason = cli._detect_incompatible_model_config(str(m))
+    assert reason is not None
+    assert "tokenizer_config.json" in reason
+    assert "HFValidationError" in reason
+
+
+def test_llama_sentencepiece_with_tokenizer_config_ok(tmp_path):
+    m = tmp_path / "llama_sentencepiece_ok"
+    _write_config(
+        m,
+        with_tokenizer=False,
+        model_type="llama",
+        architectures=["LlamaForCausalLM"],
+        max_position_embeddings=4096,
+    )
+    (m / "tokenizer.model").write_text("dummy", encoding="utf-8")
+    (m / "tokenizer_config.json").write_text("{}", encoding="utf-8")
     (m / "pytorch_model.bin").write_text("dummy", encoding="utf-8")
     assert cli._detect_incompatible_model_config(str(m)) is None
 

--- a/inference_optimizer/tests/test_multimodal_gate.py
+++ b/inference_optimizer/tests/test_multimodal_gate.py
@@ -281,9 +281,13 @@ def test_detect_qwen35_moe_text_coercible(tmp_path):
     assert hit["verdict"] == cli._VERDICT_TEXT_COERCIBLE
 
 
-def test_detect_gemma4_wrapper_with_text_config_is_text_coercible(tmp_path):
-    """A multimodal wrapper with an explicit nested text decoder should fall
-    back to text-only without requiring a per-family top-level allowlist entry."""
+def test_detect_gemma4_wrapper_deferred_to_config_compat_gate(tmp_path):
+    """Gemma4 wrappers should not emit a degraded-mode warning before fail-fast.
+
+    The current pinned framework stack does not recognize ``model_type=gemma4``;
+    the model-config gate should report the precise incompatibility instead of
+    the multimodal gate claiming the model can run in text-only degraded mode.
+    """
     m = tmp_path / "gemma4"
     _write_config(
         m,
@@ -300,9 +304,10 @@ def test_detect_gemma4_wrapper_with_text_config_is_text_coercible(tmp_path):
         },
     )
     hit = cli._detect_unsupported_model(str(m))
-    assert hit is not None
-    assert hit["verdict"] == cli._VERDICT_TEXT_COERCIBLE
-    assert hit["architecture"] == "Gemma4ForConditionalGeneration"
+    assert hit is None
+    reason = cli._detect_incompatible_model_config(str(m))
+    assert reason is not None
+    assert "gemma4" in reason
 
 
 def test_detect_known_vlm_with_text_config_still_vision_only(tmp_path):


### PR DESCRIPTION
## Summary
- Add runtime preflight gates for empty quantization methods, unsupported Gemma4 configs, and Llama tokenizer metadata gaps.
- Mirror deterministic submit-filter rules in CI model compatibility checks.
- Cover the new rules with runtime preflight and CI filter tests.

## Test plan
- python -m pytest ci/test_model_compat.py
- wsl bash -lc "cd /mnt/c/Users/chenyyan/.ssh/Hyperloom-preflight-submit-filter && python3 -m pytest inference_optimizer/tests/test_model_config_compat_preflight.py"
- wsl bash -lc "cd /mnt/c/Users/chenyyan/.ssh/Hyperloom-preflight-submit-filter && python3 -m pytest inference_optimizer/tests/test_multimodal_gate.py"
