### PR TITLE
feat(accuracy-gate): stop run on baseline accuracy failure, revert after baseline

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_accuracy_keep_gate.py
+++ b/src/hyperloom/inference_optimizer/tests/test_accuracy_keep_gate.py
@@ -5,7 +5,9 @@
 from __future__ import annotations
 
 from hyperloom.orchestrator.actions.executors._accuracy_gate import (
+    BASELINE_ACCURACY_STOP_REASON,
     accuracy_keep_block,
+    request_baseline_accuracy_stop,
     require_framework_accuracy_default,
 )
 
@@ -56,3 +58,31 @@ def test_require_default_on(monkeypatch):
 def test_require_default_env_off(monkeypatch):
     monkeypatch.setenv("INFERENCE_OPTIMIZER_REQUIRE_FRAMEWORK_ACCURACY", "0")
     assert require_framework_accuracy_default() is False
+
+
+class _StopRecorder:
+    """Minimal SharedState stub capturing ``set_stop_reason`` calls."""
+
+    def __init__(self) -> None:
+        self.stop_reason = ""
+
+    def set_stop_reason(self, value, **_kwargs):
+        self.stop_reason = value
+        return value
+
+
+def test_request_baseline_accuracy_stop_records_reason():
+    ss = _StopRecorder()
+    assert request_baseline_accuracy_stop(ss, context="unit") is True
+    assert ss.stop_reason == BASELINE_ACCURACY_STOP_REASON
+
+
+def test_request_baseline_accuracy_stop_none_shared_state():
+    assert request_baseline_accuracy_stop(None, context="unit") is False
+
+
+def test_request_baseline_accuracy_stop_without_setter():
+    class _NoSetter:
+        pass
+
+    assert request_baseline_accuracy_stop(_NoSetter(), context="unit") is False

--- a/src/hyperloom/inference_optimizer/tests/test_baseline_eval_fallback.py
+++ b/src/hyperloom/inference_optimizer/tests/test_baseline_eval_fallback.py
@@ -269,6 +269,138 @@ def test_non_eval_failure_does_not_retry(tmp_path):
     assert result.get("accuracy_source") != "eval_unavailable"
 
 
