### PR TITLE
fix(cli): correct stale inherited TRACELENS_ROOT from kernel-agent env file

### DIFF
--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -947,17 +947,27 @@ def _validate_credentials() -> None:
 
 
 def _is_placeholder_tracelens_path(value: str) -> bool:
-    """Treat .env.template's bare ``\\`` and whitespace-only values as unset.
+    """Treat unedited .env.template placeholders as unset.
+
+    Covers the bare ``\\`` / whitespace-only values plus common literal
+    placeholders (``/path/to/your/TraceLens``, ``<your-...>``) an operator
+    forgot to replace, so the pod-local fallback / installer value wins.
 
     Args:
         value (str): The candidate TraceLens path value.
 
     Returns:
-        bool: ``True`` when the value is blank or the bare backslash
-            placeholder.
+        bool: ``True`` when the value is blank or an unedited placeholder.
     """
     stripped = value.strip()
-    return stripped in ("", "\\")
+    if stripped in ("", "\\"):
+        return True
+    low = stripped.lower()
+    if "/path/to/" in low or "path/to/your" in low:
+        return True
+    if "<" in stripped and ">" in stripped:
+        return True
+    return False
 
 
 def _load_dotenv_fallback() -> None:
@@ -1006,32 +1016,102 @@ def _load_dotenv_fallback() -> None:
         print(f"Preflight: loaded {loaded} missing var(s) from {env_file} (env wins)")
 
 
-def _load_kernel_agent_env_fallback() -> None:
-    """If ``HYPERLOOM_KERNEL_AGENT_ROOT`` is unset, auto-source the
-    kernel-agent env file produced by ``inference_optimizer/scripts/
-    install.sh`` at ``$USER_DATA_PATH/runtime/kernel-agent.env.sh``
-    (overridable via ``$KERNEL_AGENT_ENV``).
+# kernel-agent env vars that MUST resolve to an existing checkout. Unlike
+# ordinary vars (env-wins no-clobber), a stale/invalid inherited value for
+# these is CORRECTED from the installer-written env file so trace_analyze does
+# not fall back to an empty pod-local dir (issue #722). Scoped to TRACELENS_ROOT
+# only: MAGPIE_PATH is deliberately excluded because a merely-existing dir that
+# is not a Magpie checkout would flip the downstream preflight into the
+# explicit-override branch and hard-fail auto-clone.
+_KERNEL_AGENT_PATH_VARS: tuple[str, ...] = ("TRACELENS_ROOT",)
 
-    Must source before any orchestrator import (trace_analyze reads HYPERLOOM_KERNEL_AGENT_ROOT at module load).
-    Hard-fail contract: looks only at $KERNEL_AGENT_ENV or $USER_DATA_PATH/runtime/kernel-agent.env.sh (no
-    parent-dir fallback); sys.exit(2) if missing/0-vars/still-unset; skip when the var is already set.
+
+def _parse_env_assignments(text: str) -> dict[str, str]:
+    """Parse ``[export] KEY=VALUE`` shell assignments into a dict (first wins)."""
+    out: dict[str, str] = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].lstrip()
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        if not key:
+            continue
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+            value = value[1:-1]
+        out.setdefault(key, value)
+    return out
+
+
+def _correct_kernel_agent_path_vars(file_vars: dict[str, str], env_path: Path) -> None:
+    """Overwrite invalid inherited path-class vars with the env file's value.
+
+    Only fires when the inherited value is unset/non-existent AND the file value
+    points at an existing dir; a valid inherited value keeps env-wins semantics.
     """
