### PR TITLE
test(ci): verify immutable E2E source SHA

### DIFF
--- a/.github/ci-e2e-sha-pin-probe.md
+++ b/.github/ci-e2e-sha-pin-probe.md
@@ -1,0 +1,6 @@
+# CI E2E SHA pin probe
+
+This temporary pull request verifies that the Kubernetes E2E workload checks
+out the exact PR commit whose GitHub status it reports.
+
+Probe revision: A


### PR DESCRIPTION
## Purpose
Temporary end-to-end verification of CI source pinning.

Commit A opens this PR and triggers the E2E workload. After its workload is created, commit B will be pushed to this branch. The running workload must retain commit A in its Kubernetes labels and checkout provenance.

Do not merge this PR.