### PR TITLE
fix(codeql): misc alerts — base-exception / mixed-returns / ineffectual (Part 1)

### DIFF
--- a/src/hyperloom/agents/kernel/tools/gemm_tuning.py
+++ b/src/hyperloom/agents/kernel/tools/gemm_tuning.py
@@ -252,7 +252,7 @@ def main(argv: list[str] | None = None) -> int:
         )
     except SystemExit as exc:
         exit_code = exc.code if exc.code is not None else 0
-    except BaseException as exc:  # noqa: BLE001 - return structured failure
+    except Exception as exc:  # noqa: BLE001 - return structured failure
         _json_line(
             {
                 "status": "failed",

--- a/src/hyperloom/inference_optimizer/cli/__init__.py
+++ b/src/hyperloom/inference_optimizer/cli/__init__.py
@@ -919,7 +919,7 @@ def _validate_and_resolve_claude_model(
         f"Refusing to start.",
         file=sys.stderr,
     )
-    sys.exit(2)
+    raise SystemExit(2)
 
 
 def _smoke_test_codex_model(

--- a/src/hyperloom/inference_optimizer/tests/test_inferencex_patcher.py
+++ b/src/hyperloom/inference_optimizer/tests/test_inferencex_patcher.py
@@ -187,7 +187,7 @@ def test_concurrent_patchers_converge_to_single_patch(fake_inferencex):
     def worker() -> None:
         try:
             results.append(ensure_benchmark_lib_patched(fake_inferencex))
-        except BaseException as exc:  # noqa: BLE001 - test-only
+        except Exception as exc:  # noqa: BLE001 - test-only
             errors.append(exc)
 
     threads = [threading.Thread(target=worker) for _ in range(8)]

--- a/src/hyperloom/inference_optimizer/tests/test_server_patcher.py
+++ b/src/hyperloom/inference_optimizer/tests/test_server_patcher.py
@@ -427,7 +427,7 @@ def test_vllm_concurrent_patchers_converge(fake_vllm_world):
     def worker() -> None:
         try:
             results.append(ensure_vllm_patched_for_tracelens())
-        except BaseException as exc:  # noqa: BLE001 - test-only
+        except Exception as exc:  # noqa: BLE001 - test-only
             errors.append(exc)
 
     threads = [threading.Thread(target=worker) for _ in range(6)]

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_subprocess.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_subprocess.py
@@ -674,7 +674,7 @@ async def test_reap_loop_process_log_activity_prevents_stale_kill(
         max_seconds=60.0,
         started=time.monotonic(),
     )
-    await writer
+    _ = await writer
 
     assert outcome["stale_heartbeat"] is False, outcome
     assert outcome["timed_out"] is False, outcome


### PR DESCRIPTION
## 背景
分批处理 `main`(4470192a) 上 CodeQL 剩余的中/高风险告警。本 PR 是 Part 1：3 类共 5 条低风险小项，全部为**行为等价**修复。

## 改动明细
| 规则 | 位置 | 修复 |
|---|---|---|
| py/catch-base-exception | tests/test_server_patcher.py:430 | `except BaseException` → `except Exception`（thread worker 收集异常，仍能捕获常规异常） |
| py/catch-base-exception | tests/test_inferencex_patcher.py:190 | 同上 |
| py/catch-base-exception | agents/kernel/tools/gemm_tuning.py:255 | `except BaseException` → `except Exception`（上方已单独处理 `SystemExit`，收窄后 KeyboardInterrupt 正常传播） |
| py/mixed-returns | inference_optimizer/cli/__init__.py:922 | 末尾 `sys.exit(2)` → `raise SystemExit(2)`，消除与显式返回混用的隐式末尾 return（与 docstring `Raises: SystemExit` 一致） |
| py/ineffectual-statement | tests/test_specialist_subprocess.py:677 | `await writer` → `_ = await writer`（await 有意等待任务并传播异常，赋值使效果对分析器显式） |

## 验证
- `py_compile` 5 个文件通过
- `ruff check` 全部通过
- 受影响用例通过：`test_reap_loop_process_log_activity_prevents_stale_kill`、`test_vllm_concurrent_patchers_converge`、`test_concurrent_patchers_converge_to_single_patch`

## 说明
与 PR #814（120 条低风险）文件不重叠，基于最新 `main` 独立成 PR。