### PR TITLE
fix(xdit): demote _xdit_patcher from runtime mutator to verifier

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_xdit_patcher.py
+++ b/src/hyperloom/inference_optimizer/tests/test_xdit_patcher.py
@@ -1,46 +1,59 @@
 # Copyright Advanced Micro Devices, Inc. All rights reserved.
 
-"""Tests for ``_xdit_patcher.ensure_xdit_profiler_patched``.
+"""Tests for ``_xdit_patcher`` — now a VERIFIER, not a mutator.
 
-Pins the patcher contract: two backward-compatible, idempotent, concurrency-safe,
-fail-soft patches on xDiT's ``base_model.py``:
-
-* Patch 1 inserts ``repeat=1`` into ``torch.profiler.schedule`` so the diffusion
-  profiler retains its active window (upstream default ``repeat=0`` discards it
-  -> empty trace, Op count == 0).
-* Patch 2 wraps ``self.pipe.scheduler.step`` in a ``record_function`` marker so
-  each denoise step is annotated (``denoise_step_<i>``), giving TraceLens
-  deterministic per-step roofline split boundaries.
+The two diffusion-profiling adaptations (``repeat=1`` + per-denoise-step
+``denoise_step_<i>`` markers) are baked into the sandbox image by the
+``hyperloom-xdit-adaptation`` overlay. This module no longer edits any file; it
+only verifies the baked sentinels are present in the running xfuser and fails
+soft (returns ``False``, logs remediation) when they are missing (stale image).
 
 Fixtures synthesize a fake xfuser tree in ``tmp_path`` discovered via
-``$XDIT_PATH``. The fixture mirrors the real ``profile()`` shape (multi-line
-``with profile(...)`` + the ``model_inference`` marker) so both patch anchors are
-exercised.
+``$XDIT_PATH`` (``base_model.py`` with / without the baked sentinels).
 """
 
 from __future__ import annotations
 
-import ast
 import importlib.util
-import threading
 from pathlib import Path
 
 import pytest
 
 from hyperloom.orchestrator.actions.executors import _xdit_patcher
 from hyperloom.orchestrator.actions.executors._xdit_patcher import (
-    _apply_annotation_patch,
-    _apply_patch_atomic,
-    _apply_repeat_patch,
     _discover_xfuser_base_models,
-    _is_patched,
+    _is_baked,
     ensure_xdit_profiler_patched,
+    verify_xdit_profiler_baked,
 )
 
-# Verbatim upstream shape (incl. the exact indentation the patcher matches on):
-# the multi-line ``with profile(...)`` block and the per-image
-# ``record_function("model_inference")`` marker, matching runner_models/base_model.py.
-_UPSTREAM_FIXTURE = """\
+_REL = ("xfuser", "model_executor", "models", "runner_models", "base_model.py")
+_PROFILER_SENTINEL = "# hyperloom: retain active window"
+_ANNOT_SENTINEL = "# hyperloom: per-denoise-step annotation"
+
+# A base_model.py that carries BOTH baked adaptations (only the sentinel-bearing
+# lines matter to the verifier; the rest is representative context).
+_BAKED_FIXTURE = """\
+class xFuserModel:
+    def profile(self, input_args):
+        schedule = torch.profiler.schedule(
+            wait=self.config.profile_wait,
+            warmup=self.config.profile_warmup,
+            active=self.config.profile_active,
+            repeat=1,  # hyperloom: retain active window (upstream repeat=0 -> empty trace)
+        )
+        with profile(schedule=schedule) as profile_object:
+            # hyperloom: per-denoise-step annotation -- wrap scheduler.step
+            _hl_denoise_step = {"i": 0}
+            for iteration in range(1):
+                _hl_reset_denoise_counter()  # hyperloom: per-denoise-step annotation
+                with record_function("model_inference"):
+                    self._run_timed_pipe(input_args)
+                profile_object.step()
+"""
+
+# The clean upstream shape (neither adaptation baked) -> verify must be False.
+_PRISTINE_FIXTURE = """\
 class xFuserModel:
     def profile(self, input_args):
         schedule = torch.profiler.schedule(
@@ -48,23 +61,12 @@ class xFuserModel:
             warmup=self.config.profile_warmup,
             active=self.config.profile_active,
         )
-        num_repetitions = self.config.profile_wait + self.config.profile_warmup + self.config.profile_active
-        with profile(
-            activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
-            schedule=schedule,
-            record_shapes=True,
-            with_stack=False,
-        ) as profile_object:
-            for iteration in range(num_repetitions):
-                log(f"Profiling iteration {iteration + 1}/{num_repetitions}")
+        with profile(schedule=schedule) as profile_object:
+            for iteration in range(1):
                 with record_function("model_inference"):
-                    output, timing = self._run_timed_pipe(input_args)
+                    self._run_timed_pipe(input_args)
                 profile_object.step()
 """
-
-_REL = ("xfuser", "model_executor", "models", "runner_models", "base_model.py")
-_SENTINEL = "# hyperloom: retain active window"
-_ANNOT_SENTINEL = "# hyperloom: per-denoise-step annotation"
 
 
 @pytest.fixture(autouse=True)
