### PR TITLE
Feat: create a quick-start docker image that minimizes user configurations and speeds up optimization process by pre-installing deps/components

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -52,7 +52,7 @@ OPENAI_BASE_URL=https://global.primus-safe.amd.com/api/v1/llm-proxy/v1
 CURSOR_API_KEY=
 # TraceLens public repo checkout. Leave empty to auto-clone under
 # $USER_DATA_PATH/runtime/source-mirrors/.
-TRACELENS_ROOT=
+TRACELENS_ROOT=/opt/TraceLens
 # OPTIONAL internal extension (roofline gap, gains, MI355/MI455 MAF). Set to its
 # checkout path ONLY to enable it; leave empty for the open-source-only report.
 # Presence of this value is the sole switch — there is no separate toggle.

--- a/quick-start/Dockerfile
+++ b/quick-start/Dockerfile
@@ -16,15 +16,14 @@ RUN --mount=type=ssh mkdir -p -m 700 /root/.ssh \
 RUN --mount=type=ssh export KERNEL_FORGE_REPO="git@github.com:AMD-AGI/KernelForge.git" && \
     bash /opt/Hyperloom/inference_optimizer/scripts/local_setup.sh --deps-root /opt --session-dir /workspace/hyperloom
 
-RUN cp /opt/Hyperloom/.env.template /opt/Hyperloom/.env
-
 COPY *.sh /workspace/hyperloom/
 RUN chmod +x /workspace/hyperloom/*.sh
 
+RUN cp /opt/Hyperloom/.env.template /opt/Hyperloom/.env
 
-ARG HYPERLOOM_REFRESH=0
-#tmp patch
-RUN --mount=type=ssh cd /opt/Hyperloom && git pull && git checkout feature/percy/quick-start && git log -2
+RUN mkdir -p /workspace/hyperloom/logs && \
+SKIP_RAY_START=1 KERNEL_AGENT_SKIP_MODEL_LOAD=1 bash -o pipefail -c  "/opt/Hyperloom/inference_optimizer/scripts/install.sh 2>&1 | tee /workspace/hyperloom/logs/pre-install.log"
 
+WORKDIR /opt/Hyperloom
 ENTRYPOINT ["/workspace/hyperloom/setup_env.sh"]
 

--- a/quick-start/Dockerfile
+++ b/quick-start/Dockerfile
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1.4
+FROM primussafe/sglang:v0.5.11-rocm720-mi30x-profilerfix
+
+
+#install AMD self-signed certificate
+RUN curl -fsSL https://raw.githubusercontent.com/AMD-AGI/Primus-SaFE/main/Scripts/setup-certs/setup.sh | bash
+
+
+RUN mkdir -p /workspace/hyperloom
+
+#clone Hyperloom
+RUN --mount=type=ssh mkdir -p -m 700 /root/.ssh \
+    && ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> /root/.ssh/known_hosts \
+    && git clone git@github.com:AMD-AGI/Hyperloom.git /opt/Hyperloom
+
+RUN --mount=type=ssh export KERNEL_FORGE_REPO="git@github.com:AMD-AGI/KernelForge.git" && \
+    bash /opt/Hyperloom/inference_optimizer/scripts/local_setup.sh --deps-root /opt --session-dir /workspace/hyperloom
+
+RUN cp /opt/Hyperloom/.env.template /opt/Hyperloom/.env
+
+COPY *.sh /workspace/hyperloom/
+RUN chmod +x /workspace/hyperloom/*.sh
+
+
+ARG HYPERLOOM_REFRESH=0
+#tmp patch
+RUN --mount=type=ssh cd /opt/Hyperloom && git pull && git checkout feature/percy/quick-start && git log -2
+
+ENTRYPOINT ["/workspace/hyperloom/setup_env.sh"]
+

--- a/quick-start/check_env.sh
+++ b/quick-start/check_env.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+source /opt/Hyperloom/.env
+
+#check if the llm gateway api is set up correctly
+response=$(echo curl -s -H \"Authorization: Bearer  ${SAFE_API_KEY}\" ${OPENAI_BASE_URL}/models | bash)
+
+#check if the response is a valid json
+if ! echo "$response" | jq . > /dev/null 2>&1; then
+    echo "Error: Failed to get a valid response from the llm gateway"
+    echo "Response: $response"
+    exit 1
+fi
+
+model=$(echo $response | jq ".data[0].id")
+
+if [ -z "$model" ]; then
+    echo "Error when checking llm gateway with the response: " ${response} 
+    echo " Please check your SAFE_API_KEY"
+    exit 1
+fi
+
+echo "LLM gateway is set up correctly"

--- a/quick-start/setup_env.sh
+++ b/quick-start/setup_env.sh
@@ -28,4 +28,5 @@ fi
 USER_DATA_PATH=${USER_DATA_PATH:-"/workspace/hyperloom"}
 sed -i "s|USER_DATA_PATH=.*|USER_DATA_PATH=${USER_DATA_PATH}|g" /opt/Hyperloom/.env
 
+
 tail -f /dev/null

--- a/quick-start/setup_env.sh
+++ b/quick-start/setup_env.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+#in /opt/Hyperloom/.env file, there's a line like this:
+#SAFE_API_KEY=ak-your-api-key-here
+#we need to replace the value of SAFE_API_KEY with the value of the environment variable SAFE_API_KEY
+sed -i "s/SAFE_API_KEY=ak-your-api-key-here/SAFE_API_KEY=${SAFE_API_KEY}/g" /opt/Hyperloom/.env
+
+#if $OPENAI_BASE_URL is set, replace it in the .env file by matching the pattern OPENAI_BASE_URL=* and replacing the value with the value of the environment variable OPENAI_BASE_URL
+if [ -n "${OPENAI_BASE_URL}" ]; then
+    sed -i "s|OPENAI_BASE_URL=.*|OPENAI_BASE_URL=${OPENAI_BASE_URL}|g" /opt/Hyperloom/.env
+fi
+
+if [ -n "${CURSOR_API_KEY}" ]; then
+    sed -i "s|CURSOR_API_KEY=.*|CURSOR_API_KEY=${CURSOR_API_KEY}|g" /opt/Hyperloom/.env
+fi
+
+TRACELENS_ROOT=${TRACELENS_ROOT:-"/opt/TraceLens"}
+sed -i "s|TRACELENS_ROOT=.*|TRACELENS_ROOT=${TRACELENS_ROOT}|g" /opt/Hyperloom/.env
+
+if [ -n "${TRACELENS_INTERNAL_ROOT}" ]; then
+    sed -i "s|TRACELENS_INTERNAL_ROOT=.*|TRACELENS_INTERNAL_ROOT=${TRACELENS_INTERNAL_ROOT}|g" /opt/Hyperloom/.env
+fi
+
+if [ -n "${INFERENCE_OPTIMIZER_FRAMEWORK_SOURCE_ROOTS}" ]; then
+    sed -i "s|INFERENCE_OPTIMIZER_FRAMEWORK_SOURCE_ROOTS=.*|INFERENCE_OPTIMIZER_FRAMEWORK_SOURCE_ROOTS=${INFERENCE_OPTIMIZER_FRAMEWORK_SOURCE_ROOTS}|g" /opt/Hyperloom/.env
+fi
+
+USER_DATA_PATH=${USER_DATA_PATH:-"/workspace/hyperloom"}
+sed -i "s|USER_DATA_PATH=.*|USER_DATA_PATH=${USER_DATA_PATH}|g" /opt/Hyperloom/.env
+
+tail -f /dev/null

--- a/src/hyperloom/agents/kernel/scripts/install.sh
+++ b/src/hyperloom/agents/kernel/scripts/install.sh
@@ -268,6 +268,9 @@ fi
 # propagates Environment block vars from the prompt into sandbox env, so
 # operators can flip this per-task without editing this script).
 KERNEL_AGENT_BUILD_GEAK_RAG_INDEX_VAL="${KERNEL_AGENT_BUILD_GEAK_RAG_INDEX:-1}"
+# Explicit alias for operators who want to skip the final model/index load
+# step during install (e.g. Docker builds without visible GPUs).
+KERNEL_AGENT_SKIP_MODEL_LOAD_VAL="${KERNEL_AGENT_SKIP_MODEL_LOAD:-0}"
 GEAK_MEMORY_STORE_PATH_VAL="${GEAK_MEMORY_STORE_PATH:-/wekafs/hyperloom/geak-memory/memory.db}"
 GEAK_SAVE_TO_KNOWLEDGE_BASE_VAL="${GEAK_SAVE_TO_KNOWLEDGE_BASE:-1}"
 GEAK_MEMORY_MIN_SPEEDUP_VAL="${GEAK_MEMORY_MIN_SPEEDUP:-1.20}"
@@ -337,6 +340,7 @@ Options:
   --dry-run          Print actions without running installs
   --with-perfskills  Also install the PerfSkills/GEAK-e2e optimizer checkout
                      (only needed for KERNEL_OPT_BACKEND_ORDER=perfskills runs).
+  --skip-model-load  Skip the final GEAK RAG model/index build step.
   -h, --help         Show this help
 
 Environment (optional):
@@ -345,6 +349,8 @@ Environment (optional):
   KERNEL_AGENT_BUILD_GEAK_RAG_INDEX=1   Build the GEAK semantic RAG index in ensure_rag_index (default).
                                         Set 0 to skip — useful for claude-only kernel-opt or CPU-only
                                         sandboxes where BGE-large embedding takes ~1.5h.
+  KERNEL_AGENT_SKIP_MODEL_LOAD=1        Alias to skip model/index loading at install time.
+                                        Equivalent to KERNEL_AGENT_BUILD_GEAK_RAG_INDEX=0.
   INSTALL_PERFSKILLS=1                  Install the PerfSkills/GEAK-e2e optimizer checkout (default 0).
                                         Equivalent to --with-perfskills. Default native users skip it.
 EOF
@@ -355,6 +361,7 @@ while [ "$#" -gt 0 ]; do
     --check-only) CHECK_ONLY=1 ;;
     --dry-run) DRY_RUN=1 ;;
     --with-perfskills) INSTALL_PERFSKILLS=1 ;;
+    --skip-model-load) KERNEL_AGENT_SKIP_MODEL_LOAD_VAL=1 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "[kernel-agent] ERROR: unknown option '$1'" >&2; usage >&2; exit 2 ;;
   esac
@@ -1300,6 +1307,12 @@ PY
 }
 
 ensure_rag_index() {
+  case "$KERNEL_AGENT_SKIP_MODEL_LOAD_VAL" in
+    1|true|TRUE|yes|YES|on|ON)
+      log "skipping GEAK model/index load step (KERNEL_AGENT_SKIP_MODEL_LOAD=$KERNEL_AGENT_SKIP_MODEL_LOAD_VAL)"
+      return 0
+      ;;
+  esac
   case "$KERNEL_AGENT_BUILD_GEAK_RAG_INDEX_VAL" in
     0|false|FALSE|no|NO|off|OFF)
       log "skipping GEAK RAG index build (KERNEL_AGENT_BUILD_GEAK_RAG_INDEX=$KERNEL_AGENT_BUILD_GEAK_RAG_INDEX_VAL)"

--- a/src/hyperloom/agents/kernel/scripts/install.sh
+++ b/src/hyperloom/agents/kernel/scripts/install.sh
@@ -305,6 +305,13 @@ CURSOR_DEFAULT_MODEL_VAL="${CURSOR_DEFAULT_MODEL:-claude-opus-4-7-thinking-xhigh
 # not differentiate, just install everything".
 CHECK_ONLY=0
 DRY_RUN=0
+# Optional build-time escape hatch: skip Ray daemon startup while still
+# installing Ray itself and all downstream dependencies (TraceLens/GEAK/OOB).
+# Useful in Docker image builds where launching background daemons is fragile.
+case "${SKIP_RAY_START:-0}" in
+  1|true|TRUE|yes|YES|on|ON) SKIP_RAY_START=1 ;;
+  *) SKIP_RAY_START=0 ;;
+esac
 # The PerfSkills/GEAK-e2e optimizer is OPT-IN: it is only used at runtime when a
 # session sets ``KERNEL_OPT_BACKEND_ORDER=perfskills``. The default runtime
 # optimizer is ``native``, so installing the second GEAK-e2e checkout (extra clone + network
@@ -333,6 +340,8 @@ Options:
   -h, --help         Show this help
 
 Environment (optional):
+  SKIP_RAY_START=1                      Skip `ray start --head` during install (default 0).
+                                        Installs ray/click but defers daemon startup to runtime.
   KERNEL_AGENT_BUILD_GEAK_RAG_INDEX=1   Build the GEAK semantic RAG index in ensure_rag_index (default).
                                         Set 0 to skip — useful for claude-only kernel-opt or CPU-only
                                         sandboxes where BGE-large embedding takes ~1.5h.
@@ -750,6 +759,10 @@ ensure_fd_limit_for_ray() {
 #      non-fatal in environments without ROCm
 ensure_ray_started() {
   if [ "$CHECK_ONLY" -eq 1 ] || [ "$DRY_RUN" -eq 1 ]; then
+    return 0
+  fi
+  if [ "$SKIP_RAY_START" -eq 1 ]; then
+    log "skipping ray head startup (SKIP_RAY_START=1)"
     return 0
   fi
   if ! command -v ray >/dev/null 2>&1; then

--- a/src/hyperloom/agents/kernel/scripts/install.sh
+++ b/src/hyperloom/agents/kernel/scripts/install.sh
@@ -796,12 +796,73 @@ _pip_install_editable() {
     fi
     die "${label} checkout not found: ${root}"
   fi
+  if [ "$CHECK_ONLY" -eq 0 ]; then
+    local project_name
+    project_name="$(_project_name_from_pyproject "$root")"
+    if [ -n "$project_name" ] && _local_install_matches_root "$project_name" "$root"; then
+      log "${label} already installed from ${root}; skipping reinstall"
+      return 0
+    fi
+  fi
   log "ensuring ${label} editable install from ${root}"
   if [ "$CHECK_ONLY" -eq 0 ]; then
     # Do not use bash -lc: login profiles reset PATH (drops venv) and break pip.
     run sh -c "cd '$root' && python3 -m pip install -q --no-cache-dir --break-system-packages -e ."
   fi
   return 0
+}
+
+_project_name_from_pyproject() {
+  local root="$1"
+  local pyproject="${root%/}/pyproject.toml"
+  [ -f "$pyproject" ] || return 0
+  python3 - "$pyproject" <<'PY' 2>/dev/null || true
+import sys
+path = sys.argv[1]
+try:
+    import tomllib
+except Exception:
+    import tomli as tomllib  # py<3.11 fallback
+with open(path, "rb") as f:
+    data = tomllib.load(f)
+name = (((data.get("project") or {}).get("name")) or "").strip()
+print(name)
+PY
+}
+
+_local_install_matches_root() {
+  local project_name="$1"
+  local root="$2"
+  [ -n "$project_name" ] || return 1
+  python3 - "$project_name" "$root" <<'PY' >/dev/null 2>&1
+import importlib.metadata
+import json
+import os
+import sys
+from urllib.parse import urlparse, unquote
+
+project = sys.argv[1]
+root = os.path.realpath(sys.argv[2])
+try:
+    dist = importlib.metadata.distribution(project)
+except importlib.metadata.PackageNotFoundError:
+    raise SystemExit(1)
+direct = dist.read_text("direct_url.json")
+if not direct:
+    raise SystemExit(1)
+try:
+    payload = json.loads(direct)
+except Exception:
+    raise SystemExit(1)
+url = payload.get("url") or ""
+if not url.startswith("file:"):
+    raise SystemExit(1)
+parsed = urlparse(url)
+installed_root = os.path.realpath(unquote(parsed.path))
+if os.path.normcase(installed_root) != os.path.normcase(root):
+    raise SystemExit(1)
+raise SystemExit(0)
+PY
 }
 
 # Internal extension is opt-in: enabled iff $TRACELENS_INTERNAL_ROOT is set.
@@ -974,7 +1035,11 @@ ensure_geak() {
     if [ -n "${GEAK_PIP_CONSTRAINT_FILE:-}" ] && [ -f "${GEAK_PIP_CONSTRAINT_FILE}" ]; then
       _PIP_CONSTRAINT_ARGS="--constraint ${GEAK_PIP_CONSTRAINT_FILE}"
     fi
-    run python3 -m pip install ${_PIP_FLAGS} ${_PIP_CONSTRAINT_ARGS} "${GEAK_ROOT}"
+    if _local_install_matches_root "mini-swe-agent" "${GEAK_ROOT}"; then
+      log "GEAK already installed from ${GEAK_ROOT}; skipping pip reinstall"
+    else
+      run python3 -m pip install ${_PIP_FLAGS} ${_PIP_CONSTRAINT_ARGS} "${GEAK_ROOT}"
+    fi
     # GEAK v3.2.0 ships 4 MCP tools under mcp_tools/; all are imported
     # by the bundled ``minisweagent`` at preprocess time:
     #   * rag-mcp                    — knowledge-base retrieval (tools.rag)
@@ -990,8 +1055,12 @@ ensure_geak() {
     # break install with "File ... does not exist".
     for _geak_mcp in rag-mcp profiler-mcp \
                     cross-session-memory-mcp automated-test-discovery; do
-      run python3 -m pip install ${_PIP_FLAGS} ${_PIP_CONSTRAINT_ARGS} \
-        "${GEAK_ROOT}/mcp_tools/${_geak_mcp}"
+      if _local_install_matches_root "${_geak_mcp}" "${GEAK_ROOT}/mcp_tools/${_geak_mcp}"; then
+        log "${_geak_mcp} already installed from ${GEAK_ROOT}/mcp_tools/${_geak_mcp}; skipping pip reinstall"
+      else
+        run python3 -m pip install ${_PIP_FLAGS} ${_PIP_CONSTRAINT_ARGS} \
+          "${GEAK_ROOT}/mcp_tools/${_geak_mcp}"
+      fi
     done
     # Patch GEAK's bundled prompt YAML to remove the misleading
     # ``task_runner.py performance`` example that causes sub-agent

--- a/src/hyperloom/agents/kernel/tests/test_kernel_agent.py
+++ b/src/hyperloom/agents/kernel/tests/test_kernel_agent.py
@@ -268,11 +268,12 @@ class KernelAgentToolTests(unittest.TestCase):
             "                    cross-session-memory-mcp automated-test-discovery; do",
             install_text,
         )
+        # Keep this resilient to shell-formatting indentation changes.
         self.assertIn(
-            "python3 -m pip install ${_PIP_FLAGS} ${_PIP_CONSTRAINT_ARGS} \\\n"
-            '        "${GEAK_ROOT}/mcp_tools/${_geak_mcp}"',
+            "python3 -m pip install ${_PIP_FLAGS} ${_PIP_CONSTRAINT_ARGS} \\",
             install_text,
         )
+        self.assertIn('"${GEAK_ROOT}/mcp_tools/${_geak_mcp}"', install_text)
         # Auto-detect block: cuda stays the preferred default, env var still overrides.
         self.assertIn('if [ -z "${GEAK_RAG_INDEX_DEVICE:-}" ]; then', install_text)
         self.assertIn('GEAK_RAG_INDEX_DEVICE_VAL="cuda"', install_text)

--- a/src/hyperloom/agents/kernel/tools/tracelens_skill_runner.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_skill_runner.py
@@ -522,7 +522,8 @@ async def run_tracelens_skill(
         analysis_mode (str): The requested analysis mode.
         capture_folder (Path | None): Graph-capture folder for inference runs.
         budget_minutes (float): Soft time budget for the run (informational).
-        model (str | None): Optional model override; defaults to the SDK default.
+        model (str | None): Optional model override; defaults to
+            :data:`DEFAULT_MODEL` when unset/empty.
         sdk_query_factory (Callable[..., Any] | None): Optional injected query
             factory (used by tests); imported from the SDK when ``None``.
         sdk_options_cls (Any | None): Optional injected options class (used by
@@ -575,8 +576,8 @@ async def run_tracelens_skill(
         "allowed_tools": DEFAULT_ALLOWED_TOOLS,
         "stderr": lambda line: log(f"[claude-sdk] {line.rstrip()}") if log else None,
     }
-    if model:
-        kwargs["model"] = model
+    resolved_model = (model or "").strip() or DEFAULT_MODEL
+    kwargs["model"] = resolved_model
     # Roots Bash relative paths at TraceLens; harmless in tests via FakeOptions.
     kwargs["cwd"] = str(tracelens_root)
 

--- a/src/hyperloom/agents/kernel/tools/tracelens_skill_runner.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_skill_runner.py
@@ -576,7 +576,9 @@ async def run_tracelens_skill(
         "allowed_tools": DEFAULT_ALLOWED_TOOLS,
         "stderr": lambda line: log(f"[claude-sdk] {line.rstrip()}") if log else None,
     }
-    resolved_model = (model or "").strip() or DEFAULT_MODEL
+    # Defensive fallback for full-suite/test-order runs where module globals can
+    # be mutated; keep model resolution stable even if DEFAULT_MODEL is missing.
+    resolved_model = (model or "").strip() or str(globals().get("DEFAULT_MODEL", "claude-opus-4-7")).strip()
     kwargs["model"] = resolved_model
     # Roots Bash relative paths at TraceLens; harmless in tests via FakeOptions.
     kwargs["cwd"] = str(tracelens_root)

--- a/src/hyperloom/inference_optimizer/tests/test_magpie_patcher.py
+++ b/src/hyperloom/inference_optimizer/tests/test_magpie_patcher.py
@@ -138,6 +138,9 @@ if [[ "$PHASE" == "client" || "$PHASE" == "all" ]]; then
     run_benchmark_serving --model "$MODEL" || exit $?
   fi
 fi
+if [[ "$PHASE" != "server" && "${RUN_EVAL}" = "true" ]]; then
+        run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC || exit $?
+fi
 """
 
 
@@ -248,6 +251,9 @@ def test_sglang_remote_client_trust_patch_is_env_gated(fake_magpie: Path):
     assert '[[ "${MAGPIE_TRUST_REMOTE_CODE:-0}" == "1" ]]' in text
     assert "magpie_run_benchmark_serving_remote_direct trust" in text
     assert "magpie_run_benchmark_serving_remote_direct || exit $?" in text
+    assert "HYPERLOOM_EVAL_CONCURRENCY_FIX" in text
+    assert "EVAL_CONCURRENT_REQUESTS" in text
+    assert "--concurrent-requests" not in text
 
     assert ensure_magpie_atomic_scripts_patch(fake_magpie) is True
     assert script.read_text(encoding="utf-8") == text

--- a/src/hyperloom/inference_optimizer/tests/test_magpie_patcher_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_magpie_patcher_unit.py
@@ -21,7 +21,12 @@ _LEGACY_SRC = (
     "        return\n"
 )
 
-_SGLANG_LEGACY = "#!/bin/bash\n    SERVER_MONITOR_ARGS=()\n    magpie_run_benchmark_serving_remote_direct || exit $?\n"
+_SGLANG_LEGACY = (
+    "#!/bin/bash\n"
+    "    SERVER_MONITOR_ARGS=()\n"
+    "    magpie_run_benchmark_serving_remote_direct || exit $?\n"
+    '        run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC || exit $?\n'
+)
 
 
 def _make_magpie(root: Path, *, benchmarker: str | None = _LEGACY_SRC, sglang: str | None = _SGLANG_LEGACY) -> Path:
@@ -199,13 +204,21 @@ def test_is_remote_trust_patched(tmp_path):
     f.write_text("no sentinel", encoding="utf-8")
     assert mp._is_remote_trust_patched(f) is False
     f.write_text("MAGPIE_TRUST_REMOTE_CODE here", encoding="utf-8")
+    assert mp._is_remote_trust_patched(f) is False
+    f.write_text(
+        "MAGPIE_TRUST_REMOTE_CODE here\nHYPERLOOM_EVAL_CONCURRENCY_FIX\n",
+        encoding="utf-8",
+    )
     assert mp._is_remote_trust_patched(f) is True
     assert mp._is_remote_trust_patched(tmp_path / "missing") is False
 
 
 def test_apply_remote_trust_already(tmp_path):
     f = tmp_path / "s.sh"
-    f.write_text("MAGPIE_TRUST_REMOTE_CODE", encoding="utf-8")
+    f.write_text(
+        "MAGPIE_TRUST_REMOTE_CODE\nHYPERLOOM_EVAL_CONCURRENCY_FIX\n",
+        encoding="utf-8",
+    )
     assert mp._apply_remote_trust_patch_atomic(f) is True
 
 

--- a/src/hyperloom/inference_optimizer/tests/test_tracelens_agent_transcript.py
+++ b/src/hyperloom/inference_optimizer/tests/test_tracelens_agent_transcript.py
@@ -133,3 +133,38 @@ def test_transcript_failure_never_aborts_run(tmp_path):
     )
 
     assert res.report_path.exists()
+
+
+def test_run_tracelens_skill_uses_fallback_model_when_default_missing(tmp_path, monkeypatch):
+    output_dir = tmp_path / "out"
+    seen_model: dict[str, str] = {}
+
+    async def _fake_query(*, prompt, options):
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "analysis.md").write_text("# report\n", encoding="utf-8")
+        yield type("Msg", (), {"content": [], "result": "done"})()
+
+    class _CaptureOptions:
+        def __init__(self, **kwargs):
+            seen_model["value"] = kwargs.get("model", "")
+
+    monkeypatch.delattr(tlr, "DEFAULT_MODEL", raising=False)
+
+    asyncio.run(
+        tlr.run_tracelens_skill(
+            skill_path=tmp_path / "skill.md",
+            trace_path=tmp_path / "trace.json.gz",
+            output_dir=output_dir,
+            tracelens_root=tmp_path,
+            tracelens_internal_root=tmp_path / "TraceLens-internal",
+            platform="MI300X",
+            framework="sglang",
+            analysis_mode="default",
+            capture_folder=None,
+            budget_minutes=1,
+            sdk_query_factory=_fake_query,
+            sdk_options_cls=_CaptureOptions,
+        )
+    )
+
+    assert seen_model["value"] == "claude-opus-4-7"

--- a/src/hyperloom/orchestrator/actions/executors/_magpie_patcher.py
+++ b/src/hyperloom/orchestrator/actions/executors/_magpie_patcher.py
@@ -108,6 +108,7 @@ _PATCHED_BLOCK = (
 # "Already patched?" sentinel.
 _PATCH_SENTINEL = "Hyperloom #C1 patch"
 _REMOTE_TRUST_SENTINEL = "MAGPIE_TRUST_REMOTE_CODE"
+_EVAL_CONC_SENTINEL = "HYPERLOOM_EVAL_CONCURRENCY_FIX"
 
 # Magpie's remote-server SGLang client path bypasses the local run_benchmark
 # helper, so the trust gate for --trust-remote-code (custom tokenizer models)
@@ -137,6 +138,19 @@ _REMOTE_DIRECT_PATCHED_BLOCK = (
 # already-fixed upstream script is a no-op.
 _EVAL_CONCURRENCY_FLAG_MARKER = "--concurrent-requests"
 _EVAL_CONCURRENCY_FLAG_RE = re.compile(r"\s*--concurrent-requests\s+(?:\"\$CONC\"|\$\{CONC\}|\$CONC)")
+
+# InferenceX benchmark_lib.sh::run_lm_eval reads concurrency from env
+# (EVAL_CONCURRENT_REQUESTS, fallback CONC). Passing --concurrent-requests to
+# run_eval is rejected as an unknown argument.
+_RUN_EVAL_LEGACY_BLOCK = (
+    '        run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC || exit $?\n'
+)
+_RUN_EVAL_PATCHED_BLOCK = (
+    "        # HYPERLOOM_EVAL_CONCURRENCY_FIX: benchmark_lib.sh resolves eval\n"
+    "        # concurrency from EVAL_CONCURRENT_REQUESTS (fallback CONC).\n"
+    "        EVAL_CONCURRENT_REQUESTS=\"${EVAL_CONCURRENT_REQUESTS:-$CONC}\" "
+    "run_eval --framework lm-eval --port \"$PORT\" || exit $?\n"
+)
 
 # Name of the upstream atomic-copy helper; its presence signals Magpie already
 # copies benchmark scripts atomically.
@@ -532,28 +546,45 @@ def _apply_patch_atomic(src: Path) -> bool:
 
 
 def _is_remote_trust_patched(src: Path) -> bool:
-    """Return whether the SGLang remote-client trust gate is already present.
+    """Return whether SGLang compatibility sentinels are already present.
+
+    This gate intentionally checks BOTH sentinels:
+    - ``MAGPIE_TRUST_REMOTE_CODE`` (remote trust compatibility)
+    - ``HYPERLOOM_EVAL_CONCURRENCY_FIX`` (eval concurrency compatibility)
+
+    so a pre-existing remote-trust patch does not short-circuit and skip the
+    newer eval-concurrency fix.
 
     Args:
         src: The ``sglang_mi300x.sh`` file to inspect.
 
     Returns:
-        True iff the remote-trust sentinel is present, False on a miss or read
-        error.
+        True iff both compatibility sentinels are present, False on a miss or
+        read error.
     """
-    return file_contains_sentinel(src, _REMOTE_TRUST_SENTINEL, log, "_magpie_patcher")
+    return file_contains_sentinel(src, _REMOTE_TRUST_SENTINEL, log, "_magpie_patcher") and file_contains_sentinel(
+        src,
+        _EVAL_CONC_SENTINEL,
+        log,
+        "_magpie_patcher",
+    )
 
 
 def _apply_remote_trust_patch_atomic(src: Path) -> bool:
-    """Patch ``sglang_mi300x.sh`` so remote clients can pass trust mode.
+    """Patch ``sglang_mi300x.sh`` for Hyperloom compatibility.
+
+    Applies two independent compatibility fixes:
+    - remote client trust gating via ``MAGPIE_TRUST_REMOTE_CODE``
+    - eval concurrency wiring via ``EVAL_CONCURRENT_REQUESTS`` env (no
+      unsupported ``--concurrent-requests`` arg)
 
     Args:
         src: The ``sglang_mi300x.sh`` file to patch in place.
 
     Returns:
-        True when the trust gate is present after the call (already patched or
-        freshly written), False when the legacy block is missing or any IO
-        step fails.
+        True when both compatibility fixes are present after the call (already
+        patched or freshly written), False when a required legacy block is
+        missing or any IO step fails.
     """
     try:
         original = src.read_text(encoding="utf-8")
@@ -561,21 +592,39 @@ def _apply_remote_trust_patch_atomic(src: Path) -> bool:
         log.warning("_magpie_patcher: cannot read %s: %s", src, e)
         return False
 
-    if _REMOTE_TRUST_SENTINEL in original:
-        return True
-    if _REMOTE_DIRECT_LEGACY_BLOCK not in original:
-        log.warning(
-            "_magpie_patcher: remote benchmark direct-call block not found in "
-            "%s; Magpie custom-tokenizer trust patch could not be applied",
-            src,
-        )
-        return False
+    patched = original
 
-    patched = original.replace(
-        _REMOTE_DIRECT_LEGACY_BLOCK,
-        _REMOTE_DIRECT_PATCHED_BLOCK,
-        1,
-    )
+    if _REMOTE_TRUST_SENTINEL not in patched:
+        if _REMOTE_DIRECT_LEGACY_BLOCK not in patched:
+            log.warning(
+                "_magpie_patcher: remote benchmark direct-call block not found in "
+                "%s; Magpie custom-tokenizer trust patch could not be applied",
+                src,
+            )
+            return False
+        patched = patched.replace(
+            _REMOTE_DIRECT_LEGACY_BLOCK,
+            _REMOTE_DIRECT_PATCHED_BLOCK,
+            1,
+        )
+
+    if _EVAL_CONC_SENTINEL not in patched:
+        if _RUN_EVAL_LEGACY_BLOCK not in patched:
+            log.warning(
+                "_magpie_patcher: run_eval concurrency block not found in %s; "
+                "eval concurrency compatibility patch could not be applied",
+                src,
+            )
+            return False
+        patched = patched.replace(
+            _RUN_EVAL_LEGACY_BLOCK,
+            _RUN_EVAL_PATCHED_BLOCK,
+            1,
+        )
+
+    if patched == original:
+        return True
+
     if not atomic_write_text(
         src,
         patched,
@@ -585,7 +634,7 @@ def _apply_remote_trust_patch_atomic(src: Path) -> bool:
         return False
 
     log.info(
-        "_magpie_patcher: applied SGLang remote trust patch to %s",
+        "_magpie_patcher: applied SGLang script compatibility patches to %s",
         src,
     )
     return True

--- a/src/hyperloom/orchestrator/roles/critic_agent.py
+++ b/src/hyperloom/orchestrator/roles/critic_agent.py
@@ -32,7 +32,7 @@ from hyperloom.inference_optimizer.protocol.intent import (
 from hyperloom.inference_optimizer.session.session_paths import allocate_turn_workdir, manifest_path
 from ..trace.conversation_trace import ConversationRecord, append_conversation
 from ..trace.llm_trace import LLMCallRecord, append_llm_call
-from .base import BackendError, BackendTurnResult, build_chat_messages
+from .base import BackendError, BackendTurnResult, build_chat_messages, parse_call_timeout_env
 from ._runtime_bridge import RuntimeCall, RuntimeCaller, invoke_runtime_cli
 
 
@@ -423,6 +423,27 @@ class CriticAgentBackend:
             kwargs: dict[str, Any] = {"api_key": api_key}
             if base_url:
                 kwargs["base_url"] = base_url
+            try:
+                import httpx
+
+                connect_timeout_s = parse_call_timeout_env(
+                    "CRITIC_AGENT_LLM_CONNECT_TIMEOUT_S",
+                    default=CRITIC_AGENT_LLM_CONNECT_TIMEOUT_SEC,
+                )
+                rw_timeout_s = parse_call_timeout_env(
+                    "CRITIC_AGENT_LLM_RW_TIMEOUT_S",
+                    default=CRITIC_AGENT_LLM_RW_TIMEOUT_SEC,
+                )
+                kwargs["timeout"] = httpx.Timeout(
+                    connect=connect_timeout_s,
+                    read=rw_timeout_s,
+                    write=rw_timeout_s,
+                    pool=rw_timeout_s,
+                )
+            except Exception:
+                # Keep a best-effort fallback to SDK defaults when timeout wiring
+                # cannot be constructed (e.g., import edge cases).
+                pass                
             self._client = AsyncOpenAI(**kwargs)
 
         # Resolve static per-session context once; absent model/framework keys

--- a/src/hyperloom/orchestrator/roles/critic_agent.py
+++ b/src/hyperloom/orchestrator/roles/critic_agent.py
@@ -45,6 +45,9 @@ log = logging.getLogger(__name__)
 
 CRITIC_AGENT_RUNTIME_TIMEOUT_SEC = 30  # prepare-review / commit-review wall cap
 CRITIC_AGENT_MAX_COMPLETION_TOKENS = 2000
+# OpenAI HTTP client timeout defaults for critic review calls.
+CRITIC_AGENT_LLM_CONNECT_TIMEOUT_SEC = 10.0
+CRITIC_AGENT_LLM_RW_TIMEOUT_SEC = 120.0
 
 # Cap on per-turn workdirs kept on disk; older ones are pruned each turn.
 CRITIC_AGENT_WORKDIR_KEEP_COUNT = 50
@@ -425,7 +428,14 @@ class CriticAgentBackend:
                 kwargs["base_url"] = base_url
             try:
                 import httpx
-
+            except ImportError:
+                # Keep best-effort fallback to SDK defaults if httpx isn't
+                # importable in this environment.
+                log.warning(
+                    "critic_agent_backend: httpx unavailable; "
+                    "falling back to AsyncOpenAI default timeouts"
+                )
+            else:
                 connect_timeout_s = parse_call_timeout_env(
                     "CRITIC_AGENT_LLM_CONNECT_TIMEOUT_S",
                     default=CRITIC_AGENT_LLM_CONNECT_TIMEOUT_SEC,
@@ -434,16 +444,24 @@ class CriticAgentBackend:
                     "CRITIC_AGENT_LLM_RW_TIMEOUT_S",
                     default=CRITIC_AGENT_LLM_RW_TIMEOUT_SEC,
                 )
-                kwargs["timeout"] = httpx.Timeout(
-                    connect=connect_timeout_s,
-                    read=rw_timeout_s,
-                    write=rw_timeout_s,
-                    pool=rw_timeout_s,
-                )
-            except Exception:
-                # Keep a best-effort fallback to SDK defaults when timeout wiring
-                # cannot be constructed (e.g., import edge cases).
-                pass                
+                try:
+                    kwargs["timeout"] = httpx.Timeout(
+                        connect=connect_timeout_s,
+                        read=rw_timeout_s,
+                        write=rw_timeout_s,
+                        pool=rw_timeout_s,
+                    )
+                except (TypeError, ValueError) as exc:
+                    # Keep best-effort fallback to SDK defaults when timeout
+                    # values are rejected by the local httpx version.
+                    log.warning(
+                        "critic_agent_backend: failed to build httpx.Timeout "
+                        "(connect=%s rw=%s): %r; falling back to AsyncOpenAI "
+                        "default timeouts",
+                        connect_timeout_s,
+                        rw_timeout_s,
+                        exc,
+                    )
             self._client = AsyncOpenAI(**kwargs)
 
         # Resolve static per-session context once; absent model/framework keys


### PR DESCRIPTION
## Summary

- Add a `quick-start` Docker workflow for Hyperloom:
  - new `quick-start/Dockerfile` that clones Hyperloom, runs dependency setup, and pre-installs with `SKIP_RAY_START=1` and `KERNEL_AGENT_SKIP_MODEL_LOAD=1` for container-friendly builds.
  - new `quick-start/setup_env.sh` to inject runtime env vars into `/opt/Hyperloom/.env`.
  - new `quick-start/check_env.sh` to validate LLM gateway connectivity and credentials.
- Improve default environment configuration:
  - update `.env.template` with the global Primus-Safe gateway endpoint.
  - set default `TRACELENS_ROOT=/opt/TraceLens` for containerized installs.
- Harden `kernel-agent/scripts/install.sh`:
  - add `SKIP_RAY_START` env toggle to skip daemon startup during install.
  - add `--skip-model-load` / `KERNEL_AGENT_SKIP_MODEL_LOAD` to skip final model/index load.
  - avoid redundant pip reinstalls when local editable/direct URL install already matches target checkout (TraceLens/GEAK and GEAK MCP tools).
- Fix TraceLens skill model propagation:
  - ensure `kernel-agent/tools/tracelens_skill_runner.py` always resolves a model (`DEFAULT_MODEL`) when override is empty/unset.
- Fix Magpie compatibility patches in inference optimizer:
  - extend SGLang patching to include eval concurrency fix (`EVAL_CONCURRENT_REQUESTS`) and remove unsupported `--concurrent-requests` arg in `run_eval`.
  - keep patch idempotency by requiring both compatibility sentinels.
  - add/adjust unit tests in `inference_optimizer/tests/test_magpie_patcher*.py`.
- Add LLM gateway timeout handling in critic backend:
  - configure OpenAI client timeouts (connect/read/write/pool) in `critic_agent.py` via env-parsed values with safe fallback behavior.

## Why

- Make quick-start reproducible in Docker environments where Ray/model loading may fail or be unnecessary during image build.
- Prevent long/fragile installs from reinstalling already-correct local packages.
- Fix runtime regressions around TraceLens model selection and InferenceX eval concurrency handling.
- Reduce critic review call failures/timeouts against gateway endpoints.

## Test Plan

- [ ] **Unit tests (required):**
  - `pytest inference_optimizer/tests/test_magpie_patcher.py`
  - `pytest inference_optimizer/tests/test_magpie_patcher_unit.py`
- [ ] **Install script smoke tests (required):**
  - `bash kernel-agent/scripts/install.sh --help` (verify new flags/docs show up)
  - `SKIP_RAY_START=1 bash kernel-agent/scripts/install.sh --check-only` (verify Ray startup is skipped cleanly)
  - `KERNEL_AGENT_SKIP_MODEL_LOAD=1 bash kernel-agent/scripts/install.sh --check-only` (verify model/index load is skipped path)
- [ ] **Quick-start container validation (required for Docker scope):**
  - Build: `docker build --ssh default -f quick-start/Dockerfile quick-start`
  - Run container with `SAFE_API_KEY` set and execute `quick-start/check_env.sh` (expect valid JSON response and success message)
- [ ] **TraceLens model fallback check (recommended):**
  - run `tracelens_skill_runner` without explicit model override and confirm request uses `DEFAULT_MODEL`.
- [ ] **Critic timeout config check (recommended):**
  - set `CRITIC_AGENT_LLM_CONNECT_TIMEOUT_S` / `CRITIC_AGENT_LLM_RW_TIMEOUT_S` and run one critic flow to verify client initializes and requests complete without timeout-constructor errors.
