### PR TITLE
feat(kernel-summary): add terminal outcome_class (success/fail/timeout/skip)

### DIFF
--- a/inference_optimizer/orchestrator/kernel_attempt_summary.py
+++ b/inference_optimizer/orchestrator/kernel_attempt_summary.py
@@ -25,6 +25,16 @@ CATEGORY_ATTEMPTED_REJECTED = "ATTEMPTED_REJECTED"
 CATEGORY_IN_FLIGHT = "IN_FLIGHT"
 CATEGORY_UNATTEMPTED = "UNATTEMPTED"
 
+#: Terminal kernel-outcome bucket. Closed 4-value set the dashboard reads
+#: directly (one uniform field across forge / geak / oob backends) instead of
+#: re-deriving from decision/status strings. ``IN_FLIGHT`` (no terminal
+#: decision) folds into ``fail`` -- a completed session should never leave a
+#: kernel mid-flight.
+OUTCOME_SUCCESS = "success"
+OUTCOME_FAIL = "fail"
+OUTCOME_TIMEOUT = "timeout"
+OUTCOME_SKIP = "skip"
+
 #: Sub-reason vocabulary for ``UNATTEMPTED`` kernels. Picked off the
 #: top15 entry's geometry (``source_file``, ``reusable_native_kernel``,
 #: ``recommended_backends``) so the front-end can filter by why.
@@ -283,6 +293,10 @@ def _load_backend_ladder(
             "attempt_id": str(a.get("attempt_id") or ""),
             "produced_artifact": produced,
         }
+        # Structured backend self-skip marker (forge bailed before any real
+        # attempt); surfaced so the outcome classifier can label ``skip``.
+        if a.get("skipped"):
+            row["skipped"] = True
         # Canonical source is elapsed_s; elapsed_sec read for forward-compat.
         elapsed = a.get("elapsed_s")
         if elapsed is None:
