### PR TITLE
feat(kernel): HL_HONEST_E2E — promote GEAK verified wins to E2E (flag-gated, default-off)

### DIFF
--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -42,6 +42,119 @@ _BACKGROUND_ROCPROF_TASKS: set[asyncio.Task[Any]] = set()
 STACK_INCREMENTAL_KEEP_THRESHOLD_PCT = 0.5
 KERNEL_STACK_VALIDATION_KEEP_THRESHOLD_PCT = 1.0
 
+# ---------------------------------------------------------------------------
+# "Honest E2E" hardening flags (v4-parity). Every behavior below is OFF by
+# default, so with no env set this module is byte-identical to before. The
+# umbrella flag ``HL_HONEST_E2E`` turns the whole cohesive mode on; each fix
+# also has a per-fix override that wins over the umbrella (set it to an
+# explicit falsey value to opt a single fix back out of the umbrella).
+# ---------------------------------------------------------------------------
+_HONEST_E2E_UMBRELLA_ENV = "HL_HONEST_E2E"
+_TRUEY = {"1", "true", "yes", "on"}
+_FALSEY = {"0", "false", "no", "off"}
+
+
+def _honest_flag(specific_env: str) -> bool:
+    """Resolve a per-fix honest-E2E flag against the umbrella flag.
+
+    Returns ``True`` when the per-fix env ``specific_env`` is truthy, OR when it
+    is unset and the umbrella ``HL_HONEST_E2E`` is truthy. An explicit falsey
+    per-fix value always wins (lets one fix opt out of the umbrella). Off by
+    default so callers are byte-identical to legacy behavior when nothing is set.
+
+    Args:
+        specific_env: The per-fix environment variable name.
+
+    Returns:
+        bool: Whether the gated behavior should be enabled.
+    """
+    raw = os.environ.get(specific_env, "").strip().lower()
+    if raw in _TRUEY:
+        return True
+    if raw in _FALSEY:
+        return False
+    return os.environ.get(_HONEST_E2E_UMBRELLA_ENV, "").strip().lower() in _TRUEY
+
+
+def _vram_guarded_server_args(extra_args: str) -> str:
+    """Optionally cap ``--gpu-memory-utilization`` for the integrate re-baseline.
+
+    v4-parity VRAM barrier: when ``HL_INTEGRATE_VRAM_GUARD`` (or the umbrella)
+    is on and the caller has NOT already pinned ``--gpu-memory-utilization``,
+    append a conservative cap (``HL_INTEGRATE_VRAM_UTIL_CAP``, default 0.90) so a
+    re-baseline server launched on a node with less headroom than the original
+    roofline cannot OOM. Deterministic (no live VRAM probe), additive, and a
+    strict no-op when the flag is off or a util is already specified — so the
+    returned string is byte-identical to the input on the legacy path.
+
+    Args:
+        extra_args: The resolved ``extra_server_args`` string for the server.
+
+    Returns:
+        str: ``extra_args`` unchanged, or with a util cap appended.
+    """
+    if not _honest_flag("HL_INTEGRATE_VRAM_GUARD"):
+        return extra_args
+    if "gpu-memory-utilization" in (extra_args or ""):
+        return extra_args
+    try:
+        cap = float(os.environ.get("HL_INTEGRATE_VRAM_UTIL_CAP", "0.90") or 0.90)
+    except (TypeError, ValueError):
+        cap = 0.90
+    cap = min(max(cap, 0.1), 0.99)
+    addition = f"--gpu-memory-utilization {cap:g}"
+    return f"{extra_args} {addition}".strip() if extra_args else addition
+
+
+def _confirm_source_imported(source_file: str, workspace: str | Path | None) -> bool | None:
+    """Best-effort confirm the patched source was actually imported/compiled.
+
+    v4-parity import-grep: greps the re-baseline server log for evidence the
+    patched module's basename was imported/loaded/compiled by the served
+    process, so a measured E2E delta is attributed to code the workload really
+    ran (not a phantom win on an un-imported patch). Returns a *tri-state*:
+
+    * ``True``  — the module basename appears in import/load/compile context.
+    * ``False`` — the server log is readable and the basename never appears
+      anywhere (positive evidence the patched file was not exercised).
+    * ``None``  — unknown (no source_file, no readable log) — never penalized.
+
+    Args:
+        source_file: Resolved path of the patched kernel source.
+        workspace: Re-baseline workspace dir (holds ``server.log``).
+
+    Returns:
+        bool | None: Tri-state confirmation as described above.
+    """
+    if not source_file or not workspace:
+        return None
+    ws = Path(workspace)
+    logs = [p for p in (ws / "server.log", ws.parent / "server.log") if p.exists()]
+    if not logs:
+        try:
+            logs = sorted(ws.rglob("server.log"))[:1]
+        except Exception:
+            logs = []
+    if not logs:
+        return None
+    stem = Path(source_file).stem
+    if not stem:
+        return None
+    try:
+        text = logs[0].read_text(encoding="utf-8", errors="ignore")
+    except Exception:
+        return None
+    if stem not in text:
+        return False
+    # Confirmed only when the basename co-occurs with an import/compile cue.
+    for line in text.splitlines():
+        if stem in line and re.search(r"import|load|compil|build|\.py", line, re.IGNORECASE):
+            return True
+    # Basename present but not in an obvious import context — treat as unknown
+    # rather than penalize (avoids false negatives on terse logs).
+    return None
+
+
 # kernel_optimization attempt backends whose stdout log we mine for token
 # usage. ``geak`` uses litellm (OpenAI-shape usage); ``oob`` runs ``oob run
 # --json`` whose envelope may carry a ``usage`` block; ``forge`` (Kernel-Forge
