### PR TITLE
Fix nonbreaking security diagnostics

### DIFF
--- a/ci/publish_results.py
+++ b/ci/publish_results.py
@@ -12,6 +12,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import requests
+
 # Public forks should opt in with their own results service URL.
 DEFAULT_SERVICE_URL = ""
 
@@ -107,12 +109,18 @@ def publish(
         The decoded JSON response from the import endpoint.
     """
     import time
-    import requests
 
     endpoint = url.rstrip("/") + "/api/import"
     headers = {"Content-Type": "application/json"}
     if token:
         headers["Authorization"] = f"Bearer {token}"
+        if endpoint.lower().startswith("http://"):
+            print(
+                "WARNING: publishing results with a bearer token over HTTP; "
+                "prefer HTTPS for production endpoints.",
+                file=sys.stderr,
+                flush=True,
+            )
     body = {"results": _normalize_submitted_at(results)}
 
     backoff = initial_backoff_s

--- a/ci/test_publish_results.py
+++ b/ci/test_publish_results.py
@@ -1,0 +1,35 @@
+# Copyright Advanced Micro Devices, Inc. All rights reserved.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import publish_results
+
+
+def test_publish_warns_but_allows_http_bearer(monkeypatch, capsys):
+    """HTTP results services remain supported, but token use is visible."""
+    calls = []
+
+    class _Resp:
+        status_code = 200
+        text = "{}"
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return {"ok": True}
+
+    def _post(endpoint, *, headers, json, timeout):
+        calls.append((endpoint, headers, json, timeout))
+        return _Resp()
+
+    monkeypatch.setattr(publish_results, "requests", SimpleNamespace(post=_post, RequestException=Exception))
+
+    out = publish_results.publish([{"run": {}}], "http://results.local", "tok", timeout=3, max_retries=1)
+
+    assert out == {"ok": True}
+    assert calls[0][0] == "http://results.local/api/import"
+    assert calls[0][1]["Authorization"] == "Bearer tok"
+    assert "WARNING" in capsys.readouterr().err

--- a/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
+++ b/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
@@ -3435,6 +3435,16 @@ def test_is_native_source_detects_device_extensions():
         assert not tlr._is_native_source(p), p
 
 
+def test_grep_for_keyword_treats_dash_prefixed_keyword_as_literal(tmp_path):
+    """Profiler-derived names can begin with ``-``; grep must not treat them
+    as command-line options."""
+    src = tmp_path / "kernel.py"
+    src.write_text("def uses_dash_prefixed_name():\n    return '--danger'\n", encoding="utf-8")
+
+    tla._GREP_CACHE.clear()
+    assert tla._grep_for_keyword("--danger", tmp_path) == [src]
+
+
 def test_aggregate_merges_native_kernel_across_call_site_lines(tmp_path):
     """A native .cu kernel invoked from two call sites reports two different
     ``#L`` lines (no Python AST def-line exists). Native sources must key on

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -1943,6 +1943,7 @@ def _grep_for_keyword(keyword: str, root: Path) -> list[Path]:
         "--include=*.h",
         "--include=*.hpp",
         "--include=*.py",
+        "--",
         keyword,
         str(root),
     ]


### PR DESCRIPTION
## Summary
- Treat dash-prefixed TraceLens grep keywords as literals by adding a grep option terminator.
- Add a non-blocking warning when publishing results with a bearer token over HTTP, without changing request behavior.
- Cover both behaviors with focused regression tests.

## Test plan
- `python -m pytest -q src/hyperloom/agents/kernel/tests/test_tracelens_csv.py::test_grep_for_keyword_treats_dash_prefixed_keyword_as_literal ci/test_publish_results.py`
- `python -m ruff check src/hyperloom/agents/kernel/tests/test_tracelens_csv.py src/hyperloom/agents/kernel/tools/tracelens_analysis.py ci/publish_results.py ci/test_publish_results.py`
- Bugbot review: no bugs found.