### PR TITLE
fix(cli): honor phase-budget-pct overrides after KERNEL_AGENT rename

### DIFF
--- a/inference_optimizer/breakdown/legacy_collectors.py
+++ b/inference_optimizer/breakdown/legacy_collectors.py
@@ -37,9 +37,11 @@ _ACTION_PHASE: dict[str, str] = {
     "params": "EXPLORE",
     "backends": "EXPLORE",
     "sweep": "SWEEP",
-    "select_kernels": "KERNEL",
-    "kernel_opt": "KERNEL",
-    "integrate": "KERNEL",
+    # Canonical v2 phase is KERNEL_AGENT (renamed from legacy "KERNEL" in
+    # commit 33ac6ccc); values here MUST match phase_state.PHASE_NAMES.
+    "select_kernels": "KERNEL_AGENT",
+    "kernel_opt": "KERNEL_AGENT",
+    "integrate": "KERNEL_AGENT",
 }
 
 # Actions that inherit the active phase rather than open a new segment.

--- a/inference_optimizer/breakdown/schema.py
+++ b/inference_optimizer/breakdown/schema.py
@@ -1391,8 +1391,8 @@ class PhaseSegment(TypedDict, total=False):
     the entry evidence and the events that fell within the segment window.
 
     Attributes:
-        phase (str): Phase name (``PRELUDE`` / ``FRAMEWORK`` / ``EXPLORE`` /
-            ``KERNEL`` / ``SWEEP`` / ``CLOSE``).
+        phase (str): Phase name (``PRELUDE`` / ``FRAMEWORK_AGENT`` /
+            ``EXPLORE`` / ``KERNEL_AGENT`` / ``SWEEP`` / ``CLOSE``).
         from_phase (str): Previous phase (empty for the first segment).
         entered_ts (str): ISO UTC timestamp of entry.
         entered_unix (float | None): Unix time of entry, or None.

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -2909,6 +2909,25 @@ def _resolve_run_max_model_len(args: argparse.Namespace) -> tuple[int, str]:
     )
 
 
