### PR TITLE
feat(warm-start): KG-native cross-model config donor + §5e graph-guid…

### DIFF
--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -367,7 +367,18 @@ _CLAUDE_ALLOWED_MODELS = (_CLAUDE_PREFERRED_MODEL, _CLAUDE_FALLBACK_MODEL)
 # Catalog probe retry contract: gateway is documented-flaky. Sleep N seconds before attempt i+1;
 # len(_CATALOG_RETRY_DELAYS_SEC) is the retry count after the initial attempt.
 _CATALOG_RETRY_DELAYS_SEC = (1.0, 3.0, 5.0)
-_CATALOG_REQUEST_TIMEOUT_SEC = 5.0
+# Per-attempt read timeout for the gateway /models catalog probe. The AMD
+# gateway is documented-flaky; on slow/borderline days a healthy /models call
+# can take ~5.5s, straddling this cutoff and causing spurious "gateway catalog
+# unreachable" launch refusals even though the gateway is up. Allow an operator
+# override via env (default unchanged at 5.0s) for slow-gateway windows.
+try:
+    _CATALOG_REQUEST_TIMEOUT_SEC = float(
+        os.environ.get("INFERENCE_OPTIMIZER_CATALOG_PROBE_TIMEOUT_SEC", "5.0")
+        or "5.0"
+    )
+except (TypeError, ValueError):
+    _CATALOG_REQUEST_TIMEOUT_SEC = 5.0
 
 # /dev/shm threshold: below this, next launch collides with stale vLLM/NCCL shm segments and hangs in zmq.
 _DEV_SHM_MIN_FREE_BYTES = 16 * 1024 * 1024 * 1024  # 16 GiB

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -3907,6 +3907,80 @@ class Coordinator:
             )
         except Exception:  # noqa: BLE001
             log.exception("framework_pr: prs_tested write failed")
