### PR TITLE
fix(perfskills): preserve serving fidelity in handoff

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_perfskills_resume_recovery.py
+++ b/src/hyperloom/inference_optimizer/tests/test_perfskills_resume_recovery.py
@@ -160,3 +160,55 @@ async def test_perfskills_kernel_phase_does_not_reuse_already_promoted_result(
     # The recovery short-circuit must NOT have fired; the normal path resolves
     # the runner (and here aborts via the injected error).
     assert resolved, "new cycle must re-run PerfSkills, not reuse stale result.json"
+
+
+@pytest.mark.asyncio
+async def test_perfskills_handoff_preserves_serving_fidelity_knobs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PerfSkills must baseline the same engine Hyperloom measured.
+
+    A missing max-model-len or GPU memory-utilization handoff lets GEAK/e2e
+    launch a subtly different vLLM server than the Hyperloom baseline, which
+    turns kernel wins into non-reproducible E2E deltas.
+    """
+    coord = Coordinator.__new__(Coordinator)
+    coord.session_dir = tmp_path
+    coord.shared_state = SharedState(
+        baseline_tput=100.0,
+        current_best={
+            "action": "baseline",
+            "tput": 100.0,
+            "extra_server_args": "--no-enable-prefix-caching",
+        },
+        model_path="/models/gpt-oss-120b",
+        gpu_type="mi355x",
+        isl=1024,
+        osl=1024,
+        conc=64,
+        max_model_len=2248,
+    )
+    coord.phase_kernel._record_perfskills_kernel_journey = lambda _result: None
+
+    monkeypatch.setenv("FRAMEWORK", "vllm")
+    monkeypatch.setenv("TP", "8")
+    monkeypatch.setenv("GPU_MEMORY_UTILIZATION", "0.9")
+
+    def _runner_resolved(_name: str) -> Path:
+        raise RuntimeError("stop after handoff write")
+
+    monkeypatch.setattr(
+        "hyperloom.orchestrator.kernel.request_handlers._kernel_agent_tool_path",
+        _runner_resolved,
+    )
+
+    await coord._run_perfskills_kernel_phase(from_phase="KERNEL")
+
+    handoff = json.loads(
+        (tmp_path / "perfskills" / "handoff.json").read_text(encoding="utf-8")
+    )
+    assert handoff["max_model_len"] == 2248
+    assert handoff["mem_fraction"] == pytest.approx(0.9)
+    assert handoff["accepted_flags"] == "--no-enable-prefix-caching"
+    assert handoff["raw_baseline_tput"] == 100.0

--- a/src/hyperloom/orchestrator/phases/kernel.py
+++ b/src/hyperloom/orchestrator/phases/kernel.py
@@ -462,6 +462,13 @@ class KernelPhase(PhaseHandler):
             "accepted_env": accepted_env,
             "launch_recipe": str(getattr(state, "baseline_config_path", "") or ""),
             "raw_baseline_tput": float(getattr(state, "baseline_tput", 0.0) or 0.0),
+            # Serving-launch fidelity: forward the same max-model-len / mem-util production
+            # (Magpie) served with, so GEAK's baseline launches the SAME engine and its baseline
+            # matches raw_baseline_tput (else the accepted SP config crashes and GEAK re-baselines
+            # on a slower stack default -> kernel wins never translate e2e). Both optional: when
+            # unset the GEAK vllm adapter applies its own production-faithful defaults.
+            "max_model_len": int(getattr(state, "max_model_len", 0) or int(os.environ.get("MAX_MODEL_LEN", "0") or 0)),
+            "mem_fraction": float(getattr(state, "mem_fraction", 0.0) or float(os.environ.get("GPU_MEMORY_UTILIZATION", "0") or 0.0)),
             "exp_root": str(self.session_dir / "perfskills"),
             # Align PerfSkills' bench CLIENT to Hyperloom's exact one (InferenceX
             # benchmark_serving.py) so final/sweep numbers are cross-harness comparable.


### PR DESCRIPTION
## Summary

- Forward `max_model_len` and `mem_fraction` into the PerfSkills handoff so GEAK/e2e launches the same vLLM engine Hyperloom measured.
- Add a regression test covering the handoff JSON before the PerfSkills runner is invoked.
- Links to #805, which documents the full TraceLens/GEAK attribution failure and the fixed-stack reproduction.

## Why

PerfSkills/GEAK-e2e uses its own baseline before optimizing kernels. If Hyperloom does not pass the same serving fidelity knobs used by its Magpie baseline, GEAK can re-baseline a different engine and then report kernel deltas that do not reproduce in Hyperloom E2E.

This is especially important for gpt-oss-120b MXFP4 / vLLM on MI355X where these knobs define the production engine:

```bash
--no-enable-prefix-caching --block-size 64 --max-model-len 2248 --trust-remote-code --gpu-memory-utilization 0.9
```

and env knobs enable the intended AITER/MXFP4 path.

## Repro / validation performed

Environment:

- 8x MI355X (`gfx950`)
- vLLM `0.21.0+rocm722`
- Model: `openai/gpt-oss-120b` MXFP4
- Workload: ISL=1024, OSL=1024, CONC=64, TP=8
- Hyperloom `main` at `9b8f8ad`
- TraceLens `main` at `df2419e`
- TraceLens-internal `a0012e42` with `TL_EXTENSION=TraceLens_internal`
- GEAK `GEAK_v4` at `6b0bf8f8` plus the RUNDOC pass-through/divergence-guard patch

Baseline smoke:

- Standalone GEAK/e2e smoke launched with the production args above and confirmed banner:
  - `gpu_memory_utilization: 0.9`
  - `max_seq_len: 2248`
  - `trust_remote_code: True`
  - `AITER_MXFP4_BF16` MoE backend
- Median throughput: `13237.075 tok/s`, spread `2.78%`

Fixed-stack Hyperloom run:

- Hyperloom baseline: `12579.1 tok/s`
- `_server_patcher`: `applied 1 TraceLens patch(es) for vllm 0.21.0 (strict=1)`
- `capture_traces/` populated with `graph_capture_rank_0.*.pt.trace.json.gz`
- MI355X roofline resolved via TraceLens-internal:
  - BF16 ~= 1725 TFLOPS
  - FP8 ~= 3500 TFLOPS
  - FP4 ~= 5660 TFLOPS
  - HBM ~= 7.4 TB/s
- `kernel_roofline.json`: 54 kernels, 44 reusable/native rows
- `kernel_candidates.json`: 44 reusable rows
- The previous `hipGraphLaunch` 78% unresolved bucket no longer dominates the list.
- MoE/attention/GEMM kernels are source-resolved candidates, including:
  - `aiter::moe_cktile2stages_gemm2_ck`
  - `aiter::moe_cktile2stages_gemm1_ck`
  - `vllm::unified_attention_with_output`
  - `vllm::rocm_aiter_fused_allreduce_rmsnorm`

Top reusable groups observed after the fix:

| Group | Aggregate GPU% |
|---|---:|
| `vllm::rocm_aiter_fused_allreduce_rmsnorm` | 22.43 |
| `_C_custom_ar::all_reduce` | 13.58 |
| `vllm::rocm_unquantized_gemm` | 9.04 |
| `aiter::moe_cktile2stages_gemm2_ck` | 8.69 |
| `vllm::unified_attention_with_output` | 5.61 |
| `aiter::moe_cktile2stages_gemm1_ck` | 3.24 |
| `aiter::moe_sorting_fwd` | 3.21 |

## Test plan

- `python3 -m pytest inference_optimizer/tests/test_perfskills_resume_recovery.py -q`
- Result: `3 passed in 0.17s`

## Notes

This PR does not hard-code any model-specific defaults into adapters. It preserves the existing pass-through design: Hyperloom forwards the fidelity knobs it already knows, and PerfSkills/GEAK can still rely on its own defaults when these fields are absent.

Closes #805.
