### PR TITLE
fix(forge): install kernel_agents in install.sh

### DIFF
--- a/src/hyperloom/agents/kernel/SKILL.md
+++ b/src/hyperloom/agents/kernel/SKILL.md
@@ -386,7 +386,7 @@ or real `torchrun --nproc=N`.
 The `forge` backend needs the private KernelForge (`kernel_agents`) package.
 The installer no longer clones it: provide it yourself before running forge,
 either by `pip install`-ing `kernel_agents`, or by setting `FORGE_PATH`
-(aliases `KERNEL_FORGE_ROOT` / `KERNEL_FORGE_PATH`) to a KernelForge checkout.
+to a KernelForge checkout.
 When neither is present, forge resolution is a silent no-op (fail-soft), so a
 run that explicitly selects forge will do nothing — verify the checkout/env is
 in place first.

--- a/src/hyperloom/agents/kernel/tools/backends/forge_submit.py
+++ b/src/hyperloom/agents/kernel/tools/backends/forge_submit.py
@@ -94,15 +94,12 @@ class _RetainedWorkspaceCollision(FileExistsError):
 def _ensure_forge_on_path() -> str:
     """Make `kernel_agents` (Kernel-Forge) importable from $FORGE_PATH.
 
-    Reads $FORGE_PATH (also accepts $KERNEL_FORGE_ROOT / $KERNEL_FORGE_PATH),
-    resolves the dir that contains the `kernel_agents` package (the repo root,
-    its `src/`, or the package dir itself) and prepends it to sys.path. When the
-    env var is unset, does nothing and relies on an installed `kernel_agents`.
-    Returns the path inserted, or "".
+    Reads $FORGE_PATH, resolves the dir that contains the `kernel_agents`
+    package (the repo root, its `src/`, or the package dir itself) and prepends
+    it to sys.path. When the env var is unset, does nothing and relies on an
+    installed `kernel_agents`. Returns the path inserted, or "".
     """
-    root = (
-        os.environ.get("FORGE_PATH") or os.environ.get("KERNEL_FORGE_ROOT") or os.environ.get("KERNEL_FORGE_PATH") or ""
-    ).strip()
+    root = (os.environ.get("FORGE_PATH") or "").strip()
     if not root:
         return ""
     for cand in (os.path.join(root, "src"), root, os.path.dirname(root)):

--- a/src/hyperloom/inference_optimizer/assets/install.sh
+++ b/src/hyperloom/inference_optimizer/assets/install.sh
@@ -712,6 +712,71 @@ ensure_forge_gemm_tune() {
   fi
 }
 
