### PR TITLE
docs: add optimization-loop diagram to the overview page

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -13,6 +13,14 @@ iteratively rewriting code to maximize throughput on AMD GPUs.
 
 ## The optimization loop
 
+![Hyperloom optimization loop: classify the model, measure a baseline, profile the GPU, and build the action stack, then run the scored DFS loop — pop the highest-scored action, execute and benchmark it, re-score and push new candidates — until scores converge, then sweep and report.](figs/optimization_loop.png)
+
+*Hyperloom classifies the model, measures a baseline, profiles the GPU, and
+builds a stack of candidate actions. It then runs a scored depth-first loop —
+pop the highest-scored action, execute and benchmark it, then re-score and push
+new candidates — until the remaining candidates no longer promise a gain, at
+which point it runs a final sweep and writes the report.*
+
 1. **Workload understanding & profiling** — submit your workload; the agent
    profiles it with TraceLens (trace collection via Magpie), capturing
    bottlenecks and roofline targets.


### PR DESCRIPTION
## Summary

- Adds the optimization-loop diagram to the **Overview** page so readers can see how Hyperloom works at a glance, right under "The optimization loop" heading.
- Reuses the existing `docs/figs/optimization_loop.png` (already committed but previously unused). No new binary asset added.

## Why Markdown image syntax (not a raw `<img>`)

The page uses `![alt](figs/optimization_loop.png)` rather than a raw `<img>` tag. MyST turns Markdown images into real docutils image nodes, so Sphinx copies the file into the built site (`_images/`) and rewrites the `src`. A raw `<img>` is passed through verbatim and is **not** copied, so it would 404 on the rendered GitHub Pages / Read the Docs site. Markdown syntax also renders correctly on GitHub.

## Test plan

- [x] `sphinx-build -b html docs docs/_build/html` → `build succeeded`.
- [x] Verified the image is copied to `_build/html/_images/optimization_loop.png` and `overview.html` references `_images/optimization_loop.png`.
- [ ] Confirm the `Docs` build check passes on this PR.
- [ ] After merge, confirm the diagram renders on the published Overview page.
