### PR TITLE
Pin Magpie install to release commit

### DIFF
--- a/docs/components/magpie.md
+++ b/docs/components/magpie.md
@@ -60,8 +60,8 @@ pip install -e .
 ```{note}
 Hyperloom installs Magpie for you during `install.sh`.
 `src/hyperloom/inference_optimizer/assets/install.sh` clones it (pinned to
-`MAGPIE_REF`, default under `$MAGPIE_PATH`) and editable-installs it, while also
-applying the Hyperloom atomic benchmark-script patch when needed.
+`MAGPIE_REF`, a commit SHA or tag, under `$MAGPIE_PATH`) and editable-installs
+it, while also applying the Hyperloom atomic benchmark-script patch when needed.
 `src/hyperloom/inference_optimizer/cli/preflight.py` can also clone + `pip install -e` Magpie on
 preflight if it is not importable; that fallback clone uses the repository
 default branch rather than the install-time `MAGPIE_REF` pin. Magpie subprocesses

--- a/src/hyperloom/inference_optimizer/assets/install.sh
+++ b/src/hyperloom/inference_optimizer/assets/install.sh
@@ -11,11 +11,10 @@
 #   1. inference_optimizer + extras (pulls in claude_agent_sdk via
 #      pyproject `[test]` extra)
 #   2. Magpie (benchmark engine) into the pod-local open-source repo tree,
-#      pinned to MAGPIE_REF
-#      (a commit SHA, mirrors the GEAK_V3_REF pin in kernel-agent)
+#      pinned to MAGPIE_REF (a commit SHA or tag)
 #   2b. Atomic-write patch for Magpie._prepare_benchmark_scripts
-#       (bugs.md §C #1 root-cause fix; fail-soft — a no-op when MAGPIE_REF
-#       is pinned to an upstream-atomic commit)
+#       (bugs.md §C #1 root-cause fix; fail-soft — a no-op when the
+#       MAGPIE_REF target already has upstream atomic copying)
 #   3. InferenceX checkout: clone from upstream pinned to INFERENCEX_REF
 #      (a commit SHA), sets INFERENCEX_PATH for runtime
 #   4. Delegates to src/hyperloom/agents/kernel/scripts/install.sh for ray, ray-head
@@ -134,25 +133,9 @@ fi
 # package (still overridable) and the old chain_framework_agent() delegation
 # below is a no-op.
 MAGPIE_REPO="${MAGPIE_REPO:-https://github.com/AMD-AGI/Magpie.git}"
-# Pin Magpie to a *commit SHA* (not a branch name) so a fresh install is
-# deterministic and an upstream force-push / rebase cannot silently change
-# what every fresh clone gets. This default-branch HEAD drift is the root
-# cause of bugs.md §C #1 version skew: Magpie merged the atomic-copy refactor
-# (`_copy_benchmark_script_atomic` in Magpie/modes/benchmark/benchmarker.py)
-# between 06-06 and 06-07. Pre-refactor clones still had the legacy
-# `shutil.copy2` + `chmod` block the in-place patcher targets; post-refactor
-# clones do not ("legacy block not found"). We deliberately pin to a
-# post-refactor SHA: the upstream code is already atomic, so the in-place
-# patch (ensure_magpie_atomic_scripts_patch) becomes a no-op and is
-# fail-soft below. Operators can re-pin with MAGPIE_REF=<tag|branch|sha>
-# (mirrors GEAK_V3_REF in src/hyperloom/agents/kernel/scripts/install.sh).
-# Pinned to AMD-AGI/Magpie main HEAD, which includes the xDiT scriptable
-# diffusion benchmark framework (#51); the previous pin
-# (b1d4dcdee7eaf7bcab4fac13ab751f61bffdc3f7, #34 Atom) predates #51 and
-# rejects framework=xdit ("Unsupported framework: xdit"), breaking every
-# xDiT baseline. Still post the atomic-copy refactor, so the in-place patch
-# stays a no-op.
-MAGPIE_REF="${MAGPIE_REF:-e1be639428070e8d1e1ca21ca5414a84bc291d94}"
+# Pin Magpie to a release commit instead of the default branch. Operators can
+# re-pin with MAGPIE_REF=<tag|sha>.
+MAGPIE_REF="${MAGPIE_REF:-3941f0d6427b8a8d877de18a2c460dea51ec383b}"
 # MAGPIE_PATH points install.sh AND the Python optimizer (cli.py /
 # _grid_runner.py / manifest.py) at the same Magpie checkout. A single var keeps
 # the installer and runtime in lockstep; setting it never silently falls back to

--- a/src/hyperloom/inference_optimizer/assets/install.sh
+++ b/src/hyperloom/inference_optimizer/assets/install.sh
@@ -135,7 +135,7 @@ fi
 MAGPIE_REPO="${MAGPIE_REPO:-https://github.com/AMD-AGI/Magpie.git}"
 # Pin Magpie to a release commit instead of the default branch. Operators can
 # re-pin with MAGPIE_REF=<tag|sha>.
-MAGPIE_REF="${MAGPIE_REF:-3941f0d6427b8a8d877de18a2c460dea51ec383b}"
+MAGPIE_REF="${MAGPIE_REF:-0171222c532db6fc5cb174667db66e34f1d9dd98}"
 # MAGPIE_PATH points install.sh AND the Python optimizer (cli.py /
 # _grid_runner.py / manifest.py) at the same Magpie checkout. A single var keeps
 # the installer and runtime in lockstep; setting it never silently falls back to

--- a/src/hyperloom/inference_optimizer/tests/test_local_setup_script.py
+++ b/src/hyperloom/inference_optimizer/tests/test_local_setup_script.py
@@ -754,21 +754,19 @@ def test_flock_serializes_concurrent_critical_sections(tmp_path: Path) -> None:
     ), f"flock did not serialize critical sections: {lines}"
 
 
-# pin-dependency-shas: install.sh must clone Magpie / InferenceX pinned to a
-# commit SHA via the SHA-aware fetch-checkout dance, and the Magpie in-place
-# patch must fail-loud on a genuine failure (strict default) while staying
-# soft on a benign no-op. Grep/static-level guards on the script text.
+# pin-dependency-refs: install.sh must clone Magpie / InferenceX pinned to a
+# deterministic ref, and Magpie must support commit SHA and tag refs.
 
 
-def test_io_install_pins_magpie_and_inferencex_to_commit_sha() -> None:
-    # Both deps pinned to a full 40-char SHA, operator-overridable; immune to HEAD drift.
+def test_io_install_pins_magpie_release_commit_and_inferencex_commit_sha() -> None:
+    # Magpie and InferenceX both default to full 40-char SHAs and avoid HEAD drift.
     text = IO_INSTALL.read_text(encoding="utf-8")
     assert '_open_source_root="${HYPERLOOM_OPEN_SOURCE_ROOT:-/opt/hyperloom/open-source-repos}"' in text
     assert 'MAGPIE_PATH="${MAGPIE_PATH:-${_open_source_root}/Magpie}"' in text
     assert 'INFERENCEX_DEFAULT_DIR="${INFERENCEX_DEFAULT_DIR:-${_open_source_root}/InferenceX}"' in text
     assert "export HYPERLOOM_OPEN_SOURCE_ROOT" not in text
     assert re.search(r'^MAGPIE_REF="\$\{MAGPIE_REF:-[0-9a-fA-F]{40}\}"', text, re.M), (
-        "MAGPIE_REF must default to a full 40-char commit SHA and be overridable"
+        "MAGPIE_REF must default to the public Magpie release commit SHA and be overridable"
     )
     assert re.search(r'^INFERENCEX_REF="\$\{INFERENCEX_REF:-[0-9a-fA-F]{40}\}"', text, re.M), (
         "INFERENCEX_REF must default to a full 40-char commit SHA and be overridable"
@@ -776,11 +774,12 @@ def test_io_install_pins_magpie_and_inferencex_to_commit_sha() -> None:
 
 
 def test_io_install_uses_sha_aware_fetch_checkout_for_both_deps() -> None:
-    # The SHA-aware fetch-checkout dance must be wired into both ensure_magpie and ensure_inferencex.
+    # SHA refs use fetch-checkout; tag refs use git clone --branch.
     text = IO_INSTALL.read_text(encoding="utf-8")
     assert "^[0-9a-fA-F]{7,40}$" in text, "missing raw-SHA detection regex"
     assert 'fetch --depth 1 origin "$ref"' in text, "missing shallow SHA fetch"
     assert "checkout -q FETCH_HEAD" in text, "missing detached SHA checkout"
+    assert 'git clone --depth 1 --branch "$ref"' in text, "missing tag ref clone path"
     assert 'git_fetch_pinned "$MAGPIE_REPO" "$MAGPIE_PATH" "$MAGPIE_REF" "Magpie"' in text, (
         "ensure_magpie must clone via the pinned fetch-checkout helper"
     )


### PR DESCRIPTION
## Summary

- Update Hyperloom's default `MAGPIE_REF` to the Magpie release commit
- Keep `MAGPIE_REF` overridable with either a commit SHA or tag
- Update Magpie install docs and static install-script checks

## Testing

- `bash -n src/hyperloom/inference_optimizer/assets/install.sh`
- `git diff --check`
- `PYTHONPYCACHEPREFIX=/private/tmp/hyperloom-pycache python -m py_compile src/hyperloom/inference_optimizer/tests/test_local_setup_script.py`

Note: full pytest was not run locally because `pytest` is not installed in this environment.