+# --- 1c. kernel_agents (KernelForge forge-loop CLI) ---
+# forge-loop shells out to `python -m kernel_agents.cli` (see forge_submit.py).
+# Unlike forge_gemm_tune / forge_fusion — which have standalone sub-pyprojects and
+# get pip-installed by the carrier from their sub-package dirs — `kernel_agents`
+# is only packaged by the KernelForge *root* pyproject and was never installed
+# here. So forge-loop relied entirely on $FORGE_PATH being present and prepended to
+# the child PYTHONPATH by _ensure_forge_on_path() at call time. When FORGE_PATH is
+# unset (as in the 2026-07-28 CI runs) `python -m kernel_agents.cli` dies with
+# `ModuleNotFoundError: No module named 'kernel_agents'` and every forge kernel
+# attempt REVERTs. Installing kernel_agents from the KernelForge root makes the
+# import succeed regardless of FORGE_PATH (root install also covers the two
+# sub-packages, so the carrier's later import checks short-circuit).
+_kernel_forge_root() {
+  # KernelForge repo root that actually contains kernel_agents. Keyed on
+  # FORGE_PATH only (CI guarantees it is exported; it is also the repo-canonical
+  # var that forge_submit reads at runtime and local_setup.sh exports).
+  local c="${FORGE_PATH:-}"
+  [ -n "$c" ] || return 1
+  if [ -f "${c%/}/pyproject.toml" ] && [ -f "${c%/}/src/kernel_agents/__init__.py" ]; then
+    printf '%s\n' "${c%/}"
+    return 0
+  fi
+  return 1
+}
+
+ensure_kernel_agents() {
+  # Gate on checkout availability, NOT on KERNEL_OPT_BACKEND_ORDER (mirrors
+  # ensure_forge_gemm_tune). install.sh frequently runs at setup time under the
+  # default geak backend, so a backend gate here would skip the install; a later
+  # forge session whose child has no FORGE_PATH would then still hit
+  # ModuleNotFoundError. Keying on the KernelForge checkout instead covers the
+  # "checkout present at install time, FORGE_PATH absent at runtime" case.
+  local root
+  if ! root="$(_kernel_forge_root)"; then
+    log "kernel_agents: FORGE_PATH not set / no KernelForge checkout there; skipping optional forge-loop install"
+    return 0
+  fi
+  if "$PYTHON" -c "import kernel_agents.cli" >/dev/null 2>&1; then
+    log "kernel_agents already importable; skipping install"
+    return 0
+  fi
+  if [ "$CHECK_ONLY" -eq 1 ]; then
+    warn "kernel_agents not importable (check-only; would install from ${root})"
+    return 0
+  fi
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "would run: ${PYTHON} -m pip install ${root}"
+    return 0
+  fi
+  log "ensuring kernel_agents from ${root} (forge-loop backend)"
+  # Deliberately NON-editable (no -e): ${root} is a shared, often read-only
+  # KernelForge checkout used by concurrent sessions. A non-editable install
+  # builds in a temp dir and never writes egg-info/build artifacts back into the
+  # checkout, so parallel runs can't race on it — this mirrors the carrier's
+  # own forge_fusion/forge_gemm_tune install (see _incontainer.sh: "Non-editable
+  # installs build in a temp dir and never write to the read-only shared
+  # checkout"). Installing the root also provides forge_gemm_tune + forge_fusion,
+  # so the carrier's later `import forge_fusion` guard short-circuits (verified:
+  # it logs "forge kernel backend ready" with no reinstall).
+  "$PYTHON" -m pip install --quiet "${PIP_EXTRA[@]}" "${root}"
+  "$PYTHON" -c "import kernel_agents, kernel_agents.cli" \
+    && log "kernel_agents installed OK from ${root}" \
+    || die "kernel_agents import failed after install from ${root}"
+}
+
 # --- 2. Magpie ---
 # The install state is the pip-installed package specified by
 # $MAGPIE_PACKAGE_SPEC. $MAGPIE_PATH remains exported for runtime code that
