### PR TITLE
fix(eval): stop false-positive install abort on refactored run_lm_eval parser

### DIFF
--- a/src/hyperloom/inference_optimizer/assets/install.sh
+++ b/src/hyperloom/inference_optimizer/assets/install.sh
@@ -817,11 +817,13 @@ if not status.atomic_ok:
     sys.exit(1)
 if not status.remote_trust_ok:
     sys.exit(2)
-# Redundant --concurrent-requests eval flag could not be stripped from a
-# generic benchmark script (unrecognised shape). Non-fatal: RUN_EVAL=true
-# baselines may abort on InferenceX's 'Unknown parameter', but the baseline
-# executor's eval-failure fallback re-runs with RUN_EVAL=false, so the run
-# still proceeds (without an accuracy gate). Distinct exit so install warns.
+# eval_flag_ok is False ONLY when a live `run_eval --concurrent-requests`
+# survives in a caller script AND InferenceX's run_lm_eval would reject it
+# (a defence-in-depth patch that merely could not be applied, with no live
+# flag, is NOT counted as a failure -- install-time now matches the run-time
+# ensure_eval_concurrency_compat judgement). This is the genuinely fatal case:
+# every RUN_EVAL=true baseline aborts on 'Unknown parameter'. Distinct exit so
+# install can name the failure mode.
 if not status.eval_flag_ok:
     sys.exit(5)
 # Defensive catch-all: a not-ok status with none of the bits above set should

--- a/src/hyperloom/inference_optimizer/tests/test_magpie_patcher_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_magpie_patcher_unit.py
@@ -785,3 +785,126 @@ def test_parser_patch_reports_failure_on_an_unrecognised_parser_block(tmp_path):
     lib.write_text("run_lm_eval() { : ; }\n", encoding="utf-8")
 
     assert mp._apply_run_lm_eval_arg_patch_atomic(lib) is False
