### PR TITLE
docs: update GEAK description to v4 and fix kernel backend order

### DIFF
--- a/docs/components/geak.md
+++ b/docs/components/geak.md
@@ -6,18 +6,19 @@ myst:
 ---
 # GEAK
 
-GEAK (Generating Efficient AI-Centric Kernels) is an agent-driven framework for end-to-end GPU kernel optimization in
-real codebases. It runs a closed loop of profiling, optimization, and
+GEAK (Generating Efficient AI-Centric Kernels) is a multi-agent framework for end-to-end GPU kernel
+optimization in real codebases. It runs a closed loop of profiling, optimization, and
 validation, and produces reviewable patches backed by reproducible benchmarks.
 GEAK supports Triton, HIP (and CUDA / Composable Kernel (CK) / HSA Code Object (HSACO)), and FlyDSL
-kernels, and extends [mini-SWE-agent](https://github.com/SWE-agent/mini-SWE-agent)
-for its agent loop and environment tooling.
+kernels. It is driven by [Claude Code](https://www.anthropic.com/claude-code) and ships two
+deterministic JS Workflows — `e2e_workflow` for whole-model serving throughput and `kernel_workflow`
+for single kernels — with a deterministic control plane (budget loop, parallel fan-out, verification,
+stop conditions) that invokes LLM agents only for judgment.
 
-Within Hyperloom, GEAK is one of the kernel-rewrite backends: when a hot kernel
-is identified, it is optimized asynchronously through GEAK. The kernel agent
-dispatches GEAK runs with placement precedence SSH (Dynamo multi-node) > Ray
-(when available) > direct CLI, so multiple candidates can be explored in
-parallel on the cluster's GPUs.
+Within Hyperloom, GEAK is the whole-pipeline end-to-end optimization delegate: when a workload is
+handed off, the orchestrator invokes GEAK once at the kernel-agent phase through the stable
+`interface/run_e2e.py` contract (a `handoff.json` in, a `result.json` back). Parallel exploration of
+candidate kernels then happens inside GEAK's Workflows on the on-box GPUs.
 
 ## Role in Hyperloom
 
@@ -28,14 +29,10 @@ orchestrator hands the optimization workload to
 GEAK checkout and launches GEAK's e2e runner (`interface/run_e2e.py`) with the
 generated session context.
 
-GEAK is distinct from the per-kernel `forge` backend:
-
-- `geak` runs the whole e2e optimization loop through GEAK.
-- `forge` targets individual kernel/GEMM opportunities through KernelForge and
-  related forge tools.
-
-This keeps the backend split explicit: use `geak` for whole-pipeline delegation
-and `forge` for per-kernel optimization. See
+When GEAK owns the phase it runs the whole optimization loop itself — both the
+end-to-end serving optimization *and* the per-kernel work underneath it, since
+GEAK's `e2e_workflow` recursively drives `kernel_workflow` to author and tune the
+individual hot kernels worth fixing. See
 [Hyperloom optimization loop](../conceptual/optimization-loop.md).
 
 ## GEAK Documentation

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -37,8 +37,8 @@ core of the current runtime:
 
 - **Kernel optimization** — Hot kernels are optimized asynchronously in parallel
   with the main loop, so kernel work doesn't block forward progress. The default
-  backend order is KernelForge (deterministic forge) first, then GEAK
-  (Triton / HIP / FlyDSL).
+  backend order is GEAK (Triton / HIP / FlyDSL) first, then KernelForge
+  (deterministic forge).
 
 - **Session artifacts and `session_breakdown.json`** — Each run produces
   reproducible session artifacts and a machine-readable `session_breakdown.json`


### PR DESCRIPTION
  Updates two GEAK-related docs:
                                                                     
  - `docs/components/geak.md`: rewrite the intro from the v3 description
    (mini-SWE-agent, SSH/Ray/CLI placement precedence) to v4 — GEAK is a
    Claude Code-driven optimizer with two deterministic JS Workflows 
    (`e2e_workflow` / `kernel_workflow`), invoked once through the stable
    `interface/run_e2e.py` contract. Also clarify that when GEAK owns the
    phase it performs both the e2e and the per-kernel optimization itself
    (no forge hand-off).                                             
  - `docs/release-notes.md`: correct the default kernel-opt backend order to
    GEAK first, then KernelForge (matches the `KERNEL_OPT_BACKEND_ORDER=geak`
    default).