### PR TITLE
ci: switch default vLLM image to profilerfix build

### DIFF
--- a/ci/optimize_submit.py
+++ b/ci/optimize_submit.py
@@ -363,9 +363,11 @@ def _default_vllm_image() -> str:
     """Return the default vLLM server image.
 
     Returns:
-        The sync-registry vLLM image (v0.21.0).
+        The pinned ``profilerfix`` vLLM image (v0.21.0 / rocm720) whose patched
+        libamdhip64/libroctracer let rocprofiler capture kernels under
+        HipGraphLaunch (same profilerfix rationale as the SGLang image).
     """
-    return "harbor.core42.primus-safe.amd.com/sync/vllm/vllm-openai-rocm:v0.21.0"
+    return "harbor.core42.primus-safe.amd.com/sync/primussafe/vllm-openai-rocm:v0.21.0-rocm720-profilerfix-20260627"
 
 
 # ── HuggingFace client ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Point the non-gemma-4 vLLM default at
primussafe/vllm-openai-rocm:v0.21.0-rocm720-profilerfix-20260627 so vLLM models get the patched libamdhip64/libroctracer (rocprofiler can capture kernels under HipGraphLaunch), matching the SGLang profilerfix image. gemma-4's dedicated image and the sglang path are unchanged.

- Description: what and why
- Linked issue(s): close/fix refs
- Tests: added/updated? commands run?
- Breaking changes: yes/no (details if yes)
