### PR TITLE
Quantization: param-gated quark shell, model-name fix, env docs

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -66,3 +66,29 @@ USER_DATA_PATH=/workspace/hyperloom
 # LANGFUSE_HOST=https://langfuse.your-domain
 # LANGFUSE_PUBLIC_KEY=pk-...
 # LANGFUSE_SECRET_KEY=sk-...
+
+# --- GEMM-tune KB short-circuit (optional) ---------------------------------
+# Reuse previously-tuned GEMM configs from gemm-tune-kb (gbrain) instead of
+# re-running tuning. Disabled by default. The gemm-tune backend must be 'forge'
+# (the default) for KB read to apply — the GEAK backend has no KB-read path.
+# GEMM_TUNING_BACKEND=forge
+# FORGE_GEMM_TUNE_KB_READ=1
+# Also short-circuit on candidate-status pages (micro-validated but not yet
+# confirmed). Without this, only 'confirmed' KB pages are applied.
+# FORGE_GEMM_TUNE_KB_ACCEPT_CANDIDATE=1
+# gbrain endpoint + token for the gemm-tune / recipe KBs. Base URL defaults to
+# the in-cluster primus-claw-dev service; a token is required for any KB read.
+# GBRAIN_BASE_URL=http://gbrain.primus-claw-dev.svc.cluster.local:80
+# GBRAIN_TOKEN=gbrain_your-token-here
+
+# --- Kernel-opt backend ladder order (optional) ----------------------------
+# Comma-separated, ordered list of source-level kernel-opt backends to try.
+# Default is the full ladder; set to restrict/reorder — e.g. 'forge' for a
+# strict forge-only run with no GEAK/OOB fallback.
+# KERNEL_OPT_BACKEND_ORDER=forge,geak,oob
+
+# --- Trace analysis route (optional) ---------------------------------------
+# 'agent' (default): LLM-driven TraceLens analysis. 'deterministic': run the
+# TraceLens Python toolchain directly (no LLM) for a faster, reproducible
+# analysis that does not consume the orchestration model.
+# HYPERLOOM_TRACE_ANALYSIS_ROUTE=deterministic

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -116,6 +116,7 @@ from .cli_bootstrap import (  # noqa: F401 - re-exported for callers/tests
     _resolve_session_dir_for_summary,
     _seed_shared_state,
     _snapshot_system_prompts,
+    resolve_model_display_name,
 )
 from .orchestrator.action_executors._aiter_jit import (
     AITER_LOCK_STALE_MINUTES,
@@ -167,7 +168,7 @@ __all__ = [
     "_default_target_summary", "_parse_conc_sweep_concs", "_print_final_summary",
     "_print_kernel_opt_summary_line", "_print_session_skeleton", "_read_failure_summary",
     "_reconcile_crash_count", "_resolve_reference_recipe", "_resolve_session_dir_for_summary",
-    "_seed_shared_state", "_snapshot_system_prompts",
+    "_seed_shared_state", "_snapshot_system_prompts", "resolve_model_display_name",
 ]
 from .manifest import load_manifest, write_manifest
 from .orchestrator.action_registry import ActionRegistry
@@ -2597,6 +2598,12 @@ async def _run_quantization_prelude(args: argparse.Namespace) -> None:
 
     args.model = Path(quantized_model_dir)
     os.environ["MODEL_PATH"] = str(quantized_model_dir)
+    # Preserve the SOURCE model identity for session naming / display. The export
+    # dir basename is always "quantized" (see quantization_request_handlers), so
+    # deriving the model name from args.model would collapse every quantized run
+    # to "quantized". Pin "<source>-quantized" so the session dir, SharedState,
+    # and manifest carry the real model name and quantized runs stay distinct.
+    args.model_display_name = f"{Path(source_model).name}-quantized"
     print(f"Quantization prelude: model -> {quantized_model_dir}")
 
 
@@ -3188,7 +3195,10 @@ async def _run_optimize(args: argparse.Namespace) -> int:
         )
 
         # session_dir defaults to <workspace_root>/<model>/<UTC ts>/ (INFERENCE_OPTIMIZER_SESSION_LAYOUT=flat for legacy).
-        session_dir = make_session_dir(model_name=args.model)
+        # Use the resolved identity so a quantized run is named after the source
+        # model (e.g. "<model>-quantized") instead of the generic export-dir
+        # basename "quantized".
+        session_dir = make_session_dir(model_name=resolve_model_display_name(args))
         # Single-optimizer guard (issue #592): a fresh per-session dir is
         # normally uncontended, but take the lock here too so the contract
         # ("one optimizer owns a session") holds uniformly and the owner pid is

--- a/inference_optimizer/cli_bootstrap.py
+++ b/inference_optimizer/cli_bootstrap.py
@@ -26,6 +26,30 @@ from .model_config_utils import summarize_model_config
 
 log = logging.getLogger(__name__)
 
