### PR TITLE
feat(hunyuan_image3): scriptable HunyuanImage-3.0 + fix session_status langfuse import + baked code_revision

### DIFF
--- a/src/hyperloom/inference_optimizer/assets/configs/baseline_hunyuan_image3.yaml
+++ b/src/hyperloom/inference_optimizer/assets/configs/baseline_hunyuan_image3.yaml
@@ -1,0 +1,78 @@
+# Magpie baseline benchmark config for HunyuanImage-3.0 (text-to-image).
+# Resolved by default_baseline_config() / _default_profile_config() when
+# $FRAMEWORK=hunyuan_image3.
+#
+# HunyuanImage-3.0 is a SCRIPTABLE (server-less) framework, like xDiT: there is
+# no OpenAI server, no benchmark_serving.py client, and no server_lifecycle
+# reuse. But unlike xDiT it is NOT an xfuser/diffusers pipeline -- it is an 80B
+# transformers AutoModelForCausalLM (trust_remote_code) driven via its own
+# `generate_image` method. The Magpie wrapper hunyuan_image3_{runner_type}.sh
+# invokes the standalone generation script once per variant, parses E2E latency,
+# runs the image-quality gate (LPIPS/SSIM/MSE vs a fixed BF16 reference), and
+# writes benchmark_report.json directly. Throughput is img/s.
+#
+# Two fields are FALLBACK ONLY and overridden at run time by the executor:
+#   - `benchmark.model`       <- --model / $MODEL_PATH
+#   - `benchmark.runner_type` <- --gpu-type / $GPU_TYPE / rocm-smi probe
+# At materialize time Hyperloom pins benchmark_script to
+# hunyuan_image3_{runner_type}.sh, so it is intentionally NOT set here.
+#
+# The quality-gate env (XDIT_QUALITY_REF / _WRITE / thresholds) is injected by
+# the shared scriptable choke point in _workload_envs (keyed on is_scriptable),
+# so the XDIT_ prefix is reused here for the gate to match what Hyperloom
+# injects. Generation knobs use the HYI3_ prefix.
+
+benchmark:
+  framework: hunyuan_image3
+  workload_kind: scriptable        # drives server-less branching in the loop
+  # benchmark_script: hunyuan_image3_mi355x.sh  # uncomment to force a script
+  model: /primus/models/tencent-HunyuanImage-3.0   # OVERRIDDEN at runtime
+  precision: bf16                  # LOCKED for a hunyuan_image3 session
+  run_mode: local
+
+  envs:
+    # Single-GPU offline path (validated on 1x MI355X, ~176GB peak / 288GB).
+    # TP>1 would require the vLLM serving fork (a different framework/image).
+    TP: 1
+    HYI3_IMAGE_SIZE: "1024x1024"
+    HYI3_DIFF_INFER_STEPS: 50      # model default; A/B smaller step counts in explore
+    HYI3_BOT_TASK: image           # direct image generation (no prompt rewrite)
+    HYI3_USE_SYSTEM_PROMPT: "None"
+    HYI3_ATTN_IMPL: sdpa           # flash_attention_2 needs flash-attn built for ROCm
+    HYI3_MOE_IMPL: eager           # flashinfer MoE not available on this ROCm stack
+    HYI3_SEED: 42
+    HYI3_NUM_ITERATIONS: 5         # timed images (steady-state)
+    HYI3_WARMUP_CALLS: 1
+    HYI3_PROMPT: "A brown and white dog running on the grass, photorealistic, warm sunlight"
+    # Image-quality gate -- same tolerance semantics as xDiT (numeric tolerance
+    # ~1e-2, ~0.15 abs allowed) rather than a tight per-pixel match. These reach
+    # the wrapper via env; the wrapper writes quality_gate.{passed,lpips,ssim,mse}
+    # and _accuracy_gate maps passed->1.0.
+    XDIT_QUALITY_REF: ""           # reference image path; injected at runtime
+    XDIT_QUALITY_LPIPS_MAX: 0.15
+    XDIT_QUALITY_SSIM_MIN: 0.85
+    XDIT_QUALITY_MSE_MAX: 0.006
+    # transformers==4.57.1 lives in a dedicated --target dir shadowing the
+    # image's system transformers; the wrapper prepends it to PYTHONPATH. Offline
+    # weights + remote code load from the pre-provisioned /primus snapshot.
+    HF_HUB_OFFLINE: "1"
+    TRANSFORMERS_OFFLINE: "1"
+    TOKENIZERS_PARALLELISM: "false"
+    PATH: "/venv/bin:/opt/rocm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    # ROCR_VISIBLE_DEVICES is injected at runtime by the executor as 0..TP-1.
+
+  gpu_selection:
+    auto: false                    # executor pins via ROCR_VISIBLE_DEVICES
+
+  server_lifecycle:
+    enabled: false                 # server-less: no reuse
+
+  timeout_seconds: 7200            # 120 min hard cap (158GB load + warmup + iters)
+
+  profiler:
+    torch_profiler:
+      enabled: false               # baseline needs throughput + quality only
+    system_profiler:
+      enabled: false
+    tracelens:
+      enabled: false

