### PR TITLE
fix(kernel): decouple fusion from GEMM tuning

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_coordinator_gemm_promote_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coordinator_gemm_promote_units.py
@@ -356,7 +356,7 @@ class TestPromoteFusionIntegrateKeep:
         assert coord.shared_state.last_fusion_integrate == {}
 
     @pytest.mark.asyncio
-    async def test_run_forge_fusion_after_gemm_handles_handler_exception(self, tmp_path, monkeypatch):
+    async def test_run_forge_fusion_handles_handler_exception(self, tmp_path, monkeypatch):
         coord = _coord(tmp_path)
         coord.bus = _Bus()
         phase = KernelPhase(coord)
@@ -366,7 +366,7 @@ class TestPromoteFusionIntegrateKeep:
 
         monkeypatch.setattr(krh_mod, "run_fusion_handler", _raise)
 
-        await phase._run_forge_fusion_after_gemm()
+        await phase._run_forge_fusion()
 
         assert coord.shared_state.last_fusion["decision"] == "REVERT"
         assert coord.shared_state.last_fusion["error_class"] == "RuntimeError"

--- a/src/hyperloom/inference_optimizer/tests/test_prelude_roofline.py
+++ b/src/hyperloom/inference_optimizer/tests/test_prelude_roofline.py
@@ -202,6 +202,32 @@ async def test_on_enter_kernel_reprofiles_on_change(coord: Coordinator, monkeypa
 
 
 @pytest.mark.asyncio
+async def test_on_enter_kernel_skips_gemm_but_still_runs_fusion(coord: Coordinator, monkeypatch):
+    """Disabling GEMM tuning must not disable the independently gated fusion stage."""
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_SKIP_GEMM_TUNING", "1")
+    monkeypatch.setattr(coord.phase_machine, "_kernel_enabled", lambda: True)
+    monkeypatch.setattr(coord.phase_kernel, "_geak_enabled", lambda: False)
+    monkeypatch.setattr(coord.phase_kernel, "_fusion_required_before_kernel_opt", lambda: True)
+    assert coord._gemm_tuning_required_before_kernel_opt() is False
+
+    fusion_calls = 0
+
+    async def _run_fusion() -> None:
+        nonlocal fusion_calls
+        fusion_calls += 1
+
+    async def _skip_reprofile() -> None:
+        return None
+
+    monkeypatch.setattr(coord.phase_kernel, "_run_forge_fusion", _run_fusion)
+    monkeypatch.setattr(coord.phase_kernel, "_maybe_reprofile_for_kernel", _skip_reprofile)
+
+    await coord._on_enter_kernel(from_phase="EXPLORE")
+
+    assert fusion_calls == 1
+
+
+@pytest.mark.asyncio
 async def test_kernel_entry_reprofile_skips_when_unchanged(coord: Coordinator):
     """Projected tput matching the last measured trace (cur == measured) skips the reprofile."""
     coord.shared_state.roofline_snapshots = [{"achieved_tok_per_sec": 100.0}]

--- a/src/hyperloom/orchestrator/phases/kernel.py
+++ b/src/hyperloom/orchestrator/phases/kernel.py
@@ -93,8 +93,10 @@ class KernelPhase(PhaseHandler):
             await self._run_geak_kernel_phase(from_phase=from_phase)
             return
         if not self._gemm_tuning_required_before_kernel_opt():
-            # No GEMM tuning here: refresh the snapshot before the LLM drives GEAK.
+            # GEMM tuning and fusion are independently gated. Refresh the
+            # snapshot, run fusion when eligible, then let the LLM drive GEAK.
             await self._maybe_reprofile_for_kernel()
+            await self._maybe_run_forge_fusion_before_kernel_opt()
             return
 
         # Refresh the snapshot before GEMM tuning targets the bottleneck.
@@ -167,11 +169,7 @@ class KernelPhase(PhaseHandler):
         )
         # Capture explore + GEMM-tuning gains before inline GEAK.
         await self._maybe_reprofile_for_kernel()
-        # Autonomous kernel fusion (forge-fusion) between GEMM tuning and generic
-        # kernel-opt; gated + non-blocking (a failure falls through to kernel-opt).
-        if self._fusion_required_before_kernel_opt():
-            await self._run_forge_fusion_after_gemm()
-            await self._maybe_reprofile_for_kernel()
+        await self._maybe_run_forge_fusion_before_kernel_opt()
         if self._should_continue_kernel_after_gemm():
             await self._run_kernel_opt_after_gemm()
 
@@ -1606,9 +1604,16 @@ class KernelPhase(PhaseHandler):
             return False
         return True
 
-    async def _run_forge_fusion_after_gemm(self) -> None:
-        """Run autonomous kernel fusion (forge-fusion) after GEMM tuning."""
-        log.info("KERNEL entry: running forge-fusion (autonomous kernel fusion) after GEMM")
+    async def _maybe_run_forge_fusion_before_kernel_opt(self) -> None:
+        """Run the independently gated forge-fusion stage before kernel_opt."""
+        if not self._fusion_required_before_kernel_opt():
+            return
+        await self._run_forge_fusion()
+        await self._maybe_reprofile_for_kernel()
+
+    async def _run_forge_fusion(self) -> None:
+        """Run autonomous kernel fusion during KERNEL entry."""
+        log.info("KERNEL entry: running forge-fusion (autonomous kernel fusion)")
         try:
             from ..kernel.request_handlers import run_fusion_handler
 


### PR DESCRIPTION
## Summary
- run the independently gated Forge Fusion stage even when GEMM tuning is disabled or already terminal
- centralize Fusion scheduling and remove the misleading after-GEMM execution name
- add regression coverage for `INFERENCE_OPTIMIZER_SKIP_GEMM_TUNING=1`

## Test plan
- [x] `python -m pytest src/hyperloom/inference_optimizer/tests/test_prelude_roofline.py src/hyperloom/inference_optimizer/tests/test_coordinator_gemm_promote_units.py src/hyperloom/inference_optimizer/tests/test_decision_framework.py -q` (86 passed)
- [x] `ruff check` and `ruff format --check` on all changed Python files