### PR TITLE
fix(cli): treat clean SWEEP completions as successful exit codes

### DIFF
--- a/src/hyperloom/inference_optimizer/cli/__init__.py
+++ b/src/hyperloom/inference_optimizer/cli/__init__.py
@@ -1227,6 +1227,29 @@ def _export_workload_envs_for_optimize(
     os.environ["EP"] = str(max(1, int(ep_resolved or 1)))
 
 
+# Terminal stop_reasons that represent a clean, successful optimizer run (exit 0).
+# Anything else (baseline / preflight failures, crashes, enablement stalls) exits
+# non-zero so CI surfaces genuine problems.
+_SUCCESS_STOP_REASONS: frozenset[str] = frozenset(
+    {
+        "target_reached",
+        "global_converged",
+        "time_exhausted",
+        "max_ticks",
+        # SWEEP finished cleanly. exit_normal_sweep returns sweep_done (shape grid)
+        # or conc_sweep_done (concurrency ladder); both mean the run optimized and
+        # closed normally (e.g. the no-kernel path), so neither is a CI failure.
+        "sweep_done",
+        "conc_sweep_done",
+    }
+)
+
+
+def _exit_code_for_stop_reason(stop_reason: str | None) -> int:
+    """Map a terminal ``stop_reason`` to a process exit code (0 success, 1 failure)."""
+    return 0 if (stop_reason or "") in _SUCCESS_STOP_REASONS else 1
+
+
 async def _run_optimize(args: argparse.Namespace) -> int:
     """Run the ``optimize`` subcommand end to end.
 
@@ -2232,17 +2255,7 @@ async def _run_optimize(args: argparse.Namespace) -> int:
     # NOTE: conc_sweep is now a SWEEP-phase action auto-enqueued by the Coordinator, not a post-hook here.
 
     _print_final_summary(coordinator.shared_state, stop_reason, session_dir)
-    return (
-        0
-        if stop_reason
-        in (
-            "target_reached",
-            "global_converged",
-            "time_exhausted",
-            "max_ticks",
-        )
-        else 1
-    )
+    return _exit_code_for_stop_reason(stop_reason)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/hyperloom/inference_optimizer/tests/test_exit_code_stop_reason.py
+++ b/src/hyperloom/inference_optimizer/tests/test_exit_code_stop_reason.py
@@ -1,0 +1,33 @@
+"""Exit-code mapping for terminal stop_reasons.
+
+Regression: a clean no-kernel run closes with stop_reason ``conc_sweep_done``
+(and a shape-grid run with ``sweep_done``). Both mean the optimizer ran and
+closed normally, yet the CLI used to return exit code 1 for them, so CI (with
+backoffLimit: 0) flagged a successful run as failed.
+"""
+from __future__ import annotations
+
+from hyperloom.inference_optimizer.cli import _exit_code_for_stop_reason
+
+
+def test_sweep_completions_exit_zero():
+    # The bug: these clean SWEEP terminals were mapped to 1.
+    assert _exit_code_for_stop_reason("conc_sweep_done") == 0
+    assert _exit_code_for_stop_reason("sweep_done") == 0
+
+
+def test_established_success_reasons_still_exit_zero():
+    for reason in ("target_reached", "global_converged", "time_exhausted", "max_ticks"):
+        assert _exit_code_for_stop_reason(reason) == 0
+
+
+def test_failure_reasons_exit_nonzero():
+    for reason in (
+        "prelude_baseline_failed",
+        "enablement_stalled",
+        "conc_sweep_failed",
+        "crash_threshold_exceeded",
+        "",
+        None,
+    ):
+        assert _exit_code_for_stop_reason(reason) == 1


### PR DESCRIPTION
## Problem
The CLI maps the terminal `stop_reason` to a process exit code, and CI runs with `backoffLimit: 0` so any non-zero exit is a hard failure. The success whitelist only accepted four reasons:

```
target_reached / global_converged / time_exhausted / max_ticks
```

A **no-kernel** run closes with `stop_reason=conc_sweep_done`, and a shape-grid run with `sweep_done` (both produced by `exit_normal_sweep`). These mean the optimizer ran and closed normally — baseline measured, sweep completed, report + artifacts written — yet they fell outside the whitelist and returned exit code 1, so CI flagged a fully successful run as failed.

## Fix
- Extract the exit-code decision into `_SUCCESS_STOP_REASONS` + `_exit_code_for_stop_reason()` (previously an inline tuple).
- Add `sweep_done` and `conc_sweep_done` to the success set. They are the two clean SWEEP terminals; both mean "optimized and closed normally".

Scope is intentionally limited to the sweep-completion terminals. Other normal-completion reasons (`no_kernel_skipped`, `plateau_*`, etc.) and the exit-code semantics of gray-area reasons (`conc_sweep_failed`, `robustness_escalated`) are deliberately left unchanged and will be discussed separately.

## Tests
- `test_sweep_completions_exit_zero`: the regression — `conc_sweep_done` / `sweep_done` now exit 0 (previously 1).
- `test_established_success_reasons_still_exit_zero`: the original four still exit 0.
- `test_failure_reasons_exit_nonzero`: genuine failures (`prelude_baseline_failed`, `enablement_stalled`, `conc_sweep_failed`, `crash_threshold_exceeded`, empty/None) still exit 1.