### PR TITLE
fix(baseline): per-session unique port for server_lifecycle reuse (backport of #971)

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_backend_gating.py
+++ b/src/hyperloom/inference_optimizer/tests/test_backend_gating.py
@@ -126,6 +126,9 @@ def test_lifecycle_delegates_to_bypass_backend(tmp_path, monkeypatch):
     cfg_path = tmp_path / "cfg.yaml"
     cfg_path.write_text(yaml.safe_dump(cfg), encoding="utf-8")
 
+    # Pin the free-port picker so the port assertion is deterministic
+    # (resolve now assigns a per-session free port on the common path).
+    monkeypatch.setattr(sl, "_pick_free_port", lambda: 8888)
     info = sl.resolve_lifecycle_params(cfg_path)
     # bypass now honors the YAML lifecycle block, so a serving framework
     # with profiling off is eligible.

--- a/src/hyperloom/inference_optimizer/tests/test_baseline_warmup_double_run.py
+++ b/src/hyperloom/inference_optimizer/tests/test_baseline_warmup_double_run.py
@@ -900,6 +900,10 @@ def test_double_run_pre_start_cleanup_kills_zombie_and_clears_stale_meta(
     output_dir = tmp_path / "ws"
     output_dir.mkdir(parents=True)
     (output_dir / "vllm_8888.pid").write_text("2147483646")
+    monkeypatch.setattr(
+        "hyperloom.orchestrator.actions.executors._server_lifecycle._pick_free_port",
+        lambda: 8888,
+    )
 
     kill_calls = {"n": 0}
 
@@ -954,6 +958,10 @@ def test_pre_start_cleanup_no_kill_when_port_free(tmp_path, monkeypatch):
     output_dir = tmp_path / "ws"
     output_dir.mkdir(parents=True)
     (output_dir / "vllm_8888.pid").write_text("2147483646")
+    monkeypatch.setattr(
+        "hyperloom.orchestrator.actions.executors._server_lifecycle._pick_free_port",
+        lambda: 8888,
+    )
 
     kill_calls = {"n": 0}
 
@@ -1006,6 +1014,10 @@ def test_pre_start_cleanup_no_kill_when_metadata_existed(tmp_path, monkeypatch):
     output_dir = tmp_path / "ws"
     output_dir.mkdir(parents=True)
     (output_dir / "vllm_8888.pid").write_text("2147483646")
+    monkeypatch.setattr(
+        "hyperloom.orchestrator.actions.executors._server_lifecycle._pick_free_port",
+        lambda: 8888,
+    )
     (output_dir / "vllm_8888.json").write_text("{}")
 
     kill_calls = {"n": 0}

--- a/src/hyperloom/inference_optimizer/tests/test_grid_runner_behavior_lock.py
+++ b/src/hyperloom/inference_optimizer/tests/test_grid_runner_behavior_lock.py
@@ -388,6 +388,12 @@ class TestAutoWarmupTeardown:
 
     def test_warmup_success_measured_success_tears_down_once(self, tmp_path, monkeypatch):
         monkeypatch.setenv("INFERENCE_OPTIMIZER_RUN_GRID_WARMUP", "1")
+        # Pin the free-port picker so the teardown-port assertion is
+        # deterministic (baseline uses a per-session free port).
+        monkeypatch.setattr(
+            "hyperloom.orchestrator.actions.executors._server_lifecycle._pick_free_port",
+            lambda: 8888,
+        )
         base = tmp_path / "base.yaml"
         _write_base_yaml(base)
         state = {"n": 0}

--- a/src/hyperloom/orchestrator/actions/executors/_server_lifecycle.py
+++ b/src/hyperloom/orchestrator/actions/executors/_server_lifecycle.py
@@ -49,6 +49,50 @@ REUSE_PORT_DEFAULT = 8888
 # Override via ``INFERENCE_OPTIMIZER_BASELINE_SERVER_READY_SEC``.
 SERVER_READY_TIMEOUT_SEC = 2700
 
+def _pick_free_port() -> int:
+    """Return an OS-assigned free TCP port.
+
+    Binds to port 0 (ephemeral) and reads back the kernel-chosen port. There
+    is a small TOCTOU window before the server actually binds, acceptable for
+    the high ephemeral range. Raises ``OSError`` if no port can be obtained.
+
+    Returns:
+        int: A currently-free TCP port.
+    """
+    import socket
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.bind(("", 0))
+        return int(s.getsockname()[1])
+    finally:
+        s.close()
+
+
+def _assign_free_port(current_port: int) -> int:
+    """Return a per-session free ephemeral port for the persistent server.
+
+    Falls back to ``current_port`` if no free port can be bound. Used on the
+    common resolution path so every backend (Magpie and bypass) gets the same
+    stale/co-tenant port-collision protection.
+
+    Args:
+        current_port: Port to keep if free-port allocation fails.
+
+    Returns:
+        int: A free port, or ``current_port`` on ``OSError``.
+    """
+    try:
+        return _pick_free_port()
+    except OSError as exc:
+        log.warning(
+            "server_lifecycle: free-port pick failed (%s); keeping port %d",
+            exc,
+            current_port,
+        )
+        return current_port
+
 
 def resolve_lifecycle_params(materialized_config_path: Path) -> dict[str, Any]:
     """Inspect the materialized YAML for server_lifecycle eligibility.
@@ -93,6 +137,13 @@ def resolve_lifecycle_params(materialized_config_path: Path) -> dict[str, Any]:
 
     backend_verdict = resolve_backend().lifecycle_eligibility(bench)
     if backend_verdict is not None:
+        # Free-port assignment lives on this common path so a non-Magpie backend
+        # (e.g. bypass) gets the same stale/co-tenant collision protection
+        # instead of falling back to the fixed default port.
+        if backend_verdict.get("eligible"):
+            backend_verdict["port"] = _assign_free_port(
+                int(backend_verdict.get("port", REUSE_PORT_DEFAULT))
+            )
         return backend_verdict
 
     # Server-less (scriptable) frameworks — e.g. xDiT diffusion — never boot a
@@ -121,6 +172,17 @@ def resolve_lifecycle_params(materialized_config_path: Path) -> dict[str, Any]:
     if profiler_on:
         info["reason"] = "torch_profiler enabled (incompatible with reuse)"
         return info
+
+    # Use a per-session free ephemeral port for the persistent server instead of
+    # a fixed default: a stale/leaked server from a prior baseline attempt
+    # (round 1 uses cleanup=false and leaves the server running) or a co-tenant
+    # job holding the fixed port makes Magpie abort every warmup with "Reuse
+    # metadata mismatch ... server on PORT=... is incompatible", so the baseline
+    # never records an accuracy and the run wrongly stops with
+    # baseline_accuracy_failed. Resolved once here; both double-run rounds share
+    # it via inject_lifecycle -> envs.PORT (server bind, Magpie reuse keying,
+    # lm-eval base_url and teardown all agree).
+    info["port"] = _assign_free_port(info["port"])
 
     info["eligible"] = True
     return info


### PR DESCRIPTION
Backports PR #971 onto **v1.0-dev**: uses a per-session unique port for server_lifecycle reuse, fixing the false baseline_accuracy_failed caused by a fixed port colliding with a leftover server on the node. Same 4-file change as #971 (server_lifecycle + 3 tests), applied cleanly with no conflicts.

Made with [Cursor](https://cursor.com)