### PR TITLE
fix: isolate co-located Ray heads by free ports + salvage sibling baseline accuracy

### DIFF
--- a/src/hyperloom/agents/kernel/scripts/install.sh
+++ b/src/hyperloom/agents/kernel/scripts/install.sh
@@ -703,6 +703,20 @@ PY
 #      with all visible GPUs advertised
 #   4. tolerate the no-GPU case (CPU-only dev box) so `--check-only` stays
 #      non-fatal in environments without ROCm
+_free_tcp_port() {
+  # Print a currently-free loopback TCP port (probe via an ephemeral bind).
+  # Echoes 0 on failure so callers fall back to Ray's default port.
+  python3 - <<'PY' 2>/dev/null || echo 0
+import socket
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+try:
+    s.bind(("127.0.0.1", 0))
+    print(s.getsockname()[1])
+finally:
+    s.close()
+PY
+}
+
 ensure_ray_started() {
   if [ "$CHECK_ONLY" -eq 1 ] || [ "$DRY_RUN" -eq 1 ]; then
     return 0
@@ -740,7 +754,20 @@ PY
   if [ "${RAY_NUM_GPUS:-}" != "" ]; then
     num_gpus="$RAY_NUM_GPUS"
   fi
-  log "starting ray head with --num-gpus=${num_gpus}"
+  # Bind the head to FREE, probed ports instead of Ray's fixed defaults (GCS
+  # 6379, client 10001). On spur many sessions share a node's host network, so
+  # the fixed ports collide: a later head attaches to an earlier/leftover head's
+  # GCS and aborts with a session-name mismatch (ray-session-isolation). No
+  # rendezvous is needed -- Ray records the chosen address in the container-
+  # private /tmp/ray/ray_current_cluster, which ``ray status`` /
+  # ``ray.init(address="auto")`` read. HL_RAY_HEAD_PORT pins the GCS port.
+  local ray_port_args=()
+  local ray_gcs_port ray_client_port
+  ray_gcs_port="${HL_RAY_HEAD_PORT:-$(_free_tcp_port)}"
+  ray_client_port="$(_free_tcp_port)"
+  [ -n "$ray_gcs_port" ] && [ "$ray_gcs_port" != "0" ] && ray_port_args+=(--port="$ray_gcs_port")
+  [ -n "$ray_client_port" ] && [ "$ray_client_port" != "0" ] && ray_port_args+=(--ray-client-server-port="$ray_client_port")
+  log "starting ray head with --num-gpus=${num_gpus} port=${ray_gcs_port}"
   # Declare the ``serving_slot`` custom resource so serving-family GPU work
   # (baseline / profile / explore / sweep / gpu_research) routed through the
   # Ray execution backend can hold the whole-machine mutex (ray_modify.plan.md
@@ -748,6 +775,7 @@ PY
   # PENDING forever, since ensure_ray_cluster connects to this existing head
   # instead of starting its own with the resource.
   if ! ray start --head --disable-usage-stats \
+       "${ray_port_args[@]}" \
        --num-gpus="$num_gpus" --include-dashboard=false \
        --resources='{"serving_slot": 1}' >/dev/null; then
     warn "ray start failed; kernel optimization will hang. Check ROCm visibility."

--- a/src/hyperloom/agents/kernel/tests/test_ray_fd_limit.py
+++ b/src/hyperloom/agents/kernel/tests/test_ray_fd_limit.py
@@ -325,3 +325,88 @@ def test_force_restart_local_cluster_declares_serving_slot(monkeypatch):
     starts = [cmd for kind, cmd in events if kind == "ray_start"]
     assert starts, "ray start was not invoked"
     _assert_declares_serving_slot(starts[0])
+
+
+import pytest  # noqa: E402
+
+
+_ISO_ENV_VARS = ("HL_RAY_HEAD_PORT", "RAY_ADDRESS")
+
+
+def _arg_value(start_cmd: tuple, flag: str):
+    """Return the ``=value`` of a ``--flag=value`` token in a ray start argv."""
+    for tok in start_cmd:
+        if tok.startswith(f"{flag}="):
+            return tok.split("=", 1)[1]
+    return None
+
+
+class TestLocalHeadPortIsolation:
+    """Free-port isolation for spur host-network co-location.
+
+    Co-scheduled sessions share only the host network, so the sole collision is
+    Ray's fixed default ports (GCS 6379 / dashboard 8265 / client 10001): the
+    later head connects to the earlier head's GCS and aborts with a session-name
+    mismatch. Each head is bound to FREE probed ports; rendezvous is via the
+    container-private ``/tmp/ray/ray_current_cluster`` (no ``--temp-dir``, no
+    ``RAY_ADDRESS`` pin), so ``ray.init(address="auto")`` still discovers it.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clean_ray_env(self, monkeypatch):
+        """Scrub override/address env so each case is deterministic."""
+        for var in _ISO_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+
+    def test_free_tcp_port_is_bindable(self):
+        """The probed port is a real, currently-free loopback TCP port."""
+        import socket
+
+        port = ray_runtime._free_tcp_port()
+        assert isinstance(port, int) and 0 < port < 65536
+        # It was released, so we can immediately bind it ourselves.
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", port))
+
+    def test_isolated_ports_are_free_and_distinct(self):
+        """GCS / dashboard / client all get distinct probed ports by default."""
+        gcs, extra = ray_runtime._isolated_head_port_args()
+        dash = int(_arg_value(tuple(extra), "--dashboard-port"))
+        client = int(_arg_value(tuple(extra), "--ray-client-server-port"))
+        assert len({gcs, dash, client}) == 3
+        for p in (gcs, dash, client):
+            assert 0 < p < 65536
+
+    def test_no_ray_address_pinned(self, monkeypatch):
+        """We must NOT set RAY_ADDRESS: ray.init(address='auto') does discovery."""
+        import os as _os
+
+        ray_runtime._isolated_head_port_args()
+        assert "RAY_ADDRESS" not in _os.environ
+
+    def test_head_port_override_pins_gcs_only(self, monkeypatch):
+        """HL_RAY_HEAD_PORT pins the GCS port; dashboard/client stay probed."""
+        monkeypatch.setenv("HL_RAY_HEAD_PORT", "6500")
+        gcs, extra = ray_runtime._isolated_head_port_args()
+        assert gcs == 6500
+        assert _arg_value(tuple(extra), "--dashboard-port") is not None
+        assert _arg_value(tuple(extra), "--ray-client-server-port") is not None
+
+    def test_ensure_ray_cluster_binds_isolated_ports(self, monkeypatch):
+        """End-to-end: ensure_ray_cluster emits probed GCS/dashboard/client ports."""
+        events: list = []
+        fake = _FakeResource(soft=1048576, hard=1048576, events=events)
+        monkeypatch.setattr(ray_runtime, "resource", fake, raising=False)
+        _install_fake_ray_start(monkeypatch, events)
+
+        ray_runtime.ensure_ray_cluster(num_gpus=8)
+
+        start = [cmd for kind, cmd in events if kind == "ray_start"][0]
+        assert _arg_value(start, "--port") is not None
+        assert _arg_value(start, "--dashboard-port") is not None
+        assert _arg_value(start, "--ray-client-server-port") is not None
+        # No --temp-dir (issue #55244); dashboard bound to loopback (security).
+        assert not any(t.startswith("--temp-dir=") for t in start)
+        assert "--dashboard-host=127.0.0.1" in start
+        assert "--num-gpus=8" in start
+        _assert_declares_serving_slot(start)

--- a/src/hyperloom/agents/kernel/tests/test_ray_version_mismatch.py
+++ b/src/hyperloom/agents/kernel/tests/test_ray_version_mismatch.py
@@ -136,7 +136,10 @@ def test_force_restart_local_cluster_runs_stop_then_start(tmp_path):
         ray_runtime.force_restart_local_cluster(num_gpus=4, log_path=log_path)
 
     assert runs[0] == ["ray", "stop", "--force"]
-    assert runs[1][:4] == ["ray", "start", "--head", "--port=6379"]
+    # The fresh head binds a probed free port (not the fixed 6379) so co-located
+    # host-network sessions never collide on Ray's default GCS port.
+    assert runs[1][:3] == ["ray", "start", "--head"]
+    assert any(tok.startswith("--port=") for tok in runs[1])
     assert "--num-gpus=4" in runs[1]
     assert log_path.exists()
 

--- a/src/hyperloom/agents/kernel/tools/backends/ray_runtime.py
+++ b/src/hyperloom/agents/kernel/tools/backends/ray_runtime.py
@@ -47,6 +47,59 @@ def _resources_start_args() -> list[str]:
     return ["--resources", json.dumps(_HEAD_CUSTOM_RESOURCES)]
 
 
+# --- Local-head port isolation (spur host-network co-location) ---------------
+# Many optimizer sessions can be co-scheduled on ONE compute node (SLURM packs
+# sub-node ``--gpus`` requests), and spur runs the container on the host network
+# stack (the bridge has no egress). Only the HOST NETWORK is shared between
+# co-located containers: each keeps a PRIVATE filesystem (no ``/tmp`` bind mount)
+# and a PRIVATE PID namespace (no ``--pid=host``). So the ONLY thing that
+# collides is Ray's FIXED default host ports (GCS 6379, dashboard 8265, client
+# 10001): the later head connects to the earlier head's GCS over 127.0.0.1:6379
+# and aborts with a session-name mismatch (``node._write_cluster_info_to_kv``),
+# hanging the kernel agent and failing every serving-lease "cluster ensure".
+#
+# Fix: bind each head to FREE, probed ports instead of the fixed defaults. No
+# cross-process coordination is needed -- Ray records the chosen GCS address in
+# the container-private ``/tmp/ray/ray_current_cluster``, so the serving lease's
+# later ``ensure()`` discovers it via ``ray status`` / ``ray.init(address=
+# "auto")`` without knowing the port. We deliberately do NOT pass ``--temp-dir``
+# (that reintroduces Ray issue #55244, where ``address="auto"`` still looks in
+# the default ``/tmp/ray`` rather than the custom dir); the default dir is
+# already container-private here. ``HL_RAY_HEAD_PORT`` pins the GCS port for
+# operators/debugging.
+_HL_RAY_HEAD_PORT_ENV = "HL_RAY_HEAD_PORT"
+
+
+def _free_tcp_port() -> int:
+    """Reserve and return a currently-free loopback TCP port.
+
+    Binds an ephemeral socket, reads the OS-assigned port, and releases it.
+    There is an inherent (tiny) TOCTOU window before ``ray start`` rebinds it;
+    on a host-network node with per-session ports this is far less likely than
+    the guaranteed 6379 collision it replaces.
+    """
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _isolated_head_port_args() -> Tuple[int, list[str]]:
+    """Return ``(gcs_port, extra_start_args)`` bound to FREE probed ports.
+
+    Isolates the GCS / dashboard / Ray-client ports so co-located sessions never
+    share Ray's fixed defaults. ``HL_RAY_HEAD_PORT`` pins the GCS port (dashboard
+    and client are still probed to avoid their own collisions).
+    """
+    port_override = os.environ.get(_HL_RAY_HEAD_PORT_ENV, "").strip()
+    gcs_port = int(port_override) if port_override.isdigit() else _free_tcp_port()
+    return gcs_port, [
+        f"--dashboard-port={_free_tcp_port()}",
+        f"--ray-client-server-port={_free_tcp_port()}",
+    ]
+
+
 def _fd_limit_warn(msg: str) -> None:
     """Emit an fd-limit warning to stderr with a stable prefix.
 
