### PR TITLE
docs: update vLLM ROCm image to profilerfix build

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ Example images (Harbor refs for the SaFE Authoring Pod path; drop the `harbor.co
 
 - SGLang MI300X: `docker.io/primussafe/sglang:v0.5.12-rocm720-mi30x-profilerfix`
 - SGLang MI355X: `docker.io/primussafe/sglang:v0.5.12-rocm720-mi35x-profilerfix`
-- vLLM MI300X: `docker.io/vllm/vllm-openai-rocm:v0.21.0`
-- vLLM MI355X: `docker.io/vllm/vllm-openai-rocm:v0.21.0`
+- vLLM MI300X: `docker.io/primussafe/vllm-openai-rocm:v0.21.0-rocm720-profilerfix`
+- vLLM MI355X: `docker.io/primussafe/vllm-openai-rocm:v0.21.0-rocm720-profilerfix`
 
 > The SGLang `-profilerfix` images patch `libamdhip64`/`libroctracer` so rocprofiler captures kernels launched under HipGraphLaunch (issue #352). Use the stock `lmsysorg/sglang:v0.5.11-rocm720-*` images once that fix lands upstream in ROCm.
 


### PR DESCRIPTION
## Summary
- Update the README example vLLM images (MI300X and MI355X) from `docker.io/vllm/vllm-openai-rocm:v0.21.0` to `docker.io/primussafe/vllm-openai-rocm:v0.21.0-rocm720-profilerfix`.

## Test plan
- [ ] Confirm the new image ref is correct and pullable.

Made with [Cursor](https://cursor.com)