### PR TITLE
fix(magpie-patcher): gate local-server client path with trust-remote-code

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_magpie_patcher.py
+++ b/src/hyperloom/inference_optimizer/tests/test_magpie_patcher.py
@@ -135,7 +135,9 @@ if [[ "$PHASE" == "client" || "$PHASE" == "all" ]]; then
     SERVER_MONITOR_ARGS=()
     magpie_run_benchmark_serving_remote_direct || exit $?
   else
-    run_benchmark_serving --model "$MODEL" || exit $?
+    run_benchmark_serving \
+        --model "$MODEL" \
+        --port "$PORT" || exit $?
   fi
 fi
 if [[ "$PHASE" != "server" && "${RUN_EVAL}" = "true" ]]; then
@@ -249,6 +251,10 @@ def test_sglang_remote_client_trust_patch_is_env_gated(fake_magpie: Path):
     assert '[[ "${MAGPIE_TRUST_REMOTE_CODE:-0}" == "1" ]]' in text
     assert "magpie_run_benchmark_serving_remote_direct trust" in text
     assert "magpie_run_benchmark_serving_remote_direct || exit $?" in text
+    # Local-server (else / run_benchmark_serving) path is gated too.
+    assert "HYPERLOOM_LOCAL_TRUST" in text
+    assert '"${LOCAL_TRUST_ARGS[@]}"' in text
+    assert 'BENCH_TRUST_REMOTE_CODE:-0' in text
     assert "HYPERLOOM_EVAL_CONCURRENCY_FIX" in text
     assert "EVAL_CONCURRENT_REQUESTS" in text
     assert "--concurrent-requests" not in text

--- a/src/hyperloom/inference_optimizer/tests/test_magpie_patcher_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_magpie_patcher_unit.py
@@ -26,6 +26,10 @@ _SGLANG_LEGACY = (
     "#!/bin/bash\n"
     "    SERVER_MONITOR_ARGS=()\n"
     "    magpie_run_benchmark_serving_remote_direct || exit $?\n"
+    "  else\n"
+    "    run_benchmark_serving \\\n"
+    '        --model "$MODEL" \\\n'
+    '        --port "$PORT" || exit $?\n'
     '        run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC || exit $?\n'
 )
 
@@ -199,6 +203,13 @@ def test_is_remote_trust_patched(tmp_path):
         "MAGPIE_TRUST_REMOTE_CODE here\nHYPERLOOM_EVAL_CONCURRENCY_FIX\n",
         encoding="utf-8",
     )
+    # Local-server trust sentinel still missing -> not fully patched.
+    assert mp._is_remote_trust_patched(f) is False
+    f.write_text(
+        "MAGPIE_TRUST_REMOTE_CODE here\nHYPERLOOM_LOCAL_TRUST\n"
+        "HYPERLOOM_EVAL_CONCURRENCY_FIX\n",
+        encoding="utf-8",
+    )
     assert mp._is_remote_trust_patched(f) is True
     assert mp._is_remote_trust_patched(tmp_path / "missing") is False
 
@@ -206,7 +217,8 @@ def test_is_remote_trust_patched(tmp_path):
 def test_apply_remote_trust_already(tmp_path):
     f = tmp_path / "s.sh"
     f.write_text(
-        "MAGPIE_TRUST_REMOTE_CODE\nHYPERLOOM_EVAL_CONCURRENCY_FIX\n",
+        "MAGPIE_TRUST_REMOTE_CODE\nHYPERLOOM_LOCAL_TRUST\n"
+        "HYPERLOOM_EVAL_CONCURRENCY_FIX\n",
         encoding="utf-8",
     )
     assert mp._apply_remote_trust_patch_atomic(f) is True
@@ -218,11 +230,29 @@ def test_apply_remote_trust_legacy_missing(tmp_path):
     assert mp._apply_remote_trust_patch_atomic(f) is False
 
 
