### PR TITLE
fix(multi-node): prevent duplicate RayJob from divergent create-rayjo…

### DIFF
--- a/src/hyperloom/inference_optimizer/multi_node/SKILL.md
+++ b/src/hyperloom/inference_optimizer/multi_node/SKILL.md
@@ -314,6 +314,20 @@ resume an in-flight launch (`MULTI_NODE_RESTART_RESUME_RUNNING=1`, default).
 
 ## Call Order
 
+> **STOP — are you running the `optimize` CLI?** If the task runs
+> `python -m hyperloom.inference_optimizer.cli optimize --nodes N>=2
+> --mn-backend rayjob ...` (i.e. you were handed `optimize`-style FLAGS
+> like `--target-gain` / `--max-hours` / `--isl/--osl/--conc`), then
+> **`optimize` performs this ENTIRE Call Order internally** — it
+> provisions/reuses the RayJob, bootstraps, and restarts the server per
+> round. In that mode **run `optimize` ONLY**; do **NOT** also run a
+> standalone `create-rayjob` / `init-env` / `restart-server` first or
+> alongside it. Doing so provisions a SECOND RayJob (the standalone CLI
+> and `optimize`'s in-process provisioning may resolve different state
+> files and each create their own workload), wasting a full node set and
+> deadlocking scheduling. The manual steps below are ONLY for driving the
+> RayJob lifecycle *without* `optimize`.
+
 1. **`create-rayjob`** — once. Persists `rayjob_id` before polling
    (overlapping retries never spawn a second RayJob), then fills
    `head_pod_ip` / `service_url` once phase is `Running`.

--- a/src/hyperloom/inference_optimizer/multi_node/commands/rayjob.py
+++ b/src/hyperloom/inference_optimizer/multi_node/commands/rayjob.py
@@ -24,9 +24,10 @@ import json
 import os
 import secrets
 import time
+from pathlib import Path
 from typing import Any
 
-from ...session.paths import mn_profile_trace_root
+from ...session.paths import ENV_CURRENT_SESSION_DIR, mn_profile_trace_root
 from .._internal import safe_client, ray_dashboard, workload_spec
 from .._internal.log import info, warn
 
@@ -48,6 +49,57 @@ _SAFE_GET_WORKLOAD_404_GRACE_S = 30.0
 _TERMINAL_FAIL_PHASES = {"Failed", "Stopped", "Cancelled"}
 
 _TERMINAL_OK_PHASES = {"Running"}