+
+
+# ---- merged-case parser (InferenceX a4bb43af+) ----------------------------
+# The pinned InferenceX (a4bb43af) refactored run_lm_eval's arg parser into a
+# single merged ``--port|--task|...|--top-p)`` case with an inner dispatch and a
+# ``>&2`` / ``return 2`` catch-all. It already reads concurrency from
+# EVAL_CONCURRENT_REQUESTS/CONC and no caller passes --concurrent-requests, so
+# accuracy eval is NOT blocked. The old per-flag legacy block no longer matches,
+# which used to make eval_flag_ok=False and (post 3166da7f) fail install with a
+# false positive.
+_BENCHMARK_LIB_MERGED_CASE = (
+    "#!/bin/bash\n"
+    "run_lm_eval() {\n"
+    '    local port="${PORT:-8888}"\n'
+    '    local top_p=1\n'
+    '    local concurrent_requests="${EVAL_CONCURRENT_REQUESTS:-${CONC:-64}}"\n'
+    "    while [[ $# -gt 0 ]]; do\n"
+    "        case \"$1\" in\n"
+    "            --port|--task|--results-dir|--gen-max-tokens|--temperature|--top-p)\n"
+    "                case \"$1\" in\n"
+    '                    --port)           port="$2" ;;\n'
+    '                    --top-p)          top_p="$2" ;;\n'
+    "                esac\n"
+    "                shift 2\n"
+    "                ;;\n"
+    "            *)\n"
+    '                echo "Unknown parameter: $1" >&2\n'
+    "                return 2\n"
+    "                ;;\n"
+    "        esac\n"
+    "    done\n"
+    "}\n"
+)
+
+
+def test_merged_case_parser_is_taught_the_flag(tmp_path):
+    """The a4bb43af merged-case parser must be patched to accept the flag."""
+    lib = tmp_path / "benchmark_lib.sh"
+    lib.write_text(_BENCHMARK_LIB_MERGED_CASE, encoding="utf-8")
+
+    assert mp._apply_run_lm_eval_arg_patch_atomic(lib) is True
+    text = lib.read_text(encoding="utf-8")
+    assert "--concurrent-requests|--concurrent_requests" in text
+    assert mp._RUN_LM_EVAL_PARSER_SENTINEL in text
+    # Idempotent second pass.
+    assert mp._apply_run_lm_eval_arg_patch_atomic(lib) is True
+    assert lib.read_text(encoding="utf-8").count("--concurrent-requests|--concurrent_requests") == 1
+
+
+def test_merged_case_env_only_ix_is_not_a_false_positive(tmp_path):
+    """Full status: merged-case parser + env concurrency + no live flag => ok.
+
+    Reproduces the shuoshuo-dev install failure: the defence-in-depth parser
+    patch could not match the refactored parser, but nothing passes the flag, so
+    the install must NOT be failed (status.ok stays True).
+    """
+    ix = tmp_path / "ix"
+    bench = ix / "benchmarks"
+    bench.mkdir(parents=True)
+    (bench / "benchmark_lib.sh").write_text(_BENCHMARK_LIB_MERGED_CASE, encoding="utf-8")
+    # A caller script that takes concurrency via env, not the flag (no live flag).
+    (bench / "vllm_mi355x.sh").write_text(
+        "#!/bin/bash\n"
+        'if [[ "$RUN_EVAL" = "true" ]]; then\n'
+        '        run_eval --framework lm-eval --port "$PORT" || exit $?\n'
+        "fi\n",
+        encoding="utf-8",
+    )
+
+    status = mp.magpie_scripts_patch_status(None, str(ix))
+    # The merged-case parser was taught the flag, so the eval fix succeeded.
+    assert status.eval_flag_ok is True
+    # atomic is a benign no-op here (no MAGPIE_PATH / benchmarker.py), not a
+    # genuine failure; install.sh treats reason=missing as fail-soft.
+    assert status.atomic_reason == mp._ATOMIC_REASON_MISSING
+    assert status.atomic_genuine_failure is False
+    assert mp.live_eval_concurrency_flag_scripts(None, str(ix)) == []
+
+
+def test_unpatchable_parser_without_live_flag_is_not_fatal(tmp_path):
+    """Narrowed judgement: even a parser we cannot teach must not fail install
+    when no caller passes the flag (aligns install-time with run-time)."""
+    ix = tmp_path / "ix"
+    bench = ix / "benchmarks"
+    bench.mkdir(parents=True)
+    # A run_lm_eval whose parser shape we cannot recognise at all.
+    (bench / "benchmark_lib.sh").write_text("run_lm_eval() { : ; }\n", encoding="utf-8")
+    # No live --concurrent-requests anywhere.
+    (bench / "vllm_mi355x.sh").write_text(
+        "#!/bin/bash\n"
+        'if [[ "$RUN_EVAL" = "true" ]]; then\n'
+        '        run_eval --framework lm-eval --port "$PORT" || exit $?\n'
+        "fi\n",
+        encoding="utf-8",
+    )
+
+    status = mp.magpie_scripts_patch_status(None, str(ix))
+    assert mp.live_eval_concurrency_flag_scripts(None, str(ix)) == []
+    # The belt patch could not apply, but nothing is blocked -> not fatal.
+    assert status.eval_flag_ok is True
+
+
+def test_unpatchable_parser_with_live_flag_stays_fatal(tmp_path):
+    """The narrowed judgement must still fail when a live flag really survives
+    an unteachable parser (no false negative)."""
+    ix = tmp_path / "ix"
+    bench = ix / "benchmarks"
+    bench.mkdir(parents=True)
+    (bench / "benchmark_lib.sh").write_text("run_lm_eval() { : ; }\n", encoding="utf-8")
+    # A caller that STILL passes the rejected flag in a shape the strip regex
+    # (which expects the $CONC variable) cannot remove: a literal value. The
+    # live-flag scan still recognises it, so it is a genuine, unstrippable blocker.
+    (bench / "vllm_mi355x.sh").write_text(
+        "#!/bin/bash\n"
+        'if [[ "$RUN_EVAL" = "true" ]]; then\n'
+        '        run_eval --framework lm-eval --port "$PORT" --concurrent-requests 64 || exit $?\n'
+        "fi\n",
+        encoding="utf-8",
+    )
+
+    status = mp.magpie_scripts_patch_status(None, str(ix))
+    assert [p.name for p in mp.live_eval_concurrency_flag_scripts(None, str(ix))] == ["vllm_mi355x.sh"]
+    assert status.eval_flag_ok is False

