### PR TITLE
docs(env): document gemm-tune KB / kernel-opt order / trace route vars

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -66,3 +66,29 @@ USER_DATA_PATH=/workspace/hyperloom
 # LANGFUSE_HOST=https://langfuse.your-domain
 # LANGFUSE_PUBLIC_KEY=pk-...
 # LANGFUSE_SECRET_KEY=sk-...
+
+# --- GEMM-tune KB short-circuit (optional) ---------------------------------
+# Reuse previously-tuned GEMM configs from gemm-tune-kb (gbrain) instead of
+# re-running tuning. Disabled by default. The gemm-tune backend must be 'forge'
+# (the default) for KB read to apply — the GEAK backend has no KB-read path.
+# GEMM_TUNING_BACKEND=forge
+# FORGE_GEMM_TUNE_KB_READ=1
+# Also short-circuit on candidate-status pages (micro-validated but not yet
+# confirmed). Without this, only 'confirmed' KB pages are applied.
+# FORGE_GEMM_TUNE_KB_ACCEPT_CANDIDATE=1
+# gbrain endpoint + token for the gemm-tune / recipe KBs. Base URL defaults to
+# the in-cluster primus-claw-dev service; a token is required for any KB read.
+# GBRAIN_BASE_URL=http://gbrain.primus-claw-dev.svc.cluster.local:80
+# GBRAIN_TOKEN=gbrain_your-token-here
+
+# --- Kernel-opt backend ladder order (optional) ----------------------------
+# Comma-separated, ordered list of source-level kernel-opt backends to try.
+# Default is the full ladder; set to restrict/reorder — e.g. 'forge' for a
+# strict forge-only run with no GEAK/OOB fallback.
+# KERNEL_OPT_BACKEND_ORDER=forge,geak,oob
+
+# --- Trace analysis route (optional) ---------------------------------------
+# 'agent' (default): LLM-driven TraceLens analysis. 'deterministic': run the
+# TraceLens Python toolchain directly (no LLM) for a faster, reproducible
+# analysis that does not consume the orchestration model.
+# HYPERLOOM_TRACE_ANALYSIS_ROUTE=deterministic


### PR DESCRIPTION
## Summary
- Add commented `.env.template` entries documenting optional knobs (all remain
  disabled/default):
  - GEMM-tune KB short-circuit (`FORGE_GEMM_TUNE_KB_READ`,
    `FORGE_GEMM_TUNE_KB_ACCEPT_CANDIDATE`, `GBRAIN_BASE_URL`/`GBRAIN_TOKEN`).
  - Kernel-opt backend ladder order (`KERNEL_OPT_BACKEND_ORDER`).
  - Trace-analysis route (`HYPERLOOM_TRACE_ANALYSIS_ROUTE`).

## Test plan
- [x] Docs-only change to `.env.template`; no code paths affected.

Made with [Cursor](https://cursor.com)