### PR TITLE
chore(lint): add pre-commit + bandit config, clear ruff backlog, fix …

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,9 @@
+# actionlint configuration.
+#
+# Declare the self-hosted runner labels used across the optimization workflows
+# so actionlint does not flag them as unknown ``runs-on`` values (false
+# positives that otherwise drown out real workflow errors).
+self-hosted-runner:
+  labels:
+    - hyperloom-4hhzn
+    - hyperloom-mh826

--- a/.github/workflows/optimize-submit.yml
+++ b/.github/workflows/optimize-submit.yml
@@ -8,8 +8,7 @@ name: SaFE Optimize Submit
 #
 # Three-stage pipeline:
 #   1. prepare    (ubuntu-latest)  — pick model source by priority:
-#                                    models > candidates_file (+ batch slice)
-#                                    > hf_top (live HF API).
+#                                    models > candidates_file (+ batch slice).
 #                                    Emits matrix JSON for stage 2.
 #   2. optimize   (matrix, hyperloom-4hhzn) — one model per parallel job.
 #                                    Each job pre-pulls its own repo to
@@ -31,7 +30,6 @@ name: SaFE Optimize Submit
 #   • Single/few models      : `-f models='Qwen/Qwen2.5-7B-Instruct ...'`
 #   • Reproducible batch run : `-f candidates_file=ci/candidates/hf_downloads_gt100_rotate_2026-06-17.json
 #                              -f batch_index=0 -f batch_size=130`
-#   • Quick HF top-N probe   : `-f hf_top=10 -f min_params=7`
 
 on:
   # No schedule of its own: this is the shared EXECUTION ENGINE. The per-pool
@@ -50,7 +48,7 @@ on:
     # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows
     # https://github.blog/changelog/2025-12-04-actions-workflow-dispatch-workflows-now-support-25-inputs/
     inputs:
-      # ── Model source (priority: models > candidates_file > legacy hf_top) ──────
+      # ── Model source (priority: models > candidates_file) ──────
       models:
         description: 'Explicit HF repo IDs (space-separated). HIGHEST priority.'
         required: false
@@ -131,11 +129,13 @@ on:
         type: choice
         options: [local, claw]
       framework:
-        description: 'Serving framework override forwarded to optimize_submit.py as --framework. Leave empty to auto-detect from the model config.'
+        # Free-form string (not a ``choice``): a choice input cannot offer an
+        # empty option for the "auto-detect" default, so this stays a string.
+        # Valid values today: sglang | vllm. Empty keeps the script's
+        # auto-detect (the Submit step only passes --framework when non-empty).
+        description: 'Serving framework override (sglang|vllm) forwarded to optimize_submit.py as --framework. Leave empty to auto-detect from the model config.'
         required: false
         default: ''
-        type: choice
-        options: ['', sglang, vllm]
       gpu_type:
         description: 'GPU type tag (overrides SaFE backend default MI355X). Leave empty to use script default (MI300X for core42).'
         required: false
@@ -238,7 +238,6 @@ jobs:
       # schedule so the real clock is used.
       INPUT_CRON_NOW:        ${{ github.event_name == 'schedule' && '' || github.event.inputs.cron_now }}
       INPUT_BATCH_SIZE:      ${{ github.event_name == 'schedule' && '240' || github.event.inputs.batch_size }}
-      INPUT_HF_TOP:          ${{ github.event.inputs.hf_top }}
       INPUT_MIN_PARAMS:      ${{ github.event.inputs.min_params }}
       # Schedule does NOT exclude leaderboard-known models so the pool keeps
       # cycling. Active-workflow exclusion is ON (same as optimize-tiny) so
@@ -975,7 +974,10 @@ jobs:
   # ── Stage 3: aggregate summary ───────────────────────────────────────────────
   summarize:
     name: Build summary
-    needs: optimize
+    # Depends on both prepare (for the ``count`` guard below) and optimize.
+    # ``optimize`` already needs ``prepare``, so listing both here only makes
+    # ``needs.prepare.outputs`` reachable in this job's ``if`` expression.
+    needs: [prepare, optimize]
     if: always() && needs.prepare.outputs.count != '0' && github.event.inputs.dry_run != 'true'
     # Run on the self-hosted hyperloom-4hhzn runner (a K8s pod in the
     # core42-hyperloom namespace) so the Publish step can reach the
@@ -1126,7 +1128,6 @@ jobs:
           WEBHOOK_URL:    ${{ secrets.WEBHOOK_URL }}
           DASHBOARD_URL:  ${{ secrets.HYPERLOOM_DASHBOARD_URL }}
           INPUT_MODELS:   ${{ github.event.inputs.models }}
-          INPUT_HF_TOP:   ${{ github.event.inputs.hf_top }}
           # Perf-leaderboard publish counts (from the previous step) so
           # send_webhook.py can render "X/N sent to perf-leaderboard" in
           # the card footer.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,55 @@
+# Pre-commit: single local front door for the CI static-analysis gates.
+#
+# Scope note: this wires the *check-only* hooks (no ``ruff-format``). The
+# repo-wide ``ruff format`` reflow (~170 files) is deferred to its own
+# mechanical PR; enable the ``ruff-format`` hook here once that lands so
+# formatting is enforced at authoring time.
+#
+# Install locally with::
+#
+#     pip install pre-commit && pre-commit install
+#
+# Run against everything once (baseline) with::
+#
+#     pre-commit run --all-files
+#
+# Hooks default to changed files only, so the existing lint backlog does not
+# block commits while it is drained; new/changed lines are gated immediately.
+repos:
+  # Ruff: same rule set as ``[tool.ruff]`` / ``[tool.ruff.lint]`` and the
+  # ``lint.yml`` CI job (E/F/W). Check only -- formatting is deferred (see note).
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.20
+    hooks:
+      - id: ruff
+        args: ["--force-exclude"]
+
+  # Bandit: reads ``[tool.bandit]`` (skips B101, excludes test trees). The
+  # ``bandit[toml]`` extra is required to parse the config from pyproject.
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.9.4
+    hooks:
+      - id: bandit
+        args: ["-c", "pyproject.toml"]
+        additional_dependencies: ["bandit[toml]"]
+
+  # ShellCheck: most hits are SC2086 (unquoted expansions) -- fast to fix.
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.11.0
+    hooks:
+      - id: shellcheck
+
+  # yamllint: ``relaxed`` preset + line-length disabled keeps the existing
+  # backlog from blocking commits while still flagging genuine YAML errors.
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+        args: ["-d", "{extends: relaxed, rules: {line-length: disable}}"]
+
+  # actionlint: lints ``.github/workflows`` -- run locally so the workflow-lint
+  # error the audit hit (actionlint did not complete in CI) surfaces early.
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,16 +26,21 @@ repos:
 
   # Bandit: reads ``[tool.bandit]`` (skips B101, excludes test trees). The
   # ``bandit[toml]`` extra is required to parse the config from pyproject.
+  # ``exclude`` re-applies the test-tree filter here because pre-commit passes
+  # explicit filenames, which bypasses ``[tool.bandit].exclude_dirs``.
   - repo: https://github.com/PyCQA/bandit
     rev: 1.9.4
     hooks:
       - id: bandit
         args: ["-c", "pyproject.toml"]
         additional_dependencies: ["bandit[toml]"]
+        exclude: "^.*/tests?/"
 
   # ShellCheck: most hits are SC2086 (unquoted expansions) -- fast to fix.
-  - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.11.0
+  # ``shellcheck-py`` ships a pip wheel (no Docker), unlike the koalaman
+  # docker-image hook, so it runs in any local/CI environment.
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
 

--- a/ci/generate_hf_matrix.py
+++ b/ci/generate_hf_matrix.py
@@ -856,14 +856,14 @@ def _matrix_entry(entry: dict | str) -> dict:
             "tp",
             "conc",
             "gain",
-			"task_id",
-			"created_at",
-			"nodes",
-			"rayjob_image",
-			"is_top",
-			"params_b",
-			"downloads",
-		):
+            "task_id",
+            "created_at",
+            "nodes",
+            "rayjob_image",
+            "is_top",
+            "params_b",
+            "downloads",
+        ):
             if entry.get(key) is not None:
                 out[key] = entry[key]
         batch_size_raw = (os.environ.get("INPUT_BATCH_SIZE") or "").strip()

--- a/ci/test_ci_generate_hf_matrix.py
+++ b/ci/test_ci_generate_hf_matrix.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import io
 import json
 import sys
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from pathlib import Path
 
 import pytest

--- a/ci/test_model_compat.py
+++ b/ci/test_model_compat.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import io
 import json
-import os
 import sys
 import urllib.error
 from pathlib import Path

--- a/inference_optimizer/orchestrator/specialist_runner.py
+++ b/inference_optimizer/orchestrator/specialist_runner.py
@@ -12,7 +12,6 @@ outcome for the audit trail.
 
 from __future__ import annotations
 
-import asyncio
 import enum
 import json
 import logging

--- a/inference_optimizer/tests/test_cli_bootstrap_coverage_unit.py
+++ b/inference_optimizer/tests/test_cli_bootstrap_coverage_unit.py
@@ -340,7 +340,7 @@ def test_kernel_opt_summary_line_prints_totals(tmp_path: Path, monkeypatch, caps
     assert "kernel_optimization_summary.json" in out
 
 
-def test_resolve_reference_recipe_branches(tmp_path: Path, monkeypatch) -> None:
+def test_resolve_reference_recipe_branches_and_final_summary(tmp_path: Path, monkeypatch, capsys) -> None:
     from inference_optimizer import reference_script
 
     assert cb._resolve_reference_recipe(_args(reference_script="")) == ("", {}, "", "")

--- a/inference_optimizer/tests/test_coordinator_runtime.py
+++ b/inference_optimizer/tests/test_coordinator_runtime.py
@@ -10,7 +10,6 @@ from typing import Any
 
 import pytest
 
-from inference_optimizer.orchestrator import coordinator
 from inference_optimizer.orchestrator.action_executors import (
     _multi_node_server_lifecycle,
     report_executor,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -292,7 +292,7 @@ relax_fail_under_repo_var = "COVERAGE_RELAX_FAIL_UNDER"
 # follow-up ratchet, not here.
 [tool.bandit]
 skips = ["B101"]
-exclude_dirs = ["*/tests", "*/test", "slides", "build", ".venv"]
+exclude_dirs = ["*/tests/*", "*/test/*", "slides", "build", ".venv"]
 
 # Pylint: minimal defaults for local runs; CI passes ``--errors-only`` so only
 # fatal/error-severity messages are reported there (see ``lint.yml``).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -283,6 +283,17 @@ pytest_ci_args = [
 # enforcement (``--cov-fail-under=0`` + no ``coverage report --fail-under`` gate).
 relax_fail_under_repo_var = "COVERAGE_RELAX_FAIL_UNDER"
 
+# Bandit security linter. ``B101`` (assert_used) is skipped repo-wide: the vast
+# majority of hits are test assertions and intentional runtime invariants, not
+# security defects. Test trees are excluded so bandit reports only first-party
+# source findings. Genuine findings (weak hash B324, string-built SQL B608,
+# hardcoded-credential B105/B106) are reviewed and annotated with ``# nosec``
+# plus a reason where legitimate. CI gating on medium+ severity is added in a
+# follow-up ratchet, not here.
+[tool.bandit]
+skips = ["B101"]
+exclude_dirs = ["*/tests", "*/test", "slides", "build", ".venv"]
+
 # Pylint: minimal defaults for local runs; CI passes ``--errors-only`` so only
 # fatal/error-severity messages are reported there (see ``lint.yml``).
 [tool.pylint.main]
@@ -333,8 +344,6 @@ ignore = ["E501", "E741"]
 # Tests routinely re-import inside function bodies (E402), redefine fixtures
 # (F811), and bind setup values they assert on indirectly (F841).
 "**/tests/**/*.py" = ["F811", "E402", "F841"]
-# CLI dispatchers use string forward-refs to keep startup cheap
-"inference_optimizer/cli.py" = ["F821"]  # remove after fixing the 5 real ones first
 # Modules that intentionally place imports after a module docstring + early
 # constants / conditional setup (lazy or ordering-sensitive imports).
 "inference_optimizer/orchestrator/coordinator.py" = ["E402"]


### PR DESCRIPTION
…real workflow bugs

Static-analysis hardening from the OSS-readiness audit triage:

- Add .pre-commit-config.yaml (ruff check, bandit, shellcheck, yamllint, actionlint); ruff-format hook deferred until the repo-wide reflow lands.
- Add [tool.bandit] (skip B101, exclude test trees) so bandit reports first-party source findings instead of ~17k test asserts.
- Add .github/actionlint.yaml declaring the self-hosted runner labels (hyperloom-4hhzn / hyperloom-mh826) to remove unknown-label noise.
- Clear ruff backlog 15 -> 1: drop 5 unused imports, fix tab indentation in ci/generate_hf_matrix.py, and remove the stale cli.py F821 per-file ignore (the referenced issues were already fixed).
- Fix a shadowed test: test_resolve_reference_recipe_branches was defined twice so the first copy (with its _print_final_summary coverage) never ran and hid a missing capsys fixture; rename + add capsys.

Fix three real optimize-submit.yml workflow bugs surfaced by actionlint:

- summarize referenced needs.prepare without listing prepare in needs, so the count==0 skip guard was always true; add prepare to needs.
- Remove dead github.event.inputs.hf_top references (not a declared input; 25-input dispatch cap is maxed) and drop its stale docs.
- framework was a choice with an empty option; make it a free-form string (empty still means auto-detect) to satisfy the workflow syntax check.

- Description: what and why
- Linked issue(s): close/fix refs
- Tests: added/updated? commands run?
- Breaking changes: yes/no (details if yes)
