### PR TITLE
fix(kernel): materialize fusion patch base from disk for non-git frameworks

### DIFF
--- a/src/hyperloom/agents/kernel/tools/apply_kernel_patch.py
+++ b/src/hyperloom/agents/kernel/tools/apply_kernel_patch.py
@@ -456,9 +456,10 @@ def parse_patch_manifest(patch_text: str) -> list[dict[str, Any]]:
         list[dict[str, Any]]: One descriptor per affected path. Each has
             ``op`` (``"write"`` or ``"delete"``), ``path`` (repo-relative
             target), ``mode`` (octal string or ``""``), ``binary`` (bool), and
-            for renames/copies a ``source`` (origin repo-relative path). A
-            rename yields two descriptors: a ``delete`` of the source and a
-            ``write`` of the dest.
+            ``is_new`` (bool: the path is created by the patch — ``--- /dev/null``,
+            a ``new file mode`` header, or a rename/copy destination — so it must
+            not be pre-seeded with a base). A rename yields two descriptors: a
+            ``delete`` of the source and a ``write`` of the dest.
 
     Raises:
         ValueError: When the patch is empty/unparseable, or a section's
@@ -491,12 +492,20 @@ def parse_patch_manifest(patch_text: str) -> list[dict[str, Any]]:
         if rename_to and rename_from:
             src = _unquote_git_path(rename_from.group(1).strip())
             dst = _unquote_git_path(rename_to.group(1).strip())
-            descriptors.append({"op": "delete", "path": src, "mode": "", "binary": False})
-            descriptors.append({"op": "write", "path": dst, "mode": mode, "binary": binary})
+            descriptors.append(
+                {"op": "delete", "path": src, "mode": "", "binary": False, "is_new": False}
+            )
+            # The rename destination is produced by the apply; it must not be
+            # pre-seeded from a base (treated as a create).
+            descriptors.append(
+                {"op": "write", "path": dst, "mode": mode, "binary": binary, "is_new": True}
+            )
             continue
         if copy_to:
             dst = _unquote_git_path(copy_to.group(1).strip())
-            descriptors.append({"op": "write", "path": dst, "mode": mode, "binary": binary})
+            descriptors.append(
+                {"op": "write", "path": dst, "mode": mode, "binary": binary, "is_new": True}
+            )
             continue
 
         minus = re.search(r"(?m)^--- (.+)$", block)
@@ -509,10 +518,15 @@ def parse_patch_manifest(patch_text: str) -> list[dict[str, Any]]:
             target = _strip_ab_prefix(minus_path)
             if not target:
                 raise ValueError(f"deletion section missing source path:\n{block[:200]}")
-            descriptors.append({"op": "delete", "path": target, "mode": "", "binary": binary})
+            descriptors.append(
+                {"op": "delete", "path": target, "mode": "", "binary": binary, "is_new": False}
+            )
             continue
 
         # Addition (--- /dev/null) or modification: dest comes from the +++ line.
+        # A creation is signalled by ``--- /dev/null`` or a ``new file mode``
+        # header; modifications carry an ``a/<path>`` on the ``---`` line.
+        is_new = minus_path == "/dev/null" or bool(new_mode_m)
         target = _strip_ab_prefix(plus_path)
         if not target:
             # Header-only entries (pure chmod) carry the path on the diff line.
@@ -521,7 +535,9 @@ def parse_patch_manifest(patch_text: str) -> list[dict[str, Any]]:
                 target = _unquote_git_path(gitline.group(2).strip())
         if not target:
             raise ValueError(f"cannot determine target path for section:\n{block[:200]}")
-        descriptors.append({"op": "write", "path": target, "mode": mode, "binary": binary})
+        descriptors.append(
+            {"op": "write", "path": target, "mode": mode, "binary": binary, "is_new": is_new}
+        )
 
     return descriptors
 

--- a/src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py
@@ -530,6 +530,48 @@ class TestForgeGemmHelperCoverage:
             snapshot / "vllm" / "model_executor" / "models" / "qwen3.py"
         ).read_text(encoding="utf-8") == "new = 2\n"
 
