### PR TITLE
Fix lm-eval cleanup deleting Magpie traces

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_eval_result_dir_wiring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_eval_result_dir_wiring.py
@@ -277,6 +277,42 @@ def test_baseline_parses_accuracy_from_eval_result_dir(tmp_path):
     assert result.get("accuracy_task") == "gsm8k"
 
 
+def test_baseline_parses_accuracy_after_eval_result_dir_cleanup(tmp_path):
+    base = tmp_path / "base.yaml"
+    _write_yaml(base)
+    output_dir = tmp_path / "ws"
+
+    def fake_run(cmd, *args, **kwargs):
+        out_idx = cmd.index("--output-dir")
+        slot = Path(cmd[out_idx + 1])
+        env = dict(kwargs.get("env") or {})
+        _fake_workspace(slot)
+        eval_root = Path(env["EVAL_RESULT_DIR"])
+        raw_result = _write_lm_eval_output(eval_root)
+        processed_dir = Path(env["RESULT_DIR"]) / "eval_processed" / raw_result.parent.name
+        processed_dir.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(raw_result.parent), str(processed_dir))
+        shutil.rmtree(eval_root)
+        return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+    executor = BaselineExecutor(
+        magpie_python="/opt/venv/bin/python",
+        default_config_path=base,
+        session_dir=tmp_path,
+    )
+    ctx = _make_ctx({"output_dir": str(output_dir), "timeout_sec": 10})
+
+    with patch(
+        "hyperloom.orchestrator.actions.executors.baseline.run_with_session_kill",
+        side_effect=fake_run,
+    ):
+        result = asyncio.run(executor(ctx))
+
+    assert result["status"] == "succeeded"
+    assert result.get("accuracy") == pytest.approx(0.83)
+    assert "eval_processed" in (result.get("accuracy_source") or "")
+
+
 def test_baseline_mn_warmup_eval_result_dir_is_discarded(tmp_path, monkeypatch):
     base = tmp_path / "base.yaml"
     _write_yaml(base)
@@ -401,6 +437,21 @@ def test_parse_eval_results_ignores_discarded_warmup_round(tmp_path):
     out = parse_eval_results(slot, framework="vllm")
     assert out.get("accuracy") == pytest.approx(0.90)
     assert "warmup_round" not in (out.get("source_file") or "")
+
+
+def test_parse_eval_results_ignores_discarded_mn_warmup_round(tmp_path):
+    slot = tmp_path / "baseline"
+    _write_results_score(
+        slot / "eval_processed" / "Qwen__model" / "results_2026-07-15T10-00-00.000000.json",
+        0.90,
+    )
+    _write_results_score(
+        slot / "mn_warmup" / "eval_output" / "Qwen__model" / "results_2026-07-15T09-00-00.000000.json",
+        0.50,
+    )
+    out = parse_eval_results(slot, framework="vllm")
+    assert out.get("accuracy") == pytest.approx(0.90)
+    assert "mn_warmup" not in (out.get("source_file") or "")
 
 
 def test_parse_eval_results_keeps_results_when_root_is_warmup_slot(tmp_path):

--- a/src/hyperloom/inference_optimizer/tests/test_eval_result_dir_wiring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_eval_result_dir_wiring.py
@@ -5,11 +5,12 @@
 InferenceX ``run_lm_eval`` (benchmark_lib.sh) reads ``$EVAL_RESULT_DIR`` for
 lm-eval's ``--output_path``; unset, it falls back to ``/tmp/eval_out-*`` so the
 ``results*.json`` escape the task workspace and the accuracy gate sees no
-baseline (``baseline_accuracy=0.0`` -> throughput-only KEEP). Hyperloom only set
-``$RESULT_DIR``. These tests pin that:
+baseline (``baseline_accuracy=0.0`` -> throughput-only KEEP). These tests pin
+that:
 
