### PR TITLE
fix(kernel): prevent grouped stalls and leaked Forge processes

### DIFF
--- a/src/hyperloom/agents/kernel/tests/test_forge_export_restore.py
+++ b/src/hyperloom/agents/kernel/tests/test_forge_export_restore.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import subprocess
 import sys
 import tempfile
+import logging
 from pathlib import Path
 
 _BACKENDS_DIR = Path(__file__).resolve().parent.parent / "tools" / "backends"
@@ -364,6 +365,88 @@ def test_prepare_inplace_autorecovers_from_stale_forge_branch():
         assert _git(repo, "rev-parse", "--abbrev-ref", "HEAD") == "main"
         assert _git(repo, "branch", "--list", branch).strip() == "", "run temp branch must be deleted"
         print("PASS test_prepare_inplace_autorecovers_from_stale_forge_branch")
+
+
+def test_terminate_forge_process_sweeps_group_after_parent_exit(monkeypatch):
+    calls = []
+
+    class Proc:
+        pid = 123
+
+        @staticmethod
+        def communicate(timeout=None):
+            return "stdout", "stderr"
+
+    monkeypatch.setattr(forge_submit, "_descendant_processes", lambda _pid: [])
+    monkeypatch.setattr(
+        forge_submit.os,
+        "killpg",
+        lambda pgid, sig: calls.append((pgid, sig)),
+    )
+
+    out, err = forge_submit._terminate_forge_process(Proc(), grace_sec=0)
+
+    assert (out, err) == ("stdout", "stderr")
+    assert calls == [
+        (123, forge_submit.signal.SIGTERM),
+        (123, forge_submit.signal.SIGKILL),
+    ]
+
+
+def test_terminate_forge_process_reports_unreaped_group(
+    monkeypatch,
+    caplog,
+):
+    group_signals = []
+    process_signals = []
+
+    class Proc:
+        pid = 123
+
+        @staticmethod
+        def communicate(timeout=None):
+            raise subprocess.TimeoutExpired("forge-loop", timeout)
+
+        @staticmethod
+        def kill():
+            raise AssertionError("killpg succeeded; direct fallback is invalid")
+
+    monkeypatch.setattr(forge_submit, "_descendant_processes", lambda _pid: [])
+    monkeypatch.setattr(
+        forge_submit,
+        "_process_group_members",
+        lambda _pgid: [(456, 99, "D")],
+    )
+    monkeypatch.setattr(
+        forge_submit,
+        "_proc_identity",
+        lambda _pid: (1, 99),
+    )
+    monkeypatch.setattr(
+        forge_submit.os,
+        "killpg",
+        lambda pgid, sig: group_signals.append((pgid, sig)),
+    )
+    monkeypatch.setattr(
+        forge_submit.os,
+        "kill",
+        lambda pid, sig: process_signals.append((pid, sig)),
+    )
+
+    with caplog.at_level(logging.WARNING, logger=forge_submit.log.name):
+        out, err = forge_submit._terminate_forge_process(
+            Proc(),
+            grace_sec=0,
+        )
+
+    assert (out, err) == ("", "")
+    assert group_signals == [
+        (123, forge_submit.signal.SIGTERM),
+        (123, forge_submit.signal.SIGKILL),
+        (123, forge_submit.signal.SIGKILL),
+    ]
+    assert process_signals == [(456, forge_submit.signal.SIGKILL)]
+    assert "was not reaped after SIGKILL" in caplog.text
 
 
 if __name__ == "__main__":

--- a/src/hyperloom/agents/kernel/tools/backends/forge_submit.py
+++ b/src/hyperloom/agents/kernel/tools/backends/forge_submit.py
@@ -1795,29 +1795,81 @@ def _signal_processes(processes: list[tuple[int, int]], sig: int) -> None:
             continue
 
 