+def _make_baseline_ctx(params: dict, shared_state) -> SimpleNamespace:
+    """A genuine ``baseline`` ctx carrying a live SharedState for stop wiring."""
+    task = SimpleNamespace(task_id="t-bl-acc", kind="baseline", params=params)
+    return SimpleNamespace(task=task, extra={"shared_state": shared_state})
+
+
+# --- baseline accuracy missing -> stop the whole run -----------------------
+def test_baseline_missing_accuracy_stops_run(tmp_path):
+    """Serving baseline with eval expected but no accuracy result -> the run
+    halts with ``stop_reason=baseline_accuracy_failed`` (broken setup)."""
+    from hyperloom.orchestrator.state.shared_state import SharedState
+
+    base = tmp_path / "base.yaml"
+    _write_yaml(base)
+
+    def fake_run(cmd, *args, **kwargs):
+        out_idx = cmd.index("--output-dir")
+        _fake_workspace(Path(cmd[out_idx + 1]))  # throughput only, no GSM8K
+        return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+    executor = BaselineExecutor(
+        magpie_python="/opt/venv/bin/python",
+        default_config_path=base,
+        session_dir=tmp_path,
+    )
+    state = SharedState()
+    ctx = _make_baseline_ctx(
+        {
+            "output_dir": str(tmp_path / "ws"),
+            "timeout_sec": 10,
+            "model_path": "/wekafs/models/Qwen-Qwen3-8B",
+            "gpu_type": "mi300x",
+        },
+        state,
+    )
+    with patch(
+        "hyperloom.orchestrator.actions.executors.baseline.run_with_session_kill",
+        side_effect=fake_run,
+    ):
+        result = _run(executor(ctx))
+
+    assert result["status"] == "succeeded"
+    assert result.get("accuracy") is None
+    assert state.stop_reason == "baseline_accuracy_failed"
+
+
+def test_baseline_operator_disabled_eval_does_not_stop(tmp_path):
+    """When the operator explicitly disables the serving eval, accuracy is
+    intentionally off: a missing accuracy result must NOT stop the run."""
+    from hyperloom.orchestrator.state.shared_state import SharedState
+
+    base = tmp_path / "base.yaml"
+    _write_yaml(base)
+
+    def fake_run(cmd, *args, **kwargs):
+        out_idx = cmd.index("--output-dir")
+        _fake_workspace(Path(cmd[out_idx + 1]))
+        return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+    executor = BaselineExecutor(
+        magpie_python="/opt/venv/bin/python",
+        default_config_path=base,
+        session_dir=tmp_path,
+    )
+    state = SharedState()
+    ctx = _make_baseline_ctx(
+        {
+            "output_dir": str(tmp_path / "ws"),
+            "timeout_sec": 10,
+            "model_path": "/wekafs/models/Qwen-Qwen3-8B",
+            "gpu_type": "mi300x",
+            "disable_run_eval": True,
+        },
+        state,
+    )
+    with patch(
+        "hyperloom.orchestrator.actions.executors.baseline.run_with_session_kill",
+        side_effect=fake_run,
+    ):
+        result = _run(executor(ctx))
+
+    assert result["status"] == "succeeded"
+    assert state.stop_reason == ""
+
+
+def test_baseline_eval_failure_fallback_stops_run(tmp_path):
+    """The eval-failure fallback still salvages the throughput baseline, but a
+    genuine baseline with no accuracy result now halts the run."""
+    from hyperloom.orchestrator.state.shared_state import SharedState
+
+    base = tmp_path / "base.yaml"
+    _write_yaml(base)
+
+    def fake_run(cmd, *args, **kwargs):
+        cfg_idx = cmd.index("--benchmark-config")
+        out_idx = cmd.index("--output-dir")
+        cfg = yaml.safe_load(Path(cmd[cfg_idx + 1]).read_text())
+        slot = Path(cmd[out_idx + 1])
+        run_eval = str(cfg["benchmark"]["envs"].get("RUN_EVAL", "true")).lower()
+        if run_eval != "false":
+            return subprocess.CompletedProcess(
+                cmd, 1, "", "ERROR: run_eval failed with exit code 1\n"
+            )
+        _fake_workspace(slot)
+        return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+    executor = BaselineExecutor(
+        magpie_python="/opt/venv/bin/python",
+        default_config_path=base,
+        session_dir=tmp_path,
+    )
+    state = SharedState()
+    ctx = _make_baseline_ctx(
+        {
+            "output_dir": str(tmp_path / "ws"),
+            "timeout_sec": 10,
+            "model_path": "/wekafs/models/Qwen-Qwen3-8B",
+            "gpu_type": "mi300x",
+        },
+        state,
+    )
+    with patch(
+        "hyperloom.orchestrator.actions.executors.baseline.run_with_session_kill",
+        side_effect=fake_run,
+    ):
+        result = _run(executor(ctx))
+
+    assert result["status"] == "succeeded"
+    assert result.get("accuracy_source") == "eval_unavailable"
+    assert state.stop_reason == "baseline_accuracy_failed"
+
+
 def test_eval_already_off_does_not_retry(tmp_path):
     base = tmp_path / "base.yaml"
     _write_yaml(base)

--- a/src/hyperloom/inference_optimizer/tests/test_baseline_eval_fallback.py
+++ b/src/hyperloom/inference_optimizer/tests/test_baseline_eval_fallback.py
@@ -401,6 +401,103 @@ def test_baseline_eval_failure_fallback_stops_run(tmp_path):
     assert state.stop_reason == "baseline_accuracy_failed"
 
 
