### PR TITLE
fix(ci): pin E2E workloads to the PR commit

### DIFF
--- a/.github/scripts/ci-e2e-dispatch.sh
+++ b/.github/scripts/ci-e2e-dispatch.sh
@@ -50,6 +50,10 @@ POLL_MAX="${POLL_MAX:-120}"
 : "${E2E_INFRA_TYPE:?E2E_INFRA_TYPE is required}"
 : "${HEAD_REF:?HEAD_REF (PR head branch) is required}"
 : "${HEAD_SHA:?HEAD_SHA (immutable PR head commit) is required}"
+if [ "$E2E_INFRA_TYPE" != "kubernetes" ]; then
+  echo "CI E2E supports only E2E_INFRA_TYPE=kubernetes; source-SHA pinning is not implemented for '$E2E_INFRA_TYPE'" >&2
+  exit 2
+fi
 API="${E2E_API_BASE%/}/api/v1/orchestration/workloads"
 
 # Fork PRs: the head branch lives in the contributor's fork, so clone from the head
@@ -60,8 +64,9 @@ if [ -n "${HEAD_REPO_URL:-}" ] && [ "${HEAD_REPO_URL}" != "${BASE_REPO_URL:-}" ]
 fi
 # The exact commit is part of the source path. Do not reuse a branch-only checkout:
 # a later push must never make this CI run test a different commit from the one its
-# GitHub status is attached to. CI_E2E_SOURCE_DIR remains an explicit escape hatch
-# for operator-managed debugging checkouts.
+# GitHub status is attached to. The default is Kubernetes Job-local /tmp, which is
+# discarded when the Job ends. CI_E2E_SOURCE_DIR is an explicit persistent override;
+# its owner is responsible for retention and cleanup.
 PR_CHECK_BASE="${CI_E2E_PR_CHECK_BASE:-/tmp/ci-e2e}"
 SRC_DIR="${CI_E2E_SOURCE_DIR:-${PR_CHECK_BASE%/}/pr_${PR_NUMBER:-manual}/${HEAD_SHA}/hyperloom}"
 
