### PR TITLE
Pass through valid workload env overrides

### DIFF
--- a/src/hyperloom/common/env_safety.py
+++ b/src/hyperloom/common/env_safety.py
@@ -59,36 +59,6 @@ _NON_SECRET_TOKEN_ENV_NAMES: frozenset[str] = frozenset(
     }
 )
 
-WORKLOAD_ENV_EXACT_ALLOWLIST: frozenset[str] = frozenset(
-    {
-        "CONC",
-        "EP",
-        "GPU_METRICS_CSV",
-        "HIP_VISIBLE_DEVICES",
-        "HF_HOME",
-        "HF_TOKEN",
-        "HTTP_PROXY",
-        "HTTPS_PROXY",
-        "HSA_FORCE_FINE_GRAIN_PCIE",
-        "ISL",
-        "MAX_MODEL_LEN",
-        "MODEL_PATH",
-        "NUM_PROMPTS",
-        "NUM_WARMUPS",
-        "NO_PROXY",
-        "OSL",
-        "PORT",
-        "PROFILE",
-        "PROFILE_EXTRA_BODY",
-        "PROFILE_OSL",
-        "RANDOM_RANGE_RATIO",
-        "ROCR_VISIBLE_DEVICES",
-        "RUN_EVAL",
-        "SERVER_LOG",
-        "TP",
-    }
-)
-
 DOTENV_EXACT_ALLOWLIST: frozenset[str] = frozenset(
     {
         "ANTHROPIC_API_KEY",
@@ -192,18 +162,11 @@ def is_allowed_workload_env_key(key: object) -> bool:
     """Return whether an untrusted workload env override is safe to materialize.
 
     Workload env maps come from KB recipes and specialist proposals where
-    unknown-but-valid tuning knobs are common. Gate only the stable hazards:
-    invalid names, loader/shell startup hooks, and non-workload credentials.
+    unknown-but-valid tuning knobs are common. Do not apply a name allowlist or
+    denylist here; the only robust cross-framework rule is valid env-key syntax.
     """
     name = str(key or "").strip()
-    upper = name.upper()
-    if not valid_env_key(upper) or upper in BLOCKED_UNTRUSTED_ENV_NAMES:
-        return False
-    if upper in _NON_SECRET_TOKEN_ENV_NAMES:
-        return True
-    if _SECRET_KEY_RE.search(upper):
-        return upper in WORKLOAD_ENV_EXACT_ALLOWLIST or upper.startswith("HF_")
-    return True
+    return valid_env_key(name)
 
 
 def is_allowed_dotenv_key(key: object) -> bool:

--- a/src/hyperloom/common/env_safety.py
+++ b/src/hyperloom/common/env_safety.py
@@ -158,17 +158,6 @@ def is_blocked_untrusted_env_key(key: object) -> bool:
     )
 
 
-def is_allowed_workload_env_key(key: object) -> bool:
-    """Return whether an untrusted workload env override is safe to materialize.
-
-    Workload env maps come from KB recipes and specialist proposals where
-    unknown-but-valid tuning knobs are common. Do not apply a name allowlist or
-    denylist here; the only robust cross-framework rule is valid env-key syntax.
-    """
-    name = str(key or "").strip()
-    return valid_env_key(name)
-
-
 def is_allowed_dotenv_key(key: object) -> bool:
     name = str(key or "").strip()
     upper = name.upper()
@@ -222,7 +211,6 @@ __all__ = [
     "filter_untrusted_env_mapping",
     "is_allowed_dotenv_key",
     "is_allowed_kernel_agent_env_key",
-    "is_allowed_workload_env_key",
     "is_blocked_untrusted_env_key",
     "scrub_child_process_env",
     "valid_env_key",

--- a/src/hyperloom/common/env_safety.py
+++ b/src/hyperloom/common/env_safety.py
@@ -51,14 +51,6 @@ BLOCKED_CHILD_ENV_NAMES: frozenset[str] = frozenset(
     }
 )
 
-_SECRET_KEY_RE = re.compile(r"(?:^|_)(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)(?:_|$)", re.IGNORECASE)
-_NON_SECRET_TOKEN_ENV_NAMES: frozenset[str] = frozenset(
-    {
-        # SGLang tuning switch; TOKEN describes quantization granularity, not a credential.
-        "SGLANG_USE_AITER_FP8_PER_TOKEN",
-    }
-)
-
 DOTENV_EXACT_ALLOWLIST: frozenset[str] = frozenset(
     {
         "ANTHROPIC_API_KEY",
@@ -148,16 +140,6 @@ def valid_env_key(key: object) -> bool:
     return bool(_ENV_KEY_RE.fullmatch(str(key or "")))
 
 
-def is_blocked_untrusted_env_key(key: object) -> bool:
-    name = str(key or "").strip()
-    upper = name.upper()
-    return (
-        not valid_env_key(name)
-        or upper in BLOCKED_UNTRUSTED_ENV_NAMES
-        or (upper not in _NON_SECRET_TOKEN_ENV_NAMES and bool(_SECRET_KEY_RE.search(upper)))
-    )
-
-
 def is_allowed_dotenv_key(key: object) -> bool:
     name = str(key or "").strip()
     upper = name.upper()
@@ -211,7 +193,6 @@ __all__ = [
     "filter_untrusted_env_mapping",
     "is_allowed_dotenv_key",
     "is_allowed_kernel_agent_env_key",
-    "is_blocked_untrusted_env_key",
     "scrub_child_process_env",
     "valid_env_key",
 ]

--- a/src/hyperloom/common/env_safety.py
+++ b/src/hyperloom/common/env_safety.py
@@ -13,7 +13,6 @@ import re
 from collections.abc import Mapping
 
 _ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-_SERVER_ARGS_RE = re.compile(r"^EXTRA_[A-Z0-9_]+_ARGS$")
 
 BLOCKED_UNTRUSTED_ENV_NAMES: frozenset[str] = frozenset(
     {
@@ -88,32 +87,6 @@ WORKLOAD_ENV_EXACT_ALLOWLIST: frozenset[str] = frozenset(
         "SERVER_LOG",
         "TP",
     }
-)
-
-WORKLOAD_ENV_PREFIX_ALLOWLIST: tuple[str, ...] = (
-    "AITER_",
-    "ATOM_",
-    "BENCH_",
-    "CUDA_",
-    "FLASHINFER_",
-    "HF_",
-    "HIP_",
-    "HSA_",
-    "HYPERLOOM_PROFILE_",
-    "MAGPIE_",
-    "MORI_",
-    "NCCL_",
-    "PROFILE_",
-    "PYTORCH_",
-    "RCCL_",
-    "ROCBLAS_",
-    "ROCM_",
-    "ROCR_",
-    "SGLANG_",
-    "TORCH_",
-    "TRITON_",
-    "VLLM_",
-    "XDIT_",
 )
 
 DOTENV_EXACT_ALLOWLIST: frozenset[str] = frozenset(

--- a/src/hyperloom/common/env_safety.py
+++ b/src/hyperloom/common/env_safety.py
@@ -216,15 +216,21 @@ def is_blocked_untrusted_env_key(key: object) -> bool:
 
 
 def is_allowed_workload_env_key(key: object) -> bool:
+    """Return whether an untrusted workload env override is safe to materialize.
+
+    Workload env maps come from KB recipes and specialist proposals where
+    unknown-but-valid tuning knobs are common. Gate only the stable hazards:
+    invalid names, loader/shell startup hooks, and non-workload credentials.
+    """
     name = str(key or "").strip()
     upper = name.upper()
     if not valid_env_key(upper) or upper in BLOCKED_UNTRUSTED_ENV_NAMES:
         return False
-    return (
-        upper in WORKLOAD_ENV_EXACT_ALLOWLIST
-        or _SERVER_ARGS_RE.fullmatch(upper) is not None
-        or any(upper.startswith(prefix) for prefix in WORKLOAD_ENV_PREFIX_ALLOWLIST)
-    )
+    if upper in _NON_SECRET_TOKEN_ENV_NAMES:
+        return True
+    if _SECRET_KEY_RE.search(upper):
+        return upper in WORKLOAD_ENV_EXACT_ALLOWLIST or upper.startswith("HF_")
+    return True
 
 
 def is_allowed_dotenv_key(key: object) -> bool:

--- a/src/hyperloom/inference_optimizer/tests/test_env_safety.py
+++ b/src/hyperloom/inference_optimizer/tests/test_env_safety.py
@@ -61,19 +61,20 @@ def test_assert_forward_env_keys_raises():
         env_safety.assert_forward_env_keys({"LD_PRELOAD": "/tmp/x.so"})
 
 
-def test_common_env_safety_filters_workload_dotenv_and_kernel_agent_keys():
+def test_common_env_safety_filters_dotenv_and_kernel_agent_keys_only():
     assert common_env_safety.is_allowed_workload_env_key("SGLANG_USE_AITER_FP8_PER_TOKEN")
     assert common_env_safety.is_allowed_workload_env_key("HF_TOKEN")
     assert common_env_safety.is_allowed_workload_env_key("EXTRA_SGLANG_ARGS")
     assert common_env_safety.is_allowed_workload_env_key("PRECISION")
     assert common_env_safety.is_allowed_workload_env_key("CUSTOM_TUNING_KNOB")
-    assert not common_env_safety.is_allowed_workload_env_key("OPENAI_API_KEY")
-    assert not common_env_safety.is_allowed_workload_env_key("SAFE_API_KEY")
-    assert not common_env_safety.is_allowed_workload_env_key("ANTHROPIC_API_KEY")
-    assert not common_env_safety.is_allowed_workload_env_key("LANGFUSE_SECRET_KEY")
-    assert not common_env_safety.is_allowed_workload_env_key("LD_PRELOAD")
-    assert not common_env_safety.is_allowed_workload_env_key("PYTHONPATH")
-    assert not common_env_safety.is_allowed_workload_env_key("PYTHONSTARTUP")
+    assert common_env_safety.is_allowed_workload_env_key("OPENAI_API_KEY")
+    assert common_env_safety.is_allowed_workload_env_key("SAFE_API_KEY")
+    assert common_env_safety.is_allowed_workload_env_key("ANTHROPIC_API_KEY")
+    assert common_env_safety.is_allowed_workload_env_key("LANGFUSE_SECRET_KEY")
+    assert common_env_safety.is_allowed_workload_env_key("LD_PRELOAD")
+    assert common_env_safety.is_allowed_workload_env_key("PYTHONPATH")
+    assert common_env_safety.is_allowed_workload_env_key("PYTHONSTARTUP")
+    assert not common_env_safety.is_allowed_workload_env_key("BAD-NAME")
 
     assert common_env_safety.is_allowed_dotenv_key("OPENAI_API_KEY")
     assert common_env_safety.is_allowed_dotenv_key("HF_TOKEN")
@@ -94,7 +95,9 @@ def test_common_env_safety_filters_workload_dotenv_and_kernel_agent_keys():
             "PRECISION": "fp8",
             "custom_tuning_knob": "enabled",
             "ANTHROPIC_API_KEY": "anthropic-secret",
+            "LD_PRELOAD": "/tmp/agent-provided.so",
             "OPENAI_API_KEY": "secret",
+            "PYTHONPATH": "/tmp/agent-provided",
             "SAFE_API_KEY": "safe-secret",
             "bad key": "nope",
             "": "empty",
@@ -105,11 +108,13 @@ def test_common_env_safety_filters_workload_dotenv_and_kernel_agent_keys():
         "bench_foo": "1",
         "PRECISION": "fp8",
         "custom_tuning_knob": "enabled",
+        "ANTHROPIC_API_KEY": "anthropic-secret",
+        "LD_PRELOAD": "/tmp/agent-provided.so",
+        "OPENAI_API_KEY": "secret",
+        "PYTHONPATH": "/tmp/agent-provided",
+        "SAFE_API_KEY": "safe-secret",
     }
     assert dropped == {
-        "ANTHROPIC_API_KEY": "not_allowed",
-        "OPENAI_API_KEY": "not_allowed",
-        "SAFE_API_KEY": "not_allowed",
         "bad key": "invalid_env_key",
         "<empty>": "invalid_env_key",
     }

--- a/src/hyperloom/inference_optimizer/tests/test_env_safety.py
+++ b/src/hyperloom/inference_optimizer/tests/test_env_safety.py
@@ -62,20 +62,6 @@ def test_assert_forward_env_keys_raises():
 
 
 def test_common_env_safety_filters_dotenv_and_kernel_agent_keys_only():
-    assert common_env_safety.is_allowed_workload_env_key("SGLANG_USE_AITER_FP8_PER_TOKEN")
-    assert common_env_safety.is_allowed_workload_env_key("HF_TOKEN")
-    assert common_env_safety.is_allowed_workload_env_key("EXTRA_SGLANG_ARGS")
-    assert common_env_safety.is_allowed_workload_env_key("PRECISION")
-    assert common_env_safety.is_allowed_workload_env_key("CUSTOM_TUNING_KNOB")
-    assert common_env_safety.is_allowed_workload_env_key("OPENAI_API_KEY")
-    assert common_env_safety.is_allowed_workload_env_key("SAFE_API_KEY")
-    assert common_env_safety.is_allowed_workload_env_key("ANTHROPIC_API_KEY")
-    assert common_env_safety.is_allowed_workload_env_key("LANGFUSE_SECRET_KEY")
-    assert common_env_safety.is_allowed_workload_env_key("LD_PRELOAD")
-    assert common_env_safety.is_allowed_workload_env_key("PYTHONPATH")
-    assert common_env_safety.is_allowed_workload_env_key("PYTHONSTARTUP")
-    assert not common_env_safety.is_allowed_workload_env_key("BAD-NAME")
-
     assert common_env_safety.is_allowed_dotenv_key("OPENAI_API_KEY")
     assert common_env_safety.is_allowed_dotenv_key("HF_TOKEN")
     assert common_env_safety.is_allowed_dotenv_key("HTTPS_PROXY")
@@ -92,7 +78,6 @@ def test_common_env_safety_filters_dotenv_and_kernel_agent_keys_only():
     allowed, dropped = common_env_safety.filter_untrusted_env_mapping(
         {
             "bench_foo": 1,
-            "PRECISION": "fp8",
             "custom_tuning_knob": "enabled",
             "ANTHROPIC_API_KEY": "anthropic-secret",
             "LD_PRELOAD": "/tmp/agent-provided.so",
@@ -102,11 +87,10 @@ def test_common_env_safety_filters_dotenv_and_kernel_agent_keys_only():
             "bad key": "nope",
             "": "empty",
         },
-        allow_predicate=common_env_safety.is_allowed_workload_env_key,
+        allow_predicate=common_env_safety.valid_env_key,
     )
     assert allowed == {
         "bench_foo": "1",
-        "PRECISION": "fp8",
         "custom_tuning_knob": "enabled",
         "ANTHROPIC_API_KEY": "anthropic-secret",
         "LD_PRELOAD": "/tmp/agent-provided.so",

--- a/src/hyperloom/inference_optimizer/tests/test_env_safety.py
+++ b/src/hyperloom/inference_optimizer/tests/test_env_safety.py
@@ -68,7 +68,12 @@ def test_common_env_safety_filters_workload_dotenv_and_kernel_agent_keys():
     assert common_env_safety.is_allowed_workload_env_key("PRECISION")
     assert common_env_safety.is_allowed_workload_env_key("CUSTOM_TUNING_KNOB")
     assert not common_env_safety.is_allowed_workload_env_key("OPENAI_API_KEY")
+    assert not common_env_safety.is_allowed_workload_env_key("SAFE_API_KEY")
+    assert not common_env_safety.is_allowed_workload_env_key("ANTHROPIC_API_KEY")
+    assert not common_env_safety.is_allowed_workload_env_key("LANGFUSE_SECRET_KEY")
     assert not common_env_safety.is_allowed_workload_env_key("LD_PRELOAD")
+    assert not common_env_safety.is_allowed_workload_env_key("PYTHONPATH")
+    assert not common_env_safety.is_allowed_workload_env_key("PYTHONSTARTUP")
 
     assert common_env_safety.is_allowed_dotenv_key("OPENAI_API_KEY")
     assert common_env_safety.is_allowed_dotenv_key("HF_TOKEN")
@@ -88,7 +93,9 @@ def test_common_env_safety_filters_workload_dotenv_and_kernel_agent_keys():
             "bench_foo": 1,
             "PRECISION": "fp8",
             "custom_tuning_knob": "enabled",
+            "ANTHROPIC_API_KEY": "anthropic-secret",
             "OPENAI_API_KEY": "secret",
+            "SAFE_API_KEY": "safe-secret",
             "bad key": "nope",
             "": "empty",
         },
@@ -100,7 +107,9 @@ def test_common_env_safety_filters_workload_dotenv_and_kernel_agent_keys():
         "custom_tuning_knob": "enabled",
     }
     assert dropped == {
+        "ANTHROPIC_API_KEY": "not_allowed",
         "OPENAI_API_KEY": "not_allowed",
+        "SAFE_API_KEY": "not_allowed",
         "bad key": "invalid_env_key",
         "<empty>": "invalid_env_key",
     }

--- a/src/hyperloom/inference_optimizer/tests/test_env_safety.py
+++ b/src/hyperloom/inference_optimizer/tests/test_env_safety.py
@@ -65,6 +65,8 @@ def test_common_env_safety_filters_workload_dotenv_and_kernel_agent_keys():
     assert common_env_safety.is_allowed_workload_env_key("SGLANG_USE_AITER_FP8_PER_TOKEN")
     assert common_env_safety.is_allowed_workload_env_key("HF_TOKEN")
     assert common_env_safety.is_allowed_workload_env_key("EXTRA_SGLANG_ARGS")
+    assert common_env_safety.is_allowed_workload_env_key("PRECISION")
+    assert common_env_safety.is_allowed_workload_env_key("CUSTOM_TUNING_KNOB")
     assert not common_env_safety.is_allowed_workload_env_key("OPENAI_API_KEY")
     assert not common_env_safety.is_allowed_workload_env_key("LD_PRELOAD")
 
@@ -84,13 +86,19 @@ def test_common_env_safety_filters_workload_dotenv_and_kernel_agent_keys():
     allowed, dropped = common_env_safety.filter_untrusted_env_mapping(
         {
             "bench_foo": 1,
+            "PRECISION": "fp8",
+            "custom_tuning_knob": "enabled",
             "OPENAI_API_KEY": "secret",
             "bad key": "nope",
             "": "empty",
         },
         allow_predicate=common_env_safety.is_allowed_workload_env_key,
     )
-    assert allowed == {"bench_foo": "1"}
+    assert allowed == {
+        "bench_foo": "1",
+        "PRECISION": "fp8",
+        "custom_tuning_knob": "enabled",
+    }
     assert dropped == {
         "OPENAI_API_KEY": "not_allowed",
         "bad key": "invalid_env_key",

--- a/src/hyperloom/inference_optimizer/tests/test_workload_envs_branches_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_workload_envs_branches_unit.py
@@ -104,19 +104,27 @@ def test_materialize_drops_loader_env_injections(tmp_path, monkeypatch):
         tmp_path / "out",
         extra_envs={
             "LD_PRELOAD": "/tmp/evil.so",
+            "OPENAI_API_KEY": "secret",
+            "PRECISION": "fp8",
             "PYTHONSTARTUP": "/tmp/pwn.py",
             "SGLANG_USE_AITER": "1",
+            "UNKNOWN_VALID_TUNING_KNOB": "enabled",
         },
         reference_envs={
             "PYTHONPATH": "/tmp/evil",
+            "REFERENCE_ONLY_KNOB": "1",
             "VLLM_ROCM_USE_AITER": "1",
         },
     )
     envs = bench["envs"]
     assert "LD_PRELOAD" not in envs
+    assert "OPENAI_API_KEY" not in envs
     assert "PYTHONSTARTUP" not in envs
     assert "PYTHONPATH" not in envs
+    assert envs["PRECISION"] == "fp8"
+    assert envs["REFERENCE_ONLY_KNOB"] == "1"
     assert envs["SGLANG_USE_AITER"] == "1"
+    assert envs["UNKNOWN_VALID_TUNING_KNOB"] == "enabled"
     assert envs["VLLM_ROCM_USE_AITER"] == "1"
 
 

--- a/src/hyperloom/inference_optimizer/tests/test_workload_envs_branches_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_workload_envs_branches_unit.py
@@ -103,10 +103,12 @@ def test_materialize_drops_loader_env_injections(tmp_path, monkeypatch):
         src,
         tmp_path / "out",
         extra_envs={
+            "ANTHROPIC_API_KEY": "anthropic-secret",
             "LD_PRELOAD": "/tmp/evil.so",
             "OPENAI_API_KEY": "secret",
             "PRECISION": "fp8",
             "PYTHONSTARTUP": "/tmp/pwn.py",
+            "SAFE_API_KEY": "safe-secret",
             "SGLANG_USE_AITER": "1",
             "UNKNOWN_VALID_TUNING_KNOB": "enabled",
         },
@@ -117,15 +119,50 @@ def test_materialize_drops_loader_env_injections(tmp_path, monkeypatch):
         },
     )
     envs = bench["envs"]
+    assert "ANTHROPIC_API_KEY" not in envs
     assert "LD_PRELOAD" not in envs
     assert "OPENAI_API_KEY" not in envs
     assert "PYTHONSTARTUP" not in envs
     assert "PYTHONPATH" not in envs
+    assert "SAFE_API_KEY" not in envs
+    assert bench["precision"] == "fp8"
     assert envs["PRECISION"] == "fp8"
     assert envs["REFERENCE_ONLY_KNOB"] == "1"
     assert envs["SGLANG_USE_AITER"] == "1"
     assert envs["UNKNOWN_VALID_TUNING_KNOB"] == "enabled"
     assert envs["VLLM_ROCM_USE_AITER"] == "1"
+
+
+def test_reference_precision_does_not_override_process_precision(tmp_path, monkeypatch):
+    _clear_env(monkeypatch)
+    _stub_server_arg_injectors(monkeypatch)
+    monkeypatch.setenv("PRECISION", "bf16")
+    src = tmp_path / "base.yaml"
+    _write(src, precision="fp16")
+    bench = _materialize(
+        src,
+        tmp_path / "out",
+        reference_envs={"PRECISION": "fp8"},
+    )
+    assert bench["precision"] == "bf16"
+    assert bench["envs"]["PRECISION"] == "fp8"
+
+
+def test_reference_precision_updates_benchmark_precision_without_process_override(
+    tmp_path,
+    monkeypatch,
+):
+    _clear_env(monkeypatch)
+    _stub_server_arg_injectors(monkeypatch)
+    src = tmp_path / "base.yaml"
+    _write(src, precision="bf16")
+    bench = _materialize(
+        src,
+        tmp_path / "out",
+        reference_envs={"PRECISION": "fp8"},
+    )
+    assert bench["precision"] == "fp8"
+    assert bench["envs"]["PRECISION"] == "fp8"
 
 
 def test_materialize_rejects_shell_control_in_server_args(tmp_path, monkeypatch):

--- a/src/hyperloom/inference_optimizer/tests/test_workload_envs_branches_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_workload_envs_branches_unit.py
@@ -94,7 +94,7 @@ def test_materialize_remove_args_and_string_unset_env(tmp_path, monkeypatch):
     assert envs["SGLANG_REMOVE_ME"] == "override"
 
 
-def test_materialize_drops_loader_env_injections(tmp_path, monkeypatch):
+def test_materialize_preserves_valid_workload_env_keys(tmp_path, monkeypatch):
     _clear_env(monkeypatch)
     _stub_server_arg_injectors(monkeypatch)
     src = tmp_path / "base.yaml"
@@ -119,12 +119,12 @@ def test_materialize_drops_loader_env_injections(tmp_path, monkeypatch):
         },
     )
     envs = bench["envs"]
