### PR TITLE
ci: parallel test suite (pytest-split shards + xdist), duration-balanced + pip cache

### DIFF
--- a/.github/workflows/tests-coverage.yml
+++ b/.github/workflows/tests-coverage.yml
@@ -6,12 +6,27 @@ name: Tests with Coverage
 # Runs on push and pull_request for all branches. Skips when every changed file
 # matches paths-ignore (documentation-only and repo-metadata edits).
 #
-# Pytest argv for CI lives in ``pyproject.toml`` → ``[tool.hyperloom.tests_coverage]``.
+# Pytest argv for CI lives in ``pyproject.toml`` -> ``[tool.hyperloom.tests_coverage]``.
 # This workflow reads that table with inline Python.
+#
+# Parallelism has two independent layers so a 2-vCPU GitHub runner is not the
+# ceiling:
+#   1. Cross-job sharding (pytest-split): the suite is split into
+#      ``total_shards`` groups, one GitHub job each (matrix ``shard`` axis).
+#   2. In-runner workers (pytest-xdist ``-n xdist_workers``): each shard job
+#      fills its own vCPUs.
+# Effective parallelism is ``total_shards * xdist_workers`` per Python version.
+#
+# Each shard writes a partial, parallel-mode coverage data file and uploads it.
+# A dependent ``coverage`` job (one per Python version) downloads every shard's
+# data, ``coverage combine``-s them, renders the Job Summary, and enforces
+# ``fail_under``. Merging is exact -- the combined total equals a full serial
+# run -- so the 90% gate is unchanged.
+#
 # Coverage per-tree summary reads ``[tool.coverage.run].source`` the same way.
-# When ``OOB/`` is present, ``pip install -e \"./OOB\"`` enables ``agent_mcp_server``
+# When ``OOB/`` is present, ``pip install -e "./OOB"`` enables ``agent_mcp_server``
 # UTs; if absent, install is skipped (``importorskip`` in OOB tests).
-# Two matrix legs (Python 3.10 + 3.11).
+# Two Python legs (3.10 + 3.11).
 # pull_request runs use the workflow definition from the PR merge ref.
 on:
   # PRs run via ``pull_request``; ``push`` is scoped to ``main`` so a same-repo
@@ -44,8 +59,103 @@ permissions:
   checks: write
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # Shard matrix: (python-version x shard). Each job runs its slice of the suite
+  # with pytest-split and in-runner xdist, then uploads a partial coverage data
+  # file. No gate here -- a single shard's coverage is intentionally incomplete.
+  # ---------------------------------------------------------------------------
   test:
