### PR TITLE
ci: split optimize-submit schedule into per-pool sub100 dispatchers

### DIFF
--- a/.github/workflows/optimize-sub100-part1.yml
+++ b/.github/workflows/optimize-sub100-part1.yml
@@ -1,0 +1,147 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+name: optimize-sub100-part1
+
+# Thin scheduler shell for the sub100 part1 pool (replaces the schedule that used
+# to live inside optimize-submit.yml, which is now a pure reusable execution
+# engine). Resolves the next batch via ci/batch_rotate.py and forwards it to
+# `SaFE Optimize Submit` (optimize-submit.yml) — same shape as part2/part3.
+#
+#   pool   = $WEKAFS_CHENYI_DIR/ci-candidates/hf_sub100_part1_20260626.json
+#   batch  = 240 (= max_parallel; a batch always runs fully in parallel)
+#   budget = max_hours 6 (== cron period)
+#
+# Cadence: every 6h at UTC 00:07 / 06:07 / 12:07 / 18:07 (Beijing 08/14/20/02) —
+# identical to the old optimize-submit schedule. Minute :07 dodges GitHub's
+# congested top-of-hour cron queue. INVARIANT: cron period == MAX_HOURS (6h).
+
+on:
+  schedule:
+    - cron: '7 0,6,12,18 * * *'
+  workflow_dispatch:
+    inputs:
+      batch_index:
+        description: 'Optional 0-based batch override. Empty = derive from the current 6-hour UTC slot.'
+        required: false
+        default: ''
+      dry_run:
+        description: 'Forward dry_run=true to SaFE Optimize Submit.'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: optimize-sub100-part1-dispatch
+  cancel-in-progress: false
+
+jobs:
+  dispatch-submit:
+    name: Dispatch sub100 part1 submit
+    runs-on: hyperloom-mh826
+    timeout-minutes: 10
+    env:
+      # Off-repo pool on /wekafs (the /wekafs root lives in the WEKAFS_CHENYI_DIR
+      # secret; generate_hf_matrix reads the absolute path as-is, and the
+      # hyperloom runners RO-mount /wekafs).
+      CANDIDATES_FILE: ${{ format('{0}/ci-candidates/hf_sub100_part1_20260626.json', secrets.WEKAFS_CHENYI_DIR) }}
+      CANDIDATES_PATH: ${{ format('{0}/ci-candidates/hf_sub100_part1_20260626.json', secrets.WEKAFS_CHENYI_DIR) }}
+      # One batch = 240 models, all run concurrently. BATCH_SIZE doubles as the
+      # max_parallel (a batch always runs fully in parallel).
+      BATCH_SIZE: '240'
+      # Rotation step (hours). MUST equal the cron PERIOD (this cron fires every
+      # 6h: 0/6/12/18 UTC), same invariant as the other pools. Also the per-task
+      # optimizer budget forwarded below.
+      MAX_HOURS: '6'
+      SUBMIT_WORKSPACES: 'core42-hyperloom'
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Resolve part1 batch
+        id: batch
+        env:
+          INPUT_BATCH_INDEX: ${{ github.event.inputs.batch_index }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ ! -f "${CANDIDATES_PATH}" ]; then
+            echo "::error::candidates pool not found: ${CANDIDATES_PATH}"
+            exit 1
+          fi
+          # Same max_hours-paced rotation as the sibling pools (ci/batch_rotate.py,
+          # unit-tested): one batch advances per MAX_HOURS of wall-clock time since
+          # the anchor, auto-rotating on schedule and honoring an explicit
+          # batch_index on manual dispatch. ANCHOR 2026-06-26 12:00Z is INHERITED
+          # from the old built-in optimize-submit schedule (generate_hf_matrix's
+          # _CRON_ANCHOR_UTC) so this pool CONTINUES the rotation already in
+          # progress instead of restarting at batch 0 and re-running done batches.
+          n=$(python3 -c "import json,os;print(len(json.load(open(os.environ['CANDIDATES_PATH'])).get('candidates') or []))")
+          out=$(python3 ci/batch_rotate.py \
+            --count "${n}" \
+            --batch-size "${BATCH_SIZE}" \
+            --batch-index "${INPUT_BATCH_INDEX:-}" \
+            --max-hours "${MAX_HOURS}" \
+            --anchor "2026-06-26T12:00:00+00:00" \
+            --event "${EVENT}")
+          bi=$(echo "$out" | cut -f1); pool=$(echo "$out" | cut -f2)
+          batches=$(echo "$out" | cut -f3); start=$(echo "$out" | cut -f4); end=$(echo "$out" | cut -f5)
+          {
+            echo "batch_index=${bi}"
+            echo "pool_size=${pool}"
+            echo "batches=${batches}"
+            echo "slice=${start}:${end}"
+          } >> "$GITHUB_OUTPUT"
+          echo "### part1 pool: ${pool} models; batch ${bi}/${batches}; slice ${start}:${end}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Dispatch SaFE Optimize Submit
+        run: |
+          set -euo pipefail
+          dry_run="${DRY_RUN:-false}"
+          ref="${GITHUB_REF_NAME}"
+          batch_index="${{ steps.batch.outputs.batch_index }}"
+
+          echo "Dispatching optimize-submit.yml on ref=${ref}"
+          echo "part1 pool: ${{ steps.batch.outputs.pool_size }} models; batch ${batch_index}/${{ steps.batch.outputs.batches }}; slice ${{ steps.batch.outputs.slice }}"
+          echo "Batch size: ${BATCH_SIZE}; max_parallel=${BATCH_SIZE}; submit_workspaces=${SUBMIT_WORKSPACES}"
+
+          payload=$(python3 - <<'PY'
+          import json
+          import os
+
+          payload = {
+              "ref": os.environ["GITHUB_REF_NAME"],
+              "inputs": {
+                  "models": "",
+                  "candidates_file": os.environ["CANDIDATES_FILE"],
+                  "batch_index": os.environ["BATCH_INDEX"],
+                  "batch_size": os.environ["BATCH_SIZE"],
+                  "exclude_leaderboard": "false",
+                  "exclude_active_workflows": "true",
+                  # A batch always runs fully in parallel, so max_parallel == batch_size.
+                  "max_parallel": os.environ["BATCH_SIZE"],
+                  "submit_workspaces": os.environ["SUBMIT_WORKSPACES"],
+                  # task wait + job timeout are derived from max_hours in
+                  # optimize-submit's prepare job (max_hours+30m / +60m).
+                  "max_hours": os.environ["MAX_HOURS"],
+                  "all_artifacts": "true",
+                  "dry_run": os.environ.get("DRY_RUN") or "false",
+              },
+          }
+          print(json.dumps(payload))
+          PY
+          )
+
+          curl -fsS \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/optimize-submit.yml/dispatches" \
+            -d "$payload"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          BATCH_INDEX: ${{ steps.batch.outputs.batch_index }}