+        # Real-time KG write-back: reflect this KEEP/REVERT as native link-graph
+        # edge(s) immediately so the live graph is queryable before the next
+        # mirror cron. Best-effort and native-only (see _emit_kg_decision).
+        self._emit_kg_decision(
+            patch_file=str(patch_path),
+            outcome=outcome,
+            gain_pct=float(delta_pct or 0.0),
+            error_class=str(error_class or ""),
+            archs=list(entry.get("applicable_arch") or []),
+        )
+
+    def _emit_kg_decision(
+        self,
+        *,
+        patch_file: str,
+        outcome: str,
+        gain_pct: float,
+        error_class: str,
+        archs: list[Any],
+    ) -> None:
+        """Emit a real-time KG edge for a KEEP/REVERT patch decision.
+
+        Mirrors the bulk kb-mirror's recipe edge mapping (a KEEP with a
+        positive gain becomes ``patch IMPROVES arch``; a REVERT becomes
+        ``patch REVERTED_ON arch``) so the live link graph reflects the
+        decision immediately, instead of only after the next mirror cron.
+
+        Native-only and best-effort: ``get_kg_client`` returns a native
+        client only when ``GBRAIN_KG_NATIVE`` is set (otherwise edges would
+        be written as a ``## Facts`` fence that gbrain ingest discards), and
+        all failures degrade silently via the ``*_safe`` wrappers so a KG
+        hiccup never affects the run.
+
+        Args:
+            patch_file: The patch identifier (edge subject).
+            outcome: ``KEEP`` or ``REVERT``.
+            gain_pct: Measured throughput delta (signed percent).
+            error_class: Failure class for a REVERT (edge ``error`` property).
+            archs: Applicable architectures (one edge per arch).
+        """
+        if not patch_file or not archs:
+            return
+        try:
+            from ..recipe_kb.kg_client import get_kg_client
+
+            kg = get_kg_client()
+            if kg is None or not getattr(kg, "_native", False) or not kg.is_available():
+                return
+            ss = self.shared_state
+            hw = str(getattr(ss, "gpu_type", "") or getattr(ss, "hardware", "") or "")
+            fw = str(getattr(ss, "framework", "") or "")
+            for raw_arch in archs:
+                arch = str(raw_arch or "").strip()
+                if not arch:
+                    continue
+                if outcome == "KEEP" and gain_pct > 0:
+                    kg.emit_fact_safe(
+                        page_slug="",
+                        subject=patch_file,
+                        predicate="IMPROVES",
+                        object=arch,
+                        properties={"gain": f"{gain_pct:+.1f}%", "hw": hw, "fw": fw},
+                    )
+                elif outcome == "REVERT":
+                    kg.emit_fact_safe(
+                        page_slug="",
+                        subject=patch_file,
+                        predicate="REVERTED_ON",
+                        object=arch,
+                        properties={"loss": f"{gain_pct:.1f}%", "error": error_class, "hw": hw, "fw": fw},
+                    )
+            log.info("kg write-back: emitted %s edge(s) for %s [%s]", len(archs), patch_file, outcome)
+        except Exception as exc:  # noqa: BLE001 - write-back is advisory
+            log.warning("kg write-back degraded: %s", exc)
 
     def _record_framework_pr_phase_done(
         self,
@@ -5830,6 +5904,81 @@ class Coordinator:
         state.warm_history_injected = True
         return added
 
+    def _filter_warm_patches_with_kg(
+        self,
+        patches: list,
+        advisory_blocked: list,
+        state: Any,
+    ) -> list:
+        """Filter replay patches using KG advisory blocks, expiry, conflicts.
+
+        Removes patches that are (a) advisory-blocked at/above the
+        configurable confidence threshold, (b) flagged ``expired`` by the
+        warm-start validity check, or (c) in a ``CONFLICTS_WITH`` relation
+        with another patch in the set. Best-effort: any failure returns the
+        input patches unchanged so replay never breaks on a KG hiccup.
+
+        Args:
+            patches: The candidate replay patches from ``recommended_replay``.
+            advisory_blocked: The ``advisory_blocked_patches`` list from the
+                warm-start context.
+            state: The live SharedState (for hardware/framework conditions).
+
+        Returns:
+            The filtered patch list.
+        """
+        if not patches:
+            return patches
+        try:
+            threshold = float(os.environ.get("WARM_REPLAY_ADVISORY_CONFIDENCE", "0.75"))
+        except (TypeError, ValueError):
+            threshold = 0.75
+
+        def _norm(value: Any) -> str:
+            return str(value or "").strip().replace(" ", "_").replace("/", "_").lower()
+
+        try:
+            advisory_drop = {
+                _norm(ab.get("patch_file"))
+                for ab in (advisory_blocked or [])
+                if isinstance(ab, dict) and float(ab.get("confidence") or 0.0) >= threshold
+            }
+            kept = [
+                p
+                for p in patches
+                if isinstance(p, dict)
+                and not p.get("expired")
+                and _norm(p.get("patch_file")) not in advisory_drop
+            ]
+            for p in patches:
+                if isinstance(p, dict) and _norm(p.get("patch_file")) in advisory_drop:
+                    log.info("warm-replay advisory block (conf>=%.2f): %s", threshold, p.get("patch_file"))
+
+            if len(kept) >= 2:
+                from ..recipe_kb.kg_client import get_kg_client
+
+                kg = get_kg_client()
+                if kg is not None and kg.is_available():
+                    knobs = [str(p.get("patch_file") or "") for p in kept]
+                    conflicts = kg.find_conflicts_safe(
+                        knobs=knobs,
+                        hardware=str(getattr(state, "gpu_type", "") or getattr(state, "hardware", "") or ""),
+                        framework=str(getattr(state, "framework", "") or ""),
+                    )
+                    drop = {_norm(c.get("knob")) for c in conflicts}
+                    if drop:
+                        for c in conflicts:
+                            log.info(
+                                "warm-replay conflict: %s conflicts_with %s",
+                                c.get("knob"),
+                                c.get("conflicts_with"),
+                            )
+                        kept = [p for p in kept if _norm(p.get("patch_file")) not in drop]
+            return kept
+        except Exception as exc:  # noqa: BLE001 - filtering is advisory only
+            log.warning("warm-replay KG patch filtering degraded: %s", exc)
+            return patches
+
     async def _maybe_enqueue_warm_replay(
         self,
         *,
@@ -5938,6 +6087,11 @@ class Coordinator:
         # Extract code patches from warm_start_context (populated by T0).
         wsc_patches = (wsc.get("recommended_replay") or {}).get("patches") or [] if isinstance(wsc, dict) else []
         wsc_blocked = wsc.get("blocked_patches") or [] if isinstance(wsc, dict) else []
+        wsc_advisory = wsc.get("advisory_blocked_patches") or [] if isinstance(wsc, dict) else []
+        # KG-driven filtering: drop high-confidence advisory blocks, expired
+        # patches, and graph-detected conflicts before replay. Best-effort —
+        # falls back to the unfiltered list on any KG failure.
+        wsc_patches = self._filter_warm_patches_with_kg(wsc_patches, wsc_advisory, state)
         if not bc_args and not bc_envs and not wsc_patches:
             state.warm_replay_outcome = {
                 "status": "skipped",
@@ -10249,6 +10403,20 @@ class Coordinator:
             params["warm_start_pitfalls"] = list(state.warm_start_pitfalls)
         if state.warm_start_lessons and "warm_start_lessons" not in params:
             params["warm_start_lessons"] = list(state.warm_start_lessons)
+        # KG graph-recommended knobs (cross-recipe IMPROVES candidates from the
+        # T0 warm-start context); advisory positive priors for the specialist.
+        if "kg_recommended_knobs" not in params:
+            wsc = getattr(state, "warm_start_context", None) or {}
+            kg_knobs = wsc.get("recommended_knobs") if isinstance(wsc, dict) else None
+            if kg_knobs:
+                params["kg_recommended_knobs"] = [k for k in kg_knobs if isinstance(k, dict)]
+        # KG graph-guided config knobs (journal KNOB_IMPROVES, runnable args/envs);
+        # only present when GBRAIN_KG_GUIDED enabled the T0 enhancement.
+        if "kg_guided_knobs" not in params:
+            wsc = getattr(state, "warm_start_context", None) or {}
+            guided = wsc.get("graph_guided_knobs") if isinstance(wsc, dict) else None
+            if guided:
+                params["kg_guided_knobs"] = [k for k in guided if isinstance(k, dict)]
         # runtime framework/version so the prompt's _format_version_note annotates version-mismatched lessons.
         if "framework" not in params:
             fw = str(getattr(state, "framework", "") or "").strip()

--- a/inference_optimizer/orchestrator/cortex_t0.py
+++ b/inference_optimizer/orchestrator/cortex_t0.py
@@ -260,6 +260,135 @@ def _max_session_gain(row: Mapping[str, Any]) -> float:
     return best
 
 
+def _donor_is_trustworthy(
+    donor: Mapping[str, Any],
+    *,
+    target_arch_slug: str,
+    target_model_type: str,
+    target_conc: Any = None,
+    target_isl: Any = None,
+    target_osl: Any = None,
+) -> bool:
+    """Gate a BORROWED (cross-model) warm-replay config donor.
+
+    Borrowing a champion config on a loose same-arch match empirically produced
+    near-zero or negative replay gains: cross-architecture configs, donors whose
+    architecture is ``unknown``, and donors whose own validated gain was zero
+    ("reproduce baseline" no-ops). A borrowed donor must therefore satisfy ALL:
+
+    * a replayable champion config (args or envs);
+    * a positive validated/session gain (rejects zero-gain donors);
+    * a concrete architecture (not ``unknown``) equal to the target's;
+    * no explicit workload-shape (conc/isl/osl) mismatch with the target.
+
+    This is only applied to BORROWED donors — a true-self (identity ``exact``)
+    replay is never gated, preserving the "reproduce my own champion" contract.
+
+    Args:
+        donor: Candidate donor recipe row.
+        target_arch_slug: Architectures slug of the workload being optimized.
+        target_model_type: Model type of the workload being optimized.
+        target_conc: Target concurrency (optional shape hint).
+        target_isl: Target input sequence length (optional shape hint).
+        target_osl: Target output sequence length (optional shape hint).
+
+    Returns:
+        ``True`` when the donor is safe to borrow for warm-replay.
+    """
+    if not isinstance(donor, Mapping):
+        return False
+    if not _has_replayable_config(donor):
+        return False
+    # RC1: require evidence of a real positive gain (no zero-gain borrows).
+    if _max_session_gain(donor) <= 0:
+        return False
+    # RC2: require a concrete architecture matching the target (no cross-arch / unknown).
+    from ..recipe_snapshot_constants import _architectures_slug
+
+    donor_arch = _architectures_slug(donor.get("architectures") or [])
+    donor_mt = str(donor.get("model_type") or "").strip().lower()
+    _unknown = {"", "unknown", "unknown_arch", "unknown_model_type"}
+    if donor_arch in _unknown or donor_mt in _unknown:
+        return False
+    if target_arch_slug and donor_arch and donor_arch != target_arch_slug:
+        return False
+    tgt_mt = str(target_model_type or "").strip().lower()
+    if tgt_mt and donor_mt and donor_mt != tgt_mt:
+        return False
+
+    # RC3: reject an explicit workload-shape mismatch (only when both are known).
+    def _shape_conflict(target_val: Any, donor_key: str) -> bool:
+        try:
+            tv = int(target_val)
+            dv = int(donor.get(donor_key))
+        except (TypeError, ValueError):
+            return False  # unknown on either side → not a conflict
+        if tv <= 0 or dv <= 0:
+            return False
+        return tv != dv
+
+    if (
+        _shape_conflict(target_conc, "conc")
+        or _shape_conflict(target_isl, "isl")
+        or _shape_conflict(target_osl, "osl")
+    ):
+        return False
+    return True
+
+
+def _kg_native_config_donor(
+    *,
+    architectures: "list[str] | None",
+    precision: str,
+    hardware: str,
+    framework: str,
+    model_type: str,
+) -> Mapping[str, Any] | None:
+    """Borrow a cross-model warm-replay donor from the native KG link-graph.
+
+    Active only when a NATIVE KG client (``GBRAIN_KG_NATIVE``) is reachable.
+    Returns a recipe-shaped donor synthesized from the strongest cross-model
+    ``KNOB_IMPROVES`` edge for the target ``arch+precision`` (single_top), or
+    ``None`` to fall back to the recipe-KB sibling search. Fully
+    degradation-safe — any failure yields ``None`` and never blocks warm-start.
+
+    Args:
+        architectures: Current model architecture list.
+        precision: Baseline precision (folded into the KG object node).
+        hardware: Hardware condition filter.
+        framework: Framework condition filter.
+        model_type: Target model type (stamped onto the synthesized donor).
+
+    Returns:
+        A recipe-shaped donor row, or ``None`` when KG is unavailable, not in
+        native mode, or carries no usable cross-model knob.
+    """
+    archs = [a for a in (architectures or []) if str(a or "").strip()]
+    if not archs:
+        return None
+    try:
+        from ..recipe_kb.kg_client import (
+            generate_warmstart_donor_graph_guided,
+            get_kg_client,
+        )
+
+        kg = get_kg_client()
+        if kg is None or not getattr(kg, "_native", False) or not kg.is_available():
+            return None
+        donor = generate_warmstart_donor_graph_guided(
+            kg,
+            architectures=archs,
+            precision=precision or "",
+            hardware=hardware or "",
+            framework=framework or "",
+            model_type=model_type or "",
+        )
+        return donor or None
+    except Exception as exc:  # noqa: BLE001 — KG donor is best-effort/advisory
+        log.info("KG-native config donor skipped: %s", exc)
+        return None
+
+
 def _find_config_donor(
     kb: Any,
     *,
@@ -270,6 +399,9 @@ def _find_config_donor(
     arch_slug: str,
     framework_version: str,
     precision: str,
+    target_conc: Any = None,
+    target_isl: Any = None,
+    target_osl: Any = None,
 ) -> tuple[Mapping[str, Any] | None, str, float]:
     """Borrow a replayable champion config from the nearest same-arch sibling.
 
@@ -279,7 +411,10 @@ def _find_config_donor(
     conf 0.95) then L3 (same arch, any framework version, conf 0.5).
 
     Only same ``hw+framework+model_type+arch(+precision)(+fwv)`` siblings are
-    considered, so the borrowed config is stack-compatible. Returns
+    searched, and each candidate must additionally clear
+    :func:`_donor_is_trustworthy` (positive validated gain, concrete matching
+    architecture, no workload-shape conflict) so a borrowed config is both
+    stack-compatible and evidence-backed. Returns
     ``(donor_row, donor_tier, donor_confidence)`` or ``(None, "", 0.0)``.
     """
     if not (model_type or arch_slug):
@@ -318,7 +453,16 @@ def _find_config_donor(
         for r in rows or []:
             if str(r.get("canonical_id") or "") == cid:
                 continue
-            if _has_replayable_config(r):
+            # Borrowed donor must clear the trustworthiness gate (validated gain,
+            # concrete matching arch, no shape conflict) — not just carry a config.
+            if _donor_is_trustworthy(
+                r,
+                target_arch_slug=arch_slug,
+                target_model_type=model_type,
+                target_conc=target_conc,
+                target_isl=target_isl,
+                target_osl=target_osl,
+            ):
                 return r, tier, conf
     return None, "", 0.0
 
@@ -335,6 +479,10 @@ def _build_warm_start_context(
     config_donor_tier: str = "",
     config_donor_confidence: float = 0.0,
     model_architectures: "list[str] | None" = None,
+    hardware: str = "",
+    framework: str = "",
+    precision: str = "",
+    kg_client: Any = None,
 ) -> dict[str, Any]:
     """Build the model-facing WarmStartContext from a KB recipe row.
 
@@ -407,7 +555,237 @@ def _build_warm_start_context(
             }
     # Extract replayable code patches from prs_tested (positive + negative).
     _extract_patches_from_prs_tested(ctx, recipe, model_architectures)
+    # KG enhancement: cross-recipe revert aggregation + arch-graph advisory
+    # blocks + graph-recommended knobs + validity. Best-effort and fully
+    # degradable — never lose the local prs_tested patches on KG failure.
+    _enhance_warm_start_with_kg(
+        ctx,
+        model_architectures=model_architectures,
+        hardware=hardware,
+        framework=framework,
+        precision=precision,
+        kg_client=kg_client,
+    )
     return ctx
+
+
+def _kg_guided_enabled() -> bool:
+    """Return ``True`` when journal-knob graph guidance is enabled.
+
+    Gated by ``GBRAIN_KG_GUIDED`` (default off) so emitting ``KNOB_*`` edges
+    and surfacing ``graph_guided_knobs`` is a deliberate opt-in that never
+    changes live behavior until explicitly turned on.
+    """
+    return os.environ.get("GBRAIN_KG_GUIDED", "").strip().lower() in ("1", "true", "yes")
+
+
+def _arch_norm(value: Any) -> str:
+    """Normalize an architecture/entity token to match KG fact slugs.
+
+    Args:
+        value: Raw architecture or entity name.
+
+    Returns:
+        The lowercased slug (spaces/slashes to underscores).
+    """
+    return str(value or "").strip().replace(" ", "_").replace("/", "_").lower()
+
+
+def _enhance_warm_start_with_kg(
+    ctx: dict[str, Any],
+    *,
+    model_architectures: "list[str] | None",
+    hardware: str,
+    framework: str,
+    precision: str = "",
+    kg_client: Any = None,
+) -> None:
+    """Augment the warm-start context with knowledge-graph signals.
+
+    Adds, when a KG backend is reachable:
+
+    * ``blocked_patches`` — cross-recipe hard blocks on the same arch
+      (``REVERTED_ON`` / ``DEGRADES`` / ``CRASHES``).
+    * ``advisory_blocked_patches`` — soft blocks inferred from related
+      architectures (decayed confidence), reached via ``USES_ARCH`` /
+      ``VARIANT_OF`` graph traversal.
+    * ``recommended_knobs`` — ``IMPROVES`` candidates for the current
+      arch+hw+fw (minus anything blocked).
+    * ``expired`` markers on replay patches whose ``VALID_FOR`` window
+      has lapsed.
+
+    The whole step is wrapped in a degradation guard: any failure leaves
+    ``ctx`` exactly as the local prs_tested logic produced it.
+
+    Args:
+        ctx: The warm-start context to mutate in place.
+        model_architectures: The current model's architecture list.
+        hardware: The current hardware/GPU identifier.
+        framework: The current inference framework.
+        kg_client: Optional injected KG client (defaults to the env-built
+            singleton; ``None`` disables enhancement).
+    """
+    archs = [a for a in (model_architectures or []) if str(a or "").strip()]
+    if not archs:
+        return
+    try:
+        kg = kg_client
+        if kg is None:
+            from ..recipe_kb.kg_client import get_kg_client
+
+            kg = get_kg_client()
+        if kg is None or not kg.is_available():
+            return
+    except Exception as exc:  # noqa: BLE001 - availability probe must never raise out
+        log.warning("KG warm-start enhancement skipped (unavailable): %s", exc)
+        return
+
+    try:
+        own_arch = {_arch_norm(a) for a in archs}
+        # 1. Architecture-family graph: reach related architectures.
+        related: set[str] = set(own_arch)
+        for arch in archs:
+            for node in kg.graph_traverse_safe(
+                start_entity=arch,
+                predicate_filter=["USES_ARCH", "VARIANT_OF"],
+                max_hops=2,
+                direction="both",
+            ):
+                if node.entity:
+                    related.add(node.entity)
+
+        # 2. Cross-recipe negatives → hard (own arch) vs advisory (related).
+        already_blocked = {
+            _arch_norm(b.get("patch_file"))
+            for b in (ctx.get("blocked_patches") or [])
+            if isinstance(b, dict)
+        }
+        hard: list[dict[str, Any]] = []
+        advisory: list[dict[str, Any]] = []
+        seen_adv: set[str] = set()
+        for fact in kg.query_facts_safe(
+            object=sorted(related),
+            predicate=["REVERTED_ON", "DEGRADES", "CRASHES"],
+            limit=100,
+        ):
+            patch = fact.subject
+            if not patch:
+                continue
+            if fact.object in own_arch:
+                if patch in already_blocked:
+                    continue
+                already_blocked.add(patch)
+                hard.append({
+                    "patch_file": patch,
+                    "reason": f"{fact.predicate}: {fact.properties.get('error') or fact.properties.get('reason', '')}",
+                    "confidence": fact.confidence,
+                    "block_type": "hard",
+                    "source": "kg",
+                })
+            else:
+                if patch in seen_adv or patch in own_arch:
+                    continue
+                seen_adv.add(patch)
+                advisory.append({
+                    "patch_file": patch,
+                    "reason": f"{fact.predicate} on related arch {fact.object}",
+                    "confidence": round(fact.confidence * 0.6, 3),
+                    "block_type": "advisory",
+                    "source": "kg",
+                })
+        if hard:
+            ctx.setdefault("blocked_patches", []).extend(hard)
+        if advisory:
+            ctx["advisory_blocked_patches"] = advisory
+
+        # 3. Positive candidates for current arch+hw+fw, minus blocked.
+        conditions: dict[str, Any] = {}
+        if hardware:
+            conditions["hw"] = hardware
+        if framework:
+            conditions["fw"] = framework
+        blocked_now = {_arch_norm(b.get("patch_file")) for b in (ctx.get("blocked_patches") or [])}
+        recommended: list[dict[str, Any]] = []
+        seen_rec: set[str] = set()
+        for fact in kg.query_facts_safe(
+            object=sorted(own_arch),
+            predicate=["IMPROVES"],
+            conditions=conditions or None,
+            limit=50,
+        ):
+            knob = fact.subject
+            if not knob or knob in blocked_now or knob in seen_rec:
+                continue
+            seen_rec.add(knob)
+            recommended.append({
+                "knob": knob,
+                "expected_gain": fact.gain,
+                "confidence": fact.confidence,
+                "source": "kg_graph",
+            })
+        if recommended:
+            recommended.sort(key=lambda r: -(r.get("expected_gain") or 0.0))
+            ctx["recommended_knobs"] = recommended
+
+        # 3b. Journal-derived config knobs (KNOB_IMPROVES), behind a flag.
+        # These carry runnable args/envs and use the fingerprint vocabulary,
+        # so they ride a separate ctx key and never mix with the patch-keyed
+        # ``recommended_knobs`` above.
+        if _kg_guided_enabled():
+            from ..recipe_kb.kg_client import generate_knob_candidates_graph_guided
+
+            knobs = generate_knob_candidates_graph_guided(
+                kg,
+                architectures=archs,
+                precision=precision,
+                hardware=hardware,
+                framework=framework,
+                max_variants=8,
+            )
+            if knobs:
+                ctx["graph_guided_knobs"] = knobs
+
+        # 4. Validity check: flag replay patches whose VALID_FOR has lapsed.
+        replay = ctx.get("recommended_replay")
+        if isinstance(replay, Mapping):
+            for patch in replay.get("patches") or []:
+                if not isinstance(patch, dict):
+                    continue
+                pf = patch.get("patch_file") or ""
+                if not pf:
+                    continue
+                for v in kg.query_facts_safe(subject=pf, predicate=["VALID_FOR"], limit=10):
+                    if _validity_expired(v.properties):
+                        patch["expired"] = True
+                        patch["expire_reason"] = f"valid_for {v.properties.get('version', '')}".strip()
+                        break
+    except Exception as exc:  # noqa: BLE001 - enhancement is advisory only
+        log.warning("KG warm-start enhancement degraded: %s", exc)
+
+
+def _validity_expired(props: Mapping[str, Any]) -> bool:
+    """Return ``True`` when a ``VALID_FOR`` fact's ``expires`` date is past.
+
+    Only an explicit ``expires`` ISO date triggers expiry; free-form
+    version ranges are intentionally not parsed here (avoids false
+    positives) and are deferred to the native KG validity engine.
+
+    Args:
+        props: The ``VALID_FOR`` fact's properties.
+
+    Returns:
+        ``True`` when ``expires`` is a past date, else ``False``.
+    """
+    expires = str(props.get("expires") or "").strip()
+    if not expires:
+        return False
+    try:
+        exp = datetime.fromisoformat(expires.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    if exp.tzinfo is None:
+        exp = exp.replace(tzinfo=timezone.utc)
+    return exp < datetime.now(timezone.utc)
 
 
 def _extract_patches_from_prs_tested(
@@ -818,11 +1196,42 @@ def run_t0_anchor(
     config_donor: Mapping[str, Any] | None = None
     config_donor_tier = ""
     config_donor_conf = 0.0
-    if warm_point and _has_replayable_config(warm_point):
+    _tgt_conc = getattr(shared_state, "conc", None)
+    _tgt_isl = getattr(shared_state, "isl", None)
+    _tgt_osl = getattr(shared_state, "osl", None)
+    # A true-self (identity ``exact``) champion always replays; a cross-model
+    # warm_point that happens to carry a config is a BORROW and must clear the
+    # trustworthiness gate before it is adopted as the replay donor.
+    if warm_point and _has_replayable_config(warm_point) and (
+        warm_tier == "exact"
+        or _donor_is_trustworthy(
+            warm_point,
+            target_arch_slug=_arch_slug,
+            target_model_type=_model_type_val,
+            target_conc=_tgt_conc,
+            target_isl=_tgt_isl,
+            target_osl=_tgt_osl,
+        )
+    ):
         config_donor = warm_point
         config_donor_tier = "self"
         config_donor_conf = warm_conf
-    elif warm_point:
+    # KG-native cross-model donor (single_top, gated by GBRAIN_KG_NATIVE): when
+    # a borrow is needed, prefer the strongest cross-model KNOB_IMPROVES edge
+    # over the recipe-KB sibling search. Degradation-safe → recipe-KB fallback.
+    if config_donor is None and warm_point:
+        kg_donor = _kg_native_config_donor(
+            architectures=_architectures_val if isinstance(_architectures_val, list) else None,
+            precision=_precision or "",
+            hardware=hw,
+            framework=_framework or "",
+            model_type=_model_type_val,
+        )
+        if kg_donor is not None:
+            config_donor = kg_donor
+            config_donor_tier = "kg_cross_model"
+            config_donor_conf = float(kg_donor.get("confidence") or 0.0)
+    if config_donor is None and warm_point:
         donor, dtier, dconf = _find_config_donor(
             kb,
             cid=cid,
@@ -832,6 +1241,9 @@ def run_t0_anchor(
             arch_slug=_arch_slug,
             framework_version=_fw_version or "",
             precision=_precision or "",
+            target_conc=_tgt_conc,
+            target_isl=_tgt_isl,
+            target_osl=_tgt_osl,
         )
         if donor is not None:
             config_donor = donor
@@ -896,6 +1308,9 @@ def run_t0_anchor(
             source=warm_source,
             recipe=warm_point or None,
             model_architectures=_architectures_val if isinstance(_architectures_val, list) else None,
+            hardware=hw,
+            framework=_framework or "",
+            precision=_precision or "",
         )
     except Exception:  # noqa: BLE001 — defensive; context is advisory
         log.exception("warm_start_context build failed")

--- a/inference_optimizer/orchestrator/specialist_runner.py
+++ b/inference_optimizer/orchestrator/specialist_runner.py
@@ -545,6 +545,8 @@ class SpecialistRunner:
                 warm_start_recipe=dict(params.get("warm_start_recipe") or {}),
                 warm_start_pitfalls=list(params.get("warm_start_pitfalls") or []),
                 warm_start_lessons=list(params.get("warm_start_lessons") or []),
+                kg_recommended_knobs=[p for p in (params.get("kg_recommended_knobs") or []) if isinstance(p, dict)],
+                kg_guided_knobs=[p for p in (params.get("kg_guided_knobs") or []) if isinstance(p, dict)],
                 pr_feed=list(params.get("pr_feed") or []),
                 pr_monitor_available=bool(params.get("pr_monitor_available", True)),
                 framework=str(params.get("framework") or ""),

--- a/inference_optimizer/orchestrator/system_prompts/specialist_prompt_builder.py
+++ b/inference_optimizer/orchestrator/system_prompts/specialist_prompt_builder.py
@@ -619,6 +619,15 @@ class SpecialistPromptInputs:
     warm_start_pitfalls: list[dict[str, Any]] = field(default_factory=list)
     # T0 lessons — positive priors from prior KEEPs; rendered as § 5b.
     warm_start_lessons: list[dict[str, Any]] = field(default_factory=list)
+    # KG graph-recommended knobs (cross-recipe IMPROVES candidates reached via
+    # the architecture family graph); advisory candidates rendered as § 5d.
+    # Each entry: ``{knob, expected_gain, confidence, source}``.
+    kg_recommended_knobs: list[dict[str, Any]] = field(default_factory=list)
+    # KG graph-guided config knobs (journal-derived ``KNOB_IMPROVES`` for the
+    # current arch+precision); rendered as § 5e. Unlike ``kg_recommended_knobs``
+    # these carry runnable ``args``/``envs``. Each entry:
+    # ``{knob, args, envs, name, expected_gain, confidence, source}``.
+    kg_guided_knobs: list[dict[str, Any]] = field(default_factory=list)
     # PR feed
     pr_feed: list[dict[str, Any]] = field(default_factory=list)
     pr_monitor_available: bool = True
@@ -1609,6 +1618,92 @@ def _section_pitfalls(inp: SpecialistPromptInputs) -> list[str]:
     return rows
 
 
+# Section 5d — KG graph-recommended knobs (advisory positive candidates)
+def _section_kg_recommended(inp: SpecialistPromptInputs) -> list[str]:
+    """Render cross-recipe ``IMPROVES`` candidates from the knowledge graph.
+
+    These are advisory priors reached via the architecture family graph
+    (``USES_ARCH`` / ``VARIANT_OF``) — knobs that improved a related
+    architecture on the same hw+fw. The specialist prioritises but never
+    blindly trusts them; the Critic still gates the final answer.
+
+    Args:
+        inp: The specialist prompt inputs (reads ``kg_recommended_knobs``).
+
+    Returns:
+        The rendered graph-recommended-knobs section lines.
+    """
+    rows = ["## 5d. GRAPH-RECOMMENDED KNOBS (cross-recipe IMPROVES — advisory, prioritise but verify)", ""]
+    if not inp.kg_recommended_knobs:
+        rows.append(_NONE_PLACEHOLDER)
+        return rows
+    for entry in inp.kg_recommended_knobs:
+        if not isinstance(entry, dict):
+            continue
+        knob = str(entry.get("knob") or "").strip()
+        if not knob:
+            continue
+        meta_bits: list[str] = []
+        gain = entry.get("expected_gain")
+        if isinstance(gain, (int, float)) and gain:
+            meta_bits.append(f"gain={float(gain):+.1f}%")
+        conf = entry.get("confidence")
+        if isinstance(conf, (int, float)) and conf > 0:
+            meta_bits.append(f"conf={float(conf):.2f}")
+        meta = f" ({', '.join(meta_bits)})" if meta_bits else ""
+        rows.append(f"- **{knob}**{meta}")
+    if len(rows) == 2:  # header + blank only; all entries filtered out
+        rows.append(_NONE_PLACEHOLDER)
+    return rows
+
+
+# Section 5e — KG graph-guided config knobs (runnable args/envs)
+def _section_kg_guided_knobs(inp: SpecialistPromptInputs) -> list[str]:
+    """Render journal-derived ``KNOB_IMPROVES`` candidates with runnable config.
+
+    These come from prior sessions' ``optimization_journal`` config knobs that
+    kept a positive gain on the same architecture+precision. Each carries the
+    exact ``args``/``envs`` to apply, so the specialist can try them directly.
+    Advisory: the specialist verifies and the Critic still gates the answer.
+
+    Args:
+        inp: The specialist prompt inputs (reads ``kg_guided_knobs``).
+
+    Returns:
+        The rendered graph-guided-knobs section lines.
+    """
+    rows = ["## 5e. GRAPH-GUIDED CONFIG KNOBS (journal KNOB_IMPROVES — runnable, prioritise but verify)", ""]
+    if not inp.kg_guided_knobs:
+        rows.append(_NONE_PLACEHOLDER)
+        return rows
+    for entry in inp.kg_guided_knobs:
+        if not isinstance(entry, dict):
+            continue
+        args = str(entry.get("args") or "").strip()
+        envs = entry.get("envs") if isinstance(entry.get("envs"), dict) else {}
+        if not args and not envs:
+            continue
+        name = str(entry.get("name") or "").strip()
+        meta_bits: list[str] = []
+        gain = entry.get("expected_gain")
+        if isinstance(gain, (int, float)) and gain:
+            meta_bits.append(f"gain={float(gain):+.1f}%")
+        ev = entry.get("evidence_count")
+        if isinstance(ev, (int, float)) and ev:
+            meta_bits.append(f"kept={int(ev)}x")
+        meta = f" ({', '.join(meta_bits)})" if meta_bits else ""
+        label = name or args
+        rows.append(f"- **{label}**{meta}")
+        if args:
+            rows.append(f"  - args: `{args}`")
+        if envs:
+            env_str = " ".join(f"{k}={v}" for k, v in envs.items())
+            rows.append(f"  - envs: `{env_str}`")
+    if len(rows) == 2:  # header + blank only; all entries filtered out
+        rows.append(_NONE_PLACEHOLDER)
+    return rows
+
+
 # Section 6 — PR feed
 def _section_pr_feed(inp: SpecialistPromptInputs) -> list[str]:
     """Render Section 6 (PR feed) of the specialist prompt.
@@ -1929,6 +2024,8 @@ def build_specialist_prompts(inp: SpecialistPromptInputs) -> tuple[str, str]:
         _section_substrate_dual_read(inp),  # 4a: § 4c (substrate × recipe cross-check)
         _section_lessons(inp),  # 5: § 5b
         _section_pitfalls(inp),  # 6: § 5c
+        _section_kg_recommended(inp),  # 6a: § 5d (KG graph-recommended knobs)
+        _section_kg_guided_knobs(inp),  # 6b: § 5e (KG graph-guided runnable knobs)
         _section_pr_feed(inp),  # 7: § 6
         _section_source_hint(inp),  # 8: § 7
     ]

--- a/inference_optimizer/recipe_kb/kg_client.py
+++ b/inference_optimizer/recipe_kb/kg_client.py
@@ -1,0 +1,1485 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Knowledge-Graph query client over the gbrain page store.
+
+The kb-mirror drivers embed a ``## Facts`` fence in every consumable page
+body (recipe / framework_patch / kernel / gemm_tune / arch_family). Each
+fence line is a typed triple::
+
+    - {Subject} {PREDICATE} {Object} (prop1: val1, prop2: val2, ...)
+
+This module turns that document substrate into a small graph query
+surface (``query_facts`` / ``graph_traverse`` / ``find_conflicts``) plus
+incremental writes (``emit_fact`` / ``retract_fact``).
+
+Two execution modes:
+
+* **Short-term (legacy)** — client-side simulation. ``query_facts``
+  drives gbrain ``search`` + client-side fence parsing/filtering;
+  ``graph_traverse`` runs a client BFS over ``query_facts``; writes are
+  read-modify-write over ``get_page`` / ``put_page``.
+* **Native (``use_native_kg``)** — maps the triple API onto gbrain's
+  first-class *link graph*. A triple ``(subject, predicate, object)``
+  becomes an edge ``add_link(from=subject, to=object, link_type=predicate,
+  context=json(properties))``; reads use ``get_links`` / ``get_backlinks``
+  / ``traverse_graph``. Because gbrain edges carry no structured
+  properties, fact properties are encoded in the edge ``context`` JSON.
+  ``add_link`` requires both endpoints to exist, so writes materialize
+  missing nodes; ``remove_link`` is pair-coarse, so ``retract_fact`` does a
+  read-modify-write that preserves the other link types on the same pair.
+  gbrain reports some write failures (e.g. ``add_link`` to a missing page)
+  as an in-band ``{"error": ...}`` payload rather than a transport error,
+  so the write paths inspect the decoded result via :func:`_rpc_failed`.
+
+Every read method has a ``*_safe`` companion that swallows transport
+failures and returns an empty result, so the KG layer can never block or
+break a warm-start that would otherwise succeed from the local store.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Sequence
+
+from .gbrain_remote_client import GbrainRemoteError, _GbrainMcp
+
+log = logging.getLogger(__name__)
+
+# Cap the number of fact lines parsed per page (mirrors the mirror-side
+# write cap) so a malformed/oversized page never blows up a query tick.
+_MAX_FACTS_PER_PAGE = 50
+# Hard ceiling on BFS breadth to bound client-side traversal cost.
+_MAX_TRAVERSE_NODES = 200
+# Default TTL for the per-client search cache (seconds). One warm-start
+# enhancement issues many repeated searches; caching avoids re-hitting the
+# foreground HTTP budget for the same query terms.
+_SEARCH_CACHE_TTL_SEC = 30.0
+
+# Parse one fence line: "- SUBJECT PREDICATE OBJECT (props)". Subject and
+# object are slug tokens (no spaces); predicate is an uppercase relation.
+_FACT_LINE_RE = re.compile(
+    r"^-\s+(?P<subject>\S+)\s+(?P<predicate>[A-Z][A-Z0-9_]*)\s+(?P<object>\S+)\s*(?:\((?P<props>.*)\))?\s*$"
+)
+
+
+def _entity(value: Any) -> str:
+    """Normalize an entity token the same way the mirror writer does.
+
+    Args:
+        value: Raw entity name.
+
+    Returns:
+        Lowercased slug (spaces/slashes to underscores), or ``""``.
+    """
+    s = str(value or "").strip().replace(" ", "_").replace("/", "_")
+    return s.lower()
+
+
+def _as_set(value: Any) -> set[str]:
+    """Coerce a scalar / pipe-string / iterable of entities to a norm set.
+
+    A predicate or entity filter may arrive as a single string, a
+    pipe-delimited alternation (``"REVERTED_ON|DEGRADES"``), or a list.
+
+    Args:
+        value: The filter value (``None`` yields an empty set).
+
+    Returns:
+        The set of normalized tokens (empty means "match any").
+    """
+    if value is None:
+        return set()
+    items: Iterable[Any]
+    if isinstance(value, str):
+        items = value.split("|")
+    elif isinstance(value, (list, tuple, set)):
+        items = value
+    else:
+        items = [value]
+    return {_entity(item) for item in items if str(item or "").strip()}
+
+
+def _parse_props(raw: str | None) -> dict[str, str]:
+    """Parse the ``(key: val, key: val)`` property blob of a fact line.
+
+    Args:
+        raw: The inner text between the parentheses (may be ``None``/empty).
+
+    Returns:
+        A mapping of property name to value (both stripped strings).
+    """
+    props: dict[str, str] = {}
+    if not raw:
+        return props
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        key, sep, val = part.partition(":")
+        if sep:
+            props[key.strip()] = val.strip()
+        else:
+            props[part] = ""
+    return props
+
+
+@dataclass
+class Fact:
+    """A typed triple parsed from a page ``## Facts`` fence."""
+
+    subject: str
+    predicate: str
+    object: str
+    properties: dict[str, str] = field(default_factory=dict)
+    source_slug: str = ""
+
+    @property
+    def gain(self) -> float:
+        """Return the signed gain percentage, or ``0.0`` when absent."""
+        return _pct(self.properties.get("gain"))
+
+    @property
+    def loss(self) -> float:
+        """Return the loss magnitude as a float, or ``0.0`` when absent."""
+        return _pct(self.properties.get("loss"))
+
+    @property
+    def confidence(self) -> float:
+        """Return the fact confidence in ``[0,1]`` (defaults to ``0.8``)."""
+        try:
+            return float(self.properties.get("confidence", 0.8))
+        except (TypeError, ValueError):
+            return 0.8
+
+
+@dataclass
+class GraphNode:
+    """A node reached during :meth:`KGClient.graph_traverse`."""
+
+    entity: str
+    depth: int
+    via: Fact
+
+
+def _pct(value: Any) -> float:
+    """Parse a percentage-like string (``"+35.2%"``) into a float.
+
+    Args:
+        value: Raw value (``"+35.2%"`` / ``"-4.2"`` / number / ``None``).
+
+    Returns:
+        The numeric value, or ``0.0`` when it cannot be parsed.
+    """
+    if value is None:
+        return 0.0
+    try:
+        return float(str(value).strip().rstrip("%"))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def parse_facts_fence(body: str, *, source_slug: str = "") -> list[Fact]:
+    """Extract all triples from a page body's ``## Facts`` fence.
+
+    Reads the bullet lines under the first ``## Facts`` header up to the
+    next ``## `` header (or end of body). Malformed lines are skipped.
+
+    Args:
+        body: The full page body markdown.
+        source_slug: Slug recorded on each parsed fact for provenance.
+
+    Returns:
+        The parsed facts (capped at :data:`_MAX_FACTS_PER_PAGE`).
+    """
+    if not body or "## Facts" not in body:
+        return []
+    facts: list[Fact] = []
+    in_fence = False
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("## "):
+            # Enter the Facts section; any other ## header ends it.
+            in_fence = stripped[3:].strip().lower().startswith("facts")
+            continue
+        if not in_fence:
+            continue
+        m = _FACT_LINE_RE.match(stripped)
+        if not m:
+            continue
+        facts.append(
+            Fact(
+                subject=_entity(m.group("subject")),
+                predicate=m.group("predicate").strip().upper(),
+                object=_entity(m.group("object")),
+                properties=_parse_props(m.group("props")),
+                source_slug=source_slug,
+            )
+        )
+        if len(facts) >= _MAX_FACTS_PER_PAGE:
+            break
+    return facts
+
+
+def format_fact_line(subject: str, predicate: str, obj: str, properties: dict[str, Any] | None) -> str:
+    """Render a triple into the canonical ``## Facts`` fence line.
+
+    Args:
+        subject: Subject entity.
+        predicate: Relation (forced uppercase).
+        obj: Object entity.
+        properties: Optional property mapping.
+
+    Returns:
+        A single fence line, e.g. ``"- a IMPROVES b (gain: +5%)"``.
+    """
+    props = properties or {}
+    inner = ", ".join(f"{k}: {v}" for k, v in props.items())
+    return f"- {_entity(subject)} {str(predicate).strip().upper()} {_entity(obj)} ({inner})"
+
+
+def _link_type(predicate: Any) -> str:
+    """Normalize a predicate into a gbrain ``link_type`` token.
+
+    gbrain link types are lowercase relation tokens (``invested_in``). The
+    mirror writer and this reader must agree on the same normalization so
+    edges round-trip.
+
+    Args:
+        predicate: Raw predicate / relation name.
+
+    Returns:
+        The lowercased link-type token, or ``""``.
+    """
+    return str(predicate or "").strip().lower()
+
+
+def _props_to_context(properties: dict[str, Any] | None) -> str:
+    """Serialize fact properties into an edge ``context`` JSON string.
+
+    gbrain edges carry no structured properties — only a free-text
+    ``context``. We encode the property map as compact JSON so the reader
+    can faithfully reconstruct it. Empty-valued properties are dropped to
+    match the mirror writer (``kg_links.props_to_context``).
+
+    Args:
+        properties: The fact property map (``None`` yields ``"{}"``).
+
+    Returns:
+        A compact JSON object string.
+    """
+    if not properties:
+        return "{}"
+    return json.dumps(
+        {str(k): str(v) for k, v in properties.items() if str(v or "").strip()},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
+def _context_to_props(context: Any) -> dict[str, str]:
+    """Parse an edge ``context`` back into a property map.
+
+    Args:
+        context: The edge context (JSON string, dict, or ``None``).
+
+    Returns:
+        A ``str -> str`` property map (empty on missing/invalid context).
+    """
+    if not context:
+        return {}
+    if isinstance(context, dict):
+        return {str(k): str(v) for k, v in context.items()}
+    try:
+        data = json.loads(context)
+    except (ValueError, TypeError):
+        return {}
+    return {str(k): str(v) for k, v in data.items()} if isinstance(data, dict) else {}
+
+
+def _rpc_failed(result: Any) -> bool:
+    """Return ``True`` when a gbrain tool result reports an in-band error.
+
+    gbrain returns some failures (e.g. ``add_link`` on a missing page) as a
+    normal content payload whose decoded JSON carries an ``error`` key, not
+    as a JSON-RPC / ``isError`` envelope. The transport only raises for the
+    latter, so write callers must inspect the decoded result themselves or a
+    failed write silently parses as success.
+
+    Args:
+        result: The decoded tool result.
+
+    Returns:
+        ``True`` when the result is an error payload.
+    """
+    return isinstance(result, dict) and bool(result.get("error"))
+
+
+def _edge_to_fact(edge: dict[str, Any]) -> Fact:
+    """Build a :class:`Fact` from a gbrain link-graph edge row.
+
+    A link-graph edge ``{from_slug, to_slug, link_type, context}`` maps to
+    the triple ``(subject=from, predicate=link_type, object=to)`` with the
+    decoded ``context`` as properties.
+
+    Args:
+        edge: A ``get_links`` / ``traverse_graph`` edge row.
+
+    Returns:
+        The corresponding :class:`Fact`.
+    """
+    return Fact(
+        subject=_entity(edge.get("from_slug")),
+        predicate=str(edge.get("link_type") or "").strip().upper(),
+        object=_entity(edge.get("to_slug")),
+        properties=_context_to_props(edge.get("context")),
+        source_slug=str(edge.get("from_slug") or ""),
+    )
+
+
+def _conditions_match(fact: Fact, conditions: dict[str, Any] | None) -> bool:
+    """Return ``True`` when every requested condition matches the fact.
+
+    Matching is lenient (normalized substring either way) because the
+    simulation layer compares free-form property text (``hw``/``fw``/
+    ``condition``/``precision``).
+
+    Args:
+        fact: The candidate fact.
+        conditions: Property constraints (``None``/empty matches all).
+
+    Returns:
+        ``True`` when all constraints are satisfied.
+    """
+    if not conditions:
+        return True
+    for key, want in conditions.items():
+        have = fact.properties.get(key)
+        if have is None:
+            return False
+        nh, nw = _entity(have), _entity(want)
+        if nw and nw not in nh and nh not in nw:
+            return False
+    return True
+
+
+class KGClient:
+    """Knowledge-graph query surface over the gbrain page store.
+
+    Short-term implementation simulates graph queries client-side via
+    ``search`` + fence parsing; long-term it delegates to native gbrain KG
+    tools when ``use_native_kg`` is set.
+    """
+
+    def __init__(self, mcp: Any, *, use_native_kg: bool = False, search_limit: int = 100) -> None:
+        """Initialize the client.
+
+        Args:
+            mcp: A duck-typed MCP client exposing ``call(tool, arguments)``.
+            use_native_kg: Delegate to native gbrain KG tools when ``True``.
+            search_limit: Default page fan-out per ``query_facts`` search.
+        """
+        self._mcp = mcp
+        self._native = bool(use_native_kg)
+        self._search_limit = max(1, int(search_limit))
+        # query_str -> (monotonic_ts, [(slug, body), ...]); bounded by TTL.
+        self._search_cache: dict[str, tuple[float, list[tuple[str, str]]]] = {}
+        # Slugs confirmed to exist (or just created) as pages. ``add_link``
+        # requires both endpoints to exist, so the native write path
+        # materializes missing nodes and memoizes them here.
+        self._known_nodes: set[str] = set()
+
+    # -- availability ------------------------------------------------------
+    def is_available(self) -> bool:
+        """Probe whether the backing store is reachable.
+
+        Returns:
+            ``True`` when a tiny ``list_pages`` probe succeeds.
+        """
+        if self._mcp is None:
+            return False
+        try:
+            self._mcp.call("list_pages", {"limit": 1})
+            return True
+        except (GbrainRemoteError, OSError, TimeoutError) as exc:
+            log.info("kg backend unavailable: %s", exc)
+            return False
+
+    # -- page access -------------------------------------------------------
+    def _cache_ttl(self) -> float:
+        """Return the search-cache TTL in seconds (env-overridable)."""
+        raw = os.environ.get("GBRAIN_KG_CACHE_TTL_SEC", "").strip()
+        if raw:
+            try:
+                return max(0.0, float(raw))
+            except ValueError:
+                pass
+        return _SEARCH_CACHE_TTL_SEC
+
+    def _search_pages(self, query: str, limit: int) -> list[tuple[str, str]]:
+        """Search pages and return ``(slug, body)`` pairs (TTL-cached).
+
+        Tolerates list / ``{results|pages|hits: [...]}`` envelopes and
+        fetches the body via ``get_page`` when the hit omits it. Results are
+        memoized per query string for :data:`_SEARCH_CACHE_TTL_SEC` so one
+        warm-start enhancement (many repeated searches) does not re-hit the
+        foreground HTTP budget for identical terms.
+
+        Args:
+            query: Free-text search string.
+            limit: Maximum hits to fetch.
+
+        Returns:
+            A list of ``(slug, body)`` tuples.
+        """
+        if self._mcp is None:
+            return []
+        ttl = self._cache_ttl()
+        now = time.monotonic()
+        cache_key = f"{query}\x00{int(limit)}"
+        if ttl > 0.0:
+            cached = self._search_cache.get(cache_key)
+            if cached is not None and now - cached[0] <= ttl:
+                return list(cached[1])
+        raw = self._mcp.call("search", {"query": query, "limit": int(limit)})
+        hits: Sequence[Any]
+        if isinstance(raw, dict):
+            hits = raw.get("results") or raw.get("pages") or raw.get("hits") or []
+        elif isinstance(raw, list):
+            hits = raw
+        else:
+            hits = []
+        out: list[tuple[str, str]] = []
+        for hit in hits:
+            if not isinstance(hit, dict):
+                continue
+            slug = str(hit.get("slug") or hit.get("id") or "")
+            body = hit.get("body")
+            if not body and slug:
+                body = self._page_body(slug)
+            if slug and body:
+                out.append((slug, str(body)))
+        if ttl > 0.0:
+            self._search_cache[cache_key] = (now, list(out))
+        return out
+
+    def _page_body(self, slug: str) -> str:
+        """Fetch a page and return its body markdown (best-effort).
+
+        Args:
+            slug: The page slug.
+
+        Returns:
+            The page body, or ``""`` when unavailable.
+        """
+        if self._mcp is None:
+            return ""
+        try:
+            page = self._mcp.call("get_page", {"slug": slug})
+        except (GbrainRemoteError, OSError, TimeoutError):
+            return ""
+        return _page_content(page)
+
+    # -- native link-graph access ------------------------------------------
+    @staticmethod
+    def _as_edges(raw: Any) -> list[dict[str, Any]]:
+        """Coerce a link-graph tool result into a list of edge rows.
+
+        gbrain returns a bare list of edges; tolerate ``{links|paths|
+        edges|nodes: [...]}`` envelopes too.
+
+        Args:
+            raw: The raw tool result.
+
+        Returns:
+            The edge rows (non-dict entries dropped).
+        """
+        rows: Any
+        if isinstance(raw, list):
+            rows = raw
+        elif isinstance(raw, dict):
+            rows = raw.get("links") or raw.get("paths") or raw.get("edges") or raw.get("nodes") or []
+        else:
+            rows = []
+        return [r for r in rows if isinstance(r, dict)]
+
+    def _get_links(self, slug: str) -> list[dict[str, Any]]:
+        """Return outgoing edges for ``slug`` (best-effort)."""
+        if self._mcp is None or not slug:
+            return []
+        return self._as_edges(self._mcp.call("get_links", {"slug": _entity(slug)}))
+
+    def _get_backlinks(self, slug: str) -> list[dict[str, Any]]:
+        """Return incoming edges for ``slug`` (best-effort)."""
+        if self._mcp is None or not slug:
+            return []
+        return self._as_edges(self._mcp.call("get_backlinks", {"slug": _entity(slug)}))
+
+    def _node_exists(self, slug: str) -> bool:
+        """Return ``True`` when a page for ``slug`` exists."""
+        try:
+            page = self._mcp.call("get_page", {"slug": slug})
+        except (GbrainRemoteError, OSError, TimeoutError):
+            return False
+        if isinstance(page, str):
+            return bool(page.strip())
+        if isinstance(page, dict):
+            if page.get("error"):
+                return False
+            return bool(page.get("slug") or page.get("body") or page.get("content"))
+        return False
+
+    def _ensure_node(self, slug: str) -> bool:
+        """Ensure a page exists for ``slug`` so ``add_link`` can target it.
+
+        ``add_link`` fails when either endpoint is missing. Missing nodes are
+        materialized as a minimal typed stub; confirmed slugs are memoized to
+        avoid repeated ``get_page`` probes within a process. The ``put_page``
+        result is inspected (gbrain reports failures in-band), so a failed
+        creation is not memoized as present.
+
+        Args:
+            slug: The entity slug to materialize.
+
+        Returns:
+            ``True`` when the node exists (pre-existing or created).
+        """
+        if not slug:
+            return False
+        if slug in self._known_nodes:
+            return True
+        if self._node_exists(slug):
+            self._known_nodes.add(slug)
+            return True
+        try:
+            res = self._mcp.call(
+                "put_page",
+                {
+                    "slug": slug,
+                    "title": slug,
+                    "content": f"# {slug}\n\nKnowledge-graph entity node.\n",
+                },
+            )
+        except (GbrainRemoteError, OSError, TimeoutError) as exc:
+            log.warning("kg _ensure_node failed for %s: %s", slug, exc)
+            return False
+        if _rpc_failed(res):
+            log.warning("kg _ensure_node error for %s: %s", slug, res.get("error"))
+            return False
+        self._known_nodes.add(slug)
+        return True
+
+    # -- query -------------------------------------------------------------
+    def query_facts(
+        self,
+        *,
+        subject: Any = None,
+        predicate: Any = None,
+        object: Any = None,  # noqa: A002 - matches KG API vocabulary
+        conditions: dict[str, Any] | None = None,
+        limit: int = 50,
+    ) -> list[Fact]:
+        """Return facts matching the given subject/predicate/object filters.
+
+        Any filter may be ``None`` (match any), a single value, a list, or
+        a pipe-delimited alternation for the predicate.
+
+        Args:
+            subject: Subject entity filter.
+            predicate: Relation filter.
+            object: Object entity filter.
+            conditions: Property constraints applied to each candidate.
+            limit: Maximum facts to return.
+
+        Returns:
+            The matching facts (deduplicated, capped at ``limit``).
+        """
+        if self._native:
+            return self._native_query_facts(subject, predicate, object, conditions, limit)
+
+        subj_set = _as_set(subject)
+        pred_set = _as_set(predicate)
+        obj_set = _as_set(object)
+
+        query_terms: list[str] = []
+        for raw in (subject, predicate, object):
+            if isinstance(raw, str) and raw and "|" not in raw:
+                query_terms.append(raw)
+            elif isinstance(raw, (list, tuple, set)) and raw:
+                query_terms.append(str(next(iter(raw))))
+        query_str = " ".join(query_terms) or "Facts"
+
+        pages = self._search_pages(query_str, self._search_limit)
+        seen: set[tuple[str, str, str]] = set()
+        out: list[Fact] = []
+        for slug, body in pages:
+            for fact in parse_facts_fence(body, source_slug=slug):
+                if subj_set and fact.subject not in subj_set:
+                    continue
+                if pred_set and _entity(fact.predicate) not in pred_set:
+                    continue
+                if obj_set and fact.object not in obj_set:
+                    continue
+                if not _conditions_match(fact, conditions):
+                    continue
+                key = (fact.subject, fact.predicate, fact.object)
+                if key in seen:
+                    continue
+                seen.add(key)
+                out.append(fact)
+                if len(out) >= int(limit):
+                    return out
+        return out
+
+    def _native_query_facts(
+        self, subject: Any, predicate: Any, object: Any, conditions: Any, limit: int  # noqa: A002
+    ) -> list[Fact]:
+        """Run ``query_facts`` over gbrain's native link graph.
+
+        Anchors on the concrete side of the triple: ``get_links`` when a
+        subject is given, otherwise ``get_backlinks`` on the object. Edges
+        are mapped to facts and filtered locally by the predicate/object/
+        subject sets and conditions (reusing the simulation filter logic).
+        Predicate-only queries cannot be served (no global edge scan) and
+        return ``[]`` — production callers always anchor on a subject or
+        object.
+
+        Args:
+            subject: Subject filter (slug or list of slugs).
+            predicate: Predicate filter.
+            object: Object filter (slug or list of slugs).
+            conditions: Property constraints.
+            limit: Maximum facts.
+
+        Returns:
+            The matching facts (deduplicated, capped at ``limit``).
+        """
+        subj_set = _as_set(subject)
+        pred_set = _as_set(predicate)
+        obj_set = _as_set(object)
+
+        if subj_set:
+            edges = [e for s in sorted(subj_set) for e in self._get_links(s)]
+        elif obj_set:
+            edges = [e for o in sorted(obj_set) for e in self._get_backlinks(o)]
+        else:
+            return []
+
+        seen: set[tuple[str, str, str]] = set()
+        out: list[Fact] = []
+        for edge in edges:
+            fact = _edge_to_fact(edge)
+            if subj_set and fact.subject not in subj_set:
+                continue
+            if pred_set and _entity(fact.predicate) not in pred_set:
+                continue
+            if obj_set and fact.object not in obj_set:
+                continue
+            if not _conditions_match(fact, conditions):
+                continue
+            key = (fact.subject, fact.predicate, fact.object)
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(fact)
+            if len(out) >= int(limit):
+                break
+        return out
+
+    def graph_traverse(
+        self,
+        *,
+        start_entity: str,
+        predicate_filter: Any = None,
+        max_hops: int = 2,
+        direction: str = "outbound",
+    ) -> list[GraphNode]:
+        """Breadth-first traversal from ``start_entity`` over the fact graph.
+
+        Args:
+            start_entity: The seed entity.
+            predicate_filter: Relations to follow (``None`` = any).
+            max_hops: Maximum traversal depth (hard-capped at 3).
+            direction: ``outbound`` / ``inbound`` / ``both``.
+
+        Returns:
+            The reached nodes (each carrying the fact it was reached by).
+        """
+        if self._native:
+            return self._native_graph_traverse(start_entity, predicate_filter, max_hops, direction)
+
+        max_hops = min(int(max_hops), 3)
+        start = _entity(start_entity)
+        visited: set[str] = set()
+        queue: list[tuple[str, int]] = [(start, 0)]
+        results: list[GraphNode] = []
+        while queue and len(visited) < _MAX_TRAVERSE_NODES:
+            entity, depth = queue.pop(0)
+            if depth >= max_hops or entity in visited:
+                continue
+            visited.add(entity)
+            facts: list[Fact] = []
+            if direction in ("outbound", "both"):
+                facts += self.query_facts(subject=entity, predicate=predicate_filter, limit=_MAX_FACTS_PER_PAGE)
+            if direction in ("inbound", "both"):
+                facts += self.query_facts(object=entity, predicate=predicate_filter, limit=_MAX_FACTS_PER_PAGE)
+            for fact in facts:
+                nxt = fact.object if fact.subject == entity else fact.subject
+                if not nxt or nxt == entity:
+                    continue
+                results.append(GraphNode(entity=nxt, depth=depth + 1, via=fact))
+                if nxt not in visited:
+                    queue.append((nxt, depth + 1))
+        return results
+
+    def _native_graph_traverse(
+        self, start_entity: str, predicate_filter: Any, max_hops: int, direction: str
+    ) -> list[GraphNode]:
+        """Run ``graph_traverse`` over gbrain's native link graph.
+
+        Maps to ``traverse_graph(slug, depth, direction)``. Passing
+        ``direction`` makes gbrain return per-hop edges (``GraphPath[]``);
+        the ``link_type`` filter is intentionally omitted so multi-relation
+        paths (e.g. ``USES_ARCH`` then ``VARIANT_OF``) are followed, then the
+        edges are filtered locally by ``predicate_filter``. Each surviving
+        edge yields a :class:`GraphNode` for its far endpoint relative to the
+        traversal direction. Output is capped at :data:`_MAX_TRAVERSE_NODES`
+        so a high-fan-in hub node cannot blow up the foreground warm-start.
+
+        Args:
+            start_entity: Seed entity.
+            predicate_filter: Relations to keep (``None`` keeps all).
+            max_hops: Traversal depth (hard-capped at 3).
+            direction: ``outbound`` / ``inbound`` / ``both``.
+
+        Returns:
+            The reached nodes.
+        """
+        dir_map = {"outbound": "out", "inbound": "in", "both": "both"}
+        native_dir = dir_map.get(direction, "out")
+        depth = min(int(max_hops), 3)
+        start = _entity(start_entity)
+        pred_set = _as_set(predicate_filter)
+
+        edges = self._as_edges(
+            self._mcp.call("traverse_graph", {"slug": start, "depth": depth, "direction": native_dir})
+        )
+
+        out: list[GraphNode] = []
+        seen: set[tuple[str, str, int]] = set()
+        for edge in edges:
+            fact = _edge_to_fact(edge)
+            if pred_set and _entity(fact.predicate) not in pred_set:
+                continue
+            if native_dir == "in":
+                nxt = fact.subject
+            elif native_dir == "both":
+                nxt = fact.object if fact.subject == start else fact.subject
+            else:
+                nxt = fact.object
+            if not nxt or nxt == start:
+                continue
+            hop = int(edge.get("depth", 1))
+            key = (nxt, fact.predicate, hop)
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(GraphNode(entity=nxt, depth=hop, via=fact))
+            if len(out) >= _MAX_TRAVERSE_NODES:
+                break
+        return out
+
+    def find_conflicts(
+        self, *, knobs: Sequence[str], hardware: str = "", framework: str = ""
+    ) -> list[dict[str, Any]]:
+        """Detect ``CONFLICTS_WITH`` relations among a set of knobs.
+
+        Args:
+            knobs: Candidate knob/patch entities to check.
+            hardware: Optional hardware condition filter.
+            framework: Optional framework condition filter.
+
+        Returns:
+            One ``{knob, conflicts_with, severity}`` dict per detected
+            conflict where both endpoints are in ``knobs``.
+        """
+        knob_set = {_entity(k) for k in knobs if str(k or "").strip()}
+        if len(knob_set) < 2:
+            return []
+        # CONFLICTS_WITH relations are structural (the mirror emits them with
+        # only ``severity``, no hw/fw props), so hardware/framework are NOT
+        # applied as hard conditions — doing so would filter out every
+        # conflict and silently disable detection. They are accepted for API
+        # parity and used only to scope conditional conflicts in the future.
+        del hardware, framework
+        out: list[dict[str, Any]] = []
+        reported: set[frozenset[str]] = set()
+        for knob in knob_set:
+            facts = self.query_facts(
+                subject=knob,
+                predicate="CONFLICTS_WITH",
+                limit=_MAX_FACTS_PER_PAGE,
+            )
+            for fact in facts:
+                if fact.object not in knob_set:
+                    continue
+                pair = frozenset({knob, fact.object})
+                if pair in reported:
+                    continue
+                reported.add(pair)
+                out.append(
+                    {
+                        "knob": fact.object,
+                        "conflicts_with": knob,
+                        "severity": fact.properties.get("severity", "hard"),
+                    }
+                )
+        return out
+
+    # -- write (read-modify-write over get_page/put_page) ------------------
+    def emit_fact(
+        self,
+        *,
+        page_slug: str,
+        subject: str,
+        predicate: str,
+        object: str,  # noqa: A002
+        properties: dict[str, Any] | None = None,
+    ) -> bool:
+        """Append a fact to a page's ``## Facts`` fence (idempotent).
+
+        Reads the page, inserts the formatted line under the existing
+        ``## Facts`` header (or creates the fence), and writes it back. A
+        duplicate ``(subject, predicate, object)`` line is a no-op.
+
+        Args:
+            page_slug: Target page slug.
+            subject: Subject entity.
+            predicate: Relation.
+            object: Object entity.
+            properties: Optional fact properties.
+
+        Returns:
+            ``True`` when the page was written, ``False`` on no-op.
+        """
+        if self._native:
+            return self._native_emit_fact(subject, predicate, object, properties)
+        content = self._page_content_raw(page_slug)
+        if content is None:
+            return False
+        line = format_fact_line(subject, predicate, object, properties)
+        existing = {(f.subject, f.predicate, f.object) for f in parse_facts_fence(content)}
+        if (_entity(subject), str(predicate).strip().upper(), _entity(object)) in existing:
+            return False
+        if "## Facts" in content:
+            new_content = content.replace("## Facts\n", f"## Facts\n{line}\n", 1)
+        else:
+            sep = "" if content.endswith("\n") else "\n"
+            new_content = f"{content}{sep}\n## Facts\n{line}\n"
+        self._mcp.call("put_page", {"slug": page_slug, "content": new_content})
+        self._search_cache.clear()
+        return True
+
+    def retract_fact(
+        self, *, page_slug: str, subject: str, predicate: str, object: str  # noqa: A002
+    ) -> bool:
+        """Remove a matching fact line from a page's ``## Facts`` fence.
+
+        Args:
+            page_slug: Target page slug.
+            subject: Subject entity.
+            predicate: Relation.
+            object: Object entity.
+
+        Returns:
+            ``True`` when a line was removed and the page rewritten.
+        """
+        if self._native:
+            return self._native_retract_fact(subject, predicate, object)
+        content = self._page_content_raw(page_slug)
+        if content is None or "## Facts" not in content:
+            return False
+        want = (_entity(subject), str(predicate).strip().upper(), _entity(object))
+        kept: list[str] = []
+        removed = False
+        for line in content.splitlines():
+            m = _FACT_LINE_RE.match(line.strip())
+            if m and (
+                _entity(m.group("subject")),
+                m.group("predicate").strip().upper(),
+                _entity(m.group("object")),
+            ) == want:
+                removed = True
+                continue
+            kept.append(line)
+        if not removed:
+            return False
+        new_content = "\n".join(kept)
+        if content.endswith("\n"):
+            new_content += "\n"
+        self._mcp.call("put_page", {"slug": page_slug, "content": new_content})
+        self._search_cache.clear()
+        return True
+
+    def _native_emit_fact(
+        self, subject: str, predicate: str, object: str, properties: dict[str, Any] | None  # noqa: A002
+    ) -> bool:
+        """Emit a fact as a native link-graph edge.
+
+        Materializes both endpoint nodes (``add_link`` requires them to
+        exist) then creates the edge. ``add_link`` is idempotent on
+        ``(from, to, link_type)``, so re-emitting upserts the context. The
+        page-anchored ``page_slug`` is irrelevant in the link-graph model
+        (the subject node is the edge source). The ``add_link`` result is
+        inspected so an in-band error reports ``False`` rather than a false
+        success.
+
+        Args:
+            subject: Subject entity.
+            predicate: Relation.
+            object: Object entity.
+            properties: Optional fact properties (encoded into ``context``).
+
+        Returns:
+            ``True`` when the edge was written, ``False`` on invalid input
+            or a backend error.
+        """
+        s = _entity(subject)
+        o = _entity(object)
+        if not s or not o:
+            return False
+        if not self._ensure_node(s) or not self._ensure_node(o):
+            return False
+        res = self._mcp.call(
+            "add_link",
+            {
+                "from": s,
+                "to": o,
+                "link_type": _link_type(predicate),
+                "context": _props_to_context(properties),
+            },
+        )
+        if _rpc_failed(res):
+            log.warning("kg add_link %s->%s error: %s", s, o, res.get("error"))
+            return False
+        return True
+
+    def _native_retract_fact(self, subject: str, predicate: str, object: str) -> bool:  # noqa: A002
+        """Retract a single typed edge from the native link graph.
+
+        ``remove_link`` deletes *every* edge between the pair, so this reads
+        the outgoing edges, removes the pair, and re-adds the survivors that
+        had a different ``link_type`` — preserving the other relations on the
+        same node pair.
+
+        Args:
+            subject: Subject entity.
+            predicate: Relation to retract.
+            object: Object entity.
+
+        Returns:
+            ``True`` when a matching edge was removed, ``False`` otherwise.
+        """
+        s = _entity(subject)
+        o = _entity(object)
+        target = _link_type(predicate)
+        if not s or not o:
+            return False
+        pair_edges = [e for e in self._get_links(s) if _entity(e.get("to_slug")) == o]
+        if not any(_link_type(e.get("link_type")) == target for e in pair_edges):
+            return False
+        survivors = [e for e in pair_edges if _link_type(e.get("link_type")) != target]
+        res = self._mcp.call("remove_link", {"from": s, "to": o})
+        if _rpc_failed(res):
+            log.warning("kg remove_link %s->%s error: %s", s, o, res.get("error"))
+            return False
+        for edge in survivors:
+            self._mcp.call(
+                "add_link",
+                {
+                    "from": s,
+                    "to": o,
+                    "link_type": _link_type(edge.get("link_type")),
+                    "context": edge.get("context") or "{}",
+                },
+            )
+        return True
+
+    def _page_content_raw(self, slug: str) -> str | None:
+        """Fetch the full raw markdown of a page for read-modify-write.
+
+        Args:
+            slug: The page slug.
+
+        Returns:
+            The page content, or ``None`` when unavailable.
+        """
+        if self._mcp is None:
+            return None
+        try:
+            page = self._mcp.call("get_page", {"slug": slug})
+        except (GbrainRemoteError, OSError, TimeoutError) as exc:
+            log.warning("kg get_page failed for %s: %s", slug, exc)
+            return None
+        content = _page_content(page, full=True)
+        return content or None
+
+    # -- graceful wrappers -------------------------------------------------
+    def query_facts_safe(self, **kwargs: Any) -> list[Fact]:
+        """Call :meth:`query_facts`, returning ``[]`` on any backend error."""
+        try:
+            return self.query_facts(**kwargs)
+        except (GbrainRemoteError, OSError, TimeoutError, ValueError) as exc:
+            log.warning("kg query_facts degraded (returning []): %s", exc)
+            return []
+
+    def graph_traverse_safe(self, **kwargs: Any) -> list[GraphNode]:
+        """Call :meth:`graph_traverse`, returning ``[]`` on any backend error."""
+        try:
+            return self.graph_traverse(**kwargs)
+        except (GbrainRemoteError, OSError, TimeoutError, ValueError) as exc:
+            log.warning("kg graph_traverse degraded (returning []): %s", exc)
+            return []
+
+    def find_conflicts_safe(self, **kwargs: Any) -> list[dict[str, Any]]:
+        """Call :meth:`find_conflicts`, returning ``[]`` on any backend error."""
+        try:
+            return self.find_conflicts(**kwargs)
+        except (GbrainRemoteError, OSError, TimeoutError, ValueError) as exc:
+            log.warning("kg find_conflicts degraded (returning []): %s", exc)
+            return []
+
+    def emit_fact_safe(self, **kwargs: Any) -> bool:
+        """Call :meth:`emit_fact`, returning ``False`` on any backend error."""
+        try:
+            return self.emit_fact(**kwargs)
+        except (GbrainRemoteError, OSError, TimeoutError, ValueError) as exc:
+            log.warning("kg emit_fact degraded (skipped): %s", exc)
+            return False
+
+    def retract_fact_safe(self, **kwargs: Any) -> bool:
+        """Call :meth:`retract_fact`, returning ``False`` on any backend error."""
+        try:
+            return self.retract_fact(**kwargs)
+        except (GbrainRemoteError, OSError, TimeoutError, ValueError) as exc:
+            log.warning("kg retract_fact degraded (skipped): %s", exc)
+            return False
+
+
+def _page_content(page: Any, *, full: bool = False) -> str:
+    """Extract a page's body (or full raw markdown) from a get_page result.
+
+    gbrain may return the page as a raw markdown string, as ``{content}``
+    /``{raw}``/``{markdown}``, or as a structured ``{frontmatter, body}``.
+    This normalizes those shapes.
+
+    Args:
+        page: The raw ``get_page`` result.
+        full: When ``True`` return the full frontmatter+body markdown;
+            otherwise return only the body (for fact parsing).
+
+    Returns:
+        The requested content, or ``""`` when nothing usable is present.
+    """
+    if isinstance(page, str):
+        return page
+    if not isinstance(page, dict):
+        return ""
+    for key in ("content", "raw", "markdown"):
+        val = page.get(key)
+        if isinstance(val, str) and val.strip():
+            return val if full else _strip_frontmatter(val)
+    body = page.get("body")
+    body = str(body) if body is not None else ""
+    if not full:
+        return body
+    # Full markdown reconstruction. Prefer a verbatim frontmatter string;
+    # otherwise re-serialize the parsed frontmatter dict so a read-modify-
+    # write never drops ``type``/``tags``/``attrs`` (which would corrupt the
+    # page). gbrain's get_page returns frontmatter as a dict, so the dict
+    # branch is the live path.
+    fm_raw = page.get("frontmatter_raw")
+    if isinstance(fm_raw, str) and fm_raw.strip():
+        return f"{fm_raw}\n\n{body}" if body else fm_raw
+    fm = page.get("frontmatter")
+    if isinstance(fm, dict) and fm:
+        fm_block = _serialize_frontmatter(fm)
+        return f"{fm_block}\n\n{body}" if body else fm_block
+    return body
+
+
+def _serialize_frontmatter(fm: dict[str, Any]) -> str:
+    """Re-serialize a parsed frontmatter dict into a ``---`` YAML block.
+
+    Mirrors the kb-mirror writer's frontmatter shape: scalars as
+    ``key: value``, lists as ``key: [a, b]``, and nested maps (``attrs``)
+    as compact JSON. Not guaranteed byte-identical to the original, but
+    preserves every semantic field so the page keeps its type/tags/config.
+
+    Args:
+        fm: The parsed frontmatter mapping.
+
+    Returns:
+        A ``---``-delimited frontmatter block.
+    """
+    lines = ["---"]
+    for key, val in fm.items():
+        if isinstance(val, dict):
+            lines.append(f"{key}: {json.dumps(val, ensure_ascii=False, default=str)}")
+        elif isinstance(val, (list, tuple)):
+            lines.append(f"{key}: [{', '.join(str(x) for x in val)}]")
+        else:
+            lines.append(f"{key}: {val}")
+    lines.append("---")
+    return "\n".join(lines)
+
+
+def _strip_frontmatter(content: str) -> str:
+    """Return the body portion below a leading ``---`` frontmatter block.
+
+    Args:
+        content: Full page markdown.
+
+    Returns:
+        The body (content unchanged when no frontmatter delimiter found).
+    """
+    if not content.startswith("---"):
+        return content
+    parts = content.split("---", 2)
+    return parts[2].lstrip("\n") if len(parts) == 3 else content
+
+
+def generate_variants_graph_guided(
+    kg: KGClient,
+    *,
+    architectures: Sequence[str],
+    hardware: str = "",
+    framework: str = "",
+    tried: Iterable[str] = (),
+    blocked: Iterable[str] = (),
+    in_stack: Iterable[str] = (),
+    max_variants: int = 8,
+) -> list[dict[str, Any]]:
+    """Propose optimization knobs from the KG causal graph (not blind search).
+
+    Queries ``IMPROVES*`` facts for the current architecture+hw+fw, drops
+    anything already tried / blocked / in the active stack, resolves
+    ``REQUIRES`` dependencies (must be satisfied by the current stack), and
+    rejects candidates that ``CONFLICTS_WITH`` an in-stack knob. Returns the
+    surviving candidates ordered by expected gain.
+
+    Args:
+        kg: The KG client used for fact lookups (degradation-safe).
+        architectures: Current model architecture list (the fact object).
+        hardware: Hardware condition filter.
+        framework: Framework condition filter.
+        tried: Knob fingerprints already attempted.
+        blocked: Blocked knob entities.
+        in_stack: Knobs already present in the optimization stack.
+        max_variants: Maximum number of candidates to return.
+
+    Returns:
+        A list of ``{knob, expected_gain, confidence, evidence_count,
+        source}`` dicts, gain-descending.
+    """
+    archs = [a for a in (architectures or []) if str(a or "").strip()]
+    if not archs:
+        return []
+    tried_set = {_entity(t) for t in tried}
+    blocked_set = {_entity(b) for b in blocked}
+    stack_set = {_entity(s) for s in in_stack}
+    conditions: dict[str, Any] = {}
+    if hardware:
+        conditions["hw"] = hardware
+    if framework:
+        conditions["fw"] = framework
+
+    candidates = kg.query_facts_safe(
+        object=list(archs),
+        predicate=["IMPROVES", "IMPROVES_TTFT", "IMPROVES_DECODE"],
+        conditions=conditions or None,
+        limit=_MAX_FACTS_PER_PAGE,
+    )
+    out: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for fact in sorted(candidates, key=lambda f: -f.gain):
+        knob = fact.subject
+        if not knob or knob in seen or knob in tried_set or knob in blocked_set or knob in stack_set:
+            continue
+        # REQUIRES: every dependency must already be in the stack.
+        deps = kg.query_facts_safe(subject=knob, predicate=["REQUIRES"], limit=_MAX_FACTS_PER_PAGE)
+        if any(d.object and d.object not in stack_set for d in deps):
+            continue
+        # CONFLICTS_WITH: reject if conflicting with an in-stack knob.
+        conflicts = kg.query_facts_safe(subject=knob, predicate=["CONFLICTS_WITH"], limit=_MAX_FACTS_PER_PAGE)
+        if any(c.object in stack_set for c in conflicts):
+            continue
+        seen.add(knob)
+        out.append({
+            "knob": knob,
+            "expected_gain": fact.gain,
+            "confidence": fact.confidence,
+            "evidence_count": int(_pct(fact.properties.get("tested_sessions")) or 1),
+            "source": "kg_causal",
+        })
+        if len(out) >= int(max_variants):
+            break
+    return out
+
+
+def _knob_object_nodes(architectures: Sequence[str], precision: str) -> list[str]:
+    """Build the ``"{arch}+{precision}"`` object nodes for knob queries.
+
+    Mirrors the journal-knob mirror writer: precision is folded into the
+    object node so per-precision knob evidence stays distinct. Falls back to
+    the bare arch when precision is unknown.
+
+    Args:
+        architectures: Current model architecture list.
+        precision: The run's baseline precision (e.g. ``"bf16"``/``"fp8"``).
+
+    Returns:
+        The list of object node slugs to anchor knob queries on.
+    """
+    archs = [_entity(a) for a in (architectures or []) if str(a or "").strip()]
+    prec = str(precision or "").strip().lower()
+    if not prec:
+        return archs
+    return [f"{a}+{prec}" for a in archs]
+
+
+def generate_knob_candidates_graph_guided(
+    kg: KGClient,
+    *,
+    architectures: Sequence[str],
+    precision: str = "",
+    hardware: str = "",
+    framework: str = "",
+    tried: Iterable[str] = (),
+    in_stack: Iterable[str] = (),
+    max_variants: int = 8,
+) -> list[dict[str, Any]]:
+    """Propose runnable config knobs from journal-derived KG knob edges.
+
+    Distinct from :func:`generate_variants_graph_guided` (which mines
+    patch-keyed ``IMPROVES`` knowledge): this reads the ``KNOB_IMPROVES`` /
+    ``KNOB_REVERTED_ON`` predicates emitted by the journal-knob mirror, whose
+    subjects are ``variant_fingerprint`` hashes (the optimizer's own knob
+    dedup identity) and whose context carries the runnable ``args``/``envs``.
+
+    Candidates with a ``KNOB_REVERTED_ON`` edge for the same arch+precision,
+    or already in ``tried`` / ``in_stack`` (by fingerprint), are dropped.
+
+    Args:
+        kg: The KG client (degradation-safe).
+        architectures: Current model architecture list.
+        precision: Baseline precision condition (folded into the object node).
+        hardware: Hardware condition filter.
+        framework: Framework condition filter.
+        tried: Knob fingerprints already attempted.
+        in_stack: Knob fingerprints already in the optimization stack.
+        max_variants: Maximum candidates to return.
+
+    Returns:
+        A list of ``{knob, args, envs, name, expected_gain, confidence,
+        evidence_count, source}`` dicts, gain-descending. ``knob`` is the
+        fingerprint; ``args``/``envs`` reconstruct a runnable variant.
+    """
+    objs = _knob_object_nodes(architectures, precision)
+    if not objs:
+        return []
+    tried_set = {_entity(t) for t in tried}
+    stack_set = {_entity(s) for s in in_stack}
+    conditions: dict[str, Any] = {}
+    if hardware:
+        conditions["hw"] = hardware
+    if framework:
+        conditions["fw"] = framework
+
+    blocked_set = {
+        f.subject
+        for f in kg.query_facts_safe(
+            object=objs, predicate=["KNOB_REVERTED_ON"], limit=_MAX_FACTS_PER_PAGE
+        )
+    }
+    candidates = kg.query_facts_safe(
+        object=objs,
+        predicate=["KNOB_IMPROVES"],
+        conditions=conditions or None,
+        limit=_MAX_FACTS_PER_PAGE,
+    )
+    out: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for fact in sorted(candidates, key=lambda f: -f.gain):
+        knob = fact.subject
+        if not knob or knob in seen or knob in tried_set or knob in blocked_set or knob in stack_set:
+            continue
+        envs_raw = fact.properties.get("envs")
+        envs: dict[str, str] = {}
+        if envs_raw:
+            try:
+                parsed = json.loads(envs_raw)
+                if isinstance(parsed, dict):
+                    envs = {str(k): str(v) for k, v in parsed.items()}
+            except (TypeError, ValueError):
+                envs = {}
+        keep_n = _pct(fact.properties.get("keep_n")) or 1
+        seen.add(knob)
+        out.append({
+            "knob": knob,
+            "args": str(fact.properties.get("args") or ""),
+            "envs": envs,
+            "name": str(fact.properties.get("name") or ""),
+            "expected_gain": fact.gain,
+            "confidence": fact.confidence,
+            "evidence_count": int(keep_n),
+            "source": "kg_knob",
+        })
+        if len(out) >= int(max_variants):
+            break
+    return out
+
+
+def generate_warmstart_donor_graph_guided(
+    kg: KGClient,
+    *,
+    architectures: Sequence[str],
+    precision: str = "",
+    hardware: str = "",
+    framework: str = "",
+    model_type: str = "",
+) -> dict[str, Any] | None:
+    """Synthesize a cross-model warm-start config donor from KG knob edges.
+
+    The warm-replay "borrow a sibling's champion" path historically searched
+    the recipe-KB for same-architecture siblings. This KG-native variant reads
+    the cross-model ``KNOB_IMPROVES`` evidence aggregated under the
+    ``{arch}+{precision}`` object node (model-agnostic by construction) and
+    adopts the SINGLE highest-evidence, positive-gain, non-reverted knob as the
+    donor config (``single_top`` — no multi-knob composition, so the replayed
+    config was actually validated as a unit).
+
+    Reuses :func:`generate_knob_candidates_graph_guided` (``max_variants=1``)
+    for identical filtering/ranking, then wraps the top candidate in a
+    recipe-shaped row so the downstream warm-replay path is unchanged.
+
+    Args:
+        kg: The KG client (degradation-safe).
+        architectures: Current model architecture list.
+        precision: Baseline precision (folded into the object node).
+        hardware: Hardware condition filter.
+        framework: Framework condition filter.
+        model_type: Target model type (informational, stamped on the donor).
+
+    Returns:
+        A recipe-shaped donor row (``best_config`` / ``validated_gain_pct`` /
+        ``confidence`` / ``provenance``), or ``None`` when KG carries no usable
+        cross-model knob (caller falls back to the recipe-KB sibling search).
+    """
+    cands = generate_knob_candidates_graph_guided(
+        kg,
+        architectures=architectures,
+        precision=precision,
+        hardware=hardware,
+        framework=framework,
+        max_variants=1,
+    )
+    if not cands:
+        return None
+    top = cands[0]
+    if float(top.get("expected_gain") or 0.0) <= 0.0:
+        return None
+    args = str(top.get("args") or "").strip()
+    envs = top.get("envs") if isinstance(top.get("envs"), dict) else {}
+    if not args and not envs:
+        return None
+    archs = [str(a) for a in (architectures or []) if str(a or "").strip()]
+    prec = str(precision or "").strip().lower()
+    obj = "+".join(_entity(a) for a in archs)
+    if prec:
+        obj = f"{obj}+{prec}"
+    return {
+        "canonical_id": f"kg-synth:{obj}:{top.get('knob') or ''}",
+        "best_config": {"extra_server_args": args, "extra_envs": envs},
+        "validated_gain_pct": float(top.get("expected_gain") or 0.0),
+        "confidence": float(top.get("confidence") or 0.0),
+        "architectures": archs,
+        "model_type": str(model_type or ""),
+        "provenance": {
+            "source": "kg_native_warmstart",
+            "knob": top.get("knob") or "",
+            "name": top.get("name") or "",
+            "evidence_count": int(top.get("evidence_count") or 0),
+        },
+    }
+
+
+def build_kg_client_from_env() -> KGClient | None:
+    """Construct a :class:`KGClient` from ``GBRAIN_*`` env vars.
+
+    Reuses the same endpoint/token as the gbrain recipe remote. Returns
+    ``None`` when the env is not configured so callers degrade silently.
+
+    Returns:
+        A configured client, or ``None`` when ``GBRAIN_BASE_URL`` /
+        ``GBRAIN_TOKEN`` are unset.
+    """
+    base_url = (os.environ.get("GBRAIN_BASE_URL", "") or "").strip()
+    token = (os.environ.get("GBRAIN_TOKEN", "") or "").strip()
+    if not base_url or not token:
+        return None
+    timeout_env = os.environ.get("GBRAIN_HTTP_TIMEOUT_SEC")
+    timeout_sec = 2.0
+    if timeout_env:
+        try:
+            timeout_sec = float(timeout_env)
+        except ValueError:
+            timeout_sec = 2.0
+    use_native = (os.environ.get("GBRAIN_KG_NATIVE", "") or "").strip().lower() in ("1", "true", "yes")
+    mcp = _GbrainMcp(base_url, token, timeout_sec)
+    return KGClient(mcp, use_native_kg=use_native)
+
+
+_CACHED_CLIENT: KGClient | None = None
+_CLIENT_RESOLVED = False
+
+
+def get_kg_client() -> KGClient | None:
+    """Return a process-wide :class:`KGClient` (lazily built from env).
+
+    The result (including ``None`` when unconfigured) is cached after the
+    first call. Use :func:`reset_kg_client` in tests to clear it.
+
+    Returns:
+        The cached client, or ``None`` when KG is not configured.
+    """
+    global _CACHED_CLIENT, _CLIENT_RESOLVED
+    if not _CLIENT_RESOLVED:
+        _CACHED_CLIENT = build_kg_client_from_env()
+        _CLIENT_RESOLVED = True
+    return _CACHED_CLIENT
+
+
+def reset_kg_client() -> None:
+    """Clear the cached client (test helper)."""
+    global _CACHED_CLIENT, _CLIENT_RESOLVED
+    _CACHED_CLIENT = None
+    _CLIENT_RESOLVED = False
+
+
+__all__ = [
+    "Fact",
+    "GraphNode",
+    "KGClient",
+    "parse_facts_fence",
+    "format_fact_line",
+    "generate_variants_graph_guided",
+    "generate_knob_candidates_graph_guided",
+    "build_kg_client_from_env",
+    "get_kg_client",
+    "reset_kg_client",
+]

--- a/inference_optimizer/tests/test_kg_client.py
+++ b/inference_optimizer/tests/test_kg_client.py
@@ -1,0 +1,721 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for the knowledge-graph client (fence parse / query / BFS / RMW writes)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from inference_optimizer.recipe_kb.gbrain_remote_client import GbrainRemoteError
+from inference_optimizer.recipe_kb.kg_client import (
+    Fact,
+    KGClient,
+    format_fact_line,
+    generate_knob_candidates_graph_guided,
+    generate_variants_graph_guided,
+    parse_facts_fence,
+)
+
+
+def _page(body: str, *, frontmatter: str = "---\ntype: recipe\n---\n\n") -> str:
+    """Wrap a body in a full page markdown string."""
+    return frontmatter + body
+
+
+class _FakeMcp:
+    """Fake MCP serving canned search/get_page and recording put_page."""
+
+    def __init__(self, pages: dict[str, str], *, search_hits: list[str] | None = None) -> None:
+        # pages: slug -> full markdown content
+        self.pages = pages
+        self.search_hits = search_hits if search_hits is not None else list(pages)
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def call(self, tool: str, args: dict[str, Any]) -> Any:
+        self.calls.append((tool, dict(args)))
+        if tool == "list_pages":
+            return [{"slug": s} for s in list(self.pages)[: args.get("limit", 100)]]
+        if tool == "search":
+            return [{"slug": s} for s in self.search_hits]
+        if tool == "get_page":
+            content = self.pages.get(args.get("slug"))
+            return {"content": content} if content is not None else {}
+        if tool == "put_page":
+            self.pages[args["slug"]] = args["content"]
+            return {"ok": True}
+        return {}
+
+
+class _BoomMcp:
+    """Fake MCP that always raises a transport error."""
+
+    def call(self, tool: str, args: dict[str, Any]) -> Any:
+        raise GbrainRemoteError("boom")
+
+
+_RECIPE_BODY = """# Recipe
+
+## Facts
+- aiter_backend IMPROVES qwen2forcausallm (gain: +35.2%, confidence: 0.95, hw: mi300x, fw: sglang)
+- fp8_kernel_patch REVERTED_ON qwen2forcausallm (loss: -4.2%, error: perf_regression, hw: mi300x)
+- chunked_prefill CRASHES mi300x (error: cuda_graph_capture, fw: sglang)
+- qwen2.5-7b USES_ARCH qwen2forcausallm ()
+"""
+
+_ARCH_BODY = """# Arch Family
+
+## Facts
+- qwen3-8b USES_ARCH qwen2forcausallm (distance: 1)
+- qwen2forcausallm VARIANT_OF llamaforcausallm (distance: 1)
+"""
+
+_CONFLICT_BODY = """# Conflicts
+
+## Facts
+- aiter_backend CONFLICTS_WITH flash_attention_v2 (severity: hard)
+- torch_compile IMPROVES qwen2forcausallm (gain: +8%, hw: mi300x)
+"""
+
+
+# -- fence parsing ---------------------------------------------------------
+def test_parse_facts_fence_extracts_triples() -> None:
+    facts = parse_facts_fence(_RECIPE_BODY, source_slug="recipe/x")
+    assert len(facts) == 4
+    f0 = facts[0]
+    assert f0.subject == "aiter_backend"
+    assert f0.predicate == "IMPROVES"
+    assert f0.object == "qwen2forcausallm"
+    assert f0.properties["gain"] == "+35.2%"
+    assert f0.gain == pytest.approx(35.2)
+    assert f0.confidence == pytest.approx(0.95)
+    assert f0.source_slug == "recipe/x"
+
+
+def test_parse_facts_fence_ignores_non_fact_sections() -> None:
+    body = "## Facts\n- a IMPROVES b ()\n\n## Evidence\n- session abc: not a fact line\n"
+    facts = parse_facts_fence(body)
+    assert len(facts) == 1
+    assert facts[0].subject == "a"
+
+
+def test_parse_facts_fence_empty_when_no_fence() -> None:
+    assert parse_facts_fence("# Title\n\nno facts here") == []
+
+
+def test_format_fact_line_roundtrip() -> None:
+    line = format_fact_line("AITER_backend", "improves", "Qwen2ForCausalLM", {"gain": "+5%"})
+    assert line == "- aiter_backend IMPROVES qwen2forcausallm (gain: +5%)"
+    parsed = parse_facts_fence("## Facts\n" + line + "\n")
+    assert parsed[0].subject == "aiter_backend"
+    assert parsed[0].predicate == "IMPROVES"
+
+
+# -- query_facts -----------------------------------------------------------
+def _client(pages: dict[str, str], **kw: Any) -> tuple[KGClient, _FakeMcp]:
+    mcp = _FakeMcp(pages, **kw)
+    return KGClient(mcp), mcp
+
+
+def test_query_facts_filters_by_predicate_alternation() -> None:
+    kg, _ = _client({"recipe/x": _page(_RECIPE_BODY)})
+    facts = kg.query_facts(predicate="REVERTED_ON|DEGRADES|CRASHES")
+    preds = {f.predicate for f in facts}
+    assert preds == {"REVERTED_ON", "CRASHES"}
+
+
+def test_query_facts_filters_by_subject_and_object() -> None:
+    kg, _ = _client({"recipe/x": _page(_RECIPE_BODY)})
+    facts = kg.query_facts(subject="aiter_backend", object="qwen2forcausallm")
+    assert len(facts) == 1
+    assert facts[0].predicate == "IMPROVES"
+
+
+def test_query_facts_object_list_matches_any() -> None:
+    kg, _ = _client({"recipe/x": _page(_RECIPE_BODY)})
+    facts = kg.query_facts(object=["qwen2forcausallm", "mixtralforcausallm"], predicate="IMPROVES")
+    assert len(facts) == 1
+    assert facts[0].subject == "aiter_backend"
+
+
+def test_query_facts_conditions_filter() -> None:
+    kg, _ = _client({"recipe/x": _page(_RECIPE_BODY)})
+    hit = kg.query_facts(predicate="IMPROVES", conditions={"hw": "mi300x"})
+    assert len(hit) == 1
+    miss = kg.query_facts(predicate="IMPROVES", conditions={"hw": "mi308x"})
+    assert miss == []
+
+
+def test_query_facts_dedups_across_pages() -> None:
+    pages = {"a": _page(_RECIPE_BODY), "b": _page(_RECIPE_BODY)}
+    kg, _ = _client(pages)
+    facts = kg.query_facts(predicate="IMPROVES")
+    assert len(facts) == 1
+
+
+def test_query_facts_respects_limit() -> None:
+    kg, _ = _client({"recipe/x": _page(_RECIPE_BODY)})
+    facts = kg.query_facts(limit=2)
+    assert len(facts) == 2
+
+
+# -- graph_traverse --------------------------------------------------------
+def test_graph_traverse_outbound_one_hop() -> None:
+    kg, _ = _client({"arch": _page(_ARCH_BODY)})
+    nodes = kg.graph_traverse(start_entity="qwen3-8b", predicate_filter=["USES_ARCH", "VARIANT_OF"], max_hops=1)
+    assert any(n.entity == "qwen2forcausallm" and n.depth == 1 for n in nodes)
+
+
+def test_graph_traverse_two_hops_reaches_base_arch() -> None:
+    kg, _ = _client({"arch": _page(_ARCH_BODY)})
+    nodes = kg.graph_traverse(
+        start_entity="qwen3-8b", predicate_filter=["USES_ARCH", "VARIANT_OF"], max_hops=2
+    )
+    entities = {n.entity for n in nodes}
+    assert "qwen2forcausallm" in entities
+    assert "llamaforcausallm" in entities
+
+
+# -- find_conflicts --------------------------------------------------------
+def test_find_conflicts_detects_pair_in_stack() -> None:
+    kg, _ = _client({"c": _page(_CONFLICT_BODY)})
+    conflicts = kg.find_conflicts(knobs=["aiter_backend", "flash_attention_v2", "torch_compile"])
+    assert len(conflicts) == 1
+    assert conflicts[0]["conflicts_with"] == "aiter_backend"
+    assert conflicts[0]["knob"] == "flash_attention_v2"
+
+
+def test_find_conflicts_skips_when_endpoint_not_in_stack() -> None:
+    kg, _ = _client({"c": _page(_CONFLICT_BODY)})
+    conflicts = kg.find_conflicts(knobs=["aiter_backend", "torch_compile"])
+    assert conflicts == []
+
+
+def test_find_conflicts_detected_even_with_hw_fw_conditions() -> None:
+    # Regression: CONFLICTS_WITH facts carry no hw/fw props; passing
+    # hardware/framework must NOT filter them out (would disable detection).
+    kg, _ = _client({"c": _page(_CONFLICT_BODY)})
+    conflicts = kg.find_conflicts(
+        knobs=["aiter_backend", "flash_attention_v2"],
+        hardware="mi300x",
+        framework="sglang",
+    )
+    assert len(conflicts) == 1
+    assert conflicts[0]["knob"] == "flash_attention_v2"
+
+
+# -- emit_fact / retract_fact (read-modify-write) --------------------------
+def test_emit_fact_appends_to_existing_fence() -> None:
+    pages = {"recipe/x": _page(_RECIPE_BODY)}
+    kg, mcp = _client(pages)
+    wrote = kg.emit_fact(
+        page_slug="recipe/x",
+        subject="torch_compile",
+        predicate="IMPROVES",
+        object="qwen2forcausallm",
+        properties={"gain": "+8%"},
+    )
+    assert wrote is True
+    facts = parse_facts_fence(mcp.pages["recipe/x"])
+    assert any(f.subject == "torch_compile" and f.predicate == "IMPROVES" for f in facts)
+
+
+def test_emit_fact_idempotent_on_duplicate() -> None:
+    pages = {"recipe/x": _page(_RECIPE_BODY)}
+    kg, mcp = _client(pages)
+    wrote = kg.emit_fact(
+        page_slug="recipe/x", subject="aiter_backend", predicate="IMPROVES", object="qwen2forcausallm"
+    )
+    assert wrote is False
+    assert not any(t == "put_page" for t, _ in mcp.calls)
+
+
+def test_emit_fact_creates_fence_when_absent() -> None:
+    pages = {"p": _page("# Title\n\nbody only\n")}
+    kg, mcp = _client(pages)
+    wrote = kg.emit_fact(page_slug="p", subject="a", predicate="IMPROVES", object="b")
+    assert wrote is True
+    assert "## Facts" in mcp.pages["p"]
+
+
+def test_retract_fact_removes_matching_line() -> None:
+    pages = {"recipe/x": _page(_RECIPE_BODY)}
+    kg, mcp = _client(pages)
+    removed = kg.retract_fact(
+        page_slug="recipe/x", subject="fp8_kernel_patch", predicate="REVERTED_ON", object="qwen2forcausallm"
+    )
+    assert removed is True
+    facts = parse_facts_fence(mcp.pages["recipe/x"])
+    assert not any(f.subject == "fp8_kernel_patch" for f in facts)
+
+
+def test_retract_fact_noop_when_absent() -> None:
+    pages = {"recipe/x": _page(_RECIPE_BODY)}
+    kg, mcp = _client(pages)
+    removed = kg.retract_fact(page_slug="recipe/x", subject="nope", predicate="IMPROVES", object="x")
+    assert removed is False
+
+
+class _StructuredMcp:
+    """Fake MCP whose get_page returns parsed {frontmatter: dict, body}."""
+
+    def __init__(self) -> None:
+        self.frontmatter = {
+            "type": "recipe",
+            "tags": ["kind:recipe", "model:qwen3"],
+            "confidence": 0.85,
+            "attrs": {"model": "qwen3", "best_config_args": "--tp 8"},
+        }
+        self.body = "# Recipe\n\n## Facts\n- a IMPROVES b ()\n"
+        self.put_content: str | None = None
+
+    def call(self, tool: str, args: dict[str, Any]) -> Any:
+        if tool == "list_pages":
+            return [{"slug": "recipe/x"}]
+        if tool == "search":
+            return [{"slug": "recipe/x"}]
+        if tool == "get_page":
+            return {"frontmatter": dict(self.frontmatter), "body": self.body}
+        if tool == "put_page":
+            self.put_content = args["content"]
+            return {"ok": True}
+        return {}
+
+
+def test_emit_fact_preserves_frontmatter_on_structured_page() -> None:
+    # Regression: when get_page returns {frontmatter: dict, body} with no raw
+    # content field, emit_fact must NOT write a body-only page (which would
+    # drop type/tags/attrs and corrupt the recipe).
+    mcp = _StructuredMcp()
+    kg = KGClient(mcp)
+    wrote = kg.emit_fact(
+        page_slug="recipe/x", subject="torch_compile", predicate="IMPROVES", object="qwen3"
+    )
+    assert wrote is True
+    assert mcp.put_content is not None
+    assert mcp.put_content.startswith("---")
+    assert "type: recipe" in mcp.put_content
+    assert "best_config_args" in mcp.put_content  # attrs preserved
+    assert "torch_compile IMPROVES qwen3" in mcp.put_content
+
+
+def test_search_cache_avoids_repeat_search() -> None:
+    pages = {"recipe/x": _page(_RECIPE_BODY)}
+    kg, mcp = _client(pages)
+    kg.query_facts(predicate="IMPROVES")
+    kg.query_facts(predicate="IMPROVES")  # identical -> served from cache
+    assert sum(1 for t, _ in mcp.calls if t == "search") == 1
+
+
+def test_emit_fact_invalidates_cache() -> None:
+    pages = {"recipe/x": _page(_RECIPE_BODY)}
+    kg, mcp = _client(pages)
+    kg.query_facts(subject="torch_compile")  # warms cache (empty result)
+    kg.emit_fact(page_slug="recipe/x", subject="torch_compile", predicate="IMPROVES", object="qwen2forcausallm")
+    facts = kg.query_facts(subject="torch_compile")  # must re-search post-write
+    assert any(f.subject == "torch_compile" for f in facts)
+
+
+# -- graceful degradation --------------------------------------------------
+def test_query_facts_safe_returns_empty_on_error() -> None:
+    kg = KGClient(_BoomMcp())
+    assert kg.query_facts_safe(predicate="IMPROVES") == []
+
+
+def test_graph_traverse_safe_returns_empty_on_error() -> None:
+    kg = KGClient(_BoomMcp())
+    assert kg.graph_traverse_safe(start_entity="x") == []
+
+
+def test_emit_fact_safe_returns_false_on_error() -> None:
+    kg = KGClient(_BoomMcp())
+    assert kg.emit_fact_safe(page_slug="x", subject="a", predicate="IMPROVES", object="b") is False
+
+
+def test_is_available_true_and_false() -> None:
+    kg_ok, _ = _client({"x": _page(_RECIPE_BODY)})
+    assert kg_ok.is_available() is True
+    assert KGClient(_BoomMcp()).is_available() is False
+
+
+# -- generate_variants_graph_guided ----------------------------------------
+_VARIANT_BODY = """# KG
+
+## Facts
+- aiter_backend IMPROVES qwen2forcausallm (gain: +35%, confidence: 0.95, hw: mi300x, fw: sglang)
+- torch_compile IMPROVES qwen2forcausallm (gain: +8%, hw: mi300x, fw: sglang)
+- decode_patch IMPROVES qwen2forcausallm (gain: +20%, hw: mi300x, fw: sglang)
+- decode_patch CONFLICTS_WITH flash_attn (severity: hard)
+- needs_dep IMPROVES qwen2forcausallm (gain: +40%, hw: mi300x, fw: sglang)
+- needs_dep REQUIRES chunked_prefill ()
+"""
+
+
+def test_graph_guided_orders_by_gain_and_excludes_in_stack() -> None:
+    kg, _ = _client({"kg": _page(_VARIANT_BODY)})
+    out = generate_variants_graph_guided(
+        kg,
+        architectures=["Qwen2ForCausalLM"],
+        hardware="mi300x",
+        framework="sglang",
+        in_stack=["aiter_backend"],  # exclude top knob
+    )
+    knobs = [v["knob"] for v in out]
+    # aiter excluded; needs_dep dropped (REQUIRES chunked_prefill not in stack);
+    # decode_patch kept (conflict target flash_attn not in stack); torch_compile kept.
+    assert "aiter_backend" not in knobs
+    assert "needs_dep" not in knobs
+    assert knobs[0] == "decode_patch"  # +20% before torch_compile +8%
+    assert "torch_compile" in knobs
+
+
+def test_graph_guided_rejects_conflict_with_stack() -> None:
+    kg, _ = _client({"kg": _page(_VARIANT_BODY)})
+    out = generate_variants_graph_guided(
+        kg,
+        architectures=["Qwen2ForCausalLM"],
+        hardware="mi300x",
+        framework="sglang",
+        in_stack=["flash_attn"],  # decode_patch conflicts with this
+    )
+    knobs = [v["knob"] for v in out]
+    assert "decode_patch" not in knobs
+
+
+def test_graph_guided_dependency_met() -> None:
+    kg, _ = _client({"kg": _page(_VARIANT_BODY)})
+    out = generate_variants_graph_guided(
+        kg,
+        architectures=["Qwen2ForCausalLM"],
+        hardware="mi300x",
+        framework="sglang",
+        in_stack=["chunked_prefill"],  # satisfies needs_dep REQUIRES
+    )
+    knobs = [v["knob"] for v in out]
+    assert "needs_dep" in knobs
+    assert knobs[0] == "needs_dep"  # +40% top
+
+
+# -- generate_knob_candidates_graph_guided ---------------------------------
+class _StubKnobKG:
+    """Stub KG returning canned facts keyed by predicate (knob path)."""
+
+    def __init__(self, facts_by_pred: dict[str, list[Fact]]) -> None:
+        self._by = facts_by_pred
+        self.queries: list[dict[str, Any]] = []
+
+    def query_facts_safe(self, **kwargs: Any) -> list[Fact]:
+        self.queries.append(kwargs)
+        pred = kwargs.get("predicate")
+        key = pred[0] if isinstance(pred, (list, tuple)) else pred
+        return list(self._by.get(str(key), []))
+
+
+def _knob_fact(subject: str, *, gain: str = "+10%", name: str = "k", args: str = "--x 1",
+               envs: str = "", keep_n: str = "2") -> Fact:
+    props = {"gain": gain, "name": name, "args": args, "keep_n": keep_n}
+    if envs:
+        props["envs"] = envs
+    return Fact(subject=subject, predicate="KNOB_IMPROVES", object="llamaforcausallm+bf16", properties=props)
+
+
+def test_knob_guided_orders_by_gain_and_surfaces_args_envs() -> None:
+    kg = _StubKnobKG({
+        "KNOB_IMPROVES": [
+            _knob_fact("fp_low", gain="+5%", args="--a 1"),
+            _knob_fact("fp_high", gain="+30%", args="--moe-runner-backend aiter",
+                       envs='{"VLLM_USE_AITER":"1"}', name="moe-aiter"),
+        ],
+    })
+    out = generate_knob_candidates_graph_guided(
+        kg, architectures=["LlamaForCausalLM"], precision="bf16", hardware="mi300x", framework="sglang",
+    )
+    assert [v["knob"] for v in out] == ["fp_high", "fp_low"]
+    assert out[0]["args"] == "--moe-runner-backend aiter"
+    assert out[0]["envs"] == {"VLLM_USE_AITER": "1"}
+    assert out[0]["name"] == "moe-aiter"
+    assert out[0]["source"] == "kg_knob"
+    # Object node folds precision in.
+    assert kg.queries[0]["object"] == ["llamaforcausallm+bf16"]
+
+
+def test_knob_guided_drops_reverted_and_tried() -> None:
+    kg = _StubKnobKG({
+        "KNOB_IMPROVES": [_knob_fact("fp_bad"), _knob_fact("fp_tried"), _knob_fact("fp_ok")],
+        "KNOB_REVERTED_ON": [Fact(subject="fp_bad", predicate="KNOB_REVERTED_ON", object="llamaforcausallm+bf16")],
+    })
+    out = generate_knob_candidates_graph_guided(
+        kg, architectures=["LlamaForCausalLM"], precision="bf16", tried=["fp_tried"],
+    )
+    knobs = [v["knob"] for v in out]
+    assert "fp_bad" not in knobs  # KNOB_REVERTED_ON blocked
+    assert "fp_tried" not in knobs  # already tried
+    assert "fp_ok" in knobs
+
+
+def test_knob_guided_no_precision_uses_bare_arch() -> None:
+    kg = _StubKnobKG({"KNOB_IMPROVES": []})
+    generate_knob_candidates_graph_guided(kg, architectures=["LlamaForCausalLM"])
+    # The REVERTED_ON probe runs first; both anchor on the bare (normalized) arch node.
+    assert kg.queries[0]["object"] == ["llamaforcausallm"]
+
+
+def test_knob_guided_no_archs_returns_empty() -> None:
+    kg = _StubKnobKG({"KNOB_IMPROVES": [_knob_fact("fp_ok")]})
+    assert generate_knob_candidates_graph_guided(kg, architectures=[]) == []
+
+
+# -- native link graph -----------------------------------------------------
+class _LinkGraphMcp:
+    """Fake MCP modeling gbrain's native link graph.
+
+    Mirrors the live contract observed against the cluster: ``add_link``
+    requires both endpoint pages to exist, edges are unique on
+    ``(from, to, link_type)`` (re-add upserts context), and
+    ``remove_link`` deletes every edge between a pair.
+    """
+
+    def __init__(self, pages: list[str] | None = None, edges: list[dict[str, Any]] | None = None) -> None:
+        self.pages: set[str] = set(pages or [])
+        self.edges: list[dict[str, Any]] = list(edges or [])
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def call(self, tool: str, args: dict[str, Any]) -> Any:
+        self.calls.append((tool, dict(args)))
+        if tool == "list_pages":
+            return [{"slug": s} for s in self.pages]
+        if tool == "get_page":
+            slug = args.get("slug")
+            return {"slug": slug, "body": "x"} if slug in self.pages else {"error": "page_not_found"}
+        if tool == "put_page":
+            self.pages.add(args["slug"])
+            return {"slug": args["slug"], "status": "created_or_updated"}
+        if tool == "add_link":
+            f, t, lt = args["from"], args["to"], args.get("link_type", "")
+            if f not in self.pages or t not in self.pages:
+                return {"error": "internal_error", "message": "addLink failed: page not found"}
+            for e in self.edges:
+                if e["from_slug"] == f and e["to_slug"] == t and e["link_type"] == lt:
+                    e["context"] = args.get("context", "{}")
+                    return {"status": "ok"}
+            self.edges.append(
+                {"from_slug": f, "to_slug": t, "link_type": lt, "context": args.get("context", "{}")}
+            )
+            return {"status": "ok"}
+        if tool == "remove_link":
+            f, t = args["from"], args["to"]
+            self.edges = [e for e in self.edges if not (e["from_slug"] == f and e["to_slug"] == t)]
+            return {"status": "ok"}
+        if tool == "get_links":
+            return [dict(e) for e in self.edges if e["from_slug"] == args["slug"]]
+        if tool == "get_backlinks":
+            return [dict(e) for e in self.edges if e["to_slug"] == args["slug"]]
+        if tool == "traverse_graph":
+            return self._traverse(args)
+        return {}
+
+    def _traverse(self, args: dict[str, Any]) -> list[dict[str, Any]]:
+        start, depth = args["slug"], int(args.get("depth", 5))
+        direction, link_type = args.get("direction", "out"), args.get("link_type")
+        out: list[dict[str, Any]] = []
+        frontier = {start}
+        for hop in range(1, depth + 1):
+            nxt: set[str] = set()
+            for e in self.edges:
+                if link_type and e["link_type"] != link_type:
+                    continue
+                if direction in ("out", "both") and e["from_slug"] in frontier:
+                    out.append({**e, "depth": hop})
+                    nxt.add(e["to_slug"])
+                if direction in ("in", "both") and e["to_slug"] in frontier:
+                    out.append({**e, "depth": hop})
+                    nxt.add(e["from_slug"])
+            frontier = nxt
+            if not frontier:
+                break
+        return out
+
+
+def test_native_query_facts_uses_get_links() -> None:
+    mcp = _LinkGraphMcp(
+        pages=["aiter_backend", "qwen2forcausallm"],
+        edges=[
+            {
+                "from_slug": "aiter_backend",
+                "to_slug": "qwen2forcausallm",
+                "link_type": "improves",
+                "context": '{"gain":"+35.2%","confidence":"0.95","hw":"mi300x"}',
+            }
+        ],
+    )
+    kg = KGClient(mcp, use_native_kg=True)
+    facts = kg.query_facts(subject="AITER_backend", predicate="IMPROVES")
+    assert any(t == "get_links" for t, _ in mcp.calls)
+    assert len(facts) == 1
+    assert facts[0].subject == "aiter_backend"
+    assert facts[0].object == "qwen2forcausallm"
+    assert facts[0].gain == pytest.approx(35.2)
+
+
+def test_native_query_facts_object_anchor_uses_backlinks() -> None:
+    mcp = _LinkGraphMcp(
+        pages=["aiter_backend", "qwen2forcausallm"],
+        edges=[
+            {
+                "from_slug": "aiter_backend",
+                "to_slug": "qwen2forcausallm",
+                "link_type": "improves",
+                "context": "{}",
+            }
+        ],
+    )
+    kg = KGClient(mcp, use_native_kg=True)
+    facts = kg.query_facts(object="Qwen2ForCausalLM", predicate=["IMPROVES"])
+    assert any(t == "get_backlinks" for t, _ in mcp.calls)
+    assert facts[0].subject == "aiter_backend"
+
+
+def test_native_query_facts_conditions_filter() -> None:
+    mcp = _LinkGraphMcp(
+        pages=["a", "arch"],
+        edges=[{"from_slug": "a", "to_slug": "arch", "link_type": "improves", "context": '{"hw":"mi300x"}'}],
+    )
+    kg = KGClient(mcp, use_native_kg=True)
+    assert kg.query_facts(subject="a", conditions={"hw": "mi300x"})
+    assert kg.query_facts(subject="a", conditions={"hw": "mi308x"}) == []
+
+
+def test_native_query_facts_predicate_only_returns_empty() -> None:
+    mcp = _LinkGraphMcp(pages=["a"], edges=[])
+    kg = KGClient(mcp, use_native_kg=True)
+    assert kg.query_facts(predicate="IMPROVES") == []
+
+
+def test_native_graph_traverse_two_hops() -> None:
+    mcp = _LinkGraphMcp(
+        pages=["qwen3-8b", "qwen2forcausallm", "llamaforcausallm"],
+        edges=[
+            {"from_slug": "qwen3-8b", "to_slug": "qwen2forcausallm", "link_type": "uses_arch", "context": "{}"},
+            {"from_slug": "qwen2forcausallm", "to_slug": "llamaforcausallm", "link_type": "variant_of", "context": "{}"},
+        ],
+    )
+    kg = KGClient(mcp, use_native_kg=True)
+    nodes = kg.graph_traverse(
+        start_entity="qwen3-8b", predicate_filter=["USES_ARCH", "VARIANT_OF"], max_hops=2
+    )
+    entities = {n.entity for n in nodes}
+    assert "qwen2forcausallm" in entities
+    assert "llamaforcausallm" in entities
+
+
+def test_native_emit_fact_materializes_nodes_and_links() -> None:
+    mcp = _LinkGraphMcp(pages=[])  # neither node exists yet
+    kg = KGClient(mcp, use_native_kg=True)
+    wrote = kg.emit_fact(
+        page_slug="ignored",
+        subject="torch_compile",
+        predicate="IMPROVES",
+        object="qwen3",
+        properties={"gain": "+8%"},
+    )
+    assert wrote is True
+    assert "torch_compile" in mcp.pages and "qwen3" in mcp.pages
+    assert len(mcp.edges) == 1
+    assert mcp.edges[0]["link_type"] == "improves"
+    assert kg.query_facts(subject="torch_compile")[0].gain == pytest.approx(8.0)
+
+
+def test_native_emit_fact_idempotent() -> None:
+    mcp = _LinkGraphMcp(pages=["a", "b"])
+    kg = KGClient(mcp, use_native_kg=True)
+    kg.emit_fact(page_slug="p", subject="a", predicate="IMPROVES", object="b")
+    kg.emit_fact(page_slug="p", subject="a", predicate="IMPROVES", object="b")
+    assert len(mcp.edges) == 1
+
+
+def test_native_retract_preserves_other_link_types() -> None:
+    mcp = _LinkGraphMcp(
+        pages=["a", "b"],
+        edges=[
+            {"from_slug": "a", "to_slug": "b", "link_type": "keep_knob", "context": "{}"},
+            {"from_slug": "a", "to_slug": "b", "link_type": "conflicts_with", "context": "{}"},
+        ],
+    )
+    kg = KGClient(mcp, use_native_kg=True)
+    removed = kg.retract_fact(page_slug="p", subject="a", predicate="KEEP_KNOB", object="b")
+    assert removed is True
+    remaining = {e["link_type"] for e in mcp.edges}
+    assert remaining == {"conflicts_with"}
+
+
+def test_native_retract_noop_when_absent() -> None:
+    mcp = _LinkGraphMcp(
+        pages=["a", "b"],
+        edges=[{"from_slug": "a", "to_slug": "b", "link_type": "keep_knob", "context": "{}"}],
+    )
+    kg = KGClient(mcp, use_native_kg=True)
+    assert kg.retract_fact(page_slug="p", subject="a", predicate="IMPROVES", object="b") is False
+    assert len(mcp.edges) == 1
+
+
+def test_native_emit_ignores_page_slug() -> None:
+    # In the link-graph model the subject node is the edge source; the legacy
+    # ``page_slug`` must not be created as a page nor used as the edge anchor.
+    mcp = _LinkGraphMcp(pages=[])
+    kg = KGClient(mcp, use_native_kg=True)
+    kg.emit_fact(page_slug="recipe/some-page", subject="a", predicate="IMPROVES", object="b")
+    assert "recipe/some-page" not in mcp.pages
+    assert mcp.edges[0]["from_slug"] == "a"
+
+
+class _AddLinkFailsMcp(_LinkGraphMcp):
+    """Link-graph fake whose ``add_link`` always reports an in-band error."""
+
+    def call(self, tool: str, args: dict[str, Any]) -> Any:
+        if tool == "add_link":
+            self.calls.append((tool, dict(args)))
+            return {"error": "internal_error", "message": "addLink failed"}
+        return super().call(tool, args)
+
+
+def test_native_emit_returns_false_on_add_link_error() -> None:
+    # gbrain reports some write failures in-band; a failed add_link must not
+    # parse as a false success.
+    mcp = _AddLinkFailsMcp(pages=["a", "b"])
+    kg = KGClient(mcp, use_native_kg=True)
+    assert kg.emit_fact(page_slug="p", subject="a", predicate="IMPROVES", object="b") is False
+    assert mcp.edges == []
+
+
+class _PutPageFailsMcp(_LinkGraphMcp):
+    """Link-graph fake whose ``put_page`` reports an in-band error."""
+
+    def call(self, tool: str, args: dict[str, Any]) -> Any:
+        if tool == "put_page":
+            self.calls.append((tool, dict(args)))
+            return {"error": "internal_error", "message": "putPage failed"}
+        return super().call(tool, args)
+
+
+def test_native_emit_returns_false_when_node_creation_fails() -> None:
+    # When a missing endpoint cannot be materialized, the edge write is aborted.
+    mcp = _PutPageFailsMcp(pages=[])
+    kg = KGClient(mcp, use_native_kg=True)
+    assert kg.emit_fact(page_slug="p", subject="a", predicate="IMPROVES", object="b") is False
+    assert mcp.edges == []
+
+
+def test_native_graph_traverse_breadth_capped() -> None:
+    # A high-fan-in hub must not blow up the foreground warm-start path.
+    from inference_optimizer.recipe_kb import kg_client as kgmod
+
+    hub = "hub"
+    leaves = [f"leaf{i}" for i in range(kgmod._MAX_TRAVERSE_NODES + 50)]
+    mcp = _LinkGraphMcp(
+        pages=[hub, *leaves],
+        edges=[{"from_slug": hub, "to_slug": l, "link_type": "improves", "context": "{}"} for l in leaves],
+    )
+    kg = KGClient(mcp, use_native_kg=True)
+    nodes = kg.graph_traverse(start_entity=hub, max_hops=1)
+    assert len(nodes) == kgmod._MAX_TRAVERSE_NODES

--- a/inference_optimizer/tests/test_kg_warmstart_donor.py
+++ b/inference_optimizer/tests/test_kg_warmstart_donor.py
@@ -1,0 +1,159 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""KG-native cross-model warm-start donor synthesis (single_top).
+
+Covers ``generate_warmstart_donor_graph_guided`` (kg_client) and the
+``_kg_native_config_donor`` cortex_t0 wiring: the strongest positive-gain,
+non-reverted ``KNOB_IMPROVES`` edge for the target arch+precision is adopted as
+a recipe-shaped donor; reverted / zero-gain / config-less / empty cases yield
+``None`` so warm-start falls back to the recipe-KB sibling search.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from inference_optimizer.recipe_kb.kg_client import (
+    Fact,
+    generate_warmstart_donor_graph_guided,
+)
+
+
+def _knob_fact(
+    *,
+    fp: str,
+    obj: str = "qwen2forcausallm+fp8",
+    gain: str = "+20%",
+    args: str = "--enable-foo",
+    envs_json: str = '{"X": "1"}',
+    name: str = "foo",
+    keep_n: str = "5",
+    predicate: str = "KNOB_IMPROVES",
+) -> Fact:
+    """Build a KNOB_IMPROVES/KNOB_REVERTED_ON fact for the fake KG."""
+    return Fact(
+        subject=fp,
+        predicate=predicate,
+        object=obj,
+        properties={
+            "gain": gain,
+            "args": args,
+            "envs": envs_json,
+            "name": name,
+            "keep_n": keep_n,
+        },
+    )
+
+
+class _FakeKG:
+    """Duck-typed KG exposing only query_facts_safe (what the generator uses)."""
+
+    def __init__(self, improves: list[Fact], reverted: list[Fact] | None = None) -> None:
+        self._improves = improves
+        self._reverted = reverted or []
+
+    def query_facts_safe(self, **kwargs: Any) -> list[Fact]:
+        preds = kwargs.get("predicate") or []
+        if "KNOB_REVERTED_ON" in preds:
+            return self._reverted
+        if "KNOB_IMPROVES" in preds:
+            return self._improves
+        return []
+
+
+_ARCHS = ["Qwen2ForCausalLM"]
+_KW = {"architectures": _ARCHS, "precision": "fp8", "hardware": "mi300x", "framework": "sglang"}
+
+
+def test_single_top_donor_picks_highest_gain() -> None:
+    kg = _FakeKG([
+        _knob_fact(fp="low", gain="+5%", args="--low"),
+        _knob_fact(fp="high", gain="+40%", args="--high", envs_json='{"Y": "2"}'),
+    ])
+    donor = generate_warmstart_donor_graph_guided(kg, model_type="qwen2", **_KW)
+    assert donor is not None
+    assert donor["best_config"]["extra_server_args"] == "--high"
+    assert donor["best_config"]["extra_envs"] == {"Y": "2"}
+    assert donor["validated_gain_pct"] == 40.0
+    assert donor["canonical_id"].startswith("kg-synth:qwen2forcausallm+fp8:")
+    assert donor["provenance"]["source"] == "kg_native_warmstart"
+
+
+def test_reverted_knob_excluded() -> None:
+    # The only improving knob is also reverted → no donor.
+    kg = _FakeKG(
+        improves=[_knob_fact(fp="r1", gain="+30%")],
+        reverted=[_knob_fact(fp="r1", predicate="KNOB_REVERTED_ON")],
+    )
+    assert generate_warmstart_donor_graph_guided(kg, **_KW) is None
+
+
+def test_zero_gain_yields_none() -> None:
+    kg = _FakeKG([_knob_fact(fp="z", gain="0%")])
+    assert generate_warmstart_donor_graph_guided(kg, **_KW) is None
+
+
+def test_configless_knob_yields_none() -> None:
+    # Positive gain but neither args nor envs → not replayable.
+    kg = _FakeKG([_knob_fact(fp="c", gain="+15%", args="", envs_json="")])
+    assert generate_warmstart_donor_graph_guided(kg, **_KW) is None
+
+
+def test_empty_kg_yields_none() -> None:
+    assert generate_warmstart_donor_graph_guided(_FakeKG([]), **_KW) is None
+
+
+def test_no_architectures_yields_none() -> None:
+    kg = _FakeKG([_knob_fact(fp="x", gain="+20%")])
+    out = generate_warmstart_donor_graph_guided(
+        kg, architectures=[], precision="fp8", hardware="mi300x", framework="sglang"
+    )
+    assert out is None
+
+
+def test_cortex_helper_requires_native_kg(monkeypatch) -> None:
+    # _kg_native_config_donor must NOT borrow from a non-native (sim) client.
+    from inference_optimizer.orchestrator import cortex_t0
+
+    class _SimKG:
+        _native = False
+
+        def is_available(self) -> bool:
+            return True
+
+        def query_facts_safe(self, **kwargs: Any) -> list[Fact]:
+            return [_knob_fact(fp="x", gain="+20%")]
+
+    monkeypatch.setattr(
+        "inference_optimizer.recipe_kb.kg_client.get_kg_client", lambda: _SimKG()
+    )
+    out = cortex_t0._kg_native_config_donor(
+        architectures=_ARCHS, precision="fp8", hardware="mi300x", framework="sglang", model_type="qwen2"
+    )
+    assert out is None
+
+
+def test_cortex_helper_returns_native_donor(monkeypatch) -> None:
+    from inference_optimizer.orchestrator import cortex_t0
+
+    class _NativeKG:
+        _native = True
+
+        def is_available(self) -> bool:
+            return True
+
+        def query_facts_safe(self, **kwargs: Any) -> list[Fact]:
+            preds = kwargs.get("predicate") or []
+            if "KNOB_IMPROVES" in preds:
+                return [_knob_fact(fp="x", gain="+25%", args="--win")]
+            return []
+
+    monkeypatch.setattr(
+        "inference_optimizer.recipe_kb.kg_client.get_kg_client", lambda: _NativeKG()
+    )
+    out = cortex_t0._kg_native_config_donor(
+        architectures=_ARCHS, precision="fp8", hardware="mi300x", framework="sglang", model_type="qwen2"
+    )
+    assert out is not None
+    assert out["best_config"]["extra_server_args"] == "--win"
+    assert out["validated_gain_pct"] == 25.0

--- a/inference_optimizer/tests/test_warm_replay_donor_gate.py
+++ b/inference_optimizer/tests/test_warm_replay_donor_gate.py
@@ -1,0 +1,149 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Warm-replay BORROWED config-donor trustworthiness gate.
+
+Covers the donor acceptance gate that prevents cross-model warm-replay from
+borrowing configs that are evidence-free (zero validated gain), cross/unknown
+architecture, or workload-shape incompatible — the empirical root causes of
+neutral/negative warm-replay gains.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from inference_optimizer.orchestrator.cortex_t0 import (
+    _donor_is_trustworthy,
+    _find_config_donor,
+)
+
+
+def _donor(
+    *,
+    arch: list[str] | None = None,
+    model_type: str = "qwen2",
+    gain: float = 12.5,
+    conc: Any = 64,
+    isl: Any = 128,
+    osl: Any = 128,
+    with_config: bool = True,
+) -> dict[str, Any]:
+    """Build a minimal donor recipe row for gate tests."""
+    row: dict[str, Any] = {
+        "canonical_id": "donor-cid",
+        "architectures": ["Qwen2ForCausalLM"] if arch is None else arch,
+        "model_type": model_type,
+        "validated_gain_pct": gain,
+        "conc": conc,
+        "isl": isl,
+        "osl": osl,
+    }
+    if with_config:
+        row["best_config"] = {"extra_server_args": "--enable-foo", "extra_envs": {"X": "1"}}
+    return row
+
+
+_TARGET = {
+    "target_arch_slug": "qwen2forcausallm",
+    "target_model_type": "qwen2",
+    "target_conc": 64,
+    "target_isl": 128,
+    "target_osl": 128,
+}
+
+
+def test_trustworthy_donor_accepted() -> None:
+    assert _donor_is_trustworthy(_donor(), **_TARGET) is True
+
+
+def test_zero_gain_donor_rejected() -> None:
+    # RC1: zero validated gain is a "reproduce baseline" no-op.
+    assert _donor_is_trustworthy(_donor(gain=0.0), **_TARGET) is False
+
+
+def test_negative_gain_donor_rejected() -> None:
+    assert _donor_is_trustworthy(_donor(gain=-5.0), **_TARGET) is False
+
+
+def test_cross_arch_donor_rejected() -> None:
+    # RC2: a llama config must not be borrowed for a qwen2 target.
+    assert _donor_is_trustworthy(_donor(arch=["LlamaForCausalLM"]), **_TARGET) is False
+
+
+def test_unknown_arch_donor_rejected() -> None:
+    # RC2: empty/unknown architecture cannot be vetted → reject.
+    assert _donor_is_trustworthy(_donor(arch=[]), **_TARGET) is False
+
+
+def test_mismatched_model_type_rejected() -> None:
+    assert _donor_is_trustworthy(_donor(model_type="flux"), **_TARGET) is False
+
+
+def test_shape_conflict_conc_rejected() -> None:
+    # RC3: a config tuned for conc=256 should not replay onto a conc=64 target.
+    assert _donor_is_trustworthy(_donor(conc=256), **_TARGET) is False
+
+
+def test_shape_conflict_isl_rejected() -> None:
+    assert _donor_is_trustworthy(_donor(isl=4096), **_TARGET) is False
+
+
+def test_missing_shape_is_lenient() -> None:
+    # Unknown shape on either side is NOT a conflict (avoid over-blocking).
+    donor = _donor(conc=None, isl=None, osl=None)
+    assert _donor_is_trustworthy(donor, **_TARGET) is True
+
+
+def test_no_config_rejected() -> None:
+    assert _donor_is_trustworthy(_donor(with_config=False), **_TARGET) is False
+
+
+class _StubKB:
+    """A search-only KB stub returning a fixed donor row list."""
+
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+
+    def search(self, *, label_match: dict[str, Any], limit: int = 10) -> list[dict[str, Any]]:  # noqa: ARG002
+        return list(self._rows)
+
+
+def _find_kwargs(**over: Any) -> dict[str, Any]:
+    base = {
+        "cid": "self-cid",
+        "hardware": "mi300x",
+        "framework": "sglang",
+        "model_type": "qwen2",
+        "arch_slug": "qwen2forcausallm",
+        "framework_version": "v1",
+        "precision": "bf16",
+        "target_conc": 64,
+        "target_isl": 128,
+        "target_osl": 128,
+    }
+    base.update(over)
+    return base
+
+
+def test_find_config_donor_skips_untrustworthy() -> None:
+    # Only the trustworthy sibling (not the zero-gain one) is borrowed.
+    kb = _StubKB([_donor(gain=0.0), _donor(gain=20.0)])
+    donor, tier, conf = _find_config_donor(kb, **_find_kwargs())
+    assert donor is not None
+    assert donor["validated_gain_pct"] == 20.0
+    assert tier == "same_arch_class"
+    assert conf == 0.95
+
+
+def test_find_config_donor_returns_none_when_all_untrustworthy() -> None:
+    kb = _StubKB([_donor(gain=0.0), _donor(arch=["LlamaForCausalLM"], gain=30.0)])
+    donor, tier, conf = _find_config_donor(kb, **_find_kwargs())
+    assert donor is None
+    assert tier == ""
+    assert conf == 0.0
+
+
+def test_find_config_donor_skips_self_cid() -> None:
+    kb = _StubKB([_donor(gain=20.0)])
+    donor, _tier, _conf = _find_config_donor(kb, **_find_kwargs(cid="donor-cid"))
+    assert donor is None

--- a/inference_optimizer/tests/test_warm_replay_kg.py
+++ b/inference_optimizer/tests/test_warm_replay_kg.py
@@ -1,0 +1,323 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Tests for KG-enhanced warm-start context in cortex_t0."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from inference_optimizer.orchestrator.cortex_t0 import _build_warm_start_context
+from inference_optimizer.recipe_kb.kg_client import KGClient
+
+_FACTS_PAGE = """# KG
+
+## Facts
+- qwen3moeforcausallm VARIANT_OF qwen2forcausallm (distance: 1)
+- bad_patch REVERTED_ON qwen3moeforcausallm (loss: -5%, error: oom)
+- fp8_kernel_patch REVERTED_ON qwen2forcausallm (loss: -4.2%, error: perf_regression)
+- aiter_backend IMPROVES qwen3moeforcausallm (gain: +30%, confidence: 0.95, hw: mi300x, fw: sglang)
+"""
+
+
+class _FakeMcp:
+    """Fake MCP returning a single facts page for all searches."""
+
+    def __init__(self, pages: dict[str, str]) -> None:
+        self.pages = pages
+
+    def call(self, tool: str, args: dict[str, Any]) -> Any:
+        if tool == "list_pages":
+            return [{"slug": s} for s in self.pages]
+        if tool == "search":
+            return [{"slug": s} for s in self.pages]
+        if tool == "get_page":
+            return {"content": self.pages.get(args.get("slug"), "")}
+        return {}
+
+
+def _kg() -> KGClient:
+    return KGClient(_FakeMcp({"kg": "---\ntype: recipe\n---\n\n" + _FACTS_PAGE}))
+
+
+def _ctx() -> dict[str, Any]:
+    return _build_warm_start_context(
+        status="hit",
+        tier="exact",
+        confidence=0.9,
+        canonical_id="inference:qwen3:mi300x:sglang:qwen3:qwen3moeforcausallm:0.5.11:fp8",
+        source="local",
+        recipe={"prs_tested": []},
+        model_architectures=["Qwen3MoeForCausalLM"],
+        hardware="mi300x",
+        framework="sglang",
+        kg_client=_kg(),
+    )
+
+
+def test_kg_hard_block_same_arch() -> None:
+    ctx = _ctx()
+    hard = [b for b in ctx.get("blocked_patches", []) if b.get("source") == "kg"]
+    assert any(b["patch_file"] == "bad_patch" and b["block_type"] == "hard" for b in hard)
+
+
+def test_kg_advisory_block_related_arch() -> None:
+    ctx = _ctx()
+    adv = ctx.get("advisory_blocked_patches", [])
+    fp8 = [b for b in adv if b["patch_file"] == "fp8_kernel_patch"]
+    assert len(fp8) == 1
+    # confidence decayed for indirect (related-arch) inference
+    assert fp8[0]["confidence"] < 0.95
+    assert fp8[0]["block_type"] == "advisory"
+
+
+def test_kg_recommended_knobs_positive() -> None:
+    ctx = _ctx()
+    recs = ctx.get("recommended_knobs", [])
+    assert any(r["knob"] == "aiter_backend" and r["expected_gain"] > 0 for r in recs)
+
+
+_KNOB_FACTS_PAGE = """# KG
+
+## Facts
+- aiter_backend IMPROVES qwen3moeforcausallm (gain: +30%, confidence: 0.95, hw: mi300x, fw: sglang)
+- abc123 KNOB_IMPROVES qwen3moeforcausallm+fp8 (gain: +12%, args: --moe-runner-backend aiter, name: moe-aiter, keep_n: 3, hw: mi300x, fw: sglang)
+"""
+
+
+def _kg_knob() -> KGClient:
+    return KGClient(_FakeMcp({"kg": "---\ntype: recipe\n---\n\n" + _KNOB_FACTS_PAGE}))
+
+
+def _ctx_knob() -> dict[str, Any]:
+    return _build_warm_start_context(
+        status="hit",
+        tier="exact",
+        confidence=0.9,
+        canonical_id="inference:qwen3:mi300x:sglang:qwen3:qwen3moeforcausallm:0.5.11:fp8",
+        source="local",
+        recipe={"prs_tested": []},
+        model_architectures=["Qwen3MoeForCausalLM"],
+        hardware="mi300x",
+        framework="sglang",
+        precision="fp8",
+        kg_client=_kg_knob(),
+    )
+
+
+def test_graph_guided_knobs_disabled_by_default(monkeypatch: Any) -> None:
+    monkeypatch.delenv("GBRAIN_KG_GUIDED", raising=False)
+    ctx = _ctx_knob()
+    assert "graph_guided_knobs" not in ctx
+
+
+def test_graph_guided_knobs_enabled_by_flag(monkeypatch: Any) -> None:
+    monkeypatch.setenv("GBRAIN_KG_GUIDED", "1")
+    ctx = _ctx_knob()
+    knobs = ctx.get("graph_guided_knobs", [])
+    assert any(
+        k["knob"] == "abc123" and k["args"] == "--moe-runner-backend aiter" and k["source"] == "kg_knob"
+        for k in knobs
+    )
+
+
+def test_filter_warm_patches_advisory_and_expiry() -> None:
+    from types import SimpleNamespace
+
+    from inference_optimizer.orchestrator.coordinator import Coordinator
+
+    patches = [
+        {"patch_file": "good.py", "measured_gain_pct": 10},
+        {"patch_file": "expired.py", "measured_gain_pct": 8, "expired": True},
+        {"patch_file": "risky.py", "measured_gain_pct": 5},
+    ]
+    advisory = [{"patch_file": "risky.py", "confidence": 0.8}]
+    state = SimpleNamespace(gpu_type="mi300x", framework="sglang")
+    kept = Coordinator._filter_warm_patches_with_kg(
+        SimpleNamespace(), patches, advisory, state
+    )
+    files = {p["patch_file"] for p in kept}
+    assert files == {"good.py"}
+
+
+def test_filter_warm_patches_keeps_low_confidence_advisory() -> None:
+    from types import SimpleNamespace
+
+    from inference_optimizer.orchestrator.coordinator import Coordinator
+
+    patches = [{"patch_file": "maybe.py", "measured_gain_pct": 5}]
+    advisory = [{"patch_file": "maybe.py", "confidence": 0.5}]  # below 0.75 threshold
+    kept = Coordinator._filter_warm_patches_with_kg(
+        SimpleNamespace(), patches, advisory, SimpleNamespace()
+    )
+    assert [p["patch_file"] for p in kept] == ["maybe.py"]
+
+
+def test_specialist_prompt_renders_kg_recommended_knobs() -> None:
+    from inference_optimizer.orchestrator.specialist_domains import get_domain
+    from inference_optimizer.orchestrator.system_prompts.specialist_prompt_builder import (
+        SpecialistPromptInputs,
+        build_specialist_prompts,
+    )
+
+    domain = get_domain("serving_specialist")
+    assert domain is not None
+    inp = SpecialistPromptInputs(
+        task_id="t-kg",
+        domain=domain,
+        max_turns=4,
+        gap_canonical_id="gap.kg",
+        gap_layer=domain.layer,
+        kg_recommended_knobs=[
+            {"knob": "aiter_backend", "expected_gain": 30.0, "confidence": 0.95, "source": "kg_graph"},
+        ],
+    )
+    _, user = build_specialist_prompts(inp)
+    assert "5d. GRAPH-RECOMMENDED KNOBS" in user
+    assert "aiter_backend" in user
+    assert "gain=+30.0%" in user
+    assert "conf=0.95" in user
+
+
+def test_specialist_prompt_renders_kg_guided_knobs() -> None:
+    from inference_optimizer.orchestrator.specialist_domains import get_domain
+    from inference_optimizer.orchestrator.system_prompts.specialist_prompt_builder import (
+        SpecialistPromptInputs,
+        build_specialist_prompts,
+    )
+
+    domain = get_domain("serving_specialist")
+    assert domain is not None
+    inp = SpecialistPromptInputs(
+        task_id="t-kg-guided",
+        domain=domain,
+        max_turns=4,
+        gap_canonical_id="gap.kg",
+        gap_layer=domain.layer,
+        kg_guided_knobs=[
+            {
+                "knob": "abc123",
+                "name": "moe-aiter",
+                "args": "--moe-runner-backend aiter",
+                "envs": {"VLLM_USE_AITER": "1"},
+                "expected_gain": 12.0,
+                "evidence_count": 3,
+                "source": "kg_knob",
+            },
+        ],
+    )
+    _, user = build_specialist_prompts(inp)
+    assert "5e. GRAPH-GUIDED CONFIG KNOBS" in user
+    assert "moe-aiter" in user
+    assert "--moe-runner-backend aiter" in user
+    assert "VLLM_USE_AITER=1" in user
+    assert "gain=+12.0%" in user
+    assert "kept=3x" in user
+
+
+def test_specialist_prompt_kg_section_placeholder_when_empty() -> None:
+    from inference_optimizer.orchestrator.specialist_domains import get_domain
+    from inference_optimizer.orchestrator.system_prompts.specialist_prompt_builder import (
+        SpecialistPromptInputs,
+        build_specialist_prompts,
+    )
+
+    domain = get_domain("serving_specialist")
+    assert domain is not None
+    inp = SpecialistPromptInputs(
+        task_id="t-kg-empty", domain=domain, max_turns=4, gap_canonical_id="gap.kg", gap_layer=domain.layer
+    )
+    _, user = build_specialist_prompts(inp)
+    assert "5d. GRAPH-RECOMMENDED KNOBS" in user  # section always present
+
+
+class _RecordingKG:
+    """Fake native KG client recording emit_fact_safe calls."""
+
+    def __init__(self, *, native: bool = True, available: bool = True) -> None:
+        self._native = native
+        self._available = available
+        self.calls: list[dict[str, Any]] = []
+
+    def is_available(self) -> bool:
+        return self._available
+
+    def emit_fact_safe(self, **kwargs: Any) -> bool:
+        self.calls.append(kwargs)
+        return True
+
+
+def _emit_decision(monkeypatch: Any, kg: Any, **kwargs: Any) -> None:
+    from types import SimpleNamespace
+
+    import inference_optimizer.recipe_kb.kg_client as kgmod
+    from inference_optimizer.orchestrator.coordinator import Coordinator
+
+    monkeypatch.setattr(kgmod, "get_kg_client", lambda: kg)
+    selfish = SimpleNamespace(shared_state=SimpleNamespace(gpu_type="mi300x", framework="sglang"))
+    Coordinator._emit_kg_decision(selfish, **kwargs)
+
+
+def test_emit_kg_decision_keep_emits_improves(monkeypatch: Any) -> None:
+    kg = _RecordingKG()
+    _emit_decision(
+        monkeypatch, kg,
+        patch_file="aiter_backend", outcome="KEEP", gain_pct=12.0, error_class="",
+        archs=["Qwen2ForCausalLM"],
+    )
+    assert len(kg.calls) == 1
+    call = kg.calls[0]
+    assert call["subject"] == "aiter_backend"
+    assert call["predicate"] == "IMPROVES"
+    assert call["object"] == "Qwen2ForCausalLM"
+    assert call["properties"]["gain"] == "+12.0%"
+    assert call["properties"]["hw"] == "mi300x"
+    assert call["properties"]["fw"] == "sglang"
+
+
+def test_emit_kg_decision_revert_emits_reverted_on(monkeypatch: Any) -> None:
+    kg = _RecordingKG()
+    _emit_decision(
+        monkeypatch, kg,
+        patch_file="fp8_patch", outcome="REVERT", gain_pct=-4.2, error_class="perf",
+        archs=["Qwen2ForCausalLM", "LlamaForCausalLM"],
+    )
+    assert {c["predicate"] for c in kg.calls} == {"REVERTED_ON"}
+    assert {c["object"] for c in kg.calls} == {"Qwen2ForCausalLM", "LlamaForCausalLM"}
+    assert kg.calls[0]["properties"]["error"] == "perf"
+
+
+def test_emit_kg_decision_skips_non_native(monkeypatch: Any) -> None:
+    # Non-native client would write a discarded fence; write-back must skip it.
+    kg = _RecordingKG(native=False)
+    _emit_decision(
+        monkeypatch, kg,
+        patch_file="p", outcome="KEEP", gain_pct=5.0, error_class="", archs=["A"],
+    )
+    assert kg.calls == []
+
+
+def test_emit_kg_decision_keep_zero_gain_no_edge(monkeypatch: Any) -> None:
+    # A KEEP with non-positive gain is not an IMPROVES claim.
+    kg = _RecordingKG()
+    _emit_decision(
+        monkeypatch, kg,
+        patch_file="p", outcome="KEEP", gain_pct=0.0, error_class="", archs=["A"],
+    )
+    assert kg.calls == []
+
+
+def test_kg_disabled_when_no_client() -> None:
+    # No kg_client and env unset -> get_kg_client() returns None -> no KG keys.
+    ctx = _build_warm_start_context(
+        status="hit",
+        tier="exact",
+        confidence=0.9,
+        canonical_id="inference:x:mi300x:sglang:llama:llamaforcausallm:0.5.11:fp8",
+        source="local",
+        recipe={"prs_tested": []},
+        model_architectures=["LlamaForCausalLM"],
+        hardware="mi300x",
+        framework="sglang",
+    )
+    assert "advisory_blocked_patches" not in ctx
+    assert "recommended_knobs" not in ctx


### PR DESCRIPTION
…ed knobs

Add native Knowledge Graph consumption for warm-start donor selection. When a model has no self recipe, synthesize a single-top cross-model config donor from KG KNOB_IMPROVES edges (config_donor_tier=kg_cross_model, config_source=kg-synth:...), gated by GBRAIN_KG_NATIVE and degradation-safe with recipe-KB fallback. Inject KG graph-guided knobs into the §5e specialist prompt section.

- recipe_kb/kg_client.py: generate_warmstart_donor_graph_guided (single_top)
- orchestrator/cortex_t0.py: _kg_native_config_donor + _donor_is_trustworthy gate, wired into borrow branch (KG primary, recipe-KB fallback)
- system_prompts/specialist_prompt_builder.py: render §5e graph-guided knobs
- coordinator.py / specialist_runner.py / cli.py: KG client wiring
- tests: kg_client, kg_warmstart_donor, warm_replay_donor_gate, warm_replay_kg

- Description: what and why
- Linked issue(s): close/fix refs
- Tests: added/updated? commands run?
- Breaking changes: yes/no (details if yes)