+    def test_materialize_unified_patch_snapshot_nongit_new_file_timestamped(self, tmp_path):
+        """A created file whose ``+++`` line carries a tab-suffixed timestamp
+        must still be recognized as a create on a NON-git root.
+
+        The new-file path is normalized exactly like ``parse_patch_manifest``
+        (strip the ``\\t<timestamp>`` suffix and the ``b/`` prefix); otherwise it
+        is misclassified as a modify, pre-seeded from disk, and ``git apply``
+        fails "already exists". Pairs a modify (base from disk) with a create in
+        the same patch.
+        """
+        repo = tmp_path / "site-packages"
+        (repo / "vllm").mkdir(parents=True)
+        (repo / "vllm" / "existing.py").write_text("old = 1\n", encoding="utf-8")
+        # NOTE: deliberately NOT a git repo -- mirrors dist-packages.
+
+        patch = tmp_path / "fusion.patch"
+        patch.write_text(
+            "diff --git a/vllm/existing.py b/vllm/existing.py\n"
+            "--- a/vllm/existing.py\n"
+            "+++ b/vllm/existing.py\n"
+            "@@ -1 +1 @@\n"
+            "-old = 1\n"
+            "+new = 2\n"
+            "diff --git a/vllm/fused_new.py b/vllm/fused_new.py\n"
+            "new file mode 100644\n"
+            "--- /dev/null\n"
+            "+++ b/vllm/fused_new.py\t2026-07-31 17:00:00.000000000 +0800\n"
+            "@@ -0,0 +1 @@\n"
+            "+created = 3\n",
+            encoding="utf-8",
+        )
+
+        snapshot = Path(
+            krh.materialize_unified_patch_snapshot(
+                patch_path=patch,
+                repo_root=repo,
+            )
+        )
+
+        assert (snapshot / "vllm" / "existing.py").read_text(encoding="utf-8") == "new = 2\n"
+        assert (snapshot / "vllm" / "fused_new.py").read_text(encoding="utf-8") == "created = 3\n"
+
     def test_materialize_unified_patch_snapshot_rejects_bad_inputs(self, tmp_path):
         repo = tmp_path / "repo"
         repo.mkdir()

--- a/src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py
@@ -491,6 +491,45 @@ class TestForgeGemmHelperCoverage:
 
         assert (snapshot / "model.py").read_text(encoding="utf-8") == "new = 2\n"
 
+    def test_materialize_unified_patch_snapshot_nongit_repo(self, tmp_path):
+        """Repro: fusion patch against a NON-git repo_root (e.g. vLLM installed
+        under site-packages/dist-packages).
+
+        forge-fusion (PR #75) emits a patch for non-git frameworks so KEPT
+        fusions reach e2e integrate, but the consumer resolved base content via
+        ``git show HEAD:<path>`` which fails outside a git repo -> the snapshot
+        never gets the base file -> ``git apply`` fails with
+        ``<path>: No such file or directory`` (observed on Qwen3-0.6B / Llama
+        vLLM sessions). The base must fall back to the on-disk source.
+        """
+        repo = tmp_path / "site-packages"
+        (repo / "vllm" / "model_executor" / "models").mkdir(parents=True)
+        target = repo / "vllm" / "model_executor" / "models" / "qwen3.py"
+        target.write_text("old = 1\n", encoding="utf-8")
+        # NOTE: deliberately NOT a git repo (no git init) -- mirrors dist-packages.
+
+        patch = tmp_path / "fusion.patch"
+        patch.write_text(
+            "diff --git a/vllm/model_executor/models/qwen3.py b/vllm/model_executor/models/qwen3.py\n"
+            "--- a/vllm/model_executor/models/qwen3.py\n"
+            "+++ b/vllm/model_executor/models/qwen3.py\n"
+            "@@ -1 +1 @@\n"
+            "-old = 1\n"
+            "+new = 2\n",
+            encoding="utf-8",
+        )
+
+        snapshot = Path(
+            krh.materialize_unified_patch_snapshot(
+                patch_path=patch,
+                repo_root=repo,
+            )
+        )
+
+        assert (
+            snapshot / "vllm" / "model_executor" / "models" / "qwen3.py"
+        ).read_text(encoding="utf-8") == "new = 2\n"
+
     def test_materialize_unified_patch_snapshot_rejects_bad_inputs(self, tmp_path):
         repo = tmp_path / "repo"
         repo.mkdir()

--- a/src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py
@@ -572,6 +572,59 @@ class TestForgeGemmHelperCoverage:
         assert (snapshot / "vllm" / "existing.py").read_text(encoding="utf-8") == "new = 2\n"
         assert (snapshot / "vllm" / "fused_new.py").read_text(encoding="utf-8") == "created = 3\n"
 