+def test_apply_remote_trust_local_block_missing(tmp_path):
+    # Remote-direct block present but the local-server run_benchmark_serving
+    # else branch is absent -> patch must fail loudly (no silent gap).
+    f = tmp_path / "s.sh"
+    f.write_text(
+        "#!/bin/bash\n"
+        "    SERVER_MONITOR_ARGS=()\n"
+        "    magpie_run_benchmark_serving_remote_direct || exit $?\n"
+        '        run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC || exit $?\n',
+        encoding="utf-8",
+    )
+    assert mp._apply_remote_trust_patch_atomic(f) is False
+
+
 def test_apply_remote_trust_applied(tmp_path):
     f = tmp_path / "s.sh"
     f.write_text(_SGLANG_LEGACY, encoding="utf-8")
     assert mp._apply_remote_trust_patch_atomic(f) is True
-    assert "MAGPIE_TRUST_REMOTE_CODE" in f.read_text(encoding="utf-8")
+    patched = f.read_text(encoding="utf-8")
+    assert "MAGPIE_TRUST_REMOTE_CODE" in patched
+    # Local-server (else / run_benchmark_serving) branch also gained the gate.
+    assert "HYPERLOOM_LOCAL_TRUST" in patched
+    assert '"${LOCAL_TRUST_ARGS[@]}"' in patched
 
 
 def test_apply_remote_trust_read_error(tmp_path):

--- a/src/hyperloom/orchestrator/actions/executors/_magpie_patcher.py
+++ b/src/hyperloom/orchestrator/actions/executors/_magpie_patcher.py
@@ -111,6 +111,30 @@ _REMOTE_DIRECT_PATCHED_BLOCK = (
     "    fi\n"
 )
 
+# Local-server SGLang client path (``BENCHMARK_BASE_URL`` unset — e.g. the
+# baseline ``server_lifecycle`` reuse path) calls InferenceX
+# ``run_benchmark_serving`` directly. Unlike the remote-direct path above this
+# branch had NO trust gate, so custom-code tokenizers (Kimi-K2.7-Code, Qwen,
+# ...) failed the client-side tokenizer load even though
+# ``MAGPIE_TRUST_REMOTE_CODE=1`` was exported. Inject the same gate here so both
+# client paths honour the trust env.
+_LOCAL_TRUST_SENTINEL = "HYPERLOOM_LOCAL_TRUST"
+_LOCAL_DIRECT_LEGACY_BLOCK = (
+    "  else\n"
+    "    run_benchmark_serving \\\n"
+    '        --model "$MODEL" \\\n'
+)
+_LOCAL_DIRECT_PATCHED_BLOCK = (
+    "  else\n"
+    "    LOCAL_TRUST_ARGS=()  # HYPERLOOM_LOCAL_TRUST\n"
+    '    if [[ "${MAGPIE_TRUST_REMOTE_CODE:-0}" == "1" || "${BENCH_TRUST_REMOTE_CODE:-0}" == "1" ]]; then\n'
+    "      LOCAL_TRUST_ARGS+=(--trust-remote-code)\n"
+    "    fi\n"
+    "    run_benchmark_serving \\\n"
+    '        "${LOCAL_TRUST_ARGS[@]}" \\\n'
+    '        --model "$MODEL" \\\n'
+)
+
 # Strip the redundant, fatal ``--concurrent-requests <CONC>`` flag from Magpie's
 # generic benchmark scripts: InferenceX's ``run_lm_eval`` rejects it as an
 # unknown flag, aborting the whole script; concurrency still flows via the
@@ -685,9 +709,10 @@ def _apply_patch_atomic_reason(src: Path) -> str:
 def _is_remote_trust_patched(src: Path) -> bool:
     """Return whether SGLang compatibility sentinels are already present.
 
-    Checks BOTH ``MAGPIE_TRUST_REMOTE_CODE`` (remote trust) and
+    Checks ``MAGPIE_TRUST_REMOTE_CODE`` (remote-direct trust),
+    ``HYPERLOOM_LOCAL_TRUST`` (local-server trust) and
     ``HYPERLOOM_EVAL_CONCURRENCY_FIX`` (eval concurrency) so a pre-existing
-    remote-trust patch does not short-circuit the eval-concurrency fix.
+    partial patch does not short-circuit the remaining fixes.
 
     Args:
         src: The ``sglang_mi300x.sh`` file to inspect.
@@ -696,19 +721,20 @@ def _is_remote_trust_patched(src: Path) -> bool:
         True iff both compatibility sentinels are present, False on a miss or
         read error.
     """