@@ -74,308 +76,80 @@ def _isolate_xdit_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("XDIT_PATH", raising=False)
 
 
-@pytest.fixture
-def fake_xdit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Build a minimal ``$XDIT_PATH/xfuser/.../base_model.py`` tree."""
+def _write_fake_xdit(tmp_path: Path, contents: str, monkeypatch: pytest.MonkeyPatch) -> Path:
     target = tmp_path.joinpath(*_REL)
     target.parent.mkdir(parents=True)
-    target.write_text(_UPSTREAM_FIXTURE, encoding="utf-8")
+    target.write_text(contents, encoding="utf-8")
     monkeypatch.setenv("XDIT_PATH", str(tmp_path))
     return target
 
 
-def test_first_call_inserts_repeat_one(fake_xdit: Path) -> None:
-    rc = ensure_xdit_profiler_patched()
-    assert rc is True
-    text = fake_xdit.read_text()
-    assert "repeat=1," in text
-    assert _SENTINEL in text
-
-
-def test_second_call_is_a_noop(fake_xdit: Path) -> None:
-    """Idempotency: re-applying must not double-patch or change bytes."""
-    ensure_xdit_profiler_patched()
-    after_first = fake_xdit.read_text()
-    rc = ensure_xdit_profiler_patched()
-    assert rc is True
-    assert fake_xdit.read_text() == after_first
-
-
-def test_repeat_appears_exactly_once(fake_xdit: Path) -> None:
-    for _ in range(5):
-        ensure_xdit_profiler_patched()
-    assert fake_xdit.read_text().count("repeat=1") == 1
-
-
-def test_patched_file_is_valid_python(fake_xdit: Path) -> None:
-    ensure_xdit_profiler_patched()
-    ast.parse(fake_xdit.read_text())
-
-
 # ---------------------------------------------------------------------------
-# Patch 2: per-denoise-step annotation
+# verify_xdit_profiler_baked
 # ---------------------------------------------------------------------------
-def test_first_call_inserts_perstep_annotation(fake_xdit: Path) -> None:
-    """The annotation patch wraps scheduler.step and inserts the per-image reset."""
-    rc = ensure_xdit_profiler_patched()
-    assert rc is True
-    text = fake_xdit.read_text()
-    assert _ANNOT_SENTINEL in text
-    # scheduler.step is wrapped and each step emits a denoise_step_<i> marker.
-    assert 'record_function(' in text
-    assert 'denoise_step_' in text
-    assert "_hl_target.step = _hl_wrapped_step" in text
-    # The per-image reset call is inserted before the model_inference marker.
-    assert "_hl_reset_denoise_counter()" in text
-    idx_reset = text.index("_hl_reset_denoise_counter()  #")
-    idx_marker = text.index('with record_function("model_inference"):')
-    assert idx_reset < idx_marker
-    # Still valid Python after both patches.
-    ast.parse(text)
+def test_verify_true_when_both_sentinels_present(tmp_path: Path, monkeypatch) -> None:
+    target = _write_fake_xdit(tmp_path, _BAKED_FIXTURE, monkeypatch)
+    assert verify_xdit_profiler_baked() is True
+    assert _is_baked(target) is True
 
 
-def _run_patched_profile(patched_src: str, scheduler, steps_per_iter: int):
-    """Exec a patched ``base_model.py`` and drive ``profile()`` with stub
-    torch/profiler primitives, returning the ordered list of ``record_function``
-    marker names. Raises whatever the wrapped step raises (e.g. RecursionError)."""
-    import contextlib
-
-    markers: list[str] = []
-
-    @contextlib.contextmanager
-    def record_function(name):  # noqa: ANN001
-        markers.append(name)
-        yield
-
-    class _Prof:
-        def step(self):  # noqa: D401
-            pass
-
-    @contextlib.contextmanager
-    def profile(*_a, **_k):  # noqa: ANN002, ANN003
-        yield _Prof()
-
-    class _Activities:
-        CPU = 1
-        CUDA = 2
-
-    class _Torch:
-        class profiler:
-            @staticmethod
-            def schedule(**_k):  # noqa: ANN003
-                return None
-
-    ns: dict = {
-        "torch": _Torch,
-        "profile": profile,
-        "ProfilerActivity": _Activities,
-        "record_function": record_function,
-        "log": lambda *_a, **_k: None,
-    }
-    exec(compile(patched_src, "<patched_base_model>", "exec"), ns)  # noqa: S102
-    model_cls = ns["xFuserModel"]
-    model = model_cls.__new__(model_cls)
-
-    class _Cfg:
-        profile_wait = 0
-        profile_warmup = 0
-        profile_active = 2  # -> 2 profiled iterations
-
-    class _Pipe:
-        pass
-
-    model.config = _Cfg()
-    model.pipe = _Pipe()
-    model.pipe.scheduler = scheduler
-
-    def _run_timed_pipe(_args):  # noqa: ANN001
-        for _ in range(steps_per_iter):
-            model.pipe.scheduler.step()
-        return ("out", 0.0)
-
-    model._run_timed_pipe = _run_timed_pipe
-    model.profile({})
-    return markers
+def test_verify_false_when_pristine(tmp_path: Path, monkeypatch) -> None:
+    """A clean upstream base_model.py (no bake) fails soft: False, file untouched."""
+    target = _write_fake_xdit(tmp_path, _PRISTINE_FIXTURE, monkeypatch)
+    before = target.read_text()
+    assert verify_xdit_profiler_baked() is False
+    assert _is_baked(target) is False
+    assert target.read_text() == before  # verifier never mutates
 
 
-def test_annotation_no_recursion_with_xfuser_wrapper(fake_xdit: Path) -> None:
-    """Regression: xfuser's scheduler wrapper delegates ``step`` to ``self.module``
-    and its ``__setattr__`` redirects writes to ``.module``. Patching/capturing the
-    wrapper's ``step`` (instead of the module's) caused infinite recursion on models
-    whose ``pipe.scheduler`` is the xfuser wrapper (e.g. SD3.5-large-turbo). The
-    patch must target ``.module`` so the wrapped call terminates."""
-    ensure_xdit_profiler_patched()
-    patched_src = fake_xdit.read_text()
-
-    class FakeInnerScheduler:
-        def __init__(self) -> None:
-            self.calls = 0
-
-        def step(self, *_a, **_k):  # noqa: ANN002, ANN003
-            self.calls += 1
-            return "ok"
-
-    class FakeXFuserSchedulerWrapper:
-        """Mirrors xFuserSchedulerBaseWrapper: delegates step to self.module and
-        redirects attribute writes onto the module."""
-
-        def __init__(self, module) -> None:  # noqa: ANN001
-            object.__setattr__(self, "module", module)
-
-        def __setattr__(self, name, value):  # noqa: ANN001
-            if name == "module":
-                object.__setattr__(self, name, value)
-            elif getattr(self, "module", None) is not None and hasattr(self.module, name):
-                setattr(self.module, name, value)
-            else:
-                object.__setattr__(self, name, value)
-
-        def step(self, *args, **kwargs):  # noqa: ANN002, ANN003
-            return self.module.step(*args, **kwargs)
-
-    inner = FakeInnerScheduler()
-    wrapper = FakeXFuserSchedulerWrapper(inner)
-
-    # Must not raise RecursionError; 2 iterations x 3 steps = 6 real step calls.
-    markers = _run_patched_profile(patched_src, wrapper, steps_per_iter=3)
-
-    assert inner.calls == 6
-    # Per-iteration reset => denoise index restarts at 0 each profiled iteration.
-    assert markers.count("denoise_step_0") == 2
-    assert markers.count("denoise_step_1") == 2
-    assert markers.count("denoise_step_2") == 2
-    assert "denoise_step_3" not in markers
-
-
-def test_annotation_no_recursion_with_plain_scheduler(fake_xdit: Path) -> None:
-    """A plain diffusers scheduler (no ``.module``) is patched in place and still
-    produces per-step markers without recursion."""
-    ensure_xdit_profiler_patched()
-    patched_src = fake_xdit.read_text()
-
-    class PlainScheduler:
-        def __init__(self) -> None:
-            self.calls = 0
-
-        def step(self, *_a, **_k):  # noqa: ANN002, ANN003
-            self.calls += 1
-            return "ok"
-
-    sched = PlainScheduler()
-    markers = _run_patched_profile(patched_src, sched, steps_per_iter=2)
-
-    assert sched.calls == 4
-    assert markers.count("denoise_step_0") == 2
-    assert markers.count("denoise_step_1") == 2
-
-
-def test_both_patches_present_after_apply(fake_xdit: Path) -> None:
-    """A fully patched file carries both sentinels and reports patched."""
-    ensure_xdit_profiler_patched()
-    assert _is_patched(fake_xdit) is True
-    text = fake_xdit.read_text()
-    assert _SENTINEL in text and _ANNOT_SENTINEL in text
-
-
-def test_is_patched_requires_both_sentinels(fake_xdit: Path) -> None:
-    """A file with only Patch 1 (repeat) is NOT considered patched (upgrade path)."""
-    repeat_only, applied = _apply_repeat_patch(fake_xdit.read_text(), fake_xdit)
-    assert applied is True
-    fake_xdit.write_text(repeat_only, encoding="utf-8")
-    assert _SENTINEL in repeat_only
-    assert _ANNOT_SENTINEL not in repeat_only
-    assert _is_patched(fake_xdit) is False
-
-
-def test_upgrade_from_repeat_only_adds_annotation(fake_xdit: Path) -> None:
-    """An older-Hyperloom file (repeat=1 only) is upgraded to add Patch 2 without
-    duplicating repeat=1."""
-    repeat_only, _ = _apply_repeat_patch(fake_xdit.read_text(), fake_xdit)
-    fake_xdit.write_text(repeat_only, encoding="utf-8")
-
-    rc = ensure_xdit_profiler_patched()
-    assert rc is True
-    text = fake_xdit.read_text()
-    assert text.count("repeat=1") == 1  # not re-applied
-    assert _ANNOT_SENTINEL in text
-    assert _is_patched(fake_xdit) is True
-    ast.parse(text)
-
-
-def test_annotation_appears_exactly_once(fake_xdit: Path) -> None:
-    """Idempotency across many calls: single wrapper install, single reset call."""
-    for _ in range(5):
-        ensure_xdit_profiler_patched()
-    text = fake_xdit.read_text()
-    assert text.count("_hl_target.step = _hl_wrapped_step") == 1
-    assert text.count("_hl_reset_denoise_counter()  #") == 1
-
-
-def test_missing_annotation_anchor_still_applies_repeat(tmp_path: Path, monkeypatch) -> None:
-    """A file with the schedule block but no ``model_inference`` marker still gets
-    Patch 1 (repeat); Patch 2 fails soft and the file stays valid."""
-    fixture_no_marker = (
-        "class xFuserModel:\n"
-        "    def profile(self, input_args):\n"
-        "        schedule = torch.profiler.schedule(\n"
-        "            wait=self.config.profile_wait,\n"
-        "            warmup=self.config.profile_warmup,\n"
+def test_verify_false_when_only_profiler_sentinel(tmp_path: Path, monkeypatch) -> None:
+    """Partial bake (repeat=1 only, no per-step annotation) is not accepted."""
+    partial = _PRISTINE_FIXTURE.replace(
+        "            active=self.config.profile_active,\n",
         "            active=self.config.profile_active,\n"
-        "        )\n"
-        "        with profile(schedule=schedule) as profile_object:\n"
-        "            for iteration in range(3):\n"
-        "                self._run_timed_pipe(input_args)\n"
-        "                profile_object.step()\n"
+        "            repeat=1,  # hyperloom: retain active window\n",
     )
-    target = tmp_path.joinpath(*_REL)
-    target.parent.mkdir(parents=True)
-    target.write_text(fixture_no_marker, encoding="utf-8")
-    monkeypatch.setenv("XDIT_PATH", str(tmp_path))
-    monkeypatch.setattr(
-        _xdit_patcher, "_discover_xfuser_base_models", lambda: [target]
-    )
-    rc = ensure_xdit_profiler_patched()
-    assert rc is True
-    text = target.read_text()
-    assert _SENTINEL in text  # Patch 1 landed
-    assert _ANNOT_SENTINEL not in text  # Patch 2 failed soft (no marker anchor)
-    assert _is_patched(target) is False
-    ast.parse(text)
+    target = _write_fake_xdit(tmp_path, partial, monkeypatch)
+    assert _PROFILER_SENTINEL in target.read_text()
+    assert _ANNOT_SENTINEL not in target.read_text()
+    assert verify_xdit_profiler_baked() is False
 
 
-def test_apply_annotation_patch_is_noop_when_already_present(fake_xdit: Path) -> None:
-    """``_apply_annotation_patch`` reports no change on an already-annotated text."""
-    text = fake_xdit.read_text()
-    text, _ = _apply_repeat_patch(text, fake_xdit)
-    text, applied1 = _apply_annotation_patch(text, fake_xdit)
-    assert applied1 is True
-    text2, applied2 = _apply_annotation_patch(text, fake_xdit)
-    assert applied2 is False
-    assert text2 == text
+def test_verify_warns_with_remediation_when_missing(
+    tmp_path: Path, monkeypatch, caplog
+) -> None:
+    _write_fake_xdit(tmp_path, _PRISTINE_FIXTURE, monkeypatch)
+    with caplog.at_level("WARNING"):
+        assert verify_xdit_profiler_baked() is False
+    assert "MISSING the baked" in caplog.text
+    assert _xdit_patcher._REQUIRED_IMAGE in caplog.text
 
 
-def test_missing_legacy_block_is_fail_soft(tmp_path: Path, monkeypatch) -> None:
-    """A file without the schedule block leaves it untouched, returns False."""
-    target = tmp_path.joinpath(*_REL)
-    target.parent.mkdir(parents=True)
-    target.write_text("x = 1\n", encoding="utf-8")
-    monkeypatch.setenv("XDIT_PATH", str(tmp_path))
-    # Restrict discovery to the fake file so a real installed xfuser in the
-    # environment cannot make the patcher report success for another root.
-    monkeypatch.setattr(
-        _xdit_patcher, "_discover_xfuser_base_models", lambda: [target]
-    )
-    assert ensure_xdit_profiler_patched() is False
-    assert target.read_text() == "x = 1\n"
-
-
-def test_no_xdit_tree_is_fail_soft(monkeypatch) -> None:
+def test_verify_false_no_xdit_tree(monkeypatch) -> None:
     """No discoverable base_model.py (empty $XDIT_PATH, no xfuser) -> False."""
-    monkeypatch.delenv("XDIT_PATH", raising=False)
+    monkeypatch.setattr(_xdit_patcher, "_discover_xfuser_base_models", lambda: [])
+    assert verify_xdit_profiler_baked() is False
+
+
+def test_verify_scans_all_discovered_and_accepts_any_baked(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """With multiple discovered files, one fully-baked copy is enough."""
+    pristine = tmp_path / "a" / "base_model.py"
+    pristine.parent.mkdir(parents=True)
+    pristine.write_text(_PRISTINE_FIXTURE, encoding="utf-8")
+    baked = tmp_path / "b" / "base_model.py"
+    baked.parent.mkdir(parents=True)
+    baked.write_text(_BAKED_FIXTURE, encoding="utf-8")
     monkeypatch.setattr(
-        _xdit_patcher, "_discover_xfuser_base_models", lambda: []
+        _xdit_patcher, "_discover_xfuser_base_models", lambda: [pristine, baked]
     )
-    assert ensure_xdit_profiler_patched() is False
+    assert verify_xdit_profiler_baked() is True
+
+
+def test_ensure_alias_is_verify() -> None:
+    """The backward-compatible name maps to the verifier (callers unchanged)."""
+    assert ensure_xdit_profiler_patched is verify_xdit_profiler_baked
 
 
 # ---------------------------------------------------------------------------
@@ -405,7 +179,7 @@ def test_discovery_uses_importable_xfuser_spec(tmp_path: Path, monkeypatch) -> N
     pkg_root = tmp_path / "site-packages"
     target = pkg_root.joinpath(*_REL)
     target.parent.mkdir(parents=True)
-    target.write_text(_UPSTREAM_FIXTURE, encoding="utf-8")
+    target.write_text(_BAKED_FIXTURE, encoding="utf-8")
     monkeypatch.delenv("XDIT_PATH", raising=False)
 
     class _Spec:
@@ -416,52 +190,8 @@ def test_discovery_uses_importable_xfuser_spec(tmp_path: Path, monkeypatch) -> N
     assert target.resolve() in found
 
 
-# ---------------------------------------------------------------------------
-# _apply_patch_atomic: IO / no-op edge cases (fail-soft, never corrupts)
-# ---------------------------------------------------------------------------
-def test_apply_returns_false_on_read_error(tmp_path: Path) -> None:
-    """An unreadable path (here a directory) fails soft, returns False."""
-    unreadable = tmp_path / "a_directory_not_a_file"
-    unreadable.mkdir()
-    assert _apply_patch_atomic(unreadable) is False
-
-
-def test_apply_returns_false_when_patch_is_a_noop(fake_xdit: Path, monkeypatch) -> None:
-    """If both patch replacements yield identical bytes, return False."""
-    # Neuter Patch 1 (repeat) and Patch 2 (annotation) so neither changes text.
-    monkeypatch.setattr(
-        _xdit_patcher, "_PATCHED_BLOCK", _xdit_patcher._LEGACY_BLOCK
-    )
-    monkeypatch.setattr(
-        _xdit_patcher, "_ANNOT_INSTALL_BLOCK", _xdit_patcher._ANNOT_INSTALL_ANCHOR
-    )
-    monkeypatch.setattr(
-        _xdit_patcher, "_ANNOT_LOOP_PATCHED", _xdit_patcher._ANNOT_LOOP_ANCHOR
-    )
-    assert _apply_patch_atomic(fake_xdit) is False
-
-
-def test_apply_returns_false_when_write_fails(fake_xdit: Path, monkeypatch) -> None:
-    """A failed atomic write is reported (False) without touching the file."""
-    original = fake_xdit.read_text()
-    monkeypatch.setattr(
-        _xdit_patcher, "atomic_write_text", lambda *a, **k: False
-    )
-    assert _apply_patch_atomic(fake_xdit) is False
-    assert fake_xdit.read_text() == original
-
-
-def test_concurrent_calls_are_safe(fake_xdit: Path) -> None:
-    """flock + atomic rename: concurrent patchers must not corrupt the file."""
-    results: list[bool] = []
-
-    def _worker() -> None:
-        results.append(ensure_xdit_profiler_patched())
-
-    threads = [threading.Thread(target=_worker) for _ in range(8)]
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join()
-    assert all(results)
-    assert fake_xdit.read_text().count("repeat=1") == 1
+def test_discovery_via_xdit_path(tmp_path: Path, monkeypatch) -> None:
+    """``$XDIT_PATH`` resolves ``$XDIT_PATH/xfuser/.../base_model.py``."""
+    target = _write_fake_xdit(tmp_path, _BAKED_FIXTURE, monkeypatch)
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
+    assert target.resolve() in _discover_xfuser_base_models()

--- a/src/hyperloom/orchestrator/actions/executors/_xdit_patcher.py
+++ b/src/hyperloom/orchestrator/actions/executors/_xdit_patcher.py
@@ -1,56 +1,29 @@
 # Copyright Advanced Micro Devices, Inc. All rights reserved.
 
-"""Idempotent, backward-compatible patcher for xDiT's diffusion profiling.
+"""Verifier for xDiT's baked diffusion-profiling adaptations.
 
-This module applies two in-place, fail-soft patches to xDiT's
-``base_model.py`` so the diffusion roofline pipeline gets a usable trace:
+Historically this module *mutated* xfuser's ``base_model.py`` in place at runtime
+to add two diffusion-profiling adaptations. Both now live as source in the
+``hyperloom-xdit-adaptation`` overlay repo and are baked into the sandbox image
+(``pytorch-xdit:v26.6-hyperloom15`` and newer) at build time, alongside the
+fp8/fp4 GEMM ``or []`` robustness guards. Runtime source mutation of ``/app`` was
+fragile (string-anchor drift, ``/app`` writability + cross-process ``flock``,
+implicit provenance), so this module no longer edits any file — it only VERIFIES
+that the running xfuser carries the baked adaptations.
 
-Patch 1 — ``repeat=1`` (retain the profiler active window)
-----------------------------------------------------------
-xDiT (``xfuser``) profiles diffusion runs with
+The two adaptations (their sentinels are asserted here):
 
-    schedule = torch.profiler.schedule(
-        wait=self.config.profile_wait,
-        warmup=self.config.profile_warmup,
-        active=self.config.profile_active,
-    )
-    num_repetitions = profile_wait + profile_warmup + profile_active
-    for _ in range(num_repetitions):
-        run_one_image()
-        profile_object.step()
+* ``repeat=1`` in ``torch.profiler.schedule`` — retains the ACTIVE profiler window
+  (upstream default ``repeat=0`` discards it, exporting an empty trace with
+  ``Op count == 0`` so TraceLens/roofline get nothing). Sentinel:
+  ``# hyperloom: retain active window``.
+* per-denoise-step ``record_function("denoise_step_<i>")`` markers around the
+  diffusers ``scheduler.step`` — deterministic per-step roofline split anchors.
+  Sentinel: ``# hyperloom: per-denoise-step annotation``.
 
-Because ``num_repetitions`` equals the schedule cycle length, the ACTIVE step is
-always the last iteration; the loop then calls ``profile_object.step()`` once
-more. With the ``torch.profiler.schedule`` default ``repeat=0`` (repeat forever)
-and no ``on_trace_ready`` callback, that trailing ``step()`` rolls the profiler
-into a fresh collection cycle and DISCARDS the just-recorded active window. The
-exported ``profile_trace_rank_*.json.gz`` then contains only metadata + a lone
-``hipDeviceSynchronize`` (``Op count == 0``), so TraceLens/roofline get an empty
-trace regardless of eager vs torch.compile. Verified on MI355X SD3.5-large:
-``repeat=1`` turns a 1.3 KB empty trace into a 6 MB trace with ~30k kernel and
-~130k cpu_op events. This patch inserts ``repeat=1`` into that schedule so one
-cycle is retained and exported.
-
-Patch 2 — per-denoise-step annotations (deterministic roofline split)
----------------------------------------------------------------------
-The diffusion roofline needs per-denoise-step boundaries to attribute kernel
-time to steps. ``profile()`` only wraps a whole image in a single
-``record_function("model_inference")``; the denoise loop lives inside the
-diffusers pipeline ``__call__`` (per model subclass), which base_model.py
-cannot reach directly. Instead this patch injects, at the top of the profiler
-``with`` block, a best-effort wrapper around ``self.pipe.scheduler.step`` — which
-diffusers calls exactly once per denoise step — that emits a
-``record_function("denoise_step_<i>")`` marker per step. Those ``user_annotation``
-events give TraceLens deterministic per-step split anchors instead of relying
-solely on steady-state kernel-pattern heuristics. Model-agnostic (all xDiT DiT
-pipelines expose ``.scheduler.step``) and fully fail-soft: any missing attribute
-or error leaves the run unchanged.
-
-Both patches are applied in place, once, never reverted: idempotent via sentinel
-substrings, serialized across processes via ``fcntl.flock``, written atomically
-(temp file + ``os.replace``). A file already carrying only Patch 1 (from an older
-Hyperloom) is upgraded to also carry Patch 2. Each patch fails soft independently
-when its anchor is missing so callers can proceed on a partially-patched file.
+Verification is fail-soft: a missing/stale bake logs a loud remediation warning
+and returns ``False`` (callers proceed; the roofline just degrades) rather than
+aborting the run.
 """
 
 from __future__ import annotations
