### PR TITLE
fix(inference): stop forcing the triton MoE runner onto aiter-only quant schemes

### DIFF
--- a/src/hyperloom/inference_optimizer/cli/model_gate.py
+++ b/src/hyperloom/inference_optimizer/cli/model_gate.py
@@ -256,6 +256,17 @@ _AMD_UNSUPPORTED_QUANT_ALGOS = frozenset({"nvfp4", "fp4"})
 
 _AMD_UNSUPPORTED_QUANT_METHODS = frozenset({"bitsandbytes", "bnb"})
 
+# Quark PTQ 4-bit MoE schemes (MXFP4 / W4A4) are implemented in sglang only on
+# the aiter/native MoE runner path; the triton runner leaves the scheme without
+# a ``runner`` attribute and the server dies on the first forward pass.
+_NATIVE_MOE_RUNNER_QUANT_METHODS = frozenset({"quark"})
+
+_MXFP4_QUANT_MARKERS = ("mxfp4", "mx_fp4", "w4a4")
+
+# ``fp4`` alone is ambiguous (nvfp4 uses it too); the e8m0 scale format is what
+# makes it MX.
+_MX_SCALE_MARKER = "e8m0"
+
 # Quant methods with a real vLLM/sglang loader. Anything else declared in
 # config.json is a private/third-party format that fails in engine init.
 # bitsandbytes/bnb are listed here but separately gated on AMD.
@@ -666,6 +677,51 @@ def _model_is_moe(model_path: str) -> bool:
         if "moe" in str(cfg.get("model_type") or "").lower():
             return True
         if any("moe" in arch.lower() for arch in _config_architectures(cfg)):
+            return True
+    return False
+
+
+def _model_moe_runner_requires_aiter(model_path: str) -> bool:
+    """Best-effort detect a MoE quant scheme that only the aiter runner serves.
+
+    A Quark PTQ 4-bit MoE checkpoint (MXFP4 / W4A4, e.g.
+    Qwen3.5-397B-A17B-MXFP4) is only wired up on sglang's aiter/native MoE
+    runner. Forcing ``--moe-runner-backend triton`` builds the scheme without a
+    ``runner`` attribute, so the first forward pass raises ``AttributeError``
+    and the server dies during cuda-graph capture. Callers use this to skip the
+    AMD triton injection and let sglang pick the backend itself. Checks the top
+    level and a nested ``text_config``. Soft-degrades to False on any missing /
+    unreadable / invalid config.
+
+    Args:
+        model_path (str): The local model directory containing ``config.json``.
+
+    Returns:
+        bool: ``True`` when the checkpoint carries a Quark 4-bit MoE scheme.
+    """
+    if not model_path:
+        return False
+    data = _load_model_config_dict(model_path)
+    if data is None:
+        return False
+    candidates = [data]
+    nested = data.get("text_config")
+    if isinstance(nested, dict):
+        candidates.append(nested)
+    for cfg in candidates:
+        qc = cfg.get("quantization_config")
+        if not isinstance(qc, dict):
+            continue
+        method = str(qc.get("quant_method") or "").strip().lower()
+        if method not in _NATIVE_MOE_RUNNER_QUANT_METHODS:
+            continue
+        try:
+            blob = json.dumps(qc).lower()
+        except (TypeError, ValueError):
+            blob = str(qc).lower()
+        if any(marker in blob for marker in _MXFP4_QUANT_MARKERS):
+            return True
+        if "fp4" in blob and _MX_SCALE_MARKER in blob:
             return True
     return False
 