--- a/src/hyperloom/inference_optimizer/tests/test_magpie_patcher_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_magpie_patcher_unit.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 
 from hyperloom.orchestrator.actions.executors import _magpie_patcher as mp
 
@@ -885,6 +886,107 @@ def test_unpatchable_parser_without_live_flag_is_not_fatal(tmp_path):
     assert mp.live_eval_concurrency_flag_scripts(None, str(ix)) == []
     # The belt patch could not apply, but nothing is blocked -> not fatal.
     assert status.eval_flag_ok is True
+
+
+# A benchmark_lib.sh with EARLIER functions that carry an identical ``*)``
+# catch-all (real a4bb43af has several before run_lm_eval, e.g. at lines 285 &
+# 451). The merged-case patch must skip these and only touch run_lm_eval's.
+_BENCHMARK_LIB_MULTI_CATCHALL = (
+    "#!/bin/bash\n"
+    "wait_for_server_ready() {\n"
+    "    while [[ $# -gt 0 ]]; do\n"
+    "        case \"$1\" in\n"
+    '            --port) port="$2"; shift 2 ;;\n'
+    "            *)\n"
+    '                echo "Unknown parameter: $1" >&2\n'
+    "                return 2\n"
+    "                ;;\n"
+    "        esac\n"
+    "    done\n"
+    "}\n"
+    "\n"
+    "parse_other() {\n"
+    "    case \"$1\" in\n"
+    "        *)\n"
+    '            echo "Unknown parameter: $1" >&2\n'
+    "            return 1\n"
+    "            ;;\n"
+    "    esac\n"
+    "}\n"
+    "\n"
+    + _BENCHMARK_LIB_MERGED_CASE
+)
+
+
+def test_merged_case_patch_lands_inside_run_lm_eval_only(tmp_path):
+    """Regression for the mis-patch bug: with earlier functions sharing the same
+    ``*)`` catch-all, the flag case must be spliced into run_lm_eval, not the
+    first matching catch-all in the file."""
+    lib = tmp_path / "benchmark_lib.sh"
+    lib.write_text(_BENCHMARK_LIB_MULTI_CATCHALL, encoding="utf-8")
+
+    assert mp._apply_run_lm_eval_arg_patch_atomic(lib) is True
+    text = lib.read_text(encoding="utf-8")
+
+    # Exactly one flag case was added, and it sits inside run_lm_eval's body.
+    assert text.count("--concurrent-requests|--concurrent_requests") == 1
+    region = mp._extract_run_lm_eval_region(text)
+    assert region is not None
+    body = text[region[0] : region[1]]
+    assert "--concurrent-requests|--concurrent_requests" in body
+    assert mp._RUN_LM_EVAL_PARSER_SENTINEL in body
+    # The earlier functions' catch-alls were left untouched.
+    before = text[: region[0]]
+    assert mp._RUN_LM_EVAL_PARSER_SENTINEL not in before
+    assert "--concurrent-requests" not in before
+    # Tolerance check (scoped to run_lm_eval) now reports True for this tree.
+    ix = tmp_path / "ix"
+    (ix / "benchmarks").mkdir(parents=True)
+    (ix / "benchmarks" / "benchmark_lib.sh").write_text(text, encoding="utf-8")
+    assert mp._inferencex_tolerates_eval_flag(str(ix)) is True
+
+
+def test_tolerance_not_fooled_by_outer_catchall_sentinel(tmp_path):
+    """A sentinel/flag that lives OUTSIDE run_lm_eval must not be read as
+    run_lm_eval tolerating the flag (guards the fatal path)."""
+    ix = tmp_path / "ix"
+    bench = ix / "benchmarks"
+    bench.mkdir(parents=True)
+    # run_lm_eval itself is an unteachable stub (no flag inside), but an earlier
+    # function carries the sentinel + a --concurrent-requests case.
+    poisoned = (
+        "#!/bin/bash\n"
+        "other_fn() {\n"
+        f"    # {mp._RUN_LM_EVAL_PARSER_SENTINEL}: not the real parser\n"
+        '    --concurrent-requests|--concurrent_requests) x="$2" ;;\n'
+        "}\n"
+        "run_lm_eval() { : ; }\n"
+    )
+    (bench / "benchmark_lib.sh").write_text(poisoned, encoding="utf-8")
+
+    assert mp._inferencex_tolerates_eval_flag(str(ix)) is False
+
+
+def test_real_pinned_benchmark_lib_patches_run_lm_eval(tmp_path):
+    """Integration: the real a4bb43af benchmark_lib.sh (if present) must get its
+    run_lm_eval taught the flag, with the sentinel landing inside that function.
+
+    Skips silently when the fixture is not checked in, so the suite stays
+    hermetic;     the logic is already covered by the multi-catch-all stub above."""
+    fixture = Path(__file__).parent / "fixtures" / "benchmark_lib_a4bb43af.sh"
+    if not fixture.is_file():
+        pytest.skip("real pinned benchmark_lib.sh fixture not present")
+    lib = tmp_path / "benchmark_lib.sh"
+    lib.write_text(fixture.read_text(encoding="utf-8"), encoding="utf-8")
+
+    assert mp._apply_run_lm_eval_arg_patch_atomic(lib) is True
+    text = lib.read_text(encoding="utf-8")
+    region = mp._extract_run_lm_eval_region(text)
+    assert region is not None
+    body = text[region[0] : region[1]]
+    assert "--concurrent-requests|--concurrent_requests" in body
+    assert mp._RUN_LM_EVAL_PARSER_SENTINEL in body
+    assert text.count("--concurrent-requests|--concurrent_requests") == 1
 
 
 def test_unpatchable_parser_with_live_flag_stays_fatal(tmp_path):