@@ -60,103 +33,24 @@ import logging
 import os
 from pathlib import Path
 
-from ._inferencex_patcher import _ensure_patched
-from ._magpie_patcher import atomic_write_text
 from ._patch_sentinel import file_contains_sentinel
 
 log = logging.getLogger(__name__)
 
-# xfuser package-relative path to the profiler schedule.
+# xfuser package-relative path to the profiled ``base_model.py``.
 _XFUSER_REL = ("model_executor", "models", "runner_models", "base_model.py")
 
-# Exact upstream schedule tail (whitespace-anchored to the single
-# ``torch.profiler.schedule(...)`` call in base_model.py).
-_LEGACY_BLOCK = (
-    "            active=self.config.profile_active,\n"
-    "        )"
-)
-_PATCHED_BLOCK = (
-    "            active=self.config.profile_active,\n"
-    "            repeat=1,  # hyperloom: retain active window "
-    "(upstream default repeat=0 discards it -> empty trace)\n"
-    "        )"
-)
-# Patch-1 ("repeat=1 present?") sentinel.
-_PATCH_SENTINEL = "# hyperloom: retain active window"
+# Sentinels the overlay bakes into base_model.py (kept in sync with
+# hyperloom-xdit-adaptation/runner_models/base_model.py).
+_PROFILER_SENTINEL = "# hyperloom: retain active window"      # Patch 1: repeat=1
+_ANNOT_SENTINEL = "# hyperloom: per-denoise-step annotation"  # Patch 2: per-step
 
