### PR TITLE
Use hot throughput for baseline metrics

### DIFF
--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -87,6 +87,21 @@ read them when invoked standalone.
 | `HIP_VISIBLE_DEVICES` | inherited | Standard HIP visible-device mask.                                   |
 | `RUN_EVAL`        | `true`      | Runs the accuracy eval step inside the workload runner by default. Set to `false`/`0`/`no`/`off` to disable; disabling emits a warning. |
 
+### Warm-throughput measurement controls
+
+These controls keep the baseline, explore/grid candidates, validation, and
+integrate-patch measurements on the same hot measure-round basis when
+single-node server lifecycle reuse is available. Leave them enabled together for
+normal leaderboard/gain runs. If you opt out of any one of them for debugging,
+treat the session as a measurement-mode experiment and re-run `baseline` before
+comparing gains with normal sessions.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `INFERENCE_OPTIMIZER_BASELINE_DOUBLE_RUN` | `1` | Baseline runs a discarded cold warmup round, then records the hot second-round throughput as `baseline_tput`; the discarded first round is retained as `baseline_cold_tput` for audit. Set to `0`/`false`/`no`/`off` for the legacy single-round baseline. |
+| `INFERENCE_OPTIMIZER_RUN_GRID_WARMUP` | `1` outside pytest | `run_grid` performs the same discarded-warmup + hot-measure flow when no explicit `server_lifecycle` was supplied and the Magpie YAML is lifecycle-eligible. This covers shared grid users such as validation, sweep, and integrate-patch. Set to `0`/`false`/`no`/`off` only when deliberately measuring cold single rounds. |
+| `INFERENCE_OPTIMIZER_EXPLORE_WARM_DECISION` | `1` | Explore uses a discarded warmup before the decision round when lifecycle reuse is eligible, so candidate KEEP/REVERT math is compared against the hot `baseline_tput` contract. Set to `0`/`false`/`no`/`off` to force the legacy cold decision path. |
+
 ---
 
 ## 5. Kernel-opt backend selection

--- a/inference_optimizer/orchestrator/action_executors/_grid_runner.py
+++ b/inference_optimizer/orchestrator/action_executors/_grid_runner.py
@@ -2023,6 +2023,14 @@ def _parse_report(workspace: Path) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
+def _run_grid_warmup_enabled() -> bool:
+    """Whether ``run_grid`` should discard a cold warmup round when possible."""
+    raw = os.environ.get("INFERENCE_OPTIMIZER_RUN_GRID_WARMUP")
+    if raw is None and os.environ.get("PYTEST_CURRENT_TEST"):
+        return False
+    return (raw if raw is not None else "1").strip().lower() not in {"0", "false", "no", "off", ""}
+
+
 def _kill_stale_servers() -> None:
     """Deep-clean any lingering inference server processes + shared memory.
 
@@ -2156,6 +2164,7 @@ def _run_magpie(
     cwd: str,
     result_dir: str | None = None,
     soft_deadline_sec: float | None = None,
+    preclean: bool = True,
 ) -> tuple[int, str, str]:
     """Blocking subprocess wrapper. Returns (rc, stdout, stderr).
 
@@ -2180,7 +2189,9 @@ def _run_magpie(
         tuple[int, str, str]: ``(returncode, stdout, stderr)``.
     """
     # Pre-clean lingering servers + shared memory (skip under pytest).
-    if not os.environ.get("PYTEST_CURRENT_TEST"):
+    # Disable this for lifecycle re-attach rounds; otherwise the warm server
+    # created by the discarded round is killed immediately before measurement.
+    if preclean and not os.environ.get("PYTEST_CURRENT_TEST"):
         _kill_stale_servers()
 
     env = os.environ.copy()
@@ -2254,6 +2265,8 @@ async def run_grid(
     result_dir: str | None = None,
     soft_deadline_sec: float | None = None,
     server_lifecycle: dict[str, Any] | None = None,
+    warmup_before_measure: bool | None = None,
+    preclean_before_run: bool = True,
 ) -> list[VariantResult]:
     """Execute every variant in ``grid`` once, in order.
 
@@ -2269,6 +2282,11 @@ async def run_grid(
     ``server_lifecycle`` (``{cleanup, pid_dir, port}``) enables Magpie's
     persistent-server reuse so a paired warm round can re-attach to a hot
     server; None keeps the legacy boot-per-variant behaviour.
+    ``warmup_before_measure`` defaults on via
+    ``INFERENCE_OPTIMIZER_RUN_GRID_WARMUP``: when no explicit
+    ``server_lifecycle`` is supplied and the YAML supports lifecycle reuse,
+    each variant gets a discarded warmup round followed by the returned hot
+    measurement round.
 
     Args:
         base_yaml_path (Path): Base Magpie YAML templated per variant.
@@ -2287,12 +2305,20 @@ async def run_grid(
             None/0 disables.
         server_lifecycle (dict[str, Any] | None): ``{cleanup, pid_dir, port}``
             enabling persistent-server reuse.
+        warmup_before_measure (bool | None): Whether to auto-run a discarded
+            warmup before returning a measured result. ``None`` resolves from
+            ``INFERENCE_OPTIMIZER_RUN_GRID_WARMUP``.
+        preclean_before_run (bool): Whether to pre-clean stale servers before
+            the measured Magpie launch. Reattach rounds must pass ``False``.
 
     Returns:
         list[VariantResult]: Per-variant results for every attempt, in order.
     """
     if not magpie_python:
         magpie_python = _resolve_magpie_python()
+    if warmup_before_measure is None:
+        warmup_before_measure = _run_grid_warmup_enabled()
+    auto_warmup_requested = bool(warmup_before_measure and server_lifecycle is None)
     results: list[VariantResult] = []
 
     # Variant-boundary robustness pulse: a bounded deterministic tick after
@@ -2351,6 +2377,8 @@ async def run_grid(
             if not keep_going_on_failure:
                 break
             continue
+        lifecycle: dict[str, Any] = {"eligible": False}
+        auto_warmup = False
         try:
             cfg_path = _build_variant_yaml(
                 base_yaml_path,
@@ -2392,6 +2420,219 @@ async def run_grid(
             if not keep_going_on_failure:
                 break
             continue
+
+        if auto_warmup_requested:
+            try:
+                from ._server_lifecycle import resolve_lifecycle_params
+
+                lifecycle = resolve_lifecycle_params(cfg_path)
+                auto_warmup = bool(lifecycle.get("eligible"))
+                if auto_warmup:
+                    cfg_path = _build_variant_yaml(
+                        base_yaml_path,
+                        base_extra_args,
+                        variant,
+                        output_subdir=slot,
+                        model_path=model_path,
+                        gpu_type=gpu_type,
+                        benchmark_script=benchmark_script,
+                        server_lifecycle={
+                            "cleanup": True,
+                            "pid_dir": str(slot),
+                            "port": int(lifecycle.get("port") or 0),
+                        },
+                    )
+                else:
+                    log.info(
+                        "grid_runner: warmup-before-measure not eligible (%s); running single measured round.",
+                        lifecycle.get("reason") or "unknown",
+                    )
+            except Exception as exc:  # noqa: BLE001
+                log.warning(
+                    "grid_runner: warmup-before-measure eligibility/materialization failed (%r); running single measured round.",
+                    exc,
+                )
+                auto_warmup = False
+
+        warmup_tput: float | None = None
+        if auto_warmup:
+            warmup_slot = slot / "warmup_round"
+            warmup_lifecycle = {
+                "cleanup": False,
+                "pid_dir": str(slot),
+                "port": int(lifecycle.get("port") or 0),
+            }
+            try:
+                warmup_cfg_path = _build_variant_yaml(
+                    base_yaml_path,
+                    base_extra_args,
+                    variant,
+                    output_subdir=warmup_slot,
+                    model_path=model_path,
+                    gpu_type=gpu_type,
+                    benchmark_script=benchmark_script,
+                    server_lifecycle=warmup_lifecycle,
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.warning(
+                    "grid_runner: variant %d/%d name=%s aborted: warmup_yaml_build_error: %r",
+                    i + 1,
+                    len(grid),
+                    variant.name,
+                    exc,
+                )
+                _write_variant_abort_marker(
+                    slot,
+                    variant_name=variant.name,
+                    error_class="warmup_yaml_build_error",
+                    error_summary=repr(exc),
+                    extra_args=variant.extra_server_args,
+                )
+                results.append(
+                    VariantResult(
+                        name=variant.name,
+                        extra_server_args=variant.extra_server_args,
+                        extra_envs=dict(variant.extra_envs),
+                        status="failed",
+                        error=f"warmup_yaml_build_error: {exc!r}",
+                        error_class="warmup_yaml_build_error",
+                        note=variant.note,
+                    )
+                )
+                await _pulse_after_variant(i)
+                if not keep_going_on_failure:
+                    break
+                continue
+
+            warmup_started_unix = time.time()
+            try:
+                warmup_rc, warmup_stdout, warmup_stderr = await asyncio.to_thread(
+                    _run_magpie,
+                    magpie_python=magpie_python,
+                    config_path=warmup_cfg_path,
+                    output_dir=warmup_slot,
+                    timeout_sec=variant_timeout_sec,
+                    cwd=cwd,
+                    result_dir=result_dir,
+                    soft_deadline_sec=None,
+                    preclean=True,
+                )
+            except subprocess.TimeoutExpired as exc:
+                from ._server_lifecycle import teardown_lifecycle_server
+
+                teardown_lifecycle_server(
+                    pid_dir=slot,
+                    framework=str(lifecycle.get("framework") or ""),
+                    port=int(lifecycle.get("port") or 0),
+                )
+                log.warning(
+                    "grid_runner: variant %d/%d name=%s aborted: warmup timeout (timeout_sec=%d): %s",
+                    i + 1,
+                    len(grid),
+                    variant.name,
+                    variant_timeout_sec,
+                    exc,
+                )
+                _write_variant_abort_marker(
+                    slot,
+                    variant_name=variant.name,
+                    error_class="warmup_magpie_timeout",
+                    error_summary=str(exc),
+                    extra_args=variant.extra_server_args,
+                )
+                results.append(
+                    VariantResult(
+                        name=variant.name,
+                        extra_server_args=variant.extra_server_args,
+                        extra_envs=dict(variant.extra_envs),
+                        status="failed",
+                        error=f"warmup_timeout: {exc}",
+                        error_class="warmup_magpie_timeout",
+                        note=variant.note,
+                        runtime_sec=round(max(0.0, time.time() - warmup_started_unix), 2),
+                        nonfatal_warnings=["run_grid_warmup_round_failed"],
+                    )
+                )
+                await _pulse_after_variant(i)
+                if not keep_going_on_failure:
+                    break
+                continue
+
+            warmup_candidates = sorted(warmup_slot.glob("benchmark_*"))
+            warmup_workspace = warmup_candidates[-1] if warmup_candidates else warmup_slot
+            warmup_harvested = harvest_leaked_artifacts(
+                warmup_workspace,
+                subprocess_started_unix=warmup_started_unix,
+            )
+            warmup_report = _parse_report(warmup_workspace) if warmup_candidates else None
+            warmup_measurement = extract_benchmark_measurement(
+                warmup_report,
+                workspace=warmup_workspace,
+                subprocess_started_unix=warmup_started_unix,
+            )
+            if warmup_rc != 0 or not warmup_measurement.get("valid_measurement"):
+                from ._server_lifecycle import teardown_lifecycle_server
+
+                teardown_lifecycle_server(
+                    pid_dir=slot,
+                    framework=str(lifecycle.get("framework") or ""),
+                    port=int(lifecycle.get("port") or 0),
+                )
+                warmup_error = (
+                    (warmup_stderr or warmup_stdout)[-2000:]
+                    if warmup_rc != 0
+                    else "warmup benchmark_report missing valid throughput/completed requests"
+                )
+                log.warning(
+                    "grid_runner: variant %d/%d name=%s aborted: warmup_round_failed (rc=%s): %s",
+                    i + 1,
+                    len(grid),
+                    variant.name,
+                    warmup_rc,
+                    warmup_error[:200],
+                )
+                _write_variant_abort_marker(
+                    slot,
+                    variant_name=variant.name,
+                    error_class="warmup_round_failed",
+                    error_summary=warmup_error,
+                    extra_args=variant.extra_server_args,
+                )
+                results.append(
+                    VariantResult(
+                        name=variant.name,
+                        extra_server_args=variant.extra_server_args,
+                        extra_envs=dict(variant.extra_envs),
+                        status="failed",
+                        workspace=str(warmup_workspace) if warmup_candidates else None,
+                        report_path=(
+                            str(warmup_workspace / "benchmark_report.json")
+                            if (warmup_workspace / "benchmark_report.json").exists()
+                            else None
+                        ),
+                        raw_result_path=warmup_measurement.get("raw_result_path"),
+                        reported_success=warmup_measurement.get("reported_success"),
+                        returncode=warmup_rc,
+                        error=warmup_error,
+                        error_class="warmup_round_failed",
+                        note=variant.note,
+                        runtime_sec=round(max(0.0, time.time() - warmup_started_unix), 2),
+                        nonfatal_warnings=[
+                            "run_grid_warmup_round_failed",
+                            *[f"harvested_leaked_artifact:{src}" for src, _ in warmup_harvested],
+                        ],
+                    )
+                )
+                await _pulse_after_variant(i)
+                if not keep_going_on_failure:
+                    break
+                continue
+            warmup_tput = warmup_measurement.get("output_throughput")
+            log.info(
+                "grid_runner: variant %s warmup tput=%.1f tok/s discarded; measuring hot round next",
+                variant.name,
+                warmup_tput or 0.0,
+            )
 
         from ._multi_node_env import log_mn_banner
 
@@ -2478,6 +2719,7 @@ async def run_grid(
                 cwd=cwd,
                 result_dir=result_dir,
                 soft_deadline_sec=soft_deadline_sec,
+                preclean=(False if auto_warmup else preclean_before_run),
             )
         except subprocess.TimeoutExpired as exc:
             # Harvest pre-timeout leaks so the variant slot captures whatever
@@ -2523,6 +2765,15 @@ async def run_grid(
             if not keep_going_on_failure:
                 break
             continue
+        finally:
+            if auto_warmup:
+                from ._server_lifecycle import teardown_lifecycle_server
+
+                teardown_lifecycle_server(
+                    pid_dir=slot,
+                    framework=str(lifecycle.get("framework") or ""),
+                    port=int(lifecycle.get("port") or 0),
+                )
 
         # Server-liveness watchdog fired: the variant's server engine/worker
         # bootstrap died but the parent process hung. Record a fast failure
@@ -2754,6 +3005,9 @@ async def run_grid(
             warnings.append("magpie_nonzero_after_valid_measurement")
         for leak_src, _ in harvested:
             warnings.append(f"harvested_leaked_artifact:{leak_src}")
+        if warmup_tput is not None:
+            warnings.append("run_grid_warmup_discarded_first")
+            warnings.append(f"warmup_round_tput:{float(warmup_tput):.1f}")
 
         if not measurement.get("valid_measurement"):
             if rc != 0:

--- a/inference_optimizer/orchestrator/action_executors/_stack_rebench.py
+++ b/inference_optimizer/orchestrator/action_executors/_stack_rebench.py
@@ -46,6 +46,7 @@ async def measure_stack_rebench(
     result_dir: str | None = None,
     magpie_python: str | None = None,
     server_lifecycle: dict[str, Any] | None = None,
+    preclean_before_run: bool = True,
 ) -> StackRebenchResult:
     """Run ``variant`` once on the stack and grade it against the floor."""
     output_slot.mkdir(parents=True, exist_ok=True)
@@ -61,6 +62,7 @@ async def measure_stack_rebench(
         result_dir=result_dir,
         magpie_python=magpie_python,
         server_lifecycle=server_lifecycle,
+        preclean_before_run=preclean_before_run,
     )
     rb = results[0] if results else None
     tput: float | None = None

--- a/inference_optimizer/orchestrator/action_executors/explore.py
+++ b/inference_optimizer/orchestrator/action_executors/explore.py
@@ -1086,6 +1086,7 @@ class ExploreExecutor:
                         result_dir=override_result_dir,
                         soft_deadline_sec=decision_deadline_sec,
                         server_lifecycle=round1_lifecycle,
+                        preclean_before_run=not use_warm_decision,
                     )
                     if not results:
                         # Defensive — run_grid returns one result per grid entry.
@@ -1333,6 +1334,7 @@ class ExploreExecutor:
                                 benchmark_script=override_script,
                                 result_dir=override_result_dir,
                                 server_lifecycle=round2_lifecycle,
+                                preclean_before_run=not lifecycle_eligible,
                             )
                             stack_rebench_tput = rebench.tput
                             stack_rebench_workspace = rebench.workspace

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -6780,19 +6780,16 @@ class Coordinator:
             tput = float(tput_raw) if tput_raw is not None else 0.0
         except (TypeError, ValueError):
             tput = 0.0
-        # ``tput`` (output_throughput) is the HOT measure round; kept only for
-        # reporting (``hot_tput``). The fair comparison value — used for gain,
-        # the stack entry, and current_best.tput (the explore/sweep anchor) —
-        # MUST be the single-fresh-server (warmup) round so it matches the
-        # measurement basis of explore/sweep variants. Fall back to ``tput``
-        # for a single-run replay that has no separate warmup round.
-        single_raw = result.get("warmup_round_tput")
+        # ``tput`` (output_throughput) is the HOT measure round and is the
+        # comparison value for gain/current_best. The discarded warmup round is
+        # retained only for audit so warm-replay does not reintroduce
+        # cold-before/hot-after drift.
+        cold_raw = result.get("warmup_round_tput")
         try:
-            single_round_tput = float(single_raw) if single_raw is not None else 0.0
+            cold_round_tput = float(cold_raw) if cold_raw is not None else 0.0
         except (TypeError, ValueError):
-            single_round_tput = 0.0
-        if single_round_tput <= 0:
-            single_round_tput = tput
+            cold_round_tput = 0.0
+        single_round_tput = tput
         hot_tput = tput
         # Use the baseline_tput captured at enqueue time so a mid-replay baseline rerun can't shift the anchor; fall back to live state.baseline_tput.
         anchor_raw = None
@@ -6872,6 +6869,7 @@ class Coordinator:
                 "extra_envs": warm_envs,
                 "tput": float(single_round_tput),
                 "hot_tput": float(hot_tput),
+                "cold_tput": float(cold_round_tput) if cold_round_tput > 0 else None,
                 "gain_pct": round(measured_gain, 3),
                 "workspace": str(result.get("workspace") or ""),
                 "ts": datetime.now(timezone.utc).isoformat(),
@@ -6907,10 +6905,9 @@ class Coordinator:
             state.current_best = {
                 "action": "warm_replay",
                 "name": "warm_replay",
-                # Single-round anchor (NOT hot) so explore/sweep variants are
-                # judged on a comparable basis; hot kept under hot_tput.
                 "tput": single_round_tput,
                 "hot_tput": hot_tput,
+                "cold_tput": cold_round_tput if cold_round_tput > 0 else None,
                 # Canonical key — matches the current_best shape _lift_to_current_best writes for KEEPs.
                 "extra_server_args": warm_args,
                 "extra_envs": warm_envs,
@@ -13865,34 +13862,22 @@ class Coordinator:
         if task_kind == "baseline":
             tput = result.get("output_throughput")
             if isinstance(tput, (int, float)) and tput > 0:
-                # Fair-comparison anchor for measurement parity.
-                # The baseline cold-start guard runs a warmup round on a
-                # fresh server (discarded for *reporting*) then a measure
-                # round that REUSES the now-hot server — the measure
-                # number (``output_throughput``) is systematically ~10-15%
-                # higher than a single fresh-server round, because an
-                # 8-request client warmup does not fully warm vLLM/SGLang
-                # (graph capture, scheduler, allocator) the way a full
-                # prior benchmark does. Every ``explore`` / ``sweep``
-                # variant, by contrast, RESTARTS the server and runs a
-                # single round, so judging them against the hot measure
-                # number penalizes each variant by that same ~10-15% and
-                # genuinely-good params can never clear the KEEP threshold.
-                # Use the warmup round's single-fresh-server tput as the
-                # comparison ANCHOR (apples-to-apples with variants) when
-                # the double-run captured it; keep the hot number for
-                # ``current_best`` / reporting below.
+                # Baseline's conclusion contract is the hot measure round:
+                # BaselineExecutor already discards the cold first round and
+                # returns the second round as ``output_throughput``. Keep the
+                # discarded value only as an audit field so leaderboard/report
+                # gain math never mixes cold-before with hot-after.
                 warmup_anchor = result.get("warmup_round_tput")
                 if isinstance(warmup_anchor, (int, float)) and warmup_anchor > 0:
-                    self.shared_state.baseline_tput = float(warmup_anchor)
+                    self.shared_state.baseline_tput = float(tput)
+                    self.shared_state.baseline_cold_tput = float(warmup_anchor)
                     self.shared_state.baseline_hot_tput = float(tput)
                     log.info(
-                        "baseline anchor: using single-round warmup tput "
-                        "%.1f as comparison anchor (hot measure %.1f kept "
-                        "for reporting) — measurement parity with explore/"
-                        "sweep variants",
-                        float(warmup_anchor),
+                        "baseline anchor: using hot measure tput %.1f as "
+                        "baseline_tput (discarded cold warmup %.1f kept as "
+                        "baseline_cold_tput)",
                         float(tput),
+                        float(warmup_anchor),
                     )
                 else:
                     self.shared_state.baseline_tput = float(tput)
@@ -13932,21 +13917,20 @@ class Coordinator:
             if isinstance(warm_runtime_raw, (int, float)) and warm_runtime_raw > 0:
                 self.shared_state.baseline_warm_runtime_sec = float(warm_runtime_raw)
                 changed = True
-            # current_best.tput is the comparison ANCHOR every explore /
-            # sweep variant is judged against (the Coordinator injects it
-            # as ``params['base_tput']`` in _handle_delegate /
-            # _materialize_approved_proposal). It MUST be the fair
-            # single-fresh-server anchor (``baseline_tput``, which the
-            # block above set to the warmup-round number under the
-            # double-run), NOT the hot measure round — otherwise every
-            # cold-restarted variant is judged against an unbeatable hot
-            # baseline and can never KEEP. Keep the hot number under a
-            # separate ``hot_tput`` field for reporting.
+            # current_best.tput follows the same hot baseline contract.
+            # run_grid/explore/integrate_patch measure optimization candidates
+            # on the same warm second-round basis when lifecycle reuse is
+            # available, so the numerator and denominator stay aligned.
             anchor_tput = float(self.shared_state.baseline_tput or 0.0)
             self.shared_state.current_best = {
                 "action": "baseline",
                 "tput": (anchor_tput if anchor_tput > 0 else (float(tput) if isinstance(tput, (int, float)) else None)),
                 "hot_tput": (float(tput) if isinstance(tput, (int, float)) else None),
+                "cold_tput": (
+                    float(warmup_anchor)
+                    if isinstance(warmup_anchor, (int, float)) and warmup_anchor > 0
+                    else None
+                ),
                 "ttft_mean_ms": result.get("ttft_mean_ms"),
                 "e2el_mean_ms": result.get("e2el_mean_ms"),
                 "tpot_mean_ms": result.get("tpot_mean_ms"),
@@ -13987,13 +13971,9 @@ class Coordinator:
                         "PRELUDE: warm-recipe history injection failed: %r",
                         exc,
                     )
-                # Step 2 — warm-recipe replay. Anchor the replay gain on the
-                # SINGLE-fresh-server-round baseline (``state.baseline_tput``,
-                # the same anchor explore/sweep variants are judged against),
-                # NOT the hot measure ``tput`` — otherwise warm-replay's gain
-                # and current_best land on the hot basis and every
-                # single-round explore variant is judged against an unbeatable
-                # hot bar (mirrors the baseline-promote invariant).
+                # Step 2 — warm-recipe replay. Anchor replay gain on the hot
+                # baseline_tput contract; candidate replays also return their
+                # hot measure round.
                 try:
                     await self._maybe_enqueue_warm_replay(
                         baseline_tput=float(self.shared_state.baseline_tput or tput),

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -13862,13 +13862,13 @@ class Coordinator:
         audit_extras: dict[str, Any] = {}
         if task_kind == "baseline":
             tput = result.get("output_throughput")
+            warmup_anchor = result.get("warmup_round_tput")
             if isinstance(tput, (int, float)) and tput > 0:
                 # Baseline's conclusion contract is the hot measure round:
                 # BaselineExecutor already discards the cold first round and
                 # returns the second round as ``output_throughput``. Keep the
                 # discarded value only as an audit field so leaderboard/report
                 # gain math never mixes cold-before with hot-after.
-                warmup_anchor = result.get("warmup_round_tput")
                 if isinstance(warmup_anchor, (int, float)) and warmup_anchor > 0:
                     self.shared_state.baseline_tput = float(tput)
                     self.shared_state.baseline_cold_tput = float(warmup_anchor)

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -6896,7 +6896,8 @@ class Coordinator:
             gp = list(getattr(state, "gain_per_stack_entry", []) or [])
             gp.append(round(measured_gain, 3))
             state.gain_per_stack_entry = gp
-            # Cumulative gain from absolute tput/baseline (stack is superposition, not additive deltas). Single-round basis (matches explore/sweep + baseline anchor).
+            # Cumulative gain is absolute tput vs baseline, not additive stack
+            # deltas. Both sides use the hot measure-round contract.
             total_gain = (single_round_tput / baseline_tput - 1.0) * 100.0
             state.cumulative_gain = round(total_gain, 3)
             state.cumulative_gain_validated = round(total_gain, 3)

--- a/inference_optimizer/orchestrator/shared_state.py
+++ b/inference_optimizer/orchestrator/shared_state.py
@@ -442,12 +442,13 @@ class SharedState:
     conc_sweep_variant_timeout_sec: int = 1800
     target_summary: str = ""
     baseline_tput: float = 0.0
-    # Hot-server measure-round tput from the baseline cold-start double-run
-    # (kept for reporting only). ``baseline_tput`` is the single-fresh-server
-    # warmup-round number used as the fair comparison ANCHOR for explore /
-    # sweep variants (which each restart the server + run one round). When
-    # the double-run is disabled / ineligible, this stays 0.0 and
-    # ``baseline_tput`` carries the only measured number.
+    # Discarded first-round tput from the baseline cold-start double-run.
+    # Kept only for audit/debugging; conclusion fields and gain math use the
+    # hot measure-round value in ``baseline_tput``.
+    baseline_cold_tput: float = 0.0
+    # Deprecated mirror of the hot measure-round tput. Kept for readers that
+    # already inspect this field; it should match ``baseline_tput`` whenever
+    # the double-run path is eligible.
     baseline_hot_tput: float = 0.0
     baseline_accuracy: float = 0.0
     # Standalone baseline-arm roofline ceiling computed right after baseline
@@ -940,6 +941,8 @@ class SharedState:
             )
             fact_layer_keys = (
                 "baseline_tput",
+                "baseline_cold_tput",
+                "baseline_hot_tput",
                 "baseline_accuracy",
                 "current_best",
                 "cumulative_gain",

--- a/inference_optimizer/tests/golden/coordinator_behavior_golden.json
+++ b/inference_optimizer/tests/golden/coordinator_behavior_golden.json
@@ -118,6 +118,7 @@
         "workspace": null
       }
     ],
+    "baseline_cold_tput": 0.0,
     "baseline_config_path": "<volatile>",
     "baseline_eager_fallback": false,
     "baseline_failure_streak": 2,

--- a/inference_optimizer/tests/test_baseline_warmup_double_run.py
+++ b/inference_optimizer/tests/test_baseline_warmup_double_run.py
@@ -233,6 +233,41 @@ def test_run_grid_discards_cold_first_round_via_lifecycle(tmp_path, monkeypatch)
     assert warmup_lc["pid_dir"] == measure_lc["pid_dir"] == str(output_dir / "variant_00_candidate")
 
 
+def test_run_grid_single_round_when_warmup_disabled(tmp_path, monkeypatch):
+    """``INFERENCE_OPTIMIZER_RUN_GRID_WARMUP=0`` keeps the legacy single-round grid path."""
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_RUN_GRID_WARMUP", "0")
+    base = tmp_path / "base.yaml"
+    _write_yaml(base, framework="vllm")
+    output_dir = tmp_path / "grid"
+
+    captured: list = []
+    fake_run, state = _cold_then_hot_fake_run(captured)
+
+    with patch(
+        "inference_optimizer.orchestrator.action_executors._grid_runner.run_with_session_kill",
+        side_effect=fake_run,
+    ):
+        results = _run(
+            run_grid(
+                base_yaml_path=base,
+                base_extra_args="",
+                grid=[GridVariant(name="candidate")],
+                output_root=output_dir,
+                magpie_python="/opt/venv/bin/python",
+                variant_timeout_sec=10,
+                gpu_type="mi300x",
+            )
+        )
+
+    assert state["calls"] == 1
+    assert len(results) == 1
+    result = results[0]
+    assert result.status == "succeeded"
+    assert result.output_throughput == pytest.approx(_COLD_TPUT)
+    assert "run_grid_warmup_discarded_first" not in result.nonfatal_warnings
+    assert "server_lifecycle" not in captured[0]["benchmark"]
+
+
 def test_baseline_single_round_when_script_not_builtin(tmp_path):
     """A non-builtin benchmark script falls back to one round even with double-run on."""
     base = tmp_path / "base.yaml"

--- a/inference_optimizer/tests/test_baseline_warmup_double_run.py
+++ b/inference_optimizer/tests/test_baseline_warmup_double_run.py
@@ -19,6 +19,10 @@ import yaml
 from inference_optimizer.orchestrator.action_executors.baseline import (
     BaselineExecutor,
 )
+from inference_optimizer.orchestrator.action_executors._grid_runner import (
+    GridVariant,
+    run_grid,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -186,6 +190,47 @@ def test_baseline_single_round_when_double_run_disabled(tmp_path, monkeypatch):
     assert result["output_throughput"] == pytest.approx(_COLD_TPUT)
     assert "warmup_round_tput" not in result
     assert "server_lifecycle" not in captured[0]["benchmark"]
+
+
+def test_run_grid_discards_cold_first_round_via_lifecycle(tmp_path, monkeypatch):
+    """The shared grid runner reports the HOT measured round when lifecycle reuse is eligible."""
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_RUN_GRID_WARMUP", "1")
+    base = tmp_path / "base.yaml"
+    _write_yaml(base, framework="vllm")
+    output_dir = tmp_path / "grid"
+
+    captured: list = []
+    fake_run, state = _cold_then_hot_fake_run(captured)
+
+    with patch(
+        "inference_optimizer.orchestrator.action_executors._grid_runner.run_with_session_kill",
+        side_effect=fake_run,
+    ):
+        results = _run(
+            run_grid(
+                base_yaml_path=base,
+                base_extra_args="",
+                grid=[GridVariant(name="candidate")],
+                output_root=output_dir,
+                magpie_python="/opt/venv/bin/python",
+                variant_timeout_sec=10,
+                gpu_type="mi300x",
+            )
+        )
+
+    assert state["calls"] == 2
+    assert len(results) == 1
+    result = results[0]
+    assert result.status == "succeeded"
+    assert result.output_throughput == pytest.approx(_HOT_TPUT)
+    assert "run_grid_warmup_discarded_first" in result.nonfatal_warnings
+
+    assert len(captured) == 2
+    warmup_lc = captured[0]["benchmark"]["server_lifecycle"]
+    measure_lc = captured[1]["benchmark"]["server_lifecycle"]
+    assert warmup_lc["cleanup"] is False
+    assert measure_lc["cleanup"] is True
+    assert warmup_lc["pid_dir"] == measure_lc["pid_dir"] == str(output_dir / "variant_00_candidate")
 
 
 def test_baseline_single_round_when_script_not_builtin(tmp_path):

--- a/inference_optimizer/tests/test_coordinator_async_methods_coverage_unit.py
+++ b/inference_optimizer/tests/test_coordinator_async_methods_coverage_unit.py
@@ -72,12 +72,15 @@ async def test_promote_baseline_sets_anchor_and_current_best(coord: Coordinator)
             "workspace": "/tmp/ws",
         },
     )
-    # warmup anchor wins as the comparison baseline; hot number kept separately
-    assert coord.shared_state.baseline_tput == 900.0
+    # Hot measure round is the conclusion baseline; cold warmup is audit-only.
+    assert coord.shared_state.baseline_tput == 1000.0
+    assert coord.shared_state.baseline_cold_tput == 900.0
     assert coord.shared_state.baseline_hot_tput == 1000.0
     assert coord.shared_state.baseline_failure_streak == 0
     assert coord.shared_state.baseline_arg_error_streak == 0
     assert coord.shared_state.current_best["action"] == "baseline"
+    assert coord.shared_state.current_best["tput"] == 1000.0
+    assert coord.shared_state.current_best["cold_tput"] == 900.0
 
 
 @pytest.mark.asyncio

--- a/inference_optimizer/tests/test_shared_state_persistence.py
+++ b/inference_optimizer/tests/test_shared_state_persistence.py
@@ -59,6 +59,8 @@ def test_save_load_round_trip(tmp_path):
         session_id="abc",
         model_name="meta-llama/Llama-3.1-8B-Instruct",
         baseline_tput=1840.0,
+        baseline_cold_tput=1600.0,
+        baseline_hot_tput=1840.0,
         cumulative_gain=12.5,
         pruned_families=["deep_kernel"],
         current_best={"action": "backends", "tput": 2010.0},
@@ -68,6 +70,8 @@ def test_save_load_round_trip(tmp_path):
     assert s2.session_id == "abc"
     assert s2.model_name == "meta-llama/Llama-3.1-8B-Instruct"
     assert s2.baseline_tput == 1840.0
+    assert s2.baseline_cold_tput == 1600.0
+    assert s2.baseline_hot_tput == 1840.0
     assert s2.cumulative_gain == 12.5
     assert s2.pruned_families == ["deep_kernel"]
     assert s2.current_best == {"action": "backends", "tput": 2010.0}

--- a/inference_optimizer/tests/test_warm_replay.py
+++ b/inference_optimizer/tests/test_warm_replay.py
@@ -489,11 +489,10 @@ def test_promote_warm_replay_passes_quality_gate_is_promoted(tmp_path):
     assert coord.shared_state.current_best["action"] == "warm_replay"
 
 
-def test_promote_warm_replay_double_run_uses_single_round_anchor(tmp_path):
-    """Double-run replay: current_best.tput / stack.tput / gain MUST use the
-    single-round (warmup) value, NOT the hot measure — so explore/sweep
-    variants (measured single-round) are judged against a comparable bar.
-    The hot measure is retained only under ``hot_tput`` for reporting.
+def test_promote_warm_replay_double_run_uses_hot_measure_round(tmp_path):
+    """Double-run replay uses the hot measure round for gain/current_best.
+
+    The discarded warmup round is retained only under ``cold_tput`` for audit.
     """
     coord = _make_coord(tmp_path, warm_start_recipe=_warm_recipe_t1())
     coord.shared_state.warm_replay_outcome = {
@@ -509,8 +508,7 @@ def test_promote_warm_replay_double_run_uses_single_round_anchor(tmp_path):
             "extra_envs": {"VLLM_ROCM_USE_AITER": "1"},
         }
     )
-    # Hot measure 738 (+23%) is discarded for the anchor; the single-round
-    # warmup 690 (+15% vs baseline 600) is the fair comparison value.
+    # Hot measure 738 (+23%) is the comparison value; warmup 690 is audit-only.
     result = {
         "status": "succeeded",
         "output_throughput": 738.0,
@@ -520,15 +518,16 @@ def test_promote_warm_replay_double_run_uses_single_round_anchor(tmp_path):
 
     cb = coord.shared_state.current_best
     assert cb["action"] == "warm_replay"
-    # Critical invariant: explore/sweep anchor is single-round, not hot.
-    assert cb["tput"] == 690.0
+    assert cb["tput"] == 738.0
     assert cb["hot_tput"] == 738.0
+    assert cb["cold_tput"] == 690.0
     entry = coord.shared_state.optimization_stack[0]
-    assert entry["tput"] == 690.0
+    assert entry["tput"] == 738.0
     assert entry["hot_tput"] == 738.0
-    assert entry["gain_pct"] == 15.0
-    assert coord.shared_state.cumulative_gain == 15.0
-    assert coord.shared_state.cumulative_gain_validated == 15.0
+    assert entry["cold_tput"] == 690.0
+    assert entry["gain_pct"] == 23.0
+    assert coord.shared_state.cumulative_gain == 23.0
+    assert coord.shared_state.cumulative_gain_validated == 23.0
 
 
 def test_promote_warm_replay_adopts_on_any_positive_gain(tmp_path):


### PR DESCRIPTION
﻿## Summary
- Store the baseline conclusion metric from the hot measure round, while keeping the discarded first-round throughput as audit-only data.
- Route shared grid measurements through a warmup-then-measure flow when lifecycle reuse is available, covering validation and integrate-patch paths that call `run_grid`.
- Update warm replay and regression coverage so gain calculations use the same hot-throughput basis.

## Test plan
- `python -m py_compile inference_optimizer/orchestrator/action_executors/_grid_runner.py inference_optimizer/orchestrator/action_executors/_stack_rebench.py inference_optimizer/orchestrator/action_executors/explore.py inference_optimizer/orchestrator/coordinator.py inference_optimizer/orchestrator/shared_state.py inference_optimizer/tests/test_baseline_warmup_double_run.py inference_optimizer/tests/test_coordinator_async_methods_coverage_unit.py inference_optimizer/tests/test_warm_replay.py`
- `python -m pytest inference_optimizer/tests/test_baseline_warmup_double_run.py::test_run_grid_discards_cold_first_round_via_lifecycle`
- Remote Project1 smoke: baseline double-run returns the `measure_round` throughput and retains `warmup_round_tput` for audit.
- Remote Project1 smoke: `run_grid` returns the hot measured throughput and emits `run_grid_warmup_discarded_first`.
