### PR TITLE
chore: remove build-plan process labels from comments and docstrings

### DIFF
--- a/inference_optimizer/breakdown/collectors.py
+++ b/inference_optimizer/breakdown/collectors.py
@@ -1230,7 +1230,7 @@ def collect_baseline(
         "benchmark_report_path": _rel(report_path, session_dir) if report_path else None,
         "attempts_history": history,
         "failure_streak": int(state.get("baseline_failure_streak") or 0),
-        # Combined backstop (P5): ALL baseline failures regardless of error_class;
+        # Combined backstop: ALL baseline failures regardless of error_class;
         # surfaces the fast-fail trigger that per-class streaks alone can hide.
         "total_failures": int(state.get("baseline_total_failures") or 0),
         "invocation": invocation,

--- a/inference_optimizer/breakdown/reporters/_renderers/roofline.py
+++ b/inference_optimizer/breakdown/reporters/_renderers/roofline.py
@@ -2,7 +2,7 @@
 
 """Roofline comparison renderer — one block per discovered ``final.json``.
 
-Silently skipped when ``roofline`` is absent/empty (pre-P3-roofline JSONs).
+Silently skipped when ``roofline`` is absent/empty (older roofline JSONs).
 """
 
 from __future__ import annotations

--- a/inference_optimizer/cli.py
+++ b/inference_optimizer/cli.py
@@ -3341,7 +3341,7 @@ async def _run_optimize(args: argparse.Namespace) -> int:
             args.no_framework_agent = True
             print("  framework phase       : DISABLED (persisted from original run)")
         elif bool(getattr(args, "no_framework_agent", False)):
-            # Inverse (P2.d): honour --no-framework-agent on resume only before FRAMEWORK is entered.
+            # Inverse: honour --no-framework-agent on resume only before FRAMEWORK is entered.
             cur_phase = (getattr(state, "phase", "") or "").strip().upper()
             if cur_phase in ("", "PRELUDE"):
                 state.framework_agent_phase_enabled = False

--- a/inference_optimizer/orchestrator/backends/critic_mock.py
+++ b/inference_optimizer/orchestrator/backends/critic_mock.py
@@ -2,7 +2,7 @@
 
 """Mock Critic backend — auto-approves every proposal it sees.
 
-Used in P0 main-path tests. Emits ``review_verdict{verdict="approve"}`` per
+Used in main-path tests. Emits ``review_verdict{verdict="approve"}`` per
 visible proposal, or a heartbeat when none are present.
 """
 

--- a/inference_optimizer/orchestrator/backends/kernel_mock.py
+++ b/inference_optimizer/orchestrator/backends/kernel_mock.py
@@ -2,7 +2,7 @@
 
 """Mock Kernel backend — auto-responds to every REQUEST it sees.
 
-Used in P0 main-path tests. Emits one ``response`` per visible request, or
+Used in main-path tests. Emits one ``response`` per visible request, or
 a heartbeat when none are present.
 """
 

--- a/inference_optimizer/orchestrator/backends/mock_backend.py
+++ b/inference_optimizer/orchestrator/backends/mock_backend.py
@@ -1,6 +1,6 @@
 # Copyright Advanced Micro Devices, Inc. All rights reserved.
 
-"""MockBackend — scripted-turn LLM stub for P0 / unit / e2e tests.
+"""MockBackend — scripted-turn LLM stub for unit / e2e tests.
 
 Deterministic, offline, token-free playback of pre-recorded turns.
 

--- a/inference_optimizer/orchestrator/backends/robustness_mock.py
+++ b/inference_optimizer/orchestrator/backends/robustness_mock.py
@@ -2,7 +2,7 @@
 
 """Mock Robustness backend — heartbeat-only, non-intervening.
 
-Used in P0 main-path tests. Emits a heartbeat every tick, optionally one
+Used in main-path tests. Emits a heartbeat every tick, optionally one
 ``alert`` after N ticks (``alert_after_ticks``) to exercise the alert pipe.
 """
 

--- a/inference_optimizer/orchestrator/coordinator.py
+++ b/inference_optimizer/orchestrator/coordinator.py
@@ -8924,7 +8924,7 @@ class Coordinator:
             log.exception("FRAMEWORK pump (%s) failed", caller)
 
     async def tick(self, n: int = 1) -> None:
-        """Run exactly ``n`` reactor passes for every agent (P0-3/P0-5/P1-4 tests); dispatcher pumps at pass end, lazy resume replay on tick 1.
+        """Run exactly ``n`` reactor passes for every agent; dispatcher pumps at pass end, lazy resume replay on tick 1.
 
         Args:
             n: Number of full reactor+dispatcher passes to run (default 1).

--- a/inference_optimizer/orchestrator/shared_state.py
+++ b/inference_optimizer/orchestrator/shared_state.py
@@ -459,7 +459,7 @@ class SharedState:
     baseline_arg_error_streak: int = 0
     # Combined backstop: ANY baseline failure (regardless of error_class) counts
     # here. Mixed classes split the per-class streaks above so neither hits its
-    # threshold; this total catches that and fast-fails (P5 anti time-exhaustion).
+    # threshold; this total catches that and fast-fails (anti time-exhaustion).
     baseline_total_failures: int = 0
     # One-shot: cuda-graph capture failure asks the next baseline to retry
     # by disabling cuda-graph capture (framework-correct flag injected by the

--- a/inference_optimizer/tests/test_action_catalogue.py
+++ b/inference_optimizer/tests/test_action_catalogue.py
@@ -1,6 +1,6 @@
 # Copyright Advanced Micro Devices, Inc. All rights reserved.
 
-"""P1-2 full action catalogue tests."""
+"""Full action catalogue tests."""
 
 from __future__ import annotations
 

--- a/inference_optimizer/tests/test_action_registry.py
+++ b/inference_optimizer/tests/test_action_registry.py
@@ -1,6 +1,6 @@
 # Copyright Advanced Micro Devices, Inc. All rights reserved.
 
-"""P1-1 ActionRegistry + ActionMetadata + PolicyGate integration tests."""
+"""ActionRegistry + ActionMetadata + PolicyGate integration tests."""
 
 from __future__ import annotations
 
@@ -91,7 +91,7 @@ def test_valid_families_v06():
     )
 
 