-# ---- Patch 2: per-denoise-step annotation ---------------------------------
-# Anchor A: opening line of the profiler ``with`` block. Present in both the
-# single-line (``with profile(schedule=schedule) as profile_object:``) and the
-# multi-line upstream form; the leading indentation stays because it precedes
-# the matched substring.
-_ANNOT_INSTALL_ANCHOR = ") as profile_object:\n"
-# Injected right after the ``with profile(...) as profile_object:`` line, at the
-# 12-space body indent. Wraps ``self.pipe.scheduler.step`` (one call per denoise
-# step) in a ``record_function("denoise_step_<i>")`` marker. Best-effort: any
-# missing attribute / error leaves the run unchanged. ``_hl_reset_denoise_counter``
-# is always defined so the per-image reset call (Anchor B) is safe even if the
-# wrap could not be installed.
-_ANNOT_INSTALL_BLOCK = (
-    ") as profile_object:\n"
-    "            # hyperloom: per-denoise-step annotation -- wrap the diffusers\n"
-    "            # scheduler.step (one call per denoise step) in a record_function\n"
-    "            # so TraceLens gets deterministic per-step split boundaries.\n"
-    "            _hl_denoise_step = {\"i\": 0, \"active\": False}\n"
-    "            def _hl_reset_denoise_counter():\n"
-    "                _hl_denoise_step[\"i\"] = 0\n"
-    "            try:\n"
-    "                _hl_sched = getattr(getattr(self, \"pipe\", None), \"scheduler\", None)\n"
-    "                # xfuser wraps the real diffusers scheduler; its __setattr__\n"
-    "                # redirects attribute writes to ``.module`` while its ``step``\n"
-    "                # delegates to ``self.module.step``. Capturing and patching the\n"
-    "                # same object (the module when present) is required -- otherwise\n"
-    "                # the captured original is the wrapper's ``step`` and calling it\n"
-    "                # re-enters our wrapper forever (RecursionError).\n"
-    "                _hl_target = getattr(_hl_sched, \"module\", None)\n"
-    "                if _hl_target is None:\n"
-    "                    _hl_target = _hl_sched\n"
-    "                _hl_orig_step = getattr(_hl_target, \"step\", None)\n"
-    "                if _hl_orig_step is not None and not getattr(\n"
-    "                    _hl_orig_step, \"_hyperloom_wrapped\", False\n"
-    "                ):\n"
-    "                    def _hl_wrapped_step(*_hl_a, **_hl_k):\n"
-    "                        # Re-entrancy guard: only the outermost step call emits\n"
-    "                        # the marker and advances the counter; any nested\n"
-    "                        # re-dispatch delegates straight to the original.\n"
-    "                        if _hl_denoise_step[\"active\"]:\n"
-    "                            return _hl_orig_step(*_hl_a, **_hl_k)\n"
-    "                        _hl_denoise_step[\"active\"] = True\n"
-    "                        try:\n"
-    "                            with record_function(\n"
-    "                                f\"denoise_step_{_hl_denoise_step['i']}\"\n"
-    "                            ):\n"
-    "                                _hl_ret = _hl_orig_step(*_hl_a, **_hl_k)\n"
-    "                        finally:\n"
-    "                            _hl_denoise_step[\"active\"] = False\n"
-    "                        _hl_denoise_step[\"i\"] += 1\n"
-    "                        return _hl_ret\n"
-    "                    _hl_wrapped_step._hyperloom_wrapped = True\n"
-    "                    _hl_target.step = _hl_wrapped_step\n"
-    "            except Exception:  # noqa: BLE001 - annotation is best-effort\n"
-    "                pass\n"
-)
-# Anchor B: the per-image inference marker. A ``_hl_reset_denoise_counter()``
-# call is inserted before it so each profiled image restarts step indexing at 0.
-_ANNOT_LOOP_ANCHOR = '                with record_function("model_inference"):'
-_ANNOT_LOOP_PATCHED = (
-    "                _hl_reset_denoise_counter()  "
-    "# hyperloom: per-denoise-step annotation\n"
-    '                with record_function("model_inference"):'
-)
-# Patch-2 ("per-step annotation present?") sentinel.
-_ANNOT_SENTINEL = "# hyperloom: per-denoise-step annotation"
-
-# System-wide lock (``/tmp`` is writable; cross-reboot persistence not needed).
-_LOCK_PATH = "/tmp/hyperloom_xdit_profiler_patcher.lock"
+# First image tag that bakes the adaptations (for the remediation message).
+_REQUIRED_IMAGE = "pytorch-xdit:v26.6-hyperloom15"
 
 
 def _discover_xfuser_base_models() -> list[Path]:
-    """Return every existing xfuser ``base_model.py`` Hyperloom should patch.
+    """Return every existing xfuser ``base_model.py`` to verify.
 
     Discovery order (deduped by resolved path):
 
@@ -166,7 +60,7 @@ def _discover_xfuser_base_models() -> list[Path]:
 
     Returns:
         A deduped list of existing ``base_model.py`` files, or ``[]`` when none
-        resolve (callers fail-soft; this is fine for tests / non-xDiT runs).
+        resolve (callers fail-soft; fine for tests / non-xDiT runs).
     """
     out: list[Path] = []
     seen: set[Path] = set()
@@ -198,152 +92,52 @@ def _discover_xfuser_base_models() -> list[Path]:
     return out
 
 
-def _is_patched(src: Path) -> bool:
-    """Return whether ``base_model.py`` carries BOTH Hyperloom patches.
-
-    A file with only Patch 1 (``repeat=1``, from an older Hyperloom) reports
-    ``False`` so ``_apply_patch_atomic`` upgrades it to also add Patch 2.
-
-    Args:
-        src: The xfuser ``base_model.py`` file to inspect.
-
-    Returns:
-        ``True`` only if both the ``repeat=1`` and the per-denoise-step sentinels
-        are present; ``False`` on a miss or read error.
-    """
+def _is_baked(src: Path) -> bool:
+    """Return whether ``base_model.py`` carries BOTH baked adaptation sentinels."""
     return file_contains_sentinel(
-        src, _PATCH_SENTINEL, log, "_xdit_patcher"
+        src, _PROFILER_SENTINEL, log, "_xdit_patcher"
     ) and file_contains_sentinel(src, _ANNOT_SENTINEL, log, "_xdit_patcher")
 
 
-def _apply_repeat_patch(text: str, src: Path) -> "tuple[str, bool]":
-    """Apply Patch 1 (``repeat=1``) to ``text`` if not already present.
+def verify_xdit_profiler_baked() -> bool:
+    """Verify the running xfuser carries the baked diffusion-profiling adaptations.
 
-    Returns the (possibly unchanged) text and whether it was modified. Logs a
-    warning and leaves ``text`` untouched when the legacy schedule block is
-    missing (xDiT layout drift), so the caller can still attempt Patch 2.
+    Returns ``True`` when at least one discovered ``base_model.py`` carries both
+    sentinels. When none do (or none are discovered), logs a fail-soft remediation
+    warning and returns ``False`` — the run proceeds but the diffusion roofline
+    trace will be empty / lack per-step split boundaries.
     """