-    return file_contains_sentinel(src, _REMOTE_TRUST_SENTINEL, log, "_magpie_patcher") and file_contains_sentinel(
-        src,
-        _EVAL_CONC_SENTINEL,
-        log,
-        "_magpie_patcher",
+    return (
+        file_contains_sentinel(src, _REMOTE_TRUST_SENTINEL, log, "_magpie_patcher")
+        and file_contains_sentinel(src, _LOCAL_TRUST_SENTINEL, log, "_magpie_patcher")
+        and file_contains_sentinel(src, _EVAL_CONC_SENTINEL, log, "_magpie_patcher")
     )
 
 
 def _apply_remote_trust_patch_atomic(src: Path) -> bool:
     """Patch ``sglang_mi300x.sh`` for Hyperloom compatibility.
 
-    Applies two independent compatibility fixes:
-    - remote client trust gating via ``MAGPIE_TRUST_REMOTE_CODE``
+    Applies three independent compatibility fixes:
+    - remote-direct client trust gating via ``MAGPIE_TRUST_REMOTE_CODE``
+    - local-server client trust gating (the ``run_benchmark_serving`` else
+      branch used by the baseline ``server_lifecycle`` reuse path)
     - eval concurrency wiring via ``EVAL_CONCURRENT_REQUESTS`` env (no
       unsupported ``--concurrent-requests`` arg)
 
@@ -739,6 +765,21 @@ def _apply_remote_trust_patch_atomic(src: Path) -> bool:
         patched = patched.replace(
             _REMOTE_DIRECT_LEGACY_BLOCK,
             _REMOTE_DIRECT_PATCHED_BLOCK,
+            1,
+        )
+
+    if _LOCAL_TRUST_SENTINEL not in patched:
+        if _LOCAL_DIRECT_LEGACY_BLOCK not in patched:
+            log.warning(
+                "_magpie_patcher: local benchmark direct-call block not found in "
+                "%s; Magpie custom-tokenizer local-client trust patch could not "
+                "be applied (baseline server_lifecycle reuse path)",
+                src,
+            )
+            return False
+        patched = patched.replace(
+            _LOCAL_DIRECT_LEGACY_BLOCK,
+            _LOCAL_DIRECT_PATCHED_BLOCK,
             1,
         )
 


### PR DESCRIPTION
## Summary

Baseline for custom-code models (e.g. `Kimi-K2.7-Code`) failed at the **client-side tokenizer load** even though the SGLang server booted fine and `MAGPIE_TRUST_REMOTE_CODE=1` / `BENCH_TRUST_REMOTE_CODE=1` were exported. Result: `baseline_acc=0`, `baseline_tput=0`, no leaderboard data.

## Root cause

Magpie's `scripts/benchmark/sglang_mi300x.sh` has **two** client dispatch paths:

```bash
if [[ -n "${BENCHMARK_BASE_URL:-}" ]]; then
    magpie_run_benchmark_serving_remote_direct || exit $?   # path A (remote-direct)
else
    run_benchmark_serving --model "$MODEL" ...              # path B (local-server)
fi
```

`_magpie_patcher.py` only injected the `--trust-remote-code` gate into **path A**. But the baseline `server_lifecycle` reuse path (local server, `BENCHMARK_BASE_URL` unset) takes **path B**, which calls InferenceX `run_benchmark_serving` directly with **no trust gate** — and `run_benchmark_serving` does not read the trust env vars. So `MAGPIE_TRUST_REMOTE_CODE=1` never reached the client tokenizer on that path.

## Fix

Add a symmetric trust gate to path B, honoring both `MAGPIE_TRUST_REMOTE_CODE` and `BENCH_TRUST_REMOTE_CODE`, tracked by a dedicated `HYPERLOOM_LOCAL_TRUST` sentinel so idempotency stays independent of the path-A patch.

## Validation

- Ran the actual `_apply_remote_trust_patch_atomic` against the **real production** `sglang_mi300x.sh`: patch applies, both sentinels present, `LOCAL_TRUST_ARGS` array injected, path-A patch preserved, idempotent on re-apply.
- Patched script passes `bash -n` syntax check.
- Updated unit tests (`test_magpie_patcher.py`, `test_magpie_patcher_unit.py`) to cover the local-server branch and a loud-failure case when the anchor is missing.

## Note

Draft: parked pending the Hyperloom open-source cutover; merge after the freeze lifts.
