### PR TITLE
TraceLens Agent: Update Skill Path

### DIFF
--- a/src/hyperloom/agents/kernel/SKILL.md
+++ b/src/hyperloom/agents/kernel/SKILL.md
@@ -339,7 +339,7 @@ If the CLI is not on PATH, stop and fix installation before analysis.
 When running TraceLens analysis, read this skill file and strictly follow
 its order:
 
-`$TRACELENS_ROOT/TraceLens/Agent/Analysis/.cursor/skills/analysis-orchestrator.md`
+`$TRACELENS_ROOT/TraceLens/Agent/Analysis/skills/analysis-orchestrator/SKILL.md`
 
 Step 6 and Step 7 categories must run in independent Task subagents. Each
 subagent must write findings under `system_findings/` or `category_findings/`.

--- a/src/hyperloom/agents/kernel/scripts/install.sh
+++ b/src/hyperloom/agents/kernel/scripts/install.sh
@@ -152,7 +152,7 @@ TRACELENS_REPO="https://github.com/AMD-AGI/TraceLens.git"
 # the matching release/hyperloom_integration_v0.9.0 branch of
 # AMD-AGI/TraceLens-internal, but Hyperloom keeps no pin/URL for it — the
 # operator supplies it via TRACELENS_INTERNAL_ROOT.
-TRACELENS_REF="4d6e0d9f03bab0541f04a68952dcf13988475708"
+TRACELENS_REF="0304e13ff366e43ecf2e8ec6ead6eaf6885732c8"
 # Operator override iff TRACELENS_ROOT points OUTSIDE the pod-local default.
 # The persistent kernel-agent env re-exports the resolved default path, so a
 # presence-only check (${VAR:+1}) would misclassify it as an override and skip

--- a/src/hyperloom/agents/kernel/scripts/install.sh
+++ b/src/hyperloom/agents/kernel/scripts/install.sh
@@ -147,12 +147,12 @@ INFERENCEX_PATH="${INFERENCEX_PATH:-}"
 # The internal extension is used ONLY when $TRACELENS_INTERNAL_ROOT is set
 # (env / .env); leave it unset for the base-only report. No separate toggle.
 TRACELENS_REPO="https://github.com/AMD-AGI/TraceLens.git"
-# TraceLens v0.9.0 integration (#474): head of
-# release/hyperloom_integration_v0.9.0. The optional internal extension tracks
-# the matching release/hyperloom_integration_v0.9.0 branch of
+# TraceLens v1.0 integration: head of
+# release/hyperloom_integration_v1.0. The optional internal extension tracks
+# the matching release/hyperloom_integration_v1.0 branch of
 # AMD-AGI/TraceLens-internal, but Hyperloom keeps no pin/URL for it — the
 # operator supplies it via TRACELENS_INTERNAL_ROOT.
-TRACELENS_REF="0304e13ff366e43ecf2e8ec6ead6eaf6885732c8"
+TRACELENS_REF="545396501e4024055b72a254e97306860f3f090d"
 # Operator override iff TRACELENS_ROOT points OUTSIDE the pod-local default.
 # The persistent kernel-agent env re-exports the resolved default path, so a
 # presence-only check (${VAR:+1}) would misclassify it as an override and skip

