### PR TITLE
[Stepping] inference-optimizer runtime hardening (framework guard, kv_cache OOM, conc_sweep recovery, SGLang patch fallback, kernel-agent turns)

### DIFF
--- a/src/hyperloom/inference_optimizer/breakdown/collectors/kernels.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/kernels.py
@@ -10,6 +10,7 @@ recorded in ``warnings`` and the section returns a best-effort partial.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 
@@ -984,6 +985,167 @@ def collect_kernel_optimization_summary(
 # Conc Sweep Summary (Breakdown panel integration spec §A2; PR #399)
 _CONC_SWEEP_SUMMARY_REL_PATH = "reports/conc_sweep_summary.json"
 
+_CONC_SWEEP_VARIANT_RE = re.compile(r"^(baseline|optimized)_conc(\d+)$")
+
+
+def _conc_sweep_successful_pairs(summary: dict[str, Any]) -> int:
+    try:
+        return int((summary.get("summary") or {}).get("successful_pairs") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _load_conc_variant_point(variant_dir: Path, *, arm: str, conc: int) -> dict[str, Any]:
+    """Best-effort point extraction from a conc_sweep variant workspace."""
+    result_paths = sorted(
+        variant_dir.rglob("inferencex_result.json"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    for result_path in result_paths:
+        data = _load_json_safe(result_path, [])
+        if not isinstance(data, dict):
+            continue
+        tput = data.get("output_throughput") or data.get("total_output_throughput")
+        try:
+            tput_f = float(tput)
+        except (TypeError, ValueError):
+            continue
+        return {
+            "arm": arm,
+            "conc": conc,
+            "status": "succeeded",
+            "output_throughput": tput_f,
+            "request_throughput": data.get("request_throughput"),
+            "total_token_throughput": data.get("total_token_throughput"),
+            "raw_result_path": _rel(result_path, variant_dir.parents[2]),
+        }
+    return {
+        "arm": arm,
+        "conc": conc,
+        "status": "failed",
+        "output_throughput": None,
+    }
+
+
+def _conc_sweep_pair_comparison(
+    baseline_points: list[dict[str, Any]],
+    optimized_points: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Pure baseline-vs-optimized outer join over CONC (no heavy deps).
+
+    Mirrors ``orchestrator.conc_sweep._build_comparison`` but stays import-light
+    so the breakdown collector never drags in Magpie/torch at report time.
+    """
+    by_b = {p["conc"]: p for p in baseline_points}
+    by_o = {p["conc"]: p for p in optimized_points}
+    concs = sorted(set(by_b) | set(by_o))
+    rows: list[dict[str, Any]] = []
+    speedups: list[float] = []
+    successful = 0
+    failed = 0
+    for c in concs:
+        b = by_b.get(c) or {}
+        o = by_o.get(c) or {}
+        bt = b.get("output_throughput")
+        ot = o.get("output_throughput")
+        speedup = None
+        delta = None
+        if isinstance(bt, (int, float)) and bt > 0 and isinstance(ot, (int, float)) and ot > 0:
+            speedup = float(ot) / float(bt)
+            delta = (speedup - 1.0) * 100.0
+            speedups.append(speedup)
+            successful += 1
+        else:
+            failed += 1
+        rows.append(
+            {
+                "conc": c,
+                "baseline_tput": bt,
+                "optimized_tput": ot,
+                "speedup": speedup,
+                "delta_pct": delta,
+                "baseline_status": b.get("status"),
+                "optimized_status": o.get("status"),
+            }
+        )
+    summary: dict[str, Any] = {
+        "successful_pairs": successful,
+        "failed_pairs": failed,
+        "best_conc": None,
+        "best_speedup": None,
+        "median_speedup": None,
+        "mean_speedup": None,
+    }
+    if speedups:
+        best_idx, best_val = max(
+            ((i, r["speedup"]) for i, r in enumerate(rows) if isinstance(r.get("speedup"), float)),
+            key=lambda x: x[1],
+        )
+        srt = sorted(speedups)
+        n = len(srt)
+        median = srt[n // 2] if n % 2 == 1 else 0.5 * (srt[n // 2 - 1] + srt[n // 2])
+        summary.update(
+            {
+                "best_conc": rows[best_idx]["conc"],
+                "best_speedup": round(best_val, 4),
+                "median_speedup": round(median, 4),
+                "mean_speedup": round(sum(speedups) / len(speedups), 4),
+            }
+        )
+    return rows, summary
+
+
+def _recover_conc_sweep_summary_from_runs(
+    session_dir: Path,
+    warnings: list[str],
+) -> dict[str, Any]:
+    """Recover a conc_sweep summary from raw run workspaces when the report is stale."""
+    runs_dir = session_dir / "runs" / "conc_sweep"
+    if not runs_dir.exists():
+        return {}
+    tasks = sorted(
+        (p for p in runs_dir.iterdir() if p.is_dir()),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    best_payload: dict[str, Any] = {}
+    best_pairs = 0
+    for task_dir in tasks:
+        baseline_points: list[dict[str, Any]] = []
+        optimized_points: list[dict[str, Any]] = []
+        for variant_dir in sorted(p for p in task_dir.iterdir() if p.is_dir()):
+            match = _CONC_SWEEP_VARIANT_RE.match(variant_dir.name)
+            if not match:
+                continue
+            arm, conc_text = match.groups()
+            point = _load_conc_variant_point(variant_dir, arm=arm, conc=int(conc_text))
+            if arm == "baseline":
+                baseline_points.append(point)
+            else:
+                optimized_points.append(point)
+        if not baseline_points and not optimized_points:
+            continue
+        baseline_points.sort(key=lambda p: p["conc"])
+        optimized_points.sort(key=lambda p: p["conc"])
+        comparison, summary = _conc_sweep_pair_comparison(baseline_points, optimized_points)
+        pairs = int(summary.get("successful_pairs") or 0)
+        payload = {
+            "schema_version": "recovered-v1",
+            "status": "succeeded" if pairs else "failed",
+            "source": "recovered_from_runs",
+            "workspace": task_dir.as_posix(),
+            "baseline": {"points": baseline_points},
+            "optimized": {"points": optimized_points},
+            "comparison": comparison,
+            "summary": summary,
+            "report_path": _rel(task_dir, session_dir) or task_dir.as_posix(),
+        }
+        if pairs > best_pairs:
+            best_payload = payload
+            best_pairs = pairs
+    return best_payload
+
 
 def collect_conc_sweep_summary(
     session_dir: Path,
@@ -1008,6 +1170,13 @@ def collect_conc_sweep_summary(
     """
     path = session_dir / _CONC_SWEEP_SUMMARY_REL_PATH
     if not path.exists():
+        recovered = _recover_conc_sweep_summary_from_runs(session_dir, warnings)
+        if _conc_sweep_successful_pairs(recovered) > 0:
+            warnings.append(
+                "conc_sweep_summary: reports/conc_sweep_summary.json absent; "
+                "recovered from runs/conc_sweep"
+            )
+            return recovered
         return {}
     blob = _load_json_safe(path, warnings)
     if not isinstance(blob, dict):
@@ -1022,6 +1191,12 @@ def collect_conc_sweep_summary(
         out["comparison"] = []
 
     out["report_path"] = _rel(path, session_dir) or _CONC_SWEEP_SUMMARY_REL_PATH
+
+    recovered = _recover_conc_sweep_summary_from_runs(session_dir, warnings)
+    if _conc_sweep_successful_pairs(recovered) > _conc_sweep_successful_pairs(out):
+        recovered["original_report_path"] = out["report_path"]
+        warnings.append("conc_sweep_summary: recovered newer successful conc_sweep data from runs/conc_sweep")
+        return recovered
     return out
 
 

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/kernels.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/kernels.py
@@ -988,6 +988,19 @@ _CONC_SWEEP_SUMMARY_REL_PATH = "reports/conc_sweep_summary.json"
 _CONC_SWEEP_VARIANT_RE = re.compile(r"^(baseline|optimized)_conc(\d+)$")
 
 
+def _safe_mtime(p: Path) -> float:
+    """mtime for sort keys; 0.0 when the entry vanished mid-scan.
+
+    Breakdown collectors must never raise, so a concurrent workspace cleanup
+    that removes a path between enumeration and ``stat`` must not surface as
+    an exception out of ``collect_conc_sweep_summary``.
+    """
+    try:
+        return p.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
 def _conc_sweep_successful_pairs(summary: dict[str, Any]) -> int:
     try:
         return int((summary.get("summary") or {}).get("successful_pairs") or 0)
@@ -999,14 +1012,16 @@ def _load_conc_variant_point(variant_dir: Path, *, arm: str, conc: int) -> dict[
     """Best-effort point extraction from a conc_sweep variant workspace."""
     result_paths = sorted(
         variant_dir.rglob("inferencex_result.json"),
-        key=lambda p: p.stat().st_mtime,
+        key=_safe_mtime,
         reverse=True,
     )
     for result_path in result_paths:
         data = _load_json_safe(result_path, [])
         if not isinstance(data, dict):
             continue
-        tput = data.get("output_throughput") or data.get("total_output_throughput")
+        tput = data.get("output_throughput")
+        if tput is None:
+            tput = data.get("total_output_throughput")
         try:
             tput_f = float(tput)
         except (TypeError, ValueError):
@@ -1109,7 +1124,7 @@ def _recover_conc_sweep_summary_from_runs(
         return {}
     tasks = sorted(
         (p for p in runs_dir.iterdir() if p.is_dir()),
-        key=lambda p: p.stat().st_mtime,
+        key=_safe_mtime,
         reverse=True,
     )
     best_payload: dict[str, Any] = {}
@@ -1117,16 +1132,19 @@ def _recover_conc_sweep_summary_from_runs(
     for task_dir in tasks:
         baseline_points: list[dict[str, Any]] = []
         optimized_points: list[dict[str, Any]] = []
-        for variant_dir in sorted(p for p in task_dir.iterdir() if p.is_dir()):
-            match = _CONC_SWEEP_VARIANT_RE.match(variant_dir.name)
-            if not match:
-                continue
-            arm, conc_text = match.groups()
-            point = _load_conc_variant_point(variant_dir, arm=arm, conc=int(conc_text))
-            if arm == "baseline":
-                baseline_points.append(point)
-            else:
-                optimized_points.append(point)
+        try:
+            for variant_dir in sorted(p for p in task_dir.iterdir() if p.is_dir()):
+                match = _CONC_SWEEP_VARIANT_RE.match(variant_dir.name)
+                if not match:
+                    continue
+                arm, conc_text = match.groups()
+                point = _load_conc_variant_point(variant_dir, arm=arm, conc=int(conc_text))
+                if arm == "baseline":
+                    baseline_points.append(point)
+                else:
+                    optimized_points.append(point)
+        except OSError:
+            continue
         if not baseline_points and not optimized_points:
             continue
         baseline_points.sort(key=lambda p: p["conc"])
@@ -1195,11 +1213,16 @@ def collect_conc_sweep_summary(
 
     out["report_path"] = _rel(path, session_dir) or _CONC_SWEEP_SUMMARY_REL_PATH
 
-    recovered = _recover_conc_sweep_summary_from_runs(session_dir, warnings)
-    if _conc_sweep_successful_pairs(recovered) > _conc_sweep_successful_pairs(out):
-        recovered["original_report_path"] = out["report_path"]
-        warnings.append("conc_sweep_summary: recovered newer successful conc_sweep data from runs/conc_sweep")
-        return recovered
+    # Only fall back to run-workspace recovery when the authoritative report
+    # has no successful pairs. A healthy report is authoritative and must not
+    # be overridden by the weaker throughput-only recompute (also skips the
+    # full runs/ scan on the healthy path).
+    if _conc_sweep_successful_pairs(out) == 0:
+        recovered = _recover_conc_sweep_summary_from_runs(session_dir, warnings)
+        if _conc_sweep_successful_pairs(recovered) > 0:
+            recovered["original_report_path"] = out["report_path"]
+            warnings.append("conc_sweep_summary: recovered successful conc_sweep data from runs/conc_sweep")
+            return recovered
     return out
 
 

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/kernels.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/kernels.py
@@ -1018,7 +1018,10 @@ def _load_conc_variant_point(variant_dir: Path, *, arm: str, conc: int) -> dict[
             "output_throughput": tput_f,
             "request_throughput": data.get("request_throughput"),
             "total_token_throughput": data.get("total_token_throughput"),
-            "raw_result_path": _rel(result_path, variant_dir.parents[2]),
+            "raw_result_path": _rel(
+                result_path,
+                variant_dir.parents[2] if len(variant_dir.parents) >= 3 else variant_dir,
+            ),
         }
     return {
         "arm": arm,

--- a/src/hyperloom/inference_optimizer/cli/__init__.py
+++ b/src/hyperloom/inference_optimizer/cli/__init__.py
@@ -1504,6 +1504,7 @@ async def _run_optimize(args: argparse.Namespace) -> int:
                     state.save(session_dir)
                     print("  backfilled model_info (from config.json)")
         if state.framework:
+            _enforce_expected_framework(state.framework)
             os.environ["FRAMEWORK"] = state.framework
             print(f"  re-exported FRAMEWORK : {state.framework}")
         if state.gpu_type:

--- a/src/hyperloom/inference_optimizer/cli/__init__.py
+++ b/src/hyperloom/inference_optimizer/cli/__init__.py
@@ -286,6 +286,47 @@ def _orchestration_rules_fragment_path() -> Path:
     return asset_system_prompts_dir() / "orchestration.md"
 
 
+def _normalise_framework_name(value: str | None) -> str:
+    """Normalize a framework string for equality checks."""
+    return str(value or "").strip().lower().replace("_", "-")
+
+
+def _enforce_expected_framework(
+    framework: str,
+    *,
+    expected: str | None = None,
+) -> None:
+    """Fail fast when a launcher-pinned expected framework is violated.
+
+    Long-running launches often pass through generated shell scripts. A stale
+    script that mutates ``$FRAMEWORK`` can otherwise silently run a different
+    backend than the operator requested. ``EXPECTED_FRAMEWORK`` is the compact
+    launcher-facing guard; ``INFERENCE_OPTIMIZER_EXPECTED_FRAMEWORK`` is the
+    namespaced equivalent for platform integrations.
+    """
+    actual = _normalise_framework_name(framework)
+    expected_raw = (
+        expected
+        if expected is not None
+        else (
+            os.environ.get("INFERENCE_OPTIMIZER_EXPECTED_FRAMEWORK", "")
+            or os.environ.get("EXPECTED_FRAMEWORK", "")
+        )
+    )
+    wanted = _normalise_framework_name(expected_raw)
+    if not wanted:
+        return
+    if wanted != actual:
+        print(
+            "ERROR: framework mismatch: "
+            f"EXPECTED_FRAMEWORK={wanted!r} but resolved framework={actual!r}. "
+            "Refusing to launch because this would run a different backend "
+            "than the operator requested.",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
+
 def _objective_summary_for_prompt(objective: Objective) -> tuple[str, float | str | None]:
     """Summarise an objective into the ``(kind, value)`` pair the prompt expects.
 
@@ -1645,6 +1686,7 @@ async def _run_optimize(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             sys.exit(2)
+        _enforce_expected_framework(framework)
         os.environ["FRAMEWORK"] = framework
         print(f"Framework       : {framework}")
 

--- a/src/hyperloom/inference_optimizer/cli/backends.py
+++ b/src/hyperloom/inference_optimizer/cli/backends.py
@@ -26,6 +26,29 @@ from hyperloom.orchestrator.roles import (
 from hyperloom.orchestrator.scoring.proposal_scorer import DEFAULT_SCORER_MODELS, ProposalScorer
 
 
+_KERNEL_AGENT_DEFAULT_MAX_TURNS = 5
+
+
+def _resolve_kernel_agent_max_turns() -> int:
+    """Resolve the kernel_agent Claude turn budget.
+
+    Reads ``INFERENCE_OPTIMIZER_KERNEL_AGENT_MAX_TURNS`` (a positive int);
+    falls back to ``_KERNEL_AGENT_DEFAULT_MAX_TURNS`` (5, unchanged default)
+    on unset/invalid/<=0. Lets an operator raise the budget to avoid a
+    "Reached maximum number of turns" failure on complex kernel tasks
+    without editing the reactor logic.
+    """
+    raw = os.environ.get("INFERENCE_OPTIMIZER_KERNEL_AGENT_MAX_TURNS", "").strip()
+    if not raw:
+        return _KERNEL_AGENT_DEFAULT_MAX_TURNS
+    try:
+        val = int(raw)
+    except ValueError:
+        return _KERNEL_AGENT_DEFAULT_MAX_TURNS
+    return val if val >= 1 else _KERNEL_AGENT_DEFAULT_MAX_TURNS
+
+
+
 def _build_backends(
     *,
     claude_model: str,
@@ -137,7 +160,10 @@ def _build_backends(
         if kernel_codex:
             backends["kernel_agent"] = CodexBackend(model=codex_model)
         else:
-            backends["kernel_agent"] = ClaudeBackend(model=claude_model, max_turns_default=5)
+            backends["kernel_agent"] = ClaudeBackend(
+                model=claude_model,
+                max_turns_default=_resolve_kernel_agent_max_turns(),
+            )
     return backends
 
 

--- a/src/hyperloom/inference_optimizer/tests/test_baseline_failure_summary.py
+++ b/src/hyperloom/inference_optimizer/tests/test_baseline_failure_summary.py
@@ -243,3 +243,28 @@ def test_classify_root_cause_type_kv_cache_oom():
         )
         == "kv_cache_oom"
     )
+
+
+def test_classify_root_cause_ignores_mem_fraction_static_in_argv():
+    # --mem-fraction-static appears verbatim in normal server argv dumps; a
+    # generic failure whose text merely echoes the launch command must NOT be
+    # mislabeled kv_cache_oom (only the specific KV-cache OOM markers should).
+    result = _classify_root_cause_type(
+        "subprocess_nonzero",
+        "server cmd: python -m sglang.launch_server "
+        "--mem-fraction-static 0.9 --tp 8; exited 1 with a segfault",
+    )
+    assert result != "kv_cache_oom"
+
+
+def test_classify_root_cause_kv_cache_oom_specific_phrase_still_matches():
+    # The actionable "Raise --mem-fraction-static above" remediation line is a
+    # genuine KV-cache OOM signal and must still classify as kv_cache_oom even
+    # when error_class is generic.
+    assert (
+        _classify_root_cause_type(
+            "subprocess_nonzero",
+            "ValueError: ... Raise --mem-fraction-static above 0.737",
+        )
+        == "kv_cache_oom"
+    )

--- a/src/hyperloom/inference_optimizer/tests/test_baseline_failure_summary.py
+++ b/src/hyperloom/inference_optimizer/tests/test_baseline_failure_summary.py
@@ -226,3 +226,20 @@ def test_format_md_surfaces_root_cause():
     assert "Root cause" in md
     assert "oom" in md
     assert "modeling_cohere2.py" not in md
+
+
+def test_classify_root_cause_type_kv_cache_oom():
+    assert (
+        _classify_root_cause_type(
+            "kv_cache_oom",
+            "Loaded weights leave no GPU memory for the KV cache",
+        )
+        == "kv_cache_oom"
+    )
+    assert (
+        _classify_root_cause_type(
+            "subprocess_nonzero",
+            "Raise --mem-fraction-static above 0.737",
+        )
+        == "kv_cache_oom"
+    )

--- a/src/hyperloom/inference_optimizer/tests/test_baseline_warmup_double_run.py
+++ b/src/hyperloom/inference_optimizer/tests/test_baseline_warmup_double_run.py
@@ -1206,3 +1206,22 @@ def test_classify_value_error_with_argv_dump_not_arg_error():
         )
         == "subprocess_nonzero"
     )
+
+
+def test_classify_kv_cache_oom_after_weight_load():
+    # KV-cache OOM can surface well after the 30s fast-exit window (weights
+    # take minutes to load), so it must be detected regardless of elapsed time.
+    tail = (
+        "ValueError: Loaded weights leave no GPU memory for the KV cache "
+        "under --mem-fraction-static=0.7. Raise --mem-fraction-static above 0.737"
+    )
+    assert _classify_subprocess_error(600.0, tail) == "kv_cache_oom"
+
+
+def test_classify_kv_cache_oom_fast_exit():
+    tail = "no GPU memory for the KV cache"
+    assert _classify_subprocess_error(3.0, tail) == "kv_cache_oom"
+
+
+def test_classify_non_kv_oom_still_nonzero():
+    assert _classify_subprocess_error(600.0, "some other runtime failure") == "subprocess_nonzero"

--- a/src/hyperloom/inference_optimizer/tests/test_baseline_warmup_double_run.py
+++ b/src/hyperloom/inference_optimizer/tests/test_baseline_warmup_double_run.py
@@ -1208,6 +1208,13 @@ def test_classify_value_error_with_argv_dump_not_arg_error():
     )
 
 
+def test_classify_subprocess_error_none_tail_does_not_crash():
+    # A slow (>=FAST_EXIT) failure with no captured stderr must not raise:
+    # stderr_tail.lower() is hoisted above the elapsed gate, so a None tail
+    # would AttributeError without the guard.
+    assert _classify_subprocess_error(600.0, None) == "subprocess_nonzero"
+
+
 def test_classify_kv_cache_oom_after_weight_load():
     # KV-cache OOM can surface well after the 30s fast-exit window (weights
     # take minutes to load), so it must be detected regardless of elapsed time.

--- a/src/hyperloom/inference_optimizer/tests/test_breakdown_conc_sweep_collectors.py
+++ b/src/hyperloom/inference_optimizer/tests/test_breakdown_conc_sweep_collectors.py
@@ -86,3 +86,53 @@ def test_collect_conc_sweep_summary_keeps_report_when_not_beaten(tmp_path: Path)
     summary = collect_conc_sweep_summary(session, warnings)
     assert summary["summary"]["successful_pairs"] == 2
     assert summary.get("source") != "recovered_from_runs"
+
+
+def test_collect_conc_sweep_summary_survives_dangling_result_symlink(tmp_path: Path):
+    # A result path that dangles/vanishes mid-scan must not raise; collectors
+    # only record to warnings and return a best-effort result.
+    import os
+
+    session = tmp_path / "session"
+    (session / "reports").mkdir(parents=True)
+    bench = session / "runs" / "conc_sweep" / "task_a" / "baseline_conc1" / "benchmark"
+    bench.mkdir(parents=True)
+    os.symlink(str(tmp_path / "missing.json"), str(bench / "inferencex_result.json"))
+    warnings: list[str] = []
+    summary = collect_conc_sweep_summary(session, warnings)  # must not raise
+    assert isinstance(summary, dict)
+
+
+def test_collect_conc_sweep_summary_does_not_override_healthy_report(tmp_path: Path):
+    # A valid report with >=1 successful pair is authoritative; recovery must be
+    # skipped entirely even if runs/ hold MORE successful pairs.
+    session = tmp_path / "session"
+    (session / "reports").mkdir(parents=True)
+    (session / "reports" / "conc_sweep_summary.json").write_text(
+        json.dumps(
+            {"status": "succeeded", "summary": {"successful_pairs": 1, "failed_pairs": 0}, "comparison": []}
+        ),
+        encoding="utf-8",
+    )
+    _write_result(session, "task_a", "baseline_conc1", 100.0)
+    _write_result(session, "task_a", "optimized_conc1", 130.0)
+    _write_result(session, "task_a", "baseline_conc4", 200.0)
+    _write_result(session, "task_a", "optimized_conc4", 260.0)  # runs = 2 pairs > report's 1
+    warnings: list[str] = []
+    summary = collect_conc_sweep_summary(session, warnings)
+    assert summary["summary"]["successful_pairs"] == 1
+    assert summary.get("source") != "recovered_from_runs"
+
+
+def test_load_conc_variant_point_keeps_zero_output_throughput(tmp_path: Path):
+    # A legitimate 0.0 output_throughput must NOT be silently replaced by
+    # total_output_throughput (the old `a or b` dropped the real zero).
+    from hyperloom.inference_optimizer.breakdown.collectors.kernels import _load_conc_variant_point
+
+    variant = tmp_path / "runs" / "conc_sweep" / "task_a" / "baseline_conc1"
+    (variant / "benchmark").mkdir(parents=True)
+    (variant / "benchmark" / "inferencex_result.json").write_text(
+        json.dumps({"output_throughput": 0.0, "total_output_throughput": 999.0}), encoding="utf-8"
+    )
+    point = _load_conc_variant_point(variant, arm="baseline", conc=1)
+    assert point["output_throughput"] == 0.0

--- a/src/hyperloom/inference_optimizer/tests/test_breakdown_conc_sweep_collectors.py
+++ b/src/hyperloom/inference_optimizer/tests/test_breakdown_conc_sweep_collectors.py
@@ -1,0 +1,66 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Regression tests for conc_sweep report collection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from hyperloom.inference_optimizer.breakdown.collectors import collect_conc_sweep_summary
+
+
+def _write_result(root: Path, task: str, variant: str, tput: float) -> None:
+    out = root / "runs" / "conc_sweep" / task / variant / "benchmark" / "inferencex_result.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps({"output_throughput": tput, "request_throughput": tput / 1000}), encoding="utf-8")
+
+
+def test_collect_conc_sweep_summary_recovers_newer_successful_task(tmp_path: Path):
+    session = tmp_path / "session"
+    (session / "reports").mkdir(parents=True)
+    (session / "reports" / "conc_sweep_summary.json").write_text(
+        json.dumps(
+            {
+                "status": "failed",
+                "summary": {"successful_pairs": 0, "failed_pairs": 8, "best_conc": None},
+                "comparison": [],
+                "workspace": str(session / "runs" / "conc_sweep" / "old_failed_task"),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    _write_result(session, "new_success_task", "baseline_conc1", 100.0)
+    _write_result(session, "new_success_task", "optimized_conc1", 150.0)
+    _write_result(session, "new_success_task", "baseline_conc4", 200.0)
+    _write_result(session, "new_success_task", "optimized_conc4", 260.0)
+
+    warnings: list[str] = []
+    summary = collect_conc_sweep_summary(session, warnings)
+
+    assert summary["status"] == "succeeded"
+    assert summary["summary"]["successful_pairs"] == 2
+    assert summary["summary"]["best_conc"] == 1
+    assert summary["source"] == "recovered_from_runs"
+    assert "original_report_path" in summary
+    assert any("recovered" in w for w in warnings)
+
+
+def test_collect_conc_sweep_summary_recovers_when_report_absent(tmp_path: Path):
+    session = tmp_path / "session"
+    (session / "reports").mkdir(parents=True)
+    _write_result(session, "task_a", "baseline_conc1", 100.0)
+    _write_result(session, "task_a", "optimized_conc1", 130.0)
+    warnings: list[str] = []
+    summary = collect_conc_sweep_summary(session, warnings)
+    assert summary["status"] == "succeeded"
+    assert summary["summary"]["successful_pairs"] == 1
+    assert summary["source"] == "recovered_from_runs"
+    assert any("absent" in w for w in warnings)
+
+def test_collect_conc_sweep_summary_absent_and_no_runs_returns_empty(tmp_path: Path):
+    session = tmp_path / "session"
+    (session / "reports").mkdir(parents=True)
+    warnings: list[str] = []
+    assert collect_conc_sweep_summary(session, warnings) == {}

--- a/src/hyperloom/inference_optimizer/tests/test_breakdown_conc_sweep_collectors.py
+++ b/src/hyperloom/inference_optimizer/tests/test_breakdown_conc_sweep_collectors.py
@@ -64,3 +64,25 @@ def test_collect_conc_sweep_summary_absent_and_no_runs_returns_empty(tmp_path: P
     (session / "reports").mkdir(parents=True)
     warnings: list[str] = []
     assert collect_conc_sweep_summary(session, warnings) == {}
+
+
+def test_collect_conc_sweep_summary_keeps_report_when_not_beaten(tmp_path: Path):
+    session = tmp_path / "session"
+    (session / "reports").mkdir(parents=True)
+    (session / "reports" / "conc_sweep_summary.json").write_text(
+        json.dumps(
+            {
+                "status": "succeeded",
+                "summary": {"successful_pairs": 2, "failed_pairs": 0},
+                "comparison": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    # Runs hold only one successful pair -> must NOT override the 2-pair report.
+    _write_result(session, "task_a", "baseline_conc1", 100.0)
+    _write_result(session, "task_a", "optimized_conc1", 130.0)
+    warnings: list[str] = []
+    summary = collect_conc_sweep_summary(session, warnings)
+    assert summary["summary"]["successful_pairs"] == 2
+    assert summary.get("source") != "recovered_from_runs"

--- a/src/hyperloom/inference_optimizer/tests/test_cli_backends_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_cli_backends_unit.py
@@ -197,3 +197,24 @@ def test_robustness_options_workload_uid_from_env(monkeypatch) -> None:
     )
     opts = clib._build_robustness_options(args)
     assert opts["workload_uid"] == "ray-42"
+
+
+# ---- _resolve_kernel_agent_max_turns ----
+def test_kernel_agent_max_turns_default(monkeypatch):
+    from hyperloom.inference_optimizer.cli import backends as cb
+    monkeypatch.delenv("INFERENCE_OPTIMIZER_KERNEL_AGENT_MAX_TURNS", raising=False)
+    assert cb._resolve_kernel_agent_max_turns() == 5
+
+
+def test_kernel_agent_max_turns_env_override(monkeypatch):
+    from hyperloom.inference_optimizer.cli import backends as cb
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_KERNEL_AGENT_MAX_TURNS", "9")
+    assert cb._resolve_kernel_agent_max_turns() == 9
+
+
+def test_kernel_agent_max_turns_invalid_falls_back(monkeypatch):
+    from hyperloom.inference_optimizer.cli import backends as cb
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_KERNEL_AGENT_MAX_TURNS", "not-an-int")
+    assert cb._resolve_kernel_agent_max_turns() == 5
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_KERNEL_AGENT_MAX_TURNS", "0")
+    assert cb._resolve_kernel_agent_max_turns() == 5

--- a/src/hyperloom/inference_optimizer/tests/test_preflight_auth_override.py
+++ b/src/hyperloom/inference_optimizer/tests/test_preflight_auth_override.py
@@ -1163,3 +1163,28 @@ def test_expected_framework_guard_rejects_mismatch(monkeypatch, capsys):
 def test_expected_framework_guard_accepts_match(monkeypatch):
     monkeypatch.setenv("EXPECTED_FRAMEWORK", "VLLM")
     cli._enforce_expected_framework("vllm")
+
+
+def test_expected_framework_guard_namespaced_env_var(monkeypatch):
+    monkeypatch.delenv("EXPECTED_FRAMEWORK", raising=False)
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_EXPECTED_FRAMEWORK", "vllm")
+    with pytest.raises(SystemExit) as exc:
+        cli._enforce_expected_framework("sglang")
+    assert exc.value.code == 2
+
+
+def test_expected_framework_guard_namespaced_takes_precedence(monkeypatch):
+    # Namespaced var wins over the compact one, so a matching compact value
+    # cannot rescue a namespaced mismatch.
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_EXPECTED_FRAMEWORK", "vllm")
+    monkeypatch.setenv("EXPECTED_FRAMEWORK", "sglang")
+    with pytest.raises(SystemExit):
+        cli._enforce_expected_framework("sglang")
+
+
+def test_expected_framework_guard_unset_is_noop(monkeypatch):
+    monkeypatch.delenv("EXPECTED_FRAMEWORK", raising=False)
+    monkeypatch.delenv("INFERENCE_OPTIMIZER_EXPECTED_FRAMEWORK", raising=False)
+    # No env pins -> guard is a no-op regardless of framework.
+    cli._enforce_expected_framework("sglang")
+    cli._enforce_expected_framework("anything")

--- a/src/hyperloom/inference_optimizer/tests/test_preflight_auth_override.py
+++ b/src/hyperloom/inference_optimizer/tests/test_preflight_auth_override.py
@@ -1145,3 +1145,21 @@ def test_cli_parser_exposes_degraded_flags():
     args = parser.parse_args(["optimize", "--model", "/x"])
     assert args.degraded_kb is False
     assert args.degraded_pr is False
+
+
+# Framework guard
+
+def test_expected_framework_guard_rejects_mismatch(monkeypatch, capsys):
+    monkeypatch.setenv("EXPECTED_FRAMEWORK", "vllm")
+    with pytest.raises(SystemExit) as exc:
+        cli._enforce_expected_framework("sglang")
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "EXPECTED_FRAMEWORK" in err
+    assert "vllm" in err
+    assert "sglang" in err
+
+
+def test_expected_framework_guard_accepts_match(monkeypatch):
+    monkeypatch.setenv("EXPECTED_FRAMEWORK", "VLLM")
+    cli._enforce_expected_framework("vllm")

--- a/src/hyperloom/inference_optimizer/tests/test_report_helpers_coverage_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_report_helpers_coverage_unit.py
@@ -255,3 +255,23 @@ def test_format_md_renders_stop_explanation():
     )
     assert "Why it stopped" in md
     assert "Robustness escalated" in md
+
+
+# ---- stop_reason explanation vocabulary coverage (M1) ----
+def test_every_stop_reason_vocab_member_has_explanation():
+    from hyperloom.orchestrator.phases.machine_state import STOP_REASON_VOCAB
+
+    missing = sorted(r for r in STOP_REASON_VOCAB if not rp._explain_stop_reason(r))
+    assert missing == [], f"stop reasons without an explanation: {missing}"
+
+
+def test_classify_root_cause_prefers_kv_cache_oom_over_generic_oom():
+    # A KV-cache OOM message can also contain the generic "out of memory"
+    # phrase; the more specific bucket must win (L1).
+    assert (
+        rp._classify_root_cause_type(
+            "kv_cache_oom",
+            "CUDA out of memory; no GPU memory for the KV cache",
+        )
+        == "kv_cache_oom"
+    )

--- a/src/hyperloom/inference_optimizer/tests/test_report_helpers_coverage_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_report_helpers_coverage_unit.py
@@ -212,3 +212,46 @@ def test_highlight_topics():
     # fallback branch
     other = rp._highlight({"a": 1, "b": "two", "c": [1, 2]}, "weird_topic", "ag")
     assert "a" in other["summary"]
+
+
+# ---- _explain_stop_reason ----
+def test_explain_stop_reason_robustness_escalated():
+    msg = rp._explain_stop_reason("robustness_escalated")
+    assert msg
+    assert "robustness" in msg.lower()
+
+
+def test_explain_stop_reason_target_reached():
+    assert "target" in rp._explain_stop_reason("target_reached").lower()
+
+
+def test_explain_stop_reason_unknown_is_empty():
+    assert rp._explain_stop_reason("some_unmapped_reason") == ""
+    assert rp._explain_stop_reason("") == ""
+
+
+def test_format_md_renders_stop_explanation():
+    md = rp._format_md(
+        {
+            "session_id": "s",
+            "model_name": "m",
+            "model_path": "/m",
+            "stop_reason": "robustness_escalated",
+            "stop_reason_explanation": "Robustness escalated: stopped early to protect validated gains.",
+            "max_minutes": 60,
+            "report_generated_at": "t0",
+            "framework": "sglang",
+            "current_best": {},
+            "baseline_tput": 100.0,
+            "cumulative_gain": 0.0,
+            "cumulative_gain_validated": 0.0,
+            "cumulative_gain_validated_stack_len": 0,
+            "optimization_stack_len": 0,
+            "crash_count": 0,
+            "pruned_families": [],
+            "event_counts_by_topic": {},
+            "highlights": [],
+        }
+    )
+    assert "Why it stopped" in md
+    assert "Robustness escalated" in md

--- a/src/hyperloom/inference_optimizer/tests/test_server_patcher_sglang_version_fallback.py
+++ b/src/hyperloom/inference_optimizer/tests/test_server_patcher_sglang_version_fallback.py
@@ -1,0 +1,45 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""Version fallback for the SGLang TraceLens patch subdir resolver."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hyperloom.orchestrator.actions.executors._server_patcher import (
+    _resolve_sglang_patches_dir,
+)
+
+
+def _mk(root: Path, name: str) -> Path:
+    d = root / name
+    d.mkdir(parents=True)
+    (d / "roofline.patch").write_text("# stub patch\n", encoding="utf-8")
+    return d
+
+
+def test_exact_version_subdir_preferred(tmp_path: Path):
+    root = tmp_path / "sglang_roofline_patches"
+    _mk(root, "sglang_0_5_11")
+    exact = _mk(root, "sglang_0_5_14")
+    assert _resolve_sglang_patches_dir(root, "0.5.14") == exact
+
+
+def test_nearest_not_newer_when_exact_missing(tmp_path: Path):
+    root = tmp_path / "sglang_roofline_patches"
+    older = _mk(root, "sglang_0_5_11")
+    _mk(root, "sglang_0_4_9")
+    # 0.5.14 has no exact dir → nearest not-newer same-minor is 0.5.11.
+    assert _resolve_sglang_patches_dir(root, "0.5.14") == older
+
+
+def test_only_newer_available_returns_none(tmp_path: Path):
+    root = tmp_path / "sglang_roofline_patches"
+    _mk(root, "sglang_0_6_0")
+    assert _resolve_sglang_patches_dir(root, "0.5.14") is None
+
+
+def test_empty_subdir_ignored(tmp_path: Path):
+    root = tmp_path / "sglang_roofline_patches"
+    (root / "sglang_0_5_11").mkdir(parents=True)  # no *.patch inside
+    assert _resolve_sglang_patches_dir(root, "0.5.14") is None

--- a/src/hyperloom/inference_optimizer/tests/test_server_patcher_sglang_version_fallback.py
+++ b/src/hyperloom/inference_optimizer/tests/test_server_patcher_sglang_version_fallback.py
@@ -43,3 +43,11 @@ def test_empty_subdir_ignored(tmp_path: Path):
     root = tmp_path / "sglang_roofline_patches"
     (root / "sglang_0_5_11").mkdir(parents=True)  # no *.patch inside
     assert _resolve_sglang_patches_dir(root, "0.5.14") is None
+
+
+def test_cross_minor_fallback_when_no_same_minor(tmp_path: Path):
+    root = tmp_path / "sglang_roofline_patches"
+    older = _mk(root, "sglang_0_4_9")
+    # No same-minor (0.5.x) subdir exists, so fall back to the nearest
+    # not-newer patched subdir across minors -> 0.4.9.
+    assert _resolve_sglang_patches_dir(root, "0.5.14") == older

--- a/src/hyperloom/inference_optimizer/tests/test_shared_state_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_shared_state_units.py
@@ -504,3 +504,25 @@ def test_record_action_failure_captures_stderr_tail_for_kv_cache_oom():
     )
     assert entry["stderr_tail"] is not None
     assert "no GPU memory for the KV cache" in entry["stderr_tail"]
+
+
+def test_record_action_attempt_kv_cache_oom_captures_stderr_tail():
+    # kv_cache_oom is a subprocess-style failure, so record_action_attempt must
+    # capture its stderr_tail into <action>_attempts (parallel to the
+    # subprocess_nonzero path).
+    s = SharedState()
+    s.record_action_attempt(
+        action="baseline",
+        task_id="t-kvoom",
+        status="failed",
+        decision="no_promote",
+        result={
+            "error_class": "kv_cache_oom",
+            "error": "Loaded weights leave no GPU memory for the KV cache",
+            "reported_success": False,
+        },
+    )
+    attempt = s.baseline_attempts[-1]
+    assert attempt["error_class"] == "kv_cache_oom"
+    assert attempt["stderr_tail"] is not None
+    assert "no GPU memory for the KV cache" in attempt["stderr_tail"]

--- a/src/hyperloom/inference_optimizer/tests/test_shared_state_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_shared_state_units.py
@@ -488,3 +488,19 @@ def test_save_load_round_trips_failure_log(tmp_path):
     assert len(s2.last_action_failures) == 1
     assert s2.last_action_failures[0]["action"] == "sweep"
     assert s2.last_action_failures[0]["error_class"] == "subprocess_nonzero"
+
+
+def test_record_action_failure_captures_stderr_tail_for_kv_cache_oom():
+    # kv_cache_oom is a subprocess-style failure: its stderr tail is the whole
+    # signal, so it must be captured like subprocess_nonzero/timeout.
+    s = SharedState()
+    entry = s.record_action_failure(
+        action="explore",
+        task_id="t-kvoom",
+        result={
+            "error_class": "kv_cache_oom",
+            "error": "Loaded weights leave no GPU memory for the KV cache",
+        },
+    )
+    assert entry["stderr_tail"] is not None
+    assert "no GPU memory for the KV cache" in entry["stderr_tail"]

--- a/src/hyperloom/orchestrator/actions/executors/_server_patcher.py
+++ b/src/hyperloom/orchestrator/actions/executors/_server_patcher.py
@@ -181,29 +181,71 @@ def _versioned_patches_subdir_name(version: str) -> str | None:
     return "sglang_" + "_".join(numeric)
 
 
+def _sglang_subdir_version_tuple(name: str) -> tuple[int, ...] | None:
+    """Parse a ``sglang_0_5_11`` patch subdir name back into ``(0, 5, 11)``.
+
+    Returns ``None`` when the name is not a versioned SGLang subdir.
+    """
+    prefix = "sglang_"
+    if not name.startswith(prefix):
+        return None
+    numeric: list[int] = []
+    for part in name[len(prefix):].split("_"):
+        if part.isdigit():
+            numeric.append(int(part))
+        else:
+            break
+    return tuple(numeric) if len(numeric) >= 2 else None
+
+
 def _resolve_sglang_patches_dir(
     patches_root: Path,
     version: str,
 ) -> Path | None:
     """Locate the SGLang patches dir for the running ``sglang`` version.
 
-    Requires the per-version subdir layout (``sglang_0_5_11/``, ...); the flat
-    v0.3 layout is unsupported. Returns the subdir when it exists and has at
-    least one ``*.patch``, else ``None`` (caller fail-softs).
+    Order (mirrors :func:`_resolve_vllm_patch_file`): exact ``sglang_X_Y_Z``
+    subdir > highest same-minor subdir whose version is <= running > nearest
+    subdir whose version is <= running (never a newer one). Only subdirs with
+    at least one ``*.patch`` qualify; ``_apply_atomic``'s ``git apply --check``
+    still guards a genuinely incompatible pick. Returns ``None`` when nothing
+    qualifies (caller fail-softs).
 
     Args:
         patches_root: Root directory holding the per-version patch subdirs.
         version: The running ``sglang`` version string.
 
     Returns:
-        The resolved patches subdir, or ``None`` when it is missing or empty.
+        The resolved patches subdir, or ``None`` when none qualifies.
     """
     subdir_name = _versioned_patches_subdir_name(version)
-    if subdir_name is None:
+    if subdir_name is not None:
+        candidate = patches_root / subdir_name
+        if candidate.is_dir() and any(candidate.glob("*.patch")):
+            return candidate
+
+    # Graceful fallback to the nearest not-newer patched subdir.
+    if not patches_root.is_dir():
         return None
-    candidate = patches_root / subdir_name
-    if candidate.is_dir() and any(candidate.glob("*.patch")):
-        return candidate
+    running = _version_tuple(version)
+    if running is None:
+        return None
+    available: dict[tuple[int, ...], Path] = {}
+    for d in patches_root.iterdir():
+        if not d.is_dir() or not any(d.glob("*.patch")):
+            continue
+        vt = _sglang_subdir_version_tuple(d.name)
+        if vt:
+            available[vt] = d
+    if not available:
+        return None
+    if len(running) >= 2:
+        same_minor = [vt for vt in available if vt[:2] == running[:2] and vt <= running]
+        if same_minor:
+            return available[max(same_minor)]
+    not_higher = [vt for vt in available if vt <= running]
+    if not_higher:
+        return available[max(not_higher)]
     return None
 
 

--- a/src/hyperloom/orchestrator/actions/executors/baseline.py
+++ b/src/hyperloom/orchestrator/actions/executors/baseline.py
@@ -118,6 +118,17 @@ _ARG_ERROR_CONTEXT_PATTERNS = (
     "unknown",
 )
 
+# KV-cache OOM: weights loaded but no room left for the KV cache. Kept
+# distinct from a generic nonzero exit so the loop/report attributes it to an
+# over-aggressive --mem-fraction-static (raise it) rather than a hard crash.
+# This surfaces AFTER weight load (often minutes in), so it must be matched
+# regardless of the fast-exit elapsed threshold.
+_KV_CACHE_OOM_MARKERS = (
+    "no gpu memory for the kv cache",
+    "leave no gpu memory",
+    "raise --mem-fraction-static above",
+)
+
 
 # Strong cuda-graph capture markers: stream-capture incompatibility, reliably
 # recoverable by disabling cuda-graph. Markers live in server.log, not the
@@ -261,9 +272,13 @@ def _classify_subprocess_error(
         ``"fast_exit_arg_error"`` for a fast exit caused by argument
         validation, else ``"subprocess_nonzero"``.
     """
+    tail = stderr_tail.lower()
+    # KV-cache OOM can surface long after weight load, so it is matched before
+    # the fast-exit elapsed gate below.
+    if any(m in tail for m in _KV_CACHE_OOM_MARKERS):
+        return "kv_cache_oom"
     if elapsed_sec >= FAST_EXIT_THRESHOLD_SEC:
         return "subprocess_nonzero"
-    tail = stderr_tail.lower()
     if any(p.lower() in tail for p in _ARG_ERROR_PATTERNS):
         return "fast_exit_arg_error"
     if "valueerror:" in tail and any(p in tail for p in _ARG_ERROR_CONTEXT_PATTERNS):

--- a/src/hyperloom/orchestrator/actions/executors/baseline.py
+++ b/src/hyperloom/orchestrator/actions/executors/baseline.py
@@ -272,7 +272,7 @@ def _classify_subprocess_error(
         ``"fast_exit_arg_error"`` for a fast exit caused by argument
         validation, else ``"subprocess_nonzero"``.
     """
-    tail = stderr_tail.lower()
+    tail = (stderr_tail or "").lower()
     # KV-cache OOM can surface long after weight load, so it is matched before
     # the fast-exit elapsed gate below.
     if any(m in tail for m in _KV_CACHE_OOM_MARKERS):

--- a/src/hyperloom/orchestrator/actions/executors/report.py
+++ b/src/hyperloom/orchestrator/actions/executors/report.py
@@ -145,15 +145,13 @@ def _classify_root_cause_type(error_class: str, error_text: str) -> str:
     Returns:
         The coarse root-cause enum string for the dashboard / ops contract.
     """
+    from .baseline import _KV_CACHE_OOM_MARKERS
+
     blob = f"{error_class} {error_text}".lower()
+    if error_class == "kv_cache_oom" or any(m in blob for m in _KV_CACHE_OOM_MARKERS):
+        return "kv_cache_oom"
     if "out of memory" in blob or "hip oom" in blob:
         return "oom"
-    if (
-        error_class == "kv_cache_oom"
-        or "no gpu memory for the kv cache" in blob
-        or "mem-fraction-static" in blob
-    ):
-        return "kv_cache_oom"
     if error_class == "timeout" or "benchmark exceeded" in blob:
         return "benchmark_timeout"
     if (
@@ -343,21 +341,56 @@ def _build_failure_summary(
 
 
 _STOP_REASON_EXPLANATIONS: dict[str, str] = {
+    # Terminal reasons the coordinator loop sets directly (DESIGN 9.1).
     "target_reached": "Target reached: the requested --target-gain / --target-tput was met.",
     "time_exhausted": "Wall-clock budget (--max-hours) was exhausted; the best validated result was kept.",
-    "global_converged": "Cyclic phases converged: repeated macro-cycles stopped yielding new validated gain.",
+    "max_ticks": "The coordinator hit its max-ticks safety cap; the best validated result was kept.",
+    "signal": "Stopped on an OS stop signal (e.g. SIGINT / SIGTERM).",
+    "emergency": (
+        "Emergency stop: recoverable crashes spiked past the safety threshold inside the crash "
+        "window; the best validated result was preserved before exit."
+    ),
+    "coordinator_exception": "The coordinator loop raised an unhandled exception; the last validated result was preserved.",
+    "custom": "A caller-supplied stop condition (stop_when) fired.",
+    "unknown": "No specific stop reason was recorded (e.g. a terminal session was resumed); treat as unclassified.",
+    # Policy / robustness governor.
+    "policy_loop": "The policy gate detected a decision loop and stopped to avoid spinning on the same transition.",
+    "crash_threshold_exceeded": "Too many recoverable crashes accumulated; the run stopped to preserve the validated result.",
     "robustness_escalated": (
         "Robustness escalated: the run stopped early (not a target hit). Common triggers are an "
         "approaching deadline, a validated-gain plateau, rising crash_count, or a stale aiter JIT build. "
         "The best validated result was locked in before exit."
     ),
-    "crash_threshold_exceeded": "Too many recoverable crashes accumulated; the run stopped to preserve the validated result.",
+    "user_stop_requested": "Stopped on an explicit operator request.",
+    "baseline_failed": "Baseline never produced a valid measurement; see the failure summary / server log.",
+    # PRELUDE-phase early exits (before optimization begins).
+    "prelude_baseline_failed": "PRELUDE baseline failed before optimization could start; see the baseline failure summary.",
+    "prelude_policy_loop": "The policy gate detected a decision loop during PRELUDE and stopped.",
+    "time_exhausted_during_prelude": "The wall-clock budget was exhausted while still in PRELUDE, before optimization began.",
+    # Cortex knowledge-plane bootstrap failures.
+    "cortex_t0_failed": "Cortex knowledge-plane bootstrap (t0) failed; the run stopped early.",
+    "cortex_drain_failed": "Cortex knowledge-plane drain failed; the run stopped early.",
+    "cortex_commit_failed": "Cortex knowledge-plane commit failed; the run stopped early.",
+    # Search / phase plateaus and completions.
     "plateau_explore": "EXPLORE plateaued: no new leverage was found in the search space.",
     "plateau_kernel": "KERNEL_AGENT plateaued: no further validated kernel win was found.",
-    "sweep_done": "SWEEP finished the configured concurrency/shape grid.",
+    "no_kernel_skipped": "No kernel candidates were available, so the kernel phase was skipped and the run closed.",
+    "sweep_done": "SWEEP finished the configured concurrency / shape grid.",
     "conc_sweep_done": "Post-sweep concurrency sweep finished.",
-    "baseline_failed": "Baseline never produced a valid measurement; see the failure summary / server log.",
-    "user_stop_requested": "Stopped on an explicit operator request.",
+    "explore_force_exit_low_budget": "EXPLORE force-exited: the remaining wall-clock budget was too low to start new work.",
+    "framework_agent_phase_done": "The framework-enablement agent completed its phase.",
+    "framework_agent_plateau": "The framework-enablement agent plateaued with no further progress.",
+    "framework_agent_force_exit_low_budget": "The framework-enablement agent force-exited on a low remaining budget.",
+    "global_converged": "Cyclic phases converged: repeated macro-cycles stopped yielding new validated gain.",
+    # Pre-flight gates (fail fast before booting a server).
+    "model_context_window_too_small": "Preflight gate: the model's max context window cannot hold the requested ISL + OSL.",
+    "unsupported_model_arch": "Preflight gate: the model architecture (e.g. multimodal / vision) is unsupported.",
+    "model_config_incompatible": (
+        "Preflight gate: config.json is corrupt or declares RoPE scaling without a max-position field, "
+        "which would crash engine init."
+    ),
+    "baseline_arg_error": "Two or more baseline attempts fast-exited on a bad CLI arg (deterministic), so the slow-baseline retry budget was not burned.",
+    "enablement_stalled": "The enablement loop made no forward progress for several consecutive rounds and stopped instead of re-deriving the same fix.",
 }
 
 

--- a/src/hyperloom/orchestrator/actions/executors/report.py
+++ b/src/hyperloom/orchestrator/actions/executors/report.py
@@ -148,6 +148,12 @@ def _classify_root_cause_type(error_class: str, error_text: str) -> str:
     blob = f"{error_class} {error_text}".lower()
     if "out of memory" in blob or "hip oom" in blob:
         return "oom"
+    if (
+        error_class == "kv_cache_oom"
+        or "no gpu memory for the kv cache" in blob
+        or "mem-fraction-static" in blob
+    ):
+        return "kv_cache_oom"
     if error_class == "timeout" or "benchmark exceeded" in blob:
         return "benchmark_timeout"
     if (
@@ -336,6 +342,34 @@ def _build_failure_summary(
         return None
 
 
+_STOP_REASON_EXPLANATIONS: dict[str, str] = {
+    "target_reached": "Target reached: the requested --target-gain / --target-tput was met.",
+    "time_exhausted": "Wall-clock budget (--max-hours) was exhausted; the best validated result was kept.",
+    "global_converged": "Cyclic phases converged: repeated macro-cycles stopped yielding new validated gain.",
+    "robustness_escalated": (
+        "Robustness escalated: the run stopped early (not a target hit). Common triggers are an "
+        "approaching deadline, a validated-gain plateau, rising crash_count, or a stale aiter JIT build. "
+        "The best validated result was locked in before exit."
+    ),
+    "crash_threshold_exceeded": "Too many recoverable crashes accumulated; the run stopped to preserve the validated result.",
+    "plateau_explore": "EXPLORE plateaued: no new leverage was found in the search space.",
+    "plateau_kernel": "KERNEL_AGENT plateaued: no further validated kernel win was found.",
+    "sweep_done": "SWEEP finished the configured concurrency/shape grid.",
+    "conc_sweep_done": "Post-sweep concurrency sweep finished.",
+    "baseline_failed": "Baseline never produced a valid measurement; see the failure summary / server log.",
+    "user_stop_requested": "Stopped on an explicit operator request.",
+}
+
+
+def _explain_stop_reason(stop_reason):
+    """Return a human-readable explanation for a terminal ``stop_reason``.
+
+    Returns ``""`` for unknown/empty reasons so callers can omit the line.
+    """
+    return _STOP_REASON_EXPLANATIONS.get(str(stop_reason or "").strip(), "")
+
+
+
 def _build_summary_dict(
     state: SharedState,
     ev_counts: dict[str, int],
@@ -366,6 +400,7 @@ def _build_summary_dict(
         "model_class": state.model_class,
         "framework": getattr(state, "framework", "") or "",
         "stop_reason": state.stop_reason,
+        "stop_reason_explanation": _explain_stop_reason(state.stop_reason),
         "baseline_tput": state.baseline_tput,
         "baseline_accuracy": state.baseline_accuracy,
         # Remaining-gaps assessment verdict + history.
@@ -432,6 +467,9 @@ def _format_md(summary: dict[str, Any]) -> str:
     lines.append("")
     lines.append(f"- **Model**: {summary['model_name']}  (`{summary['model_path']}`)")
     lines.append(f"- **Stop reason**: `{summary['stop_reason']}`")
+    stop_expl = str(summary.get("stop_reason_explanation") or "").strip()
+    if stop_expl:
+        lines.append(f"- **Why it stopped**: {stop_expl}")
     stop_detail = str(summary.get("stop_detail") or "").strip()
     if stop_detail:
         lines.append(f"- **Stop detail**: {stop_detail}")

--- a/src/hyperloom/orchestrator/state/shared_state.py
+++ b/src/hyperloom/orchestrator/state/shared_state.py
@@ -1946,7 +1946,7 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
             # failures, so the breakdown exporter can surface the raw crash.
             "stderr_tail": (
                 self._stderr_tail(result.get("error"))
-                if str(result.get("error_class") or "") in {"subprocess_nonzero", "timeout"}
+                if str(result.get("error_class") or "") in {"subprocess_nonzero", "timeout", "kv_cache_oom"}
                 else None
             ),
             "stderr_log_path": (str(result.get("stderr_log_path")) if result.get("stderr_log_path") else None),
@@ -2004,7 +2004,7 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
             "error_class": error_class_str,
             "error_excerpt": self._truncate_excerpt(result.get("error")),
             "stderr_tail": (
-                self._stderr_tail(result.get("error")) if error_class_str in {"subprocess_nonzero", "timeout"} else None
+                self._stderr_tail(result.get("error")) if error_class_str in {"subprocess_nonzero", "timeout", "kv_cache_oom"} else None
             ),
             "stderr_log_path": (str(result.get("stderr_log_path")) if result.get("stderr_log_path") else None),
             "workspace": (str(result.get("workspace")) if result.get("workspace") else None),


### PR DESCRIPTION
## Summary

Net contribution vs `main` (three-dot PR diff): **15 files, +754 / -12**. Runtime-robustness fixes for the `inference_optimizer`, surfaced during a GLM-5.2 long-horizon run. No behavior change for a healthy run — these harden error classification / reporting / recovery and add two opt-in config knobs, each with regression tests.

> Base note: #801 (bypass analysis + src-layout) is already **squash-merged into `main`**, so this branch is cut fresh from `origin/main` and carries **only** these fixes (not #801's 46-commit history). All 15 touched files are byte-identical between #801 and `main`, so the fixes apply without conflict.

## 1. Framework guard (`EXPECTED_FRAMEWORK`)
Fail fast when a launcher-pinned framework is violated. A stale `switch_to_sglang`-style script that mutates `$FRAMEWORK` otherwise silently runs a different backend than requested (observed: a `FRAMEWORK=vllm` run executed as sglang).
- `cli/__init__.py`: `_enforce_expected_framework()` reads `EXPECTED_FRAMEWORK` / `INFERENCE_OPTIMIZER_EXPECTED_FRAMEWORK`; enforced on **both** the fresh-resolve and resume paths before `os.environ["FRAMEWORK"]` is set.
- Tests: `test_preflight_auth_override.py` (mismatch / match / namespaced var / precedence / unset-noop).

## 2. KV-cache OOM classified distinctly
"Loaded weights leave no GPU memory for the KV cache" is an over-aggressive `--mem-fraction-static`, not a generic crash — so the loop/report can advise "raise mem-fraction" instead of treating it as a hard failure.
- `baseline.py`: `_KV_CACHE_OOM_MARKERS`, matched **before** the fast-exit elapsed gate (KV OOM surfaces minutes in, after weight load).
- `report.py`: a `kv_cache_oom` root-cause bucket checked **before** generic `oom`; markers are **reused from `baseline` (single source of truth)**, so a bare `--mem-fraction-static` appearing in an argv dump is no longer mis-bucketed (Bugbot finding).
- `shared_state.py`: `kv_cache_oom` added to the `stderr_tail` capture set (both recorders).
- Tests: `test_baseline_warmup_double_run.py`, `test_baseline_failure_summary.py`, `test_shared_state_units.py`.

## 3. conc_sweep summary recovery
When `reports/conc_sweep_summary.json` is absent or stale, recover the real result from the `runs/conc_sweep/` workspaces (fixed: the final report showed `successful_pairs=0` while the process had actually succeeded).
- `breakdown/collectors/kernels.py`: import-light recovery (never pulls Magpie/torch in at report time); defensive `parents[2]` base so a shallow session path can't `IndexError`.
- Tests: `test_breakdown_conc_sweep_collectors.py` (recover-absent / recover-newer / keep-a-better-existing-report / empty).

## 4. stop_reason explained in the final report
A human-readable "Why it stopped" line, aligned to the closed `STOP_REASON_VOCAB` (all 34 members) so the mapping can't silently drift.
- `report.py`: `_STOP_REASON_EXPLANATIONS` + `_explain_stop_reason()`; a coverage test imports `STOP_REASON_VOCAB` and asserts every member has a non-empty explanation.
- Tests: `test_report_helpers_coverage_unit.py`.

## 5. SGLang TraceLens patch version fallback
`_resolve_sglang_patches_dir()` falls back to the nearest not-newer same-minor (then cross-minor) patch subdir when no exact `sglang_X_Y_Z` match exists (fixed: a 0.5.14 profile degraded because only older patch dirs shipped). `_apply_atomic`'s `git apply --check` still guards a genuinely incompatible pick.
- `_server_patcher.py`; Tests: `test_server_patcher_sglang_version_fallback.py` (exact / same-minor / cross-minor / only-newer / empty-subdir).

## 6. kernel-agent max_turns configurable
`INFERENCE_OPTIMIZER_KERNEL_AGENT_MAX_TURNS` (default 5, unchanged) lets an operator raise the Claude turn budget to avoid a "Reached maximum number of turns" failure on complex kernel tasks without editing the reactor.
- `cli/backends.py`; Tests: `test_cli_backends_unit.py` (default / override / invalid / <=0).

## Commits
- `5d6782f5` core runtime fixes (sections 1–6).
- `dc9190f7` review + Bugbot follow-ups (STOP_REASON_VOCAB alignment, resume-path guard, kv_cache_oom ordering + mem-fraction specificity, conc_sweep `parents[2]` hardening, added regression tests).

## Test plan
- [x] `pytest` targeted set (the 8 touched test files) — **207 passed**
- [x] Clean branch cut from `origin/main`; PR diff is exactly the 15 fix files (no #801 history)
- [x] No conflict markers; every touched file byte-compiles
- [ ] Full CI on push
- [ ] `ruff check .` / `ruff format --check .`
