### PR TITLE
fix(model-path): degrade resolve_local_model_dir to None on EACCES (unbreak non-root CI)

### DIFF
--- a/src/hyperloom/common/model_paths.py
+++ b/src/hyperloom/common/model_paths.py
@@ -43,8 +43,16 @@ def resolve_local_model_dir(model: str | Path | None) -> Path | None:
     if not raw:
         return None
     p = Path(raw).expanduser()
-    if p.is_dir():
-        return p
+    # ``is_dir()`` can RAISE rather than return False when a parent is
+    # unreadable: pathlib only swallows ENOENT/ENOTDIR/EBADF/ELOOP, so EACCES --
+    # e.g. a non-root process stat-ing under ``/root/...`` -- propagates. Degrade
+    # to None here (this module's documented contract) so an inaccessible path
+    # can never crash the in-process model readers that call this resolver.
+    try:
+        if p.is_dir():
+            return p
+    except OSError:
+        return None
     # Repo id: reuse the engine's HF hub cache. Lazy import keeps this module
     # dependency-light -- a missing huggingface_hub just degrades to None.
     try:

--- a/src/hyperloom/inference_optimizer/tests/test_model_path_resolver.py
+++ b/src/hyperloom/inference_optimizer/tests/test_model_path_resolver.py
@@ -96,3 +96,40 @@ def test_load_model_config_dict_local_dir_unchanged(tmp_path):
     data = _load_model_config_dict(str(d))
     assert isinstance(data, dict)
     assert data.get("model_type") == "mixtral"
+
+
+def test_resolve_inaccessible_local_dir_degrades_to_none(monkeypatch):
+    """An unreadable parent makes ``Path.is_dir()`` RAISE, not return False.
+
+    ``pathlib`` only swallows ENOENT/ENOTDIR/EBADF/ELOOP, so EACCES -- e.g. a
+    non-root process stat-ing under ``/root/...`` -- propagates. The resolver
+    must degrade to ``None`` (its documented contract) instead of letting the
+    OSError escape into every in-process model reader that calls it.
+    """
+    target = "/root/quantization/google-gemma-4-26B-A4B-it/quantized"
+    real_is_dir = Path.is_dir
+
+    def _raising_is_dir(self):
+        if str(self) == target:
+            raise PermissionError(13, "Permission denied")
+        return real_is_dir(self)
+
+    monkeypatch.setattr(Path, "is_dir", _raising_is_dir)
+    assert resolve_local_model_dir(target) is None
+
+
+def test_load_model_config_dict_inaccessible_path_returns_none(monkeypatch):
+    """End-to-end: an inaccessible ``--model`` path must not crash the config
+    reader. With the resolver degrading to None, ``_load_model_config_dict``
+    falls back to the raw path and its ``read_text`` OSError guard yields None.
+    """
+    target = "/root/quantization/google-gemma-4-26B-A4B-it/quantized"
+    real_is_dir = Path.is_dir
+
+    def _raising_is_dir(self):
+        if str(self) == target:
+            raise PermissionError(13, "Permission denied")
+        return real_is_dir(self)
+
+    monkeypatch.setattr(Path, "is_dir", _raising_is_dir)
+    assert _load_model_config_dict(target) is None


### PR DESCRIPTION
﻿## Summary
main `#886` (`238f58de`, `resolve_local_model_dir`) calls `Path.is_dir()`, which **raises** on `EACCES` rather than returning `False` -- `pathlib` only swallows `ENOENT/ENOTDIR/EBADF/ELOOP`. A non-root process stat-ing a `--model` path under a restricted parent (e.g. `/root/...`) crashes every in-process model reader (roofline ceiling, model-config summary, KB tags, model-class inference, fp8 detection) via `_load_model_config_dict`, turning `main`'s Tests-with-Coverage red (`test_seed_shared_state_preserves_quantized_model_identity`, Python 3.10 + 3.11).

- Guard `is_dir()` so any `OSError` degrades to `None` -- the module's documented degrade-to-None contract -- restoring the pre-`#886` behavior.
- Add regression tests: the resolver and `_load_model_config_dict` both degrade to `None` when `is_dir()` raises `PermissionError`.

## Test plan
- [x] RED on unfixed main: both new tests raise via `model_config_utils.py:43` -> `model_paths.py:46` `is_dir()`.
- [x] GREEN after fix: `test_model_path_resolver.py` + the originally-red `test_seed_shared_state_preserves_quantized_model_identity` -> 10 passed.
- [ ] CI Tests-with-Coverage green on this PR.
