### PR TITLE
Fix Gemma4 vLLM ROCm AITER MoE startup

### DIFF
--- a/inference_optimizer/model_config_utils.py
+++ b/inference_optimizer/model_config_utils.py
@@ -78,12 +78,15 @@ def _config_architectures(config: dict) -> list[str]:
 # Single source of truth: ``cli`` reuses these for its preflight checks too.
 GEMMA2_MODEL_TYPE = "gemma2"
 GEMMA2_ARCHITECTURES = frozenset({"gemma2forcausallm"})
+GEMMA4_MODEL_TYPE = "gemma4"
+GEMMA4_ARCHITECTURES = frozenset({"gemma4forconditionalgeneration"})
 
 
 # ``gemma`` then an optional single separator then ``2`` as a standalone token
 # (start/separator on the left, separator/end on the right). Matches gemma2 /
 # gemma-2 / gemma_2 but not gemma3, gemma25, or notgemma2.
 _GEMMA2_PATH_RE = re.compile(r"(?:^|[-_.])gemma[-_.]?2(?:[-_.]|$)")
+_GEMMA4_PATH_RE = re.compile(r"(?:^|[-_.])gemma[-_.]?4(?:[-_.]|$)")
 
 
 def _path_looks_like_gemma2(model_path: str) -> bool:
@@ -102,6 +105,13 @@ def _path_looks_like_gemma2(model_path: str) -> bool:
     if not model_path:
         return False
     return _GEMMA2_PATH_RE.search(Path(model_path).name.lower()) is not None
+
+
+def _path_looks_like_gemma4(model_path: str) -> bool:
+    """Heuristic Gemma4 detection from the path when config.json is absent."""
+    if not model_path:
+        return False
+    return _GEMMA4_PATH_RE.search(Path(model_path).name.lower()) is not None
 
 
 def _config_gemma2_scopes(data: dict) -> list[dict]:
@@ -135,6 +145,16 @@ def _config_is_gemma2(data: dict) -> bool:
         if str(cfg.get("model_type") or "").strip().lower() == GEMMA2_MODEL_TYPE:
             return True
         if any(a.lower() in GEMMA2_ARCHITECTURES for a in _config_architectures(cfg)):
+            return True
+    return False
+
+
+def _config_is_gemma4(data: dict) -> bool:
+    """True when a parsed config dict declares Gemma4 (top level or text_config)."""
+    for cfg in _config_gemma2_scopes(data):
+        if str(cfg.get("model_type") or "").strip().lower() == GEMMA4_MODEL_TYPE:
+            return True
+        if any(a.lower() in GEMMA4_ARCHITECTURES for a in _config_architectures(cfg)):
             return True
     return False
 
@@ -562,3 +582,14 @@ def _model_is_gemma2(model_path: str) -> bool:
         if _config_has_model_identity(data):
             return False
     return _path_looks_like_gemma2(model_path)
+
+
+def _model_is_gemma4(model_path: str) -> bool:
+    """Best-effort detect a Gemma4 model from config.json or path heuristic."""
+    data = _load_model_config_dict(model_path)
+    if data is not None:
+        if _config_is_gemma4(data):
+            return True
+        if _config_has_model_identity(data):
+            return False
+    return _path_looks_like_gemma4(model_path)

