### PR TITLE
refactor: reduce code redundancy across agent packages (routine-1)

### DIFF
--- a/critic-agent/runtime/kb_writer.py
+++ b/critic-agent/runtime/kb_writer.py
@@ -83,40 +83,22 @@ def _read_bool_env(name: str, default: bool) -> bool:
     return raw.strip().lower() in {"1", "true", "yes", "on"}
 
 
-def _read_int_env(name: str, default: int) -> int:
-    """Read an integer environment variable, falling back on errors.
+def _read_num_env(name: str, default, cast):
+    """Read a numeric environment variable, falling back on errors.
 
     Args:
         name (str): The environment variable name.
-        default (int): Value returned when unset, blank or unparsable.
+        default: Value returned when unset, blank or unparsable.
+        cast: Numeric constructor to apply (``int`` or ``float``).
 
     Returns:
-        int: The parsed integer, or ``default``.
+        The value parsed via ``cast``, or ``default``.
     """
     raw = os.environ.get(name)
     if raw is None or not raw.strip():
         return default
     try:
-        return int(raw)
-    except ValueError:
-        return default
-
-
-def _read_float_env(name: str, default: float) -> float:
-    """Read a float environment variable, falling back on errors.
-
-    Args:
-        name (str): The environment variable name.
-        default (float): Value returned when unset, blank or unparsable.
-
-    Returns:
-        float: The parsed float, or ``default``.
-    """
-    raw = os.environ.get(name)
-    if raw is None or not raw.strip():
-        return default
-    try:
-        return float(raw)
+        return cast(raw)
     except ValueError:
         return default
 
@@ -190,9 +172,9 @@ class KBWriter:
         self.read_enabled = _read_bool_env("KB_READ_ENABLED", True)
         self._time_fn = time_fn
 
-        self._breaker_threshold = max(1, _read_int_env("CRITIC_KB_BREAKER_THRESHOLD", _DEFAULT_BREAKER_THRESHOLD))
+        self._breaker_threshold = max(1, _read_num_env("CRITIC_KB_BREAKER_THRESHOLD", _DEFAULT_BREAKER_THRESHOLD, int))
         self._breaker_cooldown = max(
-            0.0, _read_float_env("CRITIC_KB_BREAKER_COOLDOWN_SECONDS", _DEFAULT_BREAKER_COOLDOWN_SECONDS)
+            0.0, _read_num_env("CRITIC_KB_BREAKER_COOLDOWN_SECONDS", _DEFAULT_BREAKER_COOLDOWN_SECONDS, float)
         )
         self._consecutive_failures = 0
         self._unreachable_until = 0.0

--- a/framework-agent/src/framework_agent/explorer.py
+++ b/framework-agent/src/framework_agent/explorer.py
@@ -30,6 +30,7 @@ from .isolation import (
 )
 from .logging_setup import get_logger, stage_log
 from .models import Candidate, CandidateResult, ExploreRequest, Finding, PrFilter
+from .runtime.tools_api import _metric_float
 from .shell import render_template, run_command
 from .sources import primus_cortex
 from .sources._shared import _repo_slug
@@ -393,24 +394,6 @@ def _load_json(path: Path) -> dict[str, Any]:
     return data if isinstance(data, dict) else {}
 
 
-def _metric_float(data: dict[str, Any], *keys: str) -> float | None:
-    """Return the first int/float value among ``keys`` in ``data``.
-
-    Args:
-        data (dict[str, Any]): The metric mapping to read.
-        *keys (str): Candidate keys, probed in order.
-
-    Returns:
-        float | None: The first numeric value found as a float, or ``None``
-            when no key holds an int/float.
-    """
-    for key in keys:
-        value = data.get(key)
-        if isinstance(value, (int, float)):
-            return float(value)
-    return None
-
-
 def _resolve_output_path(template: str, variables: dict[str, str]) -> Path:
     """Render a path template using the candidate's variable bag.
 
@@ -566,8 +549,8 @@ def _evaluate_candidate(req: ExploreRequest, variables: dict[str, str]) -> tuple
     accuracy_template = req.outputs.get("accuracy_json", "{candidate_dir}/accuracy.json")
     benchmark = _load_json(_resolve_output_path(benchmark_template, variables))
     accuracy = _load_json(_resolve_output_path(accuracy_template, variables))
-    throughput = _metric_float(benchmark, "throughput", "output_throughput", "tput")
-    acc = _metric_float(accuracy, "accuracy", "gsm8k", "exact_match", "score")
+    throughput = _metric_float(benchmark, ("throughput", "output_throughput", "tput"))
+    acc = _metric_float(accuracy, ("accuracy", "gsm8k", "exact_match", "score"))
     completed = str(benchmark.get("completed") or benchmark.get("Completed") or "")
     return throughput, acc, completed
 

--- a/framework-agent/tests/test_explorer.py
+++ b/framework-agent/tests/test_explorer.py
@@ -132,8 +132,8 @@ def test_passes_filter_include_paths_hit() -> None:
 
 def test_metric_float_returns_first_numeric_key() -> None:
     """_metric_float returns the first numeric value found among keys."""
-    assert ex._metric_float({"a": "no", "b": 12}, "a", "b") == 12.0
-    assert ex._metric_float({"a": "no"}, "a", "missing") is None
+    assert ex._metric_float({"a": "no", "b": 12}, ("a", "b")) == 12.0
+    assert ex._metric_float({"a": "no"}, ("a", "missing")) is None
 
 
 # ---------------------------------------------------------------------------

--- a/inference_optimizer/baseline_comparison/target_analyzer.py
+++ b/inference_optimizer/baseline_comparison/target_analyzer.py
@@ -287,51 +287,35 @@ def analyze(
     )
     now = _iso_utc_now()
 
-    if not canonical_model:
+    def _skip(status: str, reason: str, warning: str) -> BaselineSummary:
+        """Persist and return a no-data summary (skipped / no_match cases)."""
         summary = BaselineSummary(
             query=query,
             fetched_at=now,
             row_count=0,
             best=None,
-            status="skipped",
-            reason="model_mapping_miss",
-            warning=(f"model name mapping miss for {model_path!r}; no display name found"),
+            status=status,
+            reason=reason,
+            warning=warning,
             source=LLM_AUTHORED_SOURCE,
         )
         _persist(summary, session_dir=session_dir)
         return summary
 
+    if not canonical_model:
+        return _skip("skipped", "model_mapping_miss",
+                     f"model name mapping miss for {model_path!r}; no display name found")
+
     if not query.gpu:
-        summary = BaselineSummary(
-            query=query,
-            fetched_at=now,
-            row_count=0,
-            best=None,
-            status="skipped",
-            reason="no_target_gpu_configured",
-            warning="compare_against_gpu is empty",
-            source=LLM_AUTHORED_SOURCE,
-        )
-        _persist(summary, session_dir=session_dir)
-        return summary
+        return _skip("skipped", "no_target_gpu_configured", "compare_against_gpu is empty")
 
     target = research_hints.load_competitor_target(Path(session_dir))
     rows = list((target or {}).get("per_conc") or [])
     points = [p for p in (_target_row_to_point(r) for r in rows) if p is not None]
 
     if not points:
-        summary = BaselineSummary(
-            query=query,
-            fetched_at=now,
-            row_count=0,
-            best=None,
-            status="no_match",
-            reason="no_competitor_target",
-            warning=("no sourced competitor_target.json available (research scout disabled or produced no targets)"),
-            source=LLM_AUTHORED_SOURCE,
-        )
-        _persist(summary, session_dir=session_dir)
-        return summary
+        return _skip("no_match", "no_competitor_target",
+                     "no sourced competitor_target.json available (research scout disabled or produced no targets)")
 
     all_points = _dedup_by_conc(points)
     best = max(points, key=lambda p: p.tput_per_gpu)

--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -3589,35 +3589,21 @@ def _scan_all_benchmark_reports(session_dir: Path) -> Iterable[Path]:
     return sorted(runs.rglob("benchmark_*/benchmark_report.json"))
 
 
-def _scan_torch_traces(session_dir: Path) -> list[Path]:
-    """Find all ``torch_trace*`` directories under ``runs/``.
+def _scan_run_dirs(session_dir: Path, pattern: str) -> list[Path]:
+    """Find all directories matching ``pattern`` under ``runs/``, sorted.
 
     Args:
         session_dir (Path): Absolute session root.
+        pattern (str): ``rglob`` pattern (e.g. ``torch_trace*`` /
+            ``system_profile*``).
 
     Returns:
-        list[Path]: Matching trace directories, sorted. Empty when none exist.
+        list[Path]: Matching directories, sorted. Empty when none exist.
     """
     runs = session_dir / "runs"
     if not runs.exists():
         return []
-    return sorted(p for p in runs.rglob("torch_trace*") if p.is_dir())
-
-
-def _scan_system_profiles(session_dir: Path) -> list[Path]:
-    """Find all ``system_profile*`` directories under ``runs/``.
-
-    Args:
-        session_dir (Path): Absolute session root.
-
-    Returns:
-        list[Path]: Matching profile directories, sorted. Empty when none
-        exist.
-    """
-    runs = session_dir / "runs"
-    if not runs.exists():
-        return []
-    return sorted(p for p in runs.rglob("system_profile*") if p.is_dir())
+    return sorted(p for p in runs.rglob(pattern) if p.is_dir())
 
 
 def _scan_server_logs(session_dir: Path) -> list[Path]:
@@ -3839,8 +3825,8 @@ def collect_telemetry(
     return {
         "baseline_report_path": _rel(baseline_report, session_dir) if baseline_report else None,
         "profile_report_paths": [_rel(p, session_dir) or str(p) for p in profile_reports],
-        "torch_trace_paths": [_rel(p, session_dir) or str(p) for p in _scan_torch_traces(session_dir)],
-        "system_profile_paths": [_rel(p, session_dir) or str(p) for p in _scan_system_profiles(session_dir)],
+        "torch_trace_paths": [_rel(p, session_dir) or str(p) for p in _scan_run_dirs(session_dir, "torch_trace*")],
+        "system_profile_paths": [_rel(p, session_dir) or str(p) for p in _scan_run_dirs(session_dir, "system_profile*")],
         "server_log_paths": [_rel(p, session_dir) or str(p) for p in _scan_server_logs(session_dir)],
         "gpu_monitor_aggregate": _aggregate_gpu_monitor(all_reports, warnings),
         # per-lane occupancy / capacity summary from the leases DB.

--- a/inference_optimizer/breakdown/exporter.py
+++ b/inference_optimizer/breakdown/exporter.py
@@ -89,49 +89,36 @@ def _merge_phase_timeline(
     return base
 
 
-def _load_state(session_dir: Path, warnings: list[str]) -> dict[str, Any]:
-    """Read ``state.json`` as a plain dict; empty dict + warning when missing.
+def _load_json(session_dir: Path, filename: str, warnings: list[str]) -> dict[str, Any]:
+    """Read ``<filename>`` from the session dir as a dict; ``{}`` + warning on failure.
 
     Args:
         session_dir: The hyperloom session directory.
-        warnings: Accumulator appended to when the file is missing or
-            unparseable.
+        filename: File to read (e.g. ``state.json`` / ``manifest.json``).
+        warnings: Accumulator appended to when the file is missing or unparseable.
 
     Returns:
-        The parsed ``state.json`` contents, or an empty dict on any failure.
+        The parsed JSON contents, or an empty dict on any failure.
     """
-    state_path = session_dir / "state.json"
-    if not state_path.exists():
-        warnings.append(f"state.json missing at {state_path}")
+    path = session_dir / filename
+    if not path.exists():
+        warnings.append(f"{filename} missing at {path}")
         return {}
     try:
-        return json.loads(state_path.read_text(encoding="utf-8"))
+        return json.loads(path.read_text(encoding="utf-8"))
     except Exception as exc:  # noqa: BLE001
-        warnings.append(f"failed to parse state.json: {exc!r}")
+        warnings.append(f"failed to parse {filename}: {exc!r}")
         return {}
+
+
+def _load_state(session_dir: Path, warnings: list[str]) -> dict[str, Any]:
+    """Read ``state.json`` as a plain dict; empty dict + warning when missing."""
+    return _load_json(session_dir, "state.json", warnings)
 
 
 def _load_manifest(session_dir: Path, warnings: list[str]) -> dict[str, Any]:
-    """Read ``manifest.json`` as a plain dict.
-
-    Args:
-        session_dir (Path): The hyperloom session directory.
-        warnings (list[str]): Accumulator appended to when the file is missing
-            or unparseable.
-
-    Returns:
-        dict[str, Any]: The parsed ``manifest.json`` contents, or an empty
-            dict on any failure.
-    """
-    manifest_path = session_dir / "manifest.json"
-    if not manifest_path.exists():
-        warnings.append(f"manifest.json missing at {manifest_path}")
-        return {}
-    try:
-        return json.loads(manifest_path.read_text(encoding="utf-8"))
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"failed to parse manifest.json: {exc!r}")
-        return {}
+    """Read ``manifest.json`` as a plain dict; empty dict + warning when missing."""
+    return _load_json(session_dir, "manifest.json", warnings)
 
 
 _ROOFLINE_NUMERIC_FIELDS = (

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -5196,49 +5196,34 @@ def _build_parser() -> argparse.ArgumentParser:
     # measured runtime and the anchor are both the warm client-only phase (apples-to-apples) and
     # one-time cold-boot / aiter recompile no longer trips the kill.
     # 0 disables (legacy variant_timeout_sec hard cap still applies); overtime kills skip stack rebench.
-    def _env_float_or(default: float, env_var: str) -> float:
-        """Resolve a float CLI default from an environment variable.
+    def _env_num_or(default, env_var: str, cast):
+        """Resolve a numeric CLI default from an environment variable.
 
         Args:
-            default (float): Value to use when the variable is unset or invalid.
+            default: Value to use when the variable is unset or invalid.
             env_var (str): The environment variable name to read.
+            cast: The numeric constructor to apply (``float`` or ``int``).
 
         Returns:
-            float: The parsed env value, or ``default`` on absence / parse error.
+            The parsed env value cast via ``cast``, or ``cast(default)`` on
+            absence / parse error.
         """
         raw = os.environ.get(env_var, "").strip()
         if not raw:
-            return float(default)
+            return cast(default)
         try:
-            return float(raw)
+            return cast(raw)
         except (TypeError, ValueError):
-            return float(default)
-
-    def _env_int_or(default: int, env_var: str) -> int:
-        """Resolve an int CLI default from an environment variable.
-
-        Args:
-            default (int): Value to use when the variable is unset or invalid.
-            env_var (str): The environment variable name to read.
-
-        Returns:
-            int: The parsed env value, or ``default`` on absence / parse error.
-        """
-        raw = os.environ.get(env_var, "").strip()
-        if not raw:
-            return int(default)
-        try:
-            return int(raw)
-        except (TypeError, ValueError):
-            return int(default)
+            return cast(default)
 
     opt.add_argument(
         "--explore-overtime-kill-ratio",
         dest="explore_overtime_kill_ratio",
         type=float,
-        default=_env_float_or(
+        default=_env_num_or(
             2.0,
             "INFERENCE_OPTIMIZER_EXPLORE_OVERTIME_KILL_RATIO",
+            float,
         ),
         help="Per-variant explore overtime kill: each single-variant "
         "Magpie run in the explore loop is reaped once its "
@@ -5260,9 +5245,10 @@ def _build_parser() -> argparse.ArgumentParser:
         "--explore-variant-timeout-sec",
         dest="explore_variant_timeout_sec",
         type=int,
-        default=_env_int_or(
+        default=_env_num_or(
             0,
             "INFERENCE_OPTIMIZER_EXPLORE_VARIANT_TIMEOUT_SEC",
+            int,
         ),
         help="Pin the per-variant hard timeout (seconds) inside the "
         "EXPLORE phase. ``0`` (default) auto-derives from "
@@ -5276,9 +5262,10 @@ def _build_parser() -> argparse.ArgumentParser:
         "--explore-variant-timeout-safety-margin",
         dest="explore_variant_timeout_safety_margin",
         type=float,
-        default=_env_float_or(
+        default=_env_num_or(
             0.5,
             "INFERENCE_OPTIMIZER_EXPLORE_VARIANT_TIMEOUT_SAFETY_MARGIN",
+            float,
         ),
         help="Headroom (as a fraction of baseline_runtime_sec) added on "
         "top of --explore-overtime-kill-ratio when the EXPLORE hard "

--- a/inference_optimizer/compat/payload_aliases.py
+++ b/inference_optimizer/compat/payload_aliases.py
@@ -124,34 +124,6 @@ def read_extra_server_args(payload: dict, *, default: str = "") -> str:
     return default
 
 
-def read_extra_server_args_from_envs(envs: dict, *, default: str = "") -> str:
-    """Same contract as :func:`read_extra_server_args` but operates on
-    the ``envs`` dict shape carried by the Magpie YAML materializer.
-
-    The per-framework env names (``EXTRA_SGLANG_ARGS``,
-    ``EXTRA_VLLM_ARGS``, ``EXTRA_ATOM_ARGS``) are **not** renamed —
-    those are the canonical per-framework slots that the Magpie
-    wrapper looks up by name. This helper covers the *payload-surface*
-    field that some materializer call-sites expose alongside the env
-    map (the framework-neutral pre-routing slot).
-
-    Args:
-        envs (dict): Magpie ``envs`` mapping that may carry the canonical or
-            legacy payload-surface key.
-        default (str): Returned when neither key is present (default ``""``).
-
-    Returns:
-        str: The coerced canonical value, the coerced legacy value (with a
-        ``DeprecationWarning``), or ``default`` when neither key is present.
-    """
-    if CANONICAL_KEY in envs:
-        return _coerce_str(envs[CANONICAL_KEY])
-    if LEGACY_KEY in envs:
-        warnings.warn(_DEPRECATION_MESSAGE, DeprecationWarning, stacklevel=3)
-        return _coerce_str(envs[LEGACY_KEY])
-    return default
-
-
 def migrate_legacy_key_in_place(payload: dict) -> bool:
     """One-shot transform helper for persisted payloads (state.json
     rows, KB JSONL records, audit DB rows). Used by the SharedState
@@ -189,6 +161,5 @@ __all__ = [
     "CANONICAL_KEY",
     "LEGACY_KEY",
     "read_extra_server_args",
-    "read_extra_server_args_from_envs",
     "migrate_legacy_key_in_place",
 ]

--- a/inference_optimizer/manifest.py
+++ b/inference_optimizer/manifest.py
@@ -131,19 +131,21 @@ def _git_revision() -> str:
     return _git_revision_at(here)
 
 
-def _git_revision_at(path: Path) -> str:
-    """Best-effort short git SHA at ``path``.
+def _git_capture(path: Path, args: list[str]) -> str:
+    """Best-effort ``git -C <path> <args>`` returning trimmed stdout.
 
     Args:
         path (Path): Directory expected to be (within) a git checkout.
+        args (list[str]): The git subcommand + flags (without the leading
+            ``git -C <path>`` prefix).
 
     Returns:
-        str: Short HEAD SHA, or an empty string when ``path`` is not a checkout
-        or the git invocation fails.
+        str: Trimmed stdout, or an empty string when ``path`` is not a checkout,
+        git returns non-zero, or the invocation fails.
     """
     try:
         out = subprocess.run(
-            ["git", "-C", str(path), "rev-parse", "--short", "HEAD"],
+            ["git", "-C", str(path), *args],
             capture_output=True,
             text=True,
             timeout=2,
@@ -153,30 +155,16 @@ def _git_revision_at(path: Path) -> str:
         return out.stdout.strip()
     except (FileNotFoundError, subprocess.TimeoutExpired, PermissionError, OSError):
         return ""
+
+
+def _git_revision_at(path: Path) -> str:
+    """Best-effort short git SHA at ``path`` (empty when not a checkout/fails)."""
+    return _git_capture(path, ["rev-parse", "--short", "HEAD"])
 
 
 def _git_remote_at(path: Path) -> str:
-    """Best-effort ``origin`` remote URL at ``path``.
-
-    Args:
-        path (Path): Directory expected to be (within) a git checkout.
-
-    Returns:
-        str: ``remote.origin.url`` value, or an empty string when unset or the
-        git invocation fails.
-    """
-    try:
-        out = subprocess.run(
-            ["git", "-C", str(path), "config", "--get", "remote.origin.url"],
-            capture_output=True,
-            text=True,
-            timeout=2,
-        )
-        if out.returncode != 0:
-            return ""
-        return out.stdout.strip()
-    except (FileNotFoundError, subprocess.TimeoutExpired, PermissionError, OSError):
-        return ""
+    """Best-effort ``origin`` remote URL at ``path`` (empty when unset/fails)."""
+    return _git_capture(path, ["config", "--get", "remote.origin.url"])
 
 
 def _path_is_relative_to(path: Path, root: Path) -> bool:

--- a/inference_optimizer/orchestrator/_json_io.py
+++ b/inference_optimizer/orchestrator/_json_io.py
@@ -1,10 +1,15 @@
-"""Shared safe-JSON read helper with one precise swallowed-exception set."""
+"""Shared safe-JSON helpers with one precise swallowed-exception set."""
 
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Any
+
+
+# Fenced ```json``` block; shared by every model-reply extractor.
+_FENCED_JSON_RE = re.compile(r"```(?:json)?\s*(\{.*?\})\s*```", re.DOTALL)
 
 
 def read_json(path: Path, default: Any = None, *, require_dict: bool = False) -> Any:
@@ -18,4 +23,42 @@ def read_json(path: Path, default: Any = None, *, require_dict: bool = False) ->
     return data
 
 
-__all__ = ["read_json"]
+def extract_first_json_with_key(text: str, key: str, bare_re: re.Pattern[str]) -> dict | None:
+    """Pull the first JSON object containing *key* out of a model reply.
+
+    Prefers a fenced ```json block (least ambiguous), then falls back to
+    *bare_re* matches, progressively trimming trailing prose until
+    ``json.loads`` accepts a candidate.
+
+    Args:
+        text: The raw model reply that may contain a JSON object.
+        key: Required top-level key the returned dict must contain.
+        bare_re: Caller-supplied bare-object fallback pattern (group 1 is the
+            candidate ``{...}``); the required key differs per caller.
+
+    Returns:
+        The first dict containing *key*, or ``None`` when none is found.
+    """
+    if not text:
+        return None
+    for m in _FENCED_JSON_RE.finditer(text):
+        try:
+            data = json.loads(m.group(1))
+        except json.JSONDecodeError:
+            continue
+        if isinstance(data, dict) and key in data:
+            return data
+    for m in bare_re.finditer(text):
+        candidate = m.group(1)
+        for end in range(len(candidate), 0, -1):
+            try:
+                data = json.loads(candidate[:end])
+            except json.JSONDecodeError:
+                continue
+            if isinstance(data, dict) and key in data:
+                return data
+            break  # parsed but wrong shape; don't keep shrinking
+    return None
+
+
+__all__ = ["read_json", "extract_first_json_with_key"]

--- a/inference_optimizer/orchestrator/backends/codex.py
+++ b/inference_optimizer/orchestrator/backends/codex.py
@@ -15,7 +15,6 @@ real credentials or network.
 from __future__ import annotations
 
 import asyncio
-import json
 import os
 import re
 from dataclasses import dataclass, field
@@ -26,6 +25,7 @@ from ...protocol.intent import (
     NoIntentEmitted,
     validate_envelope,
 )
+from .._json_io import extract_first_json_with_key
 from .base import BackendError, BackendTurnResult, build_chat_messages, parse_call_timeout_env
 
 
@@ -61,47 +61,13 @@ For Critic specifically: when reviewing a proposal, emit
 """.strip()
 
 
-# Prefer a fenced ```json block, falling back to a bare top-level {...}.
-_FENCED_JSON_RE = re.compile(r"```(?:json)?\s*(\{.*?\})\s*```", re.DOTALL)
+# Bare top-level {...} fallback containing "intents" (fenced case handled by helper).
 _BARE_JSON_RE = re.compile(r"(\{.*?\"intents\".*\})", re.DOTALL)
 
 
 def _extract_envelope(text: str) -> dict | None:
-    """Pull the first valid JSON envelope out of a model reply.
-
-    Prefers a fenced ```json block (least ambiguous), then falls back to a bare
-    top-level object containing ``"intents"``, progressively trimming trailing
-    prose until ``json.loads`` accepts the candidate.
-
-    Args:
-        text (str): The raw model reply that may contain a JSON envelope.
-
-    Returns:
-        dict | None: The first dict envelope containing an ``"intents"`` key, or
-        ``None`` when no parseable envelope is found.
-    """
-    if not text:
-        return None
-    for m in _FENCED_JSON_RE.finditer(text):
-        try:
-            data = json.loads(m.group(1))
-        except json.JSONDecodeError:
-            continue
-        if isinstance(data, dict) and "intents" in data:
-            return data
-    # Bare JSON fallback: shrink from the right until json.loads accepts it
-    # (handles trailing prose without a fence).
-    for m in _BARE_JSON_RE.finditer(text):
-        candidate = m.group(1)
-        for end in range(len(candidate), 0, -1):
-            try:
-                data = json.loads(candidate[:end])
-            except json.JSONDecodeError:
-                continue
-            if isinstance(data, dict) and "intents" in data:
-                return data
-            break  # parsed but wrong shape; don't keep shrinking
-    return None
+    """Pull the first JSON envelope (containing ``"intents"``) from a model reply."""
+    return extract_first_json_with_key(text, "intents", _BARE_JSON_RE)
 
 
 @dataclass

--- a/inference_optimizer/orchestrator/backends/critic_agent.py
+++ b/inference_optimizer/orchestrator/backends/critic_agent.py
@@ -31,6 +31,7 @@ from ...protocol.intent import (
 from ...session_paths import allocate_turn_workdir, manifest_path
 from ..trace.conversation_trace import ConversationRecord, append_conversation
 from ..trace.llm_trace import LLMCallRecord, append_llm_call
+from .._json_io import extract_first_json_with_key
 from .base import BackendError, BackendTurnResult, build_chat_messages
 from ._runtime_bridge import RuntimeCall, RuntimeCaller, invoke_runtime_cli
 
@@ -99,41 +100,13 @@ Rules (mirror SKILL.md Hard Rules + Approve Standard):
 """.strip()
 
 
-# Fenced ```json``` block first, falling back to bare {...} with "review_verdicts".
-_FENCED_JSON_RE = re.compile(r"```(?:json)?\s*(\{.*?\})\s*```", re.DOTALL)
+# Bare {...} fallback containing "review_verdicts" (fenced case handled by helper).
 _BARE_JSON_RE = re.compile(r"(\{[^{}]*\"review_verdicts\"[\s\S]*\})", re.DOTALL)
 
 
 def _extract_review_json(text: str) -> dict[str, Any] | None:
-    """Pull the first valid review JSON out of a model reply, or ``None``.
-
-    Args:
-        text: The raw model reply that may contain a review JSON object.
-
-    Returns:
-        The first dict containing a ``"review_verdicts"`` key, or ``None`` when
-        no parseable review object is found.
-    """
-    if not text:
-        return None
-    for m in _FENCED_JSON_RE.finditer(text):
-        try:
-            data = json.loads(m.group(1))
-        except json.JSONDecodeError:
-            continue
-        if isinstance(data, dict) and "review_verdicts" in data:
-            return data
-    for m in _BARE_JSON_RE.finditer(text):
-        candidate = m.group(1)
-        for end in range(len(candidate), 0, -1):
-            try:
-                data = json.loads(candidate[:end])
-            except json.JSONDecodeError:
-                continue
-            if isinstance(data, dict) and "review_verdicts" in data:
-                return data
-            break  # parsed but wrong shape; don't keep shrinking
-    return None
+    """Pull the first review JSON (containing ``"review_verdicts"``) from a model reply."""
+    return extract_first_json_with_key(text, "review_verdicts", _BARE_JSON_RE)
 
 
 def _assistant_message_with_tool_calls(msg: Any) -> dict[str, Any]:

--- a/inference_optimizer/orchestrator/backends/mcp_emit_intent.py
+++ b/inference_optimizer/orchestrator/backends/mcp_emit_intent.py
@@ -11,7 +11,6 @@ forwarding to Claude.
 
 from __future__ import annotations
 
-import importlib
 import logging
 from typing import Any, Callable
 
@@ -20,6 +19,7 @@ from ...protocol.intent import (
     IntentValidationError,
     _PAYLOAD_REQUIRED,  # type: ignore[attr-defined]
 )
+from .mcp_context_tools import _resolve_sdk
 
 
 log = logging.getLogger(__name__)
@@ -123,25 +123,6 @@ async def _emit_intent_handler(args: dict[str, Any]) -> dict[str, Any]:
             "is_error": True,
         }
     return {"content": [{"type": "text", "text": "ok"}]}
-
-
-def _resolve_sdk(sdk_module: Any | None) -> Any | None:
-    """Return the provided SDK module or import ``claude_agent_sdk``.
-
-    Args:
-        sdk_module (Any | None): An explicit SDK module override (used by
-            tests); when ``None`` the real ``claude_agent_sdk`` is imported.
-
-    Returns:
-        Any | None: The resolved SDK module, or ``None`` if the override is
-        absent and the SDK cannot be imported.
-    """
-    if sdk_module is not None:
-        return sdk_module
-    try:
-        return importlib.import_module("claude_agent_sdk")
-    except ImportError:
-        return None
 
 
 def build_emit_intent_server(

--- a/inference_optimizer/orchestrator/objective.py
+++ b/inference_optimizer/orchestrator/objective.py
@@ -22,6 +22,15 @@ class ObjectiveError(ValueError):
     """Raised by `build_objective` on bad/conflicting inputs."""
 
 
+def _resolve_current_tput(state: "SharedState") -> float:
+    """Resolve current throughput, preferring ``current_best['tput']`` over baseline (0.0 if none)."""
+    cb = state.current_best or {}
+    v = cb.get("tput") if isinstance(cb, dict) else None
+    if isinstance(v, (int, float)) and v > 0:
+        return float(v)
+    return float(state.baseline_tput or 0.0)
+
+
 # ---------------------------------------------------------------------------
 @dataclass
 class Objective(ABC):
@@ -195,22 +204,8 @@ class TargetTputObjective(Objective):
         return "tput"
 
     def _current_tput(self, state: "SharedState") -> float:
-        """Resolve the current throughput, preferring the best-so-far result.
-
-        Reads ``state.current_best['tput']`` when it is a positive number,
-        otherwise falls back to the baseline throughput.
-
-        Args:
-            state (SharedState): Current shared optimization state.
-
-        Returns:
-            float: Current throughput in tok/s/GPU, or 0.0 if none is available.
-        """
-        cb = state.current_best or {}
-        v = cb.get("tput") if isinstance(cb, dict) else None
-        if isinstance(v, (int, float)) and v > 0:
-            return float(v)
-        return float(state.baseline_tput or 0.0)
+        """Resolve current throughput (best-so-far, else baseline)."""
+        return _resolve_current_tput(state)
 
     def progress(self, state: "SharedState") -> float:
         """Compute progress as current throughput divided by the target, capped at 1.0.
@@ -308,22 +303,8 @@ class TargetBaselineObjective(Objective):
         return "baseline"
 
     def _cur(self, state: "SharedState") -> float:
-        """Resolve the current throughput, preferring the best-so-far result.
-
-        Reads ``state.current_best['tput']`` when it is a positive number,
-        otherwise falls back to the baseline throughput.
-
-        Args:
-            state (SharedState): Current shared optimization state.
-
-        Returns:
-            float: Current throughput in tok/s, or 0.0 if none is available.
-        """
-        cb = state.current_best or {}
-        v = cb.get("tput") if isinstance(cb, dict) else None
-        if isinstance(v, (int, float)) and v > 0:
-            return float(v)
-        return float(state.baseline_tput or 0.0)
+        """Resolve current throughput (best-so-far, else baseline)."""
+        return _resolve_current_tput(state)
 
     def progress(self, state: "SharedState") -> float:
         """Compute progress as current throughput divided by the reference, capped at 1.0.

--- a/inference_optimizer/orchestrator/phase_state.py
+++ b/inference_optimizer/orchestrator/phase_state.py
@@ -118,21 +118,17 @@ PHASE_ALLOWED_ACTIONS: dict[str, frozenset[str]] = {
 }
 
 
-def is_action_allowed_in_phase(action_name: str, phase: str) -> bool:
-    """Return True iff ``action_name`` is in the phase allowlist (R1; unknown phase → deny).
-
-    Args:
-        action_name (str): Candidate action name; stripped before comparison.
-        phase (str): Phase name; stripped and upper-cased before lookup.
-
-    Returns:
-        bool: True when ``action_name`` is allowed in ``phase``; False for an
-        unknown phase or a non-member action.
-    """
-    allowed = PHASE_ALLOWED_ACTIONS.get((phase or "").strip().upper())
-    if allowed is None:
+def _action_in_phase_map(action_name: str, phase: str, mapping: dict[str, frozenset[str]]) -> bool:
+    """Return True iff stripped ``action_name`` is a member of ``mapping[phase]`` (unknown phase → deny)."""
+    actions = mapping.get((phase or "").strip().upper())
+    if actions is None:
         return False
-    return (action_name or "").strip() in allowed
+    return (action_name or "").strip() in actions
+
+
+def is_action_allowed_in_phase(action_name: str, phase: str) -> bool:
+    """Return True iff ``action_name`` is in the phase allowlist (R1; unknown phase → deny)."""
+    return _action_in_phase_map(action_name, phase, PHASE_ALLOWED_ACTIONS)
 
 
 def allowed_actions_for(phase: str) -> tuple[str, ...]:
@@ -157,20 +153,8 @@ PHASE_LLM_PROPOSABLE_ACTIONS: dict[str, frozenset[str]] = {
 
 
 def is_action_llm_proposable_in_phase(action_name: str, phase: str) -> bool:
-    """Return True iff ``action_name`` is LLM-proposable in ``phase`` (unknown → deny).
-
-    Args:
-        action_name (str): Candidate action name; stripped before comparison.
-        phase (str): Phase name; stripped and upper-cased before lookup.
-
-    Returns:
-        bool: True when ``action_name`` is LLM-proposable in ``phase``; False
-        for an unknown phase or a non-member action.
-    """
-    proposable = PHASE_LLM_PROPOSABLE_ACTIONS.get((phase or "").strip().upper())
-    if proposable is None:
-        return False
-    return (action_name or "").strip() in proposable
+    """Return True iff ``action_name`` is LLM-proposable in ``phase`` (unknown → deny)."""
+    return _action_in_phase_map(action_name, phase, PHASE_LLM_PROPOSABLE_ACTIONS)
 
 
 def llm_proposable_actions_for(phase: str) -> tuple[str, ...]:

--- a/inference_optimizer/orchestrator/roofline_ceiling.py
+++ b/inference_optimizer/orchestrator/roofline_ceiling.py
@@ -604,23 +604,22 @@ def apply_runtime_dtype(meta: "ModelMeta", rt: RuntimeDtype) -> "ModelMeta":
     )
 
 
-def _resolve_peak_tflops(gpu_type: str | None, precision_tag: str | None) -> float:
-    """``(gpu, precision)`` → vendor dense peak TFLOPS; 0.0 on miss (safe-degrade signal → T_cmp unavailable, fall back to T_mem).
-
-    Args:
-        gpu_type: GPU type key (matched case-insensitively).
-        precision_tag: Precision key to look up.
-
-    Returns:
-        The vendor dense peak TFLOPS, or ``0.0`` on miss.
-    """
-    spec = HW_SPECS.get((gpu_type or "").strip().lower())
+def _resolve_tflops(
+    specs: dict[str, dict[str, Any]], gpu_type: str | None, precision_tag: str | None
+) -> float:
+    """``(gpu, precision)`` → TFLOPS from *specs*' ``peak_tflops`` table (case-insensitive); 0.0 on any miss."""
+    spec = specs.get((gpu_type or "").strip().lower())
     if spec is None:
         return 0.0
     table = spec.get("peak_tflops")
     if not isinstance(table, dict) or not precision_tag:
         return 0.0
     return float(table.get(str(precision_tag).strip().lower(), 0.0))
+
+
+def _resolve_peak_tflops(gpu_type: str | None, precision_tag: str | None) -> float:
+    """``(gpu, precision)`` → vendor dense peak TFLOPS; 0.0 on miss (safe-degrade signal → T_cmp unavailable, fall back to T_mem)."""
+    return _resolve_tflops(HW_SPECS, gpu_type, precision_tag)
 
 
 # Model metadata extraction.
@@ -1241,22 +1240,8 @@ HW_SPECS_ACHIEVABLE: dict[str, dict[str, Any]] = {
 
 
 def _resolve_achievable_tflops(gpu_type: str | None, precision_tag: str | None) -> float:
-    """Max-achievable TFLOPS from ``HW_SPECS_ACHIEVABLE``; 0.0 on miss.
-
-    Args:
-        gpu_type: GPU type key (matched case-insensitively).
-        precision_tag: Precision key to look up.
-
-    Returns:
-        The max-achievable TFLOPS, or ``0.0`` on miss.
-    """
-    spec = HW_SPECS_ACHIEVABLE.get((gpu_type or "").strip().lower())
-    if spec is None:
-        return 0.0
-    table = spec.get("peak_tflops")
-    if not isinstance(table, dict) or not precision_tag:
-        return 0.0
-    return float(table.get(str(precision_tag).strip().lower(), 0.0))
+    """Max-achievable TFLOPS from ``HW_SPECS_ACHIEVABLE``; 0.0 on miss."""
+    return _resolve_tflops(HW_SPECS_ACHIEVABLE, gpu_type, precision_tag)
 
 
 import dataclasses as _dc

--- a/inference_optimizer/orchestrator/trace/_row_utils.py
+++ b/inference_optimizer/orchestrator/trace/_row_utils.py
@@ -1,0 +1,85 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Shared row-coercion + closed-schema validation for the trace ledgers.
+
+``conversation_trace`` and ``llm_trace`` write sibling JSONL ledgers with the
+same coercion rules and the same closed-schema guard (only the field set,
+exception class, and ledger label differ). These helpers are the single source
+of that logic; ``parse_usage`` shares the int coercion.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def coerce_optional_str(value: Any) -> str | None:
+    """Coerce a value to a non-empty stripped string, or ``None``.
+
+    Args:
+        value: Arbitrary value to normalize.
+
+    Returns:
+        The stripped string, or ``None`` when it is empty or ``None``.
+    """
+    if value is None:
+        return None
+    s = str(value).strip()
+    return s or None
+
+
+def coerce_optional_int(value: Any) -> int | None:
+    """Coerce a value to ``int``, or ``None`` on a miss / bad type.
+
+    Keeps ``None`` distinct from ``0`` so a source that does not report a
+    counter is never conflated with one that genuinely spent zero.
+
+    Args:
+        value: Arbitrary value to convert.
+
+    Returns:
+        The integer value, or ``None`` on failure.
+    """
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def validate_closed_row(
+    row: dict[str, Any],
+    *,
+    fields: frozenset[str],
+    valid_components: frozenset[str],
+    error_cls: type[Exception],
+    label: str,
+) -> None:
+    """Fail fast (raising *error_cls*) if *row* deviates from the closed schema.
+
+    Checks the exact field set, a non-empty string ``session_id``, and a
+    ``component`` drawn from *valid_components*. *label* names the ledger in
+    error messages (e.g. ``conversations`` / ``llm_calls``).
+
+    Args:
+        row: A serialized ledger row dict.
+        fields: The exact set of keys the row must carry.
+        valid_components: Allowed values for the ``component`` field.
+        error_cls: Exception type raised on any violation.
+        label: Human-readable ledger name used in error messages.
+    """
+    keys = set(row.keys())
+    extra = sorted(keys - fields)
+    missing = sorted(fields - keys)
+    if extra or missing:
+        raise error_cls(f"{label} row violates closed schema: extra={extra!r} missing={missing!r}")
+    session_id = row.get("session_id")
+    if not isinstance(session_id, str) or not session_id.strip():
+        raise error_cls(f"{label} row requires a non-empty 'session_id'; got {session_id!r}")
+    component = row.get("component")
+    if component not in valid_components:
+        raise error_cls(f"{label} row 'component'={component!r} is not one of {sorted(valid_components)!r}")
+
+
+__all__ = ["coerce_optional_str", "coerce_optional_int", "validate_closed_row"]

--- a/inference_optimizer/orchestrator/trace/conversation_trace.py
+++ b/inference_optimizer/orchestrator/trace/conversation_trace.py
@@ -35,6 +35,11 @@ from typing import Any
 
 from .._time import now_iso
 from ...session_paths import conversations_path
+from ._row_utils import (
+    coerce_optional_int as _coerce_optional_int,
+    coerce_optional_str as _coerce_optional_str,
+    validate_closed_row,
+)
 from .llm_trace import VALID_COMPONENTS
 
 log = logging.getLogger(__name__)
@@ -114,38 +119,6 @@ def redact_secrets(text: str) -> str:
 _now_iso = now_iso
 
 
-def _coerce_optional_str(value: Any) -> str | None:
-    """Coerce a value to a non-empty stripped string or ``None``.
-
-    Args:
-        value: Arbitrary value to normalize.
-
-    Returns:
-        The stripped string, or ``None`` if it is empty or ``None``.
-    """
-    if value is None:
-        return None
-    s = str(value).strip()
-    return s or None
-
-
-def _coerce_optional_int(value: Any) -> int | None:
-    """Coerce a value to ``int`` or ``None`` if it cannot be parsed.
-
-    Args:
-        value: Arbitrary value to convert.
-
-    Returns:
-        The integer value, or ``None`` on failure.
-    """
-    if value is None:
-        return None
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
-
-
 def _coerce_text(value: Any) -> str:
     """Normalize a prompt / response field to a (possibly empty) string.
 
@@ -205,28 +178,14 @@ class ConversationRecord:
 
 
 def _validate_row(row: dict[str, Any]) -> None:
-    """Fail fast if ``row`` deviates from the closed schema.
-
-    Args:
-        row: A serialized conversation row dict.
-
-    Raises:
-        ConversationRowError: If the row has extra/missing fields, an empty
-            ``session_id``, or an unknown ``component``.
-    """
-    keys = set(row.keys())
-    extra = sorted(keys - _ROW_FIELDS)
-    missing = sorted(_ROW_FIELDS - keys)
-    if extra or missing:
-        raise ConversationRowError(f"conversations row violates closed schema: extra={extra!r} missing={missing!r}")
-    session_id = row.get("session_id")
-    if not isinstance(session_id, str) or not session_id.strip():
-        raise ConversationRowError(f"conversations row requires a non-empty 'session_id'; got {session_id!r}")
-    component = row.get("component")
-    if component not in VALID_COMPONENTS:
-        raise ConversationRowError(
-            f"conversations row 'component'={component!r} is not one of {sorted(VALID_COMPONENTS)!r}"
-        )
+    """Fail fast if ``row`` deviates from the conversations closed schema."""
+    validate_closed_row(
+        row,
+        fields=_ROW_FIELDS,
+        valid_components=VALID_COMPONENTS,
+        error_cls=ConversationRowError,
+        label="conversations",
+    )
 
 
 def append_conversation(

--- a/inference_optimizer/orchestrator/trace/llm_trace.py
+++ b/inference_optimizer/orchestrator/trace/llm_trace.py
@@ -36,6 +36,11 @@ from typing import Any
 
 from .._time import now_iso
 from ...session_paths import llm_calls_path
+from ._row_utils import (
+    coerce_optional_int as _coerce_optional_int,
+    coerce_optional_str as _coerce_optional_str,
+    validate_closed_row,
+)
 
 log = logging.getLogger(__name__)
 
@@ -256,63 +261,15 @@ def _coerce_optional_str_list(value: Any) -> list[str] | None:
     return out or None
 
 
-def _coerce_optional_str(value: Any) -> str | None:
-    """Coerce a value to a non-empty stripped string or ``None``.
-
-    Args:
-        value: Arbitrary value to normalize.
-
-    Returns:
-        The stripped string, or ``None`` if it is empty or ``None``.
-    """
-    if value is None:
-        return None
-    s = str(value).strip()
-    return s or None
-
-
-def _coerce_optional_int(value: Any) -> int | None:
-    """Coerce a token / index value to int, or ``None`` on miss/bad type.
-
-    Unlike the backends' ``_safe_int`` (which floors to 0), this keeps
-    ``None`` distinct from ``0``: a backend that does not report a counter
-    must not be indistinguishable from one that genuinely spent zero.
-
-    Args:
-        value: Arbitrary token / index value.
-
-    Returns:
-        The integer value, or ``None`` on a miss or bad type.
-    """
-    if value is None:
-        return None
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
-
-
 def _validate_row(row: dict[str, Any]) -> None:
-    """Fail fast if ``row`` deviates from the closed schema.
-
-    Args:
-        row: A serialized LLM-call row dict.
-
-    Raises:
-        LLMTraceRowError: If the row has extra/missing fields, an empty
-            ``session_id``, or an unknown ``component``.
-    """
-    keys = set(row.keys())
-    extra = sorted(keys - _ROW_FIELDS)
-    missing = sorted(_ROW_FIELDS - keys)
-    if extra or missing:
-        raise LLMTraceRowError(f"llm_calls row violates closed schema: extra={extra!r} missing={missing!r}")
-    session_id = row.get("session_id")
-    if not isinstance(session_id, str) or not session_id.strip():
-        raise LLMTraceRowError(f"llm_calls row requires a non-empty 'session_id'; got {session_id!r}")
-    component = row.get("component")
-    if component not in VALID_COMPONENTS:
-        raise LLMTraceRowError(f"llm_calls row 'component'={component!r} is not one of {sorted(VALID_COMPONENTS)!r}")
+    """Fail fast if ``row`` deviates from the llm_calls closed schema."""
+    validate_closed_row(
+        row,
+        fields=_ROW_FIELDS,
+        valid_components=VALID_COMPONENTS,
+        error_cls=LLMTraceRowError,
+        label="llm_calls",
+    )
 
 
 def append_llm_call(

--- a/inference_optimizer/orchestrator/trace/parse_usage.py
+++ b/inference_optimizer/orchestrator/trace/parse_usage.py
@@ -33,6 +33,8 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from ._row_utils import coerce_optional_int as _coerce_optional_int
+
 log = logging.getLogger(__name__)
 
 
@@ -45,23 +47,6 @@ _TOKEN_KEYS: tuple[str, ...] = (
     "cache_creation_input_tokens",
     "cache_read_input_tokens",
 )
-
-
-def _coerce_optional_int(value: Any) -> int | None:
-    """Coerce a value to ``int`` or ``None`` if it cannot be parsed.
-
-    Args:
-        value: Arbitrary value to convert.
-
-    Returns:
-        The integer value, or ``None`` on failure.
-    """
-    if value is None:
-        return None
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
 
 
 def normalize_usage(usage: dict[str, Any] | None) -> dict[str, int | None] | None:

--- a/inference_optimizer/recipe_kb/local_store.py
+++ b/inference_optimizer/recipe_kb/local_store.py
@@ -1387,79 +1387,30 @@ def _coerce_dict(item: Any) -> dict[str, Any] | None:
     return None
 
 
-def _normalise_findings(items: list[Any] | None) -> list[dict[str, Any]]:
-    """Coerce findings into arbor ``{description, measured_impact}`` dicts.
-
-    Args:
-        items (list[Any] | None): Findings as dicts or dataclasses;
-            uncoercible entries are skipped.
-
-    Returns:
-        list[dict[str, Any]]: One ``{description, measured_impact}``
-            dict per coercible finding.
-    """
+def _normalise_str_dicts(items: list[Any] | None, keys: tuple[str, ...]) -> list[dict[str, Any]]:
+    """Coerce each item to ``{k: str(d.get(k) or "")}`` for *keys*; skip uncoercible entries."""
     out: list[dict[str, Any]] = []
     for it in items or []:
         d = _coerce_dict(it)
         if d is None:
             continue
-        out.append(
-            {
-                "description": str(d.get("description") or ""),
-                "measured_impact": str(d.get("measured_impact") or ""),
-            }
-        )
+        out.append({k: str(d.get(k) or "") for k in keys})
     return out
+
+
+def _normalise_findings(items: list[Any] | None) -> list[dict[str, Any]]:
+    """Coerce findings into arbor ``{description, measured_impact}`` dicts."""
+    return _normalise_str_dicts(items, ("description", "measured_impact"))
 
 
 def _normalise_failures(items: list[Any] | None) -> list[dict[str, Any]]:
-    """Coerce failures into arbor ``{description, reason}`` dicts.
-
-    Args:
-        items (list[Any] | None): Failures as dicts or dataclasses;
-            uncoercible entries are skipped.
-
-    Returns:
-        list[dict[str, Any]]: One ``{description, reason}`` dict per
-            coercible failure.
-    """
-    out: list[dict[str, Any]] = []
-    for it in items or []:
-        d = _coerce_dict(it)
-        if d is None:
-            continue
-        out.append(
-            {
-                "description": str(d.get("description") or ""),
-                "reason": str(d.get("reason") or ""),
-            }
-        )
-    return out
+    """Coerce failures into arbor ``{description, reason}`` dicts."""
+    return _normalise_str_dicts(items, ("description", "reason"))
 
 
 def _normalise_gaps(items: list[Any] | None) -> list[dict[str, Any]]:
-    """Coerce gaps into arbor ``{description, metrics}`` dicts.
-
-    Args:
-        items (list[Any] | None): Gaps as dicts or dataclasses;
-            uncoercible entries are skipped.
-
-    Returns:
-        list[dict[str, Any]]: One ``{description, metrics}`` dict per
-            coercible gap.
-    """
-    out: list[dict[str, Any]] = []
-    for it in items or []:
-        d = _coerce_dict(it)
-        if d is None:
-            continue
-        out.append(
-            {
-                "description": str(d.get("description") or ""),
-                "metrics": str(d.get("metrics") or ""),
-            }
-        )
-    return out
+    """Coerce gaps into arbor ``{description, metrics}`` dicts."""
+    return _normalise_str_dicts(items, ("description", "metrics"))
 
 
 def _normalise_prs(items: list[Any] | None) -> list[dict[str, Any]]:
@@ -1497,28 +1448,8 @@ def _normalise_prs(items: list[Any] | None) -> list[dict[str, Any]]:
 
 
 def _normalise_pitfalls(items: list[Any] | None) -> list[dict[str, Any]]:
-    """Coerce pitfalls into arbor ``{description, severity}`` dicts.
-
-    Args:
-        items (list[Any] | None): Pitfalls as dicts or dataclasses;
-            uncoercible entries are skipped.
-
-    Returns:
-        list[dict[str, Any]]: One ``{description, severity}`` dict per
-            coercible pitfall.
-    """
-    out: list[dict[str, Any]] = []
-    for it in items or []:
-        d = _coerce_dict(it)
-        if d is None:
-            continue
-        out.append(
-            {
-                "description": str(d.get("description") or ""),
-                "severity": str(d.get("severity") or ""),
-            }
-        )
-    return out
+    """Coerce pitfalls into arbor ``{description, severity}`` dicts."""
+    return _normalise_str_dicts(items, ("description", "severity"))
 
 
 def _normalise_lessons(items: list[Any] | None) -> list[dict[str, Any]]:

--- a/inference_optimizer/scripts/_roofline_audit_common.py
+++ b/inference_optimizer/scripts/_roofline_audit_common.py
@@ -1,0 +1,173 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Shared state-extraction helpers for the roofline-v2 N7 scripts.
+
+``audit_roofline_decisions`` and ``verify_roofline_v2`` both read a Hyperloom
+session's ``state.json`` and derive the same decision-quality signals (discovered
+vs. proposed flags, analysis.md grounding, prompt-cache hit rate). These helpers
+are the single source of truth for that extraction so the two scripts stay in
+lockstep. Read-only, pure stdlib.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Protocol
+
+
+# Keywords the LLM is likely to quote from analysis.md when grounding a
+# PRUNE_BRANCH reason or propose-action note; used as a proxy for how often the
+# report was actually consulted.
+ANALYSIS_MD_KEYWORDS = (
+    "analysis.md",
+    "saturated",
+    "comm-bound",
+    "memory-bound",
+    "compute-bound",
+    "efficiency",
+    "Top Operations",
+    "Executive Summary",
+    "Recommendations",
+    "snapshot",
+    "rcclAllreduce",
+    "bottleneck",
+)
+
+FLAG_PATTERN = re.compile(r"--[a-z][a-z0-9_-]+")
+
+
+class _CacheCounts(Protocol):
+    """Structural type for objects carrying prompt-cache token counters."""
+
+    cache_creation_input_tokens: int
+    cache_read_input_tokens: int
+
+
+def safe_load_state(session_dir: Path) -> dict[str, Any] | None:
+    """Load ``state.json`` from a session directory if present and valid.
+
+    Args:
+        session_dir (Path): Session directory expected to contain
+            ``state.json``.
+
+    Returns:
+        dict[str, Any] | None: Parsed state mapping, or ``None`` when missing
+        or unreadable.
+    """
+    p = session_dir / "state.json"
+    if not p.is_file():
+        return None
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def flatten_discovered_flag_names(state: dict[str, Any]) -> set[str]:
+    """Collect every discovered flag name across all frameworks.
+
+    Walks ``discovered_flags[framework].{backend_flags,param_flags}`` and
+    unions the flag names.
+
+    Args:
+        state (dict[str, Any]): Parsed ``state.json`` mapping.
+
+    Returns:
+        set[str]: Set of discovered flag names; empty when none are present.
+    """
+    discovered = state.get("discovered_flags") or {}
+    names: set[str] = set()
+    if not isinstance(discovered, dict):
+        return names
+    for entry in discovered.values():
+        if not isinstance(entry, dict):
+            continue
+        for key in ("backend_flags", "param_flags"):
+            lst = entry.get(key) or []
+            if isinstance(lst, (list, tuple)):
+                names.update(str(f) for f in lst if f)
+    return names
+
+
+def extract_proposed_flags(state: dict[str, Any]) -> list[str]:
+    """Pull every ``--flag-name`` proposed across explore variants.
+
+    Scans ``explore_attempts`` and ``explore_search.tested`` entries for
+    ``extra_server_args`` strings and extracts flag tokens.
+
+    Args:
+        state (dict[str, Any]): Parsed ``state.json`` mapping.
+
+    Returns:
+        list[str]: Proposed flag names; may contain duplicates.
+    """
+    found: list[str] = []
+    attempts = state.get("explore_attempts") or []
+    if isinstance(attempts, list):
+        for entry in attempts:
+            if not isinstance(entry, dict):
+                continue
+            args = str(entry.get("extra_server_args") or "")
+            if args:
+                found.extend(FLAG_PATTERN.findall(args))
+    # Also walk explore_search.tested for fingerprints that may not have ended
+    # up in attempts (idempotency short-circuits).
+    sub = state.get("explore_search") or {}
+    tested = sub.get("tested") if isinstance(sub, dict) else None
+    if isinstance(tested, dict):
+        for snap in tested.values():
+            if isinstance(snap, dict):
+                args = str(snap.get("extra_server_args") or "")
+                if args:
+                    found.extend(FLAG_PATTERN.findall(args))
+    return found
+
+
+def count_analysis_md_references(state: dict[str, Any]) -> int:
+    """Count prune reasons and explore notes grounded on analysis.md.
+
+    Scans ``pruned_families[*].reason`` and ``explore_attempts[*].notes`` for
+    any :data:`ANALYSIS_MD_KEYWORDS` token (a proxy for how often the LLM
+    quoted the cached report when justifying a decision).
+
+    Args:
+        state (dict[str, Any]): Parsed ``state.json`` mapping.
+
+    Returns:
+        int: Number of reason/notes strings containing at least one keyword.
+    """
+    count = 0
+    pruned = state.get("pruned_families") or []
+    if isinstance(pruned, list):
+        for entry in pruned:
+            if isinstance(entry, dict):
+                reason = str(entry.get("reason") or "").lower()
+                if any(kw.lower() in reason for kw in ANALYSIS_MD_KEYWORDS):
+                    count += 1
+    attempts = state.get("explore_attempts") or []
+    if isinstance(attempts, list):
+        for entry in attempts:
+            if isinstance(entry, dict):
+                notes = str(entry.get("notes") or "").lower()
+                if any(kw.lower() in notes for kw in ANALYSIS_MD_KEYWORDS):
+                    count += 1
+    return count
+
+
+def cache_hit_rate(obj: _CacheCounts) -> float:
+    """Compute the prompt-cache read hit rate from token counters.
+
+    Args:
+        obj (_CacheCounts): Object carrying ``cache_creation_input_tokens`` and
+            ``cache_read_input_tokens``.
+
+    Returns:
+        float: ``cache_read / (cache_creation + cache_read)`` in [0, 1], or
+        ``0.0`` when no cache tokens were recorded.
+    """
+    total = obj.cache_creation_input_tokens + obj.cache_read_input_tokens
+    if total <= 0:
+        return 0.0
+    return obj.cache_read_input_tokens / total

--- a/inference_optimizer/scripts/audit_roofline_decisions.py
+++ b/inference_optimizer/scripts/audit_roofline_decisions.py
@@ -31,29 +31,19 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-
-_ANALYSIS_MD_KEYWORDS = (
-    "analysis.md",
-    "saturated",
-    "comm-bound",
-    "memory-bound",
-    "compute-bound",
-    "efficiency",
-    "Top Operations",
-    "Executive Summary",
-    "Recommendations",
-    "snapshot",
-    "rcclAllreduce",
-    "bottleneck",
+from inference_optimizer.scripts._roofline_audit_common import (
+    ANALYSIS_MD_KEYWORDS,
+    cache_hit_rate,
+    count_analysis_md_references,
+    extract_proposed_flags,
+    flatten_discovered_flag_names,
+    safe_load_state,
 )
-
-_FLAG_PATTERN = re.compile(r"--[a-z][a-z0-9_-]+")
 
 
 # ---------------------------------------------------------------------------
@@ -107,112 +97,6 @@ class AuditReport:
     cache_read_input_tokens: int = 0
 
 
-def _safe_load_state(session_dir: Path) -> dict[str, Any] | None:
-    """Load ``state.json`` from a session directory if present and valid.
-
-    Args:
-        session_dir (Path): Session directory expected to contain
-            ``state.json``.
-
-    Returns:
-        dict[str, Any] | None: Parsed state mapping, or ``None`` when missing
-        or unreadable.
-    """
-    p = session_dir / "state.json"
-    if not p.is_file():
-        return None
-    try:
-        return json.loads(p.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        return None
-
-
-def _flatten_discovered_flag_names(state: dict[str, Any]) -> set[str]:
-    """Collect every discovered flag name across all frameworks.
-
-    Walks ``discovered_flags[framework].{backend_flags,param_flags}`` and
-    unions the flag names.
-
-    Args:
-        state (dict[str, Any]): Parsed ``state.json`` mapping.
-
-    Returns:
-        set[str]: Set of discovered flag names; empty when none are present.
-    """
-    discovered = state.get("discovered_flags") or {}
-    names: set[str] = set()
-    if not isinstance(discovered, dict):
-        return names
-    for entry in discovered.values():
-        if not isinstance(entry, dict):
-            continue
-        for key in ("backend_flags", "param_flags"):
-            lst = entry.get(key) or []
-            if isinstance(lst, (list, tuple)):
-                names.update(str(f) for f in lst if f)
-    return names
-
-
-def _extract_proposed_flag_names(state: dict[str, Any]) -> list[str]:
-    """Pull every ``--flag-name`` proposed across explore variants.
-
-    Scans ``explore_attempts`` and ``explore_search.tested`` entries for
-    ``extra_server_args`` strings and extracts flag tokens.
-
-    Args:
-        state (dict[str, Any]): Parsed ``state.json`` mapping.
-
-    Returns:
-        list[str]: Proposed flag names; may contain duplicates.
-    """
-    found: list[str] = []
-    attempts = state.get("explore_attempts") or []
-    if isinstance(attempts, list):
-        for entry in attempts:
-            if not isinstance(entry, dict):
-                continue
-            args = str(entry.get("extra_server_args") or "")
-            if args:
-                found.extend(_FLAG_PATTERN.findall(args))
-    sub = state.get("explore_search") or {}
-    tested = sub.get("tested") if isinstance(sub, dict) else None
-    if isinstance(tested, dict):
-        for snap in tested.values():
-            if isinstance(snap, dict):
-                args = str(snap.get("extra_server_args") or "")
-                if args:
-                    found.extend(_FLAG_PATTERN.findall(args))
-    return found
-
-
-def _count_analysis_md_references(state: dict[str, Any]) -> int:
-    """Count prune reasons and explore notes grounded on analysis.md.
-
-    Args:
-        state (dict[str, Any]): Parsed ``state.json`` mapping.
-
-    Returns:
-        int: Number of ``pruned_families`` reasons plus ``explore_attempts``
-        notes that contain at least one analysis.md grounding keyword.
-    """
-    count = 0
-    pruned = state.get("pruned_families") or []
-    if isinstance(pruned, list):
-        for entry in pruned:
-            if isinstance(entry, dict):
-                reason = str(entry.get("reason") or "").lower()
-                if any(kw.lower() in reason for kw in _ANALYSIS_MD_KEYWORDS):
-                    count += 1
-    attempts = state.get("explore_attempts") or []
-    if isinstance(attempts, list):
-        for entry in attempts:
-            if isinstance(entry, dict):
-                notes = str(entry.get("notes") or "").lower()
-                if any(kw.lower() in notes for kw in _ANALYSIS_MD_KEYWORDS):
-                    count += 1
-    return count
-
-
 def extract(session_dir: Path) -> AuditReport:
     """Read a session directory and build its decision-quality audit.
 
@@ -227,7 +111,7 @@ def extract(session_dir: Path) -> AuditReport:
         AuditReport: Populated audit report for the session.
     """
     r = AuditReport(session_dir=session_dir)
-    state = _safe_load_state(session_dir)
+    state = safe_load_state(session_dir)
     if state is None:
         r.error = f"state.json not found / unreadable at {session_dir}"
         return r
@@ -251,13 +135,13 @@ def extract(session_dir: Path) -> AuditReport:
     if isinstance(pruned, list):
         r.pruned_families_raw = [p for p in pruned if isinstance(p, dict)]
 
-    r.discovered_flag_names = _flatten_discovered_flag_names(state)
-    r.proposed_flag_names = _extract_proposed_flag_names(state)
+    r.discovered_flag_names = flatten_discovered_flag_names(state)
+    r.proposed_flag_names = extract_proposed_flags(state)
     if r.discovered_flag_names:
         r.hallucinated_flag_names = {f for f in r.proposed_flag_names if f not in r.discovered_flag_names}
         proposed_set = set(r.proposed_flag_names)
         r.untested_flag_names = r.discovered_flag_names - proposed_set
-    r.analysis_md_referenced_count = _count_analysis_md_references(state)
+    r.analysis_md_referenced_count = count_analysis_md_references(state)
 
     cache_metrics = state.get("tick_cache_metrics") or {}
     if isinstance(cache_metrics, dict):
@@ -269,22 +153,6 @@ def extract(session_dir: Path) -> AuditReport:
 # ---------------------------------------------------------------------------
 # Rendering
 # ---------------------------------------------------------------------------
-def _cache_hit_rate(r: AuditReport) -> float:
-    """Compute the prompt-cache read hit rate for an audit report.
-
-    Args:
-        r (AuditReport): Audit report carrying cache token counters.
-
-    Returns:
-        float: ``cache_read / (cache_creation + cache_read)`` in [0, 1], or
-        ``0.0`` when no cache tokens were recorded.
-    """
-    total = r.cache_creation_input_tokens + r.cache_read_input_tokens
-    if total <= 0:
-        return 0.0
-    return r.cache_read_input_tokens / total
-
-
 def _format_roofline_timeline(attempts: list[dict[str, Any]]) -> str:
     """Render roofline action attempts as an indented text table.
 
@@ -327,7 +195,7 @@ def _format_pruned_families(pruned: list[dict[str, Any]]) -> str:
         fam = str(entry.get("family") or "?")
         source = str(entry.get("source") or "?")
         reason = str(entry.get("reason") or "")
-        grounded = any(kw.lower() in reason.lower() for kw in _ANALYSIS_MD_KEYWORDS)
+        grounded = any(kw.lower() in reason.lower() for kw in ANALYSIS_MD_KEYWORDS)
         tag = "yes" if grounded else "no"
         # Truncate reason to 100 chars for readability
         reason_short = reason if len(reason) <= 100 else reason[:97] + "..."
@@ -392,7 +260,7 @@ def render(r: AuditReport) -> str:
     out.append(_format_flag_audit(r))
     out.append("")
     out.append("  --- decision quality criteria (§10.3) ---")
-    cache = _cache_hit_rate(r)
+    cache = cache_hit_rate(r)
     quality: list[tuple[str, bool, str]] = [
         (
             "cache_hit_rate ≥ 50%",
@@ -475,7 +343,7 @@ def main(argv: list[str] | None = None) -> int:
             "analysis_md_referenced_count": report.analysis_md_referenced_count,
             "cache_creation_input_tokens": report.cache_creation_input_tokens,
             "cache_read_input_tokens": report.cache_read_input_tokens,
-            "cache_hit_rate": _cache_hit_rate(report),
+            "cache_hit_rate": cache_hit_rate(report),
         }
         print(json.dumps(payload, indent=2, default=str))
     else:

--- a/inference_optimizer/scripts/verify_roofline_v2.py
+++ b/inference_optimizer/scripts/verify_roofline_v2.py
@@ -27,12 +27,20 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+
+from inference_optimizer.scripts._roofline_audit_common import (
+    ANALYSIS_MD_KEYWORDS,
+    cache_hit_rate,
+    count_analysis_md_references,
+    extract_proposed_flags,
+    flatten_discovered_flag_names,
+    safe_load_state,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -70,45 +78,6 @@ class SessionMetrics:
     hallucinated_flag_count: int = 0
     discovered_flag_names: set[str] = field(default_factory=set)
     prune_branch_count_orchestration: int = 0
-
-
-# Keywords the LLM is likely to quote from analysis.md when grounding
-# a PRUNE_BRANCH reason or propose-action note. The LLM is instructed
-# to quote the report; we count how often that happened.
-_ANALYSIS_MD_KEYWORDS = (
-    "analysis.md",
-    "saturated",
-    "comm-bound",
-    "memory-bound",
-    "compute-bound",
-    "efficiency",
-    "Top Operations",
-    "Executive Summary",
-    "Recommendations",
-    "snapshot",
-    "rcclAllreduce",
-    "bottleneck",
-)
-
-
-def _safe_load_state(session_dir: Path) -> dict[str, Any] | None:
-    """Load ``state.json`` from a session directory if present and valid.
-
-    Args:
-        session_dir (Path): Hyperloom session directory expected to contain
-            a ``state.json`` file.
-
-    Returns:
-        dict[str, Any] | None: Parsed JSON state mapping, or ``None`` when the
-        file is missing or cannot be read/parsed as JSON.
-    """
-    p = session_dir / "state.json"
-    if not p.is_file():
-        return None
-    try:
-        return json.loads(p.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        return None
 
 
 def _parse_iso(value: Any) -> datetime | None:
@@ -182,69 +151,6 @@ def _count_action_attempts(state: dict[str, Any], action: str) -> int:
     return len(attempts) if isinstance(attempts, list) else 0
 
 
-def _flatten_discovered_flag_names(state: dict[str, Any]) -> set[str]:
-    """Collect every discovered flag name across all frameworks.
-
-    Walks ``discovered_flags[framework].{backend_flags,param_flags}`` and
-    unions the flag names into a single set.
-
-    Args:
-        state (dict[str, Any]): Parsed ``state.json`` mapping.
-
-    Returns:
-        set[str]: Set of discovered flag names; empty when none are present.
-    """
-    discovered = state.get("discovered_flags") or {}
-    names: set[str] = set()
-    if not isinstance(discovered, dict):
-        return names
-    for entry in discovered.values():
-        if not isinstance(entry, dict):
-            continue
-        for key in ("backend_flags", "param_flags"):
-            lst = entry.get(key) or []
-            if isinstance(lst, (list, tuple)):
-                names.update(str(f) for f in lst if f)
-    return names
-
-
-_FLAG_PATTERN = re.compile(r"--[a-z][a-z0-9_-]+")
-
-
-def _extract_proposed_flags(state: dict[str, Any]) -> list[str]:
-    """Pull every ``--flag-name`` proposed across explore variants.
-
-    Scans ``explore_attempts`` and ``explore_search.tested`` entries for
-    ``extra_server_args`` strings and extracts flag tokens from each.
-
-    Args:
-        state (dict[str, Any]): Parsed ``state.json`` mapping.
-
-    Returns:
-        list[str]: Flag names proposed by the LLM; may contain duplicates.
-    """
-    found: list[str] = []
-    attempts = state.get("explore_attempts") or []
-    if isinstance(attempts, list):
-        for entry in attempts:
-            if not isinstance(entry, dict):
-                continue
-            args = str(entry.get("extra_server_args") or "")
-            if args:
-                found.extend(_FLAG_PATTERN.findall(args))
-    # Also walk explore_search.tested for fingerprints that may not
-    # have ended up in attempts (idempotency short-circuits).
-    sub = state.get("explore_search") or {}
-    tested = sub.get("tested") if isinstance(sub, dict) else None
-    if isinstance(tested, dict):
-        for snap in tested.values():
-            if isinstance(snap, dict):
-                args = str(snap.get("extra_server_args") or "")
-                if args:
-                    found.extend(_FLAG_PATTERN.findall(args))
-    return found
-
-
 def _count_orchestration_prune_branch(state: dict[str, Any]) -> int:
     """Count `pruned_families` entries with source="orchestration".
 
@@ -270,46 +176,6 @@ def _count_orchestration_prune_branch(state: dict[str, Any]) -> int:
     return count
 
 
-def _count_analysis_md_references(state: dict[str, Any]) -> int:
-    """Scan PRUNE_BRANCH reasons + propose-action notes for keywords
-    that indicate the LLM grounded its decision on the cached
-    analysis.md (per §8.7 orchestration.md guidance).
-
-    Sources:
-    * `pruned_families[*].reason` (orchestration-sourced)
-    * `attempts_history` entries' `notes` field (when present)
-
-    Args:
-        state (dict[str, Any]): Parsed ``state.json`` mapping.
-
-    Returns:
-        int: Count of reason/notes strings that contain at least one
-        analysis.md grounding keyword.
-    """
-    count = 0
-    pruned = state.get("pruned_families") or []
-    if isinstance(pruned, list):
-        for entry in pruned:
-            if not isinstance(entry, dict):
-                continue
-            reason = str(entry.get("reason") or "")
-            for kw in _ANALYSIS_MD_KEYWORDS:
-                if kw.lower() in reason.lower():
-                    count += 1
-                    break
-    attempts = state.get("explore_attempts") or []
-    if isinstance(attempts, list):
-        for entry in attempts:
-            if not isinstance(entry, dict):
-                continue
-            notes = str(entry.get("notes") or "")
-            for kw in _ANALYSIS_MD_KEYWORDS:
-                if kw.lower() in notes.lower():
-                    count += 1
-                    break
-    return count
-
-
 def extract(session_dir: Path) -> SessionMetrics:
     """Read a session directory and derive its comparison metrics.
 
@@ -325,7 +191,7 @@ def extract(session_dir: Path) -> SessionMetrics:
         SessionMetrics: Populated metrics for the session.
     """
     m = SessionMetrics(session_dir=session_dir)
-    state = _safe_load_state(session_dir)
+    state = safe_load_state(session_dir)
     if state is None:
         m.error = f"state.json not found / unreadable at {session_dir}"
         return m
@@ -357,11 +223,11 @@ def extract(session_dir: Path) -> SessionMetrics:
         m.analysis_md_text = str(cached_ta.get("analysis_md_text") or "")
 
     # Decision quality
-    m.discovered_flag_names = _flatten_discovered_flag_names(state)
-    proposed = _extract_proposed_flags(state)
+    m.discovered_flag_names = flatten_discovered_flag_names(state)
+    proposed = extract_proposed_flags(state)
     if m.discovered_flag_names:
         m.hallucinated_flag_count = sum(1 for f in proposed if f not in m.discovered_flag_names)
-    m.analysis_md_referenced_count = _count_analysis_md_references(state)
+    m.analysis_md_referenced_count = count_analysis_md_references(state)
 
     # Cache metrics — the backend surfaces these to backend.calls
     # per-call. Coordinator does not aggregate to SharedState. For now
@@ -379,22 +245,6 @@ def extract(session_dir: Path) -> SessionMetrics:
 # ---------------------------------------------------------------------------
 # Rendering
 # ---------------------------------------------------------------------------
-def _cache_hit_rate(m: SessionMetrics) -> float:
-    """Compute the prompt-cache read hit rate for a session.
-
-    Args:
-        m (SessionMetrics): Session metrics carrying cache token counters.
-
-    Returns:
-        float: ``cache_read / (cache_creation + cache_read)`` in [0, 1], or
-        ``0.0`` when no cache tokens were recorded.
-    """
-    total = m.cache_creation_input_tokens + m.cache_read_input_tokens
-    if total <= 0:
-        return 0.0
-    return m.cache_read_input_tokens / total
-
-
 def _format_action_seq(stack: list[dict[str, Any]]) -> str:
     """Render an optimization stack as a compact ``kind:variant`` sequence.
 
@@ -432,8 +282,8 @@ def render(baseline: SessionMetrics, exp: SessionMetrics) -> str:
     """
     delta_gain = exp.cumulative_gain_validated_pct - baseline.cumulative_gain_validated_pct
     delta_wall = exp.wall_clock_min - baseline.wall_clock_min
-    exp_cache = _cache_hit_rate(exp)
-    base_cache = _cache_hit_rate(baseline)
+    exp_cache = cache_hit_rate(exp)
+    base_cache = cache_hit_rate(baseline)
 
     out: list[str] = []
     out.append("=" * 72)
@@ -630,14 +480,14 @@ def main(argv: list[str] | None = None) -> int:
                 "cumulative_gain_validated_pct": baseline.cumulative_gain_validated_pct,
                 "wall_clock_min": baseline.wall_clock_min,
                 "roofline_action_count": baseline.roofline_action_count,
-                "cache_hit_rate": _cache_hit_rate(baseline),
+                "cache_hit_rate": cache_hit_rate(baseline),
             },
             "exp": {
                 "session_dir": str(exp.session_dir),
                 "cumulative_gain_validated_pct": exp.cumulative_gain_validated_pct,
                 "wall_clock_min": exp.wall_clock_min,
                 "roofline_action_count": exp.roofline_action_count,
-                "cache_hit_rate": _cache_hit_rate(exp),
+                "cache_hit_rate": cache_hit_rate(exp),
                 "analysis_md_referenced_count": exp.analysis_md_referenced_count,
                 "hallucinated_flag_count": exp.hallucinated_flag_count,
                 "snapshot_id": exp.snapshot_id,

--- a/inference_optimizer/tests/conftest.py
+++ b/inference_optimizer/tests/conftest.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -76,3 +77,42 @@ def session_dir(tmp_path, monkeypatch) -> Path:
     sd = make_session_dir()
     seed_target_analysis_marker(sd)
     return sd
+
+
+def init_git_repo(
+    path: Path,
+    *,
+    seed_file: str = "src.py",
+    seed_text: str = "def f():\n    return 1\n",
+) -> None:
+    """Initialise a minimal git repo with one commit under ``path``.
+
+    Seeds a single tracked file and commits it so ``git worktree add`` and
+    patch application have a base commit to branch from. A fixed non-interactive
+    author identity is used (tests do not assert on it).
+    """
+    path.mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    env["GIT_AUTHOR_NAME"] = "Hyperloom Test"
+    env["GIT_AUTHOR_EMAIL"] = "hyperloom@test.local"
+    env["GIT_COMMITTER_NAME"] = env["GIT_AUTHOR_NAME"]
+    env["GIT_COMMITTER_EMAIL"] = env["GIT_AUTHOR_EMAIL"]
+    subprocess.run(
+        ["git", "init", "-b", "main", str(path)],
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+    (path / seed_file).write_text(seed_text, encoding="utf-8")
+    subprocess.run(
+        ["git", "-C", str(path), "add", "."],
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+    subprocess.run(
+        ["git", "-C", str(path), "commit", "-m", "init"],
+        check=True,
+        capture_output=True,
+        env=env,
+    )

--- a/inference_optimizer/tests/conftest.py
+++ b/inference_optimizer/tests/conftest.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 import pytest
 
+from inference_optimizer.paths import make_session_dir
+
 
 @pytest.fixture(autouse=True)
 def _isolate_session_layout_env(monkeypatch, tmp_path_factory):
@@ -60,3 +62,17 @@ def seed_target_analysis_marker(session_dir: Path) -> Path:
         encoding="utf-8",
     )
     return path
+
+
+@pytest.fixture
+def session_dir(tmp_path, monkeypatch) -> Path:
+    """A fresh session dir under an isolated ``USER_DATA_PATH``, seeded with the
+    ``no_target_gpu_configured`` target-analysis marker.
+
+    Shared across the test package; individual modules may still shadow it with
+    a local fixture when they need different seeding.
+    """
+    monkeypatch.setenv("USER_DATA_PATH", str(tmp_path))
+    sd = make_session_dir()
+    seed_target_analysis_marker(sd)
+    return sd

--- a/inference_optimizer/tests/test_coordinator_async_batch2_unit.py
+++ b/inference_optimizer/tests/test_coordinator_async_batch2_unit.py
@@ -24,16 +24,6 @@ from inference_optimizer.protocol.intent import Intent, IntentType
 from inference_optimizer.paths import make_session_dir
 
 
-@pytest.fixture
-def session_dir(tmp_path, monkeypatch) -> Path:
-    monkeypatch.setenv("USER_DATA_PATH", str(tmp_path))
-    sd = make_session_dir()
-    from .conftest import seed_target_analysis_marker
-
-    seed_target_analysis_marker(sd)
-    return sd
-
-
 def _heartbeat() -> Intent:
     return Intent(type=IntentType.SEND_MESSAGE, payload={"topic": "heartbeat", "body_md": "ok"})
 

--- a/inference_optimizer/tests/test_coordinator_async_methods_coverage_unit.py
+++ b/inference_optimizer/tests/test_coordinator_async_methods_coverage_unit.py
@@ -20,17 +20,6 @@ from inference_optimizer.orchestrator.backends import (
 from inference_optimizer.orchestrator.coordinator import Coordinator
 from inference_optimizer.orchestrator.task_registry import Task
 from inference_optimizer.protocol.intent import Intent, IntentType
-from inference_optimizer.paths import make_session_dir
-
-
-@pytest.fixture
-def session_dir(tmp_path, monkeypatch) -> Path:
-    monkeypatch.setenv("USER_DATA_PATH", str(tmp_path))
-    sd = make_session_dir()
-    from .conftest import seed_target_analysis_marker
-
-    seed_target_analysis_marker(sd)
-    return sd
 
 
 def _heartbeat() -> Intent:

--- a/inference_optimizer/tests/test_coordinator_runtime.py
+++ b/inference_optimizer/tests/test_coordinator_runtime.py
@@ -35,20 +35,8 @@ from inference_optimizer.orchestrator.resource_lock import (
     ResourceLockManager,
     SqliteLeaseBackend,
 )
-from inference_optimizer.paths import make_session_dir
 from inference_optimizer.session_paths import target_baseline_json
 from inference_optimizer.storage import SqliteConnection
-
-
-# fixtures
-@pytest.fixture
-def session_dir(tmp_path, monkeypatch) -> Path:
-    monkeypatch.setenv("USER_DATA_PATH", str(tmp_path))
-    sd = make_session_dir()
-    from .conftest import seed_target_analysis_marker
-
-    seed_target_analysis_marker(sd)
-    return sd
 
 
 def _heartbeat() -> Intent:

--- a/inference_optimizer/tests/test_coordinator_sync_helpers_coverage_unit.py
+++ b/inference_optimizer/tests/test_coordinator_sync_helpers_coverage_unit.py
@@ -19,17 +19,6 @@ from inference_optimizer.orchestrator.backends import (
 )
 from inference_optimizer.orchestrator.coordinator import Coordinator
 from inference_optimizer.protocol.intent import Intent, IntentType
-from inference_optimizer.paths import make_session_dir
-
-
-@pytest.fixture
-def session_dir(tmp_path, monkeypatch) -> Path:
-    monkeypatch.setenv("USER_DATA_PATH", str(tmp_path))
-    sd = make_session_dir()
-    from .conftest import seed_target_analysis_marker
-
-    seed_target_analysis_marker(sd)
-    return sd
 
 
 def _heartbeat() -> Intent:

--- a/inference_optimizer/tests/test_critic_agent_backend.py
+++ b/inference_optimizer/tests/test_critic_agent_backend.py
@@ -1157,7 +1157,6 @@ from inference_optimizer.orchestrator.backends import (
 )
 from inference_optimizer.orchestrator.coordinator import Coordinator
 from inference_optimizer.protocol.intent import Intent, IntentType
-from inference_optimizer.paths import make_session_dir
 
 
 pytestmark = pytest.mark.critic_agent_e2e
@@ -1227,17 +1226,6 @@ class _DeterministicClient:
     def __init__(self):
         self.completions = _DeterministicCompletions()
         self.chat = _DeterministicChat(self.completions)
-
-
-# Fixtures
-@pytest.fixture
-def session_dir(tmp_path, monkeypatch) -> Path:
-    monkeypatch.setenv("USER_DATA_PATH", str(tmp_path))
-    sd = make_session_dir()
-    from .conftest import seed_target_analysis_marker
-
-    seed_target_analysis_marker(sd)
-    return sd
 
 
 @pytest.fixture

--- a/inference_optimizer/tests/test_e2e_mock.py
+++ b/inference_optimizer/tests/test_e2e_mock.py
@@ -17,18 +17,6 @@ from inference_optimizer.orchestrator.backends import (
 )
 from inference_optimizer.orchestrator.coordinator import Coordinator
 from inference_optimizer.protocol.intent import Intent, IntentType
-from inference_optimizer.paths import make_session_dir
-
-
-# fixtures
-@pytest.fixture
-def session_dir(tmp_path, monkeypatch) -> Path:
-    monkeypatch.setenv("USER_DATA_PATH", str(tmp_path))
-    sd = make_session_dir()
-    from .conftest import seed_target_analysis_marker
-
-    seed_target_analysis_marker(sd)
-    return sd
 
 
 def _heartbeat() -> Intent:

--- a/inference_optimizer/tests/test_framework_agent_critic_gate.py
+++ b/inference_optimizer/tests/test_framework_agent_critic_gate.py
@@ -21,18 +21,7 @@ from inference_optimizer.orchestrator.backends import (
     ScriptedPlan,
 )
 from inference_optimizer.orchestrator.coordinator import Coordinator, PendingProposal
-from inference_optimizer.paths import make_session_dir
 from inference_optimizer.protocol.intent import Intent, IntentType
-
-
-@pytest.fixture
-def session_dir(tmp_path, monkeypatch) -> Path:
-    monkeypatch.setenv("USER_DATA_PATH", str(tmp_path))
-    sd = make_session_dir()
-    from .conftest import seed_target_analysis_marker
-
-    seed_target_analysis_marker(sd)
-    return sd
 
 
 def _heartbeat() -> Intent:

--- a/inference_optimizer/tests/test_framework_agent_executor.py
+++ b/inference_optimizer/tests/test_framework_agent_executor.py
@@ -13,6 +13,8 @@ from unittest.mock import patch
 
 import pytest
 
+from .conftest import init_git_repo
+
 from inference_optimizer.orchestrator.action_executors.framework_agent import (
     FrameworkAgentExecutor,
     _candidate_slug,
@@ -27,33 +29,6 @@ from inference_optimizer.orchestrator.task_registry import Task
 
 
 # Helpers
-def _init_git_repo(path: Path) -> None:
-    path.mkdir(parents=True, exist_ok=True)
-    env = os.environ.copy()
-    env["GIT_AUTHOR_NAME"] = "FRAMEWORK Test"
-    env["GIT_AUTHOR_EMAIL"] = "fw-pr@test.local"
-    env["GIT_COMMITTER_NAME"] = env["GIT_AUTHOR_NAME"]
-    env["GIT_COMMITTER_EMAIL"] = env["GIT_AUTHOR_EMAIL"]
-    subprocess.run(
-        ["git", "init", "-b", "main", str(path)],
-        check=True,
-        capture_output=True,
-        env=env,
-    )
-    (path / "src.py").write_text("def f():\n    return 1\n", encoding="utf-8")
-    subprocess.run(
-        ["git", "-C", str(path), "add", "."],
-        check=True,
-        capture_output=True,
-        env=env,
-    )
-    subprocess.run(
-        ["git", "-C", str(path), "commit", "-m", "init"],
-        check=True,
-        capture_output=True,
-        env=env,
-    )
-
 
 _VALID_PATCH = """\
 diff --git a/src.py b/src.py
@@ -168,7 +143,7 @@ async def test_executor_no_patch_when_no_source_at_all(tmp_path: Path):
     session_dir = tmp_path / "session"
     session_dir.mkdir()
     repo = tmp_path / "framework"
-    _init_git_repo(repo)
+    init_git_repo(repo)
     executor = FrameworkAgentExecutor(session_dir=session_dir)
     cand = {  # source-less candidate
         "repo": "sgl-project/sglang",
@@ -196,7 +171,7 @@ async def test_executor_no_patch_when_explicit_patches_all_missing(tmp_path: Pat
     session_dir = tmp_path / "session"
     session_dir.mkdir()
     repo = tmp_path / "framework"
-    _init_git_repo(repo)
+    init_git_repo(repo)
 
     executor = FrameworkAgentExecutor(session_dir=session_dir)
     cand = _make_candidate()  # carries a real diff_url
@@ -226,7 +201,7 @@ async def test_executor_apply_only_with_explicit_patch_succeeds(tmp_path: Path):
     session_dir = tmp_path / "session"
     session_dir.mkdir()
     repo = tmp_path / "framework"
-    _init_git_repo(repo)
+    init_git_repo(repo)
     patch_path = tmp_path / "p.patch"
     patch_path.write_text(_VALID_PATCH, encoding="utf-8")
 
@@ -258,7 +233,7 @@ async def test_executor_apply_failure_rolls_back(tmp_path: Path):
     session_dir = tmp_path / "session"
     session_dir.mkdir()
     repo = tmp_path / "framework"
-    _init_git_repo(repo)
+    init_git_repo(repo)
     patch_path = tmp_path / "bad.patch"
     patch_path.write_text(_BAD_PATCH, encoding="utf-8")
 
@@ -313,7 +288,7 @@ async def test_executor_fetch_failure_returns_fetch_failed(tmp_path: Path):
     session_dir = tmp_path / "session"
     session_dir.mkdir()
     repo = tmp_path / "framework"
-    _init_git_repo(repo)
+    init_git_repo(repo)
     executor = FrameworkAgentExecutor(session_dir=session_dir)
     cand = _make_candidate(
         diff_url=f"file://{tmp_path / 'missing-diff.patch'}",
@@ -350,7 +325,7 @@ async def test_executor_keep_when_delta_above_threshold(tmp_path: Path):
     session_dir = tmp_path / "session"
     session_dir.mkdir()
     repo = tmp_path / "framework"
-    _init_git_repo(repo)
+    init_git_repo(repo)
     patch_path = tmp_path / "p.patch"
     patch_path.write_text(_VALID_PATCH, encoding="utf-8")
 
@@ -395,7 +370,7 @@ async def test_executor_keep_writes_kb_lessons(tmp_path: Path, monkeypatch):
     session_dir = tmp_path / "session"
     session_dir.mkdir()
     repo = tmp_path / "framework"
-    _init_git_repo(repo)
+    init_git_repo(repo)
     patch_path = tmp_path / "p.patch"
     patch_path.write_text(_VALID_PATCH, encoding="utf-8")
 
@@ -443,7 +418,7 @@ async def test_executor_revert_writes_kb_lessons(tmp_path: Path, monkeypatch):
     session_dir = tmp_path / "session"
     session_dir.mkdir()
     repo = tmp_path / "framework"
-    _init_git_repo(repo)
+    init_git_repo(repo)
     patch_path = tmp_path / "p.patch"
     patch_path.write_text(_VALID_PATCH, encoding="utf-8")
 
@@ -486,7 +461,7 @@ async def test_executor_revert_when_delta_below_threshold(tmp_path: Path):
     session_dir = tmp_path / "session"
     session_dir.mkdir()
     repo = tmp_path / "framework"
-    _init_git_repo(repo)
+    init_git_repo(repo)
     patch_path = tmp_path / "p.patch"
     patch_path.write_text(_VALID_PATCH, encoding="utf-8")
 
@@ -525,7 +500,7 @@ async def test_executor_revert_on_accuracy_regression(tmp_path: Path):
     session_dir = tmp_path / "session"
     session_dir.mkdir()
     repo = tmp_path / "framework"
-    _init_git_repo(repo)
+    init_git_repo(repo)
     patch_path = tmp_path / "p.patch"
     patch_path.write_text(_VALID_PATCH, encoding="utf-8")
 
@@ -562,7 +537,7 @@ async def test_executor_bench_exception_triggers_revert(tmp_path: Path):
     session_dir = tmp_path / "session"
     session_dir.mkdir()
     repo = tmp_path / "framework"
-    _init_git_repo(repo)
+    init_git_repo(repo)
     patch_path = tmp_path / "p.patch"
     patch_path.write_text(_VALID_PATCH, encoding="utf-8")
 
@@ -608,7 +583,7 @@ async def test_reject_after_keep_preserves_kept_changes(tmp_path: Path):
     session_dir = tmp_path / "session"
     session_dir.mkdir()
     repo = tmp_path / "framework"
-    _init_git_repo(repo)
+    init_git_repo(repo)
 
     patch_a = tmp_path / "a.patch"
     patch_a.write_text(_VALID_PATCH, encoding="utf-8")
@@ -670,7 +645,7 @@ async def test_apply_failure_after_keep_preserves_kept_changes(tmp_path: Path):
     session_dir = tmp_path / "session"
     session_dir.mkdir()
     repo = tmp_path / "framework"
-    _init_git_repo(repo)
+    init_git_repo(repo)
 
     patch_a = tmp_path / "a.patch"
     patch_a.write_text(_VALID_PATCH, encoding="utf-8")
@@ -870,7 +845,7 @@ async def test_executor_keep_adds_new_file_pr(tmp_path: Path):
     session_dir = tmp_path / "session"
     session_dir.mkdir()
     repo = tmp_path / "framework"
-    _init_git_repo(repo)
+    init_git_repo(repo)
     patch_path = tmp_path / "add.patch"
     patch_path.write_text(_PATCH_B_ADDS_FILE, encoding="utf-8")
 
@@ -914,7 +889,7 @@ async def test_executor_cross_repo_disables_checkout_head(tmp_path: Path):
     session_dir = tmp_path / "session"
     session_dir.mkdir()
     repo = tmp_path / "framework"
-    _init_git_repo(repo)
+    init_git_repo(repo)
     subprocess.run(
         ["git", "-C", str(repo), "remote", "add", "origin", "https://github.com/sgl-project/sglang.git"],
         check=True,
@@ -1040,7 +1015,7 @@ async def test_executor_require_accuracy_blocks_keep_when_unevaluated(tmp_path: 
     session_dir = tmp_path / "session"
     session_dir.mkdir()
     repo = tmp_path / "framework"
-    _init_git_repo(repo)
+    init_git_repo(repo)
     patch_path = tmp_path / "p.patch"
     patch_path.write_text(_VALID_PATCH, encoding="utf-8")
 
@@ -1079,7 +1054,7 @@ async def test_executor_require_accuracy_degrades_without_baseline(tmp_path: Pat
     session_dir = tmp_path / "session"
     session_dir.mkdir()
     repo = tmp_path / "framework"
-    _init_git_repo(repo)
+    init_git_repo(repo)
     patch_path = tmp_path / "p.patch"
     patch_path.write_text(_VALID_PATCH, encoding="utf-8")
 

--- a/inference_optimizer/tests/test_framework_agent_reauthor.py
+++ b/inference_optimizer/tests/test_framework_agent_reauthor.py
@@ -22,18 +22,7 @@ from inference_optimizer.orchestrator.backends import (
     ScriptedPlan,
 )
 from inference_optimizer.orchestrator.coordinator import Coordinator, PendingProposal
-from inference_optimizer.paths import make_session_dir
 from inference_optimizer.protocol.intent import Intent, IntentType
-
-
-@pytest.fixture
-def session_dir(tmp_path, monkeypatch) -> Path:
-    monkeypatch.setenv("USER_DATA_PATH", str(tmp_path))
-    sd = make_session_dir()
-    from .conftest import seed_target_analysis_marker
-
-    seed_target_analysis_marker(sd)
-    return sd
 
 
 def _heartbeat() -> Intent:

--- a/inference_optimizer/tests/test_framework_agent_selection_audit_coverage_unit.py
+++ b/inference_optimizer/tests/test_framework_agent_selection_audit_coverage_unit.py
@@ -25,18 +25,7 @@ from inference_optimizer.orchestrator import phase_state as ps_mod
 from inference_optimizer.orchestrator.action_executors import framework_agent as fpr_mod
 from inference_optimizer.orchestrator.backends import Backend, MockBackend, ScriptedPlan
 from inference_optimizer.orchestrator.coordinator import Coordinator
-from inference_optimizer.paths import make_session_dir
 from inference_optimizer.protocol.intent import Intent, IntentType
-
-
-@pytest.fixture
-def session_dir(tmp_path, monkeypatch) -> Path:
-    monkeypatch.setenv("USER_DATA_PATH", str(tmp_path))
-    sd = make_session_dir()
-    from .conftest import seed_target_analysis_marker
-
-    seed_target_analysis_marker(sd)
-    return sd
 
 
 def _heartbeat() -> Intent:

--- a/inference_optimizer/tests/test_integrate_patch_executor.py
+++ b/inference_optimizer/tests/test_integrate_patch_executor.py
@@ -5,12 +5,13 @@
 from __future__ import annotations
 
 import json
-import os
 import subprocess
 from pathlib import Path
 from typing import Any
 
 import pytest
+
+from .conftest import init_git_repo
 
 from inference_optimizer.orchestrator.action_executors.integrate_patch import (
     IntegratePatchExecutor,
@@ -27,33 +28,6 @@ from inference_optimizer.orchestrator.task_registry import Task
 
 
 # Helpers
-def _init_git_repo(path: Path) -> None:
-    path.mkdir(parents=True, exist_ok=True)
-    env = os.environ.copy()
-    env["GIT_AUTHOR_NAME"] = "PR-A4 Test"
-    env["GIT_AUTHOR_EMAIL"] = "pr-a4@test.local"
-    env["GIT_COMMITTER_NAME"] = env["GIT_AUTHOR_NAME"]
-    env["GIT_COMMITTER_EMAIL"] = env["GIT_AUTHOR_EMAIL"]
-    subprocess.run(
-        ["git", "init", "-b", "main", str(path)],
-        check=True,
-        capture_output=True,
-        env=env,
-    )
-    (path / "src.py").write_text("def f():\n    return 1\n", encoding="utf-8")
-    subprocess.run(
-        ["git", "-C", str(path), "add", "."],
-        check=True,
-        capture_output=True,
-        env=env,
-    )
-    subprocess.run(
-        ["git", "-C", str(path), "commit", "-m", "init"],
-        check=True,
-        capture_output=True,
-        env=env,
-    )
-
 
 _VALID_PATCH = """\
 diff --git a/src.py b/src.py
@@ -227,7 +201,7 @@ def test_resolve_patch_paths_respects_empty_done_list(tmp_path: Path):
 # 2. git apply primitives
 def test_git_apply_succeeds_on_valid_patch(tmp_path: Path):
     repo = tmp_path / "repo"
-    _init_git_repo(repo)
+    init_git_repo(repo)
     patch = tmp_path / "valid.patch"
     patch.write_text(_VALID_PATCH, encoding="utf-8")
     ok, err = _git_apply(repo, patch)
@@ -237,7 +211,7 @@ def test_git_apply_succeeds_on_valid_patch(tmp_path: Path):
 
 def test_git_apply_fails_on_bad_patch(tmp_path: Path):
     repo = tmp_path / "repo"
-    _init_git_repo(repo)
+    init_git_repo(repo)
     patch = tmp_path / "bad.patch"
     patch.write_text(_BAD_PATCH, encoding="utf-8")
     ok, err = _git_apply(repo, patch)
@@ -247,7 +221,7 @@ def test_git_apply_fails_on_bad_patch(tmp_path: Path):
 
 def test_git_apply_reverse_rolls_back(tmp_path: Path):
     repo = tmp_path / "repo"
-    _init_git_repo(repo)
+    init_git_repo(repo)
     patch = tmp_path / "valid.patch"
     patch.write_text(_VALID_PATCH, encoding="utf-8")
     _git_apply(repo, patch)
@@ -278,7 +252,7 @@ def _deep_prefix_patch(depth: int) -> str:
 
 def test_git_apply_auto_detects_deep_p_level(tmp_path: Path):
     repo = tmp_path / "repo"
-    _init_git_repo(repo)
+    init_git_repo(repo)
     # ``b/d0/.../d6/src.py`` needs -p7 (1 for ``b/`` + 6 for d0..d5).
     patch = tmp_path / "deep.patch"
     patch.write_text(_deep_prefix_patch(6), encoding="utf-8")
@@ -294,7 +268,7 @@ def test_git_apply_auto_detects_deep_p_level(tmp_path: Path):
 # 3. Framework root resolution
 def test_resolve_framework_root_picks_explicit_when_dir(tmp_path: Path):
     repo = tmp_path / "repo"
-    _init_git_repo(repo)
+    init_git_repo(repo)
     root = _resolve_framework_root(str(repo))
     assert root is not None
     assert root.samefile(repo)
@@ -319,7 +293,7 @@ async def test_executor_apply_only_succeeds(tmp_path: Path):
     session_dir = tmp_path / "session"
     session_dir.mkdir()
     repo = tmp_path / "framework"
-    _init_git_repo(repo)
+    init_git_repo(repo)
     workspace = _write_specialist_workspace(
         session_dir,
         "t-spec-1",
@@ -349,7 +323,7 @@ async def test_executor_apply_failure_rolls_back(tmp_path: Path):
     session_dir = tmp_path / "session"
     session_dir.mkdir()
     repo = tmp_path / "framework"
-    _init_git_repo(repo)
+    init_git_repo(repo)
     workspace = _write_specialist_workspace(
         session_dir,
         "t-spec-2",
@@ -379,7 +353,7 @@ async def test_executor_missing_target_preflight_short_circuits(tmp_path: Path):
     session_dir = tmp_path / "session"
     session_dir.mkdir()
     repo = tmp_path / "framework"
-    _init_git_repo(repo)
+    init_git_repo(repo)
     _write_specialist_workspace(
         session_dir,
         "t-spec-miss",
@@ -420,7 +394,7 @@ async def test_executor_multi_node_skips_neutrally(tmp_path: Path, monkeypatch):
     session_dir = tmp_path / "session"
     session_dir.mkdir()
     repo = tmp_path / "framework"
-    _init_git_repo(repo)
+    init_git_repo(repo)
     _write_specialist_workspace(
         session_dir,
         "t-spec-mn",
@@ -464,7 +438,7 @@ async def test_executor_single_node_guard_not_triggered(tmp_path: Path, monkeypa
     session_dir = tmp_path / "session"
     session_dir.mkdir()
     repo = tmp_path / "framework"
-    _init_git_repo(repo)
+    init_git_repo(repo)
     _write_specialist_workspace(
         session_dir,
         "t-spec-sn",

--- a/inference_optimizer/tests/test_mock_backends.py
+++ b/inference_optimizer/tests/test_mock_backends.py
@@ -17,18 +17,6 @@ from inference_optimizer.orchestrator.backends import (
 )
 from inference_optimizer.orchestrator.coordinator import Coordinator
 from inference_optimizer.protocol.intent import Intent, IntentType
-from inference_optimizer.paths import make_session_dir
-
-
-# fixtures
-@pytest.fixture
-def session_dir(tmp_path, monkeypatch) -> Path:
-    monkeypatch.setenv("USER_DATA_PATH", str(tmp_path))
-    sd = make_session_dir()
-    from .conftest import seed_target_analysis_marker
-
-    seed_target_analysis_marker(sd)
-    return sd
 
 
 def _heartbeat() -> Intent:

--- a/inference_optimizer/tests/test_payload_aliases.py
+++ b/inference_optimizer/tests/test_payload_aliases.py
@@ -13,7 +13,6 @@ from inference_optimizer.compat.payload_aliases import (
     LEGACY_KEY,
     migrate_legacy_key_in_place,
     read_extra_server_args,
-    read_extra_server_args_from_envs,
 )
 
 
@@ -139,28 +138,6 @@ def test_deprecation_stacklevel_points_at_caller():
     )
 
 
-# Envs variant — same contract on the materializer-side dict
-def test_envs_variant_canonical_returned_without_warning():
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        out = read_extra_server_args_from_envs({CANONICAL_KEY: "v"})
-    assert out == "v"
-    assert [w for w in caught if issubclass(w.category, DeprecationWarning)] == []
-
-
-def test_envs_variant_legacy_emits_warning():
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        out = read_extra_server_args_from_envs({LEGACY_KEY: "v"})
-    assert out == "v"
-    dep_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
-    assert len(dep_warnings) == 1
-
-
-def test_envs_variant_default():
-    assert read_extra_server_args_from_envs({}, default="z") == "z"
-
-
 # migrate_legacy_key_in_place
 def test_migrate_legacy_only_moves_value_and_returns_true():
     """Legacy key only → copied to canonical, legacy deleted, True."""
@@ -200,7 +177,6 @@ def test_public_api_exports_match_all():
         "CANONICAL_KEY",
         "LEGACY_KEY",
         "read_extra_server_args",
-        "read_extra_server_args_from_envs",
         "migrate_legacy_key_in_place",
     }
     assert set(pa.__all__) == expected
@@ -211,5 +187,4 @@ def test_compat_package_importable():
     from inference_optimizer.compat import payload_aliases as imported
 
     assert callable(imported.read_extra_server_args)
-    assert callable(imported.read_extra_server_args_from_envs)
     assert callable(imported.migrate_legacy_key_in_place)

--- a/inference_optimizer/tests/test_resume.py
+++ b/inference_optimizer/tests/test_resume.py
@@ -27,17 +27,6 @@ from inference_optimizer.orchestrator.shared_state import SharedState
 from inference_optimizer.paths import make_session_dir
 
 
-# fixtures
-@pytest.fixture
-def session_dir(tmp_path, monkeypatch) -> Path:
-    monkeypatch.setenv("USER_DATA_PATH", str(tmp_path))
-    sd = make_session_dir()
-    from .conftest import seed_target_analysis_marker
-
-    seed_target_analysis_marker(sd)
-    return sd
-
-
 def _heartbeat() -> Intent:
     return Intent(type=IntentType.SEND_MESSAGE, payload={"topic": "heartbeat", "body_md": "ok"})
 

--- a/inference_optimizer/tests/test_specialist_subprocess.py
+++ b/inference_optimizer/tests/test_specialist_subprocess.py
@@ -20,6 +20,8 @@ from typing import Any
 
 import pytest
 
+from .conftest import init_git_repo
+
 from inference_optimizer.orchestrator.specialist_runner import (
     DEFAULT_SPECIALIST_TOOLS,
     SPECIALIST_TOOL_DENYLIST,
@@ -36,34 +38,6 @@ from inference_optimizer.orchestrator.task_registry import Task
 
 
 # Fixtures
-def _init_git_repo(path: Path) -> None:
-    """Initialise a minimal git repo with one commit so ``git worktree add`` can branch off it."""
-    path.mkdir(parents=True, exist_ok=True)
-    env = os.environ.copy()
-    env["GIT_AUTHOR_NAME"] = "PR-A2 Test"
-    env["GIT_AUTHOR_EMAIL"] = "pr-a2@test.local"
-    env["GIT_COMMITTER_NAME"] = env["GIT_AUTHOR_NAME"]
-    env["GIT_COMMITTER_EMAIL"] = env["GIT_AUTHOR_EMAIL"]
-    subprocess.run(
-        ["git", "init", "-b", "main", str(path)],
-        check=True,
-        capture_output=True,
-        env=env,
-    )
-    (path / "README.md").write_text("# pr-a2 test repo\n", encoding="utf-8")
-    subprocess.run(
-        ["git", "-C", str(path), "add", "."],
-        check=True,
-        capture_output=True,
-        env=env,
-    )
-    subprocess.run(
-        ["git", "-C", str(path), "commit", "-m", "init"],
-        check=True,
-        capture_output=True,
-        env=env,
-    )
-
 
 def _make_fake_claude(
     bin_dir: Path,
@@ -215,7 +189,7 @@ exit 3
 @pytest.fixture
 def fake_framework_repo(tmp_path: Path) -> Path:
     repo = tmp_path / "framework"
-    _init_git_repo(repo)
+    init_git_repo(repo)
     return repo
 
 


### PR DESCRIPTION


A systematic, evidence-based redundancy sweep across the Hyperloom
sub-agent packages. Duplicated functions were surfaced with an AST
structural-duplicate scanner (fingerprints function bodies after
abstracting identifiers/literals but keeping control flow), verified by
reading each candidate, and merged **only when the merge genuinely
reduces production code** (net non-test reduction `> 10` lines per merge).
Every saving comes from collapsing duplicated *code paths* into one shared
helper — never from trimming comments or docstrings.

Behavior is unchanged throughout: duplicate/public/test-pinned names are
either kept as thin wrappers or updated at all call sites, and the
affected test suites pass after each change.

**Net effect (cumulative vs `origin/main`, measured via `git diff --numstat`):**

| Scope | Added | Removed | Net |
|---|---:|---:|---:|
| Production code | 495 | 906 | **−411** |
| Test code | 92 | 262 | **−170** |
| **Total** | **587** | **1168** | **−581** |

40 files changed across 13 commits.

### What each commit collapses

**inference_optimizer — production**

- `manifest.py`: extract `_git_capture(path, args)` from `_git_revision_at`
  / `_git_remote_at` (identical best-effort `git -C <path> ...` subprocess
  + timeout/error handling, differing only by the git subcommand).
- `cli.py`: consolidate the float/int env-default resolvers into
  `_env_num_or(default, env_var, cast)`; update the three explore-timeout
  option call sites. (Also repairs a `NameError` that broke `--help` and
  every `optimize` launch during parser construction.)
- `orchestrator/roofline_ceiling.py`, `objective.py`, `phase_state.py`:
  dedup three helper pairs forked along a single dimension
  (`_resolve_peak/achievable_tflops` → `_resolve_tflops`; two current-tput
  resolvers → `_resolve_current_tput`; allowed/proposable phase checks →
  `_action_in_phase_map`). Original names kept as thin wrappers.
- `orchestrator/trace/`: new dependency-free `_row_utils.py` centralizes
  `coerce_optional_str/int` and a parametrized `validate_closed_row(...)`;
  `conversation_trace`, `llm_trace`, `parse_usage` alias/wrap it.
- `orchestrator/backends/`: `extract_first_json_with_key(...)` moved into
  the shared `_json_io.py` (codex/critic_agent become one-line wrappers);
  `mcp_emit_intent` reuses `_resolve_sdk` instead of a private copy.
- `orchestrator/compat/payload_aliases.py`: delete dead duplicate
  `read_extra_server_args_from_envs` (identical body, zero call sites).
- `breakdown/collectors.py` + `exporter.py`: merge the run-dir scanners
  into `_scan_run_dirs(...)`; extract `_load_json(...)` (state/manifest
  loaders become wrappers).
- `recipe_kb/local_store.py`: collapse `_normalise_findings/failures/gaps/
  pitfalls` into `_normalise_str_dicts(items, keys)` (wrappers kept).
- `baseline_comparison/target_analyzer.py`: fold three near-identical
  no-data summary blocks into a local `_skip()` closure.
- `scripts/`: new `_roofline_audit_common.py` shares the state.json
  extraction logic between `audit_roofline_decisions` and
  `verify_roofline_v2`.

**critic-agent — production**

- `runtime/kb_writer.py`: merge `_read_int_env` / `_read_float_env` into
  `_read_num_env(name, default, cast)`; pass the constructor at both call
  sites.

**framework-agent — production**

- `explorer.py` / `runtime/tools_api.py`: single `_metric_float`
  implementation (the `Iterable[str]` form in `tools_api`); explorer
  imports it and its call sites/test use the tuple convention.

**Tests — deduplicated (coverage preserved)**

- Hoist a byte-identical `session_dir` fixture out of 11 modules into
  `tests/conftest.py` (auto-discovered).
- Share one `init_git_repo(path, *, seed_file, seed_text)` in `conftest`
  for the three modules that each re-implemented a ~25-line git-repo seeder.

## Linked issue(s): close/fix refs

_None — internal maintenance / tech-debt cleanup._

## Tests: added/updated? commands run?

No new behavior, so no new production tests. Duplicated tests were merged
(fixtures hoisted to `conftest.py`), keeping equivalent coverage. Each
merge was verified against its affected suite; commands run include:

```bash
pytest inference_optimizer/tests            # orchestrator/backends/breakdown/recipe_kb/scripts merges
pytest critic-agent/runtime/tests/test_kb_writer.py
pytest framework-agent/tests                # 212 passed
```

Pre-existing, unrelated failures observed during the sweep (present before
these changes): a missing-`markdownify` env issue in the full unit suite
and a missing-Magpie-module issue in `test_resume` — neither is introduced
or affected here.

## Breaking changes: yes/no

**No.** All public / exported / test-pinned names are preserved (kept as
thin wrappers or re-imported), call sites updated in lockstep, and the
observable session artifacts / subprocess JSON contracts are untouched.