-* the baseline / grid subprocess env exports ``$EVAL_RESULT_DIR`` mirrored from
-  ``$RESULT_DIR``; and
+* the baseline / grid subprocess env exports ``$EVAL_RESULT_DIR`` under, but
+  separate from, ``$RESULT_DIR`` so lm-eval cleanup cannot delete Magpie traces;
+  and
 * the accuracy parse search root is aligned to that dir, where lm-eval
   (lm_eval 0.4.9.2) writes ``<root>/<model_sanitized>/results_<ts>.json``.
 """
@@ -18,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import shutil
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -57,9 +59,8 @@ def test_parse_eval_results_finds_lm_eval_output_under_root(tmp_path):
 
 
 def test_parse_eval_results_misses_when_root_is_benchmark_subdir(tmp_path):
-    # Root-cause shape: lm-eval writes under the slot (== $EVAL_RESULT_DIR), a
-    # sibling of the Magpie ``benchmark_*`` workspace. Searching from the
-    # benchmark_* subdir (the pre-fix baseline root) cannot reach the sibling.
+    # lm-eval writes outside the Magpie ``benchmark_*`` workspace. Searching from
+    # the benchmark_* subdir (the pre-fix baseline root) cannot reach it.
     _write_lm_eval_output(tmp_path)
     bench_ws = tmp_path / "benchmark_sglang_20260715_010101"
     bench_ws.mkdir(parents=True)
@@ -70,7 +71,7 @@ def test_parse_eval_results_misses_when_root_is_benchmark_subdir(tmp_path):
 # --- Grid runner env wiring ---
 
 
-def test_run_magpie_exports_eval_result_dir_mirrored_from_result_dir(tmp_path, monkeypatch):
+def test_run_magpie_exports_eval_result_dir_under_result_dir(tmp_path, monkeypatch):
     monkeypatch.setenv("PYTEST_CURRENT_TEST", "skip-kill")
     captured: dict = {}
 
@@ -89,8 +90,8 @@ def test_run_magpie_exports_eval_result_dir_mirrored_from_result_dir(tmp_path, m
             timeout_sec=5,
             cwd=str(tmp_path),
         )
-    assert captured["env"].get("EVAL_RESULT_DIR") == captured["env"]["RESULT_DIR"]
-    assert captured["env"]["EVAL_RESULT_DIR"] == str(tmp_path / "slot")
+    assert captured["env"]["RESULT_DIR"] == str(tmp_path / "slot")
+    assert captured["env"]["EVAL_RESULT_DIR"] == str(tmp_path / "slot" / "eval_output")
 
 
 def test_run_magpie_eval_result_dir_follows_result_dir_override(tmp_path, monkeypatch):
@@ -113,8 +114,39 @@ def test_run_magpie_eval_result_dir_follows_result_dir_override(tmp_path, monkey
             cwd=str(tmp_path),
             result_dir="/tmp/redirect_leak",
         )
-    assert captured["env"]["EVAL_RESULT_DIR"] == "/tmp/redirect_leak"
     assert captured["env"]["RESULT_DIR"] == "/tmp/redirect_leak"
+    assert captured["env"]["EVAL_RESULT_DIR"] == "/tmp/redirect_leak/eval_output"
+
+
+def test_run_magpie_keeps_magpie_traces_when_eval_output_is_cleaned(tmp_path, monkeypatch):
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "skip-kill")
+    output_dir = tmp_path / "slot"
+    trace_file = output_dir / "benchmark_sglang_20260716_010101" / "magpie_trace.json"
+
+    def fake_run(cmd, *args, **kwargs):
+        env = dict(kwargs.get("env") or {})
+        trace_file.parent.mkdir(parents=True)
+        trace_file.write_text("{}", encoding="utf-8")
+        eval_dir = Path(env["EVAL_RESULT_DIR"])
+        (eval_dir / "model__sanitized").mkdir(parents=True, exist_ok=True)
+        (eval_dir / "model__sanitized" / "results.json").write_text("{}", encoding="utf-8")
+        # Match benchmark_lib.sh cleanup after lm-eval output is processed.
+        shutil.rmtree(eval_dir)
+        return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+    with patch(
+        "hyperloom.orchestrator.actions.executors._grid_runner.run_with_session_kill",
+        side_effect=fake_run,
+    ):
+        _run_magpie(
+            magpie_python="/opt/venv/bin/python",
+            config_path=tmp_path / "config.yaml",
+            output_dir=output_dir,
+            timeout_sec=5,
+            cwd=str(tmp_path),
+        )
+
+    assert trace_file.exists()
 
 
 # --- Baseline executor env wiring + accuracy parse ---
@@ -205,8 +237,8 @@ def test_baseline_exports_eval_result_dir_env(tmp_path):
         result = asyncio.run(executor(ctx))
 
     assert result["status"] == "succeeded"
-    assert captured["env"].get("EVAL_RESULT_DIR") == captured["env"]["RESULT_DIR"]
-    assert captured["env"]["EVAL_RESULT_DIR"] == str(output_dir)
+    assert captured["env"]["RESULT_DIR"] == str(output_dir)
+    assert captured["env"]["EVAL_RESULT_DIR"] == str(output_dir / "eval_output")
 
 
 def test_baseline_parses_accuracy_from_eval_result_dir(tmp_path):

--- a/src/hyperloom/inference_optimizer/tests/test_eval_result_dir_wiring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_eval_result_dir_wiring.py
@@ -277,6 +277,53 @@ def test_baseline_parses_accuracy_from_eval_result_dir(tmp_path):
     assert result.get("accuracy_task") == "gsm8k"
 
 
+def test_baseline_mn_warmup_eval_result_dir_is_discarded(tmp_path, monkeypatch):
+    base = tmp_path / "base.yaml"
+    _write_yaml(base)
+    output_dir = tmp_path / "ws"
+    calls: list[tuple[Path, dict]] = []
+
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_NODES", "2")
+
+    async def fake_restart_server_for_round(*args, **kwargs):
+        return None
+
+    from hyperloom.orchestrator.actions.executors import _multi_node_server_lifecycle as mnl
+
+    monkeypatch.setattr(mnl, "restart_server_for_round", fake_restart_server_for_round)
+
+    def fake_run(cmd, *args, **kwargs):
+        out_idx = cmd.index("--output-dir")
+        slot = Path(cmd[out_idx + 1])
+        env = dict(kwargs.get("env") or {})
+        calls.append((slot, env))
+        if slot.name == "mn_warmup":
+            _write_lm_eval_output(Path(env["EVAL_RESULT_DIR"]))
+        else:
+            _fake_workspace(slot)
+        return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+    executor = BaselineExecutor(
+        magpie_python="/opt/venv/bin/python",
+        default_config_path=base,
+        session_dir=tmp_path,
+    )
+    ctx = _make_ctx({"output_dir": str(output_dir), "timeout_sec": 10})
+
+    with patch(
+        "hyperloom.orchestrator.actions.executors.baseline.run_with_session_kill",
+        side_effect=fake_run,
+    ):
+        result = asyncio.run(executor(ctx))
+
+    assert result["status"] == "succeeded"
+    assert [slot.name for slot, _env in calls] == ["mn_warmup", "ws"]
+    assert calls[0][1]["RESULT_DIR"] == str(output_dir / "mn_warmup")
+    assert calls[0][1]["EVAL_RESULT_DIR"] == str(output_dir / "mn_warmup" / "eval_output")
+    assert calls[1][1]["EVAL_RESULT_DIR"] == str(output_dir / "eval_output")
+    assert result.get("accuracy") is None
+
+
 def test_baseline_skips_accuracy_when_run_eval_disabled(tmp_path):
     """RUN_EVAL off -> no accuracy parse, even if the slot holds stale results.
 

