### PR TITLE
ci: restart batch rotation on new no-breakdown pools

### DIFF
--- a/.github/workflows/optimize-submit.yml
+++ b/.github/workflows/optimize-submit.yml
@@ -229,14 +229,15 @@ jobs:
       HF_TOKEN:              ${{ secrets.HF_TOKEN }}
       HF_TOKEN_2:            ${{ secrets.HF_TOKEN_2 }}
       INPUT_MODELS:          ${{ github.event.inputs.models }}
-      # Rolling cron cycles the downloads>100 pool (every size), ordered with
-      # not-yet-run models first so the front-anchored window picks them up
-      # before the already-run tail. With exclude_leaderboard=false (see below)
-      # the pool never drains — once the front models finish and are no longer
-      # active, the window wraps and the whole 2426-model pool keeps repeating.
-      # Schedule reads the rotate pool from /wekafs (off-repo, RO-mounted on the
+      # Rolling cron cycles the hf_sub100_part1_20260626 pool (1766 models with
+      # no prior session_breakdown, compat-filtered), ordered not-yet-run-first.
+      # The rotation anchor in generate_hf_matrix was reset to 2026-06-26 12:00Z
+      # so the cycle restarts at batch 0; with batch_size=240 the pool is 8
+      # batches and a full sweep takes 8 fires (~48h). With exclude_leaderboard=
+      # false the pool never drains — once a batch finishes it wraps and repeats.
+      # Schedule reads the pool from /wekafs (off-repo, RO-mounted on the
       # hyperloom runners) so the large candidates JSON never bloats the git repo.
-      INPUT_CANDIDATES_FILE: ${{ github.event_name == 'schedule' && format('{0}/ci-candidates/hf_downloads_gt100_rotate.json', secrets.WEKAFS_CHENYI_DIR) || github.event.inputs.candidates_file }}
+      INPUT_CANDIDATES_FILE: ${{ github.event_name == 'schedule' && format('{0}/ci-candidates/hf_sub100_part1_20260626.json', secrets.WEKAFS_CHENYI_DIR) || github.event.inputs.candidates_file }}
       # Schedule leaves batch_index empty so generate_hf_matrix derives a
       # SEQUENTIAL index from the scheduled-fire counter: each cron (UTC
       # 4/16) steps batch 0,1,2,... and wraps, marching the whole pool in

--- a/.github/workflows/optimize-tiny.yml
+++ b/.github/workflows/optimize-tiny.yml
@@ -57,9 +57,13 @@ jobs:
       # Off-repo pool on /wekafs (the /wekafs root lives in the WEKAFS_CHENYI_DIR
       # secret; generate_hf_matrix reads the absolute path as-is, and the
       # hyperloom runners RO-mount /wekafs).
-      CANDIDATES_FILE: ${{ format('{0}/ci-candidates/sub100_lt12b_pulse_notrun.json', secrets.WEKAFS_CHENYI_DIR) }}
-      CANDIDATES_PATH: ${{ format('{0}/ci-candidates/sub100_lt12b_pulse_notrun.json', secrets.WEKAFS_CHENYI_DIR) }}
+      CANDIDATES_FILE: ${{ format('{0}/ci-candidates/hf_sub100_part2_20260626.json', secrets.WEKAFS_CHENYI_DIR) }}
+      CANDIDATES_PATH: ${{ format('{0}/ci-candidates/hf_sub100_part2_20260626.json', secrets.WEKAFS_CHENYI_DIR) }}
       BATCH_SIZE: '240'
+      # Rotation step (hours). MUST equal the cron PERIOD (this cron fires every
+      # 6h: 1/7/13/19 UTC), same invariant as optimize-submit/gte100. Also the
+      # per-task optimizer budget forwarded below.
+      MAX_HOURS: '6'
       # Count-filler runs go to the hyperloom workspace only.
       SUBMIT_WORKSPACES: 'core42-hyperloom'
     steps:
@@ -69,42 +73,35 @@ jobs:
         id: batch
         env:
           INPUT_BATCH_INDEX: ${{ github.event.inputs.batch_index }}
+          EVENT: ${{ github.event_name }}
         run: |
           set -euo pipefail
-          python3 - <<'PY' >> "$GITHUB_OUTPUT"
-          import json
-          import math
-          import os
-          from datetime import datetime, timezone
-          from pathlib import Path
-
-          raw = (os.environ.get("INPUT_BATCH_INDEX") or "").strip()
-          batch_size = int(os.environ["BATCH_SIZE"])
-          data = json.loads(Path(os.environ["CANDIDATES_PATH"]).read_text(encoding="utf-8"))
-          pool_size = len(data.get("candidates") or [])
-          batches = max(math.ceil(pool_size / batch_size), 1)
-
-          if raw:
-              try:
-                  batch_index = max(int(raw), 0) % batches
-              except ValueError:
-                  batch_index = 0
-          else:
-              # 4 runs/day -> one of 4 six-hour slots; advance each day so the
-              # whole pool is swept over ~ceil(batches/4) days.
-              epoch = datetime(2026, 6, 23, tzinfo=timezone.utc)
-              now = datetime.now(timezone.utc)
-              days = max((now.date() - epoch.date()).days, 0)
-              slot = days * 4 + (now.hour // 6)
-              batch_index = slot % batches
-
-          start = batch_index * batch_size
-          end = min(start + batch_size, pool_size)
-          print(f"batch_index={batch_index}")
-          print(f"pool_size={pool_size}")
-          print(f"batches={batches}")
-          print(f"slice={start}:{end}")
-          PY
+          if [ ! -f "${CANDIDATES_PATH}" ]; then
+            echo "::error::candidates pool not found: ${CANDIDATES_PATH}"
+            exit 1
+          fi
+          # Same max_hours-paced rotation as optimize-submit/gte100 (ci/batch_rotate.py,
+          # unit-tested): one batch advances per MAX_HOURS of wall-clock time since the
+          # anchor, auto-rotating on schedule and honoring an explicit batch_index on
+          # manual dispatch. ANCHOR 2026-06-26 13:00Z restarts THIS pool's sweep at
+          # batch 0 on the next fire (13:07Z), independent of gte100's shared anchor.
+          n=$(python3 -c "import json,os;print(len(json.load(open(os.environ['CANDIDATES_PATH'])).get('candidates') or []))")
+          out=$(python3 ci/batch_rotate.py \
+            --count "${n}" \
+            --batch-size "${BATCH_SIZE}" \
+            --batch-index "${INPUT_BATCH_INDEX:-}" \
+            --max-hours "${MAX_HOURS}" \
+            --anchor "2026-06-26T13:00:00+00:00" \
+            --event "${EVENT}")
+          bi=$(echo "$out" | cut -f1); pool=$(echo "$out" | cut -f2)
+          batches=$(echo "$out" | cut -f3); start=$(echo "$out" | cut -f4); end=$(echo "$out" | cut -f5)
+          {
+            echo "batch_index=${bi}"
+            echo "pool_size=${pool}"
+            echo "batches=${batches}"
+            echo "slice=${start}:${end}"
+          } >> "$GITHUB_OUTPUT"
+          echo "### tiny pool: ${pool} models; batch ${bi}/${batches}; slice ${start}:${end}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Dispatch SaFE Optimize Submit
         run: |

--- a/ci/batch_rotate.py
+++ b/ci/batch_rotate.py
@@ -82,17 +82,21 @@ def scheduled_slot(now: datetime, *, max_hours: float | None = None,
 
 def resolve_batch_index(count: int, batch_size: int, *, event: str,
                         batch_index: str | None, now: datetime | None = None,
-                        max_hours: float | None = None) -> int:
+                        max_hours: float | None = None,
+                        anchor: datetime = ROTATE_ANCHOR_UTC) -> int:
     """Resolve the batch index to run.
 
     On ``schedule`` (or when no explicit index is given) the index auto-rotates
     from the max_hours-paced slot; on manual dispatch the provided index is used.
-    The result is always wrapped into ``[0, batches)``.
+    The result is always wrapped into ``[0, batches)``. ``anchor`` lets a caller
+    (e.g. a second dispatcher) start its own sweep at batch 0 from a different
+    instant without disturbing the shared default.
     """
     batches = num_batches(count, batch_size)
     raw = (batch_index or "").strip()
     if event == "schedule" or not raw:
-        slot = scheduled_slot(now or datetime.now(timezone.utc), max_hours=max_hours)
+        slot = scheduled_slot(now or datetime.now(timezone.utc),
+                              max_hours=max_hours, anchor=anchor)
         return slot % batches
     return int(raw) % batches
 
@@ -112,13 +116,17 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--event", default="workflow_dispatch")
     p.add_argument("--now-iso", default="")
     p.add_argument("--max-hours", default="", help="Rotation step size in hours (default 12)")
+    p.add_argument("--anchor", default="", help="ISO-8601 UTC anchor instant for batch 0 "
+                   "(default: the shared ROTATE_ANCHOR_UTC). Lets a second dispatcher "
+                   "restart its own sweep without touching the shared default.")
     args = p.parse_args(argv)
 
     now = datetime.fromisoformat(args.now_iso) if args.now_iso else None
     max_hours = float(args.max_hours) if args.max_hours else None
+    anchor = datetime.fromisoformat(args.anchor) if args.anchor else ROTATE_ANCHOR_UTC
     bi = resolve_batch_index(args.count, args.batch_size, event=args.event,
                              batch_index=args.batch_index, now=now,
-                             max_hours=max_hours)
+                             max_hours=max_hours, anchor=anchor)
     batches = num_batches(args.count, args.batch_size)
     start, end = slice_bounds(bi, args.batch_size, args.count)
     print(f"{bi}\t{args.count}\t{batches}\t{start}\t{end}")