--- a/.github/workflows/optimize-sub100-part2.yml
+++ b/.github/workflows/optimize-sub100-part2.yml
@@ -1,0 +1,148 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+name: optimize-sub100-part2
+
+# Thin scheduler shell for the sub100 part2 pool (formerly optimize-tiny). It
+# delegates to `SaFE Optimize Submit` (optimize-submit.yml) so submission,
+# waiting, artifact collection, summary rendering, webhook, and perf publishing
+# stay byte-for-byte on the regular SaFE submit path — same shape as
+# part1/part3.
+#
+#   pool   = $WEKAFS_CHENYI_DIR/ci-candidates/hf_sub100_part2_20260626.json
+#   batch  = 240 (= max_parallel; a batch always runs fully in parallel)
+#   budget = max_hours 6 (== cron period)
+#
+# The candidates JSON lives on /wekafs (RO-mounted on the hyperloom runners)
+# instead of the git repo, so the large pool never bloats git history.
+
+on:
+  # Four times a day (every 6 hours, UTC) at 01:07/07:07/13:07/19:07 UTC
+  # (Beijing 09:07 / 15:07 / 21:07 / 03:07). optimize-submit fires 1h earlier
+  # (Beijing 08/14/20/02) and optimize-gte100 1h later (Beijing 10/22), so no
+  # two start in the same hour. Minute :07 (not :00) dodges GitHub's congested
+  # top-of-hour scheduling queue.
+  schedule:
+    - cron: '7 1,7,13,19 * * *'
+  workflow_dispatch:
+    inputs:
+      batch_index:
+        description: 'Optional 0-based batch override. Empty = derive from the current 6-hour UTC slot.'
+        required: false
+        default: ''
+      dry_run:
+        description: 'Forward dry_run=true to SaFE Optimize Submit.'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: optimize-tiny-dispatch
+  cancel-in-progress: false
+
+jobs:
+  dispatch-submit:
+    name: Dispatch sub100 part2 submit
+    runs-on: hyperloom-mh826
+    timeout-minutes: 10
+    env:
+      # Off-repo pool on /wekafs (the /wekafs root lives in the WEKAFS_CHENYI_DIR
+      # secret; generate_hf_matrix reads the absolute path as-is, and the
+      # hyperloom runners RO-mount /wekafs).
+      CANDIDATES_FILE: ${{ format('{0}/ci-candidates/hf_sub100_part2_20260626.json', secrets.WEKAFS_CHENYI_DIR) }}
+      CANDIDATES_PATH: ${{ format('{0}/ci-candidates/hf_sub100_part2_20260626.json', secrets.WEKAFS_CHENYI_DIR) }}
+      BATCH_SIZE: '240'
+      # Rotation step (hours). MUST equal the cron PERIOD (this cron fires every
+      # 6h: 1/7/13/19 UTC), same invariant as the other pools. Also the per-task
+      # optimizer budget forwarded below.
+      MAX_HOURS: '6'
+      SUBMIT_WORKSPACES: 'core42-hyperloom'
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Resolve part2 batch
+        id: batch
+        env:
+          INPUT_BATCH_INDEX: ${{ github.event.inputs.batch_index }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ ! -f "${CANDIDATES_PATH}" ]; then
+            echo "::error::candidates pool not found: ${CANDIDATES_PATH}"
+            exit 1
+          fi
+          # Same max_hours-paced rotation as the sibling pools (ci/batch_rotate.py,
+          # unit-tested): one batch advances per MAX_HOURS of wall-clock time since
+          # the anchor, auto-rotating on schedule and honoring an explicit
+          # batch_index on manual dispatch. ANCHOR 2026-06-26 13:00Z aligns batch 0
+          # with the next fire (13:07Z), independent of the other pools' anchors.
+          n=$(python3 -c "import json,os;print(len(json.load(open(os.environ['CANDIDATES_PATH'])).get('candidates') or []))")
+          out=$(python3 ci/batch_rotate.py \
+            --count "${n}" \
+            --batch-size "${BATCH_SIZE}" \
+            --batch-index "${INPUT_BATCH_INDEX:-}" \
+            --max-hours "${MAX_HOURS}" \
+            --anchor "2026-06-26T13:00:00+00:00" \
+            --event "${EVENT}")
+          bi=$(echo "$out" | cut -f1); pool=$(echo "$out" | cut -f2)
+          batches=$(echo "$out" | cut -f3); start=$(echo "$out" | cut -f4); end=$(echo "$out" | cut -f5)
+          {
+            echo "batch_index=${bi}"
+            echo "pool_size=${pool}"
+            echo "batches=${batches}"
+            echo "slice=${start}:${end}"
+          } >> "$GITHUB_OUTPUT"
+          echo "### part2 pool: ${pool} models; batch ${bi}/${batches}; slice ${start}:${end}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Dispatch SaFE Optimize Submit
+        run: |
+          set -euo pipefail
+          dry_run="${DRY_RUN:-false}"
+          ref="${GITHUB_REF_NAME}"
+          batch_index="${{ steps.batch.outputs.batch_index }}"
+
+          echo "Dispatching optimize-submit.yml on ref=${ref}"
+          echo "part2 pool: ${{ steps.batch.outputs.pool_size }} models; batch ${batch_index}/${{ steps.batch.outputs.batches }}; slice ${{ steps.batch.outputs.slice }}"
+          echo "Batch size: ${BATCH_SIZE}; max_parallel=${BATCH_SIZE}; submit_workspaces=${SUBMIT_WORKSPACES}"
+
+          payload=$(python3 - <<'PY'
+          import json
+          import os
+
+          payload = {
+              "ref": os.environ["GITHUB_REF_NAME"],
+              "inputs": {
+                  "models": "",
+                  "candidates_file": os.environ["CANDIDATES_FILE"],
+                  "batch_index": os.environ["BATCH_INDEX"],
+                  "batch_size": os.environ["BATCH_SIZE"],
+                  "exclude_leaderboard": "false",
+                  "exclude_active_workflows": "true",
+                  # A batch always runs fully in parallel, so max_parallel == batch_size.
+                  "max_parallel": os.environ["BATCH_SIZE"],
+                  "submit_workspaces": os.environ["SUBMIT_WORKSPACES"],
+                  # task wait + job timeout are derived from max_hours in
+                  # optimize-submit's prepare job (max_hours+30m / +60m).
+                  "max_hours": os.environ["MAX_HOURS"],
+                  "all_artifacts": "true",
+                  "dry_run": os.environ.get("DRY_RUN") or "false",
+              },
+          }
+          print(json.dumps(payload))
+          PY
+          )
+
+          curl -fsS \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/optimize-submit.yml/dispatches" \
+            -d "$payload"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          BATCH_INDEX: ${{ steps.batch.outputs.batch_index }}

