### PR TITLE
fix(magpie-patcher): extend SGLang client trust patch to mi300x local path

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_magpie_patcher.py
+++ b/src/hyperloom/inference_optimizer/tests/test_magpie_patcher.py
@@ -302,6 +302,28 @@ def test_sglang_mi355x_local_and_remote_client_trust_is_env_gated(fake_magpie: P
     assert script.read_text(encoding="utf-8") == text
 
 
+def test_sglang_mi300x_local_client_trust_is_env_gated(fake_magpie: Path):
+    # Regression: the client-trust patch must also reach the local-server path
+    # of sglang_mi300x.sh (previously only mi355x got the local splice). Use the
+    # realistic client shape (with a local-server path) for the mi300x script.
+    script = _write_sglang_script(
+        fake_magpie,
+        _UPSTREAM_SGLANG_MI355X_SH,
+        name="sglang_mi300x.sh",
+    )
+
+    assert ensure_magpie_atomic_scripts_patch(fake_magpie) is True
+    text = script.read_text(encoding="utf-8")
+
+    assert "magpie_run_benchmark_serving_remote_direct trust" in text
+    assert "HYPERLOOM_SGLANG_LOCAL_TRUST" in text
+    assert "CLIENT_TRUST_ARGS+=(--trust-remote-code)" in text
+    assert '"${CLIENT_TRUST_ARGS[@]}"' in text
+
+    assert ensure_magpie_atomic_scripts_patch(fake_magpie) is True
+    assert script.read_text(encoding="utf-8") == text
+
+
 def test_remote_trust_drift_is_reported_separately(
     tmp_path: Path,
     caplog,

--- a/src/hyperloom/inference_optimizer/tests/test_magpie_patcher_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_magpie_patcher_unit.py
@@ -264,23 +264,26 @@ def test_apply_remote_trust_fdopen_write_error(tmp_path, monkeypatch):
     assert mp._apply_remote_trust_patch_atomic(f) is False
 
 
-def test_apply_mi355x_client_trust_applied_and_idempotent(tmp_path):
+def test_apply_sglang_client_trust_applied_and_idempotent(tmp_path):
+    # A script carrying the local-server client path (either mi300x or mi355x —
+    # the client blocks are byte-identical) gets both client paths gated.
     f = tmp_path / "sglang_mi355x.sh"
     f.write_text(_SGLANG_MI355X_LEGACY, encoding="utf-8")
 
-    assert mp._apply_mi355x_client_trust_patch_atomic(f) is True
+    assert mp._apply_sglang_client_trust_patch_atomic(f) is True
     first = f.read_text(encoding="utf-8")
     assert "HYPERLOOM_SGLANG_LOCAL_TRUST" in first
     assert "magpie_run_benchmark_serving_remote_direct trust" in first
     assert "CLIENT_TRUST_ARGS+=(--trust-remote-code)" in first
     assert '"${CLIENT_TRUST_ARGS[@]}"' in first
-    assert mp._is_mi355x_client_trust_patched(f) is True
+    assert mp._is_sglang_client_trust_patched(f) is True
 
-    assert mp._apply_mi355x_client_trust_patch_atomic(f) is True
+    assert mp._apply_sglang_client_trust_patch_atomic(f) is True
     assert f.read_text(encoding="utf-8") == first
 
 
-def test_apply_mi355x_client_trust_rejects_unknown_local_shape(tmp_path):
+def test_apply_sglang_client_trust_rejects_drifted_local_shape(tmp_path):
+    # Local path present (marker) but the splice block drifted -> fail loud.
     f = tmp_path / "sglang_mi355x.sh"
     f.write_text(
         _SGLANG_MI355X_LEGACY.replace(
@@ -289,7 +292,36 @@ def test_apply_mi355x_client_trust_rejects_unknown_local_shape(tmp_path):
         ),
         encoding="utf-8",
     )
-    assert mp._apply_mi355x_client_trust_patch_atomic(f) is False
+    assert mp._apply_sglang_client_trust_patch_atomic(f) is False
+
+
+def test_apply_sglang_client_trust_remote_only_skips_local(tmp_path):
+    # Reduced script with only the remote-direct path (no local marker): remote
+    # gets gated, the local splice is skipped rather than reported as drift.
+    f = tmp_path / "sglang_mi300x.sh"
+    f.write_text(_SGLANG_LEGACY, encoding="utf-8")
+
+    assert mp._apply_sglang_client_trust_patch_atomic(f) is True
+    text = f.read_text(encoding="utf-8")
+    assert "magpie_run_benchmark_serving_remote_direct trust" in text
+    assert "HYPERLOOM_SGLANG_LOCAL_TRUST" not in text
+    assert mp._is_sglang_client_trust_patched(f) is True
+    # Idempotent.
+    assert mp._apply_sglang_client_trust_patch_atomic(f) is True
+
+
+def test_apply_sglang_client_trust_full_mi300x_gets_local(tmp_path):
+    # A realistic mi300x script (with the local-server client path) gets BOTH
+    # the remote-direct and local-server trust gates — closing the gap where
+    # the earlier patch only ever reached mi355x.
+    f = tmp_path / "sglang_mi300x.sh"
+    f.write_text(_SGLANG_MI355X_LEGACY, encoding="utf-8")
+
+    assert mp._apply_sglang_client_trust_patch_atomic(f) is True
+    text = f.read_text(encoding="utf-8")
+    assert "magpie_run_benchmark_serving_remote_direct trust" in text
+    assert "HYPERLOOM_SGLANG_LOCAL_TRUST" in text
+    assert '"${CLIENT_TRUST_ARGS[@]}"' in text
 
 
 # ---- MagpiePatchStatus ----------------------------------------------------

--- a/src/hyperloom/orchestrator/actions/executors/_magpie_patcher.py
+++ b/src/hyperloom/orchestrator/actions/executors/_magpie_patcher.py
@@ -111,12 +111,18 @@ _REMOTE_DIRECT_PATCHED_BLOCK = (
     "    fi\n"
 )
 
-# Magpie's SGLang MI355X local-client path calls ``run_benchmark_serving``
-# directly. Unlike the vLLM MI355X script, it does not pass
-# ``--trust-remote-code``, so custom tokenizer models (for example Kimi) fail
-# before issuing a request. Build an optional argv array from the same env gate
-# used by the remote-direct path, then splice it into the local client command.
+# Magpie's SGLang local-client path (``BENCHMARK_BASE_URL`` unset — e.g. the
+# baseline ``server_lifecycle`` reuse path) calls ``run_benchmark_serving``
+# directly. Unlike the vLLM scripts it does not pass ``--trust-remote-code``, so
+# custom tokenizer models (for example Kimi) fail before issuing a request.
+# Build an optional argv array from the same env gate used by the remote-direct
+# path, then splice it into the local client command. Both the ``sglang_mi300x``
+# and ``sglang_mi355x`` scripts share these byte-identical client blocks.
 _LOCAL_TRUST_SENTINEL = "HYPERLOOM_SGLANG_LOCAL_TRUST"
+# Marks that a script actually has a local-server client path to patch. When
+# absent (reduced test layouts / scripts without the local branch) the local
+# trust splice is skipped rather than treated as drift.
+_LOCAL_PATH_MARKER = "--result-dir ${RESULT_DIR"
 _LOCAL_TRUST_ARGS_LEGACY_BLOCK = 'SERVER_MONITOR_ARGS=()\nif [[ -n "${SERVER_PID:-}" ]]; then\n'
 _LOCAL_TRUST_ARGS_PATCHED_BLOCK = (
     "SERVER_MONITOR_ARGS=()\n"
@@ -826,21 +832,46 @@ def _apply_remote_trust_patch_atomic(src: Path) -> bool:
     return True
 
 
-def _is_mi355x_client_trust_patched(src: Path) -> bool:
-    """Return whether both MI355X SGLang client paths carry trust gating."""
+def _is_sglang_client_trust_patched(src: Path) -> bool:
+    """Return whether an SGLang script's client paths already carry trust gating.
+
+    Covers both the remote-direct path and, when the script has a local-server
+    client path (:data:`_LOCAL_PATH_MARKER`), the local splice. Scripts without
+    a local path are considered patched once the remote-direct gate is present.
+
+    Args:
+        src: The ``sglang_mi300x.sh`` / ``sglang_mi355x.sh`` file to inspect.
+
+    Returns:
+        True iff the applicable client trust patches are already present, False
+        on a miss or read error.
+    """
     try:
         text = src.read_text(encoding="utf-8")
     except OSError:
         return False
-    return (
-        _LOCAL_TRUST_SENTINEL in text
-        and "magpie_run_benchmark_serving_remote_direct trust" in text
-        and '"${CLIENT_TRUST_ARGS[@]}"' in text
-    )
+    remote_ok = "magpie_run_benchmark_serving_remote_direct trust" in text
+    local_ok = _LOCAL_TRUST_SENTINEL in text or _LOCAL_PATH_MARKER not in text
+    return remote_ok and local_ok
 
 
-def _apply_mi355x_client_trust_patch_atomic(src: Path) -> bool:
-    """Patch SGLang MI355X remote and local benchmark clients for custom code."""
+def _apply_sglang_client_trust_patch_atomic(src: Path) -> bool:
+    """Patch an SGLang script's remote and local benchmark clients for custom code.
+
+    Applies to both ``sglang_mi300x.sh`` and ``sglang_mi355x.sh`` — their client
+    blocks are byte-identical. The remote-direct gate is required (a missing
+    block signals layout drift). The local splice is applied only when the
+    script actually has a local-server client path (:data:`_LOCAL_PATH_MARKER`),
+    and a drifted local block there is reported as a failure.
+
+    Args:
+        src: The SGLang benchmark script to patch in place.
+
+    Returns:
+        True when the applicable trust patches are present after the call
+        (already patched or freshly written), False when a required legacy block
+        is missing / drifted or any IO step fails.
+    """
     try:
         original = src.read_text(encoding="utf-8")
     except OSError as e:
@@ -851,7 +882,7 @@ def _apply_mi355x_client_trust_patch_atomic(src: Path) -> bool:
     if "magpie_run_benchmark_serving_remote_direct trust" not in patched:
         if _REMOTE_DIRECT_LEGACY_BLOCK not in patched:
             log.warning(
-                "_magpie_patcher: MI355X remote benchmark direct-call block "
+                "_magpie_patcher: remote benchmark direct-call block "
                 "not found in %s; custom-tokenizer trust patch could not be applied",
                 src,
             )
@@ -862,10 +893,10 @@ def _apply_mi355x_client_trust_patch_atomic(src: Path) -> bool:
             1,
         )
 
-    if _LOCAL_TRUST_SENTINEL not in patched:
+    if _LOCAL_TRUST_SENTINEL not in patched and _LOCAL_PATH_MARKER in patched:
         if _LOCAL_TRUST_ARGS_LEGACY_BLOCK not in patched or _LOCAL_CLIENT_LEGACY_BLOCK not in patched:
             log.warning(
-                "_magpie_patcher: MI355X local benchmark client block not found "
+                "_magpie_patcher: local benchmark client block not found "
                 "in %s; custom-tokenizer trust patch could not be applied",
                 src,
             )
@@ -887,13 +918,13 @@ def _apply_mi355x_client_trust_patch_atomic(src: Path) -> bool:
     if not atomic_write_text(
         src,
         patched,
-        tmp_prefix=".sglang_mi355x.sh.hyperloom_",
+        tmp_prefix=f".{src.name}.hyperloom_",
         log_prefix="_magpie_patcher",
     ):
         return False
 
     log.info(
-        "_magpie_patcher: applied SGLang MI355X client trust patches to %s",
+        "_magpie_patcher: applied SGLang client trust patches to %s",
         src,
     )
     return True
@@ -991,16 +1022,22 @@ def magpie_scripts_patch_status(
         atomic_ok = atomic_reason not in _ATOMIC_REASONS_GENUINE_FAILURE
         sglang_mi300x_script = _resolve_sglang_mi300x_script_path(magpie_dir)
         sglang_mi355x_script = _resolve_sglang_mi355x_script_path(magpie_dir)
+        sglang_scripts = [s for s in (sglang_mi300x_script, sglang_mi355x_script) if s is not None]
         trust_results: list[bool] = []
+        # MI300X additionally carries the eval-concurrency inline rewrite; keep
+        # that patcher so the script's existing behaviour is unchanged.
         if sglang_mi300x_script is not None:
             trust_results.append(
                 _is_remote_trust_patched(sglang_mi300x_script)
                 or _apply_remote_trust_patch_atomic(sglang_mi300x_script)
             )
-        if sglang_mi355x_script is not None:
+        # Both MI300X and MI355X get the full remote + local client trust patch;
+        # the client blocks are byte-identical across the two scripts, so one
+        # patcher covers each remote-direct and local-server client path.
+        for script in sglang_scripts:
             trust_results.append(
-                _is_mi355x_client_trust_patched(sglang_mi355x_script)
-                or _apply_mi355x_client_trust_patch_atomic(sglang_mi355x_script)
+                _is_sglang_client_trust_patched(script)
+                or _apply_sglang_client_trust_patch_atomic(script)
             )
         if not trust_results:
             log.info(


### PR DESCRIPTION
## What & why
The SGLang client `--trust-remote-code` patch only reached:
- `sglang_mi355x.sh` remote + local (via meina's mi355x patcher, b97a2d6), and
- `sglang_mi300x.sh` **remote-direct only** (via the remote-trust patcher).

`sglang_mi300x.sh`'s **local-server client path** (`BENCHMARK_BASE_URL` unset — the baseline `server_lifecycle` reuse path) was never gated, so custom-tokenizer models on that path still failed the client-side tokenizer load.

## Change
Both scripts share **byte-identical** client blocks, so generalise the mi355x-specific patcher into a script-agnostic _apply_sglang_client_trust_patch_atomic / _is_sglang_client_trust_patched and apply it to **both** scripts in `magpie_scripts_patch_status`.
- Remote-direct gate stays required (missing block = drift → fail-loud).
- Local splice is applied only when the script has a local-server path (`--result-dir` marker); a **drifted** local block there still fails loud, while remote-only / reduced layouts skip cleanly.
- MI300X keeps its existing eval-concurrency inline rewrite (unchanged).

Builds on top of @meina's b97a2d6.

## Tests
Added: mi300x local-client trust (full flow), remote-only skip, drifted-local reject, unified idempotency. All trust tests pass. (Local Windows run also shows 6 pre-existing failures in unrelated atomic-copy / file-lock / exec-mode-bit tests — POSIX-only, not touched by this PR.)