### PR TITLE
feat(quark): param-gated quark_quantizer shell over quantization_agent

### DIFF
--- a/inference_optimizer/orchestrator/quantization_request_handlers.py
+++ b/inference_optimizer/orchestrator/quantization_request_handlers.py
@@ -1,19 +1,24 @@
-"""Adapter: drive the quantization-agent from inference_optimizer.
+"""Adapter: drive quantization from inference_optimizer via the quark_quantizer shell.
 
-Thin shim between ``cli._run_quantization_prelude`` and the standalone
-``quantization_agent`` package. It builds an effective prompt (source model
-path + export dir + the user's ``--quantize`` text), runs
-``quantize_via_prompt`` once, and maps its ``QuantSkillRunResult.status`` to a
-concrete decision:
+Thin shim between ``cli._run_quantization_prelude`` and the ``quark_quantizer``
+shell (which itself wraps the original ``quantization_agent``). The prelude
+position and order are unchanged (it still runs ONCE before the optimization
+loop, then the caller rewrites ``--model`` to the exported model). The only
+behavioral change vs. calling ``quantization_agent`` directly is that the trigger
+is now a parameter (``enabled``) rather than an implicit code path — here we are
+past the ``--quantize`` / ``--quantize-scheme`` gate, so we enable it.
 
-  * ``success``                    -> return ``quantized_model_dir``
-  * ``partial`` (model usable)     -> warn, then return ``quantized_model_dir``
+It builds an effective prompt (source model path + export dir + the user's
+``--quantize`` text), runs the shell once, and maps its status to a decision:
+
+  * ``success``                    -> return ``output_dir``
+  * ``partial`` (model usable)     -> warn, then return ``output_dir``
   * ``partial`` (no usable model)  -> ``SystemExit(3)``
-  * ``failed``                     -> ``SystemExit(3)``
+  * ``failed`` / other             -> ``SystemExit(3)``
 
 When the user explicitly asked for quantization we must never silently fall
-through and optimize the un-quantized source model — a quantization failure
-is a hard stop for the whole run.
+through and optimize the un-quantized source model — a quantization failure is
+a hard stop for the whole run.
 """
 
 from __future__ import annotations
@@ -30,7 +35,7 @@ async def run_quantization_prelude_async(
 ) -> str:
     """Quantize ``source_model`` per ``prompt``; return the exported dir.
 
-    Awaits the async ``quantize_via_prompt`` directly (the caller already
+    Awaits the async ``quark_quantizer.quantize`` directly (the caller already
     runs inside ``asyncio.run``). Raises ``SystemExit(3)`` when no usable
     quantized model was produced.
 
@@ -45,16 +50,16 @@ async def run_quantization_prelude_async(
     Raises:
         SystemExit: If quantization failed or produced no usable model.
     """
-    # quantization_agent is a top-level package (sibling of inference_optimizer);
+    # quark_quantizer is a top-level package (sibling of inference_optimizer);
     # imported lazily so this module loads even where its deps are absent.
-    from quantization_agent import quantize_via_prompt
+    from quark_quantizer import quantize
 
     workspace = Path(workspace)
     export_dir = workspace / "quantized"
 
-    # The agent is prompt-driven: fold the source model + export dir into the
-    # prompt so the user's --quantize text can be just the scheme
-    # (e.g. "fp8 with fp8 kv_cache, exclude lm_head").
+    # Fold the source model + export dir into the prompt so the user's
+    # --quantize text can be just the scheme (e.g. "fp8 with fp8 kv_cache,
+    # exclude lm_head"). The wrapped agent's LLM turns this into the Quark CLI.
     effective_prompt = (
         f"Quantize the model at {source_model}. "
         f"Export the HuggingFace-format quantized model to {export_dir}. "
@@ -65,29 +70,24 @@ async def run_quantization_prelude_async(
         f"{prompt}"
     )
 
-    result = await quantize_via_prompt(
-        effective_prompt,
-        workspace=workspace,
-        interactive=False,
-    )
-
-    final = result.assessment.final
-    qdir = result.quantized_model_dir
+    # Reaching the prelude already means quantization was explicitly requested
+    # (the --quantize / --quantize-scheme gate in cli), so enable it here.
+    result = await quantize(effective_prompt, enabled=True, workspace=workspace)
 
     if result.status == "success":
-        print(f"Quantization: success (final={final}, eval_gap={result.assessment.eval_gap}) -> {qdir}")
-        return str(qdir)
+        print(f"Quantization: success (final={result.final}, eval_gap={result.eval_gap}) -> {result.output_dir}")
+        return str(result.output_dir)
 
-    if result.status == "partial" and qdir is not None:
+    if result.status == "partial" and result.output_dir is not None:
         print(
-            f"Quantization: PARTIAL (final={final}); quantized model is loadable "
+            f"Quantization: PARTIAL (final={result.final}); quantized model is loadable "
             f"so continuing, but audit/eval was incomplete. Review {workspace}.",
             file=sys.stderr,
         )
-        return str(qdir)
+        return str(result.output_dir)
 
     print(
-        f"ERROR: quantization {result.status} (final={final}). Refusing to "
+        f"ERROR: quantization {result.status} (final={result.final}). Refusing to "
         f"optimize the un-quantized source model. See {workspace} for details.",
         file=sys.stderr,
     )

--- a/inference_optimizer/tests/test_quantization_prelude.py
+++ b/inference_optimizer/tests/test_quantization_prelude.py
@@ -3,12 +3,12 @@
 Three groups, all offline (no Quark / Claude SDK / GPU):
 
 * Parser     — ``--quantize`` flag parses (default None / value when passed).
-* Adapter    — ``run_quantization_prelude_async`` maps QuantSkillRunResult
-               status -> decision (return dir vs SystemExit(3)).
+* Adapter    — ``run_quantization_prelude_async`` maps quark_quantizer's
+               QuarkRunResult status -> decision (return dir vs SystemExit(3)).
 * CLI hook   — ``cli._run_quantization_prelude`` is a no-op without the flag,
                skipped on --resume, and rewrites args.model otherwise.
 
-``quantize_via_prompt`` is monkeypatched so nothing real runs.
+``quark_quantizer.quantize`` is monkeypatched so nothing real runs.
 """
 
 from __future__ import annotations
@@ -30,28 +30,25 @@ from inference_optimizer.orchestrator import quantization_schemes as qs
 # ---------------------------------------------------------------------------
 
 
-def _fake_result(status: str, qdir: str | None, *, final="x", eval_gap=None):
-    """Build a stand-in for QuantSkillRunResult."""
-    assessment = types.SimpleNamespace(final=final, eval_gap=eval_gap)
+def _fake_result(status: str, output_dir: str | None, *, final="x", eval_gap=None, error=""):
+    """Build a stand-in for quark_quantizer.QuarkRunResult."""
     return types.SimpleNamespace(
-        status=status,
-        quantized_model_dir=Path(qdir) if qdir else None,
-        assessment=assessment,
+        status=status, output_dir=output_dir, final=final, eval_gap=eval_gap, error=error
     )
 
 
 def _patch_quantize(monkeypatch: pytest.MonkeyPatch, result):
-    """Replace quantization_agent.quantize_via_prompt with an async stub
-    that records its call and returns ``result``."""
-    import quantization_agent
+    """Replace quark_quantizer.quantize with an async stub that records its
+    call (prompt + enabled + kwargs) and returns ``result``."""
+    import quark_quantizer
 
     calls: list[dict] = []
 
-    async def _fake(prompt, **kwargs):
-        calls.append({"prompt": prompt, **kwargs})
+    async def _fake(prompt, *, enabled=False, **kwargs):
+        calls.append({"prompt": prompt, "enabled": enabled, **kwargs})
         return result
 
-    monkeypatch.setattr(quantization_agent, "quantize_via_prompt", _fake)
+    monkeypatch.setattr(quark_quantizer, "quantize", _fake)
     return calls
 
 
@@ -237,10 +234,13 @@ def test_adapter_success_returns_quantized_dir(tmp_path, monkeypatch):
     calls = _patch_quantize(monkeypatch, _fake_result("success", str(tmp_path / "q"), final=None, eval_gap=0.01))
     out = asyncio.run(qrh.run_quantization_prelude_async(prompt="fp8", source_model="/models/src", workspace=tmp_path))
     assert out == str(tmp_path / "q")
-    # source model + export dir folded into the effective prompt
+    # source model + export dir folded into the effective prompt; NL request kept.
     assert "/models/src" in calls[0]["prompt"]
     assert str(tmp_path / "quantized") in calls[0]["prompt"]
-    assert calls[0]["interactive"] is False
+    assert "fp8" in calls[0]["prompt"]
+    # The prelude already gated on the flag, so the shell is enabled here.
+    assert calls[0]["enabled"] is True
+    assert calls[0]["workspace"] == tmp_path
 
 
 def test_adapter_partial_with_model_returns_dir(tmp_path, monkeypatch):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ testpaths = [
     "robustness-agent/tests",
     "critic-agent/runtime/tests",
     "quantization_agent/tests",
+    "quark_quantizer/tests",
     "kernel-agent/tools/test_tracelens_arch_benchmark.py",
     "kernel-agent/tools/test_ray_fd_limit.py",
     "kernel-agent/tools/test_gemm_tuning.py",
@@ -131,6 +132,7 @@ source = [
     "framework-agent/src",
     "kernel-agent/tools",
     "quantization_agent",
+    "quark_quantizer",
     "OOB",
     "ci",
 ]
@@ -169,6 +171,8 @@ omit = [
     "kernel-agent/skills/unittest/validate_harness.py",
     # quantization_agent CLI driver (argparse entrypoint).
     "quantization_agent/cli.py",
+    # quark_quantizer CLI driver (argparse entrypoint).
+    "quark_quantizer/cli.py",
     # OOB agent_mcp_server entrypoints / server-side runtime: CLI, HTTP
     # server, scheduler, auth proxy, and the subprocess agent backends are
     # network / long-running services exercised end-to-end, not by unit

--- a/quark_quantizer/__init__.py
+++ b/quark_quantizer/__init__.py
@@ -1,0 +1,27 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""quark_quantizer — a thin, parameter-gated shell over ``quantization_agent``.
+
+The original ``quantization_agent`` (the Hyperloom driver that turns a natural
+-language prompt into Quark CLI calls and executes them) is kept as-is. This
+shell adds one thing for stability: the decision to quantize is a **parameter**
+(``enabled``), supplied by the caller (a backend, driven by a frontend toggle)
+— never inferred from free-form natural language by an outer orchestration LLM.
+
+Two inputs go in conceptually: the ``enabled`` switch and the NL ``prompt``.
+When enabled, the shell forwards the prompt to
+``quantization_agent.quantize_via_prompt`` (which does prompt -> CLI -> execute);
+when disabled it is a no-op.
+
+Public entry: :func:`quantize` (and :func:`quantize_sync`).
+"""
+
+from __future__ import annotations
+
+from .runner import QuarkRunResult, quantize, quantize_sync
+
+__all__ = [
+    "QuarkRunResult",
+    "quantize",
+    "quantize_sync",
+]

--- a/quark_quantizer/cli.py
+++ b/quark_quantizer/cli.py
@@ -1,0 +1,122 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Standalone CLI for quark_quantizer.
+
+The trigger is an explicit parameter (``--enabled``), mirroring the
+frontend->backend toggle: nothing runs unless the caller opts in. The natural
+language goes in ``--prompt`` and is forwarded to the wrapped
+``quantization_agent`` (which turns it into the Quark CLI and executes it).
+
+Example::
+
+    python -m quark_quantizer.cli \\
+        --enabled \\
+        --prompt "fp8 global scheme, fp8 kv_cache, exclude lm_head" \\
+        --workspace /scratch/run-1/wks
+
+Exit codes:
+    0   success / partial / skipped (disabled)
+    1   failed (no usable quantized model)
+    2   argparse / input validation error
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from typing import Any
+
+from .runner import quantize
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Build and parse the CLI arguments.
+
+    Args:
+        argv: Argument list; defaults to ``sys.argv`` when ``None``.
+
+    Returns:
+        The parsed namespace.
+    """
+    p = argparse.ArgumentParser(
+        prog="quark_quantizer",
+        description="Parameter-gated shell over quantization_agent (Quark PTQ).",
+    )
+    # The trigger is a parameter, not an agent decision.
+    group = p.add_mutually_exclusive_group()
+    group.add_argument(
+        "--enabled",
+        dest="enabled",
+        action="store_true",
+        help="Run quantization. Without this flag the module is a no-op (skipped).",
+    )
+    group.add_argument(
+        "--disabled",
+        dest="enabled",
+        action="store_false",
+        help="Explicitly disable (default).",
+    )
+    p.set_defaults(enabled=False)
+
+    p.add_argument("--prompt", default="", help="Natural-language quantization request.")
+    p.add_argument("--workspace", required=True, help="Scratch dir for the wrapped agent's artifacts.")
+    p.add_argument("--quark-root", default=None, help="Quark checkout root (else $QUARK_ROOT).")
+    p.add_argument("--acceptable-eval-gap", type=float, default=None, help="Max relative eval gap.")
+    p.add_argument("--model-id", default=None, help="Override the wrapped agent's model id.")
+    p.add_argument("--verbose", action="store_true", help="Stream logs to stderr.")
+    return p.parse_args(argv)
+
+
+async def _run(args: argparse.Namespace) -> int:
+    """Run one request and print a JSON summary.
+
+    Args:
+        args: Parsed CLI arguments.
+
+    Returns:
+        The process exit code.
+    """
+
+    def log(line: str) -> None:
+        if args.verbose:
+            print(line, file=sys.stderr, flush=True)
+
+    result = await quantize(
+        args.prompt,
+        enabled=args.enabled,
+        workspace=args.workspace,
+        quark_root=args.quark_root,
+        acceptable_eval_gap=args.acceptable_eval_gap,
+        model=args.model_id,
+        log=log,
+    )
+
+    summary: dict[str, Any] = {
+        "status": result.status,
+        "output_dir": result.output_dir,
+        "eval_gap": result.eval_gap,
+        "final": result.final,
+        "error": result.error,
+    }
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+    return 1 if result.status == "failed" else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Args:
+        argv: Argument list; defaults to ``sys.argv`` when ``None``.
+
+    Returns:
+        The process exit code.
+    """
+    args = _parse_args(argv)
+    return asyncio.run(_run(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/quark_quantizer/runner.py
+++ b/quark_quantizer/runner.py
@@ -1,0 +1,134 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""The shell around the original ``quantization_agent`` implementation.
+
+This module adds exactly one thing on top of the existing (Quark-driving)
+``quantization_agent``: a **parameter-based trigger**. The caller (a backend,
+driven by a frontend toggle) passes ``enabled`` to decide whether quantization
+runs at all — the outermost orchestration LLM has no natural-language path into
+this module, so it cannot accidentally activate quantization.
+
+The shell does NOT reimplement prompt->CLI->execute. When enabled it forwards
+the natural-language prompt to ``quantization_agent.quantize_via_prompt``, whose
+in-agent LLM turns the prompt into the Quark CLI and runs it. The shell only
+gates the call and normalizes the result.
+
+Conceptually two inputs go in: the ``enabled`` switch and the NL ``prompt``.
+``workspace`` (and a few optional knobs) are plumbing the wrapped agent needs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+
+@dataclass(frozen=True)
+class QuarkRunResult:
+    """Normalized outcome of a (possibly skipped) quantization request.
+
+    Attributes:
+        status: ``"skipped"`` (disabled), or the wrapped agent's status
+            (``"success"`` / ``"partial"`` / ``"failed"``).
+        output_dir: Exported quantized model dir, or ``None``.
+        eval_gap: Relative eval gap from the final attempt, if any.
+        final: The wrapped agent's final outcome id, if any.
+        error: Non-empty on shell-level failures.
+    """
+
+    status: str
+    output_dir: str | None = None
+    eval_gap: float | None = None
+    final: str | None = None
+    error: str = ""
+
+
+async def quantize(
+    prompt: str,
+    *,
+    enabled: bool = False,
+    workspace: str | Path,
+    quark_root: str | Path | None = None,
+    interactive: bool | None = False,
+    acceptable_eval_gap: float | None = None,
+    max_requantize_attempts: int = 1,
+    model: str | None = None,
+    quantize_via_prompt: Callable[..., Any] | None = None,
+    log: Callable[[str], None] | None = None,
+) -> QuarkRunResult:
+    """Quantize from a natural-language prompt, gated on ``enabled``.
+
+    Args:
+        prompt: Natural-language quantization request. Forwarded verbatim to the
+            wrapped ``quantization_agent``, whose LLM turns it into the Quark CLI.
+        enabled: Master switch (default ``False`` — the module is a no-op unless
+            the caller opts in). When ``False`` the wrapped agent is never run.
+        workspace: Directory the wrapped agent writes artifacts into.
+        quark_root: Quark checkout root; falls back to ``$QUARK_ROOT``.
+        interactive: Forwarded interactivity flag (default ``False`` = batch).
+        acceptable_eval_gap: Max tolerated relative accuracy gap.
+        max_requantize_attempts: Cap on requantize retries.
+        model: Optional model id passed to the wrapped agent.
+        quantize_via_prompt: Override for the wrapped entry (testing seam).
+        log: Optional line-logging callback.
+
+    Returns:
+        The normalized :class:`QuarkRunResult`.
+    """
+    if not enabled:
+        if log:
+            log("[quark_quantizer] disabled (enabled=False); skipping quantization")
+        return QuarkRunResult(status="skipped")
+
+    qvp = quantize_via_prompt
+    if qvp is None:
+        # quantization_agent is a top-level package (sibling of inference_optimizer);
+        # imported lazily so the shell loads even where its deps are absent.
+        from quantization_agent import quantize_via_prompt as qvp_real
+
+        qvp = qvp_real
+
+    result = await qvp(
+        prompt,
+        workspace=workspace,
+        quark_root=quark_root,
+        interactive=interactive,
+        acceptable_eval_gap=acceptable_eval_gap,
+        max_requantize_attempts=max_requantize_attempts,
+        model=model,
+        log=log,
+    )
+
+    assessment = getattr(result, "assessment", None)
+    final = getattr(assessment, "final", None)
+    eval_gap = getattr(assessment, "eval_gap", None)
+    qdir = getattr(result, "quantized_model_dir", None)
+    return QuarkRunResult(
+        status=result.status,
+        output_dir=str(qdir) if qdir else None,
+        eval_gap=eval_gap,
+        final=str(final) if final is not None else None,
+    )
+
+
+def quantize_sync(prompt: str, *, enabled: bool = False, **kwargs: Any) -> QuarkRunResult:
+    """Synchronous wrapper around :func:`quantize` for non-async callers.
+
+    Args:
+        prompt: Natural-language quantization request.
+        enabled: Master switch (see :func:`quantize`).
+        **kwargs: Forwarded to :func:`quantize`.
+
+    Returns:
+        The :class:`QuarkRunResult`.
+    """
+    return asyncio.run(quantize(prompt, enabled=enabled, **kwargs))
+
+
+__all__ = [
+    "QuarkRunResult",
+    "quantize",
+    "quantize_sync",
+]

--- a/quark_quantizer/tests/__init__.py
+++ b/quark_quantizer/tests/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.

--- a/quark_quantizer/tests/test_quark_quantizer.py
+++ b/quark_quantizer/tests/test_quark_quantizer.py
@@ -1,0 +1,160 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Offline tests for the quark_quantizer shell (no real agent / SDK / GPU).
+
+The shell adds one thing: a parameter-gated trigger around the original
+``quantization_agent.quantize_via_prompt``. These tests inject a fake
+``quantize_via_prompt`` so nothing real runs, and assert:
+
+* ``enabled=False`` is a no-op (the wrapped agent is never called),
+* ``enabled=True`` forwards the prompt + plumbing and normalizes the result.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+from quark_quantizer import runner as rn
+from quark_quantizer.runner import QuarkRunResult
+
+
+def _fake_agent_result(status: str, qdir: str | None, *, final="ok", eval_gap=0.01):
+    """Build a stand-in for quantization_agent.QuantSkillRunResult."""
+    return SimpleNamespace(
+        status=status,
+        quantized_model_dir=Path(qdir) if qdir else None,
+        assessment=SimpleNamespace(final=final, eval_gap=eval_gap),
+    )
+
+
+def _capturing_qvp(result, calls: list):
+    async def _qvp(prompt, **kwargs):
+        calls.append({"prompt": prompt, **kwargs})
+        return result
+
+    return _qvp
+
+
+# ---------------------------------------------------------------------------
+# the parameter gate
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_is_noop_and_never_calls_agent(tmp_path):
+    async def _must_not_run(*a, **k):  # pragma: no cover - asserts non-call
+        raise AssertionError("wrapped agent must not run when disabled")
+
+    res = asyncio.run(
+        rn.quantize("fp8", enabled=False, workspace=tmp_path, quantize_via_prompt=_must_not_run)
+    )
+    assert res.status == "skipped"
+    assert res.output_dir is None
+
+
+def test_disabled_by_default(tmp_path):
+    async def _must_not_run(*a, **k):  # pragma: no cover - asserts non-call
+        raise AssertionError("default must be disabled")
+
+    res = asyncio.run(rn.quantize("fp8", workspace=tmp_path, quantize_via_prompt=_must_not_run))
+    assert res.status == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# delegation + result normalization
+# ---------------------------------------------------------------------------
+
+
+def test_enabled_forwards_prompt_and_plumbing(tmp_path):
+    calls: list = []
+    qvp = _capturing_qvp(_fake_agent_result("success", str(tmp_path / "q")), calls)
+    res = asyncio.run(
+        rn.quantize(
+            "fp8 exclude lm_head",
+            enabled=True,
+            workspace=tmp_path,
+            quark_root="/qr",
+            acceptable_eval_gap=0.05,
+            quantize_via_prompt=qvp,
+        )
+    )
+    assert res.status == "success"
+    assert res.output_dir == str(tmp_path / "q")
+    assert res.eval_gap == 0.01
+    assert res.final == "ok"
+    # The NL prompt is forwarded verbatim; plumbing is passed through.
+    assert calls[0]["prompt"] == "fp8 exclude lm_head"
+    assert calls[0]["workspace"] == tmp_path
+    assert calls[0]["quark_root"] == "/qr"
+    assert calls[0]["acceptable_eval_gap"] == 0.05
+    assert calls[0]["interactive"] is False
+
+
+def test_partial_with_model_is_normalized(tmp_path):
+    calls: list = []
+    qvp = _capturing_qvp(_fake_agent_result("partial", str(tmp_path / "q"), final="eval_gap_exceeded"), calls)
+    res = asyncio.run(rn.quantize("fp8", enabled=True, workspace=tmp_path, quantize_via_prompt=qvp))
+    assert res.status == "partial"
+    assert res.output_dir == str(tmp_path / "q")
+    assert res.final == "eval_gap_exceeded"
+
+
+def test_failed_has_no_output_dir(tmp_path):
+    calls: list = []
+    qvp = _capturing_qvp(_fake_agent_result("failed", None, final="exec_model_load_failed"), calls)
+    res = asyncio.run(rn.quantize("fp8", enabled=True, workspace=tmp_path, quantize_via_prompt=qvp))
+    assert res.status == "failed"
+    assert res.output_dir is None
+    assert res.final == "exec_model_load_failed"
+
+
+def test_quantize_sync_wrapper(tmp_path):
+    calls: list = []
+    qvp = _capturing_qvp(_fake_agent_result("success", str(tmp_path / "q")), calls)
+    res = rn.quantize_sync("fp8", enabled=True, workspace=tmp_path, quantize_via_prompt=qvp)
+    assert res.status == "success"
+    assert isinstance(res, QuarkRunResult)
+
+
+# ---------------------------------------------------------------------------
+# cli (param-driven trigger)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_defaults_to_disabled():
+    from quark_quantizer import cli
+
+    args = cli._parse_args(["--workspace", "/w"])
+    assert args.enabled is False
+
+
+def test_cli_enabled_flag_and_run(monkeypatch, capsys):
+    from quark_quantizer import cli
+
+    seen: dict = {}
+
+    async def _fake_quantize(prompt, *, enabled, **kwargs):
+        seen["enabled"] = enabled
+        seen["prompt"] = prompt
+        return QuarkRunResult(status="skipped")
+
+    monkeypatch.setattr(cli, "quantize", _fake_quantize)
+    rc = cli.main(["--enabled", "--workspace", "/w", "--prompt", "fp8"])
+    import json
+
+    assert rc == 0
+    assert seen["enabled"] is True
+    assert seen["prompt"] == "fp8"
+    assert json.loads(capsys.readouterr().out)["status"] == "skipped"
+
+
+def test_cli_failed_status_exit_code(monkeypatch):
+    from quark_quantizer import cli
+
+    async def _fake_quantize(prompt, *, enabled, **kwargs):
+        return QuarkRunResult(status="failed", error="boom")
+
+    monkeypatch.setattr(cli, "quantize", _fake_quantize)
+    rc = cli.main(["--enabled", "--workspace", "/w"])
+    assert rc == 1

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,12 @@ from __future__ import annotations
 from setuptools import find_packages, setup
 
 setup(
-    packages=find_packages(include=["inference_optimizer", "inference_optimizer.*"]),
+    packages=find_packages(
+        include=[
+            "inference_optimizer",
+            "inference_optimizer.*",
+            "quark_quantizer",
+            "quark_quantizer.*",
+        ],
+    ),
 )


### PR DESCRIPTION
## Summary
- Add `quark_quantizer`, a thin shell over the existing `quantization_agent`.
  Its only addition is a **parameter-based trigger**: callers pass `enabled`
  (default `False`) to decide whether quantization runs, so an outer
  orchestration LLM has no natural-language path to accidentally activate it.
- When enabled, the shell forwards the NL prompt verbatim to
  `quantization_agent.quantize_via_prompt` (unchanged — it still turns the
  prompt into the Quark CLI and executes); when disabled it is a no-op.
- Repoint the inference_optimizer prelude adapter to call the shell
  (`enabled=True`, since reaching the prelude already means
  `--quantize`/`--quantize-scheme` was set). Prelude position/order, partial
  handling, and `SystemExit(3)` policy are unchanged. `quantization_agent` is
  kept intact.

## Test plan
- [x] Offline shell tests (fake agent seam): disabled no-op, default-disabled,
      delegation + result normalization, sync wrapper, CLI.
- [x] Adapter/prelude tests + the kept `quantization_agent` tests green.

Made with [Cursor](https://cursor.com)