### PR TITLE
feat(forge): install rocprof-compute + pin pandas<3 for Forge

### DIFF
--- a/src/hyperloom/inference_optimizer/assets/install.sh
+++ b/src/hyperloom/inference_optimizer/assets/install.sh
@@ -792,15 +792,6 @@ ensure_kernel_agents() {
 # (with the concrete "profiling will degrade to PMC" consequence) so the
 # post-mortem observability question — "why did this run profile on PMC?" — is
 # answerable from the install log alone.
-_forge_backend_selected() {
-  # True when the kernel-rewrite ladder includes the forge backend. Substring
-  # match (case-insensitive) tolerates "forge", "geak,forge", "geak forge", etc.
-  case "$(printf '%s' "${KERNEL_OPT_BACKEND_ORDER:-}" | tr '[:upper:]' '[:lower:]')" in
-    *forge*) return 0 ;;
-    *) return 1 ;;
-  esac
-}
-
 # rocprof-compute's CSV converter (utils/utils.py, v3->v2) assumes pandas'
 # legacy 'object' string dtype. pandas>=3.0 defaults future.infer_string=True,
 # so the rocprofv3 counter CSV's Agent_Id ("Agent 9") is read as the new
@@ -808,15 +799,19 @@ _forge_backend_selected() {
 # coercion and the subsequent Agent_Id<->Node_Id merge dies ("merge on str and
 # int64"). Every counter file is dropped -> rocprof-compute reports "No
 # profiling data found" -> forge silently degrades to the PMC path (no roofline;
-# optimization-potential estimable=NO). rocprof-compute runs under the forge
-# interpreter (its sys.executable == $PYTHON here), so pinning pandas<3 in THIS
-# interpreter is exactly what the tool imports. Nothing else in the stack needs
+# optimization-potential estimable=NO). Nothing else in the stack needs
 # pandas>=3 (verified: no installed dist requires it), so <3 is conflict-free.
+#
+# rocprof-compute runs under the forge interpreter; KernelForge's resolve_rocpc()
+# probes sys.executable, then /usr/bin/python3, then `python3` on PATH. We pin
+# pandas in $PYTHON, which is the forge interpreter here; if a deployment splits
+# those, pin pandas<3 in whichever interpreter forge actually runs.
+#
 # Fail-soft: a pin failure must NOT abort the install — forge still runs on PMC.
 _ensure_pandas_lt3_for_rocpc() {
-  local ver rc
+  local ver rc why
   # Decide in Python (robust vs. bash numeric parsing under set -euo pipefail).
-  # exit 0 => pandas <3 (ok); exit 1 => pandas >=3 (incompatible); 3 => absent.
+  # exit 0 => pandas <3 (ok); exit 1 => pandas >=3 (too new); 3 => absent.
   if ver="$("$PYTHON" - <<'PY'
 import sys
 try:
@@ -828,28 +823,35 @@ sys.exit(1 if int(pandas.__version__.split(".")[0]) >= 3 else 0)
 PY
 )"; then rc=0; else rc=$?; fi
 
-  if [ "$rc" -eq 3 ]; then
-    log "rocprof-compute: pandas not importable under ${PYTHON}; skipping pandas-compat pin"
-    return 0
-  fi
   if [ "$rc" -eq 0 ]; then
     log "rocprof-compute: pandas ${ver} is <3 (compatible with rocprof-compute's CSV converter); no pin needed"
     return 0
   fi
 
-  # rc == 1: pandas >=3 -> breaks rocprof-compute's v3->v2 CSV conversion.
+  # rc==1 (pandas>=3) OR rc==3 (pandas absent): both need a pinned pandas<3 in
+  # this interpreter. Installing it now also forecloses a LATER unconstrained
+  # `pip install pandas` (e.g. datasets/evaluate pulled by ensure_bench_serving_
+  # deps / ensure_xdit_quality_deps) dragging pandas>=3 back in — pip will not
+  # upgrade an already-satisfying 2.x. (ensure_rocprof_compute is ALSO ordered
+  # after those steps, so in practice pandas is already present and >=3 here.)
+  if [ "$rc" -eq 3 ]; then
+    why="pandas not yet installed"
+  else
+    why="pandas ${ver} (>=3) breaks rocprof-compute's CSV converter (Agent_Id StringDtype)"
+  fi
+
   if [ "$CHECK_ONLY" -eq 1 ]; then
-    warn "rocprof-compute: pandas ${ver} (>=3) breaks rocprof-compute's CSV converter (Agent_Id StringDtype); check-only — would pin 'pandas>=2.2.3,<3'. Until fixed, forge profiling degrades to the PMC path."
+    warn "rocprof-compute: ${why}; check-only — would pin 'pandas>=2.2.3,<3'. Until fixed, forge profiling degrades to the PMC path."
     return 0
   fi
   if [ "$DRY_RUN" -eq 1 ]; then
-    log "would run: ${PYTHON} -m pip install 'pandas>=2.2.3,<3'  (rocprof-compute pandas>=3 incompatibility)"
+    log "would run: ${PYTHON} -m pip install 'pandas>=2.2.3,<3'  (${why})"
     return 0
   fi
 
-  log "rocprof-compute: pandas ${ver} (>=3) incompatible with rocprof-compute's CSV converter; pinning to 'pandas>=2.2.3,<3'"
+  log "rocprof-compute: ${why}; installing 'pandas>=2.2.3,<3'"
   "$PYTHON" -m pip install --quiet "${PIP_EXTRA[@]}" 'pandas>=2.2.3,<3' \
-    || warn "rocprof-compute: 'pip install pandas<3' failed; forge profiling will stay on the PMC path. Check pip/network."
+    || warn "rocprof-compute: 'pip install pandas>=2.2.3,<3' failed; forge profiling will stay on the PMC path. Check pip/network."
 
   # Re-check under the SAME interpreter so the logged outcome reflects reality.
   if ver="$("$PYTHON" - <<'PY'
@@ -865,24 +867,27 @@ PY
   if [ "$rc" -eq 0 ]; then
     log "rocprof-compute: pandas pinned OK to ${ver}; forge profiling can use rocprof-compute (roofline)"
   else
-    warn "rocprof-compute: pandas still incompatible after pin (version='${ver}', rc=${rc}); forge profiling will degrade to the PMC path. A later install step may be re-pulling pandas>=3 — pin it after that step or via a constraints file."
+    warn "rocprof-compute: pandas still incompatible after pin (version='${ver}', rc=${rc}); forge profiling will degrade to the PMC path."
   fi
   return 0
 }
 
 ensure_rocprof_compute() {
-  # Gate exactly as requested: only when the forge backend is selected AND a
-  # FORGE_PATH was supplied. rocprof-compute is useless outside forge profiling,
-  # so unlike ensure_kernel_agents (which gates on checkout only) we skip the
-  # ~11 MB apt install entirely for geak-only runs.
-  if ! _forge_backend_selected; then
-    log "rocprof-compute: forge backend not selected (KERNEL_OPT_BACKEND_ORDER='${KERNEL_OPT_BACKEND_ORDER:-}'); skipping"
+  # Gate on the KernelForge checkout ONLY (via _kernel_forge_root, mirroring
+  # ensure_kernel_agents), NOT on KERNEL_OPT_BACKEND_ORDER. install.sh runs at
+  # setup time under the default geak backend — the carrier sets
+  # KERNEL_OPT_BACKEND_ORDER=forge only later on the optimize command, AFTER
+  # install.sh has finished (_incontainer.sh) — so a backend gate here would skip
+  # the install and a later forge session would still profile on the PMC path.
+  # rocprof-compute (~11 MB) + pandas<3 are only useful for forge but harmless
+  # otherwise (pandas<3 is conflict-free), so keying on the checkout is the safe,
+  # ordering-independent choice. The backend value is logged for context only.
+  local root
+  if ! root="$(_kernel_forge_root)"; then
+    log "rocprof-compute: FORGE_PATH not set / no KernelForge checkout there; skipping optional roofline-profiling deps (forge, if enabled later, uses the PMC fallback)"
     return 0
   fi
-  if [ -z "${FORGE_PATH:-}" ]; then
-    log "rocprof-compute: forge selected but FORGE_PATH unset; skipping (forge profiling will use the PMC fallback)"
-    return 0
-  fi
+  log "rocprof-compute: KernelForge checkout present at ${root} (KERNEL_OPT_BACKEND_ORDER='${KERNEL_OPT_BACKEND_ORDER:-}'); ensuring roofline profiling deps"
 
   local rocm_root base
   rocm_root="${ROCM_PATH:-/opt/rocm}"
@@ -903,25 +908,27 @@ ensure_rocprof_compute() {
   else
     log "installing rocprofiler-compute (forge profiling backend) via apt into ${rocm_root}"
     # Fail-soft throughout: never let apt failures (locked dpkg, offline mirror,
-    # missing package) abort the install. Try a plain install first; if the
-    # package index is stale, refresh once and retry.
+    # missing package) abort the install. Capture output to a log so a failure is
+    # diagnosable (do not swallow apt errors). Try once, refresh index, retry.
+    local apt_log="${TMPDIR:-/tmp}/rocpc_apt_$$.log"
     export DEBIAN_FRONTEND=noninteractive
-    if ! apt-get install -y --no-install-recommends rocprofiler-compute >/dev/null 2>&1; then
-      apt-get update -qq >/dev/null 2>&1 || true
-      apt-get install -y --no-install-recommends rocprofiler-compute >/dev/null 2>&1 || true
+    if ! apt-get install -y --no-install-recommends rocprofiler-compute >"$apt_log" 2>&1; then
+      apt-get update -qq >>"$apt_log" 2>&1 || true
+      apt-get install -y --no-install-recommends rocprofiler-compute >>"$apt_log" 2>&1 || true
     fi
     # Verify against the SAME path KernelForge's resolve_rocpc() checks.
     if [ -f "$base" ]; then
       log "rocprof-compute installed OK: ${base} present"
     else
-      warn "rocprof-compute install did not produce ${base}; forge profiling will degrade to the PMC path (no roofline; optimization-potential estimable=NO). Check apt access to the ROCm repo and the rocprofiler-compute package for this ROCm version."
+      warn "rocprof-compute install did not produce ${base}; forge profiling will degrade to the PMC path (no roofline; optimization-potential estimable=NO). apt output tail (check ROCm repo access / package name for this ROCm version):"
+      tail -n 6 "$apt_log" 2>/dev/null | while IFS= read -r _ln; do warn "  apt| ${_ln}"; done
     fi
+    rm -f "$apt_log" 2>/dev/null || true
   fi
 
-  # --- Step 2: make pandas compatible with rocprof-compute's CSV converter ---
-  # Only meaningful once the tool is present (otherwise forge is on PMC anyway,
-  # and pandas>=3 is fine for everything else). In check/dry-run we still surface
-  # the pandas dependency so the plan is visible even before the tool is there.
+  # --- Step 2: pin pandas<3 for rocprof-compute's CSV converter ---
+  # Run when the tool is present (else forge is on PMC anyway), or in check/dry-
+  # run to surface the plan even before the tool is there.
   if [ -f "$base" ] || [ "$CHECK_ONLY" -eq 1 ] || [ "$DRY_RUN" -eq 1 ]; then
     _ensure_pandas_lt3_for_rocpc
   fi
@@ -1339,7 +1346,6 @@ chain_kernel_agent() {
 ensure_inference_optimizer
 ensure_forge_gemm_tune
 ensure_kernel_agents
-ensure_rocprof_compute
 ensure_langfuse_when_enabled
 # Hold the install lock for the whole mirror-mutating region (Magpie /
 # InferenceX clones + the chained kernel-agent GEAK/TraceLens clones).
@@ -1372,6 +1378,13 @@ if [ "$HYPERLOOM_BENCHMARK_BACKEND_LC" != "bypass" ]; then
 fi
 ensure_bench_serving_deps
 ensure_xdit_quality_deps
+# rocprof-compute + pandas<3 pin AFTER the pandas-pulling steps above
+# (ensure_bench_serving_deps / ensure_xdit_quality_deps drag pandas in via
+# datasets/evaluate). Running last means the pandas<3 pin has the final say and
+# is not clobbered by a later unconstrained `pip install pandas`. Gated on the
+# KernelForge checkout, not the backend, so it applies to the default-geak
+# install that a later forge session inherits.
+ensure_rocprof_compute
 chain_kernel_agent
 # tree-reform.MD P2.5: framework-agent was promoted into
 # src/hyperloom/agents/framework/ (single hyperloom distribution), so the

--- a/src/hyperloom/inference_optimizer/assets/install.sh
+++ b/src/hyperloom/inference_optimizer/assets/install.sh
@@ -933,7 +933,14 @@ ensure_rocprof_compute() {
       log "rocprof-compute installed OK: ${base} present"
     else
       warn "rocprof-compute install did not produce ${base}; forge profiling will degrade to the PMC path (no roofline; optimization-potential estimable=NO). apt output tail (check ROCm repo access / package name for this ROCm version):"
-      tail -n 6 "$apt_log" 2>/dev/null | while IFS= read -r _ln; do warn "  apt| ${_ln}"; done
+      # Guard BOTH the missing-file case and pipefail: if the redirect above never
+      # created $apt_log (e.g. an unwritable TMPDIR), a bare `tail | while` exits
+      # non-zero and set -euo pipefail would abort install.sh — the very
+      # fail-soft invariant this diagnostic exists to serve. Only tail when the
+      # file exists, and swallow any residual pipe failure.
+      if [ -f "$apt_log" ]; then
+        tail -n 6 "$apt_log" 2>/dev/null | while IFS= read -r _ln; do warn "  apt| ${_ln}"; done || true
+      fi
     fi
     rm -f "$apt_log" 2>/dev/null || true
   fi

--- a/src/hyperloom/inference_optimizer/assets/install.sh
+++ b/src/hyperloom/inference_optimizer/assets/install.sh
@@ -775,6 +775,159 @@ ensure_kernel_agents() {
     || die "kernel_agents import failed after install from ${root}"
 }
 
+# --- 1d. rocprof-compute (rocprofiler-compute) for the forge profiling stage ---
+# forge-loop's profiling stage prefers rocprof-compute (roofline / speed-of-light)
+# and only falls back to the thin rocprofv3 "PMC" path when the tool is absent.
+# KernelForge's resolve_rocpc() looks for the tool at
+# `<ROCM_PATH>/libexec/rocprofiler-compute/rocprof_compute_base.py`; the stock
+# vllm/sglang ROCm serving images ship rocprofv3 but NOT rocprofiler-compute, so
+# every forge run silently degrades to PMC (no roofline -> optimization-potential
+# is always estimable=NO). The Python deps rocprof-compute needs are already
+# pulled in by the KernelForge root install (its base deps cover dash/kaleido/
+# matplotlib/plotille/tqdm); the only missing piece is the system tool itself,
+# which pip cannot provide — it comes from the ROCm apt package.
+#
+# This step is FAIL-SOFT by design: forge still works on the PMC path, so a
+# missing/failed rocprof-compute must NOT abort the install. Every branch logs
+# (with the concrete "profiling will degrade to PMC" consequence) so the
+# post-mortem observability question — "why did this run profile on PMC?" — is
+# answerable from the install log alone.
+_forge_backend_selected() {
+  # True when the kernel-rewrite ladder includes the forge backend. Substring
+  # match (case-insensitive) tolerates "forge", "geak,forge", "geak forge", etc.
+  case "$(printf '%s' "${KERNEL_OPT_BACKEND_ORDER:-}" | tr '[:upper:]' '[:lower:]')" in
+    *forge*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# rocprof-compute's CSV converter (utils/utils.py, v3->v2) assumes pandas'
+# legacy 'object' string dtype. pandas>=3.0 defaults future.infer_string=True,
+# so the rocprofv3 counter CSV's Agent_Id ("Agent 9") is read as the new
+# StringDtype; the converter's `dtype == "object"` guard then skips its int
+# coercion and the subsequent Agent_Id<->Node_Id merge dies ("merge on str and
+# int64"). Every counter file is dropped -> rocprof-compute reports "No
+# profiling data found" -> forge silently degrades to the PMC path (no roofline;
+# optimization-potential estimable=NO). rocprof-compute runs under the forge
+# interpreter (its sys.executable == $PYTHON here), so pinning pandas<3 in THIS
+# interpreter is exactly what the tool imports. Nothing else in the stack needs
+# pandas>=3 (verified: no installed dist requires it), so <3 is conflict-free.
+# Fail-soft: a pin failure must NOT abort the install — forge still runs on PMC.
+_ensure_pandas_lt3_for_rocpc() {
+  local ver rc
+  # Decide in Python (robust vs. bash numeric parsing under set -euo pipefail).
+  # exit 0 => pandas <3 (ok); exit 1 => pandas >=3 (incompatible); 3 => absent.
+  if ver="$("$PYTHON" - <<'PY'
+import sys
+try:
+    import pandas
+except Exception:
+    sys.exit(3)
+print(pandas.__version__)
+sys.exit(1 if int(pandas.__version__.split(".")[0]) >= 3 else 0)
+PY
+)"; then rc=0; else rc=$?; fi
+
+  if [ "$rc" -eq 3 ]; then
+    log "rocprof-compute: pandas not importable under ${PYTHON}; skipping pandas-compat pin"
+    return 0
+  fi
+  if [ "$rc" -eq 0 ]; then
+    log "rocprof-compute: pandas ${ver} is <3 (compatible with rocprof-compute's CSV converter); no pin needed"
+    return 0
+  fi
+
+  # rc == 1: pandas >=3 -> breaks rocprof-compute's v3->v2 CSV conversion.
+  if [ "$CHECK_ONLY" -eq 1 ]; then
+    warn "rocprof-compute: pandas ${ver} (>=3) breaks rocprof-compute's CSV converter (Agent_Id StringDtype); check-only — would pin 'pandas>=2.2.3,<3'. Until fixed, forge profiling degrades to the PMC path."
+    return 0
+  fi
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "would run: ${PYTHON} -m pip install 'pandas>=2.2.3,<3'  (rocprof-compute pandas>=3 incompatibility)"
+    return 0
+  fi
+
+  log "rocprof-compute: pandas ${ver} (>=3) incompatible with rocprof-compute's CSV converter; pinning to 'pandas>=2.2.3,<3'"
+  "$PYTHON" -m pip install --quiet "${PIP_EXTRA[@]}" 'pandas>=2.2.3,<3' \
+    || warn "rocprof-compute: 'pip install pandas<3' failed; forge profiling will stay on the PMC path. Check pip/network."
+
+  # Re-check under the SAME interpreter so the logged outcome reflects reality.
+  if ver="$("$PYTHON" - <<'PY'
+import sys
+try:
+    import pandas
+except Exception:
+    sys.exit(3)
+print(pandas.__version__)
+sys.exit(1 if int(pandas.__version__.split(".")[0]) >= 3 else 0)
+PY
+)"; then rc=0; else rc=$?; fi
+  if [ "$rc" -eq 0 ]; then
+    log "rocprof-compute: pandas pinned OK to ${ver}; forge profiling can use rocprof-compute (roofline)"
+  else
+    warn "rocprof-compute: pandas still incompatible after pin (version='${ver}', rc=${rc}); forge profiling will degrade to the PMC path. A later install step may be re-pulling pandas>=3 — pin it after that step or via a constraints file."
+  fi
+  return 0
+}
+
+ensure_rocprof_compute() {
+  # Gate exactly as requested: only when the forge backend is selected AND a
+  # FORGE_PATH was supplied. rocprof-compute is useless outside forge profiling,
+  # so unlike ensure_kernel_agents (which gates on checkout only) we skip the
+  # ~11 MB apt install entirely for geak-only runs.
+  if ! _forge_backend_selected; then
+    log "rocprof-compute: forge backend not selected (KERNEL_OPT_BACKEND_ORDER='${KERNEL_OPT_BACKEND_ORDER:-}'); skipping"
+    return 0
+  fi
+  if [ -z "${FORGE_PATH:-}" ]; then
+    log "rocprof-compute: forge selected but FORGE_PATH unset; skipping (forge profiling will use the PMC fallback)"
+    return 0
+  fi
+
+  local rocm_root base
+  rocm_root="${ROCM_PATH:-/opt/rocm}"
+  base="${rocm_root%/}/libexec/rocprofiler-compute/rocprof_compute_base.py"
+
+  # --- Step 1: ensure the rocprof-compute tool exists ---
+  # It is a ROCm system package (pip cannot provide it). Idempotent: skip the apt
+  # install when the file KernelForge's resolve_rocpc() checks is already present.
+  if [ -f "$base" ]; then
+    log "rocprof-compute already present at ${base}"
+  elif [ "$CHECK_ONLY" -eq 1 ]; then
+    warn "rocprof-compute not found at ${base} (check-only; would apt-get install rocprofiler-compute). Forge profiling would degrade to the PMC path."
+  elif [ "$DRY_RUN" -eq 1 ]; then
+    log "would run: apt-get install -y --no-install-recommends rocprofiler-compute"
+  elif ! command -v apt-get >/dev/null 2>&1; then
+    # No apt (RHEL/Alpine/etc.): cannot install the system package here.
+    warn "rocprof-compute: apt-get unavailable; cannot install rocprofiler-compute. Forge profiling will degrade to the PMC path (no roofline; optimization-potential estimable=NO). Bake rocprofiler-compute into the image to enable roofline profiling."
+  else
+    log "installing rocprofiler-compute (forge profiling backend) via apt into ${rocm_root}"
+    # Fail-soft throughout: never let apt failures (locked dpkg, offline mirror,
+    # missing package) abort the install. Try a plain install first; if the
+    # package index is stale, refresh once and retry.
+    export DEBIAN_FRONTEND=noninteractive
+    if ! apt-get install -y --no-install-recommends rocprofiler-compute >/dev/null 2>&1; then
+      apt-get update -qq >/dev/null 2>&1 || true
+      apt-get install -y --no-install-recommends rocprofiler-compute >/dev/null 2>&1 || true
+    fi
+    # Verify against the SAME path KernelForge's resolve_rocpc() checks.
+    if [ -f "$base" ]; then
+      log "rocprof-compute installed OK: ${base} present"
+    else
+      warn "rocprof-compute install did not produce ${base}; forge profiling will degrade to the PMC path (no roofline; optimization-potential estimable=NO). Check apt access to the ROCm repo and the rocprofiler-compute package for this ROCm version."
+    fi
+  fi
+
+  # --- Step 2: make pandas compatible with rocprof-compute's CSV converter ---
+  # Only meaningful once the tool is present (otherwise forge is on PMC anyway,
+  # and pandas>=3 is fine for everything else). In check/dry-run we still surface
+  # the pandas dependency so the plan is visible even before the tool is there.
+  if [ -f "$base" ] || [ "$CHECK_ONLY" -eq 1 ] || [ "$DRY_RUN" -eq 1 ]; then
+    _ensure_pandas_lt3_for_rocpc
+  fi
+  return 0
+}
+
 # --- 2. Magpie ---
 # The install state is the pip-installed package specified by
 # $MAGPIE_PACKAGE_SPEC. $MAGPIE_PATH remains exported for runtime code that
@@ -1186,6 +1339,7 @@ chain_kernel_agent() {
 ensure_inference_optimizer
 ensure_forge_gemm_tune
 ensure_kernel_agents
+ensure_rocprof_compute
 ensure_langfuse_when_enabled
 # Hold the install lock for the whole mirror-mutating region (Magpie /
 # InferenceX clones + the chained kernel-agent GEAK/TraceLens clones).

--- a/src/hyperloom/inference_optimizer/assets/install.sh
+++ b/src/hyperloom/inference_optimizer/assets/install.sh
@@ -802,17 +802,35 @@ ensure_kernel_agents() {
 # optimization-potential estimable=NO). Nothing else in the stack needs
 # pandas>=3 (verified: no installed dist requires it), so <3 is conflict-free.
 #
-# rocprof-compute runs under the forge interpreter; KernelForge's resolve_rocpc()
-# probes sys.executable, then /usr/bin/python3, then `python3` on PATH. We pin
-# pandas in $PYTHON, which is the forge interpreter here; if a deployment splits
-# those, pin pandas<3 in whichever interpreter forge actually runs.
+# rocprof-compute runs under the interpreter KernelForge's resolve_rocpc() picks:
+# it probes sys.executable, then /usr/bin/python3, then `python3` on PATH, and
+# uses the FIRST that can run `rocprof-compute --help`. We mirror that probe and
+# pin pandas in exactly THAT interpreter (not blindly $PYTHON), so the pin cannot
+# be a silent no-op and the log names the env that will actually run the tool.
 #
 # Fail-soft: a pin failure must NOT abort the install — forge still runs on PMC.
-_ensure_pandas_lt3_for_rocpc() {
-  local ver rc why
-  # Decide in Python (robust vs. bash numeric parsing under set -euo pipefail).
-  # exit 0 => pandas <3 (ok); exit 1 => pandas >=3 (too new); 3 => absent.
-  if ver="$("$PYTHON" - <<'PY'
+
+# Echo the interpreter resolve_rocpc() will run rocprof-compute under: the first
+# of $PYTHON, /usr/bin/python3, PATH python3 that can run `<libexec>/rocprof-
+# compute --help`. Returns non-zero with no output when none qualifies.
+_rocpc_effective_python() {
+  local libexec="$1" py seen=" "
+  for py in "$PYTHON" /usr/bin/python3 "$(command -v python3 2>/dev/null || true)"; do
+    [ -n "$py" ] || continue
+    case "$seen" in *" $py "*) continue ;; esac
+    seen="${seen}${py} "
+    if "$py" "${libexec}/rocprof-compute" --help >/dev/null 2>&1; then
+      printf '%s\n' "$py"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Print pandas version under $1 and exit: 0 => <3 (ok); 1 => >=3; 3 => absent.
+# Decided in Python (robust vs. bash numeric parsing under set -euo pipefail).
+_pandas_major_ge3() {
+  "$1" - <<'PY'
 import sys
 try:
     import pandas
@@ -821,19 +839,21 @@ except Exception:
 print(pandas.__version__)
 sys.exit(1 if int(pandas.__version__.split(".")[0]) >= 3 else 0)
 PY
-)"; then rc=0; else rc=$?; fi
+}
+
+_ensure_pandas_lt3_for_rocpc() {
+  local py="${1:-$PYTHON}" ver rc why
+  if ver="$(_pandas_major_ge3 "$py")"; then rc=0; else rc=$?; fi
 
   if [ "$rc" -eq 0 ]; then
-    log "rocprof-compute: pandas ${ver} is <3 (compatible with rocprof-compute's CSV converter); no pin needed"
+    log "rocprof-compute: pandas ${ver} is <3 under ${py} (compatible with rocprof-compute's CSV converter); no pin needed"
     return 0
   fi
 
-  # rc==1 (pandas>=3) OR rc==3 (pandas absent): both need a pinned pandas<3 in
-  # this interpreter. Installing it now also forecloses a LATER unconstrained
-  # `pip install pandas` (e.g. datasets/evaluate pulled by ensure_bench_serving_
-  # deps / ensure_xdit_quality_deps) dragging pandas>=3 back in — pip will not
-  # upgrade an already-satisfying 2.x. (ensure_rocprof_compute is ALSO ordered
-  # after those steps, so in practice pandas is already present and >=3 here.)
+  # rc==1 (pandas>=3) OR rc==3 (pandas absent): pin pandas<3 in the interpreter
+  # that runs rocprof-compute. This runs LAST in install.sh (after
+  # chain_kernel_agent — the final pip-installing step), so no later step can
+  # re-pull pandas>=3, and the re-check below is the final, truthful state.
   if [ "$rc" -eq 3 ]; then
     why="pandas not yet installed"
   else
@@ -841,33 +861,25 @@ PY
   fi
 
   if [ "$CHECK_ONLY" -eq 1 ]; then
-    warn "rocprof-compute: ${why}; check-only — would pin 'pandas>=2.2.3,<3'. Until fixed, forge profiling degrades to the PMC path."
+    warn "rocprof-compute: ${why} (interpreter ${py}); check-only — would pin 'pandas>=2.2.3,<3'. Until fixed, forge profiling degrades to the PMC path."
     return 0
   fi
   if [ "$DRY_RUN" -eq 1 ]; then
-    log "would run: ${PYTHON} -m pip install 'pandas>=2.2.3,<3'  (${why})"
+    log "would run: ${py} -m pip install 'pandas>=2.2.3,<3'  (${why})"
     return 0
   fi
 
-  log "rocprof-compute: ${why}; installing 'pandas>=2.2.3,<3'"
-  "$PYTHON" -m pip install --quiet "${PIP_EXTRA[@]}" 'pandas>=2.2.3,<3' \
-    || warn "rocprof-compute: 'pip install pandas>=2.2.3,<3' failed; forge profiling will stay on the PMC path. Check pip/network."
+  log "rocprof-compute: ${why}; installing 'pandas>=2.2.3,<3' into ${py}"
+  "$py" -m pip install --quiet "${PIP_EXTRA[@]}" 'pandas>=2.2.3,<3' \
+    || warn "rocprof-compute: 'pip install pandas>=2.2.3,<3' failed under ${py}; forge profiling will stay on the PMC path. Check pip/network."
 
-  # Re-check under the SAME interpreter so the logged outcome reflects reality.
-  if ver="$("$PYTHON" - <<'PY'
-import sys
-try:
-    import pandas
-except Exception:
-    sys.exit(3)
-print(pandas.__version__)
-sys.exit(1 if int(pandas.__version__.split(".")[0]) >= 3 else 0)
-PY
-)"; then rc=0; else rc=$?; fi
+  # Re-check the SAME interpreter, at the END of install.sh, so the logged
+  # outcome reflects what forge will actually import at runtime.
+  if ver="$(_pandas_major_ge3 "$py")"; then rc=0; else rc=$?; fi
   if [ "$rc" -eq 0 ]; then
-    log "rocprof-compute: pandas pinned OK to ${ver}; forge profiling can use rocprof-compute (roofline)"
+    log "rocprof-compute: pandas ${ver} in ${py}; forge profiling can use rocprof-compute (roofline)"
   else
-    warn "rocprof-compute: pandas still incompatible after pin (version='${ver}', rc=${rc}); forge profiling will degrade to the PMC path."
+    warn "rocprof-compute: pandas still incompatible in ${py} (version='${ver}', rc=${rc}); forge profiling will degrade to the PMC path."
   fi
   return 0
 }
@@ -927,10 +939,21 @@ ensure_rocprof_compute() {
   fi
 
   # --- Step 2: pin pandas<3 for rocprof-compute's CSV converter ---
-  # Run when the tool is present (else forge is on PMC anyway), or in check/dry-
-  # run to surface the plan even before the tool is there.
-  if [ -f "$base" ] || [ "$CHECK_ONLY" -eq 1 ] || [ "$DRY_RUN" -eq 1 ]; then
-    _ensure_pandas_lt3_for_rocpc
+  # Pin in the interpreter resolve_rocpc() will actually run the tool under (probe
+  # mirrors KernelForge). Runs when the tool is present; in check/dry-run we
+  # surface the plan against $PYTHON even before the tool exists.
+  if [ -f "$base" ]; then
+    local rocpc_py
+    if rocpc_py="$(_rocpc_effective_python "$(dirname "$base")")"; then
+      [ "$rocpc_py" = "$PYTHON" ] \
+        || log "rocprof-compute: resolve_rocpc will run under ${rocpc_py} (not \$PYTHON=${PYTHON}); pinning pandas there"
+    else
+      rocpc_py="$PYTHON"
+      warn "rocprof-compute: could not confirm which interpreter runs 'rocprof-compute --help'; pinning pandas in \$PYTHON=${PYTHON} (best effort — verify forge's runtime interpreter has pandas<3)"
+    fi
+    _ensure_pandas_lt3_for_rocpc "$rocpc_py"
+  elif [ "$CHECK_ONLY" -eq 1 ] || [ "$DRY_RUN" -eq 1 ]; then
+    _ensure_pandas_lt3_for_rocpc "$PYTHON"
   fi
   return 0
 }
@@ -1378,14 +1401,14 @@ if [ "$HYPERLOOM_BENCHMARK_BACKEND_LC" != "bypass" ]; then
 fi
 ensure_bench_serving_deps
 ensure_xdit_quality_deps
-# rocprof-compute + pandas<3 pin AFTER the pandas-pulling steps above
-# (ensure_bench_serving_deps / ensure_xdit_quality_deps drag pandas in via
-# datasets/evaluate). Running last means the pandas<3 pin has the final say and
-# is not clobbered by a later unconstrained `pip install pandas`. Gated on the
-# KernelForge checkout, not the backend, so it applies to the default-geak
-# install that a later forge session inherits.
-ensure_rocprof_compute
 chain_kernel_agent
+# rocprof-compute + pandas<3 pin runs LAST — strictly AFTER every pip-installing
+# step (chain_kernel_agent included; nothing below installs packages). This makes
+# the pandas<3 pin the final word (no later `pip install` can re-pull pandas>=3)
+# and its own re-check the truthful end state, not a premature false-positive.
+# Gated on the KernelForge checkout (not the backend): the default-geak install a
+# later forge session inherits still gets rocprof-compute + pandas<3.
+ensure_rocprof_compute
 # tree-reform.MD P2.5: framework-agent was promoted into
 # src/hyperloom/agents/framework/ (single hyperloom distribution), so the
 # `fa` CLI is already installed by ensure_inference_optimizer() above; no

--- a/src/hyperloom/inference_optimizer/assets/install.sh
+++ b/src/hyperloom/inference_optimizer/assets/install.sh
@@ -808,11 +808,23 @@ ensure_kernel_agents() {
 # pin pandas in exactly THAT interpreter (not blindly $PYTHON), so the pin cannot
 # be a silent no-op and the log names the env that will actually run the tool.
 #
+# Two known, accepted deltas vs. resolve_rocpc() (neither is a correctness bug —
+# both fall back safely and only affect which interpreter gets pinned):
+#   * First candidate: we probe $PYTHON where resolve_rocpc probes the RUNTIME
+#     sys.executable. $PYTHON is install-time sys.executable and, in the shared
+#     -venv carrier flow, is the SAME interpreter forge runs under, so they agree.
+#     If a deployment splits install-time and runtime Python, the pin may land on
+#     a non-preferred interpreter — the fallback + warn below make that visible.
+#   * `--help` passing proves rocprof-compute's deps import, NOT that its CSV
+#     conversion works on this pandas; the pandas<3 pin (below) is what closes
+#     that gap. A deeper check (pandas major inside the probe) would belong in
+#     KernelForge's resolve_rocpc(), not here.
+#
 # Fail-soft: a pin failure must NOT abort the install — forge still runs on PMC.
 
 # Echo the interpreter resolve_rocpc() will run rocprof-compute under: the first
-# of $PYTHON, /usr/bin/python3, PATH python3 that can run `<libexec>/rocprof-
-# compute --help`. Returns non-zero with no output when none qualifies.
+# of $PYTHON (install-time sys.executable), /usr/bin/python3, PATH python3 that
+# can run `<libexec>/rocprof-compute --help`. Non-zero + no output if none do.
 _rocpc_effective_python() {
   local libexec="$1" py seen=" "
   for py in "$PYTHON" /usr/bin/python3 "$(command -v python3 2>/dev/null || true)"; do

--- a/src/hyperloom/inference_optimizer/tests/test_install_rocprof_compute.py
+++ b/src/hyperloom/inference_optimizer/tests/test_install_rocprof_compute.py
@@ -154,6 +154,7 @@ def _run(
     pip_rc: int = 0,
     pip_fixes: bool = False,
     probe_rc: int = 0,
+    tmpdir: str | None = None,
     check_only: int = 0,
     dry_run: int = 0,
 ) -> dict:
@@ -196,6 +197,7 @@ export PIP_FIXES="{1 if pip_fixes else 0}"
 export APT_CREATES_TOOL="{1 if apt_creates_tool else 0}"
 export APT_RC="{apt_rc}"
 export PROBE_RC="{probe_rc}"
+{f'export TMPDIR="{tmpdir}"' if tmpdir is not None else "true"}
 {backend_line}
 {forge_line}
 
@@ -307,6 +309,24 @@ def test_failsoft_when_apt_fails_to_produce_tool(tmp_path: Path) -> None:
     assert "apt| " in r["out"], f"apt output tail should be surfaced:\n{r['out']}"
     # No tool -> pandas pin must not run (forge is on PMC anyway).
     assert not r["pip_called"], r["out"]
+
+
+def test_failsoft_when_apt_log_never_created(tmp_path: Path) -> None:
+    # Regression: an unwritable TMPDIR makes the `>"$apt_log"` redirect fail, so
+    # the log is never created. The diagnostic `tail "$apt_log" | while ...` must
+    # NOT abort install.sh under set -euo pipefail (bare pipe + pipefail would).
+    missing_tmp = tmp_path / "no_such_tmpdir"  # deliberately never created
+    r = _run(
+        tmp_path,
+        tool_present=False,
+        apt_available=True,
+        apt_creates_tool=False,
+        tmpdir=str(missing_tmp),
+    )
+    assert r["rc"] == 0 and r["reached_end"], (
+        f"missing apt_log must stay fail-soft (no abort):\n{r['out']}"
+    )
+    assert "did not produce" in r["out"]
 
 
 # --- pandas pin (Step 2) --------------------------------------------------

--- a/src/hyperloom/inference_optimizer/tests/test_install_rocprof_compute.py
+++ b/src/hyperloom/inference_optimizer/tests/test_install_rocprof_compute.py
@@ -110,6 +110,10 @@ if [ "${{1:-}}" = "-" ]; then
     *) echo "3.0.3"; exit 1 ;;
   esac
 fi
+# `<libexec>/rocprof-compute --help` probe from _rocpc_effective_python.
+case "${{1:-}}" in
+  *rocprof-compute) exit ${{PROBE_RC:-0}} ;;
+esac
 exit 0
 """
     py = tmp_path / "fake_python.sh"
@@ -149,6 +153,7 @@ def _run(
     pandas_state: str = "v3",
     pip_rc: int = 0,
     pip_fixes: bool = False,
+    probe_rc: int = 0,
     check_only: int = 0,
     dry_run: int = 0,
 ) -> dict:
@@ -190,10 +195,15 @@ export PIP_RC="{pip_rc}"
 export PIP_FIXES="{1 if pip_fixes else 0}"
 export APT_CREATES_TOOL="{1 if apt_creates_tool else 0}"
 export APT_RC="{apt_rc}"
+export PROBE_RC="{probe_rc}"
 {backend_line}
 {forge_line}
 
 {_extract_fn("_kernel_forge_root")}
+
+{_extract_fn("_rocpc_effective_python")}
+
+{_extract_fn("_pandas_major_ge3")}
 
 {_extract_fn("_ensure_pandas_lt3_for_rocpc")}
 
@@ -307,7 +317,7 @@ def test_pins_pandas_when_ge3(tmp_path: Path) -> None:
     assert r["rc"] == 0 and r["reached_end"], r["out"]
     assert r["pip_called"], f"pandas<3 pin should have run:\n{r['out']}"
     assert "installing 'pandas>=2.2.3,<3'" in r["out"]
-    assert "pandas pinned OK" in r["out"]
+    assert "forge profiling can use rocprof-compute (roofline)" in r["out"]
 
 
 def test_no_pin_when_pandas_lt3(tmp_path: Path) -> None:
@@ -325,7 +335,16 @@ def test_installs_pandas_when_absent_precludes_later_3x(tmp_path: Path) -> None:
     assert r["rc"] == 0 and r["reached_end"], r["out"]
     assert r["pip_called"], f"pandas<3 should be installed when absent:\n{r['out']}"
     assert "pandas not yet installed" in r["out"]
-    assert "pandas pinned OK" in r["out"]
+    assert "forge profiling can use rocprof-compute (roofline)" in r["out"]
+
+
+def test_probe_fallback_warns_but_still_pins(tmp_path: Path) -> None:
+    # If no candidate interpreter can run `rocprof-compute --help`, fall back to
+    # $PYTHON (best effort) with a warning — but still pin, never abort.
+    r = _run(tmp_path, tool_present=True, pandas_state="v3", pip_fixes=True, probe_rc=1)
+    assert r["rc"] == 0 and r["reached_end"], r["out"]
+    assert "could not confirm which interpreter" in r["out"]
+    assert r["pip_called"], f"pin must still run on the $PYTHON fallback:\n{r['out']}"
 
 
 def test_failsoft_when_pip_pin_fails(tmp_path: Path) -> None:
@@ -333,7 +352,7 @@ def test_failsoft_when_pip_pin_fails(tmp_path: Path) -> None:
     r = _run(tmp_path, tool_present=True, pandas_state="v3", pip_rc=5, pip_fixes=False)
     assert r["rc"] == 0 and r["reached_end"], r["out"]
     assert r["pip_called"], r["out"]
-    assert "still incompatible after pin" in r["out"]
+    assert "pandas still incompatible in" in r["out"]
 
 
 # --- CHECK_ONLY / DRY_RUN honour ------------------------------------------
@@ -364,14 +383,27 @@ def test_static_gated_on_checkout_not_backend() -> None:
     assert "backend not selected" not in body
 
 
-def test_static_call_ordered_after_pandas_pullers() -> None:
+def test_static_call_ordered_after_all_pip_steps() -> None:
     text = IO_INSTALL.read_text(encoding="utf-8")
-    # The bare top-level call must run after the deps that pull pandas, so the
-    # pandas<3 pin has the final say.
-    bench = text.rindex("\nensure_bench_serving_deps\n")
-    xdit = text.rindex("\nensure_xdit_quality_deps\n")
+    # The bare top-level call must run after EVERY pip-installing step (incl.
+    # chain_kernel_agent), so no later step can re-pull pandas>=3 and the pin's
+    # re-check is the truthful final state.
     call = text.rindex("\nensure_rocprof_compute\n")
-    assert call > bench and call > xdit, "ensure_rocprof_compute must be called last"
+    for earlier in (
+        "\nensure_bench_serving_deps\n",
+        "\nensure_xdit_quality_deps\n",
+        "\nchain_kernel_agent\n",
+    ):
+        assert call > text.rindex(earlier), f"ensure_rocprof_compute must run after {earlier.strip()}"
+
+
+def test_static_effective_python_probe_mirrors_resolve_rocpc() -> None:
+    body = _extract_fn("_rocpc_effective_python")
+    # Same candidate order KernelForge's resolve_rocpc() uses.
+    assert '"$PYTHON"' in body
+    assert "/usr/bin/python3" in body
+    assert "command -v python3" in body
+    assert "rocprof-compute" in body and "--help" in body
 
 
 def test_static_installs_rocprofiler_compute_and_verifies_resolve_path() -> None:

--- a/src/hyperloom/inference_optimizer/tests/test_install_rocprof_compute.py
+++ b/src/hyperloom/inference_optimizer/tests/test_install_rocprof_compute.py
@@ -14,10 +14,14 @@ unusable. Two things break it on a stock ROCm serving image:
      ``object`` string dtype; pandas>=3.0 (future.infer_string=True) makes its
      Agent_Id merge fail -> "No profiling data found" -> silent PMC fallback.
 
-``ensure_rocprof_compute()`` (gated on the forge backend being selected AND
-FORGE_PATH set) apt-installs the tool and pins ``pandas<3`` in the forge
-interpreter. Every branch is FAIL-SOFT: a missing tool / failed apt / failed pin
-logs and returns 0 (forge still runs on PMC) — it must never abort install.sh.
+``ensure_rocprof_compute()`` apt-installs the tool and pins ``pandas<3`` in the
+forge interpreter. Crucially it is gated on the **KernelForge checkout**
+(``_kernel_forge_root`` / FORGE_PATH), NOT on ``KERNEL_OPT_BACKEND_ORDER``:
+install.sh runs at setup time under the default geak backend and the carrier only
+sets ``KERNEL_OPT_BACKEND_ORDER=forge`` later on the optimize command, so a
+backend gate would skip the install and a later forge session would still profile
+on PMC. Every branch is FAIL-SOFT: a missing tool / failed apt / failed pin logs
+and returns 0 (forge still runs on PMC) — it must never abort install.sh.
 
 Regression cover for the 2026-07-30 investigation where every forge run profiled
 on PMC (optimization-potential estimable=NO): first because rocprof-compute was
@@ -69,6 +73,18 @@ def _curated_bindir(tmp_path: Path, *, with_apt: bool, apt_stub: Path | None) ->
     return bindir
 
 
+def _make_checkout(tmp_path: Path, *, with_kernel_agents: bool) -> Path:
+    """A fake KernelForge checkout root that _kernel_forge_root() probes for."""
+    root = tmp_path / "KernelForge"
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "pyproject.toml").write_text("[project]\nname = 'kernel-agents'\n", encoding="utf-8")
+    if with_kernel_agents:
+        ka = root / "src" / "kernel_agents"
+        ka.mkdir(parents=True, exist_ok=True)
+        (ka / "__init__.py").write_text("", encoding="utf-8")
+    return root
+
+
 def _fake_python(tmp_path: Path) -> Path:
     """Stub ``$PYTHON``.
 
@@ -107,6 +123,8 @@ def _fake_apt(tmp_path: Path, tool_base: Path) -> Path:
     apt_marker = tmp_path / APT_MARKER
     body = f"""#!/usr/bin/env bash
 : > "{apt_marker}"
+# Emit a diagnostic line (like real apt) so the caller's failure tail has content.
+echo "apt-get $*: E: simulated apt output" >&2
 if [ "${{APT_CREATES_TOOL:-0}}" = "1" ] && [ "${{1:-}}" = "install" ]; then
   mkdir -p "{tool_base.parent}"
   : > "{tool_base}"
@@ -122,8 +140,8 @@ exit ${{APT_RC:-0}}
 def _run(
     tmp_path: Path,
     *,
-    backend_order: str | None = "forge",
-    forge_path: str | None = "/some/KernelForge",
+    checkout: str = "valid",  # "valid" | "no_kernel_agents" | "unset"
+    backend_order: str | None = "geak",
     tool_present: bool = False,
     apt_available: bool = True,
     apt_creates_tool: bool = False,
@@ -141,6 +159,12 @@ def _run(
         tool_base.parent.mkdir(parents=True, exist_ok=True)
         tool_base.write_text("", encoding="utf-8")
 
+    if checkout == "unset":
+        forge_line = "unset FORGE_PATH || true"
+    else:
+        root = _make_checkout(tmp_path, with_kernel_agents=(checkout == "valid"))
+        forge_line = f'export FORGE_PATH="{root}"'
+
     fake_py = _fake_python(tmp_path)
     apt_stub = _fake_apt(tmp_path, tool_base)
     bindir = _curated_bindir(tmp_path, with_apt=apt_available, apt_stub=apt_stub)
@@ -149,11 +173,6 @@ def _run(
         f'export KERNEL_OPT_BACKEND_ORDER="{backend_order}"'
         if backend_order is not None
         else "unset KERNEL_OPT_BACKEND_ORDER || true"
-    )
-    forge_line = (
-        f'export FORGE_PATH="{forge_path}"'
-        if forge_path is not None
-        else "unset FORGE_PATH || true"
     )
 
     harness = f"""#!/usr/bin/env bash
@@ -174,7 +193,7 @@ export APT_RC="{apt_rc}"
 {backend_line}
 {forge_line}
 
-{_extract_fn("_forge_backend_selected")}
+{_extract_fn("_kernel_forge_root")}
 
 {_extract_fn("_ensure_pandas_lt3_for_rocpc")}
 
@@ -204,28 +223,45 @@ echo "[harness] reached-end rc=$?"
     }
 
 
-# --- Gate -----------------------------------------------------------------
+# --- Gate: checkout, NOT backend (the ordering fix) -----------------------
 
 
-def test_skip_when_backend_not_forge(tmp_path: Path) -> None:
-    r = _run(tmp_path, backend_order="geak")
+def test_installs_under_default_geak_when_checkout_present(tmp_path: Path) -> None:
+    # THE key regression: install.sh runs under geak (forge is set only later at
+    # optimize time), so a checkout-present geak install MUST still set forge up.
+    r = _run(
+        tmp_path,
+        checkout="valid",
+        backend_order="geak",
+        tool_present=False,
+        apt_creates_tool=True,
+        pandas_state="v3",
+        pip_fixes=True,
+    )
     assert r["rc"] == 0 and r["reached_end"], r["out"]
-    assert not r["apt_called"] and not r["pip_called"], r["out"]
-    assert "forge backend not selected" in r["out"]
-
-
-def test_forge_matched_as_substring_in_ladder(tmp_path: Path) -> None:
-    # "geak,forge" must count as forge selected (ladder ordering).
-    r = _run(tmp_path, backend_order="geak,forge", tool_present=True, pandas_state="v2")
-    assert r["rc"] == 0 and r["reached_end"], r["out"]
+    assert r["apt_called"], f"tool must install even under geak:\n{r['out']}"
+    assert r["pip_called"], f"pandas pin must run even under geak:\n{r['out']}"
     assert "forge backend not selected" not in r["out"]
 
 
-def test_skip_when_forge_but_no_forge_path(tmp_path: Path) -> None:
-    r = _run(tmp_path, backend_order="forge", forge_path=None)
+def test_installs_when_backend_unset(tmp_path: Path) -> None:
+    r = _run(tmp_path, checkout="valid", backend_order=None, tool_present=True, pandas_state="v2")
+    assert r["rc"] == 0 and r["reached_end"], r["out"]
+    assert "KernelForge checkout present" in r["out"]
+
+
+def test_skip_when_forge_path_unset(tmp_path: Path) -> None:
+    r = _run(tmp_path, checkout="unset")
     assert r["rc"] == 0 and r["reached_end"], r["out"]
     assert not r["apt_called"] and not r["pip_called"], r["out"]
-    assert "FORGE_PATH unset" in r["out"]
+    assert "FORGE_PATH not set" in r["out"]
+
+
+def test_skip_when_checkout_lacks_kernel_agents(tmp_path: Path) -> None:
+    r = _run(tmp_path, checkout="no_kernel_agents")
+    assert r["rc"] == 0 and r["reached_end"], r["out"]
+    assert not r["apt_called"] and not r["pip_called"], r["out"]
+    assert "no KernelForge checkout" in r["out"]
 
 
 # --- Tool install (Step 1) ------------------------------------------------
@@ -234,8 +270,7 @@ def test_skip_when_forge_but_no_forge_path(tmp_path: Path) -> None:
 def test_installs_tool_when_absent(tmp_path: Path) -> None:
     r = _run(tmp_path, tool_present=False, apt_creates_tool=True, pandas_state="v2")
     assert r["rc"] == 0 and r["reached_end"], r["out"]
-    assert r["apt_called"], r["out"]
-    assert r["tool_exists"], r["out"]
+    assert r["apt_called"] and r["tool_exists"], r["out"]
     assert "rocprof-compute installed OK" in r["out"]
 
 
@@ -257,9 +292,9 @@ def test_failsoft_when_apt_fails_to_produce_tool(tmp_path: Path) -> None:
     # apt runs but does not create the tool (e.g. package unavailable / rc!=0).
     r = _run(tmp_path, tool_present=False, apt_creates_tool=False, apt_rc=100)
     assert r["rc"] == 0 and r["reached_end"], r["out"]
-    assert r["apt_called"], r["out"]
-    assert not r["tool_exists"], r["out"]
+    assert r["apt_called"] and not r["tool_exists"], r["out"]
     assert "did not produce" in r["out"]
+    assert "apt| " in r["out"], f"apt output tail should be surfaced:\n{r['out']}"
     # No tool -> pandas pin must not run (forge is on PMC anyway).
     assert not r["pip_called"], r["out"]
 
@@ -271,7 +306,7 @@ def test_pins_pandas_when_ge3(tmp_path: Path) -> None:
     r = _run(tmp_path, tool_present=True, pandas_state="v3", pip_fixes=True)
     assert r["rc"] == 0 and r["reached_end"], r["out"]
     assert r["pip_called"], f"pandas<3 pin should have run:\n{r['out']}"
-    assert "pinning to 'pandas>=2.2.3,<3'" in r["out"]
+    assert "installing 'pandas>=2.2.3,<3'" in r["out"]
     assert "pandas pinned OK" in r["out"]
 
 
@@ -282,19 +317,23 @@ def test_no_pin_when_pandas_lt3(tmp_path: Path) -> None:
     assert "no pin needed" in r["out"]
 
 
+def test_installs_pandas_when_absent_precludes_later_3x(tmp_path: Path) -> None:
+    # Regression for the ordering window: if pandas is not yet installed, we must
+    # proactively install pandas<3 (not skip) so a later unconstrained
+    # `pip install pandas` (datasets/evaluate) cannot drag pandas>=3 back in.
+    r = _run(tmp_path, tool_present=True, pandas_state="absent", pip_fixes=True)
+    assert r["rc"] == 0 and r["reached_end"], r["out"]
+    assert r["pip_called"], f"pandas<3 should be installed when absent:\n{r['out']}"
+    assert "pandas not yet installed" in r["out"]
+    assert "pandas pinned OK" in r["out"]
+
+
 def test_failsoft_when_pip_pin_fails(tmp_path: Path) -> None:
     # pandas>=3, pip install exits non-zero, version stays >=3.
     r = _run(tmp_path, tool_present=True, pandas_state="v3", pip_rc=5, pip_fixes=False)
     assert r["rc"] == 0 and r["reached_end"], r["out"]
     assert r["pip_called"], r["out"]
     assert "still incompatible after pin" in r["out"]
-
-
-def test_failsoft_when_pandas_not_importable(tmp_path: Path) -> None:
-    r = _run(tmp_path, tool_present=True, pandas_state="absent")
-    assert r["rc"] == 0 and r["reached_end"], r["out"]
-    assert not r["pip_called"], r["out"]
-    assert "pandas not importable" in r["out"]
 
 
 # --- CHECK_ONLY / DRY_RUN honour ------------------------------------------
@@ -307,25 +346,37 @@ def test_dry_run_installs_nothing(tmp_path: Path) -> None:
     assert "would run" in r["out"]
 
 
-def test_check_only_installs_nothing(tmp_path: Path) -> None:
-    r = _run(tmp_path, tool_present=False, check_only=1, pandas_state="v3")
+def test_check_only_installs_nothing_and_warns_pandas(tmp_path: Path) -> None:
+    r = _run(tmp_path, tool_present=True, check_only=1, pandas_state="v3")
     assert r["rc"] == 0 and r["reached_end"], r["out"]
     assert not r["apt_called"] and not r["pip_called"], r["out"]
+    assert "would pin 'pandas>=2.2.3,<3'" in r["out"]
 
 
 # --- Static guards: keep the fix wired in ---------------------------------
 
 
-def test_static_gated_on_forge_and_forge_path() -> None:
+def test_static_gated_on_checkout_not_backend() -> None:
     body = _extract_fn("ensure_rocprof_compute")
-    assert "_forge_backend_selected" in body
-    assert "FORGE_PATH" in body
+    assert "_kernel_forge_root" in body, "must gate on the KernelForge checkout"
+    # Must NOT gate on the backend order (that was the ordering bug).
+    assert "_forge_backend_selected" not in body
+    assert "backend not selected" not in body
+
+
+def test_static_call_ordered_after_pandas_pullers() -> None:
+    text = IO_INSTALL.read_text(encoding="utf-8")
+    # The bare top-level call must run after the deps that pull pandas, so the
+    # pandas<3 pin has the final say.
+    bench = text.rindex("\nensure_bench_serving_deps\n")
+    xdit = text.rindex("\nensure_xdit_quality_deps\n")
+    call = text.rindex("\nensure_rocprof_compute\n")
+    assert call > bench and call > xdit, "ensure_rocprof_compute must be called last"
 
 
 def test_static_installs_rocprofiler_compute_and_verifies_resolve_path() -> None:
     body = _extract_fn("ensure_rocprof_compute")
     assert "rocprofiler-compute" in body, "apt package name must stay wired"
-    # verifies against the exact path KernelForge's resolve_rocpc() checks
     assert "libexec/rocprofiler-compute/rocprof_compute_base.py" in body
 
 
@@ -336,10 +387,9 @@ def test_static_pins_pandas_lt3() -> None:
 
 def test_static_fail_soft_no_hard_abort() -> None:
     # Neither function may hard-abort the installer: no die, and no bash-level
-    # `exit` STATEMENT (a line whose first token is `exit`). This deliberately
-    # ignores `sys.exit(...)` inside the embedded Python version probe (that is
-    # the fail-soft mechanism — it returns a code to the surrounding `if`) and
-    # any "exit" mentioned in comments.
+    # `exit` STATEMENT (a line whose first token is `exit`). This ignores
+    # `sys.exit(...)` inside the embedded Python probe (the fail-soft mechanism —
+    # it returns a code to the surrounding `if`) and "exit" mentioned in comments.
     for name in ("ensure_rocprof_compute", "_ensure_pandas_lt3_for_rocpc"):
         body = _extract_fn(name)
         assert "die " not in body, f"{name} must be fail-soft (no die)"

--- a/src/hyperloom/inference_optimizer/tests/test_install_rocprof_compute.py
+++ b/src/hyperloom/inference_optimizer/tests/test_install_rocprof_compute.py
@@ -404,17 +404,43 @@ def test_static_gated_on_checkout_not_backend() -> None:
 
 
 def test_static_call_ordered_after_all_pip_steps() -> None:
+    # The bare top-level call must run after EVERY pip-installing step, so no later
+    # step can re-pull pandas>=3 and the pin's re-check is the truthful final
+    # state. Derive the pip-installing steps instead of hardcoding them, so a
+    # future refactor that adds a pip step or moves the call is caught.
     text = IO_INSTALL.read_text(encoding="utf-8")
-    # The bare top-level call must run after EVERY pip-installing step (incl.
-    # chain_kernel_agent), so no later step can re-pull pandas>=3 and the pin's
-    # re-check is the truthful final state.
     call = text.rindex("\nensure_rocprof_compute\n")
-    for earlier in (
-        "\nensure_bench_serving_deps\n",
-        "\nensure_xdit_quality_deps\n",
-        "\nchain_kernel_agent\n",
-    ):
-        assert call > text.rindex(earlier), f"ensure_rocprof_compute must run after {earlier.strip()}"
+
+    # Top-level invocations: a line that is exactly a function name (col 0), i.e.
+    # ensure_*/chain_* CALLS (definitions are `name() {`, which this won't match).
+    invocations = [
+        (m.start(), m.group(1))
+        for m in re.finditer(r"^(ensure_[a-z_]+|chain_[a-z_]+)$", text, re.M)
+    ]
+    pip_steps_before = []
+    for pos, name in invocations:
+        if name == "ensure_rocprof_compute":
+            continue
+        # Only consider names that are DEFINED in this file, and whose body runs
+        # a pip install.
+        if not re.search(rf"^{name}\(\) \{{", text, re.M):
+            continue
+        body = _extract_fn(name)
+        if "pip install" in body:
+            pip_steps_before.append((pos, name))
+
+    # chain_kernel_agent installs INDIRECTLY (it shells out to another
+    # install.sh), so it has no literal "pip install" in its body — include it
+    # explicitly as a pip step that must precede the pin.
+    chain = text.rindex("\nchain_kernel_agent\n") + 1
+    pip_steps_before.append((chain, "chain_kernel_agent"))
+
+    assert pip_steps_before, "expected to find pip-installing steps to order against"
+    latest_pos, latest_name = max(pip_steps_before)
+    assert call > latest_pos, (
+        f"ensure_rocprof_compute (pos {call}) must be called AFTER every "
+        f"pip-installing step; last one is {latest_name} (pos {latest_pos})"
+    )
 
 
 def test_static_effective_python_probe_mirrors_resolve_rocpc() -> None:

--- a/src/hyperloom/inference_optimizer/tests/test_install_rocprof_compute.py
+++ b/src/hyperloom/inference_optimizer/tests/test_install_rocprof_compute.py
@@ -1,0 +1,348 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Behavioural + static guards for ``ensure_rocprof_compute()``.
+
+forge-loop's profiling stage prefers rocprof-compute (roofline / speed-of-light)
+and only degrades to the thin rocprofv3 "PMC" path when the tool is missing OR
+unusable. Two things break it on a stock ROCm serving image:
+
+  1. rocprofiler-compute (the ``rocprof-compute`` CLI, resolved by KernelForge at
+     ``<ROCM_PATH>/libexec/rocprofiler-compute/rocprof_compute_base.py``) is not
+     installed — the image ships only rocprofv3.
+  2. Even once installed, its 3.4.x CSV converter assumes pandas' legacy
+     ``object`` string dtype; pandas>=3.0 (future.infer_string=True) makes its
+     Agent_Id merge fail -> "No profiling data found" -> silent PMC fallback.
+
+``ensure_rocprof_compute()`` (gated on the forge backend being selected AND
+FORGE_PATH set) apt-installs the tool and pins ``pandas<3`` in the forge
+interpreter. Every branch is FAIL-SOFT: a missing tool / failed apt / failed pin
+logs and returns 0 (forge still runs on PMC) — it must never abort install.sh.
+
+Regression cover for the 2026-07-30 investigation where every forge run profiled
+on PMC (optimization-potential estimable=NO): first because rocprof-compute was
+absent, then because pandas 3.0 silently disabled its CSV conversion.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+IO_INSTALL = REPO_ROOT / "src" / "hyperloom" / "inference_optimizer" / "assets" / "install.sh"
+
+APT_MARKER = "apt-install-called"
+PIP_MARKER = "pip-install-called"
+
+# coreutils the extracted bash + the stubs need; PATH is curated so we control
+# whether apt-get is discoverable (for the no-apt branch).
+_PATH_TOOLS = (
+    "bash", "sh", "env", "cat", "tr", "touch", "mkdir", "rm", "printf",
+    "sed", "grep", "ls", "dirname", "chmod", "ln", "cp", "head", "tail",
+)
+
+
+def _extract_fn(name: str) -> str:
+    text = IO_INSTALL.read_text(encoding="utf-8")
+    m = re.search(rf"^{name}\(\) \{{.*?^\}}", text, re.S | re.M)
+    assert m, f"could not locate {name}() in install.sh"
+    return m.group(0)
+
+
+def _curated_bindir(tmp_path: Path, *, with_apt: bool, apt_stub: Path | None) -> Path:
+    """A PATH dir with only the tools we allow — lets us toggle apt-get presence."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir(exist_ok=True)
+    for tool in _PATH_TOOLS:
+        real = shutil.which(tool)
+        if real:
+            link = bindir / tool
+            if not link.exists():
+                link.symlink_to(real)
+    if with_apt and apt_stub is not None:
+        (bindir / "apt-get").symlink_to(apt_stub)
+    return bindir
+
+
+def _fake_python(tmp_path: Path) -> Path:
+    """Stub ``$PYTHON``.
+
+    * ``-m pip install ...``  -> touch PIP_MARKER, exit ``$PIP_RC`` (default 0).
+    * ``-``  (version-check heredoc on stdin) -> decide the pandas version:
+        - after pip ran AND ``PIP_FIXES=1``  -> print 2.3.3, exit 0 (<3)
+        - else per ``PANDAS_STATE``: absent->exit 3, v2->2.3.3/exit0, v3->3.0.3/exit1
+    """
+    pip_marker = tmp_path / PIP_MARKER
+    body = f"""#!/usr/bin/env bash
+if [ "${{1:-}}" = "-m" ] && [ "${{2:-}}" = "pip" ]; then
+  : > "{pip_marker}"
+  exit ${{PIP_RC:-0}}
+fi
+if [ "${{1:-}}" = "-" ]; then
+  cat >/dev/null 2>&1 || true   # consume the heredoc script
+  if [ -f "{pip_marker}" ] && [ "${{PIP_FIXES:-0}}" = "1" ]; then
+    echo "2.3.3"; exit 0
+  fi
+  case "${{PANDAS_STATE:-v3}}" in
+    absent) exit 3 ;;
+    v2) echo "2.3.3"; exit 0 ;;
+    *) echo "3.0.3"; exit 1 ;;
+  esac
+fi
+exit 0
+"""
+    py = tmp_path / "fake_python.sh"
+    py.write_text(body, encoding="utf-8")
+    py.chmod(py.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return py
+
+
+def _fake_apt(tmp_path: Path, tool_base: Path) -> Path:
+    """Stub ``apt-get``: touch APT_MARKER; on ``install`` optionally create the tool."""
+    apt_marker = tmp_path / APT_MARKER
+    body = f"""#!/usr/bin/env bash
+: > "{apt_marker}"
+if [ "${{APT_CREATES_TOOL:-0}}" = "1" ] && [ "${{1:-}}" = "install" ]; then
+  mkdir -p "{tool_base.parent}"
+  : > "{tool_base}"
+fi
+exit ${{APT_RC:-0}}
+"""
+    apt = tmp_path / "fake_apt_get.sh"
+    apt.write_text(body, encoding="utf-8")
+    apt.chmod(apt.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return apt
+
+
+def _run(
+    tmp_path: Path,
+    *,
+    backend_order: str | None = "forge",
+    forge_path: str | None = "/some/KernelForge",
+    tool_present: bool = False,
+    apt_available: bool = True,
+    apt_creates_tool: bool = False,
+    apt_rc: int = 0,
+    pandas_state: str = "v3",
+    pip_rc: int = 0,
+    pip_fixes: bool = False,
+    check_only: int = 0,
+    dry_run: int = 0,
+) -> dict:
+    """Run the extracted rocprof-compute functions under set -euo pipefail."""
+    rocm_root = tmp_path / "rocm"
+    tool_base = rocm_root / "libexec" / "rocprofiler-compute" / "rocprof_compute_base.py"
+    if tool_present:
+        tool_base.parent.mkdir(parents=True, exist_ok=True)
+        tool_base.write_text("", encoding="utf-8")
+
+    fake_py = _fake_python(tmp_path)
+    apt_stub = _fake_apt(tmp_path, tool_base)
+    bindir = _curated_bindir(tmp_path, with_apt=apt_available, apt_stub=apt_stub)
+
+    backend_line = (
+        f'export KERNEL_OPT_BACKEND_ORDER="{backend_order}"'
+        if backend_order is not None
+        else "unset KERNEL_OPT_BACKEND_ORDER || true"
+    )
+    forge_line = (
+        f'export FORGE_PATH="{forge_path}"'
+        if forge_path is not None
+        else "unset FORGE_PATH || true"
+    )
+
+    harness = f"""#!/usr/bin/env bash
+set -euo pipefail
+log() {{ echo "[log] $*"; }}
+warn() {{ echo "[warn] $*"; }}
+die() {{ echo "[die] $*"; exit 1; }}
+CHECK_ONLY={check_only}
+DRY_RUN={dry_run}
+PYTHON="{fake_py}"
+PIP_EXTRA=()
+export ROCM_PATH="{rocm_root}"
+export PANDAS_STATE="{pandas_state}"
+export PIP_RC="{pip_rc}"
+export PIP_FIXES="{1 if pip_fixes else 0}"
+export APT_CREATES_TOOL="{1 if apt_creates_tool else 0}"
+export APT_RC="{apt_rc}"
+{backend_line}
+{forge_line}
+
+{_extract_fn("_forge_backend_selected")}
+
+{_extract_fn("_ensure_pandas_lt3_for_rocpc")}
+
+{_extract_fn("ensure_rocprof_compute")}
+
+ensure_rocprof_compute
+echo "[harness] reached-end rc=$?"
+"""
+    script = tmp_path / "harness.sh"
+    script.write_text(harness, encoding="utf-8")
+    proc = subprocess.run(
+        ["bash", str(script)],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        env={"PATH": str(bindir)},
+        check=False,
+    )
+    return {
+        "out": proc.stdout,
+        "rc": proc.returncode,
+        "apt_called": (tmp_path / APT_MARKER).exists(),
+        "pip_called": (tmp_path / PIP_MARKER).exists(),
+        "tool_exists": tool_base.exists(),
+        "reached_end": "reached-end" in proc.stdout,
+    }
+
+
+# --- Gate -----------------------------------------------------------------
+
+
+def test_skip_when_backend_not_forge(tmp_path: Path) -> None:
+    r = _run(tmp_path, backend_order="geak")
+    assert r["rc"] == 0 and r["reached_end"], r["out"]
+    assert not r["apt_called"] and not r["pip_called"], r["out"]
+    assert "forge backend not selected" in r["out"]
+
+
+def test_forge_matched_as_substring_in_ladder(tmp_path: Path) -> None:
+    # "geak,forge" must count as forge selected (ladder ordering).
+    r = _run(tmp_path, backend_order="geak,forge", tool_present=True, pandas_state="v2")
+    assert r["rc"] == 0 and r["reached_end"], r["out"]
+    assert "forge backend not selected" not in r["out"]
+
+
+def test_skip_when_forge_but_no_forge_path(tmp_path: Path) -> None:
+    r = _run(tmp_path, backend_order="forge", forge_path=None)
+    assert r["rc"] == 0 and r["reached_end"], r["out"]
+    assert not r["apt_called"] and not r["pip_called"], r["out"]
+    assert "FORGE_PATH unset" in r["out"]
+
+
+# --- Tool install (Step 1) ------------------------------------------------
+
+
+def test_installs_tool_when_absent(tmp_path: Path) -> None:
+    r = _run(tmp_path, tool_present=False, apt_creates_tool=True, pandas_state="v2")
+    assert r["rc"] == 0 and r["reached_end"], r["out"]
+    assert r["apt_called"], r["out"]
+    assert r["tool_exists"], r["out"]
+    assert "rocprof-compute installed OK" in r["out"]
+
+
+def test_idempotent_when_tool_present(tmp_path: Path) -> None:
+    r = _run(tmp_path, tool_present=True, pandas_state="v2")
+    assert r["rc"] == 0 and r["reached_end"], r["out"]
+    assert not r["apt_called"], f"apt should be skipped when tool present:\n{r['out']}"
+    assert "already present" in r["out"]
+
+
+def test_failsoft_when_apt_unavailable(tmp_path: Path) -> None:
+    r = _run(tmp_path, tool_present=False, apt_available=False)
+    assert r["rc"] == 0 and r["reached_end"], r["out"]
+    assert not r["apt_called"], r["out"]
+    assert "apt-get unavailable" in r["out"]
+
+
+def test_failsoft_when_apt_fails_to_produce_tool(tmp_path: Path) -> None:
+    # apt runs but does not create the tool (e.g. package unavailable / rc!=0).
+    r = _run(tmp_path, tool_present=False, apt_creates_tool=False, apt_rc=100)
+    assert r["rc"] == 0 and r["reached_end"], r["out"]
+    assert r["apt_called"], r["out"]
+    assert not r["tool_exists"], r["out"]
+    assert "did not produce" in r["out"]
+    # No tool -> pandas pin must not run (forge is on PMC anyway).
+    assert not r["pip_called"], r["out"]
+
+
+# --- pandas pin (Step 2) --------------------------------------------------
+
+
+def test_pins_pandas_when_ge3(tmp_path: Path) -> None:
+    r = _run(tmp_path, tool_present=True, pandas_state="v3", pip_fixes=True)
+    assert r["rc"] == 0 and r["reached_end"], r["out"]
+    assert r["pip_called"], f"pandas<3 pin should have run:\n{r['out']}"
+    assert "pinning to 'pandas>=2.2.3,<3'" in r["out"]
+    assert "pandas pinned OK" in r["out"]
+
+
+def test_no_pin_when_pandas_lt3(tmp_path: Path) -> None:
+    r = _run(tmp_path, tool_present=True, pandas_state="v2")
+    assert r["rc"] == 0 and r["reached_end"], r["out"]
+    assert not r["pip_called"], f"no pin needed when pandas<3:\n{r['out']}"
+    assert "no pin needed" in r["out"]
+
+
+def test_failsoft_when_pip_pin_fails(tmp_path: Path) -> None:
+    # pandas>=3, pip install exits non-zero, version stays >=3.
+    r = _run(tmp_path, tool_present=True, pandas_state="v3", pip_rc=5, pip_fixes=False)
+    assert r["rc"] == 0 and r["reached_end"], r["out"]
+    assert r["pip_called"], r["out"]
+    assert "still incompatible after pin" in r["out"]
+
+
+def test_failsoft_when_pandas_not_importable(tmp_path: Path) -> None:
+    r = _run(tmp_path, tool_present=True, pandas_state="absent")
+    assert r["rc"] == 0 and r["reached_end"], r["out"]
+    assert not r["pip_called"], r["out"]
+    assert "pandas not importable" in r["out"]
+
+
+# --- CHECK_ONLY / DRY_RUN honour ------------------------------------------
+
+
+def test_dry_run_installs_nothing(tmp_path: Path) -> None:
+    r = _run(tmp_path, tool_present=False, dry_run=1, pandas_state="v3")
+    assert r["rc"] == 0 and r["reached_end"], r["out"]
+    assert not r["apt_called"] and not r["pip_called"], r["out"]
+    assert "would run" in r["out"]
+
+
+def test_check_only_installs_nothing(tmp_path: Path) -> None:
+    r = _run(tmp_path, tool_present=False, check_only=1, pandas_state="v3")
+    assert r["rc"] == 0 and r["reached_end"], r["out"]
+    assert not r["apt_called"] and not r["pip_called"], r["out"]
+
+
+# --- Static guards: keep the fix wired in ---------------------------------
+
+
+def test_static_gated_on_forge_and_forge_path() -> None:
+    body = _extract_fn("ensure_rocprof_compute")
+    assert "_forge_backend_selected" in body
+    assert "FORGE_PATH" in body
+
+
+def test_static_installs_rocprofiler_compute_and_verifies_resolve_path() -> None:
+    body = _extract_fn("ensure_rocprof_compute")
+    assert "rocprofiler-compute" in body, "apt package name must stay wired"
+    # verifies against the exact path KernelForge's resolve_rocpc() checks
+    assert "libexec/rocprofiler-compute/rocprof_compute_base.py" in body
+
+
+def test_static_pins_pandas_lt3() -> None:
+    body = _extract_fn("_ensure_pandas_lt3_for_rocpc")
+    assert "pandas>=2.2.3,<3" in body
+
+
+def test_static_fail_soft_no_hard_abort() -> None:
+    # Neither function may hard-abort the installer: no die, and no bash-level
+    # `exit` STATEMENT (a line whose first token is `exit`). This deliberately
+    # ignores `sys.exit(...)` inside the embedded Python version probe (that is
+    # the fail-soft mechanism — it returns a code to the surrounding `if`) and
+    # any "exit" mentioned in comments.
+    for name in ("ensure_rocprof_compute", "_ensure_pandas_lt3_for_rocpc"):
+        body = _extract_fn(name)
+        assert "die " not in body, f"{name} must be fail-soft (no die)"
+        assert not re.search(r"^\s*exit\b", body, re.M), (
+            f"{name} must not exit the shell (only `return 0` / fail-soft)"
+        )


### PR DESCRIPTION
…iling

forge-loop's profiling stage prefers rocprof-compute (roofline / speed-of-light) but the stock ROCm serving image ships only rocprofv3, so every forge run silently degraded to the PMC path (no roofline; optimization-potential estimable=NO). And even once rocprofiler-compute is installed, its 3.4.x CSV converter assumes pandas' legacy 'object' string dtype; pandas>=3.0 (future.infer_string=True) reads Agent_Id ("Agent 9") as StringDtype, its `dtype == "object"` coercion guard is skipped, and the Agent_Id<->Node_Id merge dies ("merge on str and int64") -> "No profiling data found" -> silent PMC fallback again.

ensure_rocprof_compute() (gated on forge backend selected + FORGE_PATH set):
  - Step 1: apt-installs rocprofiler-compute into the ROCm root (pip cannot provide the system tool). Idempotent; verifies the exact file resolve_rocpc() checks.
  - Step 2: pins pandas>=2.2.3,<3 in the forge interpreter (== the interpreter rocprof-compute runs under). Nothing in the stack requires pandas>=3 (verified conflict-free); decided via Python exit codes to stay robust under set -euo pipefail.

Both steps are FAIL-SOFT and log every branch (including the concrete "forge profiling will degrade to PMC" consequence) so the post-mortem question "why did this run profile on PMC?" is answerable from the install log alone. A missing tool / failed apt / failed pin never aborts the install — forge still runs on the PMC path.

No KernelForge changes: its resolve_rocpc path logic is already correct; the gap was purely the container (tool + pandas version).

Verified end-to-end on MI355X/gfx950: the triton_mixtral_dynamic_quant example now profiles with backend=rocprof-compute (empirical roofline + SoL), 0 PMC degrades, and optimization_potential.json flips to estimable=YES.

- Description: what and why
- Linked issue(s): close/fix refs
- Tests: added/updated? commands run?
- Breaking changes: yes/no (details if yes)
