### PR TITLE
Support single-gateway LLM configuration fallback

### DIFF
--- a/src/hyperloom/common/llm_config.py
+++ b/src/hyperloom/common/llm_config.py
@@ -1,0 +1,158 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""LLM gateway environment resolution shared by OpenAI-compatible callers."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from urllib.parse import urlsplit, urlunsplit
+
+
+class LLMConfigError(RuntimeError):
+    """Raised when a requested LLM client cannot be configured from env."""
+
+
+@dataclass(frozen=True)
+class OpenAIClientConfig:
+    """Resolved configuration for OpenAI-compatible SDK clients."""
+
+    api_key: str
+    base_url: str | None
+    default_headers: dict[str, str]
+
+    def as_kwargs(self) -> dict[str, object]:
+        """Return kwargs accepted by ``openai.AsyncOpenAI``."""
+        kwargs: dict[str, object] = {"api_key": self.api_key}
+        if self.base_url:
+            kwargs["base_url"] = self.base_url
+        if self.default_headers:
+            kwargs["default_headers"] = dict(self.default_headers)
+        return kwargs
+
+
+def parse_custom_headers(raw: str | None) -> dict[str, str]:
+    """Parse custom LLM headers from env.
+
+    ``ANTHROPIC_CUSTOM_HEADERS`` is newline-delimited ``Name: value`` in the
+    Anthropic SDK. JSON object input is accepted as a convenience for launchers
+    that already store structured environment values.
+    """
+    if not raw:
+        return {}
+    text = raw.strip()
+    if not text:
+        return {}
+    if text.startswith("{"):
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, dict):
+            return {str(k).strip(): str(v).strip() for k, v in parsed.items() if str(k).strip()}
+
+    headers: dict[str, str] = {}
+    for line in raw.splitlines():
+        name, sep, value = line.partition(":")
+        if sep and name.strip():
+            headers[name.strip()] = value.strip()
+    return headers
+
+
+def derive_openai_base_url(anthropic_base_url: str | None) -> str | None:
+    """Derive an OpenAI-compatible base URL from an Anthropic endpoint.
+
+    Explicit ``OPENAI_BASE_URL`` always wins in callers. This fallback handles
+    AMD's split gateway convention, where Anthropic traffic uses
+    ``/anthropic`` and OpenAI-compatible chat completions use ``/Unified/v1``.
+    Unknown Anthropic URLs fall back to their original value to preserve the
+    previous single-gateway behavior.
+    """
+    if not anthropic_base_url:
+        return None
+    base = anthropic_base_url.strip().rstrip("/")
+    if not base:
+        return None
+    parts = urlsplit(base)
+    path = parts.path.rstrip("/")
+    if path.endswith("/anthropic") or path == "/anthropic":
+        prefix = path[: -len("/anthropic")] if path.endswith("/anthropic") else ""
+        return urlunsplit(parts._replace(path=f"{prefix}/Unified/v1"))
+    if path.endswith("/Unified"):
+        return urlunsplit(parts._replace(path=f"{path}/v1"))
+    return base
+
+
+def resolve_openai_client_config(
+    *,
+    api_key_env: str = "OPENAI_API_KEY",
+    base_url_env: str = "OPENAI_BASE_URL",
+    env: dict[str, str] | None = None,
+) -> OpenAIClientConfig:
+    """Resolve OpenAI-compatible client config from one or more LLM env sets."""
+    source = env if env is not None else os.environ
+    api_key = (
+        (source.get(api_key_env) or "").strip()
+        or (source.get("OPENAI_API_KEY") or "").strip()
+        or (source.get("ANTHROPIC_AUTH_TOKEN") or "").strip()
+        or (source.get("ANTHROPIC_API_KEY") or "").strip()
+        or (source.get("LLM_GATEWAY_KEY") or "").strip()
+        or (source.get("SAFE_API_KEY") or "").strip()
+    )
+    if not api_key:
+        key_names = " / ".join(
+            dict.fromkeys(
+                [
+                    api_key_env,
+                    "OPENAI_API_KEY",
+                    "ANTHROPIC_AUTH_TOKEN",
+                    "ANTHROPIC_API_KEY",
+                    "LLM_GATEWAY_KEY",
+                    "SAFE_API_KEY",
+                ]
+            )
+        )
+        raise LLMConfigError(f"{key_names} not set in env (OpenAI-compatible client cannot auth)")
+
+    base_url = (
+        (source.get(base_url_env) or "").strip()
+        or (source.get("OPENAI_BASE_URL") or "").strip()
+        or derive_openai_base_url(source.get("ANTHROPIC_BASE_URL"))
+    )
+    base_url = base_url or None
+
+    headers = parse_custom_headers(source.get("OPENAI_CUSTOM_HEADERS")) or parse_custom_headers(
+        source.get("ANTHROPIC_CUSTOM_HEADERS")
+    )
+    if base_url and _should_add_amd_subscription_header(base_url, headers):
+        headers = {**headers, "Ocp-Apim-Subscription-Key": api_key}
+    return OpenAIClientConfig(api_key=api_key, base_url=base_url, default_headers=headers)
+
+
+def openai_client_kwargs(
+    *,
+    api_key_env: str = "OPENAI_API_KEY",
+    base_url_env: str = "OPENAI_BASE_URL",
+    env: dict[str, str] | None = None,
+) -> dict[str, object]:
+    """Return kwargs accepted by ``openai.AsyncOpenAI``."""
+    return resolve_openai_client_config(api_key_env=api_key_env, base_url_env=base_url_env, env=env).as_kwargs()
+
+
+def _should_add_amd_subscription_header(base_url: str, headers: dict[str, str]) -> bool:
+    if any(name.lower() == "ocp-apim-subscription-key" for name in headers):
+        return False
+    parts = urlsplit(base_url)
+    host = parts.hostname or ""
+    return host == "llm-api.amd.com" or parts.path.rstrip("/").endswith("/Unified/v1")
+
+
+__all__ = [
+    "LLMConfigError",
+    "OpenAIClientConfig",
+    "derive_openai_base_url",
+    "openai_client_kwargs",
+    "parse_custom_headers",
+    "resolve_openai_client_config",
+]

