### PR TITLE
Harden Ray setup and fix 3h demo budget

### DIFF
--- a/examples/hyperloom-qwen3-8b-3h/SKILL.md
+++ b/examples/hyperloom-qwen3-8b-3h/SKILL.md
@@ -76,7 +76,8 @@ Required optimize CLI flags:
 - `--precision bf16`
 - `--target-gain 30`
 - `--max-hours 3`
-- `--phase-budget-explore-pct 0.95`
+- `--max-minutes-explore-pct 0.46`
+- `--max-minutes-sweep-pct 0.01`
 - `--explore-force-exit-budget-pct 0.01`
 - `--explore-force-exit-hours-remaining 0.05`
 - `--no-framework-agent`
@@ -189,11 +190,13 @@ and the stop reason. Never print API keys, tokens, or custom header values.
    and critic subprocesses can import `hyperloom.agents` after changing cwd.
 3. Run in background with `setsid nohup`.
 4. Pass all required optimize CLI flags in the `python -m hyperloom.inference_optimizer.cli optimize` command. Do not rely on `.env` alone for `TP`, `CONC`, `ISL`, `OSL`, or `PRECISION`; CLI defaults can otherwise override the intended workload.
-5. Include `--phase-budget-explore-pct 0.95`,
+5. Include `--max-minutes-explore-pct 0.46`,
+   `--max-minutes-sweep-pct 0.01`,
    `--explore-force-exit-budget-pct 0.01`, and
-   `--explore-force-exit-hours-remaining 0.05` in the optimize command so most
-   of the short run budget is reserved for EXPLORE while still exiting cleanly
-   near the deadline.
+   `--explore-force-exit-hours-remaining 0.05` in the optimize command. With
+   FRAMEWORK_AGENT and KERNEL_AGENT disabled, Hyperloom redistributes their
+   shares so most of the short run budget is reserved for EXPLORE while still
+   leaving SWEEP/CLOSE time to exit cleanly near the deadline.
 6. Include `--no-framework-agent` in the optimize command so the
    FRAMEWORK_AGENT phase is skipped.
 7. Include `--no-kernel` in the optimize command so the Kernel Agent phase is skipped.

--- a/src/hyperloom/agents/kernel/scripts/install.sh
+++ b/src/hyperloom/agents/kernel/scripts/install.sh
@@ -589,29 +589,39 @@ ensure_moreutils() {
   command -v ts >/dev/null 2>&1 || warn "ts still missing after apt-get install moreutils"
 }
 