@@ -341,6 +355,72 @@ def _classify_attempted(
     if last_decision == "KEEP":
         return CATEGORY_KEEP_PENDING
     return CATEGORY_IN_FLIGHT
+
+
+def _kernel_outcome_class(
+    category: str,
+    backend_ladder: list[dict[str, Any]],
+) -> str:
+    """Map a kernel's category + backend ladder to a terminal outcome bucket.
+
+    Closed 4-value vocabulary (``success`` / ``fail`` / ``timeout`` / ``skip``),
+    derived only from structured signals so the dashboard reads one uniform
+    field across backends:
+
+    * ``success`` — kept/integrated (a KEEP reached).
+    * ``skip``    — never dispatched (``UNATTEMPTED``) OR every recorded attempt
+      self-skipped before real work (``skipped`` marker, e.g. forge bailed on a
+      compile-only/unsupported/non-git kernel).
+    * ``timeout`` — at least one attempt timed out (``error_class == timeout``)
+      and none of the above.
+    * ``fail``    — anything else that was attempted (compile/correctness/agent
+      errors, no measurable improvement, or a non-terminal ``IN_FLIGHT``).
+
+    Args:
+        category: The kernel's outcome category constant.
+        backend_ladder: Per-backend attempt rows for the kernel.
+
+    Returns:
+        One of ``OUTCOME_SUCCESS`` / ``OUTCOME_SKIP`` / ``OUTCOME_TIMEOUT`` /
+        ``OUTCOME_FAIL``.
+    """
+    if category in (CATEGORY_INTEGRATED, CATEGORY_KEEP_PENDING):
+        return OUTCOME_SUCCESS
+    if category == CATEGORY_UNATTEMPTED:
+        return OUTCOME_SKIP
+    ladder = backend_ladder or []
+    # Every recorded attempt self-skipped before doing real work -> skip. A mixed
+    # ladder (one backend skipped, another really tried) is NOT a skip.
+    if ladder and all(bool(r.get("skipped")) for r in ladder):
+        return OUTCOME_SKIP
+    if any(str(r.get("error_class") or "") == ERROR_CLASS_TIMEOUT for r in ladder):
+        return OUTCOME_TIMEOUT
+    return OUTCOME_FAIL
+
+
+def _session_kernel_opt_outcome(by_kernel: list[dict[str, Any]]) -> str:
+    """Roll per-kernel ``outcome_class`` up to one session-level verdict.
+
+    Precedence: any ``success`` -> ``success``; else if every kernel is
+    ``skip`` (or there are no kernels) -> ``skip``; else ``timeout`` only when a
+    timeout is present and no real ``fail``; otherwise ``fail``.
+
+    Args:
+        by_kernel: The per-kernel summary rows (each carrying ``outcome_class``).
+
+    Returns:
+        The session-level kernel-optimization outcome bucket.
+    """
+    classes = [str(r.get("outcome_class") or "") for r in by_kernel if r.get("outcome_class")]
+    if not classes:
+        return OUTCOME_SKIP
+    if OUTCOME_SUCCESS in classes:
+        return OUTCOME_SUCCESS
+    if all(c == OUTCOME_SKIP for c in classes):
+        return OUTCOME_SKIP
+    if OUTCOME_TIMEOUT in classes and OUTCOME_FAIL not in classes:
+        return OUTCOME_TIMEOUT
+    return OUTCOME_FAIL
 
 
 def _unattempted_reason(top_entry: dict[str, Any]) -> tuple[str, str]:
@@ -592,6 +672,9 @@ def build_kernel_optimization_summary(
         "session_id": session_id,
         "model_name": str(getattr(state, "model_name", "") or ""),
         "cumulative_gain_validated_pct": float(getattr(state, "cumulative_gain_validated", 0.0) or 0.0),
+        # Session-level kernel-optimization verdict (success/fail/timeout/skip),
+        # rolled up from each kernel's ``outcome_class``.
+        "kernel_opt_outcome": _session_kernel_opt_outcome(by_kernel),
         "totals": counts,
         "rejection_breakdown": rejection_breakdown,
         "unattempted_reason_breakdown": unattempted_breakdown,
@@ -634,6 +717,7 @@ def _render_unattempted_row(
         "reusable_native_kernel": bool(top_entry.get("reusable_native_kernel")),
         "recommended_backends": list(top_entry.get("recommended_backends") or []),
         "category": CATEGORY_UNATTEMPTED,
+        "outcome_class": OUTCOME_SKIP,
         "unattempted_reason": reason_code,
         "unattempted_detail": reason_detail,
         "summary": f"not attempted: {reason_code}",
@@ -727,6 +811,7 @@ def _render_attempted_row(
         "bound_type": str(top_entry.get("bound_type") or ""),
         "arithmetic_intensity": _to_float(top_entry.get("arithmetic_intensity")),
         "category": category,
+        "outcome_class": _kernel_outcome_class(category, ladder),
         "rejected_reason": str(attempt.get("rejected_reason") or ""),
         "summary": summary_text,
         "attempts_total": int(attempt.get("attempts") or 0),
@@ -942,6 +1027,10 @@ def _to_float(v: Any) -> float | None:
 
 __all__ = [
     "build_kernel_optimization_summary",
+    "OUTCOME_SUCCESS",
+    "OUTCOME_FAIL",
+    "OUTCOME_TIMEOUT",
+    "OUTCOME_SKIP",
     "CATEGORY_INTEGRATED",
     "CATEGORY_KEEP_PENDING",
     "ERROR_CLASS_TIMEOUT",

--- a/inference_optimizer/tests/test_kernel_attempt_summary_units.py
+++ b/inference_optimizer/tests/test_kernel_attempt_summary_units.py
@@ -194,3 +194,83 @@ def test_unattempted_reason_order():
         )[0]
         == kas.UNATTEMPTED_BELOW_CUTOFF
     )
+
+
+def test_load_backend_ladder_skipped_flag(tmp_path: Path):
+    # A forge self-skip attempt carries skipped=True; it must ride into the row.
+    payload = {
+        "attempts": [
+            {
+                "backend": "forge",
+                "status": "failed",
+                "attempt_id": "forge-1",
+                "returncode": 2,
+                "skipped": True,
+            },
+            {"backend": "geak", "status": "failed", "attempt_id": "geak-1"},
+        ],
+    }
+    f = tmp_path / "k.json"
+    f.write_text(json.dumps(payload), encoding="utf-8")
+    ladder, reason = kas._load_backend_ladder(tmp_path, "k")
+    assert reason == "" and len(ladder) == 2
+    assert ladder[0]["skipped"] is True
+    # Non-skip rows must not gain a skipped key.
+    assert "skipped" not in ladder[1]
+
+
+def test_kernel_outcome_class_mapping():
+    # success: kept / integrated.
+    assert kas._kernel_outcome_class(kas.CATEGORY_INTEGRATED, []) == kas.OUTCOME_SUCCESS
+    assert kas._kernel_outcome_class(kas.CATEGORY_KEEP_PENDING, []) == kas.OUTCOME_SUCCESS
+
+    # skip: never dispatched.
+    assert kas._kernel_outcome_class(kas.CATEGORY_UNATTEMPTED, []) == kas.OUTCOME_SKIP
+
+    # skip: every recorded attempt self-skipped.
+    all_skipped = [{"skipped": True, "error_class": kas.ERROR_CLASS_AGENT_ERROR}]
+    assert kas._kernel_outcome_class(kas.CATEGORY_ATTEMPTED_REJECTED, all_skipped) == kas.OUTCOME_SKIP
+
+    # mixed ladder (one skipped, one really failed) is NOT a skip -> fail.
+    mixed = [
+        {"skipped": True},
+        {"error_class": kas.ERROR_CLASS_COMPILE_FAILED},
+    ]
+    assert kas._kernel_outcome_class(kas.CATEGORY_ATTEMPTED_REJECTED, mixed) == kas.OUTCOME_FAIL
+
+    # timeout: any attempt timed out (and not all-skipped).
+    to = [{"error_class": kas.ERROR_CLASS_TIMEOUT}]
+    assert kas._kernel_outcome_class(kas.CATEGORY_ATTEMPTED_REJECTED, to) == kas.OUTCOME_TIMEOUT
+
+    # fail: attempted, real error, no skip/timeout.
+    fail = [{"error_class": kas.ERROR_CLASS_AGENT_ERROR}]
+    assert kas._kernel_outcome_class(kas.CATEGORY_ATTEMPTED_REJECTED, fail) == kas.OUTCOME_FAIL
+
+    # IN_FLIGHT folds into fail.
+    assert kas._kernel_outcome_class(kas.CATEGORY_IN_FLIGHT, []) == kas.OUTCOME_FAIL
+
+
+def test_session_kernel_opt_outcome_rollup():
+    out = kas._session_kernel_opt_outcome
+    # No kernels -> skip.
+    assert out([]) == kas.OUTCOME_SKIP
+    # Any success wins.
+    assert out([
+        {"outcome_class": kas.OUTCOME_FAIL},
+        {"outcome_class": kas.OUTCOME_SUCCESS},
+    ]) == kas.OUTCOME_SUCCESS
+    # All skip -> skip.
+    assert out([
+        {"outcome_class": kas.OUTCOME_SKIP},
+        {"outcome_class": kas.OUTCOME_SKIP},
+    ]) == kas.OUTCOME_SKIP
+    # timeout only when present and no real fail.
+    assert out([
+        {"outcome_class": kas.OUTCOME_SKIP},
+        {"outcome_class": kas.OUTCOME_TIMEOUT},
+    ]) == kas.OUTCOME_TIMEOUT
+    # fail dominates a co-occurring timeout.
+    assert out([
+        {"outcome_class": kas.OUTCOME_TIMEOUT},
+        {"outcome_class": kas.OUTCOME_FAIL},
+    ]) == kas.OUTCOME_FAIL

--- a/kernel-agent/tools/backends/forge_submit.py
+++ b/kernel-agent/tools/backends/forge_submit.py
@@ -1319,10 +1319,19 @@ def _export_best_artifacts(workspace: str, base_commit: str, worktree_kernel_fil
 
 
 def _normalized(returncode: int, stdout: str, stderr: str, elapsed_s: float,
-                gpu_ids: str = "") -> dict:
-    """Shape the result like oob_submit/geak_submit return dicts."""
+                gpu_ids: str = "", skipped: bool = False) -> dict:
+    """Shape the result like oob_submit/geak_submit return dicts.
+
+    ``skipped=True`` marks a forge self-skip: forge bailed before any real
+    optimization attempt (unsupported source type, repo not a clean git
+    checkout, no usable harness/driver, compile-only driver, etc.). It is the
+    structured signal downstream uses to classify the kernel outcome as ``skip``
+    rather than a kernel failure; forge returns ``returncode=2`` for every such
+    path, but consumers should read this flag rather than the return code.
+    """
     return {
         "returncode": returncode,
+        "skipped": bool(skipped),
         "stdout_tail": (stdout or "")[-4000:],
         "stderr_tail": (stderr or "")[-4000:],
         "stdout": stdout or "",
@@ -1737,7 +1746,7 @@ def submit(source_file: str, prompt_file: Path, output_dir: Path,
             2, "",
             "forge: aiter_asm prebuilt assembly compute-core (.co) is not "
             "editable from source; skipping (no rewritable kernel, no tuner)",
-            time.time() - started)
+            time.time() - started, skipped=True)
     fellow = _fellow_for_source_type(source_type)
     if kernel_kind == "aiter_ck" and fellow in ("hip-fellow", None):
         ck_fellow = _fellow_for_source_type("ck")
@@ -1748,7 +1757,7 @@ def submit(source_file: str, prompt_file: Path, output_dir: Path,
              (candidate or {}).get("operation", ""))
     if fellow is None:
         return _normalized(2, "", f"forge stage-1 supports triton only; got source_type={source_type}",
-                           time.time() - started)
+                           time.time() - started, skipped=True)
 
     session_id = output_dir.parent.name or "forge"
     kernel_id = Path(source_file).stem
@@ -1764,14 +1773,14 @@ def submit(source_file: str, prompt_file: Path, output_dir: Path,
         prep = _prepare_inplace(source_file, repo, branch)
         if prep is None:
             return _normalized(2, "", "forge: editable-finder package but repo is not a usable git "
-                               "checkout; skipping", time.time() - started)
+                               "checkout; skipping", time.time() - started, skipped=True)
         workspace, worktree_kernel, restore_info = prep
         base_commit = restore_info.get("base_commit") or ""
     else:
         wt_info = _prepare_worktree(source_file, kernel_repo, output_dir, branch)
         if wt_info is None:
             return _normalized(2, "", "forge: kernel_repo is not a clean git checkout or source_file "
-                               "not tracked; skipping (live repo untouched)", time.time() - started)
+                               "not tracked; skipping (live repo untouched)", time.time() - started, skipped=True)
         workspace, worktree_kernel, base_commit = wt_info
 
     try:
@@ -1797,7 +1806,7 @@ def submit(source_file: str, prompt_file: Path, output_dir: Path,
                     f"operation={candidate.get('operation')!r} kernel={worktree_kernel!r} "
                     f"(auto-gen supports gemm/matmul/activation/attention and HIP C++ "
                     "compile-only; other ops need a benchmark/test_command)",
-                    time.time() - started)
+                    time.time() - started, skipped=True)
             log.info("forge driver: autogen -> %s", driver)
         gpu_target = _resolve_gpu_target(candidate)
         # P0 baseline-correctness gate: a structurally broken auto-generated