+class _StopRecorder:
+    """Minimal SharedState stub capturing ``set_stop_reason`` calls."""
+
+    def __init__(self) -> None:
+        self.stop_reason = ""
+
+    def set_stop_reason(self, value, **_kwargs):
+        self.stop_reason = value
+        return value
+
+
+def _stop_ctx(framework: str, recorder) -> SimpleNamespace:
+    task = SimpleNamespace(task_id="t-bl", kind="baseline", params={"framework": framework})
+    return SimpleNamespace(task=task, extra={"shared_state": recorder})
+
+
+def _stopped(framework: str, result: dict) -> str:
+    """Run ``_maybe_stop_on_missing_baseline_accuracy`` and return the reason."""
+    executor = BaselineExecutor()
+    rec = _StopRecorder()
+    executor._maybe_stop_on_missing_baseline_accuracy(_stop_ctx(framework, rec), result)
+    return rec.stop_reason
+
+
+# --- accuracy-stop decision matrix -----------------------------------------
+def test_stop_scriptable_missing_gate_zero_accuracy():
+    # Finding: scriptable fail-closed records accuracy=0.0 -> must still stop.
+    reason = _stopped(
+        "xdit",
+        {"status": "succeeded", "accuracy": 0.0, "run_eval_disabled": True},
+    )
+    assert reason == "baseline_accuracy_failed"
+
+
+def test_stop_serving_no_accuracy_eval_on():
+    reason = _stopped(
+        "sglang",
+        {"status": "succeeded", "run_eval_disabled": False},
+    )
+    assert reason == "baseline_accuracy_failed"
+
+
+def test_stop_serving_zero_accuracy():
+    reason = _stopped(
+        "sglang",
+        {"status": "succeeded", "accuracy": 0.0, "run_eval_disabled": False},
+    )
+    assert reason == "baseline_accuracy_failed"
+
+
+def test_no_stop_serving_operator_disabled_via_config():
+    # Finding: YAML/reference-env RUN_EVAL=false folds into run_eval_disabled;
+    # operator opt-out must NOT stop even without disable_run_eval param.
+    reason = _stopped(
+        "sglang",
+        {"status": "succeeded", "run_eval_disabled": True},
+    )
+    assert reason == ""
+
+
+def test_stop_serving_eval_failure_fallback():
+    # Fallback forces RUN_EVAL=false but eval was expected and broke -> stop.
+    reason = _stopped(
+        "sglang",
+        {
+            "status": "succeeded",
+            "run_eval_disabled": True,
+            "accuracy_source": "eval_unavailable",
+        },
+    )
+    assert reason == "baseline_accuracy_failed"
+
+
+def test_no_stop_valid_accuracy():
+    reason = _stopped(
+        "sglang",
+        {"status": "succeeded", "accuracy": 0.85, "run_eval_disabled": False},
+    )
+    assert reason == ""
+
+
+def test_no_stop_when_not_genuine_baseline():
+    executor = BaselineExecutor()
+    rec = _StopRecorder()
+    task = SimpleNamespace(task_id="t", kind="replay_warm_recipe", params={"framework": "sglang"})
+    ctx = SimpleNamespace(task=task, extra={"shared_state": rec})
+    executor._maybe_stop_on_missing_baseline_accuracy(
+        ctx, {"status": "succeeded", "run_eval_disabled": False}
+    )
+    assert rec.stop_reason == ""
+
+
+def test_no_stop_when_baseline_failed():
+    reason = _stopped("sglang", {"status": "failed", "error": "boom"})
+    assert reason == ""
+
+
 def test_eval_already_off_does_not_retry(tmp_path):
     base = tmp_path / "base.yaml"
     _write_yaml(base)

