### PR TITLE
docs: add examples/README with quick-start for the local demo

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,20 @@
+# Hyperloom Examples
+
+## Available examples
+
+- [`hyperloom-local-demo.md`](hyperloom-local-demo.md) — end-to-end SGLang
+  inference-optimization walkthrough for Local Mode on a single AMD GPU host.
+
+## Quick start
+
+Clone the repo and hand the tutorial to a coding agent:
+
+```bash
+git clone git@github.com:AMD-AGI/Hyperloom.git
+cd Hyperloom
+```
+
+Then start a coding agent from the repo root — e.g. run `claude` here, or open
+this folder in Cursor — and give it this prompt:
+
+> Follow the tutorial `examples/hyperloom-local-demo.md` and run the hyperloom demo.


### PR DESCRIPTION
## Summary

Add an index `README.md` to the `examples/` directory to help new users get started quickly.

- Lists the available example tutorials, starting with the local SGLang inference-optimization demo (`hyperloom-local-demo.md`).
- Provides a copy-paste quick start that clones the repository and hands the tutorial to a coding agent (e.g. `claude` or Cursor).

## Changes

| File | Change |
| --- | --- |
| `examples/README.md` | New: examples index with quick-start instructions |

## Notes

- Documentation-only change; no application code is affected.
