### PR TITLE
Modified reprofile baseline tput, added test

### DIFF
--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -4350,26 +4350,30 @@ class Coordinator:
         return verdict_row
 
     async def _maybe_reprofile_for_kernel(self) -> None:
-        """Re-run profile+TraceLens inline on any change in projected tput vs the last profiled snapshot, so GEAK targets the current bottleneck."""
-        last_rl = float(getattr(self.shared_state, "last_roofline_tput", 0.0) or 0.0)
+        """Reprofile inline when projected tput diverges from the last measured trace, so GEAK targets the live bottleneck."""
+        before = self._last_measured_roofline_tput()
         cur = self._current_tput_from_validated_gain()
-        if last_rl <= 0 or cur <= 0:
+        if cur <= 0:
             return
-        # Reprofile on ANY material change (rise or fall) since the last roofline;
-        # a stack revert can lower validated tput, which must also re-target GEAK.
-        if abs(cur - last_rl) / last_rl < self._REPROFILE_CHANGE_TOL:
+        # With a measured trace, reprofile only on a material change; with none,
+        # fall through so GEAK still gets a real trace.
+        if before > 0 and abs(cur - before) / before < self._REPROFILE_CHANGE_TOL:
             return
-        # State-version the idempotency reason on the validated-gain stack so a
-        # genuine change re-runs (new key) while an unchanged state dedupes.
         stack_len = int(getattr(self.shared_state, "cumulative_gain_validated_stack_len", 0) or 0)
         try:
             await self.sub.run_task(
                 await self._enqueue_internal_analysis_task(reason=f"kernel_entry_g{stack_len}")
             )
-            self.shared_state.last_roofline_tput = self._current_tput_from_validated_gain()
-            self.shared_state.save(self.session_dir)
         except Exception:  # noqa: BLE001 — never block GEAK on a reprofile failure
             log.exception("kernel-entry reprofile failed; GEAK proceeds on existing snapshot")
+            return
+        # Advance the anchor only when a new snapshot actually landed.
+        after = self._last_measured_roofline_tput()
+        if after > 0 and after != before:
+            self.shared_state.last_roofline_tput = after
+            self.shared_state.save(self.session_dir)
+        else:
+            log.warning("kernel-entry reprofile produced no new snapshot; GEAK targets existing trace")
 
     def _perfskills_enabled(self) -> bool:
         """Whether the KERNEL phase is delegated to the PerfSkills e2e optimizer.
@@ -5565,6 +5569,20 @@ class Coordinator:
         except (TypeError, ValueError):
             gain = 0.0
         return base * (1.0 + gain / 100.0)
+
+    def _last_measured_roofline_tput(self) -> float:
+        """Measured tok/s of the most recent roofline snapshot; 0.0 when none."""
+        snaps = getattr(self.shared_state, "roofline_snapshots", None) or []
+        for snap in reversed(snaps):
+            if not isinstance(snap, dict):
+                continue
+            try:
+                tput = float(snap.get("achieved_tok_per_sec") or 0.0)
+            except (TypeError, ValueError):
+                tput = 0.0
+            if tput > 0:
+                return tput
+        return 0.0
 
     def _needs_roofline_for_watermark(self) -> bool:
         """True iff projected tput crossed the 10% watermark over ``last_roofline_tput`` (bootstrap guard: False until PRELUDE roofline ran; re-arm guard: False while auto_roofline_pending_task_id is in-flight).

--- a/inference_optimizer/tests/test_prelude_roofline.py
+++ b/inference_optimizer/tests/test_prelude_roofline.py
@@ -24,6 +24,7 @@ class _BareState:
     enable_roofline: bool = True
     current_best: dict[str, Any] = field(default_factory=dict)
     last_baseline: dict[str, Any] = field(default_factory=dict)
+    roofline_snapshots: list[dict[str, Any]] = field(default_factory=list)
 
     def save(self, _session_dir: Path | None) -> None:
         pass
@@ -163,22 +164,28 @@ async def test_enable_roofline_false_picks_profile_kind(coord: Coordinator):
 
 
 class _StubSub:
-    """Records tasks handed to ``run_task`` so the kernel-entry reprofile can assert it ran inline."""
+    """Records tasks handed to ``run_task``; optionally lands a fresh snapshot to simulate a completed reprofile."""
 
-    def __init__(self) -> None:
+    def __init__(self, state: Any = None, landed_tput: float | None = None) -> None:
         self.tasks_run: list[Any] = []
+        self._state = state
+        self._landed_tput = landed_tput
 
     async def run_task(self, task: Any) -> None:
         self.tasks_run.append(task)
+        if self._state is not None and self._landed_tput is not None:
+            self._state.roofline_snapshots.append(
+                {"achieved_tok_per_sec": self._landed_tput},
+            )
 
 
 @pytest.mark.asyncio
 async def test_on_enter_kernel_reprofiles_on_change(coord: Coordinator, monkeypatch):
