### PR TITLE
docs: add optimization-loop diagram to the conceptual page

### DIFF
--- a/docs/conceptual/optimization-loop.md
+++ b/docs/conceptual/optimization-loop.md
@@ -11,6 +11,8 @@ runtime contracts outward. It intentionally avoids retired action names
 and old DFS demo mechanics; the live action catalogue, phase allowlist,
 PolicyGate, and session artifacts are the source of truth.
 
+![Hyperloom optimization loop: the phase chain PRELUDE, FRAMEWORK_AGENT, EXPLORE, KERNEL_AGENT, SWEEP, and CLOSE, where SWEEP can cycle_reloop back to FRAMEWORK_AGENT when the time budget exceeds 24 hours. Cross-cutting roles — Orchestration, Critic, Robustness, and PolicyGate — govern every write, which flows emit_intent to Critic review to accuracy gate to PolicyGate to runtime state.](../images/optimization-loop.svg)
+
 ## Runtime contract
 
 The optimizer is launched through `inference_optimizer optimize`. A run

--- a/docs/images/optimization-loop.svg
+++ b/docs/images/optimization-loop.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 520" font-family="Segoe UI, Helvetica, Arial, sans-serif" role="img" aria-label="Hyperloom optimization loop: the phase chain PRELUDE, FRAMEWORK_AGENT, EXPLORE, KERNEL_AGENT, SWEEP, CLOSE, with SWEEP able to cycle back to FRAMEWORK_AGENT when the time budget exceeds 24 hours, and cross-cutting roles Orchestration, Critic, Robustness, and PolicyGate governing every write.">
+  <defs>
+    <marker id="arrowBlue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#58a6ff"/>
+    </marker>
+    <marker id="arrowOrange" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#f0883e"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="1200" height="520" rx="14" fill="#0d1117"/>
+
+  <!-- Title -->
+  <text x="24" y="40" fill="#e6edf3" font-size="23" font-weight="700">Hyperloom optimization loop</text>
+  <text x="25" y="64" fill="#8b949e" font-size="13">Phase chain enforced by PolicyGate and PHASE_ALLOWED_ACTIONS</text>
+
+  <!-- Reloop arrow: SWEEP back to FRAMEWORK_AGENT -->
+  <path d="M900,170 L900,104 L300,104 L300,170" fill="none" stroke="#f0883e" stroke-width="2" stroke-dasharray="6 5" marker-end="url(#arrowOrange)"/>
+  <text x="600" y="97" fill="#f0883e" font-size="12.5" text-anchor="middle" font-weight="600">cycle_reloop &#160;&#183;&#160; when --max-hours &gt; 24</text>
+
+  <!-- Phase boxes -->
+  <!-- b0 PRELUDE -->
+  <rect x="20" y="170" width="160" height="64" rx="9" fill="#161b22" stroke="#58a6ff" stroke-width="1.6"/>
+  <text x="100" y="200" fill="#e6edf3" font-size="14" font-weight="700" text-anchor="middle">PRELUDE</text>
+  <text x="100" y="221" fill="#8b949e" font-size="10.5" text-anchor="middle">baseline &#183; roofline</text>
+
+  <!-- b1 FRAMEWORK_AGENT -->
+  <rect x="220" y="170" width="160" height="64" rx="9" fill="#161b22" stroke="#58a6ff" stroke-width="1.6"/>
+  <text x="300" y="200" fill="#e6edf3" font-size="13" font-weight="700" text-anchor="middle">FRAMEWORK_AGENT</text>
+  <text x="300" y="221" fill="#8b949e" font-size="10.5" text-anchor="middle">discover &#183; review</text>
+
+  <!-- b2 EXPLORE -->
+  <rect x="420" y="170" width="160" height="64" rx="9" fill="#161b22" stroke="#58a6ff" stroke-width="1.6"/>
+  <text x="500" y="200" fill="#e6edf3" font-size="14" font-weight="700" text-anchor="middle">EXPLORE</text>
+  <text x="500" y="221" fill="#8b949e" font-size="10.5" text-anchor="middle">explore &#183; specialist</text>
+
+  <!-- b3 KERNEL_AGENT -->
+  <rect x="620" y="170" width="160" height="64" rx="9" fill="#161b22" stroke="#58a6ff" stroke-width="1.6"/>
+  <text x="700" y="200" fill="#e6edf3" font-size="14" font-weight="700" text-anchor="middle">KERNEL_AGENT</text>
+  <text x="700" y="221" fill="#8b949e" font-size="10.5" text-anchor="middle">kernel_opt &#183; gemm</text>
+
+  <!-- b4 SWEEP -->
+  <rect x="820" y="170" width="160" height="64" rx="9" fill="#161b22" stroke="#58a6ff" stroke-width="1.6"/>
+  <text x="900" y="200" fill="#e6edf3" font-size="14" font-weight="700" text-anchor="middle">SWEEP</text>
+  <text x="900" y="221" fill="#8b949e" font-size="10.5" text-anchor="middle">conc / ISL&#183;OSL</text>
+
+  <!-- b5 CLOSE -->
+  <rect x="1020" y="170" width="160" height="64" rx="9" fill="#161b22" stroke="#3fb950" stroke-width="1.6"/>
+  <text x="1100" y="200" fill="#e6edf3" font-size="14" font-weight="700" text-anchor="middle">CLOSE</text>
+  <text x="1100" y="221" fill="#8b949e" font-size="10.5" text-anchor="middle">report &#183; breakdown</text>
+
+  <!-- Forward arrows between phases -->
+  <line x1="180" y1="202" x2="219" y2="202" stroke="#58a6ff" stroke-width="2" marker-end="url(#arrowBlue)"/>
+  <line x1="380" y1="202" x2="419" y2="202" stroke="#58a6ff" stroke-width="2" marker-end="url(#arrowBlue)"/>
+  <line x1="580" y1="202" x2="619" y2="202" stroke="#58a6ff" stroke-width="2" marker-end="url(#arrowBlue)"/>
+  <line x1="780" y1="202" x2="819" y2="202" stroke="#58a6ff" stroke-width="2" marker-end="url(#arrowBlue)"/>
+  <line x1="980" y1="202" x2="1019" y2="202" stroke="#58a6ff" stroke-width="2" marker-end="url(#arrowBlue)"/>
+
+  <!-- Cross-cutting band -->
+  <rect x="20" y="300" width="1160" height="196" rx="11" fill="#0f141b" stroke="#30363d" stroke-width="1.2"/>
+  <text x="40" y="330" fill="#e6edf3" font-size="14" font-weight="700">Cross-cutting &#8212; active in every phase</text>
+
+  <!-- Role chips -->
+  <g>
+    <rect x="40" y="346" width="266" height="52" rx="8" fill="#161b22" stroke="#30363d"/>
+    <text x="173" y="371" fill="#e6edf3" font-size="13" font-weight="600" text-anchor="middle">Orchestration</text>
+    <text x="173" y="389" fill="#8b949e" font-size="10.5" text-anchor="middle">persistent multi-turn plan</text>
+
+    <rect x="338" y="346" width="266" height="52" rx="8" fill="#161b22" stroke="#30363d"/>
+    <text x="471" y="371" fill="#e6edf3" font-size="13" font-weight="600" text-anchor="middle">Critic</text>
+    <text x="471" y="389" fill="#8b949e" font-size="10.5" text-anchor="middle">reviews risky patches</text>
+
+    <rect x="636" y="346" width="266" height="52" rx="8" fill="#161b22" stroke="#30363d"/>
+    <text x="769" y="371" fill="#e6edf3" font-size="13" font-weight="600" text-anchor="middle">Robustness</text>
+    <text x="769" y="389" fill="#8b949e" font-size="10.5" text-anchor="middle">stalls &#183; crashes &#183; loops</text>
+
+    <rect x="934" y="346" width="246" height="52" rx="8" fill="#161b22" stroke="#30363d"/>
+    <text x="1057" y="371" fill="#e6edf3" font-size="13" font-weight="600" text-anchor="middle">PolicyGate</text>
+    <text x="1057" y="389" fill="#8b949e" font-size="10.5" text-anchor="middle">path &#183; phase &#183; leases</text>
+  </g>
+
+  <text x="40" y="432" fill="#c9d1d9" font-size="12">Every write flows: emit_intent &#8594; Critic review &#8594; accuracy gate &#8594; PolicyGate &#8594; runtime state</text>
+  <text x="40" y="458" fill="#c9d1d9" font-size="12">Memory: SharedState (current best &#183; stack &#183; history) &#183; RecipeKB (durable lessons across sessions)</text>
+  <text x="40" y="482" fill="#8b949e" font-size="11.5">Artifacts: manifest.json &#183; state.json &#183; storage/coordinator.db &#183; reports/ &#183; session_breakdown.json</text>
+</svg>


### PR DESCRIPTION
## Summary

- Adds a diagram to **`conceptual/optimization-loop.md`** showing how the optimizer works at a glance.
- The figure reflects the **current** loop: `PRELUDE → FRAMEWORK_AGENT → EXPLORE → KERNEL_AGENT → SWEEP → CLOSE`, including the `SWEEP` `cycle_reloop` back-edge (budget > 24h) and the cross-cutting roles/gates (Orchestration, Critic, Robustness, PolicyGate) that govern every write.

## Why a new SVG (not the old `optimization_loop.png`)

The pre-existing `docs/images/optimization_loop.png` depicts the **retired** DFS/`classify`/`backends` mechanics, which this page explicitly says it avoids. Rather than reuse a stale image, this adds an accurate vector diagram using the live phase/action vocabulary.

- **SVG, not raster:** labels stay crisp at any zoom and the figure is easy to edit later (plain text).
- **Markdown image syntax** (`![alt](../images/optimization-loop.svg)`), matching the convention already used in `install/quickstart.md`, so Sphinx/MyST copies it into the built site and rewrites the `src` (a raw `<img>` would not be copied and would 404 on the rendered site).

## Test plan

- [x] SVG validated as well-formed XML and visually verified (rendered via headless browser).
- [ ] `Docs` build check passes on this PR (local full-theme build not possible here: `rocm-docs-core` doesn't support the Python 3.14 on my machine; CI/RTD use 3.10/3.11).
- [ ] After merge, confirm the diagram renders on the published **How Hyperloom works → optimization loop** page.
