### PR TITLE
chore(kernel): remove dead functions from kernel-agent tools

### DIFF
--- a/kernel-agent/tests/test_flydsl_classification.py
+++ b/kernel-agent/tests/test_flydsl_classification.py
@@ -396,10 +396,6 @@ class TestOrchestratorReusableRootsInSync(unittest.TestCase):
             )
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class TestFlyDSLPseudoOpIdentification(unittest.TestCase):
     """PR #668 pseudo_op names must be classified as FlyDSL (matched by name prefix; no on-disk source)."""
 
@@ -418,13 +414,6 @@ class TestFlyDSLPseudoOpIdentification(unittest.TestCase):
     def test_generic_pseudo_op_flydsl_recognised(self) -> None:
         self.assertEqual(
             source_type_for("pseudo_op::flydsl_custom_kernel", ""),
-            "flydsl",
-        )
-
-    def test_pseudo_op_marker_wins_over_empty_source(self) -> None:
-        """Empty source_file must not block the name-based match."""
-        self.assertEqual(
-            source_type_for("pseudo_op::moe_flydsl_stage1", ""),
             "flydsl",
         )
 
@@ -466,3 +455,7 @@ class TestPseudoOpSourceFallback(unittest.TestCase):
         cand = {"source_file": "aiter/fused_moe.py(986): fused_moe_2stages"}
         out = self.mod._resolve_source_file("/no/such/file.py", cand, "k004")
         self.assertEqual(out, "aiter/fused_moe.py(986): fused_moe_2stages")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/kernel-agent/tests/test_kernel_agent.py
+++ b/kernel-agent/tests/test_kernel_agent.py
@@ -114,6 +114,7 @@ class UpdateStatusTimingTests(unittest.TestCase):
             TRACE_TOOL,
         )
         mod = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = mod
         spec.loader.exec_module(mod)  # type: ignore[union-attr]
         return mod
 
@@ -916,15 +917,6 @@ class GeakCostLimitDefaultTests(unittest.TestCase):
 
     def test_env_var_overrides_default(self) -> None:
         """HYPERLOOM_GEAK_COST_LIMIT must override the argparse default."""
-        env = {**os.environ, "HYPERLOOM_GEAK_COST_LIMIT": "12.5"}
-        probe = (
-            "import sys, re, runpy\n"
-            f"sys.argv = ['kernel_optimization.py', '--help']\n"
-            "try:\n"
-            f"    runpy.run_path(r'{OPT_TOOL}', run_name='__main__')\n"
-            "except SystemExit:\n"
-            "    pass\n"
-        )
         # AST fallback: evaluate the default expression in a controlled namespace.
         import ast
 

--- a/kernel-agent/tools/backends/forge_submit.py
+++ b/kernel-agent/tools/backends/forge_submit.py
@@ -11,8 +11,9 @@ artifact later). Emits the same artifacts every other backend does:
   <output_dir>/optimized_versions/v1_forge.<ext>   complete replaceable source
   <output_dir>/optimization_report.md              [micro_speedup] Nx + [correctness] pass
 
