### PR TITLE
feat(xdit): scriptable diffusion roofline pipeline + unit-agnostic la…

### DIFF
--- a/inference_optimizer/orchestrator/action_executors/_workload_envs.py
+++ b/inference_optimizer/orchestrator/action_executors/_workload_envs.py
@@ -445,8 +445,16 @@ def materialize_config_with_envs(
     is_profile = str(envs.get("PROFILE", "")).strip() == "1" or (
         bench.get("profiler", {}).get("torch_profiler", {}).get("enabled") is True
     )
+    # Scriptable image frameworks (xDiT diffusion) have no LLM decode
+    # steady-state window: NUM_PROMPTS / PROFILE_EXTRA_BODY.start_step and the
+    # OSL/steady-floor math below are all serving concepts xDiT never consumes.
+    # Its profiler window is defined by the xDiT bench yaml + the _xdit_patcher
+    # (repeat=1); injecting the LLM window here is inert-to-harmful, so skip it.
+    from ... import framework_registry as _fw_reg
+
+    _is_scriptable_profile = _fw_reg.is_scriptable(bench.get("framework"))
     profile_num_prompts: int | None = None
-    if is_profile:
+    if is_profile and not _is_scriptable_profile:
         try:
             r_val = float(envs.get("RANDOM_RANGE_RATIO", 1.0))
         except (TypeError, ValueError):
@@ -670,24 +678,27 @@ def materialize_config_with_envs(
                         f"{existing_sglang} --enable-shape-discovery-for-cuda-graph-profile"
                     ).strip()
 
-    if profile_num_prompts is not None:
-        # Profile mode: force-override NUM_PROMPTS to reach the steady-state
-        # window (an under-sized value empties the trace).
-        envs["NUM_PROMPTS"] = profile_num_prompts
-    else:
-        seq_cost = isl_val + osl_val
-        if seq_cost <= 1024:
-            factor = 10
-        elif seq_cost <= 4096:
-            factor = 5
-        elif seq_cost <= 16384:
-            factor = 3
+    if not _is_scriptable_profile:
+        # NUM_PROMPTS / NUM_WARMUPS are serving-request concepts; xDiT drives its
+        # own iteration count from the bench yaml, so leave them untouched.
+        if profile_num_prompts is not None:
+            # Profile mode: force-override NUM_PROMPTS to reach the steady-state
+            # window (an under-sized value empties the trace).
+            envs["NUM_PROMPTS"] = profile_num_prompts
         else:
-            factor = 2
-        if "NUM_PROMPTS" not in envs:
-            envs["NUM_PROMPTS"] = max(conc_val * factor, conc_val)
-    if "NUM_WARMUPS" not in envs:
-        envs["NUM_WARMUPS"] = min(conc_val, 8)
+            seq_cost = isl_val + osl_val
+            if seq_cost <= 1024:
+                factor = 10
+            elif seq_cost <= 4096:
+                factor = 5
+            elif seq_cost <= 16384:
+                factor = 3
+            else:
+                factor = 2
+            if "NUM_PROMPTS" not in envs:
+                envs["NUM_PROMPTS"] = max(conc_val * factor, conc_val)
+        if "NUM_WARMUPS" not in envs:
+            envs["NUM_WARMUPS"] = min(conc_val, 8)
     # ── reference-script base (lowest priority) ────────────────────────────
     # Seed the framework server-args env + envs from a reference recipe BELOW
     # the YAML base and any per-task extra_server_args. Reference flags are

--- a/inference_optimizer/orchestrator/action_executors/_xdit_patcher.py
+++ b/inference_optimizer/orchestrator/action_executors/_xdit_patcher.py
@@ -85,10 +85,10 @@ def _discover_xfuser_base_models() -> list[Path]:
 
     def _add(candidate: Path | str | None) -> None:
         if not candidate:
-            return
+            return  # pragma: no cover - defensive; current callers pass real paths
         try:
             resolved = Path(candidate).expanduser().resolve()
-        except OSError:
+        except OSError:  # pragma: no cover - resolve() rarely raises for these paths
             return
         if not resolved.is_file() or resolved in seen:
             return

--- a/inference_optimizer/orchestrator/action_executors/_xdit_patcher.py
+++ b/inference_optimizer/orchestrator/action_executors/_xdit_patcher.py
@@ -1,0 +1,202 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Idempotent, backward-compatible patcher for xDiT's torch-profiler schedule.
+
+xDiT (``xfuser``) profiles diffusion runs with
+
+    schedule = torch.profiler.schedule(
+        wait=self.config.profile_wait,
+        warmup=self.config.profile_warmup,
+        active=self.config.profile_active,
+    )
+    num_repetitions = profile_wait + profile_warmup + profile_active
+    for _ in range(num_repetitions):
+        run_one_image()
+        profile_object.step()
+
+Because ``num_repetitions`` equals the schedule cycle length, the ACTIVE step is
+always the last iteration; the loop then calls ``profile_object.step()`` once
+more. With the ``torch.profiler.schedule`` default ``repeat=0`` (repeat forever)
+and no ``on_trace_ready`` callback, that trailing ``step()`` rolls the profiler
+into a fresh collection cycle and DISCARDS the just-recorded active window. The
+exported ``profile_trace_rank_*.json.gz`` then contains only metadata + a lone
+``hipDeviceSynchronize`` (``Op count == 0``), so TraceLens/roofline get an empty
+trace regardless of eager vs torch.compile. Verified on MI355X SD3.5-large:
+``repeat=1`` turns a 1.3 KB empty trace into a 6 MB trace with ~30k kernel and
+~130k cpu_op events.
+
+This patch inserts ``repeat=1`` into that schedule so one cycle is retained and
+exported. Applied in place, once, never reverted: idempotent via a sentinel
+substring, serialized across processes via ``fcntl.flock``, written atomically
+(temp file + ``os.replace``). Returns ``False`` (non-fatal) when the legacy
+block is missing so callers can fail-soft.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import os
+from pathlib import Path
+
+from ._inferencex_patcher import _ensure_patched
+from ._magpie_patcher import atomic_write_text
+from ._patch_sentinel import file_contains_sentinel
+
+log = logging.getLogger(__name__)
+
+# xfuser package-relative path to the profiler schedule.
+_XFUSER_REL = ("model_executor", "models", "runner_models", "base_model.py")
+
+# Exact upstream schedule tail (whitespace-anchored to the single
+# ``torch.profiler.schedule(...)`` call in base_model.py).
+_LEGACY_BLOCK = (
+    "            active=self.config.profile_active,\n"
+    "        )"
+)
+_PATCHED_BLOCK = (
+    "            active=self.config.profile_active,\n"
+    "            repeat=1,  # hyperloom: retain active window "
+    "(upstream default repeat=0 discards it -> empty trace)\n"
+    "        )"
+)
+# "Already patched?" sentinel.
+_PATCH_SENTINEL = "# hyperloom: retain active window"
+
+# System-wide lock (``/tmp`` is writable; cross-reboot persistence not needed).
+_LOCK_PATH = "/tmp/hyperloom_xdit_profiler_patcher.lock"
+
+
+def _discover_xfuser_base_models() -> list[Path]:
+    """Return every existing xfuser ``base_model.py`` Hyperloom should patch.
+
+    Discovery order (deduped by resolved path):
+
+    * ``$XDIT_PATH/xfuser/<rel>`` when ``XDIT_PATH`` points at an xDiT checkout.
+    * The importable ``xfuser`` package location (``importlib`` find-spec, which
+      does not import the module), i.e. the copy the ``xdit`` subprocess runs.
+
+    Returns:
+        A deduped list of existing ``base_model.py`` files, or ``[]`` when none
+        resolve (callers fail-soft; this is fine for tests / non-xDiT runs).
+    """
+    out: list[Path] = []
+    seen: set[Path] = set()
+
+    def _add(candidate: Path | str | None) -> None:
+        if not candidate:
+            return
+        try:
+            resolved = Path(candidate).expanduser().resolve()
+        except OSError:
+            return
+        if not resolved.is_file() or resolved in seen:
+            return
+        seen.add(resolved)
+        out.append(resolved)
+
+    xdit_root = (os.environ.get("XDIT_PATH") or "").strip()
+    if xdit_root:
+        _add(Path(xdit_root).joinpath("xfuser", *_XFUSER_REL))
+
+    try:
+        spec = importlib.util.find_spec("xfuser")
+    except (ImportError, ValueError, ModuleNotFoundError):
+        spec = None
+    if spec is not None:
+        for loc in list(spec.submodule_search_locations or []):
+            _add(Path(loc).joinpath(*_XFUSER_REL))
+
+    return out
+
+
+def _is_patched(src: Path) -> bool:
+    """Return whether ``base_model.py`` already carries the ``repeat=1`` patch.
+
+    Args:
+        src: The xfuser ``base_model.py`` file to inspect.
+
+    Returns:
+        ``True`` if the patch sentinel is present; ``False`` on a miss or read
+        error.
+    """
+    return file_contains_sentinel(src, _PATCH_SENTINEL, log, "_xdit_patcher")
+
+
+def _apply_patch_atomic(src: Path) -> bool:
+    """Insert ``repeat=1`` into the profiler schedule via temp-file + atomic
+    rename so a crash mid-write cannot corrupt ``base_model.py``.
+
+    Args:
+        src: The xfuser ``base_model.py`` file to patch in place.
+
+    Returns:
+        ``True`` when the patched bytes were written; ``False`` when the legacy
+        block is missing or any IO step fails.
+    """
+    try:
+        original = src.read_text(encoding="utf-8")
+    except OSError as e:
+        log.warning("_xdit_patcher: cannot read %s: %s", src, e)
+        return False
+
+    if _LEGACY_BLOCK not in original:
+        log.warning(
+            "_xdit_patcher: expected torch.profiler.schedule(...) block not "
+            "found in %s; xDiT layout may have changed and Hyperloom needs an "
+            "updated patch. The profiler active window will be discarded "
+            "(empty diffusion trace -> roofline REVERT). Manual review needed.",
+            src,
+        )
+        return False
+
+    patched = original.replace(_LEGACY_BLOCK, _PATCHED_BLOCK, 1)
+    if patched == original:
+        return False
+
+    if not atomic_write_text(
+        src,
+        patched,
+        tmp_prefix=".base_model.py.hyperloom_",
+        log_prefix="_xdit_patcher",
+    ):
+        return False
+
+    log.info(
+        "_xdit_patcher: added repeat=1 to the torch.profiler.schedule in %s "
+        "so the diffusion profiler retains its active window (else the trace "
+        "is empty: Op count == 0)",
+        src,
+    )
+    return True
+
+
+def ensure_xdit_profiler_patched() -> bool:
+    """Ensure xDiT's ``base_model.py`` profiler schedule keeps ``repeat=1``.
+
+    Returns ``True`` when patched at exit, ``False`` (non-fatal) when the file
+    is missing or the legacy block is absent. Concurrency-safe (flock + atomic
+    rename; already-patched fast-path skips the lock).
+
+    Returns:
+        ``True`` when at least one discovered ``base_model.py`` is patched (or
+        already patched), ``False`` when none could be patched.
+    """
+    return _ensure_patched(
+        _discover_xfuser_base_models(),
+        _is_patched,
+        _apply_patch_atomic,
+        _LOCK_PATH,
+        empty_msg=(
+            "_xdit_patcher: no xfuser base_model.py discovered (checked "
+            "$XDIT_PATH and the importable xfuser package) — skipping "
+            "profiler repeat=1 patch (this is fine for tests and non-xDiT runs)"
+        ),
+        failure_msg=(
+            "_xdit_patcher: failed to patch %s; other discovered roots will "
+            "still be attempted"
+        ),
+    )
+
+
+__all__ = ["ensure_xdit_profiler_patched"]

--- a/inference_optimizer/orchestrator/action_executors/profile.py
+++ b/inference_optimizer/orchestrator/action_executors/profile.py
@@ -37,6 +37,7 @@ from ._inferencex_patcher import (
     ensure_benchmark_lib_patched,
     ensure_benchmark_serving_patched,
 )
+from ._xdit_patcher import ensure_xdit_profiler_patched
 from .baseline import BaselineExecutor
 
 
@@ -225,7 +226,7 @@ def _validate_trace_structure(
 
     Read-only; each check warns independently so partial signals stay actionable.
 
-    Returns a structured ``trace_health`` dict: ``per_kernel_attribution_degraded`` (no execute_*/user_annotation events -> cuda-graph folds per-kernel time, 0 hot kernels -> triggers eager re-profile), ``capture_traces_present``, and ``issues`` (logged warning strings).
+    Returns a structured ``trace_health`` dict: ``per_kernel_attribution_degraded`` (no execute_*/user_annotation events -> cuda-graph folds per-kernel time, 0 hot kernels -> triggers eager re-profile), ``capture_traces_present``, ``zero_ops`` (``"Op count": 0`` PyTorch Profiler span -> capture window never overlapped execution, metadata-only trace -> triggers roofline re-profile), and ``issues`` (logged warning strings).
 
     Args:
         trace_dir: The profile workspace trace directory to inspect.
@@ -239,21 +240,35 @@ def _validate_trace_structure(
     issues: list[str] = []
     per_kernel_attribution_degraded = False
     capture_traces_present = False
+    zero_ops = False
 
-    # --- Check 1: capture_traces/ presence ---
+    # Scriptable image frameworks (xDiT diffusion) produce a plain torch-
+    # profiler trace: no CUDA-graph capture sidecar (checks 1-2), no InferenceX
+    # execute_*/user_annotation per-step markers (check 3), and no steady-state
+    # splitter output (checks 4/6). Running those LLM/serving checks would emit
+    # spurious warnings and — worse — check 3 would set
+    # per_kernel_attribution_degraded and trigger a needless eager re-profile.
+    # For diffusion the only meaningful health signal is check 7 (zero_ops:
+    # metadata-only / repeat=0 empty window), which we always run below.
+    from ... import framework_registry as _fw_reg
+
+    scriptable = _fw_reg.is_scriptable(framework)
+
+    # --- Check 1: capture_traces/ presence (LLM/serving only) ---
     capture = trace_dir / "capture_traces"
     capture_files: list[Path] = []
-    if not capture.is_dir():
-        issues.append(
-            "[1] capture_traces/ subdirectory missing — graph capture "
-            "didn't fire. Verify EXTRA_VLLM_ARGS / EXTRA_SGLANG_ARGS "
-            "include the TraceLens flag and the server-side patch landed."
-        )
-    else:
-        capture_files = sorted(p for p in capture.iterdir() if p.is_file())
-        capture_traces_present = bool(capture_files)
-        if not capture_files:
-            issues.append("[1] capture_traces/ exists but is empty — graph capture path fired but produced no files.")
+    if not scriptable:
+        if not capture.is_dir():
+            issues.append(
+                "[1] capture_traces/ subdirectory missing — graph capture "
+                "didn't fire. Verify EXTRA_VLLM_ARGS / EXTRA_SGLANG_ARGS "
+                "include the TraceLens flag and the server-side patch landed."
+            )
+        else:
+            capture_files = sorted(p for p in capture.iterdir() if p.is_file())
+            capture_traces_present = bool(capture_files)
+            if not capture_files:
+                issues.append("[1] capture_traces/ exists but is empty — graph capture path fired but produced no files.")
 
     # --- Check 2 (Deval): capture file has cpu_op + Input Dims ---
     # Sample the heaviest capture file; gate cpu_op-with-Input-Dims fraction
@@ -311,7 +326,8 @@ def _validate_trace_structure(
             # confirm via a streaming scan (the 2 MB window misses markers on
             # 600 MB+ traces) to avoid false "annotations didn't fire" warnings.
             confirmed_absent = (
-                execute_count == 0
+                not scriptable
+                and execute_count == 0
                 and user_ann_count == 0
                 and not (
                     _trace_contains(main_traces[0], '"execute_')
@@ -332,7 +348,7 @@ def _validate_trace_structure(
     # An empty split means the splitter ran but got no usable events.
     split = trace_dir / "trace_split"
     split_files: list[Path] = []
-    if split.is_dir():
+    if split.is_dir() and not scriptable:
         split_files = sorted(p for p in split.iterdir() if p.is_file())
         empty_splits: list[str] = []
         for sp in split_files:
@@ -356,7 +372,7 @@ def _validate_trace_structure(
 
     # --- Check 6 (Hyperloom-specific #210 smoking-gun): _extend_* / ---
     # _decode_* without _steady_state_* in trace_split/.
-    if split.is_dir():
+    if split.is_dir() and not scriptable:
         names = [p.name for p in split_files]
         has_extend = any("_extend_" in n or "extend_only_" in n for n in names)
         has_decode = any("_decode_" in n or "decode_only_" in n for n in names)
@@ -371,6 +387,32 @@ def _validate_trace_structure(
                 "Confirm _inferencex_patcher patched Magpie's bundled "
                 "InferenceX (#210; check $MAGPIE_PATH/InferenceX/utils/"
                 "bench_serving/benchmark_serving.py)."
+            )
+
+    # --- Check 7 (Hyperloom): torch-profiler captured zero ops ---
+    # A metadata-only trace (no ``cpu_op`` / ``kernel`` events, just process/
+    # thread labels + a lone ``hipDeviceSynchronize``) means the profiler active
+    # window never recorded real execution. Observed on xDiT diffusion: the
+    # ``torch.profiler.schedule`` default ``repeat=0`` cycles back to a new
+    # collection right after the single active step, discarding the recorded
+    # window (empty ``profile_trace_rank_*.json.gz``). The trace is unusable for
+    # roofline; flag it so roofline re-profiles instead of caching an empty
+    # snapshot (silent 0% gain). Note: the ``"Op count"`` value in the
+    # ``PyTorch Profiler`` span is 0 even on HEALTHY traces, so key on the
+    # presence of ``cpu_op`` / ``kernel`` events instead.
+    if main_traces:
+        has_ops = _trace_contains(
+            main_traces[0], '"cat": "cpu_op"'
+        ) or _trace_contains(main_traces[0], '"cat": "kernel"')
+        if not has_ops:
+            zero_ops = True
+            issues.append(
+                f"[7] main trace {main_traces[0].name} has NO cpu_op / kernel "
+                "events — the torch-profiler active window recorded nothing "
+                "(metadata-only trace). On xDiT/diffusion this is the "
+                "torch.profiler.schedule repeat=0 discard (the active window is "
+                "dropped when the schedule restarts after the last active "
+                "step). The trace is unusable for roofline; re-profile needed."
             )
 
     # --- Check 5 (Deval): sglang kernel_shape_profiler presence ---
@@ -398,6 +440,7 @@ def _validate_trace_structure(
         "issues": issues,
         "per_kernel_attribution_degraded": per_kernel_attribution_degraded,
         "capture_traces_present": capture_traces_present,
+        "zero_ops": zero_ops,
     }
 
 
@@ -644,6 +687,18 @@ class ProfileExecutor(BaselineExecutor):
                 "error": f"cannot read materialized profile config {config_path}: {exc}",
             }
         bench = cfg.get("benchmark") if isinstance(cfg, dict) else {}
+        framework = ""
+        if isinstance(bench, dict):
+            framework = str(bench.get("framework") or "").strip().lower()
+        # Scriptable diffusion (xDiT) has no InferenceX server; it profiles via
+        # its own torch.profiler schedule. Patch it to retain the active window
+        # (upstream default repeat=0 discards it -> empty trace) and skip the
+        # InferenceX NUM_PROMPTS / PROFILE_EXTRA_BODY validation below.
+        from ... import framework_registry
+
+        if framework_registry.is_scriptable(framework):
+            ensure_xdit_profiler_patched()
+            return None
         inferencex_path = ""
         if isinstance(bench, dict):
             inferencex_path = str(bench.get("inferencex_path") or "").strip()

--- a/inference_optimizer/orchestrator/action_executors/roofline.py
+++ b/inference_optimizer/orchestrator/action_executors/roofline.py
@@ -401,6 +401,28 @@ class RooflineExecutor:
                     trace_path,
                 )
                 continue
+            # Op count == 0: the torch-profiler active window captured no ops
+            # (metadata-only trace). The steady-state splitter yields no
+            # execution_details.csv and roofline REVERTs with an empty snapshot.
+            # Re-profile rather than cache an empty snapshot; if every attempt
+            # is zero-ops, fail with an accurate message. The most common cause
+            # (LLM start_step applied to a scriptable/diffusion run) is fixed at
+            # window-computation time, so a re-profile self-heals a transient.
+            if bool((profile_result.get("trace_health") or {}).get("zero_ops")):
+                last_phase = "profile_zero_ops"
+                last_error = (
+                    "profile produced a metadata-only trace (PyTorch Profiler "
+                    "Op count == 0); the active capture window never overlapped "
+                    "execution — re-profile needed"
+                )
+                log.warning(
+                    "roofline profile attempt %d/%d: zero-ops trace (%s); "
+                    "re-profiling",
+                    attempt,
+                    _PROFILE_MAX_ATTEMPTS,
+                    trace_path,
+                )
+                continue
             # Success
             if attempt > 1:
                 log.info(

--- a/inference_optimizer/orchestrator/kernel_request_handlers.py
+++ b/inference_optimizer/orchestrator/kernel_request_handlers.py
@@ -2445,6 +2445,14 @@ async def trace_analyze_handler(
     if not analysis_mode and framework.lower() in {"vllm", "sglang"}:
         analysis_mode = "inference"
 
+    # Scriptable image frameworks (xDiT diffusion) are server-less and have no
+    # LLM decode steady-state window, so the TraceLens steady-state splitter
+    # cannot produce chunks and hard-fails (trace_split_no_steady_state). Feed
+    # the raw trace to TraceLens directly and drop the (LLM-only) --split-* hints.
+    from ..framework_registry import is_scriptable
+
+    scriptable = is_scriptable(framework)
+
     # Load materialized baseline workload metadata once: feeds splitter CLI flags (--split-*) so the steady-state window is correct, and enriches hot_kernels downstream.
     metadata = _load_materialized_workload_metadata(state.baseline_config_path)
     workload = metadata.get("runtime_args", {}).get("workload", {}) if isinstance(metadata, dict) else {}
@@ -2479,16 +2487,30 @@ async def trace_analyze_handler(
     if analysis_mode:
         cmd += ["--analysis-mode", str(analysis_mode)]
 
-    # Splitter workload hints. Priority: payload override > baseline metadata > drop the flag (tool keeps its env fallback). Missing hints can cause trace_split_no_steady_state.
-    split_conc = payload.get("split_conc") or workload.get("conc")
-    if split_conc not in (None, ""):
-        cmd += ["--split-conc", str(split_conc).strip()]
-    split_osl = payload.get("split_osl") or workload.get("osl")
-    if split_osl not in (None, ""):
-        cmd += ["--split-osl", str(split_osl).strip()]
-    split_r = payload.get("split_r") or workload.get("random_range_ratio")
-    if split_r not in (None, ""):
-        cmd += ["--split-r", str(split_r).strip()]
+    if scriptable:
+        # No steady-state window to extract; skip the splitter entirely.
+        cmd += ["--skip-split"]
+        # Forward the denoise-step count so the diffusion workload roofline can
+        # emit per-denoise-step timings. Priority: payload override (steps in
+        # the profiled window) > baseline workload metadata (full schedule).
+        num_denoise = payload.get("num_denoise_steps") or workload.get("num_inference_steps")
+        if num_denoise not in (None, ""):
+            try:
+                if int(num_denoise) > 0:
+                    cmd += ["--num-denoise-steps", str(int(num_denoise))]
+            except (TypeError, ValueError):
+                pass
+    else:
+        # Splitter workload hints. Priority: payload override > baseline metadata > drop the flag (tool keeps its env fallback). Missing hints can cause trace_split_no_steady_state.
+        split_conc = payload.get("split_conc") or workload.get("conc")
+        if split_conc not in (None, ""):
+            cmd += ["--split-conc", str(split_conc).strip()]
+        split_osl = payload.get("split_osl") or workload.get("osl")
+        if split_osl not in (None, ""):
+            cmd += ["--split-osl", str(split_osl).strip()]
+        split_r = payload.get("split_r") or workload.get("random_range_ratio")
+        if split_r not in (None, ""):
+            cmd += ["--split-r", str(split_r).strip()]
 
     capture_folder = (
         payload.get("capture_folder") or payload.get("graph_capture_path") or payload.get("capture_folder_path")

--- a/inference_optimizer/orchestrator/roofline_snapshot.py
+++ b/inference_optimizer/orchestrator/roofline_snapshot.py
@@ -301,6 +301,9 @@ def build_roofline_snapshot(
     mem_ceiling_tok_per_sec: float = 0.0,
     cmp_ceiling_tok_per_sec: float = 0.0,
     bound_kind: str = "unknown",
+    framework: str = "",
+    e2e_mean_ms: float = 0.0,
+    roofline_ideal_ms: float = 0.0,
 ) -> dict[str, Any]:
     """Materialise one side (baseline or latest) of the comparison.
 
@@ -316,6 +319,16 @@ def build_roofline_snapshot(
         mem_ceiling_tok_per_sec: Memory-side roofline ceiling (tok/s).
         cmp_ceiling_tok_per_sec: Compute-side roofline ceiling (tok/s).
         bound_kind: Which side dominated (e.g. ``memory`` / ``compute``).
+        e2e_mean_ms: Scriptable/diffusion primary metric — measured per-image
+            end-to-end latency (ms). The compute-bound analogue of
+            ``achieved_tok_per_sec`` (which is a memory-bound tok/s throughput);
+            stored as a sibling so the renderer picks the metric by unit.
+        roofline_ideal_ms: Compute-roofline ideal per-image latency ceiling
+            (ms) — the analogue of ``theoretical_peak_tok_per_sec`` for
+            scriptable workloads. When both ``roofline_ideal_ms`` and
+            ``e2e_mean_ms`` are positive and no tok/s ceiling applies,
+            ``within_roofline_pct`` is derived from them (ideal / measured) so
+            the same within/gap fields stay populated across units.
 
     Returns:
         A snapshot dict with the ceiling, achieved throughput, derived
@@ -326,9 +339,20 @@ def build_roofline_snapshot(
         peak=theoretical_peak_tok_per_sec,
         achieved=achieved_tok_per_sec,
     )
+    # Unit-agnostic fallback: when there is no tok/s ceiling (scriptable
+    # diffusion has a compute-latency roofline, not a decode-throughput one),
+    # derive within/gap from the ms pair. For latency "closer to the ceiling"
+    # means the measured time approaches the ideal floor, so within = ideal /
+    # measured (mirrors serving's achieved / peak: higher = nearer the ceiling).
+    if within is None and roofline_ideal_ms > 0 and e2e_mean_ms > 0:
+        within = round(roofline_ideal_ms / e2e_mean_ms * 100.0, 2)
+        gap = round(100.0 - within, 2)
     snap: dict[str, Any] = {
         "snapshot_id": snapshot_id,
         "ts": ts or "",
+        # Framework tag so the report layer renders the achieved primary metric
+        # in the right unit (serving: tok/s; scriptable xDiT: per-image latency).
+        "framework": str(framework or ""),
         # sidecar pointer — overwritten by record_trace_analyze; empty for offline callers.
         "kernel_roofline_path": "",
         "compute_pct": None,
@@ -344,6 +368,10 @@ def build_roofline_snapshot(
         "roofline_cmp_ceiling_tok_per_sec": (float(cmp_ceiling_tok_per_sec) if cmp_ceiling_tok_per_sec > 0 else None),
         "roofline_bound_kind": (str(bound_kind) if bound_kind else "unknown"),
         "achieved_tok_per_sec": (float(achieved_tok_per_sec) if achieved_tok_per_sec > 0 else None),
+        # Scriptable/diffusion siblings (compute-latency roofline). None for
+        # serving; the renderer selects tok/s vs ms by framework/unit.
+        "e2e_mean_ms": (float(e2e_mean_ms) if e2e_mean_ms > 0 else None),
+        "roofline_ideal_ms": (float(roofline_ideal_ms) if roofline_ideal_ms > 0 else None),
         "within_roofline_pct": within,
         "gap_to_roofline_pct": gap,
     }
@@ -456,17 +484,28 @@ def _fmt_delta(val: float | None) -> str:
     return f"{sign}{val:.1f}"
 
 
-def _fmt_tput(v: float | None) -> str:
-    """Format ``output_throughput`` cell; one decimal place + tok/s unit.
+def _fmt_tput(v: float | None, framework: str = "") -> str:
+    """Format the achieved primary-metric cell for the roofline table.
+
+    Serving frameworks render ``tok/s``; scriptable image frameworks (xDiT)
+    store an img/s value whose meaningful surface is per-image latency, so
+    defer to :func:`framework_registry.format_primary_metric` for the correct
+    unit (mirrors the session's primary-metric rendering after #799).
 
     Args:
-        v (float | None): The throughput value (tok/s).
+        v (float | None): The stored primary metric (tok/s for serving, img/s
+            for scriptable xDiT).
+        framework (str): Session framework name; selects the display unit.
 
     Returns:
         str: The formatted cell, or ``"—"`` when missing/non-positive.
     """
     if not isinstance(v, (int, float)) or v <= 0:
         return "—"
+    from .. import framework_registry
+
+    if framework_registry.is_scriptable(framework):
+        return framework_registry.format_primary_metric(framework, float(v))
     return f"{float(v):.1f} tok/s"
 
 
@@ -524,6 +563,20 @@ def format_roofline_metrics_table(cmp: dict[str, Any]) -> list[str]:
             f"_(single-source ceiling; baseline / latest compared against it)_"
         )
         ceiling_lines.append("")
+    else:
+        # Scriptable/diffusion has no tok/s decode ceiling; surface the
+        # compute-roofline ideal per-image latency floor instead (same unit as
+        # the achieved e2e latency, so within/gap read as a latency roofline).
+        ideal_ms = baseline.get("roofline_ideal_ms")
+        if not isinstance(ideal_ms, (int, float)) or ideal_ms <= 0:
+            ideal_ms = latest.get("roofline_ideal_ms")
+        if isinstance(ideal_ms, (int, float)) and ideal_ms > 0:
+            ceiling_lines.append(
+                f"**Compute-roofline ideal (per-image latency floor):** "
+                f"{float(ideal_ms):.1f} ms  "
+                f"_(single-source ceiling; baseline / latest compared against it)_"
+            )
+            ceiling_lines.append("")
 
     lines: list[str] = list(ceiling_lines)
     if mode == "single_snapshot":
@@ -542,7 +595,9 @@ def format_roofline_metrics_table(cmp: dict[str, Any]) -> list[str]:
         lines.append(f"| Top kernel efficiency | {cell(tk.get('efficiency_pct'))} |")
         if tk.get("name"):
             lines.append(f"| Top kernel | `{tk.get('name')}` |")
-        lines.append(f"| Achieved output_throughput | {_fmt_tput(snap.get('achieved_tok_per_sec'))} |")
+        lines.append(
+            f"| Achieved output_throughput | {_fmt_tput(snap.get('achieved_tok_per_sec'), snap.get('framework') or '')} |"
+        )
         lines.append(f"| Within roofline % | {_fmt_pct_cell(snap.get('within_roofline_pct'))} |")
         lines.append(f"| Gap to roofline % | {_fmt_pct_cell(snap.get('gap_to_roofline_pct'))} |")
         lines.append("")
@@ -575,8 +630,8 @@ def format_roofline_metrics_table(cmp: dict[str, Any]) -> list[str]:
         lines.append(f"| Top kernel | `{btk.get('name') or '—'}` | `{ltk.get('name') or '—'}` | — |")
     lines.append(
         f"| Achieved output_throughput | "
-        f"{_fmt_tput(baseline.get('achieved_tok_per_sec'))} | "
-        f"{_fmt_tput(latest.get('achieved_tok_per_sec'))} | — |"
+        f"{_fmt_tput(baseline.get('achieved_tok_per_sec'), baseline.get('framework') or '')} | "
+        f"{_fmt_tput(latest.get('achieved_tok_per_sec'), latest.get('framework') or '')} | — |"
     )
     lines.append(
         f"| Within roofline % | "

--- a/inference_optimizer/orchestrator/shared_state.py
+++ b/inference_optimizer/orchestrator/shared_state.py
@@ -1854,6 +1854,55 @@ class SharedState:
         """
         return _first_positive_tput(self.current_best)
 
+    def _scriptable_latency_roofline(
+        self, framework: str, achieved_tput: float, kernel_roofline_path: Any
+    ) -> tuple[float, float]:
+        """Resolve the (measured e2e latency, ideal latency floor) ms pair.
+
+        Scriptable/diffusion workloads have a compute-latency roofline rather
+        than a decode-throughput one. Returns ``(0.0, 0.0)`` for serving
+        frameworks and on any failure so the caller's serving path and legacy
+        behaviour are unchanged.
+
+        Args:
+            framework: Session framework name.
+            achieved_tput: Snapshot-time ``output_throughput`` (img/s for
+                scriptable xDiT).
+            kernel_roofline_path: Path to ``reports/kernel_roofline.json``; the
+                ``diffusion_roofline.json`` sidecar sits at its run-dir root.
+
+        Returns:
+            ``(e2e_mean_ms, roofline_ideal_ms)``; either element is ``0.0``
+            when unavailable.
+        """
+        try:
+            from .. import framework_registry
+
+            if not framework_registry.is_scriptable(framework):
+                return 0.0, 0.0
+            # img/s -> per-image e2e latency (ms); the achieved metric.
+            e2e_mean_ms = float(
+                framework_registry.primary_metric_value(framework, achieved_tput) or 0.0
+            )
+            # Ideal per-image latency floor from the diffusion roofline sidecar
+            # (run_dir/diffusion_roofline.json; kernel_roofline is run_dir/reports/).
+            roofline_ideal_ms = 0.0
+            try:
+                sidecar = Path(str(kernel_roofline_path)).parent.parent / "diffusion_roofline.json"
+                if sidecar.is_file():
+                    data = json.loads(sidecar.read_text(encoding="utf-8"))
+                    analytic = data.get("analytic_dit_ceiling") if isinstance(data, dict) else None
+                    totals = data.get("totals") if isinstance(data, dict) else None
+                    if isinstance(analytic, dict) and float(analytic.get("ideal_compute_us") or 0.0) > 0:
+                        roofline_ideal_ms = float(analytic["ideal_compute_us"]) / 1000.0
+                    elif isinstance(totals, dict) and float(totals.get("sigma_ideal_roofline_us") or 0.0) > 0:
+                        roofline_ideal_ms = float(totals["sigma_ideal_roofline_us"]) / 1000.0
+            except (OSError, ValueError, TypeError, json.JSONDecodeError):
+                roofline_ideal_ms = 0.0
+            return e2e_mean_ms, roofline_ideal_ms
+        except Exception:  # noqa: BLE001 — best-effort enrichment, never blocks
+            return 0.0, 0.0
+
     def record_baseline_roofline_ceiling(self) -> dict[str, Any]:
         """Compute a standalone baseline-arm roofline ceiling and cache it.
 
@@ -1898,6 +1947,7 @@ class SharedState:
             mem_ceiling_tok_per_sec=float(breakdown.mem_tok_per_sec or 0.0),
             cmp_ceiling_tok_per_sec=float(breakdown.cmp_tok_per_sec or 0.0),
             bound_kind=breakdown.bound_kind,
+            framework=str(getattr(self, "framework", "") or ""),
         )
         # Mark provenance: this is the baseline-arm ceiling backup, not a
         # trace-derived snapshot.
@@ -2132,6 +2182,15 @@ class SharedState:
             except Exception:  # noqa: BLE001 — ceiling is best-effort
                 pass
             peak_tput = float(breakdown.peak_tok_per_sec or 0.0)
+            # Scriptable/diffusion has no tok/s decode ceiling. Surface the
+            # compute-latency roofline instead: the measured per-image e2e
+            # latency (achieved) vs the compute-roofline ideal floor read from
+            # the diffusion_roofline.json sidecar. Both best-effort → 0 keeps
+            # the serving path and legacy callers unchanged.
+            fw = str(getattr(self, "framework", "") or "")
+            e2e_mean_ms, roofline_ideal_ms = self._scriptable_latency_roofline(
+                fw, achieved_tput, kernel_roofline_path
+            )
             history_entry = build_roofline_snapshot(
                 snapshot_id=snapshot_id,
                 ts=ts_iso,
@@ -2141,6 +2200,9 @@ class SharedState:
                 mem_ceiling_tok_per_sec=float(breakdown.mem_tok_per_sec or 0.0),
                 cmp_ceiling_tok_per_sec=float(breakdown.cmp_tok_per_sec or 0.0),
                 bound_kind=breakdown.bound_kind,
+                framework=fw,
+                e2e_mean_ms=e2e_mean_ms,
+                roofline_ideal_ms=roofline_ideal_ms,
             )
             # Per-op PerfModel breakdown for dashboard visualization.
             attach_perfmodel_breakdown(history_entry, self, arm=snapshot_arm)

--- a/inference_optimizer/scripts/install.sh
+++ b/inference_optimizer/scripts/install.sh
@@ -124,7 +124,13 @@ MAGPIE_REPO="${MAGPIE_REPO:-https://github.com/AMD-AGI/Magpie.git}"
 # patch (ensure_magpie_atomic_scripts_patch) becomes a no-op and is
 # fail-soft below. Operators can re-pin with MAGPIE_REF=<tag|branch|sha>
 # (mirrors GEAK_REF in kernel-agent/scripts/install.sh).
-MAGPIE_REF="${MAGPIE_REF:-b1d4dcdee7eaf7bcab4fac13ab751f61bffdc3f7}"
+# Pinned to AMD-AGI/Magpie main HEAD, which includes the xDiT scriptable
+# diffusion benchmark framework (#51); the previous pin
+# (b1d4dcdee7eaf7bcab4fac13ab751f61bffdc3f7, #34 Atom) predates #51 and
+# rejects framework=xdit ("Unsupported framework: xdit"), breaking every
+# xDiT baseline. Still post the atomic-copy refactor, so the in-place patch
+# stays a no-op.
+MAGPIE_REF="${MAGPIE_REF:-e1be639428070e8d1e1ca21ca5414a84bc291d94}"
 # MAGPIE_PATH points install.sh AND the Python optimizer (cli.py /
 # _grid_runner.py / manifest.py) at the same Magpie checkout. A single var keeps
 # the installer and runtime in lockstep; setting it never silently falls back to

--- a/inference_optimizer/tests/test_diffusion_roofline.py
+++ b/inference_optimizer/tests/test_diffusion_roofline.py
@@ -114,3 +114,39 @@ def test_build_report_no_geometry_skips_analytic(tmp_path):
     report = dr.build_report(tmp_path, num_denoise_steps=25, top_k=3)
     assert "analytic_dit_ceiling" not in report
     assert "reconciliation" not in report
+
+
+def test_print_summary_full_report_smoke(tmp_path, capsys):
+    """A report with every optional section (per-step + analytic ceiling +
+    reconciliation) must render without raising."""
+    _write_csvs(tmp_path)
+    report = dr.build_report(
+        tmp_path,
+        num_denoise_steps=25,
+        top_k=3,
+        dit_geometry={"hidden_size": 3072, "num_layers": 38, "num_tokens": 4096, "ffn_ratio": 4.0},
+        achievable_tflops=1686.0,
+    )
+    dr.print_summary(report)
+    out = capsys.readouterr().out
+    assert "diffusion workload roofline" in out
+    assert "top kernels by time" in out
+    assert "per denoise-step" in out
+    assert "a-priori DiT ceiling" in out
+
+
+def test_print_summary_minimal_report_smoke(tmp_path, capsys):
+    """No timeline -> ``gpu_busy_ratio`` None exercises the ``_fmt_pct`` n/a
+    branch; no geometry -> optional sections are omitted."""
+    _write_csvs(tmp_path, with_timeline=False)
+    report = dr.build_report(tmp_path, num_denoise_steps=None, top_k=3)
+    dr.print_summary(report)
+    out = capsys.readouterr().out
+    assert "n/a" in out
+    assert "per denoise-step" not in out
+    assert "a-priori DiT ceiling" not in out
+
+
+def test_fmt_pct_none_and_value():
+    assert dr._fmt_pct(None) == "n/a"
+    assert dr._fmt_pct(0.5) == "50.0%"

--- a/inference_optimizer/tests/test_diffusion_roofline.py
+++ b/inference_optimizer/tests/test_diffusion_roofline.py
@@ -1,0 +1,116 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Tests for the diffusion workload-level roofline aggregator.
+
+``diffusion_roofline`` (under ``kernel-agent/tools``) aggregates a per-kernel
+TraceLens CSV dir into a single workload roofline (kernel efficiency, gpu busy
+ratio, per denoise-step timings) — the compute-bound dual of the LLM decode
+memory roofline.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_TOOL_DIR = Path(__file__).resolve().parents[2] / "kernel-agent" / "tools"
+if str(_TOOL_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOL_DIR))
+
+import diffusion_roofline as dr  # noqa: E402
+
+
+def _write_csvs(csv_dir: Path, *, with_timeline: bool = True) -> None:
+    unified = csv_dir / dr.UNIFIED_CSV
+    header = [dr.COL_NAME, dr.COL_CATEGORY, dr.COL_BOUND, dr.COL_OP_COUNT, dr.COL_ROOFLINE_TIME, dr.COL_KERNEL_TIME_SUM]
+    rows = [
+        # ideal = roofline_time_first * op_count
+        ["aten::mm", "GEMM", "COMPUTE_BOUND", "10", "50", "1000"],  # ideal 500 / actual 1000
+        ["sdpa", "SDPA_fwd", "COMPUTE_BOUND", "5", "40", "1000"],  # ideal 200 / actual 1000
+        ["triton_fused", "triton", "", "2", "0", "500"],  # no perf model
+    ]
+    with unified.open("w", newline="") as f:
+        f.write(",".join(header) + "\n")
+        for r in rows:
+            f.write(",".join(r) + "\n")
+    if with_timeline:
+        (csv_dir / dr.GPU_TIMELINE_CSV).write_text(
+            "type,time ms,percent\n"
+            "computation_time,2400,96.0\n"
+            "busy_time,2450,98.0\n"
+        )
+
+
+def test_diffusion_roofline_aggregation(tmp_path):
+    _write_csvs(tmp_path)
+    report = dr.build_report(tmp_path, num_denoise_steps=25, top_k=3)
+    t = report["totals"]
+    assert t["sigma_actual_kernel_us"] == pytest.approx(2500.0)
+    assert t["sigma_ideal_roofline_us"] == pytest.approx(700.0)  # 500 + 200 + 0
+    assert t["kernel_roofline_efficiency"] == pytest.approx(700.0 / 2500.0)
+    assert t["compute_bound_us"] == pytest.approx(2000.0)
+    assert t["no_perf_model_us"] == pytest.approx(500.0)
+    assert report["gpu_busy_ratio"] == pytest.approx(0.98)
+    assert report["end_to_end_efficiency_estimate"] == pytest.approx((700.0 / 2500.0) * 0.98)
+    assert report["per_step"]["actual_kernel_us"] == pytest.approx(2500.0 / 25)
+    assert report["top_kernels"][0]["kernel_time_us"] == pytest.approx(1000.0)
+
+
+def test_diffusion_roofline_missing_timeline_is_fail_soft(tmp_path):
+    _write_csvs(tmp_path, with_timeline=False)
+    report = dr.build_report(tmp_path, num_denoise_steps=None, top_k=5)
+    assert report["gpu_busy_ratio"] is None
+    assert report["end_to_end_efficiency_estimate"] is None
+    assert "per_step" not in report
+
+
+def test_diffusion_roofline_missing_unified_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        dr.build_report(tmp_path, num_denoise_steps=None, top_k=5)
+
+
+def test_dit_analytic_flops_formula():
+    # 1 layer, 1 token, 1 step, h=2, ffn=4 -> linear = 2*(4+8)*4 = 96;
+    # attention = 2*(2*1*2) = 8; total = 104.
+    flops = dr.dit_analytic_flops(hidden_size=2, num_layers=1, num_tokens=1, num_denoise_steps=1, ffn_ratio=4.0)
+    assert flops["linear_flops"] == pytest.approx(96.0)
+    assert flops["attention_flops"] == pytest.approx(8.0)
+    assert flops["total_flops"] == pytest.approx(104.0)
+
+
+def test_dit_analytic_ceiling_and_reconcile():
+    # 1e12 FLOPs @ 1000 TFLOPS -> ideal 1e12/1e15 s = 1e-3 s = 1000 us.
+    ceiling = dr.dit_analytic_ceiling({"total_flops": 1e12}, achievable_tflops=1000.0)
+    assert ceiling["ideal_compute_us"] == pytest.approx(1000.0)
+    totals = {"sigma_ideal_roofline_us": 500.0, "sigma_actual_kernel_us": 2000.0}
+    recon = dr.reconcile(totals, ceiling)
+    assert recon["analytic_vs_trace_ideal_ratio"] == pytest.approx(2.0)
+    assert recon["analytic_achieved_efficiency"] == pytest.approx(0.5)
+
+
+def test_dit_analytic_ceiling_zero_inputs_empty():
+    assert dr.dit_analytic_ceiling({"total_flops": 0.0}, 1000.0) == {}
+    assert dr.reconcile({"sigma_ideal_roofline_us": 100.0}, {}) == {}
+
+
+def test_build_report_includes_analytic_ceiling(tmp_path):
+    _write_csvs(tmp_path)
+    report = dr.build_report(
+        tmp_path,
+        num_denoise_steps=25,
+        top_k=3,
+        dit_geometry={"hidden_size": 3072, "num_layers": 38, "num_tokens": 4096, "ffn_ratio": 4.0},
+        achievable_tflops=1686.0,
+    )
+    assert "analytic_dit_ceiling" in report
+    assert report["analytic_dit_ceiling"]["total_flops"] > 0
+    assert "reconciliation" in report
+
+
+def test_build_report_no_geometry_skips_analytic(tmp_path):
+    _write_csvs(tmp_path)
+    report = dr.build_report(tmp_path, num_denoise_steps=25, top_k=3)
+    assert "analytic_dit_ceiling" not in report
+    assert "reconciliation" not in report

--- a/inference_optimizer/tests/test_profile_trace_validator.py
+++ b/inference_optimizer/tests/test_profile_trace_validator.py
@@ -22,8 +22,10 @@ def _write_minimal_sglang_trace(
     with_execute_star: bool = True,
 ) -> None:
     """Write a tiny gzipped JSON trace blob; each flag toggles one validator signal."""
+    # Real torch/kineto traces tag op events with ``"cat": "cpu_op"``; check [7]
+    # (zero_ops) keys on that category, so the healthy fixture must carry it.
     events: list[dict] = [
-        {"name": "cpu_op", "ph": "X", "ts": 0, "dur": 1, "args": {"Input Dims": [[1, 2, 3]]}},
+        {"name": "cpu_op", "cat": "cpu_op", "ph": "X", "ts": 0, "dur": 1, "args": {"Input Dims": [[1, 2, 3]]}},
     ]
     if with_user_annotation:
         events.append(
@@ -345,6 +347,41 @@ def test_trace_health_healthy_layout(tmp_path):
     assert health["per_kernel_attribution_degraded"] is False
     assert health["capture_traces_present"] is True
     assert health["issues"] == []
+
+
+# Check [7] (Hyperloom): torch-profiler captured zero ops (metadata-only trace)
+def test_validator_warns_on_metadata_only_trace(tmp_path, caplog):
+    """A main trace with no ``cpu_op`` / ``kernel`` category events (the xDiT
+    ``torch.profiler.schedule`` ``repeat=0`` discard) must trip check [7]."""
+    trace_dir = _build_healthy_layout(tmp_path)
+    main = next(trace_dir.glob("*.trace.json.gz"))
+    main.unlink()
+    # Metadata-only trace: process/thread labels + a lone device-sync marker,
+    # but no ``"cat": "cpu_op"`` / ``"cat": "kernel"`` events.
+    payload = {
+        "schemaVersion": 1,
+        "traceEvents": [
+            {"name": "process_name", "ph": "M", "args": {"name": "python"}},
+            {"name": "thread_name", "ph": "M", "args": {"name": "MainThread"}},
+            {"name": "hipDeviceSynchronize", "ph": "X", "ts": 0, "dur": 1},
+        ],
+    }
+    with gzip.open(main, "wt", encoding="utf-8") as fh:
+        json.dump(payload, fh)
+
+    caplog.set_level(logging.WARNING)
+    health = _validate_trace_structure(trace_dir, "sglang")
+    assert health["zero_ops"] is True
+    assert any("NO cpu_op / kernel" in m for m in health["issues"]), health["issues"]
+    msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("[7]" in m for m in msgs), msgs
+
+
+def test_trace_health_healthy_layout_not_zero_ops(tmp_path):
+    """The healthy layout carries real ``cpu_op`` events → check [7] stays quiet."""
+    trace_dir = _build_healthy_layout(tmp_path)
+    health = _validate_trace_structure(trace_dir, "sglang")
+    assert health["zero_ops"] is False
 
 
 def test_trace_health_flags_degraded_attribution_cuda_graph(tmp_path):

--- a/inference_optimizer/tests/test_xdit_integration_units.py
+++ b/inference_optimizer/tests/test_xdit_integration_units.py
@@ -351,6 +351,197 @@ class TestLifecycleScriptableSkip:
         assert result["eligible"] is True
 
 
+class TestRooflineSnapshotUnits:
+    """D10: the roofline snapshot table renders the achieved primary metric in
+    the framework-correct unit (serving tok/s vs scriptable per-image ms)."""
+
+    def test_fmt_tput_serving_tok_s(self):
+        from inference_optimizer.orchestrator import roofline_snapshot as rs
+
+        assert rs._fmt_tput(123.0, "vllm") == "123.0 tok/s"
+        assert rs._fmt_tput(None, "vllm") == "—"
+
+    def test_fmt_tput_scriptable_renders_latency_ms(self):
+        from inference_optimizer.orchestrator import roofline_snapshot as rs
+
+        out = rs._fmt_tput(0.15528, "xdit")
+        assert out == "6440.0 ms"
+        assert "tok/s" not in out
+
+    def test_build_snapshot_carries_framework(self):
+        from inference_optimizer.orchestrator import roofline_snapshot as rs
+
+        snap = rs.build_roofline_snapshot(
+            snapshot_id=1, ts="t", analysis_md_path="", achieved_tok_per_sec=0.155, framework="xdit"
+        )
+        assert snap["framework"] == "xdit"
+
+    def test_metrics_table_scriptable_achieved_is_ms(self):
+        from inference_optimizer.orchestrator import roofline_snapshot as rs
+
+        snap = rs.build_roofline_snapshot(
+            snapshot_id=1, ts="t", analysis_md_path="", achieved_tok_per_sec=0.15528, framework="xdit"
+        )
+        cmp = rs.build_roofline_comparison_from_history([snap])
+        table = "\n".join(rs.format_roofline_metrics_table(cmp))
+        assert "6440.0 ms" in table
+        # Scriptable runs have no decode memory-roofline ceiling.
+        assert "decode memory-roofline ceiling" not in table
+
+    def test_snapshot_carries_latency_siblings_and_within(self):
+        """e2e_mean_ms / roofline_ideal_ms are stored at the tok/s level and
+        drive a unit-agnostic within/gap when no decode ceiling applies."""
+        from inference_optimizer.orchestrator import roofline_snapshot as rs
+
+        snap = rs.build_roofline_snapshot(
+            snapshot_id=1,
+            ts="t",
+            analysis_md_path="",
+            achieved_tok_per_sec=0.15528,  # img/s
+            framework="xdit",
+            e2e_mean_ms=6440.0,
+            roofline_ideal_ms=644.0,
+        )
+        assert snap["e2e_mean_ms"] == 6440.0
+        assert snap["roofline_ideal_ms"] == 644.0
+        # No tok/s ceiling -> within = ideal / measured = 644 / 6440 = 10%.
+        assert snap["within_roofline_pct"] == 10.0
+        assert snap["gap_to_roofline_pct"] == 90.0
+        assert snap["theoretical_peak_tok_per_sec"] is None
+
+    def test_metrics_table_scriptable_shows_compute_ceiling(self):
+        """The compact table surfaces the ms compute-roofline floor + within%."""
+        from inference_optimizer.orchestrator import roofline_snapshot as rs
+
+        snap = rs.build_roofline_snapshot(
+            snapshot_id=1,
+            ts="t",
+            analysis_md_path="",
+            achieved_tok_per_sec=0.15528,
+            framework="xdit",
+            e2e_mean_ms=6440.0,
+            roofline_ideal_ms=644.0,
+        )
+        cmp = rs.build_roofline_comparison_from_history([snap])
+        table = "\n".join(rs.format_roofline_metrics_table(cmp))
+        assert "Compute-roofline ideal (per-image latency floor):" in table
+        assert "644.0 ms" in table
+        assert "10.0%" in table
+        assert "decode memory-roofline ceiling" not in table
+
+    def test_serving_snapshot_latency_siblings_are_none(self):
+        """Serving snapshots keep tok/s within/gap and leave ms siblings unset."""
+        from inference_optimizer.orchestrator import roofline_snapshot as rs
+
+        snap = rs.build_roofline_snapshot(
+            snapshot_id=1,
+            ts="t",
+            analysis_md_path="",
+            theoretical_peak_tok_per_sec=200.0,
+            achieved_tok_per_sec=150.0,
+            framework="vllm",
+        )
+        assert snap["e2e_mean_ms"] is None
+        assert snap["roofline_ideal_ms"] is None
+        assert snap["within_roofline_pct"] == 75.0
+
+
+class TestHyperloomArchSpec:
+    """A3: TraceLens arch spec derived from hyperloom's HW_SPECS_ACHIEVABLE."""
+
+    def _tab(self):
+        import sys
+        from pathlib import Path
+
+        tool_dir = Path(__file__).resolve().parents[2] / "kernel-agent" / "tools"
+        if str(tool_dir) not in sys.path:
+            sys.path.insert(0, str(tool_dir))
+        import tracelens_arch_benchmark as tab  # noqa: WPS433
+
+        return tab
+
+    def test_build_spec_mi355x(self):
+        tab = self._tab()
+        spec = tab.build_hyperloom_arch_spec("mi355x")
+        assert spec is not None
+        assert spec["mem_bw_gbps"] == pytest.approx(8000.0)
+        maf = spec["max_achievable_tflops"]
+        # bf16 achievable + fp8 + fp4 derived from HW_SPECS_ACHIEVABLE.
+        assert maf["matrix_bf16"] == pytest.approx(1686.0)
+        assert maf["matrix_fp8"] == pytest.approx(3567.0)
+        assert maf["matrix_fp4"] == pytest.approx(5663.0)
+        assert all(v > 0 for v in maf.values())
+
+    def test_build_spec_case_insensitive_and_named(self):
+        tab = self._tab()
+        spec = tab.build_hyperloom_arch_spec("MI300X")
+        assert spec is not None
+        assert "matrix_bf16" in spec["max_achievable_tflops"]
+
+    def test_build_spec_unknown_platform_none(self):
+        tab = self._tab()
+        assert tab.build_hyperloom_arch_spec("nvidia-h100") is None
+
+    def test_write_spec_roundtrip(self, tmp_path):
+        tab = self._tab()
+        # default_arch_output_path writes under <root>/TraceLens/Agent/Analysis/utils/arch/
+        out = tab.write_hyperloom_arch_spec(tmp_path, "mi355x", lambda _m: None)
+        assert out is not None and out.is_file()
+        import json
+
+        data = json.loads(out.read_text())
+        assert data["max_achievable_tflops"]["matrix_bf16"] == pytest.approx(1686.0)
+
+
+class TestValidateTraceStructureScriptable:
+    """B5: for scriptable (xDiT) traces, the LLM/InferenceX structure checks are
+    skipped; only the zero-ops (repeat=0 empty window) health signal applies."""
+
+    def _write_trace(self, trace_dir, *, with_kernels: bool) -> None:
+        import gzip
+        import json
+
+        if with_kernels:
+            # A healthy diffusion trace: real cpu_op + kernel events, but still
+            # no execute_* / user_annotation (plain torch-profiler, no InferenceX).
+            events = [{"name": "cpu_op", "cat": "cpu_op"}, {"name": "some_gemm", "cat": "kernel"}]
+        else:
+            # A metadata-only (repeat=0 empty window) trace: no cpu_op / kernel.
+            events = [{"name": "process_labels", "cat": "process_labels"}]
+        payload = {"traceEvents": events}
+        p = trace_dir / "profile.trace.json.gz"
+        with gzip.open(p, "wt", encoding="utf-8") as fh:
+            fh.write(json.dumps(payload))
+
+    def test_scriptable_no_attribution_degradation(self, tmp_path):
+        from inference_optimizer.orchestrator.action_executors import profile as pf
+
+        self._write_trace(tmp_path, with_kernels=True)
+        health = pf._validate_trace_structure(tmp_path, "xdit")
+        # No capture-dir warning, no execute_* degradation for scriptable.
+        assert health["per_kernel_attribution_degraded"] is False
+        assert health["zero_ops"] is False
+        assert not any("capture_traces" in i for i in health["issues"])
+        assert not any("[3]" in i for i in health["issues"])
+
+    def test_scriptable_zero_ops_still_flagged(self, tmp_path):
+        from inference_optimizer.orchestrator.action_executors import profile as pf
+
+        self._write_trace(tmp_path, with_kernels=False)
+        health = pf._validate_trace_structure(tmp_path, "xdit")
+        # The one diffusion-relevant health signal is preserved.
+        assert health["zero_ops"] is True
+
+    def test_serving_still_flags_missing_annotations(self, tmp_path):
+        from inference_optimizer.orchestrator.action_executors import profile as pf
+
+        self._write_trace(tmp_path, with_kernels=True)
+        health = pf._validate_trace_structure(tmp_path, "vllm")
+        # Same trace, serving framework: the LLM checks DO run and flag the
+        # missing execute_*/user_annotation events.
+        assert health["per_kernel_attribution_degraded"] is True
+
+
 class TestQualityGateReportSelection:
     """Verify parse_quality_gate picks the most recently modified report."""
 

--- a/inference_optimizer/tests/test_xdit_patcher.py
+++ b/inference_optimizer/tests/test_xdit_patcher.py
@@ -11,6 +11,7 @@ fake xfuser tree in ``tmp_path`` discovered via ``$XDIT_PATH``.
 
 from __future__ import annotations
 
+import importlib.util
 import threading
 from pathlib import Path
 
@@ -18,6 +19,8 @@ import pytest
 
 from inference_optimizer.orchestrator.action_executors import _xdit_patcher
 from inference_optimizer.orchestrator.action_executors._xdit_patcher import (
+    _apply_patch_atomic,
+    _discover_xfuser_base_models,
     ensure_xdit_profiler_patched,
 )
 
@@ -110,6 +113,72 @@ def test_no_xdit_tree_is_fail_soft(monkeypatch) -> None:
         _xdit_patcher, "_discover_xfuser_base_models", lambda: []
     )
     assert ensure_xdit_profiler_patched() is False
+
+
+# ---------------------------------------------------------------------------
+# _discover_xfuser_base_models: discovery-path edge cases (fail-soft)
+# ---------------------------------------------------------------------------
+def test_discovery_skips_when_base_model_missing(tmp_path: Path, monkeypatch) -> None:
+    """``$XDIT_PATH`` set but the ``base_model.py`` file is absent → skipped."""
+    monkeypatch.setenv("XDIT_PATH", str(tmp_path))
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
+    assert _discover_xfuser_base_models() == []
+
+
+def test_discovery_survives_find_spec_error(monkeypatch) -> None:
+    """A raising ``importlib.util.find_spec`` must not propagate → returns []."""
+    monkeypatch.delenv("XDIT_PATH", raising=False)
+
+    def _boom(name: str):
+        raise ValueError("namespace package without a real spec")
+
+    monkeypatch.setattr(importlib.util, "find_spec", _boom)
+    assert _discover_xfuser_base_models() == []
+
+
+def test_discovery_uses_importable_xfuser_spec(tmp_path: Path, monkeypatch) -> None:
+    """When ``$XDIT_PATH`` is unset, discovery falls back to the importable
+    ``xfuser`` package location (``find_spec.submodule_search_locations``)."""
+    pkg_root = tmp_path / "site-packages"
+    target = pkg_root.joinpath(*_REL)
+    target.parent.mkdir(parents=True)
+    target.write_text(_UPSTREAM_FIXTURE, encoding="utf-8")
+    monkeypatch.delenv("XDIT_PATH", raising=False)
+
+    class _Spec:
+        submodule_search_locations = [str(pkg_root / "xfuser")]
+
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: _Spec())
+    found = _discover_xfuser_base_models()
+    assert target.resolve() in found
+
+
+# ---------------------------------------------------------------------------
+# _apply_patch_atomic: IO / no-op edge cases (fail-soft, never corrupts)
+# ---------------------------------------------------------------------------
+def test_apply_returns_false_on_read_error(tmp_path: Path) -> None:
+    """An unreadable path (here a directory) fails soft, returns False."""
+    unreadable = tmp_path / "a_directory_not_a_file"
+    unreadable.mkdir()
+    assert _apply_patch_atomic(unreadable) is False
+
+
+def test_apply_returns_false_when_patch_is_a_noop(fake_xdit: Path, monkeypatch) -> None:
+    """If replacing the legacy block yields identical bytes, return False."""
+    monkeypatch.setattr(
+        _xdit_patcher, "_PATCHED_BLOCK", _xdit_patcher._LEGACY_BLOCK
+    )
+    assert _apply_patch_atomic(fake_xdit) is False
+
+
+def test_apply_returns_false_when_write_fails(fake_xdit: Path, monkeypatch) -> None:
+    """A failed atomic write is reported (False) without touching the file."""
+    original = fake_xdit.read_text()
+    monkeypatch.setattr(
+        _xdit_patcher, "atomic_write_text", lambda *a, **k: False
+    )
+    assert _apply_patch_atomic(fake_xdit) is False
+    assert fake_xdit.read_text() == original
 
 
 def test_concurrent_calls_are_safe(fake_xdit: Path) -> None:

--- a/inference_optimizer/tests/test_xdit_patcher.py
+++ b/inference_optimizer/tests/test_xdit_patcher.py
@@ -1,0 +1,128 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Tests for ``_xdit_patcher.ensure_xdit_profiler_patched``.
+
+Pins the patcher contract: a backward-compatible, idempotent, concurrency-safe,
+fail-soft patch that inserts ``repeat=1`` into xDiT's ``torch.profiler.schedule``
+so the diffusion profiler retains its active window (upstream default
+``repeat=0`` discards it -> empty trace, Op count == 0). Fixtures synthesize a
+fake xfuser tree in ``tmp_path`` discovered via ``$XDIT_PATH``.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from inference_optimizer.orchestrator.action_executors import _xdit_patcher
+from inference_optimizer.orchestrator.action_executors._xdit_patcher import (
+    ensure_xdit_profiler_patched,
+)
+
+# Verbatim upstream shape (incl. the exact indentation the patcher matches on).
+_UPSTREAM_FIXTURE = """\
+class xFuserModel:
+    def profile(self, input_args):
+        schedule = torch.profiler.schedule(
+            wait=self.config.profile_wait,
+            warmup=self.config.profile_warmup,
+            active=self.config.profile_active,
+        )
+        num_repetitions = self.config.profile_wait + self.config.profile_warmup + self.config.profile_active
+        with profile(schedule=schedule) as profile_object:
+            for iteration in range(num_repetitions):
+                self._run_timed_pipe(input_args)
+                profile_object.step()
+"""
+
+_REL = ("xfuser", "model_executor", "models", "runner_models", "base_model.py")
+_SENTINEL = "# hyperloom: retain active window"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_xdit_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear ``$XDIT_PATH`` so a synthetic ``tmp_path`` test never discovers a
+    real on-pod xDiT checkout (tests that exercise discovery re-set it)."""
+    monkeypatch.delenv("XDIT_PATH", raising=False)
+
+
+@pytest.fixture
+def fake_xdit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Build a minimal ``$XDIT_PATH/xfuser/.../base_model.py`` tree."""
+    target = tmp_path.joinpath(*_REL)
+    target.parent.mkdir(parents=True)
+    target.write_text(_UPSTREAM_FIXTURE, encoding="utf-8")
+    monkeypatch.setenv("XDIT_PATH", str(tmp_path))
+    return target
+
+
+def test_first_call_inserts_repeat_one(fake_xdit: Path) -> None:
+    rc = ensure_xdit_profiler_patched()
+    assert rc is True
+    text = fake_xdit.read_text()
+    assert "repeat=1," in text
+    assert _SENTINEL in text
+
+
+def test_second_call_is_a_noop(fake_xdit: Path) -> None:
+    """Idempotency: re-applying must not double-patch or change bytes."""
+    ensure_xdit_profiler_patched()
+    after_first = fake_xdit.read_text()
+    rc = ensure_xdit_profiler_patched()
+    assert rc is True
+    assert fake_xdit.read_text() == after_first
+
+
+def test_repeat_appears_exactly_once(fake_xdit: Path) -> None:
+    for _ in range(5):
+        ensure_xdit_profiler_patched()
+    assert fake_xdit.read_text().count("repeat=1") == 1
+
+
+def test_patched_file_is_valid_python(fake_xdit: Path) -> None:
+    import ast
+
+    ensure_xdit_profiler_patched()
+    ast.parse(fake_xdit.read_text())
+
+
+def test_missing_legacy_block_is_fail_soft(tmp_path: Path, monkeypatch) -> None:
+    """A file without the schedule block leaves it untouched, returns False."""
+    target = tmp_path.joinpath(*_REL)
+    target.parent.mkdir(parents=True)
+    target.write_text("x = 1\n", encoding="utf-8")
+    monkeypatch.setenv("XDIT_PATH", str(tmp_path))
+    # Restrict discovery to the fake file so a real installed xfuser in the
+    # environment cannot make the patcher report success for another root.
+    monkeypatch.setattr(
+        _xdit_patcher, "_discover_xfuser_base_models", lambda: [target]
+    )
+    assert ensure_xdit_profiler_patched() is False
+    assert target.read_text() == "x = 1\n"
+
+
+def test_no_xdit_tree_is_fail_soft(monkeypatch) -> None:
+    """No discoverable base_model.py (empty $XDIT_PATH, no xfuser) -> False."""
+    monkeypatch.delenv("XDIT_PATH", raising=False)
+    monkeypatch.setattr(
+        _xdit_patcher, "_discover_xfuser_base_models", lambda: []
+    )
+    assert ensure_xdit_profiler_patched() is False
+
+
+def test_concurrent_calls_are_safe(fake_xdit: Path) -> None:
+    """flock + atomic rename: concurrent patchers must not corrupt the file."""
+    results: list[bool] = []
+
+    def _worker() -> None:
+        results.append(ensure_xdit_profiler_patched())
+
+    threads = [threading.Thread(target=_worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert all(results)
+    assert fake_xdit.read_text().count("repeat=1") == 1

--- a/kernel-agent/tools/diffusion_roofline.py
+++ b/kernel-agent/tools/diffusion_roofline.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""Workload-level (end-to-end) roofline for diffusion / scriptable traces.
+
+TraceLens' ``generate_perf_report_pytorch`` produces a *per-kernel* roofline
+(each op vs its dtype ceiling). For LLM decode, hyperloom also models a
+*workload-level* memory-bandwidth roofline (``roofline_ceiling.py``). Diffusion
+is the compute-bound dual of that: the DiT forward runs once per denoise step,
+dominated by large batched GEMMs + attention.
+
+This tool aggregates the per-kernel report into a single workload roofline:
+
+    - kernel roofline efficiency = Sigma(ideal kernel time) / Sigma(actual kernel time)
+    - gpu busy ratio             = busy_time / wall_time            (from gpu_timeline)
+    - end-to-end efficiency      ~ kernel_eff * gpu_busy_ratio
+    - per denoise-step timings   = totals / num_denoise_steps       (when provided)
+
+The two efficiency gaps it surfaces are complementary:
+  1. scheduling gap  (gpu_busy_ratio < 1): GPU idle / exposed comm / launch gaps.
+  2. kernel gap      (kernel_eff  < 1):    kernels below their roofline ceiling.
+
+Input is the ``--output_csvs_dir`` produced by generate_perf_report_pytorch
+(``unified_perf_summary.csv`` + optional ``gpu_timeline.csv``), so the workload
+roofline stays numerically consistent with the per-kernel roofline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+UNIFIED_CSV = "unified_perf_summary.csv"
+GPU_TIMELINE_CSV = "gpu_timeline.csv"
+
+# Column names as emitted by generate_perf_report_pytorch's unified summary.
+COL_KERNEL_TIME_SUM = "Kernel Time (\u00b5s)_sum"
+COL_ROOFLINE_TIME = "Roofline Time (\u00b5s)_first"
+COL_OP_COUNT = "operation_count"
+COL_BOUND = "Roofline Bound"
+COL_CATEGORY = "op category"
+COL_NAME = "name"
+
+
+def _to_float(value: Any) -> float:
+    """Best-effort float parse; blanks / non-numeric become 0.0."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _read_csv_rows(path: Path) -> list[dict[str, str]]:
+    """Read a CSV into a list of dict rows (empty list when missing)."""
+    if not path.is_file():
+        return []
+    with path.open(newline="") as f:
+        return list(csv.DictReader(f))
+
+
+def aggregate_unified(rows: list[dict[str, str]]) -> dict[str, Any]:
+    """Aggregate the unified per-kernel summary into workload totals.
+
+    Args:
+        rows: Parsed ``unified_perf_summary.csv`` rows.
+
+    Returns:
+        Dict of workload totals (actual/ideal us, bound split, kernel efficiency).
+    """
+    sigma_actual_us = 0.0
+    sigma_ideal_us = 0.0
+    compute_us = 0.0
+    memory_us = 0.0
+    no_model_us = 0.0
+    for r in rows:
+        actual = _to_float(r.get(COL_KERNEL_TIME_SUM))
+        count = _to_float(r.get(COL_OP_COUNT)) or 1.0
+        # Roofline Time is the per-instance ideal; scale by the aggregated count.
+        ideal = _to_float(r.get(COL_ROOFLINE_TIME)) * count
+        sigma_actual_us += actual
+        sigma_ideal_us += ideal
+        bound = (r.get(COL_BOUND) or "").upper()
+        if "COMPUTE" in bound:
+            compute_us += actual
+        elif "MEMORY" in bound:
+            memory_us += actual
+        else:
+            no_model_us += actual
+    kernel_eff = (sigma_ideal_us / sigma_actual_us) if sigma_actual_us > 0 else 0.0
+    return {
+        "sigma_actual_kernel_us": sigma_actual_us,
+        "sigma_ideal_roofline_us": sigma_ideal_us,
+        "kernel_roofline_efficiency": kernel_eff,
+        "compute_bound_us": compute_us,
+        "memory_bound_us": memory_us,
+        "no_perf_model_us": no_model_us,
+    }
+
+
+def parse_gpu_timeline(rows: list[dict[str, str]]) -> dict[str, float]:
+    """Extract busy / computation / exposed percentages from gpu_timeline.csv.
+
+    Args:
+        rows: Parsed ``gpu_timeline.csv`` rows (``type``, ``time ms``, ``percent``).
+
+    Returns:
+        Dict keyed by timeline ``type`` -> percent (empty when the file is absent).
+    """
+    out: dict[str, float] = {}
+    for r in rows:
+        kind = (r.get("type") or "").strip()
+        if kind:
+            out[kind] = _to_float(r.get("percent"))
+    return out
+
+
+def top_kernels(rows: list[dict[str, str]], k: int) -> list[dict[str, Any]]:
+    """Return the top-k kernels by actual kernel time for the summary block."""
+    ranked = sorted(rows, key=lambda r: _to_float(r.get(COL_KERNEL_TIME_SUM)), reverse=True)
+    out: list[dict[str, Any]] = []
+    for r in ranked[:k]:
+        out.append(
+            {
+                "name": (r.get(COL_NAME) or "")[:48],
+                "category": r.get(COL_CATEGORY) or "",
+                "bound": r.get(COL_BOUND) or "",
+                "kernel_time_us": _to_float(r.get(COL_KERNEL_TIME_SUM)),
+            }
+        )
+    return out
+
+
+def dit_analytic_flops(
+    hidden_size: int,
+    num_layers: int,
+    num_tokens: int,
+    num_denoise_steps: int,
+    ffn_ratio: float = 4.0,
+) -> dict[str, float]:
+    """A-priori forward FLOPs for a DiT-style transformer denoise run.
+
+    Standard dense-transformer accounting (2 FLOPs per MAC):
+
+      - linear (QKVO + FFN) per token/layer : 2 * (4 + 2*ffn_ratio) * h^2
+      - attention (scores + context)        : 2 * (2 * num_tokens * h)
+
+    scaled by ``num_layers * num_tokens * num_denoise_steps``. Positional MLPs,
+    adaLN modulation, patch/embed projections and the VAE are ignored, so this
+    is a lower bound on the true DiT compute (an optimistic ceiling for the
+    reconciliation cross-check, never a hard limit).
+
+    Args:
+        hidden_size: Transformer hidden dimension ``h``.
+        num_layers: Number of transformer blocks.
+        num_tokens: Sequence length (latent patches) per forward.
+        num_denoise_steps: Denoise steps in the profiled window.
+        ffn_ratio: FFN expansion factor (``intermediate / hidden``).
+
+    Returns:
+        Dict with ``linear_flops``, ``attention_flops`` and ``total_flops``.
+    """
+    h = float(hidden_size)
+    per_token_linear = 2.0 * (4.0 + 2.0 * ffn_ratio) * h * h
+    per_token_attention = 2.0 * (2.0 * float(num_tokens) * h)
+    scale = float(num_layers) * float(num_tokens) * float(num_denoise_steps)
+    linear = per_token_linear * scale
+    attention = per_token_attention * scale
+    return {
+        "linear_flops": linear,
+        "attention_flops": attention,
+        "total_flops": linear + attention,
+    }
+
+
+def dit_analytic_ceiling(
+    flops: dict[str, float], achievable_tflops: float
+) -> dict[str, Any]:
+    """Convert a-priori FLOPs into an achievable-compute time ceiling.
+
+    Args:
+        flops: Output of :func:`dit_analytic_flops`.
+        achievable_tflops: Sustained matrix TFLOPS for the run dtype (from
+            hyperloom's ``HW_SPECS_ACHIEVABLE``); the roofline ceiling divisor.
+
+    Returns:
+        Dict with the total FLOPs, the ceiling TFLOPS and the resulting
+        ideal (compute-bound) microseconds; empty when inputs are non-positive.
+    """
+    total = flops.get("total_flops", 0.0)
+    if total <= 0 or achievable_tflops <= 0:
+        return {}
+    ideal_us = total / (achievable_tflops * 1e12) * 1e6
+    return {
+        "total_flops": total,
+        "achievable_tflops": achievable_tflops,
+        "ideal_compute_us": ideal_us,
+    }
+
+
+def reconcile(
+    totals: dict[str, Any], analytic: dict[str, Any]
+) -> dict[str, Any]:
+    """Cross-check the a-priori DiT ceiling against the trace-derived roofline.
+
+    Compares the analytic compute-ideal time (from a-priori FLOPs / achievable
+    TFLOPS) against TraceLens' summed per-kernel ideal + actual times:
+
+      - ``analytic_vs_trace_ideal_ratio`` ~ 1 => the a-priori model matches the
+        kernels TraceLens attributed a perf model to (roofline is trustworthy).
+        >> 1 => the trace's per-kernel roofline under-counts DiT compute
+        (missing/unmodeled kernels); << 1 => the model omits real work.
+      - ``analytic_achieved_efficiency`` = analytic_ideal / trace_actual, the
+        end-to-end HW efficiency implied by the a-priori compute lower bound.
+
+    Args:
+        totals: Aggregated trace totals from :func:`aggregate_unified`.
+        analytic: Output of :func:`dit_analytic_ceiling` (may be empty).
+
+    Returns:
+        Dict of reconciliation ratios; empty when the analytic ceiling is absent.
+    """
+    ideal_us = analytic.get("ideal_compute_us", 0.0)
+    if ideal_us <= 0:
+        return {}
+    trace_ideal = totals.get("sigma_ideal_roofline_us", 0.0)
+    trace_actual = totals.get("sigma_actual_kernel_us", 0.0)
+    out: dict[str, Any] = {"analytic_ideal_compute_us": ideal_us}
+    if trace_ideal > 0:
+        out["analytic_vs_trace_ideal_ratio"] = ideal_us / trace_ideal
+    if trace_actual > 0:
+        out["analytic_achieved_efficiency"] = ideal_us / trace_actual
+    return out
+
+
+def build_report(
+    csv_dir: Path,
+    num_denoise_steps: int | None,
+    top_k: int,
+    *,
+    dit_geometry: dict[str, Any] | None = None,
+    achievable_tflops: float | None = None,
+) -> dict[str, Any]:
+    """Assemble the workload-level roofline report from a TraceLens CSV dir.
+
+    Args:
+        csv_dir: ``--output_csvs_dir`` from generate_perf_report_pytorch.
+        num_denoise_steps: Denoise steps in the profiled window (enables per-step).
+        top_k: How many hottest kernels to include.
+
+    Returns:
+        The full report dict (also what ``--output`` serializes).
+
+    Raises:
+        FileNotFoundError: When the unified summary CSV is missing.
+    """
+    unified_path = csv_dir / UNIFIED_CSV
+    unified_rows = _read_csv_rows(unified_path)
+    if not unified_rows:
+        raise FileNotFoundError(f"missing or empty {unified_path} (run generate_perf_report_pytorch first)")
+
+    totals = aggregate_unified(unified_rows)
+    timeline = parse_gpu_timeline(_read_csv_rows(csv_dir / GPU_TIMELINE_CSV))
+
+    busy_pct = timeline.get("busy_time")
+    gpu_busy_ratio = (busy_pct / 100.0) if busy_pct is not None else None
+    kernel_eff = totals["kernel_roofline_efficiency"]
+    end_to_end_eff = (kernel_eff * gpu_busy_ratio) if gpu_busy_ratio is not None else None
+
+    report: dict[str, Any] = {
+        "source_csv_dir": str(csv_dir),
+        "totals": totals,
+        "gpu_timeline_pct": timeline,
+        "gpu_busy_ratio": gpu_busy_ratio,
+        "end_to_end_efficiency_estimate": end_to_end_eff,
+        "top_kernels": top_kernels(unified_rows, top_k),
+    }
+
+    if num_denoise_steps and num_denoise_steps > 0:
+        report["num_denoise_steps"] = num_denoise_steps
+        report["per_step"] = {
+            "actual_kernel_us": totals["sigma_actual_kernel_us"] / num_denoise_steps,
+            "ideal_roofline_us": totals["sigma_ideal_roofline_us"] / num_denoise_steps,
+        }
+
+    # Optional a-priori DiT compute ceiling + reconciliation cross-check. Only
+    # emitted when the model geometry + achievable TFLOPS are supplied; never
+    # fabricated from the trace alone.
+    if dit_geometry and achievable_tflops and num_denoise_steps and num_denoise_steps > 0:
+        try:
+            flops = dit_analytic_flops(
+                hidden_size=int(dit_geometry["hidden_size"]),
+                num_layers=int(dit_geometry["num_layers"]),
+                num_tokens=int(dit_geometry["num_tokens"]),
+                num_denoise_steps=int(num_denoise_steps),
+                ffn_ratio=float(dit_geometry.get("ffn_ratio", 4.0)),
+            )
+            ceiling = dit_analytic_ceiling(flops, float(achievable_tflops))
+            if ceiling:
+                report["analytic_dit_ceiling"] = ceiling
+                recon = reconcile(totals, ceiling)
+                if recon:
+                    report["reconciliation"] = recon
+        except (KeyError, TypeError, ValueError):
+            pass
+    return report
+
+
+def _fmt_pct(x: float | None) -> str:
+    """Render a 0..1 ratio as a percentage string (``n/a`` when None)."""
+    return "n/a" if x is None else f"{100 * x:.1f}%"
+
+
+def print_summary(report: dict[str, Any]) -> None:
+    """Print a compact human-readable summary of the workload roofline."""
+    t = report["totals"]
+    print("=== diffusion workload roofline ===")
+    print(f"sigma actual kernel time : {t['sigma_actual_kernel_us'] / 1e6:.3f} s")
+    print(f"sigma ideal roofline time: {t['sigma_ideal_roofline_us'] / 1e6:.3f} s")
+    print(f"kernel roofline efficiency (ideal/actual): {_fmt_pct(t['kernel_roofline_efficiency'])}")
+    print(f"gpu busy ratio           : {_fmt_pct(report.get('gpu_busy_ratio'))}")
+    print(f"end-to-end efficiency est: {_fmt_pct(report.get('end_to_end_efficiency_estimate'))}")
+    denom = t["sigma_actual_kernel_us"] or 1.0
+    print(
+        "bound split (of actual):"
+        f" compute {100 * t['compute_bound_us'] / denom:.0f}%"
+        f" | memory {100 * t['memory_bound_us'] / denom:.0f}%"
+        f" | no-perf-model {100 * t['no_perf_model_us'] / denom:.0f}%"
+    )
+    if "per_step" in report:
+        ps = report["per_step"]
+        print(
+            f"per denoise-step ({report['num_denoise_steps']} steps):"
+            f" actual {ps['actual_kernel_us'] / 1e3:.2f} ms"
+            f" | ideal {ps['ideal_roofline_us'] / 1e3:.2f} ms"
+        )
+    if "analytic_dit_ceiling" in report:
+        ac = report["analytic_dit_ceiling"]
+        print(
+            "a-priori DiT ceiling:"
+            f" {ac['total_flops'] / 1e12:.1f} TFLOP @ {ac['achievable_tflops']:.0f} TFLOPS"
+            f" -> ideal {ac['ideal_compute_us'] / 1e3:.2f} ms"
+        )
+    if "reconciliation" in report:
+        rc = report["reconciliation"]
+        if "analytic_vs_trace_ideal_ratio" in rc:
+            print(f"reconciliation analytic/trace-ideal ratio: {rc['analytic_vs_trace_ideal_ratio']:.2f}")
+        if "analytic_achieved_efficiency" in rc:
+            print(f"reconciliation analytic achieved efficiency: {_fmt_pct(rc['analytic_achieved_efficiency'])}")
+    print("top kernels by time:")
+    for hk in report["top_kernels"]:
+        print(f"  {hk['kernel_time_us'] / 1e3:8.2f} ms  [{hk['bound']:12}] {hk['category']:14} {hk['name']}")
+
+
+def main() -> int:
+    """CLI entry point for the diffusion workload roofline aggregator."""
+    parser = argparse.ArgumentParser(description="Diffusion workload-level (end-to-end) roofline")
+    parser.add_argument(
+        "--perf-csv-dir",
+        required=True,
+        help="Directory produced by generate_perf_report_pytorch (--output_csvs_dir).",
+    )
+    parser.add_argument(
+        "--num-denoise-steps",
+        type=int,
+        default=0,
+        help="Denoise steps in the profiled window; enables per-step timings.",
+    )
+    parser.add_argument("--top-k", type=int, default=10, help="Hottest kernels to list.")
+    parser.add_argument("--output", default="", help="Optional path to write the report JSON.")
+    # Optional a-priori DiT ceiling cross-check (all four geometry flags + a
+    # ceiling source required to activate).
+    parser.add_argument("--dit-hidden-size", type=int, default=0, help="DiT hidden dim h (analytic ceiling).")
+    parser.add_argument("--dit-num-layers", type=int, default=0, help="DiT transformer block count.")
+    parser.add_argument("--dit-num-tokens", type=int, default=0, help="Latent patch/token count per forward.")
+    parser.add_argument("--dit-ffn-ratio", type=float, default=4.0, help="FFN expansion ratio.")
+    parser.add_argument(
+        "--achievable-tflops",
+        type=float,
+        default=0.0,
+        help="Sustained matrix TFLOPS ceiling; overrides --target-platform resolution.",
+    )
+    parser.add_argument(
+        "--target-platform",
+        default="",
+        help="GPU arch (e.g. MI355X); resolves achievable bf16 TFLOPS from HW_SPECS_ACHIEVABLE.",
+    )
+    args = parser.parse_args()
+
+    dit_geometry: dict[str, Any] | None = None
+    if args.dit_hidden_size > 0 and args.dit_num_layers > 0 and args.dit_num_tokens > 0:
+        dit_geometry = {
+            "hidden_size": args.dit_hidden_size,
+            "num_layers": args.dit_num_layers,
+            "num_tokens": args.dit_num_tokens,
+            "ffn_ratio": args.dit_ffn_ratio,
+        }
+    achievable = args.achievable_tflops or None
+    if achievable is None and args.target_platform:
+        try:
+            from inference_optimizer.orchestrator.roofline_ceiling import _resolve_achievable_tflops
+
+            resolved = _resolve_achievable_tflops(args.target_platform, "bf16")
+            achievable = resolved if resolved and resolved > 0 else None
+        except Exception:
+            achievable = None
+
+    report = build_report(
+        Path(args.perf_csv_dir).expanduser().resolve(),
+        args.num_denoise_steps or None,
+        args.top_k,
+        dit_geometry=dit_geometry,
+        achievable_tflops=achievable,
+    )
+    print_summary(report)
+    if args.output:
+        out_path = Path(args.output).expanduser().resolve()
+        out_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+        print(f"\nwrote {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/kernel-agent/tools/test_tracelens_arch_benchmark.py
+++ b/kernel-agent/tools/test_tracelens_arch_benchmark.py
@@ -173,6 +173,9 @@ def test_populate_gpu_arch_json_runs_microbench_when_missing(
 
     with (
         patch.object(tab, "resolve_arch_json_path", return_value=None),
+        # Force the microbench branch: hyperloom's achievable spec now
+        # short-circuits populate_gpu_arch_json (A3), so isolate the fallback.
+        patch.object(tab, "write_hyperloom_arch_spec", return_value=None),
         patch.object(
             tab,
             "select_idle_gpu",
@@ -263,6 +266,9 @@ def test_populate_external_raises_on_microbench_failure(
     """Open-source path surfaces a non-zero microbenchmark exit code."""
     with (
         patch.object(tab, "resolve_arch_json_path", return_value=None),
+        # A3 short-circuits on hyperloom's achievable spec; force the microbench
+        # branch so the non-zero exit code propagates as intended.
+        patch.object(tab, "write_hyperloom_arch_spec", return_value=None),
         patch.object(tab, "select_idle_gpu", return_value=0),
     ):
         with pytest.raises(RuntimeError, match="exit code 7"):

--- a/kernel-agent/tools/tracelens_analysis.py
+++ b/kernel-agent/tools/tracelens_analysis.py
@@ -4077,6 +4077,29 @@ def _raise_on_failed_deterministic_pipeline(
     )
 
 
+def _is_scriptable_framework(framework: str | None) -> bool:
+    """Return whether ``framework`` is a server-less scriptable image framework.
+
+    Scriptable frameworks (e.g. xDiT diffusion) have no LLM decode steady-state
+    phase, so trace analysis uses the plain pytorch perf report + skips the
+    steady-state splitter. Prefers the canonical ``framework_registry``; falls
+    back to a name check so the tool stays usable when run standalone (outside
+    an importable ``inference_optimizer`` package).
+
+    Args:
+        framework: Framework name (matched case-insensitively).
+
+    Returns:
+        bool: ``True`` for scriptable image frameworks.
+    """
+    try:
+        from inference_optimizer.framework_registry import is_scriptable
+
+        return is_scriptable(framework)
+    except Exception:
+        return str(framework or "").strip().lower() in {"xdit"}
+
+
 def _run_deterministic_tracelens_steps(
     trace_path: Path,
     output_dir: Path,
@@ -4113,22 +4136,40 @@ def _run_deterministic_tracelens_steps(
     csv_dir = output_dir / "perf_report_csvs"
     csv_dir.mkdir(parents=True, exist_ok=True)
 
-    # Step 1: perf report
-    report_cmd = [
-        sys.executable,
-        "-m",
-        "TraceLens.Reporting.generate_perf_report_pytorch_inference",
-        "--profile_json_path",
-        str(trace_path),
-        "--output_csvs_dir",
-        str(csv_dir),
-        "--gpu_arch_platform",
-        platform,
-        "--include_call_stack",
-        "--enable_pseudo_ops",
-    ]
-    if capture_folder and capture_folder.exists():
-        report_cmd += ["--capture_folder", str(capture_folder)]
+    # Step 1: perf report. Serving frameworks use the inference report (adds
+    # steady-state phase columns, call stacks, pseudo-ops, graph-capture replay).
+    # Scriptable image frameworks (xDiT diffusion) have no steady-state decode
+    # phase and no capture sidecar, so use the plain pytorch report, which is
+    # the variant validated to produce a clean per-kernel roofline for diffusion
+    # traces; the inference-only flags are omitted.
+    if _is_scriptable_framework(framework):
+        report_cmd = [
+            sys.executable,
+            "-m",
+            "TraceLens.Reporting.generate_perf_report_pytorch",
+            "--profile_json_path",
+            str(trace_path),
+            "--output_csvs_dir",
+            str(csv_dir),
+            "--gpu_arch_platform",
+            platform,
+        ]
+    else:
+        report_cmd = [
+            sys.executable,
+            "-m",
+            "TraceLens.Reporting.generate_perf_report_pytorch_inference",
+            "--profile_json_path",
+            str(trace_path),
+            "--output_csvs_dir",
+            str(csv_dir),
+            "--gpu_arch_platform",
+            platform,
+            "--include_call_stack",
+            "--enable_pseudo_ops",
+        ]
+        if capture_folder and capture_folder.exists():
+            report_cmd += ["--capture_folder", str(capture_folder)]
     rc = run_command(report_cmd, cwd=tl_root, log_path=log_path, timeout_s=timeout_s)
     if rc != 0:
         return rc
@@ -5731,6 +5772,40 @@ def write_reports(
         except Exception as exc:  # pragma: no cover - guard against import cycles
             print(f"[rocprof_enrich] skipped: {type(exc).__name__}: {exc}")
 
+    # Diffusion / scriptable workload-level roofline. TraceLens produces a
+    # *per-kernel* roofline (each op vs its dtype ceiling); for diffusion we also
+    # aggregate it into an end-to-end *workload* roofline (kernel efficiency x
+    # GPU busy ratio + optional per-denoise-step timings), mirroring the LLM
+    # decode memory-bound ceiling. Best-effort sidecar: never blocks the
+    # per-kernel report.
+    diffusion_roofline_path = ""
+    if _is_scriptable_framework(getattr(args, "framework", "")):
+        try:
+            tools_dir = str(Path(__file__).resolve().parent)
+            if tools_dir not in sys.path:
+                sys.path.insert(0, tools_dir)
+            from diffusion_roofline import build_report as _build_diffusion_roofline  # noqa: WPS433
+
+            _num_steps = int(getattr(args, "num_denoise_steps", 0) or 0)
+            _diff_report = _build_diffusion_roofline(
+                tracelens_dir / "perf_report_csvs",
+                _num_steps or None,
+                int(getattr(args, "top_k", 10) or 10),
+            )
+            out = run_dir / "diffusion_roofline.json"
+            atomic_write_json(out, _diff_report)
+            diffusion_roofline_path = str(out)
+            print(
+                "[diffusion_roofline] "
+                f"kernel_eff={_diff_report['totals']['kernel_roofline_efficiency']:.3f} "
+                f"gpu_busy_ratio={_diff_report.get('gpu_busy_ratio')} "
+                f"-> {out}"
+            )
+        except FileNotFoundError as exc:
+            print(f"[diffusion_roofline] skipped: {exc}")
+        except Exception as exc:  # noqa: BLE001 - best-effort sidecar
+            print(f"[diffusion_roofline] skipped: {type(exc).__name__}: {exc}")
+
     artifact_paths = {
         "trace_input_manifest": str(run_dir / "trace_input_manifest.json"),
         "kernel_candidates": str(kernel_candidates_path),
@@ -5740,6 +5815,8 @@ def write_reports(
         "trace_report_path": str(existing_report_path) if existing_report_path else "",
         "tracelens_summary": str(summary_path),
     }
+    if diffusion_roofline_path:
+        artifact_paths["diffusion_roofline"] = diffusion_roofline_path
     return artifact_paths
 
 
@@ -5832,6 +5909,16 @@ def main() -> int:
         "Leave empty for the open-source-only report.",
     )
     parser.add_argument("--roofline-json", default="")
+    parser.add_argument(
+        "--num-denoise-steps",
+        type=int,
+        default=int(os.environ.get("HYPERLOOM_NUM_DENOISE_STEPS", "0") or 0),
+        help=(
+            "Denoise steps captured in the profiled window (scriptable/xDiT "
+            "diffusion only). Enables per-denoise-step timings in the workload "
+            "roofline sidecar. Env: HYPERLOOM_NUM_DENOISE_STEPS."
+        ),
+    )
     parser.add_argument(
         "--roofline-output-name",
         default="kernel_roofline.json",

--- a/kernel-agent/tools/tracelens_arch_benchmark.py
+++ b/kernel-agent/tools/tracelens_arch_benchmark.py
@@ -205,6 +205,90 @@ def resolve_arch_json_path(platform: str) -> Path | None:
     return None
 
 
+#: hyperloom achievable-TFLOPS precision tag -> TraceLens ``max_achievable_tflops``
+#: matrix key. hyperloom keeps a single dtype table (roofline_ceiling.HW_SPECS_
+#: ACHIEVABLE); TraceLens roofline keys ceilings by ComputeSpec (matrix_<dtype>).
+_HYPERLOOM_DTYPE_TO_MATRIX_KEY: dict[str, str] = {
+    "bf16": "matrix_bf16",
+    "fp16": "matrix_fp16",
+    "fp32": "matrix_fp32",
+    "fp8": "matrix_fp8",
+    "fp4": "matrix_fp4",
+    "int8": "matrix_int8",
+}
+
+
+def build_hyperloom_arch_spec(platform: str) -> dict | None:
+    """Build a TraceLens arch spec from hyperloom's own achievable-TFLOPS table.
+
+    Uses ``roofline_ceiling.HW_SPECS_ACHIEVABLE`` (the in-repo, NDA-clear
+    achievable ceilings shared with the LLM baseline roofline) as the single
+    source of truth, so TraceLens' per-kernel roofline never depends on the
+    public bundle (MI300X/MI325X only), a TraceLens-internal checkout, or a live
+    GPU microbenchmark for newer cards (e.g. MI355X).
+
+    Args:
+        platform: Platform/architecture name (matched case-insensitively).
+
+    Returns:
+        dict | None: A TraceLens arch spec (``name`` / ``mem_bw_gbps`` /
+        ``memory_gb`` / ``max_achievable_tflops``), or ``None`` when hyperloom
+        has no achievable spec for the platform.
+    """
+    try:
+        from inference_optimizer.orchestrator.roofline_ceiling import HW_SPECS_ACHIEVABLE
+    except Exception:
+        return None
+    spec = HW_SPECS_ACHIEVABLE.get((platform or "").strip().lower())
+    if not isinstance(spec, dict):
+        return None
+    table = spec.get("peak_tflops")
+    if not isinstance(table, dict):
+        return None
+    maf: dict[str, float] = {}
+    for tag, matrix_key in _HYPERLOOM_DTYPE_TO_MATRIX_KEY.items():
+        val = table.get(tag)
+        if isinstance(val, (int, float)) and val > 0:
+            maf[matrix_key] = float(val)
+    mem_bw = spec.get("hbm_bw_gbps")
+    if not maf or not isinstance(mem_bw, (int, float)) or mem_bw <= 0:
+        return None
+    out: dict = {"name": normalize_platform(platform), "mem_bw_gbps": float(mem_bw)}
+    mem_gb = spec.get("hbm_gb")
+    if isinstance(mem_gb, (int, float)) and mem_gb > 0:
+        out["memory_gb"] = float(mem_gb)
+    out["max_achievable_tflops"] = maf
+    return out
+
+
+def write_hyperloom_arch_spec(
+    tracelens_root: Path, platform: str, log: Callable[[str], None]
+) -> Path | None:
+    """Write hyperloom's achievable arch spec into the TraceLens arch dir.
+
+    Args:
+        tracelens_root: Root of the TraceLens checkout.
+        platform: Target platform/architecture name.
+        log: Logging callable for diagnostics.
+
+    Returns:
+        Path | None: The written arch JSON path, or ``None`` when hyperloom has
+        no spec for the platform (caller falls back to the microbenchmark).
+    """
+    spec = build_hyperloom_arch_spec(platform)
+    if spec is None:
+        return None
+    out_path = default_arch_output_path(tracelens_root, platform)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(spec, indent=4) + "\n", encoding="utf-8")
+    log(
+        f"gpu_arch_json: wrote hyperloom achievable spec for {spec['name']} "
+        f"-> {out_path} (mem_bw={spec['mem_bw_gbps']} GB/s, "
+        f"dtypes={sorted(spec['max_achievable_tflops'])})"
+    )
+    return out_path
+
+
 def default_arch_output_path(tracelens_root: Path, platform: str) -> Path:
     """Return the default arch-spec JSON path for a platform.
 
@@ -353,6 +437,14 @@ def populate_gpu_arch_json(
     canonical = normalize_platform(platform)
     if not canonical:
         raise RuntimeError("target platform is empty; cannot resolve or generate gpu arch JSON")
+
+    # Prefer hyperloom's in-repo achievable spec (NDA-clear, shared with the LLM
+    # baseline roofline) over a live microbenchmark: newer cards (e.g. MI355X)
+    # are absent from the public bundle, and this keeps a single source of truth
+    # without needing an idle GPU or a TraceLens-internal checkout.
+    hyperloom_spec = write_hyperloom_arch_spec(tracelens_root, canonical, log)
+    if hyperloom_spec is not None:
+        return hyperloom_spec
 
     out_path = default_arch_output_path(tracelens_root, canonical)
     log(


### PR DESCRIPTION
…tency snapshot

Add end-to-end roofline support for scriptable (xDiT diffusion) workloads:
- A: auto --skip-split, framework-based perf-report selection, and a TraceLens arch spec derived from HW_SPECS_ACHIEVABLE (MI355X) injected before analysis.
- B: scriptable-aware profile-window envs and trace-structure validation.
- C: diffusion_roofline workload-level aggregation (kernel efficiency x GPU busy), per-denoise-step timings, a-priori DiT compute ceiling, and reconciliation.
- D: roofline snapshot renders the achieved metric in the framework-correct unit.

Also carry e2e_mean_ms / roofline_ideal_ms as siblings of the tok/s fields in the roofline snapshot so the session breakdown adapts by unit: scriptable shows a compute-latency roofline (ideal ms floor + measured e2e + within/gap) where the tok/s decode ceiling does not apply, with within/gap derived unit-agnostically.

Update arch-benchmark tests for the new hyperloom-spec precedence and make the patcher fail-soft test hermetic against an installed xfuser.

- Description: what and why
- Linked issue(s): close/fix refs
- Tests: added/updated? commands run?
- Breaking changes: yes/no (details if yes)