--- a/src/hyperloom/orchestrator/actions/executors/_magpie_patcher.py
+++ b/src/hyperloom/orchestrator/actions/executors/_magpie_patcher.py
@@ -724,12 +724,6 @@ def ensure_eval_concurrency_compat(
     are (re)asserted against the trees that will really run. Cheap and
     idempotent: scripts already clean are skipped without a write.
 
-    Args:
-        magpie_dir: Magpie root override; falls back to ``$MAGPIE_PATH``.
-        inferencex_dir: InferenceX root override (pass the *effective* /
-            mirrored checkout, not the pristine source); falls back to
-            ``$INFERENCEX_PATH``.
-
     Returns ``False`` **only** for the genuinely fatal state: a caller script
     still invokes ``run_eval`` with the flag AND InferenceX's ``run_lm_eval``
     would reject it. A defence-in-depth patch that merely could not be applied

--- a/src/hyperloom/orchestrator/actions/executors/_magpie_patcher.py
+++ b/src/hyperloom/orchestrator/actions/executors/_magpie_patcher.py
@@ -181,10 +181,13 @@ _RUN_LM_EVAL_PARSER_PATCHED_BLOCK = (
 )
 
 # InferenceX a4bb43af+ refactored the parser into a single merged case
-# (``--port|--task|...|--top-p)`` with an inner dispatch) and a ``>&2`` /
+# (``--port|--task|...|--top-p)`` with an inner dispatch and a ``>&2`` /
 # ``return 2`` catch-all, so the per-flag legacy block above no longer matches.
 # Match that catch-all (any ``return N``) and splice a dedicated
 # ``--concurrent-requests`` case in front of it, preserving the leading indent.
+# The scan is scoped to the ``run_lm_eval`` body (see
+# :func:`_extract_run_lm_eval_region`) so it never lands in an earlier
+# function's identical ``*)`` catch-all (benchmark_lib.sh has several).
 _RUN_LM_EVAL_MERGED_CATCHALL_RE = re.compile(
     r"^(?P<indent>[ \t]*)\*\)\s*\n"
     r"[ \t]*echo\s+\"Unknown parameter: \$1\"(?:\s+>&2)?\s*\n"
@@ -192,6 +195,10 @@ _RUN_LM_EVAL_MERGED_CATCHALL_RE = re.compile(
     r"[ \t]*;;\s*\n",
     re.MULTILINE,
 )
+
+# Header of the InferenceX ``run_lm_eval`` shell function; used to scope the
+# merged-case parser patch and the tolerance check to that function's body.
+_RUN_LM_EVAL_FN_MARKER = "run_lm_eval()"
 
 # InferenceX benchmark_lib.sh::run_lm_eval reads concurrency from env
 # (EVAL_CONCURRENT_REQUESTS, fallback CONC). Passing --concurrent-requests to
@@ -462,15 +469,46 @@ def _apply_eval_flag_patch_atomic(scripts_dir: Path) -> bool:
     return ok
 
 
+def _extract_run_lm_eval_region(text: str) -> tuple[int, int] | None:
+    """Return ``(start, end)`` char offsets of the ``run_lm_eval`` function body.
+
+    Scopes any parser-shape scan to that one function so an identical ``*)``
+    catch-all in an earlier ``benchmark_lib.sh`` function (there are several)
+    can never be mistaken for ``run_lm_eval``'s. The body runs from the
+    ``run_lm_eval()`` header to the next line-start ``}`` (the function's
+    closing brace at column 0), or end-of-text when that brace is absent.
+
+    Args:
+        text: The full ``benchmark_lib.sh`` source text.
+
+    Returns:
+        The ``(start, end)`` offsets of the function body, or ``None`` when the
+        ``run_lm_eval()`` header is absent.
+    """
+    start = text.find(_RUN_LM_EVAL_FN_MARKER)
+    if start == -1:
+        return None
+    close = re.search(r"^\}", text[start:], re.MULTILINE)
+    end = start + close.end() if close else len(text)
+    return start, end
+
+
 def _patch_merged_case_parser(text: str) -> str | None:
     """Splice a ``--concurrent-requests`` case before the merged-case parser's
-    ``*)`` catch-all, or return ``None`` when that catch-all is not found.
+    ``*)`` catch-all, or return ``None`` when that catch-all is not found inside
+    the ``run_lm_eval`` body.
 
     Handles the InferenceX a4bb43af+ shape where every flag shares one
     ``case`` arm; the new arm sets the ``concurrent_requests`` local the parser
-    already owns. Indentation is inherited from the matched catch-all.
+    already owns. Indentation is inherited from the matched catch-all. Matching
+    is scoped to the ``run_lm_eval`` body so the patch never lands in an
+    earlier function's identical catch-all.
     """
-    m = _RUN_LM_EVAL_MERGED_CATCHALL_RE.search(text)
+    region = _extract_run_lm_eval_region(text)
+    if region is None:
+        return None
+    start, end = region
+    m = _RUN_LM_EVAL_MERGED_CATCHALL_RE.search(text, start, end)
     if m is None:
         return None
     indent = m.group("indent")
@@ -506,8 +544,12 @@ def _apply_run_lm_eval_arg_patch_atomic(benchmark_lib: Path) -> bool:
         log.warning("_magpie_patcher: cannot read %s: %s", benchmark_lib, e)
         return False
 
-    # Already tolerant (our sentinel, or an upstream that added the flag).
-    if _RUN_LM_EVAL_PARSER_SENTINEL in original or _EVAL_CONCURRENCY_FLAG_MARKER in original:
+    # Already tolerant (our sentinel, or an upstream that added the flag) --
+    # scoped to the run_lm_eval body so a sentinel/flag elsewhere in the file
+    # does not short-circuit the patch of run_lm_eval itself.
+    _region = _extract_run_lm_eval_region(original)
+    _body = original[_region[0] : _region[1]] if _region is not None else ""
+    if _RUN_LM_EVAL_PARSER_SENTINEL in _body or _EVAL_CONCURRENCY_FLAG_MARKER in _body:
         return True
 
     if _RUN_LM_EVAL_PARSER_LEGACY_BLOCK in original:
@@ -609,7 +651,14 @@ def _inferencex_tolerates_eval_flag(inferencex_dir: Path | str | None) -> bool:
         text = lib.read_text(encoding="utf-8")
     except OSError:
         return False
-    return _RUN_LM_EVAL_PARSER_SENTINEL in text or _EVAL_CONCURRENCY_FLAG_MARKER in text
+    # Scope the check to the run_lm_eval body: a sentinel / flag anywhere else
+    # in the file (e.g. a mis-placed patch in another function's catch-all, or
+    # an unrelated comment) must NOT be read as run_lm_eval tolerating the flag.
+    region = _extract_run_lm_eval_region(text)
+    if region is None:
+        return False
+    body = text[region[0] : region[1]]
+    return _RUN_LM_EVAL_PARSER_SENTINEL in body or _EVAL_CONCURRENCY_FLAG_MARKER in body
 
 
 def live_eval_concurrency_flag_scripts(

--- a/src/hyperloom/orchestrator/actions/executors/_magpie_patcher.py
+++ b/src/hyperloom/orchestrator/actions/executors/_magpie_patcher.py
@@ -180,6 +180,19 @@ _RUN_LM_EVAL_PARSER_PATCHED_BLOCK = (
     '            *)                echo "Unknown parameter: $1"; return 1 ;;\n'
 )
 
+# InferenceX a4bb43af+ refactored the parser into a single merged case
+# (``--port|--task|...|--top-p)`` with an inner dispatch) and a ``>&2`` /
+# ``return 2`` catch-all, so the per-flag legacy block above no longer matches.
+# Match that catch-all (any ``return N``) and splice a dedicated
+# ``--concurrent-requests`` case in front of it, preserving the leading indent.
+_RUN_LM_EVAL_MERGED_CATCHALL_RE = re.compile(
+    r"^(?P<indent>[ \t]*)\*\)\s*\n"
+    r"[ \t]*echo\s+\"Unknown parameter: \$1\"(?:\s+>&2)?\s*\n"
+    r"[ \t]*return\s+\d+\s*\n"
+    r"[ \t]*;;\s*\n",
+    re.MULTILINE,
+)
+
 # InferenceX benchmark_lib.sh::run_lm_eval reads concurrency from env
 # (EVAL_CONCURRENT_REQUESTS, fallback CONC). Passing --concurrent-requests to
 # run_eval is rejected as an unknown argument.
@@ -449,6 +462,26 @@ def _apply_eval_flag_patch_atomic(scripts_dir: Path) -> bool:
     return ok
 
 
+def _patch_merged_case_parser(text: str) -> str | None:
+    """Splice a ``--concurrent-requests`` case before the merged-case parser's
+    ``*)`` catch-all, or return ``None`` when that catch-all is not found.
+
+    Handles the InferenceX a4bb43af+ shape where every flag shares one
+    ``case`` arm; the new arm sets the ``concurrent_requests`` local the parser
+    already owns. Indentation is inherited from the matched catch-all.
+    """
+    m = _RUN_LM_EVAL_MERGED_CATCHALL_RE.search(text)
+    if m is None:
+        return None
+    indent = m.group("indent")
+    new_case = (
+        f"{indent}# {_RUN_LM_EVAL_PARSER_SENTINEL}: accept the redundant flag\n"
+        f"{indent}# (concurrency also flows via EVAL_CONCURRENT_REQUESTS/CONC).\n"
+        f'{indent}--concurrent-requests|--concurrent_requests) concurrent_requests="$2"; shift 2 ;;\n'
+    )
+    return text[: m.start()] + new_case + text[m.start() :]
+
+
 def _apply_run_lm_eval_arg_patch_atomic(benchmark_lib: Path) -> bool:
     """Teach InferenceX's ``benchmark_lib.sh::run_lm_eval`` to accept the
     ``--concurrent-requests`` flag instead of aborting on ``Unknown parameter``.
@@ -477,20 +510,25 @@ def _apply_run_lm_eval_arg_patch_atomic(benchmark_lib: Path) -> bool:
     if _RUN_LM_EVAL_PARSER_SENTINEL in original or _EVAL_CONCURRENCY_FLAG_MARKER in original:
         return True
 
-    if _RUN_LM_EVAL_PARSER_LEGACY_BLOCK not in original:
-        log.warning(
-            "_magpie_patcher: run_lm_eval arg-parser block not found in %s; "
-            "cannot make it tolerate '--concurrent-requests'. RUN_EVAL=true "
-            "baselines may still abort if a stray flag survives the strip.",
-            benchmark_lib,
+    if _RUN_LM_EVAL_PARSER_LEGACY_BLOCK in original:
+        patched = original.replace(
+            _RUN_LM_EVAL_PARSER_LEGACY_BLOCK,
+            _RUN_LM_EVAL_PARSER_PATCHED_BLOCK,
+            1,
         )
-        return False
-
-    patched = original.replace(
-        _RUN_LM_EVAL_PARSER_LEGACY_BLOCK,
-        _RUN_LM_EVAL_PARSER_PATCHED_BLOCK,
-        1,
-    )
+    else:
+        # InferenceX a4bb43af+ merged-case parser: splice a dedicated
+        # --concurrent-requests case in front of the ``*)`` catch-all,
+        # preserving its indentation.
+        patched = _patch_merged_case_parser(original)
+        if patched is None:
+            log.warning(
+                "_magpie_patcher: run_lm_eval arg-parser block not found in %s; "
+                "cannot make it tolerate '--concurrent-requests'. RUN_EVAL=true "
+                "baselines may still abort if a stray flag survives the strip.",
+                benchmark_lib,
+            )
+            return False
     if patched == original:
         return False
 
@@ -663,29 +701,56 @@ def ensure_eval_concurrency_compat(
     """
     with _file_lock(_LOCK_PATH):
         applied_ok = _apply_eval_concurrency_fixes(magpie_dir, inferencex_dir)
-        blockers = live_eval_concurrency_flag_scripts(magpie_dir, inferencex_dir)
-        if blockers and not _inferencex_tolerates_eval_flag(inferencex_dir):
-            log.error(
-                "_magpie_patcher: %d benchmark script(s) still call run_eval "
-                "with '%s' and InferenceX's run_lm_eval will reject it: %s. "
-                "Accuracy eval WILL abort ('Unknown parameter'); concurrency "
-                "must flow via EVAL_CONCURRENT_REQUESTS (fallback CONC).",
-                len(blockers),
-                _EVAL_CONCURRENCY_FLAG_MARKER,
-                ", ".join(str(p) for p in blockers),
-            )
-            return False
-        if not applied_ok:
-            log.warning(
-                "_magpie_patcher: an eval-concurrency defence-in-depth patch "
-                "could not be applied (magpie=%s inferencex=%s), but no live "
-                "'run_eval ... %s' invocation was found, so accuracy eval is "
-                "not blocked.",
-                magpie_dir or os.environ.get("MAGPIE_PATH", "") or "<unset>",
-                inferencex_dir or os.environ.get("INFERENCEX_PATH", "") or "<unset>",
-                _EVAL_CONCURRENCY_FLAG_MARKER,
-            )
-        return True
+        return _eval_concurrency_unblocked(applied_ok, magpie_dir, inferencex_dir)
+
+
+def _eval_concurrency_unblocked(
+    applied_ok: bool,
+    magpie_dir: Path | str | None,
+    inferencex_dir: Path | str | None,
+) -> bool:
+    """Whether accuracy eval is unblocked given the eval-fix apply result.
+
+    The single source of truth shared by the run-time entry point
+    (:func:`ensure_eval_concurrency_compat`) and the install-time status
+    (:func:`magpie_scripts_patch_status`): a defence-in-depth patch that merely
+    could not be applied is NOT fatal on its own — only a *live*
+    ``run_eval --concurrent-requests`` that InferenceX would reject blocks eval.
+    Callers must already hold ``_LOCK_PATH``.
+
+    Args:
+        applied_ok: Result of :func:`_apply_eval_concurrency_fixes`.
+        magpie_dir: Magpie root override; falls back to ``$MAGPIE_PATH``.
+        inferencex_dir: InferenceX root override; falls back to
+            ``$INFERENCEX_PATH``.
+
+    Returns:
+        ``False`` only when a live flag survives and cannot be absorbed, else
+        ``True``.
+    """
+    blockers = live_eval_concurrency_flag_scripts(magpie_dir, inferencex_dir)
+    if blockers and not _inferencex_tolerates_eval_flag(inferencex_dir):
+        log.error(
+            "_magpie_patcher: %d benchmark script(s) still call run_eval "
+            "with '%s' and InferenceX's run_lm_eval will reject it: %s. "
+            "Accuracy eval WILL abort ('Unknown parameter'); concurrency "
+            "must flow via EVAL_CONCURRENT_REQUESTS (fallback CONC).",
+            len(blockers),
+            _EVAL_CONCURRENCY_FLAG_MARKER,
+            ", ".join(str(p) for p in blockers),
+        )
+        return False
+    if not applied_ok:
+        log.warning(
+            "_magpie_patcher: an eval-concurrency defence-in-depth patch "
+            "could not be applied (magpie=%s inferencex=%s), but no live "
+            "'run_eval ... %s' invocation was found, so accuracy eval is "
+            "not blocked.",
+            magpie_dir or os.environ.get("MAGPIE_PATH", "") or "<unset>",
+            inferencex_dir or os.environ.get("INFERENCEX_PATH", "") or "<unset>",
+            _EVAL_CONCURRENCY_FLAG_MARKER,
+        )
+    return True
 
 
 @contextmanager
@@ -1151,7 +1216,10 @@ def magpie_scripts_patch_status(
             # scripts (Magpie source + the InferenceX/benchmarks copies that
             # actually execute), not in benchmarker.py. A missing / stale
             # benchmarker.py must NOT silently skip them.
-            eval_flag_ok = _apply_eval_concurrency_fixes(magpie_dir, inferencex_dir)
+            applied_ok = _apply_eval_concurrency_fixes(magpie_dir, inferencex_dir)
+            # Align install-time with run-time: a defence-in-depth patch that
+            # could not be applied is NOT fatal unless a live flag survives.
+            eval_flag_ok = _eval_concurrency_unblocked(applied_ok, magpie_dir, inferencex_dir)
             log.info(
                 "_magpie_patcher: MAGPIE_PATH unset or benchmarker.py missing — "
                 "skipping atomic-copy patch (fine for tests / dry-runs); "
@@ -1209,7 +1277,10 @@ def magpie_scripts_patch_status(
         # Eval-concurrency fixes run LAST so the remote-trust patch on
         # sglang_mi300x.sh still finds its (flagged) legacy run_eval block
         # before the generic strip removes the flag from it.
-        eval_flag_ok = _apply_eval_concurrency_fixes(magpie_dir, inferencex_dir)
+        applied_ok = _apply_eval_concurrency_fixes(magpie_dir, inferencex_dir)
+        # Align install-time with run-time: a defence-in-depth patch that could
+        # not be applied is NOT fatal unless a live flag actually survives.
+        eval_flag_ok = _eval_concurrency_unblocked(applied_ok, magpie_dir, inferencex_dir)
         return MagpiePatchStatus(
             atomic_ok=atomic_ok,
             remote_trust_ok=remote_trust_ok,


### PR DESCRIPTION

The pinned InferenceX (a4bb43af) refactored run_lm_eval's arg parser into a single merged `--port|--task|...|--top-p)` case with a `>&2` / `return N` catch-all. The per-flag legacy block the patcher matched no longer exists, so `_apply_run_lm_eval_arg_patch_atomic` returned False, `eval_flag_ok` went False, and (since the fail-loud change) install aborted with exit 5 -- even though no caller passes `--concurrent-requests` and run_lm_eval already reads concurrency from EVAL_CONCURRENT_REQUESTS/CONC, so accuracy eval was never actually blocked.

Two fixes:
- Teach the parser patch to recognise the merged-case shape and splice a dedicated `--concurrent-requests` case before the catch-all (indent-aware), restoring the defence-in-depth belt for the run-time re-copy.
- Align install-time judgement with the run-time entry point via a shared `_eval_concurrency_unblocked` helper: a defence-in-depth patch that merely could not be applied is not fatal on its own -- only a live `run_eval --concurrent-requests` that InferenceX would reject blocks eval.

Tests: 4 new cases covering the merged-case parse/patch, the reproduced false-positive, and the narrowed judgement (unpatchable parser is non-fatal without a live flag, still fatal with one). 183 passed.