-    assert "ANTHROPIC_API_KEY" not in envs
-    assert "LD_PRELOAD" not in envs
-    assert "OPENAI_API_KEY" not in envs
-    assert "PYTHONSTARTUP" not in envs
-    assert "PYTHONPATH" not in envs
-    assert "SAFE_API_KEY" not in envs
+    assert envs["ANTHROPIC_API_KEY"] == "anthropic-secret"
+    assert envs["LD_PRELOAD"] == "/tmp/evil.so"
+    assert envs["OPENAI_API_KEY"] == "secret"
+    assert envs["PYTHONSTARTUP"] == "/tmp/pwn.py"
+    assert envs["PYTHONPATH"] == "/tmp/evil"
+    assert envs["SAFE_API_KEY"] == "safe-secret"
     assert bench["precision"] == "fp8"
     assert envs["PRECISION"] == "fp8"
     assert envs["REFERENCE_ONLY_KNOB"] == "1"

--- a/src/hyperloom/inference_optimizer/tests/test_workload_envs_branches_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_workload_envs_branches_unit.py
@@ -106,16 +106,17 @@ def test_materialize_preserves_valid_workload_env_keys(tmp_path, monkeypatch):
             "ANTHROPIC_API_KEY": "anthropic-secret",
             "LD_PRELOAD": "/tmp/evil.so",
             "OPENAI_API_KEY": "secret",