--- a/src/hyperloom/inference_optimizer/tests/test_explore_executor.py
+++ b/src/hyperloom/inference_optimizer/tests/test_explore_executor.py
@@ -501,6 +501,67 @@ async def test_explore_executor_keeps_and_reverts_per_variant(sub_agent_runner, 
 
 
 @pytest.mark.asyncio
+async def test_explore_serving_no_eval_reverts_without_stopping(sub_agent_runner, tmp_path):
+    """A high-risk serving variant that clears throughput but yields no accuracy
+    verdict used to skip the gate (throughput-only fallback). That fallback is
+    removed: the variant REVERTs (the change likely broke the eval path), but
+    the run does NOT stop -- only a broken baseline halts the run."""
+    sub, tr, _ = sub_agent_runner
+    state = SharedState()
+    state.baseline_tput = 800.0
+    state.baseline_accuracy = 0.80
+    sub.shared_state = state
+
+    base = tmp_path / "base.yaml"
+    _write_baseline_yaml(base)
+    output_dir = tmp_path / "explore-acc-revert"
+
+    def _fake_run(cmd, *args, **kwargs):
+        out_idx = cmd.index("--output-dir")
+        slot = Path(cmd[out_idx + 1])
+        _fake_workspace(slot, tput=840.0)  # +5% vs base 800 (clears throughput)
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
+
+    grid = [
+        {
+            # High-risk (precision) flag -> serving accuracy gate applies.
+            "name": "v_risky",
+            "extra_args": "--kv-cache-dtype fp8",
+            "extra_envs": {},
+            "provenance": "llm_direct",
+        }
+    ]
+    task = await tr.create(
+        kind="explore",
+        params={
+            "config_path": str(base),
+            "output_dir": str(output_dir),
+            "base_tput": 800.0,
+            "accuracy_baseline": 0.80,
+            "grid": grid,
+            "variant_timeout_sec": 10,
+        },
+        idempotency_key="ex-acc-revert",
+    )
+    sub.register_executor("explore", ExploreExecutor(session_dir=tmp_path))
+    with patch(
+        "hyperloom.orchestrator.actions.executors._grid_runner.run_with_session_kill",
+        side_effect=_fake_run,
+    ):
+        res = await sub.run_task(task)
+
+    out = res.result
+    assert out["status"] == "succeeded"
+    fp = canonical_fingerprint("--kv-cache-dtype fp8", {})
+    tested = out["explore_search_update"]["tested"][fp]
+    assert tested["outcome"] == "REVERT"
+    reasons = {lr["name"]: lr.get("reason") for lr in out["losers"]}
+    assert reasons.get("v_risky") == "accuracy_unavailable"
+    # Post-baseline accuracy failure reverts the variant but never halts the run.
+    assert state.stop_reason == ""
+
+
+@pytest.mark.asyncio
 async def test_explore_executor_keep_persists_effective_removal_stack(sub_agent_runner, tmp_path):
     sub, tr, _ = sub_agent_runner
     base = tmp_path / "base.yaml"

--- a/src/hyperloom/inference_optimizer/tests/test_warm_replay.py
+++ b/src/hyperloom/inference_optimizer/tests/test_warm_replay.py
@@ -35,6 +35,7 @@ class _StubSharedState:
     warm_replay_outcome: dict = field(default_factory=dict)
     warm_history_injected: bool = False
     auto_roofline_pending_task_id: str = ""
+    stop_reason: str = ""
     enable_roofline: bool = True
     last_baseline: dict = field(default_factory=dict)
     explore_search: dict = field(default_factory=dict)
@@ -685,6 +686,31 @@ async def test_prelude_initial_analysis_enqueued_after_warm_replay_finishes(
     assert len(coord.tasks.calls) == 2
     assert coord.tasks.calls[1]["idempotency_key"] == ("internal-analysis-prelude_initial")
     assert coord.shared_state.auto_roofline_pending_task_id
+
+
+def test_prelude_bootstrap_runs_on_positive_baseline(tmp_path):
+    coord = _make_coord(tmp_path)
+    assert coord._should_run_prelude_bootstrap(600.0) is True
+
+
+def test_prelude_bootstrap_skipped_without_throughput(tmp_path):
+    coord = _make_coord(tmp_path)
+    assert coord._should_run_prelude_bootstrap(0.0) is False
+    assert coord._should_run_prelude_bootstrap(None) is False
+
+
+def test_prelude_bootstrap_skipped_when_roofline_pending(tmp_path):
+    coord = _make_coord(tmp_path)
+    coord.shared_state.auto_roofline_pending_task_id = "task-roofline"
+    assert coord._should_run_prelude_bootstrap(600.0) is False
+
+
+def test_prelude_bootstrap_skipped_when_stop_pending(tmp_path):
+    """A baseline that halted the run (e.g. baseline_accuracy_failed) must not
+    enqueue/dispatch any post-baseline bootstrap work before the halt fires."""
+    coord = _make_coord(tmp_path)
+    coord.shared_state.stop_reason = "baseline_accuracy_failed"
+    assert coord._should_run_prelude_bootstrap(600.0) is False
 
 
 def test_inject_warm_recipe_history_skips_when_no_recipe(tmp_path):

--- a/src/hyperloom/inference_optimizer/tools/robustness_monitor.sh.example
+++ b/src/hyperloom/inference_optimizer/tools/robustness_monitor.sh.example
@@ -171,7 +171,7 @@ except ImportError:
         "time_exhausted_during_prelude", "cortex_t0_failed",
         "cortex_drain_failed", "cortex_commit_failed",
         "model_context_window_too_small", "unsupported_model_arch",
-        "model_config_incompatible",
+        "model_config_incompatible", "baseline_accuracy_failed",
     })
 
 if stop and stop in STOP_REASON_VOCAB:

--- a/src/hyperloom/orchestrator/actions/executors/_accuracy_gate.py
+++ b/src/hyperloom/orchestrator/actions/executors/_accuracy_gate.py
@@ -22,6 +22,42 @@ log = logging.getLogger(__name__)
 
 ACCURACY_THRESHOLD = 0.05  # allowed deviation
 
+# stop_reason recorded when the baseline could not produce an accuracy result
+# even though the accuracy test was expected to run. A broken baseline accuracy
+# means the environment/config is fundamentally wrong, so the whole run halts
+# rather than optimizing against an unvalidated baseline.
+BASELINE_ACCURACY_STOP_REASON = "baseline_accuracy_failed"
+
+
+def request_baseline_accuracy_stop(shared_state: Any, *, context: str) -> bool:
+    """Halt the run when the baseline accuracy test produced no result.
+
+    Only the baseline stops the run on a missing accuracy verdict: a baseline
+    with no accuracy signal (eval failed or the scriptable quality gate is
+    missing) indicates a fundamentally broken setup. Post-baseline variants that
+    fail the accuracy gate are reverted instead (the offending change is
+    dropped, the run continues).
+
+    Args:
+        shared_state: The live SharedState (``None`` in some unit contexts).
+        context: Short audit tag identifying the call site.
+
+    Returns:
+        bool: ``True`` if a stop reason was recorded.
+    """
+    if shared_state is None:
+        return False
+    setter = getattr(shared_state, "set_stop_reason", None)
+    if not callable(setter):
+        return False
+    log.warning(
+        "baseline accuracy test produced no result (%s); stopping run "
+        "(broken baseline setup)",
+        context,
+    )
+    setter(BASELINE_ACCURACY_STOP_REASON)
+    return True
+
 
 def require_framework_accuracy_default() -> bool:
     """Default for the framework source-patch accuracy-KEEP gate.
@@ -351,9 +387,11 @@ def accuracy_passed(
 
 __all__ = [
     "ACCURACY_THRESHOLD",
+    "BASELINE_ACCURACY_STOP_REASON",
     "accuracy_keep_block",
     "accuracy_passed",
     "is_high_accuracy_risk",
     "parse_eval_results",
+    "request_baseline_accuracy_stop",
     "require_framework_accuracy_default",
 ]

--- a/src/hyperloom/orchestrator/actions/executors/baseline.py
+++ b/src/hyperloom/orchestrator/actions/executors/baseline.py
@@ -1103,8 +1103,59 @@ class BaselineExecutor:
             retry["nonfatal_warnings"].append("eval_failed_fallback_no_accuracy")
             if retry.get("status") == "succeeded":
                 retry["accuracy_source"] = "eval_unavailable"
-            return retry
+            result = retry
+        self._maybe_stop_on_missing_baseline_accuracy(ctx, result, eval_already_off=eval_already_off)
         return result
+
+    def _maybe_stop_on_missing_baseline_accuracy(
+        self,
+        ctx: RunnerContext,
+        result: dict[str, Any],
+        *,
+        eval_already_off: bool,
+    ) -> None:
+        """Halt the run when a genuine baseline produced no accuracy result.
+
+        A baseline is supposed to establish the accuracy reference. If the
+        accuracy test was expected to run (serving eval not operator-disabled,
+        or any scriptable workload) but produced no result, the setup is
+        fundamentally broken and the whole run stops. When the operator
+        explicitly disabled the serving eval, accuracy is intentionally off and
+        no stop is issued. Throughput-level baseline failures are handled by the
+        Coordinator's existing ``baseline_failed`` streak logic.
+
+        Args:
+            ctx (RunnerContext): The runner context (task kind + shared_state).
+            result (dict): The final baseline result dict.
+            eval_already_off (bool): Whether the operator disabled the eval.
+        """
+        if not _should_establish_quality_ref(getattr(ctx.task, "kind", "")):
+            return
+        if result.get("status") != "succeeded":
+            return
+        if result.get("accuracy") is not None:
+            return
+        params = ctx.task.params or {}
+        framework = (
+            str(params.get("framework") or "").strip()
+            or os.environ.get("FRAMEWORK", "").strip()
+            or None
+        )
+        from hyperloom.inference_optimizer import framework_registry
+        from ._accuracy_gate import request_baseline_accuracy_stop
+
+        scriptable = framework_registry.is_scriptable(framework)
+        # Accuracy is "expected" unless the operator explicitly disabled the
+        # serving eval. Scriptable workloads always carry the quality gate, so a
+        # missing gate always counts as expected-but-failed.
+        if not (scriptable or not eval_already_off):
+            return
+        extra = getattr(ctx, "extra", None) or {}
+        shared_state = extra.get("shared_state") or self.shared_state
+        request_baseline_accuracy_stop(
+            shared_state,
+            context=f"baseline:{framework or 'unknown'}",
+        )
 
     async def _run_once(
         self,

--- a/src/hyperloom/orchestrator/actions/executors/baseline.py
+++ b/src/hyperloom/orchestrator/actions/executors/baseline.py
@@ -1104,37 +1104,45 @@ class BaselineExecutor:
             if retry.get("status") == "succeeded":
                 retry["accuracy_source"] = "eval_unavailable"
             result = retry
-        self._maybe_stop_on_missing_baseline_accuracy(ctx, result, eval_already_off=eval_already_off)
+        self._maybe_stop_on_missing_baseline_accuracy(ctx, result)
         return result
 
     def _maybe_stop_on_missing_baseline_accuracy(
         self,
         ctx: RunnerContext,
         result: dict[str, Any],
-        *,
-        eval_already_off: bool,
     ) -> None:
         """Halt the run when a genuine baseline produced no accuracy result.
 
         A baseline is supposed to establish the accuracy reference. If the