-    name: test (Python ${{ matrix.python-version }})
+    name: test (py${{ matrix.python-version }} shard ${{ matrix.shard }}/4)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11"]
+        # NOTE: keep this list length in sync with ``total_shards`` in
+        # pyproject.toml ([tool.hyperloom.tests_coverage]). GitHub matrices
+        # cannot read that value dynamically, so it is mirrored here.
+        shard: [1, 2, 3, 4]
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -e ".[test,ci]"
+          if [ -f OOB/pyproject.toml ]; then
+            pip install -e "./OOB"
+          else
+            echo "::notice::OOB/ not in checkout (no pyproject.toml); skipping editable OOB install."
+          fi
+
+      - name: Run tests with coverage (shard ${{ matrix.shard }})
+        id: pytest
+        continue-on-error: true
+        env:
+          SHARD: ${{ matrix.shard }}
+        run: |
+          set -euo pipefail
+          # Base argv + worker/shard counts come from pyproject.toml so all
+          # tuning lives in one place.
+          readarray -t PARGS < <(python3 <<'PY'
+          import pathlib
+          try:
+              import tomllib
+          except ModuleNotFoundError:
+              import tomli as tomllib
+          cfg = tomllib.loads(pathlib.Path("pyproject.toml").read_text(encoding="utf-8"))
+          t = cfg["tool"]["hyperloom"]["tests_coverage"]
+          for a in t["pytest_ci_args"]:
+              print(a)
+          print("-n"); print(str(t.get("xdist_workers", 2)))
+          print("--splits"); print(str(t.get("total_shards", 4)))
+          PY
+          )
+          RELAX="${COVERAGE_RELAX_FAIL_UNDER:-}"
+          EXTRA=()
+          if echo "$RELAX" | grep -qiE '^(1|true|yes|on)$'; then
+            # Gate is enforced later in the combine job; keep pytest-cov quiet here.
+            EXTRA=(--cov-fail-under=0)
+            echo "::notice::COVERAGE_RELAX_FAIL_UNDER is set: fail_under not enforced by pytest-cov."
+          fi
+          # Parallel-mode data file (unique per shard) so the combine job can
+          # merge every shard without clobbering. ``--group`` selects this
+          # shard's slice of the ``--splits`` partition (from PARGS).
+          export COVERAGE_FILE=".coverage.shard${SHARD}"
+          pytest "${PARGS[@]}" --group "${SHARD}" --cov-fail-under=0 "${EXTRA[@]}"
+
+      - name: Record shard outcome
+        if: always()
+        run: |
+          mkdir -p shard-status
+          echo "${{ steps.pytest.outcome }}" > "shard-status/py${{ matrix.python-version }}-shard${{ matrix.shard }}.outcome"
+
+      - name: Upload shard coverage data
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: covdata-py${{ matrix.python-version }}-shard${{ matrix.shard }}
+          path: |
+            .coverage.shard${{ matrix.shard }}
+            shard-status/*.outcome
+          include-hidden-files: true
+          retention-days: 1
+          if-no-files-found: warn
+
+  # ---------------------------------------------------------------------------
+  # Combine + gate: one job per Python version. Downloads all shard artifacts
+  # for its version, ``coverage combine``-s them, renders the Job Summary, and
+  # enforces fail_under -- exactly the pre-sharding behaviour, on the merged
+  # data. Also fails if any shard's pytest run failed.
+  # ---------------------------------------------------------------------------
+  coverage:
+    name: coverage (Python ${{ matrix.python-version }})
+    needs: test
+    if: always()
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -68,34 +178,49 @@ jobs:
             echo "::notice::OOB/ not in checkout (no pyproject.toml); skipping editable OOB install."
           fi
 
-      - name: Run tests with coverage
-        id: pytest
-        continue-on-error: true
+      - name: Download shard coverage data
+        uses: actions/download-artifact@v4
+        with:
+          pattern: covdata-py${{ matrix.python-version }}-shard*
+          merge-multiple: true
+
+      - name: Combine shard coverage
         run: |
           set -euo pipefail
-          readarray -t PARGS < <(python3 <<'PY'
-          import pathlib
-          try:
-              import tomllib
-          except ModuleNotFoundError:
-              import tomli as tomllib
-          cfg = tomllib.loads(pathlib.Path("pyproject.toml").read_text(encoding="utf-8"))
-          for a in cfg["tool"]["hyperloom"]["tests_coverage"]["pytest_ci_args"]:
-              print(a)
-          PY
-          )
-          RELAX="${COVERAGE_RELAX_FAIL_UNDER:-}"
-          EXTRA=()
-          if echo "$RELAX" | grep -qiE '^(1|true|yes|on)$'; then
-            EXTRA=(--cov-fail-under=0)
-            echo "::notice::COVERAGE_RELAX_FAIL_UNDER is set: fail_under not enforced by pytest-cov."
+          shopt -s nullglob
+          files=(.coverage.shard*)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::No shard coverage data files downloaded."
+            exit 1
           fi
-          pytest "${PARGS[@]}" "${EXTRA[@]}"
+          echo "Combining ${#files[@]} shard data file(s): ${files[*]}"
+          # ``combine`` consumes the parallel-mode files and writes ``.coverage``.
+          coverage combine "${files[@]}"
+          test -f .coverage || { echo "::error::coverage combine produced no .coverage"; exit 1; }
+
+      - name: Aggregate shard test outcomes
+        id: outcomes
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          failed=0
+          for f in shard-status/*.outcome; do
+            val="$(cat "$f")"
+            echo "$(basename "$f"): $val"
+            if [ "$val" != "success" ]; then
+              failed=1
+            fi
+          done
+          if [ "$failed" -eq 1 ]; then
+            echo "tests_ok=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "tests_ok=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Coverage summary
         if: always()
         env:
-          PYTEST_OUTCOME: ${{ steps.pytest.outcome }}
+          PYTEST_OUTCOME: ${{ steps.outcomes.outputs.tests_ok == 'true' && 'success' || 'failure' }}
         run: |
           python3 <<'PY'
           from __future__ import annotations
@@ -209,7 +334,8 @@ jobs:
                   "## Coverage (UT)",
                   "",
                   f"Python {sys.version_info.major}.{sys.version_info.minor}; "
-                  "roots and CI pytest argv from `pyproject.toml`.",
+                  "roots and CI pytest argv from `pyproject.toml`. "
+                  "Combined across sharded jobs.",
                   "",
                   "### Combined measured source (all configured trees)",
                   f"**TOTAL (line): {total}**",
@@ -234,7 +360,7 @@ jobs:
           PY
 
       - name: Enforce coverage fail_under (strict mode)
-        if: always() && steps.pytest.outcome == 'success'
+        if: always() && steps.outcomes.outputs.tests_ok == 'true'
         run: |
           python3 <<'PY'
           import os
@@ -262,7 +388,7 @@ jobs:
           PY
 
       - name: Enforce test success
-        if: always() && steps.pytest.outcome == 'failure'
+        if: always() && steps.outcomes.outputs.tests_ok != 'true'
         run: |
-          echo "::error::Tests failed (see the \"Run tests with coverage\" step log)."
+          echo "::error::One or more test shards failed (see the shard jobs' \"Run tests with coverage\" logs)."
           exit 1

--- a/.github/workflows/tests-coverage.yml
+++ b/.github/workflows/tests-coverage.yml
@@ -81,6 +81,12 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          # Cache the pip download/wheel cache keyed on the dependency spec, so
+          # the per-shard installs (this job runs total_shards x python-version
+          # times) don't re-download every run. Cache miss just falls back to a
+          # normal install.
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
         run: |
@@ -91,6 +97,29 @@ jobs:
           else
             echo "::notice::OOB/ not in checkout (no pyproject.toml); skipping editable OOB install."
           fi
+
+      # Restore the shared test-timing DB (read-only). pytest-split uses it to
+      # balance shards by measured duration instead of by test count. The cache
+      # is written only on push-to-main by the ``update-durations`` job below, so
+      # PR runs (including repeated pushes to a PR) only ever read it -- no write
+      # contention, no PR-diff pollution. A miss (new branch / 7-day eviction /
+      # first rollout) simply means pytest-split falls back to count-based
+      # splitting for that run; correctness and the 90% gate are unaffected.
+      - name: Restore test durations
+        id: durations
+        uses: actions/cache/restore@v4
+        with:
+          path: .test_durations
+          # GitHub cache keys are immutable, so update-durations saves under a
+          # rolling key (``...-v1-<run_id>``). We therefore never expect an exact
+          # hit on the bare prefix here; ``restore-keys`` prefix-matching returns
+          # the MOST RECENT cache under ``test-durations-v1-``. A single shared DB
+          # covers both Python legs (3.10/3.11 timings are close enough). The
+          # prefix is version-pinned (``-v1-``) so it survives main's
+          # force-pushes and can be rotated by bumping the version.
+          key: test-durations-v1-none
+          restore-keys: |
+            test-durations-v1-
 
       - name: Run tests with coverage (shard ${{ matrix.shard }})
         id: pytest
@@ -115,6 +144,17 @@ jobs:
           print("--splits"); print(str(t.get("total_shards", 4)))
           PY
           )
+          # Duration-based splitting when the DB is present; otherwise
+          # pytest-split falls back to count-based (no flag needed). Always
+          # (re)store this shard's own timing slice so the update-durations job
+          # can merge a fresh full DB on push-to-main.
+          SPLIT_ARGS=()
+          if [ -f .test_durations ]; then
+            SPLIT_ARGS+=(--splitting-algorithm=least_duration)
+            echo "::notice::Using cached .test_durations for duration-based sharding."
+          else
+            echo "::notice::No .test_durations cache; sharding by test count this run."
+          fi
           RELAX="${COVERAGE_RELAX_FAIL_UNDER:-}"
           EXTRA=()
           if echo "$RELAX" | grep -qiE '^(1|true|yes|on)$'; then
@@ -125,8 +165,12 @@ jobs:
           # Parallel-mode data file (unique per shard) so the combine job can
           # merge every shard without clobbering. ``--group`` selects this
           # shard's slice of the ``--splits`` partition (from PARGS).
+          # ``--store-durations`` records THIS shard's per-test timings into a
+          # shard-scoped file for the update-durations merge job.
           export COVERAGE_FILE=".coverage.shard${SHARD}"
-          pytest "${PARGS[@]}" --group "${SHARD}" --cov-fail-under=0 "${EXTRA[@]}"
+          pytest "${PARGS[@]}" --group "${SHARD}" "${SPLIT_ARGS[@]}" \
+            --store-durations --durations-path ".test_durations.shard${SHARD}" \
+            --cov-fail-under=0 "${EXTRA[@]}"
 
       - name: Record shard outcome
         if: always()
@@ -142,6 +186,19 @@ jobs:
           path: |
             .coverage.shard${{ matrix.shard }}
             shard-status/*.outcome
+          include-hidden-files: true
+          retention-days: 1
+          if-no-files-found: warn
+
+      # Upload this shard's timing slice so update-durations (push-to-main only)
+      # can merge a full fresh .test_durations. Only the 3.10 leg is uploaded to
+      # keep a single shared DB (see the restore key rationale above).
+      - name: Upload shard durations
+        if: always() && matrix.python-version == '3.10'
+        uses: actions/upload-artifact@v4
+        with:
+          name: durations-shard${{ matrix.shard }}
+          path: .test_durations.shard${{ matrix.shard }}
           include-hidden-files: true
           retention-days: 1
           if-no-files-found: warn
@@ -392,3 +449,67 @@ jobs:
         run: |
           echo "::error::One or more test shards failed (see the shard jobs' \"Run tests with coverage\" logs)."
           exit 1
+
+  # ---------------------------------------------------------------------------
+  # Refresh the shared test-timing DB. Runs ONLY on push-to-main and ONLY when
+  # every shard passed (needs: [test, coverage] + success()), so the cache is
+  # only ever updated from a complete, all-green main run -- never from a
+  # partial/failed suite and never from a PR. It merges the per-shard timing
+  # slices into one .test_durations and saves it under the fixed cache key that
+  # the test jobs restore. PRs consume this via main's cache scope (read-only).
+  # ---------------------------------------------------------------------------
+  update-durations:
+    name: update test durations (main)
+    needs: [test, coverage]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && success()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Download shard durations
+        uses: actions/download-artifact@v4
+        with:
+          pattern: durations-shard*
+          merge-multiple: true
+
+      - name: Merge shard durations into one DB
+        run: |
+          python3 <<'PY'
+          import glob, json, sys
+          merged = {}
+          files = sorted(glob.glob(".test_durations.shard*"))
+          if not files:
+              print("::warning::No shard duration files found; skipping durations refresh.")
+              sys.exit(0)
+          for f in files:
+              try:
+                  data = json.load(open(f, encoding="utf-8"))
+              except Exception as e:  # noqa: BLE001
+                  print(f"::warning::Skipping unreadable {f}: {e}")
+                  continue
+              # pytest-split writes a flat {nodeid: seconds} mapping. Shards are
+              # disjoint, so a plain update reconstructs the full-suite DB.
+              if isinstance(data, dict):
+                  merged.update(data)
+          if not merged:
+              print("::warning::Merged durations are empty; skipping refresh.")
+              sys.exit(0)
+          with open(".test_durations", "w", encoding="utf-8") as fh:
+              json.dump(merged, fh, indent=2, sort_keys=True)
+          print(f"Merged {len(files)} shard file(s) -> {len(merged)} test timings.")
+          PY
+
+      - name: Save merged durations to cache
+        if: hashFiles('.test_durations') != ''
+        uses: actions/cache/save@v4
+        with:
+          path: .test_durations
+          # Rolling key (run_id suffix) because cache entries are immutable --
+          # a fixed key would only ever save once and never refresh. The test
+          # jobs restore the newest one via the ``test-durations-v1-`` prefix.
+          # Old entries fall out via LRU / 7-day eviction on their own.
+          key: test-durations-v1-${{ github.run_id }}

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -8,4 +8,8 @@ regexes = [
   '''inferenceX_key:\s+[A-Za-z0-9._-]+''',
   '''llm_key\s*=\s*"approved-msg_abc123"''',
   '''"per_token":\s*"a8w8_untuned_gemm\.csv"''',
+  # actions/cache key/restore-keys for the CI test-duration DB in
+  # tests-coverage.yml -- a cache identifier, not a secret (flagged by the
+  # generic-api-key rule on the ``key:`` line).
+  '''(key|restore-keys):\s*test-durations-''',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,10 +70,17 @@ test = [
 ci = [
     "pytest-cov>=5.0",
     "coverage>=7.0",
-    # Parallel test execution for the coverage job (``-n auto`` in
-    # ``pytest_ci_args``). pytest-cov merges the per-worker coverage data, so
-    # the reported total is identical to a serial run.
+    # In-runner parallelism (``-n`` in ``pytest_ci_args``). pytest-cov merges
+    # the per-worker coverage data, so a single job's total is identical to a
+    # serial run. GitHub-hosted ``ubuntu-latest`` on a private/internal repo is
+    # a 2-vCPU VM, so ``-n auto`` resolves to a single worker (no speedup); the
+    # CI argv pins an explicit worker count instead (see ``pytest_ci_args``).
     "pytest-xdist>=3.5",
+    # Cross-job sharding for the coverage matrix (``--splits``/``--group`` in
+    # tests-coverage.yml). Splits the suite across N GitHub jobs; each job's
+    # partial coverage is uploaded and ``coverage combine``-d in a dependent
+    # job before the fail_under gate, so the merged total matches a full run.
+    "pytest-split>=0.8",
     "tomli>=2.0.1; python_version < '3.11'",
 ]
 # Optional live-Langfuse trace push (HYPERLOOM_LANGFUSE_ENABLE=1). The local
@@ -417,17 +424,29 @@ ignore_errors = true
 # Line coverage across all ``[tool.coverage.run].source`` trees (UT run in CI).
 fail_under = 90
 
-# GitHub Actions ``tests-coverage.yml`` reads ``pytest_ci_args`` from this table
-# using inline Python.
+# GitHub Actions ``tests-coverage.yml`` reads this table with inline Python.
 [tool.hyperloom.tests_coverage]
-# Full trailing argv for ``pytest`` in ``tests-coverage.yml`` (marker filter + cov).
+# Base trailing argv for ``pytest`` in ``tests-coverage.yml`` (marker filter +
+# coverage output). Coverage is written in parallel-data mode so each matrix
+# shard produces its own ``.coverage.*`` file; a dependent job ``coverage
+# combine``-s them before the fail_under gate, so the merged total equals a
+# full serial run. Sharding (``--splits``/``--group``) and the in-runner worker
+# count (``-n``) are appended by the workflow from ``total_shards`` /
+# ``xdist_workers`` below, not pinned here (they vary with the matrix / runner).
 pytest_ci_args = [
     "-m", "not critic_agent_e2e and not robustness_agent_e2e",
-    # Parallel workers (pytest-xdist). Coverage is merged across workers, so the
-    # total matches a serial run; cuts wall-clock roughly in half.
-    "-n", "auto",
-    "--cov=.", "--cov-report=xml", "--cov-report=term",
+    "--cov=.", "--cov-report=term",
 ]
+# In-runner pytest-xdist workers per shard job. Pinned to an explicit count
+# because GitHub-hosted ``ubuntu-latest`` on a private/internal repo is a
+# 2-vCPU VM where ``-n auto`` resolves to a single worker (verified in CI:
+# ``created: 1/1 worker``), giving no speedup. ``2`` fills both vCPUs.
+xdist_workers = 2
+# Number of GitHub matrix shards the suite is split across (pytest-split). The
+# suite is partitioned by test count into this many groups; per-shard coverage
+# is combined in a dependent job. Raising this shortens wall-clock at the cost
+# of more concurrent jobs (and Actions minutes).
+total_shards = 4
 # Repository variable name: when set to 1/true/yes/on, CI skips fail_under
 # enforcement (``--cov-fail-under=0`` + no ``coverage report --fail-under`` gate).
 relax_fail_under_repo_var = "COVERAGE_RELAX_FAIL_UNDER"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -293,6 +293,13 @@ markers = [
 #     consumed by the runtime, not import-level libraries
 [tool.coverage.run]
 branch = false
+# Record source paths relative to the repo root, not as absolute
+# ``/home/runner/work/...`` paths. Required for the sharded CI: each shard runs
+# on a separate GitHub runner and its ``.coverage.shard*`` is merged by a
+# dependent job via ``coverage combine``. Without this, differing absolute
+# checkout paths across runners would make combine treat the same file as
+# distinct entries, corrupting the merged totals. Harmless for local/serial use.
+relative_files = true
 source = [
     # tree-reform.MD P2.3: orchestrator moved under src/hyperloom. tree-reform.MD
     # P2.4: inference_optimizer moved under src/hyperloom too (both were

--- a/src/hyperloom/inference_optimizer/tests/test_ray_backend_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_ray_backend_unit.py
@@ -868,8 +868,15 @@ def test_gpu_specialist_lease_dead_actor_degrades(monkeypatch: pytest.MonkeyPatc
 
 
 # ── coverage: ServingGroupManager empty + exception branches ─────────────────
-def test_serving_group_manager_empty_before_start():
-    """A never-started SGM: ranks_alive=[] / is_alive False / stop no-op."""
+def test_serving_group_manager_empty_before_start(monkeypatch: pytest.MonkeyPatch):
+    """A never-started SGM: ranks_alive=[] / is_alive False / stop no-op.
+
+    ``close()`` does ``import ray`` before its (empty) rank loop, so a fake ray
+    is injected to keep the test self-contained: without it the test only passed
+    by accident when another test's ``sys.modules['ray']`` leaked into the same
+    process, which breaks under xdist where tests run in separate workers.
+    """
+    monkeypatch.setitem(sys.modules, "ray", _FakeRay())
     sgm = rs.ServingGroupManager(nodes=2, gpus_per_node=8)
     assert sgm.pids() == []
     assert sgm.ranks_alive() == []  # 892-893


### PR DESCRIPTION
## What

Make the coverage CI truly parallel (follow-up to #911, whose `-n auto` was a
no-op on the 2-vCPU runner). Three commits, CI-only:

1. **Sharded + xdist parallelism** — split the suite into `total_shards`
   GitHub jobs (pytest-split), each running `-n xdist_workers` (explicit, not
   `auto`). Per-shard partial coverage is uploaded and `coverage combine`-d in
   a dependent job; the 90% gate runs on the merged total (equivalent to a
   serial run). Also fixes a pre-existing order-dependent test
   (`test_serving_group_manager_empty_before_start`) exposed by xdist.
2. **Duration-balanced shards + pip cache** — shards restore a shared
   `.test_durations` (actions/cache, read-only) and split by `least_duration`;
   a `update-durations` job (push-to-main + all-green only) merges per-shard
   timing slices and saves them under a rolling cache key. Misses fall back to
   count-based splitting (correctness unaffected). pip cache on setup-python.
3. **relative_files** — record repo-relative coverage paths so cross-runner
   `coverage combine` is deterministic.

## Verified locally

- Shard partition exhaustive & disjoint (sum == total collected).
- xdist starts real workers (`created: 2/2 workers`).
- `coverage combine` total == single-run total (byte-identical), 90% gate holds.
- durations hit/miss paths, merge script, and `relative_files` path-relativity.

## This PR run validates (previously unverified in real CI)

- actions/cache rolling-key save + prefix restore
- cross-job artifacts and cross-runner combine under `relative_files`
- `update-durations` triggering only on push-to-main

## Scope

CI + one test isolation fix. No production `src/` behavior change.
