### PR TITLE
chore: bump version to 0.9.0 for v0.9 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hyperloom-inference_optimizer"
-version = "0.8.0"
+version = "0.9.0"
 description = "Inference Optimizer — single-mode 4-agent (Orchestration/Kernel/Critic/Robustness) autonomous LLM inference optimization runtime for AMD GPU platforms."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bumps the package version 0.8.0 -> 0.9.0 for the v0.9 release. Required so scripts/build_wheel.sh derives tag v0.9 and produces hyperloom_inference_optimizer-0.9.0-py3-none-any.whl for the v0.9 (draft) release. No behavior change.

Made with [Cursor](https://cursor.com)