### PR TITLE
fix(roofline): Reprofile if broken traces exist (#735)

### DIFF
--- a/inference_optimizer/orchestrator/action_executors/profile.py
+++ b/inference_optimizer/orchestrator/action_executors/profile.py
@@ -407,41 +407,50 @@ PROFILE_DEFAULT_CONFIG = asset_root() / "scripts" / "configs" / "profile_sglang.
 PROFILE_DEFAULT_TIMEOUT_SEC = 14400  # 4 h wall cap; Qwen3-32B TP=1 profile needs ~3 h with steady-state window
 
 
+def _is_capture_trace(path: Path) -> bool:
+    """True when ``path`` lives under a ``capture_traces`` directory.
+
+    CUDA-graph capture sidecars are written under ``capture_traces/`` by both
+    frameworks: SGLang as ``bs_*_rank*.json.gz`` (no ``.trace`` infix) and vLLM
+    as ``graph_capture_*.pt.trace.json.gz`` (which DOES end in ``.trace.json.gz``
+    and so would otherwise be mistaken for a real annotated trace, #735). These
+    capture the one-time graph-capture window and carry no per-iteration
+    annotations, so the steady-state splitter cannot use them. The parent
+    directory is the only framework-agnostic discriminator — a real annotated
+    serving trace never lives under ``capture_traces/``.
+    """
+    return any(part == "capture_traces" for part in path.parts)
+
+
 def _trace_files_for_dir(trace_dir: Path) -> list[Path]:
-    """Return ``*.trace.json.gz`` files under ``trace_dir`` (recursive,
-    stable order).
+    """Return annotated ``*.trace.json.gz`` files under ``trace_dir``.
+
+    Excludes capture sidecars under ``capture_traces/`` (see
+    :func:`_is_capture_trace`) so a vLLM ``graph_capture_*.pt.trace.json.gz`` is
+    never promoted as the primary annotated trace (#735).
 
     Args:
         trace_dir: The directory to scan recursively.
 
     Returns:
-        Sorted ``*.trace.json.gz`` paths found under ``trace_dir``.
+        Sorted annotated ``*.trace.json.gz`` paths, capture sidecars removed.
     """
-    return sorted(trace_dir.rglob("*.trace.json.gz"))
-
-
-# SGLang graph-capture sidecars land as ``capture_traces/bs_*_rank*.json.gz``
-# (no ``.trace`` infix), so the primary ``*.trace.json.gz`` glob misses them.
-# Scoped to capture sidecar names so arbitrary ``*.json.gz`` is never promoted.
-_CAPTURE_SIDECAR_GLOBS = ("bs_*_rank*.json.gz", "graph_capture*.json.gz")
+    return sorted(p for p in trace_dir.rglob("*.trace.json.gz") if not _is_capture_trace(p))
 
 
 def _capture_sidecar_traces_for_dir(trace_dir: Path) -> list[Path]:
-    """Return SGLang capture sidecars under ``trace_dir`` (fallback only).
+    """Return CUDA-graph capture sidecars under ``trace_dir`` (fallback only).
+
+    Anything under a ``capture_traces/`` directory, regardless of name — both
+    SGLang ``bs_*`` and vLLM ``graph_capture_*`` sidecars (#735).
 
     Args:
         trace_dir: The directory to scan recursively.
 
     Returns:
-        Sorted capture sidecar paths, excluding ``*.trace.json.gz`` already
-        covered by the primary scan.
+        Sorted capture sidecar paths found under ``capture_traces/``.
     """
-    found: set[Path] = set()
-    for pattern in _CAPTURE_SIDECAR_GLOBS:
-        for p in trace_dir.rglob(pattern):
-            if not p.name.endswith(".trace.json.gz"):
-                found.add(p)
-    return sorted(found)
+    return sorted(p for p in trace_dir.rglob("*.json.gz") if _is_capture_trace(p))
 
 
 def _preferred_main_trace_path(trace_dir: Path, trace_files: list[Path]) -> Path:

--- a/inference_optimizer/orchestrator/action_executors/roofline.py
+++ b/inference_optimizer/orchestrator/action_executors/roofline.py
@@ -375,6 +375,32 @@ class RooflineExecutor:
                     _PROFILE_MAX_ATTEMPTS,
                 )
                 continue
+            # #735: a capture-only profile yielded only CUDA-graph capture
+            # sidecars (no annotated steady-state trace flushed). Feeding those
+            # to the steady-state splitter produces "0 execution steps" and the
+            # run dies downstream with the misleading trace_split_no_steady_state.
+            # This is transient (a re-profile self-heals — observed on gpt-oss
+            # vLLM), so retry; escalate to eager so the steady-state window is
+            # captured with per-iteration annotations (mirrors the
+            # cuda_graph_attribution_degraded remedy). If every attempt stays
+            # capture-only, fail with an accurate message instead.
+            if profile_result.get("profile_trace_selection_reason") == "capture_only_fallback":
+                last_phase = "profile_capture_only"
+                last_error = (
+                    "profile produced only CUDA-graph capture sidecars under "
+                    "capture_traces/ (no annotated steady-state trace); the "
+                    "steady-state splitter cannot use these — re-profile needed"
+                )
+                log.warning(
+                    "roofline profile attempt %d/%d: capture-only trace "
+                    "(%s); retrying%s",
+                    attempt,
+                    _PROFILE_MAX_ATTEMPTS,
+                    trace_path,
+                    "" if disable_cuda_graph else f" eager ({eager_flag})",
+                )
+                disable_cuda_graph = True
+                continue
             # Success
             if attempt > 1:
                 log.info(

--- a/inference_optimizer/orchestrator/action_executors/roofline.py
+++ b/inference_optimizer/orchestrator/action_executors/roofline.py
@@ -379,11 +379,13 @@ class RooflineExecutor:
             # sidecars (no annotated steady-state trace flushed). Feeding those
             # to the steady-state splitter produces "0 execution steps" and the
             # run dies downstream with the misleading trace_split_no_steady_state.
-            # This is transient (a re-profile self-heals — observed on gpt-oss
-            # vLLM), so retry; escalate to eager so the steady-state window is
-            # captured with per-iteration annotations (mirrors the
-            # cuda_graph_attribution_degraded remedy). If every attempt stays
-            # capture-only, fail with an accurate message instead.
+            # This is transient (the annotated trace flush was cut short, not a
+            # config problem — a plain re-profile self-heals, observed on
+            # gpt-oss vLLM), so just re-do the profile + trace with the SAME
+            # graph-capture settings. Do NOT escalate to eager: graph-capture is
+            # the robust/correct profiling mode and eager changes the measured
+            # workload. If every attempt stays capture-only, fail with an
+            # accurate message instead.
             if profile_result.get("profile_trace_selection_reason") == "capture_only_fallback":
                 last_phase = "profile_capture_only"
                 last_error = (
@@ -393,13 +395,11 @@ class RooflineExecutor:
                 )
                 log.warning(
                     "roofline profile attempt %d/%d: capture-only trace "
-                    "(%s); retrying%s",
+                    "(%s); re-profiling (same graph-capture settings)",
                     attempt,
                     _PROFILE_MAX_ATTEMPTS,
                     trace_path,
-                    "" if disable_cuda_graph else f" eager ({eager_flag})",
                 )
-                disable_cuda_graph = True
                 continue
             # Success
             if attempt > 1:

--- a/inference_optimizer/tests/test_profile_trace_promotion.py
+++ b/inference_optimizer/tests/test_profile_trace_promotion.py
@@ -80,7 +80,7 @@ async def test_profile_executor_fails_when_no_trace_files(tmp_path, monkeypatch)
 
 
 def test_capture_sidecar_traces_excludes_main_trace(tmp_path):
-    """#575: capture sidecar scan finds bs_*/graph_capture but not *.trace.json.gz."""
+    """#575/#735: capture scan finds everything under capture_traces/ but no real trace."""
     from inference_optimizer.orchestrator.action_executors.profile import (
         _capture_sidecar_traces_for_dir,
     )
@@ -90,12 +90,39 @@ def test_capture_sidecar_traces_excludes_main_trace(tmp_path):
     (cap / "bs_1_rank0.json.gz").write_bytes(b"x")
     (cap / "bs_512_rank0.json.gz").write_bytes(b"x")
     (cap / "graph_capture_rank_0.json.gz").write_bytes(b"x")
-    # A real main trace must NOT be returned by the sidecar scan.
+    # #735: vLLM capture sidecar that DOES end in .trace.json.gz — must still
+    # be treated as a capture sidecar (it lives under capture_traces/).
+    (cap / "graph_capture_rank_0.123.pt.trace.json.gz").write_bytes(b"x")
+    # A real main trace (NOT under capture_traces/) must NOT be returned.
     (tmp_path / "torch_trace" / "merged-foo.trace.json.gz").write_bytes(b"x")
 
     out = _capture_sidecar_traces_for_dir(tmp_path / "torch_trace")
     names = {p.name for p in out}
-    assert names == {"bs_1_rank0.json.gz", "bs_512_rank0.json.gz", "graph_capture_rank_0.json.gz"}
+    assert names == {
+        "bs_1_rank0.json.gz",
+        "bs_512_rank0.json.gz",
+        "graph_capture_rank_0.json.gz",
+        "graph_capture_rank_0.123.pt.trace.json.gz",
+    }
+
+
+def test_trace_files_for_dir_excludes_capture_traces(tmp_path):
+    """#735: vLLM graph_capture_*.trace.json.gz under capture_traces/ is NOT a primary trace."""
+    from inference_optimizer.orchestrator.action_executors.profile import (
+        _trace_files_for_dir,
+    )
+
+    tt = tmp_path / "torch_trace"
+    cap = tt / "capture_traces"
+    cap.mkdir(parents=True)
+    # vLLM capture sidecar: ends in .trace.json.gz but lives under capture_traces/.
+    (cap / "graph_capture_rank_0.123.pt.trace.json.gz").write_bytes(b"x")
+    # A real annotated serving trace at the top level.
+    real = tt / "dp0_pp0_tp0_rank0.456.pt.trace.json.gz"
+    real.write_bytes(b"x")
+
+    out = _trace_files_for_dir(tt)
+    assert out == [real]  # capture sidecar excluded despite matching *.trace.json.gz
 
 
 @pytest.mark.asyncio

--- a/inference_optimizer/tests/test_roofline_cuda_graph_retry.py
+++ b/inference_optimizer/tests/test_roofline_cuda_graph_retry.py
@@ -138,3 +138,44 @@ async def test_vllm_eager_retry_uses_framework_env(tmp_path, monkeypatch):
     retry_args = str(seen[1].get("base_extra_args", ""))
     assert "--enforce-eager" in retry_args
     assert "--disable-cuda-graph" not in retry_args
+
+
+# #735: a profile that produced only CUDA-graph capture sidecars (capture-only
+# fallback) carries no per-iteration annotations; the steady-state splitter
+# would die downstream with the misleading trace_split_no_steady_state. The
+# roofline retry must treat this as transient: re-profile (escalating to eager),
+# and only fail with an accurate message if every attempt stays capture-only.
+_CAPTURE_ONLY = {
+    "status": "succeeded",
+    "main_trace_path": "/tmp/ws/torch_trace",
+    "trace_files": ["/tmp/ws/torch_trace/capture_traces/bs_104_rank0.json.gz"],
+    "workspace": "/tmp/ws",
+    "profile_trace_selection_reason": "capture_only_fallback",
+}
+
+
+@pytest.mark.asyncio
+async def test_capture_only_profile_retries_then_succeeds(tmp_path):
+    # First attempt is capture-only -> retry escalates to eager and the second
+    # attempt produces a real annotated trace, so the run proceeds.
+    seen = await _run(tmp_path, _CAPTURE_ONLY)
+    assert len(seen) >= 2
+    # The retry boots eager so the steady-state window gets annotated.
+    assert "--disable-cuda-graph" in str(seen[1].get("base_extra_args", ""))
+
+
+@pytest.mark.asyncio
+async def test_capture_only_every_attempt_fails_clearly(tmp_path):
+    # Every attempt stays capture-only -> terminal failure with an accurate
+    # phase, NOT the misleading downstream trace_split_no_steady_state.
+    async def always_capture_only(c):
+        return dict(_CAPTURE_ONLY)
+
+    with patch(
+        "inference_optimizer.orchestrator.action_executors.profile.profile_executor",
+        new=always_capture_only,
+    ):
+        result = await make_roofline_executor(shared_state=_state())(_ctx(tmp_path))
+    assert result["status"] == "failed"
+    assert result.get("phase") == "profile_capture_only"
+    assert "capture" in str(result.get("error", "")).lower()

--- a/inference_optimizer/tests/test_roofline_cuda_graph_retry.py
+++ b/inference_optimizer/tests/test_roofline_cuda_graph_retry.py
@@ -156,12 +156,15 @@ _CAPTURE_ONLY = {
 
 @pytest.mark.asyncio
 async def test_capture_only_profile_retries_then_succeeds(tmp_path):
-    # First attempt is capture-only -> retry escalates to eager and the second
-    # attempt produces a real annotated trace, so the run proceeds.
+    # First attempt is capture-only -> plain re-profile (SAME graph-capture
+    # settings, NOT eager) and the second attempt produces a real annotated
+    # trace, so the run proceeds.
     seen = await _run(tmp_path, _CAPTURE_ONLY)
     assert len(seen) >= 2
-    # The retry boots eager so the steady-state window gets annotated.
-    assert "--disable-cuda-graph" in str(seen[1].get("base_extra_args", ""))
+    # The retry must NOT escalate to eager — graph-capture is the robust mode
+    # and eager would change the measured workload (#735).
+    assert "--disable-cuda-graph" not in str(seen[1].get("base_extra_args", ""))
+    assert "--enforce-eager" not in str(seen[1].get("base_extra_args", ""))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #735

## Problem (#735)

Multiple workloads (GLM-4.7-FP8 / sglang, gpt-oss-120b / vLLM, Mixtral-8x7B / vLLM) repeatedly died at TraceLens with:

```
RuntimeError: trace_split_no_steady_state: TraceLens splitter produced no steady-state chunks
```

GEAK was never invoked because the pipeline aborted before producing `analysis.md` / kernel candidates.

**Root cause (evidence-backed):** the profiler started its steady-state window but never flushed an annotated serving trace (log truncates right after "Profiling starts"; the produced capture files are all fully written, so it's not disk space — looks like the profiling window being torn down early). With no annotated trace on disk, HL's `#575` capture-only fallback handed the steady-state splitter a **CUDA-graph capture sidecar**, which carries **zero per-iteration annotations**, so `--find-steady-state` produced 0 chunks and the run died downstream with the misleading split error.

Two distinct shapes, one root cause:
- **sglang:** `capture_traces/bs_*_rank0.json.gz` — caught by the existing capture-only fallback.
- **vLLM:** `capture_traces/graph_capture_*.pt.trace.json.gz` — **ends in `.trace.json.gz`**, so the primary glob wrongly promoted it as a real annotated trace (never even flagged). A flag-only fix would miss this.

## Fix (small + framework-agnostic)

The robust discriminator both shapes share: the trace lives under a `capture_traces/` **directory** (a real annotated serving trace never does).

- **`profile.py`** — new 3-line `_is_capture_trace()` keyed on the `capture_traces/` parent dir. `_trace_files_for_dir()` now excludes capture sidecars (closes the vLLM `graph_capture` hole); `_capture_sidecar_traces_for_dir()` includes everything under `capture_traces/` regardless of name.
- **`roofline.py`** — in the existing profile-retry loop, treat a capture-only profile as transient: **re-do the profile + trace with the SAME graph-capture settings**. The failure is a truncated annotated-trace flush, not a config problem — a plain re-profile self-healed on gpt-oss. Graph-capture is the robust/correct profiling mode, so the retry does **NOT** escalate to eager (`--disable-cuda-graph` / `--enforce-eager` would change the measured workload). If every attempt stays capture-only, fail with the accurate `profile_capture_only` phase instead of the misleading split error.

## Verification

Ran the patched helpers against the **real on-disk artifacts**:

| Real run | Framework | Result |
|---|---|---|
| GLM-4.7-FP8 (fail) | sglang | caught → re-profile/clear-fail (never fed to splitter) |
| gpt-oss-120b (fail) | vLLM | caught |
| Mixtral-8x7B (fail) | vLLM | caught |
| gpt-oss-120b (recovered) | vLLM | 8 annotated traces, split fine |
| GLM-4.7-FP8 (Jun-21 success) | sglang | 8 annotated traces, split fine |

Healthy runs still select exactly their annotated traces (capture sidecars correctly excluded, not mistaken for real traces). 425 tests pass (4 new), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
