### PR TITLE
fix(gemm): retry bf16 dense tuning after fp8 no-op

### DIFF
--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -4896,6 +4896,7 @@ class Coordinator:
         self._record_phase_entry_evidence(
             gemm_tuning={"status": "running", "source": "kernel_entry_auto"},
         )
+        run_gemm_tuning_handler = None
         try:
             from .kernel_request_handlers import run_gemm_tuning_handler
 
@@ -4915,6 +4916,40 @@ class Coordinator:
                 "error": repr(exc),
             }
         await self._handle_gemm_tuning_result(result)
+
+        if (
+            run_gemm_tuning_handler is not None
+            and self._should_run_bf16_dense_gemm_fallback(result)
+            and str(result.get("decision") or "").strip().upper() != "KEEP"
+        ):
+            log.info(
+                "KERNEL entry: forge fp8 GEMM tuning found no candidate; "
+                "trying bf16 dense fallback"
+            )
+            try:
+                result = await run_gemm_tuning_handler(
+                    {
+                        "task_id": "kernel_entry_gemm_tuning_bf16_fallback",
+                        "reason": "fp8_no_improvement_bf16_fallback",
+                        "precision": "bf16",
+                        "tuner": "sglang_dense_bf16",
+                    },
+                    session_dir=self.session_dir,
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.exception("KERNEL entry GEMM bf16 fallback failed")
+                result = {
+                    "status": "failed",
+                    "decision": "REVERT",
+                    "error_class": exc.__class__.__name__,
+                    "error": repr(exc),
+                    "backend": "forge",
+                    "precision": "bf16",
+                    "framework": getattr(self.shared_state, "framework", ""),
+                    "source": "fp8_no_improvement_bf16_fallback",
+                }
+            await self._handle_gemm_tuning_result(result)
+
         status = str(result.get("status") or "unknown")
         await self.bus.append_and_seq(
             Message.new(
@@ -4943,6 +4978,44 @@ class Coordinator:
         await self._maybe_reprofile_for_kernel()
         if self._should_continue_kernel_after_gemm():
             await self._run_kernel_opt_after_gemm()
+
+    def _should_run_bf16_dense_gemm_fallback(self, result: dict[str, Any]) -> bool:
+        """Return True when a forge fp8 run should try bf16 dense GEMM tuning.
+
+        Recent production runs showed the automatic KERNEL-entry GEMM step can
+        stop after a single fp8 a8w8/a8w8_blockscale no-op. Historical wins came
+        from a follow-up ``sglang_dense_bf16`` run, so make that fallback
+        deterministic when the fp8 tuner produced no E2E-validatable candidate.
+        """
+        if not isinstance(result, dict):
+            return False
+        if str(result.get("backend") or "").strip().lower() != "forge":
+            return False
+        if str(result.get("precision") or "").strip().lower() != "fp8":
+            return False
+        framework = str(
+            result.get("framework") or getattr(self.shared_state, "framework", "") or ""
+        ).strip().lower()
+        if framework != "sglang":
+            return False
+        if str(result.get("micro_decision") or "").strip().lower() != "no_improvement":
+            return False
+        if result.get("recommended_env") or result.get("extra_envs"):
+            return False
+        for tuner in result.get("tuners_run") or []:
+            if not isinstance(tuner, dict):
+                continue
+            if str(tuner.get("status") or "").strip().lower() != "ok":
+                continue
+            try:
+                improved = int(tuner.get("improved_shapes") or 0)
+            except (TypeError, ValueError):
+                improved = 0
+            if improved > 0 and str(tuner.get("env_var") or "").strip() and str(
+                tuner.get("env_value") or ""
+            ).strip():
+                return False
+        return True
 
     @staticmethod
     def _resolve_bench_protocol(recipe_path: str) -> dict[str, Any]:

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -4900,13 +4900,22 @@ class Coordinator:
         try:
             from .kernel_request_handlers import run_gemm_tuning_handler
 
-            result = await run_gemm_tuning_handler(
-                {
-                    "task_id": "kernel_entry_gemm_tuning",
-                    "reason": "kernel_entry_auto",
-                },
-                session_dir=self.session_dir,
-            )
+            if self._bf16_dense_gemm_fallback_pending():
+                log.info(
+                    "KERNEL entry: resuming pending bf16 dense GEMM fallback "
+                    "after prior forge fp8 no-candidate result"
+                )
+                result = await self._run_bf16_dense_gemm_fallback(
+                    run_gemm_tuning_handler
+                )
+            else:
+                result = await run_gemm_tuning_handler(
+                    {
+                        "task_id": "kernel_entry_gemm_tuning",
+                        "reason": "kernel_entry_auto",
+                    },
+                    session_dir=self.session_dir,
+                )
         except Exception as exc:  # noqa: BLE001
             log.exception("KERNEL entry GEMM tuning failed")
             result = {
@@ -4926,28 +4935,9 @@ class Coordinator:
                 "KERNEL entry: forge fp8 GEMM tuning found no candidate; "
                 "trying bf16 dense fallback"
             )
-            try:
-                result = await run_gemm_tuning_handler(
-                    {
-                        "task_id": "kernel_entry_gemm_tuning_bf16_fallback",
-                        "reason": "fp8_no_improvement_bf16_fallback",
-                        "precision": "bf16",
-                        "tuner": "sglang_dense_bf16",
-                    },
-                    session_dir=self.session_dir,
-                )
-            except Exception as exc:  # noqa: BLE001
-                log.exception("KERNEL entry GEMM bf16 fallback failed")
-                result = {
-                    "status": "failed",
-                    "decision": "REVERT",
-                    "error_class": exc.__class__.__name__,
-                    "error": repr(exc),
-                    "backend": "forge",
-                    "precision": "bf16",
-                    "framework": getattr(self.shared_state, "framework", ""),
-                    "source": "fp8_no_improvement_bf16_fallback",
-                }
+            result = await self._run_bf16_dense_gemm_fallback(
+                run_gemm_tuning_handler
+            )
             await self._handle_gemm_tuning_result(result)
 
         status = str(result.get("status") or "unknown")
@@ -4978,6 +4968,44 @@ class Coordinator:
         await self._maybe_reprofile_for_kernel()
         if self._should_continue_kernel_after_gemm():
             await self._run_kernel_opt_after_gemm()
+
+    async def _run_bf16_dense_gemm_fallback(
+        self,
+        run_gemm_tuning_handler: Callable[..., Any],
+    ) -> dict[str, Any]:
+        """Run the single bf16 dense fallback and stamp retry provenance."""
+        payload = {
+            "task_id": "kernel_entry_gemm_tuning_bf16_fallback",
+            "reason": "fp8_no_improvement_bf16_fallback",
+            "precision": "bf16",
+            "tuner": "sglang_dense_bf16",
+        }
+        try:
+            result = await run_gemm_tuning_handler(
+                payload,
+                session_dir=self.session_dir,
+            )
+            if not isinstance(result, dict):
+                result = {
+                    "status": "failed",
+                    "decision": "REVERT",
+                    "error": "non-dict bf16 fallback result",
+                }
+        except Exception as exc:  # noqa: BLE001
+            log.exception("KERNEL entry GEMM bf16 fallback failed")
+            result = {
+                "status": "failed",
+                "decision": "REVERT",
+                "error_class": exc.__class__.__name__,
+                "error": repr(exc),
+            }
+        result.setdefault("task_id", payload["task_id"])
+        result.setdefault("reason", payload["reason"])
+        result.setdefault("source", payload["reason"])
+        result.setdefault("backend", "forge")
+        result.setdefault("precision", "bf16")
+        result.setdefault("framework", getattr(self.shared_state, "framework", ""))
+        return result
 
     def _should_run_bf16_dense_gemm_fallback(self, result: dict[str, Any]) -> bool:
         """Return True when a forge fp8 run should try bf16 dense GEMM tuning.
@@ -5016,6 +5044,52 @@ class Coordinator:
             ).strip():
                 return False
         return True
+
+    def _bf16_dense_gemm_fallback_pending(self) -> bool:
+        """Return True when a recorded fp8 no-op still needs its bf16 retry."""
+        last = getattr(self.shared_state, "last_gemm_tuning", {}) or {}
+        return (
+            self._should_run_bf16_dense_gemm_fallback(last)
+            and not self._bf16_dense_gemm_fallback_attempted()
+        )
+
+    def _bf16_dense_gemm_fallback_attempted(self) -> bool:
+        """Detect whether the bf16 dense fallback has already been attempted."""
+        attempts: list[Any] = []
+        last = getattr(self.shared_state, "last_gemm_tuning", {}) or {}
+        if isinstance(last, dict):
+            attempts.append(last)
+        attempts.extend(getattr(self.shared_state, "gemm_tuning_attempts", None) or [])
+        return any(
+            self._is_bf16_dense_gemm_fallback_attempt(entry)
+            for entry in attempts
+            if isinstance(entry, dict)
+        )
+
+    @staticmethod
+    def _is_bf16_dense_gemm_fallback_attempt(entry: dict[str, Any]) -> bool:
+        """Identify the fallback attempt across old and newly stamped records."""
+        markers = {
+            "kernel_entry_gemm_tuning_bf16_fallback",
+            "fp8_no_improvement_bf16_fallback",
+        }
+        for key in ("task_id", "reason", "source"):
+            if str(entry.get(key) or "").strip() in markers:
+                return True
+        if "kernel_entry_gemm_tuning_bf16_fallback" in str(
+            entry.get("workspace") or ""
+        ):
+            return True
+        if str(entry.get("precision") or "").strip().lower() != "bf16":
+            return False
+        if str(entry.get("tuner") or "").strip() == "sglang_dense_bf16":
+            return True
+        for tuner in entry.get("tuners_run") or []:
+            if not isinstance(tuner, dict):
+                continue
+            if str(tuner.get("tuner") or "").strip() == "sglang_dense_bf16":
+                return True
+        return False
 
     @staticmethod
     def _resolve_bench_protocol(recipe_path: str) -> dict[str, Any]:
@@ -9957,6 +10031,8 @@ class Coordinator:
             return False
         last = getattr(ss, "last_gemm_tuning", {}) or {}
         status = str(last.get("status") or "").strip().lower()
+        if self._bf16_dense_gemm_fallback_pending():
+            return True
         return status not in {
             "ok",
             "succeeded",

--- a/inference_optimizer/orchestrator/system_prompts/prompt_builder.py
+++ b/inference_optimizer/orchestrator/system_prompts/prompt_builder.py
@@ -760,8 +760,11 @@ you want to wind down sooner.
 
   request{target_agent: 'kernel_agent', kind: 'run_gemm_tuning', params={}}
 
-  Only when `last_gemm_tuning` is empty (the Coordinator also auto-runs it at
-  KERNEL entry; eligibility is decided backend-side).
+  Usually only when `last_gemm_tuning` is empty (the Coordinator also auto-runs
+  it at KERNEL entry; eligibility is decided backend-side). Exception: if the
+  last forge FP8 attempt reports `micro_decision='no_improvement'` with no
+  E2E-validatable candidates, one `precision='bf16', tuner='sglang_dense_bf16'`
+  fallback is allowed.
 
 ### `kernel_opt` — payload for `run_optimization`
 

--- a/inference_optimizer/tests/test_coordinator_gemm_promote_units.py
+++ b/inference_optimizer/tests/test_coordinator_gemm_promote_units.py
@@ -161,6 +161,121 @@ class TestPromoteGemmTuningKeep:
         assert len(coord.shared_state.optimization_stack) == 1
 
 
+class TestBf16DenseFallback:
+    def test_fallback_predicate_requires_forge_sglang_fp8_no_candidate(self, tmp_path):
+        coord = _coord(tmp_path, framework="sglang")
+
+        assert coord._should_run_bf16_dense_gemm_fallback(
+            {
+                "backend": "forge",
+                "precision": "fp8",
+                "framework": "sglang",
+                "micro_decision": "no_improvement",
+                "tuners_run": [
+                    {
+                        "status": "no_improvement",
+                        "tuner": "a8w8",
+                        "improved_shapes": 0,
+                    }
+                ],
+            }
+        )
+
+    def test_fallback_predicate_skips_existing_candidate(self, tmp_path):
+        coord = _coord(tmp_path, framework="sglang")
+
+        assert not coord._should_run_bf16_dense_gemm_fallback(
+            {
+                "backend": "forge",
+                "precision": "fp8",
+                "framework": "sglang",
+                "micro_decision": "candidate",
+                "recommended_env": {"AITER_CONFIG_GEMM_A8W8": "/tmp/tuned.csv"},
+                "tuners_run": [
+                    {
+                        "status": "ok",
+                        "tuner": "a8w8",
+                        "improved_shapes": 4,
+                        "env_var": "AITER_CONFIG_GEMM_A8W8",
+                        "env_value": "/tmp/tuned.csv",
+                    }
+                ],
+            }
+        )
+
+    @pytest.mark.asyncio
+    async def test_kernel_entry_runs_bf16_dense_fallback_after_fp8_no_improvement(
+        self, tmp_path, monkeypatch
+    ):
+        coord = _coord(tmp_path, framework="sglang")
+        coord.bus = type(
+            "Bus",
+            (),
+            {"append_and_seq": staticmethod(lambda *_args, **_kwargs: None)},
+        )()
+
+        async def _append_and_seq(*_args, **_kwargs):
+            return None
+
+        coord.bus.append_and_seq = _append_and_seq
+        coord._kernel_enabled = lambda: True
+        coord._perfskills_enabled = lambda: False
+        coord._gemm_tuning_required_before_kernel_opt = lambda: True
+        coord._record_phase_entry_evidence = lambda **_kwargs: None
+        coord._should_continue_kernel_after_gemm = lambda: False
+
+        async def _noop(*_args, **_kwargs):
+            return None
+
+        coord._maybe_reprofile_for_kernel = _noop
+
+        calls: list[dict] = []
+        responses = [
+            {
+                "status": "ok",
+                "decision": "REVERT",
+                "backend": "forge",
+                "engine": "forge",
+                "precision": "fp8",
+                "framework": "sglang",
+                "micro_decision": "no_improvement",
+                "tuners_run": [
+                    {
+                        "status": "no_improvement",
+                        "tuner": "a8w8",
+                        "improved_shapes": 0,
+                    }
+                ],
+            },
+            {
+                "status": "ok",
+                "decision": "REVERT",
+                "backend": "forge",
+                "engine": "forge",
+                "precision": "bf16",
+                "framework": "sglang",
+                "micro_decision": "no_improvement",
+            },
+        ]
+
+        async def _fake_run_gemm(payload, *, session_dir):
+            assert session_dir == tmp_path
+            calls.append(payload)
+            return dict(responses[len(calls) - 1])
+
+        monkeypatch.setattr(krh_mod, "run_gemm_tuning_handler", _fake_run_gemm)
+
+        await coord._on_enter_kernel(from_phase="EXPLORE")
+
+        assert [c["task_id"] for c in calls] == [
+            "kernel_entry_gemm_tuning",
+            "kernel_entry_gemm_tuning_bf16_fallback",
+        ]
+        assert calls[1]["precision"] == "bf16"
+        assert calls[1]["tuner"] == "sglang_dense_bf16"
+        assert coord.shared_state.last_gemm_tuning["precision"] == "bf16"
+
+
 def _eligible_coord(tmp_path, monkeypatch, **overrides):
     """Coordinator wired for a CK-switch-eligible forge workload.
 

--- a/inference_optimizer/tests/test_coordinator_gemm_promote_units.py
+++ b/inference_optimizer/tests/test_coordinator_gemm_promote_units.py
@@ -203,6 +203,58 @@ class TestBf16DenseFallback:
             }
         )
 
+    def test_fallback_predicate_skips_candidate_reverted_by_e2e(self, tmp_path):
+        coord = _coord(tmp_path, framework="sglang")
+
+        assert not coord._should_run_bf16_dense_gemm_fallback(
+            {
+                "backend": "forge",
+                "precision": "fp8",
+                "framework": "sglang",
+                "micro_decision": "candidate_no_e2e_gain",
+                "e2e_validated": True,
+                "e2e_results": {"kept": [], "reverted": [{"tuner": "a8w8"}]},
+            }
+        )
+
+    def test_fallback_pending_resumes_terminal_fp8_no_candidate(
+        self, tmp_path, monkeypatch
+    ):
+        coord = _coord(
+            tmp_path,
+            framework="sglang",
+            precision="fp8",
+            last_gemm_tuning={
+                "status": "ok",
+                "decision": "REVERT",
+                "backend": "forge",
+                "precision": "fp8",
+                "framework": "sglang",
+                "micro_decision": "no_improvement",
+                "tuners_run": [{"status": "no_improvement", "tuner": "a8w8"}],
+            },
+        )
+        monkeypatch.setattr(krh_mod, "_resolve_gemm_tuning_backend", lambda _p: "forge")
+
+        assert coord._bf16_dense_gemm_fallback_pending() is True
+        assert coord._gemm_tuning_required_before_kernel_opt() is True
+
+        coord.shared_state.gemm_tuning_attempts.append(
+            {
+                "status": "complete",
+                "decision": "REVERT",
+                "backend": "forge",
+                "precision": "bf16",
+                "workspace": str(
+                    tmp_path / "runs/gemm_tuning/kernel_entry_gemm_tuning_bf16_fallback"
+                ),
+                "tuners_run": [{"tuner": "sglang_dense_bf16"}],
+            }
+        )
+
+        assert coord._bf16_dense_gemm_fallback_pending() is False
+        assert coord._gemm_tuning_required_before_kernel_opt() is False
+
     @pytest.mark.asyncio
     async def test_kernel_entry_runs_bf16_dense_fallback_after_fp8_no_improvement(
         self, tmp_path, monkeypatch
@@ -274,6 +326,84 @@ class TestBf16DenseFallback:
         assert calls[1]["precision"] == "bf16"
         assert calls[1]["tuner"] == "sglang_dense_bf16"
         assert coord.shared_state.last_gemm_tuning["precision"] == "bf16"
+
+    @pytest.mark.asyncio
+    async def test_kernel_entry_resumes_pending_bf16_fallback_without_rerunning_fp8(
+        self, tmp_path, monkeypatch
+    ):
+        coord = _coord(
+            tmp_path,
+            framework="sglang",
+            precision="fp8",
+            last_gemm_tuning={
+                "status": "ok",
+                "decision": "REVERT",
+                "backend": "forge",
+                "precision": "fp8",
+                "framework": "sglang",
+                "micro_decision": "no_improvement",
+                "tuners_run": [{"status": "no_improvement", "tuner": "a8w8"}],
+            },
+        )
+        coord.bus = type("Bus", (), {})()
+
+        async def _append_and_seq(*_args, **_kwargs):
+            return None
+
+        async def _noop(*_args, **_kwargs):
+            return None
+
+        coord.bus.append_and_seq = _append_and_seq
+        coord._kernel_enabled = lambda: True
+        coord._perfskills_enabled = lambda: False
+        coord._record_phase_entry_evidence = lambda **_kwargs: None
+        coord._should_continue_kernel_after_gemm = lambda: False
+        coord._maybe_reprofile_for_kernel = _noop
+        monkeypatch.setattr(krh_mod, "_resolve_gemm_tuning_backend", lambda _p: "forge")
+
+        calls: list[dict] = []
+
+        async def _fake_run_gemm(payload, *, session_dir):
+            assert session_dir == tmp_path
+            calls.append(payload)
+            return {
+                "status": "ok",
+                "decision": "REVERT",
+                "backend": "forge",
+                "engine": "forge",
+                "precision": "bf16",
+                "framework": "sglang",
+                "micro_decision": "no_improvement",
+            }
+
+        monkeypatch.setattr(krh_mod, "run_gemm_tuning_handler", _fake_run_gemm)
+
+        await coord._on_enter_kernel(from_phase="EXPLORE")
+
+        assert [c["task_id"] for c in calls] == [
+            "kernel_entry_gemm_tuning_bf16_fallback"
+        ]
+        assert calls[0]["precision"] == "bf16"
+        assert coord.shared_state.last_gemm_tuning["task_id"] == (
+            "kernel_entry_gemm_tuning_bf16_fallback"
+        )
+        assert coord._bf16_dense_gemm_fallback_pending() is False
+
+    @pytest.mark.asyncio
+    async def test_bf16_fallback_failure_is_recorded_as_attempt(self, tmp_path):
+        coord = _coord(tmp_path, framework="sglang")
+
+        async def _raise(*_args, **_kwargs):
+            raise RuntimeError("fallback boom")
+
+        result = await coord._run_bf16_dense_gemm_fallback(_raise)
+
+        assert result["status"] == "failed"
+        assert result["decision"] == "REVERT"
+        assert result["task_id"] == "kernel_entry_gemm_tuning_bf16_fallback"
+        assert result["source"] == "fp8_no_improvement_bf16_fallback"
+        assert result["precision"] == "bf16"
+        assert coord._is_bf16_dense_gemm_fallback_attempt(result) is True
 
 
 def _eligible_coord(tmp_path, monkeypatch, **overrides):


### PR DESCRIPTION
## Summary
- Add a deterministic bf16 dense GEMM fallback when the automatic forge fp8 tuner reports no candidate.
- Keep existing fp8 candidates and CK switch validation untouched, and only fallback for forge + sglang + fp8 no-improvement results.
- Update the kernel prompt and coordinator unit coverage for the fallback path.

## Test plan
- python -m py_compile inference_optimizer/orchestrator/coordinator.py inference_optimizer/orchestrator/system_prompts/prompt_builder.py inference_optimizer/tests/test_coordinator_gemm_promote_units.py
- python -c with fcntl stub: 41 passed

## Notes
- Plain Windows pytest collection still fails before tests because inference_optimizer.recipe_kb.local_store imports Linux-only fcntl; the stubbed run above is used to exercise this unit file locally.

Made with [Cursor](https://cursor.com)