-        accuracy test was expected to run (serving eval not operator-disabled,
-        or any scriptable workload) but produced no result, the setup is
-        fundamentally broken and the whole run stops. When the operator
-        explicitly disabled the serving eval, accuracy is intentionally off and
-        no stop is issued. Throughput-level baseline failures are handled by the
-        Coordinator's existing ``baseline_failed`` streak logic.
+        accuracy test was expected to run but produced no usable result, the
+        setup is fundamentally broken and the whole run stops.
+
+        "No usable result" means a missing or non-positive accuracy: scriptable
+        workloads record ``accuracy=0.0`` (fail-closed) when the quality gate is
+        absent, and serving records no accuracy at all, so both are covered.
+
+        "Expected" means accuracy was not intentionally turned off. Scriptable
+        workloads always carry the quality gate. For serving, the operator can
+        opt out via ``disable_run_eval``, an explicit ``RUN_EVAL=false`` env, or
+        a YAML/reference-env ``RUN_EVAL=false`` -- all folded into the
+        authoritative ``run_eval_disabled`` on the result. The eval-failure
+        fallback also disables eval, but it is tagged
+        ``accuracy_source="eval_unavailable"`` and must still stop (eval was
+        expected and broke). Throughput-level baseline failures are handled by
+        the Coordinator's existing ``baseline_failed`` streak logic.
 
         Args:
             ctx (RunnerContext): The runner context (task kind + shared_state).
             result (dict): The final baseline result dict.