--- a/ci/generate_hf_matrix.py
+++ b/ci/generate_hf_matrix.py
@@ -542,7 +542,10 @@ def _resolve_batch_index(pool_size: int, batch_size: int) -> int:
 # The rotation pool is ordered not-run-first, so batch 0 hits the not-yet-run
 # head. Merge the candidate-pool change before this fire so the very next cron
 # starts at batch 0; bump this if the merge slips to a later fire.
-_CRON_ANCHOR_UTC = datetime(2026, 6, 15, 16, 0, tzinfo=timezone.utc)
+# 2026-06-26: reset to restart the rotation at batch 0 on the new
+# hf_sub100_part1_20260626.json pool. The next scheduled fire (12:07 UTC) is the
+# first at/after this anchor -> batch 0.
+_CRON_ANCHOR_UTC = datetime(2026, 6, 26, 12, 0, tzinfo=timezone.utc)
 
 # Fallback optimizer budget (hours) used as the rotation step size when
 # INPUT_MAX_HOURS is unset/invalid. Keep in sync with the optimize-submit

--- a/ci/test_batch_rotate.py
+++ b/ci/test_batch_rotate.py
@@ -87,6 +87,28 @@ def test_slot_other_tz_is_normalized():
     assert br.scheduled_slot(datetime(2026, 6, 25, 11, 7, tzinfo=tz8), max_hours=12) == 0
 
 
