### PR TITLE
fix(quantize): preserve source model identity after quantization prelude

### DIFF
--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -116,6 +116,7 @@ from .cli_bootstrap import (  # noqa: F401 - re-exported for callers/tests
     _resolve_session_dir_for_summary,
     _seed_shared_state,
     _snapshot_system_prompts,
+    resolve_model_display_name,
 )
 from .orchestrator.action_executors._aiter_jit import (
     AITER_LOCK_STALE_MINUTES,
@@ -167,7 +168,7 @@ __all__ = [
     "_default_target_summary", "_parse_conc_sweep_concs", "_print_final_summary",
     "_print_kernel_opt_summary_line", "_print_session_skeleton", "_read_failure_summary",
     "_reconcile_crash_count", "_resolve_reference_recipe", "_resolve_session_dir_for_summary",
-    "_seed_shared_state", "_snapshot_system_prompts",
+    "_seed_shared_state", "_snapshot_system_prompts", "resolve_model_display_name",
 ]
 from .manifest import load_manifest, write_manifest
 from .orchestrator.action_registry import ActionRegistry
@@ -2597,6 +2598,12 @@ async def _run_quantization_prelude(args: argparse.Namespace) -> None:
 
     args.model = Path(quantized_model_dir)
     os.environ["MODEL_PATH"] = str(quantized_model_dir)
+    # Preserve the SOURCE model identity for session naming / display. The export
+    # dir basename is always "quantized" (see quantization_request_handlers), so
+    # deriving the model name from args.model would collapse every quantized run
+    # to "quantized". Pin "<source>-quantized" so the session dir, SharedState,
+    # and manifest carry the real model name and quantized runs stay distinct.
+    args.model_display_name = f"{Path(source_model).name}-quantized"
     print(f"Quantization prelude: model -> {quantized_model_dir}")
 
 
@@ -3188,7 +3195,10 @@ async def _run_optimize(args: argparse.Namespace) -> int:
         )
 
         # session_dir defaults to <workspace_root>/<model>/<UTC ts>/ (INFERENCE_OPTIMIZER_SESSION_LAYOUT=flat for legacy).
-        session_dir = make_session_dir(model_name=args.model)
+        # Use the resolved identity so a quantized run is named after the source
+        # model (e.g. "<model>-quantized") instead of the generic export-dir
+        # basename "quantized".
+        session_dir = make_session_dir(model_name=resolve_model_display_name(args))
         # Single-optimizer guard (issue #592): a fresh per-session dir is
         # normally uncontended, but take the lock here too so the contract
         # ("one optimizer owns a session") holds uniformly and the owner pid is

--- a/inference_optimizer/cli_bootstrap.py
+++ b/inference_optimizer/cli_bootstrap.py
@@ -26,6 +26,30 @@ from .model_config_utils import summarize_model_config
 
 log = logging.getLogger(__name__)
 