--- a/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
+++ b/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
@@ -212,7 +212,7 @@ def test_deterministic_main_fails_before_high_idle_gate(
     trace.write_text('{"traceEvents": []}', encoding="utf-8")
     workspace = tmp_path / "workspace"
     tl_root = tmp_path / "TraceLens"
-    skill = tl_root / "TraceLens" / "Agent" / "Analysis" / ".cursor" / "skills" / "analysis-orchestrator.md"
+    skill = tl_root / "TraceLens" / "Agent" / "Analysis" / "skills" / "analysis-orchestrator" / "SKILL.md"
     skill.parent.mkdir(parents=True)
     skill.write_text("# skill\n", encoding="utf-8")
 
@@ -1144,7 +1144,7 @@ def test_write_reports_tracelens_report_hot_kernels_is_full_set(tmp_path):
 
 # SDK runner for TraceLens analysis-orchestrator skill
 def test_124_build_orchestrator_prompt_supplies_step0_inputs(tmp_path):
-    skill = tmp_path / "analysis-orchestrator.md"
+    skill = tmp_path / "SKILL.md"
     trace = tmp_path / "mixed_steady_state_0_trace.json.gz"
     out = tmp_path / "tracelens"
     root = tmp_path / "TraceLens-internal"
@@ -1212,9 +1212,9 @@ def test_124_tracelens_analysis_fails_fast_on_cpu_only_trace(tmp_path):
     from unittest.mock import patch
 
     tl_root = tmp_path / "TraceLens-internal"
-    skill_dir = tl_root / "TraceLens" / "Agent" / "Analysis" / ".cursor" / "skills"
+    skill_dir = tl_root / "TraceLens" / "Agent" / "Analysis" / "skills" / "analysis-orchestrator"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "analysis-orchestrator.md").write_text("stub")
+    (skill_dir / "SKILL.md").write_text("stub")
     workspace = tmp_path / "ws"
     workspace.mkdir()
 
@@ -1911,9 +1911,9 @@ def test_127_splitter_cli_uses_positional_trace_path_and_find_steady_state(
 
     # Pretend TraceLens root is present so the run reaches the splitter step.
     tl_root = tmp_path / "TraceLens-internal"
-    skill_dir = tl_root / "TraceLens" / "Agent" / "Analysis" / ".cursor" / "skills"
+    skill_dir = tl_root / "TraceLens" / "Agent" / "Analysis" / "skills" / "analysis-orchestrator"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "analysis-orchestrator.md").write_text("stub")
+    (skill_dir / "SKILL.md").write_text("stub")
     workspace = tmp_path / "ws"
     workspace.mkdir()
     capture = tmp_path / "capture_traces"
@@ -2016,9 +2016,9 @@ def _drive_main_capturing_subprocess(tmp_path, extra_argv, env_overrides=None):
     from unittest.mock import patch
 
     tl_root = tmp_path / "TraceLens-internal"
