### PR TITLE
feat: honest E2E verdict (paired A/B, promotion) + faithful dispatch (dominant-kernel op-source, real dims, comm-aware select)

### DIFF
--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -98,6 +98,14 @@ def _vram_guarded_server_args(extra_args: str) -> str:
     """
     if not _honest_flag("HL_INTEGRATE_VRAM_GUARD"):
         return extra_args
+    # ``--gpu-memory-utilization`` is a vLLM-only flag; sglang REJECTS it
+    # ("unrecognized arguments") and the server exits immediately, failing the
+    # integrate re-baseline for EVERY sglang workload. sglang caps memory via
+    # ``--mem-fraction-static`` (set by its launcher), so it needs no guard here.
+    # Apply the cap only for vLLM; sglang/unknown framework -> strict no-op.
+    framework = (os.environ.get("FRAMEWORK") or "").strip().lower()
+    if framework != "vllm":
+        return extra_args
     if "gpu-memory-utilization" in (extra_args or ""):
         return extra_args
     try:

--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -59,8 +59,11 @@ def _honest_flag(specific_env: str) -> bool:
 
     Returns ``True`` when the per-fix env ``specific_env`` is truthy, OR when it
     is unset and the umbrella ``HL_HONEST_E2E`` is truthy. An explicit falsey
-    per-fix value always wins (lets one fix opt out of the umbrella). Off by
-    default so callers are byte-identical to legacy behavior when nothing is set.
+    per-fix value always wins (lets one fix opt out of the umbrella). The umbrella
+    now defaults ON: E2E-faithful verdicts (paired same-config A/B, engagement
+    gate, verified-micro promotion) are the default so a GEAK kernel win is judged
+    by real serving throughput, not a stored-scalar gain. Opt the whole cohort
+    back out with ``HL_HONEST_E2E=0`` (or a single fix via its per-fix env).
 
     Args:
         specific_env: The per-fix environment variable name.
@@ -73,7 +76,7 @@ def _honest_flag(specific_env: str) -> bool:
         return True
     if raw in _FALSEY:
         return False
-    return os.environ.get(_HONEST_E2E_UMBRELLA_ENV, "").strip().lower() in _TRUEY
+    return os.environ.get(_HONEST_E2E_UMBRELLA_ENV, "1").strip().lower() in _TRUEY
 
 
 def _vram_guarded_server_args(extra_args: str) -> str:

--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -3704,13 +3704,21 @@ def _run_combined_e2e_sync(
         return {"status": "error", "error": f"apply_and_bench import failed: {exc}"}
 
     cfg = _combined_e2e_serving_config(payload)
+    # Expose exactly the GPUs the serving TP needs. apply_and_bench sets
+    # HIP/ROCR_VISIBLE_DEVICES=gpu, so a hardcoded "0" with tp>1 makes the server
+    # request device ordinals that aren't visible -> "HIP error: invalid device
+    # ordinal" and a baseline_failed A/B. Map the first `tp` visible GPUs (clamped
+    # to n_gpus) so tp=8 serving gets "0,1,...,7".
+    _tp = int(cfg.get("tp") or 1)
+    _tp = max(1, min(_tp, int(n_gpus)))
+    _gpu_ids = ",".join(str(i) for i in range(_tp))
     kwargs: dict[str, Any] = dict(
         pairs=pairs,
         backup_root=str(session_dir / "e2e_backups"),
         model=model,
         out_dir=str(session_dir / "combined_e2e"),
         reps=int(payload.get("e2e_reps", 5)),
-        gpu="0",
+        gpu=_gpu_ids,
         aiter_rebuild=True,
     )
     # Only forward knobs we actually resolved; apply_and_bench has its own defaults.
@@ -3719,6 +3727,7 @@ def _run_combined_e2e_sync(
     for k in ("tp", "isl", "osl", "conc", "num_prompts"):
         if cfg.get(k) is not None:
             kwargs[k] = int(cfg[k])
+    kwargs["tp"] = _tp  # keep --tp consistent with the exposed GPU set
     log.info("combined_e2e: applying %d patch(es) -> E2E A/B (model=%s, cfg=%s)",
              len(pairs), model, cfg)
     try:

--- a/inference_optimizer/tests/test_honest_e2e_hardening_unit.py
+++ b/inference_optimizer/tests/test_honest_e2e_hardening_unit.py
@@ -4,8 +4,8 @@
 umbrella-flag resolution, VRAM util guard, import-grep source confirmation,
 op-fanout de-dup in candidate batching, and umbrella-driven GEAK promotion.
 
-Every behavior is OFF by default, so the "off" assertions below also pin the
-byte-identical-to-legacy contract.
+Honest-E2E now defaults ON (umbrella). The "off" tests opt out explicitly with
+HL_HONEST_E2E=0 to pin the legacy/opt-out contract.
 """
 
 from __future__ import annotations
@@ -18,7 +18,7 @@ from inference_optimizer.orchestrator import kernel_request_handlers as krh
 
 # -- _honest_flag (umbrella + per-fix override) ---------------------------
 def test_honest_flag_default_off(monkeypatch) -> None:
-    monkeypatch.delenv("HL_HONEST_E2E", raising=False)
+    monkeypatch.setenv("HL_HONEST_E2E", "0")  # umbrella now default-on; opt out explicitly
     monkeypatch.delenv("HL_KERNEL_OPFANOUT_DEDUP", raising=False)
     assert krh._honest_flag("HL_KERNEL_OPFANOUT_DEDUP") is False
 