-    if _PATCH_SENTINEL in text:
-        return text, False
-    if _LEGACY_BLOCK not in text:
+    files = _discover_xfuser_base_models()
+    if not files:
         log.warning(
-            "_xdit_patcher: expected torch.profiler.schedule(...) block not "
-            "found in %s; xDiT layout may have changed and Hyperloom needs an "
-            "updated patch. The profiler active window will be discarded "
-            "(empty diffusion trace -> roofline REVERT). Manual review needed.",
-            src,
+            "_xdit_patcher: no xfuser base_model.py discovered (checked $XDIT_PATH "
+            "and the importable xfuser package) — cannot verify the baked diffusion "
+            "profiler adaptations (this is fine for tests and non-xDiT runs)"
         )
-        return text, False
-    patched = text.replace(_LEGACY_BLOCK, _PATCHED_BLOCK, 1)
-    return patched, patched != text
-
-
-def _apply_annotation_patch(text: str, src: Path) -> "tuple[str, bool]":
-    """Apply Patch 2 (per-denoise-step annotation) to ``text`` if not present.
-
-    Requires both anchors (the profiler ``with`` line and the per-image
-    ``model_inference`` marker). Logs a warning and leaves ``text`` untouched
-    when either anchor is missing, so the caller can still keep Patch 1.
-    """
-    if _ANNOT_SENTINEL in text:
-        return text, False
-    if _ANNOT_INSTALL_ANCHOR not in text or _ANNOT_LOOP_ANCHOR not in text:
-        log.warning(
-            "_xdit_patcher: per-denoise-step annotation anchors not found in "
-            "%s (profiler-with line and/or model_inference marker); xDiT layout "
-            "may have changed. The diffusion roofline will fall back to "
-            "steady-state kernel-pattern splitting (no explicit per-step "
-            "annotations). Manual review needed.",
-            src,
-        )
-        return text, False
-    patched = text.replace(_ANNOT_INSTALL_ANCHOR, _ANNOT_INSTALL_BLOCK, 1)
-    patched = patched.replace(_ANNOT_LOOP_ANCHOR, _ANNOT_LOOP_PATCHED, 1)
-    return patched, patched != text
-
-
-def _apply_patch_atomic(src: Path) -> bool:
-    """Apply both Hyperloom patches to ``base_model.py`` via temp-file + atomic
-    rename so a crash mid-write cannot corrupt the file.
-
-    Patch 1 (``repeat=1``) and Patch 2 (per-denoise-step annotation) each apply
-    independently and fail soft when their anchor is missing. The two are
-    written together in a single atomic replace.
-
-    Args:
-        src: The xfuser ``base_model.py`` file to patch in place.
-
-    Returns:
-        ``True`` when new patched bytes were written; ``False`` when nothing
-        changed (both already present, both anchors missing) or any IO step
-        fails.
-    """
-    try:
-        original = src.read_text(encoding="utf-8")
-    except OSError as e:
-        log.warning("_xdit_patcher: cannot read %s: %s", src, e)
         return False
 