-    if os.environ.get("HYPERLOOM_KERNEL_AGENT_ROOT"):
-        return
+    for key in _KERNEL_AGENT_PATH_VARS:
+        file_val = file_vars.get(key)
+        if not file_val or not Path(file_val).is_dir():
+            continue
+        current = os.environ.get(key, "")
+        if current == file_val or (current and Path(current).is_dir()):
+            continue
+        print(
+            f"Preflight: WARNING — {key}={current or '(unset)'} does not point "
+            f"at an existing checkout; correcting to {file_val} from {env_path} "
+            f"(installer-written value wins for path vars).",
+            file=sys.stderr,
+        )
+        os.environ[key] = file_val
+
+
+def _load_kernel_agent_env_fallback() -> None:
+    """Auto-source the installer-written kernel-agent env file
+    (``$KERNEL_AGENT_ENV`` or ``$USER_DATA_PATH/runtime/kernel-agent.env.sh``).
+
+    Must source before any orchestrator import (trace_analyze reads
+    HYPERLOOM_KERNEL_AGENT_ROOT at module load). When HYPERLOOM_KERNEL_AGENT_ROOT
+    is already set, bootstrapping is skipped but the env file is still consulted
+    to CORRECT a stale/invalid inherited TRACELENS_ROOT — the fix for issue
+    #722 where a bad inherited TRACELENS_ROOT survived. Hard-fail contract
+    (root unset only): sys.exit(2) if missing/0-vars/still-unset.
+    """
     candidate = os.environ.get("KERNEL_AGENT_ENV")
     if not candidate:
         user_data = os.environ.get("USER_DATA_PATH")
-        if not user_data:
-            print(
-                "Preflight: ERROR — neither $HYPERLOOM_KERNEL_AGENT_ROOT "
-                "nor $KERNEL_AGENT_ENV nor $USER_DATA_PATH is set. Cannot "
-                "resolve kernel-agent.env.sh. Run "
-                "inference_optimizer/scripts/install.sh and export "
-                "USER_DATA_PATH=/path/to/sessions first.",
-                file=sys.stderr,
-            )
-            sys.exit(2)
-        candidate = str(Path(user_data) / "runtime" / "kernel-agent.env.sh")
+        if user_data:
+            candidate = str(Path(user_data) / "runtime" / "kernel-agent.env.sh")
+
+    if os.environ.get("HYPERLOOM_KERNEL_AGENT_ROOT"):
+        # Root is set: no bootstrap needed, but still correct invalid path vars
+        # from the env file when resolvable. Silent no-op otherwise.
+        if not candidate:
+            return
+        env_path = Path(candidate)
+        if not env_path.is_file():
+            return
+        try:
+            text = env_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return
+        _correct_kernel_agent_path_vars(_parse_env_assignments(text), env_path)
+        return
+
+    if not candidate:
+        print(
+            "Preflight: ERROR — neither $HYPERLOOM_KERNEL_AGENT_ROOT "
+            "nor $KERNEL_AGENT_ENV nor $USER_DATA_PATH is set. Cannot "
+            "resolve kernel-agent.env.sh. Run "
+            "inference_optimizer/scripts/install.sh and export "
+            "USER_DATA_PATH=/path/to/sessions first.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
     env_path = Path(candidate)
     if not env_path.is_file():
         print(
@@ -1048,7 +1128,6 @@ def _load_kernel_agent_env_fallback() -> None:
             file=sys.stderr,
         )
         sys.exit(2)
-    loaded = 0
     try:
         text = env_path.read_text(encoding="utf-8", errors="replace")
     except OSError as exc:
@@ -1057,24 +1136,13 @@ def _load_kernel_agent_env_fallback() -> None:
             file=sys.stderr,
         )
         sys.exit(2)
-    for raw in text.splitlines():
-        line = raw.strip()
-        if not line or line.startswith("#"):
-            continue
-        if line.startswith("export "):
-            line = line[len("export ") :].lstrip()
-        if "=" not in line:
-            continue
-        key, _, value = line.partition("=")
-        key = key.strip()
-        if not key:
-            continue
-        value = value.strip()
-        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
-            value = value[1:-1]
+    file_vars = _parse_env_assignments(text)
+    loaded = 0
+    for key, value in file_vars.items():
         if key not in os.environ:
             os.environ[key] = value
             loaded += 1
+    _correct_kernel_agent_path_vars(file_vars, env_path)
     if "HYPERLOOM_KERNEL_AGENT_ROOT" not in os.environ:
         print(
             f"Preflight: ERROR — sourced {env_path} ({loaded} vars) but "
@@ -1241,6 +1309,27 @@ def _check_tracelens_cli() -> None:
         f"  bash $REPO_ROOT/inference_optimizer/scripts/install.sh\n"
         f"  . {session_dir}/runtime/kernel-agent.env.sh\n"
         f"then retry `inference_optimizer optimize`. Refusing to start.",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+def _check_tracelens_root_exists() -> None:
+    """Hard-gate an explicitly set ``TRACELENS_ROOT`` at preflight (issue #722).
+
+    An operator-supplied TRACELENS_ROOT that points at a missing checkout (stale
+    path or unedited template placeholder) otherwise only surfaces ~10h later in
+    trace_analyze. Unset is fine (pod-local fallback handled downstream).
+    """
+    override = os.environ.get("TRACELENS_ROOT")
+    if not override or Path(override).is_dir():
+        return
+    print(
+        f"ERROR: TRACELENS_ROOT={override} does not point at an existing "
+        f"TraceLens checkout. It was likely inherited from a stale shell or an "
+        f"unedited .env template. Re-run inference_optimizer/scripts/install.sh "
+        f"and source $KERNEL_AGENT_ENV, point TRACELENS_ROOT at a real checkout, "
+        f"or unset it to use the pod-local default. Refusing to start.",
         file=sys.stderr,
     )
     sys.exit(2)
@@ -2033,6 +2122,9 @@ def _preflight(
     enable_roofline = getattr(args, "enable_roofline", True) if args else True
     if _tracelens_required_at_preflight(no_kernel, enable_roofline):
         _check_tracelens_cli()
+        # Fail fast on a stale/placeholder TRACELENS_ROOT before the Coordinator
+        # starts, rather than ~10h later in trace_analyze (issue #722).
+        _check_tracelens_root_exists()
     else:
         _missing_tl = [n for n in _TRACELENS_REQUIRED_CLIS if shutil.which(n) is None]
         if _missing_tl:

--- a/inference_optimizer/orchestrator/conc_sweep.py
+++ b/inference_optimizer/orchestrator/conc_sweep.py
@@ -483,8 +483,15 @@ async def run_conc_sweep(
 
     # Re-materialize (idempotent) in case we fell back to the shipped asset.
     resolved_model = str(getattr(state, "model_path", "") or "").strip() or os.environ.get("MODEL_PATH", "").strip()
-    resolved_gpu = (
-        str(getattr(state, "gpu_type", "") or "").strip().lower() or os.environ.get("GPU_TYPE", "").strip().lower()
+    # Mirror the main flow (baseline/sweep/...): prefer $GPU_TYPE (cli.py
+    # canonicalizes mi325x/mi308x -> mi300x), fall back to state.gpu_type, then
+    # canonicalize through _gpu_runner_type so the selected Magpie script is a
+    # shipped runner (sglang_mi300x.sh), never the unshipped sglang_mi325x.sh.
+    from ..cli_model_gate import _gpu_runner_type
+
+    resolved_gpu = _gpu_runner_type(
+        os.environ.get("GPU_TYPE", "").strip().lower()
+        or str(getattr(state, "gpu_type", "") or "").strip().lower()
     )
     try:
         base_yaml_path = materialize_config_with_envs(

--- a/inference_optimizer/tests/test_conc_sweep.py
+++ b/inference_optimizer/tests/test_conc_sweep.py
@@ -439,6 +439,48 @@ def test_run_conc_sweep_happy_path_writes_reports(
     assert not final_json_path.exists()
 
 
+def test_run_conc_sweep_canonicalizes_gpu_type_to_runner(
+    session_dir: Path,
+    baseline_yaml: Path,
+    monkeypatch,
+):
+    """On MI325X/MI308X conc-sweep must select the mi300x runner script, like
+    every other executor — not state.gpu_type's real type (issue: sglang_mi325x.sh
+    is not shipped by Magpie, so the real type would fail every variant)."""
+    state = _make_state(baseline_config_path=str(baseline_yaml))
+    state.gpu_type = "mi325x"
+    monkeypatch.setenv("GPU_TYPE", "mi300x")
+
+    seen: dict[str, str] = {}
+
+    def _fake_materialize(src, out_dir, **kw):
+        seen["materialize_gpu"] = kw.get("gpu_type")
+        out = Path(out_dir) / "conc_sweep_base.with_envs.yaml"
+        out.write_text(Path(src).read_text())
+        return out
+
+    async def _fake_run_grid(*, grid: list[GridVariant], **kw):
+        seen["run_grid_gpu"] = kw.get("gpu_type")
+        return [
+            _fake_variant(v.name, throughput=100.0, envs=v.extra_envs) for v in grid
+        ]
+
+    with (
+        patch(
+            "inference_optimizer.orchestrator.conc_sweep.run_grid",
+            side_effect=_fake_run_grid,
+        ),
+        patch(
+            "inference_optimizer.orchestrator.conc_sweep.materialize_config_with_envs",
+            side_effect=_fake_materialize,
+        ),
+    ):
+        asyncio.run(run_conc_sweep(state, session_dir, concs=[1]))
+
+    assert seen["materialize_gpu"] == "mi300x"
+    assert seen["run_grid_gpu"] == "mi300x"
+
+
 def test_run_conc_sweep_optimized_oom_yields_failed_pair(
     session_dir: Path,
     baseline_yaml: Path,

--- a/inference_optimizer/tests/test_resume.py
+++ b/inference_optimizer/tests/test_resume.py
@@ -564,3 +564,116 @@ class TestN24KernelAgentEnvHardFail:
         import os as _os
 
         assert _os.environ["HYPERLOOM_KERNEL_AGENT_ROOT"] == "/from/custom"
+
+
+# TraceLens root env-propagation regression (issue #722): a stale/placeholder
+# TRACELENS_ROOT inherited by the coordinator must be corrected from the
+# installer-written env file, and unedited template placeholders must be
+# treated as unset, so trace_analyze never falls back to an empty pod-local dir.
+class TestTracelensRootEnvCorrection:
+    @pytest.fixture(autouse=True)
+    def _isolate_env(self, monkeypatch):
+        for var in (
+            "HYPERLOOM_KERNEL_AGENT_ROOT",
+            "KERNEL_AGENT_ENV",
+            "USER_DATA_PATH",
+            "TRACELENS_ROOT",
+            "MAGPIE_PATH",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+    def _write_env_file(self, tmp_path, tracelens_dir):
+        runtime = tmp_path / "runtime"
+        runtime.mkdir(exist_ok=True)
+        (runtime / "kernel-agent.env.sh").write_text(
+            "export HYPERLOOM_KERNEL_AGENT_ROOT=/opt/kernel-agent\n"
+            f"export TRACELENS_ROOT='{tracelens_dir}'\n",
+            encoding="utf-8",
+        )
+
+    def test_corrects_invalid_inherited_root_from_env_file(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Root set + inherited TRACELENS_ROOT points nowhere → corrected from file."""
+        from inference_optimizer import cli
+
+        good = tmp_path / "deps" / "TraceLens"
+        good.mkdir(parents=True)
+        self._write_env_file(tmp_path, good)
+        monkeypatch.setenv("HYPERLOOM_KERNEL_AGENT_ROOT", "/opt/kernel-agent")
+        monkeypatch.setenv("USER_DATA_PATH", str(tmp_path))
+        monkeypatch.setenv("TRACELENS_ROOT", str(tmp_path / "ghost" / "TraceLens"))
+
+        cli._load_kernel_agent_env_fallback()
+
+        import os as _os
+
+        assert _os.environ["TRACELENS_ROOT"] == str(good)
+        assert "TRACELENS_ROOT" in capsys.readouterr().err
+
+    def test_keeps_valid_inherited_root(self, tmp_path, monkeypatch):
+        """A valid inherited TRACELENS_ROOT wins over the env file (env-wins)."""
+        from inference_optimizer import cli
+
+        file_dir = tmp_path / "file" / "TraceLens"
+        file_dir.mkdir(parents=True)
+        inherited = tmp_path / "inherited" / "TraceLens"
+        inherited.mkdir(parents=True)
+        self._write_env_file(tmp_path, file_dir)
+        monkeypatch.setenv("HYPERLOOM_KERNEL_AGENT_ROOT", "/opt/kernel-agent")
+        monkeypatch.setenv("USER_DATA_PATH", str(tmp_path))
+        monkeypatch.setenv("TRACELENS_ROOT", str(inherited))
+
+        cli._load_kernel_agent_env_fallback()
+
+        import os as _os
+
+        assert _os.environ["TRACELENS_ROOT"] == str(inherited)
+
+    def test_magpie_path_is_not_corrected(self, tmp_path, monkeypatch):
+        """MAGPIE_PATH is out of scope: a merely-existing non-checkout dir in the
+        env file must NOT be promoted to an explicit MAGPIE_PATH override."""
+        from inference_optimizer import cli
+
+        runtime = tmp_path / "runtime"
+        runtime.mkdir()
+        magpie_dir = tmp_path / "not-a-magpie-checkout"
+        magpie_dir.mkdir()
+        (runtime / "kernel-agent.env.sh").write_text(
+            "export HYPERLOOM_KERNEL_AGENT_ROOT=/opt/kernel-agent\n"
+            f"export MAGPIE_PATH='{magpie_dir}'\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HYPERLOOM_KERNEL_AGENT_ROOT", "/opt/kernel-agent")
+        monkeypatch.setenv("USER_DATA_PATH", str(tmp_path))
+
+        cli._load_kernel_agent_env_fallback()
+
+        import os as _os
+
+        assert _os.environ.get("MAGPIE_PATH") is None
+
+    def test_placeholder_path_to_your_is_unset(self):
+        from inference_optimizer import cli
+
+        assert cli._is_placeholder_tracelens_path("/path/to/your/TraceLens") is True
+        assert cli._is_placeholder_tracelens_path("<your-tracelens>") is True
+        assert cli._is_placeholder_tracelens_path("/tmp/hyperloom/TraceLens") is False
+
+    def test_check_root_exits_when_set_but_missing(self, tmp_path, monkeypatch):
+        from inference_optimizer import cli
+
+        monkeypatch.setenv("TRACELENS_ROOT", str(tmp_path / "ghost"))
+        with pytest.raises(SystemExit) as excinfo:
+            cli._check_tracelens_root_exists()
+        assert excinfo.value.code == 2
+
+    def test_check_root_noop_when_valid_or_unset(self, tmp_path, monkeypatch):
+        from inference_optimizer import cli
+
+        monkeypatch.delenv("TRACELENS_ROOT", raising=False)
+        cli._check_tracelens_root_exists()  # unset → no raise
+        good = tmp_path / "TraceLens"
+        good.mkdir()
+        monkeypatch.setenv("TRACELENS_ROOT", str(good))
+        cli._check_tracelens_root_exists()  # valid → no raise


### PR DESCRIPTION
trace_analyze fell back to an empty pod-local dir when the coordinator inherited a stale/placeholder TRACELENS_ROOT: _load_kernel_agent_env_fallback early-returned whenever HYPERLOOM_KERNEL_AGENT_ROOT was set, and both env loaders are no-clobber so a bad inherited value was never overridden (#722).

- Consult kernel-agent.env.sh even when the root is already set, and correct an invalid inherited TRACELENS_ROOT from the installer-written value (WARN); a valid inherited value still wins (env-wins preserved).
- Scope correction to TRACELENS_ROOT only; MAGPIE_PATH is excluded so a merely-existing non-checkout dir cannot flip the Magpie preflight into the explicit-override hard-fail branch.
- Recognise literal .env template placeholders (/path/to/your/..., <...>) as unset in _is_placeholder_tracelens_path.
- Fail fast at preflight when an explicit TRACELENS_ROOT points nowhere, instead of ~10h later in trace_analyze.

- Description: what and why
- Linked issue(s): close/fix refs
- Tests: added/updated? commands run?
- Breaking changes: yes/no (details if yes)
