### PR TITLE
fix(kernel-opt): trust verified-correctness from timed-out GEAK partial runs (unblocks KEEP→E2E)

### DIFF
--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -3622,6 +3622,37 @@ def _trust_geak_correctness() -> bool:
     return True
 
 
+def _geak_round_correctness_passed(geak_report: dict[str, Any]) -> bool:
+    """True when a GEAK report carries an explicit verified-correctness record.
+
+    A SIGTERM'd GEAK run writes ``status="incremental_after_round_N"`` and
+    embeds the round's evaluation, including a ``correctness`` block of the form
+    ``{"returncode": 0, "success": true}`` (the kernel was compiled, run, and
+    correctness-checked before the timeout). The generic key-walker
+    :func:`_extract_correctness_from_geak` misses it because the value is a
+    nested dict (key ``success``), not a ``correct``/``valid`` bool. Read the
+    explicit nested record instead.
+
+    Args:
+        geak_report (dict[str, Any]): Parsed ``final_report.json`` contents.
+
+    Returns:
+        bool: True only when ``round_evaluation.correctness.success`` is True
+            (and no failing returncode); False otherwise.
+    """
+    if not isinstance(geak_report, dict):
+        return False
+    for key in ("round_evaluation", "best_round_evaluation"):
+        ev = geak_report.get(key)
+        if isinstance(ev, dict):
+            corr = ev.get("correctness")
+            if isinstance(corr, dict):
+                rc = corr.get("returncode")
+                if corr.get("success") is True and (rc is None or rc == 0):
+                    return True
+    return False
+
+
 def _extract_correctness_from_geak(final_report_path: str | Path) -> bool | None:
     """Read correctness from GEAK-style JSON reports when present.
 
@@ -4428,14 +4459,27 @@ def build_verification(
     ):
         bp_geak = (best.get("backend_paths") or {}).get("geak_final_report", "")
         geak_status = ""
+        geak_report: dict[str, Any] = {}
         if bp_geak and Path(bp_geak).is_file():
             try:
-                geak_status = str(json.loads(Path(bp_geak).read_text(encoding="utf-8")).get("status") or "").lower()
+                geak_report = json.loads(Path(bp_geak).read_text(encoding="utf-8"))
+                geak_status = str(geak_report.get("status") or "").lower()
             except Exception:  # noqa: BLE001
+                geak_report = {}
                 geak_status = ""
         if geak_status in {"complete", "succeeded", "ok"}:
             correctness_signal = True
             correctness_source = "geak_assumed_pass"
+        # A SIGTERM'd GEAK run finalizes status="incremental_after_round_N" (not
+        # "complete"), but its already-evaluated round still carries an EXPLICIT
+        # verified-correctness record (round_evaluation.correctness.success) plus
+        # a FULL_BENCHMARK-verified speedup. Trust that: the kernel was compiled,
+        # run, and correctness-checked before the timeout — it's a real win, not
+        # an unverified artifact. Without this a verified 2.6x partial is routed
+        # to NEEDS_REVIEW and never reaches integrate/E2E (#735-followup). GEAK-only.
+        elif geak_status.startswith("incremental_after_round") and _geak_round_correctness_passed(geak_report):
+            correctness_signal = True
+            correctness_source = "geak_partial_round_verified"
     if correctness_signal is None and getattr(args, "accuracy_passed", None) is True:
         correctness_signal = True
         correctness_source = "accuracy_override"

--- a/kernel-agent/tools/test_kernel_optimization_verification.py
+++ b/kernel-agent/tools/test_kernel_optimization_verification.py
@@ -343,6 +343,92 @@ def test_geak_correctness_trust_requires_complete_status(tmp_path):
     assert verification["correctness_source"] == "missing"
 
 
+def _geak_partial_attempt(
+    tmp_path: Path,
+    *,
+    status: str = "incremental_after_round_1",
+    speedup: float = 2.6,
+    round_correctness: dict | None = None,
+):
+    """GEAK attempt whose run was SIGTERM'd mid-round: status=incremental_after_round_N,
+    final_report carries an explicit round_evaluation.correctness record."""
+    final = tmp_path / "geak_final_report.json"
+    report: dict = {
+        "status": status,
+        "best_patch": str(tmp_path / "patch_0.patch"),
+        "best_speedup": speedup,
+        "best_task": "tilelang-fp8-blockscale-rewrite",
+    }
+    if round_correctness is not None:
+        report["round_evaluation"] = {"round": 1, "correctness": round_correctness}
+    final.write_text(json.dumps(report), encoding="utf-8")
+    artifact = tmp_path / "worktree" / "gemm_op.py"
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_text("import torch\ndef run_gemm(*a, **k): pass\n", encoding="utf-8")
+    return {
+        "status": "partial",
+        "attempt_id": "geak-partial",
+        "backend": "geak",
+        "optimized_path": str(artifact),
+        "backend_paths": {
+            "geak_final_report": str(final),
+            "geak_per_task_best_speedup": str(speedup),
+            "geak_per_task_best_patch": str(tmp_path / "patch_0.patch"),
+            "geak_per_task_best_worktree": str(artifact.parent.parent),
+        },
+    }
+
+
+def test_geak_partial_with_verified_round_correctness_keeps(tmp_path):
+    """#735-followup: a SIGTERM'd GEAK run (status=incremental_after_round_1) whose
+    round_evaluation shows correctness.success=True + a verified speedup must be
+    trusted and routed to KEEP — not discarded as NEEDS_REVIEW (which never reaches
+    integrate/E2E). This is the exact DeepSeek-R1 2.6x case."""
+    verification = ko.build_verification(
+        _args(source_file="/tmp/gemm_op.py"),
+        [_geak_partial_attempt(tmp_path, speedup=2.6, round_correctness={"returncode": 0, "success": True})],
+        benchmark_available=True,
+    )
+    assert verification["micro_speedup"] == 2.6
+    assert verification["correctness_passed"] is True
+    assert verification["correctness_source"] == "geak_partial_round_verified"
+    proposal = ko.make_proposal(verification)
+    assert proposal["decision"] == "KEEP", proposal
+
+
+def test_geak_partial_without_round_correctness_stays_review(tmp_path):
+    """A partial GEAK run with NO explicit verified-correctness record must NOT be
+    trusted — stays conservative (NEEDS_REVIEW), preserving the safety gate."""
+    verification = ko.build_verification(
+        _args(source_file="/tmp/gemm_op.py"),
+        [_geak_partial_attempt(tmp_path, speedup=2.6, round_correctness=None)],
+        benchmark_available=True,
+    )
+    assert verification["correctness_passed"] is False
+    proposal = ko.make_proposal(verification)
+    assert proposal["decision"] == "NEEDS_REVIEW"
+
+
+def test_geak_partial_with_failed_round_correctness_not_trusted(tmp_path):
+    """A partial GEAK run whose round correctness FAILED must never be trusted."""
+    verification = ko.build_verification(
+        _args(source_file="/tmp/gemm_op.py"),
+        [_geak_partial_attempt(tmp_path, speedup=2.6, round_correctness={"returncode": 1, "success": False})],
+        benchmark_available=True,
+    )
+    assert verification["correctness_passed"] is False
+
+
+def test_geak_round_correctness_passed_helper():
+    """Unit-cover the nested-record reader directly."""
+    assert ko._geak_round_correctness_passed({"round_evaluation": {"correctness": {"returncode": 0, "success": True}}})
+    assert ko._geak_round_correctness_passed({"best_round_evaluation": {"correctness": {"success": True}}})
+    assert not ko._geak_round_correctness_passed({"round_evaluation": {"correctness": {"success": False}}})
+    assert not ko._geak_round_correctness_passed({"round_evaluation": {"correctness": {"returncode": 1, "success": True}}})
+    assert not ko._geak_round_correctness_passed({"status": "incremental_after_round_1"})
+    assert not ko._geak_round_correctness_passed({})
+
+
 def test_report_correctness_passes_with_reference_language(tmp_path):
     report = tmp_path / "optimization_report.md"
     report.write_text(


### PR DESCRIPTION
## Problem

GEAK is producing real, correctness-passing kernel speedups on the current sglang batch (DeepSeek-R1 **2.6x**, plus 1.85x / 1.5x / 1.43x on other workloads), but **none reach E2E** — they all land in `NEEDS_REVIEW` and no integrate task is ever dispatched, so the kernel is never applied + remeasured (the apply+E2E path from #703 never gets invoked).

## Root cause (evidence-backed, 100% confirmed from run artifacts)

A GEAK run that hits its fixed wall-clock budget (3h) is SIGTERM'd and finalizes:
```
final_report.json: status = "incremental_after_round_1"   (NOT "complete")
                   round_evaluation.correctness = {"returncode": 0, "success": true}
                   round_evaluation.speedup_source = "FULL_BENCHMARK verified result"
```
i.e. the kernel **was compiled, run, and correctness-checked** in the completed round before the timeout. HL even salvages the patch (`geak_per_task_best_patch`, `geak_per_task_best_speedup=2.6052`). But the correctness gate then drops it:

- The trust gate (`build_verification`) only accepted `status in {complete, succeeded, ok}` → an `incremental_after_round_*` status fell through.
- The generic key-walker `_extract_correctness_from_geak` scans for `correct`/`valid` **keys**; the real record is a nested dict under key `success`, so it found nothing.

→ `correctness_passed=False` → `make_proposal` returns `NEEDS_REVIEW` → Orchestration dispatches no integrate → **no apply, no E2E**. Confirmed on DeepSeek-R1: `last_kernel_opt.decision = NEEDS_REVIEW`, `integrate actions = 0`, despite a verified 2.6x.

This is an **HL-side gate bug**, not the timeout, not GEAK, not the environment. The 3h budget is fine — the win is found and verified well before it.

## Fix (GEAK-only, conservative)

- New `_geak_round_correctness_passed()` reads the explicit nested `round_evaluation.correctness.success` (and requires `returncode in {0, None}`).
- Extend the existing GEAK trust gate: an `incremental_after_round_*` status **with** that verified record **and** a measured speedup ≥ 1.0 is trusted (`correctness_source="geak_partial_round_verified"`) → routes to KEEP → integrate → apply+E2E.
- Unchanged safety: still gated by `HYPERLOOM_TRUST_GEAK_CORRECTNESS` and the ≥1.0 speedup floor. A partial with **no** record, or a **failed** record, stays `NEEDS_REVIEW`.

## Verification

- Validated against the **real** DeepSeek-R1 `final_report.json` (status `incremental_after_round_1`) → now recognized as correct.
- 96 verification tests pass, incl. 4 new: KEEP on a verified partial; NEEDS_REVIEW on missing record; not-trusted on failed record; helper unit. 154 pass across the broader kernel suite. ruff clean.

Related: #703 (apply+E2E primitive this unblocks), #742 / #743 / #744 (GEAK environment issues).
