### PR TITLE
fix(bypass): honest CUDA-graph handling in the TraceLens-free trace analysis

### DIFF
--- a/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
@@ -265,6 +265,52 @@ def test_cudagraph_replay_signal_without_recorded_kernels(tmp_path, capsys, monk
     codes = {w["code"] for w in result["trace_health_warnings"]}
     assert "bypass_no_gpu_kernels" in codes
     assert "bypass_cudagraph_replay" in codes
+    # honest degradation: attribution is unreliable (replay kernels carry no link)
+    assert result["attribution_reliable"] is False
+    assert result["data_reliability_reason"] == "cudagraph_incomplete_trace"
+
+
+def test_cudagraph_idle_marked_unreliable_and_degraded(tmp_path, capsys, monkeypatch):
+    # Honest degradation (no reconstruction): on an incomplete CUDA-graph trace
+    # the idle metric is flagged unreliable and propagated through
+    # result / timeline / manifest, and the analysis.md renders the idle cell as
+    # an em-dash (not a bogus number) plus a DATA RELIABILITY note.
+    monkeypatch.delenv("HYPERLOOM_BYPASS_STEADY_STATE", raising=False)
+    monkeypatch.delenv("HYPERLOOM_TRACELENS_IDLE_PCT_THRESHOLD", raising=False)
+    trace = tmp_path / "cudagraph.trace.json"
+    trace.write_bytes(json.dumps({"traceEvents": _CUDAGRAPH_HIGH_IDLE_TRACE_EVENTS}).encode("utf-8"))
+    rc, result, _ = _run(_base_argv(tmp_path, str(trace)), capsys)
+    assert rc == 0
+    assert result["idle_reliable"] is False
+    # recorded kernels here are linked, so attribution stays reliable
+    assert result["attribution_reliable"] is True
+    assert result["data_reliability_reason"] == "cudagraph_incomplete_trace"
+    assert result["timeline"]["idle_reliable"] is False
+    manifest = json.loads(Path(result["artifact_paths"]["trace_input_manifest"]).read_text())
+    assert manifest["idle_reliable"] is False
+    assert manifest["data_reliability_reason"] == "cudagraph_incomplete_trace"
+    # analysis.md: idle cell is the em-dash placeholder, and a reliability note fires.
+    md = Path(result["artifact_paths"]["trace_report_path"]).read_text(encoding="utf-8")
+    assert "DATA RELIABILITY" in md
+    assert "| GPU Idle % | — |" in md
+    assert "| GPU Busy % | — |" in md
+
+
+def test_normal_trace_stays_reliable(tmp_path, capsys, monkeypatch):
+    # Regression lock: a non-cudagraph trace is unaffected — reliable flags True,
+    # no reliability note, and a numeric idle is still rendered.
+    monkeypatch.delenv("HYPERLOOM_BYPASS_STEADY_STATE", raising=False)
+    trace = tmp_path / "t.trace.json"
+    trace.write_bytes(json.dumps({"traceEvents": _TRACE_EVENTS}).encode("utf-8"))
+    rc, result, _ = _run(_base_argv(tmp_path, str(trace)), capsys)
+    assert rc == 0
+    assert result["idle_reliable"] is True
+    assert result["attribution_reliable"] is True
+    assert result["data_reliability_reason"] == ""
+    md = Path(result["artifact_paths"]["trace_report_path"]).read_text(encoding="utf-8")
+    assert "DATA RELIABILITY" not in md
+    idle_row = next(ln for ln in md.splitlines() if ln.startswith("| GPU Idle %"))
+    assert "%" in idle_row  # numeric percentage rendered, not the em-dash placeholder
 
 
 # ── diffusion workload roofline ──────────────────────────────────────────────

--- a/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
@@ -76,6 +76,40 @@ _CUDAGRAPH_NO_KERNEL_TRACE_EVENTS = [
     ],
 ]
 
+# CUDA-graph trace with LOW idle (kernels packed contiguously) but LOW attribution
+# (mostly unlinked replay kernels). Isolates attribution degradation from idle:
+# idle stays reliable (sub-threshold), attribution is flagged unreliable.
+_CUDAGRAPH_LOW_ATTRIB_TRACE_EVENTS = [
+    {"cat": "cpu_op", "name": "aten::mm", "args": {"External id": 100}},
+    {"cat": "cuda_runtime", "name": "hipLaunchKernel", "args": {"correlation": 0, "External id": 100}},
+    {"cat": "kernel", "ph": "X", "name": "Cijk_gemm_HHS", "ts": 0, "dur": 5, "args": {"correlation": 0}},
+    *[
+        {"cat": "cuda_runtime", "name": "cudaGraphLaunch", "args": {"correlation": 900 + k}}
+        for k in range(8)
+    ],
+    *[
+        {"cat": "kernel", "ph": "X", "name": "paged_attention_replay", "ts": 5 + j * 20, "dur": 20,
+         "args": {"correlation": 5000 + j}}
+        for j in range(20)
+    ],
+]
+
+# Healthy CUDA-graph trace: replays present but kernels are fully recorded
+# (contiguous, low idle) and fully attributed. Locks the chosen threshold
+# semantics — CUDA graph alone does NOT mark idle unreliable; only high idle does.
+_CUDAGRAPH_HEALTHY_TRACE_EVENTS = [
+    {"cat": "cpu_op", "name": "aten::mm", "args": {"External id": 100}},
+    {"cat": "cpu_op", "name": "aten::paged_attn", "args": {"External id": 200}},
+    {"cat": "cuda_runtime", "name": "hipLaunchKernel", "args": {"correlation": 0, "External id": 100}},
+    {"cat": "cuda_runtime", "name": "hipLaunchKernel", "args": {"correlation": 1, "External id": 200}},
+    *[
+        {"cat": "cuda_runtime", "name": "cudaGraphLaunch", "args": {"correlation": 900 + k}}
+        for k in range(4)
+    ],
+    {"cat": "kernel", "ph": "X", "name": "Cijk_gemm_HHS", "ts": 0, "dur": 100, "args": {"correlation": 0}},
+    {"cat": "kernel", "ph": "X", "name": "paged_attention_v1", "ts": 100, "dur": 100, "args": {"correlation": 1}},
+]
+
 
 def _run(argv, capsys):
     rc = bta.main(argv)
@@ -311,6 +345,56 @@ def test_normal_trace_stays_reliable(tmp_path, capsys, monkeypatch):
     assert "DATA RELIABILITY" not in md
     idle_row = next(ln for ln in md.splitlines() if ln.startswith("| GPU Idle %"))
     assert "%" in idle_row  # numeric percentage rendered, not the em-dash placeholder