+
+
+def _prior_rayjob_ids_from_state_files() -> list[str]:
+    """Collect candidate ``rayjob_id`` values from every canonical state-file location.
+
+    The idempotency guard must survive state-file path divergence. ``optimize``
+    self-provisions using :func:`resolve_state_file` (session-dir), while a
+    separately-launched ``create-rayjob`` may pin
+    ``MULTI_NODE_STATE_FILE=/tmp/multi_node_state.json``; each writes its own
+    file, so a guard that reads only the current process's resolved path misses
+    the other invocation's ``rayjob_id`` and leaks a duplicate workload. Read
+    ``rayjob_id`` from all known locations (the resolved path, the session-dir
+    path, and the legacy ``/tmp`` file), de-duplicated and ordered
+    most-specific-first. Best-effort: missing / unreadable files are skipped and
+    never raise.
+
+    Returns:
+        list[str]: Distinct non-empty ``rayjob_id`` values, resolved-path first.
+    """
+    from ..state_paths import legacy_state_file, resolve_state_file
+
+    paths: list[Path] = []
+    try:
+        paths.append(resolve_state_file())
+    except Exception:  # noqa: BLE001 - resolution may raise when unpinned
+        pass
+    sess = os.environ.get(ENV_CURRENT_SESSION_DIR, "").strip()
+    if sess:
+        paths.append(Path(sess) / "runtime" / "multi_node_state.json")
+    paths.append(legacy_state_file())
+
+    ids: list[str] = []
+    seen_paths: set[str] = set()
+    for p in paths:
+        try:
+            key = str(p.resolve())
+        except OSError:
+            key = str(p)
+        if key in seen_paths:
+            continue
+        seen_paths.add(key)
+        try:
+            if not p.is_file():
+                continue
+            data = json.loads(p.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, TypeError, ValueError):
+            continue
+        wid = str((data or {}).get("rayjob_id") or "").strip()
+        if wid and wid not in ids:
+            ids.append(wid)
+    return ids
 
 
 def _checkpoint_create_rayjob_state(
@@ -316,35 +368,44 @@ def cmd_create_rayjob(args: argparse.Namespace) -> int:
     body: dict[str, Any] | None = None
 
     with safe_client.from_env() as safe:
-        # Idempotency guard: reuse a state ``rayjob_id`` that's still
-        # non-terminal in SaFE (--recreate forces a fresh workload).
+        # Idempotency guard: reuse any state ``rayjob_id`` that's still
+        # non-terminal in SaFE (--recreate forces a fresh workload). Scan ALL
+        # canonical state-file locations, not just this process's resolved path:
+        # a separately-launched create-rayjob (e.g. one that pinned
+        # MULTI_NODE_STATE_FILE=/tmp) and optimize's in-process provisioning
+        # (session-dir path) otherwise miss each other's rayjob_id and leak a
+        # duplicate workload.
         wid: str | None = None
-        existing = _mn_cli()._load_state()
-        prior_wid = (existing.get("rayjob_id") or "").strip()
-        if prior_wid and not getattr(args, "recreate", False):
+        prior_wids = [] if getattr(args, "recreate", False) else _prior_rayjob_ids_from_state_files()
+        for prior_wid in prior_wids:
             try:
                 prior_wl = safe.get_workload(prior_wid)
             except safe_client.SafeApiError as exc:
                 if exc.status == 404:
-                    info(f"prior rayjob_id={prior_wid} no longer exists in SaFE; will create a fresh workload")
-                else:
-                    raise
-            else:
-                prior_phase = str(prior_wl.get("phase") or "?")
-                if prior_phase in _TERMINAL_FAIL_PHASES:
-                    info(
-                        f"prior rayjob_id={prior_wid} is in terminal phase "
-                        f"{prior_phase!r}; will create a fresh workload"
-                    )
-                else:
-                    info(
-                        f"reusing existing rayjob_id={prior_wid} from state file "
-                        f"(phase={prior_phase}); will resume polling instead of "
-                        f"creating a new workload"
-                    )
-                    wid = prior_wid
+                    info(f"prior rayjob_id={prior_wid} no longer exists in SaFE; skipping")
+                    continue
+                raise
+            prior_phase = str(prior_wl.get("phase") or "?")
+            if prior_phase in _TERMINAL_FAIL_PHASES:
+                info(
+                    f"prior rayjob_id={prior_wid} is in terminal phase "
+                    f"{prior_phase!r}; skipping"
+                )
+                continue
+            info(
+                f"reusing existing rayjob_id={prior_wid} from state file "
+                f"(phase={prior_phase}); will resume polling instead of "
+                f"creating a new workload"
+            )
+            wid = prior_wid
+            break
 
         if wid is None:
+            if prior_wids:
+                info(
+                    "no reusable non-terminal workload among prior rayjob_ids "
+                    f"{prior_wids}; creating a fresh workload"
+                )
             pending_dashboard_token = secrets.token_urlsafe(32)
             env = dict(extra_env)
             env["RAY_DASHBOARD_TOKEN"] = pending_dashboard_token

--- a/src/hyperloom/inference_optimizer/multi_node/commands/rayjob.py
+++ b/src/hyperloom/inference_optimizer/multi_node/commands/rayjob.py
@@ -68,28 +68,29 @@ def _prior_rayjob_ids_from_state_files() -> list[str]:
     Returns:
         list[str]: Distinct non-empty ``rayjob_id`` values, resolved-path first.
     """
-    from ..state_paths import legacy_state_file, resolve_state_file
+    ids: list[str] = []
 
-    paths: list[Path] = []
+    # Primary source: the CLI's canonical state loader. It honors the same
+    # MULTI_NODE_STATE_FILE / session-dir resolution the rest of the CLI uses
+    # (and is the seam unit tests patch), so keep it authoritative and first.
     try:
-        paths.append(resolve_state_file())
-    except Exception:  # noqa: BLE001 - resolution may raise when unpinned
-        pass
+        primary = str((_mn_cli()._load_state() or {}).get("rayjob_id") or "").strip()
+    except Exception:  # noqa: BLE001 - never let state read block creation
+        primary = ""
+    if primary:
+        ids.append(primary)
+
+    # Additional canonical locations a *differently-configured* invocation may
+    # have written (state-path divergence): the session-dir file and the legacy
+    # /tmp file. De-dup by rayjob_id, so overlap with the primary path is fine.
+    from ..state_paths import legacy_state_file
+
+    extra_paths: list[Path] = []
     sess = os.environ.get(ENV_CURRENT_SESSION_DIR, "").strip()
     if sess:
-        paths.append(Path(sess) / "runtime" / "multi_node_state.json")
-    paths.append(legacy_state_file())
-
-    ids: list[str] = []
-    seen_paths: set[str] = set()
-    for p in paths:
-        try:
-            key = str(p.resolve())
-        except OSError:
-            key = str(p)
-        if key in seen_paths:
-            continue
-        seen_paths.add(key)
+        extra_paths.append(Path(sess) / "runtime" / "multi_node_state.json")
+    extra_paths.append(legacy_state_file())
+    for p in extra_paths:
         try:
             if not p.is_file():
                 continue


### PR DESCRIPTION
…b state files

A sandbox spawned two RayJobs: a standalone create-rayjob (pinning MULTI_NODE_STATE_FILE=/tmp) and optimize's in-process provisioning (session-dir state) resolved DIFFERENT state files, so each idempotency guard missed the other's rayjob_id and created its own workload -- wasting a full node set and deadlocking scheduling on a GPU-constrained cluster.

- rayjob.py: broaden cmd_create_rayjob's idempotency guard to scan ALL canonical state-file locations (resolved path, session-dir, legacy /tmp) for a live rayjob_id and reuse the first non-terminal one, instead of reading only the current process's resolved path. New helper _prior_rayjob_ids_from_state_files() (best-effort; missing/unreadable files skipped). CLI self-provisioning behavior is unchanged.
- SKILL.md: add a STOP note at the top of Call Order clarifying that `optimize --nodes>=2` self-provisions the whole lifecycle -- run optimize ONLY, never also run a standalone create-rayjob/init-env/restart-server, which is what leaked the second RayJob.

- Description: what and why
- Linked issue(s): close/fix refs
- Tests: added/updated? commands run?
- Breaking changes: yes/no (details if yes)
