### PR TITLE
fix(ray): default single-node Ray exec on

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -115,7 +115,7 @@ The following variables control the kernel optimization backend ladder.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `INFERENCE_OPTIMIZER_RAY_EXEC` | Unset (`off`) | Opt-in switch for routing single-node serving benchmarks and `needs_gpu` specialists through Ray actors. Set to `1` / `true` / `yes` / `on` to enable Ray-managed leases. Leave unset, or set `0` / `false` / `no` / `off`, to use the local subprocess path. Multi-node serving remains controlled by the multi-node backend. |
+| `INFERENCE_OPTIMIZER_RAY_EXEC` | Unset (`on` for single-node) | Controls whether single-node serving benchmarks and `needs_gpu` specialists run through Ray actors. When unset, single-node runs are routed through Ray-managed leases while multi-node stays on the multi-node backend. Set to `0` / `false` / `no` / `off` to force the local subprocess path, or `1` / `true` / `yes` / `on` to force Ray. |
 
 ---
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -27,12 +27,13 @@ The first public release of Hyperloom (1.0.0a1) combines features from the follo
   three hours remain. This removes legacy cyclic-mode branches and makes phase
   progression more predictable across bounded and long-horizon runs.
 
-- **Opt-in Ray serving and GPU execution**: The opt-in Ray path now places all
-  serving and GPU-specialist operations under the whole-machine `serving_slot`
+- **Ray-managed single-node serving and GPU execution**: The Ray path now places
+  all serving and GPU-specialist operations under the whole-machine `serving_slot`
   mutex, including framework-agent benchmarks, `integrate_patch`, and concurrency
   sweeps. GPU specialists can queue without blocking the Coordinator, serving
   receives scheduling priority, and stale AITER JIT locks are cleaned before
-  server launch. Local subprocess execution remains the default; multi-node
+  server launch. Single-node runs default to the Ray path; set
+  `INFERENCE_OPTIMIZER_RAY_EXEC=0` to force local subprocess execution. Multi-node
   behavior is unchanged.
 
 - **vLLM and serving-environment reliability**: Hyperloom now isolates co-located

--- a/src/hyperloom/inference_optimizer/tests/test_ray_backend_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_ray_backend_unit.py
@@ -43,15 +43,15 @@ def test_ray_exec_enabled_explicit_off(monkeypatch: pytest.MonkeyPatch, val: str
     assert rb.ray_exec_enabled() is False
 
 
-def test_ray_exec_off_by_default_on_single_node(
+def test_ray_exec_forced_on_single_node_by_default(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ):
-    """Unset env -> local subprocess path; Ray is opt-in."""
+    """Decision 2+4: unset env -> ON for single-node."""
     monkeypatch.delenv("INFERENCE_OPTIMIZER_RAY_EXEC", raising=False)
     monkeypatch.setenv("INFERENCE_OPTIMIZER_NODES", "1")
     monkeypatch.setenv("MULTI_NODE_STATE_FILE", str(tmp_path / "nope.json"))
-    assert rb.ray_exec_enabled() is False
+    assert rb.ray_exec_enabled() is True
 
 
 def test_ray_exec_off_on_multi_node_by_default(
@@ -1259,13 +1259,13 @@ def test_gpu_specialist_lease_close_kills_live_actor(monkeypatch: pytest.MonkeyP
     assert lease._actor is None
 
 
-def test_should_use_ray_backend_unset_single_node_false(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
-    """Env unset + not-under-pytest + single-node -> False (Ray is opt-in)."""
+def test_should_use_ray_backend_unset_single_node_true(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Env unset + not-under-pytest + single-node -> True (production default)."""
     monkeypatch.delenv("INFERENCE_OPTIMIZER_RAY_EXEC", raising=False)
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)  # bypass the pytest gate
     monkeypatch.setenv("INFERENCE_OPTIMIZER_NODES", "1")
     monkeypatch.setenv("MULTI_NODE_STATE_FILE", str(tmp_path / "nope.json"))
-    assert rb._should_use_ray_backend() is False
+    assert rb._should_use_ray_backend() is True  # 80-82
 
 
 def test_strip_visible_devices_write_error_returns_src(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):

--- a/src/hyperloom/orchestrator/actions/executors/_ray_backend.py
+++ b/src/hyperloom/orchestrator/actions/executors/_ray_backend.py
@@ -29,30 +29,36 @@ _RAY_OWNED_VISIBLE_DEVICE_VARS = (
 def ray_exec_enabled() -> bool:
     """Return whether GPU/serving work should run through the Ray backend.
 
-    Ray execution is opt-in. Set ``INFERENCE_OPTIMIZER_RAY_EXEC=1`` to route
-    single-node GPU/serving work through Ray. When unset, the local subprocess
-    path is used.
+    When ``INFERENCE_OPTIMIZER_RAY_EXEC`` is unset: ON for single-node, OFF for
+    multi-node. The env var is an explicit override / emergency escape valve.
     """
     val = os.environ.get("INFERENCE_OPTIMIZER_RAY_EXEC", "").strip().lower()
     if val in {"1", "true", "yes", "on"}:
         return True
     if val in {"0", "false", "no", "off"}:
         return False
-    return False
+    # Unset: single-node forced ON, multi-node OFF.
+    from ._multi_node_env import is_multi_node
+
+    return not is_multi_node()
 
 
 def _should_use_ray_backend() -> bool:
-    """Return whether the Ray execution route is explicitly enabled.
+    """Like :func:`ray_exec_enabled` but stays OFF under pytest when unset.
 
-    Tests and production both use the local subprocess path by default;
-    ``INFERENCE_OPTIMIZER_RAY_EXEC=1`` opts a run into the Ray path.
+    Tests run the local subprocess path by default; ``INFERENCE_OPTIMIZER_RAY_EXEC=1``
+    still opts a specific test into the Ray path.
     """
     val = os.environ.get("INFERENCE_OPTIMIZER_RAY_EXEC", "").strip().lower()
     if val in {"1", "true", "yes", "on"}:
         return True
     if val in {"0", "false", "no", "off"}:
         return False
-    return False
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        return False
+    from ._multi_node_env import is_multi_node
+
+    return not is_multi_node()
 
 
 def ray_gpu_specialist_exec_enabled() -> bool:


### PR DESCRIPTION
Restore single-node default to route GPU/serving work through the Ray backend when INFERENCE_OPTIMIZER_RAY_EXEC is unset. Multi-node stays off and pytest keeps the local subprocess path.
