### PR TITLE
Changed priority orders of hardcoded specs and benchmarking script

### DIFF
--- a/src/hyperloom/agents/kernel/tests/test_tracelens_arch_benchmark.py
+++ b/src/hyperloom/agents/kernel/tests/test_tracelens_arch_benchmark.py
@@ -173,9 +173,6 @@ def test_populate_gpu_arch_json_runs_microbench_when_missing(
 
     with (
         patch.object(tab, "resolve_arch_json_path", return_value=None),
-        # Force the microbench branch: hyperloom's achievable spec now
-        # short-circuits populate_gpu_arch_json (A3), so isolate the fallback.
-        patch.object(tab, "write_hyperloom_arch_spec", return_value=None),
         patch.object(
             tab,
             "select_idle_gpu",
@@ -263,11 +260,10 @@ def test_populate_internal_extension_returns_bundled_spec_without_benchmark(
 def test_populate_external_raises_on_microbench_failure(
     tmp_path: Path,
 ) -> None:
-    """Open-source path surfaces a non-zero microbenchmark exit code."""
+    """Open-source path surfaces a non-zero microbenchmark exit code when the
+    hyperloom fallback is also unavailable."""
     with (
         patch.object(tab, "resolve_arch_json_path", return_value=None),
-        # A3 short-circuits on hyperloom's achievable spec; force the microbench
-        # branch so the non-zero exit code propagates as intended.
         patch.object(tab, "write_hyperloom_arch_spec", return_value=None),
         patch.object(tab, "select_idle_gpu", return_value=0),
     ):
@@ -279,6 +275,65 @@ def test_populate_external_raises_on_microbench_failure(
                 log=lambda _msg: None,
                 run_command=lambda *_a, **_k: 7,
             )
+
+
+def test_populate_falls_back_to_hyperloom_when_microbench_unavailable(
+    tmp_path: Path,
+) -> None:
+    """No idle GPU -> the hyperloom achievable spec is used instead of raising."""
+    fallback = tmp_path / "MI355X.json"
+
+    with (
+        patch.object(tab, "resolve_arch_json_path", return_value=None),
+        patch.object(tab, "select_idle_gpu", side_effect=RuntimeError("no unoccupied GPU")),
+        patch.object(tab, "write_hyperloom_arch_spec", return_value=fallback),
+    ):
+        path = tab.populate_gpu_arch_json(
+            tracelens_root=tmp_path,
+            platform="MI355X",
+            internal_extension_enabled=False,
+            log=lambda _msg: None,
+            run_command=lambda *_a, **_k: 0,
+        )
+
+    assert path == fallback
+
+
+def test_populate_falls_back_to_hyperloom_on_zeroed_measured_spec(
+    tmp_path: Path,
+) -> None:
+    """A measured spec with all-zero MAF falls back to the hyperloom spec."""
+    fallback = tmp_path / "MI355X.json"
+
+    def _run_command(cmd, *, cwd, timeout_s, env=None):
+        out = Path(cmd[cmd.index("--output") + 1])
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(
+            json.dumps(
+                {
+                    "name": "MI355X",
+                    "mem_bw_gbps": 8000,
+                    "max_achievable_tflops": {"matrix_bf16": 0, "matrix_fp8": 0},
+                }
+            ),
+            encoding="utf-8",
+        )
+        return 0
+
+    with (
+        patch.object(tab, "resolve_arch_json_path", return_value=None),
+        patch.object(tab, "select_idle_gpu", return_value=0),
+        patch.object(tab, "write_hyperloom_arch_spec", return_value=fallback),
+    ):
+        path = tab.populate_gpu_arch_json(
+            tracelens_root=tmp_path,
+            platform="MI355X",
+            internal_extension_enabled=False,
+            log=lambda _msg: None,
+            run_command=_run_command,
+        )
+
+    assert path == fallback
 
 
 def _install_fake_tracelens(monkeypatch: pytest.MonkeyPatch, leaf: str, attr: str, value) -> None:

--- a/src/hyperloom/agents/kernel/tools/tracelens_arch_benchmark.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_arch_benchmark.py
@@ -399,8 +399,9 @@ def populate_gpu_arch_json(
       backfills MAF itself, so we never run the microbenchmark. Any bundled
       spec already on disk is returned as an artifact; otherwise ``None`` is
       returned and the internal extension supplies MAF at report time.
-    - When it is False (open-source path) a bundled spec short-circuits, and
-      a missing spec triggers the TraceLens microbenchmark on an idle GPU.
+    - When it is False (open-source path) a bundled spec short-circuits;
+      otherwise the TraceLens microbenchmark runs on an idle GPU, falling back
+      to hyperloom's in-repo achievable spec when it cannot produce a usable one.
 
     Args:
         tracelens_root: Root of the TraceLens checkout.
@@ -438,59 +439,63 @@ def populate_gpu_arch_json(
     if not canonical:
         raise RuntimeError("target platform is empty; cannot resolve or generate gpu arch JSON")
 
-    # Prefer hyperloom's in-repo achievable spec (NDA-clear, shared with the LLM
-    # baseline roofline) over a live microbenchmark: newer cards (e.g. MI355X)
-    # are absent from the public bundle, and this keeps a single source of truth
-    # without needing an idle GPU or a TraceLens-internal checkout.
+    # Prefer a live microbenchmark (measured MAF); fall back to hyperloom's
+    # in-repo achievable spec when no idle GPU is available or the microbenchmark
+    # cannot produce a usable spec.
+    out_path = default_arch_output_path(tracelens_root, canonical)
+    mb_error: RuntimeError | None = None
+    try:
+        log(
+            "gpu_arch_json: no bundled spec for "
+            f"{canonical} and internal extension disabled; running TraceLens "
+            f"microbenchmark -> {out_path}"
+        )
+        physical_id = select_idle_gpu(log=log)
+        rc = run_command(
+            [
+                sys.executable,
+                "-m",
+                "TraceLens.PerfModel.benchmarking.microbench",
+                "--device",
+                str(device),
+                "--warmup",
+                str(MICROBENCH_WARMUP),
+                "--rep",
+                str(MICROBENCH_REP),
+                "--output",
+                str(out_path),
+            ],
+            cwd=tracelens_root,
+            timeout_s=timeout_s,
+            env=single_physical_gpu_env(physical_id),
+        )
+        if rc != 0:
+            raise RuntimeError(f"gpu arch microbenchmark failed with exit code {rc}; see log for details")
+        if not out_path.is_file():
+            raise RuntimeError(f"gpu arch microbenchmark finished but output is missing: {out_path}")
+
+        payload = json.loads(out_path.read_text(encoding="utf-8"))
+        changed = False
+        if payload.get("name") != canonical:
+            payload["name"] = canonical
+            changed = True
+            log(f"gpu_arch_json: patched name field -> {canonical}")
+
+        # Reject / sanitize a spec with 0 (unmeasured) MAF or bandwidth before
+        # roofline consumes it as a divisor (#390).
+        changed = _sanitize_measured_arch_spec(payload, platform=canonical, out_path=out_path, log=log) or changed
+
+        if changed:
+            out_path.write_text(json.dumps(payload, indent=4) + "\n", encoding="utf-8")
+
+        log(f"gpu_arch_json: measured spec ready at {out_path}")
+        return out_path
+    except RuntimeError as exc:
+        mb_error = exc
+        log(f"gpu_arch_json: microbenchmark unusable ({exc}); falling back to hyperloom achievable spec")
+
     hyperloom_spec = write_hyperloom_arch_spec(tracelens_root, canonical, log)
     if hyperloom_spec is not None:
         return hyperloom_spec
-
-    out_path = default_arch_output_path(tracelens_root, canonical)
-    log(
-        "gpu_arch_json: no bundled spec for "
-        f"{canonical} and internal extension disabled; running TraceLens "
-        f"microbenchmark -> {out_path}"
-    )
-
-    physical_id = select_idle_gpu(log=log)
-
-    rc = run_command(
-        [
-            sys.executable,
-            "-m",
-            "TraceLens.PerfModel.benchmarking.microbench",
-            "--device",
-            str(device),
-            "--warmup",
-            str(MICROBENCH_WARMUP),
-            "--rep",
-            str(MICROBENCH_REP),
-            "--output",
-            str(out_path),
-        ],
-        cwd=tracelens_root,
-        timeout_s=timeout_s,
-        env=single_physical_gpu_env(physical_id),
-    )
-    if rc != 0:
-        raise RuntimeError(f"gpu arch microbenchmark failed with exit code {rc}; see log for details")
-    if not out_path.is_file():
-        raise RuntimeError(f"gpu arch microbenchmark finished but output is missing: {out_path}")
-
-    payload = json.loads(out_path.read_text(encoding="utf-8"))
-    changed = False
-    if payload.get("name") != canonical:
-        payload["name"] = canonical
-        changed = True
-        log(f"gpu_arch_json: patched name field -> {canonical}")
-
-    # Reject / sanitize a spec with 0 (unmeasured) MAF or bandwidth before
-    # roofline consumes it as a divisor (#390).
-    changed = _sanitize_measured_arch_spec(payload, platform=canonical, out_path=out_path, log=log) or changed
-
-    if changed:
-        out_path.write_text(json.dumps(payload, indent=4) + "\n", encoding="utf-8")
-
-    log(f"gpu_arch_json: measured spec ready at {out_path}")
-    return out_path
+    assert mb_error is not None
+    raise mb_error


### PR DESCRIPTION
## Problem

On the open-source path, `populate_gpu_arch_json` preferred hyperloom's in-repo achievable spec (`roofline_ceiling.HW_SPECS_ACHIEVABLE`) over a live GPU microbenchmark, so measured MAF was never used when an in-repo spec existed. The in repo spec is based on datasheet specs, whereas the microbenchmark based numbers are preferred for analysis. 

## Change

Swap the priority: run the TraceLens microbenchmark first (measured MAF), and fall back to the hyperloom achievable spec only when the microbenchmark can't produce a usable spec (no idle GPU, non-zero exit, missing output, or all-zero MAF/bandwidth).

- Microbench block wrapped in `try/except`; failures fall through to the hyperloom spec instead of aborting.
- Loud-failure preserved: if the fallback is also unavailable, the original microbench error is re-raised.
- Added tests for both fallback paths (microbench unavailable, zeroed measured spec).