@@ -1122,6 +1187,7 @@ chain_kernel_agent() {
 
 ensure_inference_optimizer
 ensure_forge_gemm_tune
+ensure_kernel_agents
 ensure_langfuse_when_enabled
 # Hold the install lock for the whole mirror-mutating region (Magpie /
 # InferenceX clones + the chained kernel-agent GEAK/TraceLens clones).

--- a/src/hyperloom/inference_optimizer/assets/install.sh
+++ b/src/hyperloom/inference_optimizer/assets/install.sh
@@ -658,12 +658,10 @@ PY
 
 # --- 1b. forge-gemm-tune (KernelForge deterministic GEMM tuning CLI) ---
 _forge_gemm_tune_candidates() {
-  # Explicit override first.
+  # Explicit gemm-tune override first.
   [ -n "${FORGE_GEMM_TUNE_ROOT:-}" ] && printf '%s\n' "$FORGE_GEMM_TUNE_ROOT"
-  # KernelForge root aliases used by Hyperloom's forge backend.
+  # KernelForge root (single canonical var: FORGE_PATH).
   [ -n "${FORGE_PATH:-}" ] && printf '%s\n' "${FORGE_PATH%/}/src/forge_gemm_tune" "${FORGE_PATH%/}/forge_gemm_tune"
-  [ -n "${KERNEL_FORGE_ROOT:-}" ] && printf '%s\n' "${KERNEL_FORGE_ROOT%/}/src/forge_gemm_tune" "${KERNEL_FORGE_ROOT%/}/forge_gemm_tune"
-  [ -n "${KERNEL_FORGE_PATH:-}" ] && printf '%s\n' "${KERNEL_FORGE_PATH%/}/src/forge_gemm_tune" "${KERNEL_FORGE_PATH%/}/forge_gemm_tune"
 }
 
 _resolve_forge_gemm_tune_root() {

--- a/src/hyperloom/inference_optimizer/assets/local_setup.sh
+++ b/src/hyperloom/inference_optimizer/assets/local_setup.sh
@@ -56,7 +56,7 @@ Options:
 
 Advanced env overrides:
   REPO_ROOT, USER_DATA_PATH, HYPERLOOM_DEPS_ROOT, LOCAL_SETUP_ENV,
-  FORGE_PATH, KERNEL_FORGE_ROOT, KERNEL_FORGE_PATH, KERNEL_FORGE_REPO
+  FORGE_PATH, KERNEL_FORGE_REPO
 EOF
 }
 
@@ -165,8 +165,7 @@ clone_or_update() {
 resolve_forge() {
   if [ -n "${FORGE_PATH:-}" ]; then
     [ -d "$FORGE_PATH" ] || die "FORGE_PATH is set but does not exist: ${FORGE_PATH}"
-    KERNEL_FORGE_ROOT="${KERNEL_FORGE_ROOT:-$FORGE_PATH}"
-    export FORGE_PATH KERNEL_FORGE_ROOT
+    export FORGE_PATH
     log "FORGE_PATH: using existing ${FORGE_PATH}"
     return 0
   fi
@@ -179,8 +178,7 @@ resolve_forge() {
   local root="${_open_source_root}/KernelForge"
   if clone_or_update "KernelForge" "$KERNEL_FORGE_REPO" "$root" ""; then
     FORGE_PATH="${FORGE_PATH:-$root}"
-    KERNEL_FORGE_ROOT="${KERNEL_FORGE_ROOT:-$FORGE_PATH}"
-    export FORGE_PATH KERNEL_FORGE_ROOT
+    export FORGE_PATH
     log "FORGE_PATH: ${FORGE_PATH}"
   else
     warn "KernelForge checkout unavailable (${KERNEL_FORGE_REPO}); skipping forge backend setup."
@@ -210,7 +208,6 @@ write_local_env() {
     write_export HYPERLOOM_CACHE_DIR "$_open_source_root"
     if [ -n "${FORGE_PATH:-}" ]; then
       write_export FORGE_PATH "$FORGE_PATH"
-      write_export KERNEL_FORGE_ROOT "$KERNEL_FORGE_ROOT"
     fi
   } > "$LOCAL_SETUP_ENV"
   chmod 600 "$LOCAL_SETUP_ENV"

--- a/src/hyperloom/inference_optimizer/tests/test_install_kernel_agents_idempotent.py
+++ b/src/hyperloom/inference_optimizer/tests/test_install_kernel_agents_idempotent.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Behavioural + static guards for ``ensure_kernel_agents()``.
+
+kernel_agents (the KernelForge forge-loop CLI, invoked as ``python -m
+kernel_agents.cli``) is installed from the KernelForge repo *root* resolved via
+``$FORGE_PATH``. The installer should:
+
+  * pip-install the root when FORGE_PATH points at a checkout that contains
+    kernel_agents and it is not yet importable,
+  * skip pip when ``import kernel_agents.cli`` already works (idempotent),
+  * fail-soft (log + return 0, no pip, no error) when FORGE_PATH is unset or its
+    checkout does not contain kernel_agents.
+
+Regression cover for the 2026-07-28 bug where kernel_agents was never installed
+in the container and every forge-loop attempt died with
+``ModuleNotFoundError: No module named 'kernel_agents'``.
+"""
+
+from __future__ import annotations
+
+import re
+import stat
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+IO_INSTALL = REPO_ROOT / "src" / "hyperloom" / "inference_optimizer" / "assets" / "install.sh"
+
+PIP_MARKER = "pip-install-called"
+
+
+def _extract_fn(name: str) -> str:
+    text = IO_INSTALL.read_text(encoding="utf-8")
+    m = re.search(rf"^{name}\(\) \{{.*?^\}}", text, re.S | re.M)
+    assert m, f"could not locate {name}() in install.sh"
+    return m.group(0)
+
+
+def _fake_python(tmp_path: Path, *, import_ok: bool) -> Path:
+    """Stub ``$PYTHON``.
+
+    * ``-m pip install ...``: touches PIP_MARKER, exits 0.
+    * ``-c 'import ...'``: exits per ``import_ok``; once pip has run (marker
+      present) it always succeeds, so the post-install verify passes.
+    """
+    marker = tmp_path / PIP_MARKER
+    import_check = "exit 0" if import_ok else f'[ -f "{marker}" ] && exit 0 || exit 1'
+    body = f"""#!/usr/bin/env bash
+if [ "$1" = "-m" ] && [ "$2" = "pip" ]; then
+  touch "{marker}"
+  exit 0
+fi
+if [ "$1" = "-c" ]; then
+  {import_check}
+fi
+exit 0
+"""
+    py = tmp_path / "fake_python.sh"
+    py.write_text(body, encoding="utf-8")
+    py.chmod(py.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return py
+
+
+def _make_checkout(tmp_path: Path, *, with_kernel_agents: bool) -> Path:
+    """A fake KernelForge checkout root that _kernel_forge_root() probes for."""
+    root = tmp_path / "KernelForge"
+    root.mkdir(parents=True)
+    (root / "pyproject.toml").write_text("[project]\nname = 'kernel-agents'\n", encoding="utf-8")
+    if with_kernel_agents:
+        ka = root / "src" / "kernel_agents"
+        ka.mkdir(parents=True)
+        (ka / "__init__.py").write_text("", encoding="utf-8")
+    return root
+
+
+def _run(tmp_path: Path, *, forge_path: str | None, import_ok: bool) -> tuple[str, int, bool]:
+    """Run the extracted _kernel_forge_root + ensure_kernel_agents body.
+
+    Returns (stdout, returncode, pip_called).
+    """
+    fake_py = _fake_python(tmp_path, import_ok=import_ok)
+    forge_line = (
+        f'export FORGE_PATH="{forge_path}"' if forge_path is not None else "unset FORGE_PATH || true"
+    )
+    harness = f"""#!/usr/bin/env bash
+set -euo pipefail
+log() {{ echo "[log] $*"; }}
+warn() {{ echo "[warn] $*"; }}
+die() {{ echo "[die] $*"; exit 1; }}
+CHECK_ONLY=0
+DRY_RUN=0
+PYTHON="{fake_py}"
+PIP_EXTRA=()
+{forge_line}
+
+{_extract_fn("_kernel_forge_root")}
+
+{_extract_fn("ensure_kernel_agents")}
+
+ensure_kernel_agents
+"""
+    script = tmp_path / "harness.sh"
+    script.write_text(harness, encoding="utf-8")
+    proc = subprocess.run(
+        ["bash", str(script)],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    pip_called = (tmp_path / PIP_MARKER).exists()
+    return proc.stdout, proc.returncode, pip_called
+
+
+def test_installs_when_forge_path_valid_and_not_importable(tmp_path: Path) -> None:
+    root = _make_checkout(tmp_path, with_kernel_agents=True)
+    out, rc, pip_called = _run(tmp_path, forge_path=str(root), import_ok=False)
+    assert rc == 0, out
+    assert pip_called, f"pip install should have run:\n{out}"
+    assert "ensuring kernel_agents from" in out
+    assert "kernel_agents installed OK from" in out
+
+
+def test_skip_reinstall_when_already_importable(tmp_path: Path) -> None:
+    root = _make_checkout(tmp_path, with_kernel_agents=True)
+    out, rc, pip_called = _run(tmp_path, forge_path=str(root), import_ok=True)
+    assert rc == 0, out
+    assert not pip_called, f"reinstall should have been skipped:\n{out}"
+    assert "kernel_agents already importable; skipping install" in out
+
+
+def test_fail_soft_when_forge_path_unset(tmp_path: Path) -> None:
+    out, rc, pip_called = _run(tmp_path, forge_path=None, import_ok=False)
+    assert rc == 0, f"unset FORGE_PATH must be fail-soft (rc 0):\n{out}"
+    assert not pip_called, f"no pip when FORGE_PATH unset:\n{out}"
+    assert "FORGE_PATH not set" in out
+
+
+def test_fail_soft_when_checkout_lacks_kernel_agents(tmp_path: Path) -> None:
+    root = _make_checkout(tmp_path, with_kernel_agents=False)
+    out, rc, pip_called = _run(tmp_path, forge_path=str(root), import_ok=False)
+    assert rc == 0, out
+    assert not pip_called, f"no pip when checkout has no kernel_agents:\n{out}"
+    assert "skipping optional forge-loop install" in out
+
+
+# --- Static guards: keep the fix wired in ---------------------------------
+
+
+def test_static_kernel_forge_root_keys_on_forge_path_only() -> None:
+    body = _extract_fn("_kernel_forge_root")
+    assert "FORGE_PATH" in body
+    # The consolidated resolution must not reintroduce the dropped aliases.
+    assert "KERNEL_FORGE_ROOT" not in body
+    assert "KERNEL_FORGE_PATH" not in body
+
+
+def test_static_ensure_kernel_agents_install_and_verify_wired() -> None:
+    body = _extract_fn("ensure_kernel_agents")
+    assert "pip install" in body, "install path must exist for the miss case"
+    assert "kernel_agents installed OK" in body
+    assert "already importable" in body, "idempotent skip must stay wired"
+    assert "die " in body, "post-install import must be verified (die on failure)"

--- a/src/hyperloom/orchestrator/actions/executors/_server_patcher.py
+++ b/src/hyperloom/orchestrator/actions/executors/_server_patcher.py
@@ -309,8 +309,7 @@ def ensure_sglang_patched_for_ck_blockscale(
 
     Args:
         kernelforge_root: KernelForge checkout root; falls back to
-            ``$FORGE_PATH`` / ``$KERNEL_FORGE_ROOT`` / ``$KERNEL_FORGE_PATH``
-            (in that order) when ``None``.
+            ``$FORGE_PATH`` when ``None``.
 
     Returns:
         True if the SGLang install carries the CK-routing patch at exit, False
@@ -718,12 +717,8 @@ def _resolve_sglang_apply_root(sglang_module: Path) -> tuple[Path, int] | None:
     return None
 
 
-# KernelForge root env aliases, in install.sh's precedence order.
-_KERNELFORGE_ROOT_ENV_VARS: tuple[str, ...] = (
-    "FORGE_PATH",
-    "KERNEL_FORGE_ROOT",
-    "KERNEL_FORGE_PATH",
-)
+# KernelForge root env var (single canonical var; CI/local both export it).
+_KERNELFORGE_ROOT_ENV_VARS: tuple[str, ...] = ("FORGE_PATH",)
 
 # CK fp8 block-scale routing markers added to ``fp8_utils.py`` by the
 # KernelForge-owned patch; all three must be present to count as patched.
@@ -737,9 +732,8 @@ _SGLANG_CK_BLOCKSCALE_SENTINELS: tuple[str, ...] = (
 def _resolve_kernelforge_root(arg: Path | str | None) -> Path | None:
     """Resolve the KernelForge root from arg → env aliases → None; fail-soft.
 
-    Mirrors the env precedence in ``install.sh``
-    (``FORGE_PATH`` > ``KERNEL_FORGE_ROOT`` > ``KERNEL_FORGE_PATH``); returns
-    the first candidate that exists on disk, else ``None``.
+    Reads ``FORGE_PATH`` (the single canonical KernelForge root var); returns
+    it when it exists on disk, else ``None``.
 
     Args:
         arg: Explicit KernelForge root override, or ``None`` to read the env
@@ -782,7 +776,7 @@ def _discover_sglang_ck_plan(arg: Path | str | None) -> _PatchPlan | None:
     if kernelforge_root is None:
         log.info(
             "_server_patcher: KernelForge root unset/missing "
-            "(FORGE_PATH/KERNEL_FORGE_ROOT/KERNEL_FORGE_PATH) — skip SGLang "
+            "(FORGE_PATH) — skip SGLang "
             "fp8 block-scale CK patch (SGLANG_FP8_BLOCKSCALE_CK_MAX_M will "
             "no-op on the unpatched tree)"
         )


### PR DESCRIPTION
… without FORGE_PATH

forge-loop shells out to `python -m kernel_agents.cli`, but kernel_agents was never installed in the container: install.sh only wired forge_gemm_tune, and the carrier's forge block only pip-installs forge_fusion + forge_gemm_tune (both have standalone sub-pyprojects). kernel_agents is packaged only by the KernelForge root pyproject, so it relied entirely on FORGE_PATH being injected + prepended to the child PYTHONPATH at call time. When FORGE_PATH was unset (2026-07-28 CI runs), `python -m kernel_agents.cli` failed with ModuleNotFoundError and every forge kernel attempt REVERTed (KERNEL phase produced nothing).

Add ensure_kernel_agents(): when KERNEL_OPT_BACKEND_ORDER=forge, pip install the KernelForge root (resolved from HL_FORGE_SRC/FORGE_PATH/KERNEL_FORGE_ROOT), which bundles kernel_agents + forge_gemm_tune + forge_fusion. forge-loop now imports regardless of whether FORGE_PATH is set.

- Description: what and why
- Linked issue(s): close/fix refs
- Tests: added/updated? commands run?
- Breaking changes: yes/no (details if yes)