+RAY_VERSION="${RAY_VERSION:-2.44.1}"
+# Ray 2.44.1's CLI currently fails during import with click >= 8.3.0.
+RAY_CLI_CLICK_MAX_VERSION="${RAY_CLI_CLICK_MAX_VERSION:-8.3.0}"
+RAY_INSTALL_SPEC="ray[default]==${RAY_VERSION}"
+CLICK_INSTALL_SPEC="click<${RAY_CLI_CLICK_MAX_VERSION}"
+
 ensure_ray() {
-  log "ensuring ray[default]==2.44.1 and click<8.3.0"
+  log "ensuring ${RAY_INSTALL_SPEC} and ${CLICK_INSTALL_SPEC}"
   if [ "$CHECK_ONLY" -eq 0 ]; then
-    run python3 -m pip install --quiet --no-cache-dir --break-system-packages "click<8.3.0" "ray[default]==2.44.1"
+    run python3 -m pip install --quiet --no-cache-dir --break-system-packages "$CLICK_INSTALL_SPEC" "$RAY_INSTALL_SPEC"
   fi
   if [ "$DRY_RUN" -eq 0 ]; then
-    python3 - <<'PY'
+    RAY_VERSION="$RAY_VERSION" RAY_CLI_CLICK_MAX_VERSION="$RAY_CLI_CLICK_MAX_VERSION" python3 - <<'PY'
 import importlib.metadata as md
+import os
 import re
 import sys
 
 import ray
+
+RAY_VERSION = os.environ["RAY_VERSION"]
+RAY_CLI_CLICK_MAX_VERSION = os.environ["RAY_CLI_CLICK_MAX_VERSION"]
 
 def _version_tuple(version: str) -> tuple[int, int, int]:
     parts = [int(p) for p in re.findall(r"\d+", version)[:3]]
     parts.extend([0] * (3 - len(parts)))
     return tuple(parts[:3])
 
-if ray.__version__ != "2.44.1":
-    raise SystemExit(f"ray version mismatch: {ray.__version__} != 2.44.1")
+if ray.__version__ != RAY_VERSION:
+    raise SystemExit(f"ray version mismatch: {ray.__version__} != {RAY_VERSION}")
 click_version = md.version("click")
-if _version_tuple(click_version) >= (8, 3, 0):
-    raise SystemExit(f"click version incompatible with Ray CLI: {click_version} >= 8.3.0")
+if _version_tuple(click_version) >= _version_tuple(RAY_CLI_CLICK_MAX_VERSION):
+    raise SystemExit(f"click version incompatible with Ray CLI: {click_version} >= {RAY_CLI_CLICK_MAX_VERSION}")
 try:
     from ray.scripts.scripts import main as _ray_cli_main  # noqa: F401
 except Exception as exc:

--- a/src/hyperloom/agents/kernel/scripts/install.sh
+++ b/src/hyperloom/agents/kernel/scripts/install.sh
@@ -596,10 +596,27 @@ ensure_ray() {
   fi
   if [ "$DRY_RUN" -eq 0 ]; then
     python3 - <<'PY'
-import ray, sys
+import importlib.metadata as md
+import re
+import sys
+
+import ray
+
+def _version_tuple(version: str) -> tuple[int, int, int]:
+    parts = [int(p) for p in re.findall(r"\d+", version)[:3]]
+    parts.extend([0] * (3 - len(parts)))
+    return tuple(parts[:3])
+
 if ray.__version__ != "2.44.1":
     raise SystemExit(f"ray version mismatch: {ray.__version__} != 2.44.1")
-print(f"[kernel-agent] ray version: {ray.__version__}")
+click_version = md.version("click")
+if _version_tuple(click_version) >= (8, 3, 0):
+    raise SystemExit(f"click version incompatible with Ray CLI: {click_version} >= 8.3.0")
+try:
+    from ray.scripts.scripts import main as _ray_cli_main  # noqa: F401
+except Exception as exc:
+    raise SystemExit(f"ray CLI import failed: {type(exc).__name__}: {exc}") from exc
+print(f"[kernel-agent] ray version: {ray.__version__}, click version: {click_version}")
 PY
   fi
 }
@@ -654,13 +671,27 @@ ensure_fd_limit_for_ray() {
   return 0
 }
 
+ray_head_has_serving_slot() {
+  python3 - <<'PY' >/dev/null 2>&1
+import ray
+
+ray.init(address="auto", ignore_reinit_error=True, log_to_driver=False, logging_level="error")
+try:
+    resources = ray.cluster_resources()
+finally:
+    ray.shutdown()
+raise SystemExit(0 if "serving_slot" in resources else 1)
+PY
+}
+
 # Idempotently bring up a Ray head node. Kernel backends submit Ray tasks with
 # `num_gpus>=1`; if no head is running (or one is running with --num-gpus=0)
 # kernel optimization will hang forever even when GPUs are idle. We:
-#   1. detect a live Ray head via `ray status` (any successful return = live)
-#   2. if absent, force-stop any half-started Ray and start a fresh head with
-#      all visible GPUs advertised
-#   3. tolerate the no-GPU case (CPU-only dev box) so `--check-only` stays
+#   1. detect a live Ray head via `ray status`
+#   2. reuse it only when it declares the Hyperloom `serving_slot` resource
+#   3. otherwise force-stop stale/incompatible local Ray and start a fresh head
+#      with all visible GPUs advertised
+#   4. tolerate the no-GPU case (CPU-only dev box) so `--check-only` stays
 #      non-fatal in environments without ROCm
 ensure_ray_started() {
   if [ "$CHECK_ONLY" -eq 1 ] || [ "$DRY_RUN" -eq 1 ]; then
@@ -675,10 +706,14 @@ ensure_ray_started() {
     return 0
   fi
   if ray status >/dev/null 2>&1; then
-    log "ray head already running"
-    return 0
+    if ray_head_has_serving_slot; then
+      log "ray head already running with serving_slot"
+      return 0
+    fi
+    warn "ray head already running without serving_slot; restarting local Ray head"
+  else
+    log "no live ray head detected; starting one"
   fi
-  log "no live ray head detected; starting one"
   # issue #433: raise fd limit BEFORE starting the head so the raylet inherits
   # a ceiling high enough to stay up (container default 1024 makes it abort).
   ensure_fd_limit_for_ray

--- a/src/hyperloom/inference_optimizer/cli/preflight.py
+++ b/src/hyperloom/inference_optimizer/cli/preflight.py
@@ -392,16 +392,64 @@ def _ensure_python_sdks(python_exe: str, pip_extra: list[str]) -> None:
         print(f"Preflight: installed {pip_spec}")
 
 
+_RAY_INSTALL_SPECS = ("ray[default]==2.44.1", "click<8.3.0")
+
+
+_RAY_SMOKE = r"""
+import importlib.metadata as md
+import re
+import sys
+
+def _version_tuple(version: str) -> tuple[int, int, int]:
+    parts = [int(p) for p in re.findall(r"\d+", version)[:3]]
+    parts.extend([0] * (3 - len(parts)))
+    return tuple(parts[:3])
+
+try:
+    import ray
+except Exception as exc:
+    print(f"ray import failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+    raise SystemExit(1)
+
+if ray.__version__ != "2.44.1":
+    print(f"ray version mismatch: {ray.__version__} != 2.44.1", file=sys.stderr)
+    raise SystemExit(1)
+
+try:
+    click_version = md.version("click")
+except md.PackageNotFoundError:
+    print("click is not installed", file=sys.stderr)
+    raise SystemExit(1)
+
+if _version_tuple(click_version) >= (8, 3, 0):
+    print(f"click version incompatible with Ray CLI: {click_version} >= 8.3.0", file=sys.stderr)
+    raise SystemExit(1)
+
+try:
+    from ray.scripts.scripts import main as _ray_cli_main  # noqa: F401
+except Exception as exc:
+    print(f"ray CLI import failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+    raise SystemExit(1)
+"""
+
+
+def _ray_smoke(python_exe: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [python_exe, "-c", _RAY_SMOKE],
+        capture_output=True,
+        text=True,
+    )
+
+
 def _ensure_ray(python_exe: str, pip_extra: list[str]) -> None:
     """Probe-then-install Ray using the interpreter that will import it.
 
     Ray is used broadly (multi-node scheduling, kernel/profile/recover
-    executors), not only by Magpie. The probe imports ``ray`` with
-    ``python_exe`` instead of a PATH-only ``which ray`` lookup on purpose: a
-    bypass-only host may have a stray ``ray`` executable on ``PATH`` from an
-    unrelated venv while ``python_exe`` still cannot ``import ray``, so a
-    PATH-only check would false-positive and the Ray-backed executors would
-    then fail at runtime.
+    executors), not only by Magpie. The smoke test imports ``ray`` with
+    ``python_exe``, checks the pinned Ray/click compatibility contract, and
+    imports Ray's CLI module. A PATH-only ``which ray`` lookup, or even a bare
+    ``import ray``, can false-positive when the CLI is broken by an incompatible
+    click version.
 
     Args:
         python_exe (str): The interpreter that will import Ray (and run the
@@ -409,15 +457,20 @@ def _ensure_ray(python_exe: str, pip_extra: list[str]) -> None:
         pip_extra (list[str]): Extra arguments threaded into the ``pip
             install`` invocation (e.g. ``--break-system-packages``).
     """
-    check = subprocess.run([python_exe, "-c", "import ray"], capture_output=True)
+    check = _ray_smoke(python_exe)
     if check.returncode == 0:
         print("Preflight: ray OK")
         return
-    print("Preflight: ray not importable, installing ray[default]==2.44.1 + click<8.3.0 ...")
+    reason = (check.stderr or check.stdout or "unknown Ray smoke failure").strip().splitlines()[-1]
+    print(f"Preflight: ray/click invalid ({reason}), installing ray[default]==2.44.1 + click<8.3.0 ...")
     subprocess.run(
-        [python_exe, "-m", "pip", "install", "--quiet", *pip_extra, "ray[default]==2.44.1", "click<8.3.0"],
+        [python_exe, "-m", "pip", "install", "--quiet", *pip_extra, *_RAY_INSTALL_SPECS],
         check=True,
     )
+    check = _ray_smoke(python_exe)
+    if check.returncode != 0:
+        reason = (check.stderr or check.stdout or "unknown Ray smoke failure").strip()
+        raise RuntimeError(f"Ray install completed but smoke test still failed: {reason}")
     print("Preflight: ray installed OK")
 
 

--- a/src/hyperloom/inference_optimizer/cli/preflight.py
+++ b/src/hyperloom/inference_optimizer/cli/preflight.py
@@ -392,13 +392,22 @@ def _ensure_python_sdks(python_exe: str, pip_extra: list[str]) -> None:
         print(f"Preflight: installed {pip_spec}")
 
 
-_RAY_INSTALL_SPECS = ("ray[default]==2.44.1", "click<8.3.0")
+_RAY_VERSION = "2.44.1"
+# Ray 2.44.1's CLI currently fails during import with click >= 8.3.0.
+_RAY_CLI_CLICK_MAX_VERSION = "8.3.0"
+_RAY_INSTALL_SPEC = f"ray[default]=={_RAY_VERSION}"
+_CLICK_INSTALL_SPEC = f"click<{_RAY_CLI_CLICK_MAX_VERSION}"
+_RAY_INSTALL_SPECS = (_RAY_INSTALL_SPEC, _CLICK_INSTALL_SPEC)
 
 
-_RAY_SMOKE = r"""
+_RAY_SMOKE_TEMPLATE = r"""
 import importlib.metadata as md
 import re
 import sys
+
+RAY_VERSION = "__RAY_VERSION__"
+RAY_CLI_CLICK_MAX_VERSION = "__RAY_CLI_CLICK_MAX_VERSION__"
+RAY_CLI_CLICK_MAX_VERSION_TUPLE = __RAY_CLI_CLICK_MAX_VERSION_TUPLE__
 
 def _version_tuple(version: str) -> tuple[int, int, int]:
     parts = [int(p) for p in re.findall(r"\d+", version)[:3]]
@@ -411,8 +420,8 @@ except Exception as exc:
     print(f"ray import failed: {type(exc).__name__}: {exc}", file=sys.stderr)
     raise SystemExit(1)
 
-if ray.__version__ != "2.44.1":
-    print(f"ray version mismatch: {ray.__version__} != 2.44.1", file=sys.stderr)
+if ray.__version__ != RAY_VERSION:
+    print(f"ray version mismatch: {ray.__version__} != {RAY_VERSION}", file=sys.stderr)
     raise SystemExit(1)
 
 try:
@@ -421,8 +430,11 @@ except md.PackageNotFoundError:
     print("click is not installed", file=sys.stderr)
     raise SystemExit(1)
 
-if _version_tuple(click_version) >= (8, 3, 0):
-    print(f"click version incompatible with Ray CLI: {click_version} >= 8.3.0", file=sys.stderr)
+if _version_tuple(click_version) >= RAY_CLI_CLICK_MAX_VERSION_TUPLE:
+    print(
+        f"click version incompatible with Ray CLI: {click_version} >= {RAY_CLI_CLICK_MAX_VERSION}",
+        file=sys.stderr,
+    )
     raise SystemExit(1)
 
 try:
@@ -431,6 +443,19 @@ except Exception as exc:
     print(f"ray CLI import failed: {type(exc).__name__}: {exc}", file=sys.stderr)
     raise SystemExit(1)
 """
+
+
+def _version_tuple(version: str) -> tuple[int, int, int]:
+    parts = [int(p) for p in re.findall(r"\d+", version)[:3]]
+    parts.extend([0] * (3 - len(parts)))
+    return tuple(parts[:3])
+
+
+_RAY_SMOKE = (
+    _RAY_SMOKE_TEMPLATE.replace("__RAY_VERSION__", _RAY_VERSION)
+    .replace("__RAY_CLI_CLICK_MAX_VERSION__", _RAY_CLI_CLICK_MAX_VERSION)
+    .replace("__RAY_CLI_CLICK_MAX_VERSION_TUPLE__", repr(_version_tuple(_RAY_CLI_CLICK_MAX_VERSION)))
+)
 
 
 def _ray_smoke(python_exe: str) -> subprocess.CompletedProcess:
@@ -462,7 +487,7 @@ def _ensure_ray(python_exe: str, pip_extra: list[str]) -> None:
         print("Preflight: ray OK")
         return
     reason = (check.stderr or check.stdout or "unknown Ray smoke failure").strip().splitlines()[-1]
-    print(f"Preflight: ray/click invalid ({reason}), installing ray[default]==2.44.1 + click<8.3.0 ...")
+    print(f"Preflight: ray/click invalid ({reason}), installing {_RAY_INSTALL_SPEC} + {_CLICK_INSTALL_SPEC} ...")
     subprocess.run(
         [python_exe, "-m", "pip", "install", "--quiet", *pip_extra, *_RAY_INSTALL_SPECS],
         check=True,

--- a/src/hyperloom/inference_optimizer/tests/test_backend_gating.py
+++ b/src/hyperloom/inference_optimizer/tests/test_backend_gating.py
@@ -55,11 +55,11 @@ def test_preflight_resolves_interpreter_via_backend_not_magpie():
     # Ray installs with the backend interpreter, not a hardcoded Magpie one.
     assert "benchmark_python" in src
     assert "_ensure_ray(benchmark_python, pip_extra)" in src
-    # Ray availability is probed by importing with the SAME interpreter (not
-    # shutil.which, which only inspects PATH and would false-positive on a
-    # bypass-only host that has a stray ``ray`` on PATH but cannot import it).
+    # Ray availability is probed with the SAME interpreter (not shutil.which,
+    # which only inspects PATH and would false-positive on a bypass-only host
+    # that has a stray ``ray`` on PATH but cannot run Ray correctly).
     ray_src = inspect.getsource(preflight_mod._ensure_ray)
-    assert '[python_exe, "-c", "import ray"]' in ray_src
+    assert "_ray_smoke(python_exe)" in ray_src
     assert "shutil.which" not in ray_src
     # Magpie interpreter is no longer resolved unconditionally in _preflight;
     # it comes through resolve_benchmark_interpreter for the Magpie backend.
@@ -90,6 +90,21 @@ def test_install_sh_gates_magpie_calls():
     # InferenceX stays unconditional (after the fi).
     inferencex_idx = text.index("ensure_inferencex\n", fi_idx)
     assert inferencex_idx > fi_idx
+
+
+def test_kernel_install_validates_ray_cli_and_serving_slot():
+    install_sh = Path(preflight_mod.__file__).resolve().parents[2] / "agents" / "kernel" / "scripts" / "install.sh"
+    text = install_sh.read_text(encoding="utf-8")
+
+    assert '"click<8.3.0"' in text
+    assert "click version incompatible with Ray CLI" in text
+    assert "from ray.scripts.scripts import main" in text
+
+    assert "ray_head_has_serving_slot() {" in text
+    assert '"serving_slot" in resources' in text
+    assert "ray head already running with serving_slot" in text
+    assert "ray head already running without serving_slot; restarting local Ray head" in text
+    assert "--resources='{\"serving_slot\": 1}'" in text
 
 
 def test_lifecycle_delegates_to_bypass_backend(tmp_path, monkeypatch):

--- a/src/hyperloom/inference_optimizer/tests/test_backend_gating.py
+++ b/src/hyperloom/inference_optimizer/tests/test_backend_gating.py
@@ -96,7 +96,10 @@ def test_kernel_install_validates_ray_cli_and_serving_slot():
     install_sh = Path(preflight_mod.__file__).resolve().parents[2] / "agents" / "kernel" / "scripts" / "install.sh"
     text = install_sh.read_text(encoding="utf-8")
 
-    assert '"click<8.3.0"' in text
+    assert 'RAY_VERSION="${RAY_VERSION:-2.44.1}"' in text
+    assert 'RAY_CLI_CLICK_MAX_VERSION="${RAY_CLI_CLICK_MAX_VERSION:-8.3.0}"' in text
+    assert 'RAY_INSTALL_SPEC="ray[default]==${RAY_VERSION}"' in text
+    assert 'CLICK_INSTALL_SPEC="click<${RAY_CLI_CLICK_MAX_VERSION}"' in text
     assert "click version incompatible with Ray CLI" in text
     assert "from ray.scripts.scripts import main" in text
 

--- a/src/hyperloom/inference_optimizer/tests/test_phase_budget_pct_cli.py
+++ b/src/hyperloom/inference_optimizer/tests/test_phase_budget_pct_cli.py
@@ -103,6 +103,44 @@ def test_all_phase_budget_pct_spellings_parse() -> None:
     assert normalized["CLOSE"] == pytest.approx(0.03)
 
 
+def test_qwen3_8b_3h_no_kernel_budget_shape() -> None:
+    """The 3h demo budget stays normalized after disabling framework/kernel.
+
+    The demo passes explicit EXPLORE/SWEEP caps because disabled phase shares are
+    redistributed onto the remaining work phases. A lone EXPLORE=0.95 override
+    would combine with defaults to over-budget after redistribution.
+    """
+    args = _parse_optimize(
+        [
+            "--max-hours",
+            "3",
+            "--max-minutes-explore-pct",
+            "0.46",
+            "--max-minutes-sweep-pct",
+            "0.01",
+            "--no-framework-agent",
+            "--no-kernel",
+            "--no-enable-conc-sweep",
+        ]
+    )
+    normalized = normalize_budget_pct(cli._build_phase_budget_pct(args))
+    assert sum(normalized.values()) == pytest.approx(1.0)
+
+    out = redistribute_budget_pct(
+        normalized,
+        explore_enabled=not args.no_explore,
+        kernel_enabled=not args.no_kernel,
+        framework_enabled=not args.no_framework_agent,
+    )
+    assert out[PHASE_FRAMEWORK_AGENT] == 0.0
+    assert out[PHASE_KERNEL_AGENT] == 0.0
+    assert out["PRELUDE"] == pytest.approx(0.03)
+    assert out["CLOSE"] == pytest.approx(0.02)
+    assert out["EXPLORE"] == pytest.approx(0.9297872340425532)
+    assert out["SWEEP"] == pytest.approx(0.02021276595744681)
+    assert sum(out.values()) == pytest.approx(1.0)
+
+
 def test_optimize_path_is_wired_to_helper() -> None:
     """Guard: the live optimize path must build the budget via the helper.
 

--- a/src/hyperloom/inference_optimizer/tests/test_preflight_auth_override.py
+++ b/src/hyperloom/inference_optimizer/tests/test_preflight_auth_override.py
@@ -646,8 +646,8 @@ def test_ensure_python_sdks_installs_missing_claude_agent_sdk(monkeypatch, capsy
 
 
 # _ensure_ray
-def test_ensure_ray_skips_when_importable(monkeypatch, capsys):
-    """`import ray` returns rc=0 → no pip install fires (probe uses the interpreter)."""
+def test_ensure_ray_skips_when_smoke_passes(monkeypatch, capsys):
+    """Ray/click smoke passes -> no pip install fires (probe uses the interpreter)."""
     runner = _RecordingRun([_Completed(returncode=0)])
     monkeypatch.setattr(cli_preflight.subprocess, "run", runner)
 
@@ -655,30 +655,39 @@ def test_ensure_ray_skips_when_importable(monkeypatch, capsys):
 
     assert len(runner.calls) == 1
     probe = runner.calls[0]
-    # Probe imports ray with the SAME interpreter, not shutil.which on PATH.
-    assert probe == ["/opt/venv/bin/python", "-c", "import ray"]
+    # Probe validates Ray with the SAME interpreter, not shutil.which on PATH.
+    assert probe[0:2] == ["/opt/venv/bin/python", "-c"]
+    assert "ray.__version__" in probe[2]
+    assert "ray.scripts.scripts" in probe[2]
     assert "ray OK" in capsys.readouterr().out
 
 
-def test_ensure_ray_installs_when_not_importable(monkeypatch, capsys):
-    """When `import ray` fails, pip install runs with the SAME interpreter.
+def test_ensure_ray_installs_when_smoke_fails(monkeypatch, capsys):
+    """When Ray/click smoke fails, pip install runs with the SAME interpreter.
 
     Guards the bypass-only regression: a stray ``ray`` on PATH must not stop
-    the install when the active interpreter cannot import ray.
+    the install when the active interpreter cannot run Ray correctly.
     """
-    runner = _RecordingRun([_Completed(returncode=1), _Completed(returncode=0)])
+    runner = _RecordingRun(
+        [
+            _Completed(returncode=1, stderr="click version incompatible with Ray CLI: 8.4.2 >= 8.3.0"),
+            _Completed(returncode=0),
+            _Completed(returncode=0),
+        ]
+    )
     monkeypatch.setattr(cli_preflight.subprocess, "run", runner)
 
     cli_preflight._ensure_ray("/opt/venv/bin/python", ["--break-system-packages"])
 
-    assert len(runner.calls) == 2
+    assert len(runner.calls) == 3
     install_call = runner.calls[1]
     assert install_call[0] == "/opt/venv/bin/python"
     assert install_call[1:4] == ["-m", "pip", "install"]
     assert "--break-system-packages" in install_call
     assert any(arg.startswith("ray[default]==") for arg in install_call)
+    assert "click<8.3.0" in install_call
     captured = capsys.readouterr().out
-    assert "ray not importable" in captured
+    assert "ray/click invalid" in captured
     assert "ray installed OK" in captured
 
 


### PR DESCRIPTION
## Summary

- Harden Ray setup/preflight by validating Ray version, click compatibility, and the Ray CLI import path before treating Ray as usable.
- Restart an existing local Ray head during install when it does not advertise the `serving_slot` custom resource required by serving-family work.
- Fix the Qwen3-8B 3h demo budget flags so disabling framework/kernel phases still leaves a normalized budget shape.

## Testing

- `python3 -m pytest src/hyperloom/inference_optimizer/tests/test_phase_budget_pct_cli.py::test_qwen3_8b_3h_no_kernel_budget_shape src/hyperloom/inference_optimizer/tests/test_phase_budget_pct_cli.py::test_all_phase_budget_pct_spellings_parse src/hyperloom/inference_optimizer/tests/test_preflight_auth_override.py::test_ensure_ray_skips_when_smoke_passes src/hyperloom/inference_optimizer/tests/test_preflight_auth_override.py::test_ensure_ray_installs_when_smoke_fails src/hyperloom/inference_optimizer/tests/test_backend_gating.py::test_kernel_install_validates_ray_cli_and_serving_slot`
- `bash -n src/hyperloom/agents/kernel/scripts/install.sh`
- `python3 -m py_compile src/hyperloom/inference_optimizer/cli/preflight.py`

## Local package

- Built local wheel: `dist/hyperloom_inference_optimizer-0.9.0-py3-none-any.whl`
- SHA256: `b058e97210663cb280e7ae7c42a9df94347a9bf5059f5b2d34fd7769b8e116de`
