### PR TITLE
fix(inference-optimizer): unblock gemma4 in the model-recognition gate

### DIFF
--- a/inference_optimizer/cli_model_gate.py
+++ b/inference_optimizer/cli_model_gate.py
@@ -265,12 +265,18 @@ _UNREGISTERED_CUSTOM_CONFIG_TYPES = frozenset({"kimi_k2"})
 # glm_moe_dsa: confirmed from zai-org-GLM-5.1 server.log ("model type
 # `glm_moe_dsa` but Transformers does not recognize this architecture" →
 # ModelConfig ValidationError in engine init).
+# gemma4: removed from the blocklist. The original entry assumed the framework
+# did not recognize gemma4, but the current runtime (transformers 5.5.0 +
+# vLLM 0.18.2rc1 rocm721) registers it: CONFIG_MAPPING contains "gemma4",
+# AutoConfig resolves Gemma4Config, and vLLM ModelConfig resolves
+# "Gemma4ForConditionalGeneration" (runner_type=generate) without a
+# validation/registry error. The wrapper carries vision_config, so it now
+# falls through to the text_coercible degraded-mode path instead.
 _UNRECOGNIZED_MODEL_TYPES = frozenset({
-    "deepseek_v4", "gemma4", "glm4_moe_lite", "mimo_v2_flash", "glm_moe_dsa",
+    "deepseek_v4", "glm4_moe_lite", "mimo_v2_flash", "glm_moe_dsa",
 })
 _UNRECOGNIZED_ARCHITECTURES = frozenset({
-    "deepseekv4forcausallm", "gemma4forcausallm",
-    "gemma4forconditionalgeneration", "glm4moeliteforcausallm",
+    "deepseekv4forcausallm", "glm4moeliteforcausallm",
     "mimov2flashforcausallm", "glmmoedsaforcausallm",
 })
 # Some model_type values only appear inside nested decoder configs carried by a

--- a/inference_optimizer/tests/test_model_config_compat_preflight.py
+++ b/inference_optimizer/tests/test_model_config_compat_preflight.py
@@ -276,8 +276,12 @@ def test_detect_glm_moe_dsa_unrecognized_blocked(tmp_path):
     assert reason is not None and "not recognized" in reason
 
 
-def test_detect_gemma4_unrecognized_blocked(tmp_path):
-    # google-gemma-4-26B-A4B-it: current vLLM/Transformers rejects model_type=gemma4.
+def test_detect_gemma4_now_recognized(tmp_path):
+    # google-gemma-4-26B-A4B-it: the current pinned stack (transformers 5.5.0 +
+    # vLLM 0.18.2rc1) registers gemma4 (CONFIG_MAPPING has "gemma4", AutoConfig
+    # resolves Gemma4Config, vLLM ModelConfig resolves Gemma4ForCausalLM). It was
+    # removed from the unrecognized blocklist, so a plain text Gemma4 config is no
+    # longer fail-fasted by the model-config gate.
     m = tmp_path / "gemma4"
     _write_config(
         m,
@@ -286,7 +290,7 @@ def test_detect_gemma4_unrecognized_blocked(tmp_path):
         max_position_embeddings=32768,
     )
     reason = cli._detect_incompatible_model_config(str(m))
-    assert reason is not None and "gemma4" in reason
+    assert reason is None
 
 
 def test_detect_bailing_ling_left_to_runtime_scope(tmp_path):

--- a/inference_optimizer/tests/test_multimodal_gate.py
+++ b/inference_optimizer/tests/test_multimodal_gate.py
@@ -281,12 +281,14 @@ def test_detect_qwen35_moe_text_coercible(tmp_path):
     assert hit["verdict"] == cli._VERDICT_TEXT_COERCIBLE
 
 
-def test_detect_gemma4_wrapper_deferred_to_config_compat_gate(tmp_path):
-    """Gemma4 wrappers should not emit a degraded-mode warning before fail-fast.
+def test_detect_gemma4_wrapper_text_coercible(tmp_path):
+    """Gemma4 multimodal wrappers route to the text-coercible degraded path.
 
-    The current pinned framework stack does not recognize ``model_type=gemma4``;
-    the model-config gate should report the precise incompatibility instead of
-    the multimodal gate claiming the model can run in text-only degraded mode.
+    The current pinned stack (transformers 5.5.0 + vLLM 0.18.2rc1) recognizes
+    ``model_type=gemma4``, so it was removed from the unrecognized blocklist. A
+    Gemma4 wrapper still carries ``vision_config`` but exposes a text decoder
+    (``text_config``), so the multimodal gate classifies it as text_coercible
+    (text-only degraded mode) and the model-config gate no longer fail-fasts.
     """
     m = tmp_path / "gemma4"
     _write_config(
@@ -304,10 +306,8 @@ def test_detect_gemma4_wrapper_deferred_to_config_compat_gate(tmp_path):
         },
     )
     hit = cli._detect_unsupported_model(str(m))
-    assert hit is None
-    reason = cli._detect_incompatible_model_config(str(m))
-    assert reason is not None
-    assert "gemma4" in reason
+    assert hit is not None
+    assert hit["verdict"] == cli._VERDICT_TEXT_COERCIBLE
 
 
 def test_detect_known_vlm_with_text_config_still_vision_only(tmp_path):


### PR DESCRIPTION
## Summary
- Remove `gemma4` / `Gemma4ForCausalLM` / `Gemma4ForConditionalGeneration` from `_UNRECOGNIZED_MODEL_TYPES` and `_UNRECOGNIZED_ARCHITECTURES` in `inference_optimizer/cli_model_gate.py`.
- The blocklist entry (added in #711) assumed the framework did not recognize gemma4 and fail-fasted it with `model_config_incompatible` before any bring-up.

## Why
On the current runtime (`transformers 5.5.0` + `vLLM 0.18.2rc1 rocm721`) gemma4 is fully recognized. Verified empirically:
- `transformers` `CONFIG_MAPPING` contains `gemma4` (+ `gemma4_text/vision/audio`); `AutoConfig.from_pretrained` resolves `Gemma4Config`.
- vLLM `get_config` / `ModelConfig` resolve `Gemma4ForConditionalGeneration` (`runner_type=generate`) with no validation/registry error.

So the blocklist was stale and wrongly hard-blocked the model at preflight. After removal, the wrapper still carries `vision_config`, so the gate routes it to the existing `text_coercible` degraded-mode path (text-only benchmark) instead.

## Validation
- `google-gemma-4-26B-A4B-it` now passes the gate (DEGRADED MODE text-path warning as designed) and vLLM brings up the server end-to-end. Baseline produced real throughput (~3.3k tok/s output @ TP=2, CONC=64, ISL/OSL=1024 on MI300X).

## Notes / out of scope
This PR only fixes the Hyperloom gate. Two downstream vLLM/ROCm kernel constraints surfaced during bring-up and are NOT part of this change (handled via runtime config, not code):
- aiter fused-MoE weight shuffle requires the per-shard MoE intermediate dim divisible by 32 → `moe_intermediate_size=704` fails at TP=8 (`88 % 32`); use a TP that keeps `704/TP` divisible by 32 (e.g. TP=2).
- CK `device_gemm` rejected some GEMM shapes under aiter; the harness auto-fell back to Triton attention + Triton MoE, which brings the server up cleanly.

## Test plan
- [ ] CI model-gate tests (`test_model_config_compat_preflight.py`, `test_multimodal_gate.py`)

Made with [Cursor](https://cursor.com)