+def test_slot_custom_anchor_overrides_default():
+    # A caller-supplied anchor restarts the sweep at that instant (slot 0),
+    # independent of the shared ROTATE_ANCHOR_UTC. Same `now` yields a different
+    # slot under the default vs the custom anchor.
+    anchor = _utc2(2026, 6, 26, 13, 0)
+    assert br.scheduled_slot(_utc2(2026, 6, 26, 13, 7), max_hours=6, anchor=anchor) == 0
+    assert br.scheduled_slot(_utc2(2026, 6, 26, 19, 7), max_hours=6, anchor=anchor) == 1
+    # Same instant under the default anchor is well past slot 0.
+    assert br.scheduled_slot(_utc2(2026, 6, 26, 13, 7), max_hours=6) > 0
+
+
+def test_resolve_batch_index_custom_anchor():
+    # tiny dispatcher use: anchor at the next fire -> batch 0 there, +6h -> 1.
+    anchor = _utc2(2026, 6, 26, 13, 0)
+    assert br.resolve_batch_index(2121, 240, event="schedule", batch_index=None,
+                                  now=_utc2(2026, 6, 26, 13, 7), max_hours=6,
+                                  anchor=anchor) == 0
+    assert br.resolve_batch_index(2121, 240, event="schedule", batch_index=None,
+                                  now=_utc2(2026, 6, 26, 19, 7), max_hours=6,
+                                  anchor=anchor) == 1
+
+
 # ── resolve_batch_index ─────────────────────────────────────────────────────
 
 

--- a/ci/test_ci_generate_hf_matrix.py
+++ b/ci/test_ci_generate_hf_matrix.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import io
 import json
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -123,7 +123,9 @@ def test_resolve_batch_index_empty_uses_rotation(monkeypatch):
     # Empty batch_index + a cron_now -> max_hours-paced rotation at that instant.
     monkeypatch.delenv("INPUT_BATCH_INDEX", raising=False)
     monkeypatch.setenv("INPUT_MAX_HOURS", "6")
-    monkeypatch.setenv("INPUT_CRON_NOW", "2026-06-15T22:00:00Z")  # anchor + 6h
+    # anchor + 6h -> exactly one batch advanced (relative to the live anchor so
+    # this test survives future anchor moves).
+    monkeypatch.setenv("INPUT_CRON_NOW", (gm._CRON_ANCHOR_UTC + timedelta(hours=6)).isoformat())
     assert gm._resolve_batch_index(100, 10) == 1
 
 
@@ -133,7 +135,7 @@ def test_resolve_batch_index_schedule_empty_ok(monkeypatch):
     monkeypatch.delenv("INPUT_BATCH_INDEX", raising=False)
     monkeypatch.setenv("GITHUB_EVENT_NAME", "schedule")
     monkeypatch.setenv("INPUT_MAX_HOURS", "6")
-    monkeypatch.setenv("INPUT_CRON_NOW", "2026-06-15T22:00:00Z")
+    monkeypatch.setenv("INPUT_CRON_NOW", (gm._CRON_ANCHOR_UTC + timedelta(hours=6)).isoformat())
     assert gm._resolve_batch_index(100, 10) == 1
 
 
@@ -171,7 +173,7 @@ def test_rotation_step_hours_fallback(monkeypatch):
 
 
 def test_cron_batch_index_anchor_is_zero(monkeypatch):
-    monkeypatch.setenv("INPUT_CRON_NOW", "2026-06-15T16:00:00+00:00")
+    monkeypatch.setenv("INPUT_CRON_NOW", gm._CRON_ANCHOR_UTC.isoformat())
     monkeypatch.delenv("INPUT_MAX_HOURS", raising=False)  # 6h step
     assert gm._cron_batch_index(100, 10) == 0
 
@@ -179,24 +181,24 @@ def test_cron_batch_index_anchor_is_zero(monkeypatch):
 def test_cron_batch_index_advances_by_max_hours(monkeypatch):
     # 6h step: 6h after the anchor -> exactly one batch advanced.
     monkeypatch.setenv("INPUT_MAX_HOURS", "6")
-    monkeypatch.setenv("INPUT_CRON_NOW", "2026-06-15T22:00:00Z")
+    monkeypatch.setenv("INPUT_CRON_NOW", (gm._CRON_ANCHOR_UTC + timedelta(hours=6)).isoformat())
     assert gm._cron_batch_index(100, 10) == 1
     # within the same 6h window -> still batch 0.
