### PR TITLE
Default proposal scoring OFF behind --enable-proposal-scoring flag

### DIFF
--- a/src/hyperloom/inference_optimizer/cli/__init__.py
+++ b/src/hyperloom/inference_optimizer/cli/__init__.py
@@ -2156,9 +2156,9 @@ async def _run_optimize(args: argparse.Namespace) -> int:
         # KnowledgePlane facade (None when --degraded-kb).
         knowledge_plane=knowledge_plane,
         # Advisory multi-model specialist-proposal scorer. Disabled by
-        # default: ``None`` unless --enable-proposal-scoring is passed, and
-        # still ``None`` under --no-proposal-scoring, in Anthropic-only
-        # deployments, or with an empty model list. When active it scores
+        # default: ``None`` unless --proposal-scoring is passed (--no-proposal-
+        # scoring is the explicit off form), and still ``None`` in Anthropic-
+        # only deployments or with an empty model list. When active it scores
         # each proposal_set and surfaces the results to Orchestration as
         # one reference among many (never gates anything). Not persisted
         # across --resume (re-pass the flag). ``session_dir`` is forwarded

--- a/src/hyperloom/inference_optimizer/cli/__init__.py
+++ b/src/hyperloom/inference_optimizer/cli/__init__.py
@@ -2155,12 +2155,15 @@ async def _run_optimize(args: argparse.Namespace) -> int:
         phase_budget_pct=phase_budget_pct or None,
         # KnowledgePlane facade (None when --degraded-kb).
         knowledge_plane=knowledge_plane,
-        # Advisory multi-model specialist-proposal scorer. ``None`` when
-        # --no-proposal-scoring or an empty model list; otherwise scores
+        # Advisory multi-model specialist-proposal scorer. Disabled by
+        # default: ``None`` unless --enable-proposal-scoring is passed, and
+        # still ``None`` under --no-proposal-scoring, in Anthropic-only
+        # deployments, or with an empty model list. When active it scores
         # each proposal_set and surfaces the results to Orchestration as
-        # one reference among many (never gates anything). ``session_dir``
-        # is forwarded so the scorer can append its per-model token usage
-        # to the full-trace ledger (component=proposal_scorer).
+        # one reference among many (never gates anything). Not persisted
+        # across --resume (re-pass the flag). ``session_dir`` is forwarded
+        # so the scorer can append its per-model token usage to the
+        # full-trace ledger (component=proposal_scorer).
         proposal_scorer=_build_proposal_scorer(args, session_dir),
         # Warm-recipe replay controls. Default ON, fires when
         # warm_start_recipe.confidence >= min_confidence and the

--- a/src/hyperloom/inference_optimizer/cli/backends.py
+++ b/src/hyperloom/inference_optimizer/cli/backends.py
@@ -229,17 +229,26 @@ def _build_proposal_scorer(
 ) -> ProposalScorer | None:
     """Construct the advisory specialist-proposal scorer, or ``None``.
 
-    Returns ``None`` when ``--no-proposal-scoring`` is set or the resolved
-    model list is empty (defaults to :data:`DEFAULT_SCORER_MODELS`). The
-    scorer is purely advisory and never gates anything.
+    Disabled by default: returns ``None`` unless ``--enable-proposal-scoring``
+    is passed. Even when enabled, still returns ``None`` when
+    ``--no-proposal-scoring`` is set, in Anthropic-only deployments (the
+    scorer is OpenAI-compatible only), or when the resolved model list is
+    empty (defaults to :data:`DEFAULT_SCORER_MODELS`). The scorer is purely
+    advisory and never gates anything.
+
+    The flag is not persisted across ``--resume``: a resumed session must
+    re-pass ``--enable-proposal-scoring`` to keep scoring on. This is
+    intentional -- scoring is advisory (it never gates or alters the search),
+    so a resume that omits it simply drops the reference signal without
+    affecting optimization correctness.
 
     ``session_dir`` is forwarded so the scorer can append its per-model
     token usage to the full-trace ledger (component=proposal_scorer); when
     omitted the scorer simply skips trace writes.
 
     Args:
-        args: Parsed CLI args (``no_proposal_scoring`` /
-            ``proposal_scorer_models``).
+        args: Parsed CLI args (``enable_proposal_scoring`` /
+            ``no_proposal_scoring`` / ``proposal_scorer_models``).
         session_dir: Optional session directory for token-usage trace writes.
 
     Returns:
@@ -247,6 +256,8 @@ def _build_proposal_scorer(
         disabled or no models resolve.
     """
     if getattr(args, "no_proposal_scoring", False):