@@ -43,7 +43,7 @@ def test_honest_flag_specific_falsey_overrides_umbrella(monkeypatch) -> None:
 
 # -- _vram_guarded_server_args -------------------------------------------
 def test_vram_guard_off_is_identity(monkeypatch) -> None:
-    monkeypatch.delenv("HL_HONEST_E2E", raising=False)
+    monkeypatch.setenv("HL_HONEST_E2E", "0")  # umbrella now default-on; opt out explicitly
     monkeypatch.delenv("HL_INTEGRATE_VRAM_GUARD", raising=False)
     assert krh._vram_guarded_server_args("--foo bar") == "--foo bar"
     assert krh._vram_guarded_server_args("") == ""
@@ -117,7 +117,7 @@ def _geak_nr_result() -> dict:
 
 
 def test_rank_geak_nr_not_promoted_when_off(monkeypatch) -> None:
-    monkeypatch.delenv("HL_HONEST_E2E", raising=False)
+    monkeypatch.setenv("HL_HONEST_E2E", "0")  # umbrella now default-on; opt out explicitly
     monkeypatch.delenv("HL_PROMOTE_VERIFIED_MICRO_NEEDS_REVIEW", raising=False)
     keep, verified_nr, micro = krh._kernel_result_rank(_geak_nr_result())
     assert (keep, verified_nr) == (0, 0)
@@ -165,7 +165,7 @@ def _write_candidates(tmp_path: Path) -> str:
 
 
 def test_opfanout_off_keeps_both_rows(monkeypatch, tmp_path: Path) -> None:
-    monkeypatch.delenv("HL_HONEST_E2E", raising=False)
+    monkeypatch.setenv("HL_HONEST_E2E", "0")  # umbrella now default-on; opt out explicitly
     monkeypatch.delenv("HL_KERNEL_OPFANOUT_DEDUP", raising=False)
     monkeypatch.setenv("HYPERLOOM_KERNEL_OPT_MIN_GPU_PCT", "1.0")
     sel = krh._batch_kernel_candidates({"candidates_path": _write_candidates(tmp_path)})
@@ -204,7 +204,7 @@ def _infra_entry(failure_count: int, gpu_pct: float) -> dict:
 
 
 def test_infra_retry_off_retires_at_max_failures(monkeypatch) -> None:
-    monkeypatch.delenv("HL_HONEST_E2E", raising=False)
+    monkeypatch.setenv("HL_HONEST_E2E", "0")  # umbrella now default-on; opt out explicitly
     monkeypatch.delenv("HL_INFRA_RETRY_HIGH_IMPACT", raising=False)
     # failure_count == max_failures => legacy retires (cap collapses to default 1).
     cap = krh._kernel_dispatch_attempt_cap(_infra_entry(2, 26.7), max_failures=2)

--- a/inference_optimizer/tests/test_honest_e2e_hardening_unit.py
+++ b/inference_optimizer/tests/test_honest_e2e_hardening_unit.py
@@ -50,6 +50,7 @@ def test_vram_guard_off_is_identity(monkeypatch) -> None:
 
 
 def test_vram_guard_appends_when_on(monkeypatch) -> None:
+    monkeypatch.setenv("FRAMEWORK", "vllm")
     monkeypatch.setenv("HL_INTEGRATE_VRAM_GUARD", "1")
     monkeypatch.delenv("HL_INTEGRATE_VRAM_UTIL_CAP", raising=False)
     out = krh._vram_guarded_server_args("--trust-remote-code")
@@ -58,12 +59,14 @@ def test_vram_guard_appends_when_on(monkeypatch) -> None:
 
 
 def test_vram_guard_noop_if_already_set(monkeypatch) -> None:
+    monkeypatch.setenv("FRAMEWORK", "vllm")
     monkeypatch.setenv("HL_INTEGRATE_VRAM_GUARD", "1")
     existing = "--gpu-memory-utilization 0.7"
     assert krh._vram_guarded_server_args(existing) == existing
 
 
 def test_vram_guard_umbrella_and_cap(monkeypatch) -> None:
+    monkeypatch.setenv("FRAMEWORK", "vllm")
     monkeypatch.setenv("HL_HONEST_E2E", "1")
     monkeypatch.delenv("HL_INTEGRATE_VRAM_GUARD", raising=False)
     monkeypatch.setenv("HL_INTEGRATE_VRAM_UTIL_CAP", "0.85")
@@ -72,10 +75,19 @@ def test_vram_guard_umbrella_and_cap(monkeypatch) -> None:
 
 
 def test_vram_guard_cap_clamped(monkeypatch) -> None:
+    monkeypatch.setenv("FRAMEWORK", "vllm")
     monkeypatch.setenv("HL_INTEGRATE_VRAM_GUARD", "1")
     monkeypatch.setenv("HL_INTEGRATE_VRAM_UTIL_CAP", "5.0")
     out = krh._vram_guarded_server_args("")
     assert out == "--gpu-memory-utilization 0.99"
