### PR TITLE
fix(geak): preserve queued win revalidation

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_geak_gain_alignment.py
+++ b/src/hyperloom/inference_optimizer/tests/test_geak_gain_alignment.py
@@ -365,6 +365,10 @@ async def test_2b_identity_mismatch_defers_to_geak_harness(tmp_path: Path) -> No
     coord = _coord(tmp_path, baseline=base, best_tput=3236.489)
     coord.shared_state.optimization_stack = [{"action": "geak_e2e", "tput": 3236.489}]
     coord.shared_state.resume_pending_revalidation = True
+    coord.shared_state.geak_pending = {
+        "status": "awaiting_rebench",
+        "revalidation_task_id": "reval-1",
+    }
 
     called = {"n": 0}
 
@@ -386,6 +390,9 @@ async def test_2b_identity_mismatch_defers_to_geak_harness(tmp_path: Path) -> No
     assert called["n"] == 1
     assert ss.cumulative_gain_validated == pytest.approx(0.0)
     assert ss.cumulative_gain_provenance != "geak_orch_harness_validated"
+    assert not ss.geak_pending
+    assert ss.resume_pending_revalidation is False
+    assert ss.geak_result["revalidation_status"] == "fallback_failed"
 
 
 @pytest.mark.asyncio

--- a/src/hyperloom/inference_optimizer/tests/test_geak_resume_recovery.py
+++ b/src/hyperloom/inference_optimizer/tests/test_geak_resume_recovery.py
@@ -107,10 +107,12 @@ async def test_geak_kernel_phase_recovers_existing_ok_result_on_resume(
     # The main-flow rebench was enqueued to validate the recovered candidate.
     rebench = [t for t in coord.tasks.created if (t.params or {}).get("geak_fallback")]
     assert rebench, "recovery must enqueue a geak main-flow rebench"
+    assert coord.shared_state.geak_pending["revalidation_task_id"] == rebench[0].task_id
 
     saved = json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))
     assert saved["geak_result"]["status"] == "ok"
     assert saved["geak_pending"]["status"] == "awaiting_rebench"
+    assert saved["geak_pending"]["revalidation_task_id"] == rebench[0].task_id
 
     task = await coord._enqueue_internal_sweep_task(reason="phase_entry")
 

--- a/src/hyperloom/inference_optimizer/tests/test_longrun_phase3.py
+++ b/src/hyperloom/inference_optimizer/tests/test_longrun_phase3.py
@@ -286,6 +286,84 @@ async def test_phase_transition_cancels_queued_specialist(cyclic_coordinator):
 
 
 @pytest.mark.asyncio
+async def test_geak_revalidation_blocks_sweep_transition_while_queued(cyclic_coordinator):
+    c = cyclic_coordinator
+    await _noop_phase_side_effects(c)
+    now = datetime.now(timezone.utc)
+    st = c.shared_state
+    st.phase = ps.PHASE_KERNEL_AGENT
+    st.phase_started_ts = (now - timedelta(minutes=5)).isoformat()
+    st.phase_started_unix = (now - timedelta(minutes=5)).timestamp()
+    st.start_ts = (now - timedelta(minutes=10)).isoformat()
+    st.max_minutes = 96 * 60
+    st.kernel_optimizer = "geak"
+    st.geak_result = {"status": "ok"}
+    st.geak_pending = {
+        "status": "awaiting_rebench",
+        "revalidation_task_id": "geak-revalidate-1",
+    }
+    st.set_pending_escalate_hint(ps.ESCALATE_HINT_SKIP_TO_SWEEP)
+
+    queued = await c.tasks.create(
+        kind="explore",
+        params={
+            "source": "resume_stack_revalidate",
+            "geak_fallback": True,
+        },
+        idempotency_key="geak-revalidate",
+        task_id="geak-revalidate-1",
+    )
+
+    await c._advance_phase_if_needed()
+
+    assert st.phase == ps.PHASE_KERNEL_AGENT
+    assert (await c.tasks.get(queued.task_id)).state == "queued"
+
+
+@pytest.mark.asyncio
+async def test_failed_geak_revalidation_releases_sweep_transition(cyclic_coordinator):
+    c = cyclic_coordinator
+    await _noop_phase_side_effects(c)
+    now = datetime.now(timezone.utc)
+    st = c.shared_state
+    st.phase = ps.PHASE_KERNEL_AGENT
+    st.phase_started_ts = (now - timedelta(minutes=5)).isoformat()
+    st.phase_started_unix = (now - timedelta(minutes=5)).timestamp()
+    st.start_ts = (now - timedelta(minutes=10)).isoformat()
+    st.max_minutes = 96 * 60
+    st.kernel_optimizer = "geak"
+    st.geak_result = {"status": "ok"}
+    st.geak_pending = {
+        "status": "awaiting_rebench",
+        "revalidation_task_id": "geak-revalidate-failed",
+    }
+    st.set_pending_escalate_hint(ps.ESCALATE_HINT_SKIP_TO_SWEEP)
+
+    task = await c.tasks.create(
+        kind="explore",
+        params={
+            "source": "resume_stack_revalidate",
+            "geak_fallback": True,
+        },
+        idempotency_key="geak-revalidate-failed",
+        task_id="geak-revalidate-failed",
+    )
+
+    await c._handle_unpromotable_result(
+        task,
+        {
+            "status": "failed",
+            "error_class": "subprocess_nonzero",
+            "error": "revalidation failed",
+        },
+    )
+    await c._advance_phase_if_needed()
+
+    assert not st.geak_pending
+    assert st.phase == ps.PHASE_SWEEP
+
+
+@pytest.mark.asyncio
 async def test_phase_transition_does_not_cancel_running_specialist(cyclic_coordinator):
     c = cyclic_coordinator
     await _noop_phase_side_effects(c)