+def _process_group_members(pgid: int) -> list[tuple[int, int, str]]:
+    """Return live ``(pid, start_time, state)`` members of one process group."""
+    members: list[tuple[int, int, str]] = []
+    try:
+        proc_entries = list(Path("/proc").iterdir())
+    except OSError:
+        return members
+    for entry in proc_entries:
+        if not entry.name.isdigit():
+            continue
+        try:
+            stat_text = (entry / "stat").read_text()
+            closing_paren = stat_text.rfind(")")
+            fields = stat_text[closing_paren + 2 :].split()
+            if int(fields[2]) != pgid:
+                continue
+            members.append((int(entry.name), int(fields[19]), fields[0]))
+        except (OSError, ValueError, IndexError):
+            continue
+    return members
+
+
+def _signal_process_group(
+    pgid: int,
+    sig: int,
+    *,
+    phase: str,
+) -> bool | None:
+    """Signal a Forge-owned process group and warn on non-race failures."""
+    try:
+        os.killpg(pgid, sig)
+        return True
+    except ProcessLookupError:
+        return None
+    except (PermissionError, OSError) as exc:
+        log.warning(
+            "forge process-group %s failed: pgid=%d signal=%d error=%s",
+            phase,
+            pgid,
+            sig,
+            exc,
+        )
+        return False
+
+
 def _terminate_forge_process(
     proc: subprocess.Popen,
     *,
     grace_sec: int = _FORGE_SHUTDOWN_GRACE_SEC,
 ) -> tuple[str, str]:
     """Terminate the forge-loop process group, escalating after a grace period."""
+    pgid = proc.pid
     descendants = _descendant_processes(proc.pid)
-    try:
-        os.killpg(proc.pid, signal.SIGTERM)
-    except ProcessLookupError:
-        log.debug("forge process group %d exited before SIGTERM", proc.pid)
-    except (PermissionError, OSError):
+    if _signal_process_group(
+        pgid,
+        signal.SIGTERM,
+        phase="SIGTERM",
+    ) is False:
+        _signal_processes(descendants, signal.SIGTERM)
         try:
             proc.terminate()
         except OSError as exc:
-            log.debug(
-                "forge process %d exited before terminate fallback: %s",
+            log.warning(
+                "forge direct-process terminate fallback failed: pid=%d error=%s",
                 proc.pid,
                 exc,
             )
     try:
         stdout, stderr = proc.communicate(timeout=grace_sec)
         _signal_processes(descendants, signal.SIGKILL)
+        _signal_process_group(
+            pgid,
+            signal.SIGKILL,
+            phase="post-reap SIGKILL",
+        )
         return stdout or "", stderr or ""
     except subprocess.TimeoutExpired:
         descendants = list(
@@ -1829,23 +1881,47 @@ def _terminate_forge_process(
             )
         )
         _signal_processes(descendants, signal.SIGKILL)
-        try:
-            os.killpg(proc.pid, signal.SIGKILL)
-        except ProcessLookupError:
-            log.debug("forge process group %d exited before SIGKILL", proc.pid)
-        except (PermissionError, OSError):
+        if _signal_process_group(
+            pgid,
+            signal.SIGKILL,
+            phase="timeout SIGKILL",
+        ) is False:
             try:
                 proc.kill()
             except OSError as exc:
-                log.debug(
-                    "forge process %d exited before kill fallback: %s",
+                log.warning(
+                    "forge direct-process kill fallback failed: pid=%d error=%s",
                     proc.pid,
                     exc,
                 )
         try:
             stdout, stderr = proc.communicate(timeout=5)
+            _signal_process_group(
+                pgid,
+                signal.SIGKILL,
+                phase="final SIGKILL",
+            )
             return stdout or "", stderr or ""
         except subprocess.TimeoutExpired:
+            _signal_process_group(
+                pgid,
+                signal.SIGKILL,
+                phase="reap-timeout SIGKILL",
+            )
+            residual = _process_group_members(pgid)
+            _signal_processes(
+                [(pid, start_time) for pid, start_time, _state in residual],
+                signal.SIGKILL,
+            )
+            log.warning(
+                "forge process group was not reaped after SIGKILL: "
+                "pgid=%d residual=%s",
+                pgid,
+                [
+                    {"pid": pid, "state": state}
+                    for pid, _start_time, state in residual
+                ],
+            )
             return "", ""
 
 

--- a/src/hyperloom/inference_optimizer/tests/test_task_group_dispatch_accounting.py
+++ b/src/hyperloom/inference_optimizer/tests/test_task_group_dispatch_accounting.py
@@ -727,6 +727,51 @@ def test_integrate_rejection_does_not_poison_reused_ordinal(tmp_path):
     assert [candidate["kernel_id"] for candidate in selected] == ["k002"]
 
 
+def test_grouped_integrate_revert_clears_kernel_work_pending():
+    state = SharedState()
+    state.record_kernel_opt(
+        {
+            "status": "ok",
+            "kernel_id": "k002",
+            "source_file": "/repo/operator.py",
+            "task_group_id": "tg001",
+            "task_group_key": "stable-task",
+            "task_group_primary_kernel_id": "k002",
+            "task_group_kernel_ids": ["k002"],
+            "proposal": {"decision": "KEEP"},
+            "verification": {
+                "micro_speedup": 1.2,
+                "best_artifact_path": "/artifacts/operator.py",
+            },
+            "attempts": [],
+        }
+    )
+    pending = state.pending_kernel_integration_records()[0]
+
+    state.record_kernel_integrate_result(
+        {
+            "status": "ok",
+            "decision": "REVERT",
+            "integration_id": pending["integration_id"],
+            "kernel_id": "k002",
+            "task_group_key": "stable-task",
+            "patch_path": "/artifacts/operator.py",
+            "target_file": "/repo/operator.py",
+            "gain_pct": -1.0,
+        }
+    )
+
+    assert (
+        state.kernel_opt_task_attempts["stable-task"]["integration_status"]
+        == "rejected"
+    )
+    assert (
+        state.kernel_opt_attempts["k002"]["integration_status"]
+        == "rejected"
+    )
+    assert kernel_work_pending(state) is False
+
+
 @pytest.mark.asyncio
 async def test_single_dispatch_serializes_grouped_candidate(tmp_path, monkeypatch):
     candidate = {

--- a/src/hyperloom/orchestrator/kernel/_kernel_decisions.py
+++ b/src/hyperloom/orchestrator/kernel/_kernel_decisions.py
@@ -699,10 +699,33 @@ def record_kernel_integrate_result(
         state.rejected_kernel_ids.append(kernel_id)
     entry["rejected"] = rejected
     state.kernel_integrate_attempts[key] = entry
+    task_key = str(
+        (
+            pending_record.get("task_key")
+            if isinstance(pending_record, dict)
+            else ""
+        )
+        or task_group_key
+        or ""
+    )
     if isinstance(pending_record, dict):
         pending_record["status"] = "rejected"
         pending_record["rejected_at"] = _now_iso()
         pending_record["rejected_reason"] = reason
+    if task_key:
+        stable_attempt = (state.kernel_opt_task_attempts or {}).get(task_key)
+        if isinstance(stable_attempt, dict):
+            stable_attempt["integration_status"] = "rejected"
+            stable_attempt["integration_rejected_reason"] = reason
+            stable_attempt["integration_rejected_at"] = _now_iso()
+        ordinal_attempt = (state.kernel_opt_attempts or {}).get(kernel_id)
+        if (
+            isinstance(ordinal_attempt, dict)
+            and str(ordinal_attempt.get("stable_task_key") or "") == task_key
+        ):
+            ordinal_attempt["integration_status"] = "rejected"
+            ordinal_attempt["integration_rejected_reason"] = reason
+            ordinal_attempt["integration_rejected_at"] = _now_iso()
     return entry
 
 

--- a/src/hyperloom/orchestrator/phases/machine_state.py
+++ b/src/hyperloom/orchestrator/phases/machine_state.py
@@ -1510,6 +1510,11 @@ def kernel_work_pending(state: Any) -> bool:
         decision = str(attempt.get("last_decision") or "").strip().upper()
         status = str(attempt.get("last_status") or "").strip().lower()
         rejected_reason = str(attempt.get("rejected_reason") or "").strip()
+        integration_status = str(
+            attempt.get("integration_status") or ""
+        ).strip().lower()
+        if integration_status in {"integrated", "rejected"}:
+            continue
         if kernel_id in rejected and (not task_group_key or rejected_reason):
             continue
         if decision == "KEEP":


### PR DESCRIPTION
Mark terminal integration rejections on stable task state and aggressively clean timed-out Forge process groups so kernel orchestration can progress safely.

- Description: what and why
- Linked issue(s): close/fix refs
- Tests: added/updated? commands run?
- Breaking changes: yes/no (details if yes)