-            eval_already_off (bool): Whether the operator disabled the eval.
         """
         if not _should_establish_quality_ref(getattr(ctx.task, "kind", "")):
             return
         if result.get("status") != "succeeded":
             return
-        if result.get("accuracy") is not None:
-            return
+        acc = result.get("accuracy")
+        if acc is not None and float(acc) > 0.0:
+            return  # a usable baseline accuracy exists
         params = ctx.task.params or {}
         framework = (
             str(params.get("framework") or "").strip()
@@ -1145,10 +1153,13 @@ class BaselineExecutor:
         from ._accuracy_gate import request_baseline_accuracy_stop
 
         scriptable = framework_registry.is_scriptable(framework)
-        # Accuracy is "expected" unless the operator explicitly disabled the
-        # serving eval. Scriptable workloads always carry the quality gate, so a
-        # missing gate always counts as expected-but-failed.
-        if not (scriptable or not eval_already_off):
+        # Operator opt-out only when eval was disabled AND this is not the
+        # eval-failure fallback (which forces RUN_EVAL=false but still means the
+        # eval was expected and broke). Scriptable always runs its quality gate.
+        operator_disabled_eval = bool(result.get("run_eval_disabled")) and (
+            result.get("accuracy_source") != "eval_unavailable"
+        )
+        if not (scriptable or not operator_disabled_eval):
             return
         extra = getattr(ctx, "extra", None) or {}
         shared_state = extra.get("shared_state") or self.shared_state
@@ -2107,6 +2118,11 @@ class BaselineExecutor:
             # promotes into ``SharedState.baseline_runtime_sec``, the explore
             # overtime-kill anchor. Omitted on failure paths.
             "subprocess_runtime_sec": round(subprocess_runtime_sec, 2),
+            # Authoritative (materialized-config) view of whether the serving
+            # lm-eval ran this run. The accuracy-stop decision reads this rather
+            # than re-deriving from params, so a YAML/reference-env RUN_EVAL=false
+            # is honored as an intentional opt-out.
+            "run_eval_disabled": bool(run_eval_disabled),
         }
 
         # Parse accuracy eval results (GSM8K for serving, or the image-quality

--- a/src/hyperloom/orchestrator/actions/executors/explore.py
+++ b/src/hyperloom/orchestrator/actions/executors/explore.py
@@ -1293,12 +1293,18 @@ class ExploreExecutor:
                                     float(accuracy_value),
                                 )
                             else:
-                                # No eval result. Serving: skip the gate (no
-                                # accuracy data). Scriptable: fail closed.
-                                accuracy_ok = not scriptable
+                                # No eval result. Both scriptable and serving
+                                # fail closed: a gated variant (scriptable, or a
+                                # high-risk serving variant with a baseline) that
+                                # yields no accuracy verdict likely broke the eval
+                                # path, so the change is reverted. The former
+                                # serving throughput-only skip is removed. Baseline
+                                # is where a missing accuracy result halts the run;
+                                # post-baseline it is a per-variant REVERT.
+                                accuracy_ok = False
                         if not accuracy_ok:
                             outcome = "REVERT"
-                            reason = "accuracy_drop"
+                            reason = "accuracy_unavailable" if accuracy_value is None else "accuracy_drop"
                         else:
                             outcome = "KEEP"
 

--- a/src/hyperloom/orchestrator/actions/executors/report.py
+++ b/src/hyperloom/orchestrator/actions/executors/report.py
@@ -372,6 +372,7 @@ _STOP_REASON_EXPLANATIONS: dict[str, str] = {
     ),
     "baseline_arg_error": "Two or more baseline attempts fast-exited on a bad CLI arg (deterministic), so the slow-baseline retry budget was not burned.",
     "enablement_stalled": "The enablement loop made no forward progress for several consecutive rounds and stopped instead of re-deriving the same fix.",
+    "baseline_accuracy_failed": "The baseline produced no accuracy result even though the accuracy test was expected to run (broken eval or missing quality gate). The run stopped rather than optimize against an unvalidated baseline.",
 }
 
 

--- a/src/hyperloom/orchestrator/loop/coordinator.py
+++ b/src/hyperloom/orchestrator/loop/coordinator.py
@@ -1090,6 +1090,7 @@ class Coordinator(metaclass=_CoordinatorMeta):
         "cortex_finalize_recipe_and_journal": "writeback",
         "_lift_to_current_best": "writeback",
         "_promote_to_shared_state": "writeback",
+        "_should_run_prelude_bootstrap": "writeback",
         "_detect_resume_state": "writeback",
         "replay_for_resume": "writeback",
         "_materialize_stack_config_for_resume": "writeback",

--- a/src/hyperloom/orchestrator/loop/writeback.py
+++ b/src/hyperloom/orchestrator/loop/writeback.py
@@ -1932,6 +1932,31 @@ class WritebackCollaborator:
                 (float(best_tput) - self.shared_state.baseline_tput) / self.shared_state.baseline_tput * 100.0
             )
 
+    def _should_run_prelude_bootstrap(self, tput: Any) -> bool:
+        """Whether to enqueue the post-baseline PRELUDE bootstrap chain.
+
+        Returns ``False`` when there is no positive baseline throughput, when a
+        roofline task is already pending, or when a stop is already pending
+        (e.g. the baseline accuracy test produced no result ->
+        ``baseline_accuracy_failed``). In the stop case the run is about to halt
+        at the Coordinator's end-of-tick check, so no new bootstrap work (warm
+        replay / roofline / scout / static recon) must be enqueued or dispatched
+        in the meantime.
+
+        Args:
+            tput: The promoted baseline throughput.
+
+        Returns:
+            bool: True only when the bootstrap chain should run.
+        """
+        if not (isinstance(tput, (int, float)) and tput > 0):
+            return False
+        if (self.shared_state.auto_roofline_pending_task_id or "").strip():
+            return False
+        if (self.shared_state.stop_reason or "").strip():
+            return False
+        return True
+
     async def _promote_to_shared_state(
         self,
         task_kind: str,
@@ -2049,11 +2074,7 @@ class WritebackCollaborator:
                         "baseline roofline-ceiling backup failed: %r", exc,
                     )
             # PRELUDE bootstrap (post-baseline), ordering mandatory: (1) inject warm-recipe history, (2) warm-replay, (3) auto-analysis, (4) research scout.
-            if (
-                isinstance(tput, (int, float))
-                and tput > 0
-                and not (self.shared_state.auto_roofline_pending_task_id or "").strip()
-            ):
+            if self._should_run_prelude_bootstrap(tput):
                 # History injection (fires regardless of --no-warm-replay).
                 try:
                     self._inject_warm_recipe_history_into_ledger()

--- a/src/hyperloom/orchestrator/phases/machine_state.py
+++ b/src/hyperloom/orchestrator/phases/machine_state.py
@@ -399,6 +399,12 @@ STOP_REASON_VOCAB: frozenset[str] = frozenset(
         # Enablement loop stall: >= _ENABLEMENT_MAX_STALL consecutive rounds made
         # no forward progress. A progressing round resets the streak.
         "enablement_stalled",
+        # The baseline could not produce an accuracy result even though the
+        # accuracy test was expected to run (broken eval / missing quality
+        # gate). Optimizing against an unvalidated baseline is unsafe, so the
+        # run halts. Post-baseline accuracy failures REVERT the offending
+        # change instead of stopping.
+        "baseline_accuracy_failed",
     }
 )
 


### PR DESCRIPTION
## Summary

Splits how a missing accuracy verdict is handled by phase, per updated requirements:

1. **Baseline** — if the accuracy test was *expected* to run but produced no result, the setup is fundamentally broken, so the whole run halts with `stop_reason=baseline_accuracy_failed` rather than optimizing against an unvalidated baseline. "Expected" means serving eval that the operator did not disable, or any scriptable workload (whose quality gate always runs). If the operator explicitly disabled the serving eval (`disable_run_eval` / explicit `RUN_EVAL=false`), accuracy is intentionally off and the run proceeds throughput-only.
2. **Post-baseline** (explore / integrate_patch / framework_agent) — a gated variant that yields no accuracy verdict is **reverted** (the change likely broke the eval path) and the run continues. This removes the former explore *serving* throughput-only skip, so serving now fails closed like scriptable. The `integrate_patch` / `framework_agent` revert-on-missing-verdict behavior was already correct and is unchanged.

## Changes

- `baseline.py`: new `_maybe_stop_on_missing_baseline_accuracy` — genuine baseline with no accuracy result (and accuracy expected) sets the stop reason.
- `_accuracy_gate.py`: add `BASELINE_ACCURACY_STOP_REASON` + `request_baseline_accuracy_stop` helper.
- `explore.py`: serving high-risk variant with no eval result now REVERTs instead of skipping the gate.
- `machine_state.py`, `report.py`, `robustness_monitor.sh.example`: register `baseline_accuracy_failed` in the stop-reason vocab, report explanations, and the monitor's offline fallback set.

## Test plan

- [x] `test_baseline_eval_fallback.py`: baseline missing accuracy stops the run; operator-disabled eval does not stop; eval-failure fallback stops.
- [x] `test_explore_executor.py`: serving no-eval high-risk variant REVERTs without stopping the run.
- [x] `test_accuracy_keep_gate.py`: `request_baseline_accuracy_stop` unit coverage.
- [x] Broader sweep (baseline / accuracy / explore / integrate / framework_agent / report / coordinator / phase_state / robustness / writeback): 1857 passed, 1 skipped.
- [x] ruff + linters clean.