@@ -1825,7 +1834,7 @@ def submit(source_file: str, prompt_file: Path, output_dir: Path,
                         f"forge skipped: harness baseline correctness invalid "
                         f"({gate_detail}); not spinning the agent on an "
                         "unverifiable harness",
-                        time.time() - started)
+                        time.time() - started, skipped=True)
         # Compile-only drivers cannot produce a real correctness/timing signal,
         # so any KEEP they yield is based on synthesized metrics. Skip forge for
         # such kernels (they fall through to the next ladder backend / are
@@ -1848,7 +1857,7 @@ def submit(source_file: str, prompt_file: Path, output_dir: Path,
                 "forge skipped: only a compile-only driver is available (no real "
                 "correctness/timing harness); not driving a KEEP decision off "
                 "synthesized metrics (set FORGE_ALLOW_COMPILE_ONLY=1 to override)",
-                time.time() - started)
+                time.time() - started, skipped=True)
         # GPU_TARGET is passed to Kernel-Forge's MCP server tools (build/bench/pmc)
         # via the forge-loop child env (_run_loop_via_cli sets env["GPU_TARGET"]),
         # so it is NOT written to the parent os.environ -- that would leak to the

--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -3457,6 +3457,11 @@ def run_attempt(
         "status": status,
         "error_type": status if status in {"backend_not_installed", "timeout"} else "",
         "returncode": returncode,
+        # Structured backend self-skip marker (e.g. forge bailed before any real
+        # optimization attempt: unsupported source / not a git checkout /
+        # compile-only driver). Lets the outcome classifier label the kernel as
+        # ``skip`` instead of a failure without parsing free-text stdout.
+        "skipped": bool(result.get("skipped")) if isinstance(result, dict) else False,
         "elapsed_s": elapsed,
         "prompt_path": str(prompt_file),
         "optimized_path": str(optimized_path) if optimized_path.exists() else "",

--- a/kernel-agent/tools/test_forge_submit.py
+++ b/kernel-agent/tools/test_forge_submit.py
@@ -182,6 +182,7 @@ def test_submit_skips_untracked_source(tmp_path):
         candidate={},
     )
     assert res["returncode"] == 2