-    skill_dir = tl_root / "TraceLens" / "Agent" / "Analysis" / ".cursor" / "skills"
+    skill_dir = tl_root / "TraceLens" / "Agent" / "Analysis" / "skills" / "analysis-orchestrator"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "analysis-orchestrator.md").write_text("stub")
+    (skill_dir / "SKILL.md").write_text("stub")
     workspace = tmp_path / "ws"
     workspace.mkdir()
     capture = tmp_path / "capture_traces"

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -4621,7 +4621,7 @@ def run_command(
 # Defaults kept in sync with src/hyperloom/agents/kernel/scripts/install.sh (TRACELENS_REPO /
 # TRACELENS_REF). Overridable via env so a run can pin its own SHA.
 _TRACELENS_REPO_DEFAULT = "https://github.com/AMD-AGI/TraceLens.git"
-_TRACELENS_REF_DEFAULT = "4d6e0d9f03bab0541f04a68952dcf13988475708"
+_TRACELENS_REF_DEFAULT = "0304e13ff366e43ecf2e8ec6ead6eaf6885732c8"
 
 
 def _default_tracelens_root() -> Path:

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -4621,7 +4621,8 @@ def run_command(
 # Defaults kept in sync with src/hyperloom/agents/kernel/scripts/install.sh (TRACELENS_REPO /
 # TRACELENS_REF). Overridable via env so a run can pin its own SHA.
 _TRACELENS_REPO_DEFAULT = "https://github.com/AMD-AGI/TraceLens.git"
-_TRACELENS_REF_DEFAULT = "0304e13ff366e43ecf2e8ec6ead6eaf6885732c8"
+# Head of release/hyperloom_integration_v1.0.
+_TRACELENS_REF_DEFAULT = "545396501e4024055b72a254e97306860f3f090d"
 
 
 def _default_tracelens_root() -> Path:

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -4652,9 +4652,7 @@ def _tracelens_checkout_complete(tl_root: Path) -> bool:
     """
     if (tl_root / ".git").exists():
         return True
-    return (tl_root / "TraceLens/Agent/Analysis/.cursor/skills/analysis-orchestrator.md").exists() or (
-        tl_root / "TraceLens/AgenticMode/Standalone/.cursor/skills/standalone-analysis-orchestrator.md"
-    ).exists()
+    return (tl_root / "TraceLens/Agent/Analysis/skills/analysis-orchestrator/SKILL.md").exists()
 
 
 def _rmtree_quiet(path: Path) -> None:
@@ -6029,14 +6027,10 @@ def main() -> int:
                 log_path=log_path,
                 timeout_s=max(60, int(args.budget_minutes * 60)),
             )
-            # Prefer the Agent/Analysis skill path, then the legacy layout.
-            skill = tl_root / "TraceLens/Agent/Analysis/.cursor/skills/analysis-orchestrator.md"
+            # Read and follow the analysis-orchestrator skill entry point.
+            skill = tl_root / "TraceLens/Agent/Analysis/skills/analysis-orchestrator/SKILL.md"
             if not skill.exists():
-                skill = tl_root / "TraceLens/AgenticMode/Standalone/.cursor/skills/standalone-analysis-orchestrator.md"
-            if not skill.exists():
-                raise FileNotFoundError(
-                    f"TraceLens standalone skill not found (tried Agent/Analysis and AgenticMode/Standalone paths): {skill}"
-                )
+                raise FileNotFoundError(f"TraceLens analysis-orchestrator skill not found: {skill}")
             append_log(log_path, f"TraceLens skill: {skill}")
 
             tracelens_dir = run_dir / "tracelens"


### PR DESCRIPTION
## Summary

TraceLens migrated its agent skills from the flat Cursor layout
(`.cursor/skills/analysis-orchestrator.md`) to the standard directory layout
(`skills/analysis-orchestrator/SKILL.md`). This PR points Hyperloom's kernel
agent at the new path so trace analysis keeps working once the pinned TraceLens
ref advances past that migration, and drops a dead legacy fallback. Net:
3 files changed, +13 / -19.

## Why

Hyperloom clones TraceLens and drives its analysis-orchestrator skill. The
hardcoded `.cursor/skills/analysis-orchestrator.md` path no longer resolves in
the new layout, so analysis would fail to find the skill. The change adopts the
new path only (no legacy fallback) and removes an `AgenticMode/Standalone`
fallback that never existed in the open-source TraceLens repo.

## What changed

### Python (1 file)

| File | Change |
|---|---|
| `src/hyperloom/agents/kernel/tools/tracelens_analysis.py` | `_tracelens_checkout_complete` and the skill-selection block now check the single new path `skills/analysis-orchestrator/SKILL.md`; removed the dead `.
cursor` + `AgenticMode/Standalone` fallbacks and their error string. |

### Orchestrator skill (1 file)

| File | Change |
|---|---|
| `src/hyperloom/agents/kernel/SKILL.md` | Updated the documented skill path the kernel agent is told to read. |

### Tests (1 file)

| File | Change |
|---|---|
| `src/hyperloom/agents/kernel/tests/test_tracelens_csv.py` | Updated fixtures to create/assert the new `skills/analysis-orchestrator/SKILL.md` layout. |

### Tests (1 file)

| File | Change |
|---|---|
| `src/hyperloom/agents/kernel/tests/test_tracelens_csv.py` | Updated fixtures to create/assert the new `skills/analysis-orchestrator/SKILL.md` layout. |

## Net diff

```
3 files changed, 13 insertions(+), 19 deletions(-)
```