### PR TITLE
fix(framework): invoke fa via python -m instead of PATH lookup

### DIFF
--- a/examples/hyperloom-qwen3-14b-fp8-8h/SKILL.md
+++ b/examples/hyperloom-qwen3-14b-fp8-8h/SKILL.md
@@ -76,6 +76,8 @@ Required optimize CLI flags:
 - `--precision bf16`
 - `--target-gain 30`
 - `--max-hours 8`
+- `--max-minutes-kernel-pct 0.5`
+- `--max-minutes-explore-pct 0.13`
 
 Before launch, read the repository-root `.env` file if it exists and load the needed environment variables from it, such as LLM API keys/base URLs, `FRAMEWORK`, and `HF_TOKEN`. Do not copy secret values into the prompt, terminal output, reports, or logs. Do not modify `USER_DATA_PATH`.
 

--- a/examples/hyperloom-qwen3-30b-a3b-instruct-2507-24h/SKILL.md
+++ b/examples/hyperloom-qwen3-30b-a3b-instruct-2507-24h/SKILL.md
@@ -85,6 +85,8 @@ Required optimize CLI flags:
 - `--precision bf16`
 - `--target-gain 30`
 - `--max-hours 24`
+- `--max-minutes-kernel-pct 0.5`
+- `--max-minutes-explore-pct 0.13`
 
 Before launch, read the repository-root `.env` file if it exists and load the needed environment variables from it, such as LLM API keys/base URLs, `FRAMEWORK`, and `HF_TOKEN`. Do not copy secret values into the prompt, terminal output, reports, or logs. Do not modify `USER_DATA_PATH`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,11 +105,10 @@ claude = [
 inference_optimizer = "hyperloom.inference_optimizer.cli:main"
 hyperloom = "hyperloom.inference_optimizer.setup:main"
 # tree-reform.MD P2.5: framework-agent's own ``[project.scripts]`` entries
-# (``framework-agent`` / ``fa``), preserved verbatim so the console scripts
-# keep resolving after promotion into the single ``hyperloom`` distribution.
-# The orchestrator's ``framework/client.py._resolve_fa_command()`` looks up
-# ``fa`` on PATH (``shutil.which("fa")``) before falling back to the module
-# entry ``python -m hyperloom.agents.framework.runtime.cli``; these provide it.
+# (``framework-agent`` / ``fa``), kept for interactive / manual use. The
+# orchestrator does NOT use these console scripts: ``framework/client.py``
+# invokes ``python -m hyperloom.agents.framework.runtime.cli`` directly,
+# mirroring the critic / robustness backends (PATH-independent).
 framework-agent = "hyperloom.agents.framework.runtime.cli:main"
 fa = "hyperloom.agents.framework.runtime.cli:main"
 # tree-reform.MD P2.5: robustness-agent's own ``[project.scripts]`` entry,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,8 +107,9 @@ hyperloom = "hyperloom.inference_optimizer.setup:main"
 # tree-reform.MD P2.5: framework-agent's own ``[project.scripts]`` entries
 # (``framework-agent`` / ``fa``), preserved verbatim so the console scripts
 # keep resolving after promotion into the single ``hyperloom`` distribution.
-# The orchestrator's ``framework/client.py._resolve_fa_binary()`` looks up
-# ``fa`` on PATH first (``shutil.which("fa")``), which these provide.
+# The orchestrator's ``framework/client.py._resolve_fa_command()`` looks up
+# ``fa`` on PATH (``shutil.which("fa")``) before falling back to the module
+# entry ``python -m hyperloom.agents.framework.runtime.cli``; these provide it.
 framework-agent = "hyperloom.agents.framework.runtime.cli:main"
 fa = "hyperloom.agents.framework.runtime.cli:main"
 # tree-reform.MD P2.5: robustness-agent's own ``[project.scripts]`` entry,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,11 +104,8 @@ claude = [
 [project.scripts]
 inference_optimizer = "hyperloom.inference_optimizer.cli:main"
 hyperloom = "hyperloom.inference_optimizer.setup:main"
-# tree-reform.MD P2.5: framework-agent's own ``[project.scripts]`` entries
-# (``framework-agent`` / ``fa``), kept for interactive / manual use. The
-# orchestrator does NOT use these console scripts: ``framework/client.py``
-# invokes ``python -m hyperloom.agents.framework.runtime.cli`` directly,
-# mirroring the critic / robustness backends (PATH-independent).
+# Console scripts for interactive / manual use; the orchestrator invokes
+# ``python -m hyperloom.agents.framework.runtime.cli`` directly instead.
 framework-agent = "hyperloom.agents.framework.runtime.cli:main"
 fa = "hyperloom.agents.framework.runtime.cli:main"
 # tree-reform.MD P2.5: robustness-agent's own ``[project.scripts]`` entry,

--- a/src/hyperloom/inference_optimizer/tests/test_framework_agent_client_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_framework_agent_client_unit.py
@@ -28,53 +28,12 @@ def test_repo_url_for_framework_known_and_unknown() -> None:
 
 
 # -- _resolve_fa_command ---------------------------------------------------
-def test_resolve_fa_command_explicit_env(tmp_path, monkeypatch) -> None:
-    fa = tmp_path / "fa"
-    fa.write_text("#!/bin/sh\n")
-    monkeypatch.setenv("FA_BIN", str(fa))
-    assert fac._resolve_fa_command() == [str(fa)]
-
-
-def test_resolve_fa_command_via_path(monkeypatch) -> None:
-    monkeypatch.delenv("FA_BIN", raising=False)
-    monkeypatch.delenv("FRAMEWORK_AGENT_ROOT", raising=False)
-    monkeypatch.setattr(fac.shutil, "which", lambda _n: "/usr/bin/fa")
-    assert fac._resolve_fa_command() == ["/usr/bin/fa"]
-
-
-def test_resolve_fa_command_via_interpreter_sibling(tmp_path, monkeypatch) -> None:
-    monkeypatch.delenv("FA_BIN", raising=False)
-    monkeypatch.delenv("FRAMEWORK_AGENT_ROOT", raising=False)
-    monkeypatch.setattr(fac.shutil, "which", lambda _n: None)
-    fake_python = tmp_path / "python3"
-    fake_python.write_text("")
-    sibling_fa = tmp_path / "fa"
-    sibling_fa.write_text("#!/bin/sh\n")
-    monkeypatch.setattr(fac.sys, "executable", str(fake_python))
-    assert fac._resolve_fa_command() == [str(sibling_fa)]
-
-
-def test_resolve_fa_command_via_root(tmp_path, monkeypatch) -> None:
-    monkeypatch.delenv("FA_BIN", raising=False)
-    monkeypatch.setattr(fac.shutil, "which", lambda _n: None)
-    # No interpreter-sibling fa so the legacy root fallback is reached.
-    monkeypatch.setattr(fac.sys, "executable", str(tmp_path / "nobin" / "python3"))
-    scripts = tmp_path / "scripts"
-    scripts.mkdir()
-    (scripts / "fa").write_text("#!/bin/sh\n")
-    monkeypatch.setenv("FRAMEWORK_AGENT_ROOT", str(tmp_path))
-    assert fac._resolve_fa_command() == [str(scripts / "fa")]
-
-
-def test_resolve_fa_command_falls_back_to_module(tmp_path, monkeypatch) -> None:
-    """No FA_BIN / no PATH fa / no interpreter-sibling fa / no legacy script:
-    the runtime must fall back to the current interpreter's module entry so
-    discovery never dies on a lost PATH (root-cause fix for #fa-not-found)."""
-    monkeypatch.delenv("FA_BIN", raising=False)
-    monkeypatch.delenv("FRAMEWORK_AGENT_ROOT", raising=False)
-    monkeypatch.setattr(fac.shutil, "which", lambda _n: None)
-    monkeypatch.setattr(fac.sys, "executable", str(tmp_path / "nobin" / "python3"))
-    assert fac._resolve_fa_command() == [str(tmp_path / "nobin" / "python3"), "-m", _FA_MODULE]
+def test_resolve_fa_command_is_module_invocation(monkeypatch) -> None:
+    """``fa`` always runs as ``[python, -m, <module>]`` — mirroring the critic /
+    robustness backends, so it never depends on $PATH (root-cause fix for
+    #fa-not-found)."""
+    monkeypatch.setattr(fac.sys, "executable", "/fake/python3")
+    assert fac._resolve_fa_command() == ["/fake/python3", "-m", _FA_MODULE]
 
 
 # -- _run_fa_subcommand_sync ----------------------------------------------

--- a/src/hyperloom/inference_optimizer/tests/test_framework_agent_client_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_framework_agent_client_unit.py
@@ -29,9 +29,7 @@ def test_repo_url_for_framework_known_and_unknown() -> None:
 
 # -- _resolve_fa_command ---------------------------------------------------
 def test_resolve_fa_command_is_module_invocation(monkeypatch) -> None:
-    """``fa`` always runs as ``[python, -m, <module>]`` — mirroring the critic /
-    robustness backends, so it never depends on $PATH (root-cause fix for
-    #fa-not-found)."""
+    """``fa`` runs as ``[python, -m, <module>]``, independent of $PATH."""
     monkeypatch.setattr(fac.sys, "executable", "/fake/python3")
     assert fac._resolve_fa_command() == ["/fake/python3", "-m", _FA_MODULE]
 
@@ -82,10 +80,8 @@ def test_run_fa_subcommand_sync_timeout(monkeypatch) -> None:
 
 
 def test_module_fallback_entry_starts_in_real_subprocess() -> None:
-    """Smoke: the ``python -m <module>`` fallback must actually launch and emit
-    JSON, guarding the PATH-independent path (root-cause fix for #fa-not-found)."""
-    # Pass the parent env verbatim so the child inherits any PYTHONPATH the CI
-    # relies on (a PYTHONPATH=src runner would otherwise ModuleNotFoundError).
+    """Smoke: ``python -m <module> schema`` launches and emits valid JSON."""
+    # Inherit the parent env so the child keeps PYTHONPATH.
     proc = subprocess.run(
         [sys.executable, "-m", _FA_MODULE, "schema"],
         capture_output=True,

--- a/src/hyperloom/inference_optimizer/tests/test_framework_agent_client_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_framework_agent_client_unit.py
@@ -7,6 +7,8 @@ error branches, and the ``phase_discover`` request shaping."""
 
 from __future__ import annotations
 
+import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -15,8 +17,8 @@ import pytest
 
 from hyperloom.orchestrator.framework import client as fac
 
-# Module entry point used as the environment-independent fallback command.
-_FA_MODULE = "hyperloom.agents.framework.runtime.cli"
+# Reference the resolver's own constant so the two never drift apart.
+_FA_MODULE = fac._FA_MODULE
 
 
 # -- repo_url_for_framework -----------------------------------------------
@@ -118,6 +120,23 @@ def test_run_fa_subcommand_sync_timeout(monkeypatch) -> None:
     rc, _out, err = fac._run_fa_subcommand_sync(["fa"], "phase-discover", Path("/x"), 5.0)
     assert rc == 124
     assert "timed out" in err
+
+
+def test_module_fallback_entry_starts_in_real_subprocess() -> None:
+    """Smoke: the ``python -m <module>`` fallback must actually launch and emit
+    JSON, guarding the PATH-independent path (root-cause fix for #fa-not-found)."""
+    # Pass the parent env verbatim so the child inherits any PYTHONPATH the CI
+    # relies on (a PYTHONPATH=src runner would otherwise ModuleNotFoundError).
+    proc = subprocess.run(
+        [sys.executable, "-m", _FA_MODULE, "schema"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=os.environ.copy(),
+    )
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert "schema" in payload.get("subcommands_available", [])
 
 
 # -- _invoke_fa_phase ------------------------------------------------------

--- a/src/hyperloom/inference_optimizer/tests/test_framework_agent_client_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_framework_agent_client_unit.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Coverage for ``framework_agent_client``: fa binary resolution, the sync
+"""Coverage for ``framework_agent_client``: fa command resolution, the sync
 subprocess wrapper (success / not-found / timeout), the async phase runner
 error branches, and the ``phase_discover`` request shaping."""
 
@@ -79,7 +79,7 @@ def test_run_fa_subcommand_sync_timeout(monkeypatch) -> None:
     assert "timed out" in err
 
 
-def test_module_fallback_entry_starts_in_real_subprocess() -> None:
+def test_module_entry_starts_in_real_subprocess() -> None:
     """Smoke: ``python -m <module> schema`` launches and emits valid JSON."""
     # Inherit the parent env so the child keeps PYTHONPATH.
     proc = subprocess.run(

--- a/src/hyperloom/inference_optimizer/tests/test_framework_agent_client_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_framework_agent_client_unit.py
@@ -8,11 +8,15 @@ error branches, and the ``phase_discover`` request shaping."""
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 from hyperloom.orchestrator.framework import client as fac
+
+# Module entry point used as the environment-independent fallback command.
+_FA_MODULE = "hyperloom.agents.framework.runtime.cli"
 
 
 # -- repo_url_for_framework -----------------------------------------------
@@ -21,36 +25,54 @@ def test_repo_url_for_framework_known_and_unknown() -> None:
     assert fac.repo_url_for_framework("nope") == ""
 
 
-# -- _resolve_fa_binary ----------------------------------------------------
-def test_resolve_fa_binary_explicit_env(tmp_path, monkeypatch) -> None:
+# -- _resolve_fa_command ---------------------------------------------------
+def test_resolve_fa_command_explicit_env(tmp_path, monkeypatch) -> None:
     fa = tmp_path / "fa"
     fa.write_text("#!/bin/sh\n")
     monkeypatch.setenv("FA_BIN", str(fa))
-    assert fac._resolve_fa_binary() == str(fa)
+    assert fac._resolve_fa_command() == [str(fa)]
 
 
-def test_resolve_fa_binary_via_path(monkeypatch) -> None:
+def test_resolve_fa_command_via_path(monkeypatch) -> None:
     monkeypatch.delenv("FA_BIN", raising=False)
     monkeypatch.delenv("FRAMEWORK_AGENT_ROOT", raising=False)
     monkeypatch.setattr(fac.shutil, "which", lambda _n: "/usr/bin/fa")
-    assert fac._resolve_fa_binary() == "/usr/bin/fa"
+    assert fac._resolve_fa_command() == ["/usr/bin/fa"]
 
 
-def test_resolve_fa_binary_via_root(tmp_path, monkeypatch) -> None:
+def test_resolve_fa_command_via_interpreter_sibling(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("FA_BIN", raising=False)
+    monkeypatch.delenv("FRAMEWORK_AGENT_ROOT", raising=False)
+    monkeypatch.setattr(fac.shutil, "which", lambda _n: None)
+    fake_python = tmp_path / "python3"
+    fake_python.write_text("")
+    sibling_fa = tmp_path / "fa"
+    sibling_fa.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(fac.sys, "executable", str(fake_python))
+    assert fac._resolve_fa_command() == [str(sibling_fa)]
+
+
+def test_resolve_fa_command_via_root(tmp_path, monkeypatch) -> None:
     monkeypatch.delenv("FA_BIN", raising=False)
     monkeypatch.setattr(fac.shutil, "which", lambda _n: None)
+    # No interpreter-sibling fa so the legacy root fallback is reached.
+    monkeypatch.setattr(fac.sys, "executable", str(tmp_path / "nobin" / "python3"))
     scripts = tmp_path / "scripts"
     scripts.mkdir()
     (scripts / "fa").write_text("#!/bin/sh\n")
     monkeypatch.setenv("FRAMEWORK_AGENT_ROOT", str(tmp_path))
-    assert fac._resolve_fa_binary() == str(scripts / "fa")
+    assert fac._resolve_fa_command() == [str(scripts / "fa")]
 
 
-def test_resolve_fa_binary_none(monkeypatch) -> None:
+def test_resolve_fa_command_falls_back_to_module(tmp_path, monkeypatch) -> None:
+    """No FA_BIN / no PATH fa / no interpreter-sibling fa / no legacy script:
+    the runtime must fall back to the current interpreter's module entry so
+    discovery never dies on a lost PATH (root-cause fix for #fa-not-found)."""
     monkeypatch.delenv("FA_BIN", raising=False)
     monkeypatch.delenv("FRAMEWORK_AGENT_ROOT", raising=False)
     monkeypatch.setattr(fac.shutil, "which", lambda _n: None)
-    assert fac._resolve_fa_binary() is None
+    monkeypatch.setattr(fac.sys, "executable", str(tmp_path / "nobin" / "python3"))
+    assert fac._resolve_fa_command() == [str(tmp_path / "nobin" / "python3"), "-m", _FA_MODULE]
 
 
 # -- _run_fa_subcommand_sync ----------------------------------------------
@@ -59,8 +81,23 @@ def test_run_fa_subcommand_sync_ok(monkeypatch) -> None:
         return subprocess.CompletedProcess(cmd, 0, '{"ok": 1}', "")
 
     monkeypatch.setattr(fac.subprocess, "run", _run)
-    rc, out, err = fac._run_fa_subcommand_sync("fa", "phase-discover", Path("/x"), 5.0)
+    rc, out, err = fac._run_fa_subcommand_sync(["fa"], "phase-discover", Path("/x"), 5.0)
     assert (rc, out, err) == (0, '{"ok": 1}', "")
+
+
+def test_run_fa_subcommand_sync_builds_full_command(monkeypatch) -> None:
+    """The cmd prefix is preserved verbatim and the subcommand + IO flags are
+    appended, so a multi-token module fallback prefix runs correctly."""
+    captured: dict = {}
+
+    def _run(cmd, **kw):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, "{}", "")
+
+    monkeypatch.setattr(fac.subprocess, "run", _run)
+    prefix = [sys.executable, "-m", _FA_MODULE]
+    fac._run_fa_subcommand_sync(prefix, "phase-discover", Path("/req.json"), 5.0)
+    assert captured["cmd"] == [*prefix, "phase-discover", "--request", "/req.json", "--out", "-"]
 
 
 def test_run_fa_subcommand_sync_not_found(monkeypatch) -> None:
@@ -68,7 +105,7 @@ def test_run_fa_subcommand_sync_not_found(monkeypatch) -> None:
         raise FileNotFoundError("missing")
 
     monkeypatch.setattr(fac.subprocess, "run", _run)
-    rc, _out, err = fac._run_fa_subcommand_sync("fa", "phase-discover", Path("/x"), 5.0)
+    rc, _out, err = fac._run_fa_subcommand_sync(["fa"], "phase-discover", Path("/x"), 5.0)
     assert rc == 127
     assert "not found" in err
 
@@ -78,26 +115,35 @@ def test_run_fa_subcommand_sync_timeout(monkeypatch) -> None:
         raise subprocess.TimeoutExpired(cmd="fa", timeout=5.0)
 
     monkeypatch.setattr(fac.subprocess, "run", _run)
-    rc, _out, err = fac._run_fa_subcommand_sync("fa", "phase-discover", Path("/x"), 5.0)
+    rc, _out, err = fac._run_fa_subcommand_sync(["fa"], "phase-discover", Path("/x"), 5.0)
     assert rc == 124
     assert "timed out" in err
 
 
 # -- _invoke_fa_phase ------------------------------------------------------
 @pytest.mark.asyncio
-async def test_invoke_fa_phase_no_binary(tmp_path, monkeypatch) -> None:
-    monkeypatch.setattr(fac, "_resolve_fa_binary", lambda: None)
-    with pytest.raises(RuntimeError, match="fa binary not found"):
-        await fac._invoke_fa_phase(
-            subcommand="phase-discover",
-            request={},
-            session_dir=tmp_path,
-        )
+async def test_invoke_fa_phase_uses_resolved_command(tmp_path, monkeypatch) -> None:
+    """The resolved command prefix is threaded verbatim into the sync runner."""
+    captured: dict = {}
+
+    def _fake_run(cmd_prefix, subcommand, request_path, timeout_sec):
+        captured["cmd_prefix"] = cmd_prefix
+        return (0, '{"candidates": []}', "")
+
+    monkeypatch.setattr(fac, "_resolve_fa_command", lambda: [sys.executable, "-m", _FA_MODULE])
+    monkeypatch.setattr(fac, "_run_fa_subcommand_sync", _fake_run)
+    out = await fac._invoke_fa_phase(
+        subcommand="phase-discover",
+        request={},
+        session_dir=tmp_path,
+    )
+    assert out == {"candidates": []}
+    assert captured["cmd_prefix"] == [sys.executable, "-m", _FA_MODULE]
 
 
 @pytest.mark.asyncio
 async def test_invoke_fa_phase_nonzero_rc(tmp_path, monkeypatch) -> None:
-    monkeypatch.setattr(fac, "_resolve_fa_binary", lambda: "fa")
+    monkeypatch.setattr(fac, "_resolve_fa_command", lambda: ["fa"])
     monkeypatch.setattr(
         fac,
         "_run_fa_subcommand_sync",
@@ -115,7 +161,7 @@ async def test_invoke_fa_phase_nonzero_rc(tmp_path, monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_invoke_fa_phase_invalid_json(tmp_path, monkeypatch) -> None:
-    monkeypatch.setattr(fac, "_resolve_fa_binary", lambda: "fa")
+    monkeypatch.setattr(fac, "_resolve_fa_command", lambda: ["fa"])
     monkeypatch.setattr(
         fac,
         "_run_fa_subcommand_sync",
@@ -131,7 +177,7 @@ async def test_invoke_fa_phase_invalid_json(tmp_path, monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_invoke_fa_phase_happy_path(tmp_path, monkeypatch) -> None:
-    monkeypatch.setattr(fac, "_resolve_fa_binary", lambda: "fa")
+    monkeypatch.setattr(fac, "_resolve_fa_command", lambda: ["fa"])
     monkeypatch.setattr(
         fac,
         "_run_fa_subcommand_sync",

--- a/src/hyperloom/orchestrator/framework/client.py
+++ b/src/hyperloom/orchestrator/framework/client.py
@@ -16,7 +16,6 @@ import asyncio
 import contextlib
 import json
 import os
-import shutil
 import subprocess
 import sys
 import uuid
@@ -25,37 +24,18 @@ from typing import Any
 
 from hyperloom.agents.framework.repo_map import repo_url_for_framework
 
-# Importable module entry for the ``fa`` CLI. Used as the final,
-# environment-independent fallback so discovery never dies on a lost $PATH.
+# Importable module entry for the ``fa`` CLI. Always invoked via the current
+# interpreter, mirroring the critic / robustness runtime.cli backends so the
+# call never depends on $PATH or an installed console script.
 _FA_MODULE = "hyperloom.agents.framework.runtime.cli"
 
 
 def _resolve_fa_command() -> list[str]:
-    """Resolve the command prefix used to invoke the ``fa`` CLI.
+    """Return the argv prefix for the ``fa`` CLI: ``[python, -m, <module>]``.
 
-    Resolution order: ``$FA_BIN``; ``shutil.which('fa')``; the ``fa`` script
-    next to the current interpreter; ``$FRAMEWORK_AGENT_ROOT/scripts/fa``;
-    finally ``[sys.executable, '-m', <module>]``. The module fallback never
-    depends on $PATH, so a run whose shell lost the venv bin dir still works.
-
-    Returns:
-        A non-empty argv prefix; the subcommand and IO flags are appended by
-        the caller.
+    Matches the sibling agents' ``python -m <module>`` invocation; the
+    subcommand and IO flags are appended by the caller.
     """
-    explicit = (os.environ.get("FA_BIN") or "").strip()
-    if explicit and Path(explicit).exists():
-        return [explicit]
-    via_path = shutil.which("fa")
-    if via_path:
-        return [via_path]
-    sibling = Path(sys.executable).with_name("fa")
-    if sibling.exists():
-        return [str(sibling)]
-    fa_root = (os.environ.get("FRAMEWORK_AGENT_ROOT") or "").strip()
-    if fa_root:
-        candidate = Path(fa_root) / "scripts" / "fa"
-        if candidate.exists():
-            return [str(candidate)]
     return [sys.executable, "-m", _FA_MODULE]
 
 

--- a/src/hyperloom/orchestrator/framework/client.py
+++ b/src/hyperloom/orchestrator/framework/client.py
@@ -81,7 +81,7 @@ def _run_fa_subcommand_sync(
 
     Returns:
         A ``(returncode, stdout, stderr)`` tuple; failures map to ``127``
-        (missing binary) or ``124`` (timeout).
+        (command not found) or ``124`` (timeout).
     """
     cmd = [*cmd_prefix, subcommand, "--request", str(request_path), "--out", "-"]
     try:
@@ -93,7 +93,7 @@ def _run_fa_subcommand_sync(
             check=False,
         )
     except FileNotFoundError as exc:
-        return 127, "", f"fa binary not found: {exc!r}"
+        return 127, "", f"fa command not found (prefix={cmd_prefix!r}): {exc!r}"
     except subprocess.TimeoutExpired as exc:
         return 124, "", f"fa {subcommand} timed out after {timeout_sec}s: {exc!r}"
     return cp.returncode, cp.stdout, cp.stderr
@@ -109,8 +109,7 @@ async def _invoke_fa_phase(
     """Generic async runner for ``fa phase-*`` subcommands.
 
     Writes ``request`` as temp JSON, runs the subcommand, returns parsed
-    JSON. Raises :class:`RuntimeError` on missing binary / non-zero exit /
-    parse failure.
+    JSON. Raises :class:`RuntimeError` on non-zero exit / parse failure.
 
     Args:
         subcommand: The ``fa phase-*`` subcommand to run.

--- a/src/hyperloom/orchestrator/framework/client.py
+++ b/src/hyperloom/orchestrator/framework/client.py
@@ -24,18 +24,12 @@ from typing import Any
 
 from hyperloom.agents.framework.repo_map import repo_url_for_framework
 
-# Importable module entry for the ``fa`` CLI. Always invoked via the current
-# interpreter, mirroring the critic / robustness runtime.cli backends so the
-# call never depends on $PATH or an installed console script.
+# Module entry for the ``fa`` CLI, invoked via the current interpreter.
 _FA_MODULE = "hyperloom.agents.framework.runtime.cli"
 
 
 def _resolve_fa_command() -> list[str]:
-    """Return the argv prefix for the ``fa`` CLI: ``[python, -m, <module>]``.
-
-    Matches the sibling agents' ``python -m <module>`` invocation; the
-    subcommand and IO flags are appended by the caller.
-    """
+    """Return the ``fa`` argv prefix ``[python, -m, <module>]``."""
     return [sys.executable, "-m", _FA_MODULE]
 
 
@@ -53,8 +47,7 @@ def _run_fa_subcommand_sync(
     """Sync helper: run ``<prefix> <subcommand> --request <path> --out -``. Never raises.
 
     Args:
-        cmd_prefix: The resolved ``fa`` command prefix (binary path or
-            ``[python, -m, module]``).
+        cmd_prefix: The resolved ``fa`` command prefix.
         subcommand: The ``fa`` subcommand to run.
         request_path: Path to the request JSON file.
         timeout_sec: Subprocess wall-clock timeout in seconds.

--- a/src/hyperloom/orchestrator/framework/client.py
+++ b/src/hyperloom/orchestrator/framework/client.py
@@ -258,9 +258,9 @@ async def phase_audit(
     """FRAMEWORK-phase semantic-audit shim (``fa phase-audit``).
 
     Builds the request and runs the subcommand; returns the
-    ``semantic_audit`` verdict. The caller treats a missing binary / non-zero
-    exit / parse failure (raised as :class:`RuntimeError`) as ``unknown`` and
-    preserves legacy routing.
+    ``semantic_audit`` verdict. The caller treats a non-zero exit / parse
+    failure (raised as :class:`RuntimeError`) as ``unknown`` and preserves
+    legacy routing.
 
     Args:
         candidate: The discovered candidate row (carries repo / pr_number /

--- a/src/hyperloom/orchestrator/framework/client.py
+++ b/src/hyperloom/orchestrator/framework/client.py
@@ -18,35 +18,45 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 import uuid
 from pathlib import Path
 from typing import Any
 
 from hyperloom.agents.framework.repo_map import repo_url_for_framework
 
+# Importable module entry for the ``fa`` CLI. Used as the final,
+# environment-independent fallback so discovery never dies on a lost $PATH.
+_FA_MODULE = "hyperloom.agents.framework.runtime.cli"
 
-def _resolve_fa_binary() -> str | None:
-    """Return the absolute path to the ``fa`` binary, or ``None``.
 
-    Resolution order: ``$FA_BIN``; ``shutil.which('fa')``;
-    ``$FRAMEWORK_AGENT_ROOT/scripts/fa``.
+def _resolve_fa_command() -> list[str]:
+    """Resolve the command prefix used to invoke the ``fa`` CLI.
+
+    Resolution order: ``$FA_BIN``; ``shutil.which('fa')``; the ``fa`` script
+    next to the current interpreter; ``$FRAMEWORK_AGENT_ROOT/scripts/fa``;
+    finally ``[sys.executable, '-m', <module>]``. The module fallback never
+    depends on $PATH, so a run whose shell lost the venv bin dir still works.
 
     Returns:
-        The absolute path to the ``fa`` binary, or ``None`` when it cannot be
-        located.
+        A non-empty argv prefix; the subcommand and IO flags are appended by
+        the caller.
     """
     explicit = (os.environ.get("FA_BIN") or "").strip()
     if explicit and Path(explicit).exists():
-        return explicit
+        return [explicit]
     via_path = shutil.which("fa")
     if via_path:
-        return via_path
+        return [via_path]
+    sibling = Path(sys.executable).with_name("fa")
+    if sibling.exists():
+        return [str(sibling)]
     fa_root = (os.environ.get("FRAMEWORK_AGENT_ROOT") or "").strip()
     if fa_root:
         candidate = Path(fa_root) / "scripts" / "fa"
         if candidate.exists():
-            return str(candidate)
-    return None
+            return [str(candidate)]
+    return [sys.executable, "-m", _FA_MODULE]
 
 
 DEFAULT_FA_PHASE_TIMEOUT_SEC: float = 180.0
@@ -55,15 +65,16 @@ DISCOVER_FAILURE_RETRY_LIMIT: int = 3
 
 
 def _run_fa_subcommand_sync(
-    fa_bin: str,
+    cmd_prefix: list[str],
     subcommand: str,
     request_path: Path,
     timeout_sec: float,
 ) -> "tuple[int, str, str]":
-    """Sync helper: run ``fa <subcommand> --request <path> --out -``. Never raises.
+    """Sync helper: run ``<prefix> <subcommand> --request <path> --out -``. Never raises.
 
     Args:
-        fa_bin: Path to the ``fa`` binary.
+        cmd_prefix: The resolved ``fa`` command prefix (binary path or
+            ``[python, -m, module]``).
         subcommand: The ``fa`` subcommand to run.
         request_path: Path to the request JSON file.
         timeout_sec: Subprocess wall-clock timeout in seconds.
@@ -72,7 +83,7 @@ def _run_fa_subcommand_sync(
         A ``(returncode, stdout, stderr)`` tuple; failures map to ``127``
         (missing binary) or ``124`` (timeout).
     """
-    cmd = [fa_bin, subcommand, "--request", str(request_path), "--out", "-"]
+    cmd = [*cmd_prefix, subcommand, "--request", str(request_path), "--out", "-"]
     try:
         cp = subprocess.run(
             cmd,
@@ -111,14 +122,10 @@ async def _invoke_fa_phase(
         The parsed JSON payload returned by the subcommand.
 
     Raises:
-        RuntimeError: If the ``fa`` binary is missing, the subcommand exits
-            non-zero, or its output is not valid JSON.
+        RuntimeError: If the subcommand exits non-zero or its output is not
+            valid JSON.
     """
-    fa_bin = _resolve_fa_binary()
-    if not fa_bin:
-        raise RuntimeError(
-            f"fa binary not found (subcommand={subcommand!r}); checked $FA_BIN, $PATH, $FRAMEWORK_AGENT_ROOT/scripts/fa"
-        )
+    cmd_prefix = _resolve_fa_command()
     tmp_dir = session_dir / ".fa-tmp"
     tmp_dir.mkdir(parents=True, exist_ok=True)
     request_path = tmp_dir / f"phase-{subcommand}-{uuid.uuid4().hex[:12]}.json"
@@ -129,7 +136,7 @@ async def _invoke_fa_phase(
     try:
         rc, stdout, stderr = await asyncio.to_thread(
             _run_fa_subcommand_sync,
-            fa_bin,
+            cmd_prefix,
             subcommand,
             request_path,
             timeout_sec,


### PR DESCRIPTION
## Problem

The FRAMEWORK_AGENT phase shelled out to the `fa` console script resolved only via `$FA_BIN`, `$PATH`, or `$FRAMEWORK_AGENT_ROOT/scripts/fa`. After the src-layout migration merged framework-agent into the hyperloom package, the standalone installer that persisted the venv bin dir on `PATH` was removed. Runs whose shell no longer exported that `PATH` raised `fa binary not found`, causing `phase-discover` / `phase-audit` to fail.

## Solution

Always invoke the fa CLI as:

```
[sys.executable, -m, hyperloom.agents.framework.runtime.cli]
```

This mirrors the critic and robustness agents (`python -m ...runtime.cli`) and removes any dependency on the launching shell exporting the venv bin dir. Discovery works as long as the optimizer process runs under an interpreter that can import the framework module.

Changes:
- Replace `_resolve_fa_binary()` with `_resolve_fa_command()` returning a command prefix (`list[str]`).
- Update `_run_fa_subcommand_sync` to append the subcommand and IO flags to that prefix.
- Drop `$FA_BIN` / `$PATH` / `$FRAMEWORK_AGENT_ROOT/scripts/fa` resolution entirely.
- Add a real-subprocess smoke test for the module entrypoint; refresh unit tests accordingly.

## Also in this PR

Set `--max-minutes-kernel-pct 0.5` and `--max-minutes-explore-pct 0.13` for the 8h and 24h demo skills so GEAK gets a larger fixed budget share.

## Test plan

- [x] `test_framework_agent_client_unit.py` (resolver, argv assembly, smoke test)
- [x] CI lint + test matrix (py3.10 / py3.11)