### PR TITLE
Restore LLM_GATEWAY_KEY in local demo

### DIFF
--- a/examples/hyperloom-local-demo.md
+++ b/examples/hyperloom-local-demo.md
@@ -269,16 +269,16 @@ of Claude account they will use:
 **setup-claude-2 — collect the key(s) and set the env vars** for the chosen method.
 
 - **AMD internal (gateway):** ask the user (a question) for `ANTHROPIC_BASE_URL`
-  and their `SAFE_API_KEY`. `ANTHROPIC_BASE_URL` defaults to
+  and their `LLM_GATEWAY_KEY`. `ANTHROPIC_BASE_URL` defaults to
   `https://llm-api.amd.com/Anthropic` — tell the user this and use it as-is
-  unless they provide their own. `SAFE_API_KEY` is **required**; if they don't
+  unless they provide their own. `LLM_GATEWAY_KEY` is **required**; if they don't
   have one, they can get it from <https://llm.amd.com/key-management>. Then:
 
 ```bash
-export SAFE_API_KEY="xxxxx"   # <- the user's LLM gateway key
+export LLM_GATEWAY_KEY="xxxxx"   # <- the user's LLM gateway key
 export ANTHROPIC_BASE_URL="https://llm-api.amd.com/Anthropic"   # or the user's override
 export ANTHROPIC_API_KEY="dummy"
-export ANTHROPIC_CUSTOM_HEADERS="Ocp-Apim-Subscription-Key: $SAFE_API_KEY"
+export ANTHROPIC_CUSTOM_HEADERS="Ocp-Apim-Subscription-Key: $LLM_GATEWAY_KEY"
 ```
 
 - **Personal Anthropic account:** ask the user (a question) for their
@@ -331,15 +331,15 @@ of OpenAI account they will use:
 **setup-codex-2 — collect the key(s) and set the env vars** for the chosen method.
 
 - **AMD internal (gateway):** ask the user (a question) for `OPENAI_BASE_URL` and
-  their `SAFE_API_KEY`. `OPENAI_BASE_URL` defaults to
+  their `LLM_GATEWAY_KEY`. `OPENAI_BASE_URL` defaults to
   `https://llm-api.amd.com/Unified/v1` — tell the user this and use it as-is
-  unless they provide their own. `SAFE_API_KEY` is **required**. Then:
+  unless they provide their own. `LLM_GATEWAY_KEY` is **required**. Then:
 
 ```bash
-export SAFE_API_KEY="xxxxx"   # <- the user's LLM gateway key
+export LLM_GATEWAY_KEY="xxxxx"   # <- the user's LLM gateway key
 export OPENAI_BASE_URL="https://llm-api.amd.com/Unified/v1"   # or the user's override
 export OPENAI_API_KEY="dummy"
-export OPENAI_CUSTOM_HEADERS="Ocp-Apim-Subscription-Key: $SAFE_API_KEY"
+export OPENAI_CUSTOM_HEADERS="Ocp-Apim-Subscription-Key: $LLM_GATEWAY_KEY"
 ```
 
 - **Personal OpenAI account:** ask the user (a question) for their


### PR DESCRIPTION
## Summary
- Restore AMD LLM gateway examples to use `LLM_GATEWAY_KEY` instead of `SAFE_API_KEY`.
- Update Anthropic and OpenAI custom header examples to reference `LLM_GATEWAY_KEY`.

## Test plan
- `git diff --check`
- Confirmed no `SAFE_API_KEY` references remain under `examples/`.


Made with [Cursor](https://cursor.com)