--- a/src/hyperloom/inference_optimizer/cli/__init__.py
+++ b/src/hyperloom/inference_optimizer/cli/__init__.py
@@ -27,7 +27,9 @@ import sys
 import time
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
+from hyperloom.common.llm_config import parse_custom_headers
 from .executors import (  # noqa: F401 - re-exported for callers/tests
     _NOOP_KINDS_KERNEL_ONLY,
     _REAL_EXECUTORS_FULL,
@@ -782,9 +784,7 @@ def _probe_llm_catalog(
             pass
 
     probe_url = base_url.rstrip("/") + "/models"
-    headers: dict[str, str] = {}
-    if api_key:
-        headers["Authorization"] = f"Bearer {api_key}"
+    headers = _catalog_probe_headers(base_url=base_url, api_key=api_key)
 
     delays = (0.0, *_CATALOG_RETRY_DELAYS_SEC)
     last_err: str = ""
@@ -821,7 +821,13 @@ def _probe_llm_catalog(
             last_err = f"JSON decode: {exc}"
             print(f"Preflight: catalog probe attempt {i + 1}/{len(delays)} returned non-JSON: {last_err}")
             continue
-        ids = {m["id"] for m in data.get("data") or [] if isinstance(m, dict) and isinstance(m.get("id"), str)}
+        ids: set[str] = set()
+        for model in data.get("data") or []:
+            if not isinstance(model, dict) or not isinstance(model.get("id"), str):
+                continue
+            model_id = model["id"]
+            ids.add(model_id)
+            ids.add(_catalog_compare_model_id(model_id))
         if not ids:
             last_err = "empty data[]"
             continue
@@ -829,6 +835,53 @@ def _probe_llm_catalog(
 
     print(f"Preflight: catalog probe exhausted {len(delays)} attempts ({last_err}); cannot validate model availability")
     return None
+
+
+def _catalog_probe_headers(*, base_url: str, api_key: str) -> dict[str, str]:
+    """Build headers for direct ``/models`` probes.
+
+    The Anthropic SDK supports ``ANTHROPIC_CUSTOM_HEADERS`` for gateways that
+    require subscription headers; the preflight catalog probe is a direct httpx
+    request, so it must apply the same env-specified headers itself.
+    """
+    headers = parse_custom_headers(os.environ.get("OPENAI_CUSTOM_HEADERS")) or parse_custom_headers(
+        os.environ.get("ANTHROPIC_CUSTOM_HEADERS")
+    )
+    lower_names = {name.lower() for name in headers}
+    if api_key and "authorization" not in lower_names:
+        headers["Authorization"] = f"Bearer {api_key}"
+    if api_key and "ocp-apim-subscription-key" not in lower_names:
+        parts = urlsplit(base_url)
+        if parts.hostname == "llm-api.amd.com":
+            headers["Ocp-Apim-Subscription-Key"] = api_key
+    return headers
+
+
+def _catalog_compare_model_id(model_id: str) -> str:
+    """Normalize catalog IDs for preflight comparison only."""
+    text = str(model_id or "").strip()
+    lowered = text.lower()
+    if text.lower().startswith("claude-"):
+        return lowered.replace(".", "-")
+    return lowered
+
+
+def _codex_model_should_follow_claude() -> bool:
+    """True when the operator supplied only Anthropic config."""
+    return bool(
+        (os.environ.get("ANTHROPIC_BASE_URL") or "").strip()
+        and not (os.environ.get("OPENAI_BASE_URL") or "").strip()
+    )
+
+
+def _claude_model_should_follow_codex() -> bool:
+    """True when the operator supplied only OpenAI-compatible config."""
+    if os.environ.get("INFERENCE_OPTIMIZER_CLAUDE_FOLLOWS_CODEX") == "1":
+        return True
+    return bool(
+        (os.environ.get("OPENAI_BASE_URL") or "").strip()
+        and not (os.environ.get("ANTHROPIC_BASE_URL") or "").strip()
+    )
 
 
 def _validate_and_resolve_claude_model(
@@ -864,7 +917,7 @@ def _validate_and_resolve_claude_model(
     allow_custom = os.environ.get(
         "INFERENCE_OPTIMIZER_ALLOW_CUSTOM_ORCH_MODEL",
         "",
-    ).strip().lower() in ("1", "true", "yes", "on")
+    ).strip().lower() in ("1", "true", "yes", "on") or _claude_model_should_follow_codex()
     if not allow_custom and chosen not in _CLAUDE_ALLOWED_MODELS:
         print(
             f"ERROR: --claude-model={chosen!r} is not allowed. "
@@ -924,14 +977,20 @@ def _validate_and_resolve_claude_model(
         # to the OpenAI side ONLY for a single-gateway deploy where both sides
         # resolve to the same endpoint.
         candidates: list[tuple[str, str]] = []
-        if anthropic_url:
-            candidates.append((anthropic_url, anthropic_key))
-        if openai_url and openai_url == anthropic_url:
-            # single gateway: same URL serves both; OpenAI key is a valid retry
-            candidates.append((openai_url, openai_key))
-        elif openai_url and not anthropic_url:
-            # pure single-gateway with only OPENAI_BASE_URL configured
-            candidates.append((openai_url, openai_key))
+        if _claude_model_should_follow_codex():
+            if openai_url:
+                candidates.append((openai_url, openai_key))
+            elif anthropic_url:
+                candidates.append((anthropic_url, anthropic_key))
+        else:
+            if anthropic_url:
+                candidates.append((anthropic_url, anthropic_key))
+            if openai_url and openai_url == anthropic_url:
+                # single gateway: same URL serves both; OpenAI key is a valid retry
+                candidates.append((openai_url, openai_key))
+            elif openai_url and not anthropic_url:
+                # pure single-gateway with only OPENAI_BASE_URL configured
+                candidates.append((openai_url, openai_key))
         seen_urls: set[str] = set()
         for cand_url, cand_key in candidates:
             if not cand_url or cand_url in seen_urls:
@@ -970,7 +1029,7 @@ def _validate_and_resolve_claude_model(
         )
         sys.exit(2)
 
-    if chosen in catalog_ids:
+    if chosen in catalog_ids or _catalog_compare_model_id(chosen) in catalog_ids:
         print(f"Preflight: Claude model {chosen!r} confirmed in gateway catalog")
         return catalog_ids
 
@@ -1439,10 +1498,22 @@ async def _run_optimize(args: argparse.Namespace) -> int:
             f"errors={aiter_sweep['errors']}"
         )
 
+    claude_follows_codex = _claude_model_should_follow_codex()
+    if claude_follows_codex:
+        os.environ["INFERENCE_OPTIMIZER_CLAUDE_FOLLOWS_CODEX"] = "1"
+        args.claude_model = args.codex_model
+    else:
+        os.environ.pop("INFERENCE_OPTIMIZER_CLAUDE_FOLLOWS_CODEX", None)
+
     resolved_urls = _preflight(args)
 
     # Hard-gate Claude model before any session work (mutates args.claude_model on fallback; sys.exit(2) on failure).
+    if claude_follows_codex:
+        args.claude_model = args.codex_model
+    codex_follows_claude = _codex_model_should_follow_claude()
     _validate_and_resolve_claude_model(args, resolved_urls)
+    if codex_follows_claude:
+        args.codex_model = args.claude_model
     # Codex smoke probes the OpenAI side independently (split entrypoints).
     _smoke_test_codex_model(args, resolved_urls)
 

--- a/src/hyperloom/inference_optimizer/cli/parser.py
+++ b/src/hyperloom/inference_optimizer/cli/parser.py
@@ -87,6 +87,39 @@ def _positive_int_arg(value: str) -> int:
     return parsed
 
 
+def _default_claude_model_env() -> str:
+    """Resolve the default Claude model from env."""
+    explicit = (os.environ.get("CLAUDE_MODEL") or "").strip()
+    if explicit:
+        return explicit
+    if os.environ.get("INFERENCE_OPTIMIZER_CLAUDE_FOLLOWS_CODEX") == "1":
+        return (os.environ.get("CODEX_MODEL") or "").strip() or DEFAULT_CODEX_MODEL
+    openai_url = (os.environ.get("OPENAI_BASE_URL") or "").strip()
+    anthropic_url = (os.environ.get("ANTHROPIC_BASE_URL") or "").strip()
+    if openai_url and not anthropic_url:
+        return (os.environ.get("CODEX_MODEL") or "").strip() or DEFAULT_CODEX_MODEL
+    return DEFAULT_CLAUDE_MODEL
+
+
+def _default_codex_model_env() -> str:
+    """Resolve the default Codex-style model from env.
+
+    When the operator only configured the Anthropic side, Codex-style JSON
+    roles run through the unified gateway with the same Claude model as
+    orchestration. This also overrides generated default ``CODEX_MODEL`` values
+    from setup env files. Explicit ``CODEX_MODEL`` keeps the historical
+    OpenAI-compatible behavior when an OpenAI base URL is configured.
+    """
+    anthropic_url = (os.environ.get("ANTHROPIC_BASE_URL") or "").strip()
+    openai_url = (os.environ.get("OPENAI_BASE_URL") or "").strip()
+    if anthropic_url and not openai_url:
+        return (os.environ.get("CLAUDE_MODEL") or "").strip() or DEFAULT_CLAUDE_MODEL
+    explicit = (os.environ.get("CODEX_MODEL") or "").strip()
+    if explicit:
+        return explicit
+    return DEFAULT_CODEX_MODEL
+
+
 def _parse_conc_values(raw: str, *, source: str = "CONC") -> list[int]:
     """Parse a positive integer or comma ladder without mutating env."""
     text = str(raw or "").strip()
@@ -592,8 +625,8 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     opt.add_argument("--max-ticks", type=int, default=None, help="Hard tick cap (None = unlimited; mostly for tests)")
     opt.add_argument("--tick-interval-sec", type=float, default=0.0, help="Sleep between ticks (0 = no sleep)")
-    opt.add_argument("--claude-model", type=str, default=os.environ.get("CLAUDE_MODEL", DEFAULT_CLAUDE_MODEL))
-    opt.add_argument("--codex-model", type=str, default=os.environ.get("CODEX_MODEL", DEFAULT_CODEX_MODEL))
+    opt.add_argument("--claude-model", type=str, default=_default_claude_model_env())
+    opt.add_argument("--codex-model", type=str, default=_default_codex_model_env())
     opt.add_argument(
         "--allow-mm-text-fallback",
         action=argparse.BooleanOptionalAction,

--- a/src/hyperloom/inference_optimizer/tests/test_claude_backend_helpers_coverage_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_claude_backend_helpers_coverage_unit.py
@@ -104,6 +104,58 @@ def test_conversation_session_accessors() -> None:
     assert b2.conversation_session_id is None
 
 
+def test_build_options_pins_gateway_env_and_ignores_global_settings(monkeypatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://llm-api.amd.com/anthropic")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "dummy")
+    monkeypatch.setenv("ANTHROPIC_CUSTOM_HEADERS", "Ocp-Apim-Subscription-Key: sub-key")
+    b = _backend(model="claude-opus-4-6")
+
+    opts = b._build_options(tools=[], max_turns=4, system_prompt=None)
+
+    assert opts.kwargs["setting_sources"] == []
+    child_env = opts.kwargs["env"]
+    assert child_env["ANTHROPIC_BASE_URL"] == "https://llm-api.amd.com/anthropic"
+    assert child_env["ANTHROPIC_CUSTOM_HEADERS"] == "Ocp-Apim-Subscription-Key: sub-key"
+    assert child_env["ANTHROPIC_MODEL"] == "claude-opus-4-6"
+    assert child_env["ANTHROPIC_SMALL_FAST_MODEL"] == "claude-opus-4-6"
+
+
+def test_build_options_leaves_settings_sources_unset_without_gateway_env(monkeypatch) -> None:
+    for key in (
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_CUSTOM_HEADERS",
+        "SAFE_API_KEY",
+        "LLM_GATEWAY_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    b = _backend(model="claude-opus-4-6")
+
+    opts = b._build_options(tools=[], max_turns=4, system_prompt=None)
+
+    assert "env" not in opts.kwargs
+    assert "setting_sources" not in opts.kwargs
+
+
+def test_build_options_maps_openai_gateway_env_for_claude_code(monkeypatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("ANTHROPIC_CUSTOM_HEADERS", raising=False)
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://llm-api.amd.com/Unified/v1")
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
+    monkeypatch.setenv("OPENAI_CUSTOM_HEADERS", "Ocp-Apim-Subscription-Key: openai-key")
+    b = _backend(model="claude-opus-4-6")
+
+    opts = b._build_options(tools=[], max_turns=4, system_prompt=None)
+
+    child_env = opts.kwargs["env"]
+    assert opts.kwargs["setting_sources"] == []
+    assert child_env["ANTHROPIC_API_KEY"] == "openai-key"
+    assert child_env["ANTHROPIC_AUTH_TOKEN"] == "openai-key"
+    assert child_env["ANTHROPIC_CUSTOM_HEADERS"] == "Ocp-Apim-Subscription-Key: openai-key"
+
+
 # -- block helpers ---------------------------------------------------------
 def test_iter_blocks() -> None:
     assert ClaudeBackend._iter_blocks(_Msg(content=[1, 2])) == [1, 2]

--- a/src/hyperloom/inference_optimizer/tests/test_llm_config.py
+++ b/src/hyperloom/inference_optimizer/tests/test_llm_config.py
@@ -1,0 +1,70 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+from __future__ import annotations
+
+import pytest
+
+from hyperloom.common.llm_config import (
+    LLMConfigError,
+    derive_openai_base_url,
+    openai_client_kwargs,
+    parse_custom_headers,
+)
+
+
+def test_parse_custom_headers_accepts_anthropic_env_format():
+    headers = parse_custom_headers("Ocp-Apim-Subscription-Key: ak-test\nX-Team: hyperloom")
+    assert headers == {
+        "Ocp-Apim-Subscription-Key": "ak-test",
+        "X-Team": "hyperloom",
+    }
+
+
+def test_derive_openai_base_url_from_amd_anthropic_endpoint():
+    assert (
+        derive_openai_base_url("https://llm-api.amd.com/anthropic")
+        == "https://llm-api.amd.com/Unified/v1"
+    )
+
+
+def test_openai_kwargs_from_anthropic_only_gateway_env():
+    kwargs = openai_client_kwargs(
+        env={
+            "ANTHROPIC_API_KEY": "ak-anthropic",
+            "ANTHROPIC_BASE_URL": "https://llm-api.amd.com/anthropic",
+            "ANTHROPIC_CUSTOM_HEADERS": "Ocp-Apim-Subscription-Key: ak-header",
+        }
+    )
+    assert kwargs["api_key"] == "ak-anthropic"
+    assert kwargs["base_url"] == "https://llm-api.amd.com/Unified/v1"
+    assert kwargs["default_headers"] == {"Ocp-Apim-Subscription-Key": "ak-header"}
+
+
+def test_openai_kwargs_auto_adds_amd_subscription_header_when_missing():
+    kwargs = openai_client_kwargs(
+        env={
+            "ANTHROPIC_API_KEY": "ak-anthropic",
+            "ANTHROPIC_BASE_URL": "https://llm-api.amd.com/anthropic",
+        }
+    )
+    assert kwargs["default_headers"] == {"Ocp-Apim-Subscription-Key": "ak-anthropic"}
+
+
+def test_openai_kwargs_preserves_explicit_openai_config():
+    kwargs = openai_client_kwargs(
+        env={
+            "OPENAI_API_KEY": "sk-openai",
+            "OPENAI_BASE_URL": "https://api.openai.com/v1",
+            "ANTHROPIC_API_KEY": "ak-anthropic",
+            "ANTHROPIC_BASE_URL": "https://llm-api.amd.com/anthropic",
+        }
+    )
+    assert kwargs == {
+        "api_key": "sk-openai",
+        "base_url": "https://api.openai.com/v1",
+    }
+
+
+def test_openai_kwargs_requires_a_key():
+    with pytest.raises(LLMConfigError):
+        openai_client_kwargs(env={"ANTHROPIC_BASE_URL": "https://llm-api.amd.com/anthropic"})

--- a/src/hyperloom/inference_optimizer/tests/test_preflight_auth_override.py
+++ b/src/hyperloom/inference_optimizer/tests/test_preflight_auth_override.py
@@ -829,6 +829,46 @@ def test_probe_llm_catalog_retries_on_transient_error_then_succeeds(monkeypatch)
     assert sleeps[:2] == list(cli._CATALOG_RETRY_DELAYS_SEC[:2])
 
 
+def test_probe_llm_catalog_passes_anthropic_custom_headers(monkeypatch):
+    """Direct catalog probes must use the same gateway headers as Anthropic SDK calls."""
+    monkeypatch.setattr("time.sleep", lambda s: None)
+    monkeypatch.setenv("ANTHROPIC_CUSTOM_HEADERS", "Ocp-Apim-Subscription-Key: sub-key")
+    seen: dict[str, Any] = {}
+
+    def _get(url, **kwargs):
+        seen["url"] = url
+        seen["headers"] = kwargs.get("headers") or {}
+        return _FakeResp(200, {"data": [{"id": "claude-opus-4-6"}]})
+
+    fake_httpx = type("FakeHttpx", (), {"get": staticmethod(_get)})
+    monkeypatch.setitem(sys.modules, "httpx", fake_httpx)
+
+    ids = cli._probe_llm_catalog(
+        base_url="https://llm-api.amd.com/anthropic",
+        api_key="dummy",
+    )
+    assert ids == {"claude-opus-4-6"}
+    assert seen["url"] == "https://llm-api.amd.com/anthropic/models"
+    assert seen["headers"]["Ocp-Apim-Subscription-Key"] == "sub-key"
+    assert seen["headers"]["Authorization"] == "Bearer dummy"
+
+
+def test_probe_llm_catalog_normalizes_claude_catalog_ids(monkeypatch):
+    """AMD gateway may return title-case dot-version Claude IDs."""
+    monkeypatch.setattr("time.sleep", lambda s: None)
+
+    def _get(url, **kwargs):
+        return _FakeResp(200, {"data": [{"id": "Claude-Opus-4.6"}]})
+
+    fake_httpx = type("FakeHttpx", (), {"get": staticmethod(_get)})
+    monkeypatch.setitem(sys.modules, "httpx", fake_httpx)
+
+    ids = cli._probe_llm_catalog(base_url="https://llm-api.amd.com/anthropic", api_key="dummy")
+
+    assert "Claude-Opus-4.6" in ids
+    assert "claude-opus-4-6" in ids
+
+
 def test_probe_llm_catalog_returns_none_when_all_attempts_fail(monkeypatch, capsys):
     """All 4 attempts fail → returns None."""
     monkeypatch.setattr("time.sleep", lambda s: None)
@@ -964,6 +1004,83 @@ def test_smoke_test_codex_model_warns_on_probe_failure(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "WARNING" in out
     assert "unreachable" in out
+
+
+def test_parser_anthropic_only_empty_codex_model_uses_claude_model(monkeypatch):
+    """With only Anthropic configured, an empty CODEX_MODEL follows CLAUDE_MODEL."""
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://llm-api.amd.com/anthropic")
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.setenv("CLAUDE_MODEL", "claude-opus-4-6")
+    monkeypatch.setenv("CODEX_MODEL", "")
+
+    args = cli._build_parser().parse_args(["optimize", "--model", "/m", "--framework", "vllm"])
+
+    assert args.claude_model == "claude-opus-4-6"
+    assert args.codex_model == "claude-opus-4-6"
+    assert cli._codex_model_should_follow_claude() is True
+
+
+def test_parser_anthropic_only_generated_codex_default_uses_claude_model(monkeypatch):
+    """Generated setup env defaults must not force GPT on an Anthropic-only run."""
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://llm-api.amd.com/anthropic")
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.setenv("CLAUDE_MODEL", "claude-opus-4-6")
+    monkeypatch.setenv("CODEX_MODEL", "gpt-5.4")
+
+    args = cli._build_parser().parse_args(["optimize", "--model", "/m", "--framework", "vllm"])
+
+    assert args.claude_model == "claude-opus-4-6"
+    assert args.codex_model == "claude-opus-4-6"
+
+
+def test_parser_openai_only_empty_claude_model_uses_codex_model(monkeypatch):
+    """With only OpenAI configured, an empty CLAUDE_MODEL follows CODEX_MODEL."""
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://llm-api.amd.com/Unified/v1")
+    monkeypatch.setenv("CODEX_MODEL", "GPT-5.4")
+    monkeypatch.delenv("CLAUDE_MODEL", raising=False)
+
+    args = cli._build_parser().parse_args(["optimize", "--model", "/m", "--framework", "vllm"])
+
+    assert args.claude_model == "GPT-5.4"
+    assert args.codex_model == "GPT-5.4"
+    assert cli._claude_model_should_follow_codex() is True
+
+
+def test_parser_marker_forces_claude_model_to_follow_codex(monkeypatch):
+    """Launchers may pre-derive ANTHROPIC_BASE_URL while preserving OpenAI-only model semantics."""
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_CLAUDE_FOLLOWS_CODEX", "1")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://llm-api.amd.com/Unified/v1")
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://llm-api.amd.com/Unified")
+    monkeypatch.setenv("CODEX_MODEL", "GPT-5.5")
+    monkeypatch.delenv("CLAUDE_MODEL", raising=False)
+
+    args = cli._build_parser().parse_args(["optimize", "--model", "/m", "--framework", "vllm"])
+
+    assert args.claude_model == "GPT-5.5"
+    assert args.codex_model == "GPT-5.5"
+
+
+def test_validate_claude_model_openai_only_accepts_codex_model(monkeypatch):
+    """OpenAI-only runs validate the followed orchestration model against the OpenAI catalog."""
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://llm-api.amd.com/Unified/v1")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+    monkeypatch.setenv("CODEX_MODEL", "GPT-5.4")
+    monkeypatch.delenv("CLAUDE_MODEL", raising=False)
+    seen: dict[str, str] = {}
+
+    def _capture(**kw):
+        seen["base_url"] = kw.get("base_url", "")
+        seen["api_key"] = kw.get("api_key", "")
+        return {"GPT-5.4"}
+
+    monkeypatch.setattr(cli, "_probe_llm_catalog", _capture)
+    args = cli._build_parser().parse_args(["optimize", "--model", "/m", "--framework", "vllm"])
+    cli._validate_and_resolve_claude_model(args, ("https://llm-api.amd.com/Unified", "https://llm-api.amd.com/Unified/v1"))
+
+    assert seen == {"base_url": "https://llm-api.amd.com/Unified/v1", "api_key": "sk-openai"}
+    assert args.claude_model == "GPT-5.4"
 
 
 # Merged from test_v08_ir3_preflight.py

--- a/src/hyperloom/orchestrator/roles/claude.py
+++ b/src/hyperloom/orchestrator/roles/claude.py
@@ -108,6 +108,18 @@ _RAW_COMPLETION_DISALLOWED_TOOLS: tuple[str, ...] = (
     "SlashCommand",
 )
 
+_CLAUDE_GATEWAY_SIGNAL_KEYS: tuple[str, ...] = (
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_CUSTOM_HEADERS",
+    "OPENAI_BASE_URL",
+    "OPENAI_API_KEY",
+    "OPENAI_CUSTOM_HEADERS",
+    "SAFE_API_KEY",
+    "LLM_GATEWAY_KEY",
+)
+
 
 def _import_sdk() -> tuple[Any, Any, Any]:
     """Return ``(query, ClaudeAgentOptions, sdk_module)`` or raise.
@@ -555,12 +567,13 @@ class ClaudeBackend:
         if resume_session_id:
             # Resume an existing session by id (claude-agent-sdk >= 0.2).
             kwargs["resume"] = resume_session_id
+        self._apply_sdk_env_options(kwargs)
         if self.raw_completion:
             # Single text turn: no MCP tools, all built-ins disallowed.
             kwargs["allowed_tools"] = []
             kwargs["disallowed_tools"] = list(_RAW_COMPLETION_DISALLOWED_TOOLS)
             kwargs["stderr"] = self._stderr_sink
-            return self.sdk_options_cls(**kwargs)
+            return self._instantiate_options(kwargs)
         # Drop the bare "emit_intent" name (CLI rejects unregistered names);
         # the MCP-qualified form is what wires into the SDK tool registry.
         allowed = [t for t in tools if t != EMIT_INTENT_TOOL_NAME]
@@ -584,6 +597,40 @@ class ClaudeBackend:
         # Capture CLI stderr so failures are diagnosable.
         kwargs["stderr"] = self._stderr_sink
         return self._instantiate_options(kwargs)
+
+    def _apply_sdk_env_options(self, kwargs: dict[str, Any]) -> None:
+        """Pin Claude Code subprocess auth to the current Hyperloom env.
+
+        Claude Code also reads ``~/.claude`` settings/config by default. That is
+        fine for a local interactive login, but it can override a run's
+        gateway headers and API URL. When a Hyperloom process has explicit
+        Anthropic/gateway env, pass that env to the SDK subprocess and disable
+        settings sources so the run is hermetic.
+        """
+        if not any((os.environ.get(key) or "").strip() for key in _CLAUDE_GATEWAY_SIGNAL_KEYS):
+            return
+
+        child_env = dict(os.environ)
+        fallback_key = (
+            child_env.get("ANTHROPIC_AUTH_TOKEN")
+            or child_env.get("ANTHROPIC_API_KEY")
+            or child_env.get("OPENAI_API_KEY")
+            or child_env.get("SAFE_API_KEY")
+            or child_env.get("LLM_GATEWAY_KEY")
+            or ""
+        )
+        if fallback_key:
+            child_env.setdefault("ANTHROPIC_API_KEY", fallback_key)
+            child_env.setdefault("ANTHROPIC_AUTH_TOKEN", fallback_key)
+        if "ANTHROPIC_CUSTOM_HEADERS" not in child_env and child_env.get("OPENAI_CUSTOM_HEADERS"):
+            child_env["ANTHROPIC_CUSTOM_HEADERS"] = child_env["OPENAI_CUSTOM_HEADERS"]
+        if self.model:
+            child_env.setdefault("ANTHROPIC_MODEL", self.model)
+            child_env.setdefault("ANTHROPIC_SMALL_FAST_MODEL", self.model)
+        # Keep the subprocess environment compact enough for debugging while
+        # preserving PATH/HOME/PYTHONPATH and all non-secret run metadata.
+        kwargs["env"] = child_env
+        kwargs["setting_sources"] = []
 
     def _instantiate_options(self, kwargs: dict[str, Any]) -> Any:
         """Build options, dropping ``resume`` if the SDK can't accept it.

--- a/src/hyperloom/orchestrator/roles/codex.py
+++ b/src/hyperloom/orchestrator/roles/codex.py
@@ -15,11 +15,11 @@ real credentials or network.
 from __future__ import annotations
 
 import asyncio
-import os
 import re
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
+from hyperloom.common.llm_config import LLMConfigError, openai_client_kwargs
 from hyperloom.common.jsonio import extract_first_json_with_key
 from hyperloom.inference_optimizer.protocol.intent import (
     IntentValidationError,
@@ -117,21 +117,10 @@ class CodexBackend:
         except ImportError as exc:  # pragma: no cover
             raise BackendError("openai SDK not installed; run `pip install openai>=1.50`") from exc
 
-        api_key = (
-            os.environ.get(self.api_key_env)
-            or os.environ.get("OPENAI_API_KEY")
-            or os.environ.get("ANTHROPIC_AUTH_TOKEN")
-        )
-        if not api_key:
-            raise BackendError(f"{self.api_key_env} not set in env (CodexBackend cannot auth)")
-        base_url = (
-            os.environ.get(self.base_url_env)
-            or os.environ.get("OPENAI_BASE_URL")
-            or os.environ.get("ANTHROPIC_BASE_URL")
-        )
-        kwargs: dict[str, Any] = {"api_key": api_key}
-        if base_url:
-            kwargs["base_url"] = base_url
+        try:
+            kwargs = openai_client_kwargs(api_key_env=self.api_key_env, base_url_env=self.base_url_env)
+        except LLMConfigError as exc:
+            raise BackendError(str(exc).replace("OpenAI-compatible client", "CodexBackend")) from exc
         self._client = AsyncOpenAI(**kwargs)
 
     # ------------------------------------------------------------------

--- a/src/hyperloom/orchestrator/roles/critic_agent.py
+++ b/src/hyperloom/orchestrator/roles/critic_agent.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Literal
 
+from hyperloom.common.llm_config import LLMConfigError, openai_client_kwargs
 from hyperloom.common.jsonio import extract_first_json_with_key
 from hyperloom.inference_optimizer.protocol.intent import (
     IntentValidationError,
@@ -413,19 +414,15 @@ class CriticAgentBackend:
                 from openai import AsyncOpenAI  # type: ignore[import-not-found]
             except ImportError as exc:  # pragma: no cover
                 raise BackendError("openai SDK not installed; run `pip install openai>=1.50`") from exc
-            # Codex review reasoning speaks the OpenAI protocol, so prefer the
-            # OpenAI-side key (split entrypoints); ANTHROPIC_AUTH_TOKEN is the
-            # single-gateway fallback.
-            api_key = os.environ.get("OPENAI_API_KEY") or os.environ.get("ANTHROPIC_AUTH_TOKEN")
-            if not api_key:
+            try:
+                kwargs = openai_client_kwargs()
+            except LLMConfigError as exc:
                 raise BackendError(
-                    "OPENAI_API_KEY / ANTHROPIC_AUTH_TOKEN not set "
-                    "(CriticAgentBackend cannot reach Codex for review reasoning)"
-                )
-            base_url = os.environ.get("OPENAI_BASE_URL") or os.environ.get("ANTHROPIC_BASE_URL")
-            kwargs: dict[str, Any] = {"api_key": api_key}
-            if base_url:
-                kwargs["base_url"] = base_url
+                    str(exc).replace(
+                        "OpenAI-compatible client",
+                        "CriticAgentBackend cannot reach Codex for review reasoning",
+                    )
+                ) from exc
             try:
                 import httpx
             except ImportError:

--- a/src/hyperloom/orchestrator/scoring/proposal_scorer.py
+++ b/src/hyperloom/orchestrator/scoring/proposal_scorer.py
@@ -19,13 +19,13 @@ import asyncio
 import json
 import logging
 import math
-import os
 import re
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
 
+from hyperloom.common.llm_config import LLMConfigError, openai_client_kwargs
 from hyperloom.common.jsonio import extract_first_json_with_key
 from ..roles.base import parse_call_timeout_env
 from ..loop.coordinator_helpers import format_exc_brief
@@ -204,21 +204,10 @@ class ProposalScorer:
             from openai import AsyncOpenAI  # type: ignore[import-not-found]
         except ImportError as exc:  # pragma: no cover
             raise RuntimeError("openai SDK not installed; run `pip install openai>=1.50`") from exc
-        api_key = (
-            os.environ.get(self.api_key_env)
-            or os.environ.get("OPENAI_API_KEY")
-            or os.environ.get("ANTHROPIC_AUTH_TOKEN")
-        )
-        if not api_key:
-            raise RuntimeError(f"{self.api_key_env} not set in env (ProposalScorer cannot auth)")
-        base_url = (
-            os.environ.get(self.base_url_env)
-            or os.environ.get("OPENAI_BASE_URL")
-            or os.environ.get("ANTHROPIC_BASE_URL")
-        )
-        kwargs: dict[str, Any] = {"api_key": api_key}
-        if base_url:
-            kwargs["base_url"] = base_url
+        try:
+            kwargs = openai_client_kwargs(api_key_env=self.api_key_env, base_url_env=self.base_url_env)
+        except LLMConfigError as exc:
+            raise RuntimeError(str(exc).replace("OpenAI-compatible client", "ProposalScorer")) from exc
         self._client = AsyncOpenAI(**kwargs)
         return self._client
 


### PR DESCRIPTION
## Summary
- Add shared LLM config resolution for OpenAI-compatible clients, including Anthropic/OpenAI key fallbacks, custom header parsing, and AMD Unified URL derivation.
- Make Claude Code SDK runs hermetic by passing explicit gateway env and ignoring stale global settings when gateway env is present.
- Support Anthropic-only and OpenAI/Unified-only runs with matching model fallback semantics and catalog probe headers.

## Test plan
- `python3 -m pytest src/hyperloom/inference_optimizer/tests/test_preflight_auth_override.py src/hyperloom/inference_optimizer/tests/test_claude_backend_helpers_coverage_unit.py src/hyperloom/inference_optimizer/tests/test_claude_backend.py src/hyperloom/inference_optimizer/tests/test_llm_config.py src/hyperloom/inference_optimizer/tests/test_codex_backend.py src/hyperloom/inference_optimizer/tests/test_proposal_scorer_coverage_unit.py src/hyperloom/inference_optimizer/tests/test_critic_agent_backend.py`
- Anthropic-only 12h E2E: orchestration and critic both used `claude-opus-4-6`; baseline and warm replay completed with +15.688% validated gain.
- OpenAI/Unified 3h E2E: orchestration and critic both used `GPT-5.5`; baseline, warm replay, and explore completed with +30.642% validated gain.


Made with [Cursor](https://cursor.com)