--- a/src/hyperloom/inference_optimizer/assets/configs/profile_hunyuan_image3.yaml
+++ b/src/hyperloom/inference_optimizer/assets/configs/profile_hunyuan_image3.yaml
@@ -1,0 +1,53 @@
+# Magpie profile benchmark config for HunyuanImage-3.0 (text-to-image).
+# Same contract as baseline_hunyuan_image3.yaml but with torch_profiler enabled
+# so the loop can attribute time across the autoregressive planning stage, the
+# diffusion denoise steps, and the 3D VAE decode. Resolved by
+# _default_profile_config() when $FRAMEWORK=hunyuan_image3.
+
+benchmark:
+  framework: hunyuan_image3
+  workload_kind: scriptable
+  # benchmark_script: hunyuan_image3_mi355x.sh
+  model: /primus/models/tencent-HunyuanImage-3.0   # OVERRIDDEN at runtime
+  precision: bf16
+  run_mode: local
+
+  envs:
+    TP: 1
+    HYI3_IMAGE_SIZE: "1024x1024"
+    HYI3_DIFF_INFER_STEPS: 50
+    HYI3_BOT_TASK: image
+    HYI3_USE_SYSTEM_PROMPT: "None"
+    HYI3_ATTN_IMPL: sdpa
+    HYI3_MOE_IMPL: eager
+    HYI3_SEED: 42
+    # Profiling: fewer timed images, one warmup, profiler window on the timed
+    # region only. No correctness gate during profiling (REF/WRITE forced empty
+    # by the scriptable choke point in _workload_envs when is_profile).
+    HYI3_NUM_ITERATIONS: 2
+    HYI3_WARMUP_CALLS: 1
+    HYI3_PROMPT: "A brown and white dog running on the grass, photorealistic, warm sunlight"
+    XDIT_QUALITY_REF: ""
+    XDIT_QUALITY_LPIPS_MAX: 0.15
+    XDIT_QUALITY_SSIM_MIN: 0.85
+    XDIT_QUALITY_MSE_MAX: 0.006
+    HF_HUB_OFFLINE: "1"
+    TRANSFORMERS_OFFLINE: "1"
+    TOKENIZERS_PARALLELISM: "false"
+    PATH: "/venv/bin:/opt/rocm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+  gpu_selection:
+    auto: false
+
+  server_lifecycle:
+    enabled: false
+
+  timeout_seconds: 7200
+
+  profiler:
+    torch_profiler:
+      enabled: true                # profile run: capture the timed region trace
+    system_profiler:
+      enabled: false
+    tracelens:
+      enabled: false

--- a/src/hyperloom/inference_optimizer/framework_registry.py
+++ b/src/hyperloom/inference_optimizer/framework_registry.py
@@ -105,7 +105,12 @@ FRAMEWORKS: dict[str, FrameworkSpec] = {
         name="hunyuan_image3",
         kind=SCRIPTABLE,
         extra_args_env="EXTRA_HUNYUAN_IMAGE3_ARGS",
-        repo_url="https://github.com/Tencent-Hunyuan/HunyuanImage-3.0.git",
+        # No framework-agent source repo: HunyuanImage-3.0 is a model we run
+        # as-is, not a framework whose source the perf-PR agent scouts/patches
+        # (unlike xdit). Kept out of framework_agent's _FRAMEWORK_TO_REPO_URL,
+        # so repo_url stays None to satisfy the registry<->repo_map consistency
+        # guard (test_registry_urls_match_repo_map skips None entries).
+        repo_url=None,
         supports_server_reuse=False,
         throughput_unit="img/s",
     ),

