### PR TITLE
fix(quantization): shim Quark Python 3.10 compatibility

### DIFF
--- a/docs/how-to/quantization-quark.md
+++ b/docs/how-to/quantization-quark.md
@@ -37,16 +37,18 @@ not bundle Quark or implement quantization itself; it invokes Quark's published
 skills (`quark-torch-ptq` -> `quark-torch-result-validator` ->
 `quark-torch-llm-eval`) end to end.
 
-Quark is published on PyPI (`pip install amd-quark`), but the current external
-release does not ship the `.claude/skills/quark-torch-*` skill entry points that
-Hyperloom drives. Until those skills are public, use an internal AMD Quark
-repository checkout.
+Quark is open-sourced at
+[`https://github.com/amd/Quark.git`](https://github.com/amd/Quark.git) and is
+also published on PyPI (`pip install amd-quark`). The
+`.claude/skills/quark-torch-*` skill entry points that Hyperloom drives ship on
+the `release/0.12` branch (and later), so clone that branch when you need the
+agent-driven prelude.
 
 When you run `inference_optimizer optimize`, the quantization prelude resolves
 the Quark root in this order:
 
 1. `QUARK_ROOT`
-2. The canonical default `/wekafs/hyperloom/Quark`
+2. The canonical default `/primus/hyperloom/Quark`
 
 `inference_optimizer optimize` has no `--quark-root` flag; that argument only
 exists on the standalone `quantization-agent` CLI. For the `optimize` path,
@@ -58,5 +60,5 @@ fast instead of silently optimizing the unquantized source model.
 
 ```text
 HYPERLOOM_QUANTIZE_ENABLED=1
-QUARK_ROOT=/workspace/Quark
+QUARK_ROOT=/primus/hyperloom/Quark
 ```

--- a/src/hyperloom/agents/quantization/driver/retry.py
+++ b/src/hyperloom/agents/quantization/driver/retry.py
@@ -51,15 +51,13 @@ from .runner import RunOneAttemptFn, run_one_attempt
 _COUNTER_FILE = "requantize_attempts.txt"
 
 # Canonical Quark checkout used when neither the ``quark_root`` kwarg nor the
-# ``$QUARK_ROOT`` env var is set. Until the Quark team ships a public package
-# that bundles ``.claude/skills/quark-torch-*`` (and a version-matched
-# ``amd-quark`` wheel), agents resolve the repo from this local checkout.
-DEFAULT_QUARK_ROOT = "/wekafs/hyperloom/Quark"
+# ``$QUARK_ROOT`` env var is set. Agents resolve the repo from this local
+# checkout when nothing more specific is provided.
+DEFAULT_QUARK_ROOT = "/primus/hyperloom/Quark"
 
-# Upstream git URL for the Quark repo. Left empty on purpose: fill this in once
-# the Quark repo is open-sourced so installers can clone it when the default
-# checkout is absent.
-DEFAULT_QUARK_GIT_URL = ""
+# Upstream git URL for the Quark repo. Installers clone it here when the
+# default checkout is absent.
+DEFAULT_QUARK_GIT_URL = "https://github.com/amd/Quark.git"
 
 
 @dataclass(frozen=True)

--- a/src/hyperloom/agents/quantization/driver/runner.py
+++ b/src/hyperloom/agents/quantization/driver/runner.py
@@ -18,6 +18,7 @@ user_prompt)`` into a templated prompt and hands it to the SDK.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Iterable
@@ -28,6 +29,16 @@ DEFAULT_ALLOWED_TOOLS = ["Read", "Write", "Edit", "Bash"]
 DEFAULT_MAX_TURNS = 240  # ~ Quark workflow has 4 STOPs + validator + eval; generous
 
 SKILL_RELATIVE_PATH = "SKILL.md"