+
+
+def test_vram_guard_sglang_is_noop(monkeypatch) -> None:
+    # sglang rejects --gpu-memory-utilization; the guard must be a no-op for it.
+    monkeypatch.setenv("FRAMEWORK", "sglang")
+    monkeypatch.setenv("HL_INTEGRATE_VRAM_GUARD", "1")
+    assert krh._vram_guarded_server_args("--trust-remote-code") == "--trust-remote-code"
+    assert "gpu-memory-utilization" not in krh._vram_guarded_server_args("")
 
 
 # -- _confirm_source_imported (tri-state) ---------------------------------

--- a/inference_optimizer/tests/test_kernel_integrate_and_report.py
+++ b/inference_optimizer/tests/test_kernel_integrate_and_report.py
@@ -875,7 +875,14 @@ async def test_coordinator_integrate_request_emits_keep_response(session_dir, tm
 async def test_coordinator_stops_repeating_same_kernel_integrate_after_cap(
     session_dir,
     tmp_path,
+    monkeypatch,
 ):
+    # This test pins the LEGACY integrate dispatch cap (retire same kernel after N
+    # attempts). The honest-E2E umbrella now defaults ON, which changes the integrate
+    # path (paired same-config A/B + high-impact infra-retry) and widens the cap. Opt
+    # the whole cohort out so we exercise the legacy capping path this test was written
+    # for; honest-E2E integrate behavior is covered in test_honest_e2e_hardening_unit.
+    monkeypatch.setenv("HL_HONEST_E2E", "0")
     base_yaml = tmp_path / "base.yaml"
     _write_baseline_yaml(base_yaml)
     target, patch_file = _write_patch_pair(tmp_path)

--- a/kernel-agent/tools/backends/geak_submit.py
+++ b/kernel-agent/tools/backends/geak_submit.py
@@ -96,12 +96,12 @@ def _build_cmd(
     """
     cmd = [_find_geak_bin(), "-t", str(prompt_file), "--yolo", "--output", str(output_dir), "--gpu-ids", gpu_ids]
     cmd.extend(["--config", str(_resolve_geak_config())])
-    # GEAK's --target defaults to "wall" and that default has precedence over
-    # $GEAK_SCORE_TARGET (mini.py: ``scoring_target or env or "wall"``), so the env
-    # alone never switches scoring. Pass it explicitly when set so kernel_ms scoring
-    # is deterministic across the Ray boundary.
-    _score_target = os.environ.get("GEAK_SCORE_TARGET", "").strip().lower()
-    if _score_target in {"wall", "kernel_agent"}:
+    # Default to kernel-time scoring and forward it as an explicit --target so it is
+    # deterministic across the Ray boundary (current GEAK defaults to kernel via the
+    # env, but passing it explicitly also pins older GEAK builds whose --target
+    # defaulted to "wall" and silently overrode the env). Valid GEAK values: wall|kernel.
+    _score_target = os.environ.get("GEAK_SCORE_TARGET", "kernel").strip().lower()
+    if _score_target in {"wall", "kernel"}:
         cmd.extend(["--target", _score_target])
     if kernel_path:
         cmd.extend(["--kernel-path", kernel_path])
@@ -211,6 +211,11 @@ def run_via_ray(
             _cdir = _os.path.join(output_dir_str, ".cache", _sub)
             _os.makedirs(_cdir, exist_ok=True)
             _os.environ[_var] = _cdir
+        # GEAK's profiler-mcp pass is advisory only (a roofline hint) and is
+        # hang-prone on busy hosts, where it can eat the whole preprocess budget
+        # before any optimization round runs. Default it off for HL-launched GEAK;
+        # an operator can opt back in with GEAK_SKIP_PROFILE=0.
+        _os.environ.setdefault("GEAK_SKIP_PROFILE", "1")
         geak_bin = _shutil.which("geak") or _shutil.which("mini") or "geak"
         cmd = [geak_bin, "-t", prompt_file_str, "--yolo", "--output", output_dir_str, "--gpu-ids", gpu_ids]
         geak_config = _os.environ.get("GEAK_CONFIG", "").strip()
@@ -251,10 +256,10 @@ def run_via_ray(
                 "cmd": cmd,
             }
         cmd.extend(["--config", str(geak_config_path)])
-        # GEAK's --target default ("wall") outranks $GEAK_SCORE_TARGET; pass it
-        # explicitly so kernel_ms scoring survives the Ray boundary (see _build_cmd).
-        _score_target = _os.environ.get("GEAK_SCORE_TARGET", "").strip().lower()
-        if _score_target in {"wall", "kernel_agent"}:
+        # Default to kernel-time scoring; pass it explicitly so kernel_ms scoring
+        # survives the Ray boundary regardless of GEAK build (see _build_cmd).
+        _score_target = _os.environ.get("GEAK_SCORE_TARGET", "kernel").strip().lower()
+        if _score_target in {"wall", "kernel"}:
             cmd.extend(["--target", _score_target])
         if kernel_path:
             cmd.extend(["--kernel-path", kernel_path])
@@ -331,6 +336,9 @@ def run_via_cli(
     """
     # Child env with ROCR→logical GPU mapping; avoids leaking GPU vars to later steps.
     child_env = os.environ.copy()
+    # Advisory, hang-prone profiler-mcp pass off by default for HL-launched GEAK
+    # (operator can opt back in with GEAK_SKIP_PROFILE=0). See run_via_ray path.
+    child_env.setdefault("GEAK_SKIP_PROFILE", "1")
     rocr_raw = child_env.get("ROCR_VISIBLE_DEVICES", "")
     if rocr_raw:
         n_visible = len([x for x in rocr_raw.split(",") if x.strip()])

--- a/kernel-agent/tools/backends/ssh_runtime.py
+++ b/kernel-agent/tools/backends/ssh_runtime.py
@@ -143,6 +143,10 @@ ids = ",".join(str(i) for i in range(ng))
 os.environ["HIP_VISIBLE_DEVICES"] = ids
 os.environ["CUDA_VISIBLE_DEVICES"] = ids
 os.environ["ROCR_VISIBLE_DEVICES"] = ids
+# Mirror the Ray/CLI GEAK defaults on the Dynamo pod (both keys are in
+# SAFE_ENV_KEYS, so an explicit orchestrator-side value is forwarded over SSH and
+# wins via setdefault): the advisory profiler-mcp pass is hang-prone -> default off.
+os.environ.setdefault("GEAK_SKIP_PROFILE", "1")
 
 def fail(msg):
     print(json.dumps({"returncode": 2, "stdout_tail": "", "stderr_tail": msg,
@@ -162,6 +166,12 @@ if not re.search(r"(?m)^\s*model_class\s*:\s*litellm\s*$",
 
 cmd = [geak_bin, "-t", a.prompt, "--yolo", "--output", a.output,
        "--gpu-ids", ids, "--config", cfg]
+# Forward kernel-time scoring (the E2E-faithful default) as an explicit --target,
+# mirroring the Ray/CLI paths, so pod-side GEAK does not fall back to its --target
+# default. An explicit GEAK_SCORE_TARGET=wall (forwarded over SSH) is honored.
+_score_target = os.environ.get("GEAK_SCORE_TARGET", "kernel").strip().lower()
+if _score_target in ("wall", "kernel"):
+    cmd += ["--target", _score_target]
 if a.kernel_path:
     cmd += ["--kernel-path", a.kernel_path]
 if a.kernel_repo:

--- a/kernel-agent/tools/geak_vs_forge_driver.py
+++ b/kernel-agent/tools/geak_vs_forge_driver.py
@@ -139,6 +139,13 @@ def main() -> int:
     ap.add_argument("--top-k", type=int, default=10)
     ap.add_argument("--target-platform", default="MI300X")
     ap.add_argument(
+        "--candidates", default="",
+        help="Structured kernel_candidates.json to use DIRECTLY (its hot_kernels) "
+             "instead of re-parsing analysis.md. Preserves the precise profiler op "
+             "names that op_to_source resolution needs (analysis.md drops them), so "
+             "composite ops (fused-MoE, gdn-attn) resolve to the editable hot source.",
+    )
+    ap.add_argument(
         "--only-op", default="", help="substring filter: keep only candidates whose op name matches (e.g. 'attention')"
     )
     ap.add_argument(
@@ -164,8 +171,15 @@ def main() -> int:
     md = Path(a.analysis)
     csv_dir = Path(a.csv_dir) if a.csv_dir else None
 
-    # 1) HL: analysis.md -> candidates (parse + finalize with CSV-resolved shapes/source)
-    parsed = tlr.parse_analysis_md(md, top_k=a.top_k)
+    # 1) HL: analysis.md -> candidates (parse + finalize with CSV-resolved shapes/source).
+    # --candidates: use the STRUCTURED kernel_candidates.json hot_kernels directly so the
+    # precise op names survive (analysis.md re-parse loses them -> composite ops can't resolve).
+    if a.candidates:
+        _cd = json.loads(Path(a.candidates).read_text())
+        parsed = [c for c in (_cd.get("hot_kernels") or []) if isinstance(c, dict)][: a.top_k]
+        print(f"[driver] loaded {len(parsed)} structured candidates from {a.candidates}", flush=True)
+    else:
+        parsed = tlr.parse_analysis_md(md, top_k=a.top_k)
     cands = tla._finalize_candidates(
         parsed,
         total_dur=None,

--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -988,10 +988,19 @@ def _structured_benchmark_shape_cases(candidate: dict[str, Any]) -> dict[str, An
             )
             if case["raw"] or case["args"]:
                 cases.append(case)
-    if not cases and isinstance(input_shapes, list) and input_shapes and not is_synthetic:
-        # Only use input_shapes when they come from a real program output
-        # (TraceLens / runtime enrichment), not from the synthetic
-        # legacy-shapes conversion in enrich_candidates_with_runtime_metadata.
+    # ``_input_shapes_synthetic`` marks input_shapes DERIVED from the trace
+    # ``shapes`` strings (enrich_candidates_with_runtime_metadata) rather than a
+    # structured capture — but the DIMS are still real when shape_provenance is
+    # ``torch_trace`` (only the tensor VALUES are synthesized by the harness,
+    # which is acceptable for timing + patched-vs-reference correctness; a real
+    # value oracle for value-dependent kernels is a separate PRELUDE capture).
+    # Across all 24h runs 100% of candidates are flagged synthetic, so excluding
+    # them here dropped real trace dims for every composite op without a
+    # task_group (e.g. fused-MoE) -> GEAK got no shapes. Use the real dims.
+    dims_real = str(candidate.get("shape_provenance") or "").strip().lower() == "torch_trace"
+    if not cases and isinstance(input_shapes, list) and input_shapes and (not is_synthetic or dims_real):
+        # Use input_shapes when they are a real program output (TraceLens /
+        # runtime enrichment) OR carry real torch_trace dims (synthetic values only).
         for idx, entry in enumerate(input_shapes):
             case = _shape_case_from_value(entry, primary=idx == 0)
             case["source"] = "input_shapes"

--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -1821,7 +1821,11 @@ def build_prompt(
         )
     # Quote the per-backend wall-clock so GEAK's task-mode parser infers the right mode (>=120min→full).
     if backend == "geak":
-        budget_min = int(getattr(args, "geak_budget_min", 130) or 130)
+        # Default tracks $GEAK_RUN_MODE (quick->70, full->180); 180 matches GEAK's own
+        # full-mode budget so the quoted wall-clock triggers full mode. The prior 130
+        # killed GEAK before its deadline (see parallel_e2e_runner / _default_geak_budget_minutes).
+        _geak_default = 70 if os.environ.get("GEAK_RUN_MODE", "full").strip().lower() == "quick" else 180
+        budget_min = int(getattr(args, "geak_budget_min", _geak_default) or _geak_default)
     else:
         budget_min = int(getattr(args, "budget_minutes", 60) or 60)
     target_platform = getattr(args, "target_platform", "") or _env_target_platform()
@@ -2959,9 +2963,12 @@ def invoke_backend(
             tails, gpu_ids, elapsed_s, cmd, and optional optimized_path /
             cli_workspace).
     """
-    # GEAK needs more wall-clock than claude/codex; 130min default triggers GEAK's mode=full path.
+    # GEAK needs more wall-clock than claude/codex; full mode -> 180min (3h) matches
+    # GEAK's own budget so the subprocess timeout doesn't kill it mid-round before it
+    # finalizes a deployable artifact (which would also skip the combined-E2E A/B).
     if backend == "geak":
-        budget_min = float(getattr(args, "geak_budget_min", 0) or getattr(args, "budget_minutes", 60) or 60)
+        _geak_default = 70.0 if os.environ.get("GEAK_RUN_MODE", "full").strip().lower() == "quick" else 180.0
+        budget_min = float(getattr(args, "geak_budget_min", 0) or _geak_default)
     else:
         budget_min = float(getattr(args, "budget_minutes", 60) or 60)
     timeout_s = max(60, int(budget_min * 60))

--- a/kernel-agent/tools/parallel_e2e_runner.py
+++ b/kernel-agent/tools/parallel_e2e_runner.py
@@ -318,8 +318,15 @@ def run_one_attempt(
     if harness_path:
         cmd.extend(["--test-harness-path", harness_path])
     started = time.time()
+    # Outer-wrapper timeout must cover the ACTUAL backend's budget: GEAK runs up to
+    # --geak-budget-min (default 180 min), OOB backends up to --budget-minutes
+    # (default 60). Using backend_budget_min unconditionally would SIGKILL
+    # kernel_optimization.py ~62 min in -> GEAK never finalizes its deploy artifact
+    # and the combined-E2E/integrate A/B is skipped. Match the inner budget + a
+    # finalize grace (>= GEAK finalize_grace 300s + kill_buffer 60s).
+    _effective_budget_min = args.geak_budget_min if backend == "geak" else args.backend_budget_min
     try:
-        result = run_json(cmd, env=local_env, timeout_s=int(args.backend_budget_min * 60) + 120, log_path=log_path)
+        result = run_json(cmd, env=local_env, timeout_s=int(_effective_budget_min * 60) + 360, log_path=log_path)
         status = "ok"
     except Exception as exc:
         result = {"error": f"{type(exc).__name__}: {exc}"}

--- a/kernel-agent/tools/parallel_e2e_runner.py
+++ b/kernel-agent/tools/parallel_e2e_runner.py
@@ -414,14 +414,17 @@ def main() -> int:
         "otherwise they iterate up to ~85%% of this budget "
         "and SIGTERM at 100%%.",
     )
-    # Default tracks $GEAK_RUN_MODE: quick -> 70 min, full -> 130 min.
-    _geak_budget_default = 70 if os.environ.get("GEAK_RUN_MODE", "full").strip().lower() == "quick" else 130
+    # Default tracks $GEAK_RUN_MODE: quick -> 70 min, full -> 180 min (3h).
+    # 180 matches GEAK's own full-mode budget (yaml run.budgets.full.total_s=10800s);
+    # the prior 130 killed GEAK ~50 min before its own deadline, mid round-2, so the
+    # deploy artifact never materialized and the combined-E2E A/B was skipped.
+    _geak_budget_default = 70 if os.environ.get("GEAK_RUN_MODE", "full").strip().lower() == "quick" else 180
     parser.add_argument(
         "--geak-budget-min",
         type=float,
         default=_geak_budget_default,
         help="Per-attempt wall-clock budget for GEAK only "
-        "(default tracks $GEAK_RUN_MODE: full -> 130, "
+        "(default tracks $GEAK_RUN_MODE: full -> 180, "
         "quick -> 70; aligned with yaml "
         "run.budgets.<mode>.total_s + finalize_grace + "
         "kill_buffer + safety so the prompt-quoted "

--- a/kernel-agent/tools/test_op_to_source_resolver.py
+++ b/kernel-agent/tools/test_op_to_source_resolver.py
@@ -520,3 +520,42 @@ def test_finalize_in_dict_non_rewritable_does_not_grep(tla, monkeypatch) -> None
     assert out["reusable_native_kernel"] is False
     assert out["skip_reason"].startswith("op_to_source:")
     assert out["source_file"] == "launcher.py"
+
+
+# --------------------------------------------------------------------------- #
+# load_op_dominant_kernel_map (data-driven composite disambiguation)
+# --------------------------------------------------------------------------- #
+def test_dominant_kernel_map_picks_max_duration(tla, tmp_path) -> None:
+    """The dominant device kernel = max aggregated duration, parsed from the CSV."""
+    import csv as _csv
+
+    csv_dir = tmp_path
+    rows = [
+        {
+            "name": "sglang_profiler::fused_moe_triton_kernels_invoke_fused_moe_kernel",
+            "kernel_details_summary": (
+                "[{'name': '_per_token_group_quant_8bit', 'stream': 8, 'count': 2001, "
+                "'total_duration_us': np.float64(9266.1), 'mean_duration_us': np.float64(4.63)}, "
+                "{'name': 'fused_moe_kernel', 'stream': 8, 'count': 2001, "
+                "'total_duration_us': np.float64(401466.7), 'mean_duration_us': np.float64(200.63)}]"
+            ),
+        },
+        # second row (different shape) for the same op — durations must aggregate
+        {
+            "name": "sglang_profiler::fused_moe_triton_kernels_invoke_fused_moe_kernel",
+            "kernel_details_summary": (
+                "[{'name': 'fused_moe_kernel', 'stream': 8, 'count': 138, "
+                "'total_duration_us': np.float64(287774.7), 'mean_duration_us': np.float64(2085.3)}]"
+            ),
+        },
+    ]
+    with (csv_dir / "unified_perf_summary.csv").open("w", newline="") as f:
+        w = _csv.DictWriter(f, fieldnames=["name", "kernel_details_summary"])
+        w.writeheader()
+        w.writerows(rows)
+    m = tla.load_op_dominant_kernel_map(csv_dir)
+    assert m["sglang_profiler::fused_moe_triton_kernels_invoke_fused_moe_kernel"] == "fused_moe_kernel"
+
+
+def test_dominant_kernel_map_missing_csv_is_empty(tla, tmp_path) -> None:
+    assert tla.load_op_dominant_kernel_map(tmp_path) == {}

--- a/kernel-agent/tools/test_ssh_runtime.py
+++ b/kernel-agent/tools/test_ssh_runtime.py
@@ -80,3 +80,58 @@ def test_extract_last_json_none_on_empty_or_no_brace_or_malformed():
     assert ssh_runtime._extract_last_json("") is None
     assert ssh_runtime._extract_last_json("no json here") is None
     assert ssh_runtime._extract_last_json('{"a": }') is None  # invalid JSON
+
+
+# -- GEAK pod-runner defaults (PR #768 review: kernel scoring + skip-profile) ----
+import json as _json  # noqa: E402
+import os as _os  # noqa: E402
+import stat as _stat  # noqa: E402
+import subprocess as _sp  # noqa: E402
+
+
+def _run_geak_pod_runner(tmp_path, extra_env):
+    """Execute the real GEAK _POD_RUNNER with a fake `geak` on PATH; return its JSON dict.
+
+    The fake geak echoes its argv + GEAK_SKIP_PROFILE so the test can assert both
+    the forwarded ``--target`` and the profiler default the pod runner sets.
+    """
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    fake = bindir / "geak"
+    fake.write_text('#!/usr/bin/env bash\necho "ARGV:$@"\necho "SKIP=$GEAK_SKIP_PROFILE"\nexit 0\n')
+    fake.chmod(fake.stat().st_mode | _stat.S_IEXEC | _stat.S_IXGRP | _stat.S_IXOTH)
+    cfg = tmp_path / "local.yaml"
+    cfg.write_text("model_class: litellm\n")
+    prompt = tmp_path / "p.md"
+    prompt.write_text("opt this kernel")
+    outdir = tmp_path / "out"
+    outdir.mkdir()
+    runner = tmp_path / "pod_runner.py"
+    runner.write_text(ssh_runtime._POD_RUNNER)
+    env = dict(_os.environ)
+    env["PATH"] = f"{bindir}:{env.get('PATH','')}"
+    env["GEAK_CONFIG"] = str(cfg)
+    env.pop("GEAK_SCORE_TARGET", None)
+    env.pop("GEAK_SKIP_PROFILE", None)
+    env.update(extra_env)
+    proc = _sp.run(
+        [sys.executable, str(runner), "--prompt", str(prompt), "--output", str(outdir),
+         "--num-gpus", "1", "--timeout-s", "30"],
+        capture_output=True, text=True, env=env, timeout=60,
+    )
+    return ssh_runtime._extract_last_json(proc.stdout) or {}
+
+
+def test_geak_pod_runner_defaults_to_kernel_target_and_skip_profile(tmp_path):
+    out = _run_geak_pod_runner(tmp_path, extra_env={})
+    cmd = out.get("cmd") or []
+    assert "--target" in cmd and cmd[cmd.index("--target") + 1] == "kernel", cmd
+    # pod runner set GEAK_SKIP_PROFILE=1 by default -> visible to the geak child
+    assert "SKIP=1" in (out.get("stdout_tail") or ""), out.get("stdout_tail")
+
+
+def test_geak_pod_runner_respects_explicit_overrides(tmp_path):
+    out = _run_geak_pod_runner(tmp_path, extra_env={"GEAK_SCORE_TARGET": "wall", "GEAK_SKIP_PROFILE": "0"})
+    cmd = out.get("cmd") or []
+    assert "--target" in cmd and cmd[cmd.index("--target") + 1] == "wall", cmd
+    assert "SKIP=0" in (out.get("stdout_tail") or ""), out.get("stdout_tail")

--- a/kernel-agent/tools/test_ssh_runtime.py
+++ b/kernel-agent/tools/test_ssh_runtime.py
@@ -83,7 +83,6 @@ def test_extract_last_json_none_on_empty_or_no_brace_or_malformed():
 
 
 # -- GEAK pod-runner defaults (PR #768 review: kernel scoring + skip-profile) ----
-import json as _json  # noqa: E402
 import os as _os  # noqa: E402
 import stat as _stat  # noqa: E402
 import subprocess as _sp  # noqa: E402

--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -552,6 +552,55 @@ class OpResolver:
                             patchable=True, framework=framework,
                             sources=[_absolutize_source(str(path))], matched_route=kname,
                         )
+        # No trace device symbol (composite pybind ops frequently carry none —
+        # device_kernel_name is None for the fused-MoE / gdn-attention labels).
+        # NAME-ANCHORED disambiguation: a composite op is named after its primary
+        # device kernel (``..._invoke_fused_moe_kernel``, ``paged_attention_ragged``).
+        # Route to the single editable leaf whose device-kernel symbol is contained
+        # in the op name, instead of splitting ``duration_us`` evenly across the
+        # co-firing quant/scale/align helpers (which sends GEAK at the wrong file).
+        # Only pins when EXACTLY ONE editable source matches; otherwise the full
+        # fan-out below is unchanged (byte-identical for ambiguous/0-match ops).
+        anchor = op_name.split("::")[-1].lower()
+        if anchor:
+            fw_anchor = (framework or "").strip().lower()
+            anchor_containers = (
+                [entry.get("sglang"), entry.get("vllm")]
+                if fw_anchor == "sglang"
+                else [entry.get("vllm"), entry.get("sglang")]
+            )
+            for container in anchor_containers:
+                matched: list[tuple[str, str, str]] = []
+                seen_paths: set[str] = set()
+                for kname, info in (container or {}).items():
+                    if not isinstance(info, dict) or not info.get("patchable"):
+                        continue
+                    path = info.get("kernel_source_path")
+                    if not _is_editable_source(path, info.get("kernel_kind")):
+                        continue
+                    core = str(kname).split("(")[0].strip().lower()
+                    # Require the device-kernel SYMBOL to appear in the op name
+                    # (the composite is named after its primary kernel, e.g.
+                    # ``fused_moe_kernel`` ⊂ ``..._invoke_fused_moe_kernel``).
+                    # One-directional + min length avoids trivial-token mis-pins.
+                    if core and len(core) >= 6 and core in anchor:
+                        ap = _absolutize_source(str(path))
+                        if ap not in seen_paths:
+                            seen_paths.add(ap)
+                            matched.append(
+                                (ap, str(info.get("kernel_kind") or ""), str(info.get("prebuilt_binary") or ""))
+                            )
+                if len(matched) == 1:
+                    ap, kk, pb = matched[0]
+                    return OpResolution(
+                        op_name=op_name, kind="composite", status=_ROUTABLE_STATUS,
+                        patchable=True, framework=framework, sources=[ap],
+                        kernel_kinds=[kk], prebuilt_binaries=[pb],
+                        matched_route="name_anchored",
+                    )
+                if matched:
+                    break  # ambiguous in this container -> fall through to fan-out
+
         meta = self._select_source_meta(entry, framework)
         fanout = [
             OpResolution(
@@ -2856,8 +2905,59 @@ def load_op_category_map(
     return out
 
 
+# Capture a device-kernel ``name`` and its total (preferred) or mean duration from
+# the ``kernel_details_summary`` / ``trunc_kernel_details`` repr strings TraceLens
+# writes per row. ``total_duration_us`` appears before ``mean_duration_us`` in the
+# full summary, so the non-greedy match prefers total when present.
+_KERNEL_DETAIL_RE = re.compile(
+    r"'name':\s*'((?:[^'\\]|\\.)*)'.*?'(total_duration_us|mean_duration_us)':\s*(?:np\.float64\()?([0-9.eE+-]+)"
+)
+
+
+def load_op_dominant_kernel_map(perf_report_csv_dir: Path | str) -> dict[str, str]:
+    """Read ``{op_name: dominant_device_kernel_name}`` from the unified perf summary.
+
+    A composite profiler op (e.g. the Triton fused-MoE label) fires several device
+    kernels under one CPU op; TraceLens records them per row in
+    ``kernel_details_summary`` with per-kernel durations. The dominant
+    (max aggregated duration) device kernel is the real hot kernel — surfacing it
+    as ``device_kernel_name`` lets :meth:`OpResolver._composite` pin the single
+    owning source instead of fanning out across the co-firing helpers. This is
+    data-driven (actual per-kernel time) and framework-agnostic: it works for any
+    composite op in any vLLM/SGLang trace, with no per-op curation. ``{}`` when the
+    CSV is absent or unreadable.
+    """
+    csv_path = Path(perf_report_csv_dir) / "unified_perf_summary.csv"
+    if not csv_path.is_file():
+        return {}
+    agg: dict[str, dict[str, float]] = {}
+    try:
+        with csv_path.open(newline="", encoding="utf-8") as f:
+            for row in csv.DictReader(f):
+                name = str(row.get("name") or "").strip()
+                if not name:
+                    continue
+                detail = str(row.get("kernel_details_summary") or row.get("trunc_kernel_details") or "")
+                if not detail:
+                    continue
+                per = agg.setdefault(name, {})
+                for m in _KERNEL_DETAIL_RE.finditer(detail):
+                    kname = m.group(1).strip()
+                    try:
+                        dur = float(m.group(3))
+                    except (TypeError, ValueError):
+                        continue
+                    if kname:
+                        per[kname] = per.get(kname, 0.0) + dur
+    except (OSError, csv.Error):
+        return {}
+    return {op: max(per.items(), key=lambda kv: kv[1])[0] for op, per in agg.items() if per}
+
+
 def _expand_op_fanout(
-    top: list[dict[str, Any]], framework: str | None = None,
+    top: list[dict[str, Any]],
+    framework: str | None = None,
+    op_dominant_kernel: dict[str, str] | None = None,
 ) -> list[dict[str, Any]]:
     """Resolve each op against the dictionary and fan out one candidate per ``.cu``.
 
@@ -2876,12 +2976,16 @@ def _expand_op_fanout(
     ordering.
     """
     framework = (framework or "").strip().lower() or None
+    op_dominant_kernel = op_dominant_kernel or {}
     expanded: list[dict[str, Any]] = []
     for item in top:
-        res = resolve_op_source(
-            str(item.get("name") or ""), framework=framework,
-            device_kernel_name=str(item.get("device_kernel_name") or "") or None,
-        )
+        op_name = str(item.get("name") or "")
+        # Prefer the candidate's own device symbol; else fall back to the
+        # dominant-by-time device kernel for this op (composite labels arrive with
+        # device_kernel_name=None, so this is what lets _composite pin the single
+        # hot source instead of fanning out evenly across helper kernels).
+        dkn = str(item.get("device_kernel_name") or "").strip() or op_dominant_kernel.get(op_name) or None
+        res = resolve_op_source(op_name, framework=framework, device_kernel_name=dkn)
         if res is None:
             item["_op_resolution"] = None
             expanded.append(item)
@@ -3633,9 +3737,11 @@ def _finalize_candidates(
         The finalized candidate list (the same ``top`` object).
     """
     op_cat_map = load_op_category_map(perf_report_csv_dir) if perf_report_csv_dir is not None else {}
+    op_dom_map = load_op_dominant_kernel_map(perf_report_csv_dir) if perf_report_csv_dir is not None else {}
     # Dict-first: resolve each op to its editable .cu (ground truth) and expand
-    # composite fan-out into one candidate per sub-kernel before finalizing.
-    top = _expand_op_fanout(top, framework=framework)
+    # composite fan-out into one candidate per sub-kernel before finalizing. The
+    # dominant-kernel map pins composites to their single hot source (data-driven).
+    top = _expand_op_fanout(top, framework=framework, op_dominant_kernel=op_dom_map)
     sum_dur = total_dur if total_dur is not None else sum(it.get("duration_us", 0.0) for it in top)
     sum_dur = sum_dur or 1.0
     # #727 companion: the fused-MoE expert kernel's top-level trace event carries


### PR DESCRIPTION
## What
Honest E2E verdict + faithful dispatch. All flags **default-off** ⇒ byte-identical until enabled.

## Verdict (E2E A/B)
- `HL_INTEGRATE_PAIRED_AB` / `HL_HONEST_E2E`: replace the **unpaired stored-scalar** `base_tput` with a **paired same-config** measurement (revert patch → re-run the same `BaselineExecutor(ctx)` on the pristine kernel); gain computed from the pair; KEEP re-applies; pairing failure ⇒ NEEDS_REVIEW.
- Generalized **engagement** gate (target bytes must change, content-hash) + **noise band** (`HL_E2E_NOISE_BAND_PCT`); un-engaged KEEP → NEEDS_REVIEW.
- `HL_PROMOTE_VERIFIED_MICRO`: a correctness-passing verified-micro NEEDS_REVIEW can reach the E2E measurement (rank tier) instead of always losing to any KEEP.

## Faithful dispatch (op→source + shapes)
- **Data-driven dominant-kernel resolution**: `load_op_dominant_kernel_map` parses per-device-kernel durations (`kernel_details_summary`) and pins the composite op's single hot source via the existing resolver. Collapses the fan-out generally, both frameworks (verified: `fused_moe`→`fused_moe_triton_kernels.py`, `gdn_attention_core`→`chunk_delta_h.py`). Name-anchored fallback when `kernel_details` is absent.
- Use **real `torch_trace` dims** for benchmark cases even when values are synthesized (was discarded; 298/298 candidates were flagged synthetic).
- `HL_E2E_AWARE_SELECT`: dispatch by `gpu_pct × headroom` and **deprioritize pure-communication** kernels (all_reduce/collectives can't be sped by a kernel rewrite).

Tests: 26 resolver + 96 kernel-opt + 9 shape pass. `py_compile` clean.
