### PR TITLE
ci: PR e2e smoke test (single-GPU Hyperloom run on spur)

### DIFF
--- a/.github/scripts/ci-e2e-dispatch.sh
+++ b/.github/scripts/ci-e2e-dispatch.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+# End-to-end CI smoke test: submit ONE single-GPU Hyperloom inference-optimizer
+# run built from *this PR's* branch to the robust-spur orchestration API, poll
+# until terminal, and map Succeeded->green / Failed|timeout->red. The run's
+# workload uid == CLAW_SESSION_ID (the spur task id), printed on every path.
+#
+# Requires: bash, curl, jq on the (self-hosted, in-network) runner.
+#
+# Inputs (env):
+#   ROBUST_BASE       robust-spur ingress base (default crusoe ingress)
+#   SAFE_AK           SaFE API key (ak-...), required
+#   MODEL             HF repo id                     (default Qwen/Qwen3-0.6B)
+#   MODEL_CLASS       dense|moe_mla|moe_swa|moe_mla_nsa|"" (default dense; "" -> auto-infer)
+#   GPUS              physical GPUs per replica       (default 1)
+#   TP                tensor-parallel degree          (default 1)
+#   MAX_HOURS         optimizer time budget (hours)   (default 0.5)
+#   PR_NUMBER         PR number (for the job name)
+#   HEAD_REF          PR head branch name (the code to run)
+#   HEAD_REPO_URL     PR head repo clone url (for forks)
+#   BASE_REPO_URL     base repo clone url (AMD-AGI/Hyperloom)
+#   POLL_INTERVAL_S   seconds between polls            (default 30)
+#   POLL_MAX          max polls before timeout         (default 120 => ~60min)
+#   CI_E2E_PR_CHECK_BASE  shared base for per-PR checkouts (default /shared_nfs/pr_check)
+#
+# Optional live commit status on the PR (all three required to enable):
+#   GH_STATUS_TOKEN   GitHub token with statuses:write (Actions: secrets.GITHUB_TOKEN)
+#   GH_STATUS_REPO    owner/repo (e.g. AMD-AGI/Hyperloom)
+#   GH_STATUS_SHA     PR head sha to attach the status to
+#   GH_STATUS_DETAILS_URL  link back to the Actions run (optional)
+#   STATUS_CONTEXT    status context/name (default ci-e2e/hyperloom-run)
+#   STATUS_INTERVAL_S seconds between status refreshes (default 300 => 5min)
+# On terminal, a sticky PR report comment is upserted when GH_STATUS_TOKEN +
+# GH_STATUS_REPO + numeric PR_NUMBER are set (optional PULSE_SESSION_BASE to link out).
+set -euo pipefail
+
+ROBUST_BASE="${ROBUST_BASE:-https://crusoe.primus-safe.amd.com/robust-spur-api}"
+MODEL="${MODEL:-Qwen/Qwen3-0.6B}"
+MODEL_CLASS="${MODEL_CLASS:-dense}"
+GPUS="${GPUS:-1}"
+TP="${TP:-1}"
+MAX_HOURS="${MAX_HOURS:-0.5}"
+POLL_INTERVAL_S="${POLL_INTERVAL_S:-30}"
+POLL_MAX="${POLL_MAX:-120}"
+API="${ROBUST_BASE%/}/api/v1/orchestration/workloads"
+
+: "${SAFE_AK:?SAFE_AK (SaFE API key) is required}"
+: "${HEAD_REF:?HEAD_REF (PR head branch) is required}"
+
+# Fork PRs: the head branch lives in the contributor's fork, not AMD-AGI/Hyperloom,
+# so clone from the head repo. Same-repo PRs use the base repo.
+SRC_REPO="${BASE_REPO_URL:-https://github.com/AMD-AGI/Hyperloom.git}"
+if [ -n "${HEAD_REPO_URL:-}" ] && [ "${HEAD_REPO_URL}" != "${BASE_REPO_URL:-}" ]; then
+  SRC_REPO="${HEAD_REPO_URL}"
+fi
+# Where the in-container launcher puts this PR's Hyperloom source. We give every PR
+# a stable, inspectable path under a shared base so runs are easy to find/re-clone:
+#     <base>/pr_<N>/hyperloom   (e.g. /shared_nfs/pr_check/pr_971/hyperloom)
+# Override the base with CI_E2E_PR_CHECK_BASE. Point CI_E2E_SOURCE_DIR at an existing
+# checkout to skip cloning entirely. Re-triggered runs pick up new commits because the
+# launcher refreshes this checkout when HL_CI_E2E=1 (see _incontainer.sh.in).
+PR_CHECK_BASE="${CI_E2E_PR_CHECK_BASE:-/shared_nfs/pr_check}"
+SRC_DIR="${CI_E2E_SOURCE_DIR:-${PR_CHECK_BASE%/}/pr_${PR_NUMBER:-manual}/hyperloom}"
+
+summary() { echo "$*" | tee -a "${GITHUB_STEP_SUMMARY:-/dev/null}"; }
+auth=(-H "Authorization: Bearer ${SAFE_AK}")
+
+# TLS to the internal ingress: prefer a CA bundle (CI_E2E_CACERT), fall back to
+# skip-verify only when CI_E2E_INSECURE=1 (test convenience on trusted networks).
+tls=()
+if [ -n "${CI_E2E_CACERT:-}" ]; then
+  tls=(--cacert "$CI_E2E_CACERT")
+elif [ "${CI_E2E_INSECURE:-0}" = "1" ]; then
+  tls=(-k)
+fi
+
+# ---- GitHub commit status (optional live status on the PR) ----------------
+# When GH_STATUS_TOKEN + GH_STATUS_REPO + GH_STATUS_SHA are set we publish a commit
+# status against the PR head sha and refresh it every STATUS_INTERVAL_S, so the PR's
+# checks section shows the live phase without opening the job log. Commit statuses work
+# with both the Actions GITHUB_TOKEN and a personal token. No-op when vars are absent.
+STATUS_INTERVAL_S="${STATUS_INTERVAL_S:-300}"
+STATUS_CONTEXT="${STATUS_CONTEXT:-ci-e2e/hyperloom-run}"
+GH_API="${GH_API:-https://api.github.com}"
+gh_status_on() { [ -n "${GH_STATUS_TOKEN:-}" ] && [ -n "${GH_STATUS_REPO:-}" ] && [ -n "${GH_STATUS_SHA:-}" ]; }
+post_status() { # state(pending|success|failure|error)  description
+  gh_status_on || return 0
+  local desc="${2:0:139}"
+  curl -sS -X POST \
+    -H "Authorization: Bearer ${GH_STATUS_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "${GH_API}/repos/${GH_STATUS_REPO}/statuses/${GH_STATUS_SHA}" \
+    -d "$(jq -n --arg s "$1" --arg d "$desc" --arg u "${GH_STATUS_DETAILS_URL:-}" --arg c "$STATUS_CONTEXT" \
+        '{state:$s, description:$d, context:$c} + (if $u=="" then {} else {target_url:$u} end)')" \
+    >/dev/null 2>&1 || true
+}
+
+# ---- GitHub PR report comment (optional) ----------------------------------
+# On terminal, upsert ONE sticky comment on the PR with a compact run report
+# (metadata + timeline derived from the spur API). Needs GH_STATUS_TOKEN +
+# GH_STATUS_REPO + a numeric PR_NUMBER. Optional: PULSE_SESSION_BASE to link out
+# to the full Pulse dashboard by claw_session_id. No-op when prerequisites absent.
+REPORT_MARKER="<!-- ci-e2e-report:${STATUS_CONTEXT} -->"
+gh_report_on() { [ -n "${GH_STATUS_TOKEN:-}" ] && [ -n "${GH_STATUS_REPO:-}" ] && [[ "${PR_NUMBER:-}" =~ ^[0-9]+$ ]]; }
+_epoch() { date -d "$1" +%s 2>/dev/null || true; }
+_hdur() { local s="${1:-}"; [ -z "$s" ] && { echo "–"; return; }; if [ "$s" -lt 60 ]; then echo "${s}s"; else echo "$((s/60))m $((s%60))s"; fi; }
+
+# Turn a raw platform error into a one-line, plain-language reason a reviewer can act on.
+humanize_reason() {
+  case "$1" in
+    *JobHoldMaxRequeue*)
+      echo "Slurm kept holding & requeuing the job until it gave up — usually a flaky node; just re-run." ;;
+    *baseline_accuracy*|*accuracy_failed*)
+      echo "Baseline accuracy gate failed — the model server ran but the baseline benchmark didn't pass; check the baseline logs." ;;
+    *NonZeroExitCode*|*"exhausted retries"*)
+      echo "The run crashed on the compute node (non-zero exit) — usually a node/env hiccup (e.g. a leftover process holding a port) or a runtime error; often transient, re-run first." ;;
+    *"not terminal"*|*[Tt]imeout*)
+      echo "Timed out — the run never reached a terminal state in time (task stuck, or the GPU stayed queued too long)." ;;
+    *"not associated"*|*user_name*)
+      echo "Dispatch identity rejected — CI_E2E_USER_NAME must be a member of the amd-hyperloom Slurm account." ;;
+    *128*|*Authentication*|*"could not read Username"*)
+      echo "Could not clone the PR code on the compute node — GitHub auth/permission issue." ;;
+    "")
+      echo "Unknown failure — the platform reported no error detail." ;;
+    *)
+      echo "$1" ;;
+  esac
+}
+
+report_upsert() { # result_md (e.g. "✅ Succeeded")
+  gh_report_on || return 0
+  local result="$1" q d qe de nows qd="" rt="" tot="" pulse="" actions="" reason_row="" body cid
+  q="$(printf '%s' "${detail:-}" | jq -r '[.orchestration.conditions[]|select(.phase=="Queued")][0].time // empty' 2>/dev/null || true)"
+  d="$(printf '%s' "${detail:-}" | jq -r '[.orchestration.conditions[]|select(.phase=="Dispatched")][0].time // empty' 2>/dev/null || true)"
+  qe="$(_epoch "$q")"; de="$(_epoch "$d")"; nows="$(date +%s)"
+  [ -n "$qe" ] && [ -n "$de" ] && qd="$(_hdur $((de - qe)))"
+  [ -n "$de" ] && rt="$(_hdur $((nows - de)))"
+  [ -n "$qe" ] && tot="$(_hdur $((nows - qe)))"
+  [ -n "${PULSE_SESSION_BASE:-}" ] && pulse="· [Pulse session](${PULSE_SESSION_BASE%/}/${UID_})"
+  [ -n "${GH_STATUS_DETAILS_URL:-}" ] && actions="[details](${GH_STATUS_DETAILS_URL})"
+  if [ -n "${err:-}" ]; then
+    reason_row="| reason | $(humanize_reason "$err") |
+| detail | \`${err}\` |
+"
+  fi
+  body="${REPORT_MARKER}
+## CI E2E report — ${result}
+
+| item | value |
+|---|---|
+| result | ${result} |
+| model | \`${MODEL}\` (${MODEL_CLASS:-dense}) |
+| resources | ${GPUS}× GPU, TP=${TP} |
+| PR branch | \`${HEAD_REF}\` |
+| claw_session_id | \`${UID_}\` |
+| queue → dispatch | ${qd:-–} |
+| run time | ${rt:-–} |
+| total | ${tot:-–} |
+${reason_row}
+${actions} ${pulse}"
+  cid="$(curl -sS -H "Authorization: Bearer ${GH_STATUS_TOKEN}" -H "Accept: application/vnd.github+json" \
+    "${GH_API}/repos/${GH_STATUS_REPO}/issues/${PR_NUMBER}/comments?per_page=100" 2>/dev/null \
+    | jq -r --arg m "$REPORT_MARKER" '[.[]|select(.body|contains($m))|.id][0] // empty' 2>/dev/null || true)"
+  if [ -n "$cid" ]; then
+    curl -sS -X PATCH -H "Authorization: Bearer ${GH_STATUS_TOKEN}" -H "Accept: application/vnd.github+json" \
+      "${GH_API}/repos/${GH_STATUS_REPO}/issues/comments/${cid}" \
+      -d "$(jq -n --arg b "$body" '{body:$b}')" >/dev/null 2>&1 || true
+  else
+    curl -sS -X POST -H "Authorization: Bearer ${GH_STATUS_TOKEN}" -H "Accept: application/vnd.github+json" \
+      "${GH_API}/repos/${GH_STATUS_REPO}/issues/${PR_NUMBER}/comments" \
+      -d "$(jq -n --arg b "$body" '{body:$b}')" >/dev/null 2>&1 || true
+  fi
+}
+
+# ---- submit ---------------------------------------------------------------
+params="$(jq -n \
+  --arg repo_id "$MODEL" --arg tp "$TP" --arg mh "$MAX_HOURS" \
+  --arg ref "$HEAD_REF" --arg srcrepo "$SRC_REPO" --arg srcdir "$SRC_DIR" \
+  --arg mc "$MODEL_CLASS" --arg mbase "${CI_E2E_MODEL_BASE:-}" \
+  '{REPO_ID:$repo_id, TP:$tp, MAX_HOURS:$mh,
+    HYPERLOOM_SOURCE_REF:$ref, HYPERLOOM_SOURCE_REPO:$srcrepo, HYPERLOOM_SOURCE_DIR:$srcdir}
+   + (if $mc == "" then {} else {MODEL_CLASS:$mc} end)
+   + (if $mbase == "" then {} else {HL_MODEL_BASE:$mbase} end)')"
+body="$(jq -n \
+  --arg name "ci-pr-${PR_NUMBER:-manual}-${GITHUB_RUN_ID:-local}" \
+  --arg uname "${CI_E2E_USER_NAME:-}" \
+  --argjson gpus "$GPUS" --argjson params "$params" \
+  '{name:$name, infra_type:"spur", kind:"hyperloom", replicas:1,
+    gpu_per_replica:$gpus, template:{params:$params, env:{HL_CI_E2E:"1"}}}
+   + (if $uname == "" then {} else {user_name:$uname} end)')"
+
+echo "[ci-e2e] submitting: model=$MODEL ref=$HEAD_REF gpus=$GPUS tp=$TP max_hours=$MAX_HOURS"
+resp="$(curl -sS "${tls[@]}" -w $'\n%{http_code}' -X POST "$API" \
+  "${auth[@]}" -H "Content-Type: application/json" -d "$body")"
+code="$(printf '%s' "$resp" | tail -n1)"
+json="$(printf '%s' "$resp" | sed '$d')"
+
+if [ "$code" -lt 200 ] || [ "$code" -ge 300 ]; then
+  summary "❌ submit failed (HTTP $code): $(printf '%s' "$json" | head -c 500)"
+  exit 1
+fi
+UID_="$(printf '%s' "$json" | jq -r '.uid // empty')"
+if [ -z "$UID_" ]; then
+  summary "❌ submit returned no uid: $(printf '%s' "$json" | head -c 500)"
+  exit 1
+fi
+summary "**claw_session_id (workload uid):** \`$UID_\`"
+echo "claw_session_id=$UID_" >> "${GITHUB_OUTPUT:-/dev/null}"
+# Persist the uid so a workflow `if: cancelled()` step can DELETE the workload even
+# if this process is hard-killed on cancel (the trap below is best-effort only).
+echo "$UID_" > "${CLAW_UID_FILE:-${RUNNER_TEMP:-/tmp}/claw_uid}" 2>/dev/null || true
+
+# Seed the live commit status (no-op unless GH_STATUS_* are set).
+post_status "pending" "submitted; uid=${UID_}; model=${MODEL} ref=${HEAD_REF}"
+last_push="$(date +%s)"
+
+# On cancellation (e.g. a newer commit via concurrency cancel-in-progress),
+# best-effort cancel the spur workload so we don't leak a GPU run.
+cleanup() { curl -sS "${tls[@]}" -X DELETE "$API/$UID_" "${auth[@]}" >/dev/null 2>&1 || true; }
+trap 'echo "[ci-e2e] cancelled; deleting workload $UID_"; post_status "error" "cancelled (newer commit or manual stop); uid=${UID_}"; cleanup; exit 1' INT TERM
+
+# ---- poll -----------------------------------------------------------------
+i=0
+prev_phase=""
+while [ "$i" -lt "$POLL_MAX" ]; do
+  i=$((i + 1))
+  detail="$(curl -sS "${tls[@]}" "$API/$UID_" "${auth[@]}" || true)"
+  phase="$(printf '%s' "$detail" | jq -r '.orchestration.phase // "Unknown"' 2>/dev/null || echo Unknown)"
+  spur="$(printf '%s' "$detail" | jq -r '.dispatches[-1].platform_ref // "-"' 2>/dev/null || echo -)"
+  node="$(printf '%s' "$detail" | jq -r '.dispatches[-1].nodes // "-"' 2>/dev/null || echo -)"
+  echo "[ci-e2e] poll $i/$POLL_MAX phase=$phase node=$node spur_job=$spur uid=$UID_"
+  # Announce phase transitions (from the orchestration conditions ledger).
+  if [ "$phase" != "$prev_phase" ]; then
+    cond="$(printf '%s' "$detail" | jq -r '.orchestration.conditions[-1] | "\(.time) \(.phase): \(.message)"' 2>/dev/null || echo "")"
+    echo "[ci-e2e]   >> phase ${prev_phase:-<start>} -> ${phase}${cond:+   ($cond)}"
+    prev_phase="$phase"
+  fi
+  case "$phase" in
+    Succeeded)
+      summary "✅ **PASS** — run completed. claw_session_id=\`$UID_\` spur_job=\`$spur\`"
+      post_status "success" "PASS — Succeeded; uid=${UID_}; spur_job=${spur}"
+      report_upsert "✅ Succeeded"
+      exit 0 ;;
+    Failed)
+      err="$(printf '%s' "$detail" | jq -r '.orchestration.last_error // (.orchestration.conditions[-1].message) // "unknown"' 2>/dev/null)"
+      summary "❌ **FAIL** — claw_session_id=\`$UID_\` spur_job=\`$spur\` node=\`$node\`"
+      summary "reason: $err"
+      post_status "failure" "$(humanize_reason "$err")"
+      report_upsert "❌ Failed"
+      exit 1 ;;
+  esac
+  # Throttled live status: push at most once per STATUS_INTERVAL_S (default 5min).
+  now_s="$(date +%s)"
+  if [ $((now_s - last_push)) -ge "$STATUS_INTERVAL_S" ]; then
+    post_status "pending" "running phase=${phase} (poll ${i}/${POLL_MAX}); spur_job=${spur}; uid=${UID_}"
+    last_push="$now_s"
+  fi
+  sleep "$POLL_INTERVAL_S"
+done
+
+err="not terminal after $((POLL_MAX * POLL_INTERVAL_S))s"
+summary "❌ **FAIL (timeout)** — ${err}. claw_session_id=\`$UID_\`"
+post_status "failure" "FAIL (timeout) after $((POLL_MAX * POLL_INTERVAL_S))s; uid=${UID_}"
+report_upsert "❌ Timeout"
+cleanup
+exit 1

--- a/.github/scripts/ci-e2e-dispatch.sh
+++ b/.github/scripts/ci-e2e-dispatch.sh
@@ -1,39 +1,41 @@
 #!/usr/bin/env bash
-# End-to-end CI smoke test: submit ONE single-GPU Hyperloom inference-optimizer
-# run built from *this PR's* branch to the robust-spur orchestration API, poll
-# until terminal, and map Succeeded->green / Failed|timeout->red. The run's
-# workload uid == CLAW_SESSION_ID (the spur task id), printed on every path.
+# End-to-end CI smoke test: submit ONE single-GPU inference-optimizer run built from
+# *this PR's* branch to the run API, poll until terminal, and map
+# Succeeded -> green / Failed|timeout -> red. The run's workload uid == session_id,
+# printed on every path.
 #
 # Requires: bash, curl, jq on the (self-hosted, in-network) runner.
 #
 # Inputs (env):
-#   ROBUST_BASE       robust-spur ingress base (default crusoe ingress)
-#   SAFE_AK           SaFE API key (ak-...), required
-#   MODEL             HF repo id                     (default Qwen/Qwen3-0.6B)
+#   E2E_API_BASE      run API base url                 (required)
+#   E2E_API_KEY       API key                          (required)
+#   E2E_INFRA_TYPE    infra type for the submission    (required)
+#   MODEL             HF repo id                       (default Qwen/Qwen3-0.6B)
 #   MODEL_CLASS       dense|moe_mla|moe_swa|moe_mla_nsa|"" (default dense; "" -> auto-infer)
-#   GPUS              physical GPUs per replica       (default 1)
-#   TP                tensor-parallel degree          (default 1)
-#   MAX_HOURS         optimizer time budget (hours)   (default 0.5)
+#   GPUS              physical GPUs per replica        (default 1)
+#   TP                tensor-parallel degree           (default 1)
+#   MAX_HOURS         optimizer time budget (hours)    (default 0.5)
 #   PR_NUMBER         PR number (for the job name)
 #   HEAD_REF          PR head branch name (the code to run)
 #   HEAD_REPO_URL     PR head repo clone url (for forks)
-#   BASE_REPO_URL     base repo clone url (AMD-AGI/Hyperloom)
-#   POLL_INTERVAL_S   seconds between polls            (default 30)
-#   POLL_MAX          max polls before timeout         (default 120 => ~60min)
-#   CI_E2E_PR_CHECK_BASE  shared base for per-PR checkouts (default /shared_nfs/pr_check)
+#   BASE_REPO_URL     base repo clone url
+#   MODEL_BASE        local model base dir (optional; backend fills if empty)
+#   POLL_INTERVAL_S   seconds between polls             (default 30)
+#   POLL_MAX          max polls before timeout          (default 120 => ~60min)
+#   CI_E2E_PR_CHECK_BASE  base dir for per-PR checkouts (default /tmp/ci-e2e)
+#   CI_E2E_CACERT / CI_E2E_INSECURE   TLS to the API endpoint (CA bundle / skip-verify)
 #
 # Optional live commit status on the PR (all three required to enable):
 #   GH_STATUS_TOKEN   GitHub token with statuses:write (Actions: secrets.GITHUB_TOKEN)
-#   GH_STATUS_REPO    owner/repo (e.g. AMD-AGI/Hyperloom)
+#   GH_STATUS_REPO    owner/repo
 #   GH_STATUS_SHA     PR head sha to attach the status to
 #   GH_STATUS_DETAILS_URL  link back to the Actions run (optional)
-#   STATUS_CONTEXT    status context/name (default ci-e2e/hyperloom-run)
+#   STATUS_CONTEXT    status context/name (default ci-e2e/run)
 #   STATUS_INTERVAL_S seconds between status refreshes (default 300 => 5min)
 # On terminal, a sticky PR report comment is upserted when GH_STATUS_TOKEN +
-# GH_STATUS_REPO + numeric PR_NUMBER are set (optional PULSE_SESSION_BASE to link out).
+# GH_STATUS_REPO + numeric PR_NUMBER are set.
 set -euo pipefail
 
-ROBUST_BASE="${ROBUST_BASE:-https://crusoe.primus-safe.amd.com/robust-spur-api}"
 MODEL="${MODEL:-Qwen/Qwen3-0.6B}"
 MODEL_CLASS="${MODEL_CLASS:-dense}"
 GPUS="${GPUS:-1}"
@@ -41,31 +43,31 @@ TP="${TP:-1}"
 MAX_HOURS="${MAX_HOURS:-0.5}"
 POLL_INTERVAL_S="${POLL_INTERVAL_S:-30}"
 POLL_MAX="${POLL_MAX:-120}"
-API="${ROBUST_BASE%/}/api/v1/orchestration/workloads"
 
-: "${SAFE_AK:?SAFE_AK (SaFE API key) is required}"
+: "${E2E_API_BASE:?E2E_API_BASE is required}"
+: "${E2E_API_KEY:?E2E_API_KEY is required}"
+: "${E2E_INFRA_TYPE:?E2E_INFRA_TYPE is required}"
 : "${HEAD_REF:?HEAD_REF (PR head branch) is required}"
+API="${E2E_API_BASE%/}/api/v1/orchestration/workloads"
 
-# Fork PRs: the head branch lives in the contributor's fork, not AMD-AGI/Hyperloom,
-# so clone from the head repo. Same-repo PRs use the base repo.
-SRC_REPO="${BASE_REPO_URL:-https://github.com/AMD-AGI/Hyperloom.git}"
+# Fork PRs: the head branch lives in the contributor's fork, so clone from the head
+# repo. Same-repo PRs use the base repo.
+SRC_REPO="${BASE_REPO_URL:-}"
 if [ -n "${HEAD_REPO_URL:-}" ] && [ "${HEAD_REPO_URL}" != "${BASE_REPO_URL:-}" ]; then
   SRC_REPO="${HEAD_REPO_URL}"
 fi
-# Where the in-container launcher puts this PR's Hyperloom source. We give every PR
-# a stable, inspectable path under a shared base so runs are easy to find/re-clone:
-#     <base>/pr_<N>/hyperloom   (e.g. /shared_nfs/pr_check/pr_971/hyperloom)
-# Override the base with CI_E2E_PR_CHECK_BASE. Point CI_E2E_SOURCE_DIR at an existing
-# checkout to skip cloning entirely. Re-triggered runs pick up new commits because the
-# launcher refreshes this checkout when HL_CI_E2E=1 (see _incontainer.sh.in).
-PR_CHECK_BASE="${CI_E2E_PR_CHECK_BASE:-/shared_nfs/pr_check}"
+# Where the launcher puts this PR's source: a stable, inspectable per-PR path under a
+# shared base (<base>/pr_<N>/hyperloom). Override the base with CI_E2E_PR_CHECK_BASE,
+# or point CI_E2E_SOURCE_DIR at an existing checkout to skip cloning. Re-triggered runs
+# pick up new commits because the launcher refreshes this checkout when HL_CI_E2E=1.
+PR_CHECK_BASE="${CI_E2E_PR_CHECK_BASE:-/tmp/ci-e2e}"
 SRC_DIR="${CI_E2E_SOURCE_DIR:-${PR_CHECK_BASE%/}/pr_${PR_NUMBER:-manual}/hyperloom}"
 
 summary() { echo "$*" | tee -a "${GITHUB_STEP_SUMMARY:-/dev/null}"; }
-auth=(-H "Authorization: Bearer ${SAFE_AK}")
+auth=(-H "Authorization: Bearer ${E2E_API_KEY}")
 
-# TLS to the internal ingress: prefer a CA bundle (CI_E2E_CACERT), fall back to
-# skip-verify only when CI_E2E_INSECURE=1 (test convenience on trusted networks).
+# TLS to the API endpoint: prefer a CA bundle (CI_E2E_CACERT), fall back to skip-verify
+# only when CI_E2E_INSECURE=1 (test convenience on trusted networks).
 tls=()
 if [ -n "${CI_E2E_CACERT:-}" ]; then
   tls=(--cacert "$CI_E2E_CACERT")
@@ -76,10 +78,9 @@ fi
 # ---- GitHub commit status (optional live status on the PR) ----------------
 # When GH_STATUS_TOKEN + GH_STATUS_REPO + GH_STATUS_SHA are set we publish a commit
 # status against the PR head sha and refresh it every STATUS_INTERVAL_S, so the PR's
-# checks section shows the live phase without opening the job log. Commit statuses work
-# with both the Actions GITHUB_TOKEN and a personal token. No-op when vars are absent.
+# checks section shows the live phase without opening the job log. No-op when absent.
 STATUS_INTERVAL_S="${STATUS_INTERVAL_S:-300}"
-STATUS_CONTEXT="${STATUS_CONTEXT:-ci-e2e/hyperloom-run}"
+STATUS_CONTEXT="${STATUS_CONTEXT:-ci-e2e/run}"
 GH_API="${GH_API:-https://api.github.com}"
 gh_status_on() { [ -n "${GH_STATUS_TOKEN:-}" ] && [ -n "${GH_STATUS_REPO:-}" ] && [ -n "${GH_STATUS_SHA:-}" ]; }
 post_status() { # state(pending|success|failure|error)  description
@@ -97,9 +98,7 @@ post_status() { # state(pending|success|failure|error)  description
 
 # ---- GitHub PR report comment (optional) ----------------------------------
 # On terminal, upsert ONE sticky comment on the PR with a compact run report
-# (metadata + timeline derived from the spur API). Needs GH_STATUS_TOKEN +
-# GH_STATUS_REPO + a numeric PR_NUMBER. Optional: PULSE_SESSION_BASE to link out
-# to the full Pulse dashboard by claw_session_id. No-op when prerequisites absent.
+# (metadata + timeline). Needs GH_STATUS_TOKEN + GH_STATUS_REPO + numeric PR_NUMBER.
 REPORT_MARKER="<!-- ci-e2e-report:${STATUS_CONTEXT} -->"
 gh_report_on() { [ -n "${GH_STATUS_TOKEN:-}" ] && [ -n "${GH_STATUS_REPO:-}" ] && [[ "${PR_NUMBER:-}" =~ ^[0-9]+$ ]]; }
 _epoch() { date -d "$1" +%s 2>/dev/null || true; }
@@ -109,17 +108,17 @@ _hdur() { local s="${1:-}"; [ -z "$s" ] && { echo "–"; return; }; if [ "$s" -l
 humanize_reason() {
   case "$1" in
     *JobHoldMaxRequeue*)
-      echo "Slurm kept holding & requeuing the job until it gave up — usually a flaky node; just re-run." ;;
+      echo "The scheduler kept holding & requeuing the job until it gave up — usually a flaky node; just re-run." ;;
     *baseline_accuracy*|*accuracy_failed*)
       echo "Baseline accuracy gate failed — the model server ran but the baseline benchmark didn't pass; check the baseline logs." ;;
     *NonZeroExitCode*|*"exhausted retries"*)
-      echo "The run crashed on the compute node (non-zero exit) — usually a node/env hiccup (e.g. a leftover process holding a port) or a runtime error; often transient, re-run first." ;;
+      echo "The run exited non-zero on the node — usually a node/env hiccup (e.g. a leftover process holding a port) or a runtime error; often transient, re-run first." ;;
     *"not terminal"*|*[Tt]imeout*)
       echo "Timed out — the run never reached a terminal state in time (task stuck, or the GPU stayed queued too long)." ;;
     *"not associated"*|*user_name*)
-      echo "Dispatch identity rejected — CI_E2E_USER_NAME must be a member of the amd-hyperloom Slurm account." ;;
+      echo "Dispatch identity rejected — CI_E2E_USER_NAME must be an account the runs are allowed to dispatch under." ;;
     *128*|*Authentication*|*"could not read Username"*)
-      echo "Could not clone the PR code on the compute node — GitHub auth/permission issue." ;;
+      echo "Could not clone the PR code on the node — GitHub auth/permission issue." ;;
     "")
       echo "Unknown failure — the platform reported no error detail." ;;
     *)
@@ -129,14 +128,13 @@ humanize_reason() {
 
 report_upsert() { # result_md (e.g. "✅ Succeeded")
   gh_report_on || return 0
-  local result="$1" q d qe de nows qd="" rt="" tot="" pulse="" actions="" reason_row="" body cid
+  local result="$1" q d qe de nows qd="" rt="" tot="" actions="" reason_row="" body cid
   q="$(printf '%s' "${detail:-}" | jq -r '[.orchestration.conditions[]|select(.phase=="Queued")][0].time // empty' 2>/dev/null || true)"
   d="$(printf '%s' "${detail:-}" | jq -r '[.orchestration.conditions[]|select(.phase=="Dispatched")][0].time // empty' 2>/dev/null || true)"
   qe="$(_epoch "$q")"; de="$(_epoch "$d")"; nows="$(date +%s)"
   [ -n "$qe" ] && [ -n "$de" ] && qd="$(_hdur $((de - qe)))"
   [ -n "$de" ] && rt="$(_hdur $((nows - de)))"
   [ -n "$qe" ] && tot="$(_hdur $((nows - qe)))"
-  [ -n "${PULSE_SESSION_BASE:-}" ] && pulse="· [Pulse session](${PULSE_SESSION_BASE%/}/${UID_})"
   [ -n "${GH_STATUS_DETAILS_URL:-}" ] && actions="[details](${GH_STATUS_DETAILS_URL})"
   if [ -n "${err:-}" ]; then
     reason_row="| reason | $(humanize_reason "$err") |
@@ -152,12 +150,12 @@ report_upsert() { # result_md (e.g. "✅ Succeeded")
 | model | \`${MODEL}\` (${MODEL_CLASS:-dense}) |
 | resources | ${GPUS}× GPU, TP=${TP} |
 | PR branch | \`${HEAD_REF}\` |
-| claw_session_id | \`${UID_}\` |
+| session_id | \`${UID_}\` |
 | queue → dispatch | ${qd:-–} |
 | run time | ${rt:-–} |
 | total | ${tot:-–} |
 ${reason_row}
-${actions} ${pulse}"
+${actions}"
   cid="$(curl -sS -H "Authorization: Bearer ${GH_STATUS_TOKEN}" -H "Accept: application/vnd.github+json" \
     "${GH_API}/repos/${GH_STATUS_REPO}/issues/${PR_NUMBER}/comments?per_page=100" 2>/dev/null \
     | jq -r --arg m "$REPORT_MARKER" '[.[]|select(.body|contains($m))|.id][0] // empty' 2>/dev/null || true)"
@@ -176,16 +174,16 @@ ${actions} ${pulse}"
 params="$(jq -n \
   --arg repo_id "$MODEL" --arg tp "$TP" --arg mh "$MAX_HOURS" \
   --arg ref "$HEAD_REF" --arg srcrepo "$SRC_REPO" --arg srcdir "$SRC_DIR" \
-  --arg mc "$MODEL_CLASS" --arg mbase "${CI_E2E_MODEL_BASE:-}" \
+  --arg mc "$MODEL_CLASS" --arg mbase "${MODEL_BASE:-}" \
   '{REPO_ID:$repo_id, TP:$tp, MAX_HOURS:$mh,
     HYPERLOOM_SOURCE_REF:$ref, HYPERLOOM_SOURCE_REPO:$srcrepo, HYPERLOOM_SOURCE_DIR:$srcdir}
    + (if $mc == "" then {} else {MODEL_CLASS:$mc} end)
    + (if $mbase == "" then {} else {HL_MODEL_BASE:$mbase} end)')"
 body="$(jq -n \
   --arg name "ci-pr-${PR_NUMBER:-manual}-${GITHUB_RUN_ID:-local}" \
-  --arg uname "${CI_E2E_USER_NAME:-}" \
+  --arg uname "${CI_E2E_USER_NAME:-}" --arg itype "$E2E_INFRA_TYPE" \
   --argjson gpus "$GPUS" --argjson params "$params" \
-  '{name:$name, infra_type:"spur", kind:"hyperloom", replicas:1,
+  '{name:$name, infra_type:$itype, kind:"hyperloom", replicas:1,
     gpu_per_replica:$gpus, template:{params:$params, env:{HL_CI_E2E:"1"}}}
    + (if $uname == "" then {} else {user_name:$uname} end)')"
 
@@ -204,18 +202,18 @@ if [ -z "$UID_" ]; then
   summary "❌ submit returned no uid: $(printf '%s' "$json" | head -c 500)"
   exit 1
 fi
-summary "**claw_session_id (workload uid):** \`$UID_\`"
-echo "claw_session_id=$UID_" >> "${GITHUB_OUTPUT:-/dev/null}"
-# Persist the uid so a workflow `if: cancelled()` step can DELETE the workload even
+summary "**session_id (workload uid):** \`$UID_\`"
+echo "session_id=$UID_" >> "${GITHUB_OUTPUT:-/dev/null}"
+# Persist the uid so a workflow `if: cancelled()` step can cancel the workload even
 # if this process is hard-killed on cancel (the trap below is best-effort only).
-echo "$UID_" > "${CLAW_UID_FILE:-${RUNNER_TEMP:-/tmp}/claw_uid}" 2>/dev/null || true
+echo "$UID_" > "${E2E_UID_FILE:-${RUNNER_TEMP:-/tmp}/e2e_session_uid}" 2>/dev/null || true
 
 # Seed the live commit status (no-op unless GH_STATUS_* are set).
 post_status "pending" "submitted; uid=${UID_}; model=${MODEL} ref=${HEAD_REF}"
 last_push="$(date +%s)"
 
 # On cancellation (e.g. a newer commit via concurrency cancel-in-progress),
-# best-effort cancel the spur workload so we don't leak a GPU run.
+# best-effort cancel the workload so we don't leak a GPU run.
 cleanup() { curl -sS "${tls[@]}" -X DELETE "$API/$UID_" "${auth[@]}" >/dev/null 2>&1 || true; }
 trap 'echo "[ci-e2e] cancelled; deleting workload $UID_"; post_status "error" "cancelled (newer commit or manual stop); uid=${UID_}"; cleanup; exit 1' INT TERM
 
@@ -226,9 +224,9 @@ while [ "$i" -lt "$POLL_MAX" ]; do
   i=$((i + 1))
   detail="$(curl -sS "${tls[@]}" "$API/$UID_" "${auth[@]}" || true)"
   phase="$(printf '%s' "$detail" | jq -r '.orchestration.phase // "Unknown"' 2>/dev/null || echo Unknown)"
-  spur="$(printf '%s' "$detail" | jq -r '.dispatches[-1].platform_ref // "-"' 2>/dev/null || echo -)"
+  jobref="$(printf '%s' "$detail" | jq -r '.dispatches[-1].platform_ref // "-"' 2>/dev/null || echo -)"
   node="$(printf '%s' "$detail" | jq -r '.dispatches[-1].nodes // "-"' 2>/dev/null || echo -)"
-  echo "[ci-e2e] poll $i/$POLL_MAX phase=$phase node=$node spur_job=$spur uid=$UID_"
+  echo "[ci-e2e] poll $i/$POLL_MAX phase=$phase node=$node job=$jobref uid=$UID_"
   # Announce phase transitions (from the orchestration conditions ledger).
   if [ "$phase" != "$prev_phase" ]; then
     cond="$(printf '%s' "$detail" | jq -r '.orchestration.conditions[-1] | "\(.time) \(.phase): \(.message)"' 2>/dev/null || echo "")"
@@ -237,13 +235,13 @@ while [ "$i" -lt "$POLL_MAX" ]; do
   fi
   case "$phase" in
     Succeeded)
-      summary "✅ **PASS** — run completed. claw_session_id=\`$UID_\` spur_job=\`$spur\`"
-      post_status "success" "PASS — Succeeded; uid=${UID_}; spur_job=${spur}"
+      summary "✅ **PASS** — run completed. session_id=\`$UID_\` job=\`$jobref\`"
+      post_status "success" "PASS — Succeeded; uid=${UID_}; job=${jobref}"
       report_upsert "✅ Succeeded"
       exit 0 ;;
     Failed)
       err="$(printf '%s' "$detail" | jq -r '.orchestration.last_error // (.orchestration.conditions[-1].message) // "unknown"' 2>/dev/null)"
-      summary "❌ **FAIL** — claw_session_id=\`$UID_\` spur_job=\`$spur\` node=\`$node\`"
+      summary "❌ **FAIL** — session_id=\`$UID_\` job=\`$jobref\` node=\`$node\`"
       summary "reason: $err"
       post_status "failure" "$(humanize_reason "$err")"
       report_upsert "❌ Failed"
@@ -252,14 +250,14 @@ while [ "$i" -lt "$POLL_MAX" ]; do
   # Throttled live status: push at most once per STATUS_INTERVAL_S (default 5min).
   now_s="$(date +%s)"
   if [ $((now_s - last_push)) -ge "$STATUS_INTERVAL_S" ]; then
-    post_status "pending" "running phase=${phase} (poll ${i}/${POLL_MAX}); spur_job=${spur}; uid=${UID_}"
+    post_status "pending" "running phase=${phase} (poll ${i}/${POLL_MAX}); job=${jobref}; uid=${UID_}"
     last_push="$now_s"
   fi
   sleep "$POLL_INTERVAL_S"
 done
 
 err="not terminal after $((POLL_MAX * POLL_INTERVAL_S))s"
-summary "❌ **FAIL (timeout)** — ${err}. claw_session_id=\`$UID_\`"
+summary "❌ **FAIL (timeout)** — ${err}. session_id=\`$UID_\`"
 post_status "failure" "FAIL (timeout) after $((POLL_MAX * POLL_INTERVAL_S))s; uid=${UID_}"
 report_upsert "❌ Timeout"
 cleanup

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -1,0 +1,100 @@
+name: CI E2E (single-GPU smoke run)
+
+# Every PR targeting `main` dispatches ONE single-GPU Qwen3-0.6B inference-optimizer
+# run built from the PR's branch on the spur cluster. Green if the run reaches
+# Succeeded, red on Failed/timeout. Opt OUT by adding the `skip-e2e-test` label.
+# Runs on a self-hosted runner that can reach the robust-spur ingress.
+
+on:
+  pull_request:
+    branches: [main]          # only PRs whose BASE branch is main
+    # opened/synchronize/reopened = run on create + new commits + reopen.
+    # labeled/unlabeled = re-evaluate when `skip-e2e-test` is added/removed.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  workflow_dispatch:
+    inputs:
+      head_ref:
+        description: "Hyperloom branch to run (defaults to the caller ref)"
+        required: false
+
+# A newer commit on the same PR cancels the in-flight run (the script's TERM
+# trap deletes the spur workload so no GPU is leaked).
+concurrency:
+  group: ci-e2e-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+# The workflow token writes the live commit status and the sticky PR report comment.
+permissions:
+  contents: read
+  statuses: write
+  pull-requests: write
+
+jobs:
+  e2e:
+    # Runs for every PR by default; opt out with the `skip-e2e-test` label.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      !contains(github.event.pull_request.labels.*.name, 'skip-e2e-test')
+    # Self-hosted runner registered with the label `Hyperloom-e2e-ci`
+    # (config.sh --labels Hyperloom-e2e-ci). Must reach github.com + the spur ingress.
+    runs-on: Hyperloom-e2e-ci
+    # Covers a full MAX_HOURS run (currently up to 3h) + setup/baseline overhead.
+    timeout-minutes: 240
+    steps:
+      - name: Checkout (workflow scripts only)
+        uses: actions/checkout@v4
+
+      - name: Ensure jq
+        run: command -v jq >/dev/null 2>&1 || (sudo apt-get update && sudo apt-get install -y jq)
+
+      - name: Dispatch + monitor single-GPU smoke run
+        id: run
+        env:
+          SAFE_AK: ${{ secrets.ROBUST_SPUR_SAFE_AK }}
+          ROBUST_BASE: ${{ vars.ROBUST_SPUR_BASE }}
+          MODEL: ${{ vars.CI_E2E_MODEL }}
+          MODEL_CLASS: ${{ vars.CI_E2E_MODEL_CLASS }}
+          GPUS: ${{ vars.CI_E2E_GPUS }}
+          TP: ${{ vars.CI_E2E_TP }}
+          MAX_HOURS: ${{ vars.CI_E2E_MAX_HOURS }}
+          # Slurm account identity spur dispatches under (must be an amd-hyperloom member).
+          CI_E2E_USER_NAME: ${{ vars.CI_E2E_USER_NAME }}
+          # The robust-spur ingress uses an internal CA. Skip TLS verify unless a CA
+          # bundle is provided via CI_E2E_CACERT. Override with vars.CI_E2E_INSECURE=0
+          # once the runner trusts the internal CA.
+          CI_E2E_INSECURE: ${{ vars.CI_E2E_INSECURE || '1' }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref || inputs.head_ref || github.ref_name }}
+          # Tokenized clone URLs so the compute node can clone this (private) PR branch.
+          # github.token is ephemeral (expires with the run) and can read same-repo PRs.
+          HEAD_REPO_URL: ${{ github.event.pull_request.head.repo.full_name && format('https://x-access-token:{0}@github.com/{1}.git', github.token, github.event.pull_request.head.repo.full_name) || '' }}
+          BASE_REPO_URL: ${{ format('https://x-access-token:{0}@github.com/{1}.git', github.token, github.repository) }}
+          # Live commit status on the PR, refreshed every STATUS_INTERVAL_S.
+          GH_STATUS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_STATUS_REPO: ${{ github.repository }}
+          GH_STATUS_SHA: ${{ github.event.pull_request.head.sha }}
+          GH_STATUS_DETAILS_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          STATUS_INTERVAL_S: "300"
+          # Poll long enough to cover a 3h MAX_HOURS run: 220 * 60s ≈ 3h40m.
+          POLL_INTERVAL_S: "60"
+          POLL_MAX: "220"
+        run: |
+          chmod +x .github/scripts/ci-e2e-dispatch.sh
+          .github/scripts/ci-e2e-dispatch.sh
+
+      # If the job is cancelled (manual stop, or a newer commit via concurrency
+      # cancel-in-progress), GitHub still runs this step — DELETE the spur workload
+      # so the GPU run doesn't leak. Reliable even when the main step is hard-killed.
+      - name: Cancel spur workload on job cancel
+        if: cancelled()
+        env:
+          SAFE_AK: ${{ secrets.ROBUST_SPUR_SAFE_AK }}
+          ROBUST_BASE: ${{ vars.ROBUST_SPUR_BASE }}
+        run: |
+          uid="$(cat "${RUNNER_TEMP}/claw_uid" 2>/dev/null || true)"
+          if [ -z "$uid" ]; then echo "no claw uid recorded; nothing to cancel"; exit 0; fi
+          base="${ROBUST_BASE:-https://crusoe.primus-safe.amd.com/robust-spur-api}"
+          echo "cancelling spur workload $uid"
+          curl -sS -k -o /dev/null -w 'DELETE HTTP=%{http_code}\n' \
+            -X DELETE -H "Authorization: Bearer ${SAFE_AK}" \
+            "${base%/}/api/v1/orchestration/workloads/${uid}"

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -1,9 +1,9 @@
 name: CI E2E (single-GPU smoke run)
 
-# Every PR targeting `main` dispatches ONE single-GPU Qwen3-0.6B inference-optimizer
-# run built from the PR's branch on the spur cluster. Green if the run reaches
-# Succeeded, red on Failed/timeout. Opt OUT by adding the `skip-e2e-test` label.
-# Runs on a self-hosted runner that can reach the robust-spur ingress.
+# Every PR targeting `main` dispatches ONE single-GPU inference-optimizer run built
+# from the PR's branch, monitors it, and reports green (Succeeded) / red (Failed or
+# timeout). Opt OUT by adding the `skip-e2e-test` label. Runs on a self-hosted runner
+# that can reach the run API.
 
 on:
   pull_request:
@@ -14,11 +14,11 @@ on:
   workflow_dispatch:
     inputs:
       head_ref:
-        description: "Hyperloom branch to run (defaults to the caller ref)"
+        description: "Branch to run (defaults to the caller ref)"
         required: false
 
-# A newer commit on the same PR cancels the in-flight run (the script's TERM
-# trap deletes the spur workload so no GPU is leaked).
+# A newer commit on the same PR cancels the in-flight run; the cleanup step below
+# cancels the workload so no GPU is leaked.
 concurrency:
   group: ci-e2e-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -36,9 +36,9 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       !contains(github.event.pull_request.labels.*.name, 'skip-e2e-test')
     # Self-hosted runner registered with the label `Hyperloom-e2e-ci`
-    # (config.sh --labels Hyperloom-e2e-ci). Must reach github.com + the spur ingress.
+    # (config.sh --labels Hyperloom-e2e-ci). Must reach github.com + the run API.
     runs-on: Hyperloom-e2e-ci
-    # Covers a full MAX_HOURS run (currently up to 3h) + setup/baseline overhead.
+    # Covers a full MAX_HOURS run + setup/baseline overhead.
     timeout-minutes: 240
     steps:
       - name: Checkout (workflow scripts only)
@@ -50,23 +50,26 @@ jobs:
       - name: Dispatch + monitor single-GPU smoke run
         id: run
         env:
-          SAFE_AK: ${{ secrets.ROBUST_SPUR_SAFE_AK }}
-          ROBUST_BASE: ${{ vars.ROBUST_SPUR_BASE }}
-          MODEL: ${{ vars.CI_E2E_MODEL }}
-          MODEL_CLASS: ${{ vars.CI_E2E_MODEL_CLASS }}
-          GPUS: ${{ vars.CI_E2E_GPUS }}
-          TP: ${{ vars.CI_E2E_TP }}
-          MAX_HOURS: ${{ vars.CI_E2E_MAX_HOURS }}
-          # Slurm account identity spur dispatches under (must be an amd-hyperloom member).
-          CI_E2E_USER_NAME: ${{ vars.CI_E2E_USER_NAME }}
-          # The robust-spur ingress uses an internal CA. Skip TLS verify unless a CA
-          # bundle is provided via CI_E2E_CACERT. Override with vars.CI_E2E_INSECURE=0
-          # once the runner trusts the internal CA.
-          CI_E2E_INSECURE: ${{ vars.CI_E2E_INSECURE || '1' }}
+          E2E_API_KEY: ${{ secrets.CI_E2E_API_KEY }}
+          E2E_API_BASE: ${{ secrets.CI_E2E_API_BASE }}
+          E2E_INFRA_TYPE: ${{ secrets.CI_E2E_INFRA_TYPE }}
+          MODEL: ${{ secrets.CI_E2E_MODEL }}
+          MODEL_CLASS: ${{ secrets.CI_E2E_MODEL_CLASS }}
+          MODEL_BASE: ${{ secrets.CI_E2E_MODEL_BASE }}
+          GPUS: ${{ secrets.CI_E2E_GPUS }}
+          TP: ${{ secrets.CI_E2E_TP }}
+          MAX_HOURS: ${{ secrets.CI_E2E_MAX_HOURS }}
+          # Account identity the run dispatches under.
+          CI_E2E_USER_NAME: ${{ secrets.CI_E2E_USER_NAME }}
+          # Per-PR checkout base dir.
+          CI_E2E_PR_CHECK_BASE: ${{ secrets.CI_E2E_PR_CHECK_BASE }}
+          # The API endpoint may use a private CA; skip TLS verify unless a CA bundle is
+          # provided. Set the CI_E2E_INSECURE secret to 0 once the runner trusts the CA.
+          CI_E2E_INSECURE: ${{ secrets.CI_E2E_INSECURE || '1' }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_REF: ${{ github.event.pull_request.head.ref || inputs.head_ref || github.ref_name }}
-          # Tokenized clone URLs so the compute node can clone this (private) PR branch.
-          # github.token is ephemeral (expires with the run) and can read same-repo PRs.
+          # Tokenized clone URLs so the run can clone this PR branch. github.token is
+          # ephemeral (expires with the run) and can read same-repo PRs.
           HEAD_REPO_URL: ${{ github.event.pull_request.head.repo.full_name && format('https://x-access-token:{0}@github.com/{1}.git', github.token, github.event.pull_request.head.repo.full_name) || '' }}
           BASE_REPO_URL: ${{ format('https://x-access-token:{0}@github.com/{1}.git', github.token, github.repository) }}
           # Live commit status on the PR, refreshed every STATUS_INTERVAL_S.
@@ -75,7 +78,7 @@ jobs:
           GH_STATUS_SHA: ${{ github.event.pull_request.head.sha }}
           GH_STATUS_DETAILS_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           STATUS_INTERVAL_S: "300"
-          # Poll long enough to cover a 3h MAX_HOURS run: 220 * 60s ≈ 3h40m.
+          # Poll long enough to cover the run budget.
           POLL_INTERVAL_S: "60"
           POLL_MAX: "220"
         run: |
@@ -83,18 +86,18 @@ jobs:
           .github/scripts/ci-e2e-dispatch.sh
 
       # If the job is cancelled (manual stop, or a newer commit via concurrency
-      # cancel-in-progress), GitHub still runs this step — DELETE the spur workload
-      # so the GPU run doesn't leak. Reliable even when the main step is hard-killed.
-      - name: Cancel spur workload on job cancel
+      # cancel-in-progress), GitHub still runs this step — cancel the workload so the
+      # GPU run doesn't leak. Reliable even when the main step is hard-killed.
+      - name: Cancel workload on job cancel
         if: cancelled()
         env:
-          SAFE_AK: ${{ secrets.ROBUST_SPUR_SAFE_AK }}
-          ROBUST_BASE: ${{ vars.ROBUST_SPUR_BASE }}
+          E2E_API_KEY: ${{ secrets.CI_E2E_API_KEY }}
+          E2E_API_BASE: ${{ secrets.CI_E2E_API_BASE }}
         run: |
-          uid="$(cat "${RUNNER_TEMP}/claw_uid" 2>/dev/null || true)"
-          if [ -z "$uid" ]; then echo "no claw uid recorded; nothing to cancel"; exit 0; fi
-          base="${ROBUST_BASE:-https://crusoe.primus-safe.amd.com/robust-spur-api}"
-          echo "cancelling spur workload $uid"
+          uid="$(cat "${RUNNER_TEMP}/e2e_session_uid" 2>/dev/null || true)"
+          if [ -z "$uid" ]; then echo "no session uid recorded; nothing to cancel"; exit 0; fi
+          if [ -z "${E2E_API_BASE:-}" ]; then echo "no API base; cannot cancel"; exit 0; fi
+          echo "cancelling workload $uid"
           curl -sS -k -o /dev/null -w 'DELETE HTTP=%{http_code}\n' \
-            -X DELETE -H "Authorization: Bearer ${SAFE_AK}" \
-            "${base%/}/api/v1/orchestration/workloads/${uid}"
+            -X DELETE -H "Authorization: Bearer ${E2E_API_KEY}" \
+            "${E2E_API_BASE%/}/api/v1/orchestration/workloads/${uid}"

--- a/src/hyperloom/inference_optimizer/assets/slurm/_incontainer.sh.in
+++ b/src/hyperloom/inference_optimizer/assets/slurm/_incontainer.sh.in
@@ -30,6 +30,12 @@ curl -sS -o /dev/null -w "[hl] gateway /models HTTP=%{http_code}\n" \
 #      use it as-is (e.g. a bind-mounted /mnt/vast/hyperloom) -> no network clone;
 #    - otherwise clone from GitHub into the default temp dir.
 export HYPERLOOM_SOURCE_DIR="${HYPERLOOM_SOURCE_DIR:-/tmp/Hyperloom-main}"
+# CI e2e uses a stable per-PR path (…/pr_<N>/hyperloom); wipe any prior checkout so a
+# re-triggered run always clones the branch's latest commit instead of reusing stale code.
+if [ "${HL_CI_E2E:-0}" = "1" ] && [ -e "$HYPERLOOM_SOURCE_DIR" ]; then
+  echo "[hl] CI e2e: removing stale checkout at $HYPERLOOM_SOURCE_DIR before fresh clone"
+  rm -rf "$HYPERLOOM_SOURCE_DIR"
+fi
 if [ -f "$HYPERLOOM_SOURCE_DIR/pyproject.toml" ] || [ -d "$HYPERLOOM_SOURCE_DIR/.git" ]; then
   echo "[hl] using existing Hyperloom source at $HYPERLOOM_SOURCE_DIR (no clone)"
 else


### PR DESCRIPTION
## What
Every PR targeting **main** dispatches ONE single-GPU **Qwen3-0.6B** inference-optimizer run built from the PR branch to the robust-spur cluster, monitors it, and reports **green (Succeeded) / red (Failed|timeout)**. Opt out with the **skip-e2e-test** label.

## How it surfaces on the PR
- Live **commit status** (ci-e2e/hyperloom-run) refreshed every 5 min with phase + node + transitions.
- A sticky **report comment** on terminal (model/resources/claw_session_id/timeline + **human-readable failure reason**).
- The Actions job check goes green/red.

## Runner
Self-hosted runner pool labeled **Hyperloom-e2e-ci** (K8s StatefulSet).

## Cancel behavior
Cancelling the job (or a newer commit via concurrency) cancels the spur workload through an **if:cancelled()** cleanup step.

## Files
- .github/workflows/ci-e2e.yml
- .github/scripts/ci-e2e-dispatch.sh
- src/hyperloom/inference_optimizer/assets/slurm/_incontainer.sh.in (CI refreshes per-PR checkout)

## Validated (via a staging base, now cleaned up)
🟢 green run, 🔴 red + human reason, ⛔ cancel-sync, 🟡 skip-e2e-test skip, base=main gating.

Made with [Cursor](https://cursor.com)