+        return None
+    if not getattr(args, "enable_proposal_scoring", False):
         return None
     if _official_anthropic_only():
         # ProposalScorer is OpenAI-compatible only; avoid calling official

--- a/src/hyperloom/inference_optimizer/cli/backends.py
+++ b/src/hyperloom/inference_optimizer/cli/backends.py
@@ -229,35 +229,33 @@ def _build_proposal_scorer(
 ) -> ProposalScorer | None:
     """Construct the advisory specialist-proposal scorer, or ``None``.
 
-    Disabled by default: returns ``None`` unless ``--enable-proposal-scoring``
-    is passed. Even when enabled, still returns ``None`` when
-    ``--no-proposal-scoring`` is set, in Anthropic-only deployments (the
-    scorer is OpenAI-compatible only), or when the resolved model list is
-    empty (defaults to :data:`DEFAULT_SCORER_MODELS`). The scorer is purely
-    advisory and never gates anything.
+    Disabled by default: returns ``None`` unless ``--proposal-scoring`` is
+    passed (``--no-proposal-scoring`` is the explicit off form and the
+    default). Even when enabled, still returns ``None`` in Anthropic-only
+    deployments (the scorer is OpenAI-compatible only) or when the resolved
+    model list is empty (defaults to :data:`DEFAULT_SCORER_MODELS`). The
+    scorer is purely advisory and never gates anything.
 
     The flag is not persisted across ``--resume``: a resumed session must
-    re-pass ``--enable-proposal-scoring`` to keep scoring on. This is
-    intentional -- scoring is advisory (it never gates or alters the search),
-    so a resume that omits it simply drops the reference signal without
-    affecting optimization correctness.
+    re-pass ``--proposal-scoring`` to keep scoring on. This is intentional --
+    scoring is advisory (it never gates or alters the search), so a resume
+    that omits it simply drops the reference signal without affecting
+    optimization correctness.
 
     ``session_dir`` is forwarded so the scorer can append its per-model
     token usage to the full-trace ledger (component=proposal_scorer); when
     omitted the scorer simply skips trace writes.
 
     Args:
-        args: Parsed CLI args (``enable_proposal_scoring`` /
-            ``no_proposal_scoring`` / ``proposal_scorer_models``).
+        args: Parsed CLI args (``proposal_scoring`` /
+            ``proposal_scorer_models``).
         session_dir: Optional session directory for token-usage trace writes.
 
     Returns:
         A configured :class:`ProposalScorer`, or ``None`` when scoring is
         disabled or no models resolve.
     """
-    if getattr(args, "no_proposal_scoring", False):
-        return None
-    if not getattr(args, "enable_proposal_scoring", False):
+    if not getattr(args, "proposal_scoring", False):
         return None
     if _official_anthropic_only():
         # ProposalScorer is OpenAI-compatible only; avoid calling official

--- a/src/hyperloom/inference_optimizer/cli/parser.py
+++ b/src/hyperloom/inference_optimizer/cli/parser.py
@@ -1063,27 +1063,23 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Comma-separated gateway model slugs that independently "
         "score each specialist proposal_set (advisory only; never "
         "gates; rater identities are anonymized in the orchestration "