+    def test_materialize_unified_patch_snapshot_nongit_new_file_quoted(self, tmp_path):
+        """A created file whose header path is C-quoted (git quotes paths with
+        spaces) must be recognized as a create via the shared
+        ``parse_patch_manifest`` normalization, not pre-seeded, and produced by
+        ``git apply``. Regression guard for the quoted-path branch.
+        """
+        repo = tmp_path / "site-packages"
+        (repo / "vllm").mkdir(parents=True)
+        # NOTE: deliberately NOT a git repo -- mirrors dist-packages.
+
+        patch = tmp_path / "fusion.patch"
+        patch.write_text(
+            'diff --git "a/vllm/fused new.py" "b/vllm/fused new.py"\n'
+            "new file mode 100644\n"
+            "--- /dev/null\n"
+            '+++ "b/vllm/fused new.py"\n'
+            "@@ -0,0 +1 @@\n"
+            "+created = 1\n",
+            encoding="utf-8",
+        )
+
+        snapshot = Path(
+            krh.materialize_unified_patch_snapshot(
+                patch_path=patch,
+                repo_root=repo,
+            )
+        )
+
+        assert (snapshot / "vllm" / "fused new.py").read_text(encoding="utf-8") == "created = 1\n"
+
+    def test_materialize_unified_patch_snapshot_modify_base_missing_raises(self, tmp_path):
+        """A modify whose base is neither in git HEAD nor on disk must fail with
+        a precise error instead of the opaque ``git apply`` "No such file or
+        directory".
+        """
+        repo = tmp_path / "site-packages"
+        repo.mkdir(parents=True)
+        # NOTE: NOT a git repo, and the target file does not exist on disk.
+
+        patch = tmp_path / "fusion.patch"
+        patch.write_text(
+            "diff --git a/vllm/missing.py b/vllm/missing.py\n"
+            "--- a/vllm/missing.py\n"
+            "+++ b/vllm/missing.py\n"
+            "@@ -1 +1 @@\n"
+            "-old = 1\n"
+            "+new = 2\n",
+            encoding="utf-8",
+        )
+
+        with pytest.raises(FileNotFoundError, match="patch base missing"):
+            krh.materialize_unified_patch_snapshot(patch_path=patch, repo_root=repo)
+
     def test_materialize_unified_patch_snapshot_rejects_bad_inputs(self, tmp_path):
         repo = tmp_path / "repo"
         repo.mkdir()

