### PR TITLE
feat(conc_sweep) : Boost up conc sweep, server reuse, checkpoints, and plot

### DIFF
--- a/scripts/test_conc_sweep_flow.py
+++ b/scripts/test_conc_sweep_flow.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""End-to-end validation of the single-server-per-arm concurrency sweep.
+
+Reuses a real optimization session's baseline + accepted ``current_best`` and
+runs the *current* ``run_conc_sweep`` over a descending CONC ladder against the
+real model on GPU. It then answers one question:
+
+    "As CONC descends from high to low on a single reused server, does the
+     server get killed between points?"
+
+The verdict is derived from two independent signals:
+
+  1. Result signal  — every CONC point in each arm reports a measured
+     ``output_throughput``. If the server had been killed after the boot round,
+     the lower-CONC reuse rounds would fail with connection errors.
+  2. Boot signal    — the number of distinct server *launches* per arm, counted
+     from Magpie's ``server.log`` / ``reuse_server_spawn.pid`` artifacts. In the
+     single-server path this must be exactly one launch per arm.
+
+Finally it renders the InferenceX-style throughput-vs-interactivity plot from
+the produced ``conc_sweep_summary.json`` artifact, completing the full flow.
+
+Usage::
+
+    python scripts/test_conc_sweep_flow.py \\
+        --session-dir /primus/data/zgong/Hyperloom-Sessions/Qwen3-8B/20260715T033207Z \\
+        --concs 8,4,2
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import shutil
+import sys
+import time
+from pathlib import Path
+
+# Make the src/ tree importable when run as a plain script.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SRC = _REPO_ROOT / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+# Import the executors package first so the kernel.conc_sweep <-> executors
+# circular import resolves (mirrors the test module's import order).
+import hyperloom.orchestrator.actions.executors._grid_runner  # noqa: E402,F401
+from hyperloom.inference_optimizer.session.session_paths import reports_dir, runs_root  # noqa: E402
+from hyperloom.orchestrator.kernel.conc_sweep import run_conc_sweep  # noqa: E402
+from hyperloom.orchestrator.kernel.conc_sweep_plot import render_conc_sweep_curve  # noqa: E402
+from hyperloom.orchestrator.state.shared_state import SharedState  # noqa: E402
+
+
+def _prepare_test_session(source_session: Path, out_dir: Path) -> None:
+    """Copy the source session's ``state.json`` into a fresh test dir.
+
+    We run against a copy so the real session's artifacts are never mutated.
+    ``baseline_config_path`` inside the state keeps pointing at the source
+    session's (read-only) materialized YAML, which is fine.
+
+    Args:
+        source_session: The real optimization session directory.
+        out_dir: Fresh directory to run the test sweep in.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    src_state = source_session / "state.json"
+    if not src_state.is_file():
+        raise SystemExit(f"state.json not found in {source_session}")
+    shutil.copy2(src_state, out_dir / "state.json")
+
+
+def _count_server_launches(sweep_workspace: Path, arm: str) -> tuple[int, list[str]]:
+    """Count distinct server launches for one arm under the sweep workspace.
+
+    A launch is evidenced by a non-empty ``server.log`` produced by the
+    server_lifecycle boot. Reuse rounds re-attach and do not spawn a server.
+
+    Args:
+        sweep_workspace: ``runs/conc_sweep/<task_id>`` directory.
+        arm: Arm label (``baseline`` / ``optimized``).
+
+    Returns:
+        ``(launch_count, pids)`` — the number of server.log launches found for
+        the arm and the list of distinct spawn PIDs recovered from
+        ``reuse_server_spawn.pid`` files.
+    """
+    launches = 0
+    pids: list[str] = []
+    for slot in sorted(sweep_workspace.glob(f"variant_*_{arm}_conc*")):
+        for server_log in slot.rglob("server.log"):
+            try:
+                if server_log.stat().st_size > 0:
+                    launches += 1
+            except OSError:
+                pass
+        for pid_file in slot.rglob("reuse_server_spawn.pid"):
+            try:
+                txt = pid_file.read_text(encoding="utf-8").split()
+                if txt:
+                    pids.append(txt[0])
+            except OSError:
+                pass
+    return launches, sorted(set(pids))
+
+
+def _analyze(payload: dict, sweep_workspace: Path) -> bool:
+    """Print the kill/survival verdict from the sweep payload + server logs.
+
+    Args:
+        payload: Parsed ``conc_sweep_summary.json``.
+        sweep_workspace: The ``runs/conc_sweep/<task_id>`` directory.
+
+    Returns:
+        ``True`` when the verdict is "server survived the descending ladder"
+        for every arm; ``False`` otherwise.
+    """
+    print("\n" + "=" * 78)
+    print("VERDICT: will CONC high->low kill the reused server?")
+    print("=" * 78)
+    overall_ok = True
+    for arm in ("optimized", "baseline"):
+        points = (payload.get(arm) or {}).get("points") or []
+        points = sorted(points, key=lambda p: p.get("conc") or 0, reverse=True)
+        if not points:
+            print(f"\n[{arm}] no points recorded — arm skipped.")
+            continue
+        launches, pids = _count_server_launches(sweep_workspace, arm)
+        print(f"\n[{arm}] {len(points)} CONC points (high -> low):")
+        arm_ok = True
+        for p in points:
+            conc = p.get("conc")
+            status = p.get("status")
+            tput = p.get("output_throughput")
+            marker = "ok " if status == "succeeded" and tput else "BAD"
+            if marker == "BAD":
+                arm_ok = False
+            print(f"    conc={conc:<4} status={status:<10} output_throughput={tput}")
+        print(f"  server launches counted (server.log): {launches}")
+        print(f"  distinct spawn PIDs: {pids or '(none captured)'}")
+        if arm_ok and launches <= 1:
+            print(f"  => [{arm}] SERVER SURVIVED: booted once, reused down the ladder, NOT killed.")
+        elif arm_ok and launches > 1:
+            print(f"  => [{arm}] all points ok but {launches} launches — server was restarted (check lifecycle).")
+            overall_ok = False
+        else:
+            print(f"  => [{arm}] some points failed — server may have been killed mid-ladder.")
+            overall_ok = False
+    print("\n" + "=" * 78)
+    print("ANSWER:", "NO — the server is booted once per arm and reused (not killed)."
+          if overall_ok else "SEE ABOVE — anomalies detected.")
+    print("=" * 78 + "\n")
+    return overall_ok
+
+
+async def _run(session_dir: Path, concs: list[int], variant_timeout_sec: int) -> dict:
+    """Load the copied state and run the sweep with single-server mode on.
+
+    Args:
+        session_dir: The fresh test session directory.
+        concs: Descending CONC ladder to sweep.
+        variant_timeout_sec: Per-variant hard timeout.
+
+    Returns:
+        The sweep payload dict.
+    """
+    state = SharedState.load_or_init(session_dir)
+    # The source session already COMPLETED, so its persisted lifecycle flags
+    # (closing_phase / stop_reason) and exhausted wall-clock would make the new
+    # sweep's deadline/event detection skip everything. Clear them so this
+    # deliberate re-run observes pure single-server reuse behaviour.
+    state.closing_phase = False
+    state.stop_reason = ""
+    state.max_minutes = 0  # 0 => remaining_minutes() is None (unbounded)
+    # total_budget_sec=0 disables the wall-clock budget gate too.
+    return await run_conc_sweep(
+        state,
+        session_dir,
+        concs=concs,
+        variant_timeout_sec=variant_timeout_sec,
+        total_budget_sec=0,
+        write_reports=True,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Args:
+        argv: Argument list; defaults to ``sys.argv`` when ``None``.
+
+    Returns:
+        Process exit code (0 = server survived, 1 = anomalies / no data).
+    """
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument(
+        "--session-dir",
+        type=Path,
+        default=Path("/primus/data/zgong/Hyperloom-Sessions/Qwen3-8B/20260715T033207Z"),
+        help="Real optimization session (baseline + accepted current_best).",
+    )
+    ap.add_argument("--concs", default="8,4,2", help="Descending CONC ladder (comma-separated).")
+    ap.add_argument("--variant-timeout-sec", type=int, default=1800)
+    ap.add_argument(
+        "--out-dir",
+        type=Path,
+        default=None,
+        help="Fresh test session dir; default = <session-dir>_conc_flowtest_<ts>.",
+    )
+    args = ap.parse_args(argv)
+
+    # Force the single-server-per-arm path (the behaviour under test).
+    os.environ["INFERENCE_OPTIMIZER_CONC_SWEEP_SINGLE_SERVER"] = "1"
+
+    source = args.session_dir.expanduser().resolve()
+    out_dir = args.out_dir or source.parent / f"{source.name}_conc_flowtest_{int(time.time())}"
+    out_dir = Path(out_dir).expanduser().resolve()
+    concs = [int(c) for c in str(args.concs).split(",") if c.strip()]
+
+    # Single-node: point the multi-node state file at a (non-existent) path in
+    # the test dir so is_multi_node() resolves cleanly to False (the optimizer
+    # normally binds this per-session; a standalone script must set it).
+    os.environ.setdefault("INFERENCE_OPTIMIZER_NODES", "1")
+    os.environ["MULTI_NODE_STATE_FILE"] = str(out_dir / "multi_node_state.json")
+
+    print(f"[flowtest] source session : {source}")
+    print(f"[flowtest] test session   : {out_dir}")
+    print(f"[flowtest] CONC ladder     : {concs}  (descending single-server reuse)")
+
+    _prepare_test_session(source, out_dir)
+
+    started = time.time()
+    payload = asyncio.run(_run(out_dir, concs, args.variant_timeout_sec))
+    print(f"\n[flowtest] run_conc_sweep finished in {time.time() - started:.1f}s; status={payload.get('status')}")
+
+    # Locate the sweep workspace (runs/conc_sweep/<task_id>) for boot counting.
+    cs_root = runs_root(out_dir) / "conc_sweep"
+    sweep_workspaces = sorted(cs_root.glob("conc_sweep_*"), key=lambda p: p.stat().st_mtime)
+    sweep_ws = sweep_workspaces[-1] if sweep_workspaces else cs_root
+
+    survived = _analyze(payload, sweep_ws)
+
+    # Complete the designed flow: render the plot from the produced artifact.
+    summary_json = reports_dir(out_dir) / "conc_sweep_summary.json"
+    png_out = reports_dir(out_dir) / "conc_sweep_curve.png"
+    if summary_json.is_file():
+        result = render_conc_sweep_curve(
+            summary_json,
+            png_out,
+            model_label=str(payload.get("session_id") or "Qwen3-8B"),
+            gpu_label=os.environ.get("GPU_TYPE", "mi355x").upper(),
+            tp=int(payload.get("tp") or 1),
+            isl=int(payload.get("isl") or 0),
+            osl=int(payload.get("osl") or 0),
+            draw_ceiling=True,
+        )
+        if result is not None:
+            print(f"[flowtest] plot rendered  : {result}")
+        else:
+            print("[flowtest] plot skipped (no valid data / matplotlib unavailable)")
+    print(f"[flowtest] artifact json  : {summary_json}")
+
+    return 0 if survived else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/hyperloom/inference_optimizer/cli/parser.py
+++ b/src/hyperloom/inference_optimizer/cli/parser.py
@@ -1137,8 +1137,8 @@ def _build_parser() -> argparse.ArgumentParser:
         "--conc-sweep-concs",
         dest="conc_sweep_concs",
         type=str,
