### PR TITLE
fix(codeql): document 98 intentional empty-except blocks (Part 2)

### DIFF
--- a/ci/claw_client.py
+++ b/ci/claw_client.py
@@ -373,6 +373,7 @@ class ClawClient:
                     try:
                         on_event(event_data)
                     except Exception:
+                        # User callback errors must not break the SSE event stream.
                         pass
 
                 if event_type == "toolUsed":

--- a/ci/import_session_breakdown.py
+++ b/ci/import_session_breakdown.py
@@ -582,6 +582,7 @@ def _infer_tp_from_name(name: str) -> int:
         try:
             sizes.append(float(m.group(1)))
         except ValueError:
+            # Non-numeric size token; skip it.
             pass
     if not sizes:
         n_lower = name.lower()

--- a/ci/model_compat.py
+++ b/ci/model_compat.py
@@ -248,6 +248,7 @@ def unrunnable_reason(config, repo="", model_dir=None, whitelist=None, gpu_type=
         if mpe is not None and int(mpe) <= SHORT_CTX_MAX:
             return ("short_ctx", f"max_position_embeddings={mpe}<={SHORT_CTX_MAX}")
     except (TypeError, ValueError):
+        # Missing/invalid field; fall through to the next heuristic.
         pass
 
     # 3) Phi3 longrope

--- a/ci/optimize_submit.py
+++ b/ci/optimize_submit.py
@@ -197,6 +197,7 @@ def _load_default_prompt_prefix() -> str:
         if _PROMPT_PREFIX_FILE.is_file():
             return _PROMPT_PREFIX_FILE.read_text(encoding="utf-8")
     except OSError:
+        # Prefix file unreadable; fall back to the empty prefix below.
         pass
     return ""
 

--- a/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
+++ b/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
@@ -1897,6 +1897,7 @@ def _drive_main_capturing_subprocess(tmp_path, extra_argv, env_overrides=None):
             try:
                 tla.main()
             except SystemExit:
+                # main() exits via SystemExit on success; swallow it in-test.
                 pass
     finally:
         _os.environ.clear()

--- a/src/hyperloom/agents/kernel/tools/apply_kernel_patch.py
+++ b/src/hyperloom/agents/kernel/tools/apply_kernel_patch.py
@@ -1611,6 +1611,7 @@ def apply_kernel_patch(
             try:
                 shutil.copy2(source_backup["backup_path"], target)
             except OSError:
+                # Best-effort backup restore; a filesystem error here is non-fatal.
                 pass
             return {
                 "status": "failed",
@@ -1666,6 +1667,7 @@ def apply_kernel_patch(
             try:
                 shutil.copy2(source_backup["backup_path"], target)
             except OSError:
+                # Best-effort backup restore; a filesystem error here is non-fatal.
                 pass
             return {
                 "status": "failed",
@@ -1697,6 +1699,7 @@ def apply_kernel_patch(
             try:
                 shutil.copy2(source_backup["backup_path"], target)
             except OSError:
+                # Best-effort backup restore; a filesystem error here is non-fatal.
                 pass
             if jit_build_backup.get("status") == "ok":
                 _restore_aiter_jit_build(jit_build_backup)

--- a/src/hyperloom/agents/kernel/tools/backends/forge_submit.py
+++ b/src/hyperloom/agents/kernel/tools/backends/forge_submit.py
@@ -99,6 +99,7 @@ def _resolve_gpu_target(candidate: dict) -> str:
         if m:
             return m.group(0)
     except Exception:
+        # Arch detection failed; fall back to the default gfx942 below.
         pass
     return "gfx942"
 
@@ -127,6 +128,7 @@ def _git_toplevel(path: str) -> str:
         if proc.returncode == 0:
             return proc.stdout.strip()
     except Exception:
+        # Probe command failed; return the empty string below.
         pass
     return ""
 
@@ -207,11 +209,13 @@ def _editable_roots() -> list[str]:
     try:
         scan_dirs.extend(site.getsitepackages())
     except Exception:
+        # site introspection is best-effort; skip if unavailable.
         pass
     if hasattr(site, "getusersitepackages"):
         try:
             scan_dirs.append(site.getusersitepackages())
         except Exception:
+            # site introspection is best-effort; skip if unavailable.
             pass
     # Venv / conda site-packages may not appear in sys.path when PYTHONPATH
     # is overridden and the venv is not activated. Probe conventional locations
@@ -338,10 +342,12 @@ def _release_repo_lock(lock: _RepoLock | None) -> None:
     try:
         fcntl.flock(lock.fd, fcntl.LOCK_UN)
     except OSError:
+        # Lock already released; nothing to undo.
         pass
     try:
         lock.close()
     except OSError:
+        # Lock fd already closed; nothing to release.
         pass
 
 
@@ -504,6 +510,7 @@ def _restore_inplace(restore: dict) -> None:
     try:
         Path(restore["source_file"]).write_bytes(restore["backup"])
     except OSError:
+        # Best-effort restore; a filesystem error here is non-fatal.
         pass
     # Step 5: delete the temp branch (safe now that HEAD points elsewhere).
     if restore.get("branch"):
@@ -1290,6 +1297,7 @@ def _export_best_artifacts(workspace: str, base_commit: str, worktree_kernel_fil
     try:
         shutil.copy2(worktree_kernel_file, primary)
     except OSError:
+        # Best-effort artifact copy; a filesystem error here is non-fatal.
         pass
 
     # Every file changed vs the pre-forge baseline (best-kept state == the
@@ -1310,6 +1318,7 @@ def _export_best_artifacts(workspace: str, base_commit: str, worktree_kernel_fil
         try:
             shutil.copy2(srcp, dstp)
         except OSError:
+            # Best-effort artifact copy; a filesystem error here is non-fatal.
             pass
 
     # Full multi-file patch (agent's net optimization, excludes pre-existing dirty).
@@ -1317,6 +1326,7 @@ def _export_best_artifacts(workspace: str, base_commit: str, worktree_kernel_fil
     try:
         (dst_dir / "forge.patch").write_text(patch.stdout or "")
     except OSError:
+        # Best-effort patch dump; a filesystem error here is non-fatal.
         pass
 
     return str(primary), changed
@@ -1906,6 +1916,7 @@ def submit(source_file: str, prompt_file: Path, output_dir: Path,
                 (output_dir / "optimized_versions" / "changed_files.txt").write_text(
                     "\n".join(changed_files) + "\n")
             except OSError:
+                # Best-effort manifest write; a filesystem error here is non-fatal.
                 pass
         _write_report(output_dir, baseline_ms, best_ms, improved)
         if loop_exc and baseline_ms is None:

--- a/src/hyperloom/agents/kernel/tools/backends/perfskills_runner.py
+++ b/src/hyperloom/agents/kernel/tools/backends/perfskills_runner.py
@@ -97,6 +97,7 @@ def call_perfskills(handoff: dict, output_dir: Path, *, timeout_s: int = 43200,
         try:
             os.killpg(os.getpgid(proc.pid), sig)
         except (ProcessLookupError, PermissionError):
+            # Process already exited; nothing to signal.
             pass
 
     try:

--- a/src/hyperloom/agents/kernel/tools/backends/ssh_runtime.py
+++ b/src/hyperloom/agents/kernel/tools/backends/ssh_runtime.py
@@ -543,6 +543,7 @@ def run_oob_over_ssh(
         try:
             full_stdout = Path(log_path).read_text(encoding="utf-8", errors="replace")
         except OSError:
+            # Log file unreadable; leave the captured stdout as-is.
             pass
     parsed["stdout"] = full_stdout
     return parsed

--- a/src/hyperloom/agents/kernel/tools/diffusion_roofline.py
+++ b/src/hyperloom/agents/kernel/tools/diffusion_roofline.py
@@ -330,6 +330,7 @@ def assemble_report(
                 if recon:
                     report["reconciliation"] = recon
         except (KeyError, TypeError, ValueError):
+            # Optional reconciliation data missing/malformed; skip it.
             pass
     return report
 

--- a/src/hyperloom/agents/kernel/tools/geak_prompt_patcher.py
+++ b/src/hyperloom/agents/kernel/tools/geak_prompt_patcher.py
@@ -84,6 +84,7 @@ def _atomic_write(target: Path, content: str) -> None:
     try:
         shutil.copystat(target, tmp_path)
     except OSError:
+        # copystat is best-effort metadata; ignore if the FS rejects it.
         pass
     tmp_path.replace(target)
 

--- a/src/hyperloom/agents/kernel/tools/harness_generator.py
+++ b/src/hyperloom/agents/kernel/tools/harness_generator.py
@@ -1373,6 +1373,7 @@ def maybe_generate_harness(
             try:
                 log_fn(f"[harness_gen] {msg}")
             except Exception:
+                # Logging callback errors are non-fatal.
                 pass
 
     benchmark_path = _Path(benchmark_file)

--- a/src/hyperloom/agents/kernel/tools/kernel_optimization.py
+++ b/src/hyperloom/agents/kernel/tools/kernel_optimization.py
@@ -2214,6 +2214,7 @@ def _extract_py_path(test_command: str) -> str | None:
             if part.endswith(".py"):
                 return part
     except ValueError:
+        # No matching path part; return None below.
         pass
     return None
 

--- a/src/hyperloom/agents/kernel/tools/parallel_e2e_runner.py
+++ b/src/hyperloom/agents/kernel/tools/parallel_e2e_runner.py
@@ -605,6 +605,7 @@ def main() -> int:
         try:
             _stop_ray_via_helper(bool(summary.get("ray_started_by_runner")), run_dir / "logs" / "ray.log")
         except Exception:
+            # Best-effort Ray teardown; ignore failures during cleanup.
             pass
         summary["status"] = "failed"
         summary["error"] = f"{type(exc).__name__}: {exc}"

--- a/src/hyperloom/agents/kernel/tools/tracelens_skill_runner.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_skill_runner.py
@@ -1688,14 +1688,17 @@ def aggregate_by_source_function(
         try:
             bucket["aggregate_duration_us"] += float(cand.get("duration_us") or 0.0)
         except (TypeError, ValueError):
+            # Malformed metric value; skip this contribution.
             pass
         try:
             bucket["aggregate_call_count"] += int(cand.get("call_count") or 0)
         except (TypeError, ValueError):
+            # Malformed metric value; skip this contribution.
             pass
         try:
             bucket["aggregate_gpu_pct"] += float(cand.get("gpu_pct") or 0.0)
         except (TypeError, ValueError):
+            # Malformed metric value; skip this contribution.
             pass
 
     ordered = sorted(

--- a/src/hyperloom/agents/robustness/decision/rca_engine.py
+++ b/src/hyperloom/agents/robustness/decision/rca_engine.py
@@ -306,10 +306,12 @@ class LlmRcaEngine:
         try:
             self._usage_in += int(usage.get("prompt_tokens", 0) or 0)
         except (TypeError, ValueError):
+            # Malformed usage value; skip this token count.
             pass
         try:
             self._usage_out += int(usage.get("completion_tokens", 0) or 0)
         except (TypeError, ValueError):
+            # Malformed usage value; skip this token count.
             pass
 
     def set_tick(self, tick_id: int) -> None:

--- a/src/hyperloom/agents/robustness/main.py
+++ b/src/hyperloom/agents/robustness/main.py
@@ -65,6 +65,7 @@ async def _run_reactor_mode(config: Config) -> None:
         try:
             loop.add_signal_handler(sig, _shutdown, sig)
         except NotImplementedError:
+            # Signal handlers are unavailable on this platform/loop; skip them.
             pass
 
     log.info(
@@ -90,6 +91,7 @@ async def _run_reactor_mode(config: Config) -> None:
             try:
                 await asyncio.wait_for(stop.wait(), timeout=config.standalone_tick_interval_s)
             except asyncio.TimeoutError:
+                # Tick interval elapsed with no stop request; loop again.
                 pass
     finally:
         await bundle.aclose()

--- a/src/hyperloom/agents/robustness/runtime/cli.py
+++ b/src/hyperloom/agents/robustness/runtime/cli.py
@@ -173,6 +173,7 @@ async def _run_tick(request: dict[str, Any]) -> dict[str, Any]:
         try:
             config.nodes = max(1, int(options["nodes"]))
         except (TypeError, ValueError):
+            # Invalid --nodes value; keep the existing default.
             pass
     # Opt out of the default inference-server health probe (heartbeat tests /
     # sandboxes auditing health out-of-band) without reconfiguring targets.

--- a/src/hyperloom/agents/robustness/sources/local_probe.py
+++ b/src/hyperloom/agents/robustness/sources/local_probe.py
@@ -1807,11 +1807,13 @@ def _probe_wal_size(session_dir: Path) -> dict[str, Any]:
         if wal_path.is_file():
             out["wal_bytes"] = int(wal_path.stat().st_size)
     except OSError:
+        # Stat failed; leave the size unset.
         pass
     try:
         if db_path.is_file():
             out["db_bytes"] = int(db_path.stat().st_size)
     except OSError:
+        # Stat failed; leave the size unset.
         pass
     return out
 
@@ -1919,11 +1921,13 @@ def _probe_agent_files(session_dir: Path) -> dict[str, Any]:
                 if inbox.is_file():
                     inbox_bytes = int(inbox.stat().st_size)
             except OSError:
+                # Stat failed; leave the size unset.
                 pass
             try:
                 if outbox.is_file():
                     outbox_bytes = int(outbox.stat().st_size)
             except OSError:
+                # Stat failed; leave the size unset.
                 pass
             if inbox_bytes or outbox_bytes:
                 out[role] = {

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/sessions.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/sessions.py
@@ -650,6 +650,7 @@ def collect_session(
             start = datetime.fromisoformat(start_ts.replace("Z", "+00:00"))
             elapsed_min = (datetime.now(timezone.utc) - start).total_seconds() / 60.0
         except (ValueError, TypeError):
+            # Malformed timestamp; skip elapsed-time computation.
             pass
     image = _detect_image_for_session(manifest)
     if image is None:

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/telemetry.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/telemetry.py
@@ -315,6 +315,7 @@ def _collect_lane_timeline(
                 if lane:
                     per_lane_expired[lane] = per_lane_expired.get(lane, 0) + 1
         except _sqlite3.OperationalError:
+            # Telemetry DB locked/absent; skip this expiry pass.
             pass
     finally:
         try:

--- a/src/hyperloom/inference_optimizer/experiments/roofline_sweep.py
+++ b/src/hyperloom/inference_optimizer/experiments/roofline_sweep.py
@@ -221,6 +221,7 @@ class SglangServer:
                         print(f"[server] ready on port {self.port}", flush=True)
                         return
             except Exception:
+                # Server not ready yet; retry after the sleep below.
                 pass
             time.sleep(5)
         raise RuntimeError(f"sglang server did not become ready in {self.ready_timeout_sec}s")
@@ -241,6 +242,7 @@ class SglangServer:
                 os.killpg(os.getpgid(self.proc.pid), signal.SIGKILL)
                 self.proc.wait(timeout=10)
         except ProcessLookupError:
+            # Process already exited; nothing to signal.
             pass
         print(f"[server] stopped (port {self.port})", flush=True)
 

--- a/src/hyperloom/inference_optimizer/multi_node/_internal/ssh_client.py
+++ b/src/hyperloom/inference_optimizer/multi_node/_internal/ssh_client.py
@@ -97,6 +97,7 @@ def generate_session_keypair(dest_dir: Path) -> tuple[Path, str]:
         try:
             p.unlink()
         except FileNotFoundError:
+            # File already absent; nothing to remove.
             pass
     proc = subprocess.run(
         [

--- a/src/hyperloom/inference_optimizer/multi_node/scripts/kernel_node_ops.py
+++ b/src/hyperloom/inference_optimizer/multi_node/scripts/kernel_node_ops.py
@@ -80,6 +80,7 @@ def _atomic_write_bytes(target: Path, data: bytes) -> None:
             try:
                 tmp.unlink()
             except OSError:
+                # Temp file already gone; the original error is re-raised below.
                 pass
         raise
 

--- a/src/hyperloom/inference_optimizer/multi_node/scripts/kernel_patch_multinode.py
+++ b/src/hyperloom/inference_optimizer/multi_node/scripts/kernel_patch_multinode.py
@@ -90,6 +90,7 @@ def _atomic_write_bytes(target: Path, data: bytes) -> None:
             try:
                 tmp.unlink()
             except OSError:
+                # Temp file already gone; the original error is re-raised below.
                 pass
         raise
 

--- a/src/hyperloom/inference_optimizer/multi_node/scripts/kill_multinode.py
+++ b/src/hyperloom/inference_optimizer/multi_node/scripts/kill_multinode.py
@@ -70,6 +70,7 @@ def _kill_remote(pid_dir: str, grace_sec: int) -> dict:
             try:
                 pid_file.unlink()
             except OSError:
+                # Stale PID file already removed; nothing to clean up.
                 pass
             continue
 
@@ -80,6 +81,7 @@ def _kill_remote(pid_dir: str, grace_sec: int) -> dict:
             try:
                 pid_file.unlink()
             except OSError:
+                # Stale PID file already removed; nothing to clean up.
                 pass
             continue
         try:
@@ -89,6 +91,7 @@ def _kill_remote(pid_dir: str, grace_sec: int) -> dict:
             try:
                 pid_file.unlink()
             except OSError:
+                # Stale PID file already removed; nothing to clean up.
                 pass
             continue
 
@@ -99,6 +102,7 @@ def _kill_remote(pid_dir: str, grace_sec: int) -> dict:
             try:
                 os.kill(pid, signal.SIGTERM)
             except (ProcessLookupError, PermissionError):
+                # Process already exited; nothing to signal.
                 pass
 
         time.sleep(grace_sec)
@@ -114,12 +118,14 @@ def _kill_remote(pid_dir: str, grace_sec: int) -> dict:
                 try:
                     os.kill(pid, signal.SIGKILL)
                 except (ProcessLookupError, PermissionError):
+                    # Process already exited; nothing to signal.
                     pass
 
         summary["killed"].append(f"{pid_file.name}:{pid}")
         try:
             pid_file.unlink()
         except OSError:
+            # PID file already gone; nothing to clean up.
             pass
 
     # Clean up legacy rayjoin pid files (current launch no longer creates these).
@@ -134,10 +140,12 @@ def _kill_remote(pid_dir: str, grace_sec: int) -> dict:
                 try:
                     os.killpg(os.getpgid(pid), signal.SIGTERM)
                 except (ProcessLookupError, PermissionError):
+                    # Process already exited; nothing to signal.
                     pass
         try:
             pid_file.unlink()
         except OSError:
+            # PID file already gone; nothing to clean up.
             pass
 
     return summary

--- a/src/hyperloom/inference_optimizer/multi_node/scripts/launch_dynamo_node.py
+++ b/src/hyperloom/inference_optimizer/multi_node/scripts/launch_dynamo_node.py
@@ -230,12 +230,14 @@ def _resolve_pod_ip(env: dict[str, str]) -> str:
         if ip and not ip.startswith("127."):
             return ip
     except OSError:
+        # Interface probe failed; try the next method below.
         pass
     try:
         ip = socket.gethostbyname(socket.gethostname())
         if ip and not ip.startswith("127."):
             return ip
     except OSError:
+        # Interface probe failed; fall back to localhost below.
         pass
     return "127.0.0.1"
 
@@ -407,6 +409,7 @@ def _detach_launch(cmd: list[str], log_file: Path, pid_file: Path, env: dict[str
             if log_file.is_file():
                 tail = log_file.read_text(errors="replace")[-4000:]
         except OSError:
+            # Log tail is diagnostic only; ignore read errors.
             pass
         raise RuntimeError(f"server pid={pid} exited within 0.5s: {exc}; log tail:\n{tail}") from exc
     return pid
@@ -463,6 +466,7 @@ def _wait_health(port: int, timeout_s: int, pid: int | None) -> bool:
                 if 200 <= resp.status < 300:
                     return True
         except (urllib.error.URLError, OSError):
+            # Server not ready yet; retry after the sleep below.
             pass
         if pid is not None and pid > 0:
             try:
@@ -471,6 +475,7 @@ def _wait_health(port: int, timeout_s: int, pid: int | None) -> bool:
                 _log(f"server pid={pid} died during health wait")
                 return False
             except OSError:
+                # Liveness check failed unexpectedly; keep polling.
                 pass
         time.sleep(5)
     return False
@@ -587,6 +592,7 @@ def main() -> int:
             try:
                 summary["log_tail"] = log_file.read_text(errors="replace")[-2000:]
             except OSError:
+                # Log tail is diagnostic only; ignore read errors.
                 pass
 
     print(json.dumps(summary, indent=2))

--- a/src/hyperloom/inference_optimizer/multi_node/scripts/launch_multinode.py
+++ b/src/hyperloom/inference_optimizer/multi_node/scripts/launch_multinode.py
@@ -702,6 +702,7 @@ def _wait_health(
                 if 200 <= resp.status < 300:
                     return True
         except (urllib.error.URLError, OSError):
+            # Server not ready yet; retry after the sleep below.
             pass
         # Bail early if rank 0 died, else we wait the full 1800s on a corpse.
         if rank0_pid is not None and rank0_pid > 0:
@@ -1017,6 +1018,7 @@ def main() -> int:
                 try:
                     os.killpg(os.getpgid(p2), 15)
                 except (ProcessLookupError, PermissionError):
+                    # Process already exited; nothing to signal.
                     pass
             return 1
 

--- a/src/hyperloom/inference_optimizer/tests/test_framework_agent_authoring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_framework_agent_authoring.py
@@ -162,6 +162,7 @@ class _Stub:
         try:
             candidate["_audit"] = v
         except Exception:
+            # Test double may reject attribute assignment; ignore.
             pass
         return v
 

--- a/src/hyperloom/inference_optimizer/tests/test_framework_agent_pump_integration.py
+++ b/src/hyperloom/inference_optimizer/tests/test_framework_agent_pump_integration.py
@@ -159,6 +159,7 @@ class _CoordinatorStub:
         try:
             candidate["_audit"] = v
         except Exception:
+            # Test double may reject attribute assignment; ignore.
             pass
         return v
 

--- a/src/hyperloom/inference_optimizer/tests/test_kill_spawned_server.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kill_spawned_server.py
@@ -142,11 +142,13 @@ def test_kill_my_spawned_server_reaps_grandchildren():
         try:
             pid_file.unlink()
         except FileNotFoundError:
+            # PID file already gone; nothing to clean up.
             pass
         if proc.poll() is None:
             try:
                 os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
             except (ProcessLookupError, OSError):
+                # Process already exited; nothing to signal.
                 pass
 
 
@@ -233,6 +235,7 @@ async def test_baseline_executor_kills_grandchild_on_timeout(tmp_path, monkeypat
             try:
                 os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
             except (ProcessLookupError, OSError):
+                # Process already exited; nothing to signal.
                 pass
 
 

--- a/src/hyperloom/orchestrator/actions/executors/_subprocess_kill.py
+++ b/src/hyperloom/orchestrator/actions/executors/_subprocess_kill.py
@@ -80,6 +80,7 @@ def _signal_group(pgid: int, sig: int) -> None:
     try:
         os.killpg(pgid, sig)
     except ProcessLookupError:
+        # Group already gone; nothing to signal.
         pass
     except OSError as exc:
         log.warning(
@@ -121,6 +122,7 @@ def kill_my_spawned_server(
             try:
                 proc.kill()
             except OSError:
+                # Process already exited; nothing to signal.
                 pass
         return
 
@@ -137,6 +139,7 @@ def kill_my_spawned_server(
         try:
             proc.terminate()
         except OSError:
+            # Process already exited; nothing to terminate.
             pass
         return
 
@@ -175,6 +178,7 @@ def kill_my_spawned_server(
             proc.pid,
         )
     except OSError:
+        # Child already reaped; nothing to wait on.
         pass
 
 
@@ -482,6 +486,7 @@ def server_log_death_excerpt(path: str, *, max_chars: int = 1200) -> str | None:
             if p != path
         )
     except OSError:
+        # Directory listing failed; skip sibling-file discovery.
         pass
     for candidate in candidates:
         try:

--- a/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
+++ b/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
@@ -186,6 +186,7 @@ def _visible_gpu_count() -> int:
         if count > 0:
             return count
     except Exception:
+        # GPU count probe failed; fall through to the next method.
         pass
     if shutil.which("rocm-smi"):
         try:

--- a/src/hyperloom/orchestrator/actions/executors/baseline.py
+++ b/src/hyperloom/orchestrator/actions/executors/baseline.py
@@ -1589,6 +1589,7 @@ class BaselineExecutor:
                 if p.exists():
                     p.unlink()
             except OSError:
+                # Best-effort cleanup; a filesystem error here is non-fatal.
                 pass
         # Narrow trigger: only deep-clean when the port is occupied by a
         # zombie (healthy endpoint, no metadata). Avoids killing unrelated
@@ -1788,6 +1789,7 @@ class BaselineExecutor:
         try:
             stale_server_log.unlink()
         except FileNotFoundError:
+            # Stale log already absent; nothing to remove.
             pass
         except OSError as exc:
             log.warning(

--- a/src/hyperloom/orchestrator/actions/executors/benchmark_result.py
+++ b/src/hyperloom/orchestrator/actions/executors/benchmark_result.py
@@ -372,6 +372,7 @@ def harvest_leaked_artifacts(
                     # Already under the workspace — nothing to harvest.
                     continue
                 except ValueError:
+                    # Path is outside the workspace; fall through to harvest it below.
                     pass
                 if not match.is_file():
                     continue

--- a/src/hyperloom/orchestrator/actions/executors/explore.py
+++ b/src/hyperloom/orchestrator/actions/executors/explore.py
@@ -707,6 +707,7 @@ class ExploreExecutor:
                 seed_isl = int(params.get("isl") or _yaml_envs.get("ISL") or os.environ.get("ISL") or 0)
                 seed_osl = int(params.get("osl") or _yaml_envs.get("OSL") or os.environ.get("OSL") or 0)
             except (TypeError, ValueError):
+                # Non-integer seed hint; fall back to the default grid below.
                 pass
             seed = _default_grid_for_framework(
                 framework,

--- a/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
+++ b/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
@@ -229,6 +229,7 @@ def _run_setup_commands(commands: list[str], *, cwd: Path, log_dir: Path) -> dic
     try:
         log_dir.mkdir(parents=True, exist_ok=True)
     except OSError:
+        # Logging is best-effort; a filesystem error must not fail the action.
         pass
     log_path = log_dir / "enablement_setup.log"
     env = dict(os.environ)
@@ -254,6 +255,7 @@ def _run_setup_commands(commands: list[str], *, cwd: Path, log_dir: Path) -> dic
                 with open(log_path, "a", encoding="utf-8") as fh:
                     fh.write(f"$ {cmd}\n{proc.stdout}\n{proc.stderr}\n(rc={proc.returncode})\n\n")
             except OSError:
+                # Logging is best-effort; a filesystem error must not fail the action.
                 pass
             if proc.returncode == 0:
                 applied.append(cmd)

--- a/src/hyperloom/orchestrator/bus/storage/schema.py
+++ b/src/hyperloom/orchestrator/bus/storage/schema.py
@@ -270,6 +270,7 @@ def get_lane_capacity(conn: sqlite3.Connection, lane: str) -> int:
         if row is not None:
             return int(row[0])
     except sqlite3.OperationalError:
+        # Table/row may not exist yet; treat as no value.
         pass
     finally:
         cur.close()

--- a/src/hyperloom/orchestrator/kernel/request_handlers.py
+++ b/src/hyperloom/orchestrator/kernel/request_handlers.py
@@ -1498,6 +1498,7 @@ def _read_forge_result_json(workspace: Path) -> dict[str, Any]:
             if isinstance(data, dict):
                 return data
     except (OSError, json.JSONDecodeError, ValueError):
+        # Config file missing/corrupt; return the empty dict below.
         pass
     return {}
 
@@ -2548,6 +2549,7 @@ async def trace_analyze_handler(
                 if int(num_denoise) > 0:
                     cmd += ["--num-denoise-steps", str(int(num_denoise))]
             except (TypeError, ValueError):
+                # Invalid num-denoise value; omit the flag.
                 pass
         # Forward the local model dir + precision so the diffusion roofline
         # sidecar can emit an a-priori analytic compute ceiling (approach-a),

--- a/src/hyperloom/orchestrator/kernel/roofline_ceiling.py
+++ b/src/hyperloom/orchestrator/kernel/roofline_ceiling.py
@@ -664,6 +664,7 @@ def _read_total_size(model_path: Path) -> int | None:
             if size:
                 return int(size)
         except (OSError, json.JSONDecodeError, TypeError, ValueError):
+            # Unreadable/malformed size metadata; fall back to the file-size scan below.
             pass
     return _sum_weight_file_sizes(model_path, "*.safetensors") or _sum_weight_file_sizes(model_path, "*.bin")
 

--- a/src/hyperloom/orchestrator/knowledge/cortex_t0.py
+++ b/src/hyperloom/orchestrator/knowledge/cortex_t0.py
@@ -206,6 +206,7 @@ def _recipe_is_actionable(row: Mapping[str, Any]) -> bool:
         if float(row.get("best_throughput") or 0.0) > 0.0:
             return True
     except (TypeError, ValueError):
+        # Malformed row value; fall through to the text checks below.
         pass
     for key in ("what_worked", "what_failed", "pitfalls", "lessons"):
         if row.get(key):

--- a/src/hyperloom/orchestrator/knowledge/recipe_kb/gbrain_remote_client.py
+++ b/src/hyperloom/orchestrator/knowledge/recipe_kb/gbrain_remote_client.py
@@ -121,6 +121,7 @@ def _iter_sse_objects(raw: str):
         try:
             yield json.loads(text)
         except json.JSONDecodeError:
+            # Skip malformed JSON lines in the stream.
             pass
         return
     for block in re.split(r"\r?\n\r?\n", raw):

--- a/src/hyperloom/orchestrator/knowledge/recipe_kb/local_store.py
+++ b/src/hyperloom/orchestrator/knowledge/recipe_kb/local_store.py
@@ -176,6 +176,7 @@ def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
         try:
             tmp.unlink()
         except OSError:
+            # Temp file already gone; re-raise the original write error below.
             pass
         raise
 
@@ -318,6 +319,7 @@ class _CidLock:
                 try:
                     os.close(self._fd)
                 except OSError:
+                    # FD already closed; nothing to release.
                     pass
                 self._fd = None
         self._mutex.release()

--- a/src/hyperloom/orchestrator/loop/coordinator_helpers.py
+++ b/src/hyperloom/orchestrator/loop/coordinator_helpers.py
@@ -253,11 +253,13 @@ def _parse_baseline_workload_extra(yaml_path: str) -> dict[str, Any]:
             try:
                 out["max_running_requests"] = int(tokens[i + 1])
             except ValueError:
+                # Non-integer CLI value; leave the field unset.
                 pass
         elif tok in ("--max-num-seqs",) and i + 1 < len(tokens):
             try:
                 out["max_num_seqs"] = int(tokens[i + 1])
             except ValueError:
+                # Non-integer CLI value; leave the field unset.
                 pass
         elif tok == "--enable-chunked-prefill":
             out["chunked_prefill_enabled"] = True

--- a/src/hyperloom/orchestrator/phases/kernel.py
+++ b/src/hyperloom/orchestrator/phases/kernel.py
@@ -603,6 +603,7 @@ class KernelPhase(PhaseHandler):
                 try:
                     os.killpg(os.getpgid(p.pid), sig)
                 except (ProcessLookupError, PermissionError):
+                    # Process already exited; nothing to signal.
                     pass
 
             try:

--- a/src/hyperloom/orchestrator/phases/machine_state.py
+++ b/src/hyperloom/orchestrator/phases/machine_state.py
@@ -1447,6 +1447,7 @@ def kernel_work_pending(state: Any) -> bool:
         if bool(getattr(state, "has_keep_pending_integrate", False)):
             return True
     except Exception:
+        # Optional capability probe; treat a failure as 'not available'.
         pass
 
     try:
@@ -1454,6 +1455,7 @@ def kernel_work_pending(state: Any) -> bool:
         if callable(untried_hot) and bool(untried_hot()):
             return True
     except Exception:
+        # Optional capability probe; treat a failure as 'not available'.
         pass
 
     rejected = {str(x) for x in (getattr(state, "rejected_kernel_ids", None) or [])}

--- a/src/hyperloom/orchestrator/roles/critic_agent.py
+++ b/src/hyperloom/orchestrator/roles/critic_agent.py
@@ -1194,10 +1194,12 @@ class CriticAgentBackend:
         try:
             acc["input_tokens"] += int(getattr(usage, "prompt_tokens", 0) or 0)
         except (TypeError, ValueError):
+            # Malformed usage value; skip this token count.
             pass
         try:
             acc["output_tokens"] += int(getattr(usage, "completion_tokens", 0) or 0)
         except (TypeError, ValueError):
+            # Malformed usage value; skip this token count.
             pass
 
     def set_trace_context(

--- a/src/hyperloom/orchestrator/roles/robustness_pulse.py
+++ b/src/hyperloom/orchestrator/roles/robustness_pulse.py
@@ -152,6 +152,7 @@ async def pulse(*, tick_index: int = 0, timeout_s: float = _PULSE_TIMEOUT_SEC) -
             try:
                 proc.kill()
             except ProcessLookupError:
+                # Process already exited; nothing to signal.
                 pass
             await proc.wait()
             return False

--- a/src/hyperloom/orchestrator/state/shared_state.py
+++ b/src/hyperloom/orchestrator/state/shared_state.py
@@ -1217,6 +1217,7 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
             try:
                 os.unlink(tmp)
             except OSError:
+                # Temp file already gone; re-raise the original error below.
                 pass
             raise
         # Author-time breakdown capture: snapshot state-owned sections into the

--- a/src/hyperloom/orchestrator/trace/langfuse_mapping.py
+++ b/src/hyperloom/orchestrator/trace/langfuse_mapping.py
@@ -449,6 +449,7 @@ def decision_to_scores(decision_row: dict[str, Any]) -> list[dict[str, Any]]:
                 }
             )
         except (TypeError, ValueError):
+            # Malformed metric payload; skip this event.
             pass
     # Calibration signal: the proposer's predicted gain emitted as its own
     # NUMERIC score on the SAME decision so a trace can compute the
@@ -464,6 +465,7 @@ def decision_to_scores(decision_row: dict[str, Any]) -> list[dict[str, Any]]:
                 "metadata": meta,
             })
         except (TypeError, ValueError):
+            # Malformed metric payload; skip this event.
             pass
     # Calibration signal: the proposal_scorer's pre-decision rating (mean
     # across raters) emitted as its own NUMERIC score on the SAME decision so

--- a/src/hyperloom/orchestrator/trace/parse_usage.py
+++ b/src/hyperloom/orchestrator/trace/parse_usage.py
@@ -360,6 +360,7 @@ def parse_oob_json_usage(stdout: str) -> dict[str, int | None] | None:
         if found is not None:
             return normalize_usage(found)
     except (json.JSONDecodeError, ValueError):
+        # Not valid JSON; fall through to line-by-line parsing.
         pass
     # Attempt 2: line-by-line (JSONL / mixed log output).
     last_usage: dict[str, Any] | None = None


### PR DESCRIPTION
## 背景
分批处理 `main`(4470192a) 上 CodeQL 剩余中/高风险告警。本 PR 是 Part 2：全部 **98 条 `py/empty-except`**。

## 修复方式（零控制流改动）
CodeQL 的 `py/empty-except` 判定为"except 块只有 `pass` 且**无注释**"。经逐处核对，98 处均为**合法的有意吞异常**，分三类：
1. **best-effort 清理**：删除已不存在的临时/PID 文件、释放已关闭的锁/fd、拷贝诊断产物等，失败非致命。
2. **进程信号收尾**：对可能已退出的进程/进程组发信号，`ProcessLookupError/PermissionError` 表示"已消失"，无需处理。
3. **容错解析**：`int()/float()/json.loads()/fromisoformat()` 等对可选/外部数据的解析，`ValueError/TypeError/JSONDecodeError` 时走默认分支。

对每处补充一句**贴合上下文的英文说明注释**，使 CodeQL 识别为有意忽略。**不改任何控制流/异常类型**。

## 验证
- 51 个文件 `py_compile` 全部通过
- `ruff check` 改动前后均为同样的 4 个既有错误（与本次注释无关，未新增）
- 抽查 diff 确认注释缩进与语义正确

## 说明
基于最新 `main`；与 #814 有少量文件重叠（如 `request_handlers.py`、`shared_state.py`、`explore.py`），但改动行不同（本 PR 只在 except 块内加注释），合并应无冲突。