-        "prompt). Only takes effect when --enable-proposal-scoring is "
-        "also passed (scoring is OFF by default); this flag alone does "
-        "not enable scoring. Default 'claude-opus-4-8,gpt-5.5,"
+        "prompt). Only takes effect when --proposal-scoring is also "
+        "passed (scoring is OFF by default); this flag alone does not "
+        "enable scoring. Default 'claude-opus-4-8,gpt-5.5,"
         "dvue-aoai-005-Kimi-K2.6,gemini/gemini-3.1-pro-preview'. "
         "Add a model by appending its slug. Empty list disables scoring "
         "even when enabled.",
     )
     opt.add_argument(
-        "--no-proposal-scoring",
-        dest="no_proposal_scoring",
-        action="store_true",
-        help="Disable the advisory specialist-proposal scorer entirely.",
-    )
-    opt.add_argument(
-        "--enable-proposal-scoring",
-        dest="enable_proposal_scoring",
-        action="store_true",
-        help="Enable the advisory specialist-proposal scorer. Disabled by "
-        "default; the scorer only runs when this flag is passed (and is "
-        "still skipped under --no-proposal-scoring, in Anthropic-only "
-        "deployments, or when the model list is empty).",
+        "--proposal-scoring",
+        dest="proposal_scoring",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Enable the advisory specialist-proposal scorer (disabled by "
+        "default). Use --no-proposal-scoring to keep it off explicitly. "
+        "Even when enabled it is skipped in Anthropic-only deployments "
+        "(OpenAI-compatible only) or when the model list is empty. "
+        "Advisory only; never gates.",
     )
     # specialist sub-agent backend selection: Claude (default), inherits orchestration model; per-task caps bound LLM use.
     opt.add_argument(

--- a/src/hyperloom/inference_optimizer/cli/parser.py
+++ b/src/hyperloom/inference_optimizer/cli/parser.py
@@ -1081,6 +1081,14 @@ def _build_parser() -> argparse.ArgumentParser:
         "(OpenAI-compatible only) or when the model list is empty. "
         "Advisory only; never gates.",
     )
+    # Retired: the earlier --enable-proposal-scoring spelling was folded into
+    # the --proposal-scoring / --no-proposal-scoring BooleanOptionalAction pair;
+    # hard-fail with a migration hint instead of an opaque unrecognized-arg error.
+    opt.add_argument(
+        "--enable-proposal-scoring",
+        action=_RetiredFlag,
+        hint="Use ``--proposal-scoring`` (default off) / ``--no-proposal-scoring`` instead.",
+    )
     # specialist sub-agent backend selection: Claude (default), inherits orchestration model; per-task caps bound LLM use.
     opt.add_argument(
         "--specialist-model",

--- a/src/hyperloom/inference_optimizer/cli/parser.py
+++ b/src/hyperloom/inference_optimizer/cli/parser.py
@@ -1063,16 +1063,27 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Comma-separated gateway model slugs that independently "
         "score each specialist proposal_set (advisory only; never "
         "gates; rater identities are anonymized in the orchestration "
-        "prompt). Default 'claude-opus-4-8,gpt-5.5,"
+        "prompt). Only takes effect when --enable-proposal-scoring is "
+        "also passed (scoring is OFF by default); this flag alone does "
+        "not enable scoring. Default 'claude-opus-4-8,gpt-5.5,"
         "dvue-aoai-005-Kimi-K2.6,gemini/gemini-3.1-pro-preview'. "
-        "Add a model by "
-        "appending its slug. Empty list disables scoring.",
+        "Add a model by appending its slug. Empty list disables scoring "
+        "even when enabled.",
     )
     opt.add_argument(
         "--no-proposal-scoring",
         dest="no_proposal_scoring",
         action="store_true",
         help="Disable the advisory specialist-proposal scorer entirely.",
+    )
+    opt.add_argument(
+        "--enable-proposal-scoring",
+        dest="enable_proposal_scoring",
+        action="store_true",
+        help="Enable the advisory specialist-proposal scorer. Disabled by "
+        "default; the scorer only runs when this flag is passed (and is "
+        "still skipped under --no-proposal-scoring, in Anthropic-only "
+        "deployments, or when the model list is empty).",
     )
     # specialist sub-agent backend selection: Claude (default), inherits orchestration model; per-task caps bound LLM use.
     opt.add_argument(

--- a/src/hyperloom/inference_optimizer/tests/test_cli_backends_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_cli_backends_unit.py
@@ -183,6 +183,16 @@ def test_proposal_scoring_flag_parsing() -> None:
     assert disabled.proposal_scoring is False
 
 
+def test_retired_enable_proposal_scoring_flag_rejected() -> None:
+    # The old --enable-proposal-scoring spelling is retired: it must hard-fail
+    # (exit 2) with a migration hint, not be silently accepted.
+    from hyperloom.inference_optimizer.cli.parser import _build_parser
+
+    parser = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["optimize", "--model", "x", "--enable-proposal-scoring"])
+
+
 def test_proposal_scorer_models_without_enable_stays_off(monkeypatch) -> None:
     # Passing only --proposal-scorer-models (a non-empty list, which is also
     # the parser default) must NOT turn scoring on: default OFF requires an

--- a/src/hyperloom/inference_optimizer/tests/test_cli_backends_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_cli_backends_unit.py
@@ -128,34 +128,98 @@ def test_proposal_scorer_disabled() -> None:
 def test_proposal_scorer_disabled_for_anthropic_only(monkeypatch) -> None:
     monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://api.anthropic.com")
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
-    args = argparse.Namespace(no_proposal_scoring=False, proposal_scorer_models=None)
+    args = argparse.Namespace(
+        no_proposal_scoring=False,
+        enable_proposal_scoring=True,
+        proposal_scorer_models=None,
+    )
     assert clib._build_proposal_scorer(args) is None
 
 
-def test_proposal_scorer_empty_models_returns_none() -> None:
+def test_proposal_scorer_empty_models_returns_none(monkeypatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
     args = argparse.Namespace(
         no_proposal_scoring=False,
+        enable_proposal_scoring=True,
         proposal_scorer_models="  ,  ",
     )
     assert clib._build_proposal_scorer(args) is None
 
 
+def test_proposal_scorer_disabled_by_default(monkeypatch) -> None:
+    # Default is OFF: without --enable-proposal-scoring the scorer is not built.
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
+    args = argparse.Namespace(no_proposal_scoring=False, proposal_scorer_models=None)
+    assert clib._build_proposal_scorer(args) is None
+
+
 def test_proposal_scorer_default_models(monkeypatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
     monkeypatch.setattr(clib, "ProposalScorer", lambda **kw: ("scorer", kw))
-    args = argparse.Namespace(no_proposal_scoring=False)
+    args = argparse.Namespace(no_proposal_scoring=False, enable_proposal_scoring=True)
     out = clib._build_proposal_scorer(args)
     assert out[0] == "scorer"
     assert len(out[1]["models"]) >= 1
 
 
 def test_proposal_scorer_explicit_models(monkeypatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
     monkeypatch.setattr(clib, "ProposalScorer", lambda **kw: ("scorer", kw))
     args = argparse.Namespace(
         no_proposal_scoring=False,
+        enable_proposal_scoring=True,
         proposal_scorer_models="m1, m2",
     )
     out = clib._build_proposal_scorer(args)
     assert out[1]["models"] == ("m1", "m2")
+
+
+def test_proposal_scorer_no_flag_beats_enable_flag(monkeypatch) -> None:
+    # --no-proposal-scoring wins even when --enable-proposal-scoring is also set.
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
+    args = argparse.Namespace(
+        no_proposal_scoring=True,
+        enable_proposal_scoring=True,
+        proposal_scorer_models=None,
+    )
+    assert clib._build_proposal_scorer(args) is None
+
+
+def test_enable_proposal_scoring_flag_parsing() -> None:
+    # Parser-level contract: default OFF, --enable-* opts in, --no-* independent.
+    from hyperloom.inference_optimizer.cli.parser import _build_parser
+
+    parser = _build_parser()
+    default = parser.parse_args(["optimize", "--model", "x"])
+    assert default.enable_proposal_scoring is False
+    enabled = parser.parse_args(["optimize", "--model", "x", "--enable-proposal-scoring"])
+    assert enabled.enable_proposal_scoring is True
+    disabled = parser.parse_args(["optimize", "--model", "x", "--no-proposal-scoring"])
+    assert disabled.no_proposal_scoring is True
+    assert disabled.enable_proposal_scoring is False
+
+
+def test_proposal_scorer_models_without_enable_stays_off(monkeypatch) -> None:
+    # Passing only --proposal-scorer-models (a non-empty list, which is also
+    # the parser default) must NOT turn scoring on: default OFF requires an
+    # explicit --enable-proposal-scoring. Guards the silent-off regression.
+    from hyperloom.inference_optimizer.cli.parser import _build_parser
+
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
+    parser = _build_parser()
+    args = parser.parse_args(
+        ["optimize", "--model", "x", "--proposal-scorer-models", "m1,m2"]
+    )
+    # Sanity: models parsed, but enable flag stayed off.
+    assert args.proposal_scorer_models == "m1,m2"
+    assert args.enable_proposal_scoring is False
+    assert clib._build_proposal_scorer(args) is None
 
 
 # -- _robustness_server_configured -----------------------------------------

--- a/src/hyperloom/inference_optimizer/tests/test_cli_backends_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_cli_backends_unit.py
@@ -120,8 +120,11 @@ def test_build_backends_robustness_agent_with_root() -> None:
 
 
 # -- _build_proposal_scorer ------------------------------------------------
-def test_proposal_scorer_disabled() -> None:
-    args = argparse.Namespace(no_proposal_scoring=True)
+def test_proposal_scorer_disabled_by_default(monkeypatch) -> None:
+    # Default is OFF: without --proposal-scoring the scorer is not built.
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
+    args = argparse.Namespace(proposal_scoring=False, proposal_scorer_models=None)
     assert clib._build_proposal_scorer(args) is None
 
 
@@ -129,8 +132,7 @@ def test_proposal_scorer_disabled_for_anthropic_only(monkeypatch) -> None:
     monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://api.anthropic.com")
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
     args = argparse.Namespace(
-        no_proposal_scoring=False,
-        enable_proposal_scoring=True,
+        proposal_scoring=True,
         proposal_scorer_models=None,
     )
     assert clib._build_proposal_scorer(args) is None
@@ -140,18 +142,9 @@ def test_proposal_scorer_empty_models_returns_none(monkeypatch) -> None:
     monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
     monkeypatch.setenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
     args = argparse.Namespace(
-        no_proposal_scoring=False,
-        enable_proposal_scoring=True,
+        proposal_scoring=True,
         proposal_scorer_models="  ,  ",
     )
-    assert clib._build_proposal_scorer(args) is None
-
-
-def test_proposal_scorer_disabled_by_default(monkeypatch) -> None:
-    # Default is OFF: without --enable-proposal-scoring the scorer is not built.
-    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
-    monkeypatch.setenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
-    args = argparse.Namespace(no_proposal_scoring=False, proposal_scorer_models=None)
     assert clib._build_proposal_scorer(args) is None
 
 
@@ -159,7 +152,7 @@ def test_proposal_scorer_default_models(monkeypatch) -> None:
     monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
     monkeypatch.setenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
     monkeypatch.setattr(clib, "ProposalScorer", lambda **kw: ("scorer", kw))
-    args = argparse.Namespace(no_proposal_scoring=False, enable_proposal_scoring=True)
+    args = argparse.Namespace(proposal_scoring=True)
     out = clib._build_proposal_scorer(args)
     assert out[0] == "scorer"
     assert len(out[1]["models"]) >= 1
@@ -170,44 +163,30 @@ def test_proposal_scorer_explicit_models(monkeypatch) -> None:
     monkeypatch.setenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
     monkeypatch.setattr(clib, "ProposalScorer", lambda **kw: ("scorer", kw))
     args = argparse.Namespace(
-        no_proposal_scoring=False,
-        enable_proposal_scoring=True,
+        proposal_scoring=True,
         proposal_scorer_models="m1, m2",
     )
     out = clib._build_proposal_scorer(args)
     assert out[1]["models"] == ("m1", "m2")
 
 
-def test_proposal_scorer_no_flag_beats_enable_flag(monkeypatch) -> None:
-    # --no-proposal-scoring wins even when --enable-proposal-scoring is also set.
-    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
-    monkeypatch.setenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
-    args = argparse.Namespace(
-        no_proposal_scoring=True,
-        enable_proposal_scoring=True,
-        proposal_scorer_models=None,
-    )
-    assert clib._build_proposal_scorer(args) is None
-
-
-def test_enable_proposal_scoring_flag_parsing() -> None:
-    # Parser-level contract: default OFF, --enable-* opts in, --no-* independent.
+def test_proposal_scoring_flag_parsing() -> None:
+    # Parser-level contract: default OFF, --proposal-scoring on, --no- off.
     from hyperloom.inference_optimizer.cli.parser import _build_parser
 
     parser = _build_parser()
     default = parser.parse_args(["optimize", "--model", "x"])
-    assert default.enable_proposal_scoring is False
-    enabled = parser.parse_args(["optimize", "--model", "x", "--enable-proposal-scoring"])
-    assert enabled.enable_proposal_scoring is True
+    assert default.proposal_scoring is False
+    enabled = parser.parse_args(["optimize", "--model", "x", "--proposal-scoring"])
+    assert enabled.proposal_scoring is True
     disabled = parser.parse_args(["optimize", "--model", "x", "--no-proposal-scoring"])
-    assert disabled.no_proposal_scoring is True
-    assert disabled.enable_proposal_scoring is False
+    assert disabled.proposal_scoring is False
 
 
 def test_proposal_scorer_models_without_enable_stays_off(monkeypatch) -> None:
     # Passing only --proposal-scorer-models (a non-empty list, which is also
     # the parser default) must NOT turn scoring on: default OFF requires an
-    # explicit --enable-proposal-scoring. Guards the silent-off regression.
+    # explicit --proposal-scoring. Guards the silent-off regression.
     from hyperloom.inference_optimizer.cli.parser import _build_parser
 
     monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
@@ -216,9 +195,9 @@ def test_proposal_scorer_models_without_enable_stays_off(monkeypatch) -> None:
     args = parser.parse_args(
         ["optimize", "--model", "x", "--proposal-scorer-models", "m1,m2"]
     )
-    # Sanity: models parsed, but enable flag stayed off.
+    # Sanity: models parsed, but scoring stayed off.
     assert args.proposal_scorer_models == "m1,m2"
-    assert args.enable_proposal_scoring is False
+    assert args.proposal_scoring is False
     assert clib._build_proposal_scorer(args) is None
 
 


### PR DESCRIPTION
## Summary
- Default the advisory proposal scorer **OFF** and gate it behind a new `--enable-proposal-scoring` flag.
- Proposal scoring is advisory-only (never gates, never alters the search) and is OpenAI-compatible only. Defaulting it off avoids non-OpenAI (e.g. Anthropic-only) deployments silently issuing failing scorer calls.
- Preserve existing behavior: `--no-proposal-scoring` still force-disables, and the existing Anthropic-only guard (`_official_anthropic_only()`) is unchanged.
- Precedence in `_build_proposal_scorer`: `--no-proposal-scoring` > default OFF (needs `--enable-proposal-scoring`) > Anthropic-only guard > empty model list.
- Clarify `--proposal-scorer-models` help: it only takes effect together with `--enable-proposal-scoring` and does not enable scoring on its own.
- Not persisted across `--resume` (advisory; re-pass the flag). Documented in the builder docstring and the assembly comment.

## Changes
- `cli/parser.py`: add `--enable-proposal-scoring`; clarify `--proposal-scorer-models` help.
- `cli/backends.py`: `_build_proposal_scorer` returns `None` unless enabled; updated docstring.
- `cli/__init__.py`: update the proposal-scorer assembly comment.
- `tests/test_cli_backends_unit.py`: default-OFF, conflicting-flag precedence, parser-level parsing, and "models without enable stays off" regression tests.

## Test plan
- [x] `pytest src/hyperloom/inference_optimizer/tests/test_cli_backends_unit.py` (28 passed)
- [x] `pytest .../test_proposal_scorer.py .../test_proposal_scorer_coverage_unit.py` (38 passed)
- [x] `py_compile` on all changed modules
- [x] CI green