### PR TITLE
Fix/anthropic endpoint case insensitive

### DIFF
--- a/src/hyperloom/common/llm_config.py
+++ b/src/hyperloom/common/llm_config.py
@@ -111,13 +111,15 @@ def derive_openai_base_url(anthropic_base_url: str | None) -> str | None:
     parts = urlsplit(base)
     path = parts.path.rstrip("/")
     # Match case-insensitively: AMD's default endpoint uses "/Anthropic" (issue #929).
-    # Keep the original path for slicing so any prefix casing is preserved.
+    # Keep the original path for slicing so any prefix casing is preserved, and
+    # always emit the canonical "/Unified/v1" segment.
     path_lower = path.lower()
     if path_lower.endswith("/anthropic"):
         prefix = path[: -len("/anthropic")]
         return urlunsplit(parts._replace(path=f"{prefix}/Unified/v1"))
     if path_lower.endswith("/unified"):
-        return urlunsplit(parts._replace(path=f"{path}/v1"))
+        prefix = path[: -len("/unified")]
+        return urlunsplit(parts._replace(path=f"{prefix}/Unified/v1"))
     return base
 
 

--- a/src/hyperloom/common/llm_config.py
+++ b/src/hyperloom/common/llm_config.py
@@ -99,7 +99,9 @@ def derive_openai_base_url(anthropic_base_url: str | None) -> str | None:
     Explicit ``OPENAI_BASE_URL`` always wins in callers. This fallback handles
     AMD's split gateway convention, where Anthropic traffic uses
     ``/anthropic`` and OpenAI-compatible chat completions use ``/Unified/v1``.