+
+def resolve_model_display_name(args: argparse.Namespace) -> str:
+    """Resolve the canonical model identity used for session naming / display.
+
+    The quantization prelude rewrites ``args.model`` to its generic export dir
+    (``<workspace>/quantization/<model>/quantized``), whose basename is always
+    ``quantized``. Deriving the model name from that path basename would collapse
+    every quantized run to ``quantized`` — losing the real model name and
+    colliding all quantized runs under ``<root>/quantized/<ts>``. To avoid that,
+    the prelude pins the source identity on ``args.model_display_name``; this
+    helper prefers it and otherwise falls back to the model-path basename.
+
+    Args:
+        args: Parsed CLI arguments.
+
+    Returns:
+        The pinned display name when set, else ``Path(args.model).name``.
+    """
+    override = (getattr(args, "model_display_name", "") or "").strip()
+    if override:
+        return override
+    return Path(str(getattr(args, "model", "") or "")).name
+
+
 def _seed_shared_state(
     session_dir: Path,
     args: argparse.Namespace,
@@ -200,16 +224,19 @@ def _seed_shared_state(
     # Lowest-priority base for the baseline server args; fully fail-soft.
     _ref_args, _ref_envs, _ref_model, _ref_source = _resolve_reference_recipe(args)
 
+    # Canonical model identity: prefers the quantize prelude's pinned source name
+    # over the (possibly collapsed "quantized") model-path basename.
+    _model_identity = resolve_model_display_name(args)
     state = SharedState(
         session_id=session_id,
         claw_session_id=(os.environ.get("CLAW_SESSION_ID") or "").strip(),
         sandbox_user_id=(os.environ.get("SANDBOX_USER_ID") or "").strip(),
-        model_name=Path(args.model).name,
+        model_name=_model_identity,
         model_path=str(args.model),
         model_class=args.model_class or "",
         # Advisory architecture profile; fresh-launch only (resume rehydrates, must not clobber). Soft-degrade to {}.
         model_arch=_load_model_arch(
-            _workspace_root_resolve(), Path(args.model).name
+            _workspace_root_resolve(), _model_identity
         ),
         # Architecture-identity tags from config.json stamped into recipe-snapshot extras (fine-tune carries base identity).
         model_architectures=_cfg_tags.get("architectures", []),

--- a/inference_optimizer/manifest.py
+++ b/inference_optimizer/manifest.py
@@ -413,7 +413,14 @@ def build_manifest(
     if args is not None:
         if getattr(args, "model", None):
             model_path = str(args.model)
-            model_name = Path(model_path).name
+            # Prefer the quantize prelude's pinned source identity; the rewritten
+            # export-dir basename is the generic "quantized" (would collapse the
+            # name). Mirrors cli_bootstrap.resolve_model_display_name (kept inline
+            # to avoid a manifest -> cli_bootstrap import cycle).
+            model_name = (
+                (getattr(args, "model_display_name", "") or "").strip()
+                or Path(model_path).name
+            )
         if getattr(args, "framework", None):
             framework = str(args.framework)
         if getattr(args, "gpu_type", None):

--- a/inference_optimizer/tests/test_cli_bootstrap_coverage_unit.py
+++ b/inference_optimizer/tests/test_cli_bootstrap_coverage_unit.py
@@ -124,6 +124,90 @@ def test_seed_shared_state_populates_perfskills_and_cli_overrides(
     assert json.loads((tmp_path / "state.json").read_text())["session_id"] == "session-1"
 
 
+def test_seed_shared_state_preserves_quantized_model_identity(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Regression: after the quantize prelude pins ``args.model_display_name``,
+    ``SharedState.model_name`` must use it rather than the collapsed
+    ``<...>/quantized`` path basename."""
+    monkeypatch.setattr(cb, "_load_model_config_tags", lambda _p: {})
+    monkeypatch.setattr(cb, "_load_model_arch", lambda *_a, **_k: {})
+    monkeypatch.setattr(cb, "_workspace_root_resolve", lambda: tmp_path)
+    monkeypatch.setattr(
+        cb, "_resolve_reference_recipe", lambda _args: ("", {}, "", ""),
+    )
+
+    from inference_optimizer.orchestrator import policy
+
+    monkeypatch.setattr(policy, "detect_gpu_count", lambda: 8)
+    monkeypatch.setattr(policy, "research_lane_ceiling", lambda: 16)
+
+    args = _args(
+        model="/root/quantization/google-gemma-4-26B-A4B-it/quantized",
+        model_display_name="google-gemma-4-26B-A4B-it-quantized",
+    )
+    state = cb._seed_shared_state(tmp_path, args, session_id="s-q")
+
+    assert state.model_name == "google-gemma-4-26B-A4B-it-quantized"
+    assert state.model_name != "quantized"
+
+
+def test_seed_shared_state_falls_back_to_path_basename(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Without a pinned display name (the common, non-quantized path) the model
+    name is still the plain model-path basename."""
+    monkeypatch.setattr(cb, "_load_model_config_tags", lambda _p: {})
+    monkeypatch.setattr(cb, "_load_model_arch", lambda *_a, **_k: {})
+    monkeypatch.setattr(cb, "_workspace_root_resolve", lambda: tmp_path)
+    monkeypatch.setattr(
+        cb, "_resolve_reference_recipe", lambda _args: ("", {}, "", ""),
+    )
+
+    from inference_optimizer.orchestrator import policy
+
+    monkeypatch.setattr(policy, "detect_gpu_count", lambda: 8)
+    monkeypatch.setattr(policy, "research_lane_ceiling", lambda: 16)
+
+    state = cb._seed_shared_state(
+        tmp_path, _args(model="/models/Qwen3-32B"), session_id="s-plain",
+    )
+    assert state.model_name == "Qwen3-32B"
+
+
+def test_manifest_preserves_quantized_model_identity(tmp_path: Path) -> None:
+    """Regression: ``manifest.json`` ``model_name`` must honor the pinned
+    display name from the quantize prelude, not the collapsed path basename."""
+    from inference_optimizer import manifest as m
+
+    args = _args(
+        model="/root/quantization/google-gemma-4-26B-A4B-it/quantized",
+        model_display_name="google-gemma-4-26B-A4B-it-quantized",
+    )
+    built = m.build_manifest(tmp_path, args=args, session_id="s-q")
+    assert built["model_name"] == "google-gemma-4-26B-A4B-it-quantized"
+    assert built["model_name"] != "quantized"
+    # the real path is still recorded faithfully
+    assert built["model_path"].endswith("/quantized")
+
+
+def test_resolve_model_display_name_helper() -> None:
+    """Unit cover for the identity resolver: pinned override wins, else basename."""
+    plain = SimpleNamespace(model="/models/Qwen3-32B")
+    assert cb.resolve_model_display_name(plain) == "Qwen3-32B"
+
+    pinned = SimpleNamespace(
+        model="/root/quantization/x/quantized",
+        model_display_name="x-quantized",
+    )
+    assert cb.resolve_model_display_name(pinned) == "x-quantized"
+
+    empty_override = SimpleNamespace(model="/models/Foo", model_display_name="")
+    assert cb.resolve_model_display_name(empty_override) == "Foo"
+
+
 def test_target_summary_and_conc_sweep_parser(caplog) -> None:
     assert ">= 12.5%" in cb._default_target_summary(
         _args(model="/m/foo", target_gain=12.5, target_tput=None, max_hours=4)

--- a/inference_optimizer/tests/test_quantization_prelude.py
+++ b/inference_optimizer/tests/test_quantization_prelude.py
@@ -412,3 +412,43 @@ def test_prelude_freetext_takes_priority_over_scheme(tmp_path, monkeypatch):
     args = _Args(model="/models/src", quantize="custom mxfp4 prompt", quantize_scheme="fp8")
     asyncio.run(cli._run_quantization_prelude(args))
     assert seen["prompt"] == "custom mxfp4 prompt"  # free text wins
+
+
+def test_prelude_preserves_source_model_identity(tmp_path, monkeypatch):
+    """Regression: the quantize prelude rewrites args.model to the generic
+    ``<workspace>/quantization/<model>/quantized`` export dir (basename is always
+    ``quantized``). The session / display model identity must NOT collapse to
+    ``quantized`` — otherwise every quantized run lands under
+    ``<root>/quantized/<ts>`` and the report only shows ``Model: quantized``,
+    losing the real model name and colliding across models.
+    """
+    import inference_optimizer.paths as paths
+
+    monkeypatch.setattr(paths, "workspace_root", lambda: tmp_path)
+
+    async def _fake_async(*, prompt, source_model, workspace):
+        # Mirror the real adapter: the export dir basename is always "quantized".
+        return str(tmp_path / "quantization" / "google-gemma-4-26B-A4B-it" / "quantized")
+
+    monkeypatch.setattr(qrh, "run_quantization_prelude_async", _fake_async)
+    monkeypatch.delenv("MODEL_PATH", raising=False)
+
+    args = _Args(model="/wekafs/models/google-gemma-4-26B-A4B-it", quantize="fp8")
+    asyncio.run(cli._run_quantization_prelude(args))
+
+    # The model path is rewritten to the generic quantized export dir ...
+    assert str(args.model).endswith("/quantized")
+    # ... but the identity used for session_dir / state / manifest is preserved.
+    name = cli.resolve_model_display_name(args)
+    assert name != "quantized"
+    assert name == "google-gemma-4-26B-A4B-it-quantized"
+
+
+def test_prelude_no_display_name_without_quantization(monkeypatch):
+    """Without quantization the prelude leaves args untouched, so the identity
+    resolver falls back to the plain model-path basename (no collapse, no
+    spurious suffix)."""
+    args = _Args(model="/models/Qwen3-32B", quantize=None)
+    asyncio.run(cli._run_quantization_prelude(args))
+    assert getattr(args, "model_display_name", None) in (None, "")
+    assert cli.resolve_model_display_name(args) == "Qwen3-32B"


### PR DESCRIPTION
## Summary
- After the quantization prelude rewrites `--model` to the generic export dir
  `<workspace>/quantization/<model>/quantized` (basename always `quantized`),
  the three naming sites (session dir via `make_session_dir`,
  `SharedState.model_name`, `manifest.json` model_name) all derived the name
  from that basename — collapsing every quantized run to `quantized`. The real
  model name was lost, reports showed `Model: quantized`, and concurrent
  quantized models collided under `<root>/quantized/<ts>`.
- Pin the source identity on `args.model_display_name` in the prelude
  (`<source>-quantized`) and add `resolve_model_display_name()` so all three
  sites prefer it, falling back to the path basename for non-quantized runs.
  `model_path` still records the real export dir unchanged.

## Test plan
- [x] New tests reproduce the collapse and verify the fix (prelude identity,
      `_seed_shared_state`, manifest builder, helper).
- [x] `test_quantization_prelude.py` + `test_cli_bootstrap_coverage_unit.py`
      green; regressions in `test_session_layout` / `test_resume` /
      `test_shared_state_*` / `-k manifest` green.

Made with [Cursor](https://cursor.com)