### PR TITLE
fix(kernel): decouple kernel-candidate pool cap from dispatch budget

### DIFF
--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -2456,8 +2456,6 @@ async def trace_analyze_handler(
         str(trace_input),
         "--session-id",
         str(payload.get("session_id") or session_dir.name),
-        "--top-k",
-        str(payload.get("top_k", 10)),
         "--workspace-path",
         workspace_path,
         # Pass the resolved root explicitly so the tool never depends on the
@@ -2465,6 +2463,13 @@ async def trace_analyze_handler(
         "--tracelens-root",
         str(tracelens_root),
     ]
+    # Kernel-candidate POOL size (issue #667): only forward --top-k when the
+    # request explicitly overrides it. Otherwise let tracelens_analysis.py apply
+    # its own large-pool default (env: HYPERLOOM_KERNEL_CANDIDATES_TOP_K) so the
+    # candidate-build cap and the dispatch-side budget (source-fn grouping + op
+    # dedup + attempt cap) stay decoupled and share a single source of truth.
+    if payload.get("top_k") is not None:
+        cmd += ["--top-k", str(payload.get("top_k"))]
     if model_name:
         cmd += ["--model-name", str(model_name)]
     if framework:

--- a/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -1635,6 +1635,66 @@ async def test_trace_analyze_handler_records_bypass_discovery_success(
 
 
 @pytest.mark.asyncio
+async def test_trace_analyze_handler_omits_top_k_when_not_requested(
+    session_dir,
+    monkeypatch,
+):
+    """Issue #667: without an explicit ``top_k`` the handler must NOT pass
+    ``--top-k`` so tracelens_analysis.py applies its own large-pool default
+    (candidate-build cap decoupled from the dispatch-side budget)."""
+    fake_trace = session_dir / "fake_trace_dir"
+    fake_trace.mkdir()
+    captured: dict = {}
+
+    async def fake_run_subprocess(cmd, *, timeout_sec):
+        captured["cmd"] = list(cmd)
+        return 0, json.dumps({"status": "ok", "hot_kernels": []}), ""
+
+    monkeypatch.setattr(krh, "_run_subprocess", fake_run_subprocess)
+    res = await krh.trace_analyze_handler(
+        {
+            "trace_input": str(fake_trace),
+            "session_id": session_dir.name,
+            "analysis_route": "deterministic",
+        },
+        session_dir=session_dir,
+    )
+    assert res["status"] in ("ok", "succeeded", "failed")
+    assert "--top-k" not in captured["cmd"]
+
+
+@pytest.mark.asyncio
+async def test_trace_analyze_handler_forwards_explicit_top_k(
+    session_dir,
+    monkeypatch,
+):
+    """Issue #667: an explicit ``top_k`` request param is still forwarded to
+    the tool as ``--top-k <n>`` (operator/LLM override path)."""
+    fake_trace = session_dir / "fake_trace_dir"
+    fake_trace.mkdir()
+    captured: dict = {}
+
+    async def fake_run_subprocess(cmd, *, timeout_sec):
+        captured["cmd"] = list(cmd)
+        return 0, json.dumps({"status": "ok", "hot_kernels": []}), ""
+
+    monkeypatch.setattr(krh, "_run_subprocess", fake_run_subprocess)
+    res = await krh.trace_analyze_handler(
+        {
+            "trace_input": str(fake_trace),
+            "session_id": session_dir.name,
+            "analysis_route": "deterministic",
+            "top_k": 20,
+        },
+        session_dir=session_dir,
+    )
+    assert res["status"] in ("ok", "succeeded", "failed")
+    cmd = captured["cmd"]
+    assert "--top-k" in cmd
+    assert cmd[cmd.index("--top-k") + 1] == "20"
+
+
+@pytest.mark.asyncio
 async def test_trace_analyze_handler_records_bypass_discovery_failed(
     session_dir,
     monkeypatch,

--- a/kernel-agent/tools/test_tracelens_csv.py
+++ b/kernel-agent/tools/test_tracelens_csv.py
@@ -26,6 +26,33 @@ import tracelens_analysis as tla  # noqa: E402
 import tracelens_skill_runner as tlr  # noqa: E402
 
 
+def test_default_top_k_uses_large_pool_by_default(monkeypatch):
+    """Issue #667: the candidate-build pool defaults to a large value, not 10."""
+    monkeypatch.delenv("HYPERLOOM_KERNEL_CANDIDATES_TOP_K", raising=False)
+    assert tla._default_top_k() == tla._DEFAULT_KERNEL_CANDIDATES_TOP_K
+    assert tla._default_top_k() > 10
+
+
+def test_default_top_k_env_override(monkeypatch):
+    """Issue #667: HYPERLOOM_KERNEL_CANDIDATES_TOP_K overrides the pool size."""
+    monkeypatch.setenv("HYPERLOOM_KERNEL_CANDIDATES_TOP_K", "25")
+    assert tla._default_top_k() == 25
+
+
+def test_default_top_k_zero_means_unbounded(monkeypatch):
+    """Issue #667: 0/negative disables the build-time cap (huge internal cap)."""
+    monkeypatch.setenv("HYPERLOOM_KERNEL_CANDIDATES_TOP_K", "0")
+    assert tla._default_top_k() >= 1_000_000
+    monkeypatch.setenv("HYPERLOOM_KERNEL_CANDIDATES_TOP_K", "-5")
+    assert tla._default_top_k() >= 1_000_000
+
+
+def test_default_top_k_invalid_falls_back(monkeypatch):
+    """Issue #667: a non-integer env value falls back to the default pool."""
+    monkeypatch.setenv("HYPERLOOM_KERNEL_CANDIDATES_TOP_K", "not-an-int")
+    assert tla._default_top_k() == tla._DEFAULT_KERNEL_CANDIDATES_TOP_K
+
+
 def test_deterministic_category_analysis_command_maps_manifest_names(tmp_path):
     """Deterministic route must invoke the real TraceLens script for manifest category names."""
     cases = {

--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -63,6 +63,49 @@ from _paths import workspace_root
 
 
 # ---------------------------------------------------------------------------
+# Kernel-candidate pool size (issue #667).
+#
+# ``--top-k`` caps how many analysis.md p-items / hot kernels are written into
+# ``kernel_candidates.json``. Historically this defaulted to 10, which capped
+# the candidate POOL at candidate-build time -- *before* the dispatch layer's
+# own narrowing (source-fn grouping into ``task_groups[]``, op-fanout dedup,
+# and the per-group dispatch attempt cap) had a chance to run. A tight
+# build-time cap disproportionately drops GEAK-editable ops (rmsnorm,
+# add_rmsnorm, mha_batch_prefill, fused RoPE/reshape) while non-editable ops
+# (asm ``fmoe_g1u1`` with a compiled ``.co``, hipblaslt ``aten::mm``) consume
+# the top slots.
+#
+# The two caps are now decoupled: candidate-building uses a large pool by
+# default so the dispatch layer -- which already groups/dedups and caps
+# attempts -- is the real budget gate. Override via
+# ``HYPERLOOM_KERNEL_CANDIDATES_TOP_K`` (this standalone tool) or the
+# ``top_k`` request param on the orchestrator side. A value of ``0`` (or
+# negative) means "no build-time cap".
+_DEFAULT_KERNEL_CANDIDATES_TOP_K = 100
+
+
+def _default_top_k() -> int:
+    """Resolve the default kernel-candidate pool size.
+
+    Reads ``HYPERLOOM_KERNEL_CANDIDATES_TOP_K`` when set (``0``/negative =>
+    unbounded pool, represented internally as a very large cap), otherwise
+    falls back to :data:`_DEFAULT_KERNEL_CANDIDATES_TOP_K`.
+
+    Returns:
+        The candidate-build-time cap (a large number when unbounded).
+    """
+    raw = os.environ.get("HYPERLOOM_KERNEL_CANDIDATES_TOP_K", "").strip()
+    if not raw:
+        return _DEFAULT_KERNEL_CANDIDATES_TOP_K
+    try:
+        val = int(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_KERNEL_CANDIDATES_TOP_K
+    # 0 / negative => no build-time cap (dispatch layer owns the budget).
+    return val if val > 0 else 1_000_000
+
+
+# ---------------------------------------------------------------------------
 # Dict-first op -> .cu resolver (ground-truth ``op_to_source.json``).
 #
 # TraceLens emits only a CPU op name, a ``.py`` launcher, and (assumed) a device
@@ -5737,7 +5780,16 @@ def main() -> int:
     parser.add_argument("--session-id", default="")
     parser.add_argument("--model-name", default="")
     parser.add_argument("--framework", default="")
-    parser.add_argument("--top-k", type=int, default=10)
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        default=_default_top_k(),
+        help="Kernel-candidate POOL size written to kernel_candidates.json "
+        "(issue #667). Defaults to a large pool so the dispatch layer "
+        "(source-fn grouping + op dedup + attempt cap) owns the real "
+        "budget. Override the default via HYPERLOOM_KERNEL_CANDIDATES_TOP_K "
+        "(0 or negative = no build-time cap).",
+    )
     parser.add_argument("--target-platform", default="MI355X")
     parser.add_argument("--analysis-mode", default="default")
     parser.add_argument("--runtime-env", default="local")


### PR DESCRIPTION
Issue #667 

The trace_analyze --top-k cap was applied at candidate-build time (default 10) in tracelens_analysis.py, truncating analysis.md p-items / hot kernels before the dispatch layer's own narrowing (source-fn grouping into task_groups[], op-fanout dedup, per-group attempt cap) ran. A tight build-time cap disproportionately drops GEAK-editable ops (rmsnorm, add_rmsnorm, mha_batch_prefill, fused RoPE/reshape) while non-editable ops (asm fmoe_g1u1 with a compiled .co, hipblaslt aten::mm) consume the top slots, so most default core42 runs never even consider several optimizable candidates.

Decouple the two caps: candidate-building now uses a large pool by default (100, overridable via HYPERLOOM_KERNEL_CANDIDATES_TOP_K; 0/negative = unbounded), and the dispatch layer stays the real budget gate. The orchestrator only forwards --top-k when the request explicitly sets top_k, so the tool default is the single source of truth.

Adds unit tests for _default_top_k() env handling and for the handler forwarding/omitting --top-k based on the request param.