-            "PRECISION": "fp8",
             "PYTHONSTARTUP": "/tmp/pwn.py",
             "SAFE_API_KEY": "safe-secret",
             "SGLANG_USE_AITER": "1",
             "UNKNOWN_VALID_TUNING_KNOB": "enabled",
+            "BAD-NAME": "dropped",
         },
         reference_envs={
             "PYTHONPATH": "/tmp/evil",
             "REFERENCE_ONLY_KNOB": "1",
             "VLLM_ROCM_USE_AITER": "1",
+            "bad key": "dropped",
         },
     )
     envs = bench["envs"]
@@ -125,44 +126,12 @@ def test_materialize_preserves_valid_workload_env_keys(tmp_path, monkeypatch):
     assert envs["PYTHONSTARTUP"] == "/tmp/pwn.py"
     assert envs["PYTHONPATH"] == "/tmp/evil"
     assert envs["SAFE_API_KEY"] == "safe-secret"
-    assert bench["precision"] == "fp8"
-    assert envs["PRECISION"] == "fp8"
+    assert "BAD-NAME" not in envs
+    assert "bad key" not in envs
     assert envs["REFERENCE_ONLY_KNOB"] == "1"
     assert envs["SGLANG_USE_AITER"] == "1"
     assert envs["UNKNOWN_VALID_TUNING_KNOB"] == "enabled"
     assert envs["VLLM_ROCM_USE_AITER"] == "1"