+
+def resolve_model_display_name(args: argparse.Namespace) -> str:
+    """Resolve the canonical model identity used for session naming / display.
+
+    The quantization prelude rewrites ``args.model`` to its generic export dir
+    (``<workspace>/quantization/<model>/quantized``), whose basename is always
+    ``quantized``. Deriving the model name from that path basename would collapse
+    every quantized run to ``quantized`` — losing the real model name and
+    colliding all quantized runs under ``<root>/quantized/<ts>``. To avoid that,
+    the prelude pins the source identity on ``args.model_display_name``; this
+    helper prefers it and otherwise falls back to the model-path basename.
+
+    Args:
+        args: Parsed CLI arguments.
+
+    Returns:
+        The pinned display name when set, else ``Path(args.model).name``.
+    """
+    override = (getattr(args, "model_display_name", "") or "").strip()
+    if override:
+        return override
+    return Path(str(getattr(args, "model", "") or "")).name
+
+
 def _seed_shared_state(
     session_dir: Path,
     args: argparse.Namespace,
@@ -200,16 +224,19 @@ def _seed_shared_state(
     # Lowest-priority base for the baseline server args; fully fail-soft.
     _ref_args, _ref_envs, _ref_model, _ref_source = _resolve_reference_recipe(args)
 
+    # Canonical model identity: prefers the quantize prelude's pinned source name
+    # over the (possibly collapsed "quantized") model-path basename.
+    _model_identity = resolve_model_display_name(args)
     state = SharedState(
         session_id=session_id,
         claw_session_id=(os.environ.get("CLAW_SESSION_ID") or "").strip(),
         sandbox_user_id=(os.environ.get("SANDBOX_USER_ID") or "").strip(),
-        model_name=Path(args.model).name,
+        model_name=_model_identity,
         model_path=str(args.model),
         model_class=args.model_class or "",
         # Advisory architecture profile; fresh-launch only (resume rehydrates, must not clobber). Soft-degrade to {}.
         model_arch=_load_model_arch(
-            _workspace_root_resolve(), Path(args.model).name
+            _workspace_root_resolve(), _model_identity
         ),
         # Architecture-identity tags from config.json stamped into recipe-snapshot extras (fine-tune carries base identity).
         model_architectures=_cfg_tags.get("architectures", []),

--- a/inference_optimizer/manifest.py
+++ b/inference_optimizer/manifest.py
@@ -413,7 +413,14 @@ def build_manifest(
     if args is not None:
         if getattr(args, "model", None):
             model_path = str(args.model)
-            model_name = Path(model_path).name
+            # Prefer the quantize prelude's pinned source identity; the rewritten
+            # export-dir basename is the generic "quantized" (would collapse the
+            # name). Mirrors cli_bootstrap.resolve_model_display_name (kept inline
+            # to avoid a manifest -> cli_bootstrap import cycle).
+            model_name = (
+                (getattr(args, "model_display_name", "") or "").strip()
+                or Path(model_path).name
+            )
         if getattr(args, "framework", None):
             framework = str(args.framework)
         if getattr(args, "gpu_type", None):

--- a/inference_optimizer/orchestrator/quantization_request_handlers.py
+++ b/inference_optimizer/orchestrator/quantization_request_handlers.py
@@ -1,19 +1,24 @@
-"""Adapter: drive the quantization-agent from inference_optimizer.
+"""Adapter: drive quantization from inference_optimizer via the quark_quantizer shell.
 
-Thin shim between ``cli._run_quantization_prelude`` and the standalone
-``quantization_agent`` package. It builds an effective prompt (source model
-path + export dir + the user's ``--quantize`` text), runs
-``quantize_via_prompt`` once, and maps its ``QuantSkillRunResult.status`` to a
-concrete decision:
+Thin shim between ``cli._run_quantization_prelude`` and the ``quark_quantizer``
+shell (which itself wraps the original ``quantization_agent``). The prelude
+position and order are unchanged (it still runs ONCE before the optimization
+loop, then the caller rewrites ``--model`` to the exported model). The only
+behavioral change vs. calling ``quantization_agent`` directly is that the trigger
+is now a parameter (``enabled``) rather than an implicit code path — here we are
+past the ``--quantize`` / ``--quantize-scheme`` gate, so we enable it.
 
-  * ``success``                    -> return ``quantized_model_dir``
-  * ``partial`` (model usable)     -> warn, then return ``quantized_model_dir``
+It builds an effective prompt (source model path + export dir + the user's
+``--quantize`` text), runs the shell once, and maps its status to a decision:
+
+  * ``success``                    -> return ``output_dir``
+  * ``partial`` (model usable)     -> warn, then return ``output_dir``
   * ``partial`` (no usable model)  -> ``SystemExit(3)``
-  * ``failed``                     -> ``SystemExit(3)``
+  * ``failed`` / other             -> ``SystemExit(3)``
 
 When the user explicitly asked for quantization we must never silently fall
-through and optimize the un-quantized source model — a quantization failure
-is a hard stop for the whole run.
+through and optimize the un-quantized source model — a quantization failure is
+a hard stop for the whole run.
 """
 
 from __future__ import annotations
@@ -30,7 +35,7 @@ async def run_quantization_prelude_async(
 ) -> str:
     """Quantize ``source_model`` per ``prompt``; return the exported dir.
 
-    Awaits the async ``quantize_via_prompt`` directly (the caller already
+    Awaits the async ``quark_quantizer.quantize`` directly (the caller already
     runs inside ``asyncio.run``). Raises ``SystemExit(3)`` when no usable
     quantized model was produced.
 
@@ -45,16 +50,16 @@ async def run_quantization_prelude_async(
     Raises:
         SystemExit: If quantization failed or produced no usable model.
     """
-    # quantization_agent is a top-level package (sibling of inference_optimizer);
+    # quark_quantizer is a top-level package (sibling of inference_optimizer);
     # imported lazily so this module loads even where its deps are absent.
-    from quantization_agent import quantize_via_prompt
+    from quark_quantizer import quantize
 
     workspace = Path(workspace)
     export_dir = workspace / "quantized"
 
-    # The agent is prompt-driven: fold the source model + export dir into the
-    # prompt so the user's --quantize text can be just the scheme
-    # (e.g. "fp8 with fp8 kv_cache, exclude lm_head").
+    # Fold the source model + export dir into the prompt so the user's
+    # --quantize text can be just the scheme (e.g. "fp8 with fp8 kv_cache,
+    # exclude lm_head"). The wrapped agent's LLM turns this into the Quark CLI.
     effective_prompt = (
         f"Quantize the model at {source_model}. "
         f"Export the HuggingFace-format quantized model to {export_dir}. "
@@ -65,29 +70,24 @@ async def run_quantization_prelude_async(
         f"{prompt}"
     )
 
-    result = await quantize_via_prompt(
-        effective_prompt,
-        workspace=workspace,
-        interactive=False,
-    )
-
-    final = result.assessment.final
-    qdir = result.quantized_model_dir
+    # Reaching the prelude already means quantization was explicitly requested
+    # (the --quantize / --quantize-scheme gate in cli), so enable it here.
+    result = await quantize(effective_prompt, enabled=True, workspace=workspace)
 
     if result.status == "success":
-        print(f"Quantization: success (final={final}, eval_gap={result.assessment.eval_gap}) -> {qdir}")
-        return str(qdir)
+        print(f"Quantization: success (final={result.final}, eval_gap={result.eval_gap}) -> {result.output_dir}")
+        return str(result.output_dir)
 
-    if result.status == "partial" and qdir is not None:
+    if result.status == "partial" and result.output_dir is not None:
         print(
-            f"Quantization: PARTIAL (final={final}); quantized model is loadable "
+            f"Quantization: PARTIAL (final={result.final}); quantized model is loadable "
             f"so continuing, but audit/eval was incomplete. Review {workspace}.",
             file=sys.stderr,
         )
-        return str(qdir)
+        return str(result.output_dir)
 
     print(
-        f"ERROR: quantization {result.status} (final={final}). Refusing to "
+        f"ERROR: quantization {result.status} (final={result.final}). Refusing to "
         f"optimize the un-quantized source model. See {workspace} for details.",
         file=sys.stderr,
     )

--- a/inference_optimizer/tests/test_cli_bootstrap_coverage_unit.py
+++ b/inference_optimizer/tests/test_cli_bootstrap_coverage_unit.py
@@ -124,6 +124,90 @@ def test_seed_shared_state_populates_perfskills_and_cli_overrides(
     assert json.loads((tmp_path / "state.json").read_text())["session_id"] == "session-1"
 
 
+def test_seed_shared_state_preserves_quantized_model_identity(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Regression: after the quantize prelude pins ``args.model_display_name``,
+    ``SharedState.model_name`` must use it rather than the collapsed
+    ``<...>/quantized`` path basename."""
+    monkeypatch.setattr(cb, "_load_model_config_tags", lambda _p: {})
+    monkeypatch.setattr(cb, "_load_model_arch", lambda *_a, **_k: {})
+    monkeypatch.setattr(cb, "_workspace_root_resolve", lambda: tmp_path)
+    monkeypatch.setattr(
+        cb, "_resolve_reference_recipe", lambda _args: ("", {}, "", ""),
+    )
+
+    from inference_optimizer.orchestrator import policy
+
+    monkeypatch.setattr(policy, "detect_gpu_count", lambda: 8)
+    monkeypatch.setattr(policy, "research_lane_ceiling", lambda: 16)
+
+    args = _args(
+        model="/root/quantization/google-gemma-4-26B-A4B-it/quantized",
+        model_display_name="google-gemma-4-26B-A4B-it-quantized",
+    )
+    state = cb._seed_shared_state(tmp_path, args, session_id="s-q")
+
+    assert state.model_name == "google-gemma-4-26B-A4B-it-quantized"
+    assert state.model_name != "quantized"
+
+
+def test_seed_shared_state_falls_back_to_path_basename(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Without a pinned display name (the common, non-quantized path) the model
+    name is still the plain model-path basename."""
+    monkeypatch.setattr(cb, "_load_model_config_tags", lambda _p: {})
+    monkeypatch.setattr(cb, "_load_model_arch", lambda *_a, **_k: {})
+    monkeypatch.setattr(cb, "_workspace_root_resolve", lambda: tmp_path)
+    monkeypatch.setattr(
+        cb, "_resolve_reference_recipe", lambda _args: ("", {}, "", ""),
+    )
+
+    from inference_optimizer.orchestrator import policy
+
+    monkeypatch.setattr(policy, "detect_gpu_count", lambda: 8)
+    monkeypatch.setattr(policy, "research_lane_ceiling", lambda: 16)
+
+    state = cb._seed_shared_state(
+        tmp_path, _args(model="/models/Qwen3-32B"), session_id="s-plain",
+    )
+    assert state.model_name == "Qwen3-32B"
+
+
+def test_manifest_preserves_quantized_model_identity(tmp_path: Path) -> None:
+    """Regression: ``manifest.json`` ``model_name`` must honor the pinned
+    display name from the quantize prelude, not the collapsed path basename."""
+    from inference_optimizer import manifest as m
+
+    args = _args(
+        model="/root/quantization/google-gemma-4-26B-A4B-it/quantized",
+        model_display_name="google-gemma-4-26B-A4B-it-quantized",
+    )
+    built = m.build_manifest(tmp_path, args=args, session_id="s-q")
+    assert built["model_name"] == "google-gemma-4-26B-A4B-it-quantized"
+    assert built["model_name"] != "quantized"
+    # the real path is still recorded faithfully
+    assert built["model_path"].endswith("/quantized")
+
+
+def test_resolve_model_display_name_helper() -> None:
+    """Unit cover for the identity resolver: pinned override wins, else basename."""
+    plain = SimpleNamespace(model="/models/Qwen3-32B")
+    assert cb.resolve_model_display_name(plain) == "Qwen3-32B"
+
+    pinned = SimpleNamespace(
+        model="/root/quantization/x/quantized",
+        model_display_name="x-quantized",
+    )
+    assert cb.resolve_model_display_name(pinned) == "x-quantized"
+
+    empty_override = SimpleNamespace(model="/models/Foo", model_display_name="")
+    assert cb.resolve_model_display_name(empty_override) == "Foo"
+
+
 def test_target_summary_and_conc_sweep_parser(caplog) -> None:
     assert ">= 12.5%" in cb._default_target_summary(
         _args(model="/m/foo", target_gain=12.5, target_tput=None, max_hours=4)

--- a/inference_optimizer/tests/test_quantization_prelude.py
+++ b/inference_optimizer/tests/test_quantization_prelude.py
@@ -3,12 +3,12 @@
 Three groups, all offline (no Quark / Claude SDK / GPU):
 
 * Parser     — ``--quantize`` flag parses (default None / value when passed).
-* Adapter    — ``run_quantization_prelude_async`` maps QuantSkillRunResult
-               status -> decision (return dir vs SystemExit(3)).
+* Adapter    — ``run_quantization_prelude_async`` maps quark_quantizer's
+               QuarkRunResult status -> decision (return dir vs SystemExit(3)).
 * CLI hook   — ``cli._run_quantization_prelude`` is a no-op without the flag,
                skipped on --resume, and rewrites args.model otherwise.
 
-``quantize_via_prompt`` is monkeypatched so nothing real runs.
+``quark_quantizer.quantize`` is monkeypatched so nothing real runs.
 """
 
 from __future__ import annotations
@@ -30,28 +30,25 @@ from inference_optimizer.orchestrator import quantization_schemes as qs
 # ---------------------------------------------------------------------------
 
 
-def _fake_result(status: str, qdir: str | None, *, final="x", eval_gap=None):
-    """Build a stand-in for QuantSkillRunResult."""
-    assessment = types.SimpleNamespace(final=final, eval_gap=eval_gap)
+def _fake_result(status: str, output_dir: str | None, *, final="x", eval_gap=None, error=""):
+    """Build a stand-in for quark_quantizer.QuarkRunResult."""
     return types.SimpleNamespace(
-        status=status,
-        quantized_model_dir=Path(qdir) if qdir else None,
-        assessment=assessment,
+        status=status, output_dir=output_dir, final=final, eval_gap=eval_gap, error=error
     )
 
 
 def _patch_quantize(monkeypatch: pytest.MonkeyPatch, result):
-    """Replace quantization_agent.quantize_via_prompt with an async stub
-    that records its call and returns ``result``."""
-    import quantization_agent
+    """Replace quark_quantizer.quantize with an async stub that records its
+    call (prompt + enabled + kwargs) and returns ``result``."""
+    import quark_quantizer
 
     calls: list[dict] = []
 
-    async def _fake(prompt, **kwargs):
-        calls.append({"prompt": prompt, **kwargs})
+    async def _fake(prompt, *, enabled=False, **kwargs):
+        calls.append({"prompt": prompt, "enabled": enabled, **kwargs})
         return result
 
-    monkeypatch.setattr(quantization_agent, "quantize_via_prompt", _fake)
+    monkeypatch.setattr(quark_quantizer, "quantize", _fake)
     return calls
 
 
@@ -237,10 +234,13 @@ def test_adapter_success_returns_quantized_dir(tmp_path, monkeypatch):
     calls = _patch_quantize(monkeypatch, _fake_result("success", str(tmp_path / "q"), final=None, eval_gap=0.01))
     out = asyncio.run(qrh.run_quantization_prelude_async(prompt="fp8", source_model="/models/src", workspace=tmp_path))
     assert out == str(tmp_path / "q")
-    # source model + export dir folded into the effective prompt
+    # source model + export dir folded into the effective prompt; NL request kept.
     assert "/models/src" in calls[0]["prompt"]
     assert str(tmp_path / "quantized") in calls[0]["prompt"]
-    assert calls[0]["interactive"] is False
+    assert "fp8" in calls[0]["prompt"]
+    # The prelude already gated on the flag, so the shell is enabled here.
+    assert calls[0]["enabled"] is True
+    assert calls[0]["workspace"] == tmp_path
 
 
 def test_adapter_partial_with_model_returns_dir(tmp_path, monkeypatch):

--- a/inference_optimizer/tests/test_quantization_prelude.py
+++ b/inference_optimizer/tests/test_quantization_prelude.py
@@ -412,3 +412,43 @@ def test_prelude_freetext_takes_priority_over_scheme(tmp_path, monkeypatch):
     args = _Args(model="/models/src", quantize="custom mxfp4 prompt", quantize_scheme="fp8")
     asyncio.run(cli._run_quantization_prelude(args))
     assert seen["prompt"] == "custom mxfp4 prompt"  # free text wins
+
+
+def test_prelude_preserves_source_model_identity(tmp_path, monkeypatch):
+    """Regression: the quantize prelude rewrites args.model to the generic
+    ``<workspace>/quantization/<model>/quantized`` export dir (basename is always
+    ``quantized``). The session / display model identity must NOT collapse to
+    ``quantized`` — otherwise every quantized run lands under
+    ``<root>/quantized/<ts>`` and the report only shows ``Model: quantized``,
+    losing the real model name and colliding across models.
+    """
+    import inference_optimizer.paths as paths
+
+    monkeypatch.setattr(paths, "workspace_root", lambda: tmp_path)
+
+    async def _fake_async(*, prompt, source_model, workspace):
+        # Mirror the real adapter: the export dir basename is always "quantized".
+        return str(tmp_path / "quantization" / "google-gemma-4-26B-A4B-it" / "quantized")
+
+    monkeypatch.setattr(qrh, "run_quantization_prelude_async", _fake_async)
+    monkeypatch.delenv("MODEL_PATH", raising=False)
+
+    args = _Args(model="/wekafs/models/google-gemma-4-26B-A4B-it", quantize="fp8")
+    asyncio.run(cli._run_quantization_prelude(args))
+
+    # The model path is rewritten to the generic quantized export dir ...
+    assert str(args.model).endswith("/quantized")
+    # ... but the identity used for session_dir / state / manifest is preserved.
+    name = cli.resolve_model_display_name(args)
+    assert name != "quantized"
+    assert name == "google-gemma-4-26B-A4B-it-quantized"
+
+
+def test_prelude_no_display_name_without_quantization(monkeypatch):
+    """Without quantization the prelude leaves args untouched, so the identity
+    resolver falls back to the plain model-path basename (no collapse, no
+    spurious suffix)."""
+    args = _Args(model="/models/Qwen3-32B", quantize=None)
+    asyncio.run(cli._run_quantization_prelude(args))
+    assert getattr(args, "model_display_name", None) in (None, "")
+    assert cli.resolve_model_display_name(args) == "Qwen3-32B"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ testpaths = [
     "robustness-agent/tests",
     "critic-agent/runtime/tests",
     "quantization_agent/tests",
+    "quark_quantizer/tests",
     "kernel-agent/tools/test_tracelens_arch_benchmark.py",
     "kernel-agent/tools/test_ray_fd_limit.py",
     "kernel-agent/tools/test_gemm_tuning.py",
@@ -131,6 +132,7 @@ source = [
     "framework-agent/src",
     "kernel-agent/tools",
     "quantization_agent",
+    "quark_quantizer",
     "OOB",
     "ci",
 ]
@@ -169,6 +171,8 @@ omit = [
     "kernel-agent/skills/unittest/validate_harness.py",
     # quantization_agent CLI driver (argparse entrypoint).
     "quantization_agent/cli.py",
+    # quark_quantizer CLI driver (argparse entrypoint).
+    "quark_quantizer/cli.py",
     # OOB agent_mcp_server entrypoints / server-side runtime: CLI, HTTP
     # server, scheduler, auth proxy, and the subprocess agent backends are
     # network / long-running services exercised end-to-end, not by unit

--- a/quark_quantizer/__init__.py
+++ b/quark_quantizer/__init__.py
@@ -1,0 +1,27 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""quark_quantizer — a thin, parameter-gated shell over ``quantization_agent``.
+
+The original ``quantization_agent`` (the Hyperloom driver that turns a natural
+-language prompt into Quark CLI calls and executes them) is kept as-is. This
+shell adds one thing for stability: the decision to quantize is a **parameter**
+(``enabled``), supplied by the caller (a backend, driven by a frontend toggle)
+— never inferred from free-form natural language by an outer orchestration LLM.
+
+Two inputs go in conceptually: the ``enabled`` switch and the NL ``prompt``.
+When enabled, the shell forwards the prompt to
+``quantization_agent.quantize_via_prompt`` (which does prompt -> CLI -> execute);
+when disabled it is a no-op.
+
+Public entry: :func:`quantize` (and :func:`quantize_sync`).
+"""
+
+from __future__ import annotations
+
+from .runner import QuarkRunResult, quantize, quantize_sync
+
+__all__ = [
+    "QuarkRunResult",
+    "quantize",
+    "quantize_sync",
+]

--- a/quark_quantizer/cli.py
+++ b/quark_quantizer/cli.py
@@ -1,0 +1,122 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Standalone CLI for quark_quantizer.
+
+The trigger is an explicit parameter (``--enabled``), mirroring the
+frontend->backend toggle: nothing runs unless the caller opts in. The natural
+language goes in ``--prompt`` and is forwarded to the wrapped
+``quantization_agent`` (which turns it into the Quark CLI and executes it).
+
+Example::
+
+    python -m quark_quantizer.cli \\
+        --enabled \\
+        --prompt "fp8 global scheme, fp8 kv_cache, exclude lm_head" \\
+        --workspace /scratch/run-1/wks
+
+Exit codes:
+    0   success / partial / skipped (disabled)
+    1   failed (no usable quantized model)
+    2   argparse / input validation error
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from typing import Any
+
+from .runner import quantize
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Build and parse the CLI arguments.
+
+    Args:
+        argv: Argument list; defaults to ``sys.argv`` when ``None``.
+
+    Returns:
+        The parsed namespace.
+    """
+    p = argparse.ArgumentParser(
+        prog="quark_quantizer",
+        description="Parameter-gated shell over quantization_agent (Quark PTQ).",
+    )
+    # The trigger is a parameter, not an agent decision.
+    group = p.add_mutually_exclusive_group()
+    group.add_argument(
+        "--enabled",
+        dest="enabled",
+        action="store_true",
+        help="Run quantization. Without this flag the module is a no-op (skipped).",
+    )
+    group.add_argument(
+        "--disabled",
+        dest="enabled",
+        action="store_false",
+        help="Explicitly disable (default).",
+    )
+    p.set_defaults(enabled=False)
+
+    p.add_argument("--prompt", default="", help="Natural-language quantization request.")
+    p.add_argument("--workspace", required=True, help="Scratch dir for the wrapped agent's artifacts.")
+    p.add_argument("--quark-root", default=None, help="Quark checkout root (else $QUARK_ROOT).")
+    p.add_argument("--acceptable-eval-gap", type=float, default=None, help="Max relative eval gap.")
+    p.add_argument("--model-id", default=None, help="Override the wrapped agent's model id.")
+    p.add_argument("--verbose", action="store_true", help="Stream logs to stderr.")
+    return p.parse_args(argv)
+
+
+async def _run(args: argparse.Namespace) -> int:
+    """Run one request and print a JSON summary.
+
+    Args:
+        args: Parsed CLI arguments.
+
+    Returns:
+        The process exit code.
+    """
+
+    def log(line: str) -> None:
+        if args.verbose:
+            print(line, file=sys.stderr, flush=True)
+
+    result = await quantize(
+        args.prompt,
+        enabled=args.enabled,
+        workspace=args.workspace,
+        quark_root=args.quark_root,
+        acceptable_eval_gap=args.acceptable_eval_gap,
+        model=args.model_id,
+        log=log,
+    )
+
+    summary: dict[str, Any] = {
+        "status": result.status,
+        "output_dir": result.output_dir,
+        "eval_gap": result.eval_gap,
+        "final": result.final,
+        "error": result.error,
+    }
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+    return 1 if result.status == "failed" else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Args:
+        argv: Argument list; defaults to ``sys.argv`` when ``None``.
+
+    Returns:
+        The process exit code.
+    """
+    args = _parse_args(argv)
+    return asyncio.run(_run(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/quark_quantizer/runner.py
+++ b/quark_quantizer/runner.py
@@ -1,0 +1,134 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""The shell around the original ``quantization_agent`` implementation.
+
+This module adds exactly one thing on top of the existing (Quark-driving)
+``quantization_agent``: a **parameter-based trigger**. The caller (a backend,
+driven by a frontend toggle) passes ``enabled`` to decide whether quantization
+runs at all — the outermost orchestration LLM has no natural-language path into
+this module, so it cannot accidentally activate quantization.
+
+The shell does NOT reimplement prompt->CLI->execute. When enabled it forwards
+the natural-language prompt to ``quantization_agent.quantize_via_prompt``, whose
+in-agent LLM turns the prompt into the Quark CLI and runs it. The shell only
+gates the call and normalizes the result.
+
+Conceptually two inputs go in: the ``enabled`` switch and the NL ``prompt``.
+``workspace`` (and a few optional knobs) are plumbing the wrapped agent needs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+
+@dataclass(frozen=True)
+class QuarkRunResult:
+    """Normalized outcome of a (possibly skipped) quantization request.
+
+    Attributes:
+        status: ``"skipped"`` (disabled), or the wrapped agent's status
+            (``"success"`` / ``"partial"`` / ``"failed"``).
+        output_dir: Exported quantized model dir, or ``None``.
+        eval_gap: Relative eval gap from the final attempt, if any.
+        final: The wrapped agent's final outcome id, if any.
+        error: Non-empty on shell-level failures.
+    """
+
+    status: str
+    output_dir: str | None = None
+    eval_gap: float | None = None
+    final: str | None = None
+    error: str = ""
+
+
+async def quantize(
+    prompt: str,
+    *,
+    enabled: bool = False,
+    workspace: str | Path,
+    quark_root: str | Path | None = None,
+    interactive: bool | None = False,
+    acceptable_eval_gap: float | None = None,
+    max_requantize_attempts: int = 1,
+    model: str | None = None,
+    quantize_via_prompt: Callable[..., Any] | None = None,
+    log: Callable[[str], None] | None = None,
+) -> QuarkRunResult:
+    """Quantize from a natural-language prompt, gated on ``enabled``.
+
+    Args:
+        prompt: Natural-language quantization request. Forwarded verbatim to the
+            wrapped ``quantization_agent``, whose LLM turns it into the Quark CLI.
+        enabled: Master switch (default ``False`` — the module is a no-op unless
+            the caller opts in). When ``False`` the wrapped agent is never run.
+        workspace: Directory the wrapped agent writes artifacts into.
+        quark_root: Quark checkout root; falls back to ``$QUARK_ROOT``.
+        interactive: Forwarded interactivity flag (default ``False`` = batch).
+        acceptable_eval_gap: Max tolerated relative accuracy gap.
+        max_requantize_attempts: Cap on requantize retries.
+        model: Optional model id passed to the wrapped agent.
+        quantize_via_prompt: Override for the wrapped entry (testing seam).
+        log: Optional line-logging callback.
+
+    Returns:
+        The normalized :class:`QuarkRunResult`.
+    """
+    if not enabled:
+        if log:
+            log("[quark_quantizer] disabled (enabled=False); skipping quantization")
+        return QuarkRunResult(status="skipped")
+
+    qvp = quantize_via_prompt
+    if qvp is None:
+        # quantization_agent is a top-level package (sibling of inference_optimizer);
+        # imported lazily so the shell loads even where its deps are absent.
+        from quantization_agent import quantize_via_prompt as qvp_real
+
+        qvp = qvp_real
+
+    result = await qvp(
+        prompt,
+        workspace=workspace,
+        quark_root=quark_root,
+        interactive=interactive,
+        acceptable_eval_gap=acceptable_eval_gap,
+        max_requantize_attempts=max_requantize_attempts,
+        model=model,
+        log=log,
+    )
+
+    assessment = getattr(result, "assessment", None)
+    final = getattr(assessment, "final", None)
+    eval_gap = getattr(assessment, "eval_gap", None)
+    qdir = getattr(result, "quantized_model_dir", None)
+    return QuarkRunResult(
+        status=result.status,
+        output_dir=str(qdir) if qdir else None,
+        eval_gap=eval_gap,
+        final=str(final) if final is not None else None,
+    )
+
+
+def quantize_sync(prompt: str, *, enabled: bool = False, **kwargs: Any) -> QuarkRunResult:
+    """Synchronous wrapper around :func:`quantize` for non-async callers.
+
+    Args:
+        prompt: Natural-language quantization request.
+        enabled: Master switch (see :func:`quantize`).
+        **kwargs: Forwarded to :func:`quantize`.
+
+    Returns:
+        The :class:`QuarkRunResult`.
+    """
+    return asyncio.run(quantize(prompt, enabled=enabled, **kwargs))
+
+
+__all__ = [
+    "QuarkRunResult",
+    "quantize",
+    "quantize_sync",
+]

--- a/quark_quantizer/tests/__init__.py
+++ b/quark_quantizer/tests/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.

--- a/quark_quantizer/tests/test_quark_quantizer.py
+++ b/quark_quantizer/tests/test_quark_quantizer.py
@@ -1,0 +1,160 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Offline tests for the quark_quantizer shell (no real agent / SDK / GPU).
+
+The shell adds one thing: a parameter-gated trigger around the original
+``quantization_agent.quantize_via_prompt``. These tests inject a fake
+``quantize_via_prompt`` so nothing real runs, and assert:
+
+* ``enabled=False`` is a no-op (the wrapped agent is never called),
+* ``enabled=True`` forwards the prompt + plumbing and normalizes the result.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+from quark_quantizer import runner as rn
+from quark_quantizer.runner import QuarkRunResult
+
+
+def _fake_agent_result(status: str, qdir: str | None, *, final="ok", eval_gap=0.01):
+    """Build a stand-in for quantization_agent.QuantSkillRunResult."""
+    return SimpleNamespace(
+        status=status,
+        quantized_model_dir=Path(qdir) if qdir else None,
+        assessment=SimpleNamespace(final=final, eval_gap=eval_gap),
+    )
+
+
+def _capturing_qvp(result, calls: list):
+    async def _qvp(prompt, **kwargs):
+        calls.append({"prompt": prompt, **kwargs})
+        return result
+
+    return _qvp
+
+
+# ---------------------------------------------------------------------------
+# the parameter gate
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_is_noop_and_never_calls_agent(tmp_path):
+    async def _must_not_run(*a, **k):  # pragma: no cover - asserts non-call
+        raise AssertionError("wrapped agent must not run when disabled")
+
+    res = asyncio.run(
+        rn.quantize("fp8", enabled=False, workspace=tmp_path, quantize_via_prompt=_must_not_run)
+    )
+    assert res.status == "skipped"
+    assert res.output_dir is None
+
+
+def test_disabled_by_default(tmp_path):
+    async def _must_not_run(*a, **k):  # pragma: no cover - asserts non-call
+        raise AssertionError("default must be disabled")
+
+    res = asyncio.run(rn.quantize("fp8", workspace=tmp_path, quantize_via_prompt=_must_not_run))
+    assert res.status == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# delegation + result normalization
+# ---------------------------------------------------------------------------
+
+
+def test_enabled_forwards_prompt_and_plumbing(tmp_path):
+    calls: list = []
+    qvp = _capturing_qvp(_fake_agent_result("success", str(tmp_path / "q")), calls)
+    res = asyncio.run(
+        rn.quantize(
+            "fp8 exclude lm_head",
+            enabled=True,
+            workspace=tmp_path,
+            quark_root="/qr",
+            acceptable_eval_gap=0.05,
+            quantize_via_prompt=qvp,
+        )
+    )
+    assert res.status == "success"
+    assert res.output_dir == str(tmp_path / "q")
+    assert res.eval_gap == 0.01
+    assert res.final == "ok"
+    # The NL prompt is forwarded verbatim; plumbing is passed through.
+    assert calls[0]["prompt"] == "fp8 exclude lm_head"
+    assert calls[0]["workspace"] == tmp_path
+    assert calls[0]["quark_root"] == "/qr"
+    assert calls[0]["acceptable_eval_gap"] == 0.05
+    assert calls[0]["interactive"] is False
+
+
+def test_partial_with_model_is_normalized(tmp_path):
+    calls: list = []
+    qvp = _capturing_qvp(_fake_agent_result("partial", str(tmp_path / "q"), final="eval_gap_exceeded"), calls)
+    res = asyncio.run(rn.quantize("fp8", enabled=True, workspace=tmp_path, quantize_via_prompt=qvp))
+    assert res.status == "partial"
+    assert res.output_dir == str(tmp_path / "q")
+    assert res.final == "eval_gap_exceeded"
+
+
+def test_failed_has_no_output_dir(tmp_path):
+    calls: list = []
+    qvp = _capturing_qvp(_fake_agent_result("failed", None, final="exec_model_load_failed"), calls)
+    res = asyncio.run(rn.quantize("fp8", enabled=True, workspace=tmp_path, quantize_via_prompt=qvp))
+    assert res.status == "failed"
+    assert res.output_dir is None
+    assert res.final == "exec_model_load_failed"
+
+
+def test_quantize_sync_wrapper(tmp_path):
+    calls: list = []
+    qvp = _capturing_qvp(_fake_agent_result("success", str(tmp_path / "q")), calls)
+    res = rn.quantize_sync("fp8", enabled=True, workspace=tmp_path, quantize_via_prompt=qvp)
+    assert res.status == "success"
+    assert isinstance(res, QuarkRunResult)
+
+
+# ---------------------------------------------------------------------------
+# cli (param-driven trigger)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_defaults_to_disabled():
+    from quark_quantizer import cli
+
+    args = cli._parse_args(["--workspace", "/w"])
+    assert args.enabled is False
+
+
+def test_cli_enabled_flag_and_run(monkeypatch, capsys):
+    from quark_quantizer import cli
+
+    seen: dict = {}
+
+    async def _fake_quantize(prompt, *, enabled, **kwargs):
+        seen["enabled"] = enabled
+        seen["prompt"] = prompt
+        return QuarkRunResult(status="skipped")
+
+    monkeypatch.setattr(cli, "quantize", _fake_quantize)
+    rc = cli.main(["--enabled", "--workspace", "/w", "--prompt", "fp8"])
+    import json
+
+    assert rc == 0
+    assert seen["enabled"] is True
+    assert seen["prompt"] == "fp8"
+    assert json.loads(capsys.readouterr().out)["status"] == "skipped"
+
+
+def test_cli_failed_status_exit_code(monkeypatch):
+    from quark_quantizer import cli
+
+    async def _fake_quantize(prompt, *, enabled, **kwargs):
+        return QuarkRunResult(status="failed", error="boom")
+
+    monkeypatch.setattr(cli, "quantize", _fake_quantize)
+    rc = cli.main(["--enabled", "--workspace", "/w"])
+    assert rc == 1

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,12 @@ from __future__ import annotations
 from setuptools import find_packages, setup
 
 setup(
-    packages=find_packages(include=["inference_optimizer", "inference_optimizer.*"]),
+    packages=find_packages(
+        include=[
+            "inference_optimizer",
+            "inference_optimizer.*",
+            "quark_quantizer",
+            "quark_quantizer.*",
+        ],
+    ),
 )


### PR DESCRIPTION
Bundles three independent Hyperloom changes into one PR (3 commits).

## 1. fix(quantize): preserve source model identity after quantization prelude
After the prelude rewrites `--model` to `<workspace>/quantization/<model>/quantized`
(basename always `quantized`), session dir / `SharedState.model_name` /
`manifest.json` all collapsed to `quantized`, losing the real model name and
colliding concurrent quantized runs. Pin `args.model_display_name`
(`<source>-quantized`) + add `resolve_model_display_name()`; `model_path` is
unchanged.

## 2. feat(quark): param-gated quark_quantizer shell over quantization_agent
Add `quark_quantizer`, a thin shell over the existing `quantization_agent`. Its
only addition is a parameter-based trigger (`enabled`, default `False`) so an
outer orchestration LLM has no NL path to accidentally activate quantization.
When enabled it forwards the prompt verbatim to
`quantization_agent.quantize_via_prompt` (unchanged); the prelude adapter is
repointed to the shell. `quantization_agent` kept intact.

## 3. docs(env): document gemm-tune KB / kernel-opt order / trace route vars
Commented `.env.template` entries for `FORGE_GEMM_TUNE_KB_READ` (+ gbrain),
`KERNEL_OPT_BACKEND_ORDER`, and `HYPERLOOM_TRACE_ANALYSIS_ROUTE` (all default off).

## Test plan
- [x] `quark_quantizer/tests/`, `test_quantization_prelude.py`,
      `test_cli_bootstrap_coverage_unit.py` — 55 passed.
- [x] Regressions (`test_session_layout` / `test_resume` / `test_shared_state_*`
      / `-k manifest`) green on the individual branches.

Supersedes #736, #737, #738.

Made with [Cursor](https://cursor.com)