--- a/src/hyperloom/inference_optimizer/cli/model_gate.py
+++ b/src/hyperloom/inference_optimizer/cli/model_gate.py
@@ -17,6 +17,7 @@ import sys
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from .. import gpu_types as _gpu_types
 from ..model_config_utils import (  # noqa: F401 - re-exported for callers/tests
@@ -256,16 +257,16 @@ _AMD_UNSUPPORTED_QUANT_ALGOS = frozenset({"nvfp4", "fp4"})
 
 _AMD_UNSUPPORTED_QUANT_METHODS = frozenset({"bitsandbytes", "bnb"})
 
-# Quark PTQ 4-bit MoE schemes (MXFP4 / W4A4) are implemented in sglang only on
-# the aiter/native MoE runner path; the triton runner leaves the scheme without
-# a ``runner`` attribute and the server dies on the first forward pass.
+# Quark PTQ MX-FP4 (W4A4) MoE is implemented in sglang only on its aiter MoE
+# runner; every other backend leaves the scheme without a ``runner`` attribute
+# and the server dies on the first forward pass.
 _NATIVE_MOE_RUNNER_QUANT_METHODS = frozenset({"quark"})
 
-_MXFP4_QUANT_MARKERS = ("mxfp4", "mx_fp4", "w4a4")
+# MX group size, mirroring sglang's ``QuarkConfig._is_mx_fp4`` validation.
+_MX_FP4_GROUP_SIZE = 32
 
-# ``fp4`` alone is ambiguous (nvfp4 uses it too); the e8m0 scale format is what
-# makes it MX.
-_MX_SCALE_MARKER = "e8m0"
+# sglang resolves a layer's quant config from these, most specific first.
+_QUARK_LAYER_CONFIG_KEYS = ("layer_quant_config", "layer_type_quant_config")
 
 # Quant methods with a real vLLM/sglang loader. Anything else declared in
 # config.json is a private/third-party format that fails in engine init.
@@ -681,23 +682,58 @@ def _model_is_moe(model_path: str) -> bool:
     return False
 
 
+def _is_quark_mx_fp4_entry(entry: Any) -> bool:
+    """Whether one Quark layer-config entry is the MX-FP4 (W4A4) scheme.
+
+    Mirrors sglang's ``QuarkConfig._is_mx_fp4``: weights and activations both
+    fp4, per-group with group size 32 and e8m0 scales, weights statically and
+    activations dynamically quantized. Keeping the predicate identical to
+    upstream is what makes the gate trustworthy -- a looser string match would
+    both miss real checkpoints and fire on nvfp4 ones.
+
+    Args:
+        entry (Any): A Quark config entry with ``weight`` / ``input_tensors``.
+
+    Returns:
+        bool: ``True`` when the entry describes the MX-FP4 scheme.
+    """
+    if not isinstance(entry, dict):
+        return False
+    weight = entry.get("weight")
+    inputs = entry.get("input_tensors")
+    if not isinstance(weight, dict) or not isinstance(inputs, dict):
+        return False
+    for spec in (weight, inputs):
+        if spec.get("dtype") != "fp4" or spec.get("qscheme") != "per_group":
+            return False
+        if spec.get("group_size") != _MX_FP4_GROUP_SIZE:
+            return False
+        if spec.get("scale_format") != "e8m0":
+            return False
+    return weight.get("is_dynamic") is not True and inputs.get("is_dynamic") is not False
+
+
 def _model_moe_runner_requires_aiter(model_path: str) -> bool:
     """Best-effort detect a MoE quant scheme that only the aiter runner serves.
 
-    A Quark PTQ 4-bit MoE checkpoint (MXFP4 / W4A4, e.g.
-    Qwen3.5-397B-A17B-MXFP4) is only wired up on sglang's aiter/native MoE
-    runner. Forcing ``--moe-runner-backend triton`` builds the scheme without a
-    ``runner`` attribute, so the first forward pass raises ``AttributeError``
-    and the server dies during cuda-graph capture. Callers use this to skip the
-    AMD triton injection and let sglang pick the backend itself. Checks the top
-    level and a nested ``text_config``. Soft-degrades to False on any missing /
-    unreadable / invalid config.
+    A Quark PTQ MX-FP4 MoE checkpoint (e.g. Qwen3.5-397B-A17B-MXFP4) is only
+    wired up on sglang's aiter MoE runner. Forcing ``--moe-runner-backend
+    triton`` builds the scheme without a ``runner`` attribute, so the first
+    forward pass raises ``AttributeError`` and the server dies during
+    cuda-graph capture. Callers use this to skip the AMD triton injection and
+    let sglang pick the backend itself.
+
+    Any entry may decide it: sglang resolves a MoE layer's config from
+    ``layer_quant_config`` / ``layer_type_quant_config`` before falling back to
+    ``global_quant_config``, and a mixed checkpoint can carry MX-FP4 experts
+    next to fp8 attention. Checks the top level and a nested ``text_config``.
+    Soft-degrades to False on any missing / unreadable / invalid config.
 
     Args:
         model_path (str): The local model directory containing ``config.json``.
 
     Returns:
-        bool: ``True`` when the checkpoint carries a Quark 4-bit MoE scheme.
+        bool: ``True`` when the checkpoint carries a Quark MX-FP4 MoE scheme.
     """
     if not model_path:
         return False
@@ -712,18 +748,43 @@ def _model_moe_runner_requires_aiter(model_path: str) -> bool:
         qc = cfg.get("quantization_config")
         if not isinstance(qc, dict):
             continue
-        method = str(qc.get("quant_method") or "").strip().lower()
-        if method not in _NATIVE_MOE_RUNNER_QUANT_METHODS:
+        if str(qc.get("quant_method") or "").strip().lower() not in _NATIVE_MOE_RUNNER_QUANT_METHODS:
             continue
-        try:
-            blob = json.dumps(qc).lower()
-        except (TypeError, ValueError):
-            blob = str(qc).lower()
-        if any(marker in blob for marker in _MXFP4_QUANT_MARKERS):
-            return True
-        if "fp4" in blob and _MX_SCALE_MARKER in blob:
+        entries: list[Any] = [qc.get("global_quant_config")]
+        for key in _QUARK_LAYER_CONFIG_KEYS:
+            per_layer = qc.get(key)
+            if isinstance(per_layer, dict):
+                entries.extend(per_layer.values())
+        if any(_is_quark_mx_fp4_entry(entry) for entry in entries):
             return True
     return False
+
+
+def _model_declared_quant_method(model_path: str) -> str:
+    """Return the checkpoint's declared ``quant_method``, lowercased.
+
+    Args:
+        model_path (str): The local model directory containing ``config.json``.
+
+    Returns:
+        str: The declared quant method, or ``""`` when absent/unreadable.
+    """
+    if not model_path:
+        return ""
+    data = _load_model_config_dict(model_path)
+    if data is None:
+        return ""
+    candidates = [data]
+    nested = data.get("text_config")
+    if isinstance(nested, dict):
+        candidates.append(nested)
+    for cfg in candidates:
+        qc = cfg.get("quantization_config")
+        if isinstance(qc, dict):
+            method = str(qc.get("quant_method") or "").strip().lower()
+            if method:
+                return method
+    return ""
 
 
 def _detect_amd_unsupported_quant(model_path: str) -> str | None:

--- a/src/hyperloom/inference_optimizer/tests/test_baseline_moe_runner_fallback.py
+++ b/src/hyperloom/inference_optimizer/tests/test_baseline_moe_runner_fallback.py
@@ -1,0 +1,380 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Baseline one-shot fallback when the injected MoE runner backend kills the server.
+
+Hyperloom injects ``--moe-runner-backend triton`` for MoE sglang models on AMD.
+Quant schemes without a triton MoE runner (e.g. Quark MXFP4) crash on the first
+forward pass; the executor retries once with the flag dropped.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from hyperloom.orchestrator.actions.executors.baseline import BaselineExecutor
+
+_QUARK_TRACEBACK = (
+    'File ".../quark/schemes/quark_w4a4_mxfp4_moe.py", line 295, in apply_weights\n'
+    "    return self.runner.run(dispatch_output, quant_info)\n"
+    "AttributeError: 'QuarkW4A4MXFp4MoE' object has no attribute 'runner'\n"
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_leak_root(tmp_path_factory, monkeypatch):
+    sandbox = tmp_path_factory.mktemp("isolated_leak_root")
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_LEAK_ROOTS", str(sandbox))
+    monkeypatch.delenv("HYPERLOOM_SGLANG_MOE_RUNNER_BACKEND", raising=False)
+
+
+def _moe_model_dir(tmp_path: Path) -> str:
+    """A MoE checkpoint dir with no quant marker (so triton IS injected)."""
+    d = tmp_path / "Qwen3-30B-A3B"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "config.json").write_text(
+        json.dumps({"architectures": ["Qwen3MoeForCausalLM"], "model_type": "qwen3_moe", "num_experts": 128}),
+        encoding="utf-8",
+    )
+    return str(d)
+
+
+def _write_yaml(path: Path, model: str) -> None:
+    cfg = {
+        "benchmark": {
+            "framework": "sglang",
+            "model": model,
+            "precision": "bf16",
+            "run_mode": "local",
+            "envs": {"TP": 1, "CONC": 8, "ISL": 256, "OSL": 256},
+            "timeout_seconds": 600,
+            "profiler": {
+                "torch_profiler": {"enabled": False},
+                "system_profiler": {"enabled": False},
+                "tracelens": {"enabled": False},
+            },
+            "gpu_selection": {"auto": False},
+        }
+    }
+    with path.open("w") as f:
+        yaml.safe_dump(cfg, f)
+
+
+def _fake_workspace(slot: Path, *, tput: float = 1237.0) -> Path:
+    ws = slot / "benchmark_sglang_20260728_010101"
+    ws.mkdir(parents=True)
+    (ws / "benchmark_report.json").write_text(
+        json.dumps(
+            {
+                "success": True,
+                "framework": "sglang",
+                "throughput": {
+                    "request_throughput": tput / 256,
+                    "output_throughput": tput,
+                    "total_token_throughput": tput * 2,
+                    "completed_requests": 64,
+                    "duration_seconds": 25.0,
+                },
+                "latency": {
+                    "ttft": {"mean_ms": 100.0, "p99_ms": 120.0},
+                    "e2el": {"mean_ms": 2000.0, "p99_ms": 2300.0},
+                },
+            }
+        )
+    )
+    return ws
+
+
+def _make_ctx(params: dict) -> SimpleNamespace:
+    task = SimpleNamespace(task_id="t-moe-1", params=params)
+    return SimpleNamespace(task=task, extra={})
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# --- _is_moe_runner_rooted_failure -----------------------------------------
+def test_moe_runner_failure_from_error_tail():
+    result = {"status": "failed", "error": _QUARK_TRACEBACK}
+    assert BaselineExecutor._is_moe_runner_rooted_failure(result) is True
+
+
+def test_moe_runner_failure_scans_logs(tmp_path: Path):
+    out = tmp_path / "task"
+    ws = out / "benchmark_sglang_x"
+    ws.mkdir(parents=True)
+    (ws / "server.log").write_text(_QUARK_TRACEBACK, encoding="utf-8")
+    result = {"status": "failed", "error": "server died during startup", "output_dir": str(out)}
+    assert BaselineExecutor._is_moe_runner_rooted_failure(result) is True
+
+
+def test_moe_runner_failure_negative():
+    result = {"status": "failed", "error": "CUDA out of memory"}
+    assert BaselineExecutor._is_moe_runner_rooted_failure(result) is False
+
+
+# --- end-to-end fallback ----------------------------------------------------
+def _sglang_args(cmd) -> str:
+    cfg = yaml.safe_load(Path(cmd[cmd.index("--benchmark-config") + 1]).read_text())
+    return str(cfg["benchmark"]["envs"].get("EXTRA_SGLANG_ARGS", ""))
+
+
+def test_moe_runner_crash_triggers_flagless_retry(tmp_path, monkeypatch):
+    monkeypatch.setenv("GPU_TYPE", "mi300x")
+    model = _moe_model_dir(tmp_path)
+    base = tmp_path / "base.yaml"
+    _write_yaml(base, model)
+    calls: list[str] = []
+
+    def fake_run(cmd, *args, **kwargs):
+        sglang_args = _sglang_args(cmd)
+        calls.append(sglang_args)
+        if "--moe-runner-backend" in sglang_args:
+            return subprocess.CompletedProcess(cmd, 1, "", _QUARK_TRACEBACK)
+        _fake_workspace(Path(cmd[cmd.index("--output-dir") + 1]))
+        return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+    executor = BaselineExecutor(
+        magpie_python="/opt/venv/bin/python",
+        default_config_path=base,
+        session_dir=tmp_path,
+    )
+    ctx = _make_ctx(
+        {
+            "output_dir": str(tmp_path / "ws"),
+            "timeout_sec": 10,
+            "model_path": model,
+            "gpu_type": "mi300x",
+            "disable_run_eval": True,
+        }
+    )
+    with patch(
+        "hyperloom.orchestrator.actions.executors.baseline.run_with_session_kill",
+        side_effect=fake_run,
+    ):
+        result = _run(executor(ctx))
+
+    # Warmup crashes on triton, the retry re-runs warmup + measure flagless.
+    assert len(calls) == 3
+    assert "--moe-runner-backend triton" in calls[0]
+    assert all("--moe-runner-backend" not in c for c in calls[1:])
+    assert result["status"] == "succeeded"
+    assert "moe_runner_backend_fallback_dropped_flag" in result.get("nonfatal_warnings", [])
+
+
+def test_operator_pinned_backend_is_also_dropped_on_retry(tmp_path, monkeypatch):
+    monkeypatch.setenv("GPU_TYPE", "mi300x")
+    model = _moe_model_dir(tmp_path)
+    base = tmp_path / "base.yaml"
+    _write_yaml(base, model)
+    calls: list[str] = []
+
+    def fake_run(cmd, *args, **kwargs):
+        sglang_args = _sglang_args(cmd)
+        calls.append(sglang_args)
+        if "--moe-runner-backend" in sglang_args:
+            return subprocess.CompletedProcess(cmd, 1, "", _QUARK_TRACEBACK)
+        _fake_workspace(Path(cmd[cmd.index("--output-dir") + 1]))
+        return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+    executor = BaselineExecutor(
+        magpie_python="/opt/venv/bin/python",
+        default_config_path=base,
+        session_dir=tmp_path,
+    )
+    ctx = _make_ctx(
+        {
+            "output_dir": str(tmp_path / "ws"),
+            "timeout_sec": 10,
+            "model_path": model,
+            "gpu_type": "mi300x",
+            "disable_run_eval": True,
+            "extra_server_args": "--moe-runner-backend triton --foo 1",
+        }
+    )
+    with patch(
+        "hyperloom.orchestrator.actions.executors.baseline.run_with_session_kill",
+        side_effect=fake_run,
+    ):
+        result = _run(executor(ctx))
+
+    assert len(calls) == 3
+    assert all("--moe-runner-backend" not in c for c in calls[1:])
+    assert "--foo 1" in calls[1]
+    assert result["status"] == "succeeded"
+
+
+@pytest.mark.parametrize("source", ["operator_env", "reference_recipe"])
+def test_backend_from_other_arg_sources_is_dropped_on_retry(tmp_path, monkeypatch, source):
+    """The flag can also arrive via $INFERENCE_OPTIMIZER_SERVER_ARGS or the
+    reference recipe; both are merged after the task params, so the retry must
+    strip the merged result rather than only the params."""
+    monkeypatch.setenv("GPU_TYPE", "mi300x")
+    model = _moe_model_dir(tmp_path)
+    base = tmp_path / "base.yaml"
+    _write_yaml(base, model)
+    params = {
+        "output_dir": str(tmp_path / "ws"),
+        "timeout_sec": 10,
+        "model_path": model,
+        "gpu_type": "mi300x",
+        "disable_run_eval": True,
+    }
+    if source == "operator_env":
+        monkeypatch.setenv("INFERENCE_OPTIMIZER_SERVER_ARGS", "--moe-runner-backend triton")
+    else:
+        params["reference_server_args"] = "--moe-runner-backend triton"
+    calls: list[str] = []
+
+    def fake_run(cmd, *args, **kwargs):
+        sglang_args = _sglang_args(cmd)
+        calls.append(sglang_args)
+        if "--moe-runner-backend" in sglang_args:
+            return subprocess.CompletedProcess(cmd, 1, "", _QUARK_TRACEBACK)
+        _fake_workspace(Path(cmd[cmd.index("--output-dir") + 1]))
+        return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+    executor = BaselineExecutor(
+        magpie_python="/opt/venv/bin/python",
+        default_config_path=base,
+        session_dir=tmp_path,
+    )
+    with patch(
+        "hyperloom.orchestrator.actions.executors.baseline.run_with_session_kill",
+        side_effect=fake_run,
+    ):
+        result = _run(executor(_make_ctx(params)))
+
+    assert "--moe-runner-backend triton" in calls[0]
+    assert all("--moe-runner-backend" not in c for c in calls[1:])
+    assert result["status"] == "succeeded"
+
+
+def test_moe_fallback_keeps_eval_disabled_by_earlier_fallback(tmp_path, monkeypatch):
+    """An eval-rooted failure turns eval off; a MoE failure on that retry must
+    keep it off instead of resurrecting the eval that already broke."""
+    monkeypatch.setenv("GPU_TYPE", "mi300x")
+    model = _moe_model_dir(tmp_path)
+    base = tmp_path / "base.yaml"
+    _write_yaml(base, model)
+    calls: list[tuple[str, str]] = []
+
+    def fake_run(cmd, *args, **kwargs):
+        cfg = yaml.safe_load(Path(cmd[cmd.index("--benchmark-config") + 1]).read_text())
+        run_eval = str(cfg["benchmark"]["envs"].get("RUN_EVAL", "true")).lower()
+        sglang_args = str(cfg["benchmark"]["envs"].get("EXTRA_SGLANG_ARGS", ""))
+        calls.append((run_eval, sglang_args))
+        if run_eval != "false":
+            return subprocess.CompletedProcess(cmd, 1, "", "ERROR: run_eval failed with exit code 1\n")
+        if "--moe-runner-backend" in sglang_args:
+            return subprocess.CompletedProcess(cmd, 1, "", _QUARK_TRACEBACK)
+        _fake_workspace(Path(cmd[cmd.index("--output-dir") + 1]))
+        return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+    executor = BaselineExecutor(
+        magpie_python="/opt/venv/bin/python",
+        default_config_path=base,
+        session_dir=tmp_path,
+    )
+    ctx = _make_ctx(
+        {
+            "output_dir": str(tmp_path / "ws"),
+            "timeout_sec": 10,
+            "model_path": model,
+            "gpu_type": "mi300x",
+        }
+    )
+    with patch(
+        "hyperloom.orchestrator.actions.executors.baseline.run_with_session_kill",
+        side_effect=fake_run,
+    ):
+        result = _run(executor(ctx))
+
+    assert [c[0] for c in calls] == ["true", "false", "false", "false"]
+    assert all("--moe-runner-backend" not in args for _, args in calls[2:])
+    assert result["status"] == "succeeded"
+    # Both fallbacks stay visible on the salvaged result.
+    assert result.get("accuracy_source") == "eval_unavailable"
+    warnings = result.get("nonfatal_warnings", [])
+    assert "eval_failed_fallback_no_accuracy" in warnings
+    assert "moe_runner_backend_fallback_dropped_flag" in warnings
+
+
+def test_fallback_fires_only_once(tmp_path, monkeypatch):
+    monkeypatch.setenv("GPU_TYPE", "mi300x")
+    model = _moe_model_dir(tmp_path)
+    base = tmp_path / "base.yaml"
+    _write_yaml(base, model)
+    calls: list[str] = []
+
+    def fake_run(cmd, *args, **kwargs):
+        calls.append(_sglang_args(cmd))
+        # The crash persists even without the flag: no endless retry loop.
+        return subprocess.CompletedProcess(cmd, 1, "", _QUARK_TRACEBACK)
+
+    executor = BaselineExecutor(
+        magpie_python="/opt/venv/bin/python",
+        default_config_path=base,
+        session_dir=tmp_path,
+    )
+    ctx = _make_ctx(
+        {
+            "output_dir": str(tmp_path / "ws"),
+            "timeout_sec": 10,
+            "model_path": model,
+            "gpu_type": "mi300x",
+            "disable_run_eval": True,
+        }
+    )
+    with patch(
+        "hyperloom.orchestrator.actions.executors.baseline.run_with_session_kill",
+        side_effect=fake_run,
+    ):
+        result = _run(executor(ctx))
+
+    assert len(calls) == 2
+    assert result["status"] == "failed"
+
+
+def test_unrelated_failure_does_not_retry(tmp_path, monkeypatch):
+    monkeypatch.setenv("GPU_TYPE", "mi300x")
+    model = _moe_model_dir(tmp_path)
+    base = tmp_path / "base.yaml"
+    _write_yaml(base, model)
+    calls: list[str] = []
+
+    def fake_run(cmd, *args, **kwargs):
+        calls.append(_sglang_args(cmd))
+        return subprocess.CompletedProcess(cmd, 1, "", "CUDA out of memory\n")
+
+    executor = BaselineExecutor(
+        magpie_python="/opt/venv/bin/python",
+        default_config_path=base,
+        session_dir=tmp_path,
+    )
+    ctx = _make_ctx(
+        {
+            "output_dir": str(tmp_path / "ws"),
+            "timeout_sec": 10,
+            "model_path": model,
+            "gpu_type": "mi300x",
+            "disable_run_eval": True,
+        }
+    )
+    with patch(
+        "hyperloom.orchestrator.actions.executors.baseline.run_with_session_kill",
+        side_effect=fake_run,
+    ):
+        result = _run(executor(ctx))
+
+    assert len(calls) == 1
+    assert result["status"] == "failed"

--- a/src/hyperloom/inference_optimizer/tests/test_baseline_moe_runner_fallback.py
+++ b/src/hyperloom/inference_optimizer/tests/test_baseline_moe_runner_fallback.py
@@ -47,6 +47,30 @@ def _moe_model_dir(tmp_path: Path) -> str:
     return str(d)
 
 
+def _quark_mxfp4_moe_model_dir(tmp_path: Path) -> str:
+    """A Quark MX-FP4 MoE checkpoint dir (the gate skips injection for it)."""
+    spec = {"dtype": "fp4", "qscheme": "per_group", "group_size": 32, "scale_format": "e8m0"}
+    d = tmp_path / "Qwen3.5-397B-A17B-MXFP4"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "qwen3_5_moe",
+                "num_experts": 128,
+                "quantization_config": {
+                    "quant_method": "quark",
+                    "global_quant_config": {
+                        "weight": {**spec, "is_dynamic": False},
+                        "input_tensors": {**spec, "is_dynamic": True},
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return str(d)
+
+
 def _write_yaml(path: Path, model: str) -> None:
     cfg = {
         "benchmark": {
@@ -120,6 +144,33 @@ def test_moe_runner_failure_scans_logs(tmp_path: Path):
 def test_moe_runner_failure_negative():
     result = {"status": "failed", "error": "CUDA out of memory"}
     assert BaselineExecutor._is_moe_runner_rooted_failure(result) is False
+
+
+def test_unrelated_missing_runner_attribute_is_not_a_moe_failure():
+    # A missing 'runner' attribute outside the MoE path must not burn a retry.
+    result = {
+        "status": "failed",
+        "error": (
+            'File ".../bench/harness.py", line 12, in start\n'
+            "    self.runner.run(request)\n"
+            "AttributeError: 'BenchHarness' object has no attribute 'runner'\n"
+        ),
+    }
+    assert BaselineExecutor._is_moe_runner_rooted_failure(result) is False
+
+
+def test_moe_failure_detected_for_non_quark_scheme():
+    # Detection is keyed on the MoE runner, not on Quark: sglang's int4fp8 and
+    # mxfp4 dynamic-quant MoE methods fail the same way.
+    result = {
+        "status": "failed",
+        "error": (
+            'File ".../layers/quantization/quark_int4fp8_moe.py", line 446, in apply\n'
+            "    return self.runner.run(dispatch_output, quant_info)\n"
+            "AttributeError: 'QuarkInt4Fp8MoEMethod' object has no attribute 'runner'\n"
+        ),
+    }
+    assert BaselineExecutor._is_moe_runner_rooted_failure(result) is True
 
 
 # --- end-to-end fallback ----------------------------------------------------
@@ -307,6 +358,93 @@ def test_moe_fallback_keeps_eval_disabled_by_earlier_fallback(tmp_path, monkeypa
     warnings = result.get("nonfatal_warnings", [])
     assert "eval_failed_fallback_no_accuracy" in warnings
     assert "moe_runner_backend_fallback_dropped_flag" in warnings
+
+
+def test_quark_checkpoint_with_operator_pinned_backend_recovers(tmp_path, monkeypatch):
+    """The original bug shape: on a Quark MX-FP4 checkpoint the gate skips
+    injection, but an operator pin still reaches the server on attempt 1. The
+    fallback must strip it."""
+    monkeypatch.setenv("GPU_TYPE", "mi300x")
+    model = _quark_mxfp4_moe_model_dir(tmp_path)
+    base = tmp_path / "base.yaml"
+    _write_yaml(base, model)
+    calls: list[str] = []
+
+    def fake_run(cmd, *args, **kwargs):
+        sglang_args = _sglang_args(cmd)
+        calls.append(sglang_args)
+        if "--moe-runner-backend" in sglang_args:
+            return subprocess.CompletedProcess(cmd, 1, "", _QUARK_TRACEBACK)
+        _fake_workspace(Path(cmd[cmd.index("--output-dir") + 1]))
+        return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+    executor = BaselineExecutor(
+        magpie_python="/opt/venv/bin/python",
+        default_config_path=base,
+        session_dir=tmp_path,
+    )
+    ctx = _make_ctx(
+        {
+            "output_dir": str(tmp_path / "ws"),
+            "timeout_sec": 10,
+            "model_path": model,
+            "gpu_type": "mi300x",
+            "disable_run_eval": True,
+            "extra_server_args": "--moe-runner-backend triton --mem-fraction-static 0.9",
+        }
+    )
+    with patch(
+        "hyperloom.orchestrator.actions.executors.baseline.run_with_session_kill",
+        side_effect=fake_run,
+    ):
+        result = _run(executor(ctx))
+
+    assert "--moe-runner-backend triton" in calls[0]
+    assert all("--moe-runner-backend" not in c for c in calls[1:])
+    assert "--mem-fraction-static 0.9" in calls[1]
+    assert result["status"] == "succeeded"
+
+
+def test_quark_checkpoint_without_pin_never_gets_the_flag(tmp_path, monkeypatch):
+    """With the gate in place a Quark MX-FP4 checkpoint launches clean on the
+    first attempt -- no crash, no retry."""
+    monkeypatch.setenv("GPU_TYPE", "mi300x")
+    model = _quark_mxfp4_moe_model_dir(tmp_path)
+    base = tmp_path / "base.yaml"
+    _write_yaml(base, model)
+    calls: list[str] = []
+
+    def fake_run(cmd, *args, **kwargs):
+        sglang_args = _sglang_args(cmd)
+        calls.append(sglang_args)
+        if "--moe-runner-backend" in sglang_args:
+            return subprocess.CompletedProcess(cmd, 1, "", _QUARK_TRACEBACK)
+        _fake_workspace(Path(cmd[cmd.index("--output-dir") + 1]))
+        return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+    executor = BaselineExecutor(
+        magpie_python="/opt/venv/bin/python",
+        default_config_path=base,
+        session_dir=tmp_path,
+    )
+    ctx = _make_ctx(
+        {
+            "output_dir": str(tmp_path / "ws"),
+            "timeout_sec": 10,
+            "model_path": model,
+            "gpu_type": "mi300x",
+            "disable_run_eval": True,
+        }
+    )
+    with patch(
+        "hyperloom.orchestrator.actions.executors.baseline.run_with_session_kill",
+        side_effect=fake_run,
+    ):
+        result = _run(executor(ctx))
+
+    assert all("--moe-runner-backend" not in c for c in calls)
+    assert result["status"] == "succeeded"
+    assert "moe_runner_backend_fallback_dropped_flag" not in result.get("nonfatal_warnings", [])
 
 
 def test_fallback_fires_only_once(tmp_path, monkeypatch):

--- a/src/hyperloom/inference_optimizer/tests/test_baseline_param_overrides.py
+++ b/src/hyperloom/inference_optimizer/tests/test_baseline_param_overrides.py
@@ -31,6 +31,7 @@ _CLI_STUB = SimpleNamespace(
     _load_model_max_position_embeddings=lambda _model: 32768,
     _model_has_dual_chunk_attention=lambda _model: False,
     _model_is_moe=lambda _model: False,
+    _model_moe_runner_requires_aiter=lambda _model: False,
     _resolve_amd_gpu_type=lambda gpu: str(gpu or "").lower(),
 )
 

--- a/src/hyperloom/inference_optimizer/tests/test_grid_moe_runner_backend_guard.py
+++ b/src/hyperloom/inference_optimizer/tests/test_grid_moe_runner_backend_guard.py
@@ -111,6 +111,28 @@ def test_variant_authored_backend_dropped_for_aiter_only_model(tmp_path, quark_m
     assert "--moe-runner-backend" not in args
 
 
+def test_inherited_backend_dropped_for_online_int4fp8_variant(tmp_path, plain_moe_model):
+    args = _variant_args(
+        tmp_path,
+        model=plain_moe_model,
+        base_extra_args="--moe-runner-backend triton",
+        variant_args="--quantization quark_int4fp8_moe",
+    )
+    assert "--moe-runner-backend" not in args
+    assert "--quantization quark_int4fp8_moe" in args
+
+
+def test_inherited_backend_dropped_for_online_dynamic_mxfp4_variant(tmp_path, plain_moe_model):
+    args = _variant_args(
+        tmp_path,
+        model=plain_moe_model,
+        base_extra_args="--moe-runner-backend triton",
+        variant_args="--quantization mxfp4",
+    )
+    assert "--moe-runner-backend" not in args
+    assert "--quantization mxfp4" in args
+
+
 def test_backend_kept_for_ordinary_moe_model(tmp_path, plain_moe_model):
     args = _variant_args(
         tmp_path,

--- a/src/hyperloom/inference_optimizer/tests/test_grid_moe_runner_backend_guard.py
+++ b/src/hyperloom/inference_optimizer/tests/test_grid_moe_runner_backend_guard.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Grid variants must not inherit a MoE runner backend the model cannot serve.
+
+The grid never injects ``--moe-runner-backend`` itself, but it inherits one
+from the baseline recipe it is seeded with (or from an authored variant). On an
+aiter-only quant scheme that flag is a guaranteed first-forward-pass crash, and
+the grid has no retry to salvage it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from hyperloom.orchestrator.actions.executors._grid_base import GridVariant
+from hyperloom.orchestrator.actions.executors._grid_runner import _build_variant_yaml
+
+
+def _write_model_config(dir_path: Path, config: dict) -> str:
+    dir_path.mkdir(parents=True, exist_ok=True)
+    (dir_path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    return str(dir_path)
+
+
+def _mx_fp4_entry() -> dict:
+    spec = {"dtype": "fp4", "qscheme": "per_group", "group_size": 32, "scale_format": "e8m0"}
+    return {
+        "weight": {**spec, "is_dynamic": False},
+        "input_tensors": {**spec, "is_dynamic": True},
+    }
+
+
+@pytest.fixture
+def quark_mxfp4_moe_model(tmp_path) -> str:
+    return _write_model_config(
+        tmp_path / "Qwen3.5-397B-A17B-MXFP4",
+        {
+            "model_type": "qwen3_5_moe",
+            "num_experts": 128,
+            "quantization_config": {"quant_method": "quark", "global_quant_config": _mx_fp4_entry()},
+        },
+    )
+
+
+@pytest.fixture
+def plain_moe_model(tmp_path) -> str:
+    return _write_model_config(
+        tmp_path / "Qwen3-30B-A3B",
+        {"model_type": "qwen3_moe", "num_experts": 128},
+    )
+
+
+def _base_yaml(path: Path, model: str) -> Path:
+    cfg = {
+        "benchmark": {
+            "framework": "sglang",
+            "model": model,
+            "precision": "bf16",
+            "run_mode": "local",
+            "envs": {"TP": 1, "CONC": 8, "ISL": 256, "OSL": 256},
+            "timeout_seconds": 600,
+            "profiler": {
+                "torch_profiler": {"enabled": False},
+                "system_profiler": {"enabled": False},
+                "tracelens": {"enabled": False},
+            },
+            "gpu_selection": {"auto": False},
+        }
+    }
+    with path.open("w") as f:
+        yaml.safe_dump(cfg, f)
+    return path
+
+
+def _variant_args(tmp_path: Path, *, model: str, base_extra_args: str, variant_args: str = "") -> str:
+    base = _base_yaml(tmp_path / "base.yaml", model)
+    out = _build_variant_yaml(
+        base,
+        base_extra_args,
+        GridVariant(name="v00", extra_server_args=variant_args, extra_envs={}),
+        output_subdir=tmp_path / "v00",
+        model_path=model,
+        gpu_type="mi300x",
+    )
+    cfg = yaml.safe_load(out.read_text())
+    return str(cfg["benchmark"]["envs"].get("EXTRA_SGLANG_ARGS", ""))
+
+
+def test_inherited_backend_dropped_for_aiter_only_model(tmp_path, quark_mxfp4_moe_model):
+    args = _variant_args(
+        tmp_path,
+        model=quark_mxfp4_moe_model,
+        base_extra_args="--moe-runner-backend triton --mem-fraction-static 0.9",
+    )
+    assert "--moe-runner-backend" not in args
+    assert "--mem-fraction-static 0.9" in args
+
+
+def test_variant_authored_backend_dropped_for_aiter_only_model(tmp_path, quark_mxfp4_moe_model):
+    args = _variant_args(
+        tmp_path,
+        model=quark_mxfp4_moe_model,
+        base_extra_args="",
+        variant_args="--moe-runner-backend triton",
+    )
+    assert "--moe-runner-backend" not in args
+
+
+def test_backend_kept_for_ordinary_moe_model(tmp_path, plain_moe_model):
+    args = _variant_args(
+        tmp_path,
+        model=plain_moe_model,
+        base_extra_args="--moe-runner-backend triton",
+    )
+    assert "--moe-runner-backend triton" in args

--- a/src/hyperloom/inference_optimizer/tests/test_moe_runner_backend_injection.py
+++ b/src/hyperloom/inference_optimizer/tests/test_moe_runner_backend_injection.py
@@ -189,6 +189,9 @@ def test_moe_runner_requires_aiter_true(tmp_path, quant_config):
         },
         # fp4 with a non-MX group size.
         {"quant_method": "quark", "global_quant_config": _mx_fp4_entry(weight=_mx_fp4_spec(group_size=16))},
+        # Keep exact parity with sglang: its _is_mx_fp4 compares against integer
+        # 32, so a string value is not a valid MX-FP4 config either.
+        {"quant_method": "quark", "global_quant_config": _mx_fp4_entry(weight=_mx_fp4_spec(group_size="32"))},
         # Statically quantized activations are not the W4A4 dynamic scheme.
         {
             "quant_method": "quark",

--- a/src/hyperloom/inference_optimizer/tests/test_moe_runner_backend_injection.py
+++ b/src/hyperloom/inference_optimizer/tests/test_moe_runner_backend_injection.py
@@ -81,6 +81,27 @@ def dense_model(tmp_path) -> str:
     )
 
 
+def _mx_fp4_spec(**overrides) -> dict:
+    """A Quark spec dict that satisfies sglang's ``_is_mx_fp4``."""
+    spec = {
+        "dtype": "fp4",
+        "qscheme": "per_group",
+        "group_size": 32,
+        "scale_format": "e8m0",
+        "is_dynamic": False,
+    }
+    spec.update(overrides)
+    return spec
+
+
+def _mx_fp4_entry(**overrides) -> dict:
+    return {
+        "weight": _mx_fp4_spec(),
+        "input_tensors": _mx_fp4_spec(is_dynamic=True),
+        **overrides,
+    }
+
+
 @pytest.fixture
 def quark_mxfp4_moe_model(tmp_path) -> str:
     """A Quark-PTQ MXFP4 (W4A4) MoE checkpoint dir."""
@@ -92,10 +113,7 @@ def quark_mxfp4_moe_model(tmp_path) -> str:
             "num_experts": 128,
             "quantization_config": {
                 "quant_method": "quark",
-                "global_quant_config": {
-                    "weight": {"dtype": "fp4", "group_size": 32, "scale_format": "e8m0"},
-                    "input_tensors": {"dtype": "fp4", "group_size": 32, "scale_format": "e8m0"},
-                },
+                "global_quant_config": _mx_fp4_entry(),
             },
         },
     )
@@ -141,10 +159,14 @@ def test_model_is_moe_missing_config_is_false(tmp_path):
 @pytest.mark.parametrize(
     "quant_config",
     [
-        {"quant_method": "quark", "global_quant_config": {"weight": {"dtype": "mx_fp4"}}},
-        {"quant_method": "quark", "export": {"kv_cache_group": []}, "fmt": "mxfp4"},
-        {"quant_method": "quark", "global_quant_config": {"weight": {"dtype": "fp4", "scale_format": "e8m0"}}},
-        {"quant_method": "quark", "layer_quant_config": {"*mlp.experts*": {"w4a4": True}}},
+        {"quant_method": "quark", "global_quant_config": _mx_fp4_entry()},
+        # The MoE layers alone carry MX-FP4; sglang resolves per-layer first.
+        {
+            "quant_method": "quark",
+            "global_quant_config": {"weight": {"dtype": "fp8_e4m3", "qscheme": "per_tensor"}},
+            "layer_quant_config": {"*mlp.experts*": _mx_fp4_entry()},
+        },
+        {"quant_method": "quark", "layer_type_quant_config": {"FusedMoE": _mx_fp4_entry()}},
     ],
 )
 def test_moe_runner_requires_aiter_true(tmp_path, quant_config):
@@ -156,17 +178,31 @@ def test_moe_runner_requires_aiter_true(tmp_path, quant_config):
 
 
 @pytest.mark.parametrize(
-    "config",
+    "quant_config",
     [
-        {"num_experts": 128},  # unquantized MoE
-        {"num_experts": 128, "quantization_config": {"quant_method": "fp8"}},
-        # fp4 without Quark: not the scheme that lacks a triton runner.
-        {"num_experts": 128, "quantization_config": {"quant_method": "modelopt", "fmt": "mxfp4"}},
-        # Quark without a 4-bit marker keeps the triton runner.
-        {"num_experts": 128, "quantization_config": {"quant_method": "quark", "fmt": "fp8_e4m3"}},
+        None,  # unquantized MoE
+        {"quant_method": "fp8"},
+        # nvfp4 is fp4 too, but not per_group/e8m0 microscaling.
+        {
+            "quant_method": "quark",
+            "global_quant_config": _mx_fp4_entry(weight=_mx_fp4_spec(qscheme="per_tensor", scale_format="float32")),
+        },
+        # fp4 with a non-MX group size.
+        {"quant_method": "quark", "global_quant_config": _mx_fp4_entry(weight=_mx_fp4_spec(group_size=16))},
+        # Statically quantized activations are not the W4A4 dynamic scheme.
+        {
+            "quant_method": "quark",
+            "global_quant_config": _mx_fp4_entry(input_tensors=_mx_fp4_spec(is_dynamic=False)),
+        },
+        # Same shape, but a quant method sglang routes elsewhere.
+        {"quant_method": "modelopt", "global_quant_config": _mx_fp4_entry()},
+        {"quant_method": "quark", "global_quant_config": {"weight": {"dtype": "fp8_e4m3"}}},
     ],
 )
-def test_moe_runner_requires_aiter_false(tmp_path, config):
+def test_moe_runner_requires_aiter_false(tmp_path, quant_config):
+    config: dict = {"num_experts": 128}
+    if quant_config is not None:
+        config["quantization_config"] = quant_config
     path = _write_model_config(tmp_path / "m", config)
     assert cli_model_gate._model_moe_runner_requires_aiter(path) is False
 
@@ -174,7 +210,12 @@ def test_moe_runner_requires_aiter_false(tmp_path, config):
 def test_moe_runner_requires_aiter_reads_nested_text_config(tmp_path):
     path = _write_model_config(
         tmp_path / "m",
-        {"text_config": {"num_experts": 128, "quantization_config": {"quant_method": "quark", "fmt": "mxfp4"}}},
+        {
+            "text_config": {
+                "num_experts": 128,
+                "quantization_config": {"quant_method": "quark", "global_quant_config": _mx_fp4_entry()},
+            }
+        },
     )
     assert cli_model_gate._model_moe_runner_requires_aiter(path) is True
 
@@ -235,6 +276,36 @@ def test_inject_noop_for_quark_mxfp4_moe(quark_mxfp4_moe_model):
 def test_inject_env_override_does_not_resurrect_quark_injection(quark_mxfp4_moe_model, monkeypatch):
     monkeypatch.setenv(HYPERLOOM_SGLANG_MOE_RUNNER_BACKEND_ENV, "triton")
     assert inject_sglang_moe_runner_backend("", "sglang", quark_mxfp4_moe_model, _AMD) == ""
+
+
+# Online --quantization schemes that are equally aiter-only in sglang.
+@pytest.mark.parametrize(
+    "args",
+    [
+        "--quantization quark_int4fp8_moe",
+        "--quantization=quark_int4fp8_moe",
+        "--foo 1 --quantization quark_int4fp8_moe --bar 2",
+    ],
+)
+def test_inject_noop_for_online_int4fp8_moe(moe_model, args):
+    assert inject_sglang_moe_runner_backend(args, "sglang", moe_model, _AMD) == args
+
+
+def test_inject_noop_for_online_mxfp4_dynamic_quant(moe_model):
+    # An unserialized checkpoint + --quantization mxfp4 routes to sglang's
+    # dynamic-quant MoE method, which only builds an aiter runner.
+    args = "--quantization mxfp4"
+    assert inject_sglang_moe_runner_backend(args, "sglang", moe_model, _AMD) == args
+
+
+def test_inject_still_applies_for_serialized_mxfp4_checkpoint(tmp_path):
+    # A serialized mxfp4 checkpoint uses the backend-flexible MoE method.
+    model = _write_model_config(
+        tmp_path / "gpt-oss-mxfp4",
+        {"num_experts": 128, "quantization_config": {"quant_method": "mxfp4"}},
+    )
+    out = inject_sglang_moe_runner_backend("--quantization mxfp4", "sglang", model, _AMD)
+    assert out == "--quantization mxfp4 --moe-runner-backend triton"
 
 
 def test_inject_noop_on_non_amd_gpu(moe_model):
@@ -347,6 +418,10 @@ def test_materialize_does_not_double_user_backend(tmp_path, moe_model, monkeypat
         ("--foo 1 --moe-runner-backend triton --bar 2", "--foo 1 --bar 2"),
         ("--foo 1 --moe-runner-backend=triton", "--foo 1"),
         ("--moe-runner-backend aiter", ""),
+        # Value-less flag: strip it rather than let it survive a retry.
+        ("--foo 1 --moe-runner-backend", "--foo 1"),
+        ("--moe-runner-backend", ""),
+        ("--moe-runner-backend --foo 1", "--foo 1"),
     ],
 )
 def test_remove_moe_runner_backend_arg(args, expected):

--- a/src/hyperloom/inference_optimizer/tests/test_moe_runner_backend_injection.py
+++ b/src/hyperloom/inference_optimizer/tests/test_moe_runner_backend_injection.py
@@ -81,6 +81,26 @@ def dense_model(tmp_path) -> str:
     )
 
 
+@pytest.fixture
+def quark_mxfp4_moe_model(tmp_path) -> str:
+    """A Quark-PTQ MXFP4 (W4A4) MoE checkpoint dir."""
+    return _write_model_config(
+        tmp_path / "Qwen3.5-397B-A17B-MXFP4",
+        {
+            "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+            "model_type": "qwen3_5_moe",
+            "num_experts": 128,
+            "quantization_config": {
+                "quant_method": "quark",
+                "global_quant_config": {
+                    "weight": {"dtype": "fp4", "group_size": 32, "scale_format": "e8m0"},
+                    "input_tensors": {"dtype": "fp4", "group_size": 32, "scale_format": "e8m0"},
+                },
+            },
+        },
+    )
+
+
 # _model_is_moe detection
 @pytest.mark.parametrize(
     "config",
@@ -115,6 +135,52 @@ def test_model_is_moe_false(tmp_path, config):
 
 def test_model_is_moe_missing_config_is_false(tmp_path):
     assert cli_model_gate._model_is_moe(str(tmp_path / "does-not-exist")) is False
+
+
+# _model_moe_runner_requires_aiter detection
+@pytest.mark.parametrize(
+    "quant_config",
+    [
+        {"quant_method": "quark", "global_quant_config": {"weight": {"dtype": "mx_fp4"}}},
+        {"quant_method": "quark", "export": {"kv_cache_group": []}, "fmt": "mxfp4"},
+        {"quant_method": "quark", "global_quant_config": {"weight": {"dtype": "fp4", "scale_format": "e8m0"}}},
+        {"quant_method": "quark", "layer_quant_config": {"*mlp.experts*": {"w4a4": True}}},
+    ],
+)
+def test_moe_runner_requires_aiter_true(tmp_path, quant_config):
+    path = _write_model_config(
+        tmp_path / "m",
+        {"num_experts": 128, "quantization_config": quant_config},
+    )
+    assert cli_model_gate._model_moe_runner_requires_aiter(path) is True
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"num_experts": 128},  # unquantized MoE
+        {"num_experts": 128, "quantization_config": {"quant_method": "fp8"}},
+        # fp4 without Quark: not the scheme that lacks a triton runner.
+        {"num_experts": 128, "quantization_config": {"quant_method": "modelopt", "fmt": "mxfp4"}},
+        # Quark without a 4-bit marker keeps the triton runner.
+        {"num_experts": 128, "quantization_config": {"quant_method": "quark", "fmt": "fp8_e4m3"}},
+    ],
+)
+def test_moe_runner_requires_aiter_false(tmp_path, config):
+    path = _write_model_config(tmp_path / "m", config)
+    assert cli_model_gate._model_moe_runner_requires_aiter(path) is False
+
+
+def test_moe_runner_requires_aiter_reads_nested_text_config(tmp_path):
+    path = _write_model_config(
+        tmp_path / "m",
+        {"text_config": {"num_experts": 128, "quantization_config": {"quant_method": "quark", "fmt": "mxfp4"}}},
+    )
+    assert cli_model_gate._model_moe_runner_requires_aiter(path) is True
+
+
+def test_moe_runner_requires_aiter_missing_config_is_false(tmp_path):
+    assert cli_model_gate._model_moe_runner_requires_aiter(str(tmp_path / "nope")) is False
 
 
 # inject_sglang_moe_runner_backend (pure helper)
@@ -159,6 +225,18 @@ def test_inject_noop_for_dense_model(dense_model):
     )
 
 
+def test_inject_noop_for_quark_mxfp4_moe(quark_mxfp4_moe_model):
+    # sglang's QuarkW4A4MXFp4MoE only initialises its runner on the aiter path;
+    # forcing triton crashes the server on the first forward pass.
+    assert inject_sglang_moe_runner_backend("--foo", "sglang", quark_mxfp4_moe_model, _AMD) == "--foo"
+    assert inject_sglang_moe_runner_backend("", "sglang", quark_mxfp4_moe_model, _AMD) == ""
+
+
+def test_inject_env_override_does_not_resurrect_quark_injection(quark_mxfp4_moe_model, monkeypatch):
+    monkeypatch.setenv(HYPERLOOM_SGLANG_MOE_RUNNER_BACKEND_ENV, "triton")
+    assert inject_sglang_moe_runner_backend("", "sglang", quark_mxfp4_moe_model, _AMD) == ""
+
+
 def test_inject_noop_on_non_amd_gpu(moe_model):
     # Explicit non-AMD gpu + autodetect pinned off (fixture) -> no injection.
     assert inject_sglang_moe_runner_backend("--foo", "sglang", moe_model, "h100") == "--foo"
@@ -198,6 +276,7 @@ def _materialize_envs(
     model: str,
     framework: str = "sglang",
     extra_server_args: str = "",
+    drop_moe_runner_backend: bool = False,
 ) -> dict:
     base = tmp_path / "base.yaml"
     _write_yaml(base, model=model, framework=framework)
@@ -207,6 +286,7 @@ def _materialize_envs(
         base,
         out,
         extra_server_args=extra_server_args,
+        drop_moe_runner_backend=drop_moe_runner_backend,
     )
     return yaml.safe_load(materialized.read_text())["benchmark"]["envs"]
 
@@ -221,6 +301,31 @@ def test_materialize_noop_for_dense_model_on_amd(tmp_path, dense_model, monkeypa
     monkeypatch.setenv("GPU_TYPE", _AMD)
     envs = _materialize_envs(tmp_path, model=dense_model)
     assert "--moe-runner-backend" not in envs.get("EXTRA_SGLANG_ARGS", "")
+
+
+def test_materialize_noop_for_quark_mxfp4_moe_on_amd(tmp_path, quark_mxfp4_moe_model, monkeypatch):
+    monkeypatch.setenv("GPU_TYPE", _AMD)
+    envs = _materialize_envs(tmp_path, model=quark_mxfp4_moe_model)
+    assert "--moe-runner-backend" not in envs.get("EXTRA_SGLANG_ARGS", "")
+
+
+def test_materialize_drop_skips_injection(tmp_path, moe_model, monkeypatch):
+    monkeypatch.setenv("GPU_TYPE", _AMD)
+    envs = _materialize_envs(tmp_path, model=moe_model, drop_moe_runner_backend=True)
+    assert "--moe-runner-backend" not in envs.get("EXTRA_SGLANG_ARGS", "")
+
+
+def test_materialize_drop_strips_inherited_backend(tmp_path, moe_model, monkeypatch):
+    monkeypatch.setenv("GPU_TYPE", _AMD)
+    envs = _materialize_envs(
+        tmp_path,
+        model=moe_model,
+        extra_server_args="--moe-runner-backend ck --foo 1",
+        drop_moe_runner_backend=True,
+    )
+    sglang_args = envs.get("EXTRA_SGLANG_ARGS", "")
+    assert "--moe-runner-backend" not in sglang_args
+    assert "--foo 1" in sglang_args
 
 
 def test_materialize_does_not_double_user_backend(tmp_path, moe_model, monkeypatch):

--- a/src/hyperloom/orchestrator/actions/executors/_grid_runner.py
+++ b/src/hyperloom/orchestrator/actions/executors/_grid_runner.py
@@ -90,6 +90,7 @@ from ._grid_server_args import (
     _SGLANG_MOE_RUNNER_BACKEND_FLAG as _SGLANG_MOE_RUNNER_BACKEND_FLAG,
     _SGLANG_MOE_RUNNER_BACKEND_RE as _SGLANG_MOE_RUNNER_BACKEND_RE,
     inject_sglang_moe_runner_backend as inject_sglang_moe_runner_backend,
+    moe_runner_requires_aiter as moe_runner_requires_aiter,
     apply_runtime_benchmark_overrides as apply_runtime_benchmark_overrides,
 )
 from ._grid_variant_filter import (
@@ -601,6 +602,22 @@ def _build_variant_yaml(
         remove_args=getattr(variant, "remove_args", []),
         args_mode=getattr(variant, "args_mode", "append"),
     )
+    # A grid variant never injects a MoE runner backend itself, but it does
+    # inherit one -- from the baseline recipe it was seeded with, or from an
+    # explicitly authored variant. On a model only the aiter runner can serve,
+    # that inherited flag is a guaranteed crash on the first forward pass, and
+    # the grid has no retry to salvage it, so drop it here.
+    if combined and _SGLANG_MOE_RUNNER_BACKEND_RE.search(combined):
+        from ._workload_envs import _remove_moe_runner_backend_arg
+
+        if extra_args_env == "EXTRA_SGLANG_ARGS" and moe_runner_requires_aiter(combined, model_path):
+            log.warning(
+                "grid: dropping inherited --moe-runner-backend for variant %s: "
+                "this checkpoint's MoE quant scheme is only implemented on the "
+                "aiter runner and would crash on the first forward pass.",
+                variant.name,
+            )
+            combined = _remove_moe_runner_backend_arg(combined)
     if combined:
         envs[extra_args_env] = _shell_safe_dedupe(combined)
     elif extra_args_env in envs:
@@ -2039,6 +2056,7 @@ __all__ = [
     "DEFAULT_SGLANG_AMD_MOE_RUNNER_BACKEND",
     "_SGLANG_MOE_RUNNER_BACKEND_FLAG",
     "_SGLANG_MOE_RUNNER_BACKEND_RE",
+    "moe_runner_requires_aiter",
     "inject_sglang_moe_runner_backend",
     "resolve_skip_spec",
     "_parse_skip_spec",

--- a/src/hyperloom/orchestrator/actions/executors/_grid_server_args.py
+++ b/src/hyperloom/orchestrator/actions/executors/_grid_server_args.py
@@ -762,6 +762,66 @@ _SGLANG_MOE_RUNNER_BACKEND_FLAG = "--moe-runner-backend"
 # Matches space- or equals-separated form without false-matching a longer flag.
 _SGLANG_MOE_RUNNER_BACKEND_RE = re.compile(r"--moe-runner-backend(?:[=\s]|$)")
 
+# sglang MoE schemes whose ``create_moe_runner`` only builds a runner for the
+# aiter backend (the others fall through to a bare ``pass``, so the first
+# forward pass dies on a missing ``runner``). Two are selected online through
+# ``--quantization`` rather than the checkpoint's own config: quark_int4fp8_moe
+# always, and mxfp4 only when the checkpoint is NOT mxfp4-serialized (sglang
+# then routes to its dynamic-quant MoE method, which is aiter-only too).
+_AITER_ONLY_ONLINE_QUANT_METHODS = frozenset({"quark_int4fp8_moe"})
+
+_AITER_ONLY_UNLESS_SERIALIZED_QUANT_METHOD = "mxfp4"
+
+_SGLANG_QUANTIZATION_RE = re.compile(r"--quantization[=\s]+(\S+)")
+
+
+def _online_quant_requires_aiter_moe_runner(server_args: str, model_path: str) -> bool:
+    """Whether ``--quantization`` selects an aiter-only MoE scheme.
+
+    Args:
+        server_args (str): The server-arg string to read ``--quantization`` from.
+        model_path (str): Model path, used to tell a serialized mxfp4
+            checkpoint (which gets the backend-flexible method) from an online
+            dynamic-quant one.
+
+    Returns:
+        bool: ``True`` when the selected scheme only has an aiter MoE runner.
+    """
+    match = _SGLANG_QUANTIZATION_RE.search(server_args or "")
+    if not match:
+        return False
+    quantization = match.group(1).strip().strip("\"'").lower()
+    if quantization in _AITER_ONLY_ONLINE_QUANT_METHODS:
+        return True
+    if quantization != _AITER_ONLY_UNLESS_SERIALIZED_QUANT_METHOD:
+        return False
+    from hyperloom.inference_optimizer.cli.model_gate import _model_declared_quant_method
+
+    # Mirrors sglang: is_checkpoint_mxfp4_serialized = "mxfp4" in quant_method.
+    return "mxfp4" not in _model_declared_quant_method(model_path)
+
+
+def moe_runner_requires_aiter(server_args: str | None, model_path: str | None) -> bool:
+    """Whether this model + server args resolve to an aiter-only MoE scheme.
+
+    Folds the two ways sglang can land on such a scheme: the checkpoint's own
+    Quark MX-FP4 config, and an online ``--quantization`` selection.
+
+    Args:
+        server_args (str | None): Server args, read for ``--quantization``.
+        model_path (str | None): Model path whose ``config.json`` is inspected.
+
+    Returns:
+        bool: ``True`` when only the aiter MoE runner can serve this model.
+    """
+    from hyperloom.inference_optimizer.cli.model_gate import _model_moe_runner_requires_aiter
+
+    path = str(model_path or "")
+    return _model_moe_runner_requires_aiter(path) or _online_quant_requires_aiter_moe_runner(
+        str(server_args or ""),
+        path,
+    )
+
 
 def inject_sglang_moe_runner_backend(
     server_args: str | None,
@@ -802,11 +862,9 @@ def inject_sglang_moe_runner_backend(
         return args
     if not _model_is_moe(str(model_path or "")):
         return args
-    from hyperloom.inference_optimizer.cli.model_gate import _model_moe_runner_requires_aiter
-
-    # Quark MXFP4/W4A4 MoE has no triton runner: injecting one crashes the
+    # An aiter-only MoE scheme has no triton runner: injecting one crashes the
     # server on the first forward pass. Let sglang resolve the backend itself.
-    if _model_moe_runner_requires_aiter(str(model_path or "")):
+    if moe_runner_requires_aiter(args, str(model_path or "")):
         log.info(
             "MoE model with an aiter-only quant scheme: skipping "
             "--moe-runner-backend injection (the triton runner has no "

--- a/src/hyperloom/orchestrator/actions/executors/_grid_server_args.py
+++ b/src/hyperloom/orchestrator/actions/executors/_grid_server_args.py
@@ -773,8 +773,9 @@ def inject_sglang_moe_runner_backend(
 
     Returns ``server_args`` unchanged when: framework is not sglang, a
     ``--moe-runner-backend`` is already pinned (operator wins), the GPU is not
-    an AMD/ROCm runner, or the model is not Mixture-of-Experts (fail-safe:
-    inject nothing). Otherwise appends the backend from
+    an AMD/ROCm runner, the model is not Mixture-of-Experts (fail-safe: inject
+    nothing), or the checkpoint carries a quant scheme only the aiter runner
+    implements. Otherwise appends the backend from
     ``$HYPERLOOM_SGLANG_MOE_RUNNER_BACKEND`` (default ``triton``); only this
     flag is added.
 
@@ -786,8 +787,8 @@ def inject_sglang_moe_runner_backend(
 
     Returns:
         str: ``server_args`` with ``--moe-runner-backend`` appended, or unchanged
-        for non-sglang frameworks, when already pinned, off AMD/ROCm, or for
-        non-MoE models.
+        for non-sglang frameworks, when already pinned, off AMD/ROCm, for
+        non-MoE models, or for aiter-only MoE quant schemes.
     """
     args = str(server_args or "").strip()
     if server_args_env_name(framework) != "EXTRA_SGLANG_ARGS":
@@ -800,6 +801,17 @@ def inject_sglang_moe_runner_backend(
     if not _resolve_amd_gpu_type(gpu_type):
         return args
     if not _model_is_moe(str(model_path or "")):
+        return args
+    from hyperloom.inference_optimizer.cli.model_gate import _model_moe_runner_requires_aiter
+
+    # Quark MXFP4/W4A4 MoE has no triton runner: injecting one crashes the
+    # server on the first forward pass. Let sglang resolve the backend itself.
+    if _model_moe_runner_requires_aiter(str(model_path or "")):
+        log.info(
+            "MoE model with an aiter-only quant scheme: skipping "
+            "--moe-runner-backend injection (the triton runner has no "
+            "implementation for it)."
+        )
         return args
     backend = (
         os.environ.get(HYPERLOOM_SGLANG_MOE_RUNNER_BACKEND_ENV, "").strip() or DEFAULT_SGLANG_AMD_MOE_RUNNER_BACKEND

--- a/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
+++ b/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
@@ -253,9 +253,15 @@ def _finalize_framework_server_args(
     gpu_type: str | None,
     isl_val: int,
     osl_val: int,
+    drop_moe_runner_backend: bool = False,
 ) -> None:
     """Apply the final framework server-arg guard pipeline in place
-    (context-length/watchdog/attention/MoE/EP/dedup/compact/shell-safe); order is fixed."""
+    (context-length/watchdog/attention/MoE/EP/dedup/compact/shell-safe); order is fixed.
+
+    ``drop_moe_runner_backend`` turns step 4 into a removal: the args are
+    already merged from every source (task params, ``$INFERENCE_OPTIMIZER_
+    SERVER_ARGS``, the reference recipe, the YAML base), so stripping here is
+    what guarantees a retry launches without the backend that killed it."""
     framework_env = server_args_env_name(bench.get("framework"))
     resolved_server_args = str(envs.get(framework_env, "")).strip()
     resolved_server_args = inject_sglang_context_length(
@@ -281,12 +287,16 @@ def _finalize_framework_server_args(
     # 4. MoE runner backend: aiter's CK fused-MoE JIT build is broken in some
     #    images; inject the triton MoE runner unless --moe-runner-backend is
     #    pinned.
-    resolved_server_args = inject_sglang_moe_runner_backend(
-        resolved_server_args,
-        bench.get("framework"),
-        bench.get("model"),
-        gpu_type=gpu_type or bench.get("runner_type"),
-    )
+    if drop_moe_runner_backend:
+        if framework_env == "EXTRA_SGLANG_ARGS":
+            resolved_server_args = _remove_moe_runner_backend_arg(resolved_server_args)
+    else:
+        resolved_server_args = inject_sglang_moe_runner_backend(
+            resolved_server_args,
+            bench.get("framework"),
+            bench.get("model"),
+            gpu_type=gpu_type or bench.get("runner_type"),
+        )
     resolved_server_args = inject_vllm_expert_parallel(
         resolved_server_args,
         bench.get("framework"),
@@ -329,6 +339,7 @@ def materialize_config_with_envs(
     reference_envs: dict[str, Any] | None = None,
     out_name: str = "baseline_config.with_envs.yaml",
     establish_quality_ref: bool = False,
+    drop_moe_runner_backend: bool = False,
 ) -> Path:
     """Render a per-run Magpie YAML with caller-provided overrides.
 
@@ -366,6 +377,10 @@ def materialize_config_with_envs(
             image-quality reference is ESTABLISHED (written) by this run;
             otherwise the run only COMPARES against it. See the quality-
             reference wiring block below.
+        drop_moe_runner_backend: When True, skip the AMD MoE
+            ``--moe-runner-backend`` injection and strip the flag from the
+            merged args whatever source it came from (the one-shot fallback
+            after a launch failure blamed on that backend).
 
     Returns:
         The materialized YAML path (stable file name across calls).
@@ -920,7 +935,14 @@ def materialize_config_with_envs(
     # 2. MI300X cold-compile guard: raise sglang's scheduler watchdog so the
     #    first-request aiter JIT compile survives (the 300s default fires
     #    SIGQUIT mid-warmup on a cold aiter cache).
-    _finalize_framework_server_args(envs, bench, gpu_type=gpu_type, isl_val=isl_val, osl_val=osl_val)
+    _finalize_framework_server_args(
+        envs,
+        bench,
+        gpu_type=gpu_type,
+        isl_val=isl_val,
+        osl_val=osl_val,
+        drop_moe_runner_backend=drop_moe_runner_backend,
+    )
     # ── Client trust-remote-code (model-agnostic) ─────────────────────────
     # The MI300X bench scripts always launch the SERVER with
     # --trust-remote-code, so a custom-tokenizer model's CLIENT must load the

--- a/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
+++ b/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
@@ -64,7 +64,10 @@ log = logging.getLogger(__name__)
 _GFX942_GPU_TYPES = frozenset({"mi300x", "mi308x", "mi325x"})
 
 
-_MOE_RUNNER_BACKEND_RE = re.compile(r"(?:^|\s)--moe-runner-backend(?:[=\s]+)\S+")
+# Value is optional so a bare, value-less flag (an operator typo, or a flag
+# left dangling at end-of-string) is stripped too rather than surviving into a
+# retry that is supposed to launch without it.
+_MOE_RUNNER_BACKEND_RE = re.compile(r"(?:^|\s)--moe-runner-backend(?:(?:[=\s]+)(?!--)\S+)?")
 
 # Profile-phase capture defaults. Trace size scales with captured decode steps;
 # an oversized capture serializes too slowly and kills the engine. 128 steps is

--- a/src/hyperloom/orchestrator/actions/executors/baseline.py
+++ b/src/hyperloom/orchestrator/actions/executors/baseline.py
@@ -81,11 +81,23 @@ _EVAL_FAILURE_MARKERS = (
 _LOG_SCAN_MAX_BYTES = 262_144
 
 # Markers identifying a MoE quant scheme with no implementation for the
-# ``--moe-runner-backend`` Hyperloom injects: the scheme is built without a
-# ``runner`` and the first forward pass dies (e.g. Quark MXFP4 on triton).
-_MOE_RUNNER_FAILURE_MARKERS = (
+# ``--moe-runner-backend`` in use: ``create_moe_runner`` falls through without
+# building a runner and the first forward pass dies (e.g. Quark MXFP4 on
+# triton). Both a missing-runner marker AND a MoE-scheme marker must appear, so
+# an unrelated AttributeError mentioning some other ``runner`` attribute does
+# not burn a full benchmark retry. Deliberately not keyed on Quark: sglang has
+# other aiter-only MoE schemes (quark_int4fp8_moe, the mxfp4 dynamic-quant
+# method) that fail exactly the same way.
+_MOE_RUNNER_MISSING_MARKERS = (
     "has no attribute 'runner'",
     'has no attribute "runner"',
+)
+_MOE_SCHEME_CONTEXT_MARKERS = (
+    "create_moe_runner",
+    "moe_runner",
+    "_moe.py",
+    "fused_moe",
+    "/moe/",
 )
 
 
@@ -1110,7 +1122,11 @@ class BaselineExecutor:
         return None
 
     @staticmethod
-    def _failure_carries_markers(result: dict[str, Any], markers: tuple[str, ...]) -> bool:
+    def _failure_carries_markers(
+        result: dict[str, Any],
+        markers: tuple[str, ...],
+        context_markers: tuple[str, ...] | None = None,
+    ) -> bool:
         """Whether a failed result's error tail, warnings or logs hit a marker.
 
         Scans the result's ``error`` tail + ``nonfatal_warnings`` and then any
@@ -1122,13 +1138,18 @@ class BaselineExecutor:
         Args:
             result: A ``status="failed"`` baseline result dict.
             markers: Substrings identifying the root cause being probed.
+            context_markers: When set, one of these must appear in the SAME
+                blob as a ``markers`` hit, narrowing a generic signature to the
+                subsystem that owns it.
 
         Returns:
-            ``True`` when any marker is found, else ``False``.
+            ``True`` when the marker (and its context) is found, else ``False``.
         """
 
         def _hit(text: str) -> bool:
-            return any(m in text for m in markers)
+            if not any(m in text for m in markers):
+                return False
+            return not context_markers or any(m in text for m in context_markers)
 
         if _hit(str(result.get("error") or "")):
             return True
@@ -1194,7 +1215,11 @@ class BaselineExecutor:
         Returns:
             ``True`` when a MoE-runner marker is found, else ``False``.
         """
-        return BaselineExecutor._failure_carries_markers(result, _MOE_RUNNER_FAILURE_MARKERS)
+        return BaselineExecutor._failure_carries_markers(
+            result,
+            _MOE_RUNNER_MISSING_MARKERS,
+            _MOE_SCHEME_CONTEXT_MARKERS,
+        )
 
     async def __call__(self, ctx: RunnerContext) -> dict[str, Any]:
         """Run the Magpie baseline, with a one-shot eval-failure fallback.

--- a/src/hyperloom/orchestrator/actions/executors/baseline.py
+++ b/src/hyperloom/orchestrator/actions/executors/baseline.py
@@ -54,6 +54,7 @@ from ._subprocess_kill import (
 )
 from ._workload_envs import (
     _RUN_EVAL_FALSE_VALUES,
+    _remove_moe_runner_backend_arg,
     FrameworkScriptMismatchError,
     default_baseline_config,
     materialize_config_with_envs,
@@ -77,7 +78,15 @@ _EVAL_FAILURE_MARKERS = (
     "Unknown parameter: --concurrent-requests",
 )
 # Bounded per-file read so log scanning never slurps a multi-GB server.log.
-_EVAL_SCAN_MAX_BYTES = 262_144
+_LOG_SCAN_MAX_BYTES = 262_144
+
+# Markers identifying a MoE quant scheme with no implementation for the
+# ``--moe-runner-backend`` Hyperloom injects: the scheme is built without a
+# ``runner`` and the first forward pass dies (e.g. Quark MXFP4 on triton).
+_MOE_RUNNER_FAILURE_MARKERS = (
+    "has no attribute 'runner'",
+    'has no attribute "runner"',
+)
 
 
 # Fast-exit arg errors (vLLM/sglang exits in <30s on bad CLI args)
@@ -1101,24 +1110,25 @@ class BaselineExecutor:
         return None
 
     @staticmethod
-    def _is_eval_rooted_failure(result: dict[str, Any]) -> bool:
-        """Whether a failed baseline result was caused by the accuracy eval.
+    def _failure_carries_markers(result: dict[str, Any], markers: tuple[str, ...]) -> bool:
+        """Whether a failed result's error tail, warnings or logs hit a marker.
 
         Scans the result's ``error`` tail + ``nonfatal_warnings`` and then any
-        benchmark stdout/stderr + ``server.log`` under the run's ``output_dir``
-        for ``run_eval``-failure markers. Recursive so the double-run path is
-        covered (the warmup round's logs carry the marker even when the measure
-        round failed for a downstream reason). Never raises.
+        benchmark stdout/stderr + ``server.log`` under the run's ``output_dir``.
+        Recursive so the double-run path is covered (the warmup round's logs
+        carry the marker even when the measure round failed for a downstream
+        reason). Never raises.
 
         Args:
             result: A ``status="failed"`` baseline result dict.
+            markers: Substrings identifying the root cause being probed.
 
         Returns:
-            ``True`` when an eval-failure marker is found, else ``False``.
+            ``True`` when any marker is found, else ``False``.
         """
 
         def _hit(text: str) -> bool:
-            return any(m in text for m in _EVAL_FAILURE_MARKERS)
+            return any(m in text for m in markers)
 
         if _hit(str(result.get("error") or "")):
             return True
@@ -1129,8 +1139,8 @@ class BaselineExecutor:
         if not out_dir:
             return False
         root = Path(out_dir)
-        # Double-run: the eval failure markers may live in the sibling warmup
-        # round, so climb to the shared task root to scan both rounds.
+        # Double-run: the failure markers may live in the sibling warmup round,
+        # so climb to the shared task root to scan both rounds.
         if root.name in ("warmup_round", "measure_round"):
             root = root.parent
         if not root.exists():
@@ -1148,7 +1158,7 @@ class BaselineExecutor:
                     with path.open("rb") as f:
                         f.seek(0, 2)
                         size = f.tell()
-                        f.seek(max(0, size - _EVAL_SCAN_MAX_BYTES))
+                        f.seek(max(0, size - _LOG_SCAN_MAX_BYTES))
                         chunk = f.read().decode("utf-8", "replace")
                 except OSError:
                     continue
@@ -1157,6 +1167,34 @@ class BaselineExecutor:
         except OSError:
             return False
         return False
+
+    @staticmethod
+    def _is_eval_rooted_failure(result: dict[str, Any]) -> bool:
+        """Whether a failed baseline result was caused by the accuracy eval.
+
+        Args:
+            result: A ``status="failed"`` baseline result dict.
+
+        Returns:
+            ``True`` when an eval-failure marker is found, else ``False``.
+        """
+        return BaselineExecutor._failure_carries_markers(result, _EVAL_FAILURE_MARKERS)
+
+    @staticmethod
+    def _is_moe_runner_rooted_failure(result: dict[str, Any]) -> bool:
+        """Whether a failed baseline died on the MoE runner backend in use.
+
+        The quant scheme's ``runner`` is only built on the backends it actually
+        implements, so an unsupported ``--moe-runner-backend`` surfaces as a
+        missing-attribute crash on the first forward pass.
+
+        Args:
+            result: A ``status="failed"`` baseline result dict.
+
+        Returns:
+            ``True`` when a MoE-runner marker is found, else ``False``.
+        """
+        return BaselineExecutor._failure_carries_markers(result, _MOE_RUNNER_FAILURE_MARKERS)
 
     async def __call__(self, ctx: RunnerContext) -> dict[str, Any]:
         """Run the Magpie baseline, with a one-shot eval-failure fallback.
@@ -1187,6 +1225,7 @@ class BaselineExecutor:
             "RUN_EVAL" in _extra_envs and str(_extra_envs["RUN_EVAL"]).strip().lower() in _RUN_EVAL_FALSE_VALUES
         )
         eval_already_off = is_truthy(params.get("disable_run_eval")) or _explicit_run_eval
+        eval_disabled_by_fallback = False
         if result.get("status") != "succeeded" and not eval_already_off and self._is_eval_rooted_failure(result):
             log.warning(
                 "baseline_executor: failure looks eval-rooted (InferenceX "
@@ -1199,6 +1238,28 @@ class BaselineExecutor:
             retry["nonfatal_warnings"].append("eval_failed_fallback_no_accuracy")
             if retry.get("status") == "succeeded":
                 retry["accuracy_source"] = "eval_unavailable"
+            eval_disabled_by_fallback = True
+            result = retry
+        if result.get("status") != "succeeded" and self._is_moe_runner_rooted_failure(result):
+            log.warning(
+                "baseline_executor: the server died on a MoE runner backend "
+                "that has no implementation for this checkpoint's quant "
+                "scheme; retrying once without --moe-runner-backend so the "
+                "framework picks the backend itself."
+            )
+            # Carry the eval fallback forward: the eval that broke above must
+            # stay off, and its bookkeeping must survive onto this result.
+            retry = await self._run_once(
+                ctx,
+                force_disable_eval=eval_disabled_by_fallback,
+                force_drop_moe_runner_backend=True,
+            )
+            retry.setdefault("nonfatal_warnings", [])
+            if eval_disabled_by_fallback:
+                retry["nonfatal_warnings"].append("eval_failed_fallback_no_accuracy")
+                if retry.get("status") == "succeeded":
+                    retry["accuracy_source"] = "eval_unavailable"
+            retry["nonfatal_warnings"].append("moe_runner_backend_fallback_dropped_flag")
             result = retry
         self._maybe_stop_on_missing_baseline_accuracy(ctx, result)
         return result
@@ -1333,6 +1394,7 @@ class BaselineExecutor:
         ctx: RunnerContext,
         *,
         force_disable_eval: bool = False,
+        force_drop_moe_runner_backend: bool = False,
     ) -> dict[str, Any]:
         """Run the Magpie baseline benchmark and parse its result.
 
@@ -1348,6 +1410,9 @@ class BaselineExecutor:
             force_disable_eval: When True, force ``RUN_EVAL=false`` into the
                 materialized config (the eval-failure fallback path); also set
                 by the ``disable_run_eval`` task param.
+            force_drop_moe_runner_backend: When True, strip any inherited
+                ``--moe-runner-backend`` and skip the AMD MoE injection (the
+                one-shot fallback after the backend killed the server).
 
         Returns:
             dict[str, Any]: On success, a ``status="succeeded"`` dict with
@@ -1394,6 +1459,8 @@ class BaselineExecutor:
                 cg_flag,
                 fw,
             )
+        if force_drop_moe_runner_backend:
+            effective_extra_server_args = _remove_moe_runner_backend_arg(effective_extra_server_args)
         if effective_extra_server_args or "extra_server_args" in params:
             # Keep the task envelope aligned with the materialized runtime so
             # Roofline fingerprints record one-shot eager fallback accurately.
@@ -1481,6 +1548,7 @@ class BaselineExecutor:
                 reference_server_args=ref_args,
                 reference_envs=ref_envs,
                 establish_quality_ref=is_genuine_baseline,
+                drop_moe_runner_backend=force_drop_moe_runner_backend,
             )
         except FrameworkScriptMismatchError as exc:
             # Cross-framework script override: return a structured failure.


### PR DESCRIPTION
Fixes #1036

## Summary

Hyperloom injected `--moe-runner-backend triton` for every MoE sglang model on AMD/ROCm without looking at the checkpoint's quant scheme. sglang implements the Quark MXFP4 / W4A4 MoE scheme only on its aiter path, so the forced triton runner builds the scheme without a `runner` attribute and the server dies on the first forward pass (`AttributeError: 'QuarkW4A4MXFp4MoE' object has no attribute 'runner'`). Every orchestrator run through that path — baseline, roofline, profile, sweep — failed, and no TraceLens/roofline snapshot was produced. The same checkpoint serves fine when the backend is left to sglang.

Two layers of fix:

- **Quant-aware gate.** `_model_moe_runner_requires_aiter()` reads `config.json` (top level and nested `text_config`): `quant_method: quark` plus an `mxfp4` / `mx_fp4` / `w4a4` marker, or `fp4` together with the `e8m0` MX scale format (which keeps nvfp4 out). `inject_sglang_moe_runner_backend()` skips injection for those checkpoints. Living inside the injection helper, the gate covers every path: baseline, profile, roofline and the explore/grid runner.
- **One-shot runtime fallback.** The gate can only cover schemes we already know about, so `BaselineExecutor` now detects the missing-runner signature in the failure's error tail, warnings and `server.log`, then retries once with `drop_moe_runner_backend=True`. The strip happens at the end of the server-arg pipeline, after every source is merged (task params, `$INFERENCE_OPTIMIZER_SERVER_ARGS`, the reference recipe, the YAML base), so the flag cannot come back regardless of where it originated. Fires once; a second failure is reported as-is.

Notes:

- An eval-rooted fallback that already forced `RUN_EVAL=false` carries forward into the MoE retry, so the retry neither resurrects the eval that broke nor loses its `accuracy_source` / warning bookkeeping.
- An operator-pinned `--moe-runner-backend` still wins at injection time, but is dropped on the fallback retry — at that point it is the proven cause of death.
- The log-scan used by the eval detector was extracted into a shared `_failure_carries_markers()` helper now used by both detectors.
- The runtime fallback is scoped to `BaselineExecutor` (inherited by profile/roofline). The explore/grid variant loop is covered by the gate only; a single failing variant there does not sink a whole run.

## Test plan

- [x] New: `test_baseline_moe_runner_fallback.py` — signature detection (error tail / `server.log` / negative), end-to-end flagless retry, flag arriving via `$INFERENCE_OPTIMIZER_SERVER_ARGS` and via the reference recipe, operator-pinned flag dropped on retry, eval-disabled state carried into the MoE retry, fires only once, unrelated failures do not retry.
- [x] Extended: `test_moe_runner_backend_injection.py` — Quark 4-bit detection true/false matrix, nested `text_config`, injection and `materialize_config_with_envs` skip, env override cannot resurrect the injection, `drop_moe_runner_backend` strips an inherited flag while leaving other args intact.
- [x] `pytest src/hyperloom/inference_optimizer/tests` — 8130 passed. The 2 failures (`test_bench_specialist_without_explicit_needs_gpu_is_gated`, `test_aiter_build_e2e_real_rocm`) reproduce unchanged on `main`.
- [x] `pytest src/hyperloom/agents` — 2410 passed.
- [x] `ruff check` / `ruff format --check` clean on every touched file.