### PR TITLE
feat(breakdown): backfill PerfSkills KERNEL + record recovery history

### DIFF
--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -6526,6 +6526,240 @@ def _perfskills_accepted_kernels_from_journey(
     return accepted
 
 
+def _perfskills_reconstruct_from_disk(
+    session_dir: Path,
+    warnings: list[str],
+) -> dict[str, Any] | None:
+    """Best-effort reconstruction of a PerfSkills run from on-disk survivors.
+
+    When ``state.perfskills_result`` is empty/missing — typically because the
+    coordinator was killed (external SIGKILL / OOM / budget) AFTER the e2e
+    runner produced artifacts but BEFORE the tick-boundary ``state.save`` — the
+    normalized result never lands in state and, on resume past KERNEL, the
+    section would otherwise be a bare ``status=missing`` black hole. The
+    runner's working tree under ``<session>/perfskills/`` survives on the shared
+    FS, so this scans it to recover WHAT actually ran: the handoff (proves HL
+    handed off), the e2e ``exp_root`` and the stages it reached (baseline /
+    kernels / opbench / strategy), any flushed-but-unpromoted ``result.json``
+    status, and the per-kernel ``kernel_journey`` accepted kernels.
+
+    Returns ``None`` when nothing usable is on disk (caller keeps the legacy
+    ``missing`` section). Never raises — failures append to ``warnings``.
+
+    Args:
+        session_dir (Path): Absolute session root.
+        warnings (list[str]): Shared warnings list (mutated in place).
+
+    Returns:
+        dict[str, Any] | None: The recovered evidence, or ``None``.
+    """
+    pf = session_dir / "perfskills"
+    try:
+        if not pf.is_dir():
+            return None
+    except OSError:
+        return None
+
+    def _load_json(p: Path) -> dict[str, Any]:
+        try:
+            if p.is_file():
+                obj = json.loads(p.read_text(encoding="utf-8"))
+                return obj if isinstance(obj, dict) else {}
+        except (OSError, ValueError) as exc:
+            warnings.append(
+                f"perfskills: reconstruct read failed for {p.name}: {exc}"
+            )
+        return {}
+
+    stages: list[str] = []
+    recon: dict[str, Any] = {}
+
+    # 1) handoff.json — proves HL built + handed the e2e contract off.
+    handoff = _load_json(pf / "handoff.json")
+    if handoff:
+        stages.append("handoff")
+        recon["handoff"] = {
+            "model_path": handoff.get("model_path"),
+            "framework": handoff.get("framework"),
+            "gpu_type": handoff.get("gpu_type"),
+            "tp": handoff.get("tp"),
+            "workload": handoff.get("workload"),
+            "accepted_flags": handoff.get("accepted_flags"),
+            "raw_baseline_tput": _to_float(handoff.get("raw_baseline_tput")),
+        }
+
+    # 2) a flushed-but-unpromoted result.json. A status==ok result.json is
+    #    promoted by the coordinator's crash-recovery; reaching here means the
+    #    file is absent or carried a non-ok status — record it for the audit.
+    flushed = _load_json(pf / "result.json")
+    if flushed:
+        stages.append("result_json")
+        recon["flushed_result_status"] = flushed.get("status")
+
+    # 3) the e2e exp_root (newest ``e2e_*`` dir) + the stages it reached.
+    exp_root: Path | None = None
+    try:
+        e2e_dirs = sorted(
+            (d for d in pf.iterdir() if d.is_dir() and d.name.startswith("e2e_")),
+            key=lambda d: d.name,
+        )
+        if e2e_dirs:
+            exp_root = e2e_dirs[-1]
+    except OSError as exc:
+        warnings.append(f"perfskills: reconstruct iterdir failed: {exc}")
+
+    kernels_attempted: list[dict[str, Any]] = []
+    if exp_root is not None:
+        recon["exp_root"] = _rel(exp_root, session_dir)
+        for name, label in (
+            ("baseline", "baseline"),
+            ("baseline_rerun", "baseline_rerun"),
+            ("strategy.md", "strategy"),
+            ("kernel_journey.json", "kernel_journey"),
+        ):
+            try:
+                if (exp_root / name).exists():
+                    stages.append(label)
+            except OSError:
+                continue
+        kdir = exp_root / "kernels"
+        try:
+            if kdir.is_dir():
+                stages.append("kernels")
+                for d in sorted(kdir.iterdir(), key=lambda p: p.name):
+                    if d.is_dir() and not d.name.startswith("_"):
+                        kernels_attempted.append({"name": d.name})
+                # ``_exp`` holds the per-team op-bench / recursive kernel work.
+                if (kdir / "_exp").is_dir():
+                    stages.append("opbench")
+        except OSError as exc:
+            warnings.append(f"perfskills: reconstruct kernels scan failed: {exc}")
+    recon["kernels_attempted"] = kernels_attempted
+
+    # 4) per-kernel accepted kernels from the journey (reuse the projection so
+    #    the recovered section's shape matches the producer-populated one).
+    if exp_root is not None:
+        kj = exp_root / "kernel_journey.json"
+        try:
+            if kj.is_file():
+                recon["accepted_kernels"] = (
+                    _perfskills_accepted_kernels_from_journey(
+                        {"kernel_journey_path": str(kj)}, warnings
+                    )
+                )
+        except OSError:
+            pass
+
+    # 5) newest-artifact timestamp (how far the run got in wall-clock). Bounded
+    #    to a handful of key paths — the exp_root tree can hold thousands of
+    #    profiler CSVs and a full rglob at every CLOSE would be wasteful.
+    candidates = [pf / "handoff.json", pf / "result.json"]
+    if exp_root is not None:
+        candidates += [
+            exp_root,
+            exp_root / "logs",
+            exp_root / "kernels",
+            exp_root / "strategy.md",
+            exp_root / "kernel_journey.json",
+        ]
+    newest = 0.0
+    for p in candidates:
+        try:
+            newest = max(newest, p.stat().st_mtime)
+        except OSError:
+            continue
+    if newest > 0:
+        recon["last_artifact_ts"] = datetime.fromtimestamp(
+            newest, tz=timezone.utc
+        ).isoformat()
+
+    # 6) op-bench verdicts — the direct "上报缺口现场" evidence. Each per-kernel
+    #    ``opbench_result.json`` records whether the backend bake-off found a
+    #    deployable winner (``winner_editable`` + ``isolated_speedup`` > 1). Their
+    #    presence proves the e2e DID kernel work; an all-non-editable / ≤1.0x set
+    #    explains WHY there was no win to flush (vs an outright kill). Bounded to
+    #    the top-level per-task files (the deep ``_exp`` tree is skipped).
+    opbench_results: list[dict[str, Any]] = []
+    if exp_root is not None:
+        try:
+            task_dirs = [
+                d for d in (exp_root / "kernels").iterdir()
+                if d.is_dir() and not d.name.startswith("_")
+            ] if (exp_root / "kernels").is_dir() else []
+            for task_dir in sorted(task_dirs, key=lambda p: p.name)[:12]:
+                ob = _load_json(task_dir / "opbench_result.json")
+                if ob:
+                    opbench_results.append({
+                        "task": ob.get("task") or task_dir.name,
+                        "winner_backend": ob.get("winner_backend"),
+                        "isolated_speedup": _to_float(ob.get("isolated_speedup")),
+                        "winner_editable": bool(ob.get("winner_editable")),
+                        "winner_kind": ob.get("winner_kind"),
+                    })
+        except OSError as exc:
+            warnings.append(f"perfskills: reconstruct opbench scan failed: {exc}")
+    if opbench_results:
+        recon["opbench_results"] = opbench_results
+
+    # 7) runner log tails — the run_e2e stdout/stderr survivors under
+    #    ``exp_root/logs/``. The normalized returncode/stdout_tail/stderr_tail the
+    #    coordinator would have folded into ``perfskills_result`` died with the
+    #    killed process; these on-disk logs are the closest recoverable proxy for
+    #    "how far / why". Bounded to the newest handful, tail-only.
+    log_tails: dict[str, str] = {}
+    if exp_root is not None:
+        logs_dir = exp_root / "logs"
+        try:
+            if logs_dir.is_dir():
+                logs = sorted(
+                    (p for p in logs_dir.iterdir() if p.is_file()),
+                    key=lambda p: p.stat().st_mtime,
+                )
+                for p in logs[-4:]:
+                    try:
+                        log_tails[p.name] = p.read_text(
+                            encoding="utf-8", errors="replace",
+                        )[-1500:]
+                    except OSError:
+                        continue
+        except OSError as exc:
+            warnings.append(f"perfskills: reconstruct log-tail read failed: {exc}")
+    if log_tails:
+        recon["runner_log_tails"] = log_tails
+
+    # 8) likely_cause — a conservative classification of WHY no result reached
+    #    state, so a reader does not have to re-derive it from the raw survivors:
+    #      * ``runner_reported_failure``  — a non-ok result.json was flushed.
+    #      * ``ran_no_deployable_winner`` — op-bench ran but found no editable
+    #        winner > 1.0x, so there was simply nothing to flush as a win.
+    #      * ``killed_before_flush``      — stages were reached but neither a
+    #        kernel_journey nor a result.json landed (the in-flight result died
+    #        with the process — the incident pattern: SIGKILL / budget / hang).
+    #      * ``indeterminate``            — not enough on-disk signal to classify.
+    has_journey = "kernel_journey" in stages
+    ran_opbench = "opbench" in stages or bool(opbench_results)
+    any_deployable = any(
+        (r.get("isolated_speedup") or 0.0) > 1.0 and r.get("winner_editable")
+        for r in opbench_results
+    )
+    if flushed and flushed.get("status") and flushed.get("status") != "ok":
+        likely_cause = "runner_reported_failure"
+    elif ran_opbench and not any_deployable and not has_journey:
+        likely_cause = "ran_no_deployable_winner"
+    elif stages and not has_journey and "result_json" not in stages:
+        likely_cause = "killed_before_flush"
+    else:
+        likely_cause = "indeterminate"
+    recon["likely_cause"] = likely_cause
+
+    recon["stages_reached"] = stages
+    # Nothing meaningful recovered (e.g. an empty ``perfskills/`` dir) → let the
+    # caller emit the legacy ``missing`` section.
+    if not (handoff or flushed or exp_root):
+        return None
+    return recon
+
+
 def collect_perfskills(
     session_dir: Path,
     state: dict[str, Any],
@@ -6564,13 +6798,53 @@ def collect_perfskills(
         return {}
     if not has_result:
         # Engaged via the optimizer flag but no result recorded yet/at all.
+        # Before surfacing a bare ``missing`` black hole, try to reconstruct the
+        # run from the on-disk ``perfskills/`` working tree — it survives an
+        # external kill that lost the in-memory result before the tick-boundary
+        # ``state.save`` (the exact gap behind the empty ``perfskills_result``).
+        recon = _perfskills_reconstruct_from_disk(session_dir, warnings)
+        if recon is None:
+            return {
+                "engaged": True,
+                "status": "missing",
+                "error_class": "no_result",
+                "error": (
+                    "kernel_optimizer=perfskills but no perfskills_result "
+                    "recorded"
+                ),
+                "accepted_kernels": [],
+                "accepted_heads": [],
+            }
+        recovered_kernels = recon.get("accepted_kernels") or []
         return {
             "engaged": True,
-            "status": "missing",
+            "status": "no_result_recovered_from_disk",
             "error_class": "no_result",
-            "error": "kernel_optimizer=perfskills but no perfskills_result recorded",
-            "accepted_kernels": [],
+            "error": (
+                "kernel_optimizer=perfskills but no perfskills_result was "
+                "committed to state; reconstructed the run from on-disk "
+                "perfskills/ artifacts. The runner handed off and produced "
+                "intermediate output, but the normalized result.json was never "
+                "folded into state — typically an external kill (SIGKILL / OOM "
+                "/ budget) before the tick-boundary state.save, then a resume "
+                "past KERNEL."
+            ),
+            "recovered_from_disk": True,
+            "handoff": recon.get("handoff"),
+            "exp_root": recon.get("exp_root"),
+            "stages_reached": recon.get("stages_reached") or [],
+            "kernels_attempted": recon.get("kernels_attempted") or [],
+            "opbench_results": recon.get("opbench_results") or [],
+            "runner_log_tails": recon.get("runner_log_tails") or {},
+            "likely_cause": recon.get("likely_cause"),
+            "flushed_result_status": recon.get("flushed_result_status"),
+            "last_artifact_ts": recon.get("last_artifact_ts"),
+            "accepted_kernels": recovered_kernels,
+            "accepted_kernels_source": (
+                "kernel_journey_backfill" if recovered_kernels else None
+            ),
             "accepted_heads": [],
+            "kernels_optimized": len(recovered_kernels),
         }
 
     def _rel_if_under(p: Any) -> Any:

--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -806,6 +806,83 @@ def _should_use_close_stop_reason(stop_reason: str, close_stop_reason: str) -> b
 
 
 # §1 Session metadata
+def _collect_recovery(state: dict[str, Any]) -> dict[str, Any]:
+    """Project SharedState's crash / interruption / resume signals.
+
+    SharedState already tracks whether a run crashed, was continued by the
+    steward, entered degraded mode, or has an accepted stack awaiting
+    post-resume revalidation — but none of it reaches the breakdown, so a
+    resumed run reads as if it proceeded monotonically. This folds those
+    signals into the §1 ``session.recovery`` block so a reader can see the run
+    was interrupted and continued (the context behind gaps like an empty
+    ``perfskills_result`` lost to a kill before the tick-boundary save). Pure /
+    best-effort: unparseable fields are skipped, never raised.
+
+    Args:
+        state (dict[str, Any]): Parsed ``state.json`` (SharedState-shaped).
+
+    Returns:
+        dict[str, Any]: The ``recovery`` block (see schema ``Recovery``).
+    """
+    crash_count = _to_int(state.get("crash_count")) or 0
+    crash_ts_iso: list[str] = []
+    raw_ts = state.get("crash_timestamps")
+    if isinstance(raw_ts, list):
+        for t in raw_ts:
+            try:
+                crash_ts_iso.append(
+                    datetime.fromtimestamp(float(t), tz=timezone.utc).isoformat()
+                )
+            except (TypeError, ValueError, OSError, OverflowError):
+                continue
+
+    last_exc: dict[str, Any] | None = None
+    lte = state.get("last_tick_exception")
+    if isinstance(lte, dict) and lte:
+        # Drop the (large) traceback; keep the compact postmortem header.
+        last_exc = {
+            "tick": lte.get("tick"),
+            "ts": lte.get("ts"),
+            "stage": lte.get("stage"),
+            "agent": lte.get("agent"),
+            "type": lte.get("type"),
+            "message": (str(lte.get("message") or "")[:500] or None),
+        }
+
+    infra = state.get("steward_infra_failures_by_round")
+    infra_by_round: dict[str, int] = {}
+    infra_total = 0
+    if isinstance(infra, dict):
+        for k, v in infra.items():
+            iv = _to_int(v)
+            if iv is None:
+                continue
+            infra_by_round[str(k)] = iv
+            infra_total += iv
+
+    steward_continuation = bool(state.get("steward_continuation_used"))
+    resume_pending = bool(state.get("resume_pending_revalidation"))
+    degraded = bool(state.get("degraded_mode"))
+    recovered = bool(
+        crash_count > 0
+        or crash_ts_iso
+        or steward_continuation
+        or resume_pending
+        or last_exc
+    )
+    return {
+        "recovered": recovered,
+        "crash_count": crash_count,
+        "crash_timestamps": crash_ts_iso,
+        "degraded_mode": degraded,
+        "steward_continuation_used": steward_continuation,
+        "resume_pending_revalidation": resume_pending,
+        "steward_infra_failures_total": infra_total,
+        "steward_infra_failures_by_round": infra_by_round,
+        "last_tick_exception": last_exc,
+    }
+
+
 def collect_session(
     session_dir: Path,
     state: dict[str, Any],
@@ -872,6 +949,9 @@ def collect_session(
             or ""
         ),
         "tick_count": int(state.get("tick") or 0),
+        # Crash / interruption / resume history so a resumed run is not read as
+        # a clean monotonic one (context behind e.g. an empty perfskills_result).
+        "recovery": _collect_recovery(state),
     }
 
 

--- a/inference_optimizer/breakdown/schema.py
+++ b/inference_optimizer/breakdown/schema.py
@@ -27,6 +27,47 @@ SCHEMA_VERSION_V3 = "hyperloom.session_breakdown.v3.0"
 
 
 # §1 Session metadata
+class Recovery(TypedDict, total=False):
+    """Crash / interruption / resume history for one optimization session.
+
+    Surfaces the recovery-relevant signals SharedState already tracks so the
+    breakdown records WHEN a run was interrupted and continued — the exact
+    context behind gaps like an empty ``perfskills_result`` (a tick's in-memory
+    result lost to an external kill before the tick-boundary ``state.save``,
+    then a resume). Without this the breakdown shows only the symptom; here it
+    shows the run did not proceed monotonically.
+
+    Attributes:
+        recovered (bool): True when the run crashed and/or was continued after
+            an interruption (any of the signals below fired).
+        crash_count (int): Monotonic total of Coordinator tick/agent crashes.
+        crash_timestamps (list[str]): ISO UTC timestamps of recent crashes
+            (bounded tail).
+        degraded_mode (bool): Whether the run entered degraded operation.
+        steward_continuation_used (bool): The steward continued the run after an
+            interruption / budget event.
+        resume_pending_revalidation (bool): Accepted stack awaits post-resume
+            revalidation (validated gain not yet re-trusted).
+        steward_infra_failures_total (int): Sum of steward-observed infra
+            failures across rounds.
+        steward_infra_failures_by_round (dict[str, int]): Per-round infra
+            failure counts.
+        last_tick_exception (dict[str, Any] | None): Compact summary of the last
+            Coordinator tick exception (tick / stage / type / message), traceback
+            omitted.
+    """
+
+    recovered: bool
+    crash_count: int
+    crash_timestamps: list[str]
+    degraded_mode: bool
+    steward_continuation_used: bool
+    resume_pending_revalidation: bool
+    steward_infra_failures_total: int
+    steward_infra_failures_by_round: dict[str, int]
+    last_tick_exception: dict[str, Any] | None
+
+
 class SessionMeta(TypedDict, total=False):
     """Identity, timing, and host context for one optimization session.
 
@@ -54,6 +95,7 @@ class SessionMeta(TypedDict, total=False):
             artifacts without re-deriving the path.
         tick_count (int): Number of orchestration ticks executed.
         image (str | None): Fully-qualified container image, or None if unset.
+        recovery (Recovery): Crash / interruption / resume history for the run.
     """
 
     session_id: str  # hyperloom internal id (manifest.session_id)
@@ -71,6 +113,7 @@ class SessionMeta(TypedDict, total=False):
     user_data_path: str  # USER_DATA_PATH root the run wrote under (session_dir nests beneath it)
     tick_count: int
     image: str | None  # container image fully-qualified (or None if not configured)
+    recovery: Recovery  # crash / interruption / resume history
 
 
 # §2 Workload configuration

--- a/inference_optimizer/breakdown/schema.py
+++ b/inference_optimizer/breakdown/schema.py
@@ -961,7 +961,12 @@ class Perfskills(TypedDict, total=False):
     Attributes:
         engaged (bool): True when PerfSkills owned the KERNEL_AGENT phase.
         status (str): ``ok`` / ``no_gain`` / ``error`` / ``timeout`` /
-            ``skipped`` / ``missing`` / ``unknown``.
+            ``skipped`` / ``missing`` / ``no_result_recovered_from_disk`` /
+            ``unknown``. ``no_result_recovered_from_disk`` is emitted when
+            ``perfskills_result`` was never committed to state (e.g. an external
+            kill before the tick-boundary ``state.save``, then a resume past
+            KERNEL) but the run was reconstructed from the on-disk
+            ``perfskills/`` working tree.
         error_class (str | None): Normalized failure class (None on success),
             e.g. ``timeout`` / ``insufficient_budget`` / ``no_result_json`` /
             ``runner_crashed`` / ``workflow_parse_error``.
@@ -992,6 +997,32 @@ class Perfskills(TypedDict, total=False):
         final_patch (str | None): Relative path to the final patch.
         runner_timeout_s (int | None): Budget-capped runner timeout.
         kill_timeout_s (int | None): Hard subprocess kill timeout.
+        recovered_from_disk (bool): True when the section was reconstructed from
+            the on-disk ``perfskills/`` tree because no result reached state.
+        handoff (dict[str, Any] | None): Recovered handoff summary (model /
+            framework / workload / accepted_flags) proving HL handed off.
+        exp_root (str | None): Relative path to the recovered e2e ``exp_root``.
+        stages_reached (list[str]): Stages the e2e run reached on disk
+            (``handoff`` / ``baseline`` / ``kernels`` / ``opbench`` /
+            ``strategy`` / ``kernel_journey`` / ``result_json``).
+        kernels_attempted (list[Any]): Kernel task dirs the runner created.
+        opbench_results (list[Any]): Per-kernel op-bench verdicts recovered from
+            ``opbench_result.json`` (``task`` / ``winner_backend`` /
+            ``isolated_speedup`` / ``winner_editable`` / ``winner_kind``). Proves
+            the e2e did kernel work and explains an absent win (no editable
+            winner > 1.0x ⇒ nothing to flush).
+        runner_log_tails (dict[str, str]): Newest ``exp_root/logs`` tails
+            (run_e2e stdout/stderr survivors) — the closest recoverable proxy
+            for the returncode/stdout_tail/stderr_tail lost with the killed
+            process.
+        likely_cause (str | None): Conservative classification of why no result
+            reached state -- ``runner_reported_failure`` /
+            ``ran_no_deployable_winner`` / ``killed_before_flush`` /
+            ``indeterminate``.
+        flushed_result_status (str | None): ``status`` of a flushed-but-
+            unpromoted ``result.json`` (None when absent).
+        last_artifact_ts (str | None): ISO UTC mtime of the newest recovered
+            artifact (how far the run got in wall-clock before the kill).
     """
 
     engaged: bool
@@ -999,6 +1030,16 @@ class Perfskills(TypedDict, total=False):
     error_class: str | None
     error: str | None
     returncode: int | None
+    recovered_from_disk: bool
+    handoff: dict[str, Any] | None
+    exp_root: str | None
+    stages_reached: list[str]
+    kernels_attempted: list[Any]
+    opbench_results: list[Any]
+    runner_log_tails: dict[str, str]
+    likely_cause: str | None
+    flushed_result_status: str | None
+    last_artifact_ts: str | None
     baseline_throughput_tok_s: float | None
     final_throughput_tok_s: float | None
     throughput_speedup: float | None

--- a/inference_optimizer/tests/test_breakdown_exporter_units.py
+++ b/inference_optimizer/tests/test_breakdown_exporter_units.py
@@ -282,3 +282,75 @@ class TestCollectGemmTuning:
         out = col.collect_gemm_tuning(state)
         assert len(out["runs"]) == 1
         assert out["runs"][0]["engine"] == "forge"
+
+
+# _collect_recovery + collect_session.recovery
+
+
+class TestCollectRecovery:
+    def test_clean_run_reports_not_recovered(self):
+        rec = col._collect_recovery({})
+        assert rec["recovered"] is False
+        assert rec["crash_count"] == 0
+        assert rec["crash_timestamps"] == []
+        assert rec["last_tick_exception"] is None
+        assert rec["steward_infra_failures_total"] == 0
+
+    def test_crash_and_resume_signals_surface(self):
+        # The incident shape: crashed + steward-continued + accepted stack awaits
+        # post-resume revalidation. All must show, and epoch crash timestamps are
+        # rendered as ISO UTC.
+        state = {
+            "crash_count": 2,
+            "crash_timestamps": [1782800000.0, 1782803600.5],
+            "degraded_mode": True,
+            "steward_continuation_used": True,
+            "resume_pending_revalidation": True,
+            "steward_infra_failures_by_round": {"12": 1, "13": 2},
+            "last_tick_exception": {
+                "tick": 12,
+                "ts": "2026-06-29T22:25:00Z",
+                "stage": "kernel_opt",
+                "agent": "kernel_agent",
+                "type": "TimeoutError",
+                "message": "x" * 900,
+                "traceback": "y" * 5000,
+            },
+        }
+        rec = col._collect_recovery(state)
+        assert rec["recovered"] is True
+        assert rec["crash_count"] == 2
+        assert len(rec["crash_timestamps"]) == 2
+        assert all(ts.endswith("+00:00") for ts in rec["crash_timestamps"])
+        assert rec["degraded_mode"] is True
+        assert rec["steward_continuation_used"] is True
+        assert rec["resume_pending_revalidation"] is True
+        assert rec["steward_infra_failures_total"] == 3
+        assert rec["steward_infra_failures_by_round"] == {"12": 1, "13": 2}
+        # Compact exception header; traceback dropped, message capped.
+        assert rec["last_tick_exception"]["type"] == "TimeoutError"
+        assert rec["last_tick_exception"]["tick"] == 12
+        assert "traceback" not in rec["last_tick_exception"]
+        assert len(rec["last_tick_exception"]["message"]) == 500
+
+    def test_malformed_signals_are_skipped_not_raised(self):
+        rec = col._collect_recovery(
+            {
+                "crash_count": "not-int",
+                "crash_timestamps": ["bad", None, 1782800000.0],
+                "steward_infra_failures_by_round": {"r": "x", "s": 4},
+                "last_tick_exception": "not-a-dict",
+            }
+        )
+        assert rec["crash_count"] == 0
+        assert len(rec["crash_timestamps"]) == 1  # only the parseable epoch
+        assert rec["steward_infra_failures_total"] == 4
+        assert rec["last_tick_exception"] is None
+
+    def test_collect_session_embeds_recovery_block(self, tmp_path):
+        warnings: list[str] = []
+        state = {"session_id": "s1", "crash_count": 1, "steward_continuation_used": True}
+        out = col.collect_session(tmp_path, state, {}, warnings)
+        assert "recovery" in out
+        assert out["recovery"]["recovered"] is True
+        assert out["recovery"]["crash_count"] == 1

--- a/inference_optimizer/tests/test_perfskills_breakdown_unit.py
+++ b/inference_optimizer/tests/test_perfskills_breakdown_unit.py
@@ -54,12 +54,194 @@ def test_collect_perfskills_empty_result_no_flag(tmp_path: Path) -> None:
 
 
 def test_collect_perfskills_engaged_without_result(tmp_path: Path) -> None:
+    # No on-disk perfskills/ tree → nothing to reconstruct → legacy ``missing``.
     warnings: list[str] = []
     out = collect_perfskills(tmp_path, {"kernel_optimizer": "perfskills"}, warnings)
     assert out["engaged"] is True
     assert out["status"] == "missing"
     assert out["error_class"] == "no_result"
     assert out["accepted_kernels"] == []
+    assert "recovered_from_disk" not in out
+
+
+def test_collect_perfskills_reconstructs_from_disk_when_result_missing(
+    tmp_path: Path,
+) -> None:
+    # Reproduce the incident: perfskills was engaged and the runner produced an
+    # on-disk working tree, but ``perfskills_result`` never reached state (an
+    # external kill before the tick-boundary save, then resume past KERNEL).
+    # The collector must reconstruct the run from disk instead of a bare miss.
+    pf = tmp_path / "perfskills"
+    pf.mkdir()
+    (pf / "handoff.json").write_text(
+        json.dumps(
+            {
+                "model_path": "/wekafs/models/Qwen-Qwen3-0.6B",
+                "framework": "vllm",
+                "gpu_type": "mi300x",
+                "tp": 1,
+                "workload": {"isl": 1024, "osl": 1024, "conc": 64},
+                "accepted_flags": "--kv-cache-dtype fp8",
+                "raw_baseline_tput": 10434.27,
+            }
+        ),
+        encoding="utf-8",
+    )
+    exp = pf / "e2e_Qwen-Qwen3-0.6B_20260629T174250Z"
+    (exp / "baseline").mkdir(parents=True)
+    (exp / "kernels" / "paged_attention_task").mkdir(parents=True)
+    (exp / "kernels" / "_exp").mkdir(parents=True)
+    (exp / "strategy.md").write_text("# strategy", encoding="utf-8")
+    (exp / "kernel_journey.json").write_text(
+        json.dumps(
+            {
+                "kernels": [
+                    {
+                        "kernel_id": "k002",
+                        "name": "rocm_unquantized_gemm",
+                        "gpu_pct": 17.0,
+                        "e2e": {
+                            "decision": "KEEP",
+                            "integrated": True,
+                            "e2e_gain_pct": 2.2,
+                            "validated": True,
+                            "target_file": "gemm.cu",
+                            "extra_server_args": "",
+                        },
+                        "backend_result": {"verification": {"best_backend": "geak"}},
+                        "dispatch": {"backends": ["geak"]},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    warnings: list[str] = []
+    out = collect_perfskills(tmp_path, {"kernel_optimizer": "perfskills"}, warnings)
+
+    assert out["engaged"] is True
+    assert out["status"] == "no_result_recovered_from_disk"
+    assert out["error_class"] == "no_result"
+    assert out["recovered_from_disk"] is True
+    # Handoff evidence proves HL handed off (vs a silent miss).
+    assert out["handoff"]["framework"] == "vllm"
+    assert out["handoff"]["workload"] == {"isl": 1024, "osl": 1024, "conc": 64}
+    # exp_root is relativized under the session dir.
+    assert out["exp_root"] == "perfskills/e2e_Qwen-Qwen3-0.6B_20260629T174250Z"
+    # Stages the runner reached are surfaced for forensics.
+    for stage in ("handoff", "baseline", "kernels", "opbench", "strategy",
+                  "kernel_journey"):
+        assert stage in out["stages_reached"]
+    assert out["kernels_attempted"] == [{"name": "paged_attention_task"}]
+    # Per-kernel attribution is backfilled from the surviving journey.
+    assert out["accepted_kernels_source"] == "kernel_journey_backfill"
+    assert [k["kernel_id"] for k in out["accepted_kernels"]] == ["k002"]
+    assert out["accepted_kernels"][0]["backend"] == "geak_v4"
+    assert out["kernels_optimized"] == 1
+    assert out["last_artifact_ts"] is not None
+
+
+def test_collect_perfskills_reconstruct_surfaces_opbench_logs_and_cause(
+    tmp_path: Path,
+) -> None:
+    # The incident shape: the e2e ran the op-bench bake-off (no editable winner
+    # > 1.0x) and was then killed before flushing a result/journey. The
+    # reconstruction must surface the op-bench verdicts (WHY no win), the runner
+    # log tails (the lost stdout/stderr proxy), and classify the cause.
+    pf = tmp_path / "perfskills"
+    exp = pf / "e2e_run"
+    (exp / "baseline").mkdir(parents=True)
+    task = exp / "kernels" / "rocm_unquantized_gemm_decode_family_task"
+    task.mkdir(parents=True)
+    (exp / "kernels" / "_exp").mkdir(parents=True)
+    (pf / "handoff.json").write_text(json.dumps({"framework": "vllm"}), encoding="utf-8")
+    (task / "opbench_result.json").write_text(
+        json.dumps(
+            {
+                "task": "rocm_unquantized_gemm_decode_family_task",
+                "winner_backend": "hipblaslt",
+                "isolated_speedup": 1.0,
+                "winner_editable": False,
+                "winner_kind": "none",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (exp / "logs").mkdir()
+    (exp / "logs" / "opbench_gemm.log").write_text(
+        "OPBENCH winner=hipblaslt speedup=1.0x editable=False\n", encoding="utf-8"
+    )
+
+    out = collect_perfskills(tmp_path, {"kernel_optimizer": "perfskills"}, [])
+
+    assert out["status"] == "no_result_recovered_from_disk"
+    assert out["opbench_results"][0]["winner_backend"] == "hipblaslt"
+    assert out["opbench_results"][0]["isolated_speedup"] == 1.0
+    assert out["opbench_results"][0]["winner_editable"] is False
+    assert "opbench_gemm.log" in out["runner_log_tails"]
+    assert "OPBENCH" in out["runner_log_tails"]["opbench_gemm.log"]
+    # op-bench ran, no editable winner, no journey/result → ran-no-winner.
+    assert out["likely_cause"] == "ran_no_deployable_winner"
+
+
+def test_collect_perfskills_reconstruct_cause_killed_before_flush(tmp_path: Path) -> None:
+    # Stages reached (baseline/kernels) but neither a journey nor a result.json
+    # nor any op-bench verdict landed → the in-flight result died with the
+    # process (SIGKILL / budget / hang).
+    pf = tmp_path / "perfskills"
+    exp = pf / "e2e_run"
+    (exp / "baseline").mkdir(parents=True)
+    (exp / "kernels" / "paged_attention_task").mkdir(parents=True)
+    (pf / "handoff.json").write_text(json.dumps({"framework": "vllm"}), encoding="utf-8")
+
+    out = collect_perfskills(tmp_path, {"kernel_optimizer": "perfskills"}, [])
+
+    assert out["status"] == "no_result_recovered_from_disk"
+    assert out["opbench_results"] == []
+    assert out["likely_cause"] == "killed_before_flush"
+
+
+def test_collect_perfskills_reconstruct_cause_runner_reported_failure(tmp_path: Path) -> None:
+    # A non-ok result.json was flushed (the runner itself reported the failure):
+    # the cause is the reported failure, not a silent kill.
+    pf = tmp_path / "perfskills"
+    pf.mkdir()
+    (pf / "handoff.json").write_text(json.dumps({"framework": "vllm"}), encoding="utf-8")
+    (pf / "result.json").write_text(
+        json.dumps({"status": "error", "error_class": "timeout"}), encoding="utf-8"
+    )
+
+    out = collect_perfskills(tmp_path, {"kernel_optimizer": "perfskills"}, [])
+
+    assert out["status"] == "no_result_recovered_from_disk"
+    assert out["flushed_result_status"] == "error"
+    assert out["likely_cause"] == "runner_reported_failure"
+
+
+def test_collect_perfskills_reconstruct_handoff_only(tmp_path: Path) -> None:
+    # Only the handoff landed (runner killed before writing any e2e output):
+    # still recoverable — proves engagement + handoff without an e2e exp_root.
+    pf = tmp_path / "perfskills"
+    pf.mkdir()
+    (pf / "handoff.json").write_text(
+        json.dumps({"framework": "sglang", "workload": {"conc": 32}}),
+        encoding="utf-8",
+    )
+    out = collect_perfskills(tmp_path, {"kernel_optimizer": "perfskills"}, [])
+    assert out["status"] == "no_result_recovered_from_disk"
+    assert out["recovered_from_disk"] is True
+    assert out["stages_reached"] == ["handoff"]
+    assert out["exp_root"] is None
+    assert out["accepted_kernels"] == []
+
+
+def test_collect_perfskills_empty_dir_falls_back_to_missing(tmp_path: Path) -> None:
+    # An empty perfskills/ dir carries no evidence → legacy ``missing`` section.
+    (tmp_path / "perfskills").mkdir()
+    out = collect_perfskills(tmp_path, {"kernel_optimizer": "perfskills"}, [])
+    assert out["status"] == "missing"
+    assert "recovered_from_disk" not in out
 
 
 def test_collect_perfskills_full_success_maps_fields(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Closes the trace black hole for a PerfSkills (GEAK v4) KERNEL run that was killed before its result reached state (an external SIGKILL/OOM/budget kill before the tick-boundary `state.save`, then a resume past KERNEL). Previously `session_breakdown.json` showed only the symptom — `perfskills = {status: missing}` and no hint the run was ever interrupted. Two additive breakdown changes make it auditable:

- **`perfskills` disk backfill** (`274f8ced`): when `perfskills_result` is empty/missing, reconstruct the run from the on-disk `<session>/perfskills/` tree instead of a bare miss — handoff (proves HL handed off), `exp_root` + `stages_reached`, kernels attempted, `kernel_journey` accepted-kernel backfill, opbench per-kernel bake-off verdicts, newest runner log tails (closest proxy for the lost returncode/stdout/stderr), and a conservative `likely_cause` classification.
- **`session.recovery` block** (`8f6bd5c0`): fold SharedState's already-tracked crash/interruption/resume signals into §1 `session` so a killed-then-resumed run no longer reads as clean — `recovered`, `crash_count`, `crash_timestamps` (ISO UTC), `degraded_mode`, `steward_continuation_used`, `resume_pending_revalidation`, `steward_infra_failures_total`/`by_round`, and a compact `last_tick_exception` (traceback dropped).

Both are purely additive to the breakdown schema (`Perfskills` fields + new `Recovery` TypedDict on `SessionMeta`), best-effort, and never raise — native sessions and clean runs are unaffected.

## Test plan

- [x] `test_perfskills_breakdown_unit.py` — disk reconstruction, opbench/log-tail surfacing, all `likely_cause` branches, backward-compatible `missing` fallback
- [x] `test_breakdown_exporter_units.py::TestCollectRecovery` — clean run, crash+resume combo, malformed-signal robustness, `collect_session` embedding
- [x] breakdown + perfskills + session suites: 424 passed, 1 skipped
- [x] golden breakdown / smoke / session-executor suites: 139 passed

Made with [Cursor](https://cursor.com)