### PR TITLE
[FEAT] ray-phase2: put every serving/GPU-specialist path under the Ray `serving_slot` mutex + eval/JIT reliability fixes

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_framework_agent_executor.py
+++ b/src/hyperloom/inference_optimizer/tests/test_framework_agent_executor.py
@@ -959,6 +959,44 @@ async def test_bench_candidate_accuracy_gate_reads_accuracy_key(
 
 
 @pytest.mark.asyncio
+async def test_bench_candidate_holds_and_closes_serving_lease(tmp_path: Path):
+    """phase-3 §3.1: the candidate benchmark forwards a serving lease to
+    run_grid and closes it (so it serializes on the whole-machine serving_slot
+    instead of colliding with a concurrent GPU-specialist server)."""
+    from unittest.mock import MagicMock
+
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    config_path = tmp_path / "baseline.yaml"
+    config_path.write_text("benchmark: {}\n", encoding="utf-8")
+
+    executor = FrameworkAgentExecutor(session_dir=session_dir)
+    captured: dict[str, Any] = {}
+
+    async def fake_run_grid(*args, **kwargs):  # noqa: ARG001
+        captured["serving_lease"] = kwargs.get("serving_lease")
+        return [_mk_variant_result(tput=1100.0, status="succeeded")]
+
+    lease = MagicMock()
+    from hyperloom.orchestrator.actions.executors import framework_agent as fp_mod
+    from hyperloom.orchestrator.actions.executors import _ray_serving
+
+    with (
+        patch.object(fp_mod, "run_grid", new=fake_run_grid),
+        patch.object(fp_mod, "materialize_config_with_envs", return_value=config_path),
+        patch.object(_ray_serving, "maybe_serving_lease", return_value=lease),
+    ):
+        await executor._bench_candidate(
+            params={"config_path": str(config_path)},
+            output_root=tmp_path / "out",
+            slug="lease",
+        )
+
+    assert captured["serving_lease"] is lease
+    lease.close.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_bench_candidate_accuracy_gate_skipped_without_baseline(tmp_path: Path):
     """No positive accuracy_baseline -> gate is skipped (accuracy_pass None)."""
     session_dir = tmp_path / "session"

--- a/src/hyperloom/inference_optimizer/tests/test_integrate_patch_executor.py
+++ b/src/hyperloom/inference_optimizer/tests/test_integrate_patch_executor.py
@@ -959,3 +959,44 @@ def test_derive_lane_perf_explore():
 
     assert _derive_lane({}) == "perf_explore"
     assert _derive_lane({"specialist_task_id": "abc"}) == "perf_explore"
+
+
+@pytest.mark.asyncio
+async def test_bench_patch_holds_and_closes_serving_lease(tmp_path: Path):
+    """phase-3 §3.1: the patch benchmark forwards a serving lease to run_grid
+    and closes it, so it serializes on the whole-machine serving_slot instead
+    of colliding with a concurrent GPU-specialist server (the observed
+    ``reverted_smoke_fail`` root cause)."""
+    from unittest.mock import MagicMock, patch
+
+    from hyperloom.orchestrator.actions.executors import _ray_serving
+    from hyperloom.orchestrator.actions.executors import integrate_patch as ip_mod
+    from hyperloom.orchestrator.actions.executors._grid_runner import VariantResult
+
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    config_path = tmp_path / "baseline.yaml"
+    config_path.write_text("benchmark: {}\n", encoding="utf-8")
+
+    executor = IntegratePatchExecutor(session_dir=session_dir)
+    captured: dict[str, Any] = {}
+
+    async def fake_run_grid(*args, **kwargs):  # noqa: ARG001
+        captured["serving_lease"] = kwargs.get("serving_lease")
+        return [VariantResult(name="v", extra_server_args="", extra_envs={}, status="succeeded")]
+
+    lease = MagicMock()
+    with (
+        patch.object(ip_mod, "run_grid", new=fake_run_grid),
+        patch.object(ip_mod, "materialize_config_with_envs", return_value=config_path),
+        patch.object(_ray_serving, "maybe_serving_lease", return_value=lease),
+    ):
+        await executor._bench_patch(
+            params={"config_path": str(config_path)},
+            output_root=tmp_path / "out",
+            config_changes_applied={},
+            specialist_task_id="task-abcd1234",
+        )
+
+    assert captured["serving_lease"] is lease
+    lease.close.assert_called_once()

--- a/src/hyperloom/inference_optimizer/tests/test_magpie_patcher_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_magpie_patcher_unit.py
@@ -370,6 +370,22 @@ def test_eval_flag_stripped_from_inferencex_dir(tmp_path):
     assert mp._RUN_LM_EVAL_PARSER_SENTINEL in lib
 
 
+def test_eval_concurrency_fixes_idempotent(tmp_path):
+    """Regression: a 2nd pass must stay ok. The parser patch leaves a legit
+    ``--concurrent-requests`` case in benchmark_lib.sh; the flag-strip scan must
+    skip the library rather than mis-report it as an unrecognised shape."""
+    _make_inferencex(tmp_path)
+    assert mp._apply_eval_concurrency_fixes(None, tmp_path) is True
+    # Second pass: benchmark_lib.sh now carries the parser sentinel + flag.
+    assert mp._apply_eval_concurrency_fixes(None, tmp_path) is True
+    lib = (tmp_path / "benchmarks" / "benchmark_lib.sh").read_text(encoding="utf-8")
+    # The parser case survived (not stripped) and stayed idempotent.
+    assert lib.count("--concurrent-requests|--concurrent_requests") == 1
+    assert "--concurrent-requests" not in (
+        tmp_path / "benchmarks" / "vllm_mi355x.sh"
+    ).read_text(encoding="utf-8")
+
+
 def test_eval_fixes_run_when_benchmarker_missing(monkeypatch, tmp_path):
     """Regression: a missing/stale benchmarker.py must NOT skip the eval fixes.
 

--- a/src/hyperloom/inference_optimizer/tests/test_magpie_patcher_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_magpie_patcher_unit.py
@@ -287,3 +287,131 @@ def test_patch_status_remote_trust_fails(tmp_path):
 def test_ensure_wrapper(tmp_path):
     _make_magpie(tmp_path)
     assert mp.ensure_magpie_atomic_scripts_patch(tmp_path) is True
+
+
+# ---- eval-concurrency fixes (--concurrent-requests) -----------------------
+_VLLM_LEGACY = (
+    "#!/bin/bash\n"
+    'if [[ "$RUN_EVAL" = "true" ]]; then\n'
+    '        run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC || exit $?\n'
+    "fi\n"
+)
+
+_BENCHMARK_LIB_LEGACY = (
+    "#!/bin/bash\n"
+    "run_lm_eval() {\n"
+    '    local concurrent_requests="${EVAL_CONCURRENT_REQUESTS:-${CONC:-64}}"\n'
+    "    while [[ $# -gt 0 ]]; do\n"
+    "        case $1 in\n"
+    '            --port)           port="$2"; shift 2 ;;\n'
+    '            --top-p)          top_p="$2"; shift 2 ;;\n'
+    '            *)                echo "Unknown parameter: $1"; return 1 ;;\n'
+    "        esac\n"
+    "    done\n"
+    "}\n"
+)
+
+
+def _make_inferencex(
+    root: Path,
+    *,
+    vllm: str | None = _VLLM_LEGACY,
+    benchmark_lib: str | None = _BENCHMARK_LIB_LEGACY,
+) -> Path:
+    bench = root / "benchmarks"
+    bench.mkdir(parents=True, exist_ok=True)
+    if vllm is not None:
+        (bench / "vllm_mi355x.sh").write_text(vllm, encoding="utf-8")
+    if benchmark_lib is not None:
+        (bench / "benchmark_lib.sh").write_text(benchmark_lib, encoding="utf-8")
+    return root
+
+
+def test_resolve_inferencex_benchmarks_dir(monkeypatch, tmp_path):
+    _make_inferencex(tmp_path)
+    assert mp._resolve_inferencex_benchmarks_dir(tmp_path) == tmp_path / "benchmarks"
+    monkeypatch.setenv("INFERENCEX_PATH", str(tmp_path))
+    assert mp._resolve_inferencex_benchmarks_dir(None) == tmp_path / "benchmarks"
+    monkeypatch.delenv("INFERENCEX_PATH", raising=False)
+    assert mp._resolve_inferencex_benchmarks_dir(None) is None
+    assert mp._resolve_inferencex_benchmarks_dir(tmp_path / "nope") is None
+
+
+def test_resolve_inferencex_benchmark_lib(tmp_path):
+    _make_inferencex(tmp_path)
+    lib = mp._resolve_inferencex_benchmark_lib(tmp_path)
+    assert lib is not None and lib.name == "benchmark_lib.sh"
+    assert mp._resolve_inferencex_benchmark_lib(tmp_path / "nope") is None
+
+
+def test_run_lm_eval_arg_patch_applied(tmp_path):
+    _make_inferencex(tmp_path)
+    lib = tmp_path / "benchmarks" / "benchmark_lib.sh"
+    assert mp._apply_run_lm_eval_arg_patch_atomic(lib) is True
+    text = lib.read_text(encoding="utf-8")
+    assert "--concurrent-requests|--concurrent_requests" in text
+    assert mp._RUN_LM_EVAL_PARSER_SENTINEL in text
+    # Idempotent second call.
+    assert mp._apply_run_lm_eval_arg_patch_atomic(lib) is True
+
+
+def test_run_lm_eval_arg_patch_unrecognized(tmp_path):
+    lib = tmp_path / "benchmark_lib.sh"
+    lib.write_text("run_lm_eval() { : ; }\n", encoding="utf-8")
+    assert mp._apply_run_lm_eval_arg_patch_atomic(lib) is False
+
+
+def test_eval_flag_stripped_from_inferencex_dir(tmp_path):
+    _make_inferencex(tmp_path)
+    assert mp._apply_eval_concurrency_fixes(None, tmp_path) is True
+    vllm = (tmp_path / "benchmarks" / "vllm_mi355x.sh").read_text(encoding="utf-8")
+    assert "--concurrent-requests" not in vllm
+    lib = (tmp_path / "benchmarks" / "benchmark_lib.sh").read_text(encoding="utf-8")
+    assert mp._RUN_LM_EVAL_PARSER_SENTINEL in lib
+
+
+def test_eval_fixes_run_when_benchmarker_missing(monkeypatch, tmp_path):
+    """Regression: a missing/stale benchmarker.py must NOT skip the eval fixes.
+
+    Previously ``magpie_scripts_patch_status`` early-returned when
+    ``benchmarker.py`` was unresolved, leaving the fatal ``--concurrent-requests``
+    flag live in the InferenceX copies that actually execute.
+    """
+    ix = _make_inferencex(tmp_path / "ix")
+    monkeypatch.delenv("MAGPIE_PATH", raising=False)
+    monkeypatch.setenv("INFERENCEX_PATH", str(ix))
+    status = mp.magpie_scripts_patch_status(None, str(ix))
+    # Atomic patch is a no-op (no benchmarker.py) but the eval fixes ran.
+    assert status.atomic_reason == mp._ATOMIC_REASON_MISSING
+    assert status.eval_flag_ok is True
+    vllm = (ix / "benchmarks" / "vllm_mi355x.sh").read_text(encoding="utf-8")
+    assert "--concurrent-requests" not in vllm
+    lib = (ix / "benchmarks" / "benchmark_lib.sh").read_text(encoding="utf-8")
+    assert mp._RUN_LM_EVAL_PARSER_SENTINEL in lib
+
+
+def test_full_flow_covers_inferencex_and_ordering(tmp_path):
+    """Full status flow: atomic + remote-trust + eval strip across both dirs,
+    with the remote-trust patch on sglang running BEFORE the generic strip."""
+    magpie = _make_magpie(tmp_path / "magpie")
+    # Add a flagged generic vllm script to the Magpie scripts dir too.
+    (magpie / "Magpie" / "scripts" / "benchmark" / "vllm_mi355x.sh").write_text(
+        _VLLM_LEGACY, encoding="utf-8"
+    )
+    ix = _make_inferencex(tmp_path / "ix")
+    status = mp.magpie_scripts_patch_status(str(magpie), str(ix))
+    assert status.atomic_ok is True
+    assert status.remote_trust_ok is True  # sglang patched before strip removed its flag
+    assert status.eval_flag_ok is True
+    assert status.ok is True
+    # sglang got the remote-trust rewrite (no bare flag left).
+    sglang = (magpie / "Magpie" / "scripts" / "benchmark" / "sglang_mi300x.sh").read_text(encoding="utf-8")
+    assert "MAGPIE_TRUST_REMOTE_CODE" in sglang
+    assert "--concurrent-requests" not in sglang
+    # Both Magpie's and InferenceX's generic vllm scripts were stripped.
+    assert "--concurrent-requests" not in (
+        magpie / "Magpie" / "scripts" / "benchmark" / "vllm_mi355x.sh"
+    ).read_text(encoding="utf-8")
+    assert "--concurrent-requests" not in (
+        ix / "benchmarks" / "vllm_mi355x.sh"
+    ).read_text(encoding="utf-8")

--- a/src/hyperloom/inference_optimizer/tests/test_ray_backend_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_ray_backend_unit.py
@@ -576,6 +576,45 @@ def test_ray_gpu_pending_limit_default_and_override(monkeypatch: pytest.MonkeyPa
     assert rb.ray_gpu_pending_limit() == 4  # falls back on garbage
 
 
+def test_ray_serving_priority_enabled_default_and_off(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("INFERENCE_OPTIMIZER_RAY_SERVING_PRIORITY", raising=False)
+    assert rb.ray_serving_priority_enabled() is True  # default on
+    for off in ("0", "false", "no", "off"):
+        monkeypatch.setenv("INFERENCE_OPTIMIZER_RAY_SERVING_PRIORITY", off)
+        assert rb.ray_serving_priority_enabled() is False
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_RAY_SERVING_PRIORITY", "1")
+    assert rb.ray_serving_priority_enabled() is True
+
+
+def test_serving_slot_busy_off_ray_path_is_false(monkeypatch: pytest.MonkeyPatch):
+    """Off the single-node Ray path (pytest default), serving_slot_busy never
+    probes Ray and returns False (no serving-priority pause)."""
+    monkeypatch.delenv("INFERENCE_OPTIMIZER_RAY_EXEC", raising=False)
+    assert rb.serving_slot_busy() is False
+
+
+def test_serving_slot_busy_reads_available_resources(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Under Ray, serving_slot_busy is True iff available serving_slot < 1."""
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_RAY_EXEC", "1")
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_NODES", "1")
+    monkeypatch.setenv("MULTI_NODE_STATE_FILE", str(tmp_path / "nope.json"))
+
+    class _FakeRayAvail:
+        def __init__(self, slot_avail: float):
+            self._slot = slot_avail
+
+        def is_initialized(self) -> bool:
+            return True
+
+        def available_resources(self) -> dict:
+            return {"GPU": 0.0, "serving_slot": self._slot}
+
+    monkeypatch.setitem(sys.modules, "ray", _FakeRayAvail(0.0))
+    assert rb.serving_slot_busy() is True  # slot held -> serving active
+    monkeypatch.setitem(sys.modules, "ray", _FakeRayAvail(1.0))
+    assert rb.serving_slot_busy() is False  # slot free -> no pause
+
+
 def test_ray_gpu_specialist_exec_enabled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     monkeypatch.setenv("INFERENCE_OPTIMIZER_NODES", "1")
     monkeypatch.setenv("MULTI_NODE_STATE_FILE", str(tmp_path / "nope.json"))

--- a/src/hyperloom/inference_optimizer/tests/test_ray_backend_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_ray_backend_unit.py
@@ -565,11 +565,72 @@ def test_gpu_specialist_lease_lifecycle(monkeypatch: pytest.MonkeyPatch):
     lease.close()  # idempotent
 
 
+def test_ray_gpu_pending_limit_default_and_override(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("INFERENCE_OPTIMIZER_RAY_GPU_PENDING_LIMIT", raising=False)
+    assert rb.ray_gpu_pending_limit() == 4
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_RAY_GPU_PENDING_LIMIT", "8")
+    assert rb.ray_gpu_pending_limit() == 8
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_RAY_GPU_PENDING_LIMIT", "0")
+    assert rb.ray_gpu_pending_limit() == 1  # floored at 1
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_RAY_GPU_PENDING_LIMIT", "junk")
+    assert rb.ray_gpu_pending_limit() == 4  # falls back on garbage
+
+
+def test_ray_gpu_specialist_exec_enabled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_NODES", "1")
+    monkeypatch.setenv("MULTI_NODE_STATE_FILE", str(tmp_path / "nope.json"))
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_RAY_EXEC", "1")
+    assert rb.ray_gpu_specialist_exec_enabled() is True
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_RAY_EXEC", "0")
+    assert rb.ray_gpu_specialist_exec_enabled() is False
+    # multi-node -> off even with RAY_EXEC=1
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_RAY_EXEC", "1")
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_NODES", "2")
+    assert rb.ray_gpu_specialist_exec_enabled() is False
+
+
 def test_gpu_specialist_lease_is_alive_false_before_start():
     lease = rs.GpuSpecialistLease(num_gpus=1)
     assert lease.is_alive() is False
     assert lease.exit_code() is None
     lease.close()  # no-op, no actor
+
+
+def test_gpu_specialist_lease_start_async_poll_and_pending(monkeypatch: pytest.MonkeyPatch):
+    """§3.3 non-blocking start: start_async submits without blocking; poll_started
+    returns None while pending (ray.wait empty) and the pid once ready;
+    pending_seconds is > 0 while pending and 0 after the pid is obtained."""
+
+    class _FakeRayWait(_FakeRayP2):
+        def __init__(self):
+            super().__init__()
+            self.ready = False
+
+        def wait(self, refs, num_returns=1, timeout=None):
+            return (list(refs), []) if self.ready else ([], list(refs))
+
+    fake = _FakeRayWait()
+    monkeypatch.setitem(sys.modules, "ray", fake)
+    actor = _FakeGpuActor()
+    monkeypatch.setattr(rs, "make_gpu_specialist_actor", lambda n, *, serving_slot=False: actor)
+    monkeypatch.setattr(rb, "get_ray_backend", lambda: _StubBackendP2())
+
+    lease = rs.GpuSpecialistLease(num_gpus=2)
+    lease.start_async(["claude"], env={"A": "1"}, cwd="/tmp", log_path="/tmp/p.log")
+
+    # Pending: no pid yet, positive pending time, remote call submitted (ref
+    # stored) without blocking on a result.
+    assert lease._start_ref is not None
+    assert lease.poll_started() is None
+    assert lease.pid() is None
+    assert lease.pending_seconds() >= 0.0
+
+    # Scheduled: wait reports ready -> pid resolves, pending resets to 0.
+    fake.ready = True
+    assert lease.poll_started() == 4242
+    assert lease.pid() == 4242
+    assert lease.pending_seconds() == 0.0
+    lease.close()
 
 
 def test_maybe_gpu_specialist_lease_pytest_default_none(monkeypatch: pytest.MonkeyPatch):

--- a/src/hyperloom/inference_optimizer/tests/test_resource_lanes.py
+++ b/src/hyperloom/inference_optimizer/tests/test_resource_lanes.py
@@ -257,6 +257,42 @@ async def test_specialist_gpu_pool_allocates_and_releases(conn):
 
 
 @pytest.mark.asyncio
+async def test_ray_observation_admits_up_to_pending_limit(conn):
+    """§3.2: under single-node Ray, admission is COUNT-based (pending limit),
+    not physical-capacity-based — so multiple specialists queue on ONE GPU."""
+    # A single physical GPU: the legacy try_acquire caps at 1 concurrent...
+    pool = SpecialistGpuPool(conn, gpu_ids=[0])
+    a = await pool.try_acquire_ray_observation(
+        holder_id="h-a", task_id="t-a", pending_limit=3, ttl_sec=60
+    )
+    b = await pool.try_acquire_ray_observation(
+        holder_id="h-b", task_id="t-b", pending_limit=3, ttl_sec=60
+    )
+    c = await pool.try_acquire_ray_observation(
+        holder_id="h-c", task_id="t-c", pending_limit=3, ttl_sec=60
+    )
+    # ...but the Ray observation ledger admits up to pending_limit (3) at once,
+    # each on a distinct synthetic slot id above the real device id space.
+    assert a is not None and b is not None and c is not None
+    slots = sorted(list(a.gpu_ids) + list(b.gpu_ids) + list(c.gpu_ids))
+    assert slots == [100000, 100001, 100002]
+    # Over the limit -> backpressure (None; caller keeps the task queued).
+    d = await pool.try_acquire_ray_observation(
+        holder_id="h-d", task_id="t-d", pending_limit=3, ttl_sec=60
+    )
+    assert d is None
+    # Releasing frees a slot for the next admission (reuses the low slot).
+    await pool.release(a)
+    e = await pool.try_acquire_ray_observation(
+        holder_id="h-e", task_id="t-e", pending_limit=3, ttl_sec=60
+    )
+    assert e is not None and list(e.gpu_ids) == [100000]
+    await pool.release(b)
+    await pool.release(c)
+    await pool.release(e)
+
+
+@pytest.mark.asyncio
 async def test_specialist_gpu_pool_rejects_oversized_request(conn):
     pool = SpecialistGpuPool(conn, gpu_ids=[0])
     assert (

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_dispatch_params.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_dispatch_params.py
@@ -32,7 +32,9 @@ from hyperloom.orchestrator.specialists.profile import (
     SCOPE_DOMAIN,
     SCOPE_FREEFORM,
     SpecialistProfile,
+    holds_serving_slot,
     resolve_specialist_profile,
+    uses_whole_machine_gpu_lane,
 )
 
 
@@ -106,6 +108,24 @@ def test_bench_falsy_values(falsy):
     prof = resolve_specialist_profile({"mode": "patch", "bench": falsy})
     assert prof.bench is False
     assert prof.reserves_benchmark_lane is False
+
+
+def test_holds_serving_slot_only_for_bench_capable():
+    """phase-3 §4 / invariant §6.3: only bench-capable patch specialists hold
+    the whole-machine serving_slot; authoring-only (incl. framework authoring)
+    holds num_gpus only so it can share the GPU queue."""
+    # Bench-capable patch specialist -> holds the slot.
+    assert holds_serving_slot({"mode": "patch", "bench": True}) is True
+    # Framework authoring is NOT bench-capable by default -> no slot, but it
+    # still draws from the whole-machine pool (uses_whole_machine_gpu_lane).
+    fw = {"framework_agent_authoring": True, "domain": "serving_specialist"}
+    assert holds_serving_slot(fw) is False
+    assert uses_whole_machine_gpu_lane(fw) is True
+    # A bench-capable framework specialist DOES hold the slot for that window.
+    assert holds_serving_slot({"framework_agent_authoring": True, "mode": "patch", "bench": True}) is True
+    # Plain research / non-bench GPU probe -> no slot.
+    assert holds_serving_slot({"mode": "research"}) is False
+    assert holds_serving_slot(None) is False
 
 
 def test_bench_is_meaningless_for_research_mode():

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_subprocess.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_subprocess.py
@@ -759,14 +759,28 @@ class _FakeGpuSpecialistLease:
         self.alive = True
         self.stopped = False
 
-    def start(self, cmd, *, env=None, cwd=None, log_path=None) -> int:
+    def start_async(self, cmd, *, env=None, cwd=None, log_path=None) -> None:
+        # §3.3 non-blocking start: record + stage the done file, mark the pid
+        # ready so poll_started() returns immediately on the next tick.
         self.started = {"cmd": cmd, "cwd": cwd, "log_path": log_path}
         self.env = dict(env or {})
         Path(log_path).write_text("stream-json log line\n", encoding="utf-8")
         # Graceful done — the reaper harvests this and exits.
         (self._workspace / "specialist_done.json").write_text(json.dumps({"proposal_set": []}), encoding="utf-8")
         self.alive = False
-        return 9999
+        self._pid = 9999
+
+    def poll_started(self) -> int | None:
+        return getattr(self, "_pid", None)
+
+    def pending_seconds(self) -> float:
+        return 0.0
+
+    def start(self, cmd, *, env=None, cwd=None, log_path=None) -> int:
+        self.start_async(cmd, env=env, cwd=cwd, log_path=log_path)
+        pid = self.poll_started()
+        assert pid is not None
+        return pid
 
     def is_alive(self) -> bool:
         return self.alive
@@ -776,6 +790,9 @@ class _FakeGpuSpecialistLease:
 
     def stop(self) -> None:
         self.stopped = True
+        self.alive = False
+
+    def close(self) -> None:
         self.alive = False
 
 

--- a/src/hyperloom/orchestrator/actions/executors/_grid_runner.py
+++ b/src/hyperloom/orchestrator/actions/executors/_grid_runner.py
@@ -897,6 +897,29 @@ async def run_grid(
     auto_warmup_requested = bool(warmup_before_measure and server_lifecycle is None)
     results: list[VariantResult] = []
 
+    # Reap orphaned aiter JIT build locks before booting any server. A prior GPU
+    # process killed mid-``hipcc`` (e.g. an OOM'd co-scheduled server, or a
+    # specialist reaped mid-compile) leaves a zero-byte ``FileBaton`` lock, and
+    # aiter's ``FileBaton.wait()`` spins forever with no timeout — hanging every
+    # later cold server boot (observed as repeated conc_sweep boot timeouts).
+    # ``baseline.py`` sweeps on its own cold path; this covers the grid serving
+    # paths (explore / sweep / conc_sweep / integrate_patch / framework bench).
+    # Gated on no live compiler so a genuine in-flight build is never disturbed.
+    try:
+        from ._aiter_jit import sweep_stale_aiter_locks_if_dead
+
+        _lock_sweep = sweep_stale_aiter_locks_if_dead()
+        if _lock_sweep.get("deleted"):
+            log.warning(
+                "grid_runner: reaped %d orphaned aiter JIT lock(s) under %s "
+                "before server launch (compiler_alive=%s)",
+                _lock_sweep.get("deleted"),
+                _lock_sweep.get("dir"),
+                _lock_sweep.get("compiler_alive"),
+            )
+    except Exception as exc:  # noqa: BLE001 — best-effort hygiene, never blocks the grid
+        log.debug("grid_runner: aiter lock sweep swallowed: %r", exc)
+
     # Variant-boundary robustness pulse: a bounded tick after every variant so
     # a mid-grid leak/crash surfaces between variants. Best-effort.
     async def _pulse_after_variant(idx: int) -> None:

--- a/src/hyperloom/orchestrator/actions/executors/_magpie_patcher.py
+++ b/src/hyperloom/orchestrator/actions/executors/_magpie_patcher.py
@@ -118,6 +118,27 @@ _REMOTE_DIRECT_PATCHED_BLOCK = (
 _EVAL_CONCURRENCY_FLAG_MARKER = "--concurrent-requests"
 _EVAL_CONCURRENCY_FLAG_RE = re.compile(r"\s*--concurrent-requests\s+(?:\"\$CONC\"|\$\{CONC\}|\$CONC)")
 
+# Belt-and-suspenders for the run-time re-copy: Magpie's
+# ``_prepare_benchmark_scripts`` re-copies its (possibly still-flagged) generic
+# scripts into ``$INFERENCEX_PATH/benchmarks`` on every run, so a stray
+# ``--concurrent-requests`` can survive the strip. Teach InferenceX's
+# ``benchmark_lib.sh::run_lm_eval`` arg-parser to accept the flag (it already
+# owns a ``concurrent_requests`` local, wired into ``num_concurrent=``); this
+# turns a fatal ``Unknown parameter`` abort into a no-op. Idempotent via the
+# sentinel comment.
+_RUN_LM_EVAL_PARSER_SENTINEL = "HYPERLOOM_EVAL_CONCURRENCY_ARG"
+_RUN_LM_EVAL_PARSER_LEGACY_BLOCK = (
+    '            --top-p)          top_p="$2"; shift 2 ;;\n'
+    '            *)                echo "Unknown parameter: $1"; return 1 ;;\n'
+)
+_RUN_LM_EVAL_PARSER_PATCHED_BLOCK = (
+    '            --top-p)          top_p="$2"; shift 2 ;;\n'
+    "            # HYPERLOOM_EVAL_CONCURRENCY_ARG: accept the redundant flag\n"
+    "            # (concurrency also flows via EVAL_CONCURRENT_REQUESTS/CONC).\n"
+    '            --concurrent-requests|--concurrent_requests) concurrent_requests="$2"; shift 2 ;;\n'
+    '            *)                echo "Unknown parameter: $1"; return 1 ;;\n'
+)
+
 # InferenceX benchmark_lib.sh::run_lm_eval reads concurrency from env
 # (EVAL_CONCURRENT_REQUESTS, fallback CONC). Passing --concurrent-requests to
 # run_eval is rejected as an unknown argument.
@@ -224,6 +245,58 @@ def _resolve_benchmark_scripts_dir(
     return candidate if candidate.is_dir() else None
 
 
+def _resolve_inferencex_benchmarks_dir(
+    inferencex_dir: Path | str | None,
+) -> Path | None:
+    """Resolve InferenceX's ``benchmarks`` directory when present.
+
+    Magpie's ``_prepare_benchmark_scripts`` copies its generic ``*.sh`` scripts
+    INTO ``$INFERENCEX_PATH/benchmarks`` at run time, and those copies are what
+    actually execute (they source InferenceX's ``benchmark_lib.sh``). The
+    redundant ``--concurrent-requests`` eval flag therefore also has to be
+    scrubbed here, not just in the Magpie source dir.
+
+    Args:
+        inferencex_dir: InferenceX root override; falls back to
+            ``$INFERENCEX_PATH`` when falsy.
+
+    Returns:
+        The resolved ``benchmarks`` directory, or ``None`` when unconfigured or
+        absent on disk.
+    """
+    root: Path | None = None
+    if inferencex_dir:
+        root = Path(inferencex_dir)
+    else:
+        env = (os.environ.get("INFERENCEX_PATH") or "").strip()
+        if env:
+            root = Path(env)
+    if root is None:
+        return None
+    candidate = root / "benchmarks"
+    return candidate if candidate.is_dir() else None
+
+
+def _resolve_inferencex_benchmark_lib(
+    inferencex_dir: Path | str | None,
+) -> Path | None:
+    """Resolve InferenceX's ``benchmarks/benchmark_lib.sh`` when present.
+
+    Args:
+        inferencex_dir: InferenceX root override; falls back to
+            ``$INFERENCEX_PATH`` when falsy.
+
+    Returns:
+        The resolved ``benchmark_lib.sh`` path, or ``None`` when unconfigured
+        or absent on disk.
+    """
+    scripts_dir = _resolve_inferencex_benchmarks_dir(inferencex_dir)
+    if scripts_dir is None:
+        return None
+    candidate = scripts_dir / "benchmark_lib.sh"
+    return candidate if candidate.is_file() else None
+
+
 def _strip_eval_concurrency_flag(text: str) -> str | None:
     """Return ``text`` with the redundant ``--concurrent-requests <CONC>`` flag
     removed, or ``None`` when nothing needed changing.
@@ -296,6 +369,106 @@ def _apply_eval_flag_patch_atomic(scripts_dir: Path) -> bool:
             _EVAL_CONCURRENCY_FLAG_MARKER,
             script,
         )
+    return ok
+
+
+def _apply_run_lm_eval_arg_patch_atomic(benchmark_lib: Path) -> bool:
+    """Teach InferenceX's ``benchmark_lib.sh::run_lm_eval`` to accept the
+    ``--concurrent-requests`` flag instead of aborting on ``Unknown parameter``.
+
+    Defence-in-depth for the run-time re-copy: even when the strip above misses
+    a script (wrong ``MAGPIE_PATH`` at strip time, or Magpie re-copies an
+    unstripped source over a stripped ``benchmarks`` copy), the parser now
+    tolerates the flag. Idempotent via the sentinel; a genuinely-unrecognised
+    parser shape returns ``False`` so the caller can warn.
+
+    Args:
+        benchmark_lib: The InferenceX ``benchmark_lib.sh`` file to patch.
+
+    Returns:
+        ``True`` when the parser already tolerates the flag or was patched to,
+        ``False`` when the expected parser block was not found or an IO step
+        failed.
+    """
+    try:
+        original = benchmark_lib.read_text(encoding="utf-8")
+    except OSError as e:
+        log.warning("_magpie_patcher: cannot read %s: %s", benchmark_lib, e)
+        return False
+
+    # Already tolerant (our sentinel, or an upstream that added the flag).
+    if _RUN_LM_EVAL_PARSER_SENTINEL in original or _EVAL_CONCURRENCY_FLAG_MARKER in original:
+        return True
+
+    if _RUN_LM_EVAL_PARSER_LEGACY_BLOCK not in original:
+        log.warning(
+            "_magpie_patcher: run_lm_eval arg-parser block not found in %s; "
+            "cannot make it tolerate '--concurrent-requests'. RUN_EVAL=true "
+            "baselines may still abort if a stray flag survives the strip.",
+            benchmark_lib,
+        )
+        return False
+
+    patched = original.replace(
+        _RUN_LM_EVAL_PARSER_LEGACY_BLOCK,
+        _RUN_LM_EVAL_PARSER_PATCHED_BLOCK,
+        1,
+    )
+    if patched == original:
+        return False
+
+    if not atomic_write_text(
+        benchmark_lib,
+        patched,
+        tmp_prefix=".benchmark_lib.sh.hyperloom_",
+        log_prefix="_magpie_patcher",
+    ):
+        return False
+
+    log.info(
+        "_magpie_patcher: patched %s run_lm_eval to accept '--concurrent-requests'",
+        benchmark_lib,
+    )
+    return True
+
+
+def _apply_eval_concurrency_fixes(
+    magpie_dir: Path | str | None,
+    inferencex_dir: Path | str | None,
+) -> bool:
+    """Apply every eval-concurrency compatibility fix, independent of the
+    ``benchmarker.py`` atomic-copy patch.
+
+    Scrubs the redundant ``--concurrent-requests`` flag from the Magpie source
+    scripts dir AND the InferenceX ``benchmarks`` dir (where Magpie copies them
+    to execute), then makes InferenceX's ``run_lm_eval`` tolerant of the flag as
+    a belt for the run-time re-copy. Missing dirs / files are treated as
+    not-applicable (no failure).
+
+    Args:
+        magpie_dir: Magpie root override; falls back to ``$MAGPIE_PATH``.
+        inferencex_dir: InferenceX root override; falls back to
+            ``$INFERENCEX_PATH``.
+
+    Returns:
+        ``True`` when every resolved target is clean / successfully patched,
+        ``False`` when a target was found in an unrecognised shape or an IO step
+        failed.
+    """
+    ok = True
+    scanned: set[Path] = set()
+    for scripts_dir in (
+        _resolve_benchmark_scripts_dir(magpie_dir),
+        _resolve_inferencex_benchmarks_dir(inferencex_dir),
+    ):
+        if scripts_dir is None or scripts_dir in scanned:
+            continue
+        scanned.add(scripts_dir)
+        if not _apply_eval_flag_patch_atomic(scripts_dir):
+            ok = False
+    benchmark_lib = _resolve_inferencex_benchmark_lib(inferencex_dir)
+    if benchmark_lib is not None and not _apply_run_lm_eval_arg_patch_atomic(benchmark_lib):
+        ok = False
     return ok
 
 
@@ -631,36 +804,57 @@ class MagpiePatchStatus:
 
 def magpie_scripts_patch_status(
     magpie_dir: Path | str | None = None,
+    inferencex_dir: Path | str | None = None,
 ) -> MagpiePatchStatus:
     """Return independent status for atomic-copy and remote-trust patches.
 
     Keeps a drift in the optional SGLang remote-client trust patch from being
     reported as a generic atomic-copy failure.
 
+    The eval-concurrency fixes (strip the redundant ``--concurrent-requests``
+    flag from the Magpie + InferenceX benchmark scripts, and make InferenceX's
+    ``run_lm_eval`` tolerant of it) are applied **independently** of the
+    ``benchmarker.py`` atomic-copy patch: a missing / stale ``benchmarker.py``
+    used to early-return and silently skip them, so an unresolved ``MAGPIE_PATH``
+    left the fatal flag live in the InferenceX copies that actually execute.
+
     Args:
         magpie_dir: Magpie root override; falls back to ``$MAGPIE_PATH`` when
             falsy.
+        inferencex_dir: InferenceX root override; falls back to
+            ``$INFERENCEX_PATH`` when falsy.
 
     Returns:
         A ``MagpiePatchStatus`` carrying the atomic-copy and remote-trust
         outcomes plus the classified ``atomic_reason``.
     """
     src = _resolve_benchmarker_path(magpie_dir)
-    if src is None:
-        log.info(
-            "_magpie_patcher: MAGPIE_PATH unset or benchmarker.py missing — skipping patch (fine for tests / dry-runs)",
-        )
-        # remote_trust_ok / eval_flag_ok True here mean "not applicable" (no
-        # Magpie tree to inspect); atomic_ok=False + reason=missing is fail-soft
-        # (install.sh warns, does not abort) and is NOT a genuine failure.
-        return MagpiePatchStatus(
-            atomic_ok=False,
-            remote_trust_ok=True,
-            atomic_reason=_ATOMIC_REASON_MISSING,
-            eval_flag_ok=True,
-        )
 
     with _file_lock(_LOCK_PATH):
+        if src is None:
+            # Eval-concurrency fixes run REGARDLESS of benchmarker.py resolution:
+            # the fatal --concurrent-requests flag lives in the generic *.sh
+            # scripts (Magpie source + the InferenceX/benchmarks copies that
+            # actually execute), not in benchmarker.py. A missing / stale
+            # benchmarker.py must NOT silently skip them.
+            eval_flag_ok = _apply_eval_concurrency_fixes(magpie_dir, inferencex_dir)
+            log.info(
+                "_magpie_patcher: MAGPIE_PATH unset or benchmarker.py missing — "
+                "skipping atomic-copy patch (fine for tests / dry-runs); "
+                "eval-concurrency fixes still applied where scripts were found "
+                "(eval_flag_ok=%s)",
+                eval_flag_ok,
+            )
+            # remote_trust_ok True here means "not applicable" (no Magpie tree to
+            # inspect); atomic_ok=False + reason=missing is fail-soft (install.sh
+            # warns, does not abort) and is NOT a genuine failure.
+            return MagpiePatchStatus(
+                atomic_ok=False,
+                remote_trust_ok=True,
+                atomic_reason=_ATOMIC_REASON_MISSING,
+                eval_flag_ok=eval_flag_ok,
+            )
+
         atomic_reason = _apply_patch_atomic_reason(src)
         atomic_ok = atomic_reason not in _ATOMIC_REASONS_GENUINE_FAILURE
         sglang_script = _resolve_sglang_mi300x_script_path(magpie_dir)
@@ -679,12 +873,10 @@ def magpie_scripts_patch_status(
                 "MAGPIE_TRUST_REMOTE_CODE=1 will not reach remote "
                 "benchmark_serving.py for custom-code models",
             )
-        scripts_dir = _resolve_benchmark_scripts_dir(magpie_dir)
-        if scripts_dir is None:
-            # No scripts/benchmark dir: nothing to scrub (not-applicable).
-            eval_flag_ok = True
-        else:
-            eval_flag_ok = _apply_eval_flag_patch_atomic(scripts_dir)
+        # Eval-concurrency fixes run LAST so the remote-trust patch on
+        # sglang_mi300x.sh still finds its (flagged) legacy run_eval block
+        # before the generic strip removes the flag from it.
+        eval_flag_ok = _apply_eval_concurrency_fixes(magpie_dir, inferencex_dir)
         return MagpiePatchStatus(
             atomic_ok=atomic_ok,
             remote_trust_ok=remote_trust_ok,

--- a/src/hyperloom/orchestrator/actions/executors/_magpie_patcher.py
+++ b/src/hyperloom/orchestrator/actions/executors/_magpie_patcher.py
@@ -336,6 +336,13 @@ def _apply_eval_flag_patch_atomic(scripts_dir: Path) -> bool:
     """
     ok = True
     for script in sorted(scripts_dir.glob("*.sh")):
+        # ``benchmark_lib.sh`` is the shared library, not a caller script: it
+        # legitimately references ``--concurrent-requests`` in run_lm_eval's arg
+        # parser (patched separately by _apply_run_lm_eval_arg_patch_atomic).
+        # Stripping there would corrupt the parser and the regex miss would be
+        # mis-reported as an "unrecognised shape" failure — skip it.
+        if script.name == "benchmark_lib.sh":
+            continue
         try:
             original = script.read_text(encoding="utf-8")
         except OSError as e:

--- a/src/hyperloom/orchestrator/actions/executors/_ray_backend.py
+++ b/src/hyperloom/orchestrator/actions/executors/_ray_backend.py
@@ -61,6 +61,44 @@ def _should_use_ray_backend() -> bool:
     return not is_multi_node()
 
 
+def ray_gpu_specialist_exec_enabled() -> bool:
+    """Whether ``needs_gpu`` specialists route through the Ray backend.
+
+    Mirrors the gate inside
+    :func:`hyperloom.orchestrator.actions.executors._ray_serving.maybe_gpu_specialist_lease`
+    (single-node + ``INFERENCE_OPTIMIZER_RAY_EXEC`` on + not the pytest default)
+    so the dispatcher can pick the Ray admission path (§3.2 count-based pending
+    limit, physical mutex owned by Ray ``num_gpus``) over the legacy SQLite
+    physical-capacity hard gate. Multi-node / RAY_EXEC off / pytest keep the
+    legacy SQLite pool.
+
+    Returns:
+        ``True`` when GPU specialists run through Ray on this (single) node.
+    """
+    from ._multi_node_env import is_multi_node
+
+    return _should_use_ray_backend() and not is_multi_node()
+
+
+def ray_gpu_pending_limit() -> int:
+    """Max in-flight (pending + running) GPU specialists admitted to Ray at once.
+
+    Backpressure so a burst of GPU specialists cannot flood the single-node Ray
+    queue and starve serving (§3.2 / invariant §6.5). Ray still runs only as
+    many as fit ``num_gpus`` concurrently; this bounds how many may be *queued*.
+    Override via ``INFERENCE_OPTIMIZER_RAY_GPU_PENDING_LIMIT`` (default 4,
+    floored at 1).
+
+    Returns:
+        The pending-admission ceiling (>= 1).
+    """
+    try:
+        v = int(os.environ.get("INFERENCE_OPTIMIZER_RAY_GPU_PENDING_LIMIT", "4"))
+    except (TypeError, ValueError):
+        return 4
+    return max(1, v)
+
+
 @dataclass
 class SubprocessResult:
     """Result of a subprocess executed inside a Ray worker.

--- a/src/hyperloom/orchestrator/actions/executors/_ray_backend.py
+++ b/src/hyperloom/orchestrator/actions/executors/_ray_backend.py
@@ -99,6 +99,46 @@ def ray_gpu_pending_limit() -> int:
     return max(1, v)
 
 
+def ray_serving_priority_enabled() -> bool:
+    """Whether serving is prioritized over GPU research specialists (§3.4).
+
+    When on (the default), the dispatcher pauses admitting NEW GPU research
+    specialists while serving currently holds the whole-machine slot, so a
+    research pile-up cannot starve serving. Disable with
+    ``INFERENCE_OPTIMIZER_RAY_SERVING_PRIORITY=0``.
+
+    Returns:
+        ``True`` unless the env var explicitly disables it.
+    """
+    val = os.environ.get("INFERENCE_OPTIMIZER_RAY_SERVING_PRIORITY", "").strip().lower()
+    return val not in {"0", "false", "no", "off"}
+
+
+def serving_slot_busy() -> bool:
+    """Best-effort check: is Ray's whole-machine ``serving_slot`` currently held?
+
+    ``True`` when a serving benchmark (or a bench-capable specialist) currently
+    holds the slot — i.e. serving is active. Used by the §3.4 serving-priority
+    gate to defer new GPU research specialists. Any error (Ray not initialised,
+    resource absent, probe failure) returns ``False`` so it NEVER blocks
+    dispatch, and it is a no-op off the single-node Ray path.
+
+    Returns:
+        ``True`` only when Ray reports ``serving_slot`` availability below 1.
+    """
+    if not ray_gpu_specialist_exec_enabled():
+        return False
+    try:
+        import ray  # noqa: PLC0415
+
+        if not ray.is_initialized():
+            return False
+        avail = ray.available_resources()
+        return float(avail.get("serving_slot", 1.0)) < 1.0
+    except Exception:  # noqa: BLE001 — best-effort; never block dispatch
+        return False
+
+
 @dataclass
 class SubprocessResult:
     """Result of a subprocess executed inside a Ray worker.

--- a/src/hyperloom/orchestrator/actions/executors/_ray_serving.py
+++ b/src/hyperloom/orchestrator/actions/executors/_ray_serving.py
@@ -8,6 +8,7 @@ import logging
 import os
 import signal
 import subprocess
+import time
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -482,6 +483,12 @@ class GpuSpecialistLease:
         self._ensure_log_path = ensure_log_path
         self._actor: Any = None
         self._pid: int | None = None
+        # §3.3 non-blocking start: the pending ObjectRef for the actor's
+        # ``start`` remote call, and the monotonic clock at submit time so the
+        # caller can measure Ray *pending* time separately from the subprocess's
+        # *running* wall budget.
+        self._start_ref: Any = None
+        self._pending_started_monotonic: float | None = None
 
     def start(
         self,
@@ -493,26 +500,24 @@ class GpuSpecialistLease:
     ) -> int:
         """Ensure the cluster, create the actor, launch the subprocess; return its pid.
 
-        Raises :exc:`RayInfeasibleError` for unschedulable resource requests or
-        :exc:`RaySchedTimeoutError` if the actor does not schedule within
-        :data:`_RAY_SPECIALIST_SCHED_TIMEOUT_SEC`.
+        Blocking convenience wrapper around :meth:`start_async` +
+        :meth:`poll_started` kept for callers / tests that want the legacy
+        synchronous contract. Raises :exc:`RayInfeasibleError` for unschedulable
+        resource requests or :exc:`RaySchedTimeoutError` if the actor does not
+        schedule within :data:`_RAY_SPECIALIST_SCHED_TIMEOUT_SEC`.
+
+        Prefer :meth:`start_async` + :meth:`poll_started` on the hot dispatch
+        path so Ray pending time neither blocks the event loop nor counts
+        against the specialist's wall budget (§3.3).
         """
         import ray  # noqa: PLC0415
 
-        from ._ray_backend import get_ray_backend  # noqa: PLC0415
-
-        get_ray_backend().ensure(log_path=self._ensure_log_path)
-        _assert_cluster_feasible(num_gpus=self._num_gpus, serving_slot=self._serving_slot)
-        self._actor = make_gpu_specialist_actor(
-            self._num_gpus, serving_slot=self._serving_slot
-        )
+        self.start_async(cmd, env=env, cwd=cwd, log_path=log_path)
         try:
             self._pid = int(
-                ray.get(
-                    self._actor.start.remote(cmd, env=env, cwd=cwd, log_path=log_path),
-                    timeout=_RAY_SPECIALIST_SCHED_TIMEOUT_SEC,
-                )
+                ray.get(self._start_ref, timeout=_RAY_SPECIALIST_SCHED_TIMEOUT_SEC)
             )
+            self._start_ref = None
         except ray.exceptions.GetTimeoutError as exc:
             self.close()
             raise RaySchedTimeoutError(
@@ -521,6 +526,66 @@ class GpuSpecialistLease:
                 "cluster may be fully occupied"
             ) from exc
         return self._pid
+
+    def start_async(
+        self,
+        cmd: list[str],
+        *,
+        env: dict[str, str] | None = None,
+        cwd: str | None = None,
+        log_path: str | None = None,
+    ) -> None:
+        """Create the actor and SUBMIT the subprocess launch without blocking.
+
+        Stores the pending ObjectRef; the caller must poll :meth:`poll_started`
+        until it returns a pid (non-``None``). This is the §3.3 non-blocking
+        start: Ray scheduling time is neither charged to the specialist's wall
+        budget nor allowed to block the Coordinator's event loop.
+
+        Raises :exc:`RayInfeasibleError` for a permanently-unschedulable request
+        (caller turns this into a structured task failure).
+        """
+        from ._ray_backend import get_ray_backend  # noqa: PLC0415
+
+        get_ray_backend().ensure(log_path=self._ensure_log_path)
+        _assert_cluster_feasible(num_gpus=self._num_gpus, serving_slot=self._serving_slot)
+        self._actor = make_gpu_specialist_actor(
+            self._num_gpus, serving_slot=self._serving_slot
+        )
+        self._start_ref = self._actor.start.remote(cmd, env=env, cwd=cwd, log_path=log_path)
+        self._pending_started_monotonic = time.monotonic()
+
+    def poll_started(self) -> int | None:
+        """Non-blocking poll for the launched pid.
+
+        Returns the pid once Ray has scheduled the actor and the subprocess has
+        launched, else ``None`` while still pending. Never blocks (uses
+        ``ray.wait(..., timeout=0)``), so a caller can interleave it with
+        ``asyncio.sleep`` and keep the event loop responsive (§3.3).
+        """
+        if self._pid is not None:
+            return self._pid
+        if self._start_ref is None:
+            return None
+        import ray  # noqa: PLC0415
+
+        ready, _ = ray.wait([self._start_ref], num_returns=1, timeout=0)
+        if not ready:
+            return None
+        self._pid = int(ray.get(self._start_ref))
+        self._start_ref = None
+        return self._pid
+
+    def pending_seconds(self) -> float:
+        """Seconds the actor has been PENDING (submitted, not yet scheduled).
+
+        Zero before :meth:`start_async` and after the pid is obtained. Used by
+        the caller to enforce a pending-time deadline separate from the running
+        wall budget (§3.3 / invariant §6.4).
+        """
+        if self._pending_started_monotonic is None or self._pid is not None:
+            return 0.0
+        return max(0.0, time.monotonic() - self._pending_started_monotonic)
 
     def pid(self) -> int | None:
         """Return the launched pid, or ``None`` before :meth:`start`.

--- a/src/hyperloom/orchestrator/actions/executors/framework_agent.py
+++ b/src/hyperloom/orchestrator/actions/executors/framework_agent.py
@@ -22,6 +22,7 @@ from ._git import _run_git, _run_git_cp
 from ._grid_runner import (
     GridVariant,
     VariantResult,
+    _num_gpus_for_config,
     _resolve_session_dir,
     run_grid,
     sanitize_result_dir,
@@ -1154,21 +1155,36 @@ class FrameworkAgentExecutor:
             note=f"framework:{slug}",
         )
 
-        results: list[VariantResult] = await run_grid(
-            base_yaml_path=config_path,
-            base_extra_args=str(params.get("base_extra_args") or "").strip(),
-            grid=[variant],
-            output_root=output_root,
-            magpie_python=params.get("magpie_python") or None,
-            variant_timeout_sec=int(
-                params.get("variant_timeout_sec", self.variant_timeout_sec),
-            ),
-            keep_going_on_failure=False,
-            model_path=resolved_model or None,
-            gpu_type=resolved_gpu or None,
-            benchmark_script=override_script,
-            result_dir=override_result_dir,
-        )
+        # Ray-managed GPU execution (phase-3 §3.1 / invariant §6.2): the
+        # candidate benchmark holds a serving lease (num_gpus=TP + serving_slot)
+        # for the whole run_grid, so it serializes against other serving on the
+        # whole-machine mutex instead of colliding with a concurrently-running
+        # GPU specialist server on the same card. ``None`` keeps the local path
+        # (multi-node / RAY_EXEC off / pytest default). Closed right after the
+        # grid; the accuracy parse below reads result files and needs no GPU.
+        from ._ray_serving import maybe_serving_lease
+
+        serving_lease = maybe_serving_lease(num_gpus=_num_gpus_for_config(config_path))
+        try:
+            results: list[VariantResult] = await run_grid(
+                base_yaml_path=config_path,
+                base_extra_args=str(params.get("base_extra_args") or "").strip(),
+                grid=[variant],
+                output_root=output_root,
+                magpie_python=params.get("magpie_python") or None,
+                variant_timeout_sec=int(
+                    params.get("variant_timeout_sec", self.variant_timeout_sec),
+                ),
+                keep_going_on_failure=False,
+                model_path=resolved_model or None,
+                gpu_type=resolved_gpu or None,
+                benchmark_script=override_script,
+                result_dir=override_result_dir,
+                serving_lease=serving_lease,
+            )
+        finally:
+            if serving_lease is not None:
+                serving_lease.close()
 
         bench: dict[str, Any] = {}
         if results:

--- a/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
+++ b/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
@@ -36,6 +36,7 @@ from ._nogit_patch import (
 from ._grid_runner import (
     GridVariant,
     VariantResult,
+    _num_gpus_for_config,
     _resolve_session_dir,
     run_grid,
     sanitize_result_dir,
@@ -2301,22 +2302,37 @@ class IntegratePatchExecutor:
             note=f"integrate_patch:{specialist_task_id}",
         )
 
-        results: list[VariantResult] = await run_grid(
-            base_yaml_path=config_path,
-            base_extra_args=str(params.get("base_extra_args") or "").strip(),
-            grid=[variant],
-            output_root=output_root,
-            magpie_python=params.get("magpie_python") or None,
-            variant_timeout_sec=int(
-                params.get("variant_timeout_sec", self.variant_timeout_sec),
-            ),
-            keep_going_on_failure=False,
-            model_path=resolved_model or None,
-            gpu_type=resolved_gpu or None,
-            benchmark_script=override_script,
-            result_dir=override_result_dir,
-            base_args_mode=str(params.get("base_args_mode") or "append"),
-        )
+        # Ray-managed GPU execution (phase-3 §3.1 / invariant §6.2): hold a
+        # serving lease (num_gpus=TP + serving_slot) for the whole run_grid so
+        # the patch benchmark serializes against other serving on the
+        # whole-machine mutex instead of colliding with a concurrently-running
+        # GPU specialist server on the same card (the observed
+        # ``reverted_smoke_fail`` root cause). ``None`` keeps the local path
+        # (multi-node / RAY_EXEC off / pytest default).
+        from ._ray_serving import maybe_serving_lease
+
+        serving_lease = maybe_serving_lease(num_gpus=_num_gpus_for_config(config_path))
+        try:
+            results: list[VariantResult] = await run_grid(
+                base_yaml_path=config_path,
+                base_extra_args=str(params.get("base_extra_args") or "").strip(),
+                grid=[variant],
+                output_root=output_root,
+                magpie_python=params.get("magpie_python") or None,
+                variant_timeout_sec=int(
+                    params.get("variant_timeout_sec", self.variant_timeout_sec),
+                ),
+                keep_going_on_failure=False,
+                model_path=resolved_model or None,
+                gpu_type=resolved_gpu or None,
+                benchmark_script=override_script,
+                result_dir=override_result_dir,
+                base_args_mode=str(params.get("base_args_mode") or "append"),
+                serving_lease=serving_lease,
+            )
+        finally:
+            if serving_lease is not None:
+                serving_lease.close()
 
         bench: dict[str, Any] = {}
         if results:

--- a/src/hyperloom/orchestrator/bus/gpu_pool.py
+++ b/src/hyperloom/orchestrator/bus/gpu_pool.py
@@ -33,6 +33,15 @@ from .storage.connection import SqliteConnection
 
 DEFAULT_GPU_LEASE_TTL_SEC = 1800
 
+# Reserved synthetic gpu_id base for single-node Ray pending-observation slots
+# (§3.2). Ray owns the physical card assignment, so under Ray this pool is a
+# count-based admission ledger, not a physical-id allocator: admissions take a
+# synthetic slot id in ``[_RAY_OBS_ID_BASE, _RAY_OBS_ID_BASE + pending_limit)``
+# so multiple specialists can queue on a single physical GPU (Ray serializes
+# them via ``num_gpus``) while TTL / reap / resume / release keep working on the
+# same ``gpu_leases`` table. The base is far above any real device id.
+_RAY_OBS_ID_BASE = 100000
+
 # GPU-lease / gpu_research_lane TTL grace over the agent wall budget. Iron law:
 # ``kill ≤ gpu_lease TTL ≤ gpu_research_lane TTL`` — the lease must outlive the
 # agent's wall-budget kill so cards are not reclaimed mid-compute. TTL =
@@ -279,6 +288,80 @@ class SpecialistGpuPool:
             holder_id=holder_id,
             task_id=task_id,
             gpu_ids=tuple(selected),
+            acquired_at=now_iso,
+            expires_at=expires_iso,
+        )
+
+    async def try_acquire_ray_observation(
+        self,
+        *,
+        holder_id: str,
+        task_id: str,
+        pending_limit: int,
+        ttl_sec: int = DEFAULT_GPU_LEASE_TTL_SEC,
+    ) -> GpuLease | None:
+        """Admit a GPU specialist under single-node Ray by COUNT, not physical id.
+
+        Under single-node Ray execution the physical card is Ray's (the
+        specialist runs inside a ``GpuSpecialistActor(num_gpus=…)``), so this
+        pool becomes a count-based admission ledger (§3.2): it hands out a
+        synthetic slot id from ``[_RAY_OBS_ID_BASE, _RAY_OBS_ID_BASE +
+        pending_limit)`` so up to ``pending_limit`` specialists can be in-flight
+        (pending + running) at once — Ray then serializes them on ``num_gpus``.
+        Returns ``None`` when the pending limit is already reached (backpressure;
+        the task stays queued). TTL / :meth:`reap_expired` / :meth:`release` all
+        work unchanged on the synthetic rows (same ``gpu_leases`` table).
+
+        Args:
+            holder_id: Identifier of the lease holder.
+            task_id: Identifier of the task the lease is for.
+            pending_limit: Max concurrent in-flight GPU specialists (>= 1).
+            ttl_sec: Lease time-to-live in seconds.
+
+        Returns:
+            A :class:`GpuLease` over a synthetic slot id, or ``None`` when the
+            pending limit is reached.
+        """
+        limit = max(1, int(pending_limit or 1))
+        now_ts = time.time()
+        now_iso = _now_iso()
+        expires_ts = now_ts + max(1, int(ttl_sec or DEFAULT_GPU_LEASE_TTL_SEC))
+        expires_iso = datetime.fromtimestamp(
+            expires_ts,
+            tz=timezone.utc,
+        ).isoformat(timespec="microseconds")
+
+        async with self.db.transaction() as cur:
+            cur.execute(
+                "DELETE FROM gpu_leases WHERE expires_at <= ?",
+                (now_iso,),
+            )
+            cur.execute(
+                "SELECT gpu_id FROM gpu_leases WHERE gpu_id >= ?",
+                (_RAY_OBS_ID_BASE,),
+            )
+            used = {int(r["gpu_id"]) for r in cur.fetchall()}
+            slot: int | None = None
+            for i in range(limit):
+                cand = _RAY_OBS_ID_BASE + i
+                if cand not in used:
+                    slot = cand
+                    break
+            if slot is None:
+                return None
+            cur.execute(
+                """
+                INSERT INTO gpu_leases(
+                    gpu_id, holder_id, task_id,
+                    acquired_at, expires_at, heartbeat_at
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (slot, holder_id, task_id, now_iso, expires_iso, now_iso),
+            )
+        return GpuLease(
+            holder_id=holder_id,
+            task_id=task_id,
+            gpu_ids=(slot,),
             acquired_at=now_iso,
             expires_at=expires_iso,
         )

--- a/src/hyperloom/orchestrator/kernel/conc_sweep.py
+++ b/src/hyperloom/orchestrator/kernel/conc_sweep.py
@@ -1516,6 +1516,14 @@ async def run_conc_sweep(
         )
         _last_variant_runtime_sec: float = float(variant_timeout_sec)
 
+        # phase-3 §3.1 / invariant §6.2: the legacy Option-B path restarts a
+        # server per variant, so each run_grid holds its own serving lease
+        # (num_gpus=TP + serving_slot). Releasing between variants also lets a
+        # queued serving task interleave (serving priority, §3.4). ``None`` on
+        # the local path (multi-node / RAY_EXEC off / pytest default).
+        from ..actions.executors._grid_runner import _num_gpus_for_config
+        from ..actions.executors._ray_serving import maybe_serving_lease
+
         for idx, variant in enumerate(grid):
             remaining = (deadline - time.time()) if has_budget and deadline is not None else None
             if has_budget and remaining is not None and remaining <= 0:
@@ -1588,16 +1596,22 @@ async def run_conc_sweep(
             soft_deadline: float | None = _session_soft_dl
 
             _variant_start = time.time()
-            sub_results = await run_grid(
-                base_yaml_path=base_yaml_path,
-                base_extra_args="",
-                grid=[variant],
-                output_root=workspace,
-                variant_timeout_sec=effective_timeout,
-                model_path=resolved_model,
-                gpu_type=resolved_gpu,
-                soft_deadline_sec=soft_deadline,
-            )
+            _legacy_lease = maybe_serving_lease(num_gpus=_num_gpus_for_config(base_yaml_path))
+            try:
+                sub_results = await run_grid(
+                    base_yaml_path=base_yaml_path,
+                    base_extra_args="",
+                    grid=[variant],
+                    output_root=workspace,
+                    variant_timeout_sec=effective_timeout,
+                    model_path=resolved_model,
+                    gpu_type=resolved_gpu,
+                    soft_deadline_sec=soft_deadline,
+                    serving_lease=_legacy_lease,
+                )
+            finally:
+                if _legacy_lease is not None:
+                    _legacy_lease.close()
             _last_variant_runtime_sec = time.time() - _variant_start
             results.extend(sub_results)
 

--- a/src/hyperloom/orchestrator/loop/dispatcher.py
+++ b/src/hyperloom/orchestrator/loop/dispatcher.py
@@ -324,12 +324,33 @@ class DispatcherCollaborator:
                     # kill <= gpu_lease TTL <= gpu_research_lane TTL. Both TTLs
                     # come from ``_gpu_lease_ttl_sec`` so they never drift apart.
                     gpu_ttl_sec = self._gpu_lease_ttl_sec(int(task.lease_ttl_sec or 0))
-                    gpu_lease = await gpu_pool.try_acquire(
-                        count=gpu_count,
-                        holder_id=task.task_id,
-                        task_id=task.task_id,
-                        ttl_sec=gpu_ttl_sec,
+                    # §3.2: under single-node Ray the physical GPU mutex is Ray's
+                    # ``num_gpus``, not this SQLite pool. Admit by a count-based
+                    # pending limit so multiple specialists can queue on one
+                    # physical GPU (Ray time-multiplexes them) instead of the
+                    # legacy physical-capacity hard gate that pinned it to one at
+                    # a time. Off the Ray path (multi-node / RAY_EXEC off /
+                    # pytest) the SQLite pool stays the physical mutex
+                    # (invariant §6.7).
+                    from ..actions.executors._ray_backend import (
+                        ray_gpu_pending_limit,
+                        ray_gpu_specialist_exec_enabled,
                     )
+
+                    if ray_gpu_specialist_exec_enabled():
+                        gpu_lease = await gpu_pool.try_acquire_ray_observation(
+                            holder_id=task.task_id,
+                            task_id=task.task_id,
+                            pending_limit=ray_gpu_pending_limit(),
+                            ttl_sec=gpu_ttl_sec,
+                        )
+                    else:
+                        gpu_lease = await gpu_pool.try_acquire(
+                            count=gpu_count,
+                            holder_id=task.task_id,
+                            task_id=task.task_id,
+                            ttl_sec=gpu_ttl_sec,
+                        )
                     if gpu_lease is None:
                         if lease is not None:
                             await self.locks.release(lease)

--- a/src/hyperloom/orchestrator/loop/dispatcher.py
+++ b/src/hyperloom/orchestrator/loop/dispatcher.py
@@ -223,6 +223,21 @@ class DispatcherCollaborator:
         holders = await self.locks.lane_holders()
         capacities = await self.locks.lane_capacities()
         spawned: list[tuple[Task, asyncio.Task[SubAgentResult], Any]] = []
+        # §3.4 serving priority: if serving currently holds the whole-machine
+        # slot, pause admitting NEW GPU research specialists this pass (they stay
+        # in the SQLite queue and are re-considered next pass) so a research
+        # pile-up cannot starve serving. Computed once per pass (a single cheap
+        # Ray probe); best-effort — any failure leaves it False (no pause).
+        serving_priority_pause = False
+        try:
+            from ..actions.executors._ray_backend import (
+                ray_serving_priority_enabled,
+                serving_slot_busy,
+            )
+
+            serving_priority_pause = ray_serving_priority_enabled() and serving_slot_busy()
+        except Exception:  # noqa: BLE001 — never block dispatch on the probe
+            serving_priority_pause = False
         for task in queued:
             if task.task_id in exclude_ids:
                 # Already dispatched in a prior pass of this pump.
@@ -273,6 +288,16 @@ class DispatcherCollaborator:
                     needs_gpu=needs_gpu,
                 )
                 if needs_gpu:
+                    if serving_priority_pause:
+                        # §3.4: serving is active — defer this GPU specialist to a
+                        # later pass (keep it queued) rather than piling onto the
+                        # contended GPU. Release the SQLite lane lease taken above
+                        # so it does not sit held while the task waits.
+                        if lease is not None:
+                            await self.locks.release(lease)
+                            for lane in lease.lanes:
+                                holders[lane] = max(0, int(holders.get(lane, 0)) - 1)
+                        continue
                     # Whole-machine, time-shared lane vs serving-disjoint pool:
                     # framework-authoring and bench-capable specialists lease the
                     # whole machine from ``framework_gpu_pool``; every other GPU

--- a/src/hyperloom/orchestrator/loop/dispatcher.py
+++ b/src/hyperloom/orchestrator/loop/dispatcher.py
@@ -278,6 +278,7 @@ class DispatcherCollaborator:
                     # whole machine from ``framework_gpu_pool``; every other GPU
                     # specialist leases from ``gpu_specialist_pool``.
                     from ..specialists.profile import (
+                        holds_serving_slot,
                         uses_whole_machine_gpu_lane,
                     )
 
@@ -350,14 +351,20 @@ class DispatcherCollaborator:
                         maybe_gpu_specialist_lease,
                     )
 
-                    # Whole-machine / bench-capable specialists (gpu_research_lane)
-                    # also hold the ``serving_slot`` so Ray makes them mutually
-                    # exclusive with serving (§12 T6); the serving-disjoint pool
-                    # takes ``num_gpus`` only and can run on cards disjoint from
-                    # serving.
+                    # serving_slot (phase-3 §4 / invariant §6.3): only
+                    # bench-capable specialists that start their OWN serving
+                    # loop hold the whole-machine serving_slot mutex. Authoring-
+                    # only specialists (incl. framework authoring, which does not
+                    # self-bench — its real benchmark runs through integrate_patch
+                    # / _bench_candidate under a run_grid serving lease, §3.1)
+                    # take ``num_gpus`` only, so they share the GPU queue with
+                    # other specialists instead of blocking serving for their
+                    # whole (mostly CPU-bound authoring) lifetime. Physical GPU
+                    # mutual-exclusion with serving is still enforced by Ray's
+                    # ``num_gpus`` accounting.
                     gpu_specialist_lease = maybe_gpu_specialist_lease(
                         num_gpus=gpu_count,
-                        serving_slot=whole_machine_lane,
+                        serving_slot=holds_serving_slot(params),
                     )
                     if gpu_specialist_lease is not None:
                         extra_context["gpu_ids"] = list(range(gpu_count))

--- a/src/hyperloom/orchestrator/specialists/profile.py
+++ b/src/hyperloom/orchestrator/specialists/profile.py
@@ -169,6 +169,36 @@ def uses_whole_machine_gpu_lane(params: dict[str, Any] | None) -> bool:
     return resolve_specialist_profile(p).reserves_benchmark_lane
 
 
+def holds_serving_slot(params: dict[str, Any] | None) -> bool:
+    """True when a GPU specialist must hold the whole-machine ``serving_slot``
+    Ray resource (mutually exclusive with production serving).
+
+    Only **bench-capable** patch specialists (``mode=patch`` & ``bench=true``,
+    i.e. :attr:`SpecialistProfile.reserves_benchmark_lane`) start their own
+    serving + benchmark loop and therefore must serialize against production
+    serving on the ``serving_slot`` mutex for that window.
+
+    **Authoring-only** specialists — including framework authoring, which by
+    default does NOT self-bench (its real benchmark runs through
+    ``integrate_patch`` / ``framework_agent._bench_candidate`` under a run_grid
+    serving lease, phase-3 §3.1) — hold ``num_gpus`` only. They therefore do
+    NOT block the whole-machine serving mutex for their entire (largely
+    CPU-bound authoring) lifetime and can share the GPU queue with other
+    specialists (phase-3 §4 / invariant §6.3).
+
+    Note this is deliberately narrower than :func:`uses_whole_machine_gpu_lane`,
+    which still returns ``True`` for framework authoring (it selects the
+    whole-machine *pool*); only the ``serving_slot`` Ray resource is decoupled.
+
+    Args:
+        params: The specialist dispatch params, or ``None``.
+
+    Returns:
+        ``True`` only for bench-capable patch specialists.
+    """
+    return resolve_specialist_profile(params or {}).reserves_benchmark_lane
+
+
 def resolve_specialist_profile(params: dict[str, Any] | None) -> SpecialistProfile:
     """Read ``scope`` / ``mode`` / ``bench`` / ``lane`` from dispatch params.
 
@@ -229,6 +259,7 @@ __all__ = [
     "SCOPE_FREEFORM",
     "SCOPE_VALUES",
     "SpecialistProfile",
+    "holds_serving_slot",
     "resolve_specialist_profile",
     "uses_whole_machine_gpu_lane",
 ]

--- a/src/hyperloom/orchestrator/specialists/subprocess_.py
+++ b/src/hyperloom/orchestrator/specialists/subprocess_.py
@@ -278,6 +278,25 @@ def _setup_worktree(
     return worktree_path, ""
 
 
+# §3.3: how often to poll a PENDING GPU-specialist Ray actor for its pid.
+_RAY_PENDING_POLL_INTERVAL_SEC: float = 1.0
+
+
+def _ray_specialist_pending_deadline_sec() -> float:
+    """Max seconds to wait for a GPU-specialist actor to schedule before failing.
+
+    Mirrors ``_ray_serving._RAY_SPECIALIST_SCHED_TIMEOUT_SEC`` (same env var) so
+    the async dispatch path and the legacy blocking ``start()`` agree. A pending
+    request that exceeds this becomes a structured task failure rather than an
+    unbounded stall (§3.3 / invariant §6.4: pending time is bounded and tracked
+    separately from the running wall budget).
+    """
+    try:
+        return float(os.environ.get("INFERENCE_OPTIMIZER_RAY_SPECIALIST_SCHED_TIMEOUT_SEC", "300"))
+    except (TypeError, ValueError):
+        return 300.0
+
+
 class _RayLeaseProcess:
     """``Popen``-like adapter for a specialist that runs inside a Ray actor."""
 
@@ -440,28 +459,72 @@ class SpecialistSubprocessDispatcher:
             for var in ("HIP_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES"):
                 env.pop(var, None)
 
-        proc_started = time.monotonic()
         log_fh: Any = None
+        proc_started: float
         if gpu_lease is not None:
-            # The actor opens process.log inside its worker (same host on
-            # single-node), so the reaper below still reads it directly.
+            # §3.3 non-blocking start: submit the actor launch, then poll for
+            # the pid with ``asyncio.sleep`` between polls. This keeps the
+            # Coordinator event loop responsive while Ray schedules the actor
+            # (no blocking ``ray.get``), and — combined with the timing split
+            # below — excludes Ray *pending* time from the specialist's running
+            # wall budget. A bounded pending deadline turns a permanently
+            # unschedulable request into a structured task failure instead of an
+            # unbounded stall. The actor opens process.log inside its worker
+            # (same host on single-node), so the reaper below reads it directly.
             try:
-                pid = gpu_lease.start(
+                gpu_lease.start_async(
                     cmd,
                     env=env,
                     cwd=str(worktree or workspace),
                     log_path=str(process_log),
                 )
-            except Exception as exc:  # noqa: BLE001 — surface a start failure as a result
+            except Exception as exc:  # noqa: BLE001 — surface a submit failure as a result
                 return SpecialistSubprocessResult(
                     done_payload=None,
                     exit_code=None,
                     elapsed_seconds=0.0,
                     process_log_path=str(process_log),
-                    error=f"failed to start specialist GPU actor: {exc!r}",
+                    error=f"failed to submit specialist GPU actor: {exc!r}",
                 )
+            pending_deadline_sec = _ray_specialist_pending_deadline_sec()
+            pending_start = time.monotonic()
+            pid: int | None = None
+            while True:
+                try:
+                    pid = gpu_lease.poll_started()
+                except Exception as exc:  # noqa: BLE001 — dead actor / ray error mid-schedule
+                    gpu_lease.close()
+                    return SpecialistSubprocessResult(
+                        done_payload=None,
+                        exit_code=None,
+                        elapsed_seconds=0.0,
+                        process_log_path=str(process_log),
+                        error=f"specialist GPU actor start failed: {exc!r}",
+                    )
+                if pid is not None:
+                    break
+                pending_elapsed = time.monotonic() - pending_start
+                if pending_elapsed >= pending_deadline_sec:
+                    gpu_lease.close()
+                    return SpecialistSubprocessResult(
+                        done_payload=None,
+                        exit_code=None,
+                        elapsed_seconds=0.0,
+                        process_log_path=str(process_log),
+                        error=(
+                            f"specialist GPU actor did not schedule within "
+                            f"{pending_deadline_sec:.0f}s (Ray pending deadline); "
+                            "cluster fully occupied"
+                        ),
+                    )
+                await asyncio.sleep(_RAY_PENDING_POLL_INTERVAL_SEC)
             proc: Any = _RayLeaseProcess(gpu_lease, pid)
+            # §3.3 timing split (invariant §6.4): the wall-budget clock starts
+            # only now that a real pid exists — the Ray pending time above is
+            # excluded so a slow-to-schedule actor is never mis-reaped.
+            proc_started = time.monotonic()
         else:
+            proc_started = time.monotonic()
             log_fh = process_log.open("w", encoding="utf-8")
             try:
                 proc = subprocess.Popen(


### PR DESCRIPTION


Puts the last GPU/serving call sites under the whole-machine Ray `serving_slot`
mutex, lets GPU specialists queue on one GPU with a non-blocking start, and gives
serving priority over research specialists. Also fixes two reliability bugs found
while validating on real hardware that were silently breaking `baseline` and
`conc_sweep`.

Everything stays behind the existing gate: the Ray seams return `None`/`False`
for multi-node, `INFERENCE_OPTIMIZER_RAY_EXEC=0`, and under pytest, so non-Ray
runs are unchanged.

## What changed

- **Serving leases everywhere**: the framework-agent bench, `integrate_patch`
  bench, and the legacy `conc_sweep` loop now hold a Ray serving lease
  (`num_gpus` + `serving_slot`) around their `run_grid`, so they serialize on the
  whole-machine mutex instead of booting a second server on top of a running one
  (previously an OOM kill -> spurious `reverted_smoke_fail`).
- **Framework authoring no longer holds `serving_slot`**: only bench-capable
  patch specialists take the slot; authoring-only specialists take `num_gpus`
  only and share the GPU queue. Physical exclusion with serving is still enforced
  by Ray `num_gpus`.
- **Non-blocking GPU-specialist start + count-based admission**:
  `start_async`/`poll_started` submit the actor and poll for the pid without
  blocking the Coordinator loop or charging Ray scheduling time to the wall
  budget; admission is count-based (`INFERENCE_OPTIMIZER_RAY_GPU_PENDING_LIMIT`,
  default 4) so several specialists can queue on one GPU. The SQLite physical
  gate stays on the non-Ray path.
- **Serving priority**: while serving holds the slot, the dispatcher pauses
  admitting new research specialists so they can't starve serving. Toggle with
  `INFERENCE_OPTIMIZER_RAY_SERVING_PRIORITY` (default on).
- **Eval reliability**: the Magpie/InferenceX eval-concurrency fix now applies
  reliably -- it runs even when `benchmarker.py` can't be resolved, covers the
  InferenceX benchmarks dir where the executed scripts live, and teaches
  `run_lm_eval` to accept the redundant `--concurrent-requests` flag (which
  otherwise aborts every `RUN_EVAL=true` baseline). The shared `benchmark_lib.sh`
  is excluded from the flag-strip so a second pass isn't mis-flagged.
- **Stale JIT-lock sweep**: orphaned aiter JIT build locks (left by a GPU process
  killed mid-compile) are now reaped before every grid server launch, not just
  the baseline cold path, so cold server boots don't hang.

## Validation

Offline unit suites (Ray path defaults OFF under pytest; new tests opt in with
`INFERENCE_OPTIMIZER_RAY_EXEC=1`) -- all green across the touched areas
(`test_ray_backend_unit`, `test_resource_lanes`, `test_specialist_dispatch_params`,
`test_specialist_subprocess`, `test_magpie_patcher_unit`,
`test_framework_agent_executor`, `test_integrate_patch_executor`,
`test_conc_sweep`, `test_gpu_research_lane_dispatch`,
`test_framework_whole_machine_gpu`).

New coverage: `start_async`/`poll_started`/pending timing, the pending-limit
admission, `holds_serving_slot`, the serving-priority helpers, the serving-lease
forwarding in the framework/integrate benches, and the eval-fix regression +
idempotency.

Live (Qwen3-14B-FP8, MI355X, fp8, TP=1, ISL/OSL=1024, single GPU): serving ran
through the Ray lease with `serving_slot` held during each benchmark and released
between rounds, no double-server collision, no fallback, and the Coordinator kept
ticking during baseline. The eval fix produced GSM8K results without the
"Unknown parameter" abort, and cold servers reached the build step instead of
deadlocking on a stale lock.

## Notes for reviewers

- Non-Ray / multi-node / pytest paths are unchanged (all seams return
  `None`/`False`).
- New env knobs: `INFERENCE_OPTIMIZER_RAY_GPU_PENDING_LIMIT` (default 4),
  `INFERENCE_OPTIMIZER_RAY_SERVING_PRIORITY` (default on).
- The Magpie/eval and JIT-lock fixes are applied by the in-repo patcher at
  install time (not hand-edits), so they survive a re-clone of the external
  InferenceX/Magpie checkouts.
- Ops: a cold FP8 GEMM JIT compile can exceed the default server-ready window;
  set `INFERENCE_OPTIMIZER_BASELINE_SERVER_READY_SEC` high for cold caches or
  pre-warm the aiter cache.