@@ -152,6 +157,7 @@ report_upsert() { # result_md (e.g. "✅ Succeeded")
 | model | \`${MODEL}\` (${MODEL_CLASS:-dense}) |
 | resources | ${GPUS}× GPU, TP=${TP} |
 | PR branch | \`${HEAD_REF}\` |
+| commit | \`${HEAD_SHA}\` |
 | session_id | \`${UID_}\` |
 | queue → dispatch | ${qd:-–} |
 | run time | ${rt:-–} |
@@ -185,7 +191,7 @@ params="$(jq -n \
    + (if $mc == "" then {} else {MODEL_CLASS:$mc} end)
    + (if $mbase == "" then {} else {HL_MODEL_BASE:$mbase} end)')"
 body="$(jq -n \
-  --arg name "github-e2e-ci-pr-${PR_NUMBER:-manual}-${GITHUB_RUN_ID:-local}" \
+  --arg name "ci-pr-${PR_NUMBER:-manual}-${GITHUB_RUN_ID:-local}" \
   --arg uname "${CI_E2E_USER_NAME:-}" --arg itype "$E2E_INFRA_TYPE" \
   --argjson gpus "$GPUS" --argjson params "$params" \
   '{name:$name, infra_type:$itype, kind:"hyperloom", replicas:1,
@@ -214,13 +220,13 @@ echo "session_id=$UID_" >> "${GITHUB_OUTPUT:-/dev/null}"
 echo "$UID_" > "${E2E_UID_FILE:-${RUNNER_TEMP:-/tmp}/e2e_session_uid}" 2>/dev/null || true
 
 # Seed the live commit status (no-op unless GH_STATUS_* are set).
-post_status "pending" "submitted; uid=${UID_}; model=${MODEL} ref=${HEAD_REF}"
+post_status "pending" "submitted; uid=${UID_}; model=${MODEL}; ref=${HEAD_REF}; sha=${HEAD_SHA:0:12}"
 last_push="$(date +%s)"
 
 # On cancellation (e.g. a newer commit via concurrency cancel-in-progress),
 # best-effort cancel the workload so we don't leak a GPU run.
 cleanup() { curl -sS "${tls[@]}" -X DELETE "$API/$UID_" "${auth[@]}" >/dev/null 2>&1 || true; }
-trap 'echo "[ci-e2e] cancelled; deleting workload $UID_"; post_status "error" "cancelled (newer commit or manual stop); uid=${UID_}"; cleanup; exit 1' INT TERM
+trap 'echo "[ci-e2e] cancelled; deleting workload $UID_"; post_status "error" "cancelled; uid=${UID_}; sha=${HEAD_SHA:0:12}"; cleanup; exit 1' INT TERM
 
 # ---- poll -----------------------------------------------------------------
 i=0
@@ -241,21 +247,21 @@ while [ "$i" -lt "$POLL_MAX" ]; do
   case "$phase" in
     Succeeded)
       summary "✅ **PASS** — run completed. session_id=\`$UID_\` job=\`$jobref\`"
-      post_status "success" "PASS — Succeeded; uid=${UID_}; job=${jobref}"
+      post_status "success" "PASS — uid=${UID_}; job=${jobref}; sha=${HEAD_SHA:0:12}"
       report_upsert "✅ Succeeded"
       exit 0 ;;
     Failed)
       err="$(printf '%s' "$detail" | jq -r '.orchestration.last_error // (.orchestration.conditions[-1].message) // "unknown"' 2>/dev/null)"
       summary "❌ **FAIL** — session_id=\`$UID_\` job=\`$jobref\` node=\`$node\`"
       summary "reason: $err"
-      post_status "failure" "$(humanize_reason "$err")"
+      post_status "failure" "FAIL (${HEAD_SHA:0:12}): $(humanize_reason "$err")"
       report_upsert "❌ Failed"
       exit 1 ;;
   esac
   # Throttled live status: push at most once per STATUS_INTERVAL_S (default 5min).
   now_s="$(date +%s)"
   if [ $((now_s - last_push)) -ge "$STATUS_INTERVAL_S" ]; then
-    post_status "pending" "running phase=${phase} (poll ${i}/${POLL_MAX}); job=${jobref}; uid=${UID_}"
+    post_status "pending" "running ${phase}; job=${jobref}; uid=${UID_}; sha=${HEAD_SHA:0:12}"
     last_push="$now_s"
   fi
   sleep "$POLL_INTERVAL_S"
@@ -263,7 +269,7 @@ done
 
 err="not terminal after $((POLL_MAX * POLL_INTERVAL_S))s"
 summary "❌ **FAIL (timeout)** — ${err}. session_id=\`$UID_\`"
-post_status "failure" "FAIL (timeout) after $((POLL_MAX * POLL_INTERVAL_S))s; uid=${UID_}"
+post_status "failure" "timeout; uid=${UID_}; sha=${HEAD_SHA:0:12}"
 report_upsert "❌ Timeout"
 cleanup
 exit 1

--- a/.github/scripts/ci-e2e-dispatch.sh
+++ b/.github/scripts/ci-e2e-dispatch.sh
@@ -176,14 +176,16 @@ ${actions}"
 params="$(jq -n \
   --arg repo_id "$MODEL" --arg tp "$TP" --arg mh "$MAX_HOURS" \
   --arg ref "$HEAD_REF" --arg sha "$HEAD_SHA" --arg srcrepo "$SRC_REPO" --arg srcdir "$SRC_DIR" \
+  --arg task_source "github-e2e-ci" --arg pr_number "${PR_NUMBER:-}" \
   --arg mc "$MODEL_CLASS" --arg mbase "${MODEL_BASE:-}" \
   '{REPO_ID:$repo_id, TP:$tp, MAX_HOURS:$mh,
     HYPERLOOM_SOURCE_REF:$ref, HYPERLOOM_SOURCE_SHA:$sha,
-    HYPERLOOM_SOURCE_REPO:$srcrepo, HYPERLOOM_SOURCE_DIR:$srcdir}
+    HYPERLOOM_SOURCE_REPO:$srcrepo, HYPERLOOM_SOURCE_DIR:$srcdir,
+    HYPERLOOM_TASK_SOURCE:$task_source, HYPERLOOM_SOURCE_PR:$pr_number}
    + (if $mc == "" then {} else {MODEL_CLASS:$mc} end)
    + (if $mbase == "" then {} else {HL_MODEL_BASE:$mbase} end)')"
 body="$(jq -n \
-  --arg name "ci-pr-${PR_NUMBER:-manual}-${GITHUB_RUN_ID:-local}" \
+  --arg name "github-e2e-ci-pr-${PR_NUMBER:-manual}-${GITHUB_RUN_ID:-local}" \
   --arg uname "${CI_E2E_USER_NAME:-}" --arg itype "$E2E_INFRA_TYPE" \
   --argjson gpus "$GPUS" --argjson params "$params" \
   '{name:$name, infra_type:$itype, kind:"hyperloom", replicas:1,

--- a/.github/scripts/ci-e2e-dispatch.sh
+++ b/.github/scripts/ci-e2e-dispatch.sh
@@ -17,6 +17,7 @@
 #   MAX_HOURS         optimizer time budget (hours)    (default 0.5)
 #   PR_NUMBER         PR number (for the job name)
 #   HEAD_REF          PR head branch name (the code to run)
+#   HEAD_SHA          immutable PR head commit SHA (the exact code to run)
 #   HEAD_REPO_URL     PR head repo clone url (for forks)
 #   BASE_REPO_URL     base repo clone url
 #   MODEL_BASE        local model base dir (optional; backend fills if empty)
@@ -48,6 +49,7 @@ POLL_MAX="${POLL_MAX:-120}"
 : "${E2E_API_KEY:?E2E_API_KEY is required}"
 : "${E2E_INFRA_TYPE:?E2E_INFRA_TYPE is required}"
 : "${HEAD_REF:?HEAD_REF (PR head branch) is required}"
+: "${HEAD_SHA:?HEAD_SHA (immutable PR head commit) is required}"
 API="${E2E_API_BASE%/}/api/v1/orchestration/workloads"
 
 # Fork PRs: the head branch lives in the contributor's fork, so clone from the head
@@ -56,12 +58,12 @@ SRC_REPO="${BASE_REPO_URL:-}"
 if [ -n "${HEAD_REPO_URL:-}" ] && [ "${HEAD_REPO_URL}" != "${BASE_REPO_URL:-}" ]; then
   SRC_REPO="${HEAD_REPO_URL}"
 fi
-# Where the launcher puts this PR's source: a stable, inspectable per-PR path under a
-# shared base (<base>/pr_<N>/hyperloom). Override the base with CI_E2E_PR_CHECK_BASE,
-# or point CI_E2E_SOURCE_DIR at an existing checkout to skip cloning. Re-triggered runs
-# pick up new commits because the launcher refreshes this checkout when HL_CI_E2E=1.
+# The exact commit is part of the source path. Do not reuse a branch-only checkout:
+# a later push must never make this CI run test a different commit from the one its
+# GitHub status is attached to. CI_E2E_SOURCE_DIR remains an explicit escape hatch
+# for operator-managed debugging checkouts.
 PR_CHECK_BASE="${CI_E2E_PR_CHECK_BASE:-/tmp/ci-e2e}"
-SRC_DIR="${CI_E2E_SOURCE_DIR:-${PR_CHECK_BASE%/}/pr_${PR_NUMBER:-manual}/hyperloom}"
+SRC_DIR="${CI_E2E_SOURCE_DIR:-${PR_CHECK_BASE%/}/pr_${PR_NUMBER:-manual}/${HEAD_SHA}/hyperloom}"
 
 summary() { echo "$*" | tee -a "${GITHUB_STEP_SUMMARY:-/dev/null}"; }
 auth=(-H "Authorization: Bearer ${E2E_API_KEY}")
@@ -173,10 +175,11 @@ ${actions}"
 # ---- submit ---------------------------------------------------------------
 params="$(jq -n \
   --arg repo_id "$MODEL" --arg tp "$TP" --arg mh "$MAX_HOURS" \
-  --arg ref "$HEAD_REF" --arg srcrepo "$SRC_REPO" --arg srcdir "$SRC_DIR" \
+  --arg ref "$HEAD_REF" --arg sha "$HEAD_SHA" --arg srcrepo "$SRC_REPO" --arg srcdir "$SRC_DIR" \
   --arg mc "$MODEL_CLASS" --arg mbase "${MODEL_BASE:-}" \
   '{REPO_ID:$repo_id, TP:$tp, MAX_HOURS:$mh,
-    HYPERLOOM_SOURCE_REF:$ref, HYPERLOOM_SOURCE_REPO:$srcrepo, HYPERLOOM_SOURCE_DIR:$srcdir}
+    HYPERLOOM_SOURCE_REF:$ref, HYPERLOOM_SOURCE_SHA:$sha,
+    HYPERLOOM_SOURCE_REPO:$srcrepo, HYPERLOOM_SOURCE_DIR:$srcdir}
    + (if $mc == "" then {} else {MODEL_CLASS:$mc} end)
    + (if $mbase == "" then {} else {HL_MODEL_BASE:$mbase} end)')"
 body="$(jq -n \
@@ -187,7 +190,7 @@ body="$(jq -n \
     gpu_per_replica:$gpus, template:{params:$params, env:{HL_CI_E2E:"1"}}}
    + (if $uname == "" then {} else {user_name:$uname} end)')"
 
-echo "[ci-e2e] submitting: model=$MODEL ref=$HEAD_REF gpus=$GPUS tp=$TP max_hours=$MAX_HOURS"
+echo "[ci-e2e] submitting: model=$MODEL ref=$HEAD_REF sha=$HEAD_SHA gpus=$GPUS tp=$TP max_hours=$MAX_HOURS"
 resp="$(curl -sS "${tls[@]}" -w $'\n%{http_code}' -X POST "$API" \
   "${auth[@]}" -H "Content-Type: application/json" -d "$body")"
 code="$(printf '%s' "$resp" | tail -n1)"

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -144,6 +144,10 @@ jobs:
               run=true
               ;;
           esac
+          if [ "$run" = true ] && [ -z "$head_sha" ]; then
+            echo "failed to resolve head_sha for ref=$head_ref" >&2
+            exit 1
+          fi
           echo "decision: run=$run pr=$pr_number ref=$head_ref sha=$head_sha repo=$head_repo"
           emit
 

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -25,6 +25,9 @@ on:
       head_ref:
         description: "Branch to run (defaults to the caller ref)"
         required: false
+      head_sha:
+        description: "Exact commit SHA to run (defaults to the resolved head_ref)"
+        required: false
 
 # A newer commit / retest on the same PR cancels the in-flight run; the cleanup step
 # below cancels the workload so no GPU is leaked.
@@ -82,6 +85,7 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           IS_PR_COMMENT: ${{ github.event.issue.pull_request != null }}
           DISPATCH_HEAD_REF: ${{ inputs.head_ref }}
+          DISPATCH_HEAD_SHA: ${{ inputs.head_sha }}
           REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
@@ -99,6 +103,14 @@ jobs:
             workflow_dispatch)
               run=true
               head_ref="${DISPATCH_HEAD_REF:-$REF_NAME}"
+              head_sha="${DISPATCH_HEAD_SHA:-}"
+              if [ -z "$head_sha" ]; then
+                ref_uri="$(printf '%s' "$head_ref" | jq -sRr @uri)"
+                commit_json="$(curl -sS -H "Authorization: Bearer $GH_TOKEN" \
+                  -H "Accept: application/vnd.github+json" \
+                  "$API_URL/repos/$REPO/commits/$ref_uri")"
+                head_sha="$(printf '%s' "$commit_json" | jq -r '.sha // ""')"
+              fi
               ;;
             pull_request)
               if echo "$PR_LABELS_JSON" | jq -e 'index("skip-e2e-test")' >/dev/null 2>&1; then
@@ -180,6 +192,7 @@ jobs:
           CI_E2E_INSECURE: ${{ secrets.CI_E2E_INSECURE || '1' }}
           PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
           HEAD_REF: ${{ needs.resolve.outputs.head_ref }}
+          HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
           # Tokenized clone URLs so the run can clone this PR branch. github.token is
           # ephemeral (expires with the run) and can read same-repo PRs.
           HEAD_REPO_URL: ${{ needs.resolve.outputs.head_repo && format('https://x-access-token:{0}@github.com/{1}.git', github.token, needs.resolve.outputs.head_repo) || '' }}


### PR DESCRIPTION
## Summary
- pass each CI E2E run's resolved PR commit SHA to the Hyperloom workload
- namespace CI source directories by commit and keep the branch only for audit output
- resolve an explicit commit for manual workflow dispatches

## Test plan
- [x] Normalized `bash -n .github/scripts/ci-e2e-dispatch.sh`
- [ ] Run an E2E workload against the paired template update