-# ActionRegistry — loads shipped P1-1 actions
+# ActionRegistry — loads shipped actions
 @pytest.fixture
 def registry() -> ActionRegistry:
     return ActionRegistry().load()
@@ -248,7 +248,7 @@ def test_gate_allowed_tools_for_action_no_registry_falls_back():
 
 
 def test_gate_delegate_unknown_action_no_registry_passes():
-    """Without a registry wired, PolicyGate falls back to permissive (P0 path)."""
+    """Without a registry wired, PolicyGate falls back to permissive."""
     g = PolicyGate(role_registry=default_role_registry(), action_registry=None)
     g.validate_intent(
         "orchestration",

--- a/inference_optimizer/tests/test_agent_roles_and_policy.py
+++ b/inference_optimizer/tests/test_agent_roles_and_policy.py
@@ -1,6 +1,6 @@
 # Copyright Advanced Micro Devices, Inc. All rights reserved.
 
-"""P0-2 agent role + PolicyGate tests."""
+"""Agent role + PolicyGate tests."""
 
 from __future__ import annotations
 

--- a/inference_optimizer/tests/test_claude_backend.py
+++ b/inference_optimizer/tests/test_claude_backend.py
@@ -1,6 +1,6 @@
 # Copyright Advanced Micro Devices, Inc. All rights reserved.
 
-"""P1-5 ClaudeBackend + emit_intent MCP server tests.
+"""ClaudeBackend + emit_intent MCP server tests.
 
 All tests use SDK test seams so no real Claude API calls are made and no
 ``ANTHROPIC_API_KEY`` is required.

--- a/inference_optimizer/tests/test_cli_no_framework_resume.py
+++ b/inference_optimizer/tests/test_cli_no_framework_resume.py
@@ -1,7 +1,6 @@
 # Copyright Advanced Micro Devices, Inc. All rights reserved.
 
-"""Cover the --no-framework-agent env default + resume write-back semantics
-introduced by the P2.c+d fix."""
+"""Cover the --no-framework-agent env default + resume write-back semantics."""
 
 from __future__ import annotations
 
@@ -11,7 +10,7 @@ import pytest
 from inference_optimizer import cli
 
 
-# Parser default (P2.c) — env honored when flag not passed.
+# Parser default — env honored when flag not passed.
 def _parse_optimize(argv: list[str]) -> object:
     """Helper: run the cli parser, return the parsed args namespace."""
     parser = cli._build_parser()
@@ -37,7 +36,7 @@ def test_no_framework_agent_explicit_flag_overrides_env_unset(monkeypatch: pytes
     assert getattr(args, "no_framework_agent") is True
 
 
-# Resume write-back (P2.d) — exercise just the branch logic, not the full
+# Resume write-back — exercise just the branch logic, not the full
 # CLI session-resume orchestration which needs a real session dir.
 class _ResumeStateStub:
     """Mirrors the SharedState fields the resume write-back branch reads/writes."""
@@ -66,7 +65,7 @@ def _apply_resume_writeback(state: _ResumeStateStub, args: _ArgsStub) -> str:
         cur_phase = (getattr(state, "phase", "") or "").strip().upper()
         if cur_phase in ("", "PRELUDE"):
             state.framework_agent_phase_enabled = False
-            # P2-g: persist immediately so a clean resume keeps the toggle on disk.
+            # Persist immediately so a clean resume keeps the toggle on disk.
             state.save("session_dir")
             msg = "DISABLING_RESUME"
         else:

--- a/inference_optimizer/tests/test_close_phase_sequencer.py
+++ b/inference_optimizer/tests/test_close_phase_sequencer.py
@@ -359,7 +359,7 @@ async def test_close_sequencer_falls_back_to_time_exhausted(coord):
 
 @pytest.mark.asyncio
 async def test_close_sequencer_derives_sweep_done_from_phase_history(coord):
-    """P1 regression: sequencer derives the phase_history reason rather than blanket-stamping time_exhausted."""
+    """Regression: sequencer derives the phase_history reason rather than blanket-stamping time_exhausted."""
     coord.shared_state.phase_history = [
         {"to_phase": "CLOSE", "reason": "conc_sweep_done", "evidence": {}},
     ]

--- a/inference_optimizer/tests/test_codex_backend.py
+++ b/inference_optimizer/tests/test_codex_backend.py
@@ -1,6 +1,6 @@
 # Copyright Advanced Micro Devices, Inc. All rights reserved.
 
-"""P1-7 CodexBackend tests (mock OpenAI client — no network)."""
+"""CodexBackend tests (mock OpenAI client — no network)."""
 
 from __future__ import annotations
 

--- a/inference_optimizer/tests/test_coordinator_async_methods_coverage_unit.py
+++ b/inference_optimizer/tests/test_coordinator_async_methods_coverage_unit.py
@@ -111,7 +111,7 @@ async def test_unpromotable_baseline_mixed_classes_stop_after_three_total(
     """Mixed subprocess_nonzero + fast_exit_arg_error failures must still
     fast-fail once 3 total baseline failures accrue — neither per-class streak
     reaches its own threshold, so the combined backstop is what stops the run
-    (P5: otherwise the session burns the whole budget -> time_exhausted)."""
+    (otherwise the session burns the whole budget -> time_exhausted)."""
     def _task() -> Task:
         return Task(
             task_id="bl-mixed", kind="baseline", state="running",

--- a/inference_optimizer/tests/test_coordinator_kb_writes.py
+++ b/inference_optimizer/tests/test_coordinator_kb_writes.py
@@ -2,7 +2,7 @@
 
 """Regression tests for the Coordinator -> recipe-snapshot KB write chain.
 
-P0: KEEP/REVERT/CLOSE amend the recipe row via ``_kb_amend_recipe`` ->
+KEEP/REVERT/CLOSE amend the recipe row via ``_kb_amend_recipe`` ->
 ``_workload_canonical_id``; if that helper is missing every write silently
 no-ops. Also pins the canonical_id consistency contract between Coordinator
 writes and ``cortex_t0`` anchors.
@@ -71,7 +71,7 @@ def _expected_cid() -> str:
 
 
 def test_workload_canonical_id_defined_and_consistent(tmp_path: Path) -> None:
-    """P0 regression: ``_workload_canonical_id`` exists and agrees with ``recipe_canonical_id`` and the gap anchor."""
+    """Regression: ``_workload_canonical_id`` exists and agrees with ``recipe_canonical_id`` and the gap anchor."""
     coord = _make_coordinator(tmp_path)
     assert hasattr(coord, "_workload_canonical_id")
     assert coord._workload_canonical_id() == _expected_cid()
@@ -85,7 +85,7 @@ def test_kb_amend_recipe_persists_lesson(tmp_path: Path) -> None:
         append_lesson={"statement": "raise tp to 8", "measured_impact": "+12%"},
     )
     row = coord.cortex_kb.get_recipe(canonical_id=_expected_cid())
-    assert row is not None, "lesson write silently no-opped (P0)"
+    assert row is not None, "lesson write silently no-opped"
     statements = [l.get("statement") for l in (row.get("lessons") or [])]
     assert "raise tp to 8" in statements
 
@@ -191,13 +191,13 @@ def test_kb_amend_recipe_skips_empty_architecture_tags(tmp_path: Path) -> None:
 
 
 def test_recipe_kb_enabled_is_true(tmp_path: Path) -> None:
-    """P1-2: RecipeKB exposes ``enabled`` (always True) so the T0 gate doesn't skip the SDK-fallback anchor."""
+    """RecipeKB exposes ``enabled`` (always True) so the T0 gate doesn't skip the SDK-fallback anchor."""
     kb = RecipeKB(local=LocalRecipeStore(root=tmp_path / "kb"), remote=None)
     assert kb.enabled is True
 
 
 def test_sdk_fallback_t0_anchors_into_self_cortex_kb(tmp_path: Path) -> None:
-    """P1-2: the SDK-fallback T0 anchor runs and writes into the SAME dispatcher the Coordinator holds."""
+    """The SDK-fallback T0 anchor runs and writes into the SAME dispatcher the Coordinator holds."""
     coord = _make_coordinator(tmp_path)
     assert coord.cortex_kb.enabled is True
     # Clear the already-anchored markers and re-anchor with the 5-tuple seeded.
@@ -208,7 +208,7 @@ def test_sdk_fallback_t0_anchors_into_self_cortex_kb(tmp_path: Path) -> None:
     assert row is not None, "SDK-fallback T0 did not anchor into self.cortex_kb"
 
 
-# R-6: schema field fidelity — the on-disk row must preserve severity / dict
+# Schema field fidelity — the on-disk row must preserve severity / dict
 # measured_impact / session provenance, or warm-start + dedup lose data.
 def _put(store: LocalRecipeStore, **kw) -> None:
     store.put_recipe(
@@ -259,7 +259,7 @@ def test_local_store_preserves_session_provenance(tmp_path: Path) -> None:
     assert s["stack_len"] == 3
 
 
-# R-4: _kb_amend_recipe reads the LOCAL row and preserves T0-stamped extras +
+# _kb_amend_recipe reads the LOCAL row and preserves T0-stamped extras +
 # audit fields; appends accumulate instead of clobbering.
 def test_amend_preserves_t0_extras_and_audit(tmp_path: Path) -> None:
     coord = _make_coordinator(tmp_path)
@@ -295,7 +295,7 @@ def test_amend_appends_lessons_cumulatively(tmp_path: Path) -> None:
     assert [l["statement"] for l in row["lessons"]] == ["first", "second"]
 
 
-# R-5: CLOSE finalize must not clobber a better historical best_config with an
+# CLOSE finalize must not clobber a better historical best_config with an
 # empty/worse current result, and must merge (not replace) the fingerprint.
 def test_close_does_not_clobber_better_best_config(tmp_path: Path) -> None:
     coord = _make_coordinator(tmp_path)
@@ -319,7 +319,7 @@ def test_close_does_not_clobber_better_best_config(tmp_path: Path) -> None:
     assert row["stack_fingerprint"].get("vllm_version") == "0.6.0"
 
 
-# R-7: KEEP'd kernel optimizations (incl. E2E-verified-but-no-gain) must be
+# KEEP'd kernel optimizations (incl. E2E-verified-but-no-gain) must be
 # persisted. Regression: k006 (micro 1.32x, KEEP, E2E -0.094%) vanished from
 # recipe.json because ``what_worked`` is built only from optimization_stack.
 def _seed_kept_kernel(coord: Coordinator) -> None:
@@ -379,7 +379,7 @@ def test_close_finalize_persists_kept_kernel_to_kb(tmp_path: Path) -> None:
     assert k006["e2e_gain_pct"] == -0.094
 
 
-# R-8 (P0): a bare-baseline CLOSE whose tput happens to exceed a historical
+# A bare-baseline CLOSE whose tput happens to exceed a historical
 # best must NOT overwrite the validated best_config. Regression: a flagless
 # baseline clobbered the warm_replay recipe, dropping every extra_sglang_arg.
 def test_close_does_not_clobber_with_bare_baseline_higher_tput(
@@ -478,7 +478,7 @@ def test_close_overwrites_best_when_validated_win(tmp_path: Path) -> None:
     assert "--page-size 32" in row["best_config"].get("extra_sglang_args", "")
 
 
-# R-9 (P1): kernel_optimizations[].e2e_decision must carry the integrate
+# kernel_optimizations[].e2e_decision must carry the integrate
 # verdict. Regression: k007 integrate REVERT'd (E2E -1.05%) but the row showed
 # only the micro-layer decision=KEEP, hiding the rollback.
 def test_kernel_e2e_decision_reflects_integrate_revert(tmp_path: Path) -> None:
@@ -536,7 +536,7 @@ def test_kernel_e2e_decision_micro_only_when_not_integrated(
     assert k["e2e_decision"] == ""
 
 
-# R-10 (P3): sessions[] entry must carry throughput_before/after, a date, and
+# sessions[] entry must carry throughput_before/after, a date, and
 # stack actions. Regression: rows had 0.0 / "" / [] for these fields.
 def test_session_entry_carries_throughput_date_and_actions(
     tmp_path: Path,
@@ -565,7 +565,7 @@ def test_session_entry_carries_throughput_date_and_actions(
     assert s["actions_taken"] == ["page32", "stream_interval_4"]
 
 
-# R-11 (P4): a per-variant pitfall with an empty variant dict must still carry
+# A per-variant pitfall with an empty variant dict must still carry
 # the variant NAME in its description, not collapse to the bare task kind.
 def test_pitfall_description_uses_variant_name_not_bare_kind(
     tmp_path: Path,

--- a/inference_optimizer/tests/test_coordinator_runtime.py
+++ b/inference_optimizer/tests/test_coordinator_runtime.py
@@ -1,6 +1,6 @@
 # Copyright Advanced Micro Devices, Inc. All rights reserved.
 
-"""P0-3 Coordinator + MockBackend + SubAgentRunner tests."""
+"""Coordinator + MockBackend + SubAgentRunner tests."""
 
 from __future__ import annotations
 

--- a/inference_optimizer/tests/test_decision_framework.py
+++ b/inference_optimizer/tests/test_decision_framework.py
@@ -1,6 +1,6 @@
 # Copyright Advanced Micro Devices, Inc. All rights reserved.
 
-"""P5 decision-framework regression tests.
+"""Decision-framework regression tests.
 
 Covers that ``_handle_request`` for ``run_optimization`` mirrors the
 handler result into ``shared_state.last_kernel_opt``.

--- a/inference_optimizer/tests/test_framework_agent_discover_retry.py
+++ b/inference_optimizer/tests/test_framework_agent_discover_retry.py
@@ -1,6 +1,6 @@
 # Copyright Advanced Micro Devices, Inc. All rights reserved.
 
-"""Cover the P2.b fix — ``fa phase-discover`` retries before flipping ``framework_agent_phase_done``.
+"""Cover the retry fix — ``fa phase-discover`` retries before flipping ``framework_agent_phase_done``.
 
 Tests ``_discover_next_framework_batch`` (bumps the failure counter, resets
 on success) and ``_pump_framework_agent_phase`` (flips done after the retry limit
@@ -185,7 +185,7 @@ def test_discover_timeout_default_used_when_override_zero(
     assert _fa_client.DEFAULT_FA_PHASE_TIMEOUT_SEC == 180.0
 
 
-# P2.e — enqueue failure records progress row.
+# Enqueue failure records progress row.
 class _TasksStub:
     """Mimics ``Coordinator.tasks.create_or_return_existing``; raises to simulate an enqueue failure."""
 
@@ -205,7 +205,7 @@ async def _call_enqueue(stub: _CoordinatorStub, cand: dict[str, Any]) -> None:
 
 
 def test_enqueue_failure_appends_progress_row(tmp_path: Path):
-    """Regression for P2.e: a registry failure records an ``enqueue_failed`` progress row so the next tick skips the candidate."""
+    """Regression: a registry failure records an ``enqueue_failed`` progress row so the next tick skips the candidate."""
     stub = _CoordinatorStub(tmp_path)
     stub.tasks = _TasksStub(fail=True)  # type: ignore[attr-defined]
     cand = {

--- a/inference_optimizer/tests/test_framework_agent_executor.py
+++ b/inference_optimizer/tests/test_framework_agent_executor.py
@@ -166,7 +166,7 @@ async def test_executor_no_patch_when_no_source_at_all(tmp_path: Path):
 
 @pytest.mark.asyncio
 async def test_executor_no_patch_when_explicit_patches_all_missing(tmp_path: Path):
-    """Regression for P2.a: missing explicit patches must short-circuit to
+    """Regression: missing explicit patches must short-circuit to
     no_patch, never falling back to the candidate's diff_url."""
     session_dir = tmp_path / "session"
     session_dir.mkdir()
@@ -579,7 +579,7 @@ index 0000000..1111111
 
 @pytest.mark.asyncio
 async def test_reject_after_keep_preserves_kept_changes(tmp_path: Path):
-    """Regression for P1.c: B's REVERT must reset to A's KEEP commit, not baseline."""
+    """Regression: B's REVERT must reset to A's KEEP commit, not baseline."""
     session_dir = tmp_path / "session"
     session_dir.mkdir()
     repo = tmp_path / "framework"
@@ -841,7 +841,7 @@ async def test_executor_no_diff_url_falls_back_to_checkout_head(tmp_path: Path):
 
 @pytest.mark.asyncio
 async def test_executor_keep_adds_new_file_pr(tmp_path: Path):
-    """P2 regression: a PR that ADDS a new file must KEEP cleanly via ``git add -A``."""
+    """Regression: a PR that ADDS a new file must KEEP cleanly via ``git add -A``."""
     session_dir = tmp_path / "session"
     session_dir.mkdir()
     repo = tmp_path / "framework"
@@ -885,7 +885,7 @@ async def test_executor_keep_adds_new_file_pr(tmp_path: Path):
 
 @pytest.mark.asyncio
 async def test_executor_cross_repo_disables_checkout_head(tmp_path: Path):
-    """P1 regression: a cross-repo candidate must fall back to diff_url, not checkout-head."""
+    """Regression: a cross-repo candidate must fall back to diff_url, not checkout-head."""
     session_dir = tmp_path / "session"
     session_dir.mkdir()
     repo = tmp_path / "framework"

--- a/inference_optimizer/tests/test_kernel_integrate_and_report.py
+++ b/inference_optimizer/tests/test_kernel_integrate_and_report.py
@@ -1,6 +1,6 @@
 # Copyright Advanced Micro Devices, Inc. All rights reserved.
 
-"""P2-4 tests: integrate kernel-request handler + report runner + e2e."""
+"""Integrate kernel-request handler + report runner + e2e tests."""
 
 from __future__ import annotations
 

--- a/inference_optimizer/tests/test_llm_stability_and_subprocess_kill.py
+++ b/inference_optimizer/tests/test_llm_stability_and_subprocess_kill.py
@@ -1,6 +1,6 @@
 # Copyright Advanced Micro Devices, Inc. All rights reserved.
 
-"""Sandbox-hang RCA fixes (P1-A + P2).
+"""Sandbox-hang RCA fixes.
 
 Covers the orchestrator-side LLM-transport stability env helper and the
 process-group kill in ``_run_subprocess`` that reaps a hung grandchild (the

--- a/inference_optimizer/tests/test_mock_backends.py
+++ b/inference_optimizer/tests/test_mock_backends.py
@@ -1,6 +1,6 @@
 # Copyright Advanced Micro Devices, Inc. All rights reserved.
 
-"""P0-4 mock Critic + mock Robustness adapter tests."""
+"""Mock Critic + mock Robustness adapter tests."""
 
 from __future__ import annotations
 

--- a/inference_optimizer/tests/test_objective.py
+++ b/inference_optimizer/tests/test_objective.py
@@ -1,6 +1,6 @@
 # Copyright Advanced Micro Devices, Inc. All rights reserved.
 
-"""P2-1 Objective + Coordinator.run() long-loop tests."""
+"""Objective + Coordinator.run() long-loop tests."""
 
 from __future__ import annotations
 

--- a/inference_optimizer/tests/test_phase_state_framework_agent.py
+++ b/inference_optimizer/tests/test_phase_state_framework_agent.py
@@ -199,7 +199,7 @@ def test_compute_plateau_framework_agent_returns_signal():
 
 
 def test_exit_normal_framework_agent_force_exit_evidence_carries_pending_count():
-    """Regression for P1.a — force-exit evidence surfaces ``pending_candidate_count``."""
+    """Regression: force-exit evidence surfaces ``pending_candidate_count``."""
     batches = [
         {
             "batch_id": "b1",

--- a/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -1,6 +1,6 @@
 # Copyright Advanced Micro Devices, Inc. All rights reserved.
 
-"""P2-2 tests: ProfileExecutor + kernel REQUEST programmatic handlers."""
+"""ProfileExecutor + kernel REQUEST programmatic handler tests."""
 
 from __future__ import annotations
 

--- a/inference_optimizer/tests/test_protocol_layer.py
+++ b/inference_optimizer/tests/test_protocol_layer.py
@@ -1,6 +1,6 @@
 # Copyright Advanced Micro Devices, Inc. All rights reserved.
 
-"""P0-1 protocol-layer tests (intent envelope, MessageBus, ResourceLockManager, TaskRegistry, CursorStore)."""
+"""Protocol-layer tests (intent envelope, MessageBus, ResourceLockManager, TaskRegistry, CursorStore)."""
 
 from __future__ import annotations
 

--- a/inference_optimizer/tests/test_regression_locks.py
+++ b/inference_optimizer/tests/test_regression_locks.py
@@ -1,6 +1,6 @@
 # Copyright Advanced Micro Devices, Inc. All rights reserved.
 
-"""P3 bug-fix regression tests (PR #130).
+"""Bug-fix regression tests.
 
 Bug A: ReportExecutor session_dir resolution via $USER_DATA_PATH.
 Bug B: programmatic handler advances the target-agent cursor to suppress

--- a/inference_optimizer/tests/test_resume.py
+++ b/inference_optimizer/tests/test_resume.py
@@ -1,6 +1,6 @@
 # Copyright Advanced Micro Devices, Inc. All rights reserved.
 
-"""P1-4 Coordinator resume tests.
+"""Coordinator resume tests.
 
 Covers resume detection, ``replay_for_resume`` rebuilding undecided
 pending_proposals (skipping approved/rejected), pruned_families preservation,

--- a/inference_optimizer/tests/test_roofline_ceiling.py
+++ b/inference_optimizer/tests/test_roofline_ceiling.py
@@ -632,7 +632,7 @@ class TestResolveEffectiveConcurrency:
         self,
         tmp_path,
     ):
-        """P0 fix: the materialized baseline yaml's ``CONC`` wins over ``state.conc`` (session 095726Z: state stayed at default 8 while the run used 64)."""
+        """The materialized baseline yaml's ``CONC`` wins over ``state.conc`` (session 095726Z: state stayed at default 8 while the run used 64)."""
         from inference_optimizer.orchestrator.roofline_ceiling import (
             _resolve_effective_concurrency,
         )
@@ -736,7 +736,7 @@ class TestResolveEffectiveConcurrency:
 
 
 class TestMoEBatchSaturation:
-    """P1 fix: the MoE weight-read term grows with batch as activated experts saturate toward all experts (a constant active_weight_bytes over-amortizes at high batch)."""
+    """The MoE weight-read term grows with batch as activated experts saturate toward all experts (a constant active_weight_bytes over-amortizes at high batch)."""
 
     _COMMON = dict(
         gpu_type="mi355x",
@@ -1222,7 +1222,7 @@ class TestPhysicalInterpretation095726Z:
             gpu_type="mi355x",
             tp=1,
             precision="bf16",
-            conc=8,  # stale SharedState default; yaml CONC=64 wins (P0).
+            conc=8,  # stale SharedState default; yaml CONC=64 wins.
             isl=256,
             osl=256,
             last_baseline={"extras": {"materialized_config": str(yaml_path)}},

--- a/inference_optimizer/tests/test_roofline_cuda_graph_retry.py
+++ b/inference_optimizer/tests/test_roofline_cuda_graph_retry.py
@@ -1,6 +1,6 @@
 # Copyright Advanced Micro Devices, Inc. All rights reserved.
 
-"""P7: roofline profile retry falls back to eager on a cuda-graph capture crash.
+"""Roofline profile retry falls back to eager on a cuda-graph capture crash.
 
 sglang's torch profiler collides with HIP CUDA-graph stream capture
 (hipErrorStreamCaptureUnsupported). The roofline retry must then boot the

--- a/inference_optimizer/tests/test_scaffold_smoke.py
+++ b/inference_optimizer/tests/test_scaffold_smoke.py
@@ -1,6 +1,6 @@
 # Copyright Advanced Micro Devices, Inc. All rights reserved.
 
-"""P0-0 scaffold smoke tests (package import, paths, storage schema + transactions)."""
+"""Scaffold smoke tests (package import, paths, storage schema + transactions)."""
 
 from __future__ import annotations
 

--- a/inference_optimizer/tests/test_shared_state_persistence.py
+++ b/inference_optimizer/tests/test_shared_state_persistence.py
@@ -1,6 +1,6 @@
 # Copyright Advanced Micro Devices, Inc. All rights reserved.
 
-"""P1-3 SharedState + Coordinator integration tests."""
+"""SharedState + Coordinator integration tests."""
 
 from __future__ import annotations
 

--- a/inference_optimizer/tests/test_warm_replay.py
+++ b/inference_optimizer/tests/test_warm_replay.py
@@ -305,7 +305,7 @@ async def test_warm_replay_enqueues_with_warm_best_config_args_envs(tmp_path):
 
 @pytest.mark.asyncio
 async def test_warm_replay_enqueues_with_v2_arbor_top_level_best_config(tmp_path):
-    """Regression (P0): warm-replay must read best_config from the v2 arbor TOP LEVEL, else it skips with best_config_empty."""
+    """Regression: warm-replay must read best_config from the v2 arbor TOP LEVEL, else it skips with best_config_empty."""
     recipe = _warm_recipe_v2_arbor(
         extra_sglang_args="--attention-backend AITER",
         extra_envs={"VLLM_ROCM_USE_AITER": "1"},
@@ -313,7 +313,7 @@ async def test_warm_replay_enqueues_with_v2_arbor_top_level_best_config(tmp_path
     )
     coord = _make_coord(tmp_path, warm_start_recipe=recipe)
     task = await coord._maybe_enqueue_warm_replay(baseline_tput=600.0)
-    assert task is not None, "v2 arbor top-level best_config not read (P0)"
+    assert task is not None, "v2 arbor top-level best_config not read"
     params = coord.tasks.calls[0]["params"]
     assert params["extra_sglang_args"] == "--attention-backend AITER"
     assert params["extra_envs"] == {"VLLM_ROCM_USE_AITER": "1"}
@@ -762,7 +762,7 @@ def test_inject_warm_recipe_history_adds_what_failed_rows(tmp_path):
 
 
 def test_inject_warm_recipe_history_v2_arbor_top_level(tmp_path):
-    """Regression (P0-B): the injector must read v2 ``what_failed`` at the TOP LEVEL, else negative-history injection no-ops."""
+    """Regression: the injector must read v2 ``what_failed`` at the TOP LEVEL, else negative-history injection no-ops."""
     recipe = {
         "tier": "exact",
         "confidence": 1.0,
@@ -783,7 +783,7 @@ def test_inject_warm_recipe_history_v2_arbor_top_level(tmp_path):
     coord = _make_coord(tmp_path, warm_start_recipe=recipe)
     coord.shared_state.explore_search = {}
     added = coord._inject_warm_recipe_history_into_ledger()
-    assert added == 1, "v2 arbor top-level what_failed not read (P0-B)"
+    assert added == 1, "v2 arbor top-level what_failed not read"
     rejected = coord.shared_state.explore_search["rejected"]
     assert len(rejected) == 1
     assert rejected[0]["source"] == "warm_start_recipe"

--- a/kernel-agent/tests/test_kernel_agent.py
+++ b/kernel-agent/tests/test_kernel_agent.py
@@ -100,7 +100,7 @@ def write_vendor_trace(path: Path) -> None:
 
 
 class UpdateStatusTimingTests(unittest.TestCase):
-    """Hyperloom P2-3: ``update_status`` writes ``ended_at``/``duration_seconds`` on terminal states."""
+    """``update_status`` writes ``ended_at``/``duration_seconds`` on terminal states."""
 
     def _import_module(self):
         # tools dir must be on sys.path so the sibling import resolves.

--- a/kernel-agent/tools/backends/forge_submit.py
+++ b/kernel-agent/tools/backends/forge_submit.py
@@ -1809,7 +1809,7 @@ def submit(source_file: str, prompt_file: Path, output_dir: Path,
                     time.time() - started, skipped=True)
             log.info("forge driver: autogen -> %s", driver)
         gpu_target = _resolve_gpu_target(candidate)
-        # P0 baseline-correctness gate: a structurally broken auto-generated
+        # baseline-correctness gate: a structurally broken auto-generated
         # harness fails correctness even on the unmodified kernel, which makes
         # the agent spin the entire budget reverting every iteration (0 gain).
         # Verify the baseline up front and skip forge cleanly (fall through to

--- a/robustness-agent/src/robustness_agent/role/envelope.py
+++ b/robustness-agent/src/robustness_agent/role/envelope.py
@@ -254,8 +254,8 @@ class Intent:
 class BackendTurnResult:
     """Mirror of upstream ``backends.base.BackendTurnResult``.
 
-    The Coordinator inspects ``intents`` and ignores the rest in
-    P0-3 / P0-4. ``raw_text`` is recorded for debugging only.
+    The Coordinator inspects ``intents`` and ignores the rest.
+    ``raw_text`` is recorded for debugging only.
     """
 
     intents: list[Intent] = field(default_factory=list)


### PR DESCRIPTION
# Clean up build-plan process labels in comments and docstrings

## What

Removes leftover build-plan phase/item bookkeeping labels from code comments and
docstrings, keeping the engineering description intact. These labels
(`P0-0`…`P2-4`, `P1.a`…`P2.g`, `R-4`…`R-11`, `PR #130`, `pre-P3`, `P5`/`P7`,
`Sandbox-hang RCA P1-A+P2`, etc.) encoded the original build plan's numbering and
add no runtime meaning.

Examples:

- `"""P0-0 scaffold smoke tests (…)."""` → `"""Scaffold smoke tests (…)."""`
- `"P3 bug-fix regression tests (PR #130)"` → `"Bug-fix regression tests."`
- `# … fast-fails (P5 anti time-exhaustion).` → `# … fast-fails (anti time-exhaustion).`
- `"Used in P0 main-path tests"` → `"Used in main-path tests"`

## Scope

- 39 files, comments/docstrings only. No executable code, function/class/test
  names, imports, or runtime string literals were changed.
- Also reworded the two "borderline" plan labels on real engineering gates:
  `P0/P1 fix:` prefixes in `test_roofline_ceiling.py`, and
  `P0 baseline-correctness gate` → `baseline-correctness gate` in `forge_submit.py`.

## Intentionally left untouched

- Domain terms that look similar but are live concepts: roofline P-item
  priorities (e.g. `P1: GEMM cluster`) and `IR-N` invariant rules.
- Design-doc requirement citations (`§3.14 R-09`/`R-13`) — these reference an
  external doc section (one is user-facing runtime text), not plan bookkeeping.
- Genuine historical PR citations (`PR #314`, `#321`, `#399`) that document real
  code behavior.

## Testing

- `python -m py_compile` passes on all changed Python files.
- All changed test files still collect (900 tests) with no errors.

Comment/docstring-only changes; no behavioral impact.