+
+
+def test_cudagraph_attribution_degraded_but_idle_kept(tmp_path, capsys, monkeypatch):
+    # Attribution-only degradation: a cudagraph trace with low idle (kept reliable)
+    # but low attribution. The op-attribution coverage cell is NOT nulled (the low
+    # number is accurate evidence and must match the appendix); the flag + note
+    # convey unreliability, and idle stays numeric because idle is reliable.
+    monkeypatch.delenv("HYPERLOOM_BYPASS_STEADY_STATE", raising=False)
+    monkeypatch.delenv("HYPERLOOM_TRACELENS_IDLE_PCT_THRESHOLD", raising=False)
+    trace = tmp_path / "cg_lowattrib.trace.json"
+    trace.write_bytes(json.dumps({"traceEvents": _CUDAGRAPH_LOW_ATTRIB_TRACE_EVENTS}).encode("utf-8"))
+    rc, result, _ = _run(_base_argv(tmp_path, str(trace)), capsys)
+    assert rc == 0
+    assert result["idle_reliable"] is True
+    assert result["attribution_reliable"] is False
+    assert result["data_reliability_reason"] == "cudagraph_incomplete_trace"
+    # flag mirrored into the attribution sub-block (not only top-level)
+    assert result["attribution"]["attribution_reliable"] is False
+    md = Path(result["artifact_paths"]["trace_report_path"]).read_text(encoding="utf-8")
+    assert "DATA RELIABILITY" in md and "op-attribution" in md
+    # idle kept numeric (reliable); attribution coverage kept numeric (accurate),
+    # and must not contradict the appendix by showing an em-dash.
+    idle_row = next(ln for ln in md.splitlines() if ln.startswith("| GPU Idle %"))
+    assert "%" in idle_row
+    cov_row = next(ln for ln in md.splitlines() if ln.startswith("| Op-attribution Coverage"))
+    assert "%" in cov_row and "—" not in cov_row
+
+
+def test_cudagraph_healthy_low_idle_stays_reliable(tmp_path, capsys, monkeypatch):
+    # Locks the chosen threshold semantics: CUDA-graph replays are detected, but a
+    # fully-recorded low-idle trace stays fully reliable — cudagraph alone does not
+    # mark idle unreliable; only a high (>threshold) idle does.
+    monkeypatch.delenv("HYPERLOOM_BYPASS_STEADY_STATE", raising=False)
+    monkeypatch.delenv("HYPERLOOM_TRACELENS_IDLE_PCT_THRESHOLD", raising=False)
+    trace = tmp_path / "cg_healthy.trace.json"
+    trace.write_bytes(json.dumps({"traceEvents": _CUDAGRAPH_HEALTHY_TRACE_EVENTS}).encode("utf-8"))
+    rc, result, _ = _run(_base_argv(tmp_path, str(trace)), capsys)
+    assert rc == 0
+    assert result["attribution"]["graph_launch_count"] == 4  # replays detected
+    assert result["idle_reliable"] is True
+    assert result["attribution_reliable"] is True
+    assert result["data_reliability_reason"] == ""
+    codes = {w["code"] for w in result["trace_health_warnings"]}
+    assert "bypass_cudagraph_replay" in codes  # detection still surfaced
+    assert "high_gpu_idle_pct" not in codes
+    assert result["hot_kernels"], "healthy cudagraph trace keeps candidates"
+    md = Path(result["artifact_paths"]["trace_report_path"]).read_text(encoding="utf-8")
+    assert "DATA RELIABILITY" not in md
+    idle_row = next(ln for ln in md.splitlines() if ln.startswith("| GPU Idle %"))
+    assert "%" in idle_row
 
 
 # ── diffusion workload roofline ──────────────────────────────────────────────

