### PR TITLE
docs: add status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # ROCm Hyperloom
 
+[![Tests](https://github.com/AMD-AGI/Hyperloom/actions/workflows/tests-coverage.yml/badge.svg)](https://github.com/AMD-AGI/Hyperloom/actions/workflows/tests-coverage.yml)
+[![Lint](https://github.com/AMD-AGI/Hyperloom/actions/workflows/lint.yml/badge.svg)](https://github.com/AMD-AGI/Hyperloom/actions/workflows/lint.yml)
+[![Version](https://img.shields.io/badge/version-0.8.0-blue)](pyproject.toml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
+[![Python](https://img.shields.io/badge/python-3.10%2B-blue)](pyproject.toml)
+
 ROCm™ Hyperloom is an autonomous agentic system designed to optimize end-to-end inference workloads
 (targeting both host code and GPU kernels) on AMD GPUs. Using advanced AI agents and profiling tools,
 Hyperloom analyzes your workload, identifies performance bottlenecks, implements targeted optimizations,


### PR DESCRIPTION
## Summary
Adds a row of standard status badges to the top of the README for at-a-glance project health and metadata:

- **Tests** — `tests-coverage.yml` workflow status
- **Lint** — `lint.yml` workflow status
- **Version** — current package version (`0.8.0` from `pyproject.toml`)
- **License** — MIT
- **Python** — `>=3.10`

Coverage and download badges from the "typical top 5" were intentionally omitted since there is no live source wired up (no Codecov integration and the package is not published to a registry). The Tests workflow already runs coverage, so its badge reflects test health.

## Test plan
- [ ] Confirm badges render on the rendered README (workflow badges resolve once the branch/PR runs against `main`).
- [ ] Verify links point to the correct workflow/action pages.