-    """KERNEL entry (no-GEMM path) reprofiles inline when projected tput changed since the last roofline (cur=120 vs last_rl=100), re-anchoring the watermark before GEAK."""
-    coord.sub = _StubSub()
+    """KERNEL entry (no-GEMM path) reprofiles inline when projected tput (120) diverges from the last measured trace (100), anchoring on the new snapshot."""
+    coord.shared_state.roofline_snapshots = [{"achieved_tok_per_sec": 100.0}]
+    coord.sub = _StubSub(coord.shared_state, landed_tput=120.0)
     monkeypatch.setattr(coord, "_kernel_enabled", lambda: True)
     monkeypatch.setattr(coord, "_gemm_tuning_required_before_kernel_opt", lambda: False)
-    coord.shared_state.last_roofline_tput = 100.0
     coord.shared_state.cumulative_gain_validated = 20.0  # cur = 100 * 1.20 = 120
 
     await coord._on_enter_kernel(from_phase="EXPLORE")
@@ -191,40 +198,41 @@ async def test_on_enter_kernel_reprofiles_on_change(coord: Coordinator, monkeypa
 
 @pytest.mark.asyncio
 async def test_kernel_entry_reprofile_skips_when_unchanged(coord: Coordinator):
-    """No material change vs the last roofline (cur == last_rl) skips the reprofile and leaves the anchor untouched."""
-    coord.sub = _StubSub()
-    coord.shared_state.last_roofline_tput = 100.0
-    coord.shared_state.cumulative_gain_validated = 0.0  # cur = 100 == last_rl
+    """Projected tput matching the last measured trace (cur == measured) skips the reprofile."""
+    coord.shared_state.roofline_snapshots = [{"achieved_tok_per_sec": 100.0}]
+    coord.sub = _StubSub(coord.shared_state)
+    coord.shared_state.cumulative_gain_validated = 0.0  # cur = 100 == measured
 
     await coord._maybe_reprofile_for_kernel()
 
     assert coord.sub.tasks_run == []
-    assert coord.shared_state.last_roofline_tput == 100.0
 
 
 @pytest.mark.asyncio
-async def test_kernel_entry_reprofile_skips_without_prior_roofline(coord: Coordinator):
-    """No prior roofline (last_roofline_tput == 0) means there is nothing to compare a change against; skip."""
-    coord.sub = _StubSub()
-    coord.shared_state.last_roofline_tput = 0.0
-    coord.shared_state.cumulative_gain_validated = 50.0
+async def test_kernel_entry_reprofile_runs_without_measured_trace(coord: Coordinator):
+    """No measured trace yet (no snapshot) but a non-zero projected gain still reprofiles so GEAK gets a real trace."""
+    coord.shared_state.roofline_snapshots = []
+    coord.sub = _StubSub(coord.shared_state, landed_tput=150.0)
+    coord.shared_state.cumulative_gain_validated = 50.0  # cur = 150
 
     await coord._maybe_reprofile_for_kernel()
 
-    assert coord.sub.tasks_run == []
+    assert len(coord.sub.tasks_run) == 1
+    assert coord.shared_state.last_roofline_tput == 150.0
 
 
 @pytest.mark.asyncio
 async def test_kernel_entry_reprofile_swallows_failure(coord: Coordinator):
-    """A reprofile failure is best-effort: it never propagates and the watermark anchor is left untouched."""
+    """A reprofile failure is best-effort: it never propagates and the anchor is left untouched."""
 
     class _RaisingSub:
         async def run_task(self, _task: Any) -> None:
             raise RuntimeError("profile crashed")
 
+    coord.shared_state.roofline_snapshots = [{"achieved_tok_per_sec": 100.0}]
     coord.sub = _RaisingSub()
     coord.shared_state.last_roofline_tput = 100.0
-    coord.shared_state.cumulative_gain_validated = 20.0  # cur = 120 != 100 → would trigger
+    coord.shared_state.cumulative_gain_validated = 20.0  # cur = 120 != measured 100 → triggers
 
     await coord._maybe_reprofile_for_kernel()  # must not raise
 


### PR DESCRIPTION
- **Description**: Fix kernel-entry reprofile gate in `_maybe_reprofile_for_kernel` so GEAK targets the live config. The gate previously compared the projected current tput against `last_roofline_tput`, but that anchor is itself a gain-derived projection (`baseline_tput × (1 + cumulative_gain_validated)`). When a gain (e.g. a warm-replay recipe) is validated before a trace is captured, both sides of the comparison are equal, so the reprofile is suppressed and GEAK optimizes against the stale baseline trace. The gate now compares against the throughput the last roofline snapshot was actually *measured* at (new helper `_last_measured_roofline_tput()` → `roofline_snapshots[-1].achieved_tok_per_sec`), reprofiles when no measured trace exists yet, and advances the anchor only when a new snapshot actually lands.

- **Linked issue(s)**: 
- 
- **Tests**: Updated `test_prelude_roofline.py` to drive the gate off `roofline_snapshots` (snapshot-based stub, new `roofline_snapshots` state field); flipped the "no prior roofline" case to assert it now reprofiles. Commands run: `pytest inference_optimizer/tests/test_prelude_roofline.py` (10 passed) and related coordinator/watermark suites (121 passed). Note: `pytest-asyncio` was missing from the venv though it's already required in `pyproject.toml`.

- **Breaking changes**: No. Internal orchestrator behavior change only; no API/schema/config changes.
