### PR TITLE
kb: add MiniMax-M3 MXFP8 optimization entries

### DIFF
--- a/critic-agent/kb_contributions/minimax_m3_kb_draft.json
+++ b/critic-agent/kb_contributions/minimax_m3_kb_draft.json
@@ -1,0 +1,115 @@
+{
+  "kind": "kb_draft",
+  "kb_drafts": [
+    {
+      "model_family": "minimax",
+      "category": "pitfall",
+      "action": "Run MiniMax-M3-MXFP8 with CUDA graphs enabled on gfx950 nightly image.",
+      "lesson": "The compiled torch.ops._C.fused_minimax_m3_qknorm_rope_kv_insert kernel faults with HSA_STATUS_ERROR_EXCEPTION (0x1016) in its KV-cache-insert path on gfx950 nightly. Must use --enforce-eager or replace with the AITER fallback (fused_qk_norm_rope_cache_pts_quant_shuffle + reshape_and_cache_flash + index_put_) before enabling CUDA graphs. The AITER path is graph-capturable and bit-parity verified.",
+      "model": "MiniMax-M3-MXFP8",
+      "gpu": "MI355X",
+      "framework": "vLLM",
+      "tags": ["cuda_graph", "gfx950", "attention", "kv_insert", "aiter", "mxfp8"],
+      "result": {
+        "status": "KEEP",
+        "gain_pct": 87.9,
+        "baseline_tput_per_gpu": 173.0,
+        "final_tput_per_gpu": 325.1,
+        "accuracy": "pass"
+      },
+      "confidence": 0.9,
+      "source": "final_report",
+      "context": "TP=4, CONC=64, ISL=1024, OSL=1024. vLLM ROCm nightly @ 6fbfdd18 (2026-06-12). Baseline = enforce-eager 692 tok/s total / 173 tok/s/GPU. Optimized with AITER fallback + CUDA graphs: 1300.6 tok/s total / 325.1 tok/s/GPU. GSM8K 94.5% exact match. Bit-parity verified atol/rtol 1e-2 vs PR reference.",
+      "supersedes": null,
+      "validated_date": "2026-06-13",
+      "strategy_tested": ["aiter_attention_fallback", "cuda_graph_capture"]
+    },
+    {
+      "model_family": "minimax",
+      "category": "crash_recovery",
+      "action": "Replace fused_minimax_m3_qknorm_rope_kv_insert with AITER-based fallback to restore CUDA-graph capture on gfx950.",
+      "lesson": "AITER fused_qk_norm_rope_cache_pts_quant_shuffle + reshape_and_cache_flash + index_put_ is the graph-capturable replacement for M3 fused QK-norm+RoPE+KV-insert on gfx950 nightly. Register via custom_ops (patch 01-custom_ops-aiter-fused-qknorm-rope.patch). A standalone gfx950 HIP kernel also compiled and passed parity but is not needed; the AITER path runs cleanly under graph capture.",
+      "model": "MiniMax-M3-MXFP8",
+      "gpu": "MI355X",
+      "framework": "vLLM",
+      "tags": ["aiter", "cuda_graph", "gfx950", "qknorm", "rope", "kv_insert", "mxfp8"],
+      "result": {
+        "status": "KEEP",
+        "failure_type": "gpu_fault",
+        "recovery": "Apply AITER fallback patch; remove --enforce-eager"
+      },
+      "confidence": 0.9,
+      "source": "final_report",
+      "context": "HSA_STATUS_ERROR_EXCEPTION (0x1016) on first real forward pass with CUDA graphs on gfx950 nightly. KV writes via reshape_and_cache_flash are CUDA-graph-safe. Bit-parity verified atol/rtol 1e-2.",
+      "supersedes": null,
+      "validated_date": "2026-06-13",
+      "strategy_tested": ["aiter_attention_fallback"]
+    },
+    {
+      "model_family": "minimax",
+      "category": "kernel_optimization",
+      "action": "Tune MXFP8 MoE grouped-GEMM tile sizes adaptively based on tokens-per-expert at decode for MiniMax-M3.",
+      "lesson": "At decode with topk=4, TP=4, and 128 routed experts, tokens-per-expert ≈2. Default block_m=64 wastes ~97% of each M-tile on zero-padding. Clamp block_m to next-pow2(tokens-per-expert) in [16,64] at runtime and propagate into the fused SwiGLU+quant kernel for consistent occupancy (block_m=16 → grid (16,24)=384 programs, ~1.5 waves vs 96 programs with block_m=64). Also set BLOCK_K=128→256 to halve K-iterations (requires K%256==0). Pattern applies to any MoE model with >64 experts at low concurrency.",
+      "model": "MiniMax-M3-MXFP8",
+      "gpu": "MI355X",
+      "framework": "vLLM",
+      "tags": ["moe", "gemm", "mxfp8", "tile_tuning", "block_m", "decode", "occupancy", "gfx950", "triton"],
+      "result": {
+        "status": "KEEP",
+        "gain_pct": 4.1,
+        "accuracy": "pass"
+      },
+      "confidence": 0.85,
+      "source": "final_report",
+      "context": "Stacks on CUDA-graph fix. Roofline showed MoE GEMM HBM-bound at ~20% peak BW with default tile. M3 GEMM1 K=3072, GEMM2 K=768 — both satisfy K%256==0. num_stages=3, adaptive num_warps (4 for block_m<=16, 8 otherwise). CONC=64, ISL=1024, OSL=1024, TP=4.",
+      "supersedes": null,
+      "validated_date": "2026-06-13",
+      "strategy_tested": ["adaptive_block_m", "block_k_256", "moe_tile_tuning"]
+    },
+    {
+      "model_family": "minimax",
+      "category": "kernel_optimization",
+      "action": "Tune MXFP8 dense-linear GEMM tile sizes per-M-bucket for MiniMax-M3 decode shapes.",
+      "lesson": "For MXFP8 linear GEMMs at decode (M<=256), adaptive BLOCK_M clamped to pow2 in [16,64] with num_warps=4 and num_stages=2 outperforms fixed BLOCK_N=64/128 by 1.1-1.6x in kernel time. Bucket by M: M<=48/80/112/256 use BLOCK_N=32; M>=1024 keeps the wide 128x256 tile for prefill. Dispatch is shape-based only, not workload-specific.",
+      "model": "MiniMax-M3-MXFP8",
+      "gpu": "MI355X",
+      "framework": "vLLM",
+      "tags": ["linear", "gemm", "mxfp8", "tile_tuning", "block_m", "decode", "gfx950", "triton"],
+      "result": {
+        "status": "KEEP",
+        "gain_pct": 3.6,
+        "accuracy": "pass"
+      },
+      "confidence": 0.85,
+      "source": "final_report",
+      "context": "E2E: 1284→1330 tok/s (+3.6%), TPOT 24.9→23.7ms at CONC=32 ISL=8192 OSL=1024. K=6144 (qkv/gate_up projections), TP=4. Bit-identical output verified. Submitted as vLLM PR #45875.",
+      "supersedes": null,
+      "validated_date": "2026-06-17",
+      "strategy_tested": ["per_m_bucket_dispatch", "adaptive_block_m", "mxfp8_linear_tuning"]
+    },
+    {
+      "model_family": "minimax",
+      "category": "benchmark_methodology",
+      "action": "Profile MoE GEMM HBM bandwidth utilization before tile tuning on gfx950.",
+      "lesson": "Before tuning MoE GEMM tiles, profile HBM bandwidth utilization via roofline. At decode with sparse MoE (topk=4, 128 experts, TP=4), ~20% HBM utilization is a reliable indicator that tile mismatch — not bandwidth — is the bottleneck, directing the fix immediately to block_m/BLOCK_K rather than generic sweeps. Without this step, tile sweeps are hard to interpret and incorrect tiles can significantly hurt performance.",
+      "model": "MiniMax-M3-MXFP8",
+      "gpu": "MI355X",
+      "framework": "vLLM",
+      "tags": ["roofline", "moe", "mxfp8", "bandwidth", "profiling", "tile_tuning", "gfx950"],
+      "result": {
+        "status": "KEEP",
+        "accuracy": "pass"
+      },
+      "confidence": 0.85,
+      "source": "final_report",
+      "context": "Roofline at 20% HBM utilization correctly predicted tile mismatch as root cause at CONC=64 decode with default block_m=64. Adaptive block_m fix followed directly.",
+      "supersedes": null,
+      "validated_date": "2026-06-13",
+      "strategy_tested": ["roofline_profiling"]
+    }
+  ],
+  "rejected_candidates": [],
+  "notes": [
+    "Entries 1-2 cover the same CUDA-graph fault from two angles (pitfall and recovery recipe). Entries 3-4 cover MoE and linear tile tuning that stack on the graph fix. Entry 5 is a methodology lesson generalized from the roofline-guided tile fix."
+  ]
+}


### PR DESCRIPTION
- Description: Adds 5 KB draft entries from the MiniMax-M3 MXFP8 optimization session on 4× MI355X (gfx950/CDNA4). Covers the gfx950 CUDA-graph fault and AITER fallback recipe, adaptive block_m MoE tile tuning, per-M-bucket linear GEMM tile dispatch, and a roofline-before-tuning methodology lesson. These are reusable priors the agent can load on future MoE/MXFP8 runs on MI355X to skip dead branches and converge faster.

- Linked issue(s): None

- Tests: No new tests. JSON validates against the `kb_draft` schema in `critic-agent/references/verdict_schema.md` — all 5 entries include the required fields (`model_family`, `category`, `action`, `lesson`, `model`, `gpu`, `framework`, `result`, `confidence`, `source`, `context`). File is documentation-only; CI skips on `**/*.md` / `docs/**` but this is a `.json` — pytest will run. No existing tests touch `critic-agent/kb_contributions/`.

- Breaking changes: No