-    monkeypatch.setenv("INPUT_CRON_NOW", "2026-06-15T21:59:00Z")
+    monkeypatch.setenv("INPUT_CRON_NOW", (gm._CRON_ANCHOR_UTC + timedelta(hours=5, minutes=59)).isoformat())
     assert gm._cron_batch_index(100, 10) == 0
 
 
 def test_cron_batch_index_step_scales_with_max_hours(monkeypatch):
     # 12h step: 12h after the anchor -> one batch; 24h -> two batches.
     monkeypatch.setenv("INPUT_MAX_HOURS", "12")
-    monkeypatch.setenv("INPUT_CRON_NOW", "2026-06-16T04:00:00Z")  # +12h
+    monkeypatch.setenv("INPUT_CRON_NOW", (gm._CRON_ANCHOR_UTC + timedelta(hours=12)).isoformat())  # +12h
     assert gm._cron_batch_index(100, 10) == 1
-    monkeypatch.setenv("INPUT_CRON_NOW", "2026-06-16T16:00:00Z")  # +24h
+    monkeypatch.setenv("INPUT_CRON_NOW", (gm._CRON_ANCHOR_UTC + timedelta(hours=24)).isoformat())  # +24h
     assert gm._cron_batch_index(100, 10) == 2
 
 
 def test_cron_batch_index_before_anchor_clamped(monkeypatch):
-    monkeypatch.setenv("INPUT_CRON_NOW", "2026-06-14T16:00:00+00:00")
+    monkeypatch.setenv("INPUT_CRON_NOW", (gm._CRON_ANCHOR_UTC - timedelta(days=1)).isoformat())
     assert gm._cron_batch_index(100, 10) == 0
 
 
@@ -560,9 +562,9 @@ def test_apply_exclusions_to_entries_with_active(monkeypatch):
 def test_resolve_batch_index_schedule(monkeypatch):
     monkeypatch.delenv("INPUT_BATCH_INDEX", raising=False)
     monkeypatch.setenv("GITHUB_EVENT_NAME", "schedule")
-    # max_hours-paced: anchor 06-15T16:00 -> 06-16T04:00 is +12h; at the 6h
-    # default step that is two batches advanced.
-    monkeypatch.setenv("INPUT_CRON_NOW", "2026-06-16T04:00:00Z")
+    # max_hours-paced: anchor + 12h at the 6h default step is two batches
+    # advanced (relative to the live anchor so this survives anchor moves).
+    monkeypatch.setenv("INPUT_CRON_NOW", (gm._CRON_ANCHOR_UTC + timedelta(hours=12)).isoformat())
     monkeypatch.delenv("INPUT_MAX_HOURS", raising=False)
     assert gm._resolve_batch_index(100, 10) == 2
 


### PR DESCRIPTION
- optimize-submit schedule now sweeps hf_sub100_part1_20260626.json (1766 models with no prior session_breakdown, compat-filtered)
- optimize-tiny schedule now sweeps hf_sub100_part2_20260626.json (2121) and switches from the inline epoch-slot resolver to the unit-tested, max_hours-paced ci/batch_rotate.py (same strategy as optimize-submit/gte100)
- reset generate_hf_matrix._CRON_ANCHOR_UTC to 2026-06-26 12:00Z and pass a per-dispatcher --anchor (13:00Z) for tiny so both rotations restart at batch 0 on the next scheduled fire
- batch_rotate: add --anchor override (default ROTATE_ANCHOR_UTC unchanged, so gte100 is unaffected)
- tests: make generate_hf_matrix anchor assertions anchor-relative (survive future anchor moves); add batch_rotate --anchor coverage

- Description: what and why
- Linked issue(s): close/fix refs
- Tests: added/updated? commands run?
- Breaking changes: yes/no (details if yes)