--- a/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
@@ -299,8 +299,11 @@ def test_cudagraph_replay_signal_without_recorded_kernels(tmp_path, capsys, monk
     codes = {w["code"] for w in result["trace_health_warnings"]}
     assert "bypass_no_gpu_kernels" in codes
     assert "bypass_cudagraph_replay" in codes
-    # honest degradation: attribution is unreliable (replay kernels carry no link)
+    # honest degradation: attribution is unreliable (replay kernels carry no link),
+    # and idle is unreliable too — a degenerate empty timeline (idle=0 from zero
+    # recorded GPU time) is the most severe under-recording, not a real 0% idle.
     assert result["attribution_reliable"] is False
+    assert result["idle_reliable"] is False
     assert result["data_reliability_reason"] == "cudagraph_incomplete_trace"
 
 

--- a/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
@@ -397,6 +397,34 @@ def test_cudagraph_healthy_low_idle_stays_reliable(tmp_path, capsys, monkeypatch
     assert "%" in idle_row
 
 
+def test_capture_folder_flagged_as_not_used_for_core(tmp_path, capsys, monkeypatch):
+    # Honest degradation for #4: passing --capture-folder must not silently look
+    # like it helps. The core analysis does not consume it, so a health warning
+    # says so explicitly. A run WITHOUT the flag emits no such warning.
+    monkeypatch.delenv("HYPERLOOM_BYPASS_STEADY_STATE", raising=False)
+    monkeypatch.delenv("HYPERLOOM_TRACE_SHAPE_MANIFEST", raising=False)
+    trace = tmp_path / "t.trace.json"
+    trace.write_bytes(json.dumps({"traceEvents": _TRACE_EVENTS}).encode("utf-8"))
+    cap = tmp_path / "capture_traces"
+    cap.mkdir()
+
+    rc, result, _ = _run(_base_argv(tmp_path, str(trace), extra=["--capture-folder", str(cap)]), capsys)
+    assert rc == 0
+    warn = next(
+        (w for w in result["trace_health_warnings"] if w["code"] == "bypass_capture_folder_not_used_for_core"),
+        None,
+    )
+    assert warn is not None
+    assert warn["shape_manifest_enabled"] is False
+    assert "does not consume it" in warn["message"]
+
+    # No flag -> no warning.
+    rc2, result2, _ = _run(_base_argv(tmp_path, str(trace)), capsys)
+    assert "bypass_capture_folder_not_used_for_core" not in {
+        w["code"] for w in result2["trace_health_warnings"]
+    }
+
+
 # ── diffusion workload roofline ──────────────────────────────────────────────
 
 

--- a/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
@@ -66,6 +66,16 @@ _CUDAGRAPH_HIGH_IDLE_TRACE_EVENTS = [
     {"cat": "kernel", "ph": "X", "name": "Cijk_Alik_Bljk_HHS", "ts": 100000, "dur": 100, "args": {"correlation": 7}},
 ]
 
+# CUDA-graph replay trace with the most severe under-recording: graph launches
+# are present but NO device kernel events were recorded at all.
+_CUDAGRAPH_NO_KERNEL_TRACE_EVENTS = [
+    {"cat": "cpu_op", "name": "aten::mm", "args": {"External id": 200}},
+    *[
+        {"cat": "cuda_runtime", "name": "cudaGraphLaunch", "args": {"correlation": 900 + i}}
+        for i in range(64)
+    ],
+]
+
 
 def _run(argv, capsys):
     rc = bta.main(argv)
@@ -237,6 +247,23 @@ def test_cudagraph_replay_not_suppressed_by_idle_gate(tmp_path, capsys, monkeypa
     assert "high_gpu_idle_pct" not in codes
     assert "bypass_cudagraph_unreliable_idle" in codes
     # (C) a general cudagraph-replay health signal is surfaced.
+    assert "bypass_cudagraph_replay" in codes
+
+
+def test_cudagraph_replay_signal_without_recorded_kernels(tmp_path, capsys, monkeypatch):
+    # Graph replay is a whole-trace property: even when the profiler records the
+    # graph launches but NO device kernels (the most severe under-recording case),
+    # the general cudagraph-replay signal must still be surfaced. It must not be
+    # gated behind "kernels were recorded".
+    monkeypatch.delenv("HYPERLOOM_BYPASS_STEADY_STATE", raising=False)
+    trace = tmp_path / "cudagraph_nokernel.trace.json"
+    trace.write_bytes(json.dumps({"traceEvents": _CUDAGRAPH_NO_KERNEL_TRACE_EVENTS}).encode("utf-8"))
+    rc, result, _ = _run(_base_argv(tmp_path, str(trace)), capsys)
+    assert rc == 0
+    assert result["status"] == "ok"
+    assert result["attribution"]["graph_launch_count"] == 64
+    codes = {w["code"] for w in result["trace_health_warnings"]}
+    assert "bypass_no_gpu_kernels" in codes
     assert "bypass_cudagraph_replay" in codes
 
 

--- a/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
@@ -44,6 +44,28 @@ _HIGH_IDLE_TRACE_EVENTS = [
     {"cat": "kernel", "ph": "X", "name": "Cijk_Alik_Bljk_HHS", "ts": 100000, "dur": 100, "args": {"correlation": 7}},
 ]
 
+# CUDA-graph replay trace: the workload runs via 128 cudaGraphLaunch replays but
+# the profiler only records the device kernels of a single capture, so the union
+# of recorded kernel intervals (200us) over the full event span (~99ms) yields a
+# spurious idle_pct ~99%. A correct reader must (A) count the replays by name and
+# (B) NOT let the high-idle gate suppress candidates on this unreliable idle_pct.
+_CUDAGRAPH_HIGH_IDLE_TRACE_EVENTS = [
+    {"cat": "cpu_op", "name": "aten::paged_attn", "args": {"External id": 100}},
+    {"cat": "cpu_op", "name": "aten::mm", "args": {"External id": 200}},
+    {"cat": "cuda_runtime", "name": "hipLaunchKernel", "args": {"correlation": 5, "External id": 100}},
+    {"cat": "cuda_runtime", "name": "hipLaunchKernel", "args": {"correlation": 7, "External id": 200}},
+    # 128 graph replays: cudaGraphLaunch runtime calls carry only a correlation
+    # (no "External id"), so the reader currently discards them entirely.
+    *[
+        {"cat": "cuda_runtime", "name": "cudaGraphLaunch", "args": {"correlation": 900 + i}}
+        for i in range(128)
+    ],
+    # Only the single captured graph's kernels are recorded (1/128 of real work),
+    # separated by a large gap so the naive idle formula reads ~99%.
+    {"cat": "kernel", "ph": "X", "name": "paged_attention_v1", "ts": 1000, "dur": 100, "args": {"correlation": 5}},
+    {"cat": "kernel", "ph": "X", "name": "Cijk_Alik_Bljk_HHS", "ts": 100000, "dur": 100, "args": {"correlation": 7}},
+]
+
 
 def _run(argv, capsys):
     rc = bta.main(argv)
@@ -186,6 +208,36 @@ def test_high_idle_gate_respects_threshold_env(tmp_path, capsys, monkeypatch):
     assert rc == 0
     assert result["hot_kernels"], "gate must not fire below the configured threshold"
     assert "high_gpu_idle_pct" not in {w["code"] for w in result["trace_health_warnings"]}
+
+
+def test_cudagraph_replay_not_suppressed_by_idle_gate(tmp_path, capsys, monkeypatch):
+    # Under CUDA-graph replay the recorded device kernels are sparse, so idle_pct
+    # reads spuriously high. The bypass path must (A) count the graph replays, and
+    # (B) NOT suppress the candidate lists on this unreliable idle_pct — instead of
+    # emitting the misleading high_gpu_idle_pct "route to params" warning it emits
+    # an explicit unreliability warning and (C) a general cudagraph-replay signal.
+    monkeypatch.delenv("HYPERLOOM_BYPASS_STEADY_STATE", raising=False)
+    monkeypatch.delenv("HYPERLOOM_TRACELENS_IDLE_PCT_THRESHOLD", raising=False)
+    trace = tmp_path / "cudagraph.trace.json"
+    trace.write_bytes(json.dumps({"traceEvents": _CUDAGRAPH_HIGH_IDLE_TRACE_EVENTS}).encode("utf-8"))
+    rc, result, _ = _run(_base_argv(tmp_path, str(trace)), capsys)
+    assert rc == 0
+    assert result["status"] == "ok"
+    # The naive idle formula still reports high idle on this trace ...
+    assert result["timeline"]["idle_pct"] > 80.0
+    # (A) the reader counted the 128 cudaGraphLaunch replays.
+    assert result["attribution"]["graph_launch_count"] == 128
+    codes = {w["code"] for w in result["trace_health_warnings"]}
+    # (B) candidates are retained (idle-gate suppression skipped) ...
+    assert result["hot_kernels"], "cudagraph idle_pct must not suppress candidates"
+    kc = json.loads(Path(result["artifact_paths"]["kernel_candidates"]).read_text())
+    assert kc["hot_kernels"], "kernel_candidates.json must not be suppressed under cudagraph"
+    # ... and the misleading route-to-params warning is replaced by an explicit
+    # unreliability warning.
+    assert "high_gpu_idle_pct" not in codes
+    assert "bypass_cudagraph_unreliable_idle" in codes
+    # (C) a general cudagraph-replay health signal is surfaced.
+    assert "bypass_cudagraph_replay" in codes
 
 
 # ── diffusion workload roofline ──────────────────────────────────────────────

--- a/src/hyperloom/agents/kernel/tools/_bypass_report.py
+++ b/src/hyperloom/agents/kernel/tools/_bypass_report.py
@@ -772,6 +772,9 @@ def render_analysis_md(
     throughput_unit: str = "tok/s",
     metrics_csv_path: str = "",
     summary_csv_path: str = "",
+    idle_reliable: bool = True,
+    attribution_reliable: bool = True,
+    data_reliability_reason: str = "",
 ) -> str:
     """Render the human/downstream ``analysis.md`` report (bypass route).
 
@@ -786,6 +789,12 @@ def render_analysis_md(
         framework: Serving framework tag.
         target_platform: GPU platform tag.
         throughput_unit: ``tok/s`` (text-gen) or ``img/s`` (xDiT).
+        idle_reliable: When False, the idle/busy cells are nulled (rendered as
+            "-") because the trace is an incomplete CUDA-graph capture.
+        attribution_reliable: When False, the op-attribution coverage cell is
+            nulled for the same reason.
+        data_reliability_reason: Machine tag (e.g. ``cudagraph_incomplete_trace``)
+            appended to the provenance note when any metric is unreliable.
 
     Returns:
         The full markdown report text.
@@ -817,6 +826,17 @@ def render_analysis_md(
         "exposed_comm_pct": None,  # bypass does not model exposed communication
         "exposed_memcpy_pct": memcpy_pct,
     }
+
+    # Honest degradation (no reconstruction): when the upstream trace is an
+    # incomplete CUDA-graph capture, the affected metrics are not real data, so
+    # null them (rendered as "-") rather than emit an untrustworthy number. This
+    # also stops the downstream parser from reading a spurious idle_pct.
+    if not idle_reliable:
+        exec_summary["gpu_idle_pct"] = None
+        exec_summary["gpu_busy_pct"] = None
+        system_signals["idle_pct"] = None
+    if not attribution_reliable:
+        exec_summary["attribution_pct"] = None
 
     # Top Hot Kernels rows. Displayed Eff% is the binding-side roofline
     # attainment.
@@ -870,6 +890,17 @@ def render_analysis_md(
         f"Per-kernel roofline (bound/AI/efficiency) is computed analytically from captured "
         f"operand shapes + measured kernel time (roofline_source=analytical)."
     )
+    if data_reliability_reason:
+        _unreliable = [
+            name
+            for name, ok in (("idle", idle_reliable), ("op-attribution", attribution_reliable))
+            if not ok
+        ]
+        provenance += (
+            f" DATA RELIABILITY: {', '.join(_unreliable)} unreliable "
+            f"(reason={data_reliability_reason}); affected metrics shown as '-' and must not be "
+            "treated as authoritative — the upstream trace lacks the required data (not reconstructed)."
+        )
 
     extra = _render_bypass_extra_sections(
         candidates,

--- a/src/hyperloom/agents/kernel/tools/_bypass_report.py
+++ b/src/hyperloom/agents/kernel/tools/_bypass_report.py
@@ -827,16 +827,19 @@ def render_analysis_md(
         "exposed_memcpy_pct": memcpy_pct,
     }
 
-    # Honest degradation (no reconstruction): when the upstream trace is an
-    # incomplete CUDA-graph capture, the affected metrics are not real data, so
-    # null them (rendered as "-") rather than emit an untrustworthy number. This
-    # also stops the downstream parser from reading a spurious idle_pct.
+    # Honest degradation (no reconstruction): under an incomplete CUDA-graph
+    # capture the idle/busy numbers are wrong (recorded busy is a fraction of the
+    # real busy), so null them (rendered as "-") rather than emit an untrustworthy
+    # value. This also stops the downstream parser from reading a spurious idle_pct.
+    # Op-attribution coverage is NOT nulled: the low percentage is accurate and is
+    # itself the evidence that coverage is poor; the attribution_reliable flag and
+    # the bypass_low_op_correlation warning carry the "op names/shapes unresolved"
+    # signal, and nulling it would only hide the real coverage (and contradict the
+    # appendix which reports the same figure).
     if not idle_reliable:
         exec_summary["gpu_idle_pct"] = None
         exec_summary["gpu_busy_pct"] = None
         system_signals["idle_pct"] = None
-    if not attribution_reliable:
-        exec_summary["attribution_pct"] = None
 
     # Top Hot Kernels rows. Displayed Eff% is the binding-side roofline
     # attainment.
@@ -891,15 +894,18 @@ def render_analysis_md(
         f"operand shapes + measured kernel time (roofline_source=analytical)."
     )
     if data_reliability_reason:
-        _unreliable = [
-            name
-            for name, ok in (("idle", idle_reliable), ("op-attribution", attribution_reliable))
-            if not ok
-        ]
+        _notes = []
+        if not idle_reliable:
+            _notes.append("idle/busy shown as '-' (spurious under-recording artifact)")
+        if not attribution_reliable:
+            _notes.append(
+                "op-attribution coverage is low and op names/shapes for graph-replayed kernels "
+                "are largely unresolved"
+            )
         provenance += (
-            f" DATA RELIABILITY: {', '.join(_unreliable)} unreliable "
-            f"(reason={data_reliability_reason}); affected metrics shown as '-' and must not be "
-            "treated as authoritative — the upstream trace lacks the required data (not reconstructed)."
+            f" DATA RELIABILITY (reason={data_reliability_reason}): "
+            + "; ".join(_notes)
+            + ". These reflect missing upstream data and are not reconstructed."
         )
 
     extra = _render_bypass_extra_sections(

--- a/src/hyperloom/agents/kernel/tools/_bypass_trace_reader.py
+++ b/src/hyperloom/agents/kernel/tools/_bypass_trace_reader.py
@@ -45,6 +45,15 @@ _DECODER = json.JSONDecoder()
 # Per-rank trace filename pattern (e.g. ``rank_0.trace.json.gz``).
 _RANK_RE = re.compile(r"rank[_-]?(\d+)", re.IGNORECASE)
 
+# CUDA/HIP graph-replay launch names seen on ``cuda_runtime`` events. A workload
+# that runs through captured graphs issues one such launch per replay; the
+# device kernels of the replays are under-recorded and their launching
+# ``cuda_runtime`` call carries no ``External id``, so counting these by name is
+# the only reliable in-trace signal that the timeline/attribution is a
+# graph-replay trace (and thus that idle_pct is untrustworthy). Canonical
+# definition for the tools layer -- ``_trace_shape_manifest`` reuses it.
+_GRAPH_LAUNCH_RE = re.compile(r"graphlaunch|graph_launch|hipgraphlaunch|cudagraphlaunch", re.IGNORECASE)
+
 
 def _file_size(fp: Path) -> int:
     """Return file size in bytes, or 0 on stat() failure."""
@@ -605,6 +614,10 @@ def analyze_trace(
     m_events: list[tuple[float, float, float]] = []
     annotation_windows: list[dict[str, Any]] = []
     event_total = 0
+    # Count CUDA/HIP graph-replay launches by name. These are the only in-trace
+    # evidence that the workload ran via captured graphs, which makes the
+    # recorded device kernels sparse and idle_pct unreliable (see _GRAPH_LAUNCH_RE).
+    graph_launch_count = 0
 
     fobj = _open_trace_binary(tf)
     try:
@@ -617,6 +630,8 @@ def analyze_trace(
                 extid = args.get("External id")
                 if cid is not None and extid is not None:
                     corr_to_extid[cid] = extid
+                if _GRAPH_LAUNCH_RE.search(ev.get("name") or ""):
+                    graph_launch_count += 1
                 continue
             if cat == "cpu_op":
                 args = ev.get("args") or {}
@@ -676,6 +691,7 @@ def analyze_trace(
         emit_launches=emit_launches,
     )
     body["attribution"]["annotation_window_count"] = len(annotation_windows)
+    body["attribution"]["graph_launch_count"] = graph_launch_count
 
     # Detect (relative to the input dir) whether the selected trace is a
     # CUDA-graph capture shard, so the tool layer can surface a health warning.

--- a/src/hyperloom/agents/kernel/tools/_bypass_trace_reader.py
+++ b/src/hyperloom/agents/kernel/tools/_bypass_trace_reader.py
@@ -52,7 +52,9 @@ _RANK_RE = re.compile(r"rank[_-]?(\d+)", re.IGNORECASE)
 # the only reliable in-trace signal that the timeline/attribution is a
 # graph-replay trace (and thus that idle_pct is untrustworthy). Canonical
 # definition for the tools layer -- ``_trace_shape_manifest`` reuses it.
-_GRAPH_LAUNCH_RE = re.compile(r"graphlaunch|graph_launch|hipgraphlaunch|cudagraphlaunch", re.IGNORECASE)
+# ``graphlaunch`` already matches inside ``cudaGraphLaunch`` / ``hipGraphLaunch``;
+# ``graph_launch`` additionally covers snake_case emitters.
+_GRAPH_LAUNCH_RE = re.compile(r"graphlaunch|graph_launch", re.IGNORECASE)
 
 
 def _file_size(fp: Path) -> int:

--- a/src/hyperloom/agents/kernel/tools/_trace_shape_manifest.py
+++ b/src/hyperloom/agents/kernel/tools/_trace_shape_manifest.py
@@ -43,6 +43,8 @@ import json
 import re
 from typing import Any
 
+import _bypass_trace_reader as _reader
+
 #: Manifest schema version. Bump on any breaking change to row/field semantics.
 SCHEMA_VERSION = 1
 
@@ -74,10 +76,6 @@ _TUNER_DTYPE_RE = re.compile(
     r"bf16|bfloat16|fp16|float16|half|fp8|float8|e4m3|e5m2|fp4|float4|f8|f4",
     re.IGNORECASE,
 )
-
-#: Graph-replay launch marker in the main (graph-on) trace.
-_GRAPH_LAUNCH_RE = re.compile(r"graphlaunch|graph_launch|hipgraphlaunch|cudagraphlaunch", re.IGNORECASE)
-
 
 def classify_op(name: str, op_name: str = "") -> str:
     """Return the coarse op category for a kernel/op name pair.
@@ -317,7 +315,7 @@ def count_graph_replays(main_analysis: dict[str, Any]) -> int:
     """
     total = 0
     for k in main_analysis.get("kernels") or []:
-        if _GRAPH_LAUNCH_RE.search(str(k.get("name", "") or "")):
+        if _reader._GRAPH_LAUNCH_RE.search(str(k.get("name", "") or "")):
             total += int(k.get("count", 0) or 0)
     return total
 

--- a/src/hyperloom/agents/kernel/tools/_trace_shape_manifest.py
+++ b/src/hyperloom/agents/kernel/tools/_trace_shape_manifest.py
@@ -77,6 +77,7 @@ _TUNER_DTYPE_RE = re.compile(
     re.IGNORECASE,
 )
 
+
 def classify_op(name: str, op_name: str = "") -> str:
     """Return the coarse op category for a kernel/op name pair.
 

--- a/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
@@ -647,11 +647,11 @@ def main(argv: list[str] | None = None) -> int:
                 "severity": "warning",
                 "graph_launch_count": graph_launch_count,
                 "message": (
-                    f"{graph_launch_count} CUDA-graph replay launches detected. Device kernels "
-                    "for graph replays are under-recorded and their launching runtime call "
-                    "carries no cpu_op link, so op-attribution coverage and idle_pct are "
-                    "unreliable for this trace; kernel-name classification and per-kernel GPU-time "
-                    "shares still apply."
+                    f"{graph_launch_count} CUDA-graph replay launches detected. Graph-replayed "
+                    "device kernels are under-recorded and their launching runtime call carries "
+                    "no cpu_op link; consult the idle_reliable / attribution_reliable flags for "
+                    "whether GPU-time and op-attribution are trustworthy for this trace. "
+                    "Kernel-name classification and per-kernel GPU-time shares still apply."
                 ),
             }
         )

--- a/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
@@ -117,6 +117,19 @@ def _maybe_enrich_rocprof(
         return {"status": msg}
 
 
+def _bypass_corr_warn_pct() -> float:
+    """Op-attribution coverage floor (percent) below which coverage is untrusted.
+
+    Single source shared by the ``bypass_low_op_correlation`` warning and the
+    ``attribution_reliable`` gate so they can never disagree. Tunable via
+    ``HYPERLOOM_BYPASS_CORR_WARN_PCT`` (default 10).
+    """
+    try:
+        return float(os.environ.get("HYPERLOOM_BYPASS_CORR_WARN_PCT", "10") or 10)
+    except ValueError:
+        return 10.0
+
+
 def _emit_quality_warnings(analyze: dict[str, Any], warnings: list[dict[str, Any]]) -> None:
     """Append analysis-quality health signals so weak analyses are never silent.
 
@@ -138,10 +151,7 @@ def _emit_quality_warnings(analyze: dict[str, Any], warnings: list[dict[str, Any
         others_thr = float(os.environ.get("HYPERLOOM_BYPASS_OTHERS_WARN_PCT", "40") or 40)
     except ValueError:
         others_thr = 40.0
-    try:
-        corr_thr = float(os.environ.get("HYPERLOOM_BYPASS_CORR_WARN_PCT", "10") or 10)
-    except ValueError:
-        corr_thr = 10.0
+    corr_thr = _bypass_corr_warn_pct()
 
     rollup = _report._category_rollup(analyze)
     others_pct = next((r["gpu_pct"] for r in rollup if r["category"] == "Others"), 0.0)
@@ -674,47 +684,62 @@ def main(argv: list[str] | None = None) -> int:
     # surface a high_gpu_idle_pct warning for the Coordinator.
     idle_pct_value = (analyze.get("timeline") or {}).get("idle_pct")
     idle_pct_threshold = resolve_idle_pct_threshold()
-    if isinstance(idle_pct_value, (int, float)) and float(idle_pct_value) > idle_pct_threshold:
-        if graph_launch_count > 0:
-            # CUDA-graph replay: idle_pct is unreliable here. The profiler
-            # under-records the device kernels of graph replays, so the recorded
-            # kernel intervals cover only a fraction of the real GPU-busy time and
-            # idle_pct reads spuriously high even on a near-saturated GPU. Do NOT
-            # suppress the candidate lists (that would derail the run toward
-            # parameter tuning on a false "GPU is idle" signal); keep the
-            # candidates and surface an explicit unreliability warning instead of
-            # the misleading high_gpu_idle_pct route-to-params warning. This is a
-            # bypass-side carve-out only; the shared _idle_gate threshold/warning
-            # (also used by the TraceLens route) is left untouched.
-            trace_health_warnings.append(
-                {
-                    "code": "bypass_cudagraph_unreliable_idle",
-                    "severity": "warning",
-                    "idle_pct": round(float(idle_pct_value), 2),
-                    "threshold_pct": round(idle_pct_threshold, 2),
-                    "graph_launch_count": graph_launch_count,
-                    "source": str(analysis_md_path),
-                    "message": (
-                        f"GPU idle measured {float(idle_pct_value):.2f}% (> "
-                        f"{idle_pct_threshold:.2f}%), but {graph_launch_count} CUDA-graph "
-                        "replay launches were detected. Under graph replay the profiler "
-                        "under-records device kernels, so idle_pct is unreliable and does "
-                        "NOT indicate a genuinely idle GPU. The hot-kernel candidate list is "
-                        "retained (idle-gate suppression skipped); do not route to parameter "
-                        "optimization on the basis of this idle_pct."
-                    ),
-                }
+    idle_over_threshold = isinstance(idle_pct_value, (int, float)) and float(idle_pct_value) > idle_pct_threshold
+
+    # --- data reliability (honest degradation; no reconstruction) ---
+    # When the upstream trace is an incomplete CUDA-graph capture, its GPU-time
+    # and attribution data are simply not present. We do not fabricate them; we
+    # mark them unreliable and propagate that so nothing downstream (report,
+    # roofline snapshot, specialist prompt) treats them as authoritative.
+    # * idle: a high idle reading under graph replay is an under-recording
+    #   artifact, not a genuinely idle GPU.
+    # * attribution: graph-replayed kernels carry no cpu_op link, so coverage
+    #   below the shared floor is a data gap, not a real 0%.
+    attributed_pct = float((analyze.get("attribution") or {}).get("attributed_pct") or 0.0)
+    idle_reliable = not (idle_over_threshold and graph_launch_count > 0)
+    attribution_reliable = not (graph_launch_count > 0 and attributed_pct < _bypass_corr_warn_pct())
+    data_reliability_reason = "" if (idle_reliable and attribution_reliable) else "cudagraph_incomplete_trace"
+
+    if idle_over_threshold and not idle_reliable:
+        # CUDA-graph replay: idle_pct is unreliable here. The profiler
+        # under-records the device kernels of graph replays, so the recorded
+        # kernel intervals cover only a fraction of the real GPU-busy time and
+        # idle_pct reads spuriously high even on a near-saturated GPU. Do NOT
+        # suppress the candidate lists (that would derail the run toward
+        # parameter tuning on a false "GPU is idle" signal); keep the
+        # candidates and surface an explicit unreliability warning instead of
+        # the misleading high_gpu_idle_pct route-to-params warning. This is a
+        # bypass-side carve-out only; the shared _idle_gate threshold/warning
+        # (also used by the TraceLens route) is left untouched.
+        trace_health_warnings.append(
+            {
+                "code": "bypass_cudagraph_unreliable_idle",
+                "severity": "warning",
+                "idle_pct": round(float(idle_pct_value), 2),
+                "threshold_pct": round(idle_pct_threshold, 2),
+                "graph_launch_count": graph_launch_count,
+                "source": str(analysis_md_path),
+                "message": (
+                    f"GPU idle measured {float(idle_pct_value):.2f}% (> "
+                    f"{idle_pct_threshold:.2f}%), but {graph_launch_count} CUDA-graph "
+                    "replay launches were detected. Under graph replay the profiler "
+                    "under-records device kernels, so idle_pct is unreliable and does "
+                    "NOT indicate a genuinely idle GPU. The hot-kernel candidate list is "
+                    "retained (idle-gate suppression skipped); do not route to parameter "
+                    "optimization on the basis of this idle_pct."
+                ),
+            }
+        )
+    elif idle_over_threshold:
+        for _cand_key in ("hot_kernels", "routable_kernels", "skipped_kernels", "task_groups"):
+            candidates[_cand_key] = []
+        trace_health_warnings.append(
+            build_high_idle_warning(
+                idle_pct=float(idle_pct_value),
+                threshold_pct=idle_pct_threshold,
+                report_path=analysis_md_path,
             )
-        else:
-            for _cand_key in ("hot_kernels", "routable_kernels", "skipped_kernels", "task_groups"):
-                candidates[_cand_key] = []
-            trace_health_warnings.append(
-                build_high_idle_warning(
-                    idle_pct=float(idle_pct_value),
-                    threshold_pct=idle_pct_threshold,
-                    report_path=analysis_md_path,
-                )
-            )
+        )
 
     # Stamp the report path onto each candidate (downstream reads it).
     for cand in candidates.get("hot_kernels", []):
@@ -732,6 +757,9 @@ def main(argv: list[str] | None = None) -> int:
             throughput_unit=throughput_unit,
             metrics_csv_path=str(kernel_metrics_csv_path),
             summary_csv_path=str(kernel_summary_csv_path),
+            idle_reliable=idle_reliable,
+            attribution_reliable=attribution_reliable,
+            data_reliability_reason=data_reliability_reason,
         ),
     )
     atomic_write_json(candidates_path, candidates, ensure_ascii=False, sort_keys=False, trailing_newline=False)
@@ -748,6 +776,9 @@ def main(argv: list[str] | None = None) -> int:
     )
     summary["estimated"] = estimated
     summary["analysis_degraded"] = analysis_degraded
+    summary["idle_reliable"] = idle_reliable
+    summary["attribution_reliable"] = attribution_reliable
+    summary["data_reliability_reason"] = data_reliability_reason
     # Always present (may be null) so the summary/manifest/result schemas match.
     summary["steady_window"] = steady_window  # always present (may be null)
 
@@ -762,6 +793,9 @@ def main(argv: list[str] | None = None) -> int:
             "steady_window": steady_window,
             "estimated": estimated,
             "analysis_degraded": analysis_degraded,
+            "idle_reliable": idle_reliable,
+            "attribution_reliable": attribution_reliable,
+            "data_reliability_reason": data_reliability_reason,
             "analyzed_rank": analyzed_rank,
             "rank_count": rank_count,
             "event_total": analyze.get("event_total", 0),
@@ -838,6 +872,9 @@ def main(argv: list[str] | None = None) -> int:
         "steady_window": steady_window,
         "estimated": estimated,
         "analysis_degraded": analysis_degraded,
+        "idle_reliable": idle_reliable,
+        "attribution_reliable": attribution_reliable,
+        "data_reliability_reason": data_reliability_reason,
         "analyzed_rank": analyzed_rank,
         "rank_count": rank_count,
         "num_denoise_steps": requested_denoise_steps or inferred_denoise_steps,
@@ -875,6 +912,11 @@ def main(argv: list[str] | None = None) -> int:
             "trace_input_manifest": str(manifest_path),
         },
     }
+    # Mirror the idle-reliability flag inside the timeline block so consumers
+    # reading result["timeline"] directly also see that idle_pct is untrusted.
+    if isinstance(result.get("timeline"), dict):
+        result["timeline"]["idle_reliable"] = idle_reliable
+
     # Surfaced only when the opt-in manifest was produced (P0-A / WP-1).
     result["trace_shape_manifest"] = shape_manifest
     if shape_manifest.get("status") == "ok" and shape_manifest.get("path"):

--- a/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
@@ -171,23 +171,6 @@ def _emit_quality_warnings(analyze: dict[str, Any], warnings: list[dict[str, Any
             }
         )
 
-    graph_launch_count = (analyze.get("attribution") or {}).get("graph_launch_count", 0)
-    if graph_launch_count > 0:
-        warnings.append(
-            {
-                "code": "bypass_cudagraph_replay",
-                "severity": "warning",
-                "graph_launch_count": graph_launch_count,
-                "message": (
-                    f"{graph_launch_count} CUDA-graph replay launches detected. Device kernels "
-                    "for graph replays are under-recorded and their launching runtime call "
-                    "carries no cpu_op link, so op-attribution coverage and idle_pct are "
-                    "unreliable for this trace; kernel-name classification and per-kernel GPU-time "
-                    "shares still apply."
-                ),
-            }
-        )
-
     if analyze.get("steady_window_status"):
         warnings.append(
             {
@@ -643,6 +626,26 @@ def main(argv: list[str] | None = None) -> int:
             }
         )
 
+    # CUDA-graph replay is a whole-trace property, independent of whether any
+    # device kernels were recorded, so surface it unconditionally: the zero-
+    # recorded-kernel case is exactly when graph under-recording is most severe.
+    graph_launch_count = (analyze.get("attribution") or {}).get("graph_launch_count", 0)
+    if graph_launch_count > 0:
+        trace_health_warnings.append(
+            {
+                "code": "bypass_cudagraph_replay",
+                "severity": "warning",
+                "graph_launch_count": graph_launch_count,
+                "message": (
+                    f"{graph_launch_count} CUDA-graph replay launches detected. Device kernels "
+                    "for graph replays are under-recorded and their launching runtime call "
+                    "carries no cpu_op link, so op-attribution coverage and idle_pct are "
+                    "unreliable for this trace; kernel-name classification and per-kernel GPU-time "
+                    "shares still apply."
+                ),
+            }
+        )
+
     # Analysis-quality health signals (observability only; never fatal).
     if analyze.get("kernels"):
         _emit_quality_warnings(analyze, trace_health_warnings)
@@ -671,7 +674,6 @@ def main(argv: list[str] | None = None) -> int:
     # surface a high_gpu_idle_pct warning for the Coordinator.
     idle_pct_value = (analyze.get("timeline") or {}).get("idle_pct")
     idle_pct_threshold = resolve_idle_pct_threshold()
-    graph_launch_count = (analyze.get("attribution") or {}).get("graph_launch_count", 0)
     if isinstance(idle_pct_value, (int, float)) and float(idle_pct_value) > idle_pct_threshold:
         if graph_launch_count > 0:
             # CUDA-graph replay: idle_pct is unreliable here. The profiler

--- a/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
@@ -656,6 +656,30 @@ def main(argv: list[str] | None = None) -> int:
             }
         )
 
+    # Honest degradation for --capture-folder: it is NOT consumed by the core
+    # bypass analysis (idle / attribution / candidates); it only feeds the opt-in
+    # TraceShapeManifest. Surface that explicitly when an operator passes it, so it
+    # never looks like it is filling the CUDA-graph data gaps (it is not — the
+    # capture shards are not used to reconstruct idle or op-attribution).
+    if args.capture_folder:
+        _sm_on = os.environ.get(_SHAPE_MANIFEST_ENV, "0").strip().lower() in {"1", "true", "yes", "on"}
+        trace_health_warnings.append(
+            {
+                "code": "bypass_capture_folder_not_used_for_core",
+                "severity": "warning",
+                "capture_folder": args.capture_folder,
+                "shape_manifest_enabled": _sm_on,
+                "message": (
+                    "--capture-folder was provided but the bypass core analysis "
+                    "(idle / op-attribution / kernel candidates) does not consume it; it only "
+                    f"feeds the opt-in TraceShapeManifest ({_SHAPE_MANIFEST_ENV}="
+                    f"{'on' if _sm_on else 'off'}). Capture shards are NOT used to reconstruct "
+                    "idle or op-attribution for CUDA-graph traces — those gaps remain (marked via "
+                    "idle_reliable / attribution_reliable), not filled."
+                ),
+            }
+        )
+
     # Analysis-quality health signals (observability only; never fatal).
     if analyze.get("kernels"):
         _emit_quality_warnings(analyze, trace_health_warnings)

--- a/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
@@ -844,9 +844,17 @@ def main(argv: list[str] | None = None) -> int:
             # Workload totals cover all analyzed device kernels (not just top-k).
             _workload_totals = _report.build_workload_roofline_totals(analyze, target_platform=args.target_platform)
             _all_kernels = [k for k in (analyze.get("kernels") or []) if float(k.get("gpu_time_us") or 0.0) > 0]
+            # Honest degradation: when idle is unreliable (incomplete CUDA-graph
+            # capture) the diffusion report must not derive gpu_busy_ratio from the
+            # spurious busy/idle, so null them here too (diffusion_roofline treats
+            # a missing busy_pct as gpu_busy_ratio=None, not a fabricated value).
+            _diff_timeline = dict(analyze.get("timeline") or {})
+            if not idle_reliable:
+                _diff_timeline["idle_pct"] = None
+                _diff_timeline["busy_pct"] = None
             _diff_report = build_report_from_bypass(
                 candidates.get("hot_kernels", []),
-                analyze.get("timeline") or {},
+                _diff_timeline,
                 _diff_steps,
                 top_k,
                 totals=_workload_totals,
@@ -912,10 +920,13 @@ def main(argv: list[str] | None = None) -> int:
             "trace_input_manifest": str(manifest_path),
         },
     }
-    # Mirror the idle-reliability flag inside the timeline block so consumers
-    # reading result["timeline"] directly also see that idle_pct is untrusted.
+    # Mirror the reliability flags inside their sub-blocks so consumers reading
+    # result["timeline"] / result["attribution"] directly also see the untrusted
+    # marker (not only the top-level flags).
     if isinstance(result.get("timeline"), dict):
         result["timeline"]["idle_reliable"] = idle_reliable
+    if isinstance(result.get("attribution"), dict):
+        result["attribution"]["attribution_reliable"] = attribution_reliable
 
     # Surfaced only when the opt-in manifest was produced (P0-A / WP-1).
     result["trace_shape_manifest"] = shape_manifest

--- a/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
@@ -706,21 +706,29 @@ def main(argv: list[str] | None = None) -> int:
     # High-idle gate: when GPU idle exceeds the threshold, per-kernel rewriting
     # cannot move end-to-end latency, so suppress every candidate list and
     # surface a high_gpu_idle_pct warning for the Coordinator.
-    idle_pct_value = (analyze.get("timeline") or {}).get("idle_pct")
+    _timeline = analyze.get("timeline") or {}
+    idle_pct_value = _timeline.get("idle_pct")
+    _total_ms = _timeline.get("total_time_ms")
     idle_pct_threshold = resolve_idle_pct_threshold()
     idle_over_threshold = isinstance(idle_pct_value, (int, float)) and float(idle_pct_value) > idle_pct_threshold
+    # Degenerate timeline: graph replays present but (near-)zero GPU time recorded,
+    # so idle_pct fell out as 0 from an empty timeline. This is the MOST severe
+    # under-recording, not a genuinely 0%-idle GPU.
+    idle_data_missing = not isinstance(_total_ms, (int, float)) or _total_ms <= 0.0
 
     # --- data reliability (honest degradation; no reconstruction) ---
     # When the upstream trace is an incomplete CUDA-graph capture, its GPU-time
     # and attribution data are simply not present. We do not fabricate them; we
     # mark them unreliable and propagate that so nothing downstream (report,
     # roofline snapshot, specialist prompt) treats them as authoritative.
-    # * idle: a high idle reading under graph replay is an under-recording
-    #   artifact, not a genuinely idle GPU.
+    # * idle: under graph replay a high idle reading is an under-recording artifact
+    #   (not a genuinely idle GPU); a degenerate empty timeline (idle=0 from no
+    #   recorded GPU time) is the same artifact at its extreme. A plausible
+    #   low/moderate idle computed from real recorded kernels is kept trustworthy.
     # * attribution: graph-replayed kernels carry no cpu_op link, so coverage
     #   below the shared floor is a data gap, not a real 0%.
     attributed_pct = float((analyze.get("attribution") or {}).get("attributed_pct") or 0.0)
-    idle_reliable = not (idle_over_threshold and graph_launch_count > 0)
+    idle_reliable = not (graph_launch_count > 0 and (idle_over_threshold or idle_data_missing))
     attribution_reliable = not (graph_launch_count > 0 and attributed_pct < _bypass_corr_warn_pct())
     data_reliability_reason = "" if (idle_reliable and attribution_reliable) else "cudagraph_incomplete_trace"
 

--- a/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
@@ -171,6 +171,23 @@ def _emit_quality_warnings(analyze: dict[str, Any], warnings: list[dict[str, Any
             }
         )
 
+    graph_launch_count = (analyze.get("attribution") or {}).get("graph_launch_count", 0)
+    if graph_launch_count > 0:
+        warnings.append(
+            {
+                "code": "bypass_cudagraph_replay",
+                "severity": "warning",
+                "graph_launch_count": graph_launch_count,
+                "message": (
+                    f"{graph_launch_count} CUDA-graph replay launches detected. Device kernels "
+                    "for graph replays are under-recorded and their launching runtime call "
+                    "carries no cpu_op link, so op-attribution coverage and idle_pct are "
+                    "unreliable for this trace; kernel-name classification and per-kernel GPU-time "
+                    "shares still apply."
+                ),
+            }
+        )
+
     if analyze.get("steady_window_status"):
         warnings.append(
             {
@@ -654,16 +671,48 @@ def main(argv: list[str] | None = None) -> int:
     # surface a high_gpu_idle_pct warning for the Coordinator.
     idle_pct_value = (analyze.get("timeline") or {}).get("idle_pct")
     idle_pct_threshold = resolve_idle_pct_threshold()
+    graph_launch_count = (analyze.get("attribution") or {}).get("graph_launch_count", 0)
     if isinstance(idle_pct_value, (int, float)) and float(idle_pct_value) > idle_pct_threshold:
-        for _cand_key in ("hot_kernels", "routable_kernels", "skipped_kernels", "task_groups"):
-            candidates[_cand_key] = []
-        trace_health_warnings.append(
-            build_high_idle_warning(
-                idle_pct=float(idle_pct_value),
-                threshold_pct=idle_pct_threshold,
-                report_path=analysis_md_path,
+        if graph_launch_count > 0:
+            # CUDA-graph replay: idle_pct is unreliable here. The profiler
+            # under-records the device kernels of graph replays, so the recorded
+            # kernel intervals cover only a fraction of the real GPU-busy time and
+            # idle_pct reads spuriously high even on a near-saturated GPU. Do NOT
+            # suppress the candidate lists (that would derail the run toward
+            # parameter tuning on a false "GPU is idle" signal); keep the
+            # candidates and surface an explicit unreliability warning instead of
+            # the misleading high_gpu_idle_pct route-to-params warning. This is a
+            # bypass-side carve-out only; the shared _idle_gate threshold/warning
+            # (also used by the TraceLens route) is left untouched.
+            trace_health_warnings.append(
+                {
+                    "code": "bypass_cudagraph_unreliable_idle",
+                    "severity": "warning",
+                    "idle_pct": round(float(idle_pct_value), 2),
+                    "threshold_pct": round(idle_pct_threshold, 2),
+                    "graph_launch_count": graph_launch_count,
+                    "source": str(analysis_md_path),
+                    "message": (
+                        f"GPU idle measured {float(idle_pct_value):.2f}% (> "
+                        f"{idle_pct_threshold:.2f}%), but {graph_launch_count} CUDA-graph "
+                        "replay launches were detected. Under graph replay the profiler "
+                        "under-records device kernels, so idle_pct is unreliable and does "
+                        "NOT indicate a genuinely idle GPU. The hot-kernel candidate list is "
+                        "retained (idle-gate suppression skipped); do not route to parameter "
+                        "optimization on the basis of this idle_pct."
+                    ),
+                }
             )
-        )
+        else:
+            for _cand_key in ("hot_kernels", "routable_kernels", "skipped_kernels", "task_groups"):
+                candidates[_cand_key] = []
+            trace_health_warnings.append(
+                build_high_idle_warning(
+                    idle_pct=float(idle_pct_value),
+                    threshold_pct=idle_pct_threshold,
+                    report_path=analysis_md_path,
+                )
+            )
 
     # Stamp the report path onto each candidate (downstream reads it).
     for cand in candidates.get("hot_kernels", []):


### PR DESCRIPTION
## Problem

On the bypass (TraceLens-free) trace-analysis route (`HYPERLOOM_TRACE_ANALYSIS_ROUTE=bypass`), CUDA-graph replay traces derailed the optimization loop. Root cause: the reader ignored `cuda_runtime` event **names**, so it never saw the graph-replay launches. Under graph replay the profiler under-records device kernels, so:

- **idle formula broke**: `busy = union(recorded kernels)`, `total = event span` → `busy 63ms / total 7242ms → idle 99.1%` on a near-saturated GPU.
- **attribution broke**: graph-replayed kernels have no `cpu_op` link → ~91% of kernel time unlinked (no op names/shapes/sources).
- **no integrity check**: the spurious 99% idle tripped the shared high-idle gate, **cleared every kernel candidate**, and emitted `high_gpu_idle_pct` — steering the run to "tune params, not kernels."

## Approach: honest degradation, not reconstruction

The upstream trace genuinely lacks the data (graph replays carry no per-replay device/op info). It cannot be reconstructed downstream, so this change **detects the incomplete trace and marks the affected metrics unreliable** — it never fabricates values or adds fallbacks.

## What changed (5 files, `agents/kernel/tools/`)

- **Detect** graph replays by name in `_bypass_trace_reader` → `attribution.graph_launch_count` (canonical `_GRAPH_LAUNCH_RE`, reused by `_trace_shape_manifest`).
- **Don't derail**: when graph replays are present and idle is high, skip the candidate-suppression gate and emit `bypass_cudagraph_unreliable_idle` instead of the misleading `high_gpu_idle_pct` (the shared `_idle_gate` / TraceLens route is untouched).
- **Honest degradation** of `idle` (high idle, or degenerate empty timeline, under replay) and `attribution` (coverage below the shared floor under replay): `idle_reliable` / `attribution_reliable` / `data_reliability_reason` propagated through `result` (+ `timeline`/`attribution` sub-blocks), `summary.json`, `trace_input_manifest.json`, and `analysis.md` (idle/busy rendered `—`; accurate op-attribution coverage kept + flagged; a `DATA RELIABILITY` note). xDiT diffusion sidecar nulls busy/idle when unreliable.
- **`--capture-folder`**: made its no-op explicit — it is not consumed by the core analysis (only the opt-in shape manifest) and does not reconstruct anything → `bypass_capture_folder_not_used_for_core` warning when provided.

Deliberate: `idle_reliable` keys off the idle threshold (under-recording manifests as high idle), so a plausible low idle from real recorded kernels stays trustworthy.

## Verification

Before/after on an incident-shaped trace (128 replays, ~4410 kernels, ~91% unlinked, idle 99.1%), run on a real Linux MI300X pod:

| | before | after |
|---|---|---|
| `graph_launch_count` | missing | 128 |
| hot kernels | **0 (cleared)** | 2 (retained) |
| routing warning | `high_gpu_idle_pct` | `bypass_cudagraph_unreliable_idle` + `bypass_cudagraph_replay` |
| idle in report | `99.11%` (authoritative) | `—` + DATA RELIABILITY note; `idle_reliable=False` |

Tests: bypass suite green locally and on the Linux pod (185 passed / 21 skipped on pod). Adds regression tests for detection, non-suppression, idle/attribution degradation, degenerate empty timeline, healthy-low-idle-cudagraph, and the capture-folder signal.

## Not done (deliberate)

Accurate idle values and recovered op-attribution are **not reconstructed** — the data is absent upstream; reconstructing it would mean fabricating numbers. The true fix for that belongs in the upstream trace producer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)