### PR TITLE
[WIP] fix(kernel): delegate Forge driver fallback to task preparer

### DIFF
--- a/src/hyperloom/agents/kernel/tests/test_forge_submit_driver_fallback.py
+++ b/src/hyperloom/agents/kernel/tests/test_forge_submit_driver_fallback.py
@@ -1,0 +1,108 @@
+"""Regression tests for Forge driver fallback delegation."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKENDS_DIR = Path(__file__).resolve().parent.parent / "tools" / "backends"
+sys.path.insert(0, str(_BACKENDS_DIR))
+import forge_submit  # noqa: E402
+
+
+def _submit_with_stubbed_loop(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    test_command: str = "",
+    autogen_driver: str | None = None,
+) -> tuple[dict, dict]:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    kernel = workspace / "kernel.py"
+    kernel.write_text("def kernel(x):\n    return x\n")
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text("# Optimize kernel\n")
+    output_dir = tmp_path / "forge" / "session" / "attempt"
+    captured: dict = {}
+
+    monkeypatch.setattr(forge_submit, "_needs_inplace", lambda _repo: False)
+    monkeypatch.setattr(
+        forge_submit,
+        "_prepare_worktree",
+        lambda *_args, **_kwargs: (str(workspace), str(kernel), "base-commit"),
+    )
+    monkeypatch.setattr(forge_submit, "_ensure_forge_on_path", lambda: "")
+    monkeypatch.setattr(forge_submit, "_resolve_gpu_target", lambda _candidate: "gfx942")
+    monkeypatch.setattr(
+        forge_submit,
+        "_autogen_forge_driver",
+        lambda *_args, **_kwargs: autogen_driver,
+    )
+    monkeypatch.setattr(
+        forge_submit,
+        "_export_best_artifacts",
+        lambda *_args, **_kwargs: ("", []),
+    )
+    monkeypatch.setattr(
+        forge_submit,
+        "_write_report",
+        lambda out, *_args, **_kwargs: out / "optimization_report.md",
+    )
+    monkeypatch.setattr(forge_submit, "_remove_worktree", lambda *_args, **_kwargs: None)
+
+    def fake_run_loop(**kwargs):
+        captured.update(kwargs)
+        return 1.0, 0.9, True, "loop completed", None
+
+    monkeypatch.setattr(forge_submit, "_run_loop_via_cli", fake_run_loop)
+
+    result = forge_submit.submit(
+        source_file=str(kernel),
+        prompt_file=prompt,
+        output_dir=output_dir,
+        test_command=test_command,
+        source_type="triton",
+        candidate={"operation": "unsupported_op"},
+        timeout_s=60,
+        kernel_repo=str(workspace),
+    )
+    return result, captured
+
+
+def test_missing_autogen_driver_reaches_forge_loop_task_preparer(monkeypatch, tmp_path):
+    result, captured = _submit_with_stubbed_loop(monkeypatch, tmp_path)
+
+    assert result["returncode"] == 0
+    assert result["skipped"] is False
+    assert captured["driver"].endswith("forge_task_driver.py")
+    assert not Path(captured["driver"]).exists()
+
+
+def test_adapter_and_autogen_failure_reaches_task_preparer(monkeypatch, tmp_path):
+    result, captured = _submit_with_stubbed_loop(
+        monkeypatch,
+        tmp_path,
+        test_command="python bench.py && echo unsafe",
+    )
+
+    assert result["returncode"] == 0
+    assert result["skipped"] is False
+    assert captured["driver"].endswith("forge_task_driver.py")
+
+
+def test_compile_only_driver_reaches_forge_loop_task_preparer(monkeypatch, tmp_path):
+    driver = tmp_path / "compile_only_driver.py"
+    driver.write_text('print("compile_only: True")\n')
+
+    result, captured = _submit_with_stubbed_loop(
+        monkeypatch,
+        tmp_path,
+        autogen_driver=str(driver),
+    )
+
+    assert result["returncode"] == 0
+    assert result["skipped"] is False
+    assert captured["driver"] == str(driver)

--- a/src/hyperloom/agents/kernel/tools/backends/forge_submit.py
+++ b/src/hyperloom/agents/kernel/tools/backends/forge_submit.py
@@ -1993,32 +1993,48 @@ def submit(
 
         # Driver: use the Hyperloom harness when present; otherwise auto-generate
         # a Forge-native driver from the candidate's operation + input_shapes.
+        # If neither path can produce a usable file, still invoke forge-loop with
+        # a missing driver path. Its task-preparer owns the final driver-authoring
+        # fallback and will either create a conforming driver or fail explicitly.
+        driver_from_adapter = False
         if test_command:
-            driver = _build_driver_adapter(test_command, workspace, output_dir)
-            log.info("forge driver: harness adapter from test_command")
+            try:
+                driver = _build_driver_adapter(test_command, workspace, output_dir)
+                driver_from_adapter = True
+                log.info("forge driver: harness adapter from test_command")
+            except (OSError, ValueError) as exc:
+                log.warning(
+                    "forge driver: harness adapter failed (%s); trying autogen before task-preparer",
+                    exc,
+                )
+                driver = _autogen_forge_driver(candidate, worktree_kernel, output_dir, inplace=inplace)
+                if driver is not None:
+                    log.info("forge driver: autogen fallback -> %s", driver)
+                else:
+                    driver = str(output_dir / "forge_task_driver.py")
+                    log.warning(
+                        "forge driver: adapter and autogen unavailable; delegating missing driver %s "
+                        "to forge-loop task-preparer",
+                        driver,
+                    )
         else:
             driver = _autogen_forge_driver(candidate, worktree_kernel, output_dir, inplace=inplace)
             if driver is None:
                 log.warning(
-                    "forge driver: autogen failed for op=%r kernel=%s", candidate.get("operation"), worktree_kernel
+                    "forge driver: autogen failed for op=%r kernel=%s; delegating missing "
+                    "driver to forge-loop task-preparer",
+                    candidate.get("operation"),
+                    worktree_kernel,
                 )
-                return _normalized(
-                    2,
-                    "",
-                    "forge: no test_command and could not auto-generate a driver for "
-                    f"operation={candidate.get('operation')!r} kernel={worktree_kernel!r} "
-                    f"(auto-gen supports gemm/matmul/activation/attention and HIP C++ "
-                    "compile-only; other ops need a benchmark/test_command)",
-                    time.time() - started,
-                    skipped=True,
-                )
-            log.info("forge driver: autogen -> %s", driver)
+                driver = str(output_dir / "forge_task_driver.py")
+            else:
+                log.info("forge driver: autogen -> %s", driver)
         gpu_target = _resolve_gpu_target(candidate)
         # Baseline-correctness gate: verify the unmodified kernel passes up
         # front and skip forge cleanly otherwise, instead of spinning the whole
         # budget reverting. Only gates the harness-adapter path (test_command
         # present); disable via FORGE_BASELINE_GATE=0.
-        if test_command and os.environ.get("FORGE_BASELINE_GATE", "1") != "0":
+        if driver_from_adapter and os.environ.get("FORGE_BASELINE_GATE", "1") != "0":
             gate_ok, gate_detail = _baseline_correctness_ok(driver, workspace, gpu_target, timeout_s)
             if not gate_ok:
                 autogen_fallback = _autogen_forge_driver(candidate, worktree_kernel, output_dir, inplace=inplace)
@@ -2030,42 +2046,22 @@ def submit(
                     )
                     driver = autogen_fallback
                 else:
-                    return _normalized(
-                        2,
-                        "",
-                        f"forge skipped: harness baseline correctness invalid "
-                        f"({gate_detail}); not spinning the agent on an "
-                        "unverifiable harness",
-                        time.time() - started,
-                        skipped=True,
+                    log.warning(
+                        "forge driver: harness baseline gate failed (%s) and autogen is "
+                        "unavailable; delegating adapter repair to forge-loop task-preparer",
+                        gate_detail,
                     )
-        # Compile-only drivers cannot produce a real correctness/timing signal,
-        # so any KEEP they yield rests on synthesized metrics. Skip forge for
-        # such kernels unless FORGE_ALLOW_COMPILE_ONLY=1.
-        if os.environ.get("FORGE_ALLOW_COMPILE_ONLY", "0").strip().lower() not in (
-            "1",
-            "true",
-            "yes",
-        ) and _driver_is_compile_only(driver):
-            # Log the skip so session stats / RCA can see why forge attempt
-            # counts dropped.
+        # Compile-only drivers are deliberately non-conforming: forge-loop's
+        # task-preparer must replace them with a real correctness/performance
+        # driver before the optimization loop can start.
+        if _driver_is_compile_only(driver):
             log.warning(
-                "forge skipped (compile-only, no real harness): source_file=%s "
-                "source_type=%s kernel_kind=%s op=%s -- falling through to next "
-                "backend (set FORGE_ALLOW_COMPILE_ONLY=1 to override)",
+                "forge driver is compile-only: source_file=%s source_type=%s "
+                "kernel_kind=%s op=%s; delegating to forge-loop task-preparer",
                 source_file,
                 source_type,
                 kernel_kind or "-",
                 (candidate or {}).get("operation", ""),
-            )
-            return _normalized(
-                2,
-                "",
-                "forge skipped: only a compile-only driver is available (no real "
-                "correctness/timing harness); not driving a KEEP decision off "
-                "synthesized metrics (set FORGE_ALLOW_COMPILE_ONLY=1 to override)",
-                time.time() - started,
-                skipped=True,
             )
         # GPU_TARGET is passed via the forge-loop child env (not the parent
         # os.environ, which would leak to sibling ladder backends).


### PR DESCRIPTION
Keep Forge attempts alive when driver generation is unavailable or compile-only so the loop can build a valid measurement harness before optimization.

- Description: what and why
- Linked issue(s): close/fix refs
- Tests: added/updated? commands run?
- Breaking changes: yes/no (details if yes)