@@ -202,15 +255,22 @@ def ensure_ray_cluster(num_gpus: Optional[int] = None, log_path: Optional[Path] 
     Raises:
         RuntimeError: If starting the Ray head node fails.
     """
+    # ``ray status`` reads the container-private /tmp/ray/ray_current_cluster,
+    # so a head already started by this session (kernel agent or serving lease)
+    # is reused regardless of which free port it bound.
     if ray_status_ok():
         return False
     # Raise the open-files limit before the raylet starts.
     ensure_fd_limit(log_path=log_path)
     # Bind the dashboard/jobs API to loopback (avoids exposing the
-    # unauthenticated Ray Jobs RCE surface); GCS (:6379) is unaffected.
-    cmd = ["ray", "start", "--head", "--port=6379", "--dashboard-host=127.0.0.1"]
+    # unauthenticated Ray Jobs RCE surface).
+    gcs_port, iso_args = _isolated_head_port_args()
+    cmd = ["ray", "start", "--head", f"--port={gcs_port}", "--dashboard-host=127.0.0.1"]
     if num_gpus is not None:
         cmd.append(f"--num-gpus={num_gpus}")
+    # Free, probed GCS/dashboard/client ports so co-located host-network sessions
+    # never collide on Ray's fixed defaults (6379/8265/10001).
+    cmd.extend(iso_args)
     # Declare the ``serving_slot`` custom resource (§12 T6 authoritative mutex).
     cmd.extend(_resources_start_args())
     if log_path is not None:
@@ -281,9 +341,12 @@ def force_restart_local_cluster(
     ensure_fd_limit(log_path=log_path)
     stop_cmd = ["ray", "stop", "--force"]
     # Bind the dashboard/jobs API to loopback (see ensure_ray_cluster).
-    start_cmd = ["ray", "start", "--head", "--port=6379", "--dashboard-host=127.0.0.1"]
+    gcs_port, iso_args = _isolated_head_port_args()
+    start_cmd = ["ray", "start", "--head", f"--port={gcs_port}", "--dashboard-host=127.0.0.1"]
     if num_gpus is not None:
         start_cmd.append(f"--num-gpus={num_gpus}")
+    # Free, probed GCS/dashboard/client ports (see ensure_ray_cluster).
+    start_cmd.extend(iso_args)
     # Re-declare the ``serving_slot`` custom resource after a fresh head (§12 T6).
     start_cmd.extend(_resources_start_args())
     if log_path is not None:

--- a/src/hyperloom/inference_optimizer/tests/test_baseline_eval_fallback.py
+++ b/src/hyperloom/inference_optimizer/tests/test_baseline_eval_fallback.py
@@ -399,6 +399,7 @@ class _StopRecorder:
 
     def __init__(self) -> None:
         self.stop_reason = ""
+        self.baseline_accuracy = 0.0
 
     def set_stop_reason(self, value, **_kwargs):
         self.stop_reason = value
@@ -487,6 +488,57 @@ def test_no_stop_when_not_genuine_baseline():
 def test_no_stop_when_baseline_failed():
     reason = _stopped("sglang", {"status": "failed", "error": "boom"})
     assert reason == ""
+
+
+# --- session-level salvage (sibling attempt already measured accuracy) -------
+def _write_gsm8k_results(measure_round: Path, score: float) -> None:
+    """Write a minimal lm-eval ``results*.json`` under a measure round dir."""
+    d = measure_round / "benchmark_vllm_x"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "results_x.json").write_text(
+        json.dumps({"results": {"gsm8k": {"exact_match,strict-match": score}}}),
+        encoding="utf-8",
+    )
+
+
+def test_salvage_sibling_attempt_accuracy_prevents_stop(tmp_path):
+    # A sibling attempt already produced a valid gsm8k result; the deciding
+    # attempt's own RESULT_DIR is empty. The run must NOT stop -- the accuracy
+    # is salvaged from the sibling and promoted onto the result.
+    runs_baseline = tmp_path / "runs" / "baseline"
+    good = runs_baseline / "786a793e" / "measure_round"
+    _write_gsm8k_results(good, 0.9128)
+    deciding = runs_baseline / "retry2_bootsafe"
+    deciding.mkdir(parents=True, exist_ok=True)
+
+    executor = BaselineExecutor()
+    rec = _StopRecorder()
+    result = {
+        "status": "succeeded",
+        "run_eval_disabled": False,
+        "output_dir": str(deciding),
+    }
+    executor._maybe_stop_on_missing_baseline_accuracy(_stop_ctx("vllm", rec), result)
+
+    assert rec.stop_reason == ""
+    assert result["accuracy"] == pytest.approx(0.9128)
+    assert rec.baseline_accuracy == pytest.approx(0.9128)
+    assert "baseline_accuracy_salvaged_from_sibling_attempt" in result.get("nonfatal_warnings", [])
+
+
+def test_salvage_ignores_discarded_warmup_and_stops(tmp_path):
+    # Only a discarded warmup round carries a score; parse_eval_results excludes
+    # warmup output, so there is nothing to salvage and the run stops.
+    runs_baseline = tmp_path / "runs" / "baseline"
+    _write_gsm8k_results(runs_baseline / "786a793e" / "warmup_round", 0.9)
+    deciding = runs_baseline / "retry2_bootsafe"
+    deciding.mkdir(parents=True, exist_ok=True)
+
+    reason = _stopped(
+        "vllm",
+        {"status": "succeeded", "run_eval_disabled": False, "output_dir": str(deciding)},
+    )
+    assert reason == "baseline_accuracy_failed"
 
 
 def test_eval_already_off_does_not_retry(tmp_path):

--- a/src/hyperloom/orchestrator/actions/executors/baseline.py
+++ b/src/hyperloom/orchestrator/actions/executors/baseline.py
@@ -1239,10 +1239,78 @@ class BaselineExecutor:
             return
         extra = getattr(ctx, "extra", None) or {}
         shared_state = extra.get("shared_state") or self.shared_state
+        # Session-level salvage (complements #942): the cold-start guard and the
+        # coordinator's retries each run in their own ``runs/baseline/<attempt>``
+        # dir. #942 keeps every attempt's eval output inside that attempt's
+        # ``$RESULT_DIR``, but the accuracy-stop decision runs on the *deciding*
+        # attempt -- whose dir can be empty when a prior sibling attempt already
+        # produced a valid ``results*.json``. Before halting, reuse a positive
+        # accuracy measured by any sibling attempt rather than discarding a good
+        # baseline and stopping the whole run.
+        salvaged = self._salvage_sibling_baseline_accuracy(result, framework)
+        if salvaged is not None:
+            acc_val = float(salvaged["accuracy"])
+            result["accuracy"] = acc_val
+            result["accuracy_task"] = salvaged.get("task", "gsm8k")
+            result["accuracy_metric"] = salvaged.get("metric", "")
+            result["accuracy_source"] = salvaged.get("source_file", "")
+            result.setdefault("nonfatal_warnings", [])
+            result["nonfatal_warnings"].append("baseline_accuracy_salvaged_from_sibling_attempt")
+            if shared_state is not None:
+                try:
+                    shared_state.baseline_accuracy = acc_val
+                except Exception:  # noqa: BLE001 — salvage must never break baseline
+                    log.debug("baseline_executor: salvage could not set shared_state", exc_info=True)
+            log.warning(
+                "baseline_executor: this attempt's RESULT_DIR had no accuracy, "
+                "but salvaged a valid baseline accuracy=%.4f from a sibling "
+                "attempt (%s); not stopping the run",
+                acc_val,
+                salvaged.get("source_file", ""),
+            )
+            return
         request_baseline_accuracy_stop(
             shared_state,
             context=f"baseline:{framework or 'unknown'}",
         )
+
+    def _salvage_sibling_baseline_accuracy(
+        self,
+        result: dict[str, Any],
+        framework: str | None,
+    ) -> dict[str, Any] | None:
+        """Return a positive accuracy from a sibling baseline attempt, if any.
+
+        Scans the shared ``runs/baseline`` root (the parent of this attempt's
+        ``output_dir``) so eval output written by any sibling attempt is seen.
+        Discarded warmup rounds are excluded by :func:`parse_eval_results`.
+        Best-effort: any error yields ``None`` (the caller then stops as before).
+
+        Args:
+            result: The final baseline result dict (carries ``output_dir``).
+            framework: Framework name threaded into the eval parser.
+
+        Returns:
+            The parsed eval dict when a positive accuracy is found, else
+            ``None``.
+        """
+        out = result.get("output_dir")
+        if not out:
+            return None
+        runs_root = Path(out).parent  # .../runs/baseline
+        if not runs_root.exists():
+            return None
+        try:
+            from ._accuracy_gate import parse_eval_results
+
+            eval_data = parse_eval_results(runs_root, framework=framework)
+        except Exception:  # noqa: BLE001 — salvage must never break the stop path
+            log.debug("baseline_executor: sibling-accuracy salvage scan failed", exc_info=True)
+            return None
+        acc = eval_data.get("accuracy")
+        if acc is not None and float(acc) > 0.0:
+            return eval_data
+        return None
 
     async def _run_once(
         self,


### PR DESCRIPTION
## Summary

Two independent robustness fixes surfaced while dispatching Hyperloom inference-optimizer sessions on spur (many sessions packed onto one host-network node):

1. **Ray head port isolation** (`ray_runtime.py`, `install.sh`) — spur co-locates multiple optimizer sessions on a single node's **host network**, so Ray's *fixed* default ports (GCS `6379`, dashboard `8265`, client `10001`) collide. A later head attaches to an earlier/leftover head's GCS over `127.0.0.1:6379` and aborts with a session-name mismatch, hanging the kernel agent and failing every serving-lease "cluster ensure". Fix: probe **free** TCP ports and bind the head to them instead of the fixed defaults. No cross-process rendezvous is needed — Ray records the chosen address in the container-private `/tmp/ray/ray_current_cluster`, which `ray status` / `ray.init(address="auto")` already read. `HL_RAY_HEAD_PORT` pins the GCS port for operators/debugging. Applied to both the Python backend (`ensure_ray_cluster`, `force_restart_local_cluster`) and the shell bootstrap (`ensure_ray_started`).

2. **Baseline accuracy sibling salvage** (`baseline.py`) — complements #942. The cold-start guard and coordinator retries each run in their own `runs/baseline/<attempt>` dir. The accuracy-stop decision runs on the *deciding* attempt, whose `RESULT_DIR` can be empty when a **sibling** attempt already produced a valid `results*.json`. That caused false-positive `baseline_accuracy_failed` stops. Fix: before halting, scan the shared `runs/baseline` root and reuse a positive accuracy measured by any sibling attempt instead of discarding a good baseline and stopping the whole run.

## Changes

- `agents/kernel/tools/backends/ray_runtime.py`: `_free_tcp_port()`, `_isolated_head_port_args()`; bind head to probed GCS/dashboard/client ports.
- `agents/kernel/scripts/install.sh`: `_free_tcp_port()` helper + probed `--port` / `--ray-client-server-port` in `ensure_ray_started`.
- `orchestrator/actions/executors/baseline.py`: `_salvage_sibling_baseline_accuracy()` + salvage before `request_baseline_accuracy_stop`.
- Tests: `test_ray_fd_limit.py`, `test_ray_version_mismatch.py`, `test_baseline_eval_fallback.py`.

## Test plan

- [ ] `pytest src/hyperloom/agents/kernel/tests/test_ray_fd_limit.py src/hyperloom/agents/kernel/tests/test_ray_version_mismatch.py`
- [ ] `pytest src/hyperloom/inference_optimizer/tests/test_baseline_eval_fallback.py`
- [ ] Dispatch multiple co-located sessions on one spur node; confirm each Ray head binds distinct ports and no session-name-mismatch aborts.
- [ ] Confirm a run whose deciding baseline attempt has an empty RESULT_DIR but a valid sibling result no longer stops with `baseline_accuracy_failed`.

Made with [Cursor](https://cursor.com)