-        default="1,2,4,8,16,32,64,128",
-        help="Comma-separated CONC ladder for --enable-conc-sweep. Default 1,2,4,8,16,32,64,128.",
+        default="256,128,64,32,16,8,4,2",
+        help="Comma-separated CONC ladder for --enable-conc-sweep. Default 256,128,64,32,16,8,4,2 (high-to-low for single-server arm reuse).",
     )
     opt.add_argument(
         "--conc-sweep-timeout-sec",

--- a/src/hyperloom/inference_optimizer/tests/test_cli_conc_sweep_default.py
+++ b/src/hyperloom/inference_optimizer/tests/test_cli_conc_sweep_default.py
@@ -1,6 +1,6 @@
 # Copyright Advanced Micro Devices, Inc. All rights reserved.
 
-"""Regression tests pinning the ``--enable-conc-sweep`` default to True."""
+"""Regression tests pinning the ``--enable-conc-sweep`` defaults."""
 
 from __future__ import annotations
 
@@ -62,3 +62,38 @@ def test_cli_rejects_no_baseline_double_run_flag(monkeypatch: pytest.MonkeyPatch
     with pytest.raises(SystemExit) as exc_info:
         _parse("--no-baseline-double-run")
     assert exc_info.value.code == 2
+
+
+_EXPECTED_CONCS = [256, 128, 64, 32, 16, 8, 4, 2]
+_EXPECTED_CONCS_STR = "256,128,64,32,16,8,4,2"
+
+
+def test_shared_state_default_concs():
+    """SharedState default ladder must be high-to-low for single-server arm reuse."""
+    state = SharedState()
+    assert state.conc_sweep_concs == _EXPECTED_CONCS, (
+        f"SharedState.conc_sweep_concs default mismatch. "
+        f"Expected {_EXPECTED_CONCS}, got {state.conc_sweep_concs}. "
+        "Update all three sources: DEFAULT_CONCS, parser.py, shared_state.py."
+    )
+
+
+def test_cli_default_concs():
+    """CLI --conc-sweep-concs default must match DEFAULT_CONCS."""
+    ns = _parse()
+    assert ns.conc_sweep_concs == _EXPECTED_CONCS_STR
+
+
+def test_conc_sweep_module_default_concs():
+    """conc_sweep.DEFAULT_CONCS must be kept in sync with CLI/state defaults."""
+    from hyperloom.orchestrator.kernel.conc_sweep import DEFAULT_CONCS
+
+    assert DEFAULT_CONCS == _EXPECTED_CONCS, (
+        f"DEFAULT_CONCS mismatch: expected {_EXPECTED_CONCS}, got {DEFAULT_CONCS}"
+    )
+
+
+def test_cli_custom_concs():
+    """Custom --conc-sweep-concs is parsed as a raw string (parsing happens in run_optimize)."""
+    ns = _parse("--conc-sweep-concs", "4,8,16")
+    assert ns.conc_sweep_concs == "4,8,16"

--- a/src/hyperloom/inference_optimizer/tests/test_conc_sweep.py
+++ b/src/hyperloom/inference_optimizer/tests/test_conc_sweep.py
@@ -20,9 +20,14 @@ from hyperloom.orchestrator.actions.executors._grid_runner import (
 from hyperloom.orchestrator.kernel.conc_sweep import (
     DEFAULT_CONCS,
     DEFAULT_TOTAL_BUDGET_SEC,
+    _build_arm_grid,
     _build_comparison,
     _build_grid,
+    _conc_sweep_single_server_enabled,
+    _flush_conc_sweep_report,
+    _flush_partial_conc_sweep_report,
     _has_optimization,
+    _order_concs_desc,
     run_conc_sweep,
 )
 from hyperloom.orchestrator.state.shared_state import SharedState
@@ -724,8 +729,8 @@ def test_run_conc_sweep_does_not_touch_final_json(
 
 
 def test_default_concs_is_powers_of_two():
-    """Doc-pin: default ladder is [1,2,4,8,16,32,64,128]."""
-    assert DEFAULT_CONCS == [1, 2, 4, 8, 16, 32, 64, 128]
+    """Doc-pin: default ladder is [256,128,64,32,16,8,4,2] (high-to-low for single-server reuse)."""
+    assert DEFAULT_CONCS == [256, 128, 64, 32, 16, 8, 4, 2]
 
 
 def test_default_total_budget_is_two_and_half_hours():
@@ -1197,3 +1202,861 @@ def test_conc_sweep_phase_singleton_denies_after_auto_enqueue():
         {"params": {}},
         intent_kind="propose_action",
     )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Change 2 extras: _order_concs_desc / _build_arm_grid
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_order_concs_desc_deduplicates_and_sorts():
+    assert _order_concs_desc([4, 1, 16, 4, 2]) == [16, 4, 2, 1]
+
+
+def test_order_concs_desc_already_sorted():
+    assert _order_concs_desc([8, 4, 2]) == [8, 4, 2]
+
+
+def test_order_concs_desc_single():
+    assert _order_concs_desc([7]) == [7]
+
+
+def test_build_arm_grid_single_arm_descending():
+    grid = _build_arm_grid(
+        "baseline",
+        [64, 32, 16],
+        isl=512,
+        osl=512,
+        num_prompts_factor=5,
+        arm_args="",
+        arm_envs={},
+    )
+    assert [v.name for v in grid] == ["baseline_conc64", "baseline_conc32", "baseline_conc16"]
+    assert grid[0].extra_envs["CONC"] == "64"
+    assert grid[0].extra_envs["RUN_EVAL"] == "false"
+
+
+def test_build_arm_grid_optimized_arm_carries_args():
+    grid = _build_arm_grid(
+        "optimized",
+        [4],
+        isl=1024,
+        osl=512,
+        num_prompts_factor=3,
+        arm_args="--my-flag",
+        arm_envs={"MY_ENV": "1"},
+    )
+    assert len(grid) == 1
+    assert grid[0].extra_server_args == "--my-flag"
+    assert grid[0].extra_envs["MY_ENV"] == "1"
+    assert grid[0].extra_envs["CONC"] == "4"
+    assert int(grid[0].extra_envs["NUM_PROMPTS"]) >= 4
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Change 1: soft switch + arm-major orchestration
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_conc_sweep_single_server_enabled_default(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("INFERENCE_OPTIMIZER_CONC_SWEEP_SINGLE_SERVER", raising=False)
+    assert _conc_sweep_single_server_enabled() is True
+
+
+def test_conc_sweep_single_server_enabled_off(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_CONC_SWEEP_SINGLE_SERVER", "0")
+    assert _conc_sweep_single_server_enabled() is False
+
+
+def test_conc_sweep_single_server_enabled_false_str(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_CONC_SWEEP_SINGLE_SERVER", "false")
+    assert _conc_sweep_single_server_enabled() is False
+
+
+def test_run_conc_sweep_single_server_arm_major_order(
+    session_dir: Path,
+    baseline_yaml: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """In single-server mode optimized arm runs before baseline."""
+    monkeypatch.delenv("INFERENCE_OPTIMIZER_CONC_SWEEP_SINGLE_SERVER", raising=False)
+    state = _make_state(baseline_config_path=str(baseline_yaml))
+    call_log: list[str] = []
+
+    async def _fake_run_grid(*, grid: list[GridVariant], **_kw):
+        for v in grid:
+            call_log.append(v.name)
+        return [_fake_variant(v.name, throughput=100.0, envs=v.extra_envs) for v in grid]
+
+    def _fake_materialize(src, out_dir, **_kw):
+        out = Path(out_dir) / "conc_sweep_base.with_envs.yaml"
+        out.write_text(Path(src).read_text())
+        return out
+
+    with (
+        patch("hyperloom.orchestrator.kernel.conc_sweep.run_grid", side_effect=_fake_run_grid),
+        patch("hyperloom.orchestrator.kernel.conc_sweep.materialize_config_with_envs", side_effect=_fake_materialize),
+    ):
+        payload = asyncio.run(run_conc_sweep(state, session_dir, concs=[4, 16]))
+
+    assert payload["status"] == "succeeded"
+    # optimized_ variants should appear before baseline_ variants.
+    first_opt = next((i for i, n in enumerate(call_log) if n.startswith("optimized_")), None)
+    first_base = next((i for i, n in enumerate(call_log) if n.startswith("baseline_")), None)
+    assert first_opt is not None and first_base is not None
+    assert first_opt < first_base, f"expected optimized before baseline; got {call_log}"
+
+
+def test_run_conc_sweep_single_server_concs_descending(
+    session_dir: Path,
+    baseline_yaml: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """CONCs within each arm are visited highest-to-lowest."""
+    monkeypatch.delenv("INFERENCE_OPTIMIZER_CONC_SWEEP_SINGLE_SERVER", raising=False)
+    state = _make_state(baseline_config_path=str(baseline_yaml))
+    call_log: list[str] = []
+
+    async def _fake_run_grid(*, grid: list[GridVariant], **_kw):
+        for v in grid:
+            call_log.append(v.name)
+        return [_fake_variant(v.name, throughput=100.0, envs=v.extra_envs) for v in grid]
+
+    def _fake_materialize(src, out_dir, **_kw):
+        out = Path(out_dir) / "conc_sweep_base.with_envs.yaml"
+        out.write_text(Path(src).read_text())
+        return out
+
+    with (
+        patch("hyperloom.orchestrator.kernel.conc_sweep.run_grid", side_effect=_fake_run_grid),
+        patch("hyperloom.orchestrator.kernel.conc_sweep.materialize_config_with_envs", side_effect=_fake_materialize),
+    ):
+        asyncio.run(run_conc_sweep(state, session_dir, concs=[1, 4, 16]))
+
+    opt_calls = [n for n in call_log if n.startswith("optimized_")]
+    opt_concs = [int(n.split("conc")[1]) for n in opt_calls]
+    assert opt_concs == sorted(opt_concs, reverse=True), f"expected descending, got {opt_concs}"
+
+    base_calls = [n for n in call_log if n.startswith("baseline_")]
+    base_concs = [int(n.split("conc")[1]) for n in base_calls]
+    assert base_concs == sorted(base_concs, reverse=True), f"expected descending, got {base_concs}"
+
+
+def test_run_conc_sweep_legacy_path_with_env_off(
+    session_dir: Path,
+    baseline_yaml: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """INFERENCE_OPTIMIZER_CONC_SWEEP_SINGLE_SERVER=0 uses the legacy CONC-major path."""
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_CONC_SWEEP_SINGLE_SERVER", "0")
+    state = _make_state(baseline_config_path=str(baseline_yaml))
+    call_log: list[str] = []
+
+    async def _fake_run_grid(*, grid: list[GridVariant], **_kw):
+        for v in grid:
+            call_log.append(v.name)
+        return [_fake_variant(v.name, throughput=100.0, envs=v.extra_envs) for v in grid]
+
+    def _fake_materialize(src, out_dir, **_kw):
+        out = Path(out_dir) / "conc_sweep_base.with_envs.yaml"
+        out.write_text(Path(src).read_text())
+        return out
+
+    with (
+        patch("hyperloom.orchestrator.kernel.conc_sweep.run_grid", side_effect=_fake_run_grid),
+        patch("hyperloom.orchestrator.kernel.conc_sweep.materialize_config_with_envs", side_effect=_fake_materialize),
+    ):
+        asyncio.run(run_conc_sweep(state, session_dir, concs=[4, 16]))
+
+    # Legacy: CONC-major interleaving → baseline_ and optimized_ are interleaved per CONC.
+    # The first two calls should be the same CONC (one arm each).
+    assert len(call_log) == 4
+    first_conc = call_log[0].split("conc")[1]
+    second_conc = call_log[1].split("conc")[1]
+    assert first_conc == second_conc, f"expected CONC-major interleaving; got {call_log}"
+
+
+def test_run_conc_sweep_partial_sweep_writes_incremental_checkpoint(
+    session_dir: Path,
+    baseline_yaml: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """After each conc point a partial checkpoint is written to disk."""
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_CONC_SWEEP_SINGLE_SERVER", "0")
+    state = _make_state(baseline_config_path=str(baseline_yaml))
+    checkpoints: list[dict] = []
+    json_path = session_dir / "reports" / "conc_sweep_summary.json"
+
+    real_flush = _flush_partial_conc_sweep_report
+
+    def _intercept_flush(*args, **kwargs):
+        real_flush(*args, **kwargs)
+        if json_path.exists():
+            try:
+                checkpoints.append(json.loads(json_path.read_text()))
+            except Exception:
+                pass
+
+    async def _fake_run_grid(*, grid: list[GridVariant], **_kw):
+        return [_fake_variant(v.name, throughput=100.0, envs=v.extra_envs) for v in grid]
+
+    def _fake_materialize(src, out_dir, **_kw):
+        out = Path(out_dir) / "conc_sweep_base.with_envs.yaml"
+        out.write_text(Path(src).read_text())
+        return out
+
+    with (
+        patch("hyperloom.orchestrator.kernel.conc_sweep.run_grid", side_effect=_fake_run_grid),
+        patch("hyperloom.orchestrator.kernel.conc_sweep.materialize_config_with_envs", side_effect=_fake_materialize),
+        patch("hyperloom.orchestrator.kernel.conc_sweep._flush_partial_conc_sweep_report", side_effect=_intercept_flush),
+    ):
+        asyncio.run(run_conc_sweep(state, session_dir, concs=[4, 16], write_reports=True))
+
+    # Intermediate checkpoints should carry status=in_progress.
+    assert any(c.get("status") == "in_progress" for c in checkpoints), (
+        f"no in_progress checkpoint found; checkpoints={[c.get('status') for c in checkpoints]}"
+    )
+    # Final file should have a terminal status.
+    final = json.loads(json_path.read_text())
+    assert final["status"] in {"succeeded", "failed", "skipped"}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Change 5: _flush_conc_sweep_report / _flush_partial_conc_sweep_report
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_flush_conc_sweep_report_writes_json_and_csv(session_dir: Path):
+    rdir = session_dir / "reports"
+    rdir.mkdir(parents=True, exist_ok=True)
+    json_path = rdir / "conc_sweep_summary.json"
+    csv_path = rdir / "conc_sweep_raw.csv"
+    payload: dict[str, Any] = {
+        "schema_version": "1.0",
+        "status": "succeeded",
+        "report_json_path": str(json_path),
+        "report_csv_path": str(csv_path),
+        "baseline": {"points": [{"arm": "baseline", "conc": 4, "status": "succeeded", "output_throughput": 100.0}]},
+        "optimized": {"points": []},
+    }
+    _flush_conc_sweep_report(payload, session_dir)
+    assert json_path.exists()
+    assert csv_path.exists()
+    loaded = json.loads(json_path.read_text())
+    assert loaded["status"] == "succeeded"
+    rows = list(csv.DictReader(csv_path.open()))
+    assert len(rows) == 1
+    assert rows[0]["arm"] == "baseline"
+
+
+def test_flush_conc_sweep_report_is_atomic(session_dir: Path, monkeypatch: pytest.MonkeyPatch):
+    """_flush_conc_sweep_report silently catches IO errors."""
+    rdir = session_dir / "reports"
+    rdir.mkdir(parents=True, exist_ok=True)
+    json_path = rdir / "conc_sweep_summary.json"
+    csv_path = rdir / "conc_sweep_raw.csv"
+    payload = {
+        "status": "succeeded",
+        "report_json_path": str(json_path),
+        "report_csv_path": str(csv_path),
+        "baseline": {"points": []},
+        "optimized": {"points": []},
+    }
+    # Should not raise even if atomic_write_text itself raises.
+    from hyperloom.common import io as _common_io
+    monkeypatch.setattr(_common_io, "atomic_write_text", lambda *a, **k: (_ for _ in ()).throw(OSError("disk full")))
+    _flush_conc_sweep_report(payload, session_dir)  # must not raise
+
+
+def test_flush_partial_conc_sweep_report_marks_in_progress(session_dir: Path):
+    """_flush_partial_conc_sweep_report writes status=in_progress."""
+    rdir = session_dir / "reports"
+    rdir.mkdir(parents=True, exist_ok=True)
+    json_path = rdir / "conc_sweep_summary.json"
+    csv_path = rdir / "conc_sweep_raw.csv"
+    state = _make_state()
+    result = _fake_variant("baseline_conc4", throughput=100.0, envs={"CONC": "4", "ISL": "512", "OSL": "512", "NUM_PROMPTS": "20"})
+    _flush_partial_conc_sweep_report(
+        results=[result],
+        state=state,
+        session_dir=session_dir,
+        json_path=json_path,
+        csv_path=csv_path,
+        concs=[4, 8],
+        isl=512,
+        osl=512,
+        opt_args="--x",
+        opt_envs={},
+        workspace=session_dir / "ws",
+        started_at=0.0,
+        total_budget_sec=9000,
+        has_budget=True,
+        budget_exhausted=False,
+        budget_skip_reason="",
+        budget_remaining_sec=None,
+        partial=True,
+    )
+    assert json_path.exists()
+    loaded = json.loads(json_path.read_text())
+    assert loaded["status"] == "in_progress"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Change 4: session deadline detection
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_run_conc_sweep_stops_on_closing_phase(
+    session_dir: Path,
+    baseline_yaml: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """When state.closing_phase is True, remaining variants are skipped."""
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_CONC_SWEEP_SINGLE_SERVER", "0")
+    state = _make_state(baseline_config_path=str(baseline_yaml))
+    calls: list[str] = []
+
+    async def _fake_run_grid(*, grid: list[GridVariant], **_kw):
+        for v in grid:
+            calls.append(v.name)
+        # Flip closing_phase after first call so remaining are skipped.
+        state.closing_phase = True
+        return [_fake_variant(v.name, throughput=100.0, envs=v.extra_envs) for v in grid]
+
+    def _fake_materialize(src, out_dir, **_kw):
+        out = Path(out_dir) / "conc_sweep_base.with_envs.yaml"
+        out.write_text(Path(src).read_text())
+        return out
+
+    with (
+        patch("hyperloom.orchestrator.kernel.conc_sweep.run_grid", side_effect=_fake_run_grid),
+        patch("hyperloom.orchestrator.kernel.conc_sweep.materialize_config_with_envs", side_effect=_fake_materialize),
+    ):
+        payload = asyncio.run(
+            run_conc_sweep(state, session_dir, concs=[1, 4, 16, 64])
+        )
+
+    all_points = payload["baseline"]["points"] + payload["optimized"]["points"]
+    skipped = [p for p in all_points if p["status"] == "skipped"]
+    assert len(skipped) > 0, "expected some variants to be skipped after closing_phase set"
+    assert payload["budget_exhausted"] is True
+    assert payload["budget_skip_reason"] == "session_deadline_reserve"
+
+
+def test_run_conc_sweep_session_deadline_via_remaining_minutes(
+    session_dir: Path,
+    baseline_yaml: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """When remaining_minutes() returns a tiny value, variants are skipped."""
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_CONC_SWEEP_SINGLE_SERVER", "0")
+    state = _make_state(baseline_config_path=str(baseline_yaml))
+    # Force remaining_minutes to return 0 (no budget left).
+    monkeypatch.setattr(type(state), "remaining_minutes", lambda self: 0.0)
+    # Override max_minutes so remaining_minutes is called (>0).
+    state.max_minutes = 60.0
+
+    async def _fake_run_grid(*, grid: list[GridVariant], **_kw):
+        return [_fake_variant(v.name, throughput=100.0, envs=v.extra_envs) for v in grid]
+
+    def _fake_materialize(src, out_dir, **_kw):
+        out = Path(out_dir) / "conc_sweep_base.with_envs.yaml"
+        out.write_text(Path(src).read_text())
+        return out
+
+    with (
+        patch("hyperloom.orchestrator.kernel.conc_sweep.run_grid", side_effect=_fake_run_grid),
+        patch("hyperloom.orchestrator.kernel.conc_sweep.materialize_config_with_envs", side_effect=_fake_materialize),
+    ):
+        payload = asyncio.run(
+            run_conc_sweep(state, session_dir, concs=[1, 4, 16])
+        )
+
+    all_points = payload["baseline"]["points"] + payload["optimized"]["points"]
+    # With remaining=0 and reserve=120s, all points should be skipped.
+    assert all(p["status"] == "skipped" for p in all_points), (
+        f"expected all skipped; statuses={[p['status'] for p in all_points]}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Change 3: plotting
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_render_conc_sweep_curve_no_data_returns_none(tmp_path: Path):
+    from hyperloom.orchestrator.kernel.conc_sweep_plot import render_conc_sweep_curve
+
+    payload = {
+        "baseline": {"points": []},
+        "optimized": {"points": []},
+    }
+    result = render_conc_sweep_curve(payload, tmp_path / "out.png", model_label="M", gpu_label="GPU", tp=1)
+    assert result is None
+
+
+def test_render_conc_sweep_curve_writes_png(tmp_path: Path):
+    pytest.importorskip("matplotlib")
+    from hyperloom.orchestrator.kernel.conc_sweep_plot import render_conc_sweep_curve
+
+    payload = {
+        "baseline": {
+            "points": [
+                {"conc": 16, "output_throughput": 1600.0},
+                {"conc": 4, "output_throughput": 600.0},
+            ]
+        },
+        "optimized": {
+            "points": [
+                {"conc": 16, "output_throughput": 2000.0},
+                {"conc": 4, "output_throughput": 750.0},
+            ]
+        },
+        "roofline_ceiling": {
+            "rows": [
+                {"conc": 4, "t_peak_tok_s": 800.0},
+                {"conc": 16, "t_peak_tok_s": 2500.0},
+            ]
+        },
+    }
+    out_path = tmp_path / "curve.png"
+    result = render_conc_sweep_curve(payload, out_path, model_label="TestModel", gpu_label="MI300X", tp=8)
+    assert result == out_path
+    assert out_path.exists()
+    assert out_path.stat().st_size > 0
+
+
+def test_render_conc_sweep_curve_from_file(tmp_path: Path):
+    pytest.importorskip("matplotlib")
+    from hyperloom.orchestrator.kernel.conc_sweep_plot import render_conc_sweep_curve
+
+    payload = {
+        "baseline": {"points": [{"conc": 8, "output_throughput": 800.0}]},
+        "optimized": {"points": []},
+    }
+    json_file = tmp_path / "summary.json"
+    json_file.write_text(json.dumps(payload))
+    result = render_conc_sweep_curve(json_file, tmp_path / "out.png", tp=1)
+    assert result is not None
+    assert result.exists()
+
+
+def test_render_conc_sweep_curve_missing_matplotlib_returns_none(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """When matplotlib is missing, render_conc_sweep_curve returns None gracefully."""
+    import builtins
+    _real_import = builtins.__import__
+
+    def _mock_import(name, *args, **kwargs):
+        if name == "matplotlib":
+            raise ImportError("no module named matplotlib (mocked)")
+        return _real_import(name, *args, **kwargs)
+
+    from hyperloom.orchestrator.kernel.conc_sweep_plot import render_conc_sweep_curve
+
+    monkeypatch.setattr(builtins, "__import__", _mock_import)
+    result = render_conc_sweep_curve(
+        {"baseline": {"points": [{"conc": 4, "output_throughput": 400.0}]}, "optimized": {"points": []}},
+        tmp_path / "out.png",
+        model_label="M",
+        gpu_label="G",
+        tp=1,
+    )
+    assert result is None
+
+
+def test_format_conc_sweep_curve_section_empty_summary():
+    from hyperloom.orchestrator.actions.executors.report import _format_conc_sweep_curve_section
+
+    assert _format_conc_sweep_curve_section({}) == []
+
+
+def test_format_conc_sweep_curve_section_with_png():
+    from hyperloom.orchestrator.actions.executors.report import _format_conc_sweep_curve_section
+
+    lines = _format_conc_sweep_curve_section({"conc_sweep_curve_png": "reports/conc_sweep_curve.png"})
+    assert any("conc_sweep_curve.png" in line for line in lines)
+    assert any("![" in line for line in lines)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Change 1: single-server Option A boot/reuse path (lifecycle-eligible)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _patch_lifecycle_eligible(monkeypatch: pytest.MonkeyPatch, teardown_log: list[tuple]):
+    """Patch resolve_lifecycle_params → eligible and track teardown calls."""
+    import hyperloom.orchestrator.actions.executors._server_lifecycle as _sl
+
+    def _fake_resolve(_cfg_path):
+        return {"eligible": True, "framework": "vllm", "port": 8888, "reason": ""}
+
+    def _fake_teardown(*, pid_dir, framework, port):
+        teardown_log.append((str(pid_dir), framework, port))
+
+    monkeypatch.setattr(_sl, "resolve_lifecycle_params", _fake_resolve)
+    monkeypatch.setattr(_sl, "teardown_lifecycle_server", _fake_teardown)
+
+
+def test_single_server_option_a_boot_and_reuse(
+    session_dir: Path,
+    baseline_yaml: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Option A: highest-CONC boot round + reuse rounds; one teardown per arm."""
+    monkeypatch.delenv("INFERENCE_OPTIMIZER_CONC_SWEEP_SINGLE_SERVER", raising=False)
+    teardown_log: list[tuple] = []
+    _patch_lifecycle_eligible(monkeypatch, teardown_log)
+
+    state = _make_state(baseline_config_path=str(baseline_yaml))
+    grid_calls: list[dict] = []
+
+    async def _fake_run_grid(*, grid: list[GridVariant], **kw):
+        grid_calls.append(
+            {
+                "name": grid[0].name,
+                "server_lifecycle": kw.get("server_lifecycle"),
+                "server_already_ready": kw.get("server_already_ready"),
+                "preclean_before_run": kw.get("preclean_before_run"),
+            }
+        )
+        return [_fake_variant(v.name, throughput=100.0, envs=v.extra_envs) for v in grid]
+
+    def _fake_materialize(src, out_dir, **_kw):
+        out = Path(out_dir) / "conc_sweep_base.with_envs.yaml"
+        out.write_text(Path(src).read_text())
+        return out
+
+    with (
+        patch("hyperloom.orchestrator.kernel.conc_sweep.run_grid", side_effect=_fake_run_grid),
+        patch("hyperloom.orchestrator.kernel.conc_sweep.materialize_config_with_envs", side_effect=_fake_materialize),
+    ):
+        payload = asyncio.run(run_conc_sweep(state, session_dir, concs=[4, 16, 64]))
+
+    assert payload["status"] == "succeeded"
+    # 2 arms × 3 concs = 6 run_grid calls.
+    assert len(grid_calls) == 6
+    # One teardown per arm.
+    assert len(teardown_log) == 2
+
+    # First call per arm = boot round: highest conc, server_already_ready=False, cleanup=False.
+    opt_calls = [c for c in grid_calls if c["name"].startswith("optimized_")]
+    boot = opt_calls[0]
+    assert boot["name"] == "optimized_conc64", f"boot should be highest conc; got {boot['name']}"
+    assert boot["server_already_ready"] is False
+    assert boot["server_lifecycle"]["cleanup"] is False
+    assert boot["preclean_before_run"] is True
+
+    # Middle reuse round: server_already_ready=True, cleanup=False.
+    mid = opt_calls[1]
+    assert mid["server_already_ready"] is True
+    assert mid["server_lifecycle"]["cleanup"] is False
+    assert mid["preclean_before_run"] is False
+
+    # Last reuse round: cleanup=True.
+    last = opt_calls[-1]
+    assert last["server_lifecycle"]["cleanup"] is True
+
+
+def test_single_server_boot_retry_descend(
+    session_dir: Path,
+    baseline_yaml: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """If the highest-CONC boot fails, the next lower CONC is tried as boot."""
+    monkeypatch.delenv("INFERENCE_OPTIMIZER_CONC_SWEEP_SINGLE_SERVER", raising=False)
+    teardown_log: list[tuple] = []
+    _patch_lifecycle_eligible(monkeypatch, teardown_log)
+
+    state = _make_state(baseline_config_path=str(baseline_yaml))
+    boot_attempts: list[str] = []
+
+    async def _fake_run_grid(*, grid: list[GridVariant], **kw):
+        name = grid[0].name
+        is_boot = kw.get("server_already_ready") is False
+        if is_boot:
+            boot_attempts.append(name)
+            # Fail the very first (highest-conc) boot attempt only.
+            if name.endswith("conc64"):
+                return [_fake_variant(name, throughput=None, status="failed", envs=grid[0].extra_envs, error="boot fail")]
+        return [_fake_variant(v.name, throughput=100.0, envs=v.extra_envs) for v in grid]
+
+    def _fake_materialize(src, out_dir, **_kw):
+        out = Path(out_dir) / "conc_sweep_base.with_envs.yaml"
+        out.write_text(Path(src).read_text())
+        return out
+
+    with (
+        patch("hyperloom.orchestrator.kernel.conc_sweep.run_grid", side_effect=_fake_run_grid),
+        patch("hyperloom.orchestrator.kernel.conc_sweep.materialize_config_with_envs", side_effect=_fake_materialize),
+    ):
+        payload = asyncio.run(run_conc_sweep(state, session_dir, concs=[16, 64]))
+
+    # optimized arm: boot conc64 fails → retries boot at conc16.
+    opt_boots = [b for b in boot_attempts if b.startswith("optimized_")]
+    assert "optimized_conc64" in opt_boots
+    assert "optimized_conc16" in opt_boots
+    assert payload["status"] in {"succeeded", "failed"}
+
+
+def test_single_server_all_boot_fail_falls_back_option_b(
+    session_dir: Path,
+    baseline_yaml: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """When every boot attempt fails, remaining variants run via Option B."""
+    monkeypatch.delenv("INFERENCE_OPTIMIZER_CONC_SWEEP_SINGLE_SERVER", raising=False)
+    teardown_log: list[tuple] = []
+    _patch_lifecycle_eligible(monkeypatch, teardown_log)
+
+    state = _make_state(baseline_config_path=str(baseline_yaml))
+    option_b_calls: list[str] = []
+
+    async def _fake_run_grid(*, grid: list[GridVariant], **kw):
+        name = grid[0].name
+        # Boot rounds (server_lifecycle set, not already ready) always fail.
+        if kw.get("server_already_ready") is False and kw.get("server_lifecycle"):
+            return [_fake_variant(name, throughput=None, status="failed", envs=grid[0].extra_envs, error="boot fail")]
+        # Option B path = no server_lifecycle kwarg.
+        if kw.get("server_lifecycle") is None:
+            option_b_calls.append(name)
+        return [_fake_variant(v.name, throughput=100.0, envs=v.extra_envs) for v in grid]
+
+    def _fake_materialize(src, out_dir, **_kw):
+        out = Path(out_dir) / "conc_sweep_base.with_envs.yaml"
+        out.write_text(Path(src).read_text())
+        return out
+
+    with (
+        patch("hyperloom.orchestrator.kernel.conc_sweep.run_grid", side_effect=_fake_run_grid),
+        patch("hyperloom.orchestrator.kernel.conc_sweep.materialize_config_with_envs", side_effect=_fake_materialize),
+    ):
+        payload = asyncio.run(run_conc_sweep(state, session_dir, concs=[8, 16]))
+
+    # After all boots fail, Option B (no server_lifecycle) runs the remaining variants.
+    assert len(option_b_calls) > 0, "expected Option B fallback calls"
+    assert payload["status"] in {"succeeded", "failed"}
+
+
+def test_single_server_not_eligible_uses_option_b(
+    session_dir: Path,
+    baseline_yaml: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A non-lifecycle-eligible framework routes straight to Option B."""
+    monkeypatch.delenv("INFERENCE_OPTIMIZER_CONC_SWEEP_SINGLE_SERVER", raising=False)
+    import hyperloom.orchestrator.actions.executors._server_lifecycle as _sl
+
+    monkeypatch.setattr(
+        _sl,
+        "resolve_lifecycle_params",
+        lambda _p: {"eligible": False, "framework": "", "port": 8888, "reason": "not a builtin"},
+    )
+
+    state = _make_state(baseline_config_path=str(baseline_yaml))
+    calls: list[dict] = []
+
+    async def _fake_run_grid(*, grid: list[GridVariant], **kw):
+        calls.append({"name": grid[0].name, "server_lifecycle": kw.get("server_lifecycle")})
+        return [_fake_variant(v.name, throughput=100.0, envs=v.extra_envs) for v in grid]
+
+    def _fake_materialize(src, out_dir, **_kw):
+        out = Path(out_dir) / "conc_sweep_base.with_envs.yaml"
+        out.write_text(Path(src).read_text())
+        return out
+
+    with (
+        patch("hyperloom.orchestrator.kernel.conc_sweep.run_grid", side_effect=_fake_run_grid),
+        patch("hyperloom.orchestrator.kernel.conc_sweep.materialize_config_with_envs", side_effect=_fake_materialize),
+    ):
+        payload = asyncio.run(run_conc_sweep(state, session_dir, concs=[4, 16]))
+
+    assert payload["status"] == "succeeded"
+    # Option B: no server_lifecycle kwarg on any call.
+    assert all(c["server_lifecycle"] is None for c in calls)
+
+
+def test_single_server_reuse_loop_stops_on_closing_phase(
+    session_dir: Path,
+    baseline_yaml: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """closing_phase set mid-arm skips the remaining reuse points."""
+    monkeypatch.delenv("INFERENCE_OPTIMIZER_CONC_SWEEP_SINGLE_SERVER", raising=False)
+    teardown_log: list[tuple] = []
+    _patch_lifecycle_eligible(monkeypatch, teardown_log)
+
+    state = _make_state(baseline_config_path=str(baseline_yaml))
+
+    async def _fake_run_grid(*, grid: list[GridVariant], **kw):
+        # After the boot round (server_already_ready=False), flip closing_phase.
+        if kw.get("server_already_ready") is False:
+            state.closing_phase = True
+        return [_fake_variant(v.name, throughput=100.0, envs=v.extra_envs) for v in grid]
+
+    def _fake_materialize(src, out_dir, **_kw):
+        out = Path(out_dir) / "conc_sweep_base.with_envs.yaml"
+        out.write_text(Path(src).read_text())
+        return out
+
+    with (
+        patch("hyperloom.orchestrator.kernel.conc_sweep.run_grid", side_effect=_fake_run_grid),
+        patch("hyperloom.orchestrator.kernel.conc_sweep.materialize_config_with_envs", side_effect=_fake_materialize),
+    ):
+        payload = asyncio.run(run_conc_sweep(state, session_dir, concs=[4, 16, 64]))
+
+    all_points = payload["baseline"]["points"] + payload["optimized"]["points"]
+    skipped = [p for p in all_points if p["status"] == "skipped"]
+    assert len(skipped) > 0
+    assert payload["budget_skip_reason"] == "session_deadline_reserve"
+
+
+def test_single_server_reuse_exception_recorded_as_failed(
+    session_dir: Path,
+    baseline_yaml: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """An exception in a reuse round is captured as a failed point, not raised."""
+    monkeypatch.delenv("INFERENCE_OPTIMIZER_CONC_SWEEP_SINGLE_SERVER", raising=False)
+    teardown_log: list[tuple] = []
+    _patch_lifecycle_eligible(monkeypatch, teardown_log)
+
+    state = _make_state(baseline_config_path=str(baseline_yaml))
+
+    async def _fake_run_grid(*, grid: list[GridVariant], **kw):
+        # Boot round succeeds; reuse rounds raise.
+        if kw.get("server_already_ready") is True:
+            raise RuntimeError("reuse boom")
+        return [_fake_variant(v.name, throughput=100.0, envs=v.extra_envs) for v in grid]
+
+    def _fake_materialize(src, out_dir, **_kw):
+        out = Path(out_dir) / "conc_sweep_base.with_envs.yaml"
+        out.write_text(Path(src).read_text())
+        return out
+
+    with (
+        patch("hyperloom.orchestrator.kernel.conc_sweep.run_grid", side_effect=_fake_run_grid),
+        patch("hyperloom.orchestrator.kernel.conc_sweep.materialize_config_with_envs", side_effect=_fake_materialize),
+    ):
+        payload = asyncio.run(run_conc_sweep(state, session_dir, concs=[4, 16]))
+
+    all_points = payload["baseline"]["points"] + payload["optimized"]["points"]
+    failed = [p for p in all_points if p["status"] == "failed"]
+    # Each arm: boot(conc16) ok, reuse(conc4) raises → at least 2 failed points.
+    assert len(failed) >= 2
+    assert any((p.get("error_class") or "").startswith("single_server_reuse") for p in failed)
+
+
+def test_single_server_reuse_loop_budget_exhausted(
+    session_dir: Path,
+    baseline_yaml: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Task budget exhausted mid-arm skips remaining reuse points."""
+    monkeypatch.delenv("INFERENCE_OPTIMIZER_CONC_SWEEP_SINGLE_SERVER", raising=False)
+    teardown_log: list[tuple] = []
+    _patch_lifecycle_eligible(monkeypatch, teardown_log)
+
+    state = _make_state(baseline_config_path=str(baseline_yaml))
+
+    async def _fake_run_grid(*, grid: list[GridVariant], **kw):
+        import time as _t
+
+        # Boot round consumes the whole budget so reuse points get skipped.
+        if kw.get("server_already_ready") is False:
+            _t.sleep(1.2)
+        return [_fake_variant(v.name, throughput=100.0, envs=v.extra_envs) for v in grid]
+
+    def _fake_materialize(src, out_dir, **_kw):
+        out = Path(out_dir) / "conc_sweep_base.with_envs.yaml"
+        out.write_text(Path(src).read_text())
+        return out
+
+    with (
+        patch("hyperloom.orchestrator.kernel.conc_sweep.run_grid", side_effect=_fake_run_grid),
+        patch("hyperloom.orchestrator.kernel.conc_sweep.materialize_config_with_envs", side_effect=_fake_materialize),
+    ):
+        payload = asyncio.run(
+            run_conc_sweep(
+                state,
+                session_dir,
+                concs=[4, 16, 64],
+                variant_timeout_sec=1,
+                total_budget_sec=2,
+            )
+        )
+
+    all_points = payload["baseline"]["points"] + payload["optimized"]["points"]
+    skipped = [p for p in all_points if p["status"] == "skipped"]
+    assert len(skipped) > 0
+    assert payload["budget_exhausted"] is True
+
+
+def test_single_server_boot_exception_falls_back(
+    session_dir: Path,
+    baseline_yaml: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A boot round raising an exception is caught and boot-retry-descend continues."""
+    monkeypatch.delenv("INFERENCE_OPTIMIZER_CONC_SWEEP_SINGLE_SERVER", raising=False)
+    teardown_log: list[tuple] = []
+    _patch_lifecycle_eligible(monkeypatch, teardown_log)
+
+    state = _make_state(baseline_config_path=str(baseline_yaml))
+
+    async def _fake_run_grid(*, grid: list[GridVariant], **kw):
+        name = grid[0].name
+        # Highest-conc boot raises; lower-conc boot succeeds.
+        if kw.get("server_already_ready") is False and name.endswith("conc64"):
+            raise RuntimeError("boot boom")
+        return [_fake_variant(v.name, throughput=100.0, envs=v.extra_envs) for v in grid]
+
+    def _fake_materialize(src, out_dir, **_kw):
+        out = Path(out_dir) / "conc_sweep_base.with_envs.yaml"
+        out.write_text(Path(src).read_text())
+        return out
+
+    with (
+        patch("hyperloom.orchestrator.kernel.conc_sweep.run_grid", side_effect=_fake_run_grid),
+        patch("hyperloom.orchestrator.kernel.conc_sweep.materialize_config_with_envs", side_effect=_fake_materialize),
+    ):
+        payload = asyncio.run(run_conc_sweep(state, session_dir, concs=[16, 64]))
+
+    all_points = payload["baseline"]["points"] + payload["optimized"]["points"]
+    # conc64 boot exception → recorded as failed; conc16 boots and succeeds.
+    failed = [p for p in all_points if p["status"] == "failed" and p["conc"] == 64]
+    assert len(failed) >= 1
+    assert any((p.get("error_class") or "").startswith("single_server_boot") for p in failed)
+
+
+def test_single_server_pre_arm_skip_on_closing_phase(
+    session_dir: Path,
+    baseline_yaml: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """closing_phase set before the sweep skips every arm's variants."""
+    monkeypatch.delenv("INFERENCE_OPTIMIZER_CONC_SWEEP_SINGLE_SERVER", raising=False)
+    teardown_log: list[tuple] = []
+    _patch_lifecycle_eligible(monkeypatch, teardown_log)
+
+    state = _make_state(baseline_config_path=str(baseline_yaml))
+    state.closing_phase = True
+    ran: list[str] = []
+
+    async def _fake_run_grid(*, grid: list[GridVariant], **_kw):
+        ran.append(grid[0].name)
+        return [_fake_variant(v.name, throughput=100.0, envs=v.extra_envs) for v in grid]
+
+    def _fake_materialize(src, out_dir, **_kw):
+        out = Path(out_dir) / "conc_sweep_base.with_envs.yaml"
+        out.write_text(Path(src).read_text())
+        return out
+
+    with (
+        patch("hyperloom.orchestrator.kernel.conc_sweep.run_grid", side_effect=_fake_run_grid),
+        patch("hyperloom.orchestrator.kernel.conc_sweep.materialize_config_with_envs", side_effect=_fake_materialize),
+    ):
+        payload = asyncio.run(run_conc_sweep(state, session_dir, concs=[4, 16]))
+
+    # No run_grid calls; all variants skipped before any arm starts.
+    assert ran == []
+    all_points = payload["baseline"]["points"] + payload["optimized"]["points"]
+    assert all(p["status"] == "skipped" for p in all_points)
+    assert payload["budget_skip_reason"] == "session_deadline_reserve"

--- a/src/hyperloom/orchestrator/actions/executors/report.py
+++ b/src/hyperloom/orchestrator/actions/executors/report.py
@@ -1008,7 +1008,7 @@ def _render_conc_sweep_curve_for_report(
         tp=tp,
         isl=isl,
         osl=osl,
-        draw_ceiling=True,
+        draw_ceiling=False,
     )
 
 

--- a/src/hyperloom/orchestrator/actions/executors/report.py
+++ b/src/hyperloom/orchestrator/actions/executors/report.py
@@ -571,6 +571,8 @@ def _format_md(summary: dict[str, Any]) -> str:
     if ext:
         lines.extend(_format_external_baseline_section(ext))
 
+    lines.extend(_format_conc_sweep_curve_section(summary))
+
     return "\n".join(lines)
 
 
@@ -917,6 +919,99 @@ def _format_external_baseline_section(ext: dict[str, Any]) -> list[str]:
     return lines
 
 
+def _format_conc_sweep_curve_section(summary: dict[str, Any]) -> list[str]:
+    """Render the concurrency-sweep curve section in the Markdown report.
+
+    Emits an embedded image reference when ``conc_sweep_curve_png`` is
+    present in the summary, otherwise returns an empty list.
+
+    Args:
+        summary: The full report summary dict (may contain
+            ``conc_sweep_curve_png``).
+
+    Returns:
+        Markdown lines for the curve section, or ``[]`` when no curve exists.
+    """
+    png_rel = summary.get("conc_sweep_curve_png")
+    if not png_rel:
+        return []
+    lines: list[str] = []
+    lines.append("## Concurrency Sweep — Throughput vs Interactivity")
+    lines.append("")
+    lines.append(
+        "Efficiency (tok/s/GPU) vs Interactivity (tok/s/user) across the "
+        "post-optimization concurrency ladder.  "
+        "Dark-red = baseline, orange = optimized."
+    )
+    lines.append("")
+    # Use the relative path so the image renders correctly when the report
+    # directory is the working directory.
+    lines.append(f"![Concurrency sweep curve]({png_rel})")
+    lines.append("")
+    return lines
+
+
+def _render_conc_sweep_curve_for_report(
+    session_dir: Path,
+    output_dir: Path,
+    state: SharedState,
+) -> Path | None:
+    """Render the concurrency-sweep curve PNG into the reports directory.
+
+    Loads the full ``conc_sweep_summary.json`` (not the slim pointer), calls
+    :func:`render_conc_sweep_curve`, and returns the path on success.
+
+    Args:
+        session_dir: Session directory used to locate
+            ``reports/conc_sweep_summary.json``.
+        output_dir: Reports directory where ``conc_sweep_curve.png`` is
+            written.
+        state: Shared state for model/GPU metadata passed to the plotter.
+
+    Returns:
+        Path to the written PNG, or ``None`` when the chart cannot be
+        produced (missing data, missing matplotlib, IO error).
+    """
+    from hyperloom.inference_optimizer.session.session_paths import reports_dir as _reports_dir
+    from hyperloom.orchestrator.kernel.conc_sweep_plot import render_conc_sweep_curve
+
+    json_path = _reports_dir(session_dir) / "conc_sweep_summary.json"
+    if not json_path.exists():
+        return None
+    try:
+        payload = json.loads(json_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        log.debug("report_executor: cannot load conc_sweep_summary.json for plot: %s", exc)
+        return None
+
+    # Quick check: need at least one arm with a non-None output_throughput.
+    def _has_data(arm_key: str) -> bool:
+        pts = (payload.get(arm_key) or {}).get("points") or []
+        return any(p.get("output_throughput") is not None for p in pts)
+
+    if not _has_data("baseline") and not _has_data("optimized"):
+        log.debug("report_executor: conc_sweep_summary has no throughput data — skipping plot")
+        return None
+
+    png_path = output_dir / "conc_sweep_curve.png"
+    tp = int(payload.get("tp") or getattr(state, "tp", 0) or 1)
+    model_label = str(getattr(state, "model_name", "") or "")
+    gpu_label = str(getattr(state, "gpu_type", "") or "").upper()
+    isl = int(payload.get("isl") or 0)
+    osl = int(payload.get("osl") or 0)
+
+    return render_conc_sweep_curve(
+        payload,
+        png_path,
+        model_label=model_label,
+        gpu_label=gpu_label,
+        tp=tp,
+        isl=isl,
+        osl=osl,
+        draw_ceiling=True,
+    )
+
+
 def _load_external_baseline(session_dir: Path) -> dict[str, Any] | None:
     """Best-effort load of ``target_analysis/target_baseline.json``; ``None``
     when missing / unreadable (errors swallowed so a corrupt JSON never
@@ -1189,6 +1284,22 @@ class ReportExecutor:
         cs_pointer = _read_conc_sweep_pointer(session_dir)
         if cs_pointer is not None:
             summary["conc_sweep_summary"] = cs_pointer
+
+        # Best-effort InferenceX-style concurrency sweep plot.
+        conc_sweep_curve_png: Path | None = None
+        try:
+            conc_sweep_curve_png = _render_conc_sweep_curve_for_report(
+                session_dir=session_dir,
+                output_dir=output_dir,
+                state=state,
+            )
+        except Exception:  # noqa: BLE001
+            log.debug("report_executor: conc_sweep curve render failed", exc_info=True)
+        if conc_sweep_curve_png is not None:
+            try:
+                summary["conc_sweep_curve_png"] = conc_sweep_curve_png.relative_to(session_dir).as_posix()
+            except ValueError:
+                summary["conc_sweep_curve_png"] = conc_sweep_curve_png.as_posix()
 
         json_path = output_dir / "final.json"
         md_path = output_dir / "final.md"

--- a/src/hyperloom/orchestrator/kernel/conc_sweep.py
+++ b/src/hyperloom/orchestrator/kernel/conc_sweep.py
@@ -639,11 +639,13 @@ async def _sweep_one_arm_single_server(  # noqa: PLR0913
     pid_dir.mkdir(parents=True, exist_ok=True)
 
     # Resolve lifecycle params (port, framework) from the materialized config.
+    lc_reason = "resolve_failed"
     try:
         lc_params = resolve_lifecycle_params(base_yaml_path)
         port = int(lc_params.get("port") or 8888)
         framework = str(lc_params.get("framework") or "")
         lc_eligible = bool(lc_params.get("eligible"))
+        lc_reason = str(lc_params.get("reason") or "")
     except Exception:  # noqa: BLE001
         log.debug("conc_sweep single-server: resolve_lifecycle_params failed", exc_info=True)
         lc_eligible = False
@@ -657,7 +659,7 @@ async def _sweep_one_arm_single_server(  # noqa: PLR0913
             "conc_sweep single-server: arm=%s not lifecycle-eligible (%s); "
             "using per-variant server restart (Option B)",
             arm_name,
-            lc_params.get("reason") if lc_eligible is False else "resolve_failed",
+            lc_reason,
         )
         return await _sweep_arm_option_b(
             arm_name=arm_name,

--- a/src/hyperloom/orchestrator/kernel/conc_sweep.py
+++ b/src/hyperloom/orchestrator/kernel/conc_sweep.py
@@ -17,6 +17,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from hyperloom.common import io as _common_io
 from hyperloom.common.timeutil import utc_now_compact
 from hyperloom.inference_optimizer.session.session_paths import reports_dir, runs_root
 from ..actions.executors._grid_runner import (
@@ -45,7 +46,7 @@ log = logging.getLogger(__name__)
 SCHEMA_VERSION = "1.0"
 
 # Default ladder (override via ``--conc-sweep-concs``).
-DEFAULT_CONCS: list[int] = [1, 2, 4, 8, 16, 32, 64, 128]
+DEFAULT_CONCS: list[int] = [256, 128, 64, 32, 16, 8, 4, 2]
 
 # Multiplier applied to each CONC for NUM_PROMPTS.
 DEFAULT_NUM_PROMPTS_FACTOR = 5
@@ -465,6 +466,793 @@ def _build_roofline_ceiling(
     }
 
 
+def _conc_sweep_single_server_enabled() -> bool:
+    """Return True unless ``INFERENCE_OPTIMIZER_CONC_SWEEP_SINGLE_SERVER=0``.
+
+    The soft switch allows operators to fall back to the legacy per-variant
+    server-restart path without code changes.
+
+    Returns:
+        ``True`` when single-server arm reuse is enabled (the default).
+    """
+    val = os.environ.get("INFERENCE_OPTIMIZER_CONC_SWEEP_SINGLE_SERVER", "1").strip().lower()
+    return val not in {"0", "false", "no", "off"}
+
+
+def _order_concs_desc(concs: list[int]) -> list[int]:
+    """Return a strictly descending, deduplicated copy of the CONC ladder.
+
+    Descending order is required for single-server arm sweeps: the server is
+    booted with the highest (most demanding) concurrency first so it can handle
+    all lower values without restart.
+
+    Args:
+        concs: Requested concurrency ladder (any order, may contain duplicates).
+
+    Returns:
+        A deduplicated list sorted in strictly descending order.
+    """
+    return sorted(set(concs), reverse=True)
+
+
+def _build_arm_grid(
+    arm_name: str,
+    concs_desc: list[int],
+    *,
+    isl: int,
+    osl: int,
+    num_prompts_factor: int,
+    arm_args: str,
+    arm_envs: dict[str, str],
+) -> list[GridVariant]:
+    """Build a single-arm grid in descending CONC order.
+
+    Args:
+        arm_name: Arm label (e.g. ``baseline`` or ``optimized``).
+        concs_desc: Concurrency values in strictly descending order.
+        isl: Input sequence length.
+        osl: Output sequence length.
+        num_prompts_factor: Multiplier applied to each CONC for NUM_PROMPTS.
+        arm_args: Extra server args for this arm.
+        arm_envs: Extra environment variables for this arm.
+
+    Returns:
+        List of grid variants for the arm, one per CONC in descending order.
+    """
+    skip_eval = not sweep_run_eval_enabled()
+    out: list[GridVariant] = []
+    for conc in concs_desc:
+        num_prompts = max(int(conc) * int(num_prompts_factor), int(conc))
+        envs = dict(arm_envs)
+        envs.update(
+            {
+                "CONC": str(conc),
+                "ISL": str(isl),
+                "OSL": str(osl),
+                "NUM_PROMPTS": str(num_prompts),
+            }
+        )
+        if skip_eval:
+            envs["RUN_EVAL"] = "false"
+        out.append(
+            GridVariant(
+                name=f"{arm_name}_conc{conc}",
+                extra_server_args=arm_args,
+                extra_envs=envs,
+                note=f"arm={arm_name} conc={conc} isl={isl} osl={osl}",
+            )
+        )
+    return out
+
+
+async def _sweep_one_arm_single_server(  # noqa: PLR0913
+    arm_name: str,
+    concs_desc: list[int],
+    *,
+    isl: int,
+    osl: int,
+    num_prompts_factor: int,
+    arm_args: str,
+    arm_envs: dict[str, str],
+    base_yaml_path: Path,
+    workspace: Path,
+    model_path: str,
+    gpu_type: str,
+    variant_timeout_sec: int,
+    soft_deadline_sec: float | None,
+    deadline: float | None,
+    state: SharedState,
+    session_dir: Path,
+    json_path: Path,
+    csv_path: Path,
+    started_at: float,
+    total_budget_sec: int,
+    has_budget: bool,
+    opt_args: str,
+    opt_envs: dict[str, str],
+    _all_results_ref: list[VariantResult],
+    _budget_state: dict[str, Any],
+) -> list[VariantResult]:
+    """Sweep one arm across all CONC values reusing a single persistent server.
+
+    Boots the server on the highest CONC (Option A), then reuses it for all
+    lower CONCs.  If boot fails, retries with the next lower CONC
+    (boot-retry-descend).  Falls back to the legacy per-variant server-restart
+    path (Option B) when all boot retries are exhausted.
+
+    The shared ``_all_results_ref`` list is mutated in place so incremental
+    checkpoints always see the latest cross-arm view.
+
+    Args:
+        arm_name: Label for this arm (``baseline`` or ``optimized``).
+        concs_desc: Concurrency ladder in strictly descending order.
+        isl: Input sequence length.
+        osl: Output sequence length.
+        num_prompts_factor: CONC multiplier for NUM_PROMPTS.
+        arm_args: Extra server args for this arm.
+        arm_envs: Extra environment variables for this arm.
+        base_yaml_path: Materialized base Magpie YAML path.
+        workspace: Per-sweep workspace root.
+        model_path: Resolved model path string.
+        gpu_type: Resolved GPU type string.
+        variant_timeout_sec: Per-variant hard timeout in seconds.
+        soft_deadline_sec: Session-clamped soft deadline in seconds, or None.
+        state: Shared run state (for incremental checkpoint metadata).
+        session_dir: Session directory (for incremental checkpoints).
+        json_path: Pre-resolved JSON report path.
+        csv_path: Pre-resolved CSV report path.
+        started_at: Wall-clock start of the overall sweep (for elapsed_sec).
+        total_budget_sec: Configured total budget in seconds.
+        has_budget: Whether budget tracking is active.
+        opt_args: Optimized server args (for payload metadata).
+        opt_envs: Optimized server env vars (for payload metadata).
+        _all_results_ref: Shared list of all results collected across arms;
+            mutated in place so incremental flushes have the full cross-arm
+            picture.
+        _budget_state: Mutable dict carrying budget flags (``budget_exhausted``,
+            ``budget_skip_reason``, ``budget_remaining_sec``) shared with the
+            caller so the main function can inspect the final budget status.
+
+    Returns:
+        List of VariantResult for this arm (one per CONC).
+    """
+    from ..actions.executors._server_lifecycle import (
+        resolve_lifecycle_params,
+        teardown_lifecycle_server,
+    )
+
+    arm_results: list[VariantResult] = []
+    grid = _build_arm_grid(
+        arm_name,
+        concs_desc,
+        isl=isl,
+        osl=osl,
+        num_prompts_factor=num_prompts_factor,
+        arm_args=arm_args,
+        arm_envs=arm_envs,
+    )
+    if not grid:
+        return arm_results
+
+    # Shared pid_dir for server reuse across all CONC variants in this arm.
+    pid_dir = workspace / f"server_{arm_name}"
+    pid_dir.mkdir(parents=True, exist_ok=True)
+
+    # Resolve lifecycle params (port, framework) from the materialized config.
+    try:
+        lc_params = resolve_lifecycle_params(base_yaml_path)
+        port = int(lc_params.get("port") or 8888)
+        framework = str(lc_params.get("framework") or "")
+        lc_eligible = bool(lc_params.get("eligible"))
+    except Exception:  # noqa: BLE001
+        log.debug("conc_sweep single-server: resolve_lifecycle_params failed", exc_info=True)
+        lc_eligible = False
+        port = 8888
+        framework = ""
+
+    if not lc_eligible:
+        # Framework does not support server_lifecycle — fall through to
+        # Option B (per-variant server restart via normal run_grid).
+        log.info(
+            "conc_sweep single-server: arm=%s not lifecycle-eligible (%s); "
+            "using per-variant server restart (Option B)",
+            arm_name,
+            lc_params.get("reason") if lc_eligible is False else "resolve_failed",
+        )
+        return await _sweep_arm_option_b(
+            arm_name=arm_name,
+            grid=grid,
+            base_yaml_path=base_yaml_path,
+            workspace=workspace,
+            model_path=model_path,
+            gpu_type=gpu_type,
+            variant_timeout_sec=variant_timeout_sec,
+            soft_deadline_sec=soft_deadline_sec,
+            deadline=deadline,
+            state=state,
+            session_dir=session_dir,
+            json_path=json_path,
+            csv_path=csv_path,
+            started_at=started_at,
+            total_budget_sec=total_budget_sec,
+            has_budget=has_budget,
+            opt_args=opt_args,
+            opt_envs=opt_envs,
+            _all_results_ref=_all_results_ref,
+            _budget_state=_budget_state,
+        )
+
+    # Boot-retry-descend: try each CONC from highest to lowest until boot succeeds.
+    # Failed higher-CONC boots are tracked locally; they are only committed to the
+    # permanent results when a *lower* CONC eventually boots (they represent genuine
+    # capacity failures, e.g. OOM at that CONC). If every CONC fails to boot, the
+    # whole grid is retried via Option B instead so nothing is double-counted.
+    failed_boots: list[VariantResult] = []
+    boot_idx = 0
+    boot_succeeded = False
+    while boot_idx < len(grid):
+        boot_variant = grid[boot_idx]
+        log.info(
+            "conc_sweep single-server: arm=%s boot attempt %d/%d (conc=%s)",
+            arm_name,
+            boot_idx + 1,
+            len(grid),
+            boot_variant.extra_envs.get("CONC", "?"),
+        )
+        server_lifecycle_boot = {
+            "cleanup": False,
+            "pid_dir": str(pid_dir),
+            "port": port,
+        }
+        try:
+            boot_results = await run_grid(
+                base_yaml_path=base_yaml_path,
+                base_extra_args="",
+                grid=[boot_variant],
+                output_root=workspace,
+                variant_timeout_sec=variant_timeout_sec,
+                model_path=model_path,
+                gpu_type=gpu_type,
+                server_lifecycle=server_lifecycle_boot,
+                server_already_ready=False,
+                preclean_before_run=True,
+                warmup_before_measure=False,
+                soft_deadline_sec=soft_deadline_sec,
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.warning(
+                "conc_sweep single-server: arm=%s boot conc=%s raised %r; trying next lower conc",
+                arm_name,
+                boot_variant.extra_envs.get("CONC", "?"),
+                exc,
+            )
+            boot_results = [
+                VariantResult(
+                    name=boot_variant.name,
+                    extra_server_args=boot_variant.extra_server_args,
+                    extra_envs=dict(boot_variant.extra_envs),
+                    status="failed",
+                    error=f"single_server_boot_exception: {exc}",
+                    error_class="single_server_boot_exception",
+                )
+            ]
+
+        br = boot_results[0] if boot_results else None
+        boot_failed = br is None or br.status in {"failed", "skipped"}
+
+        if boot_failed:
+            # Ensure server is torn down before retrying at a lower CONC.
+            try:
+                teardown_lifecycle_server(pid_dir=pid_dir, framework=framework, port=port)
+            except Exception:  # noqa: BLE001
+                pass
+            failed_boots.append(br or VariantResult(
+                name=boot_variant.name,
+                extra_server_args=boot_variant.extra_server_args,
+                extra_envs=dict(boot_variant.extra_envs),
+                status="failed",
+                error="single_server_boot_failed",
+                error_class="single_server_boot_failed",
+            ))
+            boot_idx += 1
+            continue
+
+        # Boot succeeded (br is not None here — boot_failed guarded above).
+        assert br is not None
+        boot_succeeded = True
+        # Commit the higher-CONC failed boots (genuine capacity failures) first.
+        for fb in failed_boots:
+            arm_results.append(fb)
+            _all_results_ref.append(fb)
+        arm_results.append(br)
+        _all_results_ref.append(br)
+        # Incremental flush after boot point.
+        _maybe_flush(
+            state=state,
+            session_dir=session_dir,
+            json_path=json_path,
+            csv_path=csv_path,
+            all_results=_all_results_ref,
+            concs=list(concs_desc),
+            isl=isl,
+            osl=osl,
+            opt_args=opt_args,
+            opt_envs=opt_envs,
+            workspace=workspace,
+            started_at=started_at,
+            total_budget_sec=total_budget_sec,
+            has_budget=has_budget,
+            budget_exhausted=_budget_state.get("budget_exhausted", False),
+            budget_skip_reason=_budget_state.get("budget_skip_reason", ""),
+            budget_remaining_sec=_budget_state.get("budget_remaining_sec"),
+        )
+        break
+
+    if not boot_succeeded:
+        # Every CONC failed to boot the persistent server — retry the full grid
+        # via Option B (per-variant restart, no lifecycle) which may succeed where
+        # persistent reuse could not. Its results supersede the failed boot attempts.
+        log.warning(
+            "conc_sweep single-server: arm=%s all boot attempts failed; "
+            "falling back to Option B (per-variant restart) for the full ladder",
+            arm_name,
+        )
+        ob_results = await _sweep_arm_option_b(
+            arm_name=arm_name,
+            grid=grid,
+            base_yaml_path=base_yaml_path,
+            workspace=workspace,
+            model_path=model_path,
+            gpu_type=gpu_type,
+            variant_timeout_sec=variant_timeout_sec,
+            soft_deadline_sec=soft_deadline_sec,
+            deadline=deadline,
+            state=state,
+            session_dir=session_dir,
+            json_path=json_path,
+            csv_path=csv_path,
+            started_at=started_at,
+            total_budget_sec=total_budget_sec,
+            has_budget=has_budget,
+            opt_args=opt_args,
+            opt_envs=opt_envs,
+            _all_results_ref=_all_results_ref,
+            _budget_state=_budget_state,
+        )
+        arm_results.extend(ob_results)
+        return arm_results
+
+    # Server is up: sweep remaining CONCs by reuse.
+    try:
+        reuse_grid = grid[boot_idx + 1:]
+        for r_idx, variant in enumerate(reuse_grid):
+            # Check task-level budget before each reuse point.
+            _reuse_remaining = (deadline - time.time()) if has_budget and deadline is not None else None
+            if has_budget and _reuse_remaining is not None and _reuse_remaining <= 0:
+                _budget_state["budget_exhausted"] = True
+                _budget_state["budget_skip_reason"] = "total_budget_exhausted"
+                _budget_state["budget_remaining_sec"] = max(0.0, float(_reuse_remaining))
+                for v in reuse_grid[r_idx:]:
+                    skip_r = _budget_skip_result(v)
+                    arm_results.append(skip_r)
+                    _all_results_ref.append(skip_r)
+                break
+            if has_budget and _reuse_remaining is not None and _reuse_remaining < float(variant_timeout_sec):
+                _budget_state["budget_exhausted"] = True
+                _budget_state["budget_skip_reason"] = "insufficient_remaining_for_variant"
+                _budget_state["budget_remaining_sec"] = max(0.0, float(_reuse_remaining))
+                for v in reuse_grid[r_idx:]:
+                    skip_r = _budget_skip_result(v)
+                    arm_results.append(skip_r)
+                    _all_results_ref.append(skip_r)
+                break
+            # Check session deadline before each reuse point.
+            if getattr(state, "closing_phase", False) or getattr(state, "stop_reason", ""):
+                _budget_state["budget_exhausted"] = True
+                _budget_state["budget_skip_reason"] = "session_deadline_reserve"
+                _budget_state["budget_remaining_sec"] = 0.0
+                for v in reuse_grid[r_idx:]:
+                    skip_r = _budget_skip_result(v)
+                    arm_results.append(skip_r)
+                    _all_results_ref.append(skip_r)
+                break
+
+            is_last = r_idx == len(reuse_grid) - 1
+            server_lifecycle_reuse = {
+                "cleanup": is_last,
+                "pid_dir": str(pid_dir),
+                "port": port,
+            }
+            try:
+                reuse_results = await run_grid(
+                    base_yaml_path=base_yaml_path,
+                    base_extra_args="",
+                    grid=[variant],
+                    output_root=workspace,
+                    variant_timeout_sec=variant_timeout_sec,
+                    model_path=model_path,
+                    gpu_type=gpu_type,
+                    server_lifecycle=server_lifecycle_reuse,
+                    server_already_ready=True,
+                    preclean_before_run=False,
+                    warmup_before_measure=False,
+                    soft_deadline_sec=soft_deadline_sec,
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.warning(
+                    "conc_sweep single-server: arm=%s reuse conc=%s raised %r",
+                    arm_name,
+                    variant.extra_envs.get("CONC", "?"),
+                    exc,
+                )
+                reuse_results = [
+                    VariantResult(
+                        name=variant.name,
+                        extra_server_args=variant.extra_server_args,
+                        extra_envs=dict(variant.extra_envs),
+                        status="failed",
+                        error=f"single_server_reuse_exception: {exc}",
+                        error_class="single_server_reuse_exception",
+                    )
+                ]
+            for rr in reuse_results:
+                arm_results.append(rr)
+                _all_results_ref.append(rr)
+            # Incremental flush after each reuse point.
+            _maybe_flush(
+                state=state,
+                session_dir=session_dir,
+                json_path=json_path,
+                csv_path=csv_path,
+                all_results=_all_results_ref,
+                concs=list(concs_desc),
+                isl=isl,
+                osl=osl,
+                opt_args=opt_args,
+                opt_envs=opt_envs,
+                workspace=workspace,
+                started_at=started_at,
+                total_budget_sec=total_budget_sec,
+                has_budget=has_budget,
+                budget_exhausted=_budget_state.get("budget_exhausted", False),
+                budget_skip_reason=_budget_state.get("budget_skip_reason", ""),
+                budget_remaining_sec=_budget_state.get("budget_remaining_sec"),
+            )
+    finally:
+        # Safety teardown — idempotent, no-op if already torn down.
+        try:
+            teardown_lifecycle_server(pid_dir=pid_dir, framework=framework, port=port)
+        except Exception:  # noqa: BLE001
+            pass
+
+    return arm_results
+
+
+async def _sweep_arm_option_b(  # noqa: PLR0913
+    arm_name: str,
+    grid: list[GridVariant],
+    *,
+    base_yaml_path: Path,
+    workspace: Path,
+    model_path: str,
+    gpu_type: str,
+    variant_timeout_sec: int,
+    soft_deadline_sec: float | None,
+    deadline: float | None,
+    state: SharedState,
+    session_dir: Path,
+    json_path: Path,
+    csv_path: Path,
+    started_at: float,
+    total_budget_sec: int,
+    has_budget: bool,
+    opt_args: str,
+    opt_envs: dict[str, str],
+    _all_results_ref: list[VariantResult],
+    _budget_state: dict[str, Any],
+) -> list[VariantResult]:
+    """Option B fallback: run each variant with its own server (legacy behaviour).
+
+    Used when ``_sweep_one_arm_single_server`` detects the framework is not
+    lifecycle-eligible or all boot retries are exhausted.
+
+    Args:
+        arm_name: Label for this arm (``baseline`` or ``optimized``).
+        grid: Pre-built grid for this arm.
+        base_yaml_path: Materialized base Magpie YAML path.
+        workspace: Per-sweep workspace root.
+        model_path: Resolved model path string.
+        gpu_type: Resolved GPU type string.
+        variant_timeout_sec: Per-variant hard timeout in seconds.
+        soft_deadline_sec: Session-clamped soft deadline in seconds, or None.
+        state: Shared run state.
+        session_dir: Session directory.
+        json_path: Pre-resolved JSON report path.
+        csv_path: Pre-resolved CSV report path.
+        started_at: Wall-clock start of the overall sweep.
+        total_budget_sec: Configured total budget in seconds.
+        has_budget: Whether budget tracking is active.
+        opt_args: Optimized server args.
+        opt_envs: Optimized server env vars.
+        _all_results_ref: Shared results list (mutated in place).
+        _budget_state: Shared budget-status dict (mutated in place).
+
+    Returns:
+        List of VariantResult for the arm (one per CONC).
+    """
+    arm_results: list[VariantResult] = []
+    for variant in grid:
+        # Task-level budget checks.
+        _ob_rem = (deadline - time.time()) if has_budget and deadline is not None else None
+        if has_budget and _ob_rem is not None and _ob_rem <= 0:
+            _budget_state["budget_exhausted"] = True
+            _budget_state["budget_skip_reason"] = "total_budget_exhausted"
+            _budget_state["budget_remaining_sec"] = max(0.0, float(_ob_rem))
+            skip_r = _budget_skip_result(variant)
+            arm_results.append(skip_r)
+            _all_results_ref.append(skip_r)
+            continue
+        if has_budget and _ob_rem is not None and _ob_rem < float(variant_timeout_sec):
+            _budget_state["budget_exhausted"] = True
+            _budget_state["budget_skip_reason"] = "insufficient_remaining_for_variant"
+            _budget_state["budget_remaining_sec"] = max(0.0, float(_ob_rem))
+            skip_r = _budget_skip_result(variant)
+            arm_results.append(skip_r)
+            _all_results_ref.append(skip_r)
+            continue
+        if getattr(state, "closing_phase", False) or getattr(state, "stop_reason", ""):
+            _budget_state["budget_exhausted"] = True
+            _budget_state["budget_skip_reason"] = "session_deadline_reserve"
+            _budget_state["budget_remaining_sec"] = 0.0
+            skip_r = _budget_skip_result(variant)
+            arm_results.append(skip_r)
+            _all_results_ref.append(skip_r)
+            continue
+        try:
+            sub = await run_grid(
+                base_yaml_path=base_yaml_path,
+                base_extra_args="",
+                grid=[variant],
+                output_root=workspace,
+                variant_timeout_sec=variant_timeout_sec,
+                model_path=model_path,
+                gpu_type=gpu_type,
+                soft_deadline_sec=soft_deadline_sec,
+            )
+        except Exception as exc:  # noqa: BLE001
+            sub = [
+                VariantResult(
+                    name=variant.name,
+                    extra_server_args=variant.extra_server_args,
+                    extra_envs=dict(variant.extra_envs),
+                    status="failed",
+                    error=f"option_b_exception: {exc}",
+                    error_class="option_b_exception",
+                )
+            ]
+        for r in sub:
+            arm_results.append(r)
+            _all_results_ref.append(r)
+        _concs = [int(v.extra_envs["CONC"]) for v in grid if v.extra_envs.get("CONC")]
+        _isl = int(next((v.extra_envs["ISL"] for v in grid if v.extra_envs.get("ISL")), "0"))
+        _osl = int(next((v.extra_envs["OSL"] for v in grid if v.extra_envs.get("OSL")), "0"))
+        _maybe_flush(
+            state=state,
+            session_dir=session_dir,
+            json_path=json_path,
+            csv_path=csv_path,
+            all_results=_all_results_ref,
+            concs=_concs,
+            isl=_isl,
+            osl=_osl,
+            opt_args=opt_args,
+            opt_envs=opt_envs,
+            workspace=workspace,
+            started_at=started_at,
+            total_budget_sec=total_budget_sec,
+            has_budget=has_budget,
+            budget_exhausted=_budget_state.get("budget_exhausted", False),
+            budget_skip_reason=_budget_state.get("budget_skip_reason", ""),
+            budget_remaining_sec=_budget_state.get("budget_remaining_sec"),
+        )
+    return arm_results
+
+
+def _maybe_flush(  # noqa: PLR0913
+    *,
+    state: SharedState,
+    session_dir: Path,
+    json_path: Path,
+    csv_path: Path,
+    all_results: list[VariantResult],
+    concs: list[int],
+    isl: int,
+    osl: int,
+    opt_args: str,
+    opt_envs: dict[str, str],
+    workspace: Path,
+    started_at: float,
+    total_budget_sec: int,
+    has_budget: bool,
+    budget_exhausted: bool,
+    budget_skip_reason: str,
+    budget_remaining_sec: float | None,
+) -> None:
+    """Build a partial payload from *all_results* and call _flush_conc_sweep_report.
+
+    A thin convenience wrapper around :func:`_flush_partial_conc_sweep_report`
+    that avoids repeating the argument list at every call site.
+
+    Args:
+        state: Shared run state (metadata fields).
+        session_dir: Session directory.
+        json_path: Pre-resolved JSON report path.
+        csv_path: Pre-resolved CSV report path.
+        all_results: All results collected so far (cross-arm).
+        concs: Full requested concurrency ladder (informational).
+        isl: Input sequence length.
+        osl: Output sequence length.
+        opt_args: Optimized server args.
+        opt_envs: Optimized server env vars.
+        workspace: Per-sweep workspace root.
+        started_at: Wall-clock start of the sweep.
+        total_budget_sec: Configured total budget in seconds.
+        has_budget: Whether budget tracking is active.
+        budget_exhausted: Whether the budget has been exhausted.
+        budget_skip_reason: Reason string when budget was exhausted.
+        budget_remaining_sec: Remaining budget seconds when exhausted.
+    """
+    _flush_partial_conc_sweep_report(
+        results=list(all_results),
+        state=state,
+        session_dir=session_dir,
+        json_path=json_path,
+        csv_path=csv_path,
+        concs=concs,
+        isl=isl,
+        osl=osl,
+        opt_args=opt_args,
+        opt_envs=opt_envs,
+        workspace=workspace,
+        started_at=started_at,
+        total_budget_sec=total_budget_sec,
+        has_budget=has_budget,
+        budget_exhausted=budget_exhausted,
+        budget_skip_reason=budget_skip_reason,
+        budget_remaining_sec=budget_remaining_sec,
+    )
+
+
+def _flush_conc_sweep_report(payload: dict[str, Any], session_dir: Path) -> None:
+    """Atomically write the conc-sweep summary JSON + CSV to the reports dir.
+
+    Safe to call after each concurrency point: uses an atomic rename so a
+    hard kill between write and rename never leaves a partial/corrupt file.
+    Internal errors are logged at DEBUG level and swallowed so the sweep loop
+    is never interrupted by an IO failure.
+
+    Args:
+        payload: The current (possibly partial) sweep payload dict.  Must
+            already carry ``report_json_path`` and ``report_csv_path`` keys.
+        session_dir: Session directory used to locate the reports sub-dir.
+    """
+    try:
+        rdir = reports_dir(session_dir)
+        rdir.mkdir(parents=True, exist_ok=True)
+        json_path = Path(payload["report_json_path"])
+        csv_path = Path(payload["report_csv_path"])
+        _common_io.atomic_write_text(
+            json_path,
+            json.dumps(payload, indent=2, ensure_ascii=False, default=str),
+        )
+        all_points: list[dict[str, Any]] = list(
+            (payload.get("baseline") or {}).get("points") or []
+        ) + list((payload.get("optimized") or {}).get("points") or [])
+        _write_csv(csv_path, all_points)
+        try:
+            from hyperloom.inference_optimizer.breakdown.recorder import instrument
+
+            instrument.record_singleton_section(
+                session_dir,
+                "conc_sweep_summary",
+                payload,
+                producer="conc_sweep",
+            )
+        except Exception:  # noqa: BLE001 — capture must never break the sweep
+            log.debug("conc_sweep breakdown capture failed", exc_info=True)
+    except Exception:  # noqa: BLE001
+        log.debug("conc_sweep: _flush_conc_sweep_report failed", exc_info=True)
+
+
+def _flush_partial_conc_sweep_report(  # noqa: PLR0913
+    *,
+    results: list[VariantResult],
+    state: SharedState,
+    session_dir: Path,
+    json_path: Path,
+    csv_path: Path,
+    concs: list[int],
+    isl: int,
+    osl: int,
+    opt_args: str,
+    opt_envs: dict[str, str],
+    workspace: Path,
+    started_at: float,
+    total_budget_sec: int,
+    has_budget: bool,
+    budget_exhausted: bool,
+    budget_skip_reason: str,
+    budget_remaining_sec: float | None,
+    partial: bool = True,
+) -> None:
+    """Build and flush an incremental payload from the results collected so far.
+
+    Extracts partial baseline/optimized points from *results*, builds a minimal
+    in-progress payload, sets ``report_json_path`` / ``report_csv_path``, and
+    delegates to :func:`_flush_conc_sweep_report`.
+
+    Args:
+        results: Variant results collected so far (may be partial).
+        state: Shared run state (used for metadata fields).
+        session_dir: Session directory for report output.
+        json_path: Destination JSON path (already resolved).
+        csv_path: Destination CSV path (already resolved).
+        concs: Full requested concurrency ladder.
+        isl: Input sequence length.
+        osl: Output sequence length.
+        opt_args: Optimized server args.
+        opt_envs: Optimized server env vars.
+        workspace: Workspace directory for this sweep run.
+        started_at: Wall-clock start time of the sweep.
+        total_budget_sec: Total budget in seconds.
+        has_budget: Whether budget tracking is active.
+        budget_exhausted: Whether the budget has been exhausted.
+        budget_skip_reason: Reason string when budget was exhausted.
+        budget_remaining_sec: Remaining budget seconds when exhausted.
+        partial: When ``True`` the status is set to ``"in_progress"`` rather
+            than a terminal status; this makes it easy to distinguish an
+            incremental checkpoint from a final write.
+    """
+    try:
+        b_pts: list[dict[str, Any]] = []
+        o_pts: list[dict[str, Any]] = []
+        for v in results:
+            if v.name.startswith("baseline_"):
+                b_pts.append(_point_from_variant(v, arm="baseline"))
+            elif v.name.startswith("optimized_"):
+                o_pts.append(_point_from_variant(v, arm="optimized"))
+        b_pts.sort(key=lambda p: p["conc"])
+        o_pts.sort(key=lambda p: p["conc"])
+
+        comparison, summary = _build_comparison(b_pts, o_pts)
+        p: dict[str, Any] = {
+            "schema_version": SCHEMA_VERSION,
+            "status": "in_progress" if partial else "unknown",
+            "session_id": str(getattr(state, "session_id", "") or session_dir.name),
+            "isl": isl,
+            "osl": osl,
+            "tp": int(getattr(state, "tp", 0) or 0),
+            "concs_requested": concs,
+            "baseline": {"extra_server_args": "", "extra_envs": {}, "points": b_pts},
+            "optimized": {"extra_server_args": opt_args, "extra_envs": opt_envs, "points": o_pts},
+            "comparison": comparison,
+            "summary": summary,
+            "workspace": workspace.as_posix(),
+            "elapsed_sec": round(time.time() - started_at, 2),
+            "total_budget_sec": total_budget_sec if has_budget else None,
+            "budget_exhausted": budget_exhausted,
+            "report_json_path": json_path.as_posix(),
+            "report_csv_path": csv_path.as_posix(),
+        }
+        if budget_exhausted:
+            p["budget_skip_reason"] = budget_skip_reason
+            if budget_remaining_sec is not None:
+                p["budget_remaining_sec"] = round(float(budget_remaining_sec), 2)
+        _flush_conc_sweep_report(p, session_dir)
+    except Exception:  # noqa: BLE001
+        log.debug("conc_sweep: _flush_partial_conc_sweep_report failed", exc_info=True)
+
+
 def _skip(reason: str, **extras: Any) -> dict[str, Any]:
     """Build a non-fatal skip envelope. Reason is operator-readable.
 
@@ -564,83 +1352,256 @@ async def run_conc_sweep(
             workspace=str(workspace),
         )
 
-    grid = _build_grid(
-        concs=concs,
-        isl=isl,
-        osl=osl,
-        num_prompts_factor=num_prompts_factor,
-        optimized_args=opt_args,
-        optimized_envs=opt_envs,
-        anchor_conc=int(getattr(state, "conc", 0) or 0),
-    )
-
-    # Variants run one at a time so the budget (<=0 disables) can stop cleanly.
     has_budget = total_budget_sec > 0
     started_at = time.time()
     deadline = started_at + total_budget_sec if has_budget else None
-    log.info(
-        "conc_sweep: launching %d variants (concs=%s isl=%d osl=%d total_budget=%s)",
-        len(grid),
-        concs,
-        isl,
-        osl,
-        f"{total_budget_sec}s" if has_budget else "unbounded",
-    )
+
+    # Pre-compute report paths so incremental checkpoints carry them.
+    rdir = reports_dir(session_dir)
+    rdir.mkdir(parents=True, exist_ok=True)
+    json_path = rdir / "conc_sweep_summary.json"
+    csv_path = rdir / "conc_sweep_raw.csv"
+
+    # Compute session soft_deadline once (used in both paths).
+    _SESSION_CLOSE_RESERVE_SEC = 120.0
+    _session_soft_dl: float | None = None
+    _session_rem_fn = getattr(state, "remaining_minutes", None)
+    if callable(_session_rem_fn):
+        _sr = _session_rem_fn()
+        if _sr is not None:
+            _sr_sec = _sr * 60.0
+            _clamped = max(0.0, _sr_sec - _SESSION_CLOSE_RESERVE_SEC)
+            _session_soft_dl = min(float(variant_timeout_sec), _clamped) if _clamped > 0 else None
+
     results: list[VariantResult] = []
     budget_exhausted = False
     budget_skip_reason = ""
     budget_remaining_sec: float | None = None
-    for idx, variant in enumerate(grid):
-        remaining = (deadline - time.time()) if has_budget else None
-        if has_budget and remaining is not None and remaining <= 0:
-            budget_exhausted = True
-            budget_skip_reason = "total_budget_exhausted"
-            budget_remaining_sec = max(0.0, float(remaining))
-            log.warning(
-                "conc_sweep: total budget exhausted (%ds); marking %d remaining variants as skipped",
-                total_budget_sec,
-                len(grid) - idx,
-            )
-            for v in grid[idx:]:
-                results.append(_budget_skip_result(v))
-            break
-        if has_budget and remaining is not None and remaining < float(variant_timeout_sec):
-            budget_exhausted = True
-            budget_skip_reason = "insufficient_remaining_for_variant"
-            budget_remaining_sec = max(0.0, float(remaining))
-            log.warning(
-                "conc_sweep: remaining budget %.1fs is below per-variant timeout %ds; "
-                "marking %d remaining variants as skipped",
-                remaining,
-                variant_timeout_sec,
-                len(grid) - idx,
-            )
-            for v in grid[idx:]:
-                results.append(_budget_skip_result(v))
-            break
 
-        effective_timeout = variant_timeout_sec
-
-        sub_results = await run_grid(
-            base_yaml_path=base_yaml_path,
-            base_extra_args="",
-            grid=[variant],
-            output_root=workspace,
-            variant_timeout_sec=effective_timeout,
-            model_path=resolved_model,
-            gpu_type=resolved_gpu,
+    if _conc_sweep_single_server_enabled():
+        # --- Arm-major single-server path (Option A) ---
+        # Order: optimized first (more informative for decision-making), then baseline.
+        # Within each arm: descending CONC so the server is booted at max capacity.
+        concs_desc = _order_concs_desc(concs)
+        log.info(
+            "conc_sweep (single-server): arms=optimized,baseline concs=%s isl=%d osl=%d total_budget=%s",
+            concs_desc,
+            isl,
+            osl,
+            f"{total_budget_sec}s" if has_budget else "unbounded",
         )
-        results.extend(sub_results)
+        _budget_state: dict[str, Any] = {
+            "budget_exhausted": budget_exhausted,
+            "budget_skip_reason": budget_skip_reason,
+            "budget_remaining_sec": budget_remaining_sec,
+        }
+        arms_order = [
+            ("optimized", opt_args, dict(opt_envs)),
+            ("baseline", "", {}),
+        ]
+        for arm_name, arm_args, arm_envs in arms_order:
+            skip_grid_fn = lambda _an=arm_name, _aa=arm_args, _ae=arm_envs: _build_arm_grid(  # noqa: E731
+                _an, concs_desc,
+                isl=isl, osl=osl,
+                num_prompts_factor=num_prompts_factor,
+                arm_args=_aa, arm_envs=_ae,
+            )
+
+            # Check overall budget before starting each arm.
+            _arm_remaining = (deadline - time.time()) if has_budget and deadline is not None else None
+            if has_budget and _arm_remaining is not None and _arm_remaining <= 0:
+                _budget_state["budget_exhausted"] = True
+                _budget_state["budget_skip_reason"] = "total_budget_exhausted"
+                _budget_state["budget_remaining_sec"] = max(0.0, float(_arm_remaining))
+                for v in skip_grid_fn():
+                    results.append(_budget_skip_result(v))
+                continue
+            if has_budget and _arm_remaining is not None and _arm_remaining < float(variant_timeout_sec):
+                _budget_state["budget_exhausted"] = True
+                _budget_state["budget_skip_reason"] = "insufficient_remaining_for_variant"
+                _budget_state["budget_remaining_sec"] = max(0.0, float(_arm_remaining))
+                for v in skip_grid_fn():
+                    results.append(_budget_skip_result(v))
+                continue
+            if getattr(state, "closing_phase", False) or getattr(state, "stop_reason", ""):
+                _budget_state["budget_exhausted"] = True
+                _budget_state["budget_skip_reason"] = "session_deadline_reserve"
+                _budget_state["budget_remaining_sec"] = 0.0
+                for v in skip_grid_fn():
+                    results.append(_budget_skip_result(v))
+                continue
+
+            await _sweep_one_arm_single_server(
+                arm_name,
+                concs_desc,
+                isl=isl,
+                osl=osl,
+                num_prompts_factor=num_prompts_factor,
+                arm_args=arm_args,
+                arm_envs=arm_envs,
+                base_yaml_path=base_yaml_path,
+                workspace=workspace,
+                model_path=resolved_model,
+                gpu_type=resolved_gpu,
+                variant_timeout_sec=variant_timeout_sec,
+                soft_deadline_sec=_session_soft_dl,
+                deadline=deadline,
+                state=state,
+                session_dir=session_dir,
+                json_path=json_path,
+                csv_path=csv_path,
+                started_at=started_at,
+                total_budget_sec=total_budget_sec,
+                has_budget=has_budget,
+                opt_args=opt_args,
+                opt_envs=opt_envs,
+                _all_results_ref=results,
+                _budget_state=_budget_state,
+            )
+            # Results are added to `results` in place by _all_results_ref.
+
+        budget_exhausted = _budget_state["budget_exhausted"]
+        budget_skip_reason = _budget_state["budget_skip_reason"]
+        budget_remaining_sec = _budget_state["budget_remaining_sec"]
+
+    else:
+        # --- Legacy CONC-major path (Option B / per-variant server restart) ---
+        grid = _build_grid(
+            concs=concs,
+            isl=isl,
+            osl=osl,
+            num_prompts_factor=num_prompts_factor,
+            optimized_args=opt_args,
+            optimized_envs=opt_envs,
+            anchor_conc=int(getattr(state, "conc", 0) or 0),
+        )
+        log.info(
+            "conc_sweep (legacy): %d variants (concs=%s isl=%d osl=%d total_budget=%s)",
+            len(grid),
+            concs,
+            isl,
+            osl,
+            f"{total_budget_sec}s" if has_budget else "unbounded",
+        )
+        _last_variant_runtime_sec: float = float(variant_timeout_sec)
+
+        for idx, variant in enumerate(grid):
+            remaining = (deadline - time.time()) if has_budget and deadline is not None else None
+            if has_budget and remaining is not None and remaining <= 0:
+                budget_exhausted = True
+                budget_skip_reason = "total_budget_exhausted"
+                budget_remaining_sec = max(0.0, float(remaining))
+                log.warning(
+                    "conc_sweep: total budget exhausted (%ds); marking %d remaining variants as skipped",
+                    total_budget_sec,
+                    len(grid) - idx,
+                )
+                for v in grid[idx:]:
+                    results.append(_budget_skip_result(v))
+                break
+            if has_budget and remaining is not None and remaining < float(variant_timeout_sec):
+                budget_exhausted = True
+                budget_skip_reason = "insufficient_remaining_for_variant"
+                budget_remaining_sec = max(0.0, float(remaining))
+                log.warning(
+                    "conc_sweep: remaining budget %.1fs is below per-variant timeout %ds; "
+                    "marking %d remaining variants as skipped",
+                    remaining,
+                    variant_timeout_sec,
+                    len(grid) - idx,
+                )
+                for v in grid[idx:]:
+                    results.append(_budget_skip_result(v))
+                break
+
+            # Session wall-clock deadline check.
+            if getattr(state, "closing_phase", False) or getattr(state, "stop_reason", ""):
+                log.info(
+                    "conc_sweep: session closing/stopped (closing_phase=%s stop_reason=%r); "
+                    "stopping sweep early at variant %d/%d",
+                    getattr(state, "closing_phase", False),
+                    getattr(state, "stop_reason", ""),
+                    idx,
+                    len(grid),
+                )
+                budget_exhausted = True
+                budget_skip_reason = "session_deadline_reserve"
+                budget_remaining_sec = 0.0
+                for v in grid[idx:]:
+                    results.append(_budget_skip_result(v))
+                break
+
+            session_rem_min = getattr(state, "remaining_minutes", None)
+            if callable(session_rem_min):
+                _session_rem = session_rem_min()
+                if _session_rem is not None:
+                    _session_rem_sec = _session_rem * 60.0
+                    _needed_sec = _last_variant_runtime_sec + _SESSION_CLOSE_RESERVE_SEC
+                    if _session_rem_sec < _needed_sec:
+                        log.warning(
+                            "conc_sweep: session budget nearly exhausted "
+                            "(remaining=%.1fs < needed=%.1fs); stopping sweep at variant %d/%d",
+                            _session_rem_sec,
+                            _needed_sec,
+                            idx,
+                            len(grid),
+                        )
+                        budget_exhausted = True
+                        budget_skip_reason = "session_deadline_reserve"
+                        budget_remaining_sec = _session_rem_sec
+                        for v in grid[idx:]:
+                            results.append(_budget_skip_result(v))
+                        break
+
+            effective_timeout = variant_timeout_sec
+            soft_deadline: float | None = _session_soft_dl
+
+            _variant_start = time.time()
+            sub_results = await run_grid(
+                base_yaml_path=base_yaml_path,
+                base_extra_args="",
+                grid=[variant],
+                output_root=workspace,
+                variant_timeout_sec=effective_timeout,
+                model_path=resolved_model,
+                gpu_type=resolved_gpu,
+                soft_deadline_sec=soft_deadline,
+            )
+            _last_variant_runtime_sec = time.time() - _variant_start
+            results.extend(sub_results)
+
+            if write_reports:
+                _flush_partial_conc_sweep_report(
+                    results=results,
+                    state=state,
+                    session_dir=session_dir,
+                    json_path=json_path,
+                    csv_path=csv_path,
+                    concs=concs,
+                    isl=isl,
+                    osl=osl,
+                    opt_args=opt_args,
+                    opt_envs=opt_envs,
+                    workspace=workspace,
+                    started_at=started_at,
+                    total_budget_sec=total_budget_sec,
+                    has_budget=has_budget,
+                    budget_exhausted=budget_exhausted,
+                    budget_skip_reason=budget_skip_reason,
+                    budget_remaining_sec=budget_remaining_sec,
+                    partial=True,
+                )
+
     elapsed_sec = time.time() - started_at
 
     # Split by arm via the variant name prefix.
     baseline_points: list[dict[str, Any]] = []
     optimized_points: list[dict[str, Any]] = []
-    for v in results:
-        if v.name.startswith("baseline_"):
-            baseline_points.append(_point_from_variant(v, arm="baseline"))
-        elif v.name.startswith("optimized_"):
-            optimized_points.append(_point_from_variant(v, arm="optimized"))
+    for vres in results:
+        if vres.name.startswith("baseline_"):
+            baseline_points.append(_point_from_variant(vres, arm="baseline"))
+        elif vres.name.startswith("optimized_"):
+            optimized_points.append(_point_from_variant(vres, arm="optimized"))
     baseline_points.sort(key=lambda p: p["conc"])
     optimized_points.sort(key=lambda p: p["conc"])
 
@@ -697,30 +1658,10 @@ async def run_conc_sweep(
         payload["roofline_ceiling"] = ceiling
 
     if write_reports:
-        rdir = reports_dir(session_dir)
-        rdir.mkdir(parents=True, exist_ok=True)
-        json_path = rdir / "conc_sweep_summary.json"
-        csv_path = rdir / "conc_sweep_raw.csv"
         # Set self-referential paths before the dump so the JSON carries them.
         payload["report_json_path"] = json_path.as_posix()
         payload["report_csv_path"] = csv_path.as_posix()
-        json_path.write_text(
-            json.dumps(payload, indent=2, ensure_ascii=False, default=str),
-            encoding="utf-8",
-        )
-        _write_csv(csv_path, baseline_points + optimized_points)
-        # Mirror the summary into the breakdown recorder.
-        try:
-            from hyperloom.inference_optimizer.breakdown.recorder import instrument
-
-            instrument.record_singleton_section(
-                session_dir,
-                "conc_sweep_summary",
-                payload,
-                producer="conc_sweep",
-            )
-        except Exception:  # noqa: BLE001 — capture must never break the sweep
-            log.debug("conc_sweep breakdown capture failed", exc_info=True)
+        _flush_conc_sweep_report(payload, session_dir)
 
     log.info(
         "conc_sweep: done — successful_pairs=%d failed_pairs=%d best_speedup=%s",
@@ -737,5 +1678,10 @@ __all__ = [
     "DEFAULT_TOTAL_BUDGET_SEC",
     "DEFAULT_VARIANT_TIMEOUT_SEC",
     "SCHEMA_VERSION",
+    "_build_arm_grid",
+    "_conc_sweep_single_server_enabled",
+    "_flush_conc_sweep_report",
+    "_flush_partial_conc_sweep_report",
+    "_order_concs_desc",
     "run_conc_sweep",
 ]

--- a/src/hyperloom/orchestrator/kernel/conc_sweep_plot.py
+++ b/src/hyperloom/orchestrator/kernel/conc_sweep_plot.py
@@ -11,10 +11,10 @@ Axes:
   x = output_throughput / conc  (tok/s per user — "interactivity")
   y = output_throughput / tp    (tok/s per GPU   — "efficiency")
 
-Colours follow the InferenceX palette:
-  baseline  — dark-red   ``#8B0000``
+Rendered on a black background for a high-contrast dashboard look. Colours:
+  baseline  — red        ``#FF4C4C``
   optimized — orange     ``#FF8C00``
-  ceiling   — light-grey ``#AAAAAA`` dashed
+  ceiling   — grey       ``#888888`` dashed (off by default)
 """
 
 from __future__ import annotations
@@ -36,9 +36,11 @@ def render_conc_sweep_curve(
     tp: int = 1,
     isl: int = 0,
     osl: int = 0,
-    draw_ceiling: bool = True,
+    draw_ceiling: bool = False,
 ) -> Path | None:
     """Render a throughput-vs-interactivity PNG from a ``conc_sweep_summary.json``.
+
+    Rendered on a dark (black) background for a high-contrast dashboard look.
 
     Args:
         payload: Either the already-parsed payload dict, or a file path to the
@@ -51,7 +53,7 @@ def render_conc_sweep_curve(
         isl: Input sequence length (informational, shown in title).
         osl: Output sequence length (informational, shown in title).
         draw_ceiling: When ``True`` and ``roofline_ceiling`` data is present,
-            draw a light-grey dashed theoretical peak line.
+            draw a dashed theoretical peak line. Off by default.
 
     Returns:
         The resolved ``Path`` of the written PNG, or ``None`` on any failure
@@ -183,66 +185,65 @@ def _render(
         log.debug("conc_sweep_plot: no valid data points in either arm — skipping plot")
         return None
 
+    # Dark theme palette.
+    bg = "#000000"
+    fg = "#E6E6E6"
+    grid_c = "#3A3A3A"
+    baseline_c = "#FF4C4C"
+    optimized_c = "#FF8C00"
+    ceiling_c = "#888888"
+
     fig, ax = plt.subplots(figsize=(10, 6))
+    fig.patch.set_facecolor(bg)
+    ax.set_facecolor(bg)
 
     if draw_ceiling:
         ceiling_data = data.get("roofline_ceiling") or {}
         cx, cy = _ceiling_series(ceiling_data, tp_eff)
         if cx:
-            ax.plot(cx, cy, "--", color="#AAAAAA", linewidth=1.2, label="Theoretical peak (roofline)")
+            ax.plot(cx, cy, "--", color=ceiling_c, linewidth=1.2, label="Theoretical peak (roofline)")
 
     if bx:
-        ax.plot(
-            bx,
-            by,
-            "o-",
-            color="#8B0000",
-            linewidth=2,
-            markersize=6,
-            label="baseline",
-        )
+        ax.plot(bx, by, "o-", color=baseline_c, linewidth=2, markersize=6, label="baseline")
         for x, y in zip(bx, by):
             ax.annotate(
-                f"{y:.0f}", (x, y), textcoords="offset points", xytext=(0, 8), ha="center", fontsize=7, color="#8B0000"
+                f"{y:.0f}", (x, y), textcoords="offset points", xytext=(0, 8),
+                ha="center", fontsize=7, color=baseline_c,
             )
 
     if ox:
-        ax.plot(
-            ox,
-            oy,
-            "s-",
-            color="#FF8C00",
-            linewidth=2,
-            markersize=6,
-            label="optimized",
-        )
+        ax.plot(ox, oy, "s-", color=optimized_c, linewidth=2, markersize=6, label="optimized")
         for x, y in zip(ox, oy):
             ax.annotate(
-                f"{y:.0f}",
-                (x, y),
-                textcoords="offset points",
-                xytext=(0, -14),
-                ha="center",
-                fontsize=7,
-                color="#FF8C00",
+                f"{y:.0f}", (x, y), textcoords="offset points", xytext=(0, -14),
+                ha="center", fontsize=7, color=optimized_c,
             )
 
-    ax.set_xlabel("Interactivity  (output_throughput / concurrency,  tok/s/user)", fontsize=10)
-    ax.set_ylabel(f"Efficiency  (output_throughput / tp={int(tp_eff)},  tok/s/GPU)", fontsize=10)
+    ax.set_xlabel("Interactivity  (output_throughput / concurrency,  tok/s/user)", fontsize=10, color=fg)
+    ax.set_ylabel(f"Efficiency  (output_throughput / tp={int(tp_eff)},  tok/s/GPU)", fontsize=10, color=fg)
 
     title_parts = [model_label or "Model"]
     if gpu_label:
         title_parts.append(gpu_label)
     if isl or osl:
         title_parts.append(f"ISL={isl} OSL={osl}")
-    ax.set_title("Concurrency Sweep — Throughput vs Interactivity\n" + " | ".join(title_parts), fontsize=11)
+    ax.set_title(
+        "Concurrency Sweep — Throughput vs Interactivity\n" + " | ".join(title_parts),
+        fontsize=11,
+        color=fg,
+    )
 
-    ax.grid(True, alpha=0.3)
-    ax.legend(loc="upper right", fontsize=9)
+    ax.grid(True, alpha=0.3, color=grid_c)
+    ax.tick_params(colors=fg)
+    for spine in ax.spines.values():
+        spine.set_color(grid_c)
+    legend = ax.legend(loc="upper right", fontsize=9, facecolor=bg, edgecolor=grid_c)
+    for text in legend.get_texts():
+        text.set_color(fg)
     fig.tight_layout()
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(str(out_path), dpi=150, format="png")
+    fig.savefig(str(out_path), dpi=150, format="png", facecolor=bg)
     plt.close(fig)
     log.info("conc_sweep_plot: wrote %s", out_path)
     return out_path

--- a/src/hyperloom/orchestrator/kernel/conc_sweep_plot.py
+++ b/src/hyperloom/orchestrator/kernel/conc_sweep_plot.py
@@ -1,0 +1,251 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+"""InferenceX-style concurrency sweep comparison chart.
+
+Renders a throughput-vs-interactivity curve for baseline vs optimised arms
+produced by :mod:`conc_sweep`.  The function is **best-effort**: any import
+failure (missing ``matplotlib``) or data / IO error is logged and ``None``
+is returned so callers can skip the chart without aborting the report.
+
+Axes:
+  x = output_throughput / conc  (tok/s per user — "interactivity")
+  y = output_throughput / tp    (tok/s per GPU   — "efficiency")
+
+Colours follow the InferenceX palette:
+  baseline  — dark-red   ``#8B0000``
+  optimized — orange     ``#FF8C00``
+  ceiling   — light-grey ``#AAAAAA`` dashed
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+def render_conc_sweep_curve(
+    payload: dict[str, Any] | str | Path,
+    out_path: str | Path,
+    *,
+    model_label: str = "",
+    gpu_label: str = "",
+    tp: int = 1,
+    isl: int = 0,
+    osl: int = 0,
+    draw_ceiling: bool = True,
+) -> Path | None:
+    """Render a throughput-vs-interactivity PNG from a ``conc_sweep_summary.json``.
+
+    Args:
+        payload: Either the already-parsed payload dict, or a file path to the
+            ``conc_sweep_summary.json`` to load.
+        out_path: Destination PNG path.
+        model_label: Model name shown in the chart title.
+        gpu_label: GPU label shown in the chart title.
+        tp: Tensor-parallel size used to normalise y-axis to tok/s/GPU.
+            When 0 the raw output_throughput is used (tp treated as 1).
+        isl: Input sequence length (informational, shown in title).
+        osl: Output sequence length (informational, shown in title).
+        draw_ceiling: When ``True`` and ``roofline_ceiling`` data is present,
+            draw a light-grey dashed theoretical peak line.
+
+    Returns:
+        The resolved ``Path`` of the written PNG, or ``None`` on any failure
+        (missing matplotlib, bad data, IO error).
+    """
+    try:
+        return _render(
+            payload=payload,
+            out_path=Path(out_path),
+            model_label=model_label,
+            gpu_label=gpu_label,
+            tp=tp,
+            isl=isl,
+            osl=osl,
+            draw_ceiling=draw_ceiling,
+        )
+    except Exception:  # noqa: BLE001
+        log.debug("conc_sweep_plot: render failed", exc_info=True)
+        return None
+
+
+def _load_payload(payload: dict[str, Any] | str | Path) -> dict[str, Any]:
+    if isinstance(payload, dict):
+        return payload
+    path = Path(payload)
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _arm_series(
+    points: list[dict[str, Any]],
+    tp_eff: float,
+) -> tuple[list[float], list[float]]:
+    """Extract (x, y) series for one arm, skipping failed/missing points.
+
+    Args:
+        points: List of conc-sweep point dicts (``conc``, ``output_throughput``, ...).
+        tp_eff: Effective TP size for y-axis normalisation (must be >= 1).
+
+    Returns:
+        ``(xs, ys)`` — interactivity (tok/s/user) and efficiency (tok/s/GPU)
+        for points with non-``None`` output_throughput, sorted ascending by x.
+    """
+    pairs: list[tuple[float, float]] = []
+    for pt in points:
+        tput = pt.get("output_throughput")
+        conc = pt.get("conc")
+        if tput is None or not conc:
+            continue
+        try:
+            tput_f = float(tput)
+            conc_f = float(conc)
+        except (TypeError, ValueError):
+            continue
+        if tput_f <= 0 or conc_f <= 0:
+            continue
+        x = tput_f / conc_f  # tok/s per user (interactivity)
+        y = tput_f / tp_eff  # tok/s per GPU  (efficiency)
+        pairs.append((x, y))
+    pairs.sort(key=lambda p: p[0])
+    if not pairs:
+        return [], []
+    return [p[0] for p in pairs], [p[1] for p in pairs]
+
+
+def _ceiling_series(
+    ceiling_data: dict[str, Any],
+    tp_eff: float,
+) -> tuple[list[float], list[float]]:
+    """Extract ceiling (x, y) from ``roofline_ceiling`` payload rows.
+
+    Args:
+        ceiling_data: The ``roofline_ceiling`` sub-dict from the payload.
+        tp_eff: Effective TP size for y-axis normalisation.
+
+    Returns:
+        ``(xs, ys)`` for the theoretical peak line, sorted ascending by x.
+        Returns ``([], [])`` when data is missing or malformed.
+    """
+    rows = ceiling_data.get("rows") or []
+    pairs: list[tuple[float, float]] = []
+    for row in rows:
+        conc = row.get("conc")
+        peak = row.get("t_peak_tok_s")
+        if conc is None or peak is None:
+            continue
+        try:
+            conc_f = float(conc)
+            peak_f = float(peak)
+        except (TypeError, ValueError):
+            continue
+        if conc_f <= 0 or peak_f <= 0:
+            continue
+        x = peak_f / conc_f  # interactivity at ceiling
+        y = peak_f / tp_eff  # efficiency at ceiling
+        pairs.append((x, y))
+    pairs.sort(key=lambda p: p[0])
+    if not pairs:
+        return [], []
+    return [p[0] for p in pairs], [p[1] for p in pairs]
+
+
+def _render(
+    payload: dict[str, Any] | str | Path,
+    out_path: Path,
+    *,
+    model_label: str,
+    gpu_label: str,
+    tp: int,
+    isl: int,
+    osl: int,
+    draw_ceiling: bool,
+) -> Path | None:
+    import matplotlib  # noqa: PLC0415
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt  # noqa: PLC0415
+
+    data = _load_payload(payload)
+    tp_eff = float(max(tp, 1))
+
+    baseline_pts = (data.get("baseline") or {}).get("points") or []
+    optimized_pts = (data.get("optimized") or {}).get("points") or []
+
+    bx, by = _arm_series(baseline_pts, tp_eff)
+    ox, oy = _arm_series(optimized_pts, tp_eff)
+
+    # Need at least the baseline to draw something useful.
+    if not bx and not ox:
+        log.debug("conc_sweep_plot: no valid data points in either arm — skipping plot")
+        return None
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+
+    if draw_ceiling:
+        ceiling_data = data.get("roofline_ceiling") or {}
+        cx, cy = _ceiling_series(ceiling_data, tp_eff)
+        if cx:
+            ax.plot(cx, cy, "--", color="#AAAAAA", linewidth=1.2, label="Theoretical peak (roofline)")
+
+    if bx:
+        ax.plot(
+            bx,
+            by,
+            "o-",
+            color="#8B0000",
+            linewidth=2,
+            markersize=6,
+            label="baseline",
+        )
+        for x, y in zip(bx, by):
+            ax.annotate(
+                f"{y:.0f}", (x, y), textcoords="offset points", xytext=(0, 8), ha="center", fontsize=7, color="#8B0000"
+            )
+
+    if ox:
+        ax.plot(
+            ox,
+            oy,
+            "s-",
+            color="#FF8C00",
+            linewidth=2,
+            markersize=6,
+            label="optimized",
+        )
+        for x, y in zip(ox, oy):
+            ax.annotate(
+                f"{y:.0f}",
+                (x, y),
+                textcoords="offset points",
+                xytext=(0, -14),
+                ha="center",
+                fontsize=7,
+                color="#FF8C00",
+            )
+
+    ax.set_xlabel("Interactivity  (output_throughput / concurrency,  tok/s/user)", fontsize=10)
+    ax.set_ylabel(f"Efficiency  (output_throughput / tp={int(tp_eff)},  tok/s/GPU)", fontsize=10)
+
+    title_parts = [model_label or "Model"]
+    if gpu_label:
+        title_parts.append(gpu_label)
+    if isl or osl:
+        title_parts.append(f"ISL={isl} OSL={osl}")
+    ax.set_title("Concurrency Sweep — Throughput vs Interactivity\n" + " | ".join(title_parts), fontsize=11)
+
+    ax.grid(True, alpha=0.3)
+    ax.legend(loc="upper right", fontsize=9)
+    fig.tight_layout()
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(str(out_path), dpi=150, format="png")
+    plt.close(fig)
+    log.info("conc_sweep_plot: wrote %s", out_path)
+    return out_path
+
+
+__all__ = ["render_conc_sweep_curve"]

--- a/src/hyperloom/orchestrator/phases/sweep.py
+++ b/src/hyperloom/orchestrator/phases/sweep.py
@@ -112,12 +112,26 @@ class SweepPhase(PhaseHandler):
             enqueue error.
         """
         state = self.shared_state
+        configured_budget = int(state.conc_sweep_total_budget_sec or 0)
+        # Clamp total_budget_sec to the remaining session wall-clock budget so
+        # a long conc_sweep cannot outlive --max-hours.  A 120 s reserve is kept
+        # for the CLOSE phase.  When remaining_minutes() returns None (or the
+        # state stub lacks it) the session has no wall-clock cap and we use the
+        # configured value as-is.
+        _CLOSE_RESERVE_SEC = 120
+        _rem_fn = getattr(state, "remaining_minutes", None)
+        session_rem = _rem_fn() if callable(_rem_fn) else None
+        if session_rem is not None:
+            session_rem_sec = int(max(0.0, session_rem * 60.0) - _CLOSE_RESERVE_SEC)
+            clamped_budget = min(configured_budget, max(0, session_rem_sec)) if configured_budget > 0 else max(0, session_rem_sec)
+        else:
+            clamped_budget = configured_budget
         params: dict[str, Any] = {
             "source": "coordinator_internal",
             "reason": str(reason),
             "concs": list(state.conc_sweep_concs or []),
             "variant_timeout_sec": int(state.conc_sweep_variant_timeout_sec or 0),
-            "total_budget_sec": int(state.conc_sweep_total_budget_sec or 0),
+            "total_budget_sec": clamped_budget,
         }
         try:
             task, was_existing = await self.tasks.create_or_return_existing(

--- a/src/hyperloom/orchestrator/state/shared_state.py
+++ b/src/hyperloom/orchestrator/state/shared_state.py
@@ -375,7 +375,7 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
     conc_sweep_enabled: bool = True
     # CONC ladder for conc_sweep (mirrors conc_sweep.DEFAULT_CONCS). Empty => skip_reason=empty_conc_list.
     conc_sweep_concs: list[int] = field(
-        default_factory=lambda: [1, 2, 4, 8, 16, 32, 64, 128],
+        default_factory=lambda: [256, 128, 64, 32, 16, 8, 4, 2],
     )
     # Total wall-clock budget (s) for conc_sweep. 0 disables the gate.
     conc_sweep_total_budget_sec: int = 9000


### PR DESCRIPTION


Refactors the post-optimization concurrency sweep so each arm reuses **one
persistent server** across all concurrency points instead of restarting a
server per point. This matters most for large models where server boot
dominates the sweep wall-clock. Alongside the reuse change it adds artifact
durability, session-deadline awareness, and an InferenceX-style comparison
plot.

<img width="1500" height="900" alt="image" src="https://github.com/user-attachments/assets/8b4d455f-d09a-4a5c-bc6b-759c9b6a01eb" />


- **Descending single-server-per-arm sweep** — the CONC ladder default flips to
  high→low (`256,128,...,2`) across `DEFAULT_CONCS`, the `--conc-sweep-concs`
  CLI default, and `SharedState`. The sweep is now arm-major (optimized first,
  then baseline): boot the server once at the highest CONC via Magpie
  `server_lifecycle` (`cleanup=False`), reuse it for every lower CONC
  (`server_already_ready=True`, no preclean), and tear it down once on the last
  point (and in `finally`). Boot-retry-descend tries the next lower CONC when
  the top fails; a non-eligible framework or total boot failure falls back to
  the legacy per-variant restart (Option B). Soft switch
  `INFERENCE_OPTIMIZER_CONC_SWEEP_SINGLE_SERVER=0` restores the old CONC-major
  path.
- **Incremental checkpoints** — the summary JSON/CSV is flushed atomically
  after every point (`status=in_progress`), so a hard kill still leaves a valid
  partial `conc_sweep_summary.json`; a terminal write lands at the end.
- **Session-deadline awareness** — before each point the sweep skips the
  remainder when `closing_phase` / `stop_reason` is set or the remaining
  wall-clock drops below the next-point estimate plus a CLOSE reserve, and
  passes a clamped `soft_deadline_sec` to `run_grid`. The SWEEP enqueue clamps
  `total_budget_sec` to the remaining session budget.
- **Throughput-vs-interactivity plot** — new
  `orchestrator/kernel/conc_sweep_plot.py::render_conc_sweep_curve` renders a
  best-effort chart (efficiency `tok/s/GPU` vs interactivity `tok/s/user`,
  baseline vs optimized) on a black background; the roofline ceiling is opt-in
  (off by default). The report executor renders `reports/conc_sweep_curve.png`
  and embeds it in `final.md`, both behind `try/except`.
- **Validator script** — `scripts/test_conc_sweep_flow.py` replays a real
  session's baseline + accepted `current_best` through `run_conc_sweep` over a
  descending ladder, verifies the server is booted once per arm and reused (not
  killed) as CONC descends, and renders the plot from the produced artifact.

## Validation

```bash
# Unit suite (offline, mocked run_grid)
python3 -m pytest -q \
  src/hyperloom/inference_optimizer/tests/test_conc_sweep.py \
  src/hyperloom/inference_optimizer/tests/test_cli_conc_sweep_default.py    # 70 + 16 passed
ruff check .                 # passed
mypy src/hyperloom/orchestrator/kernel/conc_sweep.py \
     src/hyperloom/orchestrator/kernel/conc_sweep_plot.py \
     src/hyperloom/orchestrator/actions/executors/report.py \
     src/hyperloom/orchestrator/phases/sweep.py                             # clean
```

End-to-end on real hardware (Qwen3-8B, MI355X, fp8, TP=1, ISL/OSL=256) via
`scripts/test_conc_sweep_flow.py` at ladders `8,4,2`, `32,16,8,4,2`, and the
full `256,...,2`:

- Every CONC point in both arms reported a measured `output_throughput`
  (`status=succeeded`).
- Each arm booted exactly one server (`server launches counted: 1`), reused it
  across the entire descending ladder, and tore it down once at the end. Magpie
  logs confirm: boot → `server left running` → `reusing HTTP server ...
  server_pid=<same>, cleanup_after_run=False` per lower CONC → only the final
  point logs `cleanup_after_run=True` → `cleanup finished (terminated pid=...)`.

**Answer to "does high→low CONC kill the reused server?": No** — one boot per
arm, reused down the ladder, reaped exactly once.

## Notes for reviewers

- No changes to `_grid_runner` / `_server_lifecycle` internals; the sweep
  orchestrates the existing `run_grid` + `server_lifecycle` protocol.
- All new behavior is independently reversible: single-server via the env
  switch, plotting is best-effort (returns `None` without matplotlib), and the
  incremental flush is additive.
- `matplotlib` is intentionally not added to `dependencies`; the plot import is
  guarded and the runtime already ships it.
- `scripts/test_conc_sweep_flow.py` is a manual validator (needs a GPU + a real
  session); it is not part of the CI test suite.
