### PR TITLE
fix(kernel): resolve fusion patch root consistently for non-git frameworks

### DIFF
--- a/src/hyperloom/agents/kernel/tests/test_forge_fusion.py
+++ b/src/hyperloom/agents/kernel/tests/test_forge_fusion.py
@@ -245,6 +245,29 @@ def test_normalize_manifest_kept_writes_keep_result(tmp_path, monkeypatch):
     assert result["artifact_files"] == ["foo.py"]
 
 
+def test_normalize_manifest_prefers_artifacts_repo_root(tmp_path, monkeypatch):
+    """kernel_repo must come from the root forge-fusion exported against (authoritative
+    for a non-git pip framework), NOT a git toplevel that would break patch apply."""
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    manifest = {
+        "fusion_loop": {"kept": True, "best": {"kernel_speedup": 1.2}},
+        "validation": {"kept": True},
+        "artifacts": {
+            "patch": "diff --git a/vllm/x.py",
+            "changes": [{"path": "vllm/x.py"}],
+            "repo_root": "/venv/site-packages",
+        },
+        "fusion": {"source_file": str(output_dir / "x.py")},
+    }
+    (output_dir / "fusion_manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    # even if git would resolve a (wrong) project root, the manifest root wins
+    monkeypatch.setattr(forge_fusion, "_git_toplevel", lambda _path: "/some/git/project")
+
+    result = forge_fusion._normalize_manifest(str(output_dir), rc=0)
+    assert result["kernel_repo"] == "/venv/site-packages"
+
+
 def test_normalize_manifest_missing_file_reports_error(tmp_path):
     output_dir = tmp_path / "missing"
     output_dir.mkdir()
@@ -295,24 +318,49 @@ def test_main_kept_manifest_emits_keep_result(tmp_path, monkeypatch, capsys):
     assert result["requires_e2e_validation"] is True
 
 
-def test_git_toplevel_success(monkeypatch, tmp_path):
-    def fake_run(cmd, **kwargs):
-        class R:
-            returncode = 0
-            stdout = "/repo/root\n"
+def test_git_toplevel_success(tmp_path):
+    # A git-TRACKED file resolves to its work-tree root.
+    import subprocess as sp
 
-        return R()
+    repo = tmp_path / "repo"
+    (repo / "pkg").mkdir(parents=True)
+    src = repo / "pkg" / "foo.py"
+    src.write_text("x = 1\n", encoding="utf-8")
+    for args in (["init", "-q"], ["add", "-A"],
+                 ["-c", "user.email=a@b.c", "-c", "user.name=t", "commit", "-qm", "b"]):
+        sp.run(["git", "-C", str(repo), *args], check=True, capture_output=True, text=True)
+    assert forge_fusion._git_toplevel(str(src)) == str(repo.resolve())
 
-    monkeypatch.setattr(forge_fusion.subprocess, "run", fake_run)
-    assert forge_fusion._git_toplevel(str(tmp_path / "src/foo.py")) == "/repo/root"
+
+def test_git_toplevel_untracked_in_git_uses_package_root(tmp_path):
+    # venv-in-git: an UNTRACKED pip file must resolve to the package root, not the
+    # git project root, so the package-relative patch applies.
+    import subprocess as sp
+
+    project = tmp_path / "proj"
+    site = project / ".venv" / "site-packages"
+    d = site / "vllm" / "models"
+    d.mkdir(parents=True)
+    for p in (site / "vllm", d):
+        (p / "__init__.py").write_text("", encoding="utf-8")
+    src = d / "qwen3.py"
+    src.write_text("x = 1\n", encoding="utf-8")
+    sp.run(["git", "-C", str(project), "init", "-q"], check=True, capture_output=True, text=True)
+    (project / ".gitignore").write_text(".venv/\n", encoding="utf-8")
+    sp.run(["git", "-C", str(project), "add", ".gitignore"], check=True,
+           capture_output=True, text=True)
+    sp.run(["git", "-C", str(project), "-c", "user.email=a@b.c", "-c", "user.name=t",
+            "commit", "-qm", "b"], check=True, capture_output=True, text=True)
+    assert forge_fusion._git_toplevel(str(src)) == str(site.resolve())
 
 
 def test_git_toplevel_handles_subprocess_errors(monkeypatch):
+    # git unavailable -> fall back to the package root derived from the path.
     def fake_run(*_args, **_kwargs):
         raise OSError("git missing")
 
     monkeypatch.setattr(forge_fusion.subprocess, "run", fake_run)
-    assert forge_fusion._git_toplevel("/any/path.py") == ""
+    assert forge_fusion._git_toplevel("/any/path.py") == "/any"
 
 
 def test_main_invalid_json_returns_2(tmp_path, capsys):
@@ -499,7 +547,8 @@ def test_load_input_json_empty_path_returns_empty_dict():
     assert forge_fusion._load_input_json("") == {}
 
 
-def test_git_toplevel_returns_empty_on_nonzero_exit(monkeypatch, tmp_path):
+def test_git_toplevel_returns_package_root_when_not_git(monkeypatch, tmp_path):
+    # Not a git work tree -> use the package root (matches forge-fusion's export root).
     def fake_run(cmd, **kwargs):
         class R:
             returncode = 1
@@ -508,7 +557,7 @@ def test_git_toplevel_returns_empty_on_nonzero_exit(monkeypatch, tmp_path):
         return R()
 
     monkeypatch.setattr(forge_fusion.subprocess, "run", fake_run)
-    assert forge_fusion._git_toplevel(str(tmp_path / "foo.py")) == ""
+    assert forge_fusion._git_toplevel(str(tmp_path / "foo.py")) == str(tmp_path.resolve())
 
 
 def test_emit_without_output_dir_only_prints(capsys):
@@ -562,7 +611,7 @@ def test_git_toplevel_handles_subprocess_error(monkeypatch):
         raise forge_fusion.subprocess.SubprocessError("boom")
 
     monkeypatch.setattr(forge_fusion.subprocess, "run", fake_run)
-    assert forge_fusion._git_toplevel("/x") == ""
+    assert forge_fusion._git_toplevel("/x") == "/"
 
 
 def test_terminate_process_tree_windows_uses_terminate(monkeypatch):

--- a/src/hyperloom/agents/kernel/tools/forge_fusion.py
+++ b/src/hyperloom/agents/kernel/tools/forge_fusion.py
@@ -66,18 +66,56 @@ def _inject_author_gateway_env() -> None:
     apply_llm_stability_env(os.environ)
 
 
+def _package_root(source_file: str) -> str:
+    """Install dir above the top package containing ``source_file`` (site-packages).
+
+    Mirrors forge-fusion's export root for a non-git (pip-installed) framework so the
+    patch's package-relative paths apply here. Assumes each package level ships an
+    ``__init__.py`` (true for vLLM/sglang).
+    """
+    if not source_file:
+        return ""
+    d = Path(source_file).resolve().parent
+    while d.parent != d and (d / "__init__.py").is_file():
+        d = d.parent
+    return str(d)
+
+
 def _git_toplevel(path: str) -> str:
-    """Best-effort git repo root for a source file (for integrate's patch apply)."""
+    """Best-effort repo root the patch paths are relative to (for integrate's apply).
+
+    Uses the git work-tree root ONLY when ``path`` is a git-TRACKED file there. A
+    pip-installed framework often lives under a git project's ``.venv`` yet is
+    untracked; returning the project root would make the package-relative patch fail
+    to apply. In that case (and for a plain pip install) use the package root, which
+    matches the root forge-fusion exported the patch against.
+    """
+    if not path:
+        return ""
     try:
+        parent = str(Path(path).parent)
         r = subprocess.run(
-            ["git", "-C", str(Path(path).parent), "rev-parse", "--show-toplevel"],
+            ["git", "-C", parent, "rev-parse", "--show-toplevel"],
             capture_output=True,
             text=True,
             timeout=10,
         )
-        return r.stdout.strip() if r.returncode == 0 else ""
+        if r.returncode == 0:
+            toplevel = r.stdout.strip()
+            try:
+                rel = str(Path(path).resolve().relative_to(Path(toplevel).resolve()))
+                tracked = subprocess.run(
+                    ["git", "-C", toplevel, "ls-files", "--error-unmatch", "--", rel],
+                    capture_output=True, text=True, timeout=10,
+                )
+                if tracked.returncode == 0:
+                    return toplevel
+            except ValueError:
+                pass
+            return _package_root(path) or toplevel
     except (OSError, subprocess.SubprocessError):
-        return ""
+        return _package_root(path)
+    return _package_root(path)
 
 
 def _load_input_json(path: str) -> dict[str, Any]:
@@ -246,7 +284,10 @@ def _normalize_manifest(output_dir: str, rc: int) -> dict[str, Any]:
             "patch": artifacts.get("patch"),
             # For integrate's patch-apply path.
             "source_file": src_file,
-            "kernel_repo": _git_toplevel(src_file) if src_file else "",
+            # Prefer the root forge-fusion exported the patch against (authoritative,
+            # may be a site-packages dir); fall back to deriving it from src_file.
+            "kernel_repo": str(artifacts.get("repo_root") or "")
+            or (_git_toplevel(src_file) if src_file else ""),
             "best_pattern": loop.get("best_pattern"),
             "verdict": m.get("verdict"),
             # A KEPT fusion passed kernel parity + serving smoke; the orchestrator


### PR DESCRIPTION
## Summary

Companion to KernelForge PR #75 (non-git fusion patch export). When forge-fusion
runs against a pip-installed framework (e.g. vLLM under a project-local venv),
the exported patch paths are package-relative (rooted at `site-packages`). The
Hyperloom wrapper, however, set `kernel_repo` via the git work-tree top level,
which is empty for a plain pip install or points at the wrong project root when
the venv sits inside a git repo. Integrate then applied the package-relative
patch at the wrong root and failed, so a KEPT fusion never produced an e2e number.

## Changes

- `agents/kernel/tools/forge_fusion.py`:
  - `kernel_repo` now prefers `artifacts.repo_root` from the manifest (the root
    forge-fusion actually exported the patch against), falling back to deriving
    it from `source_file`.
  - `_git_toplevel()` only trusts the git work-tree root when the source file is
    actually git-**tracked** there; otherwise (and for a plain pip install) it
    returns the package install root via the new `_package_root()`, mirroring
    forge-fusion's export root.
- Tests updated to the new contract; added venv-in-git and manifest-root cases.

## Test plan

- [ ] `pytest src/hyperloom/agents/kernel/tests/test_forge_fusion.py` (37 passed locally)
- [ ] e2e integrate applies a fusion patch for a pip-installed (non-git) vLLM