+    assert res["skipped"] is True
     assert "kernel_repo is not a clean git checkout" in res["stderr_tail"]
 
 
@@ -242,6 +243,15 @@ def test_submit_skips_without_harness_or_template(tmp_path):
         candidate={},
     )
     assert res["returncode"] == 2
+    assert res["skipped"] is True
+
+
+def test_normalized_skipped_flag():
+    """``_normalized`` carries the structured self-skip marker; default is False."""
+    skip = forge_submit._normalized(2, "", "forge skipped: ...", 0.1, skipped=True)
+    assert skip["skipped"] is True and skip["returncode"] == 2
+    ran = forge_submit._normalized(0, "forge done", "", 0.1)
+    assert ran["skipped"] is False
 
 
 def test_run_loop_via_cli_parses_result(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Adds a single authoritative classification field so downstream dashboards (pulse) stop guessing kernel outcomes from `decision`/`status` strings — the guessing is what mis-bucketed forge's `REVERT`/`PARTIAL` into a "timeout" catch-all even though zero kernels actually timed out.

- New per-kernel `outcome_class` and session-level `kernel_opt_outcome` in `kernel_optimization_summary`, with a closed 4-value vocabulary: `success` / `fail` / `timeout` / `skip`.
- Outcomes derived from **structured signals only** (no stdout/keyword parsing):
  - `success`: kept/integrated (a KEEP reached) — `INTEGRATED` / `KEEP_PENDING`.
  - `skip`: never dispatched (`UNATTEMPTED`) OR every recorded attempt self-skipped.
  - `timeout`: an attempt's `error_class == timeout`.
  - `fail`: anything else attempted (compile/correctness/agent errors, no measurable improvement, or non-terminal `IN_FLIGHT`).
- To label forge self-skips (compile-only driver, non-git repo, unsupported source) as `skip` rather than `fail`, forge now emits a structured `skipped` flag on its `returncode 2` paths. The flag is propagated forge → attempt record → backend ladder → `outcome_class`.

## Why

An audit of 50 `forge` sessions showed `failure_reason_breakdown.timeout == 0` for all of them; the real causes were forge self-skips (no real timing harness / repo not a clean git checkout) and "ran, no speedup". The "all timeout" label was purely a downstream bucketing artifact. This PR gives every backend one uniform, structured outcome field so consumers never re-derive it.

## Scope / safety

- Additive only: new fields ride through the verbatim breakdown passthrough (`out = dict(blob)`); no schema change.
- Existing fields (`error_class`, `category`, `failure_reason_breakdown`, decisions) and geak/geakv4/oob behavior are untouched.
- Historical sessions simply lack the new field (null) — no impact on historical collection.

## Test plan

- [x] `test_kernel_attempt_summary_units.py`: skipped-flag ladder propagation, 4-value `outcome_class` mapping (incl. mixed ladder ≠ skip, IN_FLIGHT → fail), session rollup precedence.
- [x] `test_forge_submit.py`: `skipped` flag on real skip paths + `_normalized` default.
- [x] `test_kernel_attempt_summary.py` + `test_breakdown_smoke.py` (150 passed) — output shape / passthrough unaffected.
- [ ] Confirm pulse reads `outcome_class` / `kernel_opt_outcome` from raw_data (downstream follow-up).

Made with [Cursor](https://cursor.com)