-
-
-def test_reference_precision_does_not_override_process_precision(tmp_path, monkeypatch):
-    _clear_env(monkeypatch)
-    _stub_server_arg_injectors(monkeypatch)
-    monkeypatch.setenv("PRECISION", "bf16")
-    src = tmp_path / "base.yaml"
-    _write(src, precision="fp16")
-    bench = _materialize(
-        src,
-        tmp_path / "out",
-        reference_envs={"PRECISION": "fp8"},
-    )
-    assert bench["precision"] == "bf16"
-    assert bench["envs"]["PRECISION"] == "fp8"
-
-
-def test_reference_precision_updates_benchmark_precision_without_process_override(
-    tmp_path,
-    monkeypatch,
-):
-    _clear_env(monkeypatch)
-    _stub_server_arg_injectors(monkeypatch)
-    src = tmp_path / "base.yaml"
-    _write(src, precision="bf16")
-    bench = _materialize(
-        src,
-        tmp_path / "out",
-        reference_envs={"PRECISION": "fp8"},
-    )
-    assert bench["precision"] == "fp8"
-    assert bench["envs"]["PRECISION"] == "fp8"
 
 
 def test_materialize_rejects_shell_control_in_server_args(tmp_path, monkeypatch):

--- a/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
+++ b/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
@@ -725,6 +725,12 @@ def materialize_config_with_envs(
         log.warning("Dropping unsafe extra_envs key %s before benchmark materialization", _dk)
     for key, value in safe_extra_envs.items():
         envs[str(key)] = str(value)
+    precision_from_extra = str(safe_extra_envs.get("PRECISION") or "").strip()
+    precision_from_envs = str(envs.get("PRECISION") or "").strip()
+    if precision_from_extra:
+        bench["precision"] = precision_from_extra
+    elif not precision and precision_from_envs:
+        bench["precision"] = precision_from_envs
     framework_env = server_args_env_name(bench.get("framework"))
     # ── Quality-reference wiring (scriptable / server-less workloads) ──────
     # Magpie forwards only ``benchmark.envs`` to the wrapper subprocess, so

--- a/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
+++ b/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
@@ -30,7 +30,7 @@ import yaml
 from hyperloom.common.coerce import to_str_list
 from hyperloom.common.env_safety import (
     filter_untrusted_env_mapping,
-    is_allowed_workload_env_key,
+    valid_env_key,
 )
 from hyperloom.inference_optimizer.session.paths import asset_root
 from ._grid_runner import (
@@ -693,10 +693,10 @@ def materialize_config_with_envs(
         )
     safe_reference_envs, dropped_reference_envs = filter_untrusted_env_mapping(
         reference_envs,
-        allow_predicate=is_allowed_workload_env_key,
+        allow_predicate=valid_env_key,
     )
     for _rk in dropped_reference_envs:
-        log.warning("Dropping unsafe reference_envs key %s before benchmark materialization", _rk)
+        log.warning("Dropping invalid reference_envs key %s before benchmark materialization", _rk)
     for _rk, _rv in safe_reference_envs.items():
         envs.setdefault(str(_rk), str(_rv))  # never clobber YAML/CLI envs
     if server_args:
@@ -719,18 +719,12 @@ def materialize_config_with_envs(
             envs[framework_env] = server_args
     safe_extra_envs, dropped_extra_envs = filter_untrusted_env_mapping(
         extra_envs,
-        allow_predicate=is_allowed_workload_env_key,
+        allow_predicate=valid_env_key,
     )
     for _dk in dropped_extra_envs:
-        log.warning("Dropping unsafe extra_envs key %s before benchmark materialization", _dk)
+        log.warning("Dropping invalid extra_envs key %s before benchmark materialization", _dk)
     for key, value in safe_extra_envs.items():
         envs[str(key)] = str(value)
-    precision_from_extra = str(safe_extra_envs.get("PRECISION") or "").strip()
-    precision_from_envs = str(envs.get("PRECISION") or "").strip()
-    if precision_from_extra:
-        bench["precision"] = precision_from_extra
-    elif not precision and precision_from_envs:
-        bench["precision"] = precision_from_envs
     framework_env = server_args_env_name(bench.get("framework"))
     # ── Quality-reference wiring (scriptable / server-less workloads) ──────
     # Magpie forwards only ``benchmark.envs`` to the wrapper subprocess, so


### PR DESCRIPTION
## Summary
- remove workload `reference_envs` / `extra_envs` name filtering so any syntactically valid env key is preserved
- keep `.env` and kernel-agent env filtering unchanged; workload envs now use only the shared valid-env-key syntax gate
- remove the obsolete workload allow helper and the `PRECISION` env-to-`benchmark.precision` sync; precision continues to be handled by the existing flag/process-env path

## Tests
- `python -m pytest src/hyperloom/inference_optimizer/tests/test_env_safety.py -q`
- `python -m pytest src/hyperloom/inference_optimizer/tests/test_workload_envs_branches_unit.py::test_materialize_preserves_valid_workload_env_keys -q`

Note: a broader local Windows run of `test_workload_envs_branches_unit.py` still hits the existing `fcntl` import limitation in unrelated tests.