--- a/inference_optimizer/orchestrator/action_executors/_grid_runner.py
+++ b/inference_optimizer/orchestrator/action_executors/_grid_runner.py
@@ -1512,7 +1512,7 @@ def inject_sglang_context_length(
     if _SGLANG_CONTEXT_LENGTH_RE.search(args):
         return args
     # Lazy import to avoid a module-level cycle through the heavy cli.py.
-    from ...cli import _load_model_max_position_embeddings
+    from ...cli_model_gate import _load_model_max_position_embeddings
 
     max_pos = _load_model_max_position_embeddings(str(model_path or ""))
     if not max_pos:
@@ -1591,7 +1591,7 @@ def inject_sglang_attention_backend(
         return args
     if _SGLANG_ATTN_BACKEND_RE.search(args):
         return args
-    from ...cli import _model_has_dual_chunk_attention
+    from ...cli_model_gate import _model_has_dual_chunk_attention
 
     if not _model_has_dual_chunk_attention(str(model_path or "")):
         return args
@@ -1658,7 +1658,7 @@ def inject_sglang_moe_runner_backend(
         return args
     if _SGLANG_MOE_RUNNER_BACKEND_RE.search(args):
         return args
-    from ...cli import _model_is_moe, _resolve_amd_gpu_type
+    from ...cli_model_gate import _model_is_moe, _resolve_amd_gpu_type
 
     if not _resolve_amd_gpu_type(gpu_type):
         return args

--- a/inference_optimizer/orchestrator/action_executors/_workload_envs.py
+++ b/inference_optimizer/orchestrator/action_executors/_workload_envs.py
@@ -46,6 +46,7 @@ from ...model_config_utils import (
     _fp8_is_per_channel_per_token,
     _load_model_config_dict,
     _model_is_gemma2,
+    _model_is_gemma4,
 )
 
 log = logging.getLogger(__name__)
@@ -71,6 +72,7 @@ _PROFILE_DEFAULT_OSL = 1024
 def _remove_moe_runner_backend_arg(args: str) -> str:
     """Remove any existing SGLang MoE runner backend flag from an args string."""
     return " ".join(_MOE_RUNNER_BACKEND_RE.sub(" ", str(args or "")).split())
+
 
 # Warn once per process when the accuracy gate is disabled.
 _RUN_EVAL_DISABLED_WARN_EMITTED = False
@@ -762,7 +764,15 @@ def materialize_config_with_envs(
     # path once the agent knows the model loads — hence setdefault/merge,
     # never overwrite). Matched on the model basename so it fires for both
     # the HF repo id and the /wekafs/models/<org>-<repo> local path.
-    _model_basename = Path(str(model_path or os.environ.get("MODEL_PATH", ""))).name.lower()
+    _model_path_str = str(model_path or os.environ.get("MODEL_PATH", ""))
+    _model_basename = Path(_model_path_str).name.lower()
+    if "vllm" in str(bench.get("framework") or "").lower() and _model_is_gemma4(_model_path_str):
+        # Gemma4 MoE text path boots through vLLM's ROCm AITER unquantized MoE
+        # backend by default, which can abort during model-load with
+        # "device_gemm ... does not support this GEMM problem" on MI300X.
+        # Successful production retries used this narrower knob (instead of
+        # disabling all AITER) and preserved the rest of the vLLM stack.
+        envs.setdefault("VLLM_ROCM_USE_AITER_MOE", "0")
     if "kimi-k2" in _model_basename:
         # Kimi K2.x at tp8 (8 heads/GPU) takes sglang's ROCm
         # fused-decode-MLA path, whose RoPE kernel aborts during CUDA-graph
@@ -996,7 +1006,10 @@ def materialize_config_with_envs(
     # Hyperloom, strictly scoped to sglang + fp8 + gfx942 + that exact quant
     # scheme so per-tensor and block-scale FP8 are never touched. setdefault so
     # an operator-set value (YAML / extra_envs) always wins.
-    from ...cli import _resolve_amd_gpu_type
+    # Canonical single-source GPU resolver. ``cli_model_gate`` is stdlib-only
+    # (it must not import ``cli``), so this stays light enough for the hot path
+    # and unit tests while avoiding a second, drift-prone implementation.
+    from ...cli_model_gate import _resolve_amd_gpu_type
 
     _model_for_quant = str(model_path or os.environ.get("MODEL_PATH", ""))
     if (

--- a/inference_optimizer/tests/test_model_config_summary.py
+++ b/inference_optimizer/tests/test_model_config_summary.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 
+from inference_optimizer import model_config_utils as mcu
 from inference_optimizer.model_config_utils import summarize_model_config
 
 
@@ -202,6 +203,34 @@ def test_summary_llm_config_nesting(tmp_path: Path) -> None:
     assert out["num_hidden_layers"] == 48
     assert out["is_moe"] is True
     assert out["num_experts"] == 128
+
+
+def test_model_is_gemma4_detects_config_and_path(tmp_path: Path) -> None:
+    m = tmp_path / "google-gemma-4-26B-A4B-it"
+    _write_config(
+        m,
+        {
+            "model_type": "gemma4",
+            "architectures": ["Gemma4ForConditionalGeneration"],
+        },
+    )
+    assert mcu._model_is_gemma4(str(m)) is True
+
+    fallback = tmp_path / "google-gemma-4-27b-it"
+    fallback.mkdir()
+    assert mcu._model_is_gemma4(str(fallback)) is True
+
+
+def test_model_is_gemma4_trusts_identified_non_gemma_config(tmp_path: Path) -> None:
+    m = tmp_path / "gemma-4-distill-llama"
+    _write_config(
+        m,
+        {
+            "model_type": "llama",
+            "architectures": ["LlamaForCausalLM"],
+        },
+    )
+    assert mcu._model_is_gemma4(str(m)) is False
 
 
 def test_summary_stub_high_priority_scope_backfilled_by_lower(tmp_path: Path) -> None:

--- a/inference_optimizer/tests/test_workload_envs_branches_unit.py
+++ b/inference_optimizer/tests/test_workload_envs_branches_unit.py
@@ -6,6 +6,7 @@ sizing."""
 
 from __future__ import annotations
 
+import json
 import sys
 from types import SimpleNamespace
 
@@ -234,6 +235,48 @@ def test_inject_vllm_expert_parallel_unit(server_args, framework, ep, expected):
 
 
 # ---- per-model work-around: mimo-v2 ---------------------------------------
+def test_vllm_gemma4_disables_aiter_moe_by_default(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_DISABLE_TP_CLAMP", "1")
+    model = tmp_path / "google-gemma-4-26B-A4B-it"
+    model.mkdir()
+    (model / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "gemma4",
+                "architectures": ["Gemma4ForConditionalGeneration"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    src = _write(tmp_path / "cfg.yaml", framework="vllm")
+
+    bench = _materialize(src, tmp_path / "out", model_path=str(model))
+
+    assert bench["envs"]["VLLM_ROCM_USE_AITER_MOE"] == "0"
+
+
+def test_vllm_gemma4_honors_explicit_aiter_moe_override(monkeypatch, tmp_path):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_DISABLE_TP_CLAMP", "1")
+    model = tmp_path / "google-gemma-4-26B-A4B-it"
+    model.mkdir()
+    (model / "config.json").write_text(
+        json.dumps({"model_type": "gemma4"}),
+        encoding="utf-8",
+    )
+    src = _write(tmp_path / "cfg.yaml", framework="vllm")
+
+    bench = _materialize(
+        src,
+        tmp_path / "out",
+        model_path=str(model),
+        extra_envs={"VLLM_ROCM_USE_AITER_MOE": "1"},
+    )
+
+    assert bench["envs"]["VLLM_ROCM_USE_AITER_MOE"] == "1"
+
+
 def test_mimo_v2_injects_triton_attention(monkeypatch, tmp_path):
     _clear_env(monkeypatch)
     monkeypatch.setenv("INFERENCE_OPTIMIZER_DISABLE_TP_CLAMP", "1")


### PR DESCRIPTION
## Summary
- Disable vLLM's ROCm AITER MoE backend by default for Gemma4 workloads via `VLLM_ROCM_USE_AITER_MOE=0`, matching the successful production retry configuration while preserving explicit user overrides.
- Add Gemma4 model detection (config architecture + path heuristics) in `model_config_utils.py`, mirroring the existing Gemma2 helpers.
- Replace heavy `cli.py` lazy imports in the workload/grid helpers with lighter modules so the relevant unit tests run without Linux-only dependencies.

## Background
On Core42, Gemma4 baseline startup under vLLM failed because the ROCm AITER MoE GEMM backend does not support Gemma4's GEMM shapes, causing EngineCore startup to die (`server_init_dead`). Successful production retries had manually set `VLLM_ROCM_USE_AITER_MOE=0` / `VLLM_ROCM_USE_AITER=0`. This change makes that safe default automatic for Gemma4 + vLLM only, while still honoring any explicit override.

## Test plan
- `python -m pytest inference_optimizer/tests/test_workload_envs_branches_unit.py inference_optimizer/tests/test_model_config_summary.py -q`
- Compared real Gemma4 Core42 sessions: failing baseline attempts had no AITER override and ended with `server_init_dead`; successful retries used `VLLM_ROCM_USE_AITER_MOE=0` or `VLLM_ROCM_USE_AITER=0`.

> Note: the earlier GEAKV4 breakdown-fallback change (`ci/optimize_submit.py`) has been removed from this PR; this PR now scopes to the Gemma4 startup fix only.