+QUARK_PY310_COMPAT_DIR = ".hyperloom_quark_py310_compat"
+QUARK_PY310_SITE_CUSTOMIZE = """\
+import datetime as _datetime
+import typing as _typing
+
+from typing_extensions import Self as _Self
+
+_typing.Self = _Self
+_datetime.UTC = _datetime.timezone.utc
+"""
 
 
 @dataclass
@@ -105,6 +116,36 @@ def resolve_skill_path(package_root: Path | None = None) -> Path:
     # level up at the package root (a runtime contract, not a driver detail).
     root = package_root if package_root is not None else Path(__file__).resolve().parent.parent
     return root / SKILL_RELATIVE_PATH
+
+
+def _prepare_quark_py310_compat(workspace: Path) -> Path:
+    """Create a workspace-local Python 3.10 compatibility shim for Quark 0.12.
+
+    Quark release/0.12 uses a small number of Python 3.11 symbols
+    (``typing.Self`` and ``datetime.UTC``). Hyperloom deployments may still run
+    the optimizer from a Python 3.10 venv, so inject the missing symbols via
+    ``sitecustomize`` without modifying the Quark checkout.
+    """
+
+    compat_dir = workspace / QUARK_PY310_COMPAT_DIR
+    compat_dir.mkdir(parents=True, exist_ok=True)
+    (compat_dir / "sitecustomize.py").write_text(QUARK_PY310_SITE_CUSTOMIZE, encoding="utf-8")
+    return compat_dir
+
+
+def _prepend_pythonpath(path: Path, current: str | None) -> str:
+    prefix = str(path)
+    return prefix if not current else prefix + os.pathsep + current
+
+
+def _quark_py310_compat_env(workspace: Path, base_env: dict[str, str] | None = None) -> dict[str, str]:
+    """Return child-process env exposing Quark's Python 3.10 shim."""
+
+    env = dict(os.environ if base_env is None else base_env)
+    compat_dir = _prepare_quark_py310_compat(workspace)
+    env["PYTHONPATH"] = _prepend_pythonpath(compat_dir, env.get("PYTHONPATH"))
+    env["PIP_IGNORE_REQUIRES_PYTHON"] = "1"
+    return env
 
 
 def build_attempt_prompt(
@@ -269,6 +310,7 @@ async def run_one_attempt(
         "system_prompt": system_prompt,
         "allowed_tools": allowed_tools or DEFAULT_ALLOWED_TOOLS,
         "stderr": (lambda line: log(f"[claude-sdk] {line.rstrip()}")) if log else None,
+        "env": _quark_py310_compat_env(workspace),
     }
     if model:
         kwargs["model"] = model
@@ -276,11 +318,24 @@ async def run_one_attempt(
 
     try:
         options = sdk_options_cls(**kwargs)
-    except TypeError:
+    except TypeError as exc:
         # Older SDK builds may not support cwd; prompt + SKILL.md use absolute
         # paths so retrying without cwd is safe.
         kwargs.pop("cwd", None)
-        options = sdk_options_cls(**kwargs)
+        try:
+            options = sdk_options_cls(**kwargs)
+        except TypeError as env_exc:
+            # The Quark py310 shim must be passed to SDK-spawned tools without
+            # mutating process-global os.environ across async awaits. If this
+            # SDK predates the env option, fail clearly instead of silently
+            # running Quark 0.12 in an incompatible Python 3.10 environment.
+            if "env" in kwargs:
+                raise RuntimeError(
+                    "claude_agent_sdk.ClaudeAgentOptions does not support env; "
+                    "upgrade claude-agent-sdk so Hyperloom can pass the Quark "
+                    "Python 3.10 compatibility shim to SDK subprocesses"
+                ) from env_exc
+            raise env_exc from exc
 
     chunks: list[str] = []
     sdk_error = ""

--- a/src/hyperloom/agents/quantization/tests/test_retry_loop.py
+++ b/src/hyperloom/agents/quantization/tests/test_retry_loop.py
@@ -74,7 +74,7 @@ async def test_quark_root_missing_fast_path(tmp_path, monkeypatch):
     # With QUARK_ROOT unset the resolver falls back to DEFAULT_QUARK_ROOT;
     # point that at a nonexistent path so the bootstrap still fails with
     # quark_root_missing (hermetic — doesn't depend on the host's real
-    # /wekafs/hyperloom/Quark checkout).
+    # /primus/hyperloom/Quark checkout).
     monkeypatch.delenv("QUARK_ROOT", raising=False)
     monkeypatch.setattr(
         "hyperloom.agents.quantization.driver.retry.DEFAULT_QUARK_ROOT",

--- a/src/hyperloom/agents/quantization/tests/test_runner.py
+++ b/src/hyperloom/agents/quantization/tests/test_runner.py
@@ -5,6 +5,8 @@ Uses ``FakeSDK`` / ``FakeOptions`` from conftest to bypass the real SDK.
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from hyperloom.agents.quantization.driver.runner import (
@@ -163,6 +165,35 @@ async def test_run_one_attempt_sets_cwd_to_quark_root(tmp_path, fake_sdk, fake_o
     options = fake_sdk.received_options[0]
     assert options.kwargs.get("cwd") == str(qr)
     assert options.kwargs.get("allowed_tools") == DEFAULT_ALLOWED_TOOLS
+
+
+@pytest.mark.asyncio
+async def test_run_one_attempt_passes_quark_py310_env_to_sdk_options(tmp_path, fake_sdk, fake_options_cls, monkeypatch):
+    skill = tmp_path / "SKILL.md"
+    skill.write_text("x", encoding="utf-8")
+    qr = tmp_path / "qr"
+    qr.mkdir()
+    monkeypatch.setenv("PYTHONPATH", "/existing/pythonpath")
+    monkeypatch.delenv("PIP_IGNORE_REQUIRES_PYTHON", raising=False)
+
+    await run_one_attempt(
+        user_prompt="x",
+        workspace=tmp_path / "ws",
+        quark_root=qr,
+        skill_path=skill,
+        sdk_query_factory=fake_sdk,
+        sdk_options_cls=fake_options_cls,
+    )
+
+    compat_dir = tmp_path / "ws" / ".hyperloom_quark_py310_compat"
+    sitecustomize = compat_dir / "sitecustomize.py"
+    env = fake_sdk.received_options[0].kwargs["env"]
+    assert sitecustomize.is_file()
+    assert "typing.Self" in sitecustomize.read_text(encoding="utf-8")
+    assert env["PYTHONPATH"] == f"{compat_dir}{os.pathsep}/existing/pythonpath"
+    assert env["PIP_IGNORE_REQUIRES_PYTHON"] == "1"
+    assert os.environ["PYTHONPATH"] == "/existing/pythonpath"
+    assert "PIP_IGNORE_REQUIRES_PYTHON" not in os.environ
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Point the quantization-agent default Quark checkout at `/primus/hyperloom/Quark` and fill `DEFAULT_QUARK_GIT_URL` with the public upstream repo: `https://github.com/amd/Quark.git`.
- Update Quark quantization docs to reference the public `release/0.12` checkout and the new canonical `/primus/hyperloom/Quark` path.
- Add a workspace-local `sitecustomize.py` shim for Quark 0.12's Python 3.11-only symbols (`typing.Self`, `datetime.UTC`) so Hyperloom can drive Quark from Python 3.10 environments without modifying the Quark checkout.
- Pass the shim via Claude SDK child `env` instead of mutating process-global `os.environ` across async awaits.
- Set `PIP_IGNORE_REQUIRES_PYTHON=1` in the SDK child env so Quark dependency installation can proceed despite Quark 0.12 metadata declaring `requires-python >=3.11`.

## Test plan

- `python -m pytest src/hyperloom/agents/quantization/tests/test_runner.py src/hyperloom/agents/quantization/tests/test_retry_loop.py -q`
- `ReadLints` on modified files: no diagnostics