### PR TITLE
fix(baseline): apply eval-dest redirect on the baseline path, not just profile

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_inferencex_patcher.py
+++ b/src/hyperloom/inference_optimizer/tests/test_inferencex_patcher.py
@@ -546,3 +546,28 @@ def test_eval_dest_patch_is_idempotent(tmp_path, monkeypatch):
     ensure_benchmark_lib_eval_dest_patched(tmp_path)
     assert lib.read_text(encoding="utf-8") == after_first
     assert after_first.count('"${RESULT_DIR:-.}/"') == 1
+
+
+def test_baseline_after_materialize_applies_eval_dest_patch(tmp_path, monkeypatch):
+    """BaselineExecutor's base hook (not just ProfileExecutor) must apply the
+    eval-dest redirect, so a pure baseline run's ``mv ./`` writes results into
+    $RESULT_DIR instead of the process cwd (the local-disk InferenceX mirror)."""
+    import yaml
+
+    from hyperloom.orchestrator.actions.executors.baseline import BaselineExecutor
+
+    ix_root = tmp_path / "InferenceX@deadbeef"
+    lib = _write_eval_dest_lib(ix_root)
+    config_path = tmp_path / "baseline.yaml"
+    config_path.write_text(
+        yaml.safe_dump({"benchmark": {"inferencex_path": str(ix_root)}}),
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("INFERENCEX_PATH", raising=False)
+
+    out = BaselineExecutor()._after_materialize_config(config_path, tmp_path / "out")
+
+    assert out is None  # baseline is never short-circuited
+    text = lib.read_text(encoding="utf-8")
+    assert 'mv -f "$jf" "${RESULT_DIR:-.}/"' in text
+    assert 'mv -f "$jf" ./ ' not in text

--- a/src/hyperloom/orchestrator/actions/executors/baseline.py
+++ b/src/hyperloom/orchestrator/actions/executors/baseline.py
@@ -58,6 +58,7 @@ from ._workload_envs import (
     default_baseline_config,
     materialize_config_with_envs,
 )
+from ._inferencex_patcher import ensure_benchmark_lib_eval_dest_patched
 from .benchmark_result import (
     extract_benchmark_measurement,
     harvest_leaked_artifacts,
@@ -1021,15 +1022,47 @@ class BaselineExecutor:
         )
         return self.default_timeout_sec
 
+    @staticmethod
+    def _inferencex_root_from_config(config_path: Path) -> str:
+        """Resolve the InferenceX checkout the subprocess will ``cd`` into.
+
+        Prefers the materialized ``benchmark.inferencex_path`` (the task-local,
+        possibly local-disk-mirrored checkout) and falls back to
+        ``$INFERENCEX_PATH``. Returns ``""`` when neither is set.
+
+        Args:
+            config_path: The materialized Magpie YAML config path.
+
+        Returns:
+            The InferenceX checkout path, or ``""`` when unresolved.
+        """
+        try:
+            cfg = yaml.safe_load(Path(config_path).read_text(encoding="utf-8")) or {}
+            bench = cfg.get("benchmark") if isinstance(cfg, dict) else {}
+            path = str((bench or {}).get("inferencex_path") or "").strip()
+        except (OSError, yaml.YAMLError):
+            path = ""
+        return path or os.environ.get("INFERENCEX_PATH", "").strip()
+
     def _after_materialize_config(
         self,
         config_path: Path,
         output_dir: Path,
     ) -> dict[str, Any] | None:
-        """Hook for subclasses after YAML materialization, before launch.
+        """Hook after YAML materialization, before launch.
 
-        ProfileExecutor uses this to patch/validate the InferenceX checkout
-        named by the rendered YAML. No-op default keeps baseline unchanged.
+        Applies the eval-dest redirect patch to the InferenceX checkout the
+        subprocess will run, so ``append_lm_eval_summary``'s ``mv ./`` writes
+        lm-eval ``results*.json`` into ``$RESULT_DIR`` (the per-task session
+        dir set in :meth:`_run_single_benchmark`) instead of the process cwd —
+        which, when InferenceX is mirrored to local disk, is a dir outside the
+        session that ``parse_eval_results`` never scans (baseline then wrongly
+        stops with ``baseline_accuracy_failed`` despite eval passing). Baseline
+        previously left this to ProfileExecutor only, so pure baseline runs
+        never got the redirect. Best-effort; never blocks the run.
+
+        ProfileExecutor overrides this to additionally validate the
+        NUM_PROMPTS / PROFILE_EXTRA_BODY patches (and short-circuit on failure).
 
         Args:
             config_path: The materialized Magpie YAML config path.
@@ -1039,6 +1072,16 @@ class BaselineExecutor:
             An early-return result dict to short-circuit the launch, or
             ``None`` to proceed with the baseline run.
         """
+        ix_root = self._inferencex_root_from_config(config_path)
+        if ix_root:
+            try:
+                ensure_benchmark_lib_eval_dest_patched(Path(ix_root))
+            except Exception as exc:  # noqa: BLE001 — patch is best-effort
+                log.warning(
+                    "baseline_executor: eval-dest patch skipped for %s: %s",
+                    ix_root,
+                    exc,
+                )
         return None
 
     @staticmethod


### PR DESCRIPTION
## Summary
`append_lm_eval_summary`'s `mv ./` moves lm-eval `results*.json` to the **process cwd** — the InferenceX checkout Magpie `cd`-s into. When InferenceX is mirrored to local disk (`~/.cache/hyperloom/inferencex_local/<hash>`, the network-FS anti-flap path), that cwd is **outside the session**, so `parse_eval_results` (which globs `runs/baseline/**`) finds nothing and the run stops with `baseline_accuracy_failed` — **even though eval passed**.

Observed false-kills on the fleet: **Qwen3-14B-FP8 gsm8k=0.934**, **Mixtral-8x7B gsm8k=0.648**.

## Root cause
The eval-dest redirect patch (`mv ./` → `mv "${RESULT_DIR:-.}/"`) was applied **only** by `ProfileExecutor._after_materialize_config`. `BaselineExecutor`'s base hook was a **no-op**, so pure baseline runs executed the **unpatched** `benchmark_lib.sh` → `mv ./` → cwd (the mirror).

Verified on the failing session: the checkout's `benchmark_lib.sh` still had the original `mv -f "$jf" ./` and logged `Moved eval artifacts to: $(pwd)`.

## Fix
Move the eval-dest patch into `BaselineExecutor._after_materialize_config` (the base hook), resolving the checkout from the materialized `benchmark.inferencex_path` (the task-local, possibly mirrored, checkout) else `$INFERENCEX_PATH`. Now **both** baseline and profile redirect eval results into `$RESULT_DIR` (the per-task session dir already set in `_run_single_benchmark`), so `parse_eval_results` finds them and the accuracy gate no longer false-fails.

- Best-effort; never blocks the run.
- `ProfileExecutor`'s override is unchanged (still validates NUM_PROMPTS / PROFILE_EXTRA_BODY on top).
- Task-scoped by construction (patches only the checkout named in *this* task's config) — no cross-task/concurrency risk.

> Supersedes the earlier salvage-side approach (harvesting `results*.json` from the mirror), which a review flagged for potentially harvesting a concurrent task's results when scanning the shared mirror root. This fixes the root cause instead.

## Test plan
- [x] `test_baseline_after_materialize_applies_eval_dest_patch` — BaselineExecutor's base hook patches the checkout's `benchmark_lib.sh` (`mv ./` → `mv "${RESULT_DIR:-.}/"`) and never short-circuits.
- [x] `test_inferencex_patcher.py` + `test_profile_and_kernel_handlers.py` — 29 passed locally.
- [ ] Fleet re-run of a mirrored model (e.g. Qwen3-14B-FP8) confirms baseline accuracy is read and the run proceeds past PRELUDE.