-    text = original
-    text, repeat_applied = _apply_repeat_patch(text, src)
-    text, annot_applied = _apply_annotation_patch(text, src)
+    for src in files:
+        if _is_baked(src):
+            log.debug(
+                "_xdit_patcher: verified baked diffusion-profiling adaptations in %s",
+                src,
+            )
+            return True
 
-    if text == original:
-        return False
-
-    if not atomic_write_text(
-        src,
-        text,
-        tmp_prefix=".base_model.py.hyperloom_",
-        log_prefix="_xdit_patcher",
-    ):
-        return False
-
-    if repeat_applied:
-        log.info(
-            "_xdit_patcher: added repeat=1 to the torch.profiler.schedule in "
-            "%s so the diffusion profiler retains its active window (else the "
-            "trace is empty: Op count == 0)",
-            src,
-        )
-    if annot_applied:
-        log.info(
-            "_xdit_patcher: added per-denoise-step record_function markers "
-            "(denoise_step_<i>) around scheduler.step in %s so TraceLens gets "
-            "deterministic per-step roofline split boundaries",
-            src,
-        )
-    return True
-
-
-def ensure_xdit_profiler_patched() -> bool:
-    """Ensure xDiT's ``base_model.py`` carries both Hyperloom diffusion patches.
-
-    Applies Patch 1 (``repeat=1``, retain the profiler active window) and Patch 2
-    (per-denoise-step ``record_function`` markers for roofline splitting). Returns
-    ``True`` when patched at exit, ``False`` (non-fatal) when the file is missing
-    or every patch anchor is absent. Concurrency-safe (flock + atomic rename;
-    already-patched fast-path skips the lock).
-
-    Returns:
-        ``True`` when at least one discovered ``base_model.py`` is patched (or
-        already patched), ``False`` when none could be patched.
-    """
-    return _ensure_patched(
-        _discover_xfuser_base_models(),
-        _is_patched,
-        _apply_patch_atomic,
-        _LOCK_PATH,
-        empty_msg=(
-            "_xdit_patcher: no xfuser base_model.py discovered (checked "
-            "$XDIT_PATH and the importable xfuser package) — skipping "
-            "diffusion profiler patches (this is fine for tests and non-xDiT runs)"
-        ),
-        failure_msg=(
-            "_xdit_patcher: failed to patch %s; other discovered roots will "
-            "still be attempted"
-        ),
+    log.warning(
+        "_xdit_patcher: xfuser base_model.py is MISSING the baked Hyperloom "
+        "diffusion-profiling adaptations (repeat=1 + per-denoise-step markers) in "
+        "%s. The diffusion roofline trace will be empty or lack per-step split "
+        "boundaries. This image predates the overlay bake — rebuild/run with the "
+        "%s image (or newer) from hyperloom-xdit-adaptation.",
+        ", ".join(str(f) for f in files),
+        _REQUIRED_IMAGE,
     )
+    return False
 
 
-__all__ = ["ensure_xdit_profiler_patched"]
+# Backward-compatible name: callers (profile.py) still import
+# ``ensure_xdit_profiler_patched``. It now verifies instead of mutating.
+ensure_xdit_profiler_patched = verify_xdit_profiler_baked
+
+__all__ = ["ensure_xdit_profiler_patched", "verify_xdit_profiler_baked"]


### PR DESCRIPTION
## Summary
- Demote `_xdit_patcher` from a runtime source **mutator** to a **verifier**. The two diffusion-profiling adaptations it used to apply in place to xfuser's `base_model.py` at runtime (`torch.profiler.schedule(repeat=1)` to retain the ACTIVE window + per-denoise-step `record_function("denoise_step_<i>")` markers around `scheduler.step`) now live as source in the `hyperloom-xdit-adaptation` overlay and are baked into the sandbox image at build time (`v26.6-hyperloom15`+), alongside the fp8/fp4 GEMM `or []` robustness guards and per-model `fp8_gemm_module_list` coverage.
- Runtime `/app` mutation was fragile (string-anchor drift, `/app` writability + cross-process `flock`, implicit provenance). `verify_xdit_profiler_baked()` now only asserts the baked sentinels are present and warns fail-soft (returns `False`) on a stale image. `ensure_xdit_profiler_patched` is kept as a backward-compatible alias, so `profile.py` is unchanged.
- Tests rewritten for the verifier contract.

## Context
Companion change lives in the `hyperloom-xdit-adaptation` overlay repo (merged to `main`), which bakes:
- **Path A** — guard every `fp8_gemm_module_list` / `fp4_gemm_module_list` iteration/membership in `base_model.py` with `(... or [])`, so `--use_fp8_gemms` / `--use_fp4_gemms` on a model without a declared list no longer crashes with `TypeError: 'NoneType' object is not iterable`.
- **Path B** — declare `fp8_gemm_module_list` on the base Qwen-Image runner and on the `*LocalAliasModel` classes (Qwen-Image, SD3/SD3.5, SRPO, FLUX.1-schnell) that the `/primus/models` snapshots resolve through.
- The profiler adaptations above (previously runtime-patched here).

## Test plan
- [x] `pytest src/hyperloom/inference_optimizer/tests/test_xdit_patcher.py` (11 passed)
- [x] Image `v26.6-hyperloom15` built via kaniko
- [x] Single-GPU e2e on the two originally-crashing models with `--use_fp8_gemms`: Qwen-Image + SD3-medium now log `Quantizing linear layers in transformer.transformer_blocks to FP8`, complete, and produce images (no `NoneType` crash)

Made with [Cursor](https://cursor.com)