-Stage 1 scope: triton / JIT kernels only (no separate build step). Compiled
-backends (hip/ck/flydsl) need a build step and are deferred.
+Scope: Triton/Python kernels use the triton fellow. Compiled kernels
+(HIP/CK/aiter/hipBLASLt/FlyDSL) are also attempted when Kernel-Forge has a
+matching fellow; compile-only drivers are skipped unless explicitly allowed.
 
 Design ref: claw-dev/docs-zh/forge-as-hyperloom-backend-integration.md
 """

--- a/kernel-agent/tools/backends/geak_submit.py
+++ b/kernel-agent/tools/backends/geak_submit.py
@@ -409,12 +409,12 @@ def submit(
     kernel_repo: str = "",
     test_command: str = "",
 ) -> dict:
-    """Submit a GEAK run, preferring Ray with a CLI fallback.
+    """Submit a GEAK run, preferring SSH/Ray placement.
 
     Ensures the output directory exists, then (when ``prefer_ray``)
     starts/attaches to a Ray cluster and runs via :func:`run_via_ray`,
-    falling back to a structured error dict on any Ray failure. When Ray
-    is not preferred, runs via :func:`run_via_cli`.
+    returning a structured error dict on Ray failure. When Ray is not
+    preferred, runs via :func:`run_via_cli`.
 
     Args:
         prompt_file (Path): Task prompt file passed to GEAK.

--- a/kernel-agent/tools/backends/oob_submit.py
+++ b/kernel-agent/tools/backends/oob_submit.py
@@ -487,7 +487,7 @@ def submit(
     extra_files: list[str] | None = None,
     kernel_repo: str = "",
 ) -> dict:
-    """Submit an OOB run, preferring Ray with a CLI fallback.
+    """Submit an OOB run, preferring SSH/Ray placement.
 
     Ensures the output directory exists, then (when ``prefer_ray``)
     starts/attaches to a Ray cluster and runs via :func:`run_via_ray`,

--- a/kernel-agent/tools/backends/perfskills_runner.py
+++ b/kernel-agent/tools/backends/perfskills_runner.py
@@ -27,8 +27,6 @@ import subprocess
 import time
 from pathlib import Path
 
-HANDOFF_SCHEMA_VERSION = 1
-
 
 def _resolve_runner() -> str:
     """Resolve run_e2e.py from $PERFSKILLS_E2E_RUNNER / $PERFSKILLS_ROOT (GEAK@GEAK_v4)."""
@@ -46,68 +44,12 @@ def _resolve_runner() -> str:
     )
 
 
-def build_handoff(
-    *,
-    model_path: str,
-    framework: str,
-    gpu_type: str,
-    tp: int,
-    workload: dict,
-    accepted_flags: str = "",
-    accepted_env: str = "",
-    launch_recipe: str = "",
-    raw_baseline_tput: float = 0.0,
-    exp_root: str,
-    gpu_ids: str = "",
-    bench_client: str = "auto",
-    inferencex_path: str = "",
-    bench_protocol: dict | None = None,
-) -> dict:
-    """Assemble the stable handoff.json payload (Hyperloom -> PerfSkills).
-
-    ``bench_protocol`` (optional) forwards Hyperloom's measurement 口径
-    (``random_range_ratio`` / ``num_prompts`` / ``num_warmups`` / ``seed``) so
-    PerfSkills' internal e2e bench measures identically. Omit it (or omit any
-    key) to leave PerfSkills on its own standalone defaults.
-    """
-    h = {
-        "schema_version": HANDOFF_SCHEMA_VERSION,
-        "model_path": model_path,
-        "framework": framework or "sglang",
-        "gpu_type": gpu_type or "",
-        "tp": int(tp or 1),
-        "workload": {
-            "isl": int(workload.get("isl", 1024)),
-            "osl": int(workload.get("osl", 1024)),
-            "conc": int(workload.get("conc", 64)),
-        },
-        "accepted_flags": accepted_flags or "",
-        "accepted_env": accepted_env or "",
-        "raw_baseline_tput": float(raw_baseline_tput or 0.0),
-        "exp_root": exp_root,
-        # Use the SAME bench client as Hyperloom (InferenceX benchmark_serving.py)
-        # so PerfSkills numbers are cross-harness comparable. "auto" lets the
-        # runner pick inferencex when an InferenceX checkout is discoverable.
-        "bench_client": bench_client or "auto",
-        "inferencex_path": inferencex_path or os.environ.get("INFERENCEX_PATH", ""),
-    }
-    if launch_recipe:
-        h["launch_recipe"] = launch_recipe
-    if gpu_ids:
-        h["gpu_ids"] = gpu_ids
-    if bench_protocol:
-        # Drop empty/None values so only resolved knobs are forwarded.
-        h["bench_protocol"] = {k: v for k, v in dict(bench_protocol).items()
-                               if v is not None and str(v).strip() != ""}
-    return h
-
-
 def call_perfskills(handoff: dict, output_dir: Path, *, timeout_s: int = 43200,
                     python_bin: str = "") -> dict:
     """Run PerfSkills e2e once and return the parsed result.json (+ run metadata).
 
     Args:
-        handoff: handoff payload (see :func:`build_handoff`).
+        handoff: handoff.json payload (Hyperloom best config + workload).
         output_dir: where handoff.json / result.json are written.
         timeout_s: subprocess timeout (default 12h).
         python_bin: python interpreter for the runner (default the current one).

--- a/kernel-agent/tools/harness_generator.py
+++ b/kernel-agent/tools/harness_generator.py
@@ -41,25 +41,6 @@ class FuncInfo:
 
 
 @dataclass
