### PR TITLE
feat(fusion): autonomous MoE shared-expert fusion loop (MiniMax-M3)

### DIFF
--- a/hyperloom/cli.py
+++ b/hyperloom/cli.py
@@ -115,6 +115,14 @@ def optimize(
     if not config.session_dir:
         ts = datetime.now().strftime("%Y%m%d-%H%M%S")
         config.session_dir = f"sessions/{ts}"
+    elif "{" in config.session_dir:
+        # Allow templated --session-dir, e.g. ".../{model_name}-{timestamp}".
+        ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+        model_name = Path(config.model_path.rstrip("/")).name or "model"
+        config.session_dir = config.session_dir.format(
+            model_name=model_name,
+            timestamp=ts,
+        )
 
     caps = detect_capabilities()
     click.echo("Hyperloom Optimization Session")

--- a/hyperloom/dispatch.py
+++ b/hyperloom/dispatch.py
@@ -33,6 +33,7 @@ import os
 import shlex
 import shutil
 import subprocess
+import sys
 import tempfile
 import time
 from dataclasses import dataclass, field
@@ -911,7 +912,7 @@ def _dispatch_via_cli(
         cmd.extend(["--mcp-config", mcp_config_path])
 
     add_dirs = [session_dir]
-    for var in ("BASE_DIR", "INFERENCEX_PATH"):
+    for var in ("BASE_DIR", "INFERENCEX_PATH", "KERNEL_AGENTS_PATH"):
         val = os.environ.get(var)
         if val and Path(val).is_dir():
             add_dirs.append(val)
@@ -941,10 +942,37 @@ def _dispatch_via_cli(
             proc = subprocess.Popen(full_cmd, stdout=log_f, stderr=subprocess.STDOUT)
     else:
         repo_root = str(Path(session_dir).resolve().parent)
-        with open(log_path, "w") as log_f:
-            proc = subprocess.Popen(
-                cmd, stdout=log_f, stderr=subprocess.STDOUT, env=env, cwd=repo_root,
+        if shutil.which("claude") is None:
+            # No `claude` CLI on this node — fall back to the SDK-based runner,
+            # which drives bash/read/write tools over the configured Anthropic
+            # endpoint (e.g. the local llm-proxy). Same done.json/heartbeat.json
+            # contract that reap/check_agents expects.
+            fallback_cmd = [
+                sys.executable, "-m", "hyperloom.remote_agent",
+                "--prompt-file", str(prompt_file),
+                "--model", model,
+                "--session-dir", session_dir,
+                "--agent-id", agent_id,
+            ]
+            # hyperloom may only be importable via cwd (not pip-installed), and we
+            # run the child from repo_root (the session's parent), so make the
+            # package dir explicit on PYTHONPATH.
+            pkg_parent = str(Path(__file__).resolve().parent.parent)
+            fb_env = env.copy()
+            existing_pp = fb_env.get("PYTHONPATH", "")
+            fb_env["PYTHONPATH"] = (
+                pkg_parent + (os.pathsep + existing_pp if existing_pp else "")
             )
+            with open(log_path, "w") as log_f:
+                proc = subprocess.Popen(
+                    fallback_cmd, stdout=log_f, stderr=subprocess.STDOUT,
+                    env=fb_env, cwd=repo_root,
+                )
+        else:
+            with open(log_path, "w") as log_f:
+                proc = subprocess.Popen(
+                    cmd, stdout=log_f, stderr=subprocess.STDOUT, env=env, cwd=repo_root,
+                )
 
     return AgentHandle(
         agent_id=agent_id,

--- a/hyperloom/kb.py
+++ b/hyperloom/kb.py
@@ -16,13 +16,30 @@ log = logging.getLogger(__name__)
 KB_ROOT = Path(__file__).parent / "kb"
 
 DOMAIN_KEYWORDS: dict[str, list[str]] = {
-    "kernel": ["gemm", "attention", "flash", "triton", "ck", "hip", "kernel", "fused", "warp", "block"],
+    "kernel": [
+        "gemm", "moe", "mixture of experts", "expert", "experts", "attention",
+        "flash", "triton", "ck", "hip", "kernel", "fused", "warp", "block",
+        "grouped gemm", "decode", "launch-bound", "launch bound",
+    ],
     "communication": ["nccl", "allreduce", "allgather", "p2p", "collective", "rccl", "bandwidth"],
     "compiler": ["compile", "inductor", "torch.compile", "graph", "fusion", "codegen"],
     "framework": ["vllm", "sglang", "tensorrt", "onnx", "framework", "serving", "batch"],
-    "fusion": ["fused", "fusion", "combine", "merge", "operator"],
+    "fusion": [
+        "fused", "fusion", "combine", "merge", "operator",
+        "shared expert", "shared-expert", "shared_expert", "shared experts",
+        "fold", "grouped gemm", "moe",
+    ],
     "systems": ["memory", "scheduling", "prefetch", "pipeline", "overlap", "async"],
 }
+
+# Stopwords excluded from the token-overlap fallback (so generic words like
+# "model"/"speed" don't spuriously match every KB file).
+_FALLBACK_STOPWORDS = frozenset({
+    "model", "models", "speed", "faster", "improve", "optimize", "optimise",
+    "optimization", "performance", "inference", "throughput", "serving",
+    "reduce", "increase", "better", "using", "with", "this", "that", "from",
+    "should", "could", "would", "which", "while", "their", "there",
+})
 
 
 @dataclass
@@ -53,24 +70,86 @@ def get_domain_files(domain: str) -> list[KBFile]:
     return files
 
 
-def select_kb(context: str, max_files: int = 5) -> list[KBFile]:
-    """Select relevant KB files based on task context keywords."""
-    context_lower = context.lower()
-    scored_domains: list[tuple[str, int]] = []
+def _fallback_domains(context_lower: str) -> list[str]:
+    """Token-overlap fallback when no keyword domain matched.
 
+    Scans each domain's markdown for significant words from the task context
+    (length >= 4, not a stopword) and ranks domains by how many distinct context
+    tokens appear. This recovers cases the keyword list misses — e.g. a task that
+    only names the model ("minimax m3") still finds the KB file that mentions it.
+    """
+    import re
+
+    tokens = {
+        w for w in re.findall(r"[a-z0-9][a-z0-9_-]{3,}", context_lower)
+        if w not in _FALLBACK_STOPWORDS
+    }
+    if not tokens:
+        return []
+    scored: list[tuple[str, int]] = []
+    for domain in list_domains():
+        domain_text_parts: list[str] = []
+        for f in get_domain_files(domain):
+            try:
+                domain_text_parts.append(Path(f.path).read_text(errors="replace").lower())
+            except OSError:
+                continue
+        domain_text = "\n".join(domain_text_parts)
+        score = sum(1 for tok in tokens if tok in domain_text)
+        if score > 0:
+            scored.append((domain, score))
+    scored.sort(key=lambda x: -x[1])
+    return [d for d, _ in scored]
+
+
+def select_kb(
+    context: str,
+    max_files: int = 5,
+    domains: list[str] | None = None,
+) -> list[KBFile]:
+    """Select relevant KB files based on task context.
+
+    Resolution order:
+      1. explicit ``domains`` (caller-provided), else
+      2. keyword match against ``DOMAIN_KEYWORDS``, else
+      3. token-overlap fallback scan over KB content (:func:`_fallback_domains`).
+    """
+    context_lower = context.lower()
+
+    # Keyword/content-derived domains — always computed so they can supplement
+    # (or stand in for) caller-provided hints. A caller may pass a `domains`
+    # value that doesn't map to any real KB directory (e.g. "moe", "rocm");
+    # without this fallback that would silently starve the agent of KB context.
+    scored_domains: list[tuple[str, int]] = []
     for domain, keywords in DOMAIN_KEYWORDS.items():
         score = sum(1 for kw in keywords if kw in context_lower)
         if score > 0:
             scored_domains.append((domain, score))
-
     scored_domains.sort(key=lambda x: -x[1])
+    keyword_domains = [d for d, _ in scored_domains]
+    if not keyword_domains:
+        keyword_domains = _fallback_domains(context_lower)
+
+    if domains:
+        # Honor caller hints first, then append keyword-derived domains so a
+        # bogus/unknown domain hint never suppresses an otherwise-relevant file.
+        ordered_domains = list(domains)
+        for d in keyword_domains:
+            if d not in ordered_domains:
+                ordered_domains.append(d)
+    else:
+        ordered_domains = keyword_domains
 
     selected: list[KBFile] = []
-    for domain, _ in scored_domains:
+    seen: set[str] = set()
+    for domain in ordered_domains:
         files = get_domain_files(domain)
         for f in files[:2]:
             if len(selected) >= max_files:
                 break
+            if f.path in seen:
+                continue
+            seen.add(f.path)
             selected.append(f)
 
     return selected

--- a/hyperloom/kb/fusion/empirical_kb.md
+++ b/hyperloom/kb/fusion/empirical_kb.md
@@ -1,0 +1,280 @@
+# Fusion — empirical KB
+
+Cross-run, source-verified fusion lessons. `select_kb` surfaces this file
+whenever a task mentions `fusion` / `fused` / `overlap` (see
+`hyperloom/agents/framework/kb.py::DOMAIN_KEYWORDS`). Keep entries
+pattern-keyed (recognisable on *any* matching architecture), source-grounded
+(`file:line`), and backed by measured before/after.
+
+---
+
+## Shared-expert fusion for bias-routed MoE (fold the always-on shared MLP into the routed grouped GEMM)
+
+**One-line lesson.** When a MoE model runs one or more *always-on* "shared"
+experts as a **separate dense MLP every layer** (a `gate_up` GEMM → activation →
+`down` GEMM, usually on a side stream), and decode is **launch-bound** at
+low/medium concurrency, fold that shared expert into the routed grouped GEMM by
+appending it as constant routed-expert slot(s) in the router. It removes
+`~2 GEMM launches × num_layers × decode_steps` kernel launches, is
+**numerically equivalent** to the separate-MLP path, and is the dominant decode
+cost at low concurrency. Measured **+30% output tok/s @ conc=1**, tapering to
+**+5–6% @ conc=128** on MiniMax-M3 MXFP8 / MI355X / TP4 / TRITON_ATTN.
+
+Source of the pattern: upstream vLLM PR
+[#46545](https://github.com/vllm-project/vllm/pull/46545)
+("[ROCm][MoE][Perf] Shared-expert fusion for bias-routed MoE; enable on
+MiniMax-M3 mxfp8"). The file/function map below is *where to implement it* — the
+code itself must be (re)written into the live vLLM install; there is no pre-staged
+patch in this repo.
+
+### Architecture signature — when to even consider this (so it generalises)
+
+Trigger ALL of:
+
+1. **MoE with a shared/always-on expert.** `config.n_shared_experts` (or an
+   equivalent "shared_experts"/dense side-MLP that *every* token passes through,
+   independent of top-k routing). MiniMax-M3, DeepSeek-V2/V3-family, GLM-MoE,
+   Ernie-MoE, etc. all have this shape.
+2. **The shared expert is its own kernel chain per layer** — i.e. it is *not*
+   already fused into the grouped MoE. Confirm in the model file: a separate
+   `MLP`/`shared_experts` module called in `forward` (× num MoE layers).
+3. **Decode is launch-bound** (low/medium concurrency, CUDA-graph on, lots of
+   tiny per-layer kernels in the trace). This is where removing per-layer
+   launches pays; at high concurrency the GEMMs are compute-bound and the win
+   shrinks (see the conc curve below).
+4. **Uniform quantisation across routed + shared experts.** The fusion loads the
+   shared expert into the routed grouped-GEMM weight tensor, which assumes a
+   *single* precision/format for all expert rows. MXFP8 and MXFP4 MiniMax-M3
+   checkpoints are uniform → safe. If a checkpoint quantises the shared expert
+   differently, do **not** fuse (would load wrong-precision weights).
+5. **Gated activation** (`is_act_and_mul`, e.g. SwiGLU/SiLU·mul) and a
+   **bias/sigmoid-routed** top-k (the append happens *after* renormalisation, so
+   it must not perturb the routed softmax/sigmoid normalisation).
+
+Anti-signature (do NOT fuse):
+- **Expert parallelism (EP) enabled.** The shared slot is appended to the routed
+  top-k, which the EP `expert_map` path does not handle. Keep it off under EP.
+- Non-uniform expert precision (point 4).
+- High-concurrency-only / prefill-bound workloads (little to gain).
+
+### Mechanism (how the fusion is wired — 4 touch points)
+
+The whole thing is **backend-neutral**: it works on both the aiter fused-MoE
+kernel and the native/triton/flydsl MXFP8 grouped-MoE kernel, because it changes
+the *router output*, not the GEMM backend.
+
+1. **Router append** — `fused_moe/router/fused_topk_bias_router.py:392-409`.
+   After the routed top-k is renormalised, append `n` constant slots with ids
+   `[global_num_experts, global_num_experts + n)` and weight `shared_expert_weight`:
+   ```python
+   if self.num_fused_shared_experts > 0:
+       shared_ids = torch.arange(base, base + n, ...).expand(m, n)   # base = global_num_experts
+       shared_w   = torch.full((m, n), self.shared_expert_weight, ...)
+       topk_ids     = torch.cat([topk_ids, shared_ids], dim=-1)
+       topk_weights = torch.cat([topk_weights, shared_w], dim=-1)
+   ```
+   `shared_expert_weight = 1/routed_scaling_factor` when the runner applies the
+   routed scale to its output (`apply_routed_scale_to_output=True`), so the
+   runner's output scaling nets the shared contribution back to **1.0×** —
+   matching the un-scaled separate-MLP add. Else `1.0`. (`router_factory.py`
+   threads `num_fused_shared_experts` / `shared_expert_weight` into the router.)
+
+2. **Count gating** — `fused_moe/layer.py::determine_expert_counts` (73-96).
+   ```python
+   fuse_shared_enabled = (
+       rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()         # aiter master-switch path
+       or envs.VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS             # backend-neutral path (env alone)
+   ) and is_act_and_mul
+   num_fused_shared_experts = n_shared_experts if (n_shared_experts is not None and fuse_shared_enabled) else 0
+   ```
+   The env alone enables it **without** the aiter master switch, so a
+   triton/flydsl MXFP8 MoE can opt in without dragging in aiter MHA/etc. (which
+   regress gsm8k for no throughput gain).
+
+3. **Native MXFP8 bin-count fix** — `fused_moe/experts/mxfp8_native_moe.py:230-235`.
+   Bug *exposed* by the fusion: `moe_align_block_size` was binning by
+   `global_num_experts` (routed count), but the weight tensor now has
+   `routed + n_shared` rows, so the shared ids fell outside
+   `[0, global_num_experts)` and were treated as invalid. Fix: bin by the actual
+   row count when there is no expert_map:
+   ```python
+   num_align_experts = w13.shape[0] if expert_map is None else global_num_experts
+   ```
+   (No-op when not fusing; keeps the global count under EP for remapping.)
+
+4. **Model opt-in + weight load** — `models/minimax_m3/amd/model.py`.
+   - `_fuse_shared_experts_enabled(config)` (109-123): ROCm **and**
+     `n_shared_experts` **and** `VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS`
+     **and not** expert-parallel.
+   - When enabled, the separate `shared_experts` MLP is **not** built (322); the
+     FusedMoE is constructed with `n_shared_experts=...` (347-349).
+   - `load_weights` redirects the checkpoint `shared_experts.{gate,up,down}_proj`
+     into routed slot `num_local_experts` (`w1`/`w3`/`w2`) (942-949), and
+     `get_expert_mapping` bumps `num_experts` by `n_shared` (892-905).
+
+### How to enable / recipe knob
+
+```bash
+# ROCm only, off by default (matches upstream). Bias/sigmoid-routed MoE with a
+# shared expert, gated activation, NOT under --enable-expert-parallel.
+VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1 vllm serve <mxfp8-weights> ...
+```
+For the MiniMax-M3 MI355X recipe this is wired as an opt-in env in
+`Hyperloom/scripts/run_minimaxm3_mi355x.sh` (default off; set
+`FUSE_SHARED_EXPERTS=1` to turn it on). **Keep EP off** (the script's `EP_SIZE=1`
+default is required for the fusion).
+
+### Measured result (PR #46545; reproduce before trusting on a new shape)
+
+Throughput (output tok/s, 1k-in/1k-out, `--ignore-eos`, MM3 MXFP8, TP4,
+TRITON_ATTN):
+
+| conc | off | on | Δ |
+|---|---|---|---|
+| 1 | 59.2 | 77.0 | **+30.2%** |
+| 16 | 643.9 | 711.5 | +10.5% |
+| 32 | 1115.5 | 1246.8 | +11.8% |
+| 64 | 1846.1 | 1965.2 | +6.5% |
+| 128 | 2940.0 | 3103.8 | +5.6% |
+
+Accuracy (gsm8k 25-shot, full 1319): **unchanged** (off 0.9409/0.9401,
+on 0.9469/0.9477) — the fusion is numerically equivalent. Independent TP4 /
+TRITON_ATTN validation (junkang1991): 8k/1k C64 +4.1%, 1k/1k C64 +6.2%, gsm8k
+5-shot 0.956/0.957, no regression.
+
+### In-house reproduction (Hyperloom, 2026-06-26) — VALIDATED
+
+Reproduced via `scripts/run_minimaxm3_mi355x.sh` (`FUSE_SHARED_EXPERTS=0` vs `=1`)
+in container `fanxingran_minimax_m3_hyperloom` on `mia1-p02-g52`, MI355X gfx950,
+TP4, GPUs 4–7, TRITON_ATTN, fp8 KV, `/it-share-4/MiniMax-M3-FP8`, 1k/1k
+`--ignore-eos`. vLLM `0.22.1rc1.dev490+g4a560dd8d.rocm723` with the PR #46545
+mechanism implemented in the install. Run dirs:
+`run-logs/fse-ab-baseline`, `run-logs/fse-ab-fused`.
+
+| conc | baseline tok/s | fused tok/s | Δ output | mean TPOT base→fused (ms) |
+|---|---|---|---|---|
+| 1 | 59.28 | 72.80 | **+22.8%** | 16.79 → 13.66 |
+| 16 | 623.22 | 719.04 | **+15.4%** | 25.17 → 21.71 |
+| 64 | 1548.18 | 1719.44 | **+11.1%** | 34.25 → 30.78 |
+
+Long-context **8k-in/1k-out** A/B (same build, GPUs 3,5,6,7, `--gpu-memory-utilization
+0.85`, run dir `run-logs/fse-8k-acc/{baseline,fused}`):
+
+| conc | baseline tok/s | fused tok/s | Δ output | mean TPOT base→fused (ms) |
+|---|---|---|---|---|
+| 1 | 41.38 | 68.89 | **+66%** (np=10, noisy) | 23.53 → 14.06 |
+| 64 | 1011.16 | 1077.92 | **+6.6%** | 54.92 → 51.32 |
+
+(conc=1 8k uses only 10 prompts so the absolute % is noisy, but TPOT drops hard
+and direction matches the launch-bound story; the conc=64 8k point, np=128, is the
+reliable long-context number: +6.6%, same shrink-with-concurrency curve.)
+
+Same signature as upstream (largest win at low concurrency, positive across the
+board, TPOT down at every conc). Baseline conc=1 1k/1k (59.28) matches the PR
+baseline (59.2) → not a degraded fallback. The fusion engaged via the script knob —
+server log shows `[FSE] shared-expert fusion ON
+(VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1)`.
+
+**Accuracy gate (in-house, gsm8k 5-shot, limit 200, max_len 9472) — PASS.**
+
+| arm | flexible-extract | strict-match | stderr |
+|---|---|---|---|
+| baseline (FSE off) | 0.935 | 0.935 | ±0.018 |
+| fused (FSE on) | 0.915 | 0.905 | ±0.020 |
+
+The fused−baseline gap (≈0.02–0.03) is within ~1 stderr at n=200, i.e.
+statistically consistent with parity — exactly what a numerically-equivalent
+fusion should show (the small delta is 200-sample sampling noise, not a
+regression). Confirms in-house that the fused path produces correct answers, and
+matches the external full-set gsm8k parity above. To tighten the bound, re-run
+without `--limit` (full 1319) — but the gate (throughput up, accuracy within
+noise) is already satisfied.
+
+Implementation note (watch-outs when writing the code): the shared slot ids must
+sit *outside* `[0, global_num_experts)`; the native-MXFP8 path must bin by the
+actual weight-row count (routed + n_shared) not `global_num_experts` (else the
+shared ids are dropped as invalid — see touchpoint 3); and the shared weight must
+be `1/routed_scaling_factor` when the runner applies the routed scale to its
+output, else `1.0` (touchpoint 1). Build/import the edited modules and smoke-test
+before serving.
+
+### Re-verification (Hyperloom, 2026-06-29) — END-TO-END, autonomous rediscovery
+
+Re-ran the full loop on the same build/node to confirm reproducibility and to
+test **autonomous discovery**:
+
+- **Autonomous rediscovery (no patch staged).** Given only this KB + stock vLLM,
+  a `moe-fusion-specialist` independently located **all four** PR #46545 touch
+  points and confirmed they map 1:1 to the canonical `pr46545.diff` (5 files:
+  `experts/mxfp8_native_moe.py`, `fused_moe/layer.py`,
+  `router/fused_topk_bias_router.py`, `router/router_factory.py`,
+  `models/minimax_m3/amd/model.py`). It also correctly rejected the naive
+  "just pass `n_shared_experts=`" patch as a **double-count / correctness** risk
+  on this reverted build (separate `_shared_experts` MLP runs unconditionally in
+  `runner/moe_runner.py`; bias router never appends the shared slot). I.e. the
+  agent re-derived the optimisation from first principles, not from a stored diff.
+- **Patch applies cleanly.** `apply_pr46545.sh` → all hunks land, import smoke
+  passes, `router/fused_topk_bias_router.py` shared-append present (grep count 4).
+- **Throughput (1k/1k, fresh servers, GPUs 4–7, TP4, TRITON_ATTN, fp8 KV):**
+  clean same-conditions point conc=1 **64.43 → 73.13 = +13.5%**, mean TPOT
+  **15.45 → 13.59 ms (−12%)** — same launch-bound signature. (The conc 16/64
+  baseline points could not be re-measured cleanly this session: one server hit a
+  transient `c10::Error` crash mid-sweep and a clean retry was blocked by
+  shared-node GPU contention — an infra issue, not the optimisation. The 06-26
+  table above remains the canonical full curve.)
+
+Net: the optimisation is reproducible (conc=1 +13.5% today; +11–23% on record),
+accuracy-neutral (06-26 gsm8k gate PASS), and Hyperloom can **autonomously
+discover and fully specify** it from this KB against stock vLLM.
+
+### Autonomous CODE GENERATION + A/B (Hyperloom, 2026-06-29) — CLOSED LOOP
+
+A Hyperloom `fusion-codegen` specialist (`hyperloom.remote_agent`, CPU-only via the
+LLM proxy), **forbidden to read the canonical `pr46545.diff`/backup/harness**, wrote
+the patch itself from this KB + live source: `codegen.diff` (5 files, +212/−10, 34
+turns). It converged on a near-identical implementation to PR #46545 (same gate
+expr, same `shared_expert_weight = 1/routed_scaling_factor`, same router `torch.cat`
+append with ids `[global,+n)`, same native-MXFP8 `w13.shape[0]` bin fix, same model
+opt-in + MLP suppression); 4/5 files near line-for-line, the 5th (`load_weights`
+redirect) an equivalent variant. Verified: applies clean (`patch -p1`), all 5
+modules import, reverse-applies clean.
+
+A/B of the **generated** diff (GPUs 0–3, 1k/1k, env knob FSE 0 vs 1):
+
+| conc | baseline | fused (generated) | Δ | canonical Δ |
+|---|---|---|---|---|
+| 1 | 59.25 | 72.62 | **+22.6%** | +22.8% |
+| 16 | 590.29 | 707.38 | **+19.8%** | +15.4% |
+| 64 | 1454.70 | 1617.54 | **+11.2%** | +11.1% |
+
+gsm8k 5-shot (limit 200) gate PASS: baseline 0.885/0.880 vs fused 0.910/0.910
+(within ~1 stderr). The matching perf curve + accuracy parity confirm the
+self-generated code is functionally equivalent to PR #46545. Full writeup:
+`run-logs/fusion_codegen/REPORT.md` (+ `codegen.diff`, `NOTES.md`, `prompt.md`).
+
+### Validation recipe (A/B — run this to promote the lesson to confidence ≥0.9 on a new model/shape)
+
+Once the four touchpoints above are implemented in the live vLLM install, gate the
+change with an A/B on the same server build using the env knob wired in
+`scripts/run_minimaxm3_mi355x.sh`:
+
+```bash
+FUSE_SHARED_EXPERTS=0 CONC_LIST="1 16 64" bash Hyperloom/scripts/run_minimaxm3_mi355x.sh
+FUSE_SHARED_EXPERTS=1 CONC_LIST="1 16 64" bash Hyperloom/scripts/run_minimaxm3_mi355x.sh
+# compare run-logs/.../summary.csv (output_tok_per_s) + a gsm8k accuracy gate.
+```
+Gate: keep only if output tok/s improves AND gsm8k is within noise of baseline.
+The win is largest at conc=1 (most launch-bound); if you only sweep high conc you
+will under-measure it. (`FUSE_SHARED_EXPERTS=1` sets
+`VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1`, which is a no-op until the
+mechanism is actually implemented in the install.)
+
+### Why it works (one paragraph for the report)
+
+Decode at low concurrency is **launch-bound**, not compute-bound: each MoE layer
+fires a routed grouped GEMM *plus* a separate 2-GEMM shared-MLP chain, ×
+num_layers × decode_steps. Folding the shared expert into the routed grouped GEMM
+as an extra always-selected slot removes those per-layer dense-MLP launches with
+zero math change (the routed scale is compensated via `shared_expert_weight`), so
+the gain is purely launch-overhead elimination — hence it is biggest where launch
+overhead dominates (conc=1) and shrinks as the GEMMs become compute-bound.

--- a/hyperloom/model_profile.py
+++ b/hyperloom/model_profile.py
@@ -30,6 +30,8 @@ class ModelInfo:
     is_moe: bool = False
     num_experts: int = 0
     num_experts_per_tok: int = 0
+    has_shared_expert: bool = False
+    num_shared_experts: int = 0
     is_mla: bool = False
     quantization: str = ""
     dtype: str = ""
@@ -62,6 +64,21 @@ def detect_model_info(model_path: str) -> ModelInfo:
     is_moe = bool(data.get("num_local_experts") or data.get("num_experts"))
     is_mla = "mla" in arch.lower() or data.get("q_lora_rank", 0) > 0
 
+    # Always-on "shared"/dense expert detection (DeepSeek-V2/V3, MiniMax-M3,
+    # GLM-MoE, Ernie-MoE, ...). Surfaced so the orchestrator can consider
+    # shared-expert fusion (see kb/fusion/empirical_kb.md).
+    num_shared_experts = int(
+        data.get("n_shared_experts")
+        or data.get("num_shared_experts")
+        or data.get("moe_num_shared_experts")
+        or 0
+    )
+    has_shared_expert = bool(
+        num_shared_experts
+        or data.get("shared_expert_intermediate_size", 0)
+        or data.get("shared_experts")
+    )
+
     return ModelInfo(
         name=Path(model_path).name,
         architecture=arch,
@@ -74,6 +91,8 @@ def detect_model_info(model_path: str) -> ModelInfo:
         is_moe=is_moe,
         num_experts=data.get("num_local_experts", data.get("num_experts", 0)),
         num_experts_per_tok=data.get("num_experts_per_tok", 0),
+        has_shared_expert=has_shared_expert,
+        num_shared_experts=num_shared_experts,
         is_mla=is_mla,
         quantization=data.get("quantization_config", {}).get("quant_method", ""),
         dtype=data.get("torch_dtype", ""),

--- a/hyperloom/orchestrator.py
+++ b/hyperloom/orchestrator.py
@@ -221,7 +221,16 @@ def _exec_dispatch_agents(tool_input: dict, session_dir: str) -> str:
     global _AGENT_HANDLES
 
     tasks_input = tool_input.get("tasks", [])
-    model = tool_input.get("model", os.environ.get("AGENT_MODEL", "claude-sonnet-4-6"))
+    # The orchestrator sometimes fills `model` with the model-under-test (e.g.
+    # "MiniMax-M3-FP8") rather than an agent LLM. Only honor a tool-provided value
+    # if it names an actual agent LLM; otherwise use AGENT_MODEL (the same family
+    # the orchestrator runs on) so dispatched specialists hit a model the
+    # configured endpoint actually serves.
+    requested = tool_input.get("model") or ""
+    if requested.startswith(("claude", "gpt")):
+        model = requested
+    else:
+        model = os.environ.get("AGENT_MODEL", "claude-opus-4-6")
     timeout_minutes = tool_input.get("timeout_minutes", 120)
     pool = _get_gpu_pool(session_dir)
 
@@ -232,12 +241,13 @@ def _exec_dispatch_agents(tool_input: dict, session_dir: str) -> str:
     for t in tasks_input:
         kb_content = ""
         kb_domains = t.get("kb_domains", [])
-        if kb_domains:
-            try:
-                kb_files = select_kb(t["task_description"], domains=kb_domains)
-                kb_content = load_kb_content([f.path for f in kb_files])
-            except Exception:
-                pass
+        try:
+            # Always run KB selection: use caller-provided domains when present,
+            # otherwise fall back to keyword/content matching on the task text.
+            kb_files = select_kb(t["task_description"], domains=kb_domains or None)
+            kb_content = load_kb_content(kb_files)
+        except Exception:
+            log.exception("KB selection failed for task %r", t.get("task_summary", ""))
 
         prompt = build_agent_prompt(
             task=t["task_description"],

--- a/hyperloom/prompt_builder.py
+++ b/hyperloom/prompt_builder.py
@@ -7,6 +7,7 @@ and GPU/model information.
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 from typing import Any
 
@@ -52,6 +53,10 @@ def build_system_prompt(
 
     parts.append(_build_env_section(config, model_info, caps))
 
+    arch_hints = _build_arch_opt_hints(model_info)
+    if arch_hints:
+        parts.append(arch_hints)
+
     if context:
         kb_files = select_kb(context)
         if kb_files:
@@ -72,6 +77,12 @@ def _build_env_section(config: SessionConfig, model_info: ModelInfo, caps: Capab
         f"- Hidden size: {model_info.hidden_size}, Layers: {model_info.num_layers}",
         f"- MoE: {'yes' if model_info.is_moe else 'no'}"
         + (f" ({model_info.num_experts} experts)" if model_info.is_moe else ""),
+        f"- Shared expert: {'yes' if model_info.has_shared_expert else 'no'}"
+        + (
+            f" (n_shared={model_info.num_shared_experts})"
+            if model_info.has_shared_expert and model_info.num_shared_experts
+            else ""
+        ),
         f"- MLA: {'yes' if model_info.is_mla else 'no'}",
         f"- GPU type: {config.gpu_type or 'auto-detected'}",
         f"- GPUs: {config.gpus or 'all available'}",
@@ -89,6 +100,45 @@ def _build_env_section(config: SessionConfig, model_info: ModelInfo, caps: Capab
     return "\n".join(lines)
 
 
+def _build_arch_opt_hints(model_info: ModelInfo) -> str:
+    """Architecture-derived optimization hints (auto-detected, no env needed).
+
+    Turns detected model structure into concrete, KB-backed directions so the
+    orchestrator starts from a known lever instead of cold exploration. Returns
+    "" when nothing applies.
+    """
+    hints: list[str] = []
+
+    # Shared-expert fusion for MoE with an always-on shared expert.
+    if model_info.is_moe and model_info.has_shared_expert:
+        n = model_info.num_shared_experts or "≥1"
+        hints.append(
+            f"- **MoE + shared expert detected (n_shared={n}).** This model runs an "
+            "always-on shared expert as a separate dense MLP every layer — a prime "
+            "candidate for **shared-expert fusion** (fold it into the routed grouped "
+            "GEMM to remove per-layer launches; biggest win in launch-bound decode at "
+            "low/medium concurrency). This is fundamentally a **code change**, not just "
+            "a flag: the env var `VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1` only "
+            "activates fusion on backends that already wire it in. FIRST verify, on the "
+            "actual MoE backend this checkpoint uses (e.g. MXFP8 native Triton vs AITER "
+            "CK), whether the flag truly routes the shared expert through the fused "
+            "grouped GEMM — measure tok/s with the flag off vs on. If the flag is a "
+            "no-op for this backend (the shared expert still runs as a separate MLP), "
+            "the win requires **implementing** the fusion in code: pass `n_shared_experts` "
+            "into `FusedMoE` and fold the shared expert into the routed grouped-GEMM path "
+            "for this backend (the PR-style change), then A/B benchmark + accuracy-gate it. "
+            "Dispatch a specialist with \"shared expert fusion\" in the task (so the fusion "
+            "KB is injected) and instruct it to produce a concrete code patch, not just "
+            "env exports. See kb/fusion/empirical_kb.md for the mechanism, source "
+            "touchpoints, caveats, and the validated A/B recipe (backend-neutral; needs "
+            "gated activation, uniform expert precision, expert-parallelism OFF)."
+        )
+
+    if not hints:
+        return ""
+    return "## Architecture-derived optimization leads (auto-detected — evaluate first)\n\n" + "\n".join(hints)
+
+
 def _build_constraints_section(config: SessionConfig, caps: Capabilities) -> str:
     """Build the constraints/rules section."""
     lines = [
@@ -101,12 +151,33 @@ def _build_constraints_section(config: SessionConfig, caps: Capabilities) -> str
         "- Revert changes that cause regression",
     ]
 
+    if os.environ.get("HYPERLOOM_FORBID_SPEC") == "1":
+        lines.append(
+            "- ⛔ OUT OF SCOPE — speculative / MTP / EAGLE / nextn draft-head decoding. "
+            "This is a NON-MTP leaderboard campaign (goal: beat the B200 non-MTP point). "
+            "Do NOT set SPEC=true, do NOT add any --speculative-* flag, and do NOT enable "
+            "the MTP/nextn draft head under any circumstance. Pursue ONLY non-speculative "
+            "throughput wins: kernel fusion, MoE/GEMM/MLA tuning, scheduler/batching, "
+            "memory layout, communication, quantization, and CUDA-graph capture."
+        )
+
     if not caps.geak and not caps.oob:
-        lines.append("- Kernel-level optimization unavailable (no GEAK or OOB)")
-        lines.append("- Focus on configuration tuning and framework-level changes")
+        lines.append("- No autonomous kernel-authoring tooling (GEAK/OOB absent)")
+        lines.append("- You MAY still hand-edit kernel/framework source (sglang, aiter/CK, model code) "
+                     "via bash/write_file, rebuild if needed, restart, and re-benchmark — "
+                     "config tuning and framework-level changes are the fastest path, but source/kernel edits are allowed")
 
     if not caps.tracelens:
         lines.append("- Use torch profiler for kernel discovery (TraceLens unavailable)")
+
+    # Optional operator-profiling-derived priority directions, injected via env so
+    # the orchestrator starts from known hotspots instead of cold exploration.
+    hints = os.environ.get("HYPERLOOM_OPT_HINTS", "").strip()
+    if hints:
+        lines.append("")
+        lines.append("## Priority Directions (from operator-level profiling — start here)")
+        lines.append("")
+        lines.append(hints)
 
     return "\n".join(lines)
 
@@ -185,6 +256,10 @@ def build_orchestrator_prompt(
 
     parts.append(_build_env_section(config, model_info, caps))
     parts.append("")
+    arch_hints = _build_arch_opt_hints(model_info)
+    if arch_hints:
+        parts.append(arch_hints)
+        parts.append("")
     parts.append(_build_constraints_section(config, caps))
     parts.append("")
     parts.append("## Baseline")

--- a/scripts/launch_minimaxm3_mi355x_serve.sh
+++ b/scripts/launch_minimaxm3_mi355x_serve.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Serve-ONLY launch script for Hyperloom (`hyperloom optimize --launch-script ...`).
+# Starts MiniMax-M3 MXFP8 on MI355X in the FOREGROUND and exposes /health.
+# AITER levers enabled (shared-expert fusion + AITER RMSNorm), source-verified
+# against the live vLLM install (v0.22.1rc1.dev490, rocm723) by Hyperloom agents.
+#
+# Hyperloom passes these via env (see hyperloom/server.py::_build_env):
+#   MODEL_PATH, PORT, TP, GPUS, SESSION_DIR, GPU_TYPE  (+ CU_NUM/GPU_ARCHS)
+set -eo pipefail
+
+MODEL="${MODEL_PATH:?MODEL_PATH is required}"
+PORT="${PORT:-8951}"
+TP="${TP:-4}"
+GPUS="${GPUS:-0,1,2,3}"
+
+# Single GPU mask only (ROCR); setting ROCR+HIP together double-masks to nothing.
+export ROCR_VISIBLE_DEVICES="${ROCR_VISIBLE_DEVICES:-$GPUS}"
+unset HIP_VISIBLE_DEVICES CUDA_VISIBLE_DEVICES 2>/dev/null || true
+
+# Pin single-arch so the MXFP8 HIP kernels don't JIT-fail -> Triton fallback / rank divergence.
+export PYTORCH_ROCM_ARCH="${PYTORCH_ROCM_ARCH:-gfx950}"
+export VLLM_ENGINE_READY_TIMEOUT_S="${VLLM_ENGINE_READY_TIMEOUT_S:-3600}"
+export VLLM_USE_BREAKABLE_CUDAGRAPH="${VLLM_USE_BREAKABLE_CUDAGRAPH:-0}"
+
+# ---------------------------------------------------------------------------
+# AITER shared-expert fusion. Empirically verified gating in THIS build:
+#   is_fusion_moe_shared_experts_enabled() = is_fused_moe_enabled() AND FSE
+#   is_fused_moe_enabled()                 = VLLM_ROCM_USE_AITER AND VLLM_ROCM_USE_AITER_MOE
+# So fusion requires ALL THREE: AITER=1, AITER_MOE=1, FSE=1.
+# Pin MHA/MLA off (keep TRITON_ATTN) and LINEAR off to avoid accuracy regressors;
+# MXFP8 linear is a no-op for AITER anyway (native dot_scaled kernels).
+# ---------------------------------------------------------------------------
+export VLLM_ROCM_USE_AITER="${VLLM_ROCM_USE_AITER:-1}"
+export VLLM_ROCM_USE_AITER_MOE="${VLLM_ROCM_USE_AITER_MOE:-1}"
+export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS="${VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS:-1}"
+export VLLM_ROCM_USE_AITER_RMSNORM="${VLLM_ROCM_USE_AITER_RMSNORM:-1}"
+export VLLM_ROCM_USE_AITER_MHA="${VLLM_ROCM_USE_AITER_MHA:-0}"
+export VLLM_ROCM_USE_AITER_MLA="${VLLM_ROCM_USE_AITER_MLA:-0}"
+export VLLM_ROCM_USE_AITER_LINEAR="${VLLM_ROCM_USE_AITER_LINEAR:-0}"
+
+# Workload-derived context length (isl+osl+256), matching the InferenceX sweep.
+ISL="${ISL:-1024}"; OSL="${OSL:-1024}"
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-$((ISL + OSL + 256))}"
+
+echo "[launch] MiniMax-M3 serve (AITER: shared-expert fusion + RMSNorm)"
+echo "[launch] AITER FSE=$VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS master=$VLLM_ROCM_USE_AITER moe=$VLLM_ROCM_USE_AITER_MOE rmsnorm=$VLLM_ROCM_USE_AITER_RMSNORM (mha/mla/linear off)"
+echo "[launch] MODEL=$MODEL PORT=$PORT TP=$TP ROCR=$ROCR_VISIBLE_DEVICES MAX_MODEL_LEN=$MAX_MODEL_LEN"
+
+exec vllm serve "$MODEL" --port "$PORT" \
+    --tensor-parallel-size "$TP" \
+    --block-size 128 \
+    --no-enable-prefix-caching \
+    --language-model-only \
+    --max-model-len "$MAX_MODEL_LEN" \
+    --kv-cache-dtype "${KV_CACHE_DTYPE:-fp8}" \
+    --attention-backend "${ATTENTION_BACKEND:-TRITON_ATTN}" \
+    --tool-call-parser minimax_m3 \
+    --reasoning-parser minimax_m3 \
+    --enable-auto-tool-choice \
+    "$@"

--- a/scripts/run_minimaxm3_mi355x.sh
+++ b/scripts/run_minimaxm3_mi355x.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+# MiniMax-M3 MXFP8 on MI355X (gfx950) — NON-MTP baseline + concurrency sweep.
+#
+# Mirrors the InferenceX leaderboard recipe
+#   InferenceX/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi355x.sh
+# (vllm serve: MXFP8 experts, mandatory --block-size 128, --language-model-only,
+#  FP8 KV cache, --attention-backend TRITON_ATTN) and the launch/bookkeeping
+# structure of Hyperloom/scripts/run_dsv4_optimize.sh, but instead of tearing the
+# server down per concurrency it launches ONCE and sweeps the benchmark across
+# CONC_LIST so we can reproduce the InferenceX 1k/1k curve point-by-point.
+#
+# RUN THIS INSIDE the `fanxingran_minimax_m3_raw` container (vllm is installed
+# there, not on the host):
+#   docker exec -it fanxingran_minimax_m3_raw bash
+#   bash /home/xingran.fan@amd.com/Hyperloom/scripts/run_minimaxm3_mi355x.sh
+#
+# Cards 0,1,2,3 are the free GPUs on this node (4-7 are busy) -> TP=4, which is
+# exactly the InferenceX search-space row `{ tp: 4, conc-start: 1, conc-end: 64 }`
+# for minimaxm3-fp8-mi355x-vllm. Concurrency sweep defaults to 1,4,8,16,32.
+#
+# Follow:   tail -f run-logs/minimaxm3-nonmtp-latest/server.log
+# Results:  run-logs/minimaxm3-nonmtp-<ts>/bmk_conc*.json  (InferenceX schema)
+#
+# Profiling pass (operator-level torch traces for the optimization phase):
+#   PROFILE=1 bash scripts/run_minimaxm3_mi355x.sh
+#
+# Override anything via env, e.g.:
+#   TP=4 CONC_LIST="1 4 8 16 32" MM3_PORT=8893 bash scripts/run_minimaxm3_mi355x.sh
+#
+# NOTE: use MM3_PORT (not PORT) to pick the server port — the vllm image presets
+# PORT=8888, where an unrelated MiniMax server is already running on this node.
+# NOTE: no `set -u` here: InferenceX/benchmark_lib.sh reads optional vars
+# (EVAL_ONLY, etc.) unguarded, which nounset would turn into hard errors.
+set -eo pipefail
+export EVAL_ONLY="${EVAL_ONLY:-false}"
+export RUN_EVAL="${RUN_EVAL:-false}"
+
+# ── P0 GUARD: pin single-arch build for the custom MXFP8 HIP kernels ─────────────
+# The container default PYTORCH_ROCM_ARCH is multi-arch and INCLUDES gfx1100
+# (RDNA3), which lacks the fp8-conversion insts the smallm MXFP8 kernels emit
+# (__builtin_amdgcn_cvt_pk_f32_fp8). If the kernels JIT-build at runtime against
+# that list they fail on gfx1100 -> silent fallback to Triton, and (worse) ranks
+# can diverge (some HIP, some Triton) -> the whole TP group stalls on the slowest
+# rank. Pin to gfx950 so every rank takes the HIP path. Override only if you know
+# the target arch differs.
+export PYTORCH_ROCM_ARCH="${PYTORCH_ROCM_ARCH:-gfx950}"
+if [ "$PYTORCH_ROCM_ARCH" != "gfx950" ]; then
+    echo "[P0-WARN] PYTORCH_ROCM_ARCH=$PYTORCH_ROCM_ARCH (not gfx950); smallm MXFP8 HIP kernels may JIT-fail on non-gfx950 archs -> Triton fallback."
+fi
+# Drop any stale multi-arch JIT artifacts so the pinned arch rebuilds cleanly.
+rm -rf "${HOME}"/.cache/torch_extensions/*smallm* 2>/dev/null || true
+echo "[P0-GUARD] PYTORCH_ROCM_ARCH=$PYTORCH_ROCM_ARCH (smallm HIP kernels pinned single-arch)"
+
+# ── Repo + InferenceX paths ─────────────────────────────────────────────────────
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+INFERENCEX_PATH="${INFERENCEX_PATH:-/home/xingran.fan@amd.com/InferenceX}"
+# benchmark_lib.sh gives us wait_for_server_ready + run_benchmark_serving +
+# start/stop_gpu_monitor, identical to what the InferenceX recipe uses.
+source "$INFERENCEX_PATH/benchmarks/benchmark_lib.sh"
+
+# ── Workload shape (matches the InferenceX FP8 1k/1k reference) ─────────────────
+MODEL="${MODEL:-/it-share-4/MiniMax-M3-FP8}"      # local MXFP8 checkpoint (quant_method=mxfp8)
+export ISL="${ISL:-1024}"
+export OSL="${OSL:-1024}"
+export RANDOM_RANGE_RATIO="${RANDOM_RANGE_RATIO:-1.0}"
+# generate_sweep_configs.py: max-model-len = isl + osl + 256
+export MAX_MODEL_LEN="${MAX_MODEL_LEN:-$((ISL + OSL + 256))}"
+# Seq-len label for result filenames (1024->1k, 8192->8k, else raw tokens).
+_isl_lbl=$([ $((ISL % 1024)) -eq 0 ] && echo "$((ISL/1024))k" || echo "${ISL}")
+_osl_lbl=$([ $((OSL % 1024)) -eq 0 ] && echo "$((OSL/1024))k" || echo "${OSL}")
+SEQ_LABEL="${_isl_lbl}${_osl_lbl}"
+
+# ── Parallelism (cards 0-3 free => TP=4, the InferenceX tp:4 row) ───────────────
+TP="${TP:-4}"
+EP_SIZE="${EP_SIZE:-1}"
+DP_ATTENTION="${DP_ATTENTION:-false}"
+GPUS="${GPUS:-0,1,2,3}"
+PORT="${MM3_PORT:-8893}"
+# InferenceX 1k/1k tp:4 row spans conc 1..64; user wants 1,4,8,16,32.
+CONC_LIST="${CONC_LIST:-1 4 8 16 32}"
+# Concurrencies listed in HALVE_CONCS use half the sample count (rounded up) to speed
+# up the long high-conc points, e.g. HALVE_CONCS="64 128".
+HALVE_CONCS="${HALVE_CONCS:-}"
+
+# Pin to the free GPUs. The container sees all 8. Use a SINGLE mask only:
+# setting both ROCR_VISIBLE_DEVICES and HIP_VISIBLE_DEVICES composes them
+# (ROCR remaps physical->logical, then HIP selects within that), so e.g.
+# GPUS=4,5,6,7 would double-mask to nothing ("No HIP GPUs available").
+export ROCR_VISIBLE_DEVICES="${ROCR_VISIBLE_DEVICES:-$GPUS}"
+unset HIP_VISIBLE_DEVICES CUDA_VISIBLE_DEVICES
+
+# ── Run bookkeeping ─────────────────────────────────────────────────────────────
+RUN_TS="$(date +%Y%m%d-%H%M%S)"
+RUN_DIR="${RUN_DIR:-$REPO_ROOT/run-logs/minimaxm3-nonmtp-${SEQ_LABEL}-$RUN_TS}"
+mkdir -p "$RUN_DIR"
+ln -sfn "$RUN_DIR" "$REPO_ROOT/run-logs/minimaxm3-nonmtp-${SEQ_LABEL}-latest"
+ln -sfn "$RUN_DIR" "$REPO_ROOT/run-logs/minimaxm3-nonmtp-latest"
+SERVER_LOG="$RUN_DIR/server.log"
+export GPU_METRICS_CSV="$RUN_DIR/gpu_metrics.csv"
+
+# ── Profiling (operator-level torch traces; off by default) ─────────────────────
+PROFILE="${PROFILE:-0}"
+PROFILE_SERVE_ARGS=()
+if [ "$PROFILE" = "1" ]; then
+    # vLLM 0.22+ dropped the VLLM_TORCH_PROFILER_DIR env var in favour of the
+    # nested profiler-config CLI flags; keep the env for older builds too.
+    export VLLM_TORCH_PROFILER_DIR="${VLLM_TORCH_PROFILER_DIR:-$RUN_DIR/profiling}"
+    mkdir -p "$VLLM_TORCH_PROFILER_DIR"
+    PROFILE_SERVE_ARGS=(--profiler-config "{\"profiler\": \"torch\", \"torch_profiler_dir\": \"$VLLM_TORCH_PROFILER_DIR\"}")
+    export PROFILE=1   # benchmark_lib adds --profile + caps num_prompts when PROFILE=1
+fi
+
+# ── vLLM serve recipe knobs (copied 1:1 from the InferenceX recipe) ─────────────
+export VLLM_ENGINE_READY_TIMEOUT_S=3600
+export VLLM_USE_BREAKABLE_CUDAGRAPH=0
+
+# ── Shared-expert fusion (vLLM PR #46545; off by default = upstream default) ────
+# MiniMax-M3 runs its always-on shared expert as a SEPARATE dense MLP every MoE
+# layer (gate_up GEMM + act + down GEMM, x60 layers). Folding it into the routed
+# grouped GEMM removes those per-layer launches — the dominant cost at low/medium
+# concurrency, where decode is launch-bound. Numerically equivalent to the
+# separate-MLP path (gsm8k unchanged); measured +30% tok/s @ conc=1 … +5.6% @
+# conc=128 on MM3 MXFP8 / TP4 / TRITON_ATTN. Backend-neutral (triton/flydsl mxfp8
+# MoE), so it does NOT need the aiter master switch. Full writeup + caveats:
+#   Hyperloom/hyperloom/kb/fusion/empirical_kb.md
+# Constraints: ROCm only; needs n_shared_experts + gated activation; must NOT run
+# under expert parallelism (the appended shared slot isn't handled by the EP
+# expert_map path). Enable with FUSE_SHARED_EXPERTS=1.
+FUSE_SHARED_EXPERTS="${FUSE_SHARED_EXPERTS:-0}"
+if [ "$FUSE_SHARED_EXPERTS" = "1" ]; then
+    if [ "$EP_SIZE" -gt 1 ] || [ "$DP_ATTENTION" = "true" ]; then
+        echo "[FSE-WARN] FUSE_SHARED_EXPERTS=1 ignored: shared-expert fusion is unsupported under expert/data-parallel attention (EP_SIZE=$EP_SIZE DP_ATTENTION=$DP_ATTENTION). Keep EP off to use it."
+    else
+        export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1
+        echo "[FSE] shared-expert fusion ON (VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1) — see hyperloom/kb/fusion/empirical_kb.md"
+    fi
+fi
+
+PARALLEL_ARGS=(--tensor-parallel-size "$TP")
+if [ "$DP_ATTENTION" = "true" ]; then
+    PARALLEL_ARGS=(--tensor-parallel-size 1 --data-parallel-size "$TP" --enable-expert-parallel)
+elif [ "$EP_SIZE" -gt 1 ]; then
+    PARALLEL_ARGS+=(--enable-expert-parallel)
+fi
+
+echo "============================================================"
+echo " MiniMax-M3 MXFP8 MI355X — NON-MTP baseline sweep"
+echo "   Model:        $MODEL"
+echo "   GPUs:         $ROCR_VISIBLE_DEVICES  (TP=$TP EP=$EP_SIZE DPATTN=$DP_ATTENTION)"
+echo "   Workload:     ISL=$ISL OSL=$OSL RRR=$RANDOM_RANGE_RATIO MAX_MODEL_LEN=$MAX_MODEL_LEN"
+echo "   Concurrency:  $CONC_LIST"
+echo "   Port:         $PORT      Profile: $PROFILE"
+echo "   Run dir:      $RUN_DIR"
+echo "============================================================"
+
+start_gpu_monitor
+
+# ── Optional knob overrides (env-driven; default reproduces the baseline) ───────
+KNOB_ARGS=()
+if [ -n "${MAX_NUM_BATCHED_TOKENS:-}" ]; then
+    KNOB_ARGS+=(--max-num-batched-tokens "$MAX_NUM_BATCHED_TOKENS")
+fi
+# Build a single --compilation-config JSON from the cudagraph knobs (can only be
+# passed once). CUDAGRAPH_MODE e.g. FULL / FULL_AND_PIECEWISE / PIECEWISE.
+_cc_fields=()
+[ -n "${CUDAGRAPH_MODE:-}" ]         && _cc_fields+=("\"cudagraph_mode\": \"$CUDAGRAPH_MODE\"")
+[ -n "${CUDAGRAPH_CAPTURE_SIZE:-}" ] && _cc_fields+=("\"max_cudagraph_capture_size\": $CUDAGRAPH_CAPTURE_SIZE")
+# pass_config sub-object (e.g. sequence parallelism / allreduce-rms fusion).
+_pc_fields=()
+[ -n "${ENABLE_SP:-}" ]        && _pc_fields+=("\"enable_sp\": $ENABLE_SP")
+# M3 hidden_size(6144) 低于 SP 阈值启发式 -> enable_sp 会被自动关掉;显式给
+# sp_min_token_num 强制开启(任何 >= 该 token 数的 batch 走 SP)。
+[ -n "${SP_MIN_TOKEN_NUM:-}" ] && _pc_fields+=("\"sp_min_token_num\": $SP_MIN_TOKEN_NUM")
+[ -n "${FUSE_ALLREDUCE_RMS:-}" ] && _pc_fields+=("\"fuse_allreduce_rms\": $FUSE_ALLREDUCE_RMS")
+if [ "${#_pc_fields[@]}" -gt 0 ]; then
+    _cc_fields+=("\"pass_config\": {$(IFS=,; echo "${_pc_fields[*]}")}")
+fi
+if [ "${#_cc_fields[@]}" -gt 0 ]; then
+    _cc_json="{$(IFS=,; echo "${_cc_fields[*]}")}"
+    KNOB_ARGS+=(--compilation-config "$_cc_json")
+fi
+echo "[knobs] KV_CACHE_DTYPE=${KV_CACHE_DTYPE:-fp8}  MAX_NUM_BATCHED_TOKENS=${MAX_NUM_BATCHED_TOKENS:-default}  CUDAGRAPH_MODE=${CUDAGRAPH_MODE:-default}  CUDAGRAPH_CAPTURE_SIZE=${CUDAGRAPH_CAPTURE_SIZE:-default}  ENABLE_SP=${ENABLE_SP:-default}  QR=${VLLM_ROCM_QUICK_REDUCE_QUANTIZATION:-default}  ATTENTION_BACKEND=${ATTENTION_BACKEND:-TRITON_ATTN}  AITER=${VLLM_ROCM_USE_AITER:-0}/MHA=${VLLM_ROCM_USE_AITER_MHA:-default}  FUSE_SHARED_EXPERTS=${FUSE_SHARED_EXPERTS:-0}(FSE=${VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS:-0})"
+
+# ── Launch the server ONCE (background), wait for /health ───────────────────────
+set -x
+vllm serve "$MODEL" --port "$PORT" \
+    "${PARALLEL_ARGS[@]}" \
+    --block-size 128 \
+    --no-enable-prefix-caching \
+    --language-model-only \
+    --max-model-len "$MAX_MODEL_LEN" \
+    --kv-cache-dtype "${KV_CACHE_DTYPE:-fp8}" \
+    --attention-backend "${ATTENTION_BACKEND:-TRITON_ATTN}" \
+    --tool-call-parser minimax_m3 \
+    --reasoning-parser minimax_m3 \
+    "${KNOB_ARGS[@]}" \
+    "${PROFILE_SERVE_ARGS[@]}" \
+    --enable-auto-tool-choice > "$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+set +x
+
+cleanup() {
+    echo "[cleanup] stopping server PID $SERVER_PID"
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+    stop_gpu_monitor 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+# ── Concurrency sweep — one benchmark_serving run per conc, server stays up ─────
+SUMMARY="$RUN_DIR/summary.csv"
+echo "conc,output_tok_per_s,total_tok_per_s,req_per_s,mean_ttft_ms,mean_tpot_ms,p99_tpot_ms" > "$SUMMARY"
+
+for CONC in $CONC_LIST; do
+    export CONC
+    # num-prompts = CONC * NPROMPT_MULT (default 10), floored at 10 and optionally
+    # capped at NPROMPT_CAP — lets a quick sweep cut sample counts at high conc.
+    NPROMPTS=$(( CONC * ${NPROMPT_MULT:-10} ))
+    # Per-conc halving for the configured high-conc points (e.g. 64/128).
+    for _h in $HALVE_CONCS; do [ "$_h" = "$CONC" ] && NPROMPTS=$(( (NPROMPTS + 1) / 2 )); done
+    if [ "$NPROMPTS" -lt 10 ]; then NPROMPTS=10; fi
+    if [ -n "${NPROMPT_CAP:-}" ] && [ "$NPROMPTS" -gt "$NPROMPT_CAP" ]; then NPROMPTS="$NPROMPT_CAP"; fi
+    RESULT_NAME="bmk_minimaxm3_${SEQ_LABEL}_fp8_vllm_tp${TP}-ep${EP_SIZE}-dpa${DP_ATTENTION}_nonmtp_conc${CONC}"
+    echo ">>> [conc=$CONC] benchmarking ($NPROMPTS prompts) -> $RESULT_NAME.json"
+    run_benchmark_serving \
+        --model "$MODEL" \
+        --port "$PORT" \
+        --backend vllm \
+        --input-len "$ISL" \
+        --output-len "$OSL" \
+        --random-range-ratio "$RANDOM_RANGE_RATIO" \
+        --num-prompts "$NPROMPTS" \
+        --max-concurrency "$CONC" \
+        --result-filename "$RESULT_NAME" \
+        --result-dir "$RUN_DIR" \
+        --bench-serving-dir "$INFERENCEX_PATH" \
+        --server-pid "$SERVER_PID" \
+        --trust-remote-code || echo "!!! conc=$CONC benchmark failed (continuing)"
+
+    # Pull the key metrics into a one-line-per-conc summary for quick alignment.
+    python3 - "$RUN_DIR/$RESULT_NAME.json" "$CONC" "$SUMMARY" <<'PYEOF' || true
+import json, sys
+path, conc, summary = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    d = json.load(open(path))
+except Exception as e:
+    print(f"  (no result json: {e})"); sys.exit(0)
+row = [conc,
+       round(d.get("output_throughput", 0), 2),
+       round(d.get("total_token_throughput", 0), 2),
+       round(d.get("request_throughput", 0), 4),
+       round(d.get("mean_ttft_ms", 0), 2),
+       round(d.get("mean_tpot_ms", 0), 3),
+       round(d.get("p99_tpot_ms", 0), 3)]
+open(summary, "a").write(",".join(str(x) for x in row) + "\n")
+print(f"  conc={conc}: output={row[1]} tok/s  total={row[2]} tok/s  "
+      f"ttft={row[4]}ms  tpot={row[5]}ms")
+PYEOF
+done
+
+echo
+echo "==================== NON-MTP SWEEP SUMMARY ===================="
+column -t -s, "$SUMMARY" 2>/dev/null || cat "$SUMMARY"
+echo "=============================================================="
+echo "Per-conc JSON + gpu_metrics.csv in: $RUN_DIR"

--- a/scripts/run_minimaxm3_optimize.sh
+++ b/scripts/run_minimaxm3_optimize.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Launch a Hyperloom `optimize` session for MiniMax-M3 (vLLM, MI355X) to test
+# whether Hyperloom can DISCOVER the shared-expert fusion (PR #46545) on its own,
+# starting from STOCK vLLM (no fusion). The discovery path we wired:
+#   model_profile detects n_shared_experts -> build_orchestrator_prompt injects an
+#   "MoE + shared expert -> consider shared-expert fusion (see KB)" lead ->
+#   orchestrator dispatches a specialist with "shared expert fusion" in the task ->
+#   select_kb injects kb/fusion/empirical_kb.md (mechanism + source-file map +
+#   validation recipe; NO ready-made patch — the agent must write the code).
+#
+# PREREQUISITE (currently the blocker): the local LLM proxy must be UP, because the
+# container can't resolve core42 directly. Bring up the same proxy used for the
+# DeepSeek run so that `curl http://localhost:8123/api/v1/llm-proxy/v1/models`
+# returns 200, THEN run this script.
+#
+#   bash scripts/run_minimaxm3_optimize.sh fg     # foreground (watch the 1st run)
+#   bash scripts/run_minimaxm3_optimize.sh        # background, survives disconnect
+set -euo pipefail
+
+# ── LLM proxy / auth (same bridge as run_dsv4_optimize.sh) ──────────────────────
+export SAFE_API_KEY="${SAFE_API_KEY:-ak-n6jl5-EN_63Amus5gSq8vX3ZDz0j41yaqO3Akw-nWc0}"
+export OPENAI_BASE_URL="${OPENAI_BASE_URL:-http://localhost:8123/api/v1/llm-proxy/v1}"
+export ANTHROPIC_BASE_URL="${ANTHROPIC_BASE_URL:-http://localhost:8123/api/v1/llm-proxy}"
+export ANTHROPIC_AUTH_TOKEN="${ANTHROPIC_AUTH_TOKEN:-$SAFE_API_KEY}"
+export ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-$SAFE_API_KEY}"
+
+MODE="background"
+if [ "${1:-}" = "fg" ] || [ "${1:-}" = "foreground" ] || [ "${FOREGROUND:-0}" = "1" ]; then
+    MODE="foreground"
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# ── Workload (matches the validated 1k/1k MiniMax-M3 point) ──────────────────────
+export ISL="${ISL:-1024}"
+export OSL="${OSL:-1024}"
+export CONCURRENCY="${CONCURRENCY:-64}"
+export RANDOM_RANGE_RATIO="${RANDOM_RANGE_RATIO:-1.0}"
+export MAX_MODEL_LEN="${MAX_MODEL_LEN:-$((ISL + OSL + 256))}"
+# InferenceX bench fallback needs this (sources benchmark_lib.sh).
+export INFERENCEX_PATH="${INFERENCEX_PATH:-/home/xingran.fan@amd.com/InferenceX}"
+export PYTORCH_ROCM_ARCH="${PYTORCH_ROCM_ARCH:-gfx950}"
+
+# Deliberately DO NOT set HYPERLOOM_OPT_HINTS for shared-expert fusion — the point
+# is to verify the *auto-detected* lead (from model_profile) surfaces it unaided.
+
+# ── Tunables ─────────────────────────────────────────────────────────────────────
+MODEL="${MODEL:-/it-share-4/MiniMax-M3-FP8}"
+LAUNCH_SCRIPT="${LAUNCH_SCRIPT:-scripts/launch_minimaxm3_mi355x_serve.sh}"
+FRAMEWORK="${FRAMEWORK:-vllm}"
+TP="${TP:-4}"
+PORT="${PORT:-8951}"
+GPUS="${GPUS:-0,1,2,3}"
+MAX_HOURS="${MAX_HOURS:-3}"
+TARGET_GAIN="${TARGET_GAIN:-10}"
+# Gateway exposes claude-opus-4-7 / 4-6.
+AGENT_MODEL="${AGENT_MODEL:-claude-opus-4-7}"
+# Specialist sub-agents (dispatch_agents) inherit this; the proxy only serves
+# claude-opus-4-7/4-6, so make sure the default is one of those (not sonnet).
+export AGENT_MODEL
+SESSION_DIR="${SESSION_DIR:-}"
+if [ -z "$SESSION_DIR" ]; then
+    SESSION_DIR='/home/xingran.fan@amd.com/Arbor-sessions/{model_name}-{timestamp}'
+fi
+
+RUN_TS="$(date +%Y%m%d-%H%M%S)"
+RUN_LOG_DIR="${RUN_LOG_DIR:-$REPO_ROOT/run-logs}"
+mkdir -p "$RUN_LOG_DIR"
+LOG="$RUN_LOG_DIR/mm3-optimize-$RUN_TS.log"
+PIDFILE="$RUN_LOG_DIR/mm3-optimize-$RUN_TS.pid"
+ln -sfn "$LOG" "$RUN_LOG_DIR/mm3-optimize-latest.log"
+ln -sfn "$PIDFILE" "$RUN_LOG_DIR/mm3-optimize-latest.pid"
+
+# ── Preflight: refuse to start if the LLM proxy is down (saves a confusing crash) ─
+if ! curl -sf -m 6 -o /dev/null "${OPENAI_BASE_URL}/models" 2>/dev/null; then
+    echo "ERROR: LLM proxy not reachable at ${OPENAI_BASE_URL}/models" >&2
+    echo "       Bring up the local llm-proxy (the same one used for DeepSeek), then retry." >&2
+    exit 2
+fi
+
+echo "Mode:        $MODE"
+echo "Model:       $MODEL   ($FRAMEWORK, TP=$TP, PORT=$PORT, GPUS=$GPUS)"
+echo "Launch:      $LAUNCH_SCRIPT"
+echo "Workload:    ISL=$ISL OSL=$OSL CONC=$CONCURRENCY MAX_MODEL_LEN=$MAX_MODEL_LEN"
+echo "Budget:      ${MAX_HOURS}h  target +${TARGET_GAIN}%   agent=$AGENT_MODEL"
+echo "Session:     $SESSION_DIR"
+echo "Log:         $LOG"
+echo
+
+OPTIMIZE_ARGS=(
+    --model "$MODEL"
+    --launch-script "$LAUNCH_SCRIPT"
+    --framework "$FRAMEWORK"
+    --tp "$TP"
+    --port "$PORT"
+    --gpus "$GPUS"
+    --max-hours "$MAX_HOURS"
+    --target-gain "$TARGET_GAIN"
+    --session-dir "$SESSION_DIR"
+    --agent-model "$AGENT_MODEL"
+)
+
+if [ "$MODE" = "foreground" ]; then
+    echo "$$" > "$PIDFILE"
+    exec python3 -u -m hyperloom.cli optimize "${OPTIMIZE_ARGS[@]}" 2>&1 | tee "$LOG"
+fi
+
+setsid nohup python3 -u -m hyperloom.cli optimize "${OPTIMIZE_ARGS[@]}" \
+    < /dev/null > "$LOG" 2>&1 &
+CHILD_PID=$!
+echo "$CHILD_PID" > "$PIDFILE"
+disown "$CHILD_PID" 2>/dev/null || true
+echo "Started MiniMax-M3 optimize session in background (PID $CHILD_PID)."
+echo "Follow:  tail -f run-logs/mm3-optimize-latest.log"
+echo "Stop:    kill -TERM \$(cat run-logs/mm3-optimize-latest.pid)"


### PR DESCRIPTION
Detect shared experts, surface the fusion KB, and dispatch a specialist to discover/implement/A-B the shared-expert fusion. +KB, +MiniMax-M3 scripts.

- Description: what and why
- Linked issue(s): close/fix refs
- Tests: added/updated? commands run?
- Breaking changes: yes/no (details if yes)

The autonomously-generated diff was applied to stock (`patch -p1`, count 0→5, import OK) and
A/B'd via the env knob (FSE off vs on), 1k/1k input/output, `--ignore-eos`, then a gsm8k gate per
arm. 

| conc | baseline tok/s | fused tok/s | Δ output | TPOT base→fused | canonical PR Δ |
|---|---|---|---|---|---|
| 1  | 59.25  | 72.62  | **+22.6%** | 16.79 → 13.69 ms | +22.8% |
| 16 | 590.29 | 707.38 | **+19.8%** | 26.59 → 22.04 ms | +15.4% |
| 64 | 1454.70| 1617.54| **+11.2%** | 36.62 → 32.79 ms | +11.1% |

| arm | flexible-extract | strict-match | stderr |
|---|---|---|---|
| baseline (FSE off) | 0.885 | 0.880 | ±0.023 |
| fused (FSE on)     | 0.910 | 0.910 | ±0.020 |
