### PR TITLE
fix(server-args): preserve JSON across argument removal

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_cli_workload_envs.py
+++ b/src/hyperloom/inference_optimizer/tests/test_cli_workload_envs.py
@@ -6,7 +6,9 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
+import re
 from types import SimpleNamespace
 
 import pytest
@@ -192,6 +194,38 @@ def test_operator_server_args_dedup_vllm_single_value_flags(tmp_path, monkeypatc
     assert args.count("--gpu-memory-utilization") == 1
     assert "--gpu-memory-utilization 0.85" in args
     assert "--trust-remote-code" in args
+
+
+def test_json_serve_arg_survives_append_merge_as_valid_json(tmp_path):
+    """JSON-valued flags appended via extra_server_args stay valid JSON.
+
+    The GEMM shape-capture path appends ``current_best.extra_server_args`` (which
+    can carry ``--compilation-config`` / ``--speculative-config`` JSON blobs) onto
+    the reused baseline config. A prior shlex round-trip in that merge stripped
+    the double quotes -> ``{cudagraph_mode:FULL}`` -> vLLM ``json.loads`` rejects
+    it at boot -> server never starts -> ``shape_capture_failed`` (no CSV). The
+    materialized config must therefore carry VALID JSON. Regression guard.
+    """
+    src = tmp_path / "cfg.yaml"
+    _write_yaml_with_envs(src, "vllm", {"EXTRA_VLLM_ARGS": "--kv-cache-dtype fp8_e4m3"})
+    # The extra_server_args reaching shape-capture already had their JSON quotes
+    # stripped by an upstream shlex round-trip (observed in the session configs),
+    # so materialize receives the unquoted-bareword form. It must not pass this
+    # broken JSON through to the launch config; the repair restores valid JSON.
+    out = materialize_config_with_envs(
+        src,
+        tmp_path / "out",
+        extra_server_args=(
+            "--compilation-config {cudagraph_mode:FULL} "
+            "--speculative-config {method:ngram,num_speculative_tokens:7}"
+        ),
+        args_mode="append",
+    )
+    args = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
+    blobs = re.findall(r"\{[^{}]*\}", args)
+    assert blobs, f"no JSON blob found in materialized args: {args!r}"
+    for blob in blobs:
+        json.loads(blob)  # must parse: broken JSON was repaired, not passed through
 
 
 def test_conc_env_ladder_materializes_as_single_baseline_conc(

--- a/src/hyperloom/inference_optimizer/tests/test_cli_workload_envs.py
+++ b/src/hyperloom/inference_optimizer/tests/test_cli_workload_envs.py
@@ -228,6 +228,32 @@ def test_json_serve_arg_survives_append_merge_as_valid_json(tmp_path):
         json.loads(blob)  # must parse: broken JSON was repaired, not passed through
 
 
+def test_json_serve_arg_survives_shape_capture_port_removal(tmp_path):
+    """The shape-capture materialization path must remove its inherited port
+    without corrupting a sibling JSON-valued server flag."""
+    src = tmp_path / "cfg.yaml"
+    _write_yaml_with_envs(
+        src,
+        "vllm",
+        {
+            "EXTRA_VLLM_ARGS": (
+                '--compilation-config {"cudagraph_mode":"FULL"} --port 8888'
+            )
+        },
+    )
+
+    out = materialize_config_with_envs(
+        src,
+        tmp_path / "out",
+        remove_args=["--port"],
+    )
+    args = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
+
+    assert "--port" not in args
+    blob = args.split("--compilation-config ", 1)[1].strip()
+    assert json.loads(blob) == {"cudagraph_mode": "FULL"}
+
+
 def test_conc_env_ladder_materializes_as_single_baseline_conc(
     tmp_path,
     monkeypatch,

--- a/src/hyperloom/inference_optimizer/tests/test_grid_runner.py
+++ b/src/hyperloom/inference_optimizer/tests/test_grid_runner.py
@@ -1342,6 +1342,17 @@ class TestCompactJsonServerArgs:
             "model": "RedHatAI/Llama-3.1-8B-Instruct-speculator",
         }
 
+    def test_quote_stripped_nested_json_is_repaired(self):
+        out = _grid_runner.compact_json_server_args(
+            "--compilation-config {method:ngram,nested:{a:1}}",
+            "vllm",
+        )
+        blob = out.split(" ", 1)[1]
+        assert json.loads(blob) == {
+            "method": "ngram",
+            "nested": {"a": 1},
+        }
+
     def test_unrepairable_json_left_verbatim(self):
         # Genuinely broken blobs that cannot be repaired to valid JSON are left
         # verbatim (no worse than before), never raising.

--- a/src/hyperloom/inference_optimizer/tests/test_grid_runner.py
+++ b/src/hyperloom/inference_optimizer/tests/test_grid_runner.py
@@ -1312,6 +1312,43 @@ class TestCompactJsonServerArgs:
         # ['--speculative-config', '{"model":"draft', 'model', 'name"}'].
         assert len(out.split()) == 4
 
+    def test_quote_stripped_json_is_repaired(self):
+        # A prior shlex round-trip (e.g. in the GEMM shape-capture path) can strip
+        # the JSON double-quotes, turning a stored-valid ``{"method":"ngram",...}``
+        # into ``{method:ngram,...}`` which vLLM's ``json.loads`` rejects at boot
+        # (observed: shape_capture server never boots -> shape_capture_failed).
+        # compact must repair the barewords back to valid JSON.
+        out = _grid_runner.compact_json_server_args(
+            "--speculative-config {method:ngram,num_speculative_tokens:7,prompt_lookup_min:2,prompt_lookup_max:8}",
+            "vllm",
+        )
+        assert out == (
+            "--speculative-config "
+            '{"method":"ngram","num_speculative_tokens":7,"prompt_lookup_min":2,"prompt_lookup_max":8}'
+        )
+        blob = out.split(" ", 1)[1]
+        json.loads(blob)  # must be valid JSON now
+
+    def test_quote_stripped_json_with_path_value_repaired(self):
+        # Bareword string values containing ``/``, ``.``, ``-`` (e.g. a model id)
+        # must also be re-quoted.
+        out = _grid_runner.compact_json_server_args(
+            "--speculative-config {method:eagle3,model:RedHatAI/Llama-3.1-8B-Instruct-speculator}",
+            "vllm",
+        )
+        blob = out.split(" ", 1)[1]
+        assert json.loads(blob) == {
+            "method": "eagle3",
+            "model": "RedHatAI/Llama-3.1-8B-Instruct-speculator",
+        }
+
+    def test_unrepairable_json_left_verbatim(self):
+        # Genuinely broken blobs that cannot be repaired to valid JSON are left
+        # verbatim (no worse than before), never raising.
+        raw = "--compilation-config {this is : not ] json"
+        out = _grid_runner.compact_json_server_args(raw, "vllm")
+        assert "{this is" in out
+
     def test_other_flags_around_json_untouched(self):
         out = _grid_runner.compact_json_server_args('--kv-cache-dtype fp8 --compilation-config {"level": 3}', "vllm")
         assert out == '--kv-cache-dtype fp8 --compilation-config {"level":3}'
@@ -1331,3 +1368,35 @@ class TestCompactJsonServerArgs:
     def test_empty_is_noop(self):
         assert _grid_runner.compact_json_server_args("", "vllm") == ""
         assert _grid_runner.compact_json_server_args(None, "vllm") == ""
+
+
+class TestRemoveServerArgsPreservesJson:
+    """``remove_server_args`` tokenizes with ``shlex.split`` (which strips JSON
+    inner double quotes) and runs AFTER ``compact_json_server_args`` in
+    ``materialize_config_with_envs`` (GEMM shape-capture always passes
+    ``remove_args=['--port']``). It must therefore re-quote/compact the JSON
+    blobs itself, or a sibling ``--compilation-config`` / ``--speculative-config``
+    is silently corrupted to unquoted barewords that vLLM rejects at boot."""
+
+    def test_remove_port_keeps_sibling_json_valid(self):
+        raw = '--compilation-config {"cudagraph_mode":"FULL"} --port 8888'
+        out = _grid_runner.remove_server_args(raw, ["--port"])
+        assert "--port" not in out
+        blob = out.split("--compilation-config ", 1)[1].strip()
+        assert json.loads(blob) == {"cudagraph_mode": "FULL"}
+
+    def test_remove_keeps_multikey_speculative_config_valid(self):
+        raw = (
+            '--speculative-config {"method":"ngram","num_speculative_tokens":7} '
+            "--port 8888"
+        )
+        out = _grid_runner.remove_server_args(raw, ["--port"])
+        blob = out.split("--speculative-config ", 1)[1].strip()
+        assert json.loads(blob) == {"method": "ngram", "num_speculative_tokens": 7}
+
+    def test_remove_noop_when_nothing_matches_keeps_json(self):
+        raw = '--compilation-config {"cudagraph_mode":"FULL"}'
+        out = _grid_runner.remove_server_args(raw, ["--port"])
+        assert json.loads(out.split("--compilation-config ", 1)[1].strip()) == {
+            "cudagraph_mode": "FULL"
+        }

--- a/src/hyperloom/orchestrator/actions/executors/_grid_server_args.py
+++ b/src/hyperloom/orchestrator/actions/executors/_grid_server_args.py
@@ -157,7 +157,11 @@ def remove_server_args(server_args: str | None, remove_args: Any) -> str:
             continue
         out.append(tok)
         i += 1
-    return " ".join(out)
+    # ``shlex.split`` above strips the inner double quotes of any JSON-valued
+    # flag (``--compilation-config {"cudagraph_mode":"FULL"}`` ->
+    # ``{cudagraph_mode:FULL}``); re-quote/compact the JSON blobs so removal
+    # never corrupts a sibling flag that vLLM parses with ``json.loads``.
+    return _reserialize_json_blobs(" ".join(out))
 
 
 def compose_server_args(
@@ -221,6 +225,40 @@ def split_config_changes(
     return server_args, coerce_extra_envs(env_items)
 
 
+# A JSON "bareword": an identifier-like token that appears where a double-quoted
+# JSON key or string value should be (letters/digits/underscore plus the ``.``,
+# ``/``, ``-`` common in model ids and paths). Numbers, ``true``/``false``/
+# ``null`` are handled separately so they stay unquoted.
+_JSON_BAREWORD = r"[A-Za-z_][A-Za-z0-9_./-]*"
+_UNQUOTED_KEY_RE = re.compile(r"([{,]\s*)(" + _JSON_BAREWORD + r")(\s*:)")
+_UNQUOTED_VALUE_RE = re.compile(r"([:\[,]\s*)(" + _JSON_BAREWORD + r")")
+
+
+def _repair_unquoted_json(blob: str) -> str | None:
+    """Repair a JSON object/array whose double quotes were stripped.
+
+    A shlex round-trip (``shlex.split`` then space-join without re-quoting)
+    strips the inner double quotes of a JSON-valued server arg, turning a
+    stored-valid ``{"method":"ngram"}`` into ``{method:ngram}`` — which vLLM's
+    ``json.loads`` rejects at boot. Re-quote bare object keys and bare string
+    values, then VALIDATE by parsing: return the compact valid-JSON string, or
+    ``None`` when it still does not parse (caller keeps the blob verbatim).
+    """
+    def _quote_value(m: "re.Match[str]") -> str:
+        prefix, word = m.group(1), m.group(2)
+        if word in ("true", "false", "null"):
+            return m.group(0)  # JSON literals stay unquoted
+        return f'{prefix}"{word}"'
+
+    # Keys first (so a re-quoted key is not re-matched as a value), then values.
+    candidate = _UNQUOTED_KEY_RE.sub(r'\1"\2"\3', blob)
+    candidate = _UNQUOTED_VALUE_RE.sub(_quote_value, candidate)
+    try:
+        return json.dumps(json.loads(candidate), separators=(",", ":"))
+    except Exception:
+        return None
+
+
 def compact_json_server_args(
     server_args: str | None,
     framework: str | None,
@@ -244,6 +282,21 @@ def compact_json_server_args(
     if not args or ("{" not in args and "[" not in args):
         return args
     if server_args_env_name(framework) == "EXTRA_SGLANG_ARGS":
+        return args
+    return _reserialize_json_blobs(args)
+
+
+def _reserialize_json_blobs(args: str) -> str:
+    """Compact (and, when needed, repair) every JSON object/array in ``args``.
+
+    Framework-agnostic core shared by :func:`compact_json_server_args` and
+    :func:`remove_server_args`. Each balanced ``{...}``/``[...]`` blob is
+    re-serialised with compact separators; a blob whose inner double quotes were
+    stripped by an earlier shlex round-trip is repaired via
+    :func:`_repair_unquoted_json`, and anything that still does not parse is left
+    verbatim (never worse than the input).
+    """
+    if "{" not in args and "[" not in args:
         return args
     out: list[str] = []
     i = 0
@@ -279,7 +332,13 @@ def compact_json_server_args(
             try:
                 out.append(json.dumps(json.loads(blob), separators=(",", ":")))
             except Exception:
-                out.append(blob)
+                # A prior shlex round-trip can strip the JSON double quotes,
+                # leaving an unquoted-bareword object (``{"m":"ngram"}`` ->
+                # ``{m:ngram}``) that vLLM's json.loads rejects at boot. Try to
+                # re-quote bare keys/values; fall back to verbatim if that still
+                # does not parse (never worse than before).
+                repaired = _repair_unquoted_json(blob)
+                out.append(repaired if repaired is not None else blob)
             i = j
         else:
             out.append(ch)

--- a/src/hyperloom/orchestrator/actions/executors/_grid_server_args.py
+++ b/src/hyperloom/orchestrator/actions/executors/_grid_server_args.py
@@ -235,7 +235,7 @@ _UNQUOTED_VALUE_RE = re.compile(r"([:\[,]\s*)(" + _JSON_BAREWORD + r")")
 
 
 def _repair_unquoted_json(blob: str) -> str | None:
-    """Repair a JSON object/array whose double quotes were stripped.
+    """Best-effort repair of a JSON blob whose double quotes were stripped.
 
     A shlex round-trip (``shlex.split`` then space-join without re-quoting)
     strips the inner double quotes of a JSON-valued server arg, turning a
@@ -243,6 +243,9 @@ def _repair_unquoted_json(blob: str) -> str | None:
     ``json.loads`` rejects at boot. Re-quote bare object keys and bare string
     values, then VALIDATE by parsing: return the compact valid-JSON string, or
     ``None`` when it still does not parse (caller keeps the blob verbatim).
+
+    This is a narrowly scoped recovery heuristic for known JSON-valued server
+    flags after shlex damage, not a general parser for JSON-like syntax.
     """
     def _quote_value(m: "re.Match[str]") -> str:
         prefix, word = m.group(1), m.group(2)


### PR DESCRIPTION
## Summary
- preserve valid JSON-valued server flags when `remove_server_args` performs an `shlex` round-trip
- share JSON blob compaction and repair between argument removal and materialization
- add regression coverage for GEMM shape capture and malformed JSON recovery

## Root cause
`remove_server_args` used `shlex.split` and rejoined tokens without restoring the inner quotes of JSON-valued flags. GEMM shape capture invokes it to remove `--port` after JSON compaction, turning valid JSON such as `{"cudagraph_mode":"FULL"}` into `{cudagraph_mode:FULL}`. vLLM then rejected the argument at startup, causing `shape_capture_failed` and preventing GEMM shape collection.

## Test plan
- [x] `python -m pytest src/hyperloom/inference_optimizer/tests/test_grid_runner.py -q` (101 passed)
- [x] verify a materialized config using `remove_args=["--port"]` retains parseable JSON
- [x] verify no linter errors in modified files