### PR TITLE
fix(gemm-tuning): stop pre-filtering forge eligibility by precision/MoE

### DIFF
--- a/inference_optimizer/actions/_meta/gemm_tuning.yaml
+++ b/inference_optimizer/actions/_meta/gemm_tuning.yaml
@@ -32,6 +32,8 @@ description: >
 pipeline_phase: deep
 typical_runtime_min: 20.0
 applicable_when:
-  - "framework in ('sglang', 'vllm')"
-  - "(precision == 'fp8' or is_moe or precision in ('bf16', 'fp4'))"
+  # forge handles any precision (bf16/fp16/fp8/fp4/mxfp4), dense or MoE; do not
+  # pre-filter on precision/MoE (real e2e KEEPs include bf16 dense). Gate only
+  # on a supported framework + the deep phase.
+  - "framework in ('sglang', 'vllm', 'vllm-aiter')"
   - "operator_bottleneck_identified or phase == 'deep'"

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -8101,21 +8101,13 @@ class Coordinator:
         backend = _resolve_gemm_tuning_backend({})
 
         if backend == "forge":
-            # forge-gemm-tune supports: any MoE model, FP8 dense,
-            # bf16/fp8/fp4 precision, sglang/vllm frameworks.
-            is_moe = bool(
-                getattr(ss, "is_moe", False)
-                or getattr(ss, "model_is_moe", False)
-                or "moe" in str(getattr(ss, "model_type", "") or "").lower()
-                or "moe" in str(getattr(ss, "model_class", "") or "").lower()
-            )
-            eligible = (
-                framework in ("sglang", "vllm", "vllm-aiter")
-                and (
-                    is_moe
-                    or precision in ("fp8", "fp4", "mxfp4")
-                )
-            )
+            # forge-gemm-tune handles any precision (bf16/fp16/fp8/fp4/mxfp4),
+            # dense or MoE, on sglang/vllm. Real e2e KEEPs span all of these —
+            # including bf16 *dense* (+11.1%) — so we must NOT pre-filter on
+            # precision/MoE here, or a category that can optimize gets silently
+            # blocked. Gate only on a supported framework and let forge itself
+            # return no_improvement when a shape can't be beaten.
+            eligible = framework in ("sglang", "vllm", "vllm-aiter")
         else:
             # GEAK: legacy FP8 + SGLang only.
             eligible = (precision == "fp8" and framework == "sglang")

--- a/inference_optimizer/tests/test_action_catalogue.py
+++ b/inference_optimizer/tests/test_action_catalogue.py
@@ -159,8 +159,12 @@ def test_gemm_tuning_action_metadata(registry):
     assert m.family == "deep_kernel"
     assert m.pipeline_phase == "deep"
     assert set(m.requires_lanes) == {"server_lifecycle", "workspace_mutation", "benchmark_lane"}
-    assert "framework in ('sglang', 'vllm')" in m.applicable_when
-    assert any("is_moe" in cond and "precision == 'fp8'" in cond for cond in m.applicable_when)
+    assert "framework in ('sglang', 'vllm', 'vllm-aiter')" in m.applicable_when
+    # forge handles any precision (bf16/fp16/fp8/fp4/mxfp4), dense or MoE; the
+    # action must NOT pre-filter on precision/MoE or bf16 dense (which has real
+    # e2e KEEPs) gets blocked. Gate only on framework + the deep phase.
+    assert any("phase == 'deep'" in cond for cond in m.applicable_when)
+    assert not any("precision" in cond for cond in m.applicable_when)
 
 
 def test_recover_owned_by_robustness_handle(registry):

--- a/inference_optimizer/tests/test_coordinator_sync_helpers_coverage_unit.py
+++ b/inference_optimizer/tests/test_coordinator_sync_helpers_coverage_unit.py
@@ -445,16 +445,22 @@ def test_skip_gemm_tuning_env(coord: Coordinator, monkeypatch) -> None:
 
 def test_gemm_tuning_required_before_kernel_opt(coord: Coordinator, monkeypatch) -> None:
     monkeypatch.delenv("INFERENCE_OPTIMIZER_SKIP_GEMM_TUNING", raising=False)
+    monkeypatch.delenv("GEMM_TUNING_BACKEND", raising=False)  # default: forge
     ss = coord.shared_state
-    # non fp8/sglang -> not required
-    ss.precision = "fp16"
-    ss.framework = "sglang"
-    assert coord._gemm_tuning_required_before_kernel_opt() is False
-    # fp8 + sglang + no terminal status -> required
-    ss.precision = "fp8"
     ss.last_gemm_tuning = {}
+    # forge backend: any precision on a supported framework is eligible — bf16/
+    # fp16 dense must NOT be pre-filtered out (real e2e KEEPs include them).
+    ss.framework = "sglang"
+    ss.precision = "fp16"
     assert coord._gemm_tuning_required_before_kernel_opt() is True
-    # terminal status -> not required
+    ss.precision = "bf16"
+    assert coord._gemm_tuning_required_before_kernel_opt() is True
+    # Unsupported framework -> not eligible.
+    ss.framework = "trt-llm"
+    assert coord._gemm_tuning_required_before_kernel_opt() is False
+    # Supported framework + terminal status -> not required (already done).
+    ss.framework = "sglang"
+    ss.precision = "fp8"
     ss.last_gemm_tuning = {"status": "succeeded"}
     assert coord._gemm_tuning_required_before_kernel_opt() is False
 


### PR DESCRIPTION
## Summary
- The kernel-entry gate `_gemm_tuning_required_before_kernel_opt` only auto-ran forge GEMM tuning for MoE or `fp8/fp4/mxfp4`, silently excluding **bf16/fp16 dense**.
- Production e2e KEEPs since the forge integration include a **bf16 dense** model (+11.1% via `forge_sglang_dense_bf16`), so the precision/MoE pre-filter was blocking a category that demonstrably optimizes.
- forge handles any precision (bf16/fp16/fp8/fp4/mxfp4), dense or MoE, and returns `no_improvement` when a shape can't be beaten — it is the right arbiter. Now gate only on a supported framework (`sglang/vllm/vllm-aiter`) and let forge decide.

## Changes
- `coordinator.py`: forge eligibility = supported framework only (drop precision/MoE pre-filter); fix the misleading comment.
- `gemm_tuning.yaml`: drop the `applicable_when` precision filter; align framework list.
- Update affected policy/metadata tests.

## Validation
- Unit: 97 passing across the affected suites.
- e2e: validating a bf16 dense model now auto-runs forge GEMM tuning through the full pipeline (separate run).

## Trade-off
Every sglang/vllm session now auto-runs GEMM tuning before kernel_opt (incl. categories that often `no_improvement`), costing extra tuning time but never pre-blocking an optimizable category — the intended policy.

Made with [Cursor](https://cursor.com)