--- a/src/hyperloom/inference_optimizer/framework_registry.py
+++ b/src/hyperloom/inference_optimizer/framework_registry.py
@@ -93,6 +93,22 @@ FRAMEWORKS: dict[str, FrameworkSpec] = {
         supports_server_reuse=False,
         throughput_unit="img/s",
     ),
+    # HunyuanImage-3.0: an 80B unified autoregressive multimodal MoE text-to-
+    # image model. Unlike the xfuser/diffusers pipelines that back ``xdit``, it
+    # is a transformers ``AutoModelForCausalLM`` (trust_remote_code) driven via
+    # its own ``generate_image`` method, so it does NOT use the xfuser
+    # sequence-parallel runner registry. It is still a SCRIPTABLE image workload
+    # (server-less single command; throughput img/s; LPIPS/SSIM/MSE quality
+    # gate), so it reuses the scriptable env plumbing in _workload_envs
+    # (XDIT_QUALITY_* injection) and the img/s -> e2el_mean_ms metric mapping.
+    "hunyuan_image3": FrameworkSpec(
+        name="hunyuan_image3",
+        kind=SCRIPTABLE,
+        extra_args_env="EXTRA_HUNYUAN_IMAGE3_ARGS",
+        repo_url="https://github.com/Tencent-Hunyuan/HunyuanImage-3.0.git",
+        supports_server_reuse=False,
+        throughput_unit="img/s",
+    ),
 }
 
 DEFAULT_FRAMEWORK = "sglang"

--- a/src/hyperloom/inference_optimizer/session/manifest.py
+++ b/src/hyperloom/inference_optimizer/session/manifest.py
@@ -121,14 +121,28 @@ def _detect_stack_fingerprint() -> dict[str, str]:
 
 
 def _git_revision() -> str:
-    """Best-effort short git SHA of the repo containing this package.
+    """Best-effort source revision of the repo containing this package.
+
+    Prefers the live git SHA (dev checkouts). Deployed container images install
+    the package without a ``.git`` tree, so the git lookup returns ``""`` and
+    ``code_revision`` shows up empty in every trace/breakdown — which makes
+    "which build introduced this regression?" impossible to answer at a glance.
+    Fall back to a build-time-baked revision from the environment
+    (``HYPERLOOM_CODE_REVISION`` / ``HYPERLOOM_GIT_SHA``, set in the image
+    Dockerfile) so the field identifies the source commit even in deployment.
 
     Returns:
-        str: Short HEAD SHA, or an empty string when the package directory is
-        not a git checkout or the lookup fails.
+        str: Short HEAD SHA, else the baked env revision, else ``""``.
     """
     here = Path(__file__).resolve().parent
-    return _git_revision_at(here)
+    rev = _git_revision_at(here)
+    if rev:
+        return rev
+    for env_var in ("HYPERLOOM_CODE_REVISION", "HYPERLOOM_GIT_SHA"):
+        val = (os.environ.get(env_var) or "").strip()
+        if val:
+            return val
+    return ""
 
 
 def _git_capture(path: Path, args: list[str]) -> str:

--- a/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
+++ b/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
@@ -259,6 +259,8 @@ def default_baseline_config() -> Path:
         name = "baseline_vllm.yaml"
     elif fw == "xdit":
         name = "baseline_xdit.yaml"
+    elif fw == "hunyuan_image3":
+        name = "baseline_hunyuan_image3.yaml"
     else:
         name = "baseline_sglang.yaml"
     return asset_root() / "assets" / "configs" / name

--- a/src/hyperloom/orchestrator/actions/executors/profile.py
+++ b/src/hyperloom/orchestrator/actions/executors/profile.py
@@ -564,6 +564,8 @@ def _default_profile_config() -> Path:
         name = "profile_vllm.yaml"
     elif fw == "xdit":
         name = "profile_xdit.yaml"
+    elif fw == "hunyuan_image3":
+        name = "profile_hunyuan_image3.yaml"
     else:
         name = "profile_sglang.yaml"
     return asset_root() / "assets" / "configs" / name
@@ -697,7 +699,12 @@ class ProfileExecutor(BaselineExecutor):
         from hyperloom.inference_optimizer import framework_registry
 
         if framework_registry.is_scriptable(framework):
-            ensure_xdit_profiler_patched()
+            # The baked-profiler verifier is xDiT/xfuser-specific (it inspects
+            # xfuser's base_model.py). Other scriptable frameworks (e.g.
+            # hunyuan_image3, a transformers CausalLM with no xfuser tree) share
+            # the server-less early-return but must not trigger the xDiT check.
+            if str(framework or "").strip().lower() == "xdit":
+                ensure_xdit_profiler_patched()
             return None
         inferencex_path = ""
         if isinstance(bench, dict):

--- a/src/hyperloom/orchestrator/state/shared_state.py
+++ b/src/hyperloom/orchestrator/state/shared_state.py
@@ -1266,7 +1266,7 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
         # the emitter throttles (on-change or slow refresh) and swallows any
         # failure, so a Langfuse hiccup never blocks or slows the save path.
         try:
-            from .trace.langfuse_emitter import record_status as _lf_record_status
+            from ..trace.langfuse_emitter import record_status as _lf_record_status
 
             _lf_record_status(session_dir, self._langfuse_status_summary())
         except Exception:  # noqa: BLE001 — status mirror must never block save


### PR DESCRIPTION
## Summary
Three related changes bundled on one branch:

1. **fix: restore `session_status` Langfuse emission** (`f93d6e05`)
   - `SharedState.save()` imported the status mirror as `from .trace.langfuse_emitter import record_status`. After the src-layout move (#808) relocated `shared_state.py` into `orchestrator/state/`, `.trace` resolves to the non-existent `orchestrator.state.trace` instead of the real emitter at `orchestrator.trace`. The `ModuleNotFoundError` was swallowed by the surrounding `try/except`, so `session_status` silently stopped emitting while every other emitter (`phases/close.py`, `roles/critic_agent.py`, already on `..trace`) kept working.
   - Fix: bump `.trace` -> `..trace` to match sibling subpackages and the emitter's actual location.

2. **feat: register HunyuanImage-3.0 as a scriptable text-to-image framework** (`e74f8502`)
   - HunyuanImage-3.0 is an 80B autoregressive multimodal MoE model driven via transformers `AutoModelForCausalLM.generate_image` (trust_remote_code), not an xfuser/diffusers pipeline. Registered as a new `scriptable` framework so it reuses the server-less quality-gate path (img/s throughput, LPIPS/SSIM/MSE, `e2el_mean_ms`) with no changes to `model_gate` or the scriptable env injection.
   - `framework_registry`: add `hunyuan_image3` (kind=scriptable, img/s).
   - `default_baseline_config` / `_default_profile_config`: select the new `baseline_hunyuan_image3.yaml` / `profile_hunyuan_image3.yaml`.
   - `profile`: scope the xDiT/xfuser baked-profiler verifier to `framework==xdit` so other scriptable frameworks keep the server-less early-return without triggering the xfuser-specific check.
   - Single-GPU offline path validated on 1x MI355X (~176GB peak / 288GB).

3. **feat: baked `code_revision` fallback** (`3b8aed4e`)
   - Deployed images install the package without a `.git` tree, so `_git_revision()` returned `""` and `code_revision` was always empty in traces/breakdowns — making "which build introduced this regression?" unanswerable. Fall back to `HYPERLOOM_CODE_REVISION` / `HYPERLOOM_GIT_SHA` (baked at image build time) when the live git lookup is empty; dev checkouts are unaffected.

## Deploy-side follow-ups (outside this PR)
- The `session_status` fix takes effect only after rebuilding + redeploying the hyperloom image from this branch.
- For `code_revision` to be populated in deployment, bake the env in the image Dockerfile, e.g. `ARG GIT_SHA` / `ENV HYPERLOOM_CODE_REVISION=${GIT_SHA}` with `--build-arg GIT_SHA=$(git rev-parse --short HEAD)`.

## Test plan
- [ ] `session_status` observations reappear in Langfuse after deploying an image built from this branch.
- [ ] `optimize --framework hunyuan_image3 --model /primus/models/tencent-HunyuanImage-3.0 --gpu-type mi355x` runs end-to-end (needs the `pytorch-xdit:v26.6-hyi3-1` image + Magpie wrapper linked in).
- [ ] Trace/breakdown `code_revision` shows the baked build commit in a deployed run.

Made with [Cursor](https://cursor.com)