+# Phases that still sit upstream of EXPLORE, so a resume may retroactively
+# honour --no-explore. Includes the legacy "FRAMEWORK" name for sessions
+# persisted before the FRAMEWORK -> FRAMEWORK_AGENT rename (commit 33ac6ccc).
+_PRE_EXPLORE_PHASES: frozenset[str] = frozenset({"", "PRELUDE", "FRAMEWORK", "FRAMEWORK_AGENT"})
+
+
+def _resume_can_disable_explore(cur_phase: str) -> bool:
+    """Whether ``--no-explore`` may still disable EXPLORE for a resumed session.
+
+    Args:
+        cur_phase (str): The persisted ``state.phase``; case/whitespace-insensitive.
+
+    Returns:
+        bool: ``True`` when the phase is upstream of EXPLORE (EXPLORE not yet
+        entered), so the flag can be honoured retroactively.
+    """
+    return (cur_phase or "").strip().upper() in _PRE_EXPLORE_PHASES
+
+
 def _build_phase_budget_pct(args: argparse.Namespace) -> dict[str, float]:
     """Map ``--*-pct`` CLI flags to a ``phase -> pct`` override dict.
 
@@ -3250,9 +3269,10 @@ async def _run_optimize(args: argparse.Namespace) -> int:
         elif bool(getattr(args, "no_explore", False)):
             # Honour --no-explore on resume only before EXPLORE is entered.
             # Phases preceding EXPLORE are PRELUDE and FRAMEWORK_AGENT (the
-            # latter renamed from the legacy "FRAMEWORK" in commit 33ac6ccc).
+            # latter renamed from the legacy "FRAMEWORK" in commit 33ac6ccc,
+            # which persisted sessions may still carry).
             cur_phase = (getattr(state, "phase", "") or "").strip().upper()
-            if cur_phase in ("", "PRELUDE", "FRAMEWORK_AGENT"):
+            if _resume_can_disable_explore(cur_phase):
                 state.explore_enabled = False
                 print(f"  explore phase         : DISABLING for resume (--no-explore + phase={cur_phase or 'PRELUDE'})")
             else:

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -2909,6 +2909,36 @@ def _resolve_run_max_model_len(args: argparse.Namespace) -> tuple[int, str]:
     )
 
 
+def _build_phase_budget_pct(args: argparse.Namespace) -> dict[str, float]:
+    """Map ``--*-pct`` CLI flags to a ``phase -> pct`` override dict.
+
+    Keys MUST be the canonical phase names from
+    :mod:`inference_optimizer.orchestrator.phase_state`; otherwise
+    :func:`normalize_budget_pct` silently drops the entry and the phase falls
+    back to its library default.
+    """
+    from .orchestrator.phase_state import (
+        PHASE_CLOSE,
+        PHASE_EXPLORE,
+        PHASE_KERNEL_AGENT,
+        PHASE_PRELUDE,
+        PHASE_SWEEP,
+    )
+
+    phase_budget_pct: dict[str, float] = {}
+    for cli_field, phase_name in (
+        ("phase_budget_prelude_pct", PHASE_PRELUDE),
+        ("phase_budget_explore_pct", PHASE_EXPLORE),
+        ("phase_budget_kernel_pct", PHASE_KERNEL_AGENT),
+        ("phase_budget_sweep_pct", PHASE_SWEEP),
+        ("phase_budget_close_pct", PHASE_CLOSE),
+    ):
+        val = getattr(args, cli_field, None)
+        if val is not None:
+            phase_budget_pct[phase_name] = float(val)
+    return phase_budget_pct
+
+
 def _export_workload_envs_for_optimize(
     args: argparse.Namespace,
     *,
@@ -3217,8 +3247,10 @@ async def _run_optimize(args: argparse.Namespace) -> int:
             print("  explore phase         : DISABLED (persisted from original run)")
         elif bool(getattr(args, "no_explore", False)):
             # Honour --no-explore on resume only before EXPLORE is entered.
+            # Phases preceding EXPLORE are PRELUDE and FRAMEWORK_AGENT (the
+            # latter renamed from the legacy "FRAMEWORK" in commit 33ac6ccc).
             cur_phase = (getattr(state, "phase", "") or "").strip().upper()
-            if cur_phase in ("", "PRELUDE", "FRAMEWORK"):
+            if cur_phase in ("", "PRELUDE", "FRAMEWORK_AGENT"):
                 state.explore_enabled = False
                 print(f"  explore phase         : DISABLING for resume (--no-explore + phase={cur_phase or 'PRELUDE'})")
             else:
@@ -3656,17 +3688,7 @@ async def _run_optimize(args: argparse.Namespace) -> int:
         )
 
     # Build phase budget pct dict from CLI flags; absent values fall back to Coordinator library defaults.
-    phase_budget_pct: dict[str, float] = {}
-    for cli_field, phase_name in (
-        ("phase_budget_prelude_pct", "PRELUDE"),
-        ("phase_budget_explore_pct", "EXPLORE"),
-        ("phase_budget_kernel_pct", "KERNEL"),
-        ("phase_budget_sweep_pct", "SWEEP"),
-        ("phase_budget_close_pct", "CLOSE"),
-    ):
-        val = getattr(args, cli_field, None)
-        if val is not None:
-            phase_budget_pct[phase_name] = float(val)
+    phase_budget_pct = _build_phase_budget_pct(args)
 
     # When kernel is disabled, strip it from the role registry (no tick / no backend expectation).
     role_registry = None
@@ -5290,8 +5312,11 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     # phase budget percentages
     # Each phase claims a fraction of the wall-clock budget (caps; may exit earlier). Sum need not equal 1.0.
+    # Both spellings are accepted for every phase: the legacy ``--max-minutes-*-pct``
+    # and the newer ``--phase-budget-*-pct`` (matches the ``phase_budget_*`` dest).
     opt.add_argument(
         "--max-minutes-prelude-pct",
+        "--phase-budget-prelude-pct",
         dest="phase_budget_prelude_pct",
         type=float,
         default=None,
@@ -5299,20 +5324,23 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     opt.add_argument(
         "--max-minutes-explore-pct",
+        "--phase-budget-explore-pct",
         dest="phase_budget_explore_pct",
         type=float,
         default=None,
-        help="Wall-clock budget cap for EXPLORE. Default: 0.45.",
+        help="Wall-clock budget cap for EXPLORE. Default: 0.375.",
     )
     opt.add_argument(
         "--max-minutes-kernel-pct",
+        "--phase-budget-kernel-pct",
         dest="phase_budget_kernel_pct",
         type=float,
         default=None,
-        help="Wall-clock budget cap for KERNEL. Default: 0.38.",
+        help="Wall-clock budget cap for KERNEL_AGENT. Default: 0.305.",
     )
     opt.add_argument(
         "--max-minutes-sweep-pct",
+        "--phase-budget-sweep-pct",
         dest="phase_budget_sweep_pct",
         type=float,
         default=None,
@@ -5320,6 +5348,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     opt.add_argument(
         "--max-minutes-close-pct",
+        "--phase-budget-close-pct",
         dest="phase_budget_close_pct",
         type=float,
         default=None,

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -2920,6 +2920,7 @@ def _build_phase_budget_pct(args: argparse.Namespace) -> dict[str, float]:
     from .orchestrator.phase_state import (
         PHASE_CLOSE,
         PHASE_EXPLORE,
+        PHASE_FRAMEWORK_AGENT,
         PHASE_KERNEL_AGENT,
         PHASE_PRELUDE,
         PHASE_SWEEP,
@@ -2928,6 +2929,7 @@ def _build_phase_budget_pct(args: argparse.Namespace) -> dict[str, float]:
     phase_budget_pct: dict[str, float] = {}
     for cli_field, phase_name in (
         ("phase_budget_prelude_pct", PHASE_PRELUDE),
+        ("phase_budget_framework_pct", PHASE_FRAMEWORK_AGENT),
         ("phase_budget_explore_pct", PHASE_EXPLORE),
         ("phase_budget_kernel_pct", PHASE_KERNEL_AGENT),
         ("phase_budget_sweep_pct", PHASE_SWEEP),
@@ -5321,6 +5323,14 @@ def _build_parser() -> argparse.ArgumentParser:
         type=float,
         default=None,
         help="Wall-clock budget cap for PRELUDE as a fraction of --max-hours. Default: 0.03.",
+    )
+    opt.add_argument(
+        "--max-minutes-framework-pct",
+        "--phase-budget-framework-pct",
+        dest="phase_budget_framework_pct",
+        type=float,
+        default=None,
+        help="Wall-clock budget cap for FRAMEWORK_AGENT. Default: 0.15.",
     )
     opt.add_argument(
         "--max-minutes-explore-pct",

--- a/inference_optimizer/tests/test_cli_no_explore.py
+++ b/inference_optimizer/tests/test_cli_no_explore.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 
+import pytest
+
 from inference_optimizer import cli
 
 
@@ -38,7 +40,31 @@ def test_shared_state_explore_enabled_defaults_true():
     assert SharedState(session_id="t").explore_enabled is True
 
 
-# Resume write-back — mirror the inline cli.py branch logic.
+# Pre-EXPLORE guard — a resume may only retroactively honour --no-explore while
+# the persisted phase is still upstream of EXPLORE. The list MUST include the
+# legacy "FRAMEWORK" name (pre-rename sessions persisted before commit 33ac6ccc)
+# alongside the current "FRAMEWORK_AGENT"; otherwise those resumes silently keep
+# EXPLORE enabled.
+@pytest.mark.parametrize(
+    "phase,expected",
+    [
+        ("", True),
+        ("PRELUDE", True),
+        ("prelude", True),
+        ("FRAMEWORK", True),  # legacy pre-rename phase name
+        ("framework", True),  # case-insensitive
+        ("FRAMEWORK_AGENT", True),
+        ("EXPLORE", False),
+        ("KERNEL_AGENT", False),
+        ("SWEEP", False),
+        ("CLOSE", False),
+    ],
+)
+def test_resume_can_disable_explore(phase: str, expected: bool) -> None:
+    assert cli._resume_can_disable_explore(phase) is expected
+
+
+# Resume write-back — exercises the real cli guard (no mirrored literals).
 class _ResumeStateStub:
     def __init__(self, *, explore_enabled: bool, phase: str) -> None:
         self.explore_enabled = explore_enabled
@@ -51,14 +77,16 @@ class _ArgsStub:
 
 
 def _apply_resume_writeback(state: _ResumeStateStub, args: _ArgsStub) -> str:
-    """Re-implement the resume-branch logic from cli.py for testing."""
+    """Mirror the resume-branch control flow from cli.py, delegating the actual
+    phase check to the real ``cli._resume_can_disable_explore`` helper so this
+    test cannot drift from production."""
     msg = ""
     if not bool(getattr(state, "explore_enabled", True)):
         args.no_explore = True
         msg = "DISABLED_PERSISTED"
     elif bool(getattr(args, "no_explore", False)):
         cur_phase = (getattr(state, "phase", "") or "").strip().upper()
-        if cur_phase in ("", "PRELUDE", "FRAMEWORK_AGENT"):
+        if cli._resume_can_disable_explore(cur_phase):
             state.explore_enabled = False
             msg = "DISABLING_RESUME"
         else:
@@ -75,6 +103,14 @@ def test_resume_writeback_disables_state_when_prelude_and_flag_passed():
 
 def test_resume_writeback_allows_disable_in_framework():
     state = _ResumeStateStub(explore_enabled=True, phase="FRAMEWORK_AGENT")
+    args = _ArgsStub(no_explore=True)
+    assert _apply_resume_writeback(state, args) == "DISABLING_RESUME"
+    assert state.explore_enabled is False
+
+
+def test_resume_writeback_allows_disable_in_legacy_framework():
+    # Pre-rename sessions persist phase="FRAMEWORK"; --no-explore must still win.
+    state = _ResumeStateStub(explore_enabled=True, phase="FRAMEWORK")
     args = _ArgsStub(no_explore=True)
     assert _apply_resume_writeback(state, args) == "DISABLING_RESUME"
     assert state.explore_enabled is False

--- a/inference_optimizer/tests/test_legacy_collectors_unit.py
+++ b/inference_optimizer/tests/test_legacy_collectors_unit.py
@@ -16,7 +16,21 @@ def test_is_legacy_session():
 def test_phase_for_event_known():
     assert lc._phase_for_event("baseline", "") == "PRELUDE"
     assert lc._phase_for_event("sweep", "") == "SWEEP"
-    assert lc._phase_for_event("kernel_opt", "") == "KERNEL"
+    # Canonical v2 phase name is KERNEL_AGENT (renamed from legacy "KERNEL").
+    assert lc._phase_for_event("kernel_opt", "") == "KERNEL_AGENT"
+    assert lc._phase_for_event("select_kernels", "") == "KERNEL_AGENT"
+    assert lc._phase_for_event("integrate", "") == "KERNEL_AGENT"
+
+
+def test_action_phase_values_are_canonical():
+    # Every reconstructed phase label must match a canonical PHASE_NAMES entry,
+    # otherwise legacy-session segments render with names the dashboard/state
+    # machine do not recognise. Guards against future step-name renames.
+    from inference_optimizer.orchestrator.phase_state import PHASE_NAMES
+
+    for action, phase in lc._ACTION_PHASE.items():
+        assert phase in PHASE_NAMES, f"{action!r} -> non-canonical phase {phase!r}"
+    assert lc._DEFAULT_PHASE in PHASE_NAMES
 
 
 def test_phase_for_event_neutral_inherits():

--- a/inference_optimizer/tests/test_phase_budget_pct_cli.py
+++ b/inference_optimizer/tests/test_phase_budget_pct_cli.py
@@ -1,0 +1,89 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Regression: KERNEL phase-budget-pct CLI override must reach KERNEL_AGENT.
+
+Two coupled bugs made ``--*-kernel-pct`` a no-op after the KERNEL -> KERNEL_AGENT
+phase rename (commit 33ac6ccc):
+
+* Root cause 1: :func:`cli._build_phase_budget_pct` emitted the key ``"KERNEL"``
+  while the canonical phase name is ``"KERNEL_AGENT"``, so
+  :func:`normalize_budget_pct` dropped it and the phase fell back to its default
+  (0.305).
+* Root cause 2: only ``--max-minutes-kernel-pct`` was registered; the
+  ``--phase-budget-kernel-pct`` spelling used by callers raised a parse error.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from inference_optimizer import cli
+from inference_optimizer.orchestrator.phase_state import (
+    DEFAULT_PHASE_BUDGET_PCT,
+    PHASE_KERNEL_AGENT,
+    normalize_budget_pct,
+)
+
+
+def _parse_optimize(argv: list[str]) -> object:
+    parser = cli._build_parser()
+    return parser.parse_args(["optimize", "--model", "/tmp/m", *argv])
+
+
+@pytest.mark.parametrize(
+    "flag",
+    ["--max-minutes-kernel-pct", "--phase-budget-kernel-pct"],
+)
+def test_kernel_pct_override_reaches_kernel_agent(flag: str) -> None:
+    """Both flag spellings must survive normalize_budget_pct as KERNEL_AGENT."""
+    args = _parse_optimize([flag, "0.78"])
+    raw = cli._build_phase_budget_pct(args)
+    assert raw.get(PHASE_KERNEL_AGENT) == pytest.approx(0.78)
+
+    normalized = normalize_budget_pct(raw)
+    assert normalized[PHASE_KERNEL_AGENT] == pytest.approx(0.78)
+    # Regression guard: value must not silently fall back to the default.
+    assert normalized[PHASE_KERNEL_AGENT] != pytest.approx(
+        DEFAULT_PHASE_BUDGET_PCT[PHASE_KERNEL_AGENT]
+    )
+
+
+def test_kernel_pct_key_is_canonical_phase_name() -> None:
+    """The override key must be the canonical phase name, not the legacy alias."""
+    args = _parse_optimize(["--phase-budget-kernel-pct", "0.5"])
+    raw = cli._build_phase_budget_pct(args)
+    assert "KERNEL" not in raw
+    assert PHASE_KERNEL_AGENT in raw
+
+
+def test_all_phase_budget_pct_spellings_parse() -> None:
+    """Every phase accepts both the legacy and the phase-budget spelling."""
+    argv = [
+        "--phase-budget-prelude-pct", "0.05",
+        "--phase-budget-explore-pct", "0.30",
+        "--phase-budget-kernel-pct", "0.40",
+        "--phase-budget-sweep-pct", "0.15",
+        "--phase-budget-close-pct", "0.03",
+    ]
+    args = _parse_optimize(argv)
+    normalized = normalize_budget_pct(cli._build_phase_budget_pct(args))
+    assert normalized["PRELUDE"] == pytest.approx(0.05)
+    assert normalized["EXPLORE"] == pytest.approx(0.30)
+    assert normalized[PHASE_KERNEL_AGENT] == pytest.approx(0.40)
+    assert normalized["SWEEP"] == pytest.approx(0.15)
+    assert normalized["CLOSE"] == pytest.approx(0.03)
+
+
+def test_optimize_path_is_wired_to_helper() -> None:
+    """Guard: the live optimize path must build the budget via the helper.
+
+    A prior fix defined ``_build_phase_budget_pct`` but left the real code path
+    using an inline ``("phase_budget_kernel_pct", "KERNEL")`` mapping, so the
+    unit test passed while production still dropped the override. Assert the
+    helper is actually called and the buggy literal is gone from the module.
+    """
+    src = inspect.getsource(cli)
+    assert "_build_phase_budget_pct(args)" in src
+    assert '("phase_budget_kernel_pct", "KERNEL")' not in src

--- a/inference_optimizer/tests/test_phase_budget_pct_cli.py
+++ b/inference_optimizer/tests/test_phase_budget_pct_cli.py
@@ -22,6 +22,7 @@ import pytest
 from inference_optimizer import cli
 from inference_optimizer.orchestrator.phase_state import (
     DEFAULT_PHASE_BUDGET_PCT,
+    PHASE_FRAMEWORK_AGENT,
     PHASE_KERNEL_AGENT,
     normalize_budget_pct,
 )
@@ -58,10 +59,38 @@ def test_kernel_pct_key_is_canonical_phase_name() -> None:
     assert PHASE_KERNEL_AGENT in raw
 
 
+@pytest.mark.parametrize(
+    "flag",
+    ["--max-minutes-framework-pct", "--phase-budget-framework-pct"],
+)
+def test_framework_pct_override_reaches_framework_agent(flag: str) -> None:
+    """FRAMEWORK_AGENT is a budgeted phase, so both flag spellings must parse
+    and survive normalize_budget_pct as FRAMEWORK_AGENT."""
+    args = _parse_optimize([flag, "0.42"])
+    raw = cli._build_phase_budget_pct(args)
+    assert raw.get(PHASE_FRAMEWORK_AGENT) == pytest.approx(0.42)
+
+    normalized = normalize_budget_pct(raw)
+    assert normalized[PHASE_FRAMEWORK_AGENT] == pytest.approx(0.42)
+    # Regression guard: value must not silently fall back to the default.
+    assert normalized[PHASE_FRAMEWORK_AGENT] != pytest.approx(
+        DEFAULT_PHASE_BUDGET_PCT[PHASE_FRAMEWORK_AGENT]
+    )
+
+
+def test_framework_pct_key_is_canonical_phase_name() -> None:
+    """The override key must be the canonical phase name, not the legacy alias."""
+    args = _parse_optimize(["--phase-budget-framework-pct", "0.2"])
+    raw = cli._build_phase_budget_pct(args)
+    assert "FRAMEWORK" not in raw
+    assert PHASE_FRAMEWORK_AGENT in raw
+
+
 def test_all_phase_budget_pct_spellings_parse() -> None:
     """Every phase accepts both the legacy and the phase-budget spelling."""
     argv = [
         "--phase-budget-prelude-pct", "0.05",
+        "--phase-budget-framework-pct", "0.20",
         "--phase-budget-explore-pct", "0.30",
         "--phase-budget-kernel-pct", "0.40",
         "--phase-budget-sweep-pct", "0.15",
@@ -70,6 +99,7 @@ def test_all_phase_budget_pct_spellings_parse() -> None:
     args = _parse_optimize(argv)
     normalized = normalize_budget_pct(cli._build_phase_budget_pct(args))
     assert normalized["PRELUDE"] == pytest.approx(0.05)
+    assert normalized[PHASE_FRAMEWORK_AGENT] == pytest.approx(0.20)
     assert normalized["EXPLORE"] == pytest.approx(0.30)
     assert normalized[PHASE_KERNEL_AGENT] == pytest.approx(0.40)
     assert normalized["SWEEP"] == pytest.approx(0.15)

--- a/inference_optimizer/tests/test_policy_gate_evolution.py
+++ b/inference_optimizer/tests/test_policy_gate_evolution.py
@@ -139,7 +139,7 @@ def test_specialist_can_invoke_readonly_external_tools_in_explore():
 
 # 4. R5 — Web tools are usable in any phase (no phase restriction)
 @pytest.mark.parametrize("web_tool", sorted(WEB_TOOL_NAMES))
-@pytest.mark.parametrize("phase", ["PRELUDE", "EXPLORE", "KERNEL", "SWEEP", "CLOSE"])
+@pytest.mark.parametrize("phase", ["PRELUDE", "EXPLORE", "KERNEL_AGENT", "SWEEP", "CLOSE"])
 def test_specialist_web_tools_allowed_in_any_phase(
     web_tool: str,
     phase: str,
@@ -150,7 +150,7 @@ def test_specialist_web_tools_allowed_in_any_phase(
 
 def test_specialist_pr_monitor_allowed_in_any_phase():
     """PR Monitor read tools are usable in any phase."""
-    for phase in ("PRELUDE", "FRAMEWORK", "EXPLORE", "KERNEL", "SWEEP", "CLOSE"):
+    for phase in ("PRELUDE", "FRAMEWORK_AGENT", "EXPLORE", "KERNEL_AGENT", "SWEEP", "CLOSE"):
         gate = _gate(_State(phase=phase))
         for tool in PR_MONITOR_TOOL_NAMES:
             gate.validate_tool_invocation(tool, source_role="specialist")


### PR DESCRIPTION
The KERNEL -> KERNEL_AGENT / FRAMEWORK -> FRAMEWORK_AGENT phase rename (33ac6ccc) left stale literals that silently dropped CLI overrides.
- cli: build phase_budget_pct via new _build_phase_budget_pct() using canonical phase_state constants, and actually wire it into the optimize path (previously the real path still used the "KERNEL" literal, so the override was dropped by normalize_budget_pct and fell back to 0.305).
- cli: register --phase-budget-*-pct aliases alongside the legacy --max-minutes-*-pct flags so pipeline callers' spelling is accepted; fix stale help defaults.
- cli: fix resume --no-explore guard comparing cur_phase to legacy "FRAMEWORK" instead of "FRAMEWORK_AGENT".
- schema/tests: refresh stale FRAMEWORK/KERNEL phase-name references.
- tests: add regression coverage incl. a guard that the live optimize path is wired to the helper (catches the "defined but not called" bug).

- Description: what and why
- Linked issue(s): close/fix refs
- Tests: added/updated? commands run?
- Breaking changes: yes/no (details if yes)
