### PR TITLE
fix(baseline): per-session unique port for server_lifecycle reuse (fixes false baseline_accuracy_failed)

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_backend_gating.py
+++ b/src/hyperloom/inference_optimizer/tests/test_backend_gating.py
@@ -126,6 +126,9 @@ def test_lifecycle_delegates_to_bypass_backend(tmp_path, monkeypatch):
     cfg_path = tmp_path / "cfg.yaml"
     cfg_path.write_text(yaml.safe_dump(cfg), encoding="utf-8")
 
+    # Pin the free-port picker so the port assertion is deterministic
+    # (resolve now assigns a per-session free port on the common path).
+    monkeypatch.setattr(sl, "_pick_free_port", lambda: 8888)
     info = sl.resolve_lifecycle_params(cfg_path)
     # bypass now honors the YAML lifecycle block, so a serving framework
     # with profiling off is eligible.

--- a/src/hyperloom/inference_optimizer/tests/test_baseline_warmup_double_run.py
+++ b/src/hyperloom/inference_optimizer/tests/test_baseline_warmup_double_run.py
@@ -900,7 +900,10 @@ def test_double_run_pre_start_cleanup_kills_zombie_and_clears_stale_meta(
     output_dir = tmp_path / "ws"
     output_dir.mkdir(parents=True)
     (output_dir / "vllm_8888.pid").write_text("2147483646")
-    monkeypatch.setenv("INFERENCE_OPTIMIZER_BASELINE_REUSE_PORT", "8888")
+    monkeypatch.setattr(
+        "hyperloom.orchestrator.actions.executors._server_lifecycle._pick_free_port",
+        lambda: 8888,
+    )
 
     kill_calls = {"n": 0}
 
@@ -955,7 +958,10 @@ def test_pre_start_cleanup_no_kill_when_port_free(tmp_path, monkeypatch):
     output_dir = tmp_path / "ws"
     output_dir.mkdir(parents=True)
     (output_dir / "vllm_8888.pid").write_text("2147483646")
-    monkeypatch.setenv("INFERENCE_OPTIMIZER_BASELINE_REUSE_PORT", "8888")
+    monkeypatch.setattr(
+        "hyperloom.orchestrator.actions.executors._server_lifecycle._pick_free_port",
+        lambda: 8888,
+    )
 
     kill_calls = {"n": 0}
 
@@ -1008,7 +1014,10 @@ def test_pre_start_cleanup_no_kill_when_metadata_existed(tmp_path, monkeypatch):
     output_dir = tmp_path / "ws"
     output_dir.mkdir(parents=True)
     (output_dir / "vllm_8888.pid").write_text("2147483646")
-    monkeypatch.setenv("INFERENCE_OPTIMIZER_BASELINE_REUSE_PORT", "8888")
+    monkeypatch.setattr(
+        "hyperloom.orchestrator.actions.executors._server_lifecycle._pick_free_port",
+        lambda: 8888,
+    )
     (output_dir / "vllm_8888.json").write_text("{}")
 
     kill_calls = {"n": 0}

--- a/src/hyperloom/inference_optimizer/tests/test_baseline_warmup_double_run.py
+++ b/src/hyperloom/inference_optimizer/tests/test_baseline_warmup_double_run.py
@@ -900,6 +900,7 @@ def test_double_run_pre_start_cleanup_kills_zombie_and_clears_stale_meta(
     output_dir = tmp_path / "ws"
     output_dir.mkdir(parents=True)
     (output_dir / "vllm_8888.pid").write_text("2147483646")
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_BASELINE_REUSE_PORT", "8888")
 
     kill_calls = {"n": 0}
 
@@ -954,6 +955,7 @@ def test_pre_start_cleanup_no_kill_when_port_free(tmp_path, monkeypatch):
     output_dir = tmp_path / "ws"
     output_dir.mkdir(parents=True)
     (output_dir / "vllm_8888.pid").write_text("2147483646")
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_BASELINE_REUSE_PORT", "8888")
 
     kill_calls = {"n": 0}
 
@@ -1006,6 +1008,7 @@ def test_pre_start_cleanup_no_kill_when_metadata_existed(tmp_path, monkeypatch):
     output_dir = tmp_path / "ws"
     output_dir.mkdir(parents=True)
     (output_dir / "vllm_8888.pid").write_text("2147483646")
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_BASELINE_REUSE_PORT", "8888")
     (output_dir / "vllm_8888.json").write_text("{}")
 
     kill_calls = {"n": 0}

--- a/src/hyperloom/inference_optimizer/tests/test_grid_runner_behavior_lock.py
+++ b/src/hyperloom/inference_optimizer/tests/test_grid_runner_behavior_lock.py
@@ -388,9 +388,12 @@ class TestAutoWarmupTeardown:
 
     def test_warmup_success_measured_success_tears_down_once(self, tmp_path, monkeypatch):
         monkeypatch.setenv("INFERENCE_OPTIMIZER_RUN_GRID_WARMUP", "1")
-        # Pin the reuse port so the teardown-port assertion is deterministic
-        # (baseline now defaults to a per-session free port).
-        monkeypatch.setenv("INFERENCE_OPTIMIZER_BASELINE_REUSE_PORT", "8888")
+        # Pin the free-port picker so the teardown-port assertion is
+        # deterministic (baseline uses a per-session free port).
+        monkeypatch.setattr(
+            "hyperloom.orchestrator.actions.executors._server_lifecycle._pick_free_port",
+            lambda: 8888,
+        )
         base = tmp_path / "base.yaml"
         _write_base_yaml(base)
         state = {"n": 0}

--- a/src/hyperloom/inference_optimizer/tests/test_grid_runner_behavior_lock.py
+++ b/src/hyperloom/inference_optimizer/tests/test_grid_runner_behavior_lock.py
@@ -388,6 +388,9 @@ class TestAutoWarmupTeardown:
 
     def test_warmup_success_measured_success_tears_down_once(self, tmp_path, monkeypatch):
         monkeypatch.setenv("INFERENCE_OPTIMIZER_RUN_GRID_WARMUP", "1")
+        # Pin the reuse port so the teardown-port assertion is deterministic
+        # (baseline now defaults to a per-session free port).
+        monkeypatch.setenv("INFERENCE_OPTIMIZER_BASELINE_REUSE_PORT", "8888")
         base = tmp_path / "base.yaml"
         _write_base_yaml(base)
         state = {"n": 0}

--- a/src/hyperloom/orchestrator/actions/executors/_server_lifecycle.py
+++ b/src/hyperloom/orchestrator/actions/executors/_server_lifecycle.py
@@ -49,6 +49,91 @@ REUSE_PORT_DEFAULT = 8888
 # Override via ``INFERENCE_OPTIMIZER_BASELINE_SERVER_READY_SEC``.
 SERVER_READY_TIMEOUT_SEC = 2700
 
+# Falsey values for the unique-port toggle.
+_UNIQUE_PORT_FALSE = frozenset({"0", "false", "no", "off"})
+
+
+def _pick_free_port() -> int:
+    """Return an OS-assigned free TCP port on the loopback interface.
+
+    Binds to port 0 (ephemeral) and reads back the kernel-chosen port. There
+    is a small TOCTOU window before the server actually binds, acceptable for
+    the high ephemeral range. Raises ``OSError`` if no port can be obtained.
+
+    Returns:
+        int: A currently-free TCP port.
+    """
+    import socket
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.bind(("", 0))
+        return int(s.getsockname()[1])
+    finally:
+        s.close()
+
+
+def _resolve_reuse_port(config_port: int) -> int:
+    """Choose the persistent-server port for the reuse protocol.
+
+    The historical fixed default (``8888``) collides when a stale/leaked server
+    from a prior baseline attempt (double-run leaves ``cleanup=false`` round-1
+    servers running) or a co-tenant job still holds the port. Magpie then aborts
+    the fresh warmup with *"Reuse metadata mismatch ... server on PORT=8888 is
+    incompatible"* — every retry re-uses the same port and re-collides, so the
+    baseline never records an accuracy and the run stops with
+    ``baseline_accuracy_failed`` even though the model serves correctly.
+
+    Resolution order:
+      1. ``INFERENCE_OPTIMIZER_BASELINE_REUSE_PORT`` — an explicit operator pin.
+      2. A per-session free ephemeral port (default), so each baseline gets a
+         clean port and never collides with a leaked/co-tenant server. Disable
+         with ``INFERENCE_OPTIMIZER_BASELINE_UNIQUE_PORT=0``.
+      3. Only the shared default (``REUSE_PORT_DEFAULT``) is overridden; a
+         deliberately non-default ``PORT`` from the config is respected.
+
+    Both double-run rounds share the returned port (resolved once per attempt),
+    and it is pinned into ``envs.PORT`` so the server bind, Magpie reuse keying,
+    the lm-eval ``base_url`` and our teardown all agree.
+
+    Args:
+        config_port: The port read from the materialized benchmark config.
+
+    Returns:
+        int: The port to pin for this baseline's persistent server.
+    """
+    pin = os.environ.get("INFERENCE_OPTIMIZER_BASELINE_REUSE_PORT", "").strip()
+    if pin:
+        try:
+            return int(pin)
+        except ValueError:
+            log.warning(
+                "server_lifecycle: invalid INFERENCE_OPTIMIZER_BASELINE_REUSE_PORT=%r; ignoring",
+                pin,
+            )
+    unique = os.environ.get("INFERENCE_OPTIMIZER_BASELINE_UNIQUE_PORT", "1").strip().lower()
+    if unique in _UNIQUE_PORT_FALSE:
+        return config_port
+    # Respect a deliberately non-default port; only replace the shared default.
+    if config_port != REUSE_PORT_DEFAULT:
+        return config_port
+    try:
+        free = _pick_free_port()
+    except OSError as exc:
+        log.warning(
+            "server_lifecycle: free-port pick failed (%s); keeping fixed port %d",
+            exc,
+            config_port,
+        )
+        return config_port
+    log.info(
+        "server_lifecycle: assigned per-session free port %d (avoids fixed-port %d reuse collisions)",
+        free,
+        config_port,
+    )
+    return free
+
 
 def resolve_lifecycle_params(materialized_config_path: Path) -> dict[str, Any]:
     """Inspect the materialized YAML for server_lifecycle eligibility.
@@ -121,6 +206,12 @@ def resolve_lifecycle_params(materialized_config_path: Path) -> dict[str, Any]:
     if profiler_on:
         info["reason"] = "torch_profiler enabled (incompatible with reuse)"
         return info
+
+    # Assign a per-session port (default: free ephemeral) so a leaked/co-tenant
+    # server on the fixed default port cannot trigger Magpie's "Reuse metadata
+    # mismatch" abort on every retry. Resolved once here; both double-run rounds
+    # share it via inject_lifecycle -> envs.PORT.
+    info["port"] = _resolve_reuse_port(int(info["port"]))
 
     info["eligible"] = True
     return info

--- a/src/hyperloom/orchestrator/actions/executors/_server_lifecycle.py
+++ b/src/hyperloom/orchestrator/actions/executors/_server_lifecycle.py
@@ -49,12 +49,8 @@ REUSE_PORT_DEFAULT = 8888
 # Override via ``INFERENCE_OPTIMIZER_BASELINE_SERVER_READY_SEC``.
 SERVER_READY_TIMEOUT_SEC = 2700
 
-# Falsey values for the unique-port toggle.
-_UNIQUE_PORT_FALSE = frozenset({"0", "false", "no", "off"})
-
-
 def _pick_free_port() -> int:
-    """Return an OS-assigned free TCP port on the loopback interface.
+    """Return an OS-assigned free TCP port.
 
     Binds to port 0 (ephemeral) and reads back the kernel-chosen port. There
     is a small TOCTOU window before the server actually binds, acceptable for
@@ -72,67 +68,6 @@ def _pick_free_port() -> int:
         return int(s.getsockname()[1])
     finally:
         s.close()
-
-
-def _resolve_reuse_port(config_port: int) -> int:
-    """Choose the persistent-server port for the reuse protocol.
-
-    The historical fixed default (``8888``) collides when a stale/leaked server
-    from a prior baseline attempt (double-run leaves ``cleanup=false`` round-1
-    servers running) or a co-tenant job still holds the port. Magpie then aborts
-    the fresh warmup with *"Reuse metadata mismatch ... server on PORT=8888 is
-    incompatible"* — every retry re-uses the same port and re-collides, so the
-    baseline never records an accuracy and the run stops with
-    ``baseline_accuracy_failed`` even though the model serves correctly.
-
-    Resolution order:
-      1. ``INFERENCE_OPTIMIZER_BASELINE_REUSE_PORT`` — an explicit operator pin.
-      2. A per-session free ephemeral port (default), so each baseline gets a
-         clean port and never collides with a leaked/co-tenant server. Disable
-         with ``INFERENCE_OPTIMIZER_BASELINE_UNIQUE_PORT=0``.
-      3. Only the shared default (``REUSE_PORT_DEFAULT``) is overridden; a
-         deliberately non-default ``PORT`` from the config is respected.
-
-    Both double-run rounds share the returned port (resolved once per attempt),
-    and it is pinned into ``envs.PORT`` so the server bind, Magpie reuse keying,
-    the lm-eval ``base_url`` and our teardown all agree.
-
-    Args:
-        config_port: The port read from the materialized benchmark config.
-
-    Returns:
-        int: The port to pin for this baseline's persistent server.
-    """
-    pin = os.environ.get("INFERENCE_OPTIMIZER_BASELINE_REUSE_PORT", "").strip()
-    if pin:
-        try:
-            return int(pin)
-        except ValueError:
-            log.warning(
-                "server_lifecycle: invalid INFERENCE_OPTIMIZER_BASELINE_REUSE_PORT=%r; ignoring",
-                pin,
-            )
-    unique = os.environ.get("INFERENCE_OPTIMIZER_BASELINE_UNIQUE_PORT", "1").strip().lower()
-    if unique in _UNIQUE_PORT_FALSE:
-        return config_port
-    # Respect a deliberately non-default port; only replace the shared default.
-    if config_port != REUSE_PORT_DEFAULT:
-        return config_port
-    try:
-        free = _pick_free_port()
-    except OSError as exc:
-        log.warning(
-            "server_lifecycle: free-port pick failed (%s); keeping fixed port %d",
-            exc,
-            config_port,
-        )
-        return config_port
-    log.info(
-        "server_lifecycle: assigned per-session free port %d (avoids fixed-port %d reuse collisions)",
-        free,
-        config_port,
-    )
-    return free
 
 
 def resolve_lifecycle_params(materialized_config_path: Path) -> dict[str, Any]:
@@ -207,11 +142,23 @@ def resolve_lifecycle_params(materialized_config_path: Path) -> dict[str, Any]:
         info["reason"] = "torch_profiler enabled (incompatible with reuse)"
         return info
 
-    # Assign a per-session port (default: free ephemeral) so a leaked/co-tenant
-    # server on the fixed default port cannot trigger Magpie's "Reuse metadata
-    # mismatch" abort on every retry. Resolved once here; both double-run rounds
-    # share it via inject_lifecycle -> envs.PORT.
-    info["port"] = _resolve_reuse_port(int(info["port"]))
+    # Use a per-session free ephemeral port for the persistent server instead of
+    # a fixed default: a stale/leaked server from a prior baseline attempt
+    # (round 1 uses cleanup=false and leaves the server running) or a co-tenant
+    # job holding the fixed port makes Magpie abort every warmup with "Reuse
+    # metadata mismatch ... server on PORT=... is incompatible", so the baseline
+    # never records an accuracy and the run wrongly stops with
+    # baseline_accuracy_failed. Resolved once here; both double-run rounds share
+    # it via inject_lifecycle -> envs.PORT (server bind, Magpie reuse keying,
+    # lm-eval base_url and teardown all agree).
+    try:
+        info["port"] = _pick_free_port()
+    except OSError as exc:
+        log.warning(
+            "server_lifecycle: free-port pick failed (%s); keeping port %d",
+            exc,
+            info["port"],
+        )
 
     info["eligible"] = True
     return info

--- a/src/hyperloom/orchestrator/actions/executors/_server_lifecycle.py
+++ b/src/hyperloom/orchestrator/actions/executors/_server_lifecycle.py
@@ -70,6 +70,30 @@ def _pick_free_port() -> int:
         s.close()
 
 
+def _assign_free_port(current_port: int) -> int:
+    """Return a per-session free ephemeral port for the persistent server.
+
+    Falls back to ``current_port`` if no free port can be bound. Used on the
+    common resolution path so every backend (Magpie and bypass) gets the same
+    stale/co-tenant port-collision protection.
+
+    Args:
+        current_port: Port to keep if free-port allocation fails.
+
+    Returns:
+        int: A free port, or ``current_port`` on ``OSError``.
+    """
+    try:
+        return _pick_free_port()
+    except OSError as exc:
+        log.warning(
+            "server_lifecycle: free-port pick failed (%s); keeping port %d",
+            exc,
+            current_port,
+        )
+        return current_port
+
+
 def resolve_lifecycle_params(materialized_config_path: Path) -> dict[str, Any]:
     """Inspect the materialized YAML for server_lifecycle eligibility.
 
@@ -113,6 +137,13 @@ def resolve_lifecycle_params(materialized_config_path: Path) -> dict[str, Any]:
 
     backend_verdict = resolve_backend().lifecycle_eligibility(bench)
     if backend_verdict is not None:
+        # Free-port assignment lives on this common path so a non-Magpie backend
+        # (e.g. bypass) gets the same stale/co-tenant collision protection
+        # instead of falling back to the fixed default port.
+        if backend_verdict.get("eligible"):
+            backend_verdict["port"] = _assign_free_port(
+                int(backend_verdict.get("port", REUSE_PORT_DEFAULT))
+            )
         return backend_verdict
 
     # Server-less (scriptable) frameworks — e.g. xDiT diffusion — never boot a
@@ -151,14 +182,7 @@ def resolve_lifecycle_params(materialized_config_path: Path) -> dict[str, Any]:
     # baseline_accuracy_failed. Resolved once here; both double-run rounds share
     # it via inject_lifecycle -> envs.PORT (server bind, Magpie reuse keying,
     # lm-eval base_url and teardown all agree).
-    try:
-        info["port"] = _pick_free_port()
-    except OSError as exc:
-        log.warning(
-            "server_lifecycle: free-port pick failed (%s); keeping port %d",
-            exc,
-            info["port"],
-        )
+    info["port"] = _assign_free_port(info["port"])
 
     info["eligible"] = True
     return info


### PR DESCRIPTION
## Problem

The baseline cold-start **double-run guard** pins a **fixed default port `8888`** for the persistent inference server (`REUSE_PORT_DEFAULT`). On host-networked spur nodes this collides:

- Round 1 (warmup) launches the server with `cleanup=false` and leaves it running for round 2 to re-attach. When an attempt fails, that server can be **left behind on 8888**.
- The coordinator retries with a **new attempt dir** (new `pid_dir`), so the leftover server has **no matching reuse metadata**, and Magpie aborts the fresh warmup in ~2s with:

  > `Reuse metadata mismatch (missing reuse metadata JSON ...); running server on PORT=8888 is incompatible with this benchmark config or leftover state is stale.`

- A **leaked server from a prior job** (or a co-tenant job) on the same host port triggers the same abort.

Every retry re-uses `8888` and re-collides, so the baseline **never records an accuracy** and the run stops with `baseline_accuracy_failed` — even though the model serves correctly. Observed on `Qwen/Qwen3-0.6B` (vLLM, bf16): the eval actually scores ~0.66 but the gate saw `0.0`.

## Fix

`resolve_lifecycle_params` now **always probes a free ephemeral port** (`_pick_free_port`, via `bind(("", 0))`) for the persistent server instead of the fixed default. Both double-run rounds share the resolved port (via `inject_lifecycle` → `envs.PORT`), so the server bind, Magpie reuse keying, the lm-eval `base_url`, and teardown all agree. A leaked/co-tenant server on the old fixed port can no longer collide.

This is safer than a node-wide process kill (which would also reap co-tenant servers). No new config knobs; a free port is always used.

## Testing

- **Unit**: `test_baseline_warmup_double_run.py` + `test_grid_runner_behavior_lock.py::TestAutoWarmupTeardown` — **44 passed**. Tests that assert a specific port monkeypatch `_pick_free_port` to return `8888`.
- **End-to-end**: a `Qwen3-0.6B` baseline run **passes on the first attempt** — lifecycle uses a unique free port (e.g. `45597`), no `Reuse metadata mismatch`, `baseline_accuracy=0.66`, `tput=13797`, `stop_reason=""` (no more `baseline_accuracy_failed`).