--- a/.github/workflows/optimize-sub100-part2.yml
+++ b/.github/workflows/optimize-sub100-part2.yml
@@ -40,7 +40,7 @@ permissions:
   actions: write
 
 concurrency:
-  group: optimize-tiny-dispatch
+  group: optimize-sub100-part2-dispatch
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/optimize-sub100-part3.yml
+++ b/.github/workflows/optimize-sub100-part3.yml
@@ -1,33 +1,32 @@
 # Copyright Advanced Micro Devices, Inc. All rights reserved.
 
-name: SaFE Optimize Tiny (count-filler)
+name: optimize-sub100-part3
 
-# Scheduled/manual entrypoint for the count-filler pool, hosted off-repo at
-#   $WEKAFS_CHENYI_DIR/ci-candidates/sub100_lt12b_pulse_notrun.json
-#   (a date-less symlink that always points at the latest filtered pool)
-#   = HF text-generation models with <12B params AND <100 downloads that pulse
-#     has NOT run yet. The goal is breadth -- sweep the long tail.
+# Scheduled/manual entrypoint for the sub100 part3 pool, hosted off-repo at
+#   $WEKAFS_CHENYI_DIR/ci-candidates/hf_sub100_part3_20260626.json
 #
-# It intentionally delegates to `SaFE Optimize Submit` so submission, waiting,
-# artifact collection, summary rendering, webhook, and perf publishing stay
-# byte-for-byte on the same path as the regular SaFE submit workflow. It runs
-# INDEPENDENTLY of the large-B production cron (optimize-submit.yml's own
-# schedule, which sweeps the gt100 rotate pool twice a day).
+# It delegates to `SaFE Optimize Submit` (optimize-submit.yml) so submission,
+# waiting, artifact collection, summary rendering, webhook, and perf publishing
+# stay byte-for-byte on the regular SaFE submit path.
 #