--- a/src/hyperloom/orchestrator/actions/executors/_accuracy_gate.py
+++ b/src/hyperloom/orchestrator/actions/executors/_accuracy_gate.py
@@ -287,17 +287,16 @@ def parse_eval_results(
     result_files: list[Path] = []
     for pattern in search_paths:
         result_files.extend(Path(f) for f in glob.glob(str(pattern), recursive=True))
-    # Never grade a discarded cold-start warmup round: ``run_grid`` (used by
-    # integrate_patch) and the baseline double-run both nest the throwaway round
-    # under a ``warmup_round/`` slot whose eval output is discarded. When the
-    # search root sits ABOVE such a round (e.g. integrate_patch grades from the
-    # grid slot, the parent of the measured ``benchmark_*`` workspace), the
-    # recursive glob would otherwise also match the warmup eval and
-    # ``sorted(...)[-1]`` can lexicographically favor it over the measured round.
-    # Drop nested ``warmup_round/`` results using a workspace-relative check so a
-    # parse rooted AT the warmup slot itself still finds its own output.
+    # Never grade a discarded warmup round: grid/baseline warmups nest throwaway
+    # eval output under a named warmup slot. When the search root sits above such
+    # a slot, the recursive glob would otherwise also match the discarded eval.
+    # Drop nested warmup results using a workspace-relative check so a parse
+    # rooted AT the warmup slot itself still finds its own output.
+    discarded_warmup_dirs = {"warmup_round", "mn_warmup"}
     result_files = [
-        p for p in result_files if "warmup_round" not in p.relative_to(workspace).parts
+        p
+        for p in result_files
+        if discarded_warmup_dirs.isdisjoint(p.relative_to(workspace).parts)
     ]
     if not result_files:
         return {"accuracy": None, "error": f"no results*.json in {workspace}"}

--- a/src/hyperloom/orchestrator/actions/executors/_grid_runner.py
+++ b/src/hyperloom/orchestrator/actions/executors/_grid_runner.py
@@ -814,11 +814,9 @@ def _run_magpie(
         env["MAGPIE_INFERENCEX_PATH"] = inferencex_path
     # RESULT_DIR default; leaks are picked up by the salvage path.
     env["RESULT_DIR"] = result_dir or str(output_dir)
-    # InferenceX ``run_lm_eval`` reads ``$EVAL_RESULT_DIR`` for lm-eval's
-    # ``--output_path``; unset it defaults to ``/tmp/eval_out-*`` and the
-    # ``results*.json`` never reach the task slot, so the accuracy gate finds no
-    # eval output. Mirror it to ``$RESULT_DIR`` so eval artifacts land in the slot.
-    env["EVAL_RESULT_DIR"] = env["RESULT_DIR"]
+    # InferenceX ``run_lm_eval`` cleans ``$EVAL_RESULT_DIR`` after processing
+    # lm-eval output. Keep it under the task slot but separate from Magpie traces.
+    env["EVAL_RESULT_DIR"] = str(Path(env["RESULT_DIR"]) / "eval_output")
     # Pin SERVER_LOG / GPU_METRICS_CSV per-task so logs land alongside
     # ``benchmark_report.json``. Always overwrite so a stale parent value can't
     # redirect into a prior run's slot.

--- a/src/hyperloom/orchestrator/actions/executors/baseline.py
+++ b/src/hyperloom/orchestrator/actions/executors/baseline.py
@@ -1779,6 +1779,7 @@ class BaselineExecutor:
                 _mn_warm_cmd = [str(_mn_warm_dir) if c == str(output_dir) else c for c in cmd]
                 _mn_warm_env = dict(env)
                 _mn_warm_env["RESULT_DIR"] = str(_mn_warm_dir)
+                _mn_warm_env["EVAL_RESULT_DIR"] = str(_mn_warm_dir / "eval_output")
                 _mn_warm_env["SERVER_LOG"] = str(_mn_warm_dir / "server.log")
                 _mn_warm_env["GPU_METRICS_CSV"] = str(_mn_warm_dir / "gpu_metrics.csv")
                 await asyncio.to_thread(

--- a/src/hyperloom/orchestrator/actions/executors/baseline.py
+++ b/src/hyperloom/orchestrator/actions/executors/baseline.py
@@ -1690,12 +1690,10 @@ class BaselineExecutor:
         # Always-on ``$RESULT_DIR`` default for scripts that respect it; scripts
         # that ignore it are caught by the salvage pass.
         env["RESULT_DIR"] = override_result_dir or str(output_dir)
-        # InferenceX ``run_lm_eval`` reads ``$EVAL_RESULT_DIR`` for lm-eval's
-        # ``--output_path``; unset it defaults to ``/tmp/eval_out-*`` and the
-        # ``results*.json`` never reach the task workspace, so the accuracy gate
-        # finds no baseline. Mirror it to ``$RESULT_DIR`` so eval artifacts land
-        # under ``output_dir`` (a sibling of the Magpie ``benchmark_*`` dir).
-        env["EVAL_RESULT_DIR"] = env["RESULT_DIR"]
+        # InferenceX ``run_lm_eval`` cleans ``$EVAL_RESULT_DIR`` after processing
+        # lm-eval output. Keep it under the task workspace but separate from
+        # Magpie's ``benchmark_*`` traces in ``$RESULT_DIR``.
+        env["EVAL_RESULT_DIR"] = str(Path(env["RESULT_DIR"]) / "eval_output")
         # Pin SERVER_LOG / GPU_METRICS_CSV per-task so wrappers write into the
         # task workspace; ``harvest_leaked_artifacts`` is the defense-in-depth net.
         env["SERVER_LOG"] = str(output_dir / "server.log")
@@ -2087,11 +2085,11 @@ class BaselineExecutor:
         else:
             from ._accuracy_gate import parse_eval_results
 
-            # lm-eval writes ``results*.json`` under ``$EVAL_RESULT_DIR`` (== the
-            # ``RESULT_DIR`` set above), a sibling of (not inside) the Magpie
-            # ``benchmark_*`` workspace. Search from that root so the recursive
-            # ``**/results*.json`` glob finds it.
-            eval_search_root = Path(env["EVAL_RESULT_DIR"])
+            # Serving lm-eval writes ``results*.json`` under ``$EVAL_RESULT_DIR``;
+            # scriptable quality gates live in Magpie's ``$RESULT_DIR`` reports.
+            eval_search_root = Path(
+                env["RESULT_DIR"] if eval_scriptable else env["EVAL_RESULT_DIR"]
+            )
             eval_data = parse_eval_results(eval_search_root, framework=eval_framework)
             if eval_data.get("accuracy") is not None:
                 result["accuracy"] = eval_data["accuracy"]

--- a/src/hyperloom/orchestrator/actions/executors/baseline.py
+++ b/src/hyperloom/orchestrator/actions/executors/baseline.py
@@ -2086,11 +2086,10 @@ class BaselineExecutor:
         else:
             from ._accuracy_gate import parse_eval_results
 
-            # Serving lm-eval writes ``results*.json`` under ``$EVAL_RESULT_DIR``;
-            # scriptable quality gates live in Magpie's ``$RESULT_DIR`` reports.
-            eval_search_root = Path(
-                env["RESULT_DIR"] if eval_scriptable else env["EVAL_RESULT_DIR"]
-            )
+            # Search from ``$RESULT_DIR`` so serving runs survive benchmark_lib.sh
+            # moving/cleaning ``$EVAL_RESULT_DIR`` and scriptable quality gates
+            # still resolve from Magpie's benchmark reports.
+            eval_search_root = Path(env["RESULT_DIR"])
             eval_data = parse_eval_results(eval_search_root, framework=eval_framework)
             if eval_data.get("accuracy") is not None:
                 result["accuracy"] = eval_data["accuracy"]

--- a/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
+++ b/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
@@ -2305,11 +2305,10 @@ class IntegratePatchExecutor:
             }
 
         accuracy_pass: bool | None = None
-        # lm-eval writes to ``$EVAL_RESULT_DIR`` (== ``RESULT_DIR`` = the grid
-        # slot, i.e. the parent of ``VariantResult.workspace``), not inside the
-        # ``benchmark_*`` workspace. Grade from that slot so the eval output is
-        # found; honor an explicit ``result_dir`` override the same way the grid
-        # subprocess does.
+        # lm-eval writes to ``$EVAL_RESULT_DIR`` under the grid slot, not inside
+        # the ``benchmark_*`` workspace. Grade from the slot so the recursive
+        # search finds eval output while honoring an explicit ``result_dir``
+        # override the same way the grid subprocess does.
         eval_search_root = override_result_dir or (
             str(Path(bench["workspace"]).parent) if bench.get("workspace") else ""
         )


### PR DESCRIPTION
## Summary
- Route lm-eval artifacts to an `eval_output` subdirectory so `benchmark_lib.sh` cleanup cannot remove Magpie traces from `RESULT_DIR`.
- Keep serving accuracy parsing pointed at `EVAL_RESULT_DIR` while scriptable quality gates continue reading Magpie reports from `RESULT_DIR`.
- Add a regression test that reproduces issue #904 by cleaning the eval output directory after Magpie traces are written.

## Test plan
- [x] `python -m pytest src/hyperloom/inference_optimizer/tests/test_eval_result_dir_wiring.py src/hyperloom/inference_optimizer/tests/test_grid_runner.py src/hyperloom/inference_optimizer/tests/test_accuracy_gate_units.py -q`
- [x] `python -m pytest src/hyperloom/inference_optimizer/tests -q` (7297 passed, 2 skipped, 6 unrelated existing real-runtime/crash-safe failures)

Fixes #904