### PR TITLE
fix: config-driven vLLM --block-size for sparse models; resolve repo-id in compat preflight

### DIFF
--- a/src/hyperloom/inference_optimizer/cli/model_gate.py
+++ b/src/hyperloom/inference_optimizer/cli/model_gate.py
@@ -1355,7 +1355,15 @@ def _run_compat_detector(
     Returns:
         str | None: The first non-None reason from the sub-chain, else ``None``.
     """
-    available = {"model_path": model_path, "data": data, "gpu_type": gpu_type}
+    # Resolve a HF repo-id to its local cache dir ONCE so every disk-reading
+    # detector (hf_quant_config.json, safetensors shards, tokenizer files, PEFT
+    # adapters, ...) sees a real directory. Without this, a repo-id launch makes
+    # Path(repo_id).is_dir() False and those detectors silently skip -- deferring
+    # "incompatible checkpoint" rejection to server init, the exact silent
+    # degradation the resolver is meant to remove. An already-local dir resolves
+    # to itself; an unresolvable id falls back to the raw path (prior behaviour).
+    resolved_mp = str(resolve_local_model_dir(model_path) or model_path)
+    available = {"model_path": resolved_mp, "data": data, "gpu_type": gpu_type}
     call_args = tuple(available[name] for name in spec.args)
     fns = spec.fn if isinstance(spec.fn, tuple) else (spec.fn,)
     for fn in fns:

--- a/src/hyperloom/inference_optimizer/model_config_utils.py
+++ b/src/hyperloom/inference_optimizer/model_config_utils.py
@@ -559,3 +559,33 @@ def _model_is_gemma2(model_path: str) -> bool:
         if _config_has_model_identity(data):
             return False
     return _path_looks_like_gemma2(model_path)
+
+
+def _sparse_kv_block_size(model_path: str) -> int | None:
+    """Return the KV-cache block size a sparse-attention model requires, or None.
+
+    Sparse-attention models (e.g. MiniMax-M3 MSA) declare a fixed page/block
+    size under ``sparse_attention_config.sparse_block_size`` (top level or a
+    nested text-tower scope). Their vLLM sparse backends only accept that exact
+    block size (``get_supported_kernel_block_sizes()`` returns just it), so the
+    paged KV cache must launch with ``--block-size <that value>`` or KV-cache
+    init aborts with "No common block size for <default>".
+
+    Config-derived and model-agnostic: returns the declared size (e.g. 128) for
+    ANY model that carries it, else ``None`` (dense model, no declared size, or
+    unreadable config -- the caller then injects nothing and keeps prior
+    behaviour). Requires a readable ``config.json`` at ``model_path``.
+
+    Args:
+        model_path: Filesystem path (or resolvable id) to the model.
+
+    Returns:
+        The required KV-cache block size, or ``None`` when undetermined.
+    """
+    data = _load_model_config_dict(model_path)
+    if not isinstance(data, dict):
+        return None
+    sparse = _merge_config_scopes(data).get("sparse_attention_config")
+    if not isinstance(sparse, dict):
+        return None
+    return to_int(sparse.get("sparse_block_size"))

--- a/src/hyperloom/inference_optimizer/tests/test_model_config_compat_preflight.py
+++ b/src/hyperloom/inference_optimizer/tests/test_model_config_compat_preflight.py
@@ -1396,3 +1396,46 @@ def test_declared_standard_quant_with_scales_index_not_blocked(tmp_path):
             }}), encoding="utf-8",
         )
         assert cli._detect_incompatible_model_config(str(m)) is None, method
+
+
+def test_run_compat_detector_resolves_repo_id_before_dispatch(tmp_path, monkeypatch):
+    """A repo-id must be resolved to its local cache dir before the waterfall so
+    disk-reading detectors receive a real directory instead of the bare repo-id
+    (which Path().is_dir() would reject, silently skipping the check)."""
+    local_dir = tmp_path / "cache" / "models--org--repo"
+    local_dir.mkdir(parents=True)
+    monkeypatch.setattr(
+        cli_model_gate,
+        "resolve_local_model_dir",
+        lambda mp: local_dir if mp == "org/repo" else None,
+    )
+    seen: dict[str, str] = {}
+
+    def _fake_detector(model_path):
+        seen["model_path"] = model_path
+        return None
+
+    spec = cli_model_gate.DetectorSpec("t", _fake_detector, args=("model_path",))
+    cli_model_gate._run_compat_detector(
+        spec, model_path="org/repo", data={}, gpu_type=None
+    )
+    assert seen["model_path"] == str(local_dir)
+
+
+def test_run_compat_detector_falls_back_to_raw_when_unresolvable(monkeypatch):
+    """An unresolvable model path (e.g. an uncached repo-id) falls back to the
+    raw string so behaviour is unchanged from before the resolver."""
+    monkeypatch.setattr(
+        cli_model_gate, "resolve_local_model_dir", lambda mp: None
+    )
+    seen: dict[str, str] = {}
+
+    def _fake_detector(model_path):
+        seen["model_path"] = model_path
+        return None
+
+    spec = cli_model_gate.DetectorSpec("t", _fake_detector, args=("model_path",))
+    cli_model_gate._run_compat_detector(
+        spec, model_path="/raw/model/path", data={}, gpu_type=None
+    )
+    assert seen["model_path"] == "/raw/model/path"

--- a/src/hyperloom/inference_optimizer/tests/test_model_config_summary.py
+++ b/src/hyperloom/inference_optimizer/tests/test_model_config_summary.py
@@ -9,7 +9,10 @@ from pathlib import Path
 
 import pytest
 
-from hyperloom.inference_optimizer.model_config_utils import summarize_model_config
+from hyperloom.inference_optimizer.model_config_utils import (
+    _sparse_kv_block_size,
+    summarize_model_config,
+)
 
 
 def _write_config(model_dir: Path, payload: dict) -> Path:
@@ -457,3 +460,31 @@ def test_shared_expert_via_nested_text_config(tmp_path: Path) -> None:
     assert out["is_moe"] is True
     assert out["has_shared_expert"] is True
     assert out["num_shared_experts"] == 1
+
+
+def test_sparse_kv_block_size_top_level(tmp_path: Path) -> None:
+    m = _write_config(
+        tmp_path / "m",
+        {"model_type": "minimax_m3", "sparse_attention_config": {"sparse_block_size": 128}},
+    )
+    assert _sparse_kv_block_size(str(m)) == 128
+
+
+def test_sparse_kv_block_size_nested_text_config(tmp_path: Path) -> None:
+    m = _write_config(
+        tmp_path / "m",
+        {"text_config": {"sparse_attention_config": {"sparse_block_size": 64}}},
+    )
+    assert _sparse_kv_block_size(str(m)) == 64
+
+
+def test_sparse_kv_block_size_dense_model_is_none(tmp_path: Path) -> None:
+    m = _write_config(tmp_path / "m", {"model_type": "llama"})
+    assert _sparse_kv_block_size(str(m)) is None
+
+
+def test_sparse_kv_block_size_unreadable_config_is_none(tmp_path: Path) -> None:
+    # No config.json (e.g. an uncached hub-id) -> None, so the caller injects
+    # nothing and preserves prior behaviour.
+    assert _sparse_kv_block_size(str(tmp_path / "nope")) is None
+    assert _sparse_kv_block_size("") is None

--- a/src/hyperloom/inference_optimizer/tests/test_roofline_ceiling.py
+++ b/src/hyperloom/inference_optimizer/tests/test_roofline_ceiling.py
@@ -322,6 +322,42 @@ class TestLoadModelMeta:
         assert meta is not None
         assert meta.head_dim == 200
 
+    def test_nested_text_config_moe_is_read(self, tmp_path):
+        # Multimodal wrappers (e.g. Kimi-K2 kimi_k25) nest the decoder shape/MoE
+        # config under text_config; the ceiling reader must flatten it or it
+        # degrades to a dense full-weight roofline (num_experts=0 -> PerfModel
+        # falls back to legacy, active_weight_bytes = full weight_bytes).
+        d = tmp_path / "m"
+        d.mkdir()
+        (d / "config.json").write_text(
+            json.dumps(
+                {
+                    "model_type": "kimi_k25",
+                    "text_config": {
+                        "num_hidden_layers": 4,
+                        "num_attention_heads": 16,
+                        "num_key_value_heads": 8,
+                        "hidden_size": 2048,
+                        "num_experts": 64,
+                        "num_experts_per_tok": 8,
+                        "moe_intermediate_size": 1024,
+                        "torch_dtype": "bfloat16",
+                    },
+                }
+            )
+        )
+        (d / "model.safetensors.index.json").write_text(
+            json.dumps({"metadata": {"total_size": 10_000_000_000}, "weight_map": {}})
+        )
+        meta = load_model_meta(d)
+        assert meta is not None
+        assert meta.num_experts == 64
+        assert meta.experts_per_tok == 8
+        assert meta.hidden_size == 2048
+        assert meta.num_kv_heads == 8
+        # MoE decomposition applied -> per-token active bytes below full weights.
+        assert 0 < meta.active_weight_bytes < meta.weight_bytes
+
     def test_missing_safetensors_index_uses_safetensor_file_sizes(self, tmp_path):
         d = tmp_path / "m"
         d.mkdir()

--- a/src/hyperloom/inference_optimizer/tests/test_roofline_ceiling.py
+++ b/src/hyperloom/inference_optimizer/tests/test_roofline_ceiling.py
@@ -26,6 +26,7 @@ from hyperloom.orchestrator.kernel.roofline_ceiling import (
     compute_kv_bytes_per_token,
     compute_peak_from_state,
     compute_roofline_breakdown_from_state,
+    compute_roofline_from_perfmodel,
     compute_theoretical_peak_output_tok_per_sec,
     load_model_meta,
     resolve_runtime_dtype,
@@ -239,6 +240,7 @@ def _write_synthetic_model(
     num_local_experts: int | None = None,
     quant_method: str | None = None,
     dtype: str | None = None,
+    expert_dtype: str | None = None,
 ) -> None:
     """Lay down a minimal HF-shaped model dir; optional kwargs emit MHA / MoE / quant / alias variants."""
     model_dir.mkdir(parents=True, exist_ok=True)
@@ -270,6 +272,8 @@ def _write_synthetic_model(
         }
     if dtype is not None:
         config["dtype"] = dtype
+    if expert_dtype is not None:
+        config["expert_dtype"] = expert_dtype
     (model_dir / "config.json").write_text(json.dumps(config))
     (model_dir / "model.safetensors.index.json").write_text(
         json.dumps({"metadata": {"total_size": total_size}, "weight_map": {}})
@@ -527,6 +531,107 @@ def _write_qwen3_moe_model(model_dir: Path, *, total_size: int) -> None:
     (model_dir / "model.safetensors.index.json").write_text(
         json.dumps({"metadata": {"total_size": total_size}, "weight_map": {}})
     )
+
+
+def _write_deepseek_v4_model(model_dir: Path, *, total_size: int, expert_dtype: str | None) -> None:
+    """Lay down a DeepSeek-V4-Pro-shaped MoE dir: fp8 attention + (optional) fp4 experts.
+
+    The routed-expert weights, sized at the *global* fp8 dtype, exceed the whole
+    on-disk checkpoint (1547 GB computed vs 865 GB real), which trips the
+    ``total_expert_bytes >= weight_bytes`` safe-degrade. Reading ``expert_dtype``
+    (fp4) is what keeps the decomposition alive.
+    """
+    model_dir.mkdir(parents=True, exist_ok=True)
+    config: dict = {
+        "architectures": ["DeepseekV4ForCausalLM"],
+        "model_type": "deepseek_v4",
+        "num_hidden_layers": 61,
+        "num_attention_heads": 128,
+        "num_key_value_heads": 1,
+        "hidden_size": 7168,
+        "head_dim": 512,
+        "moe_intermediate_size": 3072,
+        "n_routed_experts": 384,
+        "num_experts_per_tok": 6,
+        "torch_dtype": "bfloat16",
+        "quantization_config": {
+            "quant_method": "fp8",
+            "weight_block_size": [128, 128],
+            "activation_scheme": "dynamic",
+        },
+    }
+    if expert_dtype is not None:
+        config["expert_dtype"] = expert_dtype
+    (model_dir / "config.json").write_text(json.dumps(config))
+    (model_dir / "model.safetensors.index.json").write_text(
+        json.dumps({"metadata": {"total_size": total_size}, "weight_map": {}})
+    )
+
+
+class TestSeparateExpertDtype:
+    """DeepSeek-V4 stores routed experts at ``expert_dtype`` (fp4) distinct from the fp8 attention; sizing experts with the global dtype over-counts and drops the whole MoE from the ceiling."""
+
+    _TOTAL = 864_704_792_696  # real DeepSeek-V4-Pro on-disk total_size (bytes)
+
+    def test_fp4_expert_dtype_keeps_moe_decomposition(self, tmp_path):
+        """expert_dtype=fp4 → total expert bytes (~774 GB) < checkpoint → decomposition survives."""
+        _write_deepseek_v4_model(tmp_path / "m", total_size=self._TOTAL, expert_dtype="fp4")
+        meta = load_model_meta(tmp_path / "m")
+        assert meta is not None
+        assert meta.num_experts == 384
+        assert meta.experts_per_tok == 6
+        assert meta.expert_weight_dtype_bytes == 0.5
+        assert 0 < meta.active_weight_bytes < meta.weight_bytes
+        assert 0 < meta.expert_weight_bytes < meta.weight_bytes
+
+    def test_global_fp8_dtype_trips_safe_degrade(self, tmp_path):
+        """Without expert_dtype the experts are sized at fp8 → computed bytes exceed the checkpoint → MoE silently dropped (the bug this fix targets)."""
+        _write_deepseek_v4_model(tmp_path / "m", total_size=self._TOTAL, expert_dtype=None)
+        meta = load_model_meta(tmp_path / "m")
+        assert meta is not None
+        # Safe-degrade path: no expert decomposition, active == total.
+        assert meta.num_experts == 0
+        assert meta.expert_weight_bytes == 0
+        assert meta.active_weight_bytes == meta.weight_bytes
+
+    def test_perfmodel_counts_moe_and_lowers_peak(self, tmp_path):
+        """With fp4 experts the PerfModel emits a moe_fused op and the peak drops far below the attention-only (safe-degraded) ceiling."""
+        state_kwargs = dict(
+            gpu_type="mi355x",
+            tp=8,
+            precision="fp8",
+            framework="vllm",
+            conc=64,
+            isl=1024,
+            osl=1024,
+        )
+        _write_deepseek_v4_model(tmp_path / "fp4", total_size=self._TOTAL, expert_dtype="fp4")
+        _write_deepseek_v4_model(tmp_path / "degraded", total_size=self._TOTAL, expert_dtype=None)
+
+        meta_fp4 = load_model_meta(tmp_path / "fp4")
+        assert meta_fp4 is not None
+        pm = compute_roofline_from_perfmodel(
+            meta=meta_fp4,
+            gpu_type="mi355x",
+            concurrency=64,
+            isl=1024,
+            osl=1024,
+            num_gpus=8,
+            precision_tag="fp8",
+        )
+        assert pm is not None
+        assert any(op.name == "moe_fused" for op in pm.ops)
+
+        fp4_peak = compute_peak_from_state(
+            SimpleNamespace(model_path=str(tmp_path / "fp4"), **state_kwargs)
+        )
+        degraded_peak = compute_peak_from_state(
+            SimpleNamespace(model_path=str(tmp_path / "degraded"), **state_kwargs)
+        )
+        assert fp4_peak > 0.0
+        # Counting the fp4 expert IO must pull the ceiling well below the
+        # attention-only (MoE-dropped) estimate that produced within% ~= 2.6%.
+        assert fp4_peak < degraded_peak * 0.5
 
 
 class TestMoEActiveWeightBytes:

--- a/src/hyperloom/inference_optimizer/tests/test_workload_envs_branches_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_workload_envs_branches_unit.py
@@ -6,6 +6,7 @@ sizing."""
 
 from __future__ import annotations
 
+import json
 import sys
 from types import SimpleNamespace
 
@@ -259,6 +260,81 @@ def test_mimo_v2_injects_triton_attention(monkeypatch, tmp_path):
     src = _write(tmp_path / "cfg.yaml")
     bench = _materialize(src, tmp_path / "out", model_path="/wekafs/models/MiMo-V2-7B")
     assert "attention-backend triton" in bench["envs"]["EXTRA_SGLANG_ARGS"]
+
+
+def _write_sparse_model_dir(tmp_path, *, sparse_block_size=128, nested=False, name="model"):
+    """Write a minimal model dir whose config.json declares a sparse block size.
+
+    ``nested`` places ``sparse_attention_config`` under ``text_config`` (the
+    multimodal-wrapper layout) to exercise the merged-scope read path.
+    """
+    d = tmp_path / name
+    d.mkdir(exist_ok=True)
+    sparse = {"sparse_attention_config": {"sparse_block_size": sparse_block_size}}
+    cfg: dict = {"model_type": "minimax_m3"}
+    cfg.update({"text_config": sparse} if nested else sparse)
+    (d / "config.json").write_text(json.dumps(cfg), encoding="utf-8")
+    return str(d)
+
+
+def test_sparse_model_injects_block_size_from_config_vllm(monkeypatch, tmp_path):
+    # Config-derived: any model declaring sparse_attention_config.sparse_block_size
+    # gets that value as vLLM --block-size (default 16 aborts KV-cache init).
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_DISABLE_TP_CLAMP", "1")
+    model_dir = _write_sparse_model_dir(tmp_path, sparse_block_size=128)
+    src = _write(tmp_path / "cfg.yaml", framework="vllm")
+    bench = _materialize(src, tmp_path / "out", model_path=model_dir)
+    assert "--block-size 128" in bench["envs"]["EXTRA_VLLM_ARGS"]
+
+
+def test_sparse_block_size_read_from_nested_text_config(monkeypatch, tmp_path):
+    # sparse_attention_config nested under text_config (multimodal wrapper); the
+    # value is model-derived, not hardcoded (here 64 to prove it is read).
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_DISABLE_TP_CLAMP", "1")
+    model_dir = _write_sparse_model_dir(tmp_path, sparse_block_size=64, nested=True)
+    src = _write(tmp_path / "cfg.yaml", framework="vllm")
+    bench = _materialize(src, tmp_path / "out", model_path=model_dir)
+    assert "--block-size 64" in bench["envs"]["EXTRA_VLLM_ARGS"]
+
+
+def test_dense_model_no_block_size_injection(monkeypatch, tmp_path):
+    # No sparse_attention_config -> nothing injected (dense models untouched).
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_DISABLE_TP_CLAMP", "1")
+    d = tmp_path / "dense"
+    d.mkdir()
+    (d / "config.json").write_text(json.dumps({"model_type": "llama"}), encoding="utf-8")
+    src = _write(tmp_path / "cfg.yaml", framework="vllm")
+    bench = _materialize(src, tmp_path / "out", model_path=str(d))
+    assert "block-size" not in bench["envs"].get("EXTRA_VLLM_ARGS", "")
+
+
+def test_sparse_model_block_size_not_injected_for_sglang(monkeypatch, tmp_path):
+    # --block-size is a vLLM flag; sglang rejects it, so the injection is
+    # vLLM-scoped and must never touch a sglang run.
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_DISABLE_TP_CLAMP", "1")
+    model_dir = _write_sparse_model_dir(tmp_path, sparse_block_size=128)
+    src = _write(tmp_path / "cfg.yaml", framework="sglang")
+    bench = _materialize(src, tmp_path / "out", model_path=model_dir)
+    assert "block-size" not in bench["envs"].get("EXTRA_SGLANG_ARGS", "")
+    assert "block-size" not in bench["envs"].get("EXTRA_VLLM_ARGS", "")
+
+
+def test_sparse_model_respects_operator_pinned_block_size(monkeypatch, tmp_path):
+    # An explicit operator/explore --block-size wins; we must not append a
+    # second conflicting --block-size.
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_DISABLE_TP_CLAMP", "1")
+    model_dir = _write_sparse_model_dir(tmp_path, sparse_block_size=128)
+    src = _write(tmp_path / "cfg.yaml", framework="vllm")
+    bench = _materialize(
+        src, tmp_path / "out", model_path=model_dir, extra_server_args="--block-size 64"
+    )
+    assert "--block-size 64" in bench["envs"]["EXTRA_VLLM_ARGS"]
+    assert "--block-size 128" not in bench["envs"]["EXTRA_VLLM_ARGS"]
 
 
 def test_run_eval_from_env(monkeypatch, tmp_path):

--- a/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
+++ b/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
@@ -47,6 +47,7 @@ from hyperloom.inference_optimizer.model_config_utils import (
     _fp8_is_per_channel_per_token,
     _load_model_config_dict,
     _model_is_gemma2,
+    _sparse_kv_block_size,
 )
 
 log = logging.getLogger(__name__)
@@ -815,6 +816,36 @@ def materialize_config_with_envs(
                     merge_server_args(_mimo_hf_existing, _mimo_arch_override)
                     if _mimo_hf_existing
                     else _mimo_arch_override
+                )
+    # Sparse-attention KV-cache block size (config-derived, model-agnostic).
+    # Models like MiniMax-M3 (MSA) place the main K/V and the indexer side-cache
+    # in one KV-cache group whose sparse backends only accept the model's
+    # sparse_attention_config.sparse_block_size (e.g. 128). vLLM's default
+    # --block-size 16 (and the value Magpie bakes in when EXTRA_VLLM_ARGS is
+    # empty) has no common block size with it, so KV-cache init aborts with
+    # "No common block size for 16" -- baseline, roofline, and every
+    # explore/sweep variant crash at startup. Read the required size from the
+    # model config and pin --block-size at this shared choke point so it rides
+    # EXTRA_VLLM_ARGS on every path (the roofline path in particular seeds from
+    # the current-best delta and would otherwise drop the baseline's block size
+    # and fall back to the default). vLLM-only: --block-size is a vLLM flag
+    # (sglang rejects it; its sparse page size is set differently). Merge (never
+    # overwrite) and skip when a --block-size is already pinned so an explicit
+    # operator/explore choice wins; the later dedup_vllm_server_args collapses
+    # any duplicate last-wins anyway. Config unreadable (e.g. an uncached
+    # hub-id) -> None -> no injection, prior behaviour preserved.
+    if "vllm" in str(bench.get("framework") or "").lower():
+        _sparse_bs = _sparse_kv_block_size(str(model_path or bench.get("model") or ""))
+        if _sparse_bs:
+            from ._grid_runner import merge_server_args
+
+            _sp_fw_env = server_args_env_name(bench.get("framework"))
+            _sp_existing = str(envs.get(_sp_fw_env, "")).strip()
+            if "block-size" not in _sp_existing and "block_size" not in _sp_existing:
+                envs[_sp_fw_env] = (
+                    merge_server_args(_sp_existing, f"--block-size {_sparse_bs}")
+                    if _sp_existing
+                    else f"--block-size {_sparse_bs}"
                 )
     # sglang server-arg guards, applied at the FINAL framework env so any
     # operator-pinned flag is honored and never doubled. No-ops for vllm/atom.

--- a/src/hyperloom/orchestrator/kernel/roofline_ceiling.py
+++ b/src/hyperloom/orchestrator/kernel/roofline_ceiling.py
@@ -19,6 +19,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from hyperloom.inference_optimizer.model_config_utils import _merge_config_scopes
+
 
 #: GPU per-chip peak specs (keys match ``SharedState.gpu_type``, lowercase).
 #: ``hbm_bw_gbps`` is vendor peak; ``peak_tflops`` is DENSE peak (missing key
@@ -698,9 +700,18 @@ def _read_hf_config(model_path: Path) -> dict[str, Any] | None:
     if not cfg.is_file():
         return None
     try:
-        return json.loads(cfg.read_text(encoding="utf-8"))
+        data = json.loads(cfg.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
+    if not isinstance(data, dict):
+        return None
+    # Multimodal wrappers (e.g. Kimi-K2 kimi_k25) nest the real decoder shape /
+    # MoE config under text_config/llm_config/language_config; flatten it (nested
+    # wins) so num_experts / hidden_size / moe_intermediate_size / kv-heads reach
+    # the ceiling readers instead of degrading to a dense full-weight roofline
+    # (num_experts=0 -> active_weight_bytes = full weight_bytes; PerfModel falls
+    # back to the legacy top-down formula).
+    return _merge_config_scopes(data)
 
 
 def _derive_kv_heads(cfg: dict[str, Any]) -> int:

--- a/src/hyperloom/orchestrator/kernel/roofline_ceiling.py
+++ b/src/hyperloom/orchestrator/kernel/roofline_ceiling.py
@@ -638,6 +638,11 @@ class ModelMeta:
     num_experts: int = 0
     experts_per_tok: int = 0
     expert_weight_bytes: int = 0
+    # Per-element bytes for the expert (routed FFN) weights. Some MoE checkpoints
+    # store experts at a *different* precision than the rest of the model (e.g.
+    # DeepSeek-V4 ``expert_dtype: fp4`` while ``quant_method: fp8``). 0 ⇒ same as
+    # ``weight_dtype_bytes`` (dense or uniform-precision MoE).
+    expert_weight_dtype_bytes: float = 0.0
     # Extra HF config fields for per-op PerfModel breakdown (0 = unavailable).
     hidden_size: int = 0
     intermediate_size: int = 0
@@ -753,13 +758,23 @@ def _compute_expert_decomposition(
     *,
     weight_bytes: int,
     dtype_bytes: float,
+    expert_dtype_bytes: float = 0.0,
 ) -> tuple[int, int, int, int]:
     """MoE decomposition for the batch-aware roofline; returns ``(active_weight_bytes, total_expert_bytes, num_experts, experts_per_tok)``. Safe-degrades to ``(weight_bytes, 0, 0, 0)``. Handles num_experts / n_routed_experts / num_local_experts aliases.
+
+    ``expert_dtype_bytes`` sizes the routed-expert weights when they are stored
+    at a different precision than the rest of the model (e.g. DeepSeek-V4
+    ``expert_dtype: fp4`` under ``quant_method: fp8``); ``0`` falls back to
+    ``dtype_bytes``. Using the global dtype here over-counts expert bytes for
+    such checkpoints, tripping the ``total_expert_bytes >= weight_bytes``
+    safe-degrade and silently dropping the entire MoE from the ceiling.
 
     Args:
         cfg: Parsed HF ``config.json``.
         weight_bytes: Total weight bytes (the safe-degrade fallback).
-        dtype_bytes: Weight bytes-per-element.
+        dtype_bytes: Weight bytes-per-element (non-expert / fallback).
+        expert_dtype_bytes: Bytes-per-element for the routed-expert weights;
+            ``0`` falls back to ``dtype_bytes``.
 
     Returns:
         A tuple of ``(active_weight_bytes, total_expert_bytes, num_experts,
@@ -777,9 +792,10 @@ def _compute_expert_decomposition(
     hidden_size = int(cfg.get("hidden_size") or 0)
     num_layers = int(cfg.get("num_hidden_layers") or 0)
     moe_inter = int(cfg.get("moe_intermediate_size") or cfg.get("intermediate_size") or 0)
-    if hidden_size <= 0 or num_layers <= 0 or moe_inter <= 0 or dtype_bytes <= 0:
+    expert_bpe = expert_dtype_bytes if expert_dtype_bytes > 0 else dtype_bytes
+    if hidden_size <= 0 or num_layers <= 0 or moe_inter <= 0 or expert_bpe <= 0:
         return int(weight_bytes), 0, 0, 0
-    expert_bytes_per_layer = num_experts * 3 * hidden_size * moe_inter * dtype_bytes
+    expert_bytes_per_layer = num_experts * 3 * hidden_size * moe_inter * expert_bpe
     total_expert_bytes = int(num_layers * expert_bytes_per_layer)
     if total_expert_bytes <= 0 or total_expert_bytes >= int(weight_bytes):
         return int(weight_bytes), 0, 0, 0
@@ -836,10 +852,16 @@ def load_model_meta(
     if isinstance(quant_cfg, dict):
         quant_tag = str(quant_cfg.get("quant_method", "")).strip().lower()
     dtype_bytes = _resolve_dtype_bytes(quant_tag or cfg.get("torch_dtype") or cfg.get("dtype") or precision_hint)
+    # Routed experts may be stored at a distinct precision (DeepSeek-V4
+    # ``expert_dtype: fp4`` under fp8 attention). Fall back to the global dtype
+    # when the field is absent (uniform-precision MoE / dense).
+    expert_dtype_raw = str(cfg.get("expert_dtype") or "").strip()
+    expert_dtype_bytes = _resolve_dtype_bytes(expert_dtype_raw) if expert_dtype_raw else dtype_bytes
     active_weight_bytes, total_expert_bytes, num_experts, experts_per_tok = _compute_expert_decomposition(
         cfg,
         weight_bytes=weight_bytes,
         dtype_bytes=dtype_bytes,
+        expert_dtype_bytes=expert_dtype_bytes,
     )
     intermediate_size = int(cfg.get("intermediate_size") or 0)
     moe_intermediate_size = int(cfg.get("moe_intermediate_size") or 0)
@@ -855,6 +877,7 @@ def load_model_meta(
         num_experts=num_experts,
         experts_per_tok=experts_per_tok,
         expert_weight_bytes=total_expert_bytes,
+        expert_weight_dtype_bytes=(expert_dtype_bytes if num_experts > 0 else 0.0),
         hidden_size=int(cfg.get("hidden_size") or 0),
         intermediate_size=intermediate_size,
         moe_intermediate_size=moe_intermediate_size,
@@ -1889,6 +1912,9 @@ def compute_roofline_from_perfmodel(
         return None
     f_peak = f_peak_tflops * 1e12
     bpe = float(meta.weight_dtype_bytes or 2.0)
+    # Routed-expert weights may be a distinct precision (e.g. DeepSeek-V4 fp4
+    # experts under fp8 attention); size the MoE reads with it. 0 ⇒ same as bpe.
+    expert_bpe = float(meta.expert_weight_dtype_bytes or bpe)
     # Activations (input/output) are at least bf16 even for quantized-weight models.
     act_bpe = max(bpe, 2.0)
 
@@ -1984,7 +2010,7 @@ def compute_roofline_from_perfmodel(
                 meta.moe_intermediate_size,
                 meta.num_experts,
                 meta.experts_per_tok,
-                bpe,
+                expert_bpe,
                 act_bpe,
             )
             t_moe, side_moe, t_mem_moe, t_cmp_moe = _roofline_time(fl_moe, by_moe)


### PR DESCRIPTION
## Summary

- **Config-driven vLLM `--block-size` for sparse-attention models.** Sparse models (e.g. MiniMax-M3 MSA) put the main K/V and the indexer side-cache in one KV-cache group whose backends only accept the model's `sparse_attention_config.sparse_block_size` (e.g. 128). vLLM's default `--block-size 16` (and the value Magpie bakes in when `EXTRA_VLLM_ARGS` is empty) has no common block size with it, so KV-cache init aborts with `No common block size for 16` — crashing baseline, roofline, and every explore/sweep variant. A new model-agnostic helper `_sparse_kv_block_size` reads the required size from the model config, and `materialize_config_with_envs` pins `--block-size` at that shared choke point so it rides `EXTRA_VLLM_ARGS` on every path. vLLM-only; skips when a `--block-size` is already pinned (operator/explore wins); unreadable config → no injection (prior behaviour).

- **Resolve HF repo-id before the compat-preflight detectors.** `_run_compat_detector` passed the raw `model_path` to every detector, so a repo-id launch made `Path(repo_id).is_dir()` False and the disk-reading detectors (`amd_unsupported_quant` / `private_quant` / `peft_adapter_only` / `vocab_weight_shape` / tokenizer sub-chain / `amd_dual_chunk_attention`) silently skipped — deferring "incompatible checkpoint" rejection to server init. Now the path is resolved once via `resolve_local_model_dir` before dispatch so all detectors see a real directory; unresolvable → falls back to the raw path.

## Test plan

- [x] `_sparse_kv_block_size` unit tests: top-level, nested `text_config`, dense model → None, unreadable config → None
- [x] Injection tests: vLLM injects from config; sglang untouched; dense model untouched; operator-pinned `--block-size` wins
- [x] `_run_compat_detector` resolves a repo-id before dispatch; falls back to raw path when unresolvable
- [x] 203 passed across the touched suites (`test_workload_envs_branches_unit`, `test_model_config_summary`, `test_model_config_compat_preflight`)

## Notes

- Does not close the deeper gap where roofline/phases seed args from the current-best delta and can drop other baseline args; this pins `--block-size` at the choke point so it is re-applied on every path.
- Cold-cache edge: a brand-new uncached repo-id whose `config.json` isn't yet local reads as None → no injection on that first attempt; self-heals once the cache is warm. Not addressed here.
