### PR TITLE
Fix gbrain recipe KB lookup identity

### DIFF
--- a/inference_optimizer/orchestrator/cortex_t0.py
+++ b/inference_optimizer/orchestrator/cortex_t0.py
@@ -935,7 +935,13 @@ def run_t0_anchor(
     # Backfill operator-tracing metadata; T0 only stamps metadata (best_config preserved, rewritten at CLOSE).
     _extra: Mapping[str, Any] = extra_attrs if isinstance(extra_attrs, Mapping) else {}
     _model_class = str(_extra.get("model_class") or "").strip()
-    _framework = str(_extra.get("framework_name") or "").strip()
+    _framework = str(
+        _extra.get("framework_name")
+        or _extra.get("framework")
+        or getattr(shared_state, "framework", "")
+        or os.environ.get("FRAMEWORK", "")
+        or ""
+    ).strip()
     _precision = str(getattr(shared_state, "precision", "") or "").strip()
     fp: Mapping[str, Any] = stack_fingerprint if isinstance(stack_fingerprint, Mapping) else {}
     # framework_version: SharedState > stack_fingerprint > importlib auto-detect.

--- a/inference_optimizer/recipe_kb/gbrain_ingest.py
+++ b/inference_optimizer/recipe_kb/gbrain_ingest.py
@@ -65,6 +65,8 @@ _YAML_KEYWORDS = frozenset(
 )
 
 _TAG_CLEAN = str.maketrans({" ": "-", "\t": "-", "/": "-"})
+_DEFAULT_RECIPE_SLUG_PREFIX = "hyperloom-recipe-kb"
+_RECIPE_SLUG_PREFIX_ENV = "GBRAIN_RECIPE_SLUG_PREFIX"
 
 
 def _tag_value(value: Any) -> str:
@@ -80,6 +82,17 @@ def _tag_value(value: Any) -> str:
         The tag slug, or ``"unknown"`` when the value is empty.
     """
     return str(value or "").strip().lower().translate(_TAG_CLEAN).strip("-") or "unknown"
+
+
+def _recipe_slug_prefix() -> str:
+    """Return the configured gbrain recipe page slug prefix.
+
+    Returns:
+        The normalized ``GBRAIN_RECIPE_SLUG_PREFIX`` value, or the default
+        production recipe namespace when the env is unset.
+    """
+    raw = os.environ.get(_RECIPE_SLUG_PREFIX_ENV, "").strip().strip("/")
+    return raw or _DEFAULT_RECIPE_SLUG_PREFIX
 
 
 def _scalar(value: Any) -> str:
@@ -312,7 +325,7 @@ def recipe_to_page(recipe: Mapping[str, Any]) -> tuple[str, str] | None:
         "attrs": attrs,
     }
     # Stable slug from the 7-tuple canonical (colons -> path levels).
-    slug = "hyperloom-recipe-kb/" + canonical.replace(":", "/")
+    slug = _recipe_slug_prefix() + "/" + canonical.replace(":", "/")
     body_lines = [
         f"# Recipe {canonical}",
         "",

--- a/inference_optimizer/recipe_kb/gbrain_remote_client.py
+++ b/inference_optimizer/recipe_kb/gbrain_remote_client.py
@@ -13,8 +13,8 @@ Design fit: this honours the recipe_kb local-first contract verbatim —
 writes still go local-only through the dispatcher; gbrain is consulted
 for READS only.
 
-Schema adaptation (read-time): gbrain stores session-sourced recipes under
-``hyperloom-session-kb/`` by default (overridable via
+Schema adaptation (read-time): gbrain stores recipes under
+``hyperloom-recipe-kb/`` by default (overridable via
 ``GBRAIN_RECIPE_SLUG_PREFIX``) as better-landing pages (``type: recipe`` +
 ``tags: model:/gpu:/framework_name:`` + flat ``attrs``). On read we
 re-derive the 7-tuple identity from the page attrs, fall back to the
@@ -60,7 +60,7 @@ _ENVS_KEY = "extra_envs"
 _RECIPE_SCAN_CAP = 25000
 _LIST_PAGE_SIZE = 100
 _SCAN_CACHE_TTL_SEC = 60.0
-_DEFAULT_RECIPE_SLUG_PREFIX = "hyperloom-session-kb"
+_DEFAULT_RECIPE_SLUG_PREFIX = "hyperloom-recipe-kb"
 _RECIPE_SLUG_PREFIX_ENV = "GBRAIN_RECIPE_SLUG_PREFIX"
 
 # Wall-clock budget for one full ``_scan_recipes`` pass. ``search`` fetches the

--- a/inference_optimizer/recipe_kb/gbrain_remote_client.py
+++ b/inference_optimizer/recipe_kb/gbrain_remote_client.py
@@ -13,16 +13,15 @@ Design fit: this honours the recipe_kb local-first contract verbatim —
 writes still go local-only through the dispatcher; gbrain is consulted
 for READS only.
 
-Schema adaptation (read-time): gbrain stores recipes as better-landing
-pages (``type: recipe`` + ``tags: model:/gpu:/framework_name:`` + flat
-``attrs``). On read we re-derive the 5-tuple identity
-(``inference:model:hardware:framework_name:framework_version:precision``)
-from the page attrs, fall back to the ``unknown_*`` default slugs for
-dimensions gbrain never recorded, and project the page into the unified
-nested KB-interface envelope. The recipe corpus is small
-(tens-to-hundreds of rows), so ``search`` lists the ``recipe`` type and
-filters client-side, which sidesteps slug-scheme differences between
-gbrain tags and the canonical id.
+Schema adaptation (read-time): gbrain stores session-sourced recipes under
+``hyperloom-session-kb/`` by default (overridable via
+``GBRAIN_RECIPE_SLUG_PREFIX``) as better-landing pages (``type: recipe`` +
+``tags: model:/gpu:/framework_name:`` + flat ``attrs``). On read we
+re-derive the 7-tuple identity from the page attrs, fall back to the
+``unknown_*`` default slugs for dimensions gbrain never recorded, and
+project the page into the unified nested KB-interface envelope. ``search``
+lists the ``recipe`` type and filters client-side, restricted to the
+configured slug prefix so the legacy mirror corpus is ignored.
 
 Wire shape returned by every read is the unified nested KB-interface
 envelope (``labels`` / ``body`` / ``metrics`` / ``findings`` /
@@ -58,9 +57,11 @@ _ENVS_KEY = "extra_envs"
 # Listing the whole recipe type is a fallback path; prefer exact slug reads for
 # get_recipe and cache broad scans so one warm-start tick does not issue
 # thousands of MCP get_page calls repeatedly.
-_RECIPE_SCAN_CAP = 5000
+_RECIPE_SCAN_CAP = 25000
 _LIST_PAGE_SIZE = 100
 _SCAN_CACHE_TTL_SEC = 60.0
+_DEFAULT_RECIPE_SLUG_PREFIX = "hyperloom-session-kb"
+_RECIPE_SLUG_PREFIX_ENV = "GBRAIN_RECIPE_SLUG_PREFIX"
 
 # Wall-clock budget for one full ``_scan_recipes`` pass. ``search`` fetches the
 # whole recipe corpus (list_pages + a get_page per slug) and filters
@@ -432,6 +433,42 @@ def _best_config_from_attrs(attrs: Mapping[str, Any]) -> dict[str, Any]:
     return out
 
 
+def _session_entries_from_attrs(attrs: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Build traceability session entries from session-sourced gbrain attrs.
+
+    Args:
+        attrs: The flat gbrain attrs mapping.
+
+    Returns:
+        A list of ``{"session_id": ...}`` entries, preserving the page's
+        contributing session ids. Falls back to the canonical ``session_id``
+        when ``session_ids`` is absent.
+    """
+    raw_ids = attrs.get("session_ids")
+    ids: list[str] = []
+    if isinstance(raw_ids, list):
+        ids = [str(x).strip() for x in raw_ids if str(x or "").strip()]
+    sid = str(attrs.get("session_id") or "").strip()
+    if sid and sid not in ids:
+        ids.insert(0, sid)
+    return [{"session_id": sid_val} for sid_val in ids]
+
+
+def _provenance_from_attrs(frontmatter: Mapping[str, Any], attrs: Mapping[str, Any]) -> dict[str, Any]:
+    """Merge page provenance with session-sourced traceability metadata."""
+    provenance = dict(frontmatter.get("provenance") or {})
+    provenance.setdefault("source", _recipe_slug_prefix())
+    sid = str(attrs.get("session_id") or "").strip()
+    if sid:
+        provenance["session_id"] = sid
+    raw_ids = attrs.get("session_ids")
+    if isinstance(raw_ids, list):
+        session_ids = [str(x).strip() for x in raw_ids if str(x or "").strip()]
+        if session_ids:
+            provenance["session_ids"] = session_ids
+    return provenance
+
+
 def _page_to_recipe(frontmatter: Mapping[str, Any]) -> dict[str, Any] | None:
     """Adapt a gbrain recipe page's frontmatter to the unified KB shape.
 
@@ -497,7 +534,7 @@ def _page_to_recipe(frontmatter: Mapping[str, Any]) -> dict[str, Any] | None:
             "best_config": _best_config_from_attrs(attrs),
             "best_throughput": throughput,
             "stack_fingerprint": dict(attrs.get("stack_fingerprint") or {}),
-            "sessions": [],
+            "sessions": _session_entries_from_attrs(attrs),
             "last_profiled": "",
             "prs_tested": _json_list(attrs.get("prs_tested")),
         },
@@ -514,7 +551,7 @@ def _page_to_recipe(frontmatter: Mapping[str, Any]) -> dict[str, Any] | None:
         C.F_AUTHORITY: str(frontmatter.get("authority") or C.AUTHORITY_EXPERIENTIAL),
         C.F_CONFIDENCE: _as_float(frontmatter.get("confidence")) or C.DEFAULT_CONFIDENCE,
         C.F_EVIDENCE_REFS: list(frontmatter.get("evidence_refs") or []),
-        C.F_PROVENANCE: dict(frontmatter.get("provenance") or {}),
+        C.F_PROVENANCE: _provenance_from_attrs(frontmatter, attrs),
     }
 
 
@@ -574,6 +611,22 @@ def _labels_match(recipe: Mapping[str, Any], label_match: Mapping[str, Any]) -> 
         elif key in recipe_labels and recipe_labels[key] != want.get(key):
             return False
     return True
+
+
+def _recipe_slug_prefix() -> str:
+    """Return the configured gbrain recipe page slug prefix."""
+    raw = os.environ.get(_RECIPE_SLUG_PREFIX_ENV, "").strip().strip("/")
+    return raw or _DEFAULT_RECIPE_SLUG_PREFIX
+
+
+def _is_session_recipe_slug(slug: str) -> bool:
+    """Return whether a gbrain slug belongs to the configured recipe KB."""
+    return str(slug or "").startswith(_recipe_slug_prefix() + "/")
+
+
+def _slug_for_canonical(canonical_id: str) -> str:
+    """Build the configured gbrain slug for a canonical_id."""
+    return _recipe_slug_prefix() + "/" + canonical_id.replace(":", "/")
 
 
 class GbrainRemoteRecipeClient:
@@ -779,7 +832,6 @@ class GbrainRemoteRecipeClient:
         seen_slugs: set[str] = set()
         cap = min(int(limit) if limit and limit > 0 else _RECIPE_SCAN_CAP, _RECIPE_SCAN_CAP)
         pages = 0
-        max_pages = max(1, (_RECIPE_SCAN_CAP // _LIST_PAGE_SIZE) + 3)
         # Best-effort wall-clock budget: gbrain is a read side-channel and the
         # local store is always available, so a full corpus scan must not
         # dominate the foreground (T0 boot) loop. When the budget is exceeded we
@@ -788,7 +840,7 @@ class GbrainRemoteRecipeClient:
         budget = self._scan_budget()
         deadline = time.monotonic() + budget if budget > 0.0 else None
         budget_hit = False
-        while len(out) < cap and pages < max_pages:
+        while len(out) < cap:
             if deadline is not None and time.monotonic() >= deadline:
                 budget_hit = True
                 break
@@ -808,7 +860,7 @@ class GbrainRemoteRecipeClient:
                     budget_hit = True
                     break
                 slug = entry.get("slug") if isinstance(entry, dict) else None
-                if not slug or slug in seen_slugs:
+                if not slug or not _is_session_recipe_slug(str(slug)) or slug in seen_slugs:
                     continue
                 seen_slugs.add(slug)
                 new_slugs += 1
@@ -892,11 +944,36 @@ class GbrainRemoteRecipeClient:
             C.F_LABEL_MODEL_TYPE: model_type,
             C.F_LABEL_ARCHITECTURES: architectures,
         }
-        # Fast path: gbrain recipe slugs are the canonical id with ':' as path
-        # separators, so exact 7-tuple reads do not need a full corpus scan.
-        direct = self._get_page_recipe("hyperloom-recipe-kb/" + canonical_id.replace(":", "/"))
+        # Fast path: session-sourced gbrain recipe slugs are the canonical id
+        # with ':' as path separators, so exact 7-tuple reads do not need a
+        # full corpus scan.
+        direct = self._get_page_recipe(_slug_for_canonical(canonical_id))
         if direct is not None and direct.get(C.F_CANONICAL_ID) == canonical_id:
             return direct
+        if framework_version != C.DEFAULT_FRAMEWORK_VERSION_SLUG:
+            # Older raw sessions may not carry framework_version. The session
+            # mirror writes those pages under unknown_version; fall back there
+            # directly before paying for a corpus scan.
+            unknown_version_id = recipe_canonical_id(
+                model=model,
+                hardware=hardware,
+                framework_name=framework_name,
+                model_type=model_type,
+                architectures=architectures,
+                framework_version=C.DEFAULT_FRAMEWORK_VERSION_SLUG,
+                precision=precision,
+            )
+            direct = self._get_page_recipe(_slug_for_canonical(unknown_version_id))
+            relaxed_labels = {
+                C.F_LABEL_MODEL: model,
+                C.F_LABEL_HARDWARE: hardware,
+                C.F_LABEL_FRAMEWORK_NAME: framework_name,
+                C.F_LABEL_PRECISION: precision,
+                C.F_LABEL_MODEL_TYPE: model_type,
+                C.F_LABEL_ARCHITECTURES: architectures,
+            }
+            if direct is not None and _labels_match(direct, relaxed_labels):
+                return direct
         rows = self.search(label_match=label_match, limit=1)
         return rows[0] if rows else None
 

--- a/inference_optimizer/recipe_kb/gbrain_remote_client.py
+++ b/inference_optimizer/recipe_kb/gbrain_remote_client.py
@@ -789,7 +789,7 @@ class GbrainRemoteRecipeClient:
             if not isinstance(hit, Mapping):
                 continue
             slug = str(hit.get("slug") or hit.get("id") or "")
-            if not slug or slug in seen:
+            if not slug or not _is_session_recipe_slug(slug) or slug in seen:
                 continue
             seen.add(slug)
             recipe = self._get_page_recipe(slug)

--- a/inference_optimizer/tests/test_cortex_t0_anchor.py
+++ b/inference_optimizer/tests/test_cortex_t0_anchor.py
@@ -132,6 +132,33 @@ def test_t0_anchor_writes_recipe_row_with_arbor_schema(
     assert row.get("tp") == 8
 
 
+def test_t0_anchor_accepts_legacy_framework_extra_attr(
+    kb: RecipeKB,
+    session_dir: Path,
+) -> None:
+    """Legacy ``framework`` attrs should not produce unknown_framework keys."""
+    state = _FakeSharedState(framework_version="0.5.11")
+    state.framework_name = ""
+    run_t0_anchor(
+        kb,
+        state,
+        workload="m",
+        hw="mi300x",
+        extra_attrs={"framework": "sglang"},
+        session_dir=session_dir,
+    )
+
+    cid = recipe_canonical_id(
+        model="m",
+        hardware="mi300x",
+        framework_name="sglang",
+        framework_version="0.5.11",
+        precision="fp8",
+    )
+    assert kb.local.get_recipe(canonical_id=cid) is not None
+    assert "unknown_framework" not in state.warm_start_recipe.get("workload", "")
+
+
 def test_t0_anchor_writes_warm_start_snapshot_to_disk(
     kb: RecipeKB,
     session_dir: Path,

--- a/inference_optimizer/tests/test_gbrain_ingest.py
+++ b/inference_optimizer/tests/test_gbrain_ingest.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from inference_optimizer.recipe_kb.gbrain_ingest import (
     _best_config_split,
+    _recipe_slug_prefix,
     _scalar,
     ingest_local_to_gbrain,
     recipe_to_page,
@@ -97,6 +98,16 @@ def test_recipe_to_page_roundtrips_via_reader() -> None:
         "extra_envs": {"FOO": "1"},
     }
     assert r["body"]["best_throughput"] == 5800.5
+
+
+def test_recipe_to_page_uses_configured_slug_prefix(monkeypatch) -> None:
+    """The ingest write side must use the same prefix env as gbrain reads."""
+    monkeypatch.setenv("GBRAIN_RECIPE_SLUG_PREFIX", "/hyperloom-session-kb/")
+
+    slug, _content = recipe_to_page(_recipe())
+
+    assert _recipe_slug_prefix() == "hyperloom-session-kb"
+    assert slug == "hyperloom-session-kb/inference/qwen3-32b/mi300x/sglang/unknown_model_type/unknown_arch/0_5_11/fp8"
 
 
 def test_best_config_split_unwraps_nested_extra_envs() -> None:
@@ -217,6 +228,7 @@ class _FakeMcp:
 
 def test_ingest_counts_and_gates(monkeypatch) -> None:
     monkeypatch.delenv("RECIPE_KB_MIRROR_REQUIRE_SIGNAL", raising=False)
+    monkeypatch.setenv("GBRAIN_RECIPE_SLUG_PREFIX", "hyperloom-session-kb")
     recipes = [
         _recipe(),
         _recipe(canonical_id="inference:a:b:c:d:e", best_config={}),  # anchor -> mirror
@@ -231,6 +243,7 @@ def test_ingest_counts_and_gates(monkeypatch) -> None:
     assert stats["skipped_no_config"] == 1  # legacy alias
     assert stats["errors"] == 0
     assert len(mcp.puts) == 3
+    assert all(slug.startswith("hyperloom-session-kb/") for slug in mcp.puts)
 
 
 def test_ingest_dry_run_writes_nothing() -> None:

--- a/inference_optimizer/tests/test_gbrain_recipe_champion.py
+++ b/inference_optimizer/tests/test_gbrain_recipe_champion.py
@@ -25,6 +25,7 @@ from inference_optimizer.recipe_kb.gbrain_remote_client import (
 )
 
 _ARGS_KEY = "extra_server_args"
+_RECIPE_SLUG_PREFIX = "hyperloom-recipe-kb"
 
 
 class _Spec:
@@ -199,7 +200,7 @@ def _gbrain_dispatcher(local: LocalRecipeStore) -> RecipeKB:
         enabled=True,
     )
     client._mcp = _FakeMcp(  # type: ignore[assignment]
-        {f"recipe/{i}": s.gbrain_page() for i, s in enumerate(SPECS)}
+        {f"{_RECIPE_SLUG_PREFIX}/recipe/{i}": s.gbrain_page() for i, s in enumerate(SPECS)}
     )
     return RecipeKB(local=local, remote=client)
 

--- a/inference_optimizer/tests/test_gbrain_remote_recipe_client.py
+++ b/inference_optimizer/tests/test_gbrain_remote_recipe_client.py
@@ -92,6 +92,14 @@ def _recipe_page(
     }
 
 
+def _session_slug(canonical_path: str) -> str:
+    return "hyperloom-session-kb/" + canonical_path
+
+
+def _custom_slug(canonical_path: str) -> str:
+    return "custom-recipe-kb/" + canonical_path
+
+
 def test_page_to_recipe_maps_identity_and_config() -> None:
     fm = _recipe_page("Qwen/Qwen3-32B", "mi300x", "sglang", "fp8", args="--cuda-graph-max-bs 256", gain=12.5)
     r = _page_to_recipe(fm)
@@ -111,6 +119,30 @@ def test_page_to_recipe_maps_identity_and_config() -> None:
     assert r["authority"] == "EXPERIENTIAL"
 
 
+def test_page_to_recipe_projects_session_provenance() -> None:
+    fm = _recipe_page("Qwen3-32B", "mi300x", "sglang", "fp8", args="--x")
+    fm["attrs"]["session_id"] = "origin-session"
+    fm["attrs"]["session_ids"] = ["origin-session", "other-session"]
+
+    r = _page_to_recipe(fm)
+
+    assert r is not None
+    assert r["body"]["sessions"] == [{"session_id": "origin-session"}, {"session_id": "other-session"}]
+    assert r["provenance"]["source"] == "hyperloom-session-kb"
+    assert r["provenance"]["session_id"] == "origin-session"
+    assert r["provenance"]["session_ids"] == ["origin-session", "other-session"]
+
+
+def test_recipe_slug_prefix_env_controls_provenance(monkeypatch: Any) -> None:
+    monkeypatch.setenv("GBRAIN_RECIPE_SLUG_PREFIX", "custom-recipe-kb/")
+    fm = _recipe_page("Qwen3-32B", "mi300x", "sglang", "fp8")
+
+    r = _page_to_recipe(fm)
+
+    assert r is not None
+    assert r["provenance"]["source"] == "custom-recipe-kb"
+
+
 def test_page_to_recipe_requires_identity() -> None:
     assert _page_to_recipe({"attrs": {"model": "", "hardware": "mi300x"}}) is None
     assert _page_to_recipe({"attrs": {}}) is None
@@ -119,7 +151,9 @@ def test_page_to_recipe_requires_identity() -> None:
 def test_get_recipe_roundtrip() -> None:
     c = _client(
         {
-            "cortex/recipe/qwen3-32b/mi300x": _recipe_page("Qwen3-32B", "mi300x", "sglang", "fp8"),
+            _session_slug("inference/qwen3-32b/mi300x/sglang/unknown_model_type/unknown_arch/unknown_version/fp8"): (
+                _recipe_page("Qwen3-32B", "mi300x", "sglang", "fp8")
+            ),
         }
     )
     cid = "inference:qwen3-32b:mi300x:sglang:unknown_model_type:unknown_arch:unknown_version:fp8"
@@ -128,11 +162,11 @@ def test_get_recipe_roundtrip() -> None:
 
 
 def test_get_recipe_uses_direct_slug_fast_path() -> None:
-    slug = "hyperloom-recipe-kb/inference/qwen3-32b/mi300x/sglang/unknown_model_type/unknown_arch/unknown_version/fp8"
+    slug = _session_slug("inference/qwen3-32b/mi300x/sglang/unknown_model_type/unknown_arch/unknown_version/fp8")
     c = _client(
         {
             slug: _recipe_page("Qwen3-32B", "mi300x", "sglang", "fp8"),
-            "hyperloom-recipe-kb/inference/other/mi300x/sglang/unknown_model_type/unknown_arch/unknown_version/fp8": (
+            _session_slug("inference/other/mi300x/sglang/unknown_model_type/unknown_arch/unknown_version/fp8"): (
                 _recipe_page("Other", "mi300x", "sglang", "fp8")
             ),
         }
@@ -146,8 +180,35 @@ def test_get_recipe_uses_direct_slug_fast_path() -> None:
     assert [tool for tool, _ in c._mcp.calls] == ["get_page"]  # type: ignore[union-attr]
 
 
+def test_get_recipe_unknown_version_direct_fallback() -> None:
+    slug = _session_slug("inference/qwen3-32b/mi300x/sglang/qwen3/qwen3forcausallm/unknown_version/fp8")
+    fm = _recipe_page("Qwen3-32B", "mi300x", "sglang", "fp8")
+    fm["attrs"]["model_type"] = "qwen3"
+    fm["attrs"]["architectures"] = ["Qwen3ForCausalLM"]
+    c = _client({slug: fm})
+    cid = "inference:qwen3-32b:mi300x:sglang:qwen3:qwen3forcausallm:0.5.12:fp8"
+
+    r = c.get_recipe(canonical_id=cid)
+
+    assert r is not None
+    assert r["canonical_id"] == "inference:qwen3-32b:mi300x:sglang:qwen3:qwen3forcausallm:unknown_version:fp8"
+    assert [tool for tool, _ in c._mcp.calls] == ["get_page", "get_page"]  # exact then unknown_version
+
+
+def test_get_recipe_uses_configured_slug_prefix(monkeypatch: Any) -> None:
+    monkeypatch.setenv("GBRAIN_RECIPE_SLUG_PREFIX", "custom-recipe-kb")
+    slug = _custom_slug("inference/qwen3-32b/mi300x/sglang/unknown_model_type/unknown_arch/unknown_version/fp8")
+    c = _client({slug: _recipe_page("Qwen3-32B", "mi300x", "sglang", "fp8")})
+    cid = "inference:qwen3-32b:mi300x:sglang:unknown_model_type:unknown_arch:unknown_version:fp8"
+
+    r = c.get_recipe(canonical_id=cid)
+
+    assert r is not None and r["canonical_id"] == cid
+    assert c._mcp.calls[0] == ("get_page", {"slug": slug})  # type: ignore[union-attr]
+
+
 def test_get_recipe_miss_on_unknown() -> None:
-    c = _client({"cortex/recipe/a/b": _recipe_page("modelA", "mi300x")})
+    c = _client({_session_slug("inference/modela/mi300x/sglang/unknown_model_type/unknown_arch/unknown_version/unknown_precision"): _recipe_page("modelA", "mi300x")})
     assert c.get_recipe(canonical_id="inference:other:mi355x:vllm:v1:fp16") is None
 
 
@@ -166,9 +227,10 @@ def _model(row: dict[str, Any]) -> str:
 def test_search_filters_by_label_match() -> None:
     c = _client(
         {
-            "r1": _recipe_page("Qwen3-32B", "mi300x", "sglang"),
-            "r2": _recipe_page("Llama-3-70B", "mi300x", "vllm"),
-            "r3": _recipe_page("Qwen3-32B", "mi355x", "sglang"),
+            _session_slug("r1"): _recipe_page("Qwen3-32B", "mi300x", "sglang"),
+            _session_slug("r2"): _recipe_page("Llama-3-70B", "mi300x", "vllm"),
+            _session_slug("r3"): _recipe_page("Qwen3-32B", "mi355x", "sglang"),
+            "hyperloom-recipe-kb/legacy": _recipe_page("Qwen3-32B", "mi300x", "sglang"),
         }
     )
     # model-only filter → both Qwen rows. The gbrain adapter returns the
@@ -183,11 +245,26 @@ def test_search_filters_by_label_match() -> None:
     assert len(rows) == 1 and _model(rows[0]) == "llama-3-70b"
 
 
+def test_search_filters_by_configured_slug_prefix(monkeypatch: Any) -> None:
+    monkeypatch.setenv("GBRAIN_RECIPE_SLUG_PREFIX", "custom-recipe-kb")
+    c = _client(
+        {
+            _custom_slug("r1"): _recipe_page("Qwen3-32B", "mi300x", "sglang"),
+            _session_slug("r2"): _recipe_page("Qwen3-32B", "mi355x", "sglang"),
+        }
+    )
+
+    rows = c.search(label_match={"model": "Qwen3-32B"})
+
+    assert len(rows) == 1
+    assert _hw(rows[0]) == "mi300x"
+
+
 def test_search_reuses_scan_cache() -> None:
     c = _client(
         {
-            "r1": _recipe_page("Qwen3-32B", "mi300x", "sglang"),
-            "r2": _recipe_page("Llama-3-70B", "mi300x", "vllm"),
+            _session_slug("r1"): _recipe_page("Qwen3-32B", "mi300x", "sglang"),
+            _session_slug("r2"): _recipe_page("Llama-3-70B", "mi300x", "vllm"),
         }
     )
 
@@ -211,7 +288,7 @@ def test_disabled_client_returns_empty() -> None:
 
 
 def test_get_history_and_attempts_are_empty() -> None:
-    c = _client({"r1": _recipe_page("m", "mi300x")})
+    c = _client({_session_slug("r1"): _recipe_page("m", "mi300x")})
     assert c.get_history(canonical_id="inference:m:mi300x:sglang:v:p") == []
     assert c.list_attempts(canonical_id="inference:m:mi300x:sglang:v:p") == []
     assert c.list_session_attempts(session_id="s") == []

--- a/inference_optimizer/tests/test_gbrain_remote_recipe_client.py
+++ b/inference_optimizer/tests/test_gbrain_remote_recipe_client.py
@@ -96,6 +96,10 @@ def _session_slug(canonical_path: str) -> str:
     return "hyperloom-session-kb/" + canonical_path
 
 
+def _default_slug(canonical_path: str) -> str:
+    return "hyperloom-recipe-kb/" + canonical_path
+
+
 def _custom_slug(canonical_path: str) -> str:
     return "custom-recipe-kb/" + canonical_path
 
@@ -128,7 +132,7 @@ def test_page_to_recipe_projects_session_provenance() -> None:
 
     assert r is not None
     assert r["body"]["sessions"] == [{"session_id": "origin-session"}, {"session_id": "other-session"}]
-    assert r["provenance"]["source"] == "hyperloom-session-kb"
+    assert r["provenance"]["source"] == "hyperloom-recipe-kb"
     assert r["provenance"]["session_id"] == "origin-session"
     assert r["provenance"]["session_ids"] == ["origin-session", "other-session"]
 
@@ -151,7 +155,7 @@ def test_page_to_recipe_requires_identity() -> None:
 def test_get_recipe_roundtrip() -> None:
     c = _client(
         {
-            _session_slug("inference/qwen3-32b/mi300x/sglang/unknown_model_type/unknown_arch/unknown_version/fp8"): (
+            _default_slug("inference/qwen3-32b/mi300x/sglang/unknown_model_type/unknown_arch/unknown_version/fp8"): (
                 _recipe_page("Qwen3-32B", "mi300x", "sglang", "fp8")
             ),
         }
@@ -162,11 +166,11 @@ def test_get_recipe_roundtrip() -> None:
 
 
 def test_get_recipe_uses_direct_slug_fast_path() -> None:
-    slug = _session_slug("inference/qwen3-32b/mi300x/sglang/unknown_model_type/unknown_arch/unknown_version/fp8")
+    slug = _default_slug("inference/qwen3-32b/mi300x/sglang/unknown_model_type/unknown_arch/unknown_version/fp8")
     c = _client(
         {
             slug: _recipe_page("Qwen3-32B", "mi300x", "sglang", "fp8"),
-            _session_slug("inference/other/mi300x/sglang/unknown_model_type/unknown_arch/unknown_version/fp8"): (
+            _default_slug("inference/other/mi300x/sglang/unknown_model_type/unknown_arch/unknown_version/fp8"): (
                 _recipe_page("Other", "mi300x", "sglang", "fp8")
             ),
         }
@@ -181,7 +185,7 @@ def test_get_recipe_uses_direct_slug_fast_path() -> None:
 
 
 def test_get_recipe_unknown_version_direct_fallback() -> None:
-    slug = _session_slug("inference/qwen3-32b/mi300x/sglang/qwen3/qwen3forcausallm/unknown_version/fp8")
+    slug = _default_slug("inference/qwen3-32b/mi300x/sglang/qwen3/qwen3forcausallm/unknown_version/fp8")
     fm = _recipe_page("Qwen3-32B", "mi300x", "sglang", "fp8")
     fm["attrs"]["model_type"] = "qwen3"
     fm["attrs"]["architectures"] = ["Qwen3ForCausalLM"]
@@ -208,7 +212,7 @@ def test_get_recipe_uses_configured_slug_prefix(monkeypatch: Any) -> None:
 
 
 def test_get_recipe_miss_on_unknown() -> None:
-    c = _client({_session_slug("inference/modela/mi300x/sglang/unknown_model_type/unknown_arch/unknown_version/unknown_precision"): _recipe_page("modelA", "mi300x")})
+    c = _client({_default_slug("inference/modela/mi300x/sglang/unknown_model_type/unknown_arch/unknown_version/unknown_precision"): _recipe_page("modelA", "mi300x")})
     assert c.get_recipe(canonical_id="inference:other:mi355x:vllm:v1:fp16") is None
 
 
@@ -227,10 +231,10 @@ def _model(row: dict[str, Any]) -> str:
 def test_search_filters_by_label_match() -> None:
     c = _client(
         {
-            _session_slug("r1"): _recipe_page("Qwen3-32B", "mi300x", "sglang"),
-            _session_slug("r2"): _recipe_page("Llama-3-70B", "mi300x", "vllm"),
-            _session_slug("r3"): _recipe_page("Qwen3-32B", "mi355x", "sglang"),
-            "hyperloom-recipe-kb/legacy": _recipe_page("Qwen3-32B", "mi300x", "sglang"),
+            _default_slug("r1"): _recipe_page("Qwen3-32B", "mi300x", "sglang"),
+            _default_slug("r2"): _recipe_page("Llama-3-70B", "mi300x", "vllm"),
+            _default_slug("r3"): _recipe_page("Qwen3-32B", "mi355x", "sglang"),
+            _session_slug("legacy"): _recipe_page("Qwen3-32B", "mi300x", "sglang"),
         }
     )
     # model-only filter → both Qwen rows. The gbrain adapter returns the
@@ -263,8 +267,8 @@ def test_search_filters_by_configured_slug_prefix(monkeypatch: Any) -> None:
 def test_search_reuses_scan_cache() -> None:
     c = _client(
         {
-            _session_slug("r1"): _recipe_page("Qwen3-32B", "mi300x", "sglang"),
-            _session_slug("r2"): _recipe_page("Llama-3-70B", "mi300x", "vllm"),
+            _default_slug("r1"): _recipe_page("Qwen3-32B", "mi300x", "sglang"),
+            _default_slug("r2"): _recipe_page("Llama-3-70B", "mi300x", "vllm"),
         }
     )
 
@@ -288,7 +292,7 @@ def test_disabled_client_returns_empty() -> None:
 
 
 def test_get_history_and_attempts_are_empty() -> None:
-    c = _client({_session_slug("r1"): _recipe_page("m", "mi300x")})
+    c = _client({_default_slug("r1"): _recipe_page("m", "mi300x")})
     assert c.get_history(canonical_id="inference:m:mi300x:sglang:v:p") == []
     assert c.list_attempts(canonical_id="inference:m:mi300x:sglang:v:p") == []
     assert c.list_session_attempts(session_id="s") == []

--- a/inference_optimizer/tests/test_gbrain_remote_recipe_client_coverage_unit.py
+++ b/inference_optimizer/tests/test_gbrain_remote_recipe_client_coverage_unit.py
@@ -52,7 +52,7 @@ def _mcp() -> grc._GbrainMcp:
 
 def _slug(name: str) -> str:
     """Build a default recipe slug for fake gbrain pages."""
-    return f"hyperloom-session-kb/{name}"
+    return f"hyperloom-recipe-kb/{name}"
 
 
 # -- _GbrainMcp.call envelope parsing -------------------------------------

--- a/inference_optimizer/tests/test_gbrain_remote_recipe_client_coverage_unit.py
+++ b/inference_optimizer/tests/test_gbrain_remote_recipe_client_coverage_unit.py
@@ -50,6 +50,11 @@ def _mcp() -> grc._GbrainMcp:
     return grc._GbrainMcp("http://gbrain.test", "tok", 2.0)
 
 
+def _slug(name: str) -> str:
+    """Build a default recipe slug for fake gbrain pages."""
+    return f"hyperloom-session-kb/{name}"
+
+
 # -- _GbrainMcp.call envelope parsing -------------------------------------
 def test_mcp_call_transport_error(monkeypatch) -> None:
     def _boom(req, timeout=None):
@@ -374,8 +379,8 @@ def test_get_recipe_validation() -> None:
 def test_search_updated_since_and_order(monkeypatch) -> None:
     c = _client(
         {
-            "r1": _recipe_page("Qwen3-32B", "mi300x", "2026-01-01T00:00:00Z"),
-            "r2": _recipe_page("Qwen3-32B", "mi355x", "2026-03-01T00:00:00Z"),
+            _slug("r1"): _recipe_page("Qwen3-32B", "mi300x", "2026-01-01T00:00:00Z"),
+            _slug("r2"): _recipe_page("Qwen3-32B", "mi355x", "2026-03-01T00:00:00Z"),
         }
     )
     # updated_since filters out the older row
@@ -412,8 +417,8 @@ def test_label_search_uses_page_search_before_scan() -> None:
 def test_list_recent_returns_rows() -> None:
     c = _client(
         {
-            "r1": _recipe_page("m1", "mi300x", "2026-01-01T00:00:00Z"),
-            "r2": _recipe_page("m2", "mi355x", "2026-02-01T00:00:00Z"),
+            _slug("r1"): _recipe_page("m1", "mi300x", "2026-01-01T00:00:00Z"),
+            _slug("r2"): _recipe_page("m2", "mi355x", "2026-02-01T00:00:00Z"),
         }
     )
     rows = c.list_recent(limit=10)

--- a/inference_optimizer/tests/test_gbrain_remote_recipe_client_coverage_unit.py
+++ b/inference_optimizer/tests/test_gbrain_remote_recipe_client_coverage_unit.py
@@ -401,10 +401,11 @@ def test_search_metric_filter() -> None:
 
 
 def test_label_search_uses_page_search_before_scan() -> None:
-    c = _client({"r1": _recipe_page("target", "mi300x", "t1")})
+    slug = _slug("r1")
+    c = _client({slug: _recipe_page("target", "mi300x", "t1")})
     c._mcp = _FakeMcp(  # type: ignore[assignment]
-        {"r1": _recipe_page("target", "mi300x", "t1")},
-        search_slugs=["r1"],
+        {slug: _recipe_page("target", "mi300x", "t1")},
+        search_slugs=[slug],
     )
 
     rows = c.search(label_match={"model": "target"}, limit=1)
@@ -412,6 +413,29 @@ def test_label_search_uses_page_search_before_scan() -> None:
     assert len(rows) == 1
     assert rows[0]["labels"]["model"] == "target"
     assert [tool for tool, _ in c._mcp.calls] == ["search", "get_page"]  # type: ignore[union-attr]
+
+
+def test_label_search_filters_slugs_by_configured_prefix() -> None:
+    c = _client(
+        {
+            "hyperloom-session-kb/old": _recipe_page("target", "mi300x", "t1"),
+            "hyperloom-recipe-kb/new": _recipe_page("target", "mi300x", "t2"),
+        }
+    )
+    c._mcp = _FakeMcp(  # type: ignore[assignment]
+        {
+            "hyperloom-session-kb/old": _recipe_page("target", "mi300x", "t1"),
+            "hyperloom-recipe-kb/new": _recipe_page("target", "mi300x", "t2"),
+        },
+        search_slugs=["hyperloom-session-kb/old", "hyperloom-recipe-kb/new"],
+    )
+
+    rows = c.search(label_match={"model": "target"}, limit=1)
+
+    assert len(rows) == 1
+    assert rows[0]["updated_at"] == "t2"
+    assert [tool for tool, _ in c._mcp.calls] == ["search", "get_page"]  # type: ignore[union-attr]
+    assert c._mcp.calls[1][1]["slug"] == "hyperloom-recipe-kb/new"  # type: ignore[union-attr]
 
 
 def test_list_recent_returns_rows() -> None:


### PR DESCRIPTION
## Summary
- Use the gbrain recipe KB namespace by default and make the slug prefix configurable for alternate deployments.
- Preserve session provenance from gbrain recipe pages and filter scans to the configured recipe namespace.
- Fall back from `framework_name` to legacy `framework`, shared state, or `FRAMEWORK` when building warm-start recipe identities.

## Test plan
- `python3 -m pytest inference_optimizer/tests/test_cortex_t0_anchor.py inference_optimizer/tests/test_gbrain_remote_recipe_client.py inference_optimizer/tests/test_gbrain_remote_recipe_client_coverage_unit.py -q`
- Validated with Claw session `656c2c06-aeff-4e9c-b1f6-526e8494a493`: gbrain exact hit used `...:sglang:...`, no `unknown_framework`, no `recipe scan exceeded`, no `bad envelope`, warm replay reproduced +38.55%.


Made with [Cursor](https://cursor.com)