### PR TITLE
fix(test): make cortex CLI-resolver test resilient to runtime re-import

### DIFF
--- a/critic-agent/runtime/tests/test_cortex_kb_client.py
+++ b/critic-agent/runtime/tests/test_cortex_kb_client.py
@@ -218,11 +218,19 @@ def test_5xx_then_success_recovers(make_client):
 def test_cli_resolves_cortex_client_from_cortex_kb_url(monkeypatch):
     from runtime.cli import _resolve_kb_client
 
+    # Resolve ``CortexKBClient`` from the same ``runtime.cortex_kb_client``
+    # module object that ``runtime.cli`` binds at call time. Sibling suites
+    # (e.g. the orchestrator's CriticAgentBackend tests) intentionally evict
+    # the cached ``runtime.*`` modules when a backend points at a different
+    # critic root, which rebuilds these classes; a module-level import here
+    # would capture a stale class and make the ``isinstance`` check spurious.
+    from runtime.cortex_kb_client import CortexKBClient as _CortexKBClient
+
     monkeypatch.setenv("CRITIC_KB_CLIENT_MODE", "cortex")
     monkeypatch.setenv("CORTEX_KB_URL", "http://kb-service.test")
     monkeypatch.delenv("KB_BASE_URL", raising=False)
     client = _resolve_kb_client()
-    assert isinstance(client, CortexKBClient)
+    assert isinstance(client, _CortexKBClient)
     assert client.base_url == "http://kb-service.test"
 
 


### PR DESCRIPTION
## Summary

PR #718 turned the `Tests with Coverage` job red on `main`. The failing test is:

```
critic-agent/runtime/tests/test_cortex_kb_client.py::test_cli_resolves_cortex_client_from_cortex_kb_url
> assert isinstance(client, CortexKBClient)
E assert False
E  +  where False = isinstance(<runtime.cortex_kb_client.CortexKBClient object>, CortexKBClient)
```

It passes in isolation and only fails in the full suite — a cross-test global-state issue.

## Root cause

- `inference_optimizer/orchestrator/backends/critic_agent.py::_evict_stale_runtime_modules()` (pre-existing, intended) pops `runtime.*` from `sys.modules` when a `CriticAgentBackend` points at a critic root that doesn't match the cached `runtime` package.
- `inference_optimizer/tests/test_critic_agent_backend.py` constructs backends with throwaway temp roots, triggering that eviction and dropping the real `runtime.cortex_kb_client`.
- The cortex test (added by #718) captured `CortexKBClient` at module import time. After the eviction, `from runtime.cli import _resolve_kb_client` re-imports `runtime`, producing a *new* `CortexKBClient` class object, so the `isinstance` check compares against a stale class and fails.

This new test is simply the first to do a module-level `isinstance` on a `runtime.*` class after the backend suite runs, so it exposes a pre-existing fragility rather than a product bug.

## Fix

Resolve `CortexKBClient` at call time from the same `runtime.cortex_kb_client` module that `runtime.cli` binds, so both sides always reference the current class object. Test-only change (9 lines), no production code touched.

## Test plan

- [x] Repro: `pytest inference_optimizer/tests critic-agent/runtime/tests/test_cortex_kb_client.py` failed before, now **5822 passed, 7 skipped**
- [x] `test_cortex_kb_client.py` (11) + `test_critic_agent_tool_loop.py` (13) + `test_critic_agent_backend.py` all green together
- [x] Failure no longer reproduces under the full-suite ordering that CI uses

Made with [Cursor](https://cursor.com)