-    Unknown Anthropic URLs fall back to their original value.
+    The trailing path segment is matched case-insensitively so a capitalized
+    ``/Anthropic`` (AMD's default) is still recognized. Unknown Anthropic URLs
+    fall back to their original value.
     """
     if not anthropic_base_url:
         return None
@@ -108,10 +110,13 @@ def derive_openai_base_url(anthropic_base_url: str | None) -> str | None:
         return None
     parts = urlsplit(base)
     path = parts.path.rstrip("/")
-    if path.endswith("/anthropic") or path == "/anthropic":
-        prefix = path[: -len("/anthropic")] if path.endswith("/anthropic") else ""
+    # Match case-insensitively: AMD's default endpoint uses "/Anthropic" (issue #929).
+    # Keep the original path for slicing so any prefix casing is preserved.
+    path_lower = path.lower()
+    if path_lower.endswith("/anthropic"):
+        prefix = path[: -len("/anthropic")]
         return urlunsplit(parts._replace(path=f"{prefix}/Unified/v1"))
-    if path.endswith("/Unified"):
+    if path_lower.endswith("/unified"):
         return urlunsplit(parts._replace(path=f"{path}/v1"))
     return base
 

--- a/src/hyperloom/common/model_paths.py
+++ b/src/hyperloom/common/model_paths.py
@@ -21,6 +21,41 @@ from __future__ import annotations
 from pathlib import Path
 
 
+def _normalize_identity_leaf(seg: str) -> str:
+    """Collapse a single identity segment to its bare repo name.
+
+    ``models--Qwen--Qwen2.5-7B-Instruct`` / ``Qwen--Qwen2.5-7B-Instruct`` /
+    ``Qwen/Qwen2.5-7B-Instruct`` all reduce to ``Qwen2.5-7B-Instruct``.
+    """
+    s = seg.strip().strip("/").split("/")[-1]
+    if s.startswith("models--"):
+        s = s[len("models--"):]
+    if "--" in s:
+        s = s.rsplit("--", 1)[-1]
+    return s
+
+
+def model_identity_candidates(model: str | Path | None) -> set[str]:
+    """Return casefolded identity candidates for a ``--model`` / model_name value.
+
+    Covers flat dirs, bare names, HF repo ids, and HF hub cache paths (whose
+    ``snapshots/<hash>`` basename hides the repo name in an upstream
+    ``models--org--repo`` segment). Used by the model_arch stale guard so a
+    declared clean name matches whatever launch form the CLI received.
+    """
+    raw = ("" if model is None else str(model)).strip()
+    if not raw:
+        return set()
+    p = Path(raw)
+    out = {_normalize_identity_leaf(p.name)}
+    # HF hub cache hides the repo name in a mid-path models--org--repo segment;
+    # the snapshots/<hash> basename alone cannot recover it.
+    for part in p.parts:
+        if part.startswith("models--"):
+            out.add(_normalize_identity_leaf(part))
+    return {c.casefold() for c in out if c}
+
+
 def resolve_local_model_dir(model: str | Path | None) -> Path | None:
     """Resolve a ``--model`` value (local path OR HF repo id) to a local dir.
 

--- a/src/hyperloom/common/model_paths.py
+++ b/src/hyperloom/common/model_paths.py
@@ -21,39 +21,67 @@ from __future__ import annotations
 from pathlib import Path
 
 
-def _normalize_identity_leaf(seg: str) -> str:
-    """Collapse a single identity segment to its bare repo name.
+def _identity_leaf(seg: str) -> str:
+    """Reduce one identity segment to its ``org/repo`` (or bare ``repo``) form.
 
-    ``models--Qwen--Qwen2.5-7B-Instruct`` / ``Qwen--Qwen2.5-7B-Instruct`` /
-    ``Qwen/Qwen2.5-7B-Instruct`` all reduce to ``Qwen2.5-7B-Instruct``.
+    Strips a ``models--`` cache prefix and canonicalizes the ``org--repo`` cache
+    separator to ``org/repo``; a segment without org info stays bare.
     """
     s = seg.strip().strip("/").split("/")[-1]
     if s.startswith("models--"):
         s = s[len("models--"):]
-    if "--" in s:
-        s = s.rsplit("--", 1)[-1]
-    return s
+    return s.replace("--", "/")
 
 
-def model_identity_candidates(model: str | Path | None) -> set[str]:
-    """Return casefolded identity candidates for a ``--model`` / model_name value.
+def _identity_bare(full: str) -> str:
+    """Return the repo-only tail of an ``org/repo`` identity (or the value)."""
+    return full.rsplit("/", 1)[-1] if "/" in full else full
 
-    Covers flat dirs, bare names, HF repo ids, and HF hub cache paths (whose
-    ``snapshots/<hash>`` basename hides the repo name in an upstream
-    ``models--org--repo`` segment). Used by the model_arch stale guard so a
-    declared clean name matches whatever launch form the CLI received.
+
+def model_identity_candidates(model: str | Path | None) -> tuple[set[str], set[str]]:
+    """Return ``(full, bare)`` casefolded identity candidate sets.
+
+    ``full`` keeps the ``org/repo`` qualification (e.g. ``qwen/qwen2.5-7b``);
+    ``bare`` is the repo tail only (``qwen2.5-7b``). Covers flat dirs, bare
+    names, HF repo ids, and HF hub cache paths whose ``snapshots/<hash>``
+    basename hides the repo name in an upstream ``models--org--repo`` segment.
     """
     raw = ("" if model is None else str(model)).strip()
     if not raw:
-        return set()
+        return set(), set()
     p = Path(raw)
-    out = {_normalize_identity_leaf(p.name)}
+    segments = [p.name]
     # HF hub cache hides the repo name in a mid-path models--org--repo segment;
     # the snapshots/<hash> basename alone cannot recover it.
-    for part in p.parts:
-        if part.startswith("models--"):
-            out.add(_normalize_identity_leaf(part))
-    return {c.casefold() for c in out if c}
+    segments += [part for part in p.parts if part.startswith("models--")]
+    full = {_identity_leaf(s) for s in segments if s}
+    full = {f for f in full if f}
+    bare = {_identity_bare(f) for f in full}
+    return {f.casefold() for f in full}, {b.casefold() for b in bare}
+
+
+def model_identities_match(declared: str, *launched: str) -> bool:
+    """Whether ``declared`` names the same model as any ``launched`` value.
+
+    Prefers a fully-qualified ``org/repo`` match. Falls back to the repo-only
+    (bare) name ONLY when at least one side lacks org info — so two different
+    orgs sharing a repo name (``a/Llama-8B`` vs ``b/Llama-8B``) do NOT match,
+    while a declared clean name (``Llama-8B``, no org) still matches its
+    launched ``org/repo`` form.
+    """
+    d_full, d_bare = model_identity_candidates(declared)
+    l_full: set[str] = set()
+    l_bare: set[str] = set()
+    for value in launched:
+        vf, vb = model_identity_candidates(value)
+        l_full |= vf
+        l_bare |= vb
+    if d_full & l_full:
+        return True
+    # Both sides carry org qualification but no full match -> distinct models.
+    if any("/" in x for x in d_full) and any("/" in x for x in l_full):
+        return False
+    return bool(d_bare & l_bare)
 
 
 def resolve_local_model_dir(model: str | Path | None) -> Path | None:

--- a/src/hyperloom/inference_optimizer/SKILL.md
+++ b/src/hyperloom/inference_optimizer/SKILL.md
@@ -406,9 +406,11 @@ Steps for the launching agent:
    `model_arch.json` at the workspace root. Do not create a subdirectory
    such as `model_arch_advisory/`; the CLI only reads the root-level
    convention file. Include `model_name` (required for the stale-file
-   guard — its basename must match the launched `--model` basename or
-   Hyperloom ignores the file). All other fields are optional; renderers
-   drop empty fields.
+   guard). Set it to the **clean model name** (e.g. `Qwen2.5-7B-Instruct`);
+   the guard normalizes launch forms — flat dirs, HF repo ids, and HF hub
+   cache `models--org--repo/snapshots/<hash>` paths — so do NOT use the
+   snapshot commit hash. All other fields are optional; renderers drop
+   empty fields.
 
 ```json
 {

--- a/src/hyperloom/inference_optimizer/cli/bootstrap.py
+++ b/src/hyperloom/inference_optimizer/cli/bootstrap.py
@@ -238,7 +238,7 @@ def _seed_shared_state(
         model_class=args.model_class or "",
         # Advisory architecture profile; fresh-launch only. Soft-degrade to {}.
         model_arch=_load_model_arch(
-            _workspace_root_resolve(), _model_identity
+            _workspace_root_resolve(), _model_identity, str(args.model),
         ),
         # Architecture-identity tags from config.json.
         model_architectures=_cfg_tags.get("architectures", []),

--- a/src/hyperloom/inference_optimizer/cli/model_gate.py
+++ b/src/hyperloom/inference_optimizer/cli/model_gate.py
@@ -240,7 +240,7 @@ def _load_model_arch(
         dict: The advisory architecture profile, or ``{}`` when missing,
             unreadable, invalid, or stale.
     """
-    from hyperloom.common.model_paths import model_identity_candidates
+    from hyperloom.common.model_paths import model_identities_match
     arch_path = workspace_root / "model_arch.json"
     try:
         raw = arch_path.read_text(encoding="utf-8")
@@ -265,16 +265,14 @@ def _load_model_arch(
             "model_arch_missing_model_name: %s (cannot verify freshness)", arch_path
         )
         return {}
-    launched = model_identity_candidates(model_name) | model_identity_candidates(
-        launched_model
-    )
-    if not (model_identity_candidates(declared) & launched):
+    if not model_identities_match(declared, model_name, launched_model):
         logging.warning(
             "model_arch_stale_or_mismatch: %s declares model_name=%r but "
-            "launching %r — ignoring",
+            "launching model_name=%r (--model=%r) — ignoring",
             arch_path,
             declared,
             model_name,
+            launched_model,
         )
         return {}
     return data

--- a/src/hyperloom/inference_optimizer/cli/model_gate.py
+++ b/src/hyperloom/inference_optimizer/cli/model_gate.py
@@ -218,21 +218,29 @@ _SUPPORTED_QUANT_METHODS = frozenset({
 # ``.biases`` / ``.scales`` weights (plural — distinct from a standard ``.bias``).
 _MLX_QUANT_MODES = frozenset({"affine", "mlx"})
 
-def _load_model_arch(workspace_root: Path, model_name: str) -> dict:
+def _load_model_arch(
+    workspace_root: Path, model_name: str, launched_model: str = "",
+) -> dict:
     """Best-effort loader for the advisory ``<workspace_root>/model_arch.json`` profile (prompts only).
 
-    Soft-degrades to ``{}`` (never blocks launch) on missing/unreadable/invalid file. Stale-file guard:
-    require ``data["model_name"]`` basename to match launched ``--model`` basename, else WARN + ``{}``.
+    Soft-degrades to ``{}`` (never blocks launch) on missing/unreadable/invalid
+    file. Stale-file guard: the declared ``data["model_name"]`` must share an
+    identity candidate with the launched model, else WARN + ``{}``. Candidates
+    normalize flat dirs, bare names, HF repo ids, and HF hub cache
+    ``models--org--repo/snapshots/<hash>`` paths so a declared clean name still
+    matches a commit-hash launch basename.
 
     Args:
         workspace_root (Path): Directory containing ``model_arch.json``.
-        model_name (str): The launched model name, used for the stale-file
-            freshness check.
+        model_name (str): The resolved model identity (display name / basename).
+        launched_model (str): The raw ``--model`` value; carries the HF cache
+            ``models--org--repo`` segment that ``model_name`` may have lost.
 
     Returns:
         dict: The advisory architecture profile, or ``{}`` when missing,
             unreadable, invalid, or stale.
     """
+    from hyperloom.common.model_paths import model_identity_candidates
     arch_path = workspace_root / "model_arch.json"
     try:
         raw = arch_path.read_text(encoding="utf-8")
@@ -257,7 +265,10 @@ def _load_model_arch(workspace_root: Path, model_name: str) -> dict:
             "model_arch_missing_model_name: %s (cannot verify freshness)", arch_path
         )
         return {}
-    if Path(declared).name != Path(model_name).name:
+    launched = model_identity_candidates(model_name) | model_identity_candidates(
+        launched_model
+    )
+    if not (model_identity_candidates(declared) & launched):
         logging.warning(
             "model_arch_stale_or_mismatch: %s declares model_name=%r but "
             "launching %r — ignoring",

--- a/src/hyperloom/inference_optimizer/tests/test_cli_bootstrap_coverage_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_cli_bootstrap_coverage_unit.py
@@ -250,6 +250,39 @@ def test_seed_shared_state_falls_back_to_path_basename(
     assert state.model_name == "Qwen3-32B"
 
 
+def test_seed_passes_raw_model_path_to_model_arch_guard(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Regression for #930: the stale guard needs the raw ``--model`` path so an
+    HF cache ``models--org--repo/snapshots/<hash>`` launch can recover the repo
+    name; passing only the collapsed identity loses it."""
+    captured: dict[str, tuple] = {}
+
+    def _spy(*args, **_kwargs):
+        captured["args"] = args
+        return {}
+
+    monkeypatch.setattr(cb, "_load_model_config_tags", lambda _p: {})
+    monkeypatch.setattr(cb, "_load_model_arch", _spy)
+    monkeypatch.setattr(cb, "_workspace_root_resolve", lambda: tmp_path)
+    monkeypatch.setattr(
+        cb, "_resolve_reference_recipe", lambda _args: ("", {}, "", ""),
+    )
+    from hyperloom.orchestrator.policy import gate as policy
+
+    monkeypatch.setattr(policy, "detect_gpu_count", lambda: 8)
+    monkeypatch.setattr(policy, "research_lane_ceiling", lambda: 16)
+
+    raw = (
+        "/root/.cache/huggingface/hub/models--Qwen--Qwen2.5-7B-Instruct/"
+        "snapshots/a09a35458c702b33eeacc393d103063234e8bc28"
+    )
+    cb._seed_shared_state(tmp_path, _args(model=raw), session_id="s-raw")
+
+    assert captured["args"][2] == raw
+
+
 def test_manifest_preserves_quantized_model_identity(tmp_path: Path) -> None:
     """Regression: ``manifest.json`` ``model_name`` must honor the pinned
     display name from the quantize prelude, not the collapsed path basename."""

--- a/src/hyperloom/inference_optimizer/tests/test_llm_config.py
+++ b/src/hyperloom/inference_optimizer/tests/test_llm_config.py
@@ -56,6 +56,19 @@ def test_derive_openai_base_url_from_amd_anthropic_endpoint():
     )
 
 
+def test_derive_openai_base_url_is_case_insensitive():
+    # AMD's default endpoint uses a capitalized "/Anthropic" segment (issue #929);
+    # match case-insensitively so the OpenAI base URL is still derived.
+    assert (
+        derive_openai_base_url("https://llm-api.amd.com/Anthropic")
+        == "https://llm-api.amd.com/Unified/v1"
+    )
+    assert (
+        derive_openai_base_url("https://llm-api.amd.com/unified")
+        == "https://llm-api.amd.com/unified/v1"
+    )
+
+
 def test_openai_kwargs_reads_openai_custom_headers():
     """The OpenAI/Codex client applies OPENAI_CUSTOM_HEADERS verbatim."""
     kwargs = openai_client_kwargs(

--- a/src/hyperloom/inference_optimizer/tests/test_llm_config.py
+++ b/src/hyperloom/inference_optimizer/tests/test_llm_config.py
@@ -63,9 +63,10 @@ def test_derive_openai_base_url_is_case_insensitive():
         derive_openai_base_url("https://llm-api.amd.com/Anthropic")
         == "https://llm-api.amd.com/Unified/v1"
     )
+    # A lowercase "/unified" segment is normalized to the canonical "/Unified/v1".
     assert (
         derive_openai_base_url("https://llm-api.amd.com/unified")
-        == "https://llm-api.amd.com/unified/v1"
+        == "https://llm-api.amd.com/Unified/v1"
     )
 
 

--- a/src/hyperloom/inference_optimizer/tests/test_model_arch_advisory.py
+++ b/src/hyperloom/inference_optimizer/tests/test_model_arch_advisory.py
@@ -85,6 +85,57 @@ def test_load_model_arch_stale_mismatch_returns_empty(tmp_path: Path):
     assert _load_model_arch(tmp_path, "DeepSeek-R1-0528") == {}
 
 
+# 1b. HF hub cache path: launched --model is a snapshots/<hash> dir whose
+# basename is a commit hash, but the declared clean model_name must still match.
+_HF_SNAPSHOT = (
+    "/root/.cache/huggingface/hub/models--Qwen--Qwen2.5-7B-Instruct/"
+    "snapshots/a09a35458c702b33eeacc393d103063234e8bc28"
+)
+
+
+def test_load_model_arch_matches_hf_cache_snapshot_clean_name(tmp_path: Path):
+    """Declared clean name matches an HF cache snapshot launch path."""
+    _write(tmp_path, {**_VALID_ARCH, "model_name": "Qwen2.5-7B-Instruct"})
+    out = _load_model_arch(tmp_path, "a09a35458c702b33eeacc393d103063234e8bc28", _HF_SNAPSHOT)
+    assert out["attention"] == "MLA"
+
+
+def test_load_model_arch_matches_hf_cache_snapshot_org_repo(tmp_path: Path):
+    """Declared org--repo form matches an HF cache snapshot launch path."""
+    _write(tmp_path, {**_VALID_ARCH, "model_name": "Qwen--Qwen2.5-7B-Instruct"})
+    out = _load_model_arch(tmp_path, "a09a35458c702b33eeacc393d103063234e8bc28", _HF_SNAPSHOT)
+    assert out["attention"] == "MLA"
+
+
+def test_load_model_arch_matches_hf_cache_snapshot_models_form(tmp_path: Path):
+    """Declared models--org--repo form matches an HF cache snapshot launch path."""
+    _write(tmp_path, {**_VALID_ARCH, "model_name": "models--Qwen--Qwen2.5-7B-Instruct"})
+    out = _load_model_arch(tmp_path, "a09a35458c702b33eeacc393d103063234e8bc28", _HF_SNAPSHOT)
+    assert out["attention"] == "MLA"
+
+
+def test_load_model_arch_matches_repo_id(tmp_path: Path):
+    """A bare HF repo id launch matches a declared clean name."""
+    _write(tmp_path, {**_VALID_ARCH, "model_name": "Qwen2.5-7B-Instruct"})
+    out = _load_model_arch(tmp_path, "Qwen/Qwen2.5-7B-Instruct", "Qwen/Qwen2.5-7B-Instruct")
+    assert out["attention"] == "MLA"
+
+
+def test_load_model_arch_flat_dir_still_matches(tmp_path: Path):
+    """A flat model dir basename still matches (no regression)."""
+    _write(tmp_path, {**_VALID_ARCH, "model_name": "Qwen3-8B"})
+    out = _load_model_arch(tmp_path, "Qwen3-8B", "/primus/models/Qwen3-8B")
+    assert out["attention"] == "MLA"
+
+
+def test_load_model_arch_true_stale_ignored_with_hf_cache(tmp_path: Path):
+    """A different model's leftover file is still ignored under an HF cache launch."""
+    _write(tmp_path, {**_VALID_ARCH, "model_name": "Llama-3.1-8B"})
+    assert _load_model_arch(
+        tmp_path, "a09a35458c702b33eeacc393d103063234e8bc28", _HF_SNAPSHOT
+    ) == {}
+
+
 # 2. SharedState serialization round-trip
 def test_model_arch_round_trips_through_dict():
     state = SharedState(model_name="DeepSeek-R1-0528", model_arch=dict(_VALID_ARCH))

--- a/src/hyperloom/inference_optimizer/tests/test_model_arch_advisory.py
+++ b/src/hyperloom/inference_optimizer/tests/test_model_arch_advisory.py
@@ -136,6 +136,21 @@ def test_load_model_arch_true_stale_ignored_with_hf_cache(tmp_path: Path):
     ) == {}
 
 
+def test_load_model_arch_cross_org_same_repo_name_ignored(tmp_path: Path):
+    """Two different orgs sharing a repo name must NOT match when both qualify org."""
+    _write(tmp_path, {**_VALID_ARCH, "model_name": "MyOrg--Llama-8B"})
+    launch = "/root/.cache/huggingface/hub/models--OtherOrg--Llama-8B/snapshots/deadbeef"
+    assert _load_model_arch(tmp_path, "deadbeef", launch) == {}
+
+
+def test_load_model_arch_bare_name_matches_any_org(tmp_path: Path):
+    """A declared clean name with no org still matches its launched org/repo form."""
+    _write(tmp_path, {**_VALID_ARCH, "model_name": "Llama-8B"})
+    launch = "/root/.cache/huggingface/hub/models--OtherOrg--Llama-8B/snapshots/deadbeef"
+    out = _load_model_arch(tmp_path, "deadbeef", launch)
+    assert out["attention"] == "MLA"
+
+
 # 2. SharedState serialization round-trip
 def test_model_arch_round_trips_through_dict():
     state = SharedState(model_name="DeepSeek-R1-0528", model_arch=dict(_VALID_ARCH))


### PR DESCRIPTION
This PR bundles two independent, low-risk fixes.

## Fix 1: Anthropic endpoint case-insensitive matching (#929)

`derive_openai_base_url` used a case-sensitive `endswith("/anthropic")` check, so
AMD's default gateway endpoint (capitalized `/Anthropic`) was never recognized and
the OpenAI base URL was left underived (missing the `/Unified/v1` path).

- Match the trailing path segment case-insensitively (`/Anthropic`, `/anthropic`, ...).
- Preserve the original prefix casing when slicing, and always emit the canonical
  `/Unified/v1` segment.
- Also normalize a lowercase `/unified` segment to `/Unified/v1`.

Files: `src/hyperloom/common/llm_config.py`

## Fix 2: model_arch stale guard matches HF cache paths (#930)

The `model_arch.json` stale-file guard compared the declared `model_name` basename
against the launched `--model` basename. HF hub cache paths end in
`snapshots/<commit-hash>`, whose basename never equals a clean model name, so a
valid `model_arch.json` was wrongly treated as stale and dropped.

- Add `model_identity_candidates()` to normalize flat dirs, bare names, HF repo ids,
  and HF cache `models--org--repo/snapshots/<hash>` paths.
- Match the declared name against the union of launched-model candidates.
- Pass the raw `--model` into the guard so the `models--org--repo` segment is
  recoverable (the collapsed display name may be just the commit hash).
- `SKILL.md`: instruct launchers to declare the clean model name, not the snapshot hash.

Note: the guard only gates an advisory prompt profile (fail-soft, never blocks
launch); the matching is intentionally loosened relative to the previous strict
basename equality.

Files: `src/hyperloom/common/model_paths.py`,
`src/hyperloom/inference_optimizer/cli/model_gate.py`,
`src/hyperloom/inference_optimizer/cli/bootstrap.py`,
`src/hyperloom/inference_optimizer/SKILL.md`

## Testing

- `test_llm_config.py`: case-insensitive `/Anthropic` and `/unified` derivation.
- `test_model_arch_advisory.py`: HF cache snapshot / repo id / flat dir matches,
  plus true-stale still ignored.
- `test_cli_bootstrap_coverage_unit.py`: bootstrap passes the raw `--model` path
  to the guard.

Fixes #929
Fixes #930
