### PR TITLE
ci(e2e): also run e2e on PRs targeting v1.0-dev

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -7,7 +7,7 @@ name: CI E2E (single-GPU smoke run)
 
 on:
   pull_request:
-    branches: [main]          # only PRs whose BASE branch is main
+    branches: [main, v1.0-dev]   # PRs whose BASE branch is main or v1.0-dev
     # opened/synchronize/reopened = run on create + new commits + reopen.
     # labeled/unlabeled = re-evaluate when `skip-e2e-test` is added/removed.
     types: [opened, synchronize, reopened, labeled, unlabeled]


### PR DESCRIPTION
Adds v1.0-dev to the e2e workflow's branch filter so PRs targeting v1.0-dev also run the single-GPU e2e smoke test (pull_request uses the base branch's workflow, so this must live on v1.0-dev). Opt out with skip-e2e-test as usual.