-class TensorInfo:
-    """A tensor-creating assignment extracted from a function body.
-
-    Attributes:
-        var_name (str): Name of the assigned variable.
-        creation_expr (str): The unparsed creation expression (e.g.
-            ``torch.randn(M, N, dtype=...)``).
-        shape_args (list[str]): Unparsed positional shape args plus any
-            non-device keyword args.
-        dtype_expr (str | None): The unparsed ``dtype=`` expression, or
-            ``None`` when not specified.
-    """
-    var_name: str
-    creation_expr: str
-    shape_args: list[str]
-    dtype_expr: str | None
-
-
-@dataclass
 class CallInfo:
     """A captured call site and its arguments.
 
@@ -253,62 +234,6 @@ class BenchmarkAnalyzer:
                         lineno=node.lineno,
                     )
         return None
-
-    def extract_tensor_creation(self, func: FuncInfo) -> list[TensorInfo]:
-        """Extract torch.randn/empty/zeros/ones calls from a function.
-
-        Args:
-            func (FuncInfo): The function whose body is scanned for
-                tensor-creating assignments.
-
-        Returns:
-            list[TensorInfo]: One :class:`TensorInfo` per recognised
-                tensor-creation assignment; empty if the body fails to
-                parse or contains none.
-        """
-        results: list[TensorInfo] = []
-        try:
-            func_tree = ast.parse(textwrap.dedent(func.source))
-        except SyntaxError:
-            return results
-
-        for node in ast.walk(func_tree):
-            if not isinstance(node, ast.Assign):
-                continue
-            if not isinstance(node.value, ast.Call):
-                continue
-            call = node.value
-            func_name = self._call_func_name(call)
-            if func_name not in (
-                "torch.randn", "torch.empty", "torch.zeros",
-                "torch.ones", "torch.rand", "torch.empty_like",
-                "torch.randn_like",
-            ):
-                continue
-            target = node.targets[0]
-            if isinstance(target, ast.Name):
-                var_name = target.id
-            else:
-                continue
-
-            shape_args = []
-            dtype_expr = None
-            for arg in call.args:
-                shape_args.append(ast.unparse(arg))
-            for kw in call.keywords:
-                if kw.arg == "dtype":
-                    dtype_expr = ast.unparse(kw.value)
-                elif kw.arg not in ("device",):
-                    shape_args.append(f"{kw.arg}={ast.unparse(kw.value)}")
-
-            creation_expr = ast.unparse(node.value)
-            results.append(TensorInfo(
-                var_name=var_name,
-                creation_expr=creation_expr,
-                shape_args=shape_args,
-                dtype_expr=dtype_expr,
-            ))
-        return results
 
     def extract_call_to(self, func: FuncInfo, callee_name: str) -> CallInfo | None:
         """Find a call to callee_name within func's body and extract its args.

--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -933,22 +933,6 @@ def _shape_case_from_value(
     }
 
 
-def _safe_float(value: Any, default: float = 0.0) -> float:
-    """Coerce a TraceLens numeric field, returning ``default`` on drift.
-
-    Args:
-        value: The value to coerce to ``float``.
-        default: Fallback returned when ``value`` cannot be parsed.
-
-    Returns:
-        The parsed float, or ``default`` on any failure.
-    """
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return default
-
-
 def _structured_benchmark_shape_cases(candidate: dict[str, Any]) -> dict[str, Any]:
     """Expose primary/supplementary serving shapes in machine-readable form.
 
@@ -2888,27 +2872,6 @@ def _forge_output_dir(session_id: str, prompt_file: Path) -> Path:
     return out
 
 
-def _mirror_path_link(run_dir: Path, mirror: Path) -> None:
-    """Create a relative symlink inside the run dir pointing at the mirror.
-
-    Best-effort: failures (unsupported filesystem, existing link) are
-    swallowed so artifact mirroring never breaks a run.
-
-    Args:
-        run_dir (Path): The run directory the symlink is created under.
-        mirror (Path): The target directory the symlink should point at.
-    """
-    try:
-        link_dir = run_dir / mirror.parent.name  # geak / oob
-        link_dir.mkdir(parents=True, exist_ok=True)
-        link = link_dir / mirror.name
-        if link.exists() or link.is_symlink():
-            return
-        link.symlink_to(mirror, target_is_directory=True)
-    except OSError:
-        pass
-
-
 def _git_checkout_fallback(kernel_repo: str, log_path: Path) -> None:
     """Run a best-effort ``git checkout -- .`` to undo rogue agent writes.
 