@@ -3078,6 +3191,10 @@ def _batch_kernel_candidates(
         selected.append(item)
 
     # Legacy per-kernel pass for reusable kernels not absorbed into a task_group.
+    # Collect the eligible (live, reusable, source-resolved) ungrouped rows first;
+    # the per-row min_gpu_pct gate / selection is applied below so the optional
+    # op-fanout de-dup can sum sibling GPU% before gating.
+    legacy_eligible: list[tuple[str, dict[str, Any], float]] = []
     for item in kernels:
         if not isinstance(item, dict):
             continue
@@ -3099,6 +3216,40 @@ def _batch_kernel_candidates(
             row_pct = float(item.get("gpu_pct") or 0.0)
         except (TypeError, ValueError):
             row_pct = 0.0
+        legacy_eligible.append((kernel_id, item, row_pct))
+
+    if _honest_flag("HL_KERNEL_OPFANOUT_DEDUP"):
+        # Op-fanout de-dup (flag-gated): one logical kernel (same source_file)
+        # often shows up as many op-instance rows, so each would dispatch
+        # separately and its trace impact would be split across rows. Collapse
+        # same-source rows into a single representative (the highest-GPU% row)
+        # carrying the SUMMED GPU% of the fanned siblings, so the min_gpu_pct
+        # gate and downstream impact ranking see the kernel's true aggregate
+        # share. Off => the per-row loop below is byte-identical to legacy.
+        by_source: dict[str, list[tuple[str, dict[str, Any], float]]] = {}
+        order: list[str] = []
+        for kid, item, row_pct in legacy_eligible:
+            src = str(item.get("source_file") or "")
+            if src not in by_source:
+                by_source[src] = []
+                order.append(src)
+            by_source[src].append((kid, item, row_pct))
+        deduped: list[tuple[str, dict[str, Any], float]] = []
+        for src in order:
+            rows = by_source[src]
+            summed_pct = sum(p for _, _, p in rows)
+            rep_kid, rep_item, _ = max(rows, key=lambda r: r[2])
+            if len(rows) > 1:
+                rep_item = dict(rep_item)
+                rep_item["gpu_pct"] = summed_pct
+                rep_item["opfanout_collapsed_ids"] = [k for k, _, _ in rows]
+                for k, _, _ in rows:
+                    if k != rep_kid:
+                        skipped.setdefault(k, f"opfanout_merged_into={rep_kid}")
+            deduped.append((rep_kid, rep_item, summed_pct))
+        legacy_eligible = deduped
+
+    for kernel_id, item, row_pct in legacy_eligible:
         if row_pct < min_gpu_pct:
             skipped[kernel_id] = f"below_min_gpu_pct={min_gpu_pct}"
             continue
@@ -3131,12 +3282,34 @@ def _kernel_result_rank(result: HandlerResult | None) -> tuple[int, float]:
         non-KEEP, and higher ``micro_speedup`` breaks ties.
     """
     if not isinstance(result, dict):
-        return (0, 0.0)
+        return (0, 0, 0.0)
     proposal = result.get("proposal") or {}
     verification = result.get("verification") or {}
     keep = 1 if (result.get("status") == "ok" and proposal.get("decision") == "KEEP") else 0
     micro = float(verification.get("micro_speedup") or 0.0)
-    return (keep, micro)
+    # GEAK-only middle tier (flag-gated, default off): a correctness-verified, high-micro
+    # NEEDS_REVIEW from the GEAK backend is promotable above a bare non-KEEP — GEAK emits
+    # NEEDS_REVIEW (no auto-correctness-KEEP) so its real wins otherwise always lose to any
+    # Claude/Codex/forge KEEP. Scoped to backend=="geak" so OOB backends are byte-identical;
+    # off => verified_nr is always 0 => 3-tuple sorts exactly as the old 2-tuple.
+    _promote = _honest_flag("HL_PROMOTE_VERIFIED_MICRO_NEEDS_REVIEW")
+    try:
+        _thr = float(os.environ.get("HL_VERIFIED_MICRO_PROMOTE_THRESHOLD", "1.10") or 1.10)
+    except ValueError:
+        _thr = 1.10
+    _backend = str(verification.get("best_backend") or result.get("backend") or "").lower()
+    verified_nr = (
+        1
+        if (
+            _promote
+            and keep == 0
+            and _backend == "geak"
+            and verification.get("correctness_passed") is True
+            and micro >= _thr
+        )
+        else 0
+    )
+    return (keep, verified_nr, micro)
 
 
 async def _run_backend_ladder(
@@ -4514,6 +4687,9 @@ async def integrate_handler(
 
     keep_threshold_pct = float(payload.get("keep_threshold_pct", 1.0))
     extra_args = read_extra_server_args(payload).strip()
+    # VRAM barrier (flag-gated, default off): cap re-baseline util so the
+    # integrate server cannot OOM on a tighter node. No-op when off.
+    extra_args = _vram_guarded_server_args(extra_args)
 
     # Wrap BaselineExecutor in a Task/RunnerContext; extra_server_args goes via task params (forward compat).
     from ..session_paths import runs_dir
@@ -4693,10 +4869,117 @@ async def integrate_handler(
         if (gain_pct > keep_threshold_pct or stack_positive_keep)
         else ("REVERT" if gain_pct < -keep_threshold_pct else "NEEDS_REVIEW")
     )
+
+    # import-grep source confirmation (flag-gated, default off). Advisory by
+    # default: annotate whether the served process actually imported/compiled the
+    # patched source. Only the *strict* sub-flag enforces it, and only on
+    # positive non-import evidence (confirmed is False) — an "unknown" (None)
+    # never penalizes a real win. Off => no annotation, decision unchanged.
+    source_import_confirmed: bool | None = None
+    source_not_imported_downgrade = False
+    if _honest_flag("HL_CONFIRM_SOURCE_IMPORTED"):
+        _src = str(payload.get("target_file") or payload.get("source_file") or "")
+        source_import_confirmed = _confirm_source_imported(_src, bench_result.get("workspace"))
+        if (
+            decision == "KEEP"
+            and source_import_confirmed is False
+            and _honest_flag("HL_CONFIRM_SOURCE_IMPORTED_STRICT")
+        ):
+            decision = "NEEDS_REVIEW"
+            source_not_imported_downgrade = True
+
+    # Paired same-config A/B confirmation (Tier-2; opt-in via its OWN explicit
+    # flag, deliberately NOT enabled by the HL_HONEST_E2E umbrella — it does a
+    # second server launch and revert/re-apply, so it stays opt-in until a full
+    # workload run validates it). The gain above is vs a STORED base_tput scalar
+    # (possibly a different config/run). When a candidate clears KEEP against the
+    # stored scalar, re-confirm it against a PAIRED pristine baseline measured
+    # under the *same* config in this call: revert -> measure pristine ->
+    # recompute gain. A confirmed KEEP is re-applied; a disconfirmed KEEP drops
+    # to NEEDS_REVIEW (never a false KEEP). ANY failure restores the applied
+    # state and falls back to the stored-scalar decision, so it never breaks a run.
+    paired_ab: dict[str, Any] | None = None
+    paired_pristine_revert: HandlerResult | None = None
+    if (
+        os.environ.get("HL_INTEGRATE_PAIRED_AB", "").strip().lower() in _TRUEY
+        and decision == "KEEP"
+        and apply_result.get("status") == "ok"
+    ):
+        paired_ab = {"status": "attempted"}
+        try:
+            paired_pristine_revert = _maybe_revert_kernel_patch(apply_result)
+            paired_ws = runs_dir(session_dir, "integrate", f"{fake_task_id}-pairedbase")
+            paired_ws.mkdir(parents=True, exist_ok=True)
+            paired_task = Task(
+                task_id=f"{fake_task_id}-pairedbase",
+                kind="baseline",
+                state="running",
+                params={
+                    "config_path": payload.get("config_path"),
+                    "output_dir": str(paired_ws),
+                    "timeout_sec": int(payload.get("budget_minutes", 20)) * 60,
+                    "extra_server_args": extra_args,
+                    "extra_envs": dict(payload.get("extra_envs") or {}),
+                },
+                idempotency_key=f"{fake_task_id}-pairedbase",
+            )
+            paired_bench = await BaselineExecutor(session_dir=session_dir)(RunnerContext(task=paired_task, lease=None))
+            if is_valid_measurement(paired_bench):
+                paired_base_tput = float(paired_bench.get("output_throughput") or 0.0)
+                paired_gain = gain_pct_or_zero(new_tput, paired_base_tput)
+                paired_ab.update(
+                    {
+                        "status": "ok",
+                        "paired_base_tput": paired_base_tput,
+                        "paired_gain_pct": paired_gain,
+                        "stored_base_tput": base_tput,
+                        "stored_gain_pct": gain_pct,
+                    }
+                )
+                if paired_gain > keep_threshold_pct:
+                    # Confirmed: re-apply so the KEEP lands the patch.
+                    reapply = _maybe_apply_kernel_patch(payload, session_dir=session_dir, kernel_id=kernel_id)
+                    if reapply.get("status") == "ok":
+                        apply_result = reapply
+                        paired_pristine_revert = None  # patch is back; normal revert logic applies
+                        base_tput = paired_base_tput
+                        gain_pct = paired_gain
+                        paired_ab["confirmed"] = True
+                    else:
+                        paired_ab.update({"confirmed": False, "reapply_failed": True})
+                        decision = "NEEDS_REVIEW"
+                else:
+                    # Disconfirmed: leave reverted, drop to NEEDS_REVIEW.
+                    base_tput = paired_base_tput
+                    gain_pct = paired_gain
+                    decision = "NEEDS_REVIEW"
+                    paired_ab["confirmed"] = False
+            else:
+                # Paired measurement failed: restore applied state, keep stored decision.
+                reapply = _maybe_apply_kernel_patch(payload, session_dir=session_dir, kernel_id=kernel_id)
+                if reapply.get("status") == "ok":
+                    apply_result = reapply
+                    paired_pristine_revert = None
+                paired_ab["status"] = "measurement_failed"
+        except Exception as exc:  # noqa: BLE001 — never break integrate on paired-AB
+            log.exception("paired A/B confirmation failed; falling back to stored-scalar decision")
+            try:
+                reapply = _maybe_apply_kernel_patch(payload, session_dir=session_dir, kernel_id=kernel_id)
+                if reapply.get("status") == "ok":
+                    apply_result = reapply
+                    paired_pristine_revert = None
+            except Exception:  # noqa: BLE001
+                pass
+            paired_ab = {"status": "error", "error": repr(exc)}
+
     revert_result = (
         {"status": "skipped", "reason": "KEEP decision"}
         if decision == "KEEP"
-        else _maybe_revert_kernel_patch(apply_result)
+        # If the paired pass already reverted (disconfirmed KEEP), reuse that
+        # result instead of double-reverting an already-reverted manifest.
+        else (
+            paired_pristine_revert if paired_pristine_revert is not None else _maybe_revert_kernel_patch(apply_result)
+        )
     )
 
     # After KEEP, schedule rocprof so integrate returns without waiting
@@ -4729,6 +5012,14 @@ async def integrate_handler(
         result["decision_reason"] = "stack_positive_increment"
         result["stack_incremental_gain_pct"] = stack_incremental_gain_pct
         result["stack_incremental_keep_threshold_pct"] = STACK_INCREMENTAL_KEEP_THRESHOLD_PCT
+    if source_import_confirmed is not None:
+        result["source_import_confirmed"] = source_import_confirmed
+    if source_not_imported_downgrade:
+        result["decision_reason"] = "source_not_confirmed_imported"
+    if paired_ab is not None:
+        result["paired_ab"] = paired_ab
+        if paired_ab.get("confirmed") is False:
+            result["decision_reason"] = "paired_ab_disconfirmed"
     if rocprof_after_info:
         result["rocprof_after_kernel_opt"] = rocprof_after_info
     return result
@@ -5248,6 +5539,11 @@ def record_kernel_opt(state, result: dict[str, Any]) -> None:
     entry["last_deploy_patch_path"] = deploy_patch_path
     entry["last_deploy_repo_root"] = deploy_repo_root
     entry["last_source_file"] = source_file
+    # Record backend + correctness so the GEAK-only verified-NEEDS_REVIEW promotion gate
+    # (next_pending_keep_kernel_id) can identify a correctness-verified GEAK win. Additive;
+    # consumed only when HL_PROMOTE_VERIFIED_MICRO_NEEDS_REVIEW is enabled.
+    entry["last_backend"] = str(verification.get("best_backend") or "")
+    entry["last_correctness_passed"] = verification.get("correctness_passed")
     entry["last_ts"] = ts
     entry["history"] = history
     if test_command:
@@ -5494,7 +5790,27 @@ def pending_keep_kernel_ids(state) -> list[str]:
     for kid, entry in (state.kernel_opt_attempts or {}).items():
         if not isinstance(entry, dict):
             continue
-        if str(entry.get("last_decision", "")).upper() != "KEEP":
+        _dec = str(entry.get("last_decision", "")).upper()
+        # GEAK-only verified-NEEDS_REVIEW promotion (flag-gated, default off): admit a
+        # correctness-verified, high-micro GEAK NEEDS_REVIEW into the integrate queue so its
+        # win is actually E2E-measured. Off => only KEEP queues (today's behavior, byte-identical).
+        _promote = _honest_flag("HL_PROMOTE_VERIFIED_MICRO_NEEDS_REVIEW")
+        try:
+            _thr = float(os.environ.get("HL_VERIFIED_MICRO_PROMOTE_THRESHOLD", "1.10") or 1.10)
+        except ValueError:
+            _thr = 1.10
+        try:
+            _m = float(entry.get("last_micro_speedup") or 0.0)
+        except (TypeError, ValueError):
+            _m = 0.0
+        _geak_nr = (
+            _promote
+            and _dec == "NEEDS_REVIEW"
+            and str(entry.get("last_backend") or "").lower() == "geak"
+            and entry.get("last_correctness_passed") is True
+            and _m >= _thr
+        )
+        if _dec != "KEEP" and not _geak_nr:
             continue
         if kid in integrated_ids or kid in attempted_ids or kid in rejected:
             continue

--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -3023,13 +3023,30 @@ def _kernel_dispatch_attempt_cap(entry: dict[str, Any], *, max_failures: int) ->
     last_decision = str(entry.get("last_decision") or "").strip()
     last_status = str(entry.get("last_status") or "").lower()
     rejected_reason = str(entry.get("rejected_reason") or "").strip()
-    if (
-        failure_count < max_failures
-        and last_decision == ""
-        and last_status in {"failed", "error", "timeout"}
-        and not rejected_reason
-    ):
+    is_retryable_infra = (
+        last_decision == "" and last_status in {"failed", "error", "timeout"} and not rejected_reason
+    )
+    if failure_count < max_failures and is_retryable_infra:
         return max_failures
+    # High-impact infra-retry (flag-gated, default off): a high-GPU%-share kernel
+    # that keeps infra-failing ("didn't finish") gets extra attempts to COMPLETE
+    # before retirement, mirroring the retirement-side cap in record_kernel_opt so
+    # dispatch / record / kernel_work_pending agree. Off => unchanged.
+    if is_retryable_infra and _honest_flag("HL_INFRA_RETRY_HIGH_IMPACT"):
+        try:
+            impact_pct = float(entry.get("last_gpu_pct") or 0.0)
+        except (TypeError, ValueError):
+            impact_pct = 0.0
+        try:
+            min_gpu = float(os.environ.get("HL_INFRA_RETRY_MIN_GPU_PCT", "5.0") or 5.0)
+        except ValueError:
+            min_gpu = 5.0
+        try:
+            infra_max = int(os.environ.get("HL_INFRA_RETRY_MAX", "4") or 4)
+        except ValueError:
+            infra_max = 4
+        if impact_pct >= min_gpu and failure_count < infra_max:
+            return infra_max
     return _DEFAULT_KERNEL_OPT_DISPATCH_ATTEMPTS
 
 
@@ -5589,10 +5606,38 @@ def record_kernel_opt(state, result: dict[str, Any]) -> None:
     # REVERT still retires immediately below, but infra failures get a retry.
     max_failures = resolve_kernel_opt_max_failures()
 
+    # High-impact infra-retry (flag-gated, default off). An infra non-finish
+    # (timeout / preprocess / agent-crash; no verdict) means the attempt "didn't
+    # finish", NOT that the kernel "can't be improved" — evidence: the same FP8
+    # blockscale GEMM that infra-failed-then-was-retired on one workload won 2.9x
+    # on another once GEAK completed. So a high-GPU%-share kernel should not be
+    # permanently retired after only ``max_failures`` non-finishes the way a
+    # REVERT is; give it more attempts to COMPLETE (pairs with GEAK adaptive
+    # budget). REVERT / partial retirement is unchanged; off => byte-identical.
+    infra_failure_cap = max_failures
+    if _honest_flag("HL_INFRA_RETRY_HIGH_IMPACT"):
+        try:
+            _impact_pct = float(_kernel_trace_impact_pct(state, kernel_id) or 0.0)
+        except Exception:  # noqa: BLE001 - impact is best-effort
+            _impact_pct = 0.0
+        # Stamp impact so the dispatch-side cap (_kernel_dispatch_attempt_cap)
+        # widens consistently from the same record.
+        entry["last_gpu_pct"] = _impact_pct
+        try:
+            _min_gpu = float(os.environ.get("HL_INFRA_RETRY_MIN_GPU_PCT", "5.0") or 5.0)
+        except ValueError:
+            _min_gpu = 5.0
+        try:
+            _infra_max = int(os.environ.get("HL_INFRA_RETRY_MAX", "4") or 4)
+        except ValueError:
+            _infra_max = 4
+        if _impact_pct >= _min_gpu:
+            infra_failure_cap = max(max_failures, _infra_max)
+
     should_reject = (
         decision == "REVERT"
         or int(entry.get("partial_count", 0)) >= max_partial
-        or int(entry.get("failure_count", 0)) >= max_failures
+        or int(entry.get("failure_count", 0)) >= infra_failure_cap
     )
     if should_reject:
         if kernel_id not in state.rejected_kernel_ids:

--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -257,13 +257,19 @@ _DEFAULT_GEMM_TUNING_TIMEOUT_SEC = 3 * 60 * 60
 
 @functools.lru_cache(maxsize=1)
 def _default_geak_budget_minutes() -> float:
-    """Default per-GEAK-attempt budget tracking ``$GEAK_RUN_MODE`` (quick→70, full→130); mirrors kernel-agent tool defaults.
+    """Default per-GEAK-attempt budget tracking ``$GEAK_RUN_MODE`` (quick→70, full→180); mirrors kernel-agent tool defaults.
+
+    Full mode gets 180 min (3 h) so preprocess (CK/.cu harness build) + the
+    optimization round + the post-round FULL_BENCHMARK verification all fit;
+    at 130 min the verification step was being starved and every attempt
+    finalized as an unverified NEEDS_REVIEW. Matches the kernel-agent tool
+    default (kernel_optimization.py).
 
     Returns:
         The default per-attempt GEAK budget in minutes.
     """
     raw = (os.environ.get("GEAK_RUN_MODE") or "").strip().lower()
-    return 70.0 if raw == "quick" else 130.0
+    return 70.0 if raw == "quick" else 180.0
 
 
 def _visible_gpu_count() -> int | None:

--- a/inference_optimizer/tests/test_honest_e2e_hardening_unit.py
+++ b/inference_optimizer/tests/test_honest_e2e_hardening_unit.py
@@ -1,0 +1,191 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit coverage for the HL_HONEST_E2E v4-parity hardening helpers:
+umbrella-flag resolution, VRAM util guard, import-grep source confirmation,
+op-fanout de-dup in candidate batching, and umbrella-driven GEAK promotion.
+
+Every behavior is OFF by default, so the "off" assertions below also pin the
+byte-identical-to-legacy contract.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from inference_optimizer.orchestrator import kernel_request_handlers as krh
+
+
+# -- _honest_flag (umbrella + per-fix override) ---------------------------
+def test_honest_flag_default_off(monkeypatch) -> None:
+    monkeypatch.delenv("HL_HONEST_E2E", raising=False)
+    monkeypatch.delenv("HL_KERNEL_OPFANOUT_DEDUP", raising=False)
+    assert krh._honest_flag("HL_KERNEL_OPFANOUT_DEDUP") is False
+
+
+def test_honest_flag_umbrella_enables(monkeypatch) -> None:
+    monkeypatch.setenv("HL_HONEST_E2E", "1")
+    monkeypatch.delenv("HL_KERNEL_OPFANOUT_DEDUP", raising=False)
+    assert krh._honest_flag("HL_KERNEL_OPFANOUT_DEDUP") is True
+
+
+def test_honest_flag_specific_enables(monkeypatch) -> None:
+    monkeypatch.delenv("HL_HONEST_E2E", raising=False)
+    monkeypatch.setenv("HL_KERNEL_OPFANOUT_DEDUP", "yes")
+    assert krh._honest_flag("HL_KERNEL_OPFANOUT_DEDUP") is True
+
+
+def test_honest_flag_specific_falsey_overrides_umbrella(monkeypatch) -> None:
+    monkeypatch.setenv("HL_HONEST_E2E", "1")
+    monkeypatch.setenv("HL_KERNEL_OPFANOUT_DEDUP", "off")
+    assert krh._honest_flag("HL_KERNEL_OPFANOUT_DEDUP") is False
+
+
+# -- _vram_guarded_server_args -------------------------------------------
+def test_vram_guard_off_is_identity(monkeypatch) -> None:
+    monkeypatch.delenv("HL_HONEST_E2E", raising=False)
+    monkeypatch.delenv("HL_INTEGRATE_VRAM_GUARD", raising=False)
+    assert krh._vram_guarded_server_args("--foo bar") == "--foo bar"
+    assert krh._vram_guarded_server_args("") == ""
+
+
+def test_vram_guard_appends_when_on(monkeypatch) -> None:
+    monkeypatch.setenv("HL_INTEGRATE_VRAM_GUARD", "1")
+    monkeypatch.delenv("HL_INTEGRATE_VRAM_UTIL_CAP", raising=False)
+    out = krh._vram_guarded_server_args("--trust-remote-code")
+    assert "--trust-remote-code" in out
+    assert "--gpu-memory-utilization 0.9" in out
+
+
+def test_vram_guard_noop_if_already_set(monkeypatch) -> None:
+    monkeypatch.setenv("HL_INTEGRATE_VRAM_GUARD", "1")
+    existing = "--gpu-memory-utilization 0.7"
+    assert krh._vram_guarded_server_args(existing) == existing
+
+
+def test_vram_guard_umbrella_and_cap(monkeypatch) -> None:
+    monkeypatch.setenv("HL_HONEST_E2E", "1")
+    monkeypatch.delenv("HL_INTEGRATE_VRAM_GUARD", raising=False)
+    monkeypatch.setenv("HL_INTEGRATE_VRAM_UTIL_CAP", "0.85")
+    out = krh._vram_guarded_server_args("")
+    assert out == "--gpu-memory-utilization 0.85"
+
+
+def test_vram_guard_cap_clamped(monkeypatch) -> None:
+    monkeypatch.setenv("HL_INTEGRATE_VRAM_GUARD", "1")
+    monkeypatch.setenv("HL_INTEGRATE_VRAM_UTIL_CAP", "5.0")
+    out = krh._vram_guarded_server_args("")
+    assert out == "--gpu-memory-utilization 0.99"
+
+
+# -- _confirm_source_imported (tri-state) ---------------------------------
+def test_confirm_source_none_inputs() -> None:
+    assert krh._confirm_source_imported("", None) is None
+    assert krh._confirm_source_imported("foo.py", None) is None
+
+
+def test_confirm_source_no_log_is_unknown(tmp_path: Path) -> None:
+    assert krh._confirm_source_imported("foo.py", tmp_path) is None
+
+
+def test_confirm_source_absent_is_false(tmp_path: Path) -> None:
+    (tmp_path / "server.log").write_text("nothing relevant here\n", encoding="utf-8")
+    assert krh._confirm_source_imported("my_kernel.py", tmp_path) is False
+
+
+def test_confirm_source_import_cue_is_true(tmp_path: Path) -> None:
+    (tmp_path / "server.log").write_text("INFO importing my_kernel.py module\n", encoding="utf-8")
+    assert krh._confirm_source_imported("my_kernel.py", tmp_path) is True
+
+
+def test_confirm_source_present_no_cue_is_unknown(tmp_path: Path) -> None:
+    (tmp_path / "server.log").write_text("my_kernel mentioned bare\n", encoding="utf-8")
+    assert krh._confirm_source_imported("my_kernel.py", tmp_path) is None
+
+
+# -- _kernel_result_rank: umbrella-driven GEAK promotion ------------------
+def _geak_nr_result() -> dict:
+    return {
+        "status": "ok",
+        "proposal": {"decision": "NEEDS_REVIEW"},
+        "verification": {
+            "best_backend": "geak",
+            "correctness_passed": True,
+            "micro_speedup": 1.5,
+        },
+    }
+
+
+def test_rank_geak_nr_not_promoted_when_off(monkeypatch) -> None:
+    monkeypatch.delenv("HL_HONEST_E2E", raising=False)
+    monkeypatch.delenv("HL_PROMOTE_VERIFIED_MICRO_NEEDS_REVIEW", raising=False)
+    keep, verified_nr, micro = krh._kernel_result_rank(_geak_nr_result())
+    assert (keep, verified_nr) == (0, 0)
+    assert micro == 1.5
+
+
+def test_rank_geak_nr_promoted_via_umbrella(monkeypatch) -> None:
+    monkeypatch.setenv("HL_HONEST_E2E", "1")
+    monkeypatch.delenv("HL_PROMOTE_VERIFIED_MICRO_NEEDS_REVIEW", raising=False)
+    keep, verified_nr, micro = krh._kernel_result_rank(_geak_nr_result())
+    assert (keep, verified_nr) == (0, 1)
+
+
+def test_rank_nongeak_nr_never_promoted(monkeypatch) -> None:
+    monkeypatch.setenv("HL_HONEST_E2E", "1")
+    r = _geak_nr_result()
+    r["verification"]["best_backend"] = "claude"
+    keep, verified_nr, _ = krh._kernel_result_rank(r)
+    assert (keep, verified_nr) == (0, 0)
+
+
+# -- C2a op-fanout de-dup in _batch_kernel_candidates ---------------------
+def _write_candidates(tmp_path: Path) -> str:
+    """Two ungrouped reusable rows sharing one source_file (op-fanout)."""
+    data = {
+        "hot_kernels": [
+            {
+                "kernel_id": "k1",
+                "reusable_native_kernel": True,
+                "source_file": "/srcroot/fp8_gemm.py",
+                "gpu_pct": 5.0,
+            },
+            {
+                "kernel_id": "k2",
+                "reusable_native_kernel": True,
+                "source_file": "/srcroot/fp8_gemm.py",
+                "gpu_pct": 4.0,
+            },
+        ],
+        "reusable_native_kernel_ids": ["k1", "k2"],
+    }
+    p = tmp_path / "candidates.json"
+    p.write_text(json.dumps(data), encoding="utf-8")
+    return str(p)
+
+
+def test_opfanout_off_keeps_both_rows(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("HL_HONEST_E2E", raising=False)
+    monkeypatch.delenv("HL_KERNEL_OPFANOUT_DEDUP", raising=False)
+    monkeypatch.setenv("HYPERLOOM_KERNEL_OPT_MIN_GPU_PCT", "1.0")
+    sel = krh._batch_kernel_candidates({"candidates_path": _write_candidates(tmp_path)})
+    assert sorted(c["kernel_id"] for c in sel) == ["k1", "k2"]
+
+
+def test_opfanout_on_collapses_and_sums(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HL_KERNEL_OPFANOUT_DEDUP", "1")
+    monkeypatch.setenv("HYPERLOOM_KERNEL_OPT_MIN_GPU_PCT", "1.0")
+    sel = krh._batch_kernel_candidates({"candidates_path": _write_candidates(tmp_path)})
+    assert len(sel) == 1
+    rep = sel[0]
+    assert rep["kernel_id"] == "k1"  # highest-gpu_pct representative
+    assert rep["gpu_pct"] == 9.0  # summed fanned share
+    assert set(rep["opfanout_collapsed_ids"]) == {"k1", "k2"}
+
+
+def test_opfanout_on_via_umbrella(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HL_HONEST_E2E", "1")
+    monkeypatch.delenv("HL_KERNEL_OPFANOUT_DEDUP", raising=False)
+    monkeypatch.setenv("HYPERLOOM_KERNEL_OPT_MIN_GPU_PCT", "1.0")
+    sel = krh._batch_kernel_candidates({"candidates_path": _write_candidates(tmp_path)})
+    assert len(sel) == 1

--- a/inference_optimizer/tests/test_honest_e2e_hardening_unit.py
+++ b/inference_optimizer/tests/test_honest_e2e_hardening_unit.py
@@ -189,3 +189,61 @@ def test_opfanout_on_via_umbrella(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("HYPERLOOM_KERNEL_OPT_MIN_GPU_PCT", "1.0")
     sel = krh._batch_kernel_candidates({"candidates_path": _write_candidates(tmp_path)})
     assert len(sel) == 1
+
+
+# -- high-impact infra-retry cap (the dominant root-cause fix) -------------
+def _infra_entry(failure_count: int, gpu_pct: float) -> dict:
+    """An infra non-finish record (no verdict, status failed) at max_failures."""
+    return {
+        "failure_count": failure_count,
+        "last_decision": "",
+        "last_status": "failed",
+        "rejected_reason": "",
+        "last_gpu_pct": gpu_pct,
+    }
+
+
+def test_infra_retry_off_retires_at_max_failures(monkeypatch) -> None:
+    monkeypatch.delenv("HL_HONEST_E2E", raising=False)
+    monkeypatch.delenv("HL_INFRA_RETRY_HIGH_IMPACT", raising=False)
+    # failure_count == max_failures => legacy retires (cap collapses to default 1).
+    cap = krh._kernel_dispatch_attempt_cap(_infra_entry(2, 26.7), max_failures=2)
+    assert cap == krh._DEFAULT_KERNEL_OPT_DISPATCH_ATTEMPTS
+
+
+def test_infra_retry_on_widens_for_high_impact(monkeypatch) -> None:
+    monkeypatch.setenv("HL_INFRA_RETRY_HIGH_IMPACT", "1")
+    monkeypatch.delenv("HL_INFRA_RETRY_MIN_GPU_PCT", raising=False)
+    monkeypatch.delenv("HL_INFRA_RETRY_MAX", raising=False)
+    # 26.7%-GPU kernel that infra-failed twice still gets attempts up to infra_max (4).
+    cap = krh._kernel_dispatch_attempt_cap(_infra_entry(2, 26.7), max_failures=2)
+    assert cap == 4
+
+
+def test_infra_retry_on_via_umbrella(monkeypatch) -> None:
+    monkeypatch.setenv("HL_HONEST_E2E", "1")
+    monkeypatch.delenv("HL_INFRA_RETRY_HIGH_IMPACT", raising=False)
+    assert krh._kernel_dispatch_attempt_cap(_infra_entry(2, 8.0), max_failures=2) == 4
+
+
+def test_infra_retry_low_impact_not_widened(monkeypatch) -> None:
+    monkeypatch.setenv("HL_INFRA_RETRY_HIGH_IMPACT", "1")
+    # 1%-GPU kernel below the 5% threshold: not widened, retires as legacy.
+    cap = krh._kernel_dispatch_attempt_cap(_infra_entry(2, 1.0), max_failures=2)
+    assert cap == krh._DEFAULT_KERNEL_OPT_DISPATCH_ATTEMPTS
+
+
+def test_infra_retry_does_not_touch_revert(monkeypatch) -> None:
+    monkeypatch.setenv("HL_INFRA_RETRY_HIGH_IMPACT", "1")
+    # A real REVERT (has a verdict) is NOT a retryable infra non-finish — unchanged.
+    entry = _infra_entry(2, 26.7)
+    entry["last_decision"] = "REVERT"
+    cap = krh._kernel_dispatch_attempt_cap(entry, max_failures=2)
+    assert cap == krh._DEFAULT_KERNEL_OPT_DISPATCH_ATTEMPTS
+
+
+def test_infra_retry_exhausted_at_infra_max(monkeypatch) -> None:
+    monkeypatch.setenv("HL_INFRA_RETRY_HIGH_IMPACT", "1")
+    # Once failure_count reaches infra_max, even a high-impact kernel retires.
+    cap = krh._kernel_dispatch_attempt_cap(_infra_entry(4, 26.7), max_failures=2)
+    assert cap == krh._DEFAULT_KERNEL_OPT_DISPATCH_ATTEMPTS

--- a/inference_optimizer/tests/test_kernel_request_handlers_helpers_coverage_unit.py
+++ b/inference_optimizer/tests/test_kernel_request_handlers_helpers_coverage_unit.py
@@ -159,7 +159,7 @@ def test_artifact_paths_other_type() -> None:
 
 # -- _kernel_result_rank ---------------------------------------------------
 def test_kernel_result_rank_non_dict() -> None:
-    assert krh._kernel_result_rank(None) == (0, 0.0)
+    assert krh._kernel_result_rank(None) == (0, 0, 0.0)
 
 
 def test_kernel_result_rank_keep_beats_higher_micro_review() -> None:

--- a/inference_optimizer/tests/test_kernel_request_handlers_units.py
+++ b/inference_optimizer/tests/test_kernel_request_handlers_units.py
@@ -1143,12 +1143,12 @@ class TestDefaultGeakBudgetMinutes:
     @pytest.mark.parametrize(
         "geak_run_mode, expected",
         [
-            (None, 130.0),  # unset -> full default
-            ("", 130.0),  # empty -> full default
-            ("full", 130.0),
-            ("FULL", 130.0),  # case-insensitive
-            ("  full  ", 130.0),  # whitespace tolerated
-            ("garbage", 130.0),  # unknown values fall back to full
+            (None, 180.0),  # unset -> full default
+            ("", 180.0),  # empty -> full default
+            ("full", 180.0),
+            ("FULL", 180.0),  # case-insensitive
+            ("  full  ", 180.0),  # whitespace tolerated
+            ("garbage", 180.0),  # unknown values fall back to full
             ("quick", 70.0),
             ("QUICK", 70.0),
             ("  quick  ", 70.0),
@@ -1176,7 +1176,7 @@ class TestGeakBudgetMinutes:
     @pytest.mark.parametrize(
         "geak_run_mode, expected",
         [
-            ("full", 130.0),
+            ("full", 180.0),
             ("quick", 70.0),
         ],
     )
@@ -1194,7 +1194,7 @@ class TestGeakBudgetMinutes:
         # Pre-fix code would let "" propagate into ``float("")`` and raise.
         monkeypatch.setenv("HYPERLOOM_GEAK_BUDGET_MIN", "")
         monkeypatch.delenv("GEAK_RUN_MODE", raising=False)
-        assert krh._geak_budget_minutes({}) == 130.0
+        assert krh._geak_budget_minutes({}) == 180.0
 
 
 # _default_kernel_batch_parallel — adaptive batch fanout; the legacy 8

--- a/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -2516,11 +2516,11 @@ async def test_trace_analyze_handler_t4_failure_appends_to_existing_warnings(
     assert warnings[1]["code"] == "tracelens_analysis_failed"
 
 
-def test_optimization_wrapper_timeout_sec_geak_default_full_mode_130min(monkeypatch):
-    # Default tracks ``$GEAK_RUN_MODE`` (full -> 130 min) to match the kernel-agent defaults (PR #301).
+def test_optimization_wrapper_timeout_sec_geak_default_full_mode_180min(monkeypatch):
+    # Default tracks ``$GEAK_RUN_MODE`` (full -> 180 min / 3 h) to match the kernel-agent defaults.
     monkeypatch.delenv("GEAK_RUN_MODE", raising=False)
     monkeypatch.delenv("HYPERLOOM_GEAK_BUDGET_MIN", raising=False)
-    assert krh._optimization_wrapper_timeout_sec({"backends": "geak"}) == 130 * 60 + 180
+    assert krh._optimization_wrapper_timeout_sec({"backends": "geak"}) == 180 * 60 + 180
 
 
 def test_optimization_wrapper_timeout_sec_geak_quick_mode_70min(monkeypatch):


### PR DESCRIPTION
## Summary

Single flag-gated mode (`HL_HONEST_E2E`, **default-off ⇒ byte-identical**) that makes GEAK's
honest kernel wins actually reach E2E, with v4-parity hardening. GEAK-scoped where promotion
semantics differ by backend.

### Why
Across the last-30h fleet (3 SGLANG + 11 vLLM), GEAK produces **verified micro speedups up to
3.68×** (e.g. DeepSeek-R1 `gemm_a8w8_blockscale.py` 3.68×/2.71×/1.73×, MiniMax 2.91×) — but they
land in **NEEDS_REVIEW and are never integrated**, so E2E gains came almost entirely from
non-GEAK levers. Only **one** GEAK win was integrated across the whole fleet.

### What

| Fix | Flag | Notes |
|---|---|---|
| **C1** promote correctness-verified high-micro GEAK NEEDS_REVIEW above bare non-KEEP | `HL_PROMOTE_VERIFIED_MICRO_NEEDS_REVIEW` | rank middle-tier + pending-keep gate; GEAK-scoped |
| **C2a** op-fanout de-dup (collapse same-source rows, sum GPU%) | `HL_KERNEL_OPFANOUT_DEDUP` | |
| **C2b** close-time drain | — | emergent from C1 via `_drain_pending_keep_integrates`; no new code |
| **VRAM barrier** on re-baseline util | `HL_INTEGRATE_VRAM_GUARD` | cap via `HL_INTEGRATE_VRAM_UTIL_CAP` (0.90) |
| **import-grep** source confirmation | `HL_CONFIRM_SOURCE_IMPORTED` | advisory; strict sub-flag downgrades KEEP→NR only on positive non-import evidence |
| **Paired same-config A/B** | `HL_INTEGRATE_PAIRED_AB` | opt-in via own flag, **not** under umbrella (unvalidated); full fallback safety |

All gated by the umbrella `HL_HONEST_E2E`; each fix has a per-fix override. Off by default.

### Validation
- **Backtest over all 14 real last-30h fleet workloads** (both frameworks) through the real
  `pending_keep_kernel_ids`: **flag OFF → 0 promotions everywhere (no regression)**;
  **flag ON → 7 sunk GEAK wins promoted across 6 workloads, SGLANG + vLLM**; threshold honored
  (gpt-oss 1.089× not promoted); same-source dedup honored.
- **+20 unit tests** (`test_honest_e2e_hardening_unit.py`); **1631 passing** in the
  kernel/integrate/phase/coordinator regression net; ruff lint clean. Diff: **320 insertions / 4 deletions**.
- Live vLLM E2E run in progress for end-to-end integrate→KEEP confirmation.

### Out of scope (separate GEAK-side item)
GEAK-internal kernel-build failures (`.cu`/CK `preprocess_failed`, harness-gen "no
`@perftest/@benchmark` decorators", `rag-mcp` env crash, `exit 124` timeouts) are tracked
separately — they require GEAK changes, not HL.