-# Cadence: 240 models per batch, 6h optimizer budget each, 4 runs/day (every
-# 6h), all submitted to the sandbox workspace.
+# Sizing: part1/part2/part3 were carved so the three sub100 sweeps finish at
+# about the same wall-clock time. A full sweep takes pool_size / batch_size
+# batches: part1=1608/240, part2=1608/240, part3=671/100 -> all ~6.7 batches.
+# A batch always runs fully in parallel, so BATCH_SIZE doubles as max_parallel.
+#
+# Cadence: four times a day (every 6h, UTC) at 05:07/11:07/17:07/23:07 UTC
+# (Beijing 13:07 / 19:07 / 01:07 / 07:07). The sibling pools fire on different
+# hours (part1 01/07/13/19 UTC, part2 03/09/15/21 UTC) so no two start in the
+# same hour. Minute :07 (not :00) dodges GitHub's congested top-of-hour queue.
+# INVARIANT: the cron PERIOD must equal MAX_HOURS (6h); changing one without the
+# other makes the rotation double-submit (cron faster) or skip batches (slower).
 #
 # The candidates JSON lives on /wekafs (RO-mounted on the hyperloom runners)
 # instead of the git repo, so the large pool never bloats git history.
 
 on:
-  # Four times a day (every 6 hours, UTC) at 01:07/07:07/13:07/19:07 UTC
-  # (Beijing 09:07 / 15:07 / 21:07 / 03:07). optimize-submit fires 1h earlier
-  # (Beijing 08/14/20/02) and optimize-gte100 1h later (Beijing 10/22), so no
-  # two start in the same hour. Minute :07 (not :00) dodges GitHub's congested
-  # top-of-hour scheduling queue.
   schedule:
-    - cron: '7 1,7,13,19 * * *'
+    - cron: '7 5,11,17,23 * * *'
   workflow_dispatch:
     inputs:
       batch_index:
@@ -45,31 +44,32 @@ permissions:
   actions: write
 
 concurrency:
-  group: optimize-tiny-dispatch
+  group: optimize-part3-dispatch
   cancel-in-progress: false
 
 jobs:
   dispatch-submit:
-    name: Dispatch 240-model count-filler submit
+    name: Dispatch sub100 part3 submit
     runs-on: hyperloom-mh826
     timeout-minutes: 10
     env:
       # Off-repo pool on /wekafs (the /wekafs root lives in the WEKAFS_CHENYI_DIR
       # secret; generate_hf_matrix reads the absolute path as-is, and the
       # hyperloom runners RO-mount /wekafs).
-      CANDIDATES_FILE: ${{ format('{0}/ci-candidates/hf_sub100_part2_20260626.json', secrets.WEKAFS_CHENYI_DIR) }}
-      CANDIDATES_PATH: ${{ format('{0}/ci-candidates/hf_sub100_part2_20260626.json', secrets.WEKAFS_CHENYI_DIR) }}
-      BATCH_SIZE: '240'
+      CANDIDATES_FILE: ${{ format('{0}/ci-candidates/hf_sub100_part3_20260626.json', secrets.WEKAFS_CHENYI_DIR) }}
+      CANDIDATES_PATH: ${{ format('{0}/ci-candidates/hf_sub100_part3_20260626.json', secrets.WEKAFS_CHENYI_DIR) }}
+      # One batch = 100 models, all run concurrently. BATCH_SIZE doubles as the
+      # max_parallel (a batch always runs fully in parallel).
+      BATCH_SIZE: '100'
       # Rotation step (hours). MUST equal the cron PERIOD (this cron fires every
-      # 6h: 1/7/13/19 UTC), same invariant as optimize-submit/gte100. Also the
-      # per-task optimizer budget forwarded below.
+      # 6h: 5/11/17/23 UTC), same invariant as the other pools. Also the per-task
+      # optimizer budget forwarded below.
       MAX_HOURS: '6'
-      # Count-filler runs go to the hyperloom workspace only.
       SUBMIT_WORKSPACES: 'core42-hyperloom'
     steps:
       - uses: actions/checkout@v7
 
-      - name: Resolve count-filler batch
+      - name: Resolve part3 batch
         id: batch
         env:
           INPUT_BATCH_INDEX: ${{ github.event.inputs.batch_index }}
@@ -80,18 +80,18 @@ jobs:
             echo "::error::candidates pool not found: ${CANDIDATES_PATH}"
             exit 1
           fi
-          # Same max_hours-paced rotation as optimize-submit/gte100 (ci/batch_rotate.py,
-          # unit-tested): one batch advances per MAX_HOURS of wall-clock time since the
-          # anchor, auto-rotating on schedule and honoring an explicit batch_index on
-          # manual dispatch. ANCHOR 2026-06-26 13:00Z restarts THIS pool's sweep at
-          # batch 0 on the next fire (13:07Z), independent of gte100's shared anchor.
+          # Same max_hours-paced rotation as the sibling pools (ci/batch_rotate.py,
+          # unit-tested): one batch advances per MAX_HOURS of wall-clock time since
+          # the anchor, auto-rotating on schedule and honoring an explicit
+          # batch_index on manual dispatch. ANCHOR 2026-06-26 23:00Z aligns batch 0
+          # with the next fire (23:07Z), independent of the other pools' anchors.
           n=$(python3 -c "import json,os;print(len(json.load(open(os.environ['CANDIDATES_PATH'])).get('candidates') or []))")
           out=$(python3 ci/batch_rotate.py \
             --count "${n}" \
             --batch-size "${BATCH_SIZE}" \
             --batch-index "${INPUT_BATCH_INDEX:-}" \
             --max-hours "${MAX_HOURS}" \
-            --anchor "2026-06-26T13:00:00+00:00" \
+            --anchor "2026-06-26T23:00:00+00:00" \
             --event "${EVENT}")
           bi=$(echo "$out" | cut -f1); pool=$(echo "$out" | cut -f2)
           batches=$(echo "$out" | cut -f3); start=$(echo "$out" | cut -f4); end=$(echo "$out" | cut -f5)
@@ -101,7 +101,7 @@ jobs:
             echo "batches=${batches}"
             echo "slice=${start}:${end}"
           } >> "$GITHUB_OUTPUT"
-          echo "### tiny pool: ${pool} models; batch ${bi}/${batches}; slice ${start}:${end}" >> "$GITHUB_STEP_SUMMARY"
+          echo "### part3 pool: ${pool} models; batch ${bi}/${batches}; slice ${start}:${end}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Dispatch SaFE Optimize Submit
         run: |
@@ -111,8 +111,8 @@ jobs:
           batch_index="${{ steps.batch.outputs.batch_index }}"
 
           echo "Dispatching optimize-submit.yml on ref=${ref}"
-          echo "Count-filler pool: ${{ steps.batch.outputs.pool_size }} models; batch ${batch_index}/${{ steps.batch.outputs.batches }}; slice ${{ steps.batch.outputs.slice }}"
-          echo "Batch size: ${BATCH_SIZE}; max_parallel=240; submit_workspaces=${SUBMIT_WORKSPACES}"
+          echo "part3 pool: ${{ steps.batch.outputs.pool_size }} models; batch ${batch_index}/${{ steps.batch.outputs.batches }}; slice ${{ steps.batch.outputs.slice }}"
+          echo "Batch size: ${BATCH_SIZE}; max_parallel=${BATCH_SIZE}; submit_workspaces=${SUBMIT_WORKSPACES}"
 
           payload=$(python3 - <<'PY'
           import json
@@ -127,11 +127,12 @@ jobs:
                   "batch_size": os.environ["BATCH_SIZE"],
                   "exclude_leaderboard": "false",
                   "exclude_active_workflows": "true",
-                  "max_parallel": "240",
+                  # A batch always runs fully in parallel, so max_parallel == batch_size.
+                  "max_parallel": os.environ["BATCH_SIZE"],
                   "submit_workspaces": os.environ["SUBMIT_WORKSPACES"],
                   # task wait + job timeout are derived from max_hours in
                   # optimize-submit's prepare job (max_hours+30m / +60m).
-                  "max_hours": "6",
+                  "max_hours": os.environ["MAX_HOURS"],
                   "all_artifacts": "true",
                   "dry_run": os.environ.get("DRY_RUN") or "false",
               },

--- a/.github/workflows/optimize-sub100-part3.yml
+++ b/.github/workflows/optimize-sub100-part3.yml
@@ -44,7 +44,7 @@ permissions:
   actions: write
 
 concurrency:
-  group: optimize-part3-dispatch
+  group: optimize-sub100-part3-dispatch
   cancel-in-progress: false
 
 jobs:
@@ -83,15 +83,16 @@ jobs:
           # Same max_hours-paced rotation as the sibling pools (ci/batch_rotate.py,
           # unit-tested): one batch advances per MAX_HOURS of wall-clock time since
           # the anchor, auto-rotating on schedule and honoring an explicit
-          # batch_index on manual dispatch. ANCHOR 2026-06-26 23:00Z aligns batch 0
-          # with the next fire (23:07Z), independent of the other pools' anchors.
+          # batch_index on manual dispatch. ANCHOR 2026-06-27 02:00Z (Beijing
+          # 2026-06-27 10:00) is the batch-0 start, independent of the other
+          # pools' anchors.
           n=$(python3 -c "import json,os;print(len(json.load(open(os.environ['CANDIDATES_PATH'])).get('candidates') or []))")
           out=$(python3 ci/batch_rotate.py \
             --count "${n}" \
             --batch-size "${BATCH_SIZE}" \
             --batch-index "${INPUT_BATCH_INDEX:-}" \
             --max-hours "${MAX_HOURS}" \
-            --anchor "2026-06-26T23:00:00+00:00" \
+            --anchor "2026-06-27T02:00:00+00:00" \
             --event "${EVENT}")
           bi=$(echo "$out" | cut -f1); pool=$(echo "$out" | cut -f2)
           batches=$(echo "$out" | cut -f3); start=$(echo "$out" | cut -f4); end=$(echo "$out" | cut -f5)

--- a/.github/workflows/optimize-submit.yml
+++ b/.github/workflows/optimize-submit.yml
@@ -34,23 +34,11 @@ name: SaFE Optimize Submit
 #   • Quick HF top-N probe   : `-f hf_top=10 -f min_params=7`
 
 on:
-  # Rolling downloads>100 pool: 240 models every 6 hours, firing at UTC
-  # 00:07 / 06:07 / 12:07 / 18:07 (Beijing 08:07 / 14:07 / 20:07 / 02:07).
-  # Minute is :07 (not :00) on purpose — GitHub delays cron heavily at the top
-  # of the hour when many repos fire at once; an off-peak minute reduces the lag.
-  # Each fire submits the NEXT sequential 240-model slice of the rotate pool,
-  # now hosted off-repo at
-  # $WEKAFS_CHENYI_DIR/ci-candidates/hf_downloads_gt100_rotate.json
-  # (a date-less symlink that always points at the latest filtered pool;
-  # ordered not-run first; the 449 >12B multimodal models are front-loaded),
-  # stepping batch 0,1,2,... and wrapping at the pool end. Both
-  # exclude_leaderboard is OFF on schedule so the whole pool keeps cycling
-  # (re-running finished models too). exclude_active is ON to skip models
-  # already queued/running in other SaFE Optimize Submit runs.
-  # The tail batch is short (not head-wrapped) so consecutive fires never
-  # double-submit the head models. Manual workflow_dispatch is unaffected.
-  schedule:
-    - cron: '7 0,6,12,18 * * *'
+  # No schedule of its own: this is the shared EXECUTION ENGINE. The per-pool
+  # scheduler shells (optimize-sub100-part1 / -part2 / -part3) own the cron
+  # schedules and trigger this workflow via the GitHub API with their pool file,
+  # batch slice, batch_size (= max_parallel) and max_hours. Manual runs go
+  # straight through workflow_dispatch.
   workflow_dispatch:
     # ⚠️ HARD LIMIT: GitHub allows at most 25 top-level `inputs` for a
     # workflow_dispatch event (raised from 10 on 2025-12-04). Exceeding it makes

--- a/ci/candidates/inferencex_daily_fixed.json
+++ b/ci/candidates/inferencex_daily_fixed.json
@@ -171,7 +171,7 @@
       "repo_id": "google/gemma-4-26B-A4B-it",
       "framework": "vllm",
       "precision": "FP8",
-      "tp": 8,
+      "tp": 2,
       "conc": 64,
       "registered": false,
       "note": "Gemma4ForConditionalGeneration — MULTIMODAL (vision+audio+text), MoE ~26B total / ~4B active, BF16 native (no quantization_config), 256k (262144) context. Stock vLLM/sglang builds do not serve gemma-4; framework=vllm with dedicated image harbor.core42.primus-safe.amd.com/sync/vllm-openai-rocm:gemma4 (auto-selected by optimize_submit for gemma-4 repos). MI300X has no native FP4 -> dynamic FP8. Gated google repo (needs HF_TOKEN with gemma access). CAVEAT: multimodal head + 256k KV cache may need higher tp / context limiting; verify it serves for text-gen before relying on results.",


### PR DESCRIPTION
Turn optimize-submit.yml into a pure reusable execution engine (drop its built-in schedule) and move the cron scheduling into three thin dispatcher shells that trigger it via the GitHub API:

- optimize-sub100-part1: part1 pool, max_parallel 240, cron 0,6,12,18 UTC, anchor 2026-06-26T12:00Z (inherits the old submit schedule rotation).
- optimize-sub100-part2: renamed from optimize-tiny; part2 pool, 240, cron 1,7,13,19 UTC, anchor 13:00Z (unchanged tiny behavior).
- optimize-sub100-part3: NEW; part3 pool, max_parallel 100, max_hours 6, cron 5,11,17,23 UTC, anchor 23:00Z.

The submit/tiny inputs, batch rotation (incl. time anchors) and max_parallel are preserved 1:1 so part1/part2 continue the in-progress sweeps without re-running done batches; optimize-gte100 is untouched.

- Description: what and why
- Linked issue(s): close/fix refs
- Tests: added/updated? commands run?
- Breaking changes: yes/no (details if yes)