--- a/src/hyperloom/orchestrator/kernel/request_handlers.py
+++ b/src/hyperloom/orchestrator/kernel/request_handlers.py
@@ -1079,9 +1079,18 @@ def materialize_unified_patch_snapshot(
         raise FileNotFoundError(f"kernel repo does not exist: {root}")
 
     tool = _load_apply_tool()
-    descriptors = tool.parse_patch_manifest(patch.read_text(encoding="utf-8", errors="replace"))
+    patch_text = patch.read_text(encoding="utf-8", errors="replace")
+    descriptors = tool.parse_patch_manifest(patch_text)
     if not descriptors:
         raise ValueError(f"patch has no file operations: {patch}")
+
+    # Paths the patch CREATES (``--- /dev/null``): these must be produced by
+    # ``git apply``, never pre-seeded with a base, or apply fails "already
+    # exists". Everything else is a modify whose base we must supply.
+    _new_file_paths = {
+        m.group(1).strip()
+        for m in re.finditer(r"(?m)^--- /dev/null\n\+\+\+ b/(.+)$", patch_text)
+    }
 
     snap = Path(snapshot_dir) if snapshot_dir is not None else patch.parent / "fusion_snapshot"
     if snap.exists():
@@ -1101,6 +1110,19 @@ def materialize_unified_patch_snapshot(
         if base.returncode == 0:
             dst.parent.mkdir(parents=True, exist_ok=True)
             dst.write_bytes(base.stdout)
+        elif rel.as_posix() not in _new_file_paths:
+            # ``git show HEAD:`` failed and this is a MODIFY (not a create):
+            # non-git repo_root (e.g. vLLM/sglang under site-packages/
+            # dist-packages) or an untracked-but-present file. Fall back to the
+            # on-disk source. forge-fusion (PR #75) emits the patch for these
+            # non-git frameworks; without this fallback the snapshot lacks the
+            # base file and ``git apply`` fails "<path>: No such file or
+            # directory". New files (``--- /dev/null``) are intentionally left
+            # for ``git apply`` to create.
+            src = root / rel
+            if src.is_file():
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                dst.write_bytes(src.read_bytes())
 
     proc = subprocess.run(
         ["git", "apply", "--unsafe-paths", str(patch)],

--- a/src/hyperloom/orchestrator/kernel/request_handlers.py
+++ b/src/hyperloom/orchestrator/kernel/request_handlers.py
@@ -1086,10 +1086,15 @@ def materialize_unified_patch_snapshot(
 
     # Paths the patch CREATES (``--- /dev/null``): these must be produced by
     # ``git apply``, never pre-seeded with a base, or apply fails "already
-    # exists". Everything else is a modify whose base we must supply.
+    # exists". Everything else is a modify whose base we must supply. Normalize
+    # each ``+++`` path exactly as ``parse_patch_manifest`` does (strip a
+    # tab-suffixed timestamp, unquote C-quoting, drop the ``a/``/``b/`` prefix)
+    # so these match the descriptor ``path`` values below.
     _new_file_paths = {
-        m.group(1).strip()
-        for m in re.finditer(r"(?m)^--- /dev/null\n\+\+\+ b/(.+)$", patch_text)
+        tool._strip_ab_prefix(
+            tool._unquote_git_path(m.group(1).split("\t", 1)[0].strip())
+        )
+        for m in re.finditer(r"(?m)^--- /dev/null\n\+\+\+ (.+)$", patch_text)
     }
 
     snap = Path(snapshot_dir) if snapshot_dir is not None else patch.parent / "fusion_snapshot"

--- a/src/hyperloom/orchestrator/kernel/request_handlers.py
+++ b/src/hyperloom/orchestrator/kernel/request_handlers.py
@@ -1084,17 +1084,16 @@ def materialize_unified_patch_snapshot(
     if not descriptors:
         raise ValueError(f"patch has no file operations: {patch}")
 
-    # Paths the patch CREATES (``--- /dev/null``): these must be produced by
-    # ``git apply``, never pre-seeded with a base, or apply fails "already
-    # exists". Everything else is a modify whose base we must supply. Normalize
-    # each ``+++`` path exactly as ``parse_patch_manifest`` does (strip a
-    # tab-suffixed timestamp, unquote C-quoting, drop the ``a/``/``b/`` prefix)
-    # so these match the descriptor ``path`` values below.
+    # Paths the patch CREATES: these must be produced by ``git apply``, never
+    # pre-seeded with a base, or apply fails "already exists". Everything else
+    # is a modify whose base we must supply. ``is_new`` comes from
+    # ``parse_patch_manifest`` (single source of truth for both the path
+    # normalization and the create/modify disposition), which avoids a second,
+    # drift-prone parse of the raw patch text.
     _new_file_paths = {
-        tool._strip_ab_prefix(
-            tool._unquote_git_path(m.group(1).split("\t", 1)[0].strip())
-        )
-        for m in re.finditer(r"(?m)^--- /dev/null\n\+\+\+ (.+)$", patch_text)
+        str(desc.get("path") or "")
+        for desc in descriptors
+        if desc.get("op") == "write" and desc.get("is_new")
     }
 
     snap = Path(snapshot_dir) if snapshot_dir is not None else patch.parent / "fusion_snapshot"
@@ -1122,12 +1121,19 @@ def materialize_unified_patch_snapshot(
             # on-disk source. forge-fusion (PR #75) emits the patch for these
             # non-git frameworks; without this fallback the snapshot lacks the
             # base file and ``git apply`` fails "<path>: No such file or
-            # directory". New files (``--- /dev/null``) are intentionally left
-            # for ``git apply`` to create.
+            # directory". New files are intentionally left for ``git apply`` to
+            # create.
             src = root / rel
-            if src.is_file():
-                dst.parent.mkdir(parents=True, exist_ok=True)
-                dst.write_bytes(src.read_bytes())
+            if not src.is_file():
+                # Neither git HEAD nor the on-disk layout has the base. Surface
+                # a precise error here instead of the opaque ``git apply`` "No
+                # such file or directory" that would otherwise follow.
+                raise FileNotFoundError(
+                    f"patch base missing for {rel.as_posix()}: not in git HEAD "
+                    f"and not on disk under {root}"
+                )
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst.write_bytes(src.read_bytes())
 
     proc = subprocess.run(
         ["git", "apply", "--unsafe-paths", str(patch)],


### PR DESCRIPTION
## Summary

Companion to #1050 (fusion patch `repo_root` resolution) and KernelForge #75 (non-git patch export). #1050 makes the integrate wrapper pass the correct package-install root (e.g. vLLM installed under `site-packages`/`dist-packages`), but the consumer `materialize_unified_patch_snapshot` still fetched each touched file's base content via `git show HEAD:<path>`, which fails for a **non-git** root. The snapshot then lacks the base file and `git apply` fails with `<path>: No such file or directory`, so a KEPT fusion (kernel-level, serving-safe) never produces an e2e number and never enters the recipe.

Observed on Qwen3-0.6B (`fused_gate_up_silu_mul...`, 2.89x) and Llama-3.1-8B (`fused_gate_up_act...`, 2.06x) vLLM sessions that **already carried #1050** and still failed at `materialize`:
```
RuntimeError: could not materialize patch snapshot: error: vllm/model_executor/models/qwen3.py: No such file or directory
```

## Changes

- `orchestrator/kernel/request_handlers.py` (`materialize_unified_patch_snapshot`): when `git show HEAD:<path>` fails (non-git root or untracked-but-present file), fall back to reading the base from the on-disk source (`repo_root/<path>`). New files (`--- /dev/null` in the patch) are intentionally not pre-seeded so `git apply` creates them (avoids "already exists"); detected via regex over the patch text.
- Adds `test_materialize_unified_patch_snapshot_nongit_repo` (reproduces the exact failure on a non-git root).

## Test plan

- `pytest src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py` — 234 passed (incl. new non-git repro, existing git-repo and forge-fusion new-file cases).