@@ -3248,23 +3211,6 @@ def invoke_backend(
         # dirty-file state that forge just carefully restored.
         if log_path is not None and backend != "forge":
             _git_checkout_fallback(kernel_repo, log_path)
-
-
-def env_first(*names: str) -> str:
-    """Return the first non-empty environment variable among ``names``.
-
-    Args:
-        *names (str): Environment variable names to check, in priority order.
-
-    Returns:
-        str: The value of the first set, non-empty variable, or an empty
-            string when none are set.
-    """
-    for name in names:
-        value = os.environ.get(name)
-        if value:
-            return value
-    return ""
 
 
 def run_attempt(

--- a/kernel-agent/tools/kernel_optimization.py
+++ b/kernel-agent/tools/kernel_optimization.py
@@ -2900,6 +2900,19 @@ def _git_checkout_fallback(kernel_repo: str, log_path: Path) -> None:
         append_log(log_path, f"[git-fallback] failed: {type(exc).__name__}: {exc}")
 
 
+def _merge_rocprof_before(result: dict[str, Any], rocprof_before: dict[str, Any]) -> None:
+    """Copy pre-optimization rocprof metadata into a backend result."""
+    if not rocprof_before:
+        return
+    result["rocprof_before_kernel_opt_status"] = str(rocprof_before.get("status") or "")
+    if rocprof_before.get("reason"):
+        result["rocprof_before_kernel_opt_reason"] = str(rocprof_before["reason"])
+    if rocprof_before.get("json_path"):
+        result["rocprof_before_kernel_opt_json"] = str(rocprof_before["json_path"])
+    if rocprof_before.get("txt_path"):
+        result["rocprof_before_kernel_opt_txt"] = str(rocprof_before["txt_path"])
+
+
 def invoke_backend(
     backend: str,
     prompt_file: Path,
@@ -3048,14 +3061,7 @@ def invoke_backend(
                 _restore_env(previous_env)
             result["stdout"] = result.get("stdout_tail", "")
             result["output_dir"] = str(out_dir)
-            if rocprof_before:
-                result["rocprof_before_kernel_opt_status"] = str(rocprof_before.get("status") or "")
-                if rocprof_before.get("reason"):
-                    result["rocprof_before_kernel_opt_reason"] = str(rocprof_before["reason"])
-                if rocprof_before.get("json_path"):
-                    result["rocprof_before_kernel_opt_json"] = str(rocprof_before["json_path"])
-                if rocprof_before.get("txt_path"):
-                    result["rocprof_before_kernel_opt_txt"] = str(rocprof_before["txt_path"])
+            _merge_rocprof_before(result, rocprof_before)
             # Surface GEAK partial outputs so a SIGTERM'd attempt with patches is still promoted to "partial".
             final_report = out_dir / "final_report.json"
             if final_report.is_file():
@@ -3155,14 +3161,7 @@ def invoke_backend(
             result["output_dir"] = str(out_dir)
             if common_test_command:
                 result["test_command"] = common_test_command
-            if rocprof_before:
-                result["rocprof_before_kernel_opt_status"] = str(rocprof_before.get("status") or "")
-                if rocprof_before.get("reason"):
-                    result["rocprof_before_kernel_opt_reason"] = str(rocprof_before["reason"])
-                if rocprof_before.get("json_path"):
-                    result["rocprof_before_kernel_opt_json"] = str(rocprof_before["json_path"])
-                if rocprof_before.get("txt_path"):
-                    result["rocprof_before_kernel_opt_txt"] = str(rocprof_before["txt_path"])
+            _merge_rocprof_before(result, rocprof_before)
             return result
         if backend == "forge":
             # Kernel-Forge autonomous-loop backend. Runs entirely inside a git
@@ -3186,14 +3185,7 @@ def invoke_backend(
             result["output_dir"] = str(out_dir)
             if common_test_command:
                 result["test_command"] = common_test_command
-            if rocprof_before:
-                result["rocprof_before_kernel_opt_status"] = str(rocprof_before.get("status") or "")
-                if rocprof_before.get("reason"):
-                    result["rocprof_before_kernel_opt_reason"] = str(rocprof_before["reason"])
-                if rocprof_before.get("json_path"):
-                    result["rocprof_before_kernel_opt_json"] = str(rocprof_before["json_path"])
-                if rocprof_before.get("txt_path"):
-                    result["rocprof_before_kernel_opt_txt"] = str(rocprof_before["txt_path"])
+            _merge_rocprof_before(result, rocprof_before)
             return result
         return {
             "returncode": 2,

--- a/kernel-agent/tools/test_faithful_dtypes.py
+++ b/kernel-agent/tools/test_faithful_dtypes.py
@@ -88,22 +88,3 @@ def test_parse_tolerates_inserted_source_path_column(tmp_path):
     # Args shape parses — neither is corrupted by the extra 'Source Path' column.
     assert c.get("tracelens_launcher_path") == "/x/k.cu"
     assert c["shapes"] == ["(64,5120) bf16"]
-
-
-def test_parse_still_rejects_reordered_canonical_columns(tmp_path):
-    # Bound<->Efficiency swapped -> canonical relative order broken -> reject.
-    md = tmp_path / "analysis.md"
-    md.write_text(
-        "<!-- impact-begin kind=p_item category=gemm mid=4.0 low=2.0 high=8.0 -->\n"
-        "\n## Detailed Analysis\n\n### Compute Kernel Insights\n\n"
-        "<!-- reasoning-candidate tier=compute rank=1 -->\n"
-        "#### 🔴 P1: Reordered (Tensile)\n\n**Identification:** stub\n**Data:**\n"
-        "| Operation | Args | Kernel Path | Time (ms) | %E2E | Count | "
-        "FLOPS/Byte | Bound | Efficiency |\n"
-        "| --- | --- | --- | --- | --- | --- | --- | --- | --- |\n"
-        "| stub_op | (1,2) bf16 | — | 1.0 | 5 | 10 | 1000 | "
-        "compute-bound | 40% of 708 TFLOPS |\n"
-        "**Reasoning for Slowdown:** stub\n**Resolution:** stub\n",
-        encoding="utf-8",
-    )
-    assert tlr.parse_analysis_md(md, top_k=10) == []

--- a/kernel-agent/tools/test_harness_generator.py
+++ b/kernel-agent/tools/test_harness_generator.py
@@ -179,20 +179,6 @@ def test_get_test_function_toplevel_caller():
     assert tf.name == "bench_runner"
 
 
-def test_extract_tensor_creation():
-    a = hg.BenchmarkAnalyzer(BENCH_SRC)
-    dec = a.get_decorated_functions()
-    tensors = a.extract_tensor_creation(dec["torch_ref"])
-    assert tensors[0].var_name == "y"
-    assert tensors[0].dtype_expr == "torch.bfloat16"
-
-
-def test_extract_tensor_creation_syntax_error():
-    a = hg.BenchmarkAnalyzer("x = 1")
-    bad = hg.FuncInfo(name="f", params=[], source="def f(:\n  pass", decorator="", lineno=1)
-    assert a.extract_tensor_creation(bad) == []
-
-
 def test_extract_call_to():
     a = hg.BenchmarkAnalyzer(BENCH_SRC)
     dec = a.get_decorated_functions()

--- a/kernel-agent/tools/test_harness_generator.py
+++ b/kernel-agent/tools/test_harness_generator.py
@@ -224,7 +224,7 @@ def test_dim_names():
 
 
 def test_default_configs():
-    all_c, unpack, cfg_str = hg._default_configs()
+    all_c, unpack, _ = hg._default_configs()
     assert "torch.bfloat16" in all_c
     assert unpack == "M, N, dtype = cfg"
 
@@ -240,7 +240,7 @@ def test_build_configs_from_shapes():
             {"call_num": 2, "shape": "(512, 128) fp16"},
         ]
     }
-    all_c, unpack, cfg_str = hg._build_configs(candidate)
+    all_c, unpack, _ = hg._build_configs(candidate)
     assert "torch.bfloat16" in all_c
     assert "M, N, dtype = cfg" == unpack
     # Scaling expands to >= 6 configs.

--- a/kernel-agent/tools/test_op_to_source_resolver.py
+++ b/kernel-agent/tools/test_op_to_source_resolver.py
@@ -299,7 +299,7 @@ def test_composite_device_name_no_match_falls_back_to_fanout(tla) -> None:
 
 
 # --------------------------------------------------------------------------- #
-# _select_sources
+# _select_source_meta
 # --------------------------------------------------------------------------- #
 def test_select_sources_framework_hint_picks_matching_container(tla) -> None:
     """With both containers editable and neither on disk, the framework hint decides."""
@@ -309,8 +309,8 @@ def test_select_sources_framework_hint_picks_matching_container(tla) -> None:
         sglang={"ks": _kernel(_EDITABLE_CU_2)},
     )
     resolver = tla.OpResolver({})
-    assert resolver._select_sources(entry, "vllm") == [_EDITABLE_CU]
-    assert resolver._select_sources(entry, "sglang") == [_EDITABLE_CU_2]
+    assert [m[0] for m in resolver._select_source_meta(entry, "vllm")] == [_EDITABLE_CU]
+    assert [m[0] for m in resolver._select_source_meta(entry, "sglang")] == [_EDITABLE_CU_2]
 
 
 def test_select_sources_on_disk_tie_break_beats_framework_hint(tla, tmp_path: Path) -> None:
@@ -324,7 +324,7 @@ def test_select_sources_on_disk_tie_break_beats_framework_hint(tla, tmp_path: Pa
     )
     resolver = tla.OpResolver({})
     # sglang hint, but only the vllm source is present on disk -> vllm wins.
-    assert resolver._select_sources(entry, "sglang") == [str(on_disk)]
+    assert [m[0] for m in resolver._select_source_meta(entry, "sglang")] == [str(on_disk)]
 
 
 # --------------------------------------------------------------------------- #

--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -477,10 +477,6 @@ class OpResolver:
             return sgl
         return sgl or vll
 
-    def _select_sources(self, entry: dict[str, Any], framework: str | None) -> list[str]:
-        """Pick the editable source paths, routing to the installed container."""
-        return [m[0] for m in self._select_source_meta(entry, framework)]
-
     def _single(
         self, op_name: str, entry: dict[str, Any], framework: str | None,
     ) -> OpResolution:
@@ -3010,7 +3006,7 @@ def _expand_op_fanout(
     ``--framework``); it disambiguates which container's source to route to when
     both/neither are on disk. Only ``vllm``/``sglang`` are honored (the mapping's
     container keys); any other value (e.g. ``atom``) or an empty/unset value
-    falls through to ``OpResolver._select_sources``' on-disk-presence-then-default
+    falls through to ``OpResolver._select_source_meta``' on-disk-presence-then-default
     ordering.
     """
     framework = (framework or "").strip().lower() or None

--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -445,11 +445,6 @@ class OpResolver:
             ))
         return out
 
-    @classmethod
-    def _container_sources(cls, container: dict[str, Any] | None) -> list[str]:
-        """Editable, patchable source paths for one container (dedup, order-preserving)."""
-        return [m[0] for m in cls._container_source_meta(container)]
-
     def _select_source_meta(
         self, entry: dict[str, Any], framework: str | None,
     ) -> list[tuple[str, str, str]]:
@@ -3625,22 +3620,6 @@ def _resolve_other_bucket_min_gpu_pct() -> float:
         if val is not None and val >= 0:
             return val
     return _DEFAULT_OTHER_BUCKET_MIN_GPU_PCT
-
-
-def _is_other_like_category(category: str) -> bool:
-    """Return whether a category counts as the ``other`` bucket.
-
-    Args:
-        category: Raw or upstream category label.
-
-    Returns:
-        ``True`` if the label (or its normalized upstream form) is an
-        other-like category.
-    """
-    raw_l = str(category or "").strip().lower()
-    if raw_l in _OTHER_LIKE_CATEGORIES:
-        return True
-    return str(normalize_upstream_category(category or "")).strip().lower() in _OTHER_LIKE_CATEGORIES
 
 
 def recover_other_bucket_candidates(

--- a/kernel-agent/tools/tracelens_skill_runner.py
+++ b/kernel-agent/tools/tracelens_skill_runner.py
@@ -22,7 +22,6 @@ from pathlib import Path
 from typing import Any, Callable, Iterable
 
 
-DEFAULT_MODEL = "claude-opus-4-7"
 DEFAULT_ALLOWED_TOOLS = ["Read", "Write", "Edit", "Bash", "Task"]
 
 # Per-message stream-idle timeout (seconds). The in-process Claude SDK query


### PR DESCRIPTION
Delete unreferenced helpers with zero call sites across the repo:
- kernel_optimization.py: duplicate _safe_float definition (shadowed by the later one), _mirror_path_link, env_first
- tracelens_analysis.py: _container_sources, _is_other_like_category

Pure deletion, no behavior change. Verified via py_compile and the kernel-optimization / op-to-source / other-bucket test suites.