--- a/src/hyperloom/orchestrator/loop/writeback.py
+++ b/src/hyperloom/orchestrator/loop/writeback.py
@@ -421,6 +421,25 @@ class WritebackCollaborator:
         if task.kind == "conc_sweep" and not result_payload.get("status"):
             result_payload["status"] = "failed"
         any_changed = False
+        params = task.params or {}
+        if task.kind == "explore" and bool(params.get("geak_fallback")):
+            pending = getattr(self.shared_state, "geak_pending", None) or {}
+            pending_task_id = str(pending.get("revalidation_task_id") or "") if isinstance(pending, dict) else ""
+            if not pending_task_id or pending_task_id == task.task_id:
+                geak_result = (
+                    dict(self.shared_state.geak_result)
+                    if isinstance(getattr(self.shared_state, "geak_result", None), dict)
+                    else {}
+                )
+                geak_result["revalidation_status"] = "failed"
+                geak_result["revalidation_error_class"] = str(result_payload.get("error_class") or "")
+                geak_result["revalidation_error"] = str(
+                    result_payload.get("error") or result_payload.get("reason") or ""
+                )[:500]
+                self.shared_state.geak_result = geak_result
+                self.shared_state.geak_pending = {}
+                self.shared_state.resume_pending_revalidation = False
+                any_changed = True
         # Per-action audit (failed attempt) for the in-scope kinds.
         if task.kind in _AUDIT_ACTIONS:
             audit_extras: dict[str, Any] = {}
@@ -3407,7 +3426,12 @@ class WritebackCollaborator:
                     params=params_ps,
                     idempotency_key="geak-revalidate",
                 )
-                return {"task_id": task.task_id, "existing": bool(existing), "mode": "geak_2b"}
+                return {
+                    "task_id": task.task_id,
+                    "task_state": task.state,
+                    "existing": bool(existing),
+                    "mode": "geak_2b",
+                }
 
         rebuilt = self._materialize_stack_config_for_resume()
         args = str(rebuilt.get("extra_server_args") or "").strip()

--- a/src/hyperloom/orchestrator/loop/writeback.py
+++ b/src/hyperloom/orchestrator/loop/writeback.py
@@ -2480,13 +2480,35 @@ class WritebackCollaborator:
                         got_hash,
                         (task.params or {}).get("expected_cfg_hash"),
                     )
+                    fallback_result: dict[str, Any]
                     try:
                         # Routed via ``_coord`` so a test / caller that overrides
                         # ``coordinator._validate_geak_via_geak_harness`` still wins
                         # (bare-name delegation resolves it back onto this class).
-                        await self._coord._validate_geak_via_geak_harness(reason="2b_inconclusive")
-                    except Exception:  # noqa: BLE001 - defensive
+                        fallback_result = await self._coord._validate_geak_via_geak_harness(
+                            reason="2b_inconclusive"
+                        )
+                    except Exception as exc:  # noqa: BLE001 - defensive
                         log.exception("geak 2a GEAK-harness fallback failed")
+                        fallback_result = {
+                            "validated": False,
+                            "reason": repr(exc),
+                        }
+                    if not bool(fallback_result.get("validated")):
+                        geak_result = (
+                            dict(self.shared_state.geak_result)
+                            if isinstance(getattr(self.shared_state, "geak_result", None), dict)
+                            else {}
+                        )
+                        geak_result["revalidation_status"] = "fallback_failed"
+                        geak_result["revalidation_error"] = str(
+                            fallback_result.get("reason")
+                            or fallback_result.get("status")
+                            or "GEAK harness fallback did not validate"
+                        )[:500]
+                        self.shared_state.geak_result = geak_result
+                        self.shared_state.geak_pending = {}
+                        self.shared_state.resume_pending_revalidation = False
                 changed = True
             else:
                 if measured_ok and self.shared_state.baseline_tput > 0:

--- a/src/hyperloom/orchestrator/phases/kernel.py
+++ b/src/hyperloom/orchestrator/phases/kernel.py
@@ -518,6 +518,36 @@ class KernelPhase(PhaseHandler):
             state.set_pending_escalate_hint(_phase_state.ESCALATE_HINT_SKIP_TO_SWEEP)
             state.save(self.session_dir)
 
+        async def _enqueue_geak_revalidation(*, reason: str) -> bool:
+            """Enqueue and persist the rebench that keeps a GEAK win pending."""
+            try:
+                summary = await self._enqueue_internal_stack_rebench(reason=reason)
+            except Exception as exc:  # noqa: BLE001 - defensive
+                log.exception("geak: enqueue same-harness revalidation failed")
+                summary = {"skipped": True, "reason": repr(exc)}
+
+            task_id = str(summary.get("task_id") or "") if isinstance(summary, dict) else ""
+            task_state = str(summary.get("task_state") or "queued").strip().lower() if task_id else ""
+            pending = dict(state.geak_pending) if isinstance(state.geak_pending, dict) else {}
+            if task_id and task_state in {"queued", "running"}:
+                pending["status"] = "awaiting_rebench"
+                pending["revalidation_task_id"] = task_id
+                state.geak_pending = pending
+                state.save(self.session_dir)
+                return True
+
+            pending["status"] = "rebench_unavailable"
+            pending["revalidation_error"] = str(
+                (summary or {}).get("reason") or f"task settled before dispatch ({task_state or 'unknown'})"
+            )[:500]
+            state.geak_pending = pending
+            state.save(self.session_dir)
+            log.warning(
+                "geak: same-harness revalidation unavailable; candidate remains audit-only (%s)",
+                pending["revalidation_error"],
+            )
+            return False
+
         # Crash-recovery: a validated result.json written before a coordinator
         # crash is promoted on resume, guarded by ``_geak_win_already_recorded``
         # so a prior cycle's result.json does not short-circuit a fresh entry.
@@ -530,10 +560,7 @@ class KernelPhase(PhaseHandler):
             )
             _promote_recovered_result(recovered, recovered_from="existing_result_json")
             if recovered.get("status") == "ok":
-                try:
-                    await self._enqueue_internal_stack_rebench(reason="geak_e2e_win_recovered")
-                except Exception:  # noqa: BLE001 - defensive
-                    log.exception("geak: enqueue rebench for recovered result failed")
+                await _enqueue_geak_revalidation(reason="geak_e2e_win_recovered")
             return
 
         try:
@@ -641,10 +668,7 @@ class KernelPhase(PhaseHandler):
                 )
                 # Rebench-first: enqueue the main-flow rebench (candidate stays
                 # pending if a budget cap prevents it from running).
-                try:
-                    await self._enqueue_internal_stack_rebench(reason="geak_e2e_win_sigterm_recovered")
-                except Exception:  # noqa: BLE001 - defensive
-                    log.exception("geak: enqueue rebench for sigterm-recovered result failed")
+                await _enqueue_geak_revalidation(reason="geak_e2e_win_sigterm_recovered")
                 return
             _finish_skip(
                 {
@@ -706,10 +730,7 @@ class KernelPhase(PhaseHandler):
         # Enqueue the same-harness config-identity rebench — the ONLY path that
         # writes the headline. Until it lands the candidate stays pending.
         if str(result.get("status") or "") == "ok":
-            try:
-                await self._enqueue_internal_stack_rebench(reason="geak_e2e_win")
-            except Exception:  # noqa: BLE001 - defensive
-                log.exception("geak: enqueue same-harness revalidation failed")
+            await _enqueue_geak_revalidation(reason="geak_e2e_win")
         self._record_phase_entry_evidence(
             geak={
                 "status": result.get("status"),

--- a/src/hyperloom/orchestrator/phases/machine_state.py
+++ b/src/hyperloom/orchestrator/phases/machine_state.py
@@ -1545,6 +1545,16 @@ def kernel_work_pending(state: Any) -> bool:
     time/budget exits are still handled by :func:`exit_normal_kernel`.
     """
     if _geak_phase_terminal(state):
+        result = getattr(state, "geak_result", None) or {}
+        pending = getattr(state, "geak_pending", None) or {}
+        if (
+            isinstance(result, dict)
+            and str(result.get("status") or "").strip().lower() == "ok"
+            and isinstance(pending, dict)
+            and str(pending.get("status") or "").strip().lower() == "awaiting_rebench"
+            and bool(str(pending.get("revalidation_task_id") or "").strip())
+        ):
+            return True
         return False
 
     try:


### PR DESCRIPTION
## Summary
- keep the KERNEL phase active while an actionable GEAK win revalidation is queued or running
- persist the revalidation task ID so phase advancement does not cancel it before dispatch
- release the phase guard when enqueueing or executing the revalidation fails
- preserve existing behavior for non-GEAK backends and terminal GEAK outcomes without a candidate

## Tests
- 81 focused GEAK tests